### PR TITLE
policy: support sshTests

### DIFF
--- a/.github/workflows/test-integration.yaml
+++ b/.github/workflows/test-integration.yaml
@@ -203,6 +203,7 @@ jobs:
           - TestAuthWebFlowLogoutAndReloginSameUser
           - TestAuthWebFlowLogoutAndReloginNewUser
           - TestPolicyCheckCommand
+          - TestSSHTestsRejectFailingPolicy
           - TestUserCommand
           - TestPreAuthKeyCommand
           - TestPreAuthKeyCommandWithoutExpiry

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,30 @@ This feature is **beta** while behavioural coverage against Tailscale SaaS broad
 
 [#3229](https://github.com/juanfont/headscale/pull/3229)
 
+### SSH policy tests (beta)
+
+Headscale now evaluates the `sshTests` block in a policy file. Each entry names a source, one or
+more destination hosts, and three optional user lists: `accept` asserts the listed login users
+reach every destination via an accept- or check-action SSH rule, `deny` asserts none of them
+reach any destination, and `check` requires reachability specifically through a check-action
+rule. Tests run on `headscale policy set`, on SIGHUP reload (`systemctl reload headscale` /
+`kill -HUP $(pidof headscale)`), and on `headscale policy check`. A failing test rejects the
+write before it is applied, with the same error message Tailscale SaaS would return for the same
+policy.
+
+At boot a stored policy whose sshTests no longer pass — for example because a referenced user was
+deleted while the server was offline — logs a warning and the server keeps running. Fix the
+policy and reload.
+
+This feature is **beta** while behavioural coverage against Tailscale SaaS broadens.
+
+### SSH rule validation
+
+SSH rule parsing now trims surrounding whitespace on `action`, `users`, `src`, and `dst`,
+rejects empty or wildcard entries in `users`, rejects empty `acceptEnv`, and rejects negative
+`checkPeriod`. `hosts:` aliases are rejected as SSH destinations, non-ASCII tag names are
+rejected at parse time, and the wording for group-nesting cycles matches Tailscale SaaS.
+
 ### Grants
 
 We now support [Tailscale grants](https://tailscale.com/docs/features/access-control/grants)

--- a/cmd/headscale/cli/policy.go
+++ b/cmd/headscale/cli/policy.go
@@ -48,7 +48,7 @@ func init() {
 	policyCmd.AddCommand(setPolicy)
 
 	checkPolicy.Flags().StringP("file", "f", "", "Path to a policy file in HuJSON format")
-	checkPolicy.Flags().BoolP(bypassFlag, "", false, "Open the database directly (no gRPC, no running server) to validate user@ token references and to evaluate the policy's tests block. Required when those checks are needed.")
+	checkPolicy.Flags().BoolP(bypassFlag, "", false, "Open the database directly (no gRPC, no running server) to resolve user references and to evaluate the policy's tests and sshTests blocks. Required when those checks are needed.")
 	mustMarkRequired(checkPolicy, "file")
 	policyCmd.AddCommand(checkPolicy)
 }
@@ -173,8 +173,8 @@ var checkPolicy = &cobra.Command{
 	Short: "Check the Policy file for errors",
 	Long: `
 	Check validates the policy against the server's live users and nodes,
-	running any "tests" block. By default the command is a thin frontend
-	for a gRPC call to a running headscale; pass --` + bypassFlag + ` to
+	running any "tests" or "sshTests" block. By default the command is a
+	thin frontend for a gRPC call to a running headscale; pass --` + bypassFlag + ` to
 	open the database directly when headscale is not running.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		policyPath, _ := cmd.Flags().GetString("file")
@@ -208,7 +208,7 @@ var checkPolicy = &cobra.Command{
 			// NewPolicyManager validates structure and user references
 			// but intentionally skips test evaluation (boot path).
 			// SetPolicy is the user-write boundary and is what runs the
-			// tests block.
+			// tests and sshTests blocks.
 			pm, err := policy.NewPolicyManager(policyBytes, users, nodes.ViewSlice())
 			if err != nil {
 				return fmt.Errorf("parsing policy file: %w", err)

--- a/hscontrol/policy/policy_test.go
+++ b/hscontrol/policy/policy_test.go
@@ -1317,7 +1317,7 @@ func TestSSHPolicyRules(t *testing.T) {
 				]
 			}`,
 			expectErr:    true,
-			errorMessage: `invalid SSH action: "invalid", must be one of: accept, check`,
+			errorMessage: `"invalid" is not a valid action`,
 		},
 		{
 			name:       "invalid-check-period",
@@ -1341,10 +1341,15 @@ func TestSSHPolicyRules(t *testing.T) {
 				]
 			}`,
 			expectErr:    true,
-			errorMessage: "not a valid duration string",
+			errorMessage: `time: invalid duration "invalid"`,
 		},
+		// `autogroup:invalid` as an SSH user is no longer rejected:
+		// SaaS treats every `autogroup:*` user-string as a literal
+		// label and compiles it into the SSHUsers map. The compat
+		// suite covers this via ssh-malformed-user-autogroup-* — no
+		// dedicated case is needed here.
 		{
-			name:       "unsupported-autogroup",
+			name:       "ssh-user-unknown-autogroup-as-literal",
 			targetNode: taggedClient,
 			peers:      types.Nodes{&nodeUser2},
 			policy: `{
@@ -1363,8 +1368,23 @@ func TestSSHPolicyRules(t *testing.T) {
 					}
 				]
 			}`,
-			expectErr:    true,
-			errorMessage: "autogroup not supported for SSH user",
+			wantSSH: &tailcfg.SSHPolicy{Rules: []*tailcfg.SSHRule{
+				{
+					Principals: []*tailcfg.SSHPrincipal{
+						{NodeIP: "100.64.0.2"},
+					},
+					SSHUsers: map[string]string{
+						"autogroup:invalid": "autogroup:invalid",
+						"root":              "",
+					},
+					Action: &tailcfg.SSHAction{
+						Accept:                    true,
+						AllowAgentForwarding:      true,
+						AllowLocalPortForwarding:  true,
+						AllowRemotePortForwarding: true,
+					},
+				},
+			}},
 		},
 		{
 			name:       "autogroup-nonroot-should-use-wildcard-with-root-excluded",

--- a/hscontrol/policy/v2/policy.go
+++ b/hscontrol/policy/v2/policy.go
@@ -1467,27 +1467,13 @@ func (pm *PolicyManager) invalidateGlobalPolicyCache(newNodes views.Slice[types.
 	}
 }
 
-// flattenTags flattens the TagOwners by resolving nested tags and detecting cycles.
-// It will return a Owners list where all the Tag types have been resolved to their underlying Owners.
+// flattenTags resolves nested tag-owner references. Cycles
+// (tag:a -> tag:b -> tag:a, or tag:a -> tag:a) drop the cycle-causing
+// edge and contribute no addresses; non-cycle owners on the cycled tags
+// still resolve. Undefined-tag references remain a hard error.
 func flattenTags(tagOwners TagOwners, tag Tag, visiting map[Tag]bool, chain []Tag) (Owners, error) {
 	if visiting[tag] {
-		cycleStart := 0
-
-		for i, t := range chain {
-			if t == tag {
-				cycleStart = i
-				break
-			}
-		}
-
-		cycleTags := make([]string, len(chain[cycleStart:]))
-		for i, t := range chain[cycleStart:] {
-			cycleTags[i] = string(t)
-		}
-
-		slices.Sort(cycleTags)
-
-		return nil, fmt.Errorf("%w: %s", ErrCircularReference, strings.Join(cycleTags, " -> "))
+		return nil, nil
 	}
 
 	visiting[tag] = true

--- a/hscontrol/policy/v2/policy.go
+++ b/hscontrol/policy/v2/policy.go
@@ -208,6 +208,10 @@ func NewPolicyManager(b []byte, users []types.User, nodes views.Slice[types.Node
 		log.Warn().Err(testErr).Msg("policy tests failed at boot; server starting anyway, fix the policy and reload")
 	}
 
+	if testErr := pm.RunSSHTests(); testErr != nil { //nolint:noinlineerr // boot path: warn-and-continue, not return
+		log.Warn().Err(testErr).Msg("policy sshTests failed at boot; server starting anyway, fix the policy and reload")
+	}
+
 	return &pm, nil
 }
 
@@ -482,9 +486,16 @@ func (pm *PolicyManager) SetPolicy(polB []byte) (bool, error) {
 	// sandbox compiled from the new policy + current users/nodes; if
 	// they fail, return without mutating the live PolicyManager so the
 	// failed write does not knock the running config offline.
-	err = evaluateTests(pol, pm.users, pm.nodes)
-	if err != nil {
-		return false, err
+	//
+	// Aggregate ACL and SSH test failures via multierr so operators
+	// see both classes in a single response instead of having to
+	// fix-and-retry to discover the second one.
+	testErr := multierr.New(
+		evaluateTests(pol, pm.users, pm.nodes),
+		evaluateSSHTests(pol, pm.users, pm.nodes),
+	)
+	if testErr != nil {
+		return false, testErr
 	}
 
 	// Log policy metadata for debugging

--- a/hscontrol/policy/v2/sshtest.go
+++ b/hscontrol/policy/v2/sshtest.go
@@ -1,0 +1,664 @@
+package v2
+
+import (
+	"fmt"
+	"net/netip"
+	"slices"
+	"strings"
+
+	"github.com/juanfont/headscale/hscontrol/types"
+	"go4.org/netipx"
+	"tailscale.com/tailcfg"
+	"tailscale.com/types/views"
+)
+
+// sshTests assertions evaluate on user-initiated writes; boot reload
+// skips them so a stale reference does not block startup. Each entry
+// names a src and one or more dst, and uses:
+//
+//   - accept: every listed user reaches every dst via an accept- or
+//     check-action rule.
+//   - deny: no listed user reaches any dst.
+//   - check: every listed user reaches every dst via a check-action
+//     rule specifically (accept-only matches fail the assertion).
+
+// SSHPolicyTestResult is the outcome of a single SSHPolicyTest.
+type SSHPolicyTestResult struct {
+	Src    string   `json:"src"`
+	Passed bool     `json:"passed"`
+	Errors []string `json:"errors,omitempty"`
+
+	AcceptOK   map[string][]string `json:"accept_ok,omitempty"`
+	AcceptFail map[string][]string `json:"accept_fail,omitempty"`
+	DenyOK     map[string][]string `json:"deny_ok,omitempty"`
+	DenyFail   map[string][]string `json:"deny_fail,omitempty"`
+	CheckOK    map[string][]string `json:"check_ok,omitempty"`
+	CheckFail  map[string][]string `json:"check_fail,omitempty"`
+}
+
+// SSHPolicyTestResults aggregates one evaluation run.
+type SSHPolicyTestResults struct {
+	AllPassed bool                  `json:"all_passed"`
+	Results   []SSHPolicyTestResult `json:"results"`
+}
+
+// Errors renders the per-test failure breakdown joined by newlines.
+func (r SSHPolicyTestResults) Errors() string {
+	if r.AllPassed {
+		return ""
+	}
+
+	var lines []string
+
+	for _, res := range r.Results {
+		if res.Passed {
+			continue
+		}
+
+		for _, e := range res.Errors {
+			lines = append(lines, fmt.Sprintf("%s: %s", res.Src, e))
+		}
+
+		for _, user := range sortedUsers(res.AcceptFail) {
+			for _, dst := range res.AcceptFail[user] {
+				lines = append(lines, fmt.Sprintf(
+					"%s/%s -> %s: expected ALLOWED, got DENIED",
+					res.Src, displayUser(user), dst,
+				))
+			}
+		}
+
+		for _, user := range sortedUsers(res.DenyFail) {
+			for _, dst := range res.DenyFail[user] {
+				lines = append(lines, fmt.Sprintf(
+					"%s/%s -> %s: expected DENIED, got ALLOWED",
+					res.Src, displayUser(user), dst,
+				))
+			}
+		}
+
+		for _, user := range sortedUsers(res.CheckFail) {
+			for _, dst := range res.CheckFail[user] {
+				lines = append(lines, fmt.Sprintf(
+					"%s/%s -> %s: expected ALLOWED via check, got %s",
+					res.Src, displayUser(user), dst,
+					checkFailReason(res, user, dst),
+				))
+			}
+		}
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+func sortedUsers(m map[string][]string) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+
+	slices.Sort(keys)
+
+	return keys
+}
+
+// displayUser shows an empty username as `""` rather than blank.
+func displayUser(u string) string {
+	if u == "" {
+		return `""`
+	}
+
+	return u
+}
+
+// checkFailReason annotates a check-fail with whether the user reached
+// the dst via an accept rule or did not reach at all.
+func checkFailReason(res SSHPolicyTestResult, user, dst string) string {
+	if slices.Contains(res.AcceptOK[user], dst) {
+		return "ALLOWED via accept"
+	}
+
+	return "DENIED"
+}
+
+// RunSSHTests evaluates the live policy's sshTests block and wraps any
+// failure in errSSHPolicyTestsFailed.
+func (pm *PolicyManager) RunSSHTests() error {
+	if pm == nil || pm.pol == nil || len(pm.pol.SSHTests) == 0 {
+		return nil
+	}
+
+	pm.mu.Lock()
+	defer pm.mu.Unlock()
+
+	cache := make(map[types.NodeID]*tailcfg.SSHPolicy)
+	results := runSSHPolicyTests(pm.pol, pm.users, pm.nodes, cache)
+
+	if results.AllPassed {
+		return nil
+	}
+
+	return fmt.Errorf("%w:\n%s", errSSHPolicyTestsFailed, results.Errors())
+}
+
+// evaluateSSHTests runs the block against pol without mutating live state.
+func evaluateSSHTests(
+	pol *Policy,
+	users []types.User,
+	nodes views.Slice[types.NodeView],
+) error {
+	if pol == nil || len(pol.SSHTests) == 0 {
+		return nil
+	}
+
+	cache := make(map[types.NodeID]*tailcfg.SSHPolicy)
+	results := runSSHPolicyTests(pol, users, nodes, cache)
+
+	if results.AllPassed {
+		return nil
+	}
+
+	return fmt.Errorf("%w:\n%s", errSSHPolicyTestsFailed, results.Errors())
+}
+
+// runSSHPolicyTests evaluates every sshTests entry. The cache is keyed
+// by dst NodeID so repeat destinations only compile once per pass.
+func runSSHPolicyTests(
+	pol *Policy,
+	users []types.User,
+	nodes views.Slice[types.NodeView],
+	cache map[types.NodeID]*tailcfg.SSHPolicy,
+) SSHPolicyTestResults {
+	results := SSHPolicyTestResults{
+		AllPassed: true,
+		Results:   make([]SSHPolicyTestResult, 0, len(pol.SSHTests)),
+	}
+
+	for _, test := range pol.SSHTests {
+		res := runSSHPolicyTest(test, pol, users, nodes, cache)
+		if !res.Passed {
+			results.AllPassed = false
+		}
+
+		results.Results = append(results.Results, res)
+	}
+
+	return results
+}
+
+// runSSHPolicyTest evaluates one entry: resolve src → resolve dst →
+// walk accept/deny/check arrays against each dst's compiled SSH policy.
+func runSSHPolicyTest(
+	test SSHPolicyTest,
+	pol *Policy,
+	users []types.User,
+	nodes views.Slice[types.NodeView],
+	cache map[types.NodeID]*tailcfg.SSHPolicy,
+) SSHPolicyTestResult {
+	srcLabel := ""
+	if test.Src != nil {
+		srcLabel = test.Src.String()
+	}
+
+	res := SSHPolicyTestResult{
+		Src:    srcLabel,
+		Passed: true,
+	}
+
+	srcAddrs, srcUserID, err := resolveSSHTestSource(test.Src, pol, users, nodes)
+	if err != nil {
+		res.Passed = false
+		res.Errors = append(res.Errors,
+			fmt.Sprintf("failed to resolve source %q: %v", srcLabel, err))
+
+		return res
+	}
+
+	if len(srcAddrs) == 0 {
+		res.Passed = false
+		res.Errors = append(res.Errors,
+			fmt.Sprintf("source %q resolved to no IP addresses", srcLabel))
+
+		return res
+	}
+
+	// An entry with no assertion arrays would silently pass.
+	if len(test.Accept) == 0 && len(test.Deny) == 0 && len(test.Check) == 0 {
+		res.Passed = false
+		res.Errors = append(res.Errors,
+			"no accept, deny, or check assertions specified")
+
+		return res
+	}
+
+	dstNodes, emptyDsts, err := resolveSSHTestDestNodes(test.Dst, pol, users, nodes, srcUserID)
+	if err != nil {
+		res.Passed = false
+		res.Errors = append(res.Errors,
+			fmt.Sprintf("failed to resolve destinations: %v", err))
+
+		return res
+	}
+
+	// A dst resolving to zero nodes would silently pass.
+	for _, dst := range emptyDsts {
+		res.Passed = false
+		res.Errors = append(res.Errors,
+			fmt.Sprintf("dst alias %q resolved to no nodes", dst))
+	}
+
+	if len(dstNodes) == 0 {
+		return res
+	}
+
+	for _, user := range test.Accept {
+		evaluateAssertion(
+			pol, users, nodes, cache,
+			srcAddrs, dstNodes, user.String(),
+			assertAccept, &res,
+		)
+	}
+
+	for _, user := range test.Deny {
+		evaluateAssertion(
+			pol, users, nodes, cache,
+			srcAddrs, dstNodes, user.String(),
+			assertDeny, &res,
+		)
+	}
+
+	for _, user := range test.Check {
+		evaluateAssertion(
+			pol, users, nodes, cache,
+			srcAddrs, dstNodes, user.String(),
+			assertCheck, &res,
+		)
+	}
+
+	return res
+}
+
+type sshAssertion int
+
+const (
+	assertAccept sshAssertion = iota
+	assertDeny
+	assertCheck
+)
+
+// evaluateAssertion walks every (srcAddr, dstNode) pair for one user
+// and records the outcome. Empty username fails — SSH login users
+// cannot be empty even when parse accepted it.
+func evaluateAssertion(
+	pol *Policy,
+	users []types.User,
+	nodes views.Slice[types.NodeView],
+	cache map[types.NodeID]*tailcfg.SSHPolicy,
+	srcAddrs []netip.Addr,
+	dstNodes []types.NodeView,
+	user string,
+	kind sshAssertion,
+	res *SSHPolicyTestResult,
+) {
+dstLoop:
+	for _, dst := range dstNodes {
+		dstPol, err := compiledSSHPolicy(pol, users, nodes, cache, dst)
+		if err != nil {
+			res.Passed = false
+			res.Errors = append(res.Errors,
+				fmt.Sprintf("compiling SSH policy for %s: %v",
+					dst.Hostname(), err))
+
+			continue
+		}
+
+		dstLabel := dst.Hostname()
+
+		acceptHit := false
+		checkHit := false
+
+		for _, srcAddr := range srcAddrs {
+			a, c := reachability(dstPol, srcAddr, user)
+			if a {
+				acceptHit = true
+			}
+
+			if c {
+				checkHit = true
+			}
+
+			// All src IPs must agree; one counter-example fails
+			// the whole (user, dst) pair.
+			switch kind {
+			case assertAccept:
+				if !a {
+					res.Passed = false
+					res.AcceptFail = appendUserDst(res.AcceptFail, user, dstLabel)
+
+					continue dstLoop
+				}
+			case assertDeny:
+				if a {
+					res.Passed = false
+					res.DenyFail = appendUserDst(res.DenyFail, user, dstLabel)
+
+					continue dstLoop
+				}
+			case assertCheck:
+				if !c {
+					res.Passed = false
+					res.CheckFail = appendUserDst(res.CheckFail, user, dstLabel)
+
+					// Record whether the accept side passed so
+					// the rendered error can say "ALLOWED via
+					// accept" instead of "DENIED".
+					if a {
+						res.AcceptOK = appendUserDst(res.AcceptOK, user, dstLabel)
+					}
+
+					continue dstLoop
+				}
+			}
+		}
+
+		switch kind {
+		case assertAccept:
+			if acceptHit {
+				res.AcceptOK = appendUserDst(res.AcceptOK, user, dstLabel)
+			}
+		case assertDeny:
+			res.DenyOK = appendUserDst(res.DenyOK, user, dstLabel)
+		case assertCheck:
+			if checkHit {
+				res.CheckOK = appendUserDst(res.CheckOK, user, dstLabel)
+			}
+		}
+	}
+}
+
+// appendUserDst appends dst to m[user], allocating m on first use.
+func appendUserDst(m map[string][]string, user, dst string) map[string][]string {
+	if m == nil {
+		m = make(map[string][]string)
+	}
+
+	m[user] = append(m[user], dst)
+
+	return m
+}
+
+// resolveSSHTestSource returns the src's principal addresses and, for
+// user-shaped sources, the user ID (so autogroup:self can scope to it).
+// Tag, host, and IP sources return userID 0.
+func resolveSSHTestSource(
+	src Alias,
+	pol *Policy,
+	users []types.User,
+	nodes views.Slice[types.NodeView],
+) ([]netip.Addr, uint, error) {
+	if src == nil {
+		return nil, 0, nil
+	}
+
+	addrs, err := src.Resolve(pol, users, nodes)
+	if err != nil {
+		return nil, 0, fmt.Errorf("resolving: %w", err)
+	}
+
+	if addrs == nil || addrs.Empty() {
+		return nil, 0, nil
+	}
+
+	out := make([]netip.Addr, 0)
+	for a := range addrs.Iter() {
+		out = append(out, a)
+	}
+
+	var userID uint
+
+	u, ok := src.(*Username)
+	if ok {
+		resolved, rErr := u.resolveUser(users)
+		if rErr == nil {
+			userID = resolved.ID
+		}
+	}
+
+	return out, userID, nil
+}
+
+// resolveSSHTestDestNodes maps each dst alias to its destination
+// NodeViews. autogroup:self needs special handling: it cannot resolve
+// without per-node context, so it walks the node set keyed on src's
+// owning user. Other aliases resolve to an IPSet and match via InIPSet.
+func resolveSSHTestDestNodes(
+	dsts SSHTestDestinations,
+	pol *Policy,
+	users []types.User,
+	nodes views.Slice[types.NodeView],
+	srcUserID uint,
+) ([]types.NodeView, []string, error) {
+	seen := make(map[types.NodeID]struct{})
+
+	var (
+		out       []types.NodeView
+		emptyDsts []string
+	)
+
+	for _, alias := range dsts {
+		dstLabel := alias.String()
+		matched := false
+
+		if ag, ok := alias.(*AutoGroup); ok && ag.Is(AutoGroupSelf) {
+			// autogroup:self resolves to non-tagged nodes owned by
+			// the same user as src; tagged/IP sources have no user.
+			if srcUserID == 0 {
+				emptyDsts = append(emptyDsts, dstLabel)
+
+				continue
+			}
+
+			for _, n := range nodes.All() {
+				if n.IsTagged() {
+					continue
+				}
+
+				if !n.User().Valid() {
+					continue
+				}
+
+				if n.User().ID() != srcUserID {
+					continue
+				}
+
+				matched = true
+
+				if _, dup := seen[n.ID()]; dup {
+					continue
+				}
+
+				seen[n.ID()] = struct{}{}
+				out = append(out, n)
+			}
+
+			if !matched {
+				emptyDsts = append(emptyDsts, dstLabel)
+			}
+
+			continue
+		}
+
+		ips, err := alias.Resolve(pol, users, nodes)
+		if err != nil {
+			return nil, nil, fmt.Errorf("resolving destination %q: %w", dstLabel, err)
+		}
+
+		if ips == nil || ips.Empty() {
+			emptyDsts = append(emptyDsts, dstLabel)
+
+			continue
+		}
+
+		set, err := prefixesToIPSet(ips.Prefixes())
+		if err != nil {
+			return nil, nil, fmt.Errorf("building IPSet for %q: %w", dstLabel, err)
+		}
+
+		for _, n := range nodes.All() {
+			if !n.InIPSet(set) {
+				continue
+			}
+
+			matched = true
+
+			if _, dup := seen[n.ID()]; dup {
+				continue
+			}
+
+			seen[n.ID()] = struct{}{}
+			out = append(out, n)
+		}
+
+		if !matched {
+			emptyDsts = append(emptyDsts, dstLabel)
+		}
+	}
+
+	return out, emptyDsts, nil
+}
+
+// prefixesToIPSet builds the IPSet that InIPSet expects on the node
+// side.
+func prefixesToIPSet(prefixes []netip.Prefix) (*netipx.IPSet, error) {
+	var b netipx.IPSetBuilder
+
+	for _, p := range prefixes {
+		b.AddPrefix(p)
+	}
+
+	return b.IPSet()
+}
+
+// compiledSSHPolicy returns the per-node compiled SSH policy, caching
+// on miss. baseURL is empty because reachability only checks for the
+// presence of HoldAndDelegate, not its value.
+func compiledSSHPolicy(
+	pol *Policy,
+	users []types.User,
+	nodes views.Slice[types.NodeView],
+	cache map[types.NodeID]*tailcfg.SSHPolicy,
+	node types.NodeView,
+) (*tailcfg.SSHPolicy, error) {
+	if sshPol, ok := cache[node.ID()]; ok {
+		return sshPol, nil
+	}
+
+	sshPol, err := pol.compileSSHPolicy("", users, node, nodes)
+	if err != nil {
+		return nil, err
+	}
+
+	cache[node.ID()] = sshPol
+
+	return sshPol, nil
+}
+
+// reachability reports whether srcAddr can log in as user via:
+//
+//   - any matching rule (acceptHit, satisfies accept assertions)
+//   - a check-action rule (checkHit, satisfies check assertions)
+func reachability(
+	dstPolicy *tailcfg.SSHPolicy,
+	srcAddr netip.Addr,
+	user string,
+) (bool, bool) {
+	if dstPolicy == nil {
+		return false, false
+	}
+
+	var acceptHit, checkHit bool
+
+	for _, rule := range dstPolicy.Rules {
+		if !principalContainsAddr(rule.Principals, srcAddr) {
+			continue
+		}
+
+		if !sshUserMapAllows(rule.SSHUsers, user) {
+			continue
+		}
+
+		if rule.Action == nil {
+			continue
+		}
+
+		acceptHit = true
+
+		if rule.Action.HoldAndDelegate != "" {
+			checkHit = true
+		}
+
+		// Early-out only when both bits are set: a rule satisfying
+		// accept does not always satisfy check.
+		if acceptHit && checkHit {
+			return acceptHit, checkHit
+		}
+	}
+
+	return acceptHit, checkHit
+}
+
+// principalContainsAddr reports whether any principal's NodeIP matches
+// srcAddr exactly (the SSH compiler emits one principal per source IP).
+func principalContainsAddr(
+	principals []*tailcfg.SSHPrincipal,
+	srcAddr netip.Addr,
+) bool {
+	for _, p := range principals {
+		if p == nil {
+			continue
+		}
+
+		if p.NodeIP == "" {
+			continue
+		}
+
+		addr, err := netip.ParseAddr(p.NodeIP)
+		if err != nil {
+			continue
+		}
+
+		if addr == srcAddr {
+			return true
+		}
+	}
+
+	return false
+}
+
+// sshUserMapAllows reports whether SSHUsers permits user. The SSHUsers
+// wire shape (see filter.go compileSSHPolicy):
+//
+//   - SSHUsers["root"] == "root" allows root; == "" disallows it.
+//   - SSHUsers["*"] == "=" is the wildcard fallback for non-root users
+//     (set when the rule lists autogroup:nonroot).
+//   - SSHUsers[<literal>] == <literal> for every named user.
+func sshUserMapAllows(m map[string]string, user string) bool {
+	if user == "" {
+		return false
+	}
+
+	if v, ok := m[user]; ok {
+		return v != ""
+	}
+
+	if user == "root" {
+		return false
+	}
+
+	// Wildcard fallback for non-root users.
+	if v, ok := m["*"]; ok {
+		return v != ""
+	}
+
+	return false
+}

--- a/hscontrol/policy/v2/sshtest_test.go
+++ b/hscontrol/policy/v2/sshtest_test.go
@@ -1,0 +1,1000 @@
+package v2
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/juanfont/headscale/hscontrol/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gorm.io/gorm"
+)
+
+// sshTestUsers/sshTestNodes are reused across the table below to keep
+// each row focussed on the policy under exercise. Three users, six
+// nodes:
+//
+//   - alice (id 1) at headscale.net owns alice-laptop and alice-tablet
+//   - bob   (id 2) at headscale.net owns bob-laptop
+//   - thor  (id 3) at example.org   owns thor-laptop
+//   - server (alice-created tagged node) → tag:server
+//   - prod   (alice-created tagged node) → tag:prod
+func sshTestUsers() types.Users {
+	return types.Users{
+		{Model: gorm.Model{ID: 1}, Name: "alice", Email: "alice@headscale.net"},
+		{Model: gorm.Model{ID: 2}, Name: "bob", Email: "bob@headscale.net"},
+		{Model: gorm.Model{ID: 3}, Name: "thor", Email: "thor@example.org"},
+	}
+}
+
+func sshTestNodes(users types.Users) types.Nodes {
+	return types.Nodes{
+		{
+			ID:       1,
+			Hostname: "alice-laptop",
+			IPv4:     ap("100.64.0.1"),
+			IPv6:     ap("fd7a:115c:a1e0::1"),
+			User:     &users[0],
+			UserID:   &users[0].ID,
+		},
+		{
+			ID:       2,
+			Hostname: "bob-laptop",
+			IPv4:     ap("100.64.0.2"),
+			IPv6:     ap("fd7a:115c:a1e0::2"),
+			User:     &users[1],
+			UserID:   &users[1].ID,
+		},
+		{
+			ID:       3,
+			Hostname: "server",
+			IPv4:     ap("100.64.0.3"),
+			IPv6:     ap("fd7a:115c:a1e0::3"),
+			User:     &users[0],
+			UserID:   &users[0].ID,
+			Tags:     []string{"tag:server"},
+		},
+		{
+			ID:       4,
+			Hostname: "alice-tablet",
+			IPv4:     ap("100.64.0.4"),
+			IPv6:     ap("fd7a:115c:a1e0::4"),
+			User:     &users[0],
+			UserID:   &users[0].ID,
+		},
+		{
+			ID:       5,
+			Hostname: "thor-laptop",
+			IPv4:     ap("100.64.0.5"),
+			IPv6:     ap("fd7a:115c:a1e0::5"),
+			User:     &users[2],
+			UserID:   &users[2].ID,
+		},
+		{
+			ID:       6,
+			Hostname: "prod",
+			IPv4:     ap("100.64.0.6"),
+			IPv6:     ap("fd7a:115c:a1e0::6"),
+			User:     &users[0],
+			UserID:   &users[0].ID,
+			Tags:     []string{"tag:prod"},
+		},
+	}
+}
+
+// TestRunSSHTests covers the engine's per-test outcome reporting. Each
+// row constructs a PolicyManager (whose SetPolicy sandbox also exercises
+// evaluateSSHTests) and asserts on the resulting RunSSHTests behaviour.
+// SetPolicy gating is exercised separately in
+// TestSetPolicyRejectsFailingSSHTests below.
+func TestRunSSHTests(t *testing.T) {
+	users := sshTestUsers()
+	nodes := sshTestNodes(users)
+
+	tests := []struct {
+		name       string
+		policy     string
+		wantPass   bool
+		wantErrSub []string
+	}{
+		{
+			name: "accept-pass-basic",
+			policy: `{
+				"tagOwners": { "tag:server": ["alice@headscale.net"] },
+				"ssh": [{
+					"action": "accept",
+					"src":    ["alice@headscale.net"],
+					"dst":    ["tag:server"],
+					"users":  ["root"]
+				}],
+				"sshTests": [{
+					"src":    "alice@headscale.net",
+					"dst":    ["tag:server"],
+					"accept": ["root"]
+				}]
+			}`,
+			wantPass: true,
+		},
+		{
+			name: "accept-pass-multi-user-in-rule",
+			policy: `{
+				"tagOwners": { "tag:server": ["alice@headscale.net"] },
+				"ssh": [{
+					"action": "accept",
+					"src":    ["alice@headscale.net"],
+					"dst":    ["tag:server"],
+					"users":  ["root", "ubuntu"]
+				}],
+				"sshTests": [{
+					"src":    "alice@headscale.net",
+					"dst":    ["tag:server"],
+					"accept": ["root", "ubuntu"]
+				}]
+			}`,
+			wantPass: true,
+		},
+		{
+			name: "accept-fail-no-rule",
+			policy: `{
+				"tagOwners": { "tag:server": ["alice@headscale.net"] },
+				"sshTests": [{
+					"src":    "alice@headscale.net",
+					"dst":    ["tag:server"],
+					"accept": ["root"]
+				}]
+			}`,
+			wantPass:   false,
+			wantErrSub: []string{"alice@headscale.net", "root", "expected ALLOWED"},
+		},
+		{
+			name: "accept-fail-user-not-allowed-by-rule",
+			policy: `{
+				"tagOwners": { "tag:server": ["alice@headscale.net"] },
+				"ssh": [{
+					"action": "accept",
+					"src":    ["alice@headscale.net"],
+					"dst":    ["tag:server"],
+					"users":  ["root"]
+				}],
+				"sshTests": [{
+					"src":    "alice@headscale.net",
+					"dst":    ["tag:server"],
+					"accept": ["mallory"]
+				}]
+			}`,
+			wantPass:   false,
+			wantErrSub: []string{"alice@headscale.net", "mallory", "expected ALLOWED"},
+		},
+		{
+			name: "accept-fail-different-src",
+			policy: `{
+				"tagOwners": { "tag:server": ["alice@headscale.net"] },
+				"ssh": [{
+					"action": "accept",
+					"src":    ["alice@headscale.net"],
+					"dst":    ["tag:server"],
+					"users":  ["root"]
+				}],
+				"sshTests": [{
+					"src":    "bob@headscale.net",
+					"dst":    ["tag:server"],
+					"accept": ["root"]
+				}]
+			}`,
+			wantPass:   false,
+			wantErrSub: []string{"bob@headscale.net", "root", "expected ALLOWED"},
+		},
+		{
+			name: "deny-pass-no-rule",
+			policy: `{
+				"tagOwners": { "tag:server": ["alice@headscale.net"] },
+				"sshTests": [{
+					"src":  "alice@headscale.net",
+					"dst":  ["tag:server"],
+					"deny": ["root"]
+				}]
+			}`,
+			wantPass: true,
+		},
+		{
+			name: "deny-pass-rule-blocks-user",
+			policy: `{
+				"tagOwners": { "tag:server": ["alice@headscale.net"] },
+				"ssh": [{
+					"action": "accept",
+					"src":    ["alice@headscale.net"],
+					"dst":    ["tag:server"],
+					"users":  ["autogroup:nonroot"]
+				}],
+				"sshTests": [{
+					"src":  "alice@headscale.net",
+					"dst":  ["tag:server"],
+					"deny": ["root"]
+				}]
+			}`,
+			wantPass: true,
+		},
+		{
+			name: "deny-fail-rule-allows",
+			policy: `{
+				"tagOwners": { "tag:server": ["alice@headscale.net"] },
+				"ssh": [{
+					"action": "accept",
+					"src":    ["alice@headscale.net"],
+					"dst":    ["tag:server"],
+					"users":  ["root"]
+				}],
+				"sshTests": [{
+					"src":  "alice@headscale.net",
+					"dst":  ["tag:server"],
+					"deny": ["root"]
+				}]
+			}`,
+			wantPass:   false,
+			wantErrSub: []string{"alice@headscale.net", "root", "expected DENIED"},
+		},
+		{
+			name: "check-pass-rule-is-check",
+			policy: `{
+				"tagOwners": { "tag:server": ["alice@headscale.net"] },
+				"ssh": [{
+					"action": "check",
+					"src":    ["alice@headscale.net"],
+					"dst":    ["tag:server"],
+					"users":  ["root"]
+				}],
+				"sshTests": [{
+					"src":   "alice@headscale.net",
+					"dst":   ["tag:server"],
+					"check": ["root"]
+				}]
+			}`,
+			wantPass: true,
+		},
+		{
+			name: "check-fail-rule-is-accept",
+			policy: `{
+				"tagOwners": { "tag:server": ["alice@headscale.net"] },
+				"ssh": [{
+					"action": "accept",
+					"src":    ["alice@headscale.net"],
+					"dst":    ["tag:server"],
+					"users":  ["root"]
+				}],
+				"sshTests": [{
+					"src":   "alice@headscale.net",
+					"dst":   ["tag:server"],
+					"check": ["root"]
+				}]
+			}`,
+			wantPass: false,
+			wantErrSub: []string{
+				"alice@headscale.net",
+				"root",
+				"via check",
+				"via accept",
+			},
+		},
+		{
+			name: "check-pass-and-accept-pass-coexist",
+			policy: `{
+				"tagOwners": { "tag:server": ["alice@headscale.net"] },
+				"ssh": [
+					{
+						"action": "accept",
+						"src":    ["alice@headscale.net"],
+						"dst":    ["tag:server"],
+						"users":  ["root"]
+					},
+					{
+						"action": "check",
+						"src":    ["alice@headscale.net"],
+						"dst":    ["tag:server"],
+						"users":  ["ubuntu"]
+					}
+				],
+				"sshTests": [{
+					"src":    "alice@headscale.net",
+					"dst":    ["tag:server"],
+					"accept": ["root"],
+					"check":  ["ubuntu"]
+				}]
+			}`,
+			wantPass: true,
+		},
+		{
+			name: "accept-passes-on-check-rule",
+			policy: `{
+				"tagOwners": { "tag:server": ["alice@headscale.net"] },
+				"ssh": [{
+					"action": "check",
+					"src":    ["alice@headscale.net"],
+					"dst":    ["tag:server"],
+					"users":  ["root"]
+				}],
+				"sshTests": [{
+					"src":    "alice@headscale.net",
+					"dst":    ["tag:server"],
+					"accept": ["root"]
+				}]
+			}`,
+			wantPass: true,
+		},
+		{
+			name: "multi-dst-all-must-reach",
+			policy: `{
+				"tagOwners": {
+					"tag:server": ["alice@headscale.net"],
+					"tag:prod":   ["alice@headscale.net"]
+				},
+				"ssh": [{
+					"action": "accept",
+					"src":    ["alice@headscale.net"],
+					"dst":    ["tag:server"],
+					"users":  ["root"]
+				}],
+				"sshTests": [{
+					"src":    "alice@headscale.net",
+					"dst":    ["tag:server", "tag:prod"],
+					"accept": ["root"]
+				}]
+			}`,
+			wantPass: false,
+			wantErrSub: []string{
+				"alice@headscale.net",
+				"root",
+				"prod",
+				"expected ALLOWED",
+			},
+		},
+		{
+			name: "multi-user-mixed-accept-deny-check-in-one-entry",
+			policy: `{
+				"tagOwners": { "tag:server": ["alice@headscale.net"] },
+				"ssh": [
+					{
+						"action": "accept",
+						"src":    ["alice@headscale.net"],
+						"dst":    ["tag:server"],
+						"users":  ["root"]
+					},
+					{
+						"action": "check",
+						"src":    ["alice@headscale.net"],
+						"dst":    ["tag:server"],
+						"users":  ["ubuntu"]
+					}
+				],
+				"sshTests": [{
+					"src":    "alice@headscale.net",
+					"dst":    ["tag:server"],
+					"accept": ["root"],
+					"deny":   ["mallory"],
+					"check":  ["ubuntu"]
+				}]
+			}`,
+			wantPass: true,
+		},
+		{
+			name: "nonroot-allows-alice",
+			policy: `{
+				"tagOwners": { "tag:server": ["alice@headscale.net"] },
+				"ssh": [{
+					"action": "accept",
+					"src":    ["alice@headscale.net"],
+					"dst":    ["tag:server"],
+					"users":  ["autogroup:nonroot"]
+				}],
+				"sshTests": [{
+					"src":    "alice@headscale.net",
+					"dst":    ["tag:server"],
+					"accept": ["alice"]
+				}]
+			}`,
+			wantPass: true,
+		},
+		{
+			name: "nonroot-denies-root",
+			policy: `{
+				"tagOwners": { "tag:server": ["alice@headscale.net"] },
+				"ssh": [{
+					"action": "accept",
+					"src":    ["alice@headscale.net"],
+					"dst":    ["tag:server"],
+					"users":  ["autogroup:nonroot"]
+				}],
+				"sshTests": [
+					{
+						"src":    "alice@headscale.net",
+						"dst":    ["tag:server"],
+						"accept": ["root"]
+					},
+					{
+						"src":  "alice@headscale.net",
+						"dst":  ["tag:server"],
+						"deny": ["root"]
+					}
+				]
+			}`,
+			wantPass:   false,
+			wantErrSub: []string{"alice@headscale.net", "root", "expected ALLOWED"},
+		},
+		{
+			name: "wildcard-user-allows-mallory",
+			policy: `{
+				"tagOwners": { "tag:server": ["alice@headscale.net"] },
+				"ssh": [{
+					"action": "accept",
+					"src":    ["alice@headscale.net"],
+					"dst":    ["tag:server"],
+					"users":  ["autogroup:nonroot"]
+				}],
+				"sshTests": [{
+					"src":    "alice@headscale.net",
+					"dst":    ["tag:server"],
+					"accept": ["mallory"]
+				}]
+			}`,
+			wantPass: true,
+		},
+		{
+			name: "root-only-rule",
+			policy: `{
+				"tagOwners": { "tag:server": ["alice@headscale.net"] },
+				"ssh": [{
+					"action": "accept",
+					"src":    ["alice@headscale.net"],
+					"dst":    ["tag:server"],
+					"users":  ["root"]
+				}],
+				"sshTests": [
+					{
+						"src":    "alice@headscale.net",
+						"dst":    ["tag:server"],
+						"accept": ["root"]
+					},
+					{
+						"src":    "alice@headscale.net",
+						"dst":    ["tag:server"],
+						"accept": ["alice"]
+					}
+				]
+			}`,
+			wantPass:   false,
+			wantErrSub: []string{"alice@headscale.net", "alice", "expected ALLOWED"},
+		},
+		{
+			name: "autogroup-self-same-user",
+			policy: `{
+				"ssh": [{
+					"action": "accept",
+					"src":    ["autogroup:member"],
+					"dst":    ["autogroup:self"],
+					"users":  ["root"]
+				}],
+				"sshTests": [{
+					"src":    "alice@headscale.net",
+					"dst":    ["autogroup:self"],
+					"accept": ["root"]
+				}]
+			}`,
+			wantPass: true,
+		},
+		{
+			name: "autogroup-self-cross-user-fails",
+			policy: `{
+				"ssh": [{
+					"action": "accept",
+					"src":    ["alice@headscale.net"],
+					"dst":    ["autogroup:self"],
+					"users":  ["root"]
+				}],
+				"sshTests": [{
+					"src":    "bob@headscale.net",
+					"dst":    ["autogroup:self"],
+					"accept": ["root"]
+				}]
+			}`,
+			wantPass: false,
+			// autogroup:self for bob resolves to bob-laptop; the only
+			// rule allows alice as src, so reachability fails.
+			wantErrSub: []string{"bob@headscale.net", "root"},
+		},
+		{
+			name: "localpart-domain-match",
+			policy: `{
+				"tagOwners": { "tag:server": ["alice@headscale.net"] },
+				"ssh": [{
+					"action": "accept",
+					"src":    ["alice@headscale.net"],
+					"dst":    ["tag:server"],
+					"users":  ["localpart:*@headscale.net"]
+				}],
+				"sshTests": [{
+					"src":    "alice@headscale.net",
+					"dst":    ["tag:server"],
+					"accept": ["alice"]
+				}]
+			}`,
+			wantPass: true,
+		},
+		{
+			name: "localpart-domain-mismatch",
+			policy: `{
+				"tagOwners": { "tag:server": ["alice@headscale.net"] },
+				"ssh": [{
+					"action": "accept",
+					"src":    ["thor@example.org"],
+					"dst":    ["tag:server"],
+					"users":  ["localpart:*@headscale.net"]
+				}],
+				"sshTests": [{
+					"src":    "thor@example.org",
+					"dst":    ["tag:server"],
+					"accept": ["thor"]
+				}]
+			}`,
+			wantPass:   false,
+			wantErrSub: []string{"thor@example.org", "thor", "expected ALLOWED"},
+		},
+		{
+			name: "tag-as-src",
+			policy: `{
+				"tagOwners": {
+					"tag:server": ["alice@headscale.net"],
+					"tag:prod":   ["alice@headscale.net"]
+				},
+				"ssh": [{
+					"action": "accept",
+					"src":    ["tag:prod"],
+					"dst":    ["tag:server"],
+					"users":  ["root"]
+				}],
+				"sshTests": [{
+					"src":    "tag:prod",
+					"dst":    ["tag:server"],
+					"accept": ["root"]
+				}]
+			}`,
+			wantPass: true,
+		},
+		{
+			name: "acl-allows-tcp22-no-ssh-rule",
+			policy: `{
+				"tagOwners": { "tag:server": ["alice@headscale.net"] },
+				"acls": [{
+					"action": "accept",
+					"src":    ["alice@headscale.net"],
+					"dst":    ["tag:server:22"]
+				}],
+				"sshTests": [{
+					"src":    "alice@headscale.net",
+					"dst":    ["tag:server"],
+					"accept": ["root"]
+				}]
+			}`,
+			wantPass:   false,
+			wantErrSub: []string{"alice@headscale.net", "root", "expected ALLOWED"},
+		},
+		{
+			// ACL grants only TCP:80 to alice; no rule grants TCP:22.
+			// SSH rule independently allows root@tag:server. The
+			// sshTests assertion must pass on the SSH layer alone,
+			// proving the engine does not require an ACL packet-
+			// filter rule for the SSH port.
+			name: "acl-denies-tcp22-ssh-rule-allows",
+			policy: `{
+				"tagOwners": { "tag:server": ["alice@headscale.net"] },
+				"acls": [{
+					"action": "accept",
+					"src":    ["alice@headscale.net"],
+					"dst":    ["tag:server:80"]
+				}],
+				"ssh": [{
+					"action": "accept",
+					"src":    ["alice@headscale.net"],
+					"dst":    ["tag:server"],
+					"users":  ["root"]
+				}],
+				"sshTests": [{
+					"src":    "alice@headscale.net",
+					"dst":    ["tag:server"],
+					"accept": ["root"]
+				}]
+			}`,
+			wantPass: true,
+		},
+		{
+			name: "no-sshTests-block",
+			policy: `{
+				"acls": [{
+					"action": "accept",
+					"src":    ["*"],
+					"dst":    ["*:*"]
+				}]
+			}`,
+			wantPass: true,
+		},
+		{
+			name: "both-tests-and-sshTests-both-pass",
+			policy: `{
+				"tagOwners": { "tag:server": ["alice@headscale.net"] },
+				"acls": [{
+					"action": "accept",
+					"src":    ["alice@headscale.net"],
+					"dst":    ["tag:server:22"]
+				}],
+				"ssh": [{
+					"action": "accept",
+					"src":    ["alice@headscale.net"],
+					"dst":    ["tag:server"],
+					"users":  ["root"]
+				}],
+				"tests": [{
+					"src":    "alice@headscale.net",
+					"accept": ["tag:server:22"]
+				}],
+				"sshTests": [{
+					"src":    "alice@headscale.net",
+					"dst":    ["tag:server"],
+					"accept": ["root"]
+				}]
+			}`,
+			wantPass: true,
+		},
+		{
+			name: "empty-accept-deny-check-in-entry",
+			policy: `{
+				"tagOwners": { "tag:server": ["alice@headscale.net"] },
+				"sshTests": [{
+					"src": "alice@headscale.net",
+					"dst": ["tag:server"]
+				}]
+			}`,
+			wantPass:   false,
+			wantErrSub: []string{"alice@headscale.net", "no accept, deny, or check"},
+		},
+		{
+			name: "empty-user-in-accept",
+			policy: `{
+				"tagOwners": { "tag:server": ["alice@headscale.net"] },
+				"ssh": [{
+					"action": "accept",
+					"src":    ["alice@headscale.net"],
+					"dst":    ["tag:server"],
+					"users":  ["root"]
+				}],
+				"sshTests": [{
+					"src":    "alice@headscale.net",
+					"dst":    ["tag:server"],
+					"accept": [""]
+				}]
+			}`,
+			wantPass:   false,
+			wantErrSub: []string{"alice@headscale.net", "expected ALLOWED"},
+		},
+		{
+			// tag:empty has an owner but no tagged nodes, so the dst
+			// alias resolves to no nodes. Without the empty-dst guard
+			// the per-assertion loop runs zero iterations and the
+			// test silently passes — exactly the regression the
+			// guard exists to catch.
+			name: "dst-tag-with-no-tagged-nodes-fails",
+			policy: `{
+				"tagOwners": { "tag:empty": ["alice@headscale.net"] },
+				"sshTests": [{
+					"src":    "alice@headscale.net",
+					"dst":    ["tag:empty"],
+					"accept": ["root"]
+				}]
+			}`,
+			wantPass:   false,
+			wantErrSub: []string{"tag:empty", "resolved to no nodes"},
+		},
+		{
+			// autogroup:self from a tag src has no user identity to
+			// scope to, so the dst alias resolves to no nodes. Same
+			// empty-dst guard, distinct trigger path.
+			name: "dst-autogroup-self-from-tag-src-fails",
+			policy: `{
+				"tagOwners": { "tag:prod": ["alice@headscale.net"] },
+				"sshTests": [{
+					"src":    "tag:prod",
+					"dst":    ["autogroup:self"],
+					"accept": ["root"]
+				}]
+			}`,
+			wantPass:   false,
+			wantErrSub: []string{"autogroup:self", "resolved to no nodes"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pm, err := NewPolicyManager([]byte(tt.policy), users, nodes.ViewSlice())
+			require.NoError(t, err, "policy must parse and compile")
+
+			runErr := pm.RunSSHTests()
+			if tt.wantPass {
+				require.NoError(t, runErr, "sshTests should pass")
+
+				return
+			}
+
+			require.Error(t, runErr, "sshTests should fail")
+			require.ErrorIs(t, runErr, errSSHPolicyTestsFailed)
+
+			for _, sub := range tt.wantErrSub {
+				assert.Contains(t, runErr.Error(), sub,
+					"rendered error should mention %q", sub)
+			}
+		})
+	}
+}
+
+// TestRunSSHTestsBothTestsPassSSHTestsFail captures the distinction the
+// caller cares about: a passing ACL `tests` block plus a failing
+// `sshTests` block returns errSSHPolicyTestsFailed and NOT
+// errPolicyTestsFailed. The two sentinels share a literal message but
+// are distinct values.
+func TestRunSSHTestsBothTestsPassSSHTestsFail(t *testing.T) {
+	users := sshTestUsers()
+	nodes := sshTestNodes(users)
+
+	policy := `{
+		"tagOwners": { "tag:server": ["alice@headscale.net"] },
+		"acls": [{
+			"action": "accept",
+			"src":    ["alice@headscale.net"],
+			"dst":    ["tag:server:22"]
+		}],
+		"tests": [{
+			"src":    "alice@headscale.net",
+			"accept": ["tag:server:22"]
+		}],
+		"sshTests": [{
+			"src":    "alice@headscale.net",
+			"dst":    ["tag:server"],
+			"accept": ["root"]
+		}]
+	}`
+
+	pm, err := NewPolicyManager([]byte(policy), users, nodes.ViewSlice())
+	require.NoError(t, err)
+
+	// ACL tests should pass.
+	require.NoError(t, pm.RunTests())
+
+	// SSH tests should fail because there's no SSH rule for root.
+	sshErr := pm.RunSSHTests()
+	require.Error(t, sshErr)
+	require.ErrorIs(t, sshErr, errSSHPolicyTestsFailed)
+	require.NotErrorIs(t, sshErr, errPolicyTestsFailed,
+		"ACL test sentinel must not appear on SSH-only failure")
+}
+
+// TestSetPolicyRejectsFailingSSHTests asserts SetPolicy is the user-write
+// boundary: a policy whose sshTests fail is rejected without mutating
+// the live PolicyManager. SSHPolicy() output must remain the prior
+// rules.
+func TestSetPolicyRejectsFailingSSHTests(t *testing.T) {
+	users := sshTestUsers()
+	nodes := sshTestNodes(users)
+
+	good := `{
+		"tagOwners": { "tag:server": ["alice@headscale.net"] },
+		"ssh": [{
+			"action": "accept",
+			"src":    ["alice@headscale.net"],
+			"dst":    ["tag:server"],
+			"users":  ["root"]
+		}],
+		"sshTests": [{
+			"src":    "alice@headscale.net",
+			"dst":    ["tag:server"],
+			"accept": ["root"]
+		}]
+	}`
+
+	bad := `{
+		"tagOwners": { "tag:server": ["alice@headscale.net"] },
+		"ssh": [{
+			"action": "accept",
+			"src":    ["alice@headscale.net"],
+			"dst":    ["tag:server"],
+			"users":  ["root"]
+		}],
+		"sshTests": [{
+			"src":    "bob@headscale.net",
+			"dst":    ["tag:server"],
+			"accept": ["root"]
+		}]
+	}`
+
+	pm, err := NewPolicyManager([]byte(good), users, nodes.ViewSlice())
+	require.NoError(t, err)
+
+	// Snapshot SSHPolicy output for alice-laptop before the rejected
+	// write — the live PolicyManager state must still describe the
+	// previous (good) rules afterwards. JSON-marshal the snapshot so
+	// the comparison sees rule content, not just object identity: a
+	// hypothetical mutation that preserves the slice length but
+	// rewrites principals or SSHUsers would slip past a count-only
+	// assertion.
+	aliceView := nodes.ViewSlice().At(0)
+
+	beforePol, err := pm.SSHPolicy("", aliceView)
+	require.NoError(t, err)
+
+	beforeJSON, err := json.Marshal(beforePol)
+	require.NoError(t, err)
+
+	changed, err := pm.SetPolicy([]byte(bad))
+	require.Error(t, err, "SetPolicy must reject a policy whose sshTests fail")
+	require.False(t, changed, "SetPolicy must report no change when rejected")
+	require.ErrorIs(t, err, errSSHPolicyTestsFailed)
+	require.Contains(t, err.Error(), "expected ALLOWED")
+
+	afterPol, err := pm.SSHPolicy("", aliceView)
+	require.NoError(t, err)
+
+	afterJSON, err := json.Marshal(afterPol)
+	require.NoError(t, err)
+
+	require.JSONEq(t, string(beforeJSON), string(afterJSON),
+		"live SSH policy must not change after a rejected SetPolicy")
+}
+
+// TestSetPolicyAggregatesACLAndSSHTestFailures exercises the multierr
+// aggregation: when both layers fail, the returned error wraps both
+// sentinels so operators see every failure in a single round trip.
+func TestSetPolicyAggregatesACLAndSSHTestFailures(t *testing.T) {
+	users := sshTestUsers()
+	nodes := sshTestNodes(users)
+
+	good := `{
+		"tagOwners": { "tag:server": ["alice@headscale.net"] },
+		"acls": [{
+			"action": "accept",
+			"src":    ["alice@headscale.net"],
+			"dst":    ["tag:server:22"]
+		}],
+		"ssh": [{
+			"action": "accept",
+			"src":    ["alice@headscale.net"],
+			"dst":    ["tag:server"],
+			"users":  ["root"]
+		}],
+		"tests": [{
+			"src":    "alice@headscale.net",
+			"accept": ["tag:server:22"]
+		}],
+		"sshTests": [{
+			"src":    "alice@headscale.net",
+			"dst":    ["tag:server"],
+			"accept": ["root"]
+		}]
+	}`
+
+	// Both blocks fail: acls only allow alice but tests assert bob;
+	// ssh only allows alice but sshTests assert bob.
+	bad := `{
+		"tagOwners": { "tag:server": ["alice@headscale.net"] },
+		"acls": [{
+			"action": "accept",
+			"src":    ["alice@headscale.net"],
+			"dst":    ["tag:server:22"]
+		}],
+		"ssh": [{
+			"action": "accept",
+			"src":    ["alice@headscale.net"],
+			"dst":    ["tag:server"],
+			"users":  ["root"]
+		}],
+		"tests": [{
+			"src":    "bob@headscale.net",
+			"accept": ["tag:server:22"]
+		}],
+		"sshTests": [{
+			"src":    "bob@headscale.net",
+			"dst":    ["tag:server"],
+			"accept": ["root"]
+		}]
+	}`
+
+	pm, err := NewPolicyManager([]byte(good), users, nodes.ViewSlice())
+	require.NoError(t, err)
+
+	_, err = pm.SetPolicy([]byte(bad))
+	require.Error(t, err)
+	require.ErrorIs(t, err, errPolicyTestsFailed,
+		"aggregated error must wrap the ACL test sentinel")
+	require.ErrorIs(t, err, errSSHPolicyTestsFailed,
+		"aggregated error must wrap the SSH test sentinel")
+
+	body := err.Error()
+	assert.Contains(t, body, "tag:server:22",
+		"aggregated error must include the ACL failure message")
+	assert.Contains(t, body, "bob@headscale.net",
+		"aggregated error must include the bob src")
+	// The SSH renderer emits "src/user -> dst" form; the ACL renderer
+	// emits "src -> dst". Substring "/root -> " is unique to the SSH
+	// body, so finding it inside the aggregated error proves the SSH
+	// failure rendering was concatenated alongside the ACL body.
+	assert.Contains(t, body, "/root -> ",
+		"aggregated error must include the SSH-shape src/user -> dst rendering")
+}
+
+// TestNewPolicyManagerWarnsOnSSHTestsFailure asserts the boot path does
+// not error on a failing sshTests block: warn-and-continue is the right
+// behaviour for stale stored policy, mirroring the ACL tests handling.
+func TestNewPolicyManagerWarnsOnSSHTestsFailure(t *testing.T) {
+	users := sshTestUsers()
+	nodes := sshTestNodes(users)
+
+	// sshTests reference a user that does exist but no rule allows
+	// them — the test should fail at user-write but not at boot.
+	stale := `{
+		"tagOwners": { "tag:server": ["alice@headscale.net"] },
+		"sshTests": [{
+			"src":    "alice@headscale.net",
+			"dst":    ["tag:server"],
+			"accept": ["root"]
+		}]
+	}`
+
+	pm, err := NewPolicyManager([]byte(stale), users, nodes.ViewSlice())
+	require.NoError(t, err, "boot must not error on sshTests failure")
+	require.NotNil(t, pm)
+
+	// A subsequent SetPolicy of the same body must reject — that's
+	// the user-write path.
+	_, err = pm.SetPolicy([]byte(stale))
+	require.Error(t, err)
+	require.ErrorIs(t, err, errSSHPolicyTestsFailed)
+}
+
+// TestSSHPolicyTestResultsErrorsRendering checks the multi-line render
+// layout. Because the body is the user-facing error, the format needs
+// to identify (src, user, dst) cleanly across accept, deny, and check.
+func TestSSHPolicyTestResultsErrorsRendering(t *testing.T) {
+	results := SSHPolicyTestResults{
+		AllPassed: false,
+		Results: []SSHPolicyTestResult{
+			{
+				Src: "alice@headscale.net",
+				AcceptFail: map[string][]string{
+					"root": {"server"},
+				},
+			},
+			{
+				Src: "bob@headscale.net",
+				DenyFail: map[string][]string{
+					"root": {"alice-laptop"},
+				},
+			},
+			{
+				Src: "alice@headscale.net",
+				CheckFail: map[string][]string{
+					"ubuntu": {"server"},
+				},
+				AcceptOK: map[string][]string{
+					"ubuntu": {"server"},
+				},
+			},
+		},
+	}
+
+	rendered := results.Errors()
+	for _, sub := range []string{
+		"alice@headscale.net/root -> server: expected ALLOWED, got DENIED",
+		"bob@headscale.net/root -> alice-laptop: expected DENIED, got ALLOWED",
+		"alice@headscale.net/ubuntu -> server: expected ALLOWED via check, got ALLOWED via accept",
+	} {
+		assert.Contains(t, rendered, sub)
+	}
+
+	assert.Equal(t, 3, strings.Count(rendered, "\n")+1,
+		"expected one line per failing assertion")
+}

--- a/hscontrol/policy/v2/sshtester_compat_test.go
+++ b/hscontrol/policy/v2/sshtester_compat_test.go
@@ -1,0 +1,88 @@
+// Replay golden HuJSON captures under testdata/sshtest_results/*.hujson:
+// the 200 path requires headscale's evaluateSSHTests to pass; the
+// non-200 path requires headscale to reject the same input with the
+// captured error body as a substring. Divergences are listed in
+// knownSSHTesterDivergences with the engine gap each represents.
+
+package v2
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/juanfont/headscale/hscontrol/types/testcapture"
+	"github.com/stretchr/testify/require"
+)
+
+// knownSSHTesterDivergences names the engine gap for each capture where
+// headscale and upstream disagree.
+var knownSSHTesterDivergences = map[string]string{
+	"sshtest-malformed-dst-bare-ipv6": "bare-IPv6 sshTests dst: upstream parse-accepts then engine-rejects; headscale accepts (IPv4 mirror passes both sides)",
+}
+
+func TestSSHTesterCompat(t *testing.T) {
+	t.Parallel()
+
+	files, err := filepath.Glob(filepath.Join("testdata", "sshtest_results", "*.hujson"))
+	require.NoError(t, err, "failed to glob test files")
+
+	if len(files) == 0 {
+		t.Skip("no sshtest captures yet")
+	}
+
+	users := setupSSHDataCompatUsers()
+
+	for _, file := range files {
+		c, err := testcapture.Read(file)
+		require.NoError(t, err, "reading %s", file)
+
+		t.Run(c.TestID, func(t *testing.T) {
+			t.Parallel()
+
+			if reason, skip := knownSSHTesterDivergences[c.TestID]; skip {
+				t.Skip(reason)
+			}
+
+			// Each capture pins its own topology IPs; build nodes
+			// from the capture so host-alias dsts resolve.
+			nodes := buildGrantsNodesFromCapture(users, c)
+
+			policyJSON := []byte(c.Input.FullPolicy)
+
+			pm, parseErr := NewPolicyManager(policyJSON, users, nodes.ViewSlice())
+
+			if c.Input.APIResponseCode == 200 {
+				require.NoError(t, parseErr,
+					"tailscale accepted this policy; headscale must parse it")
+
+				_, setErr := pm.SetPolicy(policyJSON)
+				require.NoError(t, setErr,
+					"tailscale accepted this policy; headscale sshTests must pass")
+
+				return
+			}
+
+			var got error
+
+			switch {
+			case parseErr != nil:
+				got = parseErr
+			default:
+				_, setErr := pm.SetPolicy(policyJSON)
+				got = setErr
+			}
+
+			require.Error(t, got, "tailscale rejected; headscale must reject too")
+
+			if c.Input.APIResponseBody == nil || c.Input.APIResponseBody.Message == "" {
+				return
+			}
+
+			want := c.Input.APIResponseBody.Message
+			if !strings.Contains(got.Error(), want) {
+				t.Errorf("error body mismatch\n  tailscale wants: %q\n  headscale got:   %q", want, got.Error())
+			}
+		})
+	}
+}

--- a/hscontrol/policy/v2/tailscale_ssh_data_compat_test.go
+++ b/hscontrol/policy/v2/tailscale_ssh_data_compat_test.go
@@ -1,18 +1,9 @@
-// This file implements a data-driven test runner for SSH compatibility tests.
-// It loads HuJSON golden files from testdata/ssh_results/ssh-*.hujson, captured
-// from a Tailscale-hosted control plane, and compares headscale's SSH policy
-// compilation against the captured SSH rules.
-//
-// Each file is a testcapture.Capture containing:
-//   - The full policy that was POSTed to Tailscale SaaS (we use tf.Input.FullPolicy
-//     directly instead of reconstructing it from a sub-section)
-//   - The expected SSH rules for each of the 8 test nodes (in tf.Captures[name].SSHRules)
-//
-// Tests known to fail due to unimplemented features or known differences are
-// skipped with a TODO comment explaining the root cause.
-//
-// Test data source: testdata/ssh_results/ssh-*.hujson
-// Source format:    github.com/juanfont/headscale/hscontrol/types/testcapture
+// Replay golden HuJSON captures under testdata/ssh_results/ssh-*.hujson:
+// the 200 path compares headscale's compileSSHPolicy output node-by-node
+// against the captured SSHRules; the non-200 path requires headscale to
+// reject the same input with the captured error body as a substring.
+// Divergences are listed in sshSkipReasons (200) and sshRejectSkipReasons
+// (non-200) with the engine gap each represents.
 
 package v2
 
@@ -31,16 +22,10 @@ import (
 	"tailscale.com/tailcfg"
 )
 
-// setupSSHDataCompatUsers returns the 3 test users for SSH data-driven
-// compatibility tests. Users get norse-god names; nodes get original-151
-// pokémon names — matching the anonymized identifiers the capture
-// tool writes into the capture files.
-//
-// odin and freya live on @example.com; thor lives on @example.org so
-// that "localpart:*@example.com" resolves to exactly two users
-// (matching SaaS output) and the "user on a different email domain"
-// case stays covered by scenarios like ssh-d1 that use
-// "localpart:*@example.org".
+// setupSSHDataCompatUsers returns three users straddling two email
+// domains so that "localpart:*@example.com" resolves to exactly two
+// users (odin, freya) and the cross-domain case stays covered through
+// thor on @example.org.
 func setupSSHDataCompatUsers() types.Users {
 	return types.Users{
 		{
@@ -126,39 +111,29 @@ func loadSSHTestFile(t *testing.T, path string) *testcapture.Capture {
 	return c
 }
 
-// sshSkipReasons documents why each skipped test fails and what needs to be
-// fixed. Tests are grouped by root cause to identify high-impact changes.
+// sshSkipReasons documents captures the upstream control plane accepts
+// but headscale cannot yet represent. Each entry names the feature gap.
 var sshSkipReasons = map[string]string{
-	// USER_PASSKEY_WILDCARD (2 tests)
-	//
-	// headscale does not support passkey authentication and has no
-	// equivalent for the user:*@passkey wildcard pattern.
-	"ssh-b5":  "user:*@passkey wildcard not supported in headscale",
-	"ssh-d10": "user:*@passkey wildcard not supported in headscale",
-
-	// DOMAIN_NOT_ASSOCIATED (4 tests)
-	//
-	// SaaS validates that email domains in user:*@domain and
-	// localpart:*@domain expressions are configured tailnet domains.
-	// headscale has no concept of "associated tailnet domains" — it
-	// only has users with email addresses. These policies are
-	// legitimately rejected by SaaS but not by headscale.
-	"ssh-b4": "domain validation: headscale has no 'associated tailnet domains' concept",
-	"ssh-d1": "domain validation: headscale has no 'associated tailnet domains' concept",
-	"ssh-e1": "domain validation: headscale has no 'associated tailnet domains' concept",
-	"ssh-e2": "domain validation: headscale has no 'associated tailnet domains' concept",
+	"ssh-b5":  "headscale has no passkey authentication; user:*@passkey wildcard unsupported",
+	"ssh-d10": "headscale has no passkey authentication; user:*@passkey wildcard unsupported",
 }
 
-// TestSSHDataCompat is a data-driven test that loads all ssh-*.hujson test
-// files captured from Tailscale SaaS and compares headscale's SSH policy
-// compilation against the real Tailscale behavior.
-//
-// Each capture file contains:
-//   - The full policy that was POSTed to the SaaS API (Input.FullPolicy)
-//   - Expected SSH rules per node (Captures[name].SSHRules)
-//
-// The test converts Tailscale user email formats to headscale format and runs
-// the captured policy through unmarshalPolicy and compileSSHPolicy.
+// sshRejectSkipReasons documents captures the upstream control plane
+// rejects for reasons headscale cannot apply. Each entry names the
+// feature gap.
+var sshRejectSkipReasons = map[string]string{
+	"ssh-b4": "headscale has no associated-tailnet-domains config; user:*@domain / localpart:*@domain are not domain-validated",
+	"ssh-d1": "headscale has no associated-tailnet-domains config; user:*@domain / localpart:*@domain are not domain-validated",
+	"ssh-e1": "headscale has no associated-tailnet-domains config; user:*@domain / localpart:*@domain are not domain-validated",
+	"ssh-e2": "headscale has no associated-tailnet-domains config; user:*@domain / localpart:*@domain are not domain-validated",
+	"ssh-malformed-user-localpart-multi-glob": "headscale has no associated-tailnet-domains config; user:*@domain / localpart:*@domain are not domain-validated",
+}
+
+// TestSSHDataCompat loads every ssh-*.hujson capture, parses the policy
+// it pinned, and compiles the same per-node SSH rules to compare against
+// the captured shape. Non-200 captures replay the rejection path: the
+// recorded error body must appear as a substring of headscale's
+// rejection.
 func TestSSHDataCompat(t *testing.T) {
 	t.Parallel()
 
@@ -192,39 +167,61 @@ func TestSSHDataCompat(t *testing.T) {
 		t.Run(tf.TestID, func(t *testing.T) {
 			t.Parallel()
 
-			// Check if this test is in the skip list
-			if reason, ok := sshSkipReasons[tf.TestID]; ok {
-				t.Skipf(
-					"TODO: %s — see sshSkipReasons comments for details",
-					reason,
-				)
-
-				return
-			}
-
-			// SaaS rejected this policy — verify headscale also rejects it.
-			if tf.Error {
-				testSSHError(t, tf)
-
-				return
-			}
-
-			// Build nodes per-scenario from this file's topology.
-			// the capture tool uses clean-slate mode, so each scenario has
-			// different node IPs.
+			// Each capture pins its own topology IPs, so nodes are
+			// rebuilt from the capture rather than a shared fixture.
 			nodes := buildGrantsNodesFromCapture(users, tf)
 
-			// Use the captured full policy as is. Anonymization in
-			// captures already rewrite SaaS emails to @example.com.
-			policyJSON := tf.Input.FullPolicy
+			policyJSON := []byte(tf.Input.FullPolicy)
 
-			pol, err := unmarshalPolicy([]byte(policyJSON))
+			if tf.Input.APIResponseCode != 200 {
+				if reason, ok := sshRejectSkipReasons[tf.TestID]; ok {
+					t.Skipf("skipping: %s", reason)
+					return
+				}
+
+				pm, parseErr := NewPolicyManager(policyJSON, users, nodes.ViewSlice())
+
+				var got error
+
+				switch {
+				case parseErr != nil:
+					got = parseErr
+				default:
+					_, setErr := pm.SetPolicy(policyJSON)
+					got = setErr
+				}
+
+				require.Error(t, got, "tailscale rejected; headscale must reject too")
+
+				if tf.Input.APIResponseBody == nil ||
+					tf.Input.APIResponseBody.Message == "" {
+					return
+				}
+
+				want := tf.Input.APIResponseBody.Message
+				if !strings.Contains(got.Error(), want) {
+					t.Errorf(
+						"error body mismatch\n  tailscale wants: %q\n  headscale got:   %q",
+						want,
+						got.Error(),
+					)
+				}
+
+				return
+			}
+
+			if reason, ok := sshSkipReasons[tf.TestID]; ok {
+				t.Skipf("skipping: %s", reason)
+				return
+			}
+
+			pol, err := unmarshalPolicy(policyJSON)
 			require.NoError(
 				t,
 				err,
 				"%s: policy should parse successfully\nPolicy:\n%s",
 				tf.TestID,
-				policyJSON,
+				tf.Input.FullPolicy,
 			)
 
 			for nodeName, capture := range tf.Captures {
@@ -308,98 +305,4 @@ func TestSSHDataCompat(t *testing.T) {
 			}
 		})
 	}
-}
-
-// sshErrorMessageMap maps Tailscale SaaS error substrings to headscale
-// equivalents where the wording differs but the meaning is the same.
-var sshErrorMessageMap = map[string]string{}
-
-// testSSHError verifies that an invalid policy produces the expected error.
-func testSSHError(t *testing.T, tf *testcapture.Capture) {
-	t.Helper()
-
-	policyJSON := []byte(tf.Input.FullPolicy)
-
-	pol, err := unmarshalPolicy(policyJSON)
-	if err != nil {
-		// Parse-time error.
-		if tf.Input.APIResponseBody != nil {
-			wantMsg := tf.Input.APIResponseBody.Message
-			if wantMsg != "" {
-				assertSSHErrorContains(t, err, wantMsg, tf.TestID)
-			}
-		}
-
-		return
-	}
-
-	err = pol.validate()
-	if err != nil {
-		if tf.Input.APIResponseBody != nil {
-			wantMsg := tf.Input.APIResponseBody.Message
-			if wantMsg != "" {
-				assertSSHErrorContains(t, err, wantMsg, tf.TestID)
-			}
-		}
-
-		return
-	}
-
-	t.Errorf(
-		"%s: expected error but policy parsed and validated successfully",
-		tf.TestID,
-	)
-}
-
-// assertSSHErrorContains checks that an error message matches the
-// expected Tailscale SaaS message, using progressive fallbacks:
-//  1. Direct substring match
-//  2. Mapped equivalent from sshErrorMessageMap
-//  3. Key-part extraction (tags, autogroups)
-//  4. t.Errorf on no match (strict)
-func assertSSHErrorContains(
-	t *testing.T,
-	err error,
-	wantMsg string,
-	testID string,
-) {
-	t.Helper()
-
-	errStr := err.Error()
-
-	// 1. Direct substring match.
-	if strings.Contains(errStr, wantMsg) {
-		return
-	}
-
-	// 2. Mapped equivalent.
-	for tsKey, hsKey := range sshErrorMessageMap {
-		if strings.Contains(wantMsg, tsKey) &&
-			strings.Contains(errStr, hsKey) {
-			return
-		}
-	}
-
-	// 3. Key-part extraction.
-	for _, part := range []string{
-		"autogroup:",
-		"tag:",
-		"undefined",
-		"not valid",
-	} {
-		if strings.Contains(wantMsg, part) &&
-			strings.Contains(errStr, part) {
-			return
-		}
-	}
-
-	// 4. No match — strict failure.
-	t.Errorf(
-		"%s: error message mismatch\n"+
-			"  want (tailscale): %q\n"+
-			"  got  (headscale): %q",
-		testID,
-		wantMsg,
-		errStr,
-	)
 }

--- a/hscontrol/policy/v2/tailscale_ssh_data_compat_test.go
+++ b/hscontrol/policy/v2/tailscale_ssh_data_compat_test.go
@@ -46,61 +46,6 @@ func setupSSHDataCompatUsers() types.Users {
 	}
 }
 
-// setupSSHDataCompatNodes returns the test nodes for SSH data-driven
-// compatibility tests. Node GivenNames match the anonymized pokémon names:
-//   - bulbasaur (owned by odin)
-//   - ivysaur (owned by thor)
-//   - venusaur (owned by freya)
-//   - beedrill (tag:server)
-//   - kakuna (tag:prod)
-func setupSSHDataCompatNodes(users types.Users) types.Nodes {
-	return types.Nodes{
-		&types.Node{
-			ID:        1,
-			GivenName: "bulbasaur",
-			User:      &users[0],
-			UserID:    &users[0].ID,
-			IPv4:      ptrAddr("100.90.199.68"),
-			IPv6:      ptrAddr("fd7a:115c:a1e0::2d01:c747"),
-			Hostinfo:  &tailcfg.Hostinfo{},
-		},
-		&types.Node{
-			ID:        2,
-			GivenName: "ivysaur",
-			User:      &users[1],
-			UserID:    &users[1].ID,
-			IPv4:      ptrAddr("100.110.121.96"),
-			IPv6:      ptrAddr("fd7a:115c:a1e0::1737:7960"),
-			Hostinfo:  &tailcfg.Hostinfo{},
-		},
-		&types.Node{
-			ID:        3,
-			GivenName: "venusaur",
-			User:      &users[2],
-			UserID:    &users[2].ID,
-			IPv4:      ptrAddr("100.103.90.82"),
-			IPv6:      ptrAddr("fd7a:115c:a1e0::9e37:5a52"),
-			Hostinfo:  &tailcfg.Hostinfo{},
-		},
-		&types.Node{
-			ID:        4,
-			GivenName: "beedrill",
-			IPv4:      ptrAddr("100.108.74.26"),
-			IPv6:      ptrAddr("fd7a:115c:a1e0::b901:4a87"),
-			Tags:      []string{"tag:server"},
-			Hostinfo:  &tailcfg.Hostinfo{},
-		},
-		&types.Node{
-			ID:        5,
-			GivenName: "kakuna",
-			IPv4:      ptrAddr("100.103.8.15"),
-			IPv6:      ptrAddr("fd7a:115c:a1e0::5b37:80f"),
-			Tags:      []string{"tag:prod"},
-			Hostinfo:  &tailcfg.Hostinfo{},
-		},
-	}
-}
-
 // loadSSHTestFile loads and parses a single SSH capture HuJSON file.
 func loadSSHTestFile(t *testing.T, path string) *testcapture.Capture {
 	t.Helper()

--- a/hscontrol/policy/v2/test.go
+++ b/hscontrol/policy/v2/test.go
@@ -24,14 +24,13 @@ import (
 // The tests evaluate against the compiled global filter rules, which fold in
 // both `acls` and `grants`, so the `tests` block validates the whole policy.
 
-// errPolicyTestsFailed wraps the rendered failure body so callers can
-// type-assert when they need to react differently to test failures vs. parse
-// errors. The Error() prefix is "test(s) failed", the same string Tailscale
-// SaaS returns in the api_response_body.message — see
-// hscontrol/policy/v2/testdata/policytest_results/.
+// errPolicyTestsFailed and errSSHPolicyTestsFailed share the
+// "test(s) failed" prefix but stay distinct so callers can use
+// errors.Is to tell ACL-test and SSH-test failures apart.
 var (
-	errPolicyTestsFailed   = errors.New("test(s) failed")
-	errTestDestinationNoIP = errors.New("destination resolved to no IP addresses")
+	errPolicyTestsFailed    = errors.New("test(s) failed")
+	errSSHPolicyTestsFailed = errors.New("test(s) failed")
+	errTestDestinationNoIP  = errors.New("destination resolved to no IP addresses")
 )
 
 // PolicyTest is one entry in the policy's `tests` block.
@@ -51,6 +50,30 @@ type PolicyTest struct {
 	// Deny lists destinations in `host:port` form that must NOT be reachable
 	// from Src. A test fails if any entry is allowed by the compiled filter.
 	Deny []string `json:"deny,omitempty"`
+}
+
+// SSHPolicyTest is one entry in the policy's `sshTests` block. The
+// accept/deny/check arrays carry usernames, not destinations — every
+// listed user is asserted against every entry in Dst.
+type SSHPolicyTest struct {
+	// Src is a single source alias (user, group, tag, host, or IP).
+	Src string `json:"src"`
+
+	// Dst lists destinations the test exercises (tag, host, or SSH-
+	// compatible autogroup). Ports, CIDRs, and autogroup:internet are
+	// rejected at parse time.
+	Dst []string `json:"dst"`
+
+	// Accept lists users that must reach every Dst via an accept- or
+	// check-action rule.
+	Accept []string `json:"accept,omitempty"`
+
+	// Deny lists users that must NOT reach any Dst.
+	Deny []string `json:"deny,omitempty"`
+
+	// Check lists users that must reach every Dst via a check-action
+	// rule specifically; an accept-action rule does not satisfy this.
+	Check []string `json:"check,omitempty"`
 }
 
 // PolicyTestResult is the outcome of a single PolicyTest.

--- a/hscontrol/policy/v2/test.go
+++ b/hscontrol/policy/v2/test.go
@@ -7,6 +7,7 @@ import (
 	"slices"
 	"strings"
 
+	"github.com/go-json-experiment/json"
 	"github.com/juanfont/headscale/hscontrol/types"
 	"github.com/juanfont/headscale/hscontrol/util"
 	"tailscale.com/tailcfg"
@@ -57,23 +58,80 @@ type PolicyTest struct {
 // listed user is asserted against every entry in Dst.
 type SSHPolicyTest struct {
 	// Src is a single source alias (user, group, tag, host, or IP).
-	Src string `json:"src"`
+	Src Alias `json:"src"`
 
 	// Dst lists destinations the test exercises (tag, host, or SSH-
 	// compatible autogroup). Ports, CIDRs, and autogroup:internet are
 	// rejected at parse time.
-	Dst []string `json:"dst"`
+	Dst SSHTestDestinations `json:"dst"`
 
 	// Accept lists users that must reach every Dst via an accept- or
 	// check-action rule.
-	Accept []string `json:"accept,omitempty"`
+	Accept []SSHUser `json:"accept,omitempty"`
 
 	// Deny lists users that must NOT reach any Dst.
-	Deny []string `json:"deny,omitempty"`
+	Deny []SSHUser `json:"deny,omitempty"`
 
 	// Check lists users that must reach every Dst via a check-action
 	// rule specifically; an accept-action rule does not satisfy this.
-	Check []string `json:"check,omitempty"`
+	Check []SSHUser `json:"check,omitempty"`
+}
+
+// SSHTestDestinations is the typed list of destination aliases an
+// sshTests entry targets. validateSSHTestDestination enforces the
+// SSH-specific shape rules (no :port, no CIDR, no autogroup:internet,
+// known tag).
+type SSHTestDestinations []Alias
+
+func (d *SSHTestDestinations) UnmarshalJSON(b []byte) error {
+	var aliases []AliasEnc
+
+	err := json.Unmarshal(b, &aliases, policyJSONOpts...)
+	if err != nil {
+		return err
+	}
+
+	*d = make([]Alias, len(aliases))
+	for i, a := range aliases {
+		(*d)[i] = a.Alias
+	}
+
+	return nil
+}
+
+// UnmarshalJSON parses each typed field. An empty src lands as a nil
+// Alias so validation surfaces ErrSSHTestEmptySrc rather than a parser
+// failure.
+func (t *SSHPolicyTest) UnmarshalJSON(b []byte) error {
+	var raw struct {
+		Src    string              `json:"src"`
+		Dst    SSHTestDestinations `json:"dst"`
+		Accept []SSHUser           `json:"accept,omitempty"`
+		Deny   []SSHUser           `json:"deny,omitempty"`
+		Check  []SSHUser           `json:"check,omitempty"`
+	}
+
+	err := json.Unmarshal(b, &raw, policyJSONOpts...)
+	if err != nil {
+		return err
+	}
+
+	trimmedSrc := strings.TrimSpace(raw.Src)
+	if trimmedSrc != "" {
+		alias, parseErr := parseAlias(trimmedSrc)
+		if parseErr != nil {
+			return parseErr
+		}
+
+		t.Src = alias
+	}
+
+	t.Dst = raw.Dst
+	t.Accept = raw.Accept
+	t.Deny = raw.Deny
+	t.Check = raw.Check
+
+	return nil
 }
 
 // PolicyTestResult is the outcome of a single PolicyTest.

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-acceptenv-null.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-acceptenv-null.hujson
@@ -1,0 +1,22349 @@
+// ssh-acceptenv-null
+//
+// ssh acceptEnv = JSON null
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-13T09:05:56Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-acceptenv-null",
+	"description":    "ssh acceptEnv = JSON null",
+	"category":       "ssh",
+	"captured_at":    "2026-05-13T09:05:56.291444952Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                     \n  \n                                                                \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh acceptEnv = JSON null\",\n\t\"id\":          \"ssh-acceptenv-null\",\n\t\"policy\": {\"ssh\": [{\n\t\t\"acceptEnv\": null,\n\t\t\"action\":    \"accept\",\n\t\t\"dst\":       [\"tag:server\"],\n\t\t\"src\":       [\"thor@example.org\"],\n\t\t\"users\":     [\"root\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-edges/ssh-acceptenv-null.hujson",
+		"full_policy": {
+			"ssh": [{
+				"acceptEnv": null,
+				"action":    "accept",
+				"dst":       ["tag:server"],
+				"src":       ["thor@example.org"],
+				"users":     ["root"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7349144867247594,
+				"StableID":   "nZWMxGaSPz11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       7349144867247594,
+				"Key":        "nodekey:8a9a0864c31e5b3b5151092f6341b1d0ea5e8f11dda567a93ec4e8bca734746e",
+				"DiscoKey":   "discokey:a951bc4101a4984404a8954e603413dd63c6cd6967a8567ac64aef7829a51f51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59744",
+					"10.65.0.27:59744",
+					"172.17.0.1:59744",
+					"172.18.0.1:59744",
+					"172.19.0.1:59744",
+					"172.20.0.1:59744",
+					"172.21.0.1:59744",
+					"172.22.0.1:59744",
+					"172.23.0.1:59744",
+					"172.24.0.1:59744",
+					"172.25.0.1:59744",
+					"172.26.0.1:59744",
+					"172.27.0.1:59744",
+					"172.28.0.1:59744",
+					"172.29.0.1:59744"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:06:08.900841555Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8a9a0864c31e5b3b5151092f6341b1d0ea5e8f11dda567a93ec4e8bca734746e",
+			"MachineKey": "mkey:f1a7dd612092fe347243476d046bdb88b770df59ae7380da0ba0f2ad9d779102",
+			"Peers": [{
+				"ID":         4069156827127413,
+				"StableID":   "nz39eHrvmY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fae451d819bd4251f674c2ca3ce306142afa17f8f5d2775bf0b17c07d6ce5913",
+				"DiscoKey":   "discokey:2d35776083370160cede6d7ecc324f9d09af6e67ff53263ba9cdf8e04916407c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46050",
+					"10.65.0.27:46050",
+					"172.17.0.1:46050",
+					"172.18.0.1:46050",
+					"172.19.0.1:46050",
+					"172.20.0.1:46050",
+					"172.21.0.1:46050",
+					"172.22.0.1:46050",
+					"172.23.0.1:46050",
+					"172.24.0.1:46050",
+					"172.25.0.1:46050",
+					"172.26.0.1:46050",
+					"172.27.0.1:46050",
+					"172.28.0.1:46050",
+					"172.29.0.1:46050"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:06:02.729300584Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2945498691911599,
+				"StableID":   "nQw22rF21Q11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ef63d42f0a54510a7fab0636e6535e983713dbe511ad07701eb46540d737a358",
+				"DiscoKey":   "discokey:e79aaf48ae2ba950adc828eb7f67fad6a6ff79809385cc7ea13972cb30c50f4a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54774",
+					"10.65.0.27:54774",
+					"172.17.0.1:54774",
+					"172.18.0.1:54774",
+					"172.19.0.1:54774",
+					"172.20.0.1:54774",
+					"172.21.0.1:54774",
+					"172.22.0.1:54774",
+					"172.23.0.1:54774",
+					"172.24.0.1:54774",
+					"172.25.0.1:54774",
+					"172.26.0.1:54774",
+					"172.27.0.1:54774",
+					"172.28.0.1:54774",
+					"172.29.0.1:54774"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:06:03.364321574Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1720498219598092,
+				"StableID":   "nfgb67aDSE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e7da71bf3127c4a45c28179e3d1d65f48881e49e3e8f2d1cd872106e2bc863c",
+				"DiscoKey":   "discokey:f57f5f1b7ecbaf7b059d1e09703f016956dd701871149159795580162f004a17",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57211",
+					"10.65.0.27:57211",
+					"172.17.0.1:57211",
+					"172.18.0.1:57211",
+					"172.19.0.1:57211",
+					"172.20.0.1:57211",
+					"172.21.0.1:57211",
+					"172.22.0.1:57211",
+					"172.23.0.1:57211",
+					"172.24.0.1:57211",
+					"172.25.0.1:57211",
+					"172.26.0.1:57211",
+					"172.27.0.1:57211",
+					"172.28.0.1:57211",
+					"172.29.0.1:57211"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:06:04.045727996Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1006977852880196,
+				"StableID":   "n5jGdqb4s811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6171e9f651e818a2ff9f302698460c78f2574b991eea9850eea878f8128e4e02",
+				"DiscoKey":   "discokey:4ec33d228df30eb9b1c78e8496852b6b71e3515d879dbb35a640785768979833",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40521",
+					"10.65.0.27:40521",
+					"172.17.0.1:40521",
+					"172.18.0.1:40521",
+					"172.19.0.1:40521",
+					"172.20.0.1:40521",
+					"172.21.0.1:40521",
+					"172.22.0.1:40521",
+					"172.23.0.1:40521",
+					"172.24.0.1:40521",
+					"172.25.0.1:40521",
+					"172.26.0.1:40521",
+					"172.27.0.1:40521",
+					"172.28.0.1:40521",
+					"172.29.0.1:40521"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:06:04.577289819Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7564700820128575,
+				"StableID":   "nNQgN4s45221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:700f8dfb91a17b9f8bb2ed24d42f53d27ed8467ea9b340a285ee964ad49c3a73",
+				"DiscoKey":   "discokey:368cc773cb3d5d79c3caaaf9f87c363b38b82d52a7c8b67994d7c899d36bdb40",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60288",
+					"10.65.0.27:60288",
+					"172.17.0.1:60288",
+					"172.18.0.1:60288",
+					"172.19.0.1:60288",
+					"172.20.0.1:60288",
+					"172.21.0.1:60288",
+					"172.22.0.1:60288",
+					"172.23.0.1:60288",
+					"172.24.0.1:60288",
+					"172.25.0.1:60288",
+					"172.26.0.1:60288",
+					"172.27.0.1:60288",
+					"172.28.0.1:60288",
+					"172.29.0.1:60288"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:06:05.138789727Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         170679822932958,
+				"StableID":   "ndEFVEUJL211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7e6214ef04a8be47b2df329f9b334ab43c393caec730928f832636d10d1f0300",
+				"DiscoKey":   "discokey:deb9c042de9aa911e7e1f46ed869f22600d449c5d9e9fe45b7e1d75d42d6357c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38549",
+					"10.65.0.27:38549",
+					"172.17.0.1:38549",
+					"172.18.0.1:38549",
+					"172.19.0.1:38549",
+					"172.20.0.1:38549",
+					"172.21.0.1:38549",
+					"172.22.0.1:38549",
+					"172.23.0.1:38549",
+					"172.24.0.1:38549",
+					"172.25.0.1:38549",
+					"172.26.0.1:38549",
+					"172.27.0.1:38549",
+					"172.28.0.1:38549",
+					"172.29.0.1:38549"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:06:05.671488052Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4963259093864094,
+				"StableID":   "nDg4FDQskf11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:99d7d595275a99cb6d8145ac37ccab734ecf3bc46fb5643705de247e224bc83c",
+				"DiscoKey":   "discokey:9d0ff4a5e17152398066d88cd6182d39b50bdeb3c0c7455a57c9c231790d3b0e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50618",
+					"10.65.0.27:50618",
+					"172.17.0.1:50618",
+					"172.18.0.1:50618",
+					"172.19.0.1:50618",
+					"172.20.0.1:50618",
+					"172.21.0.1:50618",
+					"172.22.0.1:50618",
+					"172.23.0.1:50618",
+					"172.24.0.1:50618",
+					"172.25.0.1:50618",
+					"172.26.0.1:50618",
+					"172.27.0.1:50618",
+					"172.28.0.1:50618",
+					"172.29.0.1:50618"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:06:06.206189964Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1943546407355350,
+				"StableID":   "nZk3fmfEBG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9218ebc91411788c3a9984660d22098687990c320bdd6f375356f64a7a2b0e68",
+				"DiscoKey":   "discokey:1ffa9b2e2fbd1a73e09a39d6f80cc021b6ed3b812a083bbb7f3ac5e76b5e0563",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:39674",
+					"10.65.0.27:39674",
+					"172.17.0.1:39674",
+					"172.18.0.1:39674",
+					"172.19.0.1:39674",
+					"172.20.0.1:39674",
+					"172.21.0.1:39674",
+					"172.22.0.1:39674",
+					"172.23.0.1:39674",
+					"172.24.0.1:39674",
+					"172.25.0.1:39674",
+					"172.26.0.1:39674",
+					"172.27.0.1:39674",
+					"172.28.0.1:39674",
+					"172.29.0.1:39674"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:06:06.73153339Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1708133528877187,
+				"StableID":   "nSifijmcLE11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a356a22e64460ab591255811a3b615a2e848df822af39edf39acd2d3e1d891d",
+				"DiscoKey":   "discokey:3e442f32c2a1e007aa30850ab06f45bb6d1ffa7698e6ba334c749f360d4b761d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39704",
+					"10.65.0.27:39704",
+					"172.17.0.1:39704",
+					"172.18.0.1:39704",
+					"172.19.0.1:39704",
+					"172.20.0.1:39704",
+					"172.21.0.1:39704",
+					"172.22.0.1:39704",
+					"172.23.0.1:39704",
+					"172.24.0.1:39704",
+					"172.25.0.1:39704",
+					"172.26.0.1:39704",
+					"172.27.0.1:39704",
+					"172.28.0.1:39704",
+					"172.29.0.1:39704"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:06:07.276232748Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5262985869601637,
+				"StableID":   "nrPo3Sic6i11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3401487c8de1fa728e83fce8ace71e43352a05c3e227b661490b8125f65a9a18",
+				"DiscoKey":   "discokey:24c274ca3232a24b2c7bd65ad4b74da767a7749739d327300bfc351d2cbd9b2d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47081",
+					"10.65.0.27:47081",
+					"172.17.0.1:47081",
+					"172.18.0.1:47081",
+					"172.19.0.1:47081",
+					"172.20.0.1:47081",
+					"172.21.0.1:47081",
+					"172.22.0.1:47081",
+					"172.23.0.1:47081",
+					"172.24.0.1:47081",
+					"172.25.0.1:47081",
+					"172.26.0.1:47081",
+					"172.27.0.1:47081",
+					"172.28.0.1:47081",
+					"172.29.0.1:47081"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:06:07.817408191Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         916153504890789,
+				"StableID":   "nxEQ1Mov9811CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f686760c3c5be34a0bd612c59a9daab5e6df5148262ad27834ffc66014b2a36b",
+				"DiscoKey":   "discokey:ffd60d6538f69292c6f2717daf97a27f220f9d88d789e75d5c5285536034cb60",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57006",
+					"10.65.0.27:57006",
+					"172.17.0.1:57006",
+					"172.18.0.1:57006",
+					"172.19.0.1:57006",
+					"172.20.0.1:57006",
+					"172.21.0.1:57006",
+					"172.22.0.1:57006",
+					"172.23.0.1:57006",
+					"172.24.0.1:57006",
+					"172.25.0.1:57006",
+					"172.26.0.1:57006",
+					"172.27.0.1:57006",
+					"172.28.0.1:57006",
+					"172.29.0.1:57006"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:06:08.365168758Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2656983726927875,
+				"StableID":   "nAi3YWTMkM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7e4b69cfe2c88c50e8b06b9b2cf0438466d1db58c88ce7c31909b7cdf722ec60",
+				"KeyExpiry":  "2026-11-09T09:06:09Z",
+				"DiscoKey":   "discokey:0532507bb618ccd11529f82e642e6a6d30ce3fe5c07730cd9e022f9575963d46",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:59277",
+					"10.65.0.27:59277",
+					"172.17.0.1:59277",
+					"172.18.0.1:59277",
+					"172.19.0.1:59277",
+					"172.20.0.1:59277",
+					"172.21.0.1:59277",
+					"172.22.0.1:59277",
+					"172.23.0.1:59277",
+					"172.24.0.1:59277",
+					"172.25.0.1:59277",
+					"172.26.0.1:59277",
+					"172.27.0.1:59277",
+					"172.28.0.1:59277",
+					"172.29.0.1:59277"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:06:09.446241278Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6744977102580193,
+				"StableID":   "nki2US7pfu11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:d8ff1ec2b48104f077c30a221dad55554ac4880988e0c0d5cc536326a7ada577",
+				"KeyExpiry":  "2026-11-09T09:06:09Z",
+				"DiscoKey":   "discokey:c45d8cd20b6a6e62a65ca75266551eb644fd26f77a4e300bb2fc5583b3d03667",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55650",
+					"10.65.0.27:55650",
+					"172.17.0.1:55650",
+					"172.18.0.1:55650",
+					"172.19.0.1:55650",
+					"172.20.0.1:55650",
+					"172.21.0.1:55650",
+					"172.22.0.1:55650",
+					"172.23.0.1:55650",
+					"172.24.0.1:55650",
+					"172.25.0.1:55650",
+					"172.26.0.1:55650",
+					"172.27.0.1:55650",
+					"172.28.0.1:55650",
+					"172.29.0.1:55650"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:06:09.99204694Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8937434359782713,
+				"StableID":   "neFwZEFnnC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7259264d04fbd94bb35e6d00bc341968a782958f2b53e9ba3666a7972452097d",
+				"KeyExpiry":  "2026-11-09T09:06:10Z",
+				"DiscoKey":   "discokey:b849d1522e87bda0a2764a94af6a0ab2f2de4fabd17eeb751fc204be55b3bd25",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786",
+					"172.20.0.1:45786",
+					"172.21.0.1:45786",
+					"172.22.0.1:45786",
+					"172.23.0.1:45786",
+					"172.24.0.1:45786",
+					"172.25.0.1:45786",
+					"172.26.0.1:45786",
+					"172.27.0.1:45786",
+					"172.28.0.1:45786",
+					"172.29.0.1:45786"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:06:10.527555233Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{
+				"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+				"sshUsers":   {"root": "root"},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				}
+			}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7349144867247594": {
+				"ID":          7349144867247594,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		},
+		"ssh_rules": [{
+			"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+			"sshUsers":   {"root": "root"},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}
+		}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         170679822932958,
+				"StableID":   "ndEFVEUJL211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       170679822932958,
+				"Key":        "nodekey:7e6214ef04a8be47b2df329f9b334ab43c393caec730928f832636d10d1f0300",
+				"DiscoKey":   "discokey:deb9c042de9aa911e7e1f46ed869f22600d449c5d9e9fe45b7e1d75d42d6357c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38549",
+					"10.65.0.27:38549",
+					"172.17.0.1:38549",
+					"172.18.0.1:38549",
+					"172.19.0.1:38549",
+					"172.20.0.1:38549",
+					"172.21.0.1:38549",
+					"172.22.0.1:38549",
+					"172.23.0.1:38549",
+					"172.24.0.1:38549",
+					"172.25.0.1:38549",
+					"172.26.0.1:38549",
+					"172.27.0.1:38549",
+					"172.28.0.1:38549",
+					"172.29.0.1:38549"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:06:05.671488052Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7e6214ef04a8be47b2df329f9b334ab43c393caec730928f832636d10d1f0300",
+			"MachineKey": "mkey:27b77c9c2b3408f5eb00331538c2c701af8d9a604180fda512a50717ac847c3b",
+			"Peers": [{
+				"ID":         4069156827127413,
+				"StableID":   "nz39eHrvmY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fae451d819bd4251f674c2ca3ce306142afa17f8f5d2775bf0b17c07d6ce5913",
+				"DiscoKey":   "discokey:2d35776083370160cede6d7ecc324f9d09af6e67ff53263ba9cdf8e04916407c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46050",
+					"10.65.0.27:46050",
+					"172.17.0.1:46050",
+					"172.18.0.1:46050",
+					"172.19.0.1:46050",
+					"172.20.0.1:46050",
+					"172.21.0.1:46050",
+					"172.22.0.1:46050",
+					"172.23.0.1:46050",
+					"172.24.0.1:46050",
+					"172.25.0.1:46050",
+					"172.26.0.1:46050",
+					"172.27.0.1:46050",
+					"172.28.0.1:46050",
+					"172.29.0.1:46050"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:06:02.729300584Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2945498691911599,
+				"StableID":   "nQw22rF21Q11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ef63d42f0a54510a7fab0636e6535e983713dbe511ad07701eb46540d737a358",
+				"DiscoKey":   "discokey:e79aaf48ae2ba950adc828eb7f67fad6a6ff79809385cc7ea13972cb30c50f4a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54774",
+					"10.65.0.27:54774",
+					"172.17.0.1:54774",
+					"172.18.0.1:54774",
+					"172.19.0.1:54774",
+					"172.20.0.1:54774",
+					"172.21.0.1:54774",
+					"172.22.0.1:54774",
+					"172.23.0.1:54774",
+					"172.24.0.1:54774",
+					"172.25.0.1:54774",
+					"172.26.0.1:54774",
+					"172.27.0.1:54774",
+					"172.28.0.1:54774",
+					"172.29.0.1:54774"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:06:03.364321574Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1720498219598092,
+				"StableID":   "nfgb67aDSE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e7da71bf3127c4a45c28179e3d1d65f48881e49e3e8f2d1cd872106e2bc863c",
+				"DiscoKey":   "discokey:f57f5f1b7ecbaf7b059d1e09703f016956dd701871149159795580162f004a17",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57211",
+					"10.65.0.27:57211",
+					"172.17.0.1:57211",
+					"172.18.0.1:57211",
+					"172.19.0.1:57211",
+					"172.20.0.1:57211",
+					"172.21.0.1:57211",
+					"172.22.0.1:57211",
+					"172.23.0.1:57211",
+					"172.24.0.1:57211",
+					"172.25.0.1:57211",
+					"172.26.0.1:57211",
+					"172.27.0.1:57211",
+					"172.28.0.1:57211",
+					"172.29.0.1:57211"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:06:04.045727996Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1006977852880196,
+				"StableID":   "n5jGdqb4s811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6171e9f651e818a2ff9f302698460c78f2574b991eea9850eea878f8128e4e02",
+				"DiscoKey":   "discokey:4ec33d228df30eb9b1c78e8496852b6b71e3515d879dbb35a640785768979833",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40521",
+					"10.65.0.27:40521",
+					"172.17.0.1:40521",
+					"172.18.0.1:40521",
+					"172.19.0.1:40521",
+					"172.20.0.1:40521",
+					"172.21.0.1:40521",
+					"172.22.0.1:40521",
+					"172.23.0.1:40521",
+					"172.24.0.1:40521",
+					"172.25.0.1:40521",
+					"172.26.0.1:40521",
+					"172.27.0.1:40521",
+					"172.28.0.1:40521",
+					"172.29.0.1:40521"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:06:04.577289819Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7564700820128575,
+				"StableID":   "nNQgN4s45221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:700f8dfb91a17b9f8bb2ed24d42f53d27ed8467ea9b340a285ee964ad49c3a73",
+				"DiscoKey":   "discokey:368cc773cb3d5d79c3caaaf9f87c363b38b82d52a7c8b67994d7c899d36bdb40",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60288",
+					"10.65.0.27:60288",
+					"172.17.0.1:60288",
+					"172.18.0.1:60288",
+					"172.19.0.1:60288",
+					"172.20.0.1:60288",
+					"172.21.0.1:60288",
+					"172.22.0.1:60288",
+					"172.23.0.1:60288",
+					"172.24.0.1:60288",
+					"172.25.0.1:60288",
+					"172.26.0.1:60288",
+					"172.27.0.1:60288",
+					"172.28.0.1:60288",
+					"172.29.0.1:60288"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:06:05.138789727Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4963259093864094,
+				"StableID":   "nDg4FDQskf11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:99d7d595275a99cb6d8145ac37ccab734ecf3bc46fb5643705de247e224bc83c",
+				"DiscoKey":   "discokey:9d0ff4a5e17152398066d88cd6182d39b50bdeb3c0c7455a57c9c231790d3b0e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50618",
+					"10.65.0.27:50618",
+					"172.17.0.1:50618",
+					"172.18.0.1:50618",
+					"172.19.0.1:50618",
+					"172.20.0.1:50618",
+					"172.21.0.1:50618",
+					"172.22.0.1:50618",
+					"172.23.0.1:50618",
+					"172.24.0.1:50618",
+					"172.25.0.1:50618",
+					"172.26.0.1:50618",
+					"172.27.0.1:50618",
+					"172.28.0.1:50618",
+					"172.29.0.1:50618"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:06:06.206189964Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1943546407355350,
+				"StableID":   "nZk3fmfEBG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9218ebc91411788c3a9984660d22098687990c320bdd6f375356f64a7a2b0e68",
+				"DiscoKey":   "discokey:1ffa9b2e2fbd1a73e09a39d6f80cc021b6ed3b812a083bbb7f3ac5e76b5e0563",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:39674",
+					"10.65.0.27:39674",
+					"172.17.0.1:39674",
+					"172.18.0.1:39674",
+					"172.19.0.1:39674",
+					"172.20.0.1:39674",
+					"172.21.0.1:39674",
+					"172.22.0.1:39674",
+					"172.23.0.1:39674",
+					"172.24.0.1:39674",
+					"172.25.0.1:39674",
+					"172.26.0.1:39674",
+					"172.27.0.1:39674",
+					"172.28.0.1:39674",
+					"172.29.0.1:39674"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:06:06.73153339Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1708133528877187,
+				"StableID":   "nSifijmcLE11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a356a22e64460ab591255811a3b615a2e848df822af39edf39acd2d3e1d891d",
+				"DiscoKey":   "discokey:3e442f32c2a1e007aa30850ab06f45bb6d1ffa7698e6ba334c749f360d4b761d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39704",
+					"10.65.0.27:39704",
+					"172.17.0.1:39704",
+					"172.18.0.1:39704",
+					"172.19.0.1:39704",
+					"172.20.0.1:39704",
+					"172.21.0.1:39704",
+					"172.22.0.1:39704",
+					"172.23.0.1:39704",
+					"172.24.0.1:39704",
+					"172.25.0.1:39704",
+					"172.26.0.1:39704",
+					"172.27.0.1:39704",
+					"172.28.0.1:39704",
+					"172.29.0.1:39704"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:06:07.276232748Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5262985869601637,
+				"StableID":   "nrPo3Sic6i11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3401487c8de1fa728e83fce8ace71e43352a05c3e227b661490b8125f65a9a18",
+				"DiscoKey":   "discokey:24c274ca3232a24b2c7bd65ad4b74da767a7749739d327300bfc351d2cbd9b2d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47081",
+					"10.65.0.27:47081",
+					"172.17.0.1:47081",
+					"172.18.0.1:47081",
+					"172.19.0.1:47081",
+					"172.20.0.1:47081",
+					"172.21.0.1:47081",
+					"172.22.0.1:47081",
+					"172.23.0.1:47081",
+					"172.24.0.1:47081",
+					"172.25.0.1:47081",
+					"172.26.0.1:47081",
+					"172.27.0.1:47081",
+					"172.28.0.1:47081",
+					"172.29.0.1:47081"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:06:07.817408191Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         916153504890789,
+				"StableID":   "nxEQ1Mov9811CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f686760c3c5be34a0bd612c59a9daab5e6df5148262ad27834ffc66014b2a36b",
+				"DiscoKey":   "discokey:ffd60d6538f69292c6f2717daf97a27f220f9d88d789e75d5c5285536034cb60",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57006",
+					"10.65.0.27:57006",
+					"172.17.0.1:57006",
+					"172.18.0.1:57006",
+					"172.19.0.1:57006",
+					"172.20.0.1:57006",
+					"172.21.0.1:57006",
+					"172.22.0.1:57006",
+					"172.23.0.1:57006",
+					"172.24.0.1:57006",
+					"172.25.0.1:57006",
+					"172.26.0.1:57006",
+					"172.27.0.1:57006",
+					"172.28.0.1:57006",
+					"172.29.0.1:57006"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:06:08.365168758Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7349144867247594,
+				"StableID":   "nZWMxGaSPz11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a9a0864c31e5b3b5151092f6341b1d0ea5e8f11dda567a93ec4e8bca734746e",
+				"DiscoKey":   "discokey:a951bc4101a4984404a8954e603413dd63c6cd6967a8567ac64aef7829a51f51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59744",
+					"10.65.0.27:59744",
+					"172.17.0.1:59744",
+					"172.18.0.1:59744",
+					"172.19.0.1:59744",
+					"172.20.0.1:59744",
+					"172.21.0.1:59744",
+					"172.22.0.1:59744",
+					"172.23.0.1:59744",
+					"172.24.0.1:59744",
+					"172.25.0.1:59744",
+					"172.26.0.1:59744",
+					"172.27.0.1:59744",
+					"172.28.0.1:59744",
+					"172.29.0.1:59744"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:06:08.900841555Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2656983726927875,
+				"StableID":   "nAi3YWTMkM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7e4b69cfe2c88c50e8b06b9b2cf0438466d1db58c88ce7c31909b7cdf722ec60",
+				"KeyExpiry":  "2026-11-09T09:06:09Z",
+				"DiscoKey":   "discokey:0532507bb618ccd11529f82e642e6a6d30ce3fe5c07730cd9e022f9575963d46",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:59277",
+					"10.65.0.27:59277",
+					"172.17.0.1:59277",
+					"172.18.0.1:59277",
+					"172.19.0.1:59277",
+					"172.20.0.1:59277",
+					"172.21.0.1:59277",
+					"172.22.0.1:59277",
+					"172.23.0.1:59277",
+					"172.24.0.1:59277",
+					"172.25.0.1:59277",
+					"172.26.0.1:59277",
+					"172.27.0.1:59277",
+					"172.28.0.1:59277",
+					"172.29.0.1:59277"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:06:09.446241278Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6744977102580193,
+				"StableID":   "nki2US7pfu11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:d8ff1ec2b48104f077c30a221dad55554ac4880988e0c0d5cc536326a7ada577",
+				"KeyExpiry":  "2026-11-09T09:06:09Z",
+				"DiscoKey":   "discokey:c45d8cd20b6a6e62a65ca75266551eb644fd26f77a4e300bb2fc5583b3d03667",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55650",
+					"10.65.0.27:55650",
+					"172.17.0.1:55650",
+					"172.18.0.1:55650",
+					"172.19.0.1:55650",
+					"172.20.0.1:55650",
+					"172.21.0.1:55650",
+					"172.22.0.1:55650",
+					"172.23.0.1:55650",
+					"172.24.0.1:55650",
+					"172.25.0.1:55650",
+					"172.26.0.1:55650",
+					"172.27.0.1:55650",
+					"172.28.0.1:55650",
+					"172.29.0.1:55650"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:06:09.99204694Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8937434359782713,
+				"StableID":   "neFwZEFnnC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7259264d04fbd94bb35e6d00bc341968a782958f2b53e9ba3666a7972452097d",
+				"KeyExpiry":  "2026-11-09T09:06:10Z",
+				"DiscoKey":   "discokey:b849d1522e87bda0a2764a94af6a0ab2f2de4fabd17eeb751fc204be55b3bd25",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786",
+					"172.20.0.1:45786",
+					"172.21.0.1:45786",
+					"172.22.0.1:45786",
+					"172.23.0.1:45786",
+					"172.24.0.1:45786",
+					"172.25.0.1:45786",
+					"172.26.0.1:45786",
+					"172.27.0.1:45786",
+					"172.28.0.1:45786",
+					"172.29.0.1:45786"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:06:10.527555233Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "170679822932958": {
+				"ID":          170679822932958,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8937434359782713,
+				"StableID":   "neFwZEFnnC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7259264d04fbd94bb35e6d00bc341968a782958f2b53e9ba3666a7972452097d",
+				"KeyExpiry":  "2026-11-09T09:06:10Z",
+				"DiscoKey":   "discokey:b849d1522e87bda0a2764a94af6a0ab2f2de4fabd17eeb751fc204be55b3bd25",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786",
+					"172.20.0.1:45786",
+					"172.21.0.1:45786",
+					"172.22.0.1:45786",
+					"172.23.0.1:45786",
+					"172.24.0.1:45786",
+					"172.25.0.1:45786",
+					"172.26.0.1:45786",
+					"172.27.0.1:45786",
+					"172.28.0.1:45786",
+					"172.29.0.1:45786"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:06:10.527555233Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7259264d04fbd94bb35e6d00bc341968a782958f2b53e9ba3666a7972452097d",
+			"MachineKey": "mkey:8058c4716efc1923ae9887dd9e0a8d17f81253427e2f70508cbd12104f8aac09",
+			"Peers": [{
+				"ID":         4069156827127413,
+				"StableID":   "nz39eHrvmY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fae451d819bd4251f674c2ca3ce306142afa17f8f5d2775bf0b17c07d6ce5913",
+				"DiscoKey":   "discokey:2d35776083370160cede6d7ecc324f9d09af6e67ff53263ba9cdf8e04916407c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46050",
+					"10.65.0.27:46050",
+					"172.17.0.1:46050",
+					"172.18.0.1:46050",
+					"172.19.0.1:46050",
+					"172.20.0.1:46050",
+					"172.21.0.1:46050",
+					"172.22.0.1:46050",
+					"172.23.0.1:46050",
+					"172.24.0.1:46050",
+					"172.25.0.1:46050",
+					"172.26.0.1:46050",
+					"172.27.0.1:46050",
+					"172.28.0.1:46050",
+					"172.29.0.1:46050"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:06:02.729300584Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2945498691911599,
+				"StableID":   "nQw22rF21Q11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ef63d42f0a54510a7fab0636e6535e983713dbe511ad07701eb46540d737a358",
+				"DiscoKey":   "discokey:e79aaf48ae2ba950adc828eb7f67fad6a6ff79809385cc7ea13972cb30c50f4a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54774",
+					"10.65.0.27:54774",
+					"172.17.0.1:54774",
+					"172.18.0.1:54774",
+					"172.19.0.1:54774",
+					"172.20.0.1:54774",
+					"172.21.0.1:54774",
+					"172.22.0.1:54774",
+					"172.23.0.1:54774",
+					"172.24.0.1:54774",
+					"172.25.0.1:54774",
+					"172.26.0.1:54774",
+					"172.27.0.1:54774",
+					"172.28.0.1:54774",
+					"172.29.0.1:54774"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:06:03.364321574Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1720498219598092,
+				"StableID":   "nfgb67aDSE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e7da71bf3127c4a45c28179e3d1d65f48881e49e3e8f2d1cd872106e2bc863c",
+				"DiscoKey":   "discokey:f57f5f1b7ecbaf7b059d1e09703f016956dd701871149159795580162f004a17",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57211",
+					"10.65.0.27:57211",
+					"172.17.0.1:57211",
+					"172.18.0.1:57211",
+					"172.19.0.1:57211",
+					"172.20.0.1:57211",
+					"172.21.0.1:57211",
+					"172.22.0.1:57211",
+					"172.23.0.1:57211",
+					"172.24.0.1:57211",
+					"172.25.0.1:57211",
+					"172.26.0.1:57211",
+					"172.27.0.1:57211",
+					"172.28.0.1:57211",
+					"172.29.0.1:57211"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:06:04.045727996Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1006977852880196,
+				"StableID":   "n5jGdqb4s811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6171e9f651e818a2ff9f302698460c78f2574b991eea9850eea878f8128e4e02",
+				"DiscoKey":   "discokey:4ec33d228df30eb9b1c78e8496852b6b71e3515d879dbb35a640785768979833",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40521",
+					"10.65.0.27:40521",
+					"172.17.0.1:40521",
+					"172.18.0.1:40521",
+					"172.19.0.1:40521",
+					"172.20.0.1:40521",
+					"172.21.0.1:40521",
+					"172.22.0.1:40521",
+					"172.23.0.1:40521",
+					"172.24.0.1:40521",
+					"172.25.0.1:40521",
+					"172.26.0.1:40521",
+					"172.27.0.1:40521",
+					"172.28.0.1:40521",
+					"172.29.0.1:40521"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:06:04.577289819Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7564700820128575,
+				"StableID":   "nNQgN4s45221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:700f8dfb91a17b9f8bb2ed24d42f53d27ed8467ea9b340a285ee964ad49c3a73",
+				"DiscoKey":   "discokey:368cc773cb3d5d79c3caaaf9f87c363b38b82d52a7c8b67994d7c899d36bdb40",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60288",
+					"10.65.0.27:60288",
+					"172.17.0.1:60288",
+					"172.18.0.1:60288",
+					"172.19.0.1:60288",
+					"172.20.0.1:60288",
+					"172.21.0.1:60288",
+					"172.22.0.1:60288",
+					"172.23.0.1:60288",
+					"172.24.0.1:60288",
+					"172.25.0.1:60288",
+					"172.26.0.1:60288",
+					"172.27.0.1:60288",
+					"172.28.0.1:60288",
+					"172.29.0.1:60288"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:06:05.138789727Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         170679822932958,
+				"StableID":   "ndEFVEUJL211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7e6214ef04a8be47b2df329f9b334ab43c393caec730928f832636d10d1f0300",
+				"DiscoKey":   "discokey:deb9c042de9aa911e7e1f46ed869f22600d449c5d9e9fe45b7e1d75d42d6357c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38549",
+					"10.65.0.27:38549",
+					"172.17.0.1:38549",
+					"172.18.0.1:38549",
+					"172.19.0.1:38549",
+					"172.20.0.1:38549",
+					"172.21.0.1:38549",
+					"172.22.0.1:38549",
+					"172.23.0.1:38549",
+					"172.24.0.1:38549",
+					"172.25.0.1:38549",
+					"172.26.0.1:38549",
+					"172.27.0.1:38549",
+					"172.28.0.1:38549",
+					"172.29.0.1:38549"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:06:05.671488052Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4963259093864094,
+				"StableID":   "nDg4FDQskf11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:99d7d595275a99cb6d8145ac37ccab734ecf3bc46fb5643705de247e224bc83c",
+				"DiscoKey":   "discokey:9d0ff4a5e17152398066d88cd6182d39b50bdeb3c0c7455a57c9c231790d3b0e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50618",
+					"10.65.0.27:50618",
+					"172.17.0.1:50618",
+					"172.18.0.1:50618",
+					"172.19.0.1:50618",
+					"172.20.0.1:50618",
+					"172.21.0.1:50618",
+					"172.22.0.1:50618",
+					"172.23.0.1:50618",
+					"172.24.0.1:50618",
+					"172.25.0.1:50618",
+					"172.26.0.1:50618",
+					"172.27.0.1:50618",
+					"172.28.0.1:50618",
+					"172.29.0.1:50618"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:06:06.206189964Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1943546407355350,
+				"StableID":   "nZk3fmfEBG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9218ebc91411788c3a9984660d22098687990c320bdd6f375356f64a7a2b0e68",
+				"DiscoKey":   "discokey:1ffa9b2e2fbd1a73e09a39d6f80cc021b6ed3b812a083bbb7f3ac5e76b5e0563",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:39674",
+					"10.65.0.27:39674",
+					"172.17.0.1:39674",
+					"172.18.0.1:39674",
+					"172.19.0.1:39674",
+					"172.20.0.1:39674",
+					"172.21.0.1:39674",
+					"172.22.0.1:39674",
+					"172.23.0.1:39674",
+					"172.24.0.1:39674",
+					"172.25.0.1:39674",
+					"172.26.0.1:39674",
+					"172.27.0.1:39674",
+					"172.28.0.1:39674",
+					"172.29.0.1:39674"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:06:06.73153339Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1708133528877187,
+				"StableID":   "nSifijmcLE11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a356a22e64460ab591255811a3b615a2e848df822af39edf39acd2d3e1d891d",
+				"DiscoKey":   "discokey:3e442f32c2a1e007aa30850ab06f45bb6d1ffa7698e6ba334c749f360d4b761d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39704",
+					"10.65.0.27:39704",
+					"172.17.0.1:39704",
+					"172.18.0.1:39704",
+					"172.19.0.1:39704",
+					"172.20.0.1:39704",
+					"172.21.0.1:39704",
+					"172.22.0.1:39704",
+					"172.23.0.1:39704",
+					"172.24.0.1:39704",
+					"172.25.0.1:39704",
+					"172.26.0.1:39704",
+					"172.27.0.1:39704",
+					"172.28.0.1:39704",
+					"172.29.0.1:39704"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:06:07.276232748Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5262985869601637,
+				"StableID":   "nrPo3Sic6i11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3401487c8de1fa728e83fce8ace71e43352a05c3e227b661490b8125f65a9a18",
+				"DiscoKey":   "discokey:24c274ca3232a24b2c7bd65ad4b74da767a7749739d327300bfc351d2cbd9b2d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47081",
+					"10.65.0.27:47081",
+					"172.17.0.1:47081",
+					"172.18.0.1:47081",
+					"172.19.0.1:47081",
+					"172.20.0.1:47081",
+					"172.21.0.1:47081",
+					"172.22.0.1:47081",
+					"172.23.0.1:47081",
+					"172.24.0.1:47081",
+					"172.25.0.1:47081",
+					"172.26.0.1:47081",
+					"172.27.0.1:47081",
+					"172.28.0.1:47081",
+					"172.29.0.1:47081"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:06:07.817408191Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         916153504890789,
+				"StableID":   "nxEQ1Mov9811CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f686760c3c5be34a0bd612c59a9daab5e6df5148262ad27834ffc66014b2a36b",
+				"DiscoKey":   "discokey:ffd60d6538f69292c6f2717daf97a27f220f9d88d789e75d5c5285536034cb60",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57006",
+					"10.65.0.27:57006",
+					"172.17.0.1:57006",
+					"172.18.0.1:57006",
+					"172.19.0.1:57006",
+					"172.20.0.1:57006",
+					"172.21.0.1:57006",
+					"172.22.0.1:57006",
+					"172.23.0.1:57006",
+					"172.24.0.1:57006",
+					"172.25.0.1:57006",
+					"172.26.0.1:57006",
+					"172.27.0.1:57006",
+					"172.28.0.1:57006",
+					"172.29.0.1:57006"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:06:08.365168758Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7349144867247594,
+				"StableID":   "nZWMxGaSPz11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a9a0864c31e5b3b5151092f6341b1d0ea5e8f11dda567a93ec4e8bca734746e",
+				"DiscoKey":   "discokey:a951bc4101a4984404a8954e603413dd63c6cd6967a8567ac64aef7829a51f51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59744",
+					"10.65.0.27:59744",
+					"172.17.0.1:59744",
+					"172.18.0.1:59744",
+					"172.19.0.1:59744",
+					"172.20.0.1:59744",
+					"172.21.0.1:59744",
+					"172.22.0.1:59744",
+					"172.23.0.1:59744",
+					"172.24.0.1:59744",
+					"172.25.0.1:59744",
+					"172.26.0.1:59744",
+					"172.27.0.1:59744",
+					"172.28.0.1:59744",
+					"172.29.0.1:59744"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:06:08.900841555Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2656983726927875,
+				"StableID":   "nAi3YWTMkM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7e4b69cfe2c88c50e8b06b9b2cf0438466d1db58c88ce7c31909b7cdf722ec60",
+				"KeyExpiry":  "2026-11-09T09:06:09Z",
+				"DiscoKey":   "discokey:0532507bb618ccd11529f82e642e6a6d30ce3fe5c07730cd9e022f9575963d46",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:59277",
+					"10.65.0.27:59277",
+					"172.17.0.1:59277",
+					"172.18.0.1:59277",
+					"172.19.0.1:59277",
+					"172.20.0.1:59277",
+					"172.21.0.1:59277",
+					"172.22.0.1:59277",
+					"172.23.0.1:59277",
+					"172.24.0.1:59277",
+					"172.25.0.1:59277",
+					"172.26.0.1:59277",
+					"172.27.0.1:59277",
+					"172.28.0.1:59277",
+					"172.29.0.1:59277"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:06:09.446241278Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6744977102580193,
+				"StableID":   "nki2US7pfu11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:d8ff1ec2b48104f077c30a221dad55554ac4880988e0c0d5cc536326a7ada577",
+				"KeyExpiry":  "2026-11-09T09:06:09Z",
+				"DiscoKey":   "discokey:c45d8cd20b6a6e62a65ca75266551eb644fd26f77a4e300bb2fc5583b3d03667",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55650",
+					"10.65.0.27:55650",
+					"172.17.0.1:55650",
+					"172.18.0.1:55650",
+					"172.19.0.1:55650",
+					"172.20.0.1:55650",
+					"172.21.0.1:55650",
+					"172.22.0.1:55650",
+					"172.23.0.1:55650",
+					"172.24.0.1:55650",
+					"172.25.0.1:55650",
+					"172.26.0.1:55650",
+					"172.27.0.1:55650",
+					"172.28.0.1:55650",
+					"172.29.0.1:55650"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:06:09.99204694Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1720498219598092,
+				"StableID":   "nfgb67aDSE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1720498219598092,
+				"Key":        "nodekey:8e7da71bf3127c4a45c28179e3d1d65f48881e49e3e8f2d1cd872106e2bc863c",
+				"DiscoKey":   "discokey:f57f5f1b7ecbaf7b059d1e09703f016956dd701871149159795580162f004a17",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57211",
+					"10.65.0.27:57211",
+					"172.17.0.1:57211",
+					"172.18.0.1:57211",
+					"172.19.0.1:57211",
+					"172.20.0.1:57211",
+					"172.21.0.1:57211",
+					"172.22.0.1:57211",
+					"172.23.0.1:57211",
+					"172.24.0.1:57211",
+					"172.25.0.1:57211",
+					"172.26.0.1:57211",
+					"172.27.0.1:57211",
+					"172.28.0.1:57211",
+					"172.29.0.1:57211"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:06:04.045727996Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8e7da71bf3127c4a45c28179e3d1d65f48881e49e3e8f2d1cd872106e2bc863c",
+			"MachineKey": "mkey:6a7719784872faa38756054de097e0cc6a6048c27e90719280152b3994fe787e",
+			"Peers": [{
+				"ID":         4069156827127413,
+				"StableID":   "nz39eHrvmY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fae451d819bd4251f674c2ca3ce306142afa17f8f5d2775bf0b17c07d6ce5913",
+				"DiscoKey":   "discokey:2d35776083370160cede6d7ecc324f9d09af6e67ff53263ba9cdf8e04916407c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46050",
+					"10.65.0.27:46050",
+					"172.17.0.1:46050",
+					"172.18.0.1:46050",
+					"172.19.0.1:46050",
+					"172.20.0.1:46050",
+					"172.21.0.1:46050",
+					"172.22.0.1:46050",
+					"172.23.0.1:46050",
+					"172.24.0.1:46050",
+					"172.25.0.1:46050",
+					"172.26.0.1:46050",
+					"172.27.0.1:46050",
+					"172.28.0.1:46050",
+					"172.29.0.1:46050"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:06:02.729300584Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2945498691911599,
+				"StableID":   "nQw22rF21Q11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ef63d42f0a54510a7fab0636e6535e983713dbe511ad07701eb46540d737a358",
+				"DiscoKey":   "discokey:e79aaf48ae2ba950adc828eb7f67fad6a6ff79809385cc7ea13972cb30c50f4a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54774",
+					"10.65.0.27:54774",
+					"172.17.0.1:54774",
+					"172.18.0.1:54774",
+					"172.19.0.1:54774",
+					"172.20.0.1:54774",
+					"172.21.0.1:54774",
+					"172.22.0.1:54774",
+					"172.23.0.1:54774",
+					"172.24.0.1:54774",
+					"172.25.0.1:54774",
+					"172.26.0.1:54774",
+					"172.27.0.1:54774",
+					"172.28.0.1:54774",
+					"172.29.0.1:54774"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:06:03.364321574Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1006977852880196,
+				"StableID":   "n5jGdqb4s811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6171e9f651e818a2ff9f302698460c78f2574b991eea9850eea878f8128e4e02",
+				"DiscoKey":   "discokey:4ec33d228df30eb9b1c78e8496852b6b71e3515d879dbb35a640785768979833",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40521",
+					"10.65.0.27:40521",
+					"172.17.0.1:40521",
+					"172.18.0.1:40521",
+					"172.19.0.1:40521",
+					"172.20.0.1:40521",
+					"172.21.0.1:40521",
+					"172.22.0.1:40521",
+					"172.23.0.1:40521",
+					"172.24.0.1:40521",
+					"172.25.0.1:40521",
+					"172.26.0.1:40521",
+					"172.27.0.1:40521",
+					"172.28.0.1:40521",
+					"172.29.0.1:40521"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:06:04.577289819Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7564700820128575,
+				"StableID":   "nNQgN4s45221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:700f8dfb91a17b9f8bb2ed24d42f53d27ed8467ea9b340a285ee964ad49c3a73",
+				"DiscoKey":   "discokey:368cc773cb3d5d79c3caaaf9f87c363b38b82d52a7c8b67994d7c899d36bdb40",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60288",
+					"10.65.0.27:60288",
+					"172.17.0.1:60288",
+					"172.18.0.1:60288",
+					"172.19.0.1:60288",
+					"172.20.0.1:60288",
+					"172.21.0.1:60288",
+					"172.22.0.1:60288",
+					"172.23.0.1:60288",
+					"172.24.0.1:60288",
+					"172.25.0.1:60288",
+					"172.26.0.1:60288",
+					"172.27.0.1:60288",
+					"172.28.0.1:60288",
+					"172.29.0.1:60288"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:06:05.138789727Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         170679822932958,
+				"StableID":   "ndEFVEUJL211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7e6214ef04a8be47b2df329f9b334ab43c393caec730928f832636d10d1f0300",
+				"DiscoKey":   "discokey:deb9c042de9aa911e7e1f46ed869f22600d449c5d9e9fe45b7e1d75d42d6357c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38549",
+					"10.65.0.27:38549",
+					"172.17.0.1:38549",
+					"172.18.0.1:38549",
+					"172.19.0.1:38549",
+					"172.20.0.1:38549",
+					"172.21.0.1:38549",
+					"172.22.0.1:38549",
+					"172.23.0.1:38549",
+					"172.24.0.1:38549",
+					"172.25.0.1:38549",
+					"172.26.0.1:38549",
+					"172.27.0.1:38549",
+					"172.28.0.1:38549",
+					"172.29.0.1:38549"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:06:05.671488052Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4963259093864094,
+				"StableID":   "nDg4FDQskf11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:99d7d595275a99cb6d8145ac37ccab734ecf3bc46fb5643705de247e224bc83c",
+				"DiscoKey":   "discokey:9d0ff4a5e17152398066d88cd6182d39b50bdeb3c0c7455a57c9c231790d3b0e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50618",
+					"10.65.0.27:50618",
+					"172.17.0.1:50618",
+					"172.18.0.1:50618",
+					"172.19.0.1:50618",
+					"172.20.0.1:50618",
+					"172.21.0.1:50618",
+					"172.22.0.1:50618",
+					"172.23.0.1:50618",
+					"172.24.0.1:50618",
+					"172.25.0.1:50618",
+					"172.26.0.1:50618",
+					"172.27.0.1:50618",
+					"172.28.0.1:50618",
+					"172.29.0.1:50618"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:06:06.206189964Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1943546407355350,
+				"StableID":   "nZk3fmfEBG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9218ebc91411788c3a9984660d22098687990c320bdd6f375356f64a7a2b0e68",
+				"DiscoKey":   "discokey:1ffa9b2e2fbd1a73e09a39d6f80cc021b6ed3b812a083bbb7f3ac5e76b5e0563",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:39674",
+					"10.65.0.27:39674",
+					"172.17.0.1:39674",
+					"172.18.0.1:39674",
+					"172.19.0.1:39674",
+					"172.20.0.1:39674",
+					"172.21.0.1:39674",
+					"172.22.0.1:39674",
+					"172.23.0.1:39674",
+					"172.24.0.1:39674",
+					"172.25.0.1:39674",
+					"172.26.0.1:39674",
+					"172.27.0.1:39674",
+					"172.28.0.1:39674",
+					"172.29.0.1:39674"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:06:06.73153339Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1708133528877187,
+				"StableID":   "nSifijmcLE11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a356a22e64460ab591255811a3b615a2e848df822af39edf39acd2d3e1d891d",
+				"DiscoKey":   "discokey:3e442f32c2a1e007aa30850ab06f45bb6d1ffa7698e6ba334c749f360d4b761d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39704",
+					"10.65.0.27:39704",
+					"172.17.0.1:39704",
+					"172.18.0.1:39704",
+					"172.19.0.1:39704",
+					"172.20.0.1:39704",
+					"172.21.0.1:39704",
+					"172.22.0.1:39704",
+					"172.23.0.1:39704",
+					"172.24.0.1:39704",
+					"172.25.0.1:39704",
+					"172.26.0.1:39704",
+					"172.27.0.1:39704",
+					"172.28.0.1:39704",
+					"172.29.0.1:39704"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:06:07.276232748Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5262985869601637,
+				"StableID":   "nrPo3Sic6i11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3401487c8de1fa728e83fce8ace71e43352a05c3e227b661490b8125f65a9a18",
+				"DiscoKey":   "discokey:24c274ca3232a24b2c7bd65ad4b74da767a7749739d327300bfc351d2cbd9b2d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47081",
+					"10.65.0.27:47081",
+					"172.17.0.1:47081",
+					"172.18.0.1:47081",
+					"172.19.0.1:47081",
+					"172.20.0.1:47081",
+					"172.21.0.1:47081",
+					"172.22.0.1:47081",
+					"172.23.0.1:47081",
+					"172.24.0.1:47081",
+					"172.25.0.1:47081",
+					"172.26.0.1:47081",
+					"172.27.0.1:47081",
+					"172.28.0.1:47081",
+					"172.29.0.1:47081"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:06:07.817408191Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         916153504890789,
+				"StableID":   "nxEQ1Mov9811CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f686760c3c5be34a0bd612c59a9daab5e6df5148262ad27834ffc66014b2a36b",
+				"DiscoKey":   "discokey:ffd60d6538f69292c6f2717daf97a27f220f9d88d789e75d5c5285536034cb60",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57006",
+					"10.65.0.27:57006",
+					"172.17.0.1:57006",
+					"172.18.0.1:57006",
+					"172.19.0.1:57006",
+					"172.20.0.1:57006",
+					"172.21.0.1:57006",
+					"172.22.0.1:57006",
+					"172.23.0.1:57006",
+					"172.24.0.1:57006",
+					"172.25.0.1:57006",
+					"172.26.0.1:57006",
+					"172.27.0.1:57006",
+					"172.28.0.1:57006",
+					"172.29.0.1:57006"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:06:08.365168758Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7349144867247594,
+				"StableID":   "nZWMxGaSPz11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a9a0864c31e5b3b5151092f6341b1d0ea5e8f11dda567a93ec4e8bca734746e",
+				"DiscoKey":   "discokey:a951bc4101a4984404a8954e603413dd63c6cd6967a8567ac64aef7829a51f51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59744",
+					"10.65.0.27:59744",
+					"172.17.0.1:59744",
+					"172.18.0.1:59744",
+					"172.19.0.1:59744",
+					"172.20.0.1:59744",
+					"172.21.0.1:59744",
+					"172.22.0.1:59744",
+					"172.23.0.1:59744",
+					"172.24.0.1:59744",
+					"172.25.0.1:59744",
+					"172.26.0.1:59744",
+					"172.27.0.1:59744",
+					"172.28.0.1:59744",
+					"172.29.0.1:59744"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:06:08.900841555Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2656983726927875,
+				"StableID":   "nAi3YWTMkM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7e4b69cfe2c88c50e8b06b9b2cf0438466d1db58c88ce7c31909b7cdf722ec60",
+				"KeyExpiry":  "2026-11-09T09:06:09Z",
+				"DiscoKey":   "discokey:0532507bb618ccd11529f82e642e6a6d30ce3fe5c07730cd9e022f9575963d46",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:59277",
+					"10.65.0.27:59277",
+					"172.17.0.1:59277",
+					"172.18.0.1:59277",
+					"172.19.0.1:59277",
+					"172.20.0.1:59277",
+					"172.21.0.1:59277",
+					"172.22.0.1:59277",
+					"172.23.0.1:59277",
+					"172.24.0.1:59277",
+					"172.25.0.1:59277",
+					"172.26.0.1:59277",
+					"172.27.0.1:59277",
+					"172.28.0.1:59277",
+					"172.29.0.1:59277"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:06:09.446241278Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6744977102580193,
+				"StableID":   "nki2US7pfu11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:d8ff1ec2b48104f077c30a221dad55554ac4880988e0c0d5cc536326a7ada577",
+				"KeyExpiry":  "2026-11-09T09:06:09Z",
+				"DiscoKey":   "discokey:c45d8cd20b6a6e62a65ca75266551eb644fd26f77a4e300bb2fc5583b3d03667",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55650",
+					"10.65.0.27:55650",
+					"172.17.0.1:55650",
+					"172.18.0.1:55650",
+					"172.19.0.1:55650",
+					"172.20.0.1:55650",
+					"172.21.0.1:55650",
+					"172.22.0.1:55650",
+					"172.23.0.1:55650",
+					"172.24.0.1:55650",
+					"172.25.0.1:55650",
+					"172.26.0.1:55650",
+					"172.27.0.1:55650",
+					"172.28.0.1:55650",
+					"172.29.0.1:55650"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:06:09.99204694Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8937434359782713,
+				"StableID":   "neFwZEFnnC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7259264d04fbd94bb35e6d00bc341968a782958f2b53e9ba3666a7972452097d",
+				"KeyExpiry":  "2026-11-09T09:06:10Z",
+				"DiscoKey":   "discokey:b849d1522e87bda0a2764a94af6a0ab2f2de4fabd17eeb751fc204be55b3bd25",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786",
+					"172.20.0.1:45786",
+					"172.21.0.1:45786",
+					"172.22.0.1:45786",
+					"172.23.0.1:45786",
+					"172.24.0.1:45786",
+					"172.25.0.1:45786",
+					"172.26.0.1:45786",
+					"172.27.0.1:45786",
+					"172.28.0.1:45786",
+					"172.29.0.1:45786"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:06:10.527555233Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1720498219598092": {
+				"ID":          1720498219598092,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1943546407355350,
+				"StableID":   "nZk3fmfEBG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1943546407355350,
+				"Key":        "nodekey:9218ebc91411788c3a9984660d22098687990c320bdd6f375356f64a7a2b0e68",
+				"DiscoKey":   "discokey:1ffa9b2e2fbd1a73e09a39d6f80cc021b6ed3b812a083bbb7f3ac5e76b5e0563",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:39674",
+					"10.65.0.27:39674",
+					"172.17.0.1:39674",
+					"172.18.0.1:39674",
+					"172.19.0.1:39674",
+					"172.20.0.1:39674",
+					"172.21.0.1:39674",
+					"172.22.0.1:39674",
+					"172.23.0.1:39674",
+					"172.24.0.1:39674",
+					"172.25.0.1:39674",
+					"172.26.0.1:39674",
+					"172.27.0.1:39674",
+					"172.28.0.1:39674",
+					"172.29.0.1:39674"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:06:06.73153339Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9218ebc91411788c3a9984660d22098687990c320bdd6f375356f64a7a2b0e68",
+			"MachineKey": "mkey:1e5a5255f59536ae7c20d63b133433b7f5e65e56a63ec18af034203bf72bf779",
+			"Peers": [{
+				"ID":         4069156827127413,
+				"StableID":   "nz39eHrvmY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fae451d819bd4251f674c2ca3ce306142afa17f8f5d2775bf0b17c07d6ce5913",
+				"DiscoKey":   "discokey:2d35776083370160cede6d7ecc324f9d09af6e67ff53263ba9cdf8e04916407c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46050",
+					"10.65.0.27:46050",
+					"172.17.0.1:46050",
+					"172.18.0.1:46050",
+					"172.19.0.1:46050",
+					"172.20.0.1:46050",
+					"172.21.0.1:46050",
+					"172.22.0.1:46050",
+					"172.23.0.1:46050",
+					"172.24.0.1:46050",
+					"172.25.0.1:46050",
+					"172.26.0.1:46050",
+					"172.27.0.1:46050",
+					"172.28.0.1:46050",
+					"172.29.0.1:46050"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:06:02.729300584Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2945498691911599,
+				"StableID":   "nQw22rF21Q11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ef63d42f0a54510a7fab0636e6535e983713dbe511ad07701eb46540d737a358",
+				"DiscoKey":   "discokey:e79aaf48ae2ba950adc828eb7f67fad6a6ff79809385cc7ea13972cb30c50f4a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54774",
+					"10.65.0.27:54774",
+					"172.17.0.1:54774",
+					"172.18.0.1:54774",
+					"172.19.0.1:54774",
+					"172.20.0.1:54774",
+					"172.21.0.1:54774",
+					"172.22.0.1:54774",
+					"172.23.0.1:54774",
+					"172.24.0.1:54774",
+					"172.25.0.1:54774",
+					"172.26.0.1:54774",
+					"172.27.0.1:54774",
+					"172.28.0.1:54774",
+					"172.29.0.1:54774"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:06:03.364321574Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1720498219598092,
+				"StableID":   "nfgb67aDSE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e7da71bf3127c4a45c28179e3d1d65f48881e49e3e8f2d1cd872106e2bc863c",
+				"DiscoKey":   "discokey:f57f5f1b7ecbaf7b059d1e09703f016956dd701871149159795580162f004a17",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57211",
+					"10.65.0.27:57211",
+					"172.17.0.1:57211",
+					"172.18.0.1:57211",
+					"172.19.0.1:57211",
+					"172.20.0.1:57211",
+					"172.21.0.1:57211",
+					"172.22.0.1:57211",
+					"172.23.0.1:57211",
+					"172.24.0.1:57211",
+					"172.25.0.1:57211",
+					"172.26.0.1:57211",
+					"172.27.0.1:57211",
+					"172.28.0.1:57211",
+					"172.29.0.1:57211"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:06:04.045727996Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1006977852880196,
+				"StableID":   "n5jGdqb4s811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6171e9f651e818a2ff9f302698460c78f2574b991eea9850eea878f8128e4e02",
+				"DiscoKey":   "discokey:4ec33d228df30eb9b1c78e8496852b6b71e3515d879dbb35a640785768979833",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40521",
+					"10.65.0.27:40521",
+					"172.17.0.1:40521",
+					"172.18.0.1:40521",
+					"172.19.0.1:40521",
+					"172.20.0.1:40521",
+					"172.21.0.1:40521",
+					"172.22.0.1:40521",
+					"172.23.0.1:40521",
+					"172.24.0.1:40521",
+					"172.25.0.1:40521",
+					"172.26.0.1:40521",
+					"172.27.0.1:40521",
+					"172.28.0.1:40521",
+					"172.29.0.1:40521"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:06:04.577289819Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7564700820128575,
+				"StableID":   "nNQgN4s45221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:700f8dfb91a17b9f8bb2ed24d42f53d27ed8467ea9b340a285ee964ad49c3a73",
+				"DiscoKey":   "discokey:368cc773cb3d5d79c3caaaf9f87c363b38b82d52a7c8b67994d7c899d36bdb40",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60288",
+					"10.65.0.27:60288",
+					"172.17.0.1:60288",
+					"172.18.0.1:60288",
+					"172.19.0.1:60288",
+					"172.20.0.1:60288",
+					"172.21.0.1:60288",
+					"172.22.0.1:60288",
+					"172.23.0.1:60288",
+					"172.24.0.1:60288",
+					"172.25.0.1:60288",
+					"172.26.0.1:60288",
+					"172.27.0.1:60288",
+					"172.28.0.1:60288",
+					"172.29.0.1:60288"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:06:05.138789727Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         170679822932958,
+				"StableID":   "ndEFVEUJL211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7e6214ef04a8be47b2df329f9b334ab43c393caec730928f832636d10d1f0300",
+				"DiscoKey":   "discokey:deb9c042de9aa911e7e1f46ed869f22600d449c5d9e9fe45b7e1d75d42d6357c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38549",
+					"10.65.0.27:38549",
+					"172.17.0.1:38549",
+					"172.18.0.1:38549",
+					"172.19.0.1:38549",
+					"172.20.0.1:38549",
+					"172.21.0.1:38549",
+					"172.22.0.1:38549",
+					"172.23.0.1:38549",
+					"172.24.0.1:38549",
+					"172.25.0.1:38549",
+					"172.26.0.1:38549",
+					"172.27.0.1:38549",
+					"172.28.0.1:38549",
+					"172.29.0.1:38549"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:06:05.671488052Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4963259093864094,
+				"StableID":   "nDg4FDQskf11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:99d7d595275a99cb6d8145ac37ccab734ecf3bc46fb5643705de247e224bc83c",
+				"DiscoKey":   "discokey:9d0ff4a5e17152398066d88cd6182d39b50bdeb3c0c7455a57c9c231790d3b0e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50618",
+					"10.65.0.27:50618",
+					"172.17.0.1:50618",
+					"172.18.0.1:50618",
+					"172.19.0.1:50618",
+					"172.20.0.1:50618",
+					"172.21.0.1:50618",
+					"172.22.0.1:50618",
+					"172.23.0.1:50618",
+					"172.24.0.1:50618",
+					"172.25.0.1:50618",
+					"172.26.0.1:50618",
+					"172.27.0.1:50618",
+					"172.28.0.1:50618",
+					"172.29.0.1:50618"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:06:06.206189964Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1708133528877187,
+				"StableID":   "nSifijmcLE11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a356a22e64460ab591255811a3b615a2e848df822af39edf39acd2d3e1d891d",
+				"DiscoKey":   "discokey:3e442f32c2a1e007aa30850ab06f45bb6d1ffa7698e6ba334c749f360d4b761d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39704",
+					"10.65.0.27:39704",
+					"172.17.0.1:39704",
+					"172.18.0.1:39704",
+					"172.19.0.1:39704",
+					"172.20.0.1:39704",
+					"172.21.0.1:39704",
+					"172.22.0.1:39704",
+					"172.23.0.1:39704",
+					"172.24.0.1:39704",
+					"172.25.0.1:39704",
+					"172.26.0.1:39704",
+					"172.27.0.1:39704",
+					"172.28.0.1:39704",
+					"172.29.0.1:39704"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:06:07.276232748Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5262985869601637,
+				"StableID":   "nrPo3Sic6i11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3401487c8de1fa728e83fce8ace71e43352a05c3e227b661490b8125f65a9a18",
+				"DiscoKey":   "discokey:24c274ca3232a24b2c7bd65ad4b74da767a7749739d327300bfc351d2cbd9b2d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47081",
+					"10.65.0.27:47081",
+					"172.17.0.1:47081",
+					"172.18.0.1:47081",
+					"172.19.0.1:47081",
+					"172.20.0.1:47081",
+					"172.21.0.1:47081",
+					"172.22.0.1:47081",
+					"172.23.0.1:47081",
+					"172.24.0.1:47081",
+					"172.25.0.1:47081",
+					"172.26.0.1:47081",
+					"172.27.0.1:47081",
+					"172.28.0.1:47081",
+					"172.29.0.1:47081"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:06:07.817408191Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         916153504890789,
+				"StableID":   "nxEQ1Mov9811CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f686760c3c5be34a0bd612c59a9daab5e6df5148262ad27834ffc66014b2a36b",
+				"DiscoKey":   "discokey:ffd60d6538f69292c6f2717daf97a27f220f9d88d789e75d5c5285536034cb60",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57006",
+					"10.65.0.27:57006",
+					"172.17.0.1:57006",
+					"172.18.0.1:57006",
+					"172.19.0.1:57006",
+					"172.20.0.1:57006",
+					"172.21.0.1:57006",
+					"172.22.0.1:57006",
+					"172.23.0.1:57006",
+					"172.24.0.1:57006",
+					"172.25.0.1:57006",
+					"172.26.0.1:57006",
+					"172.27.0.1:57006",
+					"172.28.0.1:57006",
+					"172.29.0.1:57006"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:06:08.365168758Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7349144867247594,
+				"StableID":   "nZWMxGaSPz11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a9a0864c31e5b3b5151092f6341b1d0ea5e8f11dda567a93ec4e8bca734746e",
+				"DiscoKey":   "discokey:a951bc4101a4984404a8954e603413dd63c6cd6967a8567ac64aef7829a51f51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59744",
+					"10.65.0.27:59744",
+					"172.17.0.1:59744",
+					"172.18.0.1:59744",
+					"172.19.0.1:59744",
+					"172.20.0.1:59744",
+					"172.21.0.1:59744",
+					"172.22.0.1:59744",
+					"172.23.0.1:59744",
+					"172.24.0.1:59744",
+					"172.25.0.1:59744",
+					"172.26.0.1:59744",
+					"172.27.0.1:59744",
+					"172.28.0.1:59744",
+					"172.29.0.1:59744"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:06:08.900841555Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2656983726927875,
+				"StableID":   "nAi3YWTMkM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7e4b69cfe2c88c50e8b06b9b2cf0438466d1db58c88ce7c31909b7cdf722ec60",
+				"KeyExpiry":  "2026-11-09T09:06:09Z",
+				"DiscoKey":   "discokey:0532507bb618ccd11529f82e642e6a6d30ce3fe5c07730cd9e022f9575963d46",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:59277",
+					"10.65.0.27:59277",
+					"172.17.0.1:59277",
+					"172.18.0.1:59277",
+					"172.19.0.1:59277",
+					"172.20.0.1:59277",
+					"172.21.0.1:59277",
+					"172.22.0.1:59277",
+					"172.23.0.1:59277",
+					"172.24.0.1:59277",
+					"172.25.0.1:59277",
+					"172.26.0.1:59277",
+					"172.27.0.1:59277",
+					"172.28.0.1:59277",
+					"172.29.0.1:59277"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:06:09.446241278Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6744977102580193,
+				"StableID":   "nki2US7pfu11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:d8ff1ec2b48104f077c30a221dad55554ac4880988e0c0d5cc536326a7ada577",
+				"KeyExpiry":  "2026-11-09T09:06:09Z",
+				"DiscoKey":   "discokey:c45d8cd20b6a6e62a65ca75266551eb644fd26f77a4e300bb2fc5583b3d03667",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55650",
+					"10.65.0.27:55650",
+					"172.17.0.1:55650",
+					"172.18.0.1:55650",
+					"172.19.0.1:55650",
+					"172.20.0.1:55650",
+					"172.21.0.1:55650",
+					"172.22.0.1:55650",
+					"172.23.0.1:55650",
+					"172.24.0.1:55650",
+					"172.25.0.1:55650",
+					"172.26.0.1:55650",
+					"172.27.0.1:55650",
+					"172.28.0.1:55650",
+					"172.29.0.1:55650"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:06:09.99204694Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8937434359782713,
+				"StableID":   "neFwZEFnnC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7259264d04fbd94bb35e6d00bc341968a782958f2b53e9ba3666a7972452097d",
+				"KeyExpiry":  "2026-11-09T09:06:10Z",
+				"DiscoKey":   "discokey:b849d1522e87bda0a2764a94af6a0ab2f2de4fabd17eeb751fc204be55b3bd25",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786",
+					"172.20.0.1:45786",
+					"172.21.0.1:45786",
+					"172.22.0.1:45786",
+					"172.23.0.1:45786",
+					"172.24.0.1:45786",
+					"172.25.0.1:45786",
+					"172.26.0.1:45786",
+					"172.27.0.1:45786",
+					"172.28.0.1:45786",
+					"172.29.0.1:45786"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:06:10.527555233Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1943546407355350": {
+				"ID":          1943546407355350,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2656983726927875,
+				"StableID":   "nAi3YWTMkM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7e4b69cfe2c88c50e8b06b9b2cf0438466d1db58c88ce7c31909b7cdf722ec60",
+				"KeyExpiry":  "2026-11-09T09:06:09Z",
+				"DiscoKey":   "discokey:0532507bb618ccd11529f82e642e6a6d30ce3fe5c07730cd9e022f9575963d46",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:59277",
+					"10.65.0.27:59277",
+					"172.17.0.1:59277",
+					"172.18.0.1:59277",
+					"172.19.0.1:59277",
+					"172.20.0.1:59277",
+					"172.21.0.1:59277",
+					"172.22.0.1:59277",
+					"172.23.0.1:59277",
+					"172.24.0.1:59277",
+					"172.25.0.1:59277",
+					"172.26.0.1:59277",
+					"172.27.0.1:59277",
+					"172.28.0.1:59277",
+					"172.29.0.1:59277"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:06:09.446241278Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7e4b69cfe2c88c50e8b06b9b2cf0438466d1db58c88ce7c31909b7cdf722ec60",
+			"MachineKey": "mkey:5f3f4433644a53e9d892173e7d8e5c92cee9722da966fd89056feb768cd8de51",
+			"Peers": [{
+				"ID":         4069156827127413,
+				"StableID":   "nz39eHrvmY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fae451d819bd4251f674c2ca3ce306142afa17f8f5d2775bf0b17c07d6ce5913",
+				"DiscoKey":   "discokey:2d35776083370160cede6d7ecc324f9d09af6e67ff53263ba9cdf8e04916407c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46050",
+					"10.65.0.27:46050",
+					"172.17.0.1:46050",
+					"172.18.0.1:46050",
+					"172.19.0.1:46050",
+					"172.20.0.1:46050",
+					"172.21.0.1:46050",
+					"172.22.0.1:46050",
+					"172.23.0.1:46050",
+					"172.24.0.1:46050",
+					"172.25.0.1:46050",
+					"172.26.0.1:46050",
+					"172.27.0.1:46050",
+					"172.28.0.1:46050",
+					"172.29.0.1:46050"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:06:02.729300584Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2945498691911599,
+				"StableID":   "nQw22rF21Q11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ef63d42f0a54510a7fab0636e6535e983713dbe511ad07701eb46540d737a358",
+				"DiscoKey":   "discokey:e79aaf48ae2ba950adc828eb7f67fad6a6ff79809385cc7ea13972cb30c50f4a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54774",
+					"10.65.0.27:54774",
+					"172.17.0.1:54774",
+					"172.18.0.1:54774",
+					"172.19.0.1:54774",
+					"172.20.0.1:54774",
+					"172.21.0.1:54774",
+					"172.22.0.1:54774",
+					"172.23.0.1:54774",
+					"172.24.0.1:54774",
+					"172.25.0.1:54774",
+					"172.26.0.1:54774",
+					"172.27.0.1:54774",
+					"172.28.0.1:54774",
+					"172.29.0.1:54774"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:06:03.364321574Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1720498219598092,
+				"StableID":   "nfgb67aDSE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e7da71bf3127c4a45c28179e3d1d65f48881e49e3e8f2d1cd872106e2bc863c",
+				"DiscoKey":   "discokey:f57f5f1b7ecbaf7b059d1e09703f016956dd701871149159795580162f004a17",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57211",
+					"10.65.0.27:57211",
+					"172.17.0.1:57211",
+					"172.18.0.1:57211",
+					"172.19.0.1:57211",
+					"172.20.0.1:57211",
+					"172.21.0.1:57211",
+					"172.22.0.1:57211",
+					"172.23.0.1:57211",
+					"172.24.0.1:57211",
+					"172.25.0.1:57211",
+					"172.26.0.1:57211",
+					"172.27.0.1:57211",
+					"172.28.0.1:57211",
+					"172.29.0.1:57211"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:06:04.045727996Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1006977852880196,
+				"StableID":   "n5jGdqb4s811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6171e9f651e818a2ff9f302698460c78f2574b991eea9850eea878f8128e4e02",
+				"DiscoKey":   "discokey:4ec33d228df30eb9b1c78e8496852b6b71e3515d879dbb35a640785768979833",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40521",
+					"10.65.0.27:40521",
+					"172.17.0.1:40521",
+					"172.18.0.1:40521",
+					"172.19.0.1:40521",
+					"172.20.0.1:40521",
+					"172.21.0.1:40521",
+					"172.22.0.1:40521",
+					"172.23.0.1:40521",
+					"172.24.0.1:40521",
+					"172.25.0.1:40521",
+					"172.26.0.1:40521",
+					"172.27.0.1:40521",
+					"172.28.0.1:40521",
+					"172.29.0.1:40521"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:06:04.577289819Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7564700820128575,
+				"StableID":   "nNQgN4s45221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:700f8dfb91a17b9f8bb2ed24d42f53d27ed8467ea9b340a285ee964ad49c3a73",
+				"DiscoKey":   "discokey:368cc773cb3d5d79c3caaaf9f87c363b38b82d52a7c8b67994d7c899d36bdb40",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60288",
+					"10.65.0.27:60288",
+					"172.17.0.1:60288",
+					"172.18.0.1:60288",
+					"172.19.0.1:60288",
+					"172.20.0.1:60288",
+					"172.21.0.1:60288",
+					"172.22.0.1:60288",
+					"172.23.0.1:60288",
+					"172.24.0.1:60288",
+					"172.25.0.1:60288",
+					"172.26.0.1:60288",
+					"172.27.0.1:60288",
+					"172.28.0.1:60288",
+					"172.29.0.1:60288"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:06:05.138789727Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         170679822932958,
+				"StableID":   "ndEFVEUJL211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7e6214ef04a8be47b2df329f9b334ab43c393caec730928f832636d10d1f0300",
+				"DiscoKey":   "discokey:deb9c042de9aa911e7e1f46ed869f22600d449c5d9e9fe45b7e1d75d42d6357c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38549",
+					"10.65.0.27:38549",
+					"172.17.0.1:38549",
+					"172.18.0.1:38549",
+					"172.19.0.1:38549",
+					"172.20.0.1:38549",
+					"172.21.0.1:38549",
+					"172.22.0.1:38549",
+					"172.23.0.1:38549",
+					"172.24.0.1:38549",
+					"172.25.0.1:38549",
+					"172.26.0.1:38549",
+					"172.27.0.1:38549",
+					"172.28.0.1:38549",
+					"172.29.0.1:38549"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:06:05.671488052Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4963259093864094,
+				"StableID":   "nDg4FDQskf11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:99d7d595275a99cb6d8145ac37ccab734ecf3bc46fb5643705de247e224bc83c",
+				"DiscoKey":   "discokey:9d0ff4a5e17152398066d88cd6182d39b50bdeb3c0c7455a57c9c231790d3b0e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50618",
+					"10.65.0.27:50618",
+					"172.17.0.1:50618",
+					"172.18.0.1:50618",
+					"172.19.0.1:50618",
+					"172.20.0.1:50618",
+					"172.21.0.1:50618",
+					"172.22.0.1:50618",
+					"172.23.0.1:50618",
+					"172.24.0.1:50618",
+					"172.25.0.1:50618",
+					"172.26.0.1:50618",
+					"172.27.0.1:50618",
+					"172.28.0.1:50618",
+					"172.29.0.1:50618"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:06:06.206189964Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1943546407355350,
+				"StableID":   "nZk3fmfEBG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9218ebc91411788c3a9984660d22098687990c320bdd6f375356f64a7a2b0e68",
+				"DiscoKey":   "discokey:1ffa9b2e2fbd1a73e09a39d6f80cc021b6ed3b812a083bbb7f3ac5e76b5e0563",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:39674",
+					"10.65.0.27:39674",
+					"172.17.0.1:39674",
+					"172.18.0.1:39674",
+					"172.19.0.1:39674",
+					"172.20.0.1:39674",
+					"172.21.0.1:39674",
+					"172.22.0.1:39674",
+					"172.23.0.1:39674",
+					"172.24.0.1:39674",
+					"172.25.0.1:39674",
+					"172.26.0.1:39674",
+					"172.27.0.1:39674",
+					"172.28.0.1:39674",
+					"172.29.0.1:39674"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:06:06.73153339Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1708133528877187,
+				"StableID":   "nSifijmcLE11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a356a22e64460ab591255811a3b615a2e848df822af39edf39acd2d3e1d891d",
+				"DiscoKey":   "discokey:3e442f32c2a1e007aa30850ab06f45bb6d1ffa7698e6ba334c749f360d4b761d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39704",
+					"10.65.0.27:39704",
+					"172.17.0.1:39704",
+					"172.18.0.1:39704",
+					"172.19.0.1:39704",
+					"172.20.0.1:39704",
+					"172.21.0.1:39704",
+					"172.22.0.1:39704",
+					"172.23.0.1:39704",
+					"172.24.0.1:39704",
+					"172.25.0.1:39704",
+					"172.26.0.1:39704",
+					"172.27.0.1:39704",
+					"172.28.0.1:39704",
+					"172.29.0.1:39704"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:06:07.276232748Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5262985869601637,
+				"StableID":   "nrPo3Sic6i11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3401487c8de1fa728e83fce8ace71e43352a05c3e227b661490b8125f65a9a18",
+				"DiscoKey":   "discokey:24c274ca3232a24b2c7bd65ad4b74da767a7749739d327300bfc351d2cbd9b2d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47081",
+					"10.65.0.27:47081",
+					"172.17.0.1:47081",
+					"172.18.0.1:47081",
+					"172.19.0.1:47081",
+					"172.20.0.1:47081",
+					"172.21.0.1:47081",
+					"172.22.0.1:47081",
+					"172.23.0.1:47081",
+					"172.24.0.1:47081",
+					"172.25.0.1:47081",
+					"172.26.0.1:47081",
+					"172.27.0.1:47081",
+					"172.28.0.1:47081",
+					"172.29.0.1:47081"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:06:07.817408191Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         916153504890789,
+				"StableID":   "nxEQ1Mov9811CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f686760c3c5be34a0bd612c59a9daab5e6df5148262ad27834ffc66014b2a36b",
+				"DiscoKey":   "discokey:ffd60d6538f69292c6f2717daf97a27f220f9d88d789e75d5c5285536034cb60",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57006",
+					"10.65.0.27:57006",
+					"172.17.0.1:57006",
+					"172.18.0.1:57006",
+					"172.19.0.1:57006",
+					"172.20.0.1:57006",
+					"172.21.0.1:57006",
+					"172.22.0.1:57006",
+					"172.23.0.1:57006",
+					"172.24.0.1:57006",
+					"172.25.0.1:57006",
+					"172.26.0.1:57006",
+					"172.27.0.1:57006",
+					"172.28.0.1:57006",
+					"172.29.0.1:57006"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:06:08.365168758Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7349144867247594,
+				"StableID":   "nZWMxGaSPz11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a9a0864c31e5b3b5151092f6341b1d0ea5e8f11dda567a93ec4e8bca734746e",
+				"DiscoKey":   "discokey:a951bc4101a4984404a8954e603413dd63c6cd6967a8567ac64aef7829a51f51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59744",
+					"10.65.0.27:59744",
+					"172.17.0.1:59744",
+					"172.18.0.1:59744",
+					"172.19.0.1:59744",
+					"172.20.0.1:59744",
+					"172.21.0.1:59744",
+					"172.22.0.1:59744",
+					"172.23.0.1:59744",
+					"172.24.0.1:59744",
+					"172.25.0.1:59744",
+					"172.26.0.1:59744",
+					"172.27.0.1:59744",
+					"172.28.0.1:59744",
+					"172.29.0.1:59744"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:06:08.900841555Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6744977102580193,
+				"StableID":   "nki2US7pfu11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:d8ff1ec2b48104f077c30a221dad55554ac4880988e0c0d5cc536326a7ada577",
+				"KeyExpiry":  "2026-11-09T09:06:09Z",
+				"DiscoKey":   "discokey:c45d8cd20b6a6e62a65ca75266551eb644fd26f77a4e300bb2fc5583b3d03667",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55650",
+					"10.65.0.27:55650",
+					"172.17.0.1:55650",
+					"172.18.0.1:55650",
+					"172.19.0.1:55650",
+					"172.20.0.1:55650",
+					"172.21.0.1:55650",
+					"172.22.0.1:55650",
+					"172.23.0.1:55650",
+					"172.24.0.1:55650",
+					"172.25.0.1:55650",
+					"172.26.0.1:55650",
+					"172.27.0.1:55650",
+					"172.28.0.1:55650",
+					"172.29.0.1:55650"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:06:09.99204694Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8937434359782713,
+				"StableID":   "neFwZEFnnC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7259264d04fbd94bb35e6d00bc341968a782958f2b53e9ba3666a7972452097d",
+				"KeyExpiry":  "2026-11-09T09:06:10Z",
+				"DiscoKey":   "discokey:b849d1522e87bda0a2764a94af6a0ab2f2de4fabd17eeb751fc204be55b3bd25",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786",
+					"172.20.0.1:45786",
+					"172.21.0.1:45786",
+					"172.22.0.1:45786",
+					"172.23.0.1:45786",
+					"172.24.0.1:45786",
+					"172.25.0.1:45786",
+					"172.26.0.1:45786",
+					"172.27.0.1:45786",
+					"172.28.0.1:45786",
+					"172.29.0.1:45786"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:06:10.527555233Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         916153504890789,
+				"StableID":   "nxEQ1Mov9811CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       916153504890789,
+				"Key":        "nodekey:f686760c3c5be34a0bd612c59a9daab5e6df5148262ad27834ffc66014b2a36b",
+				"DiscoKey":   "discokey:ffd60d6538f69292c6f2717daf97a27f220f9d88d789e75d5c5285536034cb60",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57006",
+					"10.65.0.27:57006",
+					"172.17.0.1:57006",
+					"172.18.0.1:57006",
+					"172.19.0.1:57006",
+					"172.20.0.1:57006",
+					"172.21.0.1:57006",
+					"172.22.0.1:57006",
+					"172.23.0.1:57006",
+					"172.24.0.1:57006",
+					"172.25.0.1:57006",
+					"172.26.0.1:57006",
+					"172.27.0.1:57006",
+					"172.28.0.1:57006",
+					"172.29.0.1:57006"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:06:08.365168758Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f686760c3c5be34a0bd612c59a9daab5e6df5148262ad27834ffc66014b2a36b",
+			"MachineKey": "mkey:0a07cb462358371491451d718b2799d6bb17c080006bc0d74ad601b19b72023b",
+			"Peers": [{
+				"ID":         4069156827127413,
+				"StableID":   "nz39eHrvmY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fae451d819bd4251f674c2ca3ce306142afa17f8f5d2775bf0b17c07d6ce5913",
+				"DiscoKey":   "discokey:2d35776083370160cede6d7ecc324f9d09af6e67ff53263ba9cdf8e04916407c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46050",
+					"10.65.0.27:46050",
+					"172.17.0.1:46050",
+					"172.18.0.1:46050",
+					"172.19.0.1:46050",
+					"172.20.0.1:46050",
+					"172.21.0.1:46050",
+					"172.22.0.1:46050",
+					"172.23.0.1:46050",
+					"172.24.0.1:46050",
+					"172.25.0.1:46050",
+					"172.26.0.1:46050",
+					"172.27.0.1:46050",
+					"172.28.0.1:46050",
+					"172.29.0.1:46050"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:06:02.729300584Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2945498691911599,
+				"StableID":   "nQw22rF21Q11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ef63d42f0a54510a7fab0636e6535e983713dbe511ad07701eb46540d737a358",
+				"DiscoKey":   "discokey:e79aaf48ae2ba950adc828eb7f67fad6a6ff79809385cc7ea13972cb30c50f4a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54774",
+					"10.65.0.27:54774",
+					"172.17.0.1:54774",
+					"172.18.0.1:54774",
+					"172.19.0.1:54774",
+					"172.20.0.1:54774",
+					"172.21.0.1:54774",
+					"172.22.0.1:54774",
+					"172.23.0.1:54774",
+					"172.24.0.1:54774",
+					"172.25.0.1:54774",
+					"172.26.0.1:54774",
+					"172.27.0.1:54774",
+					"172.28.0.1:54774",
+					"172.29.0.1:54774"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:06:03.364321574Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1720498219598092,
+				"StableID":   "nfgb67aDSE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e7da71bf3127c4a45c28179e3d1d65f48881e49e3e8f2d1cd872106e2bc863c",
+				"DiscoKey":   "discokey:f57f5f1b7ecbaf7b059d1e09703f016956dd701871149159795580162f004a17",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57211",
+					"10.65.0.27:57211",
+					"172.17.0.1:57211",
+					"172.18.0.1:57211",
+					"172.19.0.1:57211",
+					"172.20.0.1:57211",
+					"172.21.0.1:57211",
+					"172.22.0.1:57211",
+					"172.23.0.1:57211",
+					"172.24.0.1:57211",
+					"172.25.0.1:57211",
+					"172.26.0.1:57211",
+					"172.27.0.1:57211",
+					"172.28.0.1:57211",
+					"172.29.0.1:57211"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:06:04.045727996Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1006977852880196,
+				"StableID":   "n5jGdqb4s811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6171e9f651e818a2ff9f302698460c78f2574b991eea9850eea878f8128e4e02",
+				"DiscoKey":   "discokey:4ec33d228df30eb9b1c78e8496852b6b71e3515d879dbb35a640785768979833",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40521",
+					"10.65.0.27:40521",
+					"172.17.0.1:40521",
+					"172.18.0.1:40521",
+					"172.19.0.1:40521",
+					"172.20.0.1:40521",
+					"172.21.0.1:40521",
+					"172.22.0.1:40521",
+					"172.23.0.1:40521",
+					"172.24.0.1:40521",
+					"172.25.0.1:40521",
+					"172.26.0.1:40521",
+					"172.27.0.1:40521",
+					"172.28.0.1:40521",
+					"172.29.0.1:40521"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:06:04.577289819Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7564700820128575,
+				"StableID":   "nNQgN4s45221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:700f8dfb91a17b9f8bb2ed24d42f53d27ed8467ea9b340a285ee964ad49c3a73",
+				"DiscoKey":   "discokey:368cc773cb3d5d79c3caaaf9f87c363b38b82d52a7c8b67994d7c899d36bdb40",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60288",
+					"10.65.0.27:60288",
+					"172.17.0.1:60288",
+					"172.18.0.1:60288",
+					"172.19.0.1:60288",
+					"172.20.0.1:60288",
+					"172.21.0.1:60288",
+					"172.22.0.1:60288",
+					"172.23.0.1:60288",
+					"172.24.0.1:60288",
+					"172.25.0.1:60288",
+					"172.26.0.1:60288",
+					"172.27.0.1:60288",
+					"172.28.0.1:60288",
+					"172.29.0.1:60288"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:06:05.138789727Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         170679822932958,
+				"StableID":   "ndEFVEUJL211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7e6214ef04a8be47b2df329f9b334ab43c393caec730928f832636d10d1f0300",
+				"DiscoKey":   "discokey:deb9c042de9aa911e7e1f46ed869f22600d449c5d9e9fe45b7e1d75d42d6357c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38549",
+					"10.65.0.27:38549",
+					"172.17.0.1:38549",
+					"172.18.0.1:38549",
+					"172.19.0.1:38549",
+					"172.20.0.1:38549",
+					"172.21.0.1:38549",
+					"172.22.0.1:38549",
+					"172.23.0.1:38549",
+					"172.24.0.1:38549",
+					"172.25.0.1:38549",
+					"172.26.0.1:38549",
+					"172.27.0.1:38549",
+					"172.28.0.1:38549",
+					"172.29.0.1:38549"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:06:05.671488052Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4963259093864094,
+				"StableID":   "nDg4FDQskf11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:99d7d595275a99cb6d8145ac37ccab734ecf3bc46fb5643705de247e224bc83c",
+				"DiscoKey":   "discokey:9d0ff4a5e17152398066d88cd6182d39b50bdeb3c0c7455a57c9c231790d3b0e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50618",
+					"10.65.0.27:50618",
+					"172.17.0.1:50618",
+					"172.18.0.1:50618",
+					"172.19.0.1:50618",
+					"172.20.0.1:50618",
+					"172.21.0.1:50618",
+					"172.22.0.1:50618",
+					"172.23.0.1:50618",
+					"172.24.0.1:50618",
+					"172.25.0.1:50618",
+					"172.26.0.1:50618",
+					"172.27.0.1:50618",
+					"172.28.0.1:50618",
+					"172.29.0.1:50618"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:06:06.206189964Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1943546407355350,
+				"StableID":   "nZk3fmfEBG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9218ebc91411788c3a9984660d22098687990c320bdd6f375356f64a7a2b0e68",
+				"DiscoKey":   "discokey:1ffa9b2e2fbd1a73e09a39d6f80cc021b6ed3b812a083bbb7f3ac5e76b5e0563",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:39674",
+					"10.65.0.27:39674",
+					"172.17.0.1:39674",
+					"172.18.0.1:39674",
+					"172.19.0.1:39674",
+					"172.20.0.1:39674",
+					"172.21.0.1:39674",
+					"172.22.0.1:39674",
+					"172.23.0.1:39674",
+					"172.24.0.1:39674",
+					"172.25.0.1:39674",
+					"172.26.0.1:39674",
+					"172.27.0.1:39674",
+					"172.28.0.1:39674",
+					"172.29.0.1:39674"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:06:06.73153339Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1708133528877187,
+				"StableID":   "nSifijmcLE11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a356a22e64460ab591255811a3b615a2e848df822af39edf39acd2d3e1d891d",
+				"DiscoKey":   "discokey:3e442f32c2a1e007aa30850ab06f45bb6d1ffa7698e6ba334c749f360d4b761d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39704",
+					"10.65.0.27:39704",
+					"172.17.0.1:39704",
+					"172.18.0.1:39704",
+					"172.19.0.1:39704",
+					"172.20.0.1:39704",
+					"172.21.0.1:39704",
+					"172.22.0.1:39704",
+					"172.23.0.1:39704",
+					"172.24.0.1:39704",
+					"172.25.0.1:39704",
+					"172.26.0.1:39704",
+					"172.27.0.1:39704",
+					"172.28.0.1:39704",
+					"172.29.0.1:39704"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:06:07.276232748Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5262985869601637,
+				"StableID":   "nrPo3Sic6i11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3401487c8de1fa728e83fce8ace71e43352a05c3e227b661490b8125f65a9a18",
+				"DiscoKey":   "discokey:24c274ca3232a24b2c7bd65ad4b74da767a7749739d327300bfc351d2cbd9b2d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47081",
+					"10.65.0.27:47081",
+					"172.17.0.1:47081",
+					"172.18.0.1:47081",
+					"172.19.0.1:47081",
+					"172.20.0.1:47081",
+					"172.21.0.1:47081",
+					"172.22.0.1:47081",
+					"172.23.0.1:47081",
+					"172.24.0.1:47081",
+					"172.25.0.1:47081",
+					"172.26.0.1:47081",
+					"172.27.0.1:47081",
+					"172.28.0.1:47081",
+					"172.29.0.1:47081"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:06:07.817408191Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7349144867247594,
+				"StableID":   "nZWMxGaSPz11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a9a0864c31e5b3b5151092f6341b1d0ea5e8f11dda567a93ec4e8bca734746e",
+				"DiscoKey":   "discokey:a951bc4101a4984404a8954e603413dd63c6cd6967a8567ac64aef7829a51f51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59744",
+					"10.65.0.27:59744",
+					"172.17.0.1:59744",
+					"172.18.0.1:59744",
+					"172.19.0.1:59744",
+					"172.20.0.1:59744",
+					"172.21.0.1:59744",
+					"172.22.0.1:59744",
+					"172.23.0.1:59744",
+					"172.24.0.1:59744",
+					"172.25.0.1:59744",
+					"172.26.0.1:59744",
+					"172.27.0.1:59744",
+					"172.28.0.1:59744",
+					"172.29.0.1:59744"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:06:08.900841555Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2656983726927875,
+				"StableID":   "nAi3YWTMkM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7e4b69cfe2c88c50e8b06b9b2cf0438466d1db58c88ce7c31909b7cdf722ec60",
+				"KeyExpiry":  "2026-11-09T09:06:09Z",
+				"DiscoKey":   "discokey:0532507bb618ccd11529f82e642e6a6d30ce3fe5c07730cd9e022f9575963d46",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:59277",
+					"10.65.0.27:59277",
+					"172.17.0.1:59277",
+					"172.18.0.1:59277",
+					"172.19.0.1:59277",
+					"172.20.0.1:59277",
+					"172.21.0.1:59277",
+					"172.22.0.1:59277",
+					"172.23.0.1:59277",
+					"172.24.0.1:59277",
+					"172.25.0.1:59277",
+					"172.26.0.1:59277",
+					"172.27.0.1:59277",
+					"172.28.0.1:59277",
+					"172.29.0.1:59277"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:06:09.446241278Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6744977102580193,
+				"StableID":   "nki2US7pfu11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:d8ff1ec2b48104f077c30a221dad55554ac4880988e0c0d5cc536326a7ada577",
+				"KeyExpiry":  "2026-11-09T09:06:09Z",
+				"DiscoKey":   "discokey:c45d8cd20b6a6e62a65ca75266551eb644fd26f77a4e300bb2fc5583b3d03667",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55650",
+					"10.65.0.27:55650",
+					"172.17.0.1:55650",
+					"172.18.0.1:55650",
+					"172.19.0.1:55650",
+					"172.20.0.1:55650",
+					"172.21.0.1:55650",
+					"172.22.0.1:55650",
+					"172.23.0.1:55650",
+					"172.24.0.1:55650",
+					"172.25.0.1:55650",
+					"172.26.0.1:55650",
+					"172.27.0.1:55650",
+					"172.28.0.1:55650",
+					"172.29.0.1:55650"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:06:09.99204694Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8937434359782713,
+				"StableID":   "neFwZEFnnC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7259264d04fbd94bb35e6d00bc341968a782958f2b53e9ba3666a7972452097d",
+				"KeyExpiry":  "2026-11-09T09:06:10Z",
+				"DiscoKey":   "discokey:b849d1522e87bda0a2764a94af6a0ab2f2de4fabd17eeb751fc204be55b3bd25",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786",
+					"172.20.0.1:45786",
+					"172.21.0.1:45786",
+					"172.22.0.1:45786",
+					"172.23.0.1:45786",
+					"172.24.0.1:45786",
+					"172.25.0.1:45786",
+					"172.26.0.1:45786",
+					"172.27.0.1:45786",
+					"172.28.0.1:45786",
+					"172.29.0.1:45786"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:06:10.527555233Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "916153504890789": {
+				"ID":          916153504890789,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2945498691911599,
+				"StableID":   "nQw22rF21Q11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       2945498691911599,
+				"Key":        "nodekey:ef63d42f0a54510a7fab0636e6535e983713dbe511ad07701eb46540d737a358",
+				"DiscoKey":   "discokey:e79aaf48ae2ba950adc828eb7f67fad6a6ff79809385cc7ea13972cb30c50f4a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54774",
+					"10.65.0.27:54774",
+					"172.17.0.1:54774",
+					"172.18.0.1:54774",
+					"172.19.0.1:54774",
+					"172.20.0.1:54774",
+					"172.21.0.1:54774",
+					"172.22.0.1:54774",
+					"172.23.0.1:54774",
+					"172.24.0.1:54774",
+					"172.25.0.1:54774",
+					"172.26.0.1:54774",
+					"172.27.0.1:54774",
+					"172.28.0.1:54774",
+					"172.29.0.1:54774"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:06:03.364321574Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ef63d42f0a54510a7fab0636e6535e983713dbe511ad07701eb46540d737a358",
+			"MachineKey": "mkey:ef2e6b83327d6e7752de7daa1507e608420bc9b1dfe49b24b0c87ef3e7942062",
+			"Peers": [{
+				"ID":         4069156827127413,
+				"StableID":   "nz39eHrvmY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fae451d819bd4251f674c2ca3ce306142afa17f8f5d2775bf0b17c07d6ce5913",
+				"DiscoKey":   "discokey:2d35776083370160cede6d7ecc324f9d09af6e67ff53263ba9cdf8e04916407c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46050",
+					"10.65.0.27:46050",
+					"172.17.0.1:46050",
+					"172.18.0.1:46050",
+					"172.19.0.1:46050",
+					"172.20.0.1:46050",
+					"172.21.0.1:46050",
+					"172.22.0.1:46050",
+					"172.23.0.1:46050",
+					"172.24.0.1:46050",
+					"172.25.0.1:46050",
+					"172.26.0.1:46050",
+					"172.27.0.1:46050",
+					"172.28.0.1:46050",
+					"172.29.0.1:46050"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:06:02.729300584Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1720498219598092,
+				"StableID":   "nfgb67aDSE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e7da71bf3127c4a45c28179e3d1d65f48881e49e3e8f2d1cd872106e2bc863c",
+				"DiscoKey":   "discokey:f57f5f1b7ecbaf7b059d1e09703f016956dd701871149159795580162f004a17",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57211",
+					"10.65.0.27:57211",
+					"172.17.0.1:57211",
+					"172.18.0.1:57211",
+					"172.19.0.1:57211",
+					"172.20.0.1:57211",
+					"172.21.0.1:57211",
+					"172.22.0.1:57211",
+					"172.23.0.1:57211",
+					"172.24.0.1:57211",
+					"172.25.0.1:57211",
+					"172.26.0.1:57211",
+					"172.27.0.1:57211",
+					"172.28.0.1:57211",
+					"172.29.0.1:57211"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:06:04.045727996Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1006977852880196,
+				"StableID":   "n5jGdqb4s811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6171e9f651e818a2ff9f302698460c78f2574b991eea9850eea878f8128e4e02",
+				"DiscoKey":   "discokey:4ec33d228df30eb9b1c78e8496852b6b71e3515d879dbb35a640785768979833",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40521",
+					"10.65.0.27:40521",
+					"172.17.0.1:40521",
+					"172.18.0.1:40521",
+					"172.19.0.1:40521",
+					"172.20.0.1:40521",
+					"172.21.0.1:40521",
+					"172.22.0.1:40521",
+					"172.23.0.1:40521",
+					"172.24.0.1:40521",
+					"172.25.0.1:40521",
+					"172.26.0.1:40521",
+					"172.27.0.1:40521",
+					"172.28.0.1:40521",
+					"172.29.0.1:40521"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:06:04.577289819Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7564700820128575,
+				"StableID":   "nNQgN4s45221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:700f8dfb91a17b9f8bb2ed24d42f53d27ed8467ea9b340a285ee964ad49c3a73",
+				"DiscoKey":   "discokey:368cc773cb3d5d79c3caaaf9f87c363b38b82d52a7c8b67994d7c899d36bdb40",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60288",
+					"10.65.0.27:60288",
+					"172.17.0.1:60288",
+					"172.18.0.1:60288",
+					"172.19.0.1:60288",
+					"172.20.0.1:60288",
+					"172.21.0.1:60288",
+					"172.22.0.1:60288",
+					"172.23.0.1:60288",
+					"172.24.0.1:60288",
+					"172.25.0.1:60288",
+					"172.26.0.1:60288",
+					"172.27.0.1:60288",
+					"172.28.0.1:60288",
+					"172.29.0.1:60288"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:06:05.138789727Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         170679822932958,
+				"StableID":   "ndEFVEUJL211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7e6214ef04a8be47b2df329f9b334ab43c393caec730928f832636d10d1f0300",
+				"DiscoKey":   "discokey:deb9c042de9aa911e7e1f46ed869f22600d449c5d9e9fe45b7e1d75d42d6357c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38549",
+					"10.65.0.27:38549",
+					"172.17.0.1:38549",
+					"172.18.0.1:38549",
+					"172.19.0.1:38549",
+					"172.20.0.1:38549",
+					"172.21.0.1:38549",
+					"172.22.0.1:38549",
+					"172.23.0.1:38549",
+					"172.24.0.1:38549",
+					"172.25.0.1:38549",
+					"172.26.0.1:38549",
+					"172.27.0.1:38549",
+					"172.28.0.1:38549",
+					"172.29.0.1:38549"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:06:05.671488052Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4963259093864094,
+				"StableID":   "nDg4FDQskf11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:99d7d595275a99cb6d8145ac37ccab734ecf3bc46fb5643705de247e224bc83c",
+				"DiscoKey":   "discokey:9d0ff4a5e17152398066d88cd6182d39b50bdeb3c0c7455a57c9c231790d3b0e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50618",
+					"10.65.0.27:50618",
+					"172.17.0.1:50618",
+					"172.18.0.1:50618",
+					"172.19.0.1:50618",
+					"172.20.0.1:50618",
+					"172.21.0.1:50618",
+					"172.22.0.1:50618",
+					"172.23.0.1:50618",
+					"172.24.0.1:50618",
+					"172.25.0.1:50618",
+					"172.26.0.1:50618",
+					"172.27.0.1:50618",
+					"172.28.0.1:50618",
+					"172.29.0.1:50618"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:06:06.206189964Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1943546407355350,
+				"StableID":   "nZk3fmfEBG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9218ebc91411788c3a9984660d22098687990c320bdd6f375356f64a7a2b0e68",
+				"DiscoKey":   "discokey:1ffa9b2e2fbd1a73e09a39d6f80cc021b6ed3b812a083bbb7f3ac5e76b5e0563",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:39674",
+					"10.65.0.27:39674",
+					"172.17.0.1:39674",
+					"172.18.0.1:39674",
+					"172.19.0.1:39674",
+					"172.20.0.1:39674",
+					"172.21.0.1:39674",
+					"172.22.0.1:39674",
+					"172.23.0.1:39674",
+					"172.24.0.1:39674",
+					"172.25.0.1:39674",
+					"172.26.0.1:39674",
+					"172.27.0.1:39674",
+					"172.28.0.1:39674",
+					"172.29.0.1:39674"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:06:06.73153339Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1708133528877187,
+				"StableID":   "nSifijmcLE11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a356a22e64460ab591255811a3b615a2e848df822af39edf39acd2d3e1d891d",
+				"DiscoKey":   "discokey:3e442f32c2a1e007aa30850ab06f45bb6d1ffa7698e6ba334c749f360d4b761d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39704",
+					"10.65.0.27:39704",
+					"172.17.0.1:39704",
+					"172.18.0.1:39704",
+					"172.19.0.1:39704",
+					"172.20.0.1:39704",
+					"172.21.0.1:39704",
+					"172.22.0.1:39704",
+					"172.23.0.1:39704",
+					"172.24.0.1:39704",
+					"172.25.0.1:39704",
+					"172.26.0.1:39704",
+					"172.27.0.1:39704",
+					"172.28.0.1:39704",
+					"172.29.0.1:39704"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:06:07.276232748Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5262985869601637,
+				"StableID":   "nrPo3Sic6i11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3401487c8de1fa728e83fce8ace71e43352a05c3e227b661490b8125f65a9a18",
+				"DiscoKey":   "discokey:24c274ca3232a24b2c7bd65ad4b74da767a7749739d327300bfc351d2cbd9b2d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47081",
+					"10.65.0.27:47081",
+					"172.17.0.1:47081",
+					"172.18.0.1:47081",
+					"172.19.0.1:47081",
+					"172.20.0.1:47081",
+					"172.21.0.1:47081",
+					"172.22.0.1:47081",
+					"172.23.0.1:47081",
+					"172.24.0.1:47081",
+					"172.25.0.1:47081",
+					"172.26.0.1:47081",
+					"172.27.0.1:47081",
+					"172.28.0.1:47081",
+					"172.29.0.1:47081"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:06:07.817408191Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         916153504890789,
+				"StableID":   "nxEQ1Mov9811CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f686760c3c5be34a0bd612c59a9daab5e6df5148262ad27834ffc66014b2a36b",
+				"DiscoKey":   "discokey:ffd60d6538f69292c6f2717daf97a27f220f9d88d789e75d5c5285536034cb60",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57006",
+					"10.65.0.27:57006",
+					"172.17.0.1:57006",
+					"172.18.0.1:57006",
+					"172.19.0.1:57006",
+					"172.20.0.1:57006",
+					"172.21.0.1:57006",
+					"172.22.0.1:57006",
+					"172.23.0.1:57006",
+					"172.24.0.1:57006",
+					"172.25.0.1:57006",
+					"172.26.0.1:57006",
+					"172.27.0.1:57006",
+					"172.28.0.1:57006",
+					"172.29.0.1:57006"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:06:08.365168758Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7349144867247594,
+				"StableID":   "nZWMxGaSPz11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a9a0864c31e5b3b5151092f6341b1d0ea5e8f11dda567a93ec4e8bca734746e",
+				"DiscoKey":   "discokey:a951bc4101a4984404a8954e603413dd63c6cd6967a8567ac64aef7829a51f51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59744",
+					"10.65.0.27:59744",
+					"172.17.0.1:59744",
+					"172.18.0.1:59744",
+					"172.19.0.1:59744",
+					"172.20.0.1:59744",
+					"172.21.0.1:59744",
+					"172.22.0.1:59744",
+					"172.23.0.1:59744",
+					"172.24.0.1:59744",
+					"172.25.0.1:59744",
+					"172.26.0.1:59744",
+					"172.27.0.1:59744",
+					"172.28.0.1:59744",
+					"172.29.0.1:59744"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:06:08.900841555Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2656983726927875,
+				"StableID":   "nAi3YWTMkM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7e4b69cfe2c88c50e8b06b9b2cf0438466d1db58c88ce7c31909b7cdf722ec60",
+				"KeyExpiry":  "2026-11-09T09:06:09Z",
+				"DiscoKey":   "discokey:0532507bb618ccd11529f82e642e6a6d30ce3fe5c07730cd9e022f9575963d46",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:59277",
+					"10.65.0.27:59277",
+					"172.17.0.1:59277",
+					"172.18.0.1:59277",
+					"172.19.0.1:59277",
+					"172.20.0.1:59277",
+					"172.21.0.1:59277",
+					"172.22.0.1:59277",
+					"172.23.0.1:59277",
+					"172.24.0.1:59277",
+					"172.25.0.1:59277",
+					"172.26.0.1:59277",
+					"172.27.0.1:59277",
+					"172.28.0.1:59277",
+					"172.29.0.1:59277"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:06:09.446241278Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6744977102580193,
+				"StableID":   "nki2US7pfu11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:d8ff1ec2b48104f077c30a221dad55554ac4880988e0c0d5cc536326a7ada577",
+				"KeyExpiry":  "2026-11-09T09:06:09Z",
+				"DiscoKey":   "discokey:c45d8cd20b6a6e62a65ca75266551eb644fd26f77a4e300bb2fc5583b3d03667",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55650",
+					"10.65.0.27:55650",
+					"172.17.0.1:55650",
+					"172.18.0.1:55650",
+					"172.19.0.1:55650",
+					"172.20.0.1:55650",
+					"172.21.0.1:55650",
+					"172.22.0.1:55650",
+					"172.23.0.1:55650",
+					"172.24.0.1:55650",
+					"172.25.0.1:55650",
+					"172.26.0.1:55650",
+					"172.27.0.1:55650",
+					"172.28.0.1:55650",
+					"172.29.0.1:55650"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:06:09.99204694Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8937434359782713,
+				"StableID":   "neFwZEFnnC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7259264d04fbd94bb35e6d00bc341968a782958f2b53e9ba3666a7972452097d",
+				"KeyExpiry":  "2026-11-09T09:06:10Z",
+				"DiscoKey":   "discokey:b849d1522e87bda0a2764a94af6a0ab2f2de4fabd17eeb751fc204be55b3bd25",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786",
+					"172.20.0.1:45786",
+					"172.21.0.1:45786",
+					"172.22.0.1:45786",
+					"172.23.0.1:45786",
+					"172.24.0.1:45786",
+					"172.25.0.1:45786",
+					"172.26.0.1:45786",
+					"172.27.0.1:45786",
+					"172.28.0.1:45786",
+					"172.29.0.1:45786"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:06:10.527555233Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2945498691911599": {
+				"ID":          2945498691911599,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4069156827127413,
+				"StableID":   "nz39eHrvmY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       4069156827127413,
+				"Key":        "nodekey:fae451d819bd4251f674c2ca3ce306142afa17f8f5d2775bf0b17c07d6ce5913",
+				"DiscoKey":   "discokey:2d35776083370160cede6d7ecc324f9d09af6e67ff53263ba9cdf8e04916407c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46050",
+					"10.65.0.27:46050",
+					"172.17.0.1:46050",
+					"172.18.0.1:46050",
+					"172.19.0.1:46050",
+					"172.20.0.1:46050",
+					"172.21.0.1:46050",
+					"172.22.0.1:46050",
+					"172.23.0.1:46050",
+					"172.24.0.1:46050",
+					"172.25.0.1:46050",
+					"172.26.0.1:46050",
+					"172.27.0.1:46050",
+					"172.28.0.1:46050",
+					"172.29.0.1:46050"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:06:02.729300584Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:fae451d819bd4251f674c2ca3ce306142afa17f8f5d2775bf0b17c07d6ce5913",
+			"MachineKey": "mkey:73900022dad1b0ab964d6e55e52c7c320c9fa753a0f3eb06d62d226aed2a2e22",
+			"Peers": [{
+				"ID":         2945498691911599,
+				"StableID":   "nQw22rF21Q11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ef63d42f0a54510a7fab0636e6535e983713dbe511ad07701eb46540d737a358",
+				"DiscoKey":   "discokey:e79aaf48ae2ba950adc828eb7f67fad6a6ff79809385cc7ea13972cb30c50f4a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54774",
+					"10.65.0.27:54774",
+					"172.17.0.1:54774",
+					"172.18.0.1:54774",
+					"172.19.0.1:54774",
+					"172.20.0.1:54774",
+					"172.21.0.1:54774",
+					"172.22.0.1:54774",
+					"172.23.0.1:54774",
+					"172.24.0.1:54774",
+					"172.25.0.1:54774",
+					"172.26.0.1:54774",
+					"172.27.0.1:54774",
+					"172.28.0.1:54774",
+					"172.29.0.1:54774"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:06:03.364321574Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1720498219598092,
+				"StableID":   "nfgb67aDSE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e7da71bf3127c4a45c28179e3d1d65f48881e49e3e8f2d1cd872106e2bc863c",
+				"DiscoKey":   "discokey:f57f5f1b7ecbaf7b059d1e09703f016956dd701871149159795580162f004a17",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57211",
+					"10.65.0.27:57211",
+					"172.17.0.1:57211",
+					"172.18.0.1:57211",
+					"172.19.0.1:57211",
+					"172.20.0.1:57211",
+					"172.21.0.1:57211",
+					"172.22.0.1:57211",
+					"172.23.0.1:57211",
+					"172.24.0.1:57211",
+					"172.25.0.1:57211",
+					"172.26.0.1:57211",
+					"172.27.0.1:57211",
+					"172.28.0.1:57211",
+					"172.29.0.1:57211"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:06:04.045727996Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1006977852880196,
+				"StableID":   "n5jGdqb4s811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6171e9f651e818a2ff9f302698460c78f2574b991eea9850eea878f8128e4e02",
+				"DiscoKey":   "discokey:4ec33d228df30eb9b1c78e8496852b6b71e3515d879dbb35a640785768979833",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40521",
+					"10.65.0.27:40521",
+					"172.17.0.1:40521",
+					"172.18.0.1:40521",
+					"172.19.0.1:40521",
+					"172.20.0.1:40521",
+					"172.21.0.1:40521",
+					"172.22.0.1:40521",
+					"172.23.0.1:40521",
+					"172.24.0.1:40521",
+					"172.25.0.1:40521",
+					"172.26.0.1:40521",
+					"172.27.0.1:40521",
+					"172.28.0.1:40521",
+					"172.29.0.1:40521"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:06:04.577289819Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7564700820128575,
+				"StableID":   "nNQgN4s45221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:700f8dfb91a17b9f8bb2ed24d42f53d27ed8467ea9b340a285ee964ad49c3a73",
+				"DiscoKey":   "discokey:368cc773cb3d5d79c3caaaf9f87c363b38b82d52a7c8b67994d7c899d36bdb40",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60288",
+					"10.65.0.27:60288",
+					"172.17.0.1:60288",
+					"172.18.0.1:60288",
+					"172.19.0.1:60288",
+					"172.20.0.1:60288",
+					"172.21.0.1:60288",
+					"172.22.0.1:60288",
+					"172.23.0.1:60288",
+					"172.24.0.1:60288",
+					"172.25.0.1:60288",
+					"172.26.0.1:60288",
+					"172.27.0.1:60288",
+					"172.28.0.1:60288",
+					"172.29.0.1:60288"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:06:05.138789727Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         170679822932958,
+				"StableID":   "ndEFVEUJL211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7e6214ef04a8be47b2df329f9b334ab43c393caec730928f832636d10d1f0300",
+				"DiscoKey":   "discokey:deb9c042de9aa911e7e1f46ed869f22600d449c5d9e9fe45b7e1d75d42d6357c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38549",
+					"10.65.0.27:38549",
+					"172.17.0.1:38549",
+					"172.18.0.1:38549",
+					"172.19.0.1:38549",
+					"172.20.0.1:38549",
+					"172.21.0.1:38549",
+					"172.22.0.1:38549",
+					"172.23.0.1:38549",
+					"172.24.0.1:38549",
+					"172.25.0.1:38549",
+					"172.26.0.1:38549",
+					"172.27.0.1:38549",
+					"172.28.0.1:38549",
+					"172.29.0.1:38549"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:06:05.671488052Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4963259093864094,
+				"StableID":   "nDg4FDQskf11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:99d7d595275a99cb6d8145ac37ccab734ecf3bc46fb5643705de247e224bc83c",
+				"DiscoKey":   "discokey:9d0ff4a5e17152398066d88cd6182d39b50bdeb3c0c7455a57c9c231790d3b0e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50618",
+					"10.65.0.27:50618",
+					"172.17.0.1:50618",
+					"172.18.0.1:50618",
+					"172.19.0.1:50618",
+					"172.20.0.1:50618",
+					"172.21.0.1:50618",
+					"172.22.0.1:50618",
+					"172.23.0.1:50618",
+					"172.24.0.1:50618",
+					"172.25.0.1:50618",
+					"172.26.0.1:50618",
+					"172.27.0.1:50618",
+					"172.28.0.1:50618",
+					"172.29.0.1:50618"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:06:06.206189964Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1943546407355350,
+				"StableID":   "nZk3fmfEBG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9218ebc91411788c3a9984660d22098687990c320bdd6f375356f64a7a2b0e68",
+				"DiscoKey":   "discokey:1ffa9b2e2fbd1a73e09a39d6f80cc021b6ed3b812a083bbb7f3ac5e76b5e0563",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:39674",
+					"10.65.0.27:39674",
+					"172.17.0.1:39674",
+					"172.18.0.1:39674",
+					"172.19.0.1:39674",
+					"172.20.0.1:39674",
+					"172.21.0.1:39674",
+					"172.22.0.1:39674",
+					"172.23.0.1:39674",
+					"172.24.0.1:39674",
+					"172.25.0.1:39674",
+					"172.26.0.1:39674",
+					"172.27.0.1:39674",
+					"172.28.0.1:39674",
+					"172.29.0.1:39674"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:06:06.73153339Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1708133528877187,
+				"StableID":   "nSifijmcLE11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a356a22e64460ab591255811a3b615a2e848df822af39edf39acd2d3e1d891d",
+				"DiscoKey":   "discokey:3e442f32c2a1e007aa30850ab06f45bb6d1ffa7698e6ba334c749f360d4b761d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39704",
+					"10.65.0.27:39704",
+					"172.17.0.1:39704",
+					"172.18.0.1:39704",
+					"172.19.0.1:39704",
+					"172.20.0.1:39704",
+					"172.21.0.1:39704",
+					"172.22.0.1:39704",
+					"172.23.0.1:39704",
+					"172.24.0.1:39704",
+					"172.25.0.1:39704",
+					"172.26.0.1:39704",
+					"172.27.0.1:39704",
+					"172.28.0.1:39704",
+					"172.29.0.1:39704"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:06:07.276232748Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5262985869601637,
+				"StableID":   "nrPo3Sic6i11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3401487c8de1fa728e83fce8ace71e43352a05c3e227b661490b8125f65a9a18",
+				"DiscoKey":   "discokey:24c274ca3232a24b2c7bd65ad4b74da767a7749739d327300bfc351d2cbd9b2d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47081",
+					"10.65.0.27:47081",
+					"172.17.0.1:47081",
+					"172.18.0.1:47081",
+					"172.19.0.1:47081",
+					"172.20.0.1:47081",
+					"172.21.0.1:47081",
+					"172.22.0.1:47081",
+					"172.23.0.1:47081",
+					"172.24.0.1:47081",
+					"172.25.0.1:47081",
+					"172.26.0.1:47081",
+					"172.27.0.1:47081",
+					"172.28.0.1:47081",
+					"172.29.0.1:47081"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:06:07.817408191Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         916153504890789,
+				"StableID":   "nxEQ1Mov9811CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f686760c3c5be34a0bd612c59a9daab5e6df5148262ad27834ffc66014b2a36b",
+				"DiscoKey":   "discokey:ffd60d6538f69292c6f2717daf97a27f220f9d88d789e75d5c5285536034cb60",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57006",
+					"10.65.0.27:57006",
+					"172.17.0.1:57006",
+					"172.18.0.1:57006",
+					"172.19.0.1:57006",
+					"172.20.0.1:57006",
+					"172.21.0.1:57006",
+					"172.22.0.1:57006",
+					"172.23.0.1:57006",
+					"172.24.0.1:57006",
+					"172.25.0.1:57006",
+					"172.26.0.1:57006",
+					"172.27.0.1:57006",
+					"172.28.0.1:57006",
+					"172.29.0.1:57006"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:06:08.365168758Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7349144867247594,
+				"StableID":   "nZWMxGaSPz11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a9a0864c31e5b3b5151092f6341b1d0ea5e8f11dda567a93ec4e8bca734746e",
+				"DiscoKey":   "discokey:a951bc4101a4984404a8954e603413dd63c6cd6967a8567ac64aef7829a51f51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59744",
+					"10.65.0.27:59744",
+					"172.17.0.1:59744",
+					"172.18.0.1:59744",
+					"172.19.0.1:59744",
+					"172.20.0.1:59744",
+					"172.21.0.1:59744",
+					"172.22.0.1:59744",
+					"172.23.0.1:59744",
+					"172.24.0.1:59744",
+					"172.25.0.1:59744",
+					"172.26.0.1:59744",
+					"172.27.0.1:59744",
+					"172.28.0.1:59744",
+					"172.29.0.1:59744"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:06:08.900841555Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2656983726927875,
+				"StableID":   "nAi3YWTMkM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7e4b69cfe2c88c50e8b06b9b2cf0438466d1db58c88ce7c31909b7cdf722ec60",
+				"KeyExpiry":  "2026-11-09T09:06:09Z",
+				"DiscoKey":   "discokey:0532507bb618ccd11529f82e642e6a6d30ce3fe5c07730cd9e022f9575963d46",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:59277",
+					"10.65.0.27:59277",
+					"172.17.0.1:59277",
+					"172.18.0.1:59277",
+					"172.19.0.1:59277",
+					"172.20.0.1:59277",
+					"172.21.0.1:59277",
+					"172.22.0.1:59277",
+					"172.23.0.1:59277",
+					"172.24.0.1:59277",
+					"172.25.0.1:59277",
+					"172.26.0.1:59277",
+					"172.27.0.1:59277",
+					"172.28.0.1:59277",
+					"172.29.0.1:59277"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:06:09.446241278Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6744977102580193,
+				"StableID":   "nki2US7pfu11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:d8ff1ec2b48104f077c30a221dad55554ac4880988e0c0d5cc536326a7ada577",
+				"KeyExpiry":  "2026-11-09T09:06:09Z",
+				"DiscoKey":   "discokey:c45d8cd20b6a6e62a65ca75266551eb644fd26f77a4e300bb2fc5583b3d03667",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55650",
+					"10.65.0.27:55650",
+					"172.17.0.1:55650",
+					"172.18.0.1:55650",
+					"172.19.0.1:55650",
+					"172.20.0.1:55650",
+					"172.21.0.1:55650",
+					"172.22.0.1:55650",
+					"172.23.0.1:55650",
+					"172.24.0.1:55650",
+					"172.25.0.1:55650",
+					"172.26.0.1:55650",
+					"172.27.0.1:55650",
+					"172.28.0.1:55650",
+					"172.29.0.1:55650"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:06:09.99204694Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8937434359782713,
+				"StableID":   "neFwZEFnnC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7259264d04fbd94bb35e6d00bc341968a782958f2b53e9ba3666a7972452097d",
+				"KeyExpiry":  "2026-11-09T09:06:10Z",
+				"DiscoKey":   "discokey:b849d1522e87bda0a2764a94af6a0ab2f2de4fabd17eeb751fc204be55b3bd25",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786",
+					"172.20.0.1:45786",
+					"172.21.0.1:45786",
+					"172.22.0.1:45786",
+					"172.23.0.1:45786",
+					"172.24.0.1:45786",
+					"172.25.0.1:45786",
+					"172.26.0.1:45786",
+					"172.27.0.1:45786",
+					"172.28.0.1:45786",
+					"172.29.0.1:45786"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:06:10.527555233Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4069156827127413": {
+				"ID":          4069156827127413,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7564700820128575,
+				"StableID":   "nNQgN4s45221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       7564700820128575,
+				"Key":        "nodekey:700f8dfb91a17b9f8bb2ed24d42f53d27ed8467ea9b340a285ee964ad49c3a73",
+				"DiscoKey":   "discokey:368cc773cb3d5d79c3caaaf9f87c363b38b82d52a7c8b67994d7c899d36bdb40",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60288",
+					"10.65.0.27:60288",
+					"172.17.0.1:60288",
+					"172.18.0.1:60288",
+					"172.19.0.1:60288",
+					"172.20.0.1:60288",
+					"172.21.0.1:60288",
+					"172.22.0.1:60288",
+					"172.23.0.1:60288",
+					"172.24.0.1:60288",
+					"172.25.0.1:60288",
+					"172.26.0.1:60288",
+					"172.27.0.1:60288",
+					"172.28.0.1:60288",
+					"172.29.0.1:60288"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:06:05.138789727Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:700f8dfb91a17b9f8bb2ed24d42f53d27ed8467ea9b340a285ee964ad49c3a73",
+			"MachineKey": "mkey:c7b621eb7bf04cd45bb4b528195c48780fe4c1ca8ddd3534fae66ccd95c3a863",
+			"Peers": [{
+				"ID":         4069156827127413,
+				"StableID":   "nz39eHrvmY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fae451d819bd4251f674c2ca3ce306142afa17f8f5d2775bf0b17c07d6ce5913",
+				"DiscoKey":   "discokey:2d35776083370160cede6d7ecc324f9d09af6e67ff53263ba9cdf8e04916407c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46050",
+					"10.65.0.27:46050",
+					"172.17.0.1:46050",
+					"172.18.0.1:46050",
+					"172.19.0.1:46050",
+					"172.20.0.1:46050",
+					"172.21.0.1:46050",
+					"172.22.0.1:46050",
+					"172.23.0.1:46050",
+					"172.24.0.1:46050",
+					"172.25.0.1:46050",
+					"172.26.0.1:46050",
+					"172.27.0.1:46050",
+					"172.28.0.1:46050",
+					"172.29.0.1:46050"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:06:02.729300584Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2945498691911599,
+				"StableID":   "nQw22rF21Q11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ef63d42f0a54510a7fab0636e6535e983713dbe511ad07701eb46540d737a358",
+				"DiscoKey":   "discokey:e79aaf48ae2ba950adc828eb7f67fad6a6ff79809385cc7ea13972cb30c50f4a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54774",
+					"10.65.0.27:54774",
+					"172.17.0.1:54774",
+					"172.18.0.1:54774",
+					"172.19.0.1:54774",
+					"172.20.0.1:54774",
+					"172.21.0.1:54774",
+					"172.22.0.1:54774",
+					"172.23.0.1:54774",
+					"172.24.0.1:54774",
+					"172.25.0.1:54774",
+					"172.26.0.1:54774",
+					"172.27.0.1:54774",
+					"172.28.0.1:54774",
+					"172.29.0.1:54774"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:06:03.364321574Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1720498219598092,
+				"StableID":   "nfgb67aDSE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e7da71bf3127c4a45c28179e3d1d65f48881e49e3e8f2d1cd872106e2bc863c",
+				"DiscoKey":   "discokey:f57f5f1b7ecbaf7b059d1e09703f016956dd701871149159795580162f004a17",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57211",
+					"10.65.0.27:57211",
+					"172.17.0.1:57211",
+					"172.18.0.1:57211",
+					"172.19.0.1:57211",
+					"172.20.0.1:57211",
+					"172.21.0.1:57211",
+					"172.22.0.1:57211",
+					"172.23.0.1:57211",
+					"172.24.0.1:57211",
+					"172.25.0.1:57211",
+					"172.26.0.1:57211",
+					"172.27.0.1:57211",
+					"172.28.0.1:57211",
+					"172.29.0.1:57211"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:06:04.045727996Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1006977852880196,
+				"StableID":   "n5jGdqb4s811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6171e9f651e818a2ff9f302698460c78f2574b991eea9850eea878f8128e4e02",
+				"DiscoKey":   "discokey:4ec33d228df30eb9b1c78e8496852b6b71e3515d879dbb35a640785768979833",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40521",
+					"10.65.0.27:40521",
+					"172.17.0.1:40521",
+					"172.18.0.1:40521",
+					"172.19.0.1:40521",
+					"172.20.0.1:40521",
+					"172.21.0.1:40521",
+					"172.22.0.1:40521",
+					"172.23.0.1:40521",
+					"172.24.0.1:40521",
+					"172.25.0.1:40521",
+					"172.26.0.1:40521",
+					"172.27.0.1:40521",
+					"172.28.0.1:40521",
+					"172.29.0.1:40521"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:06:04.577289819Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         170679822932958,
+				"StableID":   "ndEFVEUJL211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7e6214ef04a8be47b2df329f9b334ab43c393caec730928f832636d10d1f0300",
+				"DiscoKey":   "discokey:deb9c042de9aa911e7e1f46ed869f22600d449c5d9e9fe45b7e1d75d42d6357c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38549",
+					"10.65.0.27:38549",
+					"172.17.0.1:38549",
+					"172.18.0.1:38549",
+					"172.19.0.1:38549",
+					"172.20.0.1:38549",
+					"172.21.0.1:38549",
+					"172.22.0.1:38549",
+					"172.23.0.1:38549",
+					"172.24.0.1:38549",
+					"172.25.0.1:38549",
+					"172.26.0.1:38549",
+					"172.27.0.1:38549",
+					"172.28.0.1:38549",
+					"172.29.0.1:38549"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:06:05.671488052Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4963259093864094,
+				"StableID":   "nDg4FDQskf11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:99d7d595275a99cb6d8145ac37ccab734ecf3bc46fb5643705de247e224bc83c",
+				"DiscoKey":   "discokey:9d0ff4a5e17152398066d88cd6182d39b50bdeb3c0c7455a57c9c231790d3b0e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50618",
+					"10.65.0.27:50618",
+					"172.17.0.1:50618",
+					"172.18.0.1:50618",
+					"172.19.0.1:50618",
+					"172.20.0.1:50618",
+					"172.21.0.1:50618",
+					"172.22.0.1:50618",
+					"172.23.0.1:50618",
+					"172.24.0.1:50618",
+					"172.25.0.1:50618",
+					"172.26.0.1:50618",
+					"172.27.0.1:50618",
+					"172.28.0.1:50618",
+					"172.29.0.1:50618"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:06:06.206189964Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1943546407355350,
+				"StableID":   "nZk3fmfEBG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9218ebc91411788c3a9984660d22098687990c320bdd6f375356f64a7a2b0e68",
+				"DiscoKey":   "discokey:1ffa9b2e2fbd1a73e09a39d6f80cc021b6ed3b812a083bbb7f3ac5e76b5e0563",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:39674",
+					"10.65.0.27:39674",
+					"172.17.0.1:39674",
+					"172.18.0.1:39674",
+					"172.19.0.1:39674",
+					"172.20.0.1:39674",
+					"172.21.0.1:39674",
+					"172.22.0.1:39674",
+					"172.23.0.1:39674",
+					"172.24.0.1:39674",
+					"172.25.0.1:39674",
+					"172.26.0.1:39674",
+					"172.27.0.1:39674",
+					"172.28.0.1:39674",
+					"172.29.0.1:39674"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:06:06.73153339Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1708133528877187,
+				"StableID":   "nSifijmcLE11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a356a22e64460ab591255811a3b615a2e848df822af39edf39acd2d3e1d891d",
+				"DiscoKey":   "discokey:3e442f32c2a1e007aa30850ab06f45bb6d1ffa7698e6ba334c749f360d4b761d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39704",
+					"10.65.0.27:39704",
+					"172.17.0.1:39704",
+					"172.18.0.1:39704",
+					"172.19.0.1:39704",
+					"172.20.0.1:39704",
+					"172.21.0.1:39704",
+					"172.22.0.1:39704",
+					"172.23.0.1:39704",
+					"172.24.0.1:39704",
+					"172.25.0.1:39704",
+					"172.26.0.1:39704",
+					"172.27.0.1:39704",
+					"172.28.0.1:39704",
+					"172.29.0.1:39704"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:06:07.276232748Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5262985869601637,
+				"StableID":   "nrPo3Sic6i11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3401487c8de1fa728e83fce8ace71e43352a05c3e227b661490b8125f65a9a18",
+				"DiscoKey":   "discokey:24c274ca3232a24b2c7bd65ad4b74da767a7749739d327300bfc351d2cbd9b2d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47081",
+					"10.65.0.27:47081",
+					"172.17.0.1:47081",
+					"172.18.0.1:47081",
+					"172.19.0.1:47081",
+					"172.20.0.1:47081",
+					"172.21.0.1:47081",
+					"172.22.0.1:47081",
+					"172.23.0.1:47081",
+					"172.24.0.1:47081",
+					"172.25.0.1:47081",
+					"172.26.0.1:47081",
+					"172.27.0.1:47081",
+					"172.28.0.1:47081",
+					"172.29.0.1:47081"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:06:07.817408191Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         916153504890789,
+				"StableID":   "nxEQ1Mov9811CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f686760c3c5be34a0bd612c59a9daab5e6df5148262ad27834ffc66014b2a36b",
+				"DiscoKey":   "discokey:ffd60d6538f69292c6f2717daf97a27f220f9d88d789e75d5c5285536034cb60",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57006",
+					"10.65.0.27:57006",
+					"172.17.0.1:57006",
+					"172.18.0.1:57006",
+					"172.19.0.1:57006",
+					"172.20.0.1:57006",
+					"172.21.0.1:57006",
+					"172.22.0.1:57006",
+					"172.23.0.1:57006",
+					"172.24.0.1:57006",
+					"172.25.0.1:57006",
+					"172.26.0.1:57006",
+					"172.27.0.1:57006",
+					"172.28.0.1:57006",
+					"172.29.0.1:57006"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:06:08.365168758Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7349144867247594,
+				"StableID":   "nZWMxGaSPz11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a9a0864c31e5b3b5151092f6341b1d0ea5e8f11dda567a93ec4e8bca734746e",
+				"DiscoKey":   "discokey:a951bc4101a4984404a8954e603413dd63c6cd6967a8567ac64aef7829a51f51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59744",
+					"10.65.0.27:59744",
+					"172.17.0.1:59744",
+					"172.18.0.1:59744",
+					"172.19.0.1:59744",
+					"172.20.0.1:59744",
+					"172.21.0.1:59744",
+					"172.22.0.1:59744",
+					"172.23.0.1:59744",
+					"172.24.0.1:59744",
+					"172.25.0.1:59744",
+					"172.26.0.1:59744",
+					"172.27.0.1:59744",
+					"172.28.0.1:59744",
+					"172.29.0.1:59744"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:06:08.900841555Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2656983726927875,
+				"StableID":   "nAi3YWTMkM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7e4b69cfe2c88c50e8b06b9b2cf0438466d1db58c88ce7c31909b7cdf722ec60",
+				"KeyExpiry":  "2026-11-09T09:06:09Z",
+				"DiscoKey":   "discokey:0532507bb618ccd11529f82e642e6a6d30ce3fe5c07730cd9e022f9575963d46",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:59277",
+					"10.65.0.27:59277",
+					"172.17.0.1:59277",
+					"172.18.0.1:59277",
+					"172.19.0.1:59277",
+					"172.20.0.1:59277",
+					"172.21.0.1:59277",
+					"172.22.0.1:59277",
+					"172.23.0.1:59277",
+					"172.24.0.1:59277",
+					"172.25.0.1:59277",
+					"172.26.0.1:59277",
+					"172.27.0.1:59277",
+					"172.28.0.1:59277",
+					"172.29.0.1:59277"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:06:09.446241278Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6744977102580193,
+				"StableID":   "nki2US7pfu11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:d8ff1ec2b48104f077c30a221dad55554ac4880988e0c0d5cc536326a7ada577",
+				"KeyExpiry":  "2026-11-09T09:06:09Z",
+				"DiscoKey":   "discokey:c45d8cd20b6a6e62a65ca75266551eb644fd26f77a4e300bb2fc5583b3d03667",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55650",
+					"10.65.0.27:55650",
+					"172.17.0.1:55650",
+					"172.18.0.1:55650",
+					"172.19.0.1:55650",
+					"172.20.0.1:55650",
+					"172.21.0.1:55650",
+					"172.22.0.1:55650",
+					"172.23.0.1:55650",
+					"172.24.0.1:55650",
+					"172.25.0.1:55650",
+					"172.26.0.1:55650",
+					"172.27.0.1:55650",
+					"172.28.0.1:55650",
+					"172.29.0.1:55650"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:06:09.99204694Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8937434359782713,
+				"StableID":   "neFwZEFnnC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7259264d04fbd94bb35e6d00bc341968a782958f2b53e9ba3666a7972452097d",
+				"KeyExpiry":  "2026-11-09T09:06:10Z",
+				"DiscoKey":   "discokey:b849d1522e87bda0a2764a94af6a0ab2f2de4fabd17eeb751fc204be55b3bd25",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786",
+					"172.20.0.1:45786",
+					"172.21.0.1:45786",
+					"172.22.0.1:45786",
+					"172.23.0.1:45786",
+					"172.24.0.1:45786",
+					"172.25.0.1:45786",
+					"172.26.0.1:45786",
+					"172.27.0.1:45786",
+					"172.28.0.1:45786",
+					"172.29.0.1:45786"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:06:10.527555233Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7564700820128575": {
+				"ID":          7564700820128575,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1006977852880196,
+				"StableID":   "n5jGdqb4s811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1006977852880196,
+				"Key":        "nodekey:6171e9f651e818a2ff9f302698460c78f2574b991eea9850eea878f8128e4e02",
+				"DiscoKey":   "discokey:4ec33d228df30eb9b1c78e8496852b6b71e3515d879dbb35a640785768979833",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40521",
+					"10.65.0.27:40521",
+					"172.17.0.1:40521",
+					"172.18.0.1:40521",
+					"172.19.0.1:40521",
+					"172.20.0.1:40521",
+					"172.21.0.1:40521",
+					"172.22.0.1:40521",
+					"172.23.0.1:40521",
+					"172.24.0.1:40521",
+					"172.25.0.1:40521",
+					"172.26.0.1:40521",
+					"172.27.0.1:40521",
+					"172.28.0.1:40521",
+					"172.29.0.1:40521"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:06:04.577289819Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6171e9f651e818a2ff9f302698460c78f2574b991eea9850eea878f8128e4e02",
+			"MachineKey": "mkey:3d6bd19c3fde02fca0223a1f557dc246bf166a00a5577cd2d1e870128b38f758",
+			"Peers": [{
+				"ID":         4069156827127413,
+				"StableID":   "nz39eHrvmY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fae451d819bd4251f674c2ca3ce306142afa17f8f5d2775bf0b17c07d6ce5913",
+				"DiscoKey":   "discokey:2d35776083370160cede6d7ecc324f9d09af6e67ff53263ba9cdf8e04916407c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46050",
+					"10.65.0.27:46050",
+					"172.17.0.1:46050",
+					"172.18.0.1:46050",
+					"172.19.0.1:46050",
+					"172.20.0.1:46050",
+					"172.21.0.1:46050",
+					"172.22.0.1:46050",
+					"172.23.0.1:46050",
+					"172.24.0.1:46050",
+					"172.25.0.1:46050",
+					"172.26.0.1:46050",
+					"172.27.0.1:46050",
+					"172.28.0.1:46050",
+					"172.29.0.1:46050"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:06:02.729300584Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2945498691911599,
+				"StableID":   "nQw22rF21Q11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ef63d42f0a54510a7fab0636e6535e983713dbe511ad07701eb46540d737a358",
+				"DiscoKey":   "discokey:e79aaf48ae2ba950adc828eb7f67fad6a6ff79809385cc7ea13972cb30c50f4a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54774",
+					"10.65.0.27:54774",
+					"172.17.0.1:54774",
+					"172.18.0.1:54774",
+					"172.19.0.1:54774",
+					"172.20.0.1:54774",
+					"172.21.0.1:54774",
+					"172.22.0.1:54774",
+					"172.23.0.1:54774",
+					"172.24.0.1:54774",
+					"172.25.0.1:54774",
+					"172.26.0.1:54774",
+					"172.27.0.1:54774",
+					"172.28.0.1:54774",
+					"172.29.0.1:54774"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:06:03.364321574Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1720498219598092,
+				"StableID":   "nfgb67aDSE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e7da71bf3127c4a45c28179e3d1d65f48881e49e3e8f2d1cd872106e2bc863c",
+				"DiscoKey":   "discokey:f57f5f1b7ecbaf7b059d1e09703f016956dd701871149159795580162f004a17",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57211",
+					"10.65.0.27:57211",
+					"172.17.0.1:57211",
+					"172.18.0.1:57211",
+					"172.19.0.1:57211",
+					"172.20.0.1:57211",
+					"172.21.0.1:57211",
+					"172.22.0.1:57211",
+					"172.23.0.1:57211",
+					"172.24.0.1:57211",
+					"172.25.0.1:57211",
+					"172.26.0.1:57211",
+					"172.27.0.1:57211",
+					"172.28.0.1:57211",
+					"172.29.0.1:57211"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:06:04.045727996Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7564700820128575,
+				"StableID":   "nNQgN4s45221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:700f8dfb91a17b9f8bb2ed24d42f53d27ed8467ea9b340a285ee964ad49c3a73",
+				"DiscoKey":   "discokey:368cc773cb3d5d79c3caaaf9f87c363b38b82d52a7c8b67994d7c899d36bdb40",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60288",
+					"10.65.0.27:60288",
+					"172.17.0.1:60288",
+					"172.18.0.1:60288",
+					"172.19.0.1:60288",
+					"172.20.0.1:60288",
+					"172.21.0.1:60288",
+					"172.22.0.1:60288",
+					"172.23.0.1:60288",
+					"172.24.0.1:60288",
+					"172.25.0.1:60288",
+					"172.26.0.1:60288",
+					"172.27.0.1:60288",
+					"172.28.0.1:60288",
+					"172.29.0.1:60288"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:06:05.138789727Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         170679822932958,
+				"StableID":   "ndEFVEUJL211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7e6214ef04a8be47b2df329f9b334ab43c393caec730928f832636d10d1f0300",
+				"DiscoKey":   "discokey:deb9c042de9aa911e7e1f46ed869f22600d449c5d9e9fe45b7e1d75d42d6357c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38549",
+					"10.65.0.27:38549",
+					"172.17.0.1:38549",
+					"172.18.0.1:38549",
+					"172.19.0.1:38549",
+					"172.20.0.1:38549",
+					"172.21.0.1:38549",
+					"172.22.0.1:38549",
+					"172.23.0.1:38549",
+					"172.24.0.1:38549",
+					"172.25.0.1:38549",
+					"172.26.0.1:38549",
+					"172.27.0.1:38549",
+					"172.28.0.1:38549",
+					"172.29.0.1:38549"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:06:05.671488052Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4963259093864094,
+				"StableID":   "nDg4FDQskf11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:99d7d595275a99cb6d8145ac37ccab734ecf3bc46fb5643705de247e224bc83c",
+				"DiscoKey":   "discokey:9d0ff4a5e17152398066d88cd6182d39b50bdeb3c0c7455a57c9c231790d3b0e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50618",
+					"10.65.0.27:50618",
+					"172.17.0.1:50618",
+					"172.18.0.1:50618",
+					"172.19.0.1:50618",
+					"172.20.0.1:50618",
+					"172.21.0.1:50618",
+					"172.22.0.1:50618",
+					"172.23.0.1:50618",
+					"172.24.0.1:50618",
+					"172.25.0.1:50618",
+					"172.26.0.1:50618",
+					"172.27.0.1:50618",
+					"172.28.0.1:50618",
+					"172.29.0.1:50618"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:06:06.206189964Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1943546407355350,
+				"StableID":   "nZk3fmfEBG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9218ebc91411788c3a9984660d22098687990c320bdd6f375356f64a7a2b0e68",
+				"DiscoKey":   "discokey:1ffa9b2e2fbd1a73e09a39d6f80cc021b6ed3b812a083bbb7f3ac5e76b5e0563",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:39674",
+					"10.65.0.27:39674",
+					"172.17.0.1:39674",
+					"172.18.0.1:39674",
+					"172.19.0.1:39674",
+					"172.20.0.1:39674",
+					"172.21.0.1:39674",
+					"172.22.0.1:39674",
+					"172.23.0.1:39674",
+					"172.24.0.1:39674",
+					"172.25.0.1:39674",
+					"172.26.0.1:39674",
+					"172.27.0.1:39674",
+					"172.28.0.1:39674",
+					"172.29.0.1:39674"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:06:06.73153339Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1708133528877187,
+				"StableID":   "nSifijmcLE11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a356a22e64460ab591255811a3b615a2e848df822af39edf39acd2d3e1d891d",
+				"DiscoKey":   "discokey:3e442f32c2a1e007aa30850ab06f45bb6d1ffa7698e6ba334c749f360d4b761d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39704",
+					"10.65.0.27:39704",
+					"172.17.0.1:39704",
+					"172.18.0.1:39704",
+					"172.19.0.1:39704",
+					"172.20.0.1:39704",
+					"172.21.0.1:39704",
+					"172.22.0.1:39704",
+					"172.23.0.1:39704",
+					"172.24.0.1:39704",
+					"172.25.0.1:39704",
+					"172.26.0.1:39704",
+					"172.27.0.1:39704",
+					"172.28.0.1:39704",
+					"172.29.0.1:39704"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:06:07.276232748Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5262985869601637,
+				"StableID":   "nrPo3Sic6i11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3401487c8de1fa728e83fce8ace71e43352a05c3e227b661490b8125f65a9a18",
+				"DiscoKey":   "discokey:24c274ca3232a24b2c7bd65ad4b74da767a7749739d327300bfc351d2cbd9b2d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47081",
+					"10.65.0.27:47081",
+					"172.17.0.1:47081",
+					"172.18.0.1:47081",
+					"172.19.0.1:47081",
+					"172.20.0.1:47081",
+					"172.21.0.1:47081",
+					"172.22.0.1:47081",
+					"172.23.0.1:47081",
+					"172.24.0.1:47081",
+					"172.25.0.1:47081",
+					"172.26.0.1:47081",
+					"172.27.0.1:47081",
+					"172.28.0.1:47081",
+					"172.29.0.1:47081"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:06:07.817408191Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         916153504890789,
+				"StableID":   "nxEQ1Mov9811CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f686760c3c5be34a0bd612c59a9daab5e6df5148262ad27834ffc66014b2a36b",
+				"DiscoKey":   "discokey:ffd60d6538f69292c6f2717daf97a27f220f9d88d789e75d5c5285536034cb60",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57006",
+					"10.65.0.27:57006",
+					"172.17.0.1:57006",
+					"172.18.0.1:57006",
+					"172.19.0.1:57006",
+					"172.20.0.1:57006",
+					"172.21.0.1:57006",
+					"172.22.0.1:57006",
+					"172.23.0.1:57006",
+					"172.24.0.1:57006",
+					"172.25.0.1:57006",
+					"172.26.0.1:57006",
+					"172.27.0.1:57006",
+					"172.28.0.1:57006",
+					"172.29.0.1:57006"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:06:08.365168758Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7349144867247594,
+				"StableID":   "nZWMxGaSPz11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a9a0864c31e5b3b5151092f6341b1d0ea5e8f11dda567a93ec4e8bca734746e",
+				"DiscoKey":   "discokey:a951bc4101a4984404a8954e603413dd63c6cd6967a8567ac64aef7829a51f51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59744",
+					"10.65.0.27:59744",
+					"172.17.0.1:59744",
+					"172.18.0.1:59744",
+					"172.19.0.1:59744",
+					"172.20.0.1:59744",
+					"172.21.0.1:59744",
+					"172.22.0.1:59744",
+					"172.23.0.1:59744",
+					"172.24.0.1:59744",
+					"172.25.0.1:59744",
+					"172.26.0.1:59744",
+					"172.27.0.1:59744",
+					"172.28.0.1:59744",
+					"172.29.0.1:59744"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:06:08.900841555Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2656983726927875,
+				"StableID":   "nAi3YWTMkM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7e4b69cfe2c88c50e8b06b9b2cf0438466d1db58c88ce7c31909b7cdf722ec60",
+				"KeyExpiry":  "2026-11-09T09:06:09Z",
+				"DiscoKey":   "discokey:0532507bb618ccd11529f82e642e6a6d30ce3fe5c07730cd9e022f9575963d46",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:59277",
+					"10.65.0.27:59277",
+					"172.17.0.1:59277",
+					"172.18.0.1:59277",
+					"172.19.0.1:59277",
+					"172.20.0.1:59277",
+					"172.21.0.1:59277",
+					"172.22.0.1:59277",
+					"172.23.0.1:59277",
+					"172.24.0.1:59277",
+					"172.25.0.1:59277",
+					"172.26.0.1:59277",
+					"172.27.0.1:59277",
+					"172.28.0.1:59277",
+					"172.29.0.1:59277"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:06:09.446241278Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6744977102580193,
+				"StableID":   "nki2US7pfu11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:d8ff1ec2b48104f077c30a221dad55554ac4880988e0c0d5cc536326a7ada577",
+				"KeyExpiry":  "2026-11-09T09:06:09Z",
+				"DiscoKey":   "discokey:c45d8cd20b6a6e62a65ca75266551eb644fd26f77a4e300bb2fc5583b3d03667",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55650",
+					"10.65.0.27:55650",
+					"172.17.0.1:55650",
+					"172.18.0.1:55650",
+					"172.19.0.1:55650",
+					"172.20.0.1:55650",
+					"172.21.0.1:55650",
+					"172.22.0.1:55650",
+					"172.23.0.1:55650",
+					"172.24.0.1:55650",
+					"172.25.0.1:55650",
+					"172.26.0.1:55650",
+					"172.27.0.1:55650",
+					"172.28.0.1:55650",
+					"172.29.0.1:55650"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:06:09.99204694Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8937434359782713,
+				"StableID":   "neFwZEFnnC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7259264d04fbd94bb35e6d00bc341968a782958f2b53e9ba3666a7972452097d",
+				"KeyExpiry":  "2026-11-09T09:06:10Z",
+				"DiscoKey":   "discokey:b849d1522e87bda0a2764a94af6a0ab2f2de4fabd17eeb751fc204be55b3bd25",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786",
+					"172.20.0.1:45786",
+					"172.21.0.1:45786",
+					"172.22.0.1:45786",
+					"172.23.0.1:45786",
+					"172.24.0.1:45786",
+					"172.25.0.1:45786",
+					"172.26.0.1:45786",
+					"172.27.0.1:45786",
+					"172.28.0.1:45786",
+					"172.29.0.1:45786"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:06:10.527555233Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1006977852880196": {
+				"ID":          1006977852880196,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4963259093864094,
+				"StableID":   "nDg4FDQskf11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       4963259093864094,
+				"Key":        "nodekey:99d7d595275a99cb6d8145ac37ccab734ecf3bc46fb5643705de247e224bc83c",
+				"DiscoKey":   "discokey:9d0ff4a5e17152398066d88cd6182d39b50bdeb3c0c7455a57c9c231790d3b0e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50618",
+					"10.65.0.27:50618",
+					"172.17.0.1:50618",
+					"172.18.0.1:50618",
+					"172.19.0.1:50618",
+					"172.20.0.1:50618",
+					"172.21.0.1:50618",
+					"172.22.0.1:50618",
+					"172.23.0.1:50618",
+					"172.24.0.1:50618",
+					"172.25.0.1:50618",
+					"172.26.0.1:50618",
+					"172.27.0.1:50618",
+					"172.28.0.1:50618",
+					"172.29.0.1:50618"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:06:06.206189964Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:99d7d595275a99cb6d8145ac37ccab734ecf3bc46fb5643705de247e224bc83c",
+			"MachineKey": "mkey:da723b99061a5c742697936a017b90f37c95a8131816947065d69b036004c744",
+			"Peers": [{
+				"ID":         4069156827127413,
+				"StableID":   "nz39eHrvmY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fae451d819bd4251f674c2ca3ce306142afa17f8f5d2775bf0b17c07d6ce5913",
+				"DiscoKey":   "discokey:2d35776083370160cede6d7ecc324f9d09af6e67ff53263ba9cdf8e04916407c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46050",
+					"10.65.0.27:46050",
+					"172.17.0.1:46050",
+					"172.18.0.1:46050",
+					"172.19.0.1:46050",
+					"172.20.0.1:46050",
+					"172.21.0.1:46050",
+					"172.22.0.1:46050",
+					"172.23.0.1:46050",
+					"172.24.0.1:46050",
+					"172.25.0.1:46050",
+					"172.26.0.1:46050",
+					"172.27.0.1:46050",
+					"172.28.0.1:46050",
+					"172.29.0.1:46050"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:06:02.729300584Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2945498691911599,
+				"StableID":   "nQw22rF21Q11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ef63d42f0a54510a7fab0636e6535e983713dbe511ad07701eb46540d737a358",
+				"DiscoKey":   "discokey:e79aaf48ae2ba950adc828eb7f67fad6a6ff79809385cc7ea13972cb30c50f4a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54774",
+					"10.65.0.27:54774",
+					"172.17.0.1:54774",
+					"172.18.0.1:54774",
+					"172.19.0.1:54774",
+					"172.20.0.1:54774",
+					"172.21.0.1:54774",
+					"172.22.0.1:54774",
+					"172.23.0.1:54774",
+					"172.24.0.1:54774",
+					"172.25.0.1:54774",
+					"172.26.0.1:54774",
+					"172.27.0.1:54774",
+					"172.28.0.1:54774",
+					"172.29.0.1:54774"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:06:03.364321574Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1720498219598092,
+				"StableID":   "nfgb67aDSE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e7da71bf3127c4a45c28179e3d1d65f48881e49e3e8f2d1cd872106e2bc863c",
+				"DiscoKey":   "discokey:f57f5f1b7ecbaf7b059d1e09703f016956dd701871149159795580162f004a17",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57211",
+					"10.65.0.27:57211",
+					"172.17.0.1:57211",
+					"172.18.0.1:57211",
+					"172.19.0.1:57211",
+					"172.20.0.1:57211",
+					"172.21.0.1:57211",
+					"172.22.0.1:57211",
+					"172.23.0.1:57211",
+					"172.24.0.1:57211",
+					"172.25.0.1:57211",
+					"172.26.0.1:57211",
+					"172.27.0.1:57211",
+					"172.28.0.1:57211",
+					"172.29.0.1:57211"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:06:04.045727996Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1006977852880196,
+				"StableID":   "n5jGdqb4s811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6171e9f651e818a2ff9f302698460c78f2574b991eea9850eea878f8128e4e02",
+				"DiscoKey":   "discokey:4ec33d228df30eb9b1c78e8496852b6b71e3515d879dbb35a640785768979833",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40521",
+					"10.65.0.27:40521",
+					"172.17.0.1:40521",
+					"172.18.0.1:40521",
+					"172.19.0.1:40521",
+					"172.20.0.1:40521",
+					"172.21.0.1:40521",
+					"172.22.0.1:40521",
+					"172.23.0.1:40521",
+					"172.24.0.1:40521",
+					"172.25.0.1:40521",
+					"172.26.0.1:40521",
+					"172.27.0.1:40521",
+					"172.28.0.1:40521",
+					"172.29.0.1:40521"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:06:04.577289819Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7564700820128575,
+				"StableID":   "nNQgN4s45221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:700f8dfb91a17b9f8bb2ed24d42f53d27ed8467ea9b340a285ee964ad49c3a73",
+				"DiscoKey":   "discokey:368cc773cb3d5d79c3caaaf9f87c363b38b82d52a7c8b67994d7c899d36bdb40",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60288",
+					"10.65.0.27:60288",
+					"172.17.0.1:60288",
+					"172.18.0.1:60288",
+					"172.19.0.1:60288",
+					"172.20.0.1:60288",
+					"172.21.0.1:60288",
+					"172.22.0.1:60288",
+					"172.23.0.1:60288",
+					"172.24.0.1:60288",
+					"172.25.0.1:60288",
+					"172.26.0.1:60288",
+					"172.27.0.1:60288",
+					"172.28.0.1:60288",
+					"172.29.0.1:60288"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:06:05.138789727Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         170679822932958,
+				"StableID":   "ndEFVEUJL211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7e6214ef04a8be47b2df329f9b334ab43c393caec730928f832636d10d1f0300",
+				"DiscoKey":   "discokey:deb9c042de9aa911e7e1f46ed869f22600d449c5d9e9fe45b7e1d75d42d6357c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38549",
+					"10.65.0.27:38549",
+					"172.17.0.1:38549",
+					"172.18.0.1:38549",
+					"172.19.0.1:38549",
+					"172.20.0.1:38549",
+					"172.21.0.1:38549",
+					"172.22.0.1:38549",
+					"172.23.0.1:38549",
+					"172.24.0.1:38549",
+					"172.25.0.1:38549",
+					"172.26.0.1:38549",
+					"172.27.0.1:38549",
+					"172.28.0.1:38549",
+					"172.29.0.1:38549"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:06:05.671488052Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1943546407355350,
+				"StableID":   "nZk3fmfEBG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9218ebc91411788c3a9984660d22098687990c320bdd6f375356f64a7a2b0e68",
+				"DiscoKey":   "discokey:1ffa9b2e2fbd1a73e09a39d6f80cc021b6ed3b812a083bbb7f3ac5e76b5e0563",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:39674",
+					"10.65.0.27:39674",
+					"172.17.0.1:39674",
+					"172.18.0.1:39674",
+					"172.19.0.1:39674",
+					"172.20.0.1:39674",
+					"172.21.0.1:39674",
+					"172.22.0.1:39674",
+					"172.23.0.1:39674",
+					"172.24.0.1:39674",
+					"172.25.0.1:39674",
+					"172.26.0.1:39674",
+					"172.27.0.1:39674",
+					"172.28.0.1:39674",
+					"172.29.0.1:39674"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:06:06.73153339Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1708133528877187,
+				"StableID":   "nSifijmcLE11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a356a22e64460ab591255811a3b615a2e848df822af39edf39acd2d3e1d891d",
+				"DiscoKey":   "discokey:3e442f32c2a1e007aa30850ab06f45bb6d1ffa7698e6ba334c749f360d4b761d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39704",
+					"10.65.0.27:39704",
+					"172.17.0.1:39704",
+					"172.18.0.1:39704",
+					"172.19.0.1:39704",
+					"172.20.0.1:39704",
+					"172.21.0.1:39704",
+					"172.22.0.1:39704",
+					"172.23.0.1:39704",
+					"172.24.0.1:39704",
+					"172.25.0.1:39704",
+					"172.26.0.1:39704",
+					"172.27.0.1:39704",
+					"172.28.0.1:39704",
+					"172.29.0.1:39704"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:06:07.276232748Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5262985869601637,
+				"StableID":   "nrPo3Sic6i11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3401487c8de1fa728e83fce8ace71e43352a05c3e227b661490b8125f65a9a18",
+				"DiscoKey":   "discokey:24c274ca3232a24b2c7bd65ad4b74da767a7749739d327300bfc351d2cbd9b2d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47081",
+					"10.65.0.27:47081",
+					"172.17.0.1:47081",
+					"172.18.0.1:47081",
+					"172.19.0.1:47081",
+					"172.20.0.1:47081",
+					"172.21.0.1:47081",
+					"172.22.0.1:47081",
+					"172.23.0.1:47081",
+					"172.24.0.1:47081",
+					"172.25.0.1:47081",
+					"172.26.0.1:47081",
+					"172.27.0.1:47081",
+					"172.28.0.1:47081",
+					"172.29.0.1:47081"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:06:07.817408191Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         916153504890789,
+				"StableID":   "nxEQ1Mov9811CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f686760c3c5be34a0bd612c59a9daab5e6df5148262ad27834ffc66014b2a36b",
+				"DiscoKey":   "discokey:ffd60d6538f69292c6f2717daf97a27f220f9d88d789e75d5c5285536034cb60",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57006",
+					"10.65.0.27:57006",
+					"172.17.0.1:57006",
+					"172.18.0.1:57006",
+					"172.19.0.1:57006",
+					"172.20.0.1:57006",
+					"172.21.0.1:57006",
+					"172.22.0.1:57006",
+					"172.23.0.1:57006",
+					"172.24.0.1:57006",
+					"172.25.0.1:57006",
+					"172.26.0.1:57006",
+					"172.27.0.1:57006",
+					"172.28.0.1:57006",
+					"172.29.0.1:57006"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:06:08.365168758Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7349144867247594,
+				"StableID":   "nZWMxGaSPz11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a9a0864c31e5b3b5151092f6341b1d0ea5e8f11dda567a93ec4e8bca734746e",
+				"DiscoKey":   "discokey:a951bc4101a4984404a8954e603413dd63c6cd6967a8567ac64aef7829a51f51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59744",
+					"10.65.0.27:59744",
+					"172.17.0.1:59744",
+					"172.18.0.1:59744",
+					"172.19.0.1:59744",
+					"172.20.0.1:59744",
+					"172.21.0.1:59744",
+					"172.22.0.1:59744",
+					"172.23.0.1:59744",
+					"172.24.0.1:59744",
+					"172.25.0.1:59744",
+					"172.26.0.1:59744",
+					"172.27.0.1:59744",
+					"172.28.0.1:59744",
+					"172.29.0.1:59744"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:06:08.900841555Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2656983726927875,
+				"StableID":   "nAi3YWTMkM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7e4b69cfe2c88c50e8b06b9b2cf0438466d1db58c88ce7c31909b7cdf722ec60",
+				"KeyExpiry":  "2026-11-09T09:06:09Z",
+				"DiscoKey":   "discokey:0532507bb618ccd11529f82e642e6a6d30ce3fe5c07730cd9e022f9575963d46",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:59277",
+					"10.65.0.27:59277",
+					"172.17.0.1:59277",
+					"172.18.0.1:59277",
+					"172.19.0.1:59277",
+					"172.20.0.1:59277",
+					"172.21.0.1:59277",
+					"172.22.0.1:59277",
+					"172.23.0.1:59277",
+					"172.24.0.1:59277",
+					"172.25.0.1:59277",
+					"172.26.0.1:59277",
+					"172.27.0.1:59277",
+					"172.28.0.1:59277",
+					"172.29.0.1:59277"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:06:09.446241278Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6744977102580193,
+				"StableID":   "nki2US7pfu11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:d8ff1ec2b48104f077c30a221dad55554ac4880988e0c0d5cc536326a7ada577",
+				"KeyExpiry":  "2026-11-09T09:06:09Z",
+				"DiscoKey":   "discokey:c45d8cd20b6a6e62a65ca75266551eb644fd26f77a4e300bb2fc5583b3d03667",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55650",
+					"10.65.0.27:55650",
+					"172.17.0.1:55650",
+					"172.18.0.1:55650",
+					"172.19.0.1:55650",
+					"172.20.0.1:55650",
+					"172.21.0.1:55650",
+					"172.22.0.1:55650",
+					"172.23.0.1:55650",
+					"172.24.0.1:55650",
+					"172.25.0.1:55650",
+					"172.26.0.1:55650",
+					"172.27.0.1:55650",
+					"172.28.0.1:55650",
+					"172.29.0.1:55650"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:06:09.99204694Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8937434359782713,
+				"StableID":   "neFwZEFnnC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7259264d04fbd94bb35e6d00bc341968a782958f2b53e9ba3666a7972452097d",
+				"KeyExpiry":  "2026-11-09T09:06:10Z",
+				"DiscoKey":   "discokey:b849d1522e87bda0a2764a94af6a0ab2f2de4fabd17eeb751fc204be55b3bd25",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786",
+					"172.20.0.1:45786",
+					"172.21.0.1:45786",
+					"172.22.0.1:45786",
+					"172.23.0.1:45786",
+					"172.24.0.1:45786",
+					"172.25.0.1:45786",
+					"172.26.0.1:45786",
+					"172.27.0.1:45786",
+					"172.28.0.1:45786",
+					"172.29.0.1:45786"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:06:10.527555233Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4963259093864094": {
+				"ID":          4963259093864094,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1708133528877187,
+				"StableID":   "nSifijmcLE11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1708133528877187,
+				"Key":        "nodekey:8a356a22e64460ab591255811a3b615a2e848df822af39edf39acd2d3e1d891d",
+				"DiscoKey":   "discokey:3e442f32c2a1e007aa30850ab06f45bb6d1ffa7698e6ba334c749f360d4b761d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39704",
+					"10.65.0.27:39704",
+					"172.17.0.1:39704",
+					"172.18.0.1:39704",
+					"172.19.0.1:39704",
+					"172.20.0.1:39704",
+					"172.21.0.1:39704",
+					"172.22.0.1:39704",
+					"172.23.0.1:39704",
+					"172.24.0.1:39704",
+					"172.25.0.1:39704",
+					"172.26.0.1:39704",
+					"172.27.0.1:39704",
+					"172.28.0.1:39704",
+					"172.29.0.1:39704"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:06:07.276232748Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8a356a22e64460ab591255811a3b615a2e848df822af39edf39acd2d3e1d891d",
+			"MachineKey": "mkey:989637802ee9d2f7ef4d2f86dddb28bf9a22352fb90a62ec189f3dbb23a8653a",
+			"Peers": [{
+				"ID":         4069156827127413,
+				"StableID":   "nz39eHrvmY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fae451d819bd4251f674c2ca3ce306142afa17f8f5d2775bf0b17c07d6ce5913",
+				"DiscoKey":   "discokey:2d35776083370160cede6d7ecc324f9d09af6e67ff53263ba9cdf8e04916407c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46050",
+					"10.65.0.27:46050",
+					"172.17.0.1:46050",
+					"172.18.0.1:46050",
+					"172.19.0.1:46050",
+					"172.20.0.1:46050",
+					"172.21.0.1:46050",
+					"172.22.0.1:46050",
+					"172.23.0.1:46050",
+					"172.24.0.1:46050",
+					"172.25.0.1:46050",
+					"172.26.0.1:46050",
+					"172.27.0.1:46050",
+					"172.28.0.1:46050",
+					"172.29.0.1:46050"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:06:02.729300584Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2945498691911599,
+				"StableID":   "nQw22rF21Q11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ef63d42f0a54510a7fab0636e6535e983713dbe511ad07701eb46540d737a358",
+				"DiscoKey":   "discokey:e79aaf48ae2ba950adc828eb7f67fad6a6ff79809385cc7ea13972cb30c50f4a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54774",
+					"10.65.0.27:54774",
+					"172.17.0.1:54774",
+					"172.18.0.1:54774",
+					"172.19.0.1:54774",
+					"172.20.0.1:54774",
+					"172.21.0.1:54774",
+					"172.22.0.1:54774",
+					"172.23.0.1:54774",
+					"172.24.0.1:54774",
+					"172.25.0.1:54774",
+					"172.26.0.1:54774",
+					"172.27.0.1:54774",
+					"172.28.0.1:54774",
+					"172.29.0.1:54774"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:06:03.364321574Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1720498219598092,
+				"StableID":   "nfgb67aDSE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e7da71bf3127c4a45c28179e3d1d65f48881e49e3e8f2d1cd872106e2bc863c",
+				"DiscoKey":   "discokey:f57f5f1b7ecbaf7b059d1e09703f016956dd701871149159795580162f004a17",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57211",
+					"10.65.0.27:57211",
+					"172.17.0.1:57211",
+					"172.18.0.1:57211",
+					"172.19.0.1:57211",
+					"172.20.0.1:57211",
+					"172.21.0.1:57211",
+					"172.22.0.1:57211",
+					"172.23.0.1:57211",
+					"172.24.0.1:57211",
+					"172.25.0.1:57211",
+					"172.26.0.1:57211",
+					"172.27.0.1:57211",
+					"172.28.0.1:57211",
+					"172.29.0.1:57211"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:06:04.045727996Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1006977852880196,
+				"StableID":   "n5jGdqb4s811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6171e9f651e818a2ff9f302698460c78f2574b991eea9850eea878f8128e4e02",
+				"DiscoKey":   "discokey:4ec33d228df30eb9b1c78e8496852b6b71e3515d879dbb35a640785768979833",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40521",
+					"10.65.0.27:40521",
+					"172.17.0.1:40521",
+					"172.18.0.1:40521",
+					"172.19.0.1:40521",
+					"172.20.0.1:40521",
+					"172.21.0.1:40521",
+					"172.22.0.1:40521",
+					"172.23.0.1:40521",
+					"172.24.0.1:40521",
+					"172.25.0.1:40521",
+					"172.26.0.1:40521",
+					"172.27.0.1:40521",
+					"172.28.0.1:40521",
+					"172.29.0.1:40521"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:06:04.577289819Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7564700820128575,
+				"StableID":   "nNQgN4s45221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:700f8dfb91a17b9f8bb2ed24d42f53d27ed8467ea9b340a285ee964ad49c3a73",
+				"DiscoKey":   "discokey:368cc773cb3d5d79c3caaaf9f87c363b38b82d52a7c8b67994d7c899d36bdb40",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60288",
+					"10.65.0.27:60288",
+					"172.17.0.1:60288",
+					"172.18.0.1:60288",
+					"172.19.0.1:60288",
+					"172.20.0.1:60288",
+					"172.21.0.1:60288",
+					"172.22.0.1:60288",
+					"172.23.0.1:60288",
+					"172.24.0.1:60288",
+					"172.25.0.1:60288",
+					"172.26.0.1:60288",
+					"172.27.0.1:60288",
+					"172.28.0.1:60288",
+					"172.29.0.1:60288"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:06:05.138789727Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         170679822932958,
+				"StableID":   "ndEFVEUJL211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7e6214ef04a8be47b2df329f9b334ab43c393caec730928f832636d10d1f0300",
+				"DiscoKey":   "discokey:deb9c042de9aa911e7e1f46ed869f22600d449c5d9e9fe45b7e1d75d42d6357c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38549",
+					"10.65.0.27:38549",
+					"172.17.0.1:38549",
+					"172.18.0.1:38549",
+					"172.19.0.1:38549",
+					"172.20.0.1:38549",
+					"172.21.0.1:38549",
+					"172.22.0.1:38549",
+					"172.23.0.1:38549",
+					"172.24.0.1:38549",
+					"172.25.0.1:38549",
+					"172.26.0.1:38549",
+					"172.27.0.1:38549",
+					"172.28.0.1:38549",
+					"172.29.0.1:38549"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:06:05.671488052Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4963259093864094,
+				"StableID":   "nDg4FDQskf11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:99d7d595275a99cb6d8145ac37ccab734ecf3bc46fb5643705de247e224bc83c",
+				"DiscoKey":   "discokey:9d0ff4a5e17152398066d88cd6182d39b50bdeb3c0c7455a57c9c231790d3b0e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50618",
+					"10.65.0.27:50618",
+					"172.17.0.1:50618",
+					"172.18.0.1:50618",
+					"172.19.0.1:50618",
+					"172.20.0.1:50618",
+					"172.21.0.1:50618",
+					"172.22.0.1:50618",
+					"172.23.0.1:50618",
+					"172.24.0.1:50618",
+					"172.25.0.1:50618",
+					"172.26.0.1:50618",
+					"172.27.0.1:50618",
+					"172.28.0.1:50618",
+					"172.29.0.1:50618"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:06:06.206189964Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1943546407355350,
+				"StableID":   "nZk3fmfEBG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9218ebc91411788c3a9984660d22098687990c320bdd6f375356f64a7a2b0e68",
+				"DiscoKey":   "discokey:1ffa9b2e2fbd1a73e09a39d6f80cc021b6ed3b812a083bbb7f3ac5e76b5e0563",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:39674",
+					"10.65.0.27:39674",
+					"172.17.0.1:39674",
+					"172.18.0.1:39674",
+					"172.19.0.1:39674",
+					"172.20.0.1:39674",
+					"172.21.0.1:39674",
+					"172.22.0.1:39674",
+					"172.23.0.1:39674",
+					"172.24.0.1:39674",
+					"172.25.0.1:39674",
+					"172.26.0.1:39674",
+					"172.27.0.1:39674",
+					"172.28.0.1:39674",
+					"172.29.0.1:39674"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:06:06.73153339Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5262985869601637,
+				"StableID":   "nrPo3Sic6i11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3401487c8de1fa728e83fce8ace71e43352a05c3e227b661490b8125f65a9a18",
+				"DiscoKey":   "discokey:24c274ca3232a24b2c7bd65ad4b74da767a7749739d327300bfc351d2cbd9b2d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47081",
+					"10.65.0.27:47081",
+					"172.17.0.1:47081",
+					"172.18.0.1:47081",
+					"172.19.0.1:47081",
+					"172.20.0.1:47081",
+					"172.21.0.1:47081",
+					"172.22.0.1:47081",
+					"172.23.0.1:47081",
+					"172.24.0.1:47081",
+					"172.25.0.1:47081",
+					"172.26.0.1:47081",
+					"172.27.0.1:47081",
+					"172.28.0.1:47081",
+					"172.29.0.1:47081"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:06:07.817408191Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         916153504890789,
+				"StableID":   "nxEQ1Mov9811CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f686760c3c5be34a0bd612c59a9daab5e6df5148262ad27834ffc66014b2a36b",
+				"DiscoKey":   "discokey:ffd60d6538f69292c6f2717daf97a27f220f9d88d789e75d5c5285536034cb60",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57006",
+					"10.65.0.27:57006",
+					"172.17.0.1:57006",
+					"172.18.0.1:57006",
+					"172.19.0.1:57006",
+					"172.20.0.1:57006",
+					"172.21.0.1:57006",
+					"172.22.0.1:57006",
+					"172.23.0.1:57006",
+					"172.24.0.1:57006",
+					"172.25.0.1:57006",
+					"172.26.0.1:57006",
+					"172.27.0.1:57006",
+					"172.28.0.1:57006",
+					"172.29.0.1:57006"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:06:08.365168758Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7349144867247594,
+				"StableID":   "nZWMxGaSPz11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a9a0864c31e5b3b5151092f6341b1d0ea5e8f11dda567a93ec4e8bca734746e",
+				"DiscoKey":   "discokey:a951bc4101a4984404a8954e603413dd63c6cd6967a8567ac64aef7829a51f51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59744",
+					"10.65.0.27:59744",
+					"172.17.0.1:59744",
+					"172.18.0.1:59744",
+					"172.19.0.1:59744",
+					"172.20.0.1:59744",
+					"172.21.0.1:59744",
+					"172.22.0.1:59744",
+					"172.23.0.1:59744",
+					"172.24.0.1:59744",
+					"172.25.0.1:59744",
+					"172.26.0.1:59744",
+					"172.27.0.1:59744",
+					"172.28.0.1:59744",
+					"172.29.0.1:59744"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:06:08.900841555Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2656983726927875,
+				"StableID":   "nAi3YWTMkM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7e4b69cfe2c88c50e8b06b9b2cf0438466d1db58c88ce7c31909b7cdf722ec60",
+				"KeyExpiry":  "2026-11-09T09:06:09Z",
+				"DiscoKey":   "discokey:0532507bb618ccd11529f82e642e6a6d30ce3fe5c07730cd9e022f9575963d46",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:59277",
+					"10.65.0.27:59277",
+					"172.17.0.1:59277",
+					"172.18.0.1:59277",
+					"172.19.0.1:59277",
+					"172.20.0.1:59277",
+					"172.21.0.1:59277",
+					"172.22.0.1:59277",
+					"172.23.0.1:59277",
+					"172.24.0.1:59277",
+					"172.25.0.1:59277",
+					"172.26.0.1:59277",
+					"172.27.0.1:59277",
+					"172.28.0.1:59277",
+					"172.29.0.1:59277"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:06:09.446241278Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6744977102580193,
+				"StableID":   "nki2US7pfu11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:d8ff1ec2b48104f077c30a221dad55554ac4880988e0c0d5cc536326a7ada577",
+				"KeyExpiry":  "2026-11-09T09:06:09Z",
+				"DiscoKey":   "discokey:c45d8cd20b6a6e62a65ca75266551eb644fd26f77a4e300bb2fc5583b3d03667",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55650",
+					"10.65.0.27:55650",
+					"172.17.0.1:55650",
+					"172.18.0.1:55650",
+					"172.19.0.1:55650",
+					"172.20.0.1:55650",
+					"172.21.0.1:55650",
+					"172.22.0.1:55650",
+					"172.23.0.1:55650",
+					"172.24.0.1:55650",
+					"172.25.0.1:55650",
+					"172.26.0.1:55650",
+					"172.27.0.1:55650",
+					"172.28.0.1:55650",
+					"172.29.0.1:55650"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:06:09.99204694Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8937434359782713,
+				"StableID":   "neFwZEFnnC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7259264d04fbd94bb35e6d00bc341968a782958f2b53e9ba3666a7972452097d",
+				"KeyExpiry":  "2026-11-09T09:06:10Z",
+				"DiscoKey":   "discokey:b849d1522e87bda0a2764a94af6a0ab2f2de4fabd17eeb751fc204be55b3bd25",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786",
+					"172.20.0.1:45786",
+					"172.21.0.1:45786",
+					"172.22.0.1:45786",
+					"172.23.0.1:45786",
+					"172.24.0.1:45786",
+					"172.25.0.1:45786",
+					"172.26.0.1:45786",
+					"172.27.0.1:45786",
+					"172.28.0.1:45786",
+					"172.29.0.1:45786"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:06:10.527555233Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1708133528877187": {
+				"ID":          1708133528877187,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6744977102580193,
+				"StableID":   "nki2US7pfu11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:d8ff1ec2b48104f077c30a221dad55554ac4880988e0c0d5cc536326a7ada577",
+				"KeyExpiry":  "2026-11-09T09:06:09Z",
+				"DiscoKey":   "discokey:c45d8cd20b6a6e62a65ca75266551eb644fd26f77a4e300bb2fc5583b3d03667",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55650",
+					"10.65.0.27:55650",
+					"172.17.0.1:55650",
+					"172.18.0.1:55650",
+					"172.19.0.1:55650",
+					"172.20.0.1:55650",
+					"172.21.0.1:55650",
+					"172.22.0.1:55650",
+					"172.23.0.1:55650",
+					"172.24.0.1:55650",
+					"172.25.0.1:55650",
+					"172.26.0.1:55650",
+					"172.27.0.1:55650",
+					"172.28.0.1:55650",
+					"172.29.0.1:55650"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:06:09.99204694Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d8ff1ec2b48104f077c30a221dad55554ac4880988e0c0d5cc536326a7ada577",
+			"MachineKey": "mkey:756c060645f28ea4e26fd143f79b03a8c8dd14d2ad6cb91a2c588ce1d2292344",
+			"Peers": [{
+				"ID":         4069156827127413,
+				"StableID":   "nz39eHrvmY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fae451d819bd4251f674c2ca3ce306142afa17f8f5d2775bf0b17c07d6ce5913",
+				"DiscoKey":   "discokey:2d35776083370160cede6d7ecc324f9d09af6e67ff53263ba9cdf8e04916407c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46050",
+					"10.65.0.27:46050",
+					"172.17.0.1:46050",
+					"172.18.0.1:46050",
+					"172.19.0.1:46050",
+					"172.20.0.1:46050",
+					"172.21.0.1:46050",
+					"172.22.0.1:46050",
+					"172.23.0.1:46050",
+					"172.24.0.1:46050",
+					"172.25.0.1:46050",
+					"172.26.0.1:46050",
+					"172.27.0.1:46050",
+					"172.28.0.1:46050",
+					"172.29.0.1:46050"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:06:02.729300584Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2945498691911599,
+				"StableID":   "nQw22rF21Q11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ef63d42f0a54510a7fab0636e6535e983713dbe511ad07701eb46540d737a358",
+				"DiscoKey":   "discokey:e79aaf48ae2ba950adc828eb7f67fad6a6ff79809385cc7ea13972cb30c50f4a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54774",
+					"10.65.0.27:54774",
+					"172.17.0.1:54774",
+					"172.18.0.1:54774",
+					"172.19.0.1:54774",
+					"172.20.0.1:54774",
+					"172.21.0.1:54774",
+					"172.22.0.1:54774",
+					"172.23.0.1:54774",
+					"172.24.0.1:54774",
+					"172.25.0.1:54774",
+					"172.26.0.1:54774",
+					"172.27.0.1:54774",
+					"172.28.0.1:54774",
+					"172.29.0.1:54774"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:06:03.364321574Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1720498219598092,
+				"StableID":   "nfgb67aDSE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e7da71bf3127c4a45c28179e3d1d65f48881e49e3e8f2d1cd872106e2bc863c",
+				"DiscoKey":   "discokey:f57f5f1b7ecbaf7b059d1e09703f016956dd701871149159795580162f004a17",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57211",
+					"10.65.0.27:57211",
+					"172.17.0.1:57211",
+					"172.18.0.1:57211",
+					"172.19.0.1:57211",
+					"172.20.0.1:57211",
+					"172.21.0.1:57211",
+					"172.22.0.1:57211",
+					"172.23.0.1:57211",
+					"172.24.0.1:57211",
+					"172.25.0.1:57211",
+					"172.26.0.1:57211",
+					"172.27.0.1:57211",
+					"172.28.0.1:57211",
+					"172.29.0.1:57211"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:06:04.045727996Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1006977852880196,
+				"StableID":   "n5jGdqb4s811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6171e9f651e818a2ff9f302698460c78f2574b991eea9850eea878f8128e4e02",
+				"DiscoKey":   "discokey:4ec33d228df30eb9b1c78e8496852b6b71e3515d879dbb35a640785768979833",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40521",
+					"10.65.0.27:40521",
+					"172.17.0.1:40521",
+					"172.18.0.1:40521",
+					"172.19.0.1:40521",
+					"172.20.0.1:40521",
+					"172.21.0.1:40521",
+					"172.22.0.1:40521",
+					"172.23.0.1:40521",
+					"172.24.0.1:40521",
+					"172.25.0.1:40521",
+					"172.26.0.1:40521",
+					"172.27.0.1:40521",
+					"172.28.0.1:40521",
+					"172.29.0.1:40521"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:06:04.577289819Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7564700820128575,
+				"StableID":   "nNQgN4s45221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:700f8dfb91a17b9f8bb2ed24d42f53d27ed8467ea9b340a285ee964ad49c3a73",
+				"DiscoKey":   "discokey:368cc773cb3d5d79c3caaaf9f87c363b38b82d52a7c8b67994d7c899d36bdb40",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60288",
+					"10.65.0.27:60288",
+					"172.17.0.1:60288",
+					"172.18.0.1:60288",
+					"172.19.0.1:60288",
+					"172.20.0.1:60288",
+					"172.21.0.1:60288",
+					"172.22.0.1:60288",
+					"172.23.0.1:60288",
+					"172.24.0.1:60288",
+					"172.25.0.1:60288",
+					"172.26.0.1:60288",
+					"172.27.0.1:60288",
+					"172.28.0.1:60288",
+					"172.29.0.1:60288"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:06:05.138789727Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         170679822932958,
+				"StableID":   "ndEFVEUJL211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7e6214ef04a8be47b2df329f9b334ab43c393caec730928f832636d10d1f0300",
+				"DiscoKey":   "discokey:deb9c042de9aa911e7e1f46ed869f22600d449c5d9e9fe45b7e1d75d42d6357c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38549",
+					"10.65.0.27:38549",
+					"172.17.0.1:38549",
+					"172.18.0.1:38549",
+					"172.19.0.1:38549",
+					"172.20.0.1:38549",
+					"172.21.0.1:38549",
+					"172.22.0.1:38549",
+					"172.23.0.1:38549",
+					"172.24.0.1:38549",
+					"172.25.0.1:38549",
+					"172.26.0.1:38549",
+					"172.27.0.1:38549",
+					"172.28.0.1:38549",
+					"172.29.0.1:38549"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:06:05.671488052Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4963259093864094,
+				"StableID":   "nDg4FDQskf11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:99d7d595275a99cb6d8145ac37ccab734ecf3bc46fb5643705de247e224bc83c",
+				"DiscoKey":   "discokey:9d0ff4a5e17152398066d88cd6182d39b50bdeb3c0c7455a57c9c231790d3b0e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50618",
+					"10.65.0.27:50618",
+					"172.17.0.1:50618",
+					"172.18.0.1:50618",
+					"172.19.0.1:50618",
+					"172.20.0.1:50618",
+					"172.21.0.1:50618",
+					"172.22.0.1:50618",
+					"172.23.0.1:50618",
+					"172.24.0.1:50618",
+					"172.25.0.1:50618",
+					"172.26.0.1:50618",
+					"172.27.0.1:50618",
+					"172.28.0.1:50618",
+					"172.29.0.1:50618"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:06:06.206189964Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1943546407355350,
+				"StableID":   "nZk3fmfEBG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9218ebc91411788c3a9984660d22098687990c320bdd6f375356f64a7a2b0e68",
+				"DiscoKey":   "discokey:1ffa9b2e2fbd1a73e09a39d6f80cc021b6ed3b812a083bbb7f3ac5e76b5e0563",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:39674",
+					"10.65.0.27:39674",
+					"172.17.0.1:39674",
+					"172.18.0.1:39674",
+					"172.19.0.1:39674",
+					"172.20.0.1:39674",
+					"172.21.0.1:39674",
+					"172.22.0.1:39674",
+					"172.23.0.1:39674",
+					"172.24.0.1:39674",
+					"172.25.0.1:39674",
+					"172.26.0.1:39674",
+					"172.27.0.1:39674",
+					"172.28.0.1:39674",
+					"172.29.0.1:39674"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:06:06.73153339Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1708133528877187,
+				"StableID":   "nSifijmcLE11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a356a22e64460ab591255811a3b615a2e848df822af39edf39acd2d3e1d891d",
+				"DiscoKey":   "discokey:3e442f32c2a1e007aa30850ab06f45bb6d1ffa7698e6ba334c749f360d4b761d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39704",
+					"10.65.0.27:39704",
+					"172.17.0.1:39704",
+					"172.18.0.1:39704",
+					"172.19.0.1:39704",
+					"172.20.0.1:39704",
+					"172.21.0.1:39704",
+					"172.22.0.1:39704",
+					"172.23.0.1:39704",
+					"172.24.0.1:39704",
+					"172.25.0.1:39704",
+					"172.26.0.1:39704",
+					"172.27.0.1:39704",
+					"172.28.0.1:39704",
+					"172.29.0.1:39704"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:06:07.276232748Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5262985869601637,
+				"StableID":   "nrPo3Sic6i11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3401487c8de1fa728e83fce8ace71e43352a05c3e227b661490b8125f65a9a18",
+				"DiscoKey":   "discokey:24c274ca3232a24b2c7bd65ad4b74da767a7749739d327300bfc351d2cbd9b2d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47081",
+					"10.65.0.27:47081",
+					"172.17.0.1:47081",
+					"172.18.0.1:47081",
+					"172.19.0.1:47081",
+					"172.20.0.1:47081",
+					"172.21.0.1:47081",
+					"172.22.0.1:47081",
+					"172.23.0.1:47081",
+					"172.24.0.1:47081",
+					"172.25.0.1:47081",
+					"172.26.0.1:47081",
+					"172.27.0.1:47081",
+					"172.28.0.1:47081",
+					"172.29.0.1:47081"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:06:07.817408191Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         916153504890789,
+				"StableID":   "nxEQ1Mov9811CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f686760c3c5be34a0bd612c59a9daab5e6df5148262ad27834ffc66014b2a36b",
+				"DiscoKey":   "discokey:ffd60d6538f69292c6f2717daf97a27f220f9d88d789e75d5c5285536034cb60",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57006",
+					"10.65.0.27:57006",
+					"172.17.0.1:57006",
+					"172.18.0.1:57006",
+					"172.19.0.1:57006",
+					"172.20.0.1:57006",
+					"172.21.0.1:57006",
+					"172.22.0.1:57006",
+					"172.23.0.1:57006",
+					"172.24.0.1:57006",
+					"172.25.0.1:57006",
+					"172.26.0.1:57006",
+					"172.27.0.1:57006",
+					"172.28.0.1:57006",
+					"172.29.0.1:57006"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:06:08.365168758Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7349144867247594,
+				"StableID":   "nZWMxGaSPz11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a9a0864c31e5b3b5151092f6341b1d0ea5e8f11dda567a93ec4e8bca734746e",
+				"DiscoKey":   "discokey:a951bc4101a4984404a8954e603413dd63c6cd6967a8567ac64aef7829a51f51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59744",
+					"10.65.0.27:59744",
+					"172.17.0.1:59744",
+					"172.18.0.1:59744",
+					"172.19.0.1:59744",
+					"172.20.0.1:59744",
+					"172.21.0.1:59744",
+					"172.22.0.1:59744",
+					"172.23.0.1:59744",
+					"172.24.0.1:59744",
+					"172.25.0.1:59744",
+					"172.26.0.1:59744",
+					"172.27.0.1:59744",
+					"172.28.0.1:59744",
+					"172.29.0.1:59744"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:06:08.900841555Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2656983726927875,
+				"StableID":   "nAi3YWTMkM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7e4b69cfe2c88c50e8b06b9b2cf0438466d1db58c88ce7c31909b7cdf722ec60",
+				"KeyExpiry":  "2026-11-09T09:06:09Z",
+				"DiscoKey":   "discokey:0532507bb618ccd11529f82e642e6a6d30ce3fe5c07730cd9e022f9575963d46",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:59277",
+					"10.65.0.27:59277",
+					"172.17.0.1:59277",
+					"172.18.0.1:59277",
+					"172.19.0.1:59277",
+					"172.20.0.1:59277",
+					"172.21.0.1:59277",
+					"172.22.0.1:59277",
+					"172.23.0.1:59277",
+					"172.24.0.1:59277",
+					"172.25.0.1:59277",
+					"172.26.0.1:59277",
+					"172.27.0.1:59277",
+					"172.28.0.1:59277",
+					"172.29.0.1:59277"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:06:09.446241278Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8937434359782713,
+				"StableID":   "neFwZEFnnC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7259264d04fbd94bb35e6d00bc341968a782958f2b53e9ba3666a7972452097d",
+				"KeyExpiry":  "2026-11-09T09:06:10Z",
+				"DiscoKey":   "discokey:b849d1522e87bda0a2764a94af6a0ab2f2de4fabd17eeb751fc204be55b3bd25",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786",
+					"172.20.0.1:45786",
+					"172.21.0.1:45786",
+					"172.22.0.1:45786",
+					"172.23.0.1:45786",
+					"172.24.0.1:45786",
+					"172.25.0.1:45786",
+					"172.26.0.1:45786",
+					"172.27.0.1:45786",
+					"172.28.0.1:45786",
+					"172.29.0.1:45786"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:06:10.527555233Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5262985869601637,
+				"StableID":   "nrPo3Sic6i11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       5262985869601637,
+				"Key":        "nodekey:3401487c8de1fa728e83fce8ace71e43352a05c3e227b661490b8125f65a9a18",
+				"DiscoKey":   "discokey:24c274ca3232a24b2c7bd65ad4b74da767a7749739d327300bfc351d2cbd9b2d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47081",
+					"10.65.0.27:47081",
+					"172.17.0.1:47081",
+					"172.18.0.1:47081",
+					"172.19.0.1:47081",
+					"172.20.0.1:47081",
+					"172.21.0.1:47081",
+					"172.22.0.1:47081",
+					"172.23.0.1:47081",
+					"172.24.0.1:47081",
+					"172.25.0.1:47081",
+					"172.26.0.1:47081",
+					"172.27.0.1:47081",
+					"172.28.0.1:47081",
+					"172.29.0.1:47081"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:06:07.817408191Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3401487c8de1fa728e83fce8ace71e43352a05c3e227b661490b8125f65a9a18",
+			"MachineKey": "mkey:2b4c9440948aea5aee6475786ba58f8175accc900047e0d96e572219d7d2c851",
+			"Peers": [{
+				"ID":         4069156827127413,
+				"StableID":   "nz39eHrvmY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fae451d819bd4251f674c2ca3ce306142afa17f8f5d2775bf0b17c07d6ce5913",
+				"DiscoKey":   "discokey:2d35776083370160cede6d7ecc324f9d09af6e67ff53263ba9cdf8e04916407c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46050",
+					"10.65.0.27:46050",
+					"172.17.0.1:46050",
+					"172.18.0.1:46050",
+					"172.19.0.1:46050",
+					"172.20.0.1:46050",
+					"172.21.0.1:46050",
+					"172.22.0.1:46050",
+					"172.23.0.1:46050",
+					"172.24.0.1:46050",
+					"172.25.0.1:46050",
+					"172.26.0.1:46050",
+					"172.27.0.1:46050",
+					"172.28.0.1:46050",
+					"172.29.0.1:46050"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:06:02.729300584Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2945498691911599,
+				"StableID":   "nQw22rF21Q11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ef63d42f0a54510a7fab0636e6535e983713dbe511ad07701eb46540d737a358",
+				"DiscoKey":   "discokey:e79aaf48ae2ba950adc828eb7f67fad6a6ff79809385cc7ea13972cb30c50f4a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54774",
+					"10.65.0.27:54774",
+					"172.17.0.1:54774",
+					"172.18.0.1:54774",
+					"172.19.0.1:54774",
+					"172.20.0.1:54774",
+					"172.21.0.1:54774",
+					"172.22.0.1:54774",
+					"172.23.0.1:54774",
+					"172.24.0.1:54774",
+					"172.25.0.1:54774",
+					"172.26.0.1:54774",
+					"172.27.0.1:54774",
+					"172.28.0.1:54774",
+					"172.29.0.1:54774"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:06:03.364321574Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1720498219598092,
+				"StableID":   "nfgb67aDSE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e7da71bf3127c4a45c28179e3d1d65f48881e49e3e8f2d1cd872106e2bc863c",
+				"DiscoKey":   "discokey:f57f5f1b7ecbaf7b059d1e09703f016956dd701871149159795580162f004a17",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57211",
+					"10.65.0.27:57211",
+					"172.17.0.1:57211",
+					"172.18.0.1:57211",
+					"172.19.0.1:57211",
+					"172.20.0.1:57211",
+					"172.21.0.1:57211",
+					"172.22.0.1:57211",
+					"172.23.0.1:57211",
+					"172.24.0.1:57211",
+					"172.25.0.1:57211",
+					"172.26.0.1:57211",
+					"172.27.0.1:57211",
+					"172.28.0.1:57211",
+					"172.29.0.1:57211"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:06:04.045727996Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1006977852880196,
+				"StableID":   "n5jGdqb4s811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6171e9f651e818a2ff9f302698460c78f2574b991eea9850eea878f8128e4e02",
+				"DiscoKey":   "discokey:4ec33d228df30eb9b1c78e8496852b6b71e3515d879dbb35a640785768979833",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40521",
+					"10.65.0.27:40521",
+					"172.17.0.1:40521",
+					"172.18.0.1:40521",
+					"172.19.0.1:40521",
+					"172.20.0.1:40521",
+					"172.21.0.1:40521",
+					"172.22.0.1:40521",
+					"172.23.0.1:40521",
+					"172.24.0.1:40521",
+					"172.25.0.1:40521",
+					"172.26.0.1:40521",
+					"172.27.0.1:40521",
+					"172.28.0.1:40521",
+					"172.29.0.1:40521"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:06:04.577289819Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7564700820128575,
+				"StableID":   "nNQgN4s45221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:700f8dfb91a17b9f8bb2ed24d42f53d27ed8467ea9b340a285ee964ad49c3a73",
+				"DiscoKey":   "discokey:368cc773cb3d5d79c3caaaf9f87c363b38b82d52a7c8b67994d7c899d36bdb40",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60288",
+					"10.65.0.27:60288",
+					"172.17.0.1:60288",
+					"172.18.0.1:60288",
+					"172.19.0.1:60288",
+					"172.20.0.1:60288",
+					"172.21.0.1:60288",
+					"172.22.0.1:60288",
+					"172.23.0.1:60288",
+					"172.24.0.1:60288",
+					"172.25.0.1:60288",
+					"172.26.0.1:60288",
+					"172.27.0.1:60288",
+					"172.28.0.1:60288",
+					"172.29.0.1:60288"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:06:05.138789727Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         170679822932958,
+				"StableID":   "ndEFVEUJL211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7e6214ef04a8be47b2df329f9b334ab43c393caec730928f832636d10d1f0300",
+				"DiscoKey":   "discokey:deb9c042de9aa911e7e1f46ed869f22600d449c5d9e9fe45b7e1d75d42d6357c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38549",
+					"10.65.0.27:38549",
+					"172.17.0.1:38549",
+					"172.18.0.1:38549",
+					"172.19.0.1:38549",
+					"172.20.0.1:38549",
+					"172.21.0.1:38549",
+					"172.22.0.1:38549",
+					"172.23.0.1:38549",
+					"172.24.0.1:38549",
+					"172.25.0.1:38549",
+					"172.26.0.1:38549",
+					"172.27.0.1:38549",
+					"172.28.0.1:38549",
+					"172.29.0.1:38549"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:06:05.671488052Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4963259093864094,
+				"StableID":   "nDg4FDQskf11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:99d7d595275a99cb6d8145ac37ccab734ecf3bc46fb5643705de247e224bc83c",
+				"DiscoKey":   "discokey:9d0ff4a5e17152398066d88cd6182d39b50bdeb3c0c7455a57c9c231790d3b0e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50618",
+					"10.65.0.27:50618",
+					"172.17.0.1:50618",
+					"172.18.0.1:50618",
+					"172.19.0.1:50618",
+					"172.20.0.1:50618",
+					"172.21.0.1:50618",
+					"172.22.0.1:50618",
+					"172.23.0.1:50618",
+					"172.24.0.1:50618",
+					"172.25.0.1:50618",
+					"172.26.0.1:50618",
+					"172.27.0.1:50618",
+					"172.28.0.1:50618",
+					"172.29.0.1:50618"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:06:06.206189964Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1943546407355350,
+				"StableID":   "nZk3fmfEBG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9218ebc91411788c3a9984660d22098687990c320bdd6f375356f64a7a2b0e68",
+				"DiscoKey":   "discokey:1ffa9b2e2fbd1a73e09a39d6f80cc021b6ed3b812a083bbb7f3ac5e76b5e0563",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:39674",
+					"10.65.0.27:39674",
+					"172.17.0.1:39674",
+					"172.18.0.1:39674",
+					"172.19.0.1:39674",
+					"172.20.0.1:39674",
+					"172.21.0.1:39674",
+					"172.22.0.1:39674",
+					"172.23.0.1:39674",
+					"172.24.0.1:39674",
+					"172.25.0.1:39674",
+					"172.26.0.1:39674",
+					"172.27.0.1:39674",
+					"172.28.0.1:39674",
+					"172.29.0.1:39674"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:06:06.73153339Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1708133528877187,
+				"StableID":   "nSifijmcLE11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a356a22e64460ab591255811a3b615a2e848df822af39edf39acd2d3e1d891d",
+				"DiscoKey":   "discokey:3e442f32c2a1e007aa30850ab06f45bb6d1ffa7698e6ba334c749f360d4b761d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39704",
+					"10.65.0.27:39704",
+					"172.17.0.1:39704",
+					"172.18.0.1:39704",
+					"172.19.0.1:39704",
+					"172.20.0.1:39704",
+					"172.21.0.1:39704",
+					"172.22.0.1:39704",
+					"172.23.0.1:39704",
+					"172.24.0.1:39704",
+					"172.25.0.1:39704",
+					"172.26.0.1:39704",
+					"172.27.0.1:39704",
+					"172.28.0.1:39704",
+					"172.29.0.1:39704"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:06:07.276232748Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         916153504890789,
+				"StableID":   "nxEQ1Mov9811CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f686760c3c5be34a0bd612c59a9daab5e6df5148262ad27834ffc66014b2a36b",
+				"DiscoKey":   "discokey:ffd60d6538f69292c6f2717daf97a27f220f9d88d789e75d5c5285536034cb60",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57006",
+					"10.65.0.27:57006",
+					"172.17.0.1:57006",
+					"172.18.0.1:57006",
+					"172.19.0.1:57006",
+					"172.20.0.1:57006",
+					"172.21.0.1:57006",
+					"172.22.0.1:57006",
+					"172.23.0.1:57006",
+					"172.24.0.1:57006",
+					"172.25.0.1:57006",
+					"172.26.0.1:57006",
+					"172.27.0.1:57006",
+					"172.28.0.1:57006",
+					"172.29.0.1:57006"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:06:08.365168758Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7349144867247594,
+				"StableID":   "nZWMxGaSPz11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a9a0864c31e5b3b5151092f6341b1d0ea5e8f11dda567a93ec4e8bca734746e",
+				"DiscoKey":   "discokey:a951bc4101a4984404a8954e603413dd63c6cd6967a8567ac64aef7829a51f51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59744",
+					"10.65.0.27:59744",
+					"172.17.0.1:59744",
+					"172.18.0.1:59744",
+					"172.19.0.1:59744",
+					"172.20.0.1:59744",
+					"172.21.0.1:59744",
+					"172.22.0.1:59744",
+					"172.23.0.1:59744",
+					"172.24.0.1:59744",
+					"172.25.0.1:59744",
+					"172.26.0.1:59744",
+					"172.27.0.1:59744",
+					"172.28.0.1:59744",
+					"172.29.0.1:59744"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:06:08.900841555Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2656983726927875,
+				"StableID":   "nAi3YWTMkM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7e4b69cfe2c88c50e8b06b9b2cf0438466d1db58c88ce7c31909b7cdf722ec60",
+				"KeyExpiry":  "2026-11-09T09:06:09Z",
+				"DiscoKey":   "discokey:0532507bb618ccd11529f82e642e6a6d30ce3fe5c07730cd9e022f9575963d46",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:59277",
+					"10.65.0.27:59277",
+					"172.17.0.1:59277",
+					"172.18.0.1:59277",
+					"172.19.0.1:59277",
+					"172.20.0.1:59277",
+					"172.21.0.1:59277",
+					"172.22.0.1:59277",
+					"172.23.0.1:59277",
+					"172.24.0.1:59277",
+					"172.25.0.1:59277",
+					"172.26.0.1:59277",
+					"172.27.0.1:59277",
+					"172.28.0.1:59277",
+					"172.29.0.1:59277"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:06:09.446241278Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6744977102580193,
+				"StableID":   "nki2US7pfu11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:d8ff1ec2b48104f077c30a221dad55554ac4880988e0c0d5cc536326a7ada577",
+				"KeyExpiry":  "2026-11-09T09:06:09Z",
+				"DiscoKey":   "discokey:c45d8cd20b6a6e62a65ca75266551eb644fd26f77a4e300bb2fc5583b3d03667",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55650",
+					"10.65.0.27:55650",
+					"172.17.0.1:55650",
+					"172.18.0.1:55650",
+					"172.19.0.1:55650",
+					"172.20.0.1:55650",
+					"172.21.0.1:55650",
+					"172.22.0.1:55650",
+					"172.23.0.1:55650",
+					"172.24.0.1:55650",
+					"172.25.0.1:55650",
+					"172.26.0.1:55650",
+					"172.27.0.1:55650",
+					"172.28.0.1:55650",
+					"172.29.0.1:55650"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:06:09.99204694Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8937434359782713,
+				"StableID":   "neFwZEFnnC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7259264d04fbd94bb35e6d00bc341968a782958f2b53e9ba3666a7972452097d",
+				"KeyExpiry":  "2026-11-09T09:06:10Z",
+				"DiscoKey":   "discokey:b849d1522e87bda0a2764a94af6a0ab2f2de4fabd17eeb751fc204be55b3bd25",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786",
+					"172.20.0.1:45786",
+					"172.21.0.1:45786",
+					"172.22.0.1:45786",
+					"172.23.0.1:45786",
+					"172.24.0.1:45786",
+					"172.25.0.1:45786",
+					"172.26.0.1:45786",
+					"172.27.0.1:45786",
+					"172.28.0.1:45786",
+					"172.29.0.1:45786"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:06:10.527555233Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5262985869601637": {
+				"ID":          5262985869601637,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-acceptenv-omitted.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-acceptenv-omitted.hujson
@@ -1,0 +1,22348 @@
+// ssh-acceptenv-omitted
+//
+// ssh acceptEnv field absent
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-13T09:06:55Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-acceptenv-omitted",
+	"description":    "ssh acceptEnv field absent",
+	"category":       "ssh",
+	"captured_at":    "2026-05-13T09:06:55.853451174Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                        \n  \n                                                                   \n                        \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh acceptEnv field absent\",\n\t\"id\":          \"ssh-acceptenv-omitted\",\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"thor@example.org\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-edges/ssh-acceptenv-omitted.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["thor@example.org"],
+				"users":  ["root"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3311208731492109,
+				"StableID":   "nCnDudqerS11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       3311208731492109,
+				"Key":        "nodekey:ece627c2d681eb4dc892f1b7f6eb3f672f6ab30d8c9a74feef6ada7722408a3c",
+				"DiscoKey":   "discokey:4f273464c671a879a1b4ca54203699d36d08f96ee1e7ab2bc1049b3cac09b347",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48595",
+					"10.65.0.27:48595",
+					"172.17.0.1:48595",
+					"172.18.0.1:48595",
+					"172.19.0.1:48595",
+					"172.20.0.1:48595",
+					"172.21.0.1:48595",
+					"172.22.0.1:48595",
+					"172.23.0.1:48595",
+					"172.24.0.1:48595",
+					"172.25.0.1:48595",
+					"172.26.0.1:48595",
+					"172.27.0.1:48595",
+					"172.28.0.1:48595",
+					"172.29.0.1:48595"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:07:04.850360367Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ece627c2d681eb4dc892f1b7f6eb3f672f6ab30d8c9a74feef6ada7722408a3c",
+			"MachineKey": "mkey:c2f5fa9d8f952b706e05da093efd96df2e06e931f44b737f4e8bf3a656364b22",
+			"Peers": [{
+				"ID":         976708517211670,
+				"StableID":   "nsHv5eUMd811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:693f1096b5e38d38a2b4800cf64b8f3b97a0bf724420b872578cc1b5b9eda42f",
+				"DiscoKey":   "discokey:7809cb165bed2d629ee21964fa7edd13ba3fdfeaed8ed719f54bad6de3052d56",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47993",
+					"10.65.0.27:47993",
+					"172.17.0.1:47993",
+					"172.18.0.1:47993",
+					"172.19.0.1:47993",
+					"172.20.0.1:47993",
+					"172.21.0.1:47993",
+					"172.22.0.1:47993",
+					"172.23.0.1:47993",
+					"172.24.0.1:47993",
+					"172.25.0.1:47993",
+					"172.26.0.1:47993",
+					"172.27.0.1:47993",
+					"172.28.0.1:47993",
+					"172.29.0.1:47993"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:06:58.5101451Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3824448112674477,
+				"StableID":   "n4nZWUm6sW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07ec7614be9264bf4da7497e9aa2186bb3a3941c4044f10786082d5ef35f904d",
+				"DiscoKey":   "discokey:5b605feff2417171183d7c886260b3613ac1239dc192a53931081d5d0fbcf26e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34807",
+					"10.65.0.27:34807",
+					"172.17.0.1:34807",
+					"172.18.0.1:34807",
+					"172.19.0.1:34807",
+					"172.20.0.1:34807",
+					"172.21.0.1:34807",
+					"172.22.0.1:34807",
+					"172.23.0.1:34807",
+					"172.24.0.1:34807",
+					"172.25.0.1:34807",
+					"172.26.0.1:34807",
+					"172.27.0.1:34807",
+					"172.28.0.1:34807",
+					"172.29.0.1:34807"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:06:59.334581139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3527482195521367,
+				"StableID":   "nrLjKbybYU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31ed2c7eee6a2a519a5ff44c629b248934b3621cbf0e1bb65f4c91f09bcc8f5a",
+				"DiscoKey":   "discokey:a6fb79615ab1925f1c3ce0b5524724ffca017d3975fae0f63d1ce6a1ff5d6068",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39256",
+					"10.65.0.27:39256",
+					"172.17.0.1:39256",
+					"172.18.0.1:39256",
+					"172.19.0.1:39256",
+					"172.20.0.1:39256",
+					"172.21.0.1:39256",
+					"172.22.0.1:39256",
+					"172.23.0.1:39256",
+					"172.24.0.1:39256",
+					"172.25.0.1:39256",
+					"172.26.0.1:39256",
+					"172.27.0.1:39256",
+					"172.28.0.1:39256",
+					"172.29.0.1:39256"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:07:00.014319028Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2903606537190410,
+				"StableID":   "nj5ykZp3gP11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:50474b8b720f0f07fe21708a7bfb204fd00e64b0d318e5d3f321efd94be5dd42",
+				"DiscoKey":   "discokey:40cefa0618560ff7da77043eb69538848235b60f6c6374ae9b99f443eb06d454",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42842",
+					"10.65.0.27:42842",
+					"172.17.0.1:42842",
+					"172.18.0.1:42842",
+					"172.19.0.1:42842",
+					"172.20.0.1:42842",
+					"172.21.0.1:42842",
+					"172.22.0.1:42842",
+					"172.23.0.1:42842",
+					"172.24.0.1:42842",
+					"172.25.0.1:42842",
+					"172.26.0.1:42842",
+					"172.27.0.1:42842",
+					"172.28.0.1:42842",
+					"172.29.0.1:42842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:07:00.548368106Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6827040522615864,
+				"StableID":   "nuh8t7nyJv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b70152198f5e5e86aa84e79227f3d4d80441aebb5a39f806d59a74b9d5222506",
+				"DiscoKey":   "discokey:52277daa5b055ee6f2d00161a303f0ee0cfc022c757889c427beb190cd60d31e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:35029",
+					"10.65.0.27:35029",
+					"172.17.0.1:35029",
+					"172.18.0.1:35029",
+					"172.19.0.1:35029",
+					"172.20.0.1:35029",
+					"172.21.0.1:35029",
+					"172.22.0.1:35029",
+					"172.23.0.1:35029",
+					"172.24.0.1:35029",
+					"172.25.0.1:35029",
+					"172.26.0.1:35029",
+					"172.27.0.1:35029",
+					"172.28.0.1:35029",
+					"172.29.0.1:35029"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:07:01.089113953Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3188121042143300,
+				"StableID":   "nV5dHxXutR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:887ef6d4915e34fee99dfedda47ac9cf2596688c580675a42c3471cbebaafb11",
+				"DiscoKey":   "discokey:2ae1bcb848319c1aca0fd76bfbab00b41b9a056fb6d0dae31f6aa5830be38037",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:60559",
+					"10.65.0.27:60559",
+					"172.17.0.1:60559",
+					"172.18.0.1:60559",
+					"172.19.0.1:60559",
+					"172.20.0.1:60559",
+					"172.21.0.1:60559",
+					"172.22.0.1:60559",
+					"172.23.0.1:60559",
+					"172.24.0.1:60559",
+					"172.25.0.1:60559",
+					"172.26.0.1:60559",
+					"172.27.0.1:60559",
+					"172.28.0.1:60559",
+					"172.29.0.1:60559"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:07:01.638082773Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6026571109877032,
+				"StableID":   "njzUxcoS4p11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:18586a46b864c2ca115fc1b02bd9e189004f83438da40203ca9ae750b6d4867c",
+				"DiscoKey":   "discokey:e6c914d964da958f5bccd1e0f0438649f10177c7d2e94160426c49c294bd9550",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:46267",
+					"10.65.0.27:46267",
+					"172.17.0.1:46267",
+					"172.18.0.1:46267",
+					"172.19.0.1:46267",
+					"172.20.0.1:46267",
+					"172.21.0.1:46267",
+					"172.22.0.1:46267",
+					"172.23.0.1:46267",
+					"172.24.0.1:46267",
+					"172.25.0.1:46267",
+					"172.26.0.1:46267",
+					"172.27.0.1:46267",
+					"172.28.0.1:46267",
+					"172.29.0.1:46267"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:07:02.178830239Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3109318643116652,
+				"StableID":   "nuoa8eXDHR11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:19240fa0357506dc89722122edbf677041158ff71a947bea5301ae9c01c8847d",
+				"DiscoKey":   "discokey:63786a4d32cbdd73773c1a731cccfcf782e3f8550ffbca4137dca2792e753f53",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45928",
+					"10.65.0.27:45928",
+					"172.17.0.1:45928",
+					"172.18.0.1:45928",
+					"172.19.0.1:45928",
+					"172.20.0.1:45928",
+					"172.21.0.1:45928",
+					"172.22.0.1:45928",
+					"172.23.0.1:45928",
+					"172.24.0.1:45928",
+					"172.25.0.1:45928",
+					"172.26.0.1:45928",
+					"172.27.0.1:45928",
+					"172.28.0.1:45928",
+					"172.29.0.1:45928"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:07:02.713673659Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3420985025326015,
+				"StableID":   "nSxM5bUNiT11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5179e958e1bcee53b917d23980ecb7580fd7aee87073e51dc5a7ac5c512f305e",
+				"DiscoKey":   "discokey:ed27a9ec853c0b52ea58ff8f9db55ff7786750fd95ab32910c43367c0fc9001f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41518",
+					"10.65.0.27:41518",
+					"172.17.0.1:41518",
+					"172.18.0.1:41518",
+					"172.19.0.1:41518",
+					"172.20.0.1:41518",
+					"172.21.0.1:41518",
+					"172.22.0.1:41518",
+					"172.23.0.1:41518",
+					"172.24.0.1:41518",
+					"172.25.0.1:41518",
+					"172.26.0.1:41518",
+					"172.27.0.1:41518",
+					"172.28.0.1:41518",
+					"172.29.0.1:41518"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:07:03.260242351Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8235423448387682,
+				"StableID":   "n3PaFLcqJ721CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b5bd7a97c7b00c217cd2bd9c077b9354d5aa216043ed9106a7fd0e084372c14",
+				"DiscoKey":   "discokey:25bb0bccd6af1bce680c5e620b367bc67f38ade3332b6caae7f29431e703bd17",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53023",
+					"10.65.0.27:53023",
+					"172.17.0.1:53023",
+					"172.18.0.1:53023",
+					"172.19.0.1:53023",
+					"172.20.0.1:53023",
+					"172.21.0.1:53023",
+					"172.22.0.1:53023",
+					"172.23.0.1:53023",
+					"172.24.0.1:53023",
+					"172.25.0.1:53023",
+					"172.26.0.1:53023",
+					"172.27.0.1:53023",
+					"172.28.0.1:53023",
+					"172.29.0.1:53023"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:07:03.775745436Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1396844734654740,
+				"StableID":   "nM72w4kduB11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ffa1cbd6a2ef321eeb0ae907edbcab63a8bbdb2ae06102448a673f222c10f454",
+				"DiscoKey":   "discokey:b515939689ab44b6c96e494f002870bab12a3d1aea7d3ef97c22f85d7f720437",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37085",
+					"10.65.0.27:37085",
+					"172.17.0.1:37085",
+					"172.18.0.1:37085",
+					"172.19.0.1:37085",
+					"172.20.0.1:37085",
+					"172.21.0.1:37085",
+					"172.22.0.1:37085",
+					"172.23.0.1:37085",
+					"172.24.0.1:37085",
+					"172.25.0.1:37085",
+					"172.26.0.1:37085",
+					"172.27.0.1:37085",
+					"172.28.0.1:37085",
+					"172.29.0.1:37085"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:07:04.313556266Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7777277844117688,
+				"StableID":   "nw4n3GuLj321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:fa9004d8608a8f81c8df29395b2d8d3fa28defaa757cad8b431c5b3f3f54f504",
+				"KeyExpiry":  "2026-11-09T09:07:05Z",
+				"DiscoKey":   "discokey:a5b588857f4ff1a08e43b2d51eb969e370953bf7c1f8a5a69b9e0bbe1e992234",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38435",
+					"10.65.0.27:38435",
+					"172.17.0.1:38435",
+					"172.18.0.1:38435",
+					"172.19.0.1:38435",
+					"172.20.0.1:38435",
+					"172.21.0.1:38435",
+					"172.22.0.1:38435",
+					"172.23.0.1:38435",
+					"172.24.0.1:38435",
+					"172.25.0.1:38435",
+					"172.26.0.1:38435",
+					"172.27.0.1:38435",
+					"172.28.0.1:38435",
+					"172.29.0.1:38435"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:07:05.383804209Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2953439583137982,
+				"StableID":   "nf3EPHrc4Q11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6830c6e8462e7666dd6a590afa47674215e85c774bdb08585ef9c53d213dd83e",
+				"KeyExpiry":  "2026-11-09T09:07:05Z",
+				"DiscoKey":   "discokey:b73ed43ae299905067eef8003960a36279ceaaae6ddefc591c1a43ddb6a7377f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60165",
+					"10.65.0.27:60165",
+					"172.17.0.1:60165",
+					"172.18.0.1:60165",
+					"172.19.0.1:60165",
+					"172.20.0.1:60165",
+					"172.21.0.1:60165",
+					"172.22.0.1:60165",
+					"172.23.0.1:60165",
+					"172.24.0.1:60165",
+					"172.25.0.1:60165",
+					"172.26.0.1:60165",
+					"172.27.0.1:60165",
+					"172.28.0.1:60165",
+					"172.29.0.1:60165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:07:05.932371484Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6510634174200293,
+				"StableID":   "nvPaMYKgqs11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3db8e6ea02db37d77b3e725aebaddecd8e814a3d1a629b8786902d3594c12b22",
+				"KeyExpiry":  "2026-11-09T09:07:06Z",
+				"DiscoKey":   "discokey:dafff3180c3e748f84e9f52f7b5eb38cacc3d17037d6caffb6f482081346a31b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38090",
+					"10.65.0.27:38090",
+					"172.17.0.1:38090",
+					"172.18.0.1:38090",
+					"172.19.0.1:38090",
+					"172.20.0.1:38090",
+					"172.21.0.1:38090",
+					"172.22.0.1:38090",
+					"172.23.0.1:38090",
+					"172.24.0.1:38090",
+					"172.25.0.1:38090",
+					"172.26.0.1:38090",
+					"172.27.0.1:38090",
+					"172.28.0.1:38090",
+					"172.29.0.1:38090"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:07:06.470237579Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{
+				"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+				"sshUsers":   {"root": "root"},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				}
+			}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3311208731492109": {
+				"ID":          3311208731492109,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		},
+		"ssh_rules": [{
+			"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+			"sshUsers":   {"root": "root"},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}
+		}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3188121042143300,
+				"StableID":   "nV5dHxXutR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       3188121042143300,
+				"Key":        "nodekey:887ef6d4915e34fee99dfedda47ac9cf2596688c580675a42c3471cbebaafb11",
+				"DiscoKey":   "discokey:2ae1bcb848319c1aca0fd76bfbab00b41b9a056fb6d0dae31f6aa5830be38037",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:60559",
+					"10.65.0.27:60559",
+					"172.17.0.1:60559",
+					"172.18.0.1:60559",
+					"172.19.0.1:60559",
+					"172.20.0.1:60559",
+					"172.21.0.1:60559",
+					"172.22.0.1:60559",
+					"172.23.0.1:60559",
+					"172.24.0.1:60559",
+					"172.25.0.1:60559",
+					"172.26.0.1:60559",
+					"172.27.0.1:60559",
+					"172.28.0.1:60559",
+					"172.29.0.1:60559"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:07:01.638082773Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:887ef6d4915e34fee99dfedda47ac9cf2596688c580675a42c3471cbebaafb11",
+			"MachineKey": "mkey:a3529f8f86d13493724cfd86f949b4f310e86666f55f617fd5c54dccc634ae0b",
+			"Peers": [{
+				"ID":         976708517211670,
+				"StableID":   "nsHv5eUMd811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:693f1096b5e38d38a2b4800cf64b8f3b97a0bf724420b872578cc1b5b9eda42f",
+				"DiscoKey":   "discokey:7809cb165bed2d629ee21964fa7edd13ba3fdfeaed8ed719f54bad6de3052d56",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47993",
+					"10.65.0.27:47993",
+					"172.17.0.1:47993",
+					"172.18.0.1:47993",
+					"172.19.0.1:47993",
+					"172.20.0.1:47993",
+					"172.21.0.1:47993",
+					"172.22.0.1:47993",
+					"172.23.0.1:47993",
+					"172.24.0.1:47993",
+					"172.25.0.1:47993",
+					"172.26.0.1:47993",
+					"172.27.0.1:47993",
+					"172.28.0.1:47993",
+					"172.29.0.1:47993"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:06:58.5101451Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3824448112674477,
+				"StableID":   "n4nZWUm6sW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07ec7614be9264bf4da7497e9aa2186bb3a3941c4044f10786082d5ef35f904d",
+				"DiscoKey":   "discokey:5b605feff2417171183d7c886260b3613ac1239dc192a53931081d5d0fbcf26e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34807",
+					"10.65.0.27:34807",
+					"172.17.0.1:34807",
+					"172.18.0.1:34807",
+					"172.19.0.1:34807",
+					"172.20.0.1:34807",
+					"172.21.0.1:34807",
+					"172.22.0.1:34807",
+					"172.23.0.1:34807",
+					"172.24.0.1:34807",
+					"172.25.0.1:34807",
+					"172.26.0.1:34807",
+					"172.27.0.1:34807",
+					"172.28.0.1:34807",
+					"172.29.0.1:34807"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:06:59.334581139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3527482195521367,
+				"StableID":   "nrLjKbybYU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31ed2c7eee6a2a519a5ff44c629b248934b3621cbf0e1bb65f4c91f09bcc8f5a",
+				"DiscoKey":   "discokey:a6fb79615ab1925f1c3ce0b5524724ffca017d3975fae0f63d1ce6a1ff5d6068",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39256",
+					"10.65.0.27:39256",
+					"172.17.0.1:39256",
+					"172.18.0.1:39256",
+					"172.19.0.1:39256",
+					"172.20.0.1:39256",
+					"172.21.0.1:39256",
+					"172.22.0.1:39256",
+					"172.23.0.1:39256",
+					"172.24.0.1:39256",
+					"172.25.0.1:39256",
+					"172.26.0.1:39256",
+					"172.27.0.1:39256",
+					"172.28.0.1:39256",
+					"172.29.0.1:39256"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:07:00.014319028Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2903606537190410,
+				"StableID":   "nj5ykZp3gP11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:50474b8b720f0f07fe21708a7bfb204fd00e64b0d318e5d3f321efd94be5dd42",
+				"DiscoKey":   "discokey:40cefa0618560ff7da77043eb69538848235b60f6c6374ae9b99f443eb06d454",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42842",
+					"10.65.0.27:42842",
+					"172.17.0.1:42842",
+					"172.18.0.1:42842",
+					"172.19.0.1:42842",
+					"172.20.0.1:42842",
+					"172.21.0.1:42842",
+					"172.22.0.1:42842",
+					"172.23.0.1:42842",
+					"172.24.0.1:42842",
+					"172.25.0.1:42842",
+					"172.26.0.1:42842",
+					"172.27.0.1:42842",
+					"172.28.0.1:42842",
+					"172.29.0.1:42842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:07:00.548368106Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6827040522615864,
+				"StableID":   "nuh8t7nyJv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b70152198f5e5e86aa84e79227f3d4d80441aebb5a39f806d59a74b9d5222506",
+				"DiscoKey":   "discokey:52277daa5b055ee6f2d00161a303f0ee0cfc022c757889c427beb190cd60d31e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:35029",
+					"10.65.0.27:35029",
+					"172.17.0.1:35029",
+					"172.18.0.1:35029",
+					"172.19.0.1:35029",
+					"172.20.0.1:35029",
+					"172.21.0.1:35029",
+					"172.22.0.1:35029",
+					"172.23.0.1:35029",
+					"172.24.0.1:35029",
+					"172.25.0.1:35029",
+					"172.26.0.1:35029",
+					"172.27.0.1:35029",
+					"172.28.0.1:35029",
+					"172.29.0.1:35029"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:07:01.089113953Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6026571109877032,
+				"StableID":   "njzUxcoS4p11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:18586a46b864c2ca115fc1b02bd9e189004f83438da40203ca9ae750b6d4867c",
+				"DiscoKey":   "discokey:e6c914d964da958f5bccd1e0f0438649f10177c7d2e94160426c49c294bd9550",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:46267",
+					"10.65.0.27:46267",
+					"172.17.0.1:46267",
+					"172.18.0.1:46267",
+					"172.19.0.1:46267",
+					"172.20.0.1:46267",
+					"172.21.0.1:46267",
+					"172.22.0.1:46267",
+					"172.23.0.1:46267",
+					"172.24.0.1:46267",
+					"172.25.0.1:46267",
+					"172.26.0.1:46267",
+					"172.27.0.1:46267",
+					"172.28.0.1:46267",
+					"172.29.0.1:46267"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:07:02.178830239Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3109318643116652,
+				"StableID":   "nuoa8eXDHR11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:19240fa0357506dc89722122edbf677041158ff71a947bea5301ae9c01c8847d",
+				"DiscoKey":   "discokey:63786a4d32cbdd73773c1a731cccfcf782e3f8550ffbca4137dca2792e753f53",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45928",
+					"10.65.0.27:45928",
+					"172.17.0.1:45928",
+					"172.18.0.1:45928",
+					"172.19.0.1:45928",
+					"172.20.0.1:45928",
+					"172.21.0.1:45928",
+					"172.22.0.1:45928",
+					"172.23.0.1:45928",
+					"172.24.0.1:45928",
+					"172.25.0.1:45928",
+					"172.26.0.1:45928",
+					"172.27.0.1:45928",
+					"172.28.0.1:45928",
+					"172.29.0.1:45928"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:07:02.713673659Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3420985025326015,
+				"StableID":   "nSxM5bUNiT11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5179e958e1bcee53b917d23980ecb7580fd7aee87073e51dc5a7ac5c512f305e",
+				"DiscoKey":   "discokey:ed27a9ec853c0b52ea58ff8f9db55ff7786750fd95ab32910c43367c0fc9001f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41518",
+					"10.65.0.27:41518",
+					"172.17.0.1:41518",
+					"172.18.0.1:41518",
+					"172.19.0.1:41518",
+					"172.20.0.1:41518",
+					"172.21.0.1:41518",
+					"172.22.0.1:41518",
+					"172.23.0.1:41518",
+					"172.24.0.1:41518",
+					"172.25.0.1:41518",
+					"172.26.0.1:41518",
+					"172.27.0.1:41518",
+					"172.28.0.1:41518",
+					"172.29.0.1:41518"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:07:03.260242351Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8235423448387682,
+				"StableID":   "n3PaFLcqJ721CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b5bd7a97c7b00c217cd2bd9c077b9354d5aa216043ed9106a7fd0e084372c14",
+				"DiscoKey":   "discokey:25bb0bccd6af1bce680c5e620b367bc67f38ade3332b6caae7f29431e703bd17",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53023",
+					"10.65.0.27:53023",
+					"172.17.0.1:53023",
+					"172.18.0.1:53023",
+					"172.19.0.1:53023",
+					"172.20.0.1:53023",
+					"172.21.0.1:53023",
+					"172.22.0.1:53023",
+					"172.23.0.1:53023",
+					"172.24.0.1:53023",
+					"172.25.0.1:53023",
+					"172.26.0.1:53023",
+					"172.27.0.1:53023",
+					"172.28.0.1:53023",
+					"172.29.0.1:53023"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:07:03.775745436Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1396844734654740,
+				"StableID":   "nM72w4kduB11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ffa1cbd6a2ef321eeb0ae907edbcab63a8bbdb2ae06102448a673f222c10f454",
+				"DiscoKey":   "discokey:b515939689ab44b6c96e494f002870bab12a3d1aea7d3ef97c22f85d7f720437",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37085",
+					"10.65.0.27:37085",
+					"172.17.0.1:37085",
+					"172.18.0.1:37085",
+					"172.19.0.1:37085",
+					"172.20.0.1:37085",
+					"172.21.0.1:37085",
+					"172.22.0.1:37085",
+					"172.23.0.1:37085",
+					"172.24.0.1:37085",
+					"172.25.0.1:37085",
+					"172.26.0.1:37085",
+					"172.27.0.1:37085",
+					"172.28.0.1:37085",
+					"172.29.0.1:37085"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:07:04.313556266Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3311208731492109,
+				"StableID":   "nCnDudqerS11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ece627c2d681eb4dc892f1b7f6eb3f672f6ab30d8c9a74feef6ada7722408a3c",
+				"DiscoKey":   "discokey:4f273464c671a879a1b4ca54203699d36d08f96ee1e7ab2bc1049b3cac09b347",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48595",
+					"10.65.0.27:48595",
+					"172.17.0.1:48595",
+					"172.18.0.1:48595",
+					"172.19.0.1:48595",
+					"172.20.0.1:48595",
+					"172.21.0.1:48595",
+					"172.22.0.1:48595",
+					"172.23.0.1:48595",
+					"172.24.0.1:48595",
+					"172.25.0.1:48595",
+					"172.26.0.1:48595",
+					"172.27.0.1:48595",
+					"172.28.0.1:48595",
+					"172.29.0.1:48595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:07:04.850360367Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7777277844117688,
+				"StableID":   "nw4n3GuLj321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:fa9004d8608a8f81c8df29395b2d8d3fa28defaa757cad8b431c5b3f3f54f504",
+				"KeyExpiry":  "2026-11-09T09:07:05Z",
+				"DiscoKey":   "discokey:a5b588857f4ff1a08e43b2d51eb969e370953bf7c1f8a5a69b9e0bbe1e992234",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38435",
+					"10.65.0.27:38435",
+					"172.17.0.1:38435",
+					"172.18.0.1:38435",
+					"172.19.0.1:38435",
+					"172.20.0.1:38435",
+					"172.21.0.1:38435",
+					"172.22.0.1:38435",
+					"172.23.0.1:38435",
+					"172.24.0.1:38435",
+					"172.25.0.1:38435",
+					"172.26.0.1:38435",
+					"172.27.0.1:38435",
+					"172.28.0.1:38435",
+					"172.29.0.1:38435"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:07:05.383804209Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2953439583137982,
+				"StableID":   "nf3EPHrc4Q11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6830c6e8462e7666dd6a590afa47674215e85c774bdb08585ef9c53d213dd83e",
+				"KeyExpiry":  "2026-11-09T09:07:05Z",
+				"DiscoKey":   "discokey:b73ed43ae299905067eef8003960a36279ceaaae6ddefc591c1a43ddb6a7377f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60165",
+					"10.65.0.27:60165",
+					"172.17.0.1:60165",
+					"172.18.0.1:60165",
+					"172.19.0.1:60165",
+					"172.20.0.1:60165",
+					"172.21.0.1:60165",
+					"172.22.0.1:60165",
+					"172.23.0.1:60165",
+					"172.24.0.1:60165",
+					"172.25.0.1:60165",
+					"172.26.0.1:60165",
+					"172.27.0.1:60165",
+					"172.28.0.1:60165",
+					"172.29.0.1:60165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:07:05.932371484Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6510634174200293,
+				"StableID":   "nvPaMYKgqs11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3db8e6ea02db37d77b3e725aebaddecd8e814a3d1a629b8786902d3594c12b22",
+				"KeyExpiry":  "2026-11-09T09:07:06Z",
+				"DiscoKey":   "discokey:dafff3180c3e748f84e9f52f7b5eb38cacc3d17037d6caffb6f482081346a31b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38090",
+					"10.65.0.27:38090",
+					"172.17.0.1:38090",
+					"172.18.0.1:38090",
+					"172.19.0.1:38090",
+					"172.20.0.1:38090",
+					"172.21.0.1:38090",
+					"172.22.0.1:38090",
+					"172.23.0.1:38090",
+					"172.24.0.1:38090",
+					"172.25.0.1:38090",
+					"172.26.0.1:38090",
+					"172.27.0.1:38090",
+					"172.28.0.1:38090",
+					"172.29.0.1:38090"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:07:06.470237579Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3188121042143300": {
+				"ID":          3188121042143300,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6510634174200293,
+				"StableID":   "nvPaMYKgqs11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3db8e6ea02db37d77b3e725aebaddecd8e814a3d1a629b8786902d3594c12b22",
+				"KeyExpiry":  "2026-11-09T09:07:06Z",
+				"DiscoKey":   "discokey:dafff3180c3e748f84e9f52f7b5eb38cacc3d17037d6caffb6f482081346a31b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38090",
+					"10.65.0.27:38090",
+					"172.17.0.1:38090",
+					"172.18.0.1:38090",
+					"172.19.0.1:38090",
+					"172.20.0.1:38090",
+					"172.21.0.1:38090",
+					"172.22.0.1:38090",
+					"172.23.0.1:38090",
+					"172.24.0.1:38090",
+					"172.25.0.1:38090",
+					"172.26.0.1:38090",
+					"172.27.0.1:38090",
+					"172.28.0.1:38090",
+					"172.29.0.1:38090"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:07:06.470237579Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3db8e6ea02db37d77b3e725aebaddecd8e814a3d1a629b8786902d3594c12b22",
+			"MachineKey": "mkey:e9c8b9af2a38038758062cd33a7b4f4ae527f10fdd7b84c91386db59e8bb435c",
+			"Peers": [{
+				"ID":         976708517211670,
+				"StableID":   "nsHv5eUMd811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:693f1096b5e38d38a2b4800cf64b8f3b97a0bf724420b872578cc1b5b9eda42f",
+				"DiscoKey":   "discokey:7809cb165bed2d629ee21964fa7edd13ba3fdfeaed8ed719f54bad6de3052d56",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47993",
+					"10.65.0.27:47993",
+					"172.17.0.1:47993",
+					"172.18.0.1:47993",
+					"172.19.0.1:47993",
+					"172.20.0.1:47993",
+					"172.21.0.1:47993",
+					"172.22.0.1:47993",
+					"172.23.0.1:47993",
+					"172.24.0.1:47993",
+					"172.25.0.1:47993",
+					"172.26.0.1:47993",
+					"172.27.0.1:47993",
+					"172.28.0.1:47993",
+					"172.29.0.1:47993"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:06:58.5101451Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3824448112674477,
+				"StableID":   "n4nZWUm6sW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07ec7614be9264bf4da7497e9aa2186bb3a3941c4044f10786082d5ef35f904d",
+				"DiscoKey":   "discokey:5b605feff2417171183d7c886260b3613ac1239dc192a53931081d5d0fbcf26e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34807",
+					"10.65.0.27:34807",
+					"172.17.0.1:34807",
+					"172.18.0.1:34807",
+					"172.19.0.1:34807",
+					"172.20.0.1:34807",
+					"172.21.0.1:34807",
+					"172.22.0.1:34807",
+					"172.23.0.1:34807",
+					"172.24.0.1:34807",
+					"172.25.0.1:34807",
+					"172.26.0.1:34807",
+					"172.27.0.1:34807",
+					"172.28.0.1:34807",
+					"172.29.0.1:34807"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:06:59.334581139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3527482195521367,
+				"StableID":   "nrLjKbybYU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31ed2c7eee6a2a519a5ff44c629b248934b3621cbf0e1bb65f4c91f09bcc8f5a",
+				"DiscoKey":   "discokey:a6fb79615ab1925f1c3ce0b5524724ffca017d3975fae0f63d1ce6a1ff5d6068",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39256",
+					"10.65.0.27:39256",
+					"172.17.0.1:39256",
+					"172.18.0.1:39256",
+					"172.19.0.1:39256",
+					"172.20.0.1:39256",
+					"172.21.0.1:39256",
+					"172.22.0.1:39256",
+					"172.23.0.1:39256",
+					"172.24.0.1:39256",
+					"172.25.0.1:39256",
+					"172.26.0.1:39256",
+					"172.27.0.1:39256",
+					"172.28.0.1:39256",
+					"172.29.0.1:39256"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:07:00.014319028Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2903606537190410,
+				"StableID":   "nj5ykZp3gP11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:50474b8b720f0f07fe21708a7bfb204fd00e64b0d318e5d3f321efd94be5dd42",
+				"DiscoKey":   "discokey:40cefa0618560ff7da77043eb69538848235b60f6c6374ae9b99f443eb06d454",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42842",
+					"10.65.0.27:42842",
+					"172.17.0.1:42842",
+					"172.18.0.1:42842",
+					"172.19.0.1:42842",
+					"172.20.0.1:42842",
+					"172.21.0.1:42842",
+					"172.22.0.1:42842",
+					"172.23.0.1:42842",
+					"172.24.0.1:42842",
+					"172.25.0.1:42842",
+					"172.26.0.1:42842",
+					"172.27.0.1:42842",
+					"172.28.0.1:42842",
+					"172.29.0.1:42842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:07:00.548368106Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6827040522615864,
+				"StableID":   "nuh8t7nyJv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b70152198f5e5e86aa84e79227f3d4d80441aebb5a39f806d59a74b9d5222506",
+				"DiscoKey":   "discokey:52277daa5b055ee6f2d00161a303f0ee0cfc022c757889c427beb190cd60d31e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:35029",
+					"10.65.0.27:35029",
+					"172.17.0.1:35029",
+					"172.18.0.1:35029",
+					"172.19.0.1:35029",
+					"172.20.0.1:35029",
+					"172.21.0.1:35029",
+					"172.22.0.1:35029",
+					"172.23.0.1:35029",
+					"172.24.0.1:35029",
+					"172.25.0.1:35029",
+					"172.26.0.1:35029",
+					"172.27.0.1:35029",
+					"172.28.0.1:35029",
+					"172.29.0.1:35029"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:07:01.089113953Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3188121042143300,
+				"StableID":   "nV5dHxXutR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:887ef6d4915e34fee99dfedda47ac9cf2596688c580675a42c3471cbebaafb11",
+				"DiscoKey":   "discokey:2ae1bcb848319c1aca0fd76bfbab00b41b9a056fb6d0dae31f6aa5830be38037",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:60559",
+					"10.65.0.27:60559",
+					"172.17.0.1:60559",
+					"172.18.0.1:60559",
+					"172.19.0.1:60559",
+					"172.20.0.1:60559",
+					"172.21.0.1:60559",
+					"172.22.0.1:60559",
+					"172.23.0.1:60559",
+					"172.24.0.1:60559",
+					"172.25.0.1:60559",
+					"172.26.0.1:60559",
+					"172.27.0.1:60559",
+					"172.28.0.1:60559",
+					"172.29.0.1:60559"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:07:01.638082773Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6026571109877032,
+				"StableID":   "njzUxcoS4p11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:18586a46b864c2ca115fc1b02bd9e189004f83438da40203ca9ae750b6d4867c",
+				"DiscoKey":   "discokey:e6c914d964da958f5bccd1e0f0438649f10177c7d2e94160426c49c294bd9550",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:46267",
+					"10.65.0.27:46267",
+					"172.17.0.1:46267",
+					"172.18.0.1:46267",
+					"172.19.0.1:46267",
+					"172.20.0.1:46267",
+					"172.21.0.1:46267",
+					"172.22.0.1:46267",
+					"172.23.0.1:46267",
+					"172.24.0.1:46267",
+					"172.25.0.1:46267",
+					"172.26.0.1:46267",
+					"172.27.0.1:46267",
+					"172.28.0.1:46267",
+					"172.29.0.1:46267"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:07:02.178830239Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3109318643116652,
+				"StableID":   "nuoa8eXDHR11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:19240fa0357506dc89722122edbf677041158ff71a947bea5301ae9c01c8847d",
+				"DiscoKey":   "discokey:63786a4d32cbdd73773c1a731cccfcf782e3f8550ffbca4137dca2792e753f53",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45928",
+					"10.65.0.27:45928",
+					"172.17.0.1:45928",
+					"172.18.0.1:45928",
+					"172.19.0.1:45928",
+					"172.20.0.1:45928",
+					"172.21.0.1:45928",
+					"172.22.0.1:45928",
+					"172.23.0.1:45928",
+					"172.24.0.1:45928",
+					"172.25.0.1:45928",
+					"172.26.0.1:45928",
+					"172.27.0.1:45928",
+					"172.28.0.1:45928",
+					"172.29.0.1:45928"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:07:02.713673659Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3420985025326015,
+				"StableID":   "nSxM5bUNiT11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5179e958e1bcee53b917d23980ecb7580fd7aee87073e51dc5a7ac5c512f305e",
+				"DiscoKey":   "discokey:ed27a9ec853c0b52ea58ff8f9db55ff7786750fd95ab32910c43367c0fc9001f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41518",
+					"10.65.0.27:41518",
+					"172.17.0.1:41518",
+					"172.18.0.1:41518",
+					"172.19.0.1:41518",
+					"172.20.0.1:41518",
+					"172.21.0.1:41518",
+					"172.22.0.1:41518",
+					"172.23.0.1:41518",
+					"172.24.0.1:41518",
+					"172.25.0.1:41518",
+					"172.26.0.1:41518",
+					"172.27.0.1:41518",
+					"172.28.0.1:41518",
+					"172.29.0.1:41518"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:07:03.260242351Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8235423448387682,
+				"StableID":   "n3PaFLcqJ721CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b5bd7a97c7b00c217cd2bd9c077b9354d5aa216043ed9106a7fd0e084372c14",
+				"DiscoKey":   "discokey:25bb0bccd6af1bce680c5e620b367bc67f38ade3332b6caae7f29431e703bd17",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53023",
+					"10.65.0.27:53023",
+					"172.17.0.1:53023",
+					"172.18.0.1:53023",
+					"172.19.0.1:53023",
+					"172.20.0.1:53023",
+					"172.21.0.1:53023",
+					"172.22.0.1:53023",
+					"172.23.0.1:53023",
+					"172.24.0.1:53023",
+					"172.25.0.1:53023",
+					"172.26.0.1:53023",
+					"172.27.0.1:53023",
+					"172.28.0.1:53023",
+					"172.29.0.1:53023"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:07:03.775745436Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1396844734654740,
+				"StableID":   "nM72w4kduB11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ffa1cbd6a2ef321eeb0ae907edbcab63a8bbdb2ae06102448a673f222c10f454",
+				"DiscoKey":   "discokey:b515939689ab44b6c96e494f002870bab12a3d1aea7d3ef97c22f85d7f720437",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37085",
+					"10.65.0.27:37085",
+					"172.17.0.1:37085",
+					"172.18.0.1:37085",
+					"172.19.0.1:37085",
+					"172.20.0.1:37085",
+					"172.21.0.1:37085",
+					"172.22.0.1:37085",
+					"172.23.0.1:37085",
+					"172.24.0.1:37085",
+					"172.25.0.1:37085",
+					"172.26.0.1:37085",
+					"172.27.0.1:37085",
+					"172.28.0.1:37085",
+					"172.29.0.1:37085"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:07:04.313556266Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3311208731492109,
+				"StableID":   "nCnDudqerS11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ece627c2d681eb4dc892f1b7f6eb3f672f6ab30d8c9a74feef6ada7722408a3c",
+				"DiscoKey":   "discokey:4f273464c671a879a1b4ca54203699d36d08f96ee1e7ab2bc1049b3cac09b347",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48595",
+					"10.65.0.27:48595",
+					"172.17.0.1:48595",
+					"172.18.0.1:48595",
+					"172.19.0.1:48595",
+					"172.20.0.1:48595",
+					"172.21.0.1:48595",
+					"172.22.0.1:48595",
+					"172.23.0.1:48595",
+					"172.24.0.1:48595",
+					"172.25.0.1:48595",
+					"172.26.0.1:48595",
+					"172.27.0.1:48595",
+					"172.28.0.1:48595",
+					"172.29.0.1:48595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:07:04.850360367Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7777277844117688,
+				"StableID":   "nw4n3GuLj321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:fa9004d8608a8f81c8df29395b2d8d3fa28defaa757cad8b431c5b3f3f54f504",
+				"KeyExpiry":  "2026-11-09T09:07:05Z",
+				"DiscoKey":   "discokey:a5b588857f4ff1a08e43b2d51eb969e370953bf7c1f8a5a69b9e0bbe1e992234",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38435",
+					"10.65.0.27:38435",
+					"172.17.0.1:38435",
+					"172.18.0.1:38435",
+					"172.19.0.1:38435",
+					"172.20.0.1:38435",
+					"172.21.0.1:38435",
+					"172.22.0.1:38435",
+					"172.23.0.1:38435",
+					"172.24.0.1:38435",
+					"172.25.0.1:38435",
+					"172.26.0.1:38435",
+					"172.27.0.1:38435",
+					"172.28.0.1:38435",
+					"172.29.0.1:38435"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:07:05.383804209Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2953439583137982,
+				"StableID":   "nf3EPHrc4Q11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6830c6e8462e7666dd6a590afa47674215e85c774bdb08585ef9c53d213dd83e",
+				"KeyExpiry":  "2026-11-09T09:07:05Z",
+				"DiscoKey":   "discokey:b73ed43ae299905067eef8003960a36279ceaaae6ddefc591c1a43ddb6a7377f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60165",
+					"10.65.0.27:60165",
+					"172.17.0.1:60165",
+					"172.18.0.1:60165",
+					"172.19.0.1:60165",
+					"172.20.0.1:60165",
+					"172.21.0.1:60165",
+					"172.22.0.1:60165",
+					"172.23.0.1:60165",
+					"172.24.0.1:60165",
+					"172.25.0.1:60165",
+					"172.26.0.1:60165",
+					"172.27.0.1:60165",
+					"172.28.0.1:60165",
+					"172.29.0.1:60165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:07:05.932371484Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3527482195521367,
+				"StableID":   "nrLjKbybYU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       3527482195521367,
+				"Key":        "nodekey:31ed2c7eee6a2a519a5ff44c629b248934b3621cbf0e1bb65f4c91f09bcc8f5a",
+				"DiscoKey":   "discokey:a6fb79615ab1925f1c3ce0b5524724ffca017d3975fae0f63d1ce6a1ff5d6068",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39256",
+					"10.65.0.27:39256",
+					"172.17.0.1:39256",
+					"172.18.0.1:39256",
+					"172.19.0.1:39256",
+					"172.20.0.1:39256",
+					"172.21.0.1:39256",
+					"172.22.0.1:39256",
+					"172.23.0.1:39256",
+					"172.24.0.1:39256",
+					"172.25.0.1:39256",
+					"172.26.0.1:39256",
+					"172.27.0.1:39256",
+					"172.28.0.1:39256",
+					"172.29.0.1:39256"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:07:00.014319028Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:31ed2c7eee6a2a519a5ff44c629b248934b3621cbf0e1bb65f4c91f09bcc8f5a",
+			"MachineKey": "mkey:62b636c63d84940c0cab1ef252ffe4ea2b78e4bcbbe13821ea74ef37a8da3052",
+			"Peers": [{
+				"ID":         976708517211670,
+				"StableID":   "nsHv5eUMd811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:693f1096b5e38d38a2b4800cf64b8f3b97a0bf724420b872578cc1b5b9eda42f",
+				"DiscoKey":   "discokey:7809cb165bed2d629ee21964fa7edd13ba3fdfeaed8ed719f54bad6de3052d56",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47993",
+					"10.65.0.27:47993",
+					"172.17.0.1:47993",
+					"172.18.0.1:47993",
+					"172.19.0.1:47993",
+					"172.20.0.1:47993",
+					"172.21.0.1:47993",
+					"172.22.0.1:47993",
+					"172.23.0.1:47993",
+					"172.24.0.1:47993",
+					"172.25.0.1:47993",
+					"172.26.0.1:47993",
+					"172.27.0.1:47993",
+					"172.28.0.1:47993",
+					"172.29.0.1:47993"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:06:58.5101451Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3824448112674477,
+				"StableID":   "n4nZWUm6sW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07ec7614be9264bf4da7497e9aa2186bb3a3941c4044f10786082d5ef35f904d",
+				"DiscoKey":   "discokey:5b605feff2417171183d7c886260b3613ac1239dc192a53931081d5d0fbcf26e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34807",
+					"10.65.0.27:34807",
+					"172.17.0.1:34807",
+					"172.18.0.1:34807",
+					"172.19.0.1:34807",
+					"172.20.0.1:34807",
+					"172.21.0.1:34807",
+					"172.22.0.1:34807",
+					"172.23.0.1:34807",
+					"172.24.0.1:34807",
+					"172.25.0.1:34807",
+					"172.26.0.1:34807",
+					"172.27.0.1:34807",
+					"172.28.0.1:34807",
+					"172.29.0.1:34807"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:06:59.334581139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2903606537190410,
+				"StableID":   "nj5ykZp3gP11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:50474b8b720f0f07fe21708a7bfb204fd00e64b0d318e5d3f321efd94be5dd42",
+				"DiscoKey":   "discokey:40cefa0618560ff7da77043eb69538848235b60f6c6374ae9b99f443eb06d454",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42842",
+					"10.65.0.27:42842",
+					"172.17.0.1:42842",
+					"172.18.0.1:42842",
+					"172.19.0.1:42842",
+					"172.20.0.1:42842",
+					"172.21.0.1:42842",
+					"172.22.0.1:42842",
+					"172.23.0.1:42842",
+					"172.24.0.1:42842",
+					"172.25.0.1:42842",
+					"172.26.0.1:42842",
+					"172.27.0.1:42842",
+					"172.28.0.1:42842",
+					"172.29.0.1:42842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:07:00.548368106Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6827040522615864,
+				"StableID":   "nuh8t7nyJv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b70152198f5e5e86aa84e79227f3d4d80441aebb5a39f806d59a74b9d5222506",
+				"DiscoKey":   "discokey:52277daa5b055ee6f2d00161a303f0ee0cfc022c757889c427beb190cd60d31e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:35029",
+					"10.65.0.27:35029",
+					"172.17.0.1:35029",
+					"172.18.0.1:35029",
+					"172.19.0.1:35029",
+					"172.20.0.1:35029",
+					"172.21.0.1:35029",
+					"172.22.0.1:35029",
+					"172.23.0.1:35029",
+					"172.24.0.1:35029",
+					"172.25.0.1:35029",
+					"172.26.0.1:35029",
+					"172.27.0.1:35029",
+					"172.28.0.1:35029",
+					"172.29.0.1:35029"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:07:01.089113953Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3188121042143300,
+				"StableID":   "nV5dHxXutR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:887ef6d4915e34fee99dfedda47ac9cf2596688c580675a42c3471cbebaafb11",
+				"DiscoKey":   "discokey:2ae1bcb848319c1aca0fd76bfbab00b41b9a056fb6d0dae31f6aa5830be38037",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:60559",
+					"10.65.0.27:60559",
+					"172.17.0.1:60559",
+					"172.18.0.1:60559",
+					"172.19.0.1:60559",
+					"172.20.0.1:60559",
+					"172.21.0.1:60559",
+					"172.22.0.1:60559",
+					"172.23.0.1:60559",
+					"172.24.0.1:60559",
+					"172.25.0.1:60559",
+					"172.26.0.1:60559",
+					"172.27.0.1:60559",
+					"172.28.0.1:60559",
+					"172.29.0.1:60559"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:07:01.638082773Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6026571109877032,
+				"StableID":   "njzUxcoS4p11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:18586a46b864c2ca115fc1b02bd9e189004f83438da40203ca9ae750b6d4867c",
+				"DiscoKey":   "discokey:e6c914d964da958f5bccd1e0f0438649f10177c7d2e94160426c49c294bd9550",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:46267",
+					"10.65.0.27:46267",
+					"172.17.0.1:46267",
+					"172.18.0.1:46267",
+					"172.19.0.1:46267",
+					"172.20.0.1:46267",
+					"172.21.0.1:46267",
+					"172.22.0.1:46267",
+					"172.23.0.1:46267",
+					"172.24.0.1:46267",
+					"172.25.0.1:46267",
+					"172.26.0.1:46267",
+					"172.27.0.1:46267",
+					"172.28.0.1:46267",
+					"172.29.0.1:46267"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:07:02.178830239Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3109318643116652,
+				"StableID":   "nuoa8eXDHR11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:19240fa0357506dc89722122edbf677041158ff71a947bea5301ae9c01c8847d",
+				"DiscoKey":   "discokey:63786a4d32cbdd73773c1a731cccfcf782e3f8550ffbca4137dca2792e753f53",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45928",
+					"10.65.0.27:45928",
+					"172.17.0.1:45928",
+					"172.18.0.1:45928",
+					"172.19.0.1:45928",
+					"172.20.0.1:45928",
+					"172.21.0.1:45928",
+					"172.22.0.1:45928",
+					"172.23.0.1:45928",
+					"172.24.0.1:45928",
+					"172.25.0.1:45928",
+					"172.26.0.1:45928",
+					"172.27.0.1:45928",
+					"172.28.0.1:45928",
+					"172.29.0.1:45928"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:07:02.713673659Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3420985025326015,
+				"StableID":   "nSxM5bUNiT11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5179e958e1bcee53b917d23980ecb7580fd7aee87073e51dc5a7ac5c512f305e",
+				"DiscoKey":   "discokey:ed27a9ec853c0b52ea58ff8f9db55ff7786750fd95ab32910c43367c0fc9001f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41518",
+					"10.65.0.27:41518",
+					"172.17.0.1:41518",
+					"172.18.0.1:41518",
+					"172.19.0.1:41518",
+					"172.20.0.1:41518",
+					"172.21.0.1:41518",
+					"172.22.0.1:41518",
+					"172.23.0.1:41518",
+					"172.24.0.1:41518",
+					"172.25.0.1:41518",
+					"172.26.0.1:41518",
+					"172.27.0.1:41518",
+					"172.28.0.1:41518",
+					"172.29.0.1:41518"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:07:03.260242351Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8235423448387682,
+				"StableID":   "n3PaFLcqJ721CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b5bd7a97c7b00c217cd2bd9c077b9354d5aa216043ed9106a7fd0e084372c14",
+				"DiscoKey":   "discokey:25bb0bccd6af1bce680c5e620b367bc67f38ade3332b6caae7f29431e703bd17",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53023",
+					"10.65.0.27:53023",
+					"172.17.0.1:53023",
+					"172.18.0.1:53023",
+					"172.19.0.1:53023",
+					"172.20.0.1:53023",
+					"172.21.0.1:53023",
+					"172.22.0.1:53023",
+					"172.23.0.1:53023",
+					"172.24.0.1:53023",
+					"172.25.0.1:53023",
+					"172.26.0.1:53023",
+					"172.27.0.1:53023",
+					"172.28.0.1:53023",
+					"172.29.0.1:53023"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:07:03.775745436Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1396844734654740,
+				"StableID":   "nM72w4kduB11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ffa1cbd6a2ef321eeb0ae907edbcab63a8bbdb2ae06102448a673f222c10f454",
+				"DiscoKey":   "discokey:b515939689ab44b6c96e494f002870bab12a3d1aea7d3ef97c22f85d7f720437",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37085",
+					"10.65.0.27:37085",
+					"172.17.0.1:37085",
+					"172.18.0.1:37085",
+					"172.19.0.1:37085",
+					"172.20.0.1:37085",
+					"172.21.0.1:37085",
+					"172.22.0.1:37085",
+					"172.23.0.1:37085",
+					"172.24.0.1:37085",
+					"172.25.0.1:37085",
+					"172.26.0.1:37085",
+					"172.27.0.1:37085",
+					"172.28.0.1:37085",
+					"172.29.0.1:37085"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:07:04.313556266Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3311208731492109,
+				"StableID":   "nCnDudqerS11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ece627c2d681eb4dc892f1b7f6eb3f672f6ab30d8c9a74feef6ada7722408a3c",
+				"DiscoKey":   "discokey:4f273464c671a879a1b4ca54203699d36d08f96ee1e7ab2bc1049b3cac09b347",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48595",
+					"10.65.0.27:48595",
+					"172.17.0.1:48595",
+					"172.18.0.1:48595",
+					"172.19.0.1:48595",
+					"172.20.0.1:48595",
+					"172.21.0.1:48595",
+					"172.22.0.1:48595",
+					"172.23.0.1:48595",
+					"172.24.0.1:48595",
+					"172.25.0.1:48595",
+					"172.26.0.1:48595",
+					"172.27.0.1:48595",
+					"172.28.0.1:48595",
+					"172.29.0.1:48595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:07:04.850360367Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7777277844117688,
+				"StableID":   "nw4n3GuLj321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:fa9004d8608a8f81c8df29395b2d8d3fa28defaa757cad8b431c5b3f3f54f504",
+				"KeyExpiry":  "2026-11-09T09:07:05Z",
+				"DiscoKey":   "discokey:a5b588857f4ff1a08e43b2d51eb969e370953bf7c1f8a5a69b9e0bbe1e992234",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38435",
+					"10.65.0.27:38435",
+					"172.17.0.1:38435",
+					"172.18.0.1:38435",
+					"172.19.0.1:38435",
+					"172.20.0.1:38435",
+					"172.21.0.1:38435",
+					"172.22.0.1:38435",
+					"172.23.0.1:38435",
+					"172.24.0.1:38435",
+					"172.25.0.1:38435",
+					"172.26.0.1:38435",
+					"172.27.0.1:38435",
+					"172.28.0.1:38435",
+					"172.29.0.1:38435"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:07:05.383804209Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2953439583137982,
+				"StableID":   "nf3EPHrc4Q11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6830c6e8462e7666dd6a590afa47674215e85c774bdb08585ef9c53d213dd83e",
+				"KeyExpiry":  "2026-11-09T09:07:05Z",
+				"DiscoKey":   "discokey:b73ed43ae299905067eef8003960a36279ceaaae6ddefc591c1a43ddb6a7377f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60165",
+					"10.65.0.27:60165",
+					"172.17.0.1:60165",
+					"172.18.0.1:60165",
+					"172.19.0.1:60165",
+					"172.20.0.1:60165",
+					"172.21.0.1:60165",
+					"172.22.0.1:60165",
+					"172.23.0.1:60165",
+					"172.24.0.1:60165",
+					"172.25.0.1:60165",
+					"172.26.0.1:60165",
+					"172.27.0.1:60165",
+					"172.28.0.1:60165",
+					"172.29.0.1:60165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:07:05.932371484Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6510634174200293,
+				"StableID":   "nvPaMYKgqs11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3db8e6ea02db37d77b3e725aebaddecd8e814a3d1a629b8786902d3594c12b22",
+				"KeyExpiry":  "2026-11-09T09:07:06Z",
+				"DiscoKey":   "discokey:dafff3180c3e748f84e9f52f7b5eb38cacc3d17037d6caffb6f482081346a31b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38090",
+					"10.65.0.27:38090",
+					"172.17.0.1:38090",
+					"172.18.0.1:38090",
+					"172.19.0.1:38090",
+					"172.20.0.1:38090",
+					"172.21.0.1:38090",
+					"172.22.0.1:38090",
+					"172.23.0.1:38090",
+					"172.24.0.1:38090",
+					"172.25.0.1:38090",
+					"172.26.0.1:38090",
+					"172.27.0.1:38090",
+					"172.28.0.1:38090",
+					"172.29.0.1:38090"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:07:06.470237579Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3527482195521367": {
+				"ID":          3527482195521367,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3109318643116652,
+				"StableID":   "nuoa8eXDHR11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       3109318643116652,
+				"Key":        "nodekey:19240fa0357506dc89722122edbf677041158ff71a947bea5301ae9c01c8847d",
+				"DiscoKey":   "discokey:63786a4d32cbdd73773c1a731cccfcf782e3f8550ffbca4137dca2792e753f53",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45928",
+					"10.65.0.27:45928",
+					"172.17.0.1:45928",
+					"172.18.0.1:45928",
+					"172.19.0.1:45928",
+					"172.20.0.1:45928",
+					"172.21.0.1:45928",
+					"172.22.0.1:45928",
+					"172.23.0.1:45928",
+					"172.24.0.1:45928",
+					"172.25.0.1:45928",
+					"172.26.0.1:45928",
+					"172.27.0.1:45928",
+					"172.28.0.1:45928",
+					"172.29.0.1:45928"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:07:02.713673659Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:19240fa0357506dc89722122edbf677041158ff71a947bea5301ae9c01c8847d",
+			"MachineKey": "mkey:2e6d45a609fe48bff190e4f8dc16d7ca6ae2ffe8231a1b91361d236ecb2a987a",
+			"Peers": [{
+				"ID":         976708517211670,
+				"StableID":   "nsHv5eUMd811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:693f1096b5e38d38a2b4800cf64b8f3b97a0bf724420b872578cc1b5b9eda42f",
+				"DiscoKey":   "discokey:7809cb165bed2d629ee21964fa7edd13ba3fdfeaed8ed719f54bad6de3052d56",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47993",
+					"10.65.0.27:47993",
+					"172.17.0.1:47993",
+					"172.18.0.1:47993",
+					"172.19.0.1:47993",
+					"172.20.0.1:47993",
+					"172.21.0.1:47993",
+					"172.22.0.1:47993",
+					"172.23.0.1:47993",
+					"172.24.0.1:47993",
+					"172.25.0.1:47993",
+					"172.26.0.1:47993",
+					"172.27.0.1:47993",
+					"172.28.0.1:47993",
+					"172.29.0.1:47993"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:06:58.5101451Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3824448112674477,
+				"StableID":   "n4nZWUm6sW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07ec7614be9264bf4da7497e9aa2186bb3a3941c4044f10786082d5ef35f904d",
+				"DiscoKey":   "discokey:5b605feff2417171183d7c886260b3613ac1239dc192a53931081d5d0fbcf26e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34807",
+					"10.65.0.27:34807",
+					"172.17.0.1:34807",
+					"172.18.0.1:34807",
+					"172.19.0.1:34807",
+					"172.20.0.1:34807",
+					"172.21.0.1:34807",
+					"172.22.0.1:34807",
+					"172.23.0.1:34807",
+					"172.24.0.1:34807",
+					"172.25.0.1:34807",
+					"172.26.0.1:34807",
+					"172.27.0.1:34807",
+					"172.28.0.1:34807",
+					"172.29.0.1:34807"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:06:59.334581139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3527482195521367,
+				"StableID":   "nrLjKbybYU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31ed2c7eee6a2a519a5ff44c629b248934b3621cbf0e1bb65f4c91f09bcc8f5a",
+				"DiscoKey":   "discokey:a6fb79615ab1925f1c3ce0b5524724ffca017d3975fae0f63d1ce6a1ff5d6068",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39256",
+					"10.65.0.27:39256",
+					"172.17.0.1:39256",
+					"172.18.0.1:39256",
+					"172.19.0.1:39256",
+					"172.20.0.1:39256",
+					"172.21.0.1:39256",
+					"172.22.0.1:39256",
+					"172.23.0.1:39256",
+					"172.24.0.1:39256",
+					"172.25.0.1:39256",
+					"172.26.0.1:39256",
+					"172.27.0.1:39256",
+					"172.28.0.1:39256",
+					"172.29.0.1:39256"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:07:00.014319028Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2903606537190410,
+				"StableID":   "nj5ykZp3gP11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:50474b8b720f0f07fe21708a7bfb204fd00e64b0d318e5d3f321efd94be5dd42",
+				"DiscoKey":   "discokey:40cefa0618560ff7da77043eb69538848235b60f6c6374ae9b99f443eb06d454",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42842",
+					"10.65.0.27:42842",
+					"172.17.0.1:42842",
+					"172.18.0.1:42842",
+					"172.19.0.1:42842",
+					"172.20.0.1:42842",
+					"172.21.0.1:42842",
+					"172.22.0.1:42842",
+					"172.23.0.1:42842",
+					"172.24.0.1:42842",
+					"172.25.0.1:42842",
+					"172.26.0.1:42842",
+					"172.27.0.1:42842",
+					"172.28.0.1:42842",
+					"172.29.0.1:42842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:07:00.548368106Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6827040522615864,
+				"StableID":   "nuh8t7nyJv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b70152198f5e5e86aa84e79227f3d4d80441aebb5a39f806d59a74b9d5222506",
+				"DiscoKey":   "discokey:52277daa5b055ee6f2d00161a303f0ee0cfc022c757889c427beb190cd60d31e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:35029",
+					"10.65.0.27:35029",
+					"172.17.0.1:35029",
+					"172.18.0.1:35029",
+					"172.19.0.1:35029",
+					"172.20.0.1:35029",
+					"172.21.0.1:35029",
+					"172.22.0.1:35029",
+					"172.23.0.1:35029",
+					"172.24.0.1:35029",
+					"172.25.0.1:35029",
+					"172.26.0.1:35029",
+					"172.27.0.1:35029",
+					"172.28.0.1:35029",
+					"172.29.0.1:35029"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:07:01.089113953Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3188121042143300,
+				"StableID":   "nV5dHxXutR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:887ef6d4915e34fee99dfedda47ac9cf2596688c580675a42c3471cbebaafb11",
+				"DiscoKey":   "discokey:2ae1bcb848319c1aca0fd76bfbab00b41b9a056fb6d0dae31f6aa5830be38037",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:60559",
+					"10.65.0.27:60559",
+					"172.17.0.1:60559",
+					"172.18.0.1:60559",
+					"172.19.0.1:60559",
+					"172.20.0.1:60559",
+					"172.21.0.1:60559",
+					"172.22.0.1:60559",
+					"172.23.0.1:60559",
+					"172.24.0.1:60559",
+					"172.25.0.1:60559",
+					"172.26.0.1:60559",
+					"172.27.0.1:60559",
+					"172.28.0.1:60559",
+					"172.29.0.1:60559"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:07:01.638082773Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6026571109877032,
+				"StableID":   "njzUxcoS4p11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:18586a46b864c2ca115fc1b02bd9e189004f83438da40203ca9ae750b6d4867c",
+				"DiscoKey":   "discokey:e6c914d964da958f5bccd1e0f0438649f10177c7d2e94160426c49c294bd9550",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:46267",
+					"10.65.0.27:46267",
+					"172.17.0.1:46267",
+					"172.18.0.1:46267",
+					"172.19.0.1:46267",
+					"172.20.0.1:46267",
+					"172.21.0.1:46267",
+					"172.22.0.1:46267",
+					"172.23.0.1:46267",
+					"172.24.0.1:46267",
+					"172.25.0.1:46267",
+					"172.26.0.1:46267",
+					"172.27.0.1:46267",
+					"172.28.0.1:46267",
+					"172.29.0.1:46267"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:07:02.178830239Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3420985025326015,
+				"StableID":   "nSxM5bUNiT11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5179e958e1bcee53b917d23980ecb7580fd7aee87073e51dc5a7ac5c512f305e",
+				"DiscoKey":   "discokey:ed27a9ec853c0b52ea58ff8f9db55ff7786750fd95ab32910c43367c0fc9001f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41518",
+					"10.65.0.27:41518",
+					"172.17.0.1:41518",
+					"172.18.0.1:41518",
+					"172.19.0.1:41518",
+					"172.20.0.1:41518",
+					"172.21.0.1:41518",
+					"172.22.0.1:41518",
+					"172.23.0.1:41518",
+					"172.24.0.1:41518",
+					"172.25.0.1:41518",
+					"172.26.0.1:41518",
+					"172.27.0.1:41518",
+					"172.28.0.1:41518",
+					"172.29.0.1:41518"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:07:03.260242351Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8235423448387682,
+				"StableID":   "n3PaFLcqJ721CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b5bd7a97c7b00c217cd2bd9c077b9354d5aa216043ed9106a7fd0e084372c14",
+				"DiscoKey":   "discokey:25bb0bccd6af1bce680c5e620b367bc67f38ade3332b6caae7f29431e703bd17",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53023",
+					"10.65.0.27:53023",
+					"172.17.0.1:53023",
+					"172.18.0.1:53023",
+					"172.19.0.1:53023",
+					"172.20.0.1:53023",
+					"172.21.0.1:53023",
+					"172.22.0.1:53023",
+					"172.23.0.1:53023",
+					"172.24.0.1:53023",
+					"172.25.0.1:53023",
+					"172.26.0.1:53023",
+					"172.27.0.1:53023",
+					"172.28.0.1:53023",
+					"172.29.0.1:53023"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:07:03.775745436Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1396844734654740,
+				"StableID":   "nM72w4kduB11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ffa1cbd6a2ef321eeb0ae907edbcab63a8bbdb2ae06102448a673f222c10f454",
+				"DiscoKey":   "discokey:b515939689ab44b6c96e494f002870bab12a3d1aea7d3ef97c22f85d7f720437",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37085",
+					"10.65.0.27:37085",
+					"172.17.0.1:37085",
+					"172.18.0.1:37085",
+					"172.19.0.1:37085",
+					"172.20.0.1:37085",
+					"172.21.0.1:37085",
+					"172.22.0.1:37085",
+					"172.23.0.1:37085",
+					"172.24.0.1:37085",
+					"172.25.0.1:37085",
+					"172.26.0.1:37085",
+					"172.27.0.1:37085",
+					"172.28.0.1:37085",
+					"172.29.0.1:37085"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:07:04.313556266Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3311208731492109,
+				"StableID":   "nCnDudqerS11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ece627c2d681eb4dc892f1b7f6eb3f672f6ab30d8c9a74feef6ada7722408a3c",
+				"DiscoKey":   "discokey:4f273464c671a879a1b4ca54203699d36d08f96ee1e7ab2bc1049b3cac09b347",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48595",
+					"10.65.0.27:48595",
+					"172.17.0.1:48595",
+					"172.18.0.1:48595",
+					"172.19.0.1:48595",
+					"172.20.0.1:48595",
+					"172.21.0.1:48595",
+					"172.22.0.1:48595",
+					"172.23.0.1:48595",
+					"172.24.0.1:48595",
+					"172.25.0.1:48595",
+					"172.26.0.1:48595",
+					"172.27.0.1:48595",
+					"172.28.0.1:48595",
+					"172.29.0.1:48595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:07:04.850360367Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7777277844117688,
+				"StableID":   "nw4n3GuLj321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:fa9004d8608a8f81c8df29395b2d8d3fa28defaa757cad8b431c5b3f3f54f504",
+				"KeyExpiry":  "2026-11-09T09:07:05Z",
+				"DiscoKey":   "discokey:a5b588857f4ff1a08e43b2d51eb969e370953bf7c1f8a5a69b9e0bbe1e992234",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38435",
+					"10.65.0.27:38435",
+					"172.17.0.1:38435",
+					"172.18.0.1:38435",
+					"172.19.0.1:38435",
+					"172.20.0.1:38435",
+					"172.21.0.1:38435",
+					"172.22.0.1:38435",
+					"172.23.0.1:38435",
+					"172.24.0.1:38435",
+					"172.25.0.1:38435",
+					"172.26.0.1:38435",
+					"172.27.0.1:38435",
+					"172.28.0.1:38435",
+					"172.29.0.1:38435"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:07:05.383804209Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2953439583137982,
+				"StableID":   "nf3EPHrc4Q11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6830c6e8462e7666dd6a590afa47674215e85c774bdb08585ef9c53d213dd83e",
+				"KeyExpiry":  "2026-11-09T09:07:05Z",
+				"DiscoKey":   "discokey:b73ed43ae299905067eef8003960a36279ceaaae6ddefc591c1a43ddb6a7377f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60165",
+					"10.65.0.27:60165",
+					"172.17.0.1:60165",
+					"172.18.0.1:60165",
+					"172.19.0.1:60165",
+					"172.20.0.1:60165",
+					"172.21.0.1:60165",
+					"172.22.0.1:60165",
+					"172.23.0.1:60165",
+					"172.24.0.1:60165",
+					"172.25.0.1:60165",
+					"172.26.0.1:60165",
+					"172.27.0.1:60165",
+					"172.28.0.1:60165",
+					"172.29.0.1:60165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:07:05.932371484Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6510634174200293,
+				"StableID":   "nvPaMYKgqs11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3db8e6ea02db37d77b3e725aebaddecd8e814a3d1a629b8786902d3594c12b22",
+				"KeyExpiry":  "2026-11-09T09:07:06Z",
+				"DiscoKey":   "discokey:dafff3180c3e748f84e9f52f7b5eb38cacc3d17037d6caffb6f482081346a31b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38090",
+					"10.65.0.27:38090",
+					"172.17.0.1:38090",
+					"172.18.0.1:38090",
+					"172.19.0.1:38090",
+					"172.20.0.1:38090",
+					"172.21.0.1:38090",
+					"172.22.0.1:38090",
+					"172.23.0.1:38090",
+					"172.24.0.1:38090",
+					"172.25.0.1:38090",
+					"172.26.0.1:38090",
+					"172.27.0.1:38090",
+					"172.28.0.1:38090",
+					"172.29.0.1:38090"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:07:06.470237579Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3109318643116652": {
+				"ID":          3109318643116652,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7777277844117688,
+				"StableID":   "nw4n3GuLj321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:fa9004d8608a8f81c8df29395b2d8d3fa28defaa757cad8b431c5b3f3f54f504",
+				"KeyExpiry":  "2026-11-09T09:07:05Z",
+				"DiscoKey":   "discokey:a5b588857f4ff1a08e43b2d51eb969e370953bf7c1f8a5a69b9e0bbe1e992234",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38435",
+					"10.65.0.27:38435",
+					"172.17.0.1:38435",
+					"172.18.0.1:38435",
+					"172.19.0.1:38435",
+					"172.20.0.1:38435",
+					"172.21.0.1:38435",
+					"172.22.0.1:38435",
+					"172.23.0.1:38435",
+					"172.24.0.1:38435",
+					"172.25.0.1:38435",
+					"172.26.0.1:38435",
+					"172.27.0.1:38435",
+					"172.28.0.1:38435",
+					"172.29.0.1:38435"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:07:05.383804209Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:fa9004d8608a8f81c8df29395b2d8d3fa28defaa757cad8b431c5b3f3f54f504",
+			"MachineKey": "mkey:97e9f30d11869a28315f0ab24271efad328e2aabe32e1919af6bb4f3813ab05c",
+			"Peers": [{
+				"ID":         976708517211670,
+				"StableID":   "nsHv5eUMd811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:693f1096b5e38d38a2b4800cf64b8f3b97a0bf724420b872578cc1b5b9eda42f",
+				"DiscoKey":   "discokey:7809cb165bed2d629ee21964fa7edd13ba3fdfeaed8ed719f54bad6de3052d56",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47993",
+					"10.65.0.27:47993",
+					"172.17.0.1:47993",
+					"172.18.0.1:47993",
+					"172.19.0.1:47993",
+					"172.20.0.1:47993",
+					"172.21.0.1:47993",
+					"172.22.0.1:47993",
+					"172.23.0.1:47993",
+					"172.24.0.1:47993",
+					"172.25.0.1:47993",
+					"172.26.0.1:47993",
+					"172.27.0.1:47993",
+					"172.28.0.1:47993",
+					"172.29.0.1:47993"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:06:58.5101451Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3824448112674477,
+				"StableID":   "n4nZWUm6sW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07ec7614be9264bf4da7497e9aa2186bb3a3941c4044f10786082d5ef35f904d",
+				"DiscoKey":   "discokey:5b605feff2417171183d7c886260b3613ac1239dc192a53931081d5d0fbcf26e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34807",
+					"10.65.0.27:34807",
+					"172.17.0.1:34807",
+					"172.18.0.1:34807",
+					"172.19.0.1:34807",
+					"172.20.0.1:34807",
+					"172.21.0.1:34807",
+					"172.22.0.1:34807",
+					"172.23.0.1:34807",
+					"172.24.0.1:34807",
+					"172.25.0.1:34807",
+					"172.26.0.1:34807",
+					"172.27.0.1:34807",
+					"172.28.0.1:34807",
+					"172.29.0.1:34807"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:06:59.334581139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3527482195521367,
+				"StableID":   "nrLjKbybYU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31ed2c7eee6a2a519a5ff44c629b248934b3621cbf0e1bb65f4c91f09bcc8f5a",
+				"DiscoKey":   "discokey:a6fb79615ab1925f1c3ce0b5524724ffca017d3975fae0f63d1ce6a1ff5d6068",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39256",
+					"10.65.0.27:39256",
+					"172.17.0.1:39256",
+					"172.18.0.1:39256",
+					"172.19.0.1:39256",
+					"172.20.0.1:39256",
+					"172.21.0.1:39256",
+					"172.22.0.1:39256",
+					"172.23.0.1:39256",
+					"172.24.0.1:39256",
+					"172.25.0.1:39256",
+					"172.26.0.1:39256",
+					"172.27.0.1:39256",
+					"172.28.0.1:39256",
+					"172.29.0.1:39256"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:07:00.014319028Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2903606537190410,
+				"StableID":   "nj5ykZp3gP11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:50474b8b720f0f07fe21708a7bfb204fd00e64b0d318e5d3f321efd94be5dd42",
+				"DiscoKey":   "discokey:40cefa0618560ff7da77043eb69538848235b60f6c6374ae9b99f443eb06d454",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42842",
+					"10.65.0.27:42842",
+					"172.17.0.1:42842",
+					"172.18.0.1:42842",
+					"172.19.0.1:42842",
+					"172.20.0.1:42842",
+					"172.21.0.1:42842",
+					"172.22.0.1:42842",
+					"172.23.0.1:42842",
+					"172.24.0.1:42842",
+					"172.25.0.1:42842",
+					"172.26.0.1:42842",
+					"172.27.0.1:42842",
+					"172.28.0.1:42842",
+					"172.29.0.1:42842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:07:00.548368106Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6827040522615864,
+				"StableID":   "nuh8t7nyJv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b70152198f5e5e86aa84e79227f3d4d80441aebb5a39f806d59a74b9d5222506",
+				"DiscoKey":   "discokey:52277daa5b055ee6f2d00161a303f0ee0cfc022c757889c427beb190cd60d31e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:35029",
+					"10.65.0.27:35029",
+					"172.17.0.1:35029",
+					"172.18.0.1:35029",
+					"172.19.0.1:35029",
+					"172.20.0.1:35029",
+					"172.21.0.1:35029",
+					"172.22.0.1:35029",
+					"172.23.0.1:35029",
+					"172.24.0.1:35029",
+					"172.25.0.1:35029",
+					"172.26.0.1:35029",
+					"172.27.0.1:35029",
+					"172.28.0.1:35029",
+					"172.29.0.1:35029"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:07:01.089113953Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3188121042143300,
+				"StableID":   "nV5dHxXutR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:887ef6d4915e34fee99dfedda47ac9cf2596688c580675a42c3471cbebaafb11",
+				"DiscoKey":   "discokey:2ae1bcb848319c1aca0fd76bfbab00b41b9a056fb6d0dae31f6aa5830be38037",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:60559",
+					"10.65.0.27:60559",
+					"172.17.0.1:60559",
+					"172.18.0.1:60559",
+					"172.19.0.1:60559",
+					"172.20.0.1:60559",
+					"172.21.0.1:60559",
+					"172.22.0.1:60559",
+					"172.23.0.1:60559",
+					"172.24.0.1:60559",
+					"172.25.0.1:60559",
+					"172.26.0.1:60559",
+					"172.27.0.1:60559",
+					"172.28.0.1:60559",
+					"172.29.0.1:60559"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:07:01.638082773Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6026571109877032,
+				"StableID":   "njzUxcoS4p11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:18586a46b864c2ca115fc1b02bd9e189004f83438da40203ca9ae750b6d4867c",
+				"DiscoKey":   "discokey:e6c914d964da958f5bccd1e0f0438649f10177c7d2e94160426c49c294bd9550",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:46267",
+					"10.65.0.27:46267",
+					"172.17.0.1:46267",
+					"172.18.0.1:46267",
+					"172.19.0.1:46267",
+					"172.20.0.1:46267",
+					"172.21.0.1:46267",
+					"172.22.0.1:46267",
+					"172.23.0.1:46267",
+					"172.24.0.1:46267",
+					"172.25.0.1:46267",
+					"172.26.0.1:46267",
+					"172.27.0.1:46267",
+					"172.28.0.1:46267",
+					"172.29.0.1:46267"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:07:02.178830239Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3109318643116652,
+				"StableID":   "nuoa8eXDHR11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:19240fa0357506dc89722122edbf677041158ff71a947bea5301ae9c01c8847d",
+				"DiscoKey":   "discokey:63786a4d32cbdd73773c1a731cccfcf782e3f8550ffbca4137dca2792e753f53",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45928",
+					"10.65.0.27:45928",
+					"172.17.0.1:45928",
+					"172.18.0.1:45928",
+					"172.19.0.1:45928",
+					"172.20.0.1:45928",
+					"172.21.0.1:45928",
+					"172.22.0.1:45928",
+					"172.23.0.1:45928",
+					"172.24.0.1:45928",
+					"172.25.0.1:45928",
+					"172.26.0.1:45928",
+					"172.27.0.1:45928",
+					"172.28.0.1:45928",
+					"172.29.0.1:45928"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:07:02.713673659Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3420985025326015,
+				"StableID":   "nSxM5bUNiT11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5179e958e1bcee53b917d23980ecb7580fd7aee87073e51dc5a7ac5c512f305e",
+				"DiscoKey":   "discokey:ed27a9ec853c0b52ea58ff8f9db55ff7786750fd95ab32910c43367c0fc9001f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41518",
+					"10.65.0.27:41518",
+					"172.17.0.1:41518",
+					"172.18.0.1:41518",
+					"172.19.0.1:41518",
+					"172.20.0.1:41518",
+					"172.21.0.1:41518",
+					"172.22.0.1:41518",
+					"172.23.0.1:41518",
+					"172.24.0.1:41518",
+					"172.25.0.1:41518",
+					"172.26.0.1:41518",
+					"172.27.0.1:41518",
+					"172.28.0.1:41518",
+					"172.29.0.1:41518"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:07:03.260242351Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8235423448387682,
+				"StableID":   "n3PaFLcqJ721CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b5bd7a97c7b00c217cd2bd9c077b9354d5aa216043ed9106a7fd0e084372c14",
+				"DiscoKey":   "discokey:25bb0bccd6af1bce680c5e620b367bc67f38ade3332b6caae7f29431e703bd17",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53023",
+					"10.65.0.27:53023",
+					"172.17.0.1:53023",
+					"172.18.0.1:53023",
+					"172.19.0.1:53023",
+					"172.20.0.1:53023",
+					"172.21.0.1:53023",
+					"172.22.0.1:53023",
+					"172.23.0.1:53023",
+					"172.24.0.1:53023",
+					"172.25.0.1:53023",
+					"172.26.0.1:53023",
+					"172.27.0.1:53023",
+					"172.28.0.1:53023",
+					"172.29.0.1:53023"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:07:03.775745436Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1396844734654740,
+				"StableID":   "nM72w4kduB11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ffa1cbd6a2ef321eeb0ae907edbcab63a8bbdb2ae06102448a673f222c10f454",
+				"DiscoKey":   "discokey:b515939689ab44b6c96e494f002870bab12a3d1aea7d3ef97c22f85d7f720437",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37085",
+					"10.65.0.27:37085",
+					"172.17.0.1:37085",
+					"172.18.0.1:37085",
+					"172.19.0.1:37085",
+					"172.20.0.1:37085",
+					"172.21.0.1:37085",
+					"172.22.0.1:37085",
+					"172.23.0.1:37085",
+					"172.24.0.1:37085",
+					"172.25.0.1:37085",
+					"172.26.0.1:37085",
+					"172.27.0.1:37085",
+					"172.28.0.1:37085",
+					"172.29.0.1:37085"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:07:04.313556266Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3311208731492109,
+				"StableID":   "nCnDudqerS11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ece627c2d681eb4dc892f1b7f6eb3f672f6ab30d8c9a74feef6ada7722408a3c",
+				"DiscoKey":   "discokey:4f273464c671a879a1b4ca54203699d36d08f96ee1e7ab2bc1049b3cac09b347",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48595",
+					"10.65.0.27:48595",
+					"172.17.0.1:48595",
+					"172.18.0.1:48595",
+					"172.19.0.1:48595",
+					"172.20.0.1:48595",
+					"172.21.0.1:48595",
+					"172.22.0.1:48595",
+					"172.23.0.1:48595",
+					"172.24.0.1:48595",
+					"172.25.0.1:48595",
+					"172.26.0.1:48595",
+					"172.27.0.1:48595",
+					"172.28.0.1:48595",
+					"172.29.0.1:48595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:07:04.850360367Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2953439583137982,
+				"StableID":   "nf3EPHrc4Q11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6830c6e8462e7666dd6a590afa47674215e85c774bdb08585ef9c53d213dd83e",
+				"KeyExpiry":  "2026-11-09T09:07:05Z",
+				"DiscoKey":   "discokey:b73ed43ae299905067eef8003960a36279ceaaae6ddefc591c1a43ddb6a7377f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60165",
+					"10.65.0.27:60165",
+					"172.17.0.1:60165",
+					"172.18.0.1:60165",
+					"172.19.0.1:60165",
+					"172.20.0.1:60165",
+					"172.21.0.1:60165",
+					"172.22.0.1:60165",
+					"172.23.0.1:60165",
+					"172.24.0.1:60165",
+					"172.25.0.1:60165",
+					"172.26.0.1:60165",
+					"172.27.0.1:60165",
+					"172.28.0.1:60165",
+					"172.29.0.1:60165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:07:05.932371484Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6510634174200293,
+				"StableID":   "nvPaMYKgqs11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3db8e6ea02db37d77b3e725aebaddecd8e814a3d1a629b8786902d3594c12b22",
+				"KeyExpiry":  "2026-11-09T09:07:06Z",
+				"DiscoKey":   "discokey:dafff3180c3e748f84e9f52f7b5eb38cacc3d17037d6caffb6f482081346a31b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38090",
+					"10.65.0.27:38090",
+					"172.17.0.1:38090",
+					"172.18.0.1:38090",
+					"172.19.0.1:38090",
+					"172.20.0.1:38090",
+					"172.21.0.1:38090",
+					"172.22.0.1:38090",
+					"172.23.0.1:38090",
+					"172.24.0.1:38090",
+					"172.25.0.1:38090",
+					"172.26.0.1:38090",
+					"172.27.0.1:38090",
+					"172.28.0.1:38090",
+					"172.29.0.1:38090"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:07:06.470237579Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1396844734654740,
+				"StableID":   "nM72w4kduB11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1396844734654740,
+				"Key":        "nodekey:ffa1cbd6a2ef321eeb0ae907edbcab63a8bbdb2ae06102448a673f222c10f454",
+				"DiscoKey":   "discokey:b515939689ab44b6c96e494f002870bab12a3d1aea7d3ef97c22f85d7f720437",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37085",
+					"10.65.0.27:37085",
+					"172.17.0.1:37085",
+					"172.18.0.1:37085",
+					"172.19.0.1:37085",
+					"172.20.0.1:37085",
+					"172.21.0.1:37085",
+					"172.22.0.1:37085",
+					"172.23.0.1:37085",
+					"172.24.0.1:37085",
+					"172.25.0.1:37085",
+					"172.26.0.1:37085",
+					"172.27.0.1:37085",
+					"172.28.0.1:37085",
+					"172.29.0.1:37085"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:07:04.313556266Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ffa1cbd6a2ef321eeb0ae907edbcab63a8bbdb2ae06102448a673f222c10f454",
+			"MachineKey": "mkey:1691e26c4da15f6ecbc0bb4e744b20a6fb4412b8a0857c8cf22dfd66510bb86b",
+			"Peers": [{
+				"ID":         976708517211670,
+				"StableID":   "nsHv5eUMd811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:693f1096b5e38d38a2b4800cf64b8f3b97a0bf724420b872578cc1b5b9eda42f",
+				"DiscoKey":   "discokey:7809cb165bed2d629ee21964fa7edd13ba3fdfeaed8ed719f54bad6de3052d56",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47993",
+					"10.65.0.27:47993",
+					"172.17.0.1:47993",
+					"172.18.0.1:47993",
+					"172.19.0.1:47993",
+					"172.20.0.1:47993",
+					"172.21.0.1:47993",
+					"172.22.0.1:47993",
+					"172.23.0.1:47993",
+					"172.24.0.1:47993",
+					"172.25.0.1:47993",
+					"172.26.0.1:47993",
+					"172.27.0.1:47993",
+					"172.28.0.1:47993",
+					"172.29.0.1:47993"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:06:58.5101451Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3824448112674477,
+				"StableID":   "n4nZWUm6sW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07ec7614be9264bf4da7497e9aa2186bb3a3941c4044f10786082d5ef35f904d",
+				"DiscoKey":   "discokey:5b605feff2417171183d7c886260b3613ac1239dc192a53931081d5d0fbcf26e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34807",
+					"10.65.0.27:34807",
+					"172.17.0.1:34807",
+					"172.18.0.1:34807",
+					"172.19.0.1:34807",
+					"172.20.0.1:34807",
+					"172.21.0.1:34807",
+					"172.22.0.1:34807",
+					"172.23.0.1:34807",
+					"172.24.0.1:34807",
+					"172.25.0.1:34807",
+					"172.26.0.1:34807",
+					"172.27.0.1:34807",
+					"172.28.0.1:34807",
+					"172.29.0.1:34807"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:06:59.334581139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3527482195521367,
+				"StableID":   "nrLjKbybYU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31ed2c7eee6a2a519a5ff44c629b248934b3621cbf0e1bb65f4c91f09bcc8f5a",
+				"DiscoKey":   "discokey:a6fb79615ab1925f1c3ce0b5524724ffca017d3975fae0f63d1ce6a1ff5d6068",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39256",
+					"10.65.0.27:39256",
+					"172.17.0.1:39256",
+					"172.18.0.1:39256",
+					"172.19.0.1:39256",
+					"172.20.0.1:39256",
+					"172.21.0.1:39256",
+					"172.22.0.1:39256",
+					"172.23.0.1:39256",
+					"172.24.0.1:39256",
+					"172.25.0.1:39256",
+					"172.26.0.1:39256",
+					"172.27.0.1:39256",
+					"172.28.0.1:39256",
+					"172.29.0.1:39256"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:07:00.014319028Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2903606537190410,
+				"StableID":   "nj5ykZp3gP11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:50474b8b720f0f07fe21708a7bfb204fd00e64b0d318e5d3f321efd94be5dd42",
+				"DiscoKey":   "discokey:40cefa0618560ff7da77043eb69538848235b60f6c6374ae9b99f443eb06d454",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42842",
+					"10.65.0.27:42842",
+					"172.17.0.1:42842",
+					"172.18.0.1:42842",
+					"172.19.0.1:42842",
+					"172.20.0.1:42842",
+					"172.21.0.1:42842",
+					"172.22.0.1:42842",
+					"172.23.0.1:42842",
+					"172.24.0.1:42842",
+					"172.25.0.1:42842",
+					"172.26.0.1:42842",
+					"172.27.0.1:42842",
+					"172.28.0.1:42842",
+					"172.29.0.1:42842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:07:00.548368106Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6827040522615864,
+				"StableID":   "nuh8t7nyJv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b70152198f5e5e86aa84e79227f3d4d80441aebb5a39f806d59a74b9d5222506",
+				"DiscoKey":   "discokey:52277daa5b055ee6f2d00161a303f0ee0cfc022c757889c427beb190cd60d31e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:35029",
+					"10.65.0.27:35029",
+					"172.17.0.1:35029",
+					"172.18.0.1:35029",
+					"172.19.0.1:35029",
+					"172.20.0.1:35029",
+					"172.21.0.1:35029",
+					"172.22.0.1:35029",
+					"172.23.0.1:35029",
+					"172.24.0.1:35029",
+					"172.25.0.1:35029",
+					"172.26.0.1:35029",
+					"172.27.0.1:35029",
+					"172.28.0.1:35029",
+					"172.29.0.1:35029"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:07:01.089113953Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3188121042143300,
+				"StableID":   "nV5dHxXutR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:887ef6d4915e34fee99dfedda47ac9cf2596688c580675a42c3471cbebaafb11",
+				"DiscoKey":   "discokey:2ae1bcb848319c1aca0fd76bfbab00b41b9a056fb6d0dae31f6aa5830be38037",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:60559",
+					"10.65.0.27:60559",
+					"172.17.0.1:60559",
+					"172.18.0.1:60559",
+					"172.19.0.1:60559",
+					"172.20.0.1:60559",
+					"172.21.0.1:60559",
+					"172.22.0.1:60559",
+					"172.23.0.1:60559",
+					"172.24.0.1:60559",
+					"172.25.0.1:60559",
+					"172.26.0.1:60559",
+					"172.27.0.1:60559",
+					"172.28.0.1:60559",
+					"172.29.0.1:60559"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:07:01.638082773Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6026571109877032,
+				"StableID":   "njzUxcoS4p11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:18586a46b864c2ca115fc1b02bd9e189004f83438da40203ca9ae750b6d4867c",
+				"DiscoKey":   "discokey:e6c914d964da958f5bccd1e0f0438649f10177c7d2e94160426c49c294bd9550",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:46267",
+					"10.65.0.27:46267",
+					"172.17.0.1:46267",
+					"172.18.0.1:46267",
+					"172.19.0.1:46267",
+					"172.20.0.1:46267",
+					"172.21.0.1:46267",
+					"172.22.0.1:46267",
+					"172.23.0.1:46267",
+					"172.24.0.1:46267",
+					"172.25.0.1:46267",
+					"172.26.0.1:46267",
+					"172.27.0.1:46267",
+					"172.28.0.1:46267",
+					"172.29.0.1:46267"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:07:02.178830239Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3109318643116652,
+				"StableID":   "nuoa8eXDHR11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:19240fa0357506dc89722122edbf677041158ff71a947bea5301ae9c01c8847d",
+				"DiscoKey":   "discokey:63786a4d32cbdd73773c1a731cccfcf782e3f8550ffbca4137dca2792e753f53",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45928",
+					"10.65.0.27:45928",
+					"172.17.0.1:45928",
+					"172.18.0.1:45928",
+					"172.19.0.1:45928",
+					"172.20.0.1:45928",
+					"172.21.0.1:45928",
+					"172.22.0.1:45928",
+					"172.23.0.1:45928",
+					"172.24.0.1:45928",
+					"172.25.0.1:45928",
+					"172.26.0.1:45928",
+					"172.27.0.1:45928",
+					"172.28.0.1:45928",
+					"172.29.0.1:45928"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:07:02.713673659Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3420985025326015,
+				"StableID":   "nSxM5bUNiT11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5179e958e1bcee53b917d23980ecb7580fd7aee87073e51dc5a7ac5c512f305e",
+				"DiscoKey":   "discokey:ed27a9ec853c0b52ea58ff8f9db55ff7786750fd95ab32910c43367c0fc9001f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41518",
+					"10.65.0.27:41518",
+					"172.17.0.1:41518",
+					"172.18.0.1:41518",
+					"172.19.0.1:41518",
+					"172.20.0.1:41518",
+					"172.21.0.1:41518",
+					"172.22.0.1:41518",
+					"172.23.0.1:41518",
+					"172.24.0.1:41518",
+					"172.25.0.1:41518",
+					"172.26.0.1:41518",
+					"172.27.0.1:41518",
+					"172.28.0.1:41518",
+					"172.29.0.1:41518"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:07:03.260242351Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8235423448387682,
+				"StableID":   "n3PaFLcqJ721CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b5bd7a97c7b00c217cd2bd9c077b9354d5aa216043ed9106a7fd0e084372c14",
+				"DiscoKey":   "discokey:25bb0bccd6af1bce680c5e620b367bc67f38ade3332b6caae7f29431e703bd17",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53023",
+					"10.65.0.27:53023",
+					"172.17.0.1:53023",
+					"172.18.0.1:53023",
+					"172.19.0.1:53023",
+					"172.20.0.1:53023",
+					"172.21.0.1:53023",
+					"172.22.0.1:53023",
+					"172.23.0.1:53023",
+					"172.24.0.1:53023",
+					"172.25.0.1:53023",
+					"172.26.0.1:53023",
+					"172.27.0.1:53023",
+					"172.28.0.1:53023",
+					"172.29.0.1:53023"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:07:03.775745436Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3311208731492109,
+				"StableID":   "nCnDudqerS11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ece627c2d681eb4dc892f1b7f6eb3f672f6ab30d8c9a74feef6ada7722408a3c",
+				"DiscoKey":   "discokey:4f273464c671a879a1b4ca54203699d36d08f96ee1e7ab2bc1049b3cac09b347",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48595",
+					"10.65.0.27:48595",
+					"172.17.0.1:48595",
+					"172.18.0.1:48595",
+					"172.19.0.1:48595",
+					"172.20.0.1:48595",
+					"172.21.0.1:48595",
+					"172.22.0.1:48595",
+					"172.23.0.1:48595",
+					"172.24.0.1:48595",
+					"172.25.0.1:48595",
+					"172.26.0.1:48595",
+					"172.27.0.1:48595",
+					"172.28.0.1:48595",
+					"172.29.0.1:48595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:07:04.850360367Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7777277844117688,
+				"StableID":   "nw4n3GuLj321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:fa9004d8608a8f81c8df29395b2d8d3fa28defaa757cad8b431c5b3f3f54f504",
+				"KeyExpiry":  "2026-11-09T09:07:05Z",
+				"DiscoKey":   "discokey:a5b588857f4ff1a08e43b2d51eb969e370953bf7c1f8a5a69b9e0bbe1e992234",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38435",
+					"10.65.0.27:38435",
+					"172.17.0.1:38435",
+					"172.18.0.1:38435",
+					"172.19.0.1:38435",
+					"172.20.0.1:38435",
+					"172.21.0.1:38435",
+					"172.22.0.1:38435",
+					"172.23.0.1:38435",
+					"172.24.0.1:38435",
+					"172.25.0.1:38435",
+					"172.26.0.1:38435",
+					"172.27.0.1:38435",
+					"172.28.0.1:38435",
+					"172.29.0.1:38435"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:07:05.383804209Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2953439583137982,
+				"StableID":   "nf3EPHrc4Q11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6830c6e8462e7666dd6a590afa47674215e85c774bdb08585ef9c53d213dd83e",
+				"KeyExpiry":  "2026-11-09T09:07:05Z",
+				"DiscoKey":   "discokey:b73ed43ae299905067eef8003960a36279ceaaae6ddefc591c1a43ddb6a7377f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60165",
+					"10.65.0.27:60165",
+					"172.17.0.1:60165",
+					"172.18.0.1:60165",
+					"172.19.0.1:60165",
+					"172.20.0.1:60165",
+					"172.21.0.1:60165",
+					"172.22.0.1:60165",
+					"172.23.0.1:60165",
+					"172.24.0.1:60165",
+					"172.25.0.1:60165",
+					"172.26.0.1:60165",
+					"172.27.0.1:60165",
+					"172.28.0.1:60165",
+					"172.29.0.1:60165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:07:05.932371484Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6510634174200293,
+				"StableID":   "nvPaMYKgqs11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3db8e6ea02db37d77b3e725aebaddecd8e814a3d1a629b8786902d3594c12b22",
+				"KeyExpiry":  "2026-11-09T09:07:06Z",
+				"DiscoKey":   "discokey:dafff3180c3e748f84e9f52f7b5eb38cacc3d17037d6caffb6f482081346a31b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38090",
+					"10.65.0.27:38090",
+					"172.17.0.1:38090",
+					"172.18.0.1:38090",
+					"172.19.0.1:38090",
+					"172.20.0.1:38090",
+					"172.21.0.1:38090",
+					"172.22.0.1:38090",
+					"172.23.0.1:38090",
+					"172.24.0.1:38090",
+					"172.25.0.1:38090",
+					"172.26.0.1:38090",
+					"172.27.0.1:38090",
+					"172.28.0.1:38090",
+					"172.29.0.1:38090"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:07:06.470237579Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1396844734654740": {
+				"ID":          1396844734654740,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3824448112674477,
+				"StableID":   "n4nZWUm6sW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       3824448112674477,
+				"Key":        "nodekey:07ec7614be9264bf4da7497e9aa2186bb3a3941c4044f10786082d5ef35f904d",
+				"DiscoKey":   "discokey:5b605feff2417171183d7c886260b3613ac1239dc192a53931081d5d0fbcf26e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34807",
+					"10.65.0.27:34807",
+					"172.17.0.1:34807",
+					"172.18.0.1:34807",
+					"172.19.0.1:34807",
+					"172.20.0.1:34807",
+					"172.21.0.1:34807",
+					"172.22.0.1:34807",
+					"172.23.0.1:34807",
+					"172.24.0.1:34807",
+					"172.25.0.1:34807",
+					"172.26.0.1:34807",
+					"172.27.0.1:34807",
+					"172.28.0.1:34807",
+					"172.29.0.1:34807"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:06:59.334581139Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:07ec7614be9264bf4da7497e9aa2186bb3a3941c4044f10786082d5ef35f904d",
+			"MachineKey": "mkey:7eff314a2320f1cba3a9f6ba8cd73c6a37b3c975857076553bd6f6b027675a48",
+			"Peers": [{
+				"ID":         976708517211670,
+				"StableID":   "nsHv5eUMd811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:693f1096b5e38d38a2b4800cf64b8f3b97a0bf724420b872578cc1b5b9eda42f",
+				"DiscoKey":   "discokey:7809cb165bed2d629ee21964fa7edd13ba3fdfeaed8ed719f54bad6de3052d56",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47993",
+					"10.65.0.27:47993",
+					"172.17.0.1:47993",
+					"172.18.0.1:47993",
+					"172.19.0.1:47993",
+					"172.20.0.1:47993",
+					"172.21.0.1:47993",
+					"172.22.0.1:47993",
+					"172.23.0.1:47993",
+					"172.24.0.1:47993",
+					"172.25.0.1:47993",
+					"172.26.0.1:47993",
+					"172.27.0.1:47993",
+					"172.28.0.1:47993",
+					"172.29.0.1:47993"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:06:58.5101451Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3527482195521367,
+				"StableID":   "nrLjKbybYU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31ed2c7eee6a2a519a5ff44c629b248934b3621cbf0e1bb65f4c91f09bcc8f5a",
+				"DiscoKey":   "discokey:a6fb79615ab1925f1c3ce0b5524724ffca017d3975fae0f63d1ce6a1ff5d6068",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39256",
+					"10.65.0.27:39256",
+					"172.17.0.1:39256",
+					"172.18.0.1:39256",
+					"172.19.0.1:39256",
+					"172.20.0.1:39256",
+					"172.21.0.1:39256",
+					"172.22.0.1:39256",
+					"172.23.0.1:39256",
+					"172.24.0.1:39256",
+					"172.25.0.1:39256",
+					"172.26.0.1:39256",
+					"172.27.0.1:39256",
+					"172.28.0.1:39256",
+					"172.29.0.1:39256"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:07:00.014319028Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2903606537190410,
+				"StableID":   "nj5ykZp3gP11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:50474b8b720f0f07fe21708a7bfb204fd00e64b0d318e5d3f321efd94be5dd42",
+				"DiscoKey":   "discokey:40cefa0618560ff7da77043eb69538848235b60f6c6374ae9b99f443eb06d454",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42842",
+					"10.65.0.27:42842",
+					"172.17.0.1:42842",
+					"172.18.0.1:42842",
+					"172.19.0.1:42842",
+					"172.20.0.1:42842",
+					"172.21.0.1:42842",
+					"172.22.0.1:42842",
+					"172.23.0.1:42842",
+					"172.24.0.1:42842",
+					"172.25.0.1:42842",
+					"172.26.0.1:42842",
+					"172.27.0.1:42842",
+					"172.28.0.1:42842",
+					"172.29.0.1:42842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:07:00.548368106Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6827040522615864,
+				"StableID":   "nuh8t7nyJv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b70152198f5e5e86aa84e79227f3d4d80441aebb5a39f806d59a74b9d5222506",
+				"DiscoKey":   "discokey:52277daa5b055ee6f2d00161a303f0ee0cfc022c757889c427beb190cd60d31e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:35029",
+					"10.65.0.27:35029",
+					"172.17.0.1:35029",
+					"172.18.0.1:35029",
+					"172.19.0.1:35029",
+					"172.20.0.1:35029",
+					"172.21.0.1:35029",
+					"172.22.0.1:35029",
+					"172.23.0.1:35029",
+					"172.24.0.1:35029",
+					"172.25.0.1:35029",
+					"172.26.0.1:35029",
+					"172.27.0.1:35029",
+					"172.28.0.1:35029",
+					"172.29.0.1:35029"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:07:01.089113953Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3188121042143300,
+				"StableID":   "nV5dHxXutR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:887ef6d4915e34fee99dfedda47ac9cf2596688c580675a42c3471cbebaafb11",
+				"DiscoKey":   "discokey:2ae1bcb848319c1aca0fd76bfbab00b41b9a056fb6d0dae31f6aa5830be38037",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:60559",
+					"10.65.0.27:60559",
+					"172.17.0.1:60559",
+					"172.18.0.1:60559",
+					"172.19.0.1:60559",
+					"172.20.0.1:60559",
+					"172.21.0.1:60559",
+					"172.22.0.1:60559",
+					"172.23.0.1:60559",
+					"172.24.0.1:60559",
+					"172.25.0.1:60559",
+					"172.26.0.1:60559",
+					"172.27.0.1:60559",
+					"172.28.0.1:60559",
+					"172.29.0.1:60559"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:07:01.638082773Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6026571109877032,
+				"StableID":   "njzUxcoS4p11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:18586a46b864c2ca115fc1b02bd9e189004f83438da40203ca9ae750b6d4867c",
+				"DiscoKey":   "discokey:e6c914d964da958f5bccd1e0f0438649f10177c7d2e94160426c49c294bd9550",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:46267",
+					"10.65.0.27:46267",
+					"172.17.0.1:46267",
+					"172.18.0.1:46267",
+					"172.19.0.1:46267",
+					"172.20.0.1:46267",
+					"172.21.0.1:46267",
+					"172.22.0.1:46267",
+					"172.23.0.1:46267",
+					"172.24.0.1:46267",
+					"172.25.0.1:46267",
+					"172.26.0.1:46267",
+					"172.27.0.1:46267",
+					"172.28.0.1:46267",
+					"172.29.0.1:46267"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:07:02.178830239Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3109318643116652,
+				"StableID":   "nuoa8eXDHR11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:19240fa0357506dc89722122edbf677041158ff71a947bea5301ae9c01c8847d",
+				"DiscoKey":   "discokey:63786a4d32cbdd73773c1a731cccfcf782e3f8550ffbca4137dca2792e753f53",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45928",
+					"10.65.0.27:45928",
+					"172.17.0.1:45928",
+					"172.18.0.1:45928",
+					"172.19.0.1:45928",
+					"172.20.0.1:45928",
+					"172.21.0.1:45928",
+					"172.22.0.1:45928",
+					"172.23.0.1:45928",
+					"172.24.0.1:45928",
+					"172.25.0.1:45928",
+					"172.26.0.1:45928",
+					"172.27.0.1:45928",
+					"172.28.0.1:45928",
+					"172.29.0.1:45928"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:07:02.713673659Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3420985025326015,
+				"StableID":   "nSxM5bUNiT11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5179e958e1bcee53b917d23980ecb7580fd7aee87073e51dc5a7ac5c512f305e",
+				"DiscoKey":   "discokey:ed27a9ec853c0b52ea58ff8f9db55ff7786750fd95ab32910c43367c0fc9001f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41518",
+					"10.65.0.27:41518",
+					"172.17.0.1:41518",
+					"172.18.0.1:41518",
+					"172.19.0.1:41518",
+					"172.20.0.1:41518",
+					"172.21.0.1:41518",
+					"172.22.0.1:41518",
+					"172.23.0.1:41518",
+					"172.24.0.1:41518",
+					"172.25.0.1:41518",
+					"172.26.0.1:41518",
+					"172.27.0.1:41518",
+					"172.28.0.1:41518",
+					"172.29.0.1:41518"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:07:03.260242351Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8235423448387682,
+				"StableID":   "n3PaFLcqJ721CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b5bd7a97c7b00c217cd2bd9c077b9354d5aa216043ed9106a7fd0e084372c14",
+				"DiscoKey":   "discokey:25bb0bccd6af1bce680c5e620b367bc67f38ade3332b6caae7f29431e703bd17",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53023",
+					"10.65.0.27:53023",
+					"172.17.0.1:53023",
+					"172.18.0.1:53023",
+					"172.19.0.1:53023",
+					"172.20.0.1:53023",
+					"172.21.0.1:53023",
+					"172.22.0.1:53023",
+					"172.23.0.1:53023",
+					"172.24.0.1:53023",
+					"172.25.0.1:53023",
+					"172.26.0.1:53023",
+					"172.27.0.1:53023",
+					"172.28.0.1:53023",
+					"172.29.0.1:53023"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:07:03.775745436Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1396844734654740,
+				"StableID":   "nM72w4kduB11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ffa1cbd6a2ef321eeb0ae907edbcab63a8bbdb2ae06102448a673f222c10f454",
+				"DiscoKey":   "discokey:b515939689ab44b6c96e494f002870bab12a3d1aea7d3ef97c22f85d7f720437",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37085",
+					"10.65.0.27:37085",
+					"172.17.0.1:37085",
+					"172.18.0.1:37085",
+					"172.19.0.1:37085",
+					"172.20.0.1:37085",
+					"172.21.0.1:37085",
+					"172.22.0.1:37085",
+					"172.23.0.1:37085",
+					"172.24.0.1:37085",
+					"172.25.0.1:37085",
+					"172.26.0.1:37085",
+					"172.27.0.1:37085",
+					"172.28.0.1:37085",
+					"172.29.0.1:37085"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:07:04.313556266Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3311208731492109,
+				"StableID":   "nCnDudqerS11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ece627c2d681eb4dc892f1b7f6eb3f672f6ab30d8c9a74feef6ada7722408a3c",
+				"DiscoKey":   "discokey:4f273464c671a879a1b4ca54203699d36d08f96ee1e7ab2bc1049b3cac09b347",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48595",
+					"10.65.0.27:48595",
+					"172.17.0.1:48595",
+					"172.18.0.1:48595",
+					"172.19.0.1:48595",
+					"172.20.0.1:48595",
+					"172.21.0.1:48595",
+					"172.22.0.1:48595",
+					"172.23.0.1:48595",
+					"172.24.0.1:48595",
+					"172.25.0.1:48595",
+					"172.26.0.1:48595",
+					"172.27.0.1:48595",
+					"172.28.0.1:48595",
+					"172.29.0.1:48595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:07:04.850360367Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7777277844117688,
+				"StableID":   "nw4n3GuLj321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:fa9004d8608a8f81c8df29395b2d8d3fa28defaa757cad8b431c5b3f3f54f504",
+				"KeyExpiry":  "2026-11-09T09:07:05Z",
+				"DiscoKey":   "discokey:a5b588857f4ff1a08e43b2d51eb969e370953bf7c1f8a5a69b9e0bbe1e992234",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38435",
+					"10.65.0.27:38435",
+					"172.17.0.1:38435",
+					"172.18.0.1:38435",
+					"172.19.0.1:38435",
+					"172.20.0.1:38435",
+					"172.21.0.1:38435",
+					"172.22.0.1:38435",
+					"172.23.0.1:38435",
+					"172.24.0.1:38435",
+					"172.25.0.1:38435",
+					"172.26.0.1:38435",
+					"172.27.0.1:38435",
+					"172.28.0.1:38435",
+					"172.29.0.1:38435"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:07:05.383804209Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2953439583137982,
+				"StableID":   "nf3EPHrc4Q11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6830c6e8462e7666dd6a590afa47674215e85c774bdb08585ef9c53d213dd83e",
+				"KeyExpiry":  "2026-11-09T09:07:05Z",
+				"DiscoKey":   "discokey:b73ed43ae299905067eef8003960a36279ceaaae6ddefc591c1a43ddb6a7377f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60165",
+					"10.65.0.27:60165",
+					"172.17.0.1:60165",
+					"172.18.0.1:60165",
+					"172.19.0.1:60165",
+					"172.20.0.1:60165",
+					"172.21.0.1:60165",
+					"172.22.0.1:60165",
+					"172.23.0.1:60165",
+					"172.24.0.1:60165",
+					"172.25.0.1:60165",
+					"172.26.0.1:60165",
+					"172.27.0.1:60165",
+					"172.28.0.1:60165",
+					"172.29.0.1:60165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:07:05.932371484Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6510634174200293,
+				"StableID":   "nvPaMYKgqs11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3db8e6ea02db37d77b3e725aebaddecd8e814a3d1a629b8786902d3594c12b22",
+				"KeyExpiry":  "2026-11-09T09:07:06Z",
+				"DiscoKey":   "discokey:dafff3180c3e748f84e9f52f7b5eb38cacc3d17037d6caffb6f482081346a31b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38090",
+					"10.65.0.27:38090",
+					"172.17.0.1:38090",
+					"172.18.0.1:38090",
+					"172.19.0.1:38090",
+					"172.20.0.1:38090",
+					"172.21.0.1:38090",
+					"172.22.0.1:38090",
+					"172.23.0.1:38090",
+					"172.24.0.1:38090",
+					"172.25.0.1:38090",
+					"172.26.0.1:38090",
+					"172.27.0.1:38090",
+					"172.28.0.1:38090",
+					"172.29.0.1:38090"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:07:06.470237579Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3824448112674477": {
+				"ID":          3824448112674477,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         976708517211670,
+				"StableID":   "nsHv5eUMd811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       976708517211670,
+				"Key":        "nodekey:693f1096b5e38d38a2b4800cf64b8f3b97a0bf724420b872578cc1b5b9eda42f",
+				"DiscoKey":   "discokey:7809cb165bed2d629ee21964fa7edd13ba3fdfeaed8ed719f54bad6de3052d56",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47993",
+					"10.65.0.27:47993",
+					"172.17.0.1:47993",
+					"172.18.0.1:47993",
+					"172.19.0.1:47993",
+					"172.20.0.1:47993",
+					"172.21.0.1:47993",
+					"172.22.0.1:47993",
+					"172.23.0.1:47993",
+					"172.24.0.1:47993",
+					"172.25.0.1:47993",
+					"172.26.0.1:47993",
+					"172.27.0.1:47993",
+					"172.28.0.1:47993",
+					"172.29.0.1:47993"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:06:58.5101451Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:693f1096b5e38d38a2b4800cf64b8f3b97a0bf724420b872578cc1b5b9eda42f",
+			"MachineKey": "mkey:680638c9ce5a324d5c3ec69c1939141471775c87107af9a22840ba40c64a911a",
+			"Peers": [{
+				"ID":         3824448112674477,
+				"StableID":   "n4nZWUm6sW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07ec7614be9264bf4da7497e9aa2186bb3a3941c4044f10786082d5ef35f904d",
+				"DiscoKey":   "discokey:5b605feff2417171183d7c886260b3613ac1239dc192a53931081d5d0fbcf26e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34807",
+					"10.65.0.27:34807",
+					"172.17.0.1:34807",
+					"172.18.0.1:34807",
+					"172.19.0.1:34807",
+					"172.20.0.1:34807",
+					"172.21.0.1:34807",
+					"172.22.0.1:34807",
+					"172.23.0.1:34807",
+					"172.24.0.1:34807",
+					"172.25.0.1:34807",
+					"172.26.0.1:34807",
+					"172.27.0.1:34807",
+					"172.28.0.1:34807",
+					"172.29.0.1:34807"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:06:59.334581139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3527482195521367,
+				"StableID":   "nrLjKbybYU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31ed2c7eee6a2a519a5ff44c629b248934b3621cbf0e1bb65f4c91f09bcc8f5a",
+				"DiscoKey":   "discokey:a6fb79615ab1925f1c3ce0b5524724ffca017d3975fae0f63d1ce6a1ff5d6068",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39256",
+					"10.65.0.27:39256",
+					"172.17.0.1:39256",
+					"172.18.0.1:39256",
+					"172.19.0.1:39256",
+					"172.20.0.1:39256",
+					"172.21.0.1:39256",
+					"172.22.0.1:39256",
+					"172.23.0.1:39256",
+					"172.24.0.1:39256",
+					"172.25.0.1:39256",
+					"172.26.0.1:39256",
+					"172.27.0.1:39256",
+					"172.28.0.1:39256",
+					"172.29.0.1:39256"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:07:00.014319028Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2903606537190410,
+				"StableID":   "nj5ykZp3gP11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:50474b8b720f0f07fe21708a7bfb204fd00e64b0d318e5d3f321efd94be5dd42",
+				"DiscoKey":   "discokey:40cefa0618560ff7da77043eb69538848235b60f6c6374ae9b99f443eb06d454",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42842",
+					"10.65.0.27:42842",
+					"172.17.0.1:42842",
+					"172.18.0.1:42842",
+					"172.19.0.1:42842",
+					"172.20.0.1:42842",
+					"172.21.0.1:42842",
+					"172.22.0.1:42842",
+					"172.23.0.1:42842",
+					"172.24.0.1:42842",
+					"172.25.0.1:42842",
+					"172.26.0.1:42842",
+					"172.27.0.1:42842",
+					"172.28.0.1:42842",
+					"172.29.0.1:42842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:07:00.548368106Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6827040522615864,
+				"StableID":   "nuh8t7nyJv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b70152198f5e5e86aa84e79227f3d4d80441aebb5a39f806d59a74b9d5222506",
+				"DiscoKey":   "discokey:52277daa5b055ee6f2d00161a303f0ee0cfc022c757889c427beb190cd60d31e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:35029",
+					"10.65.0.27:35029",
+					"172.17.0.1:35029",
+					"172.18.0.1:35029",
+					"172.19.0.1:35029",
+					"172.20.0.1:35029",
+					"172.21.0.1:35029",
+					"172.22.0.1:35029",
+					"172.23.0.1:35029",
+					"172.24.0.1:35029",
+					"172.25.0.1:35029",
+					"172.26.0.1:35029",
+					"172.27.0.1:35029",
+					"172.28.0.1:35029",
+					"172.29.0.1:35029"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:07:01.089113953Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3188121042143300,
+				"StableID":   "nV5dHxXutR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:887ef6d4915e34fee99dfedda47ac9cf2596688c580675a42c3471cbebaafb11",
+				"DiscoKey":   "discokey:2ae1bcb848319c1aca0fd76bfbab00b41b9a056fb6d0dae31f6aa5830be38037",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:60559",
+					"10.65.0.27:60559",
+					"172.17.0.1:60559",
+					"172.18.0.1:60559",
+					"172.19.0.1:60559",
+					"172.20.0.1:60559",
+					"172.21.0.1:60559",
+					"172.22.0.1:60559",
+					"172.23.0.1:60559",
+					"172.24.0.1:60559",
+					"172.25.0.1:60559",
+					"172.26.0.1:60559",
+					"172.27.0.1:60559",
+					"172.28.0.1:60559",
+					"172.29.0.1:60559"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:07:01.638082773Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6026571109877032,
+				"StableID":   "njzUxcoS4p11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:18586a46b864c2ca115fc1b02bd9e189004f83438da40203ca9ae750b6d4867c",
+				"DiscoKey":   "discokey:e6c914d964da958f5bccd1e0f0438649f10177c7d2e94160426c49c294bd9550",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:46267",
+					"10.65.0.27:46267",
+					"172.17.0.1:46267",
+					"172.18.0.1:46267",
+					"172.19.0.1:46267",
+					"172.20.0.1:46267",
+					"172.21.0.1:46267",
+					"172.22.0.1:46267",
+					"172.23.0.1:46267",
+					"172.24.0.1:46267",
+					"172.25.0.1:46267",
+					"172.26.0.1:46267",
+					"172.27.0.1:46267",
+					"172.28.0.1:46267",
+					"172.29.0.1:46267"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:07:02.178830239Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3109318643116652,
+				"StableID":   "nuoa8eXDHR11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:19240fa0357506dc89722122edbf677041158ff71a947bea5301ae9c01c8847d",
+				"DiscoKey":   "discokey:63786a4d32cbdd73773c1a731cccfcf782e3f8550ffbca4137dca2792e753f53",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45928",
+					"10.65.0.27:45928",
+					"172.17.0.1:45928",
+					"172.18.0.1:45928",
+					"172.19.0.1:45928",
+					"172.20.0.1:45928",
+					"172.21.0.1:45928",
+					"172.22.0.1:45928",
+					"172.23.0.1:45928",
+					"172.24.0.1:45928",
+					"172.25.0.1:45928",
+					"172.26.0.1:45928",
+					"172.27.0.1:45928",
+					"172.28.0.1:45928",
+					"172.29.0.1:45928"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:07:02.713673659Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3420985025326015,
+				"StableID":   "nSxM5bUNiT11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5179e958e1bcee53b917d23980ecb7580fd7aee87073e51dc5a7ac5c512f305e",
+				"DiscoKey":   "discokey:ed27a9ec853c0b52ea58ff8f9db55ff7786750fd95ab32910c43367c0fc9001f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41518",
+					"10.65.0.27:41518",
+					"172.17.0.1:41518",
+					"172.18.0.1:41518",
+					"172.19.0.1:41518",
+					"172.20.0.1:41518",
+					"172.21.0.1:41518",
+					"172.22.0.1:41518",
+					"172.23.0.1:41518",
+					"172.24.0.1:41518",
+					"172.25.0.1:41518",
+					"172.26.0.1:41518",
+					"172.27.0.1:41518",
+					"172.28.0.1:41518",
+					"172.29.0.1:41518"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:07:03.260242351Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8235423448387682,
+				"StableID":   "n3PaFLcqJ721CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b5bd7a97c7b00c217cd2bd9c077b9354d5aa216043ed9106a7fd0e084372c14",
+				"DiscoKey":   "discokey:25bb0bccd6af1bce680c5e620b367bc67f38ade3332b6caae7f29431e703bd17",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53023",
+					"10.65.0.27:53023",
+					"172.17.0.1:53023",
+					"172.18.0.1:53023",
+					"172.19.0.1:53023",
+					"172.20.0.1:53023",
+					"172.21.0.1:53023",
+					"172.22.0.1:53023",
+					"172.23.0.1:53023",
+					"172.24.0.1:53023",
+					"172.25.0.1:53023",
+					"172.26.0.1:53023",
+					"172.27.0.1:53023",
+					"172.28.0.1:53023",
+					"172.29.0.1:53023"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:07:03.775745436Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1396844734654740,
+				"StableID":   "nM72w4kduB11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ffa1cbd6a2ef321eeb0ae907edbcab63a8bbdb2ae06102448a673f222c10f454",
+				"DiscoKey":   "discokey:b515939689ab44b6c96e494f002870bab12a3d1aea7d3ef97c22f85d7f720437",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37085",
+					"10.65.0.27:37085",
+					"172.17.0.1:37085",
+					"172.18.0.1:37085",
+					"172.19.0.1:37085",
+					"172.20.0.1:37085",
+					"172.21.0.1:37085",
+					"172.22.0.1:37085",
+					"172.23.0.1:37085",
+					"172.24.0.1:37085",
+					"172.25.0.1:37085",
+					"172.26.0.1:37085",
+					"172.27.0.1:37085",
+					"172.28.0.1:37085",
+					"172.29.0.1:37085"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:07:04.313556266Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3311208731492109,
+				"StableID":   "nCnDudqerS11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ece627c2d681eb4dc892f1b7f6eb3f672f6ab30d8c9a74feef6ada7722408a3c",
+				"DiscoKey":   "discokey:4f273464c671a879a1b4ca54203699d36d08f96ee1e7ab2bc1049b3cac09b347",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48595",
+					"10.65.0.27:48595",
+					"172.17.0.1:48595",
+					"172.18.0.1:48595",
+					"172.19.0.1:48595",
+					"172.20.0.1:48595",
+					"172.21.0.1:48595",
+					"172.22.0.1:48595",
+					"172.23.0.1:48595",
+					"172.24.0.1:48595",
+					"172.25.0.1:48595",
+					"172.26.0.1:48595",
+					"172.27.0.1:48595",
+					"172.28.0.1:48595",
+					"172.29.0.1:48595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:07:04.850360367Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7777277844117688,
+				"StableID":   "nw4n3GuLj321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:fa9004d8608a8f81c8df29395b2d8d3fa28defaa757cad8b431c5b3f3f54f504",
+				"KeyExpiry":  "2026-11-09T09:07:05Z",
+				"DiscoKey":   "discokey:a5b588857f4ff1a08e43b2d51eb969e370953bf7c1f8a5a69b9e0bbe1e992234",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38435",
+					"10.65.0.27:38435",
+					"172.17.0.1:38435",
+					"172.18.0.1:38435",
+					"172.19.0.1:38435",
+					"172.20.0.1:38435",
+					"172.21.0.1:38435",
+					"172.22.0.1:38435",
+					"172.23.0.1:38435",
+					"172.24.0.1:38435",
+					"172.25.0.1:38435",
+					"172.26.0.1:38435",
+					"172.27.0.1:38435",
+					"172.28.0.1:38435",
+					"172.29.0.1:38435"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:07:05.383804209Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2953439583137982,
+				"StableID":   "nf3EPHrc4Q11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6830c6e8462e7666dd6a590afa47674215e85c774bdb08585ef9c53d213dd83e",
+				"KeyExpiry":  "2026-11-09T09:07:05Z",
+				"DiscoKey":   "discokey:b73ed43ae299905067eef8003960a36279ceaaae6ddefc591c1a43ddb6a7377f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60165",
+					"10.65.0.27:60165",
+					"172.17.0.1:60165",
+					"172.18.0.1:60165",
+					"172.19.0.1:60165",
+					"172.20.0.1:60165",
+					"172.21.0.1:60165",
+					"172.22.0.1:60165",
+					"172.23.0.1:60165",
+					"172.24.0.1:60165",
+					"172.25.0.1:60165",
+					"172.26.0.1:60165",
+					"172.27.0.1:60165",
+					"172.28.0.1:60165",
+					"172.29.0.1:60165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:07:05.932371484Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6510634174200293,
+				"StableID":   "nvPaMYKgqs11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3db8e6ea02db37d77b3e725aebaddecd8e814a3d1a629b8786902d3594c12b22",
+				"KeyExpiry":  "2026-11-09T09:07:06Z",
+				"DiscoKey":   "discokey:dafff3180c3e748f84e9f52f7b5eb38cacc3d17037d6caffb6f482081346a31b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38090",
+					"10.65.0.27:38090",
+					"172.17.0.1:38090",
+					"172.18.0.1:38090",
+					"172.19.0.1:38090",
+					"172.20.0.1:38090",
+					"172.21.0.1:38090",
+					"172.22.0.1:38090",
+					"172.23.0.1:38090",
+					"172.24.0.1:38090",
+					"172.25.0.1:38090",
+					"172.26.0.1:38090",
+					"172.27.0.1:38090",
+					"172.28.0.1:38090",
+					"172.29.0.1:38090"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:07:06.470237579Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "976708517211670": {
+				"ID":          976708517211670,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6827040522615864,
+				"StableID":   "nuh8t7nyJv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       6827040522615864,
+				"Key":        "nodekey:b70152198f5e5e86aa84e79227f3d4d80441aebb5a39f806d59a74b9d5222506",
+				"DiscoKey":   "discokey:52277daa5b055ee6f2d00161a303f0ee0cfc022c757889c427beb190cd60d31e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:35029",
+					"10.65.0.27:35029",
+					"172.17.0.1:35029",
+					"172.18.0.1:35029",
+					"172.19.0.1:35029",
+					"172.20.0.1:35029",
+					"172.21.0.1:35029",
+					"172.22.0.1:35029",
+					"172.23.0.1:35029",
+					"172.24.0.1:35029",
+					"172.25.0.1:35029",
+					"172.26.0.1:35029",
+					"172.27.0.1:35029",
+					"172.28.0.1:35029",
+					"172.29.0.1:35029"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:07:01.089113953Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b70152198f5e5e86aa84e79227f3d4d80441aebb5a39f806d59a74b9d5222506",
+			"MachineKey": "mkey:ebd36d6e5d0d3e190cedf1af10544e983007a93033929fe34c5f4c30f40c1912",
+			"Peers": [{
+				"ID":         976708517211670,
+				"StableID":   "nsHv5eUMd811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:693f1096b5e38d38a2b4800cf64b8f3b97a0bf724420b872578cc1b5b9eda42f",
+				"DiscoKey":   "discokey:7809cb165bed2d629ee21964fa7edd13ba3fdfeaed8ed719f54bad6de3052d56",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47993",
+					"10.65.0.27:47993",
+					"172.17.0.1:47993",
+					"172.18.0.1:47993",
+					"172.19.0.1:47993",
+					"172.20.0.1:47993",
+					"172.21.0.1:47993",
+					"172.22.0.1:47993",
+					"172.23.0.1:47993",
+					"172.24.0.1:47993",
+					"172.25.0.1:47993",
+					"172.26.0.1:47993",
+					"172.27.0.1:47993",
+					"172.28.0.1:47993",
+					"172.29.0.1:47993"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:06:58.5101451Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3824448112674477,
+				"StableID":   "n4nZWUm6sW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07ec7614be9264bf4da7497e9aa2186bb3a3941c4044f10786082d5ef35f904d",
+				"DiscoKey":   "discokey:5b605feff2417171183d7c886260b3613ac1239dc192a53931081d5d0fbcf26e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34807",
+					"10.65.0.27:34807",
+					"172.17.0.1:34807",
+					"172.18.0.1:34807",
+					"172.19.0.1:34807",
+					"172.20.0.1:34807",
+					"172.21.0.1:34807",
+					"172.22.0.1:34807",
+					"172.23.0.1:34807",
+					"172.24.0.1:34807",
+					"172.25.0.1:34807",
+					"172.26.0.1:34807",
+					"172.27.0.1:34807",
+					"172.28.0.1:34807",
+					"172.29.0.1:34807"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:06:59.334581139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3527482195521367,
+				"StableID":   "nrLjKbybYU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31ed2c7eee6a2a519a5ff44c629b248934b3621cbf0e1bb65f4c91f09bcc8f5a",
+				"DiscoKey":   "discokey:a6fb79615ab1925f1c3ce0b5524724ffca017d3975fae0f63d1ce6a1ff5d6068",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39256",
+					"10.65.0.27:39256",
+					"172.17.0.1:39256",
+					"172.18.0.1:39256",
+					"172.19.0.1:39256",
+					"172.20.0.1:39256",
+					"172.21.0.1:39256",
+					"172.22.0.1:39256",
+					"172.23.0.1:39256",
+					"172.24.0.1:39256",
+					"172.25.0.1:39256",
+					"172.26.0.1:39256",
+					"172.27.0.1:39256",
+					"172.28.0.1:39256",
+					"172.29.0.1:39256"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:07:00.014319028Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2903606537190410,
+				"StableID":   "nj5ykZp3gP11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:50474b8b720f0f07fe21708a7bfb204fd00e64b0d318e5d3f321efd94be5dd42",
+				"DiscoKey":   "discokey:40cefa0618560ff7da77043eb69538848235b60f6c6374ae9b99f443eb06d454",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42842",
+					"10.65.0.27:42842",
+					"172.17.0.1:42842",
+					"172.18.0.1:42842",
+					"172.19.0.1:42842",
+					"172.20.0.1:42842",
+					"172.21.0.1:42842",
+					"172.22.0.1:42842",
+					"172.23.0.1:42842",
+					"172.24.0.1:42842",
+					"172.25.0.1:42842",
+					"172.26.0.1:42842",
+					"172.27.0.1:42842",
+					"172.28.0.1:42842",
+					"172.29.0.1:42842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:07:00.548368106Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3188121042143300,
+				"StableID":   "nV5dHxXutR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:887ef6d4915e34fee99dfedda47ac9cf2596688c580675a42c3471cbebaafb11",
+				"DiscoKey":   "discokey:2ae1bcb848319c1aca0fd76bfbab00b41b9a056fb6d0dae31f6aa5830be38037",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:60559",
+					"10.65.0.27:60559",
+					"172.17.0.1:60559",
+					"172.18.0.1:60559",
+					"172.19.0.1:60559",
+					"172.20.0.1:60559",
+					"172.21.0.1:60559",
+					"172.22.0.1:60559",
+					"172.23.0.1:60559",
+					"172.24.0.1:60559",
+					"172.25.0.1:60559",
+					"172.26.0.1:60559",
+					"172.27.0.1:60559",
+					"172.28.0.1:60559",
+					"172.29.0.1:60559"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:07:01.638082773Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6026571109877032,
+				"StableID":   "njzUxcoS4p11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:18586a46b864c2ca115fc1b02bd9e189004f83438da40203ca9ae750b6d4867c",
+				"DiscoKey":   "discokey:e6c914d964da958f5bccd1e0f0438649f10177c7d2e94160426c49c294bd9550",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:46267",
+					"10.65.0.27:46267",
+					"172.17.0.1:46267",
+					"172.18.0.1:46267",
+					"172.19.0.1:46267",
+					"172.20.0.1:46267",
+					"172.21.0.1:46267",
+					"172.22.0.1:46267",
+					"172.23.0.1:46267",
+					"172.24.0.1:46267",
+					"172.25.0.1:46267",
+					"172.26.0.1:46267",
+					"172.27.0.1:46267",
+					"172.28.0.1:46267",
+					"172.29.0.1:46267"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:07:02.178830239Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3109318643116652,
+				"StableID":   "nuoa8eXDHR11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:19240fa0357506dc89722122edbf677041158ff71a947bea5301ae9c01c8847d",
+				"DiscoKey":   "discokey:63786a4d32cbdd73773c1a731cccfcf782e3f8550ffbca4137dca2792e753f53",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45928",
+					"10.65.0.27:45928",
+					"172.17.0.1:45928",
+					"172.18.0.1:45928",
+					"172.19.0.1:45928",
+					"172.20.0.1:45928",
+					"172.21.0.1:45928",
+					"172.22.0.1:45928",
+					"172.23.0.1:45928",
+					"172.24.0.1:45928",
+					"172.25.0.1:45928",
+					"172.26.0.1:45928",
+					"172.27.0.1:45928",
+					"172.28.0.1:45928",
+					"172.29.0.1:45928"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:07:02.713673659Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3420985025326015,
+				"StableID":   "nSxM5bUNiT11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5179e958e1bcee53b917d23980ecb7580fd7aee87073e51dc5a7ac5c512f305e",
+				"DiscoKey":   "discokey:ed27a9ec853c0b52ea58ff8f9db55ff7786750fd95ab32910c43367c0fc9001f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41518",
+					"10.65.0.27:41518",
+					"172.17.0.1:41518",
+					"172.18.0.1:41518",
+					"172.19.0.1:41518",
+					"172.20.0.1:41518",
+					"172.21.0.1:41518",
+					"172.22.0.1:41518",
+					"172.23.0.1:41518",
+					"172.24.0.1:41518",
+					"172.25.0.1:41518",
+					"172.26.0.1:41518",
+					"172.27.0.1:41518",
+					"172.28.0.1:41518",
+					"172.29.0.1:41518"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:07:03.260242351Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8235423448387682,
+				"StableID":   "n3PaFLcqJ721CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b5bd7a97c7b00c217cd2bd9c077b9354d5aa216043ed9106a7fd0e084372c14",
+				"DiscoKey":   "discokey:25bb0bccd6af1bce680c5e620b367bc67f38ade3332b6caae7f29431e703bd17",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53023",
+					"10.65.0.27:53023",
+					"172.17.0.1:53023",
+					"172.18.0.1:53023",
+					"172.19.0.1:53023",
+					"172.20.0.1:53023",
+					"172.21.0.1:53023",
+					"172.22.0.1:53023",
+					"172.23.0.1:53023",
+					"172.24.0.1:53023",
+					"172.25.0.1:53023",
+					"172.26.0.1:53023",
+					"172.27.0.1:53023",
+					"172.28.0.1:53023",
+					"172.29.0.1:53023"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:07:03.775745436Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1396844734654740,
+				"StableID":   "nM72w4kduB11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ffa1cbd6a2ef321eeb0ae907edbcab63a8bbdb2ae06102448a673f222c10f454",
+				"DiscoKey":   "discokey:b515939689ab44b6c96e494f002870bab12a3d1aea7d3ef97c22f85d7f720437",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37085",
+					"10.65.0.27:37085",
+					"172.17.0.1:37085",
+					"172.18.0.1:37085",
+					"172.19.0.1:37085",
+					"172.20.0.1:37085",
+					"172.21.0.1:37085",
+					"172.22.0.1:37085",
+					"172.23.0.1:37085",
+					"172.24.0.1:37085",
+					"172.25.0.1:37085",
+					"172.26.0.1:37085",
+					"172.27.0.1:37085",
+					"172.28.0.1:37085",
+					"172.29.0.1:37085"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:07:04.313556266Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3311208731492109,
+				"StableID":   "nCnDudqerS11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ece627c2d681eb4dc892f1b7f6eb3f672f6ab30d8c9a74feef6ada7722408a3c",
+				"DiscoKey":   "discokey:4f273464c671a879a1b4ca54203699d36d08f96ee1e7ab2bc1049b3cac09b347",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48595",
+					"10.65.0.27:48595",
+					"172.17.0.1:48595",
+					"172.18.0.1:48595",
+					"172.19.0.1:48595",
+					"172.20.0.1:48595",
+					"172.21.0.1:48595",
+					"172.22.0.1:48595",
+					"172.23.0.1:48595",
+					"172.24.0.1:48595",
+					"172.25.0.1:48595",
+					"172.26.0.1:48595",
+					"172.27.0.1:48595",
+					"172.28.0.1:48595",
+					"172.29.0.1:48595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:07:04.850360367Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7777277844117688,
+				"StableID":   "nw4n3GuLj321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:fa9004d8608a8f81c8df29395b2d8d3fa28defaa757cad8b431c5b3f3f54f504",
+				"KeyExpiry":  "2026-11-09T09:07:05Z",
+				"DiscoKey":   "discokey:a5b588857f4ff1a08e43b2d51eb969e370953bf7c1f8a5a69b9e0bbe1e992234",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38435",
+					"10.65.0.27:38435",
+					"172.17.0.1:38435",
+					"172.18.0.1:38435",
+					"172.19.0.1:38435",
+					"172.20.0.1:38435",
+					"172.21.0.1:38435",
+					"172.22.0.1:38435",
+					"172.23.0.1:38435",
+					"172.24.0.1:38435",
+					"172.25.0.1:38435",
+					"172.26.0.1:38435",
+					"172.27.0.1:38435",
+					"172.28.0.1:38435",
+					"172.29.0.1:38435"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:07:05.383804209Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2953439583137982,
+				"StableID":   "nf3EPHrc4Q11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6830c6e8462e7666dd6a590afa47674215e85c774bdb08585ef9c53d213dd83e",
+				"KeyExpiry":  "2026-11-09T09:07:05Z",
+				"DiscoKey":   "discokey:b73ed43ae299905067eef8003960a36279ceaaae6ddefc591c1a43ddb6a7377f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60165",
+					"10.65.0.27:60165",
+					"172.17.0.1:60165",
+					"172.18.0.1:60165",
+					"172.19.0.1:60165",
+					"172.20.0.1:60165",
+					"172.21.0.1:60165",
+					"172.22.0.1:60165",
+					"172.23.0.1:60165",
+					"172.24.0.1:60165",
+					"172.25.0.1:60165",
+					"172.26.0.1:60165",
+					"172.27.0.1:60165",
+					"172.28.0.1:60165",
+					"172.29.0.1:60165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:07:05.932371484Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6510634174200293,
+				"StableID":   "nvPaMYKgqs11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3db8e6ea02db37d77b3e725aebaddecd8e814a3d1a629b8786902d3594c12b22",
+				"KeyExpiry":  "2026-11-09T09:07:06Z",
+				"DiscoKey":   "discokey:dafff3180c3e748f84e9f52f7b5eb38cacc3d17037d6caffb6f482081346a31b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38090",
+					"10.65.0.27:38090",
+					"172.17.0.1:38090",
+					"172.18.0.1:38090",
+					"172.19.0.1:38090",
+					"172.20.0.1:38090",
+					"172.21.0.1:38090",
+					"172.22.0.1:38090",
+					"172.23.0.1:38090",
+					"172.24.0.1:38090",
+					"172.25.0.1:38090",
+					"172.26.0.1:38090",
+					"172.27.0.1:38090",
+					"172.28.0.1:38090",
+					"172.29.0.1:38090"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:07:06.470237579Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6827040522615864": {
+				"ID":          6827040522615864,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2903606537190410,
+				"StableID":   "nj5ykZp3gP11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       2903606537190410,
+				"Key":        "nodekey:50474b8b720f0f07fe21708a7bfb204fd00e64b0d318e5d3f321efd94be5dd42",
+				"DiscoKey":   "discokey:40cefa0618560ff7da77043eb69538848235b60f6c6374ae9b99f443eb06d454",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42842",
+					"10.65.0.27:42842",
+					"172.17.0.1:42842",
+					"172.18.0.1:42842",
+					"172.19.0.1:42842",
+					"172.20.0.1:42842",
+					"172.21.0.1:42842",
+					"172.22.0.1:42842",
+					"172.23.0.1:42842",
+					"172.24.0.1:42842",
+					"172.25.0.1:42842",
+					"172.26.0.1:42842",
+					"172.27.0.1:42842",
+					"172.28.0.1:42842",
+					"172.29.0.1:42842"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:07:00.548368106Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:50474b8b720f0f07fe21708a7bfb204fd00e64b0d318e5d3f321efd94be5dd42",
+			"MachineKey": "mkey:61f6821aa37bf3a86e09f8b4e8d5bab8120a7e0d2a90ad37a1a1611207cd1301",
+			"Peers": [{
+				"ID":         976708517211670,
+				"StableID":   "nsHv5eUMd811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:693f1096b5e38d38a2b4800cf64b8f3b97a0bf724420b872578cc1b5b9eda42f",
+				"DiscoKey":   "discokey:7809cb165bed2d629ee21964fa7edd13ba3fdfeaed8ed719f54bad6de3052d56",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47993",
+					"10.65.0.27:47993",
+					"172.17.0.1:47993",
+					"172.18.0.1:47993",
+					"172.19.0.1:47993",
+					"172.20.0.1:47993",
+					"172.21.0.1:47993",
+					"172.22.0.1:47993",
+					"172.23.0.1:47993",
+					"172.24.0.1:47993",
+					"172.25.0.1:47993",
+					"172.26.0.1:47993",
+					"172.27.0.1:47993",
+					"172.28.0.1:47993",
+					"172.29.0.1:47993"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:06:58.5101451Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3824448112674477,
+				"StableID":   "n4nZWUm6sW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07ec7614be9264bf4da7497e9aa2186bb3a3941c4044f10786082d5ef35f904d",
+				"DiscoKey":   "discokey:5b605feff2417171183d7c886260b3613ac1239dc192a53931081d5d0fbcf26e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34807",
+					"10.65.0.27:34807",
+					"172.17.0.1:34807",
+					"172.18.0.1:34807",
+					"172.19.0.1:34807",
+					"172.20.0.1:34807",
+					"172.21.0.1:34807",
+					"172.22.0.1:34807",
+					"172.23.0.1:34807",
+					"172.24.0.1:34807",
+					"172.25.0.1:34807",
+					"172.26.0.1:34807",
+					"172.27.0.1:34807",
+					"172.28.0.1:34807",
+					"172.29.0.1:34807"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:06:59.334581139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3527482195521367,
+				"StableID":   "nrLjKbybYU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31ed2c7eee6a2a519a5ff44c629b248934b3621cbf0e1bb65f4c91f09bcc8f5a",
+				"DiscoKey":   "discokey:a6fb79615ab1925f1c3ce0b5524724ffca017d3975fae0f63d1ce6a1ff5d6068",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39256",
+					"10.65.0.27:39256",
+					"172.17.0.1:39256",
+					"172.18.0.1:39256",
+					"172.19.0.1:39256",
+					"172.20.0.1:39256",
+					"172.21.0.1:39256",
+					"172.22.0.1:39256",
+					"172.23.0.1:39256",
+					"172.24.0.1:39256",
+					"172.25.0.1:39256",
+					"172.26.0.1:39256",
+					"172.27.0.1:39256",
+					"172.28.0.1:39256",
+					"172.29.0.1:39256"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:07:00.014319028Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6827040522615864,
+				"StableID":   "nuh8t7nyJv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b70152198f5e5e86aa84e79227f3d4d80441aebb5a39f806d59a74b9d5222506",
+				"DiscoKey":   "discokey:52277daa5b055ee6f2d00161a303f0ee0cfc022c757889c427beb190cd60d31e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:35029",
+					"10.65.0.27:35029",
+					"172.17.0.1:35029",
+					"172.18.0.1:35029",
+					"172.19.0.1:35029",
+					"172.20.0.1:35029",
+					"172.21.0.1:35029",
+					"172.22.0.1:35029",
+					"172.23.0.1:35029",
+					"172.24.0.1:35029",
+					"172.25.0.1:35029",
+					"172.26.0.1:35029",
+					"172.27.0.1:35029",
+					"172.28.0.1:35029",
+					"172.29.0.1:35029"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:07:01.089113953Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3188121042143300,
+				"StableID":   "nV5dHxXutR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:887ef6d4915e34fee99dfedda47ac9cf2596688c580675a42c3471cbebaafb11",
+				"DiscoKey":   "discokey:2ae1bcb848319c1aca0fd76bfbab00b41b9a056fb6d0dae31f6aa5830be38037",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:60559",
+					"10.65.0.27:60559",
+					"172.17.0.1:60559",
+					"172.18.0.1:60559",
+					"172.19.0.1:60559",
+					"172.20.0.1:60559",
+					"172.21.0.1:60559",
+					"172.22.0.1:60559",
+					"172.23.0.1:60559",
+					"172.24.0.1:60559",
+					"172.25.0.1:60559",
+					"172.26.0.1:60559",
+					"172.27.0.1:60559",
+					"172.28.0.1:60559",
+					"172.29.0.1:60559"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:07:01.638082773Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6026571109877032,
+				"StableID":   "njzUxcoS4p11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:18586a46b864c2ca115fc1b02bd9e189004f83438da40203ca9ae750b6d4867c",
+				"DiscoKey":   "discokey:e6c914d964da958f5bccd1e0f0438649f10177c7d2e94160426c49c294bd9550",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:46267",
+					"10.65.0.27:46267",
+					"172.17.0.1:46267",
+					"172.18.0.1:46267",
+					"172.19.0.1:46267",
+					"172.20.0.1:46267",
+					"172.21.0.1:46267",
+					"172.22.0.1:46267",
+					"172.23.0.1:46267",
+					"172.24.0.1:46267",
+					"172.25.0.1:46267",
+					"172.26.0.1:46267",
+					"172.27.0.1:46267",
+					"172.28.0.1:46267",
+					"172.29.0.1:46267"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:07:02.178830239Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3109318643116652,
+				"StableID":   "nuoa8eXDHR11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:19240fa0357506dc89722122edbf677041158ff71a947bea5301ae9c01c8847d",
+				"DiscoKey":   "discokey:63786a4d32cbdd73773c1a731cccfcf782e3f8550ffbca4137dca2792e753f53",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45928",
+					"10.65.0.27:45928",
+					"172.17.0.1:45928",
+					"172.18.0.1:45928",
+					"172.19.0.1:45928",
+					"172.20.0.1:45928",
+					"172.21.0.1:45928",
+					"172.22.0.1:45928",
+					"172.23.0.1:45928",
+					"172.24.0.1:45928",
+					"172.25.0.1:45928",
+					"172.26.0.1:45928",
+					"172.27.0.1:45928",
+					"172.28.0.1:45928",
+					"172.29.0.1:45928"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:07:02.713673659Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3420985025326015,
+				"StableID":   "nSxM5bUNiT11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5179e958e1bcee53b917d23980ecb7580fd7aee87073e51dc5a7ac5c512f305e",
+				"DiscoKey":   "discokey:ed27a9ec853c0b52ea58ff8f9db55ff7786750fd95ab32910c43367c0fc9001f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41518",
+					"10.65.0.27:41518",
+					"172.17.0.1:41518",
+					"172.18.0.1:41518",
+					"172.19.0.1:41518",
+					"172.20.0.1:41518",
+					"172.21.0.1:41518",
+					"172.22.0.1:41518",
+					"172.23.0.1:41518",
+					"172.24.0.1:41518",
+					"172.25.0.1:41518",
+					"172.26.0.1:41518",
+					"172.27.0.1:41518",
+					"172.28.0.1:41518",
+					"172.29.0.1:41518"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:07:03.260242351Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8235423448387682,
+				"StableID":   "n3PaFLcqJ721CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b5bd7a97c7b00c217cd2bd9c077b9354d5aa216043ed9106a7fd0e084372c14",
+				"DiscoKey":   "discokey:25bb0bccd6af1bce680c5e620b367bc67f38ade3332b6caae7f29431e703bd17",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53023",
+					"10.65.0.27:53023",
+					"172.17.0.1:53023",
+					"172.18.0.1:53023",
+					"172.19.0.1:53023",
+					"172.20.0.1:53023",
+					"172.21.0.1:53023",
+					"172.22.0.1:53023",
+					"172.23.0.1:53023",
+					"172.24.0.1:53023",
+					"172.25.0.1:53023",
+					"172.26.0.1:53023",
+					"172.27.0.1:53023",
+					"172.28.0.1:53023",
+					"172.29.0.1:53023"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:07:03.775745436Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1396844734654740,
+				"StableID":   "nM72w4kduB11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ffa1cbd6a2ef321eeb0ae907edbcab63a8bbdb2ae06102448a673f222c10f454",
+				"DiscoKey":   "discokey:b515939689ab44b6c96e494f002870bab12a3d1aea7d3ef97c22f85d7f720437",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37085",
+					"10.65.0.27:37085",
+					"172.17.0.1:37085",
+					"172.18.0.1:37085",
+					"172.19.0.1:37085",
+					"172.20.0.1:37085",
+					"172.21.0.1:37085",
+					"172.22.0.1:37085",
+					"172.23.0.1:37085",
+					"172.24.0.1:37085",
+					"172.25.0.1:37085",
+					"172.26.0.1:37085",
+					"172.27.0.1:37085",
+					"172.28.0.1:37085",
+					"172.29.0.1:37085"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:07:04.313556266Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3311208731492109,
+				"StableID":   "nCnDudqerS11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ece627c2d681eb4dc892f1b7f6eb3f672f6ab30d8c9a74feef6ada7722408a3c",
+				"DiscoKey":   "discokey:4f273464c671a879a1b4ca54203699d36d08f96ee1e7ab2bc1049b3cac09b347",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48595",
+					"10.65.0.27:48595",
+					"172.17.0.1:48595",
+					"172.18.0.1:48595",
+					"172.19.0.1:48595",
+					"172.20.0.1:48595",
+					"172.21.0.1:48595",
+					"172.22.0.1:48595",
+					"172.23.0.1:48595",
+					"172.24.0.1:48595",
+					"172.25.0.1:48595",
+					"172.26.0.1:48595",
+					"172.27.0.1:48595",
+					"172.28.0.1:48595",
+					"172.29.0.1:48595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:07:04.850360367Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7777277844117688,
+				"StableID":   "nw4n3GuLj321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:fa9004d8608a8f81c8df29395b2d8d3fa28defaa757cad8b431c5b3f3f54f504",
+				"KeyExpiry":  "2026-11-09T09:07:05Z",
+				"DiscoKey":   "discokey:a5b588857f4ff1a08e43b2d51eb969e370953bf7c1f8a5a69b9e0bbe1e992234",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38435",
+					"10.65.0.27:38435",
+					"172.17.0.1:38435",
+					"172.18.0.1:38435",
+					"172.19.0.1:38435",
+					"172.20.0.1:38435",
+					"172.21.0.1:38435",
+					"172.22.0.1:38435",
+					"172.23.0.1:38435",
+					"172.24.0.1:38435",
+					"172.25.0.1:38435",
+					"172.26.0.1:38435",
+					"172.27.0.1:38435",
+					"172.28.0.1:38435",
+					"172.29.0.1:38435"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:07:05.383804209Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2953439583137982,
+				"StableID":   "nf3EPHrc4Q11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6830c6e8462e7666dd6a590afa47674215e85c774bdb08585ef9c53d213dd83e",
+				"KeyExpiry":  "2026-11-09T09:07:05Z",
+				"DiscoKey":   "discokey:b73ed43ae299905067eef8003960a36279ceaaae6ddefc591c1a43ddb6a7377f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60165",
+					"10.65.0.27:60165",
+					"172.17.0.1:60165",
+					"172.18.0.1:60165",
+					"172.19.0.1:60165",
+					"172.20.0.1:60165",
+					"172.21.0.1:60165",
+					"172.22.0.1:60165",
+					"172.23.0.1:60165",
+					"172.24.0.1:60165",
+					"172.25.0.1:60165",
+					"172.26.0.1:60165",
+					"172.27.0.1:60165",
+					"172.28.0.1:60165",
+					"172.29.0.1:60165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:07:05.932371484Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6510634174200293,
+				"StableID":   "nvPaMYKgqs11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3db8e6ea02db37d77b3e725aebaddecd8e814a3d1a629b8786902d3594c12b22",
+				"KeyExpiry":  "2026-11-09T09:07:06Z",
+				"DiscoKey":   "discokey:dafff3180c3e748f84e9f52f7b5eb38cacc3d17037d6caffb6f482081346a31b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38090",
+					"10.65.0.27:38090",
+					"172.17.0.1:38090",
+					"172.18.0.1:38090",
+					"172.19.0.1:38090",
+					"172.20.0.1:38090",
+					"172.21.0.1:38090",
+					"172.22.0.1:38090",
+					"172.23.0.1:38090",
+					"172.24.0.1:38090",
+					"172.25.0.1:38090",
+					"172.26.0.1:38090",
+					"172.27.0.1:38090",
+					"172.28.0.1:38090",
+					"172.29.0.1:38090"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:07:06.470237579Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2903606537190410": {
+				"ID":          2903606537190410,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6026571109877032,
+				"StableID":   "njzUxcoS4p11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       6026571109877032,
+				"Key":        "nodekey:18586a46b864c2ca115fc1b02bd9e189004f83438da40203ca9ae750b6d4867c",
+				"DiscoKey":   "discokey:e6c914d964da958f5bccd1e0f0438649f10177c7d2e94160426c49c294bd9550",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:46267",
+					"10.65.0.27:46267",
+					"172.17.0.1:46267",
+					"172.18.0.1:46267",
+					"172.19.0.1:46267",
+					"172.20.0.1:46267",
+					"172.21.0.1:46267",
+					"172.22.0.1:46267",
+					"172.23.0.1:46267",
+					"172.24.0.1:46267",
+					"172.25.0.1:46267",
+					"172.26.0.1:46267",
+					"172.27.0.1:46267",
+					"172.28.0.1:46267",
+					"172.29.0.1:46267"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:07:02.178830239Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:18586a46b864c2ca115fc1b02bd9e189004f83438da40203ca9ae750b6d4867c",
+			"MachineKey": "mkey:eb1d5525bcda65dbe878d15fc4a94c22498af0d4b76d4c1bdfde199d35b2e54c",
+			"Peers": [{
+				"ID":         976708517211670,
+				"StableID":   "nsHv5eUMd811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:693f1096b5e38d38a2b4800cf64b8f3b97a0bf724420b872578cc1b5b9eda42f",
+				"DiscoKey":   "discokey:7809cb165bed2d629ee21964fa7edd13ba3fdfeaed8ed719f54bad6de3052d56",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47993",
+					"10.65.0.27:47993",
+					"172.17.0.1:47993",
+					"172.18.0.1:47993",
+					"172.19.0.1:47993",
+					"172.20.0.1:47993",
+					"172.21.0.1:47993",
+					"172.22.0.1:47993",
+					"172.23.0.1:47993",
+					"172.24.0.1:47993",
+					"172.25.0.1:47993",
+					"172.26.0.1:47993",
+					"172.27.0.1:47993",
+					"172.28.0.1:47993",
+					"172.29.0.1:47993"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:06:58.5101451Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3824448112674477,
+				"StableID":   "n4nZWUm6sW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07ec7614be9264bf4da7497e9aa2186bb3a3941c4044f10786082d5ef35f904d",
+				"DiscoKey":   "discokey:5b605feff2417171183d7c886260b3613ac1239dc192a53931081d5d0fbcf26e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34807",
+					"10.65.0.27:34807",
+					"172.17.0.1:34807",
+					"172.18.0.1:34807",
+					"172.19.0.1:34807",
+					"172.20.0.1:34807",
+					"172.21.0.1:34807",
+					"172.22.0.1:34807",
+					"172.23.0.1:34807",
+					"172.24.0.1:34807",
+					"172.25.0.1:34807",
+					"172.26.0.1:34807",
+					"172.27.0.1:34807",
+					"172.28.0.1:34807",
+					"172.29.0.1:34807"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:06:59.334581139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3527482195521367,
+				"StableID":   "nrLjKbybYU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31ed2c7eee6a2a519a5ff44c629b248934b3621cbf0e1bb65f4c91f09bcc8f5a",
+				"DiscoKey":   "discokey:a6fb79615ab1925f1c3ce0b5524724ffca017d3975fae0f63d1ce6a1ff5d6068",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39256",
+					"10.65.0.27:39256",
+					"172.17.0.1:39256",
+					"172.18.0.1:39256",
+					"172.19.0.1:39256",
+					"172.20.0.1:39256",
+					"172.21.0.1:39256",
+					"172.22.0.1:39256",
+					"172.23.0.1:39256",
+					"172.24.0.1:39256",
+					"172.25.0.1:39256",
+					"172.26.0.1:39256",
+					"172.27.0.1:39256",
+					"172.28.0.1:39256",
+					"172.29.0.1:39256"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:07:00.014319028Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2903606537190410,
+				"StableID":   "nj5ykZp3gP11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:50474b8b720f0f07fe21708a7bfb204fd00e64b0d318e5d3f321efd94be5dd42",
+				"DiscoKey":   "discokey:40cefa0618560ff7da77043eb69538848235b60f6c6374ae9b99f443eb06d454",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42842",
+					"10.65.0.27:42842",
+					"172.17.0.1:42842",
+					"172.18.0.1:42842",
+					"172.19.0.1:42842",
+					"172.20.0.1:42842",
+					"172.21.0.1:42842",
+					"172.22.0.1:42842",
+					"172.23.0.1:42842",
+					"172.24.0.1:42842",
+					"172.25.0.1:42842",
+					"172.26.0.1:42842",
+					"172.27.0.1:42842",
+					"172.28.0.1:42842",
+					"172.29.0.1:42842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:07:00.548368106Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6827040522615864,
+				"StableID":   "nuh8t7nyJv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b70152198f5e5e86aa84e79227f3d4d80441aebb5a39f806d59a74b9d5222506",
+				"DiscoKey":   "discokey:52277daa5b055ee6f2d00161a303f0ee0cfc022c757889c427beb190cd60d31e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:35029",
+					"10.65.0.27:35029",
+					"172.17.0.1:35029",
+					"172.18.0.1:35029",
+					"172.19.0.1:35029",
+					"172.20.0.1:35029",
+					"172.21.0.1:35029",
+					"172.22.0.1:35029",
+					"172.23.0.1:35029",
+					"172.24.0.1:35029",
+					"172.25.0.1:35029",
+					"172.26.0.1:35029",
+					"172.27.0.1:35029",
+					"172.28.0.1:35029",
+					"172.29.0.1:35029"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:07:01.089113953Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3188121042143300,
+				"StableID":   "nV5dHxXutR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:887ef6d4915e34fee99dfedda47ac9cf2596688c580675a42c3471cbebaafb11",
+				"DiscoKey":   "discokey:2ae1bcb848319c1aca0fd76bfbab00b41b9a056fb6d0dae31f6aa5830be38037",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:60559",
+					"10.65.0.27:60559",
+					"172.17.0.1:60559",
+					"172.18.0.1:60559",
+					"172.19.0.1:60559",
+					"172.20.0.1:60559",
+					"172.21.0.1:60559",
+					"172.22.0.1:60559",
+					"172.23.0.1:60559",
+					"172.24.0.1:60559",
+					"172.25.0.1:60559",
+					"172.26.0.1:60559",
+					"172.27.0.1:60559",
+					"172.28.0.1:60559",
+					"172.29.0.1:60559"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:07:01.638082773Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3109318643116652,
+				"StableID":   "nuoa8eXDHR11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:19240fa0357506dc89722122edbf677041158ff71a947bea5301ae9c01c8847d",
+				"DiscoKey":   "discokey:63786a4d32cbdd73773c1a731cccfcf782e3f8550ffbca4137dca2792e753f53",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45928",
+					"10.65.0.27:45928",
+					"172.17.0.1:45928",
+					"172.18.0.1:45928",
+					"172.19.0.1:45928",
+					"172.20.0.1:45928",
+					"172.21.0.1:45928",
+					"172.22.0.1:45928",
+					"172.23.0.1:45928",
+					"172.24.0.1:45928",
+					"172.25.0.1:45928",
+					"172.26.0.1:45928",
+					"172.27.0.1:45928",
+					"172.28.0.1:45928",
+					"172.29.0.1:45928"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:07:02.713673659Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3420985025326015,
+				"StableID":   "nSxM5bUNiT11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5179e958e1bcee53b917d23980ecb7580fd7aee87073e51dc5a7ac5c512f305e",
+				"DiscoKey":   "discokey:ed27a9ec853c0b52ea58ff8f9db55ff7786750fd95ab32910c43367c0fc9001f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41518",
+					"10.65.0.27:41518",
+					"172.17.0.1:41518",
+					"172.18.0.1:41518",
+					"172.19.0.1:41518",
+					"172.20.0.1:41518",
+					"172.21.0.1:41518",
+					"172.22.0.1:41518",
+					"172.23.0.1:41518",
+					"172.24.0.1:41518",
+					"172.25.0.1:41518",
+					"172.26.0.1:41518",
+					"172.27.0.1:41518",
+					"172.28.0.1:41518",
+					"172.29.0.1:41518"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:07:03.260242351Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8235423448387682,
+				"StableID":   "n3PaFLcqJ721CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b5bd7a97c7b00c217cd2bd9c077b9354d5aa216043ed9106a7fd0e084372c14",
+				"DiscoKey":   "discokey:25bb0bccd6af1bce680c5e620b367bc67f38ade3332b6caae7f29431e703bd17",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53023",
+					"10.65.0.27:53023",
+					"172.17.0.1:53023",
+					"172.18.0.1:53023",
+					"172.19.0.1:53023",
+					"172.20.0.1:53023",
+					"172.21.0.1:53023",
+					"172.22.0.1:53023",
+					"172.23.0.1:53023",
+					"172.24.0.1:53023",
+					"172.25.0.1:53023",
+					"172.26.0.1:53023",
+					"172.27.0.1:53023",
+					"172.28.0.1:53023",
+					"172.29.0.1:53023"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:07:03.775745436Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1396844734654740,
+				"StableID":   "nM72w4kduB11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ffa1cbd6a2ef321eeb0ae907edbcab63a8bbdb2ae06102448a673f222c10f454",
+				"DiscoKey":   "discokey:b515939689ab44b6c96e494f002870bab12a3d1aea7d3ef97c22f85d7f720437",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37085",
+					"10.65.0.27:37085",
+					"172.17.0.1:37085",
+					"172.18.0.1:37085",
+					"172.19.0.1:37085",
+					"172.20.0.1:37085",
+					"172.21.0.1:37085",
+					"172.22.0.1:37085",
+					"172.23.0.1:37085",
+					"172.24.0.1:37085",
+					"172.25.0.1:37085",
+					"172.26.0.1:37085",
+					"172.27.0.1:37085",
+					"172.28.0.1:37085",
+					"172.29.0.1:37085"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:07:04.313556266Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3311208731492109,
+				"StableID":   "nCnDudqerS11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ece627c2d681eb4dc892f1b7f6eb3f672f6ab30d8c9a74feef6ada7722408a3c",
+				"DiscoKey":   "discokey:4f273464c671a879a1b4ca54203699d36d08f96ee1e7ab2bc1049b3cac09b347",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48595",
+					"10.65.0.27:48595",
+					"172.17.0.1:48595",
+					"172.18.0.1:48595",
+					"172.19.0.1:48595",
+					"172.20.0.1:48595",
+					"172.21.0.1:48595",
+					"172.22.0.1:48595",
+					"172.23.0.1:48595",
+					"172.24.0.1:48595",
+					"172.25.0.1:48595",
+					"172.26.0.1:48595",
+					"172.27.0.1:48595",
+					"172.28.0.1:48595",
+					"172.29.0.1:48595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:07:04.850360367Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7777277844117688,
+				"StableID":   "nw4n3GuLj321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:fa9004d8608a8f81c8df29395b2d8d3fa28defaa757cad8b431c5b3f3f54f504",
+				"KeyExpiry":  "2026-11-09T09:07:05Z",
+				"DiscoKey":   "discokey:a5b588857f4ff1a08e43b2d51eb969e370953bf7c1f8a5a69b9e0bbe1e992234",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38435",
+					"10.65.0.27:38435",
+					"172.17.0.1:38435",
+					"172.18.0.1:38435",
+					"172.19.0.1:38435",
+					"172.20.0.1:38435",
+					"172.21.0.1:38435",
+					"172.22.0.1:38435",
+					"172.23.0.1:38435",
+					"172.24.0.1:38435",
+					"172.25.0.1:38435",
+					"172.26.0.1:38435",
+					"172.27.0.1:38435",
+					"172.28.0.1:38435",
+					"172.29.0.1:38435"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:07:05.383804209Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2953439583137982,
+				"StableID":   "nf3EPHrc4Q11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6830c6e8462e7666dd6a590afa47674215e85c774bdb08585ef9c53d213dd83e",
+				"KeyExpiry":  "2026-11-09T09:07:05Z",
+				"DiscoKey":   "discokey:b73ed43ae299905067eef8003960a36279ceaaae6ddefc591c1a43ddb6a7377f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60165",
+					"10.65.0.27:60165",
+					"172.17.0.1:60165",
+					"172.18.0.1:60165",
+					"172.19.0.1:60165",
+					"172.20.0.1:60165",
+					"172.21.0.1:60165",
+					"172.22.0.1:60165",
+					"172.23.0.1:60165",
+					"172.24.0.1:60165",
+					"172.25.0.1:60165",
+					"172.26.0.1:60165",
+					"172.27.0.1:60165",
+					"172.28.0.1:60165",
+					"172.29.0.1:60165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:07:05.932371484Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6510634174200293,
+				"StableID":   "nvPaMYKgqs11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3db8e6ea02db37d77b3e725aebaddecd8e814a3d1a629b8786902d3594c12b22",
+				"KeyExpiry":  "2026-11-09T09:07:06Z",
+				"DiscoKey":   "discokey:dafff3180c3e748f84e9f52f7b5eb38cacc3d17037d6caffb6f482081346a31b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38090",
+					"10.65.0.27:38090",
+					"172.17.0.1:38090",
+					"172.18.0.1:38090",
+					"172.19.0.1:38090",
+					"172.20.0.1:38090",
+					"172.21.0.1:38090",
+					"172.22.0.1:38090",
+					"172.23.0.1:38090",
+					"172.24.0.1:38090",
+					"172.25.0.1:38090",
+					"172.26.0.1:38090",
+					"172.27.0.1:38090",
+					"172.28.0.1:38090",
+					"172.29.0.1:38090"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:07:06.470237579Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6026571109877032": {
+				"ID":          6026571109877032,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3420985025326015,
+				"StableID":   "nSxM5bUNiT11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       3420985025326015,
+				"Key":        "nodekey:5179e958e1bcee53b917d23980ecb7580fd7aee87073e51dc5a7ac5c512f305e",
+				"DiscoKey":   "discokey:ed27a9ec853c0b52ea58ff8f9db55ff7786750fd95ab32910c43367c0fc9001f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41518",
+					"10.65.0.27:41518",
+					"172.17.0.1:41518",
+					"172.18.0.1:41518",
+					"172.19.0.1:41518",
+					"172.20.0.1:41518",
+					"172.21.0.1:41518",
+					"172.22.0.1:41518",
+					"172.23.0.1:41518",
+					"172.24.0.1:41518",
+					"172.25.0.1:41518",
+					"172.26.0.1:41518",
+					"172.27.0.1:41518",
+					"172.28.0.1:41518",
+					"172.29.0.1:41518"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:07:03.260242351Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5179e958e1bcee53b917d23980ecb7580fd7aee87073e51dc5a7ac5c512f305e",
+			"MachineKey": "mkey:3ae01cab68806b9d78d2d781ef7cc55940fe896317dda48b145ba7bb1c04ca4d",
+			"Peers": [{
+				"ID":         976708517211670,
+				"StableID":   "nsHv5eUMd811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:693f1096b5e38d38a2b4800cf64b8f3b97a0bf724420b872578cc1b5b9eda42f",
+				"DiscoKey":   "discokey:7809cb165bed2d629ee21964fa7edd13ba3fdfeaed8ed719f54bad6de3052d56",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47993",
+					"10.65.0.27:47993",
+					"172.17.0.1:47993",
+					"172.18.0.1:47993",
+					"172.19.0.1:47993",
+					"172.20.0.1:47993",
+					"172.21.0.1:47993",
+					"172.22.0.1:47993",
+					"172.23.0.1:47993",
+					"172.24.0.1:47993",
+					"172.25.0.1:47993",
+					"172.26.0.1:47993",
+					"172.27.0.1:47993",
+					"172.28.0.1:47993",
+					"172.29.0.1:47993"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:06:58.5101451Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3824448112674477,
+				"StableID":   "n4nZWUm6sW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07ec7614be9264bf4da7497e9aa2186bb3a3941c4044f10786082d5ef35f904d",
+				"DiscoKey":   "discokey:5b605feff2417171183d7c886260b3613ac1239dc192a53931081d5d0fbcf26e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34807",
+					"10.65.0.27:34807",
+					"172.17.0.1:34807",
+					"172.18.0.1:34807",
+					"172.19.0.1:34807",
+					"172.20.0.1:34807",
+					"172.21.0.1:34807",
+					"172.22.0.1:34807",
+					"172.23.0.1:34807",
+					"172.24.0.1:34807",
+					"172.25.0.1:34807",
+					"172.26.0.1:34807",
+					"172.27.0.1:34807",
+					"172.28.0.1:34807",
+					"172.29.0.1:34807"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:06:59.334581139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3527482195521367,
+				"StableID":   "nrLjKbybYU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31ed2c7eee6a2a519a5ff44c629b248934b3621cbf0e1bb65f4c91f09bcc8f5a",
+				"DiscoKey":   "discokey:a6fb79615ab1925f1c3ce0b5524724ffca017d3975fae0f63d1ce6a1ff5d6068",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39256",
+					"10.65.0.27:39256",
+					"172.17.0.1:39256",
+					"172.18.0.1:39256",
+					"172.19.0.1:39256",
+					"172.20.0.1:39256",
+					"172.21.0.1:39256",
+					"172.22.0.1:39256",
+					"172.23.0.1:39256",
+					"172.24.0.1:39256",
+					"172.25.0.1:39256",
+					"172.26.0.1:39256",
+					"172.27.0.1:39256",
+					"172.28.0.1:39256",
+					"172.29.0.1:39256"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:07:00.014319028Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2903606537190410,
+				"StableID":   "nj5ykZp3gP11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:50474b8b720f0f07fe21708a7bfb204fd00e64b0d318e5d3f321efd94be5dd42",
+				"DiscoKey":   "discokey:40cefa0618560ff7da77043eb69538848235b60f6c6374ae9b99f443eb06d454",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42842",
+					"10.65.0.27:42842",
+					"172.17.0.1:42842",
+					"172.18.0.1:42842",
+					"172.19.0.1:42842",
+					"172.20.0.1:42842",
+					"172.21.0.1:42842",
+					"172.22.0.1:42842",
+					"172.23.0.1:42842",
+					"172.24.0.1:42842",
+					"172.25.0.1:42842",
+					"172.26.0.1:42842",
+					"172.27.0.1:42842",
+					"172.28.0.1:42842",
+					"172.29.0.1:42842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:07:00.548368106Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6827040522615864,
+				"StableID":   "nuh8t7nyJv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b70152198f5e5e86aa84e79227f3d4d80441aebb5a39f806d59a74b9d5222506",
+				"DiscoKey":   "discokey:52277daa5b055ee6f2d00161a303f0ee0cfc022c757889c427beb190cd60d31e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:35029",
+					"10.65.0.27:35029",
+					"172.17.0.1:35029",
+					"172.18.0.1:35029",
+					"172.19.0.1:35029",
+					"172.20.0.1:35029",
+					"172.21.0.1:35029",
+					"172.22.0.1:35029",
+					"172.23.0.1:35029",
+					"172.24.0.1:35029",
+					"172.25.0.1:35029",
+					"172.26.0.1:35029",
+					"172.27.0.1:35029",
+					"172.28.0.1:35029",
+					"172.29.0.1:35029"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:07:01.089113953Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3188121042143300,
+				"StableID":   "nV5dHxXutR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:887ef6d4915e34fee99dfedda47ac9cf2596688c580675a42c3471cbebaafb11",
+				"DiscoKey":   "discokey:2ae1bcb848319c1aca0fd76bfbab00b41b9a056fb6d0dae31f6aa5830be38037",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:60559",
+					"10.65.0.27:60559",
+					"172.17.0.1:60559",
+					"172.18.0.1:60559",
+					"172.19.0.1:60559",
+					"172.20.0.1:60559",
+					"172.21.0.1:60559",
+					"172.22.0.1:60559",
+					"172.23.0.1:60559",
+					"172.24.0.1:60559",
+					"172.25.0.1:60559",
+					"172.26.0.1:60559",
+					"172.27.0.1:60559",
+					"172.28.0.1:60559",
+					"172.29.0.1:60559"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:07:01.638082773Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6026571109877032,
+				"StableID":   "njzUxcoS4p11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:18586a46b864c2ca115fc1b02bd9e189004f83438da40203ca9ae750b6d4867c",
+				"DiscoKey":   "discokey:e6c914d964da958f5bccd1e0f0438649f10177c7d2e94160426c49c294bd9550",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:46267",
+					"10.65.0.27:46267",
+					"172.17.0.1:46267",
+					"172.18.0.1:46267",
+					"172.19.0.1:46267",
+					"172.20.0.1:46267",
+					"172.21.0.1:46267",
+					"172.22.0.1:46267",
+					"172.23.0.1:46267",
+					"172.24.0.1:46267",
+					"172.25.0.1:46267",
+					"172.26.0.1:46267",
+					"172.27.0.1:46267",
+					"172.28.0.1:46267",
+					"172.29.0.1:46267"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:07:02.178830239Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3109318643116652,
+				"StableID":   "nuoa8eXDHR11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:19240fa0357506dc89722122edbf677041158ff71a947bea5301ae9c01c8847d",
+				"DiscoKey":   "discokey:63786a4d32cbdd73773c1a731cccfcf782e3f8550ffbca4137dca2792e753f53",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45928",
+					"10.65.0.27:45928",
+					"172.17.0.1:45928",
+					"172.18.0.1:45928",
+					"172.19.0.1:45928",
+					"172.20.0.1:45928",
+					"172.21.0.1:45928",
+					"172.22.0.1:45928",
+					"172.23.0.1:45928",
+					"172.24.0.1:45928",
+					"172.25.0.1:45928",
+					"172.26.0.1:45928",
+					"172.27.0.1:45928",
+					"172.28.0.1:45928",
+					"172.29.0.1:45928"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:07:02.713673659Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8235423448387682,
+				"StableID":   "n3PaFLcqJ721CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b5bd7a97c7b00c217cd2bd9c077b9354d5aa216043ed9106a7fd0e084372c14",
+				"DiscoKey":   "discokey:25bb0bccd6af1bce680c5e620b367bc67f38ade3332b6caae7f29431e703bd17",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53023",
+					"10.65.0.27:53023",
+					"172.17.0.1:53023",
+					"172.18.0.1:53023",
+					"172.19.0.1:53023",
+					"172.20.0.1:53023",
+					"172.21.0.1:53023",
+					"172.22.0.1:53023",
+					"172.23.0.1:53023",
+					"172.24.0.1:53023",
+					"172.25.0.1:53023",
+					"172.26.0.1:53023",
+					"172.27.0.1:53023",
+					"172.28.0.1:53023",
+					"172.29.0.1:53023"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:07:03.775745436Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1396844734654740,
+				"StableID":   "nM72w4kduB11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ffa1cbd6a2ef321eeb0ae907edbcab63a8bbdb2ae06102448a673f222c10f454",
+				"DiscoKey":   "discokey:b515939689ab44b6c96e494f002870bab12a3d1aea7d3ef97c22f85d7f720437",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37085",
+					"10.65.0.27:37085",
+					"172.17.0.1:37085",
+					"172.18.0.1:37085",
+					"172.19.0.1:37085",
+					"172.20.0.1:37085",
+					"172.21.0.1:37085",
+					"172.22.0.1:37085",
+					"172.23.0.1:37085",
+					"172.24.0.1:37085",
+					"172.25.0.1:37085",
+					"172.26.0.1:37085",
+					"172.27.0.1:37085",
+					"172.28.0.1:37085",
+					"172.29.0.1:37085"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:07:04.313556266Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3311208731492109,
+				"StableID":   "nCnDudqerS11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ece627c2d681eb4dc892f1b7f6eb3f672f6ab30d8c9a74feef6ada7722408a3c",
+				"DiscoKey":   "discokey:4f273464c671a879a1b4ca54203699d36d08f96ee1e7ab2bc1049b3cac09b347",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48595",
+					"10.65.0.27:48595",
+					"172.17.0.1:48595",
+					"172.18.0.1:48595",
+					"172.19.0.1:48595",
+					"172.20.0.1:48595",
+					"172.21.0.1:48595",
+					"172.22.0.1:48595",
+					"172.23.0.1:48595",
+					"172.24.0.1:48595",
+					"172.25.0.1:48595",
+					"172.26.0.1:48595",
+					"172.27.0.1:48595",
+					"172.28.0.1:48595",
+					"172.29.0.1:48595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:07:04.850360367Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7777277844117688,
+				"StableID":   "nw4n3GuLj321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:fa9004d8608a8f81c8df29395b2d8d3fa28defaa757cad8b431c5b3f3f54f504",
+				"KeyExpiry":  "2026-11-09T09:07:05Z",
+				"DiscoKey":   "discokey:a5b588857f4ff1a08e43b2d51eb969e370953bf7c1f8a5a69b9e0bbe1e992234",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38435",
+					"10.65.0.27:38435",
+					"172.17.0.1:38435",
+					"172.18.0.1:38435",
+					"172.19.0.1:38435",
+					"172.20.0.1:38435",
+					"172.21.0.1:38435",
+					"172.22.0.1:38435",
+					"172.23.0.1:38435",
+					"172.24.0.1:38435",
+					"172.25.0.1:38435",
+					"172.26.0.1:38435",
+					"172.27.0.1:38435",
+					"172.28.0.1:38435",
+					"172.29.0.1:38435"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:07:05.383804209Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2953439583137982,
+				"StableID":   "nf3EPHrc4Q11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6830c6e8462e7666dd6a590afa47674215e85c774bdb08585ef9c53d213dd83e",
+				"KeyExpiry":  "2026-11-09T09:07:05Z",
+				"DiscoKey":   "discokey:b73ed43ae299905067eef8003960a36279ceaaae6ddefc591c1a43ddb6a7377f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60165",
+					"10.65.0.27:60165",
+					"172.17.0.1:60165",
+					"172.18.0.1:60165",
+					"172.19.0.1:60165",
+					"172.20.0.1:60165",
+					"172.21.0.1:60165",
+					"172.22.0.1:60165",
+					"172.23.0.1:60165",
+					"172.24.0.1:60165",
+					"172.25.0.1:60165",
+					"172.26.0.1:60165",
+					"172.27.0.1:60165",
+					"172.28.0.1:60165",
+					"172.29.0.1:60165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:07:05.932371484Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6510634174200293,
+				"StableID":   "nvPaMYKgqs11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3db8e6ea02db37d77b3e725aebaddecd8e814a3d1a629b8786902d3594c12b22",
+				"KeyExpiry":  "2026-11-09T09:07:06Z",
+				"DiscoKey":   "discokey:dafff3180c3e748f84e9f52f7b5eb38cacc3d17037d6caffb6f482081346a31b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38090",
+					"10.65.0.27:38090",
+					"172.17.0.1:38090",
+					"172.18.0.1:38090",
+					"172.19.0.1:38090",
+					"172.20.0.1:38090",
+					"172.21.0.1:38090",
+					"172.22.0.1:38090",
+					"172.23.0.1:38090",
+					"172.24.0.1:38090",
+					"172.25.0.1:38090",
+					"172.26.0.1:38090",
+					"172.27.0.1:38090",
+					"172.28.0.1:38090",
+					"172.29.0.1:38090"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:07:06.470237579Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3420985025326015": {
+				"ID":          3420985025326015,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2953439583137982,
+				"StableID":   "nf3EPHrc4Q11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6830c6e8462e7666dd6a590afa47674215e85c774bdb08585ef9c53d213dd83e",
+				"KeyExpiry":  "2026-11-09T09:07:05Z",
+				"DiscoKey":   "discokey:b73ed43ae299905067eef8003960a36279ceaaae6ddefc591c1a43ddb6a7377f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60165",
+					"10.65.0.27:60165",
+					"172.17.0.1:60165",
+					"172.18.0.1:60165",
+					"172.19.0.1:60165",
+					"172.20.0.1:60165",
+					"172.21.0.1:60165",
+					"172.22.0.1:60165",
+					"172.23.0.1:60165",
+					"172.24.0.1:60165",
+					"172.25.0.1:60165",
+					"172.26.0.1:60165",
+					"172.27.0.1:60165",
+					"172.28.0.1:60165",
+					"172.29.0.1:60165"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:07:05.932371484Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6830c6e8462e7666dd6a590afa47674215e85c774bdb08585ef9c53d213dd83e",
+			"MachineKey": "mkey:caf3eee336592139608baefdeacfa79725f068b88ae2994848f8758026a6f816",
+			"Peers": [{
+				"ID":         976708517211670,
+				"StableID":   "nsHv5eUMd811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:693f1096b5e38d38a2b4800cf64b8f3b97a0bf724420b872578cc1b5b9eda42f",
+				"DiscoKey":   "discokey:7809cb165bed2d629ee21964fa7edd13ba3fdfeaed8ed719f54bad6de3052d56",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47993",
+					"10.65.0.27:47993",
+					"172.17.0.1:47993",
+					"172.18.0.1:47993",
+					"172.19.0.1:47993",
+					"172.20.0.1:47993",
+					"172.21.0.1:47993",
+					"172.22.0.1:47993",
+					"172.23.0.1:47993",
+					"172.24.0.1:47993",
+					"172.25.0.1:47993",
+					"172.26.0.1:47993",
+					"172.27.0.1:47993",
+					"172.28.0.1:47993",
+					"172.29.0.1:47993"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:06:58.5101451Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3824448112674477,
+				"StableID":   "n4nZWUm6sW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07ec7614be9264bf4da7497e9aa2186bb3a3941c4044f10786082d5ef35f904d",
+				"DiscoKey":   "discokey:5b605feff2417171183d7c886260b3613ac1239dc192a53931081d5d0fbcf26e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34807",
+					"10.65.0.27:34807",
+					"172.17.0.1:34807",
+					"172.18.0.1:34807",
+					"172.19.0.1:34807",
+					"172.20.0.1:34807",
+					"172.21.0.1:34807",
+					"172.22.0.1:34807",
+					"172.23.0.1:34807",
+					"172.24.0.1:34807",
+					"172.25.0.1:34807",
+					"172.26.0.1:34807",
+					"172.27.0.1:34807",
+					"172.28.0.1:34807",
+					"172.29.0.1:34807"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:06:59.334581139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3527482195521367,
+				"StableID":   "nrLjKbybYU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31ed2c7eee6a2a519a5ff44c629b248934b3621cbf0e1bb65f4c91f09bcc8f5a",
+				"DiscoKey":   "discokey:a6fb79615ab1925f1c3ce0b5524724ffca017d3975fae0f63d1ce6a1ff5d6068",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39256",
+					"10.65.0.27:39256",
+					"172.17.0.1:39256",
+					"172.18.0.1:39256",
+					"172.19.0.1:39256",
+					"172.20.0.1:39256",
+					"172.21.0.1:39256",
+					"172.22.0.1:39256",
+					"172.23.0.1:39256",
+					"172.24.0.1:39256",
+					"172.25.0.1:39256",
+					"172.26.0.1:39256",
+					"172.27.0.1:39256",
+					"172.28.0.1:39256",
+					"172.29.0.1:39256"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:07:00.014319028Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2903606537190410,
+				"StableID":   "nj5ykZp3gP11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:50474b8b720f0f07fe21708a7bfb204fd00e64b0d318e5d3f321efd94be5dd42",
+				"DiscoKey":   "discokey:40cefa0618560ff7da77043eb69538848235b60f6c6374ae9b99f443eb06d454",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42842",
+					"10.65.0.27:42842",
+					"172.17.0.1:42842",
+					"172.18.0.1:42842",
+					"172.19.0.1:42842",
+					"172.20.0.1:42842",
+					"172.21.0.1:42842",
+					"172.22.0.1:42842",
+					"172.23.0.1:42842",
+					"172.24.0.1:42842",
+					"172.25.0.1:42842",
+					"172.26.0.1:42842",
+					"172.27.0.1:42842",
+					"172.28.0.1:42842",
+					"172.29.0.1:42842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:07:00.548368106Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6827040522615864,
+				"StableID":   "nuh8t7nyJv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b70152198f5e5e86aa84e79227f3d4d80441aebb5a39f806d59a74b9d5222506",
+				"DiscoKey":   "discokey:52277daa5b055ee6f2d00161a303f0ee0cfc022c757889c427beb190cd60d31e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:35029",
+					"10.65.0.27:35029",
+					"172.17.0.1:35029",
+					"172.18.0.1:35029",
+					"172.19.0.1:35029",
+					"172.20.0.1:35029",
+					"172.21.0.1:35029",
+					"172.22.0.1:35029",
+					"172.23.0.1:35029",
+					"172.24.0.1:35029",
+					"172.25.0.1:35029",
+					"172.26.0.1:35029",
+					"172.27.0.1:35029",
+					"172.28.0.1:35029",
+					"172.29.0.1:35029"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:07:01.089113953Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3188121042143300,
+				"StableID":   "nV5dHxXutR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:887ef6d4915e34fee99dfedda47ac9cf2596688c580675a42c3471cbebaafb11",
+				"DiscoKey":   "discokey:2ae1bcb848319c1aca0fd76bfbab00b41b9a056fb6d0dae31f6aa5830be38037",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:60559",
+					"10.65.0.27:60559",
+					"172.17.0.1:60559",
+					"172.18.0.1:60559",
+					"172.19.0.1:60559",
+					"172.20.0.1:60559",
+					"172.21.0.1:60559",
+					"172.22.0.1:60559",
+					"172.23.0.1:60559",
+					"172.24.0.1:60559",
+					"172.25.0.1:60559",
+					"172.26.0.1:60559",
+					"172.27.0.1:60559",
+					"172.28.0.1:60559",
+					"172.29.0.1:60559"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:07:01.638082773Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6026571109877032,
+				"StableID":   "njzUxcoS4p11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:18586a46b864c2ca115fc1b02bd9e189004f83438da40203ca9ae750b6d4867c",
+				"DiscoKey":   "discokey:e6c914d964da958f5bccd1e0f0438649f10177c7d2e94160426c49c294bd9550",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:46267",
+					"10.65.0.27:46267",
+					"172.17.0.1:46267",
+					"172.18.0.1:46267",
+					"172.19.0.1:46267",
+					"172.20.0.1:46267",
+					"172.21.0.1:46267",
+					"172.22.0.1:46267",
+					"172.23.0.1:46267",
+					"172.24.0.1:46267",
+					"172.25.0.1:46267",
+					"172.26.0.1:46267",
+					"172.27.0.1:46267",
+					"172.28.0.1:46267",
+					"172.29.0.1:46267"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:07:02.178830239Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3109318643116652,
+				"StableID":   "nuoa8eXDHR11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:19240fa0357506dc89722122edbf677041158ff71a947bea5301ae9c01c8847d",
+				"DiscoKey":   "discokey:63786a4d32cbdd73773c1a731cccfcf782e3f8550ffbca4137dca2792e753f53",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45928",
+					"10.65.0.27:45928",
+					"172.17.0.1:45928",
+					"172.18.0.1:45928",
+					"172.19.0.1:45928",
+					"172.20.0.1:45928",
+					"172.21.0.1:45928",
+					"172.22.0.1:45928",
+					"172.23.0.1:45928",
+					"172.24.0.1:45928",
+					"172.25.0.1:45928",
+					"172.26.0.1:45928",
+					"172.27.0.1:45928",
+					"172.28.0.1:45928",
+					"172.29.0.1:45928"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:07:02.713673659Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3420985025326015,
+				"StableID":   "nSxM5bUNiT11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5179e958e1bcee53b917d23980ecb7580fd7aee87073e51dc5a7ac5c512f305e",
+				"DiscoKey":   "discokey:ed27a9ec853c0b52ea58ff8f9db55ff7786750fd95ab32910c43367c0fc9001f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41518",
+					"10.65.0.27:41518",
+					"172.17.0.1:41518",
+					"172.18.0.1:41518",
+					"172.19.0.1:41518",
+					"172.20.0.1:41518",
+					"172.21.0.1:41518",
+					"172.22.0.1:41518",
+					"172.23.0.1:41518",
+					"172.24.0.1:41518",
+					"172.25.0.1:41518",
+					"172.26.0.1:41518",
+					"172.27.0.1:41518",
+					"172.28.0.1:41518",
+					"172.29.0.1:41518"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:07:03.260242351Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8235423448387682,
+				"StableID":   "n3PaFLcqJ721CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b5bd7a97c7b00c217cd2bd9c077b9354d5aa216043ed9106a7fd0e084372c14",
+				"DiscoKey":   "discokey:25bb0bccd6af1bce680c5e620b367bc67f38ade3332b6caae7f29431e703bd17",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53023",
+					"10.65.0.27:53023",
+					"172.17.0.1:53023",
+					"172.18.0.1:53023",
+					"172.19.0.1:53023",
+					"172.20.0.1:53023",
+					"172.21.0.1:53023",
+					"172.22.0.1:53023",
+					"172.23.0.1:53023",
+					"172.24.0.1:53023",
+					"172.25.0.1:53023",
+					"172.26.0.1:53023",
+					"172.27.0.1:53023",
+					"172.28.0.1:53023",
+					"172.29.0.1:53023"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:07:03.775745436Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1396844734654740,
+				"StableID":   "nM72w4kduB11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ffa1cbd6a2ef321eeb0ae907edbcab63a8bbdb2ae06102448a673f222c10f454",
+				"DiscoKey":   "discokey:b515939689ab44b6c96e494f002870bab12a3d1aea7d3ef97c22f85d7f720437",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37085",
+					"10.65.0.27:37085",
+					"172.17.0.1:37085",
+					"172.18.0.1:37085",
+					"172.19.0.1:37085",
+					"172.20.0.1:37085",
+					"172.21.0.1:37085",
+					"172.22.0.1:37085",
+					"172.23.0.1:37085",
+					"172.24.0.1:37085",
+					"172.25.0.1:37085",
+					"172.26.0.1:37085",
+					"172.27.0.1:37085",
+					"172.28.0.1:37085",
+					"172.29.0.1:37085"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:07:04.313556266Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3311208731492109,
+				"StableID":   "nCnDudqerS11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ece627c2d681eb4dc892f1b7f6eb3f672f6ab30d8c9a74feef6ada7722408a3c",
+				"DiscoKey":   "discokey:4f273464c671a879a1b4ca54203699d36d08f96ee1e7ab2bc1049b3cac09b347",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48595",
+					"10.65.0.27:48595",
+					"172.17.0.1:48595",
+					"172.18.0.1:48595",
+					"172.19.0.1:48595",
+					"172.20.0.1:48595",
+					"172.21.0.1:48595",
+					"172.22.0.1:48595",
+					"172.23.0.1:48595",
+					"172.24.0.1:48595",
+					"172.25.0.1:48595",
+					"172.26.0.1:48595",
+					"172.27.0.1:48595",
+					"172.28.0.1:48595",
+					"172.29.0.1:48595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:07:04.850360367Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7777277844117688,
+				"StableID":   "nw4n3GuLj321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:fa9004d8608a8f81c8df29395b2d8d3fa28defaa757cad8b431c5b3f3f54f504",
+				"KeyExpiry":  "2026-11-09T09:07:05Z",
+				"DiscoKey":   "discokey:a5b588857f4ff1a08e43b2d51eb969e370953bf7c1f8a5a69b9e0bbe1e992234",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38435",
+					"10.65.0.27:38435",
+					"172.17.0.1:38435",
+					"172.18.0.1:38435",
+					"172.19.0.1:38435",
+					"172.20.0.1:38435",
+					"172.21.0.1:38435",
+					"172.22.0.1:38435",
+					"172.23.0.1:38435",
+					"172.24.0.1:38435",
+					"172.25.0.1:38435",
+					"172.26.0.1:38435",
+					"172.27.0.1:38435",
+					"172.28.0.1:38435",
+					"172.29.0.1:38435"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:07:05.383804209Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6510634174200293,
+				"StableID":   "nvPaMYKgqs11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3db8e6ea02db37d77b3e725aebaddecd8e814a3d1a629b8786902d3594c12b22",
+				"KeyExpiry":  "2026-11-09T09:07:06Z",
+				"DiscoKey":   "discokey:dafff3180c3e748f84e9f52f7b5eb38cacc3d17037d6caffb6f482081346a31b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38090",
+					"10.65.0.27:38090",
+					"172.17.0.1:38090",
+					"172.18.0.1:38090",
+					"172.19.0.1:38090",
+					"172.20.0.1:38090",
+					"172.21.0.1:38090",
+					"172.22.0.1:38090",
+					"172.23.0.1:38090",
+					"172.24.0.1:38090",
+					"172.25.0.1:38090",
+					"172.26.0.1:38090",
+					"172.27.0.1:38090",
+					"172.28.0.1:38090",
+					"172.29.0.1:38090"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:07:06.470237579Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8235423448387682,
+				"StableID":   "n3PaFLcqJ721CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       8235423448387682,
+				"Key":        "nodekey:9b5bd7a97c7b00c217cd2bd9c077b9354d5aa216043ed9106a7fd0e084372c14",
+				"DiscoKey":   "discokey:25bb0bccd6af1bce680c5e620b367bc67f38ade3332b6caae7f29431e703bd17",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53023",
+					"10.65.0.27:53023",
+					"172.17.0.1:53023",
+					"172.18.0.1:53023",
+					"172.19.0.1:53023",
+					"172.20.0.1:53023",
+					"172.21.0.1:53023",
+					"172.22.0.1:53023",
+					"172.23.0.1:53023",
+					"172.24.0.1:53023",
+					"172.25.0.1:53023",
+					"172.26.0.1:53023",
+					"172.27.0.1:53023",
+					"172.28.0.1:53023",
+					"172.29.0.1:53023"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:07:03.775745436Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9b5bd7a97c7b00c217cd2bd9c077b9354d5aa216043ed9106a7fd0e084372c14",
+			"MachineKey": "mkey:669c4d12292d43f9c6e857150faf34be8e42cbc30b45c6eba36a3b141ea10255",
+			"Peers": [{
+				"ID":         976708517211670,
+				"StableID":   "nsHv5eUMd811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:693f1096b5e38d38a2b4800cf64b8f3b97a0bf724420b872578cc1b5b9eda42f",
+				"DiscoKey":   "discokey:7809cb165bed2d629ee21964fa7edd13ba3fdfeaed8ed719f54bad6de3052d56",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47993",
+					"10.65.0.27:47993",
+					"172.17.0.1:47993",
+					"172.18.0.1:47993",
+					"172.19.0.1:47993",
+					"172.20.0.1:47993",
+					"172.21.0.1:47993",
+					"172.22.0.1:47993",
+					"172.23.0.1:47993",
+					"172.24.0.1:47993",
+					"172.25.0.1:47993",
+					"172.26.0.1:47993",
+					"172.27.0.1:47993",
+					"172.28.0.1:47993",
+					"172.29.0.1:47993"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:06:58.5101451Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3824448112674477,
+				"StableID":   "n4nZWUm6sW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07ec7614be9264bf4da7497e9aa2186bb3a3941c4044f10786082d5ef35f904d",
+				"DiscoKey":   "discokey:5b605feff2417171183d7c886260b3613ac1239dc192a53931081d5d0fbcf26e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34807",
+					"10.65.0.27:34807",
+					"172.17.0.1:34807",
+					"172.18.0.1:34807",
+					"172.19.0.1:34807",
+					"172.20.0.1:34807",
+					"172.21.0.1:34807",
+					"172.22.0.1:34807",
+					"172.23.0.1:34807",
+					"172.24.0.1:34807",
+					"172.25.0.1:34807",
+					"172.26.0.1:34807",
+					"172.27.0.1:34807",
+					"172.28.0.1:34807",
+					"172.29.0.1:34807"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:06:59.334581139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3527482195521367,
+				"StableID":   "nrLjKbybYU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31ed2c7eee6a2a519a5ff44c629b248934b3621cbf0e1bb65f4c91f09bcc8f5a",
+				"DiscoKey":   "discokey:a6fb79615ab1925f1c3ce0b5524724ffca017d3975fae0f63d1ce6a1ff5d6068",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39256",
+					"10.65.0.27:39256",
+					"172.17.0.1:39256",
+					"172.18.0.1:39256",
+					"172.19.0.1:39256",
+					"172.20.0.1:39256",
+					"172.21.0.1:39256",
+					"172.22.0.1:39256",
+					"172.23.0.1:39256",
+					"172.24.0.1:39256",
+					"172.25.0.1:39256",
+					"172.26.0.1:39256",
+					"172.27.0.1:39256",
+					"172.28.0.1:39256",
+					"172.29.0.1:39256"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:07:00.014319028Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2903606537190410,
+				"StableID":   "nj5ykZp3gP11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:50474b8b720f0f07fe21708a7bfb204fd00e64b0d318e5d3f321efd94be5dd42",
+				"DiscoKey":   "discokey:40cefa0618560ff7da77043eb69538848235b60f6c6374ae9b99f443eb06d454",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42842",
+					"10.65.0.27:42842",
+					"172.17.0.1:42842",
+					"172.18.0.1:42842",
+					"172.19.0.1:42842",
+					"172.20.0.1:42842",
+					"172.21.0.1:42842",
+					"172.22.0.1:42842",
+					"172.23.0.1:42842",
+					"172.24.0.1:42842",
+					"172.25.0.1:42842",
+					"172.26.0.1:42842",
+					"172.27.0.1:42842",
+					"172.28.0.1:42842",
+					"172.29.0.1:42842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:07:00.548368106Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6827040522615864,
+				"StableID":   "nuh8t7nyJv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b70152198f5e5e86aa84e79227f3d4d80441aebb5a39f806d59a74b9d5222506",
+				"DiscoKey":   "discokey:52277daa5b055ee6f2d00161a303f0ee0cfc022c757889c427beb190cd60d31e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:35029",
+					"10.65.0.27:35029",
+					"172.17.0.1:35029",
+					"172.18.0.1:35029",
+					"172.19.0.1:35029",
+					"172.20.0.1:35029",
+					"172.21.0.1:35029",
+					"172.22.0.1:35029",
+					"172.23.0.1:35029",
+					"172.24.0.1:35029",
+					"172.25.0.1:35029",
+					"172.26.0.1:35029",
+					"172.27.0.1:35029",
+					"172.28.0.1:35029",
+					"172.29.0.1:35029"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:07:01.089113953Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3188121042143300,
+				"StableID":   "nV5dHxXutR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:887ef6d4915e34fee99dfedda47ac9cf2596688c580675a42c3471cbebaafb11",
+				"DiscoKey":   "discokey:2ae1bcb848319c1aca0fd76bfbab00b41b9a056fb6d0dae31f6aa5830be38037",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:60559",
+					"10.65.0.27:60559",
+					"172.17.0.1:60559",
+					"172.18.0.1:60559",
+					"172.19.0.1:60559",
+					"172.20.0.1:60559",
+					"172.21.0.1:60559",
+					"172.22.0.1:60559",
+					"172.23.0.1:60559",
+					"172.24.0.1:60559",
+					"172.25.0.1:60559",
+					"172.26.0.1:60559",
+					"172.27.0.1:60559",
+					"172.28.0.1:60559",
+					"172.29.0.1:60559"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:07:01.638082773Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6026571109877032,
+				"StableID":   "njzUxcoS4p11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:18586a46b864c2ca115fc1b02bd9e189004f83438da40203ca9ae750b6d4867c",
+				"DiscoKey":   "discokey:e6c914d964da958f5bccd1e0f0438649f10177c7d2e94160426c49c294bd9550",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:46267",
+					"10.65.0.27:46267",
+					"172.17.0.1:46267",
+					"172.18.0.1:46267",
+					"172.19.0.1:46267",
+					"172.20.0.1:46267",
+					"172.21.0.1:46267",
+					"172.22.0.1:46267",
+					"172.23.0.1:46267",
+					"172.24.0.1:46267",
+					"172.25.0.1:46267",
+					"172.26.0.1:46267",
+					"172.27.0.1:46267",
+					"172.28.0.1:46267",
+					"172.29.0.1:46267"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:07:02.178830239Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3109318643116652,
+				"StableID":   "nuoa8eXDHR11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:19240fa0357506dc89722122edbf677041158ff71a947bea5301ae9c01c8847d",
+				"DiscoKey":   "discokey:63786a4d32cbdd73773c1a731cccfcf782e3f8550ffbca4137dca2792e753f53",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45928",
+					"10.65.0.27:45928",
+					"172.17.0.1:45928",
+					"172.18.0.1:45928",
+					"172.19.0.1:45928",
+					"172.20.0.1:45928",
+					"172.21.0.1:45928",
+					"172.22.0.1:45928",
+					"172.23.0.1:45928",
+					"172.24.0.1:45928",
+					"172.25.0.1:45928",
+					"172.26.0.1:45928",
+					"172.27.0.1:45928",
+					"172.28.0.1:45928",
+					"172.29.0.1:45928"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:07:02.713673659Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3420985025326015,
+				"StableID":   "nSxM5bUNiT11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5179e958e1bcee53b917d23980ecb7580fd7aee87073e51dc5a7ac5c512f305e",
+				"DiscoKey":   "discokey:ed27a9ec853c0b52ea58ff8f9db55ff7786750fd95ab32910c43367c0fc9001f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41518",
+					"10.65.0.27:41518",
+					"172.17.0.1:41518",
+					"172.18.0.1:41518",
+					"172.19.0.1:41518",
+					"172.20.0.1:41518",
+					"172.21.0.1:41518",
+					"172.22.0.1:41518",
+					"172.23.0.1:41518",
+					"172.24.0.1:41518",
+					"172.25.0.1:41518",
+					"172.26.0.1:41518",
+					"172.27.0.1:41518",
+					"172.28.0.1:41518",
+					"172.29.0.1:41518"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:07:03.260242351Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1396844734654740,
+				"StableID":   "nM72w4kduB11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ffa1cbd6a2ef321eeb0ae907edbcab63a8bbdb2ae06102448a673f222c10f454",
+				"DiscoKey":   "discokey:b515939689ab44b6c96e494f002870bab12a3d1aea7d3ef97c22f85d7f720437",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37085",
+					"10.65.0.27:37085",
+					"172.17.0.1:37085",
+					"172.18.0.1:37085",
+					"172.19.0.1:37085",
+					"172.20.0.1:37085",
+					"172.21.0.1:37085",
+					"172.22.0.1:37085",
+					"172.23.0.1:37085",
+					"172.24.0.1:37085",
+					"172.25.0.1:37085",
+					"172.26.0.1:37085",
+					"172.27.0.1:37085",
+					"172.28.0.1:37085",
+					"172.29.0.1:37085"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:07:04.313556266Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3311208731492109,
+				"StableID":   "nCnDudqerS11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ece627c2d681eb4dc892f1b7f6eb3f672f6ab30d8c9a74feef6ada7722408a3c",
+				"DiscoKey":   "discokey:4f273464c671a879a1b4ca54203699d36d08f96ee1e7ab2bc1049b3cac09b347",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48595",
+					"10.65.0.27:48595",
+					"172.17.0.1:48595",
+					"172.18.0.1:48595",
+					"172.19.0.1:48595",
+					"172.20.0.1:48595",
+					"172.21.0.1:48595",
+					"172.22.0.1:48595",
+					"172.23.0.1:48595",
+					"172.24.0.1:48595",
+					"172.25.0.1:48595",
+					"172.26.0.1:48595",
+					"172.27.0.1:48595",
+					"172.28.0.1:48595",
+					"172.29.0.1:48595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:07:04.850360367Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7777277844117688,
+				"StableID":   "nw4n3GuLj321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:fa9004d8608a8f81c8df29395b2d8d3fa28defaa757cad8b431c5b3f3f54f504",
+				"KeyExpiry":  "2026-11-09T09:07:05Z",
+				"DiscoKey":   "discokey:a5b588857f4ff1a08e43b2d51eb969e370953bf7c1f8a5a69b9e0bbe1e992234",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38435",
+					"10.65.0.27:38435",
+					"172.17.0.1:38435",
+					"172.18.0.1:38435",
+					"172.19.0.1:38435",
+					"172.20.0.1:38435",
+					"172.21.0.1:38435",
+					"172.22.0.1:38435",
+					"172.23.0.1:38435",
+					"172.24.0.1:38435",
+					"172.25.0.1:38435",
+					"172.26.0.1:38435",
+					"172.27.0.1:38435",
+					"172.28.0.1:38435",
+					"172.29.0.1:38435"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:07:05.383804209Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2953439583137982,
+				"StableID":   "nf3EPHrc4Q11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6830c6e8462e7666dd6a590afa47674215e85c774bdb08585ef9c53d213dd83e",
+				"KeyExpiry":  "2026-11-09T09:07:05Z",
+				"DiscoKey":   "discokey:b73ed43ae299905067eef8003960a36279ceaaae6ddefc591c1a43ddb6a7377f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60165",
+					"10.65.0.27:60165",
+					"172.17.0.1:60165",
+					"172.18.0.1:60165",
+					"172.19.0.1:60165",
+					"172.20.0.1:60165",
+					"172.21.0.1:60165",
+					"172.22.0.1:60165",
+					"172.23.0.1:60165",
+					"172.24.0.1:60165",
+					"172.25.0.1:60165",
+					"172.26.0.1:60165",
+					"172.27.0.1:60165",
+					"172.28.0.1:60165",
+					"172.29.0.1:60165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:07:05.932371484Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6510634174200293,
+				"StableID":   "nvPaMYKgqs11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3db8e6ea02db37d77b3e725aebaddecd8e814a3d1a629b8786902d3594c12b22",
+				"KeyExpiry":  "2026-11-09T09:07:06Z",
+				"DiscoKey":   "discokey:dafff3180c3e748f84e9f52f7b5eb38cacc3d17037d6caffb6f482081346a31b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38090",
+					"10.65.0.27:38090",
+					"172.17.0.1:38090",
+					"172.18.0.1:38090",
+					"172.19.0.1:38090",
+					"172.20.0.1:38090",
+					"172.21.0.1:38090",
+					"172.22.0.1:38090",
+					"172.23.0.1:38090",
+					"172.24.0.1:38090",
+					"172.25.0.1:38090",
+					"172.26.0.1:38090",
+					"172.27.0.1:38090",
+					"172.28.0.1:38090",
+					"172.29.0.1:38090"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:07:06.470237579Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8235423448387682": {
+				"ID":          8235423448387682,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-checkperiod-null.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-checkperiod-null.hujson
@@ -1,0 +1,22343 @@
+// ssh-checkperiod-null
+//
+// ssh action=check with checkPeriod=null
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-13T09:07:51Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-checkperiod-null",
+	"description":    "ssh action=check with checkPeriod=null",
+	"category":       "ssh",
+	"captured_at":    "2026-05-13T09:07:51.709073909Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                       \n  \n                                                                    \n                                         \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh action=check with checkPeriod=null\",\n\t\"id\":          \"ssh-checkperiod-null\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\":      \"check\",\n\t\t\"checkPeriod\": null,\n\t\t\"dst\":         [\"tag:server\"],\n\t\t\"src\":         [\"thor@example.org\"],\n\t\t\"users\":       [\"root\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-edges/ssh-checkperiod-null.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action":      "check",
+				"checkPeriod": null,
+				"dst":         ["tag:server"],
+				"src":         ["thor@example.org"],
+				"users":       ["root"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2187320932896342,
+				"StableID":   "n9AGiHDe5J11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       2187320932896342,
+				"Key":        "nodekey:4125d29e37ee1197491ce85c2dbcee163a20ad4a6c7a08d4705295fac900406d",
+				"DiscoKey":   "discokey:5236a7194253215205d4412c0985e6ca8f2708526442b1e375de8cb41dc6314e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44947",
+					"10.65.0.27:44947",
+					"172.17.0.1:44947",
+					"172.18.0.1:44947",
+					"172.19.0.1:44947",
+					"172.20.0.1:44947",
+					"172.21.0.1:44947",
+					"172.22.0.1:44947",
+					"172.23.0.1:44947",
+					"172.24.0.1:44947",
+					"172.25.0.1:44947",
+					"172.26.0.1:44947",
+					"172.27.0.1:44947",
+					"172.28.0.1:44947",
+					"172.29.0.1:44947"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:08:00.396166034Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4125d29e37ee1197491ce85c2dbcee163a20ad4a6c7a08d4705295fac900406d",
+			"MachineKey": "mkey:335a025aaf90215d7286c5a6ef2360fc360026b25179258ddc605c13e5e0bd05",
+			"Peers": [{
+				"ID":         810829447912296,
+				"StableID":   "nPauke7EL711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:321691e42cd1f3bd4e4abd0e402ba434afc7f734536d4d632e7bd516bb618760",
+				"DiscoKey":   "discokey:b77974678d83b9f4798f4e442065c9aad6263c82c90c04dbfcc108195ed74e01",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:57123",
+					"10.65.0.27:57123",
+					"172.17.0.1:57123",
+					"172.18.0.1:57123",
+					"172.19.0.1:57123",
+					"172.20.0.1:57123",
+					"172.21.0.1:57123",
+					"172.22.0.1:57123",
+					"172.23.0.1:57123",
+					"172.24.0.1:57123",
+					"172.25.0.1:57123",
+					"172.26.0.1:57123",
+					"172.27.0.1:57123",
+					"172.28.0.1:57123",
+					"172.29.0.1:57123"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:07:54.357169284Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1725894913137605,
+				"StableID":   "n61dRJLfUE11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:538fecf9836662e1580b36d7cbc902a0c4d48cc501cf8778a39dbff84cf3ea60",
+				"DiscoKey":   "discokey:0186b442fd0dea6670f41fb1bacf17cb60c24dfe60305e6e75796c43ff839e4c",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34959",
+					"10.65.0.27:34959",
+					"172.17.0.1:34959",
+					"172.18.0.1:34959",
+					"172.19.0.1:34959",
+					"172.20.0.1:34959",
+					"172.21.0.1:34959",
+					"172.22.0.1:34959",
+					"172.23.0.1:34959",
+					"172.24.0.1:34959",
+					"172.25.0.1:34959",
+					"172.26.0.1:34959",
+					"172.27.0.1:34959",
+					"172.28.0.1:34959",
+					"172.29.0.1:34959"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:07:55.007120011Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4600185073665276,
+				"StableID":   "nbUENZ4Svc11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f3491a77bc70013dff32870742041ae5a0a66cd934158b9ad28a16572435225",
+				"DiscoKey":   "discokey:47cd3f912704ce3ef13cb806b89389b998842a03dd5ab3075a8929ab0c279e3e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41056",
+					"10.65.0.27:41056",
+					"172.17.0.1:41056",
+					"172.18.0.1:41056",
+					"172.19.0.1:41056",
+					"172.20.0.1:41056",
+					"172.21.0.1:41056",
+					"172.22.0.1:41056",
+					"172.23.0.1:41056",
+					"172.24.0.1:41056",
+					"172.25.0.1:41056",
+					"172.26.0.1:41056",
+					"172.27.0.1:41056",
+					"172.28.0.1:41056",
+					"172.29.0.1:41056"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:07:55.553107429Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4017552325304563,
+				"StableID":   "nrxUXeHZNY11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4cbd76d258c25d738ee9008c24cd299884c7cb180bb150d6d631f67f381f825c",
+				"DiscoKey":   "discokey:ebaa732b2df02f9c3f6ece161e1e9be271c44e87aec17530952cb6aba03d3272",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:36217",
+					"10.65.0.27:36217",
+					"172.17.0.1:36217",
+					"172.18.0.1:36217",
+					"172.19.0.1:36217",
+					"172.20.0.1:36217",
+					"172.21.0.1:36217",
+					"172.22.0.1:36217",
+					"172.23.0.1:36217",
+					"172.24.0.1:36217",
+					"172.25.0.1:36217",
+					"172.26.0.1:36217",
+					"172.27.0.1:36217",
+					"172.28.0.1:36217",
+					"172.29.0.1:36217"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:07:56.083035319Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4171462444795908,
+				"StableID":   "ndhBkCFGaZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:da0f229ae7feb8f64120873c854f1be55c864da825fbe88fc35c71b623566509",
+				"DiscoKey":   "discokey:82ed8b559e142264402bbc614511a124c8259c7b0cb1472342a72aa343715c44",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57934",
+					"10.65.0.27:57934",
+					"172.17.0.1:57934",
+					"172.18.0.1:57934",
+					"172.19.0.1:57934",
+					"172.20.0.1:57934",
+					"172.21.0.1:57934",
+					"172.22.0.1:57934",
+					"172.23.0.1:57934",
+					"172.24.0.1:57934",
+					"172.25.0.1:57934",
+					"172.26.0.1:57934",
+					"172.27.0.1:57934",
+					"172.28.0.1:57934",
+					"172.29.0.1:57934"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:07:56.615990966Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2713505144190238,
+				"StableID":   "nqCZdNBxBN11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e08b72c5d7b481b49a88673d6ac014f026f8c1cc9932a760016e9bb6e66f501",
+				"DiscoKey":   "discokey:fbb795f2a36774a19b4f0a99233f6e496967c8e7ce18c5f2781587eebe947650",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46005",
+					"10.65.0.27:46005",
+					"172.17.0.1:46005",
+					"172.18.0.1:46005",
+					"172.19.0.1:46005",
+					"172.20.0.1:46005",
+					"172.21.0.1:46005",
+					"172.22.0.1:46005",
+					"172.23.0.1:46005",
+					"172.24.0.1:46005",
+					"172.25.0.1:46005",
+					"172.26.0.1:46005",
+					"172.27.0.1:46005",
+					"172.28.0.1:46005",
+					"172.29.0.1:46005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:07:57.141625182Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2676933682225812,
+				"StableID":   "nKndmVWPuM11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6e01ff8d037c1131d93d2db63ef1eaa3da47736f72e55695bd64764847ed722c",
+				"DiscoKey":   "discokey:b570dcbfa96cd3b703dee82e88fcd391f0687d8211339a698db8a8f27ca8e361",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:56699",
+					"10.65.0.27:56699",
+					"172.17.0.1:56699",
+					"172.18.0.1:56699",
+					"172.19.0.1:56699",
+					"172.20.0.1:56699",
+					"172.21.0.1:56699",
+					"172.22.0.1:56699",
+					"172.23.0.1:56699",
+					"172.24.0.1:56699",
+					"172.25.0.1:56699",
+					"172.26.0.1:56699",
+					"172.27.0.1:56699",
+					"172.28.0.1:56699",
+					"172.29.0.1:56699"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:07:57.683334156Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         986693426944502,
+				"StableID":   "nBqENGmsh811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc4d51ce1d5ba0e7bbaf68d5816c6d135399dd12be039e0a28dae8fe497ed76e",
+				"DiscoKey":   "discokey:7c87233c5a5c0078c382cdc1bef4bf6016effe96f33365b475a956b3a3986827",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37247",
+					"10.65.0.27:37247",
+					"172.17.0.1:37247",
+					"172.18.0.1:37247",
+					"172.19.0.1:37247",
+					"172.20.0.1:37247",
+					"172.21.0.1:37247",
+					"172.22.0.1:37247",
+					"172.23.0.1:37247",
+					"172.24.0.1:37247",
+					"172.25.0.1:37247",
+					"172.26.0.1:37247",
+					"172.27.0.1:37247",
+					"172.28.0.1:37247",
+					"172.29.0.1:37247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:07:58.230872687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6149241298163959,
+				"StableID":   "n4X1SD912q11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ed63b7a38e24614aade691d4954edb406b49251e795735741752264114702840",
+				"DiscoKey":   "discokey:10ccd0394a433c4c4ef17dadb8dd899fa6877d1a4ae386f88f91642f98780d01",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35018",
+					"10.65.0.27:35018",
+					"172.17.0.1:35018",
+					"172.18.0.1:35018",
+					"172.19.0.1:35018",
+					"172.20.0.1:35018",
+					"172.21.0.1:35018",
+					"172.22.0.1:35018",
+					"172.23.0.1:35018",
+					"172.24.0.1:35018",
+					"172.25.0.1:35018",
+					"172.26.0.1:35018",
+					"172.27.0.1:35018",
+					"172.28.0.1:35018",
+					"172.29.0.1:35018"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:07:58.784586257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3989675051530892,
+				"StableID":   "nfgbJuzv9Y11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b39c7ea43c8057586598323fa68f489b94916f2d26aaf931962aae531406a745",
+				"DiscoKey":   "discokey:8632e2e3bfdc69f8d2ce0c710ed96fef0174fdbb2f4a83ca8774e1b579256966",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:57623",
+					"10.65.0.27:57623",
+					"172.17.0.1:57623",
+					"172.18.0.1:57623",
+					"172.19.0.1:57623",
+					"172.20.0.1:57623",
+					"172.21.0.1:57623",
+					"172.22.0.1:57623",
+					"172.23.0.1:57623",
+					"172.24.0.1:57623",
+					"172.25.0.1:57623",
+					"172.26.0.1:57623",
+					"172.27.0.1:57623",
+					"172.28.0.1:57623",
+					"172.29.0.1:57623"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:07:59.301475404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8823615025271065,
+				"StableID":   "nJ1XjTQEuB21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:744a06afe3ec2c5521131ed873bd98ab67a3d0c786d1f278adb81a6cb8d22152",
+				"DiscoKey":   "discokey:990087c4742a5750dab42d844b71db5b5f56d16090dc07dfd2bbc3a62ae87c07",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53341",
+					"10.65.0.27:53341",
+					"172.17.0.1:53341",
+					"172.18.0.1:53341",
+					"172.19.0.1:53341",
+					"172.20.0.1:53341",
+					"172.21.0.1:53341",
+					"172.22.0.1:53341",
+					"172.23.0.1:53341",
+					"172.24.0.1:53341",
+					"172.25.0.1:53341",
+					"172.26.0.1:53341",
+					"172.27.0.1:53341",
+					"172.28.0.1:53341",
+					"172.29.0.1:53341"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:07:59.83234113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5537895569371808,
+				"StableID":   "nPxJqJ88Fk11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e51f3252f555b15147a7d6d0383e8b3db97fc57e870978d374dca2a877c55159",
+				"KeyExpiry":  "2026-11-09T09:08:00Z",
+				"DiscoKey":   "discokey:3f3456c5f41939bdc0ee88c60293e0a8b747faa72d6667f5ed1d83ecb52e5c5f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49972",
+					"10.65.0.27:49972",
+					"172.17.0.1:49972",
+					"172.18.0.1:49972",
+					"172.19.0.1:49972",
+					"172.20.0.1:49972",
+					"172.21.0.1:49972",
+					"172.22.0.1:49972",
+					"172.23.0.1:49972",
+					"172.24.0.1:49972",
+					"172.25.0.1:49972",
+					"172.26.0.1:49972",
+					"172.27.0.1:49972",
+					"172.28.0.1:49972",
+					"172.29.0.1:49972"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:08:00.932988028Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1177251999062406,
+				"StableID":   "nfX8rzQBCA11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:52938027520d1caee1ea6694e66c2f3c681afe65efc62a52ed997be3582aec6b",
+				"KeyExpiry":  "2026-11-09T09:08:01Z",
+				"DiscoKey":   "discokey:b5587388f3deed91a2d78efdea074cd9da82d67af1822ef60d04f4bc244b5b01",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47137",
+					"10.65.0.27:47137",
+					"172.17.0.1:47137",
+					"172.18.0.1:47137",
+					"172.19.0.1:47137",
+					"172.20.0.1:47137",
+					"172.21.0.1:47137",
+					"172.22.0.1:47137",
+					"172.23.0.1:47137",
+					"172.24.0.1:47137",
+					"172.25.0.1:47137",
+					"172.26.0.1:47137",
+					"172.27.0.1:47137",
+					"172.28.0.1:47137",
+					"172.29.0.1:47137"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:08:01.471201139Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5802522798683467,
+				"StableID":   "nJ61vCSyJn11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e29baa62cb83de9502d1ac6f5ef90f568782e60f5d9c41fa697805534bd4f460",
+				"KeyExpiry":  "2026-11-09T09:08:02Z",
+				"DiscoKey":   "discokey:1e87464d36e201f1781cf0652e09c26cb9699e2eaa7434b13ab462b9ac447e58",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57459",
+					"10.65.0.27:57459",
+					"172.17.0.1:57459",
+					"172.18.0.1:57459",
+					"172.19.0.1:57459",
+					"172.20.0.1:57459",
+					"172.21.0.1:57459",
+					"172.22.0.1:57459",
+					"172.23.0.1:57459",
+					"172.24.0.1:57459",
+					"172.25.0.1:57459",
+					"172.26.0.1:57459",
+					"172.27.0.1:57459",
+					"172.28.0.1:57459",
+					"172.29.0.1:57459"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:08:02.018946565Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{
+				"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+				"sshUsers":   {"root": "root"},
+				"action": {
+					"holdAndDelegate": "https://unused/machine/ssh/action/$SRC_NODE_ID/to/$DST_NODE_ID?local_user=$LOCAL_USER"
+				}
+			}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2187320932896342": {
+				"ID":          2187320932896342,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		},
+		"ssh_rules": [{
+			"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+			"sshUsers":   {"root": "root"},
+			"action": {
+				"holdAndDelegate": "https://unused/machine/ssh/action/$SRC_NODE_ID/to/$DST_NODE_ID?local_user=$LOCAL_USER"
+			}
+		}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2713505144190238,
+				"StableID":   "nqCZdNBxBN11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       2713505144190238,
+				"Key":        "nodekey:4e08b72c5d7b481b49a88673d6ac014f026f8c1cc9932a760016e9bb6e66f501",
+				"DiscoKey":   "discokey:fbb795f2a36774a19b4f0a99233f6e496967c8e7ce18c5f2781587eebe947650",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46005",
+					"10.65.0.27:46005",
+					"172.17.0.1:46005",
+					"172.18.0.1:46005",
+					"172.19.0.1:46005",
+					"172.20.0.1:46005",
+					"172.21.0.1:46005",
+					"172.22.0.1:46005",
+					"172.23.0.1:46005",
+					"172.24.0.1:46005",
+					"172.25.0.1:46005",
+					"172.26.0.1:46005",
+					"172.27.0.1:46005",
+					"172.28.0.1:46005",
+					"172.29.0.1:46005"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:07:57.141625182Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4e08b72c5d7b481b49a88673d6ac014f026f8c1cc9932a760016e9bb6e66f501",
+			"MachineKey": "mkey:a3b12fa31016f66c55078250e62f0aebc4ac72188744b9ebe586d66bd75cac65",
+			"Peers": [{
+				"ID":         810829447912296,
+				"StableID":   "nPauke7EL711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:321691e42cd1f3bd4e4abd0e402ba434afc7f734536d4d632e7bd516bb618760",
+				"DiscoKey":   "discokey:b77974678d83b9f4798f4e442065c9aad6263c82c90c04dbfcc108195ed74e01",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:57123",
+					"10.65.0.27:57123",
+					"172.17.0.1:57123",
+					"172.18.0.1:57123",
+					"172.19.0.1:57123",
+					"172.20.0.1:57123",
+					"172.21.0.1:57123",
+					"172.22.0.1:57123",
+					"172.23.0.1:57123",
+					"172.24.0.1:57123",
+					"172.25.0.1:57123",
+					"172.26.0.1:57123",
+					"172.27.0.1:57123",
+					"172.28.0.1:57123",
+					"172.29.0.1:57123"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:07:54.357169284Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1725894913137605,
+				"StableID":   "n61dRJLfUE11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:538fecf9836662e1580b36d7cbc902a0c4d48cc501cf8778a39dbff84cf3ea60",
+				"DiscoKey":   "discokey:0186b442fd0dea6670f41fb1bacf17cb60c24dfe60305e6e75796c43ff839e4c",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34959",
+					"10.65.0.27:34959",
+					"172.17.0.1:34959",
+					"172.18.0.1:34959",
+					"172.19.0.1:34959",
+					"172.20.0.1:34959",
+					"172.21.0.1:34959",
+					"172.22.0.1:34959",
+					"172.23.0.1:34959",
+					"172.24.0.1:34959",
+					"172.25.0.1:34959",
+					"172.26.0.1:34959",
+					"172.27.0.1:34959",
+					"172.28.0.1:34959",
+					"172.29.0.1:34959"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:07:55.007120011Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4600185073665276,
+				"StableID":   "nbUENZ4Svc11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f3491a77bc70013dff32870742041ae5a0a66cd934158b9ad28a16572435225",
+				"DiscoKey":   "discokey:47cd3f912704ce3ef13cb806b89389b998842a03dd5ab3075a8929ab0c279e3e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41056",
+					"10.65.0.27:41056",
+					"172.17.0.1:41056",
+					"172.18.0.1:41056",
+					"172.19.0.1:41056",
+					"172.20.0.1:41056",
+					"172.21.0.1:41056",
+					"172.22.0.1:41056",
+					"172.23.0.1:41056",
+					"172.24.0.1:41056",
+					"172.25.0.1:41056",
+					"172.26.0.1:41056",
+					"172.27.0.1:41056",
+					"172.28.0.1:41056",
+					"172.29.0.1:41056"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:07:55.553107429Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4017552325304563,
+				"StableID":   "nrxUXeHZNY11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4cbd76d258c25d738ee9008c24cd299884c7cb180bb150d6d631f67f381f825c",
+				"DiscoKey":   "discokey:ebaa732b2df02f9c3f6ece161e1e9be271c44e87aec17530952cb6aba03d3272",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:36217",
+					"10.65.0.27:36217",
+					"172.17.0.1:36217",
+					"172.18.0.1:36217",
+					"172.19.0.1:36217",
+					"172.20.0.1:36217",
+					"172.21.0.1:36217",
+					"172.22.0.1:36217",
+					"172.23.0.1:36217",
+					"172.24.0.1:36217",
+					"172.25.0.1:36217",
+					"172.26.0.1:36217",
+					"172.27.0.1:36217",
+					"172.28.0.1:36217",
+					"172.29.0.1:36217"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:07:56.083035319Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4171462444795908,
+				"StableID":   "ndhBkCFGaZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:da0f229ae7feb8f64120873c854f1be55c864da825fbe88fc35c71b623566509",
+				"DiscoKey":   "discokey:82ed8b559e142264402bbc614511a124c8259c7b0cb1472342a72aa343715c44",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57934",
+					"10.65.0.27:57934",
+					"172.17.0.1:57934",
+					"172.18.0.1:57934",
+					"172.19.0.1:57934",
+					"172.20.0.1:57934",
+					"172.21.0.1:57934",
+					"172.22.0.1:57934",
+					"172.23.0.1:57934",
+					"172.24.0.1:57934",
+					"172.25.0.1:57934",
+					"172.26.0.1:57934",
+					"172.27.0.1:57934",
+					"172.28.0.1:57934",
+					"172.29.0.1:57934"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:07:56.615990966Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2676933682225812,
+				"StableID":   "nKndmVWPuM11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6e01ff8d037c1131d93d2db63ef1eaa3da47736f72e55695bd64764847ed722c",
+				"DiscoKey":   "discokey:b570dcbfa96cd3b703dee82e88fcd391f0687d8211339a698db8a8f27ca8e361",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:56699",
+					"10.65.0.27:56699",
+					"172.17.0.1:56699",
+					"172.18.0.1:56699",
+					"172.19.0.1:56699",
+					"172.20.0.1:56699",
+					"172.21.0.1:56699",
+					"172.22.0.1:56699",
+					"172.23.0.1:56699",
+					"172.24.0.1:56699",
+					"172.25.0.1:56699",
+					"172.26.0.1:56699",
+					"172.27.0.1:56699",
+					"172.28.0.1:56699",
+					"172.29.0.1:56699"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:07:57.683334156Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         986693426944502,
+				"StableID":   "nBqENGmsh811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc4d51ce1d5ba0e7bbaf68d5816c6d135399dd12be039e0a28dae8fe497ed76e",
+				"DiscoKey":   "discokey:7c87233c5a5c0078c382cdc1bef4bf6016effe96f33365b475a956b3a3986827",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37247",
+					"10.65.0.27:37247",
+					"172.17.0.1:37247",
+					"172.18.0.1:37247",
+					"172.19.0.1:37247",
+					"172.20.0.1:37247",
+					"172.21.0.1:37247",
+					"172.22.0.1:37247",
+					"172.23.0.1:37247",
+					"172.24.0.1:37247",
+					"172.25.0.1:37247",
+					"172.26.0.1:37247",
+					"172.27.0.1:37247",
+					"172.28.0.1:37247",
+					"172.29.0.1:37247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:07:58.230872687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6149241298163959,
+				"StableID":   "n4X1SD912q11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ed63b7a38e24614aade691d4954edb406b49251e795735741752264114702840",
+				"DiscoKey":   "discokey:10ccd0394a433c4c4ef17dadb8dd899fa6877d1a4ae386f88f91642f98780d01",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35018",
+					"10.65.0.27:35018",
+					"172.17.0.1:35018",
+					"172.18.0.1:35018",
+					"172.19.0.1:35018",
+					"172.20.0.1:35018",
+					"172.21.0.1:35018",
+					"172.22.0.1:35018",
+					"172.23.0.1:35018",
+					"172.24.0.1:35018",
+					"172.25.0.1:35018",
+					"172.26.0.1:35018",
+					"172.27.0.1:35018",
+					"172.28.0.1:35018",
+					"172.29.0.1:35018"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:07:58.784586257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3989675051530892,
+				"StableID":   "nfgbJuzv9Y11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b39c7ea43c8057586598323fa68f489b94916f2d26aaf931962aae531406a745",
+				"DiscoKey":   "discokey:8632e2e3bfdc69f8d2ce0c710ed96fef0174fdbb2f4a83ca8774e1b579256966",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:57623",
+					"10.65.0.27:57623",
+					"172.17.0.1:57623",
+					"172.18.0.1:57623",
+					"172.19.0.1:57623",
+					"172.20.0.1:57623",
+					"172.21.0.1:57623",
+					"172.22.0.1:57623",
+					"172.23.0.1:57623",
+					"172.24.0.1:57623",
+					"172.25.0.1:57623",
+					"172.26.0.1:57623",
+					"172.27.0.1:57623",
+					"172.28.0.1:57623",
+					"172.29.0.1:57623"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:07:59.301475404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8823615025271065,
+				"StableID":   "nJ1XjTQEuB21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:744a06afe3ec2c5521131ed873bd98ab67a3d0c786d1f278adb81a6cb8d22152",
+				"DiscoKey":   "discokey:990087c4742a5750dab42d844b71db5b5f56d16090dc07dfd2bbc3a62ae87c07",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53341",
+					"10.65.0.27:53341",
+					"172.17.0.1:53341",
+					"172.18.0.1:53341",
+					"172.19.0.1:53341",
+					"172.20.0.1:53341",
+					"172.21.0.1:53341",
+					"172.22.0.1:53341",
+					"172.23.0.1:53341",
+					"172.24.0.1:53341",
+					"172.25.0.1:53341",
+					"172.26.0.1:53341",
+					"172.27.0.1:53341",
+					"172.28.0.1:53341",
+					"172.29.0.1:53341"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:07:59.83234113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2187320932896342,
+				"StableID":   "n9AGiHDe5J11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4125d29e37ee1197491ce85c2dbcee163a20ad4a6c7a08d4705295fac900406d",
+				"DiscoKey":   "discokey:5236a7194253215205d4412c0985e6ca8f2708526442b1e375de8cb41dc6314e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44947",
+					"10.65.0.27:44947",
+					"172.17.0.1:44947",
+					"172.18.0.1:44947",
+					"172.19.0.1:44947",
+					"172.20.0.1:44947",
+					"172.21.0.1:44947",
+					"172.22.0.1:44947",
+					"172.23.0.1:44947",
+					"172.24.0.1:44947",
+					"172.25.0.1:44947",
+					"172.26.0.1:44947",
+					"172.27.0.1:44947",
+					"172.28.0.1:44947",
+					"172.29.0.1:44947"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:08:00.396166034Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5537895569371808,
+				"StableID":   "nPxJqJ88Fk11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e51f3252f555b15147a7d6d0383e8b3db97fc57e870978d374dca2a877c55159",
+				"KeyExpiry":  "2026-11-09T09:08:00Z",
+				"DiscoKey":   "discokey:3f3456c5f41939bdc0ee88c60293e0a8b747faa72d6667f5ed1d83ecb52e5c5f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49972",
+					"10.65.0.27:49972",
+					"172.17.0.1:49972",
+					"172.18.0.1:49972",
+					"172.19.0.1:49972",
+					"172.20.0.1:49972",
+					"172.21.0.1:49972",
+					"172.22.0.1:49972",
+					"172.23.0.1:49972",
+					"172.24.0.1:49972",
+					"172.25.0.1:49972",
+					"172.26.0.1:49972",
+					"172.27.0.1:49972",
+					"172.28.0.1:49972",
+					"172.29.0.1:49972"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:08:00.932988028Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1177251999062406,
+				"StableID":   "nfX8rzQBCA11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:52938027520d1caee1ea6694e66c2f3c681afe65efc62a52ed997be3582aec6b",
+				"KeyExpiry":  "2026-11-09T09:08:01Z",
+				"DiscoKey":   "discokey:b5587388f3deed91a2d78efdea074cd9da82d67af1822ef60d04f4bc244b5b01",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47137",
+					"10.65.0.27:47137",
+					"172.17.0.1:47137",
+					"172.18.0.1:47137",
+					"172.19.0.1:47137",
+					"172.20.0.1:47137",
+					"172.21.0.1:47137",
+					"172.22.0.1:47137",
+					"172.23.0.1:47137",
+					"172.24.0.1:47137",
+					"172.25.0.1:47137",
+					"172.26.0.1:47137",
+					"172.27.0.1:47137",
+					"172.28.0.1:47137",
+					"172.29.0.1:47137"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:08:01.471201139Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5802522798683467,
+				"StableID":   "nJ61vCSyJn11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e29baa62cb83de9502d1ac6f5ef90f568782e60f5d9c41fa697805534bd4f460",
+				"KeyExpiry":  "2026-11-09T09:08:02Z",
+				"DiscoKey":   "discokey:1e87464d36e201f1781cf0652e09c26cb9699e2eaa7434b13ab462b9ac447e58",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57459",
+					"10.65.0.27:57459",
+					"172.17.0.1:57459",
+					"172.18.0.1:57459",
+					"172.19.0.1:57459",
+					"172.20.0.1:57459",
+					"172.21.0.1:57459",
+					"172.22.0.1:57459",
+					"172.23.0.1:57459",
+					"172.24.0.1:57459",
+					"172.25.0.1:57459",
+					"172.26.0.1:57459",
+					"172.27.0.1:57459",
+					"172.28.0.1:57459",
+					"172.29.0.1:57459"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:08:02.018946565Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2713505144190238": {
+				"ID":          2713505144190238,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5802522798683467,
+				"StableID":   "nJ61vCSyJn11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e29baa62cb83de9502d1ac6f5ef90f568782e60f5d9c41fa697805534bd4f460",
+				"KeyExpiry":  "2026-11-09T09:08:02Z",
+				"DiscoKey":   "discokey:1e87464d36e201f1781cf0652e09c26cb9699e2eaa7434b13ab462b9ac447e58",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57459",
+					"10.65.0.27:57459",
+					"172.17.0.1:57459",
+					"172.18.0.1:57459",
+					"172.19.0.1:57459",
+					"172.20.0.1:57459",
+					"172.21.0.1:57459",
+					"172.22.0.1:57459",
+					"172.23.0.1:57459",
+					"172.24.0.1:57459",
+					"172.25.0.1:57459",
+					"172.26.0.1:57459",
+					"172.27.0.1:57459",
+					"172.28.0.1:57459",
+					"172.29.0.1:57459"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:08:02.018946565Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e29baa62cb83de9502d1ac6f5ef90f568782e60f5d9c41fa697805534bd4f460",
+			"MachineKey": "mkey:ca3dd8ebd8f49eddb2de3cd74ec42bbfc4bbb8df1456400accbea964b38f026c",
+			"Peers": [{
+				"ID":         810829447912296,
+				"StableID":   "nPauke7EL711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:321691e42cd1f3bd4e4abd0e402ba434afc7f734536d4d632e7bd516bb618760",
+				"DiscoKey":   "discokey:b77974678d83b9f4798f4e442065c9aad6263c82c90c04dbfcc108195ed74e01",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:57123",
+					"10.65.0.27:57123",
+					"172.17.0.1:57123",
+					"172.18.0.1:57123",
+					"172.19.0.1:57123",
+					"172.20.0.1:57123",
+					"172.21.0.1:57123",
+					"172.22.0.1:57123",
+					"172.23.0.1:57123",
+					"172.24.0.1:57123",
+					"172.25.0.1:57123",
+					"172.26.0.1:57123",
+					"172.27.0.1:57123",
+					"172.28.0.1:57123",
+					"172.29.0.1:57123"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:07:54.357169284Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1725894913137605,
+				"StableID":   "n61dRJLfUE11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:538fecf9836662e1580b36d7cbc902a0c4d48cc501cf8778a39dbff84cf3ea60",
+				"DiscoKey":   "discokey:0186b442fd0dea6670f41fb1bacf17cb60c24dfe60305e6e75796c43ff839e4c",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34959",
+					"10.65.0.27:34959",
+					"172.17.0.1:34959",
+					"172.18.0.1:34959",
+					"172.19.0.1:34959",
+					"172.20.0.1:34959",
+					"172.21.0.1:34959",
+					"172.22.0.1:34959",
+					"172.23.0.1:34959",
+					"172.24.0.1:34959",
+					"172.25.0.1:34959",
+					"172.26.0.1:34959",
+					"172.27.0.1:34959",
+					"172.28.0.1:34959",
+					"172.29.0.1:34959"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:07:55.007120011Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4600185073665276,
+				"StableID":   "nbUENZ4Svc11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f3491a77bc70013dff32870742041ae5a0a66cd934158b9ad28a16572435225",
+				"DiscoKey":   "discokey:47cd3f912704ce3ef13cb806b89389b998842a03dd5ab3075a8929ab0c279e3e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41056",
+					"10.65.0.27:41056",
+					"172.17.0.1:41056",
+					"172.18.0.1:41056",
+					"172.19.0.1:41056",
+					"172.20.0.1:41056",
+					"172.21.0.1:41056",
+					"172.22.0.1:41056",
+					"172.23.0.1:41056",
+					"172.24.0.1:41056",
+					"172.25.0.1:41056",
+					"172.26.0.1:41056",
+					"172.27.0.1:41056",
+					"172.28.0.1:41056",
+					"172.29.0.1:41056"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:07:55.553107429Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4017552325304563,
+				"StableID":   "nrxUXeHZNY11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4cbd76d258c25d738ee9008c24cd299884c7cb180bb150d6d631f67f381f825c",
+				"DiscoKey":   "discokey:ebaa732b2df02f9c3f6ece161e1e9be271c44e87aec17530952cb6aba03d3272",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:36217",
+					"10.65.0.27:36217",
+					"172.17.0.1:36217",
+					"172.18.0.1:36217",
+					"172.19.0.1:36217",
+					"172.20.0.1:36217",
+					"172.21.0.1:36217",
+					"172.22.0.1:36217",
+					"172.23.0.1:36217",
+					"172.24.0.1:36217",
+					"172.25.0.1:36217",
+					"172.26.0.1:36217",
+					"172.27.0.1:36217",
+					"172.28.0.1:36217",
+					"172.29.0.1:36217"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:07:56.083035319Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4171462444795908,
+				"StableID":   "ndhBkCFGaZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:da0f229ae7feb8f64120873c854f1be55c864da825fbe88fc35c71b623566509",
+				"DiscoKey":   "discokey:82ed8b559e142264402bbc614511a124c8259c7b0cb1472342a72aa343715c44",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57934",
+					"10.65.0.27:57934",
+					"172.17.0.1:57934",
+					"172.18.0.1:57934",
+					"172.19.0.1:57934",
+					"172.20.0.1:57934",
+					"172.21.0.1:57934",
+					"172.22.0.1:57934",
+					"172.23.0.1:57934",
+					"172.24.0.1:57934",
+					"172.25.0.1:57934",
+					"172.26.0.1:57934",
+					"172.27.0.1:57934",
+					"172.28.0.1:57934",
+					"172.29.0.1:57934"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:07:56.615990966Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2713505144190238,
+				"StableID":   "nqCZdNBxBN11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e08b72c5d7b481b49a88673d6ac014f026f8c1cc9932a760016e9bb6e66f501",
+				"DiscoKey":   "discokey:fbb795f2a36774a19b4f0a99233f6e496967c8e7ce18c5f2781587eebe947650",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46005",
+					"10.65.0.27:46005",
+					"172.17.0.1:46005",
+					"172.18.0.1:46005",
+					"172.19.0.1:46005",
+					"172.20.0.1:46005",
+					"172.21.0.1:46005",
+					"172.22.0.1:46005",
+					"172.23.0.1:46005",
+					"172.24.0.1:46005",
+					"172.25.0.1:46005",
+					"172.26.0.1:46005",
+					"172.27.0.1:46005",
+					"172.28.0.1:46005",
+					"172.29.0.1:46005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:07:57.141625182Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2676933682225812,
+				"StableID":   "nKndmVWPuM11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6e01ff8d037c1131d93d2db63ef1eaa3da47736f72e55695bd64764847ed722c",
+				"DiscoKey":   "discokey:b570dcbfa96cd3b703dee82e88fcd391f0687d8211339a698db8a8f27ca8e361",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:56699",
+					"10.65.0.27:56699",
+					"172.17.0.1:56699",
+					"172.18.0.1:56699",
+					"172.19.0.1:56699",
+					"172.20.0.1:56699",
+					"172.21.0.1:56699",
+					"172.22.0.1:56699",
+					"172.23.0.1:56699",
+					"172.24.0.1:56699",
+					"172.25.0.1:56699",
+					"172.26.0.1:56699",
+					"172.27.0.1:56699",
+					"172.28.0.1:56699",
+					"172.29.0.1:56699"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:07:57.683334156Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         986693426944502,
+				"StableID":   "nBqENGmsh811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc4d51ce1d5ba0e7bbaf68d5816c6d135399dd12be039e0a28dae8fe497ed76e",
+				"DiscoKey":   "discokey:7c87233c5a5c0078c382cdc1bef4bf6016effe96f33365b475a956b3a3986827",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37247",
+					"10.65.0.27:37247",
+					"172.17.0.1:37247",
+					"172.18.0.1:37247",
+					"172.19.0.1:37247",
+					"172.20.0.1:37247",
+					"172.21.0.1:37247",
+					"172.22.0.1:37247",
+					"172.23.0.1:37247",
+					"172.24.0.1:37247",
+					"172.25.0.1:37247",
+					"172.26.0.1:37247",
+					"172.27.0.1:37247",
+					"172.28.0.1:37247",
+					"172.29.0.1:37247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:07:58.230872687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6149241298163959,
+				"StableID":   "n4X1SD912q11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ed63b7a38e24614aade691d4954edb406b49251e795735741752264114702840",
+				"DiscoKey":   "discokey:10ccd0394a433c4c4ef17dadb8dd899fa6877d1a4ae386f88f91642f98780d01",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35018",
+					"10.65.0.27:35018",
+					"172.17.0.1:35018",
+					"172.18.0.1:35018",
+					"172.19.0.1:35018",
+					"172.20.0.1:35018",
+					"172.21.0.1:35018",
+					"172.22.0.1:35018",
+					"172.23.0.1:35018",
+					"172.24.0.1:35018",
+					"172.25.0.1:35018",
+					"172.26.0.1:35018",
+					"172.27.0.1:35018",
+					"172.28.0.1:35018",
+					"172.29.0.1:35018"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:07:58.784586257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3989675051530892,
+				"StableID":   "nfgbJuzv9Y11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b39c7ea43c8057586598323fa68f489b94916f2d26aaf931962aae531406a745",
+				"DiscoKey":   "discokey:8632e2e3bfdc69f8d2ce0c710ed96fef0174fdbb2f4a83ca8774e1b579256966",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:57623",
+					"10.65.0.27:57623",
+					"172.17.0.1:57623",
+					"172.18.0.1:57623",
+					"172.19.0.1:57623",
+					"172.20.0.1:57623",
+					"172.21.0.1:57623",
+					"172.22.0.1:57623",
+					"172.23.0.1:57623",
+					"172.24.0.1:57623",
+					"172.25.0.1:57623",
+					"172.26.0.1:57623",
+					"172.27.0.1:57623",
+					"172.28.0.1:57623",
+					"172.29.0.1:57623"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:07:59.301475404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8823615025271065,
+				"StableID":   "nJ1XjTQEuB21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:744a06afe3ec2c5521131ed873bd98ab67a3d0c786d1f278adb81a6cb8d22152",
+				"DiscoKey":   "discokey:990087c4742a5750dab42d844b71db5b5f56d16090dc07dfd2bbc3a62ae87c07",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53341",
+					"10.65.0.27:53341",
+					"172.17.0.1:53341",
+					"172.18.0.1:53341",
+					"172.19.0.1:53341",
+					"172.20.0.1:53341",
+					"172.21.0.1:53341",
+					"172.22.0.1:53341",
+					"172.23.0.1:53341",
+					"172.24.0.1:53341",
+					"172.25.0.1:53341",
+					"172.26.0.1:53341",
+					"172.27.0.1:53341",
+					"172.28.0.1:53341",
+					"172.29.0.1:53341"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:07:59.83234113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2187320932896342,
+				"StableID":   "n9AGiHDe5J11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4125d29e37ee1197491ce85c2dbcee163a20ad4a6c7a08d4705295fac900406d",
+				"DiscoKey":   "discokey:5236a7194253215205d4412c0985e6ca8f2708526442b1e375de8cb41dc6314e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44947",
+					"10.65.0.27:44947",
+					"172.17.0.1:44947",
+					"172.18.0.1:44947",
+					"172.19.0.1:44947",
+					"172.20.0.1:44947",
+					"172.21.0.1:44947",
+					"172.22.0.1:44947",
+					"172.23.0.1:44947",
+					"172.24.0.1:44947",
+					"172.25.0.1:44947",
+					"172.26.0.1:44947",
+					"172.27.0.1:44947",
+					"172.28.0.1:44947",
+					"172.29.0.1:44947"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:08:00.396166034Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5537895569371808,
+				"StableID":   "nPxJqJ88Fk11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e51f3252f555b15147a7d6d0383e8b3db97fc57e870978d374dca2a877c55159",
+				"KeyExpiry":  "2026-11-09T09:08:00Z",
+				"DiscoKey":   "discokey:3f3456c5f41939bdc0ee88c60293e0a8b747faa72d6667f5ed1d83ecb52e5c5f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49972",
+					"10.65.0.27:49972",
+					"172.17.0.1:49972",
+					"172.18.0.1:49972",
+					"172.19.0.1:49972",
+					"172.20.0.1:49972",
+					"172.21.0.1:49972",
+					"172.22.0.1:49972",
+					"172.23.0.1:49972",
+					"172.24.0.1:49972",
+					"172.25.0.1:49972",
+					"172.26.0.1:49972",
+					"172.27.0.1:49972",
+					"172.28.0.1:49972",
+					"172.29.0.1:49972"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:08:00.932988028Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1177251999062406,
+				"StableID":   "nfX8rzQBCA11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:52938027520d1caee1ea6694e66c2f3c681afe65efc62a52ed997be3582aec6b",
+				"KeyExpiry":  "2026-11-09T09:08:01Z",
+				"DiscoKey":   "discokey:b5587388f3deed91a2d78efdea074cd9da82d67af1822ef60d04f4bc244b5b01",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47137",
+					"10.65.0.27:47137",
+					"172.17.0.1:47137",
+					"172.18.0.1:47137",
+					"172.19.0.1:47137",
+					"172.20.0.1:47137",
+					"172.21.0.1:47137",
+					"172.22.0.1:47137",
+					"172.23.0.1:47137",
+					"172.24.0.1:47137",
+					"172.25.0.1:47137",
+					"172.26.0.1:47137",
+					"172.27.0.1:47137",
+					"172.28.0.1:47137",
+					"172.29.0.1:47137"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:08:01.471201139Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4600185073665276,
+				"StableID":   "nbUENZ4Svc11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       4600185073665276,
+				"Key":        "nodekey:8f3491a77bc70013dff32870742041ae5a0a66cd934158b9ad28a16572435225",
+				"DiscoKey":   "discokey:47cd3f912704ce3ef13cb806b89389b998842a03dd5ab3075a8929ab0c279e3e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41056",
+					"10.65.0.27:41056",
+					"172.17.0.1:41056",
+					"172.18.0.1:41056",
+					"172.19.0.1:41056",
+					"172.20.0.1:41056",
+					"172.21.0.1:41056",
+					"172.22.0.1:41056",
+					"172.23.0.1:41056",
+					"172.24.0.1:41056",
+					"172.25.0.1:41056",
+					"172.26.0.1:41056",
+					"172.27.0.1:41056",
+					"172.28.0.1:41056",
+					"172.29.0.1:41056"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:07:55.553107429Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8f3491a77bc70013dff32870742041ae5a0a66cd934158b9ad28a16572435225",
+			"MachineKey": "mkey:cd65543bd87feb849cfc411e0f0b29576375242c394d8c40f5fd88b839516b64",
+			"Peers": [{
+				"ID":         810829447912296,
+				"StableID":   "nPauke7EL711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:321691e42cd1f3bd4e4abd0e402ba434afc7f734536d4d632e7bd516bb618760",
+				"DiscoKey":   "discokey:b77974678d83b9f4798f4e442065c9aad6263c82c90c04dbfcc108195ed74e01",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:57123",
+					"10.65.0.27:57123",
+					"172.17.0.1:57123",
+					"172.18.0.1:57123",
+					"172.19.0.1:57123",
+					"172.20.0.1:57123",
+					"172.21.0.1:57123",
+					"172.22.0.1:57123",
+					"172.23.0.1:57123",
+					"172.24.0.1:57123",
+					"172.25.0.1:57123",
+					"172.26.0.1:57123",
+					"172.27.0.1:57123",
+					"172.28.0.1:57123",
+					"172.29.0.1:57123"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:07:54.357169284Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1725894913137605,
+				"StableID":   "n61dRJLfUE11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:538fecf9836662e1580b36d7cbc902a0c4d48cc501cf8778a39dbff84cf3ea60",
+				"DiscoKey":   "discokey:0186b442fd0dea6670f41fb1bacf17cb60c24dfe60305e6e75796c43ff839e4c",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34959",
+					"10.65.0.27:34959",
+					"172.17.0.1:34959",
+					"172.18.0.1:34959",
+					"172.19.0.1:34959",
+					"172.20.0.1:34959",
+					"172.21.0.1:34959",
+					"172.22.0.1:34959",
+					"172.23.0.1:34959",
+					"172.24.0.1:34959",
+					"172.25.0.1:34959",
+					"172.26.0.1:34959",
+					"172.27.0.1:34959",
+					"172.28.0.1:34959",
+					"172.29.0.1:34959"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:07:55.007120011Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4017552325304563,
+				"StableID":   "nrxUXeHZNY11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4cbd76d258c25d738ee9008c24cd299884c7cb180bb150d6d631f67f381f825c",
+				"DiscoKey":   "discokey:ebaa732b2df02f9c3f6ece161e1e9be271c44e87aec17530952cb6aba03d3272",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:36217",
+					"10.65.0.27:36217",
+					"172.17.0.1:36217",
+					"172.18.0.1:36217",
+					"172.19.0.1:36217",
+					"172.20.0.1:36217",
+					"172.21.0.1:36217",
+					"172.22.0.1:36217",
+					"172.23.0.1:36217",
+					"172.24.0.1:36217",
+					"172.25.0.1:36217",
+					"172.26.0.1:36217",
+					"172.27.0.1:36217",
+					"172.28.0.1:36217",
+					"172.29.0.1:36217"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:07:56.083035319Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4171462444795908,
+				"StableID":   "ndhBkCFGaZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:da0f229ae7feb8f64120873c854f1be55c864da825fbe88fc35c71b623566509",
+				"DiscoKey":   "discokey:82ed8b559e142264402bbc614511a124c8259c7b0cb1472342a72aa343715c44",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57934",
+					"10.65.0.27:57934",
+					"172.17.0.1:57934",
+					"172.18.0.1:57934",
+					"172.19.0.1:57934",
+					"172.20.0.1:57934",
+					"172.21.0.1:57934",
+					"172.22.0.1:57934",
+					"172.23.0.1:57934",
+					"172.24.0.1:57934",
+					"172.25.0.1:57934",
+					"172.26.0.1:57934",
+					"172.27.0.1:57934",
+					"172.28.0.1:57934",
+					"172.29.0.1:57934"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:07:56.615990966Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2713505144190238,
+				"StableID":   "nqCZdNBxBN11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e08b72c5d7b481b49a88673d6ac014f026f8c1cc9932a760016e9bb6e66f501",
+				"DiscoKey":   "discokey:fbb795f2a36774a19b4f0a99233f6e496967c8e7ce18c5f2781587eebe947650",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46005",
+					"10.65.0.27:46005",
+					"172.17.0.1:46005",
+					"172.18.0.1:46005",
+					"172.19.0.1:46005",
+					"172.20.0.1:46005",
+					"172.21.0.1:46005",
+					"172.22.0.1:46005",
+					"172.23.0.1:46005",
+					"172.24.0.1:46005",
+					"172.25.0.1:46005",
+					"172.26.0.1:46005",
+					"172.27.0.1:46005",
+					"172.28.0.1:46005",
+					"172.29.0.1:46005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:07:57.141625182Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2676933682225812,
+				"StableID":   "nKndmVWPuM11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6e01ff8d037c1131d93d2db63ef1eaa3da47736f72e55695bd64764847ed722c",
+				"DiscoKey":   "discokey:b570dcbfa96cd3b703dee82e88fcd391f0687d8211339a698db8a8f27ca8e361",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:56699",
+					"10.65.0.27:56699",
+					"172.17.0.1:56699",
+					"172.18.0.1:56699",
+					"172.19.0.1:56699",
+					"172.20.0.1:56699",
+					"172.21.0.1:56699",
+					"172.22.0.1:56699",
+					"172.23.0.1:56699",
+					"172.24.0.1:56699",
+					"172.25.0.1:56699",
+					"172.26.0.1:56699",
+					"172.27.0.1:56699",
+					"172.28.0.1:56699",
+					"172.29.0.1:56699"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:07:57.683334156Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         986693426944502,
+				"StableID":   "nBqENGmsh811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc4d51ce1d5ba0e7bbaf68d5816c6d135399dd12be039e0a28dae8fe497ed76e",
+				"DiscoKey":   "discokey:7c87233c5a5c0078c382cdc1bef4bf6016effe96f33365b475a956b3a3986827",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37247",
+					"10.65.0.27:37247",
+					"172.17.0.1:37247",
+					"172.18.0.1:37247",
+					"172.19.0.1:37247",
+					"172.20.0.1:37247",
+					"172.21.0.1:37247",
+					"172.22.0.1:37247",
+					"172.23.0.1:37247",
+					"172.24.0.1:37247",
+					"172.25.0.1:37247",
+					"172.26.0.1:37247",
+					"172.27.0.1:37247",
+					"172.28.0.1:37247",
+					"172.29.0.1:37247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:07:58.230872687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6149241298163959,
+				"StableID":   "n4X1SD912q11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ed63b7a38e24614aade691d4954edb406b49251e795735741752264114702840",
+				"DiscoKey":   "discokey:10ccd0394a433c4c4ef17dadb8dd899fa6877d1a4ae386f88f91642f98780d01",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35018",
+					"10.65.0.27:35018",
+					"172.17.0.1:35018",
+					"172.18.0.1:35018",
+					"172.19.0.1:35018",
+					"172.20.0.1:35018",
+					"172.21.0.1:35018",
+					"172.22.0.1:35018",
+					"172.23.0.1:35018",
+					"172.24.0.1:35018",
+					"172.25.0.1:35018",
+					"172.26.0.1:35018",
+					"172.27.0.1:35018",
+					"172.28.0.1:35018",
+					"172.29.0.1:35018"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:07:58.784586257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3989675051530892,
+				"StableID":   "nfgbJuzv9Y11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b39c7ea43c8057586598323fa68f489b94916f2d26aaf931962aae531406a745",
+				"DiscoKey":   "discokey:8632e2e3bfdc69f8d2ce0c710ed96fef0174fdbb2f4a83ca8774e1b579256966",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:57623",
+					"10.65.0.27:57623",
+					"172.17.0.1:57623",
+					"172.18.0.1:57623",
+					"172.19.0.1:57623",
+					"172.20.0.1:57623",
+					"172.21.0.1:57623",
+					"172.22.0.1:57623",
+					"172.23.0.1:57623",
+					"172.24.0.1:57623",
+					"172.25.0.1:57623",
+					"172.26.0.1:57623",
+					"172.27.0.1:57623",
+					"172.28.0.1:57623",
+					"172.29.0.1:57623"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:07:59.301475404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8823615025271065,
+				"StableID":   "nJ1XjTQEuB21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:744a06afe3ec2c5521131ed873bd98ab67a3d0c786d1f278adb81a6cb8d22152",
+				"DiscoKey":   "discokey:990087c4742a5750dab42d844b71db5b5f56d16090dc07dfd2bbc3a62ae87c07",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53341",
+					"10.65.0.27:53341",
+					"172.17.0.1:53341",
+					"172.18.0.1:53341",
+					"172.19.0.1:53341",
+					"172.20.0.1:53341",
+					"172.21.0.1:53341",
+					"172.22.0.1:53341",
+					"172.23.0.1:53341",
+					"172.24.0.1:53341",
+					"172.25.0.1:53341",
+					"172.26.0.1:53341",
+					"172.27.0.1:53341",
+					"172.28.0.1:53341",
+					"172.29.0.1:53341"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:07:59.83234113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2187320932896342,
+				"StableID":   "n9AGiHDe5J11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4125d29e37ee1197491ce85c2dbcee163a20ad4a6c7a08d4705295fac900406d",
+				"DiscoKey":   "discokey:5236a7194253215205d4412c0985e6ca8f2708526442b1e375de8cb41dc6314e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44947",
+					"10.65.0.27:44947",
+					"172.17.0.1:44947",
+					"172.18.0.1:44947",
+					"172.19.0.1:44947",
+					"172.20.0.1:44947",
+					"172.21.0.1:44947",
+					"172.22.0.1:44947",
+					"172.23.0.1:44947",
+					"172.24.0.1:44947",
+					"172.25.0.1:44947",
+					"172.26.0.1:44947",
+					"172.27.0.1:44947",
+					"172.28.0.1:44947",
+					"172.29.0.1:44947"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:08:00.396166034Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5537895569371808,
+				"StableID":   "nPxJqJ88Fk11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e51f3252f555b15147a7d6d0383e8b3db97fc57e870978d374dca2a877c55159",
+				"KeyExpiry":  "2026-11-09T09:08:00Z",
+				"DiscoKey":   "discokey:3f3456c5f41939bdc0ee88c60293e0a8b747faa72d6667f5ed1d83ecb52e5c5f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49972",
+					"10.65.0.27:49972",
+					"172.17.0.1:49972",
+					"172.18.0.1:49972",
+					"172.19.0.1:49972",
+					"172.20.0.1:49972",
+					"172.21.0.1:49972",
+					"172.22.0.1:49972",
+					"172.23.0.1:49972",
+					"172.24.0.1:49972",
+					"172.25.0.1:49972",
+					"172.26.0.1:49972",
+					"172.27.0.1:49972",
+					"172.28.0.1:49972",
+					"172.29.0.1:49972"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:08:00.932988028Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1177251999062406,
+				"StableID":   "nfX8rzQBCA11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:52938027520d1caee1ea6694e66c2f3c681afe65efc62a52ed997be3582aec6b",
+				"KeyExpiry":  "2026-11-09T09:08:01Z",
+				"DiscoKey":   "discokey:b5587388f3deed91a2d78efdea074cd9da82d67af1822ef60d04f4bc244b5b01",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47137",
+					"10.65.0.27:47137",
+					"172.17.0.1:47137",
+					"172.18.0.1:47137",
+					"172.19.0.1:47137",
+					"172.20.0.1:47137",
+					"172.21.0.1:47137",
+					"172.22.0.1:47137",
+					"172.23.0.1:47137",
+					"172.24.0.1:47137",
+					"172.25.0.1:47137",
+					"172.26.0.1:47137",
+					"172.27.0.1:47137",
+					"172.28.0.1:47137",
+					"172.29.0.1:47137"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:08:01.471201139Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5802522798683467,
+				"StableID":   "nJ61vCSyJn11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e29baa62cb83de9502d1ac6f5ef90f568782e60f5d9c41fa697805534bd4f460",
+				"KeyExpiry":  "2026-11-09T09:08:02Z",
+				"DiscoKey":   "discokey:1e87464d36e201f1781cf0652e09c26cb9699e2eaa7434b13ab462b9ac447e58",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57459",
+					"10.65.0.27:57459",
+					"172.17.0.1:57459",
+					"172.18.0.1:57459",
+					"172.19.0.1:57459",
+					"172.20.0.1:57459",
+					"172.21.0.1:57459",
+					"172.22.0.1:57459",
+					"172.23.0.1:57459",
+					"172.24.0.1:57459",
+					"172.25.0.1:57459",
+					"172.26.0.1:57459",
+					"172.27.0.1:57459",
+					"172.28.0.1:57459",
+					"172.29.0.1:57459"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:08:02.018946565Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4600185073665276": {
+				"ID":          4600185073665276,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         986693426944502,
+				"StableID":   "nBqENGmsh811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       986693426944502,
+				"Key":        "nodekey:cc4d51ce1d5ba0e7bbaf68d5816c6d135399dd12be039e0a28dae8fe497ed76e",
+				"DiscoKey":   "discokey:7c87233c5a5c0078c382cdc1bef4bf6016effe96f33365b475a956b3a3986827",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37247",
+					"10.65.0.27:37247",
+					"172.17.0.1:37247",
+					"172.18.0.1:37247",
+					"172.19.0.1:37247",
+					"172.20.0.1:37247",
+					"172.21.0.1:37247",
+					"172.22.0.1:37247",
+					"172.23.0.1:37247",
+					"172.24.0.1:37247",
+					"172.25.0.1:37247",
+					"172.26.0.1:37247",
+					"172.27.0.1:37247",
+					"172.28.0.1:37247",
+					"172.29.0.1:37247"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:07:58.230872687Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:cc4d51ce1d5ba0e7bbaf68d5816c6d135399dd12be039e0a28dae8fe497ed76e",
+			"MachineKey": "mkey:fb1d9bd7bce61eb3e9c5ef072e06725243c9069fa7eec1c1c190fc05f787d02e",
+			"Peers": [{
+				"ID":         810829447912296,
+				"StableID":   "nPauke7EL711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:321691e42cd1f3bd4e4abd0e402ba434afc7f734536d4d632e7bd516bb618760",
+				"DiscoKey":   "discokey:b77974678d83b9f4798f4e442065c9aad6263c82c90c04dbfcc108195ed74e01",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:57123",
+					"10.65.0.27:57123",
+					"172.17.0.1:57123",
+					"172.18.0.1:57123",
+					"172.19.0.1:57123",
+					"172.20.0.1:57123",
+					"172.21.0.1:57123",
+					"172.22.0.1:57123",
+					"172.23.0.1:57123",
+					"172.24.0.1:57123",
+					"172.25.0.1:57123",
+					"172.26.0.1:57123",
+					"172.27.0.1:57123",
+					"172.28.0.1:57123",
+					"172.29.0.1:57123"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:07:54.357169284Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1725894913137605,
+				"StableID":   "n61dRJLfUE11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:538fecf9836662e1580b36d7cbc902a0c4d48cc501cf8778a39dbff84cf3ea60",
+				"DiscoKey":   "discokey:0186b442fd0dea6670f41fb1bacf17cb60c24dfe60305e6e75796c43ff839e4c",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34959",
+					"10.65.0.27:34959",
+					"172.17.0.1:34959",
+					"172.18.0.1:34959",
+					"172.19.0.1:34959",
+					"172.20.0.1:34959",
+					"172.21.0.1:34959",
+					"172.22.0.1:34959",
+					"172.23.0.1:34959",
+					"172.24.0.1:34959",
+					"172.25.0.1:34959",
+					"172.26.0.1:34959",
+					"172.27.0.1:34959",
+					"172.28.0.1:34959",
+					"172.29.0.1:34959"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:07:55.007120011Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4600185073665276,
+				"StableID":   "nbUENZ4Svc11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f3491a77bc70013dff32870742041ae5a0a66cd934158b9ad28a16572435225",
+				"DiscoKey":   "discokey:47cd3f912704ce3ef13cb806b89389b998842a03dd5ab3075a8929ab0c279e3e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41056",
+					"10.65.0.27:41056",
+					"172.17.0.1:41056",
+					"172.18.0.1:41056",
+					"172.19.0.1:41056",
+					"172.20.0.1:41056",
+					"172.21.0.1:41056",
+					"172.22.0.1:41056",
+					"172.23.0.1:41056",
+					"172.24.0.1:41056",
+					"172.25.0.1:41056",
+					"172.26.0.1:41056",
+					"172.27.0.1:41056",
+					"172.28.0.1:41056",
+					"172.29.0.1:41056"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:07:55.553107429Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4017552325304563,
+				"StableID":   "nrxUXeHZNY11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4cbd76d258c25d738ee9008c24cd299884c7cb180bb150d6d631f67f381f825c",
+				"DiscoKey":   "discokey:ebaa732b2df02f9c3f6ece161e1e9be271c44e87aec17530952cb6aba03d3272",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:36217",
+					"10.65.0.27:36217",
+					"172.17.0.1:36217",
+					"172.18.0.1:36217",
+					"172.19.0.1:36217",
+					"172.20.0.1:36217",
+					"172.21.0.1:36217",
+					"172.22.0.1:36217",
+					"172.23.0.1:36217",
+					"172.24.0.1:36217",
+					"172.25.0.1:36217",
+					"172.26.0.1:36217",
+					"172.27.0.1:36217",
+					"172.28.0.1:36217",
+					"172.29.0.1:36217"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:07:56.083035319Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4171462444795908,
+				"StableID":   "ndhBkCFGaZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:da0f229ae7feb8f64120873c854f1be55c864da825fbe88fc35c71b623566509",
+				"DiscoKey":   "discokey:82ed8b559e142264402bbc614511a124c8259c7b0cb1472342a72aa343715c44",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57934",
+					"10.65.0.27:57934",
+					"172.17.0.1:57934",
+					"172.18.0.1:57934",
+					"172.19.0.1:57934",
+					"172.20.0.1:57934",
+					"172.21.0.1:57934",
+					"172.22.0.1:57934",
+					"172.23.0.1:57934",
+					"172.24.0.1:57934",
+					"172.25.0.1:57934",
+					"172.26.0.1:57934",
+					"172.27.0.1:57934",
+					"172.28.0.1:57934",
+					"172.29.0.1:57934"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:07:56.615990966Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2713505144190238,
+				"StableID":   "nqCZdNBxBN11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e08b72c5d7b481b49a88673d6ac014f026f8c1cc9932a760016e9bb6e66f501",
+				"DiscoKey":   "discokey:fbb795f2a36774a19b4f0a99233f6e496967c8e7ce18c5f2781587eebe947650",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46005",
+					"10.65.0.27:46005",
+					"172.17.0.1:46005",
+					"172.18.0.1:46005",
+					"172.19.0.1:46005",
+					"172.20.0.1:46005",
+					"172.21.0.1:46005",
+					"172.22.0.1:46005",
+					"172.23.0.1:46005",
+					"172.24.0.1:46005",
+					"172.25.0.1:46005",
+					"172.26.0.1:46005",
+					"172.27.0.1:46005",
+					"172.28.0.1:46005",
+					"172.29.0.1:46005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:07:57.141625182Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2676933682225812,
+				"StableID":   "nKndmVWPuM11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6e01ff8d037c1131d93d2db63ef1eaa3da47736f72e55695bd64764847ed722c",
+				"DiscoKey":   "discokey:b570dcbfa96cd3b703dee82e88fcd391f0687d8211339a698db8a8f27ca8e361",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:56699",
+					"10.65.0.27:56699",
+					"172.17.0.1:56699",
+					"172.18.0.1:56699",
+					"172.19.0.1:56699",
+					"172.20.0.1:56699",
+					"172.21.0.1:56699",
+					"172.22.0.1:56699",
+					"172.23.0.1:56699",
+					"172.24.0.1:56699",
+					"172.25.0.1:56699",
+					"172.26.0.1:56699",
+					"172.27.0.1:56699",
+					"172.28.0.1:56699",
+					"172.29.0.1:56699"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:07:57.683334156Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6149241298163959,
+				"StableID":   "n4X1SD912q11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ed63b7a38e24614aade691d4954edb406b49251e795735741752264114702840",
+				"DiscoKey":   "discokey:10ccd0394a433c4c4ef17dadb8dd899fa6877d1a4ae386f88f91642f98780d01",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35018",
+					"10.65.0.27:35018",
+					"172.17.0.1:35018",
+					"172.18.0.1:35018",
+					"172.19.0.1:35018",
+					"172.20.0.1:35018",
+					"172.21.0.1:35018",
+					"172.22.0.1:35018",
+					"172.23.0.1:35018",
+					"172.24.0.1:35018",
+					"172.25.0.1:35018",
+					"172.26.0.1:35018",
+					"172.27.0.1:35018",
+					"172.28.0.1:35018",
+					"172.29.0.1:35018"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:07:58.784586257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3989675051530892,
+				"StableID":   "nfgbJuzv9Y11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b39c7ea43c8057586598323fa68f489b94916f2d26aaf931962aae531406a745",
+				"DiscoKey":   "discokey:8632e2e3bfdc69f8d2ce0c710ed96fef0174fdbb2f4a83ca8774e1b579256966",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:57623",
+					"10.65.0.27:57623",
+					"172.17.0.1:57623",
+					"172.18.0.1:57623",
+					"172.19.0.1:57623",
+					"172.20.0.1:57623",
+					"172.21.0.1:57623",
+					"172.22.0.1:57623",
+					"172.23.0.1:57623",
+					"172.24.0.1:57623",
+					"172.25.0.1:57623",
+					"172.26.0.1:57623",
+					"172.27.0.1:57623",
+					"172.28.0.1:57623",
+					"172.29.0.1:57623"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:07:59.301475404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8823615025271065,
+				"StableID":   "nJ1XjTQEuB21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:744a06afe3ec2c5521131ed873bd98ab67a3d0c786d1f278adb81a6cb8d22152",
+				"DiscoKey":   "discokey:990087c4742a5750dab42d844b71db5b5f56d16090dc07dfd2bbc3a62ae87c07",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53341",
+					"10.65.0.27:53341",
+					"172.17.0.1:53341",
+					"172.18.0.1:53341",
+					"172.19.0.1:53341",
+					"172.20.0.1:53341",
+					"172.21.0.1:53341",
+					"172.22.0.1:53341",
+					"172.23.0.1:53341",
+					"172.24.0.1:53341",
+					"172.25.0.1:53341",
+					"172.26.0.1:53341",
+					"172.27.0.1:53341",
+					"172.28.0.1:53341",
+					"172.29.0.1:53341"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:07:59.83234113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2187320932896342,
+				"StableID":   "n9AGiHDe5J11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4125d29e37ee1197491ce85c2dbcee163a20ad4a6c7a08d4705295fac900406d",
+				"DiscoKey":   "discokey:5236a7194253215205d4412c0985e6ca8f2708526442b1e375de8cb41dc6314e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44947",
+					"10.65.0.27:44947",
+					"172.17.0.1:44947",
+					"172.18.0.1:44947",
+					"172.19.0.1:44947",
+					"172.20.0.1:44947",
+					"172.21.0.1:44947",
+					"172.22.0.1:44947",
+					"172.23.0.1:44947",
+					"172.24.0.1:44947",
+					"172.25.0.1:44947",
+					"172.26.0.1:44947",
+					"172.27.0.1:44947",
+					"172.28.0.1:44947",
+					"172.29.0.1:44947"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:08:00.396166034Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5537895569371808,
+				"StableID":   "nPxJqJ88Fk11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e51f3252f555b15147a7d6d0383e8b3db97fc57e870978d374dca2a877c55159",
+				"KeyExpiry":  "2026-11-09T09:08:00Z",
+				"DiscoKey":   "discokey:3f3456c5f41939bdc0ee88c60293e0a8b747faa72d6667f5ed1d83ecb52e5c5f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49972",
+					"10.65.0.27:49972",
+					"172.17.0.1:49972",
+					"172.18.0.1:49972",
+					"172.19.0.1:49972",
+					"172.20.0.1:49972",
+					"172.21.0.1:49972",
+					"172.22.0.1:49972",
+					"172.23.0.1:49972",
+					"172.24.0.1:49972",
+					"172.25.0.1:49972",
+					"172.26.0.1:49972",
+					"172.27.0.1:49972",
+					"172.28.0.1:49972",
+					"172.29.0.1:49972"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:08:00.932988028Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1177251999062406,
+				"StableID":   "nfX8rzQBCA11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:52938027520d1caee1ea6694e66c2f3c681afe65efc62a52ed997be3582aec6b",
+				"KeyExpiry":  "2026-11-09T09:08:01Z",
+				"DiscoKey":   "discokey:b5587388f3deed91a2d78efdea074cd9da82d67af1822ef60d04f4bc244b5b01",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47137",
+					"10.65.0.27:47137",
+					"172.17.0.1:47137",
+					"172.18.0.1:47137",
+					"172.19.0.1:47137",
+					"172.20.0.1:47137",
+					"172.21.0.1:47137",
+					"172.22.0.1:47137",
+					"172.23.0.1:47137",
+					"172.24.0.1:47137",
+					"172.25.0.1:47137",
+					"172.26.0.1:47137",
+					"172.27.0.1:47137",
+					"172.28.0.1:47137",
+					"172.29.0.1:47137"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:08:01.471201139Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5802522798683467,
+				"StableID":   "nJ61vCSyJn11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e29baa62cb83de9502d1ac6f5ef90f568782e60f5d9c41fa697805534bd4f460",
+				"KeyExpiry":  "2026-11-09T09:08:02Z",
+				"DiscoKey":   "discokey:1e87464d36e201f1781cf0652e09c26cb9699e2eaa7434b13ab462b9ac447e58",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57459",
+					"10.65.0.27:57459",
+					"172.17.0.1:57459",
+					"172.18.0.1:57459",
+					"172.19.0.1:57459",
+					"172.20.0.1:57459",
+					"172.21.0.1:57459",
+					"172.22.0.1:57459",
+					"172.23.0.1:57459",
+					"172.24.0.1:57459",
+					"172.25.0.1:57459",
+					"172.26.0.1:57459",
+					"172.27.0.1:57459",
+					"172.28.0.1:57459",
+					"172.29.0.1:57459"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:08:02.018946565Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "986693426944502": {
+				"ID":          986693426944502,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5537895569371808,
+				"StableID":   "nPxJqJ88Fk11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e51f3252f555b15147a7d6d0383e8b3db97fc57e870978d374dca2a877c55159",
+				"KeyExpiry":  "2026-11-09T09:08:00Z",
+				"DiscoKey":   "discokey:3f3456c5f41939bdc0ee88c60293e0a8b747faa72d6667f5ed1d83ecb52e5c5f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49972",
+					"10.65.0.27:49972",
+					"172.17.0.1:49972",
+					"172.18.0.1:49972",
+					"172.19.0.1:49972",
+					"172.20.0.1:49972",
+					"172.21.0.1:49972",
+					"172.22.0.1:49972",
+					"172.23.0.1:49972",
+					"172.24.0.1:49972",
+					"172.25.0.1:49972",
+					"172.26.0.1:49972",
+					"172.27.0.1:49972",
+					"172.28.0.1:49972",
+					"172.29.0.1:49972"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:08:00.932988028Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e51f3252f555b15147a7d6d0383e8b3db97fc57e870978d374dca2a877c55159",
+			"MachineKey": "mkey:622ff5a545cd0a9adc3573dbc0a2b686c34116af6a921191cef06825a9428f34",
+			"Peers": [{
+				"ID":         810829447912296,
+				"StableID":   "nPauke7EL711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:321691e42cd1f3bd4e4abd0e402ba434afc7f734536d4d632e7bd516bb618760",
+				"DiscoKey":   "discokey:b77974678d83b9f4798f4e442065c9aad6263c82c90c04dbfcc108195ed74e01",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:57123",
+					"10.65.0.27:57123",
+					"172.17.0.1:57123",
+					"172.18.0.1:57123",
+					"172.19.0.1:57123",
+					"172.20.0.1:57123",
+					"172.21.0.1:57123",
+					"172.22.0.1:57123",
+					"172.23.0.1:57123",
+					"172.24.0.1:57123",
+					"172.25.0.1:57123",
+					"172.26.0.1:57123",
+					"172.27.0.1:57123",
+					"172.28.0.1:57123",
+					"172.29.0.1:57123"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:07:54.357169284Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1725894913137605,
+				"StableID":   "n61dRJLfUE11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:538fecf9836662e1580b36d7cbc902a0c4d48cc501cf8778a39dbff84cf3ea60",
+				"DiscoKey":   "discokey:0186b442fd0dea6670f41fb1bacf17cb60c24dfe60305e6e75796c43ff839e4c",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34959",
+					"10.65.0.27:34959",
+					"172.17.0.1:34959",
+					"172.18.0.1:34959",
+					"172.19.0.1:34959",
+					"172.20.0.1:34959",
+					"172.21.0.1:34959",
+					"172.22.0.1:34959",
+					"172.23.0.1:34959",
+					"172.24.0.1:34959",
+					"172.25.0.1:34959",
+					"172.26.0.1:34959",
+					"172.27.0.1:34959",
+					"172.28.0.1:34959",
+					"172.29.0.1:34959"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:07:55.007120011Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4600185073665276,
+				"StableID":   "nbUENZ4Svc11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f3491a77bc70013dff32870742041ae5a0a66cd934158b9ad28a16572435225",
+				"DiscoKey":   "discokey:47cd3f912704ce3ef13cb806b89389b998842a03dd5ab3075a8929ab0c279e3e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41056",
+					"10.65.0.27:41056",
+					"172.17.0.1:41056",
+					"172.18.0.1:41056",
+					"172.19.0.1:41056",
+					"172.20.0.1:41056",
+					"172.21.0.1:41056",
+					"172.22.0.1:41056",
+					"172.23.0.1:41056",
+					"172.24.0.1:41056",
+					"172.25.0.1:41056",
+					"172.26.0.1:41056",
+					"172.27.0.1:41056",
+					"172.28.0.1:41056",
+					"172.29.0.1:41056"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:07:55.553107429Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4017552325304563,
+				"StableID":   "nrxUXeHZNY11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4cbd76d258c25d738ee9008c24cd299884c7cb180bb150d6d631f67f381f825c",
+				"DiscoKey":   "discokey:ebaa732b2df02f9c3f6ece161e1e9be271c44e87aec17530952cb6aba03d3272",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:36217",
+					"10.65.0.27:36217",
+					"172.17.0.1:36217",
+					"172.18.0.1:36217",
+					"172.19.0.1:36217",
+					"172.20.0.1:36217",
+					"172.21.0.1:36217",
+					"172.22.0.1:36217",
+					"172.23.0.1:36217",
+					"172.24.0.1:36217",
+					"172.25.0.1:36217",
+					"172.26.0.1:36217",
+					"172.27.0.1:36217",
+					"172.28.0.1:36217",
+					"172.29.0.1:36217"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:07:56.083035319Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4171462444795908,
+				"StableID":   "ndhBkCFGaZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:da0f229ae7feb8f64120873c854f1be55c864da825fbe88fc35c71b623566509",
+				"DiscoKey":   "discokey:82ed8b559e142264402bbc614511a124c8259c7b0cb1472342a72aa343715c44",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57934",
+					"10.65.0.27:57934",
+					"172.17.0.1:57934",
+					"172.18.0.1:57934",
+					"172.19.0.1:57934",
+					"172.20.0.1:57934",
+					"172.21.0.1:57934",
+					"172.22.0.1:57934",
+					"172.23.0.1:57934",
+					"172.24.0.1:57934",
+					"172.25.0.1:57934",
+					"172.26.0.1:57934",
+					"172.27.0.1:57934",
+					"172.28.0.1:57934",
+					"172.29.0.1:57934"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:07:56.615990966Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2713505144190238,
+				"StableID":   "nqCZdNBxBN11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e08b72c5d7b481b49a88673d6ac014f026f8c1cc9932a760016e9bb6e66f501",
+				"DiscoKey":   "discokey:fbb795f2a36774a19b4f0a99233f6e496967c8e7ce18c5f2781587eebe947650",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46005",
+					"10.65.0.27:46005",
+					"172.17.0.1:46005",
+					"172.18.0.1:46005",
+					"172.19.0.1:46005",
+					"172.20.0.1:46005",
+					"172.21.0.1:46005",
+					"172.22.0.1:46005",
+					"172.23.0.1:46005",
+					"172.24.0.1:46005",
+					"172.25.0.1:46005",
+					"172.26.0.1:46005",
+					"172.27.0.1:46005",
+					"172.28.0.1:46005",
+					"172.29.0.1:46005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:07:57.141625182Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2676933682225812,
+				"StableID":   "nKndmVWPuM11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6e01ff8d037c1131d93d2db63ef1eaa3da47736f72e55695bd64764847ed722c",
+				"DiscoKey":   "discokey:b570dcbfa96cd3b703dee82e88fcd391f0687d8211339a698db8a8f27ca8e361",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:56699",
+					"10.65.0.27:56699",
+					"172.17.0.1:56699",
+					"172.18.0.1:56699",
+					"172.19.0.1:56699",
+					"172.20.0.1:56699",
+					"172.21.0.1:56699",
+					"172.22.0.1:56699",
+					"172.23.0.1:56699",
+					"172.24.0.1:56699",
+					"172.25.0.1:56699",
+					"172.26.0.1:56699",
+					"172.27.0.1:56699",
+					"172.28.0.1:56699",
+					"172.29.0.1:56699"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:07:57.683334156Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         986693426944502,
+				"StableID":   "nBqENGmsh811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc4d51ce1d5ba0e7bbaf68d5816c6d135399dd12be039e0a28dae8fe497ed76e",
+				"DiscoKey":   "discokey:7c87233c5a5c0078c382cdc1bef4bf6016effe96f33365b475a956b3a3986827",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37247",
+					"10.65.0.27:37247",
+					"172.17.0.1:37247",
+					"172.18.0.1:37247",
+					"172.19.0.1:37247",
+					"172.20.0.1:37247",
+					"172.21.0.1:37247",
+					"172.22.0.1:37247",
+					"172.23.0.1:37247",
+					"172.24.0.1:37247",
+					"172.25.0.1:37247",
+					"172.26.0.1:37247",
+					"172.27.0.1:37247",
+					"172.28.0.1:37247",
+					"172.29.0.1:37247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:07:58.230872687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6149241298163959,
+				"StableID":   "n4X1SD912q11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ed63b7a38e24614aade691d4954edb406b49251e795735741752264114702840",
+				"DiscoKey":   "discokey:10ccd0394a433c4c4ef17dadb8dd899fa6877d1a4ae386f88f91642f98780d01",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35018",
+					"10.65.0.27:35018",
+					"172.17.0.1:35018",
+					"172.18.0.1:35018",
+					"172.19.0.1:35018",
+					"172.20.0.1:35018",
+					"172.21.0.1:35018",
+					"172.22.0.1:35018",
+					"172.23.0.1:35018",
+					"172.24.0.1:35018",
+					"172.25.0.1:35018",
+					"172.26.0.1:35018",
+					"172.27.0.1:35018",
+					"172.28.0.1:35018",
+					"172.29.0.1:35018"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:07:58.784586257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3989675051530892,
+				"StableID":   "nfgbJuzv9Y11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b39c7ea43c8057586598323fa68f489b94916f2d26aaf931962aae531406a745",
+				"DiscoKey":   "discokey:8632e2e3bfdc69f8d2ce0c710ed96fef0174fdbb2f4a83ca8774e1b579256966",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:57623",
+					"10.65.0.27:57623",
+					"172.17.0.1:57623",
+					"172.18.0.1:57623",
+					"172.19.0.1:57623",
+					"172.20.0.1:57623",
+					"172.21.0.1:57623",
+					"172.22.0.1:57623",
+					"172.23.0.1:57623",
+					"172.24.0.1:57623",
+					"172.25.0.1:57623",
+					"172.26.0.1:57623",
+					"172.27.0.1:57623",
+					"172.28.0.1:57623",
+					"172.29.0.1:57623"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:07:59.301475404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8823615025271065,
+				"StableID":   "nJ1XjTQEuB21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:744a06afe3ec2c5521131ed873bd98ab67a3d0c786d1f278adb81a6cb8d22152",
+				"DiscoKey":   "discokey:990087c4742a5750dab42d844b71db5b5f56d16090dc07dfd2bbc3a62ae87c07",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53341",
+					"10.65.0.27:53341",
+					"172.17.0.1:53341",
+					"172.18.0.1:53341",
+					"172.19.0.1:53341",
+					"172.20.0.1:53341",
+					"172.21.0.1:53341",
+					"172.22.0.1:53341",
+					"172.23.0.1:53341",
+					"172.24.0.1:53341",
+					"172.25.0.1:53341",
+					"172.26.0.1:53341",
+					"172.27.0.1:53341",
+					"172.28.0.1:53341",
+					"172.29.0.1:53341"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:07:59.83234113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2187320932896342,
+				"StableID":   "n9AGiHDe5J11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4125d29e37ee1197491ce85c2dbcee163a20ad4a6c7a08d4705295fac900406d",
+				"DiscoKey":   "discokey:5236a7194253215205d4412c0985e6ca8f2708526442b1e375de8cb41dc6314e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44947",
+					"10.65.0.27:44947",
+					"172.17.0.1:44947",
+					"172.18.0.1:44947",
+					"172.19.0.1:44947",
+					"172.20.0.1:44947",
+					"172.21.0.1:44947",
+					"172.22.0.1:44947",
+					"172.23.0.1:44947",
+					"172.24.0.1:44947",
+					"172.25.0.1:44947",
+					"172.26.0.1:44947",
+					"172.27.0.1:44947",
+					"172.28.0.1:44947",
+					"172.29.0.1:44947"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:08:00.396166034Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1177251999062406,
+				"StableID":   "nfX8rzQBCA11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:52938027520d1caee1ea6694e66c2f3c681afe65efc62a52ed997be3582aec6b",
+				"KeyExpiry":  "2026-11-09T09:08:01Z",
+				"DiscoKey":   "discokey:b5587388f3deed91a2d78efdea074cd9da82d67af1822ef60d04f4bc244b5b01",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47137",
+					"10.65.0.27:47137",
+					"172.17.0.1:47137",
+					"172.18.0.1:47137",
+					"172.19.0.1:47137",
+					"172.20.0.1:47137",
+					"172.21.0.1:47137",
+					"172.22.0.1:47137",
+					"172.23.0.1:47137",
+					"172.24.0.1:47137",
+					"172.25.0.1:47137",
+					"172.26.0.1:47137",
+					"172.27.0.1:47137",
+					"172.28.0.1:47137",
+					"172.29.0.1:47137"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:08:01.471201139Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5802522798683467,
+				"StableID":   "nJ61vCSyJn11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e29baa62cb83de9502d1ac6f5ef90f568782e60f5d9c41fa697805534bd4f460",
+				"KeyExpiry":  "2026-11-09T09:08:02Z",
+				"DiscoKey":   "discokey:1e87464d36e201f1781cf0652e09c26cb9699e2eaa7434b13ab462b9ac447e58",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57459",
+					"10.65.0.27:57459",
+					"172.17.0.1:57459",
+					"172.18.0.1:57459",
+					"172.19.0.1:57459",
+					"172.20.0.1:57459",
+					"172.21.0.1:57459",
+					"172.22.0.1:57459",
+					"172.23.0.1:57459",
+					"172.24.0.1:57459",
+					"172.25.0.1:57459",
+					"172.26.0.1:57459",
+					"172.27.0.1:57459",
+					"172.28.0.1:57459",
+					"172.29.0.1:57459"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:08:02.018946565Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8823615025271065,
+				"StableID":   "nJ1XjTQEuB21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       8823615025271065,
+				"Key":        "nodekey:744a06afe3ec2c5521131ed873bd98ab67a3d0c786d1f278adb81a6cb8d22152",
+				"DiscoKey":   "discokey:990087c4742a5750dab42d844b71db5b5f56d16090dc07dfd2bbc3a62ae87c07",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53341",
+					"10.65.0.27:53341",
+					"172.17.0.1:53341",
+					"172.18.0.1:53341",
+					"172.19.0.1:53341",
+					"172.20.0.1:53341",
+					"172.21.0.1:53341",
+					"172.22.0.1:53341",
+					"172.23.0.1:53341",
+					"172.24.0.1:53341",
+					"172.25.0.1:53341",
+					"172.26.0.1:53341",
+					"172.27.0.1:53341",
+					"172.28.0.1:53341",
+					"172.29.0.1:53341"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:07:59.83234113Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:744a06afe3ec2c5521131ed873bd98ab67a3d0c786d1f278adb81a6cb8d22152",
+			"MachineKey": "mkey:c2af7590c7f933766e5480017aa1d77f619ba5cbd60facf4e770bfab9515ab44",
+			"Peers": [{
+				"ID":         810829447912296,
+				"StableID":   "nPauke7EL711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:321691e42cd1f3bd4e4abd0e402ba434afc7f734536d4d632e7bd516bb618760",
+				"DiscoKey":   "discokey:b77974678d83b9f4798f4e442065c9aad6263c82c90c04dbfcc108195ed74e01",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:57123",
+					"10.65.0.27:57123",
+					"172.17.0.1:57123",
+					"172.18.0.1:57123",
+					"172.19.0.1:57123",
+					"172.20.0.1:57123",
+					"172.21.0.1:57123",
+					"172.22.0.1:57123",
+					"172.23.0.1:57123",
+					"172.24.0.1:57123",
+					"172.25.0.1:57123",
+					"172.26.0.1:57123",
+					"172.27.0.1:57123",
+					"172.28.0.1:57123",
+					"172.29.0.1:57123"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:07:54.357169284Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1725894913137605,
+				"StableID":   "n61dRJLfUE11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:538fecf9836662e1580b36d7cbc902a0c4d48cc501cf8778a39dbff84cf3ea60",
+				"DiscoKey":   "discokey:0186b442fd0dea6670f41fb1bacf17cb60c24dfe60305e6e75796c43ff839e4c",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34959",
+					"10.65.0.27:34959",
+					"172.17.0.1:34959",
+					"172.18.0.1:34959",
+					"172.19.0.1:34959",
+					"172.20.0.1:34959",
+					"172.21.0.1:34959",
+					"172.22.0.1:34959",
+					"172.23.0.1:34959",
+					"172.24.0.1:34959",
+					"172.25.0.1:34959",
+					"172.26.0.1:34959",
+					"172.27.0.1:34959",
+					"172.28.0.1:34959",
+					"172.29.0.1:34959"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:07:55.007120011Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4600185073665276,
+				"StableID":   "nbUENZ4Svc11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f3491a77bc70013dff32870742041ae5a0a66cd934158b9ad28a16572435225",
+				"DiscoKey":   "discokey:47cd3f912704ce3ef13cb806b89389b998842a03dd5ab3075a8929ab0c279e3e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41056",
+					"10.65.0.27:41056",
+					"172.17.0.1:41056",
+					"172.18.0.1:41056",
+					"172.19.0.1:41056",
+					"172.20.0.1:41056",
+					"172.21.0.1:41056",
+					"172.22.0.1:41056",
+					"172.23.0.1:41056",
+					"172.24.0.1:41056",
+					"172.25.0.1:41056",
+					"172.26.0.1:41056",
+					"172.27.0.1:41056",
+					"172.28.0.1:41056",
+					"172.29.0.1:41056"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:07:55.553107429Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4017552325304563,
+				"StableID":   "nrxUXeHZNY11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4cbd76d258c25d738ee9008c24cd299884c7cb180bb150d6d631f67f381f825c",
+				"DiscoKey":   "discokey:ebaa732b2df02f9c3f6ece161e1e9be271c44e87aec17530952cb6aba03d3272",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:36217",
+					"10.65.0.27:36217",
+					"172.17.0.1:36217",
+					"172.18.0.1:36217",
+					"172.19.0.1:36217",
+					"172.20.0.1:36217",
+					"172.21.0.1:36217",
+					"172.22.0.1:36217",
+					"172.23.0.1:36217",
+					"172.24.0.1:36217",
+					"172.25.0.1:36217",
+					"172.26.0.1:36217",
+					"172.27.0.1:36217",
+					"172.28.0.1:36217",
+					"172.29.0.1:36217"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:07:56.083035319Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4171462444795908,
+				"StableID":   "ndhBkCFGaZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:da0f229ae7feb8f64120873c854f1be55c864da825fbe88fc35c71b623566509",
+				"DiscoKey":   "discokey:82ed8b559e142264402bbc614511a124c8259c7b0cb1472342a72aa343715c44",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57934",
+					"10.65.0.27:57934",
+					"172.17.0.1:57934",
+					"172.18.0.1:57934",
+					"172.19.0.1:57934",
+					"172.20.0.1:57934",
+					"172.21.0.1:57934",
+					"172.22.0.1:57934",
+					"172.23.0.1:57934",
+					"172.24.0.1:57934",
+					"172.25.0.1:57934",
+					"172.26.0.1:57934",
+					"172.27.0.1:57934",
+					"172.28.0.1:57934",
+					"172.29.0.1:57934"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:07:56.615990966Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2713505144190238,
+				"StableID":   "nqCZdNBxBN11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e08b72c5d7b481b49a88673d6ac014f026f8c1cc9932a760016e9bb6e66f501",
+				"DiscoKey":   "discokey:fbb795f2a36774a19b4f0a99233f6e496967c8e7ce18c5f2781587eebe947650",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46005",
+					"10.65.0.27:46005",
+					"172.17.0.1:46005",
+					"172.18.0.1:46005",
+					"172.19.0.1:46005",
+					"172.20.0.1:46005",
+					"172.21.0.1:46005",
+					"172.22.0.1:46005",
+					"172.23.0.1:46005",
+					"172.24.0.1:46005",
+					"172.25.0.1:46005",
+					"172.26.0.1:46005",
+					"172.27.0.1:46005",
+					"172.28.0.1:46005",
+					"172.29.0.1:46005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:07:57.141625182Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2676933682225812,
+				"StableID":   "nKndmVWPuM11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6e01ff8d037c1131d93d2db63ef1eaa3da47736f72e55695bd64764847ed722c",
+				"DiscoKey":   "discokey:b570dcbfa96cd3b703dee82e88fcd391f0687d8211339a698db8a8f27ca8e361",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:56699",
+					"10.65.0.27:56699",
+					"172.17.0.1:56699",
+					"172.18.0.1:56699",
+					"172.19.0.1:56699",
+					"172.20.0.1:56699",
+					"172.21.0.1:56699",
+					"172.22.0.1:56699",
+					"172.23.0.1:56699",
+					"172.24.0.1:56699",
+					"172.25.0.1:56699",
+					"172.26.0.1:56699",
+					"172.27.0.1:56699",
+					"172.28.0.1:56699",
+					"172.29.0.1:56699"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:07:57.683334156Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         986693426944502,
+				"StableID":   "nBqENGmsh811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc4d51ce1d5ba0e7bbaf68d5816c6d135399dd12be039e0a28dae8fe497ed76e",
+				"DiscoKey":   "discokey:7c87233c5a5c0078c382cdc1bef4bf6016effe96f33365b475a956b3a3986827",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37247",
+					"10.65.0.27:37247",
+					"172.17.0.1:37247",
+					"172.18.0.1:37247",
+					"172.19.0.1:37247",
+					"172.20.0.1:37247",
+					"172.21.0.1:37247",
+					"172.22.0.1:37247",
+					"172.23.0.1:37247",
+					"172.24.0.1:37247",
+					"172.25.0.1:37247",
+					"172.26.0.1:37247",
+					"172.27.0.1:37247",
+					"172.28.0.1:37247",
+					"172.29.0.1:37247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:07:58.230872687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6149241298163959,
+				"StableID":   "n4X1SD912q11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ed63b7a38e24614aade691d4954edb406b49251e795735741752264114702840",
+				"DiscoKey":   "discokey:10ccd0394a433c4c4ef17dadb8dd899fa6877d1a4ae386f88f91642f98780d01",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35018",
+					"10.65.0.27:35018",
+					"172.17.0.1:35018",
+					"172.18.0.1:35018",
+					"172.19.0.1:35018",
+					"172.20.0.1:35018",
+					"172.21.0.1:35018",
+					"172.22.0.1:35018",
+					"172.23.0.1:35018",
+					"172.24.0.1:35018",
+					"172.25.0.1:35018",
+					"172.26.0.1:35018",
+					"172.27.0.1:35018",
+					"172.28.0.1:35018",
+					"172.29.0.1:35018"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:07:58.784586257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3989675051530892,
+				"StableID":   "nfgbJuzv9Y11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b39c7ea43c8057586598323fa68f489b94916f2d26aaf931962aae531406a745",
+				"DiscoKey":   "discokey:8632e2e3bfdc69f8d2ce0c710ed96fef0174fdbb2f4a83ca8774e1b579256966",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:57623",
+					"10.65.0.27:57623",
+					"172.17.0.1:57623",
+					"172.18.0.1:57623",
+					"172.19.0.1:57623",
+					"172.20.0.1:57623",
+					"172.21.0.1:57623",
+					"172.22.0.1:57623",
+					"172.23.0.1:57623",
+					"172.24.0.1:57623",
+					"172.25.0.1:57623",
+					"172.26.0.1:57623",
+					"172.27.0.1:57623",
+					"172.28.0.1:57623",
+					"172.29.0.1:57623"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:07:59.301475404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2187320932896342,
+				"StableID":   "n9AGiHDe5J11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4125d29e37ee1197491ce85c2dbcee163a20ad4a6c7a08d4705295fac900406d",
+				"DiscoKey":   "discokey:5236a7194253215205d4412c0985e6ca8f2708526442b1e375de8cb41dc6314e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44947",
+					"10.65.0.27:44947",
+					"172.17.0.1:44947",
+					"172.18.0.1:44947",
+					"172.19.0.1:44947",
+					"172.20.0.1:44947",
+					"172.21.0.1:44947",
+					"172.22.0.1:44947",
+					"172.23.0.1:44947",
+					"172.24.0.1:44947",
+					"172.25.0.1:44947",
+					"172.26.0.1:44947",
+					"172.27.0.1:44947",
+					"172.28.0.1:44947",
+					"172.29.0.1:44947"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:08:00.396166034Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5537895569371808,
+				"StableID":   "nPxJqJ88Fk11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e51f3252f555b15147a7d6d0383e8b3db97fc57e870978d374dca2a877c55159",
+				"KeyExpiry":  "2026-11-09T09:08:00Z",
+				"DiscoKey":   "discokey:3f3456c5f41939bdc0ee88c60293e0a8b747faa72d6667f5ed1d83ecb52e5c5f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49972",
+					"10.65.0.27:49972",
+					"172.17.0.1:49972",
+					"172.18.0.1:49972",
+					"172.19.0.1:49972",
+					"172.20.0.1:49972",
+					"172.21.0.1:49972",
+					"172.22.0.1:49972",
+					"172.23.0.1:49972",
+					"172.24.0.1:49972",
+					"172.25.0.1:49972",
+					"172.26.0.1:49972",
+					"172.27.0.1:49972",
+					"172.28.0.1:49972",
+					"172.29.0.1:49972"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:08:00.932988028Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1177251999062406,
+				"StableID":   "nfX8rzQBCA11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:52938027520d1caee1ea6694e66c2f3c681afe65efc62a52ed997be3582aec6b",
+				"KeyExpiry":  "2026-11-09T09:08:01Z",
+				"DiscoKey":   "discokey:b5587388f3deed91a2d78efdea074cd9da82d67af1822ef60d04f4bc244b5b01",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47137",
+					"10.65.0.27:47137",
+					"172.17.0.1:47137",
+					"172.18.0.1:47137",
+					"172.19.0.1:47137",
+					"172.20.0.1:47137",
+					"172.21.0.1:47137",
+					"172.22.0.1:47137",
+					"172.23.0.1:47137",
+					"172.24.0.1:47137",
+					"172.25.0.1:47137",
+					"172.26.0.1:47137",
+					"172.27.0.1:47137",
+					"172.28.0.1:47137",
+					"172.29.0.1:47137"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:08:01.471201139Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5802522798683467,
+				"StableID":   "nJ61vCSyJn11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e29baa62cb83de9502d1ac6f5ef90f568782e60f5d9c41fa697805534bd4f460",
+				"KeyExpiry":  "2026-11-09T09:08:02Z",
+				"DiscoKey":   "discokey:1e87464d36e201f1781cf0652e09c26cb9699e2eaa7434b13ab462b9ac447e58",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57459",
+					"10.65.0.27:57459",
+					"172.17.0.1:57459",
+					"172.18.0.1:57459",
+					"172.19.0.1:57459",
+					"172.20.0.1:57459",
+					"172.21.0.1:57459",
+					"172.22.0.1:57459",
+					"172.23.0.1:57459",
+					"172.24.0.1:57459",
+					"172.25.0.1:57459",
+					"172.26.0.1:57459",
+					"172.27.0.1:57459",
+					"172.28.0.1:57459",
+					"172.29.0.1:57459"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:08:02.018946565Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8823615025271065": {
+				"ID":          8823615025271065,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1725894913137605,
+				"StableID":   "n61dRJLfUE11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1725894913137605,
+				"Key":        "nodekey:538fecf9836662e1580b36d7cbc902a0c4d48cc501cf8778a39dbff84cf3ea60",
+				"DiscoKey":   "discokey:0186b442fd0dea6670f41fb1bacf17cb60c24dfe60305e6e75796c43ff839e4c",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34959",
+					"10.65.0.27:34959",
+					"172.17.0.1:34959",
+					"172.18.0.1:34959",
+					"172.19.0.1:34959",
+					"172.20.0.1:34959",
+					"172.21.0.1:34959",
+					"172.22.0.1:34959",
+					"172.23.0.1:34959",
+					"172.24.0.1:34959",
+					"172.25.0.1:34959",
+					"172.26.0.1:34959",
+					"172.27.0.1:34959",
+					"172.28.0.1:34959",
+					"172.29.0.1:34959"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:07:55.007120011Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:538fecf9836662e1580b36d7cbc902a0c4d48cc501cf8778a39dbff84cf3ea60",
+			"MachineKey": "mkey:5ebee45431e3fc2dc4e607829d1d2c340e2f7ceb4954553f03020bc597d44e3a",
+			"Peers": [{
+				"ID":         810829447912296,
+				"StableID":   "nPauke7EL711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:321691e42cd1f3bd4e4abd0e402ba434afc7f734536d4d632e7bd516bb618760",
+				"DiscoKey":   "discokey:b77974678d83b9f4798f4e442065c9aad6263c82c90c04dbfcc108195ed74e01",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:57123",
+					"10.65.0.27:57123",
+					"172.17.0.1:57123",
+					"172.18.0.1:57123",
+					"172.19.0.1:57123",
+					"172.20.0.1:57123",
+					"172.21.0.1:57123",
+					"172.22.0.1:57123",
+					"172.23.0.1:57123",
+					"172.24.0.1:57123",
+					"172.25.0.1:57123",
+					"172.26.0.1:57123",
+					"172.27.0.1:57123",
+					"172.28.0.1:57123",
+					"172.29.0.1:57123"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:07:54.357169284Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4600185073665276,
+				"StableID":   "nbUENZ4Svc11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f3491a77bc70013dff32870742041ae5a0a66cd934158b9ad28a16572435225",
+				"DiscoKey":   "discokey:47cd3f912704ce3ef13cb806b89389b998842a03dd5ab3075a8929ab0c279e3e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41056",
+					"10.65.0.27:41056",
+					"172.17.0.1:41056",
+					"172.18.0.1:41056",
+					"172.19.0.1:41056",
+					"172.20.0.1:41056",
+					"172.21.0.1:41056",
+					"172.22.0.1:41056",
+					"172.23.0.1:41056",
+					"172.24.0.1:41056",
+					"172.25.0.1:41056",
+					"172.26.0.1:41056",
+					"172.27.0.1:41056",
+					"172.28.0.1:41056",
+					"172.29.0.1:41056"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:07:55.553107429Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4017552325304563,
+				"StableID":   "nrxUXeHZNY11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4cbd76d258c25d738ee9008c24cd299884c7cb180bb150d6d631f67f381f825c",
+				"DiscoKey":   "discokey:ebaa732b2df02f9c3f6ece161e1e9be271c44e87aec17530952cb6aba03d3272",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:36217",
+					"10.65.0.27:36217",
+					"172.17.0.1:36217",
+					"172.18.0.1:36217",
+					"172.19.0.1:36217",
+					"172.20.0.1:36217",
+					"172.21.0.1:36217",
+					"172.22.0.1:36217",
+					"172.23.0.1:36217",
+					"172.24.0.1:36217",
+					"172.25.0.1:36217",
+					"172.26.0.1:36217",
+					"172.27.0.1:36217",
+					"172.28.0.1:36217",
+					"172.29.0.1:36217"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:07:56.083035319Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4171462444795908,
+				"StableID":   "ndhBkCFGaZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:da0f229ae7feb8f64120873c854f1be55c864da825fbe88fc35c71b623566509",
+				"DiscoKey":   "discokey:82ed8b559e142264402bbc614511a124c8259c7b0cb1472342a72aa343715c44",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57934",
+					"10.65.0.27:57934",
+					"172.17.0.1:57934",
+					"172.18.0.1:57934",
+					"172.19.0.1:57934",
+					"172.20.0.1:57934",
+					"172.21.0.1:57934",
+					"172.22.0.1:57934",
+					"172.23.0.1:57934",
+					"172.24.0.1:57934",
+					"172.25.0.1:57934",
+					"172.26.0.1:57934",
+					"172.27.0.1:57934",
+					"172.28.0.1:57934",
+					"172.29.0.1:57934"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:07:56.615990966Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2713505144190238,
+				"StableID":   "nqCZdNBxBN11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e08b72c5d7b481b49a88673d6ac014f026f8c1cc9932a760016e9bb6e66f501",
+				"DiscoKey":   "discokey:fbb795f2a36774a19b4f0a99233f6e496967c8e7ce18c5f2781587eebe947650",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46005",
+					"10.65.0.27:46005",
+					"172.17.0.1:46005",
+					"172.18.0.1:46005",
+					"172.19.0.1:46005",
+					"172.20.0.1:46005",
+					"172.21.0.1:46005",
+					"172.22.0.1:46005",
+					"172.23.0.1:46005",
+					"172.24.0.1:46005",
+					"172.25.0.1:46005",
+					"172.26.0.1:46005",
+					"172.27.0.1:46005",
+					"172.28.0.1:46005",
+					"172.29.0.1:46005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:07:57.141625182Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2676933682225812,
+				"StableID":   "nKndmVWPuM11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6e01ff8d037c1131d93d2db63ef1eaa3da47736f72e55695bd64764847ed722c",
+				"DiscoKey":   "discokey:b570dcbfa96cd3b703dee82e88fcd391f0687d8211339a698db8a8f27ca8e361",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:56699",
+					"10.65.0.27:56699",
+					"172.17.0.1:56699",
+					"172.18.0.1:56699",
+					"172.19.0.1:56699",
+					"172.20.0.1:56699",
+					"172.21.0.1:56699",
+					"172.22.0.1:56699",
+					"172.23.0.1:56699",
+					"172.24.0.1:56699",
+					"172.25.0.1:56699",
+					"172.26.0.1:56699",
+					"172.27.0.1:56699",
+					"172.28.0.1:56699",
+					"172.29.0.1:56699"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:07:57.683334156Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         986693426944502,
+				"StableID":   "nBqENGmsh811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc4d51ce1d5ba0e7bbaf68d5816c6d135399dd12be039e0a28dae8fe497ed76e",
+				"DiscoKey":   "discokey:7c87233c5a5c0078c382cdc1bef4bf6016effe96f33365b475a956b3a3986827",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37247",
+					"10.65.0.27:37247",
+					"172.17.0.1:37247",
+					"172.18.0.1:37247",
+					"172.19.0.1:37247",
+					"172.20.0.1:37247",
+					"172.21.0.1:37247",
+					"172.22.0.1:37247",
+					"172.23.0.1:37247",
+					"172.24.0.1:37247",
+					"172.25.0.1:37247",
+					"172.26.0.1:37247",
+					"172.27.0.1:37247",
+					"172.28.0.1:37247",
+					"172.29.0.1:37247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:07:58.230872687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6149241298163959,
+				"StableID":   "n4X1SD912q11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ed63b7a38e24614aade691d4954edb406b49251e795735741752264114702840",
+				"DiscoKey":   "discokey:10ccd0394a433c4c4ef17dadb8dd899fa6877d1a4ae386f88f91642f98780d01",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35018",
+					"10.65.0.27:35018",
+					"172.17.0.1:35018",
+					"172.18.0.1:35018",
+					"172.19.0.1:35018",
+					"172.20.0.1:35018",
+					"172.21.0.1:35018",
+					"172.22.0.1:35018",
+					"172.23.0.1:35018",
+					"172.24.0.1:35018",
+					"172.25.0.1:35018",
+					"172.26.0.1:35018",
+					"172.27.0.1:35018",
+					"172.28.0.1:35018",
+					"172.29.0.1:35018"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:07:58.784586257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3989675051530892,
+				"StableID":   "nfgbJuzv9Y11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b39c7ea43c8057586598323fa68f489b94916f2d26aaf931962aae531406a745",
+				"DiscoKey":   "discokey:8632e2e3bfdc69f8d2ce0c710ed96fef0174fdbb2f4a83ca8774e1b579256966",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:57623",
+					"10.65.0.27:57623",
+					"172.17.0.1:57623",
+					"172.18.0.1:57623",
+					"172.19.0.1:57623",
+					"172.20.0.1:57623",
+					"172.21.0.1:57623",
+					"172.22.0.1:57623",
+					"172.23.0.1:57623",
+					"172.24.0.1:57623",
+					"172.25.0.1:57623",
+					"172.26.0.1:57623",
+					"172.27.0.1:57623",
+					"172.28.0.1:57623",
+					"172.29.0.1:57623"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:07:59.301475404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8823615025271065,
+				"StableID":   "nJ1XjTQEuB21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:744a06afe3ec2c5521131ed873bd98ab67a3d0c786d1f278adb81a6cb8d22152",
+				"DiscoKey":   "discokey:990087c4742a5750dab42d844b71db5b5f56d16090dc07dfd2bbc3a62ae87c07",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53341",
+					"10.65.0.27:53341",
+					"172.17.0.1:53341",
+					"172.18.0.1:53341",
+					"172.19.0.1:53341",
+					"172.20.0.1:53341",
+					"172.21.0.1:53341",
+					"172.22.0.1:53341",
+					"172.23.0.1:53341",
+					"172.24.0.1:53341",
+					"172.25.0.1:53341",
+					"172.26.0.1:53341",
+					"172.27.0.1:53341",
+					"172.28.0.1:53341",
+					"172.29.0.1:53341"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:07:59.83234113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2187320932896342,
+				"StableID":   "n9AGiHDe5J11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4125d29e37ee1197491ce85c2dbcee163a20ad4a6c7a08d4705295fac900406d",
+				"DiscoKey":   "discokey:5236a7194253215205d4412c0985e6ca8f2708526442b1e375de8cb41dc6314e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44947",
+					"10.65.0.27:44947",
+					"172.17.0.1:44947",
+					"172.18.0.1:44947",
+					"172.19.0.1:44947",
+					"172.20.0.1:44947",
+					"172.21.0.1:44947",
+					"172.22.0.1:44947",
+					"172.23.0.1:44947",
+					"172.24.0.1:44947",
+					"172.25.0.1:44947",
+					"172.26.0.1:44947",
+					"172.27.0.1:44947",
+					"172.28.0.1:44947",
+					"172.29.0.1:44947"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:08:00.396166034Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5537895569371808,
+				"StableID":   "nPxJqJ88Fk11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e51f3252f555b15147a7d6d0383e8b3db97fc57e870978d374dca2a877c55159",
+				"KeyExpiry":  "2026-11-09T09:08:00Z",
+				"DiscoKey":   "discokey:3f3456c5f41939bdc0ee88c60293e0a8b747faa72d6667f5ed1d83ecb52e5c5f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49972",
+					"10.65.0.27:49972",
+					"172.17.0.1:49972",
+					"172.18.0.1:49972",
+					"172.19.0.1:49972",
+					"172.20.0.1:49972",
+					"172.21.0.1:49972",
+					"172.22.0.1:49972",
+					"172.23.0.1:49972",
+					"172.24.0.1:49972",
+					"172.25.0.1:49972",
+					"172.26.0.1:49972",
+					"172.27.0.1:49972",
+					"172.28.0.1:49972",
+					"172.29.0.1:49972"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:08:00.932988028Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1177251999062406,
+				"StableID":   "nfX8rzQBCA11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:52938027520d1caee1ea6694e66c2f3c681afe65efc62a52ed997be3582aec6b",
+				"KeyExpiry":  "2026-11-09T09:08:01Z",
+				"DiscoKey":   "discokey:b5587388f3deed91a2d78efdea074cd9da82d67af1822ef60d04f4bc244b5b01",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47137",
+					"10.65.0.27:47137",
+					"172.17.0.1:47137",
+					"172.18.0.1:47137",
+					"172.19.0.1:47137",
+					"172.20.0.1:47137",
+					"172.21.0.1:47137",
+					"172.22.0.1:47137",
+					"172.23.0.1:47137",
+					"172.24.0.1:47137",
+					"172.25.0.1:47137",
+					"172.26.0.1:47137",
+					"172.27.0.1:47137",
+					"172.28.0.1:47137",
+					"172.29.0.1:47137"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:08:01.471201139Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5802522798683467,
+				"StableID":   "nJ61vCSyJn11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e29baa62cb83de9502d1ac6f5ef90f568782e60f5d9c41fa697805534bd4f460",
+				"KeyExpiry":  "2026-11-09T09:08:02Z",
+				"DiscoKey":   "discokey:1e87464d36e201f1781cf0652e09c26cb9699e2eaa7434b13ab462b9ac447e58",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57459",
+					"10.65.0.27:57459",
+					"172.17.0.1:57459",
+					"172.18.0.1:57459",
+					"172.19.0.1:57459",
+					"172.20.0.1:57459",
+					"172.21.0.1:57459",
+					"172.22.0.1:57459",
+					"172.23.0.1:57459",
+					"172.24.0.1:57459",
+					"172.25.0.1:57459",
+					"172.26.0.1:57459",
+					"172.27.0.1:57459",
+					"172.28.0.1:57459",
+					"172.29.0.1:57459"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:08:02.018946565Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1725894913137605": {
+				"ID":          1725894913137605,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         810829447912296,
+				"StableID":   "nPauke7EL711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       810829447912296,
+				"Key":        "nodekey:321691e42cd1f3bd4e4abd0e402ba434afc7f734536d4d632e7bd516bb618760",
+				"DiscoKey":   "discokey:b77974678d83b9f4798f4e442065c9aad6263c82c90c04dbfcc108195ed74e01",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:57123",
+					"10.65.0.27:57123",
+					"172.17.0.1:57123",
+					"172.18.0.1:57123",
+					"172.19.0.1:57123",
+					"172.20.0.1:57123",
+					"172.21.0.1:57123",
+					"172.22.0.1:57123",
+					"172.23.0.1:57123",
+					"172.24.0.1:57123",
+					"172.25.0.1:57123",
+					"172.26.0.1:57123",
+					"172.27.0.1:57123",
+					"172.28.0.1:57123",
+					"172.29.0.1:57123"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:07:54.357169284Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:321691e42cd1f3bd4e4abd0e402ba434afc7f734536d4d632e7bd516bb618760",
+			"MachineKey": "mkey:9a403c28ff952d94541053c0492ea48cf5861d214a2e669198420b82415c1936",
+			"Peers": [{
+				"ID":         1725894913137605,
+				"StableID":   "n61dRJLfUE11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:538fecf9836662e1580b36d7cbc902a0c4d48cc501cf8778a39dbff84cf3ea60",
+				"DiscoKey":   "discokey:0186b442fd0dea6670f41fb1bacf17cb60c24dfe60305e6e75796c43ff839e4c",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34959",
+					"10.65.0.27:34959",
+					"172.17.0.1:34959",
+					"172.18.0.1:34959",
+					"172.19.0.1:34959",
+					"172.20.0.1:34959",
+					"172.21.0.1:34959",
+					"172.22.0.1:34959",
+					"172.23.0.1:34959",
+					"172.24.0.1:34959",
+					"172.25.0.1:34959",
+					"172.26.0.1:34959",
+					"172.27.0.1:34959",
+					"172.28.0.1:34959",
+					"172.29.0.1:34959"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:07:55.007120011Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4600185073665276,
+				"StableID":   "nbUENZ4Svc11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f3491a77bc70013dff32870742041ae5a0a66cd934158b9ad28a16572435225",
+				"DiscoKey":   "discokey:47cd3f912704ce3ef13cb806b89389b998842a03dd5ab3075a8929ab0c279e3e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41056",
+					"10.65.0.27:41056",
+					"172.17.0.1:41056",
+					"172.18.0.1:41056",
+					"172.19.0.1:41056",
+					"172.20.0.1:41056",
+					"172.21.0.1:41056",
+					"172.22.0.1:41056",
+					"172.23.0.1:41056",
+					"172.24.0.1:41056",
+					"172.25.0.1:41056",
+					"172.26.0.1:41056",
+					"172.27.0.1:41056",
+					"172.28.0.1:41056",
+					"172.29.0.1:41056"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:07:55.553107429Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4017552325304563,
+				"StableID":   "nrxUXeHZNY11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4cbd76d258c25d738ee9008c24cd299884c7cb180bb150d6d631f67f381f825c",
+				"DiscoKey":   "discokey:ebaa732b2df02f9c3f6ece161e1e9be271c44e87aec17530952cb6aba03d3272",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:36217",
+					"10.65.0.27:36217",
+					"172.17.0.1:36217",
+					"172.18.0.1:36217",
+					"172.19.0.1:36217",
+					"172.20.0.1:36217",
+					"172.21.0.1:36217",
+					"172.22.0.1:36217",
+					"172.23.0.1:36217",
+					"172.24.0.1:36217",
+					"172.25.0.1:36217",
+					"172.26.0.1:36217",
+					"172.27.0.1:36217",
+					"172.28.0.1:36217",
+					"172.29.0.1:36217"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:07:56.083035319Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4171462444795908,
+				"StableID":   "ndhBkCFGaZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:da0f229ae7feb8f64120873c854f1be55c864da825fbe88fc35c71b623566509",
+				"DiscoKey":   "discokey:82ed8b559e142264402bbc614511a124c8259c7b0cb1472342a72aa343715c44",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57934",
+					"10.65.0.27:57934",
+					"172.17.0.1:57934",
+					"172.18.0.1:57934",
+					"172.19.0.1:57934",
+					"172.20.0.1:57934",
+					"172.21.0.1:57934",
+					"172.22.0.1:57934",
+					"172.23.0.1:57934",
+					"172.24.0.1:57934",
+					"172.25.0.1:57934",
+					"172.26.0.1:57934",
+					"172.27.0.1:57934",
+					"172.28.0.1:57934",
+					"172.29.0.1:57934"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:07:56.615990966Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2713505144190238,
+				"StableID":   "nqCZdNBxBN11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e08b72c5d7b481b49a88673d6ac014f026f8c1cc9932a760016e9bb6e66f501",
+				"DiscoKey":   "discokey:fbb795f2a36774a19b4f0a99233f6e496967c8e7ce18c5f2781587eebe947650",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46005",
+					"10.65.0.27:46005",
+					"172.17.0.1:46005",
+					"172.18.0.1:46005",
+					"172.19.0.1:46005",
+					"172.20.0.1:46005",
+					"172.21.0.1:46005",
+					"172.22.0.1:46005",
+					"172.23.0.1:46005",
+					"172.24.0.1:46005",
+					"172.25.0.1:46005",
+					"172.26.0.1:46005",
+					"172.27.0.1:46005",
+					"172.28.0.1:46005",
+					"172.29.0.1:46005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:07:57.141625182Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2676933682225812,
+				"StableID":   "nKndmVWPuM11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6e01ff8d037c1131d93d2db63ef1eaa3da47736f72e55695bd64764847ed722c",
+				"DiscoKey":   "discokey:b570dcbfa96cd3b703dee82e88fcd391f0687d8211339a698db8a8f27ca8e361",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:56699",
+					"10.65.0.27:56699",
+					"172.17.0.1:56699",
+					"172.18.0.1:56699",
+					"172.19.0.1:56699",
+					"172.20.0.1:56699",
+					"172.21.0.1:56699",
+					"172.22.0.1:56699",
+					"172.23.0.1:56699",
+					"172.24.0.1:56699",
+					"172.25.0.1:56699",
+					"172.26.0.1:56699",
+					"172.27.0.1:56699",
+					"172.28.0.1:56699",
+					"172.29.0.1:56699"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:07:57.683334156Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         986693426944502,
+				"StableID":   "nBqENGmsh811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc4d51ce1d5ba0e7bbaf68d5816c6d135399dd12be039e0a28dae8fe497ed76e",
+				"DiscoKey":   "discokey:7c87233c5a5c0078c382cdc1bef4bf6016effe96f33365b475a956b3a3986827",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37247",
+					"10.65.0.27:37247",
+					"172.17.0.1:37247",
+					"172.18.0.1:37247",
+					"172.19.0.1:37247",
+					"172.20.0.1:37247",
+					"172.21.0.1:37247",
+					"172.22.0.1:37247",
+					"172.23.0.1:37247",
+					"172.24.0.1:37247",
+					"172.25.0.1:37247",
+					"172.26.0.1:37247",
+					"172.27.0.1:37247",
+					"172.28.0.1:37247",
+					"172.29.0.1:37247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:07:58.230872687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6149241298163959,
+				"StableID":   "n4X1SD912q11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ed63b7a38e24614aade691d4954edb406b49251e795735741752264114702840",
+				"DiscoKey":   "discokey:10ccd0394a433c4c4ef17dadb8dd899fa6877d1a4ae386f88f91642f98780d01",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35018",
+					"10.65.0.27:35018",
+					"172.17.0.1:35018",
+					"172.18.0.1:35018",
+					"172.19.0.1:35018",
+					"172.20.0.1:35018",
+					"172.21.0.1:35018",
+					"172.22.0.1:35018",
+					"172.23.0.1:35018",
+					"172.24.0.1:35018",
+					"172.25.0.1:35018",
+					"172.26.0.1:35018",
+					"172.27.0.1:35018",
+					"172.28.0.1:35018",
+					"172.29.0.1:35018"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:07:58.784586257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3989675051530892,
+				"StableID":   "nfgbJuzv9Y11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b39c7ea43c8057586598323fa68f489b94916f2d26aaf931962aae531406a745",
+				"DiscoKey":   "discokey:8632e2e3bfdc69f8d2ce0c710ed96fef0174fdbb2f4a83ca8774e1b579256966",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:57623",
+					"10.65.0.27:57623",
+					"172.17.0.1:57623",
+					"172.18.0.1:57623",
+					"172.19.0.1:57623",
+					"172.20.0.1:57623",
+					"172.21.0.1:57623",
+					"172.22.0.1:57623",
+					"172.23.0.1:57623",
+					"172.24.0.1:57623",
+					"172.25.0.1:57623",
+					"172.26.0.1:57623",
+					"172.27.0.1:57623",
+					"172.28.0.1:57623",
+					"172.29.0.1:57623"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:07:59.301475404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8823615025271065,
+				"StableID":   "nJ1XjTQEuB21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:744a06afe3ec2c5521131ed873bd98ab67a3d0c786d1f278adb81a6cb8d22152",
+				"DiscoKey":   "discokey:990087c4742a5750dab42d844b71db5b5f56d16090dc07dfd2bbc3a62ae87c07",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53341",
+					"10.65.0.27:53341",
+					"172.17.0.1:53341",
+					"172.18.0.1:53341",
+					"172.19.0.1:53341",
+					"172.20.0.1:53341",
+					"172.21.0.1:53341",
+					"172.22.0.1:53341",
+					"172.23.0.1:53341",
+					"172.24.0.1:53341",
+					"172.25.0.1:53341",
+					"172.26.0.1:53341",
+					"172.27.0.1:53341",
+					"172.28.0.1:53341",
+					"172.29.0.1:53341"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:07:59.83234113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2187320932896342,
+				"StableID":   "n9AGiHDe5J11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4125d29e37ee1197491ce85c2dbcee163a20ad4a6c7a08d4705295fac900406d",
+				"DiscoKey":   "discokey:5236a7194253215205d4412c0985e6ca8f2708526442b1e375de8cb41dc6314e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44947",
+					"10.65.0.27:44947",
+					"172.17.0.1:44947",
+					"172.18.0.1:44947",
+					"172.19.0.1:44947",
+					"172.20.0.1:44947",
+					"172.21.0.1:44947",
+					"172.22.0.1:44947",
+					"172.23.0.1:44947",
+					"172.24.0.1:44947",
+					"172.25.0.1:44947",
+					"172.26.0.1:44947",
+					"172.27.0.1:44947",
+					"172.28.0.1:44947",
+					"172.29.0.1:44947"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:08:00.396166034Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5537895569371808,
+				"StableID":   "nPxJqJ88Fk11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e51f3252f555b15147a7d6d0383e8b3db97fc57e870978d374dca2a877c55159",
+				"KeyExpiry":  "2026-11-09T09:08:00Z",
+				"DiscoKey":   "discokey:3f3456c5f41939bdc0ee88c60293e0a8b747faa72d6667f5ed1d83ecb52e5c5f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49972",
+					"10.65.0.27:49972",
+					"172.17.0.1:49972",
+					"172.18.0.1:49972",
+					"172.19.0.1:49972",
+					"172.20.0.1:49972",
+					"172.21.0.1:49972",
+					"172.22.0.1:49972",
+					"172.23.0.1:49972",
+					"172.24.0.1:49972",
+					"172.25.0.1:49972",
+					"172.26.0.1:49972",
+					"172.27.0.1:49972",
+					"172.28.0.1:49972",
+					"172.29.0.1:49972"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:08:00.932988028Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1177251999062406,
+				"StableID":   "nfX8rzQBCA11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:52938027520d1caee1ea6694e66c2f3c681afe65efc62a52ed997be3582aec6b",
+				"KeyExpiry":  "2026-11-09T09:08:01Z",
+				"DiscoKey":   "discokey:b5587388f3deed91a2d78efdea074cd9da82d67af1822ef60d04f4bc244b5b01",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47137",
+					"10.65.0.27:47137",
+					"172.17.0.1:47137",
+					"172.18.0.1:47137",
+					"172.19.0.1:47137",
+					"172.20.0.1:47137",
+					"172.21.0.1:47137",
+					"172.22.0.1:47137",
+					"172.23.0.1:47137",
+					"172.24.0.1:47137",
+					"172.25.0.1:47137",
+					"172.26.0.1:47137",
+					"172.27.0.1:47137",
+					"172.28.0.1:47137",
+					"172.29.0.1:47137"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:08:01.471201139Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5802522798683467,
+				"StableID":   "nJ61vCSyJn11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e29baa62cb83de9502d1ac6f5ef90f568782e60f5d9c41fa697805534bd4f460",
+				"KeyExpiry":  "2026-11-09T09:08:02Z",
+				"DiscoKey":   "discokey:1e87464d36e201f1781cf0652e09c26cb9699e2eaa7434b13ab462b9ac447e58",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57459",
+					"10.65.0.27:57459",
+					"172.17.0.1:57459",
+					"172.18.0.1:57459",
+					"172.19.0.1:57459",
+					"172.20.0.1:57459",
+					"172.21.0.1:57459",
+					"172.22.0.1:57459",
+					"172.23.0.1:57459",
+					"172.24.0.1:57459",
+					"172.25.0.1:57459",
+					"172.26.0.1:57459",
+					"172.27.0.1:57459",
+					"172.28.0.1:57459",
+					"172.29.0.1:57459"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:08:02.018946565Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "810829447912296": {
+				"ID":          810829447912296,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4171462444795908,
+				"StableID":   "ndhBkCFGaZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       4171462444795908,
+				"Key":        "nodekey:da0f229ae7feb8f64120873c854f1be55c864da825fbe88fc35c71b623566509",
+				"DiscoKey":   "discokey:82ed8b559e142264402bbc614511a124c8259c7b0cb1472342a72aa343715c44",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57934",
+					"10.65.0.27:57934",
+					"172.17.0.1:57934",
+					"172.18.0.1:57934",
+					"172.19.0.1:57934",
+					"172.20.0.1:57934",
+					"172.21.0.1:57934",
+					"172.22.0.1:57934",
+					"172.23.0.1:57934",
+					"172.24.0.1:57934",
+					"172.25.0.1:57934",
+					"172.26.0.1:57934",
+					"172.27.0.1:57934",
+					"172.28.0.1:57934",
+					"172.29.0.1:57934"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:07:56.615990966Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:da0f229ae7feb8f64120873c854f1be55c864da825fbe88fc35c71b623566509",
+			"MachineKey": "mkey:1a1859aadfa13ef20306896db405a3aeeb561a3f74cd5c95bd889b8261c6336d",
+			"Peers": [{
+				"ID":         810829447912296,
+				"StableID":   "nPauke7EL711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:321691e42cd1f3bd4e4abd0e402ba434afc7f734536d4d632e7bd516bb618760",
+				"DiscoKey":   "discokey:b77974678d83b9f4798f4e442065c9aad6263c82c90c04dbfcc108195ed74e01",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:57123",
+					"10.65.0.27:57123",
+					"172.17.0.1:57123",
+					"172.18.0.1:57123",
+					"172.19.0.1:57123",
+					"172.20.0.1:57123",
+					"172.21.0.1:57123",
+					"172.22.0.1:57123",
+					"172.23.0.1:57123",
+					"172.24.0.1:57123",
+					"172.25.0.1:57123",
+					"172.26.0.1:57123",
+					"172.27.0.1:57123",
+					"172.28.0.1:57123",
+					"172.29.0.1:57123"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:07:54.357169284Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1725894913137605,
+				"StableID":   "n61dRJLfUE11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:538fecf9836662e1580b36d7cbc902a0c4d48cc501cf8778a39dbff84cf3ea60",
+				"DiscoKey":   "discokey:0186b442fd0dea6670f41fb1bacf17cb60c24dfe60305e6e75796c43ff839e4c",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34959",
+					"10.65.0.27:34959",
+					"172.17.0.1:34959",
+					"172.18.0.1:34959",
+					"172.19.0.1:34959",
+					"172.20.0.1:34959",
+					"172.21.0.1:34959",
+					"172.22.0.1:34959",
+					"172.23.0.1:34959",
+					"172.24.0.1:34959",
+					"172.25.0.1:34959",
+					"172.26.0.1:34959",
+					"172.27.0.1:34959",
+					"172.28.0.1:34959",
+					"172.29.0.1:34959"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:07:55.007120011Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4600185073665276,
+				"StableID":   "nbUENZ4Svc11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f3491a77bc70013dff32870742041ae5a0a66cd934158b9ad28a16572435225",
+				"DiscoKey":   "discokey:47cd3f912704ce3ef13cb806b89389b998842a03dd5ab3075a8929ab0c279e3e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41056",
+					"10.65.0.27:41056",
+					"172.17.0.1:41056",
+					"172.18.0.1:41056",
+					"172.19.0.1:41056",
+					"172.20.0.1:41056",
+					"172.21.0.1:41056",
+					"172.22.0.1:41056",
+					"172.23.0.1:41056",
+					"172.24.0.1:41056",
+					"172.25.0.1:41056",
+					"172.26.0.1:41056",
+					"172.27.0.1:41056",
+					"172.28.0.1:41056",
+					"172.29.0.1:41056"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:07:55.553107429Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4017552325304563,
+				"StableID":   "nrxUXeHZNY11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4cbd76d258c25d738ee9008c24cd299884c7cb180bb150d6d631f67f381f825c",
+				"DiscoKey":   "discokey:ebaa732b2df02f9c3f6ece161e1e9be271c44e87aec17530952cb6aba03d3272",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:36217",
+					"10.65.0.27:36217",
+					"172.17.0.1:36217",
+					"172.18.0.1:36217",
+					"172.19.0.1:36217",
+					"172.20.0.1:36217",
+					"172.21.0.1:36217",
+					"172.22.0.1:36217",
+					"172.23.0.1:36217",
+					"172.24.0.1:36217",
+					"172.25.0.1:36217",
+					"172.26.0.1:36217",
+					"172.27.0.1:36217",
+					"172.28.0.1:36217",
+					"172.29.0.1:36217"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:07:56.083035319Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2713505144190238,
+				"StableID":   "nqCZdNBxBN11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e08b72c5d7b481b49a88673d6ac014f026f8c1cc9932a760016e9bb6e66f501",
+				"DiscoKey":   "discokey:fbb795f2a36774a19b4f0a99233f6e496967c8e7ce18c5f2781587eebe947650",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46005",
+					"10.65.0.27:46005",
+					"172.17.0.1:46005",
+					"172.18.0.1:46005",
+					"172.19.0.1:46005",
+					"172.20.0.1:46005",
+					"172.21.0.1:46005",
+					"172.22.0.1:46005",
+					"172.23.0.1:46005",
+					"172.24.0.1:46005",
+					"172.25.0.1:46005",
+					"172.26.0.1:46005",
+					"172.27.0.1:46005",
+					"172.28.0.1:46005",
+					"172.29.0.1:46005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:07:57.141625182Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2676933682225812,
+				"StableID":   "nKndmVWPuM11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6e01ff8d037c1131d93d2db63ef1eaa3da47736f72e55695bd64764847ed722c",
+				"DiscoKey":   "discokey:b570dcbfa96cd3b703dee82e88fcd391f0687d8211339a698db8a8f27ca8e361",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:56699",
+					"10.65.0.27:56699",
+					"172.17.0.1:56699",
+					"172.18.0.1:56699",
+					"172.19.0.1:56699",
+					"172.20.0.1:56699",
+					"172.21.0.1:56699",
+					"172.22.0.1:56699",
+					"172.23.0.1:56699",
+					"172.24.0.1:56699",
+					"172.25.0.1:56699",
+					"172.26.0.1:56699",
+					"172.27.0.1:56699",
+					"172.28.0.1:56699",
+					"172.29.0.1:56699"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:07:57.683334156Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         986693426944502,
+				"StableID":   "nBqENGmsh811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc4d51ce1d5ba0e7bbaf68d5816c6d135399dd12be039e0a28dae8fe497ed76e",
+				"DiscoKey":   "discokey:7c87233c5a5c0078c382cdc1bef4bf6016effe96f33365b475a956b3a3986827",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37247",
+					"10.65.0.27:37247",
+					"172.17.0.1:37247",
+					"172.18.0.1:37247",
+					"172.19.0.1:37247",
+					"172.20.0.1:37247",
+					"172.21.0.1:37247",
+					"172.22.0.1:37247",
+					"172.23.0.1:37247",
+					"172.24.0.1:37247",
+					"172.25.0.1:37247",
+					"172.26.0.1:37247",
+					"172.27.0.1:37247",
+					"172.28.0.1:37247",
+					"172.29.0.1:37247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:07:58.230872687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6149241298163959,
+				"StableID":   "n4X1SD912q11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ed63b7a38e24614aade691d4954edb406b49251e795735741752264114702840",
+				"DiscoKey":   "discokey:10ccd0394a433c4c4ef17dadb8dd899fa6877d1a4ae386f88f91642f98780d01",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35018",
+					"10.65.0.27:35018",
+					"172.17.0.1:35018",
+					"172.18.0.1:35018",
+					"172.19.0.1:35018",
+					"172.20.0.1:35018",
+					"172.21.0.1:35018",
+					"172.22.0.1:35018",
+					"172.23.0.1:35018",
+					"172.24.0.1:35018",
+					"172.25.0.1:35018",
+					"172.26.0.1:35018",
+					"172.27.0.1:35018",
+					"172.28.0.1:35018",
+					"172.29.0.1:35018"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:07:58.784586257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3989675051530892,
+				"StableID":   "nfgbJuzv9Y11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b39c7ea43c8057586598323fa68f489b94916f2d26aaf931962aae531406a745",
+				"DiscoKey":   "discokey:8632e2e3bfdc69f8d2ce0c710ed96fef0174fdbb2f4a83ca8774e1b579256966",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:57623",
+					"10.65.0.27:57623",
+					"172.17.0.1:57623",
+					"172.18.0.1:57623",
+					"172.19.0.1:57623",
+					"172.20.0.1:57623",
+					"172.21.0.1:57623",
+					"172.22.0.1:57623",
+					"172.23.0.1:57623",
+					"172.24.0.1:57623",
+					"172.25.0.1:57623",
+					"172.26.0.1:57623",
+					"172.27.0.1:57623",
+					"172.28.0.1:57623",
+					"172.29.0.1:57623"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:07:59.301475404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8823615025271065,
+				"StableID":   "nJ1XjTQEuB21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:744a06afe3ec2c5521131ed873bd98ab67a3d0c786d1f278adb81a6cb8d22152",
+				"DiscoKey":   "discokey:990087c4742a5750dab42d844b71db5b5f56d16090dc07dfd2bbc3a62ae87c07",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53341",
+					"10.65.0.27:53341",
+					"172.17.0.1:53341",
+					"172.18.0.1:53341",
+					"172.19.0.1:53341",
+					"172.20.0.1:53341",
+					"172.21.0.1:53341",
+					"172.22.0.1:53341",
+					"172.23.0.1:53341",
+					"172.24.0.1:53341",
+					"172.25.0.1:53341",
+					"172.26.0.1:53341",
+					"172.27.0.1:53341",
+					"172.28.0.1:53341",
+					"172.29.0.1:53341"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:07:59.83234113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2187320932896342,
+				"StableID":   "n9AGiHDe5J11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4125d29e37ee1197491ce85c2dbcee163a20ad4a6c7a08d4705295fac900406d",
+				"DiscoKey":   "discokey:5236a7194253215205d4412c0985e6ca8f2708526442b1e375de8cb41dc6314e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44947",
+					"10.65.0.27:44947",
+					"172.17.0.1:44947",
+					"172.18.0.1:44947",
+					"172.19.0.1:44947",
+					"172.20.0.1:44947",
+					"172.21.0.1:44947",
+					"172.22.0.1:44947",
+					"172.23.0.1:44947",
+					"172.24.0.1:44947",
+					"172.25.0.1:44947",
+					"172.26.0.1:44947",
+					"172.27.0.1:44947",
+					"172.28.0.1:44947",
+					"172.29.0.1:44947"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:08:00.396166034Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5537895569371808,
+				"StableID":   "nPxJqJ88Fk11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e51f3252f555b15147a7d6d0383e8b3db97fc57e870978d374dca2a877c55159",
+				"KeyExpiry":  "2026-11-09T09:08:00Z",
+				"DiscoKey":   "discokey:3f3456c5f41939bdc0ee88c60293e0a8b747faa72d6667f5ed1d83ecb52e5c5f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49972",
+					"10.65.0.27:49972",
+					"172.17.0.1:49972",
+					"172.18.0.1:49972",
+					"172.19.0.1:49972",
+					"172.20.0.1:49972",
+					"172.21.0.1:49972",
+					"172.22.0.1:49972",
+					"172.23.0.1:49972",
+					"172.24.0.1:49972",
+					"172.25.0.1:49972",
+					"172.26.0.1:49972",
+					"172.27.0.1:49972",
+					"172.28.0.1:49972",
+					"172.29.0.1:49972"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:08:00.932988028Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1177251999062406,
+				"StableID":   "nfX8rzQBCA11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:52938027520d1caee1ea6694e66c2f3c681afe65efc62a52ed997be3582aec6b",
+				"KeyExpiry":  "2026-11-09T09:08:01Z",
+				"DiscoKey":   "discokey:b5587388f3deed91a2d78efdea074cd9da82d67af1822ef60d04f4bc244b5b01",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47137",
+					"10.65.0.27:47137",
+					"172.17.0.1:47137",
+					"172.18.0.1:47137",
+					"172.19.0.1:47137",
+					"172.20.0.1:47137",
+					"172.21.0.1:47137",
+					"172.22.0.1:47137",
+					"172.23.0.1:47137",
+					"172.24.0.1:47137",
+					"172.25.0.1:47137",
+					"172.26.0.1:47137",
+					"172.27.0.1:47137",
+					"172.28.0.1:47137",
+					"172.29.0.1:47137"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:08:01.471201139Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5802522798683467,
+				"StableID":   "nJ61vCSyJn11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e29baa62cb83de9502d1ac6f5ef90f568782e60f5d9c41fa697805534bd4f460",
+				"KeyExpiry":  "2026-11-09T09:08:02Z",
+				"DiscoKey":   "discokey:1e87464d36e201f1781cf0652e09c26cb9699e2eaa7434b13ab462b9ac447e58",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57459",
+					"10.65.0.27:57459",
+					"172.17.0.1:57459",
+					"172.18.0.1:57459",
+					"172.19.0.1:57459",
+					"172.20.0.1:57459",
+					"172.21.0.1:57459",
+					"172.22.0.1:57459",
+					"172.23.0.1:57459",
+					"172.24.0.1:57459",
+					"172.25.0.1:57459",
+					"172.26.0.1:57459",
+					"172.27.0.1:57459",
+					"172.28.0.1:57459",
+					"172.29.0.1:57459"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:08:02.018946565Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4171462444795908": {
+				"ID":          4171462444795908,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4017552325304563,
+				"StableID":   "nrxUXeHZNY11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       4017552325304563,
+				"Key":        "nodekey:4cbd76d258c25d738ee9008c24cd299884c7cb180bb150d6d631f67f381f825c",
+				"DiscoKey":   "discokey:ebaa732b2df02f9c3f6ece161e1e9be271c44e87aec17530952cb6aba03d3272",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:36217",
+					"10.65.0.27:36217",
+					"172.17.0.1:36217",
+					"172.18.0.1:36217",
+					"172.19.0.1:36217",
+					"172.20.0.1:36217",
+					"172.21.0.1:36217",
+					"172.22.0.1:36217",
+					"172.23.0.1:36217",
+					"172.24.0.1:36217",
+					"172.25.0.1:36217",
+					"172.26.0.1:36217",
+					"172.27.0.1:36217",
+					"172.28.0.1:36217",
+					"172.29.0.1:36217"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:07:56.083035319Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4cbd76d258c25d738ee9008c24cd299884c7cb180bb150d6d631f67f381f825c",
+			"MachineKey": "mkey:418c5ba9f98174e14db0fda5c10a50f99f6e763d87e7913e7b024ae8a98ed105",
+			"Peers": [{
+				"ID":         810829447912296,
+				"StableID":   "nPauke7EL711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:321691e42cd1f3bd4e4abd0e402ba434afc7f734536d4d632e7bd516bb618760",
+				"DiscoKey":   "discokey:b77974678d83b9f4798f4e442065c9aad6263c82c90c04dbfcc108195ed74e01",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:57123",
+					"10.65.0.27:57123",
+					"172.17.0.1:57123",
+					"172.18.0.1:57123",
+					"172.19.0.1:57123",
+					"172.20.0.1:57123",
+					"172.21.0.1:57123",
+					"172.22.0.1:57123",
+					"172.23.0.1:57123",
+					"172.24.0.1:57123",
+					"172.25.0.1:57123",
+					"172.26.0.1:57123",
+					"172.27.0.1:57123",
+					"172.28.0.1:57123",
+					"172.29.0.1:57123"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:07:54.357169284Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1725894913137605,
+				"StableID":   "n61dRJLfUE11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:538fecf9836662e1580b36d7cbc902a0c4d48cc501cf8778a39dbff84cf3ea60",
+				"DiscoKey":   "discokey:0186b442fd0dea6670f41fb1bacf17cb60c24dfe60305e6e75796c43ff839e4c",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34959",
+					"10.65.0.27:34959",
+					"172.17.0.1:34959",
+					"172.18.0.1:34959",
+					"172.19.0.1:34959",
+					"172.20.0.1:34959",
+					"172.21.0.1:34959",
+					"172.22.0.1:34959",
+					"172.23.0.1:34959",
+					"172.24.0.1:34959",
+					"172.25.0.1:34959",
+					"172.26.0.1:34959",
+					"172.27.0.1:34959",
+					"172.28.0.1:34959",
+					"172.29.0.1:34959"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:07:55.007120011Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4600185073665276,
+				"StableID":   "nbUENZ4Svc11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f3491a77bc70013dff32870742041ae5a0a66cd934158b9ad28a16572435225",
+				"DiscoKey":   "discokey:47cd3f912704ce3ef13cb806b89389b998842a03dd5ab3075a8929ab0c279e3e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41056",
+					"10.65.0.27:41056",
+					"172.17.0.1:41056",
+					"172.18.0.1:41056",
+					"172.19.0.1:41056",
+					"172.20.0.1:41056",
+					"172.21.0.1:41056",
+					"172.22.0.1:41056",
+					"172.23.0.1:41056",
+					"172.24.0.1:41056",
+					"172.25.0.1:41056",
+					"172.26.0.1:41056",
+					"172.27.0.1:41056",
+					"172.28.0.1:41056",
+					"172.29.0.1:41056"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:07:55.553107429Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4171462444795908,
+				"StableID":   "ndhBkCFGaZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:da0f229ae7feb8f64120873c854f1be55c864da825fbe88fc35c71b623566509",
+				"DiscoKey":   "discokey:82ed8b559e142264402bbc614511a124c8259c7b0cb1472342a72aa343715c44",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57934",
+					"10.65.0.27:57934",
+					"172.17.0.1:57934",
+					"172.18.0.1:57934",
+					"172.19.0.1:57934",
+					"172.20.0.1:57934",
+					"172.21.0.1:57934",
+					"172.22.0.1:57934",
+					"172.23.0.1:57934",
+					"172.24.0.1:57934",
+					"172.25.0.1:57934",
+					"172.26.0.1:57934",
+					"172.27.0.1:57934",
+					"172.28.0.1:57934",
+					"172.29.0.1:57934"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:07:56.615990966Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2713505144190238,
+				"StableID":   "nqCZdNBxBN11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e08b72c5d7b481b49a88673d6ac014f026f8c1cc9932a760016e9bb6e66f501",
+				"DiscoKey":   "discokey:fbb795f2a36774a19b4f0a99233f6e496967c8e7ce18c5f2781587eebe947650",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46005",
+					"10.65.0.27:46005",
+					"172.17.0.1:46005",
+					"172.18.0.1:46005",
+					"172.19.0.1:46005",
+					"172.20.0.1:46005",
+					"172.21.0.1:46005",
+					"172.22.0.1:46005",
+					"172.23.0.1:46005",
+					"172.24.0.1:46005",
+					"172.25.0.1:46005",
+					"172.26.0.1:46005",
+					"172.27.0.1:46005",
+					"172.28.0.1:46005",
+					"172.29.0.1:46005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:07:57.141625182Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2676933682225812,
+				"StableID":   "nKndmVWPuM11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6e01ff8d037c1131d93d2db63ef1eaa3da47736f72e55695bd64764847ed722c",
+				"DiscoKey":   "discokey:b570dcbfa96cd3b703dee82e88fcd391f0687d8211339a698db8a8f27ca8e361",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:56699",
+					"10.65.0.27:56699",
+					"172.17.0.1:56699",
+					"172.18.0.1:56699",
+					"172.19.0.1:56699",
+					"172.20.0.1:56699",
+					"172.21.0.1:56699",
+					"172.22.0.1:56699",
+					"172.23.0.1:56699",
+					"172.24.0.1:56699",
+					"172.25.0.1:56699",
+					"172.26.0.1:56699",
+					"172.27.0.1:56699",
+					"172.28.0.1:56699",
+					"172.29.0.1:56699"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:07:57.683334156Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         986693426944502,
+				"StableID":   "nBqENGmsh811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc4d51ce1d5ba0e7bbaf68d5816c6d135399dd12be039e0a28dae8fe497ed76e",
+				"DiscoKey":   "discokey:7c87233c5a5c0078c382cdc1bef4bf6016effe96f33365b475a956b3a3986827",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37247",
+					"10.65.0.27:37247",
+					"172.17.0.1:37247",
+					"172.18.0.1:37247",
+					"172.19.0.1:37247",
+					"172.20.0.1:37247",
+					"172.21.0.1:37247",
+					"172.22.0.1:37247",
+					"172.23.0.1:37247",
+					"172.24.0.1:37247",
+					"172.25.0.1:37247",
+					"172.26.0.1:37247",
+					"172.27.0.1:37247",
+					"172.28.0.1:37247",
+					"172.29.0.1:37247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:07:58.230872687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6149241298163959,
+				"StableID":   "n4X1SD912q11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ed63b7a38e24614aade691d4954edb406b49251e795735741752264114702840",
+				"DiscoKey":   "discokey:10ccd0394a433c4c4ef17dadb8dd899fa6877d1a4ae386f88f91642f98780d01",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35018",
+					"10.65.0.27:35018",
+					"172.17.0.1:35018",
+					"172.18.0.1:35018",
+					"172.19.0.1:35018",
+					"172.20.0.1:35018",
+					"172.21.0.1:35018",
+					"172.22.0.1:35018",
+					"172.23.0.1:35018",
+					"172.24.0.1:35018",
+					"172.25.0.1:35018",
+					"172.26.0.1:35018",
+					"172.27.0.1:35018",
+					"172.28.0.1:35018",
+					"172.29.0.1:35018"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:07:58.784586257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3989675051530892,
+				"StableID":   "nfgbJuzv9Y11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b39c7ea43c8057586598323fa68f489b94916f2d26aaf931962aae531406a745",
+				"DiscoKey":   "discokey:8632e2e3bfdc69f8d2ce0c710ed96fef0174fdbb2f4a83ca8774e1b579256966",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:57623",
+					"10.65.0.27:57623",
+					"172.17.0.1:57623",
+					"172.18.0.1:57623",
+					"172.19.0.1:57623",
+					"172.20.0.1:57623",
+					"172.21.0.1:57623",
+					"172.22.0.1:57623",
+					"172.23.0.1:57623",
+					"172.24.0.1:57623",
+					"172.25.0.1:57623",
+					"172.26.0.1:57623",
+					"172.27.0.1:57623",
+					"172.28.0.1:57623",
+					"172.29.0.1:57623"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:07:59.301475404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8823615025271065,
+				"StableID":   "nJ1XjTQEuB21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:744a06afe3ec2c5521131ed873bd98ab67a3d0c786d1f278adb81a6cb8d22152",
+				"DiscoKey":   "discokey:990087c4742a5750dab42d844b71db5b5f56d16090dc07dfd2bbc3a62ae87c07",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53341",
+					"10.65.0.27:53341",
+					"172.17.0.1:53341",
+					"172.18.0.1:53341",
+					"172.19.0.1:53341",
+					"172.20.0.1:53341",
+					"172.21.0.1:53341",
+					"172.22.0.1:53341",
+					"172.23.0.1:53341",
+					"172.24.0.1:53341",
+					"172.25.0.1:53341",
+					"172.26.0.1:53341",
+					"172.27.0.1:53341",
+					"172.28.0.1:53341",
+					"172.29.0.1:53341"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:07:59.83234113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2187320932896342,
+				"StableID":   "n9AGiHDe5J11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4125d29e37ee1197491ce85c2dbcee163a20ad4a6c7a08d4705295fac900406d",
+				"DiscoKey":   "discokey:5236a7194253215205d4412c0985e6ca8f2708526442b1e375de8cb41dc6314e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44947",
+					"10.65.0.27:44947",
+					"172.17.0.1:44947",
+					"172.18.0.1:44947",
+					"172.19.0.1:44947",
+					"172.20.0.1:44947",
+					"172.21.0.1:44947",
+					"172.22.0.1:44947",
+					"172.23.0.1:44947",
+					"172.24.0.1:44947",
+					"172.25.0.1:44947",
+					"172.26.0.1:44947",
+					"172.27.0.1:44947",
+					"172.28.0.1:44947",
+					"172.29.0.1:44947"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:08:00.396166034Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5537895569371808,
+				"StableID":   "nPxJqJ88Fk11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e51f3252f555b15147a7d6d0383e8b3db97fc57e870978d374dca2a877c55159",
+				"KeyExpiry":  "2026-11-09T09:08:00Z",
+				"DiscoKey":   "discokey:3f3456c5f41939bdc0ee88c60293e0a8b747faa72d6667f5ed1d83ecb52e5c5f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49972",
+					"10.65.0.27:49972",
+					"172.17.0.1:49972",
+					"172.18.0.1:49972",
+					"172.19.0.1:49972",
+					"172.20.0.1:49972",
+					"172.21.0.1:49972",
+					"172.22.0.1:49972",
+					"172.23.0.1:49972",
+					"172.24.0.1:49972",
+					"172.25.0.1:49972",
+					"172.26.0.1:49972",
+					"172.27.0.1:49972",
+					"172.28.0.1:49972",
+					"172.29.0.1:49972"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:08:00.932988028Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1177251999062406,
+				"StableID":   "nfX8rzQBCA11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:52938027520d1caee1ea6694e66c2f3c681afe65efc62a52ed997be3582aec6b",
+				"KeyExpiry":  "2026-11-09T09:08:01Z",
+				"DiscoKey":   "discokey:b5587388f3deed91a2d78efdea074cd9da82d67af1822ef60d04f4bc244b5b01",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47137",
+					"10.65.0.27:47137",
+					"172.17.0.1:47137",
+					"172.18.0.1:47137",
+					"172.19.0.1:47137",
+					"172.20.0.1:47137",
+					"172.21.0.1:47137",
+					"172.22.0.1:47137",
+					"172.23.0.1:47137",
+					"172.24.0.1:47137",
+					"172.25.0.1:47137",
+					"172.26.0.1:47137",
+					"172.27.0.1:47137",
+					"172.28.0.1:47137",
+					"172.29.0.1:47137"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:08:01.471201139Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5802522798683467,
+				"StableID":   "nJ61vCSyJn11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e29baa62cb83de9502d1ac6f5ef90f568782e60f5d9c41fa697805534bd4f460",
+				"KeyExpiry":  "2026-11-09T09:08:02Z",
+				"DiscoKey":   "discokey:1e87464d36e201f1781cf0652e09c26cb9699e2eaa7434b13ab462b9ac447e58",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57459",
+					"10.65.0.27:57459",
+					"172.17.0.1:57459",
+					"172.18.0.1:57459",
+					"172.19.0.1:57459",
+					"172.20.0.1:57459",
+					"172.21.0.1:57459",
+					"172.22.0.1:57459",
+					"172.23.0.1:57459",
+					"172.24.0.1:57459",
+					"172.25.0.1:57459",
+					"172.26.0.1:57459",
+					"172.27.0.1:57459",
+					"172.28.0.1:57459",
+					"172.29.0.1:57459"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:08:02.018946565Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4017552325304563": {
+				"ID":          4017552325304563,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2676933682225812,
+				"StableID":   "nKndmVWPuM11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       2676933682225812,
+				"Key":        "nodekey:6e01ff8d037c1131d93d2db63ef1eaa3da47736f72e55695bd64764847ed722c",
+				"DiscoKey":   "discokey:b570dcbfa96cd3b703dee82e88fcd391f0687d8211339a698db8a8f27ca8e361",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:56699",
+					"10.65.0.27:56699",
+					"172.17.0.1:56699",
+					"172.18.0.1:56699",
+					"172.19.0.1:56699",
+					"172.20.0.1:56699",
+					"172.21.0.1:56699",
+					"172.22.0.1:56699",
+					"172.23.0.1:56699",
+					"172.24.0.1:56699",
+					"172.25.0.1:56699",
+					"172.26.0.1:56699",
+					"172.27.0.1:56699",
+					"172.28.0.1:56699",
+					"172.29.0.1:56699"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:07:57.683334156Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6e01ff8d037c1131d93d2db63ef1eaa3da47736f72e55695bd64764847ed722c",
+			"MachineKey": "mkey:5addcb02ce3f78331c51b53df37fc7dd9beb8caa814bb93ad93cba45b0b90c24",
+			"Peers": [{
+				"ID":         810829447912296,
+				"StableID":   "nPauke7EL711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:321691e42cd1f3bd4e4abd0e402ba434afc7f734536d4d632e7bd516bb618760",
+				"DiscoKey":   "discokey:b77974678d83b9f4798f4e442065c9aad6263c82c90c04dbfcc108195ed74e01",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:57123",
+					"10.65.0.27:57123",
+					"172.17.0.1:57123",
+					"172.18.0.1:57123",
+					"172.19.0.1:57123",
+					"172.20.0.1:57123",
+					"172.21.0.1:57123",
+					"172.22.0.1:57123",
+					"172.23.0.1:57123",
+					"172.24.0.1:57123",
+					"172.25.0.1:57123",
+					"172.26.0.1:57123",
+					"172.27.0.1:57123",
+					"172.28.0.1:57123",
+					"172.29.0.1:57123"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:07:54.357169284Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1725894913137605,
+				"StableID":   "n61dRJLfUE11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:538fecf9836662e1580b36d7cbc902a0c4d48cc501cf8778a39dbff84cf3ea60",
+				"DiscoKey":   "discokey:0186b442fd0dea6670f41fb1bacf17cb60c24dfe60305e6e75796c43ff839e4c",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34959",
+					"10.65.0.27:34959",
+					"172.17.0.1:34959",
+					"172.18.0.1:34959",
+					"172.19.0.1:34959",
+					"172.20.0.1:34959",
+					"172.21.0.1:34959",
+					"172.22.0.1:34959",
+					"172.23.0.1:34959",
+					"172.24.0.1:34959",
+					"172.25.0.1:34959",
+					"172.26.0.1:34959",
+					"172.27.0.1:34959",
+					"172.28.0.1:34959",
+					"172.29.0.1:34959"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:07:55.007120011Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4600185073665276,
+				"StableID":   "nbUENZ4Svc11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f3491a77bc70013dff32870742041ae5a0a66cd934158b9ad28a16572435225",
+				"DiscoKey":   "discokey:47cd3f912704ce3ef13cb806b89389b998842a03dd5ab3075a8929ab0c279e3e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41056",
+					"10.65.0.27:41056",
+					"172.17.0.1:41056",
+					"172.18.0.1:41056",
+					"172.19.0.1:41056",
+					"172.20.0.1:41056",
+					"172.21.0.1:41056",
+					"172.22.0.1:41056",
+					"172.23.0.1:41056",
+					"172.24.0.1:41056",
+					"172.25.0.1:41056",
+					"172.26.0.1:41056",
+					"172.27.0.1:41056",
+					"172.28.0.1:41056",
+					"172.29.0.1:41056"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:07:55.553107429Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4017552325304563,
+				"StableID":   "nrxUXeHZNY11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4cbd76d258c25d738ee9008c24cd299884c7cb180bb150d6d631f67f381f825c",
+				"DiscoKey":   "discokey:ebaa732b2df02f9c3f6ece161e1e9be271c44e87aec17530952cb6aba03d3272",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:36217",
+					"10.65.0.27:36217",
+					"172.17.0.1:36217",
+					"172.18.0.1:36217",
+					"172.19.0.1:36217",
+					"172.20.0.1:36217",
+					"172.21.0.1:36217",
+					"172.22.0.1:36217",
+					"172.23.0.1:36217",
+					"172.24.0.1:36217",
+					"172.25.0.1:36217",
+					"172.26.0.1:36217",
+					"172.27.0.1:36217",
+					"172.28.0.1:36217",
+					"172.29.0.1:36217"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:07:56.083035319Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4171462444795908,
+				"StableID":   "ndhBkCFGaZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:da0f229ae7feb8f64120873c854f1be55c864da825fbe88fc35c71b623566509",
+				"DiscoKey":   "discokey:82ed8b559e142264402bbc614511a124c8259c7b0cb1472342a72aa343715c44",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57934",
+					"10.65.0.27:57934",
+					"172.17.0.1:57934",
+					"172.18.0.1:57934",
+					"172.19.0.1:57934",
+					"172.20.0.1:57934",
+					"172.21.0.1:57934",
+					"172.22.0.1:57934",
+					"172.23.0.1:57934",
+					"172.24.0.1:57934",
+					"172.25.0.1:57934",
+					"172.26.0.1:57934",
+					"172.27.0.1:57934",
+					"172.28.0.1:57934",
+					"172.29.0.1:57934"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:07:56.615990966Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2713505144190238,
+				"StableID":   "nqCZdNBxBN11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e08b72c5d7b481b49a88673d6ac014f026f8c1cc9932a760016e9bb6e66f501",
+				"DiscoKey":   "discokey:fbb795f2a36774a19b4f0a99233f6e496967c8e7ce18c5f2781587eebe947650",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46005",
+					"10.65.0.27:46005",
+					"172.17.0.1:46005",
+					"172.18.0.1:46005",
+					"172.19.0.1:46005",
+					"172.20.0.1:46005",
+					"172.21.0.1:46005",
+					"172.22.0.1:46005",
+					"172.23.0.1:46005",
+					"172.24.0.1:46005",
+					"172.25.0.1:46005",
+					"172.26.0.1:46005",
+					"172.27.0.1:46005",
+					"172.28.0.1:46005",
+					"172.29.0.1:46005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:07:57.141625182Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         986693426944502,
+				"StableID":   "nBqENGmsh811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc4d51ce1d5ba0e7bbaf68d5816c6d135399dd12be039e0a28dae8fe497ed76e",
+				"DiscoKey":   "discokey:7c87233c5a5c0078c382cdc1bef4bf6016effe96f33365b475a956b3a3986827",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37247",
+					"10.65.0.27:37247",
+					"172.17.0.1:37247",
+					"172.18.0.1:37247",
+					"172.19.0.1:37247",
+					"172.20.0.1:37247",
+					"172.21.0.1:37247",
+					"172.22.0.1:37247",
+					"172.23.0.1:37247",
+					"172.24.0.1:37247",
+					"172.25.0.1:37247",
+					"172.26.0.1:37247",
+					"172.27.0.1:37247",
+					"172.28.0.1:37247",
+					"172.29.0.1:37247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:07:58.230872687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6149241298163959,
+				"StableID":   "n4X1SD912q11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ed63b7a38e24614aade691d4954edb406b49251e795735741752264114702840",
+				"DiscoKey":   "discokey:10ccd0394a433c4c4ef17dadb8dd899fa6877d1a4ae386f88f91642f98780d01",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35018",
+					"10.65.0.27:35018",
+					"172.17.0.1:35018",
+					"172.18.0.1:35018",
+					"172.19.0.1:35018",
+					"172.20.0.1:35018",
+					"172.21.0.1:35018",
+					"172.22.0.1:35018",
+					"172.23.0.1:35018",
+					"172.24.0.1:35018",
+					"172.25.0.1:35018",
+					"172.26.0.1:35018",
+					"172.27.0.1:35018",
+					"172.28.0.1:35018",
+					"172.29.0.1:35018"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:07:58.784586257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3989675051530892,
+				"StableID":   "nfgbJuzv9Y11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b39c7ea43c8057586598323fa68f489b94916f2d26aaf931962aae531406a745",
+				"DiscoKey":   "discokey:8632e2e3bfdc69f8d2ce0c710ed96fef0174fdbb2f4a83ca8774e1b579256966",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:57623",
+					"10.65.0.27:57623",
+					"172.17.0.1:57623",
+					"172.18.0.1:57623",
+					"172.19.0.1:57623",
+					"172.20.0.1:57623",
+					"172.21.0.1:57623",
+					"172.22.0.1:57623",
+					"172.23.0.1:57623",
+					"172.24.0.1:57623",
+					"172.25.0.1:57623",
+					"172.26.0.1:57623",
+					"172.27.0.1:57623",
+					"172.28.0.1:57623",
+					"172.29.0.1:57623"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:07:59.301475404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8823615025271065,
+				"StableID":   "nJ1XjTQEuB21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:744a06afe3ec2c5521131ed873bd98ab67a3d0c786d1f278adb81a6cb8d22152",
+				"DiscoKey":   "discokey:990087c4742a5750dab42d844b71db5b5f56d16090dc07dfd2bbc3a62ae87c07",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53341",
+					"10.65.0.27:53341",
+					"172.17.0.1:53341",
+					"172.18.0.1:53341",
+					"172.19.0.1:53341",
+					"172.20.0.1:53341",
+					"172.21.0.1:53341",
+					"172.22.0.1:53341",
+					"172.23.0.1:53341",
+					"172.24.0.1:53341",
+					"172.25.0.1:53341",
+					"172.26.0.1:53341",
+					"172.27.0.1:53341",
+					"172.28.0.1:53341",
+					"172.29.0.1:53341"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:07:59.83234113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2187320932896342,
+				"StableID":   "n9AGiHDe5J11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4125d29e37ee1197491ce85c2dbcee163a20ad4a6c7a08d4705295fac900406d",
+				"DiscoKey":   "discokey:5236a7194253215205d4412c0985e6ca8f2708526442b1e375de8cb41dc6314e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44947",
+					"10.65.0.27:44947",
+					"172.17.0.1:44947",
+					"172.18.0.1:44947",
+					"172.19.0.1:44947",
+					"172.20.0.1:44947",
+					"172.21.0.1:44947",
+					"172.22.0.1:44947",
+					"172.23.0.1:44947",
+					"172.24.0.1:44947",
+					"172.25.0.1:44947",
+					"172.26.0.1:44947",
+					"172.27.0.1:44947",
+					"172.28.0.1:44947",
+					"172.29.0.1:44947"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:08:00.396166034Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5537895569371808,
+				"StableID":   "nPxJqJ88Fk11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e51f3252f555b15147a7d6d0383e8b3db97fc57e870978d374dca2a877c55159",
+				"KeyExpiry":  "2026-11-09T09:08:00Z",
+				"DiscoKey":   "discokey:3f3456c5f41939bdc0ee88c60293e0a8b747faa72d6667f5ed1d83ecb52e5c5f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49972",
+					"10.65.0.27:49972",
+					"172.17.0.1:49972",
+					"172.18.0.1:49972",
+					"172.19.0.1:49972",
+					"172.20.0.1:49972",
+					"172.21.0.1:49972",
+					"172.22.0.1:49972",
+					"172.23.0.1:49972",
+					"172.24.0.1:49972",
+					"172.25.0.1:49972",
+					"172.26.0.1:49972",
+					"172.27.0.1:49972",
+					"172.28.0.1:49972",
+					"172.29.0.1:49972"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:08:00.932988028Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1177251999062406,
+				"StableID":   "nfX8rzQBCA11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:52938027520d1caee1ea6694e66c2f3c681afe65efc62a52ed997be3582aec6b",
+				"KeyExpiry":  "2026-11-09T09:08:01Z",
+				"DiscoKey":   "discokey:b5587388f3deed91a2d78efdea074cd9da82d67af1822ef60d04f4bc244b5b01",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47137",
+					"10.65.0.27:47137",
+					"172.17.0.1:47137",
+					"172.18.0.1:47137",
+					"172.19.0.1:47137",
+					"172.20.0.1:47137",
+					"172.21.0.1:47137",
+					"172.22.0.1:47137",
+					"172.23.0.1:47137",
+					"172.24.0.1:47137",
+					"172.25.0.1:47137",
+					"172.26.0.1:47137",
+					"172.27.0.1:47137",
+					"172.28.0.1:47137",
+					"172.29.0.1:47137"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:08:01.471201139Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5802522798683467,
+				"StableID":   "nJ61vCSyJn11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e29baa62cb83de9502d1ac6f5ef90f568782e60f5d9c41fa697805534bd4f460",
+				"KeyExpiry":  "2026-11-09T09:08:02Z",
+				"DiscoKey":   "discokey:1e87464d36e201f1781cf0652e09c26cb9699e2eaa7434b13ab462b9ac447e58",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57459",
+					"10.65.0.27:57459",
+					"172.17.0.1:57459",
+					"172.18.0.1:57459",
+					"172.19.0.1:57459",
+					"172.20.0.1:57459",
+					"172.21.0.1:57459",
+					"172.22.0.1:57459",
+					"172.23.0.1:57459",
+					"172.24.0.1:57459",
+					"172.25.0.1:57459",
+					"172.26.0.1:57459",
+					"172.27.0.1:57459",
+					"172.28.0.1:57459",
+					"172.29.0.1:57459"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:08:02.018946565Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2676933682225812": {
+				"ID":          2676933682225812,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6149241298163959,
+				"StableID":   "n4X1SD912q11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       6149241298163959,
+				"Key":        "nodekey:ed63b7a38e24614aade691d4954edb406b49251e795735741752264114702840",
+				"DiscoKey":   "discokey:10ccd0394a433c4c4ef17dadb8dd899fa6877d1a4ae386f88f91642f98780d01",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35018",
+					"10.65.0.27:35018",
+					"172.17.0.1:35018",
+					"172.18.0.1:35018",
+					"172.19.0.1:35018",
+					"172.20.0.1:35018",
+					"172.21.0.1:35018",
+					"172.22.0.1:35018",
+					"172.23.0.1:35018",
+					"172.24.0.1:35018",
+					"172.25.0.1:35018",
+					"172.26.0.1:35018",
+					"172.27.0.1:35018",
+					"172.28.0.1:35018",
+					"172.29.0.1:35018"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:07:58.784586257Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ed63b7a38e24614aade691d4954edb406b49251e795735741752264114702840",
+			"MachineKey": "mkey:57d42cd6efee13eb13c7ca6933e9f1e20bac53ba48fe2c1199598cfbf3e49e49",
+			"Peers": [{
+				"ID":         810829447912296,
+				"StableID":   "nPauke7EL711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:321691e42cd1f3bd4e4abd0e402ba434afc7f734536d4d632e7bd516bb618760",
+				"DiscoKey":   "discokey:b77974678d83b9f4798f4e442065c9aad6263c82c90c04dbfcc108195ed74e01",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:57123",
+					"10.65.0.27:57123",
+					"172.17.0.1:57123",
+					"172.18.0.1:57123",
+					"172.19.0.1:57123",
+					"172.20.0.1:57123",
+					"172.21.0.1:57123",
+					"172.22.0.1:57123",
+					"172.23.0.1:57123",
+					"172.24.0.1:57123",
+					"172.25.0.1:57123",
+					"172.26.0.1:57123",
+					"172.27.0.1:57123",
+					"172.28.0.1:57123",
+					"172.29.0.1:57123"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:07:54.357169284Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1725894913137605,
+				"StableID":   "n61dRJLfUE11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:538fecf9836662e1580b36d7cbc902a0c4d48cc501cf8778a39dbff84cf3ea60",
+				"DiscoKey":   "discokey:0186b442fd0dea6670f41fb1bacf17cb60c24dfe60305e6e75796c43ff839e4c",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34959",
+					"10.65.0.27:34959",
+					"172.17.0.1:34959",
+					"172.18.0.1:34959",
+					"172.19.0.1:34959",
+					"172.20.0.1:34959",
+					"172.21.0.1:34959",
+					"172.22.0.1:34959",
+					"172.23.0.1:34959",
+					"172.24.0.1:34959",
+					"172.25.0.1:34959",
+					"172.26.0.1:34959",
+					"172.27.0.1:34959",
+					"172.28.0.1:34959",
+					"172.29.0.1:34959"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:07:55.007120011Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4600185073665276,
+				"StableID":   "nbUENZ4Svc11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f3491a77bc70013dff32870742041ae5a0a66cd934158b9ad28a16572435225",
+				"DiscoKey":   "discokey:47cd3f912704ce3ef13cb806b89389b998842a03dd5ab3075a8929ab0c279e3e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41056",
+					"10.65.0.27:41056",
+					"172.17.0.1:41056",
+					"172.18.0.1:41056",
+					"172.19.0.1:41056",
+					"172.20.0.1:41056",
+					"172.21.0.1:41056",
+					"172.22.0.1:41056",
+					"172.23.0.1:41056",
+					"172.24.0.1:41056",
+					"172.25.0.1:41056",
+					"172.26.0.1:41056",
+					"172.27.0.1:41056",
+					"172.28.0.1:41056",
+					"172.29.0.1:41056"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:07:55.553107429Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4017552325304563,
+				"StableID":   "nrxUXeHZNY11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4cbd76d258c25d738ee9008c24cd299884c7cb180bb150d6d631f67f381f825c",
+				"DiscoKey":   "discokey:ebaa732b2df02f9c3f6ece161e1e9be271c44e87aec17530952cb6aba03d3272",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:36217",
+					"10.65.0.27:36217",
+					"172.17.0.1:36217",
+					"172.18.0.1:36217",
+					"172.19.0.1:36217",
+					"172.20.0.1:36217",
+					"172.21.0.1:36217",
+					"172.22.0.1:36217",
+					"172.23.0.1:36217",
+					"172.24.0.1:36217",
+					"172.25.0.1:36217",
+					"172.26.0.1:36217",
+					"172.27.0.1:36217",
+					"172.28.0.1:36217",
+					"172.29.0.1:36217"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:07:56.083035319Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4171462444795908,
+				"StableID":   "ndhBkCFGaZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:da0f229ae7feb8f64120873c854f1be55c864da825fbe88fc35c71b623566509",
+				"DiscoKey":   "discokey:82ed8b559e142264402bbc614511a124c8259c7b0cb1472342a72aa343715c44",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57934",
+					"10.65.0.27:57934",
+					"172.17.0.1:57934",
+					"172.18.0.1:57934",
+					"172.19.0.1:57934",
+					"172.20.0.1:57934",
+					"172.21.0.1:57934",
+					"172.22.0.1:57934",
+					"172.23.0.1:57934",
+					"172.24.0.1:57934",
+					"172.25.0.1:57934",
+					"172.26.0.1:57934",
+					"172.27.0.1:57934",
+					"172.28.0.1:57934",
+					"172.29.0.1:57934"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:07:56.615990966Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2713505144190238,
+				"StableID":   "nqCZdNBxBN11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e08b72c5d7b481b49a88673d6ac014f026f8c1cc9932a760016e9bb6e66f501",
+				"DiscoKey":   "discokey:fbb795f2a36774a19b4f0a99233f6e496967c8e7ce18c5f2781587eebe947650",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46005",
+					"10.65.0.27:46005",
+					"172.17.0.1:46005",
+					"172.18.0.1:46005",
+					"172.19.0.1:46005",
+					"172.20.0.1:46005",
+					"172.21.0.1:46005",
+					"172.22.0.1:46005",
+					"172.23.0.1:46005",
+					"172.24.0.1:46005",
+					"172.25.0.1:46005",
+					"172.26.0.1:46005",
+					"172.27.0.1:46005",
+					"172.28.0.1:46005",
+					"172.29.0.1:46005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:07:57.141625182Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2676933682225812,
+				"StableID":   "nKndmVWPuM11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6e01ff8d037c1131d93d2db63ef1eaa3da47736f72e55695bd64764847ed722c",
+				"DiscoKey":   "discokey:b570dcbfa96cd3b703dee82e88fcd391f0687d8211339a698db8a8f27ca8e361",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:56699",
+					"10.65.0.27:56699",
+					"172.17.0.1:56699",
+					"172.18.0.1:56699",
+					"172.19.0.1:56699",
+					"172.20.0.1:56699",
+					"172.21.0.1:56699",
+					"172.22.0.1:56699",
+					"172.23.0.1:56699",
+					"172.24.0.1:56699",
+					"172.25.0.1:56699",
+					"172.26.0.1:56699",
+					"172.27.0.1:56699",
+					"172.28.0.1:56699",
+					"172.29.0.1:56699"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:07:57.683334156Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         986693426944502,
+				"StableID":   "nBqENGmsh811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc4d51ce1d5ba0e7bbaf68d5816c6d135399dd12be039e0a28dae8fe497ed76e",
+				"DiscoKey":   "discokey:7c87233c5a5c0078c382cdc1bef4bf6016effe96f33365b475a956b3a3986827",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37247",
+					"10.65.0.27:37247",
+					"172.17.0.1:37247",
+					"172.18.0.1:37247",
+					"172.19.0.1:37247",
+					"172.20.0.1:37247",
+					"172.21.0.1:37247",
+					"172.22.0.1:37247",
+					"172.23.0.1:37247",
+					"172.24.0.1:37247",
+					"172.25.0.1:37247",
+					"172.26.0.1:37247",
+					"172.27.0.1:37247",
+					"172.28.0.1:37247",
+					"172.29.0.1:37247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:07:58.230872687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3989675051530892,
+				"StableID":   "nfgbJuzv9Y11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b39c7ea43c8057586598323fa68f489b94916f2d26aaf931962aae531406a745",
+				"DiscoKey":   "discokey:8632e2e3bfdc69f8d2ce0c710ed96fef0174fdbb2f4a83ca8774e1b579256966",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:57623",
+					"10.65.0.27:57623",
+					"172.17.0.1:57623",
+					"172.18.0.1:57623",
+					"172.19.0.1:57623",
+					"172.20.0.1:57623",
+					"172.21.0.1:57623",
+					"172.22.0.1:57623",
+					"172.23.0.1:57623",
+					"172.24.0.1:57623",
+					"172.25.0.1:57623",
+					"172.26.0.1:57623",
+					"172.27.0.1:57623",
+					"172.28.0.1:57623",
+					"172.29.0.1:57623"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:07:59.301475404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8823615025271065,
+				"StableID":   "nJ1XjTQEuB21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:744a06afe3ec2c5521131ed873bd98ab67a3d0c786d1f278adb81a6cb8d22152",
+				"DiscoKey":   "discokey:990087c4742a5750dab42d844b71db5b5f56d16090dc07dfd2bbc3a62ae87c07",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53341",
+					"10.65.0.27:53341",
+					"172.17.0.1:53341",
+					"172.18.0.1:53341",
+					"172.19.0.1:53341",
+					"172.20.0.1:53341",
+					"172.21.0.1:53341",
+					"172.22.0.1:53341",
+					"172.23.0.1:53341",
+					"172.24.0.1:53341",
+					"172.25.0.1:53341",
+					"172.26.0.1:53341",
+					"172.27.0.1:53341",
+					"172.28.0.1:53341",
+					"172.29.0.1:53341"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:07:59.83234113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2187320932896342,
+				"StableID":   "n9AGiHDe5J11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4125d29e37ee1197491ce85c2dbcee163a20ad4a6c7a08d4705295fac900406d",
+				"DiscoKey":   "discokey:5236a7194253215205d4412c0985e6ca8f2708526442b1e375de8cb41dc6314e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44947",
+					"10.65.0.27:44947",
+					"172.17.0.1:44947",
+					"172.18.0.1:44947",
+					"172.19.0.1:44947",
+					"172.20.0.1:44947",
+					"172.21.0.1:44947",
+					"172.22.0.1:44947",
+					"172.23.0.1:44947",
+					"172.24.0.1:44947",
+					"172.25.0.1:44947",
+					"172.26.0.1:44947",
+					"172.27.0.1:44947",
+					"172.28.0.1:44947",
+					"172.29.0.1:44947"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:08:00.396166034Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5537895569371808,
+				"StableID":   "nPxJqJ88Fk11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e51f3252f555b15147a7d6d0383e8b3db97fc57e870978d374dca2a877c55159",
+				"KeyExpiry":  "2026-11-09T09:08:00Z",
+				"DiscoKey":   "discokey:3f3456c5f41939bdc0ee88c60293e0a8b747faa72d6667f5ed1d83ecb52e5c5f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49972",
+					"10.65.0.27:49972",
+					"172.17.0.1:49972",
+					"172.18.0.1:49972",
+					"172.19.0.1:49972",
+					"172.20.0.1:49972",
+					"172.21.0.1:49972",
+					"172.22.0.1:49972",
+					"172.23.0.1:49972",
+					"172.24.0.1:49972",
+					"172.25.0.1:49972",
+					"172.26.0.1:49972",
+					"172.27.0.1:49972",
+					"172.28.0.1:49972",
+					"172.29.0.1:49972"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:08:00.932988028Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1177251999062406,
+				"StableID":   "nfX8rzQBCA11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:52938027520d1caee1ea6694e66c2f3c681afe65efc62a52ed997be3582aec6b",
+				"KeyExpiry":  "2026-11-09T09:08:01Z",
+				"DiscoKey":   "discokey:b5587388f3deed91a2d78efdea074cd9da82d67af1822ef60d04f4bc244b5b01",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47137",
+					"10.65.0.27:47137",
+					"172.17.0.1:47137",
+					"172.18.0.1:47137",
+					"172.19.0.1:47137",
+					"172.20.0.1:47137",
+					"172.21.0.1:47137",
+					"172.22.0.1:47137",
+					"172.23.0.1:47137",
+					"172.24.0.1:47137",
+					"172.25.0.1:47137",
+					"172.26.0.1:47137",
+					"172.27.0.1:47137",
+					"172.28.0.1:47137",
+					"172.29.0.1:47137"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:08:01.471201139Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5802522798683467,
+				"StableID":   "nJ61vCSyJn11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e29baa62cb83de9502d1ac6f5ef90f568782e60f5d9c41fa697805534bd4f460",
+				"KeyExpiry":  "2026-11-09T09:08:02Z",
+				"DiscoKey":   "discokey:1e87464d36e201f1781cf0652e09c26cb9699e2eaa7434b13ab462b9ac447e58",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57459",
+					"10.65.0.27:57459",
+					"172.17.0.1:57459",
+					"172.18.0.1:57459",
+					"172.19.0.1:57459",
+					"172.20.0.1:57459",
+					"172.21.0.1:57459",
+					"172.22.0.1:57459",
+					"172.23.0.1:57459",
+					"172.24.0.1:57459",
+					"172.25.0.1:57459",
+					"172.26.0.1:57459",
+					"172.27.0.1:57459",
+					"172.28.0.1:57459",
+					"172.29.0.1:57459"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:08:02.018946565Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6149241298163959": {
+				"ID":          6149241298163959,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1177251999062406,
+				"StableID":   "nfX8rzQBCA11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:52938027520d1caee1ea6694e66c2f3c681afe65efc62a52ed997be3582aec6b",
+				"KeyExpiry":  "2026-11-09T09:08:01Z",
+				"DiscoKey":   "discokey:b5587388f3deed91a2d78efdea074cd9da82d67af1822ef60d04f4bc244b5b01",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47137",
+					"10.65.0.27:47137",
+					"172.17.0.1:47137",
+					"172.18.0.1:47137",
+					"172.19.0.1:47137",
+					"172.20.0.1:47137",
+					"172.21.0.1:47137",
+					"172.22.0.1:47137",
+					"172.23.0.1:47137",
+					"172.24.0.1:47137",
+					"172.25.0.1:47137",
+					"172.26.0.1:47137",
+					"172.27.0.1:47137",
+					"172.28.0.1:47137",
+					"172.29.0.1:47137"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:08:01.471201139Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:52938027520d1caee1ea6694e66c2f3c681afe65efc62a52ed997be3582aec6b",
+			"MachineKey": "mkey:b8f1380a69503462590fd311eaaa66d287e62ea0233f67b33f6c1ebcfb3f7556",
+			"Peers": [{
+				"ID":         810829447912296,
+				"StableID":   "nPauke7EL711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:321691e42cd1f3bd4e4abd0e402ba434afc7f734536d4d632e7bd516bb618760",
+				"DiscoKey":   "discokey:b77974678d83b9f4798f4e442065c9aad6263c82c90c04dbfcc108195ed74e01",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:57123",
+					"10.65.0.27:57123",
+					"172.17.0.1:57123",
+					"172.18.0.1:57123",
+					"172.19.0.1:57123",
+					"172.20.0.1:57123",
+					"172.21.0.1:57123",
+					"172.22.0.1:57123",
+					"172.23.0.1:57123",
+					"172.24.0.1:57123",
+					"172.25.0.1:57123",
+					"172.26.0.1:57123",
+					"172.27.0.1:57123",
+					"172.28.0.1:57123",
+					"172.29.0.1:57123"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:07:54.357169284Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1725894913137605,
+				"StableID":   "n61dRJLfUE11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:538fecf9836662e1580b36d7cbc902a0c4d48cc501cf8778a39dbff84cf3ea60",
+				"DiscoKey":   "discokey:0186b442fd0dea6670f41fb1bacf17cb60c24dfe60305e6e75796c43ff839e4c",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34959",
+					"10.65.0.27:34959",
+					"172.17.0.1:34959",
+					"172.18.0.1:34959",
+					"172.19.0.1:34959",
+					"172.20.0.1:34959",
+					"172.21.0.1:34959",
+					"172.22.0.1:34959",
+					"172.23.0.1:34959",
+					"172.24.0.1:34959",
+					"172.25.0.1:34959",
+					"172.26.0.1:34959",
+					"172.27.0.1:34959",
+					"172.28.0.1:34959",
+					"172.29.0.1:34959"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:07:55.007120011Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4600185073665276,
+				"StableID":   "nbUENZ4Svc11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f3491a77bc70013dff32870742041ae5a0a66cd934158b9ad28a16572435225",
+				"DiscoKey":   "discokey:47cd3f912704ce3ef13cb806b89389b998842a03dd5ab3075a8929ab0c279e3e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41056",
+					"10.65.0.27:41056",
+					"172.17.0.1:41056",
+					"172.18.0.1:41056",
+					"172.19.0.1:41056",
+					"172.20.0.1:41056",
+					"172.21.0.1:41056",
+					"172.22.0.1:41056",
+					"172.23.0.1:41056",
+					"172.24.0.1:41056",
+					"172.25.0.1:41056",
+					"172.26.0.1:41056",
+					"172.27.0.1:41056",
+					"172.28.0.1:41056",
+					"172.29.0.1:41056"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:07:55.553107429Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4017552325304563,
+				"StableID":   "nrxUXeHZNY11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4cbd76d258c25d738ee9008c24cd299884c7cb180bb150d6d631f67f381f825c",
+				"DiscoKey":   "discokey:ebaa732b2df02f9c3f6ece161e1e9be271c44e87aec17530952cb6aba03d3272",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:36217",
+					"10.65.0.27:36217",
+					"172.17.0.1:36217",
+					"172.18.0.1:36217",
+					"172.19.0.1:36217",
+					"172.20.0.1:36217",
+					"172.21.0.1:36217",
+					"172.22.0.1:36217",
+					"172.23.0.1:36217",
+					"172.24.0.1:36217",
+					"172.25.0.1:36217",
+					"172.26.0.1:36217",
+					"172.27.0.1:36217",
+					"172.28.0.1:36217",
+					"172.29.0.1:36217"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:07:56.083035319Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4171462444795908,
+				"StableID":   "ndhBkCFGaZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:da0f229ae7feb8f64120873c854f1be55c864da825fbe88fc35c71b623566509",
+				"DiscoKey":   "discokey:82ed8b559e142264402bbc614511a124c8259c7b0cb1472342a72aa343715c44",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57934",
+					"10.65.0.27:57934",
+					"172.17.0.1:57934",
+					"172.18.0.1:57934",
+					"172.19.0.1:57934",
+					"172.20.0.1:57934",
+					"172.21.0.1:57934",
+					"172.22.0.1:57934",
+					"172.23.0.1:57934",
+					"172.24.0.1:57934",
+					"172.25.0.1:57934",
+					"172.26.0.1:57934",
+					"172.27.0.1:57934",
+					"172.28.0.1:57934",
+					"172.29.0.1:57934"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:07:56.615990966Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2713505144190238,
+				"StableID":   "nqCZdNBxBN11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e08b72c5d7b481b49a88673d6ac014f026f8c1cc9932a760016e9bb6e66f501",
+				"DiscoKey":   "discokey:fbb795f2a36774a19b4f0a99233f6e496967c8e7ce18c5f2781587eebe947650",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46005",
+					"10.65.0.27:46005",
+					"172.17.0.1:46005",
+					"172.18.0.1:46005",
+					"172.19.0.1:46005",
+					"172.20.0.1:46005",
+					"172.21.0.1:46005",
+					"172.22.0.1:46005",
+					"172.23.0.1:46005",
+					"172.24.0.1:46005",
+					"172.25.0.1:46005",
+					"172.26.0.1:46005",
+					"172.27.0.1:46005",
+					"172.28.0.1:46005",
+					"172.29.0.1:46005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:07:57.141625182Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2676933682225812,
+				"StableID":   "nKndmVWPuM11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6e01ff8d037c1131d93d2db63ef1eaa3da47736f72e55695bd64764847ed722c",
+				"DiscoKey":   "discokey:b570dcbfa96cd3b703dee82e88fcd391f0687d8211339a698db8a8f27ca8e361",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:56699",
+					"10.65.0.27:56699",
+					"172.17.0.1:56699",
+					"172.18.0.1:56699",
+					"172.19.0.1:56699",
+					"172.20.0.1:56699",
+					"172.21.0.1:56699",
+					"172.22.0.1:56699",
+					"172.23.0.1:56699",
+					"172.24.0.1:56699",
+					"172.25.0.1:56699",
+					"172.26.0.1:56699",
+					"172.27.0.1:56699",
+					"172.28.0.1:56699",
+					"172.29.0.1:56699"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:07:57.683334156Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         986693426944502,
+				"StableID":   "nBqENGmsh811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc4d51ce1d5ba0e7bbaf68d5816c6d135399dd12be039e0a28dae8fe497ed76e",
+				"DiscoKey":   "discokey:7c87233c5a5c0078c382cdc1bef4bf6016effe96f33365b475a956b3a3986827",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37247",
+					"10.65.0.27:37247",
+					"172.17.0.1:37247",
+					"172.18.0.1:37247",
+					"172.19.0.1:37247",
+					"172.20.0.1:37247",
+					"172.21.0.1:37247",
+					"172.22.0.1:37247",
+					"172.23.0.1:37247",
+					"172.24.0.1:37247",
+					"172.25.0.1:37247",
+					"172.26.0.1:37247",
+					"172.27.0.1:37247",
+					"172.28.0.1:37247",
+					"172.29.0.1:37247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:07:58.230872687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6149241298163959,
+				"StableID":   "n4X1SD912q11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ed63b7a38e24614aade691d4954edb406b49251e795735741752264114702840",
+				"DiscoKey":   "discokey:10ccd0394a433c4c4ef17dadb8dd899fa6877d1a4ae386f88f91642f98780d01",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35018",
+					"10.65.0.27:35018",
+					"172.17.0.1:35018",
+					"172.18.0.1:35018",
+					"172.19.0.1:35018",
+					"172.20.0.1:35018",
+					"172.21.0.1:35018",
+					"172.22.0.1:35018",
+					"172.23.0.1:35018",
+					"172.24.0.1:35018",
+					"172.25.0.1:35018",
+					"172.26.0.1:35018",
+					"172.27.0.1:35018",
+					"172.28.0.1:35018",
+					"172.29.0.1:35018"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:07:58.784586257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3989675051530892,
+				"StableID":   "nfgbJuzv9Y11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b39c7ea43c8057586598323fa68f489b94916f2d26aaf931962aae531406a745",
+				"DiscoKey":   "discokey:8632e2e3bfdc69f8d2ce0c710ed96fef0174fdbb2f4a83ca8774e1b579256966",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:57623",
+					"10.65.0.27:57623",
+					"172.17.0.1:57623",
+					"172.18.0.1:57623",
+					"172.19.0.1:57623",
+					"172.20.0.1:57623",
+					"172.21.0.1:57623",
+					"172.22.0.1:57623",
+					"172.23.0.1:57623",
+					"172.24.0.1:57623",
+					"172.25.0.1:57623",
+					"172.26.0.1:57623",
+					"172.27.0.1:57623",
+					"172.28.0.1:57623",
+					"172.29.0.1:57623"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:07:59.301475404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8823615025271065,
+				"StableID":   "nJ1XjTQEuB21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:744a06afe3ec2c5521131ed873bd98ab67a3d0c786d1f278adb81a6cb8d22152",
+				"DiscoKey":   "discokey:990087c4742a5750dab42d844b71db5b5f56d16090dc07dfd2bbc3a62ae87c07",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53341",
+					"10.65.0.27:53341",
+					"172.17.0.1:53341",
+					"172.18.0.1:53341",
+					"172.19.0.1:53341",
+					"172.20.0.1:53341",
+					"172.21.0.1:53341",
+					"172.22.0.1:53341",
+					"172.23.0.1:53341",
+					"172.24.0.1:53341",
+					"172.25.0.1:53341",
+					"172.26.0.1:53341",
+					"172.27.0.1:53341",
+					"172.28.0.1:53341",
+					"172.29.0.1:53341"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:07:59.83234113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2187320932896342,
+				"StableID":   "n9AGiHDe5J11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4125d29e37ee1197491ce85c2dbcee163a20ad4a6c7a08d4705295fac900406d",
+				"DiscoKey":   "discokey:5236a7194253215205d4412c0985e6ca8f2708526442b1e375de8cb41dc6314e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44947",
+					"10.65.0.27:44947",
+					"172.17.0.1:44947",
+					"172.18.0.1:44947",
+					"172.19.0.1:44947",
+					"172.20.0.1:44947",
+					"172.21.0.1:44947",
+					"172.22.0.1:44947",
+					"172.23.0.1:44947",
+					"172.24.0.1:44947",
+					"172.25.0.1:44947",
+					"172.26.0.1:44947",
+					"172.27.0.1:44947",
+					"172.28.0.1:44947",
+					"172.29.0.1:44947"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:08:00.396166034Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5537895569371808,
+				"StableID":   "nPxJqJ88Fk11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e51f3252f555b15147a7d6d0383e8b3db97fc57e870978d374dca2a877c55159",
+				"KeyExpiry":  "2026-11-09T09:08:00Z",
+				"DiscoKey":   "discokey:3f3456c5f41939bdc0ee88c60293e0a8b747faa72d6667f5ed1d83ecb52e5c5f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49972",
+					"10.65.0.27:49972",
+					"172.17.0.1:49972",
+					"172.18.0.1:49972",
+					"172.19.0.1:49972",
+					"172.20.0.1:49972",
+					"172.21.0.1:49972",
+					"172.22.0.1:49972",
+					"172.23.0.1:49972",
+					"172.24.0.1:49972",
+					"172.25.0.1:49972",
+					"172.26.0.1:49972",
+					"172.27.0.1:49972",
+					"172.28.0.1:49972",
+					"172.29.0.1:49972"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:08:00.932988028Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5802522798683467,
+				"StableID":   "nJ61vCSyJn11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e29baa62cb83de9502d1ac6f5ef90f568782e60f5d9c41fa697805534bd4f460",
+				"KeyExpiry":  "2026-11-09T09:08:02Z",
+				"DiscoKey":   "discokey:1e87464d36e201f1781cf0652e09c26cb9699e2eaa7434b13ab462b9ac447e58",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57459",
+					"10.65.0.27:57459",
+					"172.17.0.1:57459",
+					"172.18.0.1:57459",
+					"172.19.0.1:57459",
+					"172.20.0.1:57459",
+					"172.21.0.1:57459",
+					"172.22.0.1:57459",
+					"172.23.0.1:57459",
+					"172.24.0.1:57459",
+					"172.25.0.1:57459",
+					"172.26.0.1:57459",
+					"172.27.0.1:57459",
+					"172.28.0.1:57459",
+					"172.29.0.1:57459"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:08:02.018946565Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3989675051530892,
+				"StableID":   "nfgbJuzv9Y11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       3989675051530892,
+				"Key":        "nodekey:b39c7ea43c8057586598323fa68f489b94916f2d26aaf931962aae531406a745",
+				"DiscoKey":   "discokey:8632e2e3bfdc69f8d2ce0c710ed96fef0174fdbb2f4a83ca8774e1b579256966",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:57623",
+					"10.65.0.27:57623",
+					"172.17.0.1:57623",
+					"172.18.0.1:57623",
+					"172.19.0.1:57623",
+					"172.20.0.1:57623",
+					"172.21.0.1:57623",
+					"172.22.0.1:57623",
+					"172.23.0.1:57623",
+					"172.24.0.1:57623",
+					"172.25.0.1:57623",
+					"172.26.0.1:57623",
+					"172.27.0.1:57623",
+					"172.28.0.1:57623",
+					"172.29.0.1:57623"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:07:59.301475404Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b39c7ea43c8057586598323fa68f489b94916f2d26aaf931962aae531406a745",
+			"MachineKey": "mkey:de2bd5a0a426f3784fe3eb1efe043e1fece395d92cbc73a2d6536f29b0556404",
+			"Peers": [{
+				"ID":         810829447912296,
+				"StableID":   "nPauke7EL711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:321691e42cd1f3bd4e4abd0e402ba434afc7f734536d4d632e7bd516bb618760",
+				"DiscoKey":   "discokey:b77974678d83b9f4798f4e442065c9aad6263c82c90c04dbfcc108195ed74e01",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:57123",
+					"10.65.0.27:57123",
+					"172.17.0.1:57123",
+					"172.18.0.1:57123",
+					"172.19.0.1:57123",
+					"172.20.0.1:57123",
+					"172.21.0.1:57123",
+					"172.22.0.1:57123",
+					"172.23.0.1:57123",
+					"172.24.0.1:57123",
+					"172.25.0.1:57123",
+					"172.26.0.1:57123",
+					"172.27.0.1:57123",
+					"172.28.0.1:57123",
+					"172.29.0.1:57123"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:07:54.357169284Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1725894913137605,
+				"StableID":   "n61dRJLfUE11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:538fecf9836662e1580b36d7cbc902a0c4d48cc501cf8778a39dbff84cf3ea60",
+				"DiscoKey":   "discokey:0186b442fd0dea6670f41fb1bacf17cb60c24dfe60305e6e75796c43ff839e4c",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34959",
+					"10.65.0.27:34959",
+					"172.17.0.1:34959",
+					"172.18.0.1:34959",
+					"172.19.0.1:34959",
+					"172.20.0.1:34959",
+					"172.21.0.1:34959",
+					"172.22.0.1:34959",
+					"172.23.0.1:34959",
+					"172.24.0.1:34959",
+					"172.25.0.1:34959",
+					"172.26.0.1:34959",
+					"172.27.0.1:34959",
+					"172.28.0.1:34959",
+					"172.29.0.1:34959"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:07:55.007120011Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4600185073665276,
+				"StableID":   "nbUENZ4Svc11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f3491a77bc70013dff32870742041ae5a0a66cd934158b9ad28a16572435225",
+				"DiscoKey":   "discokey:47cd3f912704ce3ef13cb806b89389b998842a03dd5ab3075a8929ab0c279e3e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41056",
+					"10.65.0.27:41056",
+					"172.17.0.1:41056",
+					"172.18.0.1:41056",
+					"172.19.0.1:41056",
+					"172.20.0.1:41056",
+					"172.21.0.1:41056",
+					"172.22.0.1:41056",
+					"172.23.0.1:41056",
+					"172.24.0.1:41056",
+					"172.25.0.1:41056",
+					"172.26.0.1:41056",
+					"172.27.0.1:41056",
+					"172.28.0.1:41056",
+					"172.29.0.1:41056"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:07:55.553107429Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4017552325304563,
+				"StableID":   "nrxUXeHZNY11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4cbd76d258c25d738ee9008c24cd299884c7cb180bb150d6d631f67f381f825c",
+				"DiscoKey":   "discokey:ebaa732b2df02f9c3f6ece161e1e9be271c44e87aec17530952cb6aba03d3272",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:36217",
+					"10.65.0.27:36217",
+					"172.17.0.1:36217",
+					"172.18.0.1:36217",
+					"172.19.0.1:36217",
+					"172.20.0.1:36217",
+					"172.21.0.1:36217",
+					"172.22.0.1:36217",
+					"172.23.0.1:36217",
+					"172.24.0.1:36217",
+					"172.25.0.1:36217",
+					"172.26.0.1:36217",
+					"172.27.0.1:36217",
+					"172.28.0.1:36217",
+					"172.29.0.1:36217"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:07:56.083035319Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4171462444795908,
+				"StableID":   "ndhBkCFGaZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:da0f229ae7feb8f64120873c854f1be55c864da825fbe88fc35c71b623566509",
+				"DiscoKey":   "discokey:82ed8b559e142264402bbc614511a124c8259c7b0cb1472342a72aa343715c44",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57934",
+					"10.65.0.27:57934",
+					"172.17.0.1:57934",
+					"172.18.0.1:57934",
+					"172.19.0.1:57934",
+					"172.20.0.1:57934",
+					"172.21.0.1:57934",
+					"172.22.0.1:57934",
+					"172.23.0.1:57934",
+					"172.24.0.1:57934",
+					"172.25.0.1:57934",
+					"172.26.0.1:57934",
+					"172.27.0.1:57934",
+					"172.28.0.1:57934",
+					"172.29.0.1:57934"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:07:56.615990966Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2713505144190238,
+				"StableID":   "nqCZdNBxBN11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e08b72c5d7b481b49a88673d6ac014f026f8c1cc9932a760016e9bb6e66f501",
+				"DiscoKey":   "discokey:fbb795f2a36774a19b4f0a99233f6e496967c8e7ce18c5f2781587eebe947650",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46005",
+					"10.65.0.27:46005",
+					"172.17.0.1:46005",
+					"172.18.0.1:46005",
+					"172.19.0.1:46005",
+					"172.20.0.1:46005",
+					"172.21.0.1:46005",
+					"172.22.0.1:46005",
+					"172.23.0.1:46005",
+					"172.24.0.1:46005",
+					"172.25.0.1:46005",
+					"172.26.0.1:46005",
+					"172.27.0.1:46005",
+					"172.28.0.1:46005",
+					"172.29.0.1:46005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:07:57.141625182Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2676933682225812,
+				"StableID":   "nKndmVWPuM11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6e01ff8d037c1131d93d2db63ef1eaa3da47736f72e55695bd64764847ed722c",
+				"DiscoKey":   "discokey:b570dcbfa96cd3b703dee82e88fcd391f0687d8211339a698db8a8f27ca8e361",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:56699",
+					"10.65.0.27:56699",
+					"172.17.0.1:56699",
+					"172.18.0.1:56699",
+					"172.19.0.1:56699",
+					"172.20.0.1:56699",
+					"172.21.0.1:56699",
+					"172.22.0.1:56699",
+					"172.23.0.1:56699",
+					"172.24.0.1:56699",
+					"172.25.0.1:56699",
+					"172.26.0.1:56699",
+					"172.27.0.1:56699",
+					"172.28.0.1:56699",
+					"172.29.0.1:56699"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:07:57.683334156Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         986693426944502,
+				"StableID":   "nBqENGmsh811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc4d51ce1d5ba0e7bbaf68d5816c6d135399dd12be039e0a28dae8fe497ed76e",
+				"DiscoKey":   "discokey:7c87233c5a5c0078c382cdc1bef4bf6016effe96f33365b475a956b3a3986827",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37247",
+					"10.65.0.27:37247",
+					"172.17.0.1:37247",
+					"172.18.0.1:37247",
+					"172.19.0.1:37247",
+					"172.20.0.1:37247",
+					"172.21.0.1:37247",
+					"172.22.0.1:37247",
+					"172.23.0.1:37247",
+					"172.24.0.1:37247",
+					"172.25.0.1:37247",
+					"172.26.0.1:37247",
+					"172.27.0.1:37247",
+					"172.28.0.1:37247",
+					"172.29.0.1:37247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:07:58.230872687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6149241298163959,
+				"StableID":   "n4X1SD912q11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ed63b7a38e24614aade691d4954edb406b49251e795735741752264114702840",
+				"DiscoKey":   "discokey:10ccd0394a433c4c4ef17dadb8dd899fa6877d1a4ae386f88f91642f98780d01",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35018",
+					"10.65.0.27:35018",
+					"172.17.0.1:35018",
+					"172.18.0.1:35018",
+					"172.19.0.1:35018",
+					"172.20.0.1:35018",
+					"172.21.0.1:35018",
+					"172.22.0.1:35018",
+					"172.23.0.1:35018",
+					"172.24.0.1:35018",
+					"172.25.0.1:35018",
+					"172.26.0.1:35018",
+					"172.27.0.1:35018",
+					"172.28.0.1:35018",
+					"172.29.0.1:35018"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:07:58.784586257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8823615025271065,
+				"StableID":   "nJ1XjTQEuB21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:744a06afe3ec2c5521131ed873bd98ab67a3d0c786d1f278adb81a6cb8d22152",
+				"DiscoKey":   "discokey:990087c4742a5750dab42d844b71db5b5f56d16090dc07dfd2bbc3a62ae87c07",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53341",
+					"10.65.0.27:53341",
+					"172.17.0.1:53341",
+					"172.18.0.1:53341",
+					"172.19.0.1:53341",
+					"172.20.0.1:53341",
+					"172.21.0.1:53341",
+					"172.22.0.1:53341",
+					"172.23.0.1:53341",
+					"172.24.0.1:53341",
+					"172.25.0.1:53341",
+					"172.26.0.1:53341",
+					"172.27.0.1:53341",
+					"172.28.0.1:53341",
+					"172.29.0.1:53341"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:07:59.83234113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2187320932896342,
+				"StableID":   "n9AGiHDe5J11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4125d29e37ee1197491ce85c2dbcee163a20ad4a6c7a08d4705295fac900406d",
+				"DiscoKey":   "discokey:5236a7194253215205d4412c0985e6ca8f2708526442b1e375de8cb41dc6314e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44947",
+					"10.65.0.27:44947",
+					"172.17.0.1:44947",
+					"172.18.0.1:44947",
+					"172.19.0.1:44947",
+					"172.20.0.1:44947",
+					"172.21.0.1:44947",
+					"172.22.0.1:44947",
+					"172.23.0.1:44947",
+					"172.24.0.1:44947",
+					"172.25.0.1:44947",
+					"172.26.0.1:44947",
+					"172.27.0.1:44947",
+					"172.28.0.1:44947",
+					"172.29.0.1:44947"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:08:00.396166034Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5537895569371808,
+				"StableID":   "nPxJqJ88Fk11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e51f3252f555b15147a7d6d0383e8b3db97fc57e870978d374dca2a877c55159",
+				"KeyExpiry":  "2026-11-09T09:08:00Z",
+				"DiscoKey":   "discokey:3f3456c5f41939bdc0ee88c60293e0a8b747faa72d6667f5ed1d83ecb52e5c5f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49972",
+					"10.65.0.27:49972",
+					"172.17.0.1:49972",
+					"172.18.0.1:49972",
+					"172.19.0.1:49972",
+					"172.20.0.1:49972",
+					"172.21.0.1:49972",
+					"172.22.0.1:49972",
+					"172.23.0.1:49972",
+					"172.24.0.1:49972",
+					"172.25.0.1:49972",
+					"172.26.0.1:49972",
+					"172.27.0.1:49972",
+					"172.28.0.1:49972",
+					"172.29.0.1:49972"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:08:00.932988028Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1177251999062406,
+				"StableID":   "nfX8rzQBCA11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:52938027520d1caee1ea6694e66c2f3c681afe65efc62a52ed997be3582aec6b",
+				"KeyExpiry":  "2026-11-09T09:08:01Z",
+				"DiscoKey":   "discokey:b5587388f3deed91a2d78efdea074cd9da82d67af1822ef60d04f4bc244b5b01",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47137",
+					"10.65.0.27:47137",
+					"172.17.0.1:47137",
+					"172.18.0.1:47137",
+					"172.19.0.1:47137",
+					"172.20.0.1:47137",
+					"172.21.0.1:47137",
+					"172.22.0.1:47137",
+					"172.23.0.1:47137",
+					"172.24.0.1:47137",
+					"172.25.0.1:47137",
+					"172.26.0.1:47137",
+					"172.27.0.1:47137",
+					"172.28.0.1:47137",
+					"172.29.0.1:47137"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:08:01.471201139Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5802522798683467,
+				"StableID":   "nJ61vCSyJn11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e29baa62cb83de9502d1ac6f5ef90f568782e60f5d9c41fa697805534bd4f460",
+				"KeyExpiry":  "2026-11-09T09:08:02Z",
+				"DiscoKey":   "discokey:1e87464d36e201f1781cf0652e09c26cb9699e2eaa7434b13ab462b9ac447e58",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57459",
+					"10.65.0.27:57459",
+					"172.17.0.1:57459",
+					"172.18.0.1:57459",
+					"172.19.0.1:57459",
+					"172.20.0.1:57459",
+					"172.21.0.1:57459",
+					"172.22.0.1:57459",
+					"172.23.0.1:57459",
+					"172.24.0.1:57459",
+					"172.25.0.1:57459",
+					"172.26.0.1:57459",
+					"172.27.0.1:57459",
+					"172.28.0.1:57459",
+					"172.29.0.1:57459"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:08:02.018946565Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "3989675051530892": {
+				"ID":          3989675051530892,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-dst-empty-tag.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-dst-empty-tag.hujson
@@ -1,0 +1,22330 @@
+// ssh-dst-empty-tag
+//
+// ssh dst = tag:unused with no nodes carrying it
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-13T09:08:47Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-dst-empty-tag",
+	"description":    "ssh dst = tag:unused with no nodes carrying it",
+	"category":       "ssh",
+	"captured_at":    "2026-05-13T09:08:47.326992326Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                    \n  \n                                                                     \n                                                                    \n          \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh dst = tag:unused with no nodes carrying it\",\n\t\"id\":          \"ssh-dst-empty-tag\",\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:unused\"],\n\t\t\"src\":    [\"thor@example.org\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"],\n\t\t\"tag:unused\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-edges/ssh-dst-empty-tag.hujson",
+		"full_policy": {"ssh": [{
+			"action": "accept",
+			"dst":    ["tag:unused"],
+			"src":    ["thor@example.org"],
+			"users":  ["root"]
+		}], "tagOwners": {
+			"tag:prod":   ["odin@example.com"],
+			"tag:server": ["odin@example.com"],
+			"tag:unused": ["odin@example.com"]
+		}}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2824186552082163,
+				"StableID":   "nW8qdKb54P11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       2824186552082163,
+				"Key":        "nodekey:b9e12cd5333229d8b262c24e639634f0b2640bb9ebcb6d54e062127e85d9634d",
+				"DiscoKey":   "discokey:a1895321d40bc0abe8bb7c50e2e19e954d6f79c952841cbb2264137c49cb2b43",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58140",
+					"10.65.0.27:58140",
+					"172.17.0.1:58140",
+					"172.18.0.1:58140",
+					"172.19.0.1:58140",
+					"172.20.0.1:58140",
+					"172.21.0.1:58140",
+					"172.22.0.1:58140",
+					"172.23.0.1:58140",
+					"172.24.0.1:58140",
+					"172.25.0.1:58140",
+					"172.26.0.1:58140",
+					"172.27.0.1:58140",
+					"172.28.0.1:58140",
+					"172.29.0.1:58140"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:08:55.803917237Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b9e12cd5333229d8b262c24e639634f0b2640bb9ebcb6d54e062127e85d9634d",
+			"MachineKey": "mkey:f92aa8f30c37ebf0ddb84a0d8d95f4fbad2f4c2c79b54fa8aa7e834f6aeea12f",
+			"Peers": [{
+				"ID":         7910850219715433,
+				"StableID":   "nWbyU1dqm421CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c38849001c818ec01ab3884fb726ba759429abde871ec71f9c654e8c633db73d",
+				"DiscoKey":   "discokey:a5158e8c031a96f17be128393a921f0a94a461d3c25b27caba71a07e90f19e69",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43331",
+					"10.65.0.27:43331",
+					"172.17.0.1:43331",
+					"172.18.0.1:43331",
+					"172.19.0.1:43331",
+					"172.20.0.1:43331",
+					"172.21.0.1:43331",
+					"172.22.0.1:43331",
+					"172.23.0.1:43331",
+					"172.24.0.1:43331",
+					"172.25.0.1:43331",
+					"172.26.0.1:43331",
+					"172.27.0.1:43331",
+					"172.28.0.1:43331",
+					"172.29.0.1:43331"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:08:49.936876938Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6381211525566936,
+				"StableID":   "nj4m5Ac4qr11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba4bdeff5d35313d26131bd1e00e38d94105f2d2d204c657562260231fb91a18",
+				"DiscoKey":   "discokey:097063db9440512c70541de1a731980d4a34eddf48d97052d1e4866e9da65e09",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35952",
+					"10.65.0.27:35952",
+					"172.17.0.1:35952",
+					"172.18.0.1:35952",
+					"172.19.0.1:35952",
+					"172.20.0.1:35952",
+					"172.21.0.1:35952",
+					"172.22.0.1:35952",
+					"172.23.0.1:35952",
+					"172.24.0.1:35952",
+					"172.25.0.1:35952",
+					"172.26.0.1:35952",
+					"172.27.0.1:35952",
+					"172.28.0.1:35952",
+					"172.29.0.1:35952"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:08:50.43056034Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2437573544205684,
+				"StableID":   "noNL2avy2L11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7efd3b993cc568ba4d4e463aacc88c9e6e28595db86cc4bf968a22dbbce6154e",
+				"DiscoKey":   "discokey:93db8a82e3d64a77ff9d4aab6f194d68ed2bab893ef5b1c6a21f8776d75c120d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45990",
+					"10.65.0.27:45990",
+					"172.17.0.1:45990",
+					"172.18.0.1:45990",
+					"172.19.0.1:45990",
+					"172.20.0.1:45990",
+					"172.21.0.1:45990",
+					"172.22.0.1:45990",
+					"172.23.0.1:45990",
+					"172.24.0.1:45990",
+					"172.25.0.1:45990",
+					"172.26.0.1:45990",
+					"172.27.0.1:45990",
+					"172.28.0.1:45990",
+					"172.29.0.1:45990"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:08:50.973567256Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8072414054839639,
+				"StableID":   "nxXtLUd13621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1ce09e5497139ac52ccdbf6e6723e8ca61d7b0e939373c42f62d6669e865264",
+				"DiscoKey":   "discokey:f41dbf4aa82c85a3b684cc1562b75ee3d288cc3eab6e43beff65f5f5a203dd0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42593",
+					"10.65.0.27:42593",
+					"172.17.0.1:42593",
+					"172.18.0.1:42593",
+					"172.19.0.1:42593",
+					"172.20.0.1:42593",
+					"172.21.0.1:42593",
+					"172.22.0.1:42593",
+					"172.23.0.1:42593",
+					"172.24.0.1:42593",
+					"172.25.0.1:42593",
+					"172.26.0.1:42593",
+					"172.27.0.1:42593",
+					"172.28.0.1:42593",
+					"172.29.0.1:42593"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:08:51.519750495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         750134782054043,
+				"StableID":   "ncKWyamjr611CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0517119cfb430214a3965af8697e4b215e9ef9e6f7dc6af68e1629b66577ea75",
+				"DiscoKey":   "discokey:0d49066dd6ef215e5e40af4964900c9a38ddd2c0710f29ac0bbed0e637f0ec6b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:45651",
+					"10.65.0.27:45651",
+					"172.17.0.1:45651",
+					"172.18.0.1:45651",
+					"172.19.0.1:45651",
+					"172.20.0.1:45651",
+					"172.21.0.1:45651",
+					"172.22.0.1:45651",
+					"172.23.0.1:45651",
+					"172.24.0.1:45651",
+					"172.25.0.1:45651",
+					"172.26.0.1:45651",
+					"172.27.0.1:45651",
+					"172.28.0.1:45651",
+					"172.29.0.1:45651"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:08:52.067522041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         839150932034137,
+				"StableID":   "nxJwKB54Z711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0e0c28e146dd6e11cee7bd6ae352fc6307083541e4e9611baef9c388dcadb7c",
+				"DiscoKey":   "discokey:e44999b5edd3b672174f0f3ee207300641467bf3ee743dda8a6ec03ca3858d1d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44968",
+					"10.65.0.27:44968",
+					"172.17.0.1:44968",
+					"172.18.0.1:44968",
+					"172.19.0.1:44968",
+					"172.20.0.1:44968",
+					"172.21.0.1:44968",
+					"172.22.0.1:44968",
+					"172.23.0.1:44968",
+					"172.24.0.1:44968",
+					"172.25.0.1:44968",
+					"172.26.0.1:44968",
+					"172.27.0.1:44968",
+					"172.28.0.1:44968",
+					"172.29.0.1:44968"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:08:52.600909082Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8089791358291457,
+				"StableID":   "nibJ9s6tA621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3ab64f2d66959455a4bf55624555c1036e729bda4884e7c64c19b872017a0b24",
+				"DiscoKey":   "discokey:bf66d9922616d7f9186f43f321ae120c1fc3d92b0fd37194569b7e6c45917e60",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54929",
+					"10.65.0.27:54929",
+					"172.17.0.1:54929",
+					"172.18.0.1:54929",
+					"172.19.0.1:54929",
+					"172.20.0.1:54929",
+					"172.21.0.1:54929",
+					"172.22.0.1:54929",
+					"172.23.0.1:54929",
+					"172.24.0.1:54929",
+					"172.25.0.1:54929",
+					"172.26.0.1:54929",
+					"172.27.0.1:54929",
+					"172.28.0.1:54929",
+					"172.29.0.1:54929"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:08:53.136655738Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         264256607456368,
+				"StableID":   "n9qoVEag4311CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:914f7a4931682ca03a8382046587ee81000da788897acd3ea18f66907c5f022a",
+				"DiscoKey":   "discokey:04db6794db62b30f749673d0d53252ba1d0b344ff5e369904458aaf9542aa31e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33265",
+					"10.65.0.27:33265",
+					"172.17.0.1:33265",
+					"172.18.0.1:33265",
+					"172.19.0.1:33265",
+					"172.20.0.1:33265",
+					"172.21.0.1:33265",
+					"172.22.0.1:33265",
+					"172.23.0.1:33265",
+					"172.24.0.1:33265",
+					"172.25.0.1:33265",
+					"172.26.0.1:33265",
+					"172.27.0.1:33265",
+					"172.28.0.1:33265",
+					"172.29.0.1:33265"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:08:53.6659712Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7663614990686871,
+				"StableID":   "n6SoutAsq221CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:79e977f28aea31c07b128d887f62f17eb0706d96543f604a6bde62c977e8c93a",
+				"DiscoKey":   "discokey:56194a27fd68adb5985c6835a386f1899944932d8d3fe35d12ab95c687a4c31f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41401",
+					"10.65.0.27:41401",
+					"172.17.0.1:41401",
+					"172.18.0.1:41401",
+					"172.19.0.1:41401",
+					"172.20.0.1:41401",
+					"172.21.0.1:41401",
+					"172.22.0.1:41401",
+					"172.23.0.1:41401",
+					"172.24.0.1:41401",
+					"172.25.0.1:41401",
+					"172.26.0.1:41401",
+					"172.27.0.1:41401",
+					"172.28.0.1:41401",
+					"172.29.0.1:41401"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:08:54.190741062Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8861425300128914,
+				"StableID":   "ns3LFkcMCC21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4784b0e067b3c60e861aee9ab444086a3954473b09053363423a268f5982f533",
+				"DiscoKey":   "discokey:6b4ac603e565c79b1316fba83cad99d59fc6422523132d03b7ec18e4b16e8a1c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:32783",
+					"10.65.0.27:32783",
+					"172.17.0.1:32783",
+					"172.18.0.1:32783",
+					"172.19.0.1:32783",
+					"172.20.0.1:32783",
+					"172.21.0.1:32783",
+					"172.22.0.1:32783",
+					"172.23.0.1:32783",
+					"172.24.0.1:32783",
+					"172.25.0.1:32783",
+					"172.26.0.1:32783",
+					"172.27.0.1:32783",
+					"172.28.0.1:32783",
+					"172.29.0.1:32783"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:08:54.736224441Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2121942722652951,
+				"StableID":   "nNSf9Zq2aH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f36c3c3970962dfcc36ce6a541d4509d463971ab28c4109976925baa7c2b490f",
+				"DiscoKey":   "discokey:f99def593fda9b3d6cb7cb19f67e18c3d8a2c90eeb4dfd052708bfe4b0525f52",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:47554",
+					"10.65.0.27:47554",
+					"172.17.0.1:47554",
+					"172.18.0.1:47554",
+					"172.19.0.1:47554",
+					"172.20.0.1:47554",
+					"172.21.0.1:47554",
+					"172.22.0.1:47554",
+					"172.23.0.1:47554",
+					"172.24.0.1:47554",
+					"172.25.0.1:47554",
+					"172.26.0.1:47554",
+					"172.27.0.1:47554",
+					"172.28.0.1:47554",
+					"172.29.0.1:47554"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:08:55.262055371Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4537882512937851,
+				"StableID":   "nGqLRmUDSc11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f077b56a647585f47d513ae290d2e5a2fb6eda9528d80805eacb32597d18d119",
+				"KeyExpiry":  "2026-11-09T09:08:56Z",
+				"DiscoKey":   "discokey:ab946cb435f8bc1678f756256fd0cbd141b60ae9d95a1f8ebea2d9bafe5a7237",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:42345",
+					"10.65.0.27:42345",
+					"172.17.0.1:42345",
+					"172.18.0.1:42345",
+					"172.19.0.1:42345",
+					"172.20.0.1:42345",
+					"172.21.0.1:42345",
+					"172.22.0.1:42345",
+					"172.23.0.1:42345",
+					"172.24.0.1:42345",
+					"172.25.0.1:42345",
+					"172.26.0.1:42345",
+					"172.27.0.1:42345",
+					"172.28.0.1:42345",
+					"172.29.0.1:42345"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:08:56.351352972Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1999870809800905,
+				"StableID":   "nt68EUDkcG11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6cdda19e804be5e2cd8f526ebed38e87594983f6271578fd06b30dc824beae1c",
+				"KeyExpiry":  "2026-11-09T09:08:56Z",
+				"DiscoKey":   "discokey:600398c30ac3534d44775a86afb7555cdeb2cf8caa8250cd98a7fe05aa0a5a54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38381",
+					"10.65.0.27:38381",
+					"172.17.0.1:38381",
+					"172.18.0.1:38381",
+					"172.19.0.1:38381",
+					"172.20.0.1:38381",
+					"172.21.0.1:38381",
+					"172.22.0.1:38381",
+					"172.23.0.1:38381",
+					"172.24.0.1:38381",
+					"172.25.0.1:38381",
+					"172.26.0.1:38381",
+					"172.27.0.1:38381",
+					"172.28.0.1:38381",
+					"172.29.0.1:38381"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:08:56.900863642Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6973026628775446,
+				"StableID":   "nXPGBxa6Tw11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d5d8fefebcb8420b272565ade83a1d37b7c82ea35b29f4448a561e3610ca3b60",
+				"KeyExpiry":  "2026-11-09T09:08:57Z",
+				"DiscoKey":   "discokey:a2aaaf10268009cf085a278300b0b82060d85f62dcc68d3d35683f1284e1bb2b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33165",
+					"10.65.0.27:33165",
+					"172.17.0.1:33165",
+					"172.18.0.1:33165",
+					"172.19.0.1:33165",
+					"172.20.0.1:33165",
+					"172.21.0.1:33165",
+					"172.22.0.1:33165",
+					"172.23.0.1:33165",
+					"172.24.0.1:33165",
+					"172.25.0.1:33165",
+					"172.26.0.1:33165",
+					"172.27.0.1:33165",
+					"172.28.0.1:33165",
+					"172.29.0.1:33165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:08:57.437877673Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2824186552082163": {
+				"ID":          2824186552082163,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         839150932034137,
+				"StableID":   "nxJwKB54Z711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       839150932034137,
+				"Key":        "nodekey:e0e0c28e146dd6e11cee7bd6ae352fc6307083541e4e9611baef9c388dcadb7c",
+				"DiscoKey":   "discokey:e44999b5edd3b672174f0f3ee207300641467bf3ee743dda8a6ec03ca3858d1d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44968",
+					"10.65.0.27:44968",
+					"172.17.0.1:44968",
+					"172.18.0.1:44968",
+					"172.19.0.1:44968",
+					"172.20.0.1:44968",
+					"172.21.0.1:44968",
+					"172.22.0.1:44968",
+					"172.23.0.1:44968",
+					"172.24.0.1:44968",
+					"172.25.0.1:44968",
+					"172.26.0.1:44968",
+					"172.27.0.1:44968",
+					"172.28.0.1:44968",
+					"172.29.0.1:44968"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:08:52.600909082Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e0e0c28e146dd6e11cee7bd6ae352fc6307083541e4e9611baef9c388dcadb7c",
+			"MachineKey": "mkey:131ac432b587663a181facb77f7e87e756f6011087f1820aac2a7418fd33e313",
+			"Peers": [{
+				"ID":         7910850219715433,
+				"StableID":   "nWbyU1dqm421CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c38849001c818ec01ab3884fb726ba759429abde871ec71f9c654e8c633db73d",
+				"DiscoKey":   "discokey:a5158e8c031a96f17be128393a921f0a94a461d3c25b27caba71a07e90f19e69",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43331",
+					"10.65.0.27:43331",
+					"172.17.0.1:43331",
+					"172.18.0.1:43331",
+					"172.19.0.1:43331",
+					"172.20.0.1:43331",
+					"172.21.0.1:43331",
+					"172.22.0.1:43331",
+					"172.23.0.1:43331",
+					"172.24.0.1:43331",
+					"172.25.0.1:43331",
+					"172.26.0.1:43331",
+					"172.27.0.1:43331",
+					"172.28.0.1:43331",
+					"172.29.0.1:43331"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:08:49.936876938Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6381211525566936,
+				"StableID":   "nj4m5Ac4qr11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba4bdeff5d35313d26131bd1e00e38d94105f2d2d204c657562260231fb91a18",
+				"DiscoKey":   "discokey:097063db9440512c70541de1a731980d4a34eddf48d97052d1e4866e9da65e09",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35952",
+					"10.65.0.27:35952",
+					"172.17.0.1:35952",
+					"172.18.0.1:35952",
+					"172.19.0.1:35952",
+					"172.20.0.1:35952",
+					"172.21.0.1:35952",
+					"172.22.0.1:35952",
+					"172.23.0.1:35952",
+					"172.24.0.1:35952",
+					"172.25.0.1:35952",
+					"172.26.0.1:35952",
+					"172.27.0.1:35952",
+					"172.28.0.1:35952",
+					"172.29.0.1:35952"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:08:50.43056034Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2437573544205684,
+				"StableID":   "noNL2avy2L11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7efd3b993cc568ba4d4e463aacc88c9e6e28595db86cc4bf968a22dbbce6154e",
+				"DiscoKey":   "discokey:93db8a82e3d64a77ff9d4aab6f194d68ed2bab893ef5b1c6a21f8776d75c120d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45990",
+					"10.65.0.27:45990",
+					"172.17.0.1:45990",
+					"172.18.0.1:45990",
+					"172.19.0.1:45990",
+					"172.20.0.1:45990",
+					"172.21.0.1:45990",
+					"172.22.0.1:45990",
+					"172.23.0.1:45990",
+					"172.24.0.1:45990",
+					"172.25.0.1:45990",
+					"172.26.0.1:45990",
+					"172.27.0.1:45990",
+					"172.28.0.1:45990",
+					"172.29.0.1:45990"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:08:50.973567256Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8072414054839639,
+				"StableID":   "nxXtLUd13621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1ce09e5497139ac52ccdbf6e6723e8ca61d7b0e939373c42f62d6669e865264",
+				"DiscoKey":   "discokey:f41dbf4aa82c85a3b684cc1562b75ee3d288cc3eab6e43beff65f5f5a203dd0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42593",
+					"10.65.0.27:42593",
+					"172.17.0.1:42593",
+					"172.18.0.1:42593",
+					"172.19.0.1:42593",
+					"172.20.0.1:42593",
+					"172.21.0.1:42593",
+					"172.22.0.1:42593",
+					"172.23.0.1:42593",
+					"172.24.0.1:42593",
+					"172.25.0.1:42593",
+					"172.26.0.1:42593",
+					"172.27.0.1:42593",
+					"172.28.0.1:42593",
+					"172.29.0.1:42593"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:08:51.519750495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         750134782054043,
+				"StableID":   "ncKWyamjr611CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0517119cfb430214a3965af8697e4b215e9ef9e6f7dc6af68e1629b66577ea75",
+				"DiscoKey":   "discokey:0d49066dd6ef215e5e40af4964900c9a38ddd2c0710f29ac0bbed0e637f0ec6b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:45651",
+					"10.65.0.27:45651",
+					"172.17.0.1:45651",
+					"172.18.0.1:45651",
+					"172.19.0.1:45651",
+					"172.20.0.1:45651",
+					"172.21.0.1:45651",
+					"172.22.0.1:45651",
+					"172.23.0.1:45651",
+					"172.24.0.1:45651",
+					"172.25.0.1:45651",
+					"172.26.0.1:45651",
+					"172.27.0.1:45651",
+					"172.28.0.1:45651",
+					"172.29.0.1:45651"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:08:52.067522041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8089791358291457,
+				"StableID":   "nibJ9s6tA621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3ab64f2d66959455a4bf55624555c1036e729bda4884e7c64c19b872017a0b24",
+				"DiscoKey":   "discokey:bf66d9922616d7f9186f43f321ae120c1fc3d92b0fd37194569b7e6c45917e60",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54929",
+					"10.65.0.27:54929",
+					"172.17.0.1:54929",
+					"172.18.0.1:54929",
+					"172.19.0.1:54929",
+					"172.20.0.1:54929",
+					"172.21.0.1:54929",
+					"172.22.0.1:54929",
+					"172.23.0.1:54929",
+					"172.24.0.1:54929",
+					"172.25.0.1:54929",
+					"172.26.0.1:54929",
+					"172.27.0.1:54929",
+					"172.28.0.1:54929",
+					"172.29.0.1:54929"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:08:53.136655738Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         264256607456368,
+				"StableID":   "n9qoVEag4311CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:914f7a4931682ca03a8382046587ee81000da788897acd3ea18f66907c5f022a",
+				"DiscoKey":   "discokey:04db6794db62b30f749673d0d53252ba1d0b344ff5e369904458aaf9542aa31e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33265",
+					"10.65.0.27:33265",
+					"172.17.0.1:33265",
+					"172.18.0.1:33265",
+					"172.19.0.1:33265",
+					"172.20.0.1:33265",
+					"172.21.0.1:33265",
+					"172.22.0.1:33265",
+					"172.23.0.1:33265",
+					"172.24.0.1:33265",
+					"172.25.0.1:33265",
+					"172.26.0.1:33265",
+					"172.27.0.1:33265",
+					"172.28.0.1:33265",
+					"172.29.0.1:33265"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:08:53.6659712Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7663614990686871,
+				"StableID":   "n6SoutAsq221CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:79e977f28aea31c07b128d887f62f17eb0706d96543f604a6bde62c977e8c93a",
+				"DiscoKey":   "discokey:56194a27fd68adb5985c6835a386f1899944932d8d3fe35d12ab95c687a4c31f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41401",
+					"10.65.0.27:41401",
+					"172.17.0.1:41401",
+					"172.18.0.1:41401",
+					"172.19.0.1:41401",
+					"172.20.0.1:41401",
+					"172.21.0.1:41401",
+					"172.22.0.1:41401",
+					"172.23.0.1:41401",
+					"172.24.0.1:41401",
+					"172.25.0.1:41401",
+					"172.26.0.1:41401",
+					"172.27.0.1:41401",
+					"172.28.0.1:41401",
+					"172.29.0.1:41401"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:08:54.190741062Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8861425300128914,
+				"StableID":   "ns3LFkcMCC21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4784b0e067b3c60e861aee9ab444086a3954473b09053363423a268f5982f533",
+				"DiscoKey":   "discokey:6b4ac603e565c79b1316fba83cad99d59fc6422523132d03b7ec18e4b16e8a1c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:32783",
+					"10.65.0.27:32783",
+					"172.17.0.1:32783",
+					"172.18.0.1:32783",
+					"172.19.0.1:32783",
+					"172.20.0.1:32783",
+					"172.21.0.1:32783",
+					"172.22.0.1:32783",
+					"172.23.0.1:32783",
+					"172.24.0.1:32783",
+					"172.25.0.1:32783",
+					"172.26.0.1:32783",
+					"172.27.0.1:32783",
+					"172.28.0.1:32783",
+					"172.29.0.1:32783"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:08:54.736224441Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2121942722652951,
+				"StableID":   "nNSf9Zq2aH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f36c3c3970962dfcc36ce6a541d4509d463971ab28c4109976925baa7c2b490f",
+				"DiscoKey":   "discokey:f99def593fda9b3d6cb7cb19f67e18c3d8a2c90eeb4dfd052708bfe4b0525f52",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:47554",
+					"10.65.0.27:47554",
+					"172.17.0.1:47554",
+					"172.18.0.1:47554",
+					"172.19.0.1:47554",
+					"172.20.0.1:47554",
+					"172.21.0.1:47554",
+					"172.22.0.1:47554",
+					"172.23.0.1:47554",
+					"172.24.0.1:47554",
+					"172.25.0.1:47554",
+					"172.26.0.1:47554",
+					"172.27.0.1:47554",
+					"172.28.0.1:47554",
+					"172.29.0.1:47554"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:08:55.262055371Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2824186552082163,
+				"StableID":   "nW8qdKb54P11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9e12cd5333229d8b262c24e639634f0b2640bb9ebcb6d54e062127e85d9634d",
+				"DiscoKey":   "discokey:a1895321d40bc0abe8bb7c50e2e19e954d6f79c952841cbb2264137c49cb2b43",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58140",
+					"10.65.0.27:58140",
+					"172.17.0.1:58140",
+					"172.18.0.1:58140",
+					"172.19.0.1:58140",
+					"172.20.0.1:58140",
+					"172.21.0.1:58140",
+					"172.22.0.1:58140",
+					"172.23.0.1:58140",
+					"172.24.0.1:58140",
+					"172.25.0.1:58140",
+					"172.26.0.1:58140",
+					"172.27.0.1:58140",
+					"172.28.0.1:58140",
+					"172.29.0.1:58140"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:08:55.803917237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4537882512937851,
+				"StableID":   "nGqLRmUDSc11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f077b56a647585f47d513ae290d2e5a2fb6eda9528d80805eacb32597d18d119",
+				"KeyExpiry":  "2026-11-09T09:08:56Z",
+				"DiscoKey":   "discokey:ab946cb435f8bc1678f756256fd0cbd141b60ae9d95a1f8ebea2d9bafe5a7237",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:42345",
+					"10.65.0.27:42345",
+					"172.17.0.1:42345",
+					"172.18.0.1:42345",
+					"172.19.0.1:42345",
+					"172.20.0.1:42345",
+					"172.21.0.1:42345",
+					"172.22.0.1:42345",
+					"172.23.0.1:42345",
+					"172.24.0.1:42345",
+					"172.25.0.1:42345",
+					"172.26.0.1:42345",
+					"172.27.0.1:42345",
+					"172.28.0.1:42345",
+					"172.29.0.1:42345"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:08:56.351352972Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1999870809800905,
+				"StableID":   "nt68EUDkcG11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6cdda19e804be5e2cd8f526ebed38e87594983f6271578fd06b30dc824beae1c",
+				"KeyExpiry":  "2026-11-09T09:08:56Z",
+				"DiscoKey":   "discokey:600398c30ac3534d44775a86afb7555cdeb2cf8caa8250cd98a7fe05aa0a5a54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38381",
+					"10.65.0.27:38381",
+					"172.17.0.1:38381",
+					"172.18.0.1:38381",
+					"172.19.0.1:38381",
+					"172.20.0.1:38381",
+					"172.21.0.1:38381",
+					"172.22.0.1:38381",
+					"172.23.0.1:38381",
+					"172.24.0.1:38381",
+					"172.25.0.1:38381",
+					"172.26.0.1:38381",
+					"172.27.0.1:38381",
+					"172.28.0.1:38381",
+					"172.29.0.1:38381"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:08:56.900863642Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6973026628775446,
+				"StableID":   "nXPGBxa6Tw11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d5d8fefebcb8420b272565ade83a1d37b7c82ea35b29f4448a561e3610ca3b60",
+				"KeyExpiry":  "2026-11-09T09:08:57Z",
+				"DiscoKey":   "discokey:a2aaaf10268009cf085a278300b0b82060d85f62dcc68d3d35683f1284e1bb2b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33165",
+					"10.65.0.27:33165",
+					"172.17.0.1:33165",
+					"172.18.0.1:33165",
+					"172.19.0.1:33165",
+					"172.20.0.1:33165",
+					"172.21.0.1:33165",
+					"172.22.0.1:33165",
+					"172.23.0.1:33165",
+					"172.24.0.1:33165",
+					"172.25.0.1:33165",
+					"172.26.0.1:33165",
+					"172.27.0.1:33165",
+					"172.28.0.1:33165",
+					"172.29.0.1:33165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:08:57.437877673Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "839150932034137": {
+				"ID":          839150932034137,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6973026628775446,
+				"StableID":   "nXPGBxa6Tw11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d5d8fefebcb8420b272565ade83a1d37b7c82ea35b29f4448a561e3610ca3b60",
+				"KeyExpiry":  "2026-11-09T09:08:57Z",
+				"DiscoKey":   "discokey:a2aaaf10268009cf085a278300b0b82060d85f62dcc68d3d35683f1284e1bb2b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33165",
+					"10.65.0.27:33165",
+					"172.17.0.1:33165",
+					"172.18.0.1:33165",
+					"172.19.0.1:33165",
+					"172.20.0.1:33165",
+					"172.21.0.1:33165",
+					"172.22.0.1:33165",
+					"172.23.0.1:33165",
+					"172.24.0.1:33165",
+					"172.25.0.1:33165",
+					"172.26.0.1:33165",
+					"172.27.0.1:33165",
+					"172.28.0.1:33165",
+					"172.29.0.1:33165"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:08:57.437877673Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d5d8fefebcb8420b272565ade83a1d37b7c82ea35b29f4448a561e3610ca3b60",
+			"MachineKey": "mkey:a28c112d021a3fdcd1b3a6e62bbac22d19c46716994ec6873b66581561654b28",
+			"Peers": [{
+				"ID":         7910850219715433,
+				"StableID":   "nWbyU1dqm421CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c38849001c818ec01ab3884fb726ba759429abde871ec71f9c654e8c633db73d",
+				"DiscoKey":   "discokey:a5158e8c031a96f17be128393a921f0a94a461d3c25b27caba71a07e90f19e69",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43331",
+					"10.65.0.27:43331",
+					"172.17.0.1:43331",
+					"172.18.0.1:43331",
+					"172.19.0.1:43331",
+					"172.20.0.1:43331",
+					"172.21.0.1:43331",
+					"172.22.0.1:43331",
+					"172.23.0.1:43331",
+					"172.24.0.1:43331",
+					"172.25.0.1:43331",
+					"172.26.0.1:43331",
+					"172.27.0.1:43331",
+					"172.28.0.1:43331",
+					"172.29.0.1:43331"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:08:49.936876938Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6381211525566936,
+				"StableID":   "nj4m5Ac4qr11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba4bdeff5d35313d26131bd1e00e38d94105f2d2d204c657562260231fb91a18",
+				"DiscoKey":   "discokey:097063db9440512c70541de1a731980d4a34eddf48d97052d1e4866e9da65e09",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35952",
+					"10.65.0.27:35952",
+					"172.17.0.1:35952",
+					"172.18.0.1:35952",
+					"172.19.0.1:35952",
+					"172.20.0.1:35952",
+					"172.21.0.1:35952",
+					"172.22.0.1:35952",
+					"172.23.0.1:35952",
+					"172.24.0.1:35952",
+					"172.25.0.1:35952",
+					"172.26.0.1:35952",
+					"172.27.0.1:35952",
+					"172.28.0.1:35952",
+					"172.29.0.1:35952"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:08:50.43056034Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2437573544205684,
+				"StableID":   "noNL2avy2L11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7efd3b993cc568ba4d4e463aacc88c9e6e28595db86cc4bf968a22dbbce6154e",
+				"DiscoKey":   "discokey:93db8a82e3d64a77ff9d4aab6f194d68ed2bab893ef5b1c6a21f8776d75c120d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45990",
+					"10.65.0.27:45990",
+					"172.17.0.1:45990",
+					"172.18.0.1:45990",
+					"172.19.0.1:45990",
+					"172.20.0.1:45990",
+					"172.21.0.1:45990",
+					"172.22.0.1:45990",
+					"172.23.0.1:45990",
+					"172.24.0.1:45990",
+					"172.25.0.1:45990",
+					"172.26.0.1:45990",
+					"172.27.0.1:45990",
+					"172.28.0.1:45990",
+					"172.29.0.1:45990"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:08:50.973567256Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8072414054839639,
+				"StableID":   "nxXtLUd13621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1ce09e5497139ac52ccdbf6e6723e8ca61d7b0e939373c42f62d6669e865264",
+				"DiscoKey":   "discokey:f41dbf4aa82c85a3b684cc1562b75ee3d288cc3eab6e43beff65f5f5a203dd0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42593",
+					"10.65.0.27:42593",
+					"172.17.0.1:42593",
+					"172.18.0.1:42593",
+					"172.19.0.1:42593",
+					"172.20.0.1:42593",
+					"172.21.0.1:42593",
+					"172.22.0.1:42593",
+					"172.23.0.1:42593",
+					"172.24.0.1:42593",
+					"172.25.0.1:42593",
+					"172.26.0.1:42593",
+					"172.27.0.1:42593",
+					"172.28.0.1:42593",
+					"172.29.0.1:42593"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:08:51.519750495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         750134782054043,
+				"StableID":   "ncKWyamjr611CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0517119cfb430214a3965af8697e4b215e9ef9e6f7dc6af68e1629b66577ea75",
+				"DiscoKey":   "discokey:0d49066dd6ef215e5e40af4964900c9a38ddd2c0710f29ac0bbed0e637f0ec6b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:45651",
+					"10.65.0.27:45651",
+					"172.17.0.1:45651",
+					"172.18.0.1:45651",
+					"172.19.0.1:45651",
+					"172.20.0.1:45651",
+					"172.21.0.1:45651",
+					"172.22.0.1:45651",
+					"172.23.0.1:45651",
+					"172.24.0.1:45651",
+					"172.25.0.1:45651",
+					"172.26.0.1:45651",
+					"172.27.0.1:45651",
+					"172.28.0.1:45651",
+					"172.29.0.1:45651"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:08:52.067522041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         839150932034137,
+				"StableID":   "nxJwKB54Z711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0e0c28e146dd6e11cee7bd6ae352fc6307083541e4e9611baef9c388dcadb7c",
+				"DiscoKey":   "discokey:e44999b5edd3b672174f0f3ee207300641467bf3ee743dda8a6ec03ca3858d1d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44968",
+					"10.65.0.27:44968",
+					"172.17.0.1:44968",
+					"172.18.0.1:44968",
+					"172.19.0.1:44968",
+					"172.20.0.1:44968",
+					"172.21.0.1:44968",
+					"172.22.0.1:44968",
+					"172.23.0.1:44968",
+					"172.24.0.1:44968",
+					"172.25.0.1:44968",
+					"172.26.0.1:44968",
+					"172.27.0.1:44968",
+					"172.28.0.1:44968",
+					"172.29.0.1:44968"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:08:52.600909082Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8089791358291457,
+				"StableID":   "nibJ9s6tA621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3ab64f2d66959455a4bf55624555c1036e729bda4884e7c64c19b872017a0b24",
+				"DiscoKey":   "discokey:bf66d9922616d7f9186f43f321ae120c1fc3d92b0fd37194569b7e6c45917e60",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54929",
+					"10.65.0.27:54929",
+					"172.17.0.1:54929",
+					"172.18.0.1:54929",
+					"172.19.0.1:54929",
+					"172.20.0.1:54929",
+					"172.21.0.1:54929",
+					"172.22.0.1:54929",
+					"172.23.0.1:54929",
+					"172.24.0.1:54929",
+					"172.25.0.1:54929",
+					"172.26.0.1:54929",
+					"172.27.0.1:54929",
+					"172.28.0.1:54929",
+					"172.29.0.1:54929"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:08:53.136655738Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         264256607456368,
+				"StableID":   "n9qoVEag4311CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:914f7a4931682ca03a8382046587ee81000da788897acd3ea18f66907c5f022a",
+				"DiscoKey":   "discokey:04db6794db62b30f749673d0d53252ba1d0b344ff5e369904458aaf9542aa31e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33265",
+					"10.65.0.27:33265",
+					"172.17.0.1:33265",
+					"172.18.0.1:33265",
+					"172.19.0.1:33265",
+					"172.20.0.1:33265",
+					"172.21.0.1:33265",
+					"172.22.0.1:33265",
+					"172.23.0.1:33265",
+					"172.24.0.1:33265",
+					"172.25.0.1:33265",
+					"172.26.0.1:33265",
+					"172.27.0.1:33265",
+					"172.28.0.1:33265",
+					"172.29.0.1:33265"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:08:53.6659712Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7663614990686871,
+				"StableID":   "n6SoutAsq221CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:79e977f28aea31c07b128d887f62f17eb0706d96543f604a6bde62c977e8c93a",
+				"DiscoKey":   "discokey:56194a27fd68adb5985c6835a386f1899944932d8d3fe35d12ab95c687a4c31f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41401",
+					"10.65.0.27:41401",
+					"172.17.0.1:41401",
+					"172.18.0.1:41401",
+					"172.19.0.1:41401",
+					"172.20.0.1:41401",
+					"172.21.0.1:41401",
+					"172.22.0.1:41401",
+					"172.23.0.1:41401",
+					"172.24.0.1:41401",
+					"172.25.0.1:41401",
+					"172.26.0.1:41401",
+					"172.27.0.1:41401",
+					"172.28.0.1:41401",
+					"172.29.0.1:41401"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:08:54.190741062Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8861425300128914,
+				"StableID":   "ns3LFkcMCC21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4784b0e067b3c60e861aee9ab444086a3954473b09053363423a268f5982f533",
+				"DiscoKey":   "discokey:6b4ac603e565c79b1316fba83cad99d59fc6422523132d03b7ec18e4b16e8a1c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:32783",
+					"10.65.0.27:32783",
+					"172.17.0.1:32783",
+					"172.18.0.1:32783",
+					"172.19.0.1:32783",
+					"172.20.0.1:32783",
+					"172.21.0.1:32783",
+					"172.22.0.1:32783",
+					"172.23.0.1:32783",
+					"172.24.0.1:32783",
+					"172.25.0.1:32783",
+					"172.26.0.1:32783",
+					"172.27.0.1:32783",
+					"172.28.0.1:32783",
+					"172.29.0.1:32783"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:08:54.736224441Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2121942722652951,
+				"StableID":   "nNSf9Zq2aH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f36c3c3970962dfcc36ce6a541d4509d463971ab28c4109976925baa7c2b490f",
+				"DiscoKey":   "discokey:f99def593fda9b3d6cb7cb19f67e18c3d8a2c90eeb4dfd052708bfe4b0525f52",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:47554",
+					"10.65.0.27:47554",
+					"172.17.0.1:47554",
+					"172.18.0.1:47554",
+					"172.19.0.1:47554",
+					"172.20.0.1:47554",
+					"172.21.0.1:47554",
+					"172.22.0.1:47554",
+					"172.23.0.1:47554",
+					"172.24.0.1:47554",
+					"172.25.0.1:47554",
+					"172.26.0.1:47554",
+					"172.27.0.1:47554",
+					"172.28.0.1:47554",
+					"172.29.0.1:47554"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:08:55.262055371Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2824186552082163,
+				"StableID":   "nW8qdKb54P11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9e12cd5333229d8b262c24e639634f0b2640bb9ebcb6d54e062127e85d9634d",
+				"DiscoKey":   "discokey:a1895321d40bc0abe8bb7c50e2e19e954d6f79c952841cbb2264137c49cb2b43",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58140",
+					"10.65.0.27:58140",
+					"172.17.0.1:58140",
+					"172.18.0.1:58140",
+					"172.19.0.1:58140",
+					"172.20.0.1:58140",
+					"172.21.0.1:58140",
+					"172.22.0.1:58140",
+					"172.23.0.1:58140",
+					"172.24.0.1:58140",
+					"172.25.0.1:58140",
+					"172.26.0.1:58140",
+					"172.27.0.1:58140",
+					"172.28.0.1:58140",
+					"172.29.0.1:58140"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:08:55.803917237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4537882512937851,
+				"StableID":   "nGqLRmUDSc11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f077b56a647585f47d513ae290d2e5a2fb6eda9528d80805eacb32597d18d119",
+				"KeyExpiry":  "2026-11-09T09:08:56Z",
+				"DiscoKey":   "discokey:ab946cb435f8bc1678f756256fd0cbd141b60ae9d95a1f8ebea2d9bafe5a7237",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:42345",
+					"10.65.0.27:42345",
+					"172.17.0.1:42345",
+					"172.18.0.1:42345",
+					"172.19.0.1:42345",
+					"172.20.0.1:42345",
+					"172.21.0.1:42345",
+					"172.22.0.1:42345",
+					"172.23.0.1:42345",
+					"172.24.0.1:42345",
+					"172.25.0.1:42345",
+					"172.26.0.1:42345",
+					"172.27.0.1:42345",
+					"172.28.0.1:42345",
+					"172.29.0.1:42345"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:08:56.351352972Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1999870809800905,
+				"StableID":   "nt68EUDkcG11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6cdda19e804be5e2cd8f526ebed38e87594983f6271578fd06b30dc824beae1c",
+				"KeyExpiry":  "2026-11-09T09:08:56Z",
+				"DiscoKey":   "discokey:600398c30ac3534d44775a86afb7555cdeb2cf8caa8250cd98a7fe05aa0a5a54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38381",
+					"10.65.0.27:38381",
+					"172.17.0.1:38381",
+					"172.18.0.1:38381",
+					"172.19.0.1:38381",
+					"172.20.0.1:38381",
+					"172.21.0.1:38381",
+					"172.22.0.1:38381",
+					"172.23.0.1:38381",
+					"172.24.0.1:38381",
+					"172.25.0.1:38381",
+					"172.26.0.1:38381",
+					"172.27.0.1:38381",
+					"172.28.0.1:38381",
+					"172.29.0.1:38381"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:08:56.900863642Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2437573544205684,
+				"StableID":   "noNL2avy2L11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       2437573544205684,
+				"Key":        "nodekey:7efd3b993cc568ba4d4e463aacc88c9e6e28595db86cc4bf968a22dbbce6154e",
+				"DiscoKey":   "discokey:93db8a82e3d64a77ff9d4aab6f194d68ed2bab893ef5b1c6a21f8776d75c120d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45990",
+					"10.65.0.27:45990",
+					"172.17.0.1:45990",
+					"172.18.0.1:45990",
+					"172.19.0.1:45990",
+					"172.20.0.1:45990",
+					"172.21.0.1:45990",
+					"172.22.0.1:45990",
+					"172.23.0.1:45990",
+					"172.24.0.1:45990",
+					"172.25.0.1:45990",
+					"172.26.0.1:45990",
+					"172.27.0.1:45990",
+					"172.28.0.1:45990",
+					"172.29.0.1:45990"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:08:50.973567256Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7efd3b993cc568ba4d4e463aacc88c9e6e28595db86cc4bf968a22dbbce6154e",
+			"MachineKey": "mkey:bed41aee609d6a4f7216e3ea8e66ded91174b5a08c399b2d84650af7103d4943",
+			"Peers": [{
+				"ID":         7910850219715433,
+				"StableID":   "nWbyU1dqm421CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c38849001c818ec01ab3884fb726ba759429abde871ec71f9c654e8c633db73d",
+				"DiscoKey":   "discokey:a5158e8c031a96f17be128393a921f0a94a461d3c25b27caba71a07e90f19e69",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43331",
+					"10.65.0.27:43331",
+					"172.17.0.1:43331",
+					"172.18.0.1:43331",
+					"172.19.0.1:43331",
+					"172.20.0.1:43331",
+					"172.21.0.1:43331",
+					"172.22.0.1:43331",
+					"172.23.0.1:43331",
+					"172.24.0.1:43331",
+					"172.25.0.1:43331",
+					"172.26.0.1:43331",
+					"172.27.0.1:43331",
+					"172.28.0.1:43331",
+					"172.29.0.1:43331"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:08:49.936876938Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6381211525566936,
+				"StableID":   "nj4m5Ac4qr11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba4bdeff5d35313d26131bd1e00e38d94105f2d2d204c657562260231fb91a18",
+				"DiscoKey":   "discokey:097063db9440512c70541de1a731980d4a34eddf48d97052d1e4866e9da65e09",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35952",
+					"10.65.0.27:35952",
+					"172.17.0.1:35952",
+					"172.18.0.1:35952",
+					"172.19.0.1:35952",
+					"172.20.0.1:35952",
+					"172.21.0.1:35952",
+					"172.22.0.1:35952",
+					"172.23.0.1:35952",
+					"172.24.0.1:35952",
+					"172.25.0.1:35952",
+					"172.26.0.1:35952",
+					"172.27.0.1:35952",
+					"172.28.0.1:35952",
+					"172.29.0.1:35952"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:08:50.43056034Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8072414054839639,
+				"StableID":   "nxXtLUd13621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1ce09e5497139ac52ccdbf6e6723e8ca61d7b0e939373c42f62d6669e865264",
+				"DiscoKey":   "discokey:f41dbf4aa82c85a3b684cc1562b75ee3d288cc3eab6e43beff65f5f5a203dd0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42593",
+					"10.65.0.27:42593",
+					"172.17.0.1:42593",
+					"172.18.0.1:42593",
+					"172.19.0.1:42593",
+					"172.20.0.1:42593",
+					"172.21.0.1:42593",
+					"172.22.0.1:42593",
+					"172.23.0.1:42593",
+					"172.24.0.1:42593",
+					"172.25.0.1:42593",
+					"172.26.0.1:42593",
+					"172.27.0.1:42593",
+					"172.28.0.1:42593",
+					"172.29.0.1:42593"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:08:51.519750495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         750134782054043,
+				"StableID":   "ncKWyamjr611CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0517119cfb430214a3965af8697e4b215e9ef9e6f7dc6af68e1629b66577ea75",
+				"DiscoKey":   "discokey:0d49066dd6ef215e5e40af4964900c9a38ddd2c0710f29ac0bbed0e637f0ec6b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:45651",
+					"10.65.0.27:45651",
+					"172.17.0.1:45651",
+					"172.18.0.1:45651",
+					"172.19.0.1:45651",
+					"172.20.0.1:45651",
+					"172.21.0.1:45651",
+					"172.22.0.1:45651",
+					"172.23.0.1:45651",
+					"172.24.0.1:45651",
+					"172.25.0.1:45651",
+					"172.26.0.1:45651",
+					"172.27.0.1:45651",
+					"172.28.0.1:45651",
+					"172.29.0.1:45651"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:08:52.067522041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         839150932034137,
+				"StableID":   "nxJwKB54Z711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0e0c28e146dd6e11cee7bd6ae352fc6307083541e4e9611baef9c388dcadb7c",
+				"DiscoKey":   "discokey:e44999b5edd3b672174f0f3ee207300641467bf3ee743dda8a6ec03ca3858d1d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44968",
+					"10.65.0.27:44968",
+					"172.17.0.1:44968",
+					"172.18.0.1:44968",
+					"172.19.0.1:44968",
+					"172.20.0.1:44968",
+					"172.21.0.1:44968",
+					"172.22.0.1:44968",
+					"172.23.0.1:44968",
+					"172.24.0.1:44968",
+					"172.25.0.1:44968",
+					"172.26.0.1:44968",
+					"172.27.0.1:44968",
+					"172.28.0.1:44968",
+					"172.29.0.1:44968"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:08:52.600909082Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8089791358291457,
+				"StableID":   "nibJ9s6tA621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3ab64f2d66959455a4bf55624555c1036e729bda4884e7c64c19b872017a0b24",
+				"DiscoKey":   "discokey:bf66d9922616d7f9186f43f321ae120c1fc3d92b0fd37194569b7e6c45917e60",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54929",
+					"10.65.0.27:54929",
+					"172.17.0.1:54929",
+					"172.18.0.1:54929",
+					"172.19.0.1:54929",
+					"172.20.0.1:54929",
+					"172.21.0.1:54929",
+					"172.22.0.1:54929",
+					"172.23.0.1:54929",
+					"172.24.0.1:54929",
+					"172.25.0.1:54929",
+					"172.26.0.1:54929",
+					"172.27.0.1:54929",
+					"172.28.0.1:54929",
+					"172.29.0.1:54929"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:08:53.136655738Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         264256607456368,
+				"StableID":   "n9qoVEag4311CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:914f7a4931682ca03a8382046587ee81000da788897acd3ea18f66907c5f022a",
+				"DiscoKey":   "discokey:04db6794db62b30f749673d0d53252ba1d0b344ff5e369904458aaf9542aa31e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33265",
+					"10.65.0.27:33265",
+					"172.17.0.1:33265",
+					"172.18.0.1:33265",
+					"172.19.0.1:33265",
+					"172.20.0.1:33265",
+					"172.21.0.1:33265",
+					"172.22.0.1:33265",
+					"172.23.0.1:33265",
+					"172.24.0.1:33265",
+					"172.25.0.1:33265",
+					"172.26.0.1:33265",
+					"172.27.0.1:33265",
+					"172.28.0.1:33265",
+					"172.29.0.1:33265"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:08:53.6659712Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7663614990686871,
+				"StableID":   "n6SoutAsq221CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:79e977f28aea31c07b128d887f62f17eb0706d96543f604a6bde62c977e8c93a",
+				"DiscoKey":   "discokey:56194a27fd68adb5985c6835a386f1899944932d8d3fe35d12ab95c687a4c31f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41401",
+					"10.65.0.27:41401",
+					"172.17.0.1:41401",
+					"172.18.0.1:41401",
+					"172.19.0.1:41401",
+					"172.20.0.1:41401",
+					"172.21.0.1:41401",
+					"172.22.0.1:41401",
+					"172.23.0.1:41401",
+					"172.24.0.1:41401",
+					"172.25.0.1:41401",
+					"172.26.0.1:41401",
+					"172.27.0.1:41401",
+					"172.28.0.1:41401",
+					"172.29.0.1:41401"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:08:54.190741062Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8861425300128914,
+				"StableID":   "ns3LFkcMCC21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4784b0e067b3c60e861aee9ab444086a3954473b09053363423a268f5982f533",
+				"DiscoKey":   "discokey:6b4ac603e565c79b1316fba83cad99d59fc6422523132d03b7ec18e4b16e8a1c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:32783",
+					"10.65.0.27:32783",
+					"172.17.0.1:32783",
+					"172.18.0.1:32783",
+					"172.19.0.1:32783",
+					"172.20.0.1:32783",
+					"172.21.0.1:32783",
+					"172.22.0.1:32783",
+					"172.23.0.1:32783",
+					"172.24.0.1:32783",
+					"172.25.0.1:32783",
+					"172.26.0.1:32783",
+					"172.27.0.1:32783",
+					"172.28.0.1:32783",
+					"172.29.0.1:32783"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:08:54.736224441Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2121942722652951,
+				"StableID":   "nNSf9Zq2aH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f36c3c3970962dfcc36ce6a541d4509d463971ab28c4109976925baa7c2b490f",
+				"DiscoKey":   "discokey:f99def593fda9b3d6cb7cb19f67e18c3d8a2c90eeb4dfd052708bfe4b0525f52",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:47554",
+					"10.65.0.27:47554",
+					"172.17.0.1:47554",
+					"172.18.0.1:47554",
+					"172.19.0.1:47554",
+					"172.20.0.1:47554",
+					"172.21.0.1:47554",
+					"172.22.0.1:47554",
+					"172.23.0.1:47554",
+					"172.24.0.1:47554",
+					"172.25.0.1:47554",
+					"172.26.0.1:47554",
+					"172.27.0.1:47554",
+					"172.28.0.1:47554",
+					"172.29.0.1:47554"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:08:55.262055371Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2824186552082163,
+				"StableID":   "nW8qdKb54P11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9e12cd5333229d8b262c24e639634f0b2640bb9ebcb6d54e062127e85d9634d",
+				"DiscoKey":   "discokey:a1895321d40bc0abe8bb7c50e2e19e954d6f79c952841cbb2264137c49cb2b43",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58140",
+					"10.65.0.27:58140",
+					"172.17.0.1:58140",
+					"172.18.0.1:58140",
+					"172.19.0.1:58140",
+					"172.20.0.1:58140",
+					"172.21.0.1:58140",
+					"172.22.0.1:58140",
+					"172.23.0.1:58140",
+					"172.24.0.1:58140",
+					"172.25.0.1:58140",
+					"172.26.0.1:58140",
+					"172.27.0.1:58140",
+					"172.28.0.1:58140",
+					"172.29.0.1:58140"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:08:55.803917237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4537882512937851,
+				"StableID":   "nGqLRmUDSc11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f077b56a647585f47d513ae290d2e5a2fb6eda9528d80805eacb32597d18d119",
+				"KeyExpiry":  "2026-11-09T09:08:56Z",
+				"DiscoKey":   "discokey:ab946cb435f8bc1678f756256fd0cbd141b60ae9d95a1f8ebea2d9bafe5a7237",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:42345",
+					"10.65.0.27:42345",
+					"172.17.0.1:42345",
+					"172.18.0.1:42345",
+					"172.19.0.1:42345",
+					"172.20.0.1:42345",
+					"172.21.0.1:42345",
+					"172.22.0.1:42345",
+					"172.23.0.1:42345",
+					"172.24.0.1:42345",
+					"172.25.0.1:42345",
+					"172.26.0.1:42345",
+					"172.27.0.1:42345",
+					"172.28.0.1:42345",
+					"172.29.0.1:42345"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:08:56.351352972Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1999870809800905,
+				"StableID":   "nt68EUDkcG11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6cdda19e804be5e2cd8f526ebed38e87594983f6271578fd06b30dc824beae1c",
+				"KeyExpiry":  "2026-11-09T09:08:56Z",
+				"DiscoKey":   "discokey:600398c30ac3534d44775a86afb7555cdeb2cf8caa8250cd98a7fe05aa0a5a54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38381",
+					"10.65.0.27:38381",
+					"172.17.0.1:38381",
+					"172.18.0.1:38381",
+					"172.19.0.1:38381",
+					"172.20.0.1:38381",
+					"172.21.0.1:38381",
+					"172.22.0.1:38381",
+					"172.23.0.1:38381",
+					"172.24.0.1:38381",
+					"172.25.0.1:38381",
+					"172.26.0.1:38381",
+					"172.27.0.1:38381",
+					"172.28.0.1:38381",
+					"172.29.0.1:38381"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:08:56.900863642Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6973026628775446,
+				"StableID":   "nXPGBxa6Tw11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d5d8fefebcb8420b272565ade83a1d37b7c82ea35b29f4448a561e3610ca3b60",
+				"KeyExpiry":  "2026-11-09T09:08:57Z",
+				"DiscoKey":   "discokey:a2aaaf10268009cf085a278300b0b82060d85f62dcc68d3d35683f1284e1bb2b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33165",
+					"10.65.0.27:33165",
+					"172.17.0.1:33165",
+					"172.18.0.1:33165",
+					"172.19.0.1:33165",
+					"172.20.0.1:33165",
+					"172.21.0.1:33165",
+					"172.22.0.1:33165",
+					"172.23.0.1:33165",
+					"172.24.0.1:33165",
+					"172.25.0.1:33165",
+					"172.26.0.1:33165",
+					"172.27.0.1:33165",
+					"172.28.0.1:33165",
+					"172.29.0.1:33165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:08:57.437877673Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2437573544205684": {
+				"ID":          2437573544205684,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         264256607456368,
+				"StableID":   "n9qoVEag4311CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       264256607456368,
+				"Key":        "nodekey:914f7a4931682ca03a8382046587ee81000da788897acd3ea18f66907c5f022a",
+				"DiscoKey":   "discokey:04db6794db62b30f749673d0d53252ba1d0b344ff5e369904458aaf9542aa31e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33265",
+					"10.65.0.27:33265",
+					"172.17.0.1:33265",
+					"172.18.0.1:33265",
+					"172.19.0.1:33265",
+					"172.20.0.1:33265",
+					"172.21.0.1:33265",
+					"172.22.0.1:33265",
+					"172.23.0.1:33265",
+					"172.24.0.1:33265",
+					"172.25.0.1:33265",
+					"172.26.0.1:33265",
+					"172.27.0.1:33265",
+					"172.28.0.1:33265",
+					"172.29.0.1:33265"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:08:53.6659712Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:914f7a4931682ca03a8382046587ee81000da788897acd3ea18f66907c5f022a",
+			"MachineKey": "mkey:e8af6022d3e08a8b39b6d4819dab8de69426ba14a0835d6004e89bebdb449a43",
+			"Peers": [{
+				"ID":         7910850219715433,
+				"StableID":   "nWbyU1dqm421CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c38849001c818ec01ab3884fb726ba759429abde871ec71f9c654e8c633db73d",
+				"DiscoKey":   "discokey:a5158e8c031a96f17be128393a921f0a94a461d3c25b27caba71a07e90f19e69",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43331",
+					"10.65.0.27:43331",
+					"172.17.0.1:43331",
+					"172.18.0.1:43331",
+					"172.19.0.1:43331",
+					"172.20.0.1:43331",
+					"172.21.0.1:43331",
+					"172.22.0.1:43331",
+					"172.23.0.1:43331",
+					"172.24.0.1:43331",
+					"172.25.0.1:43331",
+					"172.26.0.1:43331",
+					"172.27.0.1:43331",
+					"172.28.0.1:43331",
+					"172.29.0.1:43331"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:08:49.936876938Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6381211525566936,
+				"StableID":   "nj4m5Ac4qr11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba4bdeff5d35313d26131bd1e00e38d94105f2d2d204c657562260231fb91a18",
+				"DiscoKey":   "discokey:097063db9440512c70541de1a731980d4a34eddf48d97052d1e4866e9da65e09",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35952",
+					"10.65.0.27:35952",
+					"172.17.0.1:35952",
+					"172.18.0.1:35952",
+					"172.19.0.1:35952",
+					"172.20.0.1:35952",
+					"172.21.0.1:35952",
+					"172.22.0.1:35952",
+					"172.23.0.1:35952",
+					"172.24.0.1:35952",
+					"172.25.0.1:35952",
+					"172.26.0.1:35952",
+					"172.27.0.1:35952",
+					"172.28.0.1:35952",
+					"172.29.0.1:35952"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:08:50.43056034Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2437573544205684,
+				"StableID":   "noNL2avy2L11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7efd3b993cc568ba4d4e463aacc88c9e6e28595db86cc4bf968a22dbbce6154e",
+				"DiscoKey":   "discokey:93db8a82e3d64a77ff9d4aab6f194d68ed2bab893ef5b1c6a21f8776d75c120d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45990",
+					"10.65.0.27:45990",
+					"172.17.0.1:45990",
+					"172.18.0.1:45990",
+					"172.19.0.1:45990",
+					"172.20.0.1:45990",
+					"172.21.0.1:45990",
+					"172.22.0.1:45990",
+					"172.23.0.1:45990",
+					"172.24.0.1:45990",
+					"172.25.0.1:45990",
+					"172.26.0.1:45990",
+					"172.27.0.1:45990",
+					"172.28.0.1:45990",
+					"172.29.0.1:45990"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:08:50.973567256Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8072414054839639,
+				"StableID":   "nxXtLUd13621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1ce09e5497139ac52ccdbf6e6723e8ca61d7b0e939373c42f62d6669e865264",
+				"DiscoKey":   "discokey:f41dbf4aa82c85a3b684cc1562b75ee3d288cc3eab6e43beff65f5f5a203dd0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42593",
+					"10.65.0.27:42593",
+					"172.17.0.1:42593",
+					"172.18.0.1:42593",
+					"172.19.0.1:42593",
+					"172.20.0.1:42593",
+					"172.21.0.1:42593",
+					"172.22.0.1:42593",
+					"172.23.0.1:42593",
+					"172.24.0.1:42593",
+					"172.25.0.1:42593",
+					"172.26.0.1:42593",
+					"172.27.0.1:42593",
+					"172.28.0.1:42593",
+					"172.29.0.1:42593"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:08:51.519750495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         750134782054043,
+				"StableID":   "ncKWyamjr611CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0517119cfb430214a3965af8697e4b215e9ef9e6f7dc6af68e1629b66577ea75",
+				"DiscoKey":   "discokey:0d49066dd6ef215e5e40af4964900c9a38ddd2c0710f29ac0bbed0e637f0ec6b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:45651",
+					"10.65.0.27:45651",
+					"172.17.0.1:45651",
+					"172.18.0.1:45651",
+					"172.19.0.1:45651",
+					"172.20.0.1:45651",
+					"172.21.0.1:45651",
+					"172.22.0.1:45651",
+					"172.23.0.1:45651",
+					"172.24.0.1:45651",
+					"172.25.0.1:45651",
+					"172.26.0.1:45651",
+					"172.27.0.1:45651",
+					"172.28.0.1:45651",
+					"172.29.0.1:45651"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:08:52.067522041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         839150932034137,
+				"StableID":   "nxJwKB54Z711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0e0c28e146dd6e11cee7bd6ae352fc6307083541e4e9611baef9c388dcadb7c",
+				"DiscoKey":   "discokey:e44999b5edd3b672174f0f3ee207300641467bf3ee743dda8a6ec03ca3858d1d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44968",
+					"10.65.0.27:44968",
+					"172.17.0.1:44968",
+					"172.18.0.1:44968",
+					"172.19.0.1:44968",
+					"172.20.0.1:44968",
+					"172.21.0.1:44968",
+					"172.22.0.1:44968",
+					"172.23.0.1:44968",
+					"172.24.0.1:44968",
+					"172.25.0.1:44968",
+					"172.26.0.1:44968",
+					"172.27.0.1:44968",
+					"172.28.0.1:44968",
+					"172.29.0.1:44968"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:08:52.600909082Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8089791358291457,
+				"StableID":   "nibJ9s6tA621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3ab64f2d66959455a4bf55624555c1036e729bda4884e7c64c19b872017a0b24",
+				"DiscoKey":   "discokey:bf66d9922616d7f9186f43f321ae120c1fc3d92b0fd37194569b7e6c45917e60",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54929",
+					"10.65.0.27:54929",
+					"172.17.0.1:54929",
+					"172.18.0.1:54929",
+					"172.19.0.1:54929",
+					"172.20.0.1:54929",
+					"172.21.0.1:54929",
+					"172.22.0.1:54929",
+					"172.23.0.1:54929",
+					"172.24.0.1:54929",
+					"172.25.0.1:54929",
+					"172.26.0.1:54929",
+					"172.27.0.1:54929",
+					"172.28.0.1:54929",
+					"172.29.0.1:54929"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:08:53.136655738Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7663614990686871,
+				"StableID":   "n6SoutAsq221CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:79e977f28aea31c07b128d887f62f17eb0706d96543f604a6bde62c977e8c93a",
+				"DiscoKey":   "discokey:56194a27fd68adb5985c6835a386f1899944932d8d3fe35d12ab95c687a4c31f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41401",
+					"10.65.0.27:41401",
+					"172.17.0.1:41401",
+					"172.18.0.1:41401",
+					"172.19.0.1:41401",
+					"172.20.0.1:41401",
+					"172.21.0.1:41401",
+					"172.22.0.1:41401",
+					"172.23.0.1:41401",
+					"172.24.0.1:41401",
+					"172.25.0.1:41401",
+					"172.26.0.1:41401",
+					"172.27.0.1:41401",
+					"172.28.0.1:41401",
+					"172.29.0.1:41401"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:08:54.190741062Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8861425300128914,
+				"StableID":   "ns3LFkcMCC21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4784b0e067b3c60e861aee9ab444086a3954473b09053363423a268f5982f533",
+				"DiscoKey":   "discokey:6b4ac603e565c79b1316fba83cad99d59fc6422523132d03b7ec18e4b16e8a1c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:32783",
+					"10.65.0.27:32783",
+					"172.17.0.1:32783",
+					"172.18.0.1:32783",
+					"172.19.0.1:32783",
+					"172.20.0.1:32783",
+					"172.21.0.1:32783",
+					"172.22.0.1:32783",
+					"172.23.0.1:32783",
+					"172.24.0.1:32783",
+					"172.25.0.1:32783",
+					"172.26.0.1:32783",
+					"172.27.0.1:32783",
+					"172.28.0.1:32783",
+					"172.29.0.1:32783"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:08:54.736224441Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2121942722652951,
+				"StableID":   "nNSf9Zq2aH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f36c3c3970962dfcc36ce6a541d4509d463971ab28c4109976925baa7c2b490f",
+				"DiscoKey":   "discokey:f99def593fda9b3d6cb7cb19f67e18c3d8a2c90eeb4dfd052708bfe4b0525f52",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:47554",
+					"10.65.0.27:47554",
+					"172.17.0.1:47554",
+					"172.18.0.1:47554",
+					"172.19.0.1:47554",
+					"172.20.0.1:47554",
+					"172.21.0.1:47554",
+					"172.22.0.1:47554",
+					"172.23.0.1:47554",
+					"172.24.0.1:47554",
+					"172.25.0.1:47554",
+					"172.26.0.1:47554",
+					"172.27.0.1:47554",
+					"172.28.0.1:47554",
+					"172.29.0.1:47554"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:08:55.262055371Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2824186552082163,
+				"StableID":   "nW8qdKb54P11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9e12cd5333229d8b262c24e639634f0b2640bb9ebcb6d54e062127e85d9634d",
+				"DiscoKey":   "discokey:a1895321d40bc0abe8bb7c50e2e19e954d6f79c952841cbb2264137c49cb2b43",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58140",
+					"10.65.0.27:58140",
+					"172.17.0.1:58140",
+					"172.18.0.1:58140",
+					"172.19.0.1:58140",
+					"172.20.0.1:58140",
+					"172.21.0.1:58140",
+					"172.22.0.1:58140",
+					"172.23.0.1:58140",
+					"172.24.0.1:58140",
+					"172.25.0.1:58140",
+					"172.26.0.1:58140",
+					"172.27.0.1:58140",
+					"172.28.0.1:58140",
+					"172.29.0.1:58140"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:08:55.803917237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4537882512937851,
+				"StableID":   "nGqLRmUDSc11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f077b56a647585f47d513ae290d2e5a2fb6eda9528d80805eacb32597d18d119",
+				"KeyExpiry":  "2026-11-09T09:08:56Z",
+				"DiscoKey":   "discokey:ab946cb435f8bc1678f756256fd0cbd141b60ae9d95a1f8ebea2d9bafe5a7237",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:42345",
+					"10.65.0.27:42345",
+					"172.17.0.1:42345",
+					"172.18.0.1:42345",
+					"172.19.0.1:42345",
+					"172.20.0.1:42345",
+					"172.21.0.1:42345",
+					"172.22.0.1:42345",
+					"172.23.0.1:42345",
+					"172.24.0.1:42345",
+					"172.25.0.1:42345",
+					"172.26.0.1:42345",
+					"172.27.0.1:42345",
+					"172.28.0.1:42345",
+					"172.29.0.1:42345"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:08:56.351352972Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1999870809800905,
+				"StableID":   "nt68EUDkcG11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6cdda19e804be5e2cd8f526ebed38e87594983f6271578fd06b30dc824beae1c",
+				"KeyExpiry":  "2026-11-09T09:08:56Z",
+				"DiscoKey":   "discokey:600398c30ac3534d44775a86afb7555cdeb2cf8caa8250cd98a7fe05aa0a5a54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38381",
+					"10.65.0.27:38381",
+					"172.17.0.1:38381",
+					"172.18.0.1:38381",
+					"172.19.0.1:38381",
+					"172.20.0.1:38381",
+					"172.21.0.1:38381",
+					"172.22.0.1:38381",
+					"172.23.0.1:38381",
+					"172.24.0.1:38381",
+					"172.25.0.1:38381",
+					"172.26.0.1:38381",
+					"172.27.0.1:38381",
+					"172.28.0.1:38381",
+					"172.29.0.1:38381"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:08:56.900863642Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6973026628775446,
+				"StableID":   "nXPGBxa6Tw11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d5d8fefebcb8420b272565ade83a1d37b7c82ea35b29f4448a561e3610ca3b60",
+				"KeyExpiry":  "2026-11-09T09:08:57Z",
+				"DiscoKey":   "discokey:a2aaaf10268009cf085a278300b0b82060d85f62dcc68d3d35683f1284e1bb2b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33165",
+					"10.65.0.27:33165",
+					"172.17.0.1:33165",
+					"172.18.0.1:33165",
+					"172.19.0.1:33165",
+					"172.20.0.1:33165",
+					"172.21.0.1:33165",
+					"172.22.0.1:33165",
+					"172.23.0.1:33165",
+					"172.24.0.1:33165",
+					"172.25.0.1:33165",
+					"172.26.0.1:33165",
+					"172.27.0.1:33165",
+					"172.28.0.1:33165",
+					"172.29.0.1:33165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:08:57.437877673Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "264256607456368": {
+				"ID":          264256607456368,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4537882512937851,
+				"StableID":   "nGqLRmUDSc11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f077b56a647585f47d513ae290d2e5a2fb6eda9528d80805eacb32597d18d119",
+				"KeyExpiry":  "2026-11-09T09:08:56Z",
+				"DiscoKey":   "discokey:ab946cb435f8bc1678f756256fd0cbd141b60ae9d95a1f8ebea2d9bafe5a7237",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:42345",
+					"10.65.0.27:42345",
+					"172.17.0.1:42345",
+					"172.18.0.1:42345",
+					"172.19.0.1:42345",
+					"172.20.0.1:42345",
+					"172.21.0.1:42345",
+					"172.22.0.1:42345",
+					"172.23.0.1:42345",
+					"172.24.0.1:42345",
+					"172.25.0.1:42345",
+					"172.26.0.1:42345",
+					"172.27.0.1:42345",
+					"172.28.0.1:42345",
+					"172.29.0.1:42345"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:08:56.351352972Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f077b56a647585f47d513ae290d2e5a2fb6eda9528d80805eacb32597d18d119",
+			"MachineKey": "mkey:56cd0097ad528d33839ed129d502f88a8bc2e7cd87a2035a816e40348dfa251b",
+			"Peers": [{
+				"ID":         7910850219715433,
+				"StableID":   "nWbyU1dqm421CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c38849001c818ec01ab3884fb726ba759429abde871ec71f9c654e8c633db73d",
+				"DiscoKey":   "discokey:a5158e8c031a96f17be128393a921f0a94a461d3c25b27caba71a07e90f19e69",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43331",
+					"10.65.0.27:43331",
+					"172.17.0.1:43331",
+					"172.18.0.1:43331",
+					"172.19.0.1:43331",
+					"172.20.0.1:43331",
+					"172.21.0.1:43331",
+					"172.22.0.1:43331",
+					"172.23.0.1:43331",
+					"172.24.0.1:43331",
+					"172.25.0.1:43331",
+					"172.26.0.1:43331",
+					"172.27.0.1:43331",
+					"172.28.0.1:43331",
+					"172.29.0.1:43331"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:08:49.936876938Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6381211525566936,
+				"StableID":   "nj4m5Ac4qr11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba4bdeff5d35313d26131bd1e00e38d94105f2d2d204c657562260231fb91a18",
+				"DiscoKey":   "discokey:097063db9440512c70541de1a731980d4a34eddf48d97052d1e4866e9da65e09",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35952",
+					"10.65.0.27:35952",
+					"172.17.0.1:35952",
+					"172.18.0.1:35952",
+					"172.19.0.1:35952",
+					"172.20.0.1:35952",
+					"172.21.0.1:35952",
+					"172.22.0.1:35952",
+					"172.23.0.1:35952",
+					"172.24.0.1:35952",
+					"172.25.0.1:35952",
+					"172.26.0.1:35952",
+					"172.27.0.1:35952",
+					"172.28.0.1:35952",
+					"172.29.0.1:35952"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:08:50.43056034Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2437573544205684,
+				"StableID":   "noNL2avy2L11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7efd3b993cc568ba4d4e463aacc88c9e6e28595db86cc4bf968a22dbbce6154e",
+				"DiscoKey":   "discokey:93db8a82e3d64a77ff9d4aab6f194d68ed2bab893ef5b1c6a21f8776d75c120d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45990",
+					"10.65.0.27:45990",
+					"172.17.0.1:45990",
+					"172.18.0.1:45990",
+					"172.19.0.1:45990",
+					"172.20.0.1:45990",
+					"172.21.0.1:45990",
+					"172.22.0.1:45990",
+					"172.23.0.1:45990",
+					"172.24.0.1:45990",
+					"172.25.0.1:45990",
+					"172.26.0.1:45990",
+					"172.27.0.1:45990",
+					"172.28.0.1:45990",
+					"172.29.0.1:45990"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:08:50.973567256Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8072414054839639,
+				"StableID":   "nxXtLUd13621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1ce09e5497139ac52ccdbf6e6723e8ca61d7b0e939373c42f62d6669e865264",
+				"DiscoKey":   "discokey:f41dbf4aa82c85a3b684cc1562b75ee3d288cc3eab6e43beff65f5f5a203dd0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42593",
+					"10.65.0.27:42593",
+					"172.17.0.1:42593",
+					"172.18.0.1:42593",
+					"172.19.0.1:42593",
+					"172.20.0.1:42593",
+					"172.21.0.1:42593",
+					"172.22.0.1:42593",
+					"172.23.0.1:42593",
+					"172.24.0.1:42593",
+					"172.25.0.1:42593",
+					"172.26.0.1:42593",
+					"172.27.0.1:42593",
+					"172.28.0.1:42593",
+					"172.29.0.1:42593"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:08:51.519750495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         750134782054043,
+				"StableID":   "ncKWyamjr611CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0517119cfb430214a3965af8697e4b215e9ef9e6f7dc6af68e1629b66577ea75",
+				"DiscoKey":   "discokey:0d49066dd6ef215e5e40af4964900c9a38ddd2c0710f29ac0bbed0e637f0ec6b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:45651",
+					"10.65.0.27:45651",
+					"172.17.0.1:45651",
+					"172.18.0.1:45651",
+					"172.19.0.1:45651",
+					"172.20.0.1:45651",
+					"172.21.0.1:45651",
+					"172.22.0.1:45651",
+					"172.23.0.1:45651",
+					"172.24.0.1:45651",
+					"172.25.0.1:45651",
+					"172.26.0.1:45651",
+					"172.27.0.1:45651",
+					"172.28.0.1:45651",
+					"172.29.0.1:45651"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:08:52.067522041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         839150932034137,
+				"StableID":   "nxJwKB54Z711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0e0c28e146dd6e11cee7bd6ae352fc6307083541e4e9611baef9c388dcadb7c",
+				"DiscoKey":   "discokey:e44999b5edd3b672174f0f3ee207300641467bf3ee743dda8a6ec03ca3858d1d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44968",
+					"10.65.0.27:44968",
+					"172.17.0.1:44968",
+					"172.18.0.1:44968",
+					"172.19.0.1:44968",
+					"172.20.0.1:44968",
+					"172.21.0.1:44968",
+					"172.22.0.1:44968",
+					"172.23.0.1:44968",
+					"172.24.0.1:44968",
+					"172.25.0.1:44968",
+					"172.26.0.1:44968",
+					"172.27.0.1:44968",
+					"172.28.0.1:44968",
+					"172.29.0.1:44968"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:08:52.600909082Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8089791358291457,
+				"StableID":   "nibJ9s6tA621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3ab64f2d66959455a4bf55624555c1036e729bda4884e7c64c19b872017a0b24",
+				"DiscoKey":   "discokey:bf66d9922616d7f9186f43f321ae120c1fc3d92b0fd37194569b7e6c45917e60",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54929",
+					"10.65.0.27:54929",
+					"172.17.0.1:54929",
+					"172.18.0.1:54929",
+					"172.19.0.1:54929",
+					"172.20.0.1:54929",
+					"172.21.0.1:54929",
+					"172.22.0.1:54929",
+					"172.23.0.1:54929",
+					"172.24.0.1:54929",
+					"172.25.0.1:54929",
+					"172.26.0.1:54929",
+					"172.27.0.1:54929",
+					"172.28.0.1:54929",
+					"172.29.0.1:54929"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:08:53.136655738Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         264256607456368,
+				"StableID":   "n9qoVEag4311CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:914f7a4931682ca03a8382046587ee81000da788897acd3ea18f66907c5f022a",
+				"DiscoKey":   "discokey:04db6794db62b30f749673d0d53252ba1d0b344ff5e369904458aaf9542aa31e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33265",
+					"10.65.0.27:33265",
+					"172.17.0.1:33265",
+					"172.18.0.1:33265",
+					"172.19.0.1:33265",
+					"172.20.0.1:33265",
+					"172.21.0.1:33265",
+					"172.22.0.1:33265",
+					"172.23.0.1:33265",
+					"172.24.0.1:33265",
+					"172.25.0.1:33265",
+					"172.26.0.1:33265",
+					"172.27.0.1:33265",
+					"172.28.0.1:33265",
+					"172.29.0.1:33265"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:08:53.6659712Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7663614990686871,
+				"StableID":   "n6SoutAsq221CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:79e977f28aea31c07b128d887f62f17eb0706d96543f604a6bde62c977e8c93a",
+				"DiscoKey":   "discokey:56194a27fd68adb5985c6835a386f1899944932d8d3fe35d12ab95c687a4c31f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41401",
+					"10.65.0.27:41401",
+					"172.17.0.1:41401",
+					"172.18.0.1:41401",
+					"172.19.0.1:41401",
+					"172.20.0.1:41401",
+					"172.21.0.1:41401",
+					"172.22.0.1:41401",
+					"172.23.0.1:41401",
+					"172.24.0.1:41401",
+					"172.25.0.1:41401",
+					"172.26.0.1:41401",
+					"172.27.0.1:41401",
+					"172.28.0.1:41401",
+					"172.29.0.1:41401"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:08:54.190741062Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8861425300128914,
+				"StableID":   "ns3LFkcMCC21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4784b0e067b3c60e861aee9ab444086a3954473b09053363423a268f5982f533",
+				"DiscoKey":   "discokey:6b4ac603e565c79b1316fba83cad99d59fc6422523132d03b7ec18e4b16e8a1c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:32783",
+					"10.65.0.27:32783",
+					"172.17.0.1:32783",
+					"172.18.0.1:32783",
+					"172.19.0.1:32783",
+					"172.20.0.1:32783",
+					"172.21.0.1:32783",
+					"172.22.0.1:32783",
+					"172.23.0.1:32783",
+					"172.24.0.1:32783",
+					"172.25.0.1:32783",
+					"172.26.0.1:32783",
+					"172.27.0.1:32783",
+					"172.28.0.1:32783",
+					"172.29.0.1:32783"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:08:54.736224441Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2121942722652951,
+				"StableID":   "nNSf9Zq2aH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f36c3c3970962dfcc36ce6a541d4509d463971ab28c4109976925baa7c2b490f",
+				"DiscoKey":   "discokey:f99def593fda9b3d6cb7cb19f67e18c3d8a2c90eeb4dfd052708bfe4b0525f52",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:47554",
+					"10.65.0.27:47554",
+					"172.17.0.1:47554",
+					"172.18.0.1:47554",
+					"172.19.0.1:47554",
+					"172.20.0.1:47554",
+					"172.21.0.1:47554",
+					"172.22.0.1:47554",
+					"172.23.0.1:47554",
+					"172.24.0.1:47554",
+					"172.25.0.1:47554",
+					"172.26.0.1:47554",
+					"172.27.0.1:47554",
+					"172.28.0.1:47554",
+					"172.29.0.1:47554"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:08:55.262055371Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2824186552082163,
+				"StableID":   "nW8qdKb54P11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9e12cd5333229d8b262c24e639634f0b2640bb9ebcb6d54e062127e85d9634d",
+				"DiscoKey":   "discokey:a1895321d40bc0abe8bb7c50e2e19e954d6f79c952841cbb2264137c49cb2b43",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58140",
+					"10.65.0.27:58140",
+					"172.17.0.1:58140",
+					"172.18.0.1:58140",
+					"172.19.0.1:58140",
+					"172.20.0.1:58140",
+					"172.21.0.1:58140",
+					"172.22.0.1:58140",
+					"172.23.0.1:58140",
+					"172.24.0.1:58140",
+					"172.25.0.1:58140",
+					"172.26.0.1:58140",
+					"172.27.0.1:58140",
+					"172.28.0.1:58140",
+					"172.29.0.1:58140"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:08:55.803917237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1999870809800905,
+				"StableID":   "nt68EUDkcG11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6cdda19e804be5e2cd8f526ebed38e87594983f6271578fd06b30dc824beae1c",
+				"KeyExpiry":  "2026-11-09T09:08:56Z",
+				"DiscoKey":   "discokey:600398c30ac3534d44775a86afb7555cdeb2cf8caa8250cd98a7fe05aa0a5a54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38381",
+					"10.65.0.27:38381",
+					"172.17.0.1:38381",
+					"172.18.0.1:38381",
+					"172.19.0.1:38381",
+					"172.20.0.1:38381",
+					"172.21.0.1:38381",
+					"172.22.0.1:38381",
+					"172.23.0.1:38381",
+					"172.24.0.1:38381",
+					"172.25.0.1:38381",
+					"172.26.0.1:38381",
+					"172.27.0.1:38381",
+					"172.28.0.1:38381",
+					"172.29.0.1:38381"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:08:56.900863642Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6973026628775446,
+				"StableID":   "nXPGBxa6Tw11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d5d8fefebcb8420b272565ade83a1d37b7c82ea35b29f4448a561e3610ca3b60",
+				"KeyExpiry":  "2026-11-09T09:08:57Z",
+				"DiscoKey":   "discokey:a2aaaf10268009cf085a278300b0b82060d85f62dcc68d3d35683f1284e1bb2b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33165",
+					"10.65.0.27:33165",
+					"172.17.0.1:33165",
+					"172.18.0.1:33165",
+					"172.19.0.1:33165",
+					"172.20.0.1:33165",
+					"172.21.0.1:33165",
+					"172.22.0.1:33165",
+					"172.23.0.1:33165",
+					"172.24.0.1:33165",
+					"172.25.0.1:33165",
+					"172.26.0.1:33165",
+					"172.27.0.1:33165",
+					"172.28.0.1:33165",
+					"172.29.0.1:33165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:08:57.437877673Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2121942722652951,
+				"StableID":   "nNSf9Zq2aH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       2121942722652951,
+				"Key":        "nodekey:f36c3c3970962dfcc36ce6a541d4509d463971ab28c4109976925baa7c2b490f",
+				"DiscoKey":   "discokey:f99def593fda9b3d6cb7cb19f67e18c3d8a2c90eeb4dfd052708bfe4b0525f52",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:47554",
+					"10.65.0.27:47554",
+					"172.17.0.1:47554",
+					"172.18.0.1:47554",
+					"172.19.0.1:47554",
+					"172.20.0.1:47554",
+					"172.21.0.1:47554",
+					"172.22.0.1:47554",
+					"172.23.0.1:47554",
+					"172.24.0.1:47554",
+					"172.25.0.1:47554",
+					"172.26.0.1:47554",
+					"172.27.0.1:47554",
+					"172.28.0.1:47554",
+					"172.29.0.1:47554"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:08:55.262055371Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f36c3c3970962dfcc36ce6a541d4509d463971ab28c4109976925baa7c2b490f",
+			"MachineKey": "mkey:6e0c051a08afbb274333dbf66bc8b6b883a55660313aea7b168ecbdec04fbb5e",
+			"Peers": [{
+				"ID":         7910850219715433,
+				"StableID":   "nWbyU1dqm421CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c38849001c818ec01ab3884fb726ba759429abde871ec71f9c654e8c633db73d",
+				"DiscoKey":   "discokey:a5158e8c031a96f17be128393a921f0a94a461d3c25b27caba71a07e90f19e69",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43331",
+					"10.65.0.27:43331",
+					"172.17.0.1:43331",
+					"172.18.0.1:43331",
+					"172.19.0.1:43331",
+					"172.20.0.1:43331",
+					"172.21.0.1:43331",
+					"172.22.0.1:43331",
+					"172.23.0.1:43331",
+					"172.24.0.1:43331",
+					"172.25.0.1:43331",
+					"172.26.0.1:43331",
+					"172.27.0.1:43331",
+					"172.28.0.1:43331",
+					"172.29.0.1:43331"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:08:49.936876938Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6381211525566936,
+				"StableID":   "nj4m5Ac4qr11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba4bdeff5d35313d26131bd1e00e38d94105f2d2d204c657562260231fb91a18",
+				"DiscoKey":   "discokey:097063db9440512c70541de1a731980d4a34eddf48d97052d1e4866e9da65e09",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35952",
+					"10.65.0.27:35952",
+					"172.17.0.1:35952",
+					"172.18.0.1:35952",
+					"172.19.0.1:35952",
+					"172.20.0.1:35952",
+					"172.21.0.1:35952",
+					"172.22.0.1:35952",
+					"172.23.0.1:35952",
+					"172.24.0.1:35952",
+					"172.25.0.1:35952",
+					"172.26.0.1:35952",
+					"172.27.0.1:35952",
+					"172.28.0.1:35952",
+					"172.29.0.1:35952"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:08:50.43056034Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2437573544205684,
+				"StableID":   "noNL2avy2L11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7efd3b993cc568ba4d4e463aacc88c9e6e28595db86cc4bf968a22dbbce6154e",
+				"DiscoKey":   "discokey:93db8a82e3d64a77ff9d4aab6f194d68ed2bab893ef5b1c6a21f8776d75c120d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45990",
+					"10.65.0.27:45990",
+					"172.17.0.1:45990",
+					"172.18.0.1:45990",
+					"172.19.0.1:45990",
+					"172.20.0.1:45990",
+					"172.21.0.1:45990",
+					"172.22.0.1:45990",
+					"172.23.0.1:45990",
+					"172.24.0.1:45990",
+					"172.25.0.1:45990",
+					"172.26.0.1:45990",
+					"172.27.0.1:45990",
+					"172.28.0.1:45990",
+					"172.29.0.1:45990"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:08:50.973567256Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8072414054839639,
+				"StableID":   "nxXtLUd13621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1ce09e5497139ac52ccdbf6e6723e8ca61d7b0e939373c42f62d6669e865264",
+				"DiscoKey":   "discokey:f41dbf4aa82c85a3b684cc1562b75ee3d288cc3eab6e43beff65f5f5a203dd0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42593",
+					"10.65.0.27:42593",
+					"172.17.0.1:42593",
+					"172.18.0.1:42593",
+					"172.19.0.1:42593",
+					"172.20.0.1:42593",
+					"172.21.0.1:42593",
+					"172.22.0.1:42593",
+					"172.23.0.1:42593",
+					"172.24.0.1:42593",
+					"172.25.0.1:42593",
+					"172.26.0.1:42593",
+					"172.27.0.1:42593",
+					"172.28.0.1:42593",
+					"172.29.0.1:42593"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:08:51.519750495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         750134782054043,
+				"StableID":   "ncKWyamjr611CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0517119cfb430214a3965af8697e4b215e9ef9e6f7dc6af68e1629b66577ea75",
+				"DiscoKey":   "discokey:0d49066dd6ef215e5e40af4964900c9a38ddd2c0710f29ac0bbed0e637f0ec6b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:45651",
+					"10.65.0.27:45651",
+					"172.17.0.1:45651",
+					"172.18.0.1:45651",
+					"172.19.0.1:45651",
+					"172.20.0.1:45651",
+					"172.21.0.1:45651",
+					"172.22.0.1:45651",
+					"172.23.0.1:45651",
+					"172.24.0.1:45651",
+					"172.25.0.1:45651",
+					"172.26.0.1:45651",
+					"172.27.0.1:45651",
+					"172.28.0.1:45651",
+					"172.29.0.1:45651"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:08:52.067522041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         839150932034137,
+				"StableID":   "nxJwKB54Z711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0e0c28e146dd6e11cee7bd6ae352fc6307083541e4e9611baef9c388dcadb7c",
+				"DiscoKey":   "discokey:e44999b5edd3b672174f0f3ee207300641467bf3ee743dda8a6ec03ca3858d1d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44968",
+					"10.65.0.27:44968",
+					"172.17.0.1:44968",
+					"172.18.0.1:44968",
+					"172.19.0.1:44968",
+					"172.20.0.1:44968",
+					"172.21.0.1:44968",
+					"172.22.0.1:44968",
+					"172.23.0.1:44968",
+					"172.24.0.1:44968",
+					"172.25.0.1:44968",
+					"172.26.0.1:44968",
+					"172.27.0.1:44968",
+					"172.28.0.1:44968",
+					"172.29.0.1:44968"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:08:52.600909082Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8089791358291457,
+				"StableID":   "nibJ9s6tA621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3ab64f2d66959455a4bf55624555c1036e729bda4884e7c64c19b872017a0b24",
+				"DiscoKey":   "discokey:bf66d9922616d7f9186f43f321ae120c1fc3d92b0fd37194569b7e6c45917e60",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54929",
+					"10.65.0.27:54929",
+					"172.17.0.1:54929",
+					"172.18.0.1:54929",
+					"172.19.0.1:54929",
+					"172.20.0.1:54929",
+					"172.21.0.1:54929",
+					"172.22.0.1:54929",
+					"172.23.0.1:54929",
+					"172.24.0.1:54929",
+					"172.25.0.1:54929",
+					"172.26.0.1:54929",
+					"172.27.0.1:54929",
+					"172.28.0.1:54929",
+					"172.29.0.1:54929"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:08:53.136655738Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         264256607456368,
+				"StableID":   "n9qoVEag4311CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:914f7a4931682ca03a8382046587ee81000da788897acd3ea18f66907c5f022a",
+				"DiscoKey":   "discokey:04db6794db62b30f749673d0d53252ba1d0b344ff5e369904458aaf9542aa31e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33265",
+					"10.65.0.27:33265",
+					"172.17.0.1:33265",
+					"172.18.0.1:33265",
+					"172.19.0.1:33265",
+					"172.20.0.1:33265",
+					"172.21.0.1:33265",
+					"172.22.0.1:33265",
+					"172.23.0.1:33265",
+					"172.24.0.1:33265",
+					"172.25.0.1:33265",
+					"172.26.0.1:33265",
+					"172.27.0.1:33265",
+					"172.28.0.1:33265",
+					"172.29.0.1:33265"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:08:53.6659712Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7663614990686871,
+				"StableID":   "n6SoutAsq221CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:79e977f28aea31c07b128d887f62f17eb0706d96543f604a6bde62c977e8c93a",
+				"DiscoKey":   "discokey:56194a27fd68adb5985c6835a386f1899944932d8d3fe35d12ab95c687a4c31f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41401",
+					"10.65.0.27:41401",
+					"172.17.0.1:41401",
+					"172.18.0.1:41401",
+					"172.19.0.1:41401",
+					"172.20.0.1:41401",
+					"172.21.0.1:41401",
+					"172.22.0.1:41401",
+					"172.23.0.1:41401",
+					"172.24.0.1:41401",
+					"172.25.0.1:41401",
+					"172.26.0.1:41401",
+					"172.27.0.1:41401",
+					"172.28.0.1:41401",
+					"172.29.0.1:41401"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:08:54.190741062Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8861425300128914,
+				"StableID":   "ns3LFkcMCC21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4784b0e067b3c60e861aee9ab444086a3954473b09053363423a268f5982f533",
+				"DiscoKey":   "discokey:6b4ac603e565c79b1316fba83cad99d59fc6422523132d03b7ec18e4b16e8a1c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:32783",
+					"10.65.0.27:32783",
+					"172.17.0.1:32783",
+					"172.18.0.1:32783",
+					"172.19.0.1:32783",
+					"172.20.0.1:32783",
+					"172.21.0.1:32783",
+					"172.22.0.1:32783",
+					"172.23.0.1:32783",
+					"172.24.0.1:32783",
+					"172.25.0.1:32783",
+					"172.26.0.1:32783",
+					"172.27.0.1:32783",
+					"172.28.0.1:32783",
+					"172.29.0.1:32783"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:08:54.736224441Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2824186552082163,
+				"StableID":   "nW8qdKb54P11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9e12cd5333229d8b262c24e639634f0b2640bb9ebcb6d54e062127e85d9634d",
+				"DiscoKey":   "discokey:a1895321d40bc0abe8bb7c50e2e19e954d6f79c952841cbb2264137c49cb2b43",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58140",
+					"10.65.0.27:58140",
+					"172.17.0.1:58140",
+					"172.18.0.1:58140",
+					"172.19.0.1:58140",
+					"172.20.0.1:58140",
+					"172.21.0.1:58140",
+					"172.22.0.1:58140",
+					"172.23.0.1:58140",
+					"172.24.0.1:58140",
+					"172.25.0.1:58140",
+					"172.26.0.1:58140",
+					"172.27.0.1:58140",
+					"172.28.0.1:58140",
+					"172.29.0.1:58140"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:08:55.803917237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4537882512937851,
+				"StableID":   "nGqLRmUDSc11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f077b56a647585f47d513ae290d2e5a2fb6eda9528d80805eacb32597d18d119",
+				"KeyExpiry":  "2026-11-09T09:08:56Z",
+				"DiscoKey":   "discokey:ab946cb435f8bc1678f756256fd0cbd141b60ae9d95a1f8ebea2d9bafe5a7237",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:42345",
+					"10.65.0.27:42345",
+					"172.17.0.1:42345",
+					"172.18.0.1:42345",
+					"172.19.0.1:42345",
+					"172.20.0.1:42345",
+					"172.21.0.1:42345",
+					"172.22.0.1:42345",
+					"172.23.0.1:42345",
+					"172.24.0.1:42345",
+					"172.25.0.1:42345",
+					"172.26.0.1:42345",
+					"172.27.0.1:42345",
+					"172.28.0.1:42345",
+					"172.29.0.1:42345"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:08:56.351352972Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1999870809800905,
+				"StableID":   "nt68EUDkcG11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6cdda19e804be5e2cd8f526ebed38e87594983f6271578fd06b30dc824beae1c",
+				"KeyExpiry":  "2026-11-09T09:08:56Z",
+				"DiscoKey":   "discokey:600398c30ac3534d44775a86afb7555cdeb2cf8caa8250cd98a7fe05aa0a5a54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38381",
+					"10.65.0.27:38381",
+					"172.17.0.1:38381",
+					"172.18.0.1:38381",
+					"172.19.0.1:38381",
+					"172.20.0.1:38381",
+					"172.21.0.1:38381",
+					"172.22.0.1:38381",
+					"172.23.0.1:38381",
+					"172.24.0.1:38381",
+					"172.25.0.1:38381",
+					"172.26.0.1:38381",
+					"172.27.0.1:38381",
+					"172.28.0.1:38381",
+					"172.29.0.1:38381"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:08:56.900863642Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6973026628775446,
+				"StableID":   "nXPGBxa6Tw11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d5d8fefebcb8420b272565ade83a1d37b7c82ea35b29f4448a561e3610ca3b60",
+				"KeyExpiry":  "2026-11-09T09:08:57Z",
+				"DiscoKey":   "discokey:a2aaaf10268009cf085a278300b0b82060d85f62dcc68d3d35683f1284e1bb2b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33165",
+					"10.65.0.27:33165",
+					"172.17.0.1:33165",
+					"172.18.0.1:33165",
+					"172.19.0.1:33165",
+					"172.20.0.1:33165",
+					"172.21.0.1:33165",
+					"172.22.0.1:33165",
+					"172.23.0.1:33165",
+					"172.24.0.1:33165",
+					"172.25.0.1:33165",
+					"172.26.0.1:33165",
+					"172.27.0.1:33165",
+					"172.28.0.1:33165",
+					"172.29.0.1:33165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:08:57.437877673Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2121942722652951": {
+				"ID":          2121942722652951,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6381211525566936,
+				"StableID":   "nj4m5Ac4qr11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       6381211525566936,
+				"Key":        "nodekey:ba4bdeff5d35313d26131bd1e00e38d94105f2d2d204c657562260231fb91a18",
+				"DiscoKey":   "discokey:097063db9440512c70541de1a731980d4a34eddf48d97052d1e4866e9da65e09",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35952",
+					"10.65.0.27:35952",
+					"172.17.0.1:35952",
+					"172.18.0.1:35952",
+					"172.19.0.1:35952",
+					"172.20.0.1:35952",
+					"172.21.0.1:35952",
+					"172.22.0.1:35952",
+					"172.23.0.1:35952",
+					"172.24.0.1:35952",
+					"172.25.0.1:35952",
+					"172.26.0.1:35952",
+					"172.27.0.1:35952",
+					"172.28.0.1:35952",
+					"172.29.0.1:35952"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:08:50.43056034Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ba4bdeff5d35313d26131bd1e00e38d94105f2d2d204c657562260231fb91a18",
+			"MachineKey": "mkey:3b3f8bd08271f85b9c2712720615db5b9189ca0048be848e9ad28b47abd0fb23",
+			"Peers": [{
+				"ID":         7910850219715433,
+				"StableID":   "nWbyU1dqm421CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c38849001c818ec01ab3884fb726ba759429abde871ec71f9c654e8c633db73d",
+				"DiscoKey":   "discokey:a5158e8c031a96f17be128393a921f0a94a461d3c25b27caba71a07e90f19e69",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43331",
+					"10.65.0.27:43331",
+					"172.17.0.1:43331",
+					"172.18.0.1:43331",
+					"172.19.0.1:43331",
+					"172.20.0.1:43331",
+					"172.21.0.1:43331",
+					"172.22.0.1:43331",
+					"172.23.0.1:43331",
+					"172.24.0.1:43331",
+					"172.25.0.1:43331",
+					"172.26.0.1:43331",
+					"172.27.0.1:43331",
+					"172.28.0.1:43331",
+					"172.29.0.1:43331"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:08:49.936876938Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2437573544205684,
+				"StableID":   "noNL2avy2L11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7efd3b993cc568ba4d4e463aacc88c9e6e28595db86cc4bf968a22dbbce6154e",
+				"DiscoKey":   "discokey:93db8a82e3d64a77ff9d4aab6f194d68ed2bab893ef5b1c6a21f8776d75c120d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45990",
+					"10.65.0.27:45990",
+					"172.17.0.1:45990",
+					"172.18.0.1:45990",
+					"172.19.0.1:45990",
+					"172.20.0.1:45990",
+					"172.21.0.1:45990",
+					"172.22.0.1:45990",
+					"172.23.0.1:45990",
+					"172.24.0.1:45990",
+					"172.25.0.1:45990",
+					"172.26.0.1:45990",
+					"172.27.0.1:45990",
+					"172.28.0.1:45990",
+					"172.29.0.1:45990"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:08:50.973567256Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8072414054839639,
+				"StableID":   "nxXtLUd13621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1ce09e5497139ac52ccdbf6e6723e8ca61d7b0e939373c42f62d6669e865264",
+				"DiscoKey":   "discokey:f41dbf4aa82c85a3b684cc1562b75ee3d288cc3eab6e43beff65f5f5a203dd0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42593",
+					"10.65.0.27:42593",
+					"172.17.0.1:42593",
+					"172.18.0.1:42593",
+					"172.19.0.1:42593",
+					"172.20.0.1:42593",
+					"172.21.0.1:42593",
+					"172.22.0.1:42593",
+					"172.23.0.1:42593",
+					"172.24.0.1:42593",
+					"172.25.0.1:42593",
+					"172.26.0.1:42593",
+					"172.27.0.1:42593",
+					"172.28.0.1:42593",
+					"172.29.0.1:42593"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:08:51.519750495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         750134782054043,
+				"StableID":   "ncKWyamjr611CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0517119cfb430214a3965af8697e4b215e9ef9e6f7dc6af68e1629b66577ea75",
+				"DiscoKey":   "discokey:0d49066dd6ef215e5e40af4964900c9a38ddd2c0710f29ac0bbed0e637f0ec6b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:45651",
+					"10.65.0.27:45651",
+					"172.17.0.1:45651",
+					"172.18.0.1:45651",
+					"172.19.0.1:45651",
+					"172.20.0.1:45651",
+					"172.21.0.1:45651",
+					"172.22.0.1:45651",
+					"172.23.0.1:45651",
+					"172.24.0.1:45651",
+					"172.25.0.1:45651",
+					"172.26.0.1:45651",
+					"172.27.0.1:45651",
+					"172.28.0.1:45651",
+					"172.29.0.1:45651"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:08:52.067522041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         839150932034137,
+				"StableID":   "nxJwKB54Z711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0e0c28e146dd6e11cee7bd6ae352fc6307083541e4e9611baef9c388dcadb7c",
+				"DiscoKey":   "discokey:e44999b5edd3b672174f0f3ee207300641467bf3ee743dda8a6ec03ca3858d1d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44968",
+					"10.65.0.27:44968",
+					"172.17.0.1:44968",
+					"172.18.0.1:44968",
+					"172.19.0.1:44968",
+					"172.20.0.1:44968",
+					"172.21.0.1:44968",
+					"172.22.0.1:44968",
+					"172.23.0.1:44968",
+					"172.24.0.1:44968",
+					"172.25.0.1:44968",
+					"172.26.0.1:44968",
+					"172.27.0.1:44968",
+					"172.28.0.1:44968",
+					"172.29.0.1:44968"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:08:52.600909082Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8089791358291457,
+				"StableID":   "nibJ9s6tA621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3ab64f2d66959455a4bf55624555c1036e729bda4884e7c64c19b872017a0b24",
+				"DiscoKey":   "discokey:bf66d9922616d7f9186f43f321ae120c1fc3d92b0fd37194569b7e6c45917e60",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54929",
+					"10.65.0.27:54929",
+					"172.17.0.1:54929",
+					"172.18.0.1:54929",
+					"172.19.0.1:54929",
+					"172.20.0.1:54929",
+					"172.21.0.1:54929",
+					"172.22.0.1:54929",
+					"172.23.0.1:54929",
+					"172.24.0.1:54929",
+					"172.25.0.1:54929",
+					"172.26.0.1:54929",
+					"172.27.0.1:54929",
+					"172.28.0.1:54929",
+					"172.29.0.1:54929"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:08:53.136655738Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         264256607456368,
+				"StableID":   "n9qoVEag4311CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:914f7a4931682ca03a8382046587ee81000da788897acd3ea18f66907c5f022a",
+				"DiscoKey":   "discokey:04db6794db62b30f749673d0d53252ba1d0b344ff5e369904458aaf9542aa31e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33265",
+					"10.65.0.27:33265",
+					"172.17.0.1:33265",
+					"172.18.0.1:33265",
+					"172.19.0.1:33265",
+					"172.20.0.1:33265",
+					"172.21.0.1:33265",
+					"172.22.0.1:33265",
+					"172.23.0.1:33265",
+					"172.24.0.1:33265",
+					"172.25.0.1:33265",
+					"172.26.0.1:33265",
+					"172.27.0.1:33265",
+					"172.28.0.1:33265",
+					"172.29.0.1:33265"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:08:53.6659712Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7663614990686871,
+				"StableID":   "n6SoutAsq221CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:79e977f28aea31c07b128d887f62f17eb0706d96543f604a6bde62c977e8c93a",
+				"DiscoKey":   "discokey:56194a27fd68adb5985c6835a386f1899944932d8d3fe35d12ab95c687a4c31f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41401",
+					"10.65.0.27:41401",
+					"172.17.0.1:41401",
+					"172.18.0.1:41401",
+					"172.19.0.1:41401",
+					"172.20.0.1:41401",
+					"172.21.0.1:41401",
+					"172.22.0.1:41401",
+					"172.23.0.1:41401",
+					"172.24.0.1:41401",
+					"172.25.0.1:41401",
+					"172.26.0.1:41401",
+					"172.27.0.1:41401",
+					"172.28.0.1:41401",
+					"172.29.0.1:41401"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:08:54.190741062Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8861425300128914,
+				"StableID":   "ns3LFkcMCC21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4784b0e067b3c60e861aee9ab444086a3954473b09053363423a268f5982f533",
+				"DiscoKey":   "discokey:6b4ac603e565c79b1316fba83cad99d59fc6422523132d03b7ec18e4b16e8a1c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:32783",
+					"10.65.0.27:32783",
+					"172.17.0.1:32783",
+					"172.18.0.1:32783",
+					"172.19.0.1:32783",
+					"172.20.0.1:32783",
+					"172.21.0.1:32783",
+					"172.22.0.1:32783",
+					"172.23.0.1:32783",
+					"172.24.0.1:32783",
+					"172.25.0.1:32783",
+					"172.26.0.1:32783",
+					"172.27.0.1:32783",
+					"172.28.0.1:32783",
+					"172.29.0.1:32783"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:08:54.736224441Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2121942722652951,
+				"StableID":   "nNSf9Zq2aH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f36c3c3970962dfcc36ce6a541d4509d463971ab28c4109976925baa7c2b490f",
+				"DiscoKey":   "discokey:f99def593fda9b3d6cb7cb19f67e18c3d8a2c90eeb4dfd052708bfe4b0525f52",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:47554",
+					"10.65.0.27:47554",
+					"172.17.0.1:47554",
+					"172.18.0.1:47554",
+					"172.19.0.1:47554",
+					"172.20.0.1:47554",
+					"172.21.0.1:47554",
+					"172.22.0.1:47554",
+					"172.23.0.1:47554",
+					"172.24.0.1:47554",
+					"172.25.0.1:47554",
+					"172.26.0.1:47554",
+					"172.27.0.1:47554",
+					"172.28.0.1:47554",
+					"172.29.0.1:47554"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:08:55.262055371Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2824186552082163,
+				"StableID":   "nW8qdKb54P11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9e12cd5333229d8b262c24e639634f0b2640bb9ebcb6d54e062127e85d9634d",
+				"DiscoKey":   "discokey:a1895321d40bc0abe8bb7c50e2e19e954d6f79c952841cbb2264137c49cb2b43",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58140",
+					"10.65.0.27:58140",
+					"172.17.0.1:58140",
+					"172.18.0.1:58140",
+					"172.19.0.1:58140",
+					"172.20.0.1:58140",
+					"172.21.0.1:58140",
+					"172.22.0.1:58140",
+					"172.23.0.1:58140",
+					"172.24.0.1:58140",
+					"172.25.0.1:58140",
+					"172.26.0.1:58140",
+					"172.27.0.1:58140",
+					"172.28.0.1:58140",
+					"172.29.0.1:58140"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:08:55.803917237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4537882512937851,
+				"StableID":   "nGqLRmUDSc11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f077b56a647585f47d513ae290d2e5a2fb6eda9528d80805eacb32597d18d119",
+				"KeyExpiry":  "2026-11-09T09:08:56Z",
+				"DiscoKey":   "discokey:ab946cb435f8bc1678f756256fd0cbd141b60ae9d95a1f8ebea2d9bafe5a7237",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:42345",
+					"10.65.0.27:42345",
+					"172.17.0.1:42345",
+					"172.18.0.1:42345",
+					"172.19.0.1:42345",
+					"172.20.0.1:42345",
+					"172.21.0.1:42345",
+					"172.22.0.1:42345",
+					"172.23.0.1:42345",
+					"172.24.0.1:42345",
+					"172.25.0.1:42345",
+					"172.26.0.1:42345",
+					"172.27.0.1:42345",
+					"172.28.0.1:42345",
+					"172.29.0.1:42345"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:08:56.351352972Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1999870809800905,
+				"StableID":   "nt68EUDkcG11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6cdda19e804be5e2cd8f526ebed38e87594983f6271578fd06b30dc824beae1c",
+				"KeyExpiry":  "2026-11-09T09:08:56Z",
+				"DiscoKey":   "discokey:600398c30ac3534d44775a86afb7555cdeb2cf8caa8250cd98a7fe05aa0a5a54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38381",
+					"10.65.0.27:38381",
+					"172.17.0.1:38381",
+					"172.18.0.1:38381",
+					"172.19.0.1:38381",
+					"172.20.0.1:38381",
+					"172.21.0.1:38381",
+					"172.22.0.1:38381",
+					"172.23.0.1:38381",
+					"172.24.0.1:38381",
+					"172.25.0.1:38381",
+					"172.26.0.1:38381",
+					"172.27.0.1:38381",
+					"172.28.0.1:38381",
+					"172.29.0.1:38381"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:08:56.900863642Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6973026628775446,
+				"StableID":   "nXPGBxa6Tw11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d5d8fefebcb8420b272565ade83a1d37b7c82ea35b29f4448a561e3610ca3b60",
+				"KeyExpiry":  "2026-11-09T09:08:57Z",
+				"DiscoKey":   "discokey:a2aaaf10268009cf085a278300b0b82060d85f62dcc68d3d35683f1284e1bb2b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33165",
+					"10.65.0.27:33165",
+					"172.17.0.1:33165",
+					"172.18.0.1:33165",
+					"172.19.0.1:33165",
+					"172.20.0.1:33165",
+					"172.21.0.1:33165",
+					"172.22.0.1:33165",
+					"172.23.0.1:33165",
+					"172.24.0.1:33165",
+					"172.25.0.1:33165",
+					"172.26.0.1:33165",
+					"172.27.0.1:33165",
+					"172.28.0.1:33165",
+					"172.29.0.1:33165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:08:57.437877673Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6381211525566936": {
+				"ID":          6381211525566936,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7910850219715433,
+				"StableID":   "nWbyU1dqm421CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       7910850219715433,
+				"Key":        "nodekey:c38849001c818ec01ab3884fb726ba759429abde871ec71f9c654e8c633db73d",
+				"DiscoKey":   "discokey:a5158e8c031a96f17be128393a921f0a94a461d3c25b27caba71a07e90f19e69",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43331",
+					"10.65.0.27:43331",
+					"172.17.0.1:43331",
+					"172.18.0.1:43331",
+					"172.19.0.1:43331",
+					"172.20.0.1:43331",
+					"172.21.0.1:43331",
+					"172.22.0.1:43331",
+					"172.23.0.1:43331",
+					"172.24.0.1:43331",
+					"172.25.0.1:43331",
+					"172.26.0.1:43331",
+					"172.27.0.1:43331",
+					"172.28.0.1:43331",
+					"172.29.0.1:43331"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:08:49.936876938Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c38849001c818ec01ab3884fb726ba759429abde871ec71f9c654e8c633db73d",
+			"MachineKey": "mkey:79c252b4246dc739409c1c5c30bd8b23f3ee2b884b47b561e64af1136b69326d",
+			"Peers": [{
+				"ID":         6381211525566936,
+				"StableID":   "nj4m5Ac4qr11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba4bdeff5d35313d26131bd1e00e38d94105f2d2d204c657562260231fb91a18",
+				"DiscoKey":   "discokey:097063db9440512c70541de1a731980d4a34eddf48d97052d1e4866e9da65e09",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35952",
+					"10.65.0.27:35952",
+					"172.17.0.1:35952",
+					"172.18.0.1:35952",
+					"172.19.0.1:35952",
+					"172.20.0.1:35952",
+					"172.21.0.1:35952",
+					"172.22.0.1:35952",
+					"172.23.0.1:35952",
+					"172.24.0.1:35952",
+					"172.25.0.1:35952",
+					"172.26.0.1:35952",
+					"172.27.0.1:35952",
+					"172.28.0.1:35952",
+					"172.29.0.1:35952"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:08:50.43056034Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2437573544205684,
+				"StableID":   "noNL2avy2L11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7efd3b993cc568ba4d4e463aacc88c9e6e28595db86cc4bf968a22dbbce6154e",
+				"DiscoKey":   "discokey:93db8a82e3d64a77ff9d4aab6f194d68ed2bab893ef5b1c6a21f8776d75c120d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45990",
+					"10.65.0.27:45990",
+					"172.17.0.1:45990",
+					"172.18.0.1:45990",
+					"172.19.0.1:45990",
+					"172.20.0.1:45990",
+					"172.21.0.1:45990",
+					"172.22.0.1:45990",
+					"172.23.0.1:45990",
+					"172.24.0.1:45990",
+					"172.25.0.1:45990",
+					"172.26.0.1:45990",
+					"172.27.0.1:45990",
+					"172.28.0.1:45990",
+					"172.29.0.1:45990"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:08:50.973567256Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8072414054839639,
+				"StableID":   "nxXtLUd13621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1ce09e5497139ac52ccdbf6e6723e8ca61d7b0e939373c42f62d6669e865264",
+				"DiscoKey":   "discokey:f41dbf4aa82c85a3b684cc1562b75ee3d288cc3eab6e43beff65f5f5a203dd0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42593",
+					"10.65.0.27:42593",
+					"172.17.0.1:42593",
+					"172.18.0.1:42593",
+					"172.19.0.1:42593",
+					"172.20.0.1:42593",
+					"172.21.0.1:42593",
+					"172.22.0.1:42593",
+					"172.23.0.1:42593",
+					"172.24.0.1:42593",
+					"172.25.0.1:42593",
+					"172.26.0.1:42593",
+					"172.27.0.1:42593",
+					"172.28.0.1:42593",
+					"172.29.0.1:42593"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:08:51.519750495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         750134782054043,
+				"StableID":   "ncKWyamjr611CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0517119cfb430214a3965af8697e4b215e9ef9e6f7dc6af68e1629b66577ea75",
+				"DiscoKey":   "discokey:0d49066dd6ef215e5e40af4964900c9a38ddd2c0710f29ac0bbed0e637f0ec6b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:45651",
+					"10.65.0.27:45651",
+					"172.17.0.1:45651",
+					"172.18.0.1:45651",
+					"172.19.0.1:45651",
+					"172.20.0.1:45651",
+					"172.21.0.1:45651",
+					"172.22.0.1:45651",
+					"172.23.0.1:45651",
+					"172.24.0.1:45651",
+					"172.25.0.1:45651",
+					"172.26.0.1:45651",
+					"172.27.0.1:45651",
+					"172.28.0.1:45651",
+					"172.29.0.1:45651"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:08:52.067522041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         839150932034137,
+				"StableID":   "nxJwKB54Z711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0e0c28e146dd6e11cee7bd6ae352fc6307083541e4e9611baef9c388dcadb7c",
+				"DiscoKey":   "discokey:e44999b5edd3b672174f0f3ee207300641467bf3ee743dda8a6ec03ca3858d1d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44968",
+					"10.65.0.27:44968",
+					"172.17.0.1:44968",
+					"172.18.0.1:44968",
+					"172.19.0.1:44968",
+					"172.20.0.1:44968",
+					"172.21.0.1:44968",
+					"172.22.0.1:44968",
+					"172.23.0.1:44968",
+					"172.24.0.1:44968",
+					"172.25.0.1:44968",
+					"172.26.0.1:44968",
+					"172.27.0.1:44968",
+					"172.28.0.1:44968",
+					"172.29.0.1:44968"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:08:52.600909082Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8089791358291457,
+				"StableID":   "nibJ9s6tA621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3ab64f2d66959455a4bf55624555c1036e729bda4884e7c64c19b872017a0b24",
+				"DiscoKey":   "discokey:bf66d9922616d7f9186f43f321ae120c1fc3d92b0fd37194569b7e6c45917e60",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54929",
+					"10.65.0.27:54929",
+					"172.17.0.1:54929",
+					"172.18.0.1:54929",
+					"172.19.0.1:54929",
+					"172.20.0.1:54929",
+					"172.21.0.1:54929",
+					"172.22.0.1:54929",
+					"172.23.0.1:54929",
+					"172.24.0.1:54929",
+					"172.25.0.1:54929",
+					"172.26.0.1:54929",
+					"172.27.0.1:54929",
+					"172.28.0.1:54929",
+					"172.29.0.1:54929"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:08:53.136655738Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         264256607456368,
+				"StableID":   "n9qoVEag4311CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:914f7a4931682ca03a8382046587ee81000da788897acd3ea18f66907c5f022a",
+				"DiscoKey":   "discokey:04db6794db62b30f749673d0d53252ba1d0b344ff5e369904458aaf9542aa31e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33265",
+					"10.65.0.27:33265",
+					"172.17.0.1:33265",
+					"172.18.0.1:33265",
+					"172.19.0.1:33265",
+					"172.20.0.1:33265",
+					"172.21.0.1:33265",
+					"172.22.0.1:33265",
+					"172.23.0.1:33265",
+					"172.24.0.1:33265",
+					"172.25.0.1:33265",
+					"172.26.0.1:33265",
+					"172.27.0.1:33265",
+					"172.28.0.1:33265",
+					"172.29.0.1:33265"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:08:53.6659712Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7663614990686871,
+				"StableID":   "n6SoutAsq221CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:79e977f28aea31c07b128d887f62f17eb0706d96543f604a6bde62c977e8c93a",
+				"DiscoKey":   "discokey:56194a27fd68adb5985c6835a386f1899944932d8d3fe35d12ab95c687a4c31f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41401",
+					"10.65.0.27:41401",
+					"172.17.0.1:41401",
+					"172.18.0.1:41401",
+					"172.19.0.1:41401",
+					"172.20.0.1:41401",
+					"172.21.0.1:41401",
+					"172.22.0.1:41401",
+					"172.23.0.1:41401",
+					"172.24.0.1:41401",
+					"172.25.0.1:41401",
+					"172.26.0.1:41401",
+					"172.27.0.1:41401",
+					"172.28.0.1:41401",
+					"172.29.0.1:41401"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:08:54.190741062Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8861425300128914,
+				"StableID":   "ns3LFkcMCC21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4784b0e067b3c60e861aee9ab444086a3954473b09053363423a268f5982f533",
+				"DiscoKey":   "discokey:6b4ac603e565c79b1316fba83cad99d59fc6422523132d03b7ec18e4b16e8a1c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:32783",
+					"10.65.0.27:32783",
+					"172.17.0.1:32783",
+					"172.18.0.1:32783",
+					"172.19.0.1:32783",
+					"172.20.0.1:32783",
+					"172.21.0.1:32783",
+					"172.22.0.1:32783",
+					"172.23.0.1:32783",
+					"172.24.0.1:32783",
+					"172.25.0.1:32783",
+					"172.26.0.1:32783",
+					"172.27.0.1:32783",
+					"172.28.0.1:32783",
+					"172.29.0.1:32783"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:08:54.736224441Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2121942722652951,
+				"StableID":   "nNSf9Zq2aH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f36c3c3970962dfcc36ce6a541d4509d463971ab28c4109976925baa7c2b490f",
+				"DiscoKey":   "discokey:f99def593fda9b3d6cb7cb19f67e18c3d8a2c90eeb4dfd052708bfe4b0525f52",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:47554",
+					"10.65.0.27:47554",
+					"172.17.0.1:47554",
+					"172.18.0.1:47554",
+					"172.19.0.1:47554",
+					"172.20.0.1:47554",
+					"172.21.0.1:47554",
+					"172.22.0.1:47554",
+					"172.23.0.1:47554",
+					"172.24.0.1:47554",
+					"172.25.0.1:47554",
+					"172.26.0.1:47554",
+					"172.27.0.1:47554",
+					"172.28.0.1:47554",
+					"172.29.0.1:47554"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:08:55.262055371Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2824186552082163,
+				"StableID":   "nW8qdKb54P11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9e12cd5333229d8b262c24e639634f0b2640bb9ebcb6d54e062127e85d9634d",
+				"DiscoKey":   "discokey:a1895321d40bc0abe8bb7c50e2e19e954d6f79c952841cbb2264137c49cb2b43",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58140",
+					"10.65.0.27:58140",
+					"172.17.0.1:58140",
+					"172.18.0.1:58140",
+					"172.19.0.1:58140",
+					"172.20.0.1:58140",
+					"172.21.0.1:58140",
+					"172.22.0.1:58140",
+					"172.23.0.1:58140",
+					"172.24.0.1:58140",
+					"172.25.0.1:58140",
+					"172.26.0.1:58140",
+					"172.27.0.1:58140",
+					"172.28.0.1:58140",
+					"172.29.0.1:58140"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:08:55.803917237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4537882512937851,
+				"StableID":   "nGqLRmUDSc11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f077b56a647585f47d513ae290d2e5a2fb6eda9528d80805eacb32597d18d119",
+				"KeyExpiry":  "2026-11-09T09:08:56Z",
+				"DiscoKey":   "discokey:ab946cb435f8bc1678f756256fd0cbd141b60ae9d95a1f8ebea2d9bafe5a7237",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:42345",
+					"10.65.0.27:42345",
+					"172.17.0.1:42345",
+					"172.18.0.1:42345",
+					"172.19.0.1:42345",
+					"172.20.0.1:42345",
+					"172.21.0.1:42345",
+					"172.22.0.1:42345",
+					"172.23.0.1:42345",
+					"172.24.0.1:42345",
+					"172.25.0.1:42345",
+					"172.26.0.1:42345",
+					"172.27.0.1:42345",
+					"172.28.0.1:42345",
+					"172.29.0.1:42345"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:08:56.351352972Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1999870809800905,
+				"StableID":   "nt68EUDkcG11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6cdda19e804be5e2cd8f526ebed38e87594983f6271578fd06b30dc824beae1c",
+				"KeyExpiry":  "2026-11-09T09:08:56Z",
+				"DiscoKey":   "discokey:600398c30ac3534d44775a86afb7555cdeb2cf8caa8250cd98a7fe05aa0a5a54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38381",
+					"10.65.0.27:38381",
+					"172.17.0.1:38381",
+					"172.18.0.1:38381",
+					"172.19.0.1:38381",
+					"172.20.0.1:38381",
+					"172.21.0.1:38381",
+					"172.22.0.1:38381",
+					"172.23.0.1:38381",
+					"172.24.0.1:38381",
+					"172.25.0.1:38381",
+					"172.26.0.1:38381",
+					"172.27.0.1:38381",
+					"172.28.0.1:38381",
+					"172.29.0.1:38381"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:08:56.900863642Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6973026628775446,
+				"StableID":   "nXPGBxa6Tw11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d5d8fefebcb8420b272565ade83a1d37b7c82ea35b29f4448a561e3610ca3b60",
+				"KeyExpiry":  "2026-11-09T09:08:57Z",
+				"DiscoKey":   "discokey:a2aaaf10268009cf085a278300b0b82060d85f62dcc68d3d35683f1284e1bb2b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33165",
+					"10.65.0.27:33165",
+					"172.17.0.1:33165",
+					"172.18.0.1:33165",
+					"172.19.0.1:33165",
+					"172.20.0.1:33165",
+					"172.21.0.1:33165",
+					"172.22.0.1:33165",
+					"172.23.0.1:33165",
+					"172.24.0.1:33165",
+					"172.25.0.1:33165",
+					"172.26.0.1:33165",
+					"172.27.0.1:33165",
+					"172.28.0.1:33165",
+					"172.29.0.1:33165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:08:57.437877673Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7910850219715433": {
+				"ID":          7910850219715433,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         750134782054043,
+				"StableID":   "ncKWyamjr611CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       750134782054043,
+				"Key":        "nodekey:0517119cfb430214a3965af8697e4b215e9ef9e6f7dc6af68e1629b66577ea75",
+				"DiscoKey":   "discokey:0d49066dd6ef215e5e40af4964900c9a38ddd2c0710f29ac0bbed0e637f0ec6b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:45651",
+					"10.65.0.27:45651",
+					"172.17.0.1:45651",
+					"172.18.0.1:45651",
+					"172.19.0.1:45651",
+					"172.20.0.1:45651",
+					"172.21.0.1:45651",
+					"172.22.0.1:45651",
+					"172.23.0.1:45651",
+					"172.24.0.1:45651",
+					"172.25.0.1:45651",
+					"172.26.0.1:45651",
+					"172.27.0.1:45651",
+					"172.28.0.1:45651",
+					"172.29.0.1:45651"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:08:52.067522041Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0517119cfb430214a3965af8697e4b215e9ef9e6f7dc6af68e1629b66577ea75",
+			"MachineKey": "mkey:82531ce3884effb987d5c38dfc35a3617e92a5809b9f90ccec8c4f2bfa281b22",
+			"Peers": [{
+				"ID":         7910850219715433,
+				"StableID":   "nWbyU1dqm421CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c38849001c818ec01ab3884fb726ba759429abde871ec71f9c654e8c633db73d",
+				"DiscoKey":   "discokey:a5158e8c031a96f17be128393a921f0a94a461d3c25b27caba71a07e90f19e69",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43331",
+					"10.65.0.27:43331",
+					"172.17.0.1:43331",
+					"172.18.0.1:43331",
+					"172.19.0.1:43331",
+					"172.20.0.1:43331",
+					"172.21.0.1:43331",
+					"172.22.0.1:43331",
+					"172.23.0.1:43331",
+					"172.24.0.1:43331",
+					"172.25.0.1:43331",
+					"172.26.0.1:43331",
+					"172.27.0.1:43331",
+					"172.28.0.1:43331",
+					"172.29.0.1:43331"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:08:49.936876938Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6381211525566936,
+				"StableID":   "nj4m5Ac4qr11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba4bdeff5d35313d26131bd1e00e38d94105f2d2d204c657562260231fb91a18",
+				"DiscoKey":   "discokey:097063db9440512c70541de1a731980d4a34eddf48d97052d1e4866e9da65e09",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35952",
+					"10.65.0.27:35952",
+					"172.17.0.1:35952",
+					"172.18.0.1:35952",
+					"172.19.0.1:35952",
+					"172.20.0.1:35952",
+					"172.21.0.1:35952",
+					"172.22.0.1:35952",
+					"172.23.0.1:35952",
+					"172.24.0.1:35952",
+					"172.25.0.1:35952",
+					"172.26.0.1:35952",
+					"172.27.0.1:35952",
+					"172.28.0.1:35952",
+					"172.29.0.1:35952"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:08:50.43056034Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2437573544205684,
+				"StableID":   "noNL2avy2L11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7efd3b993cc568ba4d4e463aacc88c9e6e28595db86cc4bf968a22dbbce6154e",
+				"DiscoKey":   "discokey:93db8a82e3d64a77ff9d4aab6f194d68ed2bab893ef5b1c6a21f8776d75c120d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45990",
+					"10.65.0.27:45990",
+					"172.17.0.1:45990",
+					"172.18.0.1:45990",
+					"172.19.0.1:45990",
+					"172.20.0.1:45990",
+					"172.21.0.1:45990",
+					"172.22.0.1:45990",
+					"172.23.0.1:45990",
+					"172.24.0.1:45990",
+					"172.25.0.1:45990",
+					"172.26.0.1:45990",
+					"172.27.0.1:45990",
+					"172.28.0.1:45990",
+					"172.29.0.1:45990"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:08:50.973567256Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8072414054839639,
+				"StableID":   "nxXtLUd13621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1ce09e5497139ac52ccdbf6e6723e8ca61d7b0e939373c42f62d6669e865264",
+				"DiscoKey":   "discokey:f41dbf4aa82c85a3b684cc1562b75ee3d288cc3eab6e43beff65f5f5a203dd0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42593",
+					"10.65.0.27:42593",
+					"172.17.0.1:42593",
+					"172.18.0.1:42593",
+					"172.19.0.1:42593",
+					"172.20.0.1:42593",
+					"172.21.0.1:42593",
+					"172.22.0.1:42593",
+					"172.23.0.1:42593",
+					"172.24.0.1:42593",
+					"172.25.0.1:42593",
+					"172.26.0.1:42593",
+					"172.27.0.1:42593",
+					"172.28.0.1:42593",
+					"172.29.0.1:42593"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:08:51.519750495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         839150932034137,
+				"StableID":   "nxJwKB54Z711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0e0c28e146dd6e11cee7bd6ae352fc6307083541e4e9611baef9c388dcadb7c",
+				"DiscoKey":   "discokey:e44999b5edd3b672174f0f3ee207300641467bf3ee743dda8a6ec03ca3858d1d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44968",
+					"10.65.0.27:44968",
+					"172.17.0.1:44968",
+					"172.18.0.1:44968",
+					"172.19.0.1:44968",
+					"172.20.0.1:44968",
+					"172.21.0.1:44968",
+					"172.22.0.1:44968",
+					"172.23.0.1:44968",
+					"172.24.0.1:44968",
+					"172.25.0.1:44968",
+					"172.26.0.1:44968",
+					"172.27.0.1:44968",
+					"172.28.0.1:44968",
+					"172.29.0.1:44968"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:08:52.600909082Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8089791358291457,
+				"StableID":   "nibJ9s6tA621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3ab64f2d66959455a4bf55624555c1036e729bda4884e7c64c19b872017a0b24",
+				"DiscoKey":   "discokey:bf66d9922616d7f9186f43f321ae120c1fc3d92b0fd37194569b7e6c45917e60",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54929",
+					"10.65.0.27:54929",
+					"172.17.0.1:54929",
+					"172.18.0.1:54929",
+					"172.19.0.1:54929",
+					"172.20.0.1:54929",
+					"172.21.0.1:54929",
+					"172.22.0.1:54929",
+					"172.23.0.1:54929",
+					"172.24.0.1:54929",
+					"172.25.0.1:54929",
+					"172.26.0.1:54929",
+					"172.27.0.1:54929",
+					"172.28.0.1:54929",
+					"172.29.0.1:54929"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:08:53.136655738Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         264256607456368,
+				"StableID":   "n9qoVEag4311CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:914f7a4931682ca03a8382046587ee81000da788897acd3ea18f66907c5f022a",
+				"DiscoKey":   "discokey:04db6794db62b30f749673d0d53252ba1d0b344ff5e369904458aaf9542aa31e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33265",
+					"10.65.0.27:33265",
+					"172.17.0.1:33265",
+					"172.18.0.1:33265",
+					"172.19.0.1:33265",
+					"172.20.0.1:33265",
+					"172.21.0.1:33265",
+					"172.22.0.1:33265",
+					"172.23.0.1:33265",
+					"172.24.0.1:33265",
+					"172.25.0.1:33265",
+					"172.26.0.1:33265",
+					"172.27.0.1:33265",
+					"172.28.0.1:33265",
+					"172.29.0.1:33265"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:08:53.6659712Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7663614990686871,
+				"StableID":   "n6SoutAsq221CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:79e977f28aea31c07b128d887f62f17eb0706d96543f604a6bde62c977e8c93a",
+				"DiscoKey":   "discokey:56194a27fd68adb5985c6835a386f1899944932d8d3fe35d12ab95c687a4c31f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41401",
+					"10.65.0.27:41401",
+					"172.17.0.1:41401",
+					"172.18.0.1:41401",
+					"172.19.0.1:41401",
+					"172.20.0.1:41401",
+					"172.21.0.1:41401",
+					"172.22.0.1:41401",
+					"172.23.0.1:41401",
+					"172.24.0.1:41401",
+					"172.25.0.1:41401",
+					"172.26.0.1:41401",
+					"172.27.0.1:41401",
+					"172.28.0.1:41401",
+					"172.29.0.1:41401"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:08:54.190741062Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8861425300128914,
+				"StableID":   "ns3LFkcMCC21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4784b0e067b3c60e861aee9ab444086a3954473b09053363423a268f5982f533",
+				"DiscoKey":   "discokey:6b4ac603e565c79b1316fba83cad99d59fc6422523132d03b7ec18e4b16e8a1c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:32783",
+					"10.65.0.27:32783",
+					"172.17.0.1:32783",
+					"172.18.0.1:32783",
+					"172.19.0.1:32783",
+					"172.20.0.1:32783",
+					"172.21.0.1:32783",
+					"172.22.0.1:32783",
+					"172.23.0.1:32783",
+					"172.24.0.1:32783",
+					"172.25.0.1:32783",
+					"172.26.0.1:32783",
+					"172.27.0.1:32783",
+					"172.28.0.1:32783",
+					"172.29.0.1:32783"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:08:54.736224441Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2121942722652951,
+				"StableID":   "nNSf9Zq2aH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f36c3c3970962dfcc36ce6a541d4509d463971ab28c4109976925baa7c2b490f",
+				"DiscoKey":   "discokey:f99def593fda9b3d6cb7cb19f67e18c3d8a2c90eeb4dfd052708bfe4b0525f52",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:47554",
+					"10.65.0.27:47554",
+					"172.17.0.1:47554",
+					"172.18.0.1:47554",
+					"172.19.0.1:47554",
+					"172.20.0.1:47554",
+					"172.21.0.1:47554",
+					"172.22.0.1:47554",
+					"172.23.0.1:47554",
+					"172.24.0.1:47554",
+					"172.25.0.1:47554",
+					"172.26.0.1:47554",
+					"172.27.0.1:47554",
+					"172.28.0.1:47554",
+					"172.29.0.1:47554"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:08:55.262055371Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2824186552082163,
+				"StableID":   "nW8qdKb54P11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9e12cd5333229d8b262c24e639634f0b2640bb9ebcb6d54e062127e85d9634d",
+				"DiscoKey":   "discokey:a1895321d40bc0abe8bb7c50e2e19e954d6f79c952841cbb2264137c49cb2b43",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58140",
+					"10.65.0.27:58140",
+					"172.17.0.1:58140",
+					"172.18.0.1:58140",
+					"172.19.0.1:58140",
+					"172.20.0.1:58140",
+					"172.21.0.1:58140",
+					"172.22.0.1:58140",
+					"172.23.0.1:58140",
+					"172.24.0.1:58140",
+					"172.25.0.1:58140",
+					"172.26.0.1:58140",
+					"172.27.0.1:58140",
+					"172.28.0.1:58140",
+					"172.29.0.1:58140"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:08:55.803917237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4537882512937851,
+				"StableID":   "nGqLRmUDSc11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f077b56a647585f47d513ae290d2e5a2fb6eda9528d80805eacb32597d18d119",
+				"KeyExpiry":  "2026-11-09T09:08:56Z",
+				"DiscoKey":   "discokey:ab946cb435f8bc1678f756256fd0cbd141b60ae9d95a1f8ebea2d9bafe5a7237",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:42345",
+					"10.65.0.27:42345",
+					"172.17.0.1:42345",
+					"172.18.0.1:42345",
+					"172.19.0.1:42345",
+					"172.20.0.1:42345",
+					"172.21.0.1:42345",
+					"172.22.0.1:42345",
+					"172.23.0.1:42345",
+					"172.24.0.1:42345",
+					"172.25.0.1:42345",
+					"172.26.0.1:42345",
+					"172.27.0.1:42345",
+					"172.28.0.1:42345",
+					"172.29.0.1:42345"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:08:56.351352972Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1999870809800905,
+				"StableID":   "nt68EUDkcG11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6cdda19e804be5e2cd8f526ebed38e87594983f6271578fd06b30dc824beae1c",
+				"KeyExpiry":  "2026-11-09T09:08:56Z",
+				"DiscoKey":   "discokey:600398c30ac3534d44775a86afb7555cdeb2cf8caa8250cd98a7fe05aa0a5a54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38381",
+					"10.65.0.27:38381",
+					"172.17.0.1:38381",
+					"172.18.0.1:38381",
+					"172.19.0.1:38381",
+					"172.20.0.1:38381",
+					"172.21.0.1:38381",
+					"172.22.0.1:38381",
+					"172.23.0.1:38381",
+					"172.24.0.1:38381",
+					"172.25.0.1:38381",
+					"172.26.0.1:38381",
+					"172.27.0.1:38381",
+					"172.28.0.1:38381",
+					"172.29.0.1:38381"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:08:56.900863642Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6973026628775446,
+				"StableID":   "nXPGBxa6Tw11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d5d8fefebcb8420b272565ade83a1d37b7c82ea35b29f4448a561e3610ca3b60",
+				"KeyExpiry":  "2026-11-09T09:08:57Z",
+				"DiscoKey":   "discokey:a2aaaf10268009cf085a278300b0b82060d85f62dcc68d3d35683f1284e1bb2b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33165",
+					"10.65.0.27:33165",
+					"172.17.0.1:33165",
+					"172.18.0.1:33165",
+					"172.19.0.1:33165",
+					"172.20.0.1:33165",
+					"172.21.0.1:33165",
+					"172.22.0.1:33165",
+					"172.23.0.1:33165",
+					"172.24.0.1:33165",
+					"172.25.0.1:33165",
+					"172.26.0.1:33165",
+					"172.27.0.1:33165",
+					"172.28.0.1:33165",
+					"172.29.0.1:33165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:08:57.437877673Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "750134782054043": {
+				"ID":          750134782054043,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8072414054839639,
+				"StableID":   "nxXtLUd13621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       8072414054839639,
+				"Key":        "nodekey:d1ce09e5497139ac52ccdbf6e6723e8ca61d7b0e939373c42f62d6669e865264",
+				"DiscoKey":   "discokey:f41dbf4aa82c85a3b684cc1562b75ee3d288cc3eab6e43beff65f5f5a203dd0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42593",
+					"10.65.0.27:42593",
+					"172.17.0.1:42593",
+					"172.18.0.1:42593",
+					"172.19.0.1:42593",
+					"172.20.0.1:42593",
+					"172.21.0.1:42593",
+					"172.22.0.1:42593",
+					"172.23.0.1:42593",
+					"172.24.0.1:42593",
+					"172.25.0.1:42593",
+					"172.26.0.1:42593",
+					"172.27.0.1:42593",
+					"172.28.0.1:42593",
+					"172.29.0.1:42593"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:08:51.519750495Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d1ce09e5497139ac52ccdbf6e6723e8ca61d7b0e939373c42f62d6669e865264",
+			"MachineKey": "mkey:928b432b52ea8b6c707e00d46a7c708ab23dd9f64cc26a2468a8e8bd7fada86e",
+			"Peers": [{
+				"ID":         7910850219715433,
+				"StableID":   "nWbyU1dqm421CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c38849001c818ec01ab3884fb726ba759429abde871ec71f9c654e8c633db73d",
+				"DiscoKey":   "discokey:a5158e8c031a96f17be128393a921f0a94a461d3c25b27caba71a07e90f19e69",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43331",
+					"10.65.0.27:43331",
+					"172.17.0.1:43331",
+					"172.18.0.1:43331",
+					"172.19.0.1:43331",
+					"172.20.0.1:43331",
+					"172.21.0.1:43331",
+					"172.22.0.1:43331",
+					"172.23.0.1:43331",
+					"172.24.0.1:43331",
+					"172.25.0.1:43331",
+					"172.26.0.1:43331",
+					"172.27.0.1:43331",
+					"172.28.0.1:43331",
+					"172.29.0.1:43331"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:08:49.936876938Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6381211525566936,
+				"StableID":   "nj4m5Ac4qr11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba4bdeff5d35313d26131bd1e00e38d94105f2d2d204c657562260231fb91a18",
+				"DiscoKey":   "discokey:097063db9440512c70541de1a731980d4a34eddf48d97052d1e4866e9da65e09",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35952",
+					"10.65.0.27:35952",
+					"172.17.0.1:35952",
+					"172.18.0.1:35952",
+					"172.19.0.1:35952",
+					"172.20.0.1:35952",
+					"172.21.0.1:35952",
+					"172.22.0.1:35952",
+					"172.23.0.1:35952",
+					"172.24.0.1:35952",
+					"172.25.0.1:35952",
+					"172.26.0.1:35952",
+					"172.27.0.1:35952",
+					"172.28.0.1:35952",
+					"172.29.0.1:35952"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:08:50.43056034Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2437573544205684,
+				"StableID":   "noNL2avy2L11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7efd3b993cc568ba4d4e463aacc88c9e6e28595db86cc4bf968a22dbbce6154e",
+				"DiscoKey":   "discokey:93db8a82e3d64a77ff9d4aab6f194d68ed2bab893ef5b1c6a21f8776d75c120d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45990",
+					"10.65.0.27:45990",
+					"172.17.0.1:45990",
+					"172.18.0.1:45990",
+					"172.19.0.1:45990",
+					"172.20.0.1:45990",
+					"172.21.0.1:45990",
+					"172.22.0.1:45990",
+					"172.23.0.1:45990",
+					"172.24.0.1:45990",
+					"172.25.0.1:45990",
+					"172.26.0.1:45990",
+					"172.27.0.1:45990",
+					"172.28.0.1:45990",
+					"172.29.0.1:45990"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:08:50.973567256Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         750134782054043,
+				"StableID":   "ncKWyamjr611CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0517119cfb430214a3965af8697e4b215e9ef9e6f7dc6af68e1629b66577ea75",
+				"DiscoKey":   "discokey:0d49066dd6ef215e5e40af4964900c9a38ddd2c0710f29ac0bbed0e637f0ec6b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:45651",
+					"10.65.0.27:45651",
+					"172.17.0.1:45651",
+					"172.18.0.1:45651",
+					"172.19.0.1:45651",
+					"172.20.0.1:45651",
+					"172.21.0.1:45651",
+					"172.22.0.1:45651",
+					"172.23.0.1:45651",
+					"172.24.0.1:45651",
+					"172.25.0.1:45651",
+					"172.26.0.1:45651",
+					"172.27.0.1:45651",
+					"172.28.0.1:45651",
+					"172.29.0.1:45651"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:08:52.067522041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         839150932034137,
+				"StableID":   "nxJwKB54Z711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0e0c28e146dd6e11cee7bd6ae352fc6307083541e4e9611baef9c388dcadb7c",
+				"DiscoKey":   "discokey:e44999b5edd3b672174f0f3ee207300641467bf3ee743dda8a6ec03ca3858d1d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44968",
+					"10.65.0.27:44968",
+					"172.17.0.1:44968",
+					"172.18.0.1:44968",
+					"172.19.0.1:44968",
+					"172.20.0.1:44968",
+					"172.21.0.1:44968",
+					"172.22.0.1:44968",
+					"172.23.0.1:44968",
+					"172.24.0.1:44968",
+					"172.25.0.1:44968",
+					"172.26.0.1:44968",
+					"172.27.0.1:44968",
+					"172.28.0.1:44968",
+					"172.29.0.1:44968"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:08:52.600909082Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8089791358291457,
+				"StableID":   "nibJ9s6tA621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3ab64f2d66959455a4bf55624555c1036e729bda4884e7c64c19b872017a0b24",
+				"DiscoKey":   "discokey:bf66d9922616d7f9186f43f321ae120c1fc3d92b0fd37194569b7e6c45917e60",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54929",
+					"10.65.0.27:54929",
+					"172.17.0.1:54929",
+					"172.18.0.1:54929",
+					"172.19.0.1:54929",
+					"172.20.0.1:54929",
+					"172.21.0.1:54929",
+					"172.22.0.1:54929",
+					"172.23.0.1:54929",
+					"172.24.0.1:54929",
+					"172.25.0.1:54929",
+					"172.26.0.1:54929",
+					"172.27.0.1:54929",
+					"172.28.0.1:54929",
+					"172.29.0.1:54929"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:08:53.136655738Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         264256607456368,
+				"StableID":   "n9qoVEag4311CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:914f7a4931682ca03a8382046587ee81000da788897acd3ea18f66907c5f022a",
+				"DiscoKey":   "discokey:04db6794db62b30f749673d0d53252ba1d0b344ff5e369904458aaf9542aa31e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33265",
+					"10.65.0.27:33265",
+					"172.17.0.1:33265",
+					"172.18.0.1:33265",
+					"172.19.0.1:33265",
+					"172.20.0.1:33265",
+					"172.21.0.1:33265",
+					"172.22.0.1:33265",
+					"172.23.0.1:33265",
+					"172.24.0.1:33265",
+					"172.25.0.1:33265",
+					"172.26.0.1:33265",
+					"172.27.0.1:33265",
+					"172.28.0.1:33265",
+					"172.29.0.1:33265"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:08:53.6659712Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7663614990686871,
+				"StableID":   "n6SoutAsq221CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:79e977f28aea31c07b128d887f62f17eb0706d96543f604a6bde62c977e8c93a",
+				"DiscoKey":   "discokey:56194a27fd68adb5985c6835a386f1899944932d8d3fe35d12ab95c687a4c31f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41401",
+					"10.65.0.27:41401",
+					"172.17.0.1:41401",
+					"172.18.0.1:41401",
+					"172.19.0.1:41401",
+					"172.20.0.1:41401",
+					"172.21.0.1:41401",
+					"172.22.0.1:41401",
+					"172.23.0.1:41401",
+					"172.24.0.1:41401",
+					"172.25.0.1:41401",
+					"172.26.0.1:41401",
+					"172.27.0.1:41401",
+					"172.28.0.1:41401",
+					"172.29.0.1:41401"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:08:54.190741062Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8861425300128914,
+				"StableID":   "ns3LFkcMCC21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4784b0e067b3c60e861aee9ab444086a3954473b09053363423a268f5982f533",
+				"DiscoKey":   "discokey:6b4ac603e565c79b1316fba83cad99d59fc6422523132d03b7ec18e4b16e8a1c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:32783",
+					"10.65.0.27:32783",
+					"172.17.0.1:32783",
+					"172.18.0.1:32783",
+					"172.19.0.1:32783",
+					"172.20.0.1:32783",
+					"172.21.0.1:32783",
+					"172.22.0.1:32783",
+					"172.23.0.1:32783",
+					"172.24.0.1:32783",
+					"172.25.0.1:32783",
+					"172.26.0.1:32783",
+					"172.27.0.1:32783",
+					"172.28.0.1:32783",
+					"172.29.0.1:32783"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:08:54.736224441Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2121942722652951,
+				"StableID":   "nNSf9Zq2aH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f36c3c3970962dfcc36ce6a541d4509d463971ab28c4109976925baa7c2b490f",
+				"DiscoKey":   "discokey:f99def593fda9b3d6cb7cb19f67e18c3d8a2c90eeb4dfd052708bfe4b0525f52",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:47554",
+					"10.65.0.27:47554",
+					"172.17.0.1:47554",
+					"172.18.0.1:47554",
+					"172.19.0.1:47554",
+					"172.20.0.1:47554",
+					"172.21.0.1:47554",
+					"172.22.0.1:47554",
+					"172.23.0.1:47554",
+					"172.24.0.1:47554",
+					"172.25.0.1:47554",
+					"172.26.0.1:47554",
+					"172.27.0.1:47554",
+					"172.28.0.1:47554",
+					"172.29.0.1:47554"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:08:55.262055371Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2824186552082163,
+				"StableID":   "nW8qdKb54P11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9e12cd5333229d8b262c24e639634f0b2640bb9ebcb6d54e062127e85d9634d",
+				"DiscoKey":   "discokey:a1895321d40bc0abe8bb7c50e2e19e954d6f79c952841cbb2264137c49cb2b43",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58140",
+					"10.65.0.27:58140",
+					"172.17.0.1:58140",
+					"172.18.0.1:58140",
+					"172.19.0.1:58140",
+					"172.20.0.1:58140",
+					"172.21.0.1:58140",
+					"172.22.0.1:58140",
+					"172.23.0.1:58140",
+					"172.24.0.1:58140",
+					"172.25.0.1:58140",
+					"172.26.0.1:58140",
+					"172.27.0.1:58140",
+					"172.28.0.1:58140",
+					"172.29.0.1:58140"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:08:55.803917237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4537882512937851,
+				"StableID":   "nGqLRmUDSc11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f077b56a647585f47d513ae290d2e5a2fb6eda9528d80805eacb32597d18d119",
+				"KeyExpiry":  "2026-11-09T09:08:56Z",
+				"DiscoKey":   "discokey:ab946cb435f8bc1678f756256fd0cbd141b60ae9d95a1f8ebea2d9bafe5a7237",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:42345",
+					"10.65.0.27:42345",
+					"172.17.0.1:42345",
+					"172.18.0.1:42345",
+					"172.19.0.1:42345",
+					"172.20.0.1:42345",
+					"172.21.0.1:42345",
+					"172.22.0.1:42345",
+					"172.23.0.1:42345",
+					"172.24.0.1:42345",
+					"172.25.0.1:42345",
+					"172.26.0.1:42345",
+					"172.27.0.1:42345",
+					"172.28.0.1:42345",
+					"172.29.0.1:42345"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:08:56.351352972Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1999870809800905,
+				"StableID":   "nt68EUDkcG11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6cdda19e804be5e2cd8f526ebed38e87594983f6271578fd06b30dc824beae1c",
+				"KeyExpiry":  "2026-11-09T09:08:56Z",
+				"DiscoKey":   "discokey:600398c30ac3534d44775a86afb7555cdeb2cf8caa8250cd98a7fe05aa0a5a54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38381",
+					"10.65.0.27:38381",
+					"172.17.0.1:38381",
+					"172.18.0.1:38381",
+					"172.19.0.1:38381",
+					"172.20.0.1:38381",
+					"172.21.0.1:38381",
+					"172.22.0.1:38381",
+					"172.23.0.1:38381",
+					"172.24.0.1:38381",
+					"172.25.0.1:38381",
+					"172.26.0.1:38381",
+					"172.27.0.1:38381",
+					"172.28.0.1:38381",
+					"172.29.0.1:38381"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:08:56.900863642Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6973026628775446,
+				"StableID":   "nXPGBxa6Tw11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d5d8fefebcb8420b272565ade83a1d37b7c82ea35b29f4448a561e3610ca3b60",
+				"KeyExpiry":  "2026-11-09T09:08:57Z",
+				"DiscoKey":   "discokey:a2aaaf10268009cf085a278300b0b82060d85f62dcc68d3d35683f1284e1bb2b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33165",
+					"10.65.0.27:33165",
+					"172.17.0.1:33165",
+					"172.18.0.1:33165",
+					"172.19.0.1:33165",
+					"172.20.0.1:33165",
+					"172.21.0.1:33165",
+					"172.22.0.1:33165",
+					"172.23.0.1:33165",
+					"172.24.0.1:33165",
+					"172.25.0.1:33165",
+					"172.26.0.1:33165",
+					"172.27.0.1:33165",
+					"172.28.0.1:33165",
+					"172.29.0.1:33165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:08:57.437877673Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8072414054839639": {
+				"ID":          8072414054839639,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8089791358291457,
+				"StableID":   "nibJ9s6tA621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       8089791358291457,
+				"Key":        "nodekey:3ab64f2d66959455a4bf55624555c1036e729bda4884e7c64c19b872017a0b24",
+				"DiscoKey":   "discokey:bf66d9922616d7f9186f43f321ae120c1fc3d92b0fd37194569b7e6c45917e60",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54929",
+					"10.65.0.27:54929",
+					"172.17.0.1:54929",
+					"172.18.0.1:54929",
+					"172.19.0.1:54929",
+					"172.20.0.1:54929",
+					"172.21.0.1:54929",
+					"172.22.0.1:54929",
+					"172.23.0.1:54929",
+					"172.24.0.1:54929",
+					"172.25.0.1:54929",
+					"172.26.0.1:54929",
+					"172.27.0.1:54929",
+					"172.28.0.1:54929",
+					"172.29.0.1:54929"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:08:53.136655738Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3ab64f2d66959455a4bf55624555c1036e729bda4884e7c64c19b872017a0b24",
+			"MachineKey": "mkey:192731486e344c4ce57e914340cdca6bf26b3a1e439468ad9f1a261fc1277b42",
+			"Peers": [{
+				"ID":         7910850219715433,
+				"StableID":   "nWbyU1dqm421CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c38849001c818ec01ab3884fb726ba759429abde871ec71f9c654e8c633db73d",
+				"DiscoKey":   "discokey:a5158e8c031a96f17be128393a921f0a94a461d3c25b27caba71a07e90f19e69",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43331",
+					"10.65.0.27:43331",
+					"172.17.0.1:43331",
+					"172.18.0.1:43331",
+					"172.19.0.1:43331",
+					"172.20.0.1:43331",
+					"172.21.0.1:43331",
+					"172.22.0.1:43331",
+					"172.23.0.1:43331",
+					"172.24.0.1:43331",
+					"172.25.0.1:43331",
+					"172.26.0.1:43331",
+					"172.27.0.1:43331",
+					"172.28.0.1:43331",
+					"172.29.0.1:43331"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:08:49.936876938Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6381211525566936,
+				"StableID":   "nj4m5Ac4qr11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba4bdeff5d35313d26131bd1e00e38d94105f2d2d204c657562260231fb91a18",
+				"DiscoKey":   "discokey:097063db9440512c70541de1a731980d4a34eddf48d97052d1e4866e9da65e09",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35952",
+					"10.65.0.27:35952",
+					"172.17.0.1:35952",
+					"172.18.0.1:35952",
+					"172.19.0.1:35952",
+					"172.20.0.1:35952",
+					"172.21.0.1:35952",
+					"172.22.0.1:35952",
+					"172.23.0.1:35952",
+					"172.24.0.1:35952",
+					"172.25.0.1:35952",
+					"172.26.0.1:35952",
+					"172.27.0.1:35952",
+					"172.28.0.1:35952",
+					"172.29.0.1:35952"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:08:50.43056034Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2437573544205684,
+				"StableID":   "noNL2avy2L11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7efd3b993cc568ba4d4e463aacc88c9e6e28595db86cc4bf968a22dbbce6154e",
+				"DiscoKey":   "discokey:93db8a82e3d64a77ff9d4aab6f194d68ed2bab893ef5b1c6a21f8776d75c120d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45990",
+					"10.65.0.27:45990",
+					"172.17.0.1:45990",
+					"172.18.0.1:45990",
+					"172.19.0.1:45990",
+					"172.20.0.1:45990",
+					"172.21.0.1:45990",
+					"172.22.0.1:45990",
+					"172.23.0.1:45990",
+					"172.24.0.1:45990",
+					"172.25.0.1:45990",
+					"172.26.0.1:45990",
+					"172.27.0.1:45990",
+					"172.28.0.1:45990",
+					"172.29.0.1:45990"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:08:50.973567256Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8072414054839639,
+				"StableID":   "nxXtLUd13621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1ce09e5497139ac52ccdbf6e6723e8ca61d7b0e939373c42f62d6669e865264",
+				"DiscoKey":   "discokey:f41dbf4aa82c85a3b684cc1562b75ee3d288cc3eab6e43beff65f5f5a203dd0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42593",
+					"10.65.0.27:42593",
+					"172.17.0.1:42593",
+					"172.18.0.1:42593",
+					"172.19.0.1:42593",
+					"172.20.0.1:42593",
+					"172.21.0.1:42593",
+					"172.22.0.1:42593",
+					"172.23.0.1:42593",
+					"172.24.0.1:42593",
+					"172.25.0.1:42593",
+					"172.26.0.1:42593",
+					"172.27.0.1:42593",
+					"172.28.0.1:42593",
+					"172.29.0.1:42593"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:08:51.519750495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         750134782054043,
+				"StableID":   "ncKWyamjr611CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0517119cfb430214a3965af8697e4b215e9ef9e6f7dc6af68e1629b66577ea75",
+				"DiscoKey":   "discokey:0d49066dd6ef215e5e40af4964900c9a38ddd2c0710f29ac0bbed0e637f0ec6b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:45651",
+					"10.65.0.27:45651",
+					"172.17.0.1:45651",
+					"172.18.0.1:45651",
+					"172.19.0.1:45651",
+					"172.20.0.1:45651",
+					"172.21.0.1:45651",
+					"172.22.0.1:45651",
+					"172.23.0.1:45651",
+					"172.24.0.1:45651",
+					"172.25.0.1:45651",
+					"172.26.0.1:45651",
+					"172.27.0.1:45651",
+					"172.28.0.1:45651",
+					"172.29.0.1:45651"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:08:52.067522041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         839150932034137,
+				"StableID":   "nxJwKB54Z711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0e0c28e146dd6e11cee7bd6ae352fc6307083541e4e9611baef9c388dcadb7c",
+				"DiscoKey":   "discokey:e44999b5edd3b672174f0f3ee207300641467bf3ee743dda8a6ec03ca3858d1d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44968",
+					"10.65.0.27:44968",
+					"172.17.0.1:44968",
+					"172.18.0.1:44968",
+					"172.19.0.1:44968",
+					"172.20.0.1:44968",
+					"172.21.0.1:44968",
+					"172.22.0.1:44968",
+					"172.23.0.1:44968",
+					"172.24.0.1:44968",
+					"172.25.0.1:44968",
+					"172.26.0.1:44968",
+					"172.27.0.1:44968",
+					"172.28.0.1:44968",
+					"172.29.0.1:44968"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:08:52.600909082Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         264256607456368,
+				"StableID":   "n9qoVEag4311CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:914f7a4931682ca03a8382046587ee81000da788897acd3ea18f66907c5f022a",
+				"DiscoKey":   "discokey:04db6794db62b30f749673d0d53252ba1d0b344ff5e369904458aaf9542aa31e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33265",
+					"10.65.0.27:33265",
+					"172.17.0.1:33265",
+					"172.18.0.1:33265",
+					"172.19.0.1:33265",
+					"172.20.0.1:33265",
+					"172.21.0.1:33265",
+					"172.22.0.1:33265",
+					"172.23.0.1:33265",
+					"172.24.0.1:33265",
+					"172.25.0.1:33265",
+					"172.26.0.1:33265",
+					"172.27.0.1:33265",
+					"172.28.0.1:33265",
+					"172.29.0.1:33265"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:08:53.6659712Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7663614990686871,
+				"StableID":   "n6SoutAsq221CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:79e977f28aea31c07b128d887f62f17eb0706d96543f604a6bde62c977e8c93a",
+				"DiscoKey":   "discokey:56194a27fd68adb5985c6835a386f1899944932d8d3fe35d12ab95c687a4c31f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41401",
+					"10.65.0.27:41401",
+					"172.17.0.1:41401",
+					"172.18.0.1:41401",
+					"172.19.0.1:41401",
+					"172.20.0.1:41401",
+					"172.21.0.1:41401",
+					"172.22.0.1:41401",
+					"172.23.0.1:41401",
+					"172.24.0.1:41401",
+					"172.25.0.1:41401",
+					"172.26.0.1:41401",
+					"172.27.0.1:41401",
+					"172.28.0.1:41401",
+					"172.29.0.1:41401"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:08:54.190741062Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8861425300128914,
+				"StableID":   "ns3LFkcMCC21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4784b0e067b3c60e861aee9ab444086a3954473b09053363423a268f5982f533",
+				"DiscoKey":   "discokey:6b4ac603e565c79b1316fba83cad99d59fc6422523132d03b7ec18e4b16e8a1c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:32783",
+					"10.65.0.27:32783",
+					"172.17.0.1:32783",
+					"172.18.0.1:32783",
+					"172.19.0.1:32783",
+					"172.20.0.1:32783",
+					"172.21.0.1:32783",
+					"172.22.0.1:32783",
+					"172.23.0.1:32783",
+					"172.24.0.1:32783",
+					"172.25.0.1:32783",
+					"172.26.0.1:32783",
+					"172.27.0.1:32783",
+					"172.28.0.1:32783",
+					"172.29.0.1:32783"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:08:54.736224441Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2121942722652951,
+				"StableID":   "nNSf9Zq2aH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f36c3c3970962dfcc36ce6a541d4509d463971ab28c4109976925baa7c2b490f",
+				"DiscoKey":   "discokey:f99def593fda9b3d6cb7cb19f67e18c3d8a2c90eeb4dfd052708bfe4b0525f52",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:47554",
+					"10.65.0.27:47554",
+					"172.17.0.1:47554",
+					"172.18.0.1:47554",
+					"172.19.0.1:47554",
+					"172.20.0.1:47554",
+					"172.21.0.1:47554",
+					"172.22.0.1:47554",
+					"172.23.0.1:47554",
+					"172.24.0.1:47554",
+					"172.25.0.1:47554",
+					"172.26.0.1:47554",
+					"172.27.0.1:47554",
+					"172.28.0.1:47554",
+					"172.29.0.1:47554"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:08:55.262055371Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2824186552082163,
+				"StableID":   "nW8qdKb54P11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9e12cd5333229d8b262c24e639634f0b2640bb9ebcb6d54e062127e85d9634d",
+				"DiscoKey":   "discokey:a1895321d40bc0abe8bb7c50e2e19e954d6f79c952841cbb2264137c49cb2b43",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58140",
+					"10.65.0.27:58140",
+					"172.17.0.1:58140",
+					"172.18.0.1:58140",
+					"172.19.0.1:58140",
+					"172.20.0.1:58140",
+					"172.21.0.1:58140",
+					"172.22.0.1:58140",
+					"172.23.0.1:58140",
+					"172.24.0.1:58140",
+					"172.25.0.1:58140",
+					"172.26.0.1:58140",
+					"172.27.0.1:58140",
+					"172.28.0.1:58140",
+					"172.29.0.1:58140"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:08:55.803917237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4537882512937851,
+				"StableID":   "nGqLRmUDSc11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f077b56a647585f47d513ae290d2e5a2fb6eda9528d80805eacb32597d18d119",
+				"KeyExpiry":  "2026-11-09T09:08:56Z",
+				"DiscoKey":   "discokey:ab946cb435f8bc1678f756256fd0cbd141b60ae9d95a1f8ebea2d9bafe5a7237",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:42345",
+					"10.65.0.27:42345",
+					"172.17.0.1:42345",
+					"172.18.0.1:42345",
+					"172.19.0.1:42345",
+					"172.20.0.1:42345",
+					"172.21.0.1:42345",
+					"172.22.0.1:42345",
+					"172.23.0.1:42345",
+					"172.24.0.1:42345",
+					"172.25.0.1:42345",
+					"172.26.0.1:42345",
+					"172.27.0.1:42345",
+					"172.28.0.1:42345",
+					"172.29.0.1:42345"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:08:56.351352972Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1999870809800905,
+				"StableID":   "nt68EUDkcG11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6cdda19e804be5e2cd8f526ebed38e87594983f6271578fd06b30dc824beae1c",
+				"KeyExpiry":  "2026-11-09T09:08:56Z",
+				"DiscoKey":   "discokey:600398c30ac3534d44775a86afb7555cdeb2cf8caa8250cd98a7fe05aa0a5a54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38381",
+					"10.65.0.27:38381",
+					"172.17.0.1:38381",
+					"172.18.0.1:38381",
+					"172.19.0.1:38381",
+					"172.20.0.1:38381",
+					"172.21.0.1:38381",
+					"172.22.0.1:38381",
+					"172.23.0.1:38381",
+					"172.24.0.1:38381",
+					"172.25.0.1:38381",
+					"172.26.0.1:38381",
+					"172.27.0.1:38381",
+					"172.28.0.1:38381",
+					"172.29.0.1:38381"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:08:56.900863642Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6973026628775446,
+				"StableID":   "nXPGBxa6Tw11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d5d8fefebcb8420b272565ade83a1d37b7c82ea35b29f4448a561e3610ca3b60",
+				"KeyExpiry":  "2026-11-09T09:08:57Z",
+				"DiscoKey":   "discokey:a2aaaf10268009cf085a278300b0b82060d85f62dcc68d3d35683f1284e1bb2b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33165",
+					"10.65.0.27:33165",
+					"172.17.0.1:33165",
+					"172.18.0.1:33165",
+					"172.19.0.1:33165",
+					"172.20.0.1:33165",
+					"172.21.0.1:33165",
+					"172.22.0.1:33165",
+					"172.23.0.1:33165",
+					"172.24.0.1:33165",
+					"172.25.0.1:33165",
+					"172.26.0.1:33165",
+					"172.27.0.1:33165",
+					"172.28.0.1:33165",
+					"172.29.0.1:33165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:08:57.437877673Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8089791358291457": {
+				"ID":          8089791358291457,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7663614990686871,
+				"StableID":   "n6SoutAsq221CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       7663614990686871,
+				"Key":        "nodekey:79e977f28aea31c07b128d887f62f17eb0706d96543f604a6bde62c977e8c93a",
+				"DiscoKey":   "discokey:56194a27fd68adb5985c6835a386f1899944932d8d3fe35d12ab95c687a4c31f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41401",
+					"10.65.0.27:41401",
+					"172.17.0.1:41401",
+					"172.18.0.1:41401",
+					"172.19.0.1:41401",
+					"172.20.0.1:41401",
+					"172.21.0.1:41401",
+					"172.22.0.1:41401",
+					"172.23.0.1:41401",
+					"172.24.0.1:41401",
+					"172.25.0.1:41401",
+					"172.26.0.1:41401",
+					"172.27.0.1:41401",
+					"172.28.0.1:41401",
+					"172.29.0.1:41401"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:08:54.190741062Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:79e977f28aea31c07b128d887f62f17eb0706d96543f604a6bde62c977e8c93a",
+			"MachineKey": "mkey:f56fa143ce56639a603e4b95d3a1311cd3f10b70f6d505f5fda4896d3fabb671",
+			"Peers": [{
+				"ID":         7910850219715433,
+				"StableID":   "nWbyU1dqm421CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c38849001c818ec01ab3884fb726ba759429abde871ec71f9c654e8c633db73d",
+				"DiscoKey":   "discokey:a5158e8c031a96f17be128393a921f0a94a461d3c25b27caba71a07e90f19e69",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43331",
+					"10.65.0.27:43331",
+					"172.17.0.1:43331",
+					"172.18.0.1:43331",
+					"172.19.0.1:43331",
+					"172.20.0.1:43331",
+					"172.21.0.1:43331",
+					"172.22.0.1:43331",
+					"172.23.0.1:43331",
+					"172.24.0.1:43331",
+					"172.25.0.1:43331",
+					"172.26.0.1:43331",
+					"172.27.0.1:43331",
+					"172.28.0.1:43331",
+					"172.29.0.1:43331"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:08:49.936876938Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6381211525566936,
+				"StableID":   "nj4m5Ac4qr11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba4bdeff5d35313d26131bd1e00e38d94105f2d2d204c657562260231fb91a18",
+				"DiscoKey":   "discokey:097063db9440512c70541de1a731980d4a34eddf48d97052d1e4866e9da65e09",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35952",
+					"10.65.0.27:35952",
+					"172.17.0.1:35952",
+					"172.18.0.1:35952",
+					"172.19.0.1:35952",
+					"172.20.0.1:35952",
+					"172.21.0.1:35952",
+					"172.22.0.1:35952",
+					"172.23.0.1:35952",
+					"172.24.0.1:35952",
+					"172.25.0.1:35952",
+					"172.26.0.1:35952",
+					"172.27.0.1:35952",
+					"172.28.0.1:35952",
+					"172.29.0.1:35952"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:08:50.43056034Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2437573544205684,
+				"StableID":   "noNL2avy2L11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7efd3b993cc568ba4d4e463aacc88c9e6e28595db86cc4bf968a22dbbce6154e",
+				"DiscoKey":   "discokey:93db8a82e3d64a77ff9d4aab6f194d68ed2bab893ef5b1c6a21f8776d75c120d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45990",
+					"10.65.0.27:45990",
+					"172.17.0.1:45990",
+					"172.18.0.1:45990",
+					"172.19.0.1:45990",
+					"172.20.0.1:45990",
+					"172.21.0.1:45990",
+					"172.22.0.1:45990",
+					"172.23.0.1:45990",
+					"172.24.0.1:45990",
+					"172.25.0.1:45990",
+					"172.26.0.1:45990",
+					"172.27.0.1:45990",
+					"172.28.0.1:45990",
+					"172.29.0.1:45990"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:08:50.973567256Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8072414054839639,
+				"StableID":   "nxXtLUd13621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1ce09e5497139ac52ccdbf6e6723e8ca61d7b0e939373c42f62d6669e865264",
+				"DiscoKey":   "discokey:f41dbf4aa82c85a3b684cc1562b75ee3d288cc3eab6e43beff65f5f5a203dd0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42593",
+					"10.65.0.27:42593",
+					"172.17.0.1:42593",
+					"172.18.0.1:42593",
+					"172.19.0.1:42593",
+					"172.20.0.1:42593",
+					"172.21.0.1:42593",
+					"172.22.0.1:42593",
+					"172.23.0.1:42593",
+					"172.24.0.1:42593",
+					"172.25.0.1:42593",
+					"172.26.0.1:42593",
+					"172.27.0.1:42593",
+					"172.28.0.1:42593",
+					"172.29.0.1:42593"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:08:51.519750495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         750134782054043,
+				"StableID":   "ncKWyamjr611CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0517119cfb430214a3965af8697e4b215e9ef9e6f7dc6af68e1629b66577ea75",
+				"DiscoKey":   "discokey:0d49066dd6ef215e5e40af4964900c9a38ddd2c0710f29ac0bbed0e637f0ec6b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:45651",
+					"10.65.0.27:45651",
+					"172.17.0.1:45651",
+					"172.18.0.1:45651",
+					"172.19.0.1:45651",
+					"172.20.0.1:45651",
+					"172.21.0.1:45651",
+					"172.22.0.1:45651",
+					"172.23.0.1:45651",
+					"172.24.0.1:45651",
+					"172.25.0.1:45651",
+					"172.26.0.1:45651",
+					"172.27.0.1:45651",
+					"172.28.0.1:45651",
+					"172.29.0.1:45651"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:08:52.067522041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         839150932034137,
+				"StableID":   "nxJwKB54Z711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0e0c28e146dd6e11cee7bd6ae352fc6307083541e4e9611baef9c388dcadb7c",
+				"DiscoKey":   "discokey:e44999b5edd3b672174f0f3ee207300641467bf3ee743dda8a6ec03ca3858d1d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44968",
+					"10.65.0.27:44968",
+					"172.17.0.1:44968",
+					"172.18.0.1:44968",
+					"172.19.0.1:44968",
+					"172.20.0.1:44968",
+					"172.21.0.1:44968",
+					"172.22.0.1:44968",
+					"172.23.0.1:44968",
+					"172.24.0.1:44968",
+					"172.25.0.1:44968",
+					"172.26.0.1:44968",
+					"172.27.0.1:44968",
+					"172.28.0.1:44968",
+					"172.29.0.1:44968"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:08:52.600909082Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8089791358291457,
+				"StableID":   "nibJ9s6tA621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3ab64f2d66959455a4bf55624555c1036e729bda4884e7c64c19b872017a0b24",
+				"DiscoKey":   "discokey:bf66d9922616d7f9186f43f321ae120c1fc3d92b0fd37194569b7e6c45917e60",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54929",
+					"10.65.0.27:54929",
+					"172.17.0.1:54929",
+					"172.18.0.1:54929",
+					"172.19.0.1:54929",
+					"172.20.0.1:54929",
+					"172.21.0.1:54929",
+					"172.22.0.1:54929",
+					"172.23.0.1:54929",
+					"172.24.0.1:54929",
+					"172.25.0.1:54929",
+					"172.26.0.1:54929",
+					"172.27.0.1:54929",
+					"172.28.0.1:54929",
+					"172.29.0.1:54929"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:08:53.136655738Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         264256607456368,
+				"StableID":   "n9qoVEag4311CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:914f7a4931682ca03a8382046587ee81000da788897acd3ea18f66907c5f022a",
+				"DiscoKey":   "discokey:04db6794db62b30f749673d0d53252ba1d0b344ff5e369904458aaf9542aa31e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33265",
+					"10.65.0.27:33265",
+					"172.17.0.1:33265",
+					"172.18.0.1:33265",
+					"172.19.0.1:33265",
+					"172.20.0.1:33265",
+					"172.21.0.1:33265",
+					"172.22.0.1:33265",
+					"172.23.0.1:33265",
+					"172.24.0.1:33265",
+					"172.25.0.1:33265",
+					"172.26.0.1:33265",
+					"172.27.0.1:33265",
+					"172.28.0.1:33265",
+					"172.29.0.1:33265"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:08:53.6659712Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8861425300128914,
+				"StableID":   "ns3LFkcMCC21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4784b0e067b3c60e861aee9ab444086a3954473b09053363423a268f5982f533",
+				"DiscoKey":   "discokey:6b4ac603e565c79b1316fba83cad99d59fc6422523132d03b7ec18e4b16e8a1c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:32783",
+					"10.65.0.27:32783",
+					"172.17.0.1:32783",
+					"172.18.0.1:32783",
+					"172.19.0.1:32783",
+					"172.20.0.1:32783",
+					"172.21.0.1:32783",
+					"172.22.0.1:32783",
+					"172.23.0.1:32783",
+					"172.24.0.1:32783",
+					"172.25.0.1:32783",
+					"172.26.0.1:32783",
+					"172.27.0.1:32783",
+					"172.28.0.1:32783",
+					"172.29.0.1:32783"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:08:54.736224441Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2121942722652951,
+				"StableID":   "nNSf9Zq2aH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f36c3c3970962dfcc36ce6a541d4509d463971ab28c4109976925baa7c2b490f",
+				"DiscoKey":   "discokey:f99def593fda9b3d6cb7cb19f67e18c3d8a2c90eeb4dfd052708bfe4b0525f52",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:47554",
+					"10.65.0.27:47554",
+					"172.17.0.1:47554",
+					"172.18.0.1:47554",
+					"172.19.0.1:47554",
+					"172.20.0.1:47554",
+					"172.21.0.1:47554",
+					"172.22.0.1:47554",
+					"172.23.0.1:47554",
+					"172.24.0.1:47554",
+					"172.25.0.1:47554",
+					"172.26.0.1:47554",
+					"172.27.0.1:47554",
+					"172.28.0.1:47554",
+					"172.29.0.1:47554"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:08:55.262055371Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2824186552082163,
+				"StableID":   "nW8qdKb54P11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9e12cd5333229d8b262c24e639634f0b2640bb9ebcb6d54e062127e85d9634d",
+				"DiscoKey":   "discokey:a1895321d40bc0abe8bb7c50e2e19e954d6f79c952841cbb2264137c49cb2b43",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58140",
+					"10.65.0.27:58140",
+					"172.17.0.1:58140",
+					"172.18.0.1:58140",
+					"172.19.0.1:58140",
+					"172.20.0.1:58140",
+					"172.21.0.1:58140",
+					"172.22.0.1:58140",
+					"172.23.0.1:58140",
+					"172.24.0.1:58140",
+					"172.25.0.1:58140",
+					"172.26.0.1:58140",
+					"172.27.0.1:58140",
+					"172.28.0.1:58140",
+					"172.29.0.1:58140"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:08:55.803917237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4537882512937851,
+				"StableID":   "nGqLRmUDSc11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f077b56a647585f47d513ae290d2e5a2fb6eda9528d80805eacb32597d18d119",
+				"KeyExpiry":  "2026-11-09T09:08:56Z",
+				"DiscoKey":   "discokey:ab946cb435f8bc1678f756256fd0cbd141b60ae9d95a1f8ebea2d9bafe5a7237",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:42345",
+					"10.65.0.27:42345",
+					"172.17.0.1:42345",
+					"172.18.0.1:42345",
+					"172.19.0.1:42345",
+					"172.20.0.1:42345",
+					"172.21.0.1:42345",
+					"172.22.0.1:42345",
+					"172.23.0.1:42345",
+					"172.24.0.1:42345",
+					"172.25.0.1:42345",
+					"172.26.0.1:42345",
+					"172.27.0.1:42345",
+					"172.28.0.1:42345",
+					"172.29.0.1:42345"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:08:56.351352972Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1999870809800905,
+				"StableID":   "nt68EUDkcG11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6cdda19e804be5e2cd8f526ebed38e87594983f6271578fd06b30dc824beae1c",
+				"KeyExpiry":  "2026-11-09T09:08:56Z",
+				"DiscoKey":   "discokey:600398c30ac3534d44775a86afb7555cdeb2cf8caa8250cd98a7fe05aa0a5a54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38381",
+					"10.65.0.27:38381",
+					"172.17.0.1:38381",
+					"172.18.0.1:38381",
+					"172.19.0.1:38381",
+					"172.20.0.1:38381",
+					"172.21.0.1:38381",
+					"172.22.0.1:38381",
+					"172.23.0.1:38381",
+					"172.24.0.1:38381",
+					"172.25.0.1:38381",
+					"172.26.0.1:38381",
+					"172.27.0.1:38381",
+					"172.28.0.1:38381",
+					"172.29.0.1:38381"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:08:56.900863642Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6973026628775446,
+				"StableID":   "nXPGBxa6Tw11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d5d8fefebcb8420b272565ade83a1d37b7c82ea35b29f4448a561e3610ca3b60",
+				"KeyExpiry":  "2026-11-09T09:08:57Z",
+				"DiscoKey":   "discokey:a2aaaf10268009cf085a278300b0b82060d85f62dcc68d3d35683f1284e1bb2b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33165",
+					"10.65.0.27:33165",
+					"172.17.0.1:33165",
+					"172.18.0.1:33165",
+					"172.19.0.1:33165",
+					"172.20.0.1:33165",
+					"172.21.0.1:33165",
+					"172.22.0.1:33165",
+					"172.23.0.1:33165",
+					"172.24.0.1:33165",
+					"172.25.0.1:33165",
+					"172.26.0.1:33165",
+					"172.27.0.1:33165",
+					"172.28.0.1:33165",
+					"172.29.0.1:33165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:08:57.437877673Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7663614990686871": {
+				"ID":          7663614990686871,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1999870809800905,
+				"StableID":   "nt68EUDkcG11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6cdda19e804be5e2cd8f526ebed38e87594983f6271578fd06b30dc824beae1c",
+				"KeyExpiry":  "2026-11-09T09:08:56Z",
+				"DiscoKey":   "discokey:600398c30ac3534d44775a86afb7555cdeb2cf8caa8250cd98a7fe05aa0a5a54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38381",
+					"10.65.0.27:38381",
+					"172.17.0.1:38381",
+					"172.18.0.1:38381",
+					"172.19.0.1:38381",
+					"172.20.0.1:38381",
+					"172.21.0.1:38381",
+					"172.22.0.1:38381",
+					"172.23.0.1:38381",
+					"172.24.0.1:38381",
+					"172.25.0.1:38381",
+					"172.26.0.1:38381",
+					"172.27.0.1:38381",
+					"172.28.0.1:38381",
+					"172.29.0.1:38381"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:08:56.900863642Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6cdda19e804be5e2cd8f526ebed38e87594983f6271578fd06b30dc824beae1c",
+			"MachineKey": "mkey:b1bd195b5e86c909a983517826edae23ac8e1ec564fa687fbd37753a117e805a",
+			"Peers": [{
+				"ID":         7910850219715433,
+				"StableID":   "nWbyU1dqm421CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c38849001c818ec01ab3884fb726ba759429abde871ec71f9c654e8c633db73d",
+				"DiscoKey":   "discokey:a5158e8c031a96f17be128393a921f0a94a461d3c25b27caba71a07e90f19e69",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43331",
+					"10.65.0.27:43331",
+					"172.17.0.1:43331",
+					"172.18.0.1:43331",
+					"172.19.0.1:43331",
+					"172.20.0.1:43331",
+					"172.21.0.1:43331",
+					"172.22.0.1:43331",
+					"172.23.0.1:43331",
+					"172.24.0.1:43331",
+					"172.25.0.1:43331",
+					"172.26.0.1:43331",
+					"172.27.0.1:43331",
+					"172.28.0.1:43331",
+					"172.29.0.1:43331"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:08:49.936876938Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6381211525566936,
+				"StableID":   "nj4m5Ac4qr11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba4bdeff5d35313d26131bd1e00e38d94105f2d2d204c657562260231fb91a18",
+				"DiscoKey":   "discokey:097063db9440512c70541de1a731980d4a34eddf48d97052d1e4866e9da65e09",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35952",
+					"10.65.0.27:35952",
+					"172.17.0.1:35952",
+					"172.18.0.1:35952",
+					"172.19.0.1:35952",
+					"172.20.0.1:35952",
+					"172.21.0.1:35952",
+					"172.22.0.1:35952",
+					"172.23.0.1:35952",
+					"172.24.0.1:35952",
+					"172.25.0.1:35952",
+					"172.26.0.1:35952",
+					"172.27.0.1:35952",
+					"172.28.0.1:35952",
+					"172.29.0.1:35952"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:08:50.43056034Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2437573544205684,
+				"StableID":   "noNL2avy2L11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7efd3b993cc568ba4d4e463aacc88c9e6e28595db86cc4bf968a22dbbce6154e",
+				"DiscoKey":   "discokey:93db8a82e3d64a77ff9d4aab6f194d68ed2bab893ef5b1c6a21f8776d75c120d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45990",
+					"10.65.0.27:45990",
+					"172.17.0.1:45990",
+					"172.18.0.1:45990",
+					"172.19.0.1:45990",
+					"172.20.0.1:45990",
+					"172.21.0.1:45990",
+					"172.22.0.1:45990",
+					"172.23.0.1:45990",
+					"172.24.0.1:45990",
+					"172.25.0.1:45990",
+					"172.26.0.1:45990",
+					"172.27.0.1:45990",
+					"172.28.0.1:45990",
+					"172.29.0.1:45990"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:08:50.973567256Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8072414054839639,
+				"StableID":   "nxXtLUd13621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1ce09e5497139ac52ccdbf6e6723e8ca61d7b0e939373c42f62d6669e865264",
+				"DiscoKey":   "discokey:f41dbf4aa82c85a3b684cc1562b75ee3d288cc3eab6e43beff65f5f5a203dd0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42593",
+					"10.65.0.27:42593",
+					"172.17.0.1:42593",
+					"172.18.0.1:42593",
+					"172.19.0.1:42593",
+					"172.20.0.1:42593",
+					"172.21.0.1:42593",
+					"172.22.0.1:42593",
+					"172.23.0.1:42593",
+					"172.24.0.1:42593",
+					"172.25.0.1:42593",
+					"172.26.0.1:42593",
+					"172.27.0.1:42593",
+					"172.28.0.1:42593",
+					"172.29.0.1:42593"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:08:51.519750495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         750134782054043,
+				"StableID":   "ncKWyamjr611CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0517119cfb430214a3965af8697e4b215e9ef9e6f7dc6af68e1629b66577ea75",
+				"DiscoKey":   "discokey:0d49066dd6ef215e5e40af4964900c9a38ddd2c0710f29ac0bbed0e637f0ec6b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:45651",
+					"10.65.0.27:45651",
+					"172.17.0.1:45651",
+					"172.18.0.1:45651",
+					"172.19.0.1:45651",
+					"172.20.0.1:45651",
+					"172.21.0.1:45651",
+					"172.22.0.1:45651",
+					"172.23.0.1:45651",
+					"172.24.0.1:45651",
+					"172.25.0.1:45651",
+					"172.26.0.1:45651",
+					"172.27.0.1:45651",
+					"172.28.0.1:45651",
+					"172.29.0.1:45651"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:08:52.067522041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         839150932034137,
+				"StableID":   "nxJwKB54Z711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0e0c28e146dd6e11cee7bd6ae352fc6307083541e4e9611baef9c388dcadb7c",
+				"DiscoKey":   "discokey:e44999b5edd3b672174f0f3ee207300641467bf3ee743dda8a6ec03ca3858d1d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44968",
+					"10.65.0.27:44968",
+					"172.17.0.1:44968",
+					"172.18.0.1:44968",
+					"172.19.0.1:44968",
+					"172.20.0.1:44968",
+					"172.21.0.1:44968",
+					"172.22.0.1:44968",
+					"172.23.0.1:44968",
+					"172.24.0.1:44968",
+					"172.25.0.1:44968",
+					"172.26.0.1:44968",
+					"172.27.0.1:44968",
+					"172.28.0.1:44968",
+					"172.29.0.1:44968"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:08:52.600909082Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8089791358291457,
+				"StableID":   "nibJ9s6tA621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3ab64f2d66959455a4bf55624555c1036e729bda4884e7c64c19b872017a0b24",
+				"DiscoKey":   "discokey:bf66d9922616d7f9186f43f321ae120c1fc3d92b0fd37194569b7e6c45917e60",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54929",
+					"10.65.0.27:54929",
+					"172.17.0.1:54929",
+					"172.18.0.1:54929",
+					"172.19.0.1:54929",
+					"172.20.0.1:54929",
+					"172.21.0.1:54929",
+					"172.22.0.1:54929",
+					"172.23.0.1:54929",
+					"172.24.0.1:54929",
+					"172.25.0.1:54929",
+					"172.26.0.1:54929",
+					"172.27.0.1:54929",
+					"172.28.0.1:54929",
+					"172.29.0.1:54929"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:08:53.136655738Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         264256607456368,
+				"StableID":   "n9qoVEag4311CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:914f7a4931682ca03a8382046587ee81000da788897acd3ea18f66907c5f022a",
+				"DiscoKey":   "discokey:04db6794db62b30f749673d0d53252ba1d0b344ff5e369904458aaf9542aa31e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33265",
+					"10.65.0.27:33265",
+					"172.17.0.1:33265",
+					"172.18.0.1:33265",
+					"172.19.0.1:33265",
+					"172.20.0.1:33265",
+					"172.21.0.1:33265",
+					"172.22.0.1:33265",
+					"172.23.0.1:33265",
+					"172.24.0.1:33265",
+					"172.25.0.1:33265",
+					"172.26.0.1:33265",
+					"172.27.0.1:33265",
+					"172.28.0.1:33265",
+					"172.29.0.1:33265"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:08:53.6659712Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7663614990686871,
+				"StableID":   "n6SoutAsq221CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:79e977f28aea31c07b128d887f62f17eb0706d96543f604a6bde62c977e8c93a",
+				"DiscoKey":   "discokey:56194a27fd68adb5985c6835a386f1899944932d8d3fe35d12ab95c687a4c31f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41401",
+					"10.65.0.27:41401",
+					"172.17.0.1:41401",
+					"172.18.0.1:41401",
+					"172.19.0.1:41401",
+					"172.20.0.1:41401",
+					"172.21.0.1:41401",
+					"172.22.0.1:41401",
+					"172.23.0.1:41401",
+					"172.24.0.1:41401",
+					"172.25.0.1:41401",
+					"172.26.0.1:41401",
+					"172.27.0.1:41401",
+					"172.28.0.1:41401",
+					"172.29.0.1:41401"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:08:54.190741062Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8861425300128914,
+				"StableID":   "ns3LFkcMCC21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4784b0e067b3c60e861aee9ab444086a3954473b09053363423a268f5982f533",
+				"DiscoKey":   "discokey:6b4ac603e565c79b1316fba83cad99d59fc6422523132d03b7ec18e4b16e8a1c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:32783",
+					"10.65.0.27:32783",
+					"172.17.0.1:32783",
+					"172.18.0.1:32783",
+					"172.19.0.1:32783",
+					"172.20.0.1:32783",
+					"172.21.0.1:32783",
+					"172.22.0.1:32783",
+					"172.23.0.1:32783",
+					"172.24.0.1:32783",
+					"172.25.0.1:32783",
+					"172.26.0.1:32783",
+					"172.27.0.1:32783",
+					"172.28.0.1:32783",
+					"172.29.0.1:32783"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:08:54.736224441Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2121942722652951,
+				"StableID":   "nNSf9Zq2aH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f36c3c3970962dfcc36ce6a541d4509d463971ab28c4109976925baa7c2b490f",
+				"DiscoKey":   "discokey:f99def593fda9b3d6cb7cb19f67e18c3d8a2c90eeb4dfd052708bfe4b0525f52",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:47554",
+					"10.65.0.27:47554",
+					"172.17.0.1:47554",
+					"172.18.0.1:47554",
+					"172.19.0.1:47554",
+					"172.20.0.1:47554",
+					"172.21.0.1:47554",
+					"172.22.0.1:47554",
+					"172.23.0.1:47554",
+					"172.24.0.1:47554",
+					"172.25.0.1:47554",
+					"172.26.0.1:47554",
+					"172.27.0.1:47554",
+					"172.28.0.1:47554",
+					"172.29.0.1:47554"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:08:55.262055371Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2824186552082163,
+				"StableID":   "nW8qdKb54P11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9e12cd5333229d8b262c24e639634f0b2640bb9ebcb6d54e062127e85d9634d",
+				"DiscoKey":   "discokey:a1895321d40bc0abe8bb7c50e2e19e954d6f79c952841cbb2264137c49cb2b43",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58140",
+					"10.65.0.27:58140",
+					"172.17.0.1:58140",
+					"172.18.0.1:58140",
+					"172.19.0.1:58140",
+					"172.20.0.1:58140",
+					"172.21.0.1:58140",
+					"172.22.0.1:58140",
+					"172.23.0.1:58140",
+					"172.24.0.1:58140",
+					"172.25.0.1:58140",
+					"172.26.0.1:58140",
+					"172.27.0.1:58140",
+					"172.28.0.1:58140",
+					"172.29.0.1:58140"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:08:55.803917237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4537882512937851,
+				"StableID":   "nGqLRmUDSc11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f077b56a647585f47d513ae290d2e5a2fb6eda9528d80805eacb32597d18d119",
+				"KeyExpiry":  "2026-11-09T09:08:56Z",
+				"DiscoKey":   "discokey:ab946cb435f8bc1678f756256fd0cbd141b60ae9d95a1f8ebea2d9bafe5a7237",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:42345",
+					"10.65.0.27:42345",
+					"172.17.0.1:42345",
+					"172.18.0.1:42345",
+					"172.19.0.1:42345",
+					"172.20.0.1:42345",
+					"172.21.0.1:42345",
+					"172.22.0.1:42345",
+					"172.23.0.1:42345",
+					"172.24.0.1:42345",
+					"172.25.0.1:42345",
+					"172.26.0.1:42345",
+					"172.27.0.1:42345",
+					"172.28.0.1:42345",
+					"172.29.0.1:42345"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:08:56.351352972Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6973026628775446,
+				"StableID":   "nXPGBxa6Tw11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d5d8fefebcb8420b272565ade83a1d37b7c82ea35b29f4448a561e3610ca3b60",
+				"KeyExpiry":  "2026-11-09T09:08:57Z",
+				"DiscoKey":   "discokey:a2aaaf10268009cf085a278300b0b82060d85f62dcc68d3d35683f1284e1bb2b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33165",
+					"10.65.0.27:33165",
+					"172.17.0.1:33165",
+					"172.18.0.1:33165",
+					"172.19.0.1:33165",
+					"172.20.0.1:33165",
+					"172.21.0.1:33165",
+					"172.22.0.1:33165",
+					"172.23.0.1:33165",
+					"172.24.0.1:33165",
+					"172.25.0.1:33165",
+					"172.26.0.1:33165",
+					"172.27.0.1:33165",
+					"172.28.0.1:33165",
+					"172.29.0.1:33165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:08:57.437877673Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8861425300128914,
+				"StableID":   "ns3LFkcMCC21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       8861425300128914,
+				"Key":        "nodekey:4784b0e067b3c60e861aee9ab444086a3954473b09053363423a268f5982f533",
+				"DiscoKey":   "discokey:6b4ac603e565c79b1316fba83cad99d59fc6422523132d03b7ec18e4b16e8a1c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:32783",
+					"10.65.0.27:32783",
+					"172.17.0.1:32783",
+					"172.18.0.1:32783",
+					"172.19.0.1:32783",
+					"172.20.0.1:32783",
+					"172.21.0.1:32783",
+					"172.22.0.1:32783",
+					"172.23.0.1:32783",
+					"172.24.0.1:32783",
+					"172.25.0.1:32783",
+					"172.26.0.1:32783",
+					"172.27.0.1:32783",
+					"172.28.0.1:32783",
+					"172.29.0.1:32783"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:08:54.736224441Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4784b0e067b3c60e861aee9ab444086a3954473b09053363423a268f5982f533",
+			"MachineKey": "mkey:58841061653d21d9829e817959f6ceae5d1af21369f2c3902b52e955b8b3921e",
+			"Peers": [{
+				"ID":         7910850219715433,
+				"StableID":   "nWbyU1dqm421CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c38849001c818ec01ab3884fb726ba759429abde871ec71f9c654e8c633db73d",
+				"DiscoKey":   "discokey:a5158e8c031a96f17be128393a921f0a94a461d3c25b27caba71a07e90f19e69",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43331",
+					"10.65.0.27:43331",
+					"172.17.0.1:43331",
+					"172.18.0.1:43331",
+					"172.19.0.1:43331",
+					"172.20.0.1:43331",
+					"172.21.0.1:43331",
+					"172.22.0.1:43331",
+					"172.23.0.1:43331",
+					"172.24.0.1:43331",
+					"172.25.0.1:43331",
+					"172.26.0.1:43331",
+					"172.27.0.1:43331",
+					"172.28.0.1:43331",
+					"172.29.0.1:43331"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:08:49.936876938Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6381211525566936,
+				"StableID":   "nj4m5Ac4qr11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba4bdeff5d35313d26131bd1e00e38d94105f2d2d204c657562260231fb91a18",
+				"DiscoKey":   "discokey:097063db9440512c70541de1a731980d4a34eddf48d97052d1e4866e9da65e09",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35952",
+					"10.65.0.27:35952",
+					"172.17.0.1:35952",
+					"172.18.0.1:35952",
+					"172.19.0.1:35952",
+					"172.20.0.1:35952",
+					"172.21.0.1:35952",
+					"172.22.0.1:35952",
+					"172.23.0.1:35952",
+					"172.24.0.1:35952",
+					"172.25.0.1:35952",
+					"172.26.0.1:35952",
+					"172.27.0.1:35952",
+					"172.28.0.1:35952",
+					"172.29.0.1:35952"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:08:50.43056034Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2437573544205684,
+				"StableID":   "noNL2avy2L11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7efd3b993cc568ba4d4e463aacc88c9e6e28595db86cc4bf968a22dbbce6154e",
+				"DiscoKey":   "discokey:93db8a82e3d64a77ff9d4aab6f194d68ed2bab893ef5b1c6a21f8776d75c120d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45990",
+					"10.65.0.27:45990",
+					"172.17.0.1:45990",
+					"172.18.0.1:45990",
+					"172.19.0.1:45990",
+					"172.20.0.1:45990",
+					"172.21.0.1:45990",
+					"172.22.0.1:45990",
+					"172.23.0.1:45990",
+					"172.24.0.1:45990",
+					"172.25.0.1:45990",
+					"172.26.0.1:45990",
+					"172.27.0.1:45990",
+					"172.28.0.1:45990",
+					"172.29.0.1:45990"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:08:50.973567256Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8072414054839639,
+				"StableID":   "nxXtLUd13621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1ce09e5497139ac52ccdbf6e6723e8ca61d7b0e939373c42f62d6669e865264",
+				"DiscoKey":   "discokey:f41dbf4aa82c85a3b684cc1562b75ee3d288cc3eab6e43beff65f5f5a203dd0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42593",
+					"10.65.0.27:42593",
+					"172.17.0.1:42593",
+					"172.18.0.1:42593",
+					"172.19.0.1:42593",
+					"172.20.0.1:42593",
+					"172.21.0.1:42593",
+					"172.22.0.1:42593",
+					"172.23.0.1:42593",
+					"172.24.0.1:42593",
+					"172.25.0.1:42593",
+					"172.26.0.1:42593",
+					"172.27.0.1:42593",
+					"172.28.0.1:42593",
+					"172.29.0.1:42593"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:08:51.519750495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         750134782054043,
+				"StableID":   "ncKWyamjr611CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0517119cfb430214a3965af8697e4b215e9ef9e6f7dc6af68e1629b66577ea75",
+				"DiscoKey":   "discokey:0d49066dd6ef215e5e40af4964900c9a38ddd2c0710f29ac0bbed0e637f0ec6b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:45651",
+					"10.65.0.27:45651",
+					"172.17.0.1:45651",
+					"172.18.0.1:45651",
+					"172.19.0.1:45651",
+					"172.20.0.1:45651",
+					"172.21.0.1:45651",
+					"172.22.0.1:45651",
+					"172.23.0.1:45651",
+					"172.24.0.1:45651",
+					"172.25.0.1:45651",
+					"172.26.0.1:45651",
+					"172.27.0.1:45651",
+					"172.28.0.1:45651",
+					"172.29.0.1:45651"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:08:52.067522041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         839150932034137,
+				"StableID":   "nxJwKB54Z711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0e0c28e146dd6e11cee7bd6ae352fc6307083541e4e9611baef9c388dcadb7c",
+				"DiscoKey":   "discokey:e44999b5edd3b672174f0f3ee207300641467bf3ee743dda8a6ec03ca3858d1d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44968",
+					"10.65.0.27:44968",
+					"172.17.0.1:44968",
+					"172.18.0.1:44968",
+					"172.19.0.1:44968",
+					"172.20.0.1:44968",
+					"172.21.0.1:44968",
+					"172.22.0.1:44968",
+					"172.23.0.1:44968",
+					"172.24.0.1:44968",
+					"172.25.0.1:44968",
+					"172.26.0.1:44968",
+					"172.27.0.1:44968",
+					"172.28.0.1:44968",
+					"172.29.0.1:44968"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:08:52.600909082Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8089791358291457,
+				"StableID":   "nibJ9s6tA621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3ab64f2d66959455a4bf55624555c1036e729bda4884e7c64c19b872017a0b24",
+				"DiscoKey":   "discokey:bf66d9922616d7f9186f43f321ae120c1fc3d92b0fd37194569b7e6c45917e60",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54929",
+					"10.65.0.27:54929",
+					"172.17.0.1:54929",
+					"172.18.0.1:54929",
+					"172.19.0.1:54929",
+					"172.20.0.1:54929",
+					"172.21.0.1:54929",
+					"172.22.0.1:54929",
+					"172.23.0.1:54929",
+					"172.24.0.1:54929",
+					"172.25.0.1:54929",
+					"172.26.0.1:54929",
+					"172.27.0.1:54929",
+					"172.28.0.1:54929",
+					"172.29.0.1:54929"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:08:53.136655738Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         264256607456368,
+				"StableID":   "n9qoVEag4311CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:914f7a4931682ca03a8382046587ee81000da788897acd3ea18f66907c5f022a",
+				"DiscoKey":   "discokey:04db6794db62b30f749673d0d53252ba1d0b344ff5e369904458aaf9542aa31e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33265",
+					"10.65.0.27:33265",
+					"172.17.0.1:33265",
+					"172.18.0.1:33265",
+					"172.19.0.1:33265",
+					"172.20.0.1:33265",
+					"172.21.0.1:33265",
+					"172.22.0.1:33265",
+					"172.23.0.1:33265",
+					"172.24.0.1:33265",
+					"172.25.0.1:33265",
+					"172.26.0.1:33265",
+					"172.27.0.1:33265",
+					"172.28.0.1:33265",
+					"172.29.0.1:33265"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:08:53.6659712Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7663614990686871,
+				"StableID":   "n6SoutAsq221CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:79e977f28aea31c07b128d887f62f17eb0706d96543f604a6bde62c977e8c93a",
+				"DiscoKey":   "discokey:56194a27fd68adb5985c6835a386f1899944932d8d3fe35d12ab95c687a4c31f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41401",
+					"10.65.0.27:41401",
+					"172.17.0.1:41401",
+					"172.18.0.1:41401",
+					"172.19.0.1:41401",
+					"172.20.0.1:41401",
+					"172.21.0.1:41401",
+					"172.22.0.1:41401",
+					"172.23.0.1:41401",
+					"172.24.0.1:41401",
+					"172.25.0.1:41401",
+					"172.26.0.1:41401",
+					"172.27.0.1:41401",
+					"172.28.0.1:41401",
+					"172.29.0.1:41401"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:08:54.190741062Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2121942722652951,
+				"StableID":   "nNSf9Zq2aH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f36c3c3970962dfcc36ce6a541d4509d463971ab28c4109976925baa7c2b490f",
+				"DiscoKey":   "discokey:f99def593fda9b3d6cb7cb19f67e18c3d8a2c90eeb4dfd052708bfe4b0525f52",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:47554",
+					"10.65.0.27:47554",
+					"172.17.0.1:47554",
+					"172.18.0.1:47554",
+					"172.19.0.1:47554",
+					"172.20.0.1:47554",
+					"172.21.0.1:47554",
+					"172.22.0.1:47554",
+					"172.23.0.1:47554",
+					"172.24.0.1:47554",
+					"172.25.0.1:47554",
+					"172.26.0.1:47554",
+					"172.27.0.1:47554",
+					"172.28.0.1:47554",
+					"172.29.0.1:47554"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:08:55.262055371Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2824186552082163,
+				"StableID":   "nW8qdKb54P11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9e12cd5333229d8b262c24e639634f0b2640bb9ebcb6d54e062127e85d9634d",
+				"DiscoKey":   "discokey:a1895321d40bc0abe8bb7c50e2e19e954d6f79c952841cbb2264137c49cb2b43",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58140",
+					"10.65.0.27:58140",
+					"172.17.0.1:58140",
+					"172.18.0.1:58140",
+					"172.19.0.1:58140",
+					"172.20.0.1:58140",
+					"172.21.0.1:58140",
+					"172.22.0.1:58140",
+					"172.23.0.1:58140",
+					"172.24.0.1:58140",
+					"172.25.0.1:58140",
+					"172.26.0.1:58140",
+					"172.27.0.1:58140",
+					"172.28.0.1:58140",
+					"172.29.0.1:58140"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:08:55.803917237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4537882512937851,
+				"StableID":   "nGqLRmUDSc11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f077b56a647585f47d513ae290d2e5a2fb6eda9528d80805eacb32597d18d119",
+				"KeyExpiry":  "2026-11-09T09:08:56Z",
+				"DiscoKey":   "discokey:ab946cb435f8bc1678f756256fd0cbd141b60ae9d95a1f8ebea2d9bafe5a7237",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:42345",
+					"10.65.0.27:42345",
+					"172.17.0.1:42345",
+					"172.18.0.1:42345",
+					"172.19.0.1:42345",
+					"172.20.0.1:42345",
+					"172.21.0.1:42345",
+					"172.22.0.1:42345",
+					"172.23.0.1:42345",
+					"172.24.0.1:42345",
+					"172.25.0.1:42345",
+					"172.26.0.1:42345",
+					"172.27.0.1:42345",
+					"172.28.0.1:42345",
+					"172.29.0.1:42345"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:08:56.351352972Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1999870809800905,
+				"StableID":   "nt68EUDkcG11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6cdda19e804be5e2cd8f526ebed38e87594983f6271578fd06b30dc824beae1c",
+				"KeyExpiry":  "2026-11-09T09:08:56Z",
+				"DiscoKey":   "discokey:600398c30ac3534d44775a86afb7555cdeb2cf8caa8250cd98a7fe05aa0a5a54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38381",
+					"10.65.0.27:38381",
+					"172.17.0.1:38381",
+					"172.18.0.1:38381",
+					"172.19.0.1:38381",
+					"172.20.0.1:38381",
+					"172.21.0.1:38381",
+					"172.22.0.1:38381",
+					"172.23.0.1:38381",
+					"172.24.0.1:38381",
+					"172.25.0.1:38381",
+					"172.26.0.1:38381",
+					"172.27.0.1:38381",
+					"172.28.0.1:38381",
+					"172.29.0.1:38381"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:08:56.900863642Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6973026628775446,
+				"StableID":   "nXPGBxa6Tw11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d5d8fefebcb8420b272565ade83a1d37b7c82ea35b29f4448a561e3610ca3b60",
+				"KeyExpiry":  "2026-11-09T09:08:57Z",
+				"DiscoKey":   "discokey:a2aaaf10268009cf085a278300b0b82060d85f62dcc68d3d35683f1284e1bb2b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33165",
+					"10.65.0.27:33165",
+					"172.17.0.1:33165",
+					"172.18.0.1:33165",
+					"172.19.0.1:33165",
+					"172.20.0.1:33165",
+					"172.21.0.1:33165",
+					"172.22.0.1:33165",
+					"172.23.0.1:33165",
+					"172.24.0.1:33165",
+					"172.25.0.1:33165",
+					"172.26.0.1:33165",
+					"172.27.0.1:33165",
+					"172.28.0.1:33165",
+					"172.29.0.1:33165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:08:57.437877673Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8861425300128914": {
+				"ID":          8861425300128914,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-dst-trailing-whitespace.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-dst-trailing-whitespace.hujson
@@ -1,0 +1,22348 @@
+// ssh-dst-trailing-whitespace
+//
+// ssh dst has trailing whitespace
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-13T09:09:42Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-dst-trailing-whitespace",
+	"description":    "ssh dst has trailing whitespace",
+	"category":       "ssh",
+	"captured_at":    "2026-05-13T09:09:42.729894439Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                              \n  \n                                                                       \n                        \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh dst has trailing whitespace\",\n\t\"id\":          \"ssh-dst-trailing-whitespace\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server \"],\n\t\t\"src\":    [\"thor@example.org\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-edges/ssh-dst-trailing-whitespace.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server "],
+				"src":    ["thor@example.org"],
+				"users":  ["root"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2081825077297187,
+				"StableID":   "nkwvCr1sFH11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       2081825077297187,
+				"Key":        "nodekey:83b7fe43ccf866075f0328181d2d70add517cc694bcc0056a9a856f4d8673307",
+				"DiscoKey":   "discokey:343144325f073c39cc74a2331742af006c61e006957f60786a46742dcb0df42b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49517",
+					"10.65.0.27:49517",
+					"172.17.0.1:49517",
+					"172.18.0.1:49517",
+					"172.19.0.1:49517",
+					"172.20.0.1:49517",
+					"172.21.0.1:49517",
+					"172.22.0.1:49517",
+					"172.23.0.1:49517",
+					"172.24.0.1:49517",
+					"172.25.0.1:49517",
+					"172.26.0.1:49517",
+					"172.27.0.1:49517",
+					"172.28.0.1:49517",
+					"172.29.0.1:49517"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:09:51.766590389Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:83b7fe43ccf866075f0328181d2d70add517cc694bcc0056a9a856f4d8673307",
+			"MachineKey": "mkey:7500ac9544418f23e96700e77b2c75a3b383b2049ed27256fccbce3bd5b15a0f",
+			"Peers": [{
+				"ID":         7545449853970951,
+				"StableID":   "nAL9R2BMv121CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf2b1c33b0339bfc285f5a3438d54d6ef6132de91e1006564a3bdd4766041531",
+				"DiscoKey":   "discokey:f0b35b8a47d7c0e75151d9102f26d7a6940a99da53b3cef76a2abf2cd74ab143",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52491",
+					"10.65.0.27:52491",
+					"172.17.0.1:52491",
+					"172.18.0.1:52491",
+					"172.19.0.1:52491",
+					"172.20.0.1:52491",
+					"172.21.0.1:52491",
+					"172.22.0.1:52491",
+					"172.23.0.1:52491",
+					"172.24.0.1:52491",
+					"172.25.0.1:52491",
+					"172.26.0.1:52491",
+					"172.27.0.1:52491",
+					"172.28.0.1:52491",
+					"172.29.0.1:52491"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:09:45.317446196Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6601191949024367,
+				"StableID":   "na6Jpt7hYt11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:222763516a281cf6b9de022760bdf90f572b3579368caed48197d273ba71893b",
+				"DiscoKey":   "discokey:2c8fc2aecdcac32fa49181d486093f1957845e202c75459b2ffcb6210bc2b216",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:49866",
+					"10.65.0.27:49866",
+					"172.17.0.1:49866",
+					"172.18.0.1:49866",
+					"172.19.0.1:49866",
+					"172.20.0.1:49866",
+					"172.21.0.1:49866",
+					"172.22.0.1:49866",
+					"172.23.0.1:49866",
+					"172.24.0.1:49866",
+					"172.25.0.1:49866",
+					"172.26.0.1:49866",
+					"172.27.0.1:49866",
+					"172.28.0.1:49866",
+					"172.29.0.1:49866"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:09:45.860172783Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5641686272672076,
+				"StableID":   "nmKQsqX84m11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee3c3576175d8b875911c1d25f8a5ec9f1a2547f2a616619106fca5dc0d6a158",
+				"DiscoKey":   "discokey:a12ef384bffb0c4f6562eeb34d49eeaadbb5b72e68752d1dfed195d161552c09",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41012",
+					"10.65.0.27:41012",
+					"172.17.0.1:41012",
+					"172.18.0.1:41012",
+					"172.19.0.1:41012",
+					"172.20.0.1:41012",
+					"172.21.0.1:41012",
+					"172.22.0.1:41012",
+					"172.23.0.1:41012",
+					"172.24.0.1:41012",
+					"172.25.0.1:41012",
+					"172.26.0.1:41012",
+					"172.27.0.1:41012",
+					"172.28.0.1:41012",
+					"172.29.0.1:41012"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:09:46.400765907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         251905086834600,
+				"StableID":   "nhV5vv76y211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2217ed7e2d284d12862d48bc7faa3a80ac0cb8eb3930cfd7e7a754099ab4a510",
+				"DiscoKey":   "discokey:da9e2b384db2465a717bdcdf8097c7ad2d50375aa7396b19e287ec896869433a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39237",
+					"10.65.0.27:39237",
+					"172.17.0.1:39237",
+					"172.18.0.1:39237",
+					"172.19.0.1:39237",
+					"172.20.0.1:39237",
+					"172.21.0.1:39237",
+					"172.22.0.1:39237",
+					"172.23.0.1:39237",
+					"172.24.0.1:39237",
+					"172.25.0.1:39237",
+					"172.26.0.1:39237",
+					"172.27.0.1:39237",
+					"172.28.0.1:39237",
+					"172.29.0.1:39237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:09:46.936307856Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7311289998587147,
+				"StableID":   "nWaeq3CJ6z11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5ecfa4441cec326657a9c2364b42c3b0c0155207c5a7b0fbf4d9ddcb58d46840",
+				"DiscoKey":   "discokey:2639340901c617a5c4e800f56f3ea482279b4b1ce708f1146d42263fd9315f4c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37204",
+					"10.65.0.27:37204",
+					"172.17.0.1:37204",
+					"172.18.0.1:37204",
+					"172.19.0.1:37204",
+					"172.20.0.1:37204",
+					"172.21.0.1:37204",
+					"172.22.0.1:37204",
+					"172.23.0.1:37204",
+					"172.24.0.1:37204",
+					"172.25.0.1:37204",
+					"172.26.0.1:37204",
+					"172.27.0.1:37204",
+					"172.28.0.1:37204",
+					"172.29.0.1:37204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:09:47.731176987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3844756781655839,
+				"StableID":   "nxXY3zEJ2X11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b2d4a4fab6a729dad226e73c64361cead2b21704cbe50ce4de339d50e7c2201e",
+				"DiscoKey":   "discokey:3abb4edeebe7251467fb74569a6693d582580c7387555c3e009fc61c8b600432",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52682",
+					"10.65.0.27:52682",
+					"172.17.0.1:52682",
+					"172.18.0.1:52682",
+					"172.19.0.1:52682",
+					"172.20.0.1:52682",
+					"172.21.0.1:52682",
+					"172.22.0.1:52682",
+					"172.23.0.1:52682",
+					"172.24.0.1:52682",
+					"172.25.0.1:52682",
+					"172.26.0.1:52682",
+					"172.27.0.1:52682",
+					"172.28.0.1:52682",
+					"172.29.0.1:52682"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:09:48.276209785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7721349283250464,
+				"StableID":   "nR3Geek1J321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:53cdbd2a02f426b6f1050739e8bb0158ad820823d97ee947d0669b2795b4793e",
+				"DiscoKey":   "discokey:5001bf5d922a739562c393b47298ca093ec32bd94e61c1a0d7d7c929fd37004f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57229",
+					"10.65.0.27:57229",
+					"172.17.0.1:57229",
+					"172.18.0.1:57229",
+					"172.19.0.1:57229",
+					"172.20.0.1:57229",
+					"172.21.0.1:57229",
+					"172.22.0.1:57229",
+					"172.23.0.1:57229",
+					"172.24.0.1:57229",
+					"172.25.0.1:57229",
+					"172.26.0.1:57229",
+					"172.27.0.1:57229",
+					"172.28.0.1:57229",
+					"172.29.0.1:57229"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:09:48.810725022Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8529137471312197,
+				"StableID":   "nvwUgkyrb921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e50e83c32dfa9000e243698477cdf31ac700548548634bab8d625c811a391348",
+				"DiscoKey":   "discokey:03888741ff54921b0945f19c5a06bd8ceef017baa166c393be697ad1964fe950",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:40794",
+					"10.65.0.27:40794",
+					"172.17.0.1:40794",
+					"172.18.0.1:40794",
+					"172.19.0.1:40794",
+					"172.20.0.1:40794",
+					"172.21.0.1:40794",
+					"172.22.0.1:40794",
+					"172.23.0.1:40794",
+					"172.24.0.1:40794",
+					"172.25.0.1:40794",
+					"172.26.0.1:40794",
+					"172.27.0.1:40794",
+					"172.28.0.1:40794",
+					"172.29.0.1:40794"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:09:49.345404174Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1133665446225711,
+				"StableID":   "npspRCUSr911CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af3ef8c77445c102e5a391acf22ae87176cd45610d9b7a35ef2b9a045ce86456",
+				"DiscoKey":   "discokey:c6b68fa95ac1834525dcc473f9539e27101e3ddc7214e1af4f17800e31be205f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44144",
+					"10.65.0.27:44144",
+					"172.17.0.1:44144",
+					"172.18.0.1:44144",
+					"172.19.0.1:44144",
+					"172.20.0.1:44144",
+					"172.21.0.1:44144",
+					"172.22.0.1:44144",
+					"172.23.0.1:44144",
+					"172.24.0.1:44144",
+					"172.25.0.1:44144",
+					"172.26.0.1:44144",
+					"172.27.0.1:44144",
+					"172.28.0.1:44144",
+					"172.29.0.1:44144"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:09:49.906892291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4327360026868473,
+				"StableID":   "nLg7EnQsna11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41b456fff76f073210ae1f5b1885880231b492677d82ebb16e19de0d8d05db43",
+				"DiscoKey":   "discokey:cdc9d51564ec303392666bc959439f647b6bc871300fcd3dd462490a78acf213",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55548",
+					"10.65.0.27:55548",
+					"172.17.0.1:55548",
+					"172.18.0.1:55548",
+					"172.19.0.1:55548",
+					"172.20.0.1:55548",
+					"172.21.0.1:55548",
+					"172.22.0.1:55548",
+					"172.23.0.1:55548",
+					"172.24.0.1:55548",
+					"172.25.0.1:55548",
+					"172.26.0.1:55548",
+					"172.27.0.1:55548",
+					"172.28.0.1:55548",
+					"172.29.0.1:55548"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:09:50.591259506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         597170729733715,
+				"StableID":   "nQ3MURfTf511CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae9217620a86b09c23dd2142abf1d76912df58684961c3fc62349e1e0915b149",
+				"DiscoKey":   "discokey:db83951819aa37fa450ba0b748856d853ce43a7f68a336aee82e9c045782293c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:39960",
+					"10.65.0.27:39960",
+					"172.17.0.1:39960",
+					"172.18.0.1:39960",
+					"172.19.0.1:39960",
+					"172.20.0.1:39960",
+					"172.21.0.1:39960",
+					"172.22.0.1:39960",
+					"172.23.0.1:39960",
+					"172.24.0.1:39960",
+					"172.25.0.1:39960",
+					"172.26.0.1:39960",
+					"172.27.0.1:39960",
+					"172.28.0.1:39960",
+					"172.29.0.1:39960"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:09:51.225297251Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3838711917156017,
+				"StableID":   "ntev4GTZyW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3c743971520558c0b50716981af1a5d7a4dde1747220f21ed6fa1553635e9d55",
+				"KeyExpiry":  "2026-11-09T09:09:52Z",
+				"DiscoKey":   "discokey:556ade8dabe7d02cda014c2d15219252465583c8a9ba575c4681daec63fb8175",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:55726",
+					"10.65.0.27:55726",
+					"172.17.0.1:55726",
+					"172.18.0.1:55726",
+					"172.19.0.1:55726",
+					"172.20.0.1:55726",
+					"172.21.0.1:55726",
+					"172.22.0.1:55726",
+					"172.23.0.1:55726",
+					"172.24.0.1:55726",
+					"172.25.0.1:55726",
+					"172.26.0.1:55726",
+					"172.27.0.1:55726",
+					"172.28.0.1:55726",
+					"172.29.0.1:55726"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:09:52.315081835Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2445166358548395,
+				"StableID":   "nWnW2hNR6L11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fd26b4c5deb48dc304d605470b355fd64b1fdaa576cd27fd1d8a4967983b8f1f",
+				"KeyExpiry":  "2026-11-09T09:09:52Z",
+				"DiscoKey":   "discokey:8f584643e412b124e174756c1c32f22cb30373c7098161a0ae99bb240f134d68",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52334",
+					"10.65.0.27:52334",
+					"172.17.0.1:52334",
+					"172.18.0.1:52334",
+					"172.19.0.1:52334",
+					"172.20.0.1:52334",
+					"172.21.0.1:52334",
+					"172.22.0.1:52334",
+					"172.23.0.1:52334",
+					"172.24.0.1:52334",
+					"172.25.0.1:52334",
+					"172.26.0.1:52334",
+					"172.27.0.1:52334",
+					"172.28.0.1:52334",
+					"172.29.0.1:52334"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:09:52.849051482Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3210096661715349,
+				"StableID":   "n2m6YAor4S11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:93d6d7c637d9def2c70a30aa2ce458e01e904acfe931a04897fb0fab4cd26d29",
+				"KeyExpiry":  "2026-11-09T09:09:53Z",
+				"DiscoKey":   "discokey:15054df074c7d5425e6f305994dbbc8d96cd540b1c34e640db359774fcce4226",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59567",
+					"10.65.0.27:59567",
+					"172.17.0.1:59567",
+					"172.18.0.1:59567",
+					"172.19.0.1:59567",
+					"172.20.0.1:59567",
+					"172.21.0.1:59567",
+					"172.22.0.1:59567",
+					"172.23.0.1:59567",
+					"172.24.0.1:59567",
+					"172.25.0.1:59567",
+					"172.26.0.1:59567",
+					"172.27.0.1:59567",
+					"172.28.0.1:59567",
+					"172.29.0.1:59567"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:09:53.390208111Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{
+				"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+				"sshUsers":   {"root": "root"},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				}
+			}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2081825077297187": {
+				"ID":          2081825077297187,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		},
+		"ssh_rules": [{
+			"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+			"sshUsers":   {"root": "root"},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}
+		}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3844756781655839,
+				"StableID":   "nxXY3zEJ2X11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       3844756781655839,
+				"Key":        "nodekey:b2d4a4fab6a729dad226e73c64361cead2b21704cbe50ce4de339d50e7c2201e",
+				"DiscoKey":   "discokey:3abb4edeebe7251467fb74569a6693d582580c7387555c3e009fc61c8b600432",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52682",
+					"10.65.0.27:52682",
+					"172.17.0.1:52682",
+					"172.18.0.1:52682",
+					"172.19.0.1:52682",
+					"172.20.0.1:52682",
+					"172.21.0.1:52682",
+					"172.22.0.1:52682",
+					"172.23.0.1:52682",
+					"172.24.0.1:52682",
+					"172.25.0.1:52682",
+					"172.26.0.1:52682",
+					"172.27.0.1:52682",
+					"172.28.0.1:52682",
+					"172.29.0.1:52682"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:09:48.276209785Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b2d4a4fab6a729dad226e73c64361cead2b21704cbe50ce4de339d50e7c2201e",
+			"MachineKey": "mkey:1e8891a160b3f6f04be81f3e6ac692a6d5324eda82a795e0c24500e08774f400",
+			"Peers": [{
+				"ID":         7545449853970951,
+				"StableID":   "nAL9R2BMv121CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf2b1c33b0339bfc285f5a3438d54d6ef6132de91e1006564a3bdd4766041531",
+				"DiscoKey":   "discokey:f0b35b8a47d7c0e75151d9102f26d7a6940a99da53b3cef76a2abf2cd74ab143",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52491",
+					"10.65.0.27:52491",
+					"172.17.0.1:52491",
+					"172.18.0.1:52491",
+					"172.19.0.1:52491",
+					"172.20.0.1:52491",
+					"172.21.0.1:52491",
+					"172.22.0.1:52491",
+					"172.23.0.1:52491",
+					"172.24.0.1:52491",
+					"172.25.0.1:52491",
+					"172.26.0.1:52491",
+					"172.27.0.1:52491",
+					"172.28.0.1:52491",
+					"172.29.0.1:52491"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:09:45.317446196Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6601191949024367,
+				"StableID":   "na6Jpt7hYt11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:222763516a281cf6b9de022760bdf90f572b3579368caed48197d273ba71893b",
+				"DiscoKey":   "discokey:2c8fc2aecdcac32fa49181d486093f1957845e202c75459b2ffcb6210bc2b216",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:49866",
+					"10.65.0.27:49866",
+					"172.17.0.1:49866",
+					"172.18.0.1:49866",
+					"172.19.0.1:49866",
+					"172.20.0.1:49866",
+					"172.21.0.1:49866",
+					"172.22.0.1:49866",
+					"172.23.0.1:49866",
+					"172.24.0.1:49866",
+					"172.25.0.1:49866",
+					"172.26.0.1:49866",
+					"172.27.0.1:49866",
+					"172.28.0.1:49866",
+					"172.29.0.1:49866"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:09:45.860172783Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5641686272672076,
+				"StableID":   "nmKQsqX84m11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee3c3576175d8b875911c1d25f8a5ec9f1a2547f2a616619106fca5dc0d6a158",
+				"DiscoKey":   "discokey:a12ef384bffb0c4f6562eeb34d49eeaadbb5b72e68752d1dfed195d161552c09",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41012",
+					"10.65.0.27:41012",
+					"172.17.0.1:41012",
+					"172.18.0.1:41012",
+					"172.19.0.1:41012",
+					"172.20.0.1:41012",
+					"172.21.0.1:41012",
+					"172.22.0.1:41012",
+					"172.23.0.1:41012",
+					"172.24.0.1:41012",
+					"172.25.0.1:41012",
+					"172.26.0.1:41012",
+					"172.27.0.1:41012",
+					"172.28.0.1:41012",
+					"172.29.0.1:41012"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:09:46.400765907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         251905086834600,
+				"StableID":   "nhV5vv76y211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2217ed7e2d284d12862d48bc7faa3a80ac0cb8eb3930cfd7e7a754099ab4a510",
+				"DiscoKey":   "discokey:da9e2b384db2465a717bdcdf8097c7ad2d50375aa7396b19e287ec896869433a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39237",
+					"10.65.0.27:39237",
+					"172.17.0.1:39237",
+					"172.18.0.1:39237",
+					"172.19.0.1:39237",
+					"172.20.0.1:39237",
+					"172.21.0.1:39237",
+					"172.22.0.1:39237",
+					"172.23.0.1:39237",
+					"172.24.0.1:39237",
+					"172.25.0.1:39237",
+					"172.26.0.1:39237",
+					"172.27.0.1:39237",
+					"172.28.0.1:39237",
+					"172.29.0.1:39237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:09:46.936307856Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7311289998587147,
+				"StableID":   "nWaeq3CJ6z11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5ecfa4441cec326657a9c2364b42c3b0c0155207c5a7b0fbf4d9ddcb58d46840",
+				"DiscoKey":   "discokey:2639340901c617a5c4e800f56f3ea482279b4b1ce708f1146d42263fd9315f4c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37204",
+					"10.65.0.27:37204",
+					"172.17.0.1:37204",
+					"172.18.0.1:37204",
+					"172.19.0.1:37204",
+					"172.20.0.1:37204",
+					"172.21.0.1:37204",
+					"172.22.0.1:37204",
+					"172.23.0.1:37204",
+					"172.24.0.1:37204",
+					"172.25.0.1:37204",
+					"172.26.0.1:37204",
+					"172.27.0.1:37204",
+					"172.28.0.1:37204",
+					"172.29.0.1:37204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:09:47.731176987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7721349283250464,
+				"StableID":   "nR3Geek1J321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:53cdbd2a02f426b6f1050739e8bb0158ad820823d97ee947d0669b2795b4793e",
+				"DiscoKey":   "discokey:5001bf5d922a739562c393b47298ca093ec32bd94e61c1a0d7d7c929fd37004f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57229",
+					"10.65.0.27:57229",
+					"172.17.0.1:57229",
+					"172.18.0.1:57229",
+					"172.19.0.1:57229",
+					"172.20.0.1:57229",
+					"172.21.0.1:57229",
+					"172.22.0.1:57229",
+					"172.23.0.1:57229",
+					"172.24.0.1:57229",
+					"172.25.0.1:57229",
+					"172.26.0.1:57229",
+					"172.27.0.1:57229",
+					"172.28.0.1:57229",
+					"172.29.0.1:57229"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:09:48.810725022Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8529137471312197,
+				"StableID":   "nvwUgkyrb921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e50e83c32dfa9000e243698477cdf31ac700548548634bab8d625c811a391348",
+				"DiscoKey":   "discokey:03888741ff54921b0945f19c5a06bd8ceef017baa166c393be697ad1964fe950",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:40794",
+					"10.65.0.27:40794",
+					"172.17.0.1:40794",
+					"172.18.0.1:40794",
+					"172.19.0.1:40794",
+					"172.20.0.1:40794",
+					"172.21.0.1:40794",
+					"172.22.0.1:40794",
+					"172.23.0.1:40794",
+					"172.24.0.1:40794",
+					"172.25.0.1:40794",
+					"172.26.0.1:40794",
+					"172.27.0.1:40794",
+					"172.28.0.1:40794",
+					"172.29.0.1:40794"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:09:49.345404174Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1133665446225711,
+				"StableID":   "npspRCUSr911CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af3ef8c77445c102e5a391acf22ae87176cd45610d9b7a35ef2b9a045ce86456",
+				"DiscoKey":   "discokey:c6b68fa95ac1834525dcc473f9539e27101e3ddc7214e1af4f17800e31be205f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44144",
+					"10.65.0.27:44144",
+					"172.17.0.1:44144",
+					"172.18.0.1:44144",
+					"172.19.0.1:44144",
+					"172.20.0.1:44144",
+					"172.21.0.1:44144",
+					"172.22.0.1:44144",
+					"172.23.0.1:44144",
+					"172.24.0.1:44144",
+					"172.25.0.1:44144",
+					"172.26.0.1:44144",
+					"172.27.0.1:44144",
+					"172.28.0.1:44144",
+					"172.29.0.1:44144"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:09:49.906892291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4327360026868473,
+				"StableID":   "nLg7EnQsna11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41b456fff76f073210ae1f5b1885880231b492677d82ebb16e19de0d8d05db43",
+				"DiscoKey":   "discokey:cdc9d51564ec303392666bc959439f647b6bc871300fcd3dd462490a78acf213",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55548",
+					"10.65.0.27:55548",
+					"172.17.0.1:55548",
+					"172.18.0.1:55548",
+					"172.19.0.1:55548",
+					"172.20.0.1:55548",
+					"172.21.0.1:55548",
+					"172.22.0.1:55548",
+					"172.23.0.1:55548",
+					"172.24.0.1:55548",
+					"172.25.0.1:55548",
+					"172.26.0.1:55548",
+					"172.27.0.1:55548",
+					"172.28.0.1:55548",
+					"172.29.0.1:55548"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:09:50.591259506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         597170729733715,
+				"StableID":   "nQ3MURfTf511CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae9217620a86b09c23dd2142abf1d76912df58684961c3fc62349e1e0915b149",
+				"DiscoKey":   "discokey:db83951819aa37fa450ba0b748856d853ce43a7f68a336aee82e9c045782293c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:39960",
+					"10.65.0.27:39960",
+					"172.17.0.1:39960",
+					"172.18.0.1:39960",
+					"172.19.0.1:39960",
+					"172.20.0.1:39960",
+					"172.21.0.1:39960",
+					"172.22.0.1:39960",
+					"172.23.0.1:39960",
+					"172.24.0.1:39960",
+					"172.25.0.1:39960",
+					"172.26.0.1:39960",
+					"172.27.0.1:39960",
+					"172.28.0.1:39960",
+					"172.29.0.1:39960"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:09:51.225297251Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2081825077297187,
+				"StableID":   "nkwvCr1sFH11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83b7fe43ccf866075f0328181d2d70add517cc694bcc0056a9a856f4d8673307",
+				"DiscoKey":   "discokey:343144325f073c39cc74a2331742af006c61e006957f60786a46742dcb0df42b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49517",
+					"10.65.0.27:49517",
+					"172.17.0.1:49517",
+					"172.18.0.1:49517",
+					"172.19.0.1:49517",
+					"172.20.0.1:49517",
+					"172.21.0.1:49517",
+					"172.22.0.1:49517",
+					"172.23.0.1:49517",
+					"172.24.0.1:49517",
+					"172.25.0.1:49517",
+					"172.26.0.1:49517",
+					"172.27.0.1:49517",
+					"172.28.0.1:49517",
+					"172.29.0.1:49517"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:09:51.766590389Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3838711917156017,
+				"StableID":   "ntev4GTZyW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3c743971520558c0b50716981af1a5d7a4dde1747220f21ed6fa1553635e9d55",
+				"KeyExpiry":  "2026-11-09T09:09:52Z",
+				"DiscoKey":   "discokey:556ade8dabe7d02cda014c2d15219252465583c8a9ba575c4681daec63fb8175",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:55726",
+					"10.65.0.27:55726",
+					"172.17.0.1:55726",
+					"172.18.0.1:55726",
+					"172.19.0.1:55726",
+					"172.20.0.1:55726",
+					"172.21.0.1:55726",
+					"172.22.0.1:55726",
+					"172.23.0.1:55726",
+					"172.24.0.1:55726",
+					"172.25.0.1:55726",
+					"172.26.0.1:55726",
+					"172.27.0.1:55726",
+					"172.28.0.1:55726",
+					"172.29.0.1:55726"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:09:52.315081835Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2445166358548395,
+				"StableID":   "nWnW2hNR6L11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fd26b4c5deb48dc304d605470b355fd64b1fdaa576cd27fd1d8a4967983b8f1f",
+				"KeyExpiry":  "2026-11-09T09:09:52Z",
+				"DiscoKey":   "discokey:8f584643e412b124e174756c1c32f22cb30373c7098161a0ae99bb240f134d68",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52334",
+					"10.65.0.27:52334",
+					"172.17.0.1:52334",
+					"172.18.0.1:52334",
+					"172.19.0.1:52334",
+					"172.20.0.1:52334",
+					"172.21.0.1:52334",
+					"172.22.0.1:52334",
+					"172.23.0.1:52334",
+					"172.24.0.1:52334",
+					"172.25.0.1:52334",
+					"172.26.0.1:52334",
+					"172.27.0.1:52334",
+					"172.28.0.1:52334",
+					"172.29.0.1:52334"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:09:52.849051482Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3210096661715349,
+				"StableID":   "n2m6YAor4S11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:93d6d7c637d9def2c70a30aa2ce458e01e904acfe931a04897fb0fab4cd26d29",
+				"KeyExpiry":  "2026-11-09T09:09:53Z",
+				"DiscoKey":   "discokey:15054df074c7d5425e6f305994dbbc8d96cd540b1c34e640db359774fcce4226",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59567",
+					"10.65.0.27:59567",
+					"172.17.0.1:59567",
+					"172.18.0.1:59567",
+					"172.19.0.1:59567",
+					"172.20.0.1:59567",
+					"172.21.0.1:59567",
+					"172.22.0.1:59567",
+					"172.23.0.1:59567",
+					"172.24.0.1:59567",
+					"172.25.0.1:59567",
+					"172.26.0.1:59567",
+					"172.27.0.1:59567",
+					"172.28.0.1:59567",
+					"172.29.0.1:59567"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:09:53.390208111Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3844756781655839": {
+				"ID":          3844756781655839,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3210096661715349,
+				"StableID":   "n2m6YAor4S11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:93d6d7c637d9def2c70a30aa2ce458e01e904acfe931a04897fb0fab4cd26d29",
+				"KeyExpiry":  "2026-11-09T09:09:53Z",
+				"DiscoKey":   "discokey:15054df074c7d5425e6f305994dbbc8d96cd540b1c34e640db359774fcce4226",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59567",
+					"10.65.0.27:59567",
+					"172.17.0.1:59567",
+					"172.18.0.1:59567",
+					"172.19.0.1:59567",
+					"172.20.0.1:59567",
+					"172.21.0.1:59567",
+					"172.22.0.1:59567",
+					"172.23.0.1:59567",
+					"172.24.0.1:59567",
+					"172.25.0.1:59567",
+					"172.26.0.1:59567",
+					"172.27.0.1:59567",
+					"172.28.0.1:59567",
+					"172.29.0.1:59567"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:09:53.390208111Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:93d6d7c637d9def2c70a30aa2ce458e01e904acfe931a04897fb0fab4cd26d29",
+			"MachineKey": "mkey:6ef6d3efe854a5f4e12d51e9e8d473c42d4746801604fa0d416a2f11bb91b437",
+			"Peers": [{
+				"ID":         7545449853970951,
+				"StableID":   "nAL9R2BMv121CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf2b1c33b0339bfc285f5a3438d54d6ef6132de91e1006564a3bdd4766041531",
+				"DiscoKey":   "discokey:f0b35b8a47d7c0e75151d9102f26d7a6940a99da53b3cef76a2abf2cd74ab143",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52491",
+					"10.65.0.27:52491",
+					"172.17.0.1:52491",
+					"172.18.0.1:52491",
+					"172.19.0.1:52491",
+					"172.20.0.1:52491",
+					"172.21.0.1:52491",
+					"172.22.0.1:52491",
+					"172.23.0.1:52491",
+					"172.24.0.1:52491",
+					"172.25.0.1:52491",
+					"172.26.0.1:52491",
+					"172.27.0.1:52491",
+					"172.28.0.1:52491",
+					"172.29.0.1:52491"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:09:45.317446196Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6601191949024367,
+				"StableID":   "na6Jpt7hYt11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:222763516a281cf6b9de022760bdf90f572b3579368caed48197d273ba71893b",
+				"DiscoKey":   "discokey:2c8fc2aecdcac32fa49181d486093f1957845e202c75459b2ffcb6210bc2b216",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:49866",
+					"10.65.0.27:49866",
+					"172.17.0.1:49866",
+					"172.18.0.1:49866",
+					"172.19.0.1:49866",
+					"172.20.0.1:49866",
+					"172.21.0.1:49866",
+					"172.22.0.1:49866",
+					"172.23.0.1:49866",
+					"172.24.0.1:49866",
+					"172.25.0.1:49866",
+					"172.26.0.1:49866",
+					"172.27.0.1:49866",
+					"172.28.0.1:49866",
+					"172.29.0.1:49866"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:09:45.860172783Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5641686272672076,
+				"StableID":   "nmKQsqX84m11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee3c3576175d8b875911c1d25f8a5ec9f1a2547f2a616619106fca5dc0d6a158",
+				"DiscoKey":   "discokey:a12ef384bffb0c4f6562eeb34d49eeaadbb5b72e68752d1dfed195d161552c09",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41012",
+					"10.65.0.27:41012",
+					"172.17.0.1:41012",
+					"172.18.0.1:41012",
+					"172.19.0.1:41012",
+					"172.20.0.1:41012",
+					"172.21.0.1:41012",
+					"172.22.0.1:41012",
+					"172.23.0.1:41012",
+					"172.24.0.1:41012",
+					"172.25.0.1:41012",
+					"172.26.0.1:41012",
+					"172.27.0.1:41012",
+					"172.28.0.1:41012",
+					"172.29.0.1:41012"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:09:46.400765907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         251905086834600,
+				"StableID":   "nhV5vv76y211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2217ed7e2d284d12862d48bc7faa3a80ac0cb8eb3930cfd7e7a754099ab4a510",
+				"DiscoKey":   "discokey:da9e2b384db2465a717bdcdf8097c7ad2d50375aa7396b19e287ec896869433a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39237",
+					"10.65.0.27:39237",
+					"172.17.0.1:39237",
+					"172.18.0.1:39237",
+					"172.19.0.1:39237",
+					"172.20.0.1:39237",
+					"172.21.0.1:39237",
+					"172.22.0.1:39237",
+					"172.23.0.1:39237",
+					"172.24.0.1:39237",
+					"172.25.0.1:39237",
+					"172.26.0.1:39237",
+					"172.27.0.1:39237",
+					"172.28.0.1:39237",
+					"172.29.0.1:39237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:09:46.936307856Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7311289998587147,
+				"StableID":   "nWaeq3CJ6z11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5ecfa4441cec326657a9c2364b42c3b0c0155207c5a7b0fbf4d9ddcb58d46840",
+				"DiscoKey":   "discokey:2639340901c617a5c4e800f56f3ea482279b4b1ce708f1146d42263fd9315f4c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37204",
+					"10.65.0.27:37204",
+					"172.17.0.1:37204",
+					"172.18.0.1:37204",
+					"172.19.0.1:37204",
+					"172.20.0.1:37204",
+					"172.21.0.1:37204",
+					"172.22.0.1:37204",
+					"172.23.0.1:37204",
+					"172.24.0.1:37204",
+					"172.25.0.1:37204",
+					"172.26.0.1:37204",
+					"172.27.0.1:37204",
+					"172.28.0.1:37204",
+					"172.29.0.1:37204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:09:47.731176987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3844756781655839,
+				"StableID":   "nxXY3zEJ2X11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b2d4a4fab6a729dad226e73c64361cead2b21704cbe50ce4de339d50e7c2201e",
+				"DiscoKey":   "discokey:3abb4edeebe7251467fb74569a6693d582580c7387555c3e009fc61c8b600432",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52682",
+					"10.65.0.27:52682",
+					"172.17.0.1:52682",
+					"172.18.0.1:52682",
+					"172.19.0.1:52682",
+					"172.20.0.1:52682",
+					"172.21.0.1:52682",
+					"172.22.0.1:52682",
+					"172.23.0.1:52682",
+					"172.24.0.1:52682",
+					"172.25.0.1:52682",
+					"172.26.0.1:52682",
+					"172.27.0.1:52682",
+					"172.28.0.1:52682",
+					"172.29.0.1:52682"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:09:48.276209785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7721349283250464,
+				"StableID":   "nR3Geek1J321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:53cdbd2a02f426b6f1050739e8bb0158ad820823d97ee947d0669b2795b4793e",
+				"DiscoKey":   "discokey:5001bf5d922a739562c393b47298ca093ec32bd94e61c1a0d7d7c929fd37004f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57229",
+					"10.65.0.27:57229",
+					"172.17.0.1:57229",
+					"172.18.0.1:57229",
+					"172.19.0.1:57229",
+					"172.20.0.1:57229",
+					"172.21.0.1:57229",
+					"172.22.0.1:57229",
+					"172.23.0.1:57229",
+					"172.24.0.1:57229",
+					"172.25.0.1:57229",
+					"172.26.0.1:57229",
+					"172.27.0.1:57229",
+					"172.28.0.1:57229",
+					"172.29.0.1:57229"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:09:48.810725022Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8529137471312197,
+				"StableID":   "nvwUgkyrb921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e50e83c32dfa9000e243698477cdf31ac700548548634bab8d625c811a391348",
+				"DiscoKey":   "discokey:03888741ff54921b0945f19c5a06bd8ceef017baa166c393be697ad1964fe950",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:40794",
+					"10.65.0.27:40794",
+					"172.17.0.1:40794",
+					"172.18.0.1:40794",
+					"172.19.0.1:40794",
+					"172.20.0.1:40794",
+					"172.21.0.1:40794",
+					"172.22.0.1:40794",
+					"172.23.0.1:40794",
+					"172.24.0.1:40794",
+					"172.25.0.1:40794",
+					"172.26.0.1:40794",
+					"172.27.0.1:40794",
+					"172.28.0.1:40794",
+					"172.29.0.1:40794"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:09:49.345404174Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1133665446225711,
+				"StableID":   "npspRCUSr911CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af3ef8c77445c102e5a391acf22ae87176cd45610d9b7a35ef2b9a045ce86456",
+				"DiscoKey":   "discokey:c6b68fa95ac1834525dcc473f9539e27101e3ddc7214e1af4f17800e31be205f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44144",
+					"10.65.0.27:44144",
+					"172.17.0.1:44144",
+					"172.18.0.1:44144",
+					"172.19.0.1:44144",
+					"172.20.0.1:44144",
+					"172.21.0.1:44144",
+					"172.22.0.1:44144",
+					"172.23.0.1:44144",
+					"172.24.0.1:44144",
+					"172.25.0.1:44144",
+					"172.26.0.1:44144",
+					"172.27.0.1:44144",
+					"172.28.0.1:44144",
+					"172.29.0.1:44144"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:09:49.906892291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4327360026868473,
+				"StableID":   "nLg7EnQsna11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41b456fff76f073210ae1f5b1885880231b492677d82ebb16e19de0d8d05db43",
+				"DiscoKey":   "discokey:cdc9d51564ec303392666bc959439f647b6bc871300fcd3dd462490a78acf213",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55548",
+					"10.65.0.27:55548",
+					"172.17.0.1:55548",
+					"172.18.0.1:55548",
+					"172.19.0.1:55548",
+					"172.20.0.1:55548",
+					"172.21.0.1:55548",
+					"172.22.0.1:55548",
+					"172.23.0.1:55548",
+					"172.24.0.1:55548",
+					"172.25.0.1:55548",
+					"172.26.0.1:55548",
+					"172.27.0.1:55548",
+					"172.28.0.1:55548",
+					"172.29.0.1:55548"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:09:50.591259506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         597170729733715,
+				"StableID":   "nQ3MURfTf511CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae9217620a86b09c23dd2142abf1d76912df58684961c3fc62349e1e0915b149",
+				"DiscoKey":   "discokey:db83951819aa37fa450ba0b748856d853ce43a7f68a336aee82e9c045782293c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:39960",
+					"10.65.0.27:39960",
+					"172.17.0.1:39960",
+					"172.18.0.1:39960",
+					"172.19.0.1:39960",
+					"172.20.0.1:39960",
+					"172.21.0.1:39960",
+					"172.22.0.1:39960",
+					"172.23.0.1:39960",
+					"172.24.0.1:39960",
+					"172.25.0.1:39960",
+					"172.26.0.1:39960",
+					"172.27.0.1:39960",
+					"172.28.0.1:39960",
+					"172.29.0.1:39960"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:09:51.225297251Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2081825077297187,
+				"StableID":   "nkwvCr1sFH11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83b7fe43ccf866075f0328181d2d70add517cc694bcc0056a9a856f4d8673307",
+				"DiscoKey":   "discokey:343144325f073c39cc74a2331742af006c61e006957f60786a46742dcb0df42b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49517",
+					"10.65.0.27:49517",
+					"172.17.0.1:49517",
+					"172.18.0.1:49517",
+					"172.19.0.1:49517",
+					"172.20.0.1:49517",
+					"172.21.0.1:49517",
+					"172.22.0.1:49517",
+					"172.23.0.1:49517",
+					"172.24.0.1:49517",
+					"172.25.0.1:49517",
+					"172.26.0.1:49517",
+					"172.27.0.1:49517",
+					"172.28.0.1:49517",
+					"172.29.0.1:49517"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:09:51.766590389Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3838711917156017,
+				"StableID":   "ntev4GTZyW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3c743971520558c0b50716981af1a5d7a4dde1747220f21ed6fa1553635e9d55",
+				"KeyExpiry":  "2026-11-09T09:09:52Z",
+				"DiscoKey":   "discokey:556ade8dabe7d02cda014c2d15219252465583c8a9ba575c4681daec63fb8175",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:55726",
+					"10.65.0.27:55726",
+					"172.17.0.1:55726",
+					"172.18.0.1:55726",
+					"172.19.0.1:55726",
+					"172.20.0.1:55726",
+					"172.21.0.1:55726",
+					"172.22.0.1:55726",
+					"172.23.0.1:55726",
+					"172.24.0.1:55726",
+					"172.25.0.1:55726",
+					"172.26.0.1:55726",
+					"172.27.0.1:55726",
+					"172.28.0.1:55726",
+					"172.29.0.1:55726"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:09:52.315081835Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2445166358548395,
+				"StableID":   "nWnW2hNR6L11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fd26b4c5deb48dc304d605470b355fd64b1fdaa576cd27fd1d8a4967983b8f1f",
+				"KeyExpiry":  "2026-11-09T09:09:52Z",
+				"DiscoKey":   "discokey:8f584643e412b124e174756c1c32f22cb30373c7098161a0ae99bb240f134d68",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52334",
+					"10.65.0.27:52334",
+					"172.17.0.1:52334",
+					"172.18.0.1:52334",
+					"172.19.0.1:52334",
+					"172.20.0.1:52334",
+					"172.21.0.1:52334",
+					"172.22.0.1:52334",
+					"172.23.0.1:52334",
+					"172.24.0.1:52334",
+					"172.25.0.1:52334",
+					"172.26.0.1:52334",
+					"172.27.0.1:52334",
+					"172.28.0.1:52334",
+					"172.29.0.1:52334"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:09:52.849051482Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5641686272672076,
+				"StableID":   "nmKQsqX84m11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       5641686272672076,
+				"Key":        "nodekey:ee3c3576175d8b875911c1d25f8a5ec9f1a2547f2a616619106fca5dc0d6a158",
+				"DiscoKey":   "discokey:a12ef384bffb0c4f6562eeb34d49eeaadbb5b72e68752d1dfed195d161552c09",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41012",
+					"10.65.0.27:41012",
+					"172.17.0.1:41012",
+					"172.18.0.1:41012",
+					"172.19.0.1:41012",
+					"172.20.0.1:41012",
+					"172.21.0.1:41012",
+					"172.22.0.1:41012",
+					"172.23.0.1:41012",
+					"172.24.0.1:41012",
+					"172.25.0.1:41012",
+					"172.26.0.1:41012",
+					"172.27.0.1:41012",
+					"172.28.0.1:41012",
+					"172.29.0.1:41012"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:09:46.400765907Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ee3c3576175d8b875911c1d25f8a5ec9f1a2547f2a616619106fca5dc0d6a158",
+			"MachineKey": "mkey:ebf7947048ea40a95b769f823350480c9adbae83f4ac87f716331a1d19892a7d",
+			"Peers": [{
+				"ID":         7545449853970951,
+				"StableID":   "nAL9R2BMv121CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf2b1c33b0339bfc285f5a3438d54d6ef6132de91e1006564a3bdd4766041531",
+				"DiscoKey":   "discokey:f0b35b8a47d7c0e75151d9102f26d7a6940a99da53b3cef76a2abf2cd74ab143",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52491",
+					"10.65.0.27:52491",
+					"172.17.0.1:52491",
+					"172.18.0.1:52491",
+					"172.19.0.1:52491",
+					"172.20.0.1:52491",
+					"172.21.0.1:52491",
+					"172.22.0.1:52491",
+					"172.23.0.1:52491",
+					"172.24.0.1:52491",
+					"172.25.0.1:52491",
+					"172.26.0.1:52491",
+					"172.27.0.1:52491",
+					"172.28.0.1:52491",
+					"172.29.0.1:52491"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:09:45.317446196Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6601191949024367,
+				"StableID":   "na6Jpt7hYt11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:222763516a281cf6b9de022760bdf90f572b3579368caed48197d273ba71893b",
+				"DiscoKey":   "discokey:2c8fc2aecdcac32fa49181d486093f1957845e202c75459b2ffcb6210bc2b216",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:49866",
+					"10.65.0.27:49866",
+					"172.17.0.1:49866",
+					"172.18.0.1:49866",
+					"172.19.0.1:49866",
+					"172.20.0.1:49866",
+					"172.21.0.1:49866",
+					"172.22.0.1:49866",
+					"172.23.0.1:49866",
+					"172.24.0.1:49866",
+					"172.25.0.1:49866",
+					"172.26.0.1:49866",
+					"172.27.0.1:49866",
+					"172.28.0.1:49866",
+					"172.29.0.1:49866"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:09:45.860172783Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         251905086834600,
+				"StableID":   "nhV5vv76y211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2217ed7e2d284d12862d48bc7faa3a80ac0cb8eb3930cfd7e7a754099ab4a510",
+				"DiscoKey":   "discokey:da9e2b384db2465a717bdcdf8097c7ad2d50375aa7396b19e287ec896869433a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39237",
+					"10.65.0.27:39237",
+					"172.17.0.1:39237",
+					"172.18.0.1:39237",
+					"172.19.0.1:39237",
+					"172.20.0.1:39237",
+					"172.21.0.1:39237",
+					"172.22.0.1:39237",
+					"172.23.0.1:39237",
+					"172.24.0.1:39237",
+					"172.25.0.1:39237",
+					"172.26.0.1:39237",
+					"172.27.0.1:39237",
+					"172.28.0.1:39237",
+					"172.29.0.1:39237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:09:46.936307856Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7311289998587147,
+				"StableID":   "nWaeq3CJ6z11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5ecfa4441cec326657a9c2364b42c3b0c0155207c5a7b0fbf4d9ddcb58d46840",
+				"DiscoKey":   "discokey:2639340901c617a5c4e800f56f3ea482279b4b1ce708f1146d42263fd9315f4c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37204",
+					"10.65.0.27:37204",
+					"172.17.0.1:37204",
+					"172.18.0.1:37204",
+					"172.19.0.1:37204",
+					"172.20.0.1:37204",
+					"172.21.0.1:37204",
+					"172.22.0.1:37204",
+					"172.23.0.1:37204",
+					"172.24.0.1:37204",
+					"172.25.0.1:37204",
+					"172.26.0.1:37204",
+					"172.27.0.1:37204",
+					"172.28.0.1:37204",
+					"172.29.0.1:37204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:09:47.731176987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3844756781655839,
+				"StableID":   "nxXY3zEJ2X11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b2d4a4fab6a729dad226e73c64361cead2b21704cbe50ce4de339d50e7c2201e",
+				"DiscoKey":   "discokey:3abb4edeebe7251467fb74569a6693d582580c7387555c3e009fc61c8b600432",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52682",
+					"10.65.0.27:52682",
+					"172.17.0.1:52682",
+					"172.18.0.1:52682",
+					"172.19.0.1:52682",
+					"172.20.0.1:52682",
+					"172.21.0.1:52682",
+					"172.22.0.1:52682",
+					"172.23.0.1:52682",
+					"172.24.0.1:52682",
+					"172.25.0.1:52682",
+					"172.26.0.1:52682",
+					"172.27.0.1:52682",
+					"172.28.0.1:52682",
+					"172.29.0.1:52682"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:09:48.276209785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7721349283250464,
+				"StableID":   "nR3Geek1J321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:53cdbd2a02f426b6f1050739e8bb0158ad820823d97ee947d0669b2795b4793e",
+				"DiscoKey":   "discokey:5001bf5d922a739562c393b47298ca093ec32bd94e61c1a0d7d7c929fd37004f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57229",
+					"10.65.0.27:57229",
+					"172.17.0.1:57229",
+					"172.18.0.1:57229",
+					"172.19.0.1:57229",
+					"172.20.0.1:57229",
+					"172.21.0.1:57229",
+					"172.22.0.1:57229",
+					"172.23.0.1:57229",
+					"172.24.0.1:57229",
+					"172.25.0.1:57229",
+					"172.26.0.1:57229",
+					"172.27.0.1:57229",
+					"172.28.0.1:57229",
+					"172.29.0.1:57229"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:09:48.810725022Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8529137471312197,
+				"StableID":   "nvwUgkyrb921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e50e83c32dfa9000e243698477cdf31ac700548548634bab8d625c811a391348",
+				"DiscoKey":   "discokey:03888741ff54921b0945f19c5a06bd8ceef017baa166c393be697ad1964fe950",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:40794",
+					"10.65.0.27:40794",
+					"172.17.0.1:40794",
+					"172.18.0.1:40794",
+					"172.19.0.1:40794",
+					"172.20.0.1:40794",
+					"172.21.0.1:40794",
+					"172.22.0.1:40794",
+					"172.23.0.1:40794",
+					"172.24.0.1:40794",
+					"172.25.0.1:40794",
+					"172.26.0.1:40794",
+					"172.27.0.1:40794",
+					"172.28.0.1:40794",
+					"172.29.0.1:40794"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:09:49.345404174Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1133665446225711,
+				"StableID":   "npspRCUSr911CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af3ef8c77445c102e5a391acf22ae87176cd45610d9b7a35ef2b9a045ce86456",
+				"DiscoKey":   "discokey:c6b68fa95ac1834525dcc473f9539e27101e3ddc7214e1af4f17800e31be205f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44144",
+					"10.65.0.27:44144",
+					"172.17.0.1:44144",
+					"172.18.0.1:44144",
+					"172.19.0.1:44144",
+					"172.20.0.1:44144",
+					"172.21.0.1:44144",
+					"172.22.0.1:44144",
+					"172.23.0.1:44144",
+					"172.24.0.1:44144",
+					"172.25.0.1:44144",
+					"172.26.0.1:44144",
+					"172.27.0.1:44144",
+					"172.28.0.1:44144",
+					"172.29.0.1:44144"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:09:49.906892291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4327360026868473,
+				"StableID":   "nLg7EnQsna11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41b456fff76f073210ae1f5b1885880231b492677d82ebb16e19de0d8d05db43",
+				"DiscoKey":   "discokey:cdc9d51564ec303392666bc959439f647b6bc871300fcd3dd462490a78acf213",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55548",
+					"10.65.0.27:55548",
+					"172.17.0.1:55548",
+					"172.18.0.1:55548",
+					"172.19.0.1:55548",
+					"172.20.0.1:55548",
+					"172.21.0.1:55548",
+					"172.22.0.1:55548",
+					"172.23.0.1:55548",
+					"172.24.0.1:55548",
+					"172.25.0.1:55548",
+					"172.26.0.1:55548",
+					"172.27.0.1:55548",
+					"172.28.0.1:55548",
+					"172.29.0.1:55548"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:09:50.591259506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         597170729733715,
+				"StableID":   "nQ3MURfTf511CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae9217620a86b09c23dd2142abf1d76912df58684961c3fc62349e1e0915b149",
+				"DiscoKey":   "discokey:db83951819aa37fa450ba0b748856d853ce43a7f68a336aee82e9c045782293c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:39960",
+					"10.65.0.27:39960",
+					"172.17.0.1:39960",
+					"172.18.0.1:39960",
+					"172.19.0.1:39960",
+					"172.20.0.1:39960",
+					"172.21.0.1:39960",
+					"172.22.0.1:39960",
+					"172.23.0.1:39960",
+					"172.24.0.1:39960",
+					"172.25.0.1:39960",
+					"172.26.0.1:39960",
+					"172.27.0.1:39960",
+					"172.28.0.1:39960",
+					"172.29.0.1:39960"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:09:51.225297251Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2081825077297187,
+				"StableID":   "nkwvCr1sFH11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83b7fe43ccf866075f0328181d2d70add517cc694bcc0056a9a856f4d8673307",
+				"DiscoKey":   "discokey:343144325f073c39cc74a2331742af006c61e006957f60786a46742dcb0df42b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49517",
+					"10.65.0.27:49517",
+					"172.17.0.1:49517",
+					"172.18.0.1:49517",
+					"172.19.0.1:49517",
+					"172.20.0.1:49517",
+					"172.21.0.1:49517",
+					"172.22.0.1:49517",
+					"172.23.0.1:49517",
+					"172.24.0.1:49517",
+					"172.25.0.1:49517",
+					"172.26.0.1:49517",
+					"172.27.0.1:49517",
+					"172.28.0.1:49517",
+					"172.29.0.1:49517"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:09:51.766590389Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3838711917156017,
+				"StableID":   "ntev4GTZyW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3c743971520558c0b50716981af1a5d7a4dde1747220f21ed6fa1553635e9d55",
+				"KeyExpiry":  "2026-11-09T09:09:52Z",
+				"DiscoKey":   "discokey:556ade8dabe7d02cda014c2d15219252465583c8a9ba575c4681daec63fb8175",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:55726",
+					"10.65.0.27:55726",
+					"172.17.0.1:55726",
+					"172.18.0.1:55726",
+					"172.19.0.1:55726",
+					"172.20.0.1:55726",
+					"172.21.0.1:55726",
+					"172.22.0.1:55726",
+					"172.23.0.1:55726",
+					"172.24.0.1:55726",
+					"172.25.0.1:55726",
+					"172.26.0.1:55726",
+					"172.27.0.1:55726",
+					"172.28.0.1:55726",
+					"172.29.0.1:55726"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:09:52.315081835Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2445166358548395,
+				"StableID":   "nWnW2hNR6L11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fd26b4c5deb48dc304d605470b355fd64b1fdaa576cd27fd1d8a4967983b8f1f",
+				"KeyExpiry":  "2026-11-09T09:09:52Z",
+				"DiscoKey":   "discokey:8f584643e412b124e174756c1c32f22cb30373c7098161a0ae99bb240f134d68",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52334",
+					"10.65.0.27:52334",
+					"172.17.0.1:52334",
+					"172.18.0.1:52334",
+					"172.19.0.1:52334",
+					"172.20.0.1:52334",
+					"172.21.0.1:52334",
+					"172.22.0.1:52334",
+					"172.23.0.1:52334",
+					"172.24.0.1:52334",
+					"172.25.0.1:52334",
+					"172.26.0.1:52334",
+					"172.27.0.1:52334",
+					"172.28.0.1:52334",
+					"172.29.0.1:52334"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:09:52.849051482Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3210096661715349,
+				"StableID":   "n2m6YAor4S11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:93d6d7c637d9def2c70a30aa2ce458e01e904acfe931a04897fb0fab4cd26d29",
+				"KeyExpiry":  "2026-11-09T09:09:53Z",
+				"DiscoKey":   "discokey:15054df074c7d5425e6f305994dbbc8d96cd540b1c34e640db359774fcce4226",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59567",
+					"10.65.0.27:59567",
+					"172.17.0.1:59567",
+					"172.18.0.1:59567",
+					"172.19.0.1:59567",
+					"172.20.0.1:59567",
+					"172.21.0.1:59567",
+					"172.22.0.1:59567",
+					"172.23.0.1:59567",
+					"172.24.0.1:59567",
+					"172.25.0.1:59567",
+					"172.26.0.1:59567",
+					"172.27.0.1:59567",
+					"172.28.0.1:59567",
+					"172.29.0.1:59567"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:09:53.390208111Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5641686272672076": {
+				"ID":          5641686272672076,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8529137471312197,
+				"StableID":   "nvwUgkyrb921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       8529137471312197,
+				"Key":        "nodekey:e50e83c32dfa9000e243698477cdf31ac700548548634bab8d625c811a391348",
+				"DiscoKey":   "discokey:03888741ff54921b0945f19c5a06bd8ceef017baa166c393be697ad1964fe950",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:40794",
+					"10.65.0.27:40794",
+					"172.17.0.1:40794",
+					"172.18.0.1:40794",
+					"172.19.0.1:40794",
+					"172.20.0.1:40794",
+					"172.21.0.1:40794",
+					"172.22.0.1:40794",
+					"172.23.0.1:40794",
+					"172.24.0.1:40794",
+					"172.25.0.1:40794",
+					"172.26.0.1:40794",
+					"172.27.0.1:40794",
+					"172.28.0.1:40794",
+					"172.29.0.1:40794"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:09:49.345404174Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e50e83c32dfa9000e243698477cdf31ac700548548634bab8d625c811a391348",
+			"MachineKey": "mkey:ce0c6062b623300d42bf7719d8fbcf4b567a9a6a26acee6b22fe934dc7587c7a",
+			"Peers": [{
+				"ID":         7545449853970951,
+				"StableID":   "nAL9R2BMv121CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf2b1c33b0339bfc285f5a3438d54d6ef6132de91e1006564a3bdd4766041531",
+				"DiscoKey":   "discokey:f0b35b8a47d7c0e75151d9102f26d7a6940a99da53b3cef76a2abf2cd74ab143",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52491",
+					"10.65.0.27:52491",
+					"172.17.0.1:52491",
+					"172.18.0.1:52491",
+					"172.19.0.1:52491",
+					"172.20.0.1:52491",
+					"172.21.0.1:52491",
+					"172.22.0.1:52491",
+					"172.23.0.1:52491",
+					"172.24.0.1:52491",
+					"172.25.0.1:52491",
+					"172.26.0.1:52491",
+					"172.27.0.1:52491",
+					"172.28.0.1:52491",
+					"172.29.0.1:52491"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:09:45.317446196Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6601191949024367,
+				"StableID":   "na6Jpt7hYt11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:222763516a281cf6b9de022760bdf90f572b3579368caed48197d273ba71893b",
+				"DiscoKey":   "discokey:2c8fc2aecdcac32fa49181d486093f1957845e202c75459b2ffcb6210bc2b216",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:49866",
+					"10.65.0.27:49866",
+					"172.17.0.1:49866",
+					"172.18.0.1:49866",
+					"172.19.0.1:49866",
+					"172.20.0.1:49866",
+					"172.21.0.1:49866",
+					"172.22.0.1:49866",
+					"172.23.0.1:49866",
+					"172.24.0.1:49866",
+					"172.25.0.1:49866",
+					"172.26.0.1:49866",
+					"172.27.0.1:49866",
+					"172.28.0.1:49866",
+					"172.29.0.1:49866"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:09:45.860172783Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5641686272672076,
+				"StableID":   "nmKQsqX84m11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee3c3576175d8b875911c1d25f8a5ec9f1a2547f2a616619106fca5dc0d6a158",
+				"DiscoKey":   "discokey:a12ef384bffb0c4f6562eeb34d49eeaadbb5b72e68752d1dfed195d161552c09",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41012",
+					"10.65.0.27:41012",
+					"172.17.0.1:41012",
+					"172.18.0.1:41012",
+					"172.19.0.1:41012",
+					"172.20.0.1:41012",
+					"172.21.0.1:41012",
+					"172.22.0.1:41012",
+					"172.23.0.1:41012",
+					"172.24.0.1:41012",
+					"172.25.0.1:41012",
+					"172.26.0.1:41012",
+					"172.27.0.1:41012",
+					"172.28.0.1:41012",
+					"172.29.0.1:41012"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:09:46.400765907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         251905086834600,
+				"StableID":   "nhV5vv76y211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2217ed7e2d284d12862d48bc7faa3a80ac0cb8eb3930cfd7e7a754099ab4a510",
+				"DiscoKey":   "discokey:da9e2b384db2465a717bdcdf8097c7ad2d50375aa7396b19e287ec896869433a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39237",
+					"10.65.0.27:39237",
+					"172.17.0.1:39237",
+					"172.18.0.1:39237",
+					"172.19.0.1:39237",
+					"172.20.0.1:39237",
+					"172.21.0.1:39237",
+					"172.22.0.1:39237",
+					"172.23.0.1:39237",
+					"172.24.0.1:39237",
+					"172.25.0.1:39237",
+					"172.26.0.1:39237",
+					"172.27.0.1:39237",
+					"172.28.0.1:39237",
+					"172.29.0.1:39237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:09:46.936307856Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7311289998587147,
+				"StableID":   "nWaeq3CJ6z11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5ecfa4441cec326657a9c2364b42c3b0c0155207c5a7b0fbf4d9ddcb58d46840",
+				"DiscoKey":   "discokey:2639340901c617a5c4e800f56f3ea482279b4b1ce708f1146d42263fd9315f4c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37204",
+					"10.65.0.27:37204",
+					"172.17.0.1:37204",
+					"172.18.0.1:37204",
+					"172.19.0.1:37204",
+					"172.20.0.1:37204",
+					"172.21.0.1:37204",
+					"172.22.0.1:37204",
+					"172.23.0.1:37204",
+					"172.24.0.1:37204",
+					"172.25.0.1:37204",
+					"172.26.0.1:37204",
+					"172.27.0.1:37204",
+					"172.28.0.1:37204",
+					"172.29.0.1:37204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:09:47.731176987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3844756781655839,
+				"StableID":   "nxXY3zEJ2X11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b2d4a4fab6a729dad226e73c64361cead2b21704cbe50ce4de339d50e7c2201e",
+				"DiscoKey":   "discokey:3abb4edeebe7251467fb74569a6693d582580c7387555c3e009fc61c8b600432",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52682",
+					"10.65.0.27:52682",
+					"172.17.0.1:52682",
+					"172.18.0.1:52682",
+					"172.19.0.1:52682",
+					"172.20.0.1:52682",
+					"172.21.0.1:52682",
+					"172.22.0.1:52682",
+					"172.23.0.1:52682",
+					"172.24.0.1:52682",
+					"172.25.0.1:52682",
+					"172.26.0.1:52682",
+					"172.27.0.1:52682",
+					"172.28.0.1:52682",
+					"172.29.0.1:52682"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:09:48.276209785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7721349283250464,
+				"StableID":   "nR3Geek1J321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:53cdbd2a02f426b6f1050739e8bb0158ad820823d97ee947d0669b2795b4793e",
+				"DiscoKey":   "discokey:5001bf5d922a739562c393b47298ca093ec32bd94e61c1a0d7d7c929fd37004f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57229",
+					"10.65.0.27:57229",
+					"172.17.0.1:57229",
+					"172.18.0.1:57229",
+					"172.19.0.1:57229",
+					"172.20.0.1:57229",
+					"172.21.0.1:57229",
+					"172.22.0.1:57229",
+					"172.23.0.1:57229",
+					"172.24.0.1:57229",
+					"172.25.0.1:57229",
+					"172.26.0.1:57229",
+					"172.27.0.1:57229",
+					"172.28.0.1:57229",
+					"172.29.0.1:57229"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:09:48.810725022Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1133665446225711,
+				"StableID":   "npspRCUSr911CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af3ef8c77445c102e5a391acf22ae87176cd45610d9b7a35ef2b9a045ce86456",
+				"DiscoKey":   "discokey:c6b68fa95ac1834525dcc473f9539e27101e3ddc7214e1af4f17800e31be205f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44144",
+					"10.65.0.27:44144",
+					"172.17.0.1:44144",
+					"172.18.0.1:44144",
+					"172.19.0.1:44144",
+					"172.20.0.1:44144",
+					"172.21.0.1:44144",
+					"172.22.0.1:44144",
+					"172.23.0.1:44144",
+					"172.24.0.1:44144",
+					"172.25.0.1:44144",
+					"172.26.0.1:44144",
+					"172.27.0.1:44144",
+					"172.28.0.1:44144",
+					"172.29.0.1:44144"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:09:49.906892291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4327360026868473,
+				"StableID":   "nLg7EnQsna11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41b456fff76f073210ae1f5b1885880231b492677d82ebb16e19de0d8d05db43",
+				"DiscoKey":   "discokey:cdc9d51564ec303392666bc959439f647b6bc871300fcd3dd462490a78acf213",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55548",
+					"10.65.0.27:55548",
+					"172.17.0.1:55548",
+					"172.18.0.1:55548",
+					"172.19.0.1:55548",
+					"172.20.0.1:55548",
+					"172.21.0.1:55548",
+					"172.22.0.1:55548",
+					"172.23.0.1:55548",
+					"172.24.0.1:55548",
+					"172.25.0.1:55548",
+					"172.26.0.1:55548",
+					"172.27.0.1:55548",
+					"172.28.0.1:55548",
+					"172.29.0.1:55548"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:09:50.591259506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         597170729733715,
+				"StableID":   "nQ3MURfTf511CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae9217620a86b09c23dd2142abf1d76912df58684961c3fc62349e1e0915b149",
+				"DiscoKey":   "discokey:db83951819aa37fa450ba0b748856d853ce43a7f68a336aee82e9c045782293c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:39960",
+					"10.65.0.27:39960",
+					"172.17.0.1:39960",
+					"172.18.0.1:39960",
+					"172.19.0.1:39960",
+					"172.20.0.1:39960",
+					"172.21.0.1:39960",
+					"172.22.0.1:39960",
+					"172.23.0.1:39960",
+					"172.24.0.1:39960",
+					"172.25.0.1:39960",
+					"172.26.0.1:39960",
+					"172.27.0.1:39960",
+					"172.28.0.1:39960",
+					"172.29.0.1:39960"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:09:51.225297251Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2081825077297187,
+				"StableID":   "nkwvCr1sFH11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83b7fe43ccf866075f0328181d2d70add517cc694bcc0056a9a856f4d8673307",
+				"DiscoKey":   "discokey:343144325f073c39cc74a2331742af006c61e006957f60786a46742dcb0df42b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49517",
+					"10.65.0.27:49517",
+					"172.17.0.1:49517",
+					"172.18.0.1:49517",
+					"172.19.0.1:49517",
+					"172.20.0.1:49517",
+					"172.21.0.1:49517",
+					"172.22.0.1:49517",
+					"172.23.0.1:49517",
+					"172.24.0.1:49517",
+					"172.25.0.1:49517",
+					"172.26.0.1:49517",
+					"172.27.0.1:49517",
+					"172.28.0.1:49517",
+					"172.29.0.1:49517"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:09:51.766590389Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3838711917156017,
+				"StableID":   "ntev4GTZyW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3c743971520558c0b50716981af1a5d7a4dde1747220f21ed6fa1553635e9d55",
+				"KeyExpiry":  "2026-11-09T09:09:52Z",
+				"DiscoKey":   "discokey:556ade8dabe7d02cda014c2d15219252465583c8a9ba575c4681daec63fb8175",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:55726",
+					"10.65.0.27:55726",
+					"172.17.0.1:55726",
+					"172.18.0.1:55726",
+					"172.19.0.1:55726",
+					"172.20.0.1:55726",
+					"172.21.0.1:55726",
+					"172.22.0.1:55726",
+					"172.23.0.1:55726",
+					"172.24.0.1:55726",
+					"172.25.0.1:55726",
+					"172.26.0.1:55726",
+					"172.27.0.1:55726",
+					"172.28.0.1:55726",
+					"172.29.0.1:55726"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:09:52.315081835Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2445166358548395,
+				"StableID":   "nWnW2hNR6L11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fd26b4c5deb48dc304d605470b355fd64b1fdaa576cd27fd1d8a4967983b8f1f",
+				"KeyExpiry":  "2026-11-09T09:09:52Z",
+				"DiscoKey":   "discokey:8f584643e412b124e174756c1c32f22cb30373c7098161a0ae99bb240f134d68",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52334",
+					"10.65.0.27:52334",
+					"172.17.0.1:52334",
+					"172.18.0.1:52334",
+					"172.19.0.1:52334",
+					"172.20.0.1:52334",
+					"172.21.0.1:52334",
+					"172.22.0.1:52334",
+					"172.23.0.1:52334",
+					"172.24.0.1:52334",
+					"172.25.0.1:52334",
+					"172.26.0.1:52334",
+					"172.27.0.1:52334",
+					"172.28.0.1:52334",
+					"172.29.0.1:52334"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:09:52.849051482Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3210096661715349,
+				"StableID":   "n2m6YAor4S11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:93d6d7c637d9def2c70a30aa2ce458e01e904acfe931a04897fb0fab4cd26d29",
+				"KeyExpiry":  "2026-11-09T09:09:53Z",
+				"DiscoKey":   "discokey:15054df074c7d5425e6f305994dbbc8d96cd540b1c34e640db359774fcce4226",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59567",
+					"10.65.0.27:59567",
+					"172.17.0.1:59567",
+					"172.18.0.1:59567",
+					"172.19.0.1:59567",
+					"172.20.0.1:59567",
+					"172.21.0.1:59567",
+					"172.22.0.1:59567",
+					"172.23.0.1:59567",
+					"172.24.0.1:59567",
+					"172.25.0.1:59567",
+					"172.26.0.1:59567",
+					"172.27.0.1:59567",
+					"172.28.0.1:59567",
+					"172.29.0.1:59567"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:09:53.390208111Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8529137471312197": {
+				"ID":          8529137471312197,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3838711917156017,
+				"StableID":   "ntev4GTZyW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3c743971520558c0b50716981af1a5d7a4dde1747220f21ed6fa1553635e9d55",
+				"KeyExpiry":  "2026-11-09T09:09:52Z",
+				"DiscoKey":   "discokey:556ade8dabe7d02cda014c2d15219252465583c8a9ba575c4681daec63fb8175",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:55726",
+					"10.65.0.27:55726",
+					"172.17.0.1:55726",
+					"172.18.0.1:55726",
+					"172.19.0.1:55726",
+					"172.20.0.1:55726",
+					"172.21.0.1:55726",
+					"172.22.0.1:55726",
+					"172.23.0.1:55726",
+					"172.24.0.1:55726",
+					"172.25.0.1:55726",
+					"172.26.0.1:55726",
+					"172.27.0.1:55726",
+					"172.28.0.1:55726",
+					"172.29.0.1:55726"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:09:52.315081835Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3c743971520558c0b50716981af1a5d7a4dde1747220f21ed6fa1553635e9d55",
+			"MachineKey": "mkey:a94f720ea721608de5626290f0b7e200bbe7cd31c4b0cee3b53effad966d3137",
+			"Peers": [{
+				"ID":         7545449853970951,
+				"StableID":   "nAL9R2BMv121CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf2b1c33b0339bfc285f5a3438d54d6ef6132de91e1006564a3bdd4766041531",
+				"DiscoKey":   "discokey:f0b35b8a47d7c0e75151d9102f26d7a6940a99da53b3cef76a2abf2cd74ab143",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52491",
+					"10.65.0.27:52491",
+					"172.17.0.1:52491",
+					"172.18.0.1:52491",
+					"172.19.0.1:52491",
+					"172.20.0.1:52491",
+					"172.21.0.1:52491",
+					"172.22.0.1:52491",
+					"172.23.0.1:52491",
+					"172.24.0.1:52491",
+					"172.25.0.1:52491",
+					"172.26.0.1:52491",
+					"172.27.0.1:52491",
+					"172.28.0.1:52491",
+					"172.29.0.1:52491"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:09:45.317446196Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6601191949024367,
+				"StableID":   "na6Jpt7hYt11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:222763516a281cf6b9de022760bdf90f572b3579368caed48197d273ba71893b",
+				"DiscoKey":   "discokey:2c8fc2aecdcac32fa49181d486093f1957845e202c75459b2ffcb6210bc2b216",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:49866",
+					"10.65.0.27:49866",
+					"172.17.0.1:49866",
+					"172.18.0.1:49866",
+					"172.19.0.1:49866",
+					"172.20.0.1:49866",
+					"172.21.0.1:49866",
+					"172.22.0.1:49866",
+					"172.23.0.1:49866",
+					"172.24.0.1:49866",
+					"172.25.0.1:49866",
+					"172.26.0.1:49866",
+					"172.27.0.1:49866",
+					"172.28.0.1:49866",
+					"172.29.0.1:49866"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:09:45.860172783Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5641686272672076,
+				"StableID":   "nmKQsqX84m11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee3c3576175d8b875911c1d25f8a5ec9f1a2547f2a616619106fca5dc0d6a158",
+				"DiscoKey":   "discokey:a12ef384bffb0c4f6562eeb34d49eeaadbb5b72e68752d1dfed195d161552c09",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41012",
+					"10.65.0.27:41012",
+					"172.17.0.1:41012",
+					"172.18.0.1:41012",
+					"172.19.0.1:41012",
+					"172.20.0.1:41012",
+					"172.21.0.1:41012",
+					"172.22.0.1:41012",
+					"172.23.0.1:41012",
+					"172.24.0.1:41012",
+					"172.25.0.1:41012",
+					"172.26.0.1:41012",
+					"172.27.0.1:41012",
+					"172.28.0.1:41012",
+					"172.29.0.1:41012"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:09:46.400765907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         251905086834600,
+				"StableID":   "nhV5vv76y211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2217ed7e2d284d12862d48bc7faa3a80ac0cb8eb3930cfd7e7a754099ab4a510",
+				"DiscoKey":   "discokey:da9e2b384db2465a717bdcdf8097c7ad2d50375aa7396b19e287ec896869433a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39237",
+					"10.65.0.27:39237",
+					"172.17.0.1:39237",
+					"172.18.0.1:39237",
+					"172.19.0.1:39237",
+					"172.20.0.1:39237",
+					"172.21.0.1:39237",
+					"172.22.0.1:39237",
+					"172.23.0.1:39237",
+					"172.24.0.1:39237",
+					"172.25.0.1:39237",
+					"172.26.0.1:39237",
+					"172.27.0.1:39237",
+					"172.28.0.1:39237",
+					"172.29.0.1:39237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:09:46.936307856Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7311289998587147,
+				"StableID":   "nWaeq3CJ6z11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5ecfa4441cec326657a9c2364b42c3b0c0155207c5a7b0fbf4d9ddcb58d46840",
+				"DiscoKey":   "discokey:2639340901c617a5c4e800f56f3ea482279b4b1ce708f1146d42263fd9315f4c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37204",
+					"10.65.0.27:37204",
+					"172.17.0.1:37204",
+					"172.18.0.1:37204",
+					"172.19.0.1:37204",
+					"172.20.0.1:37204",
+					"172.21.0.1:37204",
+					"172.22.0.1:37204",
+					"172.23.0.1:37204",
+					"172.24.0.1:37204",
+					"172.25.0.1:37204",
+					"172.26.0.1:37204",
+					"172.27.0.1:37204",
+					"172.28.0.1:37204",
+					"172.29.0.1:37204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:09:47.731176987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3844756781655839,
+				"StableID":   "nxXY3zEJ2X11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b2d4a4fab6a729dad226e73c64361cead2b21704cbe50ce4de339d50e7c2201e",
+				"DiscoKey":   "discokey:3abb4edeebe7251467fb74569a6693d582580c7387555c3e009fc61c8b600432",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52682",
+					"10.65.0.27:52682",
+					"172.17.0.1:52682",
+					"172.18.0.1:52682",
+					"172.19.0.1:52682",
+					"172.20.0.1:52682",
+					"172.21.0.1:52682",
+					"172.22.0.1:52682",
+					"172.23.0.1:52682",
+					"172.24.0.1:52682",
+					"172.25.0.1:52682",
+					"172.26.0.1:52682",
+					"172.27.0.1:52682",
+					"172.28.0.1:52682",
+					"172.29.0.1:52682"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:09:48.276209785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7721349283250464,
+				"StableID":   "nR3Geek1J321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:53cdbd2a02f426b6f1050739e8bb0158ad820823d97ee947d0669b2795b4793e",
+				"DiscoKey":   "discokey:5001bf5d922a739562c393b47298ca093ec32bd94e61c1a0d7d7c929fd37004f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57229",
+					"10.65.0.27:57229",
+					"172.17.0.1:57229",
+					"172.18.0.1:57229",
+					"172.19.0.1:57229",
+					"172.20.0.1:57229",
+					"172.21.0.1:57229",
+					"172.22.0.1:57229",
+					"172.23.0.1:57229",
+					"172.24.0.1:57229",
+					"172.25.0.1:57229",
+					"172.26.0.1:57229",
+					"172.27.0.1:57229",
+					"172.28.0.1:57229",
+					"172.29.0.1:57229"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:09:48.810725022Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8529137471312197,
+				"StableID":   "nvwUgkyrb921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e50e83c32dfa9000e243698477cdf31ac700548548634bab8d625c811a391348",
+				"DiscoKey":   "discokey:03888741ff54921b0945f19c5a06bd8ceef017baa166c393be697ad1964fe950",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:40794",
+					"10.65.0.27:40794",
+					"172.17.0.1:40794",
+					"172.18.0.1:40794",
+					"172.19.0.1:40794",
+					"172.20.0.1:40794",
+					"172.21.0.1:40794",
+					"172.22.0.1:40794",
+					"172.23.0.1:40794",
+					"172.24.0.1:40794",
+					"172.25.0.1:40794",
+					"172.26.0.1:40794",
+					"172.27.0.1:40794",
+					"172.28.0.1:40794",
+					"172.29.0.1:40794"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:09:49.345404174Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1133665446225711,
+				"StableID":   "npspRCUSr911CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af3ef8c77445c102e5a391acf22ae87176cd45610d9b7a35ef2b9a045ce86456",
+				"DiscoKey":   "discokey:c6b68fa95ac1834525dcc473f9539e27101e3ddc7214e1af4f17800e31be205f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44144",
+					"10.65.0.27:44144",
+					"172.17.0.1:44144",
+					"172.18.0.1:44144",
+					"172.19.0.1:44144",
+					"172.20.0.1:44144",
+					"172.21.0.1:44144",
+					"172.22.0.1:44144",
+					"172.23.0.1:44144",
+					"172.24.0.1:44144",
+					"172.25.0.1:44144",
+					"172.26.0.1:44144",
+					"172.27.0.1:44144",
+					"172.28.0.1:44144",
+					"172.29.0.1:44144"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:09:49.906892291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4327360026868473,
+				"StableID":   "nLg7EnQsna11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41b456fff76f073210ae1f5b1885880231b492677d82ebb16e19de0d8d05db43",
+				"DiscoKey":   "discokey:cdc9d51564ec303392666bc959439f647b6bc871300fcd3dd462490a78acf213",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55548",
+					"10.65.0.27:55548",
+					"172.17.0.1:55548",
+					"172.18.0.1:55548",
+					"172.19.0.1:55548",
+					"172.20.0.1:55548",
+					"172.21.0.1:55548",
+					"172.22.0.1:55548",
+					"172.23.0.1:55548",
+					"172.24.0.1:55548",
+					"172.25.0.1:55548",
+					"172.26.0.1:55548",
+					"172.27.0.1:55548",
+					"172.28.0.1:55548",
+					"172.29.0.1:55548"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:09:50.591259506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         597170729733715,
+				"StableID":   "nQ3MURfTf511CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae9217620a86b09c23dd2142abf1d76912df58684961c3fc62349e1e0915b149",
+				"DiscoKey":   "discokey:db83951819aa37fa450ba0b748856d853ce43a7f68a336aee82e9c045782293c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:39960",
+					"10.65.0.27:39960",
+					"172.17.0.1:39960",
+					"172.18.0.1:39960",
+					"172.19.0.1:39960",
+					"172.20.0.1:39960",
+					"172.21.0.1:39960",
+					"172.22.0.1:39960",
+					"172.23.0.1:39960",
+					"172.24.0.1:39960",
+					"172.25.0.1:39960",
+					"172.26.0.1:39960",
+					"172.27.0.1:39960",
+					"172.28.0.1:39960",
+					"172.29.0.1:39960"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:09:51.225297251Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2081825077297187,
+				"StableID":   "nkwvCr1sFH11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83b7fe43ccf866075f0328181d2d70add517cc694bcc0056a9a856f4d8673307",
+				"DiscoKey":   "discokey:343144325f073c39cc74a2331742af006c61e006957f60786a46742dcb0df42b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49517",
+					"10.65.0.27:49517",
+					"172.17.0.1:49517",
+					"172.18.0.1:49517",
+					"172.19.0.1:49517",
+					"172.20.0.1:49517",
+					"172.21.0.1:49517",
+					"172.22.0.1:49517",
+					"172.23.0.1:49517",
+					"172.24.0.1:49517",
+					"172.25.0.1:49517",
+					"172.26.0.1:49517",
+					"172.27.0.1:49517",
+					"172.28.0.1:49517",
+					"172.29.0.1:49517"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:09:51.766590389Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2445166358548395,
+				"StableID":   "nWnW2hNR6L11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fd26b4c5deb48dc304d605470b355fd64b1fdaa576cd27fd1d8a4967983b8f1f",
+				"KeyExpiry":  "2026-11-09T09:09:52Z",
+				"DiscoKey":   "discokey:8f584643e412b124e174756c1c32f22cb30373c7098161a0ae99bb240f134d68",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52334",
+					"10.65.0.27:52334",
+					"172.17.0.1:52334",
+					"172.18.0.1:52334",
+					"172.19.0.1:52334",
+					"172.20.0.1:52334",
+					"172.21.0.1:52334",
+					"172.22.0.1:52334",
+					"172.23.0.1:52334",
+					"172.24.0.1:52334",
+					"172.25.0.1:52334",
+					"172.26.0.1:52334",
+					"172.27.0.1:52334",
+					"172.28.0.1:52334",
+					"172.29.0.1:52334"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:09:52.849051482Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3210096661715349,
+				"StableID":   "n2m6YAor4S11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:93d6d7c637d9def2c70a30aa2ce458e01e904acfe931a04897fb0fab4cd26d29",
+				"KeyExpiry":  "2026-11-09T09:09:53Z",
+				"DiscoKey":   "discokey:15054df074c7d5425e6f305994dbbc8d96cd540b1c34e640db359774fcce4226",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59567",
+					"10.65.0.27:59567",
+					"172.17.0.1:59567",
+					"172.18.0.1:59567",
+					"172.19.0.1:59567",
+					"172.20.0.1:59567",
+					"172.21.0.1:59567",
+					"172.22.0.1:59567",
+					"172.23.0.1:59567",
+					"172.24.0.1:59567",
+					"172.25.0.1:59567",
+					"172.26.0.1:59567",
+					"172.27.0.1:59567",
+					"172.28.0.1:59567",
+					"172.29.0.1:59567"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:09:53.390208111Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         597170729733715,
+				"StableID":   "nQ3MURfTf511CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       597170729733715,
+				"Key":        "nodekey:ae9217620a86b09c23dd2142abf1d76912df58684961c3fc62349e1e0915b149",
+				"DiscoKey":   "discokey:db83951819aa37fa450ba0b748856d853ce43a7f68a336aee82e9c045782293c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:39960",
+					"10.65.0.27:39960",
+					"172.17.0.1:39960",
+					"172.18.0.1:39960",
+					"172.19.0.1:39960",
+					"172.20.0.1:39960",
+					"172.21.0.1:39960",
+					"172.22.0.1:39960",
+					"172.23.0.1:39960",
+					"172.24.0.1:39960",
+					"172.25.0.1:39960",
+					"172.26.0.1:39960",
+					"172.27.0.1:39960",
+					"172.28.0.1:39960",
+					"172.29.0.1:39960"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:09:51.225297251Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ae9217620a86b09c23dd2142abf1d76912df58684961c3fc62349e1e0915b149",
+			"MachineKey": "mkey:146d4284d40d60c0a647308f8c2b6c629caca3a8f98200cae8faccb393b52768",
+			"Peers": [{
+				"ID":         7545449853970951,
+				"StableID":   "nAL9R2BMv121CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf2b1c33b0339bfc285f5a3438d54d6ef6132de91e1006564a3bdd4766041531",
+				"DiscoKey":   "discokey:f0b35b8a47d7c0e75151d9102f26d7a6940a99da53b3cef76a2abf2cd74ab143",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52491",
+					"10.65.0.27:52491",
+					"172.17.0.1:52491",
+					"172.18.0.1:52491",
+					"172.19.0.1:52491",
+					"172.20.0.1:52491",
+					"172.21.0.1:52491",
+					"172.22.0.1:52491",
+					"172.23.0.1:52491",
+					"172.24.0.1:52491",
+					"172.25.0.1:52491",
+					"172.26.0.1:52491",
+					"172.27.0.1:52491",
+					"172.28.0.1:52491",
+					"172.29.0.1:52491"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:09:45.317446196Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6601191949024367,
+				"StableID":   "na6Jpt7hYt11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:222763516a281cf6b9de022760bdf90f572b3579368caed48197d273ba71893b",
+				"DiscoKey":   "discokey:2c8fc2aecdcac32fa49181d486093f1957845e202c75459b2ffcb6210bc2b216",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:49866",
+					"10.65.0.27:49866",
+					"172.17.0.1:49866",
+					"172.18.0.1:49866",
+					"172.19.0.1:49866",
+					"172.20.0.1:49866",
+					"172.21.0.1:49866",
+					"172.22.0.1:49866",
+					"172.23.0.1:49866",
+					"172.24.0.1:49866",
+					"172.25.0.1:49866",
+					"172.26.0.1:49866",
+					"172.27.0.1:49866",
+					"172.28.0.1:49866",
+					"172.29.0.1:49866"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:09:45.860172783Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5641686272672076,
+				"StableID":   "nmKQsqX84m11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee3c3576175d8b875911c1d25f8a5ec9f1a2547f2a616619106fca5dc0d6a158",
+				"DiscoKey":   "discokey:a12ef384bffb0c4f6562eeb34d49eeaadbb5b72e68752d1dfed195d161552c09",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41012",
+					"10.65.0.27:41012",
+					"172.17.0.1:41012",
+					"172.18.0.1:41012",
+					"172.19.0.1:41012",
+					"172.20.0.1:41012",
+					"172.21.0.1:41012",
+					"172.22.0.1:41012",
+					"172.23.0.1:41012",
+					"172.24.0.1:41012",
+					"172.25.0.1:41012",
+					"172.26.0.1:41012",
+					"172.27.0.1:41012",
+					"172.28.0.1:41012",
+					"172.29.0.1:41012"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:09:46.400765907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         251905086834600,
+				"StableID":   "nhV5vv76y211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2217ed7e2d284d12862d48bc7faa3a80ac0cb8eb3930cfd7e7a754099ab4a510",
+				"DiscoKey":   "discokey:da9e2b384db2465a717bdcdf8097c7ad2d50375aa7396b19e287ec896869433a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39237",
+					"10.65.0.27:39237",
+					"172.17.0.1:39237",
+					"172.18.0.1:39237",
+					"172.19.0.1:39237",
+					"172.20.0.1:39237",
+					"172.21.0.1:39237",
+					"172.22.0.1:39237",
+					"172.23.0.1:39237",
+					"172.24.0.1:39237",
+					"172.25.0.1:39237",
+					"172.26.0.1:39237",
+					"172.27.0.1:39237",
+					"172.28.0.1:39237",
+					"172.29.0.1:39237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:09:46.936307856Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7311289998587147,
+				"StableID":   "nWaeq3CJ6z11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5ecfa4441cec326657a9c2364b42c3b0c0155207c5a7b0fbf4d9ddcb58d46840",
+				"DiscoKey":   "discokey:2639340901c617a5c4e800f56f3ea482279b4b1ce708f1146d42263fd9315f4c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37204",
+					"10.65.0.27:37204",
+					"172.17.0.1:37204",
+					"172.18.0.1:37204",
+					"172.19.0.1:37204",
+					"172.20.0.1:37204",
+					"172.21.0.1:37204",
+					"172.22.0.1:37204",
+					"172.23.0.1:37204",
+					"172.24.0.1:37204",
+					"172.25.0.1:37204",
+					"172.26.0.1:37204",
+					"172.27.0.1:37204",
+					"172.28.0.1:37204",
+					"172.29.0.1:37204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:09:47.731176987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3844756781655839,
+				"StableID":   "nxXY3zEJ2X11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b2d4a4fab6a729dad226e73c64361cead2b21704cbe50ce4de339d50e7c2201e",
+				"DiscoKey":   "discokey:3abb4edeebe7251467fb74569a6693d582580c7387555c3e009fc61c8b600432",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52682",
+					"10.65.0.27:52682",
+					"172.17.0.1:52682",
+					"172.18.0.1:52682",
+					"172.19.0.1:52682",
+					"172.20.0.1:52682",
+					"172.21.0.1:52682",
+					"172.22.0.1:52682",
+					"172.23.0.1:52682",
+					"172.24.0.1:52682",
+					"172.25.0.1:52682",
+					"172.26.0.1:52682",
+					"172.27.0.1:52682",
+					"172.28.0.1:52682",
+					"172.29.0.1:52682"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:09:48.276209785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7721349283250464,
+				"StableID":   "nR3Geek1J321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:53cdbd2a02f426b6f1050739e8bb0158ad820823d97ee947d0669b2795b4793e",
+				"DiscoKey":   "discokey:5001bf5d922a739562c393b47298ca093ec32bd94e61c1a0d7d7c929fd37004f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57229",
+					"10.65.0.27:57229",
+					"172.17.0.1:57229",
+					"172.18.0.1:57229",
+					"172.19.0.1:57229",
+					"172.20.0.1:57229",
+					"172.21.0.1:57229",
+					"172.22.0.1:57229",
+					"172.23.0.1:57229",
+					"172.24.0.1:57229",
+					"172.25.0.1:57229",
+					"172.26.0.1:57229",
+					"172.27.0.1:57229",
+					"172.28.0.1:57229",
+					"172.29.0.1:57229"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:09:48.810725022Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8529137471312197,
+				"StableID":   "nvwUgkyrb921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e50e83c32dfa9000e243698477cdf31ac700548548634bab8d625c811a391348",
+				"DiscoKey":   "discokey:03888741ff54921b0945f19c5a06bd8ceef017baa166c393be697ad1964fe950",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:40794",
+					"10.65.0.27:40794",
+					"172.17.0.1:40794",
+					"172.18.0.1:40794",
+					"172.19.0.1:40794",
+					"172.20.0.1:40794",
+					"172.21.0.1:40794",
+					"172.22.0.1:40794",
+					"172.23.0.1:40794",
+					"172.24.0.1:40794",
+					"172.25.0.1:40794",
+					"172.26.0.1:40794",
+					"172.27.0.1:40794",
+					"172.28.0.1:40794",
+					"172.29.0.1:40794"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:09:49.345404174Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1133665446225711,
+				"StableID":   "npspRCUSr911CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af3ef8c77445c102e5a391acf22ae87176cd45610d9b7a35ef2b9a045ce86456",
+				"DiscoKey":   "discokey:c6b68fa95ac1834525dcc473f9539e27101e3ddc7214e1af4f17800e31be205f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44144",
+					"10.65.0.27:44144",
+					"172.17.0.1:44144",
+					"172.18.0.1:44144",
+					"172.19.0.1:44144",
+					"172.20.0.1:44144",
+					"172.21.0.1:44144",
+					"172.22.0.1:44144",
+					"172.23.0.1:44144",
+					"172.24.0.1:44144",
+					"172.25.0.1:44144",
+					"172.26.0.1:44144",
+					"172.27.0.1:44144",
+					"172.28.0.1:44144",
+					"172.29.0.1:44144"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:09:49.906892291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4327360026868473,
+				"StableID":   "nLg7EnQsna11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41b456fff76f073210ae1f5b1885880231b492677d82ebb16e19de0d8d05db43",
+				"DiscoKey":   "discokey:cdc9d51564ec303392666bc959439f647b6bc871300fcd3dd462490a78acf213",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55548",
+					"10.65.0.27:55548",
+					"172.17.0.1:55548",
+					"172.18.0.1:55548",
+					"172.19.0.1:55548",
+					"172.20.0.1:55548",
+					"172.21.0.1:55548",
+					"172.22.0.1:55548",
+					"172.23.0.1:55548",
+					"172.24.0.1:55548",
+					"172.25.0.1:55548",
+					"172.26.0.1:55548",
+					"172.27.0.1:55548",
+					"172.28.0.1:55548",
+					"172.29.0.1:55548"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:09:50.591259506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2081825077297187,
+				"StableID":   "nkwvCr1sFH11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83b7fe43ccf866075f0328181d2d70add517cc694bcc0056a9a856f4d8673307",
+				"DiscoKey":   "discokey:343144325f073c39cc74a2331742af006c61e006957f60786a46742dcb0df42b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49517",
+					"10.65.0.27:49517",
+					"172.17.0.1:49517",
+					"172.18.0.1:49517",
+					"172.19.0.1:49517",
+					"172.20.0.1:49517",
+					"172.21.0.1:49517",
+					"172.22.0.1:49517",
+					"172.23.0.1:49517",
+					"172.24.0.1:49517",
+					"172.25.0.1:49517",
+					"172.26.0.1:49517",
+					"172.27.0.1:49517",
+					"172.28.0.1:49517",
+					"172.29.0.1:49517"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:09:51.766590389Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3838711917156017,
+				"StableID":   "ntev4GTZyW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3c743971520558c0b50716981af1a5d7a4dde1747220f21ed6fa1553635e9d55",
+				"KeyExpiry":  "2026-11-09T09:09:52Z",
+				"DiscoKey":   "discokey:556ade8dabe7d02cda014c2d15219252465583c8a9ba575c4681daec63fb8175",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:55726",
+					"10.65.0.27:55726",
+					"172.17.0.1:55726",
+					"172.18.0.1:55726",
+					"172.19.0.1:55726",
+					"172.20.0.1:55726",
+					"172.21.0.1:55726",
+					"172.22.0.1:55726",
+					"172.23.0.1:55726",
+					"172.24.0.1:55726",
+					"172.25.0.1:55726",
+					"172.26.0.1:55726",
+					"172.27.0.1:55726",
+					"172.28.0.1:55726",
+					"172.29.0.1:55726"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:09:52.315081835Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2445166358548395,
+				"StableID":   "nWnW2hNR6L11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fd26b4c5deb48dc304d605470b355fd64b1fdaa576cd27fd1d8a4967983b8f1f",
+				"KeyExpiry":  "2026-11-09T09:09:52Z",
+				"DiscoKey":   "discokey:8f584643e412b124e174756c1c32f22cb30373c7098161a0ae99bb240f134d68",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52334",
+					"10.65.0.27:52334",
+					"172.17.0.1:52334",
+					"172.18.0.1:52334",
+					"172.19.0.1:52334",
+					"172.20.0.1:52334",
+					"172.21.0.1:52334",
+					"172.22.0.1:52334",
+					"172.23.0.1:52334",
+					"172.24.0.1:52334",
+					"172.25.0.1:52334",
+					"172.26.0.1:52334",
+					"172.27.0.1:52334",
+					"172.28.0.1:52334",
+					"172.29.0.1:52334"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:09:52.849051482Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3210096661715349,
+				"StableID":   "n2m6YAor4S11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:93d6d7c637d9def2c70a30aa2ce458e01e904acfe931a04897fb0fab4cd26d29",
+				"KeyExpiry":  "2026-11-09T09:09:53Z",
+				"DiscoKey":   "discokey:15054df074c7d5425e6f305994dbbc8d96cd540b1c34e640db359774fcce4226",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59567",
+					"10.65.0.27:59567",
+					"172.17.0.1:59567",
+					"172.18.0.1:59567",
+					"172.19.0.1:59567",
+					"172.20.0.1:59567",
+					"172.21.0.1:59567",
+					"172.22.0.1:59567",
+					"172.23.0.1:59567",
+					"172.24.0.1:59567",
+					"172.25.0.1:59567",
+					"172.26.0.1:59567",
+					"172.27.0.1:59567",
+					"172.28.0.1:59567",
+					"172.29.0.1:59567"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:09:53.390208111Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "597170729733715": {
+				"ID":          597170729733715,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6601191949024367,
+				"StableID":   "na6Jpt7hYt11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       6601191949024367,
+				"Key":        "nodekey:222763516a281cf6b9de022760bdf90f572b3579368caed48197d273ba71893b",
+				"DiscoKey":   "discokey:2c8fc2aecdcac32fa49181d486093f1957845e202c75459b2ffcb6210bc2b216",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:49866",
+					"10.65.0.27:49866",
+					"172.17.0.1:49866",
+					"172.18.0.1:49866",
+					"172.19.0.1:49866",
+					"172.20.0.1:49866",
+					"172.21.0.1:49866",
+					"172.22.0.1:49866",
+					"172.23.0.1:49866",
+					"172.24.0.1:49866",
+					"172.25.0.1:49866",
+					"172.26.0.1:49866",
+					"172.27.0.1:49866",
+					"172.28.0.1:49866",
+					"172.29.0.1:49866"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:09:45.860172783Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:222763516a281cf6b9de022760bdf90f572b3579368caed48197d273ba71893b",
+			"MachineKey": "mkey:cbec445d0053eff526fd666aab37beb1af5c992e61126435c757099e66e73511",
+			"Peers": [{
+				"ID":         7545449853970951,
+				"StableID":   "nAL9R2BMv121CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf2b1c33b0339bfc285f5a3438d54d6ef6132de91e1006564a3bdd4766041531",
+				"DiscoKey":   "discokey:f0b35b8a47d7c0e75151d9102f26d7a6940a99da53b3cef76a2abf2cd74ab143",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52491",
+					"10.65.0.27:52491",
+					"172.17.0.1:52491",
+					"172.18.0.1:52491",
+					"172.19.0.1:52491",
+					"172.20.0.1:52491",
+					"172.21.0.1:52491",
+					"172.22.0.1:52491",
+					"172.23.0.1:52491",
+					"172.24.0.1:52491",
+					"172.25.0.1:52491",
+					"172.26.0.1:52491",
+					"172.27.0.1:52491",
+					"172.28.0.1:52491",
+					"172.29.0.1:52491"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:09:45.317446196Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5641686272672076,
+				"StableID":   "nmKQsqX84m11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee3c3576175d8b875911c1d25f8a5ec9f1a2547f2a616619106fca5dc0d6a158",
+				"DiscoKey":   "discokey:a12ef384bffb0c4f6562eeb34d49eeaadbb5b72e68752d1dfed195d161552c09",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41012",
+					"10.65.0.27:41012",
+					"172.17.0.1:41012",
+					"172.18.0.1:41012",
+					"172.19.0.1:41012",
+					"172.20.0.1:41012",
+					"172.21.0.1:41012",
+					"172.22.0.1:41012",
+					"172.23.0.1:41012",
+					"172.24.0.1:41012",
+					"172.25.0.1:41012",
+					"172.26.0.1:41012",
+					"172.27.0.1:41012",
+					"172.28.0.1:41012",
+					"172.29.0.1:41012"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:09:46.400765907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         251905086834600,
+				"StableID":   "nhV5vv76y211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2217ed7e2d284d12862d48bc7faa3a80ac0cb8eb3930cfd7e7a754099ab4a510",
+				"DiscoKey":   "discokey:da9e2b384db2465a717bdcdf8097c7ad2d50375aa7396b19e287ec896869433a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39237",
+					"10.65.0.27:39237",
+					"172.17.0.1:39237",
+					"172.18.0.1:39237",
+					"172.19.0.1:39237",
+					"172.20.0.1:39237",
+					"172.21.0.1:39237",
+					"172.22.0.1:39237",
+					"172.23.0.1:39237",
+					"172.24.0.1:39237",
+					"172.25.0.1:39237",
+					"172.26.0.1:39237",
+					"172.27.0.1:39237",
+					"172.28.0.1:39237",
+					"172.29.0.1:39237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:09:46.936307856Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7311289998587147,
+				"StableID":   "nWaeq3CJ6z11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5ecfa4441cec326657a9c2364b42c3b0c0155207c5a7b0fbf4d9ddcb58d46840",
+				"DiscoKey":   "discokey:2639340901c617a5c4e800f56f3ea482279b4b1ce708f1146d42263fd9315f4c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37204",
+					"10.65.0.27:37204",
+					"172.17.0.1:37204",
+					"172.18.0.1:37204",
+					"172.19.0.1:37204",
+					"172.20.0.1:37204",
+					"172.21.0.1:37204",
+					"172.22.0.1:37204",
+					"172.23.0.1:37204",
+					"172.24.0.1:37204",
+					"172.25.0.1:37204",
+					"172.26.0.1:37204",
+					"172.27.0.1:37204",
+					"172.28.0.1:37204",
+					"172.29.0.1:37204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:09:47.731176987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3844756781655839,
+				"StableID":   "nxXY3zEJ2X11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b2d4a4fab6a729dad226e73c64361cead2b21704cbe50ce4de339d50e7c2201e",
+				"DiscoKey":   "discokey:3abb4edeebe7251467fb74569a6693d582580c7387555c3e009fc61c8b600432",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52682",
+					"10.65.0.27:52682",
+					"172.17.0.1:52682",
+					"172.18.0.1:52682",
+					"172.19.0.1:52682",
+					"172.20.0.1:52682",
+					"172.21.0.1:52682",
+					"172.22.0.1:52682",
+					"172.23.0.1:52682",
+					"172.24.0.1:52682",
+					"172.25.0.1:52682",
+					"172.26.0.1:52682",
+					"172.27.0.1:52682",
+					"172.28.0.1:52682",
+					"172.29.0.1:52682"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:09:48.276209785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7721349283250464,
+				"StableID":   "nR3Geek1J321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:53cdbd2a02f426b6f1050739e8bb0158ad820823d97ee947d0669b2795b4793e",
+				"DiscoKey":   "discokey:5001bf5d922a739562c393b47298ca093ec32bd94e61c1a0d7d7c929fd37004f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57229",
+					"10.65.0.27:57229",
+					"172.17.0.1:57229",
+					"172.18.0.1:57229",
+					"172.19.0.1:57229",
+					"172.20.0.1:57229",
+					"172.21.0.1:57229",
+					"172.22.0.1:57229",
+					"172.23.0.1:57229",
+					"172.24.0.1:57229",
+					"172.25.0.1:57229",
+					"172.26.0.1:57229",
+					"172.27.0.1:57229",
+					"172.28.0.1:57229",
+					"172.29.0.1:57229"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:09:48.810725022Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8529137471312197,
+				"StableID":   "nvwUgkyrb921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e50e83c32dfa9000e243698477cdf31ac700548548634bab8d625c811a391348",
+				"DiscoKey":   "discokey:03888741ff54921b0945f19c5a06bd8ceef017baa166c393be697ad1964fe950",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:40794",
+					"10.65.0.27:40794",
+					"172.17.0.1:40794",
+					"172.18.0.1:40794",
+					"172.19.0.1:40794",
+					"172.20.0.1:40794",
+					"172.21.0.1:40794",
+					"172.22.0.1:40794",
+					"172.23.0.1:40794",
+					"172.24.0.1:40794",
+					"172.25.0.1:40794",
+					"172.26.0.1:40794",
+					"172.27.0.1:40794",
+					"172.28.0.1:40794",
+					"172.29.0.1:40794"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:09:49.345404174Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1133665446225711,
+				"StableID":   "npspRCUSr911CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af3ef8c77445c102e5a391acf22ae87176cd45610d9b7a35ef2b9a045ce86456",
+				"DiscoKey":   "discokey:c6b68fa95ac1834525dcc473f9539e27101e3ddc7214e1af4f17800e31be205f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44144",
+					"10.65.0.27:44144",
+					"172.17.0.1:44144",
+					"172.18.0.1:44144",
+					"172.19.0.1:44144",
+					"172.20.0.1:44144",
+					"172.21.0.1:44144",
+					"172.22.0.1:44144",
+					"172.23.0.1:44144",
+					"172.24.0.1:44144",
+					"172.25.0.1:44144",
+					"172.26.0.1:44144",
+					"172.27.0.1:44144",
+					"172.28.0.1:44144",
+					"172.29.0.1:44144"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:09:49.906892291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4327360026868473,
+				"StableID":   "nLg7EnQsna11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41b456fff76f073210ae1f5b1885880231b492677d82ebb16e19de0d8d05db43",
+				"DiscoKey":   "discokey:cdc9d51564ec303392666bc959439f647b6bc871300fcd3dd462490a78acf213",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55548",
+					"10.65.0.27:55548",
+					"172.17.0.1:55548",
+					"172.18.0.1:55548",
+					"172.19.0.1:55548",
+					"172.20.0.1:55548",
+					"172.21.0.1:55548",
+					"172.22.0.1:55548",
+					"172.23.0.1:55548",
+					"172.24.0.1:55548",
+					"172.25.0.1:55548",
+					"172.26.0.1:55548",
+					"172.27.0.1:55548",
+					"172.28.0.1:55548",
+					"172.29.0.1:55548"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:09:50.591259506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         597170729733715,
+				"StableID":   "nQ3MURfTf511CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae9217620a86b09c23dd2142abf1d76912df58684961c3fc62349e1e0915b149",
+				"DiscoKey":   "discokey:db83951819aa37fa450ba0b748856d853ce43a7f68a336aee82e9c045782293c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:39960",
+					"10.65.0.27:39960",
+					"172.17.0.1:39960",
+					"172.18.0.1:39960",
+					"172.19.0.1:39960",
+					"172.20.0.1:39960",
+					"172.21.0.1:39960",
+					"172.22.0.1:39960",
+					"172.23.0.1:39960",
+					"172.24.0.1:39960",
+					"172.25.0.1:39960",
+					"172.26.0.1:39960",
+					"172.27.0.1:39960",
+					"172.28.0.1:39960",
+					"172.29.0.1:39960"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:09:51.225297251Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2081825077297187,
+				"StableID":   "nkwvCr1sFH11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83b7fe43ccf866075f0328181d2d70add517cc694bcc0056a9a856f4d8673307",
+				"DiscoKey":   "discokey:343144325f073c39cc74a2331742af006c61e006957f60786a46742dcb0df42b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49517",
+					"10.65.0.27:49517",
+					"172.17.0.1:49517",
+					"172.18.0.1:49517",
+					"172.19.0.1:49517",
+					"172.20.0.1:49517",
+					"172.21.0.1:49517",
+					"172.22.0.1:49517",
+					"172.23.0.1:49517",
+					"172.24.0.1:49517",
+					"172.25.0.1:49517",
+					"172.26.0.1:49517",
+					"172.27.0.1:49517",
+					"172.28.0.1:49517",
+					"172.29.0.1:49517"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:09:51.766590389Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3838711917156017,
+				"StableID":   "ntev4GTZyW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3c743971520558c0b50716981af1a5d7a4dde1747220f21ed6fa1553635e9d55",
+				"KeyExpiry":  "2026-11-09T09:09:52Z",
+				"DiscoKey":   "discokey:556ade8dabe7d02cda014c2d15219252465583c8a9ba575c4681daec63fb8175",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:55726",
+					"10.65.0.27:55726",
+					"172.17.0.1:55726",
+					"172.18.0.1:55726",
+					"172.19.0.1:55726",
+					"172.20.0.1:55726",
+					"172.21.0.1:55726",
+					"172.22.0.1:55726",
+					"172.23.0.1:55726",
+					"172.24.0.1:55726",
+					"172.25.0.1:55726",
+					"172.26.0.1:55726",
+					"172.27.0.1:55726",
+					"172.28.0.1:55726",
+					"172.29.0.1:55726"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:09:52.315081835Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2445166358548395,
+				"StableID":   "nWnW2hNR6L11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fd26b4c5deb48dc304d605470b355fd64b1fdaa576cd27fd1d8a4967983b8f1f",
+				"KeyExpiry":  "2026-11-09T09:09:52Z",
+				"DiscoKey":   "discokey:8f584643e412b124e174756c1c32f22cb30373c7098161a0ae99bb240f134d68",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52334",
+					"10.65.0.27:52334",
+					"172.17.0.1:52334",
+					"172.18.0.1:52334",
+					"172.19.0.1:52334",
+					"172.20.0.1:52334",
+					"172.21.0.1:52334",
+					"172.22.0.1:52334",
+					"172.23.0.1:52334",
+					"172.24.0.1:52334",
+					"172.25.0.1:52334",
+					"172.26.0.1:52334",
+					"172.27.0.1:52334",
+					"172.28.0.1:52334",
+					"172.29.0.1:52334"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:09:52.849051482Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3210096661715349,
+				"StableID":   "n2m6YAor4S11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:93d6d7c637d9def2c70a30aa2ce458e01e904acfe931a04897fb0fab4cd26d29",
+				"KeyExpiry":  "2026-11-09T09:09:53Z",
+				"DiscoKey":   "discokey:15054df074c7d5425e6f305994dbbc8d96cd540b1c34e640db359774fcce4226",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59567",
+					"10.65.0.27:59567",
+					"172.17.0.1:59567",
+					"172.18.0.1:59567",
+					"172.19.0.1:59567",
+					"172.20.0.1:59567",
+					"172.21.0.1:59567",
+					"172.22.0.1:59567",
+					"172.23.0.1:59567",
+					"172.24.0.1:59567",
+					"172.25.0.1:59567",
+					"172.26.0.1:59567",
+					"172.27.0.1:59567",
+					"172.28.0.1:59567",
+					"172.29.0.1:59567"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:09:53.390208111Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6601191949024367": {
+				"ID":          6601191949024367,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7545449853970951,
+				"StableID":   "nAL9R2BMv121CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       7545449853970951,
+				"Key":        "nodekey:bf2b1c33b0339bfc285f5a3438d54d6ef6132de91e1006564a3bdd4766041531",
+				"DiscoKey":   "discokey:f0b35b8a47d7c0e75151d9102f26d7a6940a99da53b3cef76a2abf2cd74ab143",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52491",
+					"10.65.0.27:52491",
+					"172.17.0.1:52491",
+					"172.18.0.1:52491",
+					"172.19.0.1:52491",
+					"172.20.0.1:52491",
+					"172.21.0.1:52491",
+					"172.22.0.1:52491",
+					"172.23.0.1:52491",
+					"172.24.0.1:52491",
+					"172.25.0.1:52491",
+					"172.26.0.1:52491",
+					"172.27.0.1:52491",
+					"172.28.0.1:52491",
+					"172.29.0.1:52491"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:09:45.317446196Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:bf2b1c33b0339bfc285f5a3438d54d6ef6132de91e1006564a3bdd4766041531",
+			"MachineKey": "mkey:fa24375d62898d2b7f5bc7b838ae2275e26d92c476070b21440e8cd17158242b",
+			"Peers": [{
+				"ID":         6601191949024367,
+				"StableID":   "na6Jpt7hYt11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:222763516a281cf6b9de022760bdf90f572b3579368caed48197d273ba71893b",
+				"DiscoKey":   "discokey:2c8fc2aecdcac32fa49181d486093f1957845e202c75459b2ffcb6210bc2b216",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:49866",
+					"10.65.0.27:49866",
+					"172.17.0.1:49866",
+					"172.18.0.1:49866",
+					"172.19.0.1:49866",
+					"172.20.0.1:49866",
+					"172.21.0.1:49866",
+					"172.22.0.1:49866",
+					"172.23.0.1:49866",
+					"172.24.0.1:49866",
+					"172.25.0.1:49866",
+					"172.26.0.1:49866",
+					"172.27.0.1:49866",
+					"172.28.0.1:49866",
+					"172.29.0.1:49866"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:09:45.860172783Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5641686272672076,
+				"StableID":   "nmKQsqX84m11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee3c3576175d8b875911c1d25f8a5ec9f1a2547f2a616619106fca5dc0d6a158",
+				"DiscoKey":   "discokey:a12ef384bffb0c4f6562eeb34d49eeaadbb5b72e68752d1dfed195d161552c09",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41012",
+					"10.65.0.27:41012",
+					"172.17.0.1:41012",
+					"172.18.0.1:41012",
+					"172.19.0.1:41012",
+					"172.20.0.1:41012",
+					"172.21.0.1:41012",
+					"172.22.0.1:41012",
+					"172.23.0.1:41012",
+					"172.24.0.1:41012",
+					"172.25.0.1:41012",
+					"172.26.0.1:41012",
+					"172.27.0.1:41012",
+					"172.28.0.1:41012",
+					"172.29.0.1:41012"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:09:46.400765907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         251905086834600,
+				"StableID":   "nhV5vv76y211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2217ed7e2d284d12862d48bc7faa3a80ac0cb8eb3930cfd7e7a754099ab4a510",
+				"DiscoKey":   "discokey:da9e2b384db2465a717bdcdf8097c7ad2d50375aa7396b19e287ec896869433a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39237",
+					"10.65.0.27:39237",
+					"172.17.0.1:39237",
+					"172.18.0.1:39237",
+					"172.19.0.1:39237",
+					"172.20.0.1:39237",
+					"172.21.0.1:39237",
+					"172.22.0.1:39237",
+					"172.23.0.1:39237",
+					"172.24.0.1:39237",
+					"172.25.0.1:39237",
+					"172.26.0.1:39237",
+					"172.27.0.1:39237",
+					"172.28.0.1:39237",
+					"172.29.0.1:39237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:09:46.936307856Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7311289998587147,
+				"StableID":   "nWaeq3CJ6z11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5ecfa4441cec326657a9c2364b42c3b0c0155207c5a7b0fbf4d9ddcb58d46840",
+				"DiscoKey":   "discokey:2639340901c617a5c4e800f56f3ea482279b4b1ce708f1146d42263fd9315f4c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37204",
+					"10.65.0.27:37204",
+					"172.17.0.1:37204",
+					"172.18.0.1:37204",
+					"172.19.0.1:37204",
+					"172.20.0.1:37204",
+					"172.21.0.1:37204",
+					"172.22.0.1:37204",
+					"172.23.0.1:37204",
+					"172.24.0.1:37204",
+					"172.25.0.1:37204",
+					"172.26.0.1:37204",
+					"172.27.0.1:37204",
+					"172.28.0.1:37204",
+					"172.29.0.1:37204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:09:47.731176987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3844756781655839,
+				"StableID":   "nxXY3zEJ2X11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b2d4a4fab6a729dad226e73c64361cead2b21704cbe50ce4de339d50e7c2201e",
+				"DiscoKey":   "discokey:3abb4edeebe7251467fb74569a6693d582580c7387555c3e009fc61c8b600432",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52682",
+					"10.65.0.27:52682",
+					"172.17.0.1:52682",
+					"172.18.0.1:52682",
+					"172.19.0.1:52682",
+					"172.20.0.1:52682",
+					"172.21.0.1:52682",
+					"172.22.0.1:52682",
+					"172.23.0.1:52682",
+					"172.24.0.1:52682",
+					"172.25.0.1:52682",
+					"172.26.0.1:52682",
+					"172.27.0.1:52682",
+					"172.28.0.1:52682",
+					"172.29.0.1:52682"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:09:48.276209785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7721349283250464,
+				"StableID":   "nR3Geek1J321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:53cdbd2a02f426b6f1050739e8bb0158ad820823d97ee947d0669b2795b4793e",
+				"DiscoKey":   "discokey:5001bf5d922a739562c393b47298ca093ec32bd94e61c1a0d7d7c929fd37004f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57229",
+					"10.65.0.27:57229",
+					"172.17.0.1:57229",
+					"172.18.0.1:57229",
+					"172.19.0.1:57229",
+					"172.20.0.1:57229",
+					"172.21.0.1:57229",
+					"172.22.0.1:57229",
+					"172.23.0.1:57229",
+					"172.24.0.1:57229",
+					"172.25.0.1:57229",
+					"172.26.0.1:57229",
+					"172.27.0.1:57229",
+					"172.28.0.1:57229",
+					"172.29.0.1:57229"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:09:48.810725022Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8529137471312197,
+				"StableID":   "nvwUgkyrb921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e50e83c32dfa9000e243698477cdf31ac700548548634bab8d625c811a391348",
+				"DiscoKey":   "discokey:03888741ff54921b0945f19c5a06bd8ceef017baa166c393be697ad1964fe950",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:40794",
+					"10.65.0.27:40794",
+					"172.17.0.1:40794",
+					"172.18.0.1:40794",
+					"172.19.0.1:40794",
+					"172.20.0.1:40794",
+					"172.21.0.1:40794",
+					"172.22.0.1:40794",
+					"172.23.0.1:40794",
+					"172.24.0.1:40794",
+					"172.25.0.1:40794",
+					"172.26.0.1:40794",
+					"172.27.0.1:40794",
+					"172.28.0.1:40794",
+					"172.29.0.1:40794"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:09:49.345404174Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1133665446225711,
+				"StableID":   "npspRCUSr911CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af3ef8c77445c102e5a391acf22ae87176cd45610d9b7a35ef2b9a045ce86456",
+				"DiscoKey":   "discokey:c6b68fa95ac1834525dcc473f9539e27101e3ddc7214e1af4f17800e31be205f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44144",
+					"10.65.0.27:44144",
+					"172.17.0.1:44144",
+					"172.18.0.1:44144",
+					"172.19.0.1:44144",
+					"172.20.0.1:44144",
+					"172.21.0.1:44144",
+					"172.22.0.1:44144",
+					"172.23.0.1:44144",
+					"172.24.0.1:44144",
+					"172.25.0.1:44144",
+					"172.26.0.1:44144",
+					"172.27.0.1:44144",
+					"172.28.0.1:44144",
+					"172.29.0.1:44144"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:09:49.906892291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4327360026868473,
+				"StableID":   "nLg7EnQsna11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41b456fff76f073210ae1f5b1885880231b492677d82ebb16e19de0d8d05db43",
+				"DiscoKey":   "discokey:cdc9d51564ec303392666bc959439f647b6bc871300fcd3dd462490a78acf213",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55548",
+					"10.65.0.27:55548",
+					"172.17.0.1:55548",
+					"172.18.0.1:55548",
+					"172.19.0.1:55548",
+					"172.20.0.1:55548",
+					"172.21.0.1:55548",
+					"172.22.0.1:55548",
+					"172.23.0.1:55548",
+					"172.24.0.1:55548",
+					"172.25.0.1:55548",
+					"172.26.0.1:55548",
+					"172.27.0.1:55548",
+					"172.28.0.1:55548",
+					"172.29.0.1:55548"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:09:50.591259506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         597170729733715,
+				"StableID":   "nQ3MURfTf511CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae9217620a86b09c23dd2142abf1d76912df58684961c3fc62349e1e0915b149",
+				"DiscoKey":   "discokey:db83951819aa37fa450ba0b748856d853ce43a7f68a336aee82e9c045782293c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:39960",
+					"10.65.0.27:39960",
+					"172.17.0.1:39960",
+					"172.18.0.1:39960",
+					"172.19.0.1:39960",
+					"172.20.0.1:39960",
+					"172.21.0.1:39960",
+					"172.22.0.1:39960",
+					"172.23.0.1:39960",
+					"172.24.0.1:39960",
+					"172.25.0.1:39960",
+					"172.26.0.1:39960",
+					"172.27.0.1:39960",
+					"172.28.0.1:39960",
+					"172.29.0.1:39960"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:09:51.225297251Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2081825077297187,
+				"StableID":   "nkwvCr1sFH11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83b7fe43ccf866075f0328181d2d70add517cc694bcc0056a9a856f4d8673307",
+				"DiscoKey":   "discokey:343144325f073c39cc74a2331742af006c61e006957f60786a46742dcb0df42b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49517",
+					"10.65.0.27:49517",
+					"172.17.0.1:49517",
+					"172.18.0.1:49517",
+					"172.19.0.1:49517",
+					"172.20.0.1:49517",
+					"172.21.0.1:49517",
+					"172.22.0.1:49517",
+					"172.23.0.1:49517",
+					"172.24.0.1:49517",
+					"172.25.0.1:49517",
+					"172.26.0.1:49517",
+					"172.27.0.1:49517",
+					"172.28.0.1:49517",
+					"172.29.0.1:49517"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:09:51.766590389Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3838711917156017,
+				"StableID":   "ntev4GTZyW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3c743971520558c0b50716981af1a5d7a4dde1747220f21ed6fa1553635e9d55",
+				"KeyExpiry":  "2026-11-09T09:09:52Z",
+				"DiscoKey":   "discokey:556ade8dabe7d02cda014c2d15219252465583c8a9ba575c4681daec63fb8175",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:55726",
+					"10.65.0.27:55726",
+					"172.17.0.1:55726",
+					"172.18.0.1:55726",
+					"172.19.0.1:55726",
+					"172.20.0.1:55726",
+					"172.21.0.1:55726",
+					"172.22.0.1:55726",
+					"172.23.0.1:55726",
+					"172.24.0.1:55726",
+					"172.25.0.1:55726",
+					"172.26.0.1:55726",
+					"172.27.0.1:55726",
+					"172.28.0.1:55726",
+					"172.29.0.1:55726"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:09:52.315081835Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2445166358548395,
+				"StableID":   "nWnW2hNR6L11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fd26b4c5deb48dc304d605470b355fd64b1fdaa576cd27fd1d8a4967983b8f1f",
+				"KeyExpiry":  "2026-11-09T09:09:52Z",
+				"DiscoKey":   "discokey:8f584643e412b124e174756c1c32f22cb30373c7098161a0ae99bb240f134d68",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52334",
+					"10.65.0.27:52334",
+					"172.17.0.1:52334",
+					"172.18.0.1:52334",
+					"172.19.0.1:52334",
+					"172.20.0.1:52334",
+					"172.21.0.1:52334",
+					"172.22.0.1:52334",
+					"172.23.0.1:52334",
+					"172.24.0.1:52334",
+					"172.25.0.1:52334",
+					"172.26.0.1:52334",
+					"172.27.0.1:52334",
+					"172.28.0.1:52334",
+					"172.29.0.1:52334"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:09:52.849051482Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3210096661715349,
+				"StableID":   "n2m6YAor4S11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:93d6d7c637d9def2c70a30aa2ce458e01e904acfe931a04897fb0fab4cd26d29",
+				"KeyExpiry":  "2026-11-09T09:09:53Z",
+				"DiscoKey":   "discokey:15054df074c7d5425e6f305994dbbc8d96cd540b1c34e640db359774fcce4226",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59567",
+					"10.65.0.27:59567",
+					"172.17.0.1:59567",
+					"172.18.0.1:59567",
+					"172.19.0.1:59567",
+					"172.20.0.1:59567",
+					"172.21.0.1:59567",
+					"172.22.0.1:59567",
+					"172.23.0.1:59567",
+					"172.24.0.1:59567",
+					"172.25.0.1:59567",
+					"172.26.0.1:59567",
+					"172.27.0.1:59567",
+					"172.28.0.1:59567",
+					"172.29.0.1:59567"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:09:53.390208111Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7545449853970951": {
+				"ID":          7545449853970951,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7311289998587147,
+				"StableID":   "nWaeq3CJ6z11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       7311289998587147,
+				"Key":        "nodekey:5ecfa4441cec326657a9c2364b42c3b0c0155207c5a7b0fbf4d9ddcb58d46840",
+				"DiscoKey":   "discokey:2639340901c617a5c4e800f56f3ea482279b4b1ce708f1146d42263fd9315f4c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37204",
+					"10.65.0.27:37204",
+					"172.17.0.1:37204",
+					"172.18.0.1:37204",
+					"172.19.0.1:37204",
+					"172.20.0.1:37204",
+					"172.21.0.1:37204",
+					"172.22.0.1:37204",
+					"172.23.0.1:37204",
+					"172.24.0.1:37204",
+					"172.25.0.1:37204",
+					"172.26.0.1:37204",
+					"172.27.0.1:37204",
+					"172.28.0.1:37204",
+					"172.29.0.1:37204"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:09:47.731176987Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5ecfa4441cec326657a9c2364b42c3b0c0155207c5a7b0fbf4d9ddcb58d46840",
+			"MachineKey": "mkey:1f33810583ec808e9fbf43d33fc3ba8c7382cffcbd405133d6a55b4892f1de07",
+			"Peers": [{
+				"ID":         7545449853970951,
+				"StableID":   "nAL9R2BMv121CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf2b1c33b0339bfc285f5a3438d54d6ef6132de91e1006564a3bdd4766041531",
+				"DiscoKey":   "discokey:f0b35b8a47d7c0e75151d9102f26d7a6940a99da53b3cef76a2abf2cd74ab143",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52491",
+					"10.65.0.27:52491",
+					"172.17.0.1:52491",
+					"172.18.0.1:52491",
+					"172.19.0.1:52491",
+					"172.20.0.1:52491",
+					"172.21.0.1:52491",
+					"172.22.0.1:52491",
+					"172.23.0.1:52491",
+					"172.24.0.1:52491",
+					"172.25.0.1:52491",
+					"172.26.0.1:52491",
+					"172.27.0.1:52491",
+					"172.28.0.1:52491",
+					"172.29.0.1:52491"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:09:45.317446196Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6601191949024367,
+				"StableID":   "na6Jpt7hYt11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:222763516a281cf6b9de022760bdf90f572b3579368caed48197d273ba71893b",
+				"DiscoKey":   "discokey:2c8fc2aecdcac32fa49181d486093f1957845e202c75459b2ffcb6210bc2b216",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:49866",
+					"10.65.0.27:49866",
+					"172.17.0.1:49866",
+					"172.18.0.1:49866",
+					"172.19.0.1:49866",
+					"172.20.0.1:49866",
+					"172.21.0.1:49866",
+					"172.22.0.1:49866",
+					"172.23.0.1:49866",
+					"172.24.0.1:49866",
+					"172.25.0.1:49866",
+					"172.26.0.1:49866",
+					"172.27.0.1:49866",
+					"172.28.0.1:49866",
+					"172.29.0.1:49866"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:09:45.860172783Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5641686272672076,
+				"StableID":   "nmKQsqX84m11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee3c3576175d8b875911c1d25f8a5ec9f1a2547f2a616619106fca5dc0d6a158",
+				"DiscoKey":   "discokey:a12ef384bffb0c4f6562eeb34d49eeaadbb5b72e68752d1dfed195d161552c09",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41012",
+					"10.65.0.27:41012",
+					"172.17.0.1:41012",
+					"172.18.0.1:41012",
+					"172.19.0.1:41012",
+					"172.20.0.1:41012",
+					"172.21.0.1:41012",
+					"172.22.0.1:41012",
+					"172.23.0.1:41012",
+					"172.24.0.1:41012",
+					"172.25.0.1:41012",
+					"172.26.0.1:41012",
+					"172.27.0.1:41012",
+					"172.28.0.1:41012",
+					"172.29.0.1:41012"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:09:46.400765907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         251905086834600,
+				"StableID":   "nhV5vv76y211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2217ed7e2d284d12862d48bc7faa3a80ac0cb8eb3930cfd7e7a754099ab4a510",
+				"DiscoKey":   "discokey:da9e2b384db2465a717bdcdf8097c7ad2d50375aa7396b19e287ec896869433a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39237",
+					"10.65.0.27:39237",
+					"172.17.0.1:39237",
+					"172.18.0.1:39237",
+					"172.19.0.1:39237",
+					"172.20.0.1:39237",
+					"172.21.0.1:39237",
+					"172.22.0.1:39237",
+					"172.23.0.1:39237",
+					"172.24.0.1:39237",
+					"172.25.0.1:39237",
+					"172.26.0.1:39237",
+					"172.27.0.1:39237",
+					"172.28.0.1:39237",
+					"172.29.0.1:39237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:09:46.936307856Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3844756781655839,
+				"StableID":   "nxXY3zEJ2X11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b2d4a4fab6a729dad226e73c64361cead2b21704cbe50ce4de339d50e7c2201e",
+				"DiscoKey":   "discokey:3abb4edeebe7251467fb74569a6693d582580c7387555c3e009fc61c8b600432",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52682",
+					"10.65.0.27:52682",
+					"172.17.0.1:52682",
+					"172.18.0.1:52682",
+					"172.19.0.1:52682",
+					"172.20.0.1:52682",
+					"172.21.0.1:52682",
+					"172.22.0.1:52682",
+					"172.23.0.1:52682",
+					"172.24.0.1:52682",
+					"172.25.0.1:52682",
+					"172.26.0.1:52682",
+					"172.27.0.1:52682",
+					"172.28.0.1:52682",
+					"172.29.0.1:52682"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:09:48.276209785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7721349283250464,
+				"StableID":   "nR3Geek1J321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:53cdbd2a02f426b6f1050739e8bb0158ad820823d97ee947d0669b2795b4793e",
+				"DiscoKey":   "discokey:5001bf5d922a739562c393b47298ca093ec32bd94e61c1a0d7d7c929fd37004f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57229",
+					"10.65.0.27:57229",
+					"172.17.0.1:57229",
+					"172.18.0.1:57229",
+					"172.19.0.1:57229",
+					"172.20.0.1:57229",
+					"172.21.0.1:57229",
+					"172.22.0.1:57229",
+					"172.23.0.1:57229",
+					"172.24.0.1:57229",
+					"172.25.0.1:57229",
+					"172.26.0.1:57229",
+					"172.27.0.1:57229",
+					"172.28.0.1:57229",
+					"172.29.0.1:57229"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:09:48.810725022Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8529137471312197,
+				"StableID":   "nvwUgkyrb921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e50e83c32dfa9000e243698477cdf31ac700548548634bab8d625c811a391348",
+				"DiscoKey":   "discokey:03888741ff54921b0945f19c5a06bd8ceef017baa166c393be697ad1964fe950",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:40794",
+					"10.65.0.27:40794",
+					"172.17.0.1:40794",
+					"172.18.0.1:40794",
+					"172.19.0.1:40794",
+					"172.20.0.1:40794",
+					"172.21.0.1:40794",
+					"172.22.0.1:40794",
+					"172.23.0.1:40794",
+					"172.24.0.1:40794",
+					"172.25.0.1:40794",
+					"172.26.0.1:40794",
+					"172.27.0.1:40794",
+					"172.28.0.1:40794",
+					"172.29.0.1:40794"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:09:49.345404174Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1133665446225711,
+				"StableID":   "npspRCUSr911CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af3ef8c77445c102e5a391acf22ae87176cd45610d9b7a35ef2b9a045ce86456",
+				"DiscoKey":   "discokey:c6b68fa95ac1834525dcc473f9539e27101e3ddc7214e1af4f17800e31be205f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44144",
+					"10.65.0.27:44144",
+					"172.17.0.1:44144",
+					"172.18.0.1:44144",
+					"172.19.0.1:44144",
+					"172.20.0.1:44144",
+					"172.21.0.1:44144",
+					"172.22.0.1:44144",
+					"172.23.0.1:44144",
+					"172.24.0.1:44144",
+					"172.25.0.1:44144",
+					"172.26.0.1:44144",
+					"172.27.0.1:44144",
+					"172.28.0.1:44144",
+					"172.29.0.1:44144"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:09:49.906892291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4327360026868473,
+				"StableID":   "nLg7EnQsna11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41b456fff76f073210ae1f5b1885880231b492677d82ebb16e19de0d8d05db43",
+				"DiscoKey":   "discokey:cdc9d51564ec303392666bc959439f647b6bc871300fcd3dd462490a78acf213",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55548",
+					"10.65.0.27:55548",
+					"172.17.0.1:55548",
+					"172.18.0.1:55548",
+					"172.19.0.1:55548",
+					"172.20.0.1:55548",
+					"172.21.0.1:55548",
+					"172.22.0.1:55548",
+					"172.23.0.1:55548",
+					"172.24.0.1:55548",
+					"172.25.0.1:55548",
+					"172.26.0.1:55548",
+					"172.27.0.1:55548",
+					"172.28.0.1:55548",
+					"172.29.0.1:55548"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:09:50.591259506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         597170729733715,
+				"StableID":   "nQ3MURfTf511CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae9217620a86b09c23dd2142abf1d76912df58684961c3fc62349e1e0915b149",
+				"DiscoKey":   "discokey:db83951819aa37fa450ba0b748856d853ce43a7f68a336aee82e9c045782293c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:39960",
+					"10.65.0.27:39960",
+					"172.17.0.1:39960",
+					"172.18.0.1:39960",
+					"172.19.0.1:39960",
+					"172.20.0.1:39960",
+					"172.21.0.1:39960",
+					"172.22.0.1:39960",
+					"172.23.0.1:39960",
+					"172.24.0.1:39960",
+					"172.25.0.1:39960",
+					"172.26.0.1:39960",
+					"172.27.0.1:39960",
+					"172.28.0.1:39960",
+					"172.29.0.1:39960"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:09:51.225297251Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2081825077297187,
+				"StableID":   "nkwvCr1sFH11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83b7fe43ccf866075f0328181d2d70add517cc694bcc0056a9a856f4d8673307",
+				"DiscoKey":   "discokey:343144325f073c39cc74a2331742af006c61e006957f60786a46742dcb0df42b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49517",
+					"10.65.0.27:49517",
+					"172.17.0.1:49517",
+					"172.18.0.1:49517",
+					"172.19.0.1:49517",
+					"172.20.0.1:49517",
+					"172.21.0.1:49517",
+					"172.22.0.1:49517",
+					"172.23.0.1:49517",
+					"172.24.0.1:49517",
+					"172.25.0.1:49517",
+					"172.26.0.1:49517",
+					"172.27.0.1:49517",
+					"172.28.0.1:49517",
+					"172.29.0.1:49517"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:09:51.766590389Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3838711917156017,
+				"StableID":   "ntev4GTZyW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3c743971520558c0b50716981af1a5d7a4dde1747220f21ed6fa1553635e9d55",
+				"KeyExpiry":  "2026-11-09T09:09:52Z",
+				"DiscoKey":   "discokey:556ade8dabe7d02cda014c2d15219252465583c8a9ba575c4681daec63fb8175",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:55726",
+					"10.65.0.27:55726",
+					"172.17.0.1:55726",
+					"172.18.0.1:55726",
+					"172.19.0.1:55726",
+					"172.20.0.1:55726",
+					"172.21.0.1:55726",
+					"172.22.0.1:55726",
+					"172.23.0.1:55726",
+					"172.24.0.1:55726",
+					"172.25.0.1:55726",
+					"172.26.0.1:55726",
+					"172.27.0.1:55726",
+					"172.28.0.1:55726",
+					"172.29.0.1:55726"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:09:52.315081835Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2445166358548395,
+				"StableID":   "nWnW2hNR6L11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fd26b4c5deb48dc304d605470b355fd64b1fdaa576cd27fd1d8a4967983b8f1f",
+				"KeyExpiry":  "2026-11-09T09:09:52Z",
+				"DiscoKey":   "discokey:8f584643e412b124e174756c1c32f22cb30373c7098161a0ae99bb240f134d68",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52334",
+					"10.65.0.27:52334",
+					"172.17.0.1:52334",
+					"172.18.0.1:52334",
+					"172.19.0.1:52334",
+					"172.20.0.1:52334",
+					"172.21.0.1:52334",
+					"172.22.0.1:52334",
+					"172.23.0.1:52334",
+					"172.24.0.1:52334",
+					"172.25.0.1:52334",
+					"172.26.0.1:52334",
+					"172.27.0.1:52334",
+					"172.28.0.1:52334",
+					"172.29.0.1:52334"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:09:52.849051482Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3210096661715349,
+				"StableID":   "n2m6YAor4S11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:93d6d7c637d9def2c70a30aa2ce458e01e904acfe931a04897fb0fab4cd26d29",
+				"KeyExpiry":  "2026-11-09T09:09:53Z",
+				"DiscoKey":   "discokey:15054df074c7d5425e6f305994dbbc8d96cd540b1c34e640db359774fcce4226",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59567",
+					"10.65.0.27:59567",
+					"172.17.0.1:59567",
+					"172.18.0.1:59567",
+					"172.19.0.1:59567",
+					"172.20.0.1:59567",
+					"172.21.0.1:59567",
+					"172.22.0.1:59567",
+					"172.23.0.1:59567",
+					"172.24.0.1:59567",
+					"172.25.0.1:59567",
+					"172.26.0.1:59567",
+					"172.27.0.1:59567",
+					"172.28.0.1:59567",
+					"172.29.0.1:59567"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:09:53.390208111Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7311289998587147": {
+				"ID":          7311289998587147,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         251905086834600,
+				"StableID":   "nhV5vv76y211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       251905086834600,
+				"Key":        "nodekey:2217ed7e2d284d12862d48bc7faa3a80ac0cb8eb3930cfd7e7a754099ab4a510",
+				"DiscoKey":   "discokey:da9e2b384db2465a717bdcdf8097c7ad2d50375aa7396b19e287ec896869433a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39237",
+					"10.65.0.27:39237",
+					"172.17.0.1:39237",
+					"172.18.0.1:39237",
+					"172.19.0.1:39237",
+					"172.20.0.1:39237",
+					"172.21.0.1:39237",
+					"172.22.0.1:39237",
+					"172.23.0.1:39237",
+					"172.24.0.1:39237",
+					"172.25.0.1:39237",
+					"172.26.0.1:39237",
+					"172.27.0.1:39237",
+					"172.28.0.1:39237",
+					"172.29.0.1:39237"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:09:46.936307856Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2217ed7e2d284d12862d48bc7faa3a80ac0cb8eb3930cfd7e7a754099ab4a510",
+			"MachineKey": "mkey:6c261c60a788145a51dcb2bcd64536617c9c2fe7c47a4bbae7ef6737e7bb761d",
+			"Peers": [{
+				"ID":         7545449853970951,
+				"StableID":   "nAL9R2BMv121CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf2b1c33b0339bfc285f5a3438d54d6ef6132de91e1006564a3bdd4766041531",
+				"DiscoKey":   "discokey:f0b35b8a47d7c0e75151d9102f26d7a6940a99da53b3cef76a2abf2cd74ab143",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52491",
+					"10.65.0.27:52491",
+					"172.17.0.1:52491",
+					"172.18.0.1:52491",
+					"172.19.0.1:52491",
+					"172.20.0.1:52491",
+					"172.21.0.1:52491",
+					"172.22.0.1:52491",
+					"172.23.0.1:52491",
+					"172.24.0.1:52491",
+					"172.25.0.1:52491",
+					"172.26.0.1:52491",
+					"172.27.0.1:52491",
+					"172.28.0.1:52491",
+					"172.29.0.1:52491"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:09:45.317446196Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6601191949024367,
+				"StableID":   "na6Jpt7hYt11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:222763516a281cf6b9de022760bdf90f572b3579368caed48197d273ba71893b",
+				"DiscoKey":   "discokey:2c8fc2aecdcac32fa49181d486093f1957845e202c75459b2ffcb6210bc2b216",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:49866",
+					"10.65.0.27:49866",
+					"172.17.0.1:49866",
+					"172.18.0.1:49866",
+					"172.19.0.1:49866",
+					"172.20.0.1:49866",
+					"172.21.0.1:49866",
+					"172.22.0.1:49866",
+					"172.23.0.1:49866",
+					"172.24.0.1:49866",
+					"172.25.0.1:49866",
+					"172.26.0.1:49866",
+					"172.27.0.1:49866",
+					"172.28.0.1:49866",
+					"172.29.0.1:49866"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:09:45.860172783Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5641686272672076,
+				"StableID":   "nmKQsqX84m11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee3c3576175d8b875911c1d25f8a5ec9f1a2547f2a616619106fca5dc0d6a158",
+				"DiscoKey":   "discokey:a12ef384bffb0c4f6562eeb34d49eeaadbb5b72e68752d1dfed195d161552c09",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41012",
+					"10.65.0.27:41012",
+					"172.17.0.1:41012",
+					"172.18.0.1:41012",
+					"172.19.0.1:41012",
+					"172.20.0.1:41012",
+					"172.21.0.1:41012",
+					"172.22.0.1:41012",
+					"172.23.0.1:41012",
+					"172.24.0.1:41012",
+					"172.25.0.1:41012",
+					"172.26.0.1:41012",
+					"172.27.0.1:41012",
+					"172.28.0.1:41012",
+					"172.29.0.1:41012"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:09:46.400765907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7311289998587147,
+				"StableID":   "nWaeq3CJ6z11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5ecfa4441cec326657a9c2364b42c3b0c0155207c5a7b0fbf4d9ddcb58d46840",
+				"DiscoKey":   "discokey:2639340901c617a5c4e800f56f3ea482279b4b1ce708f1146d42263fd9315f4c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37204",
+					"10.65.0.27:37204",
+					"172.17.0.1:37204",
+					"172.18.0.1:37204",
+					"172.19.0.1:37204",
+					"172.20.0.1:37204",
+					"172.21.0.1:37204",
+					"172.22.0.1:37204",
+					"172.23.0.1:37204",
+					"172.24.0.1:37204",
+					"172.25.0.1:37204",
+					"172.26.0.1:37204",
+					"172.27.0.1:37204",
+					"172.28.0.1:37204",
+					"172.29.0.1:37204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:09:47.731176987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3844756781655839,
+				"StableID":   "nxXY3zEJ2X11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b2d4a4fab6a729dad226e73c64361cead2b21704cbe50ce4de339d50e7c2201e",
+				"DiscoKey":   "discokey:3abb4edeebe7251467fb74569a6693d582580c7387555c3e009fc61c8b600432",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52682",
+					"10.65.0.27:52682",
+					"172.17.0.1:52682",
+					"172.18.0.1:52682",
+					"172.19.0.1:52682",
+					"172.20.0.1:52682",
+					"172.21.0.1:52682",
+					"172.22.0.1:52682",
+					"172.23.0.1:52682",
+					"172.24.0.1:52682",
+					"172.25.0.1:52682",
+					"172.26.0.1:52682",
+					"172.27.0.1:52682",
+					"172.28.0.1:52682",
+					"172.29.0.1:52682"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:09:48.276209785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7721349283250464,
+				"StableID":   "nR3Geek1J321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:53cdbd2a02f426b6f1050739e8bb0158ad820823d97ee947d0669b2795b4793e",
+				"DiscoKey":   "discokey:5001bf5d922a739562c393b47298ca093ec32bd94e61c1a0d7d7c929fd37004f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57229",
+					"10.65.0.27:57229",
+					"172.17.0.1:57229",
+					"172.18.0.1:57229",
+					"172.19.0.1:57229",
+					"172.20.0.1:57229",
+					"172.21.0.1:57229",
+					"172.22.0.1:57229",
+					"172.23.0.1:57229",
+					"172.24.0.1:57229",
+					"172.25.0.1:57229",
+					"172.26.0.1:57229",
+					"172.27.0.1:57229",
+					"172.28.0.1:57229",
+					"172.29.0.1:57229"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:09:48.810725022Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8529137471312197,
+				"StableID":   "nvwUgkyrb921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e50e83c32dfa9000e243698477cdf31ac700548548634bab8d625c811a391348",
+				"DiscoKey":   "discokey:03888741ff54921b0945f19c5a06bd8ceef017baa166c393be697ad1964fe950",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:40794",
+					"10.65.0.27:40794",
+					"172.17.0.1:40794",
+					"172.18.0.1:40794",
+					"172.19.0.1:40794",
+					"172.20.0.1:40794",
+					"172.21.0.1:40794",
+					"172.22.0.1:40794",
+					"172.23.0.1:40794",
+					"172.24.0.1:40794",
+					"172.25.0.1:40794",
+					"172.26.0.1:40794",
+					"172.27.0.1:40794",
+					"172.28.0.1:40794",
+					"172.29.0.1:40794"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:09:49.345404174Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1133665446225711,
+				"StableID":   "npspRCUSr911CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af3ef8c77445c102e5a391acf22ae87176cd45610d9b7a35ef2b9a045ce86456",
+				"DiscoKey":   "discokey:c6b68fa95ac1834525dcc473f9539e27101e3ddc7214e1af4f17800e31be205f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44144",
+					"10.65.0.27:44144",
+					"172.17.0.1:44144",
+					"172.18.0.1:44144",
+					"172.19.0.1:44144",
+					"172.20.0.1:44144",
+					"172.21.0.1:44144",
+					"172.22.0.1:44144",
+					"172.23.0.1:44144",
+					"172.24.0.1:44144",
+					"172.25.0.1:44144",
+					"172.26.0.1:44144",
+					"172.27.0.1:44144",
+					"172.28.0.1:44144",
+					"172.29.0.1:44144"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:09:49.906892291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4327360026868473,
+				"StableID":   "nLg7EnQsna11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41b456fff76f073210ae1f5b1885880231b492677d82ebb16e19de0d8d05db43",
+				"DiscoKey":   "discokey:cdc9d51564ec303392666bc959439f647b6bc871300fcd3dd462490a78acf213",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55548",
+					"10.65.0.27:55548",
+					"172.17.0.1:55548",
+					"172.18.0.1:55548",
+					"172.19.0.1:55548",
+					"172.20.0.1:55548",
+					"172.21.0.1:55548",
+					"172.22.0.1:55548",
+					"172.23.0.1:55548",
+					"172.24.0.1:55548",
+					"172.25.0.1:55548",
+					"172.26.0.1:55548",
+					"172.27.0.1:55548",
+					"172.28.0.1:55548",
+					"172.29.0.1:55548"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:09:50.591259506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         597170729733715,
+				"StableID":   "nQ3MURfTf511CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae9217620a86b09c23dd2142abf1d76912df58684961c3fc62349e1e0915b149",
+				"DiscoKey":   "discokey:db83951819aa37fa450ba0b748856d853ce43a7f68a336aee82e9c045782293c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:39960",
+					"10.65.0.27:39960",
+					"172.17.0.1:39960",
+					"172.18.0.1:39960",
+					"172.19.0.1:39960",
+					"172.20.0.1:39960",
+					"172.21.0.1:39960",
+					"172.22.0.1:39960",
+					"172.23.0.1:39960",
+					"172.24.0.1:39960",
+					"172.25.0.1:39960",
+					"172.26.0.1:39960",
+					"172.27.0.1:39960",
+					"172.28.0.1:39960",
+					"172.29.0.1:39960"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:09:51.225297251Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2081825077297187,
+				"StableID":   "nkwvCr1sFH11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83b7fe43ccf866075f0328181d2d70add517cc694bcc0056a9a856f4d8673307",
+				"DiscoKey":   "discokey:343144325f073c39cc74a2331742af006c61e006957f60786a46742dcb0df42b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49517",
+					"10.65.0.27:49517",
+					"172.17.0.1:49517",
+					"172.18.0.1:49517",
+					"172.19.0.1:49517",
+					"172.20.0.1:49517",
+					"172.21.0.1:49517",
+					"172.22.0.1:49517",
+					"172.23.0.1:49517",
+					"172.24.0.1:49517",
+					"172.25.0.1:49517",
+					"172.26.0.1:49517",
+					"172.27.0.1:49517",
+					"172.28.0.1:49517",
+					"172.29.0.1:49517"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:09:51.766590389Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3838711917156017,
+				"StableID":   "ntev4GTZyW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3c743971520558c0b50716981af1a5d7a4dde1747220f21ed6fa1553635e9d55",
+				"KeyExpiry":  "2026-11-09T09:09:52Z",
+				"DiscoKey":   "discokey:556ade8dabe7d02cda014c2d15219252465583c8a9ba575c4681daec63fb8175",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:55726",
+					"10.65.0.27:55726",
+					"172.17.0.1:55726",
+					"172.18.0.1:55726",
+					"172.19.0.1:55726",
+					"172.20.0.1:55726",
+					"172.21.0.1:55726",
+					"172.22.0.1:55726",
+					"172.23.0.1:55726",
+					"172.24.0.1:55726",
+					"172.25.0.1:55726",
+					"172.26.0.1:55726",
+					"172.27.0.1:55726",
+					"172.28.0.1:55726",
+					"172.29.0.1:55726"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:09:52.315081835Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2445166358548395,
+				"StableID":   "nWnW2hNR6L11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fd26b4c5deb48dc304d605470b355fd64b1fdaa576cd27fd1d8a4967983b8f1f",
+				"KeyExpiry":  "2026-11-09T09:09:52Z",
+				"DiscoKey":   "discokey:8f584643e412b124e174756c1c32f22cb30373c7098161a0ae99bb240f134d68",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52334",
+					"10.65.0.27:52334",
+					"172.17.0.1:52334",
+					"172.18.0.1:52334",
+					"172.19.0.1:52334",
+					"172.20.0.1:52334",
+					"172.21.0.1:52334",
+					"172.22.0.1:52334",
+					"172.23.0.1:52334",
+					"172.24.0.1:52334",
+					"172.25.0.1:52334",
+					"172.26.0.1:52334",
+					"172.27.0.1:52334",
+					"172.28.0.1:52334",
+					"172.29.0.1:52334"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:09:52.849051482Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3210096661715349,
+				"StableID":   "n2m6YAor4S11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:93d6d7c637d9def2c70a30aa2ce458e01e904acfe931a04897fb0fab4cd26d29",
+				"KeyExpiry":  "2026-11-09T09:09:53Z",
+				"DiscoKey":   "discokey:15054df074c7d5425e6f305994dbbc8d96cd540b1c34e640db359774fcce4226",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59567",
+					"10.65.0.27:59567",
+					"172.17.0.1:59567",
+					"172.18.0.1:59567",
+					"172.19.0.1:59567",
+					"172.20.0.1:59567",
+					"172.21.0.1:59567",
+					"172.22.0.1:59567",
+					"172.23.0.1:59567",
+					"172.24.0.1:59567",
+					"172.25.0.1:59567",
+					"172.26.0.1:59567",
+					"172.27.0.1:59567",
+					"172.28.0.1:59567",
+					"172.29.0.1:59567"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:09:53.390208111Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "251905086834600": {
+				"ID":          251905086834600,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7721349283250464,
+				"StableID":   "nR3Geek1J321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       7721349283250464,
+				"Key":        "nodekey:53cdbd2a02f426b6f1050739e8bb0158ad820823d97ee947d0669b2795b4793e",
+				"DiscoKey":   "discokey:5001bf5d922a739562c393b47298ca093ec32bd94e61c1a0d7d7c929fd37004f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57229",
+					"10.65.0.27:57229",
+					"172.17.0.1:57229",
+					"172.18.0.1:57229",
+					"172.19.0.1:57229",
+					"172.20.0.1:57229",
+					"172.21.0.1:57229",
+					"172.22.0.1:57229",
+					"172.23.0.1:57229",
+					"172.24.0.1:57229",
+					"172.25.0.1:57229",
+					"172.26.0.1:57229",
+					"172.27.0.1:57229",
+					"172.28.0.1:57229",
+					"172.29.0.1:57229"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:09:48.810725022Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:53cdbd2a02f426b6f1050739e8bb0158ad820823d97ee947d0669b2795b4793e",
+			"MachineKey": "mkey:234759fe880412b4727653683b2903a65a448c35a10e18990795986ffdf00d7c",
+			"Peers": [{
+				"ID":         7545449853970951,
+				"StableID":   "nAL9R2BMv121CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf2b1c33b0339bfc285f5a3438d54d6ef6132de91e1006564a3bdd4766041531",
+				"DiscoKey":   "discokey:f0b35b8a47d7c0e75151d9102f26d7a6940a99da53b3cef76a2abf2cd74ab143",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52491",
+					"10.65.0.27:52491",
+					"172.17.0.1:52491",
+					"172.18.0.1:52491",
+					"172.19.0.1:52491",
+					"172.20.0.1:52491",
+					"172.21.0.1:52491",
+					"172.22.0.1:52491",
+					"172.23.0.1:52491",
+					"172.24.0.1:52491",
+					"172.25.0.1:52491",
+					"172.26.0.1:52491",
+					"172.27.0.1:52491",
+					"172.28.0.1:52491",
+					"172.29.0.1:52491"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:09:45.317446196Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6601191949024367,
+				"StableID":   "na6Jpt7hYt11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:222763516a281cf6b9de022760bdf90f572b3579368caed48197d273ba71893b",
+				"DiscoKey":   "discokey:2c8fc2aecdcac32fa49181d486093f1957845e202c75459b2ffcb6210bc2b216",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:49866",
+					"10.65.0.27:49866",
+					"172.17.0.1:49866",
+					"172.18.0.1:49866",
+					"172.19.0.1:49866",
+					"172.20.0.1:49866",
+					"172.21.0.1:49866",
+					"172.22.0.1:49866",
+					"172.23.0.1:49866",
+					"172.24.0.1:49866",
+					"172.25.0.1:49866",
+					"172.26.0.1:49866",
+					"172.27.0.1:49866",
+					"172.28.0.1:49866",
+					"172.29.0.1:49866"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:09:45.860172783Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5641686272672076,
+				"StableID":   "nmKQsqX84m11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee3c3576175d8b875911c1d25f8a5ec9f1a2547f2a616619106fca5dc0d6a158",
+				"DiscoKey":   "discokey:a12ef384bffb0c4f6562eeb34d49eeaadbb5b72e68752d1dfed195d161552c09",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41012",
+					"10.65.0.27:41012",
+					"172.17.0.1:41012",
+					"172.18.0.1:41012",
+					"172.19.0.1:41012",
+					"172.20.0.1:41012",
+					"172.21.0.1:41012",
+					"172.22.0.1:41012",
+					"172.23.0.1:41012",
+					"172.24.0.1:41012",
+					"172.25.0.1:41012",
+					"172.26.0.1:41012",
+					"172.27.0.1:41012",
+					"172.28.0.1:41012",
+					"172.29.0.1:41012"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:09:46.400765907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         251905086834600,
+				"StableID":   "nhV5vv76y211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2217ed7e2d284d12862d48bc7faa3a80ac0cb8eb3930cfd7e7a754099ab4a510",
+				"DiscoKey":   "discokey:da9e2b384db2465a717bdcdf8097c7ad2d50375aa7396b19e287ec896869433a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39237",
+					"10.65.0.27:39237",
+					"172.17.0.1:39237",
+					"172.18.0.1:39237",
+					"172.19.0.1:39237",
+					"172.20.0.1:39237",
+					"172.21.0.1:39237",
+					"172.22.0.1:39237",
+					"172.23.0.1:39237",
+					"172.24.0.1:39237",
+					"172.25.0.1:39237",
+					"172.26.0.1:39237",
+					"172.27.0.1:39237",
+					"172.28.0.1:39237",
+					"172.29.0.1:39237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:09:46.936307856Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7311289998587147,
+				"StableID":   "nWaeq3CJ6z11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5ecfa4441cec326657a9c2364b42c3b0c0155207c5a7b0fbf4d9ddcb58d46840",
+				"DiscoKey":   "discokey:2639340901c617a5c4e800f56f3ea482279b4b1ce708f1146d42263fd9315f4c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37204",
+					"10.65.0.27:37204",
+					"172.17.0.1:37204",
+					"172.18.0.1:37204",
+					"172.19.0.1:37204",
+					"172.20.0.1:37204",
+					"172.21.0.1:37204",
+					"172.22.0.1:37204",
+					"172.23.0.1:37204",
+					"172.24.0.1:37204",
+					"172.25.0.1:37204",
+					"172.26.0.1:37204",
+					"172.27.0.1:37204",
+					"172.28.0.1:37204",
+					"172.29.0.1:37204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:09:47.731176987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3844756781655839,
+				"StableID":   "nxXY3zEJ2X11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b2d4a4fab6a729dad226e73c64361cead2b21704cbe50ce4de339d50e7c2201e",
+				"DiscoKey":   "discokey:3abb4edeebe7251467fb74569a6693d582580c7387555c3e009fc61c8b600432",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52682",
+					"10.65.0.27:52682",
+					"172.17.0.1:52682",
+					"172.18.0.1:52682",
+					"172.19.0.1:52682",
+					"172.20.0.1:52682",
+					"172.21.0.1:52682",
+					"172.22.0.1:52682",
+					"172.23.0.1:52682",
+					"172.24.0.1:52682",
+					"172.25.0.1:52682",
+					"172.26.0.1:52682",
+					"172.27.0.1:52682",
+					"172.28.0.1:52682",
+					"172.29.0.1:52682"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:09:48.276209785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8529137471312197,
+				"StableID":   "nvwUgkyrb921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e50e83c32dfa9000e243698477cdf31ac700548548634bab8d625c811a391348",
+				"DiscoKey":   "discokey:03888741ff54921b0945f19c5a06bd8ceef017baa166c393be697ad1964fe950",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:40794",
+					"10.65.0.27:40794",
+					"172.17.0.1:40794",
+					"172.18.0.1:40794",
+					"172.19.0.1:40794",
+					"172.20.0.1:40794",
+					"172.21.0.1:40794",
+					"172.22.0.1:40794",
+					"172.23.0.1:40794",
+					"172.24.0.1:40794",
+					"172.25.0.1:40794",
+					"172.26.0.1:40794",
+					"172.27.0.1:40794",
+					"172.28.0.1:40794",
+					"172.29.0.1:40794"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:09:49.345404174Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1133665446225711,
+				"StableID":   "npspRCUSr911CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af3ef8c77445c102e5a391acf22ae87176cd45610d9b7a35ef2b9a045ce86456",
+				"DiscoKey":   "discokey:c6b68fa95ac1834525dcc473f9539e27101e3ddc7214e1af4f17800e31be205f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44144",
+					"10.65.0.27:44144",
+					"172.17.0.1:44144",
+					"172.18.0.1:44144",
+					"172.19.0.1:44144",
+					"172.20.0.1:44144",
+					"172.21.0.1:44144",
+					"172.22.0.1:44144",
+					"172.23.0.1:44144",
+					"172.24.0.1:44144",
+					"172.25.0.1:44144",
+					"172.26.0.1:44144",
+					"172.27.0.1:44144",
+					"172.28.0.1:44144",
+					"172.29.0.1:44144"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:09:49.906892291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4327360026868473,
+				"StableID":   "nLg7EnQsna11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41b456fff76f073210ae1f5b1885880231b492677d82ebb16e19de0d8d05db43",
+				"DiscoKey":   "discokey:cdc9d51564ec303392666bc959439f647b6bc871300fcd3dd462490a78acf213",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55548",
+					"10.65.0.27:55548",
+					"172.17.0.1:55548",
+					"172.18.0.1:55548",
+					"172.19.0.1:55548",
+					"172.20.0.1:55548",
+					"172.21.0.1:55548",
+					"172.22.0.1:55548",
+					"172.23.0.1:55548",
+					"172.24.0.1:55548",
+					"172.25.0.1:55548",
+					"172.26.0.1:55548",
+					"172.27.0.1:55548",
+					"172.28.0.1:55548",
+					"172.29.0.1:55548"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:09:50.591259506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         597170729733715,
+				"StableID":   "nQ3MURfTf511CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae9217620a86b09c23dd2142abf1d76912df58684961c3fc62349e1e0915b149",
+				"DiscoKey":   "discokey:db83951819aa37fa450ba0b748856d853ce43a7f68a336aee82e9c045782293c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:39960",
+					"10.65.0.27:39960",
+					"172.17.0.1:39960",
+					"172.18.0.1:39960",
+					"172.19.0.1:39960",
+					"172.20.0.1:39960",
+					"172.21.0.1:39960",
+					"172.22.0.1:39960",
+					"172.23.0.1:39960",
+					"172.24.0.1:39960",
+					"172.25.0.1:39960",
+					"172.26.0.1:39960",
+					"172.27.0.1:39960",
+					"172.28.0.1:39960",
+					"172.29.0.1:39960"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:09:51.225297251Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2081825077297187,
+				"StableID":   "nkwvCr1sFH11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83b7fe43ccf866075f0328181d2d70add517cc694bcc0056a9a856f4d8673307",
+				"DiscoKey":   "discokey:343144325f073c39cc74a2331742af006c61e006957f60786a46742dcb0df42b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49517",
+					"10.65.0.27:49517",
+					"172.17.0.1:49517",
+					"172.18.0.1:49517",
+					"172.19.0.1:49517",
+					"172.20.0.1:49517",
+					"172.21.0.1:49517",
+					"172.22.0.1:49517",
+					"172.23.0.1:49517",
+					"172.24.0.1:49517",
+					"172.25.0.1:49517",
+					"172.26.0.1:49517",
+					"172.27.0.1:49517",
+					"172.28.0.1:49517",
+					"172.29.0.1:49517"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:09:51.766590389Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3838711917156017,
+				"StableID":   "ntev4GTZyW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3c743971520558c0b50716981af1a5d7a4dde1747220f21ed6fa1553635e9d55",
+				"KeyExpiry":  "2026-11-09T09:09:52Z",
+				"DiscoKey":   "discokey:556ade8dabe7d02cda014c2d15219252465583c8a9ba575c4681daec63fb8175",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:55726",
+					"10.65.0.27:55726",
+					"172.17.0.1:55726",
+					"172.18.0.1:55726",
+					"172.19.0.1:55726",
+					"172.20.0.1:55726",
+					"172.21.0.1:55726",
+					"172.22.0.1:55726",
+					"172.23.0.1:55726",
+					"172.24.0.1:55726",
+					"172.25.0.1:55726",
+					"172.26.0.1:55726",
+					"172.27.0.1:55726",
+					"172.28.0.1:55726",
+					"172.29.0.1:55726"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:09:52.315081835Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2445166358548395,
+				"StableID":   "nWnW2hNR6L11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fd26b4c5deb48dc304d605470b355fd64b1fdaa576cd27fd1d8a4967983b8f1f",
+				"KeyExpiry":  "2026-11-09T09:09:52Z",
+				"DiscoKey":   "discokey:8f584643e412b124e174756c1c32f22cb30373c7098161a0ae99bb240f134d68",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52334",
+					"10.65.0.27:52334",
+					"172.17.0.1:52334",
+					"172.18.0.1:52334",
+					"172.19.0.1:52334",
+					"172.20.0.1:52334",
+					"172.21.0.1:52334",
+					"172.22.0.1:52334",
+					"172.23.0.1:52334",
+					"172.24.0.1:52334",
+					"172.25.0.1:52334",
+					"172.26.0.1:52334",
+					"172.27.0.1:52334",
+					"172.28.0.1:52334",
+					"172.29.0.1:52334"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:09:52.849051482Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3210096661715349,
+				"StableID":   "n2m6YAor4S11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:93d6d7c637d9def2c70a30aa2ce458e01e904acfe931a04897fb0fab4cd26d29",
+				"KeyExpiry":  "2026-11-09T09:09:53Z",
+				"DiscoKey":   "discokey:15054df074c7d5425e6f305994dbbc8d96cd540b1c34e640db359774fcce4226",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59567",
+					"10.65.0.27:59567",
+					"172.17.0.1:59567",
+					"172.18.0.1:59567",
+					"172.19.0.1:59567",
+					"172.20.0.1:59567",
+					"172.21.0.1:59567",
+					"172.22.0.1:59567",
+					"172.23.0.1:59567",
+					"172.24.0.1:59567",
+					"172.25.0.1:59567",
+					"172.26.0.1:59567",
+					"172.27.0.1:59567",
+					"172.28.0.1:59567",
+					"172.29.0.1:59567"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:09:53.390208111Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7721349283250464": {
+				"ID":          7721349283250464,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1133665446225711,
+				"StableID":   "npspRCUSr911CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1133665446225711,
+				"Key":        "nodekey:af3ef8c77445c102e5a391acf22ae87176cd45610d9b7a35ef2b9a045ce86456",
+				"DiscoKey":   "discokey:c6b68fa95ac1834525dcc473f9539e27101e3ddc7214e1af4f17800e31be205f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44144",
+					"10.65.0.27:44144",
+					"172.17.0.1:44144",
+					"172.18.0.1:44144",
+					"172.19.0.1:44144",
+					"172.20.0.1:44144",
+					"172.21.0.1:44144",
+					"172.22.0.1:44144",
+					"172.23.0.1:44144",
+					"172.24.0.1:44144",
+					"172.25.0.1:44144",
+					"172.26.0.1:44144",
+					"172.27.0.1:44144",
+					"172.28.0.1:44144",
+					"172.29.0.1:44144"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:09:49.906892291Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:af3ef8c77445c102e5a391acf22ae87176cd45610d9b7a35ef2b9a045ce86456",
+			"MachineKey": "mkey:e28bf333e19f249255ea6af274def46ffc9a30c359a8f4c4ec06dc5f68fc6e01",
+			"Peers": [{
+				"ID":         7545449853970951,
+				"StableID":   "nAL9R2BMv121CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf2b1c33b0339bfc285f5a3438d54d6ef6132de91e1006564a3bdd4766041531",
+				"DiscoKey":   "discokey:f0b35b8a47d7c0e75151d9102f26d7a6940a99da53b3cef76a2abf2cd74ab143",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52491",
+					"10.65.0.27:52491",
+					"172.17.0.1:52491",
+					"172.18.0.1:52491",
+					"172.19.0.1:52491",
+					"172.20.0.1:52491",
+					"172.21.0.1:52491",
+					"172.22.0.1:52491",
+					"172.23.0.1:52491",
+					"172.24.0.1:52491",
+					"172.25.0.1:52491",
+					"172.26.0.1:52491",
+					"172.27.0.1:52491",
+					"172.28.0.1:52491",
+					"172.29.0.1:52491"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:09:45.317446196Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6601191949024367,
+				"StableID":   "na6Jpt7hYt11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:222763516a281cf6b9de022760bdf90f572b3579368caed48197d273ba71893b",
+				"DiscoKey":   "discokey:2c8fc2aecdcac32fa49181d486093f1957845e202c75459b2ffcb6210bc2b216",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:49866",
+					"10.65.0.27:49866",
+					"172.17.0.1:49866",
+					"172.18.0.1:49866",
+					"172.19.0.1:49866",
+					"172.20.0.1:49866",
+					"172.21.0.1:49866",
+					"172.22.0.1:49866",
+					"172.23.0.1:49866",
+					"172.24.0.1:49866",
+					"172.25.0.1:49866",
+					"172.26.0.1:49866",
+					"172.27.0.1:49866",
+					"172.28.0.1:49866",
+					"172.29.0.1:49866"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:09:45.860172783Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5641686272672076,
+				"StableID":   "nmKQsqX84m11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee3c3576175d8b875911c1d25f8a5ec9f1a2547f2a616619106fca5dc0d6a158",
+				"DiscoKey":   "discokey:a12ef384bffb0c4f6562eeb34d49eeaadbb5b72e68752d1dfed195d161552c09",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41012",
+					"10.65.0.27:41012",
+					"172.17.0.1:41012",
+					"172.18.0.1:41012",
+					"172.19.0.1:41012",
+					"172.20.0.1:41012",
+					"172.21.0.1:41012",
+					"172.22.0.1:41012",
+					"172.23.0.1:41012",
+					"172.24.0.1:41012",
+					"172.25.0.1:41012",
+					"172.26.0.1:41012",
+					"172.27.0.1:41012",
+					"172.28.0.1:41012",
+					"172.29.0.1:41012"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:09:46.400765907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         251905086834600,
+				"StableID":   "nhV5vv76y211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2217ed7e2d284d12862d48bc7faa3a80ac0cb8eb3930cfd7e7a754099ab4a510",
+				"DiscoKey":   "discokey:da9e2b384db2465a717bdcdf8097c7ad2d50375aa7396b19e287ec896869433a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39237",
+					"10.65.0.27:39237",
+					"172.17.0.1:39237",
+					"172.18.0.1:39237",
+					"172.19.0.1:39237",
+					"172.20.0.1:39237",
+					"172.21.0.1:39237",
+					"172.22.0.1:39237",
+					"172.23.0.1:39237",
+					"172.24.0.1:39237",
+					"172.25.0.1:39237",
+					"172.26.0.1:39237",
+					"172.27.0.1:39237",
+					"172.28.0.1:39237",
+					"172.29.0.1:39237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:09:46.936307856Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7311289998587147,
+				"StableID":   "nWaeq3CJ6z11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5ecfa4441cec326657a9c2364b42c3b0c0155207c5a7b0fbf4d9ddcb58d46840",
+				"DiscoKey":   "discokey:2639340901c617a5c4e800f56f3ea482279b4b1ce708f1146d42263fd9315f4c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37204",
+					"10.65.0.27:37204",
+					"172.17.0.1:37204",
+					"172.18.0.1:37204",
+					"172.19.0.1:37204",
+					"172.20.0.1:37204",
+					"172.21.0.1:37204",
+					"172.22.0.1:37204",
+					"172.23.0.1:37204",
+					"172.24.0.1:37204",
+					"172.25.0.1:37204",
+					"172.26.0.1:37204",
+					"172.27.0.1:37204",
+					"172.28.0.1:37204",
+					"172.29.0.1:37204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:09:47.731176987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3844756781655839,
+				"StableID":   "nxXY3zEJ2X11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b2d4a4fab6a729dad226e73c64361cead2b21704cbe50ce4de339d50e7c2201e",
+				"DiscoKey":   "discokey:3abb4edeebe7251467fb74569a6693d582580c7387555c3e009fc61c8b600432",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52682",
+					"10.65.0.27:52682",
+					"172.17.0.1:52682",
+					"172.18.0.1:52682",
+					"172.19.0.1:52682",
+					"172.20.0.1:52682",
+					"172.21.0.1:52682",
+					"172.22.0.1:52682",
+					"172.23.0.1:52682",
+					"172.24.0.1:52682",
+					"172.25.0.1:52682",
+					"172.26.0.1:52682",
+					"172.27.0.1:52682",
+					"172.28.0.1:52682",
+					"172.29.0.1:52682"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:09:48.276209785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7721349283250464,
+				"StableID":   "nR3Geek1J321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:53cdbd2a02f426b6f1050739e8bb0158ad820823d97ee947d0669b2795b4793e",
+				"DiscoKey":   "discokey:5001bf5d922a739562c393b47298ca093ec32bd94e61c1a0d7d7c929fd37004f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57229",
+					"10.65.0.27:57229",
+					"172.17.0.1:57229",
+					"172.18.0.1:57229",
+					"172.19.0.1:57229",
+					"172.20.0.1:57229",
+					"172.21.0.1:57229",
+					"172.22.0.1:57229",
+					"172.23.0.1:57229",
+					"172.24.0.1:57229",
+					"172.25.0.1:57229",
+					"172.26.0.1:57229",
+					"172.27.0.1:57229",
+					"172.28.0.1:57229",
+					"172.29.0.1:57229"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:09:48.810725022Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8529137471312197,
+				"StableID":   "nvwUgkyrb921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e50e83c32dfa9000e243698477cdf31ac700548548634bab8d625c811a391348",
+				"DiscoKey":   "discokey:03888741ff54921b0945f19c5a06bd8ceef017baa166c393be697ad1964fe950",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:40794",
+					"10.65.0.27:40794",
+					"172.17.0.1:40794",
+					"172.18.0.1:40794",
+					"172.19.0.1:40794",
+					"172.20.0.1:40794",
+					"172.21.0.1:40794",
+					"172.22.0.1:40794",
+					"172.23.0.1:40794",
+					"172.24.0.1:40794",
+					"172.25.0.1:40794",
+					"172.26.0.1:40794",
+					"172.27.0.1:40794",
+					"172.28.0.1:40794",
+					"172.29.0.1:40794"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:09:49.345404174Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4327360026868473,
+				"StableID":   "nLg7EnQsna11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41b456fff76f073210ae1f5b1885880231b492677d82ebb16e19de0d8d05db43",
+				"DiscoKey":   "discokey:cdc9d51564ec303392666bc959439f647b6bc871300fcd3dd462490a78acf213",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55548",
+					"10.65.0.27:55548",
+					"172.17.0.1:55548",
+					"172.18.0.1:55548",
+					"172.19.0.1:55548",
+					"172.20.0.1:55548",
+					"172.21.0.1:55548",
+					"172.22.0.1:55548",
+					"172.23.0.1:55548",
+					"172.24.0.1:55548",
+					"172.25.0.1:55548",
+					"172.26.0.1:55548",
+					"172.27.0.1:55548",
+					"172.28.0.1:55548",
+					"172.29.0.1:55548"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:09:50.591259506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         597170729733715,
+				"StableID":   "nQ3MURfTf511CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae9217620a86b09c23dd2142abf1d76912df58684961c3fc62349e1e0915b149",
+				"DiscoKey":   "discokey:db83951819aa37fa450ba0b748856d853ce43a7f68a336aee82e9c045782293c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:39960",
+					"10.65.0.27:39960",
+					"172.17.0.1:39960",
+					"172.18.0.1:39960",
+					"172.19.0.1:39960",
+					"172.20.0.1:39960",
+					"172.21.0.1:39960",
+					"172.22.0.1:39960",
+					"172.23.0.1:39960",
+					"172.24.0.1:39960",
+					"172.25.0.1:39960",
+					"172.26.0.1:39960",
+					"172.27.0.1:39960",
+					"172.28.0.1:39960",
+					"172.29.0.1:39960"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:09:51.225297251Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2081825077297187,
+				"StableID":   "nkwvCr1sFH11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83b7fe43ccf866075f0328181d2d70add517cc694bcc0056a9a856f4d8673307",
+				"DiscoKey":   "discokey:343144325f073c39cc74a2331742af006c61e006957f60786a46742dcb0df42b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49517",
+					"10.65.0.27:49517",
+					"172.17.0.1:49517",
+					"172.18.0.1:49517",
+					"172.19.0.1:49517",
+					"172.20.0.1:49517",
+					"172.21.0.1:49517",
+					"172.22.0.1:49517",
+					"172.23.0.1:49517",
+					"172.24.0.1:49517",
+					"172.25.0.1:49517",
+					"172.26.0.1:49517",
+					"172.27.0.1:49517",
+					"172.28.0.1:49517",
+					"172.29.0.1:49517"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:09:51.766590389Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3838711917156017,
+				"StableID":   "ntev4GTZyW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3c743971520558c0b50716981af1a5d7a4dde1747220f21ed6fa1553635e9d55",
+				"KeyExpiry":  "2026-11-09T09:09:52Z",
+				"DiscoKey":   "discokey:556ade8dabe7d02cda014c2d15219252465583c8a9ba575c4681daec63fb8175",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:55726",
+					"10.65.0.27:55726",
+					"172.17.0.1:55726",
+					"172.18.0.1:55726",
+					"172.19.0.1:55726",
+					"172.20.0.1:55726",
+					"172.21.0.1:55726",
+					"172.22.0.1:55726",
+					"172.23.0.1:55726",
+					"172.24.0.1:55726",
+					"172.25.0.1:55726",
+					"172.26.0.1:55726",
+					"172.27.0.1:55726",
+					"172.28.0.1:55726",
+					"172.29.0.1:55726"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:09:52.315081835Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2445166358548395,
+				"StableID":   "nWnW2hNR6L11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fd26b4c5deb48dc304d605470b355fd64b1fdaa576cd27fd1d8a4967983b8f1f",
+				"KeyExpiry":  "2026-11-09T09:09:52Z",
+				"DiscoKey":   "discokey:8f584643e412b124e174756c1c32f22cb30373c7098161a0ae99bb240f134d68",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52334",
+					"10.65.0.27:52334",
+					"172.17.0.1:52334",
+					"172.18.0.1:52334",
+					"172.19.0.1:52334",
+					"172.20.0.1:52334",
+					"172.21.0.1:52334",
+					"172.22.0.1:52334",
+					"172.23.0.1:52334",
+					"172.24.0.1:52334",
+					"172.25.0.1:52334",
+					"172.26.0.1:52334",
+					"172.27.0.1:52334",
+					"172.28.0.1:52334",
+					"172.29.0.1:52334"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:09:52.849051482Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3210096661715349,
+				"StableID":   "n2m6YAor4S11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:93d6d7c637d9def2c70a30aa2ce458e01e904acfe931a04897fb0fab4cd26d29",
+				"KeyExpiry":  "2026-11-09T09:09:53Z",
+				"DiscoKey":   "discokey:15054df074c7d5425e6f305994dbbc8d96cd540b1c34e640db359774fcce4226",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59567",
+					"10.65.0.27:59567",
+					"172.17.0.1:59567",
+					"172.18.0.1:59567",
+					"172.19.0.1:59567",
+					"172.20.0.1:59567",
+					"172.21.0.1:59567",
+					"172.22.0.1:59567",
+					"172.23.0.1:59567",
+					"172.24.0.1:59567",
+					"172.25.0.1:59567",
+					"172.26.0.1:59567",
+					"172.27.0.1:59567",
+					"172.28.0.1:59567",
+					"172.29.0.1:59567"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:09:53.390208111Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1133665446225711": {
+				"ID":          1133665446225711,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2445166358548395,
+				"StableID":   "nWnW2hNR6L11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fd26b4c5deb48dc304d605470b355fd64b1fdaa576cd27fd1d8a4967983b8f1f",
+				"KeyExpiry":  "2026-11-09T09:09:52Z",
+				"DiscoKey":   "discokey:8f584643e412b124e174756c1c32f22cb30373c7098161a0ae99bb240f134d68",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52334",
+					"10.65.0.27:52334",
+					"172.17.0.1:52334",
+					"172.18.0.1:52334",
+					"172.19.0.1:52334",
+					"172.20.0.1:52334",
+					"172.21.0.1:52334",
+					"172.22.0.1:52334",
+					"172.23.0.1:52334",
+					"172.24.0.1:52334",
+					"172.25.0.1:52334",
+					"172.26.0.1:52334",
+					"172.27.0.1:52334",
+					"172.28.0.1:52334",
+					"172.29.0.1:52334"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:09:52.849051482Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:fd26b4c5deb48dc304d605470b355fd64b1fdaa576cd27fd1d8a4967983b8f1f",
+			"MachineKey": "mkey:9f012394e9cb2857f76e6ffd339cc23f6403759a0559eb6696b02fe01515b67f",
+			"Peers": [{
+				"ID":         7545449853970951,
+				"StableID":   "nAL9R2BMv121CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf2b1c33b0339bfc285f5a3438d54d6ef6132de91e1006564a3bdd4766041531",
+				"DiscoKey":   "discokey:f0b35b8a47d7c0e75151d9102f26d7a6940a99da53b3cef76a2abf2cd74ab143",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52491",
+					"10.65.0.27:52491",
+					"172.17.0.1:52491",
+					"172.18.0.1:52491",
+					"172.19.0.1:52491",
+					"172.20.0.1:52491",
+					"172.21.0.1:52491",
+					"172.22.0.1:52491",
+					"172.23.0.1:52491",
+					"172.24.0.1:52491",
+					"172.25.0.1:52491",
+					"172.26.0.1:52491",
+					"172.27.0.1:52491",
+					"172.28.0.1:52491",
+					"172.29.0.1:52491"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:09:45.317446196Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6601191949024367,
+				"StableID":   "na6Jpt7hYt11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:222763516a281cf6b9de022760bdf90f572b3579368caed48197d273ba71893b",
+				"DiscoKey":   "discokey:2c8fc2aecdcac32fa49181d486093f1957845e202c75459b2ffcb6210bc2b216",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:49866",
+					"10.65.0.27:49866",
+					"172.17.0.1:49866",
+					"172.18.0.1:49866",
+					"172.19.0.1:49866",
+					"172.20.0.1:49866",
+					"172.21.0.1:49866",
+					"172.22.0.1:49866",
+					"172.23.0.1:49866",
+					"172.24.0.1:49866",
+					"172.25.0.1:49866",
+					"172.26.0.1:49866",
+					"172.27.0.1:49866",
+					"172.28.0.1:49866",
+					"172.29.0.1:49866"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:09:45.860172783Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5641686272672076,
+				"StableID":   "nmKQsqX84m11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee3c3576175d8b875911c1d25f8a5ec9f1a2547f2a616619106fca5dc0d6a158",
+				"DiscoKey":   "discokey:a12ef384bffb0c4f6562eeb34d49eeaadbb5b72e68752d1dfed195d161552c09",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41012",
+					"10.65.0.27:41012",
+					"172.17.0.1:41012",
+					"172.18.0.1:41012",
+					"172.19.0.1:41012",
+					"172.20.0.1:41012",
+					"172.21.0.1:41012",
+					"172.22.0.1:41012",
+					"172.23.0.1:41012",
+					"172.24.0.1:41012",
+					"172.25.0.1:41012",
+					"172.26.0.1:41012",
+					"172.27.0.1:41012",
+					"172.28.0.1:41012",
+					"172.29.0.1:41012"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:09:46.400765907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         251905086834600,
+				"StableID":   "nhV5vv76y211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2217ed7e2d284d12862d48bc7faa3a80ac0cb8eb3930cfd7e7a754099ab4a510",
+				"DiscoKey":   "discokey:da9e2b384db2465a717bdcdf8097c7ad2d50375aa7396b19e287ec896869433a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39237",
+					"10.65.0.27:39237",
+					"172.17.0.1:39237",
+					"172.18.0.1:39237",
+					"172.19.0.1:39237",
+					"172.20.0.1:39237",
+					"172.21.0.1:39237",
+					"172.22.0.1:39237",
+					"172.23.0.1:39237",
+					"172.24.0.1:39237",
+					"172.25.0.1:39237",
+					"172.26.0.1:39237",
+					"172.27.0.1:39237",
+					"172.28.0.1:39237",
+					"172.29.0.1:39237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:09:46.936307856Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7311289998587147,
+				"StableID":   "nWaeq3CJ6z11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5ecfa4441cec326657a9c2364b42c3b0c0155207c5a7b0fbf4d9ddcb58d46840",
+				"DiscoKey":   "discokey:2639340901c617a5c4e800f56f3ea482279b4b1ce708f1146d42263fd9315f4c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37204",
+					"10.65.0.27:37204",
+					"172.17.0.1:37204",
+					"172.18.0.1:37204",
+					"172.19.0.1:37204",
+					"172.20.0.1:37204",
+					"172.21.0.1:37204",
+					"172.22.0.1:37204",
+					"172.23.0.1:37204",
+					"172.24.0.1:37204",
+					"172.25.0.1:37204",
+					"172.26.0.1:37204",
+					"172.27.0.1:37204",
+					"172.28.0.1:37204",
+					"172.29.0.1:37204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:09:47.731176987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3844756781655839,
+				"StableID":   "nxXY3zEJ2X11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b2d4a4fab6a729dad226e73c64361cead2b21704cbe50ce4de339d50e7c2201e",
+				"DiscoKey":   "discokey:3abb4edeebe7251467fb74569a6693d582580c7387555c3e009fc61c8b600432",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52682",
+					"10.65.0.27:52682",
+					"172.17.0.1:52682",
+					"172.18.0.1:52682",
+					"172.19.0.1:52682",
+					"172.20.0.1:52682",
+					"172.21.0.1:52682",
+					"172.22.0.1:52682",
+					"172.23.0.1:52682",
+					"172.24.0.1:52682",
+					"172.25.0.1:52682",
+					"172.26.0.1:52682",
+					"172.27.0.1:52682",
+					"172.28.0.1:52682",
+					"172.29.0.1:52682"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:09:48.276209785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7721349283250464,
+				"StableID":   "nR3Geek1J321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:53cdbd2a02f426b6f1050739e8bb0158ad820823d97ee947d0669b2795b4793e",
+				"DiscoKey":   "discokey:5001bf5d922a739562c393b47298ca093ec32bd94e61c1a0d7d7c929fd37004f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57229",
+					"10.65.0.27:57229",
+					"172.17.0.1:57229",
+					"172.18.0.1:57229",
+					"172.19.0.1:57229",
+					"172.20.0.1:57229",
+					"172.21.0.1:57229",
+					"172.22.0.1:57229",
+					"172.23.0.1:57229",
+					"172.24.0.1:57229",
+					"172.25.0.1:57229",
+					"172.26.0.1:57229",
+					"172.27.0.1:57229",
+					"172.28.0.1:57229",
+					"172.29.0.1:57229"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:09:48.810725022Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8529137471312197,
+				"StableID":   "nvwUgkyrb921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e50e83c32dfa9000e243698477cdf31ac700548548634bab8d625c811a391348",
+				"DiscoKey":   "discokey:03888741ff54921b0945f19c5a06bd8ceef017baa166c393be697ad1964fe950",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:40794",
+					"10.65.0.27:40794",
+					"172.17.0.1:40794",
+					"172.18.0.1:40794",
+					"172.19.0.1:40794",
+					"172.20.0.1:40794",
+					"172.21.0.1:40794",
+					"172.22.0.1:40794",
+					"172.23.0.1:40794",
+					"172.24.0.1:40794",
+					"172.25.0.1:40794",
+					"172.26.0.1:40794",
+					"172.27.0.1:40794",
+					"172.28.0.1:40794",
+					"172.29.0.1:40794"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:09:49.345404174Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1133665446225711,
+				"StableID":   "npspRCUSr911CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af3ef8c77445c102e5a391acf22ae87176cd45610d9b7a35ef2b9a045ce86456",
+				"DiscoKey":   "discokey:c6b68fa95ac1834525dcc473f9539e27101e3ddc7214e1af4f17800e31be205f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44144",
+					"10.65.0.27:44144",
+					"172.17.0.1:44144",
+					"172.18.0.1:44144",
+					"172.19.0.1:44144",
+					"172.20.0.1:44144",
+					"172.21.0.1:44144",
+					"172.22.0.1:44144",
+					"172.23.0.1:44144",
+					"172.24.0.1:44144",
+					"172.25.0.1:44144",
+					"172.26.0.1:44144",
+					"172.27.0.1:44144",
+					"172.28.0.1:44144",
+					"172.29.0.1:44144"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:09:49.906892291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4327360026868473,
+				"StableID":   "nLg7EnQsna11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41b456fff76f073210ae1f5b1885880231b492677d82ebb16e19de0d8d05db43",
+				"DiscoKey":   "discokey:cdc9d51564ec303392666bc959439f647b6bc871300fcd3dd462490a78acf213",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55548",
+					"10.65.0.27:55548",
+					"172.17.0.1:55548",
+					"172.18.0.1:55548",
+					"172.19.0.1:55548",
+					"172.20.0.1:55548",
+					"172.21.0.1:55548",
+					"172.22.0.1:55548",
+					"172.23.0.1:55548",
+					"172.24.0.1:55548",
+					"172.25.0.1:55548",
+					"172.26.0.1:55548",
+					"172.27.0.1:55548",
+					"172.28.0.1:55548",
+					"172.29.0.1:55548"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:09:50.591259506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         597170729733715,
+				"StableID":   "nQ3MURfTf511CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae9217620a86b09c23dd2142abf1d76912df58684961c3fc62349e1e0915b149",
+				"DiscoKey":   "discokey:db83951819aa37fa450ba0b748856d853ce43a7f68a336aee82e9c045782293c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:39960",
+					"10.65.0.27:39960",
+					"172.17.0.1:39960",
+					"172.18.0.1:39960",
+					"172.19.0.1:39960",
+					"172.20.0.1:39960",
+					"172.21.0.1:39960",
+					"172.22.0.1:39960",
+					"172.23.0.1:39960",
+					"172.24.0.1:39960",
+					"172.25.0.1:39960",
+					"172.26.0.1:39960",
+					"172.27.0.1:39960",
+					"172.28.0.1:39960",
+					"172.29.0.1:39960"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:09:51.225297251Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2081825077297187,
+				"StableID":   "nkwvCr1sFH11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83b7fe43ccf866075f0328181d2d70add517cc694bcc0056a9a856f4d8673307",
+				"DiscoKey":   "discokey:343144325f073c39cc74a2331742af006c61e006957f60786a46742dcb0df42b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49517",
+					"10.65.0.27:49517",
+					"172.17.0.1:49517",
+					"172.18.0.1:49517",
+					"172.19.0.1:49517",
+					"172.20.0.1:49517",
+					"172.21.0.1:49517",
+					"172.22.0.1:49517",
+					"172.23.0.1:49517",
+					"172.24.0.1:49517",
+					"172.25.0.1:49517",
+					"172.26.0.1:49517",
+					"172.27.0.1:49517",
+					"172.28.0.1:49517",
+					"172.29.0.1:49517"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:09:51.766590389Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3838711917156017,
+				"StableID":   "ntev4GTZyW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3c743971520558c0b50716981af1a5d7a4dde1747220f21ed6fa1553635e9d55",
+				"KeyExpiry":  "2026-11-09T09:09:52Z",
+				"DiscoKey":   "discokey:556ade8dabe7d02cda014c2d15219252465583c8a9ba575c4681daec63fb8175",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:55726",
+					"10.65.0.27:55726",
+					"172.17.0.1:55726",
+					"172.18.0.1:55726",
+					"172.19.0.1:55726",
+					"172.20.0.1:55726",
+					"172.21.0.1:55726",
+					"172.22.0.1:55726",
+					"172.23.0.1:55726",
+					"172.24.0.1:55726",
+					"172.25.0.1:55726",
+					"172.26.0.1:55726",
+					"172.27.0.1:55726",
+					"172.28.0.1:55726",
+					"172.29.0.1:55726"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:09:52.315081835Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3210096661715349,
+				"StableID":   "n2m6YAor4S11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:93d6d7c637d9def2c70a30aa2ce458e01e904acfe931a04897fb0fab4cd26d29",
+				"KeyExpiry":  "2026-11-09T09:09:53Z",
+				"DiscoKey":   "discokey:15054df074c7d5425e6f305994dbbc8d96cd540b1c34e640db359774fcce4226",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59567",
+					"10.65.0.27:59567",
+					"172.17.0.1:59567",
+					"172.18.0.1:59567",
+					"172.19.0.1:59567",
+					"172.20.0.1:59567",
+					"172.21.0.1:59567",
+					"172.22.0.1:59567",
+					"172.23.0.1:59567",
+					"172.24.0.1:59567",
+					"172.25.0.1:59567",
+					"172.26.0.1:59567",
+					"172.27.0.1:59567",
+					"172.28.0.1:59567",
+					"172.29.0.1:59567"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:09:53.390208111Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4327360026868473,
+				"StableID":   "nLg7EnQsna11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       4327360026868473,
+				"Key":        "nodekey:41b456fff76f073210ae1f5b1885880231b492677d82ebb16e19de0d8d05db43",
+				"DiscoKey":   "discokey:cdc9d51564ec303392666bc959439f647b6bc871300fcd3dd462490a78acf213",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55548",
+					"10.65.0.27:55548",
+					"172.17.0.1:55548",
+					"172.18.0.1:55548",
+					"172.19.0.1:55548",
+					"172.20.0.1:55548",
+					"172.21.0.1:55548",
+					"172.22.0.1:55548",
+					"172.23.0.1:55548",
+					"172.24.0.1:55548",
+					"172.25.0.1:55548",
+					"172.26.0.1:55548",
+					"172.27.0.1:55548",
+					"172.28.0.1:55548",
+					"172.29.0.1:55548"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:09:50.591259506Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:41b456fff76f073210ae1f5b1885880231b492677d82ebb16e19de0d8d05db43",
+			"MachineKey": "mkey:236ed5c719bf12d655a1a085ccbdeac19032c3f071ef76cd810910cd5b16c276",
+			"Peers": [{
+				"ID":         7545449853970951,
+				"StableID":   "nAL9R2BMv121CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf2b1c33b0339bfc285f5a3438d54d6ef6132de91e1006564a3bdd4766041531",
+				"DiscoKey":   "discokey:f0b35b8a47d7c0e75151d9102f26d7a6940a99da53b3cef76a2abf2cd74ab143",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52491",
+					"10.65.0.27:52491",
+					"172.17.0.1:52491",
+					"172.18.0.1:52491",
+					"172.19.0.1:52491",
+					"172.20.0.1:52491",
+					"172.21.0.1:52491",
+					"172.22.0.1:52491",
+					"172.23.0.1:52491",
+					"172.24.0.1:52491",
+					"172.25.0.1:52491",
+					"172.26.0.1:52491",
+					"172.27.0.1:52491",
+					"172.28.0.1:52491",
+					"172.29.0.1:52491"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:09:45.317446196Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6601191949024367,
+				"StableID":   "na6Jpt7hYt11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:222763516a281cf6b9de022760bdf90f572b3579368caed48197d273ba71893b",
+				"DiscoKey":   "discokey:2c8fc2aecdcac32fa49181d486093f1957845e202c75459b2ffcb6210bc2b216",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:49866",
+					"10.65.0.27:49866",
+					"172.17.0.1:49866",
+					"172.18.0.1:49866",
+					"172.19.0.1:49866",
+					"172.20.0.1:49866",
+					"172.21.0.1:49866",
+					"172.22.0.1:49866",
+					"172.23.0.1:49866",
+					"172.24.0.1:49866",
+					"172.25.0.1:49866",
+					"172.26.0.1:49866",
+					"172.27.0.1:49866",
+					"172.28.0.1:49866",
+					"172.29.0.1:49866"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:09:45.860172783Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5641686272672076,
+				"StableID":   "nmKQsqX84m11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee3c3576175d8b875911c1d25f8a5ec9f1a2547f2a616619106fca5dc0d6a158",
+				"DiscoKey":   "discokey:a12ef384bffb0c4f6562eeb34d49eeaadbb5b72e68752d1dfed195d161552c09",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41012",
+					"10.65.0.27:41012",
+					"172.17.0.1:41012",
+					"172.18.0.1:41012",
+					"172.19.0.1:41012",
+					"172.20.0.1:41012",
+					"172.21.0.1:41012",
+					"172.22.0.1:41012",
+					"172.23.0.1:41012",
+					"172.24.0.1:41012",
+					"172.25.0.1:41012",
+					"172.26.0.1:41012",
+					"172.27.0.1:41012",
+					"172.28.0.1:41012",
+					"172.29.0.1:41012"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:09:46.400765907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         251905086834600,
+				"StableID":   "nhV5vv76y211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2217ed7e2d284d12862d48bc7faa3a80ac0cb8eb3930cfd7e7a754099ab4a510",
+				"DiscoKey":   "discokey:da9e2b384db2465a717bdcdf8097c7ad2d50375aa7396b19e287ec896869433a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39237",
+					"10.65.0.27:39237",
+					"172.17.0.1:39237",
+					"172.18.0.1:39237",
+					"172.19.0.1:39237",
+					"172.20.0.1:39237",
+					"172.21.0.1:39237",
+					"172.22.0.1:39237",
+					"172.23.0.1:39237",
+					"172.24.0.1:39237",
+					"172.25.0.1:39237",
+					"172.26.0.1:39237",
+					"172.27.0.1:39237",
+					"172.28.0.1:39237",
+					"172.29.0.1:39237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:09:46.936307856Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7311289998587147,
+				"StableID":   "nWaeq3CJ6z11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5ecfa4441cec326657a9c2364b42c3b0c0155207c5a7b0fbf4d9ddcb58d46840",
+				"DiscoKey":   "discokey:2639340901c617a5c4e800f56f3ea482279b4b1ce708f1146d42263fd9315f4c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37204",
+					"10.65.0.27:37204",
+					"172.17.0.1:37204",
+					"172.18.0.1:37204",
+					"172.19.0.1:37204",
+					"172.20.0.1:37204",
+					"172.21.0.1:37204",
+					"172.22.0.1:37204",
+					"172.23.0.1:37204",
+					"172.24.0.1:37204",
+					"172.25.0.1:37204",
+					"172.26.0.1:37204",
+					"172.27.0.1:37204",
+					"172.28.0.1:37204",
+					"172.29.0.1:37204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:09:47.731176987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3844756781655839,
+				"StableID":   "nxXY3zEJ2X11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b2d4a4fab6a729dad226e73c64361cead2b21704cbe50ce4de339d50e7c2201e",
+				"DiscoKey":   "discokey:3abb4edeebe7251467fb74569a6693d582580c7387555c3e009fc61c8b600432",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52682",
+					"10.65.0.27:52682",
+					"172.17.0.1:52682",
+					"172.18.0.1:52682",
+					"172.19.0.1:52682",
+					"172.20.0.1:52682",
+					"172.21.0.1:52682",
+					"172.22.0.1:52682",
+					"172.23.0.1:52682",
+					"172.24.0.1:52682",
+					"172.25.0.1:52682",
+					"172.26.0.1:52682",
+					"172.27.0.1:52682",
+					"172.28.0.1:52682",
+					"172.29.0.1:52682"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:09:48.276209785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7721349283250464,
+				"StableID":   "nR3Geek1J321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:53cdbd2a02f426b6f1050739e8bb0158ad820823d97ee947d0669b2795b4793e",
+				"DiscoKey":   "discokey:5001bf5d922a739562c393b47298ca093ec32bd94e61c1a0d7d7c929fd37004f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57229",
+					"10.65.0.27:57229",
+					"172.17.0.1:57229",
+					"172.18.0.1:57229",
+					"172.19.0.1:57229",
+					"172.20.0.1:57229",
+					"172.21.0.1:57229",
+					"172.22.0.1:57229",
+					"172.23.0.1:57229",
+					"172.24.0.1:57229",
+					"172.25.0.1:57229",
+					"172.26.0.1:57229",
+					"172.27.0.1:57229",
+					"172.28.0.1:57229",
+					"172.29.0.1:57229"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:09:48.810725022Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8529137471312197,
+				"StableID":   "nvwUgkyrb921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e50e83c32dfa9000e243698477cdf31ac700548548634bab8d625c811a391348",
+				"DiscoKey":   "discokey:03888741ff54921b0945f19c5a06bd8ceef017baa166c393be697ad1964fe950",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:40794",
+					"10.65.0.27:40794",
+					"172.17.0.1:40794",
+					"172.18.0.1:40794",
+					"172.19.0.1:40794",
+					"172.20.0.1:40794",
+					"172.21.0.1:40794",
+					"172.22.0.1:40794",
+					"172.23.0.1:40794",
+					"172.24.0.1:40794",
+					"172.25.0.1:40794",
+					"172.26.0.1:40794",
+					"172.27.0.1:40794",
+					"172.28.0.1:40794",
+					"172.29.0.1:40794"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:09:49.345404174Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1133665446225711,
+				"StableID":   "npspRCUSr911CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af3ef8c77445c102e5a391acf22ae87176cd45610d9b7a35ef2b9a045ce86456",
+				"DiscoKey":   "discokey:c6b68fa95ac1834525dcc473f9539e27101e3ddc7214e1af4f17800e31be205f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44144",
+					"10.65.0.27:44144",
+					"172.17.0.1:44144",
+					"172.18.0.1:44144",
+					"172.19.0.1:44144",
+					"172.20.0.1:44144",
+					"172.21.0.1:44144",
+					"172.22.0.1:44144",
+					"172.23.0.1:44144",
+					"172.24.0.1:44144",
+					"172.25.0.1:44144",
+					"172.26.0.1:44144",
+					"172.27.0.1:44144",
+					"172.28.0.1:44144",
+					"172.29.0.1:44144"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:09:49.906892291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         597170729733715,
+				"StableID":   "nQ3MURfTf511CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae9217620a86b09c23dd2142abf1d76912df58684961c3fc62349e1e0915b149",
+				"DiscoKey":   "discokey:db83951819aa37fa450ba0b748856d853ce43a7f68a336aee82e9c045782293c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:39960",
+					"10.65.0.27:39960",
+					"172.17.0.1:39960",
+					"172.18.0.1:39960",
+					"172.19.0.1:39960",
+					"172.20.0.1:39960",
+					"172.21.0.1:39960",
+					"172.22.0.1:39960",
+					"172.23.0.1:39960",
+					"172.24.0.1:39960",
+					"172.25.0.1:39960",
+					"172.26.0.1:39960",
+					"172.27.0.1:39960",
+					"172.28.0.1:39960",
+					"172.29.0.1:39960"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:09:51.225297251Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2081825077297187,
+				"StableID":   "nkwvCr1sFH11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83b7fe43ccf866075f0328181d2d70add517cc694bcc0056a9a856f4d8673307",
+				"DiscoKey":   "discokey:343144325f073c39cc74a2331742af006c61e006957f60786a46742dcb0df42b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49517",
+					"10.65.0.27:49517",
+					"172.17.0.1:49517",
+					"172.18.0.1:49517",
+					"172.19.0.1:49517",
+					"172.20.0.1:49517",
+					"172.21.0.1:49517",
+					"172.22.0.1:49517",
+					"172.23.0.1:49517",
+					"172.24.0.1:49517",
+					"172.25.0.1:49517",
+					"172.26.0.1:49517",
+					"172.27.0.1:49517",
+					"172.28.0.1:49517",
+					"172.29.0.1:49517"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:09:51.766590389Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3838711917156017,
+				"StableID":   "ntev4GTZyW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3c743971520558c0b50716981af1a5d7a4dde1747220f21ed6fa1553635e9d55",
+				"KeyExpiry":  "2026-11-09T09:09:52Z",
+				"DiscoKey":   "discokey:556ade8dabe7d02cda014c2d15219252465583c8a9ba575c4681daec63fb8175",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:55726",
+					"10.65.0.27:55726",
+					"172.17.0.1:55726",
+					"172.18.0.1:55726",
+					"172.19.0.1:55726",
+					"172.20.0.1:55726",
+					"172.21.0.1:55726",
+					"172.22.0.1:55726",
+					"172.23.0.1:55726",
+					"172.24.0.1:55726",
+					"172.25.0.1:55726",
+					"172.26.0.1:55726",
+					"172.27.0.1:55726",
+					"172.28.0.1:55726",
+					"172.29.0.1:55726"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:09:52.315081835Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2445166358548395,
+				"StableID":   "nWnW2hNR6L11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:fd26b4c5deb48dc304d605470b355fd64b1fdaa576cd27fd1d8a4967983b8f1f",
+				"KeyExpiry":  "2026-11-09T09:09:52Z",
+				"DiscoKey":   "discokey:8f584643e412b124e174756c1c32f22cb30373c7098161a0ae99bb240f134d68",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52334",
+					"10.65.0.27:52334",
+					"172.17.0.1:52334",
+					"172.18.0.1:52334",
+					"172.19.0.1:52334",
+					"172.20.0.1:52334",
+					"172.21.0.1:52334",
+					"172.22.0.1:52334",
+					"172.23.0.1:52334",
+					"172.24.0.1:52334",
+					"172.25.0.1:52334",
+					"172.26.0.1:52334",
+					"172.27.0.1:52334",
+					"172.28.0.1:52334",
+					"172.29.0.1:52334"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:09:52.849051482Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3210096661715349,
+				"StableID":   "n2m6YAor4S11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:93d6d7c637d9def2c70a30aa2ce458e01e904acfe931a04897fb0fab4cd26d29",
+				"KeyExpiry":  "2026-11-09T09:09:53Z",
+				"DiscoKey":   "discokey:15054df074c7d5425e6f305994dbbc8d96cd540b1c34e640db359774fcce4226",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59567",
+					"10.65.0.27:59567",
+					"172.17.0.1:59567",
+					"172.18.0.1:59567",
+					"172.19.0.1:59567",
+					"172.20.0.1:59567",
+					"172.21.0.1:59567",
+					"172.22.0.1:59567",
+					"172.23.0.1:59567",
+					"172.24.0.1:59567",
+					"172.25.0.1:59567",
+					"172.26.0.1:59567",
+					"172.27.0.1:59567",
+					"172.28.0.1:59567",
+					"172.29.0.1:59567"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:09:53.390208111Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4327360026868473": {
+				"ID":          4327360026868473,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-group-nested-cycle.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-group-nested-cycle.hujson
@@ -1,0 +1,22109 @@
+// ssh-group-nested-cycle
+//
+// ssh group:a <-> group:b cycle
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-13T09:10:38Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-group-nested-cycle",
+	"description":    "ssh group:a <-> group:b cycle",
+	"category":       "ssh",
+	"captured_at":    "2026-05-13T09:10:38.700057571Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {
+			"message": "groups[\"group:b\"]: \"group:a\": group members cannot be recursive"
+		},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                         \n  \n                                                                    \n                                                       \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh group:a <-> group:b cycle\",\n\t\"id\":          \"ssh-group-nested-cycle\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"groups\": {\n\t\t\"group:a\": [\"group:b\"],\n\t\t\"group:b\": [\"group:a\"]\n\t}, \"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"group:a\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-edges/ssh-group-nested-cycle.hujson",
+		"full_policy": {
+			"groups": {"group:a": ["group:b"], "group:b": ["group:a"]},
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["group:a"],
+				"users":  ["root"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2114968417180870,
+				"StableID":   "n1k7fmdsWH11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       2114968417180870,
+				"Key":        "nodekey:c1747722f6f1925a212dd4da8360d7227031d9d0c72954583c099d6e159dfa62",
+				"DiscoKey":   "discokey:192876548845a393fe66a4e34783664cdca8945ec29fc3463b01666c5150e622",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41522",
+					"10.65.0.27:41522",
+					"172.17.0.1:41522",
+					"172.18.0.1:41522",
+					"172.19.0.1:41522",
+					"172.20.0.1:41522",
+					"172.21.0.1:41522",
+					"172.22.0.1:41522",
+					"172.23.0.1:41522",
+					"172.24.0.1:41522",
+					"172.25.0.1:41522",
+					"172.26.0.1:41522",
+					"172.27.0.1:41522",
+					"172.28.0.1:41522"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:10:47.048048187Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c1747722f6f1925a212dd4da8360d7227031d9d0c72954583c099d6e159dfa62",
+			"MachineKey": "mkey:c6a8fae4f8fc6030e3c894245c2e6757280f61ab17911c3c254e680a35cbf074",
+			"Peers": [{
+				"ID":         2481161170831544,
+				"StableID":   "nw86L1uiNL11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fa2e64f9eca2a176a8585cf3f181b1d45f78c3cccf1570600109ae345693b903",
+				"DiscoKey":   "discokey:ea8048c544d4690c11c538c7dff5e923a5bbd7577bf04495426d8fa6de5e1166",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40953",
+					"10.65.0.27:40953",
+					"172.17.0.1:40953",
+					"172.18.0.1:40953",
+					"172.19.0.1:40953",
+					"172.20.0.1:40953",
+					"172.21.0.1:40953",
+					"172.22.0.1:40953",
+					"172.23.0.1:40953",
+					"172.24.0.1:40953",
+					"172.25.0.1:40953",
+					"172.26.0.1:40953",
+					"172.27.0.1:40953",
+					"172.28.0.1:40953"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:10:41.10160613Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4960289040082096,
+				"StableID":   "nfQ6m9PXjf11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5aafa1118516e2c189ac90580c021439b584bef643c71781f5e26e5f1c3a112d",
+				"DiscoKey":   "discokey:6c9266c97130bffe5ae0461594c233724a666f8b09c18ece2cab2a980d70af55",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51611",
+					"10.65.0.27:51611",
+					"172.17.0.1:51611",
+					"172.18.0.1:51611",
+					"172.19.0.1:51611",
+					"172.20.0.1:51611",
+					"172.21.0.1:51611",
+					"172.22.0.1:51611",
+					"172.23.0.1:51611",
+					"172.24.0.1:51611",
+					"172.25.0.1:51611",
+					"172.26.0.1:51611",
+					"172.27.0.1:51611",
+					"172.28.0.1:51611"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:10:41.641446003Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7768084567289187,
+				"StableID":   "nku1fjQBf321CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c03e907c0eaceaaf345e13c7a81f4f3ad52eadc4f8a3e3ac8fcf7e625426dc2e",
+				"DiscoKey":   "discokey:efac546518cac262a451f53fd59a6058165767869355102704d32dede0b98c0d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:48773",
+					"10.65.0.27:48773",
+					"172.17.0.1:48773",
+					"172.18.0.1:48773",
+					"172.19.0.1:48773",
+					"172.20.0.1:48773",
+					"172.21.0.1:48773",
+					"172.22.0.1:48773",
+					"172.23.0.1:48773",
+					"172.24.0.1:48773",
+					"172.25.0.1:48773",
+					"172.26.0.1:48773",
+					"172.27.0.1:48773",
+					"172.28.0.1:48773"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:10:42.165454589Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3195380828706430,
+				"StableID":   "nZ8PmgECxR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26aa4590e7409841077b2f9ad40ce46298f04fa175ad468f4caac75c655b8d2c",
+				"DiscoKey":   "discokey:3ac2bc5b59d129134472a9231574fab9e65ae123699c660ead3e1582f7aaf76a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:44975",
+					"10.65.0.27:44975",
+					"172.17.0.1:44975",
+					"172.18.0.1:44975",
+					"172.19.0.1:44975",
+					"172.20.0.1:44975",
+					"172.21.0.1:44975",
+					"172.22.0.1:44975",
+					"172.23.0.1:44975",
+					"172.24.0.1:44975",
+					"172.25.0.1:44975",
+					"172.26.0.1:44975",
+					"172.27.0.1:44975",
+					"172.28.0.1:44975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:10:42.699205128Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3986158479948651,
+				"StableID":   "nGo3vBdL8Y11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:338bee8bcf0c71b8365a88b135045bf456a3203bc5cc32bc9b85f8f7b60e6c59",
+				"DiscoKey":   "discokey:5ab8526604b7b75af0a06970f8c44ca44ed68726e09072b2b1bedc7f6ee5f92f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:36771",
+					"10.65.0.27:36771",
+					"172.17.0.1:36771",
+					"172.18.0.1:36771",
+					"172.19.0.1:36771",
+					"172.20.0.1:36771",
+					"172.21.0.1:36771",
+					"172.22.0.1:36771",
+					"172.23.0.1:36771",
+					"172.24.0.1:36771",
+					"172.25.0.1:36771",
+					"172.26.0.1:36771",
+					"172.27.0.1:36771",
+					"172.28.0.1:36771"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:10:43.226544237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1408740200256286,
+				"StableID":   "nmeZVYD21C11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:386f415fad86f92958f3cb6aa8a62828e388cf7fe68d7810538b9edcd7e6cf6b",
+				"DiscoKey":   "discokey:4d951ab6f3ebad15e794ce3db79649dfd2ef4a6ebba1f02a13acf645de951275",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40763",
+					"10.65.0.27:40763",
+					"172.17.0.1:40763",
+					"172.18.0.1:40763",
+					"172.19.0.1:40763",
+					"172.20.0.1:40763",
+					"172.21.0.1:40763",
+					"172.22.0.1:40763",
+					"172.23.0.1:40763",
+					"172.24.0.1:40763",
+					"172.25.0.1:40763",
+					"172.26.0.1:40763",
+					"172.27.0.1:40763",
+					"172.28.0.1:40763"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:10:43.763271407Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         818116849785060,
+				"StableID":   "nd5MWTYXP711CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e67b072f623a6ef1c4e441868b120b0e1ec414cf7f823bea4dc322b1c73fce22",
+				"DiscoKey":   "discokey:cc20da24fa4f46b0f3d869356a2f86109b821071d7b693fc2a647e3bb14b621c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37614",
+					"10.65.0.27:37614",
+					"172.17.0.1:37614",
+					"172.18.0.1:37614",
+					"172.19.0.1:37614",
+					"172.20.0.1:37614",
+					"172.21.0.1:37614",
+					"172.22.0.1:37614",
+					"172.23.0.1:37614",
+					"172.24.0.1:37614",
+					"172.25.0.1:37614",
+					"172.26.0.1:37614",
+					"172.27.0.1:37614",
+					"172.28.0.1:37614"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:10:44.315391471Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7601664281791600,
+				"StableID":   "ny9XuAqoM221CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aab665ced0d9240215455481aafefc91b37083bd5ed74c63d685170c0f01f772",
+				"DiscoKey":   "discokey:8fb60e9d9e28b607a43712f9d9524c59c615a957632e4d04c61cc2f766b13374",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58032",
+					"10.65.0.27:58032",
+					"172.17.0.1:58032",
+					"172.18.0.1:58032",
+					"172.19.0.1:58032",
+					"172.20.0.1:58032",
+					"172.21.0.1:58032",
+					"172.22.0.1:58032",
+					"172.23.0.1:58032",
+					"172.24.0.1:58032",
+					"172.25.0.1:58032",
+					"172.26.0.1:58032",
+					"172.27.0.1:58032",
+					"172.28.0.1:58032"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:10:44.903245772Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7172045565017533,
+				"StableID":   "ngYj4aUE1y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38597be773f83cca39f3d3930ba96ac7a4fc6db294fcd79dd9ebebbf37d74e66",
+				"DiscoKey":   "discokey:28c74df52a1d4519c59dfd35d9a1e960c8f50d0ce4a645650477ed3755303274",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36824",
+					"10.65.0.27:36824",
+					"172.17.0.1:36824",
+					"172.18.0.1:36824",
+					"172.19.0.1:36824",
+					"172.20.0.1:36824",
+					"172.21.0.1:36824",
+					"172.22.0.1:36824",
+					"172.23.0.1:36824",
+					"172.24.0.1:36824",
+					"172.25.0.1:36824",
+					"172.26.0.1:36824",
+					"172.27.0.1:36824",
+					"172.28.0.1:36824"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:10:45.447822606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2433647541453941,
+				"StableID":   "nYA2c4oC1L11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b90b253e23190ef9ef6573acae3dc180a4d1ce250c7c69ea763e2442f1cecb0e",
+				"DiscoKey":   "discokey:d4cc9bdd1aad555989cbea0d1d633b5a864664a53398fca05ecca6db6435607e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54770",
+					"10.65.0.27:54770",
+					"172.17.0.1:54770",
+					"172.18.0.1:54770",
+					"172.19.0.1:54770",
+					"172.20.0.1:54770",
+					"172.21.0.1:54770",
+					"172.22.0.1:54770",
+					"172.23.0.1:54770",
+					"172.24.0.1:54770",
+					"172.25.0.1:54770",
+					"172.26.0.1:54770",
+					"172.27.0.1:54770",
+					"172.28.0.1:54770"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:10:45.972100392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3094189100749093,
+				"StableID":   "ntGGHr6NAR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8d0eb408279680e87651d8931898596910cdd1a7c4f22bcd863bbca505af331b",
+				"DiscoKey":   "discokey:6e341b9d2ba93faeecfd3765d026ec000dbc206232864eb9a166c80f370bbf6c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55581",
+					"10.65.0.27:55581",
+					"172.17.0.1:55581",
+					"172.18.0.1:55581",
+					"172.19.0.1:55581",
+					"172.20.0.1:55581",
+					"172.21.0.1:55581",
+					"172.22.0.1:55581",
+					"172.23.0.1:55581",
+					"172.24.0.1:55581",
+					"172.25.0.1:55581",
+					"172.26.0.1:55581",
+					"172.27.0.1:55581",
+					"172.28.0.1:55581"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:10:46.514038595Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5879348204137845,
+				"StableID":   "nGkDvSWmun11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:773e9a5b93c7f420db6b0a12ca3367d80e3ab49c455a2a9df40952d5088d7834",
+				"KeyExpiry":  "2026-11-09T09:10:47Z",
+				"DiscoKey":   "discokey:f56b11a2d784e3cd1420750352c8f917d81c6fc40743638a7cb31708a7ff9a15",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35351",
+					"10.65.0.27:35351",
+					"172.17.0.1:35351",
+					"172.18.0.1:35351",
+					"172.19.0.1:35351",
+					"172.20.0.1:35351",
+					"172.21.0.1:35351",
+					"172.22.0.1:35351",
+					"172.23.0.1:35351",
+					"172.24.0.1:35351",
+					"172.25.0.1:35351",
+					"172.26.0.1:35351",
+					"172.27.0.1:35351",
+					"172.28.0.1:35351"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:10:47.592874778Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         68045841626599,
+				"StableID":   "nr4j13TpX111CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:981386a4b363044407a0d6c3cd468912350c9ee19025b55ba27b16b4532d1d16",
+				"KeyExpiry":  "2026-11-09T09:10:48Z",
+				"DiscoKey":   "discokey:eebc56f4dc88d3e5a9600502537d0b83e971a9fe26f3861dff6ee97805139443",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36640",
+					"10.65.0.27:36640",
+					"172.17.0.1:36640",
+					"172.18.0.1:36640",
+					"172.19.0.1:36640",
+					"172.20.0.1:36640",
+					"172.21.0.1:36640",
+					"172.22.0.1:36640",
+					"172.23.0.1:36640",
+					"172.24.0.1:36640",
+					"172.25.0.1:36640",
+					"172.26.0.1:36640",
+					"172.27.0.1:36640",
+					"172.28.0.1:36640"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:10:48.127109399Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6078694782604475,
+				"StableID":   "nrNjRF14Up11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:598464ec9b0c6a7ef22c12f8509ea7214ab175b15b236e84edc6c314a465671e",
+				"KeyExpiry":  "2026-11-09T09:10:48Z",
+				"DiscoKey":   "discokey:22177af5ff136137d2c6a8a5d9edb60e60f6b501632589dc759f9f7383e6ac6f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42180",
+					"10.65.0.27:42180",
+					"172.17.0.1:42180",
+					"172.18.0.1:42180",
+					"172.19.0.1:42180",
+					"172.20.0.1:42180",
+					"172.21.0.1:42180",
+					"172.22.0.1:42180",
+					"172.23.0.1:42180",
+					"172.24.0.1:42180",
+					"172.25.0.1:42180",
+					"172.26.0.1:42180",
+					"172.27.0.1:42180",
+					"172.28.0.1:42180"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:10:48.6705023Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2114968417180870": {
+				"ID":          2114968417180870,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1408740200256286,
+				"StableID":   "nmeZVYD21C11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1408740200256286,
+				"Key":        "nodekey:386f415fad86f92958f3cb6aa8a62828e388cf7fe68d7810538b9edcd7e6cf6b",
+				"DiscoKey":   "discokey:4d951ab6f3ebad15e794ce3db79649dfd2ef4a6ebba1f02a13acf645de951275",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40763",
+					"10.65.0.27:40763",
+					"172.17.0.1:40763",
+					"172.18.0.1:40763",
+					"172.19.0.1:40763",
+					"172.20.0.1:40763",
+					"172.21.0.1:40763",
+					"172.22.0.1:40763",
+					"172.23.0.1:40763",
+					"172.24.0.1:40763",
+					"172.25.0.1:40763",
+					"172.26.0.1:40763",
+					"172.27.0.1:40763",
+					"172.28.0.1:40763"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:10:43.763271407Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:386f415fad86f92958f3cb6aa8a62828e388cf7fe68d7810538b9edcd7e6cf6b",
+			"MachineKey": "mkey:e6d6a0953fe8b20dcd0d96590aab322c4977c5e711f19a96eb21f3791cc01b53",
+			"Peers": [{
+				"ID":         2481161170831544,
+				"StableID":   "nw86L1uiNL11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fa2e64f9eca2a176a8585cf3f181b1d45f78c3cccf1570600109ae345693b903",
+				"DiscoKey":   "discokey:ea8048c544d4690c11c538c7dff5e923a5bbd7577bf04495426d8fa6de5e1166",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40953",
+					"10.65.0.27:40953",
+					"172.17.0.1:40953",
+					"172.18.0.1:40953",
+					"172.19.0.1:40953",
+					"172.20.0.1:40953",
+					"172.21.0.1:40953",
+					"172.22.0.1:40953",
+					"172.23.0.1:40953",
+					"172.24.0.1:40953",
+					"172.25.0.1:40953",
+					"172.26.0.1:40953",
+					"172.27.0.1:40953",
+					"172.28.0.1:40953"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:10:41.10160613Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4960289040082096,
+				"StableID":   "nfQ6m9PXjf11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5aafa1118516e2c189ac90580c021439b584bef643c71781f5e26e5f1c3a112d",
+				"DiscoKey":   "discokey:6c9266c97130bffe5ae0461594c233724a666f8b09c18ece2cab2a980d70af55",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51611",
+					"10.65.0.27:51611",
+					"172.17.0.1:51611",
+					"172.18.0.1:51611",
+					"172.19.0.1:51611",
+					"172.20.0.1:51611",
+					"172.21.0.1:51611",
+					"172.22.0.1:51611",
+					"172.23.0.1:51611",
+					"172.24.0.1:51611",
+					"172.25.0.1:51611",
+					"172.26.0.1:51611",
+					"172.27.0.1:51611",
+					"172.28.0.1:51611"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:10:41.641446003Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7768084567289187,
+				"StableID":   "nku1fjQBf321CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c03e907c0eaceaaf345e13c7a81f4f3ad52eadc4f8a3e3ac8fcf7e625426dc2e",
+				"DiscoKey":   "discokey:efac546518cac262a451f53fd59a6058165767869355102704d32dede0b98c0d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:48773",
+					"10.65.0.27:48773",
+					"172.17.0.1:48773",
+					"172.18.0.1:48773",
+					"172.19.0.1:48773",
+					"172.20.0.1:48773",
+					"172.21.0.1:48773",
+					"172.22.0.1:48773",
+					"172.23.0.1:48773",
+					"172.24.0.1:48773",
+					"172.25.0.1:48773",
+					"172.26.0.1:48773",
+					"172.27.0.1:48773",
+					"172.28.0.1:48773"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:10:42.165454589Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3195380828706430,
+				"StableID":   "nZ8PmgECxR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26aa4590e7409841077b2f9ad40ce46298f04fa175ad468f4caac75c655b8d2c",
+				"DiscoKey":   "discokey:3ac2bc5b59d129134472a9231574fab9e65ae123699c660ead3e1582f7aaf76a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:44975",
+					"10.65.0.27:44975",
+					"172.17.0.1:44975",
+					"172.18.0.1:44975",
+					"172.19.0.1:44975",
+					"172.20.0.1:44975",
+					"172.21.0.1:44975",
+					"172.22.0.1:44975",
+					"172.23.0.1:44975",
+					"172.24.0.1:44975",
+					"172.25.0.1:44975",
+					"172.26.0.1:44975",
+					"172.27.0.1:44975",
+					"172.28.0.1:44975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:10:42.699205128Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3986158479948651,
+				"StableID":   "nGo3vBdL8Y11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:338bee8bcf0c71b8365a88b135045bf456a3203bc5cc32bc9b85f8f7b60e6c59",
+				"DiscoKey":   "discokey:5ab8526604b7b75af0a06970f8c44ca44ed68726e09072b2b1bedc7f6ee5f92f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:36771",
+					"10.65.0.27:36771",
+					"172.17.0.1:36771",
+					"172.18.0.1:36771",
+					"172.19.0.1:36771",
+					"172.20.0.1:36771",
+					"172.21.0.1:36771",
+					"172.22.0.1:36771",
+					"172.23.0.1:36771",
+					"172.24.0.1:36771",
+					"172.25.0.1:36771",
+					"172.26.0.1:36771",
+					"172.27.0.1:36771",
+					"172.28.0.1:36771"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:10:43.226544237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         818116849785060,
+				"StableID":   "nd5MWTYXP711CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e67b072f623a6ef1c4e441868b120b0e1ec414cf7f823bea4dc322b1c73fce22",
+				"DiscoKey":   "discokey:cc20da24fa4f46b0f3d869356a2f86109b821071d7b693fc2a647e3bb14b621c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37614",
+					"10.65.0.27:37614",
+					"172.17.0.1:37614",
+					"172.18.0.1:37614",
+					"172.19.0.1:37614",
+					"172.20.0.1:37614",
+					"172.21.0.1:37614",
+					"172.22.0.1:37614",
+					"172.23.0.1:37614",
+					"172.24.0.1:37614",
+					"172.25.0.1:37614",
+					"172.26.0.1:37614",
+					"172.27.0.1:37614",
+					"172.28.0.1:37614"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:10:44.315391471Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7601664281791600,
+				"StableID":   "ny9XuAqoM221CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aab665ced0d9240215455481aafefc91b37083bd5ed74c63d685170c0f01f772",
+				"DiscoKey":   "discokey:8fb60e9d9e28b607a43712f9d9524c59c615a957632e4d04c61cc2f766b13374",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58032",
+					"10.65.0.27:58032",
+					"172.17.0.1:58032",
+					"172.18.0.1:58032",
+					"172.19.0.1:58032",
+					"172.20.0.1:58032",
+					"172.21.0.1:58032",
+					"172.22.0.1:58032",
+					"172.23.0.1:58032",
+					"172.24.0.1:58032",
+					"172.25.0.1:58032",
+					"172.26.0.1:58032",
+					"172.27.0.1:58032",
+					"172.28.0.1:58032"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:10:44.903245772Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7172045565017533,
+				"StableID":   "ngYj4aUE1y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38597be773f83cca39f3d3930ba96ac7a4fc6db294fcd79dd9ebebbf37d74e66",
+				"DiscoKey":   "discokey:28c74df52a1d4519c59dfd35d9a1e960c8f50d0ce4a645650477ed3755303274",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36824",
+					"10.65.0.27:36824",
+					"172.17.0.1:36824",
+					"172.18.0.1:36824",
+					"172.19.0.1:36824",
+					"172.20.0.1:36824",
+					"172.21.0.1:36824",
+					"172.22.0.1:36824",
+					"172.23.0.1:36824",
+					"172.24.0.1:36824",
+					"172.25.0.1:36824",
+					"172.26.0.1:36824",
+					"172.27.0.1:36824",
+					"172.28.0.1:36824"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:10:45.447822606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2433647541453941,
+				"StableID":   "nYA2c4oC1L11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b90b253e23190ef9ef6573acae3dc180a4d1ce250c7c69ea763e2442f1cecb0e",
+				"DiscoKey":   "discokey:d4cc9bdd1aad555989cbea0d1d633b5a864664a53398fca05ecca6db6435607e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54770",
+					"10.65.0.27:54770",
+					"172.17.0.1:54770",
+					"172.18.0.1:54770",
+					"172.19.0.1:54770",
+					"172.20.0.1:54770",
+					"172.21.0.1:54770",
+					"172.22.0.1:54770",
+					"172.23.0.1:54770",
+					"172.24.0.1:54770",
+					"172.25.0.1:54770",
+					"172.26.0.1:54770",
+					"172.27.0.1:54770",
+					"172.28.0.1:54770"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:10:45.972100392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3094189100749093,
+				"StableID":   "ntGGHr6NAR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8d0eb408279680e87651d8931898596910cdd1a7c4f22bcd863bbca505af331b",
+				"DiscoKey":   "discokey:6e341b9d2ba93faeecfd3765d026ec000dbc206232864eb9a166c80f370bbf6c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55581",
+					"10.65.0.27:55581",
+					"172.17.0.1:55581",
+					"172.18.0.1:55581",
+					"172.19.0.1:55581",
+					"172.20.0.1:55581",
+					"172.21.0.1:55581",
+					"172.22.0.1:55581",
+					"172.23.0.1:55581",
+					"172.24.0.1:55581",
+					"172.25.0.1:55581",
+					"172.26.0.1:55581",
+					"172.27.0.1:55581",
+					"172.28.0.1:55581"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:10:46.514038595Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2114968417180870,
+				"StableID":   "n1k7fmdsWH11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1747722f6f1925a212dd4da8360d7227031d9d0c72954583c099d6e159dfa62",
+				"DiscoKey":   "discokey:192876548845a393fe66a4e34783664cdca8945ec29fc3463b01666c5150e622",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41522",
+					"10.65.0.27:41522",
+					"172.17.0.1:41522",
+					"172.18.0.1:41522",
+					"172.19.0.1:41522",
+					"172.20.0.1:41522",
+					"172.21.0.1:41522",
+					"172.22.0.1:41522",
+					"172.23.0.1:41522",
+					"172.24.0.1:41522",
+					"172.25.0.1:41522",
+					"172.26.0.1:41522",
+					"172.27.0.1:41522",
+					"172.28.0.1:41522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:10:47.048048187Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5879348204137845,
+				"StableID":   "nGkDvSWmun11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:773e9a5b93c7f420db6b0a12ca3367d80e3ab49c455a2a9df40952d5088d7834",
+				"KeyExpiry":  "2026-11-09T09:10:47Z",
+				"DiscoKey":   "discokey:f56b11a2d784e3cd1420750352c8f917d81c6fc40743638a7cb31708a7ff9a15",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35351",
+					"10.65.0.27:35351",
+					"172.17.0.1:35351",
+					"172.18.0.1:35351",
+					"172.19.0.1:35351",
+					"172.20.0.1:35351",
+					"172.21.0.1:35351",
+					"172.22.0.1:35351",
+					"172.23.0.1:35351",
+					"172.24.0.1:35351",
+					"172.25.0.1:35351",
+					"172.26.0.1:35351",
+					"172.27.0.1:35351",
+					"172.28.0.1:35351"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:10:47.592874778Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         68045841626599,
+				"StableID":   "nr4j13TpX111CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:981386a4b363044407a0d6c3cd468912350c9ee19025b55ba27b16b4532d1d16",
+				"KeyExpiry":  "2026-11-09T09:10:48Z",
+				"DiscoKey":   "discokey:eebc56f4dc88d3e5a9600502537d0b83e971a9fe26f3861dff6ee97805139443",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36640",
+					"10.65.0.27:36640",
+					"172.17.0.1:36640",
+					"172.18.0.1:36640",
+					"172.19.0.1:36640",
+					"172.20.0.1:36640",
+					"172.21.0.1:36640",
+					"172.22.0.1:36640",
+					"172.23.0.1:36640",
+					"172.24.0.1:36640",
+					"172.25.0.1:36640",
+					"172.26.0.1:36640",
+					"172.27.0.1:36640",
+					"172.28.0.1:36640"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:10:48.127109399Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6078694782604475,
+				"StableID":   "nrNjRF14Up11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:598464ec9b0c6a7ef22c12f8509ea7214ab175b15b236e84edc6c314a465671e",
+				"KeyExpiry":  "2026-11-09T09:10:48Z",
+				"DiscoKey":   "discokey:22177af5ff136137d2c6a8a5d9edb60e60f6b501632589dc759f9f7383e6ac6f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42180",
+					"10.65.0.27:42180",
+					"172.17.0.1:42180",
+					"172.18.0.1:42180",
+					"172.19.0.1:42180",
+					"172.20.0.1:42180",
+					"172.21.0.1:42180",
+					"172.22.0.1:42180",
+					"172.23.0.1:42180",
+					"172.24.0.1:42180",
+					"172.25.0.1:42180",
+					"172.26.0.1:42180",
+					"172.27.0.1:42180",
+					"172.28.0.1:42180"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:10:48.6705023Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1408740200256286": {
+				"ID":          1408740200256286,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6078694782604475,
+				"StableID":   "nrNjRF14Up11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:598464ec9b0c6a7ef22c12f8509ea7214ab175b15b236e84edc6c314a465671e",
+				"KeyExpiry":  "2026-11-09T09:10:48Z",
+				"DiscoKey":   "discokey:22177af5ff136137d2c6a8a5d9edb60e60f6b501632589dc759f9f7383e6ac6f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42180",
+					"10.65.0.27:42180",
+					"172.17.0.1:42180",
+					"172.18.0.1:42180",
+					"172.19.0.1:42180",
+					"172.20.0.1:42180",
+					"172.21.0.1:42180",
+					"172.22.0.1:42180",
+					"172.23.0.1:42180",
+					"172.24.0.1:42180",
+					"172.25.0.1:42180",
+					"172.26.0.1:42180",
+					"172.27.0.1:42180",
+					"172.28.0.1:42180"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:10:48.6705023Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:598464ec9b0c6a7ef22c12f8509ea7214ab175b15b236e84edc6c314a465671e",
+			"MachineKey": "mkey:82accac092cf7c8da0018469d1a1f944d6e2b4941a8505cd46546f8704f39722",
+			"Peers": [{
+				"ID":         2481161170831544,
+				"StableID":   "nw86L1uiNL11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fa2e64f9eca2a176a8585cf3f181b1d45f78c3cccf1570600109ae345693b903",
+				"DiscoKey":   "discokey:ea8048c544d4690c11c538c7dff5e923a5bbd7577bf04495426d8fa6de5e1166",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40953",
+					"10.65.0.27:40953",
+					"172.17.0.1:40953",
+					"172.18.0.1:40953",
+					"172.19.0.1:40953",
+					"172.20.0.1:40953",
+					"172.21.0.1:40953",
+					"172.22.0.1:40953",
+					"172.23.0.1:40953",
+					"172.24.0.1:40953",
+					"172.25.0.1:40953",
+					"172.26.0.1:40953",
+					"172.27.0.1:40953",
+					"172.28.0.1:40953"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:10:41.10160613Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4960289040082096,
+				"StableID":   "nfQ6m9PXjf11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5aafa1118516e2c189ac90580c021439b584bef643c71781f5e26e5f1c3a112d",
+				"DiscoKey":   "discokey:6c9266c97130bffe5ae0461594c233724a666f8b09c18ece2cab2a980d70af55",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51611",
+					"10.65.0.27:51611",
+					"172.17.0.1:51611",
+					"172.18.0.1:51611",
+					"172.19.0.1:51611",
+					"172.20.0.1:51611",
+					"172.21.0.1:51611",
+					"172.22.0.1:51611",
+					"172.23.0.1:51611",
+					"172.24.0.1:51611",
+					"172.25.0.1:51611",
+					"172.26.0.1:51611",
+					"172.27.0.1:51611",
+					"172.28.0.1:51611"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:10:41.641446003Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7768084567289187,
+				"StableID":   "nku1fjQBf321CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c03e907c0eaceaaf345e13c7a81f4f3ad52eadc4f8a3e3ac8fcf7e625426dc2e",
+				"DiscoKey":   "discokey:efac546518cac262a451f53fd59a6058165767869355102704d32dede0b98c0d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:48773",
+					"10.65.0.27:48773",
+					"172.17.0.1:48773",
+					"172.18.0.1:48773",
+					"172.19.0.1:48773",
+					"172.20.0.1:48773",
+					"172.21.0.1:48773",
+					"172.22.0.1:48773",
+					"172.23.0.1:48773",
+					"172.24.0.1:48773",
+					"172.25.0.1:48773",
+					"172.26.0.1:48773",
+					"172.27.0.1:48773",
+					"172.28.0.1:48773"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:10:42.165454589Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3195380828706430,
+				"StableID":   "nZ8PmgECxR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26aa4590e7409841077b2f9ad40ce46298f04fa175ad468f4caac75c655b8d2c",
+				"DiscoKey":   "discokey:3ac2bc5b59d129134472a9231574fab9e65ae123699c660ead3e1582f7aaf76a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:44975",
+					"10.65.0.27:44975",
+					"172.17.0.1:44975",
+					"172.18.0.1:44975",
+					"172.19.0.1:44975",
+					"172.20.0.1:44975",
+					"172.21.0.1:44975",
+					"172.22.0.1:44975",
+					"172.23.0.1:44975",
+					"172.24.0.1:44975",
+					"172.25.0.1:44975",
+					"172.26.0.1:44975",
+					"172.27.0.1:44975",
+					"172.28.0.1:44975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:10:42.699205128Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3986158479948651,
+				"StableID":   "nGo3vBdL8Y11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:338bee8bcf0c71b8365a88b135045bf456a3203bc5cc32bc9b85f8f7b60e6c59",
+				"DiscoKey":   "discokey:5ab8526604b7b75af0a06970f8c44ca44ed68726e09072b2b1bedc7f6ee5f92f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:36771",
+					"10.65.0.27:36771",
+					"172.17.0.1:36771",
+					"172.18.0.1:36771",
+					"172.19.0.1:36771",
+					"172.20.0.1:36771",
+					"172.21.0.1:36771",
+					"172.22.0.1:36771",
+					"172.23.0.1:36771",
+					"172.24.0.1:36771",
+					"172.25.0.1:36771",
+					"172.26.0.1:36771",
+					"172.27.0.1:36771",
+					"172.28.0.1:36771"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:10:43.226544237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1408740200256286,
+				"StableID":   "nmeZVYD21C11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:386f415fad86f92958f3cb6aa8a62828e388cf7fe68d7810538b9edcd7e6cf6b",
+				"DiscoKey":   "discokey:4d951ab6f3ebad15e794ce3db79649dfd2ef4a6ebba1f02a13acf645de951275",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40763",
+					"10.65.0.27:40763",
+					"172.17.0.1:40763",
+					"172.18.0.1:40763",
+					"172.19.0.1:40763",
+					"172.20.0.1:40763",
+					"172.21.0.1:40763",
+					"172.22.0.1:40763",
+					"172.23.0.1:40763",
+					"172.24.0.1:40763",
+					"172.25.0.1:40763",
+					"172.26.0.1:40763",
+					"172.27.0.1:40763",
+					"172.28.0.1:40763"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:10:43.763271407Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         818116849785060,
+				"StableID":   "nd5MWTYXP711CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e67b072f623a6ef1c4e441868b120b0e1ec414cf7f823bea4dc322b1c73fce22",
+				"DiscoKey":   "discokey:cc20da24fa4f46b0f3d869356a2f86109b821071d7b693fc2a647e3bb14b621c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37614",
+					"10.65.0.27:37614",
+					"172.17.0.1:37614",
+					"172.18.0.1:37614",
+					"172.19.0.1:37614",
+					"172.20.0.1:37614",
+					"172.21.0.1:37614",
+					"172.22.0.1:37614",
+					"172.23.0.1:37614",
+					"172.24.0.1:37614",
+					"172.25.0.1:37614",
+					"172.26.0.1:37614",
+					"172.27.0.1:37614",
+					"172.28.0.1:37614"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:10:44.315391471Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7601664281791600,
+				"StableID":   "ny9XuAqoM221CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aab665ced0d9240215455481aafefc91b37083bd5ed74c63d685170c0f01f772",
+				"DiscoKey":   "discokey:8fb60e9d9e28b607a43712f9d9524c59c615a957632e4d04c61cc2f766b13374",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58032",
+					"10.65.0.27:58032",
+					"172.17.0.1:58032",
+					"172.18.0.1:58032",
+					"172.19.0.1:58032",
+					"172.20.0.1:58032",
+					"172.21.0.1:58032",
+					"172.22.0.1:58032",
+					"172.23.0.1:58032",
+					"172.24.0.1:58032",
+					"172.25.0.1:58032",
+					"172.26.0.1:58032",
+					"172.27.0.1:58032",
+					"172.28.0.1:58032"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:10:44.903245772Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7172045565017533,
+				"StableID":   "ngYj4aUE1y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38597be773f83cca39f3d3930ba96ac7a4fc6db294fcd79dd9ebebbf37d74e66",
+				"DiscoKey":   "discokey:28c74df52a1d4519c59dfd35d9a1e960c8f50d0ce4a645650477ed3755303274",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36824",
+					"10.65.0.27:36824",
+					"172.17.0.1:36824",
+					"172.18.0.1:36824",
+					"172.19.0.1:36824",
+					"172.20.0.1:36824",
+					"172.21.0.1:36824",
+					"172.22.0.1:36824",
+					"172.23.0.1:36824",
+					"172.24.0.1:36824",
+					"172.25.0.1:36824",
+					"172.26.0.1:36824",
+					"172.27.0.1:36824",
+					"172.28.0.1:36824"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:10:45.447822606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2433647541453941,
+				"StableID":   "nYA2c4oC1L11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b90b253e23190ef9ef6573acae3dc180a4d1ce250c7c69ea763e2442f1cecb0e",
+				"DiscoKey":   "discokey:d4cc9bdd1aad555989cbea0d1d633b5a864664a53398fca05ecca6db6435607e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54770",
+					"10.65.0.27:54770",
+					"172.17.0.1:54770",
+					"172.18.0.1:54770",
+					"172.19.0.1:54770",
+					"172.20.0.1:54770",
+					"172.21.0.1:54770",
+					"172.22.0.1:54770",
+					"172.23.0.1:54770",
+					"172.24.0.1:54770",
+					"172.25.0.1:54770",
+					"172.26.0.1:54770",
+					"172.27.0.1:54770",
+					"172.28.0.1:54770"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:10:45.972100392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3094189100749093,
+				"StableID":   "ntGGHr6NAR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8d0eb408279680e87651d8931898596910cdd1a7c4f22bcd863bbca505af331b",
+				"DiscoKey":   "discokey:6e341b9d2ba93faeecfd3765d026ec000dbc206232864eb9a166c80f370bbf6c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55581",
+					"10.65.0.27:55581",
+					"172.17.0.1:55581",
+					"172.18.0.1:55581",
+					"172.19.0.1:55581",
+					"172.20.0.1:55581",
+					"172.21.0.1:55581",
+					"172.22.0.1:55581",
+					"172.23.0.1:55581",
+					"172.24.0.1:55581",
+					"172.25.0.1:55581",
+					"172.26.0.1:55581",
+					"172.27.0.1:55581",
+					"172.28.0.1:55581"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:10:46.514038595Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2114968417180870,
+				"StableID":   "n1k7fmdsWH11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1747722f6f1925a212dd4da8360d7227031d9d0c72954583c099d6e159dfa62",
+				"DiscoKey":   "discokey:192876548845a393fe66a4e34783664cdca8945ec29fc3463b01666c5150e622",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41522",
+					"10.65.0.27:41522",
+					"172.17.0.1:41522",
+					"172.18.0.1:41522",
+					"172.19.0.1:41522",
+					"172.20.0.1:41522",
+					"172.21.0.1:41522",
+					"172.22.0.1:41522",
+					"172.23.0.1:41522",
+					"172.24.0.1:41522",
+					"172.25.0.1:41522",
+					"172.26.0.1:41522",
+					"172.27.0.1:41522",
+					"172.28.0.1:41522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:10:47.048048187Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5879348204137845,
+				"StableID":   "nGkDvSWmun11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:773e9a5b93c7f420db6b0a12ca3367d80e3ab49c455a2a9df40952d5088d7834",
+				"KeyExpiry":  "2026-11-09T09:10:47Z",
+				"DiscoKey":   "discokey:f56b11a2d784e3cd1420750352c8f917d81c6fc40743638a7cb31708a7ff9a15",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35351",
+					"10.65.0.27:35351",
+					"172.17.0.1:35351",
+					"172.18.0.1:35351",
+					"172.19.0.1:35351",
+					"172.20.0.1:35351",
+					"172.21.0.1:35351",
+					"172.22.0.1:35351",
+					"172.23.0.1:35351",
+					"172.24.0.1:35351",
+					"172.25.0.1:35351",
+					"172.26.0.1:35351",
+					"172.27.0.1:35351",
+					"172.28.0.1:35351"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:10:47.592874778Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         68045841626599,
+				"StableID":   "nr4j13TpX111CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:981386a4b363044407a0d6c3cd468912350c9ee19025b55ba27b16b4532d1d16",
+				"KeyExpiry":  "2026-11-09T09:10:48Z",
+				"DiscoKey":   "discokey:eebc56f4dc88d3e5a9600502537d0b83e971a9fe26f3861dff6ee97805139443",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36640",
+					"10.65.0.27:36640",
+					"172.17.0.1:36640",
+					"172.18.0.1:36640",
+					"172.19.0.1:36640",
+					"172.20.0.1:36640",
+					"172.21.0.1:36640",
+					"172.22.0.1:36640",
+					"172.23.0.1:36640",
+					"172.24.0.1:36640",
+					"172.25.0.1:36640",
+					"172.26.0.1:36640",
+					"172.27.0.1:36640",
+					"172.28.0.1:36640"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:10:48.127109399Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7768084567289187,
+				"StableID":   "nku1fjQBf321CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       7768084567289187,
+				"Key":        "nodekey:c03e907c0eaceaaf345e13c7a81f4f3ad52eadc4f8a3e3ac8fcf7e625426dc2e",
+				"DiscoKey":   "discokey:efac546518cac262a451f53fd59a6058165767869355102704d32dede0b98c0d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:48773",
+					"10.65.0.27:48773",
+					"172.17.0.1:48773",
+					"172.18.0.1:48773",
+					"172.19.0.1:48773",
+					"172.20.0.1:48773",
+					"172.21.0.1:48773",
+					"172.22.0.1:48773",
+					"172.23.0.1:48773",
+					"172.24.0.1:48773",
+					"172.25.0.1:48773",
+					"172.26.0.1:48773",
+					"172.27.0.1:48773",
+					"172.28.0.1:48773"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:10:42.165454589Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c03e907c0eaceaaf345e13c7a81f4f3ad52eadc4f8a3e3ac8fcf7e625426dc2e",
+			"MachineKey": "mkey:4b7da3e5b01291859062cb9654e0c6c6d5c39bda62d1aef146e3aa38eaad2456",
+			"Peers": [{
+				"ID":         2481161170831544,
+				"StableID":   "nw86L1uiNL11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fa2e64f9eca2a176a8585cf3f181b1d45f78c3cccf1570600109ae345693b903",
+				"DiscoKey":   "discokey:ea8048c544d4690c11c538c7dff5e923a5bbd7577bf04495426d8fa6de5e1166",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40953",
+					"10.65.0.27:40953",
+					"172.17.0.1:40953",
+					"172.18.0.1:40953",
+					"172.19.0.1:40953",
+					"172.20.0.1:40953",
+					"172.21.0.1:40953",
+					"172.22.0.1:40953",
+					"172.23.0.1:40953",
+					"172.24.0.1:40953",
+					"172.25.0.1:40953",
+					"172.26.0.1:40953",
+					"172.27.0.1:40953",
+					"172.28.0.1:40953"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:10:41.10160613Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4960289040082096,
+				"StableID":   "nfQ6m9PXjf11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5aafa1118516e2c189ac90580c021439b584bef643c71781f5e26e5f1c3a112d",
+				"DiscoKey":   "discokey:6c9266c97130bffe5ae0461594c233724a666f8b09c18ece2cab2a980d70af55",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51611",
+					"10.65.0.27:51611",
+					"172.17.0.1:51611",
+					"172.18.0.1:51611",
+					"172.19.0.1:51611",
+					"172.20.0.1:51611",
+					"172.21.0.1:51611",
+					"172.22.0.1:51611",
+					"172.23.0.1:51611",
+					"172.24.0.1:51611",
+					"172.25.0.1:51611",
+					"172.26.0.1:51611",
+					"172.27.0.1:51611",
+					"172.28.0.1:51611"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:10:41.641446003Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3195380828706430,
+				"StableID":   "nZ8PmgECxR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26aa4590e7409841077b2f9ad40ce46298f04fa175ad468f4caac75c655b8d2c",
+				"DiscoKey":   "discokey:3ac2bc5b59d129134472a9231574fab9e65ae123699c660ead3e1582f7aaf76a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:44975",
+					"10.65.0.27:44975",
+					"172.17.0.1:44975",
+					"172.18.0.1:44975",
+					"172.19.0.1:44975",
+					"172.20.0.1:44975",
+					"172.21.0.1:44975",
+					"172.22.0.1:44975",
+					"172.23.0.1:44975",
+					"172.24.0.1:44975",
+					"172.25.0.1:44975",
+					"172.26.0.1:44975",
+					"172.27.0.1:44975",
+					"172.28.0.1:44975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:10:42.699205128Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3986158479948651,
+				"StableID":   "nGo3vBdL8Y11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:338bee8bcf0c71b8365a88b135045bf456a3203bc5cc32bc9b85f8f7b60e6c59",
+				"DiscoKey":   "discokey:5ab8526604b7b75af0a06970f8c44ca44ed68726e09072b2b1bedc7f6ee5f92f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:36771",
+					"10.65.0.27:36771",
+					"172.17.0.1:36771",
+					"172.18.0.1:36771",
+					"172.19.0.1:36771",
+					"172.20.0.1:36771",
+					"172.21.0.1:36771",
+					"172.22.0.1:36771",
+					"172.23.0.1:36771",
+					"172.24.0.1:36771",
+					"172.25.0.1:36771",
+					"172.26.0.1:36771",
+					"172.27.0.1:36771",
+					"172.28.0.1:36771"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:10:43.226544237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1408740200256286,
+				"StableID":   "nmeZVYD21C11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:386f415fad86f92958f3cb6aa8a62828e388cf7fe68d7810538b9edcd7e6cf6b",
+				"DiscoKey":   "discokey:4d951ab6f3ebad15e794ce3db79649dfd2ef4a6ebba1f02a13acf645de951275",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40763",
+					"10.65.0.27:40763",
+					"172.17.0.1:40763",
+					"172.18.0.1:40763",
+					"172.19.0.1:40763",
+					"172.20.0.1:40763",
+					"172.21.0.1:40763",
+					"172.22.0.1:40763",
+					"172.23.0.1:40763",
+					"172.24.0.1:40763",
+					"172.25.0.1:40763",
+					"172.26.0.1:40763",
+					"172.27.0.1:40763",
+					"172.28.0.1:40763"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:10:43.763271407Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         818116849785060,
+				"StableID":   "nd5MWTYXP711CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e67b072f623a6ef1c4e441868b120b0e1ec414cf7f823bea4dc322b1c73fce22",
+				"DiscoKey":   "discokey:cc20da24fa4f46b0f3d869356a2f86109b821071d7b693fc2a647e3bb14b621c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37614",
+					"10.65.0.27:37614",
+					"172.17.0.1:37614",
+					"172.18.0.1:37614",
+					"172.19.0.1:37614",
+					"172.20.0.1:37614",
+					"172.21.0.1:37614",
+					"172.22.0.1:37614",
+					"172.23.0.1:37614",
+					"172.24.0.1:37614",
+					"172.25.0.1:37614",
+					"172.26.0.1:37614",
+					"172.27.0.1:37614",
+					"172.28.0.1:37614"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:10:44.315391471Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7601664281791600,
+				"StableID":   "ny9XuAqoM221CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aab665ced0d9240215455481aafefc91b37083bd5ed74c63d685170c0f01f772",
+				"DiscoKey":   "discokey:8fb60e9d9e28b607a43712f9d9524c59c615a957632e4d04c61cc2f766b13374",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58032",
+					"10.65.0.27:58032",
+					"172.17.0.1:58032",
+					"172.18.0.1:58032",
+					"172.19.0.1:58032",
+					"172.20.0.1:58032",
+					"172.21.0.1:58032",
+					"172.22.0.1:58032",
+					"172.23.0.1:58032",
+					"172.24.0.1:58032",
+					"172.25.0.1:58032",
+					"172.26.0.1:58032",
+					"172.27.0.1:58032",
+					"172.28.0.1:58032"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:10:44.903245772Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7172045565017533,
+				"StableID":   "ngYj4aUE1y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38597be773f83cca39f3d3930ba96ac7a4fc6db294fcd79dd9ebebbf37d74e66",
+				"DiscoKey":   "discokey:28c74df52a1d4519c59dfd35d9a1e960c8f50d0ce4a645650477ed3755303274",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36824",
+					"10.65.0.27:36824",
+					"172.17.0.1:36824",
+					"172.18.0.1:36824",
+					"172.19.0.1:36824",
+					"172.20.0.1:36824",
+					"172.21.0.1:36824",
+					"172.22.0.1:36824",
+					"172.23.0.1:36824",
+					"172.24.0.1:36824",
+					"172.25.0.1:36824",
+					"172.26.0.1:36824",
+					"172.27.0.1:36824",
+					"172.28.0.1:36824"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:10:45.447822606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2433647541453941,
+				"StableID":   "nYA2c4oC1L11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b90b253e23190ef9ef6573acae3dc180a4d1ce250c7c69ea763e2442f1cecb0e",
+				"DiscoKey":   "discokey:d4cc9bdd1aad555989cbea0d1d633b5a864664a53398fca05ecca6db6435607e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54770",
+					"10.65.0.27:54770",
+					"172.17.0.1:54770",
+					"172.18.0.1:54770",
+					"172.19.0.1:54770",
+					"172.20.0.1:54770",
+					"172.21.0.1:54770",
+					"172.22.0.1:54770",
+					"172.23.0.1:54770",
+					"172.24.0.1:54770",
+					"172.25.0.1:54770",
+					"172.26.0.1:54770",
+					"172.27.0.1:54770",
+					"172.28.0.1:54770"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:10:45.972100392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3094189100749093,
+				"StableID":   "ntGGHr6NAR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8d0eb408279680e87651d8931898596910cdd1a7c4f22bcd863bbca505af331b",
+				"DiscoKey":   "discokey:6e341b9d2ba93faeecfd3765d026ec000dbc206232864eb9a166c80f370bbf6c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55581",
+					"10.65.0.27:55581",
+					"172.17.0.1:55581",
+					"172.18.0.1:55581",
+					"172.19.0.1:55581",
+					"172.20.0.1:55581",
+					"172.21.0.1:55581",
+					"172.22.0.1:55581",
+					"172.23.0.1:55581",
+					"172.24.0.1:55581",
+					"172.25.0.1:55581",
+					"172.26.0.1:55581",
+					"172.27.0.1:55581",
+					"172.28.0.1:55581"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:10:46.514038595Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2114968417180870,
+				"StableID":   "n1k7fmdsWH11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1747722f6f1925a212dd4da8360d7227031d9d0c72954583c099d6e159dfa62",
+				"DiscoKey":   "discokey:192876548845a393fe66a4e34783664cdca8945ec29fc3463b01666c5150e622",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41522",
+					"10.65.0.27:41522",
+					"172.17.0.1:41522",
+					"172.18.0.1:41522",
+					"172.19.0.1:41522",
+					"172.20.0.1:41522",
+					"172.21.0.1:41522",
+					"172.22.0.1:41522",
+					"172.23.0.1:41522",
+					"172.24.0.1:41522",
+					"172.25.0.1:41522",
+					"172.26.0.1:41522",
+					"172.27.0.1:41522",
+					"172.28.0.1:41522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:10:47.048048187Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5879348204137845,
+				"StableID":   "nGkDvSWmun11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:773e9a5b93c7f420db6b0a12ca3367d80e3ab49c455a2a9df40952d5088d7834",
+				"KeyExpiry":  "2026-11-09T09:10:47Z",
+				"DiscoKey":   "discokey:f56b11a2d784e3cd1420750352c8f917d81c6fc40743638a7cb31708a7ff9a15",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35351",
+					"10.65.0.27:35351",
+					"172.17.0.1:35351",
+					"172.18.0.1:35351",
+					"172.19.0.1:35351",
+					"172.20.0.1:35351",
+					"172.21.0.1:35351",
+					"172.22.0.1:35351",
+					"172.23.0.1:35351",
+					"172.24.0.1:35351",
+					"172.25.0.1:35351",
+					"172.26.0.1:35351",
+					"172.27.0.1:35351",
+					"172.28.0.1:35351"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:10:47.592874778Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         68045841626599,
+				"StableID":   "nr4j13TpX111CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:981386a4b363044407a0d6c3cd468912350c9ee19025b55ba27b16b4532d1d16",
+				"KeyExpiry":  "2026-11-09T09:10:48Z",
+				"DiscoKey":   "discokey:eebc56f4dc88d3e5a9600502537d0b83e971a9fe26f3861dff6ee97805139443",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36640",
+					"10.65.0.27:36640",
+					"172.17.0.1:36640",
+					"172.18.0.1:36640",
+					"172.19.0.1:36640",
+					"172.20.0.1:36640",
+					"172.21.0.1:36640",
+					"172.22.0.1:36640",
+					"172.23.0.1:36640",
+					"172.24.0.1:36640",
+					"172.25.0.1:36640",
+					"172.26.0.1:36640",
+					"172.27.0.1:36640",
+					"172.28.0.1:36640"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:10:48.127109399Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6078694782604475,
+				"StableID":   "nrNjRF14Up11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:598464ec9b0c6a7ef22c12f8509ea7214ab175b15b236e84edc6c314a465671e",
+				"KeyExpiry":  "2026-11-09T09:10:48Z",
+				"DiscoKey":   "discokey:22177af5ff136137d2c6a8a5d9edb60e60f6b501632589dc759f9f7383e6ac6f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42180",
+					"10.65.0.27:42180",
+					"172.17.0.1:42180",
+					"172.18.0.1:42180",
+					"172.19.0.1:42180",
+					"172.20.0.1:42180",
+					"172.21.0.1:42180",
+					"172.22.0.1:42180",
+					"172.23.0.1:42180",
+					"172.24.0.1:42180",
+					"172.25.0.1:42180",
+					"172.26.0.1:42180",
+					"172.27.0.1:42180",
+					"172.28.0.1:42180"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:10:48.6705023Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7768084567289187": {
+				"ID":          7768084567289187,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7601664281791600,
+				"StableID":   "ny9XuAqoM221CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       7601664281791600,
+				"Key":        "nodekey:aab665ced0d9240215455481aafefc91b37083bd5ed74c63d685170c0f01f772",
+				"DiscoKey":   "discokey:8fb60e9d9e28b607a43712f9d9524c59c615a957632e4d04c61cc2f766b13374",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58032",
+					"10.65.0.27:58032",
+					"172.17.0.1:58032",
+					"172.18.0.1:58032",
+					"172.19.0.1:58032",
+					"172.20.0.1:58032",
+					"172.21.0.1:58032",
+					"172.22.0.1:58032",
+					"172.23.0.1:58032",
+					"172.24.0.1:58032",
+					"172.25.0.1:58032",
+					"172.26.0.1:58032",
+					"172.27.0.1:58032",
+					"172.28.0.1:58032"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:10:44.903245772Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:aab665ced0d9240215455481aafefc91b37083bd5ed74c63d685170c0f01f772",
+			"MachineKey": "mkey:52ea670a84b2c46604535d287d8f0b398528a8287cde49a92d58ea1c95159256",
+			"Peers": [{
+				"ID":         2481161170831544,
+				"StableID":   "nw86L1uiNL11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fa2e64f9eca2a176a8585cf3f181b1d45f78c3cccf1570600109ae345693b903",
+				"DiscoKey":   "discokey:ea8048c544d4690c11c538c7dff5e923a5bbd7577bf04495426d8fa6de5e1166",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40953",
+					"10.65.0.27:40953",
+					"172.17.0.1:40953",
+					"172.18.0.1:40953",
+					"172.19.0.1:40953",
+					"172.20.0.1:40953",
+					"172.21.0.1:40953",
+					"172.22.0.1:40953",
+					"172.23.0.1:40953",
+					"172.24.0.1:40953",
+					"172.25.0.1:40953",
+					"172.26.0.1:40953",
+					"172.27.0.1:40953",
+					"172.28.0.1:40953"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:10:41.10160613Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4960289040082096,
+				"StableID":   "nfQ6m9PXjf11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5aafa1118516e2c189ac90580c021439b584bef643c71781f5e26e5f1c3a112d",
+				"DiscoKey":   "discokey:6c9266c97130bffe5ae0461594c233724a666f8b09c18ece2cab2a980d70af55",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51611",
+					"10.65.0.27:51611",
+					"172.17.0.1:51611",
+					"172.18.0.1:51611",
+					"172.19.0.1:51611",
+					"172.20.0.1:51611",
+					"172.21.0.1:51611",
+					"172.22.0.1:51611",
+					"172.23.0.1:51611",
+					"172.24.0.1:51611",
+					"172.25.0.1:51611",
+					"172.26.0.1:51611",
+					"172.27.0.1:51611",
+					"172.28.0.1:51611"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:10:41.641446003Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7768084567289187,
+				"StableID":   "nku1fjQBf321CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c03e907c0eaceaaf345e13c7a81f4f3ad52eadc4f8a3e3ac8fcf7e625426dc2e",
+				"DiscoKey":   "discokey:efac546518cac262a451f53fd59a6058165767869355102704d32dede0b98c0d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:48773",
+					"10.65.0.27:48773",
+					"172.17.0.1:48773",
+					"172.18.0.1:48773",
+					"172.19.0.1:48773",
+					"172.20.0.1:48773",
+					"172.21.0.1:48773",
+					"172.22.0.1:48773",
+					"172.23.0.1:48773",
+					"172.24.0.1:48773",
+					"172.25.0.1:48773",
+					"172.26.0.1:48773",
+					"172.27.0.1:48773",
+					"172.28.0.1:48773"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:10:42.165454589Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3195380828706430,
+				"StableID":   "nZ8PmgECxR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26aa4590e7409841077b2f9ad40ce46298f04fa175ad468f4caac75c655b8d2c",
+				"DiscoKey":   "discokey:3ac2bc5b59d129134472a9231574fab9e65ae123699c660ead3e1582f7aaf76a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:44975",
+					"10.65.0.27:44975",
+					"172.17.0.1:44975",
+					"172.18.0.1:44975",
+					"172.19.0.1:44975",
+					"172.20.0.1:44975",
+					"172.21.0.1:44975",
+					"172.22.0.1:44975",
+					"172.23.0.1:44975",
+					"172.24.0.1:44975",
+					"172.25.0.1:44975",
+					"172.26.0.1:44975",
+					"172.27.0.1:44975",
+					"172.28.0.1:44975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:10:42.699205128Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3986158479948651,
+				"StableID":   "nGo3vBdL8Y11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:338bee8bcf0c71b8365a88b135045bf456a3203bc5cc32bc9b85f8f7b60e6c59",
+				"DiscoKey":   "discokey:5ab8526604b7b75af0a06970f8c44ca44ed68726e09072b2b1bedc7f6ee5f92f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:36771",
+					"10.65.0.27:36771",
+					"172.17.0.1:36771",
+					"172.18.0.1:36771",
+					"172.19.0.1:36771",
+					"172.20.0.1:36771",
+					"172.21.0.1:36771",
+					"172.22.0.1:36771",
+					"172.23.0.1:36771",
+					"172.24.0.1:36771",
+					"172.25.0.1:36771",
+					"172.26.0.1:36771",
+					"172.27.0.1:36771",
+					"172.28.0.1:36771"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:10:43.226544237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1408740200256286,
+				"StableID":   "nmeZVYD21C11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:386f415fad86f92958f3cb6aa8a62828e388cf7fe68d7810538b9edcd7e6cf6b",
+				"DiscoKey":   "discokey:4d951ab6f3ebad15e794ce3db79649dfd2ef4a6ebba1f02a13acf645de951275",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40763",
+					"10.65.0.27:40763",
+					"172.17.0.1:40763",
+					"172.18.0.1:40763",
+					"172.19.0.1:40763",
+					"172.20.0.1:40763",
+					"172.21.0.1:40763",
+					"172.22.0.1:40763",
+					"172.23.0.1:40763",
+					"172.24.0.1:40763",
+					"172.25.0.1:40763",
+					"172.26.0.1:40763",
+					"172.27.0.1:40763",
+					"172.28.0.1:40763"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:10:43.763271407Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         818116849785060,
+				"StableID":   "nd5MWTYXP711CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e67b072f623a6ef1c4e441868b120b0e1ec414cf7f823bea4dc322b1c73fce22",
+				"DiscoKey":   "discokey:cc20da24fa4f46b0f3d869356a2f86109b821071d7b693fc2a647e3bb14b621c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37614",
+					"10.65.0.27:37614",
+					"172.17.0.1:37614",
+					"172.18.0.1:37614",
+					"172.19.0.1:37614",
+					"172.20.0.1:37614",
+					"172.21.0.1:37614",
+					"172.22.0.1:37614",
+					"172.23.0.1:37614",
+					"172.24.0.1:37614",
+					"172.25.0.1:37614",
+					"172.26.0.1:37614",
+					"172.27.0.1:37614",
+					"172.28.0.1:37614"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:10:44.315391471Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7172045565017533,
+				"StableID":   "ngYj4aUE1y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38597be773f83cca39f3d3930ba96ac7a4fc6db294fcd79dd9ebebbf37d74e66",
+				"DiscoKey":   "discokey:28c74df52a1d4519c59dfd35d9a1e960c8f50d0ce4a645650477ed3755303274",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36824",
+					"10.65.0.27:36824",
+					"172.17.0.1:36824",
+					"172.18.0.1:36824",
+					"172.19.0.1:36824",
+					"172.20.0.1:36824",
+					"172.21.0.1:36824",
+					"172.22.0.1:36824",
+					"172.23.0.1:36824",
+					"172.24.0.1:36824",
+					"172.25.0.1:36824",
+					"172.26.0.1:36824",
+					"172.27.0.1:36824",
+					"172.28.0.1:36824"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:10:45.447822606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2433647541453941,
+				"StableID":   "nYA2c4oC1L11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b90b253e23190ef9ef6573acae3dc180a4d1ce250c7c69ea763e2442f1cecb0e",
+				"DiscoKey":   "discokey:d4cc9bdd1aad555989cbea0d1d633b5a864664a53398fca05ecca6db6435607e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54770",
+					"10.65.0.27:54770",
+					"172.17.0.1:54770",
+					"172.18.0.1:54770",
+					"172.19.0.1:54770",
+					"172.20.0.1:54770",
+					"172.21.0.1:54770",
+					"172.22.0.1:54770",
+					"172.23.0.1:54770",
+					"172.24.0.1:54770",
+					"172.25.0.1:54770",
+					"172.26.0.1:54770",
+					"172.27.0.1:54770",
+					"172.28.0.1:54770"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:10:45.972100392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3094189100749093,
+				"StableID":   "ntGGHr6NAR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8d0eb408279680e87651d8931898596910cdd1a7c4f22bcd863bbca505af331b",
+				"DiscoKey":   "discokey:6e341b9d2ba93faeecfd3765d026ec000dbc206232864eb9a166c80f370bbf6c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55581",
+					"10.65.0.27:55581",
+					"172.17.0.1:55581",
+					"172.18.0.1:55581",
+					"172.19.0.1:55581",
+					"172.20.0.1:55581",
+					"172.21.0.1:55581",
+					"172.22.0.1:55581",
+					"172.23.0.1:55581",
+					"172.24.0.1:55581",
+					"172.25.0.1:55581",
+					"172.26.0.1:55581",
+					"172.27.0.1:55581",
+					"172.28.0.1:55581"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:10:46.514038595Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2114968417180870,
+				"StableID":   "n1k7fmdsWH11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1747722f6f1925a212dd4da8360d7227031d9d0c72954583c099d6e159dfa62",
+				"DiscoKey":   "discokey:192876548845a393fe66a4e34783664cdca8945ec29fc3463b01666c5150e622",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41522",
+					"10.65.0.27:41522",
+					"172.17.0.1:41522",
+					"172.18.0.1:41522",
+					"172.19.0.1:41522",
+					"172.20.0.1:41522",
+					"172.21.0.1:41522",
+					"172.22.0.1:41522",
+					"172.23.0.1:41522",
+					"172.24.0.1:41522",
+					"172.25.0.1:41522",
+					"172.26.0.1:41522",
+					"172.27.0.1:41522",
+					"172.28.0.1:41522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:10:47.048048187Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5879348204137845,
+				"StableID":   "nGkDvSWmun11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:773e9a5b93c7f420db6b0a12ca3367d80e3ab49c455a2a9df40952d5088d7834",
+				"KeyExpiry":  "2026-11-09T09:10:47Z",
+				"DiscoKey":   "discokey:f56b11a2d784e3cd1420750352c8f917d81c6fc40743638a7cb31708a7ff9a15",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35351",
+					"10.65.0.27:35351",
+					"172.17.0.1:35351",
+					"172.18.0.1:35351",
+					"172.19.0.1:35351",
+					"172.20.0.1:35351",
+					"172.21.0.1:35351",
+					"172.22.0.1:35351",
+					"172.23.0.1:35351",
+					"172.24.0.1:35351",
+					"172.25.0.1:35351",
+					"172.26.0.1:35351",
+					"172.27.0.1:35351",
+					"172.28.0.1:35351"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:10:47.592874778Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         68045841626599,
+				"StableID":   "nr4j13TpX111CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:981386a4b363044407a0d6c3cd468912350c9ee19025b55ba27b16b4532d1d16",
+				"KeyExpiry":  "2026-11-09T09:10:48Z",
+				"DiscoKey":   "discokey:eebc56f4dc88d3e5a9600502537d0b83e971a9fe26f3861dff6ee97805139443",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36640",
+					"10.65.0.27:36640",
+					"172.17.0.1:36640",
+					"172.18.0.1:36640",
+					"172.19.0.1:36640",
+					"172.20.0.1:36640",
+					"172.21.0.1:36640",
+					"172.22.0.1:36640",
+					"172.23.0.1:36640",
+					"172.24.0.1:36640",
+					"172.25.0.1:36640",
+					"172.26.0.1:36640",
+					"172.27.0.1:36640",
+					"172.28.0.1:36640"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:10:48.127109399Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6078694782604475,
+				"StableID":   "nrNjRF14Up11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:598464ec9b0c6a7ef22c12f8509ea7214ab175b15b236e84edc6c314a465671e",
+				"KeyExpiry":  "2026-11-09T09:10:48Z",
+				"DiscoKey":   "discokey:22177af5ff136137d2c6a8a5d9edb60e60f6b501632589dc759f9f7383e6ac6f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42180",
+					"10.65.0.27:42180",
+					"172.17.0.1:42180",
+					"172.18.0.1:42180",
+					"172.19.0.1:42180",
+					"172.20.0.1:42180",
+					"172.21.0.1:42180",
+					"172.22.0.1:42180",
+					"172.23.0.1:42180",
+					"172.24.0.1:42180",
+					"172.25.0.1:42180",
+					"172.26.0.1:42180",
+					"172.27.0.1:42180",
+					"172.28.0.1:42180"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:10:48.6705023Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7601664281791600": {
+				"ID":          7601664281791600,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5879348204137845,
+				"StableID":   "nGkDvSWmun11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:773e9a5b93c7f420db6b0a12ca3367d80e3ab49c455a2a9df40952d5088d7834",
+				"KeyExpiry":  "2026-11-09T09:10:47Z",
+				"DiscoKey":   "discokey:f56b11a2d784e3cd1420750352c8f917d81c6fc40743638a7cb31708a7ff9a15",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35351",
+					"10.65.0.27:35351",
+					"172.17.0.1:35351",
+					"172.18.0.1:35351",
+					"172.19.0.1:35351",
+					"172.20.0.1:35351",
+					"172.21.0.1:35351",
+					"172.22.0.1:35351",
+					"172.23.0.1:35351",
+					"172.24.0.1:35351",
+					"172.25.0.1:35351",
+					"172.26.0.1:35351",
+					"172.27.0.1:35351",
+					"172.28.0.1:35351"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:10:47.592874778Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:773e9a5b93c7f420db6b0a12ca3367d80e3ab49c455a2a9df40952d5088d7834",
+			"MachineKey": "mkey:1dfb0e802c06fa1c3c171cd73cc969e460c1fa9d60529800dbc0ad4cbc282d7b",
+			"Peers": [{
+				"ID":         2481161170831544,
+				"StableID":   "nw86L1uiNL11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fa2e64f9eca2a176a8585cf3f181b1d45f78c3cccf1570600109ae345693b903",
+				"DiscoKey":   "discokey:ea8048c544d4690c11c538c7dff5e923a5bbd7577bf04495426d8fa6de5e1166",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40953",
+					"10.65.0.27:40953",
+					"172.17.0.1:40953",
+					"172.18.0.1:40953",
+					"172.19.0.1:40953",
+					"172.20.0.1:40953",
+					"172.21.0.1:40953",
+					"172.22.0.1:40953",
+					"172.23.0.1:40953",
+					"172.24.0.1:40953",
+					"172.25.0.1:40953",
+					"172.26.0.1:40953",
+					"172.27.0.1:40953",
+					"172.28.0.1:40953"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:10:41.10160613Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4960289040082096,
+				"StableID":   "nfQ6m9PXjf11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5aafa1118516e2c189ac90580c021439b584bef643c71781f5e26e5f1c3a112d",
+				"DiscoKey":   "discokey:6c9266c97130bffe5ae0461594c233724a666f8b09c18ece2cab2a980d70af55",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51611",
+					"10.65.0.27:51611",
+					"172.17.0.1:51611",
+					"172.18.0.1:51611",
+					"172.19.0.1:51611",
+					"172.20.0.1:51611",
+					"172.21.0.1:51611",
+					"172.22.0.1:51611",
+					"172.23.0.1:51611",
+					"172.24.0.1:51611",
+					"172.25.0.1:51611",
+					"172.26.0.1:51611",
+					"172.27.0.1:51611",
+					"172.28.0.1:51611"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:10:41.641446003Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7768084567289187,
+				"StableID":   "nku1fjQBf321CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c03e907c0eaceaaf345e13c7a81f4f3ad52eadc4f8a3e3ac8fcf7e625426dc2e",
+				"DiscoKey":   "discokey:efac546518cac262a451f53fd59a6058165767869355102704d32dede0b98c0d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:48773",
+					"10.65.0.27:48773",
+					"172.17.0.1:48773",
+					"172.18.0.1:48773",
+					"172.19.0.1:48773",
+					"172.20.0.1:48773",
+					"172.21.0.1:48773",
+					"172.22.0.1:48773",
+					"172.23.0.1:48773",
+					"172.24.0.1:48773",
+					"172.25.0.1:48773",
+					"172.26.0.1:48773",
+					"172.27.0.1:48773",
+					"172.28.0.1:48773"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:10:42.165454589Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3195380828706430,
+				"StableID":   "nZ8PmgECxR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26aa4590e7409841077b2f9ad40ce46298f04fa175ad468f4caac75c655b8d2c",
+				"DiscoKey":   "discokey:3ac2bc5b59d129134472a9231574fab9e65ae123699c660ead3e1582f7aaf76a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:44975",
+					"10.65.0.27:44975",
+					"172.17.0.1:44975",
+					"172.18.0.1:44975",
+					"172.19.0.1:44975",
+					"172.20.0.1:44975",
+					"172.21.0.1:44975",
+					"172.22.0.1:44975",
+					"172.23.0.1:44975",
+					"172.24.0.1:44975",
+					"172.25.0.1:44975",
+					"172.26.0.1:44975",
+					"172.27.0.1:44975",
+					"172.28.0.1:44975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:10:42.699205128Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3986158479948651,
+				"StableID":   "nGo3vBdL8Y11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:338bee8bcf0c71b8365a88b135045bf456a3203bc5cc32bc9b85f8f7b60e6c59",
+				"DiscoKey":   "discokey:5ab8526604b7b75af0a06970f8c44ca44ed68726e09072b2b1bedc7f6ee5f92f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:36771",
+					"10.65.0.27:36771",
+					"172.17.0.1:36771",
+					"172.18.0.1:36771",
+					"172.19.0.1:36771",
+					"172.20.0.1:36771",
+					"172.21.0.1:36771",
+					"172.22.0.1:36771",
+					"172.23.0.1:36771",
+					"172.24.0.1:36771",
+					"172.25.0.1:36771",
+					"172.26.0.1:36771",
+					"172.27.0.1:36771",
+					"172.28.0.1:36771"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:10:43.226544237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1408740200256286,
+				"StableID":   "nmeZVYD21C11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:386f415fad86f92958f3cb6aa8a62828e388cf7fe68d7810538b9edcd7e6cf6b",
+				"DiscoKey":   "discokey:4d951ab6f3ebad15e794ce3db79649dfd2ef4a6ebba1f02a13acf645de951275",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40763",
+					"10.65.0.27:40763",
+					"172.17.0.1:40763",
+					"172.18.0.1:40763",
+					"172.19.0.1:40763",
+					"172.20.0.1:40763",
+					"172.21.0.1:40763",
+					"172.22.0.1:40763",
+					"172.23.0.1:40763",
+					"172.24.0.1:40763",
+					"172.25.0.1:40763",
+					"172.26.0.1:40763",
+					"172.27.0.1:40763",
+					"172.28.0.1:40763"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:10:43.763271407Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         818116849785060,
+				"StableID":   "nd5MWTYXP711CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e67b072f623a6ef1c4e441868b120b0e1ec414cf7f823bea4dc322b1c73fce22",
+				"DiscoKey":   "discokey:cc20da24fa4f46b0f3d869356a2f86109b821071d7b693fc2a647e3bb14b621c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37614",
+					"10.65.0.27:37614",
+					"172.17.0.1:37614",
+					"172.18.0.1:37614",
+					"172.19.0.1:37614",
+					"172.20.0.1:37614",
+					"172.21.0.1:37614",
+					"172.22.0.1:37614",
+					"172.23.0.1:37614",
+					"172.24.0.1:37614",
+					"172.25.0.1:37614",
+					"172.26.0.1:37614",
+					"172.27.0.1:37614",
+					"172.28.0.1:37614"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:10:44.315391471Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7601664281791600,
+				"StableID":   "ny9XuAqoM221CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aab665ced0d9240215455481aafefc91b37083bd5ed74c63d685170c0f01f772",
+				"DiscoKey":   "discokey:8fb60e9d9e28b607a43712f9d9524c59c615a957632e4d04c61cc2f766b13374",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58032",
+					"10.65.0.27:58032",
+					"172.17.0.1:58032",
+					"172.18.0.1:58032",
+					"172.19.0.1:58032",
+					"172.20.0.1:58032",
+					"172.21.0.1:58032",
+					"172.22.0.1:58032",
+					"172.23.0.1:58032",
+					"172.24.0.1:58032",
+					"172.25.0.1:58032",
+					"172.26.0.1:58032",
+					"172.27.0.1:58032",
+					"172.28.0.1:58032"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:10:44.903245772Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7172045565017533,
+				"StableID":   "ngYj4aUE1y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38597be773f83cca39f3d3930ba96ac7a4fc6db294fcd79dd9ebebbf37d74e66",
+				"DiscoKey":   "discokey:28c74df52a1d4519c59dfd35d9a1e960c8f50d0ce4a645650477ed3755303274",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36824",
+					"10.65.0.27:36824",
+					"172.17.0.1:36824",
+					"172.18.0.1:36824",
+					"172.19.0.1:36824",
+					"172.20.0.1:36824",
+					"172.21.0.1:36824",
+					"172.22.0.1:36824",
+					"172.23.0.1:36824",
+					"172.24.0.1:36824",
+					"172.25.0.1:36824",
+					"172.26.0.1:36824",
+					"172.27.0.1:36824",
+					"172.28.0.1:36824"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:10:45.447822606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2433647541453941,
+				"StableID":   "nYA2c4oC1L11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b90b253e23190ef9ef6573acae3dc180a4d1ce250c7c69ea763e2442f1cecb0e",
+				"DiscoKey":   "discokey:d4cc9bdd1aad555989cbea0d1d633b5a864664a53398fca05ecca6db6435607e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54770",
+					"10.65.0.27:54770",
+					"172.17.0.1:54770",
+					"172.18.0.1:54770",
+					"172.19.0.1:54770",
+					"172.20.0.1:54770",
+					"172.21.0.1:54770",
+					"172.22.0.1:54770",
+					"172.23.0.1:54770",
+					"172.24.0.1:54770",
+					"172.25.0.1:54770",
+					"172.26.0.1:54770",
+					"172.27.0.1:54770",
+					"172.28.0.1:54770"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:10:45.972100392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3094189100749093,
+				"StableID":   "ntGGHr6NAR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8d0eb408279680e87651d8931898596910cdd1a7c4f22bcd863bbca505af331b",
+				"DiscoKey":   "discokey:6e341b9d2ba93faeecfd3765d026ec000dbc206232864eb9a166c80f370bbf6c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55581",
+					"10.65.0.27:55581",
+					"172.17.0.1:55581",
+					"172.18.0.1:55581",
+					"172.19.0.1:55581",
+					"172.20.0.1:55581",
+					"172.21.0.1:55581",
+					"172.22.0.1:55581",
+					"172.23.0.1:55581",
+					"172.24.0.1:55581",
+					"172.25.0.1:55581",
+					"172.26.0.1:55581",
+					"172.27.0.1:55581",
+					"172.28.0.1:55581"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:10:46.514038595Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2114968417180870,
+				"StableID":   "n1k7fmdsWH11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1747722f6f1925a212dd4da8360d7227031d9d0c72954583c099d6e159dfa62",
+				"DiscoKey":   "discokey:192876548845a393fe66a4e34783664cdca8945ec29fc3463b01666c5150e622",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41522",
+					"10.65.0.27:41522",
+					"172.17.0.1:41522",
+					"172.18.0.1:41522",
+					"172.19.0.1:41522",
+					"172.20.0.1:41522",
+					"172.21.0.1:41522",
+					"172.22.0.1:41522",
+					"172.23.0.1:41522",
+					"172.24.0.1:41522",
+					"172.25.0.1:41522",
+					"172.26.0.1:41522",
+					"172.27.0.1:41522",
+					"172.28.0.1:41522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:10:47.048048187Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         68045841626599,
+				"StableID":   "nr4j13TpX111CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:981386a4b363044407a0d6c3cd468912350c9ee19025b55ba27b16b4532d1d16",
+				"KeyExpiry":  "2026-11-09T09:10:48Z",
+				"DiscoKey":   "discokey:eebc56f4dc88d3e5a9600502537d0b83e971a9fe26f3861dff6ee97805139443",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36640",
+					"10.65.0.27:36640",
+					"172.17.0.1:36640",
+					"172.18.0.1:36640",
+					"172.19.0.1:36640",
+					"172.20.0.1:36640",
+					"172.21.0.1:36640",
+					"172.22.0.1:36640",
+					"172.23.0.1:36640",
+					"172.24.0.1:36640",
+					"172.25.0.1:36640",
+					"172.26.0.1:36640",
+					"172.27.0.1:36640",
+					"172.28.0.1:36640"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:10:48.127109399Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6078694782604475,
+				"StableID":   "nrNjRF14Up11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:598464ec9b0c6a7ef22c12f8509ea7214ab175b15b236e84edc6c314a465671e",
+				"KeyExpiry":  "2026-11-09T09:10:48Z",
+				"DiscoKey":   "discokey:22177af5ff136137d2c6a8a5d9edb60e60f6b501632589dc759f9f7383e6ac6f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42180",
+					"10.65.0.27:42180",
+					"172.17.0.1:42180",
+					"172.18.0.1:42180",
+					"172.19.0.1:42180",
+					"172.20.0.1:42180",
+					"172.21.0.1:42180",
+					"172.22.0.1:42180",
+					"172.23.0.1:42180",
+					"172.24.0.1:42180",
+					"172.25.0.1:42180",
+					"172.26.0.1:42180",
+					"172.27.0.1:42180",
+					"172.28.0.1:42180"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:10:48.6705023Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3094189100749093,
+				"StableID":   "ntGGHr6NAR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       3094189100749093,
+				"Key":        "nodekey:8d0eb408279680e87651d8931898596910cdd1a7c4f22bcd863bbca505af331b",
+				"DiscoKey":   "discokey:6e341b9d2ba93faeecfd3765d026ec000dbc206232864eb9a166c80f370bbf6c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55581",
+					"10.65.0.27:55581",
+					"172.17.0.1:55581",
+					"172.18.0.1:55581",
+					"172.19.0.1:55581",
+					"172.20.0.1:55581",
+					"172.21.0.1:55581",
+					"172.22.0.1:55581",
+					"172.23.0.1:55581",
+					"172.24.0.1:55581",
+					"172.25.0.1:55581",
+					"172.26.0.1:55581",
+					"172.27.0.1:55581",
+					"172.28.0.1:55581"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:10:46.514038595Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8d0eb408279680e87651d8931898596910cdd1a7c4f22bcd863bbca505af331b",
+			"MachineKey": "mkey:12c4e0f0eec1e1174360cbbf521c15612d67bf50dbd6f67f68de02034b2f844d",
+			"Peers": [{
+				"ID":         2481161170831544,
+				"StableID":   "nw86L1uiNL11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fa2e64f9eca2a176a8585cf3f181b1d45f78c3cccf1570600109ae345693b903",
+				"DiscoKey":   "discokey:ea8048c544d4690c11c538c7dff5e923a5bbd7577bf04495426d8fa6de5e1166",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40953",
+					"10.65.0.27:40953",
+					"172.17.0.1:40953",
+					"172.18.0.1:40953",
+					"172.19.0.1:40953",
+					"172.20.0.1:40953",
+					"172.21.0.1:40953",
+					"172.22.0.1:40953",
+					"172.23.0.1:40953",
+					"172.24.0.1:40953",
+					"172.25.0.1:40953",
+					"172.26.0.1:40953",
+					"172.27.0.1:40953",
+					"172.28.0.1:40953"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:10:41.10160613Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4960289040082096,
+				"StableID":   "nfQ6m9PXjf11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5aafa1118516e2c189ac90580c021439b584bef643c71781f5e26e5f1c3a112d",
+				"DiscoKey":   "discokey:6c9266c97130bffe5ae0461594c233724a666f8b09c18ece2cab2a980d70af55",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51611",
+					"10.65.0.27:51611",
+					"172.17.0.1:51611",
+					"172.18.0.1:51611",
+					"172.19.0.1:51611",
+					"172.20.0.1:51611",
+					"172.21.0.1:51611",
+					"172.22.0.1:51611",
+					"172.23.0.1:51611",
+					"172.24.0.1:51611",
+					"172.25.0.1:51611",
+					"172.26.0.1:51611",
+					"172.27.0.1:51611",
+					"172.28.0.1:51611"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:10:41.641446003Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7768084567289187,
+				"StableID":   "nku1fjQBf321CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c03e907c0eaceaaf345e13c7a81f4f3ad52eadc4f8a3e3ac8fcf7e625426dc2e",
+				"DiscoKey":   "discokey:efac546518cac262a451f53fd59a6058165767869355102704d32dede0b98c0d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:48773",
+					"10.65.0.27:48773",
+					"172.17.0.1:48773",
+					"172.18.0.1:48773",
+					"172.19.0.1:48773",
+					"172.20.0.1:48773",
+					"172.21.0.1:48773",
+					"172.22.0.1:48773",
+					"172.23.0.1:48773",
+					"172.24.0.1:48773",
+					"172.25.0.1:48773",
+					"172.26.0.1:48773",
+					"172.27.0.1:48773",
+					"172.28.0.1:48773"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:10:42.165454589Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3195380828706430,
+				"StableID":   "nZ8PmgECxR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26aa4590e7409841077b2f9ad40ce46298f04fa175ad468f4caac75c655b8d2c",
+				"DiscoKey":   "discokey:3ac2bc5b59d129134472a9231574fab9e65ae123699c660ead3e1582f7aaf76a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:44975",
+					"10.65.0.27:44975",
+					"172.17.0.1:44975",
+					"172.18.0.1:44975",
+					"172.19.0.1:44975",
+					"172.20.0.1:44975",
+					"172.21.0.1:44975",
+					"172.22.0.1:44975",
+					"172.23.0.1:44975",
+					"172.24.0.1:44975",
+					"172.25.0.1:44975",
+					"172.26.0.1:44975",
+					"172.27.0.1:44975",
+					"172.28.0.1:44975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:10:42.699205128Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3986158479948651,
+				"StableID":   "nGo3vBdL8Y11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:338bee8bcf0c71b8365a88b135045bf456a3203bc5cc32bc9b85f8f7b60e6c59",
+				"DiscoKey":   "discokey:5ab8526604b7b75af0a06970f8c44ca44ed68726e09072b2b1bedc7f6ee5f92f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:36771",
+					"10.65.0.27:36771",
+					"172.17.0.1:36771",
+					"172.18.0.1:36771",
+					"172.19.0.1:36771",
+					"172.20.0.1:36771",
+					"172.21.0.1:36771",
+					"172.22.0.1:36771",
+					"172.23.0.1:36771",
+					"172.24.0.1:36771",
+					"172.25.0.1:36771",
+					"172.26.0.1:36771",
+					"172.27.0.1:36771",
+					"172.28.0.1:36771"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:10:43.226544237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1408740200256286,
+				"StableID":   "nmeZVYD21C11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:386f415fad86f92958f3cb6aa8a62828e388cf7fe68d7810538b9edcd7e6cf6b",
+				"DiscoKey":   "discokey:4d951ab6f3ebad15e794ce3db79649dfd2ef4a6ebba1f02a13acf645de951275",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40763",
+					"10.65.0.27:40763",
+					"172.17.0.1:40763",
+					"172.18.0.1:40763",
+					"172.19.0.1:40763",
+					"172.20.0.1:40763",
+					"172.21.0.1:40763",
+					"172.22.0.1:40763",
+					"172.23.0.1:40763",
+					"172.24.0.1:40763",
+					"172.25.0.1:40763",
+					"172.26.0.1:40763",
+					"172.27.0.1:40763",
+					"172.28.0.1:40763"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:10:43.763271407Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         818116849785060,
+				"StableID":   "nd5MWTYXP711CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e67b072f623a6ef1c4e441868b120b0e1ec414cf7f823bea4dc322b1c73fce22",
+				"DiscoKey":   "discokey:cc20da24fa4f46b0f3d869356a2f86109b821071d7b693fc2a647e3bb14b621c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37614",
+					"10.65.0.27:37614",
+					"172.17.0.1:37614",
+					"172.18.0.1:37614",
+					"172.19.0.1:37614",
+					"172.20.0.1:37614",
+					"172.21.0.1:37614",
+					"172.22.0.1:37614",
+					"172.23.0.1:37614",
+					"172.24.0.1:37614",
+					"172.25.0.1:37614",
+					"172.26.0.1:37614",
+					"172.27.0.1:37614",
+					"172.28.0.1:37614"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:10:44.315391471Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7601664281791600,
+				"StableID":   "ny9XuAqoM221CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aab665ced0d9240215455481aafefc91b37083bd5ed74c63d685170c0f01f772",
+				"DiscoKey":   "discokey:8fb60e9d9e28b607a43712f9d9524c59c615a957632e4d04c61cc2f766b13374",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58032",
+					"10.65.0.27:58032",
+					"172.17.0.1:58032",
+					"172.18.0.1:58032",
+					"172.19.0.1:58032",
+					"172.20.0.1:58032",
+					"172.21.0.1:58032",
+					"172.22.0.1:58032",
+					"172.23.0.1:58032",
+					"172.24.0.1:58032",
+					"172.25.0.1:58032",
+					"172.26.0.1:58032",
+					"172.27.0.1:58032",
+					"172.28.0.1:58032"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:10:44.903245772Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7172045565017533,
+				"StableID":   "ngYj4aUE1y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38597be773f83cca39f3d3930ba96ac7a4fc6db294fcd79dd9ebebbf37d74e66",
+				"DiscoKey":   "discokey:28c74df52a1d4519c59dfd35d9a1e960c8f50d0ce4a645650477ed3755303274",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36824",
+					"10.65.0.27:36824",
+					"172.17.0.1:36824",
+					"172.18.0.1:36824",
+					"172.19.0.1:36824",
+					"172.20.0.1:36824",
+					"172.21.0.1:36824",
+					"172.22.0.1:36824",
+					"172.23.0.1:36824",
+					"172.24.0.1:36824",
+					"172.25.0.1:36824",
+					"172.26.0.1:36824",
+					"172.27.0.1:36824",
+					"172.28.0.1:36824"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:10:45.447822606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2433647541453941,
+				"StableID":   "nYA2c4oC1L11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b90b253e23190ef9ef6573acae3dc180a4d1ce250c7c69ea763e2442f1cecb0e",
+				"DiscoKey":   "discokey:d4cc9bdd1aad555989cbea0d1d633b5a864664a53398fca05ecca6db6435607e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54770",
+					"10.65.0.27:54770",
+					"172.17.0.1:54770",
+					"172.18.0.1:54770",
+					"172.19.0.1:54770",
+					"172.20.0.1:54770",
+					"172.21.0.1:54770",
+					"172.22.0.1:54770",
+					"172.23.0.1:54770",
+					"172.24.0.1:54770",
+					"172.25.0.1:54770",
+					"172.26.0.1:54770",
+					"172.27.0.1:54770",
+					"172.28.0.1:54770"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:10:45.972100392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2114968417180870,
+				"StableID":   "n1k7fmdsWH11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1747722f6f1925a212dd4da8360d7227031d9d0c72954583c099d6e159dfa62",
+				"DiscoKey":   "discokey:192876548845a393fe66a4e34783664cdca8945ec29fc3463b01666c5150e622",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41522",
+					"10.65.0.27:41522",
+					"172.17.0.1:41522",
+					"172.18.0.1:41522",
+					"172.19.0.1:41522",
+					"172.20.0.1:41522",
+					"172.21.0.1:41522",
+					"172.22.0.1:41522",
+					"172.23.0.1:41522",
+					"172.24.0.1:41522",
+					"172.25.0.1:41522",
+					"172.26.0.1:41522",
+					"172.27.0.1:41522",
+					"172.28.0.1:41522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:10:47.048048187Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5879348204137845,
+				"StableID":   "nGkDvSWmun11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:773e9a5b93c7f420db6b0a12ca3367d80e3ab49c455a2a9df40952d5088d7834",
+				"KeyExpiry":  "2026-11-09T09:10:47Z",
+				"DiscoKey":   "discokey:f56b11a2d784e3cd1420750352c8f917d81c6fc40743638a7cb31708a7ff9a15",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35351",
+					"10.65.0.27:35351",
+					"172.17.0.1:35351",
+					"172.18.0.1:35351",
+					"172.19.0.1:35351",
+					"172.20.0.1:35351",
+					"172.21.0.1:35351",
+					"172.22.0.1:35351",
+					"172.23.0.1:35351",
+					"172.24.0.1:35351",
+					"172.25.0.1:35351",
+					"172.26.0.1:35351",
+					"172.27.0.1:35351",
+					"172.28.0.1:35351"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:10:47.592874778Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         68045841626599,
+				"StableID":   "nr4j13TpX111CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:981386a4b363044407a0d6c3cd468912350c9ee19025b55ba27b16b4532d1d16",
+				"KeyExpiry":  "2026-11-09T09:10:48Z",
+				"DiscoKey":   "discokey:eebc56f4dc88d3e5a9600502537d0b83e971a9fe26f3861dff6ee97805139443",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36640",
+					"10.65.0.27:36640",
+					"172.17.0.1:36640",
+					"172.18.0.1:36640",
+					"172.19.0.1:36640",
+					"172.20.0.1:36640",
+					"172.21.0.1:36640",
+					"172.22.0.1:36640",
+					"172.23.0.1:36640",
+					"172.24.0.1:36640",
+					"172.25.0.1:36640",
+					"172.26.0.1:36640",
+					"172.27.0.1:36640",
+					"172.28.0.1:36640"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:10:48.127109399Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6078694782604475,
+				"StableID":   "nrNjRF14Up11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:598464ec9b0c6a7ef22c12f8509ea7214ab175b15b236e84edc6c314a465671e",
+				"KeyExpiry":  "2026-11-09T09:10:48Z",
+				"DiscoKey":   "discokey:22177af5ff136137d2c6a8a5d9edb60e60f6b501632589dc759f9f7383e6ac6f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42180",
+					"10.65.0.27:42180",
+					"172.17.0.1:42180",
+					"172.18.0.1:42180",
+					"172.19.0.1:42180",
+					"172.20.0.1:42180",
+					"172.21.0.1:42180",
+					"172.22.0.1:42180",
+					"172.23.0.1:42180",
+					"172.24.0.1:42180",
+					"172.25.0.1:42180",
+					"172.26.0.1:42180",
+					"172.27.0.1:42180",
+					"172.28.0.1:42180"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:10:48.6705023Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3094189100749093": {
+				"ID":          3094189100749093,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4960289040082096,
+				"StableID":   "nfQ6m9PXjf11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       4960289040082096,
+				"Key":        "nodekey:5aafa1118516e2c189ac90580c021439b584bef643c71781f5e26e5f1c3a112d",
+				"DiscoKey":   "discokey:6c9266c97130bffe5ae0461594c233724a666f8b09c18ece2cab2a980d70af55",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51611",
+					"10.65.0.27:51611",
+					"172.17.0.1:51611",
+					"172.18.0.1:51611",
+					"172.19.0.1:51611",
+					"172.20.0.1:51611",
+					"172.21.0.1:51611",
+					"172.22.0.1:51611",
+					"172.23.0.1:51611",
+					"172.24.0.1:51611",
+					"172.25.0.1:51611",
+					"172.26.0.1:51611",
+					"172.27.0.1:51611",
+					"172.28.0.1:51611"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:10:41.641446003Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5aafa1118516e2c189ac90580c021439b584bef643c71781f5e26e5f1c3a112d",
+			"MachineKey": "mkey:a23985b8cf9c57e44c933fc6d0071df5bb788da525ad3f942660be862dcaf740",
+			"Peers": [{
+				"ID":         2481161170831544,
+				"StableID":   "nw86L1uiNL11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fa2e64f9eca2a176a8585cf3f181b1d45f78c3cccf1570600109ae345693b903",
+				"DiscoKey":   "discokey:ea8048c544d4690c11c538c7dff5e923a5bbd7577bf04495426d8fa6de5e1166",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40953",
+					"10.65.0.27:40953",
+					"172.17.0.1:40953",
+					"172.18.0.1:40953",
+					"172.19.0.1:40953",
+					"172.20.0.1:40953",
+					"172.21.0.1:40953",
+					"172.22.0.1:40953",
+					"172.23.0.1:40953",
+					"172.24.0.1:40953",
+					"172.25.0.1:40953",
+					"172.26.0.1:40953",
+					"172.27.0.1:40953",
+					"172.28.0.1:40953"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:10:41.10160613Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7768084567289187,
+				"StableID":   "nku1fjQBf321CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c03e907c0eaceaaf345e13c7a81f4f3ad52eadc4f8a3e3ac8fcf7e625426dc2e",
+				"DiscoKey":   "discokey:efac546518cac262a451f53fd59a6058165767869355102704d32dede0b98c0d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:48773",
+					"10.65.0.27:48773",
+					"172.17.0.1:48773",
+					"172.18.0.1:48773",
+					"172.19.0.1:48773",
+					"172.20.0.1:48773",
+					"172.21.0.1:48773",
+					"172.22.0.1:48773",
+					"172.23.0.1:48773",
+					"172.24.0.1:48773",
+					"172.25.0.1:48773",
+					"172.26.0.1:48773",
+					"172.27.0.1:48773",
+					"172.28.0.1:48773"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:10:42.165454589Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3195380828706430,
+				"StableID":   "nZ8PmgECxR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26aa4590e7409841077b2f9ad40ce46298f04fa175ad468f4caac75c655b8d2c",
+				"DiscoKey":   "discokey:3ac2bc5b59d129134472a9231574fab9e65ae123699c660ead3e1582f7aaf76a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:44975",
+					"10.65.0.27:44975",
+					"172.17.0.1:44975",
+					"172.18.0.1:44975",
+					"172.19.0.1:44975",
+					"172.20.0.1:44975",
+					"172.21.0.1:44975",
+					"172.22.0.1:44975",
+					"172.23.0.1:44975",
+					"172.24.0.1:44975",
+					"172.25.0.1:44975",
+					"172.26.0.1:44975",
+					"172.27.0.1:44975",
+					"172.28.0.1:44975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:10:42.699205128Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3986158479948651,
+				"StableID":   "nGo3vBdL8Y11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:338bee8bcf0c71b8365a88b135045bf456a3203bc5cc32bc9b85f8f7b60e6c59",
+				"DiscoKey":   "discokey:5ab8526604b7b75af0a06970f8c44ca44ed68726e09072b2b1bedc7f6ee5f92f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:36771",
+					"10.65.0.27:36771",
+					"172.17.0.1:36771",
+					"172.18.0.1:36771",
+					"172.19.0.1:36771",
+					"172.20.0.1:36771",
+					"172.21.0.1:36771",
+					"172.22.0.1:36771",
+					"172.23.0.1:36771",
+					"172.24.0.1:36771",
+					"172.25.0.1:36771",
+					"172.26.0.1:36771",
+					"172.27.0.1:36771",
+					"172.28.0.1:36771"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:10:43.226544237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1408740200256286,
+				"StableID":   "nmeZVYD21C11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:386f415fad86f92958f3cb6aa8a62828e388cf7fe68d7810538b9edcd7e6cf6b",
+				"DiscoKey":   "discokey:4d951ab6f3ebad15e794ce3db79649dfd2ef4a6ebba1f02a13acf645de951275",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40763",
+					"10.65.0.27:40763",
+					"172.17.0.1:40763",
+					"172.18.0.1:40763",
+					"172.19.0.1:40763",
+					"172.20.0.1:40763",
+					"172.21.0.1:40763",
+					"172.22.0.1:40763",
+					"172.23.0.1:40763",
+					"172.24.0.1:40763",
+					"172.25.0.1:40763",
+					"172.26.0.1:40763",
+					"172.27.0.1:40763",
+					"172.28.0.1:40763"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:10:43.763271407Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         818116849785060,
+				"StableID":   "nd5MWTYXP711CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e67b072f623a6ef1c4e441868b120b0e1ec414cf7f823bea4dc322b1c73fce22",
+				"DiscoKey":   "discokey:cc20da24fa4f46b0f3d869356a2f86109b821071d7b693fc2a647e3bb14b621c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37614",
+					"10.65.0.27:37614",
+					"172.17.0.1:37614",
+					"172.18.0.1:37614",
+					"172.19.0.1:37614",
+					"172.20.0.1:37614",
+					"172.21.0.1:37614",
+					"172.22.0.1:37614",
+					"172.23.0.1:37614",
+					"172.24.0.1:37614",
+					"172.25.0.1:37614",
+					"172.26.0.1:37614",
+					"172.27.0.1:37614",
+					"172.28.0.1:37614"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:10:44.315391471Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7601664281791600,
+				"StableID":   "ny9XuAqoM221CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aab665ced0d9240215455481aafefc91b37083bd5ed74c63d685170c0f01f772",
+				"DiscoKey":   "discokey:8fb60e9d9e28b607a43712f9d9524c59c615a957632e4d04c61cc2f766b13374",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58032",
+					"10.65.0.27:58032",
+					"172.17.0.1:58032",
+					"172.18.0.1:58032",
+					"172.19.0.1:58032",
+					"172.20.0.1:58032",
+					"172.21.0.1:58032",
+					"172.22.0.1:58032",
+					"172.23.0.1:58032",
+					"172.24.0.1:58032",
+					"172.25.0.1:58032",
+					"172.26.0.1:58032",
+					"172.27.0.1:58032",
+					"172.28.0.1:58032"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:10:44.903245772Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7172045565017533,
+				"StableID":   "ngYj4aUE1y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38597be773f83cca39f3d3930ba96ac7a4fc6db294fcd79dd9ebebbf37d74e66",
+				"DiscoKey":   "discokey:28c74df52a1d4519c59dfd35d9a1e960c8f50d0ce4a645650477ed3755303274",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36824",
+					"10.65.0.27:36824",
+					"172.17.0.1:36824",
+					"172.18.0.1:36824",
+					"172.19.0.1:36824",
+					"172.20.0.1:36824",
+					"172.21.0.1:36824",
+					"172.22.0.1:36824",
+					"172.23.0.1:36824",
+					"172.24.0.1:36824",
+					"172.25.0.1:36824",
+					"172.26.0.1:36824",
+					"172.27.0.1:36824",
+					"172.28.0.1:36824"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:10:45.447822606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2433647541453941,
+				"StableID":   "nYA2c4oC1L11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b90b253e23190ef9ef6573acae3dc180a4d1ce250c7c69ea763e2442f1cecb0e",
+				"DiscoKey":   "discokey:d4cc9bdd1aad555989cbea0d1d633b5a864664a53398fca05ecca6db6435607e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54770",
+					"10.65.0.27:54770",
+					"172.17.0.1:54770",
+					"172.18.0.1:54770",
+					"172.19.0.1:54770",
+					"172.20.0.1:54770",
+					"172.21.0.1:54770",
+					"172.22.0.1:54770",
+					"172.23.0.1:54770",
+					"172.24.0.1:54770",
+					"172.25.0.1:54770",
+					"172.26.0.1:54770",
+					"172.27.0.1:54770",
+					"172.28.0.1:54770"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:10:45.972100392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3094189100749093,
+				"StableID":   "ntGGHr6NAR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8d0eb408279680e87651d8931898596910cdd1a7c4f22bcd863bbca505af331b",
+				"DiscoKey":   "discokey:6e341b9d2ba93faeecfd3765d026ec000dbc206232864eb9a166c80f370bbf6c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55581",
+					"10.65.0.27:55581",
+					"172.17.0.1:55581",
+					"172.18.0.1:55581",
+					"172.19.0.1:55581",
+					"172.20.0.1:55581",
+					"172.21.0.1:55581",
+					"172.22.0.1:55581",
+					"172.23.0.1:55581",
+					"172.24.0.1:55581",
+					"172.25.0.1:55581",
+					"172.26.0.1:55581",
+					"172.27.0.1:55581",
+					"172.28.0.1:55581"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:10:46.514038595Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2114968417180870,
+				"StableID":   "n1k7fmdsWH11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1747722f6f1925a212dd4da8360d7227031d9d0c72954583c099d6e159dfa62",
+				"DiscoKey":   "discokey:192876548845a393fe66a4e34783664cdca8945ec29fc3463b01666c5150e622",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41522",
+					"10.65.0.27:41522",
+					"172.17.0.1:41522",
+					"172.18.0.1:41522",
+					"172.19.0.1:41522",
+					"172.20.0.1:41522",
+					"172.21.0.1:41522",
+					"172.22.0.1:41522",
+					"172.23.0.1:41522",
+					"172.24.0.1:41522",
+					"172.25.0.1:41522",
+					"172.26.0.1:41522",
+					"172.27.0.1:41522",
+					"172.28.0.1:41522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:10:47.048048187Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5879348204137845,
+				"StableID":   "nGkDvSWmun11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:773e9a5b93c7f420db6b0a12ca3367d80e3ab49c455a2a9df40952d5088d7834",
+				"KeyExpiry":  "2026-11-09T09:10:47Z",
+				"DiscoKey":   "discokey:f56b11a2d784e3cd1420750352c8f917d81c6fc40743638a7cb31708a7ff9a15",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35351",
+					"10.65.0.27:35351",
+					"172.17.0.1:35351",
+					"172.18.0.1:35351",
+					"172.19.0.1:35351",
+					"172.20.0.1:35351",
+					"172.21.0.1:35351",
+					"172.22.0.1:35351",
+					"172.23.0.1:35351",
+					"172.24.0.1:35351",
+					"172.25.0.1:35351",
+					"172.26.0.1:35351",
+					"172.27.0.1:35351",
+					"172.28.0.1:35351"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:10:47.592874778Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         68045841626599,
+				"StableID":   "nr4j13TpX111CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:981386a4b363044407a0d6c3cd468912350c9ee19025b55ba27b16b4532d1d16",
+				"KeyExpiry":  "2026-11-09T09:10:48Z",
+				"DiscoKey":   "discokey:eebc56f4dc88d3e5a9600502537d0b83e971a9fe26f3861dff6ee97805139443",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36640",
+					"10.65.0.27:36640",
+					"172.17.0.1:36640",
+					"172.18.0.1:36640",
+					"172.19.0.1:36640",
+					"172.20.0.1:36640",
+					"172.21.0.1:36640",
+					"172.22.0.1:36640",
+					"172.23.0.1:36640",
+					"172.24.0.1:36640",
+					"172.25.0.1:36640",
+					"172.26.0.1:36640",
+					"172.27.0.1:36640",
+					"172.28.0.1:36640"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:10:48.127109399Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6078694782604475,
+				"StableID":   "nrNjRF14Up11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:598464ec9b0c6a7ef22c12f8509ea7214ab175b15b236e84edc6c314a465671e",
+				"KeyExpiry":  "2026-11-09T09:10:48Z",
+				"DiscoKey":   "discokey:22177af5ff136137d2c6a8a5d9edb60e60f6b501632589dc759f9f7383e6ac6f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42180",
+					"10.65.0.27:42180",
+					"172.17.0.1:42180",
+					"172.18.0.1:42180",
+					"172.19.0.1:42180",
+					"172.20.0.1:42180",
+					"172.21.0.1:42180",
+					"172.22.0.1:42180",
+					"172.23.0.1:42180",
+					"172.24.0.1:42180",
+					"172.25.0.1:42180",
+					"172.26.0.1:42180",
+					"172.27.0.1:42180",
+					"172.28.0.1:42180"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:10:48.6705023Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4960289040082096": {
+				"ID":          4960289040082096,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2481161170831544,
+				"StableID":   "nw86L1uiNL11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       2481161170831544,
+				"Key":        "nodekey:fa2e64f9eca2a176a8585cf3f181b1d45f78c3cccf1570600109ae345693b903",
+				"DiscoKey":   "discokey:ea8048c544d4690c11c538c7dff5e923a5bbd7577bf04495426d8fa6de5e1166",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40953",
+					"10.65.0.27:40953",
+					"172.17.0.1:40953",
+					"172.18.0.1:40953",
+					"172.19.0.1:40953",
+					"172.20.0.1:40953",
+					"172.21.0.1:40953",
+					"172.22.0.1:40953",
+					"172.23.0.1:40953",
+					"172.24.0.1:40953",
+					"172.25.0.1:40953",
+					"172.26.0.1:40953",
+					"172.27.0.1:40953",
+					"172.28.0.1:40953"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:10:41.10160613Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:fa2e64f9eca2a176a8585cf3f181b1d45f78c3cccf1570600109ae345693b903",
+			"MachineKey": "mkey:762278106ef1113225ce299bce16745986a379c3031e6e8b512a488e18483624",
+			"Peers": [{
+				"ID":         4960289040082096,
+				"StableID":   "nfQ6m9PXjf11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5aafa1118516e2c189ac90580c021439b584bef643c71781f5e26e5f1c3a112d",
+				"DiscoKey":   "discokey:6c9266c97130bffe5ae0461594c233724a666f8b09c18ece2cab2a980d70af55",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51611",
+					"10.65.0.27:51611",
+					"172.17.0.1:51611",
+					"172.18.0.1:51611",
+					"172.19.0.1:51611",
+					"172.20.0.1:51611",
+					"172.21.0.1:51611",
+					"172.22.0.1:51611",
+					"172.23.0.1:51611",
+					"172.24.0.1:51611",
+					"172.25.0.1:51611",
+					"172.26.0.1:51611",
+					"172.27.0.1:51611",
+					"172.28.0.1:51611"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:10:41.641446003Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7768084567289187,
+				"StableID":   "nku1fjQBf321CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c03e907c0eaceaaf345e13c7a81f4f3ad52eadc4f8a3e3ac8fcf7e625426dc2e",
+				"DiscoKey":   "discokey:efac546518cac262a451f53fd59a6058165767869355102704d32dede0b98c0d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:48773",
+					"10.65.0.27:48773",
+					"172.17.0.1:48773",
+					"172.18.0.1:48773",
+					"172.19.0.1:48773",
+					"172.20.0.1:48773",
+					"172.21.0.1:48773",
+					"172.22.0.1:48773",
+					"172.23.0.1:48773",
+					"172.24.0.1:48773",
+					"172.25.0.1:48773",
+					"172.26.0.1:48773",
+					"172.27.0.1:48773",
+					"172.28.0.1:48773"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:10:42.165454589Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3195380828706430,
+				"StableID":   "nZ8PmgECxR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26aa4590e7409841077b2f9ad40ce46298f04fa175ad468f4caac75c655b8d2c",
+				"DiscoKey":   "discokey:3ac2bc5b59d129134472a9231574fab9e65ae123699c660ead3e1582f7aaf76a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:44975",
+					"10.65.0.27:44975",
+					"172.17.0.1:44975",
+					"172.18.0.1:44975",
+					"172.19.0.1:44975",
+					"172.20.0.1:44975",
+					"172.21.0.1:44975",
+					"172.22.0.1:44975",
+					"172.23.0.1:44975",
+					"172.24.0.1:44975",
+					"172.25.0.1:44975",
+					"172.26.0.1:44975",
+					"172.27.0.1:44975",
+					"172.28.0.1:44975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:10:42.699205128Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3986158479948651,
+				"StableID":   "nGo3vBdL8Y11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:338bee8bcf0c71b8365a88b135045bf456a3203bc5cc32bc9b85f8f7b60e6c59",
+				"DiscoKey":   "discokey:5ab8526604b7b75af0a06970f8c44ca44ed68726e09072b2b1bedc7f6ee5f92f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:36771",
+					"10.65.0.27:36771",
+					"172.17.0.1:36771",
+					"172.18.0.1:36771",
+					"172.19.0.1:36771",
+					"172.20.0.1:36771",
+					"172.21.0.1:36771",
+					"172.22.0.1:36771",
+					"172.23.0.1:36771",
+					"172.24.0.1:36771",
+					"172.25.0.1:36771",
+					"172.26.0.1:36771",
+					"172.27.0.1:36771",
+					"172.28.0.1:36771"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:10:43.226544237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1408740200256286,
+				"StableID":   "nmeZVYD21C11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:386f415fad86f92958f3cb6aa8a62828e388cf7fe68d7810538b9edcd7e6cf6b",
+				"DiscoKey":   "discokey:4d951ab6f3ebad15e794ce3db79649dfd2ef4a6ebba1f02a13acf645de951275",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40763",
+					"10.65.0.27:40763",
+					"172.17.0.1:40763",
+					"172.18.0.1:40763",
+					"172.19.0.1:40763",
+					"172.20.0.1:40763",
+					"172.21.0.1:40763",
+					"172.22.0.1:40763",
+					"172.23.0.1:40763",
+					"172.24.0.1:40763",
+					"172.25.0.1:40763",
+					"172.26.0.1:40763",
+					"172.27.0.1:40763",
+					"172.28.0.1:40763"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:10:43.763271407Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         818116849785060,
+				"StableID":   "nd5MWTYXP711CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e67b072f623a6ef1c4e441868b120b0e1ec414cf7f823bea4dc322b1c73fce22",
+				"DiscoKey":   "discokey:cc20da24fa4f46b0f3d869356a2f86109b821071d7b693fc2a647e3bb14b621c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37614",
+					"10.65.0.27:37614",
+					"172.17.0.1:37614",
+					"172.18.0.1:37614",
+					"172.19.0.1:37614",
+					"172.20.0.1:37614",
+					"172.21.0.1:37614",
+					"172.22.0.1:37614",
+					"172.23.0.1:37614",
+					"172.24.0.1:37614",
+					"172.25.0.1:37614",
+					"172.26.0.1:37614",
+					"172.27.0.1:37614",
+					"172.28.0.1:37614"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:10:44.315391471Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7601664281791600,
+				"StableID":   "ny9XuAqoM221CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aab665ced0d9240215455481aafefc91b37083bd5ed74c63d685170c0f01f772",
+				"DiscoKey":   "discokey:8fb60e9d9e28b607a43712f9d9524c59c615a957632e4d04c61cc2f766b13374",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58032",
+					"10.65.0.27:58032",
+					"172.17.0.1:58032",
+					"172.18.0.1:58032",
+					"172.19.0.1:58032",
+					"172.20.0.1:58032",
+					"172.21.0.1:58032",
+					"172.22.0.1:58032",
+					"172.23.0.1:58032",
+					"172.24.0.1:58032",
+					"172.25.0.1:58032",
+					"172.26.0.1:58032",
+					"172.27.0.1:58032",
+					"172.28.0.1:58032"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:10:44.903245772Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7172045565017533,
+				"StableID":   "ngYj4aUE1y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38597be773f83cca39f3d3930ba96ac7a4fc6db294fcd79dd9ebebbf37d74e66",
+				"DiscoKey":   "discokey:28c74df52a1d4519c59dfd35d9a1e960c8f50d0ce4a645650477ed3755303274",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36824",
+					"10.65.0.27:36824",
+					"172.17.0.1:36824",
+					"172.18.0.1:36824",
+					"172.19.0.1:36824",
+					"172.20.0.1:36824",
+					"172.21.0.1:36824",
+					"172.22.0.1:36824",
+					"172.23.0.1:36824",
+					"172.24.0.1:36824",
+					"172.25.0.1:36824",
+					"172.26.0.1:36824",
+					"172.27.0.1:36824",
+					"172.28.0.1:36824"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:10:45.447822606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2433647541453941,
+				"StableID":   "nYA2c4oC1L11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b90b253e23190ef9ef6573acae3dc180a4d1ce250c7c69ea763e2442f1cecb0e",
+				"DiscoKey":   "discokey:d4cc9bdd1aad555989cbea0d1d633b5a864664a53398fca05ecca6db6435607e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54770",
+					"10.65.0.27:54770",
+					"172.17.0.1:54770",
+					"172.18.0.1:54770",
+					"172.19.0.1:54770",
+					"172.20.0.1:54770",
+					"172.21.0.1:54770",
+					"172.22.0.1:54770",
+					"172.23.0.1:54770",
+					"172.24.0.1:54770",
+					"172.25.0.1:54770",
+					"172.26.0.1:54770",
+					"172.27.0.1:54770",
+					"172.28.0.1:54770"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:10:45.972100392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3094189100749093,
+				"StableID":   "ntGGHr6NAR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8d0eb408279680e87651d8931898596910cdd1a7c4f22bcd863bbca505af331b",
+				"DiscoKey":   "discokey:6e341b9d2ba93faeecfd3765d026ec000dbc206232864eb9a166c80f370bbf6c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55581",
+					"10.65.0.27:55581",
+					"172.17.0.1:55581",
+					"172.18.0.1:55581",
+					"172.19.0.1:55581",
+					"172.20.0.1:55581",
+					"172.21.0.1:55581",
+					"172.22.0.1:55581",
+					"172.23.0.1:55581",
+					"172.24.0.1:55581",
+					"172.25.0.1:55581",
+					"172.26.0.1:55581",
+					"172.27.0.1:55581",
+					"172.28.0.1:55581"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:10:46.514038595Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2114968417180870,
+				"StableID":   "n1k7fmdsWH11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1747722f6f1925a212dd4da8360d7227031d9d0c72954583c099d6e159dfa62",
+				"DiscoKey":   "discokey:192876548845a393fe66a4e34783664cdca8945ec29fc3463b01666c5150e622",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41522",
+					"10.65.0.27:41522",
+					"172.17.0.1:41522",
+					"172.18.0.1:41522",
+					"172.19.0.1:41522",
+					"172.20.0.1:41522",
+					"172.21.0.1:41522",
+					"172.22.0.1:41522",
+					"172.23.0.1:41522",
+					"172.24.0.1:41522",
+					"172.25.0.1:41522",
+					"172.26.0.1:41522",
+					"172.27.0.1:41522",
+					"172.28.0.1:41522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:10:47.048048187Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5879348204137845,
+				"StableID":   "nGkDvSWmun11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:773e9a5b93c7f420db6b0a12ca3367d80e3ab49c455a2a9df40952d5088d7834",
+				"KeyExpiry":  "2026-11-09T09:10:47Z",
+				"DiscoKey":   "discokey:f56b11a2d784e3cd1420750352c8f917d81c6fc40743638a7cb31708a7ff9a15",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35351",
+					"10.65.0.27:35351",
+					"172.17.0.1:35351",
+					"172.18.0.1:35351",
+					"172.19.0.1:35351",
+					"172.20.0.1:35351",
+					"172.21.0.1:35351",
+					"172.22.0.1:35351",
+					"172.23.0.1:35351",
+					"172.24.0.1:35351",
+					"172.25.0.1:35351",
+					"172.26.0.1:35351",
+					"172.27.0.1:35351",
+					"172.28.0.1:35351"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:10:47.592874778Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         68045841626599,
+				"StableID":   "nr4j13TpX111CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:981386a4b363044407a0d6c3cd468912350c9ee19025b55ba27b16b4532d1d16",
+				"KeyExpiry":  "2026-11-09T09:10:48Z",
+				"DiscoKey":   "discokey:eebc56f4dc88d3e5a9600502537d0b83e971a9fe26f3861dff6ee97805139443",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36640",
+					"10.65.0.27:36640",
+					"172.17.0.1:36640",
+					"172.18.0.1:36640",
+					"172.19.0.1:36640",
+					"172.20.0.1:36640",
+					"172.21.0.1:36640",
+					"172.22.0.1:36640",
+					"172.23.0.1:36640",
+					"172.24.0.1:36640",
+					"172.25.0.1:36640",
+					"172.26.0.1:36640",
+					"172.27.0.1:36640",
+					"172.28.0.1:36640"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:10:48.127109399Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6078694782604475,
+				"StableID":   "nrNjRF14Up11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:598464ec9b0c6a7ef22c12f8509ea7214ab175b15b236e84edc6c314a465671e",
+				"KeyExpiry":  "2026-11-09T09:10:48Z",
+				"DiscoKey":   "discokey:22177af5ff136137d2c6a8a5d9edb60e60f6b501632589dc759f9f7383e6ac6f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42180",
+					"10.65.0.27:42180",
+					"172.17.0.1:42180",
+					"172.18.0.1:42180",
+					"172.19.0.1:42180",
+					"172.20.0.1:42180",
+					"172.21.0.1:42180",
+					"172.22.0.1:42180",
+					"172.23.0.1:42180",
+					"172.24.0.1:42180",
+					"172.25.0.1:42180",
+					"172.26.0.1:42180",
+					"172.27.0.1:42180",
+					"172.28.0.1:42180"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:10:48.6705023Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2481161170831544": {
+				"ID":          2481161170831544,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3986158479948651,
+				"StableID":   "nGo3vBdL8Y11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       3986158479948651,
+				"Key":        "nodekey:338bee8bcf0c71b8365a88b135045bf456a3203bc5cc32bc9b85f8f7b60e6c59",
+				"DiscoKey":   "discokey:5ab8526604b7b75af0a06970f8c44ca44ed68726e09072b2b1bedc7f6ee5f92f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:36771",
+					"10.65.0.27:36771",
+					"172.17.0.1:36771",
+					"172.18.0.1:36771",
+					"172.19.0.1:36771",
+					"172.20.0.1:36771",
+					"172.21.0.1:36771",
+					"172.22.0.1:36771",
+					"172.23.0.1:36771",
+					"172.24.0.1:36771",
+					"172.25.0.1:36771",
+					"172.26.0.1:36771",
+					"172.27.0.1:36771",
+					"172.28.0.1:36771"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:10:43.226544237Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:338bee8bcf0c71b8365a88b135045bf456a3203bc5cc32bc9b85f8f7b60e6c59",
+			"MachineKey": "mkey:802518cef7026579f0a2fa80bdaeedc6b22d7a0429fcbe287a9f415b4be0e579",
+			"Peers": [{
+				"ID":         2481161170831544,
+				"StableID":   "nw86L1uiNL11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fa2e64f9eca2a176a8585cf3f181b1d45f78c3cccf1570600109ae345693b903",
+				"DiscoKey":   "discokey:ea8048c544d4690c11c538c7dff5e923a5bbd7577bf04495426d8fa6de5e1166",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40953",
+					"10.65.0.27:40953",
+					"172.17.0.1:40953",
+					"172.18.0.1:40953",
+					"172.19.0.1:40953",
+					"172.20.0.1:40953",
+					"172.21.0.1:40953",
+					"172.22.0.1:40953",
+					"172.23.0.1:40953",
+					"172.24.0.1:40953",
+					"172.25.0.1:40953",
+					"172.26.0.1:40953",
+					"172.27.0.1:40953",
+					"172.28.0.1:40953"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:10:41.10160613Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4960289040082096,
+				"StableID":   "nfQ6m9PXjf11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5aafa1118516e2c189ac90580c021439b584bef643c71781f5e26e5f1c3a112d",
+				"DiscoKey":   "discokey:6c9266c97130bffe5ae0461594c233724a666f8b09c18ece2cab2a980d70af55",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51611",
+					"10.65.0.27:51611",
+					"172.17.0.1:51611",
+					"172.18.0.1:51611",
+					"172.19.0.1:51611",
+					"172.20.0.1:51611",
+					"172.21.0.1:51611",
+					"172.22.0.1:51611",
+					"172.23.0.1:51611",
+					"172.24.0.1:51611",
+					"172.25.0.1:51611",
+					"172.26.0.1:51611",
+					"172.27.0.1:51611",
+					"172.28.0.1:51611"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:10:41.641446003Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7768084567289187,
+				"StableID":   "nku1fjQBf321CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c03e907c0eaceaaf345e13c7a81f4f3ad52eadc4f8a3e3ac8fcf7e625426dc2e",
+				"DiscoKey":   "discokey:efac546518cac262a451f53fd59a6058165767869355102704d32dede0b98c0d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:48773",
+					"10.65.0.27:48773",
+					"172.17.0.1:48773",
+					"172.18.0.1:48773",
+					"172.19.0.1:48773",
+					"172.20.0.1:48773",
+					"172.21.0.1:48773",
+					"172.22.0.1:48773",
+					"172.23.0.1:48773",
+					"172.24.0.1:48773",
+					"172.25.0.1:48773",
+					"172.26.0.1:48773",
+					"172.27.0.1:48773",
+					"172.28.0.1:48773"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:10:42.165454589Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3195380828706430,
+				"StableID":   "nZ8PmgECxR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26aa4590e7409841077b2f9ad40ce46298f04fa175ad468f4caac75c655b8d2c",
+				"DiscoKey":   "discokey:3ac2bc5b59d129134472a9231574fab9e65ae123699c660ead3e1582f7aaf76a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:44975",
+					"10.65.0.27:44975",
+					"172.17.0.1:44975",
+					"172.18.0.1:44975",
+					"172.19.0.1:44975",
+					"172.20.0.1:44975",
+					"172.21.0.1:44975",
+					"172.22.0.1:44975",
+					"172.23.0.1:44975",
+					"172.24.0.1:44975",
+					"172.25.0.1:44975",
+					"172.26.0.1:44975",
+					"172.27.0.1:44975",
+					"172.28.0.1:44975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:10:42.699205128Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1408740200256286,
+				"StableID":   "nmeZVYD21C11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:386f415fad86f92958f3cb6aa8a62828e388cf7fe68d7810538b9edcd7e6cf6b",
+				"DiscoKey":   "discokey:4d951ab6f3ebad15e794ce3db79649dfd2ef4a6ebba1f02a13acf645de951275",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40763",
+					"10.65.0.27:40763",
+					"172.17.0.1:40763",
+					"172.18.0.1:40763",
+					"172.19.0.1:40763",
+					"172.20.0.1:40763",
+					"172.21.0.1:40763",
+					"172.22.0.1:40763",
+					"172.23.0.1:40763",
+					"172.24.0.1:40763",
+					"172.25.0.1:40763",
+					"172.26.0.1:40763",
+					"172.27.0.1:40763",
+					"172.28.0.1:40763"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:10:43.763271407Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         818116849785060,
+				"StableID":   "nd5MWTYXP711CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e67b072f623a6ef1c4e441868b120b0e1ec414cf7f823bea4dc322b1c73fce22",
+				"DiscoKey":   "discokey:cc20da24fa4f46b0f3d869356a2f86109b821071d7b693fc2a647e3bb14b621c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37614",
+					"10.65.0.27:37614",
+					"172.17.0.1:37614",
+					"172.18.0.1:37614",
+					"172.19.0.1:37614",
+					"172.20.0.1:37614",
+					"172.21.0.1:37614",
+					"172.22.0.1:37614",
+					"172.23.0.1:37614",
+					"172.24.0.1:37614",
+					"172.25.0.1:37614",
+					"172.26.0.1:37614",
+					"172.27.0.1:37614",
+					"172.28.0.1:37614"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:10:44.315391471Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7601664281791600,
+				"StableID":   "ny9XuAqoM221CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aab665ced0d9240215455481aafefc91b37083bd5ed74c63d685170c0f01f772",
+				"DiscoKey":   "discokey:8fb60e9d9e28b607a43712f9d9524c59c615a957632e4d04c61cc2f766b13374",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58032",
+					"10.65.0.27:58032",
+					"172.17.0.1:58032",
+					"172.18.0.1:58032",
+					"172.19.0.1:58032",
+					"172.20.0.1:58032",
+					"172.21.0.1:58032",
+					"172.22.0.1:58032",
+					"172.23.0.1:58032",
+					"172.24.0.1:58032",
+					"172.25.0.1:58032",
+					"172.26.0.1:58032",
+					"172.27.0.1:58032",
+					"172.28.0.1:58032"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:10:44.903245772Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7172045565017533,
+				"StableID":   "ngYj4aUE1y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38597be773f83cca39f3d3930ba96ac7a4fc6db294fcd79dd9ebebbf37d74e66",
+				"DiscoKey":   "discokey:28c74df52a1d4519c59dfd35d9a1e960c8f50d0ce4a645650477ed3755303274",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36824",
+					"10.65.0.27:36824",
+					"172.17.0.1:36824",
+					"172.18.0.1:36824",
+					"172.19.0.1:36824",
+					"172.20.0.1:36824",
+					"172.21.0.1:36824",
+					"172.22.0.1:36824",
+					"172.23.0.1:36824",
+					"172.24.0.1:36824",
+					"172.25.0.1:36824",
+					"172.26.0.1:36824",
+					"172.27.0.1:36824",
+					"172.28.0.1:36824"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:10:45.447822606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2433647541453941,
+				"StableID":   "nYA2c4oC1L11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b90b253e23190ef9ef6573acae3dc180a4d1ce250c7c69ea763e2442f1cecb0e",
+				"DiscoKey":   "discokey:d4cc9bdd1aad555989cbea0d1d633b5a864664a53398fca05ecca6db6435607e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54770",
+					"10.65.0.27:54770",
+					"172.17.0.1:54770",
+					"172.18.0.1:54770",
+					"172.19.0.1:54770",
+					"172.20.0.1:54770",
+					"172.21.0.1:54770",
+					"172.22.0.1:54770",
+					"172.23.0.1:54770",
+					"172.24.0.1:54770",
+					"172.25.0.1:54770",
+					"172.26.0.1:54770",
+					"172.27.0.1:54770",
+					"172.28.0.1:54770"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:10:45.972100392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3094189100749093,
+				"StableID":   "ntGGHr6NAR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8d0eb408279680e87651d8931898596910cdd1a7c4f22bcd863bbca505af331b",
+				"DiscoKey":   "discokey:6e341b9d2ba93faeecfd3765d026ec000dbc206232864eb9a166c80f370bbf6c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55581",
+					"10.65.0.27:55581",
+					"172.17.0.1:55581",
+					"172.18.0.1:55581",
+					"172.19.0.1:55581",
+					"172.20.0.1:55581",
+					"172.21.0.1:55581",
+					"172.22.0.1:55581",
+					"172.23.0.1:55581",
+					"172.24.0.1:55581",
+					"172.25.0.1:55581",
+					"172.26.0.1:55581",
+					"172.27.0.1:55581",
+					"172.28.0.1:55581"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:10:46.514038595Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2114968417180870,
+				"StableID":   "n1k7fmdsWH11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1747722f6f1925a212dd4da8360d7227031d9d0c72954583c099d6e159dfa62",
+				"DiscoKey":   "discokey:192876548845a393fe66a4e34783664cdca8945ec29fc3463b01666c5150e622",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41522",
+					"10.65.0.27:41522",
+					"172.17.0.1:41522",
+					"172.18.0.1:41522",
+					"172.19.0.1:41522",
+					"172.20.0.1:41522",
+					"172.21.0.1:41522",
+					"172.22.0.1:41522",
+					"172.23.0.1:41522",
+					"172.24.0.1:41522",
+					"172.25.0.1:41522",
+					"172.26.0.1:41522",
+					"172.27.0.1:41522",
+					"172.28.0.1:41522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:10:47.048048187Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5879348204137845,
+				"StableID":   "nGkDvSWmun11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:773e9a5b93c7f420db6b0a12ca3367d80e3ab49c455a2a9df40952d5088d7834",
+				"KeyExpiry":  "2026-11-09T09:10:47Z",
+				"DiscoKey":   "discokey:f56b11a2d784e3cd1420750352c8f917d81c6fc40743638a7cb31708a7ff9a15",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35351",
+					"10.65.0.27:35351",
+					"172.17.0.1:35351",
+					"172.18.0.1:35351",
+					"172.19.0.1:35351",
+					"172.20.0.1:35351",
+					"172.21.0.1:35351",
+					"172.22.0.1:35351",
+					"172.23.0.1:35351",
+					"172.24.0.1:35351",
+					"172.25.0.1:35351",
+					"172.26.0.1:35351",
+					"172.27.0.1:35351",
+					"172.28.0.1:35351"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:10:47.592874778Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         68045841626599,
+				"StableID":   "nr4j13TpX111CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:981386a4b363044407a0d6c3cd468912350c9ee19025b55ba27b16b4532d1d16",
+				"KeyExpiry":  "2026-11-09T09:10:48Z",
+				"DiscoKey":   "discokey:eebc56f4dc88d3e5a9600502537d0b83e971a9fe26f3861dff6ee97805139443",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36640",
+					"10.65.0.27:36640",
+					"172.17.0.1:36640",
+					"172.18.0.1:36640",
+					"172.19.0.1:36640",
+					"172.20.0.1:36640",
+					"172.21.0.1:36640",
+					"172.22.0.1:36640",
+					"172.23.0.1:36640",
+					"172.24.0.1:36640",
+					"172.25.0.1:36640",
+					"172.26.0.1:36640",
+					"172.27.0.1:36640",
+					"172.28.0.1:36640"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:10:48.127109399Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6078694782604475,
+				"StableID":   "nrNjRF14Up11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:598464ec9b0c6a7ef22c12f8509ea7214ab175b15b236e84edc6c314a465671e",
+				"KeyExpiry":  "2026-11-09T09:10:48Z",
+				"DiscoKey":   "discokey:22177af5ff136137d2c6a8a5d9edb60e60f6b501632589dc759f9f7383e6ac6f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42180",
+					"10.65.0.27:42180",
+					"172.17.0.1:42180",
+					"172.18.0.1:42180",
+					"172.19.0.1:42180",
+					"172.20.0.1:42180",
+					"172.21.0.1:42180",
+					"172.22.0.1:42180",
+					"172.23.0.1:42180",
+					"172.24.0.1:42180",
+					"172.25.0.1:42180",
+					"172.26.0.1:42180",
+					"172.27.0.1:42180",
+					"172.28.0.1:42180"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:10:48.6705023Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "3986158479948651": {
+				"ID":          3986158479948651,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3195380828706430,
+				"StableID":   "nZ8PmgECxR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       3195380828706430,
+				"Key":        "nodekey:26aa4590e7409841077b2f9ad40ce46298f04fa175ad468f4caac75c655b8d2c",
+				"DiscoKey":   "discokey:3ac2bc5b59d129134472a9231574fab9e65ae123699c660ead3e1582f7aaf76a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:44975",
+					"10.65.0.27:44975",
+					"172.17.0.1:44975",
+					"172.18.0.1:44975",
+					"172.19.0.1:44975",
+					"172.20.0.1:44975",
+					"172.21.0.1:44975",
+					"172.22.0.1:44975",
+					"172.23.0.1:44975",
+					"172.24.0.1:44975",
+					"172.25.0.1:44975",
+					"172.26.0.1:44975",
+					"172.27.0.1:44975",
+					"172.28.0.1:44975"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:10:42.699205128Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:26aa4590e7409841077b2f9ad40ce46298f04fa175ad468f4caac75c655b8d2c",
+			"MachineKey": "mkey:78a0785bffcee199aca57249aa81cd228e872bf92a144012fb10375b3258926a",
+			"Peers": [{
+				"ID":         2481161170831544,
+				"StableID":   "nw86L1uiNL11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fa2e64f9eca2a176a8585cf3f181b1d45f78c3cccf1570600109ae345693b903",
+				"DiscoKey":   "discokey:ea8048c544d4690c11c538c7dff5e923a5bbd7577bf04495426d8fa6de5e1166",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40953",
+					"10.65.0.27:40953",
+					"172.17.0.1:40953",
+					"172.18.0.1:40953",
+					"172.19.0.1:40953",
+					"172.20.0.1:40953",
+					"172.21.0.1:40953",
+					"172.22.0.1:40953",
+					"172.23.0.1:40953",
+					"172.24.0.1:40953",
+					"172.25.0.1:40953",
+					"172.26.0.1:40953",
+					"172.27.0.1:40953",
+					"172.28.0.1:40953"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:10:41.10160613Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4960289040082096,
+				"StableID":   "nfQ6m9PXjf11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5aafa1118516e2c189ac90580c021439b584bef643c71781f5e26e5f1c3a112d",
+				"DiscoKey":   "discokey:6c9266c97130bffe5ae0461594c233724a666f8b09c18ece2cab2a980d70af55",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51611",
+					"10.65.0.27:51611",
+					"172.17.0.1:51611",
+					"172.18.0.1:51611",
+					"172.19.0.1:51611",
+					"172.20.0.1:51611",
+					"172.21.0.1:51611",
+					"172.22.0.1:51611",
+					"172.23.0.1:51611",
+					"172.24.0.1:51611",
+					"172.25.0.1:51611",
+					"172.26.0.1:51611",
+					"172.27.0.1:51611",
+					"172.28.0.1:51611"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:10:41.641446003Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7768084567289187,
+				"StableID":   "nku1fjQBf321CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c03e907c0eaceaaf345e13c7a81f4f3ad52eadc4f8a3e3ac8fcf7e625426dc2e",
+				"DiscoKey":   "discokey:efac546518cac262a451f53fd59a6058165767869355102704d32dede0b98c0d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:48773",
+					"10.65.0.27:48773",
+					"172.17.0.1:48773",
+					"172.18.0.1:48773",
+					"172.19.0.1:48773",
+					"172.20.0.1:48773",
+					"172.21.0.1:48773",
+					"172.22.0.1:48773",
+					"172.23.0.1:48773",
+					"172.24.0.1:48773",
+					"172.25.0.1:48773",
+					"172.26.0.1:48773",
+					"172.27.0.1:48773",
+					"172.28.0.1:48773"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:10:42.165454589Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3986158479948651,
+				"StableID":   "nGo3vBdL8Y11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:338bee8bcf0c71b8365a88b135045bf456a3203bc5cc32bc9b85f8f7b60e6c59",
+				"DiscoKey":   "discokey:5ab8526604b7b75af0a06970f8c44ca44ed68726e09072b2b1bedc7f6ee5f92f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:36771",
+					"10.65.0.27:36771",
+					"172.17.0.1:36771",
+					"172.18.0.1:36771",
+					"172.19.0.1:36771",
+					"172.20.0.1:36771",
+					"172.21.0.1:36771",
+					"172.22.0.1:36771",
+					"172.23.0.1:36771",
+					"172.24.0.1:36771",
+					"172.25.0.1:36771",
+					"172.26.0.1:36771",
+					"172.27.0.1:36771",
+					"172.28.0.1:36771"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:10:43.226544237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1408740200256286,
+				"StableID":   "nmeZVYD21C11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:386f415fad86f92958f3cb6aa8a62828e388cf7fe68d7810538b9edcd7e6cf6b",
+				"DiscoKey":   "discokey:4d951ab6f3ebad15e794ce3db79649dfd2ef4a6ebba1f02a13acf645de951275",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40763",
+					"10.65.0.27:40763",
+					"172.17.0.1:40763",
+					"172.18.0.1:40763",
+					"172.19.0.1:40763",
+					"172.20.0.1:40763",
+					"172.21.0.1:40763",
+					"172.22.0.1:40763",
+					"172.23.0.1:40763",
+					"172.24.0.1:40763",
+					"172.25.0.1:40763",
+					"172.26.0.1:40763",
+					"172.27.0.1:40763",
+					"172.28.0.1:40763"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:10:43.763271407Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         818116849785060,
+				"StableID":   "nd5MWTYXP711CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e67b072f623a6ef1c4e441868b120b0e1ec414cf7f823bea4dc322b1c73fce22",
+				"DiscoKey":   "discokey:cc20da24fa4f46b0f3d869356a2f86109b821071d7b693fc2a647e3bb14b621c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37614",
+					"10.65.0.27:37614",
+					"172.17.0.1:37614",
+					"172.18.0.1:37614",
+					"172.19.0.1:37614",
+					"172.20.0.1:37614",
+					"172.21.0.1:37614",
+					"172.22.0.1:37614",
+					"172.23.0.1:37614",
+					"172.24.0.1:37614",
+					"172.25.0.1:37614",
+					"172.26.0.1:37614",
+					"172.27.0.1:37614",
+					"172.28.0.1:37614"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:10:44.315391471Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7601664281791600,
+				"StableID":   "ny9XuAqoM221CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aab665ced0d9240215455481aafefc91b37083bd5ed74c63d685170c0f01f772",
+				"DiscoKey":   "discokey:8fb60e9d9e28b607a43712f9d9524c59c615a957632e4d04c61cc2f766b13374",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58032",
+					"10.65.0.27:58032",
+					"172.17.0.1:58032",
+					"172.18.0.1:58032",
+					"172.19.0.1:58032",
+					"172.20.0.1:58032",
+					"172.21.0.1:58032",
+					"172.22.0.1:58032",
+					"172.23.0.1:58032",
+					"172.24.0.1:58032",
+					"172.25.0.1:58032",
+					"172.26.0.1:58032",
+					"172.27.0.1:58032",
+					"172.28.0.1:58032"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:10:44.903245772Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7172045565017533,
+				"StableID":   "ngYj4aUE1y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38597be773f83cca39f3d3930ba96ac7a4fc6db294fcd79dd9ebebbf37d74e66",
+				"DiscoKey":   "discokey:28c74df52a1d4519c59dfd35d9a1e960c8f50d0ce4a645650477ed3755303274",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36824",
+					"10.65.0.27:36824",
+					"172.17.0.1:36824",
+					"172.18.0.1:36824",
+					"172.19.0.1:36824",
+					"172.20.0.1:36824",
+					"172.21.0.1:36824",
+					"172.22.0.1:36824",
+					"172.23.0.1:36824",
+					"172.24.0.1:36824",
+					"172.25.0.1:36824",
+					"172.26.0.1:36824",
+					"172.27.0.1:36824",
+					"172.28.0.1:36824"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:10:45.447822606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2433647541453941,
+				"StableID":   "nYA2c4oC1L11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b90b253e23190ef9ef6573acae3dc180a4d1ce250c7c69ea763e2442f1cecb0e",
+				"DiscoKey":   "discokey:d4cc9bdd1aad555989cbea0d1d633b5a864664a53398fca05ecca6db6435607e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54770",
+					"10.65.0.27:54770",
+					"172.17.0.1:54770",
+					"172.18.0.1:54770",
+					"172.19.0.1:54770",
+					"172.20.0.1:54770",
+					"172.21.0.1:54770",
+					"172.22.0.1:54770",
+					"172.23.0.1:54770",
+					"172.24.0.1:54770",
+					"172.25.0.1:54770",
+					"172.26.0.1:54770",
+					"172.27.0.1:54770",
+					"172.28.0.1:54770"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:10:45.972100392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3094189100749093,
+				"StableID":   "ntGGHr6NAR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8d0eb408279680e87651d8931898596910cdd1a7c4f22bcd863bbca505af331b",
+				"DiscoKey":   "discokey:6e341b9d2ba93faeecfd3765d026ec000dbc206232864eb9a166c80f370bbf6c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55581",
+					"10.65.0.27:55581",
+					"172.17.0.1:55581",
+					"172.18.0.1:55581",
+					"172.19.0.1:55581",
+					"172.20.0.1:55581",
+					"172.21.0.1:55581",
+					"172.22.0.1:55581",
+					"172.23.0.1:55581",
+					"172.24.0.1:55581",
+					"172.25.0.1:55581",
+					"172.26.0.1:55581",
+					"172.27.0.1:55581",
+					"172.28.0.1:55581"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:10:46.514038595Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2114968417180870,
+				"StableID":   "n1k7fmdsWH11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1747722f6f1925a212dd4da8360d7227031d9d0c72954583c099d6e159dfa62",
+				"DiscoKey":   "discokey:192876548845a393fe66a4e34783664cdca8945ec29fc3463b01666c5150e622",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41522",
+					"10.65.0.27:41522",
+					"172.17.0.1:41522",
+					"172.18.0.1:41522",
+					"172.19.0.1:41522",
+					"172.20.0.1:41522",
+					"172.21.0.1:41522",
+					"172.22.0.1:41522",
+					"172.23.0.1:41522",
+					"172.24.0.1:41522",
+					"172.25.0.1:41522",
+					"172.26.0.1:41522",
+					"172.27.0.1:41522",
+					"172.28.0.1:41522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:10:47.048048187Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5879348204137845,
+				"StableID":   "nGkDvSWmun11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:773e9a5b93c7f420db6b0a12ca3367d80e3ab49c455a2a9df40952d5088d7834",
+				"KeyExpiry":  "2026-11-09T09:10:47Z",
+				"DiscoKey":   "discokey:f56b11a2d784e3cd1420750352c8f917d81c6fc40743638a7cb31708a7ff9a15",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35351",
+					"10.65.0.27:35351",
+					"172.17.0.1:35351",
+					"172.18.0.1:35351",
+					"172.19.0.1:35351",
+					"172.20.0.1:35351",
+					"172.21.0.1:35351",
+					"172.22.0.1:35351",
+					"172.23.0.1:35351",
+					"172.24.0.1:35351",
+					"172.25.0.1:35351",
+					"172.26.0.1:35351",
+					"172.27.0.1:35351",
+					"172.28.0.1:35351"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:10:47.592874778Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         68045841626599,
+				"StableID":   "nr4j13TpX111CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:981386a4b363044407a0d6c3cd468912350c9ee19025b55ba27b16b4532d1d16",
+				"KeyExpiry":  "2026-11-09T09:10:48Z",
+				"DiscoKey":   "discokey:eebc56f4dc88d3e5a9600502537d0b83e971a9fe26f3861dff6ee97805139443",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36640",
+					"10.65.0.27:36640",
+					"172.17.0.1:36640",
+					"172.18.0.1:36640",
+					"172.19.0.1:36640",
+					"172.20.0.1:36640",
+					"172.21.0.1:36640",
+					"172.22.0.1:36640",
+					"172.23.0.1:36640",
+					"172.24.0.1:36640",
+					"172.25.0.1:36640",
+					"172.26.0.1:36640",
+					"172.27.0.1:36640",
+					"172.28.0.1:36640"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:10:48.127109399Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6078694782604475,
+				"StableID":   "nrNjRF14Up11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:598464ec9b0c6a7ef22c12f8509ea7214ab175b15b236e84edc6c314a465671e",
+				"KeyExpiry":  "2026-11-09T09:10:48Z",
+				"DiscoKey":   "discokey:22177af5ff136137d2c6a8a5d9edb60e60f6b501632589dc759f9f7383e6ac6f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42180",
+					"10.65.0.27:42180",
+					"172.17.0.1:42180",
+					"172.18.0.1:42180",
+					"172.19.0.1:42180",
+					"172.20.0.1:42180",
+					"172.21.0.1:42180",
+					"172.22.0.1:42180",
+					"172.23.0.1:42180",
+					"172.24.0.1:42180",
+					"172.25.0.1:42180",
+					"172.26.0.1:42180",
+					"172.27.0.1:42180",
+					"172.28.0.1:42180"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:10:48.6705023Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3195380828706430": {
+				"ID":          3195380828706430,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         818116849785060,
+				"StableID":   "nd5MWTYXP711CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       818116849785060,
+				"Key":        "nodekey:e67b072f623a6ef1c4e441868b120b0e1ec414cf7f823bea4dc322b1c73fce22",
+				"DiscoKey":   "discokey:cc20da24fa4f46b0f3d869356a2f86109b821071d7b693fc2a647e3bb14b621c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37614",
+					"10.65.0.27:37614",
+					"172.17.0.1:37614",
+					"172.18.0.1:37614",
+					"172.19.0.1:37614",
+					"172.20.0.1:37614",
+					"172.21.0.1:37614",
+					"172.22.0.1:37614",
+					"172.23.0.1:37614",
+					"172.24.0.1:37614",
+					"172.25.0.1:37614",
+					"172.26.0.1:37614",
+					"172.27.0.1:37614",
+					"172.28.0.1:37614"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:10:44.315391471Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e67b072f623a6ef1c4e441868b120b0e1ec414cf7f823bea4dc322b1c73fce22",
+			"MachineKey": "mkey:cc08647835ead8f27fd71c13b66e8aae7f96b2b4e68ac5f3be845d018edb821c",
+			"Peers": [{
+				"ID":         2481161170831544,
+				"StableID":   "nw86L1uiNL11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fa2e64f9eca2a176a8585cf3f181b1d45f78c3cccf1570600109ae345693b903",
+				"DiscoKey":   "discokey:ea8048c544d4690c11c538c7dff5e923a5bbd7577bf04495426d8fa6de5e1166",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40953",
+					"10.65.0.27:40953",
+					"172.17.0.1:40953",
+					"172.18.0.1:40953",
+					"172.19.0.1:40953",
+					"172.20.0.1:40953",
+					"172.21.0.1:40953",
+					"172.22.0.1:40953",
+					"172.23.0.1:40953",
+					"172.24.0.1:40953",
+					"172.25.0.1:40953",
+					"172.26.0.1:40953",
+					"172.27.0.1:40953",
+					"172.28.0.1:40953"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:10:41.10160613Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4960289040082096,
+				"StableID":   "nfQ6m9PXjf11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5aafa1118516e2c189ac90580c021439b584bef643c71781f5e26e5f1c3a112d",
+				"DiscoKey":   "discokey:6c9266c97130bffe5ae0461594c233724a666f8b09c18ece2cab2a980d70af55",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51611",
+					"10.65.0.27:51611",
+					"172.17.0.1:51611",
+					"172.18.0.1:51611",
+					"172.19.0.1:51611",
+					"172.20.0.1:51611",
+					"172.21.0.1:51611",
+					"172.22.0.1:51611",
+					"172.23.0.1:51611",
+					"172.24.0.1:51611",
+					"172.25.0.1:51611",
+					"172.26.0.1:51611",
+					"172.27.0.1:51611",
+					"172.28.0.1:51611"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:10:41.641446003Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7768084567289187,
+				"StableID":   "nku1fjQBf321CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c03e907c0eaceaaf345e13c7a81f4f3ad52eadc4f8a3e3ac8fcf7e625426dc2e",
+				"DiscoKey":   "discokey:efac546518cac262a451f53fd59a6058165767869355102704d32dede0b98c0d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:48773",
+					"10.65.0.27:48773",
+					"172.17.0.1:48773",
+					"172.18.0.1:48773",
+					"172.19.0.1:48773",
+					"172.20.0.1:48773",
+					"172.21.0.1:48773",
+					"172.22.0.1:48773",
+					"172.23.0.1:48773",
+					"172.24.0.1:48773",
+					"172.25.0.1:48773",
+					"172.26.0.1:48773",
+					"172.27.0.1:48773",
+					"172.28.0.1:48773"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:10:42.165454589Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3195380828706430,
+				"StableID":   "nZ8PmgECxR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26aa4590e7409841077b2f9ad40ce46298f04fa175ad468f4caac75c655b8d2c",
+				"DiscoKey":   "discokey:3ac2bc5b59d129134472a9231574fab9e65ae123699c660ead3e1582f7aaf76a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:44975",
+					"10.65.0.27:44975",
+					"172.17.0.1:44975",
+					"172.18.0.1:44975",
+					"172.19.0.1:44975",
+					"172.20.0.1:44975",
+					"172.21.0.1:44975",
+					"172.22.0.1:44975",
+					"172.23.0.1:44975",
+					"172.24.0.1:44975",
+					"172.25.0.1:44975",
+					"172.26.0.1:44975",
+					"172.27.0.1:44975",
+					"172.28.0.1:44975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:10:42.699205128Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3986158479948651,
+				"StableID":   "nGo3vBdL8Y11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:338bee8bcf0c71b8365a88b135045bf456a3203bc5cc32bc9b85f8f7b60e6c59",
+				"DiscoKey":   "discokey:5ab8526604b7b75af0a06970f8c44ca44ed68726e09072b2b1bedc7f6ee5f92f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:36771",
+					"10.65.0.27:36771",
+					"172.17.0.1:36771",
+					"172.18.0.1:36771",
+					"172.19.0.1:36771",
+					"172.20.0.1:36771",
+					"172.21.0.1:36771",
+					"172.22.0.1:36771",
+					"172.23.0.1:36771",
+					"172.24.0.1:36771",
+					"172.25.0.1:36771",
+					"172.26.0.1:36771",
+					"172.27.0.1:36771",
+					"172.28.0.1:36771"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:10:43.226544237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1408740200256286,
+				"StableID":   "nmeZVYD21C11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:386f415fad86f92958f3cb6aa8a62828e388cf7fe68d7810538b9edcd7e6cf6b",
+				"DiscoKey":   "discokey:4d951ab6f3ebad15e794ce3db79649dfd2ef4a6ebba1f02a13acf645de951275",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40763",
+					"10.65.0.27:40763",
+					"172.17.0.1:40763",
+					"172.18.0.1:40763",
+					"172.19.0.1:40763",
+					"172.20.0.1:40763",
+					"172.21.0.1:40763",
+					"172.22.0.1:40763",
+					"172.23.0.1:40763",
+					"172.24.0.1:40763",
+					"172.25.0.1:40763",
+					"172.26.0.1:40763",
+					"172.27.0.1:40763",
+					"172.28.0.1:40763"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:10:43.763271407Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7601664281791600,
+				"StableID":   "ny9XuAqoM221CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aab665ced0d9240215455481aafefc91b37083bd5ed74c63d685170c0f01f772",
+				"DiscoKey":   "discokey:8fb60e9d9e28b607a43712f9d9524c59c615a957632e4d04c61cc2f766b13374",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58032",
+					"10.65.0.27:58032",
+					"172.17.0.1:58032",
+					"172.18.0.1:58032",
+					"172.19.0.1:58032",
+					"172.20.0.1:58032",
+					"172.21.0.1:58032",
+					"172.22.0.1:58032",
+					"172.23.0.1:58032",
+					"172.24.0.1:58032",
+					"172.25.0.1:58032",
+					"172.26.0.1:58032",
+					"172.27.0.1:58032",
+					"172.28.0.1:58032"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:10:44.903245772Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7172045565017533,
+				"StableID":   "ngYj4aUE1y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38597be773f83cca39f3d3930ba96ac7a4fc6db294fcd79dd9ebebbf37d74e66",
+				"DiscoKey":   "discokey:28c74df52a1d4519c59dfd35d9a1e960c8f50d0ce4a645650477ed3755303274",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36824",
+					"10.65.0.27:36824",
+					"172.17.0.1:36824",
+					"172.18.0.1:36824",
+					"172.19.0.1:36824",
+					"172.20.0.1:36824",
+					"172.21.0.1:36824",
+					"172.22.0.1:36824",
+					"172.23.0.1:36824",
+					"172.24.0.1:36824",
+					"172.25.0.1:36824",
+					"172.26.0.1:36824",
+					"172.27.0.1:36824",
+					"172.28.0.1:36824"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:10:45.447822606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2433647541453941,
+				"StableID":   "nYA2c4oC1L11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b90b253e23190ef9ef6573acae3dc180a4d1ce250c7c69ea763e2442f1cecb0e",
+				"DiscoKey":   "discokey:d4cc9bdd1aad555989cbea0d1d633b5a864664a53398fca05ecca6db6435607e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54770",
+					"10.65.0.27:54770",
+					"172.17.0.1:54770",
+					"172.18.0.1:54770",
+					"172.19.0.1:54770",
+					"172.20.0.1:54770",
+					"172.21.0.1:54770",
+					"172.22.0.1:54770",
+					"172.23.0.1:54770",
+					"172.24.0.1:54770",
+					"172.25.0.1:54770",
+					"172.26.0.1:54770",
+					"172.27.0.1:54770",
+					"172.28.0.1:54770"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:10:45.972100392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3094189100749093,
+				"StableID":   "ntGGHr6NAR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8d0eb408279680e87651d8931898596910cdd1a7c4f22bcd863bbca505af331b",
+				"DiscoKey":   "discokey:6e341b9d2ba93faeecfd3765d026ec000dbc206232864eb9a166c80f370bbf6c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55581",
+					"10.65.0.27:55581",
+					"172.17.0.1:55581",
+					"172.18.0.1:55581",
+					"172.19.0.1:55581",
+					"172.20.0.1:55581",
+					"172.21.0.1:55581",
+					"172.22.0.1:55581",
+					"172.23.0.1:55581",
+					"172.24.0.1:55581",
+					"172.25.0.1:55581",
+					"172.26.0.1:55581",
+					"172.27.0.1:55581",
+					"172.28.0.1:55581"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:10:46.514038595Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2114968417180870,
+				"StableID":   "n1k7fmdsWH11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1747722f6f1925a212dd4da8360d7227031d9d0c72954583c099d6e159dfa62",
+				"DiscoKey":   "discokey:192876548845a393fe66a4e34783664cdca8945ec29fc3463b01666c5150e622",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41522",
+					"10.65.0.27:41522",
+					"172.17.0.1:41522",
+					"172.18.0.1:41522",
+					"172.19.0.1:41522",
+					"172.20.0.1:41522",
+					"172.21.0.1:41522",
+					"172.22.0.1:41522",
+					"172.23.0.1:41522",
+					"172.24.0.1:41522",
+					"172.25.0.1:41522",
+					"172.26.0.1:41522",
+					"172.27.0.1:41522",
+					"172.28.0.1:41522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:10:47.048048187Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5879348204137845,
+				"StableID":   "nGkDvSWmun11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:773e9a5b93c7f420db6b0a12ca3367d80e3ab49c455a2a9df40952d5088d7834",
+				"KeyExpiry":  "2026-11-09T09:10:47Z",
+				"DiscoKey":   "discokey:f56b11a2d784e3cd1420750352c8f917d81c6fc40743638a7cb31708a7ff9a15",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35351",
+					"10.65.0.27:35351",
+					"172.17.0.1:35351",
+					"172.18.0.1:35351",
+					"172.19.0.1:35351",
+					"172.20.0.1:35351",
+					"172.21.0.1:35351",
+					"172.22.0.1:35351",
+					"172.23.0.1:35351",
+					"172.24.0.1:35351",
+					"172.25.0.1:35351",
+					"172.26.0.1:35351",
+					"172.27.0.1:35351",
+					"172.28.0.1:35351"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:10:47.592874778Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         68045841626599,
+				"StableID":   "nr4j13TpX111CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:981386a4b363044407a0d6c3cd468912350c9ee19025b55ba27b16b4532d1d16",
+				"KeyExpiry":  "2026-11-09T09:10:48Z",
+				"DiscoKey":   "discokey:eebc56f4dc88d3e5a9600502537d0b83e971a9fe26f3861dff6ee97805139443",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36640",
+					"10.65.0.27:36640",
+					"172.17.0.1:36640",
+					"172.18.0.1:36640",
+					"172.19.0.1:36640",
+					"172.20.0.1:36640",
+					"172.21.0.1:36640",
+					"172.22.0.1:36640",
+					"172.23.0.1:36640",
+					"172.24.0.1:36640",
+					"172.25.0.1:36640",
+					"172.26.0.1:36640",
+					"172.27.0.1:36640",
+					"172.28.0.1:36640"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:10:48.127109399Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6078694782604475,
+				"StableID":   "nrNjRF14Up11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:598464ec9b0c6a7ef22c12f8509ea7214ab175b15b236e84edc6c314a465671e",
+				"KeyExpiry":  "2026-11-09T09:10:48Z",
+				"DiscoKey":   "discokey:22177af5ff136137d2c6a8a5d9edb60e60f6b501632589dc759f9f7383e6ac6f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42180",
+					"10.65.0.27:42180",
+					"172.17.0.1:42180",
+					"172.18.0.1:42180",
+					"172.19.0.1:42180",
+					"172.20.0.1:42180",
+					"172.21.0.1:42180",
+					"172.22.0.1:42180",
+					"172.23.0.1:42180",
+					"172.24.0.1:42180",
+					"172.25.0.1:42180",
+					"172.26.0.1:42180",
+					"172.27.0.1:42180",
+					"172.28.0.1:42180"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:10:48.6705023Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "818116849785060": {
+				"ID":          818116849785060,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7172045565017533,
+				"StableID":   "ngYj4aUE1y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       7172045565017533,
+				"Key":        "nodekey:38597be773f83cca39f3d3930ba96ac7a4fc6db294fcd79dd9ebebbf37d74e66",
+				"DiscoKey":   "discokey:28c74df52a1d4519c59dfd35d9a1e960c8f50d0ce4a645650477ed3755303274",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36824",
+					"10.65.0.27:36824",
+					"172.17.0.1:36824",
+					"172.18.0.1:36824",
+					"172.19.0.1:36824",
+					"172.20.0.1:36824",
+					"172.21.0.1:36824",
+					"172.22.0.1:36824",
+					"172.23.0.1:36824",
+					"172.24.0.1:36824",
+					"172.25.0.1:36824",
+					"172.26.0.1:36824",
+					"172.27.0.1:36824",
+					"172.28.0.1:36824"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:10:45.447822606Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:38597be773f83cca39f3d3930ba96ac7a4fc6db294fcd79dd9ebebbf37d74e66",
+			"MachineKey": "mkey:64cf78ff32c5ab347b592d75fbb29b6436ee92804834bb04872092b3b6f42c70",
+			"Peers": [{
+				"ID":         2481161170831544,
+				"StableID":   "nw86L1uiNL11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fa2e64f9eca2a176a8585cf3f181b1d45f78c3cccf1570600109ae345693b903",
+				"DiscoKey":   "discokey:ea8048c544d4690c11c538c7dff5e923a5bbd7577bf04495426d8fa6de5e1166",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40953",
+					"10.65.0.27:40953",
+					"172.17.0.1:40953",
+					"172.18.0.1:40953",
+					"172.19.0.1:40953",
+					"172.20.0.1:40953",
+					"172.21.0.1:40953",
+					"172.22.0.1:40953",
+					"172.23.0.1:40953",
+					"172.24.0.1:40953",
+					"172.25.0.1:40953",
+					"172.26.0.1:40953",
+					"172.27.0.1:40953",
+					"172.28.0.1:40953"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:10:41.10160613Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4960289040082096,
+				"StableID":   "nfQ6m9PXjf11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5aafa1118516e2c189ac90580c021439b584bef643c71781f5e26e5f1c3a112d",
+				"DiscoKey":   "discokey:6c9266c97130bffe5ae0461594c233724a666f8b09c18ece2cab2a980d70af55",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51611",
+					"10.65.0.27:51611",
+					"172.17.0.1:51611",
+					"172.18.0.1:51611",
+					"172.19.0.1:51611",
+					"172.20.0.1:51611",
+					"172.21.0.1:51611",
+					"172.22.0.1:51611",
+					"172.23.0.1:51611",
+					"172.24.0.1:51611",
+					"172.25.0.1:51611",
+					"172.26.0.1:51611",
+					"172.27.0.1:51611",
+					"172.28.0.1:51611"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:10:41.641446003Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7768084567289187,
+				"StableID":   "nku1fjQBf321CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c03e907c0eaceaaf345e13c7a81f4f3ad52eadc4f8a3e3ac8fcf7e625426dc2e",
+				"DiscoKey":   "discokey:efac546518cac262a451f53fd59a6058165767869355102704d32dede0b98c0d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:48773",
+					"10.65.0.27:48773",
+					"172.17.0.1:48773",
+					"172.18.0.1:48773",
+					"172.19.0.1:48773",
+					"172.20.0.1:48773",
+					"172.21.0.1:48773",
+					"172.22.0.1:48773",
+					"172.23.0.1:48773",
+					"172.24.0.1:48773",
+					"172.25.0.1:48773",
+					"172.26.0.1:48773",
+					"172.27.0.1:48773",
+					"172.28.0.1:48773"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:10:42.165454589Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3195380828706430,
+				"StableID":   "nZ8PmgECxR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26aa4590e7409841077b2f9ad40ce46298f04fa175ad468f4caac75c655b8d2c",
+				"DiscoKey":   "discokey:3ac2bc5b59d129134472a9231574fab9e65ae123699c660ead3e1582f7aaf76a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:44975",
+					"10.65.0.27:44975",
+					"172.17.0.1:44975",
+					"172.18.0.1:44975",
+					"172.19.0.1:44975",
+					"172.20.0.1:44975",
+					"172.21.0.1:44975",
+					"172.22.0.1:44975",
+					"172.23.0.1:44975",
+					"172.24.0.1:44975",
+					"172.25.0.1:44975",
+					"172.26.0.1:44975",
+					"172.27.0.1:44975",
+					"172.28.0.1:44975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:10:42.699205128Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3986158479948651,
+				"StableID":   "nGo3vBdL8Y11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:338bee8bcf0c71b8365a88b135045bf456a3203bc5cc32bc9b85f8f7b60e6c59",
+				"DiscoKey":   "discokey:5ab8526604b7b75af0a06970f8c44ca44ed68726e09072b2b1bedc7f6ee5f92f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:36771",
+					"10.65.0.27:36771",
+					"172.17.0.1:36771",
+					"172.18.0.1:36771",
+					"172.19.0.1:36771",
+					"172.20.0.1:36771",
+					"172.21.0.1:36771",
+					"172.22.0.1:36771",
+					"172.23.0.1:36771",
+					"172.24.0.1:36771",
+					"172.25.0.1:36771",
+					"172.26.0.1:36771",
+					"172.27.0.1:36771",
+					"172.28.0.1:36771"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:10:43.226544237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1408740200256286,
+				"StableID":   "nmeZVYD21C11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:386f415fad86f92958f3cb6aa8a62828e388cf7fe68d7810538b9edcd7e6cf6b",
+				"DiscoKey":   "discokey:4d951ab6f3ebad15e794ce3db79649dfd2ef4a6ebba1f02a13acf645de951275",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40763",
+					"10.65.0.27:40763",
+					"172.17.0.1:40763",
+					"172.18.0.1:40763",
+					"172.19.0.1:40763",
+					"172.20.0.1:40763",
+					"172.21.0.1:40763",
+					"172.22.0.1:40763",
+					"172.23.0.1:40763",
+					"172.24.0.1:40763",
+					"172.25.0.1:40763",
+					"172.26.0.1:40763",
+					"172.27.0.1:40763",
+					"172.28.0.1:40763"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:10:43.763271407Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         818116849785060,
+				"StableID":   "nd5MWTYXP711CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e67b072f623a6ef1c4e441868b120b0e1ec414cf7f823bea4dc322b1c73fce22",
+				"DiscoKey":   "discokey:cc20da24fa4f46b0f3d869356a2f86109b821071d7b693fc2a647e3bb14b621c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37614",
+					"10.65.0.27:37614",
+					"172.17.0.1:37614",
+					"172.18.0.1:37614",
+					"172.19.0.1:37614",
+					"172.20.0.1:37614",
+					"172.21.0.1:37614",
+					"172.22.0.1:37614",
+					"172.23.0.1:37614",
+					"172.24.0.1:37614",
+					"172.25.0.1:37614",
+					"172.26.0.1:37614",
+					"172.27.0.1:37614",
+					"172.28.0.1:37614"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:10:44.315391471Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7601664281791600,
+				"StableID":   "ny9XuAqoM221CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aab665ced0d9240215455481aafefc91b37083bd5ed74c63d685170c0f01f772",
+				"DiscoKey":   "discokey:8fb60e9d9e28b607a43712f9d9524c59c615a957632e4d04c61cc2f766b13374",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58032",
+					"10.65.0.27:58032",
+					"172.17.0.1:58032",
+					"172.18.0.1:58032",
+					"172.19.0.1:58032",
+					"172.20.0.1:58032",
+					"172.21.0.1:58032",
+					"172.22.0.1:58032",
+					"172.23.0.1:58032",
+					"172.24.0.1:58032",
+					"172.25.0.1:58032",
+					"172.26.0.1:58032",
+					"172.27.0.1:58032",
+					"172.28.0.1:58032"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:10:44.903245772Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2433647541453941,
+				"StableID":   "nYA2c4oC1L11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b90b253e23190ef9ef6573acae3dc180a4d1ce250c7c69ea763e2442f1cecb0e",
+				"DiscoKey":   "discokey:d4cc9bdd1aad555989cbea0d1d633b5a864664a53398fca05ecca6db6435607e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54770",
+					"10.65.0.27:54770",
+					"172.17.0.1:54770",
+					"172.18.0.1:54770",
+					"172.19.0.1:54770",
+					"172.20.0.1:54770",
+					"172.21.0.1:54770",
+					"172.22.0.1:54770",
+					"172.23.0.1:54770",
+					"172.24.0.1:54770",
+					"172.25.0.1:54770",
+					"172.26.0.1:54770",
+					"172.27.0.1:54770",
+					"172.28.0.1:54770"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:10:45.972100392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3094189100749093,
+				"StableID":   "ntGGHr6NAR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8d0eb408279680e87651d8931898596910cdd1a7c4f22bcd863bbca505af331b",
+				"DiscoKey":   "discokey:6e341b9d2ba93faeecfd3765d026ec000dbc206232864eb9a166c80f370bbf6c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55581",
+					"10.65.0.27:55581",
+					"172.17.0.1:55581",
+					"172.18.0.1:55581",
+					"172.19.0.1:55581",
+					"172.20.0.1:55581",
+					"172.21.0.1:55581",
+					"172.22.0.1:55581",
+					"172.23.0.1:55581",
+					"172.24.0.1:55581",
+					"172.25.0.1:55581",
+					"172.26.0.1:55581",
+					"172.27.0.1:55581",
+					"172.28.0.1:55581"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:10:46.514038595Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2114968417180870,
+				"StableID":   "n1k7fmdsWH11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1747722f6f1925a212dd4da8360d7227031d9d0c72954583c099d6e159dfa62",
+				"DiscoKey":   "discokey:192876548845a393fe66a4e34783664cdca8945ec29fc3463b01666c5150e622",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41522",
+					"10.65.0.27:41522",
+					"172.17.0.1:41522",
+					"172.18.0.1:41522",
+					"172.19.0.1:41522",
+					"172.20.0.1:41522",
+					"172.21.0.1:41522",
+					"172.22.0.1:41522",
+					"172.23.0.1:41522",
+					"172.24.0.1:41522",
+					"172.25.0.1:41522",
+					"172.26.0.1:41522",
+					"172.27.0.1:41522",
+					"172.28.0.1:41522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:10:47.048048187Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5879348204137845,
+				"StableID":   "nGkDvSWmun11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:773e9a5b93c7f420db6b0a12ca3367d80e3ab49c455a2a9df40952d5088d7834",
+				"KeyExpiry":  "2026-11-09T09:10:47Z",
+				"DiscoKey":   "discokey:f56b11a2d784e3cd1420750352c8f917d81c6fc40743638a7cb31708a7ff9a15",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35351",
+					"10.65.0.27:35351",
+					"172.17.0.1:35351",
+					"172.18.0.1:35351",
+					"172.19.0.1:35351",
+					"172.20.0.1:35351",
+					"172.21.0.1:35351",
+					"172.22.0.1:35351",
+					"172.23.0.1:35351",
+					"172.24.0.1:35351",
+					"172.25.0.1:35351",
+					"172.26.0.1:35351",
+					"172.27.0.1:35351",
+					"172.28.0.1:35351"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:10:47.592874778Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         68045841626599,
+				"StableID":   "nr4j13TpX111CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:981386a4b363044407a0d6c3cd468912350c9ee19025b55ba27b16b4532d1d16",
+				"KeyExpiry":  "2026-11-09T09:10:48Z",
+				"DiscoKey":   "discokey:eebc56f4dc88d3e5a9600502537d0b83e971a9fe26f3861dff6ee97805139443",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36640",
+					"10.65.0.27:36640",
+					"172.17.0.1:36640",
+					"172.18.0.1:36640",
+					"172.19.0.1:36640",
+					"172.20.0.1:36640",
+					"172.21.0.1:36640",
+					"172.22.0.1:36640",
+					"172.23.0.1:36640",
+					"172.24.0.1:36640",
+					"172.25.0.1:36640",
+					"172.26.0.1:36640",
+					"172.27.0.1:36640",
+					"172.28.0.1:36640"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:10:48.127109399Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6078694782604475,
+				"StableID":   "nrNjRF14Up11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:598464ec9b0c6a7ef22c12f8509ea7214ab175b15b236e84edc6c314a465671e",
+				"KeyExpiry":  "2026-11-09T09:10:48Z",
+				"DiscoKey":   "discokey:22177af5ff136137d2c6a8a5d9edb60e60f6b501632589dc759f9f7383e6ac6f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42180",
+					"10.65.0.27:42180",
+					"172.17.0.1:42180",
+					"172.18.0.1:42180",
+					"172.19.0.1:42180",
+					"172.20.0.1:42180",
+					"172.21.0.1:42180",
+					"172.22.0.1:42180",
+					"172.23.0.1:42180",
+					"172.24.0.1:42180",
+					"172.25.0.1:42180",
+					"172.26.0.1:42180",
+					"172.27.0.1:42180",
+					"172.28.0.1:42180"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:10:48.6705023Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7172045565017533": {
+				"ID":          7172045565017533,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         68045841626599,
+				"StableID":   "nr4j13TpX111CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:981386a4b363044407a0d6c3cd468912350c9ee19025b55ba27b16b4532d1d16",
+				"KeyExpiry":  "2026-11-09T09:10:48Z",
+				"DiscoKey":   "discokey:eebc56f4dc88d3e5a9600502537d0b83e971a9fe26f3861dff6ee97805139443",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36640",
+					"10.65.0.27:36640",
+					"172.17.0.1:36640",
+					"172.18.0.1:36640",
+					"172.19.0.1:36640",
+					"172.20.0.1:36640",
+					"172.21.0.1:36640",
+					"172.22.0.1:36640",
+					"172.23.0.1:36640",
+					"172.24.0.1:36640",
+					"172.25.0.1:36640",
+					"172.26.0.1:36640",
+					"172.27.0.1:36640",
+					"172.28.0.1:36640"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:10:48.127109399Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:981386a4b363044407a0d6c3cd468912350c9ee19025b55ba27b16b4532d1d16",
+			"MachineKey": "mkey:a36a0da87a36783807da076fbaa48c9b1d330eb2c8321aac5f751aa862c0054e",
+			"Peers": [{
+				"ID":         2481161170831544,
+				"StableID":   "nw86L1uiNL11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fa2e64f9eca2a176a8585cf3f181b1d45f78c3cccf1570600109ae345693b903",
+				"DiscoKey":   "discokey:ea8048c544d4690c11c538c7dff5e923a5bbd7577bf04495426d8fa6de5e1166",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40953",
+					"10.65.0.27:40953",
+					"172.17.0.1:40953",
+					"172.18.0.1:40953",
+					"172.19.0.1:40953",
+					"172.20.0.1:40953",
+					"172.21.0.1:40953",
+					"172.22.0.1:40953",
+					"172.23.0.1:40953",
+					"172.24.0.1:40953",
+					"172.25.0.1:40953",
+					"172.26.0.1:40953",
+					"172.27.0.1:40953",
+					"172.28.0.1:40953"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:10:41.10160613Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4960289040082096,
+				"StableID":   "nfQ6m9PXjf11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5aafa1118516e2c189ac90580c021439b584bef643c71781f5e26e5f1c3a112d",
+				"DiscoKey":   "discokey:6c9266c97130bffe5ae0461594c233724a666f8b09c18ece2cab2a980d70af55",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51611",
+					"10.65.0.27:51611",
+					"172.17.0.1:51611",
+					"172.18.0.1:51611",
+					"172.19.0.1:51611",
+					"172.20.0.1:51611",
+					"172.21.0.1:51611",
+					"172.22.0.1:51611",
+					"172.23.0.1:51611",
+					"172.24.0.1:51611",
+					"172.25.0.1:51611",
+					"172.26.0.1:51611",
+					"172.27.0.1:51611",
+					"172.28.0.1:51611"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:10:41.641446003Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7768084567289187,
+				"StableID":   "nku1fjQBf321CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c03e907c0eaceaaf345e13c7a81f4f3ad52eadc4f8a3e3ac8fcf7e625426dc2e",
+				"DiscoKey":   "discokey:efac546518cac262a451f53fd59a6058165767869355102704d32dede0b98c0d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:48773",
+					"10.65.0.27:48773",
+					"172.17.0.1:48773",
+					"172.18.0.1:48773",
+					"172.19.0.1:48773",
+					"172.20.0.1:48773",
+					"172.21.0.1:48773",
+					"172.22.0.1:48773",
+					"172.23.0.1:48773",
+					"172.24.0.1:48773",
+					"172.25.0.1:48773",
+					"172.26.0.1:48773",
+					"172.27.0.1:48773",
+					"172.28.0.1:48773"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:10:42.165454589Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3195380828706430,
+				"StableID":   "nZ8PmgECxR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26aa4590e7409841077b2f9ad40ce46298f04fa175ad468f4caac75c655b8d2c",
+				"DiscoKey":   "discokey:3ac2bc5b59d129134472a9231574fab9e65ae123699c660ead3e1582f7aaf76a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:44975",
+					"10.65.0.27:44975",
+					"172.17.0.1:44975",
+					"172.18.0.1:44975",
+					"172.19.0.1:44975",
+					"172.20.0.1:44975",
+					"172.21.0.1:44975",
+					"172.22.0.1:44975",
+					"172.23.0.1:44975",
+					"172.24.0.1:44975",
+					"172.25.0.1:44975",
+					"172.26.0.1:44975",
+					"172.27.0.1:44975",
+					"172.28.0.1:44975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:10:42.699205128Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3986158479948651,
+				"StableID":   "nGo3vBdL8Y11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:338bee8bcf0c71b8365a88b135045bf456a3203bc5cc32bc9b85f8f7b60e6c59",
+				"DiscoKey":   "discokey:5ab8526604b7b75af0a06970f8c44ca44ed68726e09072b2b1bedc7f6ee5f92f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:36771",
+					"10.65.0.27:36771",
+					"172.17.0.1:36771",
+					"172.18.0.1:36771",
+					"172.19.0.1:36771",
+					"172.20.0.1:36771",
+					"172.21.0.1:36771",
+					"172.22.0.1:36771",
+					"172.23.0.1:36771",
+					"172.24.0.1:36771",
+					"172.25.0.1:36771",
+					"172.26.0.1:36771",
+					"172.27.0.1:36771",
+					"172.28.0.1:36771"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:10:43.226544237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1408740200256286,
+				"StableID":   "nmeZVYD21C11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:386f415fad86f92958f3cb6aa8a62828e388cf7fe68d7810538b9edcd7e6cf6b",
+				"DiscoKey":   "discokey:4d951ab6f3ebad15e794ce3db79649dfd2ef4a6ebba1f02a13acf645de951275",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40763",
+					"10.65.0.27:40763",
+					"172.17.0.1:40763",
+					"172.18.0.1:40763",
+					"172.19.0.1:40763",
+					"172.20.0.1:40763",
+					"172.21.0.1:40763",
+					"172.22.0.1:40763",
+					"172.23.0.1:40763",
+					"172.24.0.1:40763",
+					"172.25.0.1:40763",
+					"172.26.0.1:40763",
+					"172.27.0.1:40763",
+					"172.28.0.1:40763"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:10:43.763271407Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         818116849785060,
+				"StableID":   "nd5MWTYXP711CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e67b072f623a6ef1c4e441868b120b0e1ec414cf7f823bea4dc322b1c73fce22",
+				"DiscoKey":   "discokey:cc20da24fa4f46b0f3d869356a2f86109b821071d7b693fc2a647e3bb14b621c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37614",
+					"10.65.0.27:37614",
+					"172.17.0.1:37614",
+					"172.18.0.1:37614",
+					"172.19.0.1:37614",
+					"172.20.0.1:37614",
+					"172.21.0.1:37614",
+					"172.22.0.1:37614",
+					"172.23.0.1:37614",
+					"172.24.0.1:37614",
+					"172.25.0.1:37614",
+					"172.26.0.1:37614",
+					"172.27.0.1:37614",
+					"172.28.0.1:37614"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:10:44.315391471Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7601664281791600,
+				"StableID":   "ny9XuAqoM221CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aab665ced0d9240215455481aafefc91b37083bd5ed74c63d685170c0f01f772",
+				"DiscoKey":   "discokey:8fb60e9d9e28b607a43712f9d9524c59c615a957632e4d04c61cc2f766b13374",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58032",
+					"10.65.0.27:58032",
+					"172.17.0.1:58032",
+					"172.18.0.1:58032",
+					"172.19.0.1:58032",
+					"172.20.0.1:58032",
+					"172.21.0.1:58032",
+					"172.22.0.1:58032",
+					"172.23.0.1:58032",
+					"172.24.0.1:58032",
+					"172.25.0.1:58032",
+					"172.26.0.1:58032",
+					"172.27.0.1:58032",
+					"172.28.0.1:58032"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:10:44.903245772Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7172045565017533,
+				"StableID":   "ngYj4aUE1y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38597be773f83cca39f3d3930ba96ac7a4fc6db294fcd79dd9ebebbf37d74e66",
+				"DiscoKey":   "discokey:28c74df52a1d4519c59dfd35d9a1e960c8f50d0ce4a645650477ed3755303274",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36824",
+					"10.65.0.27:36824",
+					"172.17.0.1:36824",
+					"172.18.0.1:36824",
+					"172.19.0.1:36824",
+					"172.20.0.1:36824",
+					"172.21.0.1:36824",
+					"172.22.0.1:36824",
+					"172.23.0.1:36824",
+					"172.24.0.1:36824",
+					"172.25.0.1:36824",
+					"172.26.0.1:36824",
+					"172.27.0.1:36824",
+					"172.28.0.1:36824"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:10:45.447822606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2433647541453941,
+				"StableID":   "nYA2c4oC1L11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b90b253e23190ef9ef6573acae3dc180a4d1ce250c7c69ea763e2442f1cecb0e",
+				"DiscoKey":   "discokey:d4cc9bdd1aad555989cbea0d1d633b5a864664a53398fca05ecca6db6435607e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54770",
+					"10.65.0.27:54770",
+					"172.17.0.1:54770",
+					"172.18.0.1:54770",
+					"172.19.0.1:54770",
+					"172.20.0.1:54770",
+					"172.21.0.1:54770",
+					"172.22.0.1:54770",
+					"172.23.0.1:54770",
+					"172.24.0.1:54770",
+					"172.25.0.1:54770",
+					"172.26.0.1:54770",
+					"172.27.0.1:54770",
+					"172.28.0.1:54770"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:10:45.972100392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3094189100749093,
+				"StableID":   "ntGGHr6NAR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8d0eb408279680e87651d8931898596910cdd1a7c4f22bcd863bbca505af331b",
+				"DiscoKey":   "discokey:6e341b9d2ba93faeecfd3765d026ec000dbc206232864eb9a166c80f370bbf6c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55581",
+					"10.65.0.27:55581",
+					"172.17.0.1:55581",
+					"172.18.0.1:55581",
+					"172.19.0.1:55581",
+					"172.20.0.1:55581",
+					"172.21.0.1:55581",
+					"172.22.0.1:55581",
+					"172.23.0.1:55581",
+					"172.24.0.1:55581",
+					"172.25.0.1:55581",
+					"172.26.0.1:55581",
+					"172.27.0.1:55581",
+					"172.28.0.1:55581"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:10:46.514038595Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2114968417180870,
+				"StableID":   "n1k7fmdsWH11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1747722f6f1925a212dd4da8360d7227031d9d0c72954583c099d6e159dfa62",
+				"DiscoKey":   "discokey:192876548845a393fe66a4e34783664cdca8945ec29fc3463b01666c5150e622",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41522",
+					"10.65.0.27:41522",
+					"172.17.0.1:41522",
+					"172.18.0.1:41522",
+					"172.19.0.1:41522",
+					"172.20.0.1:41522",
+					"172.21.0.1:41522",
+					"172.22.0.1:41522",
+					"172.23.0.1:41522",
+					"172.24.0.1:41522",
+					"172.25.0.1:41522",
+					"172.26.0.1:41522",
+					"172.27.0.1:41522",
+					"172.28.0.1:41522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:10:47.048048187Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5879348204137845,
+				"StableID":   "nGkDvSWmun11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:773e9a5b93c7f420db6b0a12ca3367d80e3ab49c455a2a9df40952d5088d7834",
+				"KeyExpiry":  "2026-11-09T09:10:47Z",
+				"DiscoKey":   "discokey:f56b11a2d784e3cd1420750352c8f917d81c6fc40743638a7cb31708a7ff9a15",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35351",
+					"10.65.0.27:35351",
+					"172.17.0.1:35351",
+					"172.18.0.1:35351",
+					"172.19.0.1:35351",
+					"172.20.0.1:35351",
+					"172.21.0.1:35351",
+					"172.22.0.1:35351",
+					"172.23.0.1:35351",
+					"172.24.0.1:35351",
+					"172.25.0.1:35351",
+					"172.26.0.1:35351",
+					"172.27.0.1:35351",
+					"172.28.0.1:35351"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:10:47.592874778Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6078694782604475,
+				"StableID":   "nrNjRF14Up11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:598464ec9b0c6a7ef22c12f8509ea7214ab175b15b236e84edc6c314a465671e",
+				"KeyExpiry":  "2026-11-09T09:10:48Z",
+				"DiscoKey":   "discokey:22177af5ff136137d2c6a8a5d9edb60e60f6b501632589dc759f9f7383e6ac6f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42180",
+					"10.65.0.27:42180",
+					"172.17.0.1:42180",
+					"172.18.0.1:42180",
+					"172.19.0.1:42180",
+					"172.20.0.1:42180",
+					"172.21.0.1:42180",
+					"172.22.0.1:42180",
+					"172.23.0.1:42180",
+					"172.24.0.1:42180",
+					"172.25.0.1:42180",
+					"172.26.0.1:42180",
+					"172.27.0.1:42180",
+					"172.28.0.1:42180"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:10:48.6705023Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2433647541453941,
+				"StableID":   "nYA2c4oC1L11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       2433647541453941,
+				"Key":        "nodekey:b90b253e23190ef9ef6573acae3dc180a4d1ce250c7c69ea763e2442f1cecb0e",
+				"DiscoKey":   "discokey:d4cc9bdd1aad555989cbea0d1d633b5a864664a53398fca05ecca6db6435607e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54770",
+					"10.65.0.27:54770",
+					"172.17.0.1:54770",
+					"172.18.0.1:54770",
+					"172.19.0.1:54770",
+					"172.20.0.1:54770",
+					"172.21.0.1:54770",
+					"172.22.0.1:54770",
+					"172.23.0.1:54770",
+					"172.24.0.1:54770",
+					"172.25.0.1:54770",
+					"172.26.0.1:54770",
+					"172.27.0.1:54770",
+					"172.28.0.1:54770"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:10:45.972100392Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b90b253e23190ef9ef6573acae3dc180a4d1ce250c7c69ea763e2442f1cecb0e",
+			"MachineKey": "mkey:eb8c8bebab54207294bf910dc892925d27e979a8d3781b4029fa0791be3a825e",
+			"Peers": [{
+				"ID":         2481161170831544,
+				"StableID":   "nw86L1uiNL11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fa2e64f9eca2a176a8585cf3f181b1d45f78c3cccf1570600109ae345693b903",
+				"DiscoKey":   "discokey:ea8048c544d4690c11c538c7dff5e923a5bbd7577bf04495426d8fa6de5e1166",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40953",
+					"10.65.0.27:40953",
+					"172.17.0.1:40953",
+					"172.18.0.1:40953",
+					"172.19.0.1:40953",
+					"172.20.0.1:40953",
+					"172.21.0.1:40953",
+					"172.22.0.1:40953",
+					"172.23.0.1:40953",
+					"172.24.0.1:40953",
+					"172.25.0.1:40953",
+					"172.26.0.1:40953",
+					"172.27.0.1:40953",
+					"172.28.0.1:40953"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:10:41.10160613Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4960289040082096,
+				"StableID":   "nfQ6m9PXjf11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5aafa1118516e2c189ac90580c021439b584bef643c71781f5e26e5f1c3a112d",
+				"DiscoKey":   "discokey:6c9266c97130bffe5ae0461594c233724a666f8b09c18ece2cab2a980d70af55",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51611",
+					"10.65.0.27:51611",
+					"172.17.0.1:51611",
+					"172.18.0.1:51611",
+					"172.19.0.1:51611",
+					"172.20.0.1:51611",
+					"172.21.0.1:51611",
+					"172.22.0.1:51611",
+					"172.23.0.1:51611",
+					"172.24.0.1:51611",
+					"172.25.0.1:51611",
+					"172.26.0.1:51611",
+					"172.27.0.1:51611",
+					"172.28.0.1:51611"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:10:41.641446003Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7768084567289187,
+				"StableID":   "nku1fjQBf321CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c03e907c0eaceaaf345e13c7a81f4f3ad52eadc4f8a3e3ac8fcf7e625426dc2e",
+				"DiscoKey":   "discokey:efac546518cac262a451f53fd59a6058165767869355102704d32dede0b98c0d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:48773",
+					"10.65.0.27:48773",
+					"172.17.0.1:48773",
+					"172.18.0.1:48773",
+					"172.19.0.1:48773",
+					"172.20.0.1:48773",
+					"172.21.0.1:48773",
+					"172.22.0.1:48773",
+					"172.23.0.1:48773",
+					"172.24.0.1:48773",
+					"172.25.0.1:48773",
+					"172.26.0.1:48773",
+					"172.27.0.1:48773",
+					"172.28.0.1:48773"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:10:42.165454589Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3195380828706430,
+				"StableID":   "nZ8PmgECxR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26aa4590e7409841077b2f9ad40ce46298f04fa175ad468f4caac75c655b8d2c",
+				"DiscoKey":   "discokey:3ac2bc5b59d129134472a9231574fab9e65ae123699c660ead3e1582f7aaf76a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:44975",
+					"10.65.0.27:44975",
+					"172.17.0.1:44975",
+					"172.18.0.1:44975",
+					"172.19.0.1:44975",
+					"172.20.0.1:44975",
+					"172.21.0.1:44975",
+					"172.22.0.1:44975",
+					"172.23.0.1:44975",
+					"172.24.0.1:44975",
+					"172.25.0.1:44975",
+					"172.26.0.1:44975",
+					"172.27.0.1:44975",
+					"172.28.0.1:44975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:10:42.699205128Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3986158479948651,
+				"StableID":   "nGo3vBdL8Y11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:338bee8bcf0c71b8365a88b135045bf456a3203bc5cc32bc9b85f8f7b60e6c59",
+				"DiscoKey":   "discokey:5ab8526604b7b75af0a06970f8c44ca44ed68726e09072b2b1bedc7f6ee5f92f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:36771",
+					"10.65.0.27:36771",
+					"172.17.0.1:36771",
+					"172.18.0.1:36771",
+					"172.19.0.1:36771",
+					"172.20.0.1:36771",
+					"172.21.0.1:36771",
+					"172.22.0.1:36771",
+					"172.23.0.1:36771",
+					"172.24.0.1:36771",
+					"172.25.0.1:36771",
+					"172.26.0.1:36771",
+					"172.27.0.1:36771",
+					"172.28.0.1:36771"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:10:43.226544237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1408740200256286,
+				"StableID":   "nmeZVYD21C11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:386f415fad86f92958f3cb6aa8a62828e388cf7fe68d7810538b9edcd7e6cf6b",
+				"DiscoKey":   "discokey:4d951ab6f3ebad15e794ce3db79649dfd2ef4a6ebba1f02a13acf645de951275",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40763",
+					"10.65.0.27:40763",
+					"172.17.0.1:40763",
+					"172.18.0.1:40763",
+					"172.19.0.1:40763",
+					"172.20.0.1:40763",
+					"172.21.0.1:40763",
+					"172.22.0.1:40763",
+					"172.23.0.1:40763",
+					"172.24.0.1:40763",
+					"172.25.0.1:40763",
+					"172.26.0.1:40763",
+					"172.27.0.1:40763",
+					"172.28.0.1:40763"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:10:43.763271407Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         818116849785060,
+				"StableID":   "nd5MWTYXP711CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e67b072f623a6ef1c4e441868b120b0e1ec414cf7f823bea4dc322b1c73fce22",
+				"DiscoKey":   "discokey:cc20da24fa4f46b0f3d869356a2f86109b821071d7b693fc2a647e3bb14b621c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37614",
+					"10.65.0.27:37614",
+					"172.17.0.1:37614",
+					"172.18.0.1:37614",
+					"172.19.0.1:37614",
+					"172.20.0.1:37614",
+					"172.21.0.1:37614",
+					"172.22.0.1:37614",
+					"172.23.0.1:37614",
+					"172.24.0.1:37614",
+					"172.25.0.1:37614",
+					"172.26.0.1:37614",
+					"172.27.0.1:37614",
+					"172.28.0.1:37614"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:10:44.315391471Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7601664281791600,
+				"StableID":   "ny9XuAqoM221CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aab665ced0d9240215455481aafefc91b37083bd5ed74c63d685170c0f01f772",
+				"DiscoKey":   "discokey:8fb60e9d9e28b607a43712f9d9524c59c615a957632e4d04c61cc2f766b13374",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58032",
+					"10.65.0.27:58032",
+					"172.17.0.1:58032",
+					"172.18.0.1:58032",
+					"172.19.0.1:58032",
+					"172.20.0.1:58032",
+					"172.21.0.1:58032",
+					"172.22.0.1:58032",
+					"172.23.0.1:58032",
+					"172.24.0.1:58032",
+					"172.25.0.1:58032",
+					"172.26.0.1:58032",
+					"172.27.0.1:58032",
+					"172.28.0.1:58032"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:10:44.903245772Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7172045565017533,
+				"StableID":   "ngYj4aUE1y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38597be773f83cca39f3d3930ba96ac7a4fc6db294fcd79dd9ebebbf37d74e66",
+				"DiscoKey":   "discokey:28c74df52a1d4519c59dfd35d9a1e960c8f50d0ce4a645650477ed3755303274",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36824",
+					"10.65.0.27:36824",
+					"172.17.0.1:36824",
+					"172.18.0.1:36824",
+					"172.19.0.1:36824",
+					"172.20.0.1:36824",
+					"172.21.0.1:36824",
+					"172.22.0.1:36824",
+					"172.23.0.1:36824",
+					"172.24.0.1:36824",
+					"172.25.0.1:36824",
+					"172.26.0.1:36824",
+					"172.27.0.1:36824",
+					"172.28.0.1:36824"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:10:45.447822606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3094189100749093,
+				"StableID":   "ntGGHr6NAR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8d0eb408279680e87651d8931898596910cdd1a7c4f22bcd863bbca505af331b",
+				"DiscoKey":   "discokey:6e341b9d2ba93faeecfd3765d026ec000dbc206232864eb9a166c80f370bbf6c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55581",
+					"10.65.0.27:55581",
+					"172.17.0.1:55581",
+					"172.18.0.1:55581",
+					"172.19.0.1:55581",
+					"172.20.0.1:55581",
+					"172.21.0.1:55581",
+					"172.22.0.1:55581",
+					"172.23.0.1:55581",
+					"172.24.0.1:55581",
+					"172.25.0.1:55581",
+					"172.26.0.1:55581",
+					"172.27.0.1:55581",
+					"172.28.0.1:55581"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:10:46.514038595Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2114968417180870,
+				"StableID":   "n1k7fmdsWH11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1747722f6f1925a212dd4da8360d7227031d9d0c72954583c099d6e159dfa62",
+				"DiscoKey":   "discokey:192876548845a393fe66a4e34783664cdca8945ec29fc3463b01666c5150e622",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41522",
+					"10.65.0.27:41522",
+					"172.17.0.1:41522",
+					"172.18.0.1:41522",
+					"172.19.0.1:41522",
+					"172.20.0.1:41522",
+					"172.21.0.1:41522",
+					"172.22.0.1:41522",
+					"172.23.0.1:41522",
+					"172.24.0.1:41522",
+					"172.25.0.1:41522",
+					"172.26.0.1:41522",
+					"172.27.0.1:41522",
+					"172.28.0.1:41522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:10:47.048048187Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5879348204137845,
+				"StableID":   "nGkDvSWmun11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:773e9a5b93c7f420db6b0a12ca3367d80e3ab49c455a2a9df40952d5088d7834",
+				"KeyExpiry":  "2026-11-09T09:10:47Z",
+				"DiscoKey":   "discokey:f56b11a2d784e3cd1420750352c8f917d81c6fc40743638a7cb31708a7ff9a15",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35351",
+					"10.65.0.27:35351",
+					"172.17.0.1:35351",
+					"172.18.0.1:35351",
+					"172.19.0.1:35351",
+					"172.20.0.1:35351",
+					"172.21.0.1:35351",
+					"172.22.0.1:35351",
+					"172.23.0.1:35351",
+					"172.24.0.1:35351",
+					"172.25.0.1:35351",
+					"172.26.0.1:35351",
+					"172.27.0.1:35351",
+					"172.28.0.1:35351"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:10:47.592874778Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         68045841626599,
+				"StableID":   "nr4j13TpX111CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:981386a4b363044407a0d6c3cd468912350c9ee19025b55ba27b16b4532d1d16",
+				"KeyExpiry":  "2026-11-09T09:10:48Z",
+				"DiscoKey":   "discokey:eebc56f4dc88d3e5a9600502537d0b83e971a9fe26f3861dff6ee97805139443",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36640",
+					"10.65.0.27:36640",
+					"172.17.0.1:36640",
+					"172.18.0.1:36640",
+					"172.19.0.1:36640",
+					"172.20.0.1:36640",
+					"172.21.0.1:36640",
+					"172.22.0.1:36640",
+					"172.23.0.1:36640",
+					"172.24.0.1:36640",
+					"172.25.0.1:36640",
+					"172.26.0.1:36640",
+					"172.27.0.1:36640",
+					"172.28.0.1:36640"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:10:48.127109399Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6078694782604475,
+				"StableID":   "nrNjRF14Up11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:598464ec9b0c6a7ef22c12f8509ea7214ab175b15b236e84edc6c314a465671e",
+				"KeyExpiry":  "2026-11-09T09:10:48Z",
+				"DiscoKey":   "discokey:22177af5ff136137d2c6a8a5d9edb60e60f6b501632589dc759f9f7383e6ac6f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42180",
+					"10.65.0.27:42180",
+					"172.17.0.1:42180",
+					"172.18.0.1:42180",
+					"172.19.0.1:42180",
+					"172.20.0.1:42180",
+					"172.21.0.1:42180",
+					"172.22.0.1:42180",
+					"172.23.0.1:42180",
+					"172.24.0.1:42180",
+					"172.25.0.1:42180",
+					"172.26.0.1:42180",
+					"172.27.0.1:42180",
+					"172.28.0.1:42180"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:10:48.6705023Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2433647541453941": {
+				"ID":          2433647541453941,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-group-nested-three-deep.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-group-nested-three-deep.hujson
@@ -1,0 +1,22113 @@
+// ssh-group-nested-three-deep
+//
+// ssh group:a -> group:b -> group:c -> user
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-13T09:11:24Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-group-nested-three-deep",
+	"description":    "ssh group:a -> group:b -> group:c -> user",
+	"category":       "ssh",
+	"captured_at":    "2026-05-13T09:11:24.664973942Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {
+			"message": "groups[\"group:b\"]: \"group:c\": group members cannot be recursive"
+		},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                              \n  \n                                                                        \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh group:a -> group:b -> group:c -> user\",\n\t\"id\":          \"ssh-group-nested-three-deep\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"groups\": {\n\t\t\"group:a\": [\"group:b\"],\n\t\t\"group:b\": [\"group:c\"],\n\t\t\"group:c\": [\"thor@example.org\"]\n\t}, \"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"group:a\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-edges/ssh-group-nested-three-deep.hujson",
+		"full_policy": {
+			"groups": {
+				"group:a": ["group:b"],
+				"group:b": ["group:c"],
+				"group:c": ["thor@example.org"]
+			},
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["group:a"],
+				"users":  ["root"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7856278415543673,
+				"StableID":   "nLSA2W78M421CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       7856278415543673,
+				"Key":        "nodekey:7cadaeda40fba18caa1a95233b305c0775f9af6fb6dd5d177177e5035c391f18",
+				"DiscoKey":   "discokey:0e27b0982812192999a486818efd2b538c068e2d6e126f1e64274a747ee2076c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56971",
+					"10.65.0.27:56971",
+					"172.17.0.1:56971",
+					"172.18.0.1:56971",
+					"172.19.0.1:56971",
+					"172.20.0.1:56971",
+					"172.21.0.1:56971",
+					"172.22.0.1:56971",
+					"172.23.0.1:56971",
+					"172.24.0.1:56971",
+					"172.25.0.1:56971",
+					"172.26.0.1:56971",
+					"172.27.0.1:56971",
+					"172.28.0.1:56971"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:11:33.269378521Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7cadaeda40fba18caa1a95233b305c0775f9af6fb6dd5d177177e5035c391f18",
+			"MachineKey": "mkey:01caf0cbd3d28fd8983c15243521d5c88247d1bc44ff0f60d02bb2056b63c855",
+			"Peers": [{
+				"ID":         4823921244737725,
+				"StableID":   "ntA1fQEmfe11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f068dde163d424c95e759f9278b627be1cf3f12b6aa7a50bb9604a80e82f097f",
+				"DiscoKey":   "discokey:6675d05fe875b8b93ac8f93688deee270c3b43e322406902e4ac1043fc06f03e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49772",
+					"10.65.0.27:49772",
+					"172.17.0.1:49772",
+					"172.18.0.1:49772",
+					"172.19.0.1:49772",
+					"172.20.0.1:49772",
+					"172.21.0.1:49772",
+					"172.22.0.1:49772",
+					"172.23.0.1:49772",
+					"172.24.0.1:49772",
+					"172.25.0.1:49772",
+					"172.26.0.1:49772",
+					"172.27.0.1:49772",
+					"172.28.0.1:49772"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:11:27.232727782Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6899673838592495,
+				"StableID":   "n8q1JTjssv11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a939923c6709e023a453589020af9955f819688b31d22c523ea2ae11a4f54473",
+				"DiscoKey":   "discokey:0bba3699d6f26057022b54d80c5442f14d6663fb2046f8852e3117ae855f5e24",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48989",
+					"10.65.0.27:48989",
+					"172.17.0.1:48989",
+					"172.18.0.1:48989",
+					"172.19.0.1:48989",
+					"172.20.0.1:48989",
+					"172.21.0.1:48989",
+					"172.22.0.1:48989",
+					"172.23.0.1:48989",
+					"172.24.0.1:48989",
+					"172.25.0.1:48989",
+					"172.26.0.1:48989",
+					"172.27.0.1:48989",
+					"172.28.0.1:48989"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:11:27.923232747Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1471710141868880,
+				"StableID":   "nmFwb8LYVC11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2298aed6a48ed64120efa52f711067dc887fbb9c78bc864a282ae81a41e96732",
+				"DiscoKey":   "discokey:6b899c9ec15deaac0adeb76364629ef96084f446898f033bc5bdf42c3c893012",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46576",
+					"10.65.0.27:46576",
+					"172.17.0.1:46576",
+					"172.18.0.1:46576",
+					"172.19.0.1:46576",
+					"172.20.0.1:46576",
+					"172.21.0.1:46576",
+					"172.22.0.1:46576",
+					"172.23.0.1:46576",
+					"172.24.0.1:46576",
+					"172.25.0.1:46576",
+					"172.26.0.1:46576",
+					"172.27.0.1:46576",
+					"172.28.0.1:46576"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:11:28.449863702Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7940710577154745,
+				"StableID":   "nA51271N1521CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:426acaea24fe205eeb09b4bcd6cfef17b807be74987d174da3507fa777b43b39",
+				"DiscoKey":   "discokey:079b1c7162b2484e86d4e530566fa84bd0aea1363341d869c93650c47ad91669",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51637",
+					"10.65.0.27:51637",
+					"172.17.0.1:51637",
+					"172.18.0.1:51637",
+					"172.19.0.1:51637",
+					"172.20.0.1:51637",
+					"172.21.0.1:51637",
+					"172.22.0.1:51637",
+					"172.23.0.1:51637",
+					"172.24.0.1:51637",
+					"172.25.0.1:51637",
+					"172.26.0.1:51637",
+					"172.27.0.1:51637",
+					"172.28.0.1:51637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:11:28.980992142Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6660706170020454,
+				"StableID":   "nouDjUTe1u11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:824d25b0ed9a20d2e5e73a97fd435be5e132f908935ff995c2856eda964e602e",
+				"DiscoKey":   "discokey:4944a073658a867807dcaaa0bcc54aa9d2985cefc75903f887aabb9d76890401",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49396",
+					"10.65.0.27:49396",
+					"172.17.0.1:49396",
+					"172.18.0.1:49396",
+					"172.19.0.1:49396",
+					"172.20.0.1:49396",
+					"172.21.0.1:49396",
+					"172.22.0.1:49396",
+					"172.23.0.1:49396",
+					"172.24.0.1:49396",
+					"172.25.0.1:49396",
+					"172.26.0.1:49396",
+					"172.27.0.1:49396",
+					"172.28.0.1:49396"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:11:29.514432602Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5873399707930875,
+				"StableID":   "nkuHgYF5sn11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc6f5a3a207f5c39ed962d0781cb807109ba7dea69a8d53d7aad93625fb7af7f",
+				"DiscoKey":   "discokey:74f2b63be50beb5872dd750c982af92e8f812a0045f04428b41a7be72219673e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:55933",
+					"10.65.0.27:55933",
+					"172.17.0.1:55933",
+					"172.18.0.1:55933",
+					"172.19.0.1:55933",
+					"172.20.0.1:55933",
+					"172.21.0.1:55933",
+					"172.22.0.1:55933",
+					"172.23.0.1:55933",
+					"172.24.0.1:55933",
+					"172.25.0.1:55933",
+					"172.26.0.1:55933",
+					"172.27.0.1:55933",
+					"172.28.0.1:55933"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:11:30.054301025Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4656389653246852,
+				"StableID":   "n1wobhTtMd11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab21ee6bc3991d19001955bdc61e9cf0a700cff60d9dfafc40f3b4b7e0014e6b",
+				"DiscoKey":   "discokey:a4ace807754e1f8f1bc5d7401a012f47722344950a7d4382f35763bc80635527",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49126",
+					"10.65.0.27:49126",
+					"172.17.0.1:49126",
+					"172.18.0.1:49126",
+					"172.19.0.1:49126",
+					"172.20.0.1:49126",
+					"172.21.0.1:49126",
+					"172.22.0.1:49126",
+					"172.23.0.1:49126",
+					"172.24.0.1:49126",
+					"172.25.0.1:49126",
+					"172.26.0.1:49126",
+					"172.27.0.1:49126",
+					"172.28.0.1:49126"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:11:30.590573831Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5001212125978712,
+				"StableID":   "n3a8jzM44g11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec03bcd34d887fac2f5806d20af78c18471da65ced6cb98a8fb8d998bcb75d7c",
+				"DiscoKey":   "discokey:26a6b3741cf31a22ad599c14d9ecf96b17c12f32eb12f421aff04a7d2cb9cf0e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:43845",
+					"10.65.0.27:43845",
+					"172.17.0.1:43845",
+					"172.18.0.1:43845",
+					"172.19.0.1:43845",
+					"172.20.0.1:43845",
+					"172.21.0.1:43845",
+					"172.22.0.1:43845",
+					"172.23.0.1:43845",
+					"172.24.0.1:43845",
+					"172.25.0.1:43845",
+					"172.26.0.1:43845",
+					"172.27.0.1:43845",
+					"172.28.0.1:43845"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:11:31.127153854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8230806459247696,
+				"StableID":   "noYQj4LkG721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:98c9889cf909a88aa69a7a805f56567152d341d8ead559c7c43a918bbc6c4550",
+				"DiscoKey":   "discokey:d8b6802b5f0f2ae9e55751ff60079767a9eb2eea4eb8a6892957efc63308fe19",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41417",
+					"10.65.0.27:41417",
+					"172.17.0.1:41417",
+					"172.18.0.1:41417",
+					"172.19.0.1:41417",
+					"172.20.0.1:41417",
+					"172.21.0.1:41417",
+					"172.22.0.1:41417",
+					"172.23.0.1:41417",
+					"172.24.0.1:41417",
+					"172.25.0.1:41417",
+					"172.26.0.1:41417",
+					"172.27.0.1:41417",
+					"172.28.0.1:41417"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:11:31.681478377Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2192643219519776,
+				"StableID":   "n9dPx7248J11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af6c197aeeb2e8861e26d078ca62f84d392098e251a67c90bea1b4be6481f54a",
+				"DiscoKey":   "discokey:7532d187e881aa70abce6c4c7bdd356aa424d83c5ffaafb82e58253c89e68f36",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53872",
+					"10.65.0.27:53872",
+					"172.17.0.1:53872",
+					"172.18.0.1:53872",
+					"172.19.0.1:53872",
+					"172.20.0.1:53872",
+					"172.21.0.1:53872",
+					"172.22.0.1:53872",
+					"172.23.0.1:53872",
+					"172.24.0.1:53872",
+					"172.25.0.1:53872",
+					"172.26.0.1:53872",
+					"172.27.0.1:53872",
+					"172.28.0.1:53872"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:11:32.210491783Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6622337448797789,
+				"StableID":   "nxapDNaGit11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dbe12d6b4c2392dca0667ad6893de8f72f4131b6f591707f4dd34780dc741826",
+				"DiscoKey":   "discokey:b9fd436af9d9e5ff2f9eaedee7859d1df32bd38fecd5ee974dccc85159f08f67",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:46146",
+					"10.65.0.27:46146",
+					"172.17.0.1:46146",
+					"172.18.0.1:46146",
+					"172.19.0.1:46146",
+					"172.20.0.1:46146",
+					"172.21.0.1:46146",
+					"172.22.0.1:46146",
+					"172.23.0.1:46146",
+					"172.24.0.1:46146",
+					"172.25.0.1:46146",
+					"172.26.0.1:46146",
+					"172.27.0.1:46146",
+					"172.28.0.1:46146"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:11:32.736529232Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3275348019449656,
+				"StableID":   "nD1SadqQaS11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e5231c42fd704c10efbcb05513f8da10f5c9075a07e35f01e68e8fed1f197303",
+				"KeyExpiry":  "2026-11-09T09:11:33Z",
+				"DiscoKey":   "discokey:366f52ee691c4951951fa6e77637baf9df2af6d4a55a58a337c203504528a558",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51315",
+					"10.65.0.27:51315",
+					"172.17.0.1:51315",
+					"172.18.0.1:51315",
+					"172.19.0.1:51315",
+					"172.20.0.1:51315",
+					"172.21.0.1:51315",
+					"172.22.0.1:51315",
+					"172.23.0.1:51315",
+					"172.24.0.1:51315",
+					"172.25.0.1:51315",
+					"172.26.0.1:51315",
+					"172.27.0.1:51315",
+					"172.28.0.1:51315"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:11:33.803521751Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4381600078349493,
+				"StableID":   "nEyfqqCSDb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ffa0f8aa48637ca141b05817dbf6a0d45e92a0147c93d303a0aaf6f0dd08100b",
+				"KeyExpiry":  "2026-11-09T09:11:34Z",
+				"DiscoKey":   "discokey:d87c169006961b0a3995a127a1b8792f58a8de44be722aeaed40c2214798ea38",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54975",
+					"10.65.0.27:54975",
+					"172.17.0.1:54975",
+					"172.18.0.1:54975",
+					"172.19.0.1:54975",
+					"172.20.0.1:54975",
+					"172.21.0.1:54975",
+					"172.22.0.1:54975",
+					"172.23.0.1:54975",
+					"172.24.0.1:54975",
+					"172.25.0.1:54975",
+					"172.26.0.1:54975",
+					"172.27.0.1:54975",
+					"172.28.0.1:54975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:11:34.358798756Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1715639806292417,
+				"StableID":   "n6VUk1x1QE11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dca640dfeecac31a14fdc8ce04c12453b3e18022a60be8130b9b0b604bcc5512",
+				"KeyExpiry":  "2026-11-09T09:11:34Z",
+				"DiscoKey":   "discokey:f31f77fed26171b732ea2c186ed3ef41e799151469c17a4b33a851462ea9ff4b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57841",
+					"10.65.0.27:57841",
+					"172.17.0.1:57841",
+					"172.18.0.1:57841",
+					"172.19.0.1:57841",
+					"172.20.0.1:57841",
+					"172.21.0.1:57841",
+					"172.22.0.1:57841",
+					"172.23.0.1:57841",
+					"172.24.0.1:57841",
+					"172.25.0.1:57841",
+					"172.26.0.1:57841",
+					"172.27.0.1:57841",
+					"172.28.0.1:57841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:11:34.864857495Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7856278415543673": {
+				"ID":          7856278415543673,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5873399707930875,
+				"StableID":   "nkuHgYF5sn11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       5873399707930875,
+				"Key":        "nodekey:cc6f5a3a207f5c39ed962d0781cb807109ba7dea69a8d53d7aad93625fb7af7f",
+				"DiscoKey":   "discokey:74f2b63be50beb5872dd750c982af92e8f812a0045f04428b41a7be72219673e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:55933",
+					"10.65.0.27:55933",
+					"172.17.0.1:55933",
+					"172.18.0.1:55933",
+					"172.19.0.1:55933",
+					"172.20.0.1:55933",
+					"172.21.0.1:55933",
+					"172.22.0.1:55933",
+					"172.23.0.1:55933",
+					"172.24.0.1:55933",
+					"172.25.0.1:55933",
+					"172.26.0.1:55933",
+					"172.27.0.1:55933",
+					"172.28.0.1:55933"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:11:30.054301025Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:cc6f5a3a207f5c39ed962d0781cb807109ba7dea69a8d53d7aad93625fb7af7f",
+			"MachineKey": "mkey:8a506cfab13fff67363e037c33366a63b8bc3213a98cdf70c37046f470f29b6e",
+			"Peers": [{
+				"ID":         4823921244737725,
+				"StableID":   "ntA1fQEmfe11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f068dde163d424c95e759f9278b627be1cf3f12b6aa7a50bb9604a80e82f097f",
+				"DiscoKey":   "discokey:6675d05fe875b8b93ac8f93688deee270c3b43e322406902e4ac1043fc06f03e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49772",
+					"10.65.0.27:49772",
+					"172.17.0.1:49772",
+					"172.18.0.1:49772",
+					"172.19.0.1:49772",
+					"172.20.0.1:49772",
+					"172.21.0.1:49772",
+					"172.22.0.1:49772",
+					"172.23.0.1:49772",
+					"172.24.0.1:49772",
+					"172.25.0.1:49772",
+					"172.26.0.1:49772",
+					"172.27.0.1:49772",
+					"172.28.0.1:49772"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:11:27.232727782Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6899673838592495,
+				"StableID":   "n8q1JTjssv11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a939923c6709e023a453589020af9955f819688b31d22c523ea2ae11a4f54473",
+				"DiscoKey":   "discokey:0bba3699d6f26057022b54d80c5442f14d6663fb2046f8852e3117ae855f5e24",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48989",
+					"10.65.0.27:48989",
+					"172.17.0.1:48989",
+					"172.18.0.1:48989",
+					"172.19.0.1:48989",
+					"172.20.0.1:48989",
+					"172.21.0.1:48989",
+					"172.22.0.1:48989",
+					"172.23.0.1:48989",
+					"172.24.0.1:48989",
+					"172.25.0.1:48989",
+					"172.26.0.1:48989",
+					"172.27.0.1:48989",
+					"172.28.0.1:48989"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:11:27.923232747Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1471710141868880,
+				"StableID":   "nmFwb8LYVC11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2298aed6a48ed64120efa52f711067dc887fbb9c78bc864a282ae81a41e96732",
+				"DiscoKey":   "discokey:6b899c9ec15deaac0adeb76364629ef96084f446898f033bc5bdf42c3c893012",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46576",
+					"10.65.0.27:46576",
+					"172.17.0.1:46576",
+					"172.18.0.1:46576",
+					"172.19.0.1:46576",
+					"172.20.0.1:46576",
+					"172.21.0.1:46576",
+					"172.22.0.1:46576",
+					"172.23.0.1:46576",
+					"172.24.0.1:46576",
+					"172.25.0.1:46576",
+					"172.26.0.1:46576",
+					"172.27.0.1:46576",
+					"172.28.0.1:46576"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:11:28.449863702Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7940710577154745,
+				"StableID":   "nA51271N1521CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:426acaea24fe205eeb09b4bcd6cfef17b807be74987d174da3507fa777b43b39",
+				"DiscoKey":   "discokey:079b1c7162b2484e86d4e530566fa84bd0aea1363341d869c93650c47ad91669",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51637",
+					"10.65.0.27:51637",
+					"172.17.0.1:51637",
+					"172.18.0.1:51637",
+					"172.19.0.1:51637",
+					"172.20.0.1:51637",
+					"172.21.0.1:51637",
+					"172.22.0.1:51637",
+					"172.23.0.1:51637",
+					"172.24.0.1:51637",
+					"172.25.0.1:51637",
+					"172.26.0.1:51637",
+					"172.27.0.1:51637",
+					"172.28.0.1:51637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:11:28.980992142Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6660706170020454,
+				"StableID":   "nouDjUTe1u11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:824d25b0ed9a20d2e5e73a97fd435be5e132f908935ff995c2856eda964e602e",
+				"DiscoKey":   "discokey:4944a073658a867807dcaaa0bcc54aa9d2985cefc75903f887aabb9d76890401",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49396",
+					"10.65.0.27:49396",
+					"172.17.0.1:49396",
+					"172.18.0.1:49396",
+					"172.19.0.1:49396",
+					"172.20.0.1:49396",
+					"172.21.0.1:49396",
+					"172.22.0.1:49396",
+					"172.23.0.1:49396",
+					"172.24.0.1:49396",
+					"172.25.0.1:49396",
+					"172.26.0.1:49396",
+					"172.27.0.1:49396",
+					"172.28.0.1:49396"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:11:29.514432602Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4656389653246852,
+				"StableID":   "n1wobhTtMd11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab21ee6bc3991d19001955bdc61e9cf0a700cff60d9dfafc40f3b4b7e0014e6b",
+				"DiscoKey":   "discokey:a4ace807754e1f8f1bc5d7401a012f47722344950a7d4382f35763bc80635527",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49126",
+					"10.65.0.27:49126",
+					"172.17.0.1:49126",
+					"172.18.0.1:49126",
+					"172.19.0.1:49126",
+					"172.20.0.1:49126",
+					"172.21.0.1:49126",
+					"172.22.0.1:49126",
+					"172.23.0.1:49126",
+					"172.24.0.1:49126",
+					"172.25.0.1:49126",
+					"172.26.0.1:49126",
+					"172.27.0.1:49126",
+					"172.28.0.1:49126"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:11:30.590573831Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5001212125978712,
+				"StableID":   "n3a8jzM44g11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec03bcd34d887fac2f5806d20af78c18471da65ced6cb98a8fb8d998bcb75d7c",
+				"DiscoKey":   "discokey:26a6b3741cf31a22ad599c14d9ecf96b17c12f32eb12f421aff04a7d2cb9cf0e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:43845",
+					"10.65.0.27:43845",
+					"172.17.0.1:43845",
+					"172.18.0.1:43845",
+					"172.19.0.1:43845",
+					"172.20.0.1:43845",
+					"172.21.0.1:43845",
+					"172.22.0.1:43845",
+					"172.23.0.1:43845",
+					"172.24.0.1:43845",
+					"172.25.0.1:43845",
+					"172.26.0.1:43845",
+					"172.27.0.1:43845",
+					"172.28.0.1:43845"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:11:31.127153854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8230806459247696,
+				"StableID":   "noYQj4LkG721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:98c9889cf909a88aa69a7a805f56567152d341d8ead559c7c43a918bbc6c4550",
+				"DiscoKey":   "discokey:d8b6802b5f0f2ae9e55751ff60079767a9eb2eea4eb8a6892957efc63308fe19",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41417",
+					"10.65.0.27:41417",
+					"172.17.0.1:41417",
+					"172.18.0.1:41417",
+					"172.19.0.1:41417",
+					"172.20.0.1:41417",
+					"172.21.0.1:41417",
+					"172.22.0.1:41417",
+					"172.23.0.1:41417",
+					"172.24.0.1:41417",
+					"172.25.0.1:41417",
+					"172.26.0.1:41417",
+					"172.27.0.1:41417",
+					"172.28.0.1:41417"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:11:31.681478377Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2192643219519776,
+				"StableID":   "n9dPx7248J11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af6c197aeeb2e8861e26d078ca62f84d392098e251a67c90bea1b4be6481f54a",
+				"DiscoKey":   "discokey:7532d187e881aa70abce6c4c7bdd356aa424d83c5ffaafb82e58253c89e68f36",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53872",
+					"10.65.0.27:53872",
+					"172.17.0.1:53872",
+					"172.18.0.1:53872",
+					"172.19.0.1:53872",
+					"172.20.0.1:53872",
+					"172.21.0.1:53872",
+					"172.22.0.1:53872",
+					"172.23.0.1:53872",
+					"172.24.0.1:53872",
+					"172.25.0.1:53872",
+					"172.26.0.1:53872",
+					"172.27.0.1:53872",
+					"172.28.0.1:53872"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:11:32.210491783Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6622337448797789,
+				"StableID":   "nxapDNaGit11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dbe12d6b4c2392dca0667ad6893de8f72f4131b6f591707f4dd34780dc741826",
+				"DiscoKey":   "discokey:b9fd436af9d9e5ff2f9eaedee7859d1df32bd38fecd5ee974dccc85159f08f67",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:46146",
+					"10.65.0.27:46146",
+					"172.17.0.1:46146",
+					"172.18.0.1:46146",
+					"172.19.0.1:46146",
+					"172.20.0.1:46146",
+					"172.21.0.1:46146",
+					"172.22.0.1:46146",
+					"172.23.0.1:46146",
+					"172.24.0.1:46146",
+					"172.25.0.1:46146",
+					"172.26.0.1:46146",
+					"172.27.0.1:46146",
+					"172.28.0.1:46146"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:11:32.736529232Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7856278415543673,
+				"StableID":   "nLSA2W78M421CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7cadaeda40fba18caa1a95233b305c0775f9af6fb6dd5d177177e5035c391f18",
+				"DiscoKey":   "discokey:0e27b0982812192999a486818efd2b538c068e2d6e126f1e64274a747ee2076c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56971",
+					"10.65.0.27:56971",
+					"172.17.0.1:56971",
+					"172.18.0.1:56971",
+					"172.19.0.1:56971",
+					"172.20.0.1:56971",
+					"172.21.0.1:56971",
+					"172.22.0.1:56971",
+					"172.23.0.1:56971",
+					"172.24.0.1:56971",
+					"172.25.0.1:56971",
+					"172.26.0.1:56971",
+					"172.27.0.1:56971",
+					"172.28.0.1:56971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:11:33.269378521Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3275348019449656,
+				"StableID":   "nD1SadqQaS11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e5231c42fd704c10efbcb05513f8da10f5c9075a07e35f01e68e8fed1f197303",
+				"KeyExpiry":  "2026-11-09T09:11:33Z",
+				"DiscoKey":   "discokey:366f52ee691c4951951fa6e77637baf9df2af6d4a55a58a337c203504528a558",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51315",
+					"10.65.0.27:51315",
+					"172.17.0.1:51315",
+					"172.18.0.1:51315",
+					"172.19.0.1:51315",
+					"172.20.0.1:51315",
+					"172.21.0.1:51315",
+					"172.22.0.1:51315",
+					"172.23.0.1:51315",
+					"172.24.0.1:51315",
+					"172.25.0.1:51315",
+					"172.26.0.1:51315",
+					"172.27.0.1:51315",
+					"172.28.0.1:51315"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:11:33.803521751Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4381600078349493,
+				"StableID":   "nEyfqqCSDb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ffa0f8aa48637ca141b05817dbf6a0d45e92a0147c93d303a0aaf6f0dd08100b",
+				"KeyExpiry":  "2026-11-09T09:11:34Z",
+				"DiscoKey":   "discokey:d87c169006961b0a3995a127a1b8792f58a8de44be722aeaed40c2214798ea38",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54975",
+					"10.65.0.27:54975",
+					"172.17.0.1:54975",
+					"172.18.0.1:54975",
+					"172.19.0.1:54975",
+					"172.20.0.1:54975",
+					"172.21.0.1:54975",
+					"172.22.0.1:54975",
+					"172.23.0.1:54975",
+					"172.24.0.1:54975",
+					"172.25.0.1:54975",
+					"172.26.0.1:54975",
+					"172.27.0.1:54975",
+					"172.28.0.1:54975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:11:34.358798756Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1715639806292417,
+				"StableID":   "n6VUk1x1QE11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dca640dfeecac31a14fdc8ce04c12453b3e18022a60be8130b9b0b604bcc5512",
+				"KeyExpiry":  "2026-11-09T09:11:34Z",
+				"DiscoKey":   "discokey:f31f77fed26171b732ea2c186ed3ef41e799151469c17a4b33a851462ea9ff4b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57841",
+					"10.65.0.27:57841",
+					"172.17.0.1:57841",
+					"172.18.0.1:57841",
+					"172.19.0.1:57841",
+					"172.20.0.1:57841",
+					"172.21.0.1:57841",
+					"172.22.0.1:57841",
+					"172.23.0.1:57841",
+					"172.24.0.1:57841",
+					"172.25.0.1:57841",
+					"172.26.0.1:57841",
+					"172.27.0.1:57841",
+					"172.28.0.1:57841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:11:34.864857495Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5873399707930875": {
+				"ID":          5873399707930875,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1715639806292417,
+				"StableID":   "n6VUk1x1QE11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dca640dfeecac31a14fdc8ce04c12453b3e18022a60be8130b9b0b604bcc5512",
+				"KeyExpiry":  "2026-11-09T09:11:34Z",
+				"DiscoKey":   "discokey:f31f77fed26171b732ea2c186ed3ef41e799151469c17a4b33a851462ea9ff4b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57841",
+					"10.65.0.27:57841",
+					"172.17.0.1:57841",
+					"172.18.0.1:57841",
+					"172.19.0.1:57841",
+					"172.20.0.1:57841",
+					"172.21.0.1:57841",
+					"172.22.0.1:57841",
+					"172.23.0.1:57841",
+					"172.24.0.1:57841",
+					"172.25.0.1:57841",
+					"172.26.0.1:57841",
+					"172.27.0.1:57841",
+					"172.28.0.1:57841"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:11:34.864857495Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:dca640dfeecac31a14fdc8ce04c12453b3e18022a60be8130b9b0b604bcc5512",
+			"MachineKey": "mkey:9464690b370ae4a2d10fa144f420aeb4e81cf8d5c2ff87b1438613ad6fa3351b",
+			"Peers": [{
+				"ID":         4823921244737725,
+				"StableID":   "ntA1fQEmfe11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f068dde163d424c95e759f9278b627be1cf3f12b6aa7a50bb9604a80e82f097f",
+				"DiscoKey":   "discokey:6675d05fe875b8b93ac8f93688deee270c3b43e322406902e4ac1043fc06f03e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49772",
+					"10.65.0.27:49772",
+					"172.17.0.1:49772",
+					"172.18.0.1:49772",
+					"172.19.0.1:49772",
+					"172.20.0.1:49772",
+					"172.21.0.1:49772",
+					"172.22.0.1:49772",
+					"172.23.0.1:49772",
+					"172.24.0.1:49772",
+					"172.25.0.1:49772",
+					"172.26.0.1:49772",
+					"172.27.0.1:49772",
+					"172.28.0.1:49772"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:11:27.232727782Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6899673838592495,
+				"StableID":   "n8q1JTjssv11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a939923c6709e023a453589020af9955f819688b31d22c523ea2ae11a4f54473",
+				"DiscoKey":   "discokey:0bba3699d6f26057022b54d80c5442f14d6663fb2046f8852e3117ae855f5e24",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48989",
+					"10.65.0.27:48989",
+					"172.17.0.1:48989",
+					"172.18.0.1:48989",
+					"172.19.0.1:48989",
+					"172.20.0.1:48989",
+					"172.21.0.1:48989",
+					"172.22.0.1:48989",
+					"172.23.0.1:48989",
+					"172.24.0.1:48989",
+					"172.25.0.1:48989",
+					"172.26.0.1:48989",
+					"172.27.0.1:48989",
+					"172.28.0.1:48989"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:11:27.923232747Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1471710141868880,
+				"StableID":   "nmFwb8LYVC11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2298aed6a48ed64120efa52f711067dc887fbb9c78bc864a282ae81a41e96732",
+				"DiscoKey":   "discokey:6b899c9ec15deaac0adeb76364629ef96084f446898f033bc5bdf42c3c893012",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46576",
+					"10.65.0.27:46576",
+					"172.17.0.1:46576",
+					"172.18.0.1:46576",
+					"172.19.0.1:46576",
+					"172.20.0.1:46576",
+					"172.21.0.1:46576",
+					"172.22.0.1:46576",
+					"172.23.0.1:46576",
+					"172.24.0.1:46576",
+					"172.25.0.1:46576",
+					"172.26.0.1:46576",
+					"172.27.0.1:46576",
+					"172.28.0.1:46576"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:11:28.449863702Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7940710577154745,
+				"StableID":   "nA51271N1521CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:426acaea24fe205eeb09b4bcd6cfef17b807be74987d174da3507fa777b43b39",
+				"DiscoKey":   "discokey:079b1c7162b2484e86d4e530566fa84bd0aea1363341d869c93650c47ad91669",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51637",
+					"10.65.0.27:51637",
+					"172.17.0.1:51637",
+					"172.18.0.1:51637",
+					"172.19.0.1:51637",
+					"172.20.0.1:51637",
+					"172.21.0.1:51637",
+					"172.22.0.1:51637",
+					"172.23.0.1:51637",
+					"172.24.0.1:51637",
+					"172.25.0.1:51637",
+					"172.26.0.1:51637",
+					"172.27.0.1:51637",
+					"172.28.0.1:51637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:11:28.980992142Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6660706170020454,
+				"StableID":   "nouDjUTe1u11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:824d25b0ed9a20d2e5e73a97fd435be5e132f908935ff995c2856eda964e602e",
+				"DiscoKey":   "discokey:4944a073658a867807dcaaa0bcc54aa9d2985cefc75903f887aabb9d76890401",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49396",
+					"10.65.0.27:49396",
+					"172.17.0.1:49396",
+					"172.18.0.1:49396",
+					"172.19.0.1:49396",
+					"172.20.0.1:49396",
+					"172.21.0.1:49396",
+					"172.22.0.1:49396",
+					"172.23.0.1:49396",
+					"172.24.0.1:49396",
+					"172.25.0.1:49396",
+					"172.26.0.1:49396",
+					"172.27.0.1:49396",
+					"172.28.0.1:49396"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:11:29.514432602Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5873399707930875,
+				"StableID":   "nkuHgYF5sn11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc6f5a3a207f5c39ed962d0781cb807109ba7dea69a8d53d7aad93625fb7af7f",
+				"DiscoKey":   "discokey:74f2b63be50beb5872dd750c982af92e8f812a0045f04428b41a7be72219673e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:55933",
+					"10.65.0.27:55933",
+					"172.17.0.1:55933",
+					"172.18.0.1:55933",
+					"172.19.0.1:55933",
+					"172.20.0.1:55933",
+					"172.21.0.1:55933",
+					"172.22.0.1:55933",
+					"172.23.0.1:55933",
+					"172.24.0.1:55933",
+					"172.25.0.1:55933",
+					"172.26.0.1:55933",
+					"172.27.0.1:55933",
+					"172.28.0.1:55933"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:11:30.054301025Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4656389653246852,
+				"StableID":   "n1wobhTtMd11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab21ee6bc3991d19001955bdc61e9cf0a700cff60d9dfafc40f3b4b7e0014e6b",
+				"DiscoKey":   "discokey:a4ace807754e1f8f1bc5d7401a012f47722344950a7d4382f35763bc80635527",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49126",
+					"10.65.0.27:49126",
+					"172.17.0.1:49126",
+					"172.18.0.1:49126",
+					"172.19.0.1:49126",
+					"172.20.0.1:49126",
+					"172.21.0.1:49126",
+					"172.22.0.1:49126",
+					"172.23.0.1:49126",
+					"172.24.0.1:49126",
+					"172.25.0.1:49126",
+					"172.26.0.1:49126",
+					"172.27.0.1:49126",
+					"172.28.0.1:49126"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:11:30.590573831Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5001212125978712,
+				"StableID":   "n3a8jzM44g11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec03bcd34d887fac2f5806d20af78c18471da65ced6cb98a8fb8d998bcb75d7c",
+				"DiscoKey":   "discokey:26a6b3741cf31a22ad599c14d9ecf96b17c12f32eb12f421aff04a7d2cb9cf0e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:43845",
+					"10.65.0.27:43845",
+					"172.17.0.1:43845",
+					"172.18.0.1:43845",
+					"172.19.0.1:43845",
+					"172.20.0.1:43845",
+					"172.21.0.1:43845",
+					"172.22.0.1:43845",
+					"172.23.0.1:43845",
+					"172.24.0.1:43845",
+					"172.25.0.1:43845",
+					"172.26.0.1:43845",
+					"172.27.0.1:43845",
+					"172.28.0.1:43845"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:11:31.127153854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8230806459247696,
+				"StableID":   "noYQj4LkG721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:98c9889cf909a88aa69a7a805f56567152d341d8ead559c7c43a918bbc6c4550",
+				"DiscoKey":   "discokey:d8b6802b5f0f2ae9e55751ff60079767a9eb2eea4eb8a6892957efc63308fe19",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41417",
+					"10.65.0.27:41417",
+					"172.17.0.1:41417",
+					"172.18.0.1:41417",
+					"172.19.0.1:41417",
+					"172.20.0.1:41417",
+					"172.21.0.1:41417",
+					"172.22.0.1:41417",
+					"172.23.0.1:41417",
+					"172.24.0.1:41417",
+					"172.25.0.1:41417",
+					"172.26.0.1:41417",
+					"172.27.0.1:41417",
+					"172.28.0.1:41417"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:11:31.681478377Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2192643219519776,
+				"StableID":   "n9dPx7248J11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af6c197aeeb2e8861e26d078ca62f84d392098e251a67c90bea1b4be6481f54a",
+				"DiscoKey":   "discokey:7532d187e881aa70abce6c4c7bdd356aa424d83c5ffaafb82e58253c89e68f36",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53872",
+					"10.65.0.27:53872",
+					"172.17.0.1:53872",
+					"172.18.0.1:53872",
+					"172.19.0.1:53872",
+					"172.20.0.1:53872",
+					"172.21.0.1:53872",
+					"172.22.0.1:53872",
+					"172.23.0.1:53872",
+					"172.24.0.1:53872",
+					"172.25.0.1:53872",
+					"172.26.0.1:53872",
+					"172.27.0.1:53872",
+					"172.28.0.1:53872"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:11:32.210491783Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6622337448797789,
+				"StableID":   "nxapDNaGit11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dbe12d6b4c2392dca0667ad6893de8f72f4131b6f591707f4dd34780dc741826",
+				"DiscoKey":   "discokey:b9fd436af9d9e5ff2f9eaedee7859d1df32bd38fecd5ee974dccc85159f08f67",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:46146",
+					"10.65.0.27:46146",
+					"172.17.0.1:46146",
+					"172.18.0.1:46146",
+					"172.19.0.1:46146",
+					"172.20.0.1:46146",
+					"172.21.0.1:46146",
+					"172.22.0.1:46146",
+					"172.23.0.1:46146",
+					"172.24.0.1:46146",
+					"172.25.0.1:46146",
+					"172.26.0.1:46146",
+					"172.27.0.1:46146",
+					"172.28.0.1:46146"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:11:32.736529232Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7856278415543673,
+				"StableID":   "nLSA2W78M421CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7cadaeda40fba18caa1a95233b305c0775f9af6fb6dd5d177177e5035c391f18",
+				"DiscoKey":   "discokey:0e27b0982812192999a486818efd2b538c068e2d6e126f1e64274a747ee2076c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56971",
+					"10.65.0.27:56971",
+					"172.17.0.1:56971",
+					"172.18.0.1:56971",
+					"172.19.0.1:56971",
+					"172.20.0.1:56971",
+					"172.21.0.1:56971",
+					"172.22.0.1:56971",
+					"172.23.0.1:56971",
+					"172.24.0.1:56971",
+					"172.25.0.1:56971",
+					"172.26.0.1:56971",
+					"172.27.0.1:56971",
+					"172.28.0.1:56971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:11:33.269378521Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3275348019449656,
+				"StableID":   "nD1SadqQaS11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e5231c42fd704c10efbcb05513f8da10f5c9075a07e35f01e68e8fed1f197303",
+				"KeyExpiry":  "2026-11-09T09:11:33Z",
+				"DiscoKey":   "discokey:366f52ee691c4951951fa6e77637baf9df2af6d4a55a58a337c203504528a558",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51315",
+					"10.65.0.27:51315",
+					"172.17.0.1:51315",
+					"172.18.0.1:51315",
+					"172.19.0.1:51315",
+					"172.20.0.1:51315",
+					"172.21.0.1:51315",
+					"172.22.0.1:51315",
+					"172.23.0.1:51315",
+					"172.24.0.1:51315",
+					"172.25.0.1:51315",
+					"172.26.0.1:51315",
+					"172.27.0.1:51315",
+					"172.28.0.1:51315"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:11:33.803521751Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4381600078349493,
+				"StableID":   "nEyfqqCSDb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ffa0f8aa48637ca141b05817dbf6a0d45e92a0147c93d303a0aaf6f0dd08100b",
+				"KeyExpiry":  "2026-11-09T09:11:34Z",
+				"DiscoKey":   "discokey:d87c169006961b0a3995a127a1b8792f58a8de44be722aeaed40c2214798ea38",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54975",
+					"10.65.0.27:54975",
+					"172.17.0.1:54975",
+					"172.18.0.1:54975",
+					"172.19.0.1:54975",
+					"172.20.0.1:54975",
+					"172.21.0.1:54975",
+					"172.22.0.1:54975",
+					"172.23.0.1:54975",
+					"172.24.0.1:54975",
+					"172.25.0.1:54975",
+					"172.26.0.1:54975",
+					"172.27.0.1:54975",
+					"172.28.0.1:54975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:11:34.358798756Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1471710141868880,
+				"StableID":   "nmFwb8LYVC11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1471710141868880,
+				"Key":        "nodekey:2298aed6a48ed64120efa52f711067dc887fbb9c78bc864a282ae81a41e96732",
+				"DiscoKey":   "discokey:6b899c9ec15deaac0adeb76364629ef96084f446898f033bc5bdf42c3c893012",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46576",
+					"10.65.0.27:46576",
+					"172.17.0.1:46576",
+					"172.18.0.1:46576",
+					"172.19.0.1:46576",
+					"172.20.0.1:46576",
+					"172.21.0.1:46576",
+					"172.22.0.1:46576",
+					"172.23.0.1:46576",
+					"172.24.0.1:46576",
+					"172.25.0.1:46576",
+					"172.26.0.1:46576",
+					"172.27.0.1:46576",
+					"172.28.0.1:46576"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:11:28.449863702Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2298aed6a48ed64120efa52f711067dc887fbb9c78bc864a282ae81a41e96732",
+			"MachineKey": "mkey:f4f011ea9dbba4719cbf2bf48b70c868fabaacac2cec0182c41ee3fa6648ae49",
+			"Peers": [{
+				"ID":         4823921244737725,
+				"StableID":   "ntA1fQEmfe11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f068dde163d424c95e759f9278b627be1cf3f12b6aa7a50bb9604a80e82f097f",
+				"DiscoKey":   "discokey:6675d05fe875b8b93ac8f93688deee270c3b43e322406902e4ac1043fc06f03e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49772",
+					"10.65.0.27:49772",
+					"172.17.0.1:49772",
+					"172.18.0.1:49772",
+					"172.19.0.1:49772",
+					"172.20.0.1:49772",
+					"172.21.0.1:49772",
+					"172.22.0.1:49772",
+					"172.23.0.1:49772",
+					"172.24.0.1:49772",
+					"172.25.0.1:49772",
+					"172.26.0.1:49772",
+					"172.27.0.1:49772",
+					"172.28.0.1:49772"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:11:27.232727782Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6899673838592495,
+				"StableID":   "n8q1JTjssv11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a939923c6709e023a453589020af9955f819688b31d22c523ea2ae11a4f54473",
+				"DiscoKey":   "discokey:0bba3699d6f26057022b54d80c5442f14d6663fb2046f8852e3117ae855f5e24",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48989",
+					"10.65.0.27:48989",
+					"172.17.0.1:48989",
+					"172.18.0.1:48989",
+					"172.19.0.1:48989",
+					"172.20.0.1:48989",
+					"172.21.0.1:48989",
+					"172.22.0.1:48989",
+					"172.23.0.1:48989",
+					"172.24.0.1:48989",
+					"172.25.0.1:48989",
+					"172.26.0.1:48989",
+					"172.27.0.1:48989",
+					"172.28.0.1:48989"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:11:27.923232747Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7940710577154745,
+				"StableID":   "nA51271N1521CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:426acaea24fe205eeb09b4bcd6cfef17b807be74987d174da3507fa777b43b39",
+				"DiscoKey":   "discokey:079b1c7162b2484e86d4e530566fa84bd0aea1363341d869c93650c47ad91669",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51637",
+					"10.65.0.27:51637",
+					"172.17.0.1:51637",
+					"172.18.0.1:51637",
+					"172.19.0.1:51637",
+					"172.20.0.1:51637",
+					"172.21.0.1:51637",
+					"172.22.0.1:51637",
+					"172.23.0.1:51637",
+					"172.24.0.1:51637",
+					"172.25.0.1:51637",
+					"172.26.0.1:51637",
+					"172.27.0.1:51637",
+					"172.28.0.1:51637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:11:28.980992142Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6660706170020454,
+				"StableID":   "nouDjUTe1u11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:824d25b0ed9a20d2e5e73a97fd435be5e132f908935ff995c2856eda964e602e",
+				"DiscoKey":   "discokey:4944a073658a867807dcaaa0bcc54aa9d2985cefc75903f887aabb9d76890401",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49396",
+					"10.65.0.27:49396",
+					"172.17.0.1:49396",
+					"172.18.0.1:49396",
+					"172.19.0.1:49396",
+					"172.20.0.1:49396",
+					"172.21.0.1:49396",
+					"172.22.0.1:49396",
+					"172.23.0.1:49396",
+					"172.24.0.1:49396",
+					"172.25.0.1:49396",
+					"172.26.0.1:49396",
+					"172.27.0.1:49396",
+					"172.28.0.1:49396"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:11:29.514432602Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5873399707930875,
+				"StableID":   "nkuHgYF5sn11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc6f5a3a207f5c39ed962d0781cb807109ba7dea69a8d53d7aad93625fb7af7f",
+				"DiscoKey":   "discokey:74f2b63be50beb5872dd750c982af92e8f812a0045f04428b41a7be72219673e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:55933",
+					"10.65.0.27:55933",
+					"172.17.0.1:55933",
+					"172.18.0.1:55933",
+					"172.19.0.1:55933",
+					"172.20.0.1:55933",
+					"172.21.0.1:55933",
+					"172.22.0.1:55933",
+					"172.23.0.1:55933",
+					"172.24.0.1:55933",
+					"172.25.0.1:55933",
+					"172.26.0.1:55933",
+					"172.27.0.1:55933",
+					"172.28.0.1:55933"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:11:30.054301025Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4656389653246852,
+				"StableID":   "n1wobhTtMd11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab21ee6bc3991d19001955bdc61e9cf0a700cff60d9dfafc40f3b4b7e0014e6b",
+				"DiscoKey":   "discokey:a4ace807754e1f8f1bc5d7401a012f47722344950a7d4382f35763bc80635527",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49126",
+					"10.65.0.27:49126",
+					"172.17.0.1:49126",
+					"172.18.0.1:49126",
+					"172.19.0.1:49126",
+					"172.20.0.1:49126",
+					"172.21.0.1:49126",
+					"172.22.0.1:49126",
+					"172.23.0.1:49126",
+					"172.24.0.1:49126",
+					"172.25.0.1:49126",
+					"172.26.0.1:49126",
+					"172.27.0.1:49126",
+					"172.28.0.1:49126"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:11:30.590573831Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5001212125978712,
+				"StableID":   "n3a8jzM44g11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec03bcd34d887fac2f5806d20af78c18471da65ced6cb98a8fb8d998bcb75d7c",
+				"DiscoKey":   "discokey:26a6b3741cf31a22ad599c14d9ecf96b17c12f32eb12f421aff04a7d2cb9cf0e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:43845",
+					"10.65.0.27:43845",
+					"172.17.0.1:43845",
+					"172.18.0.1:43845",
+					"172.19.0.1:43845",
+					"172.20.0.1:43845",
+					"172.21.0.1:43845",
+					"172.22.0.1:43845",
+					"172.23.0.1:43845",
+					"172.24.0.1:43845",
+					"172.25.0.1:43845",
+					"172.26.0.1:43845",
+					"172.27.0.1:43845",
+					"172.28.0.1:43845"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:11:31.127153854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8230806459247696,
+				"StableID":   "noYQj4LkG721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:98c9889cf909a88aa69a7a805f56567152d341d8ead559c7c43a918bbc6c4550",
+				"DiscoKey":   "discokey:d8b6802b5f0f2ae9e55751ff60079767a9eb2eea4eb8a6892957efc63308fe19",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41417",
+					"10.65.0.27:41417",
+					"172.17.0.1:41417",
+					"172.18.0.1:41417",
+					"172.19.0.1:41417",
+					"172.20.0.1:41417",
+					"172.21.0.1:41417",
+					"172.22.0.1:41417",
+					"172.23.0.1:41417",
+					"172.24.0.1:41417",
+					"172.25.0.1:41417",
+					"172.26.0.1:41417",
+					"172.27.0.1:41417",
+					"172.28.0.1:41417"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:11:31.681478377Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2192643219519776,
+				"StableID":   "n9dPx7248J11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af6c197aeeb2e8861e26d078ca62f84d392098e251a67c90bea1b4be6481f54a",
+				"DiscoKey":   "discokey:7532d187e881aa70abce6c4c7bdd356aa424d83c5ffaafb82e58253c89e68f36",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53872",
+					"10.65.0.27:53872",
+					"172.17.0.1:53872",
+					"172.18.0.1:53872",
+					"172.19.0.1:53872",
+					"172.20.0.1:53872",
+					"172.21.0.1:53872",
+					"172.22.0.1:53872",
+					"172.23.0.1:53872",
+					"172.24.0.1:53872",
+					"172.25.0.1:53872",
+					"172.26.0.1:53872",
+					"172.27.0.1:53872",
+					"172.28.0.1:53872"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:11:32.210491783Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6622337448797789,
+				"StableID":   "nxapDNaGit11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dbe12d6b4c2392dca0667ad6893de8f72f4131b6f591707f4dd34780dc741826",
+				"DiscoKey":   "discokey:b9fd436af9d9e5ff2f9eaedee7859d1df32bd38fecd5ee974dccc85159f08f67",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:46146",
+					"10.65.0.27:46146",
+					"172.17.0.1:46146",
+					"172.18.0.1:46146",
+					"172.19.0.1:46146",
+					"172.20.0.1:46146",
+					"172.21.0.1:46146",
+					"172.22.0.1:46146",
+					"172.23.0.1:46146",
+					"172.24.0.1:46146",
+					"172.25.0.1:46146",
+					"172.26.0.1:46146",
+					"172.27.0.1:46146",
+					"172.28.0.1:46146"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:11:32.736529232Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7856278415543673,
+				"StableID":   "nLSA2W78M421CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7cadaeda40fba18caa1a95233b305c0775f9af6fb6dd5d177177e5035c391f18",
+				"DiscoKey":   "discokey:0e27b0982812192999a486818efd2b538c068e2d6e126f1e64274a747ee2076c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56971",
+					"10.65.0.27:56971",
+					"172.17.0.1:56971",
+					"172.18.0.1:56971",
+					"172.19.0.1:56971",
+					"172.20.0.1:56971",
+					"172.21.0.1:56971",
+					"172.22.0.1:56971",
+					"172.23.0.1:56971",
+					"172.24.0.1:56971",
+					"172.25.0.1:56971",
+					"172.26.0.1:56971",
+					"172.27.0.1:56971",
+					"172.28.0.1:56971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:11:33.269378521Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3275348019449656,
+				"StableID":   "nD1SadqQaS11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e5231c42fd704c10efbcb05513f8da10f5c9075a07e35f01e68e8fed1f197303",
+				"KeyExpiry":  "2026-11-09T09:11:33Z",
+				"DiscoKey":   "discokey:366f52ee691c4951951fa6e77637baf9df2af6d4a55a58a337c203504528a558",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51315",
+					"10.65.0.27:51315",
+					"172.17.0.1:51315",
+					"172.18.0.1:51315",
+					"172.19.0.1:51315",
+					"172.20.0.1:51315",
+					"172.21.0.1:51315",
+					"172.22.0.1:51315",
+					"172.23.0.1:51315",
+					"172.24.0.1:51315",
+					"172.25.0.1:51315",
+					"172.26.0.1:51315",
+					"172.27.0.1:51315",
+					"172.28.0.1:51315"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:11:33.803521751Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4381600078349493,
+				"StableID":   "nEyfqqCSDb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ffa0f8aa48637ca141b05817dbf6a0d45e92a0147c93d303a0aaf6f0dd08100b",
+				"KeyExpiry":  "2026-11-09T09:11:34Z",
+				"DiscoKey":   "discokey:d87c169006961b0a3995a127a1b8792f58a8de44be722aeaed40c2214798ea38",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54975",
+					"10.65.0.27:54975",
+					"172.17.0.1:54975",
+					"172.18.0.1:54975",
+					"172.19.0.1:54975",
+					"172.20.0.1:54975",
+					"172.21.0.1:54975",
+					"172.22.0.1:54975",
+					"172.23.0.1:54975",
+					"172.24.0.1:54975",
+					"172.25.0.1:54975",
+					"172.26.0.1:54975",
+					"172.27.0.1:54975",
+					"172.28.0.1:54975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:11:34.358798756Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1715639806292417,
+				"StableID":   "n6VUk1x1QE11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dca640dfeecac31a14fdc8ce04c12453b3e18022a60be8130b9b0b604bcc5512",
+				"KeyExpiry":  "2026-11-09T09:11:34Z",
+				"DiscoKey":   "discokey:f31f77fed26171b732ea2c186ed3ef41e799151469c17a4b33a851462ea9ff4b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57841",
+					"10.65.0.27:57841",
+					"172.17.0.1:57841",
+					"172.18.0.1:57841",
+					"172.19.0.1:57841",
+					"172.20.0.1:57841",
+					"172.21.0.1:57841",
+					"172.22.0.1:57841",
+					"172.23.0.1:57841",
+					"172.24.0.1:57841",
+					"172.25.0.1:57841",
+					"172.26.0.1:57841",
+					"172.27.0.1:57841",
+					"172.28.0.1:57841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:11:34.864857495Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1471710141868880": {
+				"ID":          1471710141868880,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5001212125978712,
+				"StableID":   "n3a8jzM44g11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       5001212125978712,
+				"Key":        "nodekey:ec03bcd34d887fac2f5806d20af78c18471da65ced6cb98a8fb8d998bcb75d7c",
+				"DiscoKey":   "discokey:26a6b3741cf31a22ad599c14d9ecf96b17c12f32eb12f421aff04a7d2cb9cf0e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:43845",
+					"10.65.0.27:43845",
+					"172.17.0.1:43845",
+					"172.18.0.1:43845",
+					"172.19.0.1:43845",
+					"172.20.0.1:43845",
+					"172.21.0.1:43845",
+					"172.22.0.1:43845",
+					"172.23.0.1:43845",
+					"172.24.0.1:43845",
+					"172.25.0.1:43845",
+					"172.26.0.1:43845",
+					"172.27.0.1:43845",
+					"172.28.0.1:43845"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:11:31.127153854Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ec03bcd34d887fac2f5806d20af78c18471da65ced6cb98a8fb8d998bcb75d7c",
+			"MachineKey": "mkey:a2b9fed2e43d3aa75a07ca958439f2245820a23f09fbdf87e7719af6b87b0e6d",
+			"Peers": [{
+				"ID":         4823921244737725,
+				"StableID":   "ntA1fQEmfe11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f068dde163d424c95e759f9278b627be1cf3f12b6aa7a50bb9604a80e82f097f",
+				"DiscoKey":   "discokey:6675d05fe875b8b93ac8f93688deee270c3b43e322406902e4ac1043fc06f03e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49772",
+					"10.65.0.27:49772",
+					"172.17.0.1:49772",
+					"172.18.0.1:49772",
+					"172.19.0.1:49772",
+					"172.20.0.1:49772",
+					"172.21.0.1:49772",
+					"172.22.0.1:49772",
+					"172.23.0.1:49772",
+					"172.24.0.1:49772",
+					"172.25.0.1:49772",
+					"172.26.0.1:49772",
+					"172.27.0.1:49772",
+					"172.28.0.1:49772"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:11:27.232727782Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6899673838592495,
+				"StableID":   "n8q1JTjssv11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a939923c6709e023a453589020af9955f819688b31d22c523ea2ae11a4f54473",
+				"DiscoKey":   "discokey:0bba3699d6f26057022b54d80c5442f14d6663fb2046f8852e3117ae855f5e24",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48989",
+					"10.65.0.27:48989",
+					"172.17.0.1:48989",
+					"172.18.0.1:48989",
+					"172.19.0.1:48989",
+					"172.20.0.1:48989",
+					"172.21.0.1:48989",
+					"172.22.0.1:48989",
+					"172.23.0.1:48989",
+					"172.24.0.1:48989",
+					"172.25.0.1:48989",
+					"172.26.0.1:48989",
+					"172.27.0.1:48989",
+					"172.28.0.1:48989"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:11:27.923232747Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1471710141868880,
+				"StableID":   "nmFwb8LYVC11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2298aed6a48ed64120efa52f711067dc887fbb9c78bc864a282ae81a41e96732",
+				"DiscoKey":   "discokey:6b899c9ec15deaac0adeb76364629ef96084f446898f033bc5bdf42c3c893012",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46576",
+					"10.65.0.27:46576",
+					"172.17.0.1:46576",
+					"172.18.0.1:46576",
+					"172.19.0.1:46576",
+					"172.20.0.1:46576",
+					"172.21.0.1:46576",
+					"172.22.0.1:46576",
+					"172.23.0.1:46576",
+					"172.24.0.1:46576",
+					"172.25.0.1:46576",
+					"172.26.0.1:46576",
+					"172.27.0.1:46576",
+					"172.28.0.1:46576"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:11:28.449863702Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7940710577154745,
+				"StableID":   "nA51271N1521CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:426acaea24fe205eeb09b4bcd6cfef17b807be74987d174da3507fa777b43b39",
+				"DiscoKey":   "discokey:079b1c7162b2484e86d4e530566fa84bd0aea1363341d869c93650c47ad91669",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51637",
+					"10.65.0.27:51637",
+					"172.17.0.1:51637",
+					"172.18.0.1:51637",
+					"172.19.0.1:51637",
+					"172.20.0.1:51637",
+					"172.21.0.1:51637",
+					"172.22.0.1:51637",
+					"172.23.0.1:51637",
+					"172.24.0.1:51637",
+					"172.25.0.1:51637",
+					"172.26.0.1:51637",
+					"172.27.0.1:51637",
+					"172.28.0.1:51637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:11:28.980992142Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6660706170020454,
+				"StableID":   "nouDjUTe1u11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:824d25b0ed9a20d2e5e73a97fd435be5e132f908935ff995c2856eda964e602e",
+				"DiscoKey":   "discokey:4944a073658a867807dcaaa0bcc54aa9d2985cefc75903f887aabb9d76890401",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49396",
+					"10.65.0.27:49396",
+					"172.17.0.1:49396",
+					"172.18.0.1:49396",
+					"172.19.0.1:49396",
+					"172.20.0.1:49396",
+					"172.21.0.1:49396",
+					"172.22.0.1:49396",
+					"172.23.0.1:49396",
+					"172.24.0.1:49396",
+					"172.25.0.1:49396",
+					"172.26.0.1:49396",
+					"172.27.0.1:49396",
+					"172.28.0.1:49396"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:11:29.514432602Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5873399707930875,
+				"StableID":   "nkuHgYF5sn11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc6f5a3a207f5c39ed962d0781cb807109ba7dea69a8d53d7aad93625fb7af7f",
+				"DiscoKey":   "discokey:74f2b63be50beb5872dd750c982af92e8f812a0045f04428b41a7be72219673e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:55933",
+					"10.65.0.27:55933",
+					"172.17.0.1:55933",
+					"172.18.0.1:55933",
+					"172.19.0.1:55933",
+					"172.20.0.1:55933",
+					"172.21.0.1:55933",
+					"172.22.0.1:55933",
+					"172.23.0.1:55933",
+					"172.24.0.1:55933",
+					"172.25.0.1:55933",
+					"172.26.0.1:55933",
+					"172.27.0.1:55933",
+					"172.28.0.1:55933"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:11:30.054301025Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4656389653246852,
+				"StableID":   "n1wobhTtMd11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab21ee6bc3991d19001955bdc61e9cf0a700cff60d9dfafc40f3b4b7e0014e6b",
+				"DiscoKey":   "discokey:a4ace807754e1f8f1bc5d7401a012f47722344950a7d4382f35763bc80635527",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49126",
+					"10.65.0.27:49126",
+					"172.17.0.1:49126",
+					"172.18.0.1:49126",
+					"172.19.0.1:49126",
+					"172.20.0.1:49126",
+					"172.21.0.1:49126",
+					"172.22.0.1:49126",
+					"172.23.0.1:49126",
+					"172.24.0.1:49126",
+					"172.25.0.1:49126",
+					"172.26.0.1:49126",
+					"172.27.0.1:49126",
+					"172.28.0.1:49126"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:11:30.590573831Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8230806459247696,
+				"StableID":   "noYQj4LkG721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:98c9889cf909a88aa69a7a805f56567152d341d8ead559c7c43a918bbc6c4550",
+				"DiscoKey":   "discokey:d8b6802b5f0f2ae9e55751ff60079767a9eb2eea4eb8a6892957efc63308fe19",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41417",
+					"10.65.0.27:41417",
+					"172.17.0.1:41417",
+					"172.18.0.1:41417",
+					"172.19.0.1:41417",
+					"172.20.0.1:41417",
+					"172.21.0.1:41417",
+					"172.22.0.1:41417",
+					"172.23.0.1:41417",
+					"172.24.0.1:41417",
+					"172.25.0.1:41417",
+					"172.26.0.1:41417",
+					"172.27.0.1:41417",
+					"172.28.0.1:41417"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:11:31.681478377Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2192643219519776,
+				"StableID":   "n9dPx7248J11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af6c197aeeb2e8861e26d078ca62f84d392098e251a67c90bea1b4be6481f54a",
+				"DiscoKey":   "discokey:7532d187e881aa70abce6c4c7bdd356aa424d83c5ffaafb82e58253c89e68f36",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53872",
+					"10.65.0.27:53872",
+					"172.17.0.1:53872",
+					"172.18.0.1:53872",
+					"172.19.0.1:53872",
+					"172.20.0.1:53872",
+					"172.21.0.1:53872",
+					"172.22.0.1:53872",
+					"172.23.0.1:53872",
+					"172.24.0.1:53872",
+					"172.25.0.1:53872",
+					"172.26.0.1:53872",
+					"172.27.0.1:53872",
+					"172.28.0.1:53872"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:11:32.210491783Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6622337448797789,
+				"StableID":   "nxapDNaGit11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dbe12d6b4c2392dca0667ad6893de8f72f4131b6f591707f4dd34780dc741826",
+				"DiscoKey":   "discokey:b9fd436af9d9e5ff2f9eaedee7859d1df32bd38fecd5ee974dccc85159f08f67",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:46146",
+					"10.65.0.27:46146",
+					"172.17.0.1:46146",
+					"172.18.0.1:46146",
+					"172.19.0.1:46146",
+					"172.20.0.1:46146",
+					"172.21.0.1:46146",
+					"172.22.0.1:46146",
+					"172.23.0.1:46146",
+					"172.24.0.1:46146",
+					"172.25.0.1:46146",
+					"172.26.0.1:46146",
+					"172.27.0.1:46146",
+					"172.28.0.1:46146"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:11:32.736529232Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7856278415543673,
+				"StableID":   "nLSA2W78M421CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7cadaeda40fba18caa1a95233b305c0775f9af6fb6dd5d177177e5035c391f18",
+				"DiscoKey":   "discokey:0e27b0982812192999a486818efd2b538c068e2d6e126f1e64274a747ee2076c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56971",
+					"10.65.0.27:56971",
+					"172.17.0.1:56971",
+					"172.18.0.1:56971",
+					"172.19.0.1:56971",
+					"172.20.0.1:56971",
+					"172.21.0.1:56971",
+					"172.22.0.1:56971",
+					"172.23.0.1:56971",
+					"172.24.0.1:56971",
+					"172.25.0.1:56971",
+					"172.26.0.1:56971",
+					"172.27.0.1:56971",
+					"172.28.0.1:56971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:11:33.269378521Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3275348019449656,
+				"StableID":   "nD1SadqQaS11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e5231c42fd704c10efbcb05513f8da10f5c9075a07e35f01e68e8fed1f197303",
+				"KeyExpiry":  "2026-11-09T09:11:33Z",
+				"DiscoKey":   "discokey:366f52ee691c4951951fa6e77637baf9df2af6d4a55a58a337c203504528a558",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51315",
+					"10.65.0.27:51315",
+					"172.17.0.1:51315",
+					"172.18.0.1:51315",
+					"172.19.0.1:51315",
+					"172.20.0.1:51315",
+					"172.21.0.1:51315",
+					"172.22.0.1:51315",
+					"172.23.0.1:51315",
+					"172.24.0.1:51315",
+					"172.25.0.1:51315",
+					"172.26.0.1:51315",
+					"172.27.0.1:51315",
+					"172.28.0.1:51315"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:11:33.803521751Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4381600078349493,
+				"StableID":   "nEyfqqCSDb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ffa0f8aa48637ca141b05817dbf6a0d45e92a0147c93d303a0aaf6f0dd08100b",
+				"KeyExpiry":  "2026-11-09T09:11:34Z",
+				"DiscoKey":   "discokey:d87c169006961b0a3995a127a1b8792f58a8de44be722aeaed40c2214798ea38",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54975",
+					"10.65.0.27:54975",
+					"172.17.0.1:54975",
+					"172.18.0.1:54975",
+					"172.19.0.1:54975",
+					"172.20.0.1:54975",
+					"172.21.0.1:54975",
+					"172.22.0.1:54975",
+					"172.23.0.1:54975",
+					"172.24.0.1:54975",
+					"172.25.0.1:54975",
+					"172.26.0.1:54975",
+					"172.27.0.1:54975",
+					"172.28.0.1:54975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:11:34.358798756Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1715639806292417,
+				"StableID":   "n6VUk1x1QE11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dca640dfeecac31a14fdc8ce04c12453b3e18022a60be8130b9b0b604bcc5512",
+				"KeyExpiry":  "2026-11-09T09:11:34Z",
+				"DiscoKey":   "discokey:f31f77fed26171b732ea2c186ed3ef41e799151469c17a4b33a851462ea9ff4b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57841",
+					"10.65.0.27:57841",
+					"172.17.0.1:57841",
+					"172.18.0.1:57841",
+					"172.19.0.1:57841",
+					"172.20.0.1:57841",
+					"172.21.0.1:57841",
+					"172.22.0.1:57841",
+					"172.23.0.1:57841",
+					"172.24.0.1:57841",
+					"172.25.0.1:57841",
+					"172.26.0.1:57841",
+					"172.27.0.1:57841",
+					"172.28.0.1:57841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:11:34.864857495Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5001212125978712": {
+				"ID":          5001212125978712,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3275348019449656,
+				"StableID":   "nD1SadqQaS11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e5231c42fd704c10efbcb05513f8da10f5c9075a07e35f01e68e8fed1f197303",
+				"KeyExpiry":  "2026-11-09T09:11:33Z",
+				"DiscoKey":   "discokey:366f52ee691c4951951fa6e77637baf9df2af6d4a55a58a337c203504528a558",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51315",
+					"10.65.0.27:51315",
+					"172.17.0.1:51315",
+					"172.18.0.1:51315",
+					"172.19.0.1:51315",
+					"172.20.0.1:51315",
+					"172.21.0.1:51315",
+					"172.22.0.1:51315",
+					"172.23.0.1:51315",
+					"172.24.0.1:51315",
+					"172.25.0.1:51315",
+					"172.26.0.1:51315",
+					"172.27.0.1:51315",
+					"172.28.0.1:51315"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:11:33.803521751Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e5231c42fd704c10efbcb05513f8da10f5c9075a07e35f01e68e8fed1f197303",
+			"MachineKey": "mkey:2170927ea8f7a65df9faaa977ee353cbe9e039dfab318069acc660c1643b1e2a",
+			"Peers": [{
+				"ID":         4823921244737725,
+				"StableID":   "ntA1fQEmfe11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f068dde163d424c95e759f9278b627be1cf3f12b6aa7a50bb9604a80e82f097f",
+				"DiscoKey":   "discokey:6675d05fe875b8b93ac8f93688deee270c3b43e322406902e4ac1043fc06f03e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49772",
+					"10.65.0.27:49772",
+					"172.17.0.1:49772",
+					"172.18.0.1:49772",
+					"172.19.0.1:49772",
+					"172.20.0.1:49772",
+					"172.21.0.1:49772",
+					"172.22.0.1:49772",
+					"172.23.0.1:49772",
+					"172.24.0.1:49772",
+					"172.25.0.1:49772",
+					"172.26.0.1:49772",
+					"172.27.0.1:49772",
+					"172.28.0.1:49772"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:11:27.232727782Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6899673838592495,
+				"StableID":   "n8q1JTjssv11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a939923c6709e023a453589020af9955f819688b31d22c523ea2ae11a4f54473",
+				"DiscoKey":   "discokey:0bba3699d6f26057022b54d80c5442f14d6663fb2046f8852e3117ae855f5e24",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48989",
+					"10.65.0.27:48989",
+					"172.17.0.1:48989",
+					"172.18.0.1:48989",
+					"172.19.0.1:48989",
+					"172.20.0.1:48989",
+					"172.21.0.1:48989",
+					"172.22.0.1:48989",
+					"172.23.0.1:48989",
+					"172.24.0.1:48989",
+					"172.25.0.1:48989",
+					"172.26.0.1:48989",
+					"172.27.0.1:48989",
+					"172.28.0.1:48989"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:11:27.923232747Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1471710141868880,
+				"StableID":   "nmFwb8LYVC11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2298aed6a48ed64120efa52f711067dc887fbb9c78bc864a282ae81a41e96732",
+				"DiscoKey":   "discokey:6b899c9ec15deaac0adeb76364629ef96084f446898f033bc5bdf42c3c893012",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46576",
+					"10.65.0.27:46576",
+					"172.17.0.1:46576",
+					"172.18.0.1:46576",
+					"172.19.0.1:46576",
+					"172.20.0.1:46576",
+					"172.21.0.1:46576",
+					"172.22.0.1:46576",
+					"172.23.0.1:46576",
+					"172.24.0.1:46576",
+					"172.25.0.1:46576",
+					"172.26.0.1:46576",
+					"172.27.0.1:46576",
+					"172.28.0.1:46576"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:11:28.449863702Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7940710577154745,
+				"StableID":   "nA51271N1521CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:426acaea24fe205eeb09b4bcd6cfef17b807be74987d174da3507fa777b43b39",
+				"DiscoKey":   "discokey:079b1c7162b2484e86d4e530566fa84bd0aea1363341d869c93650c47ad91669",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51637",
+					"10.65.0.27:51637",
+					"172.17.0.1:51637",
+					"172.18.0.1:51637",
+					"172.19.0.1:51637",
+					"172.20.0.1:51637",
+					"172.21.0.1:51637",
+					"172.22.0.1:51637",
+					"172.23.0.1:51637",
+					"172.24.0.1:51637",
+					"172.25.0.1:51637",
+					"172.26.0.1:51637",
+					"172.27.0.1:51637",
+					"172.28.0.1:51637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:11:28.980992142Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6660706170020454,
+				"StableID":   "nouDjUTe1u11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:824d25b0ed9a20d2e5e73a97fd435be5e132f908935ff995c2856eda964e602e",
+				"DiscoKey":   "discokey:4944a073658a867807dcaaa0bcc54aa9d2985cefc75903f887aabb9d76890401",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49396",
+					"10.65.0.27:49396",
+					"172.17.0.1:49396",
+					"172.18.0.1:49396",
+					"172.19.0.1:49396",
+					"172.20.0.1:49396",
+					"172.21.0.1:49396",
+					"172.22.0.1:49396",
+					"172.23.0.1:49396",
+					"172.24.0.1:49396",
+					"172.25.0.1:49396",
+					"172.26.0.1:49396",
+					"172.27.0.1:49396",
+					"172.28.0.1:49396"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:11:29.514432602Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5873399707930875,
+				"StableID":   "nkuHgYF5sn11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc6f5a3a207f5c39ed962d0781cb807109ba7dea69a8d53d7aad93625fb7af7f",
+				"DiscoKey":   "discokey:74f2b63be50beb5872dd750c982af92e8f812a0045f04428b41a7be72219673e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:55933",
+					"10.65.0.27:55933",
+					"172.17.0.1:55933",
+					"172.18.0.1:55933",
+					"172.19.0.1:55933",
+					"172.20.0.1:55933",
+					"172.21.0.1:55933",
+					"172.22.0.1:55933",
+					"172.23.0.1:55933",
+					"172.24.0.1:55933",
+					"172.25.0.1:55933",
+					"172.26.0.1:55933",
+					"172.27.0.1:55933",
+					"172.28.0.1:55933"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:11:30.054301025Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4656389653246852,
+				"StableID":   "n1wobhTtMd11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab21ee6bc3991d19001955bdc61e9cf0a700cff60d9dfafc40f3b4b7e0014e6b",
+				"DiscoKey":   "discokey:a4ace807754e1f8f1bc5d7401a012f47722344950a7d4382f35763bc80635527",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49126",
+					"10.65.0.27:49126",
+					"172.17.0.1:49126",
+					"172.18.0.1:49126",
+					"172.19.0.1:49126",
+					"172.20.0.1:49126",
+					"172.21.0.1:49126",
+					"172.22.0.1:49126",
+					"172.23.0.1:49126",
+					"172.24.0.1:49126",
+					"172.25.0.1:49126",
+					"172.26.0.1:49126",
+					"172.27.0.1:49126",
+					"172.28.0.1:49126"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:11:30.590573831Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5001212125978712,
+				"StableID":   "n3a8jzM44g11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec03bcd34d887fac2f5806d20af78c18471da65ced6cb98a8fb8d998bcb75d7c",
+				"DiscoKey":   "discokey:26a6b3741cf31a22ad599c14d9ecf96b17c12f32eb12f421aff04a7d2cb9cf0e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:43845",
+					"10.65.0.27:43845",
+					"172.17.0.1:43845",
+					"172.18.0.1:43845",
+					"172.19.0.1:43845",
+					"172.20.0.1:43845",
+					"172.21.0.1:43845",
+					"172.22.0.1:43845",
+					"172.23.0.1:43845",
+					"172.24.0.1:43845",
+					"172.25.0.1:43845",
+					"172.26.0.1:43845",
+					"172.27.0.1:43845",
+					"172.28.0.1:43845"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:11:31.127153854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8230806459247696,
+				"StableID":   "noYQj4LkG721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:98c9889cf909a88aa69a7a805f56567152d341d8ead559c7c43a918bbc6c4550",
+				"DiscoKey":   "discokey:d8b6802b5f0f2ae9e55751ff60079767a9eb2eea4eb8a6892957efc63308fe19",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41417",
+					"10.65.0.27:41417",
+					"172.17.0.1:41417",
+					"172.18.0.1:41417",
+					"172.19.0.1:41417",
+					"172.20.0.1:41417",
+					"172.21.0.1:41417",
+					"172.22.0.1:41417",
+					"172.23.0.1:41417",
+					"172.24.0.1:41417",
+					"172.25.0.1:41417",
+					"172.26.0.1:41417",
+					"172.27.0.1:41417",
+					"172.28.0.1:41417"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:11:31.681478377Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2192643219519776,
+				"StableID":   "n9dPx7248J11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af6c197aeeb2e8861e26d078ca62f84d392098e251a67c90bea1b4be6481f54a",
+				"DiscoKey":   "discokey:7532d187e881aa70abce6c4c7bdd356aa424d83c5ffaafb82e58253c89e68f36",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53872",
+					"10.65.0.27:53872",
+					"172.17.0.1:53872",
+					"172.18.0.1:53872",
+					"172.19.0.1:53872",
+					"172.20.0.1:53872",
+					"172.21.0.1:53872",
+					"172.22.0.1:53872",
+					"172.23.0.1:53872",
+					"172.24.0.1:53872",
+					"172.25.0.1:53872",
+					"172.26.0.1:53872",
+					"172.27.0.1:53872",
+					"172.28.0.1:53872"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:11:32.210491783Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6622337448797789,
+				"StableID":   "nxapDNaGit11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dbe12d6b4c2392dca0667ad6893de8f72f4131b6f591707f4dd34780dc741826",
+				"DiscoKey":   "discokey:b9fd436af9d9e5ff2f9eaedee7859d1df32bd38fecd5ee974dccc85159f08f67",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:46146",
+					"10.65.0.27:46146",
+					"172.17.0.1:46146",
+					"172.18.0.1:46146",
+					"172.19.0.1:46146",
+					"172.20.0.1:46146",
+					"172.21.0.1:46146",
+					"172.22.0.1:46146",
+					"172.23.0.1:46146",
+					"172.24.0.1:46146",
+					"172.25.0.1:46146",
+					"172.26.0.1:46146",
+					"172.27.0.1:46146",
+					"172.28.0.1:46146"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:11:32.736529232Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7856278415543673,
+				"StableID":   "nLSA2W78M421CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7cadaeda40fba18caa1a95233b305c0775f9af6fb6dd5d177177e5035c391f18",
+				"DiscoKey":   "discokey:0e27b0982812192999a486818efd2b538c068e2d6e126f1e64274a747ee2076c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56971",
+					"10.65.0.27:56971",
+					"172.17.0.1:56971",
+					"172.18.0.1:56971",
+					"172.19.0.1:56971",
+					"172.20.0.1:56971",
+					"172.21.0.1:56971",
+					"172.22.0.1:56971",
+					"172.23.0.1:56971",
+					"172.24.0.1:56971",
+					"172.25.0.1:56971",
+					"172.26.0.1:56971",
+					"172.27.0.1:56971",
+					"172.28.0.1:56971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:11:33.269378521Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4381600078349493,
+				"StableID":   "nEyfqqCSDb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ffa0f8aa48637ca141b05817dbf6a0d45e92a0147c93d303a0aaf6f0dd08100b",
+				"KeyExpiry":  "2026-11-09T09:11:34Z",
+				"DiscoKey":   "discokey:d87c169006961b0a3995a127a1b8792f58a8de44be722aeaed40c2214798ea38",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54975",
+					"10.65.0.27:54975",
+					"172.17.0.1:54975",
+					"172.18.0.1:54975",
+					"172.19.0.1:54975",
+					"172.20.0.1:54975",
+					"172.21.0.1:54975",
+					"172.22.0.1:54975",
+					"172.23.0.1:54975",
+					"172.24.0.1:54975",
+					"172.25.0.1:54975",
+					"172.26.0.1:54975",
+					"172.27.0.1:54975",
+					"172.28.0.1:54975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:11:34.358798756Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1715639806292417,
+				"StableID":   "n6VUk1x1QE11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dca640dfeecac31a14fdc8ce04c12453b3e18022a60be8130b9b0b604bcc5512",
+				"KeyExpiry":  "2026-11-09T09:11:34Z",
+				"DiscoKey":   "discokey:f31f77fed26171b732ea2c186ed3ef41e799151469c17a4b33a851462ea9ff4b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57841",
+					"10.65.0.27:57841",
+					"172.17.0.1:57841",
+					"172.18.0.1:57841",
+					"172.19.0.1:57841",
+					"172.20.0.1:57841",
+					"172.21.0.1:57841",
+					"172.22.0.1:57841",
+					"172.23.0.1:57841",
+					"172.24.0.1:57841",
+					"172.25.0.1:57841",
+					"172.26.0.1:57841",
+					"172.27.0.1:57841",
+					"172.28.0.1:57841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:11:34.864857495Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6622337448797789,
+				"StableID":   "nxapDNaGit11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       6622337448797789,
+				"Key":        "nodekey:dbe12d6b4c2392dca0667ad6893de8f72f4131b6f591707f4dd34780dc741826",
+				"DiscoKey":   "discokey:b9fd436af9d9e5ff2f9eaedee7859d1df32bd38fecd5ee974dccc85159f08f67",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:46146",
+					"10.65.0.27:46146",
+					"172.17.0.1:46146",
+					"172.18.0.1:46146",
+					"172.19.0.1:46146",
+					"172.20.0.1:46146",
+					"172.21.0.1:46146",
+					"172.22.0.1:46146",
+					"172.23.0.1:46146",
+					"172.24.0.1:46146",
+					"172.25.0.1:46146",
+					"172.26.0.1:46146",
+					"172.27.0.1:46146",
+					"172.28.0.1:46146"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:11:32.736529232Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:dbe12d6b4c2392dca0667ad6893de8f72f4131b6f591707f4dd34780dc741826",
+			"MachineKey": "mkey:2d899accff6b5f34bf419b65f33d1e6d5a60442a8c951278e4d9ec166484d52e",
+			"Peers": [{
+				"ID":         4823921244737725,
+				"StableID":   "ntA1fQEmfe11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f068dde163d424c95e759f9278b627be1cf3f12b6aa7a50bb9604a80e82f097f",
+				"DiscoKey":   "discokey:6675d05fe875b8b93ac8f93688deee270c3b43e322406902e4ac1043fc06f03e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49772",
+					"10.65.0.27:49772",
+					"172.17.0.1:49772",
+					"172.18.0.1:49772",
+					"172.19.0.1:49772",
+					"172.20.0.1:49772",
+					"172.21.0.1:49772",
+					"172.22.0.1:49772",
+					"172.23.0.1:49772",
+					"172.24.0.1:49772",
+					"172.25.0.1:49772",
+					"172.26.0.1:49772",
+					"172.27.0.1:49772",
+					"172.28.0.1:49772"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:11:27.232727782Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6899673838592495,
+				"StableID":   "n8q1JTjssv11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a939923c6709e023a453589020af9955f819688b31d22c523ea2ae11a4f54473",
+				"DiscoKey":   "discokey:0bba3699d6f26057022b54d80c5442f14d6663fb2046f8852e3117ae855f5e24",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48989",
+					"10.65.0.27:48989",
+					"172.17.0.1:48989",
+					"172.18.0.1:48989",
+					"172.19.0.1:48989",
+					"172.20.0.1:48989",
+					"172.21.0.1:48989",
+					"172.22.0.1:48989",
+					"172.23.0.1:48989",
+					"172.24.0.1:48989",
+					"172.25.0.1:48989",
+					"172.26.0.1:48989",
+					"172.27.0.1:48989",
+					"172.28.0.1:48989"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:11:27.923232747Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1471710141868880,
+				"StableID":   "nmFwb8LYVC11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2298aed6a48ed64120efa52f711067dc887fbb9c78bc864a282ae81a41e96732",
+				"DiscoKey":   "discokey:6b899c9ec15deaac0adeb76364629ef96084f446898f033bc5bdf42c3c893012",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46576",
+					"10.65.0.27:46576",
+					"172.17.0.1:46576",
+					"172.18.0.1:46576",
+					"172.19.0.1:46576",
+					"172.20.0.1:46576",
+					"172.21.0.1:46576",
+					"172.22.0.1:46576",
+					"172.23.0.1:46576",
+					"172.24.0.1:46576",
+					"172.25.0.1:46576",
+					"172.26.0.1:46576",
+					"172.27.0.1:46576",
+					"172.28.0.1:46576"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:11:28.449863702Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7940710577154745,
+				"StableID":   "nA51271N1521CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:426acaea24fe205eeb09b4bcd6cfef17b807be74987d174da3507fa777b43b39",
+				"DiscoKey":   "discokey:079b1c7162b2484e86d4e530566fa84bd0aea1363341d869c93650c47ad91669",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51637",
+					"10.65.0.27:51637",
+					"172.17.0.1:51637",
+					"172.18.0.1:51637",
+					"172.19.0.1:51637",
+					"172.20.0.1:51637",
+					"172.21.0.1:51637",
+					"172.22.0.1:51637",
+					"172.23.0.1:51637",
+					"172.24.0.1:51637",
+					"172.25.0.1:51637",
+					"172.26.0.1:51637",
+					"172.27.0.1:51637",
+					"172.28.0.1:51637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:11:28.980992142Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6660706170020454,
+				"StableID":   "nouDjUTe1u11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:824d25b0ed9a20d2e5e73a97fd435be5e132f908935ff995c2856eda964e602e",
+				"DiscoKey":   "discokey:4944a073658a867807dcaaa0bcc54aa9d2985cefc75903f887aabb9d76890401",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49396",
+					"10.65.0.27:49396",
+					"172.17.0.1:49396",
+					"172.18.0.1:49396",
+					"172.19.0.1:49396",
+					"172.20.0.1:49396",
+					"172.21.0.1:49396",
+					"172.22.0.1:49396",
+					"172.23.0.1:49396",
+					"172.24.0.1:49396",
+					"172.25.0.1:49396",
+					"172.26.0.1:49396",
+					"172.27.0.1:49396",
+					"172.28.0.1:49396"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:11:29.514432602Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5873399707930875,
+				"StableID":   "nkuHgYF5sn11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc6f5a3a207f5c39ed962d0781cb807109ba7dea69a8d53d7aad93625fb7af7f",
+				"DiscoKey":   "discokey:74f2b63be50beb5872dd750c982af92e8f812a0045f04428b41a7be72219673e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:55933",
+					"10.65.0.27:55933",
+					"172.17.0.1:55933",
+					"172.18.0.1:55933",
+					"172.19.0.1:55933",
+					"172.20.0.1:55933",
+					"172.21.0.1:55933",
+					"172.22.0.1:55933",
+					"172.23.0.1:55933",
+					"172.24.0.1:55933",
+					"172.25.0.1:55933",
+					"172.26.0.1:55933",
+					"172.27.0.1:55933",
+					"172.28.0.1:55933"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:11:30.054301025Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4656389653246852,
+				"StableID":   "n1wobhTtMd11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab21ee6bc3991d19001955bdc61e9cf0a700cff60d9dfafc40f3b4b7e0014e6b",
+				"DiscoKey":   "discokey:a4ace807754e1f8f1bc5d7401a012f47722344950a7d4382f35763bc80635527",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49126",
+					"10.65.0.27:49126",
+					"172.17.0.1:49126",
+					"172.18.0.1:49126",
+					"172.19.0.1:49126",
+					"172.20.0.1:49126",
+					"172.21.0.1:49126",
+					"172.22.0.1:49126",
+					"172.23.0.1:49126",
+					"172.24.0.1:49126",
+					"172.25.0.1:49126",
+					"172.26.0.1:49126",
+					"172.27.0.1:49126",
+					"172.28.0.1:49126"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:11:30.590573831Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5001212125978712,
+				"StableID":   "n3a8jzM44g11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec03bcd34d887fac2f5806d20af78c18471da65ced6cb98a8fb8d998bcb75d7c",
+				"DiscoKey":   "discokey:26a6b3741cf31a22ad599c14d9ecf96b17c12f32eb12f421aff04a7d2cb9cf0e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:43845",
+					"10.65.0.27:43845",
+					"172.17.0.1:43845",
+					"172.18.0.1:43845",
+					"172.19.0.1:43845",
+					"172.20.0.1:43845",
+					"172.21.0.1:43845",
+					"172.22.0.1:43845",
+					"172.23.0.1:43845",
+					"172.24.0.1:43845",
+					"172.25.0.1:43845",
+					"172.26.0.1:43845",
+					"172.27.0.1:43845",
+					"172.28.0.1:43845"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:11:31.127153854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8230806459247696,
+				"StableID":   "noYQj4LkG721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:98c9889cf909a88aa69a7a805f56567152d341d8ead559c7c43a918bbc6c4550",
+				"DiscoKey":   "discokey:d8b6802b5f0f2ae9e55751ff60079767a9eb2eea4eb8a6892957efc63308fe19",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41417",
+					"10.65.0.27:41417",
+					"172.17.0.1:41417",
+					"172.18.0.1:41417",
+					"172.19.0.1:41417",
+					"172.20.0.1:41417",
+					"172.21.0.1:41417",
+					"172.22.0.1:41417",
+					"172.23.0.1:41417",
+					"172.24.0.1:41417",
+					"172.25.0.1:41417",
+					"172.26.0.1:41417",
+					"172.27.0.1:41417",
+					"172.28.0.1:41417"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:11:31.681478377Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2192643219519776,
+				"StableID":   "n9dPx7248J11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af6c197aeeb2e8861e26d078ca62f84d392098e251a67c90bea1b4be6481f54a",
+				"DiscoKey":   "discokey:7532d187e881aa70abce6c4c7bdd356aa424d83c5ffaafb82e58253c89e68f36",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53872",
+					"10.65.0.27:53872",
+					"172.17.0.1:53872",
+					"172.18.0.1:53872",
+					"172.19.0.1:53872",
+					"172.20.0.1:53872",
+					"172.21.0.1:53872",
+					"172.22.0.1:53872",
+					"172.23.0.1:53872",
+					"172.24.0.1:53872",
+					"172.25.0.1:53872",
+					"172.26.0.1:53872",
+					"172.27.0.1:53872",
+					"172.28.0.1:53872"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:11:32.210491783Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7856278415543673,
+				"StableID":   "nLSA2W78M421CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7cadaeda40fba18caa1a95233b305c0775f9af6fb6dd5d177177e5035c391f18",
+				"DiscoKey":   "discokey:0e27b0982812192999a486818efd2b538c068e2d6e126f1e64274a747ee2076c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56971",
+					"10.65.0.27:56971",
+					"172.17.0.1:56971",
+					"172.18.0.1:56971",
+					"172.19.0.1:56971",
+					"172.20.0.1:56971",
+					"172.21.0.1:56971",
+					"172.22.0.1:56971",
+					"172.23.0.1:56971",
+					"172.24.0.1:56971",
+					"172.25.0.1:56971",
+					"172.26.0.1:56971",
+					"172.27.0.1:56971",
+					"172.28.0.1:56971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:11:33.269378521Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3275348019449656,
+				"StableID":   "nD1SadqQaS11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e5231c42fd704c10efbcb05513f8da10f5c9075a07e35f01e68e8fed1f197303",
+				"KeyExpiry":  "2026-11-09T09:11:33Z",
+				"DiscoKey":   "discokey:366f52ee691c4951951fa6e77637baf9df2af6d4a55a58a337c203504528a558",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51315",
+					"10.65.0.27:51315",
+					"172.17.0.1:51315",
+					"172.18.0.1:51315",
+					"172.19.0.1:51315",
+					"172.20.0.1:51315",
+					"172.21.0.1:51315",
+					"172.22.0.1:51315",
+					"172.23.0.1:51315",
+					"172.24.0.1:51315",
+					"172.25.0.1:51315",
+					"172.26.0.1:51315",
+					"172.27.0.1:51315",
+					"172.28.0.1:51315"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:11:33.803521751Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4381600078349493,
+				"StableID":   "nEyfqqCSDb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ffa0f8aa48637ca141b05817dbf6a0d45e92a0147c93d303a0aaf6f0dd08100b",
+				"KeyExpiry":  "2026-11-09T09:11:34Z",
+				"DiscoKey":   "discokey:d87c169006961b0a3995a127a1b8792f58a8de44be722aeaed40c2214798ea38",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54975",
+					"10.65.0.27:54975",
+					"172.17.0.1:54975",
+					"172.18.0.1:54975",
+					"172.19.0.1:54975",
+					"172.20.0.1:54975",
+					"172.21.0.1:54975",
+					"172.22.0.1:54975",
+					"172.23.0.1:54975",
+					"172.24.0.1:54975",
+					"172.25.0.1:54975",
+					"172.26.0.1:54975",
+					"172.27.0.1:54975",
+					"172.28.0.1:54975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:11:34.358798756Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1715639806292417,
+				"StableID":   "n6VUk1x1QE11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dca640dfeecac31a14fdc8ce04c12453b3e18022a60be8130b9b0b604bcc5512",
+				"KeyExpiry":  "2026-11-09T09:11:34Z",
+				"DiscoKey":   "discokey:f31f77fed26171b732ea2c186ed3ef41e799151469c17a4b33a851462ea9ff4b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57841",
+					"10.65.0.27:57841",
+					"172.17.0.1:57841",
+					"172.18.0.1:57841",
+					"172.19.0.1:57841",
+					"172.20.0.1:57841",
+					"172.21.0.1:57841",
+					"172.22.0.1:57841",
+					"172.23.0.1:57841",
+					"172.24.0.1:57841",
+					"172.25.0.1:57841",
+					"172.26.0.1:57841",
+					"172.27.0.1:57841",
+					"172.28.0.1:57841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:11:34.864857495Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6622337448797789": {
+				"ID":          6622337448797789,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6899673838592495,
+				"StableID":   "n8q1JTjssv11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       6899673838592495,
+				"Key":        "nodekey:a939923c6709e023a453589020af9955f819688b31d22c523ea2ae11a4f54473",
+				"DiscoKey":   "discokey:0bba3699d6f26057022b54d80c5442f14d6663fb2046f8852e3117ae855f5e24",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48989",
+					"10.65.0.27:48989",
+					"172.17.0.1:48989",
+					"172.18.0.1:48989",
+					"172.19.0.1:48989",
+					"172.20.0.1:48989",
+					"172.21.0.1:48989",
+					"172.22.0.1:48989",
+					"172.23.0.1:48989",
+					"172.24.0.1:48989",
+					"172.25.0.1:48989",
+					"172.26.0.1:48989",
+					"172.27.0.1:48989",
+					"172.28.0.1:48989"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:11:27.923232747Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a939923c6709e023a453589020af9955f819688b31d22c523ea2ae11a4f54473",
+			"MachineKey": "mkey:3fcb3f5ba7d9ac185e0e80d5179389e67e151e60168f01a46c7ff98887bcf153",
+			"Peers": [{
+				"ID":         4823921244737725,
+				"StableID":   "ntA1fQEmfe11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f068dde163d424c95e759f9278b627be1cf3f12b6aa7a50bb9604a80e82f097f",
+				"DiscoKey":   "discokey:6675d05fe875b8b93ac8f93688deee270c3b43e322406902e4ac1043fc06f03e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49772",
+					"10.65.0.27:49772",
+					"172.17.0.1:49772",
+					"172.18.0.1:49772",
+					"172.19.0.1:49772",
+					"172.20.0.1:49772",
+					"172.21.0.1:49772",
+					"172.22.0.1:49772",
+					"172.23.0.1:49772",
+					"172.24.0.1:49772",
+					"172.25.0.1:49772",
+					"172.26.0.1:49772",
+					"172.27.0.1:49772",
+					"172.28.0.1:49772"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:11:27.232727782Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1471710141868880,
+				"StableID":   "nmFwb8LYVC11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2298aed6a48ed64120efa52f711067dc887fbb9c78bc864a282ae81a41e96732",
+				"DiscoKey":   "discokey:6b899c9ec15deaac0adeb76364629ef96084f446898f033bc5bdf42c3c893012",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46576",
+					"10.65.0.27:46576",
+					"172.17.0.1:46576",
+					"172.18.0.1:46576",
+					"172.19.0.1:46576",
+					"172.20.0.1:46576",
+					"172.21.0.1:46576",
+					"172.22.0.1:46576",
+					"172.23.0.1:46576",
+					"172.24.0.1:46576",
+					"172.25.0.1:46576",
+					"172.26.0.1:46576",
+					"172.27.0.1:46576",
+					"172.28.0.1:46576"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:11:28.449863702Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7940710577154745,
+				"StableID":   "nA51271N1521CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:426acaea24fe205eeb09b4bcd6cfef17b807be74987d174da3507fa777b43b39",
+				"DiscoKey":   "discokey:079b1c7162b2484e86d4e530566fa84bd0aea1363341d869c93650c47ad91669",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51637",
+					"10.65.0.27:51637",
+					"172.17.0.1:51637",
+					"172.18.0.1:51637",
+					"172.19.0.1:51637",
+					"172.20.0.1:51637",
+					"172.21.0.1:51637",
+					"172.22.0.1:51637",
+					"172.23.0.1:51637",
+					"172.24.0.1:51637",
+					"172.25.0.1:51637",
+					"172.26.0.1:51637",
+					"172.27.0.1:51637",
+					"172.28.0.1:51637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:11:28.980992142Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6660706170020454,
+				"StableID":   "nouDjUTe1u11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:824d25b0ed9a20d2e5e73a97fd435be5e132f908935ff995c2856eda964e602e",
+				"DiscoKey":   "discokey:4944a073658a867807dcaaa0bcc54aa9d2985cefc75903f887aabb9d76890401",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49396",
+					"10.65.0.27:49396",
+					"172.17.0.1:49396",
+					"172.18.0.1:49396",
+					"172.19.0.1:49396",
+					"172.20.0.1:49396",
+					"172.21.0.1:49396",
+					"172.22.0.1:49396",
+					"172.23.0.1:49396",
+					"172.24.0.1:49396",
+					"172.25.0.1:49396",
+					"172.26.0.1:49396",
+					"172.27.0.1:49396",
+					"172.28.0.1:49396"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:11:29.514432602Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5873399707930875,
+				"StableID":   "nkuHgYF5sn11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc6f5a3a207f5c39ed962d0781cb807109ba7dea69a8d53d7aad93625fb7af7f",
+				"DiscoKey":   "discokey:74f2b63be50beb5872dd750c982af92e8f812a0045f04428b41a7be72219673e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:55933",
+					"10.65.0.27:55933",
+					"172.17.0.1:55933",
+					"172.18.0.1:55933",
+					"172.19.0.1:55933",
+					"172.20.0.1:55933",
+					"172.21.0.1:55933",
+					"172.22.0.1:55933",
+					"172.23.0.1:55933",
+					"172.24.0.1:55933",
+					"172.25.0.1:55933",
+					"172.26.0.1:55933",
+					"172.27.0.1:55933",
+					"172.28.0.1:55933"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:11:30.054301025Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4656389653246852,
+				"StableID":   "n1wobhTtMd11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab21ee6bc3991d19001955bdc61e9cf0a700cff60d9dfafc40f3b4b7e0014e6b",
+				"DiscoKey":   "discokey:a4ace807754e1f8f1bc5d7401a012f47722344950a7d4382f35763bc80635527",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49126",
+					"10.65.0.27:49126",
+					"172.17.0.1:49126",
+					"172.18.0.1:49126",
+					"172.19.0.1:49126",
+					"172.20.0.1:49126",
+					"172.21.0.1:49126",
+					"172.22.0.1:49126",
+					"172.23.0.1:49126",
+					"172.24.0.1:49126",
+					"172.25.0.1:49126",
+					"172.26.0.1:49126",
+					"172.27.0.1:49126",
+					"172.28.0.1:49126"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:11:30.590573831Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5001212125978712,
+				"StableID":   "n3a8jzM44g11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec03bcd34d887fac2f5806d20af78c18471da65ced6cb98a8fb8d998bcb75d7c",
+				"DiscoKey":   "discokey:26a6b3741cf31a22ad599c14d9ecf96b17c12f32eb12f421aff04a7d2cb9cf0e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:43845",
+					"10.65.0.27:43845",
+					"172.17.0.1:43845",
+					"172.18.0.1:43845",
+					"172.19.0.1:43845",
+					"172.20.0.1:43845",
+					"172.21.0.1:43845",
+					"172.22.0.1:43845",
+					"172.23.0.1:43845",
+					"172.24.0.1:43845",
+					"172.25.0.1:43845",
+					"172.26.0.1:43845",
+					"172.27.0.1:43845",
+					"172.28.0.1:43845"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:11:31.127153854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8230806459247696,
+				"StableID":   "noYQj4LkG721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:98c9889cf909a88aa69a7a805f56567152d341d8ead559c7c43a918bbc6c4550",
+				"DiscoKey":   "discokey:d8b6802b5f0f2ae9e55751ff60079767a9eb2eea4eb8a6892957efc63308fe19",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41417",
+					"10.65.0.27:41417",
+					"172.17.0.1:41417",
+					"172.18.0.1:41417",
+					"172.19.0.1:41417",
+					"172.20.0.1:41417",
+					"172.21.0.1:41417",
+					"172.22.0.1:41417",
+					"172.23.0.1:41417",
+					"172.24.0.1:41417",
+					"172.25.0.1:41417",
+					"172.26.0.1:41417",
+					"172.27.0.1:41417",
+					"172.28.0.1:41417"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:11:31.681478377Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2192643219519776,
+				"StableID":   "n9dPx7248J11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af6c197aeeb2e8861e26d078ca62f84d392098e251a67c90bea1b4be6481f54a",
+				"DiscoKey":   "discokey:7532d187e881aa70abce6c4c7bdd356aa424d83c5ffaafb82e58253c89e68f36",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53872",
+					"10.65.0.27:53872",
+					"172.17.0.1:53872",
+					"172.18.0.1:53872",
+					"172.19.0.1:53872",
+					"172.20.0.1:53872",
+					"172.21.0.1:53872",
+					"172.22.0.1:53872",
+					"172.23.0.1:53872",
+					"172.24.0.1:53872",
+					"172.25.0.1:53872",
+					"172.26.0.1:53872",
+					"172.27.0.1:53872",
+					"172.28.0.1:53872"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:11:32.210491783Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6622337448797789,
+				"StableID":   "nxapDNaGit11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dbe12d6b4c2392dca0667ad6893de8f72f4131b6f591707f4dd34780dc741826",
+				"DiscoKey":   "discokey:b9fd436af9d9e5ff2f9eaedee7859d1df32bd38fecd5ee974dccc85159f08f67",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:46146",
+					"10.65.0.27:46146",
+					"172.17.0.1:46146",
+					"172.18.0.1:46146",
+					"172.19.0.1:46146",
+					"172.20.0.1:46146",
+					"172.21.0.1:46146",
+					"172.22.0.1:46146",
+					"172.23.0.1:46146",
+					"172.24.0.1:46146",
+					"172.25.0.1:46146",
+					"172.26.0.1:46146",
+					"172.27.0.1:46146",
+					"172.28.0.1:46146"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:11:32.736529232Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7856278415543673,
+				"StableID":   "nLSA2W78M421CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7cadaeda40fba18caa1a95233b305c0775f9af6fb6dd5d177177e5035c391f18",
+				"DiscoKey":   "discokey:0e27b0982812192999a486818efd2b538c068e2d6e126f1e64274a747ee2076c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56971",
+					"10.65.0.27:56971",
+					"172.17.0.1:56971",
+					"172.18.0.1:56971",
+					"172.19.0.1:56971",
+					"172.20.0.1:56971",
+					"172.21.0.1:56971",
+					"172.22.0.1:56971",
+					"172.23.0.1:56971",
+					"172.24.0.1:56971",
+					"172.25.0.1:56971",
+					"172.26.0.1:56971",
+					"172.27.0.1:56971",
+					"172.28.0.1:56971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:11:33.269378521Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3275348019449656,
+				"StableID":   "nD1SadqQaS11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e5231c42fd704c10efbcb05513f8da10f5c9075a07e35f01e68e8fed1f197303",
+				"KeyExpiry":  "2026-11-09T09:11:33Z",
+				"DiscoKey":   "discokey:366f52ee691c4951951fa6e77637baf9df2af6d4a55a58a337c203504528a558",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51315",
+					"10.65.0.27:51315",
+					"172.17.0.1:51315",
+					"172.18.0.1:51315",
+					"172.19.0.1:51315",
+					"172.20.0.1:51315",
+					"172.21.0.1:51315",
+					"172.22.0.1:51315",
+					"172.23.0.1:51315",
+					"172.24.0.1:51315",
+					"172.25.0.1:51315",
+					"172.26.0.1:51315",
+					"172.27.0.1:51315",
+					"172.28.0.1:51315"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:11:33.803521751Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4381600078349493,
+				"StableID":   "nEyfqqCSDb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ffa0f8aa48637ca141b05817dbf6a0d45e92a0147c93d303a0aaf6f0dd08100b",
+				"KeyExpiry":  "2026-11-09T09:11:34Z",
+				"DiscoKey":   "discokey:d87c169006961b0a3995a127a1b8792f58a8de44be722aeaed40c2214798ea38",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54975",
+					"10.65.0.27:54975",
+					"172.17.0.1:54975",
+					"172.18.0.1:54975",
+					"172.19.0.1:54975",
+					"172.20.0.1:54975",
+					"172.21.0.1:54975",
+					"172.22.0.1:54975",
+					"172.23.0.1:54975",
+					"172.24.0.1:54975",
+					"172.25.0.1:54975",
+					"172.26.0.1:54975",
+					"172.27.0.1:54975",
+					"172.28.0.1:54975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:11:34.358798756Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1715639806292417,
+				"StableID":   "n6VUk1x1QE11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dca640dfeecac31a14fdc8ce04c12453b3e18022a60be8130b9b0b604bcc5512",
+				"KeyExpiry":  "2026-11-09T09:11:34Z",
+				"DiscoKey":   "discokey:f31f77fed26171b732ea2c186ed3ef41e799151469c17a4b33a851462ea9ff4b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57841",
+					"10.65.0.27:57841",
+					"172.17.0.1:57841",
+					"172.18.0.1:57841",
+					"172.19.0.1:57841",
+					"172.20.0.1:57841",
+					"172.21.0.1:57841",
+					"172.22.0.1:57841",
+					"172.23.0.1:57841",
+					"172.24.0.1:57841",
+					"172.25.0.1:57841",
+					"172.26.0.1:57841",
+					"172.27.0.1:57841",
+					"172.28.0.1:57841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:11:34.864857495Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6899673838592495": {
+				"ID":          6899673838592495,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4823921244737725,
+				"StableID":   "ntA1fQEmfe11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       4823921244737725,
+				"Key":        "nodekey:f068dde163d424c95e759f9278b627be1cf3f12b6aa7a50bb9604a80e82f097f",
+				"DiscoKey":   "discokey:6675d05fe875b8b93ac8f93688deee270c3b43e322406902e4ac1043fc06f03e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49772",
+					"10.65.0.27:49772",
+					"172.17.0.1:49772",
+					"172.18.0.1:49772",
+					"172.19.0.1:49772",
+					"172.20.0.1:49772",
+					"172.21.0.1:49772",
+					"172.22.0.1:49772",
+					"172.23.0.1:49772",
+					"172.24.0.1:49772",
+					"172.25.0.1:49772",
+					"172.26.0.1:49772",
+					"172.27.0.1:49772",
+					"172.28.0.1:49772"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:11:27.232727782Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f068dde163d424c95e759f9278b627be1cf3f12b6aa7a50bb9604a80e82f097f",
+			"MachineKey": "mkey:383fa7dc54b50e093313247274e68a3a984d6f2567a31ddcc3b6e9830c96315f",
+			"Peers": [{
+				"ID":         6899673838592495,
+				"StableID":   "n8q1JTjssv11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a939923c6709e023a453589020af9955f819688b31d22c523ea2ae11a4f54473",
+				"DiscoKey":   "discokey:0bba3699d6f26057022b54d80c5442f14d6663fb2046f8852e3117ae855f5e24",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48989",
+					"10.65.0.27:48989",
+					"172.17.0.1:48989",
+					"172.18.0.1:48989",
+					"172.19.0.1:48989",
+					"172.20.0.1:48989",
+					"172.21.0.1:48989",
+					"172.22.0.1:48989",
+					"172.23.0.1:48989",
+					"172.24.0.1:48989",
+					"172.25.0.1:48989",
+					"172.26.0.1:48989",
+					"172.27.0.1:48989",
+					"172.28.0.1:48989"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:11:27.923232747Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1471710141868880,
+				"StableID":   "nmFwb8LYVC11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2298aed6a48ed64120efa52f711067dc887fbb9c78bc864a282ae81a41e96732",
+				"DiscoKey":   "discokey:6b899c9ec15deaac0adeb76364629ef96084f446898f033bc5bdf42c3c893012",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46576",
+					"10.65.0.27:46576",
+					"172.17.0.1:46576",
+					"172.18.0.1:46576",
+					"172.19.0.1:46576",
+					"172.20.0.1:46576",
+					"172.21.0.1:46576",
+					"172.22.0.1:46576",
+					"172.23.0.1:46576",
+					"172.24.0.1:46576",
+					"172.25.0.1:46576",
+					"172.26.0.1:46576",
+					"172.27.0.1:46576",
+					"172.28.0.1:46576"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:11:28.449863702Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7940710577154745,
+				"StableID":   "nA51271N1521CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:426acaea24fe205eeb09b4bcd6cfef17b807be74987d174da3507fa777b43b39",
+				"DiscoKey":   "discokey:079b1c7162b2484e86d4e530566fa84bd0aea1363341d869c93650c47ad91669",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51637",
+					"10.65.0.27:51637",
+					"172.17.0.1:51637",
+					"172.18.0.1:51637",
+					"172.19.0.1:51637",
+					"172.20.0.1:51637",
+					"172.21.0.1:51637",
+					"172.22.0.1:51637",
+					"172.23.0.1:51637",
+					"172.24.0.1:51637",
+					"172.25.0.1:51637",
+					"172.26.0.1:51637",
+					"172.27.0.1:51637",
+					"172.28.0.1:51637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:11:28.980992142Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6660706170020454,
+				"StableID":   "nouDjUTe1u11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:824d25b0ed9a20d2e5e73a97fd435be5e132f908935ff995c2856eda964e602e",
+				"DiscoKey":   "discokey:4944a073658a867807dcaaa0bcc54aa9d2985cefc75903f887aabb9d76890401",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49396",
+					"10.65.0.27:49396",
+					"172.17.0.1:49396",
+					"172.18.0.1:49396",
+					"172.19.0.1:49396",
+					"172.20.0.1:49396",
+					"172.21.0.1:49396",
+					"172.22.0.1:49396",
+					"172.23.0.1:49396",
+					"172.24.0.1:49396",
+					"172.25.0.1:49396",
+					"172.26.0.1:49396",
+					"172.27.0.1:49396",
+					"172.28.0.1:49396"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:11:29.514432602Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5873399707930875,
+				"StableID":   "nkuHgYF5sn11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc6f5a3a207f5c39ed962d0781cb807109ba7dea69a8d53d7aad93625fb7af7f",
+				"DiscoKey":   "discokey:74f2b63be50beb5872dd750c982af92e8f812a0045f04428b41a7be72219673e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:55933",
+					"10.65.0.27:55933",
+					"172.17.0.1:55933",
+					"172.18.0.1:55933",
+					"172.19.0.1:55933",
+					"172.20.0.1:55933",
+					"172.21.0.1:55933",
+					"172.22.0.1:55933",
+					"172.23.0.1:55933",
+					"172.24.0.1:55933",
+					"172.25.0.1:55933",
+					"172.26.0.1:55933",
+					"172.27.0.1:55933",
+					"172.28.0.1:55933"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:11:30.054301025Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4656389653246852,
+				"StableID":   "n1wobhTtMd11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab21ee6bc3991d19001955bdc61e9cf0a700cff60d9dfafc40f3b4b7e0014e6b",
+				"DiscoKey":   "discokey:a4ace807754e1f8f1bc5d7401a012f47722344950a7d4382f35763bc80635527",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49126",
+					"10.65.0.27:49126",
+					"172.17.0.1:49126",
+					"172.18.0.1:49126",
+					"172.19.0.1:49126",
+					"172.20.0.1:49126",
+					"172.21.0.1:49126",
+					"172.22.0.1:49126",
+					"172.23.0.1:49126",
+					"172.24.0.1:49126",
+					"172.25.0.1:49126",
+					"172.26.0.1:49126",
+					"172.27.0.1:49126",
+					"172.28.0.1:49126"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:11:30.590573831Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5001212125978712,
+				"StableID":   "n3a8jzM44g11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec03bcd34d887fac2f5806d20af78c18471da65ced6cb98a8fb8d998bcb75d7c",
+				"DiscoKey":   "discokey:26a6b3741cf31a22ad599c14d9ecf96b17c12f32eb12f421aff04a7d2cb9cf0e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:43845",
+					"10.65.0.27:43845",
+					"172.17.0.1:43845",
+					"172.18.0.1:43845",
+					"172.19.0.1:43845",
+					"172.20.0.1:43845",
+					"172.21.0.1:43845",
+					"172.22.0.1:43845",
+					"172.23.0.1:43845",
+					"172.24.0.1:43845",
+					"172.25.0.1:43845",
+					"172.26.0.1:43845",
+					"172.27.0.1:43845",
+					"172.28.0.1:43845"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:11:31.127153854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8230806459247696,
+				"StableID":   "noYQj4LkG721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:98c9889cf909a88aa69a7a805f56567152d341d8ead559c7c43a918bbc6c4550",
+				"DiscoKey":   "discokey:d8b6802b5f0f2ae9e55751ff60079767a9eb2eea4eb8a6892957efc63308fe19",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41417",
+					"10.65.0.27:41417",
+					"172.17.0.1:41417",
+					"172.18.0.1:41417",
+					"172.19.0.1:41417",
+					"172.20.0.1:41417",
+					"172.21.0.1:41417",
+					"172.22.0.1:41417",
+					"172.23.0.1:41417",
+					"172.24.0.1:41417",
+					"172.25.0.1:41417",
+					"172.26.0.1:41417",
+					"172.27.0.1:41417",
+					"172.28.0.1:41417"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:11:31.681478377Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2192643219519776,
+				"StableID":   "n9dPx7248J11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af6c197aeeb2e8861e26d078ca62f84d392098e251a67c90bea1b4be6481f54a",
+				"DiscoKey":   "discokey:7532d187e881aa70abce6c4c7bdd356aa424d83c5ffaafb82e58253c89e68f36",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53872",
+					"10.65.0.27:53872",
+					"172.17.0.1:53872",
+					"172.18.0.1:53872",
+					"172.19.0.1:53872",
+					"172.20.0.1:53872",
+					"172.21.0.1:53872",
+					"172.22.0.1:53872",
+					"172.23.0.1:53872",
+					"172.24.0.1:53872",
+					"172.25.0.1:53872",
+					"172.26.0.1:53872",
+					"172.27.0.1:53872",
+					"172.28.0.1:53872"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:11:32.210491783Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6622337448797789,
+				"StableID":   "nxapDNaGit11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dbe12d6b4c2392dca0667ad6893de8f72f4131b6f591707f4dd34780dc741826",
+				"DiscoKey":   "discokey:b9fd436af9d9e5ff2f9eaedee7859d1df32bd38fecd5ee974dccc85159f08f67",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:46146",
+					"10.65.0.27:46146",
+					"172.17.0.1:46146",
+					"172.18.0.1:46146",
+					"172.19.0.1:46146",
+					"172.20.0.1:46146",
+					"172.21.0.1:46146",
+					"172.22.0.1:46146",
+					"172.23.0.1:46146",
+					"172.24.0.1:46146",
+					"172.25.0.1:46146",
+					"172.26.0.1:46146",
+					"172.27.0.1:46146",
+					"172.28.0.1:46146"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:11:32.736529232Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7856278415543673,
+				"StableID":   "nLSA2W78M421CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7cadaeda40fba18caa1a95233b305c0775f9af6fb6dd5d177177e5035c391f18",
+				"DiscoKey":   "discokey:0e27b0982812192999a486818efd2b538c068e2d6e126f1e64274a747ee2076c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56971",
+					"10.65.0.27:56971",
+					"172.17.0.1:56971",
+					"172.18.0.1:56971",
+					"172.19.0.1:56971",
+					"172.20.0.1:56971",
+					"172.21.0.1:56971",
+					"172.22.0.1:56971",
+					"172.23.0.1:56971",
+					"172.24.0.1:56971",
+					"172.25.0.1:56971",
+					"172.26.0.1:56971",
+					"172.27.0.1:56971",
+					"172.28.0.1:56971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:11:33.269378521Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3275348019449656,
+				"StableID":   "nD1SadqQaS11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e5231c42fd704c10efbcb05513f8da10f5c9075a07e35f01e68e8fed1f197303",
+				"KeyExpiry":  "2026-11-09T09:11:33Z",
+				"DiscoKey":   "discokey:366f52ee691c4951951fa6e77637baf9df2af6d4a55a58a337c203504528a558",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51315",
+					"10.65.0.27:51315",
+					"172.17.0.1:51315",
+					"172.18.0.1:51315",
+					"172.19.0.1:51315",
+					"172.20.0.1:51315",
+					"172.21.0.1:51315",
+					"172.22.0.1:51315",
+					"172.23.0.1:51315",
+					"172.24.0.1:51315",
+					"172.25.0.1:51315",
+					"172.26.0.1:51315",
+					"172.27.0.1:51315",
+					"172.28.0.1:51315"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:11:33.803521751Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4381600078349493,
+				"StableID":   "nEyfqqCSDb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ffa0f8aa48637ca141b05817dbf6a0d45e92a0147c93d303a0aaf6f0dd08100b",
+				"KeyExpiry":  "2026-11-09T09:11:34Z",
+				"DiscoKey":   "discokey:d87c169006961b0a3995a127a1b8792f58a8de44be722aeaed40c2214798ea38",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54975",
+					"10.65.0.27:54975",
+					"172.17.0.1:54975",
+					"172.18.0.1:54975",
+					"172.19.0.1:54975",
+					"172.20.0.1:54975",
+					"172.21.0.1:54975",
+					"172.22.0.1:54975",
+					"172.23.0.1:54975",
+					"172.24.0.1:54975",
+					"172.25.0.1:54975",
+					"172.26.0.1:54975",
+					"172.27.0.1:54975",
+					"172.28.0.1:54975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:11:34.358798756Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1715639806292417,
+				"StableID":   "n6VUk1x1QE11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dca640dfeecac31a14fdc8ce04c12453b3e18022a60be8130b9b0b604bcc5512",
+				"KeyExpiry":  "2026-11-09T09:11:34Z",
+				"DiscoKey":   "discokey:f31f77fed26171b732ea2c186ed3ef41e799151469c17a4b33a851462ea9ff4b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57841",
+					"10.65.0.27:57841",
+					"172.17.0.1:57841",
+					"172.18.0.1:57841",
+					"172.19.0.1:57841",
+					"172.20.0.1:57841",
+					"172.21.0.1:57841",
+					"172.22.0.1:57841",
+					"172.23.0.1:57841",
+					"172.24.0.1:57841",
+					"172.25.0.1:57841",
+					"172.26.0.1:57841",
+					"172.27.0.1:57841",
+					"172.28.0.1:57841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:11:34.864857495Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4823921244737725": {
+				"ID":          4823921244737725,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6660706170020454,
+				"StableID":   "nouDjUTe1u11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       6660706170020454,
+				"Key":        "nodekey:824d25b0ed9a20d2e5e73a97fd435be5e132f908935ff995c2856eda964e602e",
+				"DiscoKey":   "discokey:4944a073658a867807dcaaa0bcc54aa9d2985cefc75903f887aabb9d76890401",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49396",
+					"10.65.0.27:49396",
+					"172.17.0.1:49396",
+					"172.18.0.1:49396",
+					"172.19.0.1:49396",
+					"172.20.0.1:49396",
+					"172.21.0.1:49396",
+					"172.22.0.1:49396",
+					"172.23.0.1:49396",
+					"172.24.0.1:49396",
+					"172.25.0.1:49396",
+					"172.26.0.1:49396",
+					"172.27.0.1:49396",
+					"172.28.0.1:49396"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:11:29.514432602Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:824d25b0ed9a20d2e5e73a97fd435be5e132f908935ff995c2856eda964e602e",
+			"MachineKey": "mkey:bdd3fa5f1836636ae913527f94b99b53c9e988d9a573d428f7dfa3e1fada2a2e",
+			"Peers": [{
+				"ID":         4823921244737725,
+				"StableID":   "ntA1fQEmfe11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f068dde163d424c95e759f9278b627be1cf3f12b6aa7a50bb9604a80e82f097f",
+				"DiscoKey":   "discokey:6675d05fe875b8b93ac8f93688deee270c3b43e322406902e4ac1043fc06f03e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49772",
+					"10.65.0.27:49772",
+					"172.17.0.1:49772",
+					"172.18.0.1:49772",
+					"172.19.0.1:49772",
+					"172.20.0.1:49772",
+					"172.21.0.1:49772",
+					"172.22.0.1:49772",
+					"172.23.0.1:49772",
+					"172.24.0.1:49772",
+					"172.25.0.1:49772",
+					"172.26.0.1:49772",
+					"172.27.0.1:49772",
+					"172.28.0.1:49772"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:11:27.232727782Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6899673838592495,
+				"StableID":   "n8q1JTjssv11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a939923c6709e023a453589020af9955f819688b31d22c523ea2ae11a4f54473",
+				"DiscoKey":   "discokey:0bba3699d6f26057022b54d80c5442f14d6663fb2046f8852e3117ae855f5e24",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48989",
+					"10.65.0.27:48989",
+					"172.17.0.1:48989",
+					"172.18.0.1:48989",
+					"172.19.0.1:48989",
+					"172.20.0.1:48989",
+					"172.21.0.1:48989",
+					"172.22.0.1:48989",
+					"172.23.0.1:48989",
+					"172.24.0.1:48989",
+					"172.25.0.1:48989",
+					"172.26.0.1:48989",
+					"172.27.0.1:48989",
+					"172.28.0.1:48989"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:11:27.923232747Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1471710141868880,
+				"StableID":   "nmFwb8LYVC11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2298aed6a48ed64120efa52f711067dc887fbb9c78bc864a282ae81a41e96732",
+				"DiscoKey":   "discokey:6b899c9ec15deaac0adeb76364629ef96084f446898f033bc5bdf42c3c893012",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46576",
+					"10.65.0.27:46576",
+					"172.17.0.1:46576",
+					"172.18.0.1:46576",
+					"172.19.0.1:46576",
+					"172.20.0.1:46576",
+					"172.21.0.1:46576",
+					"172.22.0.1:46576",
+					"172.23.0.1:46576",
+					"172.24.0.1:46576",
+					"172.25.0.1:46576",
+					"172.26.0.1:46576",
+					"172.27.0.1:46576",
+					"172.28.0.1:46576"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:11:28.449863702Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7940710577154745,
+				"StableID":   "nA51271N1521CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:426acaea24fe205eeb09b4bcd6cfef17b807be74987d174da3507fa777b43b39",
+				"DiscoKey":   "discokey:079b1c7162b2484e86d4e530566fa84bd0aea1363341d869c93650c47ad91669",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51637",
+					"10.65.0.27:51637",
+					"172.17.0.1:51637",
+					"172.18.0.1:51637",
+					"172.19.0.1:51637",
+					"172.20.0.1:51637",
+					"172.21.0.1:51637",
+					"172.22.0.1:51637",
+					"172.23.0.1:51637",
+					"172.24.0.1:51637",
+					"172.25.0.1:51637",
+					"172.26.0.1:51637",
+					"172.27.0.1:51637",
+					"172.28.0.1:51637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:11:28.980992142Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5873399707930875,
+				"StableID":   "nkuHgYF5sn11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc6f5a3a207f5c39ed962d0781cb807109ba7dea69a8d53d7aad93625fb7af7f",
+				"DiscoKey":   "discokey:74f2b63be50beb5872dd750c982af92e8f812a0045f04428b41a7be72219673e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:55933",
+					"10.65.0.27:55933",
+					"172.17.0.1:55933",
+					"172.18.0.1:55933",
+					"172.19.0.1:55933",
+					"172.20.0.1:55933",
+					"172.21.0.1:55933",
+					"172.22.0.1:55933",
+					"172.23.0.1:55933",
+					"172.24.0.1:55933",
+					"172.25.0.1:55933",
+					"172.26.0.1:55933",
+					"172.27.0.1:55933",
+					"172.28.0.1:55933"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:11:30.054301025Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4656389653246852,
+				"StableID":   "n1wobhTtMd11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab21ee6bc3991d19001955bdc61e9cf0a700cff60d9dfafc40f3b4b7e0014e6b",
+				"DiscoKey":   "discokey:a4ace807754e1f8f1bc5d7401a012f47722344950a7d4382f35763bc80635527",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49126",
+					"10.65.0.27:49126",
+					"172.17.0.1:49126",
+					"172.18.0.1:49126",
+					"172.19.0.1:49126",
+					"172.20.0.1:49126",
+					"172.21.0.1:49126",
+					"172.22.0.1:49126",
+					"172.23.0.1:49126",
+					"172.24.0.1:49126",
+					"172.25.0.1:49126",
+					"172.26.0.1:49126",
+					"172.27.0.1:49126",
+					"172.28.0.1:49126"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:11:30.590573831Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5001212125978712,
+				"StableID":   "n3a8jzM44g11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec03bcd34d887fac2f5806d20af78c18471da65ced6cb98a8fb8d998bcb75d7c",
+				"DiscoKey":   "discokey:26a6b3741cf31a22ad599c14d9ecf96b17c12f32eb12f421aff04a7d2cb9cf0e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:43845",
+					"10.65.0.27:43845",
+					"172.17.0.1:43845",
+					"172.18.0.1:43845",
+					"172.19.0.1:43845",
+					"172.20.0.1:43845",
+					"172.21.0.1:43845",
+					"172.22.0.1:43845",
+					"172.23.0.1:43845",
+					"172.24.0.1:43845",
+					"172.25.0.1:43845",
+					"172.26.0.1:43845",
+					"172.27.0.1:43845",
+					"172.28.0.1:43845"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:11:31.127153854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8230806459247696,
+				"StableID":   "noYQj4LkG721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:98c9889cf909a88aa69a7a805f56567152d341d8ead559c7c43a918bbc6c4550",
+				"DiscoKey":   "discokey:d8b6802b5f0f2ae9e55751ff60079767a9eb2eea4eb8a6892957efc63308fe19",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41417",
+					"10.65.0.27:41417",
+					"172.17.0.1:41417",
+					"172.18.0.1:41417",
+					"172.19.0.1:41417",
+					"172.20.0.1:41417",
+					"172.21.0.1:41417",
+					"172.22.0.1:41417",
+					"172.23.0.1:41417",
+					"172.24.0.1:41417",
+					"172.25.0.1:41417",
+					"172.26.0.1:41417",
+					"172.27.0.1:41417",
+					"172.28.0.1:41417"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:11:31.681478377Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2192643219519776,
+				"StableID":   "n9dPx7248J11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af6c197aeeb2e8861e26d078ca62f84d392098e251a67c90bea1b4be6481f54a",
+				"DiscoKey":   "discokey:7532d187e881aa70abce6c4c7bdd356aa424d83c5ffaafb82e58253c89e68f36",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53872",
+					"10.65.0.27:53872",
+					"172.17.0.1:53872",
+					"172.18.0.1:53872",
+					"172.19.0.1:53872",
+					"172.20.0.1:53872",
+					"172.21.0.1:53872",
+					"172.22.0.1:53872",
+					"172.23.0.1:53872",
+					"172.24.0.1:53872",
+					"172.25.0.1:53872",
+					"172.26.0.1:53872",
+					"172.27.0.1:53872",
+					"172.28.0.1:53872"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:11:32.210491783Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6622337448797789,
+				"StableID":   "nxapDNaGit11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dbe12d6b4c2392dca0667ad6893de8f72f4131b6f591707f4dd34780dc741826",
+				"DiscoKey":   "discokey:b9fd436af9d9e5ff2f9eaedee7859d1df32bd38fecd5ee974dccc85159f08f67",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:46146",
+					"10.65.0.27:46146",
+					"172.17.0.1:46146",
+					"172.18.0.1:46146",
+					"172.19.0.1:46146",
+					"172.20.0.1:46146",
+					"172.21.0.1:46146",
+					"172.22.0.1:46146",
+					"172.23.0.1:46146",
+					"172.24.0.1:46146",
+					"172.25.0.1:46146",
+					"172.26.0.1:46146",
+					"172.27.0.1:46146",
+					"172.28.0.1:46146"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:11:32.736529232Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7856278415543673,
+				"StableID":   "nLSA2W78M421CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7cadaeda40fba18caa1a95233b305c0775f9af6fb6dd5d177177e5035c391f18",
+				"DiscoKey":   "discokey:0e27b0982812192999a486818efd2b538c068e2d6e126f1e64274a747ee2076c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56971",
+					"10.65.0.27:56971",
+					"172.17.0.1:56971",
+					"172.18.0.1:56971",
+					"172.19.0.1:56971",
+					"172.20.0.1:56971",
+					"172.21.0.1:56971",
+					"172.22.0.1:56971",
+					"172.23.0.1:56971",
+					"172.24.0.1:56971",
+					"172.25.0.1:56971",
+					"172.26.0.1:56971",
+					"172.27.0.1:56971",
+					"172.28.0.1:56971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:11:33.269378521Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3275348019449656,
+				"StableID":   "nD1SadqQaS11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e5231c42fd704c10efbcb05513f8da10f5c9075a07e35f01e68e8fed1f197303",
+				"KeyExpiry":  "2026-11-09T09:11:33Z",
+				"DiscoKey":   "discokey:366f52ee691c4951951fa6e77637baf9df2af6d4a55a58a337c203504528a558",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51315",
+					"10.65.0.27:51315",
+					"172.17.0.1:51315",
+					"172.18.0.1:51315",
+					"172.19.0.1:51315",
+					"172.20.0.1:51315",
+					"172.21.0.1:51315",
+					"172.22.0.1:51315",
+					"172.23.0.1:51315",
+					"172.24.0.1:51315",
+					"172.25.0.1:51315",
+					"172.26.0.1:51315",
+					"172.27.0.1:51315",
+					"172.28.0.1:51315"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:11:33.803521751Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4381600078349493,
+				"StableID":   "nEyfqqCSDb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ffa0f8aa48637ca141b05817dbf6a0d45e92a0147c93d303a0aaf6f0dd08100b",
+				"KeyExpiry":  "2026-11-09T09:11:34Z",
+				"DiscoKey":   "discokey:d87c169006961b0a3995a127a1b8792f58a8de44be722aeaed40c2214798ea38",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54975",
+					"10.65.0.27:54975",
+					"172.17.0.1:54975",
+					"172.18.0.1:54975",
+					"172.19.0.1:54975",
+					"172.20.0.1:54975",
+					"172.21.0.1:54975",
+					"172.22.0.1:54975",
+					"172.23.0.1:54975",
+					"172.24.0.1:54975",
+					"172.25.0.1:54975",
+					"172.26.0.1:54975",
+					"172.27.0.1:54975",
+					"172.28.0.1:54975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:11:34.358798756Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1715639806292417,
+				"StableID":   "n6VUk1x1QE11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dca640dfeecac31a14fdc8ce04c12453b3e18022a60be8130b9b0b604bcc5512",
+				"KeyExpiry":  "2026-11-09T09:11:34Z",
+				"DiscoKey":   "discokey:f31f77fed26171b732ea2c186ed3ef41e799151469c17a4b33a851462ea9ff4b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57841",
+					"10.65.0.27:57841",
+					"172.17.0.1:57841",
+					"172.18.0.1:57841",
+					"172.19.0.1:57841",
+					"172.20.0.1:57841",
+					"172.21.0.1:57841",
+					"172.22.0.1:57841",
+					"172.23.0.1:57841",
+					"172.24.0.1:57841",
+					"172.25.0.1:57841",
+					"172.26.0.1:57841",
+					"172.27.0.1:57841",
+					"172.28.0.1:57841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:11:34.864857495Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6660706170020454": {
+				"ID":          6660706170020454,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7940710577154745,
+				"StableID":   "nA51271N1521CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       7940710577154745,
+				"Key":        "nodekey:426acaea24fe205eeb09b4bcd6cfef17b807be74987d174da3507fa777b43b39",
+				"DiscoKey":   "discokey:079b1c7162b2484e86d4e530566fa84bd0aea1363341d869c93650c47ad91669",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51637",
+					"10.65.0.27:51637",
+					"172.17.0.1:51637",
+					"172.18.0.1:51637",
+					"172.19.0.1:51637",
+					"172.20.0.1:51637",
+					"172.21.0.1:51637",
+					"172.22.0.1:51637",
+					"172.23.0.1:51637",
+					"172.24.0.1:51637",
+					"172.25.0.1:51637",
+					"172.26.0.1:51637",
+					"172.27.0.1:51637",
+					"172.28.0.1:51637"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:11:28.980992142Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:426acaea24fe205eeb09b4bcd6cfef17b807be74987d174da3507fa777b43b39",
+			"MachineKey": "mkey:4dfd1d1061c991b93fc427ec79020caa28ac6f4fb571b409c2dd683e7049e96c",
+			"Peers": [{
+				"ID":         4823921244737725,
+				"StableID":   "ntA1fQEmfe11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f068dde163d424c95e759f9278b627be1cf3f12b6aa7a50bb9604a80e82f097f",
+				"DiscoKey":   "discokey:6675d05fe875b8b93ac8f93688deee270c3b43e322406902e4ac1043fc06f03e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49772",
+					"10.65.0.27:49772",
+					"172.17.0.1:49772",
+					"172.18.0.1:49772",
+					"172.19.0.1:49772",
+					"172.20.0.1:49772",
+					"172.21.0.1:49772",
+					"172.22.0.1:49772",
+					"172.23.0.1:49772",
+					"172.24.0.1:49772",
+					"172.25.0.1:49772",
+					"172.26.0.1:49772",
+					"172.27.0.1:49772",
+					"172.28.0.1:49772"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:11:27.232727782Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6899673838592495,
+				"StableID":   "n8q1JTjssv11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a939923c6709e023a453589020af9955f819688b31d22c523ea2ae11a4f54473",
+				"DiscoKey":   "discokey:0bba3699d6f26057022b54d80c5442f14d6663fb2046f8852e3117ae855f5e24",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48989",
+					"10.65.0.27:48989",
+					"172.17.0.1:48989",
+					"172.18.0.1:48989",
+					"172.19.0.1:48989",
+					"172.20.0.1:48989",
+					"172.21.0.1:48989",
+					"172.22.0.1:48989",
+					"172.23.0.1:48989",
+					"172.24.0.1:48989",
+					"172.25.0.1:48989",
+					"172.26.0.1:48989",
+					"172.27.0.1:48989",
+					"172.28.0.1:48989"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:11:27.923232747Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1471710141868880,
+				"StableID":   "nmFwb8LYVC11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2298aed6a48ed64120efa52f711067dc887fbb9c78bc864a282ae81a41e96732",
+				"DiscoKey":   "discokey:6b899c9ec15deaac0adeb76364629ef96084f446898f033bc5bdf42c3c893012",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46576",
+					"10.65.0.27:46576",
+					"172.17.0.1:46576",
+					"172.18.0.1:46576",
+					"172.19.0.1:46576",
+					"172.20.0.1:46576",
+					"172.21.0.1:46576",
+					"172.22.0.1:46576",
+					"172.23.0.1:46576",
+					"172.24.0.1:46576",
+					"172.25.0.1:46576",
+					"172.26.0.1:46576",
+					"172.27.0.1:46576",
+					"172.28.0.1:46576"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:11:28.449863702Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6660706170020454,
+				"StableID":   "nouDjUTe1u11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:824d25b0ed9a20d2e5e73a97fd435be5e132f908935ff995c2856eda964e602e",
+				"DiscoKey":   "discokey:4944a073658a867807dcaaa0bcc54aa9d2985cefc75903f887aabb9d76890401",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49396",
+					"10.65.0.27:49396",
+					"172.17.0.1:49396",
+					"172.18.0.1:49396",
+					"172.19.0.1:49396",
+					"172.20.0.1:49396",
+					"172.21.0.1:49396",
+					"172.22.0.1:49396",
+					"172.23.0.1:49396",
+					"172.24.0.1:49396",
+					"172.25.0.1:49396",
+					"172.26.0.1:49396",
+					"172.27.0.1:49396",
+					"172.28.0.1:49396"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:11:29.514432602Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5873399707930875,
+				"StableID":   "nkuHgYF5sn11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc6f5a3a207f5c39ed962d0781cb807109ba7dea69a8d53d7aad93625fb7af7f",
+				"DiscoKey":   "discokey:74f2b63be50beb5872dd750c982af92e8f812a0045f04428b41a7be72219673e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:55933",
+					"10.65.0.27:55933",
+					"172.17.0.1:55933",
+					"172.18.0.1:55933",
+					"172.19.0.1:55933",
+					"172.20.0.1:55933",
+					"172.21.0.1:55933",
+					"172.22.0.1:55933",
+					"172.23.0.1:55933",
+					"172.24.0.1:55933",
+					"172.25.0.1:55933",
+					"172.26.0.1:55933",
+					"172.27.0.1:55933",
+					"172.28.0.1:55933"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:11:30.054301025Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4656389653246852,
+				"StableID":   "n1wobhTtMd11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab21ee6bc3991d19001955bdc61e9cf0a700cff60d9dfafc40f3b4b7e0014e6b",
+				"DiscoKey":   "discokey:a4ace807754e1f8f1bc5d7401a012f47722344950a7d4382f35763bc80635527",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49126",
+					"10.65.0.27:49126",
+					"172.17.0.1:49126",
+					"172.18.0.1:49126",
+					"172.19.0.1:49126",
+					"172.20.0.1:49126",
+					"172.21.0.1:49126",
+					"172.22.0.1:49126",
+					"172.23.0.1:49126",
+					"172.24.0.1:49126",
+					"172.25.0.1:49126",
+					"172.26.0.1:49126",
+					"172.27.0.1:49126",
+					"172.28.0.1:49126"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:11:30.590573831Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5001212125978712,
+				"StableID":   "n3a8jzM44g11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec03bcd34d887fac2f5806d20af78c18471da65ced6cb98a8fb8d998bcb75d7c",
+				"DiscoKey":   "discokey:26a6b3741cf31a22ad599c14d9ecf96b17c12f32eb12f421aff04a7d2cb9cf0e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:43845",
+					"10.65.0.27:43845",
+					"172.17.0.1:43845",
+					"172.18.0.1:43845",
+					"172.19.0.1:43845",
+					"172.20.0.1:43845",
+					"172.21.0.1:43845",
+					"172.22.0.1:43845",
+					"172.23.0.1:43845",
+					"172.24.0.1:43845",
+					"172.25.0.1:43845",
+					"172.26.0.1:43845",
+					"172.27.0.1:43845",
+					"172.28.0.1:43845"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:11:31.127153854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8230806459247696,
+				"StableID":   "noYQj4LkG721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:98c9889cf909a88aa69a7a805f56567152d341d8ead559c7c43a918bbc6c4550",
+				"DiscoKey":   "discokey:d8b6802b5f0f2ae9e55751ff60079767a9eb2eea4eb8a6892957efc63308fe19",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41417",
+					"10.65.0.27:41417",
+					"172.17.0.1:41417",
+					"172.18.0.1:41417",
+					"172.19.0.1:41417",
+					"172.20.0.1:41417",
+					"172.21.0.1:41417",
+					"172.22.0.1:41417",
+					"172.23.0.1:41417",
+					"172.24.0.1:41417",
+					"172.25.0.1:41417",
+					"172.26.0.1:41417",
+					"172.27.0.1:41417",
+					"172.28.0.1:41417"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:11:31.681478377Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2192643219519776,
+				"StableID":   "n9dPx7248J11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af6c197aeeb2e8861e26d078ca62f84d392098e251a67c90bea1b4be6481f54a",
+				"DiscoKey":   "discokey:7532d187e881aa70abce6c4c7bdd356aa424d83c5ffaafb82e58253c89e68f36",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53872",
+					"10.65.0.27:53872",
+					"172.17.0.1:53872",
+					"172.18.0.1:53872",
+					"172.19.0.1:53872",
+					"172.20.0.1:53872",
+					"172.21.0.1:53872",
+					"172.22.0.1:53872",
+					"172.23.0.1:53872",
+					"172.24.0.1:53872",
+					"172.25.0.1:53872",
+					"172.26.0.1:53872",
+					"172.27.0.1:53872",
+					"172.28.0.1:53872"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:11:32.210491783Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6622337448797789,
+				"StableID":   "nxapDNaGit11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dbe12d6b4c2392dca0667ad6893de8f72f4131b6f591707f4dd34780dc741826",
+				"DiscoKey":   "discokey:b9fd436af9d9e5ff2f9eaedee7859d1df32bd38fecd5ee974dccc85159f08f67",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:46146",
+					"10.65.0.27:46146",
+					"172.17.0.1:46146",
+					"172.18.0.1:46146",
+					"172.19.0.1:46146",
+					"172.20.0.1:46146",
+					"172.21.0.1:46146",
+					"172.22.0.1:46146",
+					"172.23.0.1:46146",
+					"172.24.0.1:46146",
+					"172.25.0.1:46146",
+					"172.26.0.1:46146",
+					"172.27.0.1:46146",
+					"172.28.0.1:46146"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:11:32.736529232Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7856278415543673,
+				"StableID":   "nLSA2W78M421CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7cadaeda40fba18caa1a95233b305c0775f9af6fb6dd5d177177e5035c391f18",
+				"DiscoKey":   "discokey:0e27b0982812192999a486818efd2b538c068e2d6e126f1e64274a747ee2076c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56971",
+					"10.65.0.27:56971",
+					"172.17.0.1:56971",
+					"172.18.0.1:56971",
+					"172.19.0.1:56971",
+					"172.20.0.1:56971",
+					"172.21.0.1:56971",
+					"172.22.0.1:56971",
+					"172.23.0.1:56971",
+					"172.24.0.1:56971",
+					"172.25.0.1:56971",
+					"172.26.0.1:56971",
+					"172.27.0.1:56971",
+					"172.28.0.1:56971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:11:33.269378521Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3275348019449656,
+				"StableID":   "nD1SadqQaS11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e5231c42fd704c10efbcb05513f8da10f5c9075a07e35f01e68e8fed1f197303",
+				"KeyExpiry":  "2026-11-09T09:11:33Z",
+				"DiscoKey":   "discokey:366f52ee691c4951951fa6e77637baf9df2af6d4a55a58a337c203504528a558",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51315",
+					"10.65.0.27:51315",
+					"172.17.0.1:51315",
+					"172.18.0.1:51315",
+					"172.19.0.1:51315",
+					"172.20.0.1:51315",
+					"172.21.0.1:51315",
+					"172.22.0.1:51315",
+					"172.23.0.1:51315",
+					"172.24.0.1:51315",
+					"172.25.0.1:51315",
+					"172.26.0.1:51315",
+					"172.27.0.1:51315",
+					"172.28.0.1:51315"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:11:33.803521751Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4381600078349493,
+				"StableID":   "nEyfqqCSDb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ffa0f8aa48637ca141b05817dbf6a0d45e92a0147c93d303a0aaf6f0dd08100b",
+				"KeyExpiry":  "2026-11-09T09:11:34Z",
+				"DiscoKey":   "discokey:d87c169006961b0a3995a127a1b8792f58a8de44be722aeaed40c2214798ea38",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54975",
+					"10.65.0.27:54975",
+					"172.17.0.1:54975",
+					"172.18.0.1:54975",
+					"172.19.0.1:54975",
+					"172.20.0.1:54975",
+					"172.21.0.1:54975",
+					"172.22.0.1:54975",
+					"172.23.0.1:54975",
+					"172.24.0.1:54975",
+					"172.25.0.1:54975",
+					"172.26.0.1:54975",
+					"172.27.0.1:54975",
+					"172.28.0.1:54975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:11:34.358798756Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1715639806292417,
+				"StableID":   "n6VUk1x1QE11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dca640dfeecac31a14fdc8ce04c12453b3e18022a60be8130b9b0b604bcc5512",
+				"KeyExpiry":  "2026-11-09T09:11:34Z",
+				"DiscoKey":   "discokey:f31f77fed26171b732ea2c186ed3ef41e799151469c17a4b33a851462ea9ff4b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57841",
+					"10.65.0.27:57841",
+					"172.17.0.1:57841",
+					"172.18.0.1:57841",
+					"172.19.0.1:57841",
+					"172.20.0.1:57841",
+					"172.21.0.1:57841",
+					"172.22.0.1:57841",
+					"172.23.0.1:57841",
+					"172.24.0.1:57841",
+					"172.25.0.1:57841",
+					"172.26.0.1:57841",
+					"172.27.0.1:57841",
+					"172.28.0.1:57841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:11:34.864857495Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7940710577154745": {
+				"ID":          7940710577154745,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4656389653246852,
+				"StableID":   "n1wobhTtMd11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       4656389653246852,
+				"Key":        "nodekey:ab21ee6bc3991d19001955bdc61e9cf0a700cff60d9dfafc40f3b4b7e0014e6b",
+				"DiscoKey":   "discokey:a4ace807754e1f8f1bc5d7401a012f47722344950a7d4382f35763bc80635527",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49126",
+					"10.65.0.27:49126",
+					"172.17.0.1:49126",
+					"172.18.0.1:49126",
+					"172.19.0.1:49126",
+					"172.20.0.1:49126",
+					"172.21.0.1:49126",
+					"172.22.0.1:49126",
+					"172.23.0.1:49126",
+					"172.24.0.1:49126",
+					"172.25.0.1:49126",
+					"172.26.0.1:49126",
+					"172.27.0.1:49126",
+					"172.28.0.1:49126"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:11:30.590573831Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ab21ee6bc3991d19001955bdc61e9cf0a700cff60d9dfafc40f3b4b7e0014e6b",
+			"MachineKey": "mkey:af6a05425816c1b6794e3f38076d76f597787157ba33a90d661a4e21faf1e720",
+			"Peers": [{
+				"ID":         4823921244737725,
+				"StableID":   "ntA1fQEmfe11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f068dde163d424c95e759f9278b627be1cf3f12b6aa7a50bb9604a80e82f097f",
+				"DiscoKey":   "discokey:6675d05fe875b8b93ac8f93688deee270c3b43e322406902e4ac1043fc06f03e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49772",
+					"10.65.0.27:49772",
+					"172.17.0.1:49772",
+					"172.18.0.1:49772",
+					"172.19.0.1:49772",
+					"172.20.0.1:49772",
+					"172.21.0.1:49772",
+					"172.22.0.1:49772",
+					"172.23.0.1:49772",
+					"172.24.0.1:49772",
+					"172.25.0.1:49772",
+					"172.26.0.1:49772",
+					"172.27.0.1:49772",
+					"172.28.0.1:49772"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:11:27.232727782Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6899673838592495,
+				"StableID":   "n8q1JTjssv11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a939923c6709e023a453589020af9955f819688b31d22c523ea2ae11a4f54473",
+				"DiscoKey":   "discokey:0bba3699d6f26057022b54d80c5442f14d6663fb2046f8852e3117ae855f5e24",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48989",
+					"10.65.0.27:48989",
+					"172.17.0.1:48989",
+					"172.18.0.1:48989",
+					"172.19.0.1:48989",
+					"172.20.0.1:48989",
+					"172.21.0.1:48989",
+					"172.22.0.1:48989",
+					"172.23.0.1:48989",
+					"172.24.0.1:48989",
+					"172.25.0.1:48989",
+					"172.26.0.1:48989",
+					"172.27.0.1:48989",
+					"172.28.0.1:48989"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:11:27.923232747Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1471710141868880,
+				"StableID":   "nmFwb8LYVC11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2298aed6a48ed64120efa52f711067dc887fbb9c78bc864a282ae81a41e96732",
+				"DiscoKey":   "discokey:6b899c9ec15deaac0adeb76364629ef96084f446898f033bc5bdf42c3c893012",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46576",
+					"10.65.0.27:46576",
+					"172.17.0.1:46576",
+					"172.18.0.1:46576",
+					"172.19.0.1:46576",
+					"172.20.0.1:46576",
+					"172.21.0.1:46576",
+					"172.22.0.1:46576",
+					"172.23.0.1:46576",
+					"172.24.0.1:46576",
+					"172.25.0.1:46576",
+					"172.26.0.1:46576",
+					"172.27.0.1:46576",
+					"172.28.0.1:46576"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:11:28.449863702Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7940710577154745,
+				"StableID":   "nA51271N1521CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:426acaea24fe205eeb09b4bcd6cfef17b807be74987d174da3507fa777b43b39",
+				"DiscoKey":   "discokey:079b1c7162b2484e86d4e530566fa84bd0aea1363341d869c93650c47ad91669",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51637",
+					"10.65.0.27:51637",
+					"172.17.0.1:51637",
+					"172.18.0.1:51637",
+					"172.19.0.1:51637",
+					"172.20.0.1:51637",
+					"172.21.0.1:51637",
+					"172.22.0.1:51637",
+					"172.23.0.1:51637",
+					"172.24.0.1:51637",
+					"172.25.0.1:51637",
+					"172.26.0.1:51637",
+					"172.27.0.1:51637",
+					"172.28.0.1:51637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:11:28.980992142Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6660706170020454,
+				"StableID":   "nouDjUTe1u11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:824d25b0ed9a20d2e5e73a97fd435be5e132f908935ff995c2856eda964e602e",
+				"DiscoKey":   "discokey:4944a073658a867807dcaaa0bcc54aa9d2985cefc75903f887aabb9d76890401",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49396",
+					"10.65.0.27:49396",
+					"172.17.0.1:49396",
+					"172.18.0.1:49396",
+					"172.19.0.1:49396",
+					"172.20.0.1:49396",
+					"172.21.0.1:49396",
+					"172.22.0.1:49396",
+					"172.23.0.1:49396",
+					"172.24.0.1:49396",
+					"172.25.0.1:49396",
+					"172.26.0.1:49396",
+					"172.27.0.1:49396",
+					"172.28.0.1:49396"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:11:29.514432602Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5873399707930875,
+				"StableID":   "nkuHgYF5sn11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc6f5a3a207f5c39ed962d0781cb807109ba7dea69a8d53d7aad93625fb7af7f",
+				"DiscoKey":   "discokey:74f2b63be50beb5872dd750c982af92e8f812a0045f04428b41a7be72219673e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:55933",
+					"10.65.0.27:55933",
+					"172.17.0.1:55933",
+					"172.18.0.1:55933",
+					"172.19.0.1:55933",
+					"172.20.0.1:55933",
+					"172.21.0.1:55933",
+					"172.22.0.1:55933",
+					"172.23.0.1:55933",
+					"172.24.0.1:55933",
+					"172.25.0.1:55933",
+					"172.26.0.1:55933",
+					"172.27.0.1:55933",
+					"172.28.0.1:55933"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:11:30.054301025Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5001212125978712,
+				"StableID":   "n3a8jzM44g11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec03bcd34d887fac2f5806d20af78c18471da65ced6cb98a8fb8d998bcb75d7c",
+				"DiscoKey":   "discokey:26a6b3741cf31a22ad599c14d9ecf96b17c12f32eb12f421aff04a7d2cb9cf0e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:43845",
+					"10.65.0.27:43845",
+					"172.17.0.1:43845",
+					"172.18.0.1:43845",
+					"172.19.0.1:43845",
+					"172.20.0.1:43845",
+					"172.21.0.1:43845",
+					"172.22.0.1:43845",
+					"172.23.0.1:43845",
+					"172.24.0.1:43845",
+					"172.25.0.1:43845",
+					"172.26.0.1:43845",
+					"172.27.0.1:43845",
+					"172.28.0.1:43845"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:11:31.127153854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8230806459247696,
+				"StableID":   "noYQj4LkG721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:98c9889cf909a88aa69a7a805f56567152d341d8ead559c7c43a918bbc6c4550",
+				"DiscoKey":   "discokey:d8b6802b5f0f2ae9e55751ff60079767a9eb2eea4eb8a6892957efc63308fe19",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41417",
+					"10.65.0.27:41417",
+					"172.17.0.1:41417",
+					"172.18.0.1:41417",
+					"172.19.0.1:41417",
+					"172.20.0.1:41417",
+					"172.21.0.1:41417",
+					"172.22.0.1:41417",
+					"172.23.0.1:41417",
+					"172.24.0.1:41417",
+					"172.25.0.1:41417",
+					"172.26.0.1:41417",
+					"172.27.0.1:41417",
+					"172.28.0.1:41417"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:11:31.681478377Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2192643219519776,
+				"StableID":   "n9dPx7248J11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af6c197aeeb2e8861e26d078ca62f84d392098e251a67c90bea1b4be6481f54a",
+				"DiscoKey":   "discokey:7532d187e881aa70abce6c4c7bdd356aa424d83c5ffaafb82e58253c89e68f36",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53872",
+					"10.65.0.27:53872",
+					"172.17.0.1:53872",
+					"172.18.0.1:53872",
+					"172.19.0.1:53872",
+					"172.20.0.1:53872",
+					"172.21.0.1:53872",
+					"172.22.0.1:53872",
+					"172.23.0.1:53872",
+					"172.24.0.1:53872",
+					"172.25.0.1:53872",
+					"172.26.0.1:53872",
+					"172.27.0.1:53872",
+					"172.28.0.1:53872"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:11:32.210491783Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6622337448797789,
+				"StableID":   "nxapDNaGit11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dbe12d6b4c2392dca0667ad6893de8f72f4131b6f591707f4dd34780dc741826",
+				"DiscoKey":   "discokey:b9fd436af9d9e5ff2f9eaedee7859d1df32bd38fecd5ee974dccc85159f08f67",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:46146",
+					"10.65.0.27:46146",
+					"172.17.0.1:46146",
+					"172.18.0.1:46146",
+					"172.19.0.1:46146",
+					"172.20.0.1:46146",
+					"172.21.0.1:46146",
+					"172.22.0.1:46146",
+					"172.23.0.1:46146",
+					"172.24.0.1:46146",
+					"172.25.0.1:46146",
+					"172.26.0.1:46146",
+					"172.27.0.1:46146",
+					"172.28.0.1:46146"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:11:32.736529232Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7856278415543673,
+				"StableID":   "nLSA2W78M421CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7cadaeda40fba18caa1a95233b305c0775f9af6fb6dd5d177177e5035c391f18",
+				"DiscoKey":   "discokey:0e27b0982812192999a486818efd2b538c068e2d6e126f1e64274a747ee2076c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56971",
+					"10.65.0.27:56971",
+					"172.17.0.1:56971",
+					"172.18.0.1:56971",
+					"172.19.0.1:56971",
+					"172.20.0.1:56971",
+					"172.21.0.1:56971",
+					"172.22.0.1:56971",
+					"172.23.0.1:56971",
+					"172.24.0.1:56971",
+					"172.25.0.1:56971",
+					"172.26.0.1:56971",
+					"172.27.0.1:56971",
+					"172.28.0.1:56971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:11:33.269378521Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3275348019449656,
+				"StableID":   "nD1SadqQaS11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e5231c42fd704c10efbcb05513f8da10f5c9075a07e35f01e68e8fed1f197303",
+				"KeyExpiry":  "2026-11-09T09:11:33Z",
+				"DiscoKey":   "discokey:366f52ee691c4951951fa6e77637baf9df2af6d4a55a58a337c203504528a558",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51315",
+					"10.65.0.27:51315",
+					"172.17.0.1:51315",
+					"172.18.0.1:51315",
+					"172.19.0.1:51315",
+					"172.20.0.1:51315",
+					"172.21.0.1:51315",
+					"172.22.0.1:51315",
+					"172.23.0.1:51315",
+					"172.24.0.1:51315",
+					"172.25.0.1:51315",
+					"172.26.0.1:51315",
+					"172.27.0.1:51315",
+					"172.28.0.1:51315"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:11:33.803521751Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4381600078349493,
+				"StableID":   "nEyfqqCSDb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ffa0f8aa48637ca141b05817dbf6a0d45e92a0147c93d303a0aaf6f0dd08100b",
+				"KeyExpiry":  "2026-11-09T09:11:34Z",
+				"DiscoKey":   "discokey:d87c169006961b0a3995a127a1b8792f58a8de44be722aeaed40c2214798ea38",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54975",
+					"10.65.0.27:54975",
+					"172.17.0.1:54975",
+					"172.18.0.1:54975",
+					"172.19.0.1:54975",
+					"172.20.0.1:54975",
+					"172.21.0.1:54975",
+					"172.22.0.1:54975",
+					"172.23.0.1:54975",
+					"172.24.0.1:54975",
+					"172.25.0.1:54975",
+					"172.26.0.1:54975",
+					"172.27.0.1:54975",
+					"172.28.0.1:54975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:11:34.358798756Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1715639806292417,
+				"StableID":   "n6VUk1x1QE11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dca640dfeecac31a14fdc8ce04c12453b3e18022a60be8130b9b0b604bcc5512",
+				"KeyExpiry":  "2026-11-09T09:11:34Z",
+				"DiscoKey":   "discokey:f31f77fed26171b732ea2c186ed3ef41e799151469c17a4b33a851462ea9ff4b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57841",
+					"10.65.0.27:57841",
+					"172.17.0.1:57841",
+					"172.18.0.1:57841",
+					"172.19.0.1:57841",
+					"172.20.0.1:57841",
+					"172.21.0.1:57841",
+					"172.22.0.1:57841",
+					"172.23.0.1:57841",
+					"172.24.0.1:57841",
+					"172.25.0.1:57841",
+					"172.26.0.1:57841",
+					"172.27.0.1:57841",
+					"172.28.0.1:57841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:11:34.864857495Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4656389653246852": {
+				"ID":          4656389653246852,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8230806459247696,
+				"StableID":   "noYQj4LkG721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       8230806459247696,
+				"Key":        "nodekey:98c9889cf909a88aa69a7a805f56567152d341d8ead559c7c43a918bbc6c4550",
+				"DiscoKey":   "discokey:d8b6802b5f0f2ae9e55751ff60079767a9eb2eea4eb8a6892957efc63308fe19",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41417",
+					"10.65.0.27:41417",
+					"172.17.0.1:41417",
+					"172.18.0.1:41417",
+					"172.19.0.1:41417",
+					"172.20.0.1:41417",
+					"172.21.0.1:41417",
+					"172.22.0.1:41417",
+					"172.23.0.1:41417",
+					"172.24.0.1:41417",
+					"172.25.0.1:41417",
+					"172.26.0.1:41417",
+					"172.27.0.1:41417",
+					"172.28.0.1:41417"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:11:31.681478377Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:98c9889cf909a88aa69a7a805f56567152d341d8ead559c7c43a918bbc6c4550",
+			"MachineKey": "mkey:4bed31da62f8bfc36b9864ec92f4e785e62f186c1b63edf26a7279baacad7f00",
+			"Peers": [{
+				"ID":         4823921244737725,
+				"StableID":   "ntA1fQEmfe11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f068dde163d424c95e759f9278b627be1cf3f12b6aa7a50bb9604a80e82f097f",
+				"DiscoKey":   "discokey:6675d05fe875b8b93ac8f93688deee270c3b43e322406902e4ac1043fc06f03e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49772",
+					"10.65.0.27:49772",
+					"172.17.0.1:49772",
+					"172.18.0.1:49772",
+					"172.19.0.1:49772",
+					"172.20.0.1:49772",
+					"172.21.0.1:49772",
+					"172.22.0.1:49772",
+					"172.23.0.1:49772",
+					"172.24.0.1:49772",
+					"172.25.0.1:49772",
+					"172.26.0.1:49772",
+					"172.27.0.1:49772",
+					"172.28.0.1:49772"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:11:27.232727782Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6899673838592495,
+				"StableID":   "n8q1JTjssv11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a939923c6709e023a453589020af9955f819688b31d22c523ea2ae11a4f54473",
+				"DiscoKey":   "discokey:0bba3699d6f26057022b54d80c5442f14d6663fb2046f8852e3117ae855f5e24",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48989",
+					"10.65.0.27:48989",
+					"172.17.0.1:48989",
+					"172.18.0.1:48989",
+					"172.19.0.1:48989",
+					"172.20.0.1:48989",
+					"172.21.0.1:48989",
+					"172.22.0.1:48989",
+					"172.23.0.1:48989",
+					"172.24.0.1:48989",
+					"172.25.0.1:48989",
+					"172.26.0.1:48989",
+					"172.27.0.1:48989",
+					"172.28.0.1:48989"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:11:27.923232747Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1471710141868880,
+				"StableID":   "nmFwb8LYVC11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2298aed6a48ed64120efa52f711067dc887fbb9c78bc864a282ae81a41e96732",
+				"DiscoKey":   "discokey:6b899c9ec15deaac0adeb76364629ef96084f446898f033bc5bdf42c3c893012",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46576",
+					"10.65.0.27:46576",
+					"172.17.0.1:46576",
+					"172.18.0.1:46576",
+					"172.19.0.1:46576",
+					"172.20.0.1:46576",
+					"172.21.0.1:46576",
+					"172.22.0.1:46576",
+					"172.23.0.1:46576",
+					"172.24.0.1:46576",
+					"172.25.0.1:46576",
+					"172.26.0.1:46576",
+					"172.27.0.1:46576",
+					"172.28.0.1:46576"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:11:28.449863702Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7940710577154745,
+				"StableID":   "nA51271N1521CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:426acaea24fe205eeb09b4bcd6cfef17b807be74987d174da3507fa777b43b39",
+				"DiscoKey":   "discokey:079b1c7162b2484e86d4e530566fa84bd0aea1363341d869c93650c47ad91669",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51637",
+					"10.65.0.27:51637",
+					"172.17.0.1:51637",
+					"172.18.0.1:51637",
+					"172.19.0.1:51637",
+					"172.20.0.1:51637",
+					"172.21.0.1:51637",
+					"172.22.0.1:51637",
+					"172.23.0.1:51637",
+					"172.24.0.1:51637",
+					"172.25.0.1:51637",
+					"172.26.0.1:51637",
+					"172.27.0.1:51637",
+					"172.28.0.1:51637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:11:28.980992142Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6660706170020454,
+				"StableID":   "nouDjUTe1u11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:824d25b0ed9a20d2e5e73a97fd435be5e132f908935ff995c2856eda964e602e",
+				"DiscoKey":   "discokey:4944a073658a867807dcaaa0bcc54aa9d2985cefc75903f887aabb9d76890401",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49396",
+					"10.65.0.27:49396",
+					"172.17.0.1:49396",
+					"172.18.0.1:49396",
+					"172.19.0.1:49396",
+					"172.20.0.1:49396",
+					"172.21.0.1:49396",
+					"172.22.0.1:49396",
+					"172.23.0.1:49396",
+					"172.24.0.1:49396",
+					"172.25.0.1:49396",
+					"172.26.0.1:49396",
+					"172.27.0.1:49396",
+					"172.28.0.1:49396"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:11:29.514432602Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5873399707930875,
+				"StableID":   "nkuHgYF5sn11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc6f5a3a207f5c39ed962d0781cb807109ba7dea69a8d53d7aad93625fb7af7f",
+				"DiscoKey":   "discokey:74f2b63be50beb5872dd750c982af92e8f812a0045f04428b41a7be72219673e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:55933",
+					"10.65.0.27:55933",
+					"172.17.0.1:55933",
+					"172.18.0.1:55933",
+					"172.19.0.1:55933",
+					"172.20.0.1:55933",
+					"172.21.0.1:55933",
+					"172.22.0.1:55933",
+					"172.23.0.1:55933",
+					"172.24.0.1:55933",
+					"172.25.0.1:55933",
+					"172.26.0.1:55933",
+					"172.27.0.1:55933",
+					"172.28.0.1:55933"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:11:30.054301025Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4656389653246852,
+				"StableID":   "n1wobhTtMd11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab21ee6bc3991d19001955bdc61e9cf0a700cff60d9dfafc40f3b4b7e0014e6b",
+				"DiscoKey":   "discokey:a4ace807754e1f8f1bc5d7401a012f47722344950a7d4382f35763bc80635527",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49126",
+					"10.65.0.27:49126",
+					"172.17.0.1:49126",
+					"172.18.0.1:49126",
+					"172.19.0.1:49126",
+					"172.20.0.1:49126",
+					"172.21.0.1:49126",
+					"172.22.0.1:49126",
+					"172.23.0.1:49126",
+					"172.24.0.1:49126",
+					"172.25.0.1:49126",
+					"172.26.0.1:49126",
+					"172.27.0.1:49126",
+					"172.28.0.1:49126"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:11:30.590573831Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5001212125978712,
+				"StableID":   "n3a8jzM44g11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec03bcd34d887fac2f5806d20af78c18471da65ced6cb98a8fb8d998bcb75d7c",
+				"DiscoKey":   "discokey:26a6b3741cf31a22ad599c14d9ecf96b17c12f32eb12f421aff04a7d2cb9cf0e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:43845",
+					"10.65.0.27:43845",
+					"172.17.0.1:43845",
+					"172.18.0.1:43845",
+					"172.19.0.1:43845",
+					"172.20.0.1:43845",
+					"172.21.0.1:43845",
+					"172.22.0.1:43845",
+					"172.23.0.1:43845",
+					"172.24.0.1:43845",
+					"172.25.0.1:43845",
+					"172.26.0.1:43845",
+					"172.27.0.1:43845",
+					"172.28.0.1:43845"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:11:31.127153854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2192643219519776,
+				"StableID":   "n9dPx7248J11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af6c197aeeb2e8861e26d078ca62f84d392098e251a67c90bea1b4be6481f54a",
+				"DiscoKey":   "discokey:7532d187e881aa70abce6c4c7bdd356aa424d83c5ffaafb82e58253c89e68f36",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53872",
+					"10.65.0.27:53872",
+					"172.17.0.1:53872",
+					"172.18.0.1:53872",
+					"172.19.0.1:53872",
+					"172.20.0.1:53872",
+					"172.21.0.1:53872",
+					"172.22.0.1:53872",
+					"172.23.0.1:53872",
+					"172.24.0.1:53872",
+					"172.25.0.1:53872",
+					"172.26.0.1:53872",
+					"172.27.0.1:53872",
+					"172.28.0.1:53872"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:11:32.210491783Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6622337448797789,
+				"StableID":   "nxapDNaGit11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dbe12d6b4c2392dca0667ad6893de8f72f4131b6f591707f4dd34780dc741826",
+				"DiscoKey":   "discokey:b9fd436af9d9e5ff2f9eaedee7859d1df32bd38fecd5ee974dccc85159f08f67",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:46146",
+					"10.65.0.27:46146",
+					"172.17.0.1:46146",
+					"172.18.0.1:46146",
+					"172.19.0.1:46146",
+					"172.20.0.1:46146",
+					"172.21.0.1:46146",
+					"172.22.0.1:46146",
+					"172.23.0.1:46146",
+					"172.24.0.1:46146",
+					"172.25.0.1:46146",
+					"172.26.0.1:46146",
+					"172.27.0.1:46146",
+					"172.28.0.1:46146"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:11:32.736529232Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7856278415543673,
+				"StableID":   "nLSA2W78M421CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7cadaeda40fba18caa1a95233b305c0775f9af6fb6dd5d177177e5035c391f18",
+				"DiscoKey":   "discokey:0e27b0982812192999a486818efd2b538c068e2d6e126f1e64274a747ee2076c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56971",
+					"10.65.0.27:56971",
+					"172.17.0.1:56971",
+					"172.18.0.1:56971",
+					"172.19.0.1:56971",
+					"172.20.0.1:56971",
+					"172.21.0.1:56971",
+					"172.22.0.1:56971",
+					"172.23.0.1:56971",
+					"172.24.0.1:56971",
+					"172.25.0.1:56971",
+					"172.26.0.1:56971",
+					"172.27.0.1:56971",
+					"172.28.0.1:56971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:11:33.269378521Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3275348019449656,
+				"StableID":   "nD1SadqQaS11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e5231c42fd704c10efbcb05513f8da10f5c9075a07e35f01e68e8fed1f197303",
+				"KeyExpiry":  "2026-11-09T09:11:33Z",
+				"DiscoKey":   "discokey:366f52ee691c4951951fa6e77637baf9df2af6d4a55a58a337c203504528a558",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51315",
+					"10.65.0.27:51315",
+					"172.17.0.1:51315",
+					"172.18.0.1:51315",
+					"172.19.0.1:51315",
+					"172.20.0.1:51315",
+					"172.21.0.1:51315",
+					"172.22.0.1:51315",
+					"172.23.0.1:51315",
+					"172.24.0.1:51315",
+					"172.25.0.1:51315",
+					"172.26.0.1:51315",
+					"172.27.0.1:51315",
+					"172.28.0.1:51315"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:11:33.803521751Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4381600078349493,
+				"StableID":   "nEyfqqCSDb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ffa0f8aa48637ca141b05817dbf6a0d45e92a0147c93d303a0aaf6f0dd08100b",
+				"KeyExpiry":  "2026-11-09T09:11:34Z",
+				"DiscoKey":   "discokey:d87c169006961b0a3995a127a1b8792f58a8de44be722aeaed40c2214798ea38",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54975",
+					"10.65.0.27:54975",
+					"172.17.0.1:54975",
+					"172.18.0.1:54975",
+					"172.19.0.1:54975",
+					"172.20.0.1:54975",
+					"172.21.0.1:54975",
+					"172.22.0.1:54975",
+					"172.23.0.1:54975",
+					"172.24.0.1:54975",
+					"172.25.0.1:54975",
+					"172.26.0.1:54975",
+					"172.27.0.1:54975",
+					"172.28.0.1:54975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:11:34.358798756Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1715639806292417,
+				"StableID":   "n6VUk1x1QE11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dca640dfeecac31a14fdc8ce04c12453b3e18022a60be8130b9b0b604bcc5512",
+				"KeyExpiry":  "2026-11-09T09:11:34Z",
+				"DiscoKey":   "discokey:f31f77fed26171b732ea2c186ed3ef41e799151469c17a4b33a851462ea9ff4b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57841",
+					"10.65.0.27:57841",
+					"172.17.0.1:57841",
+					"172.18.0.1:57841",
+					"172.19.0.1:57841",
+					"172.20.0.1:57841",
+					"172.21.0.1:57841",
+					"172.22.0.1:57841",
+					"172.23.0.1:57841",
+					"172.24.0.1:57841",
+					"172.25.0.1:57841",
+					"172.26.0.1:57841",
+					"172.27.0.1:57841",
+					"172.28.0.1:57841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:11:34.864857495Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8230806459247696": {
+				"ID":          8230806459247696,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4381600078349493,
+				"StableID":   "nEyfqqCSDb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ffa0f8aa48637ca141b05817dbf6a0d45e92a0147c93d303a0aaf6f0dd08100b",
+				"KeyExpiry":  "2026-11-09T09:11:34Z",
+				"DiscoKey":   "discokey:d87c169006961b0a3995a127a1b8792f58a8de44be722aeaed40c2214798ea38",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54975",
+					"10.65.0.27:54975",
+					"172.17.0.1:54975",
+					"172.18.0.1:54975",
+					"172.19.0.1:54975",
+					"172.20.0.1:54975",
+					"172.21.0.1:54975",
+					"172.22.0.1:54975",
+					"172.23.0.1:54975",
+					"172.24.0.1:54975",
+					"172.25.0.1:54975",
+					"172.26.0.1:54975",
+					"172.27.0.1:54975",
+					"172.28.0.1:54975"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:11:34.358798756Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ffa0f8aa48637ca141b05817dbf6a0d45e92a0147c93d303a0aaf6f0dd08100b",
+			"MachineKey": "mkey:f432ca6ec8f6dcd78b43d928f9899c3529c2e26c04ecba1b0dc732fc6e4eba19",
+			"Peers": [{
+				"ID":         4823921244737725,
+				"StableID":   "ntA1fQEmfe11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f068dde163d424c95e759f9278b627be1cf3f12b6aa7a50bb9604a80e82f097f",
+				"DiscoKey":   "discokey:6675d05fe875b8b93ac8f93688deee270c3b43e322406902e4ac1043fc06f03e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49772",
+					"10.65.0.27:49772",
+					"172.17.0.1:49772",
+					"172.18.0.1:49772",
+					"172.19.0.1:49772",
+					"172.20.0.1:49772",
+					"172.21.0.1:49772",
+					"172.22.0.1:49772",
+					"172.23.0.1:49772",
+					"172.24.0.1:49772",
+					"172.25.0.1:49772",
+					"172.26.0.1:49772",
+					"172.27.0.1:49772",
+					"172.28.0.1:49772"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:11:27.232727782Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6899673838592495,
+				"StableID":   "n8q1JTjssv11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a939923c6709e023a453589020af9955f819688b31d22c523ea2ae11a4f54473",
+				"DiscoKey":   "discokey:0bba3699d6f26057022b54d80c5442f14d6663fb2046f8852e3117ae855f5e24",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48989",
+					"10.65.0.27:48989",
+					"172.17.0.1:48989",
+					"172.18.0.1:48989",
+					"172.19.0.1:48989",
+					"172.20.0.1:48989",
+					"172.21.0.1:48989",
+					"172.22.0.1:48989",
+					"172.23.0.1:48989",
+					"172.24.0.1:48989",
+					"172.25.0.1:48989",
+					"172.26.0.1:48989",
+					"172.27.0.1:48989",
+					"172.28.0.1:48989"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:11:27.923232747Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1471710141868880,
+				"StableID":   "nmFwb8LYVC11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2298aed6a48ed64120efa52f711067dc887fbb9c78bc864a282ae81a41e96732",
+				"DiscoKey":   "discokey:6b899c9ec15deaac0adeb76364629ef96084f446898f033bc5bdf42c3c893012",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46576",
+					"10.65.0.27:46576",
+					"172.17.0.1:46576",
+					"172.18.0.1:46576",
+					"172.19.0.1:46576",
+					"172.20.0.1:46576",
+					"172.21.0.1:46576",
+					"172.22.0.1:46576",
+					"172.23.0.1:46576",
+					"172.24.0.1:46576",
+					"172.25.0.1:46576",
+					"172.26.0.1:46576",
+					"172.27.0.1:46576",
+					"172.28.0.1:46576"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:11:28.449863702Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7940710577154745,
+				"StableID":   "nA51271N1521CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:426acaea24fe205eeb09b4bcd6cfef17b807be74987d174da3507fa777b43b39",
+				"DiscoKey":   "discokey:079b1c7162b2484e86d4e530566fa84bd0aea1363341d869c93650c47ad91669",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51637",
+					"10.65.0.27:51637",
+					"172.17.0.1:51637",
+					"172.18.0.1:51637",
+					"172.19.0.1:51637",
+					"172.20.0.1:51637",
+					"172.21.0.1:51637",
+					"172.22.0.1:51637",
+					"172.23.0.1:51637",
+					"172.24.0.1:51637",
+					"172.25.0.1:51637",
+					"172.26.0.1:51637",
+					"172.27.0.1:51637",
+					"172.28.0.1:51637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:11:28.980992142Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6660706170020454,
+				"StableID":   "nouDjUTe1u11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:824d25b0ed9a20d2e5e73a97fd435be5e132f908935ff995c2856eda964e602e",
+				"DiscoKey":   "discokey:4944a073658a867807dcaaa0bcc54aa9d2985cefc75903f887aabb9d76890401",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49396",
+					"10.65.0.27:49396",
+					"172.17.0.1:49396",
+					"172.18.0.1:49396",
+					"172.19.0.1:49396",
+					"172.20.0.1:49396",
+					"172.21.0.1:49396",
+					"172.22.0.1:49396",
+					"172.23.0.1:49396",
+					"172.24.0.1:49396",
+					"172.25.0.1:49396",
+					"172.26.0.1:49396",
+					"172.27.0.1:49396",
+					"172.28.0.1:49396"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:11:29.514432602Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5873399707930875,
+				"StableID":   "nkuHgYF5sn11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc6f5a3a207f5c39ed962d0781cb807109ba7dea69a8d53d7aad93625fb7af7f",
+				"DiscoKey":   "discokey:74f2b63be50beb5872dd750c982af92e8f812a0045f04428b41a7be72219673e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:55933",
+					"10.65.0.27:55933",
+					"172.17.0.1:55933",
+					"172.18.0.1:55933",
+					"172.19.0.1:55933",
+					"172.20.0.1:55933",
+					"172.21.0.1:55933",
+					"172.22.0.1:55933",
+					"172.23.0.1:55933",
+					"172.24.0.1:55933",
+					"172.25.0.1:55933",
+					"172.26.0.1:55933",
+					"172.27.0.1:55933",
+					"172.28.0.1:55933"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:11:30.054301025Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4656389653246852,
+				"StableID":   "n1wobhTtMd11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab21ee6bc3991d19001955bdc61e9cf0a700cff60d9dfafc40f3b4b7e0014e6b",
+				"DiscoKey":   "discokey:a4ace807754e1f8f1bc5d7401a012f47722344950a7d4382f35763bc80635527",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49126",
+					"10.65.0.27:49126",
+					"172.17.0.1:49126",
+					"172.18.0.1:49126",
+					"172.19.0.1:49126",
+					"172.20.0.1:49126",
+					"172.21.0.1:49126",
+					"172.22.0.1:49126",
+					"172.23.0.1:49126",
+					"172.24.0.1:49126",
+					"172.25.0.1:49126",
+					"172.26.0.1:49126",
+					"172.27.0.1:49126",
+					"172.28.0.1:49126"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:11:30.590573831Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5001212125978712,
+				"StableID":   "n3a8jzM44g11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec03bcd34d887fac2f5806d20af78c18471da65ced6cb98a8fb8d998bcb75d7c",
+				"DiscoKey":   "discokey:26a6b3741cf31a22ad599c14d9ecf96b17c12f32eb12f421aff04a7d2cb9cf0e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:43845",
+					"10.65.0.27:43845",
+					"172.17.0.1:43845",
+					"172.18.0.1:43845",
+					"172.19.0.1:43845",
+					"172.20.0.1:43845",
+					"172.21.0.1:43845",
+					"172.22.0.1:43845",
+					"172.23.0.1:43845",
+					"172.24.0.1:43845",
+					"172.25.0.1:43845",
+					"172.26.0.1:43845",
+					"172.27.0.1:43845",
+					"172.28.0.1:43845"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:11:31.127153854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8230806459247696,
+				"StableID":   "noYQj4LkG721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:98c9889cf909a88aa69a7a805f56567152d341d8ead559c7c43a918bbc6c4550",
+				"DiscoKey":   "discokey:d8b6802b5f0f2ae9e55751ff60079767a9eb2eea4eb8a6892957efc63308fe19",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41417",
+					"10.65.0.27:41417",
+					"172.17.0.1:41417",
+					"172.18.0.1:41417",
+					"172.19.0.1:41417",
+					"172.20.0.1:41417",
+					"172.21.0.1:41417",
+					"172.22.0.1:41417",
+					"172.23.0.1:41417",
+					"172.24.0.1:41417",
+					"172.25.0.1:41417",
+					"172.26.0.1:41417",
+					"172.27.0.1:41417",
+					"172.28.0.1:41417"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:11:31.681478377Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2192643219519776,
+				"StableID":   "n9dPx7248J11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af6c197aeeb2e8861e26d078ca62f84d392098e251a67c90bea1b4be6481f54a",
+				"DiscoKey":   "discokey:7532d187e881aa70abce6c4c7bdd356aa424d83c5ffaafb82e58253c89e68f36",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53872",
+					"10.65.0.27:53872",
+					"172.17.0.1:53872",
+					"172.18.0.1:53872",
+					"172.19.0.1:53872",
+					"172.20.0.1:53872",
+					"172.21.0.1:53872",
+					"172.22.0.1:53872",
+					"172.23.0.1:53872",
+					"172.24.0.1:53872",
+					"172.25.0.1:53872",
+					"172.26.0.1:53872",
+					"172.27.0.1:53872",
+					"172.28.0.1:53872"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:11:32.210491783Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6622337448797789,
+				"StableID":   "nxapDNaGit11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dbe12d6b4c2392dca0667ad6893de8f72f4131b6f591707f4dd34780dc741826",
+				"DiscoKey":   "discokey:b9fd436af9d9e5ff2f9eaedee7859d1df32bd38fecd5ee974dccc85159f08f67",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:46146",
+					"10.65.0.27:46146",
+					"172.17.0.1:46146",
+					"172.18.0.1:46146",
+					"172.19.0.1:46146",
+					"172.20.0.1:46146",
+					"172.21.0.1:46146",
+					"172.22.0.1:46146",
+					"172.23.0.1:46146",
+					"172.24.0.1:46146",
+					"172.25.0.1:46146",
+					"172.26.0.1:46146",
+					"172.27.0.1:46146",
+					"172.28.0.1:46146"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:11:32.736529232Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7856278415543673,
+				"StableID":   "nLSA2W78M421CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7cadaeda40fba18caa1a95233b305c0775f9af6fb6dd5d177177e5035c391f18",
+				"DiscoKey":   "discokey:0e27b0982812192999a486818efd2b538c068e2d6e126f1e64274a747ee2076c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56971",
+					"10.65.0.27:56971",
+					"172.17.0.1:56971",
+					"172.18.0.1:56971",
+					"172.19.0.1:56971",
+					"172.20.0.1:56971",
+					"172.21.0.1:56971",
+					"172.22.0.1:56971",
+					"172.23.0.1:56971",
+					"172.24.0.1:56971",
+					"172.25.0.1:56971",
+					"172.26.0.1:56971",
+					"172.27.0.1:56971",
+					"172.28.0.1:56971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:11:33.269378521Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3275348019449656,
+				"StableID":   "nD1SadqQaS11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e5231c42fd704c10efbcb05513f8da10f5c9075a07e35f01e68e8fed1f197303",
+				"KeyExpiry":  "2026-11-09T09:11:33Z",
+				"DiscoKey":   "discokey:366f52ee691c4951951fa6e77637baf9df2af6d4a55a58a337c203504528a558",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51315",
+					"10.65.0.27:51315",
+					"172.17.0.1:51315",
+					"172.18.0.1:51315",
+					"172.19.0.1:51315",
+					"172.20.0.1:51315",
+					"172.21.0.1:51315",
+					"172.22.0.1:51315",
+					"172.23.0.1:51315",
+					"172.24.0.1:51315",
+					"172.25.0.1:51315",
+					"172.26.0.1:51315",
+					"172.27.0.1:51315",
+					"172.28.0.1:51315"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:11:33.803521751Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1715639806292417,
+				"StableID":   "n6VUk1x1QE11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dca640dfeecac31a14fdc8ce04c12453b3e18022a60be8130b9b0b604bcc5512",
+				"KeyExpiry":  "2026-11-09T09:11:34Z",
+				"DiscoKey":   "discokey:f31f77fed26171b732ea2c186ed3ef41e799151469c17a4b33a851462ea9ff4b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57841",
+					"10.65.0.27:57841",
+					"172.17.0.1:57841",
+					"172.18.0.1:57841",
+					"172.19.0.1:57841",
+					"172.20.0.1:57841",
+					"172.21.0.1:57841",
+					"172.22.0.1:57841",
+					"172.23.0.1:57841",
+					"172.24.0.1:57841",
+					"172.25.0.1:57841",
+					"172.26.0.1:57841",
+					"172.27.0.1:57841",
+					"172.28.0.1:57841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:11:34.864857495Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2192643219519776,
+				"StableID":   "n9dPx7248J11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       2192643219519776,
+				"Key":        "nodekey:af6c197aeeb2e8861e26d078ca62f84d392098e251a67c90bea1b4be6481f54a",
+				"DiscoKey":   "discokey:7532d187e881aa70abce6c4c7bdd356aa424d83c5ffaafb82e58253c89e68f36",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53872",
+					"10.65.0.27:53872",
+					"172.17.0.1:53872",
+					"172.18.0.1:53872",
+					"172.19.0.1:53872",
+					"172.20.0.1:53872",
+					"172.21.0.1:53872",
+					"172.22.0.1:53872",
+					"172.23.0.1:53872",
+					"172.24.0.1:53872",
+					"172.25.0.1:53872",
+					"172.26.0.1:53872",
+					"172.27.0.1:53872",
+					"172.28.0.1:53872"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:11:32.210491783Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:af6c197aeeb2e8861e26d078ca62f84d392098e251a67c90bea1b4be6481f54a",
+			"MachineKey": "mkey:be2caac3d7ddebdacc24b610e78b6fcfac43e948a94c0da43df44e09d68c6d00",
+			"Peers": [{
+				"ID":         4823921244737725,
+				"StableID":   "ntA1fQEmfe11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f068dde163d424c95e759f9278b627be1cf3f12b6aa7a50bb9604a80e82f097f",
+				"DiscoKey":   "discokey:6675d05fe875b8b93ac8f93688deee270c3b43e322406902e4ac1043fc06f03e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49772",
+					"10.65.0.27:49772",
+					"172.17.0.1:49772",
+					"172.18.0.1:49772",
+					"172.19.0.1:49772",
+					"172.20.0.1:49772",
+					"172.21.0.1:49772",
+					"172.22.0.1:49772",
+					"172.23.0.1:49772",
+					"172.24.0.1:49772",
+					"172.25.0.1:49772",
+					"172.26.0.1:49772",
+					"172.27.0.1:49772",
+					"172.28.0.1:49772"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:11:27.232727782Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6899673838592495,
+				"StableID":   "n8q1JTjssv11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a939923c6709e023a453589020af9955f819688b31d22c523ea2ae11a4f54473",
+				"DiscoKey":   "discokey:0bba3699d6f26057022b54d80c5442f14d6663fb2046f8852e3117ae855f5e24",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48989",
+					"10.65.0.27:48989",
+					"172.17.0.1:48989",
+					"172.18.0.1:48989",
+					"172.19.0.1:48989",
+					"172.20.0.1:48989",
+					"172.21.0.1:48989",
+					"172.22.0.1:48989",
+					"172.23.0.1:48989",
+					"172.24.0.1:48989",
+					"172.25.0.1:48989",
+					"172.26.0.1:48989",
+					"172.27.0.1:48989",
+					"172.28.0.1:48989"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:11:27.923232747Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1471710141868880,
+				"StableID":   "nmFwb8LYVC11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2298aed6a48ed64120efa52f711067dc887fbb9c78bc864a282ae81a41e96732",
+				"DiscoKey":   "discokey:6b899c9ec15deaac0adeb76364629ef96084f446898f033bc5bdf42c3c893012",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46576",
+					"10.65.0.27:46576",
+					"172.17.0.1:46576",
+					"172.18.0.1:46576",
+					"172.19.0.1:46576",
+					"172.20.0.1:46576",
+					"172.21.0.1:46576",
+					"172.22.0.1:46576",
+					"172.23.0.1:46576",
+					"172.24.0.1:46576",
+					"172.25.0.1:46576",
+					"172.26.0.1:46576",
+					"172.27.0.1:46576",
+					"172.28.0.1:46576"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:11:28.449863702Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7940710577154745,
+				"StableID":   "nA51271N1521CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:426acaea24fe205eeb09b4bcd6cfef17b807be74987d174da3507fa777b43b39",
+				"DiscoKey":   "discokey:079b1c7162b2484e86d4e530566fa84bd0aea1363341d869c93650c47ad91669",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51637",
+					"10.65.0.27:51637",
+					"172.17.0.1:51637",
+					"172.18.0.1:51637",
+					"172.19.0.1:51637",
+					"172.20.0.1:51637",
+					"172.21.0.1:51637",
+					"172.22.0.1:51637",
+					"172.23.0.1:51637",
+					"172.24.0.1:51637",
+					"172.25.0.1:51637",
+					"172.26.0.1:51637",
+					"172.27.0.1:51637",
+					"172.28.0.1:51637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:11:28.980992142Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6660706170020454,
+				"StableID":   "nouDjUTe1u11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:824d25b0ed9a20d2e5e73a97fd435be5e132f908935ff995c2856eda964e602e",
+				"DiscoKey":   "discokey:4944a073658a867807dcaaa0bcc54aa9d2985cefc75903f887aabb9d76890401",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49396",
+					"10.65.0.27:49396",
+					"172.17.0.1:49396",
+					"172.18.0.1:49396",
+					"172.19.0.1:49396",
+					"172.20.0.1:49396",
+					"172.21.0.1:49396",
+					"172.22.0.1:49396",
+					"172.23.0.1:49396",
+					"172.24.0.1:49396",
+					"172.25.0.1:49396",
+					"172.26.0.1:49396",
+					"172.27.0.1:49396",
+					"172.28.0.1:49396"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:11:29.514432602Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5873399707930875,
+				"StableID":   "nkuHgYF5sn11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc6f5a3a207f5c39ed962d0781cb807109ba7dea69a8d53d7aad93625fb7af7f",
+				"DiscoKey":   "discokey:74f2b63be50beb5872dd750c982af92e8f812a0045f04428b41a7be72219673e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:55933",
+					"10.65.0.27:55933",
+					"172.17.0.1:55933",
+					"172.18.0.1:55933",
+					"172.19.0.1:55933",
+					"172.20.0.1:55933",
+					"172.21.0.1:55933",
+					"172.22.0.1:55933",
+					"172.23.0.1:55933",
+					"172.24.0.1:55933",
+					"172.25.0.1:55933",
+					"172.26.0.1:55933",
+					"172.27.0.1:55933",
+					"172.28.0.1:55933"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:11:30.054301025Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4656389653246852,
+				"StableID":   "n1wobhTtMd11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab21ee6bc3991d19001955bdc61e9cf0a700cff60d9dfafc40f3b4b7e0014e6b",
+				"DiscoKey":   "discokey:a4ace807754e1f8f1bc5d7401a012f47722344950a7d4382f35763bc80635527",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49126",
+					"10.65.0.27:49126",
+					"172.17.0.1:49126",
+					"172.18.0.1:49126",
+					"172.19.0.1:49126",
+					"172.20.0.1:49126",
+					"172.21.0.1:49126",
+					"172.22.0.1:49126",
+					"172.23.0.1:49126",
+					"172.24.0.1:49126",
+					"172.25.0.1:49126",
+					"172.26.0.1:49126",
+					"172.27.0.1:49126",
+					"172.28.0.1:49126"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:11:30.590573831Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5001212125978712,
+				"StableID":   "n3a8jzM44g11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec03bcd34d887fac2f5806d20af78c18471da65ced6cb98a8fb8d998bcb75d7c",
+				"DiscoKey":   "discokey:26a6b3741cf31a22ad599c14d9ecf96b17c12f32eb12f421aff04a7d2cb9cf0e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:43845",
+					"10.65.0.27:43845",
+					"172.17.0.1:43845",
+					"172.18.0.1:43845",
+					"172.19.0.1:43845",
+					"172.20.0.1:43845",
+					"172.21.0.1:43845",
+					"172.22.0.1:43845",
+					"172.23.0.1:43845",
+					"172.24.0.1:43845",
+					"172.25.0.1:43845",
+					"172.26.0.1:43845",
+					"172.27.0.1:43845",
+					"172.28.0.1:43845"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:11:31.127153854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8230806459247696,
+				"StableID":   "noYQj4LkG721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:98c9889cf909a88aa69a7a805f56567152d341d8ead559c7c43a918bbc6c4550",
+				"DiscoKey":   "discokey:d8b6802b5f0f2ae9e55751ff60079767a9eb2eea4eb8a6892957efc63308fe19",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41417",
+					"10.65.0.27:41417",
+					"172.17.0.1:41417",
+					"172.18.0.1:41417",
+					"172.19.0.1:41417",
+					"172.20.0.1:41417",
+					"172.21.0.1:41417",
+					"172.22.0.1:41417",
+					"172.23.0.1:41417",
+					"172.24.0.1:41417",
+					"172.25.0.1:41417",
+					"172.26.0.1:41417",
+					"172.27.0.1:41417",
+					"172.28.0.1:41417"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:11:31.681478377Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6622337448797789,
+				"StableID":   "nxapDNaGit11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dbe12d6b4c2392dca0667ad6893de8f72f4131b6f591707f4dd34780dc741826",
+				"DiscoKey":   "discokey:b9fd436af9d9e5ff2f9eaedee7859d1df32bd38fecd5ee974dccc85159f08f67",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:46146",
+					"10.65.0.27:46146",
+					"172.17.0.1:46146",
+					"172.18.0.1:46146",
+					"172.19.0.1:46146",
+					"172.20.0.1:46146",
+					"172.21.0.1:46146",
+					"172.22.0.1:46146",
+					"172.23.0.1:46146",
+					"172.24.0.1:46146",
+					"172.25.0.1:46146",
+					"172.26.0.1:46146",
+					"172.27.0.1:46146",
+					"172.28.0.1:46146"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:11:32.736529232Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7856278415543673,
+				"StableID":   "nLSA2W78M421CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7cadaeda40fba18caa1a95233b305c0775f9af6fb6dd5d177177e5035c391f18",
+				"DiscoKey":   "discokey:0e27b0982812192999a486818efd2b538c068e2d6e126f1e64274a747ee2076c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56971",
+					"10.65.0.27:56971",
+					"172.17.0.1:56971",
+					"172.18.0.1:56971",
+					"172.19.0.1:56971",
+					"172.20.0.1:56971",
+					"172.21.0.1:56971",
+					"172.22.0.1:56971",
+					"172.23.0.1:56971",
+					"172.24.0.1:56971",
+					"172.25.0.1:56971",
+					"172.26.0.1:56971",
+					"172.27.0.1:56971",
+					"172.28.0.1:56971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:11:33.269378521Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3275348019449656,
+				"StableID":   "nD1SadqQaS11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e5231c42fd704c10efbcb05513f8da10f5c9075a07e35f01e68e8fed1f197303",
+				"KeyExpiry":  "2026-11-09T09:11:33Z",
+				"DiscoKey":   "discokey:366f52ee691c4951951fa6e77637baf9df2af6d4a55a58a337c203504528a558",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51315",
+					"10.65.0.27:51315",
+					"172.17.0.1:51315",
+					"172.18.0.1:51315",
+					"172.19.0.1:51315",
+					"172.20.0.1:51315",
+					"172.21.0.1:51315",
+					"172.22.0.1:51315",
+					"172.23.0.1:51315",
+					"172.24.0.1:51315",
+					"172.25.0.1:51315",
+					"172.26.0.1:51315",
+					"172.27.0.1:51315",
+					"172.28.0.1:51315"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:11:33.803521751Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4381600078349493,
+				"StableID":   "nEyfqqCSDb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ffa0f8aa48637ca141b05817dbf6a0d45e92a0147c93d303a0aaf6f0dd08100b",
+				"KeyExpiry":  "2026-11-09T09:11:34Z",
+				"DiscoKey":   "discokey:d87c169006961b0a3995a127a1b8792f58a8de44be722aeaed40c2214798ea38",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54975",
+					"10.65.0.27:54975",
+					"172.17.0.1:54975",
+					"172.18.0.1:54975",
+					"172.19.0.1:54975",
+					"172.20.0.1:54975",
+					"172.21.0.1:54975",
+					"172.22.0.1:54975",
+					"172.23.0.1:54975",
+					"172.24.0.1:54975",
+					"172.25.0.1:54975",
+					"172.26.0.1:54975",
+					"172.27.0.1:54975",
+					"172.28.0.1:54975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:11:34.358798756Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1715639806292417,
+				"StableID":   "n6VUk1x1QE11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dca640dfeecac31a14fdc8ce04c12453b3e18022a60be8130b9b0b604bcc5512",
+				"KeyExpiry":  "2026-11-09T09:11:34Z",
+				"DiscoKey":   "discokey:f31f77fed26171b732ea2c186ed3ef41e799151469c17a4b33a851462ea9ff4b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57841",
+					"10.65.0.27:57841",
+					"172.17.0.1:57841",
+					"172.18.0.1:57841",
+					"172.19.0.1:57841",
+					"172.20.0.1:57841",
+					"172.21.0.1:57841",
+					"172.22.0.1:57841",
+					"172.23.0.1:57841",
+					"172.24.0.1:57841",
+					"172.25.0.1:57841",
+					"172.26.0.1:57841",
+					"172.27.0.1:57841",
+					"172.28.0.1:57841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:11:34.864857495Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2192643219519776": {
+				"ID":          2192643219519776,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-group-nested-two-deep.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-group-nested-two-deep.hujson
@@ -1,0 +1,22109 @@
+// ssh-group-nested-two-deep
+//
+// ssh group:outer -> group:inner -> user
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-13T09:12:10Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-group-nested-two-deep",
+	"description":    "ssh group:outer -> group:inner -> user",
+	"category":       "ssh",
+	"captured_at":    "2026-05-13T09:12:10.872213412Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {
+			"message": "groups[\"group:outer\"]: \"group:inner\": group members cannot be recursive"
+		},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                            \n  \n                                                                         \n                                                      \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh group:outer -> group:inner -> user\",\n\t\"id\":          \"ssh-group-nested-two-deep\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"groups\": {\n\t\t\"group:inner\": [\"thor@example.org\"],\n\t\t\"group:outer\": [\"group:inner\"]\n\t}, \"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"group:outer\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-edges/ssh-group-nested-two-deep.hujson",
+		"full_policy": {
+			"groups": {"group:inner": ["thor@example.org"], "group:outer": ["group:inner"]},
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["group:outer"],
+				"users":  ["root"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         239431495141524,
+				"StableID":   "n1ZCLeTSs211CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       239431495141524,
+				"Key":        "nodekey:ac0dfaa903776a1252993dfedec0484f42538f85c55ffeaf608ab0ca7f21ad16",
+				"DiscoKey":   "discokey:5a1bf7676693f704282e50e85fbb55c89a73057d1db81615ae09c7d8f78b7374",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48599",
+					"10.65.0.27:48599",
+					"172.17.0.1:48599",
+					"172.18.0.1:48599",
+					"172.19.0.1:48599",
+					"172.20.0.1:48599",
+					"172.21.0.1:48599",
+					"172.22.0.1:48599",
+					"172.23.0.1:48599",
+					"172.24.0.1:48599",
+					"172.25.0.1:48599",
+					"172.26.0.1:48599",
+					"172.27.0.1:48599",
+					"172.28.0.1:48599"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:12:19.36713742Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ac0dfaa903776a1252993dfedec0484f42538f85c55ffeaf608ab0ca7f21ad16",
+			"MachineKey": "mkey:f81bb7b4dcca0f76703d496c08328a11f045fc63bc9dd9aea4495e68dc4fd943",
+			"Peers": [{
+				"ID":         6295043190505720,
+				"StableID":   "nR5BPP73Ar11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65bc1919c2b0271b65099b25733e8e937c9c25dcef10a78bf1439dfde8dc7c10",
+				"DiscoKey":   "discokey:b428fa4819b6410ef2c55a0589b735f3f8afdba37349adcf02b92510a3fa7e6b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51096",
+					"10.65.0.27:51096",
+					"172.17.0.1:51096",
+					"172.18.0.1:51096",
+					"172.19.0.1:51096",
+					"172.20.0.1:51096",
+					"172.21.0.1:51096",
+					"172.22.0.1:51096",
+					"172.23.0.1:51096",
+					"172.24.0.1:51096",
+					"172.25.0.1:51096",
+					"172.26.0.1:51096",
+					"172.27.0.1:51096",
+					"172.28.0.1:51096"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:12:13.451963393Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1136127687261480,
+				"StableID":   "n1djEa9Zs911CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15c02f336a07c3ec0f1030c2c1c7f2e719ee6ea39579baa726d63dbd618cfc33",
+				"DiscoKey":   "discokey:5b64b686e272e958d2761ad35f7504aea2e767c49e482ead424839639b891274",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43492",
+					"10.65.0.27:43492",
+					"172.17.0.1:43492",
+					"172.18.0.1:43492",
+					"172.19.0.1:43492",
+					"172.20.0.1:43492",
+					"172.21.0.1:43492",
+					"172.22.0.1:43492",
+					"172.23.0.1:43492",
+					"172.24.0.1:43492",
+					"172.25.0.1:43492",
+					"172.26.0.1:43492",
+					"172.27.0.1:43492",
+					"172.28.0.1:43492"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:12:13.959144721Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2547803460419977,
+				"StableID":   "nxGkFeUutL11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8343057cdbc9fd2178bc789bf1e86259d1747812264a6433e43bb5429efca076",
+				"DiscoKey":   "discokey:e47e67ee170c98bf4cd4c6affc8a7b721a9d07dc27a2dbcc02558d712482f42e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34838",
+					"10.65.0.27:34838",
+					"172.17.0.1:34838",
+					"172.18.0.1:34838",
+					"172.19.0.1:34838",
+					"172.20.0.1:34838",
+					"172.21.0.1:34838",
+					"172.22.0.1:34838",
+					"172.23.0.1:34838",
+					"172.24.0.1:34838",
+					"172.25.0.1:34838",
+					"172.26.0.1:34838",
+					"172.27.0.1:34838",
+					"172.28.0.1:34838"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:12:14.499294893Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7449375176885547,
+				"StableID":   "npKHCLTqA121CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6519d9431c7294cc474e2e8fc38bc615114d4e1c499aaf8aeaebdebb56650756",
+				"DiscoKey":   "discokey:956784a0e52ed592bf42657dc900851fba54255903d4e0b6c4899e224311d62a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39201",
+					"10.65.0.27:39201",
+					"172.17.0.1:39201",
+					"172.18.0.1:39201",
+					"172.19.0.1:39201",
+					"172.20.0.1:39201",
+					"172.21.0.1:39201",
+					"172.22.0.1:39201",
+					"172.23.0.1:39201",
+					"172.24.0.1:39201",
+					"172.25.0.1:39201",
+					"172.26.0.1:39201",
+					"172.27.0.1:39201",
+					"172.28.0.1:39201"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:12:15.047991044Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1896790269306614,
+				"StableID":   "nTF3ruT4pF11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb460ef87abc28392030ffaed9a90acb13d737f7d4e2afd3c5cf30c9d8d6ce25",
+				"DiscoKey":   "discokey:a34c729de869d75828aeecc4024dc1476a2472e95393add1da74cb4e1dcbd649",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49922",
+					"10.65.0.27:49922",
+					"172.17.0.1:49922",
+					"172.18.0.1:49922",
+					"172.19.0.1:49922",
+					"172.20.0.1:49922",
+					"172.21.0.1:49922",
+					"172.22.0.1:49922",
+					"172.23.0.1:49922",
+					"172.24.0.1:49922",
+					"172.25.0.1:49922",
+					"172.26.0.1:49922",
+					"172.27.0.1:49922",
+					"172.28.0.1:49922"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:12:15.612155909Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5441526217295054,
+				"StableID":   "nuL6CffUVj11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1412aa2d544b885ebfa6f5bf07d9916a2852336d6465b60a685669734b56c75a",
+				"DiscoKey":   "discokey:4c4cb78776a0e12809d426e51ce1b9d152283d9877ebc17356a54c531f75f90a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46088",
+					"10.65.0.27:46088",
+					"172.17.0.1:46088",
+					"172.18.0.1:46088",
+					"172.19.0.1:46088",
+					"172.20.0.1:46088",
+					"172.21.0.1:46088",
+					"172.22.0.1:46088",
+					"172.23.0.1:46088",
+					"172.24.0.1:46088",
+					"172.25.0.1:46088",
+					"172.26.0.1:46088",
+					"172.27.0.1:46088",
+					"172.28.0.1:46088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:12:16.125093181Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6714736858617273,
+				"StableID":   "ngpGfZk7Su11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c7911d74f6a95c41cfbdc25933cda62584b81a423180a178c93e514cfecd5c6e",
+				"DiscoKey":   "discokey:53a1da3164b465eaa28141e7748a014dc2882e2ac8a8ade0c10cc2e1b81f642b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38348",
+					"10.65.0.27:38348",
+					"172.17.0.1:38348",
+					"172.18.0.1:38348",
+					"172.19.0.1:38348",
+					"172.20.0.1:38348",
+					"172.21.0.1:38348",
+					"172.22.0.1:38348",
+					"172.23.0.1:38348",
+					"172.24.0.1:38348",
+					"172.25.0.1:38348",
+					"172.26.0.1:38348",
+					"172.27.0.1:38348",
+					"172.28.0.1:38348"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:12:16.680850142Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3993055006255034,
+				"StableID":   "nPK3LUnTBY11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4483129363b3efe9d6e7f77e2c419993f6c93ac46886e2c65d66be7897d9945",
+				"DiscoKey":   "discokey:7aab69b601d715623f7faecd298d9d9c3ca661e48ff8e687a8fb956ea2721d3d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45745",
+					"10.65.0.27:45745",
+					"172.17.0.1:45745",
+					"172.18.0.1:45745",
+					"172.19.0.1:45745",
+					"172.20.0.1:45745",
+					"172.21.0.1:45745",
+					"172.22.0.1:45745",
+					"172.23.0.1:45745",
+					"172.24.0.1:45745",
+					"172.25.0.1:45745",
+					"172.26.0.1:45745",
+					"172.27.0.1:45745",
+					"172.28.0.1:45745"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:12:17.232728467Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         499258226074813,
+				"StableID":   "nkeuogf7u411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86de751b04e98f3f3e24662d954552ab27100bc4007cbd9d7fce7909bc653646",
+				"DiscoKey":   "discokey:2258666515a6c49fd642bd18313e7cd8c18c6ad3d66117a208110ffcd32f4518",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46872",
+					"10.65.0.27:46872",
+					"172.17.0.1:46872",
+					"172.18.0.1:46872",
+					"172.19.0.1:46872",
+					"172.20.0.1:46872",
+					"172.21.0.1:46872",
+					"172.22.0.1:46872",
+					"172.23.0.1:46872",
+					"172.24.0.1:46872",
+					"172.25.0.1:46872",
+					"172.26.0.1:46872",
+					"172.27.0.1:46872",
+					"172.28.0.1:46872"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:12:17.767226823Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5612001404879938,
+				"StableID":   "n5zgk7mgpk11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e078662eee1d237d130ec3464b5c8f01d12d4909933a8e5130d78d5b5acf6c4c",
+				"DiscoKey":   "discokey:d6267a1368efc7c7bd14582560ce0318075e69fbfe4479f5039e584e0457fc25",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56980",
+					"10.65.0.27:56980",
+					"172.17.0.1:56980",
+					"172.18.0.1:56980",
+					"172.19.0.1:56980",
+					"172.20.0.1:56980",
+					"172.21.0.1:56980",
+					"172.22.0.1:56980",
+					"172.23.0.1:56980",
+					"172.24.0.1:56980",
+					"172.25.0.1:56980",
+					"172.26.0.1:56980",
+					"172.27.0.1:56980",
+					"172.28.0.1:56980"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:12:18.319591263Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4715059007190742,
+				"StableID":   "nVrFW5cTpd11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5c974ab3854ff917eff17a52db4bef59f55bbc38aff6c0ce67baa68ee66fe2b",
+				"DiscoKey":   "discokey:7179a468c9cf2ba6142561fddefcb48f77d50806b6f3357c1c366b009d14911a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42733",
+					"10.65.0.27:42733",
+					"172.17.0.1:42733",
+					"172.18.0.1:42733",
+					"172.19.0.1:42733",
+					"172.20.0.1:42733",
+					"172.21.0.1:42733",
+					"172.22.0.1:42733",
+					"172.23.0.1:42733",
+					"172.24.0.1:42733",
+					"172.25.0.1:42733",
+					"172.26.0.1:42733",
+					"172.27.0.1:42733",
+					"172.28.0.1:42733"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:12:18.808278656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6327755590799875,
+				"StableID":   "nncKBkQrQr11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5bc136530a7a3d8cd063e53488889156f0d776a1a568c506a4f535629ecaf814",
+				"KeyExpiry":  "2026-11-09T09:12:19Z",
+				"DiscoKey":   "discokey:804a065e484e011f2d8ee5627b209d7ddd6c9699e3f72744d5cfe887d2ed7857",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35110",
+					"10.65.0.27:35110",
+					"172.17.0.1:35110",
+					"172.18.0.1:35110",
+					"172.19.0.1:35110",
+					"172.20.0.1:35110",
+					"172.21.0.1:35110",
+					"172.22.0.1:35110",
+					"172.23.0.1:35110",
+					"172.24.0.1:35110",
+					"172.25.0.1:35110",
+					"172.26.0.1:35110",
+					"172.27.0.1:35110",
+					"172.28.0.1:35110"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:12:19.92157994Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         239211059311227,
+				"StableID":   "nG5xAofLs211CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:69a2e516bd0240aa24cb1aeeac3002b103f5b3b8b971f4a54b5977c4395a104f",
+				"KeyExpiry":  "2026-11-09T09:12:20Z",
+				"DiscoKey":   "discokey:b3678915cab02bc3cfde16542ab71daf35672432939d3e93a04c443f37f5295e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47307",
+					"10.65.0.27:47307",
+					"172.17.0.1:47307",
+					"172.18.0.1:47307",
+					"172.19.0.1:47307",
+					"172.20.0.1:47307",
+					"172.21.0.1:47307",
+					"172.22.0.1:47307",
+					"172.23.0.1:47307",
+					"172.24.0.1:47307",
+					"172.25.0.1:47307",
+					"172.26.0.1:47307",
+					"172.27.0.1:47307",
+					"172.28.0.1:47307"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:12:20.451669488Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         146478454007342,
+				"StableID":   "nVgYPxjL9211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dfcf396c81bf3904aef3622810e304cdd156b0d140bd2bc4ba1f4775d4dacb71",
+				"KeyExpiry":  "2026-11-09T09:12:21Z",
+				"DiscoKey":   "discokey:ed46f6e38c977c94ed2ebf24418b84a4637c8745555fca6bfb402082c6ef940a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36999",
+					"10.65.0.27:36999",
+					"172.17.0.1:36999",
+					"172.18.0.1:36999",
+					"172.19.0.1:36999",
+					"172.20.0.1:36999",
+					"172.21.0.1:36999",
+					"172.22.0.1:36999",
+					"172.23.0.1:36999",
+					"172.24.0.1:36999",
+					"172.25.0.1:36999",
+					"172.26.0.1:36999",
+					"172.27.0.1:36999",
+					"172.28.0.1:36999"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:12:21.006885452Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "239431495141524": {
+				"ID":          239431495141524,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5441526217295054,
+				"StableID":   "nuL6CffUVj11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       5441526217295054,
+				"Key":        "nodekey:1412aa2d544b885ebfa6f5bf07d9916a2852336d6465b60a685669734b56c75a",
+				"DiscoKey":   "discokey:4c4cb78776a0e12809d426e51ce1b9d152283d9877ebc17356a54c531f75f90a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46088",
+					"10.65.0.27:46088",
+					"172.17.0.1:46088",
+					"172.18.0.1:46088",
+					"172.19.0.1:46088",
+					"172.20.0.1:46088",
+					"172.21.0.1:46088",
+					"172.22.0.1:46088",
+					"172.23.0.1:46088",
+					"172.24.0.1:46088",
+					"172.25.0.1:46088",
+					"172.26.0.1:46088",
+					"172.27.0.1:46088",
+					"172.28.0.1:46088"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:12:16.125093181Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1412aa2d544b885ebfa6f5bf07d9916a2852336d6465b60a685669734b56c75a",
+			"MachineKey": "mkey:8dac96a3b7d35642f4c34668faa03f83aeda7ad595ee247b491fa9f606fac803",
+			"Peers": [{
+				"ID":         6295043190505720,
+				"StableID":   "nR5BPP73Ar11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65bc1919c2b0271b65099b25733e8e937c9c25dcef10a78bf1439dfde8dc7c10",
+				"DiscoKey":   "discokey:b428fa4819b6410ef2c55a0589b735f3f8afdba37349adcf02b92510a3fa7e6b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51096",
+					"10.65.0.27:51096",
+					"172.17.0.1:51096",
+					"172.18.0.1:51096",
+					"172.19.0.1:51096",
+					"172.20.0.1:51096",
+					"172.21.0.1:51096",
+					"172.22.0.1:51096",
+					"172.23.0.1:51096",
+					"172.24.0.1:51096",
+					"172.25.0.1:51096",
+					"172.26.0.1:51096",
+					"172.27.0.1:51096",
+					"172.28.0.1:51096"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:12:13.451963393Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1136127687261480,
+				"StableID":   "n1djEa9Zs911CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15c02f336a07c3ec0f1030c2c1c7f2e719ee6ea39579baa726d63dbd618cfc33",
+				"DiscoKey":   "discokey:5b64b686e272e958d2761ad35f7504aea2e767c49e482ead424839639b891274",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43492",
+					"10.65.0.27:43492",
+					"172.17.0.1:43492",
+					"172.18.0.1:43492",
+					"172.19.0.1:43492",
+					"172.20.0.1:43492",
+					"172.21.0.1:43492",
+					"172.22.0.1:43492",
+					"172.23.0.1:43492",
+					"172.24.0.1:43492",
+					"172.25.0.1:43492",
+					"172.26.0.1:43492",
+					"172.27.0.1:43492",
+					"172.28.0.1:43492"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:12:13.959144721Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2547803460419977,
+				"StableID":   "nxGkFeUutL11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8343057cdbc9fd2178bc789bf1e86259d1747812264a6433e43bb5429efca076",
+				"DiscoKey":   "discokey:e47e67ee170c98bf4cd4c6affc8a7b721a9d07dc27a2dbcc02558d712482f42e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34838",
+					"10.65.0.27:34838",
+					"172.17.0.1:34838",
+					"172.18.0.1:34838",
+					"172.19.0.1:34838",
+					"172.20.0.1:34838",
+					"172.21.0.1:34838",
+					"172.22.0.1:34838",
+					"172.23.0.1:34838",
+					"172.24.0.1:34838",
+					"172.25.0.1:34838",
+					"172.26.0.1:34838",
+					"172.27.0.1:34838",
+					"172.28.0.1:34838"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:12:14.499294893Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7449375176885547,
+				"StableID":   "npKHCLTqA121CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6519d9431c7294cc474e2e8fc38bc615114d4e1c499aaf8aeaebdebb56650756",
+				"DiscoKey":   "discokey:956784a0e52ed592bf42657dc900851fba54255903d4e0b6c4899e224311d62a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39201",
+					"10.65.0.27:39201",
+					"172.17.0.1:39201",
+					"172.18.0.1:39201",
+					"172.19.0.1:39201",
+					"172.20.0.1:39201",
+					"172.21.0.1:39201",
+					"172.22.0.1:39201",
+					"172.23.0.1:39201",
+					"172.24.0.1:39201",
+					"172.25.0.1:39201",
+					"172.26.0.1:39201",
+					"172.27.0.1:39201",
+					"172.28.0.1:39201"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:12:15.047991044Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1896790269306614,
+				"StableID":   "nTF3ruT4pF11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb460ef87abc28392030ffaed9a90acb13d737f7d4e2afd3c5cf30c9d8d6ce25",
+				"DiscoKey":   "discokey:a34c729de869d75828aeecc4024dc1476a2472e95393add1da74cb4e1dcbd649",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49922",
+					"10.65.0.27:49922",
+					"172.17.0.1:49922",
+					"172.18.0.1:49922",
+					"172.19.0.1:49922",
+					"172.20.0.1:49922",
+					"172.21.0.1:49922",
+					"172.22.0.1:49922",
+					"172.23.0.1:49922",
+					"172.24.0.1:49922",
+					"172.25.0.1:49922",
+					"172.26.0.1:49922",
+					"172.27.0.1:49922",
+					"172.28.0.1:49922"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:12:15.612155909Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6714736858617273,
+				"StableID":   "ngpGfZk7Su11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c7911d74f6a95c41cfbdc25933cda62584b81a423180a178c93e514cfecd5c6e",
+				"DiscoKey":   "discokey:53a1da3164b465eaa28141e7748a014dc2882e2ac8a8ade0c10cc2e1b81f642b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38348",
+					"10.65.0.27:38348",
+					"172.17.0.1:38348",
+					"172.18.0.1:38348",
+					"172.19.0.1:38348",
+					"172.20.0.1:38348",
+					"172.21.0.1:38348",
+					"172.22.0.1:38348",
+					"172.23.0.1:38348",
+					"172.24.0.1:38348",
+					"172.25.0.1:38348",
+					"172.26.0.1:38348",
+					"172.27.0.1:38348",
+					"172.28.0.1:38348"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:12:16.680850142Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3993055006255034,
+				"StableID":   "nPK3LUnTBY11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4483129363b3efe9d6e7f77e2c419993f6c93ac46886e2c65d66be7897d9945",
+				"DiscoKey":   "discokey:7aab69b601d715623f7faecd298d9d9c3ca661e48ff8e687a8fb956ea2721d3d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45745",
+					"10.65.0.27:45745",
+					"172.17.0.1:45745",
+					"172.18.0.1:45745",
+					"172.19.0.1:45745",
+					"172.20.0.1:45745",
+					"172.21.0.1:45745",
+					"172.22.0.1:45745",
+					"172.23.0.1:45745",
+					"172.24.0.1:45745",
+					"172.25.0.1:45745",
+					"172.26.0.1:45745",
+					"172.27.0.1:45745",
+					"172.28.0.1:45745"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:12:17.232728467Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         499258226074813,
+				"StableID":   "nkeuogf7u411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86de751b04e98f3f3e24662d954552ab27100bc4007cbd9d7fce7909bc653646",
+				"DiscoKey":   "discokey:2258666515a6c49fd642bd18313e7cd8c18c6ad3d66117a208110ffcd32f4518",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46872",
+					"10.65.0.27:46872",
+					"172.17.0.1:46872",
+					"172.18.0.1:46872",
+					"172.19.0.1:46872",
+					"172.20.0.1:46872",
+					"172.21.0.1:46872",
+					"172.22.0.1:46872",
+					"172.23.0.1:46872",
+					"172.24.0.1:46872",
+					"172.25.0.1:46872",
+					"172.26.0.1:46872",
+					"172.27.0.1:46872",
+					"172.28.0.1:46872"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:12:17.767226823Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5612001404879938,
+				"StableID":   "n5zgk7mgpk11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e078662eee1d237d130ec3464b5c8f01d12d4909933a8e5130d78d5b5acf6c4c",
+				"DiscoKey":   "discokey:d6267a1368efc7c7bd14582560ce0318075e69fbfe4479f5039e584e0457fc25",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56980",
+					"10.65.0.27:56980",
+					"172.17.0.1:56980",
+					"172.18.0.1:56980",
+					"172.19.0.1:56980",
+					"172.20.0.1:56980",
+					"172.21.0.1:56980",
+					"172.22.0.1:56980",
+					"172.23.0.1:56980",
+					"172.24.0.1:56980",
+					"172.25.0.1:56980",
+					"172.26.0.1:56980",
+					"172.27.0.1:56980",
+					"172.28.0.1:56980"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:12:18.319591263Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4715059007190742,
+				"StableID":   "nVrFW5cTpd11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5c974ab3854ff917eff17a52db4bef59f55bbc38aff6c0ce67baa68ee66fe2b",
+				"DiscoKey":   "discokey:7179a468c9cf2ba6142561fddefcb48f77d50806b6f3357c1c366b009d14911a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42733",
+					"10.65.0.27:42733",
+					"172.17.0.1:42733",
+					"172.18.0.1:42733",
+					"172.19.0.1:42733",
+					"172.20.0.1:42733",
+					"172.21.0.1:42733",
+					"172.22.0.1:42733",
+					"172.23.0.1:42733",
+					"172.24.0.1:42733",
+					"172.25.0.1:42733",
+					"172.26.0.1:42733",
+					"172.27.0.1:42733",
+					"172.28.0.1:42733"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:12:18.808278656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         239431495141524,
+				"StableID":   "n1ZCLeTSs211CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ac0dfaa903776a1252993dfedec0484f42538f85c55ffeaf608ab0ca7f21ad16",
+				"DiscoKey":   "discokey:5a1bf7676693f704282e50e85fbb55c89a73057d1db81615ae09c7d8f78b7374",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48599",
+					"10.65.0.27:48599",
+					"172.17.0.1:48599",
+					"172.18.0.1:48599",
+					"172.19.0.1:48599",
+					"172.20.0.1:48599",
+					"172.21.0.1:48599",
+					"172.22.0.1:48599",
+					"172.23.0.1:48599",
+					"172.24.0.1:48599",
+					"172.25.0.1:48599",
+					"172.26.0.1:48599",
+					"172.27.0.1:48599",
+					"172.28.0.1:48599"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:12:19.36713742Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6327755590799875,
+				"StableID":   "nncKBkQrQr11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5bc136530a7a3d8cd063e53488889156f0d776a1a568c506a4f535629ecaf814",
+				"KeyExpiry":  "2026-11-09T09:12:19Z",
+				"DiscoKey":   "discokey:804a065e484e011f2d8ee5627b209d7ddd6c9699e3f72744d5cfe887d2ed7857",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35110",
+					"10.65.0.27:35110",
+					"172.17.0.1:35110",
+					"172.18.0.1:35110",
+					"172.19.0.1:35110",
+					"172.20.0.1:35110",
+					"172.21.0.1:35110",
+					"172.22.0.1:35110",
+					"172.23.0.1:35110",
+					"172.24.0.1:35110",
+					"172.25.0.1:35110",
+					"172.26.0.1:35110",
+					"172.27.0.1:35110",
+					"172.28.0.1:35110"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:12:19.92157994Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         239211059311227,
+				"StableID":   "nG5xAofLs211CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:69a2e516bd0240aa24cb1aeeac3002b103f5b3b8b971f4a54b5977c4395a104f",
+				"KeyExpiry":  "2026-11-09T09:12:20Z",
+				"DiscoKey":   "discokey:b3678915cab02bc3cfde16542ab71daf35672432939d3e93a04c443f37f5295e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47307",
+					"10.65.0.27:47307",
+					"172.17.0.1:47307",
+					"172.18.0.1:47307",
+					"172.19.0.1:47307",
+					"172.20.0.1:47307",
+					"172.21.0.1:47307",
+					"172.22.0.1:47307",
+					"172.23.0.1:47307",
+					"172.24.0.1:47307",
+					"172.25.0.1:47307",
+					"172.26.0.1:47307",
+					"172.27.0.1:47307",
+					"172.28.0.1:47307"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:12:20.451669488Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         146478454007342,
+				"StableID":   "nVgYPxjL9211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dfcf396c81bf3904aef3622810e304cdd156b0d140bd2bc4ba1f4775d4dacb71",
+				"KeyExpiry":  "2026-11-09T09:12:21Z",
+				"DiscoKey":   "discokey:ed46f6e38c977c94ed2ebf24418b84a4637c8745555fca6bfb402082c6ef940a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36999",
+					"10.65.0.27:36999",
+					"172.17.0.1:36999",
+					"172.18.0.1:36999",
+					"172.19.0.1:36999",
+					"172.20.0.1:36999",
+					"172.21.0.1:36999",
+					"172.22.0.1:36999",
+					"172.23.0.1:36999",
+					"172.24.0.1:36999",
+					"172.25.0.1:36999",
+					"172.26.0.1:36999",
+					"172.27.0.1:36999",
+					"172.28.0.1:36999"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:12:21.006885452Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5441526217295054": {
+				"ID":          5441526217295054,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         146478454007342,
+				"StableID":   "nVgYPxjL9211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dfcf396c81bf3904aef3622810e304cdd156b0d140bd2bc4ba1f4775d4dacb71",
+				"KeyExpiry":  "2026-11-09T09:12:21Z",
+				"DiscoKey":   "discokey:ed46f6e38c977c94ed2ebf24418b84a4637c8745555fca6bfb402082c6ef940a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36999",
+					"10.65.0.27:36999",
+					"172.17.0.1:36999",
+					"172.18.0.1:36999",
+					"172.19.0.1:36999",
+					"172.20.0.1:36999",
+					"172.21.0.1:36999",
+					"172.22.0.1:36999",
+					"172.23.0.1:36999",
+					"172.24.0.1:36999",
+					"172.25.0.1:36999",
+					"172.26.0.1:36999",
+					"172.27.0.1:36999",
+					"172.28.0.1:36999"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:12:21.006885452Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:dfcf396c81bf3904aef3622810e304cdd156b0d140bd2bc4ba1f4775d4dacb71",
+			"MachineKey": "mkey:7dbe8701221d2daa37cf984446857c42357675834f3d50feb21f689a7faf9c3f",
+			"Peers": [{
+				"ID":         6295043190505720,
+				"StableID":   "nR5BPP73Ar11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65bc1919c2b0271b65099b25733e8e937c9c25dcef10a78bf1439dfde8dc7c10",
+				"DiscoKey":   "discokey:b428fa4819b6410ef2c55a0589b735f3f8afdba37349adcf02b92510a3fa7e6b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51096",
+					"10.65.0.27:51096",
+					"172.17.0.1:51096",
+					"172.18.0.1:51096",
+					"172.19.0.1:51096",
+					"172.20.0.1:51096",
+					"172.21.0.1:51096",
+					"172.22.0.1:51096",
+					"172.23.0.1:51096",
+					"172.24.0.1:51096",
+					"172.25.0.1:51096",
+					"172.26.0.1:51096",
+					"172.27.0.1:51096",
+					"172.28.0.1:51096"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:12:13.451963393Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1136127687261480,
+				"StableID":   "n1djEa9Zs911CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15c02f336a07c3ec0f1030c2c1c7f2e719ee6ea39579baa726d63dbd618cfc33",
+				"DiscoKey":   "discokey:5b64b686e272e958d2761ad35f7504aea2e767c49e482ead424839639b891274",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43492",
+					"10.65.0.27:43492",
+					"172.17.0.1:43492",
+					"172.18.0.1:43492",
+					"172.19.0.1:43492",
+					"172.20.0.1:43492",
+					"172.21.0.1:43492",
+					"172.22.0.1:43492",
+					"172.23.0.1:43492",
+					"172.24.0.1:43492",
+					"172.25.0.1:43492",
+					"172.26.0.1:43492",
+					"172.27.0.1:43492",
+					"172.28.0.1:43492"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:12:13.959144721Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2547803460419977,
+				"StableID":   "nxGkFeUutL11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8343057cdbc9fd2178bc789bf1e86259d1747812264a6433e43bb5429efca076",
+				"DiscoKey":   "discokey:e47e67ee170c98bf4cd4c6affc8a7b721a9d07dc27a2dbcc02558d712482f42e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34838",
+					"10.65.0.27:34838",
+					"172.17.0.1:34838",
+					"172.18.0.1:34838",
+					"172.19.0.1:34838",
+					"172.20.0.1:34838",
+					"172.21.0.1:34838",
+					"172.22.0.1:34838",
+					"172.23.0.1:34838",
+					"172.24.0.1:34838",
+					"172.25.0.1:34838",
+					"172.26.0.1:34838",
+					"172.27.0.1:34838",
+					"172.28.0.1:34838"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:12:14.499294893Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7449375176885547,
+				"StableID":   "npKHCLTqA121CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6519d9431c7294cc474e2e8fc38bc615114d4e1c499aaf8aeaebdebb56650756",
+				"DiscoKey":   "discokey:956784a0e52ed592bf42657dc900851fba54255903d4e0b6c4899e224311d62a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39201",
+					"10.65.0.27:39201",
+					"172.17.0.1:39201",
+					"172.18.0.1:39201",
+					"172.19.0.1:39201",
+					"172.20.0.1:39201",
+					"172.21.0.1:39201",
+					"172.22.0.1:39201",
+					"172.23.0.1:39201",
+					"172.24.0.1:39201",
+					"172.25.0.1:39201",
+					"172.26.0.1:39201",
+					"172.27.0.1:39201",
+					"172.28.0.1:39201"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:12:15.047991044Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1896790269306614,
+				"StableID":   "nTF3ruT4pF11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb460ef87abc28392030ffaed9a90acb13d737f7d4e2afd3c5cf30c9d8d6ce25",
+				"DiscoKey":   "discokey:a34c729de869d75828aeecc4024dc1476a2472e95393add1da74cb4e1dcbd649",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49922",
+					"10.65.0.27:49922",
+					"172.17.0.1:49922",
+					"172.18.0.1:49922",
+					"172.19.0.1:49922",
+					"172.20.0.1:49922",
+					"172.21.0.1:49922",
+					"172.22.0.1:49922",
+					"172.23.0.1:49922",
+					"172.24.0.1:49922",
+					"172.25.0.1:49922",
+					"172.26.0.1:49922",
+					"172.27.0.1:49922",
+					"172.28.0.1:49922"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:12:15.612155909Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5441526217295054,
+				"StableID":   "nuL6CffUVj11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1412aa2d544b885ebfa6f5bf07d9916a2852336d6465b60a685669734b56c75a",
+				"DiscoKey":   "discokey:4c4cb78776a0e12809d426e51ce1b9d152283d9877ebc17356a54c531f75f90a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46088",
+					"10.65.0.27:46088",
+					"172.17.0.1:46088",
+					"172.18.0.1:46088",
+					"172.19.0.1:46088",
+					"172.20.0.1:46088",
+					"172.21.0.1:46088",
+					"172.22.0.1:46088",
+					"172.23.0.1:46088",
+					"172.24.0.1:46088",
+					"172.25.0.1:46088",
+					"172.26.0.1:46088",
+					"172.27.0.1:46088",
+					"172.28.0.1:46088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:12:16.125093181Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6714736858617273,
+				"StableID":   "ngpGfZk7Su11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c7911d74f6a95c41cfbdc25933cda62584b81a423180a178c93e514cfecd5c6e",
+				"DiscoKey":   "discokey:53a1da3164b465eaa28141e7748a014dc2882e2ac8a8ade0c10cc2e1b81f642b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38348",
+					"10.65.0.27:38348",
+					"172.17.0.1:38348",
+					"172.18.0.1:38348",
+					"172.19.0.1:38348",
+					"172.20.0.1:38348",
+					"172.21.0.1:38348",
+					"172.22.0.1:38348",
+					"172.23.0.1:38348",
+					"172.24.0.1:38348",
+					"172.25.0.1:38348",
+					"172.26.0.1:38348",
+					"172.27.0.1:38348",
+					"172.28.0.1:38348"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:12:16.680850142Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3993055006255034,
+				"StableID":   "nPK3LUnTBY11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4483129363b3efe9d6e7f77e2c419993f6c93ac46886e2c65d66be7897d9945",
+				"DiscoKey":   "discokey:7aab69b601d715623f7faecd298d9d9c3ca661e48ff8e687a8fb956ea2721d3d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45745",
+					"10.65.0.27:45745",
+					"172.17.0.1:45745",
+					"172.18.0.1:45745",
+					"172.19.0.1:45745",
+					"172.20.0.1:45745",
+					"172.21.0.1:45745",
+					"172.22.0.1:45745",
+					"172.23.0.1:45745",
+					"172.24.0.1:45745",
+					"172.25.0.1:45745",
+					"172.26.0.1:45745",
+					"172.27.0.1:45745",
+					"172.28.0.1:45745"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:12:17.232728467Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         499258226074813,
+				"StableID":   "nkeuogf7u411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86de751b04e98f3f3e24662d954552ab27100bc4007cbd9d7fce7909bc653646",
+				"DiscoKey":   "discokey:2258666515a6c49fd642bd18313e7cd8c18c6ad3d66117a208110ffcd32f4518",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46872",
+					"10.65.0.27:46872",
+					"172.17.0.1:46872",
+					"172.18.0.1:46872",
+					"172.19.0.1:46872",
+					"172.20.0.1:46872",
+					"172.21.0.1:46872",
+					"172.22.0.1:46872",
+					"172.23.0.1:46872",
+					"172.24.0.1:46872",
+					"172.25.0.1:46872",
+					"172.26.0.1:46872",
+					"172.27.0.1:46872",
+					"172.28.0.1:46872"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:12:17.767226823Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5612001404879938,
+				"StableID":   "n5zgk7mgpk11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e078662eee1d237d130ec3464b5c8f01d12d4909933a8e5130d78d5b5acf6c4c",
+				"DiscoKey":   "discokey:d6267a1368efc7c7bd14582560ce0318075e69fbfe4479f5039e584e0457fc25",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56980",
+					"10.65.0.27:56980",
+					"172.17.0.1:56980",
+					"172.18.0.1:56980",
+					"172.19.0.1:56980",
+					"172.20.0.1:56980",
+					"172.21.0.1:56980",
+					"172.22.0.1:56980",
+					"172.23.0.1:56980",
+					"172.24.0.1:56980",
+					"172.25.0.1:56980",
+					"172.26.0.1:56980",
+					"172.27.0.1:56980",
+					"172.28.0.1:56980"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:12:18.319591263Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4715059007190742,
+				"StableID":   "nVrFW5cTpd11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5c974ab3854ff917eff17a52db4bef59f55bbc38aff6c0ce67baa68ee66fe2b",
+				"DiscoKey":   "discokey:7179a468c9cf2ba6142561fddefcb48f77d50806b6f3357c1c366b009d14911a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42733",
+					"10.65.0.27:42733",
+					"172.17.0.1:42733",
+					"172.18.0.1:42733",
+					"172.19.0.1:42733",
+					"172.20.0.1:42733",
+					"172.21.0.1:42733",
+					"172.22.0.1:42733",
+					"172.23.0.1:42733",
+					"172.24.0.1:42733",
+					"172.25.0.1:42733",
+					"172.26.0.1:42733",
+					"172.27.0.1:42733",
+					"172.28.0.1:42733"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:12:18.808278656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         239431495141524,
+				"StableID":   "n1ZCLeTSs211CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ac0dfaa903776a1252993dfedec0484f42538f85c55ffeaf608ab0ca7f21ad16",
+				"DiscoKey":   "discokey:5a1bf7676693f704282e50e85fbb55c89a73057d1db81615ae09c7d8f78b7374",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48599",
+					"10.65.0.27:48599",
+					"172.17.0.1:48599",
+					"172.18.0.1:48599",
+					"172.19.0.1:48599",
+					"172.20.0.1:48599",
+					"172.21.0.1:48599",
+					"172.22.0.1:48599",
+					"172.23.0.1:48599",
+					"172.24.0.1:48599",
+					"172.25.0.1:48599",
+					"172.26.0.1:48599",
+					"172.27.0.1:48599",
+					"172.28.0.1:48599"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:12:19.36713742Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6327755590799875,
+				"StableID":   "nncKBkQrQr11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5bc136530a7a3d8cd063e53488889156f0d776a1a568c506a4f535629ecaf814",
+				"KeyExpiry":  "2026-11-09T09:12:19Z",
+				"DiscoKey":   "discokey:804a065e484e011f2d8ee5627b209d7ddd6c9699e3f72744d5cfe887d2ed7857",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35110",
+					"10.65.0.27:35110",
+					"172.17.0.1:35110",
+					"172.18.0.1:35110",
+					"172.19.0.1:35110",
+					"172.20.0.1:35110",
+					"172.21.0.1:35110",
+					"172.22.0.1:35110",
+					"172.23.0.1:35110",
+					"172.24.0.1:35110",
+					"172.25.0.1:35110",
+					"172.26.0.1:35110",
+					"172.27.0.1:35110",
+					"172.28.0.1:35110"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:12:19.92157994Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         239211059311227,
+				"StableID":   "nG5xAofLs211CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:69a2e516bd0240aa24cb1aeeac3002b103f5b3b8b971f4a54b5977c4395a104f",
+				"KeyExpiry":  "2026-11-09T09:12:20Z",
+				"DiscoKey":   "discokey:b3678915cab02bc3cfde16542ab71daf35672432939d3e93a04c443f37f5295e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47307",
+					"10.65.0.27:47307",
+					"172.17.0.1:47307",
+					"172.18.0.1:47307",
+					"172.19.0.1:47307",
+					"172.20.0.1:47307",
+					"172.21.0.1:47307",
+					"172.22.0.1:47307",
+					"172.23.0.1:47307",
+					"172.24.0.1:47307",
+					"172.25.0.1:47307",
+					"172.26.0.1:47307",
+					"172.27.0.1:47307",
+					"172.28.0.1:47307"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:12:20.451669488Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2547803460419977,
+				"StableID":   "nxGkFeUutL11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       2547803460419977,
+				"Key":        "nodekey:8343057cdbc9fd2178bc789bf1e86259d1747812264a6433e43bb5429efca076",
+				"DiscoKey":   "discokey:e47e67ee170c98bf4cd4c6affc8a7b721a9d07dc27a2dbcc02558d712482f42e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34838",
+					"10.65.0.27:34838",
+					"172.17.0.1:34838",
+					"172.18.0.1:34838",
+					"172.19.0.1:34838",
+					"172.20.0.1:34838",
+					"172.21.0.1:34838",
+					"172.22.0.1:34838",
+					"172.23.0.1:34838",
+					"172.24.0.1:34838",
+					"172.25.0.1:34838",
+					"172.26.0.1:34838",
+					"172.27.0.1:34838",
+					"172.28.0.1:34838"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:12:14.499294893Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8343057cdbc9fd2178bc789bf1e86259d1747812264a6433e43bb5429efca076",
+			"MachineKey": "mkey:2d48bcedddd7ad7b6aaf1d1826a49dd488f9bbbb0787bbbc8c8e5970b593912f",
+			"Peers": [{
+				"ID":         6295043190505720,
+				"StableID":   "nR5BPP73Ar11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65bc1919c2b0271b65099b25733e8e937c9c25dcef10a78bf1439dfde8dc7c10",
+				"DiscoKey":   "discokey:b428fa4819b6410ef2c55a0589b735f3f8afdba37349adcf02b92510a3fa7e6b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51096",
+					"10.65.0.27:51096",
+					"172.17.0.1:51096",
+					"172.18.0.1:51096",
+					"172.19.0.1:51096",
+					"172.20.0.1:51096",
+					"172.21.0.1:51096",
+					"172.22.0.1:51096",
+					"172.23.0.1:51096",
+					"172.24.0.1:51096",
+					"172.25.0.1:51096",
+					"172.26.0.1:51096",
+					"172.27.0.1:51096",
+					"172.28.0.1:51096"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:12:13.451963393Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1136127687261480,
+				"StableID":   "n1djEa9Zs911CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15c02f336a07c3ec0f1030c2c1c7f2e719ee6ea39579baa726d63dbd618cfc33",
+				"DiscoKey":   "discokey:5b64b686e272e958d2761ad35f7504aea2e767c49e482ead424839639b891274",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43492",
+					"10.65.0.27:43492",
+					"172.17.0.1:43492",
+					"172.18.0.1:43492",
+					"172.19.0.1:43492",
+					"172.20.0.1:43492",
+					"172.21.0.1:43492",
+					"172.22.0.1:43492",
+					"172.23.0.1:43492",
+					"172.24.0.1:43492",
+					"172.25.0.1:43492",
+					"172.26.0.1:43492",
+					"172.27.0.1:43492",
+					"172.28.0.1:43492"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:12:13.959144721Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7449375176885547,
+				"StableID":   "npKHCLTqA121CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6519d9431c7294cc474e2e8fc38bc615114d4e1c499aaf8aeaebdebb56650756",
+				"DiscoKey":   "discokey:956784a0e52ed592bf42657dc900851fba54255903d4e0b6c4899e224311d62a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39201",
+					"10.65.0.27:39201",
+					"172.17.0.1:39201",
+					"172.18.0.1:39201",
+					"172.19.0.1:39201",
+					"172.20.0.1:39201",
+					"172.21.0.1:39201",
+					"172.22.0.1:39201",
+					"172.23.0.1:39201",
+					"172.24.0.1:39201",
+					"172.25.0.1:39201",
+					"172.26.0.1:39201",
+					"172.27.0.1:39201",
+					"172.28.0.1:39201"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:12:15.047991044Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1896790269306614,
+				"StableID":   "nTF3ruT4pF11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb460ef87abc28392030ffaed9a90acb13d737f7d4e2afd3c5cf30c9d8d6ce25",
+				"DiscoKey":   "discokey:a34c729de869d75828aeecc4024dc1476a2472e95393add1da74cb4e1dcbd649",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49922",
+					"10.65.0.27:49922",
+					"172.17.0.1:49922",
+					"172.18.0.1:49922",
+					"172.19.0.1:49922",
+					"172.20.0.1:49922",
+					"172.21.0.1:49922",
+					"172.22.0.1:49922",
+					"172.23.0.1:49922",
+					"172.24.0.1:49922",
+					"172.25.0.1:49922",
+					"172.26.0.1:49922",
+					"172.27.0.1:49922",
+					"172.28.0.1:49922"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:12:15.612155909Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5441526217295054,
+				"StableID":   "nuL6CffUVj11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1412aa2d544b885ebfa6f5bf07d9916a2852336d6465b60a685669734b56c75a",
+				"DiscoKey":   "discokey:4c4cb78776a0e12809d426e51ce1b9d152283d9877ebc17356a54c531f75f90a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46088",
+					"10.65.0.27:46088",
+					"172.17.0.1:46088",
+					"172.18.0.1:46088",
+					"172.19.0.1:46088",
+					"172.20.0.1:46088",
+					"172.21.0.1:46088",
+					"172.22.0.1:46088",
+					"172.23.0.1:46088",
+					"172.24.0.1:46088",
+					"172.25.0.1:46088",
+					"172.26.0.1:46088",
+					"172.27.0.1:46088",
+					"172.28.0.1:46088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:12:16.125093181Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6714736858617273,
+				"StableID":   "ngpGfZk7Su11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c7911d74f6a95c41cfbdc25933cda62584b81a423180a178c93e514cfecd5c6e",
+				"DiscoKey":   "discokey:53a1da3164b465eaa28141e7748a014dc2882e2ac8a8ade0c10cc2e1b81f642b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38348",
+					"10.65.0.27:38348",
+					"172.17.0.1:38348",
+					"172.18.0.1:38348",
+					"172.19.0.1:38348",
+					"172.20.0.1:38348",
+					"172.21.0.1:38348",
+					"172.22.0.1:38348",
+					"172.23.0.1:38348",
+					"172.24.0.1:38348",
+					"172.25.0.1:38348",
+					"172.26.0.1:38348",
+					"172.27.0.1:38348",
+					"172.28.0.1:38348"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:12:16.680850142Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3993055006255034,
+				"StableID":   "nPK3LUnTBY11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4483129363b3efe9d6e7f77e2c419993f6c93ac46886e2c65d66be7897d9945",
+				"DiscoKey":   "discokey:7aab69b601d715623f7faecd298d9d9c3ca661e48ff8e687a8fb956ea2721d3d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45745",
+					"10.65.0.27:45745",
+					"172.17.0.1:45745",
+					"172.18.0.1:45745",
+					"172.19.0.1:45745",
+					"172.20.0.1:45745",
+					"172.21.0.1:45745",
+					"172.22.0.1:45745",
+					"172.23.0.1:45745",
+					"172.24.0.1:45745",
+					"172.25.0.1:45745",
+					"172.26.0.1:45745",
+					"172.27.0.1:45745",
+					"172.28.0.1:45745"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:12:17.232728467Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         499258226074813,
+				"StableID":   "nkeuogf7u411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86de751b04e98f3f3e24662d954552ab27100bc4007cbd9d7fce7909bc653646",
+				"DiscoKey":   "discokey:2258666515a6c49fd642bd18313e7cd8c18c6ad3d66117a208110ffcd32f4518",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46872",
+					"10.65.0.27:46872",
+					"172.17.0.1:46872",
+					"172.18.0.1:46872",
+					"172.19.0.1:46872",
+					"172.20.0.1:46872",
+					"172.21.0.1:46872",
+					"172.22.0.1:46872",
+					"172.23.0.1:46872",
+					"172.24.0.1:46872",
+					"172.25.0.1:46872",
+					"172.26.0.1:46872",
+					"172.27.0.1:46872",
+					"172.28.0.1:46872"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:12:17.767226823Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5612001404879938,
+				"StableID":   "n5zgk7mgpk11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e078662eee1d237d130ec3464b5c8f01d12d4909933a8e5130d78d5b5acf6c4c",
+				"DiscoKey":   "discokey:d6267a1368efc7c7bd14582560ce0318075e69fbfe4479f5039e584e0457fc25",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56980",
+					"10.65.0.27:56980",
+					"172.17.0.1:56980",
+					"172.18.0.1:56980",
+					"172.19.0.1:56980",
+					"172.20.0.1:56980",
+					"172.21.0.1:56980",
+					"172.22.0.1:56980",
+					"172.23.0.1:56980",
+					"172.24.0.1:56980",
+					"172.25.0.1:56980",
+					"172.26.0.1:56980",
+					"172.27.0.1:56980",
+					"172.28.0.1:56980"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:12:18.319591263Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4715059007190742,
+				"StableID":   "nVrFW5cTpd11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5c974ab3854ff917eff17a52db4bef59f55bbc38aff6c0ce67baa68ee66fe2b",
+				"DiscoKey":   "discokey:7179a468c9cf2ba6142561fddefcb48f77d50806b6f3357c1c366b009d14911a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42733",
+					"10.65.0.27:42733",
+					"172.17.0.1:42733",
+					"172.18.0.1:42733",
+					"172.19.0.1:42733",
+					"172.20.0.1:42733",
+					"172.21.0.1:42733",
+					"172.22.0.1:42733",
+					"172.23.0.1:42733",
+					"172.24.0.1:42733",
+					"172.25.0.1:42733",
+					"172.26.0.1:42733",
+					"172.27.0.1:42733",
+					"172.28.0.1:42733"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:12:18.808278656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         239431495141524,
+				"StableID":   "n1ZCLeTSs211CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ac0dfaa903776a1252993dfedec0484f42538f85c55ffeaf608ab0ca7f21ad16",
+				"DiscoKey":   "discokey:5a1bf7676693f704282e50e85fbb55c89a73057d1db81615ae09c7d8f78b7374",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48599",
+					"10.65.0.27:48599",
+					"172.17.0.1:48599",
+					"172.18.0.1:48599",
+					"172.19.0.1:48599",
+					"172.20.0.1:48599",
+					"172.21.0.1:48599",
+					"172.22.0.1:48599",
+					"172.23.0.1:48599",
+					"172.24.0.1:48599",
+					"172.25.0.1:48599",
+					"172.26.0.1:48599",
+					"172.27.0.1:48599",
+					"172.28.0.1:48599"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:12:19.36713742Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6327755590799875,
+				"StableID":   "nncKBkQrQr11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5bc136530a7a3d8cd063e53488889156f0d776a1a568c506a4f535629ecaf814",
+				"KeyExpiry":  "2026-11-09T09:12:19Z",
+				"DiscoKey":   "discokey:804a065e484e011f2d8ee5627b209d7ddd6c9699e3f72744d5cfe887d2ed7857",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35110",
+					"10.65.0.27:35110",
+					"172.17.0.1:35110",
+					"172.18.0.1:35110",
+					"172.19.0.1:35110",
+					"172.20.0.1:35110",
+					"172.21.0.1:35110",
+					"172.22.0.1:35110",
+					"172.23.0.1:35110",
+					"172.24.0.1:35110",
+					"172.25.0.1:35110",
+					"172.26.0.1:35110",
+					"172.27.0.1:35110",
+					"172.28.0.1:35110"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:12:19.92157994Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         239211059311227,
+				"StableID":   "nG5xAofLs211CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:69a2e516bd0240aa24cb1aeeac3002b103f5b3b8b971f4a54b5977c4395a104f",
+				"KeyExpiry":  "2026-11-09T09:12:20Z",
+				"DiscoKey":   "discokey:b3678915cab02bc3cfde16542ab71daf35672432939d3e93a04c443f37f5295e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47307",
+					"10.65.0.27:47307",
+					"172.17.0.1:47307",
+					"172.18.0.1:47307",
+					"172.19.0.1:47307",
+					"172.20.0.1:47307",
+					"172.21.0.1:47307",
+					"172.22.0.1:47307",
+					"172.23.0.1:47307",
+					"172.24.0.1:47307",
+					"172.25.0.1:47307",
+					"172.26.0.1:47307",
+					"172.27.0.1:47307",
+					"172.28.0.1:47307"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:12:20.451669488Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         146478454007342,
+				"StableID":   "nVgYPxjL9211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dfcf396c81bf3904aef3622810e304cdd156b0d140bd2bc4ba1f4775d4dacb71",
+				"KeyExpiry":  "2026-11-09T09:12:21Z",
+				"DiscoKey":   "discokey:ed46f6e38c977c94ed2ebf24418b84a4637c8745555fca6bfb402082c6ef940a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36999",
+					"10.65.0.27:36999",
+					"172.17.0.1:36999",
+					"172.18.0.1:36999",
+					"172.19.0.1:36999",
+					"172.20.0.1:36999",
+					"172.21.0.1:36999",
+					"172.22.0.1:36999",
+					"172.23.0.1:36999",
+					"172.24.0.1:36999",
+					"172.25.0.1:36999",
+					"172.26.0.1:36999",
+					"172.27.0.1:36999",
+					"172.28.0.1:36999"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:12:21.006885452Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2547803460419977": {
+				"ID":          2547803460419977,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3993055006255034,
+				"StableID":   "nPK3LUnTBY11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       3993055006255034,
+				"Key":        "nodekey:e4483129363b3efe9d6e7f77e2c419993f6c93ac46886e2c65d66be7897d9945",
+				"DiscoKey":   "discokey:7aab69b601d715623f7faecd298d9d9c3ca661e48ff8e687a8fb956ea2721d3d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45745",
+					"10.65.0.27:45745",
+					"172.17.0.1:45745",
+					"172.18.0.1:45745",
+					"172.19.0.1:45745",
+					"172.20.0.1:45745",
+					"172.21.0.1:45745",
+					"172.22.0.1:45745",
+					"172.23.0.1:45745",
+					"172.24.0.1:45745",
+					"172.25.0.1:45745",
+					"172.26.0.1:45745",
+					"172.27.0.1:45745",
+					"172.28.0.1:45745"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:12:17.232728467Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e4483129363b3efe9d6e7f77e2c419993f6c93ac46886e2c65d66be7897d9945",
+			"MachineKey": "mkey:642cff03ca7f757092679e0fd6052d4540995645554f6077b0454530226e9a66",
+			"Peers": [{
+				"ID":         6295043190505720,
+				"StableID":   "nR5BPP73Ar11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65bc1919c2b0271b65099b25733e8e937c9c25dcef10a78bf1439dfde8dc7c10",
+				"DiscoKey":   "discokey:b428fa4819b6410ef2c55a0589b735f3f8afdba37349adcf02b92510a3fa7e6b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51096",
+					"10.65.0.27:51096",
+					"172.17.0.1:51096",
+					"172.18.0.1:51096",
+					"172.19.0.1:51096",
+					"172.20.0.1:51096",
+					"172.21.0.1:51096",
+					"172.22.0.1:51096",
+					"172.23.0.1:51096",
+					"172.24.0.1:51096",
+					"172.25.0.1:51096",
+					"172.26.0.1:51096",
+					"172.27.0.1:51096",
+					"172.28.0.1:51096"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:12:13.451963393Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1136127687261480,
+				"StableID":   "n1djEa9Zs911CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15c02f336a07c3ec0f1030c2c1c7f2e719ee6ea39579baa726d63dbd618cfc33",
+				"DiscoKey":   "discokey:5b64b686e272e958d2761ad35f7504aea2e767c49e482ead424839639b891274",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43492",
+					"10.65.0.27:43492",
+					"172.17.0.1:43492",
+					"172.18.0.1:43492",
+					"172.19.0.1:43492",
+					"172.20.0.1:43492",
+					"172.21.0.1:43492",
+					"172.22.0.1:43492",
+					"172.23.0.1:43492",
+					"172.24.0.1:43492",
+					"172.25.0.1:43492",
+					"172.26.0.1:43492",
+					"172.27.0.1:43492",
+					"172.28.0.1:43492"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:12:13.959144721Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2547803460419977,
+				"StableID":   "nxGkFeUutL11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8343057cdbc9fd2178bc789bf1e86259d1747812264a6433e43bb5429efca076",
+				"DiscoKey":   "discokey:e47e67ee170c98bf4cd4c6affc8a7b721a9d07dc27a2dbcc02558d712482f42e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34838",
+					"10.65.0.27:34838",
+					"172.17.0.1:34838",
+					"172.18.0.1:34838",
+					"172.19.0.1:34838",
+					"172.20.0.1:34838",
+					"172.21.0.1:34838",
+					"172.22.0.1:34838",
+					"172.23.0.1:34838",
+					"172.24.0.1:34838",
+					"172.25.0.1:34838",
+					"172.26.0.1:34838",
+					"172.27.0.1:34838",
+					"172.28.0.1:34838"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:12:14.499294893Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7449375176885547,
+				"StableID":   "npKHCLTqA121CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6519d9431c7294cc474e2e8fc38bc615114d4e1c499aaf8aeaebdebb56650756",
+				"DiscoKey":   "discokey:956784a0e52ed592bf42657dc900851fba54255903d4e0b6c4899e224311d62a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39201",
+					"10.65.0.27:39201",
+					"172.17.0.1:39201",
+					"172.18.0.1:39201",
+					"172.19.0.1:39201",
+					"172.20.0.1:39201",
+					"172.21.0.1:39201",
+					"172.22.0.1:39201",
+					"172.23.0.1:39201",
+					"172.24.0.1:39201",
+					"172.25.0.1:39201",
+					"172.26.0.1:39201",
+					"172.27.0.1:39201",
+					"172.28.0.1:39201"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:12:15.047991044Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1896790269306614,
+				"StableID":   "nTF3ruT4pF11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb460ef87abc28392030ffaed9a90acb13d737f7d4e2afd3c5cf30c9d8d6ce25",
+				"DiscoKey":   "discokey:a34c729de869d75828aeecc4024dc1476a2472e95393add1da74cb4e1dcbd649",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49922",
+					"10.65.0.27:49922",
+					"172.17.0.1:49922",
+					"172.18.0.1:49922",
+					"172.19.0.1:49922",
+					"172.20.0.1:49922",
+					"172.21.0.1:49922",
+					"172.22.0.1:49922",
+					"172.23.0.1:49922",
+					"172.24.0.1:49922",
+					"172.25.0.1:49922",
+					"172.26.0.1:49922",
+					"172.27.0.1:49922",
+					"172.28.0.1:49922"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:12:15.612155909Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5441526217295054,
+				"StableID":   "nuL6CffUVj11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1412aa2d544b885ebfa6f5bf07d9916a2852336d6465b60a685669734b56c75a",
+				"DiscoKey":   "discokey:4c4cb78776a0e12809d426e51ce1b9d152283d9877ebc17356a54c531f75f90a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46088",
+					"10.65.0.27:46088",
+					"172.17.0.1:46088",
+					"172.18.0.1:46088",
+					"172.19.0.1:46088",
+					"172.20.0.1:46088",
+					"172.21.0.1:46088",
+					"172.22.0.1:46088",
+					"172.23.0.1:46088",
+					"172.24.0.1:46088",
+					"172.25.0.1:46088",
+					"172.26.0.1:46088",
+					"172.27.0.1:46088",
+					"172.28.0.1:46088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:12:16.125093181Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6714736858617273,
+				"StableID":   "ngpGfZk7Su11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c7911d74f6a95c41cfbdc25933cda62584b81a423180a178c93e514cfecd5c6e",
+				"DiscoKey":   "discokey:53a1da3164b465eaa28141e7748a014dc2882e2ac8a8ade0c10cc2e1b81f642b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38348",
+					"10.65.0.27:38348",
+					"172.17.0.1:38348",
+					"172.18.0.1:38348",
+					"172.19.0.1:38348",
+					"172.20.0.1:38348",
+					"172.21.0.1:38348",
+					"172.22.0.1:38348",
+					"172.23.0.1:38348",
+					"172.24.0.1:38348",
+					"172.25.0.1:38348",
+					"172.26.0.1:38348",
+					"172.27.0.1:38348",
+					"172.28.0.1:38348"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:12:16.680850142Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         499258226074813,
+				"StableID":   "nkeuogf7u411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86de751b04e98f3f3e24662d954552ab27100bc4007cbd9d7fce7909bc653646",
+				"DiscoKey":   "discokey:2258666515a6c49fd642bd18313e7cd8c18c6ad3d66117a208110ffcd32f4518",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46872",
+					"10.65.0.27:46872",
+					"172.17.0.1:46872",
+					"172.18.0.1:46872",
+					"172.19.0.1:46872",
+					"172.20.0.1:46872",
+					"172.21.0.1:46872",
+					"172.22.0.1:46872",
+					"172.23.0.1:46872",
+					"172.24.0.1:46872",
+					"172.25.0.1:46872",
+					"172.26.0.1:46872",
+					"172.27.0.1:46872",
+					"172.28.0.1:46872"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:12:17.767226823Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5612001404879938,
+				"StableID":   "n5zgk7mgpk11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e078662eee1d237d130ec3464b5c8f01d12d4909933a8e5130d78d5b5acf6c4c",
+				"DiscoKey":   "discokey:d6267a1368efc7c7bd14582560ce0318075e69fbfe4479f5039e584e0457fc25",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56980",
+					"10.65.0.27:56980",
+					"172.17.0.1:56980",
+					"172.18.0.1:56980",
+					"172.19.0.1:56980",
+					"172.20.0.1:56980",
+					"172.21.0.1:56980",
+					"172.22.0.1:56980",
+					"172.23.0.1:56980",
+					"172.24.0.1:56980",
+					"172.25.0.1:56980",
+					"172.26.0.1:56980",
+					"172.27.0.1:56980",
+					"172.28.0.1:56980"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:12:18.319591263Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4715059007190742,
+				"StableID":   "nVrFW5cTpd11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5c974ab3854ff917eff17a52db4bef59f55bbc38aff6c0ce67baa68ee66fe2b",
+				"DiscoKey":   "discokey:7179a468c9cf2ba6142561fddefcb48f77d50806b6f3357c1c366b009d14911a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42733",
+					"10.65.0.27:42733",
+					"172.17.0.1:42733",
+					"172.18.0.1:42733",
+					"172.19.0.1:42733",
+					"172.20.0.1:42733",
+					"172.21.0.1:42733",
+					"172.22.0.1:42733",
+					"172.23.0.1:42733",
+					"172.24.0.1:42733",
+					"172.25.0.1:42733",
+					"172.26.0.1:42733",
+					"172.27.0.1:42733",
+					"172.28.0.1:42733"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:12:18.808278656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         239431495141524,
+				"StableID":   "n1ZCLeTSs211CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ac0dfaa903776a1252993dfedec0484f42538f85c55ffeaf608ab0ca7f21ad16",
+				"DiscoKey":   "discokey:5a1bf7676693f704282e50e85fbb55c89a73057d1db81615ae09c7d8f78b7374",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48599",
+					"10.65.0.27:48599",
+					"172.17.0.1:48599",
+					"172.18.0.1:48599",
+					"172.19.0.1:48599",
+					"172.20.0.1:48599",
+					"172.21.0.1:48599",
+					"172.22.0.1:48599",
+					"172.23.0.1:48599",
+					"172.24.0.1:48599",
+					"172.25.0.1:48599",
+					"172.26.0.1:48599",
+					"172.27.0.1:48599",
+					"172.28.0.1:48599"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:12:19.36713742Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6327755590799875,
+				"StableID":   "nncKBkQrQr11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5bc136530a7a3d8cd063e53488889156f0d776a1a568c506a4f535629ecaf814",
+				"KeyExpiry":  "2026-11-09T09:12:19Z",
+				"DiscoKey":   "discokey:804a065e484e011f2d8ee5627b209d7ddd6c9699e3f72744d5cfe887d2ed7857",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35110",
+					"10.65.0.27:35110",
+					"172.17.0.1:35110",
+					"172.18.0.1:35110",
+					"172.19.0.1:35110",
+					"172.20.0.1:35110",
+					"172.21.0.1:35110",
+					"172.22.0.1:35110",
+					"172.23.0.1:35110",
+					"172.24.0.1:35110",
+					"172.25.0.1:35110",
+					"172.26.0.1:35110",
+					"172.27.0.1:35110",
+					"172.28.0.1:35110"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:12:19.92157994Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         239211059311227,
+				"StableID":   "nG5xAofLs211CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:69a2e516bd0240aa24cb1aeeac3002b103f5b3b8b971f4a54b5977c4395a104f",
+				"KeyExpiry":  "2026-11-09T09:12:20Z",
+				"DiscoKey":   "discokey:b3678915cab02bc3cfde16542ab71daf35672432939d3e93a04c443f37f5295e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47307",
+					"10.65.0.27:47307",
+					"172.17.0.1:47307",
+					"172.18.0.1:47307",
+					"172.19.0.1:47307",
+					"172.20.0.1:47307",
+					"172.21.0.1:47307",
+					"172.22.0.1:47307",
+					"172.23.0.1:47307",
+					"172.24.0.1:47307",
+					"172.25.0.1:47307",
+					"172.26.0.1:47307",
+					"172.27.0.1:47307",
+					"172.28.0.1:47307"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:12:20.451669488Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         146478454007342,
+				"StableID":   "nVgYPxjL9211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dfcf396c81bf3904aef3622810e304cdd156b0d140bd2bc4ba1f4775d4dacb71",
+				"KeyExpiry":  "2026-11-09T09:12:21Z",
+				"DiscoKey":   "discokey:ed46f6e38c977c94ed2ebf24418b84a4637c8745555fca6bfb402082c6ef940a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36999",
+					"10.65.0.27:36999",
+					"172.17.0.1:36999",
+					"172.18.0.1:36999",
+					"172.19.0.1:36999",
+					"172.20.0.1:36999",
+					"172.21.0.1:36999",
+					"172.22.0.1:36999",
+					"172.23.0.1:36999",
+					"172.24.0.1:36999",
+					"172.25.0.1:36999",
+					"172.26.0.1:36999",
+					"172.27.0.1:36999",
+					"172.28.0.1:36999"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:12:21.006885452Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "3993055006255034": {
+				"ID":          3993055006255034,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6327755590799875,
+				"StableID":   "nncKBkQrQr11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5bc136530a7a3d8cd063e53488889156f0d776a1a568c506a4f535629ecaf814",
+				"KeyExpiry":  "2026-11-09T09:12:19Z",
+				"DiscoKey":   "discokey:804a065e484e011f2d8ee5627b209d7ddd6c9699e3f72744d5cfe887d2ed7857",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35110",
+					"10.65.0.27:35110",
+					"172.17.0.1:35110",
+					"172.18.0.1:35110",
+					"172.19.0.1:35110",
+					"172.20.0.1:35110",
+					"172.21.0.1:35110",
+					"172.22.0.1:35110",
+					"172.23.0.1:35110",
+					"172.24.0.1:35110",
+					"172.25.0.1:35110",
+					"172.26.0.1:35110",
+					"172.27.0.1:35110",
+					"172.28.0.1:35110"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:12:19.92157994Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5bc136530a7a3d8cd063e53488889156f0d776a1a568c506a4f535629ecaf814",
+			"MachineKey": "mkey:8e8fa6976565dd82f1f5c02c327f4581f61e30685f64366d352215e7df43b31e",
+			"Peers": [{
+				"ID":         6295043190505720,
+				"StableID":   "nR5BPP73Ar11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65bc1919c2b0271b65099b25733e8e937c9c25dcef10a78bf1439dfde8dc7c10",
+				"DiscoKey":   "discokey:b428fa4819b6410ef2c55a0589b735f3f8afdba37349adcf02b92510a3fa7e6b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51096",
+					"10.65.0.27:51096",
+					"172.17.0.1:51096",
+					"172.18.0.1:51096",
+					"172.19.0.1:51096",
+					"172.20.0.1:51096",
+					"172.21.0.1:51096",
+					"172.22.0.1:51096",
+					"172.23.0.1:51096",
+					"172.24.0.1:51096",
+					"172.25.0.1:51096",
+					"172.26.0.1:51096",
+					"172.27.0.1:51096",
+					"172.28.0.1:51096"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:12:13.451963393Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1136127687261480,
+				"StableID":   "n1djEa9Zs911CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15c02f336a07c3ec0f1030c2c1c7f2e719ee6ea39579baa726d63dbd618cfc33",
+				"DiscoKey":   "discokey:5b64b686e272e958d2761ad35f7504aea2e767c49e482ead424839639b891274",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43492",
+					"10.65.0.27:43492",
+					"172.17.0.1:43492",
+					"172.18.0.1:43492",
+					"172.19.0.1:43492",
+					"172.20.0.1:43492",
+					"172.21.0.1:43492",
+					"172.22.0.1:43492",
+					"172.23.0.1:43492",
+					"172.24.0.1:43492",
+					"172.25.0.1:43492",
+					"172.26.0.1:43492",
+					"172.27.0.1:43492",
+					"172.28.0.1:43492"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:12:13.959144721Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2547803460419977,
+				"StableID":   "nxGkFeUutL11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8343057cdbc9fd2178bc789bf1e86259d1747812264a6433e43bb5429efca076",
+				"DiscoKey":   "discokey:e47e67ee170c98bf4cd4c6affc8a7b721a9d07dc27a2dbcc02558d712482f42e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34838",
+					"10.65.0.27:34838",
+					"172.17.0.1:34838",
+					"172.18.0.1:34838",
+					"172.19.0.1:34838",
+					"172.20.0.1:34838",
+					"172.21.0.1:34838",
+					"172.22.0.1:34838",
+					"172.23.0.1:34838",
+					"172.24.0.1:34838",
+					"172.25.0.1:34838",
+					"172.26.0.1:34838",
+					"172.27.0.1:34838",
+					"172.28.0.1:34838"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:12:14.499294893Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7449375176885547,
+				"StableID":   "npKHCLTqA121CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6519d9431c7294cc474e2e8fc38bc615114d4e1c499aaf8aeaebdebb56650756",
+				"DiscoKey":   "discokey:956784a0e52ed592bf42657dc900851fba54255903d4e0b6c4899e224311d62a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39201",
+					"10.65.0.27:39201",
+					"172.17.0.1:39201",
+					"172.18.0.1:39201",
+					"172.19.0.1:39201",
+					"172.20.0.1:39201",
+					"172.21.0.1:39201",
+					"172.22.0.1:39201",
+					"172.23.0.1:39201",
+					"172.24.0.1:39201",
+					"172.25.0.1:39201",
+					"172.26.0.1:39201",
+					"172.27.0.1:39201",
+					"172.28.0.1:39201"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:12:15.047991044Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1896790269306614,
+				"StableID":   "nTF3ruT4pF11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb460ef87abc28392030ffaed9a90acb13d737f7d4e2afd3c5cf30c9d8d6ce25",
+				"DiscoKey":   "discokey:a34c729de869d75828aeecc4024dc1476a2472e95393add1da74cb4e1dcbd649",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49922",
+					"10.65.0.27:49922",
+					"172.17.0.1:49922",
+					"172.18.0.1:49922",
+					"172.19.0.1:49922",
+					"172.20.0.1:49922",
+					"172.21.0.1:49922",
+					"172.22.0.1:49922",
+					"172.23.0.1:49922",
+					"172.24.0.1:49922",
+					"172.25.0.1:49922",
+					"172.26.0.1:49922",
+					"172.27.0.1:49922",
+					"172.28.0.1:49922"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:12:15.612155909Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5441526217295054,
+				"StableID":   "nuL6CffUVj11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1412aa2d544b885ebfa6f5bf07d9916a2852336d6465b60a685669734b56c75a",
+				"DiscoKey":   "discokey:4c4cb78776a0e12809d426e51ce1b9d152283d9877ebc17356a54c531f75f90a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46088",
+					"10.65.0.27:46088",
+					"172.17.0.1:46088",
+					"172.18.0.1:46088",
+					"172.19.0.1:46088",
+					"172.20.0.1:46088",
+					"172.21.0.1:46088",
+					"172.22.0.1:46088",
+					"172.23.0.1:46088",
+					"172.24.0.1:46088",
+					"172.25.0.1:46088",
+					"172.26.0.1:46088",
+					"172.27.0.1:46088",
+					"172.28.0.1:46088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:12:16.125093181Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6714736858617273,
+				"StableID":   "ngpGfZk7Su11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c7911d74f6a95c41cfbdc25933cda62584b81a423180a178c93e514cfecd5c6e",
+				"DiscoKey":   "discokey:53a1da3164b465eaa28141e7748a014dc2882e2ac8a8ade0c10cc2e1b81f642b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38348",
+					"10.65.0.27:38348",
+					"172.17.0.1:38348",
+					"172.18.0.1:38348",
+					"172.19.0.1:38348",
+					"172.20.0.1:38348",
+					"172.21.0.1:38348",
+					"172.22.0.1:38348",
+					"172.23.0.1:38348",
+					"172.24.0.1:38348",
+					"172.25.0.1:38348",
+					"172.26.0.1:38348",
+					"172.27.0.1:38348",
+					"172.28.0.1:38348"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:12:16.680850142Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3993055006255034,
+				"StableID":   "nPK3LUnTBY11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4483129363b3efe9d6e7f77e2c419993f6c93ac46886e2c65d66be7897d9945",
+				"DiscoKey":   "discokey:7aab69b601d715623f7faecd298d9d9c3ca661e48ff8e687a8fb956ea2721d3d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45745",
+					"10.65.0.27:45745",
+					"172.17.0.1:45745",
+					"172.18.0.1:45745",
+					"172.19.0.1:45745",
+					"172.20.0.1:45745",
+					"172.21.0.1:45745",
+					"172.22.0.1:45745",
+					"172.23.0.1:45745",
+					"172.24.0.1:45745",
+					"172.25.0.1:45745",
+					"172.26.0.1:45745",
+					"172.27.0.1:45745",
+					"172.28.0.1:45745"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:12:17.232728467Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         499258226074813,
+				"StableID":   "nkeuogf7u411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86de751b04e98f3f3e24662d954552ab27100bc4007cbd9d7fce7909bc653646",
+				"DiscoKey":   "discokey:2258666515a6c49fd642bd18313e7cd8c18c6ad3d66117a208110ffcd32f4518",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46872",
+					"10.65.0.27:46872",
+					"172.17.0.1:46872",
+					"172.18.0.1:46872",
+					"172.19.0.1:46872",
+					"172.20.0.1:46872",
+					"172.21.0.1:46872",
+					"172.22.0.1:46872",
+					"172.23.0.1:46872",
+					"172.24.0.1:46872",
+					"172.25.0.1:46872",
+					"172.26.0.1:46872",
+					"172.27.0.1:46872",
+					"172.28.0.1:46872"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:12:17.767226823Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5612001404879938,
+				"StableID":   "n5zgk7mgpk11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e078662eee1d237d130ec3464b5c8f01d12d4909933a8e5130d78d5b5acf6c4c",
+				"DiscoKey":   "discokey:d6267a1368efc7c7bd14582560ce0318075e69fbfe4479f5039e584e0457fc25",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56980",
+					"10.65.0.27:56980",
+					"172.17.0.1:56980",
+					"172.18.0.1:56980",
+					"172.19.0.1:56980",
+					"172.20.0.1:56980",
+					"172.21.0.1:56980",
+					"172.22.0.1:56980",
+					"172.23.0.1:56980",
+					"172.24.0.1:56980",
+					"172.25.0.1:56980",
+					"172.26.0.1:56980",
+					"172.27.0.1:56980",
+					"172.28.0.1:56980"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:12:18.319591263Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4715059007190742,
+				"StableID":   "nVrFW5cTpd11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5c974ab3854ff917eff17a52db4bef59f55bbc38aff6c0ce67baa68ee66fe2b",
+				"DiscoKey":   "discokey:7179a468c9cf2ba6142561fddefcb48f77d50806b6f3357c1c366b009d14911a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42733",
+					"10.65.0.27:42733",
+					"172.17.0.1:42733",
+					"172.18.0.1:42733",
+					"172.19.0.1:42733",
+					"172.20.0.1:42733",
+					"172.21.0.1:42733",
+					"172.22.0.1:42733",
+					"172.23.0.1:42733",
+					"172.24.0.1:42733",
+					"172.25.0.1:42733",
+					"172.26.0.1:42733",
+					"172.27.0.1:42733",
+					"172.28.0.1:42733"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:12:18.808278656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         239431495141524,
+				"StableID":   "n1ZCLeTSs211CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ac0dfaa903776a1252993dfedec0484f42538f85c55ffeaf608ab0ca7f21ad16",
+				"DiscoKey":   "discokey:5a1bf7676693f704282e50e85fbb55c89a73057d1db81615ae09c7d8f78b7374",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48599",
+					"10.65.0.27:48599",
+					"172.17.0.1:48599",
+					"172.18.0.1:48599",
+					"172.19.0.1:48599",
+					"172.20.0.1:48599",
+					"172.21.0.1:48599",
+					"172.22.0.1:48599",
+					"172.23.0.1:48599",
+					"172.24.0.1:48599",
+					"172.25.0.1:48599",
+					"172.26.0.1:48599",
+					"172.27.0.1:48599",
+					"172.28.0.1:48599"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:12:19.36713742Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         239211059311227,
+				"StableID":   "nG5xAofLs211CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:69a2e516bd0240aa24cb1aeeac3002b103f5b3b8b971f4a54b5977c4395a104f",
+				"KeyExpiry":  "2026-11-09T09:12:20Z",
+				"DiscoKey":   "discokey:b3678915cab02bc3cfde16542ab71daf35672432939d3e93a04c443f37f5295e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47307",
+					"10.65.0.27:47307",
+					"172.17.0.1:47307",
+					"172.18.0.1:47307",
+					"172.19.0.1:47307",
+					"172.20.0.1:47307",
+					"172.21.0.1:47307",
+					"172.22.0.1:47307",
+					"172.23.0.1:47307",
+					"172.24.0.1:47307",
+					"172.25.0.1:47307",
+					"172.26.0.1:47307",
+					"172.27.0.1:47307",
+					"172.28.0.1:47307"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:12:20.451669488Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         146478454007342,
+				"StableID":   "nVgYPxjL9211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dfcf396c81bf3904aef3622810e304cdd156b0d140bd2bc4ba1f4775d4dacb71",
+				"KeyExpiry":  "2026-11-09T09:12:21Z",
+				"DiscoKey":   "discokey:ed46f6e38c977c94ed2ebf24418b84a4637c8745555fca6bfb402082c6ef940a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36999",
+					"10.65.0.27:36999",
+					"172.17.0.1:36999",
+					"172.18.0.1:36999",
+					"172.19.0.1:36999",
+					"172.20.0.1:36999",
+					"172.21.0.1:36999",
+					"172.22.0.1:36999",
+					"172.23.0.1:36999",
+					"172.24.0.1:36999",
+					"172.25.0.1:36999",
+					"172.26.0.1:36999",
+					"172.27.0.1:36999",
+					"172.28.0.1:36999"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:12:21.006885452Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4715059007190742,
+				"StableID":   "nVrFW5cTpd11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       4715059007190742,
+				"Key":        "nodekey:c5c974ab3854ff917eff17a52db4bef59f55bbc38aff6c0ce67baa68ee66fe2b",
+				"DiscoKey":   "discokey:7179a468c9cf2ba6142561fddefcb48f77d50806b6f3357c1c366b009d14911a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42733",
+					"10.65.0.27:42733",
+					"172.17.0.1:42733",
+					"172.18.0.1:42733",
+					"172.19.0.1:42733",
+					"172.20.0.1:42733",
+					"172.21.0.1:42733",
+					"172.22.0.1:42733",
+					"172.23.0.1:42733",
+					"172.24.0.1:42733",
+					"172.25.0.1:42733",
+					"172.26.0.1:42733",
+					"172.27.0.1:42733",
+					"172.28.0.1:42733"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:12:18.808278656Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c5c974ab3854ff917eff17a52db4bef59f55bbc38aff6c0ce67baa68ee66fe2b",
+			"MachineKey": "mkey:f2fd1947fc8e517bfee064c95b2175506a77bd5602d14726fc9d432ed31f4c37",
+			"Peers": [{
+				"ID":         6295043190505720,
+				"StableID":   "nR5BPP73Ar11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65bc1919c2b0271b65099b25733e8e937c9c25dcef10a78bf1439dfde8dc7c10",
+				"DiscoKey":   "discokey:b428fa4819b6410ef2c55a0589b735f3f8afdba37349adcf02b92510a3fa7e6b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51096",
+					"10.65.0.27:51096",
+					"172.17.0.1:51096",
+					"172.18.0.1:51096",
+					"172.19.0.1:51096",
+					"172.20.0.1:51096",
+					"172.21.0.1:51096",
+					"172.22.0.1:51096",
+					"172.23.0.1:51096",
+					"172.24.0.1:51096",
+					"172.25.0.1:51096",
+					"172.26.0.1:51096",
+					"172.27.0.1:51096",
+					"172.28.0.1:51096"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:12:13.451963393Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1136127687261480,
+				"StableID":   "n1djEa9Zs911CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15c02f336a07c3ec0f1030c2c1c7f2e719ee6ea39579baa726d63dbd618cfc33",
+				"DiscoKey":   "discokey:5b64b686e272e958d2761ad35f7504aea2e767c49e482ead424839639b891274",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43492",
+					"10.65.0.27:43492",
+					"172.17.0.1:43492",
+					"172.18.0.1:43492",
+					"172.19.0.1:43492",
+					"172.20.0.1:43492",
+					"172.21.0.1:43492",
+					"172.22.0.1:43492",
+					"172.23.0.1:43492",
+					"172.24.0.1:43492",
+					"172.25.0.1:43492",
+					"172.26.0.1:43492",
+					"172.27.0.1:43492",
+					"172.28.0.1:43492"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:12:13.959144721Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2547803460419977,
+				"StableID":   "nxGkFeUutL11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8343057cdbc9fd2178bc789bf1e86259d1747812264a6433e43bb5429efca076",
+				"DiscoKey":   "discokey:e47e67ee170c98bf4cd4c6affc8a7b721a9d07dc27a2dbcc02558d712482f42e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34838",
+					"10.65.0.27:34838",
+					"172.17.0.1:34838",
+					"172.18.0.1:34838",
+					"172.19.0.1:34838",
+					"172.20.0.1:34838",
+					"172.21.0.1:34838",
+					"172.22.0.1:34838",
+					"172.23.0.1:34838",
+					"172.24.0.1:34838",
+					"172.25.0.1:34838",
+					"172.26.0.1:34838",
+					"172.27.0.1:34838",
+					"172.28.0.1:34838"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:12:14.499294893Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7449375176885547,
+				"StableID":   "npKHCLTqA121CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6519d9431c7294cc474e2e8fc38bc615114d4e1c499aaf8aeaebdebb56650756",
+				"DiscoKey":   "discokey:956784a0e52ed592bf42657dc900851fba54255903d4e0b6c4899e224311d62a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39201",
+					"10.65.0.27:39201",
+					"172.17.0.1:39201",
+					"172.18.0.1:39201",
+					"172.19.0.1:39201",
+					"172.20.0.1:39201",
+					"172.21.0.1:39201",
+					"172.22.0.1:39201",
+					"172.23.0.1:39201",
+					"172.24.0.1:39201",
+					"172.25.0.1:39201",
+					"172.26.0.1:39201",
+					"172.27.0.1:39201",
+					"172.28.0.1:39201"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:12:15.047991044Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1896790269306614,
+				"StableID":   "nTF3ruT4pF11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb460ef87abc28392030ffaed9a90acb13d737f7d4e2afd3c5cf30c9d8d6ce25",
+				"DiscoKey":   "discokey:a34c729de869d75828aeecc4024dc1476a2472e95393add1da74cb4e1dcbd649",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49922",
+					"10.65.0.27:49922",
+					"172.17.0.1:49922",
+					"172.18.0.1:49922",
+					"172.19.0.1:49922",
+					"172.20.0.1:49922",
+					"172.21.0.1:49922",
+					"172.22.0.1:49922",
+					"172.23.0.1:49922",
+					"172.24.0.1:49922",
+					"172.25.0.1:49922",
+					"172.26.0.1:49922",
+					"172.27.0.1:49922",
+					"172.28.0.1:49922"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:12:15.612155909Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5441526217295054,
+				"StableID":   "nuL6CffUVj11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1412aa2d544b885ebfa6f5bf07d9916a2852336d6465b60a685669734b56c75a",
+				"DiscoKey":   "discokey:4c4cb78776a0e12809d426e51ce1b9d152283d9877ebc17356a54c531f75f90a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46088",
+					"10.65.0.27:46088",
+					"172.17.0.1:46088",
+					"172.18.0.1:46088",
+					"172.19.0.1:46088",
+					"172.20.0.1:46088",
+					"172.21.0.1:46088",
+					"172.22.0.1:46088",
+					"172.23.0.1:46088",
+					"172.24.0.1:46088",
+					"172.25.0.1:46088",
+					"172.26.0.1:46088",
+					"172.27.0.1:46088",
+					"172.28.0.1:46088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:12:16.125093181Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6714736858617273,
+				"StableID":   "ngpGfZk7Su11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c7911d74f6a95c41cfbdc25933cda62584b81a423180a178c93e514cfecd5c6e",
+				"DiscoKey":   "discokey:53a1da3164b465eaa28141e7748a014dc2882e2ac8a8ade0c10cc2e1b81f642b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38348",
+					"10.65.0.27:38348",
+					"172.17.0.1:38348",
+					"172.18.0.1:38348",
+					"172.19.0.1:38348",
+					"172.20.0.1:38348",
+					"172.21.0.1:38348",
+					"172.22.0.1:38348",
+					"172.23.0.1:38348",
+					"172.24.0.1:38348",
+					"172.25.0.1:38348",
+					"172.26.0.1:38348",
+					"172.27.0.1:38348",
+					"172.28.0.1:38348"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:12:16.680850142Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3993055006255034,
+				"StableID":   "nPK3LUnTBY11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4483129363b3efe9d6e7f77e2c419993f6c93ac46886e2c65d66be7897d9945",
+				"DiscoKey":   "discokey:7aab69b601d715623f7faecd298d9d9c3ca661e48ff8e687a8fb956ea2721d3d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45745",
+					"10.65.0.27:45745",
+					"172.17.0.1:45745",
+					"172.18.0.1:45745",
+					"172.19.0.1:45745",
+					"172.20.0.1:45745",
+					"172.21.0.1:45745",
+					"172.22.0.1:45745",
+					"172.23.0.1:45745",
+					"172.24.0.1:45745",
+					"172.25.0.1:45745",
+					"172.26.0.1:45745",
+					"172.27.0.1:45745",
+					"172.28.0.1:45745"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:12:17.232728467Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         499258226074813,
+				"StableID":   "nkeuogf7u411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86de751b04e98f3f3e24662d954552ab27100bc4007cbd9d7fce7909bc653646",
+				"DiscoKey":   "discokey:2258666515a6c49fd642bd18313e7cd8c18c6ad3d66117a208110ffcd32f4518",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46872",
+					"10.65.0.27:46872",
+					"172.17.0.1:46872",
+					"172.18.0.1:46872",
+					"172.19.0.1:46872",
+					"172.20.0.1:46872",
+					"172.21.0.1:46872",
+					"172.22.0.1:46872",
+					"172.23.0.1:46872",
+					"172.24.0.1:46872",
+					"172.25.0.1:46872",
+					"172.26.0.1:46872",
+					"172.27.0.1:46872",
+					"172.28.0.1:46872"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:12:17.767226823Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5612001404879938,
+				"StableID":   "n5zgk7mgpk11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e078662eee1d237d130ec3464b5c8f01d12d4909933a8e5130d78d5b5acf6c4c",
+				"DiscoKey":   "discokey:d6267a1368efc7c7bd14582560ce0318075e69fbfe4479f5039e584e0457fc25",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56980",
+					"10.65.0.27:56980",
+					"172.17.0.1:56980",
+					"172.18.0.1:56980",
+					"172.19.0.1:56980",
+					"172.20.0.1:56980",
+					"172.21.0.1:56980",
+					"172.22.0.1:56980",
+					"172.23.0.1:56980",
+					"172.24.0.1:56980",
+					"172.25.0.1:56980",
+					"172.26.0.1:56980",
+					"172.27.0.1:56980",
+					"172.28.0.1:56980"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:12:18.319591263Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         239431495141524,
+				"StableID":   "n1ZCLeTSs211CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ac0dfaa903776a1252993dfedec0484f42538f85c55ffeaf608ab0ca7f21ad16",
+				"DiscoKey":   "discokey:5a1bf7676693f704282e50e85fbb55c89a73057d1db81615ae09c7d8f78b7374",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48599",
+					"10.65.0.27:48599",
+					"172.17.0.1:48599",
+					"172.18.0.1:48599",
+					"172.19.0.1:48599",
+					"172.20.0.1:48599",
+					"172.21.0.1:48599",
+					"172.22.0.1:48599",
+					"172.23.0.1:48599",
+					"172.24.0.1:48599",
+					"172.25.0.1:48599",
+					"172.26.0.1:48599",
+					"172.27.0.1:48599",
+					"172.28.0.1:48599"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:12:19.36713742Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6327755590799875,
+				"StableID":   "nncKBkQrQr11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5bc136530a7a3d8cd063e53488889156f0d776a1a568c506a4f535629ecaf814",
+				"KeyExpiry":  "2026-11-09T09:12:19Z",
+				"DiscoKey":   "discokey:804a065e484e011f2d8ee5627b209d7ddd6c9699e3f72744d5cfe887d2ed7857",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35110",
+					"10.65.0.27:35110",
+					"172.17.0.1:35110",
+					"172.18.0.1:35110",
+					"172.19.0.1:35110",
+					"172.20.0.1:35110",
+					"172.21.0.1:35110",
+					"172.22.0.1:35110",
+					"172.23.0.1:35110",
+					"172.24.0.1:35110",
+					"172.25.0.1:35110",
+					"172.26.0.1:35110",
+					"172.27.0.1:35110",
+					"172.28.0.1:35110"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:12:19.92157994Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         239211059311227,
+				"StableID":   "nG5xAofLs211CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:69a2e516bd0240aa24cb1aeeac3002b103f5b3b8b971f4a54b5977c4395a104f",
+				"KeyExpiry":  "2026-11-09T09:12:20Z",
+				"DiscoKey":   "discokey:b3678915cab02bc3cfde16542ab71daf35672432939d3e93a04c443f37f5295e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47307",
+					"10.65.0.27:47307",
+					"172.17.0.1:47307",
+					"172.18.0.1:47307",
+					"172.19.0.1:47307",
+					"172.20.0.1:47307",
+					"172.21.0.1:47307",
+					"172.22.0.1:47307",
+					"172.23.0.1:47307",
+					"172.24.0.1:47307",
+					"172.25.0.1:47307",
+					"172.26.0.1:47307",
+					"172.27.0.1:47307",
+					"172.28.0.1:47307"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:12:20.451669488Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         146478454007342,
+				"StableID":   "nVgYPxjL9211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dfcf396c81bf3904aef3622810e304cdd156b0d140bd2bc4ba1f4775d4dacb71",
+				"KeyExpiry":  "2026-11-09T09:12:21Z",
+				"DiscoKey":   "discokey:ed46f6e38c977c94ed2ebf24418b84a4637c8745555fca6bfb402082c6ef940a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36999",
+					"10.65.0.27:36999",
+					"172.17.0.1:36999",
+					"172.18.0.1:36999",
+					"172.19.0.1:36999",
+					"172.20.0.1:36999",
+					"172.21.0.1:36999",
+					"172.22.0.1:36999",
+					"172.23.0.1:36999",
+					"172.24.0.1:36999",
+					"172.25.0.1:36999",
+					"172.26.0.1:36999",
+					"172.27.0.1:36999",
+					"172.28.0.1:36999"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:12:21.006885452Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4715059007190742": {
+				"ID":          4715059007190742,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1136127687261480,
+				"StableID":   "n1djEa9Zs911CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1136127687261480,
+				"Key":        "nodekey:15c02f336a07c3ec0f1030c2c1c7f2e719ee6ea39579baa726d63dbd618cfc33",
+				"DiscoKey":   "discokey:5b64b686e272e958d2761ad35f7504aea2e767c49e482ead424839639b891274",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43492",
+					"10.65.0.27:43492",
+					"172.17.0.1:43492",
+					"172.18.0.1:43492",
+					"172.19.0.1:43492",
+					"172.20.0.1:43492",
+					"172.21.0.1:43492",
+					"172.22.0.1:43492",
+					"172.23.0.1:43492",
+					"172.24.0.1:43492",
+					"172.25.0.1:43492",
+					"172.26.0.1:43492",
+					"172.27.0.1:43492",
+					"172.28.0.1:43492"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:12:13.959144721Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:15c02f336a07c3ec0f1030c2c1c7f2e719ee6ea39579baa726d63dbd618cfc33",
+			"MachineKey": "mkey:45f60404494fe59092fafa665a5b603f1225e259be87883c6b00030fcc9bd813",
+			"Peers": [{
+				"ID":         6295043190505720,
+				"StableID":   "nR5BPP73Ar11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65bc1919c2b0271b65099b25733e8e937c9c25dcef10a78bf1439dfde8dc7c10",
+				"DiscoKey":   "discokey:b428fa4819b6410ef2c55a0589b735f3f8afdba37349adcf02b92510a3fa7e6b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51096",
+					"10.65.0.27:51096",
+					"172.17.0.1:51096",
+					"172.18.0.1:51096",
+					"172.19.0.1:51096",
+					"172.20.0.1:51096",
+					"172.21.0.1:51096",
+					"172.22.0.1:51096",
+					"172.23.0.1:51096",
+					"172.24.0.1:51096",
+					"172.25.0.1:51096",
+					"172.26.0.1:51096",
+					"172.27.0.1:51096",
+					"172.28.0.1:51096"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:12:13.451963393Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2547803460419977,
+				"StableID":   "nxGkFeUutL11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8343057cdbc9fd2178bc789bf1e86259d1747812264a6433e43bb5429efca076",
+				"DiscoKey":   "discokey:e47e67ee170c98bf4cd4c6affc8a7b721a9d07dc27a2dbcc02558d712482f42e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34838",
+					"10.65.0.27:34838",
+					"172.17.0.1:34838",
+					"172.18.0.1:34838",
+					"172.19.0.1:34838",
+					"172.20.0.1:34838",
+					"172.21.0.1:34838",
+					"172.22.0.1:34838",
+					"172.23.0.1:34838",
+					"172.24.0.1:34838",
+					"172.25.0.1:34838",
+					"172.26.0.1:34838",
+					"172.27.0.1:34838",
+					"172.28.0.1:34838"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:12:14.499294893Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7449375176885547,
+				"StableID":   "npKHCLTqA121CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6519d9431c7294cc474e2e8fc38bc615114d4e1c499aaf8aeaebdebb56650756",
+				"DiscoKey":   "discokey:956784a0e52ed592bf42657dc900851fba54255903d4e0b6c4899e224311d62a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39201",
+					"10.65.0.27:39201",
+					"172.17.0.1:39201",
+					"172.18.0.1:39201",
+					"172.19.0.1:39201",
+					"172.20.0.1:39201",
+					"172.21.0.1:39201",
+					"172.22.0.1:39201",
+					"172.23.0.1:39201",
+					"172.24.0.1:39201",
+					"172.25.0.1:39201",
+					"172.26.0.1:39201",
+					"172.27.0.1:39201",
+					"172.28.0.1:39201"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:12:15.047991044Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1896790269306614,
+				"StableID":   "nTF3ruT4pF11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb460ef87abc28392030ffaed9a90acb13d737f7d4e2afd3c5cf30c9d8d6ce25",
+				"DiscoKey":   "discokey:a34c729de869d75828aeecc4024dc1476a2472e95393add1da74cb4e1dcbd649",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49922",
+					"10.65.0.27:49922",
+					"172.17.0.1:49922",
+					"172.18.0.1:49922",
+					"172.19.0.1:49922",
+					"172.20.0.1:49922",
+					"172.21.0.1:49922",
+					"172.22.0.1:49922",
+					"172.23.0.1:49922",
+					"172.24.0.1:49922",
+					"172.25.0.1:49922",
+					"172.26.0.1:49922",
+					"172.27.0.1:49922",
+					"172.28.0.1:49922"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:12:15.612155909Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5441526217295054,
+				"StableID":   "nuL6CffUVj11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1412aa2d544b885ebfa6f5bf07d9916a2852336d6465b60a685669734b56c75a",
+				"DiscoKey":   "discokey:4c4cb78776a0e12809d426e51ce1b9d152283d9877ebc17356a54c531f75f90a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46088",
+					"10.65.0.27:46088",
+					"172.17.0.1:46088",
+					"172.18.0.1:46088",
+					"172.19.0.1:46088",
+					"172.20.0.1:46088",
+					"172.21.0.1:46088",
+					"172.22.0.1:46088",
+					"172.23.0.1:46088",
+					"172.24.0.1:46088",
+					"172.25.0.1:46088",
+					"172.26.0.1:46088",
+					"172.27.0.1:46088",
+					"172.28.0.1:46088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:12:16.125093181Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6714736858617273,
+				"StableID":   "ngpGfZk7Su11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c7911d74f6a95c41cfbdc25933cda62584b81a423180a178c93e514cfecd5c6e",
+				"DiscoKey":   "discokey:53a1da3164b465eaa28141e7748a014dc2882e2ac8a8ade0c10cc2e1b81f642b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38348",
+					"10.65.0.27:38348",
+					"172.17.0.1:38348",
+					"172.18.0.1:38348",
+					"172.19.0.1:38348",
+					"172.20.0.1:38348",
+					"172.21.0.1:38348",
+					"172.22.0.1:38348",
+					"172.23.0.1:38348",
+					"172.24.0.1:38348",
+					"172.25.0.1:38348",
+					"172.26.0.1:38348",
+					"172.27.0.1:38348",
+					"172.28.0.1:38348"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:12:16.680850142Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3993055006255034,
+				"StableID":   "nPK3LUnTBY11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4483129363b3efe9d6e7f77e2c419993f6c93ac46886e2c65d66be7897d9945",
+				"DiscoKey":   "discokey:7aab69b601d715623f7faecd298d9d9c3ca661e48ff8e687a8fb956ea2721d3d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45745",
+					"10.65.0.27:45745",
+					"172.17.0.1:45745",
+					"172.18.0.1:45745",
+					"172.19.0.1:45745",
+					"172.20.0.1:45745",
+					"172.21.0.1:45745",
+					"172.22.0.1:45745",
+					"172.23.0.1:45745",
+					"172.24.0.1:45745",
+					"172.25.0.1:45745",
+					"172.26.0.1:45745",
+					"172.27.0.1:45745",
+					"172.28.0.1:45745"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:12:17.232728467Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         499258226074813,
+				"StableID":   "nkeuogf7u411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86de751b04e98f3f3e24662d954552ab27100bc4007cbd9d7fce7909bc653646",
+				"DiscoKey":   "discokey:2258666515a6c49fd642bd18313e7cd8c18c6ad3d66117a208110ffcd32f4518",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46872",
+					"10.65.0.27:46872",
+					"172.17.0.1:46872",
+					"172.18.0.1:46872",
+					"172.19.0.1:46872",
+					"172.20.0.1:46872",
+					"172.21.0.1:46872",
+					"172.22.0.1:46872",
+					"172.23.0.1:46872",
+					"172.24.0.1:46872",
+					"172.25.0.1:46872",
+					"172.26.0.1:46872",
+					"172.27.0.1:46872",
+					"172.28.0.1:46872"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:12:17.767226823Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5612001404879938,
+				"StableID":   "n5zgk7mgpk11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e078662eee1d237d130ec3464b5c8f01d12d4909933a8e5130d78d5b5acf6c4c",
+				"DiscoKey":   "discokey:d6267a1368efc7c7bd14582560ce0318075e69fbfe4479f5039e584e0457fc25",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56980",
+					"10.65.0.27:56980",
+					"172.17.0.1:56980",
+					"172.18.0.1:56980",
+					"172.19.0.1:56980",
+					"172.20.0.1:56980",
+					"172.21.0.1:56980",
+					"172.22.0.1:56980",
+					"172.23.0.1:56980",
+					"172.24.0.1:56980",
+					"172.25.0.1:56980",
+					"172.26.0.1:56980",
+					"172.27.0.1:56980",
+					"172.28.0.1:56980"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:12:18.319591263Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4715059007190742,
+				"StableID":   "nVrFW5cTpd11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5c974ab3854ff917eff17a52db4bef59f55bbc38aff6c0ce67baa68ee66fe2b",
+				"DiscoKey":   "discokey:7179a468c9cf2ba6142561fddefcb48f77d50806b6f3357c1c366b009d14911a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42733",
+					"10.65.0.27:42733",
+					"172.17.0.1:42733",
+					"172.18.0.1:42733",
+					"172.19.0.1:42733",
+					"172.20.0.1:42733",
+					"172.21.0.1:42733",
+					"172.22.0.1:42733",
+					"172.23.0.1:42733",
+					"172.24.0.1:42733",
+					"172.25.0.1:42733",
+					"172.26.0.1:42733",
+					"172.27.0.1:42733",
+					"172.28.0.1:42733"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:12:18.808278656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         239431495141524,
+				"StableID":   "n1ZCLeTSs211CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ac0dfaa903776a1252993dfedec0484f42538f85c55ffeaf608ab0ca7f21ad16",
+				"DiscoKey":   "discokey:5a1bf7676693f704282e50e85fbb55c89a73057d1db81615ae09c7d8f78b7374",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48599",
+					"10.65.0.27:48599",
+					"172.17.0.1:48599",
+					"172.18.0.1:48599",
+					"172.19.0.1:48599",
+					"172.20.0.1:48599",
+					"172.21.0.1:48599",
+					"172.22.0.1:48599",
+					"172.23.0.1:48599",
+					"172.24.0.1:48599",
+					"172.25.0.1:48599",
+					"172.26.0.1:48599",
+					"172.27.0.1:48599",
+					"172.28.0.1:48599"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:12:19.36713742Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6327755590799875,
+				"StableID":   "nncKBkQrQr11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5bc136530a7a3d8cd063e53488889156f0d776a1a568c506a4f535629ecaf814",
+				"KeyExpiry":  "2026-11-09T09:12:19Z",
+				"DiscoKey":   "discokey:804a065e484e011f2d8ee5627b209d7ddd6c9699e3f72744d5cfe887d2ed7857",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35110",
+					"10.65.0.27:35110",
+					"172.17.0.1:35110",
+					"172.18.0.1:35110",
+					"172.19.0.1:35110",
+					"172.20.0.1:35110",
+					"172.21.0.1:35110",
+					"172.22.0.1:35110",
+					"172.23.0.1:35110",
+					"172.24.0.1:35110",
+					"172.25.0.1:35110",
+					"172.26.0.1:35110",
+					"172.27.0.1:35110",
+					"172.28.0.1:35110"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:12:19.92157994Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         239211059311227,
+				"StableID":   "nG5xAofLs211CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:69a2e516bd0240aa24cb1aeeac3002b103f5b3b8b971f4a54b5977c4395a104f",
+				"KeyExpiry":  "2026-11-09T09:12:20Z",
+				"DiscoKey":   "discokey:b3678915cab02bc3cfde16542ab71daf35672432939d3e93a04c443f37f5295e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47307",
+					"10.65.0.27:47307",
+					"172.17.0.1:47307",
+					"172.18.0.1:47307",
+					"172.19.0.1:47307",
+					"172.20.0.1:47307",
+					"172.21.0.1:47307",
+					"172.22.0.1:47307",
+					"172.23.0.1:47307",
+					"172.24.0.1:47307",
+					"172.25.0.1:47307",
+					"172.26.0.1:47307",
+					"172.27.0.1:47307",
+					"172.28.0.1:47307"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:12:20.451669488Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         146478454007342,
+				"StableID":   "nVgYPxjL9211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dfcf396c81bf3904aef3622810e304cdd156b0d140bd2bc4ba1f4775d4dacb71",
+				"KeyExpiry":  "2026-11-09T09:12:21Z",
+				"DiscoKey":   "discokey:ed46f6e38c977c94ed2ebf24418b84a4637c8745555fca6bfb402082c6ef940a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36999",
+					"10.65.0.27:36999",
+					"172.17.0.1:36999",
+					"172.18.0.1:36999",
+					"172.19.0.1:36999",
+					"172.20.0.1:36999",
+					"172.21.0.1:36999",
+					"172.22.0.1:36999",
+					"172.23.0.1:36999",
+					"172.24.0.1:36999",
+					"172.25.0.1:36999",
+					"172.26.0.1:36999",
+					"172.27.0.1:36999",
+					"172.28.0.1:36999"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:12:21.006885452Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1136127687261480": {
+				"ID":          1136127687261480,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6295043190505720,
+				"StableID":   "nR5BPP73Ar11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       6295043190505720,
+				"Key":        "nodekey:65bc1919c2b0271b65099b25733e8e937c9c25dcef10a78bf1439dfde8dc7c10",
+				"DiscoKey":   "discokey:b428fa4819b6410ef2c55a0589b735f3f8afdba37349adcf02b92510a3fa7e6b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51096",
+					"10.65.0.27:51096",
+					"172.17.0.1:51096",
+					"172.18.0.1:51096",
+					"172.19.0.1:51096",
+					"172.20.0.1:51096",
+					"172.21.0.1:51096",
+					"172.22.0.1:51096",
+					"172.23.0.1:51096",
+					"172.24.0.1:51096",
+					"172.25.0.1:51096",
+					"172.26.0.1:51096",
+					"172.27.0.1:51096",
+					"172.28.0.1:51096"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:12:13.451963393Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:65bc1919c2b0271b65099b25733e8e937c9c25dcef10a78bf1439dfde8dc7c10",
+			"MachineKey": "mkey:40944a8eaff0c976dc33819f9ff7524a1d36a08fd6fb0ec0968dc22a2f302d71",
+			"Peers": [{
+				"ID":         1136127687261480,
+				"StableID":   "n1djEa9Zs911CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15c02f336a07c3ec0f1030c2c1c7f2e719ee6ea39579baa726d63dbd618cfc33",
+				"DiscoKey":   "discokey:5b64b686e272e958d2761ad35f7504aea2e767c49e482ead424839639b891274",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43492",
+					"10.65.0.27:43492",
+					"172.17.0.1:43492",
+					"172.18.0.1:43492",
+					"172.19.0.1:43492",
+					"172.20.0.1:43492",
+					"172.21.0.1:43492",
+					"172.22.0.1:43492",
+					"172.23.0.1:43492",
+					"172.24.0.1:43492",
+					"172.25.0.1:43492",
+					"172.26.0.1:43492",
+					"172.27.0.1:43492",
+					"172.28.0.1:43492"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:12:13.959144721Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2547803460419977,
+				"StableID":   "nxGkFeUutL11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8343057cdbc9fd2178bc789bf1e86259d1747812264a6433e43bb5429efca076",
+				"DiscoKey":   "discokey:e47e67ee170c98bf4cd4c6affc8a7b721a9d07dc27a2dbcc02558d712482f42e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34838",
+					"10.65.0.27:34838",
+					"172.17.0.1:34838",
+					"172.18.0.1:34838",
+					"172.19.0.1:34838",
+					"172.20.0.1:34838",
+					"172.21.0.1:34838",
+					"172.22.0.1:34838",
+					"172.23.0.1:34838",
+					"172.24.0.1:34838",
+					"172.25.0.1:34838",
+					"172.26.0.1:34838",
+					"172.27.0.1:34838",
+					"172.28.0.1:34838"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:12:14.499294893Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7449375176885547,
+				"StableID":   "npKHCLTqA121CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6519d9431c7294cc474e2e8fc38bc615114d4e1c499aaf8aeaebdebb56650756",
+				"DiscoKey":   "discokey:956784a0e52ed592bf42657dc900851fba54255903d4e0b6c4899e224311d62a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39201",
+					"10.65.0.27:39201",
+					"172.17.0.1:39201",
+					"172.18.0.1:39201",
+					"172.19.0.1:39201",
+					"172.20.0.1:39201",
+					"172.21.0.1:39201",
+					"172.22.0.1:39201",
+					"172.23.0.1:39201",
+					"172.24.0.1:39201",
+					"172.25.0.1:39201",
+					"172.26.0.1:39201",
+					"172.27.0.1:39201",
+					"172.28.0.1:39201"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:12:15.047991044Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1896790269306614,
+				"StableID":   "nTF3ruT4pF11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb460ef87abc28392030ffaed9a90acb13d737f7d4e2afd3c5cf30c9d8d6ce25",
+				"DiscoKey":   "discokey:a34c729de869d75828aeecc4024dc1476a2472e95393add1da74cb4e1dcbd649",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49922",
+					"10.65.0.27:49922",
+					"172.17.0.1:49922",
+					"172.18.0.1:49922",
+					"172.19.0.1:49922",
+					"172.20.0.1:49922",
+					"172.21.0.1:49922",
+					"172.22.0.1:49922",
+					"172.23.0.1:49922",
+					"172.24.0.1:49922",
+					"172.25.0.1:49922",
+					"172.26.0.1:49922",
+					"172.27.0.1:49922",
+					"172.28.0.1:49922"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:12:15.612155909Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5441526217295054,
+				"StableID":   "nuL6CffUVj11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1412aa2d544b885ebfa6f5bf07d9916a2852336d6465b60a685669734b56c75a",
+				"DiscoKey":   "discokey:4c4cb78776a0e12809d426e51ce1b9d152283d9877ebc17356a54c531f75f90a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46088",
+					"10.65.0.27:46088",
+					"172.17.0.1:46088",
+					"172.18.0.1:46088",
+					"172.19.0.1:46088",
+					"172.20.0.1:46088",
+					"172.21.0.1:46088",
+					"172.22.0.1:46088",
+					"172.23.0.1:46088",
+					"172.24.0.1:46088",
+					"172.25.0.1:46088",
+					"172.26.0.1:46088",
+					"172.27.0.1:46088",
+					"172.28.0.1:46088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:12:16.125093181Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6714736858617273,
+				"StableID":   "ngpGfZk7Su11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c7911d74f6a95c41cfbdc25933cda62584b81a423180a178c93e514cfecd5c6e",
+				"DiscoKey":   "discokey:53a1da3164b465eaa28141e7748a014dc2882e2ac8a8ade0c10cc2e1b81f642b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38348",
+					"10.65.0.27:38348",
+					"172.17.0.1:38348",
+					"172.18.0.1:38348",
+					"172.19.0.1:38348",
+					"172.20.0.1:38348",
+					"172.21.0.1:38348",
+					"172.22.0.1:38348",
+					"172.23.0.1:38348",
+					"172.24.0.1:38348",
+					"172.25.0.1:38348",
+					"172.26.0.1:38348",
+					"172.27.0.1:38348",
+					"172.28.0.1:38348"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:12:16.680850142Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3993055006255034,
+				"StableID":   "nPK3LUnTBY11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4483129363b3efe9d6e7f77e2c419993f6c93ac46886e2c65d66be7897d9945",
+				"DiscoKey":   "discokey:7aab69b601d715623f7faecd298d9d9c3ca661e48ff8e687a8fb956ea2721d3d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45745",
+					"10.65.0.27:45745",
+					"172.17.0.1:45745",
+					"172.18.0.1:45745",
+					"172.19.0.1:45745",
+					"172.20.0.1:45745",
+					"172.21.0.1:45745",
+					"172.22.0.1:45745",
+					"172.23.0.1:45745",
+					"172.24.0.1:45745",
+					"172.25.0.1:45745",
+					"172.26.0.1:45745",
+					"172.27.0.1:45745",
+					"172.28.0.1:45745"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:12:17.232728467Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         499258226074813,
+				"StableID":   "nkeuogf7u411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86de751b04e98f3f3e24662d954552ab27100bc4007cbd9d7fce7909bc653646",
+				"DiscoKey":   "discokey:2258666515a6c49fd642bd18313e7cd8c18c6ad3d66117a208110ffcd32f4518",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46872",
+					"10.65.0.27:46872",
+					"172.17.0.1:46872",
+					"172.18.0.1:46872",
+					"172.19.0.1:46872",
+					"172.20.0.1:46872",
+					"172.21.0.1:46872",
+					"172.22.0.1:46872",
+					"172.23.0.1:46872",
+					"172.24.0.1:46872",
+					"172.25.0.1:46872",
+					"172.26.0.1:46872",
+					"172.27.0.1:46872",
+					"172.28.0.1:46872"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:12:17.767226823Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5612001404879938,
+				"StableID":   "n5zgk7mgpk11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e078662eee1d237d130ec3464b5c8f01d12d4909933a8e5130d78d5b5acf6c4c",
+				"DiscoKey":   "discokey:d6267a1368efc7c7bd14582560ce0318075e69fbfe4479f5039e584e0457fc25",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56980",
+					"10.65.0.27:56980",
+					"172.17.0.1:56980",
+					"172.18.0.1:56980",
+					"172.19.0.1:56980",
+					"172.20.0.1:56980",
+					"172.21.0.1:56980",
+					"172.22.0.1:56980",
+					"172.23.0.1:56980",
+					"172.24.0.1:56980",
+					"172.25.0.1:56980",
+					"172.26.0.1:56980",
+					"172.27.0.1:56980",
+					"172.28.0.1:56980"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:12:18.319591263Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4715059007190742,
+				"StableID":   "nVrFW5cTpd11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5c974ab3854ff917eff17a52db4bef59f55bbc38aff6c0ce67baa68ee66fe2b",
+				"DiscoKey":   "discokey:7179a468c9cf2ba6142561fddefcb48f77d50806b6f3357c1c366b009d14911a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42733",
+					"10.65.0.27:42733",
+					"172.17.0.1:42733",
+					"172.18.0.1:42733",
+					"172.19.0.1:42733",
+					"172.20.0.1:42733",
+					"172.21.0.1:42733",
+					"172.22.0.1:42733",
+					"172.23.0.1:42733",
+					"172.24.0.1:42733",
+					"172.25.0.1:42733",
+					"172.26.0.1:42733",
+					"172.27.0.1:42733",
+					"172.28.0.1:42733"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:12:18.808278656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         239431495141524,
+				"StableID":   "n1ZCLeTSs211CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ac0dfaa903776a1252993dfedec0484f42538f85c55ffeaf608ab0ca7f21ad16",
+				"DiscoKey":   "discokey:5a1bf7676693f704282e50e85fbb55c89a73057d1db81615ae09c7d8f78b7374",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48599",
+					"10.65.0.27:48599",
+					"172.17.0.1:48599",
+					"172.18.0.1:48599",
+					"172.19.0.1:48599",
+					"172.20.0.1:48599",
+					"172.21.0.1:48599",
+					"172.22.0.1:48599",
+					"172.23.0.1:48599",
+					"172.24.0.1:48599",
+					"172.25.0.1:48599",
+					"172.26.0.1:48599",
+					"172.27.0.1:48599",
+					"172.28.0.1:48599"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:12:19.36713742Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6327755590799875,
+				"StableID":   "nncKBkQrQr11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5bc136530a7a3d8cd063e53488889156f0d776a1a568c506a4f535629ecaf814",
+				"KeyExpiry":  "2026-11-09T09:12:19Z",
+				"DiscoKey":   "discokey:804a065e484e011f2d8ee5627b209d7ddd6c9699e3f72744d5cfe887d2ed7857",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35110",
+					"10.65.0.27:35110",
+					"172.17.0.1:35110",
+					"172.18.0.1:35110",
+					"172.19.0.1:35110",
+					"172.20.0.1:35110",
+					"172.21.0.1:35110",
+					"172.22.0.1:35110",
+					"172.23.0.1:35110",
+					"172.24.0.1:35110",
+					"172.25.0.1:35110",
+					"172.26.0.1:35110",
+					"172.27.0.1:35110",
+					"172.28.0.1:35110"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:12:19.92157994Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         239211059311227,
+				"StableID":   "nG5xAofLs211CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:69a2e516bd0240aa24cb1aeeac3002b103f5b3b8b971f4a54b5977c4395a104f",
+				"KeyExpiry":  "2026-11-09T09:12:20Z",
+				"DiscoKey":   "discokey:b3678915cab02bc3cfde16542ab71daf35672432939d3e93a04c443f37f5295e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47307",
+					"10.65.0.27:47307",
+					"172.17.0.1:47307",
+					"172.18.0.1:47307",
+					"172.19.0.1:47307",
+					"172.20.0.1:47307",
+					"172.21.0.1:47307",
+					"172.22.0.1:47307",
+					"172.23.0.1:47307",
+					"172.24.0.1:47307",
+					"172.25.0.1:47307",
+					"172.26.0.1:47307",
+					"172.27.0.1:47307",
+					"172.28.0.1:47307"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:12:20.451669488Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         146478454007342,
+				"StableID":   "nVgYPxjL9211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dfcf396c81bf3904aef3622810e304cdd156b0d140bd2bc4ba1f4775d4dacb71",
+				"KeyExpiry":  "2026-11-09T09:12:21Z",
+				"DiscoKey":   "discokey:ed46f6e38c977c94ed2ebf24418b84a4637c8745555fca6bfb402082c6ef940a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36999",
+					"10.65.0.27:36999",
+					"172.17.0.1:36999",
+					"172.18.0.1:36999",
+					"172.19.0.1:36999",
+					"172.20.0.1:36999",
+					"172.21.0.1:36999",
+					"172.22.0.1:36999",
+					"172.23.0.1:36999",
+					"172.24.0.1:36999",
+					"172.25.0.1:36999",
+					"172.26.0.1:36999",
+					"172.27.0.1:36999",
+					"172.28.0.1:36999"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:12:21.006885452Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6295043190505720": {
+				"ID":          6295043190505720,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1896790269306614,
+				"StableID":   "nTF3ruT4pF11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1896790269306614,
+				"Key":        "nodekey:fb460ef87abc28392030ffaed9a90acb13d737f7d4e2afd3c5cf30c9d8d6ce25",
+				"DiscoKey":   "discokey:a34c729de869d75828aeecc4024dc1476a2472e95393add1da74cb4e1dcbd649",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49922",
+					"10.65.0.27:49922",
+					"172.17.0.1:49922",
+					"172.18.0.1:49922",
+					"172.19.0.1:49922",
+					"172.20.0.1:49922",
+					"172.21.0.1:49922",
+					"172.22.0.1:49922",
+					"172.23.0.1:49922",
+					"172.24.0.1:49922",
+					"172.25.0.1:49922",
+					"172.26.0.1:49922",
+					"172.27.0.1:49922",
+					"172.28.0.1:49922"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:12:15.612155909Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:fb460ef87abc28392030ffaed9a90acb13d737f7d4e2afd3c5cf30c9d8d6ce25",
+			"MachineKey": "mkey:94e2482318465710a0057b5a6927cb589f99d15f0170e6728f29db70cb23e97f",
+			"Peers": [{
+				"ID":         6295043190505720,
+				"StableID":   "nR5BPP73Ar11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65bc1919c2b0271b65099b25733e8e937c9c25dcef10a78bf1439dfde8dc7c10",
+				"DiscoKey":   "discokey:b428fa4819b6410ef2c55a0589b735f3f8afdba37349adcf02b92510a3fa7e6b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51096",
+					"10.65.0.27:51096",
+					"172.17.0.1:51096",
+					"172.18.0.1:51096",
+					"172.19.0.1:51096",
+					"172.20.0.1:51096",
+					"172.21.0.1:51096",
+					"172.22.0.1:51096",
+					"172.23.0.1:51096",
+					"172.24.0.1:51096",
+					"172.25.0.1:51096",
+					"172.26.0.1:51096",
+					"172.27.0.1:51096",
+					"172.28.0.1:51096"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:12:13.451963393Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1136127687261480,
+				"StableID":   "n1djEa9Zs911CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15c02f336a07c3ec0f1030c2c1c7f2e719ee6ea39579baa726d63dbd618cfc33",
+				"DiscoKey":   "discokey:5b64b686e272e958d2761ad35f7504aea2e767c49e482ead424839639b891274",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43492",
+					"10.65.0.27:43492",
+					"172.17.0.1:43492",
+					"172.18.0.1:43492",
+					"172.19.0.1:43492",
+					"172.20.0.1:43492",
+					"172.21.0.1:43492",
+					"172.22.0.1:43492",
+					"172.23.0.1:43492",
+					"172.24.0.1:43492",
+					"172.25.0.1:43492",
+					"172.26.0.1:43492",
+					"172.27.0.1:43492",
+					"172.28.0.1:43492"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:12:13.959144721Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2547803460419977,
+				"StableID":   "nxGkFeUutL11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8343057cdbc9fd2178bc789bf1e86259d1747812264a6433e43bb5429efca076",
+				"DiscoKey":   "discokey:e47e67ee170c98bf4cd4c6affc8a7b721a9d07dc27a2dbcc02558d712482f42e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34838",
+					"10.65.0.27:34838",
+					"172.17.0.1:34838",
+					"172.18.0.1:34838",
+					"172.19.0.1:34838",
+					"172.20.0.1:34838",
+					"172.21.0.1:34838",
+					"172.22.0.1:34838",
+					"172.23.0.1:34838",
+					"172.24.0.1:34838",
+					"172.25.0.1:34838",
+					"172.26.0.1:34838",
+					"172.27.0.1:34838",
+					"172.28.0.1:34838"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:12:14.499294893Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7449375176885547,
+				"StableID":   "npKHCLTqA121CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6519d9431c7294cc474e2e8fc38bc615114d4e1c499aaf8aeaebdebb56650756",
+				"DiscoKey":   "discokey:956784a0e52ed592bf42657dc900851fba54255903d4e0b6c4899e224311d62a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39201",
+					"10.65.0.27:39201",
+					"172.17.0.1:39201",
+					"172.18.0.1:39201",
+					"172.19.0.1:39201",
+					"172.20.0.1:39201",
+					"172.21.0.1:39201",
+					"172.22.0.1:39201",
+					"172.23.0.1:39201",
+					"172.24.0.1:39201",
+					"172.25.0.1:39201",
+					"172.26.0.1:39201",
+					"172.27.0.1:39201",
+					"172.28.0.1:39201"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:12:15.047991044Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5441526217295054,
+				"StableID":   "nuL6CffUVj11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1412aa2d544b885ebfa6f5bf07d9916a2852336d6465b60a685669734b56c75a",
+				"DiscoKey":   "discokey:4c4cb78776a0e12809d426e51ce1b9d152283d9877ebc17356a54c531f75f90a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46088",
+					"10.65.0.27:46088",
+					"172.17.0.1:46088",
+					"172.18.0.1:46088",
+					"172.19.0.1:46088",
+					"172.20.0.1:46088",
+					"172.21.0.1:46088",
+					"172.22.0.1:46088",
+					"172.23.0.1:46088",
+					"172.24.0.1:46088",
+					"172.25.0.1:46088",
+					"172.26.0.1:46088",
+					"172.27.0.1:46088",
+					"172.28.0.1:46088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:12:16.125093181Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6714736858617273,
+				"StableID":   "ngpGfZk7Su11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c7911d74f6a95c41cfbdc25933cda62584b81a423180a178c93e514cfecd5c6e",
+				"DiscoKey":   "discokey:53a1da3164b465eaa28141e7748a014dc2882e2ac8a8ade0c10cc2e1b81f642b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38348",
+					"10.65.0.27:38348",
+					"172.17.0.1:38348",
+					"172.18.0.1:38348",
+					"172.19.0.1:38348",
+					"172.20.0.1:38348",
+					"172.21.0.1:38348",
+					"172.22.0.1:38348",
+					"172.23.0.1:38348",
+					"172.24.0.1:38348",
+					"172.25.0.1:38348",
+					"172.26.0.1:38348",
+					"172.27.0.1:38348",
+					"172.28.0.1:38348"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:12:16.680850142Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3993055006255034,
+				"StableID":   "nPK3LUnTBY11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4483129363b3efe9d6e7f77e2c419993f6c93ac46886e2c65d66be7897d9945",
+				"DiscoKey":   "discokey:7aab69b601d715623f7faecd298d9d9c3ca661e48ff8e687a8fb956ea2721d3d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45745",
+					"10.65.0.27:45745",
+					"172.17.0.1:45745",
+					"172.18.0.1:45745",
+					"172.19.0.1:45745",
+					"172.20.0.1:45745",
+					"172.21.0.1:45745",
+					"172.22.0.1:45745",
+					"172.23.0.1:45745",
+					"172.24.0.1:45745",
+					"172.25.0.1:45745",
+					"172.26.0.1:45745",
+					"172.27.0.1:45745",
+					"172.28.0.1:45745"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:12:17.232728467Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         499258226074813,
+				"StableID":   "nkeuogf7u411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86de751b04e98f3f3e24662d954552ab27100bc4007cbd9d7fce7909bc653646",
+				"DiscoKey":   "discokey:2258666515a6c49fd642bd18313e7cd8c18c6ad3d66117a208110ffcd32f4518",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46872",
+					"10.65.0.27:46872",
+					"172.17.0.1:46872",
+					"172.18.0.1:46872",
+					"172.19.0.1:46872",
+					"172.20.0.1:46872",
+					"172.21.0.1:46872",
+					"172.22.0.1:46872",
+					"172.23.0.1:46872",
+					"172.24.0.1:46872",
+					"172.25.0.1:46872",
+					"172.26.0.1:46872",
+					"172.27.0.1:46872",
+					"172.28.0.1:46872"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:12:17.767226823Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5612001404879938,
+				"StableID":   "n5zgk7mgpk11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e078662eee1d237d130ec3464b5c8f01d12d4909933a8e5130d78d5b5acf6c4c",
+				"DiscoKey":   "discokey:d6267a1368efc7c7bd14582560ce0318075e69fbfe4479f5039e584e0457fc25",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56980",
+					"10.65.0.27:56980",
+					"172.17.0.1:56980",
+					"172.18.0.1:56980",
+					"172.19.0.1:56980",
+					"172.20.0.1:56980",
+					"172.21.0.1:56980",
+					"172.22.0.1:56980",
+					"172.23.0.1:56980",
+					"172.24.0.1:56980",
+					"172.25.0.1:56980",
+					"172.26.0.1:56980",
+					"172.27.0.1:56980",
+					"172.28.0.1:56980"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:12:18.319591263Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4715059007190742,
+				"StableID":   "nVrFW5cTpd11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5c974ab3854ff917eff17a52db4bef59f55bbc38aff6c0ce67baa68ee66fe2b",
+				"DiscoKey":   "discokey:7179a468c9cf2ba6142561fddefcb48f77d50806b6f3357c1c366b009d14911a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42733",
+					"10.65.0.27:42733",
+					"172.17.0.1:42733",
+					"172.18.0.1:42733",
+					"172.19.0.1:42733",
+					"172.20.0.1:42733",
+					"172.21.0.1:42733",
+					"172.22.0.1:42733",
+					"172.23.0.1:42733",
+					"172.24.0.1:42733",
+					"172.25.0.1:42733",
+					"172.26.0.1:42733",
+					"172.27.0.1:42733",
+					"172.28.0.1:42733"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:12:18.808278656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         239431495141524,
+				"StableID":   "n1ZCLeTSs211CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ac0dfaa903776a1252993dfedec0484f42538f85c55ffeaf608ab0ca7f21ad16",
+				"DiscoKey":   "discokey:5a1bf7676693f704282e50e85fbb55c89a73057d1db81615ae09c7d8f78b7374",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48599",
+					"10.65.0.27:48599",
+					"172.17.0.1:48599",
+					"172.18.0.1:48599",
+					"172.19.0.1:48599",
+					"172.20.0.1:48599",
+					"172.21.0.1:48599",
+					"172.22.0.1:48599",
+					"172.23.0.1:48599",
+					"172.24.0.1:48599",
+					"172.25.0.1:48599",
+					"172.26.0.1:48599",
+					"172.27.0.1:48599",
+					"172.28.0.1:48599"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:12:19.36713742Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6327755590799875,
+				"StableID":   "nncKBkQrQr11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5bc136530a7a3d8cd063e53488889156f0d776a1a568c506a4f535629ecaf814",
+				"KeyExpiry":  "2026-11-09T09:12:19Z",
+				"DiscoKey":   "discokey:804a065e484e011f2d8ee5627b209d7ddd6c9699e3f72744d5cfe887d2ed7857",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35110",
+					"10.65.0.27:35110",
+					"172.17.0.1:35110",
+					"172.18.0.1:35110",
+					"172.19.0.1:35110",
+					"172.20.0.1:35110",
+					"172.21.0.1:35110",
+					"172.22.0.1:35110",
+					"172.23.0.1:35110",
+					"172.24.0.1:35110",
+					"172.25.0.1:35110",
+					"172.26.0.1:35110",
+					"172.27.0.1:35110",
+					"172.28.0.1:35110"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:12:19.92157994Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         239211059311227,
+				"StableID":   "nG5xAofLs211CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:69a2e516bd0240aa24cb1aeeac3002b103f5b3b8b971f4a54b5977c4395a104f",
+				"KeyExpiry":  "2026-11-09T09:12:20Z",
+				"DiscoKey":   "discokey:b3678915cab02bc3cfde16542ab71daf35672432939d3e93a04c443f37f5295e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47307",
+					"10.65.0.27:47307",
+					"172.17.0.1:47307",
+					"172.18.0.1:47307",
+					"172.19.0.1:47307",
+					"172.20.0.1:47307",
+					"172.21.0.1:47307",
+					"172.22.0.1:47307",
+					"172.23.0.1:47307",
+					"172.24.0.1:47307",
+					"172.25.0.1:47307",
+					"172.26.0.1:47307",
+					"172.27.0.1:47307",
+					"172.28.0.1:47307"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:12:20.451669488Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         146478454007342,
+				"StableID":   "nVgYPxjL9211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dfcf396c81bf3904aef3622810e304cdd156b0d140bd2bc4ba1f4775d4dacb71",
+				"KeyExpiry":  "2026-11-09T09:12:21Z",
+				"DiscoKey":   "discokey:ed46f6e38c977c94ed2ebf24418b84a4637c8745555fca6bfb402082c6ef940a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36999",
+					"10.65.0.27:36999",
+					"172.17.0.1:36999",
+					"172.18.0.1:36999",
+					"172.19.0.1:36999",
+					"172.20.0.1:36999",
+					"172.21.0.1:36999",
+					"172.22.0.1:36999",
+					"172.23.0.1:36999",
+					"172.24.0.1:36999",
+					"172.25.0.1:36999",
+					"172.26.0.1:36999",
+					"172.27.0.1:36999",
+					"172.28.0.1:36999"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:12:21.006885452Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1896790269306614": {
+				"ID":          1896790269306614,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7449375176885547,
+				"StableID":   "npKHCLTqA121CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       7449375176885547,
+				"Key":        "nodekey:6519d9431c7294cc474e2e8fc38bc615114d4e1c499aaf8aeaebdebb56650756",
+				"DiscoKey":   "discokey:956784a0e52ed592bf42657dc900851fba54255903d4e0b6c4899e224311d62a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39201",
+					"10.65.0.27:39201",
+					"172.17.0.1:39201",
+					"172.18.0.1:39201",
+					"172.19.0.1:39201",
+					"172.20.0.1:39201",
+					"172.21.0.1:39201",
+					"172.22.0.1:39201",
+					"172.23.0.1:39201",
+					"172.24.0.1:39201",
+					"172.25.0.1:39201",
+					"172.26.0.1:39201",
+					"172.27.0.1:39201",
+					"172.28.0.1:39201"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:12:15.047991044Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6519d9431c7294cc474e2e8fc38bc615114d4e1c499aaf8aeaebdebb56650756",
+			"MachineKey": "mkey:d33b8fa70bd6d69a8c4a7c055a4f2441c889b3c497528d329e5207151bb03f26",
+			"Peers": [{
+				"ID":         6295043190505720,
+				"StableID":   "nR5BPP73Ar11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65bc1919c2b0271b65099b25733e8e937c9c25dcef10a78bf1439dfde8dc7c10",
+				"DiscoKey":   "discokey:b428fa4819b6410ef2c55a0589b735f3f8afdba37349adcf02b92510a3fa7e6b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51096",
+					"10.65.0.27:51096",
+					"172.17.0.1:51096",
+					"172.18.0.1:51096",
+					"172.19.0.1:51096",
+					"172.20.0.1:51096",
+					"172.21.0.1:51096",
+					"172.22.0.1:51096",
+					"172.23.0.1:51096",
+					"172.24.0.1:51096",
+					"172.25.0.1:51096",
+					"172.26.0.1:51096",
+					"172.27.0.1:51096",
+					"172.28.0.1:51096"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:12:13.451963393Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1136127687261480,
+				"StableID":   "n1djEa9Zs911CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15c02f336a07c3ec0f1030c2c1c7f2e719ee6ea39579baa726d63dbd618cfc33",
+				"DiscoKey":   "discokey:5b64b686e272e958d2761ad35f7504aea2e767c49e482ead424839639b891274",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43492",
+					"10.65.0.27:43492",
+					"172.17.0.1:43492",
+					"172.18.0.1:43492",
+					"172.19.0.1:43492",
+					"172.20.0.1:43492",
+					"172.21.0.1:43492",
+					"172.22.0.1:43492",
+					"172.23.0.1:43492",
+					"172.24.0.1:43492",
+					"172.25.0.1:43492",
+					"172.26.0.1:43492",
+					"172.27.0.1:43492",
+					"172.28.0.1:43492"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:12:13.959144721Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2547803460419977,
+				"StableID":   "nxGkFeUutL11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8343057cdbc9fd2178bc789bf1e86259d1747812264a6433e43bb5429efca076",
+				"DiscoKey":   "discokey:e47e67ee170c98bf4cd4c6affc8a7b721a9d07dc27a2dbcc02558d712482f42e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34838",
+					"10.65.0.27:34838",
+					"172.17.0.1:34838",
+					"172.18.0.1:34838",
+					"172.19.0.1:34838",
+					"172.20.0.1:34838",
+					"172.21.0.1:34838",
+					"172.22.0.1:34838",
+					"172.23.0.1:34838",
+					"172.24.0.1:34838",
+					"172.25.0.1:34838",
+					"172.26.0.1:34838",
+					"172.27.0.1:34838",
+					"172.28.0.1:34838"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:12:14.499294893Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1896790269306614,
+				"StableID":   "nTF3ruT4pF11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb460ef87abc28392030ffaed9a90acb13d737f7d4e2afd3c5cf30c9d8d6ce25",
+				"DiscoKey":   "discokey:a34c729de869d75828aeecc4024dc1476a2472e95393add1da74cb4e1dcbd649",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49922",
+					"10.65.0.27:49922",
+					"172.17.0.1:49922",
+					"172.18.0.1:49922",
+					"172.19.0.1:49922",
+					"172.20.0.1:49922",
+					"172.21.0.1:49922",
+					"172.22.0.1:49922",
+					"172.23.0.1:49922",
+					"172.24.0.1:49922",
+					"172.25.0.1:49922",
+					"172.26.0.1:49922",
+					"172.27.0.1:49922",
+					"172.28.0.1:49922"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:12:15.612155909Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5441526217295054,
+				"StableID":   "nuL6CffUVj11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1412aa2d544b885ebfa6f5bf07d9916a2852336d6465b60a685669734b56c75a",
+				"DiscoKey":   "discokey:4c4cb78776a0e12809d426e51ce1b9d152283d9877ebc17356a54c531f75f90a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46088",
+					"10.65.0.27:46088",
+					"172.17.0.1:46088",
+					"172.18.0.1:46088",
+					"172.19.0.1:46088",
+					"172.20.0.1:46088",
+					"172.21.0.1:46088",
+					"172.22.0.1:46088",
+					"172.23.0.1:46088",
+					"172.24.0.1:46088",
+					"172.25.0.1:46088",
+					"172.26.0.1:46088",
+					"172.27.0.1:46088",
+					"172.28.0.1:46088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:12:16.125093181Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6714736858617273,
+				"StableID":   "ngpGfZk7Su11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c7911d74f6a95c41cfbdc25933cda62584b81a423180a178c93e514cfecd5c6e",
+				"DiscoKey":   "discokey:53a1da3164b465eaa28141e7748a014dc2882e2ac8a8ade0c10cc2e1b81f642b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38348",
+					"10.65.0.27:38348",
+					"172.17.0.1:38348",
+					"172.18.0.1:38348",
+					"172.19.0.1:38348",
+					"172.20.0.1:38348",
+					"172.21.0.1:38348",
+					"172.22.0.1:38348",
+					"172.23.0.1:38348",
+					"172.24.0.1:38348",
+					"172.25.0.1:38348",
+					"172.26.0.1:38348",
+					"172.27.0.1:38348",
+					"172.28.0.1:38348"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:12:16.680850142Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3993055006255034,
+				"StableID":   "nPK3LUnTBY11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4483129363b3efe9d6e7f77e2c419993f6c93ac46886e2c65d66be7897d9945",
+				"DiscoKey":   "discokey:7aab69b601d715623f7faecd298d9d9c3ca661e48ff8e687a8fb956ea2721d3d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45745",
+					"10.65.0.27:45745",
+					"172.17.0.1:45745",
+					"172.18.0.1:45745",
+					"172.19.0.1:45745",
+					"172.20.0.1:45745",
+					"172.21.0.1:45745",
+					"172.22.0.1:45745",
+					"172.23.0.1:45745",
+					"172.24.0.1:45745",
+					"172.25.0.1:45745",
+					"172.26.0.1:45745",
+					"172.27.0.1:45745",
+					"172.28.0.1:45745"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:12:17.232728467Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         499258226074813,
+				"StableID":   "nkeuogf7u411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86de751b04e98f3f3e24662d954552ab27100bc4007cbd9d7fce7909bc653646",
+				"DiscoKey":   "discokey:2258666515a6c49fd642bd18313e7cd8c18c6ad3d66117a208110ffcd32f4518",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46872",
+					"10.65.0.27:46872",
+					"172.17.0.1:46872",
+					"172.18.0.1:46872",
+					"172.19.0.1:46872",
+					"172.20.0.1:46872",
+					"172.21.0.1:46872",
+					"172.22.0.1:46872",
+					"172.23.0.1:46872",
+					"172.24.0.1:46872",
+					"172.25.0.1:46872",
+					"172.26.0.1:46872",
+					"172.27.0.1:46872",
+					"172.28.0.1:46872"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:12:17.767226823Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5612001404879938,
+				"StableID":   "n5zgk7mgpk11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e078662eee1d237d130ec3464b5c8f01d12d4909933a8e5130d78d5b5acf6c4c",
+				"DiscoKey":   "discokey:d6267a1368efc7c7bd14582560ce0318075e69fbfe4479f5039e584e0457fc25",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56980",
+					"10.65.0.27:56980",
+					"172.17.0.1:56980",
+					"172.18.0.1:56980",
+					"172.19.0.1:56980",
+					"172.20.0.1:56980",
+					"172.21.0.1:56980",
+					"172.22.0.1:56980",
+					"172.23.0.1:56980",
+					"172.24.0.1:56980",
+					"172.25.0.1:56980",
+					"172.26.0.1:56980",
+					"172.27.0.1:56980",
+					"172.28.0.1:56980"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:12:18.319591263Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4715059007190742,
+				"StableID":   "nVrFW5cTpd11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5c974ab3854ff917eff17a52db4bef59f55bbc38aff6c0ce67baa68ee66fe2b",
+				"DiscoKey":   "discokey:7179a468c9cf2ba6142561fddefcb48f77d50806b6f3357c1c366b009d14911a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42733",
+					"10.65.0.27:42733",
+					"172.17.0.1:42733",
+					"172.18.0.1:42733",
+					"172.19.0.1:42733",
+					"172.20.0.1:42733",
+					"172.21.0.1:42733",
+					"172.22.0.1:42733",
+					"172.23.0.1:42733",
+					"172.24.0.1:42733",
+					"172.25.0.1:42733",
+					"172.26.0.1:42733",
+					"172.27.0.1:42733",
+					"172.28.0.1:42733"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:12:18.808278656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         239431495141524,
+				"StableID":   "n1ZCLeTSs211CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ac0dfaa903776a1252993dfedec0484f42538f85c55ffeaf608ab0ca7f21ad16",
+				"DiscoKey":   "discokey:5a1bf7676693f704282e50e85fbb55c89a73057d1db81615ae09c7d8f78b7374",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48599",
+					"10.65.0.27:48599",
+					"172.17.0.1:48599",
+					"172.18.0.1:48599",
+					"172.19.0.1:48599",
+					"172.20.0.1:48599",
+					"172.21.0.1:48599",
+					"172.22.0.1:48599",
+					"172.23.0.1:48599",
+					"172.24.0.1:48599",
+					"172.25.0.1:48599",
+					"172.26.0.1:48599",
+					"172.27.0.1:48599",
+					"172.28.0.1:48599"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:12:19.36713742Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6327755590799875,
+				"StableID":   "nncKBkQrQr11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5bc136530a7a3d8cd063e53488889156f0d776a1a568c506a4f535629ecaf814",
+				"KeyExpiry":  "2026-11-09T09:12:19Z",
+				"DiscoKey":   "discokey:804a065e484e011f2d8ee5627b209d7ddd6c9699e3f72744d5cfe887d2ed7857",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35110",
+					"10.65.0.27:35110",
+					"172.17.0.1:35110",
+					"172.18.0.1:35110",
+					"172.19.0.1:35110",
+					"172.20.0.1:35110",
+					"172.21.0.1:35110",
+					"172.22.0.1:35110",
+					"172.23.0.1:35110",
+					"172.24.0.1:35110",
+					"172.25.0.1:35110",
+					"172.26.0.1:35110",
+					"172.27.0.1:35110",
+					"172.28.0.1:35110"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:12:19.92157994Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         239211059311227,
+				"StableID":   "nG5xAofLs211CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:69a2e516bd0240aa24cb1aeeac3002b103f5b3b8b971f4a54b5977c4395a104f",
+				"KeyExpiry":  "2026-11-09T09:12:20Z",
+				"DiscoKey":   "discokey:b3678915cab02bc3cfde16542ab71daf35672432939d3e93a04c443f37f5295e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47307",
+					"10.65.0.27:47307",
+					"172.17.0.1:47307",
+					"172.18.0.1:47307",
+					"172.19.0.1:47307",
+					"172.20.0.1:47307",
+					"172.21.0.1:47307",
+					"172.22.0.1:47307",
+					"172.23.0.1:47307",
+					"172.24.0.1:47307",
+					"172.25.0.1:47307",
+					"172.26.0.1:47307",
+					"172.27.0.1:47307",
+					"172.28.0.1:47307"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:12:20.451669488Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         146478454007342,
+				"StableID":   "nVgYPxjL9211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dfcf396c81bf3904aef3622810e304cdd156b0d140bd2bc4ba1f4775d4dacb71",
+				"KeyExpiry":  "2026-11-09T09:12:21Z",
+				"DiscoKey":   "discokey:ed46f6e38c977c94ed2ebf24418b84a4637c8745555fca6bfb402082c6ef940a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36999",
+					"10.65.0.27:36999",
+					"172.17.0.1:36999",
+					"172.18.0.1:36999",
+					"172.19.0.1:36999",
+					"172.20.0.1:36999",
+					"172.21.0.1:36999",
+					"172.22.0.1:36999",
+					"172.23.0.1:36999",
+					"172.24.0.1:36999",
+					"172.25.0.1:36999",
+					"172.26.0.1:36999",
+					"172.27.0.1:36999",
+					"172.28.0.1:36999"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:12:21.006885452Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7449375176885547": {
+				"ID":          7449375176885547,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6714736858617273,
+				"StableID":   "ngpGfZk7Su11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       6714736858617273,
+				"Key":        "nodekey:c7911d74f6a95c41cfbdc25933cda62584b81a423180a178c93e514cfecd5c6e",
+				"DiscoKey":   "discokey:53a1da3164b465eaa28141e7748a014dc2882e2ac8a8ade0c10cc2e1b81f642b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38348",
+					"10.65.0.27:38348",
+					"172.17.0.1:38348",
+					"172.18.0.1:38348",
+					"172.19.0.1:38348",
+					"172.20.0.1:38348",
+					"172.21.0.1:38348",
+					"172.22.0.1:38348",
+					"172.23.0.1:38348",
+					"172.24.0.1:38348",
+					"172.25.0.1:38348",
+					"172.26.0.1:38348",
+					"172.27.0.1:38348",
+					"172.28.0.1:38348"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:12:16.680850142Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c7911d74f6a95c41cfbdc25933cda62584b81a423180a178c93e514cfecd5c6e",
+			"MachineKey": "mkey:7e9e2121af864533237655b8a6987c35bbdff9eed55089868fd45f0252e6560e",
+			"Peers": [{
+				"ID":         6295043190505720,
+				"StableID":   "nR5BPP73Ar11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65bc1919c2b0271b65099b25733e8e937c9c25dcef10a78bf1439dfde8dc7c10",
+				"DiscoKey":   "discokey:b428fa4819b6410ef2c55a0589b735f3f8afdba37349adcf02b92510a3fa7e6b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51096",
+					"10.65.0.27:51096",
+					"172.17.0.1:51096",
+					"172.18.0.1:51096",
+					"172.19.0.1:51096",
+					"172.20.0.1:51096",
+					"172.21.0.1:51096",
+					"172.22.0.1:51096",
+					"172.23.0.1:51096",
+					"172.24.0.1:51096",
+					"172.25.0.1:51096",
+					"172.26.0.1:51096",
+					"172.27.0.1:51096",
+					"172.28.0.1:51096"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:12:13.451963393Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1136127687261480,
+				"StableID":   "n1djEa9Zs911CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15c02f336a07c3ec0f1030c2c1c7f2e719ee6ea39579baa726d63dbd618cfc33",
+				"DiscoKey":   "discokey:5b64b686e272e958d2761ad35f7504aea2e767c49e482ead424839639b891274",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43492",
+					"10.65.0.27:43492",
+					"172.17.0.1:43492",
+					"172.18.0.1:43492",
+					"172.19.0.1:43492",
+					"172.20.0.1:43492",
+					"172.21.0.1:43492",
+					"172.22.0.1:43492",
+					"172.23.0.1:43492",
+					"172.24.0.1:43492",
+					"172.25.0.1:43492",
+					"172.26.0.1:43492",
+					"172.27.0.1:43492",
+					"172.28.0.1:43492"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:12:13.959144721Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2547803460419977,
+				"StableID":   "nxGkFeUutL11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8343057cdbc9fd2178bc789bf1e86259d1747812264a6433e43bb5429efca076",
+				"DiscoKey":   "discokey:e47e67ee170c98bf4cd4c6affc8a7b721a9d07dc27a2dbcc02558d712482f42e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34838",
+					"10.65.0.27:34838",
+					"172.17.0.1:34838",
+					"172.18.0.1:34838",
+					"172.19.0.1:34838",
+					"172.20.0.1:34838",
+					"172.21.0.1:34838",
+					"172.22.0.1:34838",
+					"172.23.0.1:34838",
+					"172.24.0.1:34838",
+					"172.25.0.1:34838",
+					"172.26.0.1:34838",
+					"172.27.0.1:34838",
+					"172.28.0.1:34838"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:12:14.499294893Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7449375176885547,
+				"StableID":   "npKHCLTqA121CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6519d9431c7294cc474e2e8fc38bc615114d4e1c499aaf8aeaebdebb56650756",
+				"DiscoKey":   "discokey:956784a0e52ed592bf42657dc900851fba54255903d4e0b6c4899e224311d62a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39201",
+					"10.65.0.27:39201",
+					"172.17.0.1:39201",
+					"172.18.0.1:39201",
+					"172.19.0.1:39201",
+					"172.20.0.1:39201",
+					"172.21.0.1:39201",
+					"172.22.0.1:39201",
+					"172.23.0.1:39201",
+					"172.24.0.1:39201",
+					"172.25.0.1:39201",
+					"172.26.0.1:39201",
+					"172.27.0.1:39201",
+					"172.28.0.1:39201"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:12:15.047991044Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1896790269306614,
+				"StableID":   "nTF3ruT4pF11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb460ef87abc28392030ffaed9a90acb13d737f7d4e2afd3c5cf30c9d8d6ce25",
+				"DiscoKey":   "discokey:a34c729de869d75828aeecc4024dc1476a2472e95393add1da74cb4e1dcbd649",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49922",
+					"10.65.0.27:49922",
+					"172.17.0.1:49922",
+					"172.18.0.1:49922",
+					"172.19.0.1:49922",
+					"172.20.0.1:49922",
+					"172.21.0.1:49922",
+					"172.22.0.1:49922",
+					"172.23.0.1:49922",
+					"172.24.0.1:49922",
+					"172.25.0.1:49922",
+					"172.26.0.1:49922",
+					"172.27.0.1:49922",
+					"172.28.0.1:49922"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:12:15.612155909Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5441526217295054,
+				"StableID":   "nuL6CffUVj11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1412aa2d544b885ebfa6f5bf07d9916a2852336d6465b60a685669734b56c75a",
+				"DiscoKey":   "discokey:4c4cb78776a0e12809d426e51ce1b9d152283d9877ebc17356a54c531f75f90a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46088",
+					"10.65.0.27:46088",
+					"172.17.0.1:46088",
+					"172.18.0.1:46088",
+					"172.19.0.1:46088",
+					"172.20.0.1:46088",
+					"172.21.0.1:46088",
+					"172.22.0.1:46088",
+					"172.23.0.1:46088",
+					"172.24.0.1:46088",
+					"172.25.0.1:46088",
+					"172.26.0.1:46088",
+					"172.27.0.1:46088",
+					"172.28.0.1:46088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:12:16.125093181Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3993055006255034,
+				"StableID":   "nPK3LUnTBY11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4483129363b3efe9d6e7f77e2c419993f6c93ac46886e2c65d66be7897d9945",
+				"DiscoKey":   "discokey:7aab69b601d715623f7faecd298d9d9c3ca661e48ff8e687a8fb956ea2721d3d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45745",
+					"10.65.0.27:45745",
+					"172.17.0.1:45745",
+					"172.18.0.1:45745",
+					"172.19.0.1:45745",
+					"172.20.0.1:45745",
+					"172.21.0.1:45745",
+					"172.22.0.1:45745",
+					"172.23.0.1:45745",
+					"172.24.0.1:45745",
+					"172.25.0.1:45745",
+					"172.26.0.1:45745",
+					"172.27.0.1:45745",
+					"172.28.0.1:45745"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:12:17.232728467Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         499258226074813,
+				"StableID":   "nkeuogf7u411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86de751b04e98f3f3e24662d954552ab27100bc4007cbd9d7fce7909bc653646",
+				"DiscoKey":   "discokey:2258666515a6c49fd642bd18313e7cd8c18c6ad3d66117a208110ffcd32f4518",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46872",
+					"10.65.0.27:46872",
+					"172.17.0.1:46872",
+					"172.18.0.1:46872",
+					"172.19.0.1:46872",
+					"172.20.0.1:46872",
+					"172.21.0.1:46872",
+					"172.22.0.1:46872",
+					"172.23.0.1:46872",
+					"172.24.0.1:46872",
+					"172.25.0.1:46872",
+					"172.26.0.1:46872",
+					"172.27.0.1:46872",
+					"172.28.0.1:46872"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:12:17.767226823Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5612001404879938,
+				"StableID":   "n5zgk7mgpk11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e078662eee1d237d130ec3464b5c8f01d12d4909933a8e5130d78d5b5acf6c4c",
+				"DiscoKey":   "discokey:d6267a1368efc7c7bd14582560ce0318075e69fbfe4479f5039e584e0457fc25",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56980",
+					"10.65.0.27:56980",
+					"172.17.0.1:56980",
+					"172.18.0.1:56980",
+					"172.19.0.1:56980",
+					"172.20.0.1:56980",
+					"172.21.0.1:56980",
+					"172.22.0.1:56980",
+					"172.23.0.1:56980",
+					"172.24.0.1:56980",
+					"172.25.0.1:56980",
+					"172.26.0.1:56980",
+					"172.27.0.1:56980",
+					"172.28.0.1:56980"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:12:18.319591263Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4715059007190742,
+				"StableID":   "nVrFW5cTpd11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5c974ab3854ff917eff17a52db4bef59f55bbc38aff6c0ce67baa68ee66fe2b",
+				"DiscoKey":   "discokey:7179a468c9cf2ba6142561fddefcb48f77d50806b6f3357c1c366b009d14911a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42733",
+					"10.65.0.27:42733",
+					"172.17.0.1:42733",
+					"172.18.0.1:42733",
+					"172.19.0.1:42733",
+					"172.20.0.1:42733",
+					"172.21.0.1:42733",
+					"172.22.0.1:42733",
+					"172.23.0.1:42733",
+					"172.24.0.1:42733",
+					"172.25.0.1:42733",
+					"172.26.0.1:42733",
+					"172.27.0.1:42733",
+					"172.28.0.1:42733"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:12:18.808278656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         239431495141524,
+				"StableID":   "n1ZCLeTSs211CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ac0dfaa903776a1252993dfedec0484f42538f85c55ffeaf608ab0ca7f21ad16",
+				"DiscoKey":   "discokey:5a1bf7676693f704282e50e85fbb55c89a73057d1db81615ae09c7d8f78b7374",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48599",
+					"10.65.0.27:48599",
+					"172.17.0.1:48599",
+					"172.18.0.1:48599",
+					"172.19.0.1:48599",
+					"172.20.0.1:48599",
+					"172.21.0.1:48599",
+					"172.22.0.1:48599",
+					"172.23.0.1:48599",
+					"172.24.0.1:48599",
+					"172.25.0.1:48599",
+					"172.26.0.1:48599",
+					"172.27.0.1:48599",
+					"172.28.0.1:48599"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:12:19.36713742Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6327755590799875,
+				"StableID":   "nncKBkQrQr11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5bc136530a7a3d8cd063e53488889156f0d776a1a568c506a4f535629ecaf814",
+				"KeyExpiry":  "2026-11-09T09:12:19Z",
+				"DiscoKey":   "discokey:804a065e484e011f2d8ee5627b209d7ddd6c9699e3f72744d5cfe887d2ed7857",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35110",
+					"10.65.0.27:35110",
+					"172.17.0.1:35110",
+					"172.18.0.1:35110",
+					"172.19.0.1:35110",
+					"172.20.0.1:35110",
+					"172.21.0.1:35110",
+					"172.22.0.1:35110",
+					"172.23.0.1:35110",
+					"172.24.0.1:35110",
+					"172.25.0.1:35110",
+					"172.26.0.1:35110",
+					"172.27.0.1:35110",
+					"172.28.0.1:35110"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:12:19.92157994Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         239211059311227,
+				"StableID":   "nG5xAofLs211CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:69a2e516bd0240aa24cb1aeeac3002b103f5b3b8b971f4a54b5977c4395a104f",
+				"KeyExpiry":  "2026-11-09T09:12:20Z",
+				"DiscoKey":   "discokey:b3678915cab02bc3cfde16542ab71daf35672432939d3e93a04c443f37f5295e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47307",
+					"10.65.0.27:47307",
+					"172.17.0.1:47307",
+					"172.18.0.1:47307",
+					"172.19.0.1:47307",
+					"172.20.0.1:47307",
+					"172.21.0.1:47307",
+					"172.22.0.1:47307",
+					"172.23.0.1:47307",
+					"172.24.0.1:47307",
+					"172.25.0.1:47307",
+					"172.26.0.1:47307",
+					"172.27.0.1:47307",
+					"172.28.0.1:47307"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:12:20.451669488Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         146478454007342,
+				"StableID":   "nVgYPxjL9211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dfcf396c81bf3904aef3622810e304cdd156b0d140bd2bc4ba1f4775d4dacb71",
+				"KeyExpiry":  "2026-11-09T09:12:21Z",
+				"DiscoKey":   "discokey:ed46f6e38c977c94ed2ebf24418b84a4637c8745555fca6bfb402082c6ef940a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36999",
+					"10.65.0.27:36999",
+					"172.17.0.1:36999",
+					"172.18.0.1:36999",
+					"172.19.0.1:36999",
+					"172.20.0.1:36999",
+					"172.21.0.1:36999",
+					"172.22.0.1:36999",
+					"172.23.0.1:36999",
+					"172.24.0.1:36999",
+					"172.25.0.1:36999",
+					"172.26.0.1:36999",
+					"172.27.0.1:36999",
+					"172.28.0.1:36999"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:12:21.006885452Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6714736858617273": {
+				"ID":          6714736858617273,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         499258226074813,
+				"StableID":   "nkeuogf7u411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       499258226074813,
+				"Key":        "nodekey:86de751b04e98f3f3e24662d954552ab27100bc4007cbd9d7fce7909bc653646",
+				"DiscoKey":   "discokey:2258666515a6c49fd642bd18313e7cd8c18c6ad3d66117a208110ffcd32f4518",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46872",
+					"10.65.0.27:46872",
+					"172.17.0.1:46872",
+					"172.18.0.1:46872",
+					"172.19.0.1:46872",
+					"172.20.0.1:46872",
+					"172.21.0.1:46872",
+					"172.22.0.1:46872",
+					"172.23.0.1:46872",
+					"172.24.0.1:46872",
+					"172.25.0.1:46872",
+					"172.26.0.1:46872",
+					"172.27.0.1:46872",
+					"172.28.0.1:46872"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:12:17.767226823Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:86de751b04e98f3f3e24662d954552ab27100bc4007cbd9d7fce7909bc653646",
+			"MachineKey": "mkey:b5b6997f642e242a2392a942599a0860861462c7b0ec88d08b0bdec29811f134",
+			"Peers": [{
+				"ID":         6295043190505720,
+				"StableID":   "nR5BPP73Ar11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65bc1919c2b0271b65099b25733e8e937c9c25dcef10a78bf1439dfde8dc7c10",
+				"DiscoKey":   "discokey:b428fa4819b6410ef2c55a0589b735f3f8afdba37349adcf02b92510a3fa7e6b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51096",
+					"10.65.0.27:51096",
+					"172.17.0.1:51096",
+					"172.18.0.1:51096",
+					"172.19.0.1:51096",
+					"172.20.0.1:51096",
+					"172.21.0.1:51096",
+					"172.22.0.1:51096",
+					"172.23.0.1:51096",
+					"172.24.0.1:51096",
+					"172.25.0.1:51096",
+					"172.26.0.1:51096",
+					"172.27.0.1:51096",
+					"172.28.0.1:51096"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:12:13.451963393Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1136127687261480,
+				"StableID":   "n1djEa9Zs911CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15c02f336a07c3ec0f1030c2c1c7f2e719ee6ea39579baa726d63dbd618cfc33",
+				"DiscoKey":   "discokey:5b64b686e272e958d2761ad35f7504aea2e767c49e482ead424839639b891274",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43492",
+					"10.65.0.27:43492",
+					"172.17.0.1:43492",
+					"172.18.0.1:43492",
+					"172.19.0.1:43492",
+					"172.20.0.1:43492",
+					"172.21.0.1:43492",
+					"172.22.0.1:43492",
+					"172.23.0.1:43492",
+					"172.24.0.1:43492",
+					"172.25.0.1:43492",
+					"172.26.0.1:43492",
+					"172.27.0.1:43492",
+					"172.28.0.1:43492"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:12:13.959144721Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2547803460419977,
+				"StableID":   "nxGkFeUutL11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8343057cdbc9fd2178bc789bf1e86259d1747812264a6433e43bb5429efca076",
+				"DiscoKey":   "discokey:e47e67ee170c98bf4cd4c6affc8a7b721a9d07dc27a2dbcc02558d712482f42e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34838",
+					"10.65.0.27:34838",
+					"172.17.0.1:34838",
+					"172.18.0.1:34838",
+					"172.19.0.1:34838",
+					"172.20.0.1:34838",
+					"172.21.0.1:34838",
+					"172.22.0.1:34838",
+					"172.23.0.1:34838",
+					"172.24.0.1:34838",
+					"172.25.0.1:34838",
+					"172.26.0.1:34838",
+					"172.27.0.1:34838",
+					"172.28.0.1:34838"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:12:14.499294893Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7449375176885547,
+				"StableID":   "npKHCLTqA121CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6519d9431c7294cc474e2e8fc38bc615114d4e1c499aaf8aeaebdebb56650756",
+				"DiscoKey":   "discokey:956784a0e52ed592bf42657dc900851fba54255903d4e0b6c4899e224311d62a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39201",
+					"10.65.0.27:39201",
+					"172.17.0.1:39201",
+					"172.18.0.1:39201",
+					"172.19.0.1:39201",
+					"172.20.0.1:39201",
+					"172.21.0.1:39201",
+					"172.22.0.1:39201",
+					"172.23.0.1:39201",
+					"172.24.0.1:39201",
+					"172.25.0.1:39201",
+					"172.26.0.1:39201",
+					"172.27.0.1:39201",
+					"172.28.0.1:39201"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:12:15.047991044Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1896790269306614,
+				"StableID":   "nTF3ruT4pF11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb460ef87abc28392030ffaed9a90acb13d737f7d4e2afd3c5cf30c9d8d6ce25",
+				"DiscoKey":   "discokey:a34c729de869d75828aeecc4024dc1476a2472e95393add1da74cb4e1dcbd649",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49922",
+					"10.65.0.27:49922",
+					"172.17.0.1:49922",
+					"172.18.0.1:49922",
+					"172.19.0.1:49922",
+					"172.20.0.1:49922",
+					"172.21.0.1:49922",
+					"172.22.0.1:49922",
+					"172.23.0.1:49922",
+					"172.24.0.1:49922",
+					"172.25.0.1:49922",
+					"172.26.0.1:49922",
+					"172.27.0.1:49922",
+					"172.28.0.1:49922"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:12:15.612155909Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5441526217295054,
+				"StableID":   "nuL6CffUVj11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1412aa2d544b885ebfa6f5bf07d9916a2852336d6465b60a685669734b56c75a",
+				"DiscoKey":   "discokey:4c4cb78776a0e12809d426e51ce1b9d152283d9877ebc17356a54c531f75f90a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46088",
+					"10.65.0.27:46088",
+					"172.17.0.1:46088",
+					"172.18.0.1:46088",
+					"172.19.0.1:46088",
+					"172.20.0.1:46088",
+					"172.21.0.1:46088",
+					"172.22.0.1:46088",
+					"172.23.0.1:46088",
+					"172.24.0.1:46088",
+					"172.25.0.1:46088",
+					"172.26.0.1:46088",
+					"172.27.0.1:46088",
+					"172.28.0.1:46088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:12:16.125093181Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6714736858617273,
+				"StableID":   "ngpGfZk7Su11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c7911d74f6a95c41cfbdc25933cda62584b81a423180a178c93e514cfecd5c6e",
+				"DiscoKey":   "discokey:53a1da3164b465eaa28141e7748a014dc2882e2ac8a8ade0c10cc2e1b81f642b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38348",
+					"10.65.0.27:38348",
+					"172.17.0.1:38348",
+					"172.18.0.1:38348",
+					"172.19.0.1:38348",
+					"172.20.0.1:38348",
+					"172.21.0.1:38348",
+					"172.22.0.1:38348",
+					"172.23.0.1:38348",
+					"172.24.0.1:38348",
+					"172.25.0.1:38348",
+					"172.26.0.1:38348",
+					"172.27.0.1:38348",
+					"172.28.0.1:38348"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:12:16.680850142Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3993055006255034,
+				"StableID":   "nPK3LUnTBY11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4483129363b3efe9d6e7f77e2c419993f6c93ac46886e2c65d66be7897d9945",
+				"DiscoKey":   "discokey:7aab69b601d715623f7faecd298d9d9c3ca661e48ff8e687a8fb956ea2721d3d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45745",
+					"10.65.0.27:45745",
+					"172.17.0.1:45745",
+					"172.18.0.1:45745",
+					"172.19.0.1:45745",
+					"172.20.0.1:45745",
+					"172.21.0.1:45745",
+					"172.22.0.1:45745",
+					"172.23.0.1:45745",
+					"172.24.0.1:45745",
+					"172.25.0.1:45745",
+					"172.26.0.1:45745",
+					"172.27.0.1:45745",
+					"172.28.0.1:45745"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:12:17.232728467Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5612001404879938,
+				"StableID":   "n5zgk7mgpk11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e078662eee1d237d130ec3464b5c8f01d12d4909933a8e5130d78d5b5acf6c4c",
+				"DiscoKey":   "discokey:d6267a1368efc7c7bd14582560ce0318075e69fbfe4479f5039e584e0457fc25",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56980",
+					"10.65.0.27:56980",
+					"172.17.0.1:56980",
+					"172.18.0.1:56980",
+					"172.19.0.1:56980",
+					"172.20.0.1:56980",
+					"172.21.0.1:56980",
+					"172.22.0.1:56980",
+					"172.23.0.1:56980",
+					"172.24.0.1:56980",
+					"172.25.0.1:56980",
+					"172.26.0.1:56980",
+					"172.27.0.1:56980",
+					"172.28.0.1:56980"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:12:18.319591263Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4715059007190742,
+				"StableID":   "nVrFW5cTpd11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5c974ab3854ff917eff17a52db4bef59f55bbc38aff6c0ce67baa68ee66fe2b",
+				"DiscoKey":   "discokey:7179a468c9cf2ba6142561fddefcb48f77d50806b6f3357c1c366b009d14911a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42733",
+					"10.65.0.27:42733",
+					"172.17.0.1:42733",
+					"172.18.0.1:42733",
+					"172.19.0.1:42733",
+					"172.20.0.1:42733",
+					"172.21.0.1:42733",
+					"172.22.0.1:42733",
+					"172.23.0.1:42733",
+					"172.24.0.1:42733",
+					"172.25.0.1:42733",
+					"172.26.0.1:42733",
+					"172.27.0.1:42733",
+					"172.28.0.1:42733"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:12:18.808278656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         239431495141524,
+				"StableID":   "n1ZCLeTSs211CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ac0dfaa903776a1252993dfedec0484f42538f85c55ffeaf608ab0ca7f21ad16",
+				"DiscoKey":   "discokey:5a1bf7676693f704282e50e85fbb55c89a73057d1db81615ae09c7d8f78b7374",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48599",
+					"10.65.0.27:48599",
+					"172.17.0.1:48599",
+					"172.18.0.1:48599",
+					"172.19.0.1:48599",
+					"172.20.0.1:48599",
+					"172.21.0.1:48599",
+					"172.22.0.1:48599",
+					"172.23.0.1:48599",
+					"172.24.0.1:48599",
+					"172.25.0.1:48599",
+					"172.26.0.1:48599",
+					"172.27.0.1:48599",
+					"172.28.0.1:48599"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:12:19.36713742Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6327755590799875,
+				"StableID":   "nncKBkQrQr11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5bc136530a7a3d8cd063e53488889156f0d776a1a568c506a4f535629ecaf814",
+				"KeyExpiry":  "2026-11-09T09:12:19Z",
+				"DiscoKey":   "discokey:804a065e484e011f2d8ee5627b209d7ddd6c9699e3f72744d5cfe887d2ed7857",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35110",
+					"10.65.0.27:35110",
+					"172.17.0.1:35110",
+					"172.18.0.1:35110",
+					"172.19.0.1:35110",
+					"172.20.0.1:35110",
+					"172.21.0.1:35110",
+					"172.22.0.1:35110",
+					"172.23.0.1:35110",
+					"172.24.0.1:35110",
+					"172.25.0.1:35110",
+					"172.26.0.1:35110",
+					"172.27.0.1:35110",
+					"172.28.0.1:35110"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:12:19.92157994Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         239211059311227,
+				"StableID":   "nG5xAofLs211CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:69a2e516bd0240aa24cb1aeeac3002b103f5b3b8b971f4a54b5977c4395a104f",
+				"KeyExpiry":  "2026-11-09T09:12:20Z",
+				"DiscoKey":   "discokey:b3678915cab02bc3cfde16542ab71daf35672432939d3e93a04c443f37f5295e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47307",
+					"10.65.0.27:47307",
+					"172.17.0.1:47307",
+					"172.18.0.1:47307",
+					"172.19.0.1:47307",
+					"172.20.0.1:47307",
+					"172.21.0.1:47307",
+					"172.22.0.1:47307",
+					"172.23.0.1:47307",
+					"172.24.0.1:47307",
+					"172.25.0.1:47307",
+					"172.26.0.1:47307",
+					"172.27.0.1:47307",
+					"172.28.0.1:47307"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:12:20.451669488Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         146478454007342,
+				"StableID":   "nVgYPxjL9211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dfcf396c81bf3904aef3622810e304cdd156b0d140bd2bc4ba1f4775d4dacb71",
+				"KeyExpiry":  "2026-11-09T09:12:21Z",
+				"DiscoKey":   "discokey:ed46f6e38c977c94ed2ebf24418b84a4637c8745555fca6bfb402082c6ef940a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36999",
+					"10.65.0.27:36999",
+					"172.17.0.1:36999",
+					"172.18.0.1:36999",
+					"172.19.0.1:36999",
+					"172.20.0.1:36999",
+					"172.21.0.1:36999",
+					"172.22.0.1:36999",
+					"172.23.0.1:36999",
+					"172.24.0.1:36999",
+					"172.25.0.1:36999",
+					"172.26.0.1:36999",
+					"172.27.0.1:36999",
+					"172.28.0.1:36999"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:12:21.006885452Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "499258226074813": {
+				"ID":          499258226074813,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         239211059311227,
+				"StableID":   "nG5xAofLs211CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:69a2e516bd0240aa24cb1aeeac3002b103f5b3b8b971f4a54b5977c4395a104f",
+				"KeyExpiry":  "2026-11-09T09:12:20Z",
+				"DiscoKey":   "discokey:b3678915cab02bc3cfde16542ab71daf35672432939d3e93a04c443f37f5295e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47307",
+					"10.65.0.27:47307",
+					"172.17.0.1:47307",
+					"172.18.0.1:47307",
+					"172.19.0.1:47307",
+					"172.20.0.1:47307",
+					"172.21.0.1:47307",
+					"172.22.0.1:47307",
+					"172.23.0.1:47307",
+					"172.24.0.1:47307",
+					"172.25.0.1:47307",
+					"172.26.0.1:47307",
+					"172.27.0.1:47307",
+					"172.28.0.1:47307"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:12:20.451669488Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:69a2e516bd0240aa24cb1aeeac3002b103f5b3b8b971f4a54b5977c4395a104f",
+			"MachineKey": "mkey:745b60ad1792ea80ca3941586c135d73339641f500b1585f65f9bf69ff3e085c",
+			"Peers": [{
+				"ID":         6295043190505720,
+				"StableID":   "nR5BPP73Ar11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65bc1919c2b0271b65099b25733e8e937c9c25dcef10a78bf1439dfde8dc7c10",
+				"DiscoKey":   "discokey:b428fa4819b6410ef2c55a0589b735f3f8afdba37349adcf02b92510a3fa7e6b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51096",
+					"10.65.0.27:51096",
+					"172.17.0.1:51096",
+					"172.18.0.1:51096",
+					"172.19.0.1:51096",
+					"172.20.0.1:51096",
+					"172.21.0.1:51096",
+					"172.22.0.1:51096",
+					"172.23.0.1:51096",
+					"172.24.0.1:51096",
+					"172.25.0.1:51096",
+					"172.26.0.1:51096",
+					"172.27.0.1:51096",
+					"172.28.0.1:51096"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:12:13.451963393Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1136127687261480,
+				"StableID":   "n1djEa9Zs911CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15c02f336a07c3ec0f1030c2c1c7f2e719ee6ea39579baa726d63dbd618cfc33",
+				"DiscoKey":   "discokey:5b64b686e272e958d2761ad35f7504aea2e767c49e482ead424839639b891274",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43492",
+					"10.65.0.27:43492",
+					"172.17.0.1:43492",
+					"172.18.0.1:43492",
+					"172.19.0.1:43492",
+					"172.20.0.1:43492",
+					"172.21.0.1:43492",
+					"172.22.0.1:43492",
+					"172.23.0.1:43492",
+					"172.24.0.1:43492",
+					"172.25.0.1:43492",
+					"172.26.0.1:43492",
+					"172.27.0.1:43492",
+					"172.28.0.1:43492"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:12:13.959144721Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2547803460419977,
+				"StableID":   "nxGkFeUutL11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8343057cdbc9fd2178bc789bf1e86259d1747812264a6433e43bb5429efca076",
+				"DiscoKey":   "discokey:e47e67ee170c98bf4cd4c6affc8a7b721a9d07dc27a2dbcc02558d712482f42e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34838",
+					"10.65.0.27:34838",
+					"172.17.0.1:34838",
+					"172.18.0.1:34838",
+					"172.19.0.1:34838",
+					"172.20.0.1:34838",
+					"172.21.0.1:34838",
+					"172.22.0.1:34838",
+					"172.23.0.1:34838",
+					"172.24.0.1:34838",
+					"172.25.0.1:34838",
+					"172.26.0.1:34838",
+					"172.27.0.1:34838",
+					"172.28.0.1:34838"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:12:14.499294893Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7449375176885547,
+				"StableID":   "npKHCLTqA121CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6519d9431c7294cc474e2e8fc38bc615114d4e1c499aaf8aeaebdebb56650756",
+				"DiscoKey":   "discokey:956784a0e52ed592bf42657dc900851fba54255903d4e0b6c4899e224311d62a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39201",
+					"10.65.0.27:39201",
+					"172.17.0.1:39201",
+					"172.18.0.1:39201",
+					"172.19.0.1:39201",
+					"172.20.0.1:39201",
+					"172.21.0.1:39201",
+					"172.22.0.1:39201",
+					"172.23.0.1:39201",
+					"172.24.0.1:39201",
+					"172.25.0.1:39201",
+					"172.26.0.1:39201",
+					"172.27.0.1:39201",
+					"172.28.0.1:39201"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:12:15.047991044Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1896790269306614,
+				"StableID":   "nTF3ruT4pF11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb460ef87abc28392030ffaed9a90acb13d737f7d4e2afd3c5cf30c9d8d6ce25",
+				"DiscoKey":   "discokey:a34c729de869d75828aeecc4024dc1476a2472e95393add1da74cb4e1dcbd649",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49922",
+					"10.65.0.27:49922",
+					"172.17.0.1:49922",
+					"172.18.0.1:49922",
+					"172.19.0.1:49922",
+					"172.20.0.1:49922",
+					"172.21.0.1:49922",
+					"172.22.0.1:49922",
+					"172.23.0.1:49922",
+					"172.24.0.1:49922",
+					"172.25.0.1:49922",
+					"172.26.0.1:49922",
+					"172.27.0.1:49922",
+					"172.28.0.1:49922"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:12:15.612155909Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5441526217295054,
+				"StableID":   "nuL6CffUVj11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1412aa2d544b885ebfa6f5bf07d9916a2852336d6465b60a685669734b56c75a",
+				"DiscoKey":   "discokey:4c4cb78776a0e12809d426e51ce1b9d152283d9877ebc17356a54c531f75f90a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46088",
+					"10.65.0.27:46088",
+					"172.17.0.1:46088",
+					"172.18.0.1:46088",
+					"172.19.0.1:46088",
+					"172.20.0.1:46088",
+					"172.21.0.1:46088",
+					"172.22.0.1:46088",
+					"172.23.0.1:46088",
+					"172.24.0.1:46088",
+					"172.25.0.1:46088",
+					"172.26.0.1:46088",
+					"172.27.0.1:46088",
+					"172.28.0.1:46088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:12:16.125093181Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6714736858617273,
+				"StableID":   "ngpGfZk7Su11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c7911d74f6a95c41cfbdc25933cda62584b81a423180a178c93e514cfecd5c6e",
+				"DiscoKey":   "discokey:53a1da3164b465eaa28141e7748a014dc2882e2ac8a8ade0c10cc2e1b81f642b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38348",
+					"10.65.0.27:38348",
+					"172.17.0.1:38348",
+					"172.18.0.1:38348",
+					"172.19.0.1:38348",
+					"172.20.0.1:38348",
+					"172.21.0.1:38348",
+					"172.22.0.1:38348",
+					"172.23.0.1:38348",
+					"172.24.0.1:38348",
+					"172.25.0.1:38348",
+					"172.26.0.1:38348",
+					"172.27.0.1:38348",
+					"172.28.0.1:38348"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:12:16.680850142Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3993055006255034,
+				"StableID":   "nPK3LUnTBY11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4483129363b3efe9d6e7f77e2c419993f6c93ac46886e2c65d66be7897d9945",
+				"DiscoKey":   "discokey:7aab69b601d715623f7faecd298d9d9c3ca661e48ff8e687a8fb956ea2721d3d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45745",
+					"10.65.0.27:45745",
+					"172.17.0.1:45745",
+					"172.18.0.1:45745",
+					"172.19.0.1:45745",
+					"172.20.0.1:45745",
+					"172.21.0.1:45745",
+					"172.22.0.1:45745",
+					"172.23.0.1:45745",
+					"172.24.0.1:45745",
+					"172.25.0.1:45745",
+					"172.26.0.1:45745",
+					"172.27.0.1:45745",
+					"172.28.0.1:45745"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:12:17.232728467Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         499258226074813,
+				"StableID":   "nkeuogf7u411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86de751b04e98f3f3e24662d954552ab27100bc4007cbd9d7fce7909bc653646",
+				"DiscoKey":   "discokey:2258666515a6c49fd642bd18313e7cd8c18c6ad3d66117a208110ffcd32f4518",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46872",
+					"10.65.0.27:46872",
+					"172.17.0.1:46872",
+					"172.18.0.1:46872",
+					"172.19.0.1:46872",
+					"172.20.0.1:46872",
+					"172.21.0.1:46872",
+					"172.22.0.1:46872",
+					"172.23.0.1:46872",
+					"172.24.0.1:46872",
+					"172.25.0.1:46872",
+					"172.26.0.1:46872",
+					"172.27.0.1:46872",
+					"172.28.0.1:46872"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:12:17.767226823Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5612001404879938,
+				"StableID":   "n5zgk7mgpk11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e078662eee1d237d130ec3464b5c8f01d12d4909933a8e5130d78d5b5acf6c4c",
+				"DiscoKey":   "discokey:d6267a1368efc7c7bd14582560ce0318075e69fbfe4479f5039e584e0457fc25",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56980",
+					"10.65.0.27:56980",
+					"172.17.0.1:56980",
+					"172.18.0.1:56980",
+					"172.19.0.1:56980",
+					"172.20.0.1:56980",
+					"172.21.0.1:56980",
+					"172.22.0.1:56980",
+					"172.23.0.1:56980",
+					"172.24.0.1:56980",
+					"172.25.0.1:56980",
+					"172.26.0.1:56980",
+					"172.27.0.1:56980",
+					"172.28.0.1:56980"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:12:18.319591263Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4715059007190742,
+				"StableID":   "nVrFW5cTpd11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5c974ab3854ff917eff17a52db4bef59f55bbc38aff6c0ce67baa68ee66fe2b",
+				"DiscoKey":   "discokey:7179a468c9cf2ba6142561fddefcb48f77d50806b6f3357c1c366b009d14911a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42733",
+					"10.65.0.27:42733",
+					"172.17.0.1:42733",
+					"172.18.0.1:42733",
+					"172.19.0.1:42733",
+					"172.20.0.1:42733",
+					"172.21.0.1:42733",
+					"172.22.0.1:42733",
+					"172.23.0.1:42733",
+					"172.24.0.1:42733",
+					"172.25.0.1:42733",
+					"172.26.0.1:42733",
+					"172.27.0.1:42733",
+					"172.28.0.1:42733"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:12:18.808278656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         239431495141524,
+				"StableID":   "n1ZCLeTSs211CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ac0dfaa903776a1252993dfedec0484f42538f85c55ffeaf608ab0ca7f21ad16",
+				"DiscoKey":   "discokey:5a1bf7676693f704282e50e85fbb55c89a73057d1db81615ae09c7d8f78b7374",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48599",
+					"10.65.0.27:48599",
+					"172.17.0.1:48599",
+					"172.18.0.1:48599",
+					"172.19.0.1:48599",
+					"172.20.0.1:48599",
+					"172.21.0.1:48599",
+					"172.22.0.1:48599",
+					"172.23.0.1:48599",
+					"172.24.0.1:48599",
+					"172.25.0.1:48599",
+					"172.26.0.1:48599",
+					"172.27.0.1:48599",
+					"172.28.0.1:48599"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:12:19.36713742Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6327755590799875,
+				"StableID":   "nncKBkQrQr11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5bc136530a7a3d8cd063e53488889156f0d776a1a568c506a4f535629ecaf814",
+				"KeyExpiry":  "2026-11-09T09:12:19Z",
+				"DiscoKey":   "discokey:804a065e484e011f2d8ee5627b209d7ddd6c9699e3f72744d5cfe887d2ed7857",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35110",
+					"10.65.0.27:35110",
+					"172.17.0.1:35110",
+					"172.18.0.1:35110",
+					"172.19.0.1:35110",
+					"172.20.0.1:35110",
+					"172.21.0.1:35110",
+					"172.22.0.1:35110",
+					"172.23.0.1:35110",
+					"172.24.0.1:35110",
+					"172.25.0.1:35110",
+					"172.26.0.1:35110",
+					"172.27.0.1:35110",
+					"172.28.0.1:35110"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:12:19.92157994Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         146478454007342,
+				"StableID":   "nVgYPxjL9211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dfcf396c81bf3904aef3622810e304cdd156b0d140bd2bc4ba1f4775d4dacb71",
+				"KeyExpiry":  "2026-11-09T09:12:21Z",
+				"DiscoKey":   "discokey:ed46f6e38c977c94ed2ebf24418b84a4637c8745555fca6bfb402082c6ef940a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36999",
+					"10.65.0.27:36999",
+					"172.17.0.1:36999",
+					"172.18.0.1:36999",
+					"172.19.0.1:36999",
+					"172.20.0.1:36999",
+					"172.21.0.1:36999",
+					"172.22.0.1:36999",
+					"172.23.0.1:36999",
+					"172.24.0.1:36999",
+					"172.25.0.1:36999",
+					"172.26.0.1:36999",
+					"172.27.0.1:36999",
+					"172.28.0.1:36999"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:12:21.006885452Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5612001404879938,
+				"StableID":   "n5zgk7mgpk11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       5612001404879938,
+				"Key":        "nodekey:e078662eee1d237d130ec3464b5c8f01d12d4909933a8e5130d78d5b5acf6c4c",
+				"DiscoKey":   "discokey:d6267a1368efc7c7bd14582560ce0318075e69fbfe4479f5039e584e0457fc25",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56980",
+					"10.65.0.27:56980",
+					"172.17.0.1:56980",
+					"172.18.0.1:56980",
+					"172.19.0.1:56980",
+					"172.20.0.1:56980",
+					"172.21.0.1:56980",
+					"172.22.0.1:56980",
+					"172.23.0.1:56980",
+					"172.24.0.1:56980",
+					"172.25.0.1:56980",
+					"172.26.0.1:56980",
+					"172.27.0.1:56980",
+					"172.28.0.1:56980"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:12:18.319591263Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e078662eee1d237d130ec3464b5c8f01d12d4909933a8e5130d78d5b5acf6c4c",
+			"MachineKey": "mkey:3fcc50973a7299049fe726b7c3cb9fbf572897fc31d50ea703fe3a138cd23e38",
+			"Peers": [{
+				"ID":         6295043190505720,
+				"StableID":   "nR5BPP73Ar11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65bc1919c2b0271b65099b25733e8e937c9c25dcef10a78bf1439dfde8dc7c10",
+				"DiscoKey":   "discokey:b428fa4819b6410ef2c55a0589b735f3f8afdba37349adcf02b92510a3fa7e6b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51096",
+					"10.65.0.27:51096",
+					"172.17.0.1:51096",
+					"172.18.0.1:51096",
+					"172.19.0.1:51096",
+					"172.20.0.1:51096",
+					"172.21.0.1:51096",
+					"172.22.0.1:51096",
+					"172.23.0.1:51096",
+					"172.24.0.1:51096",
+					"172.25.0.1:51096",
+					"172.26.0.1:51096",
+					"172.27.0.1:51096",
+					"172.28.0.1:51096"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:12:13.451963393Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1136127687261480,
+				"StableID":   "n1djEa9Zs911CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15c02f336a07c3ec0f1030c2c1c7f2e719ee6ea39579baa726d63dbd618cfc33",
+				"DiscoKey":   "discokey:5b64b686e272e958d2761ad35f7504aea2e767c49e482ead424839639b891274",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43492",
+					"10.65.0.27:43492",
+					"172.17.0.1:43492",
+					"172.18.0.1:43492",
+					"172.19.0.1:43492",
+					"172.20.0.1:43492",
+					"172.21.0.1:43492",
+					"172.22.0.1:43492",
+					"172.23.0.1:43492",
+					"172.24.0.1:43492",
+					"172.25.0.1:43492",
+					"172.26.0.1:43492",
+					"172.27.0.1:43492",
+					"172.28.0.1:43492"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:12:13.959144721Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2547803460419977,
+				"StableID":   "nxGkFeUutL11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8343057cdbc9fd2178bc789bf1e86259d1747812264a6433e43bb5429efca076",
+				"DiscoKey":   "discokey:e47e67ee170c98bf4cd4c6affc8a7b721a9d07dc27a2dbcc02558d712482f42e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34838",
+					"10.65.0.27:34838",
+					"172.17.0.1:34838",
+					"172.18.0.1:34838",
+					"172.19.0.1:34838",
+					"172.20.0.1:34838",
+					"172.21.0.1:34838",
+					"172.22.0.1:34838",
+					"172.23.0.1:34838",
+					"172.24.0.1:34838",
+					"172.25.0.1:34838",
+					"172.26.0.1:34838",
+					"172.27.0.1:34838",
+					"172.28.0.1:34838"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:12:14.499294893Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7449375176885547,
+				"StableID":   "npKHCLTqA121CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6519d9431c7294cc474e2e8fc38bc615114d4e1c499aaf8aeaebdebb56650756",
+				"DiscoKey":   "discokey:956784a0e52ed592bf42657dc900851fba54255903d4e0b6c4899e224311d62a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39201",
+					"10.65.0.27:39201",
+					"172.17.0.1:39201",
+					"172.18.0.1:39201",
+					"172.19.0.1:39201",
+					"172.20.0.1:39201",
+					"172.21.0.1:39201",
+					"172.22.0.1:39201",
+					"172.23.0.1:39201",
+					"172.24.0.1:39201",
+					"172.25.0.1:39201",
+					"172.26.0.1:39201",
+					"172.27.0.1:39201",
+					"172.28.0.1:39201"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:12:15.047991044Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1896790269306614,
+				"StableID":   "nTF3ruT4pF11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb460ef87abc28392030ffaed9a90acb13d737f7d4e2afd3c5cf30c9d8d6ce25",
+				"DiscoKey":   "discokey:a34c729de869d75828aeecc4024dc1476a2472e95393add1da74cb4e1dcbd649",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49922",
+					"10.65.0.27:49922",
+					"172.17.0.1:49922",
+					"172.18.0.1:49922",
+					"172.19.0.1:49922",
+					"172.20.0.1:49922",
+					"172.21.0.1:49922",
+					"172.22.0.1:49922",
+					"172.23.0.1:49922",
+					"172.24.0.1:49922",
+					"172.25.0.1:49922",
+					"172.26.0.1:49922",
+					"172.27.0.1:49922",
+					"172.28.0.1:49922"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:12:15.612155909Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5441526217295054,
+				"StableID":   "nuL6CffUVj11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1412aa2d544b885ebfa6f5bf07d9916a2852336d6465b60a685669734b56c75a",
+				"DiscoKey":   "discokey:4c4cb78776a0e12809d426e51ce1b9d152283d9877ebc17356a54c531f75f90a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46088",
+					"10.65.0.27:46088",
+					"172.17.0.1:46088",
+					"172.18.0.1:46088",
+					"172.19.0.1:46088",
+					"172.20.0.1:46088",
+					"172.21.0.1:46088",
+					"172.22.0.1:46088",
+					"172.23.0.1:46088",
+					"172.24.0.1:46088",
+					"172.25.0.1:46088",
+					"172.26.0.1:46088",
+					"172.27.0.1:46088",
+					"172.28.0.1:46088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:12:16.125093181Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6714736858617273,
+				"StableID":   "ngpGfZk7Su11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c7911d74f6a95c41cfbdc25933cda62584b81a423180a178c93e514cfecd5c6e",
+				"DiscoKey":   "discokey:53a1da3164b465eaa28141e7748a014dc2882e2ac8a8ade0c10cc2e1b81f642b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38348",
+					"10.65.0.27:38348",
+					"172.17.0.1:38348",
+					"172.18.0.1:38348",
+					"172.19.0.1:38348",
+					"172.20.0.1:38348",
+					"172.21.0.1:38348",
+					"172.22.0.1:38348",
+					"172.23.0.1:38348",
+					"172.24.0.1:38348",
+					"172.25.0.1:38348",
+					"172.26.0.1:38348",
+					"172.27.0.1:38348",
+					"172.28.0.1:38348"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:12:16.680850142Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3993055006255034,
+				"StableID":   "nPK3LUnTBY11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4483129363b3efe9d6e7f77e2c419993f6c93ac46886e2c65d66be7897d9945",
+				"DiscoKey":   "discokey:7aab69b601d715623f7faecd298d9d9c3ca661e48ff8e687a8fb956ea2721d3d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45745",
+					"10.65.0.27:45745",
+					"172.17.0.1:45745",
+					"172.18.0.1:45745",
+					"172.19.0.1:45745",
+					"172.20.0.1:45745",
+					"172.21.0.1:45745",
+					"172.22.0.1:45745",
+					"172.23.0.1:45745",
+					"172.24.0.1:45745",
+					"172.25.0.1:45745",
+					"172.26.0.1:45745",
+					"172.27.0.1:45745",
+					"172.28.0.1:45745"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:12:17.232728467Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         499258226074813,
+				"StableID":   "nkeuogf7u411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86de751b04e98f3f3e24662d954552ab27100bc4007cbd9d7fce7909bc653646",
+				"DiscoKey":   "discokey:2258666515a6c49fd642bd18313e7cd8c18c6ad3d66117a208110ffcd32f4518",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46872",
+					"10.65.0.27:46872",
+					"172.17.0.1:46872",
+					"172.18.0.1:46872",
+					"172.19.0.1:46872",
+					"172.20.0.1:46872",
+					"172.21.0.1:46872",
+					"172.22.0.1:46872",
+					"172.23.0.1:46872",
+					"172.24.0.1:46872",
+					"172.25.0.1:46872",
+					"172.26.0.1:46872",
+					"172.27.0.1:46872",
+					"172.28.0.1:46872"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:12:17.767226823Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4715059007190742,
+				"StableID":   "nVrFW5cTpd11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5c974ab3854ff917eff17a52db4bef59f55bbc38aff6c0ce67baa68ee66fe2b",
+				"DiscoKey":   "discokey:7179a468c9cf2ba6142561fddefcb48f77d50806b6f3357c1c366b009d14911a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42733",
+					"10.65.0.27:42733",
+					"172.17.0.1:42733",
+					"172.18.0.1:42733",
+					"172.19.0.1:42733",
+					"172.20.0.1:42733",
+					"172.21.0.1:42733",
+					"172.22.0.1:42733",
+					"172.23.0.1:42733",
+					"172.24.0.1:42733",
+					"172.25.0.1:42733",
+					"172.26.0.1:42733",
+					"172.27.0.1:42733",
+					"172.28.0.1:42733"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:12:18.808278656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         239431495141524,
+				"StableID":   "n1ZCLeTSs211CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ac0dfaa903776a1252993dfedec0484f42538f85c55ffeaf608ab0ca7f21ad16",
+				"DiscoKey":   "discokey:5a1bf7676693f704282e50e85fbb55c89a73057d1db81615ae09c7d8f78b7374",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48599",
+					"10.65.0.27:48599",
+					"172.17.0.1:48599",
+					"172.18.0.1:48599",
+					"172.19.0.1:48599",
+					"172.20.0.1:48599",
+					"172.21.0.1:48599",
+					"172.22.0.1:48599",
+					"172.23.0.1:48599",
+					"172.24.0.1:48599",
+					"172.25.0.1:48599",
+					"172.26.0.1:48599",
+					"172.27.0.1:48599",
+					"172.28.0.1:48599"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:12:19.36713742Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6327755590799875,
+				"StableID":   "nncKBkQrQr11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5bc136530a7a3d8cd063e53488889156f0d776a1a568c506a4f535629ecaf814",
+				"KeyExpiry":  "2026-11-09T09:12:19Z",
+				"DiscoKey":   "discokey:804a065e484e011f2d8ee5627b209d7ddd6c9699e3f72744d5cfe887d2ed7857",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35110",
+					"10.65.0.27:35110",
+					"172.17.0.1:35110",
+					"172.18.0.1:35110",
+					"172.19.0.1:35110",
+					"172.20.0.1:35110",
+					"172.21.0.1:35110",
+					"172.22.0.1:35110",
+					"172.23.0.1:35110",
+					"172.24.0.1:35110",
+					"172.25.0.1:35110",
+					"172.26.0.1:35110",
+					"172.27.0.1:35110",
+					"172.28.0.1:35110"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:12:19.92157994Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         239211059311227,
+				"StableID":   "nG5xAofLs211CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:69a2e516bd0240aa24cb1aeeac3002b103f5b3b8b971f4a54b5977c4395a104f",
+				"KeyExpiry":  "2026-11-09T09:12:20Z",
+				"DiscoKey":   "discokey:b3678915cab02bc3cfde16542ab71daf35672432939d3e93a04c443f37f5295e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47307",
+					"10.65.0.27:47307",
+					"172.17.0.1:47307",
+					"172.18.0.1:47307",
+					"172.19.0.1:47307",
+					"172.20.0.1:47307",
+					"172.21.0.1:47307",
+					"172.22.0.1:47307",
+					"172.23.0.1:47307",
+					"172.24.0.1:47307",
+					"172.25.0.1:47307",
+					"172.26.0.1:47307",
+					"172.27.0.1:47307",
+					"172.28.0.1:47307"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:12:20.451669488Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         146478454007342,
+				"StableID":   "nVgYPxjL9211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dfcf396c81bf3904aef3622810e304cdd156b0d140bd2bc4ba1f4775d4dacb71",
+				"KeyExpiry":  "2026-11-09T09:12:21Z",
+				"DiscoKey":   "discokey:ed46f6e38c977c94ed2ebf24418b84a4637c8745555fca6bfb402082c6ef940a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36999",
+					"10.65.0.27:36999",
+					"172.17.0.1:36999",
+					"172.18.0.1:36999",
+					"172.19.0.1:36999",
+					"172.20.0.1:36999",
+					"172.21.0.1:36999",
+					"172.22.0.1:36999",
+					"172.23.0.1:36999",
+					"172.24.0.1:36999",
+					"172.25.0.1:36999",
+					"172.26.0.1:36999",
+					"172.27.0.1:36999",
+					"172.28.0.1:36999"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:12:21.006885452Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5612001404879938": {
+				"ID":          5612001404879938,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-hosts-as-dst-multi-host-prefix.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-hosts-as-dst-multi-host-prefix.hujson
@@ -1,0 +1,22107 @@
+// ssh-hosts-as-dst-multi-host-prefix
+//
+// ssh dst = hosts alias resolving to a /8 prefix
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-13T09:12:57Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-hosts-as-dst-multi-host-prefix",
+	"description":    "ssh dst = hosts alias resolving to a /8 prefix",
+	"category":       "ssh",
+	"captured_at":    "2026-05-13T09:12:57.018243075Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "invalid dst \"netblock\""},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                     \n  \n                                                                     \n                                                                       \n                                  \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh dst = hosts alias resolving to a /8 prefix\",\n\t\"id\":          \"ssh-hosts-as-dst-multi-host-prefix\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"hosts\": {\"netblock\": \"10.0.0.0/8\"}, \"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"netblock\"],\n\t\t\"src\":    [\"thor@example.org\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-edges/ssh-hosts-as-dst-multi-host-prefix.hujson",
+		"full_policy": {
+			"hosts": {"netblock": "10.0.0.0/8"},
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["netblock"],
+				"src":    ["thor@example.org"],
+				"users":  ["root"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8954367754846020,
+				"StableID":   "n3xphJ4TvC21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       8954367754846020,
+				"Key":        "nodekey:1478f202bcf9d2358a3d4bd05990d244b0ede5e37176f220100c9ab9caddf83f",
+				"DiscoKey":   "discokey:bdfdb84530e8ed69e6a52c1146abe1035638c81ff55c208dd6b77faf1f212961",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36975",
+					"10.65.0.27:36975",
+					"172.17.0.1:36975",
+					"172.18.0.1:36975",
+					"172.19.0.1:36975",
+					"172.20.0.1:36975",
+					"172.21.0.1:36975",
+					"172.22.0.1:36975",
+					"172.23.0.1:36975",
+					"172.24.0.1:36975",
+					"172.25.0.1:36975",
+					"172.26.0.1:36975",
+					"172.27.0.1:36975",
+					"172.28.0.1:36975"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:13:05.499755672Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1478f202bcf9d2358a3d4bd05990d244b0ede5e37176f220100c9ab9caddf83f",
+			"MachineKey": "mkey:d0aff33269036fffe8f9fa38c4c7bec30344bb1bc45c1cfe7fd78cc6fb10de60",
+			"Peers": [{
+				"ID":         2567328734081892,
+				"StableID":   "nKewpbNk3M11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9a3edf80566cfe2025a9e4cd4d28991ca2da492f8c2f40dfbace8b4a09a03717",
+				"DiscoKey":   "discokey:5dc5f7d29170494bdab5203619193c0d8d74c1d4224a77b5b1d461f3c7933367",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40530",
+					"10.65.0.27:40530",
+					"172.17.0.1:40530",
+					"172.18.0.1:40530",
+					"172.19.0.1:40530",
+					"172.20.0.1:40530",
+					"172.21.0.1:40530",
+					"172.22.0.1:40530",
+					"172.23.0.1:40530",
+					"172.24.0.1:40530",
+					"172.25.0.1:40530",
+					"172.26.0.1:40530",
+					"172.27.0.1:40530",
+					"172.28.0.1:40530"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:12:59.647166872Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7206557288195694,
+				"StableID":   "ny2zrJ3sGy11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0e5b5ed54171c5e0678a67c1125a2a8b4d997038a3882c7dec8f97a5cee4801",
+				"DiscoKey":   "discokey:d45c577103e63b846c63df3e17a710b4126afa42360fa9e359f292bc626c7b3b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51060",
+					"10.65.0.27:51060",
+					"172.17.0.1:51060",
+					"172.18.0.1:51060",
+					"172.19.0.1:51060",
+					"172.20.0.1:51060",
+					"172.21.0.1:51060",
+					"172.22.0.1:51060",
+					"172.23.0.1:51060",
+					"172.24.0.1:51060",
+					"172.25.0.1:51060",
+					"172.26.0.1:51060",
+					"172.27.0.1:51060",
+					"172.28.0.1:51060"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:13:00.169667073Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4106394864656361,
+				"StableID":   "nSf4Wj2o4Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:215f6e8a47dfcd7f56e458256cb40fae14c86b1735dfe6c663a015d475a37749",
+				"DiscoKey":   "discokey:83e995e8e6c60c623248419305639fec671109cf8837cc19d992a4ea0aabc038",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40236",
+					"10.65.0.27:40236",
+					"172.17.0.1:40236",
+					"172.18.0.1:40236",
+					"172.19.0.1:40236",
+					"172.20.0.1:40236",
+					"172.21.0.1:40236",
+					"172.22.0.1:40236",
+					"172.23.0.1:40236",
+					"172.24.0.1:40236",
+					"172.25.0.1:40236",
+					"172.26.0.1:40236",
+					"172.27.0.1:40236",
+					"172.28.0.1:40236"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:13:00.72138567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8128686347202576,
+				"StableID":   "nyoA8noVU621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c049dc4190a545ec005bda37dd71345d3527d9875eee9b81a713e5f5aa56d718",
+				"DiscoKey":   "discokey:5bac4af261be794cfafb8d36f595b9ad563b2bebcd85bda11a1e0d76d4d63570",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50062",
+					"10.65.0.27:50062",
+					"172.17.0.1:50062",
+					"172.18.0.1:50062",
+					"172.19.0.1:50062",
+					"172.20.0.1:50062",
+					"172.21.0.1:50062",
+					"172.22.0.1:50062",
+					"172.23.0.1:50062",
+					"172.24.0.1:50062",
+					"172.25.0.1:50062",
+					"172.26.0.1:50062",
+					"172.27.0.1:50062",
+					"172.28.0.1:50062"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:13:01.252552597Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7664065760950815,
+				"StableID":   "naJEwf15r221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe1974aa2836492e1d7621a82d54ce0da7e56eb9be8a240d4f8963b4e9dbaa66",
+				"DiscoKey":   "discokey:91c0b24fd236d13165f37e8a36da74788988076094ba81bc1b7ba11ec0e9684e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41359",
+					"10.65.0.27:41359",
+					"172.17.0.1:41359",
+					"172.18.0.1:41359",
+					"172.19.0.1:41359",
+					"172.20.0.1:41359",
+					"172.21.0.1:41359",
+					"172.22.0.1:41359",
+					"172.23.0.1:41359",
+					"172.24.0.1:41359",
+					"172.25.0.1:41359",
+					"172.26.0.1:41359",
+					"172.27.0.1:41359",
+					"172.28.0.1:41359"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:13:01.779887028Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5669431039962502,
+				"StableID":   "nFbvwhLhGm11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1de5dcd0ef424a06beeb0b92363e94df5b327b3b51432ede5b056e3ac3f9f918",
+				"DiscoKey":   "discokey:06ae531352ce3d4c98a875fb8b032c960179c99f515df59b0a70f7764ac1e238",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40400",
+					"10.65.0.27:40400",
+					"172.17.0.1:40400",
+					"172.18.0.1:40400",
+					"172.19.0.1:40400",
+					"172.20.0.1:40400",
+					"172.21.0.1:40400",
+					"172.22.0.1:40400",
+					"172.23.0.1:40400",
+					"172.24.0.1:40400",
+					"172.25.0.1:40400",
+					"172.26.0.1:40400",
+					"172.27.0.1:40400",
+					"172.28.0.1:40400"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:13:02.311757801Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5130927302190635,
+				"StableID":   "n2WFf4mo4h11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:78b03139cfaefbd82e006f5ebe9cfcee0ba5235c2f016446c83405050fae5031",
+				"DiscoKey":   "discokey:2be290a222fd9e29f4ba6e72ffe63748f694b6890b2f12ee47e46d6eb58ec868",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54766",
+					"10.65.0.27:54766",
+					"172.17.0.1:54766",
+					"172.18.0.1:54766",
+					"172.19.0.1:54766",
+					"172.20.0.1:54766",
+					"172.21.0.1:54766",
+					"172.22.0.1:54766",
+					"172.23.0.1:54766",
+					"172.24.0.1:54766",
+					"172.25.0.1:54766",
+					"172.26.0.1:54766",
+					"172.27.0.1:54766",
+					"172.28.0.1:54766"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:13:02.835145745Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4166281204287168,
+				"StableID":   "nKAGGG9vXZ11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:997819540939b3a2441e4038631e8df0b159445c7cf5938ab375d8a058d47032",
+				"DiscoKey":   "discokey:5476eb0a0556ff05c0f9bfd950437e26b21ad1baa7ecae0ddb0e4b87f80c8e10",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:51700",
+					"10.65.0.27:51700",
+					"172.17.0.1:51700",
+					"172.18.0.1:51700",
+					"172.19.0.1:51700",
+					"172.20.0.1:51700",
+					"172.21.0.1:51700",
+					"172.22.0.1:51700",
+					"172.23.0.1:51700",
+					"172.24.0.1:51700",
+					"172.25.0.1:51700",
+					"172.26.0.1:51700",
+					"172.27.0.1:51700",
+					"172.28.0.1:51700"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:13:03.368157068Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4996382569491718,
+				"StableID":   "n3DkMsVs1g11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:46e8be6fb3bc9c1c5cb6963553d2f490e95f7c71c60ee96bed1f67a751ffa00e",
+				"DiscoKey":   "discokey:f6a27125101f87e31cc72c8d2870bd9b77bbc059c2d9d8bcbf96847f071bc75c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46511",
+					"10.65.0.27:46511",
+					"172.17.0.1:46511",
+					"172.18.0.1:46511",
+					"172.19.0.1:46511",
+					"172.20.0.1:46511",
+					"172.21.0.1:46511",
+					"172.22.0.1:46511",
+					"172.23.0.1:46511",
+					"172.24.0.1:46511",
+					"172.25.0.1:46511",
+					"172.26.0.1:46511",
+					"172.27.0.1:46511",
+					"172.28.0.1:46511"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:13:03.895352755Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8816360523537563,
+				"StableID":   "nSgtFnqwqB21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:df694e52776bcd93de661ecc3794046afef62941b054c74cf14fa551e83d8f7d",
+				"DiscoKey":   "discokey:3da66f21123faa21abdf8268b638e319698540f3370127a5efd152e4d6cca54d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60870",
+					"10.65.0.27:60870",
+					"172.17.0.1:60870",
+					"172.18.0.1:60870",
+					"172.19.0.1:60870",
+					"172.20.0.1:60870",
+					"172.21.0.1:60870",
+					"172.22.0.1:60870",
+					"172.23.0.1:60870",
+					"172.24.0.1:60870",
+					"172.25.0.1:60870",
+					"172.26.0.1:60870",
+					"172.27.0.1:60870",
+					"172.28.0.1:60870"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:13:04.416197291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4794516992630629,
+				"StableID":   "nSV2bDqSSe11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77add75392b721048b328a58d454e34ef02bfbe986727e6b070569d13676bb66",
+				"DiscoKey":   "discokey:1d12ca01b3211d8b85aef2f7a72f410da4c16cbffd521ed7f5a3aaaf4147b703",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40692",
+					"10.65.0.27:40692",
+					"172.17.0.1:40692",
+					"172.18.0.1:40692",
+					"172.19.0.1:40692",
+					"172.20.0.1:40692",
+					"172.21.0.1:40692",
+					"172.22.0.1:40692",
+					"172.23.0.1:40692",
+					"172.24.0.1:40692",
+					"172.25.0.1:40692",
+					"172.26.0.1:40692",
+					"172.27.0.1:40692",
+					"172.28.0.1:40692"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:13:04.959224986Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5759216140094256,
+				"StableID":   "n7rsnqqMym11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b1e83ead3c15eebac7d0103510a9eb9007f328d6a78c14678fd1c5e501602f1f",
+				"KeyExpiry":  "2026-11-09T09:13:06Z",
+				"DiscoKey":   "discokey:e9efbe7700ec8a7d48274cdfd3a668450d6b50723236fdc9d5df16ee25fad946",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:56882",
+					"10.65.0.27:56882",
+					"172.17.0.1:56882",
+					"172.18.0.1:56882",
+					"172.19.0.1:56882",
+					"172.20.0.1:56882",
+					"172.21.0.1:56882",
+					"172.22.0.1:56882",
+					"172.23.0.1:56882",
+					"172.24.0.1:56882",
+					"172.25.0.1:56882",
+					"172.26.0.1:56882",
+					"172.27.0.1:56882",
+					"172.28.0.1:56882"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:13:06.059576787Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2980139549275919,
+				"StableID":   "nC1kxKDiGQ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:778281a8bc8d2f190f04911d0cb5f2060c3b573b56435b64e00de2d8ff70cf7e",
+				"KeyExpiry":  "2026-11-09T09:13:06Z",
+				"DiscoKey":   "discokey:0e35513354b029f8207d7d4bf04d1595a89618f12865580a1763d03f264ba452",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57119",
+					"10.65.0.27:57119",
+					"172.17.0.1:57119",
+					"172.18.0.1:57119",
+					"172.19.0.1:57119",
+					"172.20.0.1:57119",
+					"172.21.0.1:57119",
+					"172.22.0.1:57119",
+					"172.23.0.1:57119",
+					"172.24.0.1:57119",
+					"172.25.0.1:57119",
+					"172.26.0.1:57119",
+					"172.27.0.1:57119",
+					"172.28.0.1:57119"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:13:06.582362451Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7727483352200269,
+				"StableID":   "np41KHtnL321CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3494764321ef3bd81e9ea5ed328f860aa3e9a1a6094042ac16ddef50972a0e13",
+				"KeyExpiry":  "2026-11-09T09:13:07Z",
+				"DiscoKey":   "discokey:7c9cc96f297fce93a0bff696af8e9065246e1dddcce8820d1e4375d76884f000",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:46552",
+					"10.65.0.27:46552",
+					"172.17.0.1:46552",
+					"172.18.0.1:46552",
+					"172.19.0.1:46552",
+					"172.20.0.1:46552",
+					"172.21.0.1:46552",
+					"172.22.0.1:46552",
+					"172.23.0.1:46552",
+					"172.24.0.1:46552",
+					"172.25.0.1:46552",
+					"172.26.0.1:46552",
+					"172.27.0.1:46552",
+					"172.28.0.1:46552"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:13:07.112575941Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8954367754846020": {
+				"ID":          8954367754846020,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5669431039962502,
+				"StableID":   "nFbvwhLhGm11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       5669431039962502,
+				"Key":        "nodekey:1de5dcd0ef424a06beeb0b92363e94df5b327b3b51432ede5b056e3ac3f9f918",
+				"DiscoKey":   "discokey:06ae531352ce3d4c98a875fb8b032c960179c99f515df59b0a70f7764ac1e238",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40400",
+					"10.65.0.27:40400",
+					"172.17.0.1:40400",
+					"172.18.0.1:40400",
+					"172.19.0.1:40400",
+					"172.20.0.1:40400",
+					"172.21.0.1:40400",
+					"172.22.0.1:40400",
+					"172.23.0.1:40400",
+					"172.24.0.1:40400",
+					"172.25.0.1:40400",
+					"172.26.0.1:40400",
+					"172.27.0.1:40400",
+					"172.28.0.1:40400"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:13:02.311757801Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1de5dcd0ef424a06beeb0b92363e94df5b327b3b51432ede5b056e3ac3f9f918",
+			"MachineKey": "mkey:a80033d6bd73a56b9f58b13301677d183a4c510b6ed96b57aea02798c3f98f21",
+			"Peers": [{
+				"ID":         2567328734081892,
+				"StableID":   "nKewpbNk3M11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9a3edf80566cfe2025a9e4cd4d28991ca2da492f8c2f40dfbace8b4a09a03717",
+				"DiscoKey":   "discokey:5dc5f7d29170494bdab5203619193c0d8d74c1d4224a77b5b1d461f3c7933367",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40530",
+					"10.65.0.27:40530",
+					"172.17.0.1:40530",
+					"172.18.0.1:40530",
+					"172.19.0.1:40530",
+					"172.20.0.1:40530",
+					"172.21.0.1:40530",
+					"172.22.0.1:40530",
+					"172.23.0.1:40530",
+					"172.24.0.1:40530",
+					"172.25.0.1:40530",
+					"172.26.0.1:40530",
+					"172.27.0.1:40530",
+					"172.28.0.1:40530"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:12:59.647166872Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7206557288195694,
+				"StableID":   "ny2zrJ3sGy11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0e5b5ed54171c5e0678a67c1125a2a8b4d997038a3882c7dec8f97a5cee4801",
+				"DiscoKey":   "discokey:d45c577103e63b846c63df3e17a710b4126afa42360fa9e359f292bc626c7b3b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51060",
+					"10.65.0.27:51060",
+					"172.17.0.1:51060",
+					"172.18.0.1:51060",
+					"172.19.0.1:51060",
+					"172.20.0.1:51060",
+					"172.21.0.1:51060",
+					"172.22.0.1:51060",
+					"172.23.0.1:51060",
+					"172.24.0.1:51060",
+					"172.25.0.1:51060",
+					"172.26.0.1:51060",
+					"172.27.0.1:51060",
+					"172.28.0.1:51060"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:13:00.169667073Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4106394864656361,
+				"StableID":   "nSf4Wj2o4Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:215f6e8a47dfcd7f56e458256cb40fae14c86b1735dfe6c663a015d475a37749",
+				"DiscoKey":   "discokey:83e995e8e6c60c623248419305639fec671109cf8837cc19d992a4ea0aabc038",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40236",
+					"10.65.0.27:40236",
+					"172.17.0.1:40236",
+					"172.18.0.1:40236",
+					"172.19.0.1:40236",
+					"172.20.0.1:40236",
+					"172.21.0.1:40236",
+					"172.22.0.1:40236",
+					"172.23.0.1:40236",
+					"172.24.0.1:40236",
+					"172.25.0.1:40236",
+					"172.26.0.1:40236",
+					"172.27.0.1:40236",
+					"172.28.0.1:40236"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:13:00.72138567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8128686347202576,
+				"StableID":   "nyoA8noVU621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c049dc4190a545ec005bda37dd71345d3527d9875eee9b81a713e5f5aa56d718",
+				"DiscoKey":   "discokey:5bac4af261be794cfafb8d36f595b9ad563b2bebcd85bda11a1e0d76d4d63570",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50062",
+					"10.65.0.27:50062",
+					"172.17.0.1:50062",
+					"172.18.0.1:50062",
+					"172.19.0.1:50062",
+					"172.20.0.1:50062",
+					"172.21.0.1:50062",
+					"172.22.0.1:50062",
+					"172.23.0.1:50062",
+					"172.24.0.1:50062",
+					"172.25.0.1:50062",
+					"172.26.0.1:50062",
+					"172.27.0.1:50062",
+					"172.28.0.1:50062"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:13:01.252552597Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7664065760950815,
+				"StableID":   "naJEwf15r221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe1974aa2836492e1d7621a82d54ce0da7e56eb9be8a240d4f8963b4e9dbaa66",
+				"DiscoKey":   "discokey:91c0b24fd236d13165f37e8a36da74788988076094ba81bc1b7ba11ec0e9684e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41359",
+					"10.65.0.27:41359",
+					"172.17.0.1:41359",
+					"172.18.0.1:41359",
+					"172.19.0.1:41359",
+					"172.20.0.1:41359",
+					"172.21.0.1:41359",
+					"172.22.0.1:41359",
+					"172.23.0.1:41359",
+					"172.24.0.1:41359",
+					"172.25.0.1:41359",
+					"172.26.0.1:41359",
+					"172.27.0.1:41359",
+					"172.28.0.1:41359"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:13:01.779887028Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5130927302190635,
+				"StableID":   "n2WFf4mo4h11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:78b03139cfaefbd82e006f5ebe9cfcee0ba5235c2f016446c83405050fae5031",
+				"DiscoKey":   "discokey:2be290a222fd9e29f4ba6e72ffe63748f694b6890b2f12ee47e46d6eb58ec868",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54766",
+					"10.65.0.27:54766",
+					"172.17.0.1:54766",
+					"172.18.0.1:54766",
+					"172.19.0.1:54766",
+					"172.20.0.1:54766",
+					"172.21.0.1:54766",
+					"172.22.0.1:54766",
+					"172.23.0.1:54766",
+					"172.24.0.1:54766",
+					"172.25.0.1:54766",
+					"172.26.0.1:54766",
+					"172.27.0.1:54766",
+					"172.28.0.1:54766"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:13:02.835145745Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4166281204287168,
+				"StableID":   "nKAGGG9vXZ11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:997819540939b3a2441e4038631e8df0b159445c7cf5938ab375d8a058d47032",
+				"DiscoKey":   "discokey:5476eb0a0556ff05c0f9bfd950437e26b21ad1baa7ecae0ddb0e4b87f80c8e10",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:51700",
+					"10.65.0.27:51700",
+					"172.17.0.1:51700",
+					"172.18.0.1:51700",
+					"172.19.0.1:51700",
+					"172.20.0.1:51700",
+					"172.21.0.1:51700",
+					"172.22.0.1:51700",
+					"172.23.0.1:51700",
+					"172.24.0.1:51700",
+					"172.25.0.1:51700",
+					"172.26.0.1:51700",
+					"172.27.0.1:51700",
+					"172.28.0.1:51700"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:13:03.368157068Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4996382569491718,
+				"StableID":   "n3DkMsVs1g11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:46e8be6fb3bc9c1c5cb6963553d2f490e95f7c71c60ee96bed1f67a751ffa00e",
+				"DiscoKey":   "discokey:f6a27125101f87e31cc72c8d2870bd9b77bbc059c2d9d8bcbf96847f071bc75c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46511",
+					"10.65.0.27:46511",
+					"172.17.0.1:46511",
+					"172.18.0.1:46511",
+					"172.19.0.1:46511",
+					"172.20.0.1:46511",
+					"172.21.0.1:46511",
+					"172.22.0.1:46511",
+					"172.23.0.1:46511",
+					"172.24.0.1:46511",
+					"172.25.0.1:46511",
+					"172.26.0.1:46511",
+					"172.27.0.1:46511",
+					"172.28.0.1:46511"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:13:03.895352755Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8816360523537563,
+				"StableID":   "nSgtFnqwqB21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:df694e52776bcd93de661ecc3794046afef62941b054c74cf14fa551e83d8f7d",
+				"DiscoKey":   "discokey:3da66f21123faa21abdf8268b638e319698540f3370127a5efd152e4d6cca54d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60870",
+					"10.65.0.27:60870",
+					"172.17.0.1:60870",
+					"172.18.0.1:60870",
+					"172.19.0.1:60870",
+					"172.20.0.1:60870",
+					"172.21.0.1:60870",
+					"172.22.0.1:60870",
+					"172.23.0.1:60870",
+					"172.24.0.1:60870",
+					"172.25.0.1:60870",
+					"172.26.0.1:60870",
+					"172.27.0.1:60870",
+					"172.28.0.1:60870"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:13:04.416197291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4794516992630629,
+				"StableID":   "nSV2bDqSSe11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77add75392b721048b328a58d454e34ef02bfbe986727e6b070569d13676bb66",
+				"DiscoKey":   "discokey:1d12ca01b3211d8b85aef2f7a72f410da4c16cbffd521ed7f5a3aaaf4147b703",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40692",
+					"10.65.0.27:40692",
+					"172.17.0.1:40692",
+					"172.18.0.1:40692",
+					"172.19.0.1:40692",
+					"172.20.0.1:40692",
+					"172.21.0.1:40692",
+					"172.22.0.1:40692",
+					"172.23.0.1:40692",
+					"172.24.0.1:40692",
+					"172.25.0.1:40692",
+					"172.26.0.1:40692",
+					"172.27.0.1:40692",
+					"172.28.0.1:40692"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:13:04.959224986Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8954367754846020,
+				"StableID":   "n3xphJ4TvC21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1478f202bcf9d2358a3d4bd05990d244b0ede5e37176f220100c9ab9caddf83f",
+				"DiscoKey":   "discokey:bdfdb84530e8ed69e6a52c1146abe1035638c81ff55c208dd6b77faf1f212961",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36975",
+					"10.65.0.27:36975",
+					"172.17.0.1:36975",
+					"172.18.0.1:36975",
+					"172.19.0.1:36975",
+					"172.20.0.1:36975",
+					"172.21.0.1:36975",
+					"172.22.0.1:36975",
+					"172.23.0.1:36975",
+					"172.24.0.1:36975",
+					"172.25.0.1:36975",
+					"172.26.0.1:36975",
+					"172.27.0.1:36975",
+					"172.28.0.1:36975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:13:05.499755672Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5759216140094256,
+				"StableID":   "n7rsnqqMym11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b1e83ead3c15eebac7d0103510a9eb9007f328d6a78c14678fd1c5e501602f1f",
+				"KeyExpiry":  "2026-11-09T09:13:06Z",
+				"DiscoKey":   "discokey:e9efbe7700ec8a7d48274cdfd3a668450d6b50723236fdc9d5df16ee25fad946",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:56882",
+					"10.65.0.27:56882",
+					"172.17.0.1:56882",
+					"172.18.0.1:56882",
+					"172.19.0.1:56882",
+					"172.20.0.1:56882",
+					"172.21.0.1:56882",
+					"172.22.0.1:56882",
+					"172.23.0.1:56882",
+					"172.24.0.1:56882",
+					"172.25.0.1:56882",
+					"172.26.0.1:56882",
+					"172.27.0.1:56882",
+					"172.28.0.1:56882"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:13:06.059576787Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2980139549275919,
+				"StableID":   "nC1kxKDiGQ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:778281a8bc8d2f190f04911d0cb5f2060c3b573b56435b64e00de2d8ff70cf7e",
+				"KeyExpiry":  "2026-11-09T09:13:06Z",
+				"DiscoKey":   "discokey:0e35513354b029f8207d7d4bf04d1595a89618f12865580a1763d03f264ba452",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57119",
+					"10.65.0.27:57119",
+					"172.17.0.1:57119",
+					"172.18.0.1:57119",
+					"172.19.0.1:57119",
+					"172.20.0.1:57119",
+					"172.21.0.1:57119",
+					"172.22.0.1:57119",
+					"172.23.0.1:57119",
+					"172.24.0.1:57119",
+					"172.25.0.1:57119",
+					"172.26.0.1:57119",
+					"172.27.0.1:57119",
+					"172.28.0.1:57119"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:13:06.582362451Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7727483352200269,
+				"StableID":   "np41KHtnL321CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3494764321ef3bd81e9ea5ed328f860aa3e9a1a6094042ac16ddef50972a0e13",
+				"KeyExpiry":  "2026-11-09T09:13:07Z",
+				"DiscoKey":   "discokey:7c9cc96f297fce93a0bff696af8e9065246e1dddcce8820d1e4375d76884f000",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:46552",
+					"10.65.0.27:46552",
+					"172.17.0.1:46552",
+					"172.18.0.1:46552",
+					"172.19.0.1:46552",
+					"172.20.0.1:46552",
+					"172.21.0.1:46552",
+					"172.22.0.1:46552",
+					"172.23.0.1:46552",
+					"172.24.0.1:46552",
+					"172.25.0.1:46552",
+					"172.26.0.1:46552",
+					"172.27.0.1:46552",
+					"172.28.0.1:46552"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:13:07.112575941Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5669431039962502": {
+				"ID":          5669431039962502,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7727483352200269,
+				"StableID":   "np41KHtnL321CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3494764321ef3bd81e9ea5ed328f860aa3e9a1a6094042ac16ddef50972a0e13",
+				"KeyExpiry":  "2026-11-09T09:13:07Z",
+				"DiscoKey":   "discokey:7c9cc96f297fce93a0bff696af8e9065246e1dddcce8820d1e4375d76884f000",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:46552",
+					"10.65.0.27:46552",
+					"172.17.0.1:46552",
+					"172.18.0.1:46552",
+					"172.19.0.1:46552",
+					"172.20.0.1:46552",
+					"172.21.0.1:46552",
+					"172.22.0.1:46552",
+					"172.23.0.1:46552",
+					"172.24.0.1:46552",
+					"172.25.0.1:46552",
+					"172.26.0.1:46552",
+					"172.27.0.1:46552",
+					"172.28.0.1:46552"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:13:07.112575941Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3494764321ef3bd81e9ea5ed328f860aa3e9a1a6094042ac16ddef50972a0e13",
+			"MachineKey": "mkey:ef8c098c60a7dbafaaf60cff6e99a8faa2952c81bda0cecd5131531cccebd33b",
+			"Peers": [{
+				"ID":         2567328734081892,
+				"StableID":   "nKewpbNk3M11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9a3edf80566cfe2025a9e4cd4d28991ca2da492f8c2f40dfbace8b4a09a03717",
+				"DiscoKey":   "discokey:5dc5f7d29170494bdab5203619193c0d8d74c1d4224a77b5b1d461f3c7933367",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40530",
+					"10.65.0.27:40530",
+					"172.17.0.1:40530",
+					"172.18.0.1:40530",
+					"172.19.0.1:40530",
+					"172.20.0.1:40530",
+					"172.21.0.1:40530",
+					"172.22.0.1:40530",
+					"172.23.0.1:40530",
+					"172.24.0.1:40530",
+					"172.25.0.1:40530",
+					"172.26.0.1:40530",
+					"172.27.0.1:40530",
+					"172.28.0.1:40530"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:12:59.647166872Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7206557288195694,
+				"StableID":   "ny2zrJ3sGy11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0e5b5ed54171c5e0678a67c1125a2a8b4d997038a3882c7dec8f97a5cee4801",
+				"DiscoKey":   "discokey:d45c577103e63b846c63df3e17a710b4126afa42360fa9e359f292bc626c7b3b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51060",
+					"10.65.0.27:51060",
+					"172.17.0.1:51060",
+					"172.18.0.1:51060",
+					"172.19.0.1:51060",
+					"172.20.0.1:51060",
+					"172.21.0.1:51060",
+					"172.22.0.1:51060",
+					"172.23.0.1:51060",
+					"172.24.0.1:51060",
+					"172.25.0.1:51060",
+					"172.26.0.1:51060",
+					"172.27.0.1:51060",
+					"172.28.0.1:51060"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:13:00.169667073Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4106394864656361,
+				"StableID":   "nSf4Wj2o4Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:215f6e8a47dfcd7f56e458256cb40fae14c86b1735dfe6c663a015d475a37749",
+				"DiscoKey":   "discokey:83e995e8e6c60c623248419305639fec671109cf8837cc19d992a4ea0aabc038",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40236",
+					"10.65.0.27:40236",
+					"172.17.0.1:40236",
+					"172.18.0.1:40236",
+					"172.19.0.1:40236",
+					"172.20.0.1:40236",
+					"172.21.0.1:40236",
+					"172.22.0.1:40236",
+					"172.23.0.1:40236",
+					"172.24.0.1:40236",
+					"172.25.0.1:40236",
+					"172.26.0.1:40236",
+					"172.27.0.1:40236",
+					"172.28.0.1:40236"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:13:00.72138567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8128686347202576,
+				"StableID":   "nyoA8noVU621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c049dc4190a545ec005bda37dd71345d3527d9875eee9b81a713e5f5aa56d718",
+				"DiscoKey":   "discokey:5bac4af261be794cfafb8d36f595b9ad563b2bebcd85bda11a1e0d76d4d63570",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50062",
+					"10.65.0.27:50062",
+					"172.17.0.1:50062",
+					"172.18.0.1:50062",
+					"172.19.0.1:50062",
+					"172.20.0.1:50062",
+					"172.21.0.1:50062",
+					"172.22.0.1:50062",
+					"172.23.0.1:50062",
+					"172.24.0.1:50062",
+					"172.25.0.1:50062",
+					"172.26.0.1:50062",
+					"172.27.0.1:50062",
+					"172.28.0.1:50062"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:13:01.252552597Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7664065760950815,
+				"StableID":   "naJEwf15r221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe1974aa2836492e1d7621a82d54ce0da7e56eb9be8a240d4f8963b4e9dbaa66",
+				"DiscoKey":   "discokey:91c0b24fd236d13165f37e8a36da74788988076094ba81bc1b7ba11ec0e9684e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41359",
+					"10.65.0.27:41359",
+					"172.17.0.1:41359",
+					"172.18.0.1:41359",
+					"172.19.0.1:41359",
+					"172.20.0.1:41359",
+					"172.21.0.1:41359",
+					"172.22.0.1:41359",
+					"172.23.0.1:41359",
+					"172.24.0.1:41359",
+					"172.25.0.1:41359",
+					"172.26.0.1:41359",
+					"172.27.0.1:41359",
+					"172.28.0.1:41359"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:13:01.779887028Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5669431039962502,
+				"StableID":   "nFbvwhLhGm11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1de5dcd0ef424a06beeb0b92363e94df5b327b3b51432ede5b056e3ac3f9f918",
+				"DiscoKey":   "discokey:06ae531352ce3d4c98a875fb8b032c960179c99f515df59b0a70f7764ac1e238",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40400",
+					"10.65.0.27:40400",
+					"172.17.0.1:40400",
+					"172.18.0.1:40400",
+					"172.19.0.1:40400",
+					"172.20.0.1:40400",
+					"172.21.0.1:40400",
+					"172.22.0.1:40400",
+					"172.23.0.1:40400",
+					"172.24.0.1:40400",
+					"172.25.0.1:40400",
+					"172.26.0.1:40400",
+					"172.27.0.1:40400",
+					"172.28.0.1:40400"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:13:02.311757801Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5130927302190635,
+				"StableID":   "n2WFf4mo4h11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:78b03139cfaefbd82e006f5ebe9cfcee0ba5235c2f016446c83405050fae5031",
+				"DiscoKey":   "discokey:2be290a222fd9e29f4ba6e72ffe63748f694b6890b2f12ee47e46d6eb58ec868",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54766",
+					"10.65.0.27:54766",
+					"172.17.0.1:54766",
+					"172.18.0.1:54766",
+					"172.19.0.1:54766",
+					"172.20.0.1:54766",
+					"172.21.0.1:54766",
+					"172.22.0.1:54766",
+					"172.23.0.1:54766",
+					"172.24.0.1:54766",
+					"172.25.0.1:54766",
+					"172.26.0.1:54766",
+					"172.27.0.1:54766",
+					"172.28.0.1:54766"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:13:02.835145745Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4166281204287168,
+				"StableID":   "nKAGGG9vXZ11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:997819540939b3a2441e4038631e8df0b159445c7cf5938ab375d8a058d47032",
+				"DiscoKey":   "discokey:5476eb0a0556ff05c0f9bfd950437e26b21ad1baa7ecae0ddb0e4b87f80c8e10",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:51700",
+					"10.65.0.27:51700",
+					"172.17.0.1:51700",
+					"172.18.0.1:51700",
+					"172.19.0.1:51700",
+					"172.20.0.1:51700",
+					"172.21.0.1:51700",
+					"172.22.0.1:51700",
+					"172.23.0.1:51700",
+					"172.24.0.1:51700",
+					"172.25.0.1:51700",
+					"172.26.0.1:51700",
+					"172.27.0.1:51700",
+					"172.28.0.1:51700"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:13:03.368157068Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4996382569491718,
+				"StableID":   "n3DkMsVs1g11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:46e8be6fb3bc9c1c5cb6963553d2f490e95f7c71c60ee96bed1f67a751ffa00e",
+				"DiscoKey":   "discokey:f6a27125101f87e31cc72c8d2870bd9b77bbc059c2d9d8bcbf96847f071bc75c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46511",
+					"10.65.0.27:46511",
+					"172.17.0.1:46511",
+					"172.18.0.1:46511",
+					"172.19.0.1:46511",
+					"172.20.0.1:46511",
+					"172.21.0.1:46511",
+					"172.22.0.1:46511",
+					"172.23.0.1:46511",
+					"172.24.0.1:46511",
+					"172.25.0.1:46511",
+					"172.26.0.1:46511",
+					"172.27.0.1:46511",
+					"172.28.0.1:46511"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:13:03.895352755Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8816360523537563,
+				"StableID":   "nSgtFnqwqB21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:df694e52776bcd93de661ecc3794046afef62941b054c74cf14fa551e83d8f7d",
+				"DiscoKey":   "discokey:3da66f21123faa21abdf8268b638e319698540f3370127a5efd152e4d6cca54d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60870",
+					"10.65.0.27:60870",
+					"172.17.0.1:60870",
+					"172.18.0.1:60870",
+					"172.19.0.1:60870",
+					"172.20.0.1:60870",
+					"172.21.0.1:60870",
+					"172.22.0.1:60870",
+					"172.23.0.1:60870",
+					"172.24.0.1:60870",
+					"172.25.0.1:60870",
+					"172.26.0.1:60870",
+					"172.27.0.1:60870",
+					"172.28.0.1:60870"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:13:04.416197291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4794516992630629,
+				"StableID":   "nSV2bDqSSe11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77add75392b721048b328a58d454e34ef02bfbe986727e6b070569d13676bb66",
+				"DiscoKey":   "discokey:1d12ca01b3211d8b85aef2f7a72f410da4c16cbffd521ed7f5a3aaaf4147b703",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40692",
+					"10.65.0.27:40692",
+					"172.17.0.1:40692",
+					"172.18.0.1:40692",
+					"172.19.0.1:40692",
+					"172.20.0.1:40692",
+					"172.21.0.1:40692",
+					"172.22.0.1:40692",
+					"172.23.0.1:40692",
+					"172.24.0.1:40692",
+					"172.25.0.1:40692",
+					"172.26.0.1:40692",
+					"172.27.0.1:40692",
+					"172.28.0.1:40692"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:13:04.959224986Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8954367754846020,
+				"StableID":   "n3xphJ4TvC21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1478f202bcf9d2358a3d4bd05990d244b0ede5e37176f220100c9ab9caddf83f",
+				"DiscoKey":   "discokey:bdfdb84530e8ed69e6a52c1146abe1035638c81ff55c208dd6b77faf1f212961",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36975",
+					"10.65.0.27:36975",
+					"172.17.0.1:36975",
+					"172.18.0.1:36975",
+					"172.19.0.1:36975",
+					"172.20.0.1:36975",
+					"172.21.0.1:36975",
+					"172.22.0.1:36975",
+					"172.23.0.1:36975",
+					"172.24.0.1:36975",
+					"172.25.0.1:36975",
+					"172.26.0.1:36975",
+					"172.27.0.1:36975",
+					"172.28.0.1:36975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:13:05.499755672Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5759216140094256,
+				"StableID":   "n7rsnqqMym11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b1e83ead3c15eebac7d0103510a9eb9007f328d6a78c14678fd1c5e501602f1f",
+				"KeyExpiry":  "2026-11-09T09:13:06Z",
+				"DiscoKey":   "discokey:e9efbe7700ec8a7d48274cdfd3a668450d6b50723236fdc9d5df16ee25fad946",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:56882",
+					"10.65.0.27:56882",
+					"172.17.0.1:56882",
+					"172.18.0.1:56882",
+					"172.19.0.1:56882",
+					"172.20.0.1:56882",
+					"172.21.0.1:56882",
+					"172.22.0.1:56882",
+					"172.23.0.1:56882",
+					"172.24.0.1:56882",
+					"172.25.0.1:56882",
+					"172.26.0.1:56882",
+					"172.27.0.1:56882",
+					"172.28.0.1:56882"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:13:06.059576787Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2980139549275919,
+				"StableID":   "nC1kxKDiGQ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:778281a8bc8d2f190f04911d0cb5f2060c3b573b56435b64e00de2d8ff70cf7e",
+				"KeyExpiry":  "2026-11-09T09:13:06Z",
+				"DiscoKey":   "discokey:0e35513354b029f8207d7d4bf04d1595a89618f12865580a1763d03f264ba452",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57119",
+					"10.65.0.27:57119",
+					"172.17.0.1:57119",
+					"172.18.0.1:57119",
+					"172.19.0.1:57119",
+					"172.20.0.1:57119",
+					"172.21.0.1:57119",
+					"172.22.0.1:57119",
+					"172.23.0.1:57119",
+					"172.24.0.1:57119",
+					"172.25.0.1:57119",
+					"172.26.0.1:57119",
+					"172.27.0.1:57119",
+					"172.28.0.1:57119"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:13:06.582362451Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4106394864656361,
+				"StableID":   "nSf4Wj2o4Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       4106394864656361,
+				"Key":        "nodekey:215f6e8a47dfcd7f56e458256cb40fae14c86b1735dfe6c663a015d475a37749",
+				"DiscoKey":   "discokey:83e995e8e6c60c623248419305639fec671109cf8837cc19d992a4ea0aabc038",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40236",
+					"10.65.0.27:40236",
+					"172.17.0.1:40236",
+					"172.18.0.1:40236",
+					"172.19.0.1:40236",
+					"172.20.0.1:40236",
+					"172.21.0.1:40236",
+					"172.22.0.1:40236",
+					"172.23.0.1:40236",
+					"172.24.0.1:40236",
+					"172.25.0.1:40236",
+					"172.26.0.1:40236",
+					"172.27.0.1:40236",
+					"172.28.0.1:40236"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:13:00.72138567Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:215f6e8a47dfcd7f56e458256cb40fae14c86b1735dfe6c663a015d475a37749",
+			"MachineKey": "mkey:721d1705d04f664d0a114ed868988f2fe12bfe97992583f17c974725fdcc5144",
+			"Peers": [{
+				"ID":         2567328734081892,
+				"StableID":   "nKewpbNk3M11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9a3edf80566cfe2025a9e4cd4d28991ca2da492f8c2f40dfbace8b4a09a03717",
+				"DiscoKey":   "discokey:5dc5f7d29170494bdab5203619193c0d8d74c1d4224a77b5b1d461f3c7933367",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40530",
+					"10.65.0.27:40530",
+					"172.17.0.1:40530",
+					"172.18.0.1:40530",
+					"172.19.0.1:40530",
+					"172.20.0.1:40530",
+					"172.21.0.1:40530",
+					"172.22.0.1:40530",
+					"172.23.0.1:40530",
+					"172.24.0.1:40530",
+					"172.25.0.1:40530",
+					"172.26.0.1:40530",
+					"172.27.0.1:40530",
+					"172.28.0.1:40530"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:12:59.647166872Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7206557288195694,
+				"StableID":   "ny2zrJ3sGy11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0e5b5ed54171c5e0678a67c1125a2a8b4d997038a3882c7dec8f97a5cee4801",
+				"DiscoKey":   "discokey:d45c577103e63b846c63df3e17a710b4126afa42360fa9e359f292bc626c7b3b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51060",
+					"10.65.0.27:51060",
+					"172.17.0.1:51060",
+					"172.18.0.1:51060",
+					"172.19.0.1:51060",
+					"172.20.0.1:51060",
+					"172.21.0.1:51060",
+					"172.22.0.1:51060",
+					"172.23.0.1:51060",
+					"172.24.0.1:51060",
+					"172.25.0.1:51060",
+					"172.26.0.1:51060",
+					"172.27.0.1:51060",
+					"172.28.0.1:51060"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:13:00.169667073Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8128686347202576,
+				"StableID":   "nyoA8noVU621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c049dc4190a545ec005bda37dd71345d3527d9875eee9b81a713e5f5aa56d718",
+				"DiscoKey":   "discokey:5bac4af261be794cfafb8d36f595b9ad563b2bebcd85bda11a1e0d76d4d63570",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50062",
+					"10.65.0.27:50062",
+					"172.17.0.1:50062",
+					"172.18.0.1:50062",
+					"172.19.0.1:50062",
+					"172.20.0.1:50062",
+					"172.21.0.1:50062",
+					"172.22.0.1:50062",
+					"172.23.0.1:50062",
+					"172.24.0.1:50062",
+					"172.25.0.1:50062",
+					"172.26.0.1:50062",
+					"172.27.0.1:50062",
+					"172.28.0.1:50062"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:13:01.252552597Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7664065760950815,
+				"StableID":   "naJEwf15r221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe1974aa2836492e1d7621a82d54ce0da7e56eb9be8a240d4f8963b4e9dbaa66",
+				"DiscoKey":   "discokey:91c0b24fd236d13165f37e8a36da74788988076094ba81bc1b7ba11ec0e9684e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41359",
+					"10.65.0.27:41359",
+					"172.17.0.1:41359",
+					"172.18.0.1:41359",
+					"172.19.0.1:41359",
+					"172.20.0.1:41359",
+					"172.21.0.1:41359",
+					"172.22.0.1:41359",
+					"172.23.0.1:41359",
+					"172.24.0.1:41359",
+					"172.25.0.1:41359",
+					"172.26.0.1:41359",
+					"172.27.0.1:41359",
+					"172.28.0.1:41359"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:13:01.779887028Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5669431039962502,
+				"StableID":   "nFbvwhLhGm11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1de5dcd0ef424a06beeb0b92363e94df5b327b3b51432ede5b056e3ac3f9f918",
+				"DiscoKey":   "discokey:06ae531352ce3d4c98a875fb8b032c960179c99f515df59b0a70f7764ac1e238",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40400",
+					"10.65.0.27:40400",
+					"172.17.0.1:40400",
+					"172.18.0.1:40400",
+					"172.19.0.1:40400",
+					"172.20.0.1:40400",
+					"172.21.0.1:40400",
+					"172.22.0.1:40400",
+					"172.23.0.1:40400",
+					"172.24.0.1:40400",
+					"172.25.0.1:40400",
+					"172.26.0.1:40400",
+					"172.27.0.1:40400",
+					"172.28.0.1:40400"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:13:02.311757801Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5130927302190635,
+				"StableID":   "n2WFf4mo4h11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:78b03139cfaefbd82e006f5ebe9cfcee0ba5235c2f016446c83405050fae5031",
+				"DiscoKey":   "discokey:2be290a222fd9e29f4ba6e72ffe63748f694b6890b2f12ee47e46d6eb58ec868",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54766",
+					"10.65.0.27:54766",
+					"172.17.0.1:54766",
+					"172.18.0.1:54766",
+					"172.19.0.1:54766",
+					"172.20.0.1:54766",
+					"172.21.0.1:54766",
+					"172.22.0.1:54766",
+					"172.23.0.1:54766",
+					"172.24.0.1:54766",
+					"172.25.0.1:54766",
+					"172.26.0.1:54766",
+					"172.27.0.1:54766",
+					"172.28.0.1:54766"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:13:02.835145745Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4166281204287168,
+				"StableID":   "nKAGGG9vXZ11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:997819540939b3a2441e4038631e8df0b159445c7cf5938ab375d8a058d47032",
+				"DiscoKey":   "discokey:5476eb0a0556ff05c0f9bfd950437e26b21ad1baa7ecae0ddb0e4b87f80c8e10",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:51700",
+					"10.65.0.27:51700",
+					"172.17.0.1:51700",
+					"172.18.0.1:51700",
+					"172.19.0.1:51700",
+					"172.20.0.1:51700",
+					"172.21.0.1:51700",
+					"172.22.0.1:51700",
+					"172.23.0.1:51700",
+					"172.24.0.1:51700",
+					"172.25.0.1:51700",
+					"172.26.0.1:51700",
+					"172.27.0.1:51700",
+					"172.28.0.1:51700"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:13:03.368157068Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4996382569491718,
+				"StableID":   "n3DkMsVs1g11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:46e8be6fb3bc9c1c5cb6963553d2f490e95f7c71c60ee96bed1f67a751ffa00e",
+				"DiscoKey":   "discokey:f6a27125101f87e31cc72c8d2870bd9b77bbc059c2d9d8bcbf96847f071bc75c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46511",
+					"10.65.0.27:46511",
+					"172.17.0.1:46511",
+					"172.18.0.1:46511",
+					"172.19.0.1:46511",
+					"172.20.0.1:46511",
+					"172.21.0.1:46511",
+					"172.22.0.1:46511",
+					"172.23.0.1:46511",
+					"172.24.0.1:46511",
+					"172.25.0.1:46511",
+					"172.26.0.1:46511",
+					"172.27.0.1:46511",
+					"172.28.0.1:46511"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:13:03.895352755Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8816360523537563,
+				"StableID":   "nSgtFnqwqB21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:df694e52776bcd93de661ecc3794046afef62941b054c74cf14fa551e83d8f7d",
+				"DiscoKey":   "discokey:3da66f21123faa21abdf8268b638e319698540f3370127a5efd152e4d6cca54d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60870",
+					"10.65.0.27:60870",
+					"172.17.0.1:60870",
+					"172.18.0.1:60870",
+					"172.19.0.1:60870",
+					"172.20.0.1:60870",
+					"172.21.0.1:60870",
+					"172.22.0.1:60870",
+					"172.23.0.1:60870",
+					"172.24.0.1:60870",
+					"172.25.0.1:60870",
+					"172.26.0.1:60870",
+					"172.27.0.1:60870",
+					"172.28.0.1:60870"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:13:04.416197291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4794516992630629,
+				"StableID":   "nSV2bDqSSe11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77add75392b721048b328a58d454e34ef02bfbe986727e6b070569d13676bb66",
+				"DiscoKey":   "discokey:1d12ca01b3211d8b85aef2f7a72f410da4c16cbffd521ed7f5a3aaaf4147b703",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40692",
+					"10.65.0.27:40692",
+					"172.17.0.1:40692",
+					"172.18.0.1:40692",
+					"172.19.0.1:40692",
+					"172.20.0.1:40692",
+					"172.21.0.1:40692",
+					"172.22.0.1:40692",
+					"172.23.0.1:40692",
+					"172.24.0.1:40692",
+					"172.25.0.1:40692",
+					"172.26.0.1:40692",
+					"172.27.0.1:40692",
+					"172.28.0.1:40692"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:13:04.959224986Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8954367754846020,
+				"StableID":   "n3xphJ4TvC21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1478f202bcf9d2358a3d4bd05990d244b0ede5e37176f220100c9ab9caddf83f",
+				"DiscoKey":   "discokey:bdfdb84530e8ed69e6a52c1146abe1035638c81ff55c208dd6b77faf1f212961",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36975",
+					"10.65.0.27:36975",
+					"172.17.0.1:36975",
+					"172.18.0.1:36975",
+					"172.19.0.1:36975",
+					"172.20.0.1:36975",
+					"172.21.0.1:36975",
+					"172.22.0.1:36975",
+					"172.23.0.1:36975",
+					"172.24.0.1:36975",
+					"172.25.0.1:36975",
+					"172.26.0.1:36975",
+					"172.27.0.1:36975",
+					"172.28.0.1:36975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:13:05.499755672Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5759216140094256,
+				"StableID":   "n7rsnqqMym11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b1e83ead3c15eebac7d0103510a9eb9007f328d6a78c14678fd1c5e501602f1f",
+				"KeyExpiry":  "2026-11-09T09:13:06Z",
+				"DiscoKey":   "discokey:e9efbe7700ec8a7d48274cdfd3a668450d6b50723236fdc9d5df16ee25fad946",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:56882",
+					"10.65.0.27:56882",
+					"172.17.0.1:56882",
+					"172.18.0.1:56882",
+					"172.19.0.1:56882",
+					"172.20.0.1:56882",
+					"172.21.0.1:56882",
+					"172.22.0.1:56882",
+					"172.23.0.1:56882",
+					"172.24.0.1:56882",
+					"172.25.0.1:56882",
+					"172.26.0.1:56882",
+					"172.27.0.1:56882",
+					"172.28.0.1:56882"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:13:06.059576787Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2980139549275919,
+				"StableID":   "nC1kxKDiGQ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:778281a8bc8d2f190f04911d0cb5f2060c3b573b56435b64e00de2d8ff70cf7e",
+				"KeyExpiry":  "2026-11-09T09:13:06Z",
+				"DiscoKey":   "discokey:0e35513354b029f8207d7d4bf04d1595a89618f12865580a1763d03f264ba452",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57119",
+					"10.65.0.27:57119",
+					"172.17.0.1:57119",
+					"172.18.0.1:57119",
+					"172.19.0.1:57119",
+					"172.20.0.1:57119",
+					"172.21.0.1:57119",
+					"172.22.0.1:57119",
+					"172.23.0.1:57119",
+					"172.24.0.1:57119",
+					"172.25.0.1:57119",
+					"172.26.0.1:57119",
+					"172.27.0.1:57119",
+					"172.28.0.1:57119"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:13:06.582362451Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7727483352200269,
+				"StableID":   "np41KHtnL321CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3494764321ef3bd81e9ea5ed328f860aa3e9a1a6094042ac16ddef50972a0e13",
+				"KeyExpiry":  "2026-11-09T09:13:07Z",
+				"DiscoKey":   "discokey:7c9cc96f297fce93a0bff696af8e9065246e1dddcce8820d1e4375d76884f000",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:46552",
+					"10.65.0.27:46552",
+					"172.17.0.1:46552",
+					"172.18.0.1:46552",
+					"172.19.0.1:46552",
+					"172.20.0.1:46552",
+					"172.21.0.1:46552",
+					"172.22.0.1:46552",
+					"172.23.0.1:46552",
+					"172.24.0.1:46552",
+					"172.25.0.1:46552",
+					"172.26.0.1:46552",
+					"172.27.0.1:46552",
+					"172.28.0.1:46552"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:13:07.112575941Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4106394864656361": {
+				"ID":          4106394864656361,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4166281204287168,
+				"StableID":   "nKAGGG9vXZ11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       4166281204287168,
+				"Key":        "nodekey:997819540939b3a2441e4038631e8df0b159445c7cf5938ab375d8a058d47032",
+				"DiscoKey":   "discokey:5476eb0a0556ff05c0f9bfd950437e26b21ad1baa7ecae0ddb0e4b87f80c8e10",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:51700",
+					"10.65.0.27:51700",
+					"172.17.0.1:51700",
+					"172.18.0.1:51700",
+					"172.19.0.1:51700",
+					"172.20.0.1:51700",
+					"172.21.0.1:51700",
+					"172.22.0.1:51700",
+					"172.23.0.1:51700",
+					"172.24.0.1:51700",
+					"172.25.0.1:51700",
+					"172.26.0.1:51700",
+					"172.27.0.1:51700",
+					"172.28.0.1:51700"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:13:03.368157068Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:997819540939b3a2441e4038631e8df0b159445c7cf5938ab375d8a058d47032",
+			"MachineKey": "mkey:3c6c6039dd997f40821f9a0a84b889dff250f240a881ef02379b8774a5c81840",
+			"Peers": [{
+				"ID":         2567328734081892,
+				"StableID":   "nKewpbNk3M11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9a3edf80566cfe2025a9e4cd4d28991ca2da492f8c2f40dfbace8b4a09a03717",
+				"DiscoKey":   "discokey:5dc5f7d29170494bdab5203619193c0d8d74c1d4224a77b5b1d461f3c7933367",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40530",
+					"10.65.0.27:40530",
+					"172.17.0.1:40530",
+					"172.18.0.1:40530",
+					"172.19.0.1:40530",
+					"172.20.0.1:40530",
+					"172.21.0.1:40530",
+					"172.22.0.1:40530",
+					"172.23.0.1:40530",
+					"172.24.0.1:40530",
+					"172.25.0.1:40530",
+					"172.26.0.1:40530",
+					"172.27.0.1:40530",
+					"172.28.0.1:40530"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:12:59.647166872Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7206557288195694,
+				"StableID":   "ny2zrJ3sGy11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0e5b5ed54171c5e0678a67c1125a2a8b4d997038a3882c7dec8f97a5cee4801",
+				"DiscoKey":   "discokey:d45c577103e63b846c63df3e17a710b4126afa42360fa9e359f292bc626c7b3b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51060",
+					"10.65.0.27:51060",
+					"172.17.0.1:51060",
+					"172.18.0.1:51060",
+					"172.19.0.1:51060",
+					"172.20.0.1:51060",
+					"172.21.0.1:51060",
+					"172.22.0.1:51060",
+					"172.23.0.1:51060",
+					"172.24.0.1:51060",
+					"172.25.0.1:51060",
+					"172.26.0.1:51060",
+					"172.27.0.1:51060",
+					"172.28.0.1:51060"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:13:00.169667073Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4106394864656361,
+				"StableID":   "nSf4Wj2o4Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:215f6e8a47dfcd7f56e458256cb40fae14c86b1735dfe6c663a015d475a37749",
+				"DiscoKey":   "discokey:83e995e8e6c60c623248419305639fec671109cf8837cc19d992a4ea0aabc038",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40236",
+					"10.65.0.27:40236",
+					"172.17.0.1:40236",
+					"172.18.0.1:40236",
+					"172.19.0.1:40236",
+					"172.20.0.1:40236",
+					"172.21.0.1:40236",
+					"172.22.0.1:40236",
+					"172.23.0.1:40236",
+					"172.24.0.1:40236",
+					"172.25.0.1:40236",
+					"172.26.0.1:40236",
+					"172.27.0.1:40236",
+					"172.28.0.1:40236"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:13:00.72138567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8128686347202576,
+				"StableID":   "nyoA8noVU621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c049dc4190a545ec005bda37dd71345d3527d9875eee9b81a713e5f5aa56d718",
+				"DiscoKey":   "discokey:5bac4af261be794cfafb8d36f595b9ad563b2bebcd85bda11a1e0d76d4d63570",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50062",
+					"10.65.0.27:50062",
+					"172.17.0.1:50062",
+					"172.18.0.1:50062",
+					"172.19.0.1:50062",
+					"172.20.0.1:50062",
+					"172.21.0.1:50062",
+					"172.22.0.1:50062",
+					"172.23.0.1:50062",
+					"172.24.0.1:50062",
+					"172.25.0.1:50062",
+					"172.26.0.1:50062",
+					"172.27.0.1:50062",
+					"172.28.0.1:50062"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:13:01.252552597Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7664065760950815,
+				"StableID":   "naJEwf15r221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe1974aa2836492e1d7621a82d54ce0da7e56eb9be8a240d4f8963b4e9dbaa66",
+				"DiscoKey":   "discokey:91c0b24fd236d13165f37e8a36da74788988076094ba81bc1b7ba11ec0e9684e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41359",
+					"10.65.0.27:41359",
+					"172.17.0.1:41359",
+					"172.18.0.1:41359",
+					"172.19.0.1:41359",
+					"172.20.0.1:41359",
+					"172.21.0.1:41359",
+					"172.22.0.1:41359",
+					"172.23.0.1:41359",
+					"172.24.0.1:41359",
+					"172.25.0.1:41359",
+					"172.26.0.1:41359",
+					"172.27.0.1:41359",
+					"172.28.0.1:41359"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:13:01.779887028Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5669431039962502,
+				"StableID":   "nFbvwhLhGm11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1de5dcd0ef424a06beeb0b92363e94df5b327b3b51432ede5b056e3ac3f9f918",
+				"DiscoKey":   "discokey:06ae531352ce3d4c98a875fb8b032c960179c99f515df59b0a70f7764ac1e238",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40400",
+					"10.65.0.27:40400",
+					"172.17.0.1:40400",
+					"172.18.0.1:40400",
+					"172.19.0.1:40400",
+					"172.20.0.1:40400",
+					"172.21.0.1:40400",
+					"172.22.0.1:40400",
+					"172.23.0.1:40400",
+					"172.24.0.1:40400",
+					"172.25.0.1:40400",
+					"172.26.0.1:40400",
+					"172.27.0.1:40400",
+					"172.28.0.1:40400"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:13:02.311757801Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5130927302190635,
+				"StableID":   "n2WFf4mo4h11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:78b03139cfaefbd82e006f5ebe9cfcee0ba5235c2f016446c83405050fae5031",
+				"DiscoKey":   "discokey:2be290a222fd9e29f4ba6e72ffe63748f694b6890b2f12ee47e46d6eb58ec868",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54766",
+					"10.65.0.27:54766",
+					"172.17.0.1:54766",
+					"172.18.0.1:54766",
+					"172.19.0.1:54766",
+					"172.20.0.1:54766",
+					"172.21.0.1:54766",
+					"172.22.0.1:54766",
+					"172.23.0.1:54766",
+					"172.24.0.1:54766",
+					"172.25.0.1:54766",
+					"172.26.0.1:54766",
+					"172.27.0.1:54766",
+					"172.28.0.1:54766"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:13:02.835145745Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4996382569491718,
+				"StableID":   "n3DkMsVs1g11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:46e8be6fb3bc9c1c5cb6963553d2f490e95f7c71c60ee96bed1f67a751ffa00e",
+				"DiscoKey":   "discokey:f6a27125101f87e31cc72c8d2870bd9b77bbc059c2d9d8bcbf96847f071bc75c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46511",
+					"10.65.0.27:46511",
+					"172.17.0.1:46511",
+					"172.18.0.1:46511",
+					"172.19.0.1:46511",
+					"172.20.0.1:46511",
+					"172.21.0.1:46511",
+					"172.22.0.1:46511",
+					"172.23.0.1:46511",
+					"172.24.0.1:46511",
+					"172.25.0.1:46511",
+					"172.26.0.1:46511",
+					"172.27.0.1:46511",
+					"172.28.0.1:46511"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:13:03.895352755Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8816360523537563,
+				"StableID":   "nSgtFnqwqB21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:df694e52776bcd93de661ecc3794046afef62941b054c74cf14fa551e83d8f7d",
+				"DiscoKey":   "discokey:3da66f21123faa21abdf8268b638e319698540f3370127a5efd152e4d6cca54d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60870",
+					"10.65.0.27:60870",
+					"172.17.0.1:60870",
+					"172.18.0.1:60870",
+					"172.19.0.1:60870",
+					"172.20.0.1:60870",
+					"172.21.0.1:60870",
+					"172.22.0.1:60870",
+					"172.23.0.1:60870",
+					"172.24.0.1:60870",
+					"172.25.0.1:60870",
+					"172.26.0.1:60870",
+					"172.27.0.1:60870",
+					"172.28.0.1:60870"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:13:04.416197291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4794516992630629,
+				"StableID":   "nSV2bDqSSe11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77add75392b721048b328a58d454e34ef02bfbe986727e6b070569d13676bb66",
+				"DiscoKey":   "discokey:1d12ca01b3211d8b85aef2f7a72f410da4c16cbffd521ed7f5a3aaaf4147b703",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40692",
+					"10.65.0.27:40692",
+					"172.17.0.1:40692",
+					"172.18.0.1:40692",
+					"172.19.0.1:40692",
+					"172.20.0.1:40692",
+					"172.21.0.1:40692",
+					"172.22.0.1:40692",
+					"172.23.0.1:40692",
+					"172.24.0.1:40692",
+					"172.25.0.1:40692",
+					"172.26.0.1:40692",
+					"172.27.0.1:40692",
+					"172.28.0.1:40692"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:13:04.959224986Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8954367754846020,
+				"StableID":   "n3xphJ4TvC21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1478f202bcf9d2358a3d4bd05990d244b0ede5e37176f220100c9ab9caddf83f",
+				"DiscoKey":   "discokey:bdfdb84530e8ed69e6a52c1146abe1035638c81ff55c208dd6b77faf1f212961",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36975",
+					"10.65.0.27:36975",
+					"172.17.0.1:36975",
+					"172.18.0.1:36975",
+					"172.19.0.1:36975",
+					"172.20.0.1:36975",
+					"172.21.0.1:36975",
+					"172.22.0.1:36975",
+					"172.23.0.1:36975",
+					"172.24.0.1:36975",
+					"172.25.0.1:36975",
+					"172.26.0.1:36975",
+					"172.27.0.1:36975",
+					"172.28.0.1:36975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:13:05.499755672Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5759216140094256,
+				"StableID":   "n7rsnqqMym11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b1e83ead3c15eebac7d0103510a9eb9007f328d6a78c14678fd1c5e501602f1f",
+				"KeyExpiry":  "2026-11-09T09:13:06Z",
+				"DiscoKey":   "discokey:e9efbe7700ec8a7d48274cdfd3a668450d6b50723236fdc9d5df16ee25fad946",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:56882",
+					"10.65.0.27:56882",
+					"172.17.0.1:56882",
+					"172.18.0.1:56882",
+					"172.19.0.1:56882",
+					"172.20.0.1:56882",
+					"172.21.0.1:56882",
+					"172.22.0.1:56882",
+					"172.23.0.1:56882",
+					"172.24.0.1:56882",
+					"172.25.0.1:56882",
+					"172.26.0.1:56882",
+					"172.27.0.1:56882",
+					"172.28.0.1:56882"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:13:06.059576787Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2980139549275919,
+				"StableID":   "nC1kxKDiGQ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:778281a8bc8d2f190f04911d0cb5f2060c3b573b56435b64e00de2d8ff70cf7e",
+				"KeyExpiry":  "2026-11-09T09:13:06Z",
+				"DiscoKey":   "discokey:0e35513354b029f8207d7d4bf04d1595a89618f12865580a1763d03f264ba452",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57119",
+					"10.65.0.27:57119",
+					"172.17.0.1:57119",
+					"172.18.0.1:57119",
+					"172.19.0.1:57119",
+					"172.20.0.1:57119",
+					"172.21.0.1:57119",
+					"172.22.0.1:57119",
+					"172.23.0.1:57119",
+					"172.24.0.1:57119",
+					"172.25.0.1:57119",
+					"172.26.0.1:57119",
+					"172.27.0.1:57119",
+					"172.28.0.1:57119"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:13:06.582362451Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7727483352200269,
+				"StableID":   "np41KHtnL321CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3494764321ef3bd81e9ea5ed328f860aa3e9a1a6094042ac16ddef50972a0e13",
+				"KeyExpiry":  "2026-11-09T09:13:07Z",
+				"DiscoKey":   "discokey:7c9cc96f297fce93a0bff696af8e9065246e1dddcce8820d1e4375d76884f000",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:46552",
+					"10.65.0.27:46552",
+					"172.17.0.1:46552",
+					"172.18.0.1:46552",
+					"172.19.0.1:46552",
+					"172.20.0.1:46552",
+					"172.21.0.1:46552",
+					"172.22.0.1:46552",
+					"172.23.0.1:46552",
+					"172.24.0.1:46552",
+					"172.25.0.1:46552",
+					"172.26.0.1:46552",
+					"172.27.0.1:46552",
+					"172.28.0.1:46552"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:13:07.112575941Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4166281204287168": {
+				"ID":          4166281204287168,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5759216140094256,
+				"StableID":   "n7rsnqqMym11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b1e83ead3c15eebac7d0103510a9eb9007f328d6a78c14678fd1c5e501602f1f",
+				"KeyExpiry":  "2026-11-09T09:13:06Z",
+				"DiscoKey":   "discokey:e9efbe7700ec8a7d48274cdfd3a668450d6b50723236fdc9d5df16ee25fad946",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:56882",
+					"10.65.0.27:56882",
+					"172.17.0.1:56882",
+					"172.18.0.1:56882",
+					"172.19.0.1:56882",
+					"172.20.0.1:56882",
+					"172.21.0.1:56882",
+					"172.22.0.1:56882",
+					"172.23.0.1:56882",
+					"172.24.0.1:56882",
+					"172.25.0.1:56882",
+					"172.26.0.1:56882",
+					"172.27.0.1:56882",
+					"172.28.0.1:56882"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:13:06.059576787Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b1e83ead3c15eebac7d0103510a9eb9007f328d6a78c14678fd1c5e501602f1f",
+			"MachineKey": "mkey:5b34adc6fccf2955e000de917dd25d460285a2634cc715e69f12c4becb498546",
+			"Peers": [{
+				"ID":         2567328734081892,
+				"StableID":   "nKewpbNk3M11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9a3edf80566cfe2025a9e4cd4d28991ca2da492f8c2f40dfbace8b4a09a03717",
+				"DiscoKey":   "discokey:5dc5f7d29170494bdab5203619193c0d8d74c1d4224a77b5b1d461f3c7933367",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40530",
+					"10.65.0.27:40530",
+					"172.17.0.1:40530",
+					"172.18.0.1:40530",
+					"172.19.0.1:40530",
+					"172.20.0.1:40530",
+					"172.21.0.1:40530",
+					"172.22.0.1:40530",
+					"172.23.0.1:40530",
+					"172.24.0.1:40530",
+					"172.25.0.1:40530",
+					"172.26.0.1:40530",
+					"172.27.0.1:40530",
+					"172.28.0.1:40530"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:12:59.647166872Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7206557288195694,
+				"StableID":   "ny2zrJ3sGy11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0e5b5ed54171c5e0678a67c1125a2a8b4d997038a3882c7dec8f97a5cee4801",
+				"DiscoKey":   "discokey:d45c577103e63b846c63df3e17a710b4126afa42360fa9e359f292bc626c7b3b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51060",
+					"10.65.0.27:51060",
+					"172.17.0.1:51060",
+					"172.18.0.1:51060",
+					"172.19.0.1:51060",
+					"172.20.0.1:51060",
+					"172.21.0.1:51060",
+					"172.22.0.1:51060",
+					"172.23.0.1:51060",
+					"172.24.0.1:51060",
+					"172.25.0.1:51060",
+					"172.26.0.1:51060",
+					"172.27.0.1:51060",
+					"172.28.0.1:51060"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:13:00.169667073Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4106394864656361,
+				"StableID":   "nSf4Wj2o4Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:215f6e8a47dfcd7f56e458256cb40fae14c86b1735dfe6c663a015d475a37749",
+				"DiscoKey":   "discokey:83e995e8e6c60c623248419305639fec671109cf8837cc19d992a4ea0aabc038",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40236",
+					"10.65.0.27:40236",
+					"172.17.0.1:40236",
+					"172.18.0.1:40236",
+					"172.19.0.1:40236",
+					"172.20.0.1:40236",
+					"172.21.0.1:40236",
+					"172.22.0.1:40236",
+					"172.23.0.1:40236",
+					"172.24.0.1:40236",
+					"172.25.0.1:40236",
+					"172.26.0.1:40236",
+					"172.27.0.1:40236",
+					"172.28.0.1:40236"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:13:00.72138567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8128686347202576,
+				"StableID":   "nyoA8noVU621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c049dc4190a545ec005bda37dd71345d3527d9875eee9b81a713e5f5aa56d718",
+				"DiscoKey":   "discokey:5bac4af261be794cfafb8d36f595b9ad563b2bebcd85bda11a1e0d76d4d63570",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50062",
+					"10.65.0.27:50062",
+					"172.17.0.1:50062",
+					"172.18.0.1:50062",
+					"172.19.0.1:50062",
+					"172.20.0.1:50062",
+					"172.21.0.1:50062",
+					"172.22.0.1:50062",
+					"172.23.0.1:50062",
+					"172.24.0.1:50062",
+					"172.25.0.1:50062",
+					"172.26.0.1:50062",
+					"172.27.0.1:50062",
+					"172.28.0.1:50062"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:13:01.252552597Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7664065760950815,
+				"StableID":   "naJEwf15r221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe1974aa2836492e1d7621a82d54ce0da7e56eb9be8a240d4f8963b4e9dbaa66",
+				"DiscoKey":   "discokey:91c0b24fd236d13165f37e8a36da74788988076094ba81bc1b7ba11ec0e9684e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41359",
+					"10.65.0.27:41359",
+					"172.17.0.1:41359",
+					"172.18.0.1:41359",
+					"172.19.0.1:41359",
+					"172.20.0.1:41359",
+					"172.21.0.1:41359",
+					"172.22.0.1:41359",
+					"172.23.0.1:41359",
+					"172.24.0.1:41359",
+					"172.25.0.1:41359",
+					"172.26.0.1:41359",
+					"172.27.0.1:41359",
+					"172.28.0.1:41359"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:13:01.779887028Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5669431039962502,
+				"StableID":   "nFbvwhLhGm11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1de5dcd0ef424a06beeb0b92363e94df5b327b3b51432ede5b056e3ac3f9f918",
+				"DiscoKey":   "discokey:06ae531352ce3d4c98a875fb8b032c960179c99f515df59b0a70f7764ac1e238",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40400",
+					"10.65.0.27:40400",
+					"172.17.0.1:40400",
+					"172.18.0.1:40400",
+					"172.19.0.1:40400",
+					"172.20.0.1:40400",
+					"172.21.0.1:40400",
+					"172.22.0.1:40400",
+					"172.23.0.1:40400",
+					"172.24.0.1:40400",
+					"172.25.0.1:40400",
+					"172.26.0.1:40400",
+					"172.27.0.1:40400",
+					"172.28.0.1:40400"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:13:02.311757801Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5130927302190635,
+				"StableID":   "n2WFf4mo4h11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:78b03139cfaefbd82e006f5ebe9cfcee0ba5235c2f016446c83405050fae5031",
+				"DiscoKey":   "discokey:2be290a222fd9e29f4ba6e72ffe63748f694b6890b2f12ee47e46d6eb58ec868",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54766",
+					"10.65.0.27:54766",
+					"172.17.0.1:54766",
+					"172.18.0.1:54766",
+					"172.19.0.1:54766",
+					"172.20.0.1:54766",
+					"172.21.0.1:54766",
+					"172.22.0.1:54766",
+					"172.23.0.1:54766",
+					"172.24.0.1:54766",
+					"172.25.0.1:54766",
+					"172.26.0.1:54766",
+					"172.27.0.1:54766",
+					"172.28.0.1:54766"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:13:02.835145745Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4166281204287168,
+				"StableID":   "nKAGGG9vXZ11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:997819540939b3a2441e4038631e8df0b159445c7cf5938ab375d8a058d47032",
+				"DiscoKey":   "discokey:5476eb0a0556ff05c0f9bfd950437e26b21ad1baa7ecae0ddb0e4b87f80c8e10",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:51700",
+					"10.65.0.27:51700",
+					"172.17.0.1:51700",
+					"172.18.0.1:51700",
+					"172.19.0.1:51700",
+					"172.20.0.1:51700",
+					"172.21.0.1:51700",
+					"172.22.0.1:51700",
+					"172.23.0.1:51700",
+					"172.24.0.1:51700",
+					"172.25.0.1:51700",
+					"172.26.0.1:51700",
+					"172.27.0.1:51700",
+					"172.28.0.1:51700"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:13:03.368157068Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4996382569491718,
+				"StableID":   "n3DkMsVs1g11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:46e8be6fb3bc9c1c5cb6963553d2f490e95f7c71c60ee96bed1f67a751ffa00e",
+				"DiscoKey":   "discokey:f6a27125101f87e31cc72c8d2870bd9b77bbc059c2d9d8bcbf96847f071bc75c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46511",
+					"10.65.0.27:46511",
+					"172.17.0.1:46511",
+					"172.18.0.1:46511",
+					"172.19.0.1:46511",
+					"172.20.0.1:46511",
+					"172.21.0.1:46511",
+					"172.22.0.1:46511",
+					"172.23.0.1:46511",
+					"172.24.0.1:46511",
+					"172.25.0.1:46511",
+					"172.26.0.1:46511",
+					"172.27.0.1:46511",
+					"172.28.0.1:46511"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:13:03.895352755Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8816360523537563,
+				"StableID":   "nSgtFnqwqB21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:df694e52776bcd93de661ecc3794046afef62941b054c74cf14fa551e83d8f7d",
+				"DiscoKey":   "discokey:3da66f21123faa21abdf8268b638e319698540f3370127a5efd152e4d6cca54d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60870",
+					"10.65.0.27:60870",
+					"172.17.0.1:60870",
+					"172.18.0.1:60870",
+					"172.19.0.1:60870",
+					"172.20.0.1:60870",
+					"172.21.0.1:60870",
+					"172.22.0.1:60870",
+					"172.23.0.1:60870",
+					"172.24.0.1:60870",
+					"172.25.0.1:60870",
+					"172.26.0.1:60870",
+					"172.27.0.1:60870",
+					"172.28.0.1:60870"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:13:04.416197291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4794516992630629,
+				"StableID":   "nSV2bDqSSe11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77add75392b721048b328a58d454e34ef02bfbe986727e6b070569d13676bb66",
+				"DiscoKey":   "discokey:1d12ca01b3211d8b85aef2f7a72f410da4c16cbffd521ed7f5a3aaaf4147b703",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40692",
+					"10.65.0.27:40692",
+					"172.17.0.1:40692",
+					"172.18.0.1:40692",
+					"172.19.0.1:40692",
+					"172.20.0.1:40692",
+					"172.21.0.1:40692",
+					"172.22.0.1:40692",
+					"172.23.0.1:40692",
+					"172.24.0.1:40692",
+					"172.25.0.1:40692",
+					"172.26.0.1:40692",
+					"172.27.0.1:40692",
+					"172.28.0.1:40692"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:13:04.959224986Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8954367754846020,
+				"StableID":   "n3xphJ4TvC21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1478f202bcf9d2358a3d4bd05990d244b0ede5e37176f220100c9ab9caddf83f",
+				"DiscoKey":   "discokey:bdfdb84530e8ed69e6a52c1146abe1035638c81ff55c208dd6b77faf1f212961",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36975",
+					"10.65.0.27:36975",
+					"172.17.0.1:36975",
+					"172.18.0.1:36975",
+					"172.19.0.1:36975",
+					"172.20.0.1:36975",
+					"172.21.0.1:36975",
+					"172.22.0.1:36975",
+					"172.23.0.1:36975",
+					"172.24.0.1:36975",
+					"172.25.0.1:36975",
+					"172.26.0.1:36975",
+					"172.27.0.1:36975",
+					"172.28.0.1:36975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:13:05.499755672Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2980139549275919,
+				"StableID":   "nC1kxKDiGQ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:778281a8bc8d2f190f04911d0cb5f2060c3b573b56435b64e00de2d8ff70cf7e",
+				"KeyExpiry":  "2026-11-09T09:13:06Z",
+				"DiscoKey":   "discokey:0e35513354b029f8207d7d4bf04d1595a89618f12865580a1763d03f264ba452",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57119",
+					"10.65.0.27:57119",
+					"172.17.0.1:57119",
+					"172.18.0.1:57119",
+					"172.19.0.1:57119",
+					"172.20.0.1:57119",
+					"172.21.0.1:57119",
+					"172.22.0.1:57119",
+					"172.23.0.1:57119",
+					"172.24.0.1:57119",
+					"172.25.0.1:57119",
+					"172.26.0.1:57119",
+					"172.27.0.1:57119",
+					"172.28.0.1:57119"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:13:06.582362451Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7727483352200269,
+				"StableID":   "np41KHtnL321CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3494764321ef3bd81e9ea5ed328f860aa3e9a1a6094042ac16ddef50972a0e13",
+				"KeyExpiry":  "2026-11-09T09:13:07Z",
+				"DiscoKey":   "discokey:7c9cc96f297fce93a0bff696af8e9065246e1dddcce8820d1e4375d76884f000",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:46552",
+					"10.65.0.27:46552",
+					"172.17.0.1:46552",
+					"172.18.0.1:46552",
+					"172.19.0.1:46552",
+					"172.20.0.1:46552",
+					"172.21.0.1:46552",
+					"172.22.0.1:46552",
+					"172.23.0.1:46552",
+					"172.24.0.1:46552",
+					"172.25.0.1:46552",
+					"172.26.0.1:46552",
+					"172.27.0.1:46552",
+					"172.28.0.1:46552"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:13:07.112575941Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4794516992630629,
+				"StableID":   "nSV2bDqSSe11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       4794516992630629,
+				"Key":        "nodekey:77add75392b721048b328a58d454e34ef02bfbe986727e6b070569d13676bb66",
+				"DiscoKey":   "discokey:1d12ca01b3211d8b85aef2f7a72f410da4c16cbffd521ed7f5a3aaaf4147b703",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40692",
+					"10.65.0.27:40692",
+					"172.17.0.1:40692",
+					"172.18.0.1:40692",
+					"172.19.0.1:40692",
+					"172.20.0.1:40692",
+					"172.21.0.1:40692",
+					"172.22.0.1:40692",
+					"172.23.0.1:40692",
+					"172.24.0.1:40692",
+					"172.25.0.1:40692",
+					"172.26.0.1:40692",
+					"172.27.0.1:40692",
+					"172.28.0.1:40692"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:13:04.959224986Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:77add75392b721048b328a58d454e34ef02bfbe986727e6b070569d13676bb66",
+			"MachineKey": "mkey:3580988efaaed6046e7c53e1a1200b986b9e6ca8b8b7962b9eb6f440169e6931",
+			"Peers": [{
+				"ID":         2567328734081892,
+				"StableID":   "nKewpbNk3M11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9a3edf80566cfe2025a9e4cd4d28991ca2da492f8c2f40dfbace8b4a09a03717",
+				"DiscoKey":   "discokey:5dc5f7d29170494bdab5203619193c0d8d74c1d4224a77b5b1d461f3c7933367",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40530",
+					"10.65.0.27:40530",
+					"172.17.0.1:40530",
+					"172.18.0.1:40530",
+					"172.19.0.1:40530",
+					"172.20.0.1:40530",
+					"172.21.0.1:40530",
+					"172.22.0.1:40530",
+					"172.23.0.1:40530",
+					"172.24.0.1:40530",
+					"172.25.0.1:40530",
+					"172.26.0.1:40530",
+					"172.27.0.1:40530",
+					"172.28.0.1:40530"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:12:59.647166872Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7206557288195694,
+				"StableID":   "ny2zrJ3sGy11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0e5b5ed54171c5e0678a67c1125a2a8b4d997038a3882c7dec8f97a5cee4801",
+				"DiscoKey":   "discokey:d45c577103e63b846c63df3e17a710b4126afa42360fa9e359f292bc626c7b3b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51060",
+					"10.65.0.27:51060",
+					"172.17.0.1:51060",
+					"172.18.0.1:51060",
+					"172.19.0.1:51060",
+					"172.20.0.1:51060",
+					"172.21.0.1:51060",
+					"172.22.0.1:51060",
+					"172.23.0.1:51060",
+					"172.24.0.1:51060",
+					"172.25.0.1:51060",
+					"172.26.0.1:51060",
+					"172.27.0.1:51060",
+					"172.28.0.1:51060"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:13:00.169667073Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4106394864656361,
+				"StableID":   "nSf4Wj2o4Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:215f6e8a47dfcd7f56e458256cb40fae14c86b1735dfe6c663a015d475a37749",
+				"DiscoKey":   "discokey:83e995e8e6c60c623248419305639fec671109cf8837cc19d992a4ea0aabc038",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40236",
+					"10.65.0.27:40236",
+					"172.17.0.1:40236",
+					"172.18.0.1:40236",
+					"172.19.0.1:40236",
+					"172.20.0.1:40236",
+					"172.21.0.1:40236",
+					"172.22.0.1:40236",
+					"172.23.0.1:40236",
+					"172.24.0.1:40236",
+					"172.25.0.1:40236",
+					"172.26.0.1:40236",
+					"172.27.0.1:40236",
+					"172.28.0.1:40236"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:13:00.72138567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8128686347202576,
+				"StableID":   "nyoA8noVU621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c049dc4190a545ec005bda37dd71345d3527d9875eee9b81a713e5f5aa56d718",
+				"DiscoKey":   "discokey:5bac4af261be794cfafb8d36f595b9ad563b2bebcd85bda11a1e0d76d4d63570",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50062",
+					"10.65.0.27:50062",
+					"172.17.0.1:50062",
+					"172.18.0.1:50062",
+					"172.19.0.1:50062",
+					"172.20.0.1:50062",
+					"172.21.0.1:50062",
+					"172.22.0.1:50062",
+					"172.23.0.1:50062",
+					"172.24.0.1:50062",
+					"172.25.0.1:50062",
+					"172.26.0.1:50062",
+					"172.27.0.1:50062",
+					"172.28.0.1:50062"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:13:01.252552597Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7664065760950815,
+				"StableID":   "naJEwf15r221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe1974aa2836492e1d7621a82d54ce0da7e56eb9be8a240d4f8963b4e9dbaa66",
+				"DiscoKey":   "discokey:91c0b24fd236d13165f37e8a36da74788988076094ba81bc1b7ba11ec0e9684e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41359",
+					"10.65.0.27:41359",
+					"172.17.0.1:41359",
+					"172.18.0.1:41359",
+					"172.19.0.1:41359",
+					"172.20.0.1:41359",
+					"172.21.0.1:41359",
+					"172.22.0.1:41359",
+					"172.23.0.1:41359",
+					"172.24.0.1:41359",
+					"172.25.0.1:41359",
+					"172.26.0.1:41359",
+					"172.27.0.1:41359",
+					"172.28.0.1:41359"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:13:01.779887028Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5669431039962502,
+				"StableID":   "nFbvwhLhGm11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1de5dcd0ef424a06beeb0b92363e94df5b327b3b51432ede5b056e3ac3f9f918",
+				"DiscoKey":   "discokey:06ae531352ce3d4c98a875fb8b032c960179c99f515df59b0a70f7764ac1e238",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40400",
+					"10.65.0.27:40400",
+					"172.17.0.1:40400",
+					"172.18.0.1:40400",
+					"172.19.0.1:40400",
+					"172.20.0.1:40400",
+					"172.21.0.1:40400",
+					"172.22.0.1:40400",
+					"172.23.0.1:40400",
+					"172.24.0.1:40400",
+					"172.25.0.1:40400",
+					"172.26.0.1:40400",
+					"172.27.0.1:40400",
+					"172.28.0.1:40400"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:13:02.311757801Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5130927302190635,
+				"StableID":   "n2WFf4mo4h11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:78b03139cfaefbd82e006f5ebe9cfcee0ba5235c2f016446c83405050fae5031",
+				"DiscoKey":   "discokey:2be290a222fd9e29f4ba6e72ffe63748f694b6890b2f12ee47e46d6eb58ec868",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54766",
+					"10.65.0.27:54766",
+					"172.17.0.1:54766",
+					"172.18.0.1:54766",
+					"172.19.0.1:54766",
+					"172.20.0.1:54766",
+					"172.21.0.1:54766",
+					"172.22.0.1:54766",
+					"172.23.0.1:54766",
+					"172.24.0.1:54766",
+					"172.25.0.1:54766",
+					"172.26.0.1:54766",
+					"172.27.0.1:54766",
+					"172.28.0.1:54766"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:13:02.835145745Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4166281204287168,
+				"StableID":   "nKAGGG9vXZ11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:997819540939b3a2441e4038631e8df0b159445c7cf5938ab375d8a058d47032",
+				"DiscoKey":   "discokey:5476eb0a0556ff05c0f9bfd950437e26b21ad1baa7ecae0ddb0e4b87f80c8e10",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:51700",
+					"10.65.0.27:51700",
+					"172.17.0.1:51700",
+					"172.18.0.1:51700",
+					"172.19.0.1:51700",
+					"172.20.0.1:51700",
+					"172.21.0.1:51700",
+					"172.22.0.1:51700",
+					"172.23.0.1:51700",
+					"172.24.0.1:51700",
+					"172.25.0.1:51700",
+					"172.26.0.1:51700",
+					"172.27.0.1:51700",
+					"172.28.0.1:51700"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:13:03.368157068Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4996382569491718,
+				"StableID":   "n3DkMsVs1g11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:46e8be6fb3bc9c1c5cb6963553d2f490e95f7c71c60ee96bed1f67a751ffa00e",
+				"DiscoKey":   "discokey:f6a27125101f87e31cc72c8d2870bd9b77bbc059c2d9d8bcbf96847f071bc75c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46511",
+					"10.65.0.27:46511",
+					"172.17.0.1:46511",
+					"172.18.0.1:46511",
+					"172.19.0.1:46511",
+					"172.20.0.1:46511",
+					"172.21.0.1:46511",
+					"172.22.0.1:46511",
+					"172.23.0.1:46511",
+					"172.24.0.1:46511",
+					"172.25.0.1:46511",
+					"172.26.0.1:46511",
+					"172.27.0.1:46511",
+					"172.28.0.1:46511"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:13:03.895352755Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8816360523537563,
+				"StableID":   "nSgtFnqwqB21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:df694e52776bcd93de661ecc3794046afef62941b054c74cf14fa551e83d8f7d",
+				"DiscoKey":   "discokey:3da66f21123faa21abdf8268b638e319698540f3370127a5efd152e4d6cca54d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60870",
+					"10.65.0.27:60870",
+					"172.17.0.1:60870",
+					"172.18.0.1:60870",
+					"172.19.0.1:60870",
+					"172.20.0.1:60870",
+					"172.21.0.1:60870",
+					"172.22.0.1:60870",
+					"172.23.0.1:60870",
+					"172.24.0.1:60870",
+					"172.25.0.1:60870",
+					"172.26.0.1:60870",
+					"172.27.0.1:60870",
+					"172.28.0.1:60870"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:13:04.416197291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8954367754846020,
+				"StableID":   "n3xphJ4TvC21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1478f202bcf9d2358a3d4bd05990d244b0ede5e37176f220100c9ab9caddf83f",
+				"DiscoKey":   "discokey:bdfdb84530e8ed69e6a52c1146abe1035638c81ff55c208dd6b77faf1f212961",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36975",
+					"10.65.0.27:36975",
+					"172.17.0.1:36975",
+					"172.18.0.1:36975",
+					"172.19.0.1:36975",
+					"172.20.0.1:36975",
+					"172.21.0.1:36975",
+					"172.22.0.1:36975",
+					"172.23.0.1:36975",
+					"172.24.0.1:36975",
+					"172.25.0.1:36975",
+					"172.26.0.1:36975",
+					"172.27.0.1:36975",
+					"172.28.0.1:36975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:13:05.499755672Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5759216140094256,
+				"StableID":   "n7rsnqqMym11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b1e83ead3c15eebac7d0103510a9eb9007f328d6a78c14678fd1c5e501602f1f",
+				"KeyExpiry":  "2026-11-09T09:13:06Z",
+				"DiscoKey":   "discokey:e9efbe7700ec8a7d48274cdfd3a668450d6b50723236fdc9d5df16ee25fad946",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:56882",
+					"10.65.0.27:56882",
+					"172.17.0.1:56882",
+					"172.18.0.1:56882",
+					"172.19.0.1:56882",
+					"172.20.0.1:56882",
+					"172.21.0.1:56882",
+					"172.22.0.1:56882",
+					"172.23.0.1:56882",
+					"172.24.0.1:56882",
+					"172.25.0.1:56882",
+					"172.26.0.1:56882",
+					"172.27.0.1:56882",
+					"172.28.0.1:56882"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:13:06.059576787Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2980139549275919,
+				"StableID":   "nC1kxKDiGQ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:778281a8bc8d2f190f04911d0cb5f2060c3b573b56435b64e00de2d8ff70cf7e",
+				"KeyExpiry":  "2026-11-09T09:13:06Z",
+				"DiscoKey":   "discokey:0e35513354b029f8207d7d4bf04d1595a89618f12865580a1763d03f264ba452",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57119",
+					"10.65.0.27:57119",
+					"172.17.0.1:57119",
+					"172.18.0.1:57119",
+					"172.19.0.1:57119",
+					"172.20.0.1:57119",
+					"172.21.0.1:57119",
+					"172.22.0.1:57119",
+					"172.23.0.1:57119",
+					"172.24.0.1:57119",
+					"172.25.0.1:57119",
+					"172.26.0.1:57119",
+					"172.27.0.1:57119",
+					"172.28.0.1:57119"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:13:06.582362451Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7727483352200269,
+				"StableID":   "np41KHtnL321CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3494764321ef3bd81e9ea5ed328f860aa3e9a1a6094042ac16ddef50972a0e13",
+				"KeyExpiry":  "2026-11-09T09:13:07Z",
+				"DiscoKey":   "discokey:7c9cc96f297fce93a0bff696af8e9065246e1dddcce8820d1e4375d76884f000",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:46552",
+					"10.65.0.27:46552",
+					"172.17.0.1:46552",
+					"172.18.0.1:46552",
+					"172.19.0.1:46552",
+					"172.20.0.1:46552",
+					"172.21.0.1:46552",
+					"172.22.0.1:46552",
+					"172.23.0.1:46552",
+					"172.24.0.1:46552",
+					"172.25.0.1:46552",
+					"172.26.0.1:46552",
+					"172.27.0.1:46552",
+					"172.28.0.1:46552"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:13:07.112575941Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4794516992630629": {
+				"ID":          4794516992630629,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7206557288195694,
+				"StableID":   "ny2zrJ3sGy11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       7206557288195694,
+				"Key":        "nodekey:d0e5b5ed54171c5e0678a67c1125a2a8b4d997038a3882c7dec8f97a5cee4801",
+				"DiscoKey":   "discokey:d45c577103e63b846c63df3e17a710b4126afa42360fa9e359f292bc626c7b3b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51060",
+					"10.65.0.27:51060",
+					"172.17.0.1:51060",
+					"172.18.0.1:51060",
+					"172.19.0.1:51060",
+					"172.20.0.1:51060",
+					"172.21.0.1:51060",
+					"172.22.0.1:51060",
+					"172.23.0.1:51060",
+					"172.24.0.1:51060",
+					"172.25.0.1:51060",
+					"172.26.0.1:51060",
+					"172.27.0.1:51060",
+					"172.28.0.1:51060"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:13:00.169667073Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d0e5b5ed54171c5e0678a67c1125a2a8b4d997038a3882c7dec8f97a5cee4801",
+			"MachineKey": "mkey:33b308b47d4b78fc7f85b172cb06bd00f6caa330dfcb1eb058c457400d8d3f16",
+			"Peers": [{
+				"ID":         2567328734081892,
+				"StableID":   "nKewpbNk3M11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9a3edf80566cfe2025a9e4cd4d28991ca2da492f8c2f40dfbace8b4a09a03717",
+				"DiscoKey":   "discokey:5dc5f7d29170494bdab5203619193c0d8d74c1d4224a77b5b1d461f3c7933367",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40530",
+					"10.65.0.27:40530",
+					"172.17.0.1:40530",
+					"172.18.0.1:40530",
+					"172.19.0.1:40530",
+					"172.20.0.1:40530",
+					"172.21.0.1:40530",
+					"172.22.0.1:40530",
+					"172.23.0.1:40530",
+					"172.24.0.1:40530",
+					"172.25.0.1:40530",
+					"172.26.0.1:40530",
+					"172.27.0.1:40530",
+					"172.28.0.1:40530"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:12:59.647166872Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4106394864656361,
+				"StableID":   "nSf4Wj2o4Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:215f6e8a47dfcd7f56e458256cb40fae14c86b1735dfe6c663a015d475a37749",
+				"DiscoKey":   "discokey:83e995e8e6c60c623248419305639fec671109cf8837cc19d992a4ea0aabc038",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40236",
+					"10.65.0.27:40236",
+					"172.17.0.1:40236",
+					"172.18.0.1:40236",
+					"172.19.0.1:40236",
+					"172.20.0.1:40236",
+					"172.21.0.1:40236",
+					"172.22.0.1:40236",
+					"172.23.0.1:40236",
+					"172.24.0.1:40236",
+					"172.25.0.1:40236",
+					"172.26.0.1:40236",
+					"172.27.0.1:40236",
+					"172.28.0.1:40236"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:13:00.72138567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8128686347202576,
+				"StableID":   "nyoA8noVU621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c049dc4190a545ec005bda37dd71345d3527d9875eee9b81a713e5f5aa56d718",
+				"DiscoKey":   "discokey:5bac4af261be794cfafb8d36f595b9ad563b2bebcd85bda11a1e0d76d4d63570",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50062",
+					"10.65.0.27:50062",
+					"172.17.0.1:50062",
+					"172.18.0.1:50062",
+					"172.19.0.1:50062",
+					"172.20.0.1:50062",
+					"172.21.0.1:50062",
+					"172.22.0.1:50062",
+					"172.23.0.1:50062",
+					"172.24.0.1:50062",
+					"172.25.0.1:50062",
+					"172.26.0.1:50062",
+					"172.27.0.1:50062",
+					"172.28.0.1:50062"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:13:01.252552597Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7664065760950815,
+				"StableID":   "naJEwf15r221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe1974aa2836492e1d7621a82d54ce0da7e56eb9be8a240d4f8963b4e9dbaa66",
+				"DiscoKey":   "discokey:91c0b24fd236d13165f37e8a36da74788988076094ba81bc1b7ba11ec0e9684e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41359",
+					"10.65.0.27:41359",
+					"172.17.0.1:41359",
+					"172.18.0.1:41359",
+					"172.19.0.1:41359",
+					"172.20.0.1:41359",
+					"172.21.0.1:41359",
+					"172.22.0.1:41359",
+					"172.23.0.1:41359",
+					"172.24.0.1:41359",
+					"172.25.0.1:41359",
+					"172.26.0.1:41359",
+					"172.27.0.1:41359",
+					"172.28.0.1:41359"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:13:01.779887028Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5669431039962502,
+				"StableID":   "nFbvwhLhGm11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1de5dcd0ef424a06beeb0b92363e94df5b327b3b51432ede5b056e3ac3f9f918",
+				"DiscoKey":   "discokey:06ae531352ce3d4c98a875fb8b032c960179c99f515df59b0a70f7764ac1e238",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40400",
+					"10.65.0.27:40400",
+					"172.17.0.1:40400",
+					"172.18.0.1:40400",
+					"172.19.0.1:40400",
+					"172.20.0.1:40400",
+					"172.21.0.1:40400",
+					"172.22.0.1:40400",
+					"172.23.0.1:40400",
+					"172.24.0.1:40400",
+					"172.25.0.1:40400",
+					"172.26.0.1:40400",
+					"172.27.0.1:40400",
+					"172.28.0.1:40400"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:13:02.311757801Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5130927302190635,
+				"StableID":   "n2WFf4mo4h11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:78b03139cfaefbd82e006f5ebe9cfcee0ba5235c2f016446c83405050fae5031",
+				"DiscoKey":   "discokey:2be290a222fd9e29f4ba6e72ffe63748f694b6890b2f12ee47e46d6eb58ec868",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54766",
+					"10.65.0.27:54766",
+					"172.17.0.1:54766",
+					"172.18.0.1:54766",
+					"172.19.0.1:54766",
+					"172.20.0.1:54766",
+					"172.21.0.1:54766",
+					"172.22.0.1:54766",
+					"172.23.0.1:54766",
+					"172.24.0.1:54766",
+					"172.25.0.1:54766",
+					"172.26.0.1:54766",
+					"172.27.0.1:54766",
+					"172.28.0.1:54766"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:13:02.835145745Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4166281204287168,
+				"StableID":   "nKAGGG9vXZ11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:997819540939b3a2441e4038631e8df0b159445c7cf5938ab375d8a058d47032",
+				"DiscoKey":   "discokey:5476eb0a0556ff05c0f9bfd950437e26b21ad1baa7ecae0ddb0e4b87f80c8e10",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:51700",
+					"10.65.0.27:51700",
+					"172.17.0.1:51700",
+					"172.18.0.1:51700",
+					"172.19.0.1:51700",
+					"172.20.0.1:51700",
+					"172.21.0.1:51700",
+					"172.22.0.1:51700",
+					"172.23.0.1:51700",
+					"172.24.0.1:51700",
+					"172.25.0.1:51700",
+					"172.26.0.1:51700",
+					"172.27.0.1:51700",
+					"172.28.0.1:51700"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:13:03.368157068Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4996382569491718,
+				"StableID":   "n3DkMsVs1g11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:46e8be6fb3bc9c1c5cb6963553d2f490e95f7c71c60ee96bed1f67a751ffa00e",
+				"DiscoKey":   "discokey:f6a27125101f87e31cc72c8d2870bd9b77bbc059c2d9d8bcbf96847f071bc75c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46511",
+					"10.65.0.27:46511",
+					"172.17.0.1:46511",
+					"172.18.0.1:46511",
+					"172.19.0.1:46511",
+					"172.20.0.1:46511",
+					"172.21.0.1:46511",
+					"172.22.0.1:46511",
+					"172.23.0.1:46511",
+					"172.24.0.1:46511",
+					"172.25.0.1:46511",
+					"172.26.0.1:46511",
+					"172.27.0.1:46511",
+					"172.28.0.1:46511"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:13:03.895352755Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8816360523537563,
+				"StableID":   "nSgtFnqwqB21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:df694e52776bcd93de661ecc3794046afef62941b054c74cf14fa551e83d8f7d",
+				"DiscoKey":   "discokey:3da66f21123faa21abdf8268b638e319698540f3370127a5efd152e4d6cca54d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60870",
+					"10.65.0.27:60870",
+					"172.17.0.1:60870",
+					"172.18.0.1:60870",
+					"172.19.0.1:60870",
+					"172.20.0.1:60870",
+					"172.21.0.1:60870",
+					"172.22.0.1:60870",
+					"172.23.0.1:60870",
+					"172.24.0.1:60870",
+					"172.25.0.1:60870",
+					"172.26.0.1:60870",
+					"172.27.0.1:60870",
+					"172.28.0.1:60870"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:13:04.416197291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4794516992630629,
+				"StableID":   "nSV2bDqSSe11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77add75392b721048b328a58d454e34ef02bfbe986727e6b070569d13676bb66",
+				"DiscoKey":   "discokey:1d12ca01b3211d8b85aef2f7a72f410da4c16cbffd521ed7f5a3aaaf4147b703",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40692",
+					"10.65.0.27:40692",
+					"172.17.0.1:40692",
+					"172.18.0.1:40692",
+					"172.19.0.1:40692",
+					"172.20.0.1:40692",
+					"172.21.0.1:40692",
+					"172.22.0.1:40692",
+					"172.23.0.1:40692",
+					"172.24.0.1:40692",
+					"172.25.0.1:40692",
+					"172.26.0.1:40692",
+					"172.27.0.1:40692",
+					"172.28.0.1:40692"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:13:04.959224986Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8954367754846020,
+				"StableID":   "n3xphJ4TvC21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1478f202bcf9d2358a3d4bd05990d244b0ede5e37176f220100c9ab9caddf83f",
+				"DiscoKey":   "discokey:bdfdb84530e8ed69e6a52c1146abe1035638c81ff55c208dd6b77faf1f212961",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36975",
+					"10.65.0.27:36975",
+					"172.17.0.1:36975",
+					"172.18.0.1:36975",
+					"172.19.0.1:36975",
+					"172.20.0.1:36975",
+					"172.21.0.1:36975",
+					"172.22.0.1:36975",
+					"172.23.0.1:36975",
+					"172.24.0.1:36975",
+					"172.25.0.1:36975",
+					"172.26.0.1:36975",
+					"172.27.0.1:36975",
+					"172.28.0.1:36975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:13:05.499755672Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5759216140094256,
+				"StableID":   "n7rsnqqMym11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b1e83ead3c15eebac7d0103510a9eb9007f328d6a78c14678fd1c5e501602f1f",
+				"KeyExpiry":  "2026-11-09T09:13:06Z",
+				"DiscoKey":   "discokey:e9efbe7700ec8a7d48274cdfd3a668450d6b50723236fdc9d5df16ee25fad946",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:56882",
+					"10.65.0.27:56882",
+					"172.17.0.1:56882",
+					"172.18.0.1:56882",
+					"172.19.0.1:56882",
+					"172.20.0.1:56882",
+					"172.21.0.1:56882",
+					"172.22.0.1:56882",
+					"172.23.0.1:56882",
+					"172.24.0.1:56882",
+					"172.25.0.1:56882",
+					"172.26.0.1:56882",
+					"172.27.0.1:56882",
+					"172.28.0.1:56882"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:13:06.059576787Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2980139549275919,
+				"StableID":   "nC1kxKDiGQ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:778281a8bc8d2f190f04911d0cb5f2060c3b573b56435b64e00de2d8ff70cf7e",
+				"KeyExpiry":  "2026-11-09T09:13:06Z",
+				"DiscoKey":   "discokey:0e35513354b029f8207d7d4bf04d1595a89618f12865580a1763d03f264ba452",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57119",
+					"10.65.0.27:57119",
+					"172.17.0.1:57119",
+					"172.18.0.1:57119",
+					"172.19.0.1:57119",
+					"172.20.0.1:57119",
+					"172.21.0.1:57119",
+					"172.22.0.1:57119",
+					"172.23.0.1:57119",
+					"172.24.0.1:57119",
+					"172.25.0.1:57119",
+					"172.26.0.1:57119",
+					"172.27.0.1:57119",
+					"172.28.0.1:57119"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:13:06.582362451Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7727483352200269,
+				"StableID":   "np41KHtnL321CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3494764321ef3bd81e9ea5ed328f860aa3e9a1a6094042ac16ddef50972a0e13",
+				"KeyExpiry":  "2026-11-09T09:13:07Z",
+				"DiscoKey":   "discokey:7c9cc96f297fce93a0bff696af8e9065246e1dddcce8820d1e4375d76884f000",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:46552",
+					"10.65.0.27:46552",
+					"172.17.0.1:46552",
+					"172.18.0.1:46552",
+					"172.19.0.1:46552",
+					"172.20.0.1:46552",
+					"172.21.0.1:46552",
+					"172.22.0.1:46552",
+					"172.23.0.1:46552",
+					"172.24.0.1:46552",
+					"172.25.0.1:46552",
+					"172.26.0.1:46552",
+					"172.27.0.1:46552",
+					"172.28.0.1:46552"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:13:07.112575941Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7206557288195694": {
+				"ID":          7206557288195694,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2567328734081892,
+				"StableID":   "nKewpbNk3M11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       2567328734081892,
+				"Key":        "nodekey:9a3edf80566cfe2025a9e4cd4d28991ca2da492f8c2f40dfbace8b4a09a03717",
+				"DiscoKey":   "discokey:5dc5f7d29170494bdab5203619193c0d8d74c1d4224a77b5b1d461f3c7933367",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40530",
+					"10.65.0.27:40530",
+					"172.17.0.1:40530",
+					"172.18.0.1:40530",
+					"172.19.0.1:40530",
+					"172.20.0.1:40530",
+					"172.21.0.1:40530",
+					"172.22.0.1:40530",
+					"172.23.0.1:40530",
+					"172.24.0.1:40530",
+					"172.25.0.1:40530",
+					"172.26.0.1:40530",
+					"172.27.0.1:40530",
+					"172.28.0.1:40530"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:12:59.647166872Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9a3edf80566cfe2025a9e4cd4d28991ca2da492f8c2f40dfbace8b4a09a03717",
+			"MachineKey": "mkey:c38588f951c1a9ea82cf81a620fe2a6444299264e70757e531aea8dc8dc9095e",
+			"Peers": [{
+				"ID":         7206557288195694,
+				"StableID":   "ny2zrJ3sGy11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0e5b5ed54171c5e0678a67c1125a2a8b4d997038a3882c7dec8f97a5cee4801",
+				"DiscoKey":   "discokey:d45c577103e63b846c63df3e17a710b4126afa42360fa9e359f292bc626c7b3b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51060",
+					"10.65.0.27:51060",
+					"172.17.0.1:51060",
+					"172.18.0.1:51060",
+					"172.19.0.1:51060",
+					"172.20.0.1:51060",
+					"172.21.0.1:51060",
+					"172.22.0.1:51060",
+					"172.23.0.1:51060",
+					"172.24.0.1:51060",
+					"172.25.0.1:51060",
+					"172.26.0.1:51060",
+					"172.27.0.1:51060",
+					"172.28.0.1:51060"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:13:00.169667073Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4106394864656361,
+				"StableID":   "nSf4Wj2o4Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:215f6e8a47dfcd7f56e458256cb40fae14c86b1735dfe6c663a015d475a37749",
+				"DiscoKey":   "discokey:83e995e8e6c60c623248419305639fec671109cf8837cc19d992a4ea0aabc038",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40236",
+					"10.65.0.27:40236",
+					"172.17.0.1:40236",
+					"172.18.0.1:40236",
+					"172.19.0.1:40236",
+					"172.20.0.1:40236",
+					"172.21.0.1:40236",
+					"172.22.0.1:40236",
+					"172.23.0.1:40236",
+					"172.24.0.1:40236",
+					"172.25.0.1:40236",
+					"172.26.0.1:40236",
+					"172.27.0.1:40236",
+					"172.28.0.1:40236"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:13:00.72138567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8128686347202576,
+				"StableID":   "nyoA8noVU621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c049dc4190a545ec005bda37dd71345d3527d9875eee9b81a713e5f5aa56d718",
+				"DiscoKey":   "discokey:5bac4af261be794cfafb8d36f595b9ad563b2bebcd85bda11a1e0d76d4d63570",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50062",
+					"10.65.0.27:50062",
+					"172.17.0.1:50062",
+					"172.18.0.1:50062",
+					"172.19.0.1:50062",
+					"172.20.0.1:50062",
+					"172.21.0.1:50062",
+					"172.22.0.1:50062",
+					"172.23.0.1:50062",
+					"172.24.0.1:50062",
+					"172.25.0.1:50062",
+					"172.26.0.1:50062",
+					"172.27.0.1:50062",
+					"172.28.0.1:50062"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:13:01.252552597Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7664065760950815,
+				"StableID":   "naJEwf15r221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe1974aa2836492e1d7621a82d54ce0da7e56eb9be8a240d4f8963b4e9dbaa66",
+				"DiscoKey":   "discokey:91c0b24fd236d13165f37e8a36da74788988076094ba81bc1b7ba11ec0e9684e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41359",
+					"10.65.0.27:41359",
+					"172.17.0.1:41359",
+					"172.18.0.1:41359",
+					"172.19.0.1:41359",
+					"172.20.0.1:41359",
+					"172.21.0.1:41359",
+					"172.22.0.1:41359",
+					"172.23.0.1:41359",
+					"172.24.0.1:41359",
+					"172.25.0.1:41359",
+					"172.26.0.1:41359",
+					"172.27.0.1:41359",
+					"172.28.0.1:41359"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:13:01.779887028Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5669431039962502,
+				"StableID":   "nFbvwhLhGm11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1de5dcd0ef424a06beeb0b92363e94df5b327b3b51432ede5b056e3ac3f9f918",
+				"DiscoKey":   "discokey:06ae531352ce3d4c98a875fb8b032c960179c99f515df59b0a70f7764ac1e238",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40400",
+					"10.65.0.27:40400",
+					"172.17.0.1:40400",
+					"172.18.0.1:40400",
+					"172.19.0.1:40400",
+					"172.20.0.1:40400",
+					"172.21.0.1:40400",
+					"172.22.0.1:40400",
+					"172.23.0.1:40400",
+					"172.24.0.1:40400",
+					"172.25.0.1:40400",
+					"172.26.0.1:40400",
+					"172.27.0.1:40400",
+					"172.28.0.1:40400"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:13:02.311757801Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5130927302190635,
+				"StableID":   "n2WFf4mo4h11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:78b03139cfaefbd82e006f5ebe9cfcee0ba5235c2f016446c83405050fae5031",
+				"DiscoKey":   "discokey:2be290a222fd9e29f4ba6e72ffe63748f694b6890b2f12ee47e46d6eb58ec868",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54766",
+					"10.65.0.27:54766",
+					"172.17.0.1:54766",
+					"172.18.0.1:54766",
+					"172.19.0.1:54766",
+					"172.20.0.1:54766",
+					"172.21.0.1:54766",
+					"172.22.0.1:54766",
+					"172.23.0.1:54766",
+					"172.24.0.1:54766",
+					"172.25.0.1:54766",
+					"172.26.0.1:54766",
+					"172.27.0.1:54766",
+					"172.28.0.1:54766"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:13:02.835145745Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4166281204287168,
+				"StableID":   "nKAGGG9vXZ11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:997819540939b3a2441e4038631e8df0b159445c7cf5938ab375d8a058d47032",
+				"DiscoKey":   "discokey:5476eb0a0556ff05c0f9bfd950437e26b21ad1baa7ecae0ddb0e4b87f80c8e10",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:51700",
+					"10.65.0.27:51700",
+					"172.17.0.1:51700",
+					"172.18.0.1:51700",
+					"172.19.0.1:51700",
+					"172.20.0.1:51700",
+					"172.21.0.1:51700",
+					"172.22.0.1:51700",
+					"172.23.0.1:51700",
+					"172.24.0.1:51700",
+					"172.25.0.1:51700",
+					"172.26.0.1:51700",
+					"172.27.0.1:51700",
+					"172.28.0.1:51700"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:13:03.368157068Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4996382569491718,
+				"StableID":   "n3DkMsVs1g11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:46e8be6fb3bc9c1c5cb6963553d2f490e95f7c71c60ee96bed1f67a751ffa00e",
+				"DiscoKey":   "discokey:f6a27125101f87e31cc72c8d2870bd9b77bbc059c2d9d8bcbf96847f071bc75c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46511",
+					"10.65.0.27:46511",
+					"172.17.0.1:46511",
+					"172.18.0.1:46511",
+					"172.19.0.1:46511",
+					"172.20.0.1:46511",
+					"172.21.0.1:46511",
+					"172.22.0.1:46511",
+					"172.23.0.1:46511",
+					"172.24.0.1:46511",
+					"172.25.0.1:46511",
+					"172.26.0.1:46511",
+					"172.27.0.1:46511",
+					"172.28.0.1:46511"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:13:03.895352755Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8816360523537563,
+				"StableID":   "nSgtFnqwqB21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:df694e52776bcd93de661ecc3794046afef62941b054c74cf14fa551e83d8f7d",
+				"DiscoKey":   "discokey:3da66f21123faa21abdf8268b638e319698540f3370127a5efd152e4d6cca54d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60870",
+					"10.65.0.27:60870",
+					"172.17.0.1:60870",
+					"172.18.0.1:60870",
+					"172.19.0.1:60870",
+					"172.20.0.1:60870",
+					"172.21.0.1:60870",
+					"172.22.0.1:60870",
+					"172.23.0.1:60870",
+					"172.24.0.1:60870",
+					"172.25.0.1:60870",
+					"172.26.0.1:60870",
+					"172.27.0.1:60870",
+					"172.28.0.1:60870"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:13:04.416197291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4794516992630629,
+				"StableID":   "nSV2bDqSSe11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77add75392b721048b328a58d454e34ef02bfbe986727e6b070569d13676bb66",
+				"DiscoKey":   "discokey:1d12ca01b3211d8b85aef2f7a72f410da4c16cbffd521ed7f5a3aaaf4147b703",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40692",
+					"10.65.0.27:40692",
+					"172.17.0.1:40692",
+					"172.18.0.1:40692",
+					"172.19.0.1:40692",
+					"172.20.0.1:40692",
+					"172.21.0.1:40692",
+					"172.22.0.1:40692",
+					"172.23.0.1:40692",
+					"172.24.0.1:40692",
+					"172.25.0.1:40692",
+					"172.26.0.1:40692",
+					"172.27.0.1:40692",
+					"172.28.0.1:40692"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:13:04.959224986Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8954367754846020,
+				"StableID":   "n3xphJ4TvC21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1478f202bcf9d2358a3d4bd05990d244b0ede5e37176f220100c9ab9caddf83f",
+				"DiscoKey":   "discokey:bdfdb84530e8ed69e6a52c1146abe1035638c81ff55c208dd6b77faf1f212961",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36975",
+					"10.65.0.27:36975",
+					"172.17.0.1:36975",
+					"172.18.0.1:36975",
+					"172.19.0.1:36975",
+					"172.20.0.1:36975",
+					"172.21.0.1:36975",
+					"172.22.0.1:36975",
+					"172.23.0.1:36975",
+					"172.24.0.1:36975",
+					"172.25.0.1:36975",
+					"172.26.0.1:36975",
+					"172.27.0.1:36975",
+					"172.28.0.1:36975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:13:05.499755672Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5759216140094256,
+				"StableID":   "n7rsnqqMym11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b1e83ead3c15eebac7d0103510a9eb9007f328d6a78c14678fd1c5e501602f1f",
+				"KeyExpiry":  "2026-11-09T09:13:06Z",
+				"DiscoKey":   "discokey:e9efbe7700ec8a7d48274cdfd3a668450d6b50723236fdc9d5df16ee25fad946",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:56882",
+					"10.65.0.27:56882",
+					"172.17.0.1:56882",
+					"172.18.0.1:56882",
+					"172.19.0.1:56882",
+					"172.20.0.1:56882",
+					"172.21.0.1:56882",
+					"172.22.0.1:56882",
+					"172.23.0.1:56882",
+					"172.24.0.1:56882",
+					"172.25.0.1:56882",
+					"172.26.0.1:56882",
+					"172.27.0.1:56882",
+					"172.28.0.1:56882"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:13:06.059576787Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2980139549275919,
+				"StableID":   "nC1kxKDiGQ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:778281a8bc8d2f190f04911d0cb5f2060c3b573b56435b64e00de2d8ff70cf7e",
+				"KeyExpiry":  "2026-11-09T09:13:06Z",
+				"DiscoKey":   "discokey:0e35513354b029f8207d7d4bf04d1595a89618f12865580a1763d03f264ba452",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57119",
+					"10.65.0.27:57119",
+					"172.17.0.1:57119",
+					"172.18.0.1:57119",
+					"172.19.0.1:57119",
+					"172.20.0.1:57119",
+					"172.21.0.1:57119",
+					"172.22.0.1:57119",
+					"172.23.0.1:57119",
+					"172.24.0.1:57119",
+					"172.25.0.1:57119",
+					"172.26.0.1:57119",
+					"172.27.0.1:57119",
+					"172.28.0.1:57119"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:13:06.582362451Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7727483352200269,
+				"StableID":   "np41KHtnL321CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3494764321ef3bd81e9ea5ed328f860aa3e9a1a6094042ac16ddef50972a0e13",
+				"KeyExpiry":  "2026-11-09T09:13:07Z",
+				"DiscoKey":   "discokey:7c9cc96f297fce93a0bff696af8e9065246e1dddcce8820d1e4375d76884f000",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:46552",
+					"10.65.0.27:46552",
+					"172.17.0.1:46552",
+					"172.18.0.1:46552",
+					"172.19.0.1:46552",
+					"172.20.0.1:46552",
+					"172.21.0.1:46552",
+					"172.22.0.1:46552",
+					"172.23.0.1:46552",
+					"172.24.0.1:46552",
+					"172.25.0.1:46552",
+					"172.26.0.1:46552",
+					"172.27.0.1:46552",
+					"172.28.0.1:46552"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:13:07.112575941Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2567328734081892": {
+				"ID":          2567328734081892,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7664065760950815,
+				"StableID":   "naJEwf15r221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       7664065760950815,
+				"Key":        "nodekey:fe1974aa2836492e1d7621a82d54ce0da7e56eb9be8a240d4f8963b4e9dbaa66",
+				"DiscoKey":   "discokey:91c0b24fd236d13165f37e8a36da74788988076094ba81bc1b7ba11ec0e9684e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41359",
+					"10.65.0.27:41359",
+					"172.17.0.1:41359",
+					"172.18.0.1:41359",
+					"172.19.0.1:41359",
+					"172.20.0.1:41359",
+					"172.21.0.1:41359",
+					"172.22.0.1:41359",
+					"172.23.0.1:41359",
+					"172.24.0.1:41359",
+					"172.25.0.1:41359",
+					"172.26.0.1:41359",
+					"172.27.0.1:41359",
+					"172.28.0.1:41359"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:13:01.779887028Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:fe1974aa2836492e1d7621a82d54ce0da7e56eb9be8a240d4f8963b4e9dbaa66",
+			"MachineKey": "mkey:2d199b290742f557be8c2974c6d2858b99db13750a00c2d31e390ba8e65c0168",
+			"Peers": [{
+				"ID":         2567328734081892,
+				"StableID":   "nKewpbNk3M11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9a3edf80566cfe2025a9e4cd4d28991ca2da492f8c2f40dfbace8b4a09a03717",
+				"DiscoKey":   "discokey:5dc5f7d29170494bdab5203619193c0d8d74c1d4224a77b5b1d461f3c7933367",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40530",
+					"10.65.0.27:40530",
+					"172.17.0.1:40530",
+					"172.18.0.1:40530",
+					"172.19.0.1:40530",
+					"172.20.0.1:40530",
+					"172.21.0.1:40530",
+					"172.22.0.1:40530",
+					"172.23.0.1:40530",
+					"172.24.0.1:40530",
+					"172.25.0.1:40530",
+					"172.26.0.1:40530",
+					"172.27.0.1:40530",
+					"172.28.0.1:40530"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:12:59.647166872Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7206557288195694,
+				"StableID":   "ny2zrJ3sGy11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0e5b5ed54171c5e0678a67c1125a2a8b4d997038a3882c7dec8f97a5cee4801",
+				"DiscoKey":   "discokey:d45c577103e63b846c63df3e17a710b4126afa42360fa9e359f292bc626c7b3b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51060",
+					"10.65.0.27:51060",
+					"172.17.0.1:51060",
+					"172.18.0.1:51060",
+					"172.19.0.1:51060",
+					"172.20.0.1:51060",
+					"172.21.0.1:51060",
+					"172.22.0.1:51060",
+					"172.23.0.1:51060",
+					"172.24.0.1:51060",
+					"172.25.0.1:51060",
+					"172.26.0.1:51060",
+					"172.27.0.1:51060",
+					"172.28.0.1:51060"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:13:00.169667073Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4106394864656361,
+				"StableID":   "nSf4Wj2o4Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:215f6e8a47dfcd7f56e458256cb40fae14c86b1735dfe6c663a015d475a37749",
+				"DiscoKey":   "discokey:83e995e8e6c60c623248419305639fec671109cf8837cc19d992a4ea0aabc038",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40236",
+					"10.65.0.27:40236",
+					"172.17.0.1:40236",
+					"172.18.0.1:40236",
+					"172.19.0.1:40236",
+					"172.20.0.1:40236",
+					"172.21.0.1:40236",
+					"172.22.0.1:40236",
+					"172.23.0.1:40236",
+					"172.24.0.1:40236",
+					"172.25.0.1:40236",
+					"172.26.0.1:40236",
+					"172.27.0.1:40236",
+					"172.28.0.1:40236"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:13:00.72138567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8128686347202576,
+				"StableID":   "nyoA8noVU621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c049dc4190a545ec005bda37dd71345d3527d9875eee9b81a713e5f5aa56d718",
+				"DiscoKey":   "discokey:5bac4af261be794cfafb8d36f595b9ad563b2bebcd85bda11a1e0d76d4d63570",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50062",
+					"10.65.0.27:50062",
+					"172.17.0.1:50062",
+					"172.18.0.1:50062",
+					"172.19.0.1:50062",
+					"172.20.0.1:50062",
+					"172.21.0.1:50062",
+					"172.22.0.1:50062",
+					"172.23.0.1:50062",
+					"172.24.0.1:50062",
+					"172.25.0.1:50062",
+					"172.26.0.1:50062",
+					"172.27.0.1:50062",
+					"172.28.0.1:50062"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:13:01.252552597Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5669431039962502,
+				"StableID":   "nFbvwhLhGm11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1de5dcd0ef424a06beeb0b92363e94df5b327b3b51432ede5b056e3ac3f9f918",
+				"DiscoKey":   "discokey:06ae531352ce3d4c98a875fb8b032c960179c99f515df59b0a70f7764ac1e238",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40400",
+					"10.65.0.27:40400",
+					"172.17.0.1:40400",
+					"172.18.0.1:40400",
+					"172.19.0.1:40400",
+					"172.20.0.1:40400",
+					"172.21.0.1:40400",
+					"172.22.0.1:40400",
+					"172.23.0.1:40400",
+					"172.24.0.1:40400",
+					"172.25.0.1:40400",
+					"172.26.0.1:40400",
+					"172.27.0.1:40400",
+					"172.28.0.1:40400"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:13:02.311757801Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5130927302190635,
+				"StableID":   "n2WFf4mo4h11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:78b03139cfaefbd82e006f5ebe9cfcee0ba5235c2f016446c83405050fae5031",
+				"DiscoKey":   "discokey:2be290a222fd9e29f4ba6e72ffe63748f694b6890b2f12ee47e46d6eb58ec868",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54766",
+					"10.65.0.27:54766",
+					"172.17.0.1:54766",
+					"172.18.0.1:54766",
+					"172.19.0.1:54766",
+					"172.20.0.1:54766",
+					"172.21.0.1:54766",
+					"172.22.0.1:54766",
+					"172.23.0.1:54766",
+					"172.24.0.1:54766",
+					"172.25.0.1:54766",
+					"172.26.0.1:54766",
+					"172.27.0.1:54766",
+					"172.28.0.1:54766"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:13:02.835145745Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4166281204287168,
+				"StableID":   "nKAGGG9vXZ11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:997819540939b3a2441e4038631e8df0b159445c7cf5938ab375d8a058d47032",
+				"DiscoKey":   "discokey:5476eb0a0556ff05c0f9bfd950437e26b21ad1baa7ecae0ddb0e4b87f80c8e10",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:51700",
+					"10.65.0.27:51700",
+					"172.17.0.1:51700",
+					"172.18.0.1:51700",
+					"172.19.0.1:51700",
+					"172.20.0.1:51700",
+					"172.21.0.1:51700",
+					"172.22.0.1:51700",
+					"172.23.0.1:51700",
+					"172.24.0.1:51700",
+					"172.25.0.1:51700",
+					"172.26.0.1:51700",
+					"172.27.0.1:51700",
+					"172.28.0.1:51700"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:13:03.368157068Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4996382569491718,
+				"StableID":   "n3DkMsVs1g11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:46e8be6fb3bc9c1c5cb6963553d2f490e95f7c71c60ee96bed1f67a751ffa00e",
+				"DiscoKey":   "discokey:f6a27125101f87e31cc72c8d2870bd9b77bbc059c2d9d8bcbf96847f071bc75c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46511",
+					"10.65.0.27:46511",
+					"172.17.0.1:46511",
+					"172.18.0.1:46511",
+					"172.19.0.1:46511",
+					"172.20.0.1:46511",
+					"172.21.0.1:46511",
+					"172.22.0.1:46511",
+					"172.23.0.1:46511",
+					"172.24.0.1:46511",
+					"172.25.0.1:46511",
+					"172.26.0.1:46511",
+					"172.27.0.1:46511",
+					"172.28.0.1:46511"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:13:03.895352755Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8816360523537563,
+				"StableID":   "nSgtFnqwqB21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:df694e52776bcd93de661ecc3794046afef62941b054c74cf14fa551e83d8f7d",
+				"DiscoKey":   "discokey:3da66f21123faa21abdf8268b638e319698540f3370127a5efd152e4d6cca54d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60870",
+					"10.65.0.27:60870",
+					"172.17.0.1:60870",
+					"172.18.0.1:60870",
+					"172.19.0.1:60870",
+					"172.20.0.1:60870",
+					"172.21.0.1:60870",
+					"172.22.0.1:60870",
+					"172.23.0.1:60870",
+					"172.24.0.1:60870",
+					"172.25.0.1:60870",
+					"172.26.0.1:60870",
+					"172.27.0.1:60870",
+					"172.28.0.1:60870"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:13:04.416197291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4794516992630629,
+				"StableID":   "nSV2bDqSSe11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77add75392b721048b328a58d454e34ef02bfbe986727e6b070569d13676bb66",
+				"DiscoKey":   "discokey:1d12ca01b3211d8b85aef2f7a72f410da4c16cbffd521ed7f5a3aaaf4147b703",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40692",
+					"10.65.0.27:40692",
+					"172.17.0.1:40692",
+					"172.18.0.1:40692",
+					"172.19.0.1:40692",
+					"172.20.0.1:40692",
+					"172.21.0.1:40692",
+					"172.22.0.1:40692",
+					"172.23.0.1:40692",
+					"172.24.0.1:40692",
+					"172.25.0.1:40692",
+					"172.26.0.1:40692",
+					"172.27.0.1:40692",
+					"172.28.0.1:40692"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:13:04.959224986Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8954367754846020,
+				"StableID":   "n3xphJ4TvC21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1478f202bcf9d2358a3d4bd05990d244b0ede5e37176f220100c9ab9caddf83f",
+				"DiscoKey":   "discokey:bdfdb84530e8ed69e6a52c1146abe1035638c81ff55c208dd6b77faf1f212961",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36975",
+					"10.65.0.27:36975",
+					"172.17.0.1:36975",
+					"172.18.0.1:36975",
+					"172.19.0.1:36975",
+					"172.20.0.1:36975",
+					"172.21.0.1:36975",
+					"172.22.0.1:36975",
+					"172.23.0.1:36975",
+					"172.24.0.1:36975",
+					"172.25.0.1:36975",
+					"172.26.0.1:36975",
+					"172.27.0.1:36975",
+					"172.28.0.1:36975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:13:05.499755672Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5759216140094256,
+				"StableID":   "n7rsnqqMym11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b1e83ead3c15eebac7d0103510a9eb9007f328d6a78c14678fd1c5e501602f1f",
+				"KeyExpiry":  "2026-11-09T09:13:06Z",
+				"DiscoKey":   "discokey:e9efbe7700ec8a7d48274cdfd3a668450d6b50723236fdc9d5df16ee25fad946",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:56882",
+					"10.65.0.27:56882",
+					"172.17.0.1:56882",
+					"172.18.0.1:56882",
+					"172.19.0.1:56882",
+					"172.20.0.1:56882",
+					"172.21.0.1:56882",
+					"172.22.0.1:56882",
+					"172.23.0.1:56882",
+					"172.24.0.1:56882",
+					"172.25.0.1:56882",
+					"172.26.0.1:56882",
+					"172.27.0.1:56882",
+					"172.28.0.1:56882"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:13:06.059576787Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2980139549275919,
+				"StableID":   "nC1kxKDiGQ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:778281a8bc8d2f190f04911d0cb5f2060c3b573b56435b64e00de2d8ff70cf7e",
+				"KeyExpiry":  "2026-11-09T09:13:06Z",
+				"DiscoKey":   "discokey:0e35513354b029f8207d7d4bf04d1595a89618f12865580a1763d03f264ba452",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57119",
+					"10.65.0.27:57119",
+					"172.17.0.1:57119",
+					"172.18.0.1:57119",
+					"172.19.0.1:57119",
+					"172.20.0.1:57119",
+					"172.21.0.1:57119",
+					"172.22.0.1:57119",
+					"172.23.0.1:57119",
+					"172.24.0.1:57119",
+					"172.25.0.1:57119",
+					"172.26.0.1:57119",
+					"172.27.0.1:57119",
+					"172.28.0.1:57119"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:13:06.582362451Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7727483352200269,
+				"StableID":   "np41KHtnL321CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3494764321ef3bd81e9ea5ed328f860aa3e9a1a6094042ac16ddef50972a0e13",
+				"KeyExpiry":  "2026-11-09T09:13:07Z",
+				"DiscoKey":   "discokey:7c9cc96f297fce93a0bff696af8e9065246e1dddcce8820d1e4375d76884f000",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:46552",
+					"10.65.0.27:46552",
+					"172.17.0.1:46552",
+					"172.18.0.1:46552",
+					"172.19.0.1:46552",
+					"172.20.0.1:46552",
+					"172.21.0.1:46552",
+					"172.22.0.1:46552",
+					"172.23.0.1:46552",
+					"172.24.0.1:46552",
+					"172.25.0.1:46552",
+					"172.26.0.1:46552",
+					"172.27.0.1:46552",
+					"172.28.0.1:46552"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:13:07.112575941Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7664065760950815": {
+				"ID":          7664065760950815,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8128686347202576,
+				"StableID":   "nyoA8noVU621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       8128686347202576,
+				"Key":        "nodekey:c049dc4190a545ec005bda37dd71345d3527d9875eee9b81a713e5f5aa56d718",
+				"DiscoKey":   "discokey:5bac4af261be794cfafb8d36f595b9ad563b2bebcd85bda11a1e0d76d4d63570",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50062",
+					"10.65.0.27:50062",
+					"172.17.0.1:50062",
+					"172.18.0.1:50062",
+					"172.19.0.1:50062",
+					"172.20.0.1:50062",
+					"172.21.0.1:50062",
+					"172.22.0.1:50062",
+					"172.23.0.1:50062",
+					"172.24.0.1:50062",
+					"172.25.0.1:50062",
+					"172.26.0.1:50062",
+					"172.27.0.1:50062",
+					"172.28.0.1:50062"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:13:01.252552597Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c049dc4190a545ec005bda37dd71345d3527d9875eee9b81a713e5f5aa56d718",
+			"MachineKey": "mkey:2365f4985a1d205d7a0a2d5d2fc5711aef208dfffefffe6b09675f9f27711864",
+			"Peers": [{
+				"ID":         2567328734081892,
+				"StableID":   "nKewpbNk3M11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9a3edf80566cfe2025a9e4cd4d28991ca2da492f8c2f40dfbace8b4a09a03717",
+				"DiscoKey":   "discokey:5dc5f7d29170494bdab5203619193c0d8d74c1d4224a77b5b1d461f3c7933367",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40530",
+					"10.65.0.27:40530",
+					"172.17.0.1:40530",
+					"172.18.0.1:40530",
+					"172.19.0.1:40530",
+					"172.20.0.1:40530",
+					"172.21.0.1:40530",
+					"172.22.0.1:40530",
+					"172.23.0.1:40530",
+					"172.24.0.1:40530",
+					"172.25.0.1:40530",
+					"172.26.0.1:40530",
+					"172.27.0.1:40530",
+					"172.28.0.1:40530"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:12:59.647166872Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7206557288195694,
+				"StableID":   "ny2zrJ3sGy11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0e5b5ed54171c5e0678a67c1125a2a8b4d997038a3882c7dec8f97a5cee4801",
+				"DiscoKey":   "discokey:d45c577103e63b846c63df3e17a710b4126afa42360fa9e359f292bc626c7b3b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51060",
+					"10.65.0.27:51060",
+					"172.17.0.1:51060",
+					"172.18.0.1:51060",
+					"172.19.0.1:51060",
+					"172.20.0.1:51060",
+					"172.21.0.1:51060",
+					"172.22.0.1:51060",
+					"172.23.0.1:51060",
+					"172.24.0.1:51060",
+					"172.25.0.1:51060",
+					"172.26.0.1:51060",
+					"172.27.0.1:51060",
+					"172.28.0.1:51060"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:13:00.169667073Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4106394864656361,
+				"StableID":   "nSf4Wj2o4Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:215f6e8a47dfcd7f56e458256cb40fae14c86b1735dfe6c663a015d475a37749",
+				"DiscoKey":   "discokey:83e995e8e6c60c623248419305639fec671109cf8837cc19d992a4ea0aabc038",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40236",
+					"10.65.0.27:40236",
+					"172.17.0.1:40236",
+					"172.18.0.1:40236",
+					"172.19.0.1:40236",
+					"172.20.0.1:40236",
+					"172.21.0.1:40236",
+					"172.22.0.1:40236",
+					"172.23.0.1:40236",
+					"172.24.0.1:40236",
+					"172.25.0.1:40236",
+					"172.26.0.1:40236",
+					"172.27.0.1:40236",
+					"172.28.0.1:40236"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:13:00.72138567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7664065760950815,
+				"StableID":   "naJEwf15r221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe1974aa2836492e1d7621a82d54ce0da7e56eb9be8a240d4f8963b4e9dbaa66",
+				"DiscoKey":   "discokey:91c0b24fd236d13165f37e8a36da74788988076094ba81bc1b7ba11ec0e9684e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41359",
+					"10.65.0.27:41359",
+					"172.17.0.1:41359",
+					"172.18.0.1:41359",
+					"172.19.0.1:41359",
+					"172.20.0.1:41359",
+					"172.21.0.1:41359",
+					"172.22.0.1:41359",
+					"172.23.0.1:41359",
+					"172.24.0.1:41359",
+					"172.25.0.1:41359",
+					"172.26.0.1:41359",
+					"172.27.0.1:41359",
+					"172.28.0.1:41359"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:13:01.779887028Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5669431039962502,
+				"StableID":   "nFbvwhLhGm11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1de5dcd0ef424a06beeb0b92363e94df5b327b3b51432ede5b056e3ac3f9f918",
+				"DiscoKey":   "discokey:06ae531352ce3d4c98a875fb8b032c960179c99f515df59b0a70f7764ac1e238",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40400",
+					"10.65.0.27:40400",
+					"172.17.0.1:40400",
+					"172.18.0.1:40400",
+					"172.19.0.1:40400",
+					"172.20.0.1:40400",
+					"172.21.0.1:40400",
+					"172.22.0.1:40400",
+					"172.23.0.1:40400",
+					"172.24.0.1:40400",
+					"172.25.0.1:40400",
+					"172.26.0.1:40400",
+					"172.27.0.1:40400",
+					"172.28.0.1:40400"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:13:02.311757801Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5130927302190635,
+				"StableID":   "n2WFf4mo4h11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:78b03139cfaefbd82e006f5ebe9cfcee0ba5235c2f016446c83405050fae5031",
+				"DiscoKey":   "discokey:2be290a222fd9e29f4ba6e72ffe63748f694b6890b2f12ee47e46d6eb58ec868",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54766",
+					"10.65.0.27:54766",
+					"172.17.0.1:54766",
+					"172.18.0.1:54766",
+					"172.19.0.1:54766",
+					"172.20.0.1:54766",
+					"172.21.0.1:54766",
+					"172.22.0.1:54766",
+					"172.23.0.1:54766",
+					"172.24.0.1:54766",
+					"172.25.0.1:54766",
+					"172.26.0.1:54766",
+					"172.27.0.1:54766",
+					"172.28.0.1:54766"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:13:02.835145745Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4166281204287168,
+				"StableID":   "nKAGGG9vXZ11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:997819540939b3a2441e4038631e8df0b159445c7cf5938ab375d8a058d47032",
+				"DiscoKey":   "discokey:5476eb0a0556ff05c0f9bfd950437e26b21ad1baa7ecae0ddb0e4b87f80c8e10",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:51700",
+					"10.65.0.27:51700",
+					"172.17.0.1:51700",
+					"172.18.0.1:51700",
+					"172.19.0.1:51700",
+					"172.20.0.1:51700",
+					"172.21.0.1:51700",
+					"172.22.0.1:51700",
+					"172.23.0.1:51700",
+					"172.24.0.1:51700",
+					"172.25.0.1:51700",
+					"172.26.0.1:51700",
+					"172.27.0.1:51700",
+					"172.28.0.1:51700"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:13:03.368157068Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4996382569491718,
+				"StableID":   "n3DkMsVs1g11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:46e8be6fb3bc9c1c5cb6963553d2f490e95f7c71c60ee96bed1f67a751ffa00e",
+				"DiscoKey":   "discokey:f6a27125101f87e31cc72c8d2870bd9b77bbc059c2d9d8bcbf96847f071bc75c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46511",
+					"10.65.0.27:46511",
+					"172.17.0.1:46511",
+					"172.18.0.1:46511",
+					"172.19.0.1:46511",
+					"172.20.0.1:46511",
+					"172.21.0.1:46511",
+					"172.22.0.1:46511",
+					"172.23.0.1:46511",
+					"172.24.0.1:46511",
+					"172.25.0.1:46511",
+					"172.26.0.1:46511",
+					"172.27.0.1:46511",
+					"172.28.0.1:46511"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:13:03.895352755Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8816360523537563,
+				"StableID":   "nSgtFnqwqB21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:df694e52776bcd93de661ecc3794046afef62941b054c74cf14fa551e83d8f7d",
+				"DiscoKey":   "discokey:3da66f21123faa21abdf8268b638e319698540f3370127a5efd152e4d6cca54d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60870",
+					"10.65.0.27:60870",
+					"172.17.0.1:60870",
+					"172.18.0.1:60870",
+					"172.19.0.1:60870",
+					"172.20.0.1:60870",
+					"172.21.0.1:60870",
+					"172.22.0.1:60870",
+					"172.23.0.1:60870",
+					"172.24.0.1:60870",
+					"172.25.0.1:60870",
+					"172.26.0.1:60870",
+					"172.27.0.1:60870",
+					"172.28.0.1:60870"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:13:04.416197291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4794516992630629,
+				"StableID":   "nSV2bDqSSe11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77add75392b721048b328a58d454e34ef02bfbe986727e6b070569d13676bb66",
+				"DiscoKey":   "discokey:1d12ca01b3211d8b85aef2f7a72f410da4c16cbffd521ed7f5a3aaaf4147b703",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40692",
+					"10.65.0.27:40692",
+					"172.17.0.1:40692",
+					"172.18.0.1:40692",
+					"172.19.0.1:40692",
+					"172.20.0.1:40692",
+					"172.21.0.1:40692",
+					"172.22.0.1:40692",
+					"172.23.0.1:40692",
+					"172.24.0.1:40692",
+					"172.25.0.1:40692",
+					"172.26.0.1:40692",
+					"172.27.0.1:40692",
+					"172.28.0.1:40692"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:13:04.959224986Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8954367754846020,
+				"StableID":   "n3xphJ4TvC21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1478f202bcf9d2358a3d4bd05990d244b0ede5e37176f220100c9ab9caddf83f",
+				"DiscoKey":   "discokey:bdfdb84530e8ed69e6a52c1146abe1035638c81ff55c208dd6b77faf1f212961",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36975",
+					"10.65.0.27:36975",
+					"172.17.0.1:36975",
+					"172.18.0.1:36975",
+					"172.19.0.1:36975",
+					"172.20.0.1:36975",
+					"172.21.0.1:36975",
+					"172.22.0.1:36975",
+					"172.23.0.1:36975",
+					"172.24.0.1:36975",
+					"172.25.0.1:36975",
+					"172.26.0.1:36975",
+					"172.27.0.1:36975",
+					"172.28.0.1:36975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:13:05.499755672Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5759216140094256,
+				"StableID":   "n7rsnqqMym11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b1e83ead3c15eebac7d0103510a9eb9007f328d6a78c14678fd1c5e501602f1f",
+				"KeyExpiry":  "2026-11-09T09:13:06Z",
+				"DiscoKey":   "discokey:e9efbe7700ec8a7d48274cdfd3a668450d6b50723236fdc9d5df16ee25fad946",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:56882",
+					"10.65.0.27:56882",
+					"172.17.0.1:56882",
+					"172.18.0.1:56882",
+					"172.19.0.1:56882",
+					"172.20.0.1:56882",
+					"172.21.0.1:56882",
+					"172.22.0.1:56882",
+					"172.23.0.1:56882",
+					"172.24.0.1:56882",
+					"172.25.0.1:56882",
+					"172.26.0.1:56882",
+					"172.27.0.1:56882",
+					"172.28.0.1:56882"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:13:06.059576787Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2980139549275919,
+				"StableID":   "nC1kxKDiGQ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:778281a8bc8d2f190f04911d0cb5f2060c3b573b56435b64e00de2d8ff70cf7e",
+				"KeyExpiry":  "2026-11-09T09:13:06Z",
+				"DiscoKey":   "discokey:0e35513354b029f8207d7d4bf04d1595a89618f12865580a1763d03f264ba452",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57119",
+					"10.65.0.27:57119",
+					"172.17.0.1:57119",
+					"172.18.0.1:57119",
+					"172.19.0.1:57119",
+					"172.20.0.1:57119",
+					"172.21.0.1:57119",
+					"172.22.0.1:57119",
+					"172.23.0.1:57119",
+					"172.24.0.1:57119",
+					"172.25.0.1:57119",
+					"172.26.0.1:57119",
+					"172.27.0.1:57119",
+					"172.28.0.1:57119"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:13:06.582362451Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7727483352200269,
+				"StableID":   "np41KHtnL321CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3494764321ef3bd81e9ea5ed328f860aa3e9a1a6094042ac16ddef50972a0e13",
+				"KeyExpiry":  "2026-11-09T09:13:07Z",
+				"DiscoKey":   "discokey:7c9cc96f297fce93a0bff696af8e9065246e1dddcce8820d1e4375d76884f000",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:46552",
+					"10.65.0.27:46552",
+					"172.17.0.1:46552",
+					"172.18.0.1:46552",
+					"172.19.0.1:46552",
+					"172.20.0.1:46552",
+					"172.21.0.1:46552",
+					"172.22.0.1:46552",
+					"172.23.0.1:46552",
+					"172.24.0.1:46552",
+					"172.25.0.1:46552",
+					"172.26.0.1:46552",
+					"172.27.0.1:46552",
+					"172.28.0.1:46552"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:13:07.112575941Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8128686347202576": {
+				"ID":          8128686347202576,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5130927302190635,
+				"StableID":   "n2WFf4mo4h11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       5130927302190635,
+				"Key":        "nodekey:78b03139cfaefbd82e006f5ebe9cfcee0ba5235c2f016446c83405050fae5031",
+				"DiscoKey":   "discokey:2be290a222fd9e29f4ba6e72ffe63748f694b6890b2f12ee47e46d6eb58ec868",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54766",
+					"10.65.0.27:54766",
+					"172.17.0.1:54766",
+					"172.18.0.1:54766",
+					"172.19.0.1:54766",
+					"172.20.0.1:54766",
+					"172.21.0.1:54766",
+					"172.22.0.1:54766",
+					"172.23.0.1:54766",
+					"172.24.0.1:54766",
+					"172.25.0.1:54766",
+					"172.26.0.1:54766",
+					"172.27.0.1:54766",
+					"172.28.0.1:54766"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:13:02.835145745Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:78b03139cfaefbd82e006f5ebe9cfcee0ba5235c2f016446c83405050fae5031",
+			"MachineKey": "mkey:21002cd7755286e96e0023c8eda27a45c4ddb2f81c7c9be01b675e9d8cf11f23",
+			"Peers": [{
+				"ID":         2567328734081892,
+				"StableID":   "nKewpbNk3M11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9a3edf80566cfe2025a9e4cd4d28991ca2da492f8c2f40dfbace8b4a09a03717",
+				"DiscoKey":   "discokey:5dc5f7d29170494bdab5203619193c0d8d74c1d4224a77b5b1d461f3c7933367",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40530",
+					"10.65.0.27:40530",
+					"172.17.0.1:40530",
+					"172.18.0.1:40530",
+					"172.19.0.1:40530",
+					"172.20.0.1:40530",
+					"172.21.0.1:40530",
+					"172.22.0.1:40530",
+					"172.23.0.1:40530",
+					"172.24.0.1:40530",
+					"172.25.0.1:40530",
+					"172.26.0.1:40530",
+					"172.27.0.1:40530",
+					"172.28.0.1:40530"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:12:59.647166872Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7206557288195694,
+				"StableID":   "ny2zrJ3sGy11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0e5b5ed54171c5e0678a67c1125a2a8b4d997038a3882c7dec8f97a5cee4801",
+				"DiscoKey":   "discokey:d45c577103e63b846c63df3e17a710b4126afa42360fa9e359f292bc626c7b3b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51060",
+					"10.65.0.27:51060",
+					"172.17.0.1:51060",
+					"172.18.0.1:51060",
+					"172.19.0.1:51060",
+					"172.20.0.1:51060",
+					"172.21.0.1:51060",
+					"172.22.0.1:51060",
+					"172.23.0.1:51060",
+					"172.24.0.1:51060",
+					"172.25.0.1:51060",
+					"172.26.0.1:51060",
+					"172.27.0.1:51060",
+					"172.28.0.1:51060"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:13:00.169667073Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4106394864656361,
+				"StableID":   "nSf4Wj2o4Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:215f6e8a47dfcd7f56e458256cb40fae14c86b1735dfe6c663a015d475a37749",
+				"DiscoKey":   "discokey:83e995e8e6c60c623248419305639fec671109cf8837cc19d992a4ea0aabc038",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40236",
+					"10.65.0.27:40236",
+					"172.17.0.1:40236",
+					"172.18.0.1:40236",
+					"172.19.0.1:40236",
+					"172.20.0.1:40236",
+					"172.21.0.1:40236",
+					"172.22.0.1:40236",
+					"172.23.0.1:40236",
+					"172.24.0.1:40236",
+					"172.25.0.1:40236",
+					"172.26.0.1:40236",
+					"172.27.0.1:40236",
+					"172.28.0.1:40236"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:13:00.72138567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8128686347202576,
+				"StableID":   "nyoA8noVU621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c049dc4190a545ec005bda37dd71345d3527d9875eee9b81a713e5f5aa56d718",
+				"DiscoKey":   "discokey:5bac4af261be794cfafb8d36f595b9ad563b2bebcd85bda11a1e0d76d4d63570",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50062",
+					"10.65.0.27:50062",
+					"172.17.0.1:50062",
+					"172.18.0.1:50062",
+					"172.19.0.1:50062",
+					"172.20.0.1:50062",
+					"172.21.0.1:50062",
+					"172.22.0.1:50062",
+					"172.23.0.1:50062",
+					"172.24.0.1:50062",
+					"172.25.0.1:50062",
+					"172.26.0.1:50062",
+					"172.27.0.1:50062",
+					"172.28.0.1:50062"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:13:01.252552597Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7664065760950815,
+				"StableID":   "naJEwf15r221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe1974aa2836492e1d7621a82d54ce0da7e56eb9be8a240d4f8963b4e9dbaa66",
+				"DiscoKey":   "discokey:91c0b24fd236d13165f37e8a36da74788988076094ba81bc1b7ba11ec0e9684e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41359",
+					"10.65.0.27:41359",
+					"172.17.0.1:41359",
+					"172.18.0.1:41359",
+					"172.19.0.1:41359",
+					"172.20.0.1:41359",
+					"172.21.0.1:41359",
+					"172.22.0.1:41359",
+					"172.23.0.1:41359",
+					"172.24.0.1:41359",
+					"172.25.0.1:41359",
+					"172.26.0.1:41359",
+					"172.27.0.1:41359",
+					"172.28.0.1:41359"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:13:01.779887028Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5669431039962502,
+				"StableID":   "nFbvwhLhGm11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1de5dcd0ef424a06beeb0b92363e94df5b327b3b51432ede5b056e3ac3f9f918",
+				"DiscoKey":   "discokey:06ae531352ce3d4c98a875fb8b032c960179c99f515df59b0a70f7764ac1e238",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40400",
+					"10.65.0.27:40400",
+					"172.17.0.1:40400",
+					"172.18.0.1:40400",
+					"172.19.0.1:40400",
+					"172.20.0.1:40400",
+					"172.21.0.1:40400",
+					"172.22.0.1:40400",
+					"172.23.0.1:40400",
+					"172.24.0.1:40400",
+					"172.25.0.1:40400",
+					"172.26.0.1:40400",
+					"172.27.0.1:40400",
+					"172.28.0.1:40400"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:13:02.311757801Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4166281204287168,
+				"StableID":   "nKAGGG9vXZ11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:997819540939b3a2441e4038631e8df0b159445c7cf5938ab375d8a058d47032",
+				"DiscoKey":   "discokey:5476eb0a0556ff05c0f9bfd950437e26b21ad1baa7ecae0ddb0e4b87f80c8e10",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:51700",
+					"10.65.0.27:51700",
+					"172.17.0.1:51700",
+					"172.18.0.1:51700",
+					"172.19.0.1:51700",
+					"172.20.0.1:51700",
+					"172.21.0.1:51700",
+					"172.22.0.1:51700",
+					"172.23.0.1:51700",
+					"172.24.0.1:51700",
+					"172.25.0.1:51700",
+					"172.26.0.1:51700",
+					"172.27.0.1:51700",
+					"172.28.0.1:51700"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:13:03.368157068Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4996382569491718,
+				"StableID":   "n3DkMsVs1g11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:46e8be6fb3bc9c1c5cb6963553d2f490e95f7c71c60ee96bed1f67a751ffa00e",
+				"DiscoKey":   "discokey:f6a27125101f87e31cc72c8d2870bd9b77bbc059c2d9d8bcbf96847f071bc75c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46511",
+					"10.65.0.27:46511",
+					"172.17.0.1:46511",
+					"172.18.0.1:46511",
+					"172.19.0.1:46511",
+					"172.20.0.1:46511",
+					"172.21.0.1:46511",
+					"172.22.0.1:46511",
+					"172.23.0.1:46511",
+					"172.24.0.1:46511",
+					"172.25.0.1:46511",
+					"172.26.0.1:46511",
+					"172.27.0.1:46511",
+					"172.28.0.1:46511"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:13:03.895352755Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8816360523537563,
+				"StableID":   "nSgtFnqwqB21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:df694e52776bcd93de661ecc3794046afef62941b054c74cf14fa551e83d8f7d",
+				"DiscoKey":   "discokey:3da66f21123faa21abdf8268b638e319698540f3370127a5efd152e4d6cca54d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60870",
+					"10.65.0.27:60870",
+					"172.17.0.1:60870",
+					"172.18.0.1:60870",
+					"172.19.0.1:60870",
+					"172.20.0.1:60870",
+					"172.21.0.1:60870",
+					"172.22.0.1:60870",
+					"172.23.0.1:60870",
+					"172.24.0.1:60870",
+					"172.25.0.1:60870",
+					"172.26.0.1:60870",
+					"172.27.0.1:60870",
+					"172.28.0.1:60870"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:13:04.416197291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4794516992630629,
+				"StableID":   "nSV2bDqSSe11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77add75392b721048b328a58d454e34ef02bfbe986727e6b070569d13676bb66",
+				"DiscoKey":   "discokey:1d12ca01b3211d8b85aef2f7a72f410da4c16cbffd521ed7f5a3aaaf4147b703",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40692",
+					"10.65.0.27:40692",
+					"172.17.0.1:40692",
+					"172.18.0.1:40692",
+					"172.19.0.1:40692",
+					"172.20.0.1:40692",
+					"172.21.0.1:40692",
+					"172.22.0.1:40692",
+					"172.23.0.1:40692",
+					"172.24.0.1:40692",
+					"172.25.0.1:40692",
+					"172.26.0.1:40692",
+					"172.27.0.1:40692",
+					"172.28.0.1:40692"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:13:04.959224986Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8954367754846020,
+				"StableID":   "n3xphJ4TvC21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1478f202bcf9d2358a3d4bd05990d244b0ede5e37176f220100c9ab9caddf83f",
+				"DiscoKey":   "discokey:bdfdb84530e8ed69e6a52c1146abe1035638c81ff55c208dd6b77faf1f212961",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36975",
+					"10.65.0.27:36975",
+					"172.17.0.1:36975",
+					"172.18.0.1:36975",
+					"172.19.0.1:36975",
+					"172.20.0.1:36975",
+					"172.21.0.1:36975",
+					"172.22.0.1:36975",
+					"172.23.0.1:36975",
+					"172.24.0.1:36975",
+					"172.25.0.1:36975",
+					"172.26.0.1:36975",
+					"172.27.0.1:36975",
+					"172.28.0.1:36975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:13:05.499755672Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5759216140094256,
+				"StableID":   "n7rsnqqMym11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b1e83ead3c15eebac7d0103510a9eb9007f328d6a78c14678fd1c5e501602f1f",
+				"KeyExpiry":  "2026-11-09T09:13:06Z",
+				"DiscoKey":   "discokey:e9efbe7700ec8a7d48274cdfd3a668450d6b50723236fdc9d5df16ee25fad946",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:56882",
+					"10.65.0.27:56882",
+					"172.17.0.1:56882",
+					"172.18.0.1:56882",
+					"172.19.0.1:56882",
+					"172.20.0.1:56882",
+					"172.21.0.1:56882",
+					"172.22.0.1:56882",
+					"172.23.0.1:56882",
+					"172.24.0.1:56882",
+					"172.25.0.1:56882",
+					"172.26.0.1:56882",
+					"172.27.0.1:56882",
+					"172.28.0.1:56882"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:13:06.059576787Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2980139549275919,
+				"StableID":   "nC1kxKDiGQ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:778281a8bc8d2f190f04911d0cb5f2060c3b573b56435b64e00de2d8ff70cf7e",
+				"KeyExpiry":  "2026-11-09T09:13:06Z",
+				"DiscoKey":   "discokey:0e35513354b029f8207d7d4bf04d1595a89618f12865580a1763d03f264ba452",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57119",
+					"10.65.0.27:57119",
+					"172.17.0.1:57119",
+					"172.18.0.1:57119",
+					"172.19.0.1:57119",
+					"172.20.0.1:57119",
+					"172.21.0.1:57119",
+					"172.22.0.1:57119",
+					"172.23.0.1:57119",
+					"172.24.0.1:57119",
+					"172.25.0.1:57119",
+					"172.26.0.1:57119",
+					"172.27.0.1:57119",
+					"172.28.0.1:57119"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:13:06.582362451Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7727483352200269,
+				"StableID":   "np41KHtnL321CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3494764321ef3bd81e9ea5ed328f860aa3e9a1a6094042ac16ddef50972a0e13",
+				"KeyExpiry":  "2026-11-09T09:13:07Z",
+				"DiscoKey":   "discokey:7c9cc96f297fce93a0bff696af8e9065246e1dddcce8820d1e4375d76884f000",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:46552",
+					"10.65.0.27:46552",
+					"172.17.0.1:46552",
+					"172.18.0.1:46552",
+					"172.19.0.1:46552",
+					"172.20.0.1:46552",
+					"172.21.0.1:46552",
+					"172.22.0.1:46552",
+					"172.23.0.1:46552",
+					"172.24.0.1:46552",
+					"172.25.0.1:46552",
+					"172.26.0.1:46552",
+					"172.27.0.1:46552",
+					"172.28.0.1:46552"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:13:07.112575941Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5130927302190635": {
+				"ID":          5130927302190635,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4996382569491718,
+				"StableID":   "n3DkMsVs1g11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       4996382569491718,
+				"Key":        "nodekey:46e8be6fb3bc9c1c5cb6963553d2f490e95f7c71c60ee96bed1f67a751ffa00e",
+				"DiscoKey":   "discokey:f6a27125101f87e31cc72c8d2870bd9b77bbc059c2d9d8bcbf96847f071bc75c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46511",
+					"10.65.0.27:46511",
+					"172.17.0.1:46511",
+					"172.18.0.1:46511",
+					"172.19.0.1:46511",
+					"172.20.0.1:46511",
+					"172.21.0.1:46511",
+					"172.22.0.1:46511",
+					"172.23.0.1:46511",
+					"172.24.0.1:46511",
+					"172.25.0.1:46511",
+					"172.26.0.1:46511",
+					"172.27.0.1:46511",
+					"172.28.0.1:46511"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:13:03.895352755Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:46e8be6fb3bc9c1c5cb6963553d2f490e95f7c71c60ee96bed1f67a751ffa00e",
+			"MachineKey": "mkey:b950d003ea4144b40d3fbbf76c1af0d327636a19dfd3d822790f9aa95255c46e",
+			"Peers": [{
+				"ID":         2567328734081892,
+				"StableID":   "nKewpbNk3M11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9a3edf80566cfe2025a9e4cd4d28991ca2da492f8c2f40dfbace8b4a09a03717",
+				"DiscoKey":   "discokey:5dc5f7d29170494bdab5203619193c0d8d74c1d4224a77b5b1d461f3c7933367",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40530",
+					"10.65.0.27:40530",
+					"172.17.0.1:40530",
+					"172.18.0.1:40530",
+					"172.19.0.1:40530",
+					"172.20.0.1:40530",
+					"172.21.0.1:40530",
+					"172.22.0.1:40530",
+					"172.23.0.1:40530",
+					"172.24.0.1:40530",
+					"172.25.0.1:40530",
+					"172.26.0.1:40530",
+					"172.27.0.1:40530",
+					"172.28.0.1:40530"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:12:59.647166872Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7206557288195694,
+				"StableID":   "ny2zrJ3sGy11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0e5b5ed54171c5e0678a67c1125a2a8b4d997038a3882c7dec8f97a5cee4801",
+				"DiscoKey":   "discokey:d45c577103e63b846c63df3e17a710b4126afa42360fa9e359f292bc626c7b3b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51060",
+					"10.65.0.27:51060",
+					"172.17.0.1:51060",
+					"172.18.0.1:51060",
+					"172.19.0.1:51060",
+					"172.20.0.1:51060",
+					"172.21.0.1:51060",
+					"172.22.0.1:51060",
+					"172.23.0.1:51060",
+					"172.24.0.1:51060",
+					"172.25.0.1:51060",
+					"172.26.0.1:51060",
+					"172.27.0.1:51060",
+					"172.28.0.1:51060"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:13:00.169667073Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4106394864656361,
+				"StableID":   "nSf4Wj2o4Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:215f6e8a47dfcd7f56e458256cb40fae14c86b1735dfe6c663a015d475a37749",
+				"DiscoKey":   "discokey:83e995e8e6c60c623248419305639fec671109cf8837cc19d992a4ea0aabc038",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40236",
+					"10.65.0.27:40236",
+					"172.17.0.1:40236",
+					"172.18.0.1:40236",
+					"172.19.0.1:40236",
+					"172.20.0.1:40236",
+					"172.21.0.1:40236",
+					"172.22.0.1:40236",
+					"172.23.0.1:40236",
+					"172.24.0.1:40236",
+					"172.25.0.1:40236",
+					"172.26.0.1:40236",
+					"172.27.0.1:40236",
+					"172.28.0.1:40236"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:13:00.72138567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8128686347202576,
+				"StableID":   "nyoA8noVU621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c049dc4190a545ec005bda37dd71345d3527d9875eee9b81a713e5f5aa56d718",
+				"DiscoKey":   "discokey:5bac4af261be794cfafb8d36f595b9ad563b2bebcd85bda11a1e0d76d4d63570",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50062",
+					"10.65.0.27:50062",
+					"172.17.0.1:50062",
+					"172.18.0.1:50062",
+					"172.19.0.1:50062",
+					"172.20.0.1:50062",
+					"172.21.0.1:50062",
+					"172.22.0.1:50062",
+					"172.23.0.1:50062",
+					"172.24.0.1:50062",
+					"172.25.0.1:50062",
+					"172.26.0.1:50062",
+					"172.27.0.1:50062",
+					"172.28.0.1:50062"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:13:01.252552597Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7664065760950815,
+				"StableID":   "naJEwf15r221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe1974aa2836492e1d7621a82d54ce0da7e56eb9be8a240d4f8963b4e9dbaa66",
+				"DiscoKey":   "discokey:91c0b24fd236d13165f37e8a36da74788988076094ba81bc1b7ba11ec0e9684e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41359",
+					"10.65.0.27:41359",
+					"172.17.0.1:41359",
+					"172.18.0.1:41359",
+					"172.19.0.1:41359",
+					"172.20.0.1:41359",
+					"172.21.0.1:41359",
+					"172.22.0.1:41359",
+					"172.23.0.1:41359",
+					"172.24.0.1:41359",
+					"172.25.0.1:41359",
+					"172.26.0.1:41359",
+					"172.27.0.1:41359",
+					"172.28.0.1:41359"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:13:01.779887028Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5669431039962502,
+				"StableID":   "nFbvwhLhGm11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1de5dcd0ef424a06beeb0b92363e94df5b327b3b51432ede5b056e3ac3f9f918",
+				"DiscoKey":   "discokey:06ae531352ce3d4c98a875fb8b032c960179c99f515df59b0a70f7764ac1e238",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40400",
+					"10.65.0.27:40400",
+					"172.17.0.1:40400",
+					"172.18.0.1:40400",
+					"172.19.0.1:40400",
+					"172.20.0.1:40400",
+					"172.21.0.1:40400",
+					"172.22.0.1:40400",
+					"172.23.0.1:40400",
+					"172.24.0.1:40400",
+					"172.25.0.1:40400",
+					"172.26.0.1:40400",
+					"172.27.0.1:40400",
+					"172.28.0.1:40400"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:13:02.311757801Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5130927302190635,
+				"StableID":   "n2WFf4mo4h11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:78b03139cfaefbd82e006f5ebe9cfcee0ba5235c2f016446c83405050fae5031",
+				"DiscoKey":   "discokey:2be290a222fd9e29f4ba6e72ffe63748f694b6890b2f12ee47e46d6eb58ec868",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54766",
+					"10.65.0.27:54766",
+					"172.17.0.1:54766",
+					"172.18.0.1:54766",
+					"172.19.0.1:54766",
+					"172.20.0.1:54766",
+					"172.21.0.1:54766",
+					"172.22.0.1:54766",
+					"172.23.0.1:54766",
+					"172.24.0.1:54766",
+					"172.25.0.1:54766",
+					"172.26.0.1:54766",
+					"172.27.0.1:54766",
+					"172.28.0.1:54766"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:13:02.835145745Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4166281204287168,
+				"StableID":   "nKAGGG9vXZ11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:997819540939b3a2441e4038631e8df0b159445c7cf5938ab375d8a058d47032",
+				"DiscoKey":   "discokey:5476eb0a0556ff05c0f9bfd950437e26b21ad1baa7ecae0ddb0e4b87f80c8e10",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:51700",
+					"10.65.0.27:51700",
+					"172.17.0.1:51700",
+					"172.18.0.1:51700",
+					"172.19.0.1:51700",
+					"172.20.0.1:51700",
+					"172.21.0.1:51700",
+					"172.22.0.1:51700",
+					"172.23.0.1:51700",
+					"172.24.0.1:51700",
+					"172.25.0.1:51700",
+					"172.26.0.1:51700",
+					"172.27.0.1:51700",
+					"172.28.0.1:51700"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:13:03.368157068Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8816360523537563,
+				"StableID":   "nSgtFnqwqB21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:df694e52776bcd93de661ecc3794046afef62941b054c74cf14fa551e83d8f7d",
+				"DiscoKey":   "discokey:3da66f21123faa21abdf8268b638e319698540f3370127a5efd152e4d6cca54d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60870",
+					"10.65.0.27:60870",
+					"172.17.0.1:60870",
+					"172.18.0.1:60870",
+					"172.19.0.1:60870",
+					"172.20.0.1:60870",
+					"172.21.0.1:60870",
+					"172.22.0.1:60870",
+					"172.23.0.1:60870",
+					"172.24.0.1:60870",
+					"172.25.0.1:60870",
+					"172.26.0.1:60870",
+					"172.27.0.1:60870",
+					"172.28.0.1:60870"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:13:04.416197291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4794516992630629,
+				"StableID":   "nSV2bDqSSe11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77add75392b721048b328a58d454e34ef02bfbe986727e6b070569d13676bb66",
+				"DiscoKey":   "discokey:1d12ca01b3211d8b85aef2f7a72f410da4c16cbffd521ed7f5a3aaaf4147b703",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40692",
+					"10.65.0.27:40692",
+					"172.17.0.1:40692",
+					"172.18.0.1:40692",
+					"172.19.0.1:40692",
+					"172.20.0.1:40692",
+					"172.21.0.1:40692",
+					"172.22.0.1:40692",
+					"172.23.0.1:40692",
+					"172.24.0.1:40692",
+					"172.25.0.1:40692",
+					"172.26.0.1:40692",
+					"172.27.0.1:40692",
+					"172.28.0.1:40692"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:13:04.959224986Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8954367754846020,
+				"StableID":   "n3xphJ4TvC21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1478f202bcf9d2358a3d4bd05990d244b0ede5e37176f220100c9ab9caddf83f",
+				"DiscoKey":   "discokey:bdfdb84530e8ed69e6a52c1146abe1035638c81ff55c208dd6b77faf1f212961",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36975",
+					"10.65.0.27:36975",
+					"172.17.0.1:36975",
+					"172.18.0.1:36975",
+					"172.19.0.1:36975",
+					"172.20.0.1:36975",
+					"172.21.0.1:36975",
+					"172.22.0.1:36975",
+					"172.23.0.1:36975",
+					"172.24.0.1:36975",
+					"172.25.0.1:36975",
+					"172.26.0.1:36975",
+					"172.27.0.1:36975",
+					"172.28.0.1:36975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:13:05.499755672Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5759216140094256,
+				"StableID":   "n7rsnqqMym11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b1e83ead3c15eebac7d0103510a9eb9007f328d6a78c14678fd1c5e501602f1f",
+				"KeyExpiry":  "2026-11-09T09:13:06Z",
+				"DiscoKey":   "discokey:e9efbe7700ec8a7d48274cdfd3a668450d6b50723236fdc9d5df16ee25fad946",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:56882",
+					"10.65.0.27:56882",
+					"172.17.0.1:56882",
+					"172.18.0.1:56882",
+					"172.19.0.1:56882",
+					"172.20.0.1:56882",
+					"172.21.0.1:56882",
+					"172.22.0.1:56882",
+					"172.23.0.1:56882",
+					"172.24.0.1:56882",
+					"172.25.0.1:56882",
+					"172.26.0.1:56882",
+					"172.27.0.1:56882",
+					"172.28.0.1:56882"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:13:06.059576787Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2980139549275919,
+				"StableID":   "nC1kxKDiGQ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:778281a8bc8d2f190f04911d0cb5f2060c3b573b56435b64e00de2d8ff70cf7e",
+				"KeyExpiry":  "2026-11-09T09:13:06Z",
+				"DiscoKey":   "discokey:0e35513354b029f8207d7d4bf04d1595a89618f12865580a1763d03f264ba452",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57119",
+					"10.65.0.27:57119",
+					"172.17.0.1:57119",
+					"172.18.0.1:57119",
+					"172.19.0.1:57119",
+					"172.20.0.1:57119",
+					"172.21.0.1:57119",
+					"172.22.0.1:57119",
+					"172.23.0.1:57119",
+					"172.24.0.1:57119",
+					"172.25.0.1:57119",
+					"172.26.0.1:57119",
+					"172.27.0.1:57119",
+					"172.28.0.1:57119"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:13:06.582362451Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7727483352200269,
+				"StableID":   "np41KHtnL321CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3494764321ef3bd81e9ea5ed328f860aa3e9a1a6094042ac16ddef50972a0e13",
+				"KeyExpiry":  "2026-11-09T09:13:07Z",
+				"DiscoKey":   "discokey:7c9cc96f297fce93a0bff696af8e9065246e1dddcce8820d1e4375d76884f000",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:46552",
+					"10.65.0.27:46552",
+					"172.17.0.1:46552",
+					"172.18.0.1:46552",
+					"172.19.0.1:46552",
+					"172.20.0.1:46552",
+					"172.21.0.1:46552",
+					"172.22.0.1:46552",
+					"172.23.0.1:46552",
+					"172.24.0.1:46552",
+					"172.25.0.1:46552",
+					"172.26.0.1:46552",
+					"172.27.0.1:46552",
+					"172.28.0.1:46552"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:13:07.112575941Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4996382569491718": {
+				"ID":          4996382569491718,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2980139549275919,
+				"StableID":   "nC1kxKDiGQ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:778281a8bc8d2f190f04911d0cb5f2060c3b573b56435b64e00de2d8ff70cf7e",
+				"KeyExpiry":  "2026-11-09T09:13:06Z",
+				"DiscoKey":   "discokey:0e35513354b029f8207d7d4bf04d1595a89618f12865580a1763d03f264ba452",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57119",
+					"10.65.0.27:57119",
+					"172.17.0.1:57119",
+					"172.18.0.1:57119",
+					"172.19.0.1:57119",
+					"172.20.0.1:57119",
+					"172.21.0.1:57119",
+					"172.22.0.1:57119",
+					"172.23.0.1:57119",
+					"172.24.0.1:57119",
+					"172.25.0.1:57119",
+					"172.26.0.1:57119",
+					"172.27.0.1:57119",
+					"172.28.0.1:57119"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:13:06.582362451Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:778281a8bc8d2f190f04911d0cb5f2060c3b573b56435b64e00de2d8ff70cf7e",
+			"MachineKey": "mkey:9865152d0d9f9b26383cfb5cfa8b5a5d820503eb73dc1fff4c19ef0eee229c20",
+			"Peers": [{
+				"ID":         2567328734081892,
+				"StableID":   "nKewpbNk3M11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9a3edf80566cfe2025a9e4cd4d28991ca2da492f8c2f40dfbace8b4a09a03717",
+				"DiscoKey":   "discokey:5dc5f7d29170494bdab5203619193c0d8d74c1d4224a77b5b1d461f3c7933367",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40530",
+					"10.65.0.27:40530",
+					"172.17.0.1:40530",
+					"172.18.0.1:40530",
+					"172.19.0.1:40530",
+					"172.20.0.1:40530",
+					"172.21.0.1:40530",
+					"172.22.0.1:40530",
+					"172.23.0.1:40530",
+					"172.24.0.1:40530",
+					"172.25.0.1:40530",
+					"172.26.0.1:40530",
+					"172.27.0.1:40530",
+					"172.28.0.1:40530"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:12:59.647166872Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7206557288195694,
+				"StableID":   "ny2zrJ3sGy11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0e5b5ed54171c5e0678a67c1125a2a8b4d997038a3882c7dec8f97a5cee4801",
+				"DiscoKey":   "discokey:d45c577103e63b846c63df3e17a710b4126afa42360fa9e359f292bc626c7b3b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51060",
+					"10.65.0.27:51060",
+					"172.17.0.1:51060",
+					"172.18.0.1:51060",
+					"172.19.0.1:51060",
+					"172.20.0.1:51060",
+					"172.21.0.1:51060",
+					"172.22.0.1:51060",
+					"172.23.0.1:51060",
+					"172.24.0.1:51060",
+					"172.25.0.1:51060",
+					"172.26.0.1:51060",
+					"172.27.0.1:51060",
+					"172.28.0.1:51060"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:13:00.169667073Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4106394864656361,
+				"StableID":   "nSf4Wj2o4Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:215f6e8a47dfcd7f56e458256cb40fae14c86b1735dfe6c663a015d475a37749",
+				"DiscoKey":   "discokey:83e995e8e6c60c623248419305639fec671109cf8837cc19d992a4ea0aabc038",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40236",
+					"10.65.0.27:40236",
+					"172.17.0.1:40236",
+					"172.18.0.1:40236",
+					"172.19.0.1:40236",
+					"172.20.0.1:40236",
+					"172.21.0.1:40236",
+					"172.22.0.1:40236",
+					"172.23.0.1:40236",
+					"172.24.0.1:40236",
+					"172.25.0.1:40236",
+					"172.26.0.1:40236",
+					"172.27.0.1:40236",
+					"172.28.0.1:40236"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:13:00.72138567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8128686347202576,
+				"StableID":   "nyoA8noVU621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c049dc4190a545ec005bda37dd71345d3527d9875eee9b81a713e5f5aa56d718",
+				"DiscoKey":   "discokey:5bac4af261be794cfafb8d36f595b9ad563b2bebcd85bda11a1e0d76d4d63570",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50062",
+					"10.65.0.27:50062",
+					"172.17.0.1:50062",
+					"172.18.0.1:50062",
+					"172.19.0.1:50062",
+					"172.20.0.1:50062",
+					"172.21.0.1:50062",
+					"172.22.0.1:50062",
+					"172.23.0.1:50062",
+					"172.24.0.1:50062",
+					"172.25.0.1:50062",
+					"172.26.0.1:50062",
+					"172.27.0.1:50062",
+					"172.28.0.1:50062"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:13:01.252552597Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7664065760950815,
+				"StableID":   "naJEwf15r221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe1974aa2836492e1d7621a82d54ce0da7e56eb9be8a240d4f8963b4e9dbaa66",
+				"DiscoKey":   "discokey:91c0b24fd236d13165f37e8a36da74788988076094ba81bc1b7ba11ec0e9684e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41359",
+					"10.65.0.27:41359",
+					"172.17.0.1:41359",
+					"172.18.0.1:41359",
+					"172.19.0.1:41359",
+					"172.20.0.1:41359",
+					"172.21.0.1:41359",
+					"172.22.0.1:41359",
+					"172.23.0.1:41359",
+					"172.24.0.1:41359",
+					"172.25.0.1:41359",
+					"172.26.0.1:41359",
+					"172.27.0.1:41359",
+					"172.28.0.1:41359"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:13:01.779887028Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5669431039962502,
+				"StableID":   "nFbvwhLhGm11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1de5dcd0ef424a06beeb0b92363e94df5b327b3b51432ede5b056e3ac3f9f918",
+				"DiscoKey":   "discokey:06ae531352ce3d4c98a875fb8b032c960179c99f515df59b0a70f7764ac1e238",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40400",
+					"10.65.0.27:40400",
+					"172.17.0.1:40400",
+					"172.18.0.1:40400",
+					"172.19.0.1:40400",
+					"172.20.0.1:40400",
+					"172.21.0.1:40400",
+					"172.22.0.1:40400",
+					"172.23.0.1:40400",
+					"172.24.0.1:40400",
+					"172.25.0.1:40400",
+					"172.26.0.1:40400",
+					"172.27.0.1:40400",
+					"172.28.0.1:40400"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:13:02.311757801Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5130927302190635,
+				"StableID":   "n2WFf4mo4h11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:78b03139cfaefbd82e006f5ebe9cfcee0ba5235c2f016446c83405050fae5031",
+				"DiscoKey":   "discokey:2be290a222fd9e29f4ba6e72ffe63748f694b6890b2f12ee47e46d6eb58ec868",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54766",
+					"10.65.0.27:54766",
+					"172.17.0.1:54766",
+					"172.18.0.1:54766",
+					"172.19.0.1:54766",
+					"172.20.0.1:54766",
+					"172.21.0.1:54766",
+					"172.22.0.1:54766",
+					"172.23.0.1:54766",
+					"172.24.0.1:54766",
+					"172.25.0.1:54766",
+					"172.26.0.1:54766",
+					"172.27.0.1:54766",
+					"172.28.0.1:54766"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:13:02.835145745Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4166281204287168,
+				"StableID":   "nKAGGG9vXZ11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:997819540939b3a2441e4038631e8df0b159445c7cf5938ab375d8a058d47032",
+				"DiscoKey":   "discokey:5476eb0a0556ff05c0f9bfd950437e26b21ad1baa7ecae0ddb0e4b87f80c8e10",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:51700",
+					"10.65.0.27:51700",
+					"172.17.0.1:51700",
+					"172.18.0.1:51700",
+					"172.19.0.1:51700",
+					"172.20.0.1:51700",
+					"172.21.0.1:51700",
+					"172.22.0.1:51700",
+					"172.23.0.1:51700",
+					"172.24.0.1:51700",
+					"172.25.0.1:51700",
+					"172.26.0.1:51700",
+					"172.27.0.1:51700",
+					"172.28.0.1:51700"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:13:03.368157068Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4996382569491718,
+				"StableID":   "n3DkMsVs1g11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:46e8be6fb3bc9c1c5cb6963553d2f490e95f7c71c60ee96bed1f67a751ffa00e",
+				"DiscoKey":   "discokey:f6a27125101f87e31cc72c8d2870bd9b77bbc059c2d9d8bcbf96847f071bc75c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46511",
+					"10.65.0.27:46511",
+					"172.17.0.1:46511",
+					"172.18.0.1:46511",
+					"172.19.0.1:46511",
+					"172.20.0.1:46511",
+					"172.21.0.1:46511",
+					"172.22.0.1:46511",
+					"172.23.0.1:46511",
+					"172.24.0.1:46511",
+					"172.25.0.1:46511",
+					"172.26.0.1:46511",
+					"172.27.0.1:46511",
+					"172.28.0.1:46511"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:13:03.895352755Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8816360523537563,
+				"StableID":   "nSgtFnqwqB21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:df694e52776bcd93de661ecc3794046afef62941b054c74cf14fa551e83d8f7d",
+				"DiscoKey":   "discokey:3da66f21123faa21abdf8268b638e319698540f3370127a5efd152e4d6cca54d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60870",
+					"10.65.0.27:60870",
+					"172.17.0.1:60870",
+					"172.18.0.1:60870",
+					"172.19.0.1:60870",
+					"172.20.0.1:60870",
+					"172.21.0.1:60870",
+					"172.22.0.1:60870",
+					"172.23.0.1:60870",
+					"172.24.0.1:60870",
+					"172.25.0.1:60870",
+					"172.26.0.1:60870",
+					"172.27.0.1:60870",
+					"172.28.0.1:60870"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:13:04.416197291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4794516992630629,
+				"StableID":   "nSV2bDqSSe11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77add75392b721048b328a58d454e34ef02bfbe986727e6b070569d13676bb66",
+				"DiscoKey":   "discokey:1d12ca01b3211d8b85aef2f7a72f410da4c16cbffd521ed7f5a3aaaf4147b703",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40692",
+					"10.65.0.27:40692",
+					"172.17.0.1:40692",
+					"172.18.0.1:40692",
+					"172.19.0.1:40692",
+					"172.20.0.1:40692",
+					"172.21.0.1:40692",
+					"172.22.0.1:40692",
+					"172.23.0.1:40692",
+					"172.24.0.1:40692",
+					"172.25.0.1:40692",
+					"172.26.0.1:40692",
+					"172.27.0.1:40692",
+					"172.28.0.1:40692"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:13:04.959224986Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8954367754846020,
+				"StableID":   "n3xphJ4TvC21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1478f202bcf9d2358a3d4bd05990d244b0ede5e37176f220100c9ab9caddf83f",
+				"DiscoKey":   "discokey:bdfdb84530e8ed69e6a52c1146abe1035638c81ff55c208dd6b77faf1f212961",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36975",
+					"10.65.0.27:36975",
+					"172.17.0.1:36975",
+					"172.18.0.1:36975",
+					"172.19.0.1:36975",
+					"172.20.0.1:36975",
+					"172.21.0.1:36975",
+					"172.22.0.1:36975",
+					"172.23.0.1:36975",
+					"172.24.0.1:36975",
+					"172.25.0.1:36975",
+					"172.26.0.1:36975",
+					"172.27.0.1:36975",
+					"172.28.0.1:36975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:13:05.499755672Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5759216140094256,
+				"StableID":   "n7rsnqqMym11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b1e83ead3c15eebac7d0103510a9eb9007f328d6a78c14678fd1c5e501602f1f",
+				"KeyExpiry":  "2026-11-09T09:13:06Z",
+				"DiscoKey":   "discokey:e9efbe7700ec8a7d48274cdfd3a668450d6b50723236fdc9d5df16ee25fad946",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:56882",
+					"10.65.0.27:56882",
+					"172.17.0.1:56882",
+					"172.18.0.1:56882",
+					"172.19.0.1:56882",
+					"172.20.0.1:56882",
+					"172.21.0.1:56882",
+					"172.22.0.1:56882",
+					"172.23.0.1:56882",
+					"172.24.0.1:56882",
+					"172.25.0.1:56882",
+					"172.26.0.1:56882",
+					"172.27.0.1:56882",
+					"172.28.0.1:56882"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:13:06.059576787Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7727483352200269,
+				"StableID":   "np41KHtnL321CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3494764321ef3bd81e9ea5ed328f860aa3e9a1a6094042ac16ddef50972a0e13",
+				"KeyExpiry":  "2026-11-09T09:13:07Z",
+				"DiscoKey":   "discokey:7c9cc96f297fce93a0bff696af8e9065246e1dddcce8820d1e4375d76884f000",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:46552",
+					"10.65.0.27:46552",
+					"172.17.0.1:46552",
+					"172.18.0.1:46552",
+					"172.19.0.1:46552",
+					"172.20.0.1:46552",
+					"172.21.0.1:46552",
+					"172.22.0.1:46552",
+					"172.23.0.1:46552",
+					"172.24.0.1:46552",
+					"172.25.0.1:46552",
+					"172.26.0.1:46552",
+					"172.27.0.1:46552",
+					"172.28.0.1:46552"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:13:07.112575941Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8816360523537563,
+				"StableID":   "nSgtFnqwqB21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       8816360523537563,
+				"Key":        "nodekey:df694e52776bcd93de661ecc3794046afef62941b054c74cf14fa551e83d8f7d",
+				"DiscoKey":   "discokey:3da66f21123faa21abdf8268b638e319698540f3370127a5efd152e4d6cca54d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60870",
+					"10.65.0.27:60870",
+					"172.17.0.1:60870",
+					"172.18.0.1:60870",
+					"172.19.0.1:60870",
+					"172.20.0.1:60870",
+					"172.21.0.1:60870",
+					"172.22.0.1:60870",
+					"172.23.0.1:60870",
+					"172.24.0.1:60870",
+					"172.25.0.1:60870",
+					"172.26.0.1:60870",
+					"172.27.0.1:60870",
+					"172.28.0.1:60870"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:13:04.416197291Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:df694e52776bcd93de661ecc3794046afef62941b054c74cf14fa551e83d8f7d",
+			"MachineKey": "mkey:c68629c94a5d9eb6067551a5c9d810f6b3fbb47b57674d247a5be68991ec8e2e",
+			"Peers": [{
+				"ID":         2567328734081892,
+				"StableID":   "nKewpbNk3M11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9a3edf80566cfe2025a9e4cd4d28991ca2da492f8c2f40dfbace8b4a09a03717",
+				"DiscoKey":   "discokey:5dc5f7d29170494bdab5203619193c0d8d74c1d4224a77b5b1d461f3c7933367",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40530",
+					"10.65.0.27:40530",
+					"172.17.0.1:40530",
+					"172.18.0.1:40530",
+					"172.19.0.1:40530",
+					"172.20.0.1:40530",
+					"172.21.0.1:40530",
+					"172.22.0.1:40530",
+					"172.23.0.1:40530",
+					"172.24.0.1:40530",
+					"172.25.0.1:40530",
+					"172.26.0.1:40530",
+					"172.27.0.1:40530",
+					"172.28.0.1:40530"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:12:59.647166872Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7206557288195694,
+				"StableID":   "ny2zrJ3sGy11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0e5b5ed54171c5e0678a67c1125a2a8b4d997038a3882c7dec8f97a5cee4801",
+				"DiscoKey":   "discokey:d45c577103e63b846c63df3e17a710b4126afa42360fa9e359f292bc626c7b3b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51060",
+					"10.65.0.27:51060",
+					"172.17.0.1:51060",
+					"172.18.0.1:51060",
+					"172.19.0.1:51060",
+					"172.20.0.1:51060",
+					"172.21.0.1:51060",
+					"172.22.0.1:51060",
+					"172.23.0.1:51060",
+					"172.24.0.1:51060",
+					"172.25.0.1:51060",
+					"172.26.0.1:51060",
+					"172.27.0.1:51060",
+					"172.28.0.1:51060"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:13:00.169667073Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4106394864656361,
+				"StableID":   "nSf4Wj2o4Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:215f6e8a47dfcd7f56e458256cb40fae14c86b1735dfe6c663a015d475a37749",
+				"DiscoKey":   "discokey:83e995e8e6c60c623248419305639fec671109cf8837cc19d992a4ea0aabc038",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40236",
+					"10.65.0.27:40236",
+					"172.17.0.1:40236",
+					"172.18.0.1:40236",
+					"172.19.0.1:40236",
+					"172.20.0.1:40236",
+					"172.21.0.1:40236",
+					"172.22.0.1:40236",
+					"172.23.0.1:40236",
+					"172.24.0.1:40236",
+					"172.25.0.1:40236",
+					"172.26.0.1:40236",
+					"172.27.0.1:40236",
+					"172.28.0.1:40236"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:13:00.72138567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8128686347202576,
+				"StableID":   "nyoA8noVU621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c049dc4190a545ec005bda37dd71345d3527d9875eee9b81a713e5f5aa56d718",
+				"DiscoKey":   "discokey:5bac4af261be794cfafb8d36f595b9ad563b2bebcd85bda11a1e0d76d4d63570",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50062",
+					"10.65.0.27:50062",
+					"172.17.0.1:50062",
+					"172.18.0.1:50062",
+					"172.19.0.1:50062",
+					"172.20.0.1:50062",
+					"172.21.0.1:50062",
+					"172.22.0.1:50062",
+					"172.23.0.1:50062",
+					"172.24.0.1:50062",
+					"172.25.0.1:50062",
+					"172.26.0.1:50062",
+					"172.27.0.1:50062",
+					"172.28.0.1:50062"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:13:01.252552597Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7664065760950815,
+				"StableID":   "naJEwf15r221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe1974aa2836492e1d7621a82d54ce0da7e56eb9be8a240d4f8963b4e9dbaa66",
+				"DiscoKey":   "discokey:91c0b24fd236d13165f37e8a36da74788988076094ba81bc1b7ba11ec0e9684e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41359",
+					"10.65.0.27:41359",
+					"172.17.0.1:41359",
+					"172.18.0.1:41359",
+					"172.19.0.1:41359",
+					"172.20.0.1:41359",
+					"172.21.0.1:41359",
+					"172.22.0.1:41359",
+					"172.23.0.1:41359",
+					"172.24.0.1:41359",
+					"172.25.0.1:41359",
+					"172.26.0.1:41359",
+					"172.27.0.1:41359",
+					"172.28.0.1:41359"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:13:01.779887028Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5669431039962502,
+				"StableID":   "nFbvwhLhGm11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1de5dcd0ef424a06beeb0b92363e94df5b327b3b51432ede5b056e3ac3f9f918",
+				"DiscoKey":   "discokey:06ae531352ce3d4c98a875fb8b032c960179c99f515df59b0a70f7764ac1e238",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40400",
+					"10.65.0.27:40400",
+					"172.17.0.1:40400",
+					"172.18.0.1:40400",
+					"172.19.0.1:40400",
+					"172.20.0.1:40400",
+					"172.21.0.1:40400",
+					"172.22.0.1:40400",
+					"172.23.0.1:40400",
+					"172.24.0.1:40400",
+					"172.25.0.1:40400",
+					"172.26.0.1:40400",
+					"172.27.0.1:40400",
+					"172.28.0.1:40400"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:13:02.311757801Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5130927302190635,
+				"StableID":   "n2WFf4mo4h11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:78b03139cfaefbd82e006f5ebe9cfcee0ba5235c2f016446c83405050fae5031",
+				"DiscoKey":   "discokey:2be290a222fd9e29f4ba6e72ffe63748f694b6890b2f12ee47e46d6eb58ec868",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54766",
+					"10.65.0.27:54766",
+					"172.17.0.1:54766",
+					"172.18.0.1:54766",
+					"172.19.0.1:54766",
+					"172.20.0.1:54766",
+					"172.21.0.1:54766",
+					"172.22.0.1:54766",
+					"172.23.0.1:54766",
+					"172.24.0.1:54766",
+					"172.25.0.1:54766",
+					"172.26.0.1:54766",
+					"172.27.0.1:54766",
+					"172.28.0.1:54766"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:13:02.835145745Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4166281204287168,
+				"StableID":   "nKAGGG9vXZ11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:997819540939b3a2441e4038631e8df0b159445c7cf5938ab375d8a058d47032",
+				"DiscoKey":   "discokey:5476eb0a0556ff05c0f9bfd950437e26b21ad1baa7ecae0ddb0e4b87f80c8e10",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:51700",
+					"10.65.0.27:51700",
+					"172.17.0.1:51700",
+					"172.18.0.1:51700",
+					"172.19.0.1:51700",
+					"172.20.0.1:51700",
+					"172.21.0.1:51700",
+					"172.22.0.1:51700",
+					"172.23.0.1:51700",
+					"172.24.0.1:51700",
+					"172.25.0.1:51700",
+					"172.26.0.1:51700",
+					"172.27.0.1:51700",
+					"172.28.0.1:51700"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:13:03.368157068Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4996382569491718,
+				"StableID":   "n3DkMsVs1g11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:46e8be6fb3bc9c1c5cb6963553d2f490e95f7c71c60ee96bed1f67a751ffa00e",
+				"DiscoKey":   "discokey:f6a27125101f87e31cc72c8d2870bd9b77bbc059c2d9d8bcbf96847f071bc75c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46511",
+					"10.65.0.27:46511",
+					"172.17.0.1:46511",
+					"172.18.0.1:46511",
+					"172.19.0.1:46511",
+					"172.20.0.1:46511",
+					"172.21.0.1:46511",
+					"172.22.0.1:46511",
+					"172.23.0.1:46511",
+					"172.24.0.1:46511",
+					"172.25.0.1:46511",
+					"172.26.0.1:46511",
+					"172.27.0.1:46511",
+					"172.28.0.1:46511"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:13:03.895352755Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4794516992630629,
+				"StableID":   "nSV2bDqSSe11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77add75392b721048b328a58d454e34ef02bfbe986727e6b070569d13676bb66",
+				"DiscoKey":   "discokey:1d12ca01b3211d8b85aef2f7a72f410da4c16cbffd521ed7f5a3aaaf4147b703",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40692",
+					"10.65.0.27:40692",
+					"172.17.0.1:40692",
+					"172.18.0.1:40692",
+					"172.19.0.1:40692",
+					"172.20.0.1:40692",
+					"172.21.0.1:40692",
+					"172.22.0.1:40692",
+					"172.23.0.1:40692",
+					"172.24.0.1:40692",
+					"172.25.0.1:40692",
+					"172.26.0.1:40692",
+					"172.27.0.1:40692",
+					"172.28.0.1:40692"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:13:04.959224986Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8954367754846020,
+				"StableID":   "n3xphJ4TvC21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1478f202bcf9d2358a3d4bd05990d244b0ede5e37176f220100c9ab9caddf83f",
+				"DiscoKey":   "discokey:bdfdb84530e8ed69e6a52c1146abe1035638c81ff55c208dd6b77faf1f212961",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36975",
+					"10.65.0.27:36975",
+					"172.17.0.1:36975",
+					"172.18.0.1:36975",
+					"172.19.0.1:36975",
+					"172.20.0.1:36975",
+					"172.21.0.1:36975",
+					"172.22.0.1:36975",
+					"172.23.0.1:36975",
+					"172.24.0.1:36975",
+					"172.25.0.1:36975",
+					"172.26.0.1:36975",
+					"172.27.0.1:36975",
+					"172.28.0.1:36975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:13:05.499755672Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5759216140094256,
+				"StableID":   "n7rsnqqMym11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b1e83ead3c15eebac7d0103510a9eb9007f328d6a78c14678fd1c5e501602f1f",
+				"KeyExpiry":  "2026-11-09T09:13:06Z",
+				"DiscoKey":   "discokey:e9efbe7700ec8a7d48274cdfd3a668450d6b50723236fdc9d5df16ee25fad946",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:56882",
+					"10.65.0.27:56882",
+					"172.17.0.1:56882",
+					"172.18.0.1:56882",
+					"172.19.0.1:56882",
+					"172.20.0.1:56882",
+					"172.21.0.1:56882",
+					"172.22.0.1:56882",
+					"172.23.0.1:56882",
+					"172.24.0.1:56882",
+					"172.25.0.1:56882",
+					"172.26.0.1:56882",
+					"172.27.0.1:56882",
+					"172.28.0.1:56882"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:13:06.059576787Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2980139549275919,
+				"StableID":   "nC1kxKDiGQ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:778281a8bc8d2f190f04911d0cb5f2060c3b573b56435b64e00de2d8ff70cf7e",
+				"KeyExpiry":  "2026-11-09T09:13:06Z",
+				"DiscoKey":   "discokey:0e35513354b029f8207d7d4bf04d1595a89618f12865580a1763d03f264ba452",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57119",
+					"10.65.0.27:57119",
+					"172.17.0.1:57119",
+					"172.18.0.1:57119",
+					"172.19.0.1:57119",
+					"172.20.0.1:57119",
+					"172.21.0.1:57119",
+					"172.22.0.1:57119",
+					"172.23.0.1:57119",
+					"172.24.0.1:57119",
+					"172.25.0.1:57119",
+					"172.26.0.1:57119",
+					"172.27.0.1:57119",
+					"172.28.0.1:57119"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:13:06.582362451Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7727483352200269,
+				"StableID":   "np41KHtnL321CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3494764321ef3bd81e9ea5ed328f860aa3e9a1a6094042ac16ddef50972a0e13",
+				"KeyExpiry":  "2026-11-09T09:13:07Z",
+				"DiscoKey":   "discokey:7c9cc96f297fce93a0bff696af8e9065246e1dddcce8820d1e4375d76884f000",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:46552",
+					"10.65.0.27:46552",
+					"172.17.0.1:46552",
+					"172.18.0.1:46552",
+					"172.19.0.1:46552",
+					"172.20.0.1:46552",
+					"172.21.0.1:46552",
+					"172.22.0.1:46552",
+					"172.23.0.1:46552",
+					"172.24.0.1:46552",
+					"172.25.0.1:46552",
+					"172.26.0.1:46552",
+					"172.27.0.1:46552",
+					"172.28.0.1:46552"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:13:07.112575941Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8816360523537563": {
+				"ID":          8816360523537563,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-hosts-as-dst-single-ip.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-hosts-as-dst-single-ip.hujson
@@ -1,0 +1,22107 @@
+// ssh-hosts-as-dst-single-ip
+//
+// ssh dst = hosts alias resolving to a single IP
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-13T09:13:44Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-hosts-as-dst-single-ip",
+	"description":    "ssh dst = hosts alias resolving to a single IP",
+	"category":       "ssh",
+	"captured_at":    "2026-05-13T09:13:44.270316646Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "invalid dst \"srv\""},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                             \n  \n                                                                      \n                                                                     \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh dst = hosts alias resolving to a single IP\",\n\t\"id\":          \"ssh-hosts-as-dst-single-ip\",\n\t\"policy\": {\"hosts\": {\"srv\": \"100.64.0.16\"}, \"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"srv\"],\n\t\t\"src\":    [\"thor@example.org\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-edges/ssh-hosts-as-dst-single-ip.hujson",
+		"full_policy": {
+			"hosts": {"srv": "100.64.0.16"},
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["srv"],
+				"src":    ["thor@example.org"],
+				"users":  ["root"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1394021246640640,
+				"StableID":   "n3NvxJaMtB11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1394021246640640,
+				"Key":        "nodekey:5fb6653ad217217a2c56e9017d38db7ce1331a96fb389a774ab6b31459a3fb27",
+				"DiscoKey":   "discokey:75c30f7c43cafad3e3c423c5f02ce9236bd88881ef05a7aa983a8854fd33d007",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58655",
+					"10.65.0.27:58655",
+					"172.17.0.1:58655",
+					"172.18.0.1:58655",
+					"172.19.0.1:58655",
+					"172.20.0.1:58655",
+					"172.21.0.1:58655",
+					"172.22.0.1:58655",
+					"172.23.0.1:58655",
+					"172.24.0.1:58655",
+					"172.25.0.1:58655",
+					"172.26.0.1:58655",
+					"172.27.0.1:58655",
+					"172.28.0.1:58655"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:13:52.743055689Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5fb6653ad217217a2c56e9017d38db7ce1331a96fb389a774ab6b31459a3fb27",
+			"MachineKey": "mkey:ca5ad1714436fd6d22ce1bb4b3fafde040e7e93f4cedae3474fb7b9373db2315",
+			"Peers": [{
+				"ID":         1198500343174197,
+				"StableID":   "nnmmFAaoMA11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:240f04f24aa13822252cbc3331eb7282991f64f29b7d9ac2befea60e896ef054",
+				"DiscoKey":   "discokey:ec8422f81c6380d3d6ed4f7fb5533072e378cd12cc5a06a94f667abc8a57c735",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:32935",
+					"10.65.0.27:32935",
+					"172.17.0.1:32935",
+					"172.18.0.1:32935",
+					"172.19.0.1:32935",
+					"172.20.0.1:32935",
+					"172.21.0.1:32935",
+					"172.22.0.1:32935",
+					"172.23.0.1:32935",
+					"172.24.0.1:32935",
+					"172.25.0.1:32935",
+					"172.26.0.1:32935",
+					"172.27.0.1:32935",
+					"172.28.0.1:32935"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:13:46.866938583Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5681187607005970,
+				"StableID":   "nBy3XZA2Nm11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:689e4a53f458215c7fe16a8c184c25724501d72d939e064df8f01398a492bf47",
+				"DiscoKey":   "discokey:2b3c1ce5b6b1d0405e2901e81a6465eef0881f513a2ee2274c701c371de73b6e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:38614",
+					"10.65.0.27:38614",
+					"172.17.0.1:38614",
+					"172.18.0.1:38614",
+					"172.19.0.1:38614",
+					"172.20.0.1:38614",
+					"172.21.0.1:38614",
+					"172.22.0.1:38614",
+					"172.23.0.1:38614",
+					"172.24.0.1:38614",
+					"172.25.0.1:38614",
+					"172.26.0.1:38614",
+					"172.27.0.1:38614",
+					"172.28.0.1:38614"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:13:47.376361337Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         12931462317159,
+				"StableID":   "naWW3tgr6111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b616fb9f37c2d3c5666f8339afed4dcd65336f5d6b4ff82d2da3af6efdacf12",
+				"DiscoKey":   "discokey:bec41e4ae574c1a59263182ed64c39ea7b104fa761ea0374e39f5f814e95af44",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59648",
+					"10.65.0.27:59648",
+					"172.17.0.1:59648",
+					"172.18.0.1:59648",
+					"172.19.0.1:59648",
+					"172.20.0.1:59648",
+					"172.21.0.1:59648",
+					"172.22.0.1:59648",
+					"172.23.0.1:59648",
+					"172.24.0.1:59648",
+					"172.25.0.1:59648",
+					"172.26.0.1:59648",
+					"172.27.0.1:59648",
+					"172.28.0.1:59648"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:13:47.91854552Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7962419053186660,
+				"StableID":   "nwQ1iJFCB521CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1919b336c3693103d358715b27cab626f647d1a16d164cf5d49aedd2ef924f73",
+				"DiscoKey":   "discokey:73f5523af2c0b1d4dd5c5014d41ae7df45fa1a7ee02057a69150b72725eb024f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53407",
+					"10.65.0.27:53407",
+					"172.17.0.1:53407",
+					"172.18.0.1:53407",
+					"172.19.0.1:53407",
+					"172.20.0.1:53407",
+					"172.21.0.1:53407",
+					"172.22.0.1:53407",
+					"172.23.0.1:53407",
+					"172.24.0.1:53407",
+					"172.25.0.1:53407",
+					"172.26.0.1:53407",
+					"172.27.0.1:53407",
+					"172.28.0.1:53407"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:13:48.443469076Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6044746052499738,
+				"StableID":   "nZE9QGEgCp11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22b70227ae88b9fda9788c3772c332407cdb89148f91c10176ca8b8903ff1363",
+				"DiscoKey":   "discokey:0fe71482954ba2363754e028708fb46b481ff00096be262ea4f006ca7ad8e916",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52558",
+					"10.65.0.27:52558",
+					"172.17.0.1:52558",
+					"172.18.0.1:52558",
+					"172.19.0.1:52558",
+					"172.20.0.1:52558",
+					"172.21.0.1:52558",
+					"172.22.0.1:52558",
+					"172.23.0.1:52558",
+					"172.24.0.1:52558",
+					"172.25.0.1:52558",
+					"172.26.0.1:52558",
+					"172.27.0.1:52558",
+					"172.28.0.1:52558"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:13:48.99964013Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5433078469590070,
+				"StableID":   "nBmxezkeRj11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8374fb267d55809e52504290e6ffeee33efde8ebaf7a7b623b5014bba304e425",
+				"DiscoKey":   "discokey:048c34a79aa49896a13903eef96e816e4b4e663fd7ca02a21bc2c4b356ab4146",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46826",
+					"10.65.0.27:46826",
+					"172.17.0.1:46826",
+					"172.18.0.1:46826",
+					"172.19.0.1:46826",
+					"172.20.0.1:46826",
+					"172.21.0.1:46826",
+					"172.22.0.1:46826",
+					"172.23.0.1:46826",
+					"172.24.0.1:46826",
+					"172.25.0.1:46826",
+					"172.26.0.1:46826",
+					"172.27.0.1:46826",
+					"172.28.0.1:46826"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:13:49.537845082Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2090937420854518,
+				"StableID":   "nsFXo4PzKH11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fd6ec88dd199fb11999e2d7d422e1414e6d70b7fce1f27b05b5f38d055196670",
+				"DiscoKey":   "discokey:1db436dff3600f11b84dfabc0662c7d4aee6c73367fe018562583e0a5604d344",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:34160",
+					"10.65.0.27:34160",
+					"172.17.0.1:34160",
+					"172.18.0.1:34160",
+					"172.19.0.1:34160",
+					"172.20.0.1:34160",
+					"172.21.0.1:34160",
+					"172.22.0.1:34160",
+					"172.23.0.1:34160",
+					"172.24.0.1:34160",
+					"172.25.0.1:34160",
+					"172.26.0.1:34160",
+					"172.27.0.1:34160",
+					"172.28.0.1:34160"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:13:50.07963397Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8304711186217950,
+				"StableID":   "nRnxNUgDr721CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d49968ed4b6e801f8bcfd75d2970d5e8d0b027b6cfc0b8c2c45c01e6df263151",
+				"DiscoKey":   "discokey:aea7b0e953bfef0d6a6c0814d25e731c9963eadb70924378da868b42a43e0400",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58025",
+					"10.65.0.27:58025",
+					"172.17.0.1:58025",
+					"172.18.0.1:58025",
+					"172.19.0.1:58025",
+					"172.20.0.1:58025",
+					"172.21.0.1:58025",
+					"172.22.0.1:58025",
+					"172.23.0.1:58025",
+					"172.24.0.1:58025",
+					"172.25.0.1:58025",
+					"172.26.0.1:58025",
+					"172.27.0.1:58025",
+					"172.28.0.1:58025"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:13:50.615674201Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         850548047160251,
+				"StableID":   "nxm2NPTDe711CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a84426ee164e9dec6e36d1d4ee19a179cf3d0b1dbad9a7dc0e60a3cdd0524e69",
+				"DiscoKey":   "discokey:90b4b8be3269ab9acbb2b879ca50b01ace17583683a8bbe8827c2554b729e656",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56047",
+					"10.65.0.27:56047",
+					"172.17.0.1:56047",
+					"172.18.0.1:56047",
+					"172.19.0.1:56047",
+					"172.20.0.1:56047",
+					"172.21.0.1:56047",
+					"172.22.0.1:56047",
+					"172.23.0.1:56047",
+					"172.24.0.1:56047",
+					"172.25.0.1:56047",
+					"172.26.0.1:56047",
+					"172.27.0.1:56047",
+					"172.28.0.1:56047"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:13:51.157675554Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         386192675168184,
+				"StableID":   "nTkVFMdu1411CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65590cb7a0a1b156cd97548850712f0b5c133b69282c80783264e2a065fdff0e",
+				"DiscoKey":   "discokey:ca4024426bcbe73444222fb3b3209f6117900f75cf74e5bb9ed8347bf0d65b55",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60971",
+					"10.65.0.27:60971",
+					"172.17.0.1:60971",
+					"172.18.0.1:60971",
+					"172.19.0.1:60971",
+					"172.20.0.1:60971",
+					"172.21.0.1:60971",
+					"172.22.0.1:60971",
+					"172.23.0.1:60971",
+					"172.24.0.1:60971",
+					"172.25.0.1:60971",
+					"172.26.0.1:60971",
+					"172.27.0.1:60971",
+					"172.28.0.1:60971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:13:51.662720535Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4704402975167966,
+				"StableID":   "nd4nSxgdjd11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f1ae1a9f931a41b4aba1300de94df66a2281c2b941d91a32521da4e952bf0651",
+				"DiscoKey":   "discokey:fa05c6c50cc38d0b64d4d60f0844cd3a54e82ea25f982a4e9ef1eaba08163946",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44348",
+					"10.65.0.27:44348",
+					"172.17.0.1:44348",
+					"172.18.0.1:44348",
+					"172.19.0.1:44348",
+					"172.20.0.1:44348",
+					"172.21.0.1:44348",
+					"172.22.0.1:44348",
+					"172.23.0.1:44348",
+					"172.24.0.1:44348",
+					"172.25.0.1:44348",
+					"172.26.0.1:44348",
+					"172.27.0.1:44348",
+					"172.28.0.1:44348"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:13:52.186640841Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7697324779720731,
+				"StableID":   "nanwXqf87321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7f81a6816c056d92f3704369a6fdc539d85d1fdfa41c4ace70942e5139888128",
+				"KeyExpiry":  "2026-11-09T09:13:53Z",
+				"DiscoKey":   "discokey:11c3892b44cfc9dfc564cb22131b80cbe9f67efc1a196ed7d89aa5cbba2b6d69",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43789",
+					"10.65.0.27:43789",
+					"172.17.0.1:43789",
+					"172.18.0.1:43789",
+					"172.19.0.1:43789",
+					"172.20.0.1:43789",
+					"172.21.0.1:43789",
+					"172.22.0.1:43789",
+					"172.23.0.1:43789",
+					"172.24.0.1:43789",
+					"172.25.0.1:43789",
+					"172.26.0.1:43789",
+					"172.27.0.1:43789",
+					"172.28.0.1:43789"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:13:53.276284579Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6802839220756022,
+				"StableID":   "nDUAiw328v11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c608580ec5c8dc961136d45191c29953ac601954fcd3bff2e24bf1f422775c54",
+				"KeyExpiry":  "2026-11-09T09:13:53Z",
+				"DiscoKey":   "discokey:b6e7700deeeeca23395db19fa7c9869a106f94702e24a2145d4ffc49b8766710",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39909",
+					"10.65.0.27:39909",
+					"172.17.0.1:39909",
+					"172.18.0.1:39909",
+					"172.19.0.1:39909",
+					"172.20.0.1:39909",
+					"172.21.0.1:39909",
+					"172.22.0.1:39909",
+					"172.23.0.1:39909",
+					"172.24.0.1:39909",
+					"172.25.0.1:39909",
+					"172.26.0.1:39909",
+					"172.27.0.1:39909",
+					"172.28.0.1:39909"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:13:53.846011491Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5958266231653377,
+				"StableID":   "nnKVmvYWXo11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b632c8a0f0684027efe19c151240b992be582ebb9cb868e39cdd0bc70d6c4859",
+				"KeyExpiry":  "2026-11-09T09:13:54Z",
+				"DiscoKey":   "discokey:f99ec748364ad51f9d7e83f1f08951353651063950f648d7f4a6c98573494c3e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41042",
+					"10.65.0.27:41042",
+					"172.17.0.1:41042",
+					"172.18.0.1:41042",
+					"172.19.0.1:41042",
+					"172.20.0.1:41042",
+					"172.21.0.1:41042",
+					"172.22.0.1:41042",
+					"172.23.0.1:41042",
+					"172.24.0.1:41042",
+					"172.25.0.1:41042",
+					"172.26.0.1:41042",
+					"172.27.0.1:41042",
+					"172.28.0.1:41042"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:13:54.362859818Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1394021246640640": {
+				"ID":          1394021246640640,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5433078469590070,
+				"StableID":   "nBmxezkeRj11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       5433078469590070,
+				"Key":        "nodekey:8374fb267d55809e52504290e6ffeee33efde8ebaf7a7b623b5014bba304e425",
+				"DiscoKey":   "discokey:048c34a79aa49896a13903eef96e816e4b4e663fd7ca02a21bc2c4b356ab4146",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46826",
+					"10.65.0.27:46826",
+					"172.17.0.1:46826",
+					"172.18.0.1:46826",
+					"172.19.0.1:46826",
+					"172.20.0.1:46826",
+					"172.21.0.1:46826",
+					"172.22.0.1:46826",
+					"172.23.0.1:46826",
+					"172.24.0.1:46826",
+					"172.25.0.1:46826",
+					"172.26.0.1:46826",
+					"172.27.0.1:46826",
+					"172.28.0.1:46826"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:13:49.537845082Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8374fb267d55809e52504290e6ffeee33efde8ebaf7a7b623b5014bba304e425",
+			"MachineKey": "mkey:fbeba549e1539da7fe0006fca29619a683f0f7f7bc5cdaab385477c204421158",
+			"Peers": [{
+				"ID":         1198500343174197,
+				"StableID":   "nnmmFAaoMA11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:240f04f24aa13822252cbc3331eb7282991f64f29b7d9ac2befea60e896ef054",
+				"DiscoKey":   "discokey:ec8422f81c6380d3d6ed4f7fb5533072e378cd12cc5a06a94f667abc8a57c735",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:32935",
+					"10.65.0.27:32935",
+					"172.17.0.1:32935",
+					"172.18.0.1:32935",
+					"172.19.0.1:32935",
+					"172.20.0.1:32935",
+					"172.21.0.1:32935",
+					"172.22.0.1:32935",
+					"172.23.0.1:32935",
+					"172.24.0.1:32935",
+					"172.25.0.1:32935",
+					"172.26.0.1:32935",
+					"172.27.0.1:32935",
+					"172.28.0.1:32935"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:13:46.866938583Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5681187607005970,
+				"StableID":   "nBy3XZA2Nm11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:689e4a53f458215c7fe16a8c184c25724501d72d939e064df8f01398a492bf47",
+				"DiscoKey":   "discokey:2b3c1ce5b6b1d0405e2901e81a6465eef0881f513a2ee2274c701c371de73b6e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:38614",
+					"10.65.0.27:38614",
+					"172.17.0.1:38614",
+					"172.18.0.1:38614",
+					"172.19.0.1:38614",
+					"172.20.0.1:38614",
+					"172.21.0.1:38614",
+					"172.22.0.1:38614",
+					"172.23.0.1:38614",
+					"172.24.0.1:38614",
+					"172.25.0.1:38614",
+					"172.26.0.1:38614",
+					"172.27.0.1:38614",
+					"172.28.0.1:38614"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:13:47.376361337Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         12931462317159,
+				"StableID":   "naWW3tgr6111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b616fb9f37c2d3c5666f8339afed4dcd65336f5d6b4ff82d2da3af6efdacf12",
+				"DiscoKey":   "discokey:bec41e4ae574c1a59263182ed64c39ea7b104fa761ea0374e39f5f814e95af44",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59648",
+					"10.65.0.27:59648",
+					"172.17.0.1:59648",
+					"172.18.0.1:59648",
+					"172.19.0.1:59648",
+					"172.20.0.1:59648",
+					"172.21.0.1:59648",
+					"172.22.0.1:59648",
+					"172.23.0.1:59648",
+					"172.24.0.1:59648",
+					"172.25.0.1:59648",
+					"172.26.0.1:59648",
+					"172.27.0.1:59648",
+					"172.28.0.1:59648"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:13:47.91854552Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7962419053186660,
+				"StableID":   "nwQ1iJFCB521CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1919b336c3693103d358715b27cab626f647d1a16d164cf5d49aedd2ef924f73",
+				"DiscoKey":   "discokey:73f5523af2c0b1d4dd5c5014d41ae7df45fa1a7ee02057a69150b72725eb024f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53407",
+					"10.65.0.27:53407",
+					"172.17.0.1:53407",
+					"172.18.0.1:53407",
+					"172.19.0.1:53407",
+					"172.20.0.1:53407",
+					"172.21.0.1:53407",
+					"172.22.0.1:53407",
+					"172.23.0.1:53407",
+					"172.24.0.1:53407",
+					"172.25.0.1:53407",
+					"172.26.0.1:53407",
+					"172.27.0.1:53407",
+					"172.28.0.1:53407"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:13:48.443469076Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6044746052499738,
+				"StableID":   "nZE9QGEgCp11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22b70227ae88b9fda9788c3772c332407cdb89148f91c10176ca8b8903ff1363",
+				"DiscoKey":   "discokey:0fe71482954ba2363754e028708fb46b481ff00096be262ea4f006ca7ad8e916",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52558",
+					"10.65.0.27:52558",
+					"172.17.0.1:52558",
+					"172.18.0.1:52558",
+					"172.19.0.1:52558",
+					"172.20.0.1:52558",
+					"172.21.0.1:52558",
+					"172.22.0.1:52558",
+					"172.23.0.1:52558",
+					"172.24.0.1:52558",
+					"172.25.0.1:52558",
+					"172.26.0.1:52558",
+					"172.27.0.1:52558",
+					"172.28.0.1:52558"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:13:48.99964013Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2090937420854518,
+				"StableID":   "nsFXo4PzKH11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fd6ec88dd199fb11999e2d7d422e1414e6d70b7fce1f27b05b5f38d055196670",
+				"DiscoKey":   "discokey:1db436dff3600f11b84dfabc0662c7d4aee6c73367fe018562583e0a5604d344",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:34160",
+					"10.65.0.27:34160",
+					"172.17.0.1:34160",
+					"172.18.0.1:34160",
+					"172.19.0.1:34160",
+					"172.20.0.1:34160",
+					"172.21.0.1:34160",
+					"172.22.0.1:34160",
+					"172.23.0.1:34160",
+					"172.24.0.1:34160",
+					"172.25.0.1:34160",
+					"172.26.0.1:34160",
+					"172.27.0.1:34160",
+					"172.28.0.1:34160"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:13:50.07963397Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8304711186217950,
+				"StableID":   "nRnxNUgDr721CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d49968ed4b6e801f8bcfd75d2970d5e8d0b027b6cfc0b8c2c45c01e6df263151",
+				"DiscoKey":   "discokey:aea7b0e953bfef0d6a6c0814d25e731c9963eadb70924378da868b42a43e0400",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58025",
+					"10.65.0.27:58025",
+					"172.17.0.1:58025",
+					"172.18.0.1:58025",
+					"172.19.0.1:58025",
+					"172.20.0.1:58025",
+					"172.21.0.1:58025",
+					"172.22.0.1:58025",
+					"172.23.0.1:58025",
+					"172.24.0.1:58025",
+					"172.25.0.1:58025",
+					"172.26.0.1:58025",
+					"172.27.0.1:58025",
+					"172.28.0.1:58025"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:13:50.615674201Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         850548047160251,
+				"StableID":   "nxm2NPTDe711CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a84426ee164e9dec6e36d1d4ee19a179cf3d0b1dbad9a7dc0e60a3cdd0524e69",
+				"DiscoKey":   "discokey:90b4b8be3269ab9acbb2b879ca50b01ace17583683a8bbe8827c2554b729e656",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56047",
+					"10.65.0.27:56047",
+					"172.17.0.1:56047",
+					"172.18.0.1:56047",
+					"172.19.0.1:56047",
+					"172.20.0.1:56047",
+					"172.21.0.1:56047",
+					"172.22.0.1:56047",
+					"172.23.0.1:56047",
+					"172.24.0.1:56047",
+					"172.25.0.1:56047",
+					"172.26.0.1:56047",
+					"172.27.0.1:56047",
+					"172.28.0.1:56047"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:13:51.157675554Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         386192675168184,
+				"StableID":   "nTkVFMdu1411CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65590cb7a0a1b156cd97548850712f0b5c133b69282c80783264e2a065fdff0e",
+				"DiscoKey":   "discokey:ca4024426bcbe73444222fb3b3209f6117900f75cf74e5bb9ed8347bf0d65b55",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60971",
+					"10.65.0.27:60971",
+					"172.17.0.1:60971",
+					"172.18.0.1:60971",
+					"172.19.0.1:60971",
+					"172.20.0.1:60971",
+					"172.21.0.1:60971",
+					"172.22.0.1:60971",
+					"172.23.0.1:60971",
+					"172.24.0.1:60971",
+					"172.25.0.1:60971",
+					"172.26.0.1:60971",
+					"172.27.0.1:60971",
+					"172.28.0.1:60971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:13:51.662720535Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4704402975167966,
+				"StableID":   "nd4nSxgdjd11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f1ae1a9f931a41b4aba1300de94df66a2281c2b941d91a32521da4e952bf0651",
+				"DiscoKey":   "discokey:fa05c6c50cc38d0b64d4d60f0844cd3a54e82ea25f982a4e9ef1eaba08163946",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44348",
+					"10.65.0.27:44348",
+					"172.17.0.1:44348",
+					"172.18.0.1:44348",
+					"172.19.0.1:44348",
+					"172.20.0.1:44348",
+					"172.21.0.1:44348",
+					"172.22.0.1:44348",
+					"172.23.0.1:44348",
+					"172.24.0.1:44348",
+					"172.25.0.1:44348",
+					"172.26.0.1:44348",
+					"172.27.0.1:44348",
+					"172.28.0.1:44348"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:13:52.186640841Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1394021246640640,
+				"StableID":   "n3NvxJaMtB11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fb6653ad217217a2c56e9017d38db7ce1331a96fb389a774ab6b31459a3fb27",
+				"DiscoKey":   "discokey:75c30f7c43cafad3e3c423c5f02ce9236bd88881ef05a7aa983a8854fd33d007",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58655",
+					"10.65.0.27:58655",
+					"172.17.0.1:58655",
+					"172.18.0.1:58655",
+					"172.19.0.1:58655",
+					"172.20.0.1:58655",
+					"172.21.0.1:58655",
+					"172.22.0.1:58655",
+					"172.23.0.1:58655",
+					"172.24.0.1:58655",
+					"172.25.0.1:58655",
+					"172.26.0.1:58655",
+					"172.27.0.1:58655",
+					"172.28.0.1:58655"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:13:52.743055689Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7697324779720731,
+				"StableID":   "nanwXqf87321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7f81a6816c056d92f3704369a6fdc539d85d1fdfa41c4ace70942e5139888128",
+				"KeyExpiry":  "2026-11-09T09:13:53Z",
+				"DiscoKey":   "discokey:11c3892b44cfc9dfc564cb22131b80cbe9f67efc1a196ed7d89aa5cbba2b6d69",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43789",
+					"10.65.0.27:43789",
+					"172.17.0.1:43789",
+					"172.18.0.1:43789",
+					"172.19.0.1:43789",
+					"172.20.0.1:43789",
+					"172.21.0.1:43789",
+					"172.22.0.1:43789",
+					"172.23.0.1:43789",
+					"172.24.0.1:43789",
+					"172.25.0.1:43789",
+					"172.26.0.1:43789",
+					"172.27.0.1:43789",
+					"172.28.0.1:43789"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:13:53.276284579Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6802839220756022,
+				"StableID":   "nDUAiw328v11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c608580ec5c8dc961136d45191c29953ac601954fcd3bff2e24bf1f422775c54",
+				"KeyExpiry":  "2026-11-09T09:13:53Z",
+				"DiscoKey":   "discokey:b6e7700deeeeca23395db19fa7c9869a106f94702e24a2145d4ffc49b8766710",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39909",
+					"10.65.0.27:39909",
+					"172.17.0.1:39909",
+					"172.18.0.1:39909",
+					"172.19.0.1:39909",
+					"172.20.0.1:39909",
+					"172.21.0.1:39909",
+					"172.22.0.1:39909",
+					"172.23.0.1:39909",
+					"172.24.0.1:39909",
+					"172.25.0.1:39909",
+					"172.26.0.1:39909",
+					"172.27.0.1:39909",
+					"172.28.0.1:39909"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:13:53.846011491Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5958266231653377,
+				"StableID":   "nnKVmvYWXo11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b632c8a0f0684027efe19c151240b992be582ebb9cb868e39cdd0bc70d6c4859",
+				"KeyExpiry":  "2026-11-09T09:13:54Z",
+				"DiscoKey":   "discokey:f99ec748364ad51f9d7e83f1f08951353651063950f648d7f4a6c98573494c3e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41042",
+					"10.65.0.27:41042",
+					"172.17.0.1:41042",
+					"172.18.0.1:41042",
+					"172.19.0.1:41042",
+					"172.20.0.1:41042",
+					"172.21.0.1:41042",
+					"172.22.0.1:41042",
+					"172.23.0.1:41042",
+					"172.24.0.1:41042",
+					"172.25.0.1:41042",
+					"172.26.0.1:41042",
+					"172.27.0.1:41042",
+					"172.28.0.1:41042"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:13:54.362859818Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5433078469590070": {
+				"ID":          5433078469590070,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5958266231653377,
+				"StableID":   "nnKVmvYWXo11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b632c8a0f0684027efe19c151240b992be582ebb9cb868e39cdd0bc70d6c4859",
+				"KeyExpiry":  "2026-11-09T09:13:54Z",
+				"DiscoKey":   "discokey:f99ec748364ad51f9d7e83f1f08951353651063950f648d7f4a6c98573494c3e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41042",
+					"10.65.0.27:41042",
+					"172.17.0.1:41042",
+					"172.18.0.1:41042",
+					"172.19.0.1:41042",
+					"172.20.0.1:41042",
+					"172.21.0.1:41042",
+					"172.22.0.1:41042",
+					"172.23.0.1:41042",
+					"172.24.0.1:41042",
+					"172.25.0.1:41042",
+					"172.26.0.1:41042",
+					"172.27.0.1:41042",
+					"172.28.0.1:41042"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:13:54.362859818Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b632c8a0f0684027efe19c151240b992be582ebb9cb868e39cdd0bc70d6c4859",
+			"MachineKey": "mkey:71464a73ff456068bcdd59e6c1e84535d342a086fc4300c721faed57f9882407",
+			"Peers": [{
+				"ID":         1198500343174197,
+				"StableID":   "nnmmFAaoMA11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:240f04f24aa13822252cbc3331eb7282991f64f29b7d9ac2befea60e896ef054",
+				"DiscoKey":   "discokey:ec8422f81c6380d3d6ed4f7fb5533072e378cd12cc5a06a94f667abc8a57c735",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:32935",
+					"10.65.0.27:32935",
+					"172.17.0.1:32935",
+					"172.18.0.1:32935",
+					"172.19.0.1:32935",
+					"172.20.0.1:32935",
+					"172.21.0.1:32935",
+					"172.22.0.1:32935",
+					"172.23.0.1:32935",
+					"172.24.0.1:32935",
+					"172.25.0.1:32935",
+					"172.26.0.1:32935",
+					"172.27.0.1:32935",
+					"172.28.0.1:32935"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:13:46.866938583Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5681187607005970,
+				"StableID":   "nBy3XZA2Nm11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:689e4a53f458215c7fe16a8c184c25724501d72d939e064df8f01398a492bf47",
+				"DiscoKey":   "discokey:2b3c1ce5b6b1d0405e2901e81a6465eef0881f513a2ee2274c701c371de73b6e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:38614",
+					"10.65.0.27:38614",
+					"172.17.0.1:38614",
+					"172.18.0.1:38614",
+					"172.19.0.1:38614",
+					"172.20.0.1:38614",
+					"172.21.0.1:38614",
+					"172.22.0.1:38614",
+					"172.23.0.1:38614",
+					"172.24.0.1:38614",
+					"172.25.0.1:38614",
+					"172.26.0.1:38614",
+					"172.27.0.1:38614",
+					"172.28.0.1:38614"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:13:47.376361337Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         12931462317159,
+				"StableID":   "naWW3tgr6111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b616fb9f37c2d3c5666f8339afed4dcd65336f5d6b4ff82d2da3af6efdacf12",
+				"DiscoKey":   "discokey:bec41e4ae574c1a59263182ed64c39ea7b104fa761ea0374e39f5f814e95af44",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59648",
+					"10.65.0.27:59648",
+					"172.17.0.1:59648",
+					"172.18.0.1:59648",
+					"172.19.0.1:59648",
+					"172.20.0.1:59648",
+					"172.21.0.1:59648",
+					"172.22.0.1:59648",
+					"172.23.0.1:59648",
+					"172.24.0.1:59648",
+					"172.25.0.1:59648",
+					"172.26.0.1:59648",
+					"172.27.0.1:59648",
+					"172.28.0.1:59648"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:13:47.91854552Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7962419053186660,
+				"StableID":   "nwQ1iJFCB521CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1919b336c3693103d358715b27cab626f647d1a16d164cf5d49aedd2ef924f73",
+				"DiscoKey":   "discokey:73f5523af2c0b1d4dd5c5014d41ae7df45fa1a7ee02057a69150b72725eb024f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53407",
+					"10.65.0.27:53407",
+					"172.17.0.1:53407",
+					"172.18.0.1:53407",
+					"172.19.0.1:53407",
+					"172.20.0.1:53407",
+					"172.21.0.1:53407",
+					"172.22.0.1:53407",
+					"172.23.0.1:53407",
+					"172.24.0.1:53407",
+					"172.25.0.1:53407",
+					"172.26.0.1:53407",
+					"172.27.0.1:53407",
+					"172.28.0.1:53407"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:13:48.443469076Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6044746052499738,
+				"StableID":   "nZE9QGEgCp11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22b70227ae88b9fda9788c3772c332407cdb89148f91c10176ca8b8903ff1363",
+				"DiscoKey":   "discokey:0fe71482954ba2363754e028708fb46b481ff00096be262ea4f006ca7ad8e916",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52558",
+					"10.65.0.27:52558",
+					"172.17.0.1:52558",
+					"172.18.0.1:52558",
+					"172.19.0.1:52558",
+					"172.20.0.1:52558",
+					"172.21.0.1:52558",
+					"172.22.0.1:52558",
+					"172.23.0.1:52558",
+					"172.24.0.1:52558",
+					"172.25.0.1:52558",
+					"172.26.0.1:52558",
+					"172.27.0.1:52558",
+					"172.28.0.1:52558"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:13:48.99964013Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5433078469590070,
+				"StableID":   "nBmxezkeRj11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8374fb267d55809e52504290e6ffeee33efde8ebaf7a7b623b5014bba304e425",
+				"DiscoKey":   "discokey:048c34a79aa49896a13903eef96e816e4b4e663fd7ca02a21bc2c4b356ab4146",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46826",
+					"10.65.0.27:46826",
+					"172.17.0.1:46826",
+					"172.18.0.1:46826",
+					"172.19.0.1:46826",
+					"172.20.0.1:46826",
+					"172.21.0.1:46826",
+					"172.22.0.1:46826",
+					"172.23.0.1:46826",
+					"172.24.0.1:46826",
+					"172.25.0.1:46826",
+					"172.26.0.1:46826",
+					"172.27.0.1:46826",
+					"172.28.0.1:46826"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:13:49.537845082Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2090937420854518,
+				"StableID":   "nsFXo4PzKH11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fd6ec88dd199fb11999e2d7d422e1414e6d70b7fce1f27b05b5f38d055196670",
+				"DiscoKey":   "discokey:1db436dff3600f11b84dfabc0662c7d4aee6c73367fe018562583e0a5604d344",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:34160",
+					"10.65.0.27:34160",
+					"172.17.0.1:34160",
+					"172.18.0.1:34160",
+					"172.19.0.1:34160",
+					"172.20.0.1:34160",
+					"172.21.0.1:34160",
+					"172.22.0.1:34160",
+					"172.23.0.1:34160",
+					"172.24.0.1:34160",
+					"172.25.0.1:34160",
+					"172.26.0.1:34160",
+					"172.27.0.1:34160",
+					"172.28.0.1:34160"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:13:50.07963397Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8304711186217950,
+				"StableID":   "nRnxNUgDr721CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d49968ed4b6e801f8bcfd75d2970d5e8d0b027b6cfc0b8c2c45c01e6df263151",
+				"DiscoKey":   "discokey:aea7b0e953bfef0d6a6c0814d25e731c9963eadb70924378da868b42a43e0400",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58025",
+					"10.65.0.27:58025",
+					"172.17.0.1:58025",
+					"172.18.0.1:58025",
+					"172.19.0.1:58025",
+					"172.20.0.1:58025",
+					"172.21.0.1:58025",
+					"172.22.0.1:58025",
+					"172.23.0.1:58025",
+					"172.24.0.1:58025",
+					"172.25.0.1:58025",
+					"172.26.0.1:58025",
+					"172.27.0.1:58025",
+					"172.28.0.1:58025"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:13:50.615674201Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         850548047160251,
+				"StableID":   "nxm2NPTDe711CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a84426ee164e9dec6e36d1d4ee19a179cf3d0b1dbad9a7dc0e60a3cdd0524e69",
+				"DiscoKey":   "discokey:90b4b8be3269ab9acbb2b879ca50b01ace17583683a8bbe8827c2554b729e656",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56047",
+					"10.65.0.27:56047",
+					"172.17.0.1:56047",
+					"172.18.0.1:56047",
+					"172.19.0.1:56047",
+					"172.20.0.1:56047",
+					"172.21.0.1:56047",
+					"172.22.0.1:56047",
+					"172.23.0.1:56047",
+					"172.24.0.1:56047",
+					"172.25.0.1:56047",
+					"172.26.0.1:56047",
+					"172.27.0.1:56047",
+					"172.28.0.1:56047"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:13:51.157675554Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         386192675168184,
+				"StableID":   "nTkVFMdu1411CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65590cb7a0a1b156cd97548850712f0b5c133b69282c80783264e2a065fdff0e",
+				"DiscoKey":   "discokey:ca4024426bcbe73444222fb3b3209f6117900f75cf74e5bb9ed8347bf0d65b55",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60971",
+					"10.65.0.27:60971",
+					"172.17.0.1:60971",
+					"172.18.0.1:60971",
+					"172.19.0.1:60971",
+					"172.20.0.1:60971",
+					"172.21.0.1:60971",
+					"172.22.0.1:60971",
+					"172.23.0.1:60971",
+					"172.24.0.1:60971",
+					"172.25.0.1:60971",
+					"172.26.0.1:60971",
+					"172.27.0.1:60971",
+					"172.28.0.1:60971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:13:51.662720535Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4704402975167966,
+				"StableID":   "nd4nSxgdjd11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f1ae1a9f931a41b4aba1300de94df66a2281c2b941d91a32521da4e952bf0651",
+				"DiscoKey":   "discokey:fa05c6c50cc38d0b64d4d60f0844cd3a54e82ea25f982a4e9ef1eaba08163946",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44348",
+					"10.65.0.27:44348",
+					"172.17.0.1:44348",
+					"172.18.0.1:44348",
+					"172.19.0.1:44348",
+					"172.20.0.1:44348",
+					"172.21.0.1:44348",
+					"172.22.0.1:44348",
+					"172.23.0.1:44348",
+					"172.24.0.1:44348",
+					"172.25.0.1:44348",
+					"172.26.0.1:44348",
+					"172.27.0.1:44348",
+					"172.28.0.1:44348"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:13:52.186640841Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1394021246640640,
+				"StableID":   "n3NvxJaMtB11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fb6653ad217217a2c56e9017d38db7ce1331a96fb389a774ab6b31459a3fb27",
+				"DiscoKey":   "discokey:75c30f7c43cafad3e3c423c5f02ce9236bd88881ef05a7aa983a8854fd33d007",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58655",
+					"10.65.0.27:58655",
+					"172.17.0.1:58655",
+					"172.18.0.1:58655",
+					"172.19.0.1:58655",
+					"172.20.0.1:58655",
+					"172.21.0.1:58655",
+					"172.22.0.1:58655",
+					"172.23.0.1:58655",
+					"172.24.0.1:58655",
+					"172.25.0.1:58655",
+					"172.26.0.1:58655",
+					"172.27.0.1:58655",
+					"172.28.0.1:58655"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:13:52.743055689Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7697324779720731,
+				"StableID":   "nanwXqf87321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7f81a6816c056d92f3704369a6fdc539d85d1fdfa41c4ace70942e5139888128",
+				"KeyExpiry":  "2026-11-09T09:13:53Z",
+				"DiscoKey":   "discokey:11c3892b44cfc9dfc564cb22131b80cbe9f67efc1a196ed7d89aa5cbba2b6d69",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43789",
+					"10.65.0.27:43789",
+					"172.17.0.1:43789",
+					"172.18.0.1:43789",
+					"172.19.0.1:43789",
+					"172.20.0.1:43789",
+					"172.21.0.1:43789",
+					"172.22.0.1:43789",
+					"172.23.0.1:43789",
+					"172.24.0.1:43789",
+					"172.25.0.1:43789",
+					"172.26.0.1:43789",
+					"172.27.0.1:43789",
+					"172.28.0.1:43789"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:13:53.276284579Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6802839220756022,
+				"StableID":   "nDUAiw328v11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c608580ec5c8dc961136d45191c29953ac601954fcd3bff2e24bf1f422775c54",
+				"KeyExpiry":  "2026-11-09T09:13:53Z",
+				"DiscoKey":   "discokey:b6e7700deeeeca23395db19fa7c9869a106f94702e24a2145d4ffc49b8766710",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39909",
+					"10.65.0.27:39909",
+					"172.17.0.1:39909",
+					"172.18.0.1:39909",
+					"172.19.0.1:39909",
+					"172.20.0.1:39909",
+					"172.21.0.1:39909",
+					"172.22.0.1:39909",
+					"172.23.0.1:39909",
+					"172.24.0.1:39909",
+					"172.25.0.1:39909",
+					"172.26.0.1:39909",
+					"172.27.0.1:39909",
+					"172.28.0.1:39909"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:13:53.846011491Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         12931462317159,
+				"StableID":   "naWW3tgr6111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       12931462317159,
+				"Key":        "nodekey:3b616fb9f37c2d3c5666f8339afed4dcd65336f5d6b4ff82d2da3af6efdacf12",
+				"DiscoKey":   "discokey:bec41e4ae574c1a59263182ed64c39ea7b104fa761ea0374e39f5f814e95af44",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59648",
+					"10.65.0.27:59648",
+					"172.17.0.1:59648",
+					"172.18.0.1:59648",
+					"172.19.0.1:59648",
+					"172.20.0.1:59648",
+					"172.21.0.1:59648",
+					"172.22.0.1:59648",
+					"172.23.0.1:59648",
+					"172.24.0.1:59648",
+					"172.25.0.1:59648",
+					"172.26.0.1:59648",
+					"172.27.0.1:59648",
+					"172.28.0.1:59648"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:13:47.91854552Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3b616fb9f37c2d3c5666f8339afed4dcd65336f5d6b4ff82d2da3af6efdacf12",
+			"MachineKey": "mkey:cf0d7e7336427f9d0759aede4e2b58d0e915490f96ed0eddceddcbb48b33b23e",
+			"Peers": [{
+				"ID":         1198500343174197,
+				"StableID":   "nnmmFAaoMA11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:240f04f24aa13822252cbc3331eb7282991f64f29b7d9ac2befea60e896ef054",
+				"DiscoKey":   "discokey:ec8422f81c6380d3d6ed4f7fb5533072e378cd12cc5a06a94f667abc8a57c735",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:32935",
+					"10.65.0.27:32935",
+					"172.17.0.1:32935",
+					"172.18.0.1:32935",
+					"172.19.0.1:32935",
+					"172.20.0.1:32935",
+					"172.21.0.1:32935",
+					"172.22.0.1:32935",
+					"172.23.0.1:32935",
+					"172.24.0.1:32935",
+					"172.25.0.1:32935",
+					"172.26.0.1:32935",
+					"172.27.0.1:32935",
+					"172.28.0.1:32935"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:13:46.866938583Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5681187607005970,
+				"StableID":   "nBy3XZA2Nm11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:689e4a53f458215c7fe16a8c184c25724501d72d939e064df8f01398a492bf47",
+				"DiscoKey":   "discokey:2b3c1ce5b6b1d0405e2901e81a6465eef0881f513a2ee2274c701c371de73b6e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:38614",
+					"10.65.0.27:38614",
+					"172.17.0.1:38614",
+					"172.18.0.1:38614",
+					"172.19.0.1:38614",
+					"172.20.0.1:38614",
+					"172.21.0.1:38614",
+					"172.22.0.1:38614",
+					"172.23.0.1:38614",
+					"172.24.0.1:38614",
+					"172.25.0.1:38614",
+					"172.26.0.1:38614",
+					"172.27.0.1:38614",
+					"172.28.0.1:38614"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:13:47.376361337Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7962419053186660,
+				"StableID":   "nwQ1iJFCB521CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1919b336c3693103d358715b27cab626f647d1a16d164cf5d49aedd2ef924f73",
+				"DiscoKey":   "discokey:73f5523af2c0b1d4dd5c5014d41ae7df45fa1a7ee02057a69150b72725eb024f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53407",
+					"10.65.0.27:53407",
+					"172.17.0.1:53407",
+					"172.18.0.1:53407",
+					"172.19.0.1:53407",
+					"172.20.0.1:53407",
+					"172.21.0.1:53407",
+					"172.22.0.1:53407",
+					"172.23.0.1:53407",
+					"172.24.0.1:53407",
+					"172.25.0.1:53407",
+					"172.26.0.1:53407",
+					"172.27.0.1:53407",
+					"172.28.0.1:53407"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:13:48.443469076Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6044746052499738,
+				"StableID":   "nZE9QGEgCp11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22b70227ae88b9fda9788c3772c332407cdb89148f91c10176ca8b8903ff1363",
+				"DiscoKey":   "discokey:0fe71482954ba2363754e028708fb46b481ff00096be262ea4f006ca7ad8e916",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52558",
+					"10.65.0.27:52558",
+					"172.17.0.1:52558",
+					"172.18.0.1:52558",
+					"172.19.0.1:52558",
+					"172.20.0.1:52558",
+					"172.21.0.1:52558",
+					"172.22.0.1:52558",
+					"172.23.0.1:52558",
+					"172.24.0.1:52558",
+					"172.25.0.1:52558",
+					"172.26.0.1:52558",
+					"172.27.0.1:52558",
+					"172.28.0.1:52558"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:13:48.99964013Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5433078469590070,
+				"StableID":   "nBmxezkeRj11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8374fb267d55809e52504290e6ffeee33efde8ebaf7a7b623b5014bba304e425",
+				"DiscoKey":   "discokey:048c34a79aa49896a13903eef96e816e4b4e663fd7ca02a21bc2c4b356ab4146",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46826",
+					"10.65.0.27:46826",
+					"172.17.0.1:46826",
+					"172.18.0.1:46826",
+					"172.19.0.1:46826",
+					"172.20.0.1:46826",
+					"172.21.0.1:46826",
+					"172.22.0.1:46826",
+					"172.23.0.1:46826",
+					"172.24.0.1:46826",
+					"172.25.0.1:46826",
+					"172.26.0.1:46826",
+					"172.27.0.1:46826",
+					"172.28.0.1:46826"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:13:49.537845082Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2090937420854518,
+				"StableID":   "nsFXo4PzKH11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fd6ec88dd199fb11999e2d7d422e1414e6d70b7fce1f27b05b5f38d055196670",
+				"DiscoKey":   "discokey:1db436dff3600f11b84dfabc0662c7d4aee6c73367fe018562583e0a5604d344",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:34160",
+					"10.65.0.27:34160",
+					"172.17.0.1:34160",
+					"172.18.0.1:34160",
+					"172.19.0.1:34160",
+					"172.20.0.1:34160",
+					"172.21.0.1:34160",
+					"172.22.0.1:34160",
+					"172.23.0.1:34160",
+					"172.24.0.1:34160",
+					"172.25.0.1:34160",
+					"172.26.0.1:34160",
+					"172.27.0.1:34160",
+					"172.28.0.1:34160"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:13:50.07963397Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8304711186217950,
+				"StableID":   "nRnxNUgDr721CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d49968ed4b6e801f8bcfd75d2970d5e8d0b027b6cfc0b8c2c45c01e6df263151",
+				"DiscoKey":   "discokey:aea7b0e953bfef0d6a6c0814d25e731c9963eadb70924378da868b42a43e0400",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58025",
+					"10.65.0.27:58025",
+					"172.17.0.1:58025",
+					"172.18.0.1:58025",
+					"172.19.0.1:58025",
+					"172.20.0.1:58025",
+					"172.21.0.1:58025",
+					"172.22.0.1:58025",
+					"172.23.0.1:58025",
+					"172.24.0.1:58025",
+					"172.25.0.1:58025",
+					"172.26.0.1:58025",
+					"172.27.0.1:58025",
+					"172.28.0.1:58025"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:13:50.615674201Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         850548047160251,
+				"StableID":   "nxm2NPTDe711CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a84426ee164e9dec6e36d1d4ee19a179cf3d0b1dbad9a7dc0e60a3cdd0524e69",
+				"DiscoKey":   "discokey:90b4b8be3269ab9acbb2b879ca50b01ace17583683a8bbe8827c2554b729e656",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56047",
+					"10.65.0.27:56047",
+					"172.17.0.1:56047",
+					"172.18.0.1:56047",
+					"172.19.0.1:56047",
+					"172.20.0.1:56047",
+					"172.21.0.1:56047",
+					"172.22.0.1:56047",
+					"172.23.0.1:56047",
+					"172.24.0.1:56047",
+					"172.25.0.1:56047",
+					"172.26.0.1:56047",
+					"172.27.0.1:56047",
+					"172.28.0.1:56047"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:13:51.157675554Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         386192675168184,
+				"StableID":   "nTkVFMdu1411CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65590cb7a0a1b156cd97548850712f0b5c133b69282c80783264e2a065fdff0e",
+				"DiscoKey":   "discokey:ca4024426bcbe73444222fb3b3209f6117900f75cf74e5bb9ed8347bf0d65b55",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60971",
+					"10.65.0.27:60971",
+					"172.17.0.1:60971",
+					"172.18.0.1:60971",
+					"172.19.0.1:60971",
+					"172.20.0.1:60971",
+					"172.21.0.1:60971",
+					"172.22.0.1:60971",
+					"172.23.0.1:60971",
+					"172.24.0.1:60971",
+					"172.25.0.1:60971",
+					"172.26.0.1:60971",
+					"172.27.0.1:60971",
+					"172.28.0.1:60971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:13:51.662720535Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4704402975167966,
+				"StableID":   "nd4nSxgdjd11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f1ae1a9f931a41b4aba1300de94df66a2281c2b941d91a32521da4e952bf0651",
+				"DiscoKey":   "discokey:fa05c6c50cc38d0b64d4d60f0844cd3a54e82ea25f982a4e9ef1eaba08163946",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44348",
+					"10.65.0.27:44348",
+					"172.17.0.1:44348",
+					"172.18.0.1:44348",
+					"172.19.0.1:44348",
+					"172.20.0.1:44348",
+					"172.21.0.1:44348",
+					"172.22.0.1:44348",
+					"172.23.0.1:44348",
+					"172.24.0.1:44348",
+					"172.25.0.1:44348",
+					"172.26.0.1:44348",
+					"172.27.0.1:44348",
+					"172.28.0.1:44348"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:13:52.186640841Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1394021246640640,
+				"StableID":   "n3NvxJaMtB11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fb6653ad217217a2c56e9017d38db7ce1331a96fb389a774ab6b31459a3fb27",
+				"DiscoKey":   "discokey:75c30f7c43cafad3e3c423c5f02ce9236bd88881ef05a7aa983a8854fd33d007",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58655",
+					"10.65.0.27:58655",
+					"172.17.0.1:58655",
+					"172.18.0.1:58655",
+					"172.19.0.1:58655",
+					"172.20.0.1:58655",
+					"172.21.0.1:58655",
+					"172.22.0.1:58655",
+					"172.23.0.1:58655",
+					"172.24.0.1:58655",
+					"172.25.0.1:58655",
+					"172.26.0.1:58655",
+					"172.27.0.1:58655",
+					"172.28.0.1:58655"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:13:52.743055689Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7697324779720731,
+				"StableID":   "nanwXqf87321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7f81a6816c056d92f3704369a6fdc539d85d1fdfa41c4ace70942e5139888128",
+				"KeyExpiry":  "2026-11-09T09:13:53Z",
+				"DiscoKey":   "discokey:11c3892b44cfc9dfc564cb22131b80cbe9f67efc1a196ed7d89aa5cbba2b6d69",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43789",
+					"10.65.0.27:43789",
+					"172.17.0.1:43789",
+					"172.18.0.1:43789",
+					"172.19.0.1:43789",
+					"172.20.0.1:43789",
+					"172.21.0.1:43789",
+					"172.22.0.1:43789",
+					"172.23.0.1:43789",
+					"172.24.0.1:43789",
+					"172.25.0.1:43789",
+					"172.26.0.1:43789",
+					"172.27.0.1:43789",
+					"172.28.0.1:43789"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:13:53.276284579Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6802839220756022,
+				"StableID":   "nDUAiw328v11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c608580ec5c8dc961136d45191c29953ac601954fcd3bff2e24bf1f422775c54",
+				"KeyExpiry":  "2026-11-09T09:13:53Z",
+				"DiscoKey":   "discokey:b6e7700deeeeca23395db19fa7c9869a106f94702e24a2145d4ffc49b8766710",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39909",
+					"10.65.0.27:39909",
+					"172.17.0.1:39909",
+					"172.18.0.1:39909",
+					"172.19.0.1:39909",
+					"172.20.0.1:39909",
+					"172.21.0.1:39909",
+					"172.22.0.1:39909",
+					"172.23.0.1:39909",
+					"172.24.0.1:39909",
+					"172.25.0.1:39909",
+					"172.26.0.1:39909",
+					"172.27.0.1:39909",
+					"172.28.0.1:39909"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:13:53.846011491Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5958266231653377,
+				"StableID":   "nnKVmvYWXo11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b632c8a0f0684027efe19c151240b992be582ebb9cb868e39cdd0bc70d6c4859",
+				"KeyExpiry":  "2026-11-09T09:13:54Z",
+				"DiscoKey":   "discokey:f99ec748364ad51f9d7e83f1f08951353651063950f648d7f4a6c98573494c3e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41042",
+					"10.65.0.27:41042",
+					"172.17.0.1:41042",
+					"172.18.0.1:41042",
+					"172.19.0.1:41042",
+					"172.20.0.1:41042",
+					"172.21.0.1:41042",
+					"172.22.0.1:41042",
+					"172.23.0.1:41042",
+					"172.24.0.1:41042",
+					"172.25.0.1:41042",
+					"172.26.0.1:41042",
+					"172.27.0.1:41042",
+					"172.28.0.1:41042"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:13:54.362859818Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "12931462317159": {
+				"ID":          12931462317159,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8304711186217950,
+				"StableID":   "nRnxNUgDr721CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       8304711186217950,
+				"Key":        "nodekey:d49968ed4b6e801f8bcfd75d2970d5e8d0b027b6cfc0b8c2c45c01e6df263151",
+				"DiscoKey":   "discokey:aea7b0e953bfef0d6a6c0814d25e731c9963eadb70924378da868b42a43e0400",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58025",
+					"10.65.0.27:58025",
+					"172.17.0.1:58025",
+					"172.18.0.1:58025",
+					"172.19.0.1:58025",
+					"172.20.0.1:58025",
+					"172.21.0.1:58025",
+					"172.22.0.1:58025",
+					"172.23.0.1:58025",
+					"172.24.0.1:58025",
+					"172.25.0.1:58025",
+					"172.26.0.1:58025",
+					"172.27.0.1:58025",
+					"172.28.0.1:58025"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:13:50.615674201Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d49968ed4b6e801f8bcfd75d2970d5e8d0b027b6cfc0b8c2c45c01e6df263151",
+			"MachineKey": "mkey:2b37a8bc4ea2c5f87a3106703b8157fe0b0483c528484a523e9aa5108a825a46",
+			"Peers": [{
+				"ID":         1198500343174197,
+				"StableID":   "nnmmFAaoMA11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:240f04f24aa13822252cbc3331eb7282991f64f29b7d9ac2befea60e896ef054",
+				"DiscoKey":   "discokey:ec8422f81c6380d3d6ed4f7fb5533072e378cd12cc5a06a94f667abc8a57c735",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:32935",
+					"10.65.0.27:32935",
+					"172.17.0.1:32935",
+					"172.18.0.1:32935",
+					"172.19.0.1:32935",
+					"172.20.0.1:32935",
+					"172.21.0.1:32935",
+					"172.22.0.1:32935",
+					"172.23.0.1:32935",
+					"172.24.0.1:32935",
+					"172.25.0.1:32935",
+					"172.26.0.1:32935",
+					"172.27.0.1:32935",
+					"172.28.0.1:32935"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:13:46.866938583Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5681187607005970,
+				"StableID":   "nBy3XZA2Nm11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:689e4a53f458215c7fe16a8c184c25724501d72d939e064df8f01398a492bf47",
+				"DiscoKey":   "discokey:2b3c1ce5b6b1d0405e2901e81a6465eef0881f513a2ee2274c701c371de73b6e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:38614",
+					"10.65.0.27:38614",
+					"172.17.0.1:38614",
+					"172.18.0.1:38614",
+					"172.19.0.1:38614",
+					"172.20.0.1:38614",
+					"172.21.0.1:38614",
+					"172.22.0.1:38614",
+					"172.23.0.1:38614",
+					"172.24.0.1:38614",
+					"172.25.0.1:38614",
+					"172.26.0.1:38614",
+					"172.27.0.1:38614",
+					"172.28.0.1:38614"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:13:47.376361337Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         12931462317159,
+				"StableID":   "naWW3tgr6111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b616fb9f37c2d3c5666f8339afed4dcd65336f5d6b4ff82d2da3af6efdacf12",
+				"DiscoKey":   "discokey:bec41e4ae574c1a59263182ed64c39ea7b104fa761ea0374e39f5f814e95af44",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59648",
+					"10.65.0.27:59648",
+					"172.17.0.1:59648",
+					"172.18.0.1:59648",
+					"172.19.0.1:59648",
+					"172.20.0.1:59648",
+					"172.21.0.1:59648",
+					"172.22.0.1:59648",
+					"172.23.0.1:59648",
+					"172.24.0.1:59648",
+					"172.25.0.1:59648",
+					"172.26.0.1:59648",
+					"172.27.0.1:59648",
+					"172.28.0.1:59648"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:13:47.91854552Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7962419053186660,
+				"StableID":   "nwQ1iJFCB521CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1919b336c3693103d358715b27cab626f647d1a16d164cf5d49aedd2ef924f73",
+				"DiscoKey":   "discokey:73f5523af2c0b1d4dd5c5014d41ae7df45fa1a7ee02057a69150b72725eb024f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53407",
+					"10.65.0.27:53407",
+					"172.17.0.1:53407",
+					"172.18.0.1:53407",
+					"172.19.0.1:53407",
+					"172.20.0.1:53407",
+					"172.21.0.1:53407",
+					"172.22.0.1:53407",
+					"172.23.0.1:53407",
+					"172.24.0.1:53407",
+					"172.25.0.1:53407",
+					"172.26.0.1:53407",
+					"172.27.0.1:53407",
+					"172.28.0.1:53407"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:13:48.443469076Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6044746052499738,
+				"StableID":   "nZE9QGEgCp11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22b70227ae88b9fda9788c3772c332407cdb89148f91c10176ca8b8903ff1363",
+				"DiscoKey":   "discokey:0fe71482954ba2363754e028708fb46b481ff00096be262ea4f006ca7ad8e916",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52558",
+					"10.65.0.27:52558",
+					"172.17.0.1:52558",
+					"172.18.0.1:52558",
+					"172.19.0.1:52558",
+					"172.20.0.1:52558",
+					"172.21.0.1:52558",
+					"172.22.0.1:52558",
+					"172.23.0.1:52558",
+					"172.24.0.1:52558",
+					"172.25.0.1:52558",
+					"172.26.0.1:52558",
+					"172.27.0.1:52558",
+					"172.28.0.1:52558"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:13:48.99964013Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5433078469590070,
+				"StableID":   "nBmxezkeRj11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8374fb267d55809e52504290e6ffeee33efde8ebaf7a7b623b5014bba304e425",
+				"DiscoKey":   "discokey:048c34a79aa49896a13903eef96e816e4b4e663fd7ca02a21bc2c4b356ab4146",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46826",
+					"10.65.0.27:46826",
+					"172.17.0.1:46826",
+					"172.18.0.1:46826",
+					"172.19.0.1:46826",
+					"172.20.0.1:46826",
+					"172.21.0.1:46826",
+					"172.22.0.1:46826",
+					"172.23.0.1:46826",
+					"172.24.0.1:46826",
+					"172.25.0.1:46826",
+					"172.26.0.1:46826",
+					"172.27.0.1:46826",
+					"172.28.0.1:46826"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:13:49.537845082Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2090937420854518,
+				"StableID":   "nsFXo4PzKH11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fd6ec88dd199fb11999e2d7d422e1414e6d70b7fce1f27b05b5f38d055196670",
+				"DiscoKey":   "discokey:1db436dff3600f11b84dfabc0662c7d4aee6c73367fe018562583e0a5604d344",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:34160",
+					"10.65.0.27:34160",
+					"172.17.0.1:34160",
+					"172.18.0.1:34160",
+					"172.19.0.1:34160",
+					"172.20.0.1:34160",
+					"172.21.0.1:34160",
+					"172.22.0.1:34160",
+					"172.23.0.1:34160",
+					"172.24.0.1:34160",
+					"172.25.0.1:34160",
+					"172.26.0.1:34160",
+					"172.27.0.1:34160",
+					"172.28.0.1:34160"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:13:50.07963397Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         850548047160251,
+				"StableID":   "nxm2NPTDe711CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a84426ee164e9dec6e36d1d4ee19a179cf3d0b1dbad9a7dc0e60a3cdd0524e69",
+				"DiscoKey":   "discokey:90b4b8be3269ab9acbb2b879ca50b01ace17583683a8bbe8827c2554b729e656",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56047",
+					"10.65.0.27:56047",
+					"172.17.0.1:56047",
+					"172.18.0.1:56047",
+					"172.19.0.1:56047",
+					"172.20.0.1:56047",
+					"172.21.0.1:56047",
+					"172.22.0.1:56047",
+					"172.23.0.1:56047",
+					"172.24.0.1:56047",
+					"172.25.0.1:56047",
+					"172.26.0.1:56047",
+					"172.27.0.1:56047",
+					"172.28.0.1:56047"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:13:51.157675554Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         386192675168184,
+				"StableID":   "nTkVFMdu1411CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65590cb7a0a1b156cd97548850712f0b5c133b69282c80783264e2a065fdff0e",
+				"DiscoKey":   "discokey:ca4024426bcbe73444222fb3b3209f6117900f75cf74e5bb9ed8347bf0d65b55",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60971",
+					"10.65.0.27:60971",
+					"172.17.0.1:60971",
+					"172.18.0.1:60971",
+					"172.19.0.1:60971",
+					"172.20.0.1:60971",
+					"172.21.0.1:60971",
+					"172.22.0.1:60971",
+					"172.23.0.1:60971",
+					"172.24.0.1:60971",
+					"172.25.0.1:60971",
+					"172.26.0.1:60971",
+					"172.27.0.1:60971",
+					"172.28.0.1:60971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:13:51.662720535Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4704402975167966,
+				"StableID":   "nd4nSxgdjd11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f1ae1a9f931a41b4aba1300de94df66a2281c2b941d91a32521da4e952bf0651",
+				"DiscoKey":   "discokey:fa05c6c50cc38d0b64d4d60f0844cd3a54e82ea25f982a4e9ef1eaba08163946",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44348",
+					"10.65.0.27:44348",
+					"172.17.0.1:44348",
+					"172.18.0.1:44348",
+					"172.19.0.1:44348",
+					"172.20.0.1:44348",
+					"172.21.0.1:44348",
+					"172.22.0.1:44348",
+					"172.23.0.1:44348",
+					"172.24.0.1:44348",
+					"172.25.0.1:44348",
+					"172.26.0.1:44348",
+					"172.27.0.1:44348",
+					"172.28.0.1:44348"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:13:52.186640841Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1394021246640640,
+				"StableID":   "n3NvxJaMtB11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fb6653ad217217a2c56e9017d38db7ce1331a96fb389a774ab6b31459a3fb27",
+				"DiscoKey":   "discokey:75c30f7c43cafad3e3c423c5f02ce9236bd88881ef05a7aa983a8854fd33d007",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58655",
+					"10.65.0.27:58655",
+					"172.17.0.1:58655",
+					"172.18.0.1:58655",
+					"172.19.0.1:58655",
+					"172.20.0.1:58655",
+					"172.21.0.1:58655",
+					"172.22.0.1:58655",
+					"172.23.0.1:58655",
+					"172.24.0.1:58655",
+					"172.25.0.1:58655",
+					"172.26.0.1:58655",
+					"172.27.0.1:58655",
+					"172.28.0.1:58655"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:13:52.743055689Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7697324779720731,
+				"StableID":   "nanwXqf87321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7f81a6816c056d92f3704369a6fdc539d85d1fdfa41c4ace70942e5139888128",
+				"KeyExpiry":  "2026-11-09T09:13:53Z",
+				"DiscoKey":   "discokey:11c3892b44cfc9dfc564cb22131b80cbe9f67efc1a196ed7d89aa5cbba2b6d69",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43789",
+					"10.65.0.27:43789",
+					"172.17.0.1:43789",
+					"172.18.0.1:43789",
+					"172.19.0.1:43789",
+					"172.20.0.1:43789",
+					"172.21.0.1:43789",
+					"172.22.0.1:43789",
+					"172.23.0.1:43789",
+					"172.24.0.1:43789",
+					"172.25.0.1:43789",
+					"172.26.0.1:43789",
+					"172.27.0.1:43789",
+					"172.28.0.1:43789"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:13:53.276284579Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6802839220756022,
+				"StableID":   "nDUAiw328v11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c608580ec5c8dc961136d45191c29953ac601954fcd3bff2e24bf1f422775c54",
+				"KeyExpiry":  "2026-11-09T09:13:53Z",
+				"DiscoKey":   "discokey:b6e7700deeeeca23395db19fa7c9869a106f94702e24a2145d4ffc49b8766710",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39909",
+					"10.65.0.27:39909",
+					"172.17.0.1:39909",
+					"172.18.0.1:39909",
+					"172.19.0.1:39909",
+					"172.20.0.1:39909",
+					"172.21.0.1:39909",
+					"172.22.0.1:39909",
+					"172.23.0.1:39909",
+					"172.24.0.1:39909",
+					"172.25.0.1:39909",
+					"172.26.0.1:39909",
+					"172.27.0.1:39909",
+					"172.28.0.1:39909"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:13:53.846011491Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5958266231653377,
+				"StableID":   "nnKVmvYWXo11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b632c8a0f0684027efe19c151240b992be582ebb9cb868e39cdd0bc70d6c4859",
+				"KeyExpiry":  "2026-11-09T09:13:54Z",
+				"DiscoKey":   "discokey:f99ec748364ad51f9d7e83f1f08951353651063950f648d7f4a6c98573494c3e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41042",
+					"10.65.0.27:41042",
+					"172.17.0.1:41042",
+					"172.18.0.1:41042",
+					"172.19.0.1:41042",
+					"172.20.0.1:41042",
+					"172.21.0.1:41042",
+					"172.22.0.1:41042",
+					"172.23.0.1:41042",
+					"172.24.0.1:41042",
+					"172.25.0.1:41042",
+					"172.26.0.1:41042",
+					"172.27.0.1:41042",
+					"172.28.0.1:41042"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:13:54.362859818Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8304711186217950": {
+				"ID":          8304711186217950,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7697324779720731,
+				"StableID":   "nanwXqf87321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7f81a6816c056d92f3704369a6fdc539d85d1fdfa41c4ace70942e5139888128",
+				"KeyExpiry":  "2026-11-09T09:13:53Z",
+				"DiscoKey":   "discokey:11c3892b44cfc9dfc564cb22131b80cbe9f67efc1a196ed7d89aa5cbba2b6d69",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43789",
+					"10.65.0.27:43789",
+					"172.17.0.1:43789",
+					"172.18.0.1:43789",
+					"172.19.0.1:43789",
+					"172.20.0.1:43789",
+					"172.21.0.1:43789",
+					"172.22.0.1:43789",
+					"172.23.0.1:43789",
+					"172.24.0.1:43789",
+					"172.25.0.1:43789",
+					"172.26.0.1:43789",
+					"172.27.0.1:43789",
+					"172.28.0.1:43789"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:13:53.276284579Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7f81a6816c056d92f3704369a6fdc539d85d1fdfa41c4ace70942e5139888128",
+			"MachineKey": "mkey:5850c6acf32411a43fca5f311c542dfa14e8d42684b69321491f7e5514b8bf33",
+			"Peers": [{
+				"ID":         1198500343174197,
+				"StableID":   "nnmmFAaoMA11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:240f04f24aa13822252cbc3331eb7282991f64f29b7d9ac2befea60e896ef054",
+				"DiscoKey":   "discokey:ec8422f81c6380d3d6ed4f7fb5533072e378cd12cc5a06a94f667abc8a57c735",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:32935",
+					"10.65.0.27:32935",
+					"172.17.0.1:32935",
+					"172.18.0.1:32935",
+					"172.19.0.1:32935",
+					"172.20.0.1:32935",
+					"172.21.0.1:32935",
+					"172.22.0.1:32935",
+					"172.23.0.1:32935",
+					"172.24.0.1:32935",
+					"172.25.0.1:32935",
+					"172.26.0.1:32935",
+					"172.27.0.1:32935",
+					"172.28.0.1:32935"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:13:46.866938583Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5681187607005970,
+				"StableID":   "nBy3XZA2Nm11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:689e4a53f458215c7fe16a8c184c25724501d72d939e064df8f01398a492bf47",
+				"DiscoKey":   "discokey:2b3c1ce5b6b1d0405e2901e81a6465eef0881f513a2ee2274c701c371de73b6e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:38614",
+					"10.65.0.27:38614",
+					"172.17.0.1:38614",
+					"172.18.0.1:38614",
+					"172.19.0.1:38614",
+					"172.20.0.1:38614",
+					"172.21.0.1:38614",
+					"172.22.0.1:38614",
+					"172.23.0.1:38614",
+					"172.24.0.1:38614",
+					"172.25.0.1:38614",
+					"172.26.0.1:38614",
+					"172.27.0.1:38614",
+					"172.28.0.1:38614"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:13:47.376361337Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         12931462317159,
+				"StableID":   "naWW3tgr6111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b616fb9f37c2d3c5666f8339afed4dcd65336f5d6b4ff82d2da3af6efdacf12",
+				"DiscoKey":   "discokey:bec41e4ae574c1a59263182ed64c39ea7b104fa761ea0374e39f5f814e95af44",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59648",
+					"10.65.0.27:59648",
+					"172.17.0.1:59648",
+					"172.18.0.1:59648",
+					"172.19.0.1:59648",
+					"172.20.0.1:59648",
+					"172.21.0.1:59648",
+					"172.22.0.1:59648",
+					"172.23.0.1:59648",
+					"172.24.0.1:59648",
+					"172.25.0.1:59648",
+					"172.26.0.1:59648",
+					"172.27.0.1:59648",
+					"172.28.0.1:59648"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:13:47.91854552Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7962419053186660,
+				"StableID":   "nwQ1iJFCB521CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1919b336c3693103d358715b27cab626f647d1a16d164cf5d49aedd2ef924f73",
+				"DiscoKey":   "discokey:73f5523af2c0b1d4dd5c5014d41ae7df45fa1a7ee02057a69150b72725eb024f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53407",
+					"10.65.0.27:53407",
+					"172.17.0.1:53407",
+					"172.18.0.1:53407",
+					"172.19.0.1:53407",
+					"172.20.0.1:53407",
+					"172.21.0.1:53407",
+					"172.22.0.1:53407",
+					"172.23.0.1:53407",
+					"172.24.0.1:53407",
+					"172.25.0.1:53407",
+					"172.26.0.1:53407",
+					"172.27.0.1:53407",
+					"172.28.0.1:53407"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:13:48.443469076Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6044746052499738,
+				"StableID":   "nZE9QGEgCp11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22b70227ae88b9fda9788c3772c332407cdb89148f91c10176ca8b8903ff1363",
+				"DiscoKey":   "discokey:0fe71482954ba2363754e028708fb46b481ff00096be262ea4f006ca7ad8e916",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52558",
+					"10.65.0.27:52558",
+					"172.17.0.1:52558",
+					"172.18.0.1:52558",
+					"172.19.0.1:52558",
+					"172.20.0.1:52558",
+					"172.21.0.1:52558",
+					"172.22.0.1:52558",
+					"172.23.0.1:52558",
+					"172.24.0.1:52558",
+					"172.25.0.1:52558",
+					"172.26.0.1:52558",
+					"172.27.0.1:52558",
+					"172.28.0.1:52558"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:13:48.99964013Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5433078469590070,
+				"StableID":   "nBmxezkeRj11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8374fb267d55809e52504290e6ffeee33efde8ebaf7a7b623b5014bba304e425",
+				"DiscoKey":   "discokey:048c34a79aa49896a13903eef96e816e4b4e663fd7ca02a21bc2c4b356ab4146",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46826",
+					"10.65.0.27:46826",
+					"172.17.0.1:46826",
+					"172.18.0.1:46826",
+					"172.19.0.1:46826",
+					"172.20.0.1:46826",
+					"172.21.0.1:46826",
+					"172.22.0.1:46826",
+					"172.23.0.1:46826",
+					"172.24.0.1:46826",
+					"172.25.0.1:46826",
+					"172.26.0.1:46826",
+					"172.27.0.1:46826",
+					"172.28.0.1:46826"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:13:49.537845082Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2090937420854518,
+				"StableID":   "nsFXo4PzKH11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fd6ec88dd199fb11999e2d7d422e1414e6d70b7fce1f27b05b5f38d055196670",
+				"DiscoKey":   "discokey:1db436dff3600f11b84dfabc0662c7d4aee6c73367fe018562583e0a5604d344",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:34160",
+					"10.65.0.27:34160",
+					"172.17.0.1:34160",
+					"172.18.0.1:34160",
+					"172.19.0.1:34160",
+					"172.20.0.1:34160",
+					"172.21.0.1:34160",
+					"172.22.0.1:34160",
+					"172.23.0.1:34160",
+					"172.24.0.1:34160",
+					"172.25.0.1:34160",
+					"172.26.0.1:34160",
+					"172.27.0.1:34160",
+					"172.28.0.1:34160"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:13:50.07963397Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8304711186217950,
+				"StableID":   "nRnxNUgDr721CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d49968ed4b6e801f8bcfd75d2970d5e8d0b027b6cfc0b8c2c45c01e6df263151",
+				"DiscoKey":   "discokey:aea7b0e953bfef0d6a6c0814d25e731c9963eadb70924378da868b42a43e0400",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58025",
+					"10.65.0.27:58025",
+					"172.17.0.1:58025",
+					"172.18.0.1:58025",
+					"172.19.0.1:58025",
+					"172.20.0.1:58025",
+					"172.21.0.1:58025",
+					"172.22.0.1:58025",
+					"172.23.0.1:58025",
+					"172.24.0.1:58025",
+					"172.25.0.1:58025",
+					"172.26.0.1:58025",
+					"172.27.0.1:58025",
+					"172.28.0.1:58025"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:13:50.615674201Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         850548047160251,
+				"StableID":   "nxm2NPTDe711CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a84426ee164e9dec6e36d1d4ee19a179cf3d0b1dbad9a7dc0e60a3cdd0524e69",
+				"DiscoKey":   "discokey:90b4b8be3269ab9acbb2b879ca50b01ace17583683a8bbe8827c2554b729e656",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56047",
+					"10.65.0.27:56047",
+					"172.17.0.1:56047",
+					"172.18.0.1:56047",
+					"172.19.0.1:56047",
+					"172.20.0.1:56047",
+					"172.21.0.1:56047",
+					"172.22.0.1:56047",
+					"172.23.0.1:56047",
+					"172.24.0.1:56047",
+					"172.25.0.1:56047",
+					"172.26.0.1:56047",
+					"172.27.0.1:56047",
+					"172.28.0.1:56047"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:13:51.157675554Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         386192675168184,
+				"StableID":   "nTkVFMdu1411CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65590cb7a0a1b156cd97548850712f0b5c133b69282c80783264e2a065fdff0e",
+				"DiscoKey":   "discokey:ca4024426bcbe73444222fb3b3209f6117900f75cf74e5bb9ed8347bf0d65b55",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60971",
+					"10.65.0.27:60971",
+					"172.17.0.1:60971",
+					"172.18.0.1:60971",
+					"172.19.0.1:60971",
+					"172.20.0.1:60971",
+					"172.21.0.1:60971",
+					"172.22.0.1:60971",
+					"172.23.0.1:60971",
+					"172.24.0.1:60971",
+					"172.25.0.1:60971",
+					"172.26.0.1:60971",
+					"172.27.0.1:60971",
+					"172.28.0.1:60971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:13:51.662720535Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4704402975167966,
+				"StableID":   "nd4nSxgdjd11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f1ae1a9f931a41b4aba1300de94df66a2281c2b941d91a32521da4e952bf0651",
+				"DiscoKey":   "discokey:fa05c6c50cc38d0b64d4d60f0844cd3a54e82ea25f982a4e9ef1eaba08163946",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44348",
+					"10.65.0.27:44348",
+					"172.17.0.1:44348",
+					"172.18.0.1:44348",
+					"172.19.0.1:44348",
+					"172.20.0.1:44348",
+					"172.21.0.1:44348",
+					"172.22.0.1:44348",
+					"172.23.0.1:44348",
+					"172.24.0.1:44348",
+					"172.25.0.1:44348",
+					"172.26.0.1:44348",
+					"172.27.0.1:44348",
+					"172.28.0.1:44348"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:13:52.186640841Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1394021246640640,
+				"StableID":   "n3NvxJaMtB11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fb6653ad217217a2c56e9017d38db7ce1331a96fb389a774ab6b31459a3fb27",
+				"DiscoKey":   "discokey:75c30f7c43cafad3e3c423c5f02ce9236bd88881ef05a7aa983a8854fd33d007",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58655",
+					"10.65.0.27:58655",
+					"172.17.0.1:58655",
+					"172.18.0.1:58655",
+					"172.19.0.1:58655",
+					"172.20.0.1:58655",
+					"172.21.0.1:58655",
+					"172.22.0.1:58655",
+					"172.23.0.1:58655",
+					"172.24.0.1:58655",
+					"172.25.0.1:58655",
+					"172.26.0.1:58655",
+					"172.27.0.1:58655",
+					"172.28.0.1:58655"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:13:52.743055689Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6802839220756022,
+				"StableID":   "nDUAiw328v11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c608580ec5c8dc961136d45191c29953ac601954fcd3bff2e24bf1f422775c54",
+				"KeyExpiry":  "2026-11-09T09:13:53Z",
+				"DiscoKey":   "discokey:b6e7700deeeeca23395db19fa7c9869a106f94702e24a2145d4ffc49b8766710",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39909",
+					"10.65.0.27:39909",
+					"172.17.0.1:39909",
+					"172.18.0.1:39909",
+					"172.19.0.1:39909",
+					"172.20.0.1:39909",
+					"172.21.0.1:39909",
+					"172.22.0.1:39909",
+					"172.23.0.1:39909",
+					"172.24.0.1:39909",
+					"172.25.0.1:39909",
+					"172.26.0.1:39909",
+					"172.27.0.1:39909",
+					"172.28.0.1:39909"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:13:53.846011491Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5958266231653377,
+				"StableID":   "nnKVmvYWXo11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b632c8a0f0684027efe19c151240b992be582ebb9cb868e39cdd0bc70d6c4859",
+				"KeyExpiry":  "2026-11-09T09:13:54Z",
+				"DiscoKey":   "discokey:f99ec748364ad51f9d7e83f1f08951353651063950f648d7f4a6c98573494c3e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41042",
+					"10.65.0.27:41042",
+					"172.17.0.1:41042",
+					"172.18.0.1:41042",
+					"172.19.0.1:41042",
+					"172.20.0.1:41042",
+					"172.21.0.1:41042",
+					"172.22.0.1:41042",
+					"172.23.0.1:41042",
+					"172.24.0.1:41042",
+					"172.25.0.1:41042",
+					"172.26.0.1:41042",
+					"172.27.0.1:41042",
+					"172.28.0.1:41042"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:13:54.362859818Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4704402975167966,
+				"StableID":   "nd4nSxgdjd11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       4704402975167966,
+				"Key":        "nodekey:f1ae1a9f931a41b4aba1300de94df66a2281c2b941d91a32521da4e952bf0651",
+				"DiscoKey":   "discokey:fa05c6c50cc38d0b64d4d60f0844cd3a54e82ea25f982a4e9ef1eaba08163946",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44348",
+					"10.65.0.27:44348",
+					"172.17.0.1:44348",
+					"172.18.0.1:44348",
+					"172.19.0.1:44348",
+					"172.20.0.1:44348",
+					"172.21.0.1:44348",
+					"172.22.0.1:44348",
+					"172.23.0.1:44348",
+					"172.24.0.1:44348",
+					"172.25.0.1:44348",
+					"172.26.0.1:44348",
+					"172.27.0.1:44348",
+					"172.28.0.1:44348"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:13:52.186640841Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f1ae1a9f931a41b4aba1300de94df66a2281c2b941d91a32521da4e952bf0651",
+			"MachineKey": "mkey:4adb89a4baa68cad9f0af1c654b079d6aff8d837f6a401450afc40e31b687a16",
+			"Peers": [{
+				"ID":         1198500343174197,
+				"StableID":   "nnmmFAaoMA11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:240f04f24aa13822252cbc3331eb7282991f64f29b7d9ac2befea60e896ef054",
+				"DiscoKey":   "discokey:ec8422f81c6380d3d6ed4f7fb5533072e378cd12cc5a06a94f667abc8a57c735",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:32935",
+					"10.65.0.27:32935",
+					"172.17.0.1:32935",
+					"172.18.0.1:32935",
+					"172.19.0.1:32935",
+					"172.20.0.1:32935",
+					"172.21.0.1:32935",
+					"172.22.0.1:32935",
+					"172.23.0.1:32935",
+					"172.24.0.1:32935",
+					"172.25.0.1:32935",
+					"172.26.0.1:32935",
+					"172.27.0.1:32935",
+					"172.28.0.1:32935"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:13:46.866938583Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5681187607005970,
+				"StableID":   "nBy3XZA2Nm11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:689e4a53f458215c7fe16a8c184c25724501d72d939e064df8f01398a492bf47",
+				"DiscoKey":   "discokey:2b3c1ce5b6b1d0405e2901e81a6465eef0881f513a2ee2274c701c371de73b6e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:38614",
+					"10.65.0.27:38614",
+					"172.17.0.1:38614",
+					"172.18.0.1:38614",
+					"172.19.0.1:38614",
+					"172.20.0.1:38614",
+					"172.21.0.1:38614",
+					"172.22.0.1:38614",
+					"172.23.0.1:38614",
+					"172.24.0.1:38614",
+					"172.25.0.1:38614",
+					"172.26.0.1:38614",
+					"172.27.0.1:38614",
+					"172.28.0.1:38614"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:13:47.376361337Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         12931462317159,
+				"StableID":   "naWW3tgr6111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b616fb9f37c2d3c5666f8339afed4dcd65336f5d6b4ff82d2da3af6efdacf12",
+				"DiscoKey":   "discokey:bec41e4ae574c1a59263182ed64c39ea7b104fa761ea0374e39f5f814e95af44",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59648",
+					"10.65.0.27:59648",
+					"172.17.0.1:59648",
+					"172.18.0.1:59648",
+					"172.19.0.1:59648",
+					"172.20.0.1:59648",
+					"172.21.0.1:59648",
+					"172.22.0.1:59648",
+					"172.23.0.1:59648",
+					"172.24.0.1:59648",
+					"172.25.0.1:59648",
+					"172.26.0.1:59648",
+					"172.27.0.1:59648",
+					"172.28.0.1:59648"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:13:47.91854552Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7962419053186660,
+				"StableID":   "nwQ1iJFCB521CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1919b336c3693103d358715b27cab626f647d1a16d164cf5d49aedd2ef924f73",
+				"DiscoKey":   "discokey:73f5523af2c0b1d4dd5c5014d41ae7df45fa1a7ee02057a69150b72725eb024f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53407",
+					"10.65.0.27:53407",
+					"172.17.0.1:53407",
+					"172.18.0.1:53407",
+					"172.19.0.1:53407",
+					"172.20.0.1:53407",
+					"172.21.0.1:53407",
+					"172.22.0.1:53407",
+					"172.23.0.1:53407",
+					"172.24.0.1:53407",
+					"172.25.0.1:53407",
+					"172.26.0.1:53407",
+					"172.27.0.1:53407",
+					"172.28.0.1:53407"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:13:48.443469076Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6044746052499738,
+				"StableID":   "nZE9QGEgCp11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22b70227ae88b9fda9788c3772c332407cdb89148f91c10176ca8b8903ff1363",
+				"DiscoKey":   "discokey:0fe71482954ba2363754e028708fb46b481ff00096be262ea4f006ca7ad8e916",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52558",
+					"10.65.0.27:52558",
+					"172.17.0.1:52558",
+					"172.18.0.1:52558",
+					"172.19.0.1:52558",
+					"172.20.0.1:52558",
+					"172.21.0.1:52558",
+					"172.22.0.1:52558",
+					"172.23.0.1:52558",
+					"172.24.0.1:52558",
+					"172.25.0.1:52558",
+					"172.26.0.1:52558",
+					"172.27.0.1:52558",
+					"172.28.0.1:52558"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:13:48.99964013Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5433078469590070,
+				"StableID":   "nBmxezkeRj11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8374fb267d55809e52504290e6ffeee33efde8ebaf7a7b623b5014bba304e425",
+				"DiscoKey":   "discokey:048c34a79aa49896a13903eef96e816e4b4e663fd7ca02a21bc2c4b356ab4146",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46826",
+					"10.65.0.27:46826",
+					"172.17.0.1:46826",
+					"172.18.0.1:46826",
+					"172.19.0.1:46826",
+					"172.20.0.1:46826",
+					"172.21.0.1:46826",
+					"172.22.0.1:46826",
+					"172.23.0.1:46826",
+					"172.24.0.1:46826",
+					"172.25.0.1:46826",
+					"172.26.0.1:46826",
+					"172.27.0.1:46826",
+					"172.28.0.1:46826"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:13:49.537845082Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2090937420854518,
+				"StableID":   "nsFXo4PzKH11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fd6ec88dd199fb11999e2d7d422e1414e6d70b7fce1f27b05b5f38d055196670",
+				"DiscoKey":   "discokey:1db436dff3600f11b84dfabc0662c7d4aee6c73367fe018562583e0a5604d344",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:34160",
+					"10.65.0.27:34160",
+					"172.17.0.1:34160",
+					"172.18.0.1:34160",
+					"172.19.0.1:34160",
+					"172.20.0.1:34160",
+					"172.21.0.1:34160",
+					"172.22.0.1:34160",
+					"172.23.0.1:34160",
+					"172.24.0.1:34160",
+					"172.25.0.1:34160",
+					"172.26.0.1:34160",
+					"172.27.0.1:34160",
+					"172.28.0.1:34160"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:13:50.07963397Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8304711186217950,
+				"StableID":   "nRnxNUgDr721CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d49968ed4b6e801f8bcfd75d2970d5e8d0b027b6cfc0b8c2c45c01e6df263151",
+				"DiscoKey":   "discokey:aea7b0e953bfef0d6a6c0814d25e731c9963eadb70924378da868b42a43e0400",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58025",
+					"10.65.0.27:58025",
+					"172.17.0.1:58025",
+					"172.18.0.1:58025",
+					"172.19.0.1:58025",
+					"172.20.0.1:58025",
+					"172.21.0.1:58025",
+					"172.22.0.1:58025",
+					"172.23.0.1:58025",
+					"172.24.0.1:58025",
+					"172.25.0.1:58025",
+					"172.26.0.1:58025",
+					"172.27.0.1:58025",
+					"172.28.0.1:58025"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:13:50.615674201Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         850548047160251,
+				"StableID":   "nxm2NPTDe711CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a84426ee164e9dec6e36d1d4ee19a179cf3d0b1dbad9a7dc0e60a3cdd0524e69",
+				"DiscoKey":   "discokey:90b4b8be3269ab9acbb2b879ca50b01ace17583683a8bbe8827c2554b729e656",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56047",
+					"10.65.0.27:56047",
+					"172.17.0.1:56047",
+					"172.18.0.1:56047",
+					"172.19.0.1:56047",
+					"172.20.0.1:56047",
+					"172.21.0.1:56047",
+					"172.22.0.1:56047",
+					"172.23.0.1:56047",
+					"172.24.0.1:56047",
+					"172.25.0.1:56047",
+					"172.26.0.1:56047",
+					"172.27.0.1:56047",
+					"172.28.0.1:56047"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:13:51.157675554Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         386192675168184,
+				"StableID":   "nTkVFMdu1411CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65590cb7a0a1b156cd97548850712f0b5c133b69282c80783264e2a065fdff0e",
+				"DiscoKey":   "discokey:ca4024426bcbe73444222fb3b3209f6117900f75cf74e5bb9ed8347bf0d65b55",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60971",
+					"10.65.0.27:60971",
+					"172.17.0.1:60971",
+					"172.18.0.1:60971",
+					"172.19.0.1:60971",
+					"172.20.0.1:60971",
+					"172.21.0.1:60971",
+					"172.22.0.1:60971",
+					"172.23.0.1:60971",
+					"172.24.0.1:60971",
+					"172.25.0.1:60971",
+					"172.26.0.1:60971",
+					"172.27.0.1:60971",
+					"172.28.0.1:60971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:13:51.662720535Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1394021246640640,
+				"StableID":   "n3NvxJaMtB11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fb6653ad217217a2c56e9017d38db7ce1331a96fb389a774ab6b31459a3fb27",
+				"DiscoKey":   "discokey:75c30f7c43cafad3e3c423c5f02ce9236bd88881ef05a7aa983a8854fd33d007",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58655",
+					"10.65.0.27:58655",
+					"172.17.0.1:58655",
+					"172.18.0.1:58655",
+					"172.19.0.1:58655",
+					"172.20.0.1:58655",
+					"172.21.0.1:58655",
+					"172.22.0.1:58655",
+					"172.23.0.1:58655",
+					"172.24.0.1:58655",
+					"172.25.0.1:58655",
+					"172.26.0.1:58655",
+					"172.27.0.1:58655",
+					"172.28.0.1:58655"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:13:52.743055689Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7697324779720731,
+				"StableID":   "nanwXqf87321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7f81a6816c056d92f3704369a6fdc539d85d1fdfa41c4ace70942e5139888128",
+				"KeyExpiry":  "2026-11-09T09:13:53Z",
+				"DiscoKey":   "discokey:11c3892b44cfc9dfc564cb22131b80cbe9f67efc1a196ed7d89aa5cbba2b6d69",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43789",
+					"10.65.0.27:43789",
+					"172.17.0.1:43789",
+					"172.18.0.1:43789",
+					"172.19.0.1:43789",
+					"172.20.0.1:43789",
+					"172.21.0.1:43789",
+					"172.22.0.1:43789",
+					"172.23.0.1:43789",
+					"172.24.0.1:43789",
+					"172.25.0.1:43789",
+					"172.26.0.1:43789",
+					"172.27.0.1:43789",
+					"172.28.0.1:43789"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:13:53.276284579Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6802839220756022,
+				"StableID":   "nDUAiw328v11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c608580ec5c8dc961136d45191c29953ac601954fcd3bff2e24bf1f422775c54",
+				"KeyExpiry":  "2026-11-09T09:13:53Z",
+				"DiscoKey":   "discokey:b6e7700deeeeca23395db19fa7c9869a106f94702e24a2145d4ffc49b8766710",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39909",
+					"10.65.0.27:39909",
+					"172.17.0.1:39909",
+					"172.18.0.1:39909",
+					"172.19.0.1:39909",
+					"172.20.0.1:39909",
+					"172.21.0.1:39909",
+					"172.22.0.1:39909",
+					"172.23.0.1:39909",
+					"172.24.0.1:39909",
+					"172.25.0.1:39909",
+					"172.26.0.1:39909",
+					"172.27.0.1:39909",
+					"172.28.0.1:39909"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:13:53.846011491Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5958266231653377,
+				"StableID":   "nnKVmvYWXo11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b632c8a0f0684027efe19c151240b992be582ebb9cb868e39cdd0bc70d6c4859",
+				"KeyExpiry":  "2026-11-09T09:13:54Z",
+				"DiscoKey":   "discokey:f99ec748364ad51f9d7e83f1f08951353651063950f648d7f4a6c98573494c3e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41042",
+					"10.65.0.27:41042",
+					"172.17.0.1:41042",
+					"172.18.0.1:41042",
+					"172.19.0.1:41042",
+					"172.20.0.1:41042",
+					"172.21.0.1:41042",
+					"172.22.0.1:41042",
+					"172.23.0.1:41042",
+					"172.24.0.1:41042",
+					"172.25.0.1:41042",
+					"172.26.0.1:41042",
+					"172.27.0.1:41042",
+					"172.28.0.1:41042"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:13:54.362859818Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4704402975167966": {
+				"ID":          4704402975167966,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5681187607005970,
+				"StableID":   "nBy3XZA2Nm11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       5681187607005970,
+				"Key":        "nodekey:689e4a53f458215c7fe16a8c184c25724501d72d939e064df8f01398a492bf47",
+				"DiscoKey":   "discokey:2b3c1ce5b6b1d0405e2901e81a6465eef0881f513a2ee2274c701c371de73b6e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:38614",
+					"10.65.0.27:38614",
+					"172.17.0.1:38614",
+					"172.18.0.1:38614",
+					"172.19.0.1:38614",
+					"172.20.0.1:38614",
+					"172.21.0.1:38614",
+					"172.22.0.1:38614",
+					"172.23.0.1:38614",
+					"172.24.0.1:38614",
+					"172.25.0.1:38614",
+					"172.26.0.1:38614",
+					"172.27.0.1:38614",
+					"172.28.0.1:38614"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:13:47.376361337Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:689e4a53f458215c7fe16a8c184c25724501d72d939e064df8f01398a492bf47",
+			"MachineKey": "mkey:0132aa51e44015ea00d5cad904234f4a9c755b71123e3a0bb19ab5e259f72b14",
+			"Peers": [{
+				"ID":         1198500343174197,
+				"StableID":   "nnmmFAaoMA11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:240f04f24aa13822252cbc3331eb7282991f64f29b7d9ac2befea60e896ef054",
+				"DiscoKey":   "discokey:ec8422f81c6380d3d6ed4f7fb5533072e378cd12cc5a06a94f667abc8a57c735",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:32935",
+					"10.65.0.27:32935",
+					"172.17.0.1:32935",
+					"172.18.0.1:32935",
+					"172.19.0.1:32935",
+					"172.20.0.1:32935",
+					"172.21.0.1:32935",
+					"172.22.0.1:32935",
+					"172.23.0.1:32935",
+					"172.24.0.1:32935",
+					"172.25.0.1:32935",
+					"172.26.0.1:32935",
+					"172.27.0.1:32935",
+					"172.28.0.1:32935"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:13:46.866938583Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         12931462317159,
+				"StableID":   "naWW3tgr6111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b616fb9f37c2d3c5666f8339afed4dcd65336f5d6b4ff82d2da3af6efdacf12",
+				"DiscoKey":   "discokey:bec41e4ae574c1a59263182ed64c39ea7b104fa761ea0374e39f5f814e95af44",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59648",
+					"10.65.0.27:59648",
+					"172.17.0.1:59648",
+					"172.18.0.1:59648",
+					"172.19.0.1:59648",
+					"172.20.0.1:59648",
+					"172.21.0.1:59648",
+					"172.22.0.1:59648",
+					"172.23.0.1:59648",
+					"172.24.0.1:59648",
+					"172.25.0.1:59648",
+					"172.26.0.1:59648",
+					"172.27.0.1:59648",
+					"172.28.0.1:59648"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:13:47.91854552Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7962419053186660,
+				"StableID":   "nwQ1iJFCB521CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1919b336c3693103d358715b27cab626f647d1a16d164cf5d49aedd2ef924f73",
+				"DiscoKey":   "discokey:73f5523af2c0b1d4dd5c5014d41ae7df45fa1a7ee02057a69150b72725eb024f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53407",
+					"10.65.0.27:53407",
+					"172.17.0.1:53407",
+					"172.18.0.1:53407",
+					"172.19.0.1:53407",
+					"172.20.0.1:53407",
+					"172.21.0.1:53407",
+					"172.22.0.1:53407",
+					"172.23.0.1:53407",
+					"172.24.0.1:53407",
+					"172.25.0.1:53407",
+					"172.26.0.1:53407",
+					"172.27.0.1:53407",
+					"172.28.0.1:53407"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:13:48.443469076Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6044746052499738,
+				"StableID":   "nZE9QGEgCp11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22b70227ae88b9fda9788c3772c332407cdb89148f91c10176ca8b8903ff1363",
+				"DiscoKey":   "discokey:0fe71482954ba2363754e028708fb46b481ff00096be262ea4f006ca7ad8e916",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52558",
+					"10.65.0.27:52558",
+					"172.17.0.1:52558",
+					"172.18.0.1:52558",
+					"172.19.0.1:52558",
+					"172.20.0.1:52558",
+					"172.21.0.1:52558",
+					"172.22.0.1:52558",
+					"172.23.0.1:52558",
+					"172.24.0.1:52558",
+					"172.25.0.1:52558",
+					"172.26.0.1:52558",
+					"172.27.0.1:52558",
+					"172.28.0.1:52558"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:13:48.99964013Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5433078469590070,
+				"StableID":   "nBmxezkeRj11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8374fb267d55809e52504290e6ffeee33efde8ebaf7a7b623b5014bba304e425",
+				"DiscoKey":   "discokey:048c34a79aa49896a13903eef96e816e4b4e663fd7ca02a21bc2c4b356ab4146",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46826",
+					"10.65.0.27:46826",
+					"172.17.0.1:46826",
+					"172.18.0.1:46826",
+					"172.19.0.1:46826",
+					"172.20.0.1:46826",
+					"172.21.0.1:46826",
+					"172.22.0.1:46826",
+					"172.23.0.1:46826",
+					"172.24.0.1:46826",
+					"172.25.0.1:46826",
+					"172.26.0.1:46826",
+					"172.27.0.1:46826",
+					"172.28.0.1:46826"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:13:49.537845082Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2090937420854518,
+				"StableID":   "nsFXo4PzKH11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fd6ec88dd199fb11999e2d7d422e1414e6d70b7fce1f27b05b5f38d055196670",
+				"DiscoKey":   "discokey:1db436dff3600f11b84dfabc0662c7d4aee6c73367fe018562583e0a5604d344",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:34160",
+					"10.65.0.27:34160",
+					"172.17.0.1:34160",
+					"172.18.0.1:34160",
+					"172.19.0.1:34160",
+					"172.20.0.1:34160",
+					"172.21.0.1:34160",
+					"172.22.0.1:34160",
+					"172.23.0.1:34160",
+					"172.24.0.1:34160",
+					"172.25.0.1:34160",
+					"172.26.0.1:34160",
+					"172.27.0.1:34160",
+					"172.28.0.1:34160"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:13:50.07963397Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8304711186217950,
+				"StableID":   "nRnxNUgDr721CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d49968ed4b6e801f8bcfd75d2970d5e8d0b027b6cfc0b8c2c45c01e6df263151",
+				"DiscoKey":   "discokey:aea7b0e953bfef0d6a6c0814d25e731c9963eadb70924378da868b42a43e0400",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58025",
+					"10.65.0.27:58025",
+					"172.17.0.1:58025",
+					"172.18.0.1:58025",
+					"172.19.0.1:58025",
+					"172.20.0.1:58025",
+					"172.21.0.1:58025",
+					"172.22.0.1:58025",
+					"172.23.0.1:58025",
+					"172.24.0.1:58025",
+					"172.25.0.1:58025",
+					"172.26.0.1:58025",
+					"172.27.0.1:58025",
+					"172.28.0.1:58025"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:13:50.615674201Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         850548047160251,
+				"StableID":   "nxm2NPTDe711CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a84426ee164e9dec6e36d1d4ee19a179cf3d0b1dbad9a7dc0e60a3cdd0524e69",
+				"DiscoKey":   "discokey:90b4b8be3269ab9acbb2b879ca50b01ace17583683a8bbe8827c2554b729e656",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56047",
+					"10.65.0.27:56047",
+					"172.17.0.1:56047",
+					"172.18.0.1:56047",
+					"172.19.0.1:56047",
+					"172.20.0.1:56047",
+					"172.21.0.1:56047",
+					"172.22.0.1:56047",
+					"172.23.0.1:56047",
+					"172.24.0.1:56047",
+					"172.25.0.1:56047",
+					"172.26.0.1:56047",
+					"172.27.0.1:56047",
+					"172.28.0.1:56047"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:13:51.157675554Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         386192675168184,
+				"StableID":   "nTkVFMdu1411CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65590cb7a0a1b156cd97548850712f0b5c133b69282c80783264e2a065fdff0e",
+				"DiscoKey":   "discokey:ca4024426bcbe73444222fb3b3209f6117900f75cf74e5bb9ed8347bf0d65b55",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60971",
+					"10.65.0.27:60971",
+					"172.17.0.1:60971",
+					"172.18.0.1:60971",
+					"172.19.0.1:60971",
+					"172.20.0.1:60971",
+					"172.21.0.1:60971",
+					"172.22.0.1:60971",
+					"172.23.0.1:60971",
+					"172.24.0.1:60971",
+					"172.25.0.1:60971",
+					"172.26.0.1:60971",
+					"172.27.0.1:60971",
+					"172.28.0.1:60971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:13:51.662720535Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4704402975167966,
+				"StableID":   "nd4nSxgdjd11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f1ae1a9f931a41b4aba1300de94df66a2281c2b941d91a32521da4e952bf0651",
+				"DiscoKey":   "discokey:fa05c6c50cc38d0b64d4d60f0844cd3a54e82ea25f982a4e9ef1eaba08163946",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44348",
+					"10.65.0.27:44348",
+					"172.17.0.1:44348",
+					"172.18.0.1:44348",
+					"172.19.0.1:44348",
+					"172.20.0.1:44348",
+					"172.21.0.1:44348",
+					"172.22.0.1:44348",
+					"172.23.0.1:44348",
+					"172.24.0.1:44348",
+					"172.25.0.1:44348",
+					"172.26.0.1:44348",
+					"172.27.0.1:44348",
+					"172.28.0.1:44348"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:13:52.186640841Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1394021246640640,
+				"StableID":   "n3NvxJaMtB11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fb6653ad217217a2c56e9017d38db7ce1331a96fb389a774ab6b31459a3fb27",
+				"DiscoKey":   "discokey:75c30f7c43cafad3e3c423c5f02ce9236bd88881ef05a7aa983a8854fd33d007",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58655",
+					"10.65.0.27:58655",
+					"172.17.0.1:58655",
+					"172.18.0.1:58655",
+					"172.19.0.1:58655",
+					"172.20.0.1:58655",
+					"172.21.0.1:58655",
+					"172.22.0.1:58655",
+					"172.23.0.1:58655",
+					"172.24.0.1:58655",
+					"172.25.0.1:58655",
+					"172.26.0.1:58655",
+					"172.27.0.1:58655",
+					"172.28.0.1:58655"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:13:52.743055689Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7697324779720731,
+				"StableID":   "nanwXqf87321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7f81a6816c056d92f3704369a6fdc539d85d1fdfa41c4ace70942e5139888128",
+				"KeyExpiry":  "2026-11-09T09:13:53Z",
+				"DiscoKey":   "discokey:11c3892b44cfc9dfc564cb22131b80cbe9f67efc1a196ed7d89aa5cbba2b6d69",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43789",
+					"10.65.0.27:43789",
+					"172.17.0.1:43789",
+					"172.18.0.1:43789",
+					"172.19.0.1:43789",
+					"172.20.0.1:43789",
+					"172.21.0.1:43789",
+					"172.22.0.1:43789",
+					"172.23.0.1:43789",
+					"172.24.0.1:43789",
+					"172.25.0.1:43789",
+					"172.26.0.1:43789",
+					"172.27.0.1:43789",
+					"172.28.0.1:43789"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:13:53.276284579Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6802839220756022,
+				"StableID":   "nDUAiw328v11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c608580ec5c8dc961136d45191c29953ac601954fcd3bff2e24bf1f422775c54",
+				"KeyExpiry":  "2026-11-09T09:13:53Z",
+				"DiscoKey":   "discokey:b6e7700deeeeca23395db19fa7c9869a106f94702e24a2145d4ffc49b8766710",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39909",
+					"10.65.0.27:39909",
+					"172.17.0.1:39909",
+					"172.18.0.1:39909",
+					"172.19.0.1:39909",
+					"172.20.0.1:39909",
+					"172.21.0.1:39909",
+					"172.22.0.1:39909",
+					"172.23.0.1:39909",
+					"172.24.0.1:39909",
+					"172.25.0.1:39909",
+					"172.26.0.1:39909",
+					"172.27.0.1:39909",
+					"172.28.0.1:39909"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:13:53.846011491Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5958266231653377,
+				"StableID":   "nnKVmvYWXo11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b632c8a0f0684027efe19c151240b992be582ebb9cb868e39cdd0bc70d6c4859",
+				"KeyExpiry":  "2026-11-09T09:13:54Z",
+				"DiscoKey":   "discokey:f99ec748364ad51f9d7e83f1f08951353651063950f648d7f4a6c98573494c3e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41042",
+					"10.65.0.27:41042",
+					"172.17.0.1:41042",
+					"172.18.0.1:41042",
+					"172.19.0.1:41042",
+					"172.20.0.1:41042",
+					"172.21.0.1:41042",
+					"172.22.0.1:41042",
+					"172.23.0.1:41042",
+					"172.24.0.1:41042",
+					"172.25.0.1:41042",
+					"172.26.0.1:41042",
+					"172.27.0.1:41042",
+					"172.28.0.1:41042"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:13:54.362859818Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5681187607005970": {
+				"ID":          5681187607005970,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1198500343174197,
+				"StableID":   "nnmmFAaoMA11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1198500343174197,
+				"Key":        "nodekey:240f04f24aa13822252cbc3331eb7282991f64f29b7d9ac2befea60e896ef054",
+				"DiscoKey":   "discokey:ec8422f81c6380d3d6ed4f7fb5533072e378cd12cc5a06a94f667abc8a57c735",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:32935",
+					"10.65.0.27:32935",
+					"172.17.0.1:32935",
+					"172.18.0.1:32935",
+					"172.19.0.1:32935",
+					"172.20.0.1:32935",
+					"172.21.0.1:32935",
+					"172.22.0.1:32935",
+					"172.23.0.1:32935",
+					"172.24.0.1:32935",
+					"172.25.0.1:32935",
+					"172.26.0.1:32935",
+					"172.27.0.1:32935",
+					"172.28.0.1:32935"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:13:46.866938583Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:240f04f24aa13822252cbc3331eb7282991f64f29b7d9ac2befea60e896ef054",
+			"MachineKey": "mkey:cd91325d8a7c9b5a5e1e0c05bf5154b634006b565921dfdb336d6ff2b112264d",
+			"Peers": [{
+				"ID":         5681187607005970,
+				"StableID":   "nBy3XZA2Nm11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:689e4a53f458215c7fe16a8c184c25724501d72d939e064df8f01398a492bf47",
+				"DiscoKey":   "discokey:2b3c1ce5b6b1d0405e2901e81a6465eef0881f513a2ee2274c701c371de73b6e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:38614",
+					"10.65.0.27:38614",
+					"172.17.0.1:38614",
+					"172.18.0.1:38614",
+					"172.19.0.1:38614",
+					"172.20.0.1:38614",
+					"172.21.0.1:38614",
+					"172.22.0.1:38614",
+					"172.23.0.1:38614",
+					"172.24.0.1:38614",
+					"172.25.0.1:38614",
+					"172.26.0.1:38614",
+					"172.27.0.1:38614",
+					"172.28.0.1:38614"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:13:47.376361337Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         12931462317159,
+				"StableID":   "naWW3tgr6111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b616fb9f37c2d3c5666f8339afed4dcd65336f5d6b4ff82d2da3af6efdacf12",
+				"DiscoKey":   "discokey:bec41e4ae574c1a59263182ed64c39ea7b104fa761ea0374e39f5f814e95af44",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59648",
+					"10.65.0.27:59648",
+					"172.17.0.1:59648",
+					"172.18.0.1:59648",
+					"172.19.0.1:59648",
+					"172.20.0.1:59648",
+					"172.21.0.1:59648",
+					"172.22.0.1:59648",
+					"172.23.0.1:59648",
+					"172.24.0.1:59648",
+					"172.25.0.1:59648",
+					"172.26.0.1:59648",
+					"172.27.0.1:59648",
+					"172.28.0.1:59648"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:13:47.91854552Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7962419053186660,
+				"StableID":   "nwQ1iJFCB521CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1919b336c3693103d358715b27cab626f647d1a16d164cf5d49aedd2ef924f73",
+				"DiscoKey":   "discokey:73f5523af2c0b1d4dd5c5014d41ae7df45fa1a7ee02057a69150b72725eb024f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53407",
+					"10.65.0.27:53407",
+					"172.17.0.1:53407",
+					"172.18.0.1:53407",
+					"172.19.0.1:53407",
+					"172.20.0.1:53407",
+					"172.21.0.1:53407",
+					"172.22.0.1:53407",
+					"172.23.0.1:53407",
+					"172.24.0.1:53407",
+					"172.25.0.1:53407",
+					"172.26.0.1:53407",
+					"172.27.0.1:53407",
+					"172.28.0.1:53407"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:13:48.443469076Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6044746052499738,
+				"StableID":   "nZE9QGEgCp11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22b70227ae88b9fda9788c3772c332407cdb89148f91c10176ca8b8903ff1363",
+				"DiscoKey":   "discokey:0fe71482954ba2363754e028708fb46b481ff00096be262ea4f006ca7ad8e916",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52558",
+					"10.65.0.27:52558",
+					"172.17.0.1:52558",
+					"172.18.0.1:52558",
+					"172.19.0.1:52558",
+					"172.20.0.1:52558",
+					"172.21.0.1:52558",
+					"172.22.0.1:52558",
+					"172.23.0.1:52558",
+					"172.24.0.1:52558",
+					"172.25.0.1:52558",
+					"172.26.0.1:52558",
+					"172.27.0.1:52558",
+					"172.28.0.1:52558"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:13:48.99964013Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5433078469590070,
+				"StableID":   "nBmxezkeRj11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8374fb267d55809e52504290e6ffeee33efde8ebaf7a7b623b5014bba304e425",
+				"DiscoKey":   "discokey:048c34a79aa49896a13903eef96e816e4b4e663fd7ca02a21bc2c4b356ab4146",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46826",
+					"10.65.0.27:46826",
+					"172.17.0.1:46826",
+					"172.18.0.1:46826",
+					"172.19.0.1:46826",
+					"172.20.0.1:46826",
+					"172.21.0.1:46826",
+					"172.22.0.1:46826",
+					"172.23.0.1:46826",
+					"172.24.0.1:46826",
+					"172.25.0.1:46826",
+					"172.26.0.1:46826",
+					"172.27.0.1:46826",
+					"172.28.0.1:46826"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:13:49.537845082Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2090937420854518,
+				"StableID":   "nsFXo4PzKH11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fd6ec88dd199fb11999e2d7d422e1414e6d70b7fce1f27b05b5f38d055196670",
+				"DiscoKey":   "discokey:1db436dff3600f11b84dfabc0662c7d4aee6c73367fe018562583e0a5604d344",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:34160",
+					"10.65.0.27:34160",
+					"172.17.0.1:34160",
+					"172.18.0.1:34160",
+					"172.19.0.1:34160",
+					"172.20.0.1:34160",
+					"172.21.0.1:34160",
+					"172.22.0.1:34160",
+					"172.23.0.1:34160",
+					"172.24.0.1:34160",
+					"172.25.0.1:34160",
+					"172.26.0.1:34160",
+					"172.27.0.1:34160",
+					"172.28.0.1:34160"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:13:50.07963397Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8304711186217950,
+				"StableID":   "nRnxNUgDr721CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d49968ed4b6e801f8bcfd75d2970d5e8d0b027b6cfc0b8c2c45c01e6df263151",
+				"DiscoKey":   "discokey:aea7b0e953bfef0d6a6c0814d25e731c9963eadb70924378da868b42a43e0400",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58025",
+					"10.65.0.27:58025",
+					"172.17.0.1:58025",
+					"172.18.0.1:58025",
+					"172.19.0.1:58025",
+					"172.20.0.1:58025",
+					"172.21.0.1:58025",
+					"172.22.0.1:58025",
+					"172.23.0.1:58025",
+					"172.24.0.1:58025",
+					"172.25.0.1:58025",
+					"172.26.0.1:58025",
+					"172.27.0.1:58025",
+					"172.28.0.1:58025"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:13:50.615674201Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         850548047160251,
+				"StableID":   "nxm2NPTDe711CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a84426ee164e9dec6e36d1d4ee19a179cf3d0b1dbad9a7dc0e60a3cdd0524e69",
+				"DiscoKey":   "discokey:90b4b8be3269ab9acbb2b879ca50b01ace17583683a8bbe8827c2554b729e656",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56047",
+					"10.65.0.27:56047",
+					"172.17.0.1:56047",
+					"172.18.0.1:56047",
+					"172.19.0.1:56047",
+					"172.20.0.1:56047",
+					"172.21.0.1:56047",
+					"172.22.0.1:56047",
+					"172.23.0.1:56047",
+					"172.24.0.1:56047",
+					"172.25.0.1:56047",
+					"172.26.0.1:56047",
+					"172.27.0.1:56047",
+					"172.28.0.1:56047"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:13:51.157675554Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         386192675168184,
+				"StableID":   "nTkVFMdu1411CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65590cb7a0a1b156cd97548850712f0b5c133b69282c80783264e2a065fdff0e",
+				"DiscoKey":   "discokey:ca4024426bcbe73444222fb3b3209f6117900f75cf74e5bb9ed8347bf0d65b55",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60971",
+					"10.65.0.27:60971",
+					"172.17.0.1:60971",
+					"172.18.0.1:60971",
+					"172.19.0.1:60971",
+					"172.20.0.1:60971",
+					"172.21.0.1:60971",
+					"172.22.0.1:60971",
+					"172.23.0.1:60971",
+					"172.24.0.1:60971",
+					"172.25.0.1:60971",
+					"172.26.0.1:60971",
+					"172.27.0.1:60971",
+					"172.28.0.1:60971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:13:51.662720535Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4704402975167966,
+				"StableID":   "nd4nSxgdjd11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f1ae1a9f931a41b4aba1300de94df66a2281c2b941d91a32521da4e952bf0651",
+				"DiscoKey":   "discokey:fa05c6c50cc38d0b64d4d60f0844cd3a54e82ea25f982a4e9ef1eaba08163946",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44348",
+					"10.65.0.27:44348",
+					"172.17.0.1:44348",
+					"172.18.0.1:44348",
+					"172.19.0.1:44348",
+					"172.20.0.1:44348",
+					"172.21.0.1:44348",
+					"172.22.0.1:44348",
+					"172.23.0.1:44348",
+					"172.24.0.1:44348",
+					"172.25.0.1:44348",
+					"172.26.0.1:44348",
+					"172.27.0.1:44348",
+					"172.28.0.1:44348"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:13:52.186640841Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1394021246640640,
+				"StableID":   "n3NvxJaMtB11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fb6653ad217217a2c56e9017d38db7ce1331a96fb389a774ab6b31459a3fb27",
+				"DiscoKey":   "discokey:75c30f7c43cafad3e3c423c5f02ce9236bd88881ef05a7aa983a8854fd33d007",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58655",
+					"10.65.0.27:58655",
+					"172.17.0.1:58655",
+					"172.18.0.1:58655",
+					"172.19.0.1:58655",
+					"172.20.0.1:58655",
+					"172.21.0.1:58655",
+					"172.22.0.1:58655",
+					"172.23.0.1:58655",
+					"172.24.0.1:58655",
+					"172.25.0.1:58655",
+					"172.26.0.1:58655",
+					"172.27.0.1:58655",
+					"172.28.0.1:58655"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:13:52.743055689Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7697324779720731,
+				"StableID":   "nanwXqf87321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7f81a6816c056d92f3704369a6fdc539d85d1fdfa41c4ace70942e5139888128",
+				"KeyExpiry":  "2026-11-09T09:13:53Z",
+				"DiscoKey":   "discokey:11c3892b44cfc9dfc564cb22131b80cbe9f67efc1a196ed7d89aa5cbba2b6d69",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43789",
+					"10.65.0.27:43789",
+					"172.17.0.1:43789",
+					"172.18.0.1:43789",
+					"172.19.0.1:43789",
+					"172.20.0.1:43789",
+					"172.21.0.1:43789",
+					"172.22.0.1:43789",
+					"172.23.0.1:43789",
+					"172.24.0.1:43789",
+					"172.25.0.1:43789",
+					"172.26.0.1:43789",
+					"172.27.0.1:43789",
+					"172.28.0.1:43789"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:13:53.276284579Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6802839220756022,
+				"StableID":   "nDUAiw328v11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c608580ec5c8dc961136d45191c29953ac601954fcd3bff2e24bf1f422775c54",
+				"KeyExpiry":  "2026-11-09T09:13:53Z",
+				"DiscoKey":   "discokey:b6e7700deeeeca23395db19fa7c9869a106f94702e24a2145d4ffc49b8766710",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39909",
+					"10.65.0.27:39909",
+					"172.17.0.1:39909",
+					"172.18.0.1:39909",
+					"172.19.0.1:39909",
+					"172.20.0.1:39909",
+					"172.21.0.1:39909",
+					"172.22.0.1:39909",
+					"172.23.0.1:39909",
+					"172.24.0.1:39909",
+					"172.25.0.1:39909",
+					"172.26.0.1:39909",
+					"172.27.0.1:39909",
+					"172.28.0.1:39909"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:13:53.846011491Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5958266231653377,
+				"StableID":   "nnKVmvYWXo11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b632c8a0f0684027efe19c151240b992be582ebb9cb868e39cdd0bc70d6c4859",
+				"KeyExpiry":  "2026-11-09T09:13:54Z",
+				"DiscoKey":   "discokey:f99ec748364ad51f9d7e83f1f08951353651063950f648d7f4a6c98573494c3e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41042",
+					"10.65.0.27:41042",
+					"172.17.0.1:41042",
+					"172.18.0.1:41042",
+					"172.19.0.1:41042",
+					"172.20.0.1:41042",
+					"172.21.0.1:41042",
+					"172.22.0.1:41042",
+					"172.23.0.1:41042",
+					"172.24.0.1:41042",
+					"172.25.0.1:41042",
+					"172.26.0.1:41042",
+					"172.27.0.1:41042",
+					"172.28.0.1:41042"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:13:54.362859818Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1198500343174197": {
+				"ID":          1198500343174197,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}, "1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6044746052499738,
+				"StableID":   "nZE9QGEgCp11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       6044746052499738,
+				"Key":        "nodekey:22b70227ae88b9fda9788c3772c332407cdb89148f91c10176ca8b8903ff1363",
+				"DiscoKey":   "discokey:0fe71482954ba2363754e028708fb46b481ff00096be262ea4f006ca7ad8e916",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52558",
+					"10.65.0.27:52558",
+					"172.17.0.1:52558",
+					"172.18.0.1:52558",
+					"172.19.0.1:52558",
+					"172.20.0.1:52558",
+					"172.21.0.1:52558",
+					"172.22.0.1:52558",
+					"172.23.0.1:52558",
+					"172.24.0.1:52558",
+					"172.25.0.1:52558",
+					"172.26.0.1:52558",
+					"172.27.0.1:52558",
+					"172.28.0.1:52558"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:13:48.99964013Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:22b70227ae88b9fda9788c3772c332407cdb89148f91c10176ca8b8903ff1363",
+			"MachineKey": "mkey:82795db96200a9d92cef8510c20a6199ba73051d9a7bea321174eaf003d5f15e",
+			"Peers": [{
+				"ID":         1198500343174197,
+				"StableID":   "nnmmFAaoMA11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:240f04f24aa13822252cbc3331eb7282991f64f29b7d9ac2befea60e896ef054",
+				"DiscoKey":   "discokey:ec8422f81c6380d3d6ed4f7fb5533072e378cd12cc5a06a94f667abc8a57c735",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:32935",
+					"10.65.0.27:32935",
+					"172.17.0.1:32935",
+					"172.18.0.1:32935",
+					"172.19.0.1:32935",
+					"172.20.0.1:32935",
+					"172.21.0.1:32935",
+					"172.22.0.1:32935",
+					"172.23.0.1:32935",
+					"172.24.0.1:32935",
+					"172.25.0.1:32935",
+					"172.26.0.1:32935",
+					"172.27.0.1:32935",
+					"172.28.0.1:32935"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:13:46.866938583Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5681187607005970,
+				"StableID":   "nBy3XZA2Nm11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:689e4a53f458215c7fe16a8c184c25724501d72d939e064df8f01398a492bf47",
+				"DiscoKey":   "discokey:2b3c1ce5b6b1d0405e2901e81a6465eef0881f513a2ee2274c701c371de73b6e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:38614",
+					"10.65.0.27:38614",
+					"172.17.0.1:38614",
+					"172.18.0.1:38614",
+					"172.19.0.1:38614",
+					"172.20.0.1:38614",
+					"172.21.0.1:38614",
+					"172.22.0.1:38614",
+					"172.23.0.1:38614",
+					"172.24.0.1:38614",
+					"172.25.0.1:38614",
+					"172.26.0.1:38614",
+					"172.27.0.1:38614",
+					"172.28.0.1:38614"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:13:47.376361337Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         12931462317159,
+				"StableID":   "naWW3tgr6111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b616fb9f37c2d3c5666f8339afed4dcd65336f5d6b4ff82d2da3af6efdacf12",
+				"DiscoKey":   "discokey:bec41e4ae574c1a59263182ed64c39ea7b104fa761ea0374e39f5f814e95af44",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59648",
+					"10.65.0.27:59648",
+					"172.17.0.1:59648",
+					"172.18.0.1:59648",
+					"172.19.0.1:59648",
+					"172.20.0.1:59648",
+					"172.21.0.1:59648",
+					"172.22.0.1:59648",
+					"172.23.0.1:59648",
+					"172.24.0.1:59648",
+					"172.25.0.1:59648",
+					"172.26.0.1:59648",
+					"172.27.0.1:59648",
+					"172.28.0.1:59648"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:13:47.91854552Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7962419053186660,
+				"StableID":   "nwQ1iJFCB521CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1919b336c3693103d358715b27cab626f647d1a16d164cf5d49aedd2ef924f73",
+				"DiscoKey":   "discokey:73f5523af2c0b1d4dd5c5014d41ae7df45fa1a7ee02057a69150b72725eb024f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53407",
+					"10.65.0.27:53407",
+					"172.17.0.1:53407",
+					"172.18.0.1:53407",
+					"172.19.0.1:53407",
+					"172.20.0.1:53407",
+					"172.21.0.1:53407",
+					"172.22.0.1:53407",
+					"172.23.0.1:53407",
+					"172.24.0.1:53407",
+					"172.25.0.1:53407",
+					"172.26.0.1:53407",
+					"172.27.0.1:53407",
+					"172.28.0.1:53407"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:13:48.443469076Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5433078469590070,
+				"StableID":   "nBmxezkeRj11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8374fb267d55809e52504290e6ffeee33efde8ebaf7a7b623b5014bba304e425",
+				"DiscoKey":   "discokey:048c34a79aa49896a13903eef96e816e4b4e663fd7ca02a21bc2c4b356ab4146",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46826",
+					"10.65.0.27:46826",
+					"172.17.0.1:46826",
+					"172.18.0.1:46826",
+					"172.19.0.1:46826",
+					"172.20.0.1:46826",
+					"172.21.0.1:46826",
+					"172.22.0.1:46826",
+					"172.23.0.1:46826",
+					"172.24.0.1:46826",
+					"172.25.0.1:46826",
+					"172.26.0.1:46826",
+					"172.27.0.1:46826",
+					"172.28.0.1:46826"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:13:49.537845082Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2090937420854518,
+				"StableID":   "nsFXo4PzKH11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fd6ec88dd199fb11999e2d7d422e1414e6d70b7fce1f27b05b5f38d055196670",
+				"DiscoKey":   "discokey:1db436dff3600f11b84dfabc0662c7d4aee6c73367fe018562583e0a5604d344",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:34160",
+					"10.65.0.27:34160",
+					"172.17.0.1:34160",
+					"172.18.0.1:34160",
+					"172.19.0.1:34160",
+					"172.20.0.1:34160",
+					"172.21.0.1:34160",
+					"172.22.0.1:34160",
+					"172.23.0.1:34160",
+					"172.24.0.1:34160",
+					"172.25.0.1:34160",
+					"172.26.0.1:34160",
+					"172.27.0.1:34160",
+					"172.28.0.1:34160"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:13:50.07963397Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8304711186217950,
+				"StableID":   "nRnxNUgDr721CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d49968ed4b6e801f8bcfd75d2970d5e8d0b027b6cfc0b8c2c45c01e6df263151",
+				"DiscoKey":   "discokey:aea7b0e953bfef0d6a6c0814d25e731c9963eadb70924378da868b42a43e0400",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58025",
+					"10.65.0.27:58025",
+					"172.17.0.1:58025",
+					"172.18.0.1:58025",
+					"172.19.0.1:58025",
+					"172.20.0.1:58025",
+					"172.21.0.1:58025",
+					"172.22.0.1:58025",
+					"172.23.0.1:58025",
+					"172.24.0.1:58025",
+					"172.25.0.1:58025",
+					"172.26.0.1:58025",
+					"172.27.0.1:58025",
+					"172.28.0.1:58025"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:13:50.615674201Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         850548047160251,
+				"StableID":   "nxm2NPTDe711CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a84426ee164e9dec6e36d1d4ee19a179cf3d0b1dbad9a7dc0e60a3cdd0524e69",
+				"DiscoKey":   "discokey:90b4b8be3269ab9acbb2b879ca50b01ace17583683a8bbe8827c2554b729e656",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56047",
+					"10.65.0.27:56047",
+					"172.17.0.1:56047",
+					"172.18.0.1:56047",
+					"172.19.0.1:56047",
+					"172.20.0.1:56047",
+					"172.21.0.1:56047",
+					"172.22.0.1:56047",
+					"172.23.0.1:56047",
+					"172.24.0.1:56047",
+					"172.25.0.1:56047",
+					"172.26.0.1:56047",
+					"172.27.0.1:56047",
+					"172.28.0.1:56047"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:13:51.157675554Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         386192675168184,
+				"StableID":   "nTkVFMdu1411CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65590cb7a0a1b156cd97548850712f0b5c133b69282c80783264e2a065fdff0e",
+				"DiscoKey":   "discokey:ca4024426bcbe73444222fb3b3209f6117900f75cf74e5bb9ed8347bf0d65b55",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60971",
+					"10.65.0.27:60971",
+					"172.17.0.1:60971",
+					"172.18.0.1:60971",
+					"172.19.0.1:60971",
+					"172.20.0.1:60971",
+					"172.21.0.1:60971",
+					"172.22.0.1:60971",
+					"172.23.0.1:60971",
+					"172.24.0.1:60971",
+					"172.25.0.1:60971",
+					"172.26.0.1:60971",
+					"172.27.0.1:60971",
+					"172.28.0.1:60971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:13:51.662720535Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4704402975167966,
+				"StableID":   "nd4nSxgdjd11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f1ae1a9f931a41b4aba1300de94df66a2281c2b941d91a32521da4e952bf0651",
+				"DiscoKey":   "discokey:fa05c6c50cc38d0b64d4d60f0844cd3a54e82ea25f982a4e9ef1eaba08163946",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44348",
+					"10.65.0.27:44348",
+					"172.17.0.1:44348",
+					"172.18.0.1:44348",
+					"172.19.0.1:44348",
+					"172.20.0.1:44348",
+					"172.21.0.1:44348",
+					"172.22.0.1:44348",
+					"172.23.0.1:44348",
+					"172.24.0.1:44348",
+					"172.25.0.1:44348",
+					"172.26.0.1:44348",
+					"172.27.0.1:44348",
+					"172.28.0.1:44348"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:13:52.186640841Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1394021246640640,
+				"StableID":   "n3NvxJaMtB11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fb6653ad217217a2c56e9017d38db7ce1331a96fb389a774ab6b31459a3fb27",
+				"DiscoKey":   "discokey:75c30f7c43cafad3e3c423c5f02ce9236bd88881ef05a7aa983a8854fd33d007",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58655",
+					"10.65.0.27:58655",
+					"172.17.0.1:58655",
+					"172.18.0.1:58655",
+					"172.19.0.1:58655",
+					"172.20.0.1:58655",
+					"172.21.0.1:58655",
+					"172.22.0.1:58655",
+					"172.23.0.1:58655",
+					"172.24.0.1:58655",
+					"172.25.0.1:58655",
+					"172.26.0.1:58655",
+					"172.27.0.1:58655",
+					"172.28.0.1:58655"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:13:52.743055689Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7697324779720731,
+				"StableID":   "nanwXqf87321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7f81a6816c056d92f3704369a6fdc539d85d1fdfa41c4ace70942e5139888128",
+				"KeyExpiry":  "2026-11-09T09:13:53Z",
+				"DiscoKey":   "discokey:11c3892b44cfc9dfc564cb22131b80cbe9f67efc1a196ed7d89aa5cbba2b6d69",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43789",
+					"10.65.0.27:43789",
+					"172.17.0.1:43789",
+					"172.18.0.1:43789",
+					"172.19.0.1:43789",
+					"172.20.0.1:43789",
+					"172.21.0.1:43789",
+					"172.22.0.1:43789",
+					"172.23.0.1:43789",
+					"172.24.0.1:43789",
+					"172.25.0.1:43789",
+					"172.26.0.1:43789",
+					"172.27.0.1:43789",
+					"172.28.0.1:43789"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:13:53.276284579Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6802839220756022,
+				"StableID":   "nDUAiw328v11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c608580ec5c8dc961136d45191c29953ac601954fcd3bff2e24bf1f422775c54",
+				"KeyExpiry":  "2026-11-09T09:13:53Z",
+				"DiscoKey":   "discokey:b6e7700deeeeca23395db19fa7c9869a106f94702e24a2145d4ffc49b8766710",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39909",
+					"10.65.0.27:39909",
+					"172.17.0.1:39909",
+					"172.18.0.1:39909",
+					"172.19.0.1:39909",
+					"172.20.0.1:39909",
+					"172.21.0.1:39909",
+					"172.22.0.1:39909",
+					"172.23.0.1:39909",
+					"172.24.0.1:39909",
+					"172.25.0.1:39909",
+					"172.26.0.1:39909",
+					"172.27.0.1:39909",
+					"172.28.0.1:39909"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:13:53.846011491Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5958266231653377,
+				"StableID":   "nnKVmvYWXo11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b632c8a0f0684027efe19c151240b992be582ebb9cb868e39cdd0bc70d6c4859",
+				"KeyExpiry":  "2026-11-09T09:13:54Z",
+				"DiscoKey":   "discokey:f99ec748364ad51f9d7e83f1f08951353651063950f648d7f4a6c98573494c3e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41042",
+					"10.65.0.27:41042",
+					"172.17.0.1:41042",
+					"172.18.0.1:41042",
+					"172.19.0.1:41042",
+					"172.20.0.1:41042",
+					"172.21.0.1:41042",
+					"172.22.0.1:41042",
+					"172.23.0.1:41042",
+					"172.24.0.1:41042",
+					"172.25.0.1:41042",
+					"172.26.0.1:41042",
+					"172.27.0.1:41042",
+					"172.28.0.1:41042"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:13:54.362859818Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6044746052499738": {
+				"ID":          6044746052499738,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7962419053186660,
+				"StableID":   "nwQ1iJFCB521CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       7962419053186660,
+				"Key":        "nodekey:1919b336c3693103d358715b27cab626f647d1a16d164cf5d49aedd2ef924f73",
+				"DiscoKey":   "discokey:73f5523af2c0b1d4dd5c5014d41ae7df45fa1a7ee02057a69150b72725eb024f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53407",
+					"10.65.0.27:53407",
+					"172.17.0.1:53407",
+					"172.18.0.1:53407",
+					"172.19.0.1:53407",
+					"172.20.0.1:53407",
+					"172.21.0.1:53407",
+					"172.22.0.1:53407",
+					"172.23.0.1:53407",
+					"172.24.0.1:53407",
+					"172.25.0.1:53407",
+					"172.26.0.1:53407",
+					"172.27.0.1:53407",
+					"172.28.0.1:53407"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:13:48.443469076Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1919b336c3693103d358715b27cab626f647d1a16d164cf5d49aedd2ef924f73",
+			"MachineKey": "mkey:b305400bd91944fcbf2fab468edccf0fe6c9d615beaf406eed346806c4eb9212",
+			"Peers": [{
+				"ID":         1198500343174197,
+				"StableID":   "nnmmFAaoMA11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:240f04f24aa13822252cbc3331eb7282991f64f29b7d9ac2befea60e896ef054",
+				"DiscoKey":   "discokey:ec8422f81c6380d3d6ed4f7fb5533072e378cd12cc5a06a94f667abc8a57c735",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:32935",
+					"10.65.0.27:32935",
+					"172.17.0.1:32935",
+					"172.18.0.1:32935",
+					"172.19.0.1:32935",
+					"172.20.0.1:32935",
+					"172.21.0.1:32935",
+					"172.22.0.1:32935",
+					"172.23.0.1:32935",
+					"172.24.0.1:32935",
+					"172.25.0.1:32935",
+					"172.26.0.1:32935",
+					"172.27.0.1:32935",
+					"172.28.0.1:32935"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:13:46.866938583Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5681187607005970,
+				"StableID":   "nBy3XZA2Nm11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:689e4a53f458215c7fe16a8c184c25724501d72d939e064df8f01398a492bf47",
+				"DiscoKey":   "discokey:2b3c1ce5b6b1d0405e2901e81a6465eef0881f513a2ee2274c701c371de73b6e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:38614",
+					"10.65.0.27:38614",
+					"172.17.0.1:38614",
+					"172.18.0.1:38614",
+					"172.19.0.1:38614",
+					"172.20.0.1:38614",
+					"172.21.0.1:38614",
+					"172.22.0.1:38614",
+					"172.23.0.1:38614",
+					"172.24.0.1:38614",
+					"172.25.0.1:38614",
+					"172.26.0.1:38614",
+					"172.27.0.1:38614",
+					"172.28.0.1:38614"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:13:47.376361337Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         12931462317159,
+				"StableID":   "naWW3tgr6111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b616fb9f37c2d3c5666f8339afed4dcd65336f5d6b4ff82d2da3af6efdacf12",
+				"DiscoKey":   "discokey:bec41e4ae574c1a59263182ed64c39ea7b104fa761ea0374e39f5f814e95af44",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59648",
+					"10.65.0.27:59648",
+					"172.17.0.1:59648",
+					"172.18.0.1:59648",
+					"172.19.0.1:59648",
+					"172.20.0.1:59648",
+					"172.21.0.1:59648",
+					"172.22.0.1:59648",
+					"172.23.0.1:59648",
+					"172.24.0.1:59648",
+					"172.25.0.1:59648",
+					"172.26.0.1:59648",
+					"172.27.0.1:59648",
+					"172.28.0.1:59648"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:13:47.91854552Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6044746052499738,
+				"StableID":   "nZE9QGEgCp11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22b70227ae88b9fda9788c3772c332407cdb89148f91c10176ca8b8903ff1363",
+				"DiscoKey":   "discokey:0fe71482954ba2363754e028708fb46b481ff00096be262ea4f006ca7ad8e916",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52558",
+					"10.65.0.27:52558",
+					"172.17.0.1:52558",
+					"172.18.0.1:52558",
+					"172.19.0.1:52558",
+					"172.20.0.1:52558",
+					"172.21.0.1:52558",
+					"172.22.0.1:52558",
+					"172.23.0.1:52558",
+					"172.24.0.1:52558",
+					"172.25.0.1:52558",
+					"172.26.0.1:52558",
+					"172.27.0.1:52558",
+					"172.28.0.1:52558"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:13:48.99964013Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5433078469590070,
+				"StableID":   "nBmxezkeRj11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8374fb267d55809e52504290e6ffeee33efde8ebaf7a7b623b5014bba304e425",
+				"DiscoKey":   "discokey:048c34a79aa49896a13903eef96e816e4b4e663fd7ca02a21bc2c4b356ab4146",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46826",
+					"10.65.0.27:46826",
+					"172.17.0.1:46826",
+					"172.18.0.1:46826",
+					"172.19.0.1:46826",
+					"172.20.0.1:46826",
+					"172.21.0.1:46826",
+					"172.22.0.1:46826",
+					"172.23.0.1:46826",
+					"172.24.0.1:46826",
+					"172.25.0.1:46826",
+					"172.26.0.1:46826",
+					"172.27.0.1:46826",
+					"172.28.0.1:46826"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:13:49.537845082Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2090937420854518,
+				"StableID":   "nsFXo4PzKH11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fd6ec88dd199fb11999e2d7d422e1414e6d70b7fce1f27b05b5f38d055196670",
+				"DiscoKey":   "discokey:1db436dff3600f11b84dfabc0662c7d4aee6c73367fe018562583e0a5604d344",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:34160",
+					"10.65.0.27:34160",
+					"172.17.0.1:34160",
+					"172.18.0.1:34160",
+					"172.19.0.1:34160",
+					"172.20.0.1:34160",
+					"172.21.0.1:34160",
+					"172.22.0.1:34160",
+					"172.23.0.1:34160",
+					"172.24.0.1:34160",
+					"172.25.0.1:34160",
+					"172.26.0.1:34160",
+					"172.27.0.1:34160",
+					"172.28.0.1:34160"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:13:50.07963397Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8304711186217950,
+				"StableID":   "nRnxNUgDr721CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d49968ed4b6e801f8bcfd75d2970d5e8d0b027b6cfc0b8c2c45c01e6df263151",
+				"DiscoKey":   "discokey:aea7b0e953bfef0d6a6c0814d25e731c9963eadb70924378da868b42a43e0400",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58025",
+					"10.65.0.27:58025",
+					"172.17.0.1:58025",
+					"172.18.0.1:58025",
+					"172.19.0.1:58025",
+					"172.20.0.1:58025",
+					"172.21.0.1:58025",
+					"172.22.0.1:58025",
+					"172.23.0.1:58025",
+					"172.24.0.1:58025",
+					"172.25.0.1:58025",
+					"172.26.0.1:58025",
+					"172.27.0.1:58025",
+					"172.28.0.1:58025"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:13:50.615674201Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         850548047160251,
+				"StableID":   "nxm2NPTDe711CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a84426ee164e9dec6e36d1d4ee19a179cf3d0b1dbad9a7dc0e60a3cdd0524e69",
+				"DiscoKey":   "discokey:90b4b8be3269ab9acbb2b879ca50b01ace17583683a8bbe8827c2554b729e656",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56047",
+					"10.65.0.27:56047",
+					"172.17.0.1:56047",
+					"172.18.0.1:56047",
+					"172.19.0.1:56047",
+					"172.20.0.1:56047",
+					"172.21.0.1:56047",
+					"172.22.0.1:56047",
+					"172.23.0.1:56047",
+					"172.24.0.1:56047",
+					"172.25.0.1:56047",
+					"172.26.0.1:56047",
+					"172.27.0.1:56047",
+					"172.28.0.1:56047"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:13:51.157675554Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         386192675168184,
+				"StableID":   "nTkVFMdu1411CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65590cb7a0a1b156cd97548850712f0b5c133b69282c80783264e2a065fdff0e",
+				"DiscoKey":   "discokey:ca4024426bcbe73444222fb3b3209f6117900f75cf74e5bb9ed8347bf0d65b55",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60971",
+					"10.65.0.27:60971",
+					"172.17.0.1:60971",
+					"172.18.0.1:60971",
+					"172.19.0.1:60971",
+					"172.20.0.1:60971",
+					"172.21.0.1:60971",
+					"172.22.0.1:60971",
+					"172.23.0.1:60971",
+					"172.24.0.1:60971",
+					"172.25.0.1:60971",
+					"172.26.0.1:60971",
+					"172.27.0.1:60971",
+					"172.28.0.1:60971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:13:51.662720535Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4704402975167966,
+				"StableID":   "nd4nSxgdjd11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f1ae1a9f931a41b4aba1300de94df66a2281c2b941d91a32521da4e952bf0651",
+				"DiscoKey":   "discokey:fa05c6c50cc38d0b64d4d60f0844cd3a54e82ea25f982a4e9ef1eaba08163946",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44348",
+					"10.65.0.27:44348",
+					"172.17.0.1:44348",
+					"172.18.0.1:44348",
+					"172.19.0.1:44348",
+					"172.20.0.1:44348",
+					"172.21.0.1:44348",
+					"172.22.0.1:44348",
+					"172.23.0.1:44348",
+					"172.24.0.1:44348",
+					"172.25.0.1:44348",
+					"172.26.0.1:44348",
+					"172.27.0.1:44348",
+					"172.28.0.1:44348"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:13:52.186640841Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1394021246640640,
+				"StableID":   "n3NvxJaMtB11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fb6653ad217217a2c56e9017d38db7ce1331a96fb389a774ab6b31459a3fb27",
+				"DiscoKey":   "discokey:75c30f7c43cafad3e3c423c5f02ce9236bd88881ef05a7aa983a8854fd33d007",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58655",
+					"10.65.0.27:58655",
+					"172.17.0.1:58655",
+					"172.18.0.1:58655",
+					"172.19.0.1:58655",
+					"172.20.0.1:58655",
+					"172.21.0.1:58655",
+					"172.22.0.1:58655",
+					"172.23.0.1:58655",
+					"172.24.0.1:58655",
+					"172.25.0.1:58655",
+					"172.26.0.1:58655",
+					"172.27.0.1:58655",
+					"172.28.0.1:58655"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:13:52.743055689Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7697324779720731,
+				"StableID":   "nanwXqf87321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7f81a6816c056d92f3704369a6fdc539d85d1fdfa41c4ace70942e5139888128",
+				"KeyExpiry":  "2026-11-09T09:13:53Z",
+				"DiscoKey":   "discokey:11c3892b44cfc9dfc564cb22131b80cbe9f67efc1a196ed7d89aa5cbba2b6d69",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43789",
+					"10.65.0.27:43789",
+					"172.17.0.1:43789",
+					"172.18.0.1:43789",
+					"172.19.0.1:43789",
+					"172.20.0.1:43789",
+					"172.21.0.1:43789",
+					"172.22.0.1:43789",
+					"172.23.0.1:43789",
+					"172.24.0.1:43789",
+					"172.25.0.1:43789",
+					"172.26.0.1:43789",
+					"172.27.0.1:43789",
+					"172.28.0.1:43789"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:13:53.276284579Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6802839220756022,
+				"StableID":   "nDUAiw328v11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c608580ec5c8dc961136d45191c29953ac601954fcd3bff2e24bf1f422775c54",
+				"KeyExpiry":  "2026-11-09T09:13:53Z",
+				"DiscoKey":   "discokey:b6e7700deeeeca23395db19fa7c9869a106f94702e24a2145d4ffc49b8766710",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39909",
+					"10.65.0.27:39909",
+					"172.17.0.1:39909",
+					"172.18.0.1:39909",
+					"172.19.0.1:39909",
+					"172.20.0.1:39909",
+					"172.21.0.1:39909",
+					"172.22.0.1:39909",
+					"172.23.0.1:39909",
+					"172.24.0.1:39909",
+					"172.25.0.1:39909",
+					"172.26.0.1:39909",
+					"172.27.0.1:39909",
+					"172.28.0.1:39909"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:13:53.846011491Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5958266231653377,
+				"StableID":   "nnKVmvYWXo11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b632c8a0f0684027efe19c151240b992be582ebb9cb868e39cdd0bc70d6c4859",
+				"KeyExpiry":  "2026-11-09T09:13:54Z",
+				"DiscoKey":   "discokey:f99ec748364ad51f9d7e83f1f08951353651063950f648d7f4a6c98573494c3e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41042",
+					"10.65.0.27:41042",
+					"172.17.0.1:41042",
+					"172.18.0.1:41042",
+					"172.19.0.1:41042",
+					"172.20.0.1:41042",
+					"172.21.0.1:41042",
+					"172.22.0.1:41042",
+					"172.23.0.1:41042",
+					"172.24.0.1:41042",
+					"172.25.0.1:41042",
+					"172.26.0.1:41042",
+					"172.27.0.1:41042",
+					"172.28.0.1:41042"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:13:54.362859818Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7962419053186660": {
+				"ID":          7962419053186660,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2090937420854518,
+				"StableID":   "nsFXo4PzKH11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       2090937420854518,
+				"Key":        "nodekey:fd6ec88dd199fb11999e2d7d422e1414e6d70b7fce1f27b05b5f38d055196670",
+				"DiscoKey":   "discokey:1db436dff3600f11b84dfabc0662c7d4aee6c73367fe018562583e0a5604d344",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:34160",
+					"10.65.0.27:34160",
+					"172.17.0.1:34160",
+					"172.18.0.1:34160",
+					"172.19.0.1:34160",
+					"172.20.0.1:34160",
+					"172.21.0.1:34160",
+					"172.22.0.1:34160",
+					"172.23.0.1:34160",
+					"172.24.0.1:34160",
+					"172.25.0.1:34160",
+					"172.26.0.1:34160",
+					"172.27.0.1:34160",
+					"172.28.0.1:34160"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:13:50.07963397Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:fd6ec88dd199fb11999e2d7d422e1414e6d70b7fce1f27b05b5f38d055196670",
+			"MachineKey": "mkey:0a5f6d4a01d4cba5f730092f70718284a100f84323ca67caa8898bd306c00243",
+			"Peers": [{
+				"ID":         1198500343174197,
+				"StableID":   "nnmmFAaoMA11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:240f04f24aa13822252cbc3331eb7282991f64f29b7d9ac2befea60e896ef054",
+				"DiscoKey":   "discokey:ec8422f81c6380d3d6ed4f7fb5533072e378cd12cc5a06a94f667abc8a57c735",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:32935",
+					"10.65.0.27:32935",
+					"172.17.0.1:32935",
+					"172.18.0.1:32935",
+					"172.19.0.1:32935",
+					"172.20.0.1:32935",
+					"172.21.0.1:32935",
+					"172.22.0.1:32935",
+					"172.23.0.1:32935",
+					"172.24.0.1:32935",
+					"172.25.0.1:32935",
+					"172.26.0.1:32935",
+					"172.27.0.1:32935",
+					"172.28.0.1:32935"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:13:46.866938583Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5681187607005970,
+				"StableID":   "nBy3XZA2Nm11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:689e4a53f458215c7fe16a8c184c25724501d72d939e064df8f01398a492bf47",
+				"DiscoKey":   "discokey:2b3c1ce5b6b1d0405e2901e81a6465eef0881f513a2ee2274c701c371de73b6e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:38614",
+					"10.65.0.27:38614",
+					"172.17.0.1:38614",
+					"172.18.0.1:38614",
+					"172.19.0.1:38614",
+					"172.20.0.1:38614",
+					"172.21.0.1:38614",
+					"172.22.0.1:38614",
+					"172.23.0.1:38614",
+					"172.24.0.1:38614",
+					"172.25.0.1:38614",
+					"172.26.0.1:38614",
+					"172.27.0.1:38614",
+					"172.28.0.1:38614"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:13:47.376361337Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         12931462317159,
+				"StableID":   "naWW3tgr6111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b616fb9f37c2d3c5666f8339afed4dcd65336f5d6b4ff82d2da3af6efdacf12",
+				"DiscoKey":   "discokey:bec41e4ae574c1a59263182ed64c39ea7b104fa761ea0374e39f5f814e95af44",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59648",
+					"10.65.0.27:59648",
+					"172.17.0.1:59648",
+					"172.18.0.1:59648",
+					"172.19.0.1:59648",
+					"172.20.0.1:59648",
+					"172.21.0.1:59648",
+					"172.22.0.1:59648",
+					"172.23.0.1:59648",
+					"172.24.0.1:59648",
+					"172.25.0.1:59648",
+					"172.26.0.1:59648",
+					"172.27.0.1:59648",
+					"172.28.0.1:59648"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:13:47.91854552Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7962419053186660,
+				"StableID":   "nwQ1iJFCB521CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1919b336c3693103d358715b27cab626f647d1a16d164cf5d49aedd2ef924f73",
+				"DiscoKey":   "discokey:73f5523af2c0b1d4dd5c5014d41ae7df45fa1a7ee02057a69150b72725eb024f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53407",
+					"10.65.0.27:53407",
+					"172.17.0.1:53407",
+					"172.18.0.1:53407",
+					"172.19.0.1:53407",
+					"172.20.0.1:53407",
+					"172.21.0.1:53407",
+					"172.22.0.1:53407",
+					"172.23.0.1:53407",
+					"172.24.0.1:53407",
+					"172.25.0.1:53407",
+					"172.26.0.1:53407",
+					"172.27.0.1:53407",
+					"172.28.0.1:53407"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:13:48.443469076Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6044746052499738,
+				"StableID":   "nZE9QGEgCp11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22b70227ae88b9fda9788c3772c332407cdb89148f91c10176ca8b8903ff1363",
+				"DiscoKey":   "discokey:0fe71482954ba2363754e028708fb46b481ff00096be262ea4f006ca7ad8e916",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52558",
+					"10.65.0.27:52558",
+					"172.17.0.1:52558",
+					"172.18.0.1:52558",
+					"172.19.0.1:52558",
+					"172.20.0.1:52558",
+					"172.21.0.1:52558",
+					"172.22.0.1:52558",
+					"172.23.0.1:52558",
+					"172.24.0.1:52558",
+					"172.25.0.1:52558",
+					"172.26.0.1:52558",
+					"172.27.0.1:52558",
+					"172.28.0.1:52558"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:13:48.99964013Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5433078469590070,
+				"StableID":   "nBmxezkeRj11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8374fb267d55809e52504290e6ffeee33efde8ebaf7a7b623b5014bba304e425",
+				"DiscoKey":   "discokey:048c34a79aa49896a13903eef96e816e4b4e663fd7ca02a21bc2c4b356ab4146",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46826",
+					"10.65.0.27:46826",
+					"172.17.0.1:46826",
+					"172.18.0.1:46826",
+					"172.19.0.1:46826",
+					"172.20.0.1:46826",
+					"172.21.0.1:46826",
+					"172.22.0.1:46826",
+					"172.23.0.1:46826",
+					"172.24.0.1:46826",
+					"172.25.0.1:46826",
+					"172.26.0.1:46826",
+					"172.27.0.1:46826",
+					"172.28.0.1:46826"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:13:49.537845082Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8304711186217950,
+				"StableID":   "nRnxNUgDr721CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d49968ed4b6e801f8bcfd75d2970d5e8d0b027b6cfc0b8c2c45c01e6df263151",
+				"DiscoKey":   "discokey:aea7b0e953bfef0d6a6c0814d25e731c9963eadb70924378da868b42a43e0400",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58025",
+					"10.65.0.27:58025",
+					"172.17.0.1:58025",
+					"172.18.0.1:58025",
+					"172.19.0.1:58025",
+					"172.20.0.1:58025",
+					"172.21.0.1:58025",
+					"172.22.0.1:58025",
+					"172.23.0.1:58025",
+					"172.24.0.1:58025",
+					"172.25.0.1:58025",
+					"172.26.0.1:58025",
+					"172.27.0.1:58025",
+					"172.28.0.1:58025"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:13:50.615674201Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         850548047160251,
+				"StableID":   "nxm2NPTDe711CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a84426ee164e9dec6e36d1d4ee19a179cf3d0b1dbad9a7dc0e60a3cdd0524e69",
+				"DiscoKey":   "discokey:90b4b8be3269ab9acbb2b879ca50b01ace17583683a8bbe8827c2554b729e656",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56047",
+					"10.65.0.27:56047",
+					"172.17.0.1:56047",
+					"172.18.0.1:56047",
+					"172.19.0.1:56047",
+					"172.20.0.1:56047",
+					"172.21.0.1:56047",
+					"172.22.0.1:56047",
+					"172.23.0.1:56047",
+					"172.24.0.1:56047",
+					"172.25.0.1:56047",
+					"172.26.0.1:56047",
+					"172.27.0.1:56047",
+					"172.28.0.1:56047"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:13:51.157675554Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         386192675168184,
+				"StableID":   "nTkVFMdu1411CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65590cb7a0a1b156cd97548850712f0b5c133b69282c80783264e2a065fdff0e",
+				"DiscoKey":   "discokey:ca4024426bcbe73444222fb3b3209f6117900f75cf74e5bb9ed8347bf0d65b55",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60971",
+					"10.65.0.27:60971",
+					"172.17.0.1:60971",
+					"172.18.0.1:60971",
+					"172.19.0.1:60971",
+					"172.20.0.1:60971",
+					"172.21.0.1:60971",
+					"172.22.0.1:60971",
+					"172.23.0.1:60971",
+					"172.24.0.1:60971",
+					"172.25.0.1:60971",
+					"172.26.0.1:60971",
+					"172.27.0.1:60971",
+					"172.28.0.1:60971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:13:51.662720535Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4704402975167966,
+				"StableID":   "nd4nSxgdjd11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f1ae1a9f931a41b4aba1300de94df66a2281c2b941d91a32521da4e952bf0651",
+				"DiscoKey":   "discokey:fa05c6c50cc38d0b64d4d60f0844cd3a54e82ea25f982a4e9ef1eaba08163946",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44348",
+					"10.65.0.27:44348",
+					"172.17.0.1:44348",
+					"172.18.0.1:44348",
+					"172.19.0.1:44348",
+					"172.20.0.1:44348",
+					"172.21.0.1:44348",
+					"172.22.0.1:44348",
+					"172.23.0.1:44348",
+					"172.24.0.1:44348",
+					"172.25.0.1:44348",
+					"172.26.0.1:44348",
+					"172.27.0.1:44348",
+					"172.28.0.1:44348"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:13:52.186640841Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1394021246640640,
+				"StableID":   "n3NvxJaMtB11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fb6653ad217217a2c56e9017d38db7ce1331a96fb389a774ab6b31459a3fb27",
+				"DiscoKey":   "discokey:75c30f7c43cafad3e3c423c5f02ce9236bd88881ef05a7aa983a8854fd33d007",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58655",
+					"10.65.0.27:58655",
+					"172.17.0.1:58655",
+					"172.18.0.1:58655",
+					"172.19.0.1:58655",
+					"172.20.0.1:58655",
+					"172.21.0.1:58655",
+					"172.22.0.1:58655",
+					"172.23.0.1:58655",
+					"172.24.0.1:58655",
+					"172.25.0.1:58655",
+					"172.26.0.1:58655",
+					"172.27.0.1:58655",
+					"172.28.0.1:58655"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:13:52.743055689Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7697324779720731,
+				"StableID":   "nanwXqf87321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7f81a6816c056d92f3704369a6fdc539d85d1fdfa41c4ace70942e5139888128",
+				"KeyExpiry":  "2026-11-09T09:13:53Z",
+				"DiscoKey":   "discokey:11c3892b44cfc9dfc564cb22131b80cbe9f67efc1a196ed7d89aa5cbba2b6d69",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43789",
+					"10.65.0.27:43789",
+					"172.17.0.1:43789",
+					"172.18.0.1:43789",
+					"172.19.0.1:43789",
+					"172.20.0.1:43789",
+					"172.21.0.1:43789",
+					"172.22.0.1:43789",
+					"172.23.0.1:43789",
+					"172.24.0.1:43789",
+					"172.25.0.1:43789",
+					"172.26.0.1:43789",
+					"172.27.0.1:43789",
+					"172.28.0.1:43789"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:13:53.276284579Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6802839220756022,
+				"StableID":   "nDUAiw328v11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c608580ec5c8dc961136d45191c29953ac601954fcd3bff2e24bf1f422775c54",
+				"KeyExpiry":  "2026-11-09T09:13:53Z",
+				"DiscoKey":   "discokey:b6e7700deeeeca23395db19fa7c9869a106f94702e24a2145d4ffc49b8766710",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39909",
+					"10.65.0.27:39909",
+					"172.17.0.1:39909",
+					"172.18.0.1:39909",
+					"172.19.0.1:39909",
+					"172.20.0.1:39909",
+					"172.21.0.1:39909",
+					"172.22.0.1:39909",
+					"172.23.0.1:39909",
+					"172.24.0.1:39909",
+					"172.25.0.1:39909",
+					"172.26.0.1:39909",
+					"172.27.0.1:39909",
+					"172.28.0.1:39909"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:13:53.846011491Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5958266231653377,
+				"StableID":   "nnKVmvYWXo11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b632c8a0f0684027efe19c151240b992be582ebb9cb868e39cdd0bc70d6c4859",
+				"KeyExpiry":  "2026-11-09T09:13:54Z",
+				"DiscoKey":   "discokey:f99ec748364ad51f9d7e83f1f08951353651063950f648d7f4a6c98573494c3e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41042",
+					"10.65.0.27:41042",
+					"172.17.0.1:41042",
+					"172.18.0.1:41042",
+					"172.19.0.1:41042",
+					"172.20.0.1:41042",
+					"172.21.0.1:41042",
+					"172.22.0.1:41042",
+					"172.23.0.1:41042",
+					"172.24.0.1:41042",
+					"172.25.0.1:41042",
+					"172.26.0.1:41042",
+					"172.27.0.1:41042",
+					"172.28.0.1:41042"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:13:54.362859818Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2090937420854518": {
+				"ID":          2090937420854518,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         850548047160251,
+				"StableID":   "nxm2NPTDe711CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       850548047160251,
+				"Key":        "nodekey:a84426ee164e9dec6e36d1d4ee19a179cf3d0b1dbad9a7dc0e60a3cdd0524e69",
+				"DiscoKey":   "discokey:90b4b8be3269ab9acbb2b879ca50b01ace17583683a8bbe8827c2554b729e656",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56047",
+					"10.65.0.27:56047",
+					"172.17.0.1:56047",
+					"172.18.0.1:56047",
+					"172.19.0.1:56047",
+					"172.20.0.1:56047",
+					"172.21.0.1:56047",
+					"172.22.0.1:56047",
+					"172.23.0.1:56047",
+					"172.24.0.1:56047",
+					"172.25.0.1:56047",
+					"172.26.0.1:56047",
+					"172.27.0.1:56047",
+					"172.28.0.1:56047"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:13:51.157675554Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a84426ee164e9dec6e36d1d4ee19a179cf3d0b1dbad9a7dc0e60a3cdd0524e69",
+			"MachineKey": "mkey:a9c651cd2d581441ed1c9b3ce5dd43759a79d5543a5a8fb0f40f4ef172cb8122",
+			"Peers": [{
+				"ID":         1198500343174197,
+				"StableID":   "nnmmFAaoMA11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:240f04f24aa13822252cbc3331eb7282991f64f29b7d9ac2befea60e896ef054",
+				"DiscoKey":   "discokey:ec8422f81c6380d3d6ed4f7fb5533072e378cd12cc5a06a94f667abc8a57c735",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:32935",
+					"10.65.0.27:32935",
+					"172.17.0.1:32935",
+					"172.18.0.1:32935",
+					"172.19.0.1:32935",
+					"172.20.0.1:32935",
+					"172.21.0.1:32935",
+					"172.22.0.1:32935",
+					"172.23.0.1:32935",
+					"172.24.0.1:32935",
+					"172.25.0.1:32935",
+					"172.26.0.1:32935",
+					"172.27.0.1:32935",
+					"172.28.0.1:32935"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:13:46.866938583Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5681187607005970,
+				"StableID":   "nBy3XZA2Nm11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:689e4a53f458215c7fe16a8c184c25724501d72d939e064df8f01398a492bf47",
+				"DiscoKey":   "discokey:2b3c1ce5b6b1d0405e2901e81a6465eef0881f513a2ee2274c701c371de73b6e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:38614",
+					"10.65.0.27:38614",
+					"172.17.0.1:38614",
+					"172.18.0.1:38614",
+					"172.19.0.1:38614",
+					"172.20.0.1:38614",
+					"172.21.0.1:38614",
+					"172.22.0.1:38614",
+					"172.23.0.1:38614",
+					"172.24.0.1:38614",
+					"172.25.0.1:38614",
+					"172.26.0.1:38614",
+					"172.27.0.1:38614",
+					"172.28.0.1:38614"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:13:47.376361337Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         12931462317159,
+				"StableID":   "naWW3tgr6111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b616fb9f37c2d3c5666f8339afed4dcd65336f5d6b4ff82d2da3af6efdacf12",
+				"DiscoKey":   "discokey:bec41e4ae574c1a59263182ed64c39ea7b104fa761ea0374e39f5f814e95af44",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59648",
+					"10.65.0.27:59648",
+					"172.17.0.1:59648",
+					"172.18.0.1:59648",
+					"172.19.0.1:59648",
+					"172.20.0.1:59648",
+					"172.21.0.1:59648",
+					"172.22.0.1:59648",
+					"172.23.0.1:59648",
+					"172.24.0.1:59648",
+					"172.25.0.1:59648",
+					"172.26.0.1:59648",
+					"172.27.0.1:59648",
+					"172.28.0.1:59648"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:13:47.91854552Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7962419053186660,
+				"StableID":   "nwQ1iJFCB521CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1919b336c3693103d358715b27cab626f647d1a16d164cf5d49aedd2ef924f73",
+				"DiscoKey":   "discokey:73f5523af2c0b1d4dd5c5014d41ae7df45fa1a7ee02057a69150b72725eb024f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53407",
+					"10.65.0.27:53407",
+					"172.17.0.1:53407",
+					"172.18.0.1:53407",
+					"172.19.0.1:53407",
+					"172.20.0.1:53407",
+					"172.21.0.1:53407",
+					"172.22.0.1:53407",
+					"172.23.0.1:53407",
+					"172.24.0.1:53407",
+					"172.25.0.1:53407",
+					"172.26.0.1:53407",
+					"172.27.0.1:53407",
+					"172.28.0.1:53407"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:13:48.443469076Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6044746052499738,
+				"StableID":   "nZE9QGEgCp11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22b70227ae88b9fda9788c3772c332407cdb89148f91c10176ca8b8903ff1363",
+				"DiscoKey":   "discokey:0fe71482954ba2363754e028708fb46b481ff00096be262ea4f006ca7ad8e916",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52558",
+					"10.65.0.27:52558",
+					"172.17.0.1:52558",
+					"172.18.0.1:52558",
+					"172.19.0.1:52558",
+					"172.20.0.1:52558",
+					"172.21.0.1:52558",
+					"172.22.0.1:52558",
+					"172.23.0.1:52558",
+					"172.24.0.1:52558",
+					"172.25.0.1:52558",
+					"172.26.0.1:52558",
+					"172.27.0.1:52558",
+					"172.28.0.1:52558"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:13:48.99964013Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5433078469590070,
+				"StableID":   "nBmxezkeRj11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8374fb267d55809e52504290e6ffeee33efde8ebaf7a7b623b5014bba304e425",
+				"DiscoKey":   "discokey:048c34a79aa49896a13903eef96e816e4b4e663fd7ca02a21bc2c4b356ab4146",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46826",
+					"10.65.0.27:46826",
+					"172.17.0.1:46826",
+					"172.18.0.1:46826",
+					"172.19.0.1:46826",
+					"172.20.0.1:46826",
+					"172.21.0.1:46826",
+					"172.22.0.1:46826",
+					"172.23.0.1:46826",
+					"172.24.0.1:46826",
+					"172.25.0.1:46826",
+					"172.26.0.1:46826",
+					"172.27.0.1:46826",
+					"172.28.0.1:46826"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:13:49.537845082Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2090937420854518,
+				"StableID":   "nsFXo4PzKH11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fd6ec88dd199fb11999e2d7d422e1414e6d70b7fce1f27b05b5f38d055196670",
+				"DiscoKey":   "discokey:1db436dff3600f11b84dfabc0662c7d4aee6c73367fe018562583e0a5604d344",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:34160",
+					"10.65.0.27:34160",
+					"172.17.0.1:34160",
+					"172.18.0.1:34160",
+					"172.19.0.1:34160",
+					"172.20.0.1:34160",
+					"172.21.0.1:34160",
+					"172.22.0.1:34160",
+					"172.23.0.1:34160",
+					"172.24.0.1:34160",
+					"172.25.0.1:34160",
+					"172.26.0.1:34160",
+					"172.27.0.1:34160",
+					"172.28.0.1:34160"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:13:50.07963397Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8304711186217950,
+				"StableID":   "nRnxNUgDr721CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d49968ed4b6e801f8bcfd75d2970d5e8d0b027b6cfc0b8c2c45c01e6df263151",
+				"DiscoKey":   "discokey:aea7b0e953bfef0d6a6c0814d25e731c9963eadb70924378da868b42a43e0400",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58025",
+					"10.65.0.27:58025",
+					"172.17.0.1:58025",
+					"172.18.0.1:58025",
+					"172.19.0.1:58025",
+					"172.20.0.1:58025",
+					"172.21.0.1:58025",
+					"172.22.0.1:58025",
+					"172.23.0.1:58025",
+					"172.24.0.1:58025",
+					"172.25.0.1:58025",
+					"172.26.0.1:58025",
+					"172.27.0.1:58025",
+					"172.28.0.1:58025"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:13:50.615674201Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         386192675168184,
+				"StableID":   "nTkVFMdu1411CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65590cb7a0a1b156cd97548850712f0b5c133b69282c80783264e2a065fdff0e",
+				"DiscoKey":   "discokey:ca4024426bcbe73444222fb3b3209f6117900f75cf74e5bb9ed8347bf0d65b55",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60971",
+					"10.65.0.27:60971",
+					"172.17.0.1:60971",
+					"172.18.0.1:60971",
+					"172.19.0.1:60971",
+					"172.20.0.1:60971",
+					"172.21.0.1:60971",
+					"172.22.0.1:60971",
+					"172.23.0.1:60971",
+					"172.24.0.1:60971",
+					"172.25.0.1:60971",
+					"172.26.0.1:60971",
+					"172.27.0.1:60971",
+					"172.28.0.1:60971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:13:51.662720535Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4704402975167966,
+				"StableID":   "nd4nSxgdjd11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f1ae1a9f931a41b4aba1300de94df66a2281c2b941d91a32521da4e952bf0651",
+				"DiscoKey":   "discokey:fa05c6c50cc38d0b64d4d60f0844cd3a54e82ea25f982a4e9ef1eaba08163946",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44348",
+					"10.65.0.27:44348",
+					"172.17.0.1:44348",
+					"172.18.0.1:44348",
+					"172.19.0.1:44348",
+					"172.20.0.1:44348",
+					"172.21.0.1:44348",
+					"172.22.0.1:44348",
+					"172.23.0.1:44348",
+					"172.24.0.1:44348",
+					"172.25.0.1:44348",
+					"172.26.0.1:44348",
+					"172.27.0.1:44348",
+					"172.28.0.1:44348"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:13:52.186640841Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1394021246640640,
+				"StableID":   "n3NvxJaMtB11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fb6653ad217217a2c56e9017d38db7ce1331a96fb389a774ab6b31459a3fb27",
+				"DiscoKey":   "discokey:75c30f7c43cafad3e3c423c5f02ce9236bd88881ef05a7aa983a8854fd33d007",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58655",
+					"10.65.0.27:58655",
+					"172.17.0.1:58655",
+					"172.18.0.1:58655",
+					"172.19.0.1:58655",
+					"172.20.0.1:58655",
+					"172.21.0.1:58655",
+					"172.22.0.1:58655",
+					"172.23.0.1:58655",
+					"172.24.0.1:58655",
+					"172.25.0.1:58655",
+					"172.26.0.1:58655",
+					"172.27.0.1:58655",
+					"172.28.0.1:58655"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:13:52.743055689Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7697324779720731,
+				"StableID":   "nanwXqf87321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7f81a6816c056d92f3704369a6fdc539d85d1fdfa41c4ace70942e5139888128",
+				"KeyExpiry":  "2026-11-09T09:13:53Z",
+				"DiscoKey":   "discokey:11c3892b44cfc9dfc564cb22131b80cbe9f67efc1a196ed7d89aa5cbba2b6d69",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43789",
+					"10.65.0.27:43789",
+					"172.17.0.1:43789",
+					"172.18.0.1:43789",
+					"172.19.0.1:43789",
+					"172.20.0.1:43789",
+					"172.21.0.1:43789",
+					"172.22.0.1:43789",
+					"172.23.0.1:43789",
+					"172.24.0.1:43789",
+					"172.25.0.1:43789",
+					"172.26.0.1:43789",
+					"172.27.0.1:43789",
+					"172.28.0.1:43789"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:13:53.276284579Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6802839220756022,
+				"StableID":   "nDUAiw328v11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c608580ec5c8dc961136d45191c29953ac601954fcd3bff2e24bf1f422775c54",
+				"KeyExpiry":  "2026-11-09T09:13:53Z",
+				"DiscoKey":   "discokey:b6e7700deeeeca23395db19fa7c9869a106f94702e24a2145d4ffc49b8766710",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39909",
+					"10.65.0.27:39909",
+					"172.17.0.1:39909",
+					"172.18.0.1:39909",
+					"172.19.0.1:39909",
+					"172.20.0.1:39909",
+					"172.21.0.1:39909",
+					"172.22.0.1:39909",
+					"172.23.0.1:39909",
+					"172.24.0.1:39909",
+					"172.25.0.1:39909",
+					"172.26.0.1:39909",
+					"172.27.0.1:39909",
+					"172.28.0.1:39909"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:13:53.846011491Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5958266231653377,
+				"StableID":   "nnKVmvYWXo11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b632c8a0f0684027efe19c151240b992be582ebb9cb868e39cdd0bc70d6c4859",
+				"KeyExpiry":  "2026-11-09T09:13:54Z",
+				"DiscoKey":   "discokey:f99ec748364ad51f9d7e83f1f08951353651063950f648d7f4a6c98573494c3e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41042",
+					"10.65.0.27:41042",
+					"172.17.0.1:41042",
+					"172.18.0.1:41042",
+					"172.19.0.1:41042",
+					"172.20.0.1:41042",
+					"172.21.0.1:41042",
+					"172.22.0.1:41042",
+					"172.23.0.1:41042",
+					"172.24.0.1:41042",
+					"172.25.0.1:41042",
+					"172.26.0.1:41042",
+					"172.27.0.1:41042",
+					"172.28.0.1:41042"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:13:54.362859818Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "850548047160251": {
+				"ID":          850548047160251,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6802839220756022,
+				"StableID":   "nDUAiw328v11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c608580ec5c8dc961136d45191c29953ac601954fcd3bff2e24bf1f422775c54",
+				"KeyExpiry":  "2026-11-09T09:13:53Z",
+				"DiscoKey":   "discokey:b6e7700deeeeca23395db19fa7c9869a106f94702e24a2145d4ffc49b8766710",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39909",
+					"10.65.0.27:39909",
+					"172.17.0.1:39909",
+					"172.18.0.1:39909",
+					"172.19.0.1:39909",
+					"172.20.0.1:39909",
+					"172.21.0.1:39909",
+					"172.22.0.1:39909",
+					"172.23.0.1:39909",
+					"172.24.0.1:39909",
+					"172.25.0.1:39909",
+					"172.26.0.1:39909",
+					"172.27.0.1:39909",
+					"172.28.0.1:39909"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:13:53.846011491Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c608580ec5c8dc961136d45191c29953ac601954fcd3bff2e24bf1f422775c54",
+			"MachineKey": "mkey:3c9733a0a7712b34905745c8d79fb46429ecddad02677d2911c52ca78f4fec32",
+			"Peers": [{
+				"ID":         1198500343174197,
+				"StableID":   "nnmmFAaoMA11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:240f04f24aa13822252cbc3331eb7282991f64f29b7d9ac2befea60e896ef054",
+				"DiscoKey":   "discokey:ec8422f81c6380d3d6ed4f7fb5533072e378cd12cc5a06a94f667abc8a57c735",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:32935",
+					"10.65.0.27:32935",
+					"172.17.0.1:32935",
+					"172.18.0.1:32935",
+					"172.19.0.1:32935",
+					"172.20.0.1:32935",
+					"172.21.0.1:32935",
+					"172.22.0.1:32935",
+					"172.23.0.1:32935",
+					"172.24.0.1:32935",
+					"172.25.0.1:32935",
+					"172.26.0.1:32935",
+					"172.27.0.1:32935",
+					"172.28.0.1:32935"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:13:46.866938583Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5681187607005970,
+				"StableID":   "nBy3XZA2Nm11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:689e4a53f458215c7fe16a8c184c25724501d72d939e064df8f01398a492bf47",
+				"DiscoKey":   "discokey:2b3c1ce5b6b1d0405e2901e81a6465eef0881f513a2ee2274c701c371de73b6e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:38614",
+					"10.65.0.27:38614",
+					"172.17.0.1:38614",
+					"172.18.0.1:38614",
+					"172.19.0.1:38614",
+					"172.20.0.1:38614",
+					"172.21.0.1:38614",
+					"172.22.0.1:38614",
+					"172.23.0.1:38614",
+					"172.24.0.1:38614",
+					"172.25.0.1:38614",
+					"172.26.0.1:38614",
+					"172.27.0.1:38614",
+					"172.28.0.1:38614"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:13:47.376361337Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         12931462317159,
+				"StableID":   "naWW3tgr6111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b616fb9f37c2d3c5666f8339afed4dcd65336f5d6b4ff82d2da3af6efdacf12",
+				"DiscoKey":   "discokey:bec41e4ae574c1a59263182ed64c39ea7b104fa761ea0374e39f5f814e95af44",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59648",
+					"10.65.0.27:59648",
+					"172.17.0.1:59648",
+					"172.18.0.1:59648",
+					"172.19.0.1:59648",
+					"172.20.0.1:59648",
+					"172.21.0.1:59648",
+					"172.22.0.1:59648",
+					"172.23.0.1:59648",
+					"172.24.0.1:59648",
+					"172.25.0.1:59648",
+					"172.26.0.1:59648",
+					"172.27.0.1:59648",
+					"172.28.0.1:59648"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:13:47.91854552Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7962419053186660,
+				"StableID":   "nwQ1iJFCB521CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1919b336c3693103d358715b27cab626f647d1a16d164cf5d49aedd2ef924f73",
+				"DiscoKey":   "discokey:73f5523af2c0b1d4dd5c5014d41ae7df45fa1a7ee02057a69150b72725eb024f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53407",
+					"10.65.0.27:53407",
+					"172.17.0.1:53407",
+					"172.18.0.1:53407",
+					"172.19.0.1:53407",
+					"172.20.0.1:53407",
+					"172.21.0.1:53407",
+					"172.22.0.1:53407",
+					"172.23.0.1:53407",
+					"172.24.0.1:53407",
+					"172.25.0.1:53407",
+					"172.26.0.1:53407",
+					"172.27.0.1:53407",
+					"172.28.0.1:53407"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:13:48.443469076Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6044746052499738,
+				"StableID":   "nZE9QGEgCp11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22b70227ae88b9fda9788c3772c332407cdb89148f91c10176ca8b8903ff1363",
+				"DiscoKey":   "discokey:0fe71482954ba2363754e028708fb46b481ff00096be262ea4f006ca7ad8e916",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52558",
+					"10.65.0.27:52558",
+					"172.17.0.1:52558",
+					"172.18.0.1:52558",
+					"172.19.0.1:52558",
+					"172.20.0.1:52558",
+					"172.21.0.1:52558",
+					"172.22.0.1:52558",
+					"172.23.0.1:52558",
+					"172.24.0.1:52558",
+					"172.25.0.1:52558",
+					"172.26.0.1:52558",
+					"172.27.0.1:52558",
+					"172.28.0.1:52558"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:13:48.99964013Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5433078469590070,
+				"StableID":   "nBmxezkeRj11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8374fb267d55809e52504290e6ffeee33efde8ebaf7a7b623b5014bba304e425",
+				"DiscoKey":   "discokey:048c34a79aa49896a13903eef96e816e4b4e663fd7ca02a21bc2c4b356ab4146",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46826",
+					"10.65.0.27:46826",
+					"172.17.0.1:46826",
+					"172.18.0.1:46826",
+					"172.19.0.1:46826",
+					"172.20.0.1:46826",
+					"172.21.0.1:46826",
+					"172.22.0.1:46826",
+					"172.23.0.1:46826",
+					"172.24.0.1:46826",
+					"172.25.0.1:46826",
+					"172.26.0.1:46826",
+					"172.27.0.1:46826",
+					"172.28.0.1:46826"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:13:49.537845082Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2090937420854518,
+				"StableID":   "nsFXo4PzKH11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fd6ec88dd199fb11999e2d7d422e1414e6d70b7fce1f27b05b5f38d055196670",
+				"DiscoKey":   "discokey:1db436dff3600f11b84dfabc0662c7d4aee6c73367fe018562583e0a5604d344",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:34160",
+					"10.65.0.27:34160",
+					"172.17.0.1:34160",
+					"172.18.0.1:34160",
+					"172.19.0.1:34160",
+					"172.20.0.1:34160",
+					"172.21.0.1:34160",
+					"172.22.0.1:34160",
+					"172.23.0.1:34160",
+					"172.24.0.1:34160",
+					"172.25.0.1:34160",
+					"172.26.0.1:34160",
+					"172.27.0.1:34160",
+					"172.28.0.1:34160"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:13:50.07963397Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8304711186217950,
+				"StableID":   "nRnxNUgDr721CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d49968ed4b6e801f8bcfd75d2970d5e8d0b027b6cfc0b8c2c45c01e6df263151",
+				"DiscoKey":   "discokey:aea7b0e953bfef0d6a6c0814d25e731c9963eadb70924378da868b42a43e0400",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58025",
+					"10.65.0.27:58025",
+					"172.17.0.1:58025",
+					"172.18.0.1:58025",
+					"172.19.0.1:58025",
+					"172.20.0.1:58025",
+					"172.21.0.1:58025",
+					"172.22.0.1:58025",
+					"172.23.0.1:58025",
+					"172.24.0.1:58025",
+					"172.25.0.1:58025",
+					"172.26.0.1:58025",
+					"172.27.0.1:58025",
+					"172.28.0.1:58025"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:13:50.615674201Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         850548047160251,
+				"StableID":   "nxm2NPTDe711CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a84426ee164e9dec6e36d1d4ee19a179cf3d0b1dbad9a7dc0e60a3cdd0524e69",
+				"DiscoKey":   "discokey:90b4b8be3269ab9acbb2b879ca50b01ace17583683a8bbe8827c2554b729e656",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56047",
+					"10.65.0.27:56047",
+					"172.17.0.1:56047",
+					"172.18.0.1:56047",
+					"172.19.0.1:56047",
+					"172.20.0.1:56047",
+					"172.21.0.1:56047",
+					"172.22.0.1:56047",
+					"172.23.0.1:56047",
+					"172.24.0.1:56047",
+					"172.25.0.1:56047",
+					"172.26.0.1:56047",
+					"172.27.0.1:56047",
+					"172.28.0.1:56047"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:13:51.157675554Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         386192675168184,
+				"StableID":   "nTkVFMdu1411CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65590cb7a0a1b156cd97548850712f0b5c133b69282c80783264e2a065fdff0e",
+				"DiscoKey":   "discokey:ca4024426bcbe73444222fb3b3209f6117900f75cf74e5bb9ed8347bf0d65b55",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60971",
+					"10.65.0.27:60971",
+					"172.17.0.1:60971",
+					"172.18.0.1:60971",
+					"172.19.0.1:60971",
+					"172.20.0.1:60971",
+					"172.21.0.1:60971",
+					"172.22.0.1:60971",
+					"172.23.0.1:60971",
+					"172.24.0.1:60971",
+					"172.25.0.1:60971",
+					"172.26.0.1:60971",
+					"172.27.0.1:60971",
+					"172.28.0.1:60971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:13:51.662720535Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4704402975167966,
+				"StableID":   "nd4nSxgdjd11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f1ae1a9f931a41b4aba1300de94df66a2281c2b941d91a32521da4e952bf0651",
+				"DiscoKey":   "discokey:fa05c6c50cc38d0b64d4d60f0844cd3a54e82ea25f982a4e9ef1eaba08163946",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44348",
+					"10.65.0.27:44348",
+					"172.17.0.1:44348",
+					"172.18.0.1:44348",
+					"172.19.0.1:44348",
+					"172.20.0.1:44348",
+					"172.21.0.1:44348",
+					"172.22.0.1:44348",
+					"172.23.0.1:44348",
+					"172.24.0.1:44348",
+					"172.25.0.1:44348",
+					"172.26.0.1:44348",
+					"172.27.0.1:44348",
+					"172.28.0.1:44348"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:13:52.186640841Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1394021246640640,
+				"StableID":   "n3NvxJaMtB11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fb6653ad217217a2c56e9017d38db7ce1331a96fb389a774ab6b31459a3fb27",
+				"DiscoKey":   "discokey:75c30f7c43cafad3e3c423c5f02ce9236bd88881ef05a7aa983a8854fd33d007",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58655",
+					"10.65.0.27:58655",
+					"172.17.0.1:58655",
+					"172.18.0.1:58655",
+					"172.19.0.1:58655",
+					"172.20.0.1:58655",
+					"172.21.0.1:58655",
+					"172.22.0.1:58655",
+					"172.23.0.1:58655",
+					"172.24.0.1:58655",
+					"172.25.0.1:58655",
+					"172.26.0.1:58655",
+					"172.27.0.1:58655",
+					"172.28.0.1:58655"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:13:52.743055689Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7697324779720731,
+				"StableID":   "nanwXqf87321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7f81a6816c056d92f3704369a6fdc539d85d1fdfa41c4ace70942e5139888128",
+				"KeyExpiry":  "2026-11-09T09:13:53Z",
+				"DiscoKey":   "discokey:11c3892b44cfc9dfc564cb22131b80cbe9f67efc1a196ed7d89aa5cbba2b6d69",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43789",
+					"10.65.0.27:43789",
+					"172.17.0.1:43789",
+					"172.18.0.1:43789",
+					"172.19.0.1:43789",
+					"172.20.0.1:43789",
+					"172.21.0.1:43789",
+					"172.22.0.1:43789",
+					"172.23.0.1:43789",
+					"172.24.0.1:43789",
+					"172.25.0.1:43789",
+					"172.26.0.1:43789",
+					"172.27.0.1:43789",
+					"172.28.0.1:43789"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:13:53.276284579Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5958266231653377,
+				"StableID":   "nnKVmvYWXo11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b632c8a0f0684027efe19c151240b992be582ebb9cb868e39cdd0bc70d6c4859",
+				"KeyExpiry":  "2026-11-09T09:13:54Z",
+				"DiscoKey":   "discokey:f99ec748364ad51f9d7e83f1f08951353651063950f648d7f4a6c98573494c3e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41042",
+					"10.65.0.27:41042",
+					"172.17.0.1:41042",
+					"172.18.0.1:41042",
+					"172.19.0.1:41042",
+					"172.20.0.1:41042",
+					"172.21.0.1:41042",
+					"172.22.0.1:41042",
+					"172.23.0.1:41042",
+					"172.24.0.1:41042",
+					"172.25.0.1:41042",
+					"172.26.0.1:41042",
+					"172.27.0.1:41042",
+					"172.28.0.1:41042"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:13:54.362859818Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         386192675168184,
+				"StableID":   "nTkVFMdu1411CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       386192675168184,
+				"Key":        "nodekey:65590cb7a0a1b156cd97548850712f0b5c133b69282c80783264e2a065fdff0e",
+				"DiscoKey":   "discokey:ca4024426bcbe73444222fb3b3209f6117900f75cf74e5bb9ed8347bf0d65b55",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60971",
+					"10.65.0.27:60971",
+					"172.17.0.1:60971",
+					"172.18.0.1:60971",
+					"172.19.0.1:60971",
+					"172.20.0.1:60971",
+					"172.21.0.1:60971",
+					"172.22.0.1:60971",
+					"172.23.0.1:60971",
+					"172.24.0.1:60971",
+					"172.25.0.1:60971",
+					"172.26.0.1:60971",
+					"172.27.0.1:60971",
+					"172.28.0.1:60971"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:13:51.662720535Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:65590cb7a0a1b156cd97548850712f0b5c133b69282c80783264e2a065fdff0e",
+			"MachineKey": "mkey:95ddce78854c5dca0dbc95581e56f017728558025cb1845e56baeec50aa88510",
+			"Peers": [{
+				"ID":         1198500343174197,
+				"StableID":   "nnmmFAaoMA11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:240f04f24aa13822252cbc3331eb7282991f64f29b7d9ac2befea60e896ef054",
+				"DiscoKey":   "discokey:ec8422f81c6380d3d6ed4f7fb5533072e378cd12cc5a06a94f667abc8a57c735",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:32935",
+					"10.65.0.27:32935",
+					"172.17.0.1:32935",
+					"172.18.0.1:32935",
+					"172.19.0.1:32935",
+					"172.20.0.1:32935",
+					"172.21.0.1:32935",
+					"172.22.0.1:32935",
+					"172.23.0.1:32935",
+					"172.24.0.1:32935",
+					"172.25.0.1:32935",
+					"172.26.0.1:32935",
+					"172.27.0.1:32935",
+					"172.28.0.1:32935"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:13:46.866938583Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5681187607005970,
+				"StableID":   "nBy3XZA2Nm11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:689e4a53f458215c7fe16a8c184c25724501d72d939e064df8f01398a492bf47",
+				"DiscoKey":   "discokey:2b3c1ce5b6b1d0405e2901e81a6465eef0881f513a2ee2274c701c371de73b6e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:38614",
+					"10.65.0.27:38614",
+					"172.17.0.1:38614",
+					"172.18.0.1:38614",
+					"172.19.0.1:38614",
+					"172.20.0.1:38614",
+					"172.21.0.1:38614",
+					"172.22.0.1:38614",
+					"172.23.0.1:38614",
+					"172.24.0.1:38614",
+					"172.25.0.1:38614",
+					"172.26.0.1:38614",
+					"172.27.0.1:38614",
+					"172.28.0.1:38614"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:13:47.376361337Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         12931462317159,
+				"StableID":   "naWW3tgr6111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b616fb9f37c2d3c5666f8339afed4dcd65336f5d6b4ff82d2da3af6efdacf12",
+				"DiscoKey":   "discokey:bec41e4ae574c1a59263182ed64c39ea7b104fa761ea0374e39f5f814e95af44",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59648",
+					"10.65.0.27:59648",
+					"172.17.0.1:59648",
+					"172.18.0.1:59648",
+					"172.19.0.1:59648",
+					"172.20.0.1:59648",
+					"172.21.0.1:59648",
+					"172.22.0.1:59648",
+					"172.23.0.1:59648",
+					"172.24.0.1:59648",
+					"172.25.0.1:59648",
+					"172.26.0.1:59648",
+					"172.27.0.1:59648",
+					"172.28.0.1:59648"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:13:47.91854552Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7962419053186660,
+				"StableID":   "nwQ1iJFCB521CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1919b336c3693103d358715b27cab626f647d1a16d164cf5d49aedd2ef924f73",
+				"DiscoKey":   "discokey:73f5523af2c0b1d4dd5c5014d41ae7df45fa1a7ee02057a69150b72725eb024f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53407",
+					"10.65.0.27:53407",
+					"172.17.0.1:53407",
+					"172.18.0.1:53407",
+					"172.19.0.1:53407",
+					"172.20.0.1:53407",
+					"172.21.0.1:53407",
+					"172.22.0.1:53407",
+					"172.23.0.1:53407",
+					"172.24.0.1:53407",
+					"172.25.0.1:53407",
+					"172.26.0.1:53407",
+					"172.27.0.1:53407",
+					"172.28.0.1:53407"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:13:48.443469076Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6044746052499738,
+				"StableID":   "nZE9QGEgCp11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22b70227ae88b9fda9788c3772c332407cdb89148f91c10176ca8b8903ff1363",
+				"DiscoKey":   "discokey:0fe71482954ba2363754e028708fb46b481ff00096be262ea4f006ca7ad8e916",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52558",
+					"10.65.0.27:52558",
+					"172.17.0.1:52558",
+					"172.18.0.1:52558",
+					"172.19.0.1:52558",
+					"172.20.0.1:52558",
+					"172.21.0.1:52558",
+					"172.22.0.1:52558",
+					"172.23.0.1:52558",
+					"172.24.0.1:52558",
+					"172.25.0.1:52558",
+					"172.26.0.1:52558",
+					"172.27.0.1:52558",
+					"172.28.0.1:52558"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:13:48.99964013Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5433078469590070,
+				"StableID":   "nBmxezkeRj11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8374fb267d55809e52504290e6ffeee33efde8ebaf7a7b623b5014bba304e425",
+				"DiscoKey":   "discokey:048c34a79aa49896a13903eef96e816e4b4e663fd7ca02a21bc2c4b356ab4146",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:46826",
+					"10.65.0.27:46826",
+					"172.17.0.1:46826",
+					"172.18.0.1:46826",
+					"172.19.0.1:46826",
+					"172.20.0.1:46826",
+					"172.21.0.1:46826",
+					"172.22.0.1:46826",
+					"172.23.0.1:46826",
+					"172.24.0.1:46826",
+					"172.25.0.1:46826",
+					"172.26.0.1:46826",
+					"172.27.0.1:46826",
+					"172.28.0.1:46826"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:13:49.537845082Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2090937420854518,
+				"StableID":   "nsFXo4PzKH11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fd6ec88dd199fb11999e2d7d422e1414e6d70b7fce1f27b05b5f38d055196670",
+				"DiscoKey":   "discokey:1db436dff3600f11b84dfabc0662c7d4aee6c73367fe018562583e0a5604d344",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:34160",
+					"10.65.0.27:34160",
+					"172.17.0.1:34160",
+					"172.18.0.1:34160",
+					"172.19.0.1:34160",
+					"172.20.0.1:34160",
+					"172.21.0.1:34160",
+					"172.22.0.1:34160",
+					"172.23.0.1:34160",
+					"172.24.0.1:34160",
+					"172.25.0.1:34160",
+					"172.26.0.1:34160",
+					"172.27.0.1:34160",
+					"172.28.0.1:34160"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:13:50.07963397Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8304711186217950,
+				"StableID":   "nRnxNUgDr721CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d49968ed4b6e801f8bcfd75d2970d5e8d0b027b6cfc0b8c2c45c01e6df263151",
+				"DiscoKey":   "discokey:aea7b0e953bfef0d6a6c0814d25e731c9963eadb70924378da868b42a43e0400",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58025",
+					"10.65.0.27:58025",
+					"172.17.0.1:58025",
+					"172.18.0.1:58025",
+					"172.19.0.1:58025",
+					"172.20.0.1:58025",
+					"172.21.0.1:58025",
+					"172.22.0.1:58025",
+					"172.23.0.1:58025",
+					"172.24.0.1:58025",
+					"172.25.0.1:58025",
+					"172.26.0.1:58025",
+					"172.27.0.1:58025",
+					"172.28.0.1:58025"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:13:50.615674201Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         850548047160251,
+				"StableID":   "nxm2NPTDe711CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a84426ee164e9dec6e36d1d4ee19a179cf3d0b1dbad9a7dc0e60a3cdd0524e69",
+				"DiscoKey":   "discokey:90b4b8be3269ab9acbb2b879ca50b01ace17583683a8bbe8827c2554b729e656",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56047",
+					"10.65.0.27:56047",
+					"172.17.0.1:56047",
+					"172.18.0.1:56047",
+					"172.19.0.1:56047",
+					"172.20.0.1:56047",
+					"172.21.0.1:56047",
+					"172.22.0.1:56047",
+					"172.23.0.1:56047",
+					"172.24.0.1:56047",
+					"172.25.0.1:56047",
+					"172.26.0.1:56047",
+					"172.27.0.1:56047",
+					"172.28.0.1:56047"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:13:51.157675554Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4704402975167966,
+				"StableID":   "nd4nSxgdjd11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f1ae1a9f931a41b4aba1300de94df66a2281c2b941d91a32521da4e952bf0651",
+				"DiscoKey":   "discokey:fa05c6c50cc38d0b64d4d60f0844cd3a54e82ea25f982a4e9ef1eaba08163946",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44348",
+					"10.65.0.27:44348",
+					"172.17.0.1:44348",
+					"172.18.0.1:44348",
+					"172.19.0.1:44348",
+					"172.20.0.1:44348",
+					"172.21.0.1:44348",
+					"172.22.0.1:44348",
+					"172.23.0.1:44348",
+					"172.24.0.1:44348",
+					"172.25.0.1:44348",
+					"172.26.0.1:44348",
+					"172.27.0.1:44348",
+					"172.28.0.1:44348"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:13:52.186640841Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1394021246640640,
+				"StableID":   "n3NvxJaMtB11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fb6653ad217217a2c56e9017d38db7ce1331a96fb389a774ab6b31459a3fb27",
+				"DiscoKey":   "discokey:75c30f7c43cafad3e3c423c5f02ce9236bd88881ef05a7aa983a8854fd33d007",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58655",
+					"10.65.0.27:58655",
+					"172.17.0.1:58655",
+					"172.18.0.1:58655",
+					"172.19.0.1:58655",
+					"172.20.0.1:58655",
+					"172.21.0.1:58655",
+					"172.22.0.1:58655",
+					"172.23.0.1:58655",
+					"172.24.0.1:58655",
+					"172.25.0.1:58655",
+					"172.26.0.1:58655",
+					"172.27.0.1:58655",
+					"172.28.0.1:58655"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:13:52.743055689Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7697324779720731,
+				"StableID":   "nanwXqf87321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7f81a6816c056d92f3704369a6fdc539d85d1fdfa41c4ace70942e5139888128",
+				"KeyExpiry":  "2026-11-09T09:13:53Z",
+				"DiscoKey":   "discokey:11c3892b44cfc9dfc564cb22131b80cbe9f67efc1a196ed7d89aa5cbba2b6d69",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43789",
+					"10.65.0.27:43789",
+					"172.17.0.1:43789",
+					"172.18.0.1:43789",
+					"172.19.0.1:43789",
+					"172.20.0.1:43789",
+					"172.21.0.1:43789",
+					"172.22.0.1:43789",
+					"172.23.0.1:43789",
+					"172.24.0.1:43789",
+					"172.25.0.1:43789",
+					"172.26.0.1:43789",
+					"172.27.0.1:43789",
+					"172.28.0.1:43789"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:13:53.276284579Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6802839220756022,
+				"StableID":   "nDUAiw328v11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c608580ec5c8dc961136d45191c29953ac601954fcd3bff2e24bf1f422775c54",
+				"KeyExpiry":  "2026-11-09T09:13:53Z",
+				"DiscoKey":   "discokey:b6e7700deeeeca23395db19fa7c9869a106f94702e24a2145d4ffc49b8766710",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39909",
+					"10.65.0.27:39909",
+					"172.17.0.1:39909",
+					"172.18.0.1:39909",
+					"172.19.0.1:39909",
+					"172.20.0.1:39909",
+					"172.21.0.1:39909",
+					"172.22.0.1:39909",
+					"172.23.0.1:39909",
+					"172.24.0.1:39909",
+					"172.25.0.1:39909",
+					"172.26.0.1:39909",
+					"172.27.0.1:39909",
+					"172.28.0.1:39909"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:13:53.846011491Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5958266231653377,
+				"StableID":   "nnKVmvYWXo11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b632c8a0f0684027efe19c151240b992be582ebb9cb868e39cdd0bc70d6c4859",
+				"KeyExpiry":  "2026-11-09T09:13:54Z",
+				"DiscoKey":   "discokey:f99ec748364ad51f9d7e83f1f08951353651063950f648d7f4a6c98573494c3e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41042",
+					"10.65.0.27:41042",
+					"172.17.0.1:41042",
+					"172.18.0.1:41042",
+					"172.19.0.1:41042",
+					"172.20.0.1:41042",
+					"172.21.0.1:41042",
+					"172.22.0.1:41042",
+					"172.23.0.1:41042",
+					"172.24.0.1:41042",
+					"172.25.0.1:41042",
+					"172.26.0.1:41042",
+					"172.27.0.1:41042",
+					"172.28.0.1:41042"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:13:54.362859818Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "386192675168184": {
+				"ID":          386192675168184,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-acceptenv-bad-glob.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-acceptenv-bad-glob.hujson
@@ -1,0 +1,20105 @@
+// ssh-malformed-acceptenv-bad-glob
+//
+// ssh acceptEnv double-star glob is rejected
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T21:49:01Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-malformed-acceptenv-bad-glob",
+	"description":    "ssh acceptEnv double-star glob is rejected",
+	"category":       "ssh",
+	"captured_at":    "2026-05-12T21:49:01.677887395Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                   \n  \n                                                                    \n                                                         \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh acceptEnv double-star glob is rejected\",\n\t\"id\":          \"ssh-malformed-acceptenv-bad-glob\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"acceptEnv\": [\"**\"],\n\t\t\"action\":    \"accept\",\n\t\t\"dst\":       [\"tag:server\"],\n\t\t\"src\":       [\"autogroup:member\"],\n\t\t\"users\":     [\"root\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-malformed/ssh-malformed-acceptenv-bad-glob.hujson",
+		"full_policy": {
+			"ssh": [{
+				"acceptEnv": ["**"],
+				"action":    "accept",
+				"dst":       ["tag:server"],
+				"src":       ["autogroup:member"],
+				"users":     ["root"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2203141394618887,
+				"StableID":   "nLfsjjnoCJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       2203141394618887,
+				"Key":        "nodekey:3453c7e18a404cfddd1cfdbe77685328d109bcfba27d638f26c11c98e95a737a",
+				"DiscoKey":   "discokey:b669fb349e410b95c45ab36e77a66935fd7b31f810e27de1fc3a199049775d51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35888",
+					"10.65.0.27:35888",
+					"172.17.0.1:35888",
+					"172.18.0.1:35888",
+					"172.19.0.1:35888"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:49:16.022684649Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3453c7e18a404cfddd1cfdbe77685328d109bcfba27d638f26c11c98e95a737a",
+			"MachineKey": "mkey:dd3517be8996c7507b5b708865045facb9d624d382d901e019a25619adbd916e",
+			"Peers": [{
+				"ID":         2595605725024588,
+				"StableID":   "nXLogLAZGM11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:14a115699713e890c9ebfd1debe10c2955f916f5f2f9722fe5f1feb4b811e252",
+				"DiscoKey":   "discokey:fd34e073defe44541d380b4c33a1d77cc1221e9757157787927dcd821a3e2219",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40696",
+					"10.65.0.27:40696",
+					"172.17.0.1:40696",
+					"172.18.0.1:40696",
+					"172.19.0.1:40696"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:49:10.064815739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7042396524582791,
+				"StableID":   "n43mKGpWzw11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38ae018d24adab03d2e46a464f480279ede3ae5bd252e131de5c4b7fbea8dd70",
+				"DiscoKey":   "discokey:c4fdd0fed0b5a4fdeab03a2ce1d74f4edcafa739f929eb014e34a6032abc8224",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:38715",
+					"10.65.0.27:38715",
+					"172.17.0.1:38715",
+					"172.18.0.1:38715",
+					"172.19.0.1:38715"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:49:10.609682656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1183280254117873,
+				"StableID":   "nUG17RmuEA11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4390c15f3125750f4a9e2b22a7d7806e6199c382802003a2cdb35bc19ae9a32e",
+				"DiscoKey":   "discokey:e36de856145dd7e2754fe0322eda7879310f63a1b2c72df0152bb076f611f47b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:47272",
+					"10.65.0.27:47272",
+					"172.17.0.1:47272",
+					"172.18.0.1:47272",
+					"172.19.0.1:47272"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:49:11.140917354Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2218056842991332,
+				"StableID":   "nXNWqLbZKJ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28f70453d3c468887468d1258c09e6468800d017111b99af7b569a2314418a2d",
+				"DiscoKey":   "discokey:4ef6a887f47edfdc701745fce2faedbfff9ade73f331d563045031554c14f85d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35181",
+					"10.65.0.27:35181",
+					"172.17.0.1:35181",
+					"172.18.0.1:35181",
+					"172.19.0.1:35181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:49:11.683535327Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         746689446529713,
+				"StableID":   "nEdNUQGBq611CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab2e486bb8a6fdb92739451606d15232bbf6535af74e1a91b9b07d094835822b",
+				"DiscoKey":   "discokey:2025685b7907dbd1e900b1baeace89931dc193dae2d0ba614cf12cb11d8eb66c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41671",
+					"10.65.0.27:41671",
+					"172.17.0.1:41671",
+					"172.18.0.1:41671",
+					"172.19.0.1:41671"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:49:12.233898047Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4327983417894694,
+				"StableID":   "n5A5AZn9oa11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6d3ae4d06183ea1bead68acad8a90eb516dfac343f0a82b7365c2cec87f8e64",
+				"DiscoKey":   "discokey:26ee058c7dbc87ed44cfcae9d88a8205f9548b05e5504284eda15234f79f4e78",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54900",
+					"10.65.0.27:54900",
+					"172.17.0.1:54900",
+					"172.18.0.1:54900",
+					"172.19.0.1:54900"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:49:12.774546426Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8662887182080140,
+				"StableID":   "nwJncgMSeA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:05d473005abe8dc116ae56f5d1fdf629f0847c243d316d7cd9d41d96d561ed25",
+				"DiscoKey":   "discokey:5e6c3b8fa777c273041cd28af21a4e8c29710cb73d507da21713cb0418381a24",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52368",
+					"10.65.0.27:52368",
+					"172.17.0.1:52368",
+					"172.18.0.1:52368",
+					"172.19.0.1:52368"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:49:13.302903115Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         431529393613490,
+				"StableID":   "nHz1pdYSN411CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec7d6d70b11cba72fd0940dfb8a2d9bea86790409c782b33368bb9ec6471f550",
+				"DiscoKey":   "discokey:2a26fcb59058f5b52912afaf9422cfee53c0e566d2cd28838b5db04e9b0ad038",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36296",
+					"10.65.0.27:36296",
+					"172.17.0.1:36296",
+					"172.18.0.1:36296",
+					"172.19.0.1:36296"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:49:13.842342868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         910957886262895,
+				"StableID":   "nYoryVKa7811CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06c727e305f7e7195d99e93233d9a2803b52c748c7db417b099e3f454d0b882d",
+				"DiscoKey":   "discokey:14c36ce284e0e02b05e63ebbee8f2fb6f07ef6a60c4da0be42e83190d661b813",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42643",
+					"10.65.0.27:42643",
+					"172.17.0.1:42643",
+					"172.18.0.1:42643",
+					"172.19.0.1:42643"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:49:14.386907943Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         166908153790418,
+				"StableID":   "ny821sPbJ211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f27617a6dc635a2c1af4604dc3c73509e67243d2840bd025f478c00c6bfce6d",
+				"DiscoKey":   "discokey:2e07fcc0a089360338b3ffa93ddf8b1ed73293d18b2222e401e85eee1b046e41",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38488",
+					"10.65.0.27:38488",
+					"172.17.0.1:38488",
+					"172.18.0.1:38488",
+					"172.19.0.1:38488"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:49:14.927640924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1502109014378542,
+				"StableID":   "nfZTsgrJjC11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec7db7e4eb604d75b66d69733a1a067cf9536593fd857760d54d968d90236f48",
+				"DiscoKey":   "discokey:ec8de26619283d20beb293de62cbae66574f9906e68e99ddaac047cf647eba1b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60046",
+					"10.65.0.27:60046",
+					"172.17.0.1:60046",
+					"172.18.0.1:60046",
+					"172.19.0.1:60046"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:49:15.468825067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7574053010769617,
+				"StableID":   "nEZGShXJ9221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0f521e4ca342b6e1a782c54783b263369fcc7f9f5778b126706efac0f5acc74f",
+				"KeyExpiry":  "2026-11-08T21:49:16Z",
+				"DiscoKey":   "discokey:d37d6a768804229a0d54df49ddd6466e49bca0b7932f93a405b1a5666dbce57f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38301",
+					"10.65.0.27:38301",
+					"172.17.0.1:38301",
+					"172.18.0.1:38301",
+					"172.19.0.1:38301"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:49:16.556149353Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         940518938194514,
+				"StableID":   "nPVvuaqxL811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:dc757d461633aa1d469b5f88a14871937df499b7d1561ea7248a9c5db869f052",
+				"KeyExpiry":  "2026-11-08T21:49:17Z",
+				"DiscoKey":   "discokey:ac001a108a7d11c3e4d6ae6ecea6c37f60bf445e6d9ff5096d0303e611b2e865",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59722",
+					"10.65.0.27:59722",
+					"172.17.0.1:59722",
+					"172.18.0.1:59722",
+					"172.19.0.1:59722"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:49:17.098234886Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1433377374142785,
+				"StableID":   "nprbBoPBCC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9464d26862c21ab5a714719dde84fac8cb7b4a8a523a7d78c4fa69971fea376f",
+				"KeyExpiry":  "2026-11-08T21:49:17Z",
+				"DiscoKey":   "discokey:561cf4cc2a53e2dd29e6f24814dde8c32b70a8d7ed1af41d9c32d7f37ccac507",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59993",
+					"10.65.0.27:59993",
+					"172.17.0.1:59993",
+					"172.18.0.1:59993",
+					"172.19.0.1:59993"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:49:17.638950635Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{"principals": [
+				{"nodeIP": "100.64.0.17"},
+				{"nodeIP": "100.64.0.18"},
+				{"nodeIP": "100.64.0.19"},
+				{"nodeIP": "fd7a:115c:a1e0::13"},
+				{"nodeIP": "fd7a:115c:a1e0::12"},
+				{"nodeIP": "fd7a:115c:a1e0::11"}
+			], "sshUsers": {"root": "root"}, "action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}, "acceptEnv": ["**"]}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2203141394618887": {
+				"ID":          2203141394618887,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		},
+		"ssh_rules": [{"principals": [
+			{"nodeIP": "100.64.0.17"},
+			{"nodeIP": "100.64.0.18"},
+			{"nodeIP": "100.64.0.19"},
+			{"nodeIP": "fd7a:115c:a1e0::13"},
+			{"nodeIP": "fd7a:115c:a1e0::12"},
+			{"nodeIP": "fd7a:115c:a1e0::11"}
+		], "sshUsers": {"root": "root"}, "action": {
+			"accept":                    true,
+			"allowAgentForwarding":      true,
+			"allowLocalPortForwarding":  true,
+			"allowRemotePortForwarding": true
+		}, "acceptEnv": ["**"]}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4327983417894694,
+				"StableID":   "n5A5AZn9oa11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       4327983417894694,
+				"Key":        "nodekey:f6d3ae4d06183ea1bead68acad8a90eb516dfac343f0a82b7365c2cec87f8e64",
+				"DiscoKey":   "discokey:26ee058c7dbc87ed44cfcae9d88a8205f9548b05e5504284eda15234f79f4e78",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54900",
+					"10.65.0.27:54900",
+					"172.17.0.1:54900",
+					"172.18.0.1:54900",
+					"172.19.0.1:54900"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:49:12.774546426Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f6d3ae4d06183ea1bead68acad8a90eb516dfac343f0a82b7365c2cec87f8e64",
+			"MachineKey": "mkey:e013eaca4cd7949a78f8827844b06cf185679c0d0db9b4a5bf61758908571511",
+			"Peers": [{
+				"ID":         2595605725024588,
+				"StableID":   "nXLogLAZGM11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:14a115699713e890c9ebfd1debe10c2955f916f5f2f9722fe5f1feb4b811e252",
+				"DiscoKey":   "discokey:fd34e073defe44541d380b4c33a1d77cc1221e9757157787927dcd821a3e2219",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40696",
+					"10.65.0.27:40696",
+					"172.17.0.1:40696",
+					"172.18.0.1:40696",
+					"172.19.0.1:40696"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:49:10.064815739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7042396524582791,
+				"StableID":   "n43mKGpWzw11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38ae018d24adab03d2e46a464f480279ede3ae5bd252e131de5c4b7fbea8dd70",
+				"DiscoKey":   "discokey:c4fdd0fed0b5a4fdeab03a2ce1d74f4edcafa739f929eb014e34a6032abc8224",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:38715",
+					"10.65.0.27:38715",
+					"172.17.0.1:38715",
+					"172.18.0.1:38715",
+					"172.19.0.1:38715"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:49:10.609682656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1183280254117873,
+				"StableID":   "nUG17RmuEA11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4390c15f3125750f4a9e2b22a7d7806e6199c382802003a2cdb35bc19ae9a32e",
+				"DiscoKey":   "discokey:e36de856145dd7e2754fe0322eda7879310f63a1b2c72df0152bb076f611f47b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:47272",
+					"10.65.0.27:47272",
+					"172.17.0.1:47272",
+					"172.18.0.1:47272",
+					"172.19.0.1:47272"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:49:11.140917354Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2218056842991332,
+				"StableID":   "nXNWqLbZKJ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28f70453d3c468887468d1258c09e6468800d017111b99af7b569a2314418a2d",
+				"DiscoKey":   "discokey:4ef6a887f47edfdc701745fce2faedbfff9ade73f331d563045031554c14f85d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35181",
+					"10.65.0.27:35181",
+					"172.17.0.1:35181",
+					"172.18.0.1:35181",
+					"172.19.0.1:35181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:49:11.683535327Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         746689446529713,
+				"StableID":   "nEdNUQGBq611CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab2e486bb8a6fdb92739451606d15232bbf6535af74e1a91b9b07d094835822b",
+				"DiscoKey":   "discokey:2025685b7907dbd1e900b1baeace89931dc193dae2d0ba614cf12cb11d8eb66c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41671",
+					"10.65.0.27:41671",
+					"172.17.0.1:41671",
+					"172.18.0.1:41671",
+					"172.19.0.1:41671"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:49:12.233898047Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8662887182080140,
+				"StableID":   "nwJncgMSeA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:05d473005abe8dc116ae56f5d1fdf629f0847c243d316d7cd9d41d96d561ed25",
+				"DiscoKey":   "discokey:5e6c3b8fa777c273041cd28af21a4e8c29710cb73d507da21713cb0418381a24",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52368",
+					"10.65.0.27:52368",
+					"172.17.0.1:52368",
+					"172.18.0.1:52368",
+					"172.19.0.1:52368"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:49:13.302903115Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         431529393613490,
+				"StableID":   "nHz1pdYSN411CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec7d6d70b11cba72fd0940dfb8a2d9bea86790409c782b33368bb9ec6471f550",
+				"DiscoKey":   "discokey:2a26fcb59058f5b52912afaf9422cfee53c0e566d2cd28838b5db04e9b0ad038",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36296",
+					"10.65.0.27:36296",
+					"172.17.0.1:36296",
+					"172.18.0.1:36296",
+					"172.19.0.1:36296"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:49:13.842342868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         910957886262895,
+				"StableID":   "nYoryVKa7811CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06c727e305f7e7195d99e93233d9a2803b52c748c7db417b099e3f454d0b882d",
+				"DiscoKey":   "discokey:14c36ce284e0e02b05e63ebbee8f2fb6f07ef6a60c4da0be42e83190d661b813",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42643",
+					"10.65.0.27:42643",
+					"172.17.0.1:42643",
+					"172.18.0.1:42643",
+					"172.19.0.1:42643"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:49:14.386907943Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         166908153790418,
+				"StableID":   "ny821sPbJ211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f27617a6dc635a2c1af4604dc3c73509e67243d2840bd025f478c00c6bfce6d",
+				"DiscoKey":   "discokey:2e07fcc0a089360338b3ffa93ddf8b1ed73293d18b2222e401e85eee1b046e41",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38488",
+					"10.65.0.27:38488",
+					"172.17.0.1:38488",
+					"172.18.0.1:38488",
+					"172.19.0.1:38488"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:49:14.927640924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1502109014378542,
+				"StableID":   "nfZTsgrJjC11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec7db7e4eb604d75b66d69733a1a067cf9536593fd857760d54d968d90236f48",
+				"DiscoKey":   "discokey:ec8de26619283d20beb293de62cbae66574f9906e68e99ddaac047cf647eba1b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60046",
+					"10.65.0.27:60046",
+					"172.17.0.1:60046",
+					"172.18.0.1:60046",
+					"172.19.0.1:60046"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:49:15.468825067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2203141394618887,
+				"StableID":   "nLfsjjnoCJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3453c7e18a404cfddd1cfdbe77685328d109bcfba27d638f26c11c98e95a737a",
+				"DiscoKey":   "discokey:b669fb349e410b95c45ab36e77a66935fd7b31f810e27de1fc3a199049775d51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35888",
+					"10.65.0.27:35888",
+					"172.17.0.1:35888",
+					"172.18.0.1:35888",
+					"172.19.0.1:35888"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:49:16.022684649Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7574053010769617,
+				"StableID":   "nEZGShXJ9221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0f521e4ca342b6e1a782c54783b263369fcc7f9f5778b126706efac0f5acc74f",
+				"KeyExpiry":  "2026-11-08T21:49:16Z",
+				"DiscoKey":   "discokey:d37d6a768804229a0d54df49ddd6466e49bca0b7932f93a405b1a5666dbce57f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38301",
+					"10.65.0.27:38301",
+					"172.17.0.1:38301",
+					"172.18.0.1:38301",
+					"172.19.0.1:38301"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:49:16.556149353Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         940518938194514,
+				"StableID":   "nPVvuaqxL811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:dc757d461633aa1d469b5f88a14871937df499b7d1561ea7248a9c5db869f052",
+				"KeyExpiry":  "2026-11-08T21:49:17Z",
+				"DiscoKey":   "discokey:ac001a108a7d11c3e4d6ae6ecea6c37f60bf445e6d9ff5096d0303e611b2e865",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59722",
+					"10.65.0.27:59722",
+					"172.17.0.1:59722",
+					"172.18.0.1:59722",
+					"172.19.0.1:59722"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:49:17.098234886Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1433377374142785,
+				"StableID":   "nprbBoPBCC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9464d26862c21ab5a714719dde84fac8cb7b4a8a523a7d78c4fa69971fea376f",
+				"KeyExpiry":  "2026-11-08T21:49:17Z",
+				"DiscoKey":   "discokey:561cf4cc2a53e2dd29e6f24814dde8c32b70a8d7ed1af41d9c32d7f37ccac507",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59993",
+					"10.65.0.27:59993",
+					"172.17.0.1:59993",
+					"172.18.0.1:59993",
+					"172.19.0.1:59993"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:49:17.638950635Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4327983417894694": {
+				"ID":          4327983417894694,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1433377374142785,
+				"StableID":   "nprbBoPBCC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9464d26862c21ab5a714719dde84fac8cb7b4a8a523a7d78c4fa69971fea376f",
+				"KeyExpiry":  "2026-11-08T21:49:17Z",
+				"DiscoKey":   "discokey:561cf4cc2a53e2dd29e6f24814dde8c32b70a8d7ed1af41d9c32d7f37ccac507",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59993",
+					"10.65.0.27:59993",
+					"172.17.0.1:59993",
+					"172.18.0.1:59993",
+					"172.19.0.1:59993"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:49:17.638950635Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9464d26862c21ab5a714719dde84fac8cb7b4a8a523a7d78c4fa69971fea376f",
+			"MachineKey": "mkey:171600eaa45b2d7712ab63af7bef99c6eb27eea13617a312b0812a35f1832e12",
+			"Peers": [{
+				"ID":         2595605725024588,
+				"StableID":   "nXLogLAZGM11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:14a115699713e890c9ebfd1debe10c2955f916f5f2f9722fe5f1feb4b811e252",
+				"DiscoKey":   "discokey:fd34e073defe44541d380b4c33a1d77cc1221e9757157787927dcd821a3e2219",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40696",
+					"10.65.0.27:40696",
+					"172.17.0.1:40696",
+					"172.18.0.1:40696",
+					"172.19.0.1:40696"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:49:10.064815739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7042396524582791,
+				"StableID":   "n43mKGpWzw11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38ae018d24adab03d2e46a464f480279ede3ae5bd252e131de5c4b7fbea8dd70",
+				"DiscoKey":   "discokey:c4fdd0fed0b5a4fdeab03a2ce1d74f4edcafa739f929eb014e34a6032abc8224",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:38715",
+					"10.65.0.27:38715",
+					"172.17.0.1:38715",
+					"172.18.0.1:38715",
+					"172.19.0.1:38715"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:49:10.609682656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1183280254117873,
+				"StableID":   "nUG17RmuEA11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4390c15f3125750f4a9e2b22a7d7806e6199c382802003a2cdb35bc19ae9a32e",
+				"DiscoKey":   "discokey:e36de856145dd7e2754fe0322eda7879310f63a1b2c72df0152bb076f611f47b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:47272",
+					"10.65.0.27:47272",
+					"172.17.0.1:47272",
+					"172.18.0.1:47272",
+					"172.19.0.1:47272"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:49:11.140917354Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2218056842991332,
+				"StableID":   "nXNWqLbZKJ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28f70453d3c468887468d1258c09e6468800d017111b99af7b569a2314418a2d",
+				"DiscoKey":   "discokey:4ef6a887f47edfdc701745fce2faedbfff9ade73f331d563045031554c14f85d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35181",
+					"10.65.0.27:35181",
+					"172.17.0.1:35181",
+					"172.18.0.1:35181",
+					"172.19.0.1:35181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:49:11.683535327Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         746689446529713,
+				"StableID":   "nEdNUQGBq611CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab2e486bb8a6fdb92739451606d15232bbf6535af74e1a91b9b07d094835822b",
+				"DiscoKey":   "discokey:2025685b7907dbd1e900b1baeace89931dc193dae2d0ba614cf12cb11d8eb66c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41671",
+					"10.65.0.27:41671",
+					"172.17.0.1:41671",
+					"172.18.0.1:41671",
+					"172.19.0.1:41671"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:49:12.233898047Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4327983417894694,
+				"StableID":   "n5A5AZn9oa11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6d3ae4d06183ea1bead68acad8a90eb516dfac343f0a82b7365c2cec87f8e64",
+				"DiscoKey":   "discokey:26ee058c7dbc87ed44cfcae9d88a8205f9548b05e5504284eda15234f79f4e78",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54900",
+					"10.65.0.27:54900",
+					"172.17.0.1:54900",
+					"172.18.0.1:54900",
+					"172.19.0.1:54900"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:49:12.774546426Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8662887182080140,
+				"StableID":   "nwJncgMSeA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:05d473005abe8dc116ae56f5d1fdf629f0847c243d316d7cd9d41d96d561ed25",
+				"DiscoKey":   "discokey:5e6c3b8fa777c273041cd28af21a4e8c29710cb73d507da21713cb0418381a24",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52368",
+					"10.65.0.27:52368",
+					"172.17.0.1:52368",
+					"172.18.0.1:52368",
+					"172.19.0.1:52368"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:49:13.302903115Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         431529393613490,
+				"StableID":   "nHz1pdYSN411CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec7d6d70b11cba72fd0940dfb8a2d9bea86790409c782b33368bb9ec6471f550",
+				"DiscoKey":   "discokey:2a26fcb59058f5b52912afaf9422cfee53c0e566d2cd28838b5db04e9b0ad038",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36296",
+					"10.65.0.27:36296",
+					"172.17.0.1:36296",
+					"172.18.0.1:36296",
+					"172.19.0.1:36296"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:49:13.842342868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         910957886262895,
+				"StableID":   "nYoryVKa7811CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06c727e305f7e7195d99e93233d9a2803b52c748c7db417b099e3f454d0b882d",
+				"DiscoKey":   "discokey:14c36ce284e0e02b05e63ebbee8f2fb6f07ef6a60c4da0be42e83190d661b813",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42643",
+					"10.65.0.27:42643",
+					"172.17.0.1:42643",
+					"172.18.0.1:42643",
+					"172.19.0.1:42643"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:49:14.386907943Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         166908153790418,
+				"StableID":   "ny821sPbJ211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f27617a6dc635a2c1af4604dc3c73509e67243d2840bd025f478c00c6bfce6d",
+				"DiscoKey":   "discokey:2e07fcc0a089360338b3ffa93ddf8b1ed73293d18b2222e401e85eee1b046e41",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38488",
+					"10.65.0.27:38488",
+					"172.17.0.1:38488",
+					"172.18.0.1:38488",
+					"172.19.0.1:38488"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:49:14.927640924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1502109014378542,
+				"StableID":   "nfZTsgrJjC11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec7db7e4eb604d75b66d69733a1a067cf9536593fd857760d54d968d90236f48",
+				"DiscoKey":   "discokey:ec8de26619283d20beb293de62cbae66574f9906e68e99ddaac047cf647eba1b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60046",
+					"10.65.0.27:60046",
+					"172.17.0.1:60046",
+					"172.18.0.1:60046",
+					"172.19.0.1:60046"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:49:15.468825067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2203141394618887,
+				"StableID":   "nLfsjjnoCJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3453c7e18a404cfddd1cfdbe77685328d109bcfba27d638f26c11c98e95a737a",
+				"DiscoKey":   "discokey:b669fb349e410b95c45ab36e77a66935fd7b31f810e27de1fc3a199049775d51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35888",
+					"10.65.0.27:35888",
+					"172.17.0.1:35888",
+					"172.18.0.1:35888",
+					"172.19.0.1:35888"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:49:16.022684649Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7574053010769617,
+				"StableID":   "nEZGShXJ9221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0f521e4ca342b6e1a782c54783b263369fcc7f9f5778b126706efac0f5acc74f",
+				"KeyExpiry":  "2026-11-08T21:49:16Z",
+				"DiscoKey":   "discokey:d37d6a768804229a0d54df49ddd6466e49bca0b7932f93a405b1a5666dbce57f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38301",
+					"10.65.0.27:38301",
+					"172.17.0.1:38301",
+					"172.18.0.1:38301",
+					"172.19.0.1:38301"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:49:16.556149353Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         940518938194514,
+				"StableID":   "nPVvuaqxL811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:dc757d461633aa1d469b5f88a14871937df499b7d1561ea7248a9c5db869f052",
+				"KeyExpiry":  "2026-11-08T21:49:17Z",
+				"DiscoKey":   "discokey:ac001a108a7d11c3e4d6ae6ecea6c37f60bf445e6d9ff5096d0303e611b2e865",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59722",
+					"10.65.0.27:59722",
+					"172.17.0.1:59722",
+					"172.18.0.1:59722",
+					"172.19.0.1:59722"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:49:17.098234886Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1183280254117873,
+				"StableID":   "nUG17RmuEA11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1183280254117873,
+				"Key":        "nodekey:4390c15f3125750f4a9e2b22a7d7806e6199c382802003a2cdb35bc19ae9a32e",
+				"DiscoKey":   "discokey:e36de856145dd7e2754fe0322eda7879310f63a1b2c72df0152bb076f611f47b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:47272",
+					"10.65.0.27:47272",
+					"172.17.0.1:47272",
+					"172.18.0.1:47272",
+					"172.19.0.1:47272"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:49:11.140917354Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4390c15f3125750f4a9e2b22a7d7806e6199c382802003a2cdb35bc19ae9a32e",
+			"MachineKey": "mkey:003c4a519a1cbc39af21b3fd44ab9e343d3bcc9df82a8bd400a0e0ec1288302d",
+			"Peers": [{
+				"ID":         2595605725024588,
+				"StableID":   "nXLogLAZGM11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:14a115699713e890c9ebfd1debe10c2955f916f5f2f9722fe5f1feb4b811e252",
+				"DiscoKey":   "discokey:fd34e073defe44541d380b4c33a1d77cc1221e9757157787927dcd821a3e2219",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40696",
+					"10.65.0.27:40696",
+					"172.17.0.1:40696",
+					"172.18.0.1:40696",
+					"172.19.0.1:40696"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:49:10.064815739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7042396524582791,
+				"StableID":   "n43mKGpWzw11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38ae018d24adab03d2e46a464f480279ede3ae5bd252e131de5c4b7fbea8dd70",
+				"DiscoKey":   "discokey:c4fdd0fed0b5a4fdeab03a2ce1d74f4edcafa739f929eb014e34a6032abc8224",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:38715",
+					"10.65.0.27:38715",
+					"172.17.0.1:38715",
+					"172.18.0.1:38715",
+					"172.19.0.1:38715"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:49:10.609682656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2218056842991332,
+				"StableID":   "nXNWqLbZKJ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28f70453d3c468887468d1258c09e6468800d017111b99af7b569a2314418a2d",
+				"DiscoKey":   "discokey:4ef6a887f47edfdc701745fce2faedbfff9ade73f331d563045031554c14f85d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35181",
+					"10.65.0.27:35181",
+					"172.17.0.1:35181",
+					"172.18.0.1:35181",
+					"172.19.0.1:35181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:49:11.683535327Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         746689446529713,
+				"StableID":   "nEdNUQGBq611CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab2e486bb8a6fdb92739451606d15232bbf6535af74e1a91b9b07d094835822b",
+				"DiscoKey":   "discokey:2025685b7907dbd1e900b1baeace89931dc193dae2d0ba614cf12cb11d8eb66c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41671",
+					"10.65.0.27:41671",
+					"172.17.0.1:41671",
+					"172.18.0.1:41671",
+					"172.19.0.1:41671"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:49:12.233898047Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4327983417894694,
+				"StableID":   "n5A5AZn9oa11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6d3ae4d06183ea1bead68acad8a90eb516dfac343f0a82b7365c2cec87f8e64",
+				"DiscoKey":   "discokey:26ee058c7dbc87ed44cfcae9d88a8205f9548b05e5504284eda15234f79f4e78",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54900",
+					"10.65.0.27:54900",
+					"172.17.0.1:54900",
+					"172.18.0.1:54900",
+					"172.19.0.1:54900"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:49:12.774546426Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8662887182080140,
+				"StableID":   "nwJncgMSeA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:05d473005abe8dc116ae56f5d1fdf629f0847c243d316d7cd9d41d96d561ed25",
+				"DiscoKey":   "discokey:5e6c3b8fa777c273041cd28af21a4e8c29710cb73d507da21713cb0418381a24",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52368",
+					"10.65.0.27:52368",
+					"172.17.0.1:52368",
+					"172.18.0.1:52368",
+					"172.19.0.1:52368"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:49:13.302903115Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         431529393613490,
+				"StableID":   "nHz1pdYSN411CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec7d6d70b11cba72fd0940dfb8a2d9bea86790409c782b33368bb9ec6471f550",
+				"DiscoKey":   "discokey:2a26fcb59058f5b52912afaf9422cfee53c0e566d2cd28838b5db04e9b0ad038",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36296",
+					"10.65.0.27:36296",
+					"172.17.0.1:36296",
+					"172.18.0.1:36296",
+					"172.19.0.1:36296"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:49:13.842342868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         910957886262895,
+				"StableID":   "nYoryVKa7811CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06c727e305f7e7195d99e93233d9a2803b52c748c7db417b099e3f454d0b882d",
+				"DiscoKey":   "discokey:14c36ce284e0e02b05e63ebbee8f2fb6f07ef6a60c4da0be42e83190d661b813",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42643",
+					"10.65.0.27:42643",
+					"172.17.0.1:42643",
+					"172.18.0.1:42643",
+					"172.19.0.1:42643"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:49:14.386907943Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         166908153790418,
+				"StableID":   "ny821sPbJ211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f27617a6dc635a2c1af4604dc3c73509e67243d2840bd025f478c00c6bfce6d",
+				"DiscoKey":   "discokey:2e07fcc0a089360338b3ffa93ddf8b1ed73293d18b2222e401e85eee1b046e41",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38488",
+					"10.65.0.27:38488",
+					"172.17.0.1:38488",
+					"172.18.0.1:38488",
+					"172.19.0.1:38488"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:49:14.927640924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1502109014378542,
+				"StableID":   "nfZTsgrJjC11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec7db7e4eb604d75b66d69733a1a067cf9536593fd857760d54d968d90236f48",
+				"DiscoKey":   "discokey:ec8de26619283d20beb293de62cbae66574f9906e68e99ddaac047cf647eba1b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60046",
+					"10.65.0.27:60046",
+					"172.17.0.1:60046",
+					"172.18.0.1:60046",
+					"172.19.0.1:60046"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:49:15.468825067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2203141394618887,
+				"StableID":   "nLfsjjnoCJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3453c7e18a404cfddd1cfdbe77685328d109bcfba27d638f26c11c98e95a737a",
+				"DiscoKey":   "discokey:b669fb349e410b95c45ab36e77a66935fd7b31f810e27de1fc3a199049775d51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35888",
+					"10.65.0.27:35888",
+					"172.17.0.1:35888",
+					"172.18.0.1:35888",
+					"172.19.0.1:35888"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:49:16.022684649Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7574053010769617,
+				"StableID":   "nEZGShXJ9221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0f521e4ca342b6e1a782c54783b263369fcc7f9f5778b126706efac0f5acc74f",
+				"KeyExpiry":  "2026-11-08T21:49:16Z",
+				"DiscoKey":   "discokey:d37d6a768804229a0d54df49ddd6466e49bca0b7932f93a405b1a5666dbce57f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38301",
+					"10.65.0.27:38301",
+					"172.17.0.1:38301",
+					"172.18.0.1:38301",
+					"172.19.0.1:38301"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:49:16.556149353Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         940518938194514,
+				"StableID":   "nPVvuaqxL811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:dc757d461633aa1d469b5f88a14871937df499b7d1561ea7248a9c5db869f052",
+				"KeyExpiry":  "2026-11-08T21:49:17Z",
+				"DiscoKey":   "discokey:ac001a108a7d11c3e4d6ae6ecea6c37f60bf445e6d9ff5096d0303e611b2e865",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59722",
+					"10.65.0.27:59722",
+					"172.17.0.1:59722",
+					"172.18.0.1:59722",
+					"172.19.0.1:59722"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:49:17.098234886Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1433377374142785,
+				"StableID":   "nprbBoPBCC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9464d26862c21ab5a714719dde84fac8cb7b4a8a523a7d78c4fa69971fea376f",
+				"KeyExpiry":  "2026-11-08T21:49:17Z",
+				"DiscoKey":   "discokey:561cf4cc2a53e2dd29e6f24814dde8c32b70a8d7ed1af41d9c32d7f37ccac507",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59993",
+					"10.65.0.27:59993",
+					"172.17.0.1:59993",
+					"172.18.0.1:59993",
+					"172.19.0.1:59993"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:49:17.638950635Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1183280254117873": {
+				"ID":          1183280254117873,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         431529393613490,
+				"StableID":   "nHz1pdYSN411CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       431529393613490,
+				"Key":        "nodekey:ec7d6d70b11cba72fd0940dfb8a2d9bea86790409c782b33368bb9ec6471f550",
+				"DiscoKey":   "discokey:2a26fcb59058f5b52912afaf9422cfee53c0e566d2cd28838b5db04e9b0ad038",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36296",
+					"10.65.0.27:36296",
+					"172.17.0.1:36296",
+					"172.18.0.1:36296",
+					"172.19.0.1:36296"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:49:13.842342868Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ec7d6d70b11cba72fd0940dfb8a2d9bea86790409c782b33368bb9ec6471f550",
+			"MachineKey": "mkey:be1ef4e297c710d89c399953baa37e4a1a6e2213080f658b3fdb17a4b258a71b",
+			"Peers": [{
+				"ID":         2595605725024588,
+				"StableID":   "nXLogLAZGM11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:14a115699713e890c9ebfd1debe10c2955f916f5f2f9722fe5f1feb4b811e252",
+				"DiscoKey":   "discokey:fd34e073defe44541d380b4c33a1d77cc1221e9757157787927dcd821a3e2219",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40696",
+					"10.65.0.27:40696",
+					"172.17.0.1:40696",
+					"172.18.0.1:40696",
+					"172.19.0.1:40696"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:49:10.064815739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7042396524582791,
+				"StableID":   "n43mKGpWzw11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38ae018d24adab03d2e46a464f480279ede3ae5bd252e131de5c4b7fbea8dd70",
+				"DiscoKey":   "discokey:c4fdd0fed0b5a4fdeab03a2ce1d74f4edcafa739f929eb014e34a6032abc8224",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:38715",
+					"10.65.0.27:38715",
+					"172.17.0.1:38715",
+					"172.18.0.1:38715",
+					"172.19.0.1:38715"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:49:10.609682656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1183280254117873,
+				"StableID":   "nUG17RmuEA11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4390c15f3125750f4a9e2b22a7d7806e6199c382802003a2cdb35bc19ae9a32e",
+				"DiscoKey":   "discokey:e36de856145dd7e2754fe0322eda7879310f63a1b2c72df0152bb076f611f47b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:47272",
+					"10.65.0.27:47272",
+					"172.17.0.1:47272",
+					"172.18.0.1:47272",
+					"172.19.0.1:47272"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:49:11.140917354Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2218056842991332,
+				"StableID":   "nXNWqLbZKJ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28f70453d3c468887468d1258c09e6468800d017111b99af7b569a2314418a2d",
+				"DiscoKey":   "discokey:4ef6a887f47edfdc701745fce2faedbfff9ade73f331d563045031554c14f85d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35181",
+					"10.65.0.27:35181",
+					"172.17.0.1:35181",
+					"172.18.0.1:35181",
+					"172.19.0.1:35181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:49:11.683535327Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         746689446529713,
+				"StableID":   "nEdNUQGBq611CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab2e486bb8a6fdb92739451606d15232bbf6535af74e1a91b9b07d094835822b",
+				"DiscoKey":   "discokey:2025685b7907dbd1e900b1baeace89931dc193dae2d0ba614cf12cb11d8eb66c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41671",
+					"10.65.0.27:41671",
+					"172.17.0.1:41671",
+					"172.18.0.1:41671",
+					"172.19.0.1:41671"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:49:12.233898047Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4327983417894694,
+				"StableID":   "n5A5AZn9oa11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6d3ae4d06183ea1bead68acad8a90eb516dfac343f0a82b7365c2cec87f8e64",
+				"DiscoKey":   "discokey:26ee058c7dbc87ed44cfcae9d88a8205f9548b05e5504284eda15234f79f4e78",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54900",
+					"10.65.0.27:54900",
+					"172.17.0.1:54900",
+					"172.18.0.1:54900",
+					"172.19.0.1:54900"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:49:12.774546426Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8662887182080140,
+				"StableID":   "nwJncgMSeA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:05d473005abe8dc116ae56f5d1fdf629f0847c243d316d7cd9d41d96d561ed25",
+				"DiscoKey":   "discokey:5e6c3b8fa777c273041cd28af21a4e8c29710cb73d507da21713cb0418381a24",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52368",
+					"10.65.0.27:52368",
+					"172.17.0.1:52368",
+					"172.18.0.1:52368",
+					"172.19.0.1:52368"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:49:13.302903115Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         910957886262895,
+				"StableID":   "nYoryVKa7811CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06c727e305f7e7195d99e93233d9a2803b52c748c7db417b099e3f454d0b882d",
+				"DiscoKey":   "discokey:14c36ce284e0e02b05e63ebbee8f2fb6f07ef6a60c4da0be42e83190d661b813",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42643",
+					"10.65.0.27:42643",
+					"172.17.0.1:42643",
+					"172.18.0.1:42643",
+					"172.19.0.1:42643"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:49:14.386907943Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         166908153790418,
+				"StableID":   "ny821sPbJ211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f27617a6dc635a2c1af4604dc3c73509e67243d2840bd025f478c00c6bfce6d",
+				"DiscoKey":   "discokey:2e07fcc0a089360338b3ffa93ddf8b1ed73293d18b2222e401e85eee1b046e41",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38488",
+					"10.65.0.27:38488",
+					"172.17.0.1:38488",
+					"172.18.0.1:38488",
+					"172.19.0.1:38488"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:49:14.927640924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1502109014378542,
+				"StableID":   "nfZTsgrJjC11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec7db7e4eb604d75b66d69733a1a067cf9536593fd857760d54d968d90236f48",
+				"DiscoKey":   "discokey:ec8de26619283d20beb293de62cbae66574f9906e68e99ddaac047cf647eba1b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60046",
+					"10.65.0.27:60046",
+					"172.17.0.1:60046",
+					"172.18.0.1:60046",
+					"172.19.0.1:60046"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:49:15.468825067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2203141394618887,
+				"StableID":   "nLfsjjnoCJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3453c7e18a404cfddd1cfdbe77685328d109bcfba27d638f26c11c98e95a737a",
+				"DiscoKey":   "discokey:b669fb349e410b95c45ab36e77a66935fd7b31f810e27de1fc3a199049775d51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35888",
+					"10.65.0.27:35888",
+					"172.17.0.1:35888",
+					"172.18.0.1:35888",
+					"172.19.0.1:35888"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:49:16.022684649Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7574053010769617,
+				"StableID":   "nEZGShXJ9221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0f521e4ca342b6e1a782c54783b263369fcc7f9f5778b126706efac0f5acc74f",
+				"KeyExpiry":  "2026-11-08T21:49:16Z",
+				"DiscoKey":   "discokey:d37d6a768804229a0d54df49ddd6466e49bca0b7932f93a405b1a5666dbce57f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38301",
+					"10.65.0.27:38301",
+					"172.17.0.1:38301",
+					"172.18.0.1:38301",
+					"172.19.0.1:38301"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:49:16.556149353Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         940518938194514,
+				"StableID":   "nPVvuaqxL811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:dc757d461633aa1d469b5f88a14871937df499b7d1561ea7248a9c5db869f052",
+				"KeyExpiry":  "2026-11-08T21:49:17Z",
+				"DiscoKey":   "discokey:ac001a108a7d11c3e4d6ae6ecea6c37f60bf445e6d9ff5096d0303e611b2e865",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59722",
+					"10.65.0.27:59722",
+					"172.17.0.1:59722",
+					"172.18.0.1:59722",
+					"172.19.0.1:59722"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:49:17.098234886Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1433377374142785,
+				"StableID":   "nprbBoPBCC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9464d26862c21ab5a714719dde84fac8cb7b4a8a523a7d78c4fa69971fea376f",
+				"KeyExpiry":  "2026-11-08T21:49:17Z",
+				"DiscoKey":   "discokey:561cf4cc2a53e2dd29e6f24814dde8c32b70a8d7ed1af41d9c32d7f37ccac507",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59993",
+					"10.65.0.27:59993",
+					"172.17.0.1:59993",
+					"172.18.0.1:59993",
+					"172.19.0.1:59993"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:49:17.638950635Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "431529393613490": {
+				"ID":          431529393613490,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7574053010769617,
+				"StableID":   "nEZGShXJ9221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0f521e4ca342b6e1a782c54783b263369fcc7f9f5778b126706efac0f5acc74f",
+				"KeyExpiry":  "2026-11-08T21:49:16Z",
+				"DiscoKey":   "discokey:d37d6a768804229a0d54df49ddd6466e49bca0b7932f93a405b1a5666dbce57f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38301",
+					"10.65.0.27:38301",
+					"172.17.0.1:38301",
+					"172.18.0.1:38301",
+					"172.19.0.1:38301"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:49:16.556149353Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0f521e4ca342b6e1a782c54783b263369fcc7f9f5778b126706efac0f5acc74f",
+			"MachineKey": "mkey:5de9caa77036f42abd960ab1fb7903e29757ff001a230b09ff2fca35eb554f71",
+			"Peers": [{
+				"ID":         2595605725024588,
+				"StableID":   "nXLogLAZGM11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:14a115699713e890c9ebfd1debe10c2955f916f5f2f9722fe5f1feb4b811e252",
+				"DiscoKey":   "discokey:fd34e073defe44541d380b4c33a1d77cc1221e9757157787927dcd821a3e2219",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40696",
+					"10.65.0.27:40696",
+					"172.17.0.1:40696",
+					"172.18.0.1:40696",
+					"172.19.0.1:40696"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:49:10.064815739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7042396524582791,
+				"StableID":   "n43mKGpWzw11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38ae018d24adab03d2e46a464f480279ede3ae5bd252e131de5c4b7fbea8dd70",
+				"DiscoKey":   "discokey:c4fdd0fed0b5a4fdeab03a2ce1d74f4edcafa739f929eb014e34a6032abc8224",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:38715",
+					"10.65.0.27:38715",
+					"172.17.0.1:38715",
+					"172.18.0.1:38715",
+					"172.19.0.1:38715"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:49:10.609682656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1183280254117873,
+				"StableID":   "nUG17RmuEA11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4390c15f3125750f4a9e2b22a7d7806e6199c382802003a2cdb35bc19ae9a32e",
+				"DiscoKey":   "discokey:e36de856145dd7e2754fe0322eda7879310f63a1b2c72df0152bb076f611f47b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:47272",
+					"10.65.0.27:47272",
+					"172.17.0.1:47272",
+					"172.18.0.1:47272",
+					"172.19.0.1:47272"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:49:11.140917354Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2218056842991332,
+				"StableID":   "nXNWqLbZKJ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28f70453d3c468887468d1258c09e6468800d017111b99af7b569a2314418a2d",
+				"DiscoKey":   "discokey:4ef6a887f47edfdc701745fce2faedbfff9ade73f331d563045031554c14f85d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35181",
+					"10.65.0.27:35181",
+					"172.17.0.1:35181",
+					"172.18.0.1:35181",
+					"172.19.0.1:35181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:49:11.683535327Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         746689446529713,
+				"StableID":   "nEdNUQGBq611CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab2e486bb8a6fdb92739451606d15232bbf6535af74e1a91b9b07d094835822b",
+				"DiscoKey":   "discokey:2025685b7907dbd1e900b1baeace89931dc193dae2d0ba614cf12cb11d8eb66c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41671",
+					"10.65.0.27:41671",
+					"172.17.0.1:41671",
+					"172.18.0.1:41671",
+					"172.19.0.1:41671"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:49:12.233898047Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4327983417894694,
+				"StableID":   "n5A5AZn9oa11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6d3ae4d06183ea1bead68acad8a90eb516dfac343f0a82b7365c2cec87f8e64",
+				"DiscoKey":   "discokey:26ee058c7dbc87ed44cfcae9d88a8205f9548b05e5504284eda15234f79f4e78",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54900",
+					"10.65.0.27:54900",
+					"172.17.0.1:54900",
+					"172.18.0.1:54900",
+					"172.19.0.1:54900"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:49:12.774546426Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8662887182080140,
+				"StableID":   "nwJncgMSeA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:05d473005abe8dc116ae56f5d1fdf629f0847c243d316d7cd9d41d96d561ed25",
+				"DiscoKey":   "discokey:5e6c3b8fa777c273041cd28af21a4e8c29710cb73d507da21713cb0418381a24",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52368",
+					"10.65.0.27:52368",
+					"172.17.0.1:52368",
+					"172.18.0.1:52368",
+					"172.19.0.1:52368"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:49:13.302903115Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         431529393613490,
+				"StableID":   "nHz1pdYSN411CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec7d6d70b11cba72fd0940dfb8a2d9bea86790409c782b33368bb9ec6471f550",
+				"DiscoKey":   "discokey:2a26fcb59058f5b52912afaf9422cfee53c0e566d2cd28838b5db04e9b0ad038",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36296",
+					"10.65.0.27:36296",
+					"172.17.0.1:36296",
+					"172.18.0.1:36296",
+					"172.19.0.1:36296"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:49:13.842342868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         910957886262895,
+				"StableID":   "nYoryVKa7811CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06c727e305f7e7195d99e93233d9a2803b52c748c7db417b099e3f454d0b882d",
+				"DiscoKey":   "discokey:14c36ce284e0e02b05e63ebbee8f2fb6f07ef6a60c4da0be42e83190d661b813",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42643",
+					"10.65.0.27:42643",
+					"172.17.0.1:42643",
+					"172.18.0.1:42643",
+					"172.19.0.1:42643"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:49:14.386907943Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         166908153790418,
+				"StableID":   "ny821sPbJ211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f27617a6dc635a2c1af4604dc3c73509e67243d2840bd025f478c00c6bfce6d",
+				"DiscoKey":   "discokey:2e07fcc0a089360338b3ffa93ddf8b1ed73293d18b2222e401e85eee1b046e41",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38488",
+					"10.65.0.27:38488",
+					"172.17.0.1:38488",
+					"172.18.0.1:38488",
+					"172.19.0.1:38488"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:49:14.927640924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1502109014378542,
+				"StableID":   "nfZTsgrJjC11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec7db7e4eb604d75b66d69733a1a067cf9536593fd857760d54d968d90236f48",
+				"DiscoKey":   "discokey:ec8de26619283d20beb293de62cbae66574f9906e68e99ddaac047cf647eba1b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60046",
+					"10.65.0.27:60046",
+					"172.17.0.1:60046",
+					"172.18.0.1:60046",
+					"172.19.0.1:60046"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:49:15.468825067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2203141394618887,
+				"StableID":   "nLfsjjnoCJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3453c7e18a404cfddd1cfdbe77685328d109bcfba27d638f26c11c98e95a737a",
+				"DiscoKey":   "discokey:b669fb349e410b95c45ab36e77a66935fd7b31f810e27de1fc3a199049775d51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35888",
+					"10.65.0.27:35888",
+					"172.17.0.1:35888",
+					"172.18.0.1:35888",
+					"172.19.0.1:35888"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:49:16.022684649Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         940518938194514,
+				"StableID":   "nPVvuaqxL811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:dc757d461633aa1d469b5f88a14871937df499b7d1561ea7248a9c5db869f052",
+				"KeyExpiry":  "2026-11-08T21:49:17Z",
+				"DiscoKey":   "discokey:ac001a108a7d11c3e4d6ae6ecea6c37f60bf445e6d9ff5096d0303e611b2e865",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59722",
+					"10.65.0.27:59722",
+					"172.17.0.1:59722",
+					"172.18.0.1:59722",
+					"172.19.0.1:59722"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:49:17.098234886Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1433377374142785,
+				"StableID":   "nprbBoPBCC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9464d26862c21ab5a714719dde84fac8cb7b4a8a523a7d78c4fa69971fea376f",
+				"KeyExpiry":  "2026-11-08T21:49:17Z",
+				"DiscoKey":   "discokey:561cf4cc2a53e2dd29e6f24814dde8c32b70a8d7ed1af41d9c32d7f37ccac507",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59993",
+					"10.65.0.27:59993",
+					"172.17.0.1:59993",
+					"172.18.0.1:59993",
+					"172.19.0.1:59993"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:49:17.638950635Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1502109014378542,
+				"StableID":   "nfZTsgrJjC11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1502109014378542,
+				"Key":        "nodekey:ec7db7e4eb604d75b66d69733a1a067cf9536593fd857760d54d968d90236f48",
+				"DiscoKey":   "discokey:ec8de26619283d20beb293de62cbae66574f9906e68e99ddaac047cf647eba1b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60046",
+					"10.65.0.27:60046",
+					"172.17.0.1:60046",
+					"172.18.0.1:60046",
+					"172.19.0.1:60046"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:49:15.468825067Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ec7db7e4eb604d75b66d69733a1a067cf9536593fd857760d54d968d90236f48",
+			"MachineKey": "mkey:2041d174935ce9e692567416aeef020bb16038ce73d3baf892dc6e0a21227b75",
+			"Peers": [{
+				"ID":         2595605725024588,
+				"StableID":   "nXLogLAZGM11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:14a115699713e890c9ebfd1debe10c2955f916f5f2f9722fe5f1feb4b811e252",
+				"DiscoKey":   "discokey:fd34e073defe44541d380b4c33a1d77cc1221e9757157787927dcd821a3e2219",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40696",
+					"10.65.0.27:40696",
+					"172.17.0.1:40696",
+					"172.18.0.1:40696",
+					"172.19.0.1:40696"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:49:10.064815739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7042396524582791,
+				"StableID":   "n43mKGpWzw11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38ae018d24adab03d2e46a464f480279ede3ae5bd252e131de5c4b7fbea8dd70",
+				"DiscoKey":   "discokey:c4fdd0fed0b5a4fdeab03a2ce1d74f4edcafa739f929eb014e34a6032abc8224",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:38715",
+					"10.65.0.27:38715",
+					"172.17.0.1:38715",
+					"172.18.0.1:38715",
+					"172.19.0.1:38715"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:49:10.609682656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1183280254117873,
+				"StableID":   "nUG17RmuEA11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4390c15f3125750f4a9e2b22a7d7806e6199c382802003a2cdb35bc19ae9a32e",
+				"DiscoKey":   "discokey:e36de856145dd7e2754fe0322eda7879310f63a1b2c72df0152bb076f611f47b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:47272",
+					"10.65.0.27:47272",
+					"172.17.0.1:47272",
+					"172.18.0.1:47272",
+					"172.19.0.1:47272"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:49:11.140917354Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2218056842991332,
+				"StableID":   "nXNWqLbZKJ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28f70453d3c468887468d1258c09e6468800d017111b99af7b569a2314418a2d",
+				"DiscoKey":   "discokey:4ef6a887f47edfdc701745fce2faedbfff9ade73f331d563045031554c14f85d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35181",
+					"10.65.0.27:35181",
+					"172.17.0.1:35181",
+					"172.18.0.1:35181",
+					"172.19.0.1:35181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:49:11.683535327Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         746689446529713,
+				"StableID":   "nEdNUQGBq611CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab2e486bb8a6fdb92739451606d15232bbf6535af74e1a91b9b07d094835822b",
+				"DiscoKey":   "discokey:2025685b7907dbd1e900b1baeace89931dc193dae2d0ba614cf12cb11d8eb66c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41671",
+					"10.65.0.27:41671",
+					"172.17.0.1:41671",
+					"172.18.0.1:41671",
+					"172.19.0.1:41671"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:49:12.233898047Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4327983417894694,
+				"StableID":   "n5A5AZn9oa11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6d3ae4d06183ea1bead68acad8a90eb516dfac343f0a82b7365c2cec87f8e64",
+				"DiscoKey":   "discokey:26ee058c7dbc87ed44cfcae9d88a8205f9548b05e5504284eda15234f79f4e78",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54900",
+					"10.65.0.27:54900",
+					"172.17.0.1:54900",
+					"172.18.0.1:54900",
+					"172.19.0.1:54900"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:49:12.774546426Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8662887182080140,
+				"StableID":   "nwJncgMSeA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:05d473005abe8dc116ae56f5d1fdf629f0847c243d316d7cd9d41d96d561ed25",
+				"DiscoKey":   "discokey:5e6c3b8fa777c273041cd28af21a4e8c29710cb73d507da21713cb0418381a24",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52368",
+					"10.65.0.27:52368",
+					"172.17.0.1:52368",
+					"172.18.0.1:52368",
+					"172.19.0.1:52368"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:49:13.302903115Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         431529393613490,
+				"StableID":   "nHz1pdYSN411CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec7d6d70b11cba72fd0940dfb8a2d9bea86790409c782b33368bb9ec6471f550",
+				"DiscoKey":   "discokey:2a26fcb59058f5b52912afaf9422cfee53c0e566d2cd28838b5db04e9b0ad038",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36296",
+					"10.65.0.27:36296",
+					"172.17.0.1:36296",
+					"172.18.0.1:36296",
+					"172.19.0.1:36296"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:49:13.842342868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         910957886262895,
+				"StableID":   "nYoryVKa7811CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06c727e305f7e7195d99e93233d9a2803b52c748c7db417b099e3f454d0b882d",
+				"DiscoKey":   "discokey:14c36ce284e0e02b05e63ebbee8f2fb6f07ef6a60c4da0be42e83190d661b813",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42643",
+					"10.65.0.27:42643",
+					"172.17.0.1:42643",
+					"172.18.0.1:42643",
+					"172.19.0.1:42643"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:49:14.386907943Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         166908153790418,
+				"StableID":   "ny821sPbJ211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f27617a6dc635a2c1af4604dc3c73509e67243d2840bd025f478c00c6bfce6d",
+				"DiscoKey":   "discokey:2e07fcc0a089360338b3ffa93ddf8b1ed73293d18b2222e401e85eee1b046e41",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38488",
+					"10.65.0.27:38488",
+					"172.17.0.1:38488",
+					"172.18.0.1:38488",
+					"172.19.0.1:38488"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:49:14.927640924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2203141394618887,
+				"StableID":   "nLfsjjnoCJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3453c7e18a404cfddd1cfdbe77685328d109bcfba27d638f26c11c98e95a737a",
+				"DiscoKey":   "discokey:b669fb349e410b95c45ab36e77a66935fd7b31f810e27de1fc3a199049775d51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35888",
+					"10.65.0.27:35888",
+					"172.17.0.1:35888",
+					"172.18.0.1:35888",
+					"172.19.0.1:35888"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:49:16.022684649Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7574053010769617,
+				"StableID":   "nEZGShXJ9221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0f521e4ca342b6e1a782c54783b263369fcc7f9f5778b126706efac0f5acc74f",
+				"KeyExpiry":  "2026-11-08T21:49:16Z",
+				"DiscoKey":   "discokey:d37d6a768804229a0d54df49ddd6466e49bca0b7932f93a405b1a5666dbce57f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38301",
+					"10.65.0.27:38301",
+					"172.17.0.1:38301",
+					"172.18.0.1:38301",
+					"172.19.0.1:38301"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:49:16.556149353Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         940518938194514,
+				"StableID":   "nPVvuaqxL811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:dc757d461633aa1d469b5f88a14871937df499b7d1561ea7248a9c5db869f052",
+				"KeyExpiry":  "2026-11-08T21:49:17Z",
+				"DiscoKey":   "discokey:ac001a108a7d11c3e4d6ae6ecea6c37f60bf445e6d9ff5096d0303e611b2e865",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59722",
+					"10.65.0.27:59722",
+					"172.17.0.1:59722",
+					"172.18.0.1:59722",
+					"172.19.0.1:59722"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:49:17.098234886Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1433377374142785,
+				"StableID":   "nprbBoPBCC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9464d26862c21ab5a714719dde84fac8cb7b4a8a523a7d78c4fa69971fea376f",
+				"KeyExpiry":  "2026-11-08T21:49:17Z",
+				"DiscoKey":   "discokey:561cf4cc2a53e2dd29e6f24814dde8c32b70a8d7ed1af41d9c32d7f37ccac507",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59993",
+					"10.65.0.27:59993",
+					"172.17.0.1:59993",
+					"172.18.0.1:59993",
+					"172.19.0.1:59993"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:49:17.638950635Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1502109014378542": {
+				"ID":          1502109014378542,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7042396524582791,
+				"StableID":   "n43mKGpWzw11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       7042396524582791,
+				"Key":        "nodekey:38ae018d24adab03d2e46a464f480279ede3ae5bd252e131de5c4b7fbea8dd70",
+				"DiscoKey":   "discokey:c4fdd0fed0b5a4fdeab03a2ce1d74f4edcafa739f929eb014e34a6032abc8224",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:38715",
+					"10.65.0.27:38715",
+					"172.17.0.1:38715",
+					"172.18.0.1:38715",
+					"172.19.0.1:38715"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:49:10.609682656Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:38ae018d24adab03d2e46a464f480279ede3ae5bd252e131de5c4b7fbea8dd70",
+			"MachineKey": "mkey:e06bd4ade087627e9281d52209fee685026c0432e94d5f0e3473de576848af6c",
+			"Peers": [{
+				"ID":         2595605725024588,
+				"StableID":   "nXLogLAZGM11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:14a115699713e890c9ebfd1debe10c2955f916f5f2f9722fe5f1feb4b811e252",
+				"DiscoKey":   "discokey:fd34e073defe44541d380b4c33a1d77cc1221e9757157787927dcd821a3e2219",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40696",
+					"10.65.0.27:40696",
+					"172.17.0.1:40696",
+					"172.18.0.1:40696",
+					"172.19.0.1:40696"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:49:10.064815739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1183280254117873,
+				"StableID":   "nUG17RmuEA11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4390c15f3125750f4a9e2b22a7d7806e6199c382802003a2cdb35bc19ae9a32e",
+				"DiscoKey":   "discokey:e36de856145dd7e2754fe0322eda7879310f63a1b2c72df0152bb076f611f47b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:47272",
+					"10.65.0.27:47272",
+					"172.17.0.1:47272",
+					"172.18.0.1:47272",
+					"172.19.0.1:47272"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:49:11.140917354Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2218056842991332,
+				"StableID":   "nXNWqLbZKJ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28f70453d3c468887468d1258c09e6468800d017111b99af7b569a2314418a2d",
+				"DiscoKey":   "discokey:4ef6a887f47edfdc701745fce2faedbfff9ade73f331d563045031554c14f85d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35181",
+					"10.65.0.27:35181",
+					"172.17.0.1:35181",
+					"172.18.0.1:35181",
+					"172.19.0.1:35181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:49:11.683535327Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         746689446529713,
+				"StableID":   "nEdNUQGBq611CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab2e486bb8a6fdb92739451606d15232bbf6535af74e1a91b9b07d094835822b",
+				"DiscoKey":   "discokey:2025685b7907dbd1e900b1baeace89931dc193dae2d0ba614cf12cb11d8eb66c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41671",
+					"10.65.0.27:41671",
+					"172.17.0.1:41671",
+					"172.18.0.1:41671",
+					"172.19.0.1:41671"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:49:12.233898047Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4327983417894694,
+				"StableID":   "n5A5AZn9oa11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6d3ae4d06183ea1bead68acad8a90eb516dfac343f0a82b7365c2cec87f8e64",
+				"DiscoKey":   "discokey:26ee058c7dbc87ed44cfcae9d88a8205f9548b05e5504284eda15234f79f4e78",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54900",
+					"10.65.0.27:54900",
+					"172.17.0.1:54900",
+					"172.18.0.1:54900",
+					"172.19.0.1:54900"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:49:12.774546426Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8662887182080140,
+				"StableID":   "nwJncgMSeA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:05d473005abe8dc116ae56f5d1fdf629f0847c243d316d7cd9d41d96d561ed25",
+				"DiscoKey":   "discokey:5e6c3b8fa777c273041cd28af21a4e8c29710cb73d507da21713cb0418381a24",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52368",
+					"10.65.0.27:52368",
+					"172.17.0.1:52368",
+					"172.18.0.1:52368",
+					"172.19.0.1:52368"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:49:13.302903115Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         431529393613490,
+				"StableID":   "nHz1pdYSN411CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec7d6d70b11cba72fd0940dfb8a2d9bea86790409c782b33368bb9ec6471f550",
+				"DiscoKey":   "discokey:2a26fcb59058f5b52912afaf9422cfee53c0e566d2cd28838b5db04e9b0ad038",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36296",
+					"10.65.0.27:36296",
+					"172.17.0.1:36296",
+					"172.18.0.1:36296",
+					"172.19.0.1:36296"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:49:13.842342868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         910957886262895,
+				"StableID":   "nYoryVKa7811CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06c727e305f7e7195d99e93233d9a2803b52c748c7db417b099e3f454d0b882d",
+				"DiscoKey":   "discokey:14c36ce284e0e02b05e63ebbee8f2fb6f07ef6a60c4da0be42e83190d661b813",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42643",
+					"10.65.0.27:42643",
+					"172.17.0.1:42643",
+					"172.18.0.1:42643",
+					"172.19.0.1:42643"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:49:14.386907943Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         166908153790418,
+				"StableID":   "ny821sPbJ211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f27617a6dc635a2c1af4604dc3c73509e67243d2840bd025f478c00c6bfce6d",
+				"DiscoKey":   "discokey:2e07fcc0a089360338b3ffa93ddf8b1ed73293d18b2222e401e85eee1b046e41",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38488",
+					"10.65.0.27:38488",
+					"172.17.0.1:38488",
+					"172.18.0.1:38488",
+					"172.19.0.1:38488"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:49:14.927640924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1502109014378542,
+				"StableID":   "nfZTsgrJjC11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec7db7e4eb604d75b66d69733a1a067cf9536593fd857760d54d968d90236f48",
+				"DiscoKey":   "discokey:ec8de26619283d20beb293de62cbae66574f9906e68e99ddaac047cf647eba1b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60046",
+					"10.65.0.27:60046",
+					"172.17.0.1:60046",
+					"172.18.0.1:60046",
+					"172.19.0.1:60046"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:49:15.468825067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2203141394618887,
+				"StableID":   "nLfsjjnoCJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3453c7e18a404cfddd1cfdbe77685328d109bcfba27d638f26c11c98e95a737a",
+				"DiscoKey":   "discokey:b669fb349e410b95c45ab36e77a66935fd7b31f810e27de1fc3a199049775d51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35888",
+					"10.65.0.27:35888",
+					"172.17.0.1:35888",
+					"172.18.0.1:35888",
+					"172.19.0.1:35888"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:49:16.022684649Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7574053010769617,
+				"StableID":   "nEZGShXJ9221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0f521e4ca342b6e1a782c54783b263369fcc7f9f5778b126706efac0f5acc74f",
+				"KeyExpiry":  "2026-11-08T21:49:16Z",
+				"DiscoKey":   "discokey:d37d6a768804229a0d54df49ddd6466e49bca0b7932f93a405b1a5666dbce57f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38301",
+					"10.65.0.27:38301",
+					"172.17.0.1:38301",
+					"172.18.0.1:38301",
+					"172.19.0.1:38301"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:49:16.556149353Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         940518938194514,
+				"StableID":   "nPVvuaqxL811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:dc757d461633aa1d469b5f88a14871937df499b7d1561ea7248a9c5db869f052",
+				"KeyExpiry":  "2026-11-08T21:49:17Z",
+				"DiscoKey":   "discokey:ac001a108a7d11c3e4d6ae6ecea6c37f60bf445e6d9ff5096d0303e611b2e865",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59722",
+					"10.65.0.27:59722",
+					"172.17.0.1:59722",
+					"172.18.0.1:59722",
+					"172.19.0.1:59722"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:49:17.098234886Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1433377374142785,
+				"StableID":   "nprbBoPBCC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9464d26862c21ab5a714719dde84fac8cb7b4a8a523a7d78c4fa69971fea376f",
+				"KeyExpiry":  "2026-11-08T21:49:17Z",
+				"DiscoKey":   "discokey:561cf4cc2a53e2dd29e6f24814dde8c32b70a8d7ed1af41d9c32d7f37ccac507",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59993",
+					"10.65.0.27:59993",
+					"172.17.0.1:59993",
+					"172.18.0.1:59993",
+					"172.19.0.1:59993"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:49:17.638950635Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7042396524582791": {
+				"ID":          7042396524582791,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2595605725024588,
+				"StableID":   "nXLogLAZGM11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       2595605725024588,
+				"Key":        "nodekey:14a115699713e890c9ebfd1debe10c2955f916f5f2f9722fe5f1feb4b811e252",
+				"DiscoKey":   "discokey:fd34e073defe44541d380b4c33a1d77cc1221e9757157787927dcd821a3e2219",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40696",
+					"10.65.0.27:40696",
+					"172.17.0.1:40696",
+					"172.18.0.1:40696",
+					"172.19.0.1:40696"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:49:10.064815739Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:14a115699713e890c9ebfd1debe10c2955f916f5f2f9722fe5f1feb4b811e252",
+			"MachineKey": "mkey:90ec45b66b6f6fe516e433eed84ed9ddf3422c3c1680e4baad77f8b16762f24c",
+			"Peers": [{
+				"ID":         7042396524582791,
+				"StableID":   "n43mKGpWzw11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38ae018d24adab03d2e46a464f480279ede3ae5bd252e131de5c4b7fbea8dd70",
+				"DiscoKey":   "discokey:c4fdd0fed0b5a4fdeab03a2ce1d74f4edcafa739f929eb014e34a6032abc8224",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:38715",
+					"10.65.0.27:38715",
+					"172.17.0.1:38715",
+					"172.18.0.1:38715",
+					"172.19.0.1:38715"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:49:10.609682656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1183280254117873,
+				"StableID":   "nUG17RmuEA11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4390c15f3125750f4a9e2b22a7d7806e6199c382802003a2cdb35bc19ae9a32e",
+				"DiscoKey":   "discokey:e36de856145dd7e2754fe0322eda7879310f63a1b2c72df0152bb076f611f47b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:47272",
+					"10.65.0.27:47272",
+					"172.17.0.1:47272",
+					"172.18.0.1:47272",
+					"172.19.0.1:47272"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:49:11.140917354Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2218056842991332,
+				"StableID":   "nXNWqLbZKJ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28f70453d3c468887468d1258c09e6468800d017111b99af7b569a2314418a2d",
+				"DiscoKey":   "discokey:4ef6a887f47edfdc701745fce2faedbfff9ade73f331d563045031554c14f85d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35181",
+					"10.65.0.27:35181",
+					"172.17.0.1:35181",
+					"172.18.0.1:35181",
+					"172.19.0.1:35181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:49:11.683535327Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         746689446529713,
+				"StableID":   "nEdNUQGBq611CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab2e486bb8a6fdb92739451606d15232bbf6535af74e1a91b9b07d094835822b",
+				"DiscoKey":   "discokey:2025685b7907dbd1e900b1baeace89931dc193dae2d0ba614cf12cb11d8eb66c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41671",
+					"10.65.0.27:41671",
+					"172.17.0.1:41671",
+					"172.18.0.1:41671",
+					"172.19.0.1:41671"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:49:12.233898047Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4327983417894694,
+				"StableID":   "n5A5AZn9oa11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6d3ae4d06183ea1bead68acad8a90eb516dfac343f0a82b7365c2cec87f8e64",
+				"DiscoKey":   "discokey:26ee058c7dbc87ed44cfcae9d88a8205f9548b05e5504284eda15234f79f4e78",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54900",
+					"10.65.0.27:54900",
+					"172.17.0.1:54900",
+					"172.18.0.1:54900",
+					"172.19.0.1:54900"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:49:12.774546426Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8662887182080140,
+				"StableID":   "nwJncgMSeA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:05d473005abe8dc116ae56f5d1fdf629f0847c243d316d7cd9d41d96d561ed25",
+				"DiscoKey":   "discokey:5e6c3b8fa777c273041cd28af21a4e8c29710cb73d507da21713cb0418381a24",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52368",
+					"10.65.0.27:52368",
+					"172.17.0.1:52368",
+					"172.18.0.1:52368",
+					"172.19.0.1:52368"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:49:13.302903115Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         431529393613490,
+				"StableID":   "nHz1pdYSN411CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec7d6d70b11cba72fd0940dfb8a2d9bea86790409c782b33368bb9ec6471f550",
+				"DiscoKey":   "discokey:2a26fcb59058f5b52912afaf9422cfee53c0e566d2cd28838b5db04e9b0ad038",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36296",
+					"10.65.0.27:36296",
+					"172.17.0.1:36296",
+					"172.18.0.1:36296",
+					"172.19.0.1:36296"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:49:13.842342868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         910957886262895,
+				"StableID":   "nYoryVKa7811CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06c727e305f7e7195d99e93233d9a2803b52c748c7db417b099e3f454d0b882d",
+				"DiscoKey":   "discokey:14c36ce284e0e02b05e63ebbee8f2fb6f07ef6a60c4da0be42e83190d661b813",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42643",
+					"10.65.0.27:42643",
+					"172.17.0.1:42643",
+					"172.18.0.1:42643",
+					"172.19.0.1:42643"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:49:14.386907943Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         166908153790418,
+				"StableID":   "ny821sPbJ211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f27617a6dc635a2c1af4604dc3c73509e67243d2840bd025f478c00c6bfce6d",
+				"DiscoKey":   "discokey:2e07fcc0a089360338b3ffa93ddf8b1ed73293d18b2222e401e85eee1b046e41",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38488",
+					"10.65.0.27:38488",
+					"172.17.0.1:38488",
+					"172.18.0.1:38488",
+					"172.19.0.1:38488"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:49:14.927640924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1502109014378542,
+				"StableID":   "nfZTsgrJjC11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec7db7e4eb604d75b66d69733a1a067cf9536593fd857760d54d968d90236f48",
+				"DiscoKey":   "discokey:ec8de26619283d20beb293de62cbae66574f9906e68e99ddaac047cf647eba1b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60046",
+					"10.65.0.27:60046",
+					"172.17.0.1:60046",
+					"172.18.0.1:60046",
+					"172.19.0.1:60046"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:49:15.468825067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2203141394618887,
+				"StableID":   "nLfsjjnoCJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3453c7e18a404cfddd1cfdbe77685328d109bcfba27d638f26c11c98e95a737a",
+				"DiscoKey":   "discokey:b669fb349e410b95c45ab36e77a66935fd7b31f810e27de1fc3a199049775d51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35888",
+					"10.65.0.27:35888",
+					"172.17.0.1:35888",
+					"172.18.0.1:35888",
+					"172.19.0.1:35888"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:49:16.022684649Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7574053010769617,
+				"StableID":   "nEZGShXJ9221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0f521e4ca342b6e1a782c54783b263369fcc7f9f5778b126706efac0f5acc74f",
+				"KeyExpiry":  "2026-11-08T21:49:16Z",
+				"DiscoKey":   "discokey:d37d6a768804229a0d54df49ddd6466e49bca0b7932f93a405b1a5666dbce57f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38301",
+					"10.65.0.27:38301",
+					"172.17.0.1:38301",
+					"172.18.0.1:38301",
+					"172.19.0.1:38301"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:49:16.556149353Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         940518938194514,
+				"StableID":   "nPVvuaqxL811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:dc757d461633aa1d469b5f88a14871937df499b7d1561ea7248a9c5db869f052",
+				"KeyExpiry":  "2026-11-08T21:49:17Z",
+				"DiscoKey":   "discokey:ac001a108a7d11c3e4d6ae6ecea6c37f60bf445e6d9ff5096d0303e611b2e865",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59722",
+					"10.65.0.27:59722",
+					"172.17.0.1:59722",
+					"172.18.0.1:59722",
+					"172.19.0.1:59722"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:49:17.098234886Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1433377374142785,
+				"StableID":   "nprbBoPBCC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9464d26862c21ab5a714719dde84fac8cb7b4a8a523a7d78c4fa69971fea376f",
+				"KeyExpiry":  "2026-11-08T21:49:17Z",
+				"DiscoKey":   "discokey:561cf4cc2a53e2dd29e6f24814dde8c32b70a8d7ed1af41d9c32d7f37ccac507",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59993",
+					"10.65.0.27:59993",
+					"172.17.0.1:59993",
+					"172.18.0.1:59993",
+					"172.19.0.1:59993"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:49:17.638950635Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2595605725024588": {
+				"ID":          2595605725024588,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         746689446529713,
+				"StableID":   "nEdNUQGBq611CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       746689446529713,
+				"Key":        "nodekey:ab2e486bb8a6fdb92739451606d15232bbf6535af74e1a91b9b07d094835822b",
+				"DiscoKey":   "discokey:2025685b7907dbd1e900b1baeace89931dc193dae2d0ba614cf12cb11d8eb66c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41671",
+					"10.65.0.27:41671",
+					"172.17.0.1:41671",
+					"172.18.0.1:41671",
+					"172.19.0.1:41671"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:49:12.233898047Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ab2e486bb8a6fdb92739451606d15232bbf6535af74e1a91b9b07d094835822b",
+			"MachineKey": "mkey:f30cc4c9d1d74e96f36f00feddae957f150300ae720289c77c3377cb9a80dd02",
+			"Peers": [{
+				"ID":         2595605725024588,
+				"StableID":   "nXLogLAZGM11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:14a115699713e890c9ebfd1debe10c2955f916f5f2f9722fe5f1feb4b811e252",
+				"DiscoKey":   "discokey:fd34e073defe44541d380b4c33a1d77cc1221e9757157787927dcd821a3e2219",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40696",
+					"10.65.0.27:40696",
+					"172.17.0.1:40696",
+					"172.18.0.1:40696",
+					"172.19.0.1:40696"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:49:10.064815739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7042396524582791,
+				"StableID":   "n43mKGpWzw11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38ae018d24adab03d2e46a464f480279ede3ae5bd252e131de5c4b7fbea8dd70",
+				"DiscoKey":   "discokey:c4fdd0fed0b5a4fdeab03a2ce1d74f4edcafa739f929eb014e34a6032abc8224",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:38715",
+					"10.65.0.27:38715",
+					"172.17.0.1:38715",
+					"172.18.0.1:38715",
+					"172.19.0.1:38715"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:49:10.609682656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1183280254117873,
+				"StableID":   "nUG17RmuEA11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4390c15f3125750f4a9e2b22a7d7806e6199c382802003a2cdb35bc19ae9a32e",
+				"DiscoKey":   "discokey:e36de856145dd7e2754fe0322eda7879310f63a1b2c72df0152bb076f611f47b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:47272",
+					"10.65.0.27:47272",
+					"172.17.0.1:47272",
+					"172.18.0.1:47272",
+					"172.19.0.1:47272"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:49:11.140917354Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2218056842991332,
+				"StableID":   "nXNWqLbZKJ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28f70453d3c468887468d1258c09e6468800d017111b99af7b569a2314418a2d",
+				"DiscoKey":   "discokey:4ef6a887f47edfdc701745fce2faedbfff9ade73f331d563045031554c14f85d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35181",
+					"10.65.0.27:35181",
+					"172.17.0.1:35181",
+					"172.18.0.1:35181",
+					"172.19.0.1:35181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:49:11.683535327Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4327983417894694,
+				"StableID":   "n5A5AZn9oa11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6d3ae4d06183ea1bead68acad8a90eb516dfac343f0a82b7365c2cec87f8e64",
+				"DiscoKey":   "discokey:26ee058c7dbc87ed44cfcae9d88a8205f9548b05e5504284eda15234f79f4e78",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54900",
+					"10.65.0.27:54900",
+					"172.17.0.1:54900",
+					"172.18.0.1:54900",
+					"172.19.0.1:54900"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:49:12.774546426Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8662887182080140,
+				"StableID":   "nwJncgMSeA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:05d473005abe8dc116ae56f5d1fdf629f0847c243d316d7cd9d41d96d561ed25",
+				"DiscoKey":   "discokey:5e6c3b8fa777c273041cd28af21a4e8c29710cb73d507da21713cb0418381a24",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52368",
+					"10.65.0.27:52368",
+					"172.17.0.1:52368",
+					"172.18.0.1:52368",
+					"172.19.0.1:52368"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:49:13.302903115Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         431529393613490,
+				"StableID":   "nHz1pdYSN411CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec7d6d70b11cba72fd0940dfb8a2d9bea86790409c782b33368bb9ec6471f550",
+				"DiscoKey":   "discokey:2a26fcb59058f5b52912afaf9422cfee53c0e566d2cd28838b5db04e9b0ad038",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36296",
+					"10.65.0.27:36296",
+					"172.17.0.1:36296",
+					"172.18.0.1:36296",
+					"172.19.0.1:36296"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:49:13.842342868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         910957886262895,
+				"StableID":   "nYoryVKa7811CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06c727e305f7e7195d99e93233d9a2803b52c748c7db417b099e3f454d0b882d",
+				"DiscoKey":   "discokey:14c36ce284e0e02b05e63ebbee8f2fb6f07ef6a60c4da0be42e83190d661b813",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42643",
+					"10.65.0.27:42643",
+					"172.17.0.1:42643",
+					"172.18.0.1:42643",
+					"172.19.0.1:42643"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:49:14.386907943Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         166908153790418,
+				"StableID":   "ny821sPbJ211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f27617a6dc635a2c1af4604dc3c73509e67243d2840bd025f478c00c6bfce6d",
+				"DiscoKey":   "discokey:2e07fcc0a089360338b3ffa93ddf8b1ed73293d18b2222e401e85eee1b046e41",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38488",
+					"10.65.0.27:38488",
+					"172.17.0.1:38488",
+					"172.18.0.1:38488",
+					"172.19.0.1:38488"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:49:14.927640924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1502109014378542,
+				"StableID":   "nfZTsgrJjC11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec7db7e4eb604d75b66d69733a1a067cf9536593fd857760d54d968d90236f48",
+				"DiscoKey":   "discokey:ec8de26619283d20beb293de62cbae66574f9906e68e99ddaac047cf647eba1b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60046",
+					"10.65.0.27:60046",
+					"172.17.0.1:60046",
+					"172.18.0.1:60046",
+					"172.19.0.1:60046"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:49:15.468825067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2203141394618887,
+				"StableID":   "nLfsjjnoCJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3453c7e18a404cfddd1cfdbe77685328d109bcfba27d638f26c11c98e95a737a",
+				"DiscoKey":   "discokey:b669fb349e410b95c45ab36e77a66935fd7b31f810e27de1fc3a199049775d51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35888",
+					"10.65.0.27:35888",
+					"172.17.0.1:35888",
+					"172.18.0.1:35888",
+					"172.19.0.1:35888"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:49:16.022684649Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7574053010769617,
+				"StableID":   "nEZGShXJ9221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0f521e4ca342b6e1a782c54783b263369fcc7f9f5778b126706efac0f5acc74f",
+				"KeyExpiry":  "2026-11-08T21:49:16Z",
+				"DiscoKey":   "discokey:d37d6a768804229a0d54df49ddd6466e49bca0b7932f93a405b1a5666dbce57f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38301",
+					"10.65.0.27:38301",
+					"172.17.0.1:38301",
+					"172.18.0.1:38301",
+					"172.19.0.1:38301"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:49:16.556149353Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         940518938194514,
+				"StableID":   "nPVvuaqxL811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:dc757d461633aa1d469b5f88a14871937df499b7d1561ea7248a9c5db869f052",
+				"KeyExpiry":  "2026-11-08T21:49:17Z",
+				"DiscoKey":   "discokey:ac001a108a7d11c3e4d6ae6ecea6c37f60bf445e6d9ff5096d0303e611b2e865",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59722",
+					"10.65.0.27:59722",
+					"172.17.0.1:59722",
+					"172.18.0.1:59722",
+					"172.19.0.1:59722"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:49:17.098234886Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1433377374142785,
+				"StableID":   "nprbBoPBCC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9464d26862c21ab5a714719dde84fac8cb7b4a8a523a7d78c4fa69971fea376f",
+				"KeyExpiry":  "2026-11-08T21:49:17Z",
+				"DiscoKey":   "discokey:561cf4cc2a53e2dd29e6f24814dde8c32b70a8d7ed1af41d9c32d7f37ccac507",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59993",
+					"10.65.0.27:59993",
+					"172.17.0.1:59993",
+					"172.18.0.1:59993",
+					"172.19.0.1:59993"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:49:17.638950635Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "746689446529713": {
+				"ID":          746689446529713,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2218056842991332,
+				"StableID":   "nXNWqLbZKJ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       2218056842991332,
+				"Key":        "nodekey:28f70453d3c468887468d1258c09e6468800d017111b99af7b569a2314418a2d",
+				"DiscoKey":   "discokey:4ef6a887f47edfdc701745fce2faedbfff9ade73f331d563045031554c14f85d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35181",
+					"10.65.0.27:35181",
+					"172.17.0.1:35181",
+					"172.18.0.1:35181",
+					"172.19.0.1:35181"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:49:11.683535327Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:28f70453d3c468887468d1258c09e6468800d017111b99af7b569a2314418a2d",
+			"MachineKey": "mkey:41a76a16acfd7e23ee7854fc99400b8d7e9cc60038be0af5f27e81d04d63ee10",
+			"Peers": [{
+				"ID":         2595605725024588,
+				"StableID":   "nXLogLAZGM11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:14a115699713e890c9ebfd1debe10c2955f916f5f2f9722fe5f1feb4b811e252",
+				"DiscoKey":   "discokey:fd34e073defe44541d380b4c33a1d77cc1221e9757157787927dcd821a3e2219",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40696",
+					"10.65.0.27:40696",
+					"172.17.0.1:40696",
+					"172.18.0.1:40696",
+					"172.19.0.1:40696"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:49:10.064815739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7042396524582791,
+				"StableID":   "n43mKGpWzw11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38ae018d24adab03d2e46a464f480279ede3ae5bd252e131de5c4b7fbea8dd70",
+				"DiscoKey":   "discokey:c4fdd0fed0b5a4fdeab03a2ce1d74f4edcafa739f929eb014e34a6032abc8224",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:38715",
+					"10.65.0.27:38715",
+					"172.17.0.1:38715",
+					"172.18.0.1:38715",
+					"172.19.0.1:38715"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:49:10.609682656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1183280254117873,
+				"StableID":   "nUG17RmuEA11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4390c15f3125750f4a9e2b22a7d7806e6199c382802003a2cdb35bc19ae9a32e",
+				"DiscoKey":   "discokey:e36de856145dd7e2754fe0322eda7879310f63a1b2c72df0152bb076f611f47b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:47272",
+					"10.65.0.27:47272",
+					"172.17.0.1:47272",
+					"172.18.0.1:47272",
+					"172.19.0.1:47272"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:49:11.140917354Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         746689446529713,
+				"StableID":   "nEdNUQGBq611CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab2e486bb8a6fdb92739451606d15232bbf6535af74e1a91b9b07d094835822b",
+				"DiscoKey":   "discokey:2025685b7907dbd1e900b1baeace89931dc193dae2d0ba614cf12cb11d8eb66c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41671",
+					"10.65.0.27:41671",
+					"172.17.0.1:41671",
+					"172.18.0.1:41671",
+					"172.19.0.1:41671"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:49:12.233898047Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4327983417894694,
+				"StableID":   "n5A5AZn9oa11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6d3ae4d06183ea1bead68acad8a90eb516dfac343f0a82b7365c2cec87f8e64",
+				"DiscoKey":   "discokey:26ee058c7dbc87ed44cfcae9d88a8205f9548b05e5504284eda15234f79f4e78",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54900",
+					"10.65.0.27:54900",
+					"172.17.0.1:54900",
+					"172.18.0.1:54900",
+					"172.19.0.1:54900"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:49:12.774546426Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8662887182080140,
+				"StableID":   "nwJncgMSeA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:05d473005abe8dc116ae56f5d1fdf629f0847c243d316d7cd9d41d96d561ed25",
+				"DiscoKey":   "discokey:5e6c3b8fa777c273041cd28af21a4e8c29710cb73d507da21713cb0418381a24",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52368",
+					"10.65.0.27:52368",
+					"172.17.0.1:52368",
+					"172.18.0.1:52368",
+					"172.19.0.1:52368"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:49:13.302903115Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         431529393613490,
+				"StableID":   "nHz1pdYSN411CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec7d6d70b11cba72fd0940dfb8a2d9bea86790409c782b33368bb9ec6471f550",
+				"DiscoKey":   "discokey:2a26fcb59058f5b52912afaf9422cfee53c0e566d2cd28838b5db04e9b0ad038",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36296",
+					"10.65.0.27:36296",
+					"172.17.0.1:36296",
+					"172.18.0.1:36296",
+					"172.19.0.1:36296"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:49:13.842342868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         910957886262895,
+				"StableID":   "nYoryVKa7811CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06c727e305f7e7195d99e93233d9a2803b52c748c7db417b099e3f454d0b882d",
+				"DiscoKey":   "discokey:14c36ce284e0e02b05e63ebbee8f2fb6f07ef6a60c4da0be42e83190d661b813",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42643",
+					"10.65.0.27:42643",
+					"172.17.0.1:42643",
+					"172.18.0.1:42643",
+					"172.19.0.1:42643"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:49:14.386907943Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         166908153790418,
+				"StableID":   "ny821sPbJ211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f27617a6dc635a2c1af4604dc3c73509e67243d2840bd025f478c00c6bfce6d",
+				"DiscoKey":   "discokey:2e07fcc0a089360338b3ffa93ddf8b1ed73293d18b2222e401e85eee1b046e41",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38488",
+					"10.65.0.27:38488",
+					"172.17.0.1:38488",
+					"172.18.0.1:38488",
+					"172.19.0.1:38488"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:49:14.927640924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1502109014378542,
+				"StableID":   "nfZTsgrJjC11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec7db7e4eb604d75b66d69733a1a067cf9536593fd857760d54d968d90236f48",
+				"DiscoKey":   "discokey:ec8de26619283d20beb293de62cbae66574f9906e68e99ddaac047cf647eba1b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60046",
+					"10.65.0.27:60046",
+					"172.17.0.1:60046",
+					"172.18.0.1:60046",
+					"172.19.0.1:60046"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:49:15.468825067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2203141394618887,
+				"StableID":   "nLfsjjnoCJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3453c7e18a404cfddd1cfdbe77685328d109bcfba27d638f26c11c98e95a737a",
+				"DiscoKey":   "discokey:b669fb349e410b95c45ab36e77a66935fd7b31f810e27de1fc3a199049775d51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35888",
+					"10.65.0.27:35888",
+					"172.17.0.1:35888",
+					"172.18.0.1:35888",
+					"172.19.0.1:35888"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:49:16.022684649Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7574053010769617,
+				"StableID":   "nEZGShXJ9221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0f521e4ca342b6e1a782c54783b263369fcc7f9f5778b126706efac0f5acc74f",
+				"KeyExpiry":  "2026-11-08T21:49:16Z",
+				"DiscoKey":   "discokey:d37d6a768804229a0d54df49ddd6466e49bca0b7932f93a405b1a5666dbce57f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38301",
+					"10.65.0.27:38301",
+					"172.17.0.1:38301",
+					"172.18.0.1:38301",
+					"172.19.0.1:38301"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:49:16.556149353Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         940518938194514,
+				"StableID":   "nPVvuaqxL811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:dc757d461633aa1d469b5f88a14871937df499b7d1561ea7248a9c5db869f052",
+				"KeyExpiry":  "2026-11-08T21:49:17Z",
+				"DiscoKey":   "discokey:ac001a108a7d11c3e4d6ae6ecea6c37f60bf445e6d9ff5096d0303e611b2e865",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59722",
+					"10.65.0.27:59722",
+					"172.17.0.1:59722",
+					"172.18.0.1:59722",
+					"172.19.0.1:59722"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:49:17.098234886Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1433377374142785,
+				"StableID":   "nprbBoPBCC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9464d26862c21ab5a714719dde84fac8cb7b4a8a523a7d78c4fa69971fea376f",
+				"KeyExpiry":  "2026-11-08T21:49:17Z",
+				"DiscoKey":   "discokey:561cf4cc2a53e2dd29e6f24814dde8c32b70a8d7ed1af41d9c32d7f37ccac507",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59993",
+					"10.65.0.27:59993",
+					"172.17.0.1:59993",
+					"172.18.0.1:59993",
+					"172.19.0.1:59993"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:49:17.638950635Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2218056842991332": {
+				"ID":          2218056842991332,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8662887182080140,
+				"StableID":   "nwJncgMSeA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       8662887182080140,
+				"Key":        "nodekey:05d473005abe8dc116ae56f5d1fdf629f0847c243d316d7cd9d41d96d561ed25",
+				"DiscoKey":   "discokey:5e6c3b8fa777c273041cd28af21a4e8c29710cb73d507da21713cb0418381a24",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52368",
+					"10.65.0.27:52368",
+					"172.17.0.1:52368",
+					"172.18.0.1:52368",
+					"172.19.0.1:52368"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:49:13.302903115Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:05d473005abe8dc116ae56f5d1fdf629f0847c243d316d7cd9d41d96d561ed25",
+			"MachineKey": "mkey:3fd4c43a606e32b820ed0b28910dfda507c3924ca9c96a5a54c90358ffd76802",
+			"Peers": [{
+				"ID":         2595605725024588,
+				"StableID":   "nXLogLAZGM11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:14a115699713e890c9ebfd1debe10c2955f916f5f2f9722fe5f1feb4b811e252",
+				"DiscoKey":   "discokey:fd34e073defe44541d380b4c33a1d77cc1221e9757157787927dcd821a3e2219",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40696",
+					"10.65.0.27:40696",
+					"172.17.0.1:40696",
+					"172.18.0.1:40696",
+					"172.19.0.1:40696"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:49:10.064815739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7042396524582791,
+				"StableID":   "n43mKGpWzw11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38ae018d24adab03d2e46a464f480279ede3ae5bd252e131de5c4b7fbea8dd70",
+				"DiscoKey":   "discokey:c4fdd0fed0b5a4fdeab03a2ce1d74f4edcafa739f929eb014e34a6032abc8224",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:38715",
+					"10.65.0.27:38715",
+					"172.17.0.1:38715",
+					"172.18.0.1:38715",
+					"172.19.0.1:38715"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:49:10.609682656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1183280254117873,
+				"StableID":   "nUG17RmuEA11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4390c15f3125750f4a9e2b22a7d7806e6199c382802003a2cdb35bc19ae9a32e",
+				"DiscoKey":   "discokey:e36de856145dd7e2754fe0322eda7879310f63a1b2c72df0152bb076f611f47b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:47272",
+					"10.65.0.27:47272",
+					"172.17.0.1:47272",
+					"172.18.0.1:47272",
+					"172.19.0.1:47272"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:49:11.140917354Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2218056842991332,
+				"StableID":   "nXNWqLbZKJ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28f70453d3c468887468d1258c09e6468800d017111b99af7b569a2314418a2d",
+				"DiscoKey":   "discokey:4ef6a887f47edfdc701745fce2faedbfff9ade73f331d563045031554c14f85d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35181",
+					"10.65.0.27:35181",
+					"172.17.0.1:35181",
+					"172.18.0.1:35181",
+					"172.19.0.1:35181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:49:11.683535327Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         746689446529713,
+				"StableID":   "nEdNUQGBq611CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab2e486bb8a6fdb92739451606d15232bbf6535af74e1a91b9b07d094835822b",
+				"DiscoKey":   "discokey:2025685b7907dbd1e900b1baeace89931dc193dae2d0ba614cf12cb11d8eb66c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41671",
+					"10.65.0.27:41671",
+					"172.17.0.1:41671",
+					"172.18.0.1:41671",
+					"172.19.0.1:41671"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:49:12.233898047Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4327983417894694,
+				"StableID":   "n5A5AZn9oa11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6d3ae4d06183ea1bead68acad8a90eb516dfac343f0a82b7365c2cec87f8e64",
+				"DiscoKey":   "discokey:26ee058c7dbc87ed44cfcae9d88a8205f9548b05e5504284eda15234f79f4e78",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54900",
+					"10.65.0.27:54900",
+					"172.17.0.1:54900",
+					"172.18.0.1:54900",
+					"172.19.0.1:54900"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:49:12.774546426Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         431529393613490,
+				"StableID":   "nHz1pdYSN411CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec7d6d70b11cba72fd0940dfb8a2d9bea86790409c782b33368bb9ec6471f550",
+				"DiscoKey":   "discokey:2a26fcb59058f5b52912afaf9422cfee53c0e566d2cd28838b5db04e9b0ad038",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36296",
+					"10.65.0.27:36296",
+					"172.17.0.1:36296",
+					"172.18.0.1:36296",
+					"172.19.0.1:36296"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:49:13.842342868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         910957886262895,
+				"StableID":   "nYoryVKa7811CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06c727e305f7e7195d99e93233d9a2803b52c748c7db417b099e3f454d0b882d",
+				"DiscoKey":   "discokey:14c36ce284e0e02b05e63ebbee8f2fb6f07ef6a60c4da0be42e83190d661b813",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42643",
+					"10.65.0.27:42643",
+					"172.17.0.1:42643",
+					"172.18.0.1:42643",
+					"172.19.0.1:42643"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:49:14.386907943Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         166908153790418,
+				"StableID":   "ny821sPbJ211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f27617a6dc635a2c1af4604dc3c73509e67243d2840bd025f478c00c6bfce6d",
+				"DiscoKey":   "discokey:2e07fcc0a089360338b3ffa93ddf8b1ed73293d18b2222e401e85eee1b046e41",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38488",
+					"10.65.0.27:38488",
+					"172.17.0.1:38488",
+					"172.18.0.1:38488",
+					"172.19.0.1:38488"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:49:14.927640924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1502109014378542,
+				"StableID":   "nfZTsgrJjC11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec7db7e4eb604d75b66d69733a1a067cf9536593fd857760d54d968d90236f48",
+				"DiscoKey":   "discokey:ec8de26619283d20beb293de62cbae66574f9906e68e99ddaac047cf647eba1b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60046",
+					"10.65.0.27:60046",
+					"172.17.0.1:60046",
+					"172.18.0.1:60046",
+					"172.19.0.1:60046"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:49:15.468825067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2203141394618887,
+				"StableID":   "nLfsjjnoCJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3453c7e18a404cfddd1cfdbe77685328d109bcfba27d638f26c11c98e95a737a",
+				"DiscoKey":   "discokey:b669fb349e410b95c45ab36e77a66935fd7b31f810e27de1fc3a199049775d51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35888",
+					"10.65.0.27:35888",
+					"172.17.0.1:35888",
+					"172.18.0.1:35888",
+					"172.19.0.1:35888"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:49:16.022684649Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7574053010769617,
+				"StableID":   "nEZGShXJ9221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0f521e4ca342b6e1a782c54783b263369fcc7f9f5778b126706efac0f5acc74f",
+				"KeyExpiry":  "2026-11-08T21:49:16Z",
+				"DiscoKey":   "discokey:d37d6a768804229a0d54df49ddd6466e49bca0b7932f93a405b1a5666dbce57f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38301",
+					"10.65.0.27:38301",
+					"172.17.0.1:38301",
+					"172.18.0.1:38301",
+					"172.19.0.1:38301"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:49:16.556149353Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         940518938194514,
+				"StableID":   "nPVvuaqxL811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:dc757d461633aa1d469b5f88a14871937df499b7d1561ea7248a9c5db869f052",
+				"KeyExpiry":  "2026-11-08T21:49:17Z",
+				"DiscoKey":   "discokey:ac001a108a7d11c3e4d6ae6ecea6c37f60bf445e6d9ff5096d0303e611b2e865",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59722",
+					"10.65.0.27:59722",
+					"172.17.0.1:59722",
+					"172.18.0.1:59722",
+					"172.19.0.1:59722"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:49:17.098234886Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1433377374142785,
+				"StableID":   "nprbBoPBCC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9464d26862c21ab5a714719dde84fac8cb7b4a8a523a7d78c4fa69971fea376f",
+				"KeyExpiry":  "2026-11-08T21:49:17Z",
+				"DiscoKey":   "discokey:561cf4cc2a53e2dd29e6f24814dde8c32b70a8d7ed1af41d9c32d7f37ccac507",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59993",
+					"10.65.0.27:59993",
+					"172.17.0.1:59993",
+					"172.18.0.1:59993",
+					"172.19.0.1:59993"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:49:17.638950635Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8662887182080140": {
+				"ID":          8662887182080140,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         910957886262895,
+				"StableID":   "nYoryVKa7811CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       910957886262895,
+				"Key":        "nodekey:06c727e305f7e7195d99e93233d9a2803b52c748c7db417b099e3f454d0b882d",
+				"DiscoKey":   "discokey:14c36ce284e0e02b05e63ebbee8f2fb6f07ef6a60c4da0be42e83190d661b813",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42643",
+					"10.65.0.27:42643",
+					"172.17.0.1:42643",
+					"172.18.0.1:42643",
+					"172.19.0.1:42643"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:49:14.386907943Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:06c727e305f7e7195d99e93233d9a2803b52c748c7db417b099e3f454d0b882d",
+			"MachineKey": "mkey:1e7e96a492a70efd46866f7a2ebb8cd656ba24ae3e109d936dfc850e04ef9d4a",
+			"Peers": [{
+				"ID":         2595605725024588,
+				"StableID":   "nXLogLAZGM11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:14a115699713e890c9ebfd1debe10c2955f916f5f2f9722fe5f1feb4b811e252",
+				"DiscoKey":   "discokey:fd34e073defe44541d380b4c33a1d77cc1221e9757157787927dcd821a3e2219",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40696",
+					"10.65.0.27:40696",
+					"172.17.0.1:40696",
+					"172.18.0.1:40696",
+					"172.19.0.1:40696"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:49:10.064815739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7042396524582791,
+				"StableID":   "n43mKGpWzw11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38ae018d24adab03d2e46a464f480279ede3ae5bd252e131de5c4b7fbea8dd70",
+				"DiscoKey":   "discokey:c4fdd0fed0b5a4fdeab03a2ce1d74f4edcafa739f929eb014e34a6032abc8224",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:38715",
+					"10.65.0.27:38715",
+					"172.17.0.1:38715",
+					"172.18.0.1:38715",
+					"172.19.0.1:38715"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:49:10.609682656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1183280254117873,
+				"StableID":   "nUG17RmuEA11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4390c15f3125750f4a9e2b22a7d7806e6199c382802003a2cdb35bc19ae9a32e",
+				"DiscoKey":   "discokey:e36de856145dd7e2754fe0322eda7879310f63a1b2c72df0152bb076f611f47b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:47272",
+					"10.65.0.27:47272",
+					"172.17.0.1:47272",
+					"172.18.0.1:47272",
+					"172.19.0.1:47272"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:49:11.140917354Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2218056842991332,
+				"StableID":   "nXNWqLbZKJ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28f70453d3c468887468d1258c09e6468800d017111b99af7b569a2314418a2d",
+				"DiscoKey":   "discokey:4ef6a887f47edfdc701745fce2faedbfff9ade73f331d563045031554c14f85d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35181",
+					"10.65.0.27:35181",
+					"172.17.0.1:35181",
+					"172.18.0.1:35181",
+					"172.19.0.1:35181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:49:11.683535327Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         746689446529713,
+				"StableID":   "nEdNUQGBq611CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab2e486bb8a6fdb92739451606d15232bbf6535af74e1a91b9b07d094835822b",
+				"DiscoKey":   "discokey:2025685b7907dbd1e900b1baeace89931dc193dae2d0ba614cf12cb11d8eb66c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41671",
+					"10.65.0.27:41671",
+					"172.17.0.1:41671",
+					"172.18.0.1:41671",
+					"172.19.0.1:41671"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:49:12.233898047Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4327983417894694,
+				"StableID":   "n5A5AZn9oa11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6d3ae4d06183ea1bead68acad8a90eb516dfac343f0a82b7365c2cec87f8e64",
+				"DiscoKey":   "discokey:26ee058c7dbc87ed44cfcae9d88a8205f9548b05e5504284eda15234f79f4e78",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54900",
+					"10.65.0.27:54900",
+					"172.17.0.1:54900",
+					"172.18.0.1:54900",
+					"172.19.0.1:54900"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:49:12.774546426Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8662887182080140,
+				"StableID":   "nwJncgMSeA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:05d473005abe8dc116ae56f5d1fdf629f0847c243d316d7cd9d41d96d561ed25",
+				"DiscoKey":   "discokey:5e6c3b8fa777c273041cd28af21a4e8c29710cb73d507da21713cb0418381a24",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52368",
+					"10.65.0.27:52368",
+					"172.17.0.1:52368",
+					"172.18.0.1:52368",
+					"172.19.0.1:52368"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:49:13.302903115Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         431529393613490,
+				"StableID":   "nHz1pdYSN411CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec7d6d70b11cba72fd0940dfb8a2d9bea86790409c782b33368bb9ec6471f550",
+				"DiscoKey":   "discokey:2a26fcb59058f5b52912afaf9422cfee53c0e566d2cd28838b5db04e9b0ad038",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36296",
+					"10.65.0.27:36296",
+					"172.17.0.1:36296",
+					"172.18.0.1:36296",
+					"172.19.0.1:36296"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:49:13.842342868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         166908153790418,
+				"StableID":   "ny821sPbJ211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f27617a6dc635a2c1af4604dc3c73509e67243d2840bd025f478c00c6bfce6d",
+				"DiscoKey":   "discokey:2e07fcc0a089360338b3ffa93ddf8b1ed73293d18b2222e401e85eee1b046e41",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38488",
+					"10.65.0.27:38488",
+					"172.17.0.1:38488",
+					"172.18.0.1:38488",
+					"172.19.0.1:38488"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:49:14.927640924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1502109014378542,
+				"StableID":   "nfZTsgrJjC11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec7db7e4eb604d75b66d69733a1a067cf9536593fd857760d54d968d90236f48",
+				"DiscoKey":   "discokey:ec8de26619283d20beb293de62cbae66574f9906e68e99ddaac047cf647eba1b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60046",
+					"10.65.0.27:60046",
+					"172.17.0.1:60046",
+					"172.18.0.1:60046",
+					"172.19.0.1:60046"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:49:15.468825067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2203141394618887,
+				"StableID":   "nLfsjjnoCJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3453c7e18a404cfddd1cfdbe77685328d109bcfba27d638f26c11c98e95a737a",
+				"DiscoKey":   "discokey:b669fb349e410b95c45ab36e77a66935fd7b31f810e27de1fc3a199049775d51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35888",
+					"10.65.0.27:35888",
+					"172.17.0.1:35888",
+					"172.18.0.1:35888",
+					"172.19.0.1:35888"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:49:16.022684649Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7574053010769617,
+				"StableID":   "nEZGShXJ9221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0f521e4ca342b6e1a782c54783b263369fcc7f9f5778b126706efac0f5acc74f",
+				"KeyExpiry":  "2026-11-08T21:49:16Z",
+				"DiscoKey":   "discokey:d37d6a768804229a0d54df49ddd6466e49bca0b7932f93a405b1a5666dbce57f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38301",
+					"10.65.0.27:38301",
+					"172.17.0.1:38301",
+					"172.18.0.1:38301",
+					"172.19.0.1:38301"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:49:16.556149353Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         940518938194514,
+				"StableID":   "nPVvuaqxL811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:dc757d461633aa1d469b5f88a14871937df499b7d1561ea7248a9c5db869f052",
+				"KeyExpiry":  "2026-11-08T21:49:17Z",
+				"DiscoKey":   "discokey:ac001a108a7d11c3e4d6ae6ecea6c37f60bf445e6d9ff5096d0303e611b2e865",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59722",
+					"10.65.0.27:59722",
+					"172.17.0.1:59722",
+					"172.18.0.1:59722",
+					"172.19.0.1:59722"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:49:17.098234886Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1433377374142785,
+				"StableID":   "nprbBoPBCC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9464d26862c21ab5a714719dde84fac8cb7b4a8a523a7d78c4fa69971fea376f",
+				"KeyExpiry":  "2026-11-08T21:49:17Z",
+				"DiscoKey":   "discokey:561cf4cc2a53e2dd29e6f24814dde8c32b70a8d7ed1af41d9c32d7f37ccac507",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59993",
+					"10.65.0.27:59993",
+					"172.17.0.1:59993",
+					"172.18.0.1:59993",
+					"172.19.0.1:59993"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:49:17.638950635Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "910957886262895": {
+				"ID":          910957886262895,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         940518938194514,
+				"StableID":   "nPVvuaqxL811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:dc757d461633aa1d469b5f88a14871937df499b7d1561ea7248a9c5db869f052",
+				"KeyExpiry":  "2026-11-08T21:49:17Z",
+				"DiscoKey":   "discokey:ac001a108a7d11c3e4d6ae6ecea6c37f60bf445e6d9ff5096d0303e611b2e865",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59722",
+					"10.65.0.27:59722",
+					"172.17.0.1:59722",
+					"172.18.0.1:59722",
+					"172.19.0.1:59722"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:49:17.098234886Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:dc757d461633aa1d469b5f88a14871937df499b7d1561ea7248a9c5db869f052",
+			"MachineKey": "mkey:78f7031bfafc7599e5d147b61a244c498aa80f1b182e0a4984ba57a26a4d310f",
+			"Peers": [{
+				"ID":         2595605725024588,
+				"StableID":   "nXLogLAZGM11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:14a115699713e890c9ebfd1debe10c2955f916f5f2f9722fe5f1feb4b811e252",
+				"DiscoKey":   "discokey:fd34e073defe44541d380b4c33a1d77cc1221e9757157787927dcd821a3e2219",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40696",
+					"10.65.0.27:40696",
+					"172.17.0.1:40696",
+					"172.18.0.1:40696",
+					"172.19.0.1:40696"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:49:10.064815739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7042396524582791,
+				"StableID":   "n43mKGpWzw11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38ae018d24adab03d2e46a464f480279ede3ae5bd252e131de5c4b7fbea8dd70",
+				"DiscoKey":   "discokey:c4fdd0fed0b5a4fdeab03a2ce1d74f4edcafa739f929eb014e34a6032abc8224",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:38715",
+					"10.65.0.27:38715",
+					"172.17.0.1:38715",
+					"172.18.0.1:38715",
+					"172.19.0.1:38715"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:49:10.609682656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1183280254117873,
+				"StableID":   "nUG17RmuEA11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4390c15f3125750f4a9e2b22a7d7806e6199c382802003a2cdb35bc19ae9a32e",
+				"DiscoKey":   "discokey:e36de856145dd7e2754fe0322eda7879310f63a1b2c72df0152bb076f611f47b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:47272",
+					"10.65.0.27:47272",
+					"172.17.0.1:47272",
+					"172.18.0.1:47272",
+					"172.19.0.1:47272"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:49:11.140917354Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2218056842991332,
+				"StableID":   "nXNWqLbZKJ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28f70453d3c468887468d1258c09e6468800d017111b99af7b569a2314418a2d",
+				"DiscoKey":   "discokey:4ef6a887f47edfdc701745fce2faedbfff9ade73f331d563045031554c14f85d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35181",
+					"10.65.0.27:35181",
+					"172.17.0.1:35181",
+					"172.18.0.1:35181",
+					"172.19.0.1:35181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:49:11.683535327Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         746689446529713,
+				"StableID":   "nEdNUQGBq611CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab2e486bb8a6fdb92739451606d15232bbf6535af74e1a91b9b07d094835822b",
+				"DiscoKey":   "discokey:2025685b7907dbd1e900b1baeace89931dc193dae2d0ba614cf12cb11d8eb66c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41671",
+					"10.65.0.27:41671",
+					"172.17.0.1:41671",
+					"172.18.0.1:41671",
+					"172.19.0.1:41671"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:49:12.233898047Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4327983417894694,
+				"StableID":   "n5A5AZn9oa11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6d3ae4d06183ea1bead68acad8a90eb516dfac343f0a82b7365c2cec87f8e64",
+				"DiscoKey":   "discokey:26ee058c7dbc87ed44cfcae9d88a8205f9548b05e5504284eda15234f79f4e78",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54900",
+					"10.65.0.27:54900",
+					"172.17.0.1:54900",
+					"172.18.0.1:54900",
+					"172.19.0.1:54900"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:49:12.774546426Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8662887182080140,
+				"StableID":   "nwJncgMSeA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:05d473005abe8dc116ae56f5d1fdf629f0847c243d316d7cd9d41d96d561ed25",
+				"DiscoKey":   "discokey:5e6c3b8fa777c273041cd28af21a4e8c29710cb73d507da21713cb0418381a24",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52368",
+					"10.65.0.27:52368",
+					"172.17.0.1:52368",
+					"172.18.0.1:52368",
+					"172.19.0.1:52368"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:49:13.302903115Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         431529393613490,
+				"StableID":   "nHz1pdYSN411CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec7d6d70b11cba72fd0940dfb8a2d9bea86790409c782b33368bb9ec6471f550",
+				"DiscoKey":   "discokey:2a26fcb59058f5b52912afaf9422cfee53c0e566d2cd28838b5db04e9b0ad038",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36296",
+					"10.65.0.27:36296",
+					"172.17.0.1:36296",
+					"172.18.0.1:36296",
+					"172.19.0.1:36296"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:49:13.842342868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         910957886262895,
+				"StableID":   "nYoryVKa7811CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06c727e305f7e7195d99e93233d9a2803b52c748c7db417b099e3f454d0b882d",
+				"DiscoKey":   "discokey:14c36ce284e0e02b05e63ebbee8f2fb6f07ef6a60c4da0be42e83190d661b813",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42643",
+					"10.65.0.27:42643",
+					"172.17.0.1:42643",
+					"172.18.0.1:42643",
+					"172.19.0.1:42643"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:49:14.386907943Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         166908153790418,
+				"StableID":   "ny821sPbJ211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f27617a6dc635a2c1af4604dc3c73509e67243d2840bd025f478c00c6bfce6d",
+				"DiscoKey":   "discokey:2e07fcc0a089360338b3ffa93ddf8b1ed73293d18b2222e401e85eee1b046e41",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38488",
+					"10.65.0.27:38488",
+					"172.17.0.1:38488",
+					"172.18.0.1:38488",
+					"172.19.0.1:38488"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:49:14.927640924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1502109014378542,
+				"StableID":   "nfZTsgrJjC11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec7db7e4eb604d75b66d69733a1a067cf9536593fd857760d54d968d90236f48",
+				"DiscoKey":   "discokey:ec8de26619283d20beb293de62cbae66574f9906e68e99ddaac047cf647eba1b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60046",
+					"10.65.0.27:60046",
+					"172.17.0.1:60046",
+					"172.18.0.1:60046",
+					"172.19.0.1:60046"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:49:15.468825067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2203141394618887,
+				"StableID":   "nLfsjjnoCJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3453c7e18a404cfddd1cfdbe77685328d109bcfba27d638f26c11c98e95a737a",
+				"DiscoKey":   "discokey:b669fb349e410b95c45ab36e77a66935fd7b31f810e27de1fc3a199049775d51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35888",
+					"10.65.0.27:35888",
+					"172.17.0.1:35888",
+					"172.18.0.1:35888",
+					"172.19.0.1:35888"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:49:16.022684649Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7574053010769617,
+				"StableID":   "nEZGShXJ9221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0f521e4ca342b6e1a782c54783b263369fcc7f9f5778b126706efac0f5acc74f",
+				"KeyExpiry":  "2026-11-08T21:49:16Z",
+				"DiscoKey":   "discokey:d37d6a768804229a0d54df49ddd6466e49bca0b7932f93a405b1a5666dbce57f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38301",
+					"10.65.0.27:38301",
+					"172.17.0.1:38301",
+					"172.18.0.1:38301",
+					"172.19.0.1:38301"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:49:16.556149353Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1433377374142785,
+				"StableID":   "nprbBoPBCC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9464d26862c21ab5a714719dde84fac8cb7b4a8a523a7d78c4fa69971fea376f",
+				"KeyExpiry":  "2026-11-08T21:49:17Z",
+				"DiscoKey":   "discokey:561cf4cc2a53e2dd29e6f24814dde8c32b70a8d7ed1af41d9c32d7f37ccac507",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59993",
+					"10.65.0.27:59993",
+					"172.17.0.1:59993",
+					"172.18.0.1:59993",
+					"172.19.0.1:59993"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:49:17.638950635Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         166908153790418,
+				"StableID":   "ny821sPbJ211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       166908153790418,
+				"Key":        "nodekey:7f27617a6dc635a2c1af4604dc3c73509e67243d2840bd025f478c00c6bfce6d",
+				"DiscoKey":   "discokey:2e07fcc0a089360338b3ffa93ddf8b1ed73293d18b2222e401e85eee1b046e41",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38488",
+					"10.65.0.27:38488",
+					"172.17.0.1:38488",
+					"172.18.0.1:38488",
+					"172.19.0.1:38488"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:49:14.927640924Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7f27617a6dc635a2c1af4604dc3c73509e67243d2840bd025f478c00c6bfce6d",
+			"MachineKey": "mkey:be8dc27640de4ea5f0b9d9b9b00ee15168139ecd56e84efdc421d8c4471ade5a",
+			"Peers": [{
+				"ID":         2595605725024588,
+				"StableID":   "nXLogLAZGM11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:14a115699713e890c9ebfd1debe10c2955f916f5f2f9722fe5f1feb4b811e252",
+				"DiscoKey":   "discokey:fd34e073defe44541d380b4c33a1d77cc1221e9757157787927dcd821a3e2219",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40696",
+					"10.65.0.27:40696",
+					"172.17.0.1:40696",
+					"172.18.0.1:40696",
+					"172.19.0.1:40696"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:49:10.064815739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7042396524582791,
+				"StableID":   "n43mKGpWzw11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38ae018d24adab03d2e46a464f480279ede3ae5bd252e131de5c4b7fbea8dd70",
+				"DiscoKey":   "discokey:c4fdd0fed0b5a4fdeab03a2ce1d74f4edcafa739f929eb014e34a6032abc8224",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:38715",
+					"10.65.0.27:38715",
+					"172.17.0.1:38715",
+					"172.18.0.1:38715",
+					"172.19.0.1:38715"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:49:10.609682656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1183280254117873,
+				"StableID":   "nUG17RmuEA11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4390c15f3125750f4a9e2b22a7d7806e6199c382802003a2cdb35bc19ae9a32e",
+				"DiscoKey":   "discokey:e36de856145dd7e2754fe0322eda7879310f63a1b2c72df0152bb076f611f47b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:47272",
+					"10.65.0.27:47272",
+					"172.17.0.1:47272",
+					"172.18.0.1:47272",
+					"172.19.0.1:47272"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:49:11.140917354Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2218056842991332,
+				"StableID":   "nXNWqLbZKJ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28f70453d3c468887468d1258c09e6468800d017111b99af7b569a2314418a2d",
+				"DiscoKey":   "discokey:4ef6a887f47edfdc701745fce2faedbfff9ade73f331d563045031554c14f85d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35181",
+					"10.65.0.27:35181",
+					"172.17.0.1:35181",
+					"172.18.0.1:35181",
+					"172.19.0.1:35181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:49:11.683535327Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         746689446529713,
+				"StableID":   "nEdNUQGBq611CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab2e486bb8a6fdb92739451606d15232bbf6535af74e1a91b9b07d094835822b",
+				"DiscoKey":   "discokey:2025685b7907dbd1e900b1baeace89931dc193dae2d0ba614cf12cb11d8eb66c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41671",
+					"10.65.0.27:41671",
+					"172.17.0.1:41671",
+					"172.18.0.1:41671",
+					"172.19.0.1:41671"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:49:12.233898047Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4327983417894694,
+				"StableID":   "n5A5AZn9oa11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6d3ae4d06183ea1bead68acad8a90eb516dfac343f0a82b7365c2cec87f8e64",
+				"DiscoKey":   "discokey:26ee058c7dbc87ed44cfcae9d88a8205f9548b05e5504284eda15234f79f4e78",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54900",
+					"10.65.0.27:54900",
+					"172.17.0.1:54900",
+					"172.18.0.1:54900",
+					"172.19.0.1:54900"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:49:12.774546426Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8662887182080140,
+				"StableID":   "nwJncgMSeA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:05d473005abe8dc116ae56f5d1fdf629f0847c243d316d7cd9d41d96d561ed25",
+				"DiscoKey":   "discokey:5e6c3b8fa777c273041cd28af21a4e8c29710cb73d507da21713cb0418381a24",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52368",
+					"10.65.0.27:52368",
+					"172.17.0.1:52368",
+					"172.18.0.1:52368",
+					"172.19.0.1:52368"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:49:13.302903115Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         431529393613490,
+				"StableID":   "nHz1pdYSN411CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec7d6d70b11cba72fd0940dfb8a2d9bea86790409c782b33368bb9ec6471f550",
+				"DiscoKey":   "discokey:2a26fcb59058f5b52912afaf9422cfee53c0e566d2cd28838b5db04e9b0ad038",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36296",
+					"10.65.0.27:36296",
+					"172.17.0.1:36296",
+					"172.18.0.1:36296",
+					"172.19.0.1:36296"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:49:13.842342868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         910957886262895,
+				"StableID":   "nYoryVKa7811CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06c727e305f7e7195d99e93233d9a2803b52c748c7db417b099e3f454d0b882d",
+				"DiscoKey":   "discokey:14c36ce284e0e02b05e63ebbee8f2fb6f07ef6a60c4da0be42e83190d661b813",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42643",
+					"10.65.0.27:42643",
+					"172.17.0.1:42643",
+					"172.18.0.1:42643",
+					"172.19.0.1:42643"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:49:14.386907943Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1502109014378542,
+				"StableID":   "nfZTsgrJjC11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec7db7e4eb604d75b66d69733a1a067cf9536593fd857760d54d968d90236f48",
+				"DiscoKey":   "discokey:ec8de26619283d20beb293de62cbae66574f9906e68e99ddaac047cf647eba1b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60046",
+					"10.65.0.27:60046",
+					"172.17.0.1:60046",
+					"172.18.0.1:60046",
+					"172.19.0.1:60046"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:49:15.468825067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2203141394618887,
+				"StableID":   "nLfsjjnoCJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3453c7e18a404cfddd1cfdbe77685328d109bcfba27d638f26c11c98e95a737a",
+				"DiscoKey":   "discokey:b669fb349e410b95c45ab36e77a66935fd7b31f810e27de1fc3a199049775d51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35888",
+					"10.65.0.27:35888",
+					"172.17.0.1:35888",
+					"172.18.0.1:35888",
+					"172.19.0.1:35888"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:49:16.022684649Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7574053010769617,
+				"StableID":   "nEZGShXJ9221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0f521e4ca342b6e1a782c54783b263369fcc7f9f5778b126706efac0f5acc74f",
+				"KeyExpiry":  "2026-11-08T21:49:16Z",
+				"DiscoKey":   "discokey:d37d6a768804229a0d54df49ddd6466e49bca0b7932f93a405b1a5666dbce57f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38301",
+					"10.65.0.27:38301",
+					"172.17.0.1:38301",
+					"172.18.0.1:38301",
+					"172.19.0.1:38301"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:49:16.556149353Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         940518938194514,
+				"StableID":   "nPVvuaqxL811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:dc757d461633aa1d469b5f88a14871937df499b7d1561ea7248a9c5db869f052",
+				"KeyExpiry":  "2026-11-08T21:49:17Z",
+				"DiscoKey":   "discokey:ac001a108a7d11c3e4d6ae6ecea6c37f60bf445e6d9ff5096d0303e611b2e865",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59722",
+					"10.65.0.27:59722",
+					"172.17.0.1:59722",
+					"172.18.0.1:59722",
+					"172.19.0.1:59722"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:49:17.098234886Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1433377374142785,
+				"StableID":   "nprbBoPBCC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9464d26862c21ab5a714719dde84fac8cb7b4a8a523a7d78c4fa69971fea376f",
+				"KeyExpiry":  "2026-11-08T21:49:17Z",
+				"DiscoKey":   "discokey:561cf4cc2a53e2dd29e6f24814dde8c32b70a8d7ed1af41d9c32d7f37ccac507",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59993",
+					"10.65.0.27:59993",
+					"172.17.0.1:59993",
+					"172.18.0.1:59993",
+					"172.19.0.1:59993"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:49:17.638950635Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "166908153790418": {
+				"ID":          166908153790418,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-acceptenv-empty.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-acceptenv-empty.hujson
@@ -1,0 +1,20082 @@
+// ssh-malformed-acceptenv-empty
+//
+// ssh acceptEnv empty string is rejected
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T21:50:02Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-malformed-acceptenv-empty",
+	"description":    "ssh acceptEnv empty string is rejected",
+	"category":       "ssh",
+	"captured_at":    "2026-05-12T21:50:02.954578913Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "acceptEnv values cannot be empty"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                \n  \n                                       \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh acceptEnv empty string is rejected\",\n\t\"id\":          \"ssh-malformed-acceptenv-empty\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"acceptEnv\": [\"\"],\n\t\t\"action\":    \"accept\",\n\t\t\"dst\":       [\"tag:server\"],\n\t\t\"src\":       [\"autogroup:member\"],\n\t\t\"users\":     [\"root\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-malformed/ssh-malformed-acceptenv-empty.hujson",
+		"full_policy": {
+			"ssh": [{
+				"acceptEnv": [""],
+				"action":    "accept",
+				"dst":       ["tag:server"],
+				"src":       ["autogroup:member"],
+				"users":     ["root"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6163617912692372,
+				"StableID":   "n36MdsnW8q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       6163617912692372,
+				"Key":        "nodekey:eddae4c993276f7b2b5840a12a18ee0bb2e1ce33dfaa9a649a258a14e03ef511",
+				"DiscoKey":   "discokey:92ac080ac94b12637bf83b12e2265e39dae28ff1636b3baad1f542170a30f000",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:42367",
+					"10.65.0.27:42367",
+					"172.17.0.1:42367",
+					"172.18.0.1:42367",
+					"172.19.0.1:42367"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:50:11.428739795Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:eddae4c993276f7b2b5840a12a18ee0bb2e1ce33dfaa9a649a258a14e03ef511",
+			"MachineKey": "mkey:bceda9276c07b53d9b20828738024795341ccb6a46e709272b9087e8d971625c",
+			"Peers": [{
+				"ID":         6625227475231950,
+				"StableID":   "nFTixVVajt11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90fcbf1ad58ef8563c8ee652fb6e7761c16641ac6e5b6b757c1e39bae482f113",
+				"DiscoKey":   "discokey:1b82489d4a371ce057192a9e37c1901f886a7b25f788b7736fc2cc9482387273",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33930",
+					"10.65.0.27:33930",
+					"172.17.0.1:33930",
+					"172.18.0.1:33930",
+					"172.19.0.1:33930"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:50:05.529551314Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5134075546780876,
+				"StableID":   "n7zgFcTE6h11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5648cf90babe07790eb7c3cb5a98df2c85fc988c9740b081da4c824e446e2028",
+				"DiscoKey":   "discokey:244d0fdfea0126edd0d23d5c457ace853b64b576d24528ff312e3a35b4aedd03",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51927",
+					"10.65.0.27:51927",
+					"172.17.0.1:51927",
+					"172.18.0.1:51927",
+					"172.19.0.1:51927"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:50:06.010196053Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7739482568080407,
+				"StableID":   "nzpqvp5ES321CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4b8dfb2fc0245b0c946a6dc15def7147302e67427a7b138bedf7ed3b903f271",
+				"DiscoKey":   "discokey:debd3e359fad846d274d8594ab65fe71fc0762b33b6b30de6dfe354c94b80f10",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:51129",
+					"10.65.0.27:51129",
+					"172.17.0.1:51129",
+					"172.18.0.1:51129",
+					"172.19.0.1:51129"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:50:06.549681383Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5611305016224092,
+				"StableID":   "nDRoG8UNpk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca2338efb9bd78b8696fc15df28683fdc7bad9521aaf6f49b5c99d4eb94cd66f",
+				"DiscoKey":   "discokey:942e5b261eae7d154f9ff256b054eddc1575ddf53e526a6bfce1dc459a7dff4c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49649",
+					"10.65.0.27:49649",
+					"172.17.0.1:49649",
+					"172.18.0.1:49649",
+					"172.19.0.1:49649"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:50:07.097990745Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7223325092152205,
+				"StableID":   "ngnAH6WTQy11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1327edde3f67214164b0fe2f28abb9c0c5e0b03c40953d270a028ee9cea0a764",
+				"DiscoKey":   "discokey:26936e7f6ea63c733d36ad53ee6501bb9990b652dc4594f535e231e5d913a52f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:54326",
+					"10.65.0.27:54326",
+					"172.17.0.1:54326",
+					"172.18.0.1:54326",
+					"172.19.0.1:54326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:50:07.636979821Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         463642494993577,
+				"StableID":   "nvdacv6zc411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1112f75004aa82c778985c437128f6deaf6fd9e830d030caba98705a1e23ef57",
+				"DiscoKey":   "discokey:36860faf5c2193e3f53de89f267d2698d2469a32476c01f7376b97daa16f8d20",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:32861",
+					"10.65.0.27:32861",
+					"172.17.0.1:32861",
+					"172.18.0.1:32861",
+					"172.19.0.1:32861"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:50:08.182538709Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4217434516485789,
+				"StableID":   "nEBAJVr5wZ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ed05ffaded4b0d3d199e73685cde3d710708e0568136abb3c7dbfae1b7d52d3c",
+				"DiscoKey":   "discokey:4974ae6aec603f79e40a95852d545ff79be2a69d651a593721660ee3df51427b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35238",
+					"10.65.0.27:35238",
+					"172.17.0.1:35238",
+					"172.18.0.1:35238",
+					"172.19.0.1:35238"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:50:08.714646927Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6658212941527777,
+				"StableID":   "nCpVftxWzt11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7b460a57862a7407e3eaf12d5491fe4b585e74c86fa688c97aacaf3b9e88bc5a",
+				"DiscoKey":   "discokey:aa55a178e6c855a88d36c8cece677c6cd27564842d68e0348a452045ff37a268",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:56882",
+					"10.65.0.27:56882",
+					"172.17.0.1:56882",
+					"172.18.0.1:56882",
+					"172.19.0.1:56882"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:50:09.273818206Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3529305711163648,
+				"StableID":   "nmT3AqsRZU11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:96ef6337e8bcafd869253c00fedf5eba2d1e1a805720353586b34da45f646061",
+				"DiscoKey":   "discokey:8c86a8f141c1e7833b687561c75efb7320f9aee43c2c435a82482fae4905066c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33867",
+					"10.65.0.27:33867",
+					"172.17.0.1:33867",
+					"172.18.0.1:33867",
+					"172.19.0.1:33867"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:50:09.791505245Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4355610744675286,
+				"StableID":   "n7RHRVWf1b11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85ef0a3b5218694a655cda07a460a362da05a457e56f5aa9d9d000d1e3eb8b1f",
+				"DiscoKey":   "discokey:8950ee167c429142e8c9856e5eb27ecae26d2dc1f0df8b35f3800e447af6410d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:34584",
+					"10.65.0.27:34584",
+					"172.17.0.1:34584",
+					"172.18.0.1:34584",
+					"172.19.0.1:34584"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:50:10.339831499Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2151322144431074,
+				"StableID":   "nbPi3vaLoH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eca8973b3cc6927706f8ee99e4fd6c0458394e2a60060eec856aeb4f93799c77",
+				"DiscoKey":   "discokey:736b9236a67d97d90554a6bd15d9ad1b337cc4231cc11fc7eff8aa7f709a2e16",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51887",
+					"10.65.0.27:51887",
+					"172.17.0.1:51887",
+					"172.18.0.1:51887",
+					"172.19.0.1:51887"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:50:10.878711627Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6524636438685117,
+				"StableID":   "nYA6Xr82xs11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a4a960d2074c5da1ed25f1fb368b1a9a5e3e6916d784b1b1386f16f53bdc7448",
+				"KeyExpiry":  "2026-11-08T21:50:11Z",
+				"DiscoKey":   "discokey:6607f7e7b624b6ae22f6e0d7d7d8eead196c76230eaa33b1bbf78443ed57de31",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47249",
+					"10.65.0.27:47249",
+					"172.17.0.1:47249",
+					"172.18.0.1:47249",
+					"172.19.0.1:47249"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:50:11.960875922Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4535244346071940,
+				"StableID":   "n7xZeMB2Rc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:39942571da581342e0641ebe9691e7c27142898ced25e9ca690567dcf77ce069",
+				"KeyExpiry":  "2026-11-08T21:50:12Z",
+				"DiscoKey":   "discokey:f88ce12faa767bc1b32ee183c0a4ffab5e8f9a4481ace9c4e375793f944b816d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35948",
+					"10.65.0.27:35948",
+					"172.17.0.1:35948",
+					"172.18.0.1:35948",
+					"172.19.0.1:35948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:50:12.501153112Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8966211731136578,
+				"StableID":   "nHCCLLBp1D21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1c0acb7466b59e9da6293fe6564a1a5dc19e1b048a3c366cb8b71b14dc6f0a3b",
+				"KeyExpiry":  "2026-11-08T21:50:13Z",
+				"DiscoKey":   "discokey:94dc554bbe37455a2492c05cdefb1968e6e02f0733f69f2d5b3cc3eaa78a7625",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:37204",
+					"10.65.0.27:37204",
+					"172.17.0.1:37204",
+					"172.18.0.1:37204",
+					"172.19.0.1:37204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:50:13.04294014Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6163617912692372": {
+				"ID":          6163617912692372,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         463642494993577,
+				"StableID":   "nvdacv6zc411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       463642494993577,
+				"Key":        "nodekey:1112f75004aa82c778985c437128f6deaf6fd9e830d030caba98705a1e23ef57",
+				"DiscoKey":   "discokey:36860faf5c2193e3f53de89f267d2698d2469a32476c01f7376b97daa16f8d20",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:32861",
+					"10.65.0.27:32861",
+					"172.17.0.1:32861",
+					"172.18.0.1:32861",
+					"172.19.0.1:32861"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:50:08.182538709Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1112f75004aa82c778985c437128f6deaf6fd9e830d030caba98705a1e23ef57",
+			"MachineKey": "mkey:1671653ccb54f1a12b029857d2c825b5c9fe3e72f06251cf0636f77a0fd52766",
+			"Peers": [{
+				"ID":         6625227475231950,
+				"StableID":   "nFTixVVajt11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90fcbf1ad58ef8563c8ee652fb6e7761c16641ac6e5b6b757c1e39bae482f113",
+				"DiscoKey":   "discokey:1b82489d4a371ce057192a9e37c1901f886a7b25f788b7736fc2cc9482387273",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33930",
+					"10.65.0.27:33930",
+					"172.17.0.1:33930",
+					"172.18.0.1:33930",
+					"172.19.0.1:33930"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:50:05.529551314Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5134075546780876,
+				"StableID":   "n7zgFcTE6h11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5648cf90babe07790eb7c3cb5a98df2c85fc988c9740b081da4c824e446e2028",
+				"DiscoKey":   "discokey:244d0fdfea0126edd0d23d5c457ace853b64b576d24528ff312e3a35b4aedd03",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51927",
+					"10.65.0.27:51927",
+					"172.17.0.1:51927",
+					"172.18.0.1:51927",
+					"172.19.0.1:51927"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:50:06.010196053Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7739482568080407,
+				"StableID":   "nzpqvp5ES321CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4b8dfb2fc0245b0c946a6dc15def7147302e67427a7b138bedf7ed3b903f271",
+				"DiscoKey":   "discokey:debd3e359fad846d274d8594ab65fe71fc0762b33b6b30de6dfe354c94b80f10",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:51129",
+					"10.65.0.27:51129",
+					"172.17.0.1:51129",
+					"172.18.0.1:51129",
+					"172.19.0.1:51129"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:50:06.549681383Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5611305016224092,
+				"StableID":   "nDRoG8UNpk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca2338efb9bd78b8696fc15df28683fdc7bad9521aaf6f49b5c99d4eb94cd66f",
+				"DiscoKey":   "discokey:942e5b261eae7d154f9ff256b054eddc1575ddf53e526a6bfce1dc459a7dff4c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49649",
+					"10.65.0.27:49649",
+					"172.17.0.1:49649",
+					"172.18.0.1:49649",
+					"172.19.0.1:49649"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:50:07.097990745Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7223325092152205,
+				"StableID":   "ngnAH6WTQy11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1327edde3f67214164b0fe2f28abb9c0c5e0b03c40953d270a028ee9cea0a764",
+				"DiscoKey":   "discokey:26936e7f6ea63c733d36ad53ee6501bb9990b652dc4594f535e231e5d913a52f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:54326",
+					"10.65.0.27:54326",
+					"172.17.0.1:54326",
+					"172.18.0.1:54326",
+					"172.19.0.1:54326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:50:07.636979821Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4217434516485789,
+				"StableID":   "nEBAJVr5wZ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ed05ffaded4b0d3d199e73685cde3d710708e0568136abb3c7dbfae1b7d52d3c",
+				"DiscoKey":   "discokey:4974ae6aec603f79e40a95852d545ff79be2a69d651a593721660ee3df51427b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35238",
+					"10.65.0.27:35238",
+					"172.17.0.1:35238",
+					"172.18.0.1:35238",
+					"172.19.0.1:35238"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:50:08.714646927Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6658212941527777,
+				"StableID":   "nCpVftxWzt11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7b460a57862a7407e3eaf12d5491fe4b585e74c86fa688c97aacaf3b9e88bc5a",
+				"DiscoKey":   "discokey:aa55a178e6c855a88d36c8cece677c6cd27564842d68e0348a452045ff37a268",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:56882",
+					"10.65.0.27:56882",
+					"172.17.0.1:56882",
+					"172.18.0.1:56882",
+					"172.19.0.1:56882"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:50:09.273818206Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3529305711163648,
+				"StableID":   "nmT3AqsRZU11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:96ef6337e8bcafd869253c00fedf5eba2d1e1a805720353586b34da45f646061",
+				"DiscoKey":   "discokey:8c86a8f141c1e7833b687561c75efb7320f9aee43c2c435a82482fae4905066c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33867",
+					"10.65.0.27:33867",
+					"172.17.0.1:33867",
+					"172.18.0.1:33867",
+					"172.19.0.1:33867"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:50:09.791505245Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4355610744675286,
+				"StableID":   "n7RHRVWf1b11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85ef0a3b5218694a655cda07a460a362da05a457e56f5aa9d9d000d1e3eb8b1f",
+				"DiscoKey":   "discokey:8950ee167c429142e8c9856e5eb27ecae26d2dc1f0df8b35f3800e447af6410d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:34584",
+					"10.65.0.27:34584",
+					"172.17.0.1:34584",
+					"172.18.0.1:34584",
+					"172.19.0.1:34584"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:50:10.339831499Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2151322144431074,
+				"StableID":   "nbPi3vaLoH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eca8973b3cc6927706f8ee99e4fd6c0458394e2a60060eec856aeb4f93799c77",
+				"DiscoKey":   "discokey:736b9236a67d97d90554a6bd15d9ad1b337cc4231cc11fc7eff8aa7f709a2e16",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51887",
+					"10.65.0.27:51887",
+					"172.17.0.1:51887",
+					"172.18.0.1:51887",
+					"172.19.0.1:51887"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:50:10.878711627Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6163617912692372,
+				"StableID":   "n36MdsnW8q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eddae4c993276f7b2b5840a12a18ee0bb2e1ce33dfaa9a649a258a14e03ef511",
+				"DiscoKey":   "discokey:92ac080ac94b12637bf83b12e2265e39dae28ff1636b3baad1f542170a30f000",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:42367",
+					"10.65.0.27:42367",
+					"172.17.0.1:42367",
+					"172.18.0.1:42367",
+					"172.19.0.1:42367"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:50:11.428739795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6524636438685117,
+				"StableID":   "nYA6Xr82xs11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a4a960d2074c5da1ed25f1fb368b1a9a5e3e6916d784b1b1386f16f53bdc7448",
+				"KeyExpiry":  "2026-11-08T21:50:11Z",
+				"DiscoKey":   "discokey:6607f7e7b624b6ae22f6e0d7d7d8eead196c76230eaa33b1bbf78443ed57de31",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47249",
+					"10.65.0.27:47249",
+					"172.17.0.1:47249",
+					"172.18.0.1:47249",
+					"172.19.0.1:47249"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:50:11.960875922Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4535244346071940,
+				"StableID":   "n7xZeMB2Rc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:39942571da581342e0641ebe9691e7c27142898ced25e9ca690567dcf77ce069",
+				"KeyExpiry":  "2026-11-08T21:50:12Z",
+				"DiscoKey":   "discokey:f88ce12faa767bc1b32ee183c0a4ffab5e8f9a4481ace9c4e375793f944b816d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35948",
+					"10.65.0.27:35948",
+					"172.17.0.1:35948",
+					"172.18.0.1:35948",
+					"172.19.0.1:35948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:50:12.501153112Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8966211731136578,
+				"StableID":   "nHCCLLBp1D21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1c0acb7466b59e9da6293fe6564a1a5dc19e1b048a3c366cb8b71b14dc6f0a3b",
+				"KeyExpiry":  "2026-11-08T21:50:13Z",
+				"DiscoKey":   "discokey:94dc554bbe37455a2492c05cdefb1968e6e02f0733f69f2d5b3cc3eaa78a7625",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:37204",
+					"10.65.0.27:37204",
+					"172.17.0.1:37204",
+					"172.18.0.1:37204",
+					"172.19.0.1:37204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:50:13.04294014Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "463642494993577": {
+				"ID":          463642494993577,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8966211731136578,
+				"StableID":   "nHCCLLBp1D21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1c0acb7466b59e9da6293fe6564a1a5dc19e1b048a3c366cb8b71b14dc6f0a3b",
+				"KeyExpiry":  "2026-11-08T21:50:13Z",
+				"DiscoKey":   "discokey:94dc554bbe37455a2492c05cdefb1968e6e02f0733f69f2d5b3cc3eaa78a7625",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:37204",
+					"10.65.0.27:37204",
+					"172.17.0.1:37204",
+					"172.18.0.1:37204",
+					"172.19.0.1:37204"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:50:13.04294014Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1c0acb7466b59e9da6293fe6564a1a5dc19e1b048a3c366cb8b71b14dc6f0a3b",
+			"MachineKey": "mkey:13fcfd6e9e8b24eeb810b7a558b2629d871b0dcadc4b3b5a608202938a86260c",
+			"Peers": [{
+				"ID":         6625227475231950,
+				"StableID":   "nFTixVVajt11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90fcbf1ad58ef8563c8ee652fb6e7761c16641ac6e5b6b757c1e39bae482f113",
+				"DiscoKey":   "discokey:1b82489d4a371ce057192a9e37c1901f886a7b25f788b7736fc2cc9482387273",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33930",
+					"10.65.0.27:33930",
+					"172.17.0.1:33930",
+					"172.18.0.1:33930",
+					"172.19.0.1:33930"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:50:05.529551314Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5134075546780876,
+				"StableID":   "n7zgFcTE6h11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5648cf90babe07790eb7c3cb5a98df2c85fc988c9740b081da4c824e446e2028",
+				"DiscoKey":   "discokey:244d0fdfea0126edd0d23d5c457ace853b64b576d24528ff312e3a35b4aedd03",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51927",
+					"10.65.0.27:51927",
+					"172.17.0.1:51927",
+					"172.18.0.1:51927",
+					"172.19.0.1:51927"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:50:06.010196053Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7739482568080407,
+				"StableID":   "nzpqvp5ES321CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4b8dfb2fc0245b0c946a6dc15def7147302e67427a7b138bedf7ed3b903f271",
+				"DiscoKey":   "discokey:debd3e359fad846d274d8594ab65fe71fc0762b33b6b30de6dfe354c94b80f10",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:51129",
+					"10.65.0.27:51129",
+					"172.17.0.1:51129",
+					"172.18.0.1:51129",
+					"172.19.0.1:51129"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:50:06.549681383Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5611305016224092,
+				"StableID":   "nDRoG8UNpk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca2338efb9bd78b8696fc15df28683fdc7bad9521aaf6f49b5c99d4eb94cd66f",
+				"DiscoKey":   "discokey:942e5b261eae7d154f9ff256b054eddc1575ddf53e526a6bfce1dc459a7dff4c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49649",
+					"10.65.0.27:49649",
+					"172.17.0.1:49649",
+					"172.18.0.1:49649",
+					"172.19.0.1:49649"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:50:07.097990745Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7223325092152205,
+				"StableID":   "ngnAH6WTQy11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1327edde3f67214164b0fe2f28abb9c0c5e0b03c40953d270a028ee9cea0a764",
+				"DiscoKey":   "discokey:26936e7f6ea63c733d36ad53ee6501bb9990b652dc4594f535e231e5d913a52f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:54326",
+					"10.65.0.27:54326",
+					"172.17.0.1:54326",
+					"172.18.0.1:54326",
+					"172.19.0.1:54326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:50:07.636979821Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         463642494993577,
+				"StableID":   "nvdacv6zc411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1112f75004aa82c778985c437128f6deaf6fd9e830d030caba98705a1e23ef57",
+				"DiscoKey":   "discokey:36860faf5c2193e3f53de89f267d2698d2469a32476c01f7376b97daa16f8d20",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:32861",
+					"10.65.0.27:32861",
+					"172.17.0.1:32861",
+					"172.18.0.1:32861",
+					"172.19.0.1:32861"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:50:08.182538709Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4217434516485789,
+				"StableID":   "nEBAJVr5wZ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ed05ffaded4b0d3d199e73685cde3d710708e0568136abb3c7dbfae1b7d52d3c",
+				"DiscoKey":   "discokey:4974ae6aec603f79e40a95852d545ff79be2a69d651a593721660ee3df51427b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35238",
+					"10.65.0.27:35238",
+					"172.17.0.1:35238",
+					"172.18.0.1:35238",
+					"172.19.0.1:35238"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:50:08.714646927Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6658212941527777,
+				"StableID":   "nCpVftxWzt11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7b460a57862a7407e3eaf12d5491fe4b585e74c86fa688c97aacaf3b9e88bc5a",
+				"DiscoKey":   "discokey:aa55a178e6c855a88d36c8cece677c6cd27564842d68e0348a452045ff37a268",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:56882",
+					"10.65.0.27:56882",
+					"172.17.0.1:56882",
+					"172.18.0.1:56882",
+					"172.19.0.1:56882"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:50:09.273818206Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3529305711163648,
+				"StableID":   "nmT3AqsRZU11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:96ef6337e8bcafd869253c00fedf5eba2d1e1a805720353586b34da45f646061",
+				"DiscoKey":   "discokey:8c86a8f141c1e7833b687561c75efb7320f9aee43c2c435a82482fae4905066c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33867",
+					"10.65.0.27:33867",
+					"172.17.0.1:33867",
+					"172.18.0.1:33867",
+					"172.19.0.1:33867"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:50:09.791505245Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4355610744675286,
+				"StableID":   "n7RHRVWf1b11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85ef0a3b5218694a655cda07a460a362da05a457e56f5aa9d9d000d1e3eb8b1f",
+				"DiscoKey":   "discokey:8950ee167c429142e8c9856e5eb27ecae26d2dc1f0df8b35f3800e447af6410d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:34584",
+					"10.65.0.27:34584",
+					"172.17.0.1:34584",
+					"172.18.0.1:34584",
+					"172.19.0.1:34584"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:50:10.339831499Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2151322144431074,
+				"StableID":   "nbPi3vaLoH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eca8973b3cc6927706f8ee99e4fd6c0458394e2a60060eec856aeb4f93799c77",
+				"DiscoKey":   "discokey:736b9236a67d97d90554a6bd15d9ad1b337cc4231cc11fc7eff8aa7f709a2e16",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51887",
+					"10.65.0.27:51887",
+					"172.17.0.1:51887",
+					"172.18.0.1:51887",
+					"172.19.0.1:51887"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:50:10.878711627Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6163617912692372,
+				"StableID":   "n36MdsnW8q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eddae4c993276f7b2b5840a12a18ee0bb2e1ce33dfaa9a649a258a14e03ef511",
+				"DiscoKey":   "discokey:92ac080ac94b12637bf83b12e2265e39dae28ff1636b3baad1f542170a30f000",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:42367",
+					"10.65.0.27:42367",
+					"172.17.0.1:42367",
+					"172.18.0.1:42367",
+					"172.19.0.1:42367"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:50:11.428739795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6524636438685117,
+				"StableID":   "nYA6Xr82xs11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a4a960d2074c5da1ed25f1fb368b1a9a5e3e6916d784b1b1386f16f53bdc7448",
+				"KeyExpiry":  "2026-11-08T21:50:11Z",
+				"DiscoKey":   "discokey:6607f7e7b624b6ae22f6e0d7d7d8eead196c76230eaa33b1bbf78443ed57de31",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47249",
+					"10.65.0.27:47249",
+					"172.17.0.1:47249",
+					"172.18.0.1:47249",
+					"172.19.0.1:47249"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:50:11.960875922Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4535244346071940,
+				"StableID":   "n7xZeMB2Rc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:39942571da581342e0641ebe9691e7c27142898ced25e9ca690567dcf77ce069",
+				"KeyExpiry":  "2026-11-08T21:50:12Z",
+				"DiscoKey":   "discokey:f88ce12faa767bc1b32ee183c0a4ffab5e8f9a4481ace9c4e375793f944b816d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35948",
+					"10.65.0.27:35948",
+					"172.17.0.1:35948",
+					"172.18.0.1:35948",
+					"172.19.0.1:35948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:50:12.501153112Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7739482568080407,
+				"StableID":   "nzpqvp5ES321CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       7739482568080407,
+				"Key":        "nodekey:a4b8dfb2fc0245b0c946a6dc15def7147302e67427a7b138bedf7ed3b903f271",
+				"DiscoKey":   "discokey:debd3e359fad846d274d8594ab65fe71fc0762b33b6b30de6dfe354c94b80f10",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:51129",
+					"10.65.0.27:51129",
+					"172.17.0.1:51129",
+					"172.18.0.1:51129",
+					"172.19.0.1:51129"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:50:06.549681383Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a4b8dfb2fc0245b0c946a6dc15def7147302e67427a7b138bedf7ed3b903f271",
+			"MachineKey": "mkey:7f42f5a5fd05f98b6a29ea71b1f674f73a0dab0ae9405dd7581744338098952e",
+			"Peers": [{
+				"ID":         6625227475231950,
+				"StableID":   "nFTixVVajt11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90fcbf1ad58ef8563c8ee652fb6e7761c16641ac6e5b6b757c1e39bae482f113",
+				"DiscoKey":   "discokey:1b82489d4a371ce057192a9e37c1901f886a7b25f788b7736fc2cc9482387273",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33930",
+					"10.65.0.27:33930",
+					"172.17.0.1:33930",
+					"172.18.0.1:33930",
+					"172.19.0.1:33930"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:50:05.529551314Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5134075546780876,
+				"StableID":   "n7zgFcTE6h11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5648cf90babe07790eb7c3cb5a98df2c85fc988c9740b081da4c824e446e2028",
+				"DiscoKey":   "discokey:244d0fdfea0126edd0d23d5c457ace853b64b576d24528ff312e3a35b4aedd03",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51927",
+					"10.65.0.27:51927",
+					"172.17.0.1:51927",
+					"172.18.0.1:51927",
+					"172.19.0.1:51927"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:50:06.010196053Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5611305016224092,
+				"StableID":   "nDRoG8UNpk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca2338efb9bd78b8696fc15df28683fdc7bad9521aaf6f49b5c99d4eb94cd66f",
+				"DiscoKey":   "discokey:942e5b261eae7d154f9ff256b054eddc1575ddf53e526a6bfce1dc459a7dff4c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49649",
+					"10.65.0.27:49649",
+					"172.17.0.1:49649",
+					"172.18.0.1:49649",
+					"172.19.0.1:49649"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:50:07.097990745Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7223325092152205,
+				"StableID":   "ngnAH6WTQy11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1327edde3f67214164b0fe2f28abb9c0c5e0b03c40953d270a028ee9cea0a764",
+				"DiscoKey":   "discokey:26936e7f6ea63c733d36ad53ee6501bb9990b652dc4594f535e231e5d913a52f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:54326",
+					"10.65.0.27:54326",
+					"172.17.0.1:54326",
+					"172.18.0.1:54326",
+					"172.19.0.1:54326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:50:07.636979821Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         463642494993577,
+				"StableID":   "nvdacv6zc411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1112f75004aa82c778985c437128f6deaf6fd9e830d030caba98705a1e23ef57",
+				"DiscoKey":   "discokey:36860faf5c2193e3f53de89f267d2698d2469a32476c01f7376b97daa16f8d20",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:32861",
+					"10.65.0.27:32861",
+					"172.17.0.1:32861",
+					"172.18.0.1:32861",
+					"172.19.0.1:32861"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:50:08.182538709Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4217434516485789,
+				"StableID":   "nEBAJVr5wZ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ed05ffaded4b0d3d199e73685cde3d710708e0568136abb3c7dbfae1b7d52d3c",
+				"DiscoKey":   "discokey:4974ae6aec603f79e40a95852d545ff79be2a69d651a593721660ee3df51427b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35238",
+					"10.65.0.27:35238",
+					"172.17.0.1:35238",
+					"172.18.0.1:35238",
+					"172.19.0.1:35238"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:50:08.714646927Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6658212941527777,
+				"StableID":   "nCpVftxWzt11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7b460a57862a7407e3eaf12d5491fe4b585e74c86fa688c97aacaf3b9e88bc5a",
+				"DiscoKey":   "discokey:aa55a178e6c855a88d36c8cece677c6cd27564842d68e0348a452045ff37a268",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:56882",
+					"10.65.0.27:56882",
+					"172.17.0.1:56882",
+					"172.18.0.1:56882",
+					"172.19.0.1:56882"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:50:09.273818206Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3529305711163648,
+				"StableID":   "nmT3AqsRZU11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:96ef6337e8bcafd869253c00fedf5eba2d1e1a805720353586b34da45f646061",
+				"DiscoKey":   "discokey:8c86a8f141c1e7833b687561c75efb7320f9aee43c2c435a82482fae4905066c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33867",
+					"10.65.0.27:33867",
+					"172.17.0.1:33867",
+					"172.18.0.1:33867",
+					"172.19.0.1:33867"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:50:09.791505245Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4355610744675286,
+				"StableID":   "n7RHRVWf1b11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85ef0a3b5218694a655cda07a460a362da05a457e56f5aa9d9d000d1e3eb8b1f",
+				"DiscoKey":   "discokey:8950ee167c429142e8c9856e5eb27ecae26d2dc1f0df8b35f3800e447af6410d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:34584",
+					"10.65.0.27:34584",
+					"172.17.0.1:34584",
+					"172.18.0.1:34584",
+					"172.19.0.1:34584"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:50:10.339831499Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2151322144431074,
+				"StableID":   "nbPi3vaLoH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eca8973b3cc6927706f8ee99e4fd6c0458394e2a60060eec856aeb4f93799c77",
+				"DiscoKey":   "discokey:736b9236a67d97d90554a6bd15d9ad1b337cc4231cc11fc7eff8aa7f709a2e16",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51887",
+					"10.65.0.27:51887",
+					"172.17.0.1:51887",
+					"172.18.0.1:51887",
+					"172.19.0.1:51887"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:50:10.878711627Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6163617912692372,
+				"StableID":   "n36MdsnW8q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eddae4c993276f7b2b5840a12a18ee0bb2e1ce33dfaa9a649a258a14e03ef511",
+				"DiscoKey":   "discokey:92ac080ac94b12637bf83b12e2265e39dae28ff1636b3baad1f542170a30f000",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:42367",
+					"10.65.0.27:42367",
+					"172.17.0.1:42367",
+					"172.18.0.1:42367",
+					"172.19.0.1:42367"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:50:11.428739795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6524636438685117,
+				"StableID":   "nYA6Xr82xs11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a4a960d2074c5da1ed25f1fb368b1a9a5e3e6916d784b1b1386f16f53bdc7448",
+				"KeyExpiry":  "2026-11-08T21:50:11Z",
+				"DiscoKey":   "discokey:6607f7e7b624b6ae22f6e0d7d7d8eead196c76230eaa33b1bbf78443ed57de31",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47249",
+					"10.65.0.27:47249",
+					"172.17.0.1:47249",
+					"172.18.0.1:47249",
+					"172.19.0.1:47249"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:50:11.960875922Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4535244346071940,
+				"StableID":   "n7xZeMB2Rc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:39942571da581342e0641ebe9691e7c27142898ced25e9ca690567dcf77ce069",
+				"KeyExpiry":  "2026-11-08T21:50:12Z",
+				"DiscoKey":   "discokey:f88ce12faa767bc1b32ee183c0a4ffab5e8f9a4481ace9c4e375793f944b816d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35948",
+					"10.65.0.27:35948",
+					"172.17.0.1:35948",
+					"172.18.0.1:35948",
+					"172.19.0.1:35948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:50:12.501153112Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8966211731136578,
+				"StableID":   "nHCCLLBp1D21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1c0acb7466b59e9da6293fe6564a1a5dc19e1b048a3c366cb8b71b14dc6f0a3b",
+				"KeyExpiry":  "2026-11-08T21:50:13Z",
+				"DiscoKey":   "discokey:94dc554bbe37455a2492c05cdefb1968e6e02f0733f69f2d5b3cc3eaa78a7625",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:37204",
+					"10.65.0.27:37204",
+					"172.17.0.1:37204",
+					"172.18.0.1:37204",
+					"172.19.0.1:37204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:50:13.04294014Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7739482568080407": {
+				"ID":          7739482568080407,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6658212941527777,
+				"StableID":   "nCpVftxWzt11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       6658212941527777,
+				"Key":        "nodekey:7b460a57862a7407e3eaf12d5491fe4b585e74c86fa688c97aacaf3b9e88bc5a",
+				"DiscoKey":   "discokey:aa55a178e6c855a88d36c8cece677c6cd27564842d68e0348a452045ff37a268",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:56882",
+					"10.65.0.27:56882",
+					"172.17.0.1:56882",
+					"172.18.0.1:56882",
+					"172.19.0.1:56882"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:50:09.273818206Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7b460a57862a7407e3eaf12d5491fe4b585e74c86fa688c97aacaf3b9e88bc5a",
+			"MachineKey": "mkey:34e3f125d4deb331c403356d8318b05e9b6ab286155b967f8acaf2878ea65a77",
+			"Peers": [{
+				"ID":         6625227475231950,
+				"StableID":   "nFTixVVajt11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90fcbf1ad58ef8563c8ee652fb6e7761c16641ac6e5b6b757c1e39bae482f113",
+				"DiscoKey":   "discokey:1b82489d4a371ce057192a9e37c1901f886a7b25f788b7736fc2cc9482387273",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33930",
+					"10.65.0.27:33930",
+					"172.17.0.1:33930",
+					"172.18.0.1:33930",
+					"172.19.0.1:33930"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:50:05.529551314Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5134075546780876,
+				"StableID":   "n7zgFcTE6h11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5648cf90babe07790eb7c3cb5a98df2c85fc988c9740b081da4c824e446e2028",
+				"DiscoKey":   "discokey:244d0fdfea0126edd0d23d5c457ace853b64b576d24528ff312e3a35b4aedd03",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51927",
+					"10.65.0.27:51927",
+					"172.17.0.1:51927",
+					"172.18.0.1:51927",
+					"172.19.0.1:51927"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:50:06.010196053Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7739482568080407,
+				"StableID":   "nzpqvp5ES321CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4b8dfb2fc0245b0c946a6dc15def7147302e67427a7b138bedf7ed3b903f271",
+				"DiscoKey":   "discokey:debd3e359fad846d274d8594ab65fe71fc0762b33b6b30de6dfe354c94b80f10",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:51129",
+					"10.65.0.27:51129",
+					"172.17.0.1:51129",
+					"172.18.0.1:51129",
+					"172.19.0.1:51129"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:50:06.549681383Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5611305016224092,
+				"StableID":   "nDRoG8UNpk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca2338efb9bd78b8696fc15df28683fdc7bad9521aaf6f49b5c99d4eb94cd66f",
+				"DiscoKey":   "discokey:942e5b261eae7d154f9ff256b054eddc1575ddf53e526a6bfce1dc459a7dff4c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49649",
+					"10.65.0.27:49649",
+					"172.17.0.1:49649",
+					"172.18.0.1:49649",
+					"172.19.0.1:49649"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:50:07.097990745Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7223325092152205,
+				"StableID":   "ngnAH6WTQy11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1327edde3f67214164b0fe2f28abb9c0c5e0b03c40953d270a028ee9cea0a764",
+				"DiscoKey":   "discokey:26936e7f6ea63c733d36ad53ee6501bb9990b652dc4594f535e231e5d913a52f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:54326",
+					"10.65.0.27:54326",
+					"172.17.0.1:54326",
+					"172.18.0.1:54326",
+					"172.19.0.1:54326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:50:07.636979821Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         463642494993577,
+				"StableID":   "nvdacv6zc411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1112f75004aa82c778985c437128f6deaf6fd9e830d030caba98705a1e23ef57",
+				"DiscoKey":   "discokey:36860faf5c2193e3f53de89f267d2698d2469a32476c01f7376b97daa16f8d20",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:32861",
+					"10.65.0.27:32861",
+					"172.17.0.1:32861",
+					"172.18.0.1:32861",
+					"172.19.0.1:32861"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:50:08.182538709Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4217434516485789,
+				"StableID":   "nEBAJVr5wZ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ed05ffaded4b0d3d199e73685cde3d710708e0568136abb3c7dbfae1b7d52d3c",
+				"DiscoKey":   "discokey:4974ae6aec603f79e40a95852d545ff79be2a69d651a593721660ee3df51427b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35238",
+					"10.65.0.27:35238",
+					"172.17.0.1:35238",
+					"172.18.0.1:35238",
+					"172.19.0.1:35238"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:50:08.714646927Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3529305711163648,
+				"StableID":   "nmT3AqsRZU11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:96ef6337e8bcafd869253c00fedf5eba2d1e1a805720353586b34da45f646061",
+				"DiscoKey":   "discokey:8c86a8f141c1e7833b687561c75efb7320f9aee43c2c435a82482fae4905066c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33867",
+					"10.65.0.27:33867",
+					"172.17.0.1:33867",
+					"172.18.0.1:33867",
+					"172.19.0.1:33867"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:50:09.791505245Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4355610744675286,
+				"StableID":   "n7RHRVWf1b11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85ef0a3b5218694a655cda07a460a362da05a457e56f5aa9d9d000d1e3eb8b1f",
+				"DiscoKey":   "discokey:8950ee167c429142e8c9856e5eb27ecae26d2dc1f0df8b35f3800e447af6410d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:34584",
+					"10.65.0.27:34584",
+					"172.17.0.1:34584",
+					"172.18.0.1:34584",
+					"172.19.0.1:34584"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:50:10.339831499Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2151322144431074,
+				"StableID":   "nbPi3vaLoH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eca8973b3cc6927706f8ee99e4fd6c0458394e2a60060eec856aeb4f93799c77",
+				"DiscoKey":   "discokey:736b9236a67d97d90554a6bd15d9ad1b337cc4231cc11fc7eff8aa7f709a2e16",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51887",
+					"10.65.0.27:51887",
+					"172.17.0.1:51887",
+					"172.18.0.1:51887",
+					"172.19.0.1:51887"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:50:10.878711627Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6163617912692372,
+				"StableID":   "n36MdsnW8q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eddae4c993276f7b2b5840a12a18ee0bb2e1ce33dfaa9a649a258a14e03ef511",
+				"DiscoKey":   "discokey:92ac080ac94b12637bf83b12e2265e39dae28ff1636b3baad1f542170a30f000",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:42367",
+					"10.65.0.27:42367",
+					"172.17.0.1:42367",
+					"172.18.0.1:42367",
+					"172.19.0.1:42367"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:50:11.428739795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6524636438685117,
+				"StableID":   "nYA6Xr82xs11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a4a960d2074c5da1ed25f1fb368b1a9a5e3e6916d784b1b1386f16f53bdc7448",
+				"KeyExpiry":  "2026-11-08T21:50:11Z",
+				"DiscoKey":   "discokey:6607f7e7b624b6ae22f6e0d7d7d8eead196c76230eaa33b1bbf78443ed57de31",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47249",
+					"10.65.0.27:47249",
+					"172.17.0.1:47249",
+					"172.18.0.1:47249",
+					"172.19.0.1:47249"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:50:11.960875922Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4535244346071940,
+				"StableID":   "n7xZeMB2Rc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:39942571da581342e0641ebe9691e7c27142898ced25e9ca690567dcf77ce069",
+				"KeyExpiry":  "2026-11-08T21:50:12Z",
+				"DiscoKey":   "discokey:f88ce12faa767bc1b32ee183c0a4ffab5e8f9a4481ace9c4e375793f944b816d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35948",
+					"10.65.0.27:35948",
+					"172.17.0.1:35948",
+					"172.18.0.1:35948",
+					"172.19.0.1:35948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:50:12.501153112Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8966211731136578,
+				"StableID":   "nHCCLLBp1D21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1c0acb7466b59e9da6293fe6564a1a5dc19e1b048a3c366cb8b71b14dc6f0a3b",
+				"KeyExpiry":  "2026-11-08T21:50:13Z",
+				"DiscoKey":   "discokey:94dc554bbe37455a2492c05cdefb1968e6e02f0733f69f2d5b3cc3eaa78a7625",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:37204",
+					"10.65.0.27:37204",
+					"172.17.0.1:37204",
+					"172.18.0.1:37204",
+					"172.19.0.1:37204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:50:13.04294014Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6658212941527777": {
+				"ID":          6658212941527777,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6524636438685117,
+				"StableID":   "nYA6Xr82xs11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a4a960d2074c5da1ed25f1fb368b1a9a5e3e6916d784b1b1386f16f53bdc7448",
+				"KeyExpiry":  "2026-11-08T21:50:11Z",
+				"DiscoKey":   "discokey:6607f7e7b624b6ae22f6e0d7d7d8eead196c76230eaa33b1bbf78443ed57de31",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47249",
+					"10.65.0.27:47249",
+					"172.17.0.1:47249",
+					"172.18.0.1:47249",
+					"172.19.0.1:47249"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:50:11.960875922Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a4a960d2074c5da1ed25f1fb368b1a9a5e3e6916d784b1b1386f16f53bdc7448",
+			"MachineKey": "mkey:1e093d52c0f6f2277382d8359894769648311b67296cf305b29bdeeeaaf1127d",
+			"Peers": [{
+				"ID":         6625227475231950,
+				"StableID":   "nFTixVVajt11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90fcbf1ad58ef8563c8ee652fb6e7761c16641ac6e5b6b757c1e39bae482f113",
+				"DiscoKey":   "discokey:1b82489d4a371ce057192a9e37c1901f886a7b25f788b7736fc2cc9482387273",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33930",
+					"10.65.0.27:33930",
+					"172.17.0.1:33930",
+					"172.18.0.1:33930",
+					"172.19.0.1:33930"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:50:05.529551314Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5134075546780876,
+				"StableID":   "n7zgFcTE6h11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5648cf90babe07790eb7c3cb5a98df2c85fc988c9740b081da4c824e446e2028",
+				"DiscoKey":   "discokey:244d0fdfea0126edd0d23d5c457ace853b64b576d24528ff312e3a35b4aedd03",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51927",
+					"10.65.0.27:51927",
+					"172.17.0.1:51927",
+					"172.18.0.1:51927",
+					"172.19.0.1:51927"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:50:06.010196053Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7739482568080407,
+				"StableID":   "nzpqvp5ES321CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4b8dfb2fc0245b0c946a6dc15def7147302e67427a7b138bedf7ed3b903f271",
+				"DiscoKey":   "discokey:debd3e359fad846d274d8594ab65fe71fc0762b33b6b30de6dfe354c94b80f10",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:51129",
+					"10.65.0.27:51129",
+					"172.17.0.1:51129",
+					"172.18.0.1:51129",
+					"172.19.0.1:51129"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:50:06.549681383Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5611305016224092,
+				"StableID":   "nDRoG8UNpk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca2338efb9bd78b8696fc15df28683fdc7bad9521aaf6f49b5c99d4eb94cd66f",
+				"DiscoKey":   "discokey:942e5b261eae7d154f9ff256b054eddc1575ddf53e526a6bfce1dc459a7dff4c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49649",
+					"10.65.0.27:49649",
+					"172.17.0.1:49649",
+					"172.18.0.1:49649",
+					"172.19.0.1:49649"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:50:07.097990745Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7223325092152205,
+				"StableID":   "ngnAH6WTQy11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1327edde3f67214164b0fe2f28abb9c0c5e0b03c40953d270a028ee9cea0a764",
+				"DiscoKey":   "discokey:26936e7f6ea63c733d36ad53ee6501bb9990b652dc4594f535e231e5d913a52f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:54326",
+					"10.65.0.27:54326",
+					"172.17.0.1:54326",
+					"172.18.0.1:54326",
+					"172.19.0.1:54326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:50:07.636979821Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         463642494993577,
+				"StableID":   "nvdacv6zc411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1112f75004aa82c778985c437128f6deaf6fd9e830d030caba98705a1e23ef57",
+				"DiscoKey":   "discokey:36860faf5c2193e3f53de89f267d2698d2469a32476c01f7376b97daa16f8d20",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:32861",
+					"10.65.0.27:32861",
+					"172.17.0.1:32861",
+					"172.18.0.1:32861",
+					"172.19.0.1:32861"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:50:08.182538709Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4217434516485789,
+				"StableID":   "nEBAJVr5wZ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ed05ffaded4b0d3d199e73685cde3d710708e0568136abb3c7dbfae1b7d52d3c",
+				"DiscoKey":   "discokey:4974ae6aec603f79e40a95852d545ff79be2a69d651a593721660ee3df51427b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35238",
+					"10.65.0.27:35238",
+					"172.17.0.1:35238",
+					"172.18.0.1:35238",
+					"172.19.0.1:35238"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:50:08.714646927Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6658212941527777,
+				"StableID":   "nCpVftxWzt11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7b460a57862a7407e3eaf12d5491fe4b585e74c86fa688c97aacaf3b9e88bc5a",
+				"DiscoKey":   "discokey:aa55a178e6c855a88d36c8cece677c6cd27564842d68e0348a452045ff37a268",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:56882",
+					"10.65.0.27:56882",
+					"172.17.0.1:56882",
+					"172.18.0.1:56882",
+					"172.19.0.1:56882"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:50:09.273818206Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3529305711163648,
+				"StableID":   "nmT3AqsRZU11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:96ef6337e8bcafd869253c00fedf5eba2d1e1a805720353586b34da45f646061",
+				"DiscoKey":   "discokey:8c86a8f141c1e7833b687561c75efb7320f9aee43c2c435a82482fae4905066c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33867",
+					"10.65.0.27:33867",
+					"172.17.0.1:33867",
+					"172.18.0.1:33867",
+					"172.19.0.1:33867"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:50:09.791505245Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4355610744675286,
+				"StableID":   "n7RHRVWf1b11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85ef0a3b5218694a655cda07a460a362da05a457e56f5aa9d9d000d1e3eb8b1f",
+				"DiscoKey":   "discokey:8950ee167c429142e8c9856e5eb27ecae26d2dc1f0df8b35f3800e447af6410d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:34584",
+					"10.65.0.27:34584",
+					"172.17.0.1:34584",
+					"172.18.0.1:34584",
+					"172.19.0.1:34584"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:50:10.339831499Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2151322144431074,
+				"StableID":   "nbPi3vaLoH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eca8973b3cc6927706f8ee99e4fd6c0458394e2a60060eec856aeb4f93799c77",
+				"DiscoKey":   "discokey:736b9236a67d97d90554a6bd15d9ad1b337cc4231cc11fc7eff8aa7f709a2e16",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51887",
+					"10.65.0.27:51887",
+					"172.17.0.1:51887",
+					"172.18.0.1:51887",
+					"172.19.0.1:51887"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:50:10.878711627Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6163617912692372,
+				"StableID":   "n36MdsnW8q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eddae4c993276f7b2b5840a12a18ee0bb2e1ce33dfaa9a649a258a14e03ef511",
+				"DiscoKey":   "discokey:92ac080ac94b12637bf83b12e2265e39dae28ff1636b3baad1f542170a30f000",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:42367",
+					"10.65.0.27:42367",
+					"172.17.0.1:42367",
+					"172.18.0.1:42367",
+					"172.19.0.1:42367"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:50:11.428739795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4535244346071940,
+				"StableID":   "n7xZeMB2Rc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:39942571da581342e0641ebe9691e7c27142898ced25e9ca690567dcf77ce069",
+				"KeyExpiry":  "2026-11-08T21:50:12Z",
+				"DiscoKey":   "discokey:f88ce12faa767bc1b32ee183c0a4ffab5e8f9a4481ace9c4e375793f944b816d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35948",
+					"10.65.0.27:35948",
+					"172.17.0.1:35948",
+					"172.18.0.1:35948",
+					"172.19.0.1:35948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:50:12.501153112Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8966211731136578,
+				"StableID":   "nHCCLLBp1D21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1c0acb7466b59e9da6293fe6564a1a5dc19e1b048a3c366cb8b71b14dc6f0a3b",
+				"KeyExpiry":  "2026-11-08T21:50:13Z",
+				"DiscoKey":   "discokey:94dc554bbe37455a2492c05cdefb1968e6e02f0733f69f2d5b3cc3eaa78a7625",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:37204",
+					"10.65.0.27:37204",
+					"172.17.0.1:37204",
+					"172.18.0.1:37204",
+					"172.19.0.1:37204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:50:13.04294014Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2151322144431074,
+				"StableID":   "nbPi3vaLoH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       2151322144431074,
+				"Key":        "nodekey:eca8973b3cc6927706f8ee99e4fd6c0458394e2a60060eec856aeb4f93799c77",
+				"DiscoKey":   "discokey:736b9236a67d97d90554a6bd15d9ad1b337cc4231cc11fc7eff8aa7f709a2e16",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51887",
+					"10.65.0.27:51887",
+					"172.17.0.1:51887",
+					"172.18.0.1:51887",
+					"172.19.0.1:51887"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:50:10.878711627Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:eca8973b3cc6927706f8ee99e4fd6c0458394e2a60060eec856aeb4f93799c77",
+			"MachineKey": "mkey:339b0d085d149406a875abd707036645f4c8eea67ffb76a8388fdbcef4aad56e",
+			"Peers": [{
+				"ID":         6625227475231950,
+				"StableID":   "nFTixVVajt11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90fcbf1ad58ef8563c8ee652fb6e7761c16641ac6e5b6b757c1e39bae482f113",
+				"DiscoKey":   "discokey:1b82489d4a371ce057192a9e37c1901f886a7b25f788b7736fc2cc9482387273",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33930",
+					"10.65.0.27:33930",
+					"172.17.0.1:33930",
+					"172.18.0.1:33930",
+					"172.19.0.1:33930"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:50:05.529551314Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5134075546780876,
+				"StableID":   "n7zgFcTE6h11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5648cf90babe07790eb7c3cb5a98df2c85fc988c9740b081da4c824e446e2028",
+				"DiscoKey":   "discokey:244d0fdfea0126edd0d23d5c457ace853b64b576d24528ff312e3a35b4aedd03",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51927",
+					"10.65.0.27:51927",
+					"172.17.0.1:51927",
+					"172.18.0.1:51927",
+					"172.19.0.1:51927"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:50:06.010196053Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7739482568080407,
+				"StableID":   "nzpqvp5ES321CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4b8dfb2fc0245b0c946a6dc15def7147302e67427a7b138bedf7ed3b903f271",
+				"DiscoKey":   "discokey:debd3e359fad846d274d8594ab65fe71fc0762b33b6b30de6dfe354c94b80f10",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:51129",
+					"10.65.0.27:51129",
+					"172.17.0.1:51129",
+					"172.18.0.1:51129",
+					"172.19.0.1:51129"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:50:06.549681383Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5611305016224092,
+				"StableID":   "nDRoG8UNpk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca2338efb9bd78b8696fc15df28683fdc7bad9521aaf6f49b5c99d4eb94cd66f",
+				"DiscoKey":   "discokey:942e5b261eae7d154f9ff256b054eddc1575ddf53e526a6bfce1dc459a7dff4c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49649",
+					"10.65.0.27:49649",
+					"172.17.0.1:49649",
+					"172.18.0.1:49649",
+					"172.19.0.1:49649"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:50:07.097990745Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7223325092152205,
+				"StableID":   "ngnAH6WTQy11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1327edde3f67214164b0fe2f28abb9c0c5e0b03c40953d270a028ee9cea0a764",
+				"DiscoKey":   "discokey:26936e7f6ea63c733d36ad53ee6501bb9990b652dc4594f535e231e5d913a52f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:54326",
+					"10.65.0.27:54326",
+					"172.17.0.1:54326",
+					"172.18.0.1:54326",
+					"172.19.0.1:54326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:50:07.636979821Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         463642494993577,
+				"StableID":   "nvdacv6zc411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1112f75004aa82c778985c437128f6deaf6fd9e830d030caba98705a1e23ef57",
+				"DiscoKey":   "discokey:36860faf5c2193e3f53de89f267d2698d2469a32476c01f7376b97daa16f8d20",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:32861",
+					"10.65.0.27:32861",
+					"172.17.0.1:32861",
+					"172.18.0.1:32861",
+					"172.19.0.1:32861"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:50:08.182538709Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4217434516485789,
+				"StableID":   "nEBAJVr5wZ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ed05ffaded4b0d3d199e73685cde3d710708e0568136abb3c7dbfae1b7d52d3c",
+				"DiscoKey":   "discokey:4974ae6aec603f79e40a95852d545ff79be2a69d651a593721660ee3df51427b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35238",
+					"10.65.0.27:35238",
+					"172.17.0.1:35238",
+					"172.18.0.1:35238",
+					"172.19.0.1:35238"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:50:08.714646927Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6658212941527777,
+				"StableID":   "nCpVftxWzt11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7b460a57862a7407e3eaf12d5491fe4b585e74c86fa688c97aacaf3b9e88bc5a",
+				"DiscoKey":   "discokey:aa55a178e6c855a88d36c8cece677c6cd27564842d68e0348a452045ff37a268",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:56882",
+					"10.65.0.27:56882",
+					"172.17.0.1:56882",
+					"172.18.0.1:56882",
+					"172.19.0.1:56882"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:50:09.273818206Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3529305711163648,
+				"StableID":   "nmT3AqsRZU11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:96ef6337e8bcafd869253c00fedf5eba2d1e1a805720353586b34da45f646061",
+				"DiscoKey":   "discokey:8c86a8f141c1e7833b687561c75efb7320f9aee43c2c435a82482fae4905066c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33867",
+					"10.65.0.27:33867",
+					"172.17.0.1:33867",
+					"172.18.0.1:33867",
+					"172.19.0.1:33867"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:50:09.791505245Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4355610744675286,
+				"StableID":   "n7RHRVWf1b11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85ef0a3b5218694a655cda07a460a362da05a457e56f5aa9d9d000d1e3eb8b1f",
+				"DiscoKey":   "discokey:8950ee167c429142e8c9856e5eb27ecae26d2dc1f0df8b35f3800e447af6410d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:34584",
+					"10.65.0.27:34584",
+					"172.17.0.1:34584",
+					"172.18.0.1:34584",
+					"172.19.0.1:34584"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:50:10.339831499Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6163617912692372,
+				"StableID":   "n36MdsnW8q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eddae4c993276f7b2b5840a12a18ee0bb2e1ce33dfaa9a649a258a14e03ef511",
+				"DiscoKey":   "discokey:92ac080ac94b12637bf83b12e2265e39dae28ff1636b3baad1f542170a30f000",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:42367",
+					"10.65.0.27:42367",
+					"172.17.0.1:42367",
+					"172.18.0.1:42367",
+					"172.19.0.1:42367"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:50:11.428739795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6524636438685117,
+				"StableID":   "nYA6Xr82xs11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a4a960d2074c5da1ed25f1fb368b1a9a5e3e6916d784b1b1386f16f53bdc7448",
+				"KeyExpiry":  "2026-11-08T21:50:11Z",
+				"DiscoKey":   "discokey:6607f7e7b624b6ae22f6e0d7d7d8eead196c76230eaa33b1bbf78443ed57de31",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47249",
+					"10.65.0.27:47249",
+					"172.17.0.1:47249",
+					"172.18.0.1:47249",
+					"172.19.0.1:47249"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:50:11.960875922Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4535244346071940,
+				"StableID":   "n7xZeMB2Rc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:39942571da581342e0641ebe9691e7c27142898ced25e9ca690567dcf77ce069",
+				"KeyExpiry":  "2026-11-08T21:50:12Z",
+				"DiscoKey":   "discokey:f88ce12faa767bc1b32ee183c0a4ffab5e8f9a4481ace9c4e375793f944b816d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35948",
+					"10.65.0.27:35948",
+					"172.17.0.1:35948",
+					"172.18.0.1:35948",
+					"172.19.0.1:35948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:50:12.501153112Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8966211731136578,
+				"StableID":   "nHCCLLBp1D21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1c0acb7466b59e9da6293fe6564a1a5dc19e1b048a3c366cb8b71b14dc6f0a3b",
+				"KeyExpiry":  "2026-11-08T21:50:13Z",
+				"DiscoKey":   "discokey:94dc554bbe37455a2492c05cdefb1968e6e02f0733f69f2d5b3cc3eaa78a7625",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:37204",
+					"10.65.0.27:37204",
+					"172.17.0.1:37204",
+					"172.18.0.1:37204",
+					"172.19.0.1:37204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:50:13.04294014Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2151322144431074": {
+				"ID":          2151322144431074,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5134075546780876,
+				"StableID":   "n7zgFcTE6h11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       5134075546780876,
+				"Key":        "nodekey:5648cf90babe07790eb7c3cb5a98df2c85fc988c9740b081da4c824e446e2028",
+				"DiscoKey":   "discokey:244d0fdfea0126edd0d23d5c457ace853b64b576d24528ff312e3a35b4aedd03",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51927",
+					"10.65.0.27:51927",
+					"172.17.0.1:51927",
+					"172.18.0.1:51927",
+					"172.19.0.1:51927"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:50:06.010196053Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5648cf90babe07790eb7c3cb5a98df2c85fc988c9740b081da4c824e446e2028",
+			"MachineKey": "mkey:60a7c10195dd96bc2c9b56c8131d28362abae7929f12d1d2a3958c463b8a3713",
+			"Peers": [{
+				"ID":         6625227475231950,
+				"StableID":   "nFTixVVajt11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90fcbf1ad58ef8563c8ee652fb6e7761c16641ac6e5b6b757c1e39bae482f113",
+				"DiscoKey":   "discokey:1b82489d4a371ce057192a9e37c1901f886a7b25f788b7736fc2cc9482387273",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33930",
+					"10.65.0.27:33930",
+					"172.17.0.1:33930",
+					"172.18.0.1:33930",
+					"172.19.0.1:33930"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:50:05.529551314Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7739482568080407,
+				"StableID":   "nzpqvp5ES321CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4b8dfb2fc0245b0c946a6dc15def7147302e67427a7b138bedf7ed3b903f271",
+				"DiscoKey":   "discokey:debd3e359fad846d274d8594ab65fe71fc0762b33b6b30de6dfe354c94b80f10",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:51129",
+					"10.65.0.27:51129",
+					"172.17.0.1:51129",
+					"172.18.0.1:51129",
+					"172.19.0.1:51129"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:50:06.549681383Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5611305016224092,
+				"StableID":   "nDRoG8UNpk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca2338efb9bd78b8696fc15df28683fdc7bad9521aaf6f49b5c99d4eb94cd66f",
+				"DiscoKey":   "discokey:942e5b261eae7d154f9ff256b054eddc1575ddf53e526a6bfce1dc459a7dff4c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49649",
+					"10.65.0.27:49649",
+					"172.17.0.1:49649",
+					"172.18.0.1:49649",
+					"172.19.0.1:49649"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:50:07.097990745Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7223325092152205,
+				"StableID":   "ngnAH6WTQy11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1327edde3f67214164b0fe2f28abb9c0c5e0b03c40953d270a028ee9cea0a764",
+				"DiscoKey":   "discokey:26936e7f6ea63c733d36ad53ee6501bb9990b652dc4594f535e231e5d913a52f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:54326",
+					"10.65.0.27:54326",
+					"172.17.0.1:54326",
+					"172.18.0.1:54326",
+					"172.19.0.1:54326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:50:07.636979821Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         463642494993577,
+				"StableID":   "nvdacv6zc411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1112f75004aa82c778985c437128f6deaf6fd9e830d030caba98705a1e23ef57",
+				"DiscoKey":   "discokey:36860faf5c2193e3f53de89f267d2698d2469a32476c01f7376b97daa16f8d20",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:32861",
+					"10.65.0.27:32861",
+					"172.17.0.1:32861",
+					"172.18.0.1:32861",
+					"172.19.0.1:32861"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:50:08.182538709Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4217434516485789,
+				"StableID":   "nEBAJVr5wZ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ed05ffaded4b0d3d199e73685cde3d710708e0568136abb3c7dbfae1b7d52d3c",
+				"DiscoKey":   "discokey:4974ae6aec603f79e40a95852d545ff79be2a69d651a593721660ee3df51427b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35238",
+					"10.65.0.27:35238",
+					"172.17.0.1:35238",
+					"172.18.0.1:35238",
+					"172.19.0.1:35238"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:50:08.714646927Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6658212941527777,
+				"StableID":   "nCpVftxWzt11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7b460a57862a7407e3eaf12d5491fe4b585e74c86fa688c97aacaf3b9e88bc5a",
+				"DiscoKey":   "discokey:aa55a178e6c855a88d36c8cece677c6cd27564842d68e0348a452045ff37a268",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:56882",
+					"10.65.0.27:56882",
+					"172.17.0.1:56882",
+					"172.18.0.1:56882",
+					"172.19.0.1:56882"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:50:09.273818206Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3529305711163648,
+				"StableID":   "nmT3AqsRZU11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:96ef6337e8bcafd869253c00fedf5eba2d1e1a805720353586b34da45f646061",
+				"DiscoKey":   "discokey:8c86a8f141c1e7833b687561c75efb7320f9aee43c2c435a82482fae4905066c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33867",
+					"10.65.0.27:33867",
+					"172.17.0.1:33867",
+					"172.18.0.1:33867",
+					"172.19.0.1:33867"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:50:09.791505245Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4355610744675286,
+				"StableID":   "n7RHRVWf1b11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85ef0a3b5218694a655cda07a460a362da05a457e56f5aa9d9d000d1e3eb8b1f",
+				"DiscoKey":   "discokey:8950ee167c429142e8c9856e5eb27ecae26d2dc1f0df8b35f3800e447af6410d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:34584",
+					"10.65.0.27:34584",
+					"172.17.0.1:34584",
+					"172.18.0.1:34584",
+					"172.19.0.1:34584"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:50:10.339831499Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2151322144431074,
+				"StableID":   "nbPi3vaLoH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eca8973b3cc6927706f8ee99e4fd6c0458394e2a60060eec856aeb4f93799c77",
+				"DiscoKey":   "discokey:736b9236a67d97d90554a6bd15d9ad1b337cc4231cc11fc7eff8aa7f709a2e16",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51887",
+					"10.65.0.27:51887",
+					"172.17.0.1:51887",
+					"172.18.0.1:51887",
+					"172.19.0.1:51887"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:50:10.878711627Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6163617912692372,
+				"StableID":   "n36MdsnW8q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eddae4c993276f7b2b5840a12a18ee0bb2e1ce33dfaa9a649a258a14e03ef511",
+				"DiscoKey":   "discokey:92ac080ac94b12637bf83b12e2265e39dae28ff1636b3baad1f542170a30f000",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:42367",
+					"10.65.0.27:42367",
+					"172.17.0.1:42367",
+					"172.18.0.1:42367",
+					"172.19.0.1:42367"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:50:11.428739795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6524636438685117,
+				"StableID":   "nYA6Xr82xs11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a4a960d2074c5da1ed25f1fb368b1a9a5e3e6916d784b1b1386f16f53bdc7448",
+				"KeyExpiry":  "2026-11-08T21:50:11Z",
+				"DiscoKey":   "discokey:6607f7e7b624b6ae22f6e0d7d7d8eead196c76230eaa33b1bbf78443ed57de31",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47249",
+					"10.65.0.27:47249",
+					"172.17.0.1:47249",
+					"172.18.0.1:47249",
+					"172.19.0.1:47249"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:50:11.960875922Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4535244346071940,
+				"StableID":   "n7xZeMB2Rc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:39942571da581342e0641ebe9691e7c27142898ced25e9ca690567dcf77ce069",
+				"KeyExpiry":  "2026-11-08T21:50:12Z",
+				"DiscoKey":   "discokey:f88ce12faa767bc1b32ee183c0a4ffab5e8f9a4481ace9c4e375793f944b816d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35948",
+					"10.65.0.27:35948",
+					"172.17.0.1:35948",
+					"172.18.0.1:35948",
+					"172.19.0.1:35948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:50:12.501153112Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8966211731136578,
+				"StableID":   "nHCCLLBp1D21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1c0acb7466b59e9da6293fe6564a1a5dc19e1b048a3c366cb8b71b14dc6f0a3b",
+				"KeyExpiry":  "2026-11-08T21:50:13Z",
+				"DiscoKey":   "discokey:94dc554bbe37455a2492c05cdefb1968e6e02f0733f69f2d5b3cc3eaa78a7625",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:37204",
+					"10.65.0.27:37204",
+					"172.17.0.1:37204",
+					"172.18.0.1:37204",
+					"172.19.0.1:37204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:50:13.04294014Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5134075546780876": {
+				"ID":          5134075546780876,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6625227475231950,
+				"StableID":   "nFTixVVajt11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       6625227475231950,
+				"Key":        "nodekey:90fcbf1ad58ef8563c8ee652fb6e7761c16641ac6e5b6b757c1e39bae482f113",
+				"DiscoKey":   "discokey:1b82489d4a371ce057192a9e37c1901f886a7b25f788b7736fc2cc9482387273",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33930",
+					"10.65.0.27:33930",
+					"172.17.0.1:33930",
+					"172.18.0.1:33930",
+					"172.19.0.1:33930"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:50:05.529551314Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:90fcbf1ad58ef8563c8ee652fb6e7761c16641ac6e5b6b757c1e39bae482f113",
+			"MachineKey": "mkey:eedf5c9b39ae46cb94043656753ddd8a5d10d3f1d658dbf24e0057be8d239638",
+			"Peers": [{
+				"ID":         5134075546780876,
+				"StableID":   "n7zgFcTE6h11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5648cf90babe07790eb7c3cb5a98df2c85fc988c9740b081da4c824e446e2028",
+				"DiscoKey":   "discokey:244d0fdfea0126edd0d23d5c457ace853b64b576d24528ff312e3a35b4aedd03",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51927",
+					"10.65.0.27:51927",
+					"172.17.0.1:51927",
+					"172.18.0.1:51927",
+					"172.19.0.1:51927"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:50:06.010196053Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7739482568080407,
+				"StableID":   "nzpqvp5ES321CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4b8dfb2fc0245b0c946a6dc15def7147302e67427a7b138bedf7ed3b903f271",
+				"DiscoKey":   "discokey:debd3e359fad846d274d8594ab65fe71fc0762b33b6b30de6dfe354c94b80f10",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:51129",
+					"10.65.0.27:51129",
+					"172.17.0.1:51129",
+					"172.18.0.1:51129",
+					"172.19.0.1:51129"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:50:06.549681383Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5611305016224092,
+				"StableID":   "nDRoG8UNpk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca2338efb9bd78b8696fc15df28683fdc7bad9521aaf6f49b5c99d4eb94cd66f",
+				"DiscoKey":   "discokey:942e5b261eae7d154f9ff256b054eddc1575ddf53e526a6bfce1dc459a7dff4c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49649",
+					"10.65.0.27:49649",
+					"172.17.0.1:49649",
+					"172.18.0.1:49649",
+					"172.19.0.1:49649"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:50:07.097990745Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7223325092152205,
+				"StableID":   "ngnAH6WTQy11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1327edde3f67214164b0fe2f28abb9c0c5e0b03c40953d270a028ee9cea0a764",
+				"DiscoKey":   "discokey:26936e7f6ea63c733d36ad53ee6501bb9990b652dc4594f535e231e5d913a52f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:54326",
+					"10.65.0.27:54326",
+					"172.17.0.1:54326",
+					"172.18.0.1:54326",
+					"172.19.0.1:54326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:50:07.636979821Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         463642494993577,
+				"StableID":   "nvdacv6zc411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1112f75004aa82c778985c437128f6deaf6fd9e830d030caba98705a1e23ef57",
+				"DiscoKey":   "discokey:36860faf5c2193e3f53de89f267d2698d2469a32476c01f7376b97daa16f8d20",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:32861",
+					"10.65.0.27:32861",
+					"172.17.0.1:32861",
+					"172.18.0.1:32861",
+					"172.19.0.1:32861"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:50:08.182538709Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4217434516485789,
+				"StableID":   "nEBAJVr5wZ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ed05ffaded4b0d3d199e73685cde3d710708e0568136abb3c7dbfae1b7d52d3c",
+				"DiscoKey":   "discokey:4974ae6aec603f79e40a95852d545ff79be2a69d651a593721660ee3df51427b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35238",
+					"10.65.0.27:35238",
+					"172.17.0.1:35238",
+					"172.18.0.1:35238",
+					"172.19.0.1:35238"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:50:08.714646927Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6658212941527777,
+				"StableID":   "nCpVftxWzt11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7b460a57862a7407e3eaf12d5491fe4b585e74c86fa688c97aacaf3b9e88bc5a",
+				"DiscoKey":   "discokey:aa55a178e6c855a88d36c8cece677c6cd27564842d68e0348a452045ff37a268",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:56882",
+					"10.65.0.27:56882",
+					"172.17.0.1:56882",
+					"172.18.0.1:56882",
+					"172.19.0.1:56882"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:50:09.273818206Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3529305711163648,
+				"StableID":   "nmT3AqsRZU11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:96ef6337e8bcafd869253c00fedf5eba2d1e1a805720353586b34da45f646061",
+				"DiscoKey":   "discokey:8c86a8f141c1e7833b687561c75efb7320f9aee43c2c435a82482fae4905066c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33867",
+					"10.65.0.27:33867",
+					"172.17.0.1:33867",
+					"172.18.0.1:33867",
+					"172.19.0.1:33867"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:50:09.791505245Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4355610744675286,
+				"StableID":   "n7RHRVWf1b11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85ef0a3b5218694a655cda07a460a362da05a457e56f5aa9d9d000d1e3eb8b1f",
+				"DiscoKey":   "discokey:8950ee167c429142e8c9856e5eb27ecae26d2dc1f0df8b35f3800e447af6410d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:34584",
+					"10.65.0.27:34584",
+					"172.17.0.1:34584",
+					"172.18.0.1:34584",
+					"172.19.0.1:34584"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:50:10.339831499Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2151322144431074,
+				"StableID":   "nbPi3vaLoH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eca8973b3cc6927706f8ee99e4fd6c0458394e2a60060eec856aeb4f93799c77",
+				"DiscoKey":   "discokey:736b9236a67d97d90554a6bd15d9ad1b337cc4231cc11fc7eff8aa7f709a2e16",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51887",
+					"10.65.0.27:51887",
+					"172.17.0.1:51887",
+					"172.18.0.1:51887",
+					"172.19.0.1:51887"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:50:10.878711627Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6163617912692372,
+				"StableID":   "n36MdsnW8q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eddae4c993276f7b2b5840a12a18ee0bb2e1ce33dfaa9a649a258a14e03ef511",
+				"DiscoKey":   "discokey:92ac080ac94b12637bf83b12e2265e39dae28ff1636b3baad1f542170a30f000",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:42367",
+					"10.65.0.27:42367",
+					"172.17.0.1:42367",
+					"172.18.0.1:42367",
+					"172.19.0.1:42367"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:50:11.428739795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6524636438685117,
+				"StableID":   "nYA6Xr82xs11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a4a960d2074c5da1ed25f1fb368b1a9a5e3e6916d784b1b1386f16f53bdc7448",
+				"KeyExpiry":  "2026-11-08T21:50:11Z",
+				"DiscoKey":   "discokey:6607f7e7b624b6ae22f6e0d7d7d8eead196c76230eaa33b1bbf78443ed57de31",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47249",
+					"10.65.0.27:47249",
+					"172.17.0.1:47249",
+					"172.18.0.1:47249",
+					"172.19.0.1:47249"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:50:11.960875922Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4535244346071940,
+				"StableID":   "n7xZeMB2Rc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:39942571da581342e0641ebe9691e7c27142898ced25e9ca690567dcf77ce069",
+				"KeyExpiry":  "2026-11-08T21:50:12Z",
+				"DiscoKey":   "discokey:f88ce12faa767bc1b32ee183c0a4ffab5e8f9a4481ace9c4e375793f944b816d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35948",
+					"10.65.0.27:35948",
+					"172.17.0.1:35948",
+					"172.18.0.1:35948",
+					"172.19.0.1:35948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:50:12.501153112Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8966211731136578,
+				"StableID":   "nHCCLLBp1D21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1c0acb7466b59e9da6293fe6564a1a5dc19e1b048a3c366cb8b71b14dc6f0a3b",
+				"KeyExpiry":  "2026-11-08T21:50:13Z",
+				"DiscoKey":   "discokey:94dc554bbe37455a2492c05cdefb1968e6e02f0733f69f2d5b3cc3eaa78a7625",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:37204",
+					"10.65.0.27:37204",
+					"172.17.0.1:37204",
+					"172.18.0.1:37204",
+					"172.19.0.1:37204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:50:13.04294014Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6625227475231950": {
+				"ID":          6625227475231950,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7223325092152205,
+				"StableID":   "ngnAH6WTQy11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       7223325092152205,
+				"Key":        "nodekey:1327edde3f67214164b0fe2f28abb9c0c5e0b03c40953d270a028ee9cea0a764",
+				"DiscoKey":   "discokey:26936e7f6ea63c733d36ad53ee6501bb9990b652dc4594f535e231e5d913a52f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:54326",
+					"10.65.0.27:54326",
+					"172.17.0.1:54326",
+					"172.18.0.1:54326",
+					"172.19.0.1:54326"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:50:07.636979821Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1327edde3f67214164b0fe2f28abb9c0c5e0b03c40953d270a028ee9cea0a764",
+			"MachineKey": "mkey:3e814c8d6266e79e25d358d30fc32cbfdd5d9facfc27736cbc008eba6484f936",
+			"Peers": [{
+				"ID":         6625227475231950,
+				"StableID":   "nFTixVVajt11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90fcbf1ad58ef8563c8ee652fb6e7761c16641ac6e5b6b757c1e39bae482f113",
+				"DiscoKey":   "discokey:1b82489d4a371ce057192a9e37c1901f886a7b25f788b7736fc2cc9482387273",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33930",
+					"10.65.0.27:33930",
+					"172.17.0.1:33930",
+					"172.18.0.1:33930",
+					"172.19.0.1:33930"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:50:05.529551314Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5134075546780876,
+				"StableID":   "n7zgFcTE6h11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5648cf90babe07790eb7c3cb5a98df2c85fc988c9740b081da4c824e446e2028",
+				"DiscoKey":   "discokey:244d0fdfea0126edd0d23d5c457ace853b64b576d24528ff312e3a35b4aedd03",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51927",
+					"10.65.0.27:51927",
+					"172.17.0.1:51927",
+					"172.18.0.1:51927",
+					"172.19.0.1:51927"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:50:06.010196053Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7739482568080407,
+				"StableID":   "nzpqvp5ES321CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4b8dfb2fc0245b0c946a6dc15def7147302e67427a7b138bedf7ed3b903f271",
+				"DiscoKey":   "discokey:debd3e359fad846d274d8594ab65fe71fc0762b33b6b30de6dfe354c94b80f10",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:51129",
+					"10.65.0.27:51129",
+					"172.17.0.1:51129",
+					"172.18.0.1:51129",
+					"172.19.0.1:51129"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:50:06.549681383Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5611305016224092,
+				"StableID":   "nDRoG8UNpk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca2338efb9bd78b8696fc15df28683fdc7bad9521aaf6f49b5c99d4eb94cd66f",
+				"DiscoKey":   "discokey:942e5b261eae7d154f9ff256b054eddc1575ddf53e526a6bfce1dc459a7dff4c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49649",
+					"10.65.0.27:49649",
+					"172.17.0.1:49649",
+					"172.18.0.1:49649",
+					"172.19.0.1:49649"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:50:07.097990745Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         463642494993577,
+				"StableID":   "nvdacv6zc411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1112f75004aa82c778985c437128f6deaf6fd9e830d030caba98705a1e23ef57",
+				"DiscoKey":   "discokey:36860faf5c2193e3f53de89f267d2698d2469a32476c01f7376b97daa16f8d20",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:32861",
+					"10.65.0.27:32861",
+					"172.17.0.1:32861",
+					"172.18.0.1:32861",
+					"172.19.0.1:32861"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:50:08.182538709Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4217434516485789,
+				"StableID":   "nEBAJVr5wZ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ed05ffaded4b0d3d199e73685cde3d710708e0568136abb3c7dbfae1b7d52d3c",
+				"DiscoKey":   "discokey:4974ae6aec603f79e40a95852d545ff79be2a69d651a593721660ee3df51427b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35238",
+					"10.65.0.27:35238",
+					"172.17.0.1:35238",
+					"172.18.0.1:35238",
+					"172.19.0.1:35238"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:50:08.714646927Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6658212941527777,
+				"StableID":   "nCpVftxWzt11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7b460a57862a7407e3eaf12d5491fe4b585e74c86fa688c97aacaf3b9e88bc5a",
+				"DiscoKey":   "discokey:aa55a178e6c855a88d36c8cece677c6cd27564842d68e0348a452045ff37a268",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:56882",
+					"10.65.0.27:56882",
+					"172.17.0.1:56882",
+					"172.18.0.1:56882",
+					"172.19.0.1:56882"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:50:09.273818206Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3529305711163648,
+				"StableID":   "nmT3AqsRZU11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:96ef6337e8bcafd869253c00fedf5eba2d1e1a805720353586b34da45f646061",
+				"DiscoKey":   "discokey:8c86a8f141c1e7833b687561c75efb7320f9aee43c2c435a82482fae4905066c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33867",
+					"10.65.0.27:33867",
+					"172.17.0.1:33867",
+					"172.18.0.1:33867",
+					"172.19.0.1:33867"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:50:09.791505245Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4355610744675286,
+				"StableID":   "n7RHRVWf1b11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85ef0a3b5218694a655cda07a460a362da05a457e56f5aa9d9d000d1e3eb8b1f",
+				"DiscoKey":   "discokey:8950ee167c429142e8c9856e5eb27ecae26d2dc1f0df8b35f3800e447af6410d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:34584",
+					"10.65.0.27:34584",
+					"172.17.0.1:34584",
+					"172.18.0.1:34584",
+					"172.19.0.1:34584"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:50:10.339831499Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2151322144431074,
+				"StableID":   "nbPi3vaLoH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eca8973b3cc6927706f8ee99e4fd6c0458394e2a60060eec856aeb4f93799c77",
+				"DiscoKey":   "discokey:736b9236a67d97d90554a6bd15d9ad1b337cc4231cc11fc7eff8aa7f709a2e16",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51887",
+					"10.65.0.27:51887",
+					"172.17.0.1:51887",
+					"172.18.0.1:51887",
+					"172.19.0.1:51887"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:50:10.878711627Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6163617912692372,
+				"StableID":   "n36MdsnW8q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eddae4c993276f7b2b5840a12a18ee0bb2e1ce33dfaa9a649a258a14e03ef511",
+				"DiscoKey":   "discokey:92ac080ac94b12637bf83b12e2265e39dae28ff1636b3baad1f542170a30f000",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:42367",
+					"10.65.0.27:42367",
+					"172.17.0.1:42367",
+					"172.18.0.1:42367",
+					"172.19.0.1:42367"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:50:11.428739795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6524636438685117,
+				"StableID":   "nYA6Xr82xs11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a4a960d2074c5da1ed25f1fb368b1a9a5e3e6916d784b1b1386f16f53bdc7448",
+				"KeyExpiry":  "2026-11-08T21:50:11Z",
+				"DiscoKey":   "discokey:6607f7e7b624b6ae22f6e0d7d7d8eead196c76230eaa33b1bbf78443ed57de31",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47249",
+					"10.65.0.27:47249",
+					"172.17.0.1:47249",
+					"172.18.0.1:47249",
+					"172.19.0.1:47249"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:50:11.960875922Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4535244346071940,
+				"StableID":   "n7xZeMB2Rc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:39942571da581342e0641ebe9691e7c27142898ced25e9ca690567dcf77ce069",
+				"KeyExpiry":  "2026-11-08T21:50:12Z",
+				"DiscoKey":   "discokey:f88ce12faa767bc1b32ee183c0a4ffab5e8f9a4481ace9c4e375793f944b816d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35948",
+					"10.65.0.27:35948",
+					"172.17.0.1:35948",
+					"172.18.0.1:35948",
+					"172.19.0.1:35948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:50:12.501153112Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8966211731136578,
+				"StableID":   "nHCCLLBp1D21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1c0acb7466b59e9da6293fe6564a1a5dc19e1b048a3c366cb8b71b14dc6f0a3b",
+				"KeyExpiry":  "2026-11-08T21:50:13Z",
+				"DiscoKey":   "discokey:94dc554bbe37455a2492c05cdefb1968e6e02f0733f69f2d5b3cc3eaa78a7625",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:37204",
+					"10.65.0.27:37204",
+					"172.17.0.1:37204",
+					"172.18.0.1:37204",
+					"172.19.0.1:37204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:50:13.04294014Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7223325092152205": {
+				"ID":          7223325092152205,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5611305016224092,
+				"StableID":   "nDRoG8UNpk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       5611305016224092,
+				"Key":        "nodekey:ca2338efb9bd78b8696fc15df28683fdc7bad9521aaf6f49b5c99d4eb94cd66f",
+				"DiscoKey":   "discokey:942e5b261eae7d154f9ff256b054eddc1575ddf53e526a6bfce1dc459a7dff4c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49649",
+					"10.65.0.27:49649",
+					"172.17.0.1:49649",
+					"172.18.0.1:49649",
+					"172.19.0.1:49649"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:50:07.097990745Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ca2338efb9bd78b8696fc15df28683fdc7bad9521aaf6f49b5c99d4eb94cd66f",
+			"MachineKey": "mkey:25d35a6cb8528a12ad4be515f806b09b0c8f683dfcf676b83009294eef672475",
+			"Peers": [{
+				"ID":         6625227475231950,
+				"StableID":   "nFTixVVajt11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90fcbf1ad58ef8563c8ee652fb6e7761c16641ac6e5b6b757c1e39bae482f113",
+				"DiscoKey":   "discokey:1b82489d4a371ce057192a9e37c1901f886a7b25f788b7736fc2cc9482387273",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33930",
+					"10.65.0.27:33930",
+					"172.17.0.1:33930",
+					"172.18.0.1:33930",
+					"172.19.0.1:33930"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:50:05.529551314Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5134075546780876,
+				"StableID":   "n7zgFcTE6h11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5648cf90babe07790eb7c3cb5a98df2c85fc988c9740b081da4c824e446e2028",
+				"DiscoKey":   "discokey:244d0fdfea0126edd0d23d5c457ace853b64b576d24528ff312e3a35b4aedd03",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51927",
+					"10.65.0.27:51927",
+					"172.17.0.1:51927",
+					"172.18.0.1:51927",
+					"172.19.0.1:51927"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:50:06.010196053Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7739482568080407,
+				"StableID":   "nzpqvp5ES321CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4b8dfb2fc0245b0c946a6dc15def7147302e67427a7b138bedf7ed3b903f271",
+				"DiscoKey":   "discokey:debd3e359fad846d274d8594ab65fe71fc0762b33b6b30de6dfe354c94b80f10",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:51129",
+					"10.65.0.27:51129",
+					"172.17.0.1:51129",
+					"172.18.0.1:51129",
+					"172.19.0.1:51129"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:50:06.549681383Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7223325092152205,
+				"StableID":   "ngnAH6WTQy11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1327edde3f67214164b0fe2f28abb9c0c5e0b03c40953d270a028ee9cea0a764",
+				"DiscoKey":   "discokey:26936e7f6ea63c733d36ad53ee6501bb9990b652dc4594f535e231e5d913a52f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:54326",
+					"10.65.0.27:54326",
+					"172.17.0.1:54326",
+					"172.18.0.1:54326",
+					"172.19.0.1:54326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:50:07.636979821Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         463642494993577,
+				"StableID":   "nvdacv6zc411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1112f75004aa82c778985c437128f6deaf6fd9e830d030caba98705a1e23ef57",
+				"DiscoKey":   "discokey:36860faf5c2193e3f53de89f267d2698d2469a32476c01f7376b97daa16f8d20",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:32861",
+					"10.65.0.27:32861",
+					"172.17.0.1:32861",
+					"172.18.0.1:32861",
+					"172.19.0.1:32861"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:50:08.182538709Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4217434516485789,
+				"StableID":   "nEBAJVr5wZ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ed05ffaded4b0d3d199e73685cde3d710708e0568136abb3c7dbfae1b7d52d3c",
+				"DiscoKey":   "discokey:4974ae6aec603f79e40a95852d545ff79be2a69d651a593721660ee3df51427b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35238",
+					"10.65.0.27:35238",
+					"172.17.0.1:35238",
+					"172.18.0.1:35238",
+					"172.19.0.1:35238"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:50:08.714646927Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6658212941527777,
+				"StableID":   "nCpVftxWzt11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7b460a57862a7407e3eaf12d5491fe4b585e74c86fa688c97aacaf3b9e88bc5a",
+				"DiscoKey":   "discokey:aa55a178e6c855a88d36c8cece677c6cd27564842d68e0348a452045ff37a268",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:56882",
+					"10.65.0.27:56882",
+					"172.17.0.1:56882",
+					"172.18.0.1:56882",
+					"172.19.0.1:56882"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:50:09.273818206Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3529305711163648,
+				"StableID":   "nmT3AqsRZU11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:96ef6337e8bcafd869253c00fedf5eba2d1e1a805720353586b34da45f646061",
+				"DiscoKey":   "discokey:8c86a8f141c1e7833b687561c75efb7320f9aee43c2c435a82482fae4905066c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33867",
+					"10.65.0.27:33867",
+					"172.17.0.1:33867",
+					"172.18.0.1:33867",
+					"172.19.0.1:33867"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:50:09.791505245Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4355610744675286,
+				"StableID":   "n7RHRVWf1b11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85ef0a3b5218694a655cda07a460a362da05a457e56f5aa9d9d000d1e3eb8b1f",
+				"DiscoKey":   "discokey:8950ee167c429142e8c9856e5eb27ecae26d2dc1f0df8b35f3800e447af6410d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:34584",
+					"10.65.0.27:34584",
+					"172.17.0.1:34584",
+					"172.18.0.1:34584",
+					"172.19.0.1:34584"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:50:10.339831499Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2151322144431074,
+				"StableID":   "nbPi3vaLoH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eca8973b3cc6927706f8ee99e4fd6c0458394e2a60060eec856aeb4f93799c77",
+				"DiscoKey":   "discokey:736b9236a67d97d90554a6bd15d9ad1b337cc4231cc11fc7eff8aa7f709a2e16",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51887",
+					"10.65.0.27:51887",
+					"172.17.0.1:51887",
+					"172.18.0.1:51887",
+					"172.19.0.1:51887"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:50:10.878711627Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6163617912692372,
+				"StableID":   "n36MdsnW8q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eddae4c993276f7b2b5840a12a18ee0bb2e1ce33dfaa9a649a258a14e03ef511",
+				"DiscoKey":   "discokey:92ac080ac94b12637bf83b12e2265e39dae28ff1636b3baad1f542170a30f000",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:42367",
+					"10.65.0.27:42367",
+					"172.17.0.1:42367",
+					"172.18.0.1:42367",
+					"172.19.0.1:42367"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:50:11.428739795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6524636438685117,
+				"StableID":   "nYA6Xr82xs11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a4a960d2074c5da1ed25f1fb368b1a9a5e3e6916d784b1b1386f16f53bdc7448",
+				"KeyExpiry":  "2026-11-08T21:50:11Z",
+				"DiscoKey":   "discokey:6607f7e7b624b6ae22f6e0d7d7d8eead196c76230eaa33b1bbf78443ed57de31",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47249",
+					"10.65.0.27:47249",
+					"172.17.0.1:47249",
+					"172.18.0.1:47249",
+					"172.19.0.1:47249"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:50:11.960875922Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4535244346071940,
+				"StableID":   "n7xZeMB2Rc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:39942571da581342e0641ebe9691e7c27142898ced25e9ca690567dcf77ce069",
+				"KeyExpiry":  "2026-11-08T21:50:12Z",
+				"DiscoKey":   "discokey:f88ce12faa767bc1b32ee183c0a4ffab5e8f9a4481ace9c4e375793f944b816d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35948",
+					"10.65.0.27:35948",
+					"172.17.0.1:35948",
+					"172.18.0.1:35948",
+					"172.19.0.1:35948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:50:12.501153112Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8966211731136578,
+				"StableID":   "nHCCLLBp1D21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1c0acb7466b59e9da6293fe6564a1a5dc19e1b048a3c366cb8b71b14dc6f0a3b",
+				"KeyExpiry":  "2026-11-08T21:50:13Z",
+				"DiscoKey":   "discokey:94dc554bbe37455a2492c05cdefb1968e6e02f0733f69f2d5b3cc3eaa78a7625",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:37204",
+					"10.65.0.27:37204",
+					"172.17.0.1:37204",
+					"172.18.0.1:37204",
+					"172.19.0.1:37204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:50:13.04294014Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5611305016224092": {
+				"ID":          5611305016224092,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4217434516485789,
+				"StableID":   "nEBAJVr5wZ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       4217434516485789,
+				"Key":        "nodekey:ed05ffaded4b0d3d199e73685cde3d710708e0568136abb3c7dbfae1b7d52d3c",
+				"DiscoKey":   "discokey:4974ae6aec603f79e40a95852d545ff79be2a69d651a593721660ee3df51427b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35238",
+					"10.65.0.27:35238",
+					"172.17.0.1:35238",
+					"172.18.0.1:35238",
+					"172.19.0.1:35238"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:50:08.714646927Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ed05ffaded4b0d3d199e73685cde3d710708e0568136abb3c7dbfae1b7d52d3c",
+			"MachineKey": "mkey:af32300fa2c3e5ad6aabf42b301de68e48c72d7faf8b9387c0e57465bb6cb664",
+			"Peers": [{
+				"ID":         6625227475231950,
+				"StableID":   "nFTixVVajt11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90fcbf1ad58ef8563c8ee652fb6e7761c16641ac6e5b6b757c1e39bae482f113",
+				"DiscoKey":   "discokey:1b82489d4a371ce057192a9e37c1901f886a7b25f788b7736fc2cc9482387273",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33930",
+					"10.65.0.27:33930",
+					"172.17.0.1:33930",
+					"172.18.0.1:33930",
+					"172.19.0.1:33930"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:50:05.529551314Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5134075546780876,
+				"StableID":   "n7zgFcTE6h11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5648cf90babe07790eb7c3cb5a98df2c85fc988c9740b081da4c824e446e2028",
+				"DiscoKey":   "discokey:244d0fdfea0126edd0d23d5c457ace853b64b576d24528ff312e3a35b4aedd03",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51927",
+					"10.65.0.27:51927",
+					"172.17.0.1:51927",
+					"172.18.0.1:51927",
+					"172.19.0.1:51927"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:50:06.010196053Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7739482568080407,
+				"StableID":   "nzpqvp5ES321CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4b8dfb2fc0245b0c946a6dc15def7147302e67427a7b138bedf7ed3b903f271",
+				"DiscoKey":   "discokey:debd3e359fad846d274d8594ab65fe71fc0762b33b6b30de6dfe354c94b80f10",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:51129",
+					"10.65.0.27:51129",
+					"172.17.0.1:51129",
+					"172.18.0.1:51129",
+					"172.19.0.1:51129"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:50:06.549681383Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5611305016224092,
+				"StableID":   "nDRoG8UNpk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca2338efb9bd78b8696fc15df28683fdc7bad9521aaf6f49b5c99d4eb94cd66f",
+				"DiscoKey":   "discokey:942e5b261eae7d154f9ff256b054eddc1575ddf53e526a6bfce1dc459a7dff4c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49649",
+					"10.65.0.27:49649",
+					"172.17.0.1:49649",
+					"172.18.0.1:49649",
+					"172.19.0.1:49649"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:50:07.097990745Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7223325092152205,
+				"StableID":   "ngnAH6WTQy11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1327edde3f67214164b0fe2f28abb9c0c5e0b03c40953d270a028ee9cea0a764",
+				"DiscoKey":   "discokey:26936e7f6ea63c733d36ad53ee6501bb9990b652dc4594f535e231e5d913a52f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:54326",
+					"10.65.0.27:54326",
+					"172.17.0.1:54326",
+					"172.18.0.1:54326",
+					"172.19.0.1:54326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:50:07.636979821Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         463642494993577,
+				"StableID":   "nvdacv6zc411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1112f75004aa82c778985c437128f6deaf6fd9e830d030caba98705a1e23ef57",
+				"DiscoKey":   "discokey:36860faf5c2193e3f53de89f267d2698d2469a32476c01f7376b97daa16f8d20",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:32861",
+					"10.65.0.27:32861",
+					"172.17.0.1:32861",
+					"172.18.0.1:32861",
+					"172.19.0.1:32861"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:50:08.182538709Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6658212941527777,
+				"StableID":   "nCpVftxWzt11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7b460a57862a7407e3eaf12d5491fe4b585e74c86fa688c97aacaf3b9e88bc5a",
+				"DiscoKey":   "discokey:aa55a178e6c855a88d36c8cece677c6cd27564842d68e0348a452045ff37a268",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:56882",
+					"10.65.0.27:56882",
+					"172.17.0.1:56882",
+					"172.18.0.1:56882",
+					"172.19.0.1:56882"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:50:09.273818206Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3529305711163648,
+				"StableID":   "nmT3AqsRZU11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:96ef6337e8bcafd869253c00fedf5eba2d1e1a805720353586b34da45f646061",
+				"DiscoKey":   "discokey:8c86a8f141c1e7833b687561c75efb7320f9aee43c2c435a82482fae4905066c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33867",
+					"10.65.0.27:33867",
+					"172.17.0.1:33867",
+					"172.18.0.1:33867",
+					"172.19.0.1:33867"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:50:09.791505245Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4355610744675286,
+				"StableID":   "n7RHRVWf1b11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85ef0a3b5218694a655cda07a460a362da05a457e56f5aa9d9d000d1e3eb8b1f",
+				"DiscoKey":   "discokey:8950ee167c429142e8c9856e5eb27ecae26d2dc1f0df8b35f3800e447af6410d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:34584",
+					"10.65.0.27:34584",
+					"172.17.0.1:34584",
+					"172.18.0.1:34584",
+					"172.19.0.1:34584"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:50:10.339831499Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2151322144431074,
+				"StableID":   "nbPi3vaLoH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eca8973b3cc6927706f8ee99e4fd6c0458394e2a60060eec856aeb4f93799c77",
+				"DiscoKey":   "discokey:736b9236a67d97d90554a6bd15d9ad1b337cc4231cc11fc7eff8aa7f709a2e16",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51887",
+					"10.65.0.27:51887",
+					"172.17.0.1:51887",
+					"172.18.0.1:51887",
+					"172.19.0.1:51887"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:50:10.878711627Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6163617912692372,
+				"StableID":   "n36MdsnW8q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eddae4c993276f7b2b5840a12a18ee0bb2e1ce33dfaa9a649a258a14e03ef511",
+				"DiscoKey":   "discokey:92ac080ac94b12637bf83b12e2265e39dae28ff1636b3baad1f542170a30f000",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:42367",
+					"10.65.0.27:42367",
+					"172.17.0.1:42367",
+					"172.18.0.1:42367",
+					"172.19.0.1:42367"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:50:11.428739795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6524636438685117,
+				"StableID":   "nYA6Xr82xs11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a4a960d2074c5da1ed25f1fb368b1a9a5e3e6916d784b1b1386f16f53bdc7448",
+				"KeyExpiry":  "2026-11-08T21:50:11Z",
+				"DiscoKey":   "discokey:6607f7e7b624b6ae22f6e0d7d7d8eead196c76230eaa33b1bbf78443ed57de31",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47249",
+					"10.65.0.27:47249",
+					"172.17.0.1:47249",
+					"172.18.0.1:47249",
+					"172.19.0.1:47249"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:50:11.960875922Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4535244346071940,
+				"StableID":   "n7xZeMB2Rc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:39942571da581342e0641ebe9691e7c27142898ced25e9ca690567dcf77ce069",
+				"KeyExpiry":  "2026-11-08T21:50:12Z",
+				"DiscoKey":   "discokey:f88ce12faa767bc1b32ee183c0a4ffab5e8f9a4481ace9c4e375793f944b816d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35948",
+					"10.65.0.27:35948",
+					"172.17.0.1:35948",
+					"172.18.0.1:35948",
+					"172.19.0.1:35948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:50:12.501153112Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8966211731136578,
+				"StableID":   "nHCCLLBp1D21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1c0acb7466b59e9da6293fe6564a1a5dc19e1b048a3c366cb8b71b14dc6f0a3b",
+				"KeyExpiry":  "2026-11-08T21:50:13Z",
+				"DiscoKey":   "discokey:94dc554bbe37455a2492c05cdefb1968e6e02f0733f69f2d5b3cc3eaa78a7625",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:37204",
+					"10.65.0.27:37204",
+					"172.17.0.1:37204",
+					"172.18.0.1:37204",
+					"172.19.0.1:37204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:50:13.04294014Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4217434516485789": {
+				"ID":          4217434516485789,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3529305711163648,
+				"StableID":   "nmT3AqsRZU11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       3529305711163648,
+				"Key":        "nodekey:96ef6337e8bcafd869253c00fedf5eba2d1e1a805720353586b34da45f646061",
+				"DiscoKey":   "discokey:8c86a8f141c1e7833b687561c75efb7320f9aee43c2c435a82482fae4905066c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33867",
+					"10.65.0.27:33867",
+					"172.17.0.1:33867",
+					"172.18.0.1:33867",
+					"172.19.0.1:33867"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:50:09.791505245Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:96ef6337e8bcafd869253c00fedf5eba2d1e1a805720353586b34da45f646061",
+			"MachineKey": "mkey:9632686a9a344bf446f305494125660106a7fe880b3d807c965a6053f9c3ac74",
+			"Peers": [{
+				"ID":         6625227475231950,
+				"StableID":   "nFTixVVajt11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90fcbf1ad58ef8563c8ee652fb6e7761c16641ac6e5b6b757c1e39bae482f113",
+				"DiscoKey":   "discokey:1b82489d4a371ce057192a9e37c1901f886a7b25f788b7736fc2cc9482387273",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33930",
+					"10.65.0.27:33930",
+					"172.17.0.1:33930",
+					"172.18.0.1:33930",
+					"172.19.0.1:33930"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:50:05.529551314Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5134075546780876,
+				"StableID":   "n7zgFcTE6h11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5648cf90babe07790eb7c3cb5a98df2c85fc988c9740b081da4c824e446e2028",
+				"DiscoKey":   "discokey:244d0fdfea0126edd0d23d5c457ace853b64b576d24528ff312e3a35b4aedd03",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51927",
+					"10.65.0.27:51927",
+					"172.17.0.1:51927",
+					"172.18.0.1:51927",
+					"172.19.0.1:51927"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:50:06.010196053Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7739482568080407,
+				"StableID":   "nzpqvp5ES321CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4b8dfb2fc0245b0c946a6dc15def7147302e67427a7b138bedf7ed3b903f271",
+				"DiscoKey":   "discokey:debd3e359fad846d274d8594ab65fe71fc0762b33b6b30de6dfe354c94b80f10",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:51129",
+					"10.65.0.27:51129",
+					"172.17.0.1:51129",
+					"172.18.0.1:51129",
+					"172.19.0.1:51129"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:50:06.549681383Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5611305016224092,
+				"StableID":   "nDRoG8UNpk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca2338efb9bd78b8696fc15df28683fdc7bad9521aaf6f49b5c99d4eb94cd66f",
+				"DiscoKey":   "discokey:942e5b261eae7d154f9ff256b054eddc1575ddf53e526a6bfce1dc459a7dff4c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49649",
+					"10.65.0.27:49649",
+					"172.17.0.1:49649",
+					"172.18.0.1:49649",
+					"172.19.0.1:49649"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:50:07.097990745Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7223325092152205,
+				"StableID":   "ngnAH6WTQy11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1327edde3f67214164b0fe2f28abb9c0c5e0b03c40953d270a028ee9cea0a764",
+				"DiscoKey":   "discokey:26936e7f6ea63c733d36ad53ee6501bb9990b652dc4594f535e231e5d913a52f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:54326",
+					"10.65.0.27:54326",
+					"172.17.0.1:54326",
+					"172.18.0.1:54326",
+					"172.19.0.1:54326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:50:07.636979821Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         463642494993577,
+				"StableID":   "nvdacv6zc411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1112f75004aa82c778985c437128f6deaf6fd9e830d030caba98705a1e23ef57",
+				"DiscoKey":   "discokey:36860faf5c2193e3f53de89f267d2698d2469a32476c01f7376b97daa16f8d20",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:32861",
+					"10.65.0.27:32861",
+					"172.17.0.1:32861",
+					"172.18.0.1:32861",
+					"172.19.0.1:32861"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:50:08.182538709Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4217434516485789,
+				"StableID":   "nEBAJVr5wZ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ed05ffaded4b0d3d199e73685cde3d710708e0568136abb3c7dbfae1b7d52d3c",
+				"DiscoKey":   "discokey:4974ae6aec603f79e40a95852d545ff79be2a69d651a593721660ee3df51427b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35238",
+					"10.65.0.27:35238",
+					"172.17.0.1:35238",
+					"172.18.0.1:35238",
+					"172.19.0.1:35238"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:50:08.714646927Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6658212941527777,
+				"StableID":   "nCpVftxWzt11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7b460a57862a7407e3eaf12d5491fe4b585e74c86fa688c97aacaf3b9e88bc5a",
+				"DiscoKey":   "discokey:aa55a178e6c855a88d36c8cece677c6cd27564842d68e0348a452045ff37a268",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:56882",
+					"10.65.0.27:56882",
+					"172.17.0.1:56882",
+					"172.18.0.1:56882",
+					"172.19.0.1:56882"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:50:09.273818206Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4355610744675286,
+				"StableID":   "n7RHRVWf1b11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85ef0a3b5218694a655cda07a460a362da05a457e56f5aa9d9d000d1e3eb8b1f",
+				"DiscoKey":   "discokey:8950ee167c429142e8c9856e5eb27ecae26d2dc1f0df8b35f3800e447af6410d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:34584",
+					"10.65.0.27:34584",
+					"172.17.0.1:34584",
+					"172.18.0.1:34584",
+					"172.19.0.1:34584"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:50:10.339831499Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2151322144431074,
+				"StableID":   "nbPi3vaLoH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eca8973b3cc6927706f8ee99e4fd6c0458394e2a60060eec856aeb4f93799c77",
+				"DiscoKey":   "discokey:736b9236a67d97d90554a6bd15d9ad1b337cc4231cc11fc7eff8aa7f709a2e16",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51887",
+					"10.65.0.27:51887",
+					"172.17.0.1:51887",
+					"172.18.0.1:51887",
+					"172.19.0.1:51887"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:50:10.878711627Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6163617912692372,
+				"StableID":   "n36MdsnW8q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eddae4c993276f7b2b5840a12a18ee0bb2e1ce33dfaa9a649a258a14e03ef511",
+				"DiscoKey":   "discokey:92ac080ac94b12637bf83b12e2265e39dae28ff1636b3baad1f542170a30f000",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:42367",
+					"10.65.0.27:42367",
+					"172.17.0.1:42367",
+					"172.18.0.1:42367",
+					"172.19.0.1:42367"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:50:11.428739795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6524636438685117,
+				"StableID":   "nYA6Xr82xs11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a4a960d2074c5da1ed25f1fb368b1a9a5e3e6916d784b1b1386f16f53bdc7448",
+				"KeyExpiry":  "2026-11-08T21:50:11Z",
+				"DiscoKey":   "discokey:6607f7e7b624b6ae22f6e0d7d7d8eead196c76230eaa33b1bbf78443ed57de31",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47249",
+					"10.65.0.27:47249",
+					"172.17.0.1:47249",
+					"172.18.0.1:47249",
+					"172.19.0.1:47249"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:50:11.960875922Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4535244346071940,
+				"StableID":   "n7xZeMB2Rc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:39942571da581342e0641ebe9691e7c27142898ced25e9ca690567dcf77ce069",
+				"KeyExpiry":  "2026-11-08T21:50:12Z",
+				"DiscoKey":   "discokey:f88ce12faa767bc1b32ee183c0a4ffab5e8f9a4481ace9c4e375793f944b816d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35948",
+					"10.65.0.27:35948",
+					"172.17.0.1:35948",
+					"172.18.0.1:35948",
+					"172.19.0.1:35948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:50:12.501153112Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8966211731136578,
+				"StableID":   "nHCCLLBp1D21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1c0acb7466b59e9da6293fe6564a1a5dc19e1b048a3c366cb8b71b14dc6f0a3b",
+				"KeyExpiry":  "2026-11-08T21:50:13Z",
+				"DiscoKey":   "discokey:94dc554bbe37455a2492c05cdefb1968e6e02f0733f69f2d5b3cc3eaa78a7625",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:37204",
+					"10.65.0.27:37204",
+					"172.17.0.1:37204",
+					"172.18.0.1:37204",
+					"172.19.0.1:37204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:50:13.04294014Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3529305711163648": {
+				"ID":          3529305711163648,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4535244346071940,
+				"StableID":   "n7xZeMB2Rc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:39942571da581342e0641ebe9691e7c27142898ced25e9ca690567dcf77ce069",
+				"KeyExpiry":  "2026-11-08T21:50:12Z",
+				"DiscoKey":   "discokey:f88ce12faa767bc1b32ee183c0a4ffab5e8f9a4481ace9c4e375793f944b816d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35948",
+					"10.65.0.27:35948",
+					"172.17.0.1:35948",
+					"172.18.0.1:35948",
+					"172.19.0.1:35948"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:50:12.501153112Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:39942571da581342e0641ebe9691e7c27142898ced25e9ca690567dcf77ce069",
+			"MachineKey": "mkey:198eee5c29566bf81b9dce179b98c448e992198c9b54bfa13f6778ff88ab430c",
+			"Peers": [{
+				"ID":         6625227475231950,
+				"StableID":   "nFTixVVajt11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90fcbf1ad58ef8563c8ee652fb6e7761c16641ac6e5b6b757c1e39bae482f113",
+				"DiscoKey":   "discokey:1b82489d4a371ce057192a9e37c1901f886a7b25f788b7736fc2cc9482387273",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33930",
+					"10.65.0.27:33930",
+					"172.17.0.1:33930",
+					"172.18.0.1:33930",
+					"172.19.0.1:33930"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:50:05.529551314Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5134075546780876,
+				"StableID":   "n7zgFcTE6h11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5648cf90babe07790eb7c3cb5a98df2c85fc988c9740b081da4c824e446e2028",
+				"DiscoKey":   "discokey:244d0fdfea0126edd0d23d5c457ace853b64b576d24528ff312e3a35b4aedd03",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51927",
+					"10.65.0.27:51927",
+					"172.17.0.1:51927",
+					"172.18.0.1:51927",
+					"172.19.0.1:51927"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:50:06.010196053Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7739482568080407,
+				"StableID":   "nzpqvp5ES321CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4b8dfb2fc0245b0c946a6dc15def7147302e67427a7b138bedf7ed3b903f271",
+				"DiscoKey":   "discokey:debd3e359fad846d274d8594ab65fe71fc0762b33b6b30de6dfe354c94b80f10",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:51129",
+					"10.65.0.27:51129",
+					"172.17.0.1:51129",
+					"172.18.0.1:51129",
+					"172.19.0.1:51129"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:50:06.549681383Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5611305016224092,
+				"StableID":   "nDRoG8UNpk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca2338efb9bd78b8696fc15df28683fdc7bad9521aaf6f49b5c99d4eb94cd66f",
+				"DiscoKey":   "discokey:942e5b261eae7d154f9ff256b054eddc1575ddf53e526a6bfce1dc459a7dff4c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49649",
+					"10.65.0.27:49649",
+					"172.17.0.1:49649",
+					"172.18.0.1:49649",
+					"172.19.0.1:49649"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:50:07.097990745Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7223325092152205,
+				"StableID":   "ngnAH6WTQy11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1327edde3f67214164b0fe2f28abb9c0c5e0b03c40953d270a028ee9cea0a764",
+				"DiscoKey":   "discokey:26936e7f6ea63c733d36ad53ee6501bb9990b652dc4594f535e231e5d913a52f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:54326",
+					"10.65.0.27:54326",
+					"172.17.0.1:54326",
+					"172.18.0.1:54326",
+					"172.19.0.1:54326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:50:07.636979821Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         463642494993577,
+				"StableID":   "nvdacv6zc411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1112f75004aa82c778985c437128f6deaf6fd9e830d030caba98705a1e23ef57",
+				"DiscoKey":   "discokey:36860faf5c2193e3f53de89f267d2698d2469a32476c01f7376b97daa16f8d20",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:32861",
+					"10.65.0.27:32861",
+					"172.17.0.1:32861",
+					"172.18.0.1:32861",
+					"172.19.0.1:32861"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:50:08.182538709Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4217434516485789,
+				"StableID":   "nEBAJVr5wZ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ed05ffaded4b0d3d199e73685cde3d710708e0568136abb3c7dbfae1b7d52d3c",
+				"DiscoKey":   "discokey:4974ae6aec603f79e40a95852d545ff79be2a69d651a593721660ee3df51427b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35238",
+					"10.65.0.27:35238",
+					"172.17.0.1:35238",
+					"172.18.0.1:35238",
+					"172.19.0.1:35238"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:50:08.714646927Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6658212941527777,
+				"StableID":   "nCpVftxWzt11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7b460a57862a7407e3eaf12d5491fe4b585e74c86fa688c97aacaf3b9e88bc5a",
+				"DiscoKey":   "discokey:aa55a178e6c855a88d36c8cece677c6cd27564842d68e0348a452045ff37a268",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:56882",
+					"10.65.0.27:56882",
+					"172.17.0.1:56882",
+					"172.18.0.1:56882",
+					"172.19.0.1:56882"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:50:09.273818206Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3529305711163648,
+				"StableID":   "nmT3AqsRZU11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:96ef6337e8bcafd869253c00fedf5eba2d1e1a805720353586b34da45f646061",
+				"DiscoKey":   "discokey:8c86a8f141c1e7833b687561c75efb7320f9aee43c2c435a82482fae4905066c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33867",
+					"10.65.0.27:33867",
+					"172.17.0.1:33867",
+					"172.18.0.1:33867",
+					"172.19.0.1:33867"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:50:09.791505245Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4355610744675286,
+				"StableID":   "n7RHRVWf1b11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85ef0a3b5218694a655cda07a460a362da05a457e56f5aa9d9d000d1e3eb8b1f",
+				"DiscoKey":   "discokey:8950ee167c429142e8c9856e5eb27ecae26d2dc1f0df8b35f3800e447af6410d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:34584",
+					"10.65.0.27:34584",
+					"172.17.0.1:34584",
+					"172.18.0.1:34584",
+					"172.19.0.1:34584"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:50:10.339831499Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2151322144431074,
+				"StableID":   "nbPi3vaLoH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eca8973b3cc6927706f8ee99e4fd6c0458394e2a60060eec856aeb4f93799c77",
+				"DiscoKey":   "discokey:736b9236a67d97d90554a6bd15d9ad1b337cc4231cc11fc7eff8aa7f709a2e16",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51887",
+					"10.65.0.27:51887",
+					"172.17.0.1:51887",
+					"172.18.0.1:51887",
+					"172.19.0.1:51887"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:50:10.878711627Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6163617912692372,
+				"StableID":   "n36MdsnW8q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eddae4c993276f7b2b5840a12a18ee0bb2e1ce33dfaa9a649a258a14e03ef511",
+				"DiscoKey":   "discokey:92ac080ac94b12637bf83b12e2265e39dae28ff1636b3baad1f542170a30f000",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:42367",
+					"10.65.0.27:42367",
+					"172.17.0.1:42367",
+					"172.18.0.1:42367",
+					"172.19.0.1:42367"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:50:11.428739795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6524636438685117,
+				"StableID":   "nYA6Xr82xs11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a4a960d2074c5da1ed25f1fb368b1a9a5e3e6916d784b1b1386f16f53bdc7448",
+				"KeyExpiry":  "2026-11-08T21:50:11Z",
+				"DiscoKey":   "discokey:6607f7e7b624b6ae22f6e0d7d7d8eead196c76230eaa33b1bbf78443ed57de31",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47249",
+					"10.65.0.27:47249",
+					"172.17.0.1:47249",
+					"172.18.0.1:47249",
+					"172.19.0.1:47249"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:50:11.960875922Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8966211731136578,
+				"StableID":   "nHCCLLBp1D21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1c0acb7466b59e9da6293fe6564a1a5dc19e1b048a3c366cb8b71b14dc6f0a3b",
+				"KeyExpiry":  "2026-11-08T21:50:13Z",
+				"DiscoKey":   "discokey:94dc554bbe37455a2492c05cdefb1968e6e02f0733f69f2d5b3cc3eaa78a7625",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:37204",
+					"10.65.0.27:37204",
+					"172.17.0.1:37204",
+					"172.18.0.1:37204",
+					"172.19.0.1:37204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:50:13.04294014Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4355610744675286,
+				"StableID":   "n7RHRVWf1b11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       4355610744675286,
+				"Key":        "nodekey:85ef0a3b5218694a655cda07a460a362da05a457e56f5aa9d9d000d1e3eb8b1f",
+				"DiscoKey":   "discokey:8950ee167c429142e8c9856e5eb27ecae26d2dc1f0df8b35f3800e447af6410d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:34584",
+					"10.65.0.27:34584",
+					"172.17.0.1:34584",
+					"172.18.0.1:34584",
+					"172.19.0.1:34584"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:50:10.339831499Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:85ef0a3b5218694a655cda07a460a362da05a457e56f5aa9d9d000d1e3eb8b1f",
+			"MachineKey": "mkey:7ede480cd5ab698fac756556362e3812e13f73776c5cea0a8ff51c113b34656a",
+			"Peers": [{
+				"ID":         6625227475231950,
+				"StableID":   "nFTixVVajt11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90fcbf1ad58ef8563c8ee652fb6e7761c16641ac6e5b6b757c1e39bae482f113",
+				"DiscoKey":   "discokey:1b82489d4a371ce057192a9e37c1901f886a7b25f788b7736fc2cc9482387273",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33930",
+					"10.65.0.27:33930",
+					"172.17.0.1:33930",
+					"172.18.0.1:33930",
+					"172.19.0.1:33930"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:50:05.529551314Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5134075546780876,
+				"StableID":   "n7zgFcTE6h11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5648cf90babe07790eb7c3cb5a98df2c85fc988c9740b081da4c824e446e2028",
+				"DiscoKey":   "discokey:244d0fdfea0126edd0d23d5c457ace853b64b576d24528ff312e3a35b4aedd03",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51927",
+					"10.65.0.27:51927",
+					"172.17.0.1:51927",
+					"172.18.0.1:51927",
+					"172.19.0.1:51927"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:50:06.010196053Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7739482568080407,
+				"StableID":   "nzpqvp5ES321CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4b8dfb2fc0245b0c946a6dc15def7147302e67427a7b138bedf7ed3b903f271",
+				"DiscoKey":   "discokey:debd3e359fad846d274d8594ab65fe71fc0762b33b6b30de6dfe354c94b80f10",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:51129",
+					"10.65.0.27:51129",
+					"172.17.0.1:51129",
+					"172.18.0.1:51129",
+					"172.19.0.1:51129"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:50:06.549681383Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5611305016224092,
+				"StableID":   "nDRoG8UNpk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca2338efb9bd78b8696fc15df28683fdc7bad9521aaf6f49b5c99d4eb94cd66f",
+				"DiscoKey":   "discokey:942e5b261eae7d154f9ff256b054eddc1575ddf53e526a6bfce1dc459a7dff4c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49649",
+					"10.65.0.27:49649",
+					"172.17.0.1:49649",
+					"172.18.0.1:49649",
+					"172.19.0.1:49649"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:50:07.097990745Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7223325092152205,
+				"StableID":   "ngnAH6WTQy11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1327edde3f67214164b0fe2f28abb9c0c5e0b03c40953d270a028ee9cea0a764",
+				"DiscoKey":   "discokey:26936e7f6ea63c733d36ad53ee6501bb9990b652dc4594f535e231e5d913a52f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:54326",
+					"10.65.0.27:54326",
+					"172.17.0.1:54326",
+					"172.18.0.1:54326",
+					"172.19.0.1:54326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:50:07.636979821Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         463642494993577,
+				"StableID":   "nvdacv6zc411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1112f75004aa82c778985c437128f6deaf6fd9e830d030caba98705a1e23ef57",
+				"DiscoKey":   "discokey:36860faf5c2193e3f53de89f267d2698d2469a32476c01f7376b97daa16f8d20",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:32861",
+					"10.65.0.27:32861",
+					"172.17.0.1:32861",
+					"172.18.0.1:32861",
+					"172.19.0.1:32861"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:50:08.182538709Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4217434516485789,
+				"StableID":   "nEBAJVr5wZ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ed05ffaded4b0d3d199e73685cde3d710708e0568136abb3c7dbfae1b7d52d3c",
+				"DiscoKey":   "discokey:4974ae6aec603f79e40a95852d545ff79be2a69d651a593721660ee3df51427b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35238",
+					"10.65.0.27:35238",
+					"172.17.0.1:35238",
+					"172.18.0.1:35238",
+					"172.19.0.1:35238"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:50:08.714646927Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6658212941527777,
+				"StableID":   "nCpVftxWzt11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7b460a57862a7407e3eaf12d5491fe4b585e74c86fa688c97aacaf3b9e88bc5a",
+				"DiscoKey":   "discokey:aa55a178e6c855a88d36c8cece677c6cd27564842d68e0348a452045ff37a268",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:56882",
+					"10.65.0.27:56882",
+					"172.17.0.1:56882",
+					"172.18.0.1:56882",
+					"172.19.0.1:56882"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:50:09.273818206Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3529305711163648,
+				"StableID":   "nmT3AqsRZU11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:96ef6337e8bcafd869253c00fedf5eba2d1e1a805720353586b34da45f646061",
+				"DiscoKey":   "discokey:8c86a8f141c1e7833b687561c75efb7320f9aee43c2c435a82482fae4905066c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33867",
+					"10.65.0.27:33867",
+					"172.17.0.1:33867",
+					"172.18.0.1:33867",
+					"172.19.0.1:33867"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:50:09.791505245Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2151322144431074,
+				"StableID":   "nbPi3vaLoH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eca8973b3cc6927706f8ee99e4fd6c0458394e2a60060eec856aeb4f93799c77",
+				"DiscoKey":   "discokey:736b9236a67d97d90554a6bd15d9ad1b337cc4231cc11fc7eff8aa7f709a2e16",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51887",
+					"10.65.0.27:51887",
+					"172.17.0.1:51887",
+					"172.18.0.1:51887",
+					"172.19.0.1:51887"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:50:10.878711627Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6163617912692372,
+				"StableID":   "n36MdsnW8q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eddae4c993276f7b2b5840a12a18ee0bb2e1ce33dfaa9a649a258a14e03ef511",
+				"DiscoKey":   "discokey:92ac080ac94b12637bf83b12e2265e39dae28ff1636b3baad1f542170a30f000",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:42367",
+					"10.65.0.27:42367",
+					"172.17.0.1:42367",
+					"172.18.0.1:42367",
+					"172.19.0.1:42367"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:50:11.428739795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6524636438685117,
+				"StableID":   "nYA6Xr82xs11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a4a960d2074c5da1ed25f1fb368b1a9a5e3e6916d784b1b1386f16f53bdc7448",
+				"KeyExpiry":  "2026-11-08T21:50:11Z",
+				"DiscoKey":   "discokey:6607f7e7b624b6ae22f6e0d7d7d8eead196c76230eaa33b1bbf78443ed57de31",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47249",
+					"10.65.0.27:47249",
+					"172.17.0.1:47249",
+					"172.18.0.1:47249",
+					"172.19.0.1:47249"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:50:11.960875922Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4535244346071940,
+				"StableID":   "n7xZeMB2Rc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:39942571da581342e0641ebe9691e7c27142898ced25e9ca690567dcf77ce069",
+				"KeyExpiry":  "2026-11-08T21:50:12Z",
+				"DiscoKey":   "discokey:f88ce12faa767bc1b32ee183c0a4ffab5e8f9a4481ace9c4e375793f944b816d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35948",
+					"10.65.0.27:35948",
+					"172.17.0.1:35948",
+					"172.18.0.1:35948",
+					"172.19.0.1:35948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:50:12.501153112Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8966211731136578,
+				"StableID":   "nHCCLLBp1D21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1c0acb7466b59e9da6293fe6564a1a5dc19e1b048a3c366cb8b71b14dc6f0a3b",
+				"KeyExpiry":  "2026-11-08T21:50:13Z",
+				"DiscoKey":   "discokey:94dc554bbe37455a2492c05cdefb1968e6e02f0733f69f2d5b3cc3eaa78a7625",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:37204",
+					"10.65.0.27:37204",
+					"172.17.0.1:37204",
+					"172.18.0.1:37204",
+					"172.19.0.1:37204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:50:13.04294014Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4355610744675286": {
+				"ID":          4355610744675286,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-acceptenv-glob-shapes.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-acceptenv-glob-shapes.hujson
@@ -1,0 +1,20105 @@
+// ssh-malformed-acceptenv-glob-shapes
+//
+// ssh acceptEnv with various glob shapes
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-13T07:25:08Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-malformed-acceptenv-glob-shapes",
+	"description":    "ssh acceptEnv with various glob shapes",
+	"category":       "ssh",
+	"captured_at":    "2026-05-13T07:25:08.057077019Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                      \n  \n                                                                   \n                                                                   \n                                           \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh acceptEnv with various glob shapes\",\n\t\"id\":          \"ssh-malformed-acceptenv-glob-shapes\",\n\t\"policy\": {\"ssh\": [{\n\t\t\"acceptEnv\": [\"*X\", \"X*\", \"X*Y\", \"*X*\"],\n\t\t\"action\":    \"accept\",\n\t\t\"dst\":       [\"tag:server\"],\n\t\t\"src\":       [\"autogroup:member\"],\n\t\t\"users\":     [\"root\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-edge/ssh-malformed-acceptenv-glob-shapes.hujson",
+		"full_policy": {
+			"ssh": [{
+				"acceptEnv": ["*X", "X*", "X*Y", "*X*"],
+				"action":    "accept",
+				"dst":       ["tag:server"],
+				"src":       ["autogroup:member"],
+				"users":     ["root"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5596237398539731,
+				"StableID":   "ntmfVgfYhk11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       5596237398539731,
+				"Key":        "nodekey:2c323ef4ba56d8b62a3fc781c2aa970bf91a0d7ed890ebe5865328abb2555f22",
+				"DiscoKey":   "discokey:c8719e1f556a6923371ed2dfa4c008e075365a13b12ce5bae0220ebe4394f042",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58033",
+					"10.65.0.27:58033",
+					"172.17.0.1:58033",
+					"172.18.0.1:58033",
+					"172.19.0.1:58033"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:25:21.463695724Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2c323ef4ba56d8b62a3fc781c2aa970bf91a0d7ed890ebe5865328abb2555f22",
+			"MachineKey": "mkey:0560035735471ff68b3086e83011fa988514d4ea26998472281689ca3f57d26b",
+			"Peers": [{
+				"ID":         7033265457719453,
+				"StableID":   "n8ALDXxNvw11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97b092807554919b3f2ca63da1d2563dd1d68d156a01f8063c18b37618f0fe16",
+				"DiscoKey":   "discokey:02437bf4810f9b2eab4faa0a95ed7554a68e77c62349d9cb577d229e4b869621",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:59370",
+					"10.65.0.27:59370",
+					"172.17.0.1:59370",
+					"172.18.0.1:59370",
+					"172.19.0.1:59370"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:25:14.647702931Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5018459439570437,
+				"StableID":   "nS1YmLRsBg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6f2a4caf1ea3dee0e9f04d9fec96d45bce5ac52767bdd59123827a5e3986ae27",
+				"DiscoKey":   "discokey:d02c0ae33326d6116e1f0f8d9bc344b13569cd0aa5a72bd37484f36c98280c22",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40885",
+					"10.65.0.27:40885",
+					"172.17.0.1:40885",
+					"172.18.0.1:40885",
+					"172.19.0.1:40885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:25:15.77530771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7406573529314029,
+				"StableID":   "naKdAP8Tqz11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a605faa95c0411d7bedcbfd0c3c0fcc132f5bf8a3d6f320da9cfd380a1216c07",
+				"DiscoKey":   "discokey:d9951aa07acdc958f1b303ea70510e99b23700263a9f20e9ff0c6d7b94166a3d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41042",
+					"10.65.0.27:41042",
+					"172.17.0.1:41042",
+					"172.18.0.1:41042",
+					"172.19.0.1:41042"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:25:16.647581746Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1523904849378188,
+				"StableID":   "nFU1BzPBuC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2adea3024e9474888510edb35b7121f648361632bc0efeba54fa86bfafd157d",
+				"DiscoKey":   "discokey:534efb2e6bfe6e1080e1e1f72038c0b00b58fd547dcde98a4c79c82c420a7f4d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59208",
+					"10.65.0.27:59208",
+					"172.17.0.1:59208",
+					"172.18.0.1:59208",
+					"172.19.0.1:59208"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:25:17.134360684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4130257300345700,
+				"StableID":   "n3LLEdrbFZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1013a44fb7f2388126c37059f74f1ab7a3956195aeeece648f0416092cf6d708",
+				"DiscoKey":   "discokey:e9812a838e42c94122feae3b96f8a2a95f95f001dc4e1889dec2db4f12c8a724",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41255",
+					"10.65.0.27:41255",
+					"172.17.0.1:41255",
+					"172.18.0.1:41255",
+					"172.19.0.1:41255"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:25:17.684355567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6367116164312672,
+				"StableID":   "ndByG1Mgir11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85f2b69d0ac922b062ae322fcd44585bae5fbc348187427496c08f4975a83b5f",
+				"DiscoKey":   "discokey:bc0d2a06eda37620615039b35ef9ccc699cfda76f1d9c11a97b6df996e4a6b5e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52970",
+					"10.65.0.27:52970",
+					"172.17.0.1:52970",
+					"172.18.0.1:52970",
+					"172.19.0.1:52970"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:25:18.206091103Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1514851276370035,
+				"StableID":   "nntqvJa5qC11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fabbedda0abf5795ddd763fcef4e8448cf30015e003ccada73cfa860b88187c",
+				"DiscoKey":   "discokey:4cf55f4ca305b6de569fcb188a729d5ac61095716bddbcc7d69d0a818f2cb34c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58727",
+					"10.65.0.27:58727",
+					"172.17.0.1:58727",
+					"172.18.0.1:58727",
+					"172.19.0.1:58727"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:25:18.752272343Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1720558131027891,
+				"StableID":   "nrULGP9FSE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc62de889be17f18f4b6f68c52e07c5b243a51e9c9468f9a519bd9d873156624",
+				"DiscoKey":   "discokey:ea747d6033194936a3cd868de636ca6fa0302e838cb8fd9ffe5f011a8ba8e90e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:51743",
+					"10.65.0.27:51743",
+					"172.17.0.1:51743",
+					"172.18.0.1:51743",
+					"172.19.0.1:51743"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:25:19.302126246Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2311423039873039,
+				"StableID":   "nNrMwVAr3K11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1dbe3fc5be2c1683e3c18da29086be569f0b7a837c0758c309d2a01ac050e651",
+				"DiscoKey":   "discokey:107ef0da987d5f5f8f2b405ca6618d9a70e401b4ca5719a97c0bbc2d7968bd43",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33800",
+					"10.65.0.27:33800",
+					"172.17.0.1:33800",
+					"172.18.0.1:33800",
+					"172.19.0.1:33800"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:25:19.84790873Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3963006022562156,
+				"StableID":   "n7JAYzSrwX11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d463e1a413e1737b02a711cbed86fb6ed582132332855894f0579985c492a707",
+				"DiscoKey":   "discokey:989dfd487fbbd1c82e919994c79403f05431c6fb5499e9c4abd09af253d66b35",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:45441",
+					"10.65.0.27:45441",
+					"172.17.0.1:45441",
+					"172.18.0.1:45441",
+					"172.19.0.1:45441"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:25:20.383940942Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6673170920100261,
+				"StableID":   "nQGX1JtH7u11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90da8fac19af990e5f72b8b2d766c12fb0aee0ab9c23d440d8e33b928c5e507b",
+				"DiscoKey":   "discokey:9d6e17c71f27026dba6d142f1d66e1cddfed9c9aeaed63e570695da0de989412",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43603",
+					"10.65.0.27:43603",
+					"172.17.0.1:43603",
+					"172.18.0.1:43603",
+					"172.19.0.1:43603"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:25:20.925023366Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         806975654302069,
+				"StableID":   "ngQKDAtUJ711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d6a21d7bcee59fb449e03303128c802e2ba5a335cfd79057f5e2c64845a7526d",
+				"KeyExpiry":  "2026-11-09T07:25:22Z",
+				"DiscoKey":   "discokey:dda85a4eef1d21a17dd805463f31091324c200ff8721f6e46f4167e6907c0e56",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35947",
+					"10.65.0.27:35947",
+					"172.17.0.1:35947",
+					"172.18.0.1:35947",
+					"172.19.0.1:35947"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:25:22.000384279Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7473794549005958,
+				"StableID":   "nHaLVkutM121CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ee87ffe9a2aa91bf126d380bfaec4f05189545d0006b8cf309688a1314ab5d0c",
+				"KeyExpiry":  "2026-11-09T07:25:22Z",
+				"DiscoKey":   "discokey:24fa5573eaf4177afa174dcdc842530b963bed127b5b4553d91f82f0dd3d6737",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34262",
+					"10.65.0.27:34262",
+					"172.17.0.1:34262",
+					"172.18.0.1:34262",
+					"172.19.0.1:34262"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:25:22.58802508Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         370077202905546,
+				"StableID":   "nygk9SJct311CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b140448a88bf5cdfba90d390996b4473062df1de5b77c06361a24881a2aa6913",
+				"KeyExpiry":  "2026-11-09T07:25:23Z",
+				"DiscoKey":   "discokey:8ed0756ea013123480b4828d44588debaeba8c91a7f4dd5f4651a1fe0936085f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60293",
+					"10.65.0.27:60293",
+					"172.17.0.1:60293",
+					"172.18.0.1:60293",
+					"172.19.0.1:60293"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:25:23.068538493Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{"principals": [
+				{"nodeIP": "100.64.0.17"},
+				{"nodeIP": "100.64.0.18"},
+				{"nodeIP": "100.64.0.19"},
+				{"nodeIP": "fd7a:115c:a1e0::12"},
+				{"nodeIP": "fd7a:115c:a1e0::11"},
+				{"nodeIP": "fd7a:115c:a1e0::13"}
+			], "sshUsers": {"root": "root"}, "action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}, "acceptEnv": ["*X", "X*", "X*Y", "*X*"]}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5596237398539731": {
+				"ID":          5596237398539731,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		},
+		"ssh_rules": [{"principals": [
+			{"nodeIP": "100.64.0.17"},
+			{"nodeIP": "100.64.0.18"},
+			{"nodeIP": "100.64.0.19"},
+			{"nodeIP": "fd7a:115c:a1e0::12"},
+			{"nodeIP": "fd7a:115c:a1e0::11"},
+			{"nodeIP": "fd7a:115c:a1e0::13"}
+		], "sshUsers": {"root": "root"}, "action": {
+			"accept":                    true,
+			"allowAgentForwarding":      true,
+			"allowLocalPortForwarding":  true,
+			"allowRemotePortForwarding": true
+		}, "acceptEnv": ["*X", "X*", "X*Y", "*X*"]}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6367116164312672,
+				"StableID":   "ndByG1Mgir11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       6367116164312672,
+				"Key":        "nodekey:85f2b69d0ac922b062ae322fcd44585bae5fbc348187427496c08f4975a83b5f",
+				"DiscoKey":   "discokey:bc0d2a06eda37620615039b35ef9ccc699cfda76f1d9c11a97b6df996e4a6b5e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52970",
+					"10.65.0.27:52970",
+					"172.17.0.1:52970",
+					"172.18.0.1:52970",
+					"172.19.0.1:52970"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:25:18.206091103Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:85f2b69d0ac922b062ae322fcd44585bae5fbc348187427496c08f4975a83b5f",
+			"MachineKey": "mkey:ff93d26db4705958729f1d0bb69875aadf5b54f394904790177ca85b02c30c0c",
+			"Peers": [{
+				"ID":         7033265457719453,
+				"StableID":   "n8ALDXxNvw11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97b092807554919b3f2ca63da1d2563dd1d68d156a01f8063c18b37618f0fe16",
+				"DiscoKey":   "discokey:02437bf4810f9b2eab4faa0a95ed7554a68e77c62349d9cb577d229e4b869621",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:59370",
+					"10.65.0.27:59370",
+					"172.17.0.1:59370",
+					"172.18.0.1:59370",
+					"172.19.0.1:59370"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:25:14.647702931Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5018459439570437,
+				"StableID":   "nS1YmLRsBg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6f2a4caf1ea3dee0e9f04d9fec96d45bce5ac52767bdd59123827a5e3986ae27",
+				"DiscoKey":   "discokey:d02c0ae33326d6116e1f0f8d9bc344b13569cd0aa5a72bd37484f36c98280c22",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40885",
+					"10.65.0.27:40885",
+					"172.17.0.1:40885",
+					"172.18.0.1:40885",
+					"172.19.0.1:40885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:25:15.77530771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7406573529314029,
+				"StableID":   "naKdAP8Tqz11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a605faa95c0411d7bedcbfd0c3c0fcc132f5bf8a3d6f320da9cfd380a1216c07",
+				"DiscoKey":   "discokey:d9951aa07acdc958f1b303ea70510e99b23700263a9f20e9ff0c6d7b94166a3d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41042",
+					"10.65.0.27:41042",
+					"172.17.0.1:41042",
+					"172.18.0.1:41042",
+					"172.19.0.1:41042"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:25:16.647581746Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1523904849378188,
+				"StableID":   "nFU1BzPBuC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2adea3024e9474888510edb35b7121f648361632bc0efeba54fa86bfafd157d",
+				"DiscoKey":   "discokey:534efb2e6bfe6e1080e1e1f72038c0b00b58fd547dcde98a4c79c82c420a7f4d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59208",
+					"10.65.0.27:59208",
+					"172.17.0.1:59208",
+					"172.18.0.1:59208",
+					"172.19.0.1:59208"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:25:17.134360684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4130257300345700,
+				"StableID":   "n3LLEdrbFZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1013a44fb7f2388126c37059f74f1ab7a3956195aeeece648f0416092cf6d708",
+				"DiscoKey":   "discokey:e9812a838e42c94122feae3b96f8a2a95f95f001dc4e1889dec2db4f12c8a724",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41255",
+					"10.65.0.27:41255",
+					"172.17.0.1:41255",
+					"172.18.0.1:41255",
+					"172.19.0.1:41255"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:25:17.684355567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1514851276370035,
+				"StableID":   "nntqvJa5qC11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fabbedda0abf5795ddd763fcef4e8448cf30015e003ccada73cfa860b88187c",
+				"DiscoKey":   "discokey:4cf55f4ca305b6de569fcb188a729d5ac61095716bddbcc7d69d0a818f2cb34c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58727",
+					"10.65.0.27:58727",
+					"172.17.0.1:58727",
+					"172.18.0.1:58727",
+					"172.19.0.1:58727"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:25:18.752272343Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1720558131027891,
+				"StableID":   "nrULGP9FSE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc62de889be17f18f4b6f68c52e07c5b243a51e9c9468f9a519bd9d873156624",
+				"DiscoKey":   "discokey:ea747d6033194936a3cd868de636ca6fa0302e838cb8fd9ffe5f011a8ba8e90e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:51743",
+					"10.65.0.27:51743",
+					"172.17.0.1:51743",
+					"172.18.0.1:51743",
+					"172.19.0.1:51743"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:25:19.302126246Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2311423039873039,
+				"StableID":   "nNrMwVAr3K11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1dbe3fc5be2c1683e3c18da29086be569f0b7a837c0758c309d2a01ac050e651",
+				"DiscoKey":   "discokey:107ef0da987d5f5f8f2b405ca6618d9a70e401b4ca5719a97c0bbc2d7968bd43",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33800",
+					"10.65.0.27:33800",
+					"172.17.0.1:33800",
+					"172.18.0.1:33800",
+					"172.19.0.1:33800"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:25:19.84790873Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3963006022562156,
+				"StableID":   "n7JAYzSrwX11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d463e1a413e1737b02a711cbed86fb6ed582132332855894f0579985c492a707",
+				"DiscoKey":   "discokey:989dfd487fbbd1c82e919994c79403f05431c6fb5499e9c4abd09af253d66b35",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:45441",
+					"10.65.0.27:45441",
+					"172.17.0.1:45441",
+					"172.18.0.1:45441",
+					"172.19.0.1:45441"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:25:20.383940942Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6673170920100261,
+				"StableID":   "nQGX1JtH7u11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90da8fac19af990e5f72b8b2d766c12fb0aee0ab9c23d440d8e33b928c5e507b",
+				"DiscoKey":   "discokey:9d6e17c71f27026dba6d142f1d66e1cddfed9c9aeaed63e570695da0de989412",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43603",
+					"10.65.0.27:43603",
+					"172.17.0.1:43603",
+					"172.18.0.1:43603",
+					"172.19.0.1:43603"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:25:20.925023366Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5596237398539731,
+				"StableID":   "ntmfVgfYhk11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c323ef4ba56d8b62a3fc781c2aa970bf91a0d7ed890ebe5865328abb2555f22",
+				"DiscoKey":   "discokey:c8719e1f556a6923371ed2dfa4c008e075365a13b12ce5bae0220ebe4394f042",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58033",
+					"10.65.0.27:58033",
+					"172.17.0.1:58033",
+					"172.18.0.1:58033",
+					"172.19.0.1:58033"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:25:21.463695724Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         806975654302069,
+				"StableID":   "ngQKDAtUJ711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d6a21d7bcee59fb449e03303128c802e2ba5a335cfd79057f5e2c64845a7526d",
+				"KeyExpiry":  "2026-11-09T07:25:22Z",
+				"DiscoKey":   "discokey:dda85a4eef1d21a17dd805463f31091324c200ff8721f6e46f4167e6907c0e56",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35947",
+					"10.65.0.27:35947",
+					"172.17.0.1:35947",
+					"172.18.0.1:35947",
+					"172.19.0.1:35947"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:25:22.000384279Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7473794549005958,
+				"StableID":   "nHaLVkutM121CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ee87ffe9a2aa91bf126d380bfaec4f05189545d0006b8cf309688a1314ab5d0c",
+				"KeyExpiry":  "2026-11-09T07:25:22Z",
+				"DiscoKey":   "discokey:24fa5573eaf4177afa174dcdc842530b963bed127b5b4553d91f82f0dd3d6737",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34262",
+					"10.65.0.27:34262",
+					"172.17.0.1:34262",
+					"172.18.0.1:34262",
+					"172.19.0.1:34262"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:25:22.58802508Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         370077202905546,
+				"StableID":   "nygk9SJct311CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b140448a88bf5cdfba90d390996b4473062df1de5b77c06361a24881a2aa6913",
+				"KeyExpiry":  "2026-11-09T07:25:23Z",
+				"DiscoKey":   "discokey:8ed0756ea013123480b4828d44588debaeba8c91a7f4dd5f4651a1fe0936085f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60293",
+					"10.65.0.27:60293",
+					"172.17.0.1:60293",
+					"172.18.0.1:60293",
+					"172.19.0.1:60293"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:25:23.068538493Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6367116164312672": {
+				"ID":          6367116164312672,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         370077202905546,
+				"StableID":   "nygk9SJct311CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b140448a88bf5cdfba90d390996b4473062df1de5b77c06361a24881a2aa6913",
+				"KeyExpiry":  "2026-11-09T07:25:23Z",
+				"DiscoKey":   "discokey:8ed0756ea013123480b4828d44588debaeba8c91a7f4dd5f4651a1fe0936085f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60293",
+					"10.65.0.27:60293",
+					"172.17.0.1:60293",
+					"172.18.0.1:60293",
+					"172.19.0.1:60293"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:25:23.068538493Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b140448a88bf5cdfba90d390996b4473062df1de5b77c06361a24881a2aa6913",
+			"MachineKey": "mkey:e8ec92ef8da6f8dcb9590e93836f95a82583347cef9f86b60520a3dcea766877",
+			"Peers": [{
+				"ID":         7033265457719453,
+				"StableID":   "n8ALDXxNvw11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97b092807554919b3f2ca63da1d2563dd1d68d156a01f8063c18b37618f0fe16",
+				"DiscoKey":   "discokey:02437bf4810f9b2eab4faa0a95ed7554a68e77c62349d9cb577d229e4b869621",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:59370",
+					"10.65.0.27:59370",
+					"172.17.0.1:59370",
+					"172.18.0.1:59370",
+					"172.19.0.1:59370"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:25:14.647702931Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5018459439570437,
+				"StableID":   "nS1YmLRsBg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6f2a4caf1ea3dee0e9f04d9fec96d45bce5ac52767bdd59123827a5e3986ae27",
+				"DiscoKey":   "discokey:d02c0ae33326d6116e1f0f8d9bc344b13569cd0aa5a72bd37484f36c98280c22",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40885",
+					"10.65.0.27:40885",
+					"172.17.0.1:40885",
+					"172.18.0.1:40885",
+					"172.19.0.1:40885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:25:15.77530771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7406573529314029,
+				"StableID":   "naKdAP8Tqz11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a605faa95c0411d7bedcbfd0c3c0fcc132f5bf8a3d6f320da9cfd380a1216c07",
+				"DiscoKey":   "discokey:d9951aa07acdc958f1b303ea70510e99b23700263a9f20e9ff0c6d7b94166a3d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41042",
+					"10.65.0.27:41042",
+					"172.17.0.1:41042",
+					"172.18.0.1:41042",
+					"172.19.0.1:41042"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:25:16.647581746Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1523904849378188,
+				"StableID":   "nFU1BzPBuC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2adea3024e9474888510edb35b7121f648361632bc0efeba54fa86bfafd157d",
+				"DiscoKey":   "discokey:534efb2e6bfe6e1080e1e1f72038c0b00b58fd547dcde98a4c79c82c420a7f4d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59208",
+					"10.65.0.27:59208",
+					"172.17.0.1:59208",
+					"172.18.0.1:59208",
+					"172.19.0.1:59208"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:25:17.134360684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4130257300345700,
+				"StableID":   "n3LLEdrbFZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1013a44fb7f2388126c37059f74f1ab7a3956195aeeece648f0416092cf6d708",
+				"DiscoKey":   "discokey:e9812a838e42c94122feae3b96f8a2a95f95f001dc4e1889dec2db4f12c8a724",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41255",
+					"10.65.0.27:41255",
+					"172.17.0.1:41255",
+					"172.18.0.1:41255",
+					"172.19.0.1:41255"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:25:17.684355567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6367116164312672,
+				"StableID":   "ndByG1Mgir11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85f2b69d0ac922b062ae322fcd44585bae5fbc348187427496c08f4975a83b5f",
+				"DiscoKey":   "discokey:bc0d2a06eda37620615039b35ef9ccc699cfda76f1d9c11a97b6df996e4a6b5e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52970",
+					"10.65.0.27:52970",
+					"172.17.0.1:52970",
+					"172.18.0.1:52970",
+					"172.19.0.1:52970"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:25:18.206091103Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1514851276370035,
+				"StableID":   "nntqvJa5qC11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fabbedda0abf5795ddd763fcef4e8448cf30015e003ccada73cfa860b88187c",
+				"DiscoKey":   "discokey:4cf55f4ca305b6de569fcb188a729d5ac61095716bddbcc7d69d0a818f2cb34c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58727",
+					"10.65.0.27:58727",
+					"172.17.0.1:58727",
+					"172.18.0.1:58727",
+					"172.19.0.1:58727"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:25:18.752272343Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1720558131027891,
+				"StableID":   "nrULGP9FSE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc62de889be17f18f4b6f68c52e07c5b243a51e9c9468f9a519bd9d873156624",
+				"DiscoKey":   "discokey:ea747d6033194936a3cd868de636ca6fa0302e838cb8fd9ffe5f011a8ba8e90e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:51743",
+					"10.65.0.27:51743",
+					"172.17.0.1:51743",
+					"172.18.0.1:51743",
+					"172.19.0.1:51743"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:25:19.302126246Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2311423039873039,
+				"StableID":   "nNrMwVAr3K11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1dbe3fc5be2c1683e3c18da29086be569f0b7a837c0758c309d2a01ac050e651",
+				"DiscoKey":   "discokey:107ef0da987d5f5f8f2b405ca6618d9a70e401b4ca5719a97c0bbc2d7968bd43",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33800",
+					"10.65.0.27:33800",
+					"172.17.0.1:33800",
+					"172.18.0.1:33800",
+					"172.19.0.1:33800"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:25:19.84790873Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3963006022562156,
+				"StableID":   "n7JAYzSrwX11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d463e1a413e1737b02a711cbed86fb6ed582132332855894f0579985c492a707",
+				"DiscoKey":   "discokey:989dfd487fbbd1c82e919994c79403f05431c6fb5499e9c4abd09af253d66b35",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:45441",
+					"10.65.0.27:45441",
+					"172.17.0.1:45441",
+					"172.18.0.1:45441",
+					"172.19.0.1:45441"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:25:20.383940942Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6673170920100261,
+				"StableID":   "nQGX1JtH7u11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90da8fac19af990e5f72b8b2d766c12fb0aee0ab9c23d440d8e33b928c5e507b",
+				"DiscoKey":   "discokey:9d6e17c71f27026dba6d142f1d66e1cddfed9c9aeaed63e570695da0de989412",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43603",
+					"10.65.0.27:43603",
+					"172.17.0.1:43603",
+					"172.18.0.1:43603",
+					"172.19.0.1:43603"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:25:20.925023366Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5596237398539731,
+				"StableID":   "ntmfVgfYhk11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c323ef4ba56d8b62a3fc781c2aa970bf91a0d7ed890ebe5865328abb2555f22",
+				"DiscoKey":   "discokey:c8719e1f556a6923371ed2dfa4c008e075365a13b12ce5bae0220ebe4394f042",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58033",
+					"10.65.0.27:58033",
+					"172.17.0.1:58033",
+					"172.18.0.1:58033",
+					"172.19.0.1:58033"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:25:21.463695724Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         806975654302069,
+				"StableID":   "ngQKDAtUJ711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d6a21d7bcee59fb449e03303128c802e2ba5a335cfd79057f5e2c64845a7526d",
+				"KeyExpiry":  "2026-11-09T07:25:22Z",
+				"DiscoKey":   "discokey:dda85a4eef1d21a17dd805463f31091324c200ff8721f6e46f4167e6907c0e56",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35947",
+					"10.65.0.27:35947",
+					"172.17.0.1:35947",
+					"172.18.0.1:35947",
+					"172.19.0.1:35947"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:25:22.000384279Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7473794549005958,
+				"StableID":   "nHaLVkutM121CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ee87ffe9a2aa91bf126d380bfaec4f05189545d0006b8cf309688a1314ab5d0c",
+				"KeyExpiry":  "2026-11-09T07:25:22Z",
+				"DiscoKey":   "discokey:24fa5573eaf4177afa174dcdc842530b963bed127b5b4553d91f82f0dd3d6737",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34262",
+					"10.65.0.27:34262",
+					"172.17.0.1:34262",
+					"172.18.0.1:34262",
+					"172.19.0.1:34262"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:25:22.58802508Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7406573529314029,
+				"StableID":   "naKdAP8Tqz11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       7406573529314029,
+				"Key":        "nodekey:a605faa95c0411d7bedcbfd0c3c0fcc132f5bf8a3d6f320da9cfd380a1216c07",
+				"DiscoKey":   "discokey:d9951aa07acdc958f1b303ea70510e99b23700263a9f20e9ff0c6d7b94166a3d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41042",
+					"10.65.0.27:41042",
+					"172.17.0.1:41042",
+					"172.18.0.1:41042",
+					"172.19.0.1:41042"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:25:16.647581746Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a605faa95c0411d7bedcbfd0c3c0fcc132f5bf8a3d6f320da9cfd380a1216c07",
+			"MachineKey": "mkey:b4f72f471040b610dbdf7170beeeed4335c5b698648da953948f21bce8eb8305",
+			"Peers": [{
+				"ID":         7033265457719453,
+				"StableID":   "n8ALDXxNvw11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97b092807554919b3f2ca63da1d2563dd1d68d156a01f8063c18b37618f0fe16",
+				"DiscoKey":   "discokey:02437bf4810f9b2eab4faa0a95ed7554a68e77c62349d9cb577d229e4b869621",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:59370",
+					"10.65.0.27:59370",
+					"172.17.0.1:59370",
+					"172.18.0.1:59370",
+					"172.19.0.1:59370"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:25:14.647702931Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5018459439570437,
+				"StableID":   "nS1YmLRsBg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6f2a4caf1ea3dee0e9f04d9fec96d45bce5ac52767bdd59123827a5e3986ae27",
+				"DiscoKey":   "discokey:d02c0ae33326d6116e1f0f8d9bc344b13569cd0aa5a72bd37484f36c98280c22",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40885",
+					"10.65.0.27:40885",
+					"172.17.0.1:40885",
+					"172.18.0.1:40885",
+					"172.19.0.1:40885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:25:15.77530771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1523904849378188,
+				"StableID":   "nFU1BzPBuC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2adea3024e9474888510edb35b7121f648361632bc0efeba54fa86bfafd157d",
+				"DiscoKey":   "discokey:534efb2e6bfe6e1080e1e1f72038c0b00b58fd547dcde98a4c79c82c420a7f4d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59208",
+					"10.65.0.27:59208",
+					"172.17.0.1:59208",
+					"172.18.0.1:59208",
+					"172.19.0.1:59208"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:25:17.134360684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4130257300345700,
+				"StableID":   "n3LLEdrbFZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1013a44fb7f2388126c37059f74f1ab7a3956195aeeece648f0416092cf6d708",
+				"DiscoKey":   "discokey:e9812a838e42c94122feae3b96f8a2a95f95f001dc4e1889dec2db4f12c8a724",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41255",
+					"10.65.0.27:41255",
+					"172.17.0.1:41255",
+					"172.18.0.1:41255",
+					"172.19.0.1:41255"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:25:17.684355567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6367116164312672,
+				"StableID":   "ndByG1Mgir11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85f2b69d0ac922b062ae322fcd44585bae5fbc348187427496c08f4975a83b5f",
+				"DiscoKey":   "discokey:bc0d2a06eda37620615039b35ef9ccc699cfda76f1d9c11a97b6df996e4a6b5e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52970",
+					"10.65.0.27:52970",
+					"172.17.0.1:52970",
+					"172.18.0.1:52970",
+					"172.19.0.1:52970"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:25:18.206091103Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1514851276370035,
+				"StableID":   "nntqvJa5qC11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fabbedda0abf5795ddd763fcef4e8448cf30015e003ccada73cfa860b88187c",
+				"DiscoKey":   "discokey:4cf55f4ca305b6de569fcb188a729d5ac61095716bddbcc7d69d0a818f2cb34c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58727",
+					"10.65.0.27:58727",
+					"172.17.0.1:58727",
+					"172.18.0.1:58727",
+					"172.19.0.1:58727"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:25:18.752272343Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1720558131027891,
+				"StableID":   "nrULGP9FSE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc62de889be17f18f4b6f68c52e07c5b243a51e9c9468f9a519bd9d873156624",
+				"DiscoKey":   "discokey:ea747d6033194936a3cd868de636ca6fa0302e838cb8fd9ffe5f011a8ba8e90e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:51743",
+					"10.65.0.27:51743",
+					"172.17.0.1:51743",
+					"172.18.0.1:51743",
+					"172.19.0.1:51743"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:25:19.302126246Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2311423039873039,
+				"StableID":   "nNrMwVAr3K11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1dbe3fc5be2c1683e3c18da29086be569f0b7a837c0758c309d2a01ac050e651",
+				"DiscoKey":   "discokey:107ef0da987d5f5f8f2b405ca6618d9a70e401b4ca5719a97c0bbc2d7968bd43",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33800",
+					"10.65.0.27:33800",
+					"172.17.0.1:33800",
+					"172.18.0.1:33800",
+					"172.19.0.1:33800"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:25:19.84790873Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3963006022562156,
+				"StableID":   "n7JAYzSrwX11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d463e1a413e1737b02a711cbed86fb6ed582132332855894f0579985c492a707",
+				"DiscoKey":   "discokey:989dfd487fbbd1c82e919994c79403f05431c6fb5499e9c4abd09af253d66b35",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:45441",
+					"10.65.0.27:45441",
+					"172.17.0.1:45441",
+					"172.18.0.1:45441",
+					"172.19.0.1:45441"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:25:20.383940942Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6673170920100261,
+				"StableID":   "nQGX1JtH7u11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90da8fac19af990e5f72b8b2d766c12fb0aee0ab9c23d440d8e33b928c5e507b",
+				"DiscoKey":   "discokey:9d6e17c71f27026dba6d142f1d66e1cddfed9c9aeaed63e570695da0de989412",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43603",
+					"10.65.0.27:43603",
+					"172.17.0.1:43603",
+					"172.18.0.1:43603",
+					"172.19.0.1:43603"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:25:20.925023366Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5596237398539731,
+				"StableID":   "ntmfVgfYhk11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c323ef4ba56d8b62a3fc781c2aa970bf91a0d7ed890ebe5865328abb2555f22",
+				"DiscoKey":   "discokey:c8719e1f556a6923371ed2dfa4c008e075365a13b12ce5bae0220ebe4394f042",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58033",
+					"10.65.0.27:58033",
+					"172.17.0.1:58033",
+					"172.18.0.1:58033",
+					"172.19.0.1:58033"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:25:21.463695724Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         806975654302069,
+				"StableID":   "ngQKDAtUJ711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d6a21d7bcee59fb449e03303128c802e2ba5a335cfd79057f5e2c64845a7526d",
+				"KeyExpiry":  "2026-11-09T07:25:22Z",
+				"DiscoKey":   "discokey:dda85a4eef1d21a17dd805463f31091324c200ff8721f6e46f4167e6907c0e56",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35947",
+					"10.65.0.27:35947",
+					"172.17.0.1:35947",
+					"172.18.0.1:35947",
+					"172.19.0.1:35947"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:25:22.000384279Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7473794549005958,
+				"StableID":   "nHaLVkutM121CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ee87ffe9a2aa91bf126d380bfaec4f05189545d0006b8cf309688a1314ab5d0c",
+				"KeyExpiry":  "2026-11-09T07:25:22Z",
+				"DiscoKey":   "discokey:24fa5573eaf4177afa174dcdc842530b963bed127b5b4553d91f82f0dd3d6737",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34262",
+					"10.65.0.27:34262",
+					"172.17.0.1:34262",
+					"172.18.0.1:34262",
+					"172.19.0.1:34262"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:25:22.58802508Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         370077202905546,
+				"StableID":   "nygk9SJct311CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b140448a88bf5cdfba90d390996b4473062df1de5b77c06361a24881a2aa6913",
+				"KeyExpiry":  "2026-11-09T07:25:23Z",
+				"DiscoKey":   "discokey:8ed0756ea013123480b4828d44588debaeba8c91a7f4dd5f4651a1fe0936085f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60293",
+					"10.65.0.27:60293",
+					"172.17.0.1:60293",
+					"172.18.0.1:60293",
+					"172.19.0.1:60293"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:25:23.068538493Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7406573529314029": {
+				"ID":          7406573529314029,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1720558131027891,
+				"StableID":   "nrULGP9FSE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1720558131027891,
+				"Key":        "nodekey:dc62de889be17f18f4b6f68c52e07c5b243a51e9c9468f9a519bd9d873156624",
+				"DiscoKey":   "discokey:ea747d6033194936a3cd868de636ca6fa0302e838cb8fd9ffe5f011a8ba8e90e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:51743",
+					"10.65.0.27:51743",
+					"172.17.0.1:51743",
+					"172.18.0.1:51743",
+					"172.19.0.1:51743"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:25:19.302126246Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:dc62de889be17f18f4b6f68c52e07c5b243a51e9c9468f9a519bd9d873156624",
+			"MachineKey": "mkey:e4b79a8fe67c92e35862d8a77d4297fbd673bdff635079d30437aa8a57042331",
+			"Peers": [{
+				"ID":         7033265457719453,
+				"StableID":   "n8ALDXxNvw11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97b092807554919b3f2ca63da1d2563dd1d68d156a01f8063c18b37618f0fe16",
+				"DiscoKey":   "discokey:02437bf4810f9b2eab4faa0a95ed7554a68e77c62349d9cb577d229e4b869621",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:59370",
+					"10.65.0.27:59370",
+					"172.17.0.1:59370",
+					"172.18.0.1:59370",
+					"172.19.0.1:59370"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:25:14.647702931Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5018459439570437,
+				"StableID":   "nS1YmLRsBg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6f2a4caf1ea3dee0e9f04d9fec96d45bce5ac52767bdd59123827a5e3986ae27",
+				"DiscoKey":   "discokey:d02c0ae33326d6116e1f0f8d9bc344b13569cd0aa5a72bd37484f36c98280c22",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40885",
+					"10.65.0.27:40885",
+					"172.17.0.1:40885",
+					"172.18.0.1:40885",
+					"172.19.0.1:40885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:25:15.77530771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7406573529314029,
+				"StableID":   "naKdAP8Tqz11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a605faa95c0411d7bedcbfd0c3c0fcc132f5bf8a3d6f320da9cfd380a1216c07",
+				"DiscoKey":   "discokey:d9951aa07acdc958f1b303ea70510e99b23700263a9f20e9ff0c6d7b94166a3d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41042",
+					"10.65.0.27:41042",
+					"172.17.0.1:41042",
+					"172.18.0.1:41042",
+					"172.19.0.1:41042"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:25:16.647581746Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1523904849378188,
+				"StableID":   "nFU1BzPBuC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2adea3024e9474888510edb35b7121f648361632bc0efeba54fa86bfafd157d",
+				"DiscoKey":   "discokey:534efb2e6bfe6e1080e1e1f72038c0b00b58fd547dcde98a4c79c82c420a7f4d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59208",
+					"10.65.0.27:59208",
+					"172.17.0.1:59208",
+					"172.18.0.1:59208",
+					"172.19.0.1:59208"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:25:17.134360684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4130257300345700,
+				"StableID":   "n3LLEdrbFZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1013a44fb7f2388126c37059f74f1ab7a3956195aeeece648f0416092cf6d708",
+				"DiscoKey":   "discokey:e9812a838e42c94122feae3b96f8a2a95f95f001dc4e1889dec2db4f12c8a724",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41255",
+					"10.65.0.27:41255",
+					"172.17.0.1:41255",
+					"172.18.0.1:41255",
+					"172.19.0.1:41255"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:25:17.684355567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6367116164312672,
+				"StableID":   "ndByG1Mgir11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85f2b69d0ac922b062ae322fcd44585bae5fbc348187427496c08f4975a83b5f",
+				"DiscoKey":   "discokey:bc0d2a06eda37620615039b35ef9ccc699cfda76f1d9c11a97b6df996e4a6b5e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52970",
+					"10.65.0.27:52970",
+					"172.17.0.1:52970",
+					"172.18.0.1:52970",
+					"172.19.0.1:52970"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:25:18.206091103Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1514851276370035,
+				"StableID":   "nntqvJa5qC11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fabbedda0abf5795ddd763fcef4e8448cf30015e003ccada73cfa860b88187c",
+				"DiscoKey":   "discokey:4cf55f4ca305b6de569fcb188a729d5ac61095716bddbcc7d69d0a818f2cb34c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58727",
+					"10.65.0.27:58727",
+					"172.17.0.1:58727",
+					"172.18.0.1:58727",
+					"172.19.0.1:58727"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:25:18.752272343Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2311423039873039,
+				"StableID":   "nNrMwVAr3K11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1dbe3fc5be2c1683e3c18da29086be569f0b7a837c0758c309d2a01ac050e651",
+				"DiscoKey":   "discokey:107ef0da987d5f5f8f2b405ca6618d9a70e401b4ca5719a97c0bbc2d7968bd43",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33800",
+					"10.65.0.27:33800",
+					"172.17.0.1:33800",
+					"172.18.0.1:33800",
+					"172.19.0.1:33800"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:25:19.84790873Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3963006022562156,
+				"StableID":   "n7JAYzSrwX11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d463e1a413e1737b02a711cbed86fb6ed582132332855894f0579985c492a707",
+				"DiscoKey":   "discokey:989dfd487fbbd1c82e919994c79403f05431c6fb5499e9c4abd09af253d66b35",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:45441",
+					"10.65.0.27:45441",
+					"172.17.0.1:45441",
+					"172.18.0.1:45441",
+					"172.19.0.1:45441"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:25:20.383940942Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6673170920100261,
+				"StableID":   "nQGX1JtH7u11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90da8fac19af990e5f72b8b2d766c12fb0aee0ab9c23d440d8e33b928c5e507b",
+				"DiscoKey":   "discokey:9d6e17c71f27026dba6d142f1d66e1cddfed9c9aeaed63e570695da0de989412",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43603",
+					"10.65.0.27:43603",
+					"172.17.0.1:43603",
+					"172.18.0.1:43603",
+					"172.19.0.1:43603"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:25:20.925023366Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5596237398539731,
+				"StableID":   "ntmfVgfYhk11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c323ef4ba56d8b62a3fc781c2aa970bf91a0d7ed890ebe5865328abb2555f22",
+				"DiscoKey":   "discokey:c8719e1f556a6923371ed2dfa4c008e075365a13b12ce5bae0220ebe4394f042",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58033",
+					"10.65.0.27:58033",
+					"172.17.0.1:58033",
+					"172.18.0.1:58033",
+					"172.19.0.1:58033"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:25:21.463695724Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         806975654302069,
+				"StableID":   "ngQKDAtUJ711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d6a21d7bcee59fb449e03303128c802e2ba5a335cfd79057f5e2c64845a7526d",
+				"KeyExpiry":  "2026-11-09T07:25:22Z",
+				"DiscoKey":   "discokey:dda85a4eef1d21a17dd805463f31091324c200ff8721f6e46f4167e6907c0e56",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35947",
+					"10.65.0.27:35947",
+					"172.17.0.1:35947",
+					"172.18.0.1:35947",
+					"172.19.0.1:35947"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:25:22.000384279Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7473794549005958,
+				"StableID":   "nHaLVkutM121CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ee87ffe9a2aa91bf126d380bfaec4f05189545d0006b8cf309688a1314ab5d0c",
+				"KeyExpiry":  "2026-11-09T07:25:22Z",
+				"DiscoKey":   "discokey:24fa5573eaf4177afa174dcdc842530b963bed127b5b4553d91f82f0dd3d6737",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34262",
+					"10.65.0.27:34262",
+					"172.17.0.1:34262",
+					"172.18.0.1:34262",
+					"172.19.0.1:34262"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:25:22.58802508Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         370077202905546,
+				"StableID":   "nygk9SJct311CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b140448a88bf5cdfba90d390996b4473062df1de5b77c06361a24881a2aa6913",
+				"KeyExpiry":  "2026-11-09T07:25:23Z",
+				"DiscoKey":   "discokey:8ed0756ea013123480b4828d44588debaeba8c91a7f4dd5f4651a1fe0936085f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60293",
+					"10.65.0.27:60293",
+					"172.17.0.1:60293",
+					"172.18.0.1:60293",
+					"172.19.0.1:60293"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:25:23.068538493Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1720558131027891": {
+				"ID":          1720558131027891,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         806975654302069,
+				"StableID":   "ngQKDAtUJ711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d6a21d7bcee59fb449e03303128c802e2ba5a335cfd79057f5e2c64845a7526d",
+				"KeyExpiry":  "2026-11-09T07:25:22Z",
+				"DiscoKey":   "discokey:dda85a4eef1d21a17dd805463f31091324c200ff8721f6e46f4167e6907c0e56",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35947",
+					"10.65.0.27:35947",
+					"172.17.0.1:35947",
+					"172.18.0.1:35947",
+					"172.19.0.1:35947"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:25:22.000384279Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d6a21d7bcee59fb449e03303128c802e2ba5a335cfd79057f5e2c64845a7526d",
+			"MachineKey": "mkey:31e40443222c3905a5243ea88e5de301cc83e42c3a89a42023d7fc0deae2773e",
+			"Peers": [{
+				"ID":         7033265457719453,
+				"StableID":   "n8ALDXxNvw11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97b092807554919b3f2ca63da1d2563dd1d68d156a01f8063c18b37618f0fe16",
+				"DiscoKey":   "discokey:02437bf4810f9b2eab4faa0a95ed7554a68e77c62349d9cb577d229e4b869621",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:59370",
+					"10.65.0.27:59370",
+					"172.17.0.1:59370",
+					"172.18.0.1:59370",
+					"172.19.0.1:59370"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:25:14.647702931Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5018459439570437,
+				"StableID":   "nS1YmLRsBg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6f2a4caf1ea3dee0e9f04d9fec96d45bce5ac52767bdd59123827a5e3986ae27",
+				"DiscoKey":   "discokey:d02c0ae33326d6116e1f0f8d9bc344b13569cd0aa5a72bd37484f36c98280c22",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40885",
+					"10.65.0.27:40885",
+					"172.17.0.1:40885",
+					"172.18.0.1:40885",
+					"172.19.0.1:40885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:25:15.77530771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7406573529314029,
+				"StableID":   "naKdAP8Tqz11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a605faa95c0411d7bedcbfd0c3c0fcc132f5bf8a3d6f320da9cfd380a1216c07",
+				"DiscoKey":   "discokey:d9951aa07acdc958f1b303ea70510e99b23700263a9f20e9ff0c6d7b94166a3d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41042",
+					"10.65.0.27:41042",
+					"172.17.0.1:41042",
+					"172.18.0.1:41042",
+					"172.19.0.1:41042"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:25:16.647581746Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1523904849378188,
+				"StableID":   "nFU1BzPBuC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2adea3024e9474888510edb35b7121f648361632bc0efeba54fa86bfafd157d",
+				"DiscoKey":   "discokey:534efb2e6bfe6e1080e1e1f72038c0b00b58fd547dcde98a4c79c82c420a7f4d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59208",
+					"10.65.0.27:59208",
+					"172.17.0.1:59208",
+					"172.18.0.1:59208",
+					"172.19.0.1:59208"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:25:17.134360684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4130257300345700,
+				"StableID":   "n3LLEdrbFZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1013a44fb7f2388126c37059f74f1ab7a3956195aeeece648f0416092cf6d708",
+				"DiscoKey":   "discokey:e9812a838e42c94122feae3b96f8a2a95f95f001dc4e1889dec2db4f12c8a724",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41255",
+					"10.65.0.27:41255",
+					"172.17.0.1:41255",
+					"172.18.0.1:41255",
+					"172.19.0.1:41255"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:25:17.684355567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6367116164312672,
+				"StableID":   "ndByG1Mgir11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85f2b69d0ac922b062ae322fcd44585bae5fbc348187427496c08f4975a83b5f",
+				"DiscoKey":   "discokey:bc0d2a06eda37620615039b35ef9ccc699cfda76f1d9c11a97b6df996e4a6b5e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52970",
+					"10.65.0.27:52970",
+					"172.17.0.1:52970",
+					"172.18.0.1:52970",
+					"172.19.0.1:52970"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:25:18.206091103Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1514851276370035,
+				"StableID":   "nntqvJa5qC11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fabbedda0abf5795ddd763fcef4e8448cf30015e003ccada73cfa860b88187c",
+				"DiscoKey":   "discokey:4cf55f4ca305b6de569fcb188a729d5ac61095716bddbcc7d69d0a818f2cb34c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58727",
+					"10.65.0.27:58727",
+					"172.17.0.1:58727",
+					"172.18.0.1:58727",
+					"172.19.0.1:58727"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:25:18.752272343Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1720558131027891,
+				"StableID":   "nrULGP9FSE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc62de889be17f18f4b6f68c52e07c5b243a51e9c9468f9a519bd9d873156624",
+				"DiscoKey":   "discokey:ea747d6033194936a3cd868de636ca6fa0302e838cb8fd9ffe5f011a8ba8e90e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:51743",
+					"10.65.0.27:51743",
+					"172.17.0.1:51743",
+					"172.18.0.1:51743",
+					"172.19.0.1:51743"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:25:19.302126246Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2311423039873039,
+				"StableID":   "nNrMwVAr3K11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1dbe3fc5be2c1683e3c18da29086be569f0b7a837c0758c309d2a01ac050e651",
+				"DiscoKey":   "discokey:107ef0da987d5f5f8f2b405ca6618d9a70e401b4ca5719a97c0bbc2d7968bd43",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33800",
+					"10.65.0.27:33800",
+					"172.17.0.1:33800",
+					"172.18.0.1:33800",
+					"172.19.0.1:33800"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:25:19.84790873Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3963006022562156,
+				"StableID":   "n7JAYzSrwX11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d463e1a413e1737b02a711cbed86fb6ed582132332855894f0579985c492a707",
+				"DiscoKey":   "discokey:989dfd487fbbd1c82e919994c79403f05431c6fb5499e9c4abd09af253d66b35",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:45441",
+					"10.65.0.27:45441",
+					"172.17.0.1:45441",
+					"172.18.0.1:45441",
+					"172.19.0.1:45441"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:25:20.383940942Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6673170920100261,
+				"StableID":   "nQGX1JtH7u11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90da8fac19af990e5f72b8b2d766c12fb0aee0ab9c23d440d8e33b928c5e507b",
+				"DiscoKey":   "discokey:9d6e17c71f27026dba6d142f1d66e1cddfed9c9aeaed63e570695da0de989412",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43603",
+					"10.65.0.27:43603",
+					"172.17.0.1:43603",
+					"172.18.0.1:43603",
+					"172.19.0.1:43603"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:25:20.925023366Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5596237398539731,
+				"StableID":   "ntmfVgfYhk11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c323ef4ba56d8b62a3fc781c2aa970bf91a0d7ed890ebe5865328abb2555f22",
+				"DiscoKey":   "discokey:c8719e1f556a6923371ed2dfa4c008e075365a13b12ce5bae0220ebe4394f042",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58033",
+					"10.65.0.27:58033",
+					"172.17.0.1:58033",
+					"172.18.0.1:58033",
+					"172.19.0.1:58033"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:25:21.463695724Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7473794549005958,
+				"StableID":   "nHaLVkutM121CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ee87ffe9a2aa91bf126d380bfaec4f05189545d0006b8cf309688a1314ab5d0c",
+				"KeyExpiry":  "2026-11-09T07:25:22Z",
+				"DiscoKey":   "discokey:24fa5573eaf4177afa174dcdc842530b963bed127b5b4553d91f82f0dd3d6737",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34262",
+					"10.65.0.27:34262",
+					"172.17.0.1:34262",
+					"172.18.0.1:34262",
+					"172.19.0.1:34262"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:25:22.58802508Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         370077202905546,
+				"StableID":   "nygk9SJct311CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b140448a88bf5cdfba90d390996b4473062df1de5b77c06361a24881a2aa6913",
+				"KeyExpiry":  "2026-11-09T07:25:23Z",
+				"DiscoKey":   "discokey:8ed0756ea013123480b4828d44588debaeba8c91a7f4dd5f4651a1fe0936085f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60293",
+					"10.65.0.27:60293",
+					"172.17.0.1:60293",
+					"172.18.0.1:60293",
+					"172.19.0.1:60293"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:25:23.068538493Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6673170920100261,
+				"StableID":   "nQGX1JtH7u11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       6673170920100261,
+				"Key":        "nodekey:90da8fac19af990e5f72b8b2d766c12fb0aee0ab9c23d440d8e33b928c5e507b",
+				"DiscoKey":   "discokey:9d6e17c71f27026dba6d142f1d66e1cddfed9c9aeaed63e570695da0de989412",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43603",
+					"10.65.0.27:43603",
+					"172.17.0.1:43603",
+					"172.18.0.1:43603",
+					"172.19.0.1:43603"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:25:20.925023366Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:90da8fac19af990e5f72b8b2d766c12fb0aee0ab9c23d440d8e33b928c5e507b",
+			"MachineKey": "mkey:8c19b36187cfc23b05bd0a48864f1a2f7fe91224df18377bccd1efb8bfaaa507",
+			"Peers": [{
+				"ID":         7033265457719453,
+				"StableID":   "n8ALDXxNvw11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97b092807554919b3f2ca63da1d2563dd1d68d156a01f8063c18b37618f0fe16",
+				"DiscoKey":   "discokey:02437bf4810f9b2eab4faa0a95ed7554a68e77c62349d9cb577d229e4b869621",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:59370",
+					"10.65.0.27:59370",
+					"172.17.0.1:59370",
+					"172.18.0.1:59370",
+					"172.19.0.1:59370"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:25:14.647702931Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5018459439570437,
+				"StableID":   "nS1YmLRsBg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6f2a4caf1ea3dee0e9f04d9fec96d45bce5ac52767bdd59123827a5e3986ae27",
+				"DiscoKey":   "discokey:d02c0ae33326d6116e1f0f8d9bc344b13569cd0aa5a72bd37484f36c98280c22",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40885",
+					"10.65.0.27:40885",
+					"172.17.0.1:40885",
+					"172.18.0.1:40885",
+					"172.19.0.1:40885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:25:15.77530771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7406573529314029,
+				"StableID":   "naKdAP8Tqz11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a605faa95c0411d7bedcbfd0c3c0fcc132f5bf8a3d6f320da9cfd380a1216c07",
+				"DiscoKey":   "discokey:d9951aa07acdc958f1b303ea70510e99b23700263a9f20e9ff0c6d7b94166a3d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41042",
+					"10.65.0.27:41042",
+					"172.17.0.1:41042",
+					"172.18.0.1:41042",
+					"172.19.0.1:41042"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:25:16.647581746Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1523904849378188,
+				"StableID":   "nFU1BzPBuC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2adea3024e9474888510edb35b7121f648361632bc0efeba54fa86bfafd157d",
+				"DiscoKey":   "discokey:534efb2e6bfe6e1080e1e1f72038c0b00b58fd547dcde98a4c79c82c420a7f4d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59208",
+					"10.65.0.27:59208",
+					"172.17.0.1:59208",
+					"172.18.0.1:59208",
+					"172.19.0.1:59208"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:25:17.134360684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4130257300345700,
+				"StableID":   "n3LLEdrbFZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1013a44fb7f2388126c37059f74f1ab7a3956195aeeece648f0416092cf6d708",
+				"DiscoKey":   "discokey:e9812a838e42c94122feae3b96f8a2a95f95f001dc4e1889dec2db4f12c8a724",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41255",
+					"10.65.0.27:41255",
+					"172.17.0.1:41255",
+					"172.18.0.1:41255",
+					"172.19.0.1:41255"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:25:17.684355567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6367116164312672,
+				"StableID":   "ndByG1Mgir11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85f2b69d0ac922b062ae322fcd44585bae5fbc348187427496c08f4975a83b5f",
+				"DiscoKey":   "discokey:bc0d2a06eda37620615039b35ef9ccc699cfda76f1d9c11a97b6df996e4a6b5e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52970",
+					"10.65.0.27:52970",
+					"172.17.0.1:52970",
+					"172.18.0.1:52970",
+					"172.19.0.1:52970"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:25:18.206091103Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1514851276370035,
+				"StableID":   "nntqvJa5qC11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fabbedda0abf5795ddd763fcef4e8448cf30015e003ccada73cfa860b88187c",
+				"DiscoKey":   "discokey:4cf55f4ca305b6de569fcb188a729d5ac61095716bddbcc7d69d0a818f2cb34c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58727",
+					"10.65.0.27:58727",
+					"172.17.0.1:58727",
+					"172.18.0.1:58727",
+					"172.19.0.1:58727"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:25:18.752272343Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1720558131027891,
+				"StableID":   "nrULGP9FSE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc62de889be17f18f4b6f68c52e07c5b243a51e9c9468f9a519bd9d873156624",
+				"DiscoKey":   "discokey:ea747d6033194936a3cd868de636ca6fa0302e838cb8fd9ffe5f011a8ba8e90e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:51743",
+					"10.65.0.27:51743",
+					"172.17.0.1:51743",
+					"172.18.0.1:51743",
+					"172.19.0.1:51743"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:25:19.302126246Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2311423039873039,
+				"StableID":   "nNrMwVAr3K11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1dbe3fc5be2c1683e3c18da29086be569f0b7a837c0758c309d2a01ac050e651",
+				"DiscoKey":   "discokey:107ef0da987d5f5f8f2b405ca6618d9a70e401b4ca5719a97c0bbc2d7968bd43",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33800",
+					"10.65.0.27:33800",
+					"172.17.0.1:33800",
+					"172.18.0.1:33800",
+					"172.19.0.1:33800"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:25:19.84790873Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3963006022562156,
+				"StableID":   "n7JAYzSrwX11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d463e1a413e1737b02a711cbed86fb6ed582132332855894f0579985c492a707",
+				"DiscoKey":   "discokey:989dfd487fbbd1c82e919994c79403f05431c6fb5499e9c4abd09af253d66b35",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:45441",
+					"10.65.0.27:45441",
+					"172.17.0.1:45441",
+					"172.18.0.1:45441",
+					"172.19.0.1:45441"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:25:20.383940942Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5596237398539731,
+				"StableID":   "ntmfVgfYhk11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c323ef4ba56d8b62a3fc781c2aa970bf91a0d7ed890ebe5865328abb2555f22",
+				"DiscoKey":   "discokey:c8719e1f556a6923371ed2dfa4c008e075365a13b12ce5bae0220ebe4394f042",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58033",
+					"10.65.0.27:58033",
+					"172.17.0.1:58033",
+					"172.18.0.1:58033",
+					"172.19.0.1:58033"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:25:21.463695724Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         806975654302069,
+				"StableID":   "ngQKDAtUJ711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d6a21d7bcee59fb449e03303128c802e2ba5a335cfd79057f5e2c64845a7526d",
+				"KeyExpiry":  "2026-11-09T07:25:22Z",
+				"DiscoKey":   "discokey:dda85a4eef1d21a17dd805463f31091324c200ff8721f6e46f4167e6907c0e56",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35947",
+					"10.65.0.27:35947",
+					"172.17.0.1:35947",
+					"172.18.0.1:35947",
+					"172.19.0.1:35947"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:25:22.000384279Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7473794549005958,
+				"StableID":   "nHaLVkutM121CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ee87ffe9a2aa91bf126d380bfaec4f05189545d0006b8cf309688a1314ab5d0c",
+				"KeyExpiry":  "2026-11-09T07:25:22Z",
+				"DiscoKey":   "discokey:24fa5573eaf4177afa174dcdc842530b963bed127b5b4553d91f82f0dd3d6737",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34262",
+					"10.65.0.27:34262",
+					"172.17.0.1:34262",
+					"172.18.0.1:34262",
+					"172.19.0.1:34262"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:25:22.58802508Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         370077202905546,
+				"StableID":   "nygk9SJct311CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b140448a88bf5cdfba90d390996b4473062df1de5b77c06361a24881a2aa6913",
+				"KeyExpiry":  "2026-11-09T07:25:23Z",
+				"DiscoKey":   "discokey:8ed0756ea013123480b4828d44588debaeba8c91a7f4dd5f4651a1fe0936085f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60293",
+					"10.65.0.27:60293",
+					"172.17.0.1:60293",
+					"172.18.0.1:60293",
+					"172.19.0.1:60293"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:25:23.068538493Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6673170920100261": {
+				"ID":          6673170920100261,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5018459439570437,
+				"StableID":   "nS1YmLRsBg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       5018459439570437,
+				"Key":        "nodekey:6f2a4caf1ea3dee0e9f04d9fec96d45bce5ac52767bdd59123827a5e3986ae27",
+				"DiscoKey":   "discokey:d02c0ae33326d6116e1f0f8d9bc344b13569cd0aa5a72bd37484f36c98280c22",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40885",
+					"10.65.0.27:40885",
+					"172.17.0.1:40885",
+					"172.18.0.1:40885",
+					"172.19.0.1:40885"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:25:15.77530771Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6f2a4caf1ea3dee0e9f04d9fec96d45bce5ac52767bdd59123827a5e3986ae27",
+			"MachineKey": "mkey:896e694af5b4d309c4b5f4b686faf067c3120ee894719bc8254f93917cb30477",
+			"Peers": [{
+				"ID":         7033265457719453,
+				"StableID":   "n8ALDXxNvw11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97b092807554919b3f2ca63da1d2563dd1d68d156a01f8063c18b37618f0fe16",
+				"DiscoKey":   "discokey:02437bf4810f9b2eab4faa0a95ed7554a68e77c62349d9cb577d229e4b869621",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:59370",
+					"10.65.0.27:59370",
+					"172.17.0.1:59370",
+					"172.18.0.1:59370",
+					"172.19.0.1:59370"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:25:14.647702931Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7406573529314029,
+				"StableID":   "naKdAP8Tqz11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a605faa95c0411d7bedcbfd0c3c0fcc132f5bf8a3d6f320da9cfd380a1216c07",
+				"DiscoKey":   "discokey:d9951aa07acdc958f1b303ea70510e99b23700263a9f20e9ff0c6d7b94166a3d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41042",
+					"10.65.0.27:41042",
+					"172.17.0.1:41042",
+					"172.18.0.1:41042",
+					"172.19.0.1:41042"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:25:16.647581746Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1523904849378188,
+				"StableID":   "nFU1BzPBuC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2adea3024e9474888510edb35b7121f648361632bc0efeba54fa86bfafd157d",
+				"DiscoKey":   "discokey:534efb2e6bfe6e1080e1e1f72038c0b00b58fd547dcde98a4c79c82c420a7f4d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59208",
+					"10.65.0.27:59208",
+					"172.17.0.1:59208",
+					"172.18.0.1:59208",
+					"172.19.0.1:59208"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:25:17.134360684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4130257300345700,
+				"StableID":   "n3LLEdrbFZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1013a44fb7f2388126c37059f74f1ab7a3956195aeeece648f0416092cf6d708",
+				"DiscoKey":   "discokey:e9812a838e42c94122feae3b96f8a2a95f95f001dc4e1889dec2db4f12c8a724",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41255",
+					"10.65.0.27:41255",
+					"172.17.0.1:41255",
+					"172.18.0.1:41255",
+					"172.19.0.1:41255"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:25:17.684355567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6367116164312672,
+				"StableID":   "ndByG1Mgir11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85f2b69d0ac922b062ae322fcd44585bae5fbc348187427496c08f4975a83b5f",
+				"DiscoKey":   "discokey:bc0d2a06eda37620615039b35ef9ccc699cfda76f1d9c11a97b6df996e4a6b5e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52970",
+					"10.65.0.27:52970",
+					"172.17.0.1:52970",
+					"172.18.0.1:52970",
+					"172.19.0.1:52970"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:25:18.206091103Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1514851276370035,
+				"StableID":   "nntqvJa5qC11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fabbedda0abf5795ddd763fcef4e8448cf30015e003ccada73cfa860b88187c",
+				"DiscoKey":   "discokey:4cf55f4ca305b6de569fcb188a729d5ac61095716bddbcc7d69d0a818f2cb34c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58727",
+					"10.65.0.27:58727",
+					"172.17.0.1:58727",
+					"172.18.0.1:58727",
+					"172.19.0.1:58727"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:25:18.752272343Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1720558131027891,
+				"StableID":   "nrULGP9FSE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc62de889be17f18f4b6f68c52e07c5b243a51e9c9468f9a519bd9d873156624",
+				"DiscoKey":   "discokey:ea747d6033194936a3cd868de636ca6fa0302e838cb8fd9ffe5f011a8ba8e90e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:51743",
+					"10.65.0.27:51743",
+					"172.17.0.1:51743",
+					"172.18.0.1:51743",
+					"172.19.0.1:51743"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:25:19.302126246Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2311423039873039,
+				"StableID":   "nNrMwVAr3K11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1dbe3fc5be2c1683e3c18da29086be569f0b7a837c0758c309d2a01ac050e651",
+				"DiscoKey":   "discokey:107ef0da987d5f5f8f2b405ca6618d9a70e401b4ca5719a97c0bbc2d7968bd43",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33800",
+					"10.65.0.27:33800",
+					"172.17.0.1:33800",
+					"172.18.0.1:33800",
+					"172.19.0.1:33800"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:25:19.84790873Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3963006022562156,
+				"StableID":   "n7JAYzSrwX11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d463e1a413e1737b02a711cbed86fb6ed582132332855894f0579985c492a707",
+				"DiscoKey":   "discokey:989dfd487fbbd1c82e919994c79403f05431c6fb5499e9c4abd09af253d66b35",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:45441",
+					"10.65.0.27:45441",
+					"172.17.0.1:45441",
+					"172.18.0.1:45441",
+					"172.19.0.1:45441"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:25:20.383940942Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6673170920100261,
+				"StableID":   "nQGX1JtH7u11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90da8fac19af990e5f72b8b2d766c12fb0aee0ab9c23d440d8e33b928c5e507b",
+				"DiscoKey":   "discokey:9d6e17c71f27026dba6d142f1d66e1cddfed9c9aeaed63e570695da0de989412",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43603",
+					"10.65.0.27:43603",
+					"172.17.0.1:43603",
+					"172.18.0.1:43603",
+					"172.19.0.1:43603"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:25:20.925023366Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5596237398539731,
+				"StableID":   "ntmfVgfYhk11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c323ef4ba56d8b62a3fc781c2aa970bf91a0d7ed890ebe5865328abb2555f22",
+				"DiscoKey":   "discokey:c8719e1f556a6923371ed2dfa4c008e075365a13b12ce5bae0220ebe4394f042",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58033",
+					"10.65.0.27:58033",
+					"172.17.0.1:58033",
+					"172.18.0.1:58033",
+					"172.19.0.1:58033"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:25:21.463695724Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         806975654302069,
+				"StableID":   "ngQKDAtUJ711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d6a21d7bcee59fb449e03303128c802e2ba5a335cfd79057f5e2c64845a7526d",
+				"KeyExpiry":  "2026-11-09T07:25:22Z",
+				"DiscoKey":   "discokey:dda85a4eef1d21a17dd805463f31091324c200ff8721f6e46f4167e6907c0e56",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35947",
+					"10.65.0.27:35947",
+					"172.17.0.1:35947",
+					"172.18.0.1:35947",
+					"172.19.0.1:35947"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:25:22.000384279Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7473794549005958,
+				"StableID":   "nHaLVkutM121CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ee87ffe9a2aa91bf126d380bfaec4f05189545d0006b8cf309688a1314ab5d0c",
+				"KeyExpiry":  "2026-11-09T07:25:22Z",
+				"DiscoKey":   "discokey:24fa5573eaf4177afa174dcdc842530b963bed127b5b4553d91f82f0dd3d6737",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34262",
+					"10.65.0.27:34262",
+					"172.17.0.1:34262",
+					"172.18.0.1:34262",
+					"172.19.0.1:34262"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:25:22.58802508Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         370077202905546,
+				"StableID":   "nygk9SJct311CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b140448a88bf5cdfba90d390996b4473062df1de5b77c06361a24881a2aa6913",
+				"KeyExpiry":  "2026-11-09T07:25:23Z",
+				"DiscoKey":   "discokey:8ed0756ea013123480b4828d44588debaeba8c91a7f4dd5f4651a1fe0936085f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60293",
+					"10.65.0.27:60293",
+					"172.17.0.1:60293",
+					"172.18.0.1:60293",
+					"172.19.0.1:60293"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:25:23.068538493Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5018459439570437": {
+				"ID":          5018459439570437,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7033265457719453,
+				"StableID":   "n8ALDXxNvw11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       7033265457719453,
+				"Key":        "nodekey:97b092807554919b3f2ca63da1d2563dd1d68d156a01f8063c18b37618f0fe16",
+				"DiscoKey":   "discokey:02437bf4810f9b2eab4faa0a95ed7554a68e77c62349d9cb577d229e4b869621",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:59370",
+					"10.65.0.27:59370",
+					"172.17.0.1:59370",
+					"172.18.0.1:59370",
+					"172.19.0.1:59370"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:25:14.647702931Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:97b092807554919b3f2ca63da1d2563dd1d68d156a01f8063c18b37618f0fe16",
+			"MachineKey": "mkey:7df64fb92634f9e6af47409c74b28115e860de30f085aa1bc1b9ced8403e7234",
+			"Peers": [{
+				"ID":         5018459439570437,
+				"StableID":   "nS1YmLRsBg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6f2a4caf1ea3dee0e9f04d9fec96d45bce5ac52767bdd59123827a5e3986ae27",
+				"DiscoKey":   "discokey:d02c0ae33326d6116e1f0f8d9bc344b13569cd0aa5a72bd37484f36c98280c22",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40885",
+					"10.65.0.27:40885",
+					"172.17.0.1:40885",
+					"172.18.0.1:40885",
+					"172.19.0.1:40885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:25:15.77530771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7406573529314029,
+				"StableID":   "naKdAP8Tqz11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a605faa95c0411d7bedcbfd0c3c0fcc132f5bf8a3d6f320da9cfd380a1216c07",
+				"DiscoKey":   "discokey:d9951aa07acdc958f1b303ea70510e99b23700263a9f20e9ff0c6d7b94166a3d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41042",
+					"10.65.0.27:41042",
+					"172.17.0.1:41042",
+					"172.18.0.1:41042",
+					"172.19.0.1:41042"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:25:16.647581746Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1523904849378188,
+				"StableID":   "nFU1BzPBuC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2adea3024e9474888510edb35b7121f648361632bc0efeba54fa86bfafd157d",
+				"DiscoKey":   "discokey:534efb2e6bfe6e1080e1e1f72038c0b00b58fd547dcde98a4c79c82c420a7f4d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59208",
+					"10.65.0.27:59208",
+					"172.17.0.1:59208",
+					"172.18.0.1:59208",
+					"172.19.0.1:59208"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:25:17.134360684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4130257300345700,
+				"StableID":   "n3LLEdrbFZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1013a44fb7f2388126c37059f74f1ab7a3956195aeeece648f0416092cf6d708",
+				"DiscoKey":   "discokey:e9812a838e42c94122feae3b96f8a2a95f95f001dc4e1889dec2db4f12c8a724",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41255",
+					"10.65.0.27:41255",
+					"172.17.0.1:41255",
+					"172.18.0.1:41255",
+					"172.19.0.1:41255"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:25:17.684355567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6367116164312672,
+				"StableID":   "ndByG1Mgir11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85f2b69d0ac922b062ae322fcd44585bae5fbc348187427496c08f4975a83b5f",
+				"DiscoKey":   "discokey:bc0d2a06eda37620615039b35ef9ccc699cfda76f1d9c11a97b6df996e4a6b5e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52970",
+					"10.65.0.27:52970",
+					"172.17.0.1:52970",
+					"172.18.0.1:52970",
+					"172.19.0.1:52970"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:25:18.206091103Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1514851276370035,
+				"StableID":   "nntqvJa5qC11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fabbedda0abf5795ddd763fcef4e8448cf30015e003ccada73cfa860b88187c",
+				"DiscoKey":   "discokey:4cf55f4ca305b6de569fcb188a729d5ac61095716bddbcc7d69d0a818f2cb34c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58727",
+					"10.65.0.27:58727",
+					"172.17.0.1:58727",
+					"172.18.0.1:58727",
+					"172.19.0.1:58727"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:25:18.752272343Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1720558131027891,
+				"StableID":   "nrULGP9FSE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc62de889be17f18f4b6f68c52e07c5b243a51e9c9468f9a519bd9d873156624",
+				"DiscoKey":   "discokey:ea747d6033194936a3cd868de636ca6fa0302e838cb8fd9ffe5f011a8ba8e90e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:51743",
+					"10.65.0.27:51743",
+					"172.17.0.1:51743",
+					"172.18.0.1:51743",
+					"172.19.0.1:51743"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:25:19.302126246Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2311423039873039,
+				"StableID":   "nNrMwVAr3K11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1dbe3fc5be2c1683e3c18da29086be569f0b7a837c0758c309d2a01ac050e651",
+				"DiscoKey":   "discokey:107ef0da987d5f5f8f2b405ca6618d9a70e401b4ca5719a97c0bbc2d7968bd43",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33800",
+					"10.65.0.27:33800",
+					"172.17.0.1:33800",
+					"172.18.0.1:33800",
+					"172.19.0.1:33800"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:25:19.84790873Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3963006022562156,
+				"StableID":   "n7JAYzSrwX11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d463e1a413e1737b02a711cbed86fb6ed582132332855894f0579985c492a707",
+				"DiscoKey":   "discokey:989dfd487fbbd1c82e919994c79403f05431c6fb5499e9c4abd09af253d66b35",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:45441",
+					"10.65.0.27:45441",
+					"172.17.0.1:45441",
+					"172.18.0.1:45441",
+					"172.19.0.1:45441"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:25:20.383940942Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6673170920100261,
+				"StableID":   "nQGX1JtH7u11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90da8fac19af990e5f72b8b2d766c12fb0aee0ab9c23d440d8e33b928c5e507b",
+				"DiscoKey":   "discokey:9d6e17c71f27026dba6d142f1d66e1cddfed9c9aeaed63e570695da0de989412",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43603",
+					"10.65.0.27:43603",
+					"172.17.0.1:43603",
+					"172.18.0.1:43603",
+					"172.19.0.1:43603"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:25:20.925023366Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5596237398539731,
+				"StableID":   "ntmfVgfYhk11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c323ef4ba56d8b62a3fc781c2aa970bf91a0d7ed890ebe5865328abb2555f22",
+				"DiscoKey":   "discokey:c8719e1f556a6923371ed2dfa4c008e075365a13b12ce5bae0220ebe4394f042",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58033",
+					"10.65.0.27:58033",
+					"172.17.0.1:58033",
+					"172.18.0.1:58033",
+					"172.19.0.1:58033"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:25:21.463695724Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         806975654302069,
+				"StableID":   "ngQKDAtUJ711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d6a21d7bcee59fb449e03303128c802e2ba5a335cfd79057f5e2c64845a7526d",
+				"KeyExpiry":  "2026-11-09T07:25:22Z",
+				"DiscoKey":   "discokey:dda85a4eef1d21a17dd805463f31091324c200ff8721f6e46f4167e6907c0e56",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35947",
+					"10.65.0.27:35947",
+					"172.17.0.1:35947",
+					"172.18.0.1:35947",
+					"172.19.0.1:35947"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:25:22.000384279Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7473794549005958,
+				"StableID":   "nHaLVkutM121CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ee87ffe9a2aa91bf126d380bfaec4f05189545d0006b8cf309688a1314ab5d0c",
+				"KeyExpiry":  "2026-11-09T07:25:22Z",
+				"DiscoKey":   "discokey:24fa5573eaf4177afa174dcdc842530b963bed127b5b4553d91f82f0dd3d6737",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34262",
+					"10.65.0.27:34262",
+					"172.17.0.1:34262",
+					"172.18.0.1:34262",
+					"172.19.0.1:34262"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:25:22.58802508Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         370077202905546,
+				"StableID":   "nygk9SJct311CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b140448a88bf5cdfba90d390996b4473062df1de5b77c06361a24881a2aa6913",
+				"KeyExpiry":  "2026-11-09T07:25:23Z",
+				"DiscoKey":   "discokey:8ed0756ea013123480b4828d44588debaeba8c91a7f4dd5f4651a1fe0936085f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60293",
+					"10.65.0.27:60293",
+					"172.17.0.1:60293",
+					"172.18.0.1:60293",
+					"172.19.0.1:60293"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:25:23.068538493Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7033265457719453": {
+				"ID":          7033265457719453,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4130257300345700,
+				"StableID":   "n3LLEdrbFZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       4130257300345700,
+				"Key":        "nodekey:1013a44fb7f2388126c37059f74f1ab7a3956195aeeece648f0416092cf6d708",
+				"DiscoKey":   "discokey:e9812a838e42c94122feae3b96f8a2a95f95f001dc4e1889dec2db4f12c8a724",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41255",
+					"10.65.0.27:41255",
+					"172.17.0.1:41255",
+					"172.18.0.1:41255",
+					"172.19.0.1:41255"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:25:17.684355567Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1013a44fb7f2388126c37059f74f1ab7a3956195aeeece648f0416092cf6d708",
+			"MachineKey": "mkey:fccd089a04be5ce6c64a7aaac8d18e3a0f16f14ab88701608efc2f03f9e9494d",
+			"Peers": [{
+				"ID":         7033265457719453,
+				"StableID":   "n8ALDXxNvw11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97b092807554919b3f2ca63da1d2563dd1d68d156a01f8063c18b37618f0fe16",
+				"DiscoKey":   "discokey:02437bf4810f9b2eab4faa0a95ed7554a68e77c62349d9cb577d229e4b869621",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:59370",
+					"10.65.0.27:59370",
+					"172.17.0.1:59370",
+					"172.18.0.1:59370",
+					"172.19.0.1:59370"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:25:14.647702931Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5018459439570437,
+				"StableID":   "nS1YmLRsBg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6f2a4caf1ea3dee0e9f04d9fec96d45bce5ac52767bdd59123827a5e3986ae27",
+				"DiscoKey":   "discokey:d02c0ae33326d6116e1f0f8d9bc344b13569cd0aa5a72bd37484f36c98280c22",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40885",
+					"10.65.0.27:40885",
+					"172.17.0.1:40885",
+					"172.18.0.1:40885",
+					"172.19.0.1:40885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:25:15.77530771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7406573529314029,
+				"StableID":   "naKdAP8Tqz11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a605faa95c0411d7bedcbfd0c3c0fcc132f5bf8a3d6f320da9cfd380a1216c07",
+				"DiscoKey":   "discokey:d9951aa07acdc958f1b303ea70510e99b23700263a9f20e9ff0c6d7b94166a3d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41042",
+					"10.65.0.27:41042",
+					"172.17.0.1:41042",
+					"172.18.0.1:41042",
+					"172.19.0.1:41042"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:25:16.647581746Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1523904849378188,
+				"StableID":   "nFU1BzPBuC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2adea3024e9474888510edb35b7121f648361632bc0efeba54fa86bfafd157d",
+				"DiscoKey":   "discokey:534efb2e6bfe6e1080e1e1f72038c0b00b58fd547dcde98a4c79c82c420a7f4d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59208",
+					"10.65.0.27:59208",
+					"172.17.0.1:59208",
+					"172.18.0.1:59208",
+					"172.19.0.1:59208"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:25:17.134360684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6367116164312672,
+				"StableID":   "ndByG1Mgir11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85f2b69d0ac922b062ae322fcd44585bae5fbc348187427496c08f4975a83b5f",
+				"DiscoKey":   "discokey:bc0d2a06eda37620615039b35ef9ccc699cfda76f1d9c11a97b6df996e4a6b5e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52970",
+					"10.65.0.27:52970",
+					"172.17.0.1:52970",
+					"172.18.0.1:52970",
+					"172.19.0.1:52970"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:25:18.206091103Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1514851276370035,
+				"StableID":   "nntqvJa5qC11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fabbedda0abf5795ddd763fcef4e8448cf30015e003ccada73cfa860b88187c",
+				"DiscoKey":   "discokey:4cf55f4ca305b6de569fcb188a729d5ac61095716bddbcc7d69d0a818f2cb34c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58727",
+					"10.65.0.27:58727",
+					"172.17.0.1:58727",
+					"172.18.0.1:58727",
+					"172.19.0.1:58727"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:25:18.752272343Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1720558131027891,
+				"StableID":   "nrULGP9FSE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc62de889be17f18f4b6f68c52e07c5b243a51e9c9468f9a519bd9d873156624",
+				"DiscoKey":   "discokey:ea747d6033194936a3cd868de636ca6fa0302e838cb8fd9ffe5f011a8ba8e90e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:51743",
+					"10.65.0.27:51743",
+					"172.17.0.1:51743",
+					"172.18.0.1:51743",
+					"172.19.0.1:51743"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:25:19.302126246Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2311423039873039,
+				"StableID":   "nNrMwVAr3K11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1dbe3fc5be2c1683e3c18da29086be569f0b7a837c0758c309d2a01ac050e651",
+				"DiscoKey":   "discokey:107ef0da987d5f5f8f2b405ca6618d9a70e401b4ca5719a97c0bbc2d7968bd43",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33800",
+					"10.65.0.27:33800",
+					"172.17.0.1:33800",
+					"172.18.0.1:33800",
+					"172.19.0.1:33800"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:25:19.84790873Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3963006022562156,
+				"StableID":   "n7JAYzSrwX11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d463e1a413e1737b02a711cbed86fb6ed582132332855894f0579985c492a707",
+				"DiscoKey":   "discokey:989dfd487fbbd1c82e919994c79403f05431c6fb5499e9c4abd09af253d66b35",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:45441",
+					"10.65.0.27:45441",
+					"172.17.0.1:45441",
+					"172.18.0.1:45441",
+					"172.19.0.1:45441"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:25:20.383940942Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6673170920100261,
+				"StableID":   "nQGX1JtH7u11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90da8fac19af990e5f72b8b2d766c12fb0aee0ab9c23d440d8e33b928c5e507b",
+				"DiscoKey":   "discokey:9d6e17c71f27026dba6d142f1d66e1cddfed9c9aeaed63e570695da0de989412",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43603",
+					"10.65.0.27:43603",
+					"172.17.0.1:43603",
+					"172.18.0.1:43603",
+					"172.19.0.1:43603"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:25:20.925023366Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5596237398539731,
+				"StableID":   "ntmfVgfYhk11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c323ef4ba56d8b62a3fc781c2aa970bf91a0d7ed890ebe5865328abb2555f22",
+				"DiscoKey":   "discokey:c8719e1f556a6923371ed2dfa4c008e075365a13b12ce5bae0220ebe4394f042",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58033",
+					"10.65.0.27:58033",
+					"172.17.0.1:58033",
+					"172.18.0.1:58033",
+					"172.19.0.1:58033"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:25:21.463695724Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         806975654302069,
+				"StableID":   "ngQKDAtUJ711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d6a21d7bcee59fb449e03303128c802e2ba5a335cfd79057f5e2c64845a7526d",
+				"KeyExpiry":  "2026-11-09T07:25:22Z",
+				"DiscoKey":   "discokey:dda85a4eef1d21a17dd805463f31091324c200ff8721f6e46f4167e6907c0e56",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35947",
+					"10.65.0.27:35947",
+					"172.17.0.1:35947",
+					"172.18.0.1:35947",
+					"172.19.0.1:35947"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:25:22.000384279Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7473794549005958,
+				"StableID":   "nHaLVkutM121CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ee87ffe9a2aa91bf126d380bfaec4f05189545d0006b8cf309688a1314ab5d0c",
+				"KeyExpiry":  "2026-11-09T07:25:22Z",
+				"DiscoKey":   "discokey:24fa5573eaf4177afa174dcdc842530b963bed127b5b4553d91f82f0dd3d6737",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34262",
+					"10.65.0.27:34262",
+					"172.17.0.1:34262",
+					"172.18.0.1:34262",
+					"172.19.0.1:34262"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:25:22.58802508Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         370077202905546,
+				"StableID":   "nygk9SJct311CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b140448a88bf5cdfba90d390996b4473062df1de5b77c06361a24881a2aa6913",
+				"KeyExpiry":  "2026-11-09T07:25:23Z",
+				"DiscoKey":   "discokey:8ed0756ea013123480b4828d44588debaeba8c91a7f4dd5f4651a1fe0936085f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60293",
+					"10.65.0.27:60293",
+					"172.17.0.1:60293",
+					"172.18.0.1:60293",
+					"172.19.0.1:60293"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:25:23.068538493Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4130257300345700": {
+				"ID":          4130257300345700,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1523904849378188,
+				"StableID":   "nFU1BzPBuC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1523904849378188,
+				"Key":        "nodekey:e2adea3024e9474888510edb35b7121f648361632bc0efeba54fa86bfafd157d",
+				"DiscoKey":   "discokey:534efb2e6bfe6e1080e1e1f72038c0b00b58fd547dcde98a4c79c82c420a7f4d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59208",
+					"10.65.0.27:59208",
+					"172.17.0.1:59208",
+					"172.18.0.1:59208",
+					"172.19.0.1:59208"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:25:17.134360684Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e2adea3024e9474888510edb35b7121f648361632bc0efeba54fa86bfafd157d",
+			"MachineKey": "mkey:796b7576693a078849523d5bcde08fe731a1173d79f1874b4135fa60de663006",
+			"Peers": [{
+				"ID":         7033265457719453,
+				"StableID":   "n8ALDXxNvw11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97b092807554919b3f2ca63da1d2563dd1d68d156a01f8063c18b37618f0fe16",
+				"DiscoKey":   "discokey:02437bf4810f9b2eab4faa0a95ed7554a68e77c62349d9cb577d229e4b869621",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:59370",
+					"10.65.0.27:59370",
+					"172.17.0.1:59370",
+					"172.18.0.1:59370",
+					"172.19.0.1:59370"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:25:14.647702931Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5018459439570437,
+				"StableID":   "nS1YmLRsBg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6f2a4caf1ea3dee0e9f04d9fec96d45bce5ac52767bdd59123827a5e3986ae27",
+				"DiscoKey":   "discokey:d02c0ae33326d6116e1f0f8d9bc344b13569cd0aa5a72bd37484f36c98280c22",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40885",
+					"10.65.0.27:40885",
+					"172.17.0.1:40885",
+					"172.18.0.1:40885",
+					"172.19.0.1:40885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:25:15.77530771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7406573529314029,
+				"StableID":   "naKdAP8Tqz11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a605faa95c0411d7bedcbfd0c3c0fcc132f5bf8a3d6f320da9cfd380a1216c07",
+				"DiscoKey":   "discokey:d9951aa07acdc958f1b303ea70510e99b23700263a9f20e9ff0c6d7b94166a3d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41042",
+					"10.65.0.27:41042",
+					"172.17.0.1:41042",
+					"172.18.0.1:41042",
+					"172.19.0.1:41042"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:25:16.647581746Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4130257300345700,
+				"StableID":   "n3LLEdrbFZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1013a44fb7f2388126c37059f74f1ab7a3956195aeeece648f0416092cf6d708",
+				"DiscoKey":   "discokey:e9812a838e42c94122feae3b96f8a2a95f95f001dc4e1889dec2db4f12c8a724",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41255",
+					"10.65.0.27:41255",
+					"172.17.0.1:41255",
+					"172.18.0.1:41255",
+					"172.19.0.1:41255"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:25:17.684355567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6367116164312672,
+				"StableID":   "ndByG1Mgir11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85f2b69d0ac922b062ae322fcd44585bae5fbc348187427496c08f4975a83b5f",
+				"DiscoKey":   "discokey:bc0d2a06eda37620615039b35ef9ccc699cfda76f1d9c11a97b6df996e4a6b5e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52970",
+					"10.65.0.27:52970",
+					"172.17.0.1:52970",
+					"172.18.0.1:52970",
+					"172.19.0.1:52970"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:25:18.206091103Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1514851276370035,
+				"StableID":   "nntqvJa5qC11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fabbedda0abf5795ddd763fcef4e8448cf30015e003ccada73cfa860b88187c",
+				"DiscoKey":   "discokey:4cf55f4ca305b6de569fcb188a729d5ac61095716bddbcc7d69d0a818f2cb34c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58727",
+					"10.65.0.27:58727",
+					"172.17.0.1:58727",
+					"172.18.0.1:58727",
+					"172.19.0.1:58727"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:25:18.752272343Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1720558131027891,
+				"StableID":   "nrULGP9FSE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc62de889be17f18f4b6f68c52e07c5b243a51e9c9468f9a519bd9d873156624",
+				"DiscoKey":   "discokey:ea747d6033194936a3cd868de636ca6fa0302e838cb8fd9ffe5f011a8ba8e90e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:51743",
+					"10.65.0.27:51743",
+					"172.17.0.1:51743",
+					"172.18.0.1:51743",
+					"172.19.0.1:51743"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:25:19.302126246Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2311423039873039,
+				"StableID":   "nNrMwVAr3K11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1dbe3fc5be2c1683e3c18da29086be569f0b7a837c0758c309d2a01ac050e651",
+				"DiscoKey":   "discokey:107ef0da987d5f5f8f2b405ca6618d9a70e401b4ca5719a97c0bbc2d7968bd43",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33800",
+					"10.65.0.27:33800",
+					"172.17.0.1:33800",
+					"172.18.0.1:33800",
+					"172.19.0.1:33800"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:25:19.84790873Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3963006022562156,
+				"StableID":   "n7JAYzSrwX11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d463e1a413e1737b02a711cbed86fb6ed582132332855894f0579985c492a707",
+				"DiscoKey":   "discokey:989dfd487fbbd1c82e919994c79403f05431c6fb5499e9c4abd09af253d66b35",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:45441",
+					"10.65.0.27:45441",
+					"172.17.0.1:45441",
+					"172.18.0.1:45441",
+					"172.19.0.1:45441"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:25:20.383940942Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6673170920100261,
+				"StableID":   "nQGX1JtH7u11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90da8fac19af990e5f72b8b2d766c12fb0aee0ab9c23d440d8e33b928c5e507b",
+				"DiscoKey":   "discokey:9d6e17c71f27026dba6d142f1d66e1cddfed9c9aeaed63e570695da0de989412",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43603",
+					"10.65.0.27:43603",
+					"172.17.0.1:43603",
+					"172.18.0.1:43603",
+					"172.19.0.1:43603"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:25:20.925023366Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5596237398539731,
+				"StableID":   "ntmfVgfYhk11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c323ef4ba56d8b62a3fc781c2aa970bf91a0d7ed890ebe5865328abb2555f22",
+				"DiscoKey":   "discokey:c8719e1f556a6923371ed2dfa4c008e075365a13b12ce5bae0220ebe4394f042",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58033",
+					"10.65.0.27:58033",
+					"172.17.0.1:58033",
+					"172.18.0.1:58033",
+					"172.19.0.1:58033"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:25:21.463695724Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         806975654302069,
+				"StableID":   "ngQKDAtUJ711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d6a21d7bcee59fb449e03303128c802e2ba5a335cfd79057f5e2c64845a7526d",
+				"KeyExpiry":  "2026-11-09T07:25:22Z",
+				"DiscoKey":   "discokey:dda85a4eef1d21a17dd805463f31091324c200ff8721f6e46f4167e6907c0e56",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35947",
+					"10.65.0.27:35947",
+					"172.17.0.1:35947",
+					"172.18.0.1:35947",
+					"172.19.0.1:35947"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:25:22.000384279Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7473794549005958,
+				"StableID":   "nHaLVkutM121CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ee87ffe9a2aa91bf126d380bfaec4f05189545d0006b8cf309688a1314ab5d0c",
+				"KeyExpiry":  "2026-11-09T07:25:22Z",
+				"DiscoKey":   "discokey:24fa5573eaf4177afa174dcdc842530b963bed127b5b4553d91f82f0dd3d6737",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34262",
+					"10.65.0.27:34262",
+					"172.17.0.1:34262",
+					"172.18.0.1:34262",
+					"172.19.0.1:34262"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:25:22.58802508Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         370077202905546,
+				"StableID":   "nygk9SJct311CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b140448a88bf5cdfba90d390996b4473062df1de5b77c06361a24881a2aa6913",
+				"KeyExpiry":  "2026-11-09T07:25:23Z",
+				"DiscoKey":   "discokey:8ed0756ea013123480b4828d44588debaeba8c91a7f4dd5f4651a1fe0936085f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60293",
+					"10.65.0.27:60293",
+					"172.17.0.1:60293",
+					"172.18.0.1:60293",
+					"172.19.0.1:60293"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:25:23.068538493Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1523904849378188": {
+				"ID":          1523904849378188,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1514851276370035,
+				"StableID":   "nntqvJa5qC11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1514851276370035,
+				"Key":        "nodekey:5fabbedda0abf5795ddd763fcef4e8448cf30015e003ccada73cfa860b88187c",
+				"DiscoKey":   "discokey:4cf55f4ca305b6de569fcb188a729d5ac61095716bddbcc7d69d0a818f2cb34c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58727",
+					"10.65.0.27:58727",
+					"172.17.0.1:58727",
+					"172.18.0.1:58727",
+					"172.19.0.1:58727"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:25:18.752272343Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5fabbedda0abf5795ddd763fcef4e8448cf30015e003ccada73cfa860b88187c",
+			"MachineKey": "mkey:c9366c66162ad5c8e8d948ce895c5205a3d54839e3579434714bc5e5d714c468",
+			"Peers": [{
+				"ID":         7033265457719453,
+				"StableID":   "n8ALDXxNvw11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97b092807554919b3f2ca63da1d2563dd1d68d156a01f8063c18b37618f0fe16",
+				"DiscoKey":   "discokey:02437bf4810f9b2eab4faa0a95ed7554a68e77c62349d9cb577d229e4b869621",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:59370",
+					"10.65.0.27:59370",
+					"172.17.0.1:59370",
+					"172.18.0.1:59370",
+					"172.19.0.1:59370"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:25:14.647702931Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5018459439570437,
+				"StableID":   "nS1YmLRsBg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6f2a4caf1ea3dee0e9f04d9fec96d45bce5ac52767bdd59123827a5e3986ae27",
+				"DiscoKey":   "discokey:d02c0ae33326d6116e1f0f8d9bc344b13569cd0aa5a72bd37484f36c98280c22",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40885",
+					"10.65.0.27:40885",
+					"172.17.0.1:40885",
+					"172.18.0.1:40885",
+					"172.19.0.1:40885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:25:15.77530771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7406573529314029,
+				"StableID":   "naKdAP8Tqz11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a605faa95c0411d7bedcbfd0c3c0fcc132f5bf8a3d6f320da9cfd380a1216c07",
+				"DiscoKey":   "discokey:d9951aa07acdc958f1b303ea70510e99b23700263a9f20e9ff0c6d7b94166a3d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41042",
+					"10.65.0.27:41042",
+					"172.17.0.1:41042",
+					"172.18.0.1:41042",
+					"172.19.0.1:41042"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:25:16.647581746Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1523904849378188,
+				"StableID":   "nFU1BzPBuC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2adea3024e9474888510edb35b7121f648361632bc0efeba54fa86bfafd157d",
+				"DiscoKey":   "discokey:534efb2e6bfe6e1080e1e1f72038c0b00b58fd547dcde98a4c79c82c420a7f4d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59208",
+					"10.65.0.27:59208",
+					"172.17.0.1:59208",
+					"172.18.0.1:59208",
+					"172.19.0.1:59208"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:25:17.134360684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4130257300345700,
+				"StableID":   "n3LLEdrbFZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1013a44fb7f2388126c37059f74f1ab7a3956195aeeece648f0416092cf6d708",
+				"DiscoKey":   "discokey:e9812a838e42c94122feae3b96f8a2a95f95f001dc4e1889dec2db4f12c8a724",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41255",
+					"10.65.0.27:41255",
+					"172.17.0.1:41255",
+					"172.18.0.1:41255",
+					"172.19.0.1:41255"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:25:17.684355567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6367116164312672,
+				"StableID":   "ndByG1Mgir11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85f2b69d0ac922b062ae322fcd44585bae5fbc348187427496c08f4975a83b5f",
+				"DiscoKey":   "discokey:bc0d2a06eda37620615039b35ef9ccc699cfda76f1d9c11a97b6df996e4a6b5e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52970",
+					"10.65.0.27:52970",
+					"172.17.0.1:52970",
+					"172.18.0.1:52970",
+					"172.19.0.1:52970"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:25:18.206091103Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1720558131027891,
+				"StableID":   "nrULGP9FSE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc62de889be17f18f4b6f68c52e07c5b243a51e9c9468f9a519bd9d873156624",
+				"DiscoKey":   "discokey:ea747d6033194936a3cd868de636ca6fa0302e838cb8fd9ffe5f011a8ba8e90e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:51743",
+					"10.65.0.27:51743",
+					"172.17.0.1:51743",
+					"172.18.0.1:51743",
+					"172.19.0.1:51743"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:25:19.302126246Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2311423039873039,
+				"StableID":   "nNrMwVAr3K11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1dbe3fc5be2c1683e3c18da29086be569f0b7a837c0758c309d2a01ac050e651",
+				"DiscoKey":   "discokey:107ef0da987d5f5f8f2b405ca6618d9a70e401b4ca5719a97c0bbc2d7968bd43",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33800",
+					"10.65.0.27:33800",
+					"172.17.0.1:33800",
+					"172.18.0.1:33800",
+					"172.19.0.1:33800"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:25:19.84790873Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3963006022562156,
+				"StableID":   "n7JAYzSrwX11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d463e1a413e1737b02a711cbed86fb6ed582132332855894f0579985c492a707",
+				"DiscoKey":   "discokey:989dfd487fbbd1c82e919994c79403f05431c6fb5499e9c4abd09af253d66b35",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:45441",
+					"10.65.0.27:45441",
+					"172.17.0.1:45441",
+					"172.18.0.1:45441",
+					"172.19.0.1:45441"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:25:20.383940942Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6673170920100261,
+				"StableID":   "nQGX1JtH7u11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90da8fac19af990e5f72b8b2d766c12fb0aee0ab9c23d440d8e33b928c5e507b",
+				"DiscoKey":   "discokey:9d6e17c71f27026dba6d142f1d66e1cddfed9c9aeaed63e570695da0de989412",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43603",
+					"10.65.0.27:43603",
+					"172.17.0.1:43603",
+					"172.18.0.1:43603",
+					"172.19.0.1:43603"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:25:20.925023366Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5596237398539731,
+				"StableID":   "ntmfVgfYhk11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c323ef4ba56d8b62a3fc781c2aa970bf91a0d7ed890ebe5865328abb2555f22",
+				"DiscoKey":   "discokey:c8719e1f556a6923371ed2dfa4c008e075365a13b12ce5bae0220ebe4394f042",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58033",
+					"10.65.0.27:58033",
+					"172.17.0.1:58033",
+					"172.18.0.1:58033",
+					"172.19.0.1:58033"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:25:21.463695724Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         806975654302069,
+				"StableID":   "ngQKDAtUJ711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d6a21d7bcee59fb449e03303128c802e2ba5a335cfd79057f5e2c64845a7526d",
+				"KeyExpiry":  "2026-11-09T07:25:22Z",
+				"DiscoKey":   "discokey:dda85a4eef1d21a17dd805463f31091324c200ff8721f6e46f4167e6907c0e56",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35947",
+					"10.65.0.27:35947",
+					"172.17.0.1:35947",
+					"172.18.0.1:35947",
+					"172.19.0.1:35947"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:25:22.000384279Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7473794549005958,
+				"StableID":   "nHaLVkutM121CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ee87ffe9a2aa91bf126d380bfaec4f05189545d0006b8cf309688a1314ab5d0c",
+				"KeyExpiry":  "2026-11-09T07:25:22Z",
+				"DiscoKey":   "discokey:24fa5573eaf4177afa174dcdc842530b963bed127b5b4553d91f82f0dd3d6737",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34262",
+					"10.65.0.27:34262",
+					"172.17.0.1:34262",
+					"172.18.0.1:34262",
+					"172.19.0.1:34262"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:25:22.58802508Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         370077202905546,
+				"StableID":   "nygk9SJct311CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b140448a88bf5cdfba90d390996b4473062df1de5b77c06361a24881a2aa6913",
+				"KeyExpiry":  "2026-11-09T07:25:23Z",
+				"DiscoKey":   "discokey:8ed0756ea013123480b4828d44588debaeba8c91a7f4dd5f4651a1fe0936085f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60293",
+					"10.65.0.27:60293",
+					"172.17.0.1:60293",
+					"172.18.0.1:60293",
+					"172.19.0.1:60293"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:25:23.068538493Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1514851276370035": {
+				"ID":          1514851276370035,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2311423039873039,
+				"StableID":   "nNrMwVAr3K11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       2311423039873039,
+				"Key":        "nodekey:1dbe3fc5be2c1683e3c18da29086be569f0b7a837c0758c309d2a01ac050e651",
+				"DiscoKey":   "discokey:107ef0da987d5f5f8f2b405ca6618d9a70e401b4ca5719a97c0bbc2d7968bd43",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33800",
+					"10.65.0.27:33800",
+					"172.17.0.1:33800",
+					"172.18.0.1:33800",
+					"172.19.0.1:33800"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:25:19.84790873Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1dbe3fc5be2c1683e3c18da29086be569f0b7a837c0758c309d2a01ac050e651",
+			"MachineKey": "mkey:42a32e58529a3f817905692e3609241682269cfaf81f474756591bba4ebc4a58",
+			"Peers": [{
+				"ID":         7033265457719453,
+				"StableID":   "n8ALDXxNvw11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97b092807554919b3f2ca63da1d2563dd1d68d156a01f8063c18b37618f0fe16",
+				"DiscoKey":   "discokey:02437bf4810f9b2eab4faa0a95ed7554a68e77c62349d9cb577d229e4b869621",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:59370",
+					"10.65.0.27:59370",
+					"172.17.0.1:59370",
+					"172.18.0.1:59370",
+					"172.19.0.1:59370"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:25:14.647702931Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5018459439570437,
+				"StableID":   "nS1YmLRsBg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6f2a4caf1ea3dee0e9f04d9fec96d45bce5ac52767bdd59123827a5e3986ae27",
+				"DiscoKey":   "discokey:d02c0ae33326d6116e1f0f8d9bc344b13569cd0aa5a72bd37484f36c98280c22",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40885",
+					"10.65.0.27:40885",
+					"172.17.0.1:40885",
+					"172.18.0.1:40885",
+					"172.19.0.1:40885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:25:15.77530771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7406573529314029,
+				"StableID":   "naKdAP8Tqz11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a605faa95c0411d7bedcbfd0c3c0fcc132f5bf8a3d6f320da9cfd380a1216c07",
+				"DiscoKey":   "discokey:d9951aa07acdc958f1b303ea70510e99b23700263a9f20e9ff0c6d7b94166a3d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41042",
+					"10.65.0.27:41042",
+					"172.17.0.1:41042",
+					"172.18.0.1:41042",
+					"172.19.0.1:41042"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:25:16.647581746Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1523904849378188,
+				"StableID":   "nFU1BzPBuC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2adea3024e9474888510edb35b7121f648361632bc0efeba54fa86bfafd157d",
+				"DiscoKey":   "discokey:534efb2e6bfe6e1080e1e1f72038c0b00b58fd547dcde98a4c79c82c420a7f4d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59208",
+					"10.65.0.27:59208",
+					"172.17.0.1:59208",
+					"172.18.0.1:59208",
+					"172.19.0.1:59208"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:25:17.134360684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4130257300345700,
+				"StableID":   "n3LLEdrbFZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1013a44fb7f2388126c37059f74f1ab7a3956195aeeece648f0416092cf6d708",
+				"DiscoKey":   "discokey:e9812a838e42c94122feae3b96f8a2a95f95f001dc4e1889dec2db4f12c8a724",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41255",
+					"10.65.0.27:41255",
+					"172.17.0.1:41255",
+					"172.18.0.1:41255",
+					"172.19.0.1:41255"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:25:17.684355567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6367116164312672,
+				"StableID":   "ndByG1Mgir11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85f2b69d0ac922b062ae322fcd44585bae5fbc348187427496c08f4975a83b5f",
+				"DiscoKey":   "discokey:bc0d2a06eda37620615039b35ef9ccc699cfda76f1d9c11a97b6df996e4a6b5e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52970",
+					"10.65.0.27:52970",
+					"172.17.0.1:52970",
+					"172.18.0.1:52970",
+					"172.19.0.1:52970"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:25:18.206091103Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1514851276370035,
+				"StableID":   "nntqvJa5qC11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fabbedda0abf5795ddd763fcef4e8448cf30015e003ccada73cfa860b88187c",
+				"DiscoKey":   "discokey:4cf55f4ca305b6de569fcb188a729d5ac61095716bddbcc7d69d0a818f2cb34c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58727",
+					"10.65.0.27:58727",
+					"172.17.0.1:58727",
+					"172.18.0.1:58727",
+					"172.19.0.1:58727"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:25:18.752272343Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1720558131027891,
+				"StableID":   "nrULGP9FSE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc62de889be17f18f4b6f68c52e07c5b243a51e9c9468f9a519bd9d873156624",
+				"DiscoKey":   "discokey:ea747d6033194936a3cd868de636ca6fa0302e838cb8fd9ffe5f011a8ba8e90e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:51743",
+					"10.65.0.27:51743",
+					"172.17.0.1:51743",
+					"172.18.0.1:51743",
+					"172.19.0.1:51743"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:25:19.302126246Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3963006022562156,
+				"StableID":   "n7JAYzSrwX11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d463e1a413e1737b02a711cbed86fb6ed582132332855894f0579985c492a707",
+				"DiscoKey":   "discokey:989dfd487fbbd1c82e919994c79403f05431c6fb5499e9c4abd09af253d66b35",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:45441",
+					"10.65.0.27:45441",
+					"172.17.0.1:45441",
+					"172.18.0.1:45441",
+					"172.19.0.1:45441"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:25:20.383940942Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6673170920100261,
+				"StableID":   "nQGX1JtH7u11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90da8fac19af990e5f72b8b2d766c12fb0aee0ab9c23d440d8e33b928c5e507b",
+				"DiscoKey":   "discokey:9d6e17c71f27026dba6d142f1d66e1cddfed9c9aeaed63e570695da0de989412",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43603",
+					"10.65.0.27:43603",
+					"172.17.0.1:43603",
+					"172.18.0.1:43603",
+					"172.19.0.1:43603"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:25:20.925023366Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5596237398539731,
+				"StableID":   "ntmfVgfYhk11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c323ef4ba56d8b62a3fc781c2aa970bf91a0d7ed890ebe5865328abb2555f22",
+				"DiscoKey":   "discokey:c8719e1f556a6923371ed2dfa4c008e075365a13b12ce5bae0220ebe4394f042",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58033",
+					"10.65.0.27:58033",
+					"172.17.0.1:58033",
+					"172.18.0.1:58033",
+					"172.19.0.1:58033"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:25:21.463695724Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         806975654302069,
+				"StableID":   "ngQKDAtUJ711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d6a21d7bcee59fb449e03303128c802e2ba5a335cfd79057f5e2c64845a7526d",
+				"KeyExpiry":  "2026-11-09T07:25:22Z",
+				"DiscoKey":   "discokey:dda85a4eef1d21a17dd805463f31091324c200ff8721f6e46f4167e6907c0e56",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35947",
+					"10.65.0.27:35947",
+					"172.17.0.1:35947",
+					"172.18.0.1:35947",
+					"172.19.0.1:35947"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:25:22.000384279Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7473794549005958,
+				"StableID":   "nHaLVkutM121CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ee87ffe9a2aa91bf126d380bfaec4f05189545d0006b8cf309688a1314ab5d0c",
+				"KeyExpiry":  "2026-11-09T07:25:22Z",
+				"DiscoKey":   "discokey:24fa5573eaf4177afa174dcdc842530b963bed127b5b4553d91f82f0dd3d6737",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34262",
+					"10.65.0.27:34262",
+					"172.17.0.1:34262",
+					"172.18.0.1:34262",
+					"172.19.0.1:34262"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:25:22.58802508Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         370077202905546,
+				"StableID":   "nygk9SJct311CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b140448a88bf5cdfba90d390996b4473062df1de5b77c06361a24881a2aa6913",
+				"KeyExpiry":  "2026-11-09T07:25:23Z",
+				"DiscoKey":   "discokey:8ed0756ea013123480b4828d44588debaeba8c91a7f4dd5f4651a1fe0936085f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60293",
+					"10.65.0.27:60293",
+					"172.17.0.1:60293",
+					"172.18.0.1:60293",
+					"172.19.0.1:60293"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:25:23.068538493Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2311423039873039": {
+				"ID":          2311423039873039,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7473794549005958,
+				"StableID":   "nHaLVkutM121CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ee87ffe9a2aa91bf126d380bfaec4f05189545d0006b8cf309688a1314ab5d0c",
+				"KeyExpiry":  "2026-11-09T07:25:22Z",
+				"DiscoKey":   "discokey:24fa5573eaf4177afa174dcdc842530b963bed127b5b4553d91f82f0dd3d6737",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34262",
+					"10.65.0.27:34262",
+					"172.17.0.1:34262",
+					"172.18.0.1:34262",
+					"172.19.0.1:34262"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:25:22.58802508Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ee87ffe9a2aa91bf126d380bfaec4f05189545d0006b8cf309688a1314ab5d0c",
+			"MachineKey": "mkey:2f13d553033510f458eed20fffe9096d43ba2b45722572fba572758b921df81a",
+			"Peers": [{
+				"ID":         7033265457719453,
+				"StableID":   "n8ALDXxNvw11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97b092807554919b3f2ca63da1d2563dd1d68d156a01f8063c18b37618f0fe16",
+				"DiscoKey":   "discokey:02437bf4810f9b2eab4faa0a95ed7554a68e77c62349d9cb577d229e4b869621",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:59370",
+					"10.65.0.27:59370",
+					"172.17.0.1:59370",
+					"172.18.0.1:59370",
+					"172.19.0.1:59370"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:25:14.647702931Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5018459439570437,
+				"StableID":   "nS1YmLRsBg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6f2a4caf1ea3dee0e9f04d9fec96d45bce5ac52767bdd59123827a5e3986ae27",
+				"DiscoKey":   "discokey:d02c0ae33326d6116e1f0f8d9bc344b13569cd0aa5a72bd37484f36c98280c22",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40885",
+					"10.65.0.27:40885",
+					"172.17.0.1:40885",
+					"172.18.0.1:40885",
+					"172.19.0.1:40885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:25:15.77530771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7406573529314029,
+				"StableID":   "naKdAP8Tqz11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a605faa95c0411d7bedcbfd0c3c0fcc132f5bf8a3d6f320da9cfd380a1216c07",
+				"DiscoKey":   "discokey:d9951aa07acdc958f1b303ea70510e99b23700263a9f20e9ff0c6d7b94166a3d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41042",
+					"10.65.0.27:41042",
+					"172.17.0.1:41042",
+					"172.18.0.1:41042",
+					"172.19.0.1:41042"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:25:16.647581746Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1523904849378188,
+				"StableID":   "nFU1BzPBuC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2adea3024e9474888510edb35b7121f648361632bc0efeba54fa86bfafd157d",
+				"DiscoKey":   "discokey:534efb2e6bfe6e1080e1e1f72038c0b00b58fd547dcde98a4c79c82c420a7f4d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59208",
+					"10.65.0.27:59208",
+					"172.17.0.1:59208",
+					"172.18.0.1:59208",
+					"172.19.0.1:59208"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:25:17.134360684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4130257300345700,
+				"StableID":   "n3LLEdrbFZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1013a44fb7f2388126c37059f74f1ab7a3956195aeeece648f0416092cf6d708",
+				"DiscoKey":   "discokey:e9812a838e42c94122feae3b96f8a2a95f95f001dc4e1889dec2db4f12c8a724",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41255",
+					"10.65.0.27:41255",
+					"172.17.0.1:41255",
+					"172.18.0.1:41255",
+					"172.19.0.1:41255"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:25:17.684355567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6367116164312672,
+				"StableID":   "ndByG1Mgir11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85f2b69d0ac922b062ae322fcd44585bae5fbc348187427496c08f4975a83b5f",
+				"DiscoKey":   "discokey:bc0d2a06eda37620615039b35ef9ccc699cfda76f1d9c11a97b6df996e4a6b5e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52970",
+					"10.65.0.27:52970",
+					"172.17.0.1:52970",
+					"172.18.0.1:52970",
+					"172.19.0.1:52970"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:25:18.206091103Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1514851276370035,
+				"StableID":   "nntqvJa5qC11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fabbedda0abf5795ddd763fcef4e8448cf30015e003ccada73cfa860b88187c",
+				"DiscoKey":   "discokey:4cf55f4ca305b6de569fcb188a729d5ac61095716bddbcc7d69d0a818f2cb34c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58727",
+					"10.65.0.27:58727",
+					"172.17.0.1:58727",
+					"172.18.0.1:58727",
+					"172.19.0.1:58727"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:25:18.752272343Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1720558131027891,
+				"StableID":   "nrULGP9FSE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc62de889be17f18f4b6f68c52e07c5b243a51e9c9468f9a519bd9d873156624",
+				"DiscoKey":   "discokey:ea747d6033194936a3cd868de636ca6fa0302e838cb8fd9ffe5f011a8ba8e90e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:51743",
+					"10.65.0.27:51743",
+					"172.17.0.1:51743",
+					"172.18.0.1:51743",
+					"172.19.0.1:51743"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:25:19.302126246Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2311423039873039,
+				"StableID":   "nNrMwVAr3K11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1dbe3fc5be2c1683e3c18da29086be569f0b7a837c0758c309d2a01ac050e651",
+				"DiscoKey":   "discokey:107ef0da987d5f5f8f2b405ca6618d9a70e401b4ca5719a97c0bbc2d7968bd43",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33800",
+					"10.65.0.27:33800",
+					"172.17.0.1:33800",
+					"172.18.0.1:33800",
+					"172.19.0.1:33800"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:25:19.84790873Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3963006022562156,
+				"StableID":   "n7JAYzSrwX11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d463e1a413e1737b02a711cbed86fb6ed582132332855894f0579985c492a707",
+				"DiscoKey":   "discokey:989dfd487fbbd1c82e919994c79403f05431c6fb5499e9c4abd09af253d66b35",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:45441",
+					"10.65.0.27:45441",
+					"172.17.0.1:45441",
+					"172.18.0.1:45441",
+					"172.19.0.1:45441"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:25:20.383940942Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6673170920100261,
+				"StableID":   "nQGX1JtH7u11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90da8fac19af990e5f72b8b2d766c12fb0aee0ab9c23d440d8e33b928c5e507b",
+				"DiscoKey":   "discokey:9d6e17c71f27026dba6d142f1d66e1cddfed9c9aeaed63e570695da0de989412",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43603",
+					"10.65.0.27:43603",
+					"172.17.0.1:43603",
+					"172.18.0.1:43603",
+					"172.19.0.1:43603"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:25:20.925023366Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5596237398539731,
+				"StableID":   "ntmfVgfYhk11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c323ef4ba56d8b62a3fc781c2aa970bf91a0d7ed890ebe5865328abb2555f22",
+				"DiscoKey":   "discokey:c8719e1f556a6923371ed2dfa4c008e075365a13b12ce5bae0220ebe4394f042",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58033",
+					"10.65.0.27:58033",
+					"172.17.0.1:58033",
+					"172.18.0.1:58033",
+					"172.19.0.1:58033"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:25:21.463695724Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         806975654302069,
+				"StableID":   "ngQKDAtUJ711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d6a21d7bcee59fb449e03303128c802e2ba5a335cfd79057f5e2c64845a7526d",
+				"KeyExpiry":  "2026-11-09T07:25:22Z",
+				"DiscoKey":   "discokey:dda85a4eef1d21a17dd805463f31091324c200ff8721f6e46f4167e6907c0e56",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35947",
+					"10.65.0.27:35947",
+					"172.17.0.1:35947",
+					"172.18.0.1:35947",
+					"172.19.0.1:35947"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:25:22.000384279Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         370077202905546,
+				"StableID":   "nygk9SJct311CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b140448a88bf5cdfba90d390996b4473062df1de5b77c06361a24881a2aa6913",
+				"KeyExpiry":  "2026-11-09T07:25:23Z",
+				"DiscoKey":   "discokey:8ed0756ea013123480b4828d44588debaeba8c91a7f4dd5f4651a1fe0936085f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60293",
+					"10.65.0.27:60293",
+					"172.17.0.1:60293",
+					"172.18.0.1:60293",
+					"172.19.0.1:60293"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:25:23.068538493Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3963006022562156,
+				"StableID":   "n7JAYzSrwX11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       3963006022562156,
+				"Key":        "nodekey:d463e1a413e1737b02a711cbed86fb6ed582132332855894f0579985c492a707",
+				"DiscoKey":   "discokey:989dfd487fbbd1c82e919994c79403f05431c6fb5499e9c4abd09af253d66b35",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:45441",
+					"10.65.0.27:45441",
+					"172.17.0.1:45441",
+					"172.18.0.1:45441",
+					"172.19.0.1:45441"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:25:20.383940942Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d463e1a413e1737b02a711cbed86fb6ed582132332855894f0579985c492a707",
+			"MachineKey": "mkey:d411197dcf04201170c5f96cc67985b19365fdfdbc76310992557e80b33ed04c",
+			"Peers": [{
+				"ID":         7033265457719453,
+				"StableID":   "n8ALDXxNvw11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97b092807554919b3f2ca63da1d2563dd1d68d156a01f8063c18b37618f0fe16",
+				"DiscoKey":   "discokey:02437bf4810f9b2eab4faa0a95ed7554a68e77c62349d9cb577d229e4b869621",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:59370",
+					"10.65.0.27:59370",
+					"172.17.0.1:59370",
+					"172.18.0.1:59370",
+					"172.19.0.1:59370"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:25:14.647702931Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5018459439570437,
+				"StableID":   "nS1YmLRsBg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6f2a4caf1ea3dee0e9f04d9fec96d45bce5ac52767bdd59123827a5e3986ae27",
+				"DiscoKey":   "discokey:d02c0ae33326d6116e1f0f8d9bc344b13569cd0aa5a72bd37484f36c98280c22",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40885",
+					"10.65.0.27:40885",
+					"172.17.0.1:40885",
+					"172.18.0.1:40885",
+					"172.19.0.1:40885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:25:15.77530771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7406573529314029,
+				"StableID":   "naKdAP8Tqz11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a605faa95c0411d7bedcbfd0c3c0fcc132f5bf8a3d6f320da9cfd380a1216c07",
+				"DiscoKey":   "discokey:d9951aa07acdc958f1b303ea70510e99b23700263a9f20e9ff0c6d7b94166a3d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41042",
+					"10.65.0.27:41042",
+					"172.17.0.1:41042",
+					"172.18.0.1:41042",
+					"172.19.0.1:41042"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:25:16.647581746Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1523904849378188,
+				"StableID":   "nFU1BzPBuC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2adea3024e9474888510edb35b7121f648361632bc0efeba54fa86bfafd157d",
+				"DiscoKey":   "discokey:534efb2e6bfe6e1080e1e1f72038c0b00b58fd547dcde98a4c79c82c420a7f4d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59208",
+					"10.65.0.27:59208",
+					"172.17.0.1:59208",
+					"172.18.0.1:59208",
+					"172.19.0.1:59208"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:25:17.134360684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4130257300345700,
+				"StableID":   "n3LLEdrbFZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1013a44fb7f2388126c37059f74f1ab7a3956195aeeece648f0416092cf6d708",
+				"DiscoKey":   "discokey:e9812a838e42c94122feae3b96f8a2a95f95f001dc4e1889dec2db4f12c8a724",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41255",
+					"10.65.0.27:41255",
+					"172.17.0.1:41255",
+					"172.18.0.1:41255",
+					"172.19.0.1:41255"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:25:17.684355567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6367116164312672,
+				"StableID":   "ndByG1Mgir11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85f2b69d0ac922b062ae322fcd44585bae5fbc348187427496c08f4975a83b5f",
+				"DiscoKey":   "discokey:bc0d2a06eda37620615039b35ef9ccc699cfda76f1d9c11a97b6df996e4a6b5e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52970",
+					"10.65.0.27:52970",
+					"172.17.0.1:52970",
+					"172.18.0.1:52970",
+					"172.19.0.1:52970"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:25:18.206091103Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1514851276370035,
+				"StableID":   "nntqvJa5qC11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fabbedda0abf5795ddd763fcef4e8448cf30015e003ccada73cfa860b88187c",
+				"DiscoKey":   "discokey:4cf55f4ca305b6de569fcb188a729d5ac61095716bddbcc7d69d0a818f2cb34c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58727",
+					"10.65.0.27:58727",
+					"172.17.0.1:58727",
+					"172.18.0.1:58727",
+					"172.19.0.1:58727"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:25:18.752272343Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1720558131027891,
+				"StableID":   "nrULGP9FSE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc62de889be17f18f4b6f68c52e07c5b243a51e9c9468f9a519bd9d873156624",
+				"DiscoKey":   "discokey:ea747d6033194936a3cd868de636ca6fa0302e838cb8fd9ffe5f011a8ba8e90e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:51743",
+					"10.65.0.27:51743",
+					"172.17.0.1:51743",
+					"172.18.0.1:51743",
+					"172.19.0.1:51743"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:25:19.302126246Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2311423039873039,
+				"StableID":   "nNrMwVAr3K11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1dbe3fc5be2c1683e3c18da29086be569f0b7a837c0758c309d2a01ac050e651",
+				"DiscoKey":   "discokey:107ef0da987d5f5f8f2b405ca6618d9a70e401b4ca5719a97c0bbc2d7968bd43",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33800",
+					"10.65.0.27:33800",
+					"172.17.0.1:33800",
+					"172.18.0.1:33800",
+					"172.19.0.1:33800"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:25:19.84790873Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6673170920100261,
+				"StableID":   "nQGX1JtH7u11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90da8fac19af990e5f72b8b2d766c12fb0aee0ab9c23d440d8e33b928c5e507b",
+				"DiscoKey":   "discokey:9d6e17c71f27026dba6d142f1d66e1cddfed9c9aeaed63e570695da0de989412",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43603",
+					"10.65.0.27:43603",
+					"172.17.0.1:43603",
+					"172.18.0.1:43603",
+					"172.19.0.1:43603"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:25:20.925023366Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5596237398539731,
+				"StableID":   "ntmfVgfYhk11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c323ef4ba56d8b62a3fc781c2aa970bf91a0d7ed890ebe5865328abb2555f22",
+				"DiscoKey":   "discokey:c8719e1f556a6923371ed2dfa4c008e075365a13b12ce5bae0220ebe4394f042",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:58033",
+					"10.65.0.27:58033",
+					"172.17.0.1:58033",
+					"172.18.0.1:58033",
+					"172.19.0.1:58033"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:25:21.463695724Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         806975654302069,
+				"StableID":   "ngQKDAtUJ711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d6a21d7bcee59fb449e03303128c802e2ba5a335cfd79057f5e2c64845a7526d",
+				"KeyExpiry":  "2026-11-09T07:25:22Z",
+				"DiscoKey":   "discokey:dda85a4eef1d21a17dd805463f31091324c200ff8721f6e46f4167e6907c0e56",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35947",
+					"10.65.0.27:35947",
+					"172.17.0.1:35947",
+					"172.18.0.1:35947",
+					"172.19.0.1:35947"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:25:22.000384279Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7473794549005958,
+				"StableID":   "nHaLVkutM121CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ee87ffe9a2aa91bf126d380bfaec4f05189545d0006b8cf309688a1314ab5d0c",
+				"KeyExpiry":  "2026-11-09T07:25:22Z",
+				"DiscoKey":   "discokey:24fa5573eaf4177afa174dcdc842530b963bed127b5b4553d91f82f0dd3d6737",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34262",
+					"10.65.0.27:34262",
+					"172.17.0.1:34262",
+					"172.18.0.1:34262",
+					"172.19.0.1:34262"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:25:22.58802508Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         370077202905546,
+				"StableID":   "nygk9SJct311CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b140448a88bf5cdfba90d390996b4473062df1de5b77c06361a24881a2aa6913",
+				"KeyExpiry":  "2026-11-09T07:25:23Z",
+				"DiscoKey":   "discokey:8ed0756ea013123480b4828d44588debaeba8c91a7f4dd5f4651a1fe0936085f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60293",
+					"10.65.0.27:60293",
+					"172.17.0.1:60293",
+					"172.18.0.1:60293",
+					"172.19.0.1:60293"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:25:23.068538493Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3963006022562156": {
+				"ID":          3963006022562156,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-action-deny.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-action-deny.hujson
@@ -1,0 +1,20081 @@
+// ssh-malformed-action-deny
+//
+// ssh action deny is rejected
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T21:50:49Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-malformed-action-deny",
+	"description":    "ssh action deny is rejected",
+	"category":       "ssh",
+	"captured_at":    "2026-05-12T21:50:49.103698398Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "\"deny\" is not a valid action"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                            \n  \n                                                               \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh action deny is rejected\",\n\t\"id\":          \"ssh-malformed-action-deny\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"deny\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"autogroup:member\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-malformed/ssh-malformed-action-deny.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "deny",
+				"dst":    ["tag:server"],
+				"src":    ["autogroup:member"],
+				"users":  ["root"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         269944687634845,
+				"StableID":   "nv9XfNzF7311CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       269944687634845,
+				"Key":        "nodekey:2faec7c09f5595929002d75a12bd06c3027fcbc0ce39c1bc679e0350ba88ee01",
+				"DiscoKey":   "discokey:7a8022a8b86b52a2c33fe7bf6f7581459875b637068e9ed900004d0d166efd51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36811",
+					"10.65.0.27:36811",
+					"172.17.0.1:36811",
+					"172.18.0.1:36811",
+					"172.19.0.1:36811"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:50:57.621416223Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2faec7c09f5595929002d75a12bd06c3027fcbc0ce39c1bc679e0350ba88ee01",
+			"MachineKey": "mkey:d3428c00dd8e1c558f8eaa7d64a6bca43e89c556a9c380856b850b56ba91a92c",
+			"Peers": [{
+				"ID":         968680837477776,
+				"StableID":   "nqZwWybiZ811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ffd5c87946d681fb584ee51bd06ed4e51d2a8cd2c832436dfd6b5783e9e8b37",
+				"DiscoKey":   "discokey:1205ba137a2de6c7ef967d4f4c022ff6a20f2e1f959975d7bb35921541419330",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:57835",
+					"10.65.0.27:57835",
+					"172.17.0.1:57835",
+					"172.18.0.1:57835",
+					"172.19.0.1:57835"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:50:51.68571398Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5260154043304652,
+				"StableID":   "nXepFyKL5i11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28db6e7978c9f2f885a63d2f6ffa4fb3cd128070c868ced5a1d29c5c2c179543",
+				"DiscoKey":   "discokey:25a9e9c373600720a7e16efff1e5e8993ed4fafd022be72d1cc314ad4a6d4847",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50616",
+					"10.65.0.27:50616",
+					"172.17.0.1:50616",
+					"172.18.0.1:50616",
+					"172.19.0.1:50616"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:50:52.230388804Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         26853145814640,
+				"StableID":   "nD9QYRPAD111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9880579da6e1819130736f9ab4301432c181a7dcf0d95a9f408dd2fe44e32b1d",
+				"DiscoKey":   "discokey:df13acdcdebdd05c81fea462946c607b0d19f96966ef61fe30be99d6c1fc4743",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53241",
+					"10.65.0.27:53241",
+					"172.17.0.1:53241",
+					"172.18.0.1:53241",
+					"172.19.0.1:53241"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:50:52.770679863Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8155594954834163,
+				"StableID":   "nQssdhegg621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0e179857c0adcb3cfbe558fc76bcfdf4d5c819bf9215fbd02fe8a79e96fde02",
+				"DiscoKey":   "discokey:9918256c5e1c313a1de71ff68cac3b87a36c890baaa8fdf9748f73da7cf58433",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51886",
+					"10.65.0.27:51886",
+					"172.17.0.1:51886",
+					"172.18.0.1:51886",
+					"172.19.0.1:51886"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:50:53.307812557Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3719056762313891,
+				"StableID":   "nk5umFKN3W11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f317cd9b223c1f14fd9dd1c491f54298332c43aa6a222a8230e3539896c98503",
+				"DiscoKey":   "discokey:f50499f376496e23c219e8ecb1fdb75c25ef029ac807d3129382375db874751d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33406",
+					"10.65.0.27:33406",
+					"172.17.0.1:33406",
+					"172.18.0.1:33406",
+					"172.19.0.1:33406"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:50:53.858003446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7237902144095889,
+				"StableID":   "nLneS8R4Xy11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b19e27a86bcc1b60c4edfa744fce1772da8144d1fc1047447e205d39de554f7a",
+				"DiscoKey":   "discokey:cc91bdff6247e1b6f592aa4301f48cbef433c6684057ad8a6f6bd272496b5b41",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53839",
+					"10.65.0.27:53839",
+					"172.17.0.1:53839",
+					"172.18.0.1:53839",
+					"172.19.0.1:53839"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:50:54.388481816Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6837257259921048,
+				"StableID":   "njkMyw9cPv11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4c4221032a4c26cf6cd69d668102971b3023991d0e512f804289394a0448f2d",
+				"DiscoKey":   "discokey:4c761ac683acfdd6981c51ed632ffc59e11748648f87af6d215a5be409db930a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48344",
+					"10.65.0.27:48344",
+					"172.17.0.1:48344",
+					"172.18.0.1:48344",
+					"172.19.0.1:48344"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:50:54.92809966Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3401762228091282,
+				"StableID":   "nZGvJUXfZT11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b82b5c77b3c67b82ec5fc454c17cd26bc1a6d288defbd0047fc6ce77ffbfdf73",
+				"DiscoKey":   "discokey:0dbe56a371694b7b2e2f5ccd20b072fc256a434fffdef9ed9e1fb27d6670527c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52046",
+					"10.65.0.27:52046",
+					"172.17.0.1:52046",
+					"172.18.0.1:52046",
+					"172.19.0.1:52046"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:50:55.473629781Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8097669955681323,
+				"StableID":   "ntPJpP4TE621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ace813b8ee5954947c37f526af381f31aed93892714f8f506a20ac165d586b48",
+				"DiscoKey":   "discokey:5ae62e13077fa6798bab0e3836e4973dcd0b03aa512e4ce5c0fd2981f78c9113",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48858",
+					"10.65.0.27:48858",
+					"172.17.0.1:48858",
+					"172.18.0.1:48858",
+					"172.19.0.1:48858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:50:56.003451711Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5921762583239446,
+				"StableID":   "njsjMNfyEo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c17d80d9c65794f3dc0765708f597a4eaf7daa8c4153f5b68c6c4c44d6e3547",
+				"DiscoKey":   "discokey:acde5212a7e81340cc1a031cddb7b9e693fc05cd0253876b80b58bf22e461249",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56300",
+					"10.65.0.27:56300",
+					"172.17.0.1:56300",
+					"172.18.0.1:56300",
+					"172.19.0.1:56300"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:50:56.537801395Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4912179265883428,
+				"StableID":   "nPWzkwcjMf11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9897edf24079fbcb7278ff680f06da5abe2547bada4f7a9333819f766375b00a",
+				"DiscoKey":   "discokey:d88f87bb9575f8e7d3d69da254b510a1c9d4b9b51c64b768f6f0e66736617945",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36850",
+					"10.65.0.27:36850",
+					"172.17.0.1:36850",
+					"172.18.0.1:36850",
+					"172.19.0.1:36850"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:50:57.089625315Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7540982333003941,
+				"StableID":   "n2wRtUpKt121CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8eb2c055e9eca6aa3351f7678bd6abf05a90f098630b3b2f3ab03390fba8fc07",
+				"KeyExpiry":  "2026-11-08T21:50:58Z",
+				"DiscoKey":   "discokey:67b23576ebaab173e36d282ea01095f0ccc7c3c023e7bc50f2b17d4acaa26a67",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34276",
+					"10.65.0.27:34276",
+					"172.17.0.1:34276",
+					"172.18.0.1:34276",
+					"172.19.0.1:34276"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:50:58.184084138Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4803304395061543,
+				"StableID":   "nUhQFNfRWe11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8006cacc76d819a8dd1736b54d7f4f8d642f176bd069242f250d1695b9fd346d",
+				"KeyExpiry":  "2026-11-08T21:50:58Z",
+				"DiscoKey":   "discokey:a713fab733bfe980c034fe8d28c0396a52a8e141c0c4f21aa1b047d53714e432",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35344",
+					"10.65.0.27:35344",
+					"172.17.0.1:35344",
+					"172.18.0.1:35344",
+					"172.19.0.1:35344"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:50:58.702458496Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4382350036694651,
+				"StableID":   "n4qD6TumDb11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b9a0f3e20759548f3c672ba2e63c8eb3cbbfc23a818cb68ff2d5a82fbdb77805",
+				"KeyExpiry":  "2026-11-08T21:50:59Z",
+				"DiscoKey":   "discokey:4ac4396dd0e2f5d0c4cec4115cbe35ce77ce101aad6b81652770c5813b4f811e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:32851",
+					"10.65.0.27:32851",
+					"172.17.0.1:32851",
+					"172.18.0.1:32851",
+					"172.19.0.1:32851"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:50:59.238113861Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "269944687634845": {
+				"ID":          269944687634845,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7237902144095889,
+				"StableID":   "nLneS8R4Xy11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       7237902144095889,
+				"Key":        "nodekey:b19e27a86bcc1b60c4edfa744fce1772da8144d1fc1047447e205d39de554f7a",
+				"DiscoKey":   "discokey:cc91bdff6247e1b6f592aa4301f48cbef433c6684057ad8a6f6bd272496b5b41",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53839",
+					"10.65.0.27:53839",
+					"172.17.0.1:53839",
+					"172.18.0.1:53839",
+					"172.19.0.1:53839"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:50:54.388481816Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b19e27a86bcc1b60c4edfa744fce1772da8144d1fc1047447e205d39de554f7a",
+			"MachineKey": "mkey:5a0fea227e70e4b833dbb8ae4088776e1b82960f248c6bc2a2ab6e6e80b9dd5a",
+			"Peers": [{
+				"ID":         968680837477776,
+				"StableID":   "nqZwWybiZ811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ffd5c87946d681fb584ee51bd06ed4e51d2a8cd2c832436dfd6b5783e9e8b37",
+				"DiscoKey":   "discokey:1205ba137a2de6c7ef967d4f4c022ff6a20f2e1f959975d7bb35921541419330",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:57835",
+					"10.65.0.27:57835",
+					"172.17.0.1:57835",
+					"172.18.0.1:57835",
+					"172.19.0.1:57835"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:50:51.68571398Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5260154043304652,
+				"StableID":   "nXepFyKL5i11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28db6e7978c9f2f885a63d2f6ffa4fb3cd128070c868ced5a1d29c5c2c179543",
+				"DiscoKey":   "discokey:25a9e9c373600720a7e16efff1e5e8993ed4fafd022be72d1cc314ad4a6d4847",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50616",
+					"10.65.0.27:50616",
+					"172.17.0.1:50616",
+					"172.18.0.1:50616",
+					"172.19.0.1:50616"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:50:52.230388804Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         26853145814640,
+				"StableID":   "nD9QYRPAD111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9880579da6e1819130736f9ab4301432c181a7dcf0d95a9f408dd2fe44e32b1d",
+				"DiscoKey":   "discokey:df13acdcdebdd05c81fea462946c607b0d19f96966ef61fe30be99d6c1fc4743",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53241",
+					"10.65.0.27:53241",
+					"172.17.0.1:53241",
+					"172.18.0.1:53241",
+					"172.19.0.1:53241"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:50:52.770679863Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8155594954834163,
+				"StableID":   "nQssdhegg621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0e179857c0adcb3cfbe558fc76bcfdf4d5c819bf9215fbd02fe8a79e96fde02",
+				"DiscoKey":   "discokey:9918256c5e1c313a1de71ff68cac3b87a36c890baaa8fdf9748f73da7cf58433",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51886",
+					"10.65.0.27:51886",
+					"172.17.0.1:51886",
+					"172.18.0.1:51886",
+					"172.19.0.1:51886"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:50:53.307812557Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3719056762313891,
+				"StableID":   "nk5umFKN3W11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f317cd9b223c1f14fd9dd1c491f54298332c43aa6a222a8230e3539896c98503",
+				"DiscoKey":   "discokey:f50499f376496e23c219e8ecb1fdb75c25ef029ac807d3129382375db874751d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33406",
+					"10.65.0.27:33406",
+					"172.17.0.1:33406",
+					"172.18.0.1:33406",
+					"172.19.0.1:33406"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:50:53.858003446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6837257259921048,
+				"StableID":   "njkMyw9cPv11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4c4221032a4c26cf6cd69d668102971b3023991d0e512f804289394a0448f2d",
+				"DiscoKey":   "discokey:4c761ac683acfdd6981c51ed632ffc59e11748648f87af6d215a5be409db930a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48344",
+					"10.65.0.27:48344",
+					"172.17.0.1:48344",
+					"172.18.0.1:48344",
+					"172.19.0.1:48344"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:50:54.92809966Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3401762228091282,
+				"StableID":   "nZGvJUXfZT11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b82b5c77b3c67b82ec5fc454c17cd26bc1a6d288defbd0047fc6ce77ffbfdf73",
+				"DiscoKey":   "discokey:0dbe56a371694b7b2e2f5ccd20b072fc256a434fffdef9ed9e1fb27d6670527c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52046",
+					"10.65.0.27:52046",
+					"172.17.0.1:52046",
+					"172.18.0.1:52046",
+					"172.19.0.1:52046"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:50:55.473629781Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8097669955681323,
+				"StableID":   "ntPJpP4TE621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ace813b8ee5954947c37f526af381f31aed93892714f8f506a20ac165d586b48",
+				"DiscoKey":   "discokey:5ae62e13077fa6798bab0e3836e4973dcd0b03aa512e4ce5c0fd2981f78c9113",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48858",
+					"10.65.0.27:48858",
+					"172.17.0.1:48858",
+					"172.18.0.1:48858",
+					"172.19.0.1:48858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:50:56.003451711Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5921762583239446,
+				"StableID":   "njsjMNfyEo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c17d80d9c65794f3dc0765708f597a4eaf7daa8c4153f5b68c6c4c44d6e3547",
+				"DiscoKey":   "discokey:acde5212a7e81340cc1a031cddb7b9e693fc05cd0253876b80b58bf22e461249",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56300",
+					"10.65.0.27:56300",
+					"172.17.0.1:56300",
+					"172.18.0.1:56300",
+					"172.19.0.1:56300"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:50:56.537801395Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4912179265883428,
+				"StableID":   "nPWzkwcjMf11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9897edf24079fbcb7278ff680f06da5abe2547bada4f7a9333819f766375b00a",
+				"DiscoKey":   "discokey:d88f87bb9575f8e7d3d69da254b510a1c9d4b9b51c64b768f6f0e66736617945",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36850",
+					"10.65.0.27:36850",
+					"172.17.0.1:36850",
+					"172.18.0.1:36850",
+					"172.19.0.1:36850"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:50:57.089625315Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         269944687634845,
+				"StableID":   "nv9XfNzF7311CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2faec7c09f5595929002d75a12bd06c3027fcbc0ce39c1bc679e0350ba88ee01",
+				"DiscoKey":   "discokey:7a8022a8b86b52a2c33fe7bf6f7581459875b637068e9ed900004d0d166efd51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36811",
+					"10.65.0.27:36811",
+					"172.17.0.1:36811",
+					"172.18.0.1:36811",
+					"172.19.0.1:36811"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:50:57.621416223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7540982333003941,
+				"StableID":   "n2wRtUpKt121CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8eb2c055e9eca6aa3351f7678bd6abf05a90f098630b3b2f3ab03390fba8fc07",
+				"KeyExpiry":  "2026-11-08T21:50:58Z",
+				"DiscoKey":   "discokey:67b23576ebaab173e36d282ea01095f0ccc7c3c023e7bc50f2b17d4acaa26a67",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34276",
+					"10.65.0.27:34276",
+					"172.17.0.1:34276",
+					"172.18.0.1:34276",
+					"172.19.0.1:34276"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:50:58.184084138Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4803304395061543,
+				"StableID":   "nUhQFNfRWe11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8006cacc76d819a8dd1736b54d7f4f8d642f176bd069242f250d1695b9fd346d",
+				"KeyExpiry":  "2026-11-08T21:50:58Z",
+				"DiscoKey":   "discokey:a713fab733bfe980c034fe8d28c0396a52a8e141c0c4f21aa1b047d53714e432",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35344",
+					"10.65.0.27:35344",
+					"172.17.0.1:35344",
+					"172.18.0.1:35344",
+					"172.19.0.1:35344"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:50:58.702458496Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4382350036694651,
+				"StableID":   "n4qD6TumDb11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b9a0f3e20759548f3c672ba2e63c8eb3cbbfc23a818cb68ff2d5a82fbdb77805",
+				"KeyExpiry":  "2026-11-08T21:50:59Z",
+				"DiscoKey":   "discokey:4ac4396dd0e2f5d0c4cec4115cbe35ce77ce101aad6b81652770c5813b4f811e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:32851",
+					"10.65.0.27:32851",
+					"172.17.0.1:32851",
+					"172.18.0.1:32851",
+					"172.19.0.1:32851"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:50:59.238113861Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7237902144095889": {
+				"ID":          7237902144095889,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4382350036694651,
+				"StableID":   "n4qD6TumDb11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b9a0f3e20759548f3c672ba2e63c8eb3cbbfc23a818cb68ff2d5a82fbdb77805",
+				"KeyExpiry":  "2026-11-08T21:50:59Z",
+				"DiscoKey":   "discokey:4ac4396dd0e2f5d0c4cec4115cbe35ce77ce101aad6b81652770c5813b4f811e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:32851",
+					"10.65.0.27:32851",
+					"172.17.0.1:32851",
+					"172.18.0.1:32851",
+					"172.19.0.1:32851"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:50:59.238113861Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b9a0f3e20759548f3c672ba2e63c8eb3cbbfc23a818cb68ff2d5a82fbdb77805",
+			"MachineKey": "mkey:64bb0c8bfdbe2d109fb8d2092f05487870fdd571622fd794a89f5fd28e85e80b",
+			"Peers": [{
+				"ID":         968680837477776,
+				"StableID":   "nqZwWybiZ811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ffd5c87946d681fb584ee51bd06ed4e51d2a8cd2c832436dfd6b5783e9e8b37",
+				"DiscoKey":   "discokey:1205ba137a2de6c7ef967d4f4c022ff6a20f2e1f959975d7bb35921541419330",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:57835",
+					"10.65.0.27:57835",
+					"172.17.0.1:57835",
+					"172.18.0.1:57835",
+					"172.19.0.1:57835"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:50:51.68571398Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5260154043304652,
+				"StableID":   "nXepFyKL5i11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28db6e7978c9f2f885a63d2f6ffa4fb3cd128070c868ced5a1d29c5c2c179543",
+				"DiscoKey":   "discokey:25a9e9c373600720a7e16efff1e5e8993ed4fafd022be72d1cc314ad4a6d4847",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50616",
+					"10.65.0.27:50616",
+					"172.17.0.1:50616",
+					"172.18.0.1:50616",
+					"172.19.0.1:50616"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:50:52.230388804Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         26853145814640,
+				"StableID":   "nD9QYRPAD111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9880579da6e1819130736f9ab4301432c181a7dcf0d95a9f408dd2fe44e32b1d",
+				"DiscoKey":   "discokey:df13acdcdebdd05c81fea462946c607b0d19f96966ef61fe30be99d6c1fc4743",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53241",
+					"10.65.0.27:53241",
+					"172.17.0.1:53241",
+					"172.18.0.1:53241",
+					"172.19.0.1:53241"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:50:52.770679863Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8155594954834163,
+				"StableID":   "nQssdhegg621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0e179857c0adcb3cfbe558fc76bcfdf4d5c819bf9215fbd02fe8a79e96fde02",
+				"DiscoKey":   "discokey:9918256c5e1c313a1de71ff68cac3b87a36c890baaa8fdf9748f73da7cf58433",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51886",
+					"10.65.0.27:51886",
+					"172.17.0.1:51886",
+					"172.18.0.1:51886",
+					"172.19.0.1:51886"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:50:53.307812557Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3719056762313891,
+				"StableID":   "nk5umFKN3W11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f317cd9b223c1f14fd9dd1c491f54298332c43aa6a222a8230e3539896c98503",
+				"DiscoKey":   "discokey:f50499f376496e23c219e8ecb1fdb75c25ef029ac807d3129382375db874751d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33406",
+					"10.65.0.27:33406",
+					"172.17.0.1:33406",
+					"172.18.0.1:33406",
+					"172.19.0.1:33406"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:50:53.858003446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7237902144095889,
+				"StableID":   "nLneS8R4Xy11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b19e27a86bcc1b60c4edfa744fce1772da8144d1fc1047447e205d39de554f7a",
+				"DiscoKey":   "discokey:cc91bdff6247e1b6f592aa4301f48cbef433c6684057ad8a6f6bd272496b5b41",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53839",
+					"10.65.0.27:53839",
+					"172.17.0.1:53839",
+					"172.18.0.1:53839",
+					"172.19.0.1:53839"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:50:54.388481816Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6837257259921048,
+				"StableID":   "njkMyw9cPv11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4c4221032a4c26cf6cd69d668102971b3023991d0e512f804289394a0448f2d",
+				"DiscoKey":   "discokey:4c761ac683acfdd6981c51ed632ffc59e11748648f87af6d215a5be409db930a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48344",
+					"10.65.0.27:48344",
+					"172.17.0.1:48344",
+					"172.18.0.1:48344",
+					"172.19.0.1:48344"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:50:54.92809966Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3401762228091282,
+				"StableID":   "nZGvJUXfZT11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b82b5c77b3c67b82ec5fc454c17cd26bc1a6d288defbd0047fc6ce77ffbfdf73",
+				"DiscoKey":   "discokey:0dbe56a371694b7b2e2f5ccd20b072fc256a434fffdef9ed9e1fb27d6670527c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52046",
+					"10.65.0.27:52046",
+					"172.17.0.1:52046",
+					"172.18.0.1:52046",
+					"172.19.0.1:52046"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:50:55.473629781Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8097669955681323,
+				"StableID":   "ntPJpP4TE621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ace813b8ee5954947c37f526af381f31aed93892714f8f506a20ac165d586b48",
+				"DiscoKey":   "discokey:5ae62e13077fa6798bab0e3836e4973dcd0b03aa512e4ce5c0fd2981f78c9113",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48858",
+					"10.65.0.27:48858",
+					"172.17.0.1:48858",
+					"172.18.0.1:48858",
+					"172.19.0.1:48858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:50:56.003451711Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5921762583239446,
+				"StableID":   "njsjMNfyEo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c17d80d9c65794f3dc0765708f597a4eaf7daa8c4153f5b68c6c4c44d6e3547",
+				"DiscoKey":   "discokey:acde5212a7e81340cc1a031cddb7b9e693fc05cd0253876b80b58bf22e461249",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56300",
+					"10.65.0.27:56300",
+					"172.17.0.1:56300",
+					"172.18.0.1:56300",
+					"172.19.0.1:56300"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:50:56.537801395Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4912179265883428,
+				"StableID":   "nPWzkwcjMf11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9897edf24079fbcb7278ff680f06da5abe2547bada4f7a9333819f766375b00a",
+				"DiscoKey":   "discokey:d88f87bb9575f8e7d3d69da254b510a1c9d4b9b51c64b768f6f0e66736617945",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36850",
+					"10.65.0.27:36850",
+					"172.17.0.1:36850",
+					"172.18.0.1:36850",
+					"172.19.0.1:36850"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:50:57.089625315Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         269944687634845,
+				"StableID":   "nv9XfNzF7311CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2faec7c09f5595929002d75a12bd06c3027fcbc0ce39c1bc679e0350ba88ee01",
+				"DiscoKey":   "discokey:7a8022a8b86b52a2c33fe7bf6f7581459875b637068e9ed900004d0d166efd51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36811",
+					"10.65.0.27:36811",
+					"172.17.0.1:36811",
+					"172.18.0.1:36811",
+					"172.19.0.1:36811"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:50:57.621416223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7540982333003941,
+				"StableID":   "n2wRtUpKt121CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8eb2c055e9eca6aa3351f7678bd6abf05a90f098630b3b2f3ab03390fba8fc07",
+				"KeyExpiry":  "2026-11-08T21:50:58Z",
+				"DiscoKey":   "discokey:67b23576ebaab173e36d282ea01095f0ccc7c3c023e7bc50f2b17d4acaa26a67",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34276",
+					"10.65.0.27:34276",
+					"172.17.0.1:34276",
+					"172.18.0.1:34276",
+					"172.19.0.1:34276"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:50:58.184084138Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4803304395061543,
+				"StableID":   "nUhQFNfRWe11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8006cacc76d819a8dd1736b54d7f4f8d642f176bd069242f250d1695b9fd346d",
+				"KeyExpiry":  "2026-11-08T21:50:58Z",
+				"DiscoKey":   "discokey:a713fab733bfe980c034fe8d28c0396a52a8e141c0c4f21aa1b047d53714e432",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35344",
+					"10.65.0.27:35344",
+					"172.17.0.1:35344",
+					"172.18.0.1:35344",
+					"172.19.0.1:35344"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:50:58.702458496Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         26853145814640,
+				"StableID":   "nD9QYRPAD111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       26853145814640,
+				"Key":        "nodekey:9880579da6e1819130736f9ab4301432c181a7dcf0d95a9f408dd2fe44e32b1d",
+				"DiscoKey":   "discokey:df13acdcdebdd05c81fea462946c607b0d19f96966ef61fe30be99d6c1fc4743",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53241",
+					"10.65.0.27:53241",
+					"172.17.0.1:53241",
+					"172.18.0.1:53241",
+					"172.19.0.1:53241"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:50:52.770679863Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9880579da6e1819130736f9ab4301432c181a7dcf0d95a9f408dd2fe44e32b1d",
+			"MachineKey": "mkey:995bbb92c1b0ca759a9e917769a2ab8fc03317a9245a31ebf7563f6683e1fc38",
+			"Peers": [{
+				"ID":         968680837477776,
+				"StableID":   "nqZwWybiZ811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ffd5c87946d681fb584ee51bd06ed4e51d2a8cd2c832436dfd6b5783e9e8b37",
+				"DiscoKey":   "discokey:1205ba137a2de6c7ef967d4f4c022ff6a20f2e1f959975d7bb35921541419330",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:57835",
+					"10.65.0.27:57835",
+					"172.17.0.1:57835",
+					"172.18.0.1:57835",
+					"172.19.0.1:57835"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:50:51.68571398Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5260154043304652,
+				"StableID":   "nXepFyKL5i11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28db6e7978c9f2f885a63d2f6ffa4fb3cd128070c868ced5a1d29c5c2c179543",
+				"DiscoKey":   "discokey:25a9e9c373600720a7e16efff1e5e8993ed4fafd022be72d1cc314ad4a6d4847",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50616",
+					"10.65.0.27:50616",
+					"172.17.0.1:50616",
+					"172.18.0.1:50616",
+					"172.19.0.1:50616"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:50:52.230388804Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8155594954834163,
+				"StableID":   "nQssdhegg621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0e179857c0adcb3cfbe558fc76bcfdf4d5c819bf9215fbd02fe8a79e96fde02",
+				"DiscoKey":   "discokey:9918256c5e1c313a1de71ff68cac3b87a36c890baaa8fdf9748f73da7cf58433",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51886",
+					"10.65.0.27:51886",
+					"172.17.0.1:51886",
+					"172.18.0.1:51886",
+					"172.19.0.1:51886"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:50:53.307812557Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3719056762313891,
+				"StableID":   "nk5umFKN3W11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f317cd9b223c1f14fd9dd1c491f54298332c43aa6a222a8230e3539896c98503",
+				"DiscoKey":   "discokey:f50499f376496e23c219e8ecb1fdb75c25ef029ac807d3129382375db874751d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33406",
+					"10.65.0.27:33406",
+					"172.17.0.1:33406",
+					"172.18.0.1:33406",
+					"172.19.0.1:33406"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:50:53.858003446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7237902144095889,
+				"StableID":   "nLneS8R4Xy11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b19e27a86bcc1b60c4edfa744fce1772da8144d1fc1047447e205d39de554f7a",
+				"DiscoKey":   "discokey:cc91bdff6247e1b6f592aa4301f48cbef433c6684057ad8a6f6bd272496b5b41",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53839",
+					"10.65.0.27:53839",
+					"172.17.0.1:53839",
+					"172.18.0.1:53839",
+					"172.19.0.1:53839"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:50:54.388481816Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6837257259921048,
+				"StableID":   "njkMyw9cPv11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4c4221032a4c26cf6cd69d668102971b3023991d0e512f804289394a0448f2d",
+				"DiscoKey":   "discokey:4c761ac683acfdd6981c51ed632ffc59e11748648f87af6d215a5be409db930a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48344",
+					"10.65.0.27:48344",
+					"172.17.0.1:48344",
+					"172.18.0.1:48344",
+					"172.19.0.1:48344"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:50:54.92809966Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3401762228091282,
+				"StableID":   "nZGvJUXfZT11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b82b5c77b3c67b82ec5fc454c17cd26bc1a6d288defbd0047fc6ce77ffbfdf73",
+				"DiscoKey":   "discokey:0dbe56a371694b7b2e2f5ccd20b072fc256a434fffdef9ed9e1fb27d6670527c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52046",
+					"10.65.0.27:52046",
+					"172.17.0.1:52046",
+					"172.18.0.1:52046",
+					"172.19.0.1:52046"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:50:55.473629781Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8097669955681323,
+				"StableID":   "ntPJpP4TE621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ace813b8ee5954947c37f526af381f31aed93892714f8f506a20ac165d586b48",
+				"DiscoKey":   "discokey:5ae62e13077fa6798bab0e3836e4973dcd0b03aa512e4ce5c0fd2981f78c9113",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48858",
+					"10.65.0.27:48858",
+					"172.17.0.1:48858",
+					"172.18.0.1:48858",
+					"172.19.0.1:48858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:50:56.003451711Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5921762583239446,
+				"StableID":   "njsjMNfyEo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c17d80d9c65794f3dc0765708f597a4eaf7daa8c4153f5b68c6c4c44d6e3547",
+				"DiscoKey":   "discokey:acde5212a7e81340cc1a031cddb7b9e693fc05cd0253876b80b58bf22e461249",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56300",
+					"10.65.0.27:56300",
+					"172.17.0.1:56300",
+					"172.18.0.1:56300",
+					"172.19.0.1:56300"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:50:56.537801395Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4912179265883428,
+				"StableID":   "nPWzkwcjMf11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9897edf24079fbcb7278ff680f06da5abe2547bada4f7a9333819f766375b00a",
+				"DiscoKey":   "discokey:d88f87bb9575f8e7d3d69da254b510a1c9d4b9b51c64b768f6f0e66736617945",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36850",
+					"10.65.0.27:36850",
+					"172.17.0.1:36850",
+					"172.18.0.1:36850",
+					"172.19.0.1:36850"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:50:57.089625315Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         269944687634845,
+				"StableID":   "nv9XfNzF7311CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2faec7c09f5595929002d75a12bd06c3027fcbc0ce39c1bc679e0350ba88ee01",
+				"DiscoKey":   "discokey:7a8022a8b86b52a2c33fe7bf6f7581459875b637068e9ed900004d0d166efd51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36811",
+					"10.65.0.27:36811",
+					"172.17.0.1:36811",
+					"172.18.0.1:36811",
+					"172.19.0.1:36811"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:50:57.621416223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7540982333003941,
+				"StableID":   "n2wRtUpKt121CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8eb2c055e9eca6aa3351f7678bd6abf05a90f098630b3b2f3ab03390fba8fc07",
+				"KeyExpiry":  "2026-11-08T21:50:58Z",
+				"DiscoKey":   "discokey:67b23576ebaab173e36d282ea01095f0ccc7c3c023e7bc50f2b17d4acaa26a67",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34276",
+					"10.65.0.27:34276",
+					"172.17.0.1:34276",
+					"172.18.0.1:34276",
+					"172.19.0.1:34276"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:50:58.184084138Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4803304395061543,
+				"StableID":   "nUhQFNfRWe11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8006cacc76d819a8dd1736b54d7f4f8d642f176bd069242f250d1695b9fd346d",
+				"KeyExpiry":  "2026-11-08T21:50:58Z",
+				"DiscoKey":   "discokey:a713fab733bfe980c034fe8d28c0396a52a8e141c0c4f21aa1b047d53714e432",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35344",
+					"10.65.0.27:35344",
+					"172.17.0.1:35344",
+					"172.18.0.1:35344",
+					"172.19.0.1:35344"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:50:58.702458496Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4382350036694651,
+				"StableID":   "n4qD6TumDb11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b9a0f3e20759548f3c672ba2e63c8eb3cbbfc23a818cb68ff2d5a82fbdb77805",
+				"KeyExpiry":  "2026-11-08T21:50:59Z",
+				"DiscoKey":   "discokey:4ac4396dd0e2f5d0c4cec4115cbe35ce77ce101aad6b81652770c5813b4f811e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:32851",
+					"10.65.0.27:32851",
+					"172.17.0.1:32851",
+					"172.18.0.1:32851",
+					"172.19.0.1:32851"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:50:59.238113861Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "26853145814640": {
+				"ID":          26853145814640,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3401762228091282,
+				"StableID":   "nZGvJUXfZT11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       3401762228091282,
+				"Key":        "nodekey:b82b5c77b3c67b82ec5fc454c17cd26bc1a6d288defbd0047fc6ce77ffbfdf73",
+				"DiscoKey":   "discokey:0dbe56a371694b7b2e2f5ccd20b072fc256a434fffdef9ed9e1fb27d6670527c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52046",
+					"10.65.0.27:52046",
+					"172.17.0.1:52046",
+					"172.18.0.1:52046",
+					"172.19.0.1:52046"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:50:55.473629781Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b82b5c77b3c67b82ec5fc454c17cd26bc1a6d288defbd0047fc6ce77ffbfdf73",
+			"MachineKey": "mkey:3cf81d51432f339bc91cc352ee8f864439da412db258d4cd6d699f06f405ba26",
+			"Peers": [{
+				"ID":         968680837477776,
+				"StableID":   "nqZwWybiZ811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ffd5c87946d681fb584ee51bd06ed4e51d2a8cd2c832436dfd6b5783e9e8b37",
+				"DiscoKey":   "discokey:1205ba137a2de6c7ef967d4f4c022ff6a20f2e1f959975d7bb35921541419330",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:57835",
+					"10.65.0.27:57835",
+					"172.17.0.1:57835",
+					"172.18.0.1:57835",
+					"172.19.0.1:57835"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:50:51.68571398Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5260154043304652,
+				"StableID":   "nXepFyKL5i11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28db6e7978c9f2f885a63d2f6ffa4fb3cd128070c868ced5a1d29c5c2c179543",
+				"DiscoKey":   "discokey:25a9e9c373600720a7e16efff1e5e8993ed4fafd022be72d1cc314ad4a6d4847",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50616",
+					"10.65.0.27:50616",
+					"172.17.0.1:50616",
+					"172.18.0.1:50616",
+					"172.19.0.1:50616"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:50:52.230388804Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         26853145814640,
+				"StableID":   "nD9QYRPAD111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9880579da6e1819130736f9ab4301432c181a7dcf0d95a9f408dd2fe44e32b1d",
+				"DiscoKey":   "discokey:df13acdcdebdd05c81fea462946c607b0d19f96966ef61fe30be99d6c1fc4743",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53241",
+					"10.65.0.27:53241",
+					"172.17.0.1:53241",
+					"172.18.0.1:53241",
+					"172.19.0.1:53241"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:50:52.770679863Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8155594954834163,
+				"StableID":   "nQssdhegg621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0e179857c0adcb3cfbe558fc76bcfdf4d5c819bf9215fbd02fe8a79e96fde02",
+				"DiscoKey":   "discokey:9918256c5e1c313a1de71ff68cac3b87a36c890baaa8fdf9748f73da7cf58433",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51886",
+					"10.65.0.27:51886",
+					"172.17.0.1:51886",
+					"172.18.0.1:51886",
+					"172.19.0.1:51886"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:50:53.307812557Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3719056762313891,
+				"StableID":   "nk5umFKN3W11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f317cd9b223c1f14fd9dd1c491f54298332c43aa6a222a8230e3539896c98503",
+				"DiscoKey":   "discokey:f50499f376496e23c219e8ecb1fdb75c25ef029ac807d3129382375db874751d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33406",
+					"10.65.0.27:33406",
+					"172.17.0.1:33406",
+					"172.18.0.1:33406",
+					"172.19.0.1:33406"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:50:53.858003446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7237902144095889,
+				"StableID":   "nLneS8R4Xy11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b19e27a86bcc1b60c4edfa744fce1772da8144d1fc1047447e205d39de554f7a",
+				"DiscoKey":   "discokey:cc91bdff6247e1b6f592aa4301f48cbef433c6684057ad8a6f6bd272496b5b41",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53839",
+					"10.65.0.27:53839",
+					"172.17.0.1:53839",
+					"172.18.0.1:53839",
+					"172.19.0.1:53839"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:50:54.388481816Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6837257259921048,
+				"StableID":   "njkMyw9cPv11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4c4221032a4c26cf6cd69d668102971b3023991d0e512f804289394a0448f2d",
+				"DiscoKey":   "discokey:4c761ac683acfdd6981c51ed632ffc59e11748648f87af6d215a5be409db930a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48344",
+					"10.65.0.27:48344",
+					"172.17.0.1:48344",
+					"172.18.0.1:48344",
+					"172.19.0.1:48344"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:50:54.92809966Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8097669955681323,
+				"StableID":   "ntPJpP4TE621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ace813b8ee5954947c37f526af381f31aed93892714f8f506a20ac165d586b48",
+				"DiscoKey":   "discokey:5ae62e13077fa6798bab0e3836e4973dcd0b03aa512e4ce5c0fd2981f78c9113",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48858",
+					"10.65.0.27:48858",
+					"172.17.0.1:48858",
+					"172.18.0.1:48858",
+					"172.19.0.1:48858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:50:56.003451711Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5921762583239446,
+				"StableID":   "njsjMNfyEo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c17d80d9c65794f3dc0765708f597a4eaf7daa8c4153f5b68c6c4c44d6e3547",
+				"DiscoKey":   "discokey:acde5212a7e81340cc1a031cddb7b9e693fc05cd0253876b80b58bf22e461249",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56300",
+					"10.65.0.27:56300",
+					"172.17.0.1:56300",
+					"172.18.0.1:56300",
+					"172.19.0.1:56300"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:50:56.537801395Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4912179265883428,
+				"StableID":   "nPWzkwcjMf11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9897edf24079fbcb7278ff680f06da5abe2547bada4f7a9333819f766375b00a",
+				"DiscoKey":   "discokey:d88f87bb9575f8e7d3d69da254b510a1c9d4b9b51c64b768f6f0e66736617945",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36850",
+					"10.65.0.27:36850",
+					"172.17.0.1:36850",
+					"172.18.0.1:36850",
+					"172.19.0.1:36850"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:50:57.089625315Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         269944687634845,
+				"StableID":   "nv9XfNzF7311CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2faec7c09f5595929002d75a12bd06c3027fcbc0ce39c1bc679e0350ba88ee01",
+				"DiscoKey":   "discokey:7a8022a8b86b52a2c33fe7bf6f7581459875b637068e9ed900004d0d166efd51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36811",
+					"10.65.0.27:36811",
+					"172.17.0.1:36811",
+					"172.18.0.1:36811",
+					"172.19.0.1:36811"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:50:57.621416223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7540982333003941,
+				"StableID":   "n2wRtUpKt121CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8eb2c055e9eca6aa3351f7678bd6abf05a90f098630b3b2f3ab03390fba8fc07",
+				"KeyExpiry":  "2026-11-08T21:50:58Z",
+				"DiscoKey":   "discokey:67b23576ebaab173e36d282ea01095f0ccc7c3c023e7bc50f2b17d4acaa26a67",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34276",
+					"10.65.0.27:34276",
+					"172.17.0.1:34276",
+					"172.18.0.1:34276",
+					"172.19.0.1:34276"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:50:58.184084138Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4803304395061543,
+				"StableID":   "nUhQFNfRWe11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8006cacc76d819a8dd1736b54d7f4f8d642f176bd069242f250d1695b9fd346d",
+				"KeyExpiry":  "2026-11-08T21:50:58Z",
+				"DiscoKey":   "discokey:a713fab733bfe980c034fe8d28c0396a52a8e141c0c4f21aa1b047d53714e432",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35344",
+					"10.65.0.27:35344",
+					"172.17.0.1:35344",
+					"172.18.0.1:35344",
+					"172.19.0.1:35344"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:50:58.702458496Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4382350036694651,
+				"StableID":   "n4qD6TumDb11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b9a0f3e20759548f3c672ba2e63c8eb3cbbfc23a818cb68ff2d5a82fbdb77805",
+				"KeyExpiry":  "2026-11-08T21:50:59Z",
+				"DiscoKey":   "discokey:4ac4396dd0e2f5d0c4cec4115cbe35ce77ce101aad6b81652770c5813b4f811e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:32851",
+					"10.65.0.27:32851",
+					"172.17.0.1:32851",
+					"172.18.0.1:32851",
+					"172.19.0.1:32851"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:50:59.238113861Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3401762228091282": {
+				"ID":          3401762228091282,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7540982333003941,
+				"StableID":   "n2wRtUpKt121CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8eb2c055e9eca6aa3351f7678bd6abf05a90f098630b3b2f3ab03390fba8fc07",
+				"KeyExpiry":  "2026-11-08T21:50:58Z",
+				"DiscoKey":   "discokey:67b23576ebaab173e36d282ea01095f0ccc7c3c023e7bc50f2b17d4acaa26a67",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34276",
+					"10.65.0.27:34276",
+					"172.17.0.1:34276",
+					"172.18.0.1:34276",
+					"172.19.0.1:34276"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:50:58.184084138Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8eb2c055e9eca6aa3351f7678bd6abf05a90f098630b3b2f3ab03390fba8fc07",
+			"MachineKey": "mkey:964c1a1c8785a7f1b77c842f760bbe1098b6fc1617cc2c540e4ac074b8ee3c61",
+			"Peers": [{
+				"ID":         968680837477776,
+				"StableID":   "nqZwWybiZ811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ffd5c87946d681fb584ee51bd06ed4e51d2a8cd2c832436dfd6b5783e9e8b37",
+				"DiscoKey":   "discokey:1205ba137a2de6c7ef967d4f4c022ff6a20f2e1f959975d7bb35921541419330",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:57835",
+					"10.65.0.27:57835",
+					"172.17.0.1:57835",
+					"172.18.0.1:57835",
+					"172.19.0.1:57835"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:50:51.68571398Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5260154043304652,
+				"StableID":   "nXepFyKL5i11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28db6e7978c9f2f885a63d2f6ffa4fb3cd128070c868ced5a1d29c5c2c179543",
+				"DiscoKey":   "discokey:25a9e9c373600720a7e16efff1e5e8993ed4fafd022be72d1cc314ad4a6d4847",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50616",
+					"10.65.0.27:50616",
+					"172.17.0.1:50616",
+					"172.18.0.1:50616",
+					"172.19.0.1:50616"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:50:52.230388804Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         26853145814640,
+				"StableID":   "nD9QYRPAD111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9880579da6e1819130736f9ab4301432c181a7dcf0d95a9f408dd2fe44e32b1d",
+				"DiscoKey":   "discokey:df13acdcdebdd05c81fea462946c607b0d19f96966ef61fe30be99d6c1fc4743",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53241",
+					"10.65.0.27:53241",
+					"172.17.0.1:53241",
+					"172.18.0.1:53241",
+					"172.19.0.1:53241"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:50:52.770679863Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8155594954834163,
+				"StableID":   "nQssdhegg621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0e179857c0adcb3cfbe558fc76bcfdf4d5c819bf9215fbd02fe8a79e96fde02",
+				"DiscoKey":   "discokey:9918256c5e1c313a1de71ff68cac3b87a36c890baaa8fdf9748f73da7cf58433",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51886",
+					"10.65.0.27:51886",
+					"172.17.0.1:51886",
+					"172.18.0.1:51886",
+					"172.19.0.1:51886"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:50:53.307812557Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3719056762313891,
+				"StableID":   "nk5umFKN3W11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f317cd9b223c1f14fd9dd1c491f54298332c43aa6a222a8230e3539896c98503",
+				"DiscoKey":   "discokey:f50499f376496e23c219e8ecb1fdb75c25ef029ac807d3129382375db874751d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33406",
+					"10.65.0.27:33406",
+					"172.17.0.1:33406",
+					"172.18.0.1:33406",
+					"172.19.0.1:33406"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:50:53.858003446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7237902144095889,
+				"StableID":   "nLneS8R4Xy11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b19e27a86bcc1b60c4edfa744fce1772da8144d1fc1047447e205d39de554f7a",
+				"DiscoKey":   "discokey:cc91bdff6247e1b6f592aa4301f48cbef433c6684057ad8a6f6bd272496b5b41",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53839",
+					"10.65.0.27:53839",
+					"172.17.0.1:53839",
+					"172.18.0.1:53839",
+					"172.19.0.1:53839"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:50:54.388481816Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6837257259921048,
+				"StableID":   "njkMyw9cPv11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4c4221032a4c26cf6cd69d668102971b3023991d0e512f804289394a0448f2d",
+				"DiscoKey":   "discokey:4c761ac683acfdd6981c51ed632ffc59e11748648f87af6d215a5be409db930a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48344",
+					"10.65.0.27:48344",
+					"172.17.0.1:48344",
+					"172.18.0.1:48344",
+					"172.19.0.1:48344"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:50:54.92809966Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3401762228091282,
+				"StableID":   "nZGvJUXfZT11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b82b5c77b3c67b82ec5fc454c17cd26bc1a6d288defbd0047fc6ce77ffbfdf73",
+				"DiscoKey":   "discokey:0dbe56a371694b7b2e2f5ccd20b072fc256a434fffdef9ed9e1fb27d6670527c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52046",
+					"10.65.0.27:52046",
+					"172.17.0.1:52046",
+					"172.18.0.1:52046",
+					"172.19.0.1:52046"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:50:55.473629781Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8097669955681323,
+				"StableID":   "ntPJpP4TE621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ace813b8ee5954947c37f526af381f31aed93892714f8f506a20ac165d586b48",
+				"DiscoKey":   "discokey:5ae62e13077fa6798bab0e3836e4973dcd0b03aa512e4ce5c0fd2981f78c9113",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48858",
+					"10.65.0.27:48858",
+					"172.17.0.1:48858",
+					"172.18.0.1:48858",
+					"172.19.0.1:48858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:50:56.003451711Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5921762583239446,
+				"StableID":   "njsjMNfyEo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c17d80d9c65794f3dc0765708f597a4eaf7daa8c4153f5b68c6c4c44d6e3547",
+				"DiscoKey":   "discokey:acde5212a7e81340cc1a031cddb7b9e693fc05cd0253876b80b58bf22e461249",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56300",
+					"10.65.0.27:56300",
+					"172.17.0.1:56300",
+					"172.18.0.1:56300",
+					"172.19.0.1:56300"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:50:56.537801395Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4912179265883428,
+				"StableID":   "nPWzkwcjMf11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9897edf24079fbcb7278ff680f06da5abe2547bada4f7a9333819f766375b00a",
+				"DiscoKey":   "discokey:d88f87bb9575f8e7d3d69da254b510a1c9d4b9b51c64b768f6f0e66736617945",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36850",
+					"10.65.0.27:36850",
+					"172.17.0.1:36850",
+					"172.18.0.1:36850",
+					"172.19.0.1:36850"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:50:57.089625315Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         269944687634845,
+				"StableID":   "nv9XfNzF7311CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2faec7c09f5595929002d75a12bd06c3027fcbc0ce39c1bc679e0350ba88ee01",
+				"DiscoKey":   "discokey:7a8022a8b86b52a2c33fe7bf6f7581459875b637068e9ed900004d0d166efd51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36811",
+					"10.65.0.27:36811",
+					"172.17.0.1:36811",
+					"172.18.0.1:36811",
+					"172.19.0.1:36811"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:50:57.621416223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4803304395061543,
+				"StableID":   "nUhQFNfRWe11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8006cacc76d819a8dd1736b54d7f4f8d642f176bd069242f250d1695b9fd346d",
+				"KeyExpiry":  "2026-11-08T21:50:58Z",
+				"DiscoKey":   "discokey:a713fab733bfe980c034fe8d28c0396a52a8e141c0c4f21aa1b047d53714e432",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35344",
+					"10.65.0.27:35344",
+					"172.17.0.1:35344",
+					"172.18.0.1:35344",
+					"172.19.0.1:35344"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:50:58.702458496Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4382350036694651,
+				"StableID":   "n4qD6TumDb11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b9a0f3e20759548f3c672ba2e63c8eb3cbbfc23a818cb68ff2d5a82fbdb77805",
+				"KeyExpiry":  "2026-11-08T21:50:59Z",
+				"DiscoKey":   "discokey:4ac4396dd0e2f5d0c4cec4115cbe35ce77ce101aad6b81652770c5813b4f811e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:32851",
+					"10.65.0.27:32851",
+					"172.17.0.1:32851",
+					"172.18.0.1:32851",
+					"172.19.0.1:32851"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:50:59.238113861Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4912179265883428,
+				"StableID":   "nPWzkwcjMf11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       4912179265883428,
+				"Key":        "nodekey:9897edf24079fbcb7278ff680f06da5abe2547bada4f7a9333819f766375b00a",
+				"DiscoKey":   "discokey:d88f87bb9575f8e7d3d69da254b510a1c9d4b9b51c64b768f6f0e66736617945",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36850",
+					"10.65.0.27:36850",
+					"172.17.0.1:36850",
+					"172.18.0.1:36850",
+					"172.19.0.1:36850"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:50:57.089625315Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9897edf24079fbcb7278ff680f06da5abe2547bada4f7a9333819f766375b00a",
+			"MachineKey": "mkey:b05c6e10d6f10934fdbcb299366e4cd893868bddb27e60331f8380c386513846",
+			"Peers": [{
+				"ID":         968680837477776,
+				"StableID":   "nqZwWybiZ811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ffd5c87946d681fb584ee51bd06ed4e51d2a8cd2c832436dfd6b5783e9e8b37",
+				"DiscoKey":   "discokey:1205ba137a2de6c7ef967d4f4c022ff6a20f2e1f959975d7bb35921541419330",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:57835",
+					"10.65.0.27:57835",
+					"172.17.0.1:57835",
+					"172.18.0.1:57835",
+					"172.19.0.1:57835"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:50:51.68571398Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5260154043304652,
+				"StableID":   "nXepFyKL5i11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28db6e7978c9f2f885a63d2f6ffa4fb3cd128070c868ced5a1d29c5c2c179543",
+				"DiscoKey":   "discokey:25a9e9c373600720a7e16efff1e5e8993ed4fafd022be72d1cc314ad4a6d4847",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50616",
+					"10.65.0.27:50616",
+					"172.17.0.1:50616",
+					"172.18.0.1:50616",
+					"172.19.0.1:50616"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:50:52.230388804Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         26853145814640,
+				"StableID":   "nD9QYRPAD111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9880579da6e1819130736f9ab4301432c181a7dcf0d95a9f408dd2fe44e32b1d",
+				"DiscoKey":   "discokey:df13acdcdebdd05c81fea462946c607b0d19f96966ef61fe30be99d6c1fc4743",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53241",
+					"10.65.0.27:53241",
+					"172.17.0.1:53241",
+					"172.18.0.1:53241",
+					"172.19.0.1:53241"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:50:52.770679863Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8155594954834163,
+				"StableID":   "nQssdhegg621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0e179857c0adcb3cfbe558fc76bcfdf4d5c819bf9215fbd02fe8a79e96fde02",
+				"DiscoKey":   "discokey:9918256c5e1c313a1de71ff68cac3b87a36c890baaa8fdf9748f73da7cf58433",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51886",
+					"10.65.0.27:51886",
+					"172.17.0.1:51886",
+					"172.18.0.1:51886",
+					"172.19.0.1:51886"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:50:53.307812557Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3719056762313891,
+				"StableID":   "nk5umFKN3W11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f317cd9b223c1f14fd9dd1c491f54298332c43aa6a222a8230e3539896c98503",
+				"DiscoKey":   "discokey:f50499f376496e23c219e8ecb1fdb75c25ef029ac807d3129382375db874751d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33406",
+					"10.65.0.27:33406",
+					"172.17.0.1:33406",
+					"172.18.0.1:33406",
+					"172.19.0.1:33406"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:50:53.858003446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7237902144095889,
+				"StableID":   "nLneS8R4Xy11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b19e27a86bcc1b60c4edfa744fce1772da8144d1fc1047447e205d39de554f7a",
+				"DiscoKey":   "discokey:cc91bdff6247e1b6f592aa4301f48cbef433c6684057ad8a6f6bd272496b5b41",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53839",
+					"10.65.0.27:53839",
+					"172.17.0.1:53839",
+					"172.18.0.1:53839",
+					"172.19.0.1:53839"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:50:54.388481816Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6837257259921048,
+				"StableID":   "njkMyw9cPv11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4c4221032a4c26cf6cd69d668102971b3023991d0e512f804289394a0448f2d",
+				"DiscoKey":   "discokey:4c761ac683acfdd6981c51ed632ffc59e11748648f87af6d215a5be409db930a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48344",
+					"10.65.0.27:48344",
+					"172.17.0.1:48344",
+					"172.18.0.1:48344",
+					"172.19.0.1:48344"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:50:54.92809966Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3401762228091282,
+				"StableID":   "nZGvJUXfZT11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b82b5c77b3c67b82ec5fc454c17cd26bc1a6d288defbd0047fc6ce77ffbfdf73",
+				"DiscoKey":   "discokey:0dbe56a371694b7b2e2f5ccd20b072fc256a434fffdef9ed9e1fb27d6670527c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52046",
+					"10.65.0.27:52046",
+					"172.17.0.1:52046",
+					"172.18.0.1:52046",
+					"172.19.0.1:52046"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:50:55.473629781Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8097669955681323,
+				"StableID":   "ntPJpP4TE621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ace813b8ee5954947c37f526af381f31aed93892714f8f506a20ac165d586b48",
+				"DiscoKey":   "discokey:5ae62e13077fa6798bab0e3836e4973dcd0b03aa512e4ce5c0fd2981f78c9113",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48858",
+					"10.65.0.27:48858",
+					"172.17.0.1:48858",
+					"172.18.0.1:48858",
+					"172.19.0.1:48858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:50:56.003451711Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5921762583239446,
+				"StableID":   "njsjMNfyEo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c17d80d9c65794f3dc0765708f597a4eaf7daa8c4153f5b68c6c4c44d6e3547",
+				"DiscoKey":   "discokey:acde5212a7e81340cc1a031cddb7b9e693fc05cd0253876b80b58bf22e461249",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56300",
+					"10.65.0.27:56300",
+					"172.17.0.1:56300",
+					"172.18.0.1:56300",
+					"172.19.0.1:56300"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:50:56.537801395Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         269944687634845,
+				"StableID":   "nv9XfNzF7311CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2faec7c09f5595929002d75a12bd06c3027fcbc0ce39c1bc679e0350ba88ee01",
+				"DiscoKey":   "discokey:7a8022a8b86b52a2c33fe7bf6f7581459875b637068e9ed900004d0d166efd51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36811",
+					"10.65.0.27:36811",
+					"172.17.0.1:36811",
+					"172.18.0.1:36811",
+					"172.19.0.1:36811"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:50:57.621416223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7540982333003941,
+				"StableID":   "n2wRtUpKt121CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8eb2c055e9eca6aa3351f7678bd6abf05a90f098630b3b2f3ab03390fba8fc07",
+				"KeyExpiry":  "2026-11-08T21:50:58Z",
+				"DiscoKey":   "discokey:67b23576ebaab173e36d282ea01095f0ccc7c3c023e7bc50f2b17d4acaa26a67",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34276",
+					"10.65.0.27:34276",
+					"172.17.0.1:34276",
+					"172.18.0.1:34276",
+					"172.19.0.1:34276"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:50:58.184084138Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4803304395061543,
+				"StableID":   "nUhQFNfRWe11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8006cacc76d819a8dd1736b54d7f4f8d642f176bd069242f250d1695b9fd346d",
+				"KeyExpiry":  "2026-11-08T21:50:58Z",
+				"DiscoKey":   "discokey:a713fab733bfe980c034fe8d28c0396a52a8e141c0c4f21aa1b047d53714e432",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35344",
+					"10.65.0.27:35344",
+					"172.17.0.1:35344",
+					"172.18.0.1:35344",
+					"172.19.0.1:35344"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:50:58.702458496Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4382350036694651,
+				"StableID":   "n4qD6TumDb11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b9a0f3e20759548f3c672ba2e63c8eb3cbbfc23a818cb68ff2d5a82fbdb77805",
+				"KeyExpiry":  "2026-11-08T21:50:59Z",
+				"DiscoKey":   "discokey:4ac4396dd0e2f5d0c4cec4115cbe35ce77ce101aad6b81652770c5813b4f811e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:32851",
+					"10.65.0.27:32851",
+					"172.17.0.1:32851",
+					"172.18.0.1:32851",
+					"172.19.0.1:32851"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:50:59.238113861Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4912179265883428": {
+				"ID":          4912179265883428,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5260154043304652,
+				"StableID":   "nXepFyKL5i11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       5260154043304652,
+				"Key":        "nodekey:28db6e7978c9f2f885a63d2f6ffa4fb3cd128070c868ced5a1d29c5c2c179543",
+				"DiscoKey":   "discokey:25a9e9c373600720a7e16efff1e5e8993ed4fafd022be72d1cc314ad4a6d4847",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50616",
+					"10.65.0.27:50616",
+					"172.17.0.1:50616",
+					"172.18.0.1:50616",
+					"172.19.0.1:50616"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:50:52.230388804Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:28db6e7978c9f2f885a63d2f6ffa4fb3cd128070c868ced5a1d29c5c2c179543",
+			"MachineKey": "mkey:b4728cec92cbc53d10c4fb63e3ed85ad8f52a526d93f763e00eadc4d4c42700c",
+			"Peers": [{
+				"ID":         968680837477776,
+				"StableID":   "nqZwWybiZ811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ffd5c87946d681fb584ee51bd06ed4e51d2a8cd2c832436dfd6b5783e9e8b37",
+				"DiscoKey":   "discokey:1205ba137a2de6c7ef967d4f4c022ff6a20f2e1f959975d7bb35921541419330",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:57835",
+					"10.65.0.27:57835",
+					"172.17.0.1:57835",
+					"172.18.0.1:57835",
+					"172.19.0.1:57835"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:50:51.68571398Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         26853145814640,
+				"StableID":   "nD9QYRPAD111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9880579da6e1819130736f9ab4301432c181a7dcf0d95a9f408dd2fe44e32b1d",
+				"DiscoKey":   "discokey:df13acdcdebdd05c81fea462946c607b0d19f96966ef61fe30be99d6c1fc4743",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53241",
+					"10.65.0.27:53241",
+					"172.17.0.1:53241",
+					"172.18.0.1:53241",
+					"172.19.0.1:53241"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:50:52.770679863Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8155594954834163,
+				"StableID":   "nQssdhegg621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0e179857c0adcb3cfbe558fc76bcfdf4d5c819bf9215fbd02fe8a79e96fde02",
+				"DiscoKey":   "discokey:9918256c5e1c313a1de71ff68cac3b87a36c890baaa8fdf9748f73da7cf58433",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51886",
+					"10.65.0.27:51886",
+					"172.17.0.1:51886",
+					"172.18.0.1:51886",
+					"172.19.0.1:51886"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:50:53.307812557Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3719056762313891,
+				"StableID":   "nk5umFKN3W11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f317cd9b223c1f14fd9dd1c491f54298332c43aa6a222a8230e3539896c98503",
+				"DiscoKey":   "discokey:f50499f376496e23c219e8ecb1fdb75c25ef029ac807d3129382375db874751d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33406",
+					"10.65.0.27:33406",
+					"172.17.0.1:33406",
+					"172.18.0.1:33406",
+					"172.19.0.1:33406"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:50:53.858003446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7237902144095889,
+				"StableID":   "nLneS8R4Xy11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b19e27a86bcc1b60c4edfa744fce1772da8144d1fc1047447e205d39de554f7a",
+				"DiscoKey":   "discokey:cc91bdff6247e1b6f592aa4301f48cbef433c6684057ad8a6f6bd272496b5b41",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53839",
+					"10.65.0.27:53839",
+					"172.17.0.1:53839",
+					"172.18.0.1:53839",
+					"172.19.0.1:53839"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:50:54.388481816Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6837257259921048,
+				"StableID":   "njkMyw9cPv11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4c4221032a4c26cf6cd69d668102971b3023991d0e512f804289394a0448f2d",
+				"DiscoKey":   "discokey:4c761ac683acfdd6981c51ed632ffc59e11748648f87af6d215a5be409db930a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48344",
+					"10.65.0.27:48344",
+					"172.17.0.1:48344",
+					"172.18.0.1:48344",
+					"172.19.0.1:48344"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:50:54.92809966Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3401762228091282,
+				"StableID":   "nZGvJUXfZT11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b82b5c77b3c67b82ec5fc454c17cd26bc1a6d288defbd0047fc6ce77ffbfdf73",
+				"DiscoKey":   "discokey:0dbe56a371694b7b2e2f5ccd20b072fc256a434fffdef9ed9e1fb27d6670527c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52046",
+					"10.65.0.27:52046",
+					"172.17.0.1:52046",
+					"172.18.0.1:52046",
+					"172.19.0.1:52046"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:50:55.473629781Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8097669955681323,
+				"StableID":   "ntPJpP4TE621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ace813b8ee5954947c37f526af381f31aed93892714f8f506a20ac165d586b48",
+				"DiscoKey":   "discokey:5ae62e13077fa6798bab0e3836e4973dcd0b03aa512e4ce5c0fd2981f78c9113",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48858",
+					"10.65.0.27:48858",
+					"172.17.0.1:48858",
+					"172.18.0.1:48858",
+					"172.19.0.1:48858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:50:56.003451711Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5921762583239446,
+				"StableID":   "njsjMNfyEo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c17d80d9c65794f3dc0765708f597a4eaf7daa8c4153f5b68c6c4c44d6e3547",
+				"DiscoKey":   "discokey:acde5212a7e81340cc1a031cddb7b9e693fc05cd0253876b80b58bf22e461249",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56300",
+					"10.65.0.27:56300",
+					"172.17.0.1:56300",
+					"172.18.0.1:56300",
+					"172.19.0.1:56300"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:50:56.537801395Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4912179265883428,
+				"StableID":   "nPWzkwcjMf11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9897edf24079fbcb7278ff680f06da5abe2547bada4f7a9333819f766375b00a",
+				"DiscoKey":   "discokey:d88f87bb9575f8e7d3d69da254b510a1c9d4b9b51c64b768f6f0e66736617945",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36850",
+					"10.65.0.27:36850",
+					"172.17.0.1:36850",
+					"172.18.0.1:36850",
+					"172.19.0.1:36850"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:50:57.089625315Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         269944687634845,
+				"StableID":   "nv9XfNzF7311CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2faec7c09f5595929002d75a12bd06c3027fcbc0ce39c1bc679e0350ba88ee01",
+				"DiscoKey":   "discokey:7a8022a8b86b52a2c33fe7bf6f7581459875b637068e9ed900004d0d166efd51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36811",
+					"10.65.0.27:36811",
+					"172.17.0.1:36811",
+					"172.18.0.1:36811",
+					"172.19.0.1:36811"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:50:57.621416223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7540982333003941,
+				"StableID":   "n2wRtUpKt121CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8eb2c055e9eca6aa3351f7678bd6abf05a90f098630b3b2f3ab03390fba8fc07",
+				"KeyExpiry":  "2026-11-08T21:50:58Z",
+				"DiscoKey":   "discokey:67b23576ebaab173e36d282ea01095f0ccc7c3c023e7bc50f2b17d4acaa26a67",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34276",
+					"10.65.0.27:34276",
+					"172.17.0.1:34276",
+					"172.18.0.1:34276",
+					"172.19.0.1:34276"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:50:58.184084138Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4803304395061543,
+				"StableID":   "nUhQFNfRWe11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8006cacc76d819a8dd1736b54d7f4f8d642f176bd069242f250d1695b9fd346d",
+				"KeyExpiry":  "2026-11-08T21:50:58Z",
+				"DiscoKey":   "discokey:a713fab733bfe980c034fe8d28c0396a52a8e141c0c4f21aa1b047d53714e432",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35344",
+					"10.65.0.27:35344",
+					"172.17.0.1:35344",
+					"172.18.0.1:35344",
+					"172.19.0.1:35344"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:50:58.702458496Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4382350036694651,
+				"StableID":   "n4qD6TumDb11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b9a0f3e20759548f3c672ba2e63c8eb3cbbfc23a818cb68ff2d5a82fbdb77805",
+				"KeyExpiry":  "2026-11-08T21:50:59Z",
+				"DiscoKey":   "discokey:4ac4396dd0e2f5d0c4cec4115cbe35ce77ce101aad6b81652770c5813b4f811e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:32851",
+					"10.65.0.27:32851",
+					"172.17.0.1:32851",
+					"172.18.0.1:32851",
+					"172.19.0.1:32851"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:50:59.238113861Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5260154043304652": {
+				"ID":          5260154043304652,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         968680837477776,
+				"StableID":   "nqZwWybiZ811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       968680837477776,
+				"Key":        "nodekey:7ffd5c87946d681fb584ee51bd06ed4e51d2a8cd2c832436dfd6b5783e9e8b37",
+				"DiscoKey":   "discokey:1205ba137a2de6c7ef967d4f4c022ff6a20f2e1f959975d7bb35921541419330",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:57835",
+					"10.65.0.27:57835",
+					"172.17.0.1:57835",
+					"172.18.0.1:57835",
+					"172.19.0.1:57835"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:50:51.68571398Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7ffd5c87946d681fb584ee51bd06ed4e51d2a8cd2c832436dfd6b5783e9e8b37",
+			"MachineKey": "mkey:3f812081598e628fbc9f4a3e909e41b9df51472bf37226c269aab9e92a27e544",
+			"Peers": [{
+				"ID":         5260154043304652,
+				"StableID":   "nXepFyKL5i11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28db6e7978c9f2f885a63d2f6ffa4fb3cd128070c868ced5a1d29c5c2c179543",
+				"DiscoKey":   "discokey:25a9e9c373600720a7e16efff1e5e8993ed4fafd022be72d1cc314ad4a6d4847",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50616",
+					"10.65.0.27:50616",
+					"172.17.0.1:50616",
+					"172.18.0.1:50616",
+					"172.19.0.1:50616"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:50:52.230388804Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         26853145814640,
+				"StableID":   "nD9QYRPAD111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9880579da6e1819130736f9ab4301432c181a7dcf0d95a9f408dd2fe44e32b1d",
+				"DiscoKey":   "discokey:df13acdcdebdd05c81fea462946c607b0d19f96966ef61fe30be99d6c1fc4743",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53241",
+					"10.65.0.27:53241",
+					"172.17.0.1:53241",
+					"172.18.0.1:53241",
+					"172.19.0.1:53241"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:50:52.770679863Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8155594954834163,
+				"StableID":   "nQssdhegg621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0e179857c0adcb3cfbe558fc76bcfdf4d5c819bf9215fbd02fe8a79e96fde02",
+				"DiscoKey":   "discokey:9918256c5e1c313a1de71ff68cac3b87a36c890baaa8fdf9748f73da7cf58433",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51886",
+					"10.65.0.27:51886",
+					"172.17.0.1:51886",
+					"172.18.0.1:51886",
+					"172.19.0.1:51886"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:50:53.307812557Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3719056762313891,
+				"StableID":   "nk5umFKN3W11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f317cd9b223c1f14fd9dd1c491f54298332c43aa6a222a8230e3539896c98503",
+				"DiscoKey":   "discokey:f50499f376496e23c219e8ecb1fdb75c25ef029ac807d3129382375db874751d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33406",
+					"10.65.0.27:33406",
+					"172.17.0.1:33406",
+					"172.18.0.1:33406",
+					"172.19.0.1:33406"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:50:53.858003446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7237902144095889,
+				"StableID":   "nLneS8R4Xy11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b19e27a86bcc1b60c4edfa744fce1772da8144d1fc1047447e205d39de554f7a",
+				"DiscoKey":   "discokey:cc91bdff6247e1b6f592aa4301f48cbef433c6684057ad8a6f6bd272496b5b41",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53839",
+					"10.65.0.27:53839",
+					"172.17.0.1:53839",
+					"172.18.0.1:53839",
+					"172.19.0.1:53839"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:50:54.388481816Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6837257259921048,
+				"StableID":   "njkMyw9cPv11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4c4221032a4c26cf6cd69d668102971b3023991d0e512f804289394a0448f2d",
+				"DiscoKey":   "discokey:4c761ac683acfdd6981c51ed632ffc59e11748648f87af6d215a5be409db930a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48344",
+					"10.65.0.27:48344",
+					"172.17.0.1:48344",
+					"172.18.0.1:48344",
+					"172.19.0.1:48344"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:50:54.92809966Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3401762228091282,
+				"StableID":   "nZGvJUXfZT11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b82b5c77b3c67b82ec5fc454c17cd26bc1a6d288defbd0047fc6ce77ffbfdf73",
+				"DiscoKey":   "discokey:0dbe56a371694b7b2e2f5ccd20b072fc256a434fffdef9ed9e1fb27d6670527c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52046",
+					"10.65.0.27:52046",
+					"172.17.0.1:52046",
+					"172.18.0.1:52046",
+					"172.19.0.1:52046"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:50:55.473629781Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8097669955681323,
+				"StableID":   "ntPJpP4TE621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ace813b8ee5954947c37f526af381f31aed93892714f8f506a20ac165d586b48",
+				"DiscoKey":   "discokey:5ae62e13077fa6798bab0e3836e4973dcd0b03aa512e4ce5c0fd2981f78c9113",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48858",
+					"10.65.0.27:48858",
+					"172.17.0.1:48858",
+					"172.18.0.1:48858",
+					"172.19.0.1:48858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:50:56.003451711Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5921762583239446,
+				"StableID":   "njsjMNfyEo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c17d80d9c65794f3dc0765708f597a4eaf7daa8c4153f5b68c6c4c44d6e3547",
+				"DiscoKey":   "discokey:acde5212a7e81340cc1a031cddb7b9e693fc05cd0253876b80b58bf22e461249",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56300",
+					"10.65.0.27:56300",
+					"172.17.0.1:56300",
+					"172.18.0.1:56300",
+					"172.19.0.1:56300"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:50:56.537801395Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4912179265883428,
+				"StableID":   "nPWzkwcjMf11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9897edf24079fbcb7278ff680f06da5abe2547bada4f7a9333819f766375b00a",
+				"DiscoKey":   "discokey:d88f87bb9575f8e7d3d69da254b510a1c9d4b9b51c64b768f6f0e66736617945",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36850",
+					"10.65.0.27:36850",
+					"172.17.0.1:36850",
+					"172.18.0.1:36850",
+					"172.19.0.1:36850"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:50:57.089625315Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         269944687634845,
+				"StableID":   "nv9XfNzF7311CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2faec7c09f5595929002d75a12bd06c3027fcbc0ce39c1bc679e0350ba88ee01",
+				"DiscoKey":   "discokey:7a8022a8b86b52a2c33fe7bf6f7581459875b637068e9ed900004d0d166efd51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36811",
+					"10.65.0.27:36811",
+					"172.17.0.1:36811",
+					"172.18.0.1:36811",
+					"172.19.0.1:36811"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:50:57.621416223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7540982333003941,
+				"StableID":   "n2wRtUpKt121CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8eb2c055e9eca6aa3351f7678bd6abf05a90f098630b3b2f3ab03390fba8fc07",
+				"KeyExpiry":  "2026-11-08T21:50:58Z",
+				"DiscoKey":   "discokey:67b23576ebaab173e36d282ea01095f0ccc7c3c023e7bc50f2b17d4acaa26a67",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34276",
+					"10.65.0.27:34276",
+					"172.17.0.1:34276",
+					"172.18.0.1:34276",
+					"172.19.0.1:34276"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:50:58.184084138Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4803304395061543,
+				"StableID":   "nUhQFNfRWe11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8006cacc76d819a8dd1736b54d7f4f8d642f176bd069242f250d1695b9fd346d",
+				"KeyExpiry":  "2026-11-08T21:50:58Z",
+				"DiscoKey":   "discokey:a713fab733bfe980c034fe8d28c0396a52a8e141c0c4f21aa1b047d53714e432",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35344",
+					"10.65.0.27:35344",
+					"172.17.0.1:35344",
+					"172.18.0.1:35344",
+					"172.19.0.1:35344"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:50:58.702458496Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4382350036694651,
+				"StableID":   "n4qD6TumDb11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b9a0f3e20759548f3c672ba2e63c8eb3cbbfc23a818cb68ff2d5a82fbdb77805",
+				"KeyExpiry":  "2026-11-08T21:50:59Z",
+				"DiscoKey":   "discokey:4ac4396dd0e2f5d0c4cec4115cbe35ce77ce101aad6b81652770c5813b4f811e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:32851",
+					"10.65.0.27:32851",
+					"172.17.0.1:32851",
+					"172.18.0.1:32851",
+					"172.19.0.1:32851"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:50:59.238113861Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "968680837477776": {
+				"ID":          968680837477776,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3719056762313891,
+				"StableID":   "nk5umFKN3W11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       3719056762313891,
+				"Key":        "nodekey:f317cd9b223c1f14fd9dd1c491f54298332c43aa6a222a8230e3539896c98503",
+				"DiscoKey":   "discokey:f50499f376496e23c219e8ecb1fdb75c25ef029ac807d3129382375db874751d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33406",
+					"10.65.0.27:33406",
+					"172.17.0.1:33406",
+					"172.18.0.1:33406",
+					"172.19.0.1:33406"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:50:53.858003446Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f317cd9b223c1f14fd9dd1c491f54298332c43aa6a222a8230e3539896c98503",
+			"MachineKey": "mkey:edaccf723ad67b8e7cc7c2cc89510a5c2863b4636378f055fa87fd6db86a2649",
+			"Peers": [{
+				"ID":         968680837477776,
+				"StableID":   "nqZwWybiZ811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ffd5c87946d681fb584ee51bd06ed4e51d2a8cd2c832436dfd6b5783e9e8b37",
+				"DiscoKey":   "discokey:1205ba137a2de6c7ef967d4f4c022ff6a20f2e1f959975d7bb35921541419330",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:57835",
+					"10.65.0.27:57835",
+					"172.17.0.1:57835",
+					"172.18.0.1:57835",
+					"172.19.0.1:57835"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:50:51.68571398Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5260154043304652,
+				"StableID":   "nXepFyKL5i11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28db6e7978c9f2f885a63d2f6ffa4fb3cd128070c868ced5a1d29c5c2c179543",
+				"DiscoKey":   "discokey:25a9e9c373600720a7e16efff1e5e8993ed4fafd022be72d1cc314ad4a6d4847",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50616",
+					"10.65.0.27:50616",
+					"172.17.0.1:50616",
+					"172.18.0.1:50616",
+					"172.19.0.1:50616"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:50:52.230388804Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         26853145814640,
+				"StableID":   "nD9QYRPAD111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9880579da6e1819130736f9ab4301432c181a7dcf0d95a9f408dd2fe44e32b1d",
+				"DiscoKey":   "discokey:df13acdcdebdd05c81fea462946c607b0d19f96966ef61fe30be99d6c1fc4743",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53241",
+					"10.65.0.27:53241",
+					"172.17.0.1:53241",
+					"172.18.0.1:53241",
+					"172.19.0.1:53241"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:50:52.770679863Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8155594954834163,
+				"StableID":   "nQssdhegg621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0e179857c0adcb3cfbe558fc76bcfdf4d5c819bf9215fbd02fe8a79e96fde02",
+				"DiscoKey":   "discokey:9918256c5e1c313a1de71ff68cac3b87a36c890baaa8fdf9748f73da7cf58433",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51886",
+					"10.65.0.27:51886",
+					"172.17.0.1:51886",
+					"172.18.0.1:51886",
+					"172.19.0.1:51886"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:50:53.307812557Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7237902144095889,
+				"StableID":   "nLneS8R4Xy11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b19e27a86bcc1b60c4edfa744fce1772da8144d1fc1047447e205d39de554f7a",
+				"DiscoKey":   "discokey:cc91bdff6247e1b6f592aa4301f48cbef433c6684057ad8a6f6bd272496b5b41",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53839",
+					"10.65.0.27:53839",
+					"172.17.0.1:53839",
+					"172.18.0.1:53839",
+					"172.19.0.1:53839"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:50:54.388481816Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6837257259921048,
+				"StableID":   "njkMyw9cPv11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4c4221032a4c26cf6cd69d668102971b3023991d0e512f804289394a0448f2d",
+				"DiscoKey":   "discokey:4c761ac683acfdd6981c51ed632ffc59e11748648f87af6d215a5be409db930a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48344",
+					"10.65.0.27:48344",
+					"172.17.0.1:48344",
+					"172.18.0.1:48344",
+					"172.19.0.1:48344"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:50:54.92809966Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3401762228091282,
+				"StableID":   "nZGvJUXfZT11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b82b5c77b3c67b82ec5fc454c17cd26bc1a6d288defbd0047fc6ce77ffbfdf73",
+				"DiscoKey":   "discokey:0dbe56a371694b7b2e2f5ccd20b072fc256a434fffdef9ed9e1fb27d6670527c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52046",
+					"10.65.0.27:52046",
+					"172.17.0.1:52046",
+					"172.18.0.1:52046",
+					"172.19.0.1:52046"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:50:55.473629781Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8097669955681323,
+				"StableID":   "ntPJpP4TE621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ace813b8ee5954947c37f526af381f31aed93892714f8f506a20ac165d586b48",
+				"DiscoKey":   "discokey:5ae62e13077fa6798bab0e3836e4973dcd0b03aa512e4ce5c0fd2981f78c9113",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48858",
+					"10.65.0.27:48858",
+					"172.17.0.1:48858",
+					"172.18.0.1:48858",
+					"172.19.0.1:48858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:50:56.003451711Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5921762583239446,
+				"StableID":   "njsjMNfyEo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c17d80d9c65794f3dc0765708f597a4eaf7daa8c4153f5b68c6c4c44d6e3547",
+				"DiscoKey":   "discokey:acde5212a7e81340cc1a031cddb7b9e693fc05cd0253876b80b58bf22e461249",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56300",
+					"10.65.0.27:56300",
+					"172.17.0.1:56300",
+					"172.18.0.1:56300",
+					"172.19.0.1:56300"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:50:56.537801395Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4912179265883428,
+				"StableID":   "nPWzkwcjMf11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9897edf24079fbcb7278ff680f06da5abe2547bada4f7a9333819f766375b00a",
+				"DiscoKey":   "discokey:d88f87bb9575f8e7d3d69da254b510a1c9d4b9b51c64b768f6f0e66736617945",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36850",
+					"10.65.0.27:36850",
+					"172.17.0.1:36850",
+					"172.18.0.1:36850",
+					"172.19.0.1:36850"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:50:57.089625315Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         269944687634845,
+				"StableID":   "nv9XfNzF7311CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2faec7c09f5595929002d75a12bd06c3027fcbc0ce39c1bc679e0350ba88ee01",
+				"DiscoKey":   "discokey:7a8022a8b86b52a2c33fe7bf6f7581459875b637068e9ed900004d0d166efd51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36811",
+					"10.65.0.27:36811",
+					"172.17.0.1:36811",
+					"172.18.0.1:36811",
+					"172.19.0.1:36811"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:50:57.621416223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7540982333003941,
+				"StableID":   "n2wRtUpKt121CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8eb2c055e9eca6aa3351f7678bd6abf05a90f098630b3b2f3ab03390fba8fc07",
+				"KeyExpiry":  "2026-11-08T21:50:58Z",
+				"DiscoKey":   "discokey:67b23576ebaab173e36d282ea01095f0ccc7c3c023e7bc50f2b17d4acaa26a67",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34276",
+					"10.65.0.27:34276",
+					"172.17.0.1:34276",
+					"172.18.0.1:34276",
+					"172.19.0.1:34276"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:50:58.184084138Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4803304395061543,
+				"StableID":   "nUhQFNfRWe11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8006cacc76d819a8dd1736b54d7f4f8d642f176bd069242f250d1695b9fd346d",
+				"KeyExpiry":  "2026-11-08T21:50:58Z",
+				"DiscoKey":   "discokey:a713fab733bfe980c034fe8d28c0396a52a8e141c0c4f21aa1b047d53714e432",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35344",
+					"10.65.0.27:35344",
+					"172.17.0.1:35344",
+					"172.18.0.1:35344",
+					"172.19.0.1:35344"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:50:58.702458496Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4382350036694651,
+				"StableID":   "n4qD6TumDb11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b9a0f3e20759548f3c672ba2e63c8eb3cbbfc23a818cb68ff2d5a82fbdb77805",
+				"KeyExpiry":  "2026-11-08T21:50:59Z",
+				"DiscoKey":   "discokey:4ac4396dd0e2f5d0c4cec4115cbe35ce77ce101aad6b81652770c5813b4f811e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:32851",
+					"10.65.0.27:32851",
+					"172.17.0.1:32851",
+					"172.18.0.1:32851",
+					"172.19.0.1:32851"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:50:59.238113861Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3719056762313891": {
+				"ID":          3719056762313891,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8155594954834163,
+				"StableID":   "nQssdhegg621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       8155594954834163,
+				"Key":        "nodekey:a0e179857c0adcb3cfbe558fc76bcfdf4d5c819bf9215fbd02fe8a79e96fde02",
+				"DiscoKey":   "discokey:9918256c5e1c313a1de71ff68cac3b87a36c890baaa8fdf9748f73da7cf58433",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51886",
+					"10.65.0.27:51886",
+					"172.17.0.1:51886",
+					"172.18.0.1:51886",
+					"172.19.0.1:51886"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:50:53.307812557Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a0e179857c0adcb3cfbe558fc76bcfdf4d5c819bf9215fbd02fe8a79e96fde02",
+			"MachineKey": "mkey:4865f65198ac86aabc8b0a531531513349d4e86275efeb4fad21e7b2c79c1468",
+			"Peers": [{
+				"ID":         968680837477776,
+				"StableID":   "nqZwWybiZ811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ffd5c87946d681fb584ee51bd06ed4e51d2a8cd2c832436dfd6b5783e9e8b37",
+				"DiscoKey":   "discokey:1205ba137a2de6c7ef967d4f4c022ff6a20f2e1f959975d7bb35921541419330",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:57835",
+					"10.65.0.27:57835",
+					"172.17.0.1:57835",
+					"172.18.0.1:57835",
+					"172.19.0.1:57835"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:50:51.68571398Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5260154043304652,
+				"StableID":   "nXepFyKL5i11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28db6e7978c9f2f885a63d2f6ffa4fb3cd128070c868ced5a1d29c5c2c179543",
+				"DiscoKey":   "discokey:25a9e9c373600720a7e16efff1e5e8993ed4fafd022be72d1cc314ad4a6d4847",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50616",
+					"10.65.0.27:50616",
+					"172.17.0.1:50616",
+					"172.18.0.1:50616",
+					"172.19.0.1:50616"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:50:52.230388804Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         26853145814640,
+				"StableID":   "nD9QYRPAD111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9880579da6e1819130736f9ab4301432c181a7dcf0d95a9f408dd2fe44e32b1d",
+				"DiscoKey":   "discokey:df13acdcdebdd05c81fea462946c607b0d19f96966ef61fe30be99d6c1fc4743",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53241",
+					"10.65.0.27:53241",
+					"172.17.0.1:53241",
+					"172.18.0.1:53241",
+					"172.19.0.1:53241"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:50:52.770679863Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3719056762313891,
+				"StableID":   "nk5umFKN3W11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f317cd9b223c1f14fd9dd1c491f54298332c43aa6a222a8230e3539896c98503",
+				"DiscoKey":   "discokey:f50499f376496e23c219e8ecb1fdb75c25ef029ac807d3129382375db874751d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33406",
+					"10.65.0.27:33406",
+					"172.17.0.1:33406",
+					"172.18.0.1:33406",
+					"172.19.0.1:33406"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:50:53.858003446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7237902144095889,
+				"StableID":   "nLneS8R4Xy11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b19e27a86bcc1b60c4edfa744fce1772da8144d1fc1047447e205d39de554f7a",
+				"DiscoKey":   "discokey:cc91bdff6247e1b6f592aa4301f48cbef433c6684057ad8a6f6bd272496b5b41",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53839",
+					"10.65.0.27:53839",
+					"172.17.0.1:53839",
+					"172.18.0.1:53839",
+					"172.19.0.1:53839"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:50:54.388481816Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6837257259921048,
+				"StableID":   "njkMyw9cPv11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4c4221032a4c26cf6cd69d668102971b3023991d0e512f804289394a0448f2d",
+				"DiscoKey":   "discokey:4c761ac683acfdd6981c51ed632ffc59e11748648f87af6d215a5be409db930a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48344",
+					"10.65.0.27:48344",
+					"172.17.0.1:48344",
+					"172.18.0.1:48344",
+					"172.19.0.1:48344"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:50:54.92809966Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3401762228091282,
+				"StableID":   "nZGvJUXfZT11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b82b5c77b3c67b82ec5fc454c17cd26bc1a6d288defbd0047fc6ce77ffbfdf73",
+				"DiscoKey":   "discokey:0dbe56a371694b7b2e2f5ccd20b072fc256a434fffdef9ed9e1fb27d6670527c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52046",
+					"10.65.0.27:52046",
+					"172.17.0.1:52046",
+					"172.18.0.1:52046",
+					"172.19.0.1:52046"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:50:55.473629781Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8097669955681323,
+				"StableID":   "ntPJpP4TE621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ace813b8ee5954947c37f526af381f31aed93892714f8f506a20ac165d586b48",
+				"DiscoKey":   "discokey:5ae62e13077fa6798bab0e3836e4973dcd0b03aa512e4ce5c0fd2981f78c9113",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48858",
+					"10.65.0.27:48858",
+					"172.17.0.1:48858",
+					"172.18.0.1:48858",
+					"172.19.0.1:48858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:50:56.003451711Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5921762583239446,
+				"StableID":   "njsjMNfyEo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c17d80d9c65794f3dc0765708f597a4eaf7daa8c4153f5b68c6c4c44d6e3547",
+				"DiscoKey":   "discokey:acde5212a7e81340cc1a031cddb7b9e693fc05cd0253876b80b58bf22e461249",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56300",
+					"10.65.0.27:56300",
+					"172.17.0.1:56300",
+					"172.18.0.1:56300",
+					"172.19.0.1:56300"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:50:56.537801395Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4912179265883428,
+				"StableID":   "nPWzkwcjMf11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9897edf24079fbcb7278ff680f06da5abe2547bada4f7a9333819f766375b00a",
+				"DiscoKey":   "discokey:d88f87bb9575f8e7d3d69da254b510a1c9d4b9b51c64b768f6f0e66736617945",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36850",
+					"10.65.0.27:36850",
+					"172.17.0.1:36850",
+					"172.18.0.1:36850",
+					"172.19.0.1:36850"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:50:57.089625315Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         269944687634845,
+				"StableID":   "nv9XfNzF7311CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2faec7c09f5595929002d75a12bd06c3027fcbc0ce39c1bc679e0350ba88ee01",
+				"DiscoKey":   "discokey:7a8022a8b86b52a2c33fe7bf6f7581459875b637068e9ed900004d0d166efd51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36811",
+					"10.65.0.27:36811",
+					"172.17.0.1:36811",
+					"172.18.0.1:36811",
+					"172.19.0.1:36811"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:50:57.621416223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7540982333003941,
+				"StableID":   "n2wRtUpKt121CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8eb2c055e9eca6aa3351f7678bd6abf05a90f098630b3b2f3ab03390fba8fc07",
+				"KeyExpiry":  "2026-11-08T21:50:58Z",
+				"DiscoKey":   "discokey:67b23576ebaab173e36d282ea01095f0ccc7c3c023e7bc50f2b17d4acaa26a67",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34276",
+					"10.65.0.27:34276",
+					"172.17.0.1:34276",
+					"172.18.0.1:34276",
+					"172.19.0.1:34276"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:50:58.184084138Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4803304395061543,
+				"StableID":   "nUhQFNfRWe11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8006cacc76d819a8dd1736b54d7f4f8d642f176bd069242f250d1695b9fd346d",
+				"KeyExpiry":  "2026-11-08T21:50:58Z",
+				"DiscoKey":   "discokey:a713fab733bfe980c034fe8d28c0396a52a8e141c0c4f21aa1b047d53714e432",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35344",
+					"10.65.0.27:35344",
+					"172.17.0.1:35344",
+					"172.18.0.1:35344",
+					"172.19.0.1:35344"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:50:58.702458496Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4382350036694651,
+				"StableID":   "n4qD6TumDb11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b9a0f3e20759548f3c672ba2e63c8eb3cbbfc23a818cb68ff2d5a82fbdb77805",
+				"KeyExpiry":  "2026-11-08T21:50:59Z",
+				"DiscoKey":   "discokey:4ac4396dd0e2f5d0c4cec4115cbe35ce77ce101aad6b81652770c5813b4f811e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:32851",
+					"10.65.0.27:32851",
+					"172.17.0.1:32851",
+					"172.18.0.1:32851",
+					"172.19.0.1:32851"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:50:59.238113861Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8155594954834163": {
+				"ID":          8155594954834163,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6837257259921048,
+				"StableID":   "njkMyw9cPv11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       6837257259921048,
+				"Key":        "nodekey:a4c4221032a4c26cf6cd69d668102971b3023991d0e512f804289394a0448f2d",
+				"DiscoKey":   "discokey:4c761ac683acfdd6981c51ed632ffc59e11748648f87af6d215a5be409db930a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48344",
+					"10.65.0.27:48344",
+					"172.17.0.1:48344",
+					"172.18.0.1:48344",
+					"172.19.0.1:48344"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:50:54.92809966Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a4c4221032a4c26cf6cd69d668102971b3023991d0e512f804289394a0448f2d",
+			"MachineKey": "mkey:ba1cae1dab5143a2fb34afa52ba5beafa8b48ca22f2e8f412f418a836d9f8d1f",
+			"Peers": [{
+				"ID":         968680837477776,
+				"StableID":   "nqZwWybiZ811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ffd5c87946d681fb584ee51bd06ed4e51d2a8cd2c832436dfd6b5783e9e8b37",
+				"DiscoKey":   "discokey:1205ba137a2de6c7ef967d4f4c022ff6a20f2e1f959975d7bb35921541419330",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:57835",
+					"10.65.0.27:57835",
+					"172.17.0.1:57835",
+					"172.18.0.1:57835",
+					"172.19.0.1:57835"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:50:51.68571398Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5260154043304652,
+				"StableID":   "nXepFyKL5i11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28db6e7978c9f2f885a63d2f6ffa4fb3cd128070c868ced5a1d29c5c2c179543",
+				"DiscoKey":   "discokey:25a9e9c373600720a7e16efff1e5e8993ed4fafd022be72d1cc314ad4a6d4847",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50616",
+					"10.65.0.27:50616",
+					"172.17.0.1:50616",
+					"172.18.0.1:50616",
+					"172.19.0.1:50616"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:50:52.230388804Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         26853145814640,
+				"StableID":   "nD9QYRPAD111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9880579da6e1819130736f9ab4301432c181a7dcf0d95a9f408dd2fe44e32b1d",
+				"DiscoKey":   "discokey:df13acdcdebdd05c81fea462946c607b0d19f96966ef61fe30be99d6c1fc4743",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53241",
+					"10.65.0.27:53241",
+					"172.17.0.1:53241",
+					"172.18.0.1:53241",
+					"172.19.0.1:53241"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:50:52.770679863Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8155594954834163,
+				"StableID":   "nQssdhegg621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0e179857c0adcb3cfbe558fc76bcfdf4d5c819bf9215fbd02fe8a79e96fde02",
+				"DiscoKey":   "discokey:9918256c5e1c313a1de71ff68cac3b87a36c890baaa8fdf9748f73da7cf58433",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51886",
+					"10.65.0.27:51886",
+					"172.17.0.1:51886",
+					"172.18.0.1:51886",
+					"172.19.0.1:51886"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:50:53.307812557Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3719056762313891,
+				"StableID":   "nk5umFKN3W11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f317cd9b223c1f14fd9dd1c491f54298332c43aa6a222a8230e3539896c98503",
+				"DiscoKey":   "discokey:f50499f376496e23c219e8ecb1fdb75c25ef029ac807d3129382375db874751d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33406",
+					"10.65.0.27:33406",
+					"172.17.0.1:33406",
+					"172.18.0.1:33406",
+					"172.19.0.1:33406"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:50:53.858003446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7237902144095889,
+				"StableID":   "nLneS8R4Xy11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b19e27a86bcc1b60c4edfa744fce1772da8144d1fc1047447e205d39de554f7a",
+				"DiscoKey":   "discokey:cc91bdff6247e1b6f592aa4301f48cbef433c6684057ad8a6f6bd272496b5b41",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53839",
+					"10.65.0.27:53839",
+					"172.17.0.1:53839",
+					"172.18.0.1:53839",
+					"172.19.0.1:53839"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:50:54.388481816Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3401762228091282,
+				"StableID":   "nZGvJUXfZT11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b82b5c77b3c67b82ec5fc454c17cd26bc1a6d288defbd0047fc6ce77ffbfdf73",
+				"DiscoKey":   "discokey:0dbe56a371694b7b2e2f5ccd20b072fc256a434fffdef9ed9e1fb27d6670527c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52046",
+					"10.65.0.27:52046",
+					"172.17.0.1:52046",
+					"172.18.0.1:52046",
+					"172.19.0.1:52046"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:50:55.473629781Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8097669955681323,
+				"StableID":   "ntPJpP4TE621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ace813b8ee5954947c37f526af381f31aed93892714f8f506a20ac165d586b48",
+				"DiscoKey":   "discokey:5ae62e13077fa6798bab0e3836e4973dcd0b03aa512e4ce5c0fd2981f78c9113",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48858",
+					"10.65.0.27:48858",
+					"172.17.0.1:48858",
+					"172.18.0.1:48858",
+					"172.19.0.1:48858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:50:56.003451711Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5921762583239446,
+				"StableID":   "njsjMNfyEo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c17d80d9c65794f3dc0765708f597a4eaf7daa8c4153f5b68c6c4c44d6e3547",
+				"DiscoKey":   "discokey:acde5212a7e81340cc1a031cddb7b9e693fc05cd0253876b80b58bf22e461249",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56300",
+					"10.65.0.27:56300",
+					"172.17.0.1:56300",
+					"172.18.0.1:56300",
+					"172.19.0.1:56300"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:50:56.537801395Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4912179265883428,
+				"StableID":   "nPWzkwcjMf11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9897edf24079fbcb7278ff680f06da5abe2547bada4f7a9333819f766375b00a",
+				"DiscoKey":   "discokey:d88f87bb9575f8e7d3d69da254b510a1c9d4b9b51c64b768f6f0e66736617945",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36850",
+					"10.65.0.27:36850",
+					"172.17.0.1:36850",
+					"172.18.0.1:36850",
+					"172.19.0.1:36850"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:50:57.089625315Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         269944687634845,
+				"StableID":   "nv9XfNzF7311CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2faec7c09f5595929002d75a12bd06c3027fcbc0ce39c1bc679e0350ba88ee01",
+				"DiscoKey":   "discokey:7a8022a8b86b52a2c33fe7bf6f7581459875b637068e9ed900004d0d166efd51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36811",
+					"10.65.0.27:36811",
+					"172.17.0.1:36811",
+					"172.18.0.1:36811",
+					"172.19.0.1:36811"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:50:57.621416223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7540982333003941,
+				"StableID":   "n2wRtUpKt121CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8eb2c055e9eca6aa3351f7678bd6abf05a90f098630b3b2f3ab03390fba8fc07",
+				"KeyExpiry":  "2026-11-08T21:50:58Z",
+				"DiscoKey":   "discokey:67b23576ebaab173e36d282ea01095f0ccc7c3c023e7bc50f2b17d4acaa26a67",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34276",
+					"10.65.0.27:34276",
+					"172.17.0.1:34276",
+					"172.18.0.1:34276",
+					"172.19.0.1:34276"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:50:58.184084138Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4803304395061543,
+				"StableID":   "nUhQFNfRWe11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8006cacc76d819a8dd1736b54d7f4f8d642f176bd069242f250d1695b9fd346d",
+				"KeyExpiry":  "2026-11-08T21:50:58Z",
+				"DiscoKey":   "discokey:a713fab733bfe980c034fe8d28c0396a52a8e141c0c4f21aa1b047d53714e432",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35344",
+					"10.65.0.27:35344",
+					"172.17.0.1:35344",
+					"172.18.0.1:35344",
+					"172.19.0.1:35344"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:50:58.702458496Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4382350036694651,
+				"StableID":   "n4qD6TumDb11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b9a0f3e20759548f3c672ba2e63c8eb3cbbfc23a818cb68ff2d5a82fbdb77805",
+				"KeyExpiry":  "2026-11-08T21:50:59Z",
+				"DiscoKey":   "discokey:4ac4396dd0e2f5d0c4cec4115cbe35ce77ce101aad6b81652770c5813b4f811e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:32851",
+					"10.65.0.27:32851",
+					"172.17.0.1:32851",
+					"172.18.0.1:32851",
+					"172.19.0.1:32851"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:50:59.238113861Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6837257259921048": {
+				"ID":          6837257259921048,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8097669955681323,
+				"StableID":   "ntPJpP4TE621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       8097669955681323,
+				"Key":        "nodekey:ace813b8ee5954947c37f526af381f31aed93892714f8f506a20ac165d586b48",
+				"DiscoKey":   "discokey:5ae62e13077fa6798bab0e3836e4973dcd0b03aa512e4ce5c0fd2981f78c9113",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48858",
+					"10.65.0.27:48858",
+					"172.17.0.1:48858",
+					"172.18.0.1:48858",
+					"172.19.0.1:48858"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:50:56.003451711Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ace813b8ee5954947c37f526af381f31aed93892714f8f506a20ac165d586b48",
+			"MachineKey": "mkey:fd6aef6ada6b3aef8f60b0625c6e30cafce5f49e8824f7ab8fb91a66a00c9e32",
+			"Peers": [{
+				"ID":         968680837477776,
+				"StableID":   "nqZwWybiZ811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ffd5c87946d681fb584ee51bd06ed4e51d2a8cd2c832436dfd6b5783e9e8b37",
+				"DiscoKey":   "discokey:1205ba137a2de6c7ef967d4f4c022ff6a20f2e1f959975d7bb35921541419330",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:57835",
+					"10.65.0.27:57835",
+					"172.17.0.1:57835",
+					"172.18.0.1:57835",
+					"172.19.0.1:57835"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:50:51.68571398Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5260154043304652,
+				"StableID":   "nXepFyKL5i11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28db6e7978c9f2f885a63d2f6ffa4fb3cd128070c868ced5a1d29c5c2c179543",
+				"DiscoKey":   "discokey:25a9e9c373600720a7e16efff1e5e8993ed4fafd022be72d1cc314ad4a6d4847",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50616",
+					"10.65.0.27:50616",
+					"172.17.0.1:50616",
+					"172.18.0.1:50616",
+					"172.19.0.1:50616"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:50:52.230388804Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         26853145814640,
+				"StableID":   "nD9QYRPAD111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9880579da6e1819130736f9ab4301432c181a7dcf0d95a9f408dd2fe44e32b1d",
+				"DiscoKey":   "discokey:df13acdcdebdd05c81fea462946c607b0d19f96966ef61fe30be99d6c1fc4743",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53241",
+					"10.65.0.27:53241",
+					"172.17.0.1:53241",
+					"172.18.0.1:53241",
+					"172.19.0.1:53241"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:50:52.770679863Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8155594954834163,
+				"StableID":   "nQssdhegg621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0e179857c0adcb3cfbe558fc76bcfdf4d5c819bf9215fbd02fe8a79e96fde02",
+				"DiscoKey":   "discokey:9918256c5e1c313a1de71ff68cac3b87a36c890baaa8fdf9748f73da7cf58433",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51886",
+					"10.65.0.27:51886",
+					"172.17.0.1:51886",
+					"172.18.0.1:51886",
+					"172.19.0.1:51886"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:50:53.307812557Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3719056762313891,
+				"StableID":   "nk5umFKN3W11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f317cd9b223c1f14fd9dd1c491f54298332c43aa6a222a8230e3539896c98503",
+				"DiscoKey":   "discokey:f50499f376496e23c219e8ecb1fdb75c25ef029ac807d3129382375db874751d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33406",
+					"10.65.0.27:33406",
+					"172.17.0.1:33406",
+					"172.18.0.1:33406",
+					"172.19.0.1:33406"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:50:53.858003446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7237902144095889,
+				"StableID":   "nLneS8R4Xy11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b19e27a86bcc1b60c4edfa744fce1772da8144d1fc1047447e205d39de554f7a",
+				"DiscoKey":   "discokey:cc91bdff6247e1b6f592aa4301f48cbef433c6684057ad8a6f6bd272496b5b41",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53839",
+					"10.65.0.27:53839",
+					"172.17.0.1:53839",
+					"172.18.0.1:53839",
+					"172.19.0.1:53839"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:50:54.388481816Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6837257259921048,
+				"StableID":   "njkMyw9cPv11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4c4221032a4c26cf6cd69d668102971b3023991d0e512f804289394a0448f2d",
+				"DiscoKey":   "discokey:4c761ac683acfdd6981c51ed632ffc59e11748648f87af6d215a5be409db930a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48344",
+					"10.65.0.27:48344",
+					"172.17.0.1:48344",
+					"172.18.0.1:48344",
+					"172.19.0.1:48344"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:50:54.92809966Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3401762228091282,
+				"StableID":   "nZGvJUXfZT11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b82b5c77b3c67b82ec5fc454c17cd26bc1a6d288defbd0047fc6ce77ffbfdf73",
+				"DiscoKey":   "discokey:0dbe56a371694b7b2e2f5ccd20b072fc256a434fffdef9ed9e1fb27d6670527c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52046",
+					"10.65.0.27:52046",
+					"172.17.0.1:52046",
+					"172.18.0.1:52046",
+					"172.19.0.1:52046"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:50:55.473629781Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5921762583239446,
+				"StableID":   "njsjMNfyEo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c17d80d9c65794f3dc0765708f597a4eaf7daa8c4153f5b68c6c4c44d6e3547",
+				"DiscoKey":   "discokey:acde5212a7e81340cc1a031cddb7b9e693fc05cd0253876b80b58bf22e461249",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56300",
+					"10.65.0.27:56300",
+					"172.17.0.1:56300",
+					"172.18.0.1:56300",
+					"172.19.0.1:56300"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:50:56.537801395Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4912179265883428,
+				"StableID":   "nPWzkwcjMf11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9897edf24079fbcb7278ff680f06da5abe2547bada4f7a9333819f766375b00a",
+				"DiscoKey":   "discokey:d88f87bb9575f8e7d3d69da254b510a1c9d4b9b51c64b768f6f0e66736617945",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36850",
+					"10.65.0.27:36850",
+					"172.17.0.1:36850",
+					"172.18.0.1:36850",
+					"172.19.0.1:36850"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:50:57.089625315Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         269944687634845,
+				"StableID":   "nv9XfNzF7311CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2faec7c09f5595929002d75a12bd06c3027fcbc0ce39c1bc679e0350ba88ee01",
+				"DiscoKey":   "discokey:7a8022a8b86b52a2c33fe7bf6f7581459875b637068e9ed900004d0d166efd51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36811",
+					"10.65.0.27:36811",
+					"172.17.0.1:36811",
+					"172.18.0.1:36811",
+					"172.19.0.1:36811"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:50:57.621416223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7540982333003941,
+				"StableID":   "n2wRtUpKt121CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8eb2c055e9eca6aa3351f7678bd6abf05a90f098630b3b2f3ab03390fba8fc07",
+				"KeyExpiry":  "2026-11-08T21:50:58Z",
+				"DiscoKey":   "discokey:67b23576ebaab173e36d282ea01095f0ccc7c3c023e7bc50f2b17d4acaa26a67",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34276",
+					"10.65.0.27:34276",
+					"172.17.0.1:34276",
+					"172.18.0.1:34276",
+					"172.19.0.1:34276"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:50:58.184084138Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4803304395061543,
+				"StableID":   "nUhQFNfRWe11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8006cacc76d819a8dd1736b54d7f4f8d642f176bd069242f250d1695b9fd346d",
+				"KeyExpiry":  "2026-11-08T21:50:58Z",
+				"DiscoKey":   "discokey:a713fab733bfe980c034fe8d28c0396a52a8e141c0c4f21aa1b047d53714e432",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35344",
+					"10.65.0.27:35344",
+					"172.17.0.1:35344",
+					"172.18.0.1:35344",
+					"172.19.0.1:35344"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:50:58.702458496Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4382350036694651,
+				"StableID":   "n4qD6TumDb11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b9a0f3e20759548f3c672ba2e63c8eb3cbbfc23a818cb68ff2d5a82fbdb77805",
+				"KeyExpiry":  "2026-11-08T21:50:59Z",
+				"DiscoKey":   "discokey:4ac4396dd0e2f5d0c4cec4115cbe35ce77ce101aad6b81652770c5813b4f811e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:32851",
+					"10.65.0.27:32851",
+					"172.17.0.1:32851",
+					"172.18.0.1:32851",
+					"172.19.0.1:32851"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:50:59.238113861Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8097669955681323": {
+				"ID":          8097669955681323,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4803304395061543,
+				"StableID":   "nUhQFNfRWe11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8006cacc76d819a8dd1736b54d7f4f8d642f176bd069242f250d1695b9fd346d",
+				"KeyExpiry":  "2026-11-08T21:50:58Z",
+				"DiscoKey":   "discokey:a713fab733bfe980c034fe8d28c0396a52a8e141c0c4f21aa1b047d53714e432",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35344",
+					"10.65.0.27:35344",
+					"172.17.0.1:35344",
+					"172.18.0.1:35344",
+					"172.19.0.1:35344"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:50:58.702458496Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8006cacc76d819a8dd1736b54d7f4f8d642f176bd069242f250d1695b9fd346d",
+			"MachineKey": "mkey:c34a3863902a59c12c59981c17308cff8ea8daa05af4f5be6d89c07074784a43",
+			"Peers": [{
+				"ID":         968680837477776,
+				"StableID":   "nqZwWybiZ811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ffd5c87946d681fb584ee51bd06ed4e51d2a8cd2c832436dfd6b5783e9e8b37",
+				"DiscoKey":   "discokey:1205ba137a2de6c7ef967d4f4c022ff6a20f2e1f959975d7bb35921541419330",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:57835",
+					"10.65.0.27:57835",
+					"172.17.0.1:57835",
+					"172.18.0.1:57835",
+					"172.19.0.1:57835"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:50:51.68571398Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5260154043304652,
+				"StableID":   "nXepFyKL5i11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28db6e7978c9f2f885a63d2f6ffa4fb3cd128070c868ced5a1d29c5c2c179543",
+				"DiscoKey":   "discokey:25a9e9c373600720a7e16efff1e5e8993ed4fafd022be72d1cc314ad4a6d4847",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50616",
+					"10.65.0.27:50616",
+					"172.17.0.1:50616",
+					"172.18.0.1:50616",
+					"172.19.0.1:50616"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:50:52.230388804Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         26853145814640,
+				"StableID":   "nD9QYRPAD111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9880579da6e1819130736f9ab4301432c181a7dcf0d95a9f408dd2fe44e32b1d",
+				"DiscoKey":   "discokey:df13acdcdebdd05c81fea462946c607b0d19f96966ef61fe30be99d6c1fc4743",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53241",
+					"10.65.0.27:53241",
+					"172.17.0.1:53241",
+					"172.18.0.1:53241",
+					"172.19.0.1:53241"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:50:52.770679863Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8155594954834163,
+				"StableID":   "nQssdhegg621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0e179857c0adcb3cfbe558fc76bcfdf4d5c819bf9215fbd02fe8a79e96fde02",
+				"DiscoKey":   "discokey:9918256c5e1c313a1de71ff68cac3b87a36c890baaa8fdf9748f73da7cf58433",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51886",
+					"10.65.0.27:51886",
+					"172.17.0.1:51886",
+					"172.18.0.1:51886",
+					"172.19.0.1:51886"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:50:53.307812557Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3719056762313891,
+				"StableID":   "nk5umFKN3W11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f317cd9b223c1f14fd9dd1c491f54298332c43aa6a222a8230e3539896c98503",
+				"DiscoKey":   "discokey:f50499f376496e23c219e8ecb1fdb75c25ef029ac807d3129382375db874751d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33406",
+					"10.65.0.27:33406",
+					"172.17.0.1:33406",
+					"172.18.0.1:33406",
+					"172.19.0.1:33406"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:50:53.858003446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7237902144095889,
+				"StableID":   "nLneS8R4Xy11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b19e27a86bcc1b60c4edfa744fce1772da8144d1fc1047447e205d39de554f7a",
+				"DiscoKey":   "discokey:cc91bdff6247e1b6f592aa4301f48cbef433c6684057ad8a6f6bd272496b5b41",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53839",
+					"10.65.0.27:53839",
+					"172.17.0.1:53839",
+					"172.18.0.1:53839",
+					"172.19.0.1:53839"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:50:54.388481816Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6837257259921048,
+				"StableID":   "njkMyw9cPv11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4c4221032a4c26cf6cd69d668102971b3023991d0e512f804289394a0448f2d",
+				"DiscoKey":   "discokey:4c761ac683acfdd6981c51ed632ffc59e11748648f87af6d215a5be409db930a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48344",
+					"10.65.0.27:48344",
+					"172.17.0.1:48344",
+					"172.18.0.1:48344",
+					"172.19.0.1:48344"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:50:54.92809966Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3401762228091282,
+				"StableID":   "nZGvJUXfZT11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b82b5c77b3c67b82ec5fc454c17cd26bc1a6d288defbd0047fc6ce77ffbfdf73",
+				"DiscoKey":   "discokey:0dbe56a371694b7b2e2f5ccd20b072fc256a434fffdef9ed9e1fb27d6670527c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52046",
+					"10.65.0.27:52046",
+					"172.17.0.1:52046",
+					"172.18.0.1:52046",
+					"172.19.0.1:52046"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:50:55.473629781Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8097669955681323,
+				"StableID":   "ntPJpP4TE621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ace813b8ee5954947c37f526af381f31aed93892714f8f506a20ac165d586b48",
+				"DiscoKey":   "discokey:5ae62e13077fa6798bab0e3836e4973dcd0b03aa512e4ce5c0fd2981f78c9113",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48858",
+					"10.65.0.27:48858",
+					"172.17.0.1:48858",
+					"172.18.0.1:48858",
+					"172.19.0.1:48858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:50:56.003451711Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5921762583239446,
+				"StableID":   "njsjMNfyEo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c17d80d9c65794f3dc0765708f597a4eaf7daa8c4153f5b68c6c4c44d6e3547",
+				"DiscoKey":   "discokey:acde5212a7e81340cc1a031cddb7b9e693fc05cd0253876b80b58bf22e461249",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56300",
+					"10.65.0.27:56300",
+					"172.17.0.1:56300",
+					"172.18.0.1:56300",
+					"172.19.0.1:56300"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:50:56.537801395Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4912179265883428,
+				"StableID":   "nPWzkwcjMf11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9897edf24079fbcb7278ff680f06da5abe2547bada4f7a9333819f766375b00a",
+				"DiscoKey":   "discokey:d88f87bb9575f8e7d3d69da254b510a1c9d4b9b51c64b768f6f0e66736617945",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36850",
+					"10.65.0.27:36850",
+					"172.17.0.1:36850",
+					"172.18.0.1:36850",
+					"172.19.0.1:36850"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:50:57.089625315Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         269944687634845,
+				"StableID":   "nv9XfNzF7311CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2faec7c09f5595929002d75a12bd06c3027fcbc0ce39c1bc679e0350ba88ee01",
+				"DiscoKey":   "discokey:7a8022a8b86b52a2c33fe7bf6f7581459875b637068e9ed900004d0d166efd51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36811",
+					"10.65.0.27:36811",
+					"172.17.0.1:36811",
+					"172.18.0.1:36811",
+					"172.19.0.1:36811"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:50:57.621416223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7540982333003941,
+				"StableID":   "n2wRtUpKt121CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8eb2c055e9eca6aa3351f7678bd6abf05a90f098630b3b2f3ab03390fba8fc07",
+				"KeyExpiry":  "2026-11-08T21:50:58Z",
+				"DiscoKey":   "discokey:67b23576ebaab173e36d282ea01095f0ccc7c3c023e7bc50f2b17d4acaa26a67",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34276",
+					"10.65.0.27:34276",
+					"172.17.0.1:34276",
+					"172.18.0.1:34276",
+					"172.19.0.1:34276"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:50:58.184084138Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4382350036694651,
+				"StableID":   "n4qD6TumDb11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b9a0f3e20759548f3c672ba2e63c8eb3cbbfc23a818cb68ff2d5a82fbdb77805",
+				"KeyExpiry":  "2026-11-08T21:50:59Z",
+				"DiscoKey":   "discokey:4ac4396dd0e2f5d0c4cec4115cbe35ce77ce101aad6b81652770c5813b4f811e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:32851",
+					"10.65.0.27:32851",
+					"172.17.0.1:32851",
+					"172.18.0.1:32851",
+					"172.19.0.1:32851"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:50:59.238113861Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5921762583239446,
+				"StableID":   "njsjMNfyEo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       5921762583239446,
+				"Key":        "nodekey:8c17d80d9c65794f3dc0765708f597a4eaf7daa8c4153f5b68c6c4c44d6e3547",
+				"DiscoKey":   "discokey:acde5212a7e81340cc1a031cddb7b9e693fc05cd0253876b80b58bf22e461249",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56300",
+					"10.65.0.27:56300",
+					"172.17.0.1:56300",
+					"172.18.0.1:56300",
+					"172.19.0.1:56300"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:50:56.537801395Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8c17d80d9c65794f3dc0765708f597a4eaf7daa8c4153f5b68c6c4c44d6e3547",
+			"MachineKey": "mkey:aed443063ada14a3537f7f7dcd70ff061b7ca377ad0fe970c7667983e07be54d",
+			"Peers": [{
+				"ID":         968680837477776,
+				"StableID":   "nqZwWybiZ811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ffd5c87946d681fb584ee51bd06ed4e51d2a8cd2c832436dfd6b5783e9e8b37",
+				"DiscoKey":   "discokey:1205ba137a2de6c7ef967d4f4c022ff6a20f2e1f959975d7bb35921541419330",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:57835",
+					"10.65.0.27:57835",
+					"172.17.0.1:57835",
+					"172.18.0.1:57835",
+					"172.19.0.1:57835"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:50:51.68571398Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5260154043304652,
+				"StableID":   "nXepFyKL5i11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28db6e7978c9f2f885a63d2f6ffa4fb3cd128070c868ced5a1d29c5c2c179543",
+				"DiscoKey":   "discokey:25a9e9c373600720a7e16efff1e5e8993ed4fafd022be72d1cc314ad4a6d4847",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50616",
+					"10.65.0.27:50616",
+					"172.17.0.1:50616",
+					"172.18.0.1:50616",
+					"172.19.0.1:50616"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:50:52.230388804Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         26853145814640,
+				"StableID":   "nD9QYRPAD111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9880579da6e1819130736f9ab4301432c181a7dcf0d95a9f408dd2fe44e32b1d",
+				"DiscoKey":   "discokey:df13acdcdebdd05c81fea462946c607b0d19f96966ef61fe30be99d6c1fc4743",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53241",
+					"10.65.0.27:53241",
+					"172.17.0.1:53241",
+					"172.18.0.1:53241",
+					"172.19.0.1:53241"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:50:52.770679863Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8155594954834163,
+				"StableID":   "nQssdhegg621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0e179857c0adcb3cfbe558fc76bcfdf4d5c819bf9215fbd02fe8a79e96fde02",
+				"DiscoKey":   "discokey:9918256c5e1c313a1de71ff68cac3b87a36c890baaa8fdf9748f73da7cf58433",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51886",
+					"10.65.0.27:51886",
+					"172.17.0.1:51886",
+					"172.18.0.1:51886",
+					"172.19.0.1:51886"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:50:53.307812557Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3719056762313891,
+				"StableID":   "nk5umFKN3W11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f317cd9b223c1f14fd9dd1c491f54298332c43aa6a222a8230e3539896c98503",
+				"DiscoKey":   "discokey:f50499f376496e23c219e8ecb1fdb75c25ef029ac807d3129382375db874751d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33406",
+					"10.65.0.27:33406",
+					"172.17.0.1:33406",
+					"172.18.0.1:33406",
+					"172.19.0.1:33406"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:50:53.858003446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7237902144095889,
+				"StableID":   "nLneS8R4Xy11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b19e27a86bcc1b60c4edfa744fce1772da8144d1fc1047447e205d39de554f7a",
+				"DiscoKey":   "discokey:cc91bdff6247e1b6f592aa4301f48cbef433c6684057ad8a6f6bd272496b5b41",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53839",
+					"10.65.0.27:53839",
+					"172.17.0.1:53839",
+					"172.18.0.1:53839",
+					"172.19.0.1:53839"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:50:54.388481816Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6837257259921048,
+				"StableID":   "njkMyw9cPv11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4c4221032a4c26cf6cd69d668102971b3023991d0e512f804289394a0448f2d",
+				"DiscoKey":   "discokey:4c761ac683acfdd6981c51ed632ffc59e11748648f87af6d215a5be409db930a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48344",
+					"10.65.0.27:48344",
+					"172.17.0.1:48344",
+					"172.18.0.1:48344",
+					"172.19.0.1:48344"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:50:54.92809966Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3401762228091282,
+				"StableID":   "nZGvJUXfZT11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b82b5c77b3c67b82ec5fc454c17cd26bc1a6d288defbd0047fc6ce77ffbfdf73",
+				"DiscoKey":   "discokey:0dbe56a371694b7b2e2f5ccd20b072fc256a434fffdef9ed9e1fb27d6670527c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52046",
+					"10.65.0.27:52046",
+					"172.17.0.1:52046",
+					"172.18.0.1:52046",
+					"172.19.0.1:52046"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:50:55.473629781Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8097669955681323,
+				"StableID":   "ntPJpP4TE621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ace813b8ee5954947c37f526af381f31aed93892714f8f506a20ac165d586b48",
+				"DiscoKey":   "discokey:5ae62e13077fa6798bab0e3836e4973dcd0b03aa512e4ce5c0fd2981f78c9113",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48858",
+					"10.65.0.27:48858",
+					"172.17.0.1:48858",
+					"172.18.0.1:48858",
+					"172.19.0.1:48858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:50:56.003451711Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4912179265883428,
+				"StableID":   "nPWzkwcjMf11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9897edf24079fbcb7278ff680f06da5abe2547bada4f7a9333819f766375b00a",
+				"DiscoKey":   "discokey:d88f87bb9575f8e7d3d69da254b510a1c9d4b9b51c64b768f6f0e66736617945",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36850",
+					"10.65.0.27:36850",
+					"172.17.0.1:36850",
+					"172.18.0.1:36850",
+					"172.19.0.1:36850"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:50:57.089625315Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         269944687634845,
+				"StableID":   "nv9XfNzF7311CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2faec7c09f5595929002d75a12bd06c3027fcbc0ce39c1bc679e0350ba88ee01",
+				"DiscoKey":   "discokey:7a8022a8b86b52a2c33fe7bf6f7581459875b637068e9ed900004d0d166efd51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36811",
+					"10.65.0.27:36811",
+					"172.17.0.1:36811",
+					"172.18.0.1:36811",
+					"172.19.0.1:36811"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:50:57.621416223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7540982333003941,
+				"StableID":   "n2wRtUpKt121CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8eb2c055e9eca6aa3351f7678bd6abf05a90f098630b3b2f3ab03390fba8fc07",
+				"KeyExpiry":  "2026-11-08T21:50:58Z",
+				"DiscoKey":   "discokey:67b23576ebaab173e36d282ea01095f0ccc7c3c023e7bc50f2b17d4acaa26a67",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34276",
+					"10.65.0.27:34276",
+					"172.17.0.1:34276",
+					"172.18.0.1:34276",
+					"172.19.0.1:34276"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:50:58.184084138Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4803304395061543,
+				"StableID":   "nUhQFNfRWe11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8006cacc76d819a8dd1736b54d7f4f8d642f176bd069242f250d1695b9fd346d",
+				"KeyExpiry":  "2026-11-08T21:50:58Z",
+				"DiscoKey":   "discokey:a713fab733bfe980c034fe8d28c0396a52a8e141c0c4f21aa1b047d53714e432",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35344",
+					"10.65.0.27:35344",
+					"172.17.0.1:35344",
+					"172.18.0.1:35344",
+					"172.19.0.1:35344"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:50:58.702458496Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4382350036694651,
+				"StableID":   "n4qD6TumDb11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b9a0f3e20759548f3c672ba2e63c8eb3cbbfc23a818cb68ff2d5a82fbdb77805",
+				"KeyExpiry":  "2026-11-08T21:50:59Z",
+				"DiscoKey":   "discokey:4ac4396dd0e2f5d0c4cec4115cbe35ce77ce101aad6b81652770c5813b4f811e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:32851",
+					"10.65.0.27:32851",
+					"172.17.0.1:32851",
+					"172.18.0.1:32851",
+					"172.19.0.1:32851"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:50:59.238113861Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5921762583239446": {
+				"ID":          5921762583239446,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-action-empty.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-action-empty.hujson
@@ -1,0 +1,20081 @@
+// ssh-malformed-action-empty
+//
+// ssh action empty string is rejected
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T21:51:35Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-malformed-action-empty",
+	"description":    "ssh action empty string is rejected",
+	"category":       "ssh",
+	"captured_at":    "2026-05-12T21:51:35.296978541Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "action must be specified"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                             \n  \n                              \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh action empty string is rejected\",\n\t\"id\":          \"ssh-malformed-action-empty\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"autogroup:member\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-malformed/ssh-malformed-action-empty.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "",
+				"dst":    ["tag:server"],
+				"src":    ["autogroup:member"],
+				"users":  ["root"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3983629297884225,
+				"StableID":   "naRskpBC7Y11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       3983629297884225,
+				"Key":        "nodekey:a114b46675991ab6e62632b5c5f5d3bf3e94dabf03505f444aed2bcd68999d55",
+				"DiscoKey":   "discokey:e2cda9587784a622bdd15c4c1f626c591e2ad814ca3153f27a22d706113f8d5a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:55724",
+					"10.65.0.27:55724",
+					"172.17.0.1:55724",
+					"172.18.0.1:55724",
+					"172.19.0.1:55724"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:51:44.523493178Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a114b46675991ab6e62632b5c5f5d3bf3e94dabf03505f444aed2bcd68999d55",
+			"MachineKey": "mkey:fc1a9439bc66bfec43f15f1ed41599aa7cf5c337082925974168a0fa70ac6606",
+			"Peers": [{
+				"ID":         3740735190292067,
+				"StableID":   "nUumDgmBDW11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c54cd3f2733c308db78096efbe6197089911891a7d8e10b20442576d67246d2f",
+				"DiscoKey":   "discokey:a00fa6830438f7af48ba8625bdac76b49db54c2831d1fdbee51f13e433d12664",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:60844",
+					"10.65.0.27:60844",
+					"172.17.0.1:60844",
+					"172.18.0.1:60844",
+					"172.19.0.1:60844"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:51:37.823637125Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7170555244955655,
+				"StableID":   "n28sayKZzx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cbecf899f3a6e80cf6000d5eba1b79f173fafead63b49d97d9a167b1f5239a76",
+				"DiscoKey":   "discokey:73faf4c6ef724a76d075d64aee4dee679b7335bab6cce281fe90646b31574a45",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40044",
+					"10.65.0.27:40044",
+					"172.17.0.1:40044",
+					"172.18.0.1:40044",
+					"172.19.0.1:40044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:51:38.329563385Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1943241934471156,
+				"StableID":   "nTxvRtf6BG11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:963a522773752726a3c32b2a9edec14877a84a102cb375b8bfb390ae5c192302",
+				"DiscoKey":   "discokey:db26fe36338aee76899472ce56519f72ce80691d4755ea36d2696373fdec3d54",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:44889",
+					"10.65.0.27:44889",
+					"172.17.0.1:44889",
+					"172.18.0.1:44889",
+					"172.19.0.1:44889"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:51:38.865247333Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2621170226034401,
+				"StableID":   "nQij6Sh8UM11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:caba25eb91ad0c35e2ce3782dac16d3b3dd31d555b8e406a9bdb24b891bbbe4d",
+				"DiscoKey":   "discokey:b0fe86e6c654f6862ef0f47b5f11ef2b40b36d3ff0626e8d540457b93b4d4949",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42859",
+					"10.65.0.27:42859",
+					"172.17.0.1:42859",
+					"172.18.0.1:42859",
+					"172.19.0.1:42859"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:51:39.412896526Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5071159392986909,
+				"StableID":   "nLvwBykjbg11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:60c65c038df4bcda1e567d718586346b198d8bb551886f826f76988959c75206",
+				"DiscoKey":   "discokey:91f11f812c508a90ecd1c9ec8e0f1233e64f4e14664c55fa8c59bcc1a71c5f44",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37471",
+					"10.65.0.27:37471",
+					"172.17.0.1:37471",
+					"172.18.0.1:37471",
+					"172.19.0.1:37471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:51:39.994715221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5097843118802719,
+				"StableID":   "nxuZfGhpog11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1d2962ddf14ba8c0a1fb24d9979d0bac319806525cc8bfbdc2dba4eda710118",
+				"DiscoKey":   "discokey:1f01b0d809bf6b35fb2ccecae788d839c95577493717a912bd2f88c12aec242e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39245",
+					"10.65.0.27:39245",
+					"172.17.0.1:39245",
+					"172.18.0.1:39245",
+					"172.19.0.1:39245"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:51:40.49365522Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6540106155930384,
+				"StableID":   "nyKaTvV25t11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1cda4660ab2df7c9e755447756ae9817d39f5eab6c57a31fc3dbb55a48af2c6c",
+				"DiscoKey":   "discokey:2274fcd7bcc61f82d4bcdebd50ca44e9ab7ab984fb43a0b50a2c9694dda4b162",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43819",
+					"10.65.0.27:43819",
+					"172.17.0.1:43819",
+					"172.18.0.1:43819",
+					"172.19.0.1:43819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:51:41.035462015Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6444673744224709,
+				"StableID":   "nSXf2meoKs11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b62999515789877c7ef800d988e2f9d98951ebf224463ddbf59d00fd1026fa32",
+				"DiscoKey":   "discokey:d58be7eefc0eaa415a497680047269197f06d9a2fe20930a892f1b12c71e2a50",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38003",
+					"10.65.0.27:38003",
+					"172.17.0.1:38003",
+					"172.18.0.1:38003",
+					"172.19.0.1:38003"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:51:41.605890793Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8764868429056629,
+				"StableID":   "nY8FCQEdSB21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e199a38fae627dfaff452c02f19bad662f2fe86abda72fd7e2c2702a1149b15",
+				"DiscoKey":   "discokey:346e022c2fb936b13f9ec7e0a36949c59b9b2d35d1a61aff9b3b6d4e33ab0d79",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53248",
+					"10.65.0.27:53248",
+					"172.17.0.1:53248",
+					"172.18.0.1:53248",
+					"172.19.0.1:53248"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:51:42.824577674Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4223447621657124,
+				"StableID":   "nDBvopooyZ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aac3b7b1280cac6b5928330d55d45daa07c02fc8900943baf8f3f79b8e67980c",
+				"DiscoKey":   "discokey:820fa969dc306c4cf52f0c29d8020c6d4ba292e9d8f28d9f3e504ce67fb12d1e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51080",
+					"10.65.0.27:51080",
+					"172.17.0.1:51080",
+					"172.18.0.1:51080",
+					"172.19.0.1:51080"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:51:43.439981461Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8100241366053895,
+				"StableID":   "nxZbY6ccF621CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fbcddd6df0764cde26ec82ece56ec7d003961c0a0a70a549896f6eed8f232d12",
+				"DiscoKey":   "discokey:cead8ea24d9a4416efb1166e29ed225ae9ff0a3dc994429c79a753088b19cc1f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41397",
+					"10.65.0.27:41397",
+					"172.17.0.1:41397",
+					"172.18.0.1:41397",
+					"172.19.0.1:41397"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:51:43.988243603Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8388054674282503,
+				"StableID":   "narJ2RyxV821CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:be680e169e4274024ba4d68cfb5d5f0ed0d4258bce27ed3fab54b482df3dca70",
+				"KeyExpiry":  "2026-11-08T21:51:45Z",
+				"DiscoKey":   "discokey:2f6143628ccdbcb58f9f4c5329d3678452f9669dd6f0e3222212d52c1a210861",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45313",
+					"10.65.0.27:45313",
+					"172.17.0.1:45313",
+					"172.18.0.1:45313",
+					"172.19.0.1:45313"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:51:45.068378828Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6571167376157198,
+				"StableID":   "nd6H8cR6Kt11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a33f4048e2b1ac9a2cb28d85a2bb6c91a64ae6c14341118a4f1e1518d68d7477",
+				"KeyExpiry":  "2026-11-08T21:51:45Z",
+				"DiscoKey":   "discokey:ce3284585a008b1b247aa7694af4a7af46c1bc9f3922cb6bbd327daf61cea534",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46040",
+					"10.65.0.27:46040",
+					"172.17.0.1:46040",
+					"172.18.0.1:46040",
+					"172.19.0.1:46040"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:51:45.724213033Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2056737066031535,
+				"StableID":   "nSrUZizV4H11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f871bb25d314e4e9f73fbb700492f2f12d54367142b028e215c816fd59a5ca27",
+				"KeyExpiry":  "2026-11-08T21:51:46Z",
+				"DiscoKey":   "discokey:ff1a96cd82ec6ea8e4988deba4a8542697f036d9ff8f396ac7bcc8f68547b835",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47753",
+					"10.65.0.27:47753",
+					"172.17.0.1:47753",
+					"172.18.0.1:47753",
+					"172.19.0.1:47753"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:51:46.402631464Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "3983629297884225": {
+				"ID":          3983629297884225,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5097843118802719,
+				"StableID":   "nxuZfGhpog11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       5097843118802719,
+				"Key":        "nodekey:c1d2962ddf14ba8c0a1fb24d9979d0bac319806525cc8bfbdc2dba4eda710118",
+				"DiscoKey":   "discokey:1f01b0d809bf6b35fb2ccecae788d839c95577493717a912bd2f88c12aec242e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39245",
+					"10.65.0.27:39245",
+					"172.17.0.1:39245",
+					"172.18.0.1:39245",
+					"172.19.0.1:39245"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:51:40.49365522Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c1d2962ddf14ba8c0a1fb24d9979d0bac319806525cc8bfbdc2dba4eda710118",
+			"MachineKey": "mkey:6e8e174a758d593b0e020865ef055ff7076c9e648315ebd8a99e05c83190ef40",
+			"Peers": [{
+				"ID":         3740735190292067,
+				"StableID":   "nUumDgmBDW11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c54cd3f2733c308db78096efbe6197089911891a7d8e10b20442576d67246d2f",
+				"DiscoKey":   "discokey:a00fa6830438f7af48ba8625bdac76b49db54c2831d1fdbee51f13e433d12664",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:60844",
+					"10.65.0.27:60844",
+					"172.17.0.1:60844",
+					"172.18.0.1:60844",
+					"172.19.0.1:60844"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:51:37.823637125Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7170555244955655,
+				"StableID":   "n28sayKZzx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cbecf899f3a6e80cf6000d5eba1b79f173fafead63b49d97d9a167b1f5239a76",
+				"DiscoKey":   "discokey:73faf4c6ef724a76d075d64aee4dee679b7335bab6cce281fe90646b31574a45",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40044",
+					"10.65.0.27:40044",
+					"172.17.0.1:40044",
+					"172.18.0.1:40044",
+					"172.19.0.1:40044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:51:38.329563385Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1943241934471156,
+				"StableID":   "nTxvRtf6BG11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:963a522773752726a3c32b2a9edec14877a84a102cb375b8bfb390ae5c192302",
+				"DiscoKey":   "discokey:db26fe36338aee76899472ce56519f72ce80691d4755ea36d2696373fdec3d54",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:44889",
+					"10.65.0.27:44889",
+					"172.17.0.1:44889",
+					"172.18.0.1:44889",
+					"172.19.0.1:44889"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:51:38.865247333Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2621170226034401,
+				"StableID":   "nQij6Sh8UM11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:caba25eb91ad0c35e2ce3782dac16d3b3dd31d555b8e406a9bdb24b891bbbe4d",
+				"DiscoKey":   "discokey:b0fe86e6c654f6862ef0f47b5f11ef2b40b36d3ff0626e8d540457b93b4d4949",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42859",
+					"10.65.0.27:42859",
+					"172.17.0.1:42859",
+					"172.18.0.1:42859",
+					"172.19.0.1:42859"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:51:39.412896526Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5071159392986909,
+				"StableID":   "nLvwBykjbg11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:60c65c038df4bcda1e567d718586346b198d8bb551886f826f76988959c75206",
+				"DiscoKey":   "discokey:91f11f812c508a90ecd1c9ec8e0f1233e64f4e14664c55fa8c59bcc1a71c5f44",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37471",
+					"10.65.0.27:37471",
+					"172.17.0.1:37471",
+					"172.18.0.1:37471",
+					"172.19.0.1:37471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:51:39.994715221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6540106155930384,
+				"StableID":   "nyKaTvV25t11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1cda4660ab2df7c9e755447756ae9817d39f5eab6c57a31fc3dbb55a48af2c6c",
+				"DiscoKey":   "discokey:2274fcd7bcc61f82d4bcdebd50ca44e9ab7ab984fb43a0b50a2c9694dda4b162",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43819",
+					"10.65.0.27:43819",
+					"172.17.0.1:43819",
+					"172.18.0.1:43819",
+					"172.19.0.1:43819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:51:41.035462015Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6444673744224709,
+				"StableID":   "nSXf2meoKs11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b62999515789877c7ef800d988e2f9d98951ebf224463ddbf59d00fd1026fa32",
+				"DiscoKey":   "discokey:d58be7eefc0eaa415a497680047269197f06d9a2fe20930a892f1b12c71e2a50",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38003",
+					"10.65.0.27:38003",
+					"172.17.0.1:38003",
+					"172.18.0.1:38003",
+					"172.19.0.1:38003"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:51:41.605890793Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8764868429056629,
+				"StableID":   "nY8FCQEdSB21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e199a38fae627dfaff452c02f19bad662f2fe86abda72fd7e2c2702a1149b15",
+				"DiscoKey":   "discokey:346e022c2fb936b13f9ec7e0a36949c59b9b2d35d1a61aff9b3b6d4e33ab0d79",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53248",
+					"10.65.0.27:53248",
+					"172.17.0.1:53248",
+					"172.18.0.1:53248",
+					"172.19.0.1:53248"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:51:42.824577674Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4223447621657124,
+				"StableID":   "nDBvopooyZ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aac3b7b1280cac6b5928330d55d45daa07c02fc8900943baf8f3f79b8e67980c",
+				"DiscoKey":   "discokey:820fa969dc306c4cf52f0c29d8020c6d4ba292e9d8f28d9f3e504ce67fb12d1e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51080",
+					"10.65.0.27:51080",
+					"172.17.0.1:51080",
+					"172.18.0.1:51080",
+					"172.19.0.1:51080"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:51:43.439981461Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8100241366053895,
+				"StableID":   "nxZbY6ccF621CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fbcddd6df0764cde26ec82ece56ec7d003961c0a0a70a549896f6eed8f232d12",
+				"DiscoKey":   "discokey:cead8ea24d9a4416efb1166e29ed225ae9ff0a3dc994429c79a753088b19cc1f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41397",
+					"10.65.0.27:41397",
+					"172.17.0.1:41397",
+					"172.18.0.1:41397",
+					"172.19.0.1:41397"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:51:43.988243603Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3983629297884225,
+				"StableID":   "naRskpBC7Y11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a114b46675991ab6e62632b5c5f5d3bf3e94dabf03505f444aed2bcd68999d55",
+				"DiscoKey":   "discokey:e2cda9587784a622bdd15c4c1f626c591e2ad814ca3153f27a22d706113f8d5a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:55724",
+					"10.65.0.27:55724",
+					"172.17.0.1:55724",
+					"172.18.0.1:55724",
+					"172.19.0.1:55724"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:51:44.523493178Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8388054674282503,
+				"StableID":   "narJ2RyxV821CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:be680e169e4274024ba4d68cfb5d5f0ed0d4258bce27ed3fab54b482df3dca70",
+				"KeyExpiry":  "2026-11-08T21:51:45Z",
+				"DiscoKey":   "discokey:2f6143628ccdbcb58f9f4c5329d3678452f9669dd6f0e3222212d52c1a210861",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45313",
+					"10.65.0.27:45313",
+					"172.17.0.1:45313",
+					"172.18.0.1:45313",
+					"172.19.0.1:45313"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:51:45.068378828Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6571167376157198,
+				"StableID":   "nd6H8cR6Kt11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a33f4048e2b1ac9a2cb28d85a2bb6c91a64ae6c14341118a4f1e1518d68d7477",
+				"KeyExpiry":  "2026-11-08T21:51:45Z",
+				"DiscoKey":   "discokey:ce3284585a008b1b247aa7694af4a7af46c1bc9f3922cb6bbd327daf61cea534",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46040",
+					"10.65.0.27:46040",
+					"172.17.0.1:46040",
+					"172.18.0.1:46040",
+					"172.19.0.1:46040"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:51:45.724213033Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2056737066031535,
+				"StableID":   "nSrUZizV4H11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f871bb25d314e4e9f73fbb700492f2f12d54367142b028e215c816fd59a5ca27",
+				"KeyExpiry":  "2026-11-08T21:51:46Z",
+				"DiscoKey":   "discokey:ff1a96cd82ec6ea8e4988deba4a8542697f036d9ff8f396ac7bcc8f68547b835",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47753",
+					"10.65.0.27:47753",
+					"172.17.0.1:47753",
+					"172.18.0.1:47753",
+					"172.19.0.1:47753"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:51:46.402631464Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5097843118802719": {
+				"ID":          5097843118802719,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2056737066031535,
+				"StableID":   "nSrUZizV4H11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f871bb25d314e4e9f73fbb700492f2f12d54367142b028e215c816fd59a5ca27",
+				"KeyExpiry":  "2026-11-08T21:51:46Z",
+				"DiscoKey":   "discokey:ff1a96cd82ec6ea8e4988deba4a8542697f036d9ff8f396ac7bcc8f68547b835",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47753",
+					"10.65.0.27:47753",
+					"172.17.0.1:47753",
+					"172.18.0.1:47753",
+					"172.19.0.1:47753"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:51:46.402631464Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f871bb25d314e4e9f73fbb700492f2f12d54367142b028e215c816fd59a5ca27",
+			"MachineKey": "mkey:c1b532fcd6eac1aaf9f137dfecde2118b789bd9975f172ea1db3729725328a10",
+			"Peers": [{
+				"ID":         3740735190292067,
+				"StableID":   "nUumDgmBDW11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c54cd3f2733c308db78096efbe6197089911891a7d8e10b20442576d67246d2f",
+				"DiscoKey":   "discokey:a00fa6830438f7af48ba8625bdac76b49db54c2831d1fdbee51f13e433d12664",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:60844",
+					"10.65.0.27:60844",
+					"172.17.0.1:60844",
+					"172.18.0.1:60844",
+					"172.19.0.1:60844"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:51:37.823637125Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7170555244955655,
+				"StableID":   "n28sayKZzx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cbecf899f3a6e80cf6000d5eba1b79f173fafead63b49d97d9a167b1f5239a76",
+				"DiscoKey":   "discokey:73faf4c6ef724a76d075d64aee4dee679b7335bab6cce281fe90646b31574a45",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40044",
+					"10.65.0.27:40044",
+					"172.17.0.1:40044",
+					"172.18.0.1:40044",
+					"172.19.0.1:40044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:51:38.329563385Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1943241934471156,
+				"StableID":   "nTxvRtf6BG11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:963a522773752726a3c32b2a9edec14877a84a102cb375b8bfb390ae5c192302",
+				"DiscoKey":   "discokey:db26fe36338aee76899472ce56519f72ce80691d4755ea36d2696373fdec3d54",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:44889",
+					"10.65.0.27:44889",
+					"172.17.0.1:44889",
+					"172.18.0.1:44889",
+					"172.19.0.1:44889"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:51:38.865247333Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2621170226034401,
+				"StableID":   "nQij6Sh8UM11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:caba25eb91ad0c35e2ce3782dac16d3b3dd31d555b8e406a9bdb24b891bbbe4d",
+				"DiscoKey":   "discokey:b0fe86e6c654f6862ef0f47b5f11ef2b40b36d3ff0626e8d540457b93b4d4949",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42859",
+					"10.65.0.27:42859",
+					"172.17.0.1:42859",
+					"172.18.0.1:42859",
+					"172.19.0.1:42859"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:51:39.412896526Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5071159392986909,
+				"StableID":   "nLvwBykjbg11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:60c65c038df4bcda1e567d718586346b198d8bb551886f826f76988959c75206",
+				"DiscoKey":   "discokey:91f11f812c508a90ecd1c9ec8e0f1233e64f4e14664c55fa8c59bcc1a71c5f44",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37471",
+					"10.65.0.27:37471",
+					"172.17.0.1:37471",
+					"172.18.0.1:37471",
+					"172.19.0.1:37471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:51:39.994715221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5097843118802719,
+				"StableID":   "nxuZfGhpog11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1d2962ddf14ba8c0a1fb24d9979d0bac319806525cc8bfbdc2dba4eda710118",
+				"DiscoKey":   "discokey:1f01b0d809bf6b35fb2ccecae788d839c95577493717a912bd2f88c12aec242e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39245",
+					"10.65.0.27:39245",
+					"172.17.0.1:39245",
+					"172.18.0.1:39245",
+					"172.19.0.1:39245"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:51:40.49365522Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6540106155930384,
+				"StableID":   "nyKaTvV25t11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1cda4660ab2df7c9e755447756ae9817d39f5eab6c57a31fc3dbb55a48af2c6c",
+				"DiscoKey":   "discokey:2274fcd7bcc61f82d4bcdebd50ca44e9ab7ab984fb43a0b50a2c9694dda4b162",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43819",
+					"10.65.0.27:43819",
+					"172.17.0.1:43819",
+					"172.18.0.1:43819",
+					"172.19.0.1:43819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:51:41.035462015Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6444673744224709,
+				"StableID":   "nSXf2meoKs11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b62999515789877c7ef800d988e2f9d98951ebf224463ddbf59d00fd1026fa32",
+				"DiscoKey":   "discokey:d58be7eefc0eaa415a497680047269197f06d9a2fe20930a892f1b12c71e2a50",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38003",
+					"10.65.0.27:38003",
+					"172.17.0.1:38003",
+					"172.18.0.1:38003",
+					"172.19.0.1:38003"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:51:41.605890793Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8764868429056629,
+				"StableID":   "nY8FCQEdSB21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e199a38fae627dfaff452c02f19bad662f2fe86abda72fd7e2c2702a1149b15",
+				"DiscoKey":   "discokey:346e022c2fb936b13f9ec7e0a36949c59b9b2d35d1a61aff9b3b6d4e33ab0d79",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53248",
+					"10.65.0.27:53248",
+					"172.17.0.1:53248",
+					"172.18.0.1:53248",
+					"172.19.0.1:53248"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:51:42.824577674Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4223447621657124,
+				"StableID":   "nDBvopooyZ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aac3b7b1280cac6b5928330d55d45daa07c02fc8900943baf8f3f79b8e67980c",
+				"DiscoKey":   "discokey:820fa969dc306c4cf52f0c29d8020c6d4ba292e9d8f28d9f3e504ce67fb12d1e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51080",
+					"10.65.0.27:51080",
+					"172.17.0.1:51080",
+					"172.18.0.1:51080",
+					"172.19.0.1:51080"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:51:43.439981461Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8100241366053895,
+				"StableID":   "nxZbY6ccF621CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fbcddd6df0764cde26ec82ece56ec7d003961c0a0a70a549896f6eed8f232d12",
+				"DiscoKey":   "discokey:cead8ea24d9a4416efb1166e29ed225ae9ff0a3dc994429c79a753088b19cc1f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41397",
+					"10.65.0.27:41397",
+					"172.17.0.1:41397",
+					"172.18.0.1:41397",
+					"172.19.0.1:41397"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:51:43.988243603Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3983629297884225,
+				"StableID":   "naRskpBC7Y11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a114b46675991ab6e62632b5c5f5d3bf3e94dabf03505f444aed2bcd68999d55",
+				"DiscoKey":   "discokey:e2cda9587784a622bdd15c4c1f626c591e2ad814ca3153f27a22d706113f8d5a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:55724",
+					"10.65.0.27:55724",
+					"172.17.0.1:55724",
+					"172.18.0.1:55724",
+					"172.19.0.1:55724"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:51:44.523493178Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8388054674282503,
+				"StableID":   "narJ2RyxV821CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:be680e169e4274024ba4d68cfb5d5f0ed0d4258bce27ed3fab54b482df3dca70",
+				"KeyExpiry":  "2026-11-08T21:51:45Z",
+				"DiscoKey":   "discokey:2f6143628ccdbcb58f9f4c5329d3678452f9669dd6f0e3222212d52c1a210861",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45313",
+					"10.65.0.27:45313",
+					"172.17.0.1:45313",
+					"172.18.0.1:45313",
+					"172.19.0.1:45313"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:51:45.068378828Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6571167376157198,
+				"StableID":   "nd6H8cR6Kt11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a33f4048e2b1ac9a2cb28d85a2bb6c91a64ae6c14341118a4f1e1518d68d7477",
+				"KeyExpiry":  "2026-11-08T21:51:45Z",
+				"DiscoKey":   "discokey:ce3284585a008b1b247aa7694af4a7af46c1bc9f3922cb6bbd327daf61cea534",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46040",
+					"10.65.0.27:46040",
+					"172.17.0.1:46040",
+					"172.18.0.1:46040",
+					"172.19.0.1:46040"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:51:45.724213033Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1943241934471156,
+				"StableID":   "nTxvRtf6BG11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1943241934471156,
+				"Key":        "nodekey:963a522773752726a3c32b2a9edec14877a84a102cb375b8bfb390ae5c192302",
+				"DiscoKey":   "discokey:db26fe36338aee76899472ce56519f72ce80691d4755ea36d2696373fdec3d54",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:44889",
+					"10.65.0.27:44889",
+					"172.17.0.1:44889",
+					"172.18.0.1:44889",
+					"172.19.0.1:44889"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:51:38.865247333Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:963a522773752726a3c32b2a9edec14877a84a102cb375b8bfb390ae5c192302",
+			"MachineKey": "mkey:b710f6c76fadac03e2dd5bb468269b8cd014a3514cf057dbd51509ff78a4cb24",
+			"Peers": [{
+				"ID":         3740735190292067,
+				"StableID":   "nUumDgmBDW11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c54cd3f2733c308db78096efbe6197089911891a7d8e10b20442576d67246d2f",
+				"DiscoKey":   "discokey:a00fa6830438f7af48ba8625bdac76b49db54c2831d1fdbee51f13e433d12664",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:60844",
+					"10.65.0.27:60844",
+					"172.17.0.1:60844",
+					"172.18.0.1:60844",
+					"172.19.0.1:60844"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:51:37.823637125Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7170555244955655,
+				"StableID":   "n28sayKZzx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cbecf899f3a6e80cf6000d5eba1b79f173fafead63b49d97d9a167b1f5239a76",
+				"DiscoKey":   "discokey:73faf4c6ef724a76d075d64aee4dee679b7335bab6cce281fe90646b31574a45",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40044",
+					"10.65.0.27:40044",
+					"172.17.0.1:40044",
+					"172.18.0.1:40044",
+					"172.19.0.1:40044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:51:38.329563385Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2621170226034401,
+				"StableID":   "nQij6Sh8UM11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:caba25eb91ad0c35e2ce3782dac16d3b3dd31d555b8e406a9bdb24b891bbbe4d",
+				"DiscoKey":   "discokey:b0fe86e6c654f6862ef0f47b5f11ef2b40b36d3ff0626e8d540457b93b4d4949",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42859",
+					"10.65.0.27:42859",
+					"172.17.0.1:42859",
+					"172.18.0.1:42859",
+					"172.19.0.1:42859"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:51:39.412896526Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5071159392986909,
+				"StableID":   "nLvwBykjbg11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:60c65c038df4bcda1e567d718586346b198d8bb551886f826f76988959c75206",
+				"DiscoKey":   "discokey:91f11f812c508a90ecd1c9ec8e0f1233e64f4e14664c55fa8c59bcc1a71c5f44",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37471",
+					"10.65.0.27:37471",
+					"172.17.0.1:37471",
+					"172.18.0.1:37471",
+					"172.19.0.1:37471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:51:39.994715221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5097843118802719,
+				"StableID":   "nxuZfGhpog11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1d2962ddf14ba8c0a1fb24d9979d0bac319806525cc8bfbdc2dba4eda710118",
+				"DiscoKey":   "discokey:1f01b0d809bf6b35fb2ccecae788d839c95577493717a912bd2f88c12aec242e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39245",
+					"10.65.0.27:39245",
+					"172.17.0.1:39245",
+					"172.18.0.1:39245",
+					"172.19.0.1:39245"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:51:40.49365522Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6540106155930384,
+				"StableID":   "nyKaTvV25t11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1cda4660ab2df7c9e755447756ae9817d39f5eab6c57a31fc3dbb55a48af2c6c",
+				"DiscoKey":   "discokey:2274fcd7bcc61f82d4bcdebd50ca44e9ab7ab984fb43a0b50a2c9694dda4b162",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43819",
+					"10.65.0.27:43819",
+					"172.17.0.1:43819",
+					"172.18.0.1:43819",
+					"172.19.0.1:43819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:51:41.035462015Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6444673744224709,
+				"StableID":   "nSXf2meoKs11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b62999515789877c7ef800d988e2f9d98951ebf224463ddbf59d00fd1026fa32",
+				"DiscoKey":   "discokey:d58be7eefc0eaa415a497680047269197f06d9a2fe20930a892f1b12c71e2a50",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38003",
+					"10.65.0.27:38003",
+					"172.17.0.1:38003",
+					"172.18.0.1:38003",
+					"172.19.0.1:38003"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:51:41.605890793Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8764868429056629,
+				"StableID":   "nY8FCQEdSB21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e199a38fae627dfaff452c02f19bad662f2fe86abda72fd7e2c2702a1149b15",
+				"DiscoKey":   "discokey:346e022c2fb936b13f9ec7e0a36949c59b9b2d35d1a61aff9b3b6d4e33ab0d79",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53248",
+					"10.65.0.27:53248",
+					"172.17.0.1:53248",
+					"172.18.0.1:53248",
+					"172.19.0.1:53248"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:51:42.824577674Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4223447621657124,
+				"StableID":   "nDBvopooyZ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aac3b7b1280cac6b5928330d55d45daa07c02fc8900943baf8f3f79b8e67980c",
+				"DiscoKey":   "discokey:820fa969dc306c4cf52f0c29d8020c6d4ba292e9d8f28d9f3e504ce67fb12d1e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51080",
+					"10.65.0.27:51080",
+					"172.17.0.1:51080",
+					"172.18.0.1:51080",
+					"172.19.0.1:51080"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:51:43.439981461Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8100241366053895,
+				"StableID":   "nxZbY6ccF621CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fbcddd6df0764cde26ec82ece56ec7d003961c0a0a70a549896f6eed8f232d12",
+				"DiscoKey":   "discokey:cead8ea24d9a4416efb1166e29ed225ae9ff0a3dc994429c79a753088b19cc1f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41397",
+					"10.65.0.27:41397",
+					"172.17.0.1:41397",
+					"172.18.0.1:41397",
+					"172.19.0.1:41397"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:51:43.988243603Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3983629297884225,
+				"StableID":   "naRskpBC7Y11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a114b46675991ab6e62632b5c5f5d3bf3e94dabf03505f444aed2bcd68999d55",
+				"DiscoKey":   "discokey:e2cda9587784a622bdd15c4c1f626c591e2ad814ca3153f27a22d706113f8d5a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:55724",
+					"10.65.0.27:55724",
+					"172.17.0.1:55724",
+					"172.18.0.1:55724",
+					"172.19.0.1:55724"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:51:44.523493178Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8388054674282503,
+				"StableID":   "narJ2RyxV821CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:be680e169e4274024ba4d68cfb5d5f0ed0d4258bce27ed3fab54b482df3dca70",
+				"KeyExpiry":  "2026-11-08T21:51:45Z",
+				"DiscoKey":   "discokey:2f6143628ccdbcb58f9f4c5329d3678452f9669dd6f0e3222212d52c1a210861",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45313",
+					"10.65.0.27:45313",
+					"172.17.0.1:45313",
+					"172.18.0.1:45313",
+					"172.19.0.1:45313"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:51:45.068378828Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6571167376157198,
+				"StableID":   "nd6H8cR6Kt11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a33f4048e2b1ac9a2cb28d85a2bb6c91a64ae6c14341118a4f1e1518d68d7477",
+				"KeyExpiry":  "2026-11-08T21:51:45Z",
+				"DiscoKey":   "discokey:ce3284585a008b1b247aa7694af4a7af46c1bc9f3922cb6bbd327daf61cea534",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46040",
+					"10.65.0.27:46040",
+					"172.17.0.1:46040",
+					"172.18.0.1:46040",
+					"172.19.0.1:46040"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:51:45.724213033Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2056737066031535,
+				"StableID":   "nSrUZizV4H11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f871bb25d314e4e9f73fbb700492f2f12d54367142b028e215c816fd59a5ca27",
+				"KeyExpiry":  "2026-11-08T21:51:46Z",
+				"DiscoKey":   "discokey:ff1a96cd82ec6ea8e4988deba4a8542697f036d9ff8f396ac7bcc8f68547b835",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47753",
+					"10.65.0.27:47753",
+					"172.17.0.1:47753",
+					"172.18.0.1:47753",
+					"172.19.0.1:47753"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:51:46.402631464Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1943241934471156": {
+				"ID":          1943241934471156,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6444673744224709,
+				"StableID":   "nSXf2meoKs11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       6444673744224709,
+				"Key":        "nodekey:b62999515789877c7ef800d988e2f9d98951ebf224463ddbf59d00fd1026fa32",
+				"DiscoKey":   "discokey:d58be7eefc0eaa415a497680047269197f06d9a2fe20930a892f1b12c71e2a50",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38003",
+					"10.65.0.27:38003",
+					"172.17.0.1:38003",
+					"172.18.0.1:38003",
+					"172.19.0.1:38003"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:51:41.605890793Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b62999515789877c7ef800d988e2f9d98951ebf224463ddbf59d00fd1026fa32",
+			"MachineKey": "mkey:4410cad7f6a6f372e7dbaf20a165dcafa47cbfd270cb9ea279243457b124212e",
+			"Peers": [{
+				"ID":         3740735190292067,
+				"StableID":   "nUumDgmBDW11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c54cd3f2733c308db78096efbe6197089911891a7d8e10b20442576d67246d2f",
+				"DiscoKey":   "discokey:a00fa6830438f7af48ba8625bdac76b49db54c2831d1fdbee51f13e433d12664",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:60844",
+					"10.65.0.27:60844",
+					"172.17.0.1:60844",
+					"172.18.0.1:60844",
+					"172.19.0.1:60844"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:51:37.823637125Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7170555244955655,
+				"StableID":   "n28sayKZzx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cbecf899f3a6e80cf6000d5eba1b79f173fafead63b49d97d9a167b1f5239a76",
+				"DiscoKey":   "discokey:73faf4c6ef724a76d075d64aee4dee679b7335bab6cce281fe90646b31574a45",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40044",
+					"10.65.0.27:40044",
+					"172.17.0.1:40044",
+					"172.18.0.1:40044",
+					"172.19.0.1:40044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:51:38.329563385Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1943241934471156,
+				"StableID":   "nTxvRtf6BG11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:963a522773752726a3c32b2a9edec14877a84a102cb375b8bfb390ae5c192302",
+				"DiscoKey":   "discokey:db26fe36338aee76899472ce56519f72ce80691d4755ea36d2696373fdec3d54",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:44889",
+					"10.65.0.27:44889",
+					"172.17.0.1:44889",
+					"172.18.0.1:44889",
+					"172.19.0.1:44889"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:51:38.865247333Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2621170226034401,
+				"StableID":   "nQij6Sh8UM11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:caba25eb91ad0c35e2ce3782dac16d3b3dd31d555b8e406a9bdb24b891bbbe4d",
+				"DiscoKey":   "discokey:b0fe86e6c654f6862ef0f47b5f11ef2b40b36d3ff0626e8d540457b93b4d4949",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42859",
+					"10.65.0.27:42859",
+					"172.17.0.1:42859",
+					"172.18.0.1:42859",
+					"172.19.0.1:42859"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:51:39.412896526Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5071159392986909,
+				"StableID":   "nLvwBykjbg11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:60c65c038df4bcda1e567d718586346b198d8bb551886f826f76988959c75206",
+				"DiscoKey":   "discokey:91f11f812c508a90ecd1c9ec8e0f1233e64f4e14664c55fa8c59bcc1a71c5f44",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37471",
+					"10.65.0.27:37471",
+					"172.17.0.1:37471",
+					"172.18.0.1:37471",
+					"172.19.0.1:37471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:51:39.994715221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5097843118802719,
+				"StableID":   "nxuZfGhpog11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1d2962ddf14ba8c0a1fb24d9979d0bac319806525cc8bfbdc2dba4eda710118",
+				"DiscoKey":   "discokey:1f01b0d809bf6b35fb2ccecae788d839c95577493717a912bd2f88c12aec242e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39245",
+					"10.65.0.27:39245",
+					"172.17.0.1:39245",
+					"172.18.0.1:39245",
+					"172.19.0.1:39245"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:51:40.49365522Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6540106155930384,
+				"StableID":   "nyKaTvV25t11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1cda4660ab2df7c9e755447756ae9817d39f5eab6c57a31fc3dbb55a48af2c6c",
+				"DiscoKey":   "discokey:2274fcd7bcc61f82d4bcdebd50ca44e9ab7ab984fb43a0b50a2c9694dda4b162",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43819",
+					"10.65.0.27:43819",
+					"172.17.0.1:43819",
+					"172.18.0.1:43819",
+					"172.19.0.1:43819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:51:41.035462015Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8764868429056629,
+				"StableID":   "nY8FCQEdSB21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e199a38fae627dfaff452c02f19bad662f2fe86abda72fd7e2c2702a1149b15",
+				"DiscoKey":   "discokey:346e022c2fb936b13f9ec7e0a36949c59b9b2d35d1a61aff9b3b6d4e33ab0d79",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53248",
+					"10.65.0.27:53248",
+					"172.17.0.1:53248",
+					"172.18.0.1:53248",
+					"172.19.0.1:53248"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:51:42.824577674Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4223447621657124,
+				"StableID":   "nDBvopooyZ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aac3b7b1280cac6b5928330d55d45daa07c02fc8900943baf8f3f79b8e67980c",
+				"DiscoKey":   "discokey:820fa969dc306c4cf52f0c29d8020c6d4ba292e9d8f28d9f3e504ce67fb12d1e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51080",
+					"10.65.0.27:51080",
+					"172.17.0.1:51080",
+					"172.18.0.1:51080",
+					"172.19.0.1:51080"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:51:43.439981461Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8100241366053895,
+				"StableID":   "nxZbY6ccF621CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fbcddd6df0764cde26ec82ece56ec7d003961c0a0a70a549896f6eed8f232d12",
+				"DiscoKey":   "discokey:cead8ea24d9a4416efb1166e29ed225ae9ff0a3dc994429c79a753088b19cc1f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41397",
+					"10.65.0.27:41397",
+					"172.17.0.1:41397",
+					"172.18.0.1:41397",
+					"172.19.0.1:41397"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:51:43.988243603Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3983629297884225,
+				"StableID":   "naRskpBC7Y11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a114b46675991ab6e62632b5c5f5d3bf3e94dabf03505f444aed2bcd68999d55",
+				"DiscoKey":   "discokey:e2cda9587784a622bdd15c4c1f626c591e2ad814ca3153f27a22d706113f8d5a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:55724",
+					"10.65.0.27:55724",
+					"172.17.0.1:55724",
+					"172.18.0.1:55724",
+					"172.19.0.1:55724"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:51:44.523493178Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8388054674282503,
+				"StableID":   "narJ2RyxV821CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:be680e169e4274024ba4d68cfb5d5f0ed0d4258bce27ed3fab54b482df3dca70",
+				"KeyExpiry":  "2026-11-08T21:51:45Z",
+				"DiscoKey":   "discokey:2f6143628ccdbcb58f9f4c5329d3678452f9669dd6f0e3222212d52c1a210861",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45313",
+					"10.65.0.27:45313",
+					"172.17.0.1:45313",
+					"172.18.0.1:45313",
+					"172.19.0.1:45313"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:51:45.068378828Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6571167376157198,
+				"StableID":   "nd6H8cR6Kt11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a33f4048e2b1ac9a2cb28d85a2bb6c91a64ae6c14341118a4f1e1518d68d7477",
+				"KeyExpiry":  "2026-11-08T21:51:45Z",
+				"DiscoKey":   "discokey:ce3284585a008b1b247aa7694af4a7af46c1bc9f3922cb6bbd327daf61cea534",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46040",
+					"10.65.0.27:46040",
+					"172.17.0.1:46040",
+					"172.18.0.1:46040",
+					"172.19.0.1:46040"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:51:45.724213033Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2056737066031535,
+				"StableID":   "nSrUZizV4H11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f871bb25d314e4e9f73fbb700492f2f12d54367142b028e215c816fd59a5ca27",
+				"KeyExpiry":  "2026-11-08T21:51:46Z",
+				"DiscoKey":   "discokey:ff1a96cd82ec6ea8e4988deba4a8542697f036d9ff8f396ac7bcc8f68547b835",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47753",
+					"10.65.0.27:47753",
+					"172.17.0.1:47753",
+					"172.18.0.1:47753",
+					"172.19.0.1:47753"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:51:46.402631464Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6444673744224709": {
+				"ID":          6444673744224709,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8388054674282503,
+				"StableID":   "narJ2RyxV821CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:be680e169e4274024ba4d68cfb5d5f0ed0d4258bce27ed3fab54b482df3dca70",
+				"KeyExpiry":  "2026-11-08T21:51:45Z",
+				"DiscoKey":   "discokey:2f6143628ccdbcb58f9f4c5329d3678452f9669dd6f0e3222212d52c1a210861",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45313",
+					"10.65.0.27:45313",
+					"172.17.0.1:45313",
+					"172.18.0.1:45313",
+					"172.19.0.1:45313"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:51:45.068378828Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:be680e169e4274024ba4d68cfb5d5f0ed0d4258bce27ed3fab54b482df3dca70",
+			"MachineKey": "mkey:78ff69697e7d48dfc938cf104389a34bd061b5d0b435f46033915baddefeb477",
+			"Peers": [{
+				"ID":         3740735190292067,
+				"StableID":   "nUumDgmBDW11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c54cd3f2733c308db78096efbe6197089911891a7d8e10b20442576d67246d2f",
+				"DiscoKey":   "discokey:a00fa6830438f7af48ba8625bdac76b49db54c2831d1fdbee51f13e433d12664",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:60844",
+					"10.65.0.27:60844",
+					"172.17.0.1:60844",
+					"172.18.0.1:60844",
+					"172.19.0.1:60844"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:51:37.823637125Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7170555244955655,
+				"StableID":   "n28sayKZzx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cbecf899f3a6e80cf6000d5eba1b79f173fafead63b49d97d9a167b1f5239a76",
+				"DiscoKey":   "discokey:73faf4c6ef724a76d075d64aee4dee679b7335bab6cce281fe90646b31574a45",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40044",
+					"10.65.0.27:40044",
+					"172.17.0.1:40044",
+					"172.18.0.1:40044",
+					"172.19.0.1:40044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:51:38.329563385Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1943241934471156,
+				"StableID":   "nTxvRtf6BG11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:963a522773752726a3c32b2a9edec14877a84a102cb375b8bfb390ae5c192302",
+				"DiscoKey":   "discokey:db26fe36338aee76899472ce56519f72ce80691d4755ea36d2696373fdec3d54",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:44889",
+					"10.65.0.27:44889",
+					"172.17.0.1:44889",
+					"172.18.0.1:44889",
+					"172.19.0.1:44889"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:51:38.865247333Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2621170226034401,
+				"StableID":   "nQij6Sh8UM11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:caba25eb91ad0c35e2ce3782dac16d3b3dd31d555b8e406a9bdb24b891bbbe4d",
+				"DiscoKey":   "discokey:b0fe86e6c654f6862ef0f47b5f11ef2b40b36d3ff0626e8d540457b93b4d4949",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42859",
+					"10.65.0.27:42859",
+					"172.17.0.1:42859",
+					"172.18.0.1:42859",
+					"172.19.0.1:42859"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:51:39.412896526Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5071159392986909,
+				"StableID":   "nLvwBykjbg11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:60c65c038df4bcda1e567d718586346b198d8bb551886f826f76988959c75206",
+				"DiscoKey":   "discokey:91f11f812c508a90ecd1c9ec8e0f1233e64f4e14664c55fa8c59bcc1a71c5f44",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37471",
+					"10.65.0.27:37471",
+					"172.17.0.1:37471",
+					"172.18.0.1:37471",
+					"172.19.0.1:37471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:51:39.994715221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5097843118802719,
+				"StableID":   "nxuZfGhpog11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1d2962ddf14ba8c0a1fb24d9979d0bac319806525cc8bfbdc2dba4eda710118",
+				"DiscoKey":   "discokey:1f01b0d809bf6b35fb2ccecae788d839c95577493717a912bd2f88c12aec242e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39245",
+					"10.65.0.27:39245",
+					"172.17.0.1:39245",
+					"172.18.0.1:39245",
+					"172.19.0.1:39245"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:51:40.49365522Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6540106155930384,
+				"StableID":   "nyKaTvV25t11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1cda4660ab2df7c9e755447756ae9817d39f5eab6c57a31fc3dbb55a48af2c6c",
+				"DiscoKey":   "discokey:2274fcd7bcc61f82d4bcdebd50ca44e9ab7ab984fb43a0b50a2c9694dda4b162",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43819",
+					"10.65.0.27:43819",
+					"172.17.0.1:43819",
+					"172.18.0.1:43819",
+					"172.19.0.1:43819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:51:41.035462015Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6444673744224709,
+				"StableID":   "nSXf2meoKs11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b62999515789877c7ef800d988e2f9d98951ebf224463ddbf59d00fd1026fa32",
+				"DiscoKey":   "discokey:d58be7eefc0eaa415a497680047269197f06d9a2fe20930a892f1b12c71e2a50",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38003",
+					"10.65.0.27:38003",
+					"172.17.0.1:38003",
+					"172.18.0.1:38003",
+					"172.19.0.1:38003"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:51:41.605890793Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8764868429056629,
+				"StableID":   "nY8FCQEdSB21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e199a38fae627dfaff452c02f19bad662f2fe86abda72fd7e2c2702a1149b15",
+				"DiscoKey":   "discokey:346e022c2fb936b13f9ec7e0a36949c59b9b2d35d1a61aff9b3b6d4e33ab0d79",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53248",
+					"10.65.0.27:53248",
+					"172.17.0.1:53248",
+					"172.18.0.1:53248",
+					"172.19.0.1:53248"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:51:42.824577674Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4223447621657124,
+				"StableID":   "nDBvopooyZ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aac3b7b1280cac6b5928330d55d45daa07c02fc8900943baf8f3f79b8e67980c",
+				"DiscoKey":   "discokey:820fa969dc306c4cf52f0c29d8020c6d4ba292e9d8f28d9f3e504ce67fb12d1e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51080",
+					"10.65.0.27:51080",
+					"172.17.0.1:51080",
+					"172.18.0.1:51080",
+					"172.19.0.1:51080"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:51:43.439981461Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8100241366053895,
+				"StableID":   "nxZbY6ccF621CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fbcddd6df0764cde26ec82ece56ec7d003961c0a0a70a549896f6eed8f232d12",
+				"DiscoKey":   "discokey:cead8ea24d9a4416efb1166e29ed225ae9ff0a3dc994429c79a753088b19cc1f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41397",
+					"10.65.0.27:41397",
+					"172.17.0.1:41397",
+					"172.18.0.1:41397",
+					"172.19.0.1:41397"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:51:43.988243603Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3983629297884225,
+				"StableID":   "naRskpBC7Y11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a114b46675991ab6e62632b5c5f5d3bf3e94dabf03505f444aed2bcd68999d55",
+				"DiscoKey":   "discokey:e2cda9587784a622bdd15c4c1f626c591e2ad814ca3153f27a22d706113f8d5a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:55724",
+					"10.65.0.27:55724",
+					"172.17.0.1:55724",
+					"172.18.0.1:55724",
+					"172.19.0.1:55724"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:51:44.523493178Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6571167376157198,
+				"StableID":   "nd6H8cR6Kt11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a33f4048e2b1ac9a2cb28d85a2bb6c91a64ae6c14341118a4f1e1518d68d7477",
+				"KeyExpiry":  "2026-11-08T21:51:45Z",
+				"DiscoKey":   "discokey:ce3284585a008b1b247aa7694af4a7af46c1bc9f3922cb6bbd327daf61cea534",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46040",
+					"10.65.0.27:46040",
+					"172.17.0.1:46040",
+					"172.18.0.1:46040",
+					"172.19.0.1:46040"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:51:45.724213033Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2056737066031535,
+				"StableID":   "nSrUZizV4H11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f871bb25d314e4e9f73fbb700492f2f12d54367142b028e215c816fd59a5ca27",
+				"KeyExpiry":  "2026-11-08T21:51:46Z",
+				"DiscoKey":   "discokey:ff1a96cd82ec6ea8e4988deba4a8542697f036d9ff8f396ac7bcc8f68547b835",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47753",
+					"10.65.0.27:47753",
+					"172.17.0.1:47753",
+					"172.18.0.1:47753",
+					"172.19.0.1:47753"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:51:46.402631464Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8100241366053895,
+				"StableID":   "nxZbY6ccF621CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       8100241366053895,
+				"Key":        "nodekey:fbcddd6df0764cde26ec82ece56ec7d003961c0a0a70a549896f6eed8f232d12",
+				"DiscoKey":   "discokey:cead8ea24d9a4416efb1166e29ed225ae9ff0a3dc994429c79a753088b19cc1f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41397",
+					"10.65.0.27:41397",
+					"172.17.0.1:41397",
+					"172.18.0.1:41397",
+					"172.19.0.1:41397"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:51:43.988243603Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:fbcddd6df0764cde26ec82ece56ec7d003961c0a0a70a549896f6eed8f232d12",
+			"MachineKey": "mkey:9fd463a47809d33b6b745092097ddce54a9c14dda09fae8e612365b599d6f00d",
+			"Peers": [{
+				"ID":         3740735190292067,
+				"StableID":   "nUumDgmBDW11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c54cd3f2733c308db78096efbe6197089911891a7d8e10b20442576d67246d2f",
+				"DiscoKey":   "discokey:a00fa6830438f7af48ba8625bdac76b49db54c2831d1fdbee51f13e433d12664",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:60844",
+					"10.65.0.27:60844",
+					"172.17.0.1:60844",
+					"172.18.0.1:60844",
+					"172.19.0.1:60844"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:51:37.823637125Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7170555244955655,
+				"StableID":   "n28sayKZzx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cbecf899f3a6e80cf6000d5eba1b79f173fafead63b49d97d9a167b1f5239a76",
+				"DiscoKey":   "discokey:73faf4c6ef724a76d075d64aee4dee679b7335bab6cce281fe90646b31574a45",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40044",
+					"10.65.0.27:40044",
+					"172.17.0.1:40044",
+					"172.18.0.1:40044",
+					"172.19.0.1:40044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:51:38.329563385Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1943241934471156,
+				"StableID":   "nTxvRtf6BG11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:963a522773752726a3c32b2a9edec14877a84a102cb375b8bfb390ae5c192302",
+				"DiscoKey":   "discokey:db26fe36338aee76899472ce56519f72ce80691d4755ea36d2696373fdec3d54",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:44889",
+					"10.65.0.27:44889",
+					"172.17.0.1:44889",
+					"172.18.0.1:44889",
+					"172.19.0.1:44889"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:51:38.865247333Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2621170226034401,
+				"StableID":   "nQij6Sh8UM11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:caba25eb91ad0c35e2ce3782dac16d3b3dd31d555b8e406a9bdb24b891bbbe4d",
+				"DiscoKey":   "discokey:b0fe86e6c654f6862ef0f47b5f11ef2b40b36d3ff0626e8d540457b93b4d4949",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42859",
+					"10.65.0.27:42859",
+					"172.17.0.1:42859",
+					"172.18.0.1:42859",
+					"172.19.0.1:42859"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:51:39.412896526Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5071159392986909,
+				"StableID":   "nLvwBykjbg11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:60c65c038df4bcda1e567d718586346b198d8bb551886f826f76988959c75206",
+				"DiscoKey":   "discokey:91f11f812c508a90ecd1c9ec8e0f1233e64f4e14664c55fa8c59bcc1a71c5f44",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37471",
+					"10.65.0.27:37471",
+					"172.17.0.1:37471",
+					"172.18.0.1:37471",
+					"172.19.0.1:37471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:51:39.994715221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5097843118802719,
+				"StableID":   "nxuZfGhpog11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1d2962ddf14ba8c0a1fb24d9979d0bac319806525cc8bfbdc2dba4eda710118",
+				"DiscoKey":   "discokey:1f01b0d809bf6b35fb2ccecae788d839c95577493717a912bd2f88c12aec242e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39245",
+					"10.65.0.27:39245",
+					"172.17.0.1:39245",
+					"172.18.0.1:39245",
+					"172.19.0.1:39245"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:51:40.49365522Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6540106155930384,
+				"StableID":   "nyKaTvV25t11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1cda4660ab2df7c9e755447756ae9817d39f5eab6c57a31fc3dbb55a48af2c6c",
+				"DiscoKey":   "discokey:2274fcd7bcc61f82d4bcdebd50ca44e9ab7ab984fb43a0b50a2c9694dda4b162",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43819",
+					"10.65.0.27:43819",
+					"172.17.0.1:43819",
+					"172.18.0.1:43819",
+					"172.19.0.1:43819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:51:41.035462015Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6444673744224709,
+				"StableID":   "nSXf2meoKs11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b62999515789877c7ef800d988e2f9d98951ebf224463ddbf59d00fd1026fa32",
+				"DiscoKey":   "discokey:d58be7eefc0eaa415a497680047269197f06d9a2fe20930a892f1b12c71e2a50",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38003",
+					"10.65.0.27:38003",
+					"172.17.0.1:38003",
+					"172.18.0.1:38003",
+					"172.19.0.1:38003"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:51:41.605890793Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8764868429056629,
+				"StableID":   "nY8FCQEdSB21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e199a38fae627dfaff452c02f19bad662f2fe86abda72fd7e2c2702a1149b15",
+				"DiscoKey":   "discokey:346e022c2fb936b13f9ec7e0a36949c59b9b2d35d1a61aff9b3b6d4e33ab0d79",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53248",
+					"10.65.0.27:53248",
+					"172.17.0.1:53248",
+					"172.18.0.1:53248",
+					"172.19.0.1:53248"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:51:42.824577674Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4223447621657124,
+				"StableID":   "nDBvopooyZ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aac3b7b1280cac6b5928330d55d45daa07c02fc8900943baf8f3f79b8e67980c",
+				"DiscoKey":   "discokey:820fa969dc306c4cf52f0c29d8020c6d4ba292e9d8f28d9f3e504ce67fb12d1e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51080",
+					"10.65.0.27:51080",
+					"172.17.0.1:51080",
+					"172.18.0.1:51080",
+					"172.19.0.1:51080"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:51:43.439981461Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3983629297884225,
+				"StableID":   "naRskpBC7Y11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a114b46675991ab6e62632b5c5f5d3bf3e94dabf03505f444aed2bcd68999d55",
+				"DiscoKey":   "discokey:e2cda9587784a622bdd15c4c1f626c591e2ad814ca3153f27a22d706113f8d5a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:55724",
+					"10.65.0.27:55724",
+					"172.17.0.1:55724",
+					"172.18.0.1:55724",
+					"172.19.0.1:55724"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:51:44.523493178Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8388054674282503,
+				"StableID":   "narJ2RyxV821CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:be680e169e4274024ba4d68cfb5d5f0ed0d4258bce27ed3fab54b482df3dca70",
+				"KeyExpiry":  "2026-11-08T21:51:45Z",
+				"DiscoKey":   "discokey:2f6143628ccdbcb58f9f4c5329d3678452f9669dd6f0e3222212d52c1a210861",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45313",
+					"10.65.0.27:45313",
+					"172.17.0.1:45313",
+					"172.18.0.1:45313",
+					"172.19.0.1:45313"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:51:45.068378828Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6571167376157198,
+				"StableID":   "nd6H8cR6Kt11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a33f4048e2b1ac9a2cb28d85a2bb6c91a64ae6c14341118a4f1e1518d68d7477",
+				"KeyExpiry":  "2026-11-08T21:51:45Z",
+				"DiscoKey":   "discokey:ce3284585a008b1b247aa7694af4a7af46c1bc9f3922cb6bbd327daf61cea534",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46040",
+					"10.65.0.27:46040",
+					"172.17.0.1:46040",
+					"172.18.0.1:46040",
+					"172.19.0.1:46040"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:51:45.724213033Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2056737066031535,
+				"StableID":   "nSrUZizV4H11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f871bb25d314e4e9f73fbb700492f2f12d54367142b028e215c816fd59a5ca27",
+				"KeyExpiry":  "2026-11-08T21:51:46Z",
+				"DiscoKey":   "discokey:ff1a96cd82ec6ea8e4988deba4a8542697f036d9ff8f396ac7bcc8f68547b835",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47753",
+					"10.65.0.27:47753",
+					"172.17.0.1:47753",
+					"172.18.0.1:47753",
+					"172.19.0.1:47753"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:51:46.402631464Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8100241366053895": {
+				"ID":          8100241366053895,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7170555244955655,
+				"StableID":   "n28sayKZzx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       7170555244955655,
+				"Key":        "nodekey:cbecf899f3a6e80cf6000d5eba1b79f173fafead63b49d97d9a167b1f5239a76",
+				"DiscoKey":   "discokey:73faf4c6ef724a76d075d64aee4dee679b7335bab6cce281fe90646b31574a45",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40044",
+					"10.65.0.27:40044",
+					"172.17.0.1:40044",
+					"172.18.0.1:40044",
+					"172.19.0.1:40044"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:51:38.329563385Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:cbecf899f3a6e80cf6000d5eba1b79f173fafead63b49d97d9a167b1f5239a76",
+			"MachineKey": "mkey:91960357ef469eac9b398a300408e4e02b5bdac06f61a4bff69daf3f164cc262",
+			"Peers": [{
+				"ID":         3740735190292067,
+				"StableID":   "nUumDgmBDW11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c54cd3f2733c308db78096efbe6197089911891a7d8e10b20442576d67246d2f",
+				"DiscoKey":   "discokey:a00fa6830438f7af48ba8625bdac76b49db54c2831d1fdbee51f13e433d12664",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:60844",
+					"10.65.0.27:60844",
+					"172.17.0.1:60844",
+					"172.18.0.1:60844",
+					"172.19.0.1:60844"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:51:37.823637125Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1943241934471156,
+				"StableID":   "nTxvRtf6BG11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:963a522773752726a3c32b2a9edec14877a84a102cb375b8bfb390ae5c192302",
+				"DiscoKey":   "discokey:db26fe36338aee76899472ce56519f72ce80691d4755ea36d2696373fdec3d54",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:44889",
+					"10.65.0.27:44889",
+					"172.17.0.1:44889",
+					"172.18.0.1:44889",
+					"172.19.0.1:44889"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:51:38.865247333Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2621170226034401,
+				"StableID":   "nQij6Sh8UM11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:caba25eb91ad0c35e2ce3782dac16d3b3dd31d555b8e406a9bdb24b891bbbe4d",
+				"DiscoKey":   "discokey:b0fe86e6c654f6862ef0f47b5f11ef2b40b36d3ff0626e8d540457b93b4d4949",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42859",
+					"10.65.0.27:42859",
+					"172.17.0.1:42859",
+					"172.18.0.1:42859",
+					"172.19.0.1:42859"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:51:39.412896526Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5071159392986909,
+				"StableID":   "nLvwBykjbg11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:60c65c038df4bcda1e567d718586346b198d8bb551886f826f76988959c75206",
+				"DiscoKey":   "discokey:91f11f812c508a90ecd1c9ec8e0f1233e64f4e14664c55fa8c59bcc1a71c5f44",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37471",
+					"10.65.0.27:37471",
+					"172.17.0.1:37471",
+					"172.18.0.1:37471",
+					"172.19.0.1:37471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:51:39.994715221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5097843118802719,
+				"StableID":   "nxuZfGhpog11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1d2962ddf14ba8c0a1fb24d9979d0bac319806525cc8bfbdc2dba4eda710118",
+				"DiscoKey":   "discokey:1f01b0d809bf6b35fb2ccecae788d839c95577493717a912bd2f88c12aec242e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39245",
+					"10.65.0.27:39245",
+					"172.17.0.1:39245",
+					"172.18.0.1:39245",
+					"172.19.0.1:39245"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:51:40.49365522Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6540106155930384,
+				"StableID":   "nyKaTvV25t11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1cda4660ab2df7c9e755447756ae9817d39f5eab6c57a31fc3dbb55a48af2c6c",
+				"DiscoKey":   "discokey:2274fcd7bcc61f82d4bcdebd50ca44e9ab7ab984fb43a0b50a2c9694dda4b162",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43819",
+					"10.65.0.27:43819",
+					"172.17.0.1:43819",
+					"172.18.0.1:43819",
+					"172.19.0.1:43819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:51:41.035462015Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6444673744224709,
+				"StableID":   "nSXf2meoKs11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b62999515789877c7ef800d988e2f9d98951ebf224463ddbf59d00fd1026fa32",
+				"DiscoKey":   "discokey:d58be7eefc0eaa415a497680047269197f06d9a2fe20930a892f1b12c71e2a50",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38003",
+					"10.65.0.27:38003",
+					"172.17.0.1:38003",
+					"172.18.0.1:38003",
+					"172.19.0.1:38003"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:51:41.605890793Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8764868429056629,
+				"StableID":   "nY8FCQEdSB21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e199a38fae627dfaff452c02f19bad662f2fe86abda72fd7e2c2702a1149b15",
+				"DiscoKey":   "discokey:346e022c2fb936b13f9ec7e0a36949c59b9b2d35d1a61aff9b3b6d4e33ab0d79",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53248",
+					"10.65.0.27:53248",
+					"172.17.0.1:53248",
+					"172.18.0.1:53248",
+					"172.19.0.1:53248"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:51:42.824577674Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4223447621657124,
+				"StableID":   "nDBvopooyZ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aac3b7b1280cac6b5928330d55d45daa07c02fc8900943baf8f3f79b8e67980c",
+				"DiscoKey":   "discokey:820fa969dc306c4cf52f0c29d8020c6d4ba292e9d8f28d9f3e504ce67fb12d1e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51080",
+					"10.65.0.27:51080",
+					"172.17.0.1:51080",
+					"172.18.0.1:51080",
+					"172.19.0.1:51080"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:51:43.439981461Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8100241366053895,
+				"StableID":   "nxZbY6ccF621CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fbcddd6df0764cde26ec82ece56ec7d003961c0a0a70a549896f6eed8f232d12",
+				"DiscoKey":   "discokey:cead8ea24d9a4416efb1166e29ed225ae9ff0a3dc994429c79a753088b19cc1f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41397",
+					"10.65.0.27:41397",
+					"172.17.0.1:41397",
+					"172.18.0.1:41397",
+					"172.19.0.1:41397"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:51:43.988243603Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3983629297884225,
+				"StableID":   "naRskpBC7Y11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a114b46675991ab6e62632b5c5f5d3bf3e94dabf03505f444aed2bcd68999d55",
+				"DiscoKey":   "discokey:e2cda9587784a622bdd15c4c1f626c591e2ad814ca3153f27a22d706113f8d5a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:55724",
+					"10.65.0.27:55724",
+					"172.17.0.1:55724",
+					"172.18.0.1:55724",
+					"172.19.0.1:55724"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:51:44.523493178Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8388054674282503,
+				"StableID":   "narJ2RyxV821CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:be680e169e4274024ba4d68cfb5d5f0ed0d4258bce27ed3fab54b482df3dca70",
+				"KeyExpiry":  "2026-11-08T21:51:45Z",
+				"DiscoKey":   "discokey:2f6143628ccdbcb58f9f4c5329d3678452f9669dd6f0e3222212d52c1a210861",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45313",
+					"10.65.0.27:45313",
+					"172.17.0.1:45313",
+					"172.18.0.1:45313",
+					"172.19.0.1:45313"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:51:45.068378828Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6571167376157198,
+				"StableID":   "nd6H8cR6Kt11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a33f4048e2b1ac9a2cb28d85a2bb6c91a64ae6c14341118a4f1e1518d68d7477",
+				"KeyExpiry":  "2026-11-08T21:51:45Z",
+				"DiscoKey":   "discokey:ce3284585a008b1b247aa7694af4a7af46c1bc9f3922cb6bbd327daf61cea534",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46040",
+					"10.65.0.27:46040",
+					"172.17.0.1:46040",
+					"172.18.0.1:46040",
+					"172.19.0.1:46040"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:51:45.724213033Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2056737066031535,
+				"StableID":   "nSrUZizV4H11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f871bb25d314e4e9f73fbb700492f2f12d54367142b028e215c816fd59a5ca27",
+				"KeyExpiry":  "2026-11-08T21:51:46Z",
+				"DiscoKey":   "discokey:ff1a96cd82ec6ea8e4988deba4a8542697f036d9ff8f396ac7bcc8f68547b835",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47753",
+					"10.65.0.27:47753",
+					"172.17.0.1:47753",
+					"172.18.0.1:47753",
+					"172.19.0.1:47753"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:51:46.402631464Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7170555244955655": {
+				"ID":          7170555244955655,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3740735190292067,
+				"StableID":   "nUumDgmBDW11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       3740735190292067,
+				"Key":        "nodekey:c54cd3f2733c308db78096efbe6197089911891a7d8e10b20442576d67246d2f",
+				"DiscoKey":   "discokey:a00fa6830438f7af48ba8625bdac76b49db54c2831d1fdbee51f13e433d12664",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:60844",
+					"10.65.0.27:60844",
+					"172.17.0.1:60844",
+					"172.18.0.1:60844",
+					"172.19.0.1:60844"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:51:37.823637125Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c54cd3f2733c308db78096efbe6197089911891a7d8e10b20442576d67246d2f",
+			"MachineKey": "mkey:4fc61ba2c8547730ef52ffc6a6a9d1e9efdb908aadce4012fbf5ec58372e8845",
+			"Peers": [{
+				"ID":         7170555244955655,
+				"StableID":   "n28sayKZzx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cbecf899f3a6e80cf6000d5eba1b79f173fafead63b49d97d9a167b1f5239a76",
+				"DiscoKey":   "discokey:73faf4c6ef724a76d075d64aee4dee679b7335bab6cce281fe90646b31574a45",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40044",
+					"10.65.0.27:40044",
+					"172.17.0.1:40044",
+					"172.18.0.1:40044",
+					"172.19.0.1:40044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:51:38.329563385Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1943241934471156,
+				"StableID":   "nTxvRtf6BG11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:963a522773752726a3c32b2a9edec14877a84a102cb375b8bfb390ae5c192302",
+				"DiscoKey":   "discokey:db26fe36338aee76899472ce56519f72ce80691d4755ea36d2696373fdec3d54",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:44889",
+					"10.65.0.27:44889",
+					"172.17.0.1:44889",
+					"172.18.0.1:44889",
+					"172.19.0.1:44889"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:51:38.865247333Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2621170226034401,
+				"StableID":   "nQij6Sh8UM11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:caba25eb91ad0c35e2ce3782dac16d3b3dd31d555b8e406a9bdb24b891bbbe4d",
+				"DiscoKey":   "discokey:b0fe86e6c654f6862ef0f47b5f11ef2b40b36d3ff0626e8d540457b93b4d4949",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42859",
+					"10.65.0.27:42859",
+					"172.17.0.1:42859",
+					"172.18.0.1:42859",
+					"172.19.0.1:42859"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:51:39.412896526Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5071159392986909,
+				"StableID":   "nLvwBykjbg11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:60c65c038df4bcda1e567d718586346b198d8bb551886f826f76988959c75206",
+				"DiscoKey":   "discokey:91f11f812c508a90ecd1c9ec8e0f1233e64f4e14664c55fa8c59bcc1a71c5f44",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37471",
+					"10.65.0.27:37471",
+					"172.17.0.1:37471",
+					"172.18.0.1:37471",
+					"172.19.0.1:37471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:51:39.994715221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5097843118802719,
+				"StableID":   "nxuZfGhpog11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1d2962ddf14ba8c0a1fb24d9979d0bac319806525cc8bfbdc2dba4eda710118",
+				"DiscoKey":   "discokey:1f01b0d809bf6b35fb2ccecae788d839c95577493717a912bd2f88c12aec242e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39245",
+					"10.65.0.27:39245",
+					"172.17.0.1:39245",
+					"172.18.0.1:39245",
+					"172.19.0.1:39245"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:51:40.49365522Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6540106155930384,
+				"StableID":   "nyKaTvV25t11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1cda4660ab2df7c9e755447756ae9817d39f5eab6c57a31fc3dbb55a48af2c6c",
+				"DiscoKey":   "discokey:2274fcd7bcc61f82d4bcdebd50ca44e9ab7ab984fb43a0b50a2c9694dda4b162",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43819",
+					"10.65.0.27:43819",
+					"172.17.0.1:43819",
+					"172.18.0.1:43819",
+					"172.19.0.1:43819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:51:41.035462015Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6444673744224709,
+				"StableID":   "nSXf2meoKs11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b62999515789877c7ef800d988e2f9d98951ebf224463ddbf59d00fd1026fa32",
+				"DiscoKey":   "discokey:d58be7eefc0eaa415a497680047269197f06d9a2fe20930a892f1b12c71e2a50",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38003",
+					"10.65.0.27:38003",
+					"172.17.0.1:38003",
+					"172.18.0.1:38003",
+					"172.19.0.1:38003"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:51:41.605890793Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8764868429056629,
+				"StableID":   "nY8FCQEdSB21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e199a38fae627dfaff452c02f19bad662f2fe86abda72fd7e2c2702a1149b15",
+				"DiscoKey":   "discokey:346e022c2fb936b13f9ec7e0a36949c59b9b2d35d1a61aff9b3b6d4e33ab0d79",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53248",
+					"10.65.0.27:53248",
+					"172.17.0.1:53248",
+					"172.18.0.1:53248",
+					"172.19.0.1:53248"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:51:42.824577674Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4223447621657124,
+				"StableID":   "nDBvopooyZ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aac3b7b1280cac6b5928330d55d45daa07c02fc8900943baf8f3f79b8e67980c",
+				"DiscoKey":   "discokey:820fa969dc306c4cf52f0c29d8020c6d4ba292e9d8f28d9f3e504ce67fb12d1e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51080",
+					"10.65.0.27:51080",
+					"172.17.0.1:51080",
+					"172.18.0.1:51080",
+					"172.19.0.1:51080"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:51:43.439981461Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8100241366053895,
+				"StableID":   "nxZbY6ccF621CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fbcddd6df0764cde26ec82ece56ec7d003961c0a0a70a549896f6eed8f232d12",
+				"DiscoKey":   "discokey:cead8ea24d9a4416efb1166e29ed225ae9ff0a3dc994429c79a753088b19cc1f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41397",
+					"10.65.0.27:41397",
+					"172.17.0.1:41397",
+					"172.18.0.1:41397",
+					"172.19.0.1:41397"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:51:43.988243603Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3983629297884225,
+				"StableID":   "naRskpBC7Y11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a114b46675991ab6e62632b5c5f5d3bf3e94dabf03505f444aed2bcd68999d55",
+				"DiscoKey":   "discokey:e2cda9587784a622bdd15c4c1f626c591e2ad814ca3153f27a22d706113f8d5a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:55724",
+					"10.65.0.27:55724",
+					"172.17.0.1:55724",
+					"172.18.0.1:55724",
+					"172.19.0.1:55724"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:51:44.523493178Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8388054674282503,
+				"StableID":   "narJ2RyxV821CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:be680e169e4274024ba4d68cfb5d5f0ed0d4258bce27ed3fab54b482df3dca70",
+				"KeyExpiry":  "2026-11-08T21:51:45Z",
+				"DiscoKey":   "discokey:2f6143628ccdbcb58f9f4c5329d3678452f9669dd6f0e3222212d52c1a210861",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45313",
+					"10.65.0.27:45313",
+					"172.17.0.1:45313",
+					"172.18.0.1:45313",
+					"172.19.0.1:45313"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:51:45.068378828Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6571167376157198,
+				"StableID":   "nd6H8cR6Kt11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a33f4048e2b1ac9a2cb28d85a2bb6c91a64ae6c14341118a4f1e1518d68d7477",
+				"KeyExpiry":  "2026-11-08T21:51:45Z",
+				"DiscoKey":   "discokey:ce3284585a008b1b247aa7694af4a7af46c1bc9f3922cb6bbd327daf61cea534",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46040",
+					"10.65.0.27:46040",
+					"172.17.0.1:46040",
+					"172.18.0.1:46040",
+					"172.19.0.1:46040"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:51:45.724213033Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2056737066031535,
+				"StableID":   "nSrUZizV4H11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f871bb25d314e4e9f73fbb700492f2f12d54367142b028e215c816fd59a5ca27",
+				"KeyExpiry":  "2026-11-08T21:51:46Z",
+				"DiscoKey":   "discokey:ff1a96cd82ec6ea8e4988deba4a8542697f036d9ff8f396ac7bcc8f68547b835",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47753",
+					"10.65.0.27:47753",
+					"172.17.0.1:47753",
+					"172.18.0.1:47753",
+					"172.19.0.1:47753"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:51:46.402631464Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3740735190292067": {
+				"ID":          3740735190292067,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5071159392986909,
+				"StableID":   "nLvwBykjbg11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       5071159392986909,
+				"Key":        "nodekey:60c65c038df4bcda1e567d718586346b198d8bb551886f826f76988959c75206",
+				"DiscoKey":   "discokey:91f11f812c508a90ecd1c9ec8e0f1233e64f4e14664c55fa8c59bcc1a71c5f44",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37471",
+					"10.65.0.27:37471",
+					"172.17.0.1:37471",
+					"172.18.0.1:37471",
+					"172.19.0.1:37471"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:51:39.994715221Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:60c65c038df4bcda1e567d718586346b198d8bb551886f826f76988959c75206",
+			"MachineKey": "mkey:90dc3605efdf7133a5dca27a8494bd2620ae793a57ee8b95739820e7c0982973",
+			"Peers": [{
+				"ID":         3740735190292067,
+				"StableID":   "nUumDgmBDW11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c54cd3f2733c308db78096efbe6197089911891a7d8e10b20442576d67246d2f",
+				"DiscoKey":   "discokey:a00fa6830438f7af48ba8625bdac76b49db54c2831d1fdbee51f13e433d12664",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:60844",
+					"10.65.0.27:60844",
+					"172.17.0.1:60844",
+					"172.18.0.1:60844",
+					"172.19.0.1:60844"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:51:37.823637125Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7170555244955655,
+				"StableID":   "n28sayKZzx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cbecf899f3a6e80cf6000d5eba1b79f173fafead63b49d97d9a167b1f5239a76",
+				"DiscoKey":   "discokey:73faf4c6ef724a76d075d64aee4dee679b7335bab6cce281fe90646b31574a45",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40044",
+					"10.65.0.27:40044",
+					"172.17.0.1:40044",
+					"172.18.0.1:40044",
+					"172.19.0.1:40044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:51:38.329563385Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1943241934471156,
+				"StableID":   "nTxvRtf6BG11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:963a522773752726a3c32b2a9edec14877a84a102cb375b8bfb390ae5c192302",
+				"DiscoKey":   "discokey:db26fe36338aee76899472ce56519f72ce80691d4755ea36d2696373fdec3d54",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:44889",
+					"10.65.0.27:44889",
+					"172.17.0.1:44889",
+					"172.18.0.1:44889",
+					"172.19.0.1:44889"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:51:38.865247333Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2621170226034401,
+				"StableID":   "nQij6Sh8UM11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:caba25eb91ad0c35e2ce3782dac16d3b3dd31d555b8e406a9bdb24b891bbbe4d",
+				"DiscoKey":   "discokey:b0fe86e6c654f6862ef0f47b5f11ef2b40b36d3ff0626e8d540457b93b4d4949",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42859",
+					"10.65.0.27:42859",
+					"172.17.0.1:42859",
+					"172.18.0.1:42859",
+					"172.19.0.1:42859"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:51:39.412896526Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5097843118802719,
+				"StableID":   "nxuZfGhpog11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1d2962ddf14ba8c0a1fb24d9979d0bac319806525cc8bfbdc2dba4eda710118",
+				"DiscoKey":   "discokey:1f01b0d809bf6b35fb2ccecae788d839c95577493717a912bd2f88c12aec242e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39245",
+					"10.65.0.27:39245",
+					"172.17.0.1:39245",
+					"172.18.0.1:39245",
+					"172.19.0.1:39245"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:51:40.49365522Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6540106155930384,
+				"StableID":   "nyKaTvV25t11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1cda4660ab2df7c9e755447756ae9817d39f5eab6c57a31fc3dbb55a48af2c6c",
+				"DiscoKey":   "discokey:2274fcd7bcc61f82d4bcdebd50ca44e9ab7ab984fb43a0b50a2c9694dda4b162",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43819",
+					"10.65.0.27:43819",
+					"172.17.0.1:43819",
+					"172.18.0.1:43819",
+					"172.19.0.1:43819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:51:41.035462015Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6444673744224709,
+				"StableID":   "nSXf2meoKs11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b62999515789877c7ef800d988e2f9d98951ebf224463ddbf59d00fd1026fa32",
+				"DiscoKey":   "discokey:d58be7eefc0eaa415a497680047269197f06d9a2fe20930a892f1b12c71e2a50",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38003",
+					"10.65.0.27:38003",
+					"172.17.0.1:38003",
+					"172.18.0.1:38003",
+					"172.19.0.1:38003"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:51:41.605890793Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8764868429056629,
+				"StableID":   "nY8FCQEdSB21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e199a38fae627dfaff452c02f19bad662f2fe86abda72fd7e2c2702a1149b15",
+				"DiscoKey":   "discokey:346e022c2fb936b13f9ec7e0a36949c59b9b2d35d1a61aff9b3b6d4e33ab0d79",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53248",
+					"10.65.0.27:53248",
+					"172.17.0.1:53248",
+					"172.18.0.1:53248",
+					"172.19.0.1:53248"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:51:42.824577674Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4223447621657124,
+				"StableID":   "nDBvopooyZ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aac3b7b1280cac6b5928330d55d45daa07c02fc8900943baf8f3f79b8e67980c",
+				"DiscoKey":   "discokey:820fa969dc306c4cf52f0c29d8020c6d4ba292e9d8f28d9f3e504ce67fb12d1e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51080",
+					"10.65.0.27:51080",
+					"172.17.0.1:51080",
+					"172.18.0.1:51080",
+					"172.19.0.1:51080"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:51:43.439981461Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8100241366053895,
+				"StableID":   "nxZbY6ccF621CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fbcddd6df0764cde26ec82ece56ec7d003961c0a0a70a549896f6eed8f232d12",
+				"DiscoKey":   "discokey:cead8ea24d9a4416efb1166e29ed225ae9ff0a3dc994429c79a753088b19cc1f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41397",
+					"10.65.0.27:41397",
+					"172.17.0.1:41397",
+					"172.18.0.1:41397",
+					"172.19.0.1:41397"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:51:43.988243603Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3983629297884225,
+				"StableID":   "naRskpBC7Y11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a114b46675991ab6e62632b5c5f5d3bf3e94dabf03505f444aed2bcd68999d55",
+				"DiscoKey":   "discokey:e2cda9587784a622bdd15c4c1f626c591e2ad814ca3153f27a22d706113f8d5a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:55724",
+					"10.65.0.27:55724",
+					"172.17.0.1:55724",
+					"172.18.0.1:55724",
+					"172.19.0.1:55724"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:51:44.523493178Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8388054674282503,
+				"StableID":   "narJ2RyxV821CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:be680e169e4274024ba4d68cfb5d5f0ed0d4258bce27ed3fab54b482df3dca70",
+				"KeyExpiry":  "2026-11-08T21:51:45Z",
+				"DiscoKey":   "discokey:2f6143628ccdbcb58f9f4c5329d3678452f9669dd6f0e3222212d52c1a210861",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45313",
+					"10.65.0.27:45313",
+					"172.17.0.1:45313",
+					"172.18.0.1:45313",
+					"172.19.0.1:45313"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:51:45.068378828Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6571167376157198,
+				"StableID":   "nd6H8cR6Kt11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a33f4048e2b1ac9a2cb28d85a2bb6c91a64ae6c14341118a4f1e1518d68d7477",
+				"KeyExpiry":  "2026-11-08T21:51:45Z",
+				"DiscoKey":   "discokey:ce3284585a008b1b247aa7694af4a7af46c1bc9f3922cb6bbd327daf61cea534",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46040",
+					"10.65.0.27:46040",
+					"172.17.0.1:46040",
+					"172.18.0.1:46040",
+					"172.19.0.1:46040"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:51:45.724213033Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2056737066031535,
+				"StableID":   "nSrUZizV4H11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f871bb25d314e4e9f73fbb700492f2f12d54367142b028e215c816fd59a5ca27",
+				"KeyExpiry":  "2026-11-08T21:51:46Z",
+				"DiscoKey":   "discokey:ff1a96cd82ec6ea8e4988deba4a8542697f036d9ff8f396ac7bcc8f68547b835",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47753",
+					"10.65.0.27:47753",
+					"172.17.0.1:47753",
+					"172.18.0.1:47753",
+					"172.19.0.1:47753"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:51:46.402631464Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5071159392986909": {
+				"ID":          5071159392986909,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2621170226034401,
+				"StableID":   "nQij6Sh8UM11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       2621170226034401,
+				"Key":        "nodekey:caba25eb91ad0c35e2ce3782dac16d3b3dd31d555b8e406a9bdb24b891bbbe4d",
+				"DiscoKey":   "discokey:b0fe86e6c654f6862ef0f47b5f11ef2b40b36d3ff0626e8d540457b93b4d4949",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42859",
+					"10.65.0.27:42859",
+					"172.17.0.1:42859",
+					"172.18.0.1:42859",
+					"172.19.0.1:42859"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:51:39.412896526Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:caba25eb91ad0c35e2ce3782dac16d3b3dd31d555b8e406a9bdb24b891bbbe4d",
+			"MachineKey": "mkey:037bdc7730e7b19a5cf7473ddde6b41968f1c86a320c8d8f83e4ddec7e38eb2d",
+			"Peers": [{
+				"ID":         3740735190292067,
+				"StableID":   "nUumDgmBDW11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c54cd3f2733c308db78096efbe6197089911891a7d8e10b20442576d67246d2f",
+				"DiscoKey":   "discokey:a00fa6830438f7af48ba8625bdac76b49db54c2831d1fdbee51f13e433d12664",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:60844",
+					"10.65.0.27:60844",
+					"172.17.0.1:60844",
+					"172.18.0.1:60844",
+					"172.19.0.1:60844"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:51:37.823637125Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7170555244955655,
+				"StableID":   "n28sayKZzx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cbecf899f3a6e80cf6000d5eba1b79f173fafead63b49d97d9a167b1f5239a76",
+				"DiscoKey":   "discokey:73faf4c6ef724a76d075d64aee4dee679b7335bab6cce281fe90646b31574a45",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40044",
+					"10.65.0.27:40044",
+					"172.17.0.1:40044",
+					"172.18.0.1:40044",
+					"172.19.0.1:40044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:51:38.329563385Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1943241934471156,
+				"StableID":   "nTxvRtf6BG11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:963a522773752726a3c32b2a9edec14877a84a102cb375b8bfb390ae5c192302",
+				"DiscoKey":   "discokey:db26fe36338aee76899472ce56519f72ce80691d4755ea36d2696373fdec3d54",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:44889",
+					"10.65.0.27:44889",
+					"172.17.0.1:44889",
+					"172.18.0.1:44889",
+					"172.19.0.1:44889"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:51:38.865247333Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5071159392986909,
+				"StableID":   "nLvwBykjbg11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:60c65c038df4bcda1e567d718586346b198d8bb551886f826f76988959c75206",
+				"DiscoKey":   "discokey:91f11f812c508a90ecd1c9ec8e0f1233e64f4e14664c55fa8c59bcc1a71c5f44",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37471",
+					"10.65.0.27:37471",
+					"172.17.0.1:37471",
+					"172.18.0.1:37471",
+					"172.19.0.1:37471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:51:39.994715221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5097843118802719,
+				"StableID":   "nxuZfGhpog11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1d2962ddf14ba8c0a1fb24d9979d0bac319806525cc8bfbdc2dba4eda710118",
+				"DiscoKey":   "discokey:1f01b0d809bf6b35fb2ccecae788d839c95577493717a912bd2f88c12aec242e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39245",
+					"10.65.0.27:39245",
+					"172.17.0.1:39245",
+					"172.18.0.1:39245",
+					"172.19.0.1:39245"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:51:40.49365522Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6540106155930384,
+				"StableID":   "nyKaTvV25t11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1cda4660ab2df7c9e755447756ae9817d39f5eab6c57a31fc3dbb55a48af2c6c",
+				"DiscoKey":   "discokey:2274fcd7bcc61f82d4bcdebd50ca44e9ab7ab984fb43a0b50a2c9694dda4b162",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43819",
+					"10.65.0.27:43819",
+					"172.17.0.1:43819",
+					"172.18.0.1:43819",
+					"172.19.0.1:43819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:51:41.035462015Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6444673744224709,
+				"StableID":   "nSXf2meoKs11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b62999515789877c7ef800d988e2f9d98951ebf224463ddbf59d00fd1026fa32",
+				"DiscoKey":   "discokey:d58be7eefc0eaa415a497680047269197f06d9a2fe20930a892f1b12c71e2a50",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38003",
+					"10.65.0.27:38003",
+					"172.17.0.1:38003",
+					"172.18.0.1:38003",
+					"172.19.0.1:38003"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:51:41.605890793Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8764868429056629,
+				"StableID":   "nY8FCQEdSB21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e199a38fae627dfaff452c02f19bad662f2fe86abda72fd7e2c2702a1149b15",
+				"DiscoKey":   "discokey:346e022c2fb936b13f9ec7e0a36949c59b9b2d35d1a61aff9b3b6d4e33ab0d79",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53248",
+					"10.65.0.27:53248",
+					"172.17.0.1:53248",
+					"172.18.0.1:53248",
+					"172.19.0.1:53248"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:51:42.824577674Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4223447621657124,
+				"StableID":   "nDBvopooyZ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aac3b7b1280cac6b5928330d55d45daa07c02fc8900943baf8f3f79b8e67980c",
+				"DiscoKey":   "discokey:820fa969dc306c4cf52f0c29d8020c6d4ba292e9d8f28d9f3e504ce67fb12d1e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51080",
+					"10.65.0.27:51080",
+					"172.17.0.1:51080",
+					"172.18.0.1:51080",
+					"172.19.0.1:51080"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:51:43.439981461Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8100241366053895,
+				"StableID":   "nxZbY6ccF621CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fbcddd6df0764cde26ec82ece56ec7d003961c0a0a70a549896f6eed8f232d12",
+				"DiscoKey":   "discokey:cead8ea24d9a4416efb1166e29ed225ae9ff0a3dc994429c79a753088b19cc1f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41397",
+					"10.65.0.27:41397",
+					"172.17.0.1:41397",
+					"172.18.0.1:41397",
+					"172.19.0.1:41397"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:51:43.988243603Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3983629297884225,
+				"StableID":   "naRskpBC7Y11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a114b46675991ab6e62632b5c5f5d3bf3e94dabf03505f444aed2bcd68999d55",
+				"DiscoKey":   "discokey:e2cda9587784a622bdd15c4c1f626c591e2ad814ca3153f27a22d706113f8d5a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:55724",
+					"10.65.0.27:55724",
+					"172.17.0.1:55724",
+					"172.18.0.1:55724",
+					"172.19.0.1:55724"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:51:44.523493178Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8388054674282503,
+				"StableID":   "narJ2RyxV821CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:be680e169e4274024ba4d68cfb5d5f0ed0d4258bce27ed3fab54b482df3dca70",
+				"KeyExpiry":  "2026-11-08T21:51:45Z",
+				"DiscoKey":   "discokey:2f6143628ccdbcb58f9f4c5329d3678452f9669dd6f0e3222212d52c1a210861",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45313",
+					"10.65.0.27:45313",
+					"172.17.0.1:45313",
+					"172.18.0.1:45313",
+					"172.19.0.1:45313"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:51:45.068378828Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6571167376157198,
+				"StableID":   "nd6H8cR6Kt11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a33f4048e2b1ac9a2cb28d85a2bb6c91a64ae6c14341118a4f1e1518d68d7477",
+				"KeyExpiry":  "2026-11-08T21:51:45Z",
+				"DiscoKey":   "discokey:ce3284585a008b1b247aa7694af4a7af46c1bc9f3922cb6bbd327daf61cea534",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46040",
+					"10.65.0.27:46040",
+					"172.17.0.1:46040",
+					"172.18.0.1:46040",
+					"172.19.0.1:46040"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:51:45.724213033Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2056737066031535,
+				"StableID":   "nSrUZizV4H11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f871bb25d314e4e9f73fbb700492f2f12d54367142b028e215c816fd59a5ca27",
+				"KeyExpiry":  "2026-11-08T21:51:46Z",
+				"DiscoKey":   "discokey:ff1a96cd82ec6ea8e4988deba4a8542697f036d9ff8f396ac7bcc8f68547b835",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47753",
+					"10.65.0.27:47753",
+					"172.17.0.1:47753",
+					"172.18.0.1:47753",
+					"172.19.0.1:47753"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:51:46.402631464Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2621170226034401": {
+				"ID":          2621170226034401,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6540106155930384,
+				"StableID":   "nyKaTvV25t11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       6540106155930384,
+				"Key":        "nodekey:1cda4660ab2df7c9e755447756ae9817d39f5eab6c57a31fc3dbb55a48af2c6c",
+				"DiscoKey":   "discokey:2274fcd7bcc61f82d4bcdebd50ca44e9ab7ab984fb43a0b50a2c9694dda4b162",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43819",
+					"10.65.0.27:43819",
+					"172.17.0.1:43819",
+					"172.18.0.1:43819",
+					"172.19.0.1:43819"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:51:41.035462015Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1cda4660ab2df7c9e755447756ae9817d39f5eab6c57a31fc3dbb55a48af2c6c",
+			"MachineKey": "mkey:9dfdde94078a154bad3d87259caedf56c1f74eff99d5d546ed112387d991841e",
+			"Peers": [{
+				"ID":         3740735190292067,
+				"StableID":   "nUumDgmBDW11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c54cd3f2733c308db78096efbe6197089911891a7d8e10b20442576d67246d2f",
+				"DiscoKey":   "discokey:a00fa6830438f7af48ba8625bdac76b49db54c2831d1fdbee51f13e433d12664",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:60844",
+					"10.65.0.27:60844",
+					"172.17.0.1:60844",
+					"172.18.0.1:60844",
+					"172.19.0.1:60844"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:51:37.823637125Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7170555244955655,
+				"StableID":   "n28sayKZzx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cbecf899f3a6e80cf6000d5eba1b79f173fafead63b49d97d9a167b1f5239a76",
+				"DiscoKey":   "discokey:73faf4c6ef724a76d075d64aee4dee679b7335bab6cce281fe90646b31574a45",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40044",
+					"10.65.0.27:40044",
+					"172.17.0.1:40044",
+					"172.18.0.1:40044",
+					"172.19.0.1:40044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:51:38.329563385Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1943241934471156,
+				"StableID":   "nTxvRtf6BG11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:963a522773752726a3c32b2a9edec14877a84a102cb375b8bfb390ae5c192302",
+				"DiscoKey":   "discokey:db26fe36338aee76899472ce56519f72ce80691d4755ea36d2696373fdec3d54",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:44889",
+					"10.65.0.27:44889",
+					"172.17.0.1:44889",
+					"172.18.0.1:44889",
+					"172.19.0.1:44889"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:51:38.865247333Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2621170226034401,
+				"StableID":   "nQij6Sh8UM11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:caba25eb91ad0c35e2ce3782dac16d3b3dd31d555b8e406a9bdb24b891bbbe4d",
+				"DiscoKey":   "discokey:b0fe86e6c654f6862ef0f47b5f11ef2b40b36d3ff0626e8d540457b93b4d4949",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42859",
+					"10.65.0.27:42859",
+					"172.17.0.1:42859",
+					"172.18.0.1:42859",
+					"172.19.0.1:42859"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:51:39.412896526Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5071159392986909,
+				"StableID":   "nLvwBykjbg11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:60c65c038df4bcda1e567d718586346b198d8bb551886f826f76988959c75206",
+				"DiscoKey":   "discokey:91f11f812c508a90ecd1c9ec8e0f1233e64f4e14664c55fa8c59bcc1a71c5f44",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37471",
+					"10.65.0.27:37471",
+					"172.17.0.1:37471",
+					"172.18.0.1:37471",
+					"172.19.0.1:37471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:51:39.994715221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5097843118802719,
+				"StableID":   "nxuZfGhpog11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1d2962ddf14ba8c0a1fb24d9979d0bac319806525cc8bfbdc2dba4eda710118",
+				"DiscoKey":   "discokey:1f01b0d809bf6b35fb2ccecae788d839c95577493717a912bd2f88c12aec242e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39245",
+					"10.65.0.27:39245",
+					"172.17.0.1:39245",
+					"172.18.0.1:39245",
+					"172.19.0.1:39245"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:51:40.49365522Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6444673744224709,
+				"StableID":   "nSXf2meoKs11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b62999515789877c7ef800d988e2f9d98951ebf224463ddbf59d00fd1026fa32",
+				"DiscoKey":   "discokey:d58be7eefc0eaa415a497680047269197f06d9a2fe20930a892f1b12c71e2a50",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38003",
+					"10.65.0.27:38003",
+					"172.17.0.1:38003",
+					"172.18.0.1:38003",
+					"172.19.0.1:38003"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:51:41.605890793Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8764868429056629,
+				"StableID":   "nY8FCQEdSB21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e199a38fae627dfaff452c02f19bad662f2fe86abda72fd7e2c2702a1149b15",
+				"DiscoKey":   "discokey:346e022c2fb936b13f9ec7e0a36949c59b9b2d35d1a61aff9b3b6d4e33ab0d79",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53248",
+					"10.65.0.27:53248",
+					"172.17.0.1:53248",
+					"172.18.0.1:53248",
+					"172.19.0.1:53248"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:51:42.824577674Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4223447621657124,
+				"StableID":   "nDBvopooyZ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aac3b7b1280cac6b5928330d55d45daa07c02fc8900943baf8f3f79b8e67980c",
+				"DiscoKey":   "discokey:820fa969dc306c4cf52f0c29d8020c6d4ba292e9d8f28d9f3e504ce67fb12d1e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51080",
+					"10.65.0.27:51080",
+					"172.17.0.1:51080",
+					"172.18.0.1:51080",
+					"172.19.0.1:51080"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:51:43.439981461Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8100241366053895,
+				"StableID":   "nxZbY6ccF621CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fbcddd6df0764cde26ec82ece56ec7d003961c0a0a70a549896f6eed8f232d12",
+				"DiscoKey":   "discokey:cead8ea24d9a4416efb1166e29ed225ae9ff0a3dc994429c79a753088b19cc1f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41397",
+					"10.65.0.27:41397",
+					"172.17.0.1:41397",
+					"172.18.0.1:41397",
+					"172.19.0.1:41397"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:51:43.988243603Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3983629297884225,
+				"StableID":   "naRskpBC7Y11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a114b46675991ab6e62632b5c5f5d3bf3e94dabf03505f444aed2bcd68999d55",
+				"DiscoKey":   "discokey:e2cda9587784a622bdd15c4c1f626c591e2ad814ca3153f27a22d706113f8d5a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:55724",
+					"10.65.0.27:55724",
+					"172.17.0.1:55724",
+					"172.18.0.1:55724",
+					"172.19.0.1:55724"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:51:44.523493178Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8388054674282503,
+				"StableID":   "narJ2RyxV821CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:be680e169e4274024ba4d68cfb5d5f0ed0d4258bce27ed3fab54b482df3dca70",
+				"KeyExpiry":  "2026-11-08T21:51:45Z",
+				"DiscoKey":   "discokey:2f6143628ccdbcb58f9f4c5329d3678452f9669dd6f0e3222212d52c1a210861",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45313",
+					"10.65.0.27:45313",
+					"172.17.0.1:45313",
+					"172.18.0.1:45313",
+					"172.19.0.1:45313"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:51:45.068378828Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6571167376157198,
+				"StableID":   "nd6H8cR6Kt11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a33f4048e2b1ac9a2cb28d85a2bb6c91a64ae6c14341118a4f1e1518d68d7477",
+				"KeyExpiry":  "2026-11-08T21:51:45Z",
+				"DiscoKey":   "discokey:ce3284585a008b1b247aa7694af4a7af46c1bc9f3922cb6bbd327daf61cea534",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46040",
+					"10.65.0.27:46040",
+					"172.17.0.1:46040",
+					"172.18.0.1:46040",
+					"172.19.0.1:46040"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:51:45.724213033Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2056737066031535,
+				"StableID":   "nSrUZizV4H11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f871bb25d314e4e9f73fbb700492f2f12d54367142b028e215c816fd59a5ca27",
+				"KeyExpiry":  "2026-11-08T21:51:46Z",
+				"DiscoKey":   "discokey:ff1a96cd82ec6ea8e4988deba4a8542697f036d9ff8f396ac7bcc8f68547b835",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47753",
+					"10.65.0.27:47753",
+					"172.17.0.1:47753",
+					"172.18.0.1:47753",
+					"172.19.0.1:47753"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:51:46.402631464Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6540106155930384": {
+				"ID":          6540106155930384,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8764868429056629,
+				"StableID":   "nY8FCQEdSB21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       8764868429056629,
+				"Key":        "nodekey:0e199a38fae627dfaff452c02f19bad662f2fe86abda72fd7e2c2702a1149b15",
+				"DiscoKey":   "discokey:346e022c2fb936b13f9ec7e0a36949c59b9b2d35d1a61aff9b3b6d4e33ab0d79",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53248",
+					"10.65.0.27:53248",
+					"172.17.0.1:53248",
+					"172.18.0.1:53248",
+					"172.19.0.1:53248"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:51:42.824577674Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0e199a38fae627dfaff452c02f19bad662f2fe86abda72fd7e2c2702a1149b15",
+			"MachineKey": "mkey:f5c1ae57e9564ed3361852bd2f1246cb6df71123efd12e6043d7a77e9502ac1d",
+			"Peers": [{
+				"ID":         3740735190292067,
+				"StableID":   "nUumDgmBDW11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c54cd3f2733c308db78096efbe6197089911891a7d8e10b20442576d67246d2f",
+				"DiscoKey":   "discokey:a00fa6830438f7af48ba8625bdac76b49db54c2831d1fdbee51f13e433d12664",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:60844",
+					"10.65.0.27:60844",
+					"172.17.0.1:60844",
+					"172.18.0.1:60844",
+					"172.19.0.1:60844"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:51:37.823637125Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7170555244955655,
+				"StableID":   "n28sayKZzx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cbecf899f3a6e80cf6000d5eba1b79f173fafead63b49d97d9a167b1f5239a76",
+				"DiscoKey":   "discokey:73faf4c6ef724a76d075d64aee4dee679b7335bab6cce281fe90646b31574a45",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40044",
+					"10.65.0.27:40044",
+					"172.17.0.1:40044",
+					"172.18.0.1:40044",
+					"172.19.0.1:40044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:51:38.329563385Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1943241934471156,
+				"StableID":   "nTxvRtf6BG11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:963a522773752726a3c32b2a9edec14877a84a102cb375b8bfb390ae5c192302",
+				"DiscoKey":   "discokey:db26fe36338aee76899472ce56519f72ce80691d4755ea36d2696373fdec3d54",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:44889",
+					"10.65.0.27:44889",
+					"172.17.0.1:44889",
+					"172.18.0.1:44889",
+					"172.19.0.1:44889"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:51:38.865247333Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2621170226034401,
+				"StableID":   "nQij6Sh8UM11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:caba25eb91ad0c35e2ce3782dac16d3b3dd31d555b8e406a9bdb24b891bbbe4d",
+				"DiscoKey":   "discokey:b0fe86e6c654f6862ef0f47b5f11ef2b40b36d3ff0626e8d540457b93b4d4949",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42859",
+					"10.65.0.27:42859",
+					"172.17.0.1:42859",
+					"172.18.0.1:42859",
+					"172.19.0.1:42859"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:51:39.412896526Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5071159392986909,
+				"StableID":   "nLvwBykjbg11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:60c65c038df4bcda1e567d718586346b198d8bb551886f826f76988959c75206",
+				"DiscoKey":   "discokey:91f11f812c508a90ecd1c9ec8e0f1233e64f4e14664c55fa8c59bcc1a71c5f44",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37471",
+					"10.65.0.27:37471",
+					"172.17.0.1:37471",
+					"172.18.0.1:37471",
+					"172.19.0.1:37471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:51:39.994715221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5097843118802719,
+				"StableID":   "nxuZfGhpog11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1d2962ddf14ba8c0a1fb24d9979d0bac319806525cc8bfbdc2dba4eda710118",
+				"DiscoKey":   "discokey:1f01b0d809bf6b35fb2ccecae788d839c95577493717a912bd2f88c12aec242e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39245",
+					"10.65.0.27:39245",
+					"172.17.0.1:39245",
+					"172.18.0.1:39245",
+					"172.19.0.1:39245"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:51:40.49365522Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6540106155930384,
+				"StableID":   "nyKaTvV25t11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1cda4660ab2df7c9e755447756ae9817d39f5eab6c57a31fc3dbb55a48af2c6c",
+				"DiscoKey":   "discokey:2274fcd7bcc61f82d4bcdebd50ca44e9ab7ab984fb43a0b50a2c9694dda4b162",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43819",
+					"10.65.0.27:43819",
+					"172.17.0.1:43819",
+					"172.18.0.1:43819",
+					"172.19.0.1:43819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:51:41.035462015Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6444673744224709,
+				"StableID":   "nSXf2meoKs11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b62999515789877c7ef800d988e2f9d98951ebf224463ddbf59d00fd1026fa32",
+				"DiscoKey":   "discokey:d58be7eefc0eaa415a497680047269197f06d9a2fe20930a892f1b12c71e2a50",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38003",
+					"10.65.0.27:38003",
+					"172.17.0.1:38003",
+					"172.18.0.1:38003",
+					"172.19.0.1:38003"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:51:41.605890793Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4223447621657124,
+				"StableID":   "nDBvopooyZ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aac3b7b1280cac6b5928330d55d45daa07c02fc8900943baf8f3f79b8e67980c",
+				"DiscoKey":   "discokey:820fa969dc306c4cf52f0c29d8020c6d4ba292e9d8f28d9f3e504ce67fb12d1e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51080",
+					"10.65.0.27:51080",
+					"172.17.0.1:51080",
+					"172.18.0.1:51080",
+					"172.19.0.1:51080"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:51:43.439981461Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8100241366053895,
+				"StableID":   "nxZbY6ccF621CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fbcddd6df0764cde26ec82ece56ec7d003961c0a0a70a549896f6eed8f232d12",
+				"DiscoKey":   "discokey:cead8ea24d9a4416efb1166e29ed225ae9ff0a3dc994429c79a753088b19cc1f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41397",
+					"10.65.0.27:41397",
+					"172.17.0.1:41397",
+					"172.18.0.1:41397",
+					"172.19.0.1:41397"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:51:43.988243603Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3983629297884225,
+				"StableID":   "naRskpBC7Y11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a114b46675991ab6e62632b5c5f5d3bf3e94dabf03505f444aed2bcd68999d55",
+				"DiscoKey":   "discokey:e2cda9587784a622bdd15c4c1f626c591e2ad814ca3153f27a22d706113f8d5a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:55724",
+					"10.65.0.27:55724",
+					"172.17.0.1:55724",
+					"172.18.0.1:55724",
+					"172.19.0.1:55724"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:51:44.523493178Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8388054674282503,
+				"StableID":   "narJ2RyxV821CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:be680e169e4274024ba4d68cfb5d5f0ed0d4258bce27ed3fab54b482df3dca70",
+				"KeyExpiry":  "2026-11-08T21:51:45Z",
+				"DiscoKey":   "discokey:2f6143628ccdbcb58f9f4c5329d3678452f9669dd6f0e3222212d52c1a210861",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45313",
+					"10.65.0.27:45313",
+					"172.17.0.1:45313",
+					"172.18.0.1:45313",
+					"172.19.0.1:45313"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:51:45.068378828Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6571167376157198,
+				"StableID":   "nd6H8cR6Kt11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a33f4048e2b1ac9a2cb28d85a2bb6c91a64ae6c14341118a4f1e1518d68d7477",
+				"KeyExpiry":  "2026-11-08T21:51:45Z",
+				"DiscoKey":   "discokey:ce3284585a008b1b247aa7694af4a7af46c1bc9f3922cb6bbd327daf61cea534",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46040",
+					"10.65.0.27:46040",
+					"172.17.0.1:46040",
+					"172.18.0.1:46040",
+					"172.19.0.1:46040"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:51:45.724213033Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2056737066031535,
+				"StableID":   "nSrUZizV4H11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f871bb25d314e4e9f73fbb700492f2f12d54367142b028e215c816fd59a5ca27",
+				"KeyExpiry":  "2026-11-08T21:51:46Z",
+				"DiscoKey":   "discokey:ff1a96cd82ec6ea8e4988deba4a8542697f036d9ff8f396ac7bcc8f68547b835",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47753",
+					"10.65.0.27:47753",
+					"172.17.0.1:47753",
+					"172.18.0.1:47753",
+					"172.19.0.1:47753"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:51:46.402631464Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8764868429056629": {
+				"ID":          8764868429056629,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6571167376157198,
+				"StableID":   "nd6H8cR6Kt11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a33f4048e2b1ac9a2cb28d85a2bb6c91a64ae6c14341118a4f1e1518d68d7477",
+				"KeyExpiry":  "2026-11-08T21:51:45Z",
+				"DiscoKey":   "discokey:ce3284585a008b1b247aa7694af4a7af46c1bc9f3922cb6bbd327daf61cea534",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46040",
+					"10.65.0.27:46040",
+					"172.17.0.1:46040",
+					"172.18.0.1:46040",
+					"172.19.0.1:46040"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:51:45.724213033Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a33f4048e2b1ac9a2cb28d85a2bb6c91a64ae6c14341118a4f1e1518d68d7477",
+			"MachineKey": "mkey:93a72cf9fc009b498da7be3007843eaf92d33b258343e045887a0cb802a2210b",
+			"Peers": [{
+				"ID":         3740735190292067,
+				"StableID":   "nUumDgmBDW11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c54cd3f2733c308db78096efbe6197089911891a7d8e10b20442576d67246d2f",
+				"DiscoKey":   "discokey:a00fa6830438f7af48ba8625bdac76b49db54c2831d1fdbee51f13e433d12664",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:60844",
+					"10.65.0.27:60844",
+					"172.17.0.1:60844",
+					"172.18.0.1:60844",
+					"172.19.0.1:60844"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:51:37.823637125Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7170555244955655,
+				"StableID":   "n28sayKZzx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cbecf899f3a6e80cf6000d5eba1b79f173fafead63b49d97d9a167b1f5239a76",
+				"DiscoKey":   "discokey:73faf4c6ef724a76d075d64aee4dee679b7335bab6cce281fe90646b31574a45",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40044",
+					"10.65.0.27:40044",
+					"172.17.0.1:40044",
+					"172.18.0.1:40044",
+					"172.19.0.1:40044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:51:38.329563385Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1943241934471156,
+				"StableID":   "nTxvRtf6BG11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:963a522773752726a3c32b2a9edec14877a84a102cb375b8bfb390ae5c192302",
+				"DiscoKey":   "discokey:db26fe36338aee76899472ce56519f72ce80691d4755ea36d2696373fdec3d54",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:44889",
+					"10.65.0.27:44889",
+					"172.17.0.1:44889",
+					"172.18.0.1:44889",
+					"172.19.0.1:44889"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:51:38.865247333Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2621170226034401,
+				"StableID":   "nQij6Sh8UM11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:caba25eb91ad0c35e2ce3782dac16d3b3dd31d555b8e406a9bdb24b891bbbe4d",
+				"DiscoKey":   "discokey:b0fe86e6c654f6862ef0f47b5f11ef2b40b36d3ff0626e8d540457b93b4d4949",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42859",
+					"10.65.0.27:42859",
+					"172.17.0.1:42859",
+					"172.18.0.1:42859",
+					"172.19.0.1:42859"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:51:39.412896526Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5071159392986909,
+				"StableID":   "nLvwBykjbg11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:60c65c038df4bcda1e567d718586346b198d8bb551886f826f76988959c75206",
+				"DiscoKey":   "discokey:91f11f812c508a90ecd1c9ec8e0f1233e64f4e14664c55fa8c59bcc1a71c5f44",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37471",
+					"10.65.0.27:37471",
+					"172.17.0.1:37471",
+					"172.18.0.1:37471",
+					"172.19.0.1:37471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:51:39.994715221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5097843118802719,
+				"StableID":   "nxuZfGhpog11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1d2962ddf14ba8c0a1fb24d9979d0bac319806525cc8bfbdc2dba4eda710118",
+				"DiscoKey":   "discokey:1f01b0d809bf6b35fb2ccecae788d839c95577493717a912bd2f88c12aec242e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39245",
+					"10.65.0.27:39245",
+					"172.17.0.1:39245",
+					"172.18.0.1:39245",
+					"172.19.0.1:39245"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:51:40.49365522Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6540106155930384,
+				"StableID":   "nyKaTvV25t11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1cda4660ab2df7c9e755447756ae9817d39f5eab6c57a31fc3dbb55a48af2c6c",
+				"DiscoKey":   "discokey:2274fcd7bcc61f82d4bcdebd50ca44e9ab7ab984fb43a0b50a2c9694dda4b162",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43819",
+					"10.65.0.27:43819",
+					"172.17.0.1:43819",
+					"172.18.0.1:43819",
+					"172.19.0.1:43819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:51:41.035462015Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6444673744224709,
+				"StableID":   "nSXf2meoKs11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b62999515789877c7ef800d988e2f9d98951ebf224463ddbf59d00fd1026fa32",
+				"DiscoKey":   "discokey:d58be7eefc0eaa415a497680047269197f06d9a2fe20930a892f1b12c71e2a50",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38003",
+					"10.65.0.27:38003",
+					"172.17.0.1:38003",
+					"172.18.0.1:38003",
+					"172.19.0.1:38003"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:51:41.605890793Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8764868429056629,
+				"StableID":   "nY8FCQEdSB21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e199a38fae627dfaff452c02f19bad662f2fe86abda72fd7e2c2702a1149b15",
+				"DiscoKey":   "discokey:346e022c2fb936b13f9ec7e0a36949c59b9b2d35d1a61aff9b3b6d4e33ab0d79",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53248",
+					"10.65.0.27:53248",
+					"172.17.0.1:53248",
+					"172.18.0.1:53248",
+					"172.19.0.1:53248"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:51:42.824577674Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4223447621657124,
+				"StableID":   "nDBvopooyZ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aac3b7b1280cac6b5928330d55d45daa07c02fc8900943baf8f3f79b8e67980c",
+				"DiscoKey":   "discokey:820fa969dc306c4cf52f0c29d8020c6d4ba292e9d8f28d9f3e504ce67fb12d1e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51080",
+					"10.65.0.27:51080",
+					"172.17.0.1:51080",
+					"172.18.0.1:51080",
+					"172.19.0.1:51080"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:51:43.439981461Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8100241366053895,
+				"StableID":   "nxZbY6ccF621CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fbcddd6df0764cde26ec82ece56ec7d003961c0a0a70a549896f6eed8f232d12",
+				"DiscoKey":   "discokey:cead8ea24d9a4416efb1166e29ed225ae9ff0a3dc994429c79a753088b19cc1f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41397",
+					"10.65.0.27:41397",
+					"172.17.0.1:41397",
+					"172.18.0.1:41397",
+					"172.19.0.1:41397"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:51:43.988243603Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3983629297884225,
+				"StableID":   "naRskpBC7Y11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a114b46675991ab6e62632b5c5f5d3bf3e94dabf03505f444aed2bcd68999d55",
+				"DiscoKey":   "discokey:e2cda9587784a622bdd15c4c1f626c591e2ad814ca3153f27a22d706113f8d5a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:55724",
+					"10.65.0.27:55724",
+					"172.17.0.1:55724",
+					"172.18.0.1:55724",
+					"172.19.0.1:55724"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:51:44.523493178Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8388054674282503,
+				"StableID":   "narJ2RyxV821CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:be680e169e4274024ba4d68cfb5d5f0ed0d4258bce27ed3fab54b482df3dca70",
+				"KeyExpiry":  "2026-11-08T21:51:45Z",
+				"DiscoKey":   "discokey:2f6143628ccdbcb58f9f4c5329d3678452f9669dd6f0e3222212d52c1a210861",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45313",
+					"10.65.0.27:45313",
+					"172.17.0.1:45313",
+					"172.18.0.1:45313",
+					"172.19.0.1:45313"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:51:45.068378828Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2056737066031535,
+				"StableID":   "nSrUZizV4H11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f871bb25d314e4e9f73fbb700492f2f12d54367142b028e215c816fd59a5ca27",
+				"KeyExpiry":  "2026-11-08T21:51:46Z",
+				"DiscoKey":   "discokey:ff1a96cd82ec6ea8e4988deba4a8542697f036d9ff8f396ac7bcc8f68547b835",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47753",
+					"10.65.0.27:47753",
+					"172.17.0.1:47753",
+					"172.18.0.1:47753",
+					"172.19.0.1:47753"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:51:46.402631464Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4223447621657124,
+				"StableID":   "nDBvopooyZ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       4223447621657124,
+				"Key":        "nodekey:aac3b7b1280cac6b5928330d55d45daa07c02fc8900943baf8f3f79b8e67980c",
+				"DiscoKey":   "discokey:820fa969dc306c4cf52f0c29d8020c6d4ba292e9d8f28d9f3e504ce67fb12d1e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51080",
+					"10.65.0.27:51080",
+					"172.17.0.1:51080",
+					"172.18.0.1:51080",
+					"172.19.0.1:51080"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:51:43.439981461Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:aac3b7b1280cac6b5928330d55d45daa07c02fc8900943baf8f3f79b8e67980c",
+			"MachineKey": "mkey:85bebfc1fbf8b84a91d16ac21c4ef108e6c3ba24a1abd8fb7d728a639c667b34",
+			"Peers": [{
+				"ID":         3740735190292067,
+				"StableID":   "nUumDgmBDW11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c54cd3f2733c308db78096efbe6197089911891a7d8e10b20442576d67246d2f",
+				"DiscoKey":   "discokey:a00fa6830438f7af48ba8625bdac76b49db54c2831d1fdbee51f13e433d12664",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:60844",
+					"10.65.0.27:60844",
+					"172.17.0.1:60844",
+					"172.18.0.1:60844",
+					"172.19.0.1:60844"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:51:37.823637125Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7170555244955655,
+				"StableID":   "n28sayKZzx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cbecf899f3a6e80cf6000d5eba1b79f173fafead63b49d97d9a167b1f5239a76",
+				"DiscoKey":   "discokey:73faf4c6ef724a76d075d64aee4dee679b7335bab6cce281fe90646b31574a45",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40044",
+					"10.65.0.27:40044",
+					"172.17.0.1:40044",
+					"172.18.0.1:40044",
+					"172.19.0.1:40044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:51:38.329563385Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1943241934471156,
+				"StableID":   "nTxvRtf6BG11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:963a522773752726a3c32b2a9edec14877a84a102cb375b8bfb390ae5c192302",
+				"DiscoKey":   "discokey:db26fe36338aee76899472ce56519f72ce80691d4755ea36d2696373fdec3d54",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:44889",
+					"10.65.0.27:44889",
+					"172.17.0.1:44889",
+					"172.18.0.1:44889",
+					"172.19.0.1:44889"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:51:38.865247333Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2621170226034401,
+				"StableID":   "nQij6Sh8UM11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:caba25eb91ad0c35e2ce3782dac16d3b3dd31d555b8e406a9bdb24b891bbbe4d",
+				"DiscoKey":   "discokey:b0fe86e6c654f6862ef0f47b5f11ef2b40b36d3ff0626e8d540457b93b4d4949",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42859",
+					"10.65.0.27:42859",
+					"172.17.0.1:42859",
+					"172.18.0.1:42859",
+					"172.19.0.1:42859"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:51:39.412896526Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5071159392986909,
+				"StableID":   "nLvwBykjbg11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:60c65c038df4bcda1e567d718586346b198d8bb551886f826f76988959c75206",
+				"DiscoKey":   "discokey:91f11f812c508a90ecd1c9ec8e0f1233e64f4e14664c55fa8c59bcc1a71c5f44",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37471",
+					"10.65.0.27:37471",
+					"172.17.0.1:37471",
+					"172.18.0.1:37471",
+					"172.19.0.1:37471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:51:39.994715221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5097843118802719,
+				"StableID":   "nxuZfGhpog11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1d2962ddf14ba8c0a1fb24d9979d0bac319806525cc8bfbdc2dba4eda710118",
+				"DiscoKey":   "discokey:1f01b0d809bf6b35fb2ccecae788d839c95577493717a912bd2f88c12aec242e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39245",
+					"10.65.0.27:39245",
+					"172.17.0.1:39245",
+					"172.18.0.1:39245",
+					"172.19.0.1:39245"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:51:40.49365522Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6540106155930384,
+				"StableID":   "nyKaTvV25t11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1cda4660ab2df7c9e755447756ae9817d39f5eab6c57a31fc3dbb55a48af2c6c",
+				"DiscoKey":   "discokey:2274fcd7bcc61f82d4bcdebd50ca44e9ab7ab984fb43a0b50a2c9694dda4b162",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43819",
+					"10.65.0.27:43819",
+					"172.17.0.1:43819",
+					"172.18.0.1:43819",
+					"172.19.0.1:43819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:51:41.035462015Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6444673744224709,
+				"StableID":   "nSXf2meoKs11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b62999515789877c7ef800d988e2f9d98951ebf224463ddbf59d00fd1026fa32",
+				"DiscoKey":   "discokey:d58be7eefc0eaa415a497680047269197f06d9a2fe20930a892f1b12c71e2a50",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38003",
+					"10.65.0.27:38003",
+					"172.17.0.1:38003",
+					"172.18.0.1:38003",
+					"172.19.0.1:38003"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:51:41.605890793Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8764868429056629,
+				"StableID":   "nY8FCQEdSB21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e199a38fae627dfaff452c02f19bad662f2fe86abda72fd7e2c2702a1149b15",
+				"DiscoKey":   "discokey:346e022c2fb936b13f9ec7e0a36949c59b9b2d35d1a61aff9b3b6d4e33ab0d79",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53248",
+					"10.65.0.27:53248",
+					"172.17.0.1:53248",
+					"172.18.0.1:53248",
+					"172.19.0.1:53248"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:51:42.824577674Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8100241366053895,
+				"StableID":   "nxZbY6ccF621CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fbcddd6df0764cde26ec82ece56ec7d003961c0a0a70a549896f6eed8f232d12",
+				"DiscoKey":   "discokey:cead8ea24d9a4416efb1166e29ed225ae9ff0a3dc994429c79a753088b19cc1f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41397",
+					"10.65.0.27:41397",
+					"172.17.0.1:41397",
+					"172.18.0.1:41397",
+					"172.19.0.1:41397"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:51:43.988243603Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3983629297884225,
+				"StableID":   "naRskpBC7Y11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a114b46675991ab6e62632b5c5f5d3bf3e94dabf03505f444aed2bcd68999d55",
+				"DiscoKey":   "discokey:e2cda9587784a622bdd15c4c1f626c591e2ad814ca3153f27a22d706113f8d5a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:55724",
+					"10.65.0.27:55724",
+					"172.17.0.1:55724",
+					"172.18.0.1:55724",
+					"172.19.0.1:55724"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:51:44.523493178Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8388054674282503,
+				"StableID":   "narJ2RyxV821CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:be680e169e4274024ba4d68cfb5d5f0ed0d4258bce27ed3fab54b482df3dca70",
+				"KeyExpiry":  "2026-11-08T21:51:45Z",
+				"DiscoKey":   "discokey:2f6143628ccdbcb58f9f4c5329d3678452f9669dd6f0e3222212d52c1a210861",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45313",
+					"10.65.0.27:45313",
+					"172.17.0.1:45313",
+					"172.18.0.1:45313",
+					"172.19.0.1:45313"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:51:45.068378828Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6571167376157198,
+				"StableID":   "nd6H8cR6Kt11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a33f4048e2b1ac9a2cb28d85a2bb6c91a64ae6c14341118a4f1e1518d68d7477",
+				"KeyExpiry":  "2026-11-08T21:51:45Z",
+				"DiscoKey":   "discokey:ce3284585a008b1b247aa7694af4a7af46c1bc9f3922cb6bbd327daf61cea534",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46040",
+					"10.65.0.27:46040",
+					"172.17.0.1:46040",
+					"172.18.0.1:46040",
+					"172.19.0.1:46040"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:51:45.724213033Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2056737066031535,
+				"StableID":   "nSrUZizV4H11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f871bb25d314e4e9f73fbb700492f2f12d54367142b028e215c816fd59a5ca27",
+				"KeyExpiry":  "2026-11-08T21:51:46Z",
+				"DiscoKey":   "discokey:ff1a96cd82ec6ea8e4988deba4a8542697f036d9ff8f396ac7bcc8f68547b835",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47753",
+					"10.65.0.27:47753",
+					"172.17.0.1:47753",
+					"172.18.0.1:47753",
+					"172.19.0.1:47753"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:51:46.402631464Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4223447621657124": {
+				"ID":          4223447621657124,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-action-missing.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-action-missing.hujson
@@ -1,0 +1,20078 @@
+// ssh-malformed-action-missing
+//
+// ssh action field missing is rejected
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T21:52:22Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-malformed-action-missing",
+	"description":    "ssh action field missing is rejected",
+	"category":       "ssh",
+	"captured_at":    "2026-05-12T21:52:22.435119075Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "action must be specified"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                               \n  \n                                 \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh action field missing is rejected\",\n\t\"id\":          \"ssh-malformed-action-missing\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"dst\":   [\"tag:server\"],\n\t\t\"src\":   [\"autogroup:member\"],\n\t\t\"users\": [\"root\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-malformed/ssh-malformed-action-missing.hujson",
+		"full_policy": {
+			"ssh": [
+				{"dst": ["tag:server"], "src": ["autogroup:member"], "users": ["root"]}
+			],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6704035779830000,
+				"StableID":   "nRMMyoeGMu11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       6704035779830000,
+				"Key":        "nodekey:f074cc8984de067e38e5c898c63f96ade37d719a20ebc7eb3200c50c0fde1c35",
+				"DiscoKey":   "discokey:3f3d642bcd8820b60a2445e9b53fd945fdedfc386738e4029073b064b8781d0f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47324",
+					"10.65.0.27:47324",
+					"172.17.0.1:47324",
+					"172.18.0.1:47324",
+					"172.19.0.1:47324"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:52:31.010533712Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f074cc8984de067e38e5c898c63f96ade37d719a20ebc7eb3200c50c0fde1c35",
+			"MachineKey": "mkey:1dabdc79bd906e0a13d8516423ade6ef8360a6242878b9b134605a43ea38f969",
+			"Peers": [{
+				"ID":         5336743594628542,
+				"StableID":   "nqLydsC2gi11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26ac58a77b2156bd4619c1b8c041d3315892de9247abb0523afb1e1547098618",
+				"DiscoKey":   "discokey:904d3ec64780e7e40556d21045966dfd32ddd5d4e6a98ebc72984b7bbd117d1f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:37908",
+					"10.65.0.27:37908",
+					"172.17.0.1:37908",
+					"172.18.0.1:37908",
+					"172.19.0.1:37908"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:52:25.107245782Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1388943353778738,
+				"StableID":   "nhehxpB4rB11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8c2675ae0569f34d9a313c69691b1e319722b3d094dc21def96c03b505c8129",
+				"DiscoKey":   "discokey:fcafc2fb0a87d63cca6b050946107a4d715afd74448cf9c6da5081ae7ba0e267",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:57209",
+					"10.65.0.27:57209",
+					"172.17.0.1:57209",
+					"172.18.0.1:57209",
+					"172.19.0.1:57209"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:52:25.604523299Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7063401917802150,
+				"StableID":   "nyEazGb2Ax11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:223f4272749196af577b225a7a488610532cce356bf3a9ef8aec33a732e7d920",
+				"DiscoKey":   "discokey:34e83f38efebb14ddbc68acda1c72655c9e535465f8659c4bab1ce374199a442",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:38553",
+					"10.65.0.27:38553",
+					"172.17.0.1:38553",
+					"172.18.0.1:38553",
+					"172.19.0.1:38553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:52:26.149992802Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3197928985796109,
+				"StableID":   "n4SXgxAMyR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:642e7824806b8d06f25632a58b0300762b847fdb9f45e2c96afc6d5ebe9c7d16",
+				"DiscoKey":   "discokey:c99cff6692c3e4230abeb4c21a72307ed8ea4b12fcf7568fc7697d11e49b6c19",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49441",
+					"10.65.0.27:49441",
+					"172.17.0.1:49441",
+					"172.18.0.1:49441",
+					"172.19.0.1:49441"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:52:26.686954215Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4894805468870921,
+				"StableID":   "npgzotEsDf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8815bb6fd1367e7b3fb2827c8a64c20f385f3b66ca40d124931686fb53c0eb65",
+				"DiscoKey":   "discokey:ccb7ddfb790f135f8533768289d8dea0bec6a3aa1bd826a290726d4a0f716141",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38997",
+					"10.65.0.27:38997",
+					"172.17.0.1:38997",
+					"172.18.0.1:38997",
+					"172.19.0.1:38997"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:52:27.249206735Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1628686280806333,
+				"StableID":   "nnoiTxpdiD11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36d642e7af7d50ac8fd9d02a46fb66fd669914079967945a86bd5eb18c1ae021",
+				"DiscoKey":   "discokey:dea8201be35ee0d8f039d5304fc9eb32e680350de08b2ad2f60bee092b1add4f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39925",
+					"10.65.0.27:39925",
+					"172.17.0.1:39925",
+					"172.18.0.1:39925",
+					"172.19.0.1:39925"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:52:27.770269562Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         482423346820269,
+				"StableID":   "nJfHBiSVm411CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b891c764ae0185ebd75bc03f9813d8b1026185bec3366cd00b79bcb7ba86fa3b",
+				"DiscoKey":   "discokey:e41c116c21b3acb560340a6f7ec790312d66bb78a112eb66249afbaa4341f86c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57372",
+					"10.65.0.27:57372",
+					"172.17.0.1:57372",
+					"172.18.0.1:57372",
+					"172.19.0.1:57372"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:52:28.304998679Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5908298984831681,
+				"StableID":   "nJyfGkzs8o11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc9491e039887d5166e1abf3cce0d056baf550e0477367d054bbe9dea2afee61",
+				"DiscoKey":   "discokey:c3a139b292d4bcae4414eb364e4f8d0156a67a267cb48a44fd236c0ccb8cde11",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:44308",
+					"10.65.0.27:44308",
+					"172.17.0.1:44308",
+					"172.18.0.1:44308",
+					"172.19.0.1:44308"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:52:28.84662133Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         338363147555957,
+				"StableID":   "nSMQg7EFe311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7261332eca0497d23625c1d6e05a40c3abbcd586ffecbd92dd75c8bc63af573e",
+				"DiscoKey":   "discokey:9264de6ae10d5ebd6c4c08a3df227df02accadb4646181181f6f625f7ca7dc54",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44522",
+					"10.65.0.27:44522",
+					"172.17.0.1:44522",
+					"172.18.0.1:44522",
+					"172.19.0.1:44522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:52:29.387544549Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5882942605188778,
+				"StableID":   "nu89qjvPwn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ad000e396248db10eaa3cec51f475b8beca1f2411d4aff38f7bad70b774a543",
+				"DiscoKey":   "discokey:1a5bd847423d07e723964f03d8caa85d14523d5ac342995f2ef636895e5f0d6e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38359",
+					"10.65.0.27:38359",
+					"172.17.0.1:38359",
+					"172.18.0.1:38359",
+					"172.19.0.1:38359"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:52:29.929902408Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2162014968835529,
+				"StableID":   "niRmK6UBtH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a500226877487a7c409c3701b5f7e7db9e3ee5e8437756d705280747e4b8a6f",
+				"DiscoKey":   "discokey:b9cc07e45a1fb2e06d9392ce347aad2dad3af5c43c871814daf89e5facb47566",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42328",
+					"10.65.0.27:42328",
+					"172.17.0.1:42328",
+					"172.18.0.1:42328",
+					"172.19.0.1:42328"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:52:30.515991067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1415764837397018,
+				"StableID":   "nfu4d1kC4C11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a2fb3f1ea5c159fd6d0e07fb200fc0d6724a637a93e38d6a7dc4d4278746c27d",
+				"KeyExpiry":  "2026-11-08T21:52:31Z",
+				"DiscoKey":   "discokey:55af747d47ba3d00676ecb7d951c060930babb53891ec6b8d4a17ed738b74008",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52384",
+					"10.65.0.27:52384",
+					"172.17.0.1:52384",
+					"172.18.0.1:52384",
+					"172.19.0.1:52384"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:52:31.580694753Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7269730603186265,
+				"StableID":   "nJV5PkVUmy11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b703bee326c0c54e09bebeb1901b01e9c330928178e6fe2a0f80b99784b99561",
+				"KeyExpiry":  "2026-11-08T21:52:32Z",
+				"DiscoKey":   "discokey:f57df15cc665ce3cf4830de0a362e246d9b575f7db817a8ed1ce8e307253b663",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50595",
+					"10.65.0.27:50595",
+					"172.17.0.1:50595",
+					"172.18.0.1:50595",
+					"172.19.0.1:50595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:52:32.104077102Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3574989046928154,
+				"StableID":   "nTjv6Du7vU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7786be5ee86a446d73b1c09a05f83483944163c703d9f1ac75fa8ea92410c375",
+				"KeyExpiry":  "2026-11-08T21:52:32Z",
+				"DiscoKey":   "discokey:ccf5277a82b195f1fc6f4672b0b8258d337339b0fac2e309fcff85b284753f38",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:43607",
+					"10.65.0.27:43607",
+					"172.17.0.1:43607",
+					"172.18.0.1:43607",
+					"172.19.0.1:43607"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:52:32.637445732Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6704035779830000": {
+				"ID":          6704035779830000,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1628686280806333,
+				"StableID":   "nnoiTxpdiD11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1628686280806333,
+				"Key":        "nodekey:36d642e7af7d50ac8fd9d02a46fb66fd669914079967945a86bd5eb18c1ae021",
+				"DiscoKey":   "discokey:dea8201be35ee0d8f039d5304fc9eb32e680350de08b2ad2f60bee092b1add4f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39925",
+					"10.65.0.27:39925",
+					"172.17.0.1:39925",
+					"172.18.0.1:39925",
+					"172.19.0.1:39925"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:52:27.770269562Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:36d642e7af7d50ac8fd9d02a46fb66fd669914079967945a86bd5eb18c1ae021",
+			"MachineKey": "mkey:4862e1b0a45aca23686aca155ffc02dff19601f9ba912d0c0e04257782824d3a",
+			"Peers": [{
+				"ID":         5336743594628542,
+				"StableID":   "nqLydsC2gi11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26ac58a77b2156bd4619c1b8c041d3315892de9247abb0523afb1e1547098618",
+				"DiscoKey":   "discokey:904d3ec64780e7e40556d21045966dfd32ddd5d4e6a98ebc72984b7bbd117d1f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:37908",
+					"10.65.0.27:37908",
+					"172.17.0.1:37908",
+					"172.18.0.1:37908",
+					"172.19.0.1:37908"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:52:25.107245782Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1388943353778738,
+				"StableID":   "nhehxpB4rB11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8c2675ae0569f34d9a313c69691b1e319722b3d094dc21def96c03b505c8129",
+				"DiscoKey":   "discokey:fcafc2fb0a87d63cca6b050946107a4d715afd74448cf9c6da5081ae7ba0e267",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:57209",
+					"10.65.0.27:57209",
+					"172.17.0.1:57209",
+					"172.18.0.1:57209",
+					"172.19.0.1:57209"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:52:25.604523299Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7063401917802150,
+				"StableID":   "nyEazGb2Ax11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:223f4272749196af577b225a7a488610532cce356bf3a9ef8aec33a732e7d920",
+				"DiscoKey":   "discokey:34e83f38efebb14ddbc68acda1c72655c9e535465f8659c4bab1ce374199a442",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:38553",
+					"10.65.0.27:38553",
+					"172.17.0.1:38553",
+					"172.18.0.1:38553",
+					"172.19.0.1:38553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:52:26.149992802Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3197928985796109,
+				"StableID":   "n4SXgxAMyR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:642e7824806b8d06f25632a58b0300762b847fdb9f45e2c96afc6d5ebe9c7d16",
+				"DiscoKey":   "discokey:c99cff6692c3e4230abeb4c21a72307ed8ea4b12fcf7568fc7697d11e49b6c19",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49441",
+					"10.65.0.27:49441",
+					"172.17.0.1:49441",
+					"172.18.0.1:49441",
+					"172.19.0.1:49441"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:52:26.686954215Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4894805468870921,
+				"StableID":   "npgzotEsDf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8815bb6fd1367e7b3fb2827c8a64c20f385f3b66ca40d124931686fb53c0eb65",
+				"DiscoKey":   "discokey:ccb7ddfb790f135f8533768289d8dea0bec6a3aa1bd826a290726d4a0f716141",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38997",
+					"10.65.0.27:38997",
+					"172.17.0.1:38997",
+					"172.18.0.1:38997",
+					"172.19.0.1:38997"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:52:27.249206735Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         482423346820269,
+				"StableID":   "nJfHBiSVm411CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b891c764ae0185ebd75bc03f9813d8b1026185bec3366cd00b79bcb7ba86fa3b",
+				"DiscoKey":   "discokey:e41c116c21b3acb560340a6f7ec790312d66bb78a112eb66249afbaa4341f86c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57372",
+					"10.65.0.27:57372",
+					"172.17.0.1:57372",
+					"172.18.0.1:57372",
+					"172.19.0.1:57372"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:52:28.304998679Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5908298984831681,
+				"StableID":   "nJyfGkzs8o11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc9491e039887d5166e1abf3cce0d056baf550e0477367d054bbe9dea2afee61",
+				"DiscoKey":   "discokey:c3a139b292d4bcae4414eb364e4f8d0156a67a267cb48a44fd236c0ccb8cde11",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:44308",
+					"10.65.0.27:44308",
+					"172.17.0.1:44308",
+					"172.18.0.1:44308",
+					"172.19.0.1:44308"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:52:28.84662133Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         338363147555957,
+				"StableID":   "nSMQg7EFe311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7261332eca0497d23625c1d6e05a40c3abbcd586ffecbd92dd75c8bc63af573e",
+				"DiscoKey":   "discokey:9264de6ae10d5ebd6c4c08a3df227df02accadb4646181181f6f625f7ca7dc54",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44522",
+					"10.65.0.27:44522",
+					"172.17.0.1:44522",
+					"172.18.0.1:44522",
+					"172.19.0.1:44522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:52:29.387544549Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5882942605188778,
+				"StableID":   "nu89qjvPwn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ad000e396248db10eaa3cec51f475b8beca1f2411d4aff38f7bad70b774a543",
+				"DiscoKey":   "discokey:1a5bd847423d07e723964f03d8caa85d14523d5ac342995f2ef636895e5f0d6e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38359",
+					"10.65.0.27:38359",
+					"172.17.0.1:38359",
+					"172.18.0.1:38359",
+					"172.19.0.1:38359"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:52:29.929902408Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2162014968835529,
+				"StableID":   "niRmK6UBtH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a500226877487a7c409c3701b5f7e7db9e3ee5e8437756d705280747e4b8a6f",
+				"DiscoKey":   "discokey:b9cc07e45a1fb2e06d9392ce347aad2dad3af5c43c871814daf89e5facb47566",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42328",
+					"10.65.0.27:42328",
+					"172.17.0.1:42328",
+					"172.18.0.1:42328",
+					"172.19.0.1:42328"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:52:30.515991067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6704035779830000,
+				"StableID":   "nRMMyoeGMu11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f074cc8984de067e38e5c898c63f96ade37d719a20ebc7eb3200c50c0fde1c35",
+				"DiscoKey":   "discokey:3f3d642bcd8820b60a2445e9b53fd945fdedfc386738e4029073b064b8781d0f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47324",
+					"10.65.0.27:47324",
+					"172.17.0.1:47324",
+					"172.18.0.1:47324",
+					"172.19.0.1:47324"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:52:31.010533712Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1415764837397018,
+				"StableID":   "nfu4d1kC4C11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a2fb3f1ea5c159fd6d0e07fb200fc0d6724a637a93e38d6a7dc4d4278746c27d",
+				"KeyExpiry":  "2026-11-08T21:52:31Z",
+				"DiscoKey":   "discokey:55af747d47ba3d00676ecb7d951c060930babb53891ec6b8d4a17ed738b74008",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52384",
+					"10.65.0.27:52384",
+					"172.17.0.1:52384",
+					"172.18.0.1:52384",
+					"172.19.0.1:52384"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:52:31.580694753Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7269730603186265,
+				"StableID":   "nJV5PkVUmy11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b703bee326c0c54e09bebeb1901b01e9c330928178e6fe2a0f80b99784b99561",
+				"KeyExpiry":  "2026-11-08T21:52:32Z",
+				"DiscoKey":   "discokey:f57df15cc665ce3cf4830de0a362e246d9b575f7db817a8ed1ce8e307253b663",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50595",
+					"10.65.0.27:50595",
+					"172.17.0.1:50595",
+					"172.18.0.1:50595",
+					"172.19.0.1:50595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:52:32.104077102Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3574989046928154,
+				"StableID":   "nTjv6Du7vU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7786be5ee86a446d73b1c09a05f83483944163c703d9f1ac75fa8ea92410c375",
+				"KeyExpiry":  "2026-11-08T21:52:32Z",
+				"DiscoKey":   "discokey:ccf5277a82b195f1fc6f4672b0b8258d337339b0fac2e309fcff85b284753f38",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:43607",
+					"10.65.0.27:43607",
+					"172.17.0.1:43607",
+					"172.18.0.1:43607",
+					"172.19.0.1:43607"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:52:32.637445732Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1628686280806333": {
+				"ID":          1628686280806333,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3574989046928154,
+				"StableID":   "nTjv6Du7vU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7786be5ee86a446d73b1c09a05f83483944163c703d9f1ac75fa8ea92410c375",
+				"KeyExpiry":  "2026-11-08T21:52:32Z",
+				"DiscoKey":   "discokey:ccf5277a82b195f1fc6f4672b0b8258d337339b0fac2e309fcff85b284753f38",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:43607",
+					"10.65.0.27:43607",
+					"172.17.0.1:43607",
+					"172.18.0.1:43607",
+					"172.19.0.1:43607"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:52:32.637445732Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7786be5ee86a446d73b1c09a05f83483944163c703d9f1ac75fa8ea92410c375",
+			"MachineKey": "mkey:b8cbe6d55bc555d0c9b8974767c4ff2e7916bf267684081ba4b87d9ed074d37c",
+			"Peers": [{
+				"ID":         5336743594628542,
+				"StableID":   "nqLydsC2gi11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26ac58a77b2156bd4619c1b8c041d3315892de9247abb0523afb1e1547098618",
+				"DiscoKey":   "discokey:904d3ec64780e7e40556d21045966dfd32ddd5d4e6a98ebc72984b7bbd117d1f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:37908",
+					"10.65.0.27:37908",
+					"172.17.0.1:37908",
+					"172.18.0.1:37908",
+					"172.19.0.1:37908"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:52:25.107245782Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1388943353778738,
+				"StableID":   "nhehxpB4rB11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8c2675ae0569f34d9a313c69691b1e319722b3d094dc21def96c03b505c8129",
+				"DiscoKey":   "discokey:fcafc2fb0a87d63cca6b050946107a4d715afd74448cf9c6da5081ae7ba0e267",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:57209",
+					"10.65.0.27:57209",
+					"172.17.0.1:57209",
+					"172.18.0.1:57209",
+					"172.19.0.1:57209"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:52:25.604523299Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7063401917802150,
+				"StableID":   "nyEazGb2Ax11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:223f4272749196af577b225a7a488610532cce356bf3a9ef8aec33a732e7d920",
+				"DiscoKey":   "discokey:34e83f38efebb14ddbc68acda1c72655c9e535465f8659c4bab1ce374199a442",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:38553",
+					"10.65.0.27:38553",
+					"172.17.0.1:38553",
+					"172.18.0.1:38553",
+					"172.19.0.1:38553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:52:26.149992802Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3197928985796109,
+				"StableID":   "n4SXgxAMyR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:642e7824806b8d06f25632a58b0300762b847fdb9f45e2c96afc6d5ebe9c7d16",
+				"DiscoKey":   "discokey:c99cff6692c3e4230abeb4c21a72307ed8ea4b12fcf7568fc7697d11e49b6c19",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49441",
+					"10.65.0.27:49441",
+					"172.17.0.1:49441",
+					"172.18.0.1:49441",
+					"172.19.0.1:49441"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:52:26.686954215Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4894805468870921,
+				"StableID":   "npgzotEsDf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8815bb6fd1367e7b3fb2827c8a64c20f385f3b66ca40d124931686fb53c0eb65",
+				"DiscoKey":   "discokey:ccb7ddfb790f135f8533768289d8dea0bec6a3aa1bd826a290726d4a0f716141",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38997",
+					"10.65.0.27:38997",
+					"172.17.0.1:38997",
+					"172.18.0.1:38997",
+					"172.19.0.1:38997"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:52:27.249206735Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1628686280806333,
+				"StableID":   "nnoiTxpdiD11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36d642e7af7d50ac8fd9d02a46fb66fd669914079967945a86bd5eb18c1ae021",
+				"DiscoKey":   "discokey:dea8201be35ee0d8f039d5304fc9eb32e680350de08b2ad2f60bee092b1add4f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39925",
+					"10.65.0.27:39925",
+					"172.17.0.1:39925",
+					"172.18.0.1:39925",
+					"172.19.0.1:39925"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:52:27.770269562Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         482423346820269,
+				"StableID":   "nJfHBiSVm411CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b891c764ae0185ebd75bc03f9813d8b1026185bec3366cd00b79bcb7ba86fa3b",
+				"DiscoKey":   "discokey:e41c116c21b3acb560340a6f7ec790312d66bb78a112eb66249afbaa4341f86c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57372",
+					"10.65.0.27:57372",
+					"172.17.0.1:57372",
+					"172.18.0.1:57372",
+					"172.19.0.1:57372"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:52:28.304998679Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5908298984831681,
+				"StableID":   "nJyfGkzs8o11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc9491e039887d5166e1abf3cce0d056baf550e0477367d054bbe9dea2afee61",
+				"DiscoKey":   "discokey:c3a139b292d4bcae4414eb364e4f8d0156a67a267cb48a44fd236c0ccb8cde11",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:44308",
+					"10.65.0.27:44308",
+					"172.17.0.1:44308",
+					"172.18.0.1:44308",
+					"172.19.0.1:44308"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:52:28.84662133Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         338363147555957,
+				"StableID":   "nSMQg7EFe311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7261332eca0497d23625c1d6e05a40c3abbcd586ffecbd92dd75c8bc63af573e",
+				"DiscoKey":   "discokey:9264de6ae10d5ebd6c4c08a3df227df02accadb4646181181f6f625f7ca7dc54",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44522",
+					"10.65.0.27:44522",
+					"172.17.0.1:44522",
+					"172.18.0.1:44522",
+					"172.19.0.1:44522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:52:29.387544549Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5882942605188778,
+				"StableID":   "nu89qjvPwn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ad000e396248db10eaa3cec51f475b8beca1f2411d4aff38f7bad70b774a543",
+				"DiscoKey":   "discokey:1a5bd847423d07e723964f03d8caa85d14523d5ac342995f2ef636895e5f0d6e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38359",
+					"10.65.0.27:38359",
+					"172.17.0.1:38359",
+					"172.18.0.1:38359",
+					"172.19.0.1:38359"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:52:29.929902408Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2162014968835529,
+				"StableID":   "niRmK6UBtH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a500226877487a7c409c3701b5f7e7db9e3ee5e8437756d705280747e4b8a6f",
+				"DiscoKey":   "discokey:b9cc07e45a1fb2e06d9392ce347aad2dad3af5c43c871814daf89e5facb47566",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42328",
+					"10.65.0.27:42328",
+					"172.17.0.1:42328",
+					"172.18.0.1:42328",
+					"172.19.0.1:42328"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:52:30.515991067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6704035779830000,
+				"StableID":   "nRMMyoeGMu11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f074cc8984de067e38e5c898c63f96ade37d719a20ebc7eb3200c50c0fde1c35",
+				"DiscoKey":   "discokey:3f3d642bcd8820b60a2445e9b53fd945fdedfc386738e4029073b064b8781d0f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47324",
+					"10.65.0.27:47324",
+					"172.17.0.1:47324",
+					"172.18.0.1:47324",
+					"172.19.0.1:47324"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:52:31.010533712Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1415764837397018,
+				"StableID":   "nfu4d1kC4C11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a2fb3f1ea5c159fd6d0e07fb200fc0d6724a637a93e38d6a7dc4d4278746c27d",
+				"KeyExpiry":  "2026-11-08T21:52:31Z",
+				"DiscoKey":   "discokey:55af747d47ba3d00676ecb7d951c060930babb53891ec6b8d4a17ed738b74008",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52384",
+					"10.65.0.27:52384",
+					"172.17.0.1:52384",
+					"172.18.0.1:52384",
+					"172.19.0.1:52384"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:52:31.580694753Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7269730603186265,
+				"StableID":   "nJV5PkVUmy11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b703bee326c0c54e09bebeb1901b01e9c330928178e6fe2a0f80b99784b99561",
+				"KeyExpiry":  "2026-11-08T21:52:32Z",
+				"DiscoKey":   "discokey:f57df15cc665ce3cf4830de0a362e246d9b575f7db817a8ed1ce8e307253b663",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50595",
+					"10.65.0.27:50595",
+					"172.17.0.1:50595",
+					"172.18.0.1:50595",
+					"172.19.0.1:50595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:52:32.104077102Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7063401917802150,
+				"StableID":   "nyEazGb2Ax11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       7063401917802150,
+				"Key":        "nodekey:223f4272749196af577b225a7a488610532cce356bf3a9ef8aec33a732e7d920",
+				"DiscoKey":   "discokey:34e83f38efebb14ddbc68acda1c72655c9e535465f8659c4bab1ce374199a442",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:38553",
+					"10.65.0.27:38553",
+					"172.17.0.1:38553",
+					"172.18.0.1:38553",
+					"172.19.0.1:38553"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:52:26.149992802Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:223f4272749196af577b225a7a488610532cce356bf3a9ef8aec33a732e7d920",
+			"MachineKey": "mkey:7625c87047ff60ab3524da40cd651ec42a3feab4cb6b2dd66f6f0f2cf1f83060",
+			"Peers": [{
+				"ID":         5336743594628542,
+				"StableID":   "nqLydsC2gi11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26ac58a77b2156bd4619c1b8c041d3315892de9247abb0523afb1e1547098618",
+				"DiscoKey":   "discokey:904d3ec64780e7e40556d21045966dfd32ddd5d4e6a98ebc72984b7bbd117d1f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:37908",
+					"10.65.0.27:37908",
+					"172.17.0.1:37908",
+					"172.18.0.1:37908",
+					"172.19.0.1:37908"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:52:25.107245782Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1388943353778738,
+				"StableID":   "nhehxpB4rB11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8c2675ae0569f34d9a313c69691b1e319722b3d094dc21def96c03b505c8129",
+				"DiscoKey":   "discokey:fcafc2fb0a87d63cca6b050946107a4d715afd74448cf9c6da5081ae7ba0e267",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:57209",
+					"10.65.0.27:57209",
+					"172.17.0.1:57209",
+					"172.18.0.1:57209",
+					"172.19.0.1:57209"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:52:25.604523299Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3197928985796109,
+				"StableID":   "n4SXgxAMyR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:642e7824806b8d06f25632a58b0300762b847fdb9f45e2c96afc6d5ebe9c7d16",
+				"DiscoKey":   "discokey:c99cff6692c3e4230abeb4c21a72307ed8ea4b12fcf7568fc7697d11e49b6c19",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49441",
+					"10.65.0.27:49441",
+					"172.17.0.1:49441",
+					"172.18.0.1:49441",
+					"172.19.0.1:49441"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:52:26.686954215Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4894805468870921,
+				"StableID":   "npgzotEsDf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8815bb6fd1367e7b3fb2827c8a64c20f385f3b66ca40d124931686fb53c0eb65",
+				"DiscoKey":   "discokey:ccb7ddfb790f135f8533768289d8dea0bec6a3aa1bd826a290726d4a0f716141",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38997",
+					"10.65.0.27:38997",
+					"172.17.0.1:38997",
+					"172.18.0.1:38997",
+					"172.19.0.1:38997"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:52:27.249206735Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1628686280806333,
+				"StableID":   "nnoiTxpdiD11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36d642e7af7d50ac8fd9d02a46fb66fd669914079967945a86bd5eb18c1ae021",
+				"DiscoKey":   "discokey:dea8201be35ee0d8f039d5304fc9eb32e680350de08b2ad2f60bee092b1add4f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39925",
+					"10.65.0.27:39925",
+					"172.17.0.1:39925",
+					"172.18.0.1:39925",
+					"172.19.0.1:39925"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:52:27.770269562Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         482423346820269,
+				"StableID":   "nJfHBiSVm411CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b891c764ae0185ebd75bc03f9813d8b1026185bec3366cd00b79bcb7ba86fa3b",
+				"DiscoKey":   "discokey:e41c116c21b3acb560340a6f7ec790312d66bb78a112eb66249afbaa4341f86c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57372",
+					"10.65.0.27:57372",
+					"172.17.0.1:57372",
+					"172.18.0.1:57372",
+					"172.19.0.1:57372"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:52:28.304998679Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5908298984831681,
+				"StableID":   "nJyfGkzs8o11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc9491e039887d5166e1abf3cce0d056baf550e0477367d054bbe9dea2afee61",
+				"DiscoKey":   "discokey:c3a139b292d4bcae4414eb364e4f8d0156a67a267cb48a44fd236c0ccb8cde11",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:44308",
+					"10.65.0.27:44308",
+					"172.17.0.1:44308",
+					"172.18.0.1:44308",
+					"172.19.0.1:44308"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:52:28.84662133Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         338363147555957,
+				"StableID":   "nSMQg7EFe311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7261332eca0497d23625c1d6e05a40c3abbcd586ffecbd92dd75c8bc63af573e",
+				"DiscoKey":   "discokey:9264de6ae10d5ebd6c4c08a3df227df02accadb4646181181f6f625f7ca7dc54",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44522",
+					"10.65.0.27:44522",
+					"172.17.0.1:44522",
+					"172.18.0.1:44522",
+					"172.19.0.1:44522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:52:29.387544549Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5882942605188778,
+				"StableID":   "nu89qjvPwn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ad000e396248db10eaa3cec51f475b8beca1f2411d4aff38f7bad70b774a543",
+				"DiscoKey":   "discokey:1a5bd847423d07e723964f03d8caa85d14523d5ac342995f2ef636895e5f0d6e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38359",
+					"10.65.0.27:38359",
+					"172.17.0.1:38359",
+					"172.18.0.1:38359",
+					"172.19.0.1:38359"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:52:29.929902408Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2162014968835529,
+				"StableID":   "niRmK6UBtH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a500226877487a7c409c3701b5f7e7db9e3ee5e8437756d705280747e4b8a6f",
+				"DiscoKey":   "discokey:b9cc07e45a1fb2e06d9392ce347aad2dad3af5c43c871814daf89e5facb47566",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42328",
+					"10.65.0.27:42328",
+					"172.17.0.1:42328",
+					"172.18.0.1:42328",
+					"172.19.0.1:42328"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:52:30.515991067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6704035779830000,
+				"StableID":   "nRMMyoeGMu11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f074cc8984de067e38e5c898c63f96ade37d719a20ebc7eb3200c50c0fde1c35",
+				"DiscoKey":   "discokey:3f3d642bcd8820b60a2445e9b53fd945fdedfc386738e4029073b064b8781d0f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47324",
+					"10.65.0.27:47324",
+					"172.17.0.1:47324",
+					"172.18.0.1:47324",
+					"172.19.0.1:47324"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:52:31.010533712Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1415764837397018,
+				"StableID":   "nfu4d1kC4C11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a2fb3f1ea5c159fd6d0e07fb200fc0d6724a637a93e38d6a7dc4d4278746c27d",
+				"KeyExpiry":  "2026-11-08T21:52:31Z",
+				"DiscoKey":   "discokey:55af747d47ba3d00676ecb7d951c060930babb53891ec6b8d4a17ed738b74008",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52384",
+					"10.65.0.27:52384",
+					"172.17.0.1:52384",
+					"172.18.0.1:52384",
+					"172.19.0.1:52384"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:52:31.580694753Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7269730603186265,
+				"StableID":   "nJV5PkVUmy11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b703bee326c0c54e09bebeb1901b01e9c330928178e6fe2a0f80b99784b99561",
+				"KeyExpiry":  "2026-11-08T21:52:32Z",
+				"DiscoKey":   "discokey:f57df15cc665ce3cf4830de0a362e246d9b575f7db817a8ed1ce8e307253b663",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50595",
+					"10.65.0.27:50595",
+					"172.17.0.1:50595",
+					"172.18.0.1:50595",
+					"172.19.0.1:50595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:52:32.104077102Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3574989046928154,
+				"StableID":   "nTjv6Du7vU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7786be5ee86a446d73b1c09a05f83483944163c703d9f1ac75fa8ea92410c375",
+				"KeyExpiry":  "2026-11-08T21:52:32Z",
+				"DiscoKey":   "discokey:ccf5277a82b195f1fc6f4672b0b8258d337339b0fac2e309fcff85b284753f38",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:43607",
+					"10.65.0.27:43607",
+					"172.17.0.1:43607",
+					"172.18.0.1:43607",
+					"172.19.0.1:43607"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:52:32.637445732Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7063401917802150": {
+				"ID":          7063401917802150,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5908298984831681,
+				"StableID":   "nJyfGkzs8o11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       5908298984831681,
+				"Key":        "nodekey:fc9491e039887d5166e1abf3cce0d056baf550e0477367d054bbe9dea2afee61",
+				"DiscoKey":   "discokey:c3a139b292d4bcae4414eb364e4f8d0156a67a267cb48a44fd236c0ccb8cde11",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:44308",
+					"10.65.0.27:44308",
+					"172.17.0.1:44308",
+					"172.18.0.1:44308",
+					"172.19.0.1:44308"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:52:28.84662133Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:fc9491e039887d5166e1abf3cce0d056baf550e0477367d054bbe9dea2afee61",
+			"MachineKey": "mkey:170a33068a9ab37662cc0cccfe243e493765a7f8b076acbe0178964012a15263",
+			"Peers": [{
+				"ID":         5336743594628542,
+				"StableID":   "nqLydsC2gi11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26ac58a77b2156bd4619c1b8c041d3315892de9247abb0523afb1e1547098618",
+				"DiscoKey":   "discokey:904d3ec64780e7e40556d21045966dfd32ddd5d4e6a98ebc72984b7bbd117d1f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:37908",
+					"10.65.0.27:37908",
+					"172.17.0.1:37908",
+					"172.18.0.1:37908",
+					"172.19.0.1:37908"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:52:25.107245782Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1388943353778738,
+				"StableID":   "nhehxpB4rB11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8c2675ae0569f34d9a313c69691b1e319722b3d094dc21def96c03b505c8129",
+				"DiscoKey":   "discokey:fcafc2fb0a87d63cca6b050946107a4d715afd74448cf9c6da5081ae7ba0e267",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:57209",
+					"10.65.0.27:57209",
+					"172.17.0.1:57209",
+					"172.18.0.1:57209",
+					"172.19.0.1:57209"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:52:25.604523299Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7063401917802150,
+				"StableID":   "nyEazGb2Ax11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:223f4272749196af577b225a7a488610532cce356bf3a9ef8aec33a732e7d920",
+				"DiscoKey":   "discokey:34e83f38efebb14ddbc68acda1c72655c9e535465f8659c4bab1ce374199a442",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:38553",
+					"10.65.0.27:38553",
+					"172.17.0.1:38553",
+					"172.18.0.1:38553",
+					"172.19.0.1:38553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:52:26.149992802Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3197928985796109,
+				"StableID":   "n4SXgxAMyR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:642e7824806b8d06f25632a58b0300762b847fdb9f45e2c96afc6d5ebe9c7d16",
+				"DiscoKey":   "discokey:c99cff6692c3e4230abeb4c21a72307ed8ea4b12fcf7568fc7697d11e49b6c19",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49441",
+					"10.65.0.27:49441",
+					"172.17.0.1:49441",
+					"172.18.0.1:49441",
+					"172.19.0.1:49441"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:52:26.686954215Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4894805468870921,
+				"StableID":   "npgzotEsDf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8815bb6fd1367e7b3fb2827c8a64c20f385f3b66ca40d124931686fb53c0eb65",
+				"DiscoKey":   "discokey:ccb7ddfb790f135f8533768289d8dea0bec6a3aa1bd826a290726d4a0f716141",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38997",
+					"10.65.0.27:38997",
+					"172.17.0.1:38997",
+					"172.18.0.1:38997",
+					"172.19.0.1:38997"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:52:27.249206735Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1628686280806333,
+				"StableID":   "nnoiTxpdiD11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36d642e7af7d50ac8fd9d02a46fb66fd669914079967945a86bd5eb18c1ae021",
+				"DiscoKey":   "discokey:dea8201be35ee0d8f039d5304fc9eb32e680350de08b2ad2f60bee092b1add4f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39925",
+					"10.65.0.27:39925",
+					"172.17.0.1:39925",
+					"172.18.0.1:39925",
+					"172.19.0.1:39925"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:52:27.770269562Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         482423346820269,
+				"StableID":   "nJfHBiSVm411CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b891c764ae0185ebd75bc03f9813d8b1026185bec3366cd00b79bcb7ba86fa3b",
+				"DiscoKey":   "discokey:e41c116c21b3acb560340a6f7ec790312d66bb78a112eb66249afbaa4341f86c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57372",
+					"10.65.0.27:57372",
+					"172.17.0.1:57372",
+					"172.18.0.1:57372",
+					"172.19.0.1:57372"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:52:28.304998679Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         338363147555957,
+				"StableID":   "nSMQg7EFe311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7261332eca0497d23625c1d6e05a40c3abbcd586ffecbd92dd75c8bc63af573e",
+				"DiscoKey":   "discokey:9264de6ae10d5ebd6c4c08a3df227df02accadb4646181181f6f625f7ca7dc54",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44522",
+					"10.65.0.27:44522",
+					"172.17.0.1:44522",
+					"172.18.0.1:44522",
+					"172.19.0.1:44522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:52:29.387544549Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5882942605188778,
+				"StableID":   "nu89qjvPwn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ad000e396248db10eaa3cec51f475b8beca1f2411d4aff38f7bad70b774a543",
+				"DiscoKey":   "discokey:1a5bd847423d07e723964f03d8caa85d14523d5ac342995f2ef636895e5f0d6e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38359",
+					"10.65.0.27:38359",
+					"172.17.0.1:38359",
+					"172.18.0.1:38359",
+					"172.19.0.1:38359"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:52:29.929902408Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2162014968835529,
+				"StableID":   "niRmK6UBtH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a500226877487a7c409c3701b5f7e7db9e3ee5e8437756d705280747e4b8a6f",
+				"DiscoKey":   "discokey:b9cc07e45a1fb2e06d9392ce347aad2dad3af5c43c871814daf89e5facb47566",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42328",
+					"10.65.0.27:42328",
+					"172.17.0.1:42328",
+					"172.18.0.1:42328",
+					"172.19.0.1:42328"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:52:30.515991067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6704035779830000,
+				"StableID":   "nRMMyoeGMu11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f074cc8984de067e38e5c898c63f96ade37d719a20ebc7eb3200c50c0fde1c35",
+				"DiscoKey":   "discokey:3f3d642bcd8820b60a2445e9b53fd945fdedfc386738e4029073b064b8781d0f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47324",
+					"10.65.0.27:47324",
+					"172.17.0.1:47324",
+					"172.18.0.1:47324",
+					"172.19.0.1:47324"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:52:31.010533712Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1415764837397018,
+				"StableID":   "nfu4d1kC4C11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a2fb3f1ea5c159fd6d0e07fb200fc0d6724a637a93e38d6a7dc4d4278746c27d",
+				"KeyExpiry":  "2026-11-08T21:52:31Z",
+				"DiscoKey":   "discokey:55af747d47ba3d00676ecb7d951c060930babb53891ec6b8d4a17ed738b74008",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52384",
+					"10.65.0.27:52384",
+					"172.17.0.1:52384",
+					"172.18.0.1:52384",
+					"172.19.0.1:52384"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:52:31.580694753Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7269730603186265,
+				"StableID":   "nJV5PkVUmy11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b703bee326c0c54e09bebeb1901b01e9c330928178e6fe2a0f80b99784b99561",
+				"KeyExpiry":  "2026-11-08T21:52:32Z",
+				"DiscoKey":   "discokey:f57df15cc665ce3cf4830de0a362e246d9b575f7db817a8ed1ce8e307253b663",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50595",
+					"10.65.0.27:50595",
+					"172.17.0.1:50595",
+					"172.18.0.1:50595",
+					"172.19.0.1:50595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:52:32.104077102Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3574989046928154,
+				"StableID":   "nTjv6Du7vU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7786be5ee86a446d73b1c09a05f83483944163c703d9f1ac75fa8ea92410c375",
+				"KeyExpiry":  "2026-11-08T21:52:32Z",
+				"DiscoKey":   "discokey:ccf5277a82b195f1fc6f4672b0b8258d337339b0fac2e309fcff85b284753f38",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:43607",
+					"10.65.0.27:43607",
+					"172.17.0.1:43607",
+					"172.18.0.1:43607",
+					"172.19.0.1:43607"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:52:32.637445732Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5908298984831681": {
+				"ID":          5908298984831681,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1415764837397018,
+				"StableID":   "nfu4d1kC4C11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a2fb3f1ea5c159fd6d0e07fb200fc0d6724a637a93e38d6a7dc4d4278746c27d",
+				"KeyExpiry":  "2026-11-08T21:52:31Z",
+				"DiscoKey":   "discokey:55af747d47ba3d00676ecb7d951c060930babb53891ec6b8d4a17ed738b74008",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52384",
+					"10.65.0.27:52384",
+					"172.17.0.1:52384",
+					"172.18.0.1:52384",
+					"172.19.0.1:52384"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:52:31.580694753Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a2fb3f1ea5c159fd6d0e07fb200fc0d6724a637a93e38d6a7dc4d4278746c27d",
+			"MachineKey": "mkey:111fd790cbd379b5da558072b5aaac3d5cfcfff0e37751b70face51870204a39",
+			"Peers": [{
+				"ID":         5336743594628542,
+				"StableID":   "nqLydsC2gi11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26ac58a77b2156bd4619c1b8c041d3315892de9247abb0523afb1e1547098618",
+				"DiscoKey":   "discokey:904d3ec64780e7e40556d21045966dfd32ddd5d4e6a98ebc72984b7bbd117d1f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:37908",
+					"10.65.0.27:37908",
+					"172.17.0.1:37908",
+					"172.18.0.1:37908",
+					"172.19.0.1:37908"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:52:25.107245782Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1388943353778738,
+				"StableID":   "nhehxpB4rB11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8c2675ae0569f34d9a313c69691b1e319722b3d094dc21def96c03b505c8129",
+				"DiscoKey":   "discokey:fcafc2fb0a87d63cca6b050946107a4d715afd74448cf9c6da5081ae7ba0e267",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:57209",
+					"10.65.0.27:57209",
+					"172.17.0.1:57209",
+					"172.18.0.1:57209",
+					"172.19.0.1:57209"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:52:25.604523299Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7063401917802150,
+				"StableID":   "nyEazGb2Ax11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:223f4272749196af577b225a7a488610532cce356bf3a9ef8aec33a732e7d920",
+				"DiscoKey":   "discokey:34e83f38efebb14ddbc68acda1c72655c9e535465f8659c4bab1ce374199a442",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:38553",
+					"10.65.0.27:38553",
+					"172.17.0.1:38553",
+					"172.18.0.1:38553",
+					"172.19.0.1:38553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:52:26.149992802Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3197928985796109,
+				"StableID":   "n4SXgxAMyR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:642e7824806b8d06f25632a58b0300762b847fdb9f45e2c96afc6d5ebe9c7d16",
+				"DiscoKey":   "discokey:c99cff6692c3e4230abeb4c21a72307ed8ea4b12fcf7568fc7697d11e49b6c19",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49441",
+					"10.65.0.27:49441",
+					"172.17.0.1:49441",
+					"172.18.0.1:49441",
+					"172.19.0.1:49441"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:52:26.686954215Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4894805468870921,
+				"StableID":   "npgzotEsDf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8815bb6fd1367e7b3fb2827c8a64c20f385f3b66ca40d124931686fb53c0eb65",
+				"DiscoKey":   "discokey:ccb7ddfb790f135f8533768289d8dea0bec6a3aa1bd826a290726d4a0f716141",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38997",
+					"10.65.0.27:38997",
+					"172.17.0.1:38997",
+					"172.18.0.1:38997",
+					"172.19.0.1:38997"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:52:27.249206735Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1628686280806333,
+				"StableID":   "nnoiTxpdiD11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36d642e7af7d50ac8fd9d02a46fb66fd669914079967945a86bd5eb18c1ae021",
+				"DiscoKey":   "discokey:dea8201be35ee0d8f039d5304fc9eb32e680350de08b2ad2f60bee092b1add4f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39925",
+					"10.65.0.27:39925",
+					"172.17.0.1:39925",
+					"172.18.0.1:39925",
+					"172.19.0.1:39925"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:52:27.770269562Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         482423346820269,
+				"StableID":   "nJfHBiSVm411CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b891c764ae0185ebd75bc03f9813d8b1026185bec3366cd00b79bcb7ba86fa3b",
+				"DiscoKey":   "discokey:e41c116c21b3acb560340a6f7ec790312d66bb78a112eb66249afbaa4341f86c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57372",
+					"10.65.0.27:57372",
+					"172.17.0.1:57372",
+					"172.18.0.1:57372",
+					"172.19.0.1:57372"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:52:28.304998679Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5908298984831681,
+				"StableID":   "nJyfGkzs8o11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc9491e039887d5166e1abf3cce0d056baf550e0477367d054bbe9dea2afee61",
+				"DiscoKey":   "discokey:c3a139b292d4bcae4414eb364e4f8d0156a67a267cb48a44fd236c0ccb8cde11",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:44308",
+					"10.65.0.27:44308",
+					"172.17.0.1:44308",
+					"172.18.0.1:44308",
+					"172.19.0.1:44308"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:52:28.84662133Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         338363147555957,
+				"StableID":   "nSMQg7EFe311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7261332eca0497d23625c1d6e05a40c3abbcd586ffecbd92dd75c8bc63af573e",
+				"DiscoKey":   "discokey:9264de6ae10d5ebd6c4c08a3df227df02accadb4646181181f6f625f7ca7dc54",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44522",
+					"10.65.0.27:44522",
+					"172.17.0.1:44522",
+					"172.18.0.1:44522",
+					"172.19.0.1:44522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:52:29.387544549Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5882942605188778,
+				"StableID":   "nu89qjvPwn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ad000e396248db10eaa3cec51f475b8beca1f2411d4aff38f7bad70b774a543",
+				"DiscoKey":   "discokey:1a5bd847423d07e723964f03d8caa85d14523d5ac342995f2ef636895e5f0d6e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38359",
+					"10.65.0.27:38359",
+					"172.17.0.1:38359",
+					"172.18.0.1:38359",
+					"172.19.0.1:38359"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:52:29.929902408Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2162014968835529,
+				"StableID":   "niRmK6UBtH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a500226877487a7c409c3701b5f7e7db9e3ee5e8437756d705280747e4b8a6f",
+				"DiscoKey":   "discokey:b9cc07e45a1fb2e06d9392ce347aad2dad3af5c43c871814daf89e5facb47566",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42328",
+					"10.65.0.27:42328",
+					"172.17.0.1:42328",
+					"172.18.0.1:42328",
+					"172.19.0.1:42328"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:52:30.515991067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6704035779830000,
+				"StableID":   "nRMMyoeGMu11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f074cc8984de067e38e5c898c63f96ade37d719a20ebc7eb3200c50c0fde1c35",
+				"DiscoKey":   "discokey:3f3d642bcd8820b60a2445e9b53fd945fdedfc386738e4029073b064b8781d0f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47324",
+					"10.65.0.27:47324",
+					"172.17.0.1:47324",
+					"172.18.0.1:47324",
+					"172.19.0.1:47324"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:52:31.010533712Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7269730603186265,
+				"StableID":   "nJV5PkVUmy11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b703bee326c0c54e09bebeb1901b01e9c330928178e6fe2a0f80b99784b99561",
+				"KeyExpiry":  "2026-11-08T21:52:32Z",
+				"DiscoKey":   "discokey:f57df15cc665ce3cf4830de0a362e246d9b575f7db817a8ed1ce8e307253b663",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50595",
+					"10.65.0.27:50595",
+					"172.17.0.1:50595",
+					"172.18.0.1:50595",
+					"172.19.0.1:50595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:52:32.104077102Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3574989046928154,
+				"StableID":   "nTjv6Du7vU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7786be5ee86a446d73b1c09a05f83483944163c703d9f1ac75fa8ea92410c375",
+				"KeyExpiry":  "2026-11-08T21:52:32Z",
+				"DiscoKey":   "discokey:ccf5277a82b195f1fc6f4672b0b8258d337339b0fac2e309fcff85b284753f38",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:43607",
+					"10.65.0.27:43607",
+					"172.17.0.1:43607",
+					"172.18.0.1:43607",
+					"172.19.0.1:43607"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:52:32.637445732Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2162014968835529,
+				"StableID":   "niRmK6UBtH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       2162014968835529,
+				"Key":        "nodekey:3a500226877487a7c409c3701b5f7e7db9e3ee5e8437756d705280747e4b8a6f",
+				"DiscoKey":   "discokey:b9cc07e45a1fb2e06d9392ce347aad2dad3af5c43c871814daf89e5facb47566",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42328",
+					"10.65.0.27:42328",
+					"172.17.0.1:42328",
+					"172.18.0.1:42328",
+					"172.19.0.1:42328"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:52:30.515991067Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3a500226877487a7c409c3701b5f7e7db9e3ee5e8437756d705280747e4b8a6f",
+			"MachineKey": "mkey:21b2f76bb04dd1bd2437f13f8cd944c647476f63d467cec4c1363b2a4af6181a",
+			"Peers": [{
+				"ID":         5336743594628542,
+				"StableID":   "nqLydsC2gi11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26ac58a77b2156bd4619c1b8c041d3315892de9247abb0523afb1e1547098618",
+				"DiscoKey":   "discokey:904d3ec64780e7e40556d21045966dfd32ddd5d4e6a98ebc72984b7bbd117d1f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:37908",
+					"10.65.0.27:37908",
+					"172.17.0.1:37908",
+					"172.18.0.1:37908",
+					"172.19.0.1:37908"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:52:25.107245782Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1388943353778738,
+				"StableID":   "nhehxpB4rB11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8c2675ae0569f34d9a313c69691b1e319722b3d094dc21def96c03b505c8129",
+				"DiscoKey":   "discokey:fcafc2fb0a87d63cca6b050946107a4d715afd74448cf9c6da5081ae7ba0e267",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:57209",
+					"10.65.0.27:57209",
+					"172.17.0.1:57209",
+					"172.18.0.1:57209",
+					"172.19.0.1:57209"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:52:25.604523299Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7063401917802150,
+				"StableID":   "nyEazGb2Ax11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:223f4272749196af577b225a7a488610532cce356bf3a9ef8aec33a732e7d920",
+				"DiscoKey":   "discokey:34e83f38efebb14ddbc68acda1c72655c9e535465f8659c4bab1ce374199a442",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:38553",
+					"10.65.0.27:38553",
+					"172.17.0.1:38553",
+					"172.18.0.1:38553",
+					"172.19.0.1:38553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:52:26.149992802Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3197928985796109,
+				"StableID":   "n4SXgxAMyR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:642e7824806b8d06f25632a58b0300762b847fdb9f45e2c96afc6d5ebe9c7d16",
+				"DiscoKey":   "discokey:c99cff6692c3e4230abeb4c21a72307ed8ea4b12fcf7568fc7697d11e49b6c19",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49441",
+					"10.65.0.27:49441",
+					"172.17.0.1:49441",
+					"172.18.0.1:49441",
+					"172.19.0.1:49441"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:52:26.686954215Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4894805468870921,
+				"StableID":   "npgzotEsDf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8815bb6fd1367e7b3fb2827c8a64c20f385f3b66ca40d124931686fb53c0eb65",
+				"DiscoKey":   "discokey:ccb7ddfb790f135f8533768289d8dea0bec6a3aa1bd826a290726d4a0f716141",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38997",
+					"10.65.0.27:38997",
+					"172.17.0.1:38997",
+					"172.18.0.1:38997",
+					"172.19.0.1:38997"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:52:27.249206735Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1628686280806333,
+				"StableID":   "nnoiTxpdiD11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36d642e7af7d50ac8fd9d02a46fb66fd669914079967945a86bd5eb18c1ae021",
+				"DiscoKey":   "discokey:dea8201be35ee0d8f039d5304fc9eb32e680350de08b2ad2f60bee092b1add4f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39925",
+					"10.65.0.27:39925",
+					"172.17.0.1:39925",
+					"172.18.0.1:39925",
+					"172.19.0.1:39925"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:52:27.770269562Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         482423346820269,
+				"StableID":   "nJfHBiSVm411CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b891c764ae0185ebd75bc03f9813d8b1026185bec3366cd00b79bcb7ba86fa3b",
+				"DiscoKey":   "discokey:e41c116c21b3acb560340a6f7ec790312d66bb78a112eb66249afbaa4341f86c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57372",
+					"10.65.0.27:57372",
+					"172.17.0.1:57372",
+					"172.18.0.1:57372",
+					"172.19.0.1:57372"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:52:28.304998679Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5908298984831681,
+				"StableID":   "nJyfGkzs8o11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc9491e039887d5166e1abf3cce0d056baf550e0477367d054bbe9dea2afee61",
+				"DiscoKey":   "discokey:c3a139b292d4bcae4414eb364e4f8d0156a67a267cb48a44fd236c0ccb8cde11",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:44308",
+					"10.65.0.27:44308",
+					"172.17.0.1:44308",
+					"172.18.0.1:44308",
+					"172.19.0.1:44308"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:52:28.84662133Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         338363147555957,
+				"StableID":   "nSMQg7EFe311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7261332eca0497d23625c1d6e05a40c3abbcd586ffecbd92dd75c8bc63af573e",
+				"DiscoKey":   "discokey:9264de6ae10d5ebd6c4c08a3df227df02accadb4646181181f6f625f7ca7dc54",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44522",
+					"10.65.0.27:44522",
+					"172.17.0.1:44522",
+					"172.18.0.1:44522",
+					"172.19.0.1:44522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:52:29.387544549Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5882942605188778,
+				"StableID":   "nu89qjvPwn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ad000e396248db10eaa3cec51f475b8beca1f2411d4aff38f7bad70b774a543",
+				"DiscoKey":   "discokey:1a5bd847423d07e723964f03d8caa85d14523d5ac342995f2ef636895e5f0d6e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38359",
+					"10.65.0.27:38359",
+					"172.17.0.1:38359",
+					"172.18.0.1:38359",
+					"172.19.0.1:38359"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:52:29.929902408Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6704035779830000,
+				"StableID":   "nRMMyoeGMu11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f074cc8984de067e38e5c898c63f96ade37d719a20ebc7eb3200c50c0fde1c35",
+				"DiscoKey":   "discokey:3f3d642bcd8820b60a2445e9b53fd945fdedfc386738e4029073b064b8781d0f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47324",
+					"10.65.0.27:47324",
+					"172.17.0.1:47324",
+					"172.18.0.1:47324",
+					"172.19.0.1:47324"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:52:31.010533712Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1415764837397018,
+				"StableID":   "nfu4d1kC4C11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a2fb3f1ea5c159fd6d0e07fb200fc0d6724a637a93e38d6a7dc4d4278746c27d",
+				"KeyExpiry":  "2026-11-08T21:52:31Z",
+				"DiscoKey":   "discokey:55af747d47ba3d00676ecb7d951c060930babb53891ec6b8d4a17ed738b74008",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52384",
+					"10.65.0.27:52384",
+					"172.17.0.1:52384",
+					"172.18.0.1:52384",
+					"172.19.0.1:52384"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:52:31.580694753Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7269730603186265,
+				"StableID":   "nJV5PkVUmy11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b703bee326c0c54e09bebeb1901b01e9c330928178e6fe2a0f80b99784b99561",
+				"KeyExpiry":  "2026-11-08T21:52:32Z",
+				"DiscoKey":   "discokey:f57df15cc665ce3cf4830de0a362e246d9b575f7db817a8ed1ce8e307253b663",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50595",
+					"10.65.0.27:50595",
+					"172.17.0.1:50595",
+					"172.18.0.1:50595",
+					"172.19.0.1:50595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:52:32.104077102Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3574989046928154,
+				"StableID":   "nTjv6Du7vU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7786be5ee86a446d73b1c09a05f83483944163c703d9f1ac75fa8ea92410c375",
+				"KeyExpiry":  "2026-11-08T21:52:32Z",
+				"DiscoKey":   "discokey:ccf5277a82b195f1fc6f4672b0b8258d337339b0fac2e309fcff85b284753f38",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:43607",
+					"10.65.0.27:43607",
+					"172.17.0.1:43607",
+					"172.18.0.1:43607",
+					"172.19.0.1:43607"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:52:32.637445732Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2162014968835529": {
+				"ID":          2162014968835529,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1388943353778738,
+				"StableID":   "nhehxpB4rB11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1388943353778738,
+				"Key":        "nodekey:a8c2675ae0569f34d9a313c69691b1e319722b3d094dc21def96c03b505c8129",
+				"DiscoKey":   "discokey:fcafc2fb0a87d63cca6b050946107a4d715afd74448cf9c6da5081ae7ba0e267",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:57209",
+					"10.65.0.27:57209",
+					"172.17.0.1:57209",
+					"172.18.0.1:57209",
+					"172.19.0.1:57209"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:52:25.604523299Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a8c2675ae0569f34d9a313c69691b1e319722b3d094dc21def96c03b505c8129",
+			"MachineKey": "mkey:4b860fc747eea40a2b80d5b4d3dad32405e536cfce56d18b669f0b3e9793fd55",
+			"Peers": [{
+				"ID":         5336743594628542,
+				"StableID":   "nqLydsC2gi11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26ac58a77b2156bd4619c1b8c041d3315892de9247abb0523afb1e1547098618",
+				"DiscoKey":   "discokey:904d3ec64780e7e40556d21045966dfd32ddd5d4e6a98ebc72984b7bbd117d1f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:37908",
+					"10.65.0.27:37908",
+					"172.17.0.1:37908",
+					"172.18.0.1:37908",
+					"172.19.0.1:37908"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:52:25.107245782Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7063401917802150,
+				"StableID":   "nyEazGb2Ax11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:223f4272749196af577b225a7a488610532cce356bf3a9ef8aec33a732e7d920",
+				"DiscoKey":   "discokey:34e83f38efebb14ddbc68acda1c72655c9e535465f8659c4bab1ce374199a442",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:38553",
+					"10.65.0.27:38553",
+					"172.17.0.1:38553",
+					"172.18.0.1:38553",
+					"172.19.0.1:38553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:52:26.149992802Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3197928985796109,
+				"StableID":   "n4SXgxAMyR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:642e7824806b8d06f25632a58b0300762b847fdb9f45e2c96afc6d5ebe9c7d16",
+				"DiscoKey":   "discokey:c99cff6692c3e4230abeb4c21a72307ed8ea4b12fcf7568fc7697d11e49b6c19",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49441",
+					"10.65.0.27:49441",
+					"172.17.0.1:49441",
+					"172.18.0.1:49441",
+					"172.19.0.1:49441"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:52:26.686954215Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4894805468870921,
+				"StableID":   "npgzotEsDf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8815bb6fd1367e7b3fb2827c8a64c20f385f3b66ca40d124931686fb53c0eb65",
+				"DiscoKey":   "discokey:ccb7ddfb790f135f8533768289d8dea0bec6a3aa1bd826a290726d4a0f716141",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38997",
+					"10.65.0.27:38997",
+					"172.17.0.1:38997",
+					"172.18.0.1:38997",
+					"172.19.0.1:38997"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:52:27.249206735Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1628686280806333,
+				"StableID":   "nnoiTxpdiD11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36d642e7af7d50ac8fd9d02a46fb66fd669914079967945a86bd5eb18c1ae021",
+				"DiscoKey":   "discokey:dea8201be35ee0d8f039d5304fc9eb32e680350de08b2ad2f60bee092b1add4f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39925",
+					"10.65.0.27:39925",
+					"172.17.0.1:39925",
+					"172.18.0.1:39925",
+					"172.19.0.1:39925"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:52:27.770269562Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         482423346820269,
+				"StableID":   "nJfHBiSVm411CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b891c764ae0185ebd75bc03f9813d8b1026185bec3366cd00b79bcb7ba86fa3b",
+				"DiscoKey":   "discokey:e41c116c21b3acb560340a6f7ec790312d66bb78a112eb66249afbaa4341f86c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57372",
+					"10.65.0.27:57372",
+					"172.17.0.1:57372",
+					"172.18.0.1:57372",
+					"172.19.0.1:57372"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:52:28.304998679Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5908298984831681,
+				"StableID":   "nJyfGkzs8o11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc9491e039887d5166e1abf3cce0d056baf550e0477367d054bbe9dea2afee61",
+				"DiscoKey":   "discokey:c3a139b292d4bcae4414eb364e4f8d0156a67a267cb48a44fd236c0ccb8cde11",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:44308",
+					"10.65.0.27:44308",
+					"172.17.0.1:44308",
+					"172.18.0.1:44308",
+					"172.19.0.1:44308"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:52:28.84662133Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         338363147555957,
+				"StableID":   "nSMQg7EFe311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7261332eca0497d23625c1d6e05a40c3abbcd586ffecbd92dd75c8bc63af573e",
+				"DiscoKey":   "discokey:9264de6ae10d5ebd6c4c08a3df227df02accadb4646181181f6f625f7ca7dc54",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44522",
+					"10.65.0.27:44522",
+					"172.17.0.1:44522",
+					"172.18.0.1:44522",
+					"172.19.0.1:44522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:52:29.387544549Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5882942605188778,
+				"StableID":   "nu89qjvPwn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ad000e396248db10eaa3cec51f475b8beca1f2411d4aff38f7bad70b774a543",
+				"DiscoKey":   "discokey:1a5bd847423d07e723964f03d8caa85d14523d5ac342995f2ef636895e5f0d6e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38359",
+					"10.65.0.27:38359",
+					"172.17.0.1:38359",
+					"172.18.0.1:38359",
+					"172.19.0.1:38359"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:52:29.929902408Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2162014968835529,
+				"StableID":   "niRmK6UBtH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a500226877487a7c409c3701b5f7e7db9e3ee5e8437756d705280747e4b8a6f",
+				"DiscoKey":   "discokey:b9cc07e45a1fb2e06d9392ce347aad2dad3af5c43c871814daf89e5facb47566",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42328",
+					"10.65.0.27:42328",
+					"172.17.0.1:42328",
+					"172.18.0.1:42328",
+					"172.19.0.1:42328"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:52:30.515991067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6704035779830000,
+				"StableID":   "nRMMyoeGMu11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f074cc8984de067e38e5c898c63f96ade37d719a20ebc7eb3200c50c0fde1c35",
+				"DiscoKey":   "discokey:3f3d642bcd8820b60a2445e9b53fd945fdedfc386738e4029073b064b8781d0f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47324",
+					"10.65.0.27:47324",
+					"172.17.0.1:47324",
+					"172.18.0.1:47324",
+					"172.19.0.1:47324"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:52:31.010533712Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1415764837397018,
+				"StableID":   "nfu4d1kC4C11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a2fb3f1ea5c159fd6d0e07fb200fc0d6724a637a93e38d6a7dc4d4278746c27d",
+				"KeyExpiry":  "2026-11-08T21:52:31Z",
+				"DiscoKey":   "discokey:55af747d47ba3d00676ecb7d951c060930babb53891ec6b8d4a17ed738b74008",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52384",
+					"10.65.0.27:52384",
+					"172.17.0.1:52384",
+					"172.18.0.1:52384",
+					"172.19.0.1:52384"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:52:31.580694753Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7269730603186265,
+				"StableID":   "nJV5PkVUmy11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b703bee326c0c54e09bebeb1901b01e9c330928178e6fe2a0f80b99784b99561",
+				"KeyExpiry":  "2026-11-08T21:52:32Z",
+				"DiscoKey":   "discokey:f57df15cc665ce3cf4830de0a362e246d9b575f7db817a8ed1ce8e307253b663",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50595",
+					"10.65.0.27:50595",
+					"172.17.0.1:50595",
+					"172.18.0.1:50595",
+					"172.19.0.1:50595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:52:32.104077102Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3574989046928154,
+				"StableID":   "nTjv6Du7vU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7786be5ee86a446d73b1c09a05f83483944163c703d9f1ac75fa8ea92410c375",
+				"KeyExpiry":  "2026-11-08T21:52:32Z",
+				"DiscoKey":   "discokey:ccf5277a82b195f1fc6f4672b0b8258d337339b0fac2e309fcff85b284753f38",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:43607",
+					"10.65.0.27:43607",
+					"172.17.0.1:43607",
+					"172.18.0.1:43607",
+					"172.19.0.1:43607"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:52:32.637445732Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1388943353778738": {
+				"ID":          1388943353778738,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5336743594628542,
+				"StableID":   "nqLydsC2gi11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       5336743594628542,
+				"Key":        "nodekey:26ac58a77b2156bd4619c1b8c041d3315892de9247abb0523afb1e1547098618",
+				"DiscoKey":   "discokey:904d3ec64780e7e40556d21045966dfd32ddd5d4e6a98ebc72984b7bbd117d1f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:37908",
+					"10.65.0.27:37908",
+					"172.17.0.1:37908",
+					"172.18.0.1:37908",
+					"172.19.0.1:37908"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:52:25.107245782Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:26ac58a77b2156bd4619c1b8c041d3315892de9247abb0523afb1e1547098618",
+			"MachineKey": "mkey:a6207548ba6d74878a2f44da6b9ff552a211b5aacb68438fc63779ee0c8c396e",
+			"Peers": [{
+				"ID":         1388943353778738,
+				"StableID":   "nhehxpB4rB11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8c2675ae0569f34d9a313c69691b1e319722b3d094dc21def96c03b505c8129",
+				"DiscoKey":   "discokey:fcafc2fb0a87d63cca6b050946107a4d715afd74448cf9c6da5081ae7ba0e267",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:57209",
+					"10.65.0.27:57209",
+					"172.17.0.1:57209",
+					"172.18.0.1:57209",
+					"172.19.0.1:57209"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:52:25.604523299Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7063401917802150,
+				"StableID":   "nyEazGb2Ax11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:223f4272749196af577b225a7a488610532cce356bf3a9ef8aec33a732e7d920",
+				"DiscoKey":   "discokey:34e83f38efebb14ddbc68acda1c72655c9e535465f8659c4bab1ce374199a442",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:38553",
+					"10.65.0.27:38553",
+					"172.17.0.1:38553",
+					"172.18.0.1:38553",
+					"172.19.0.1:38553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:52:26.149992802Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3197928985796109,
+				"StableID":   "n4SXgxAMyR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:642e7824806b8d06f25632a58b0300762b847fdb9f45e2c96afc6d5ebe9c7d16",
+				"DiscoKey":   "discokey:c99cff6692c3e4230abeb4c21a72307ed8ea4b12fcf7568fc7697d11e49b6c19",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49441",
+					"10.65.0.27:49441",
+					"172.17.0.1:49441",
+					"172.18.0.1:49441",
+					"172.19.0.1:49441"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:52:26.686954215Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4894805468870921,
+				"StableID":   "npgzotEsDf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8815bb6fd1367e7b3fb2827c8a64c20f385f3b66ca40d124931686fb53c0eb65",
+				"DiscoKey":   "discokey:ccb7ddfb790f135f8533768289d8dea0bec6a3aa1bd826a290726d4a0f716141",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38997",
+					"10.65.0.27:38997",
+					"172.17.0.1:38997",
+					"172.18.0.1:38997",
+					"172.19.0.1:38997"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:52:27.249206735Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1628686280806333,
+				"StableID":   "nnoiTxpdiD11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36d642e7af7d50ac8fd9d02a46fb66fd669914079967945a86bd5eb18c1ae021",
+				"DiscoKey":   "discokey:dea8201be35ee0d8f039d5304fc9eb32e680350de08b2ad2f60bee092b1add4f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39925",
+					"10.65.0.27:39925",
+					"172.17.0.1:39925",
+					"172.18.0.1:39925",
+					"172.19.0.1:39925"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:52:27.770269562Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         482423346820269,
+				"StableID":   "nJfHBiSVm411CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b891c764ae0185ebd75bc03f9813d8b1026185bec3366cd00b79bcb7ba86fa3b",
+				"DiscoKey":   "discokey:e41c116c21b3acb560340a6f7ec790312d66bb78a112eb66249afbaa4341f86c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57372",
+					"10.65.0.27:57372",
+					"172.17.0.1:57372",
+					"172.18.0.1:57372",
+					"172.19.0.1:57372"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:52:28.304998679Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5908298984831681,
+				"StableID":   "nJyfGkzs8o11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc9491e039887d5166e1abf3cce0d056baf550e0477367d054bbe9dea2afee61",
+				"DiscoKey":   "discokey:c3a139b292d4bcae4414eb364e4f8d0156a67a267cb48a44fd236c0ccb8cde11",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:44308",
+					"10.65.0.27:44308",
+					"172.17.0.1:44308",
+					"172.18.0.1:44308",
+					"172.19.0.1:44308"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:52:28.84662133Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         338363147555957,
+				"StableID":   "nSMQg7EFe311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7261332eca0497d23625c1d6e05a40c3abbcd586ffecbd92dd75c8bc63af573e",
+				"DiscoKey":   "discokey:9264de6ae10d5ebd6c4c08a3df227df02accadb4646181181f6f625f7ca7dc54",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44522",
+					"10.65.0.27:44522",
+					"172.17.0.1:44522",
+					"172.18.0.1:44522",
+					"172.19.0.1:44522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:52:29.387544549Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5882942605188778,
+				"StableID":   "nu89qjvPwn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ad000e396248db10eaa3cec51f475b8beca1f2411d4aff38f7bad70b774a543",
+				"DiscoKey":   "discokey:1a5bd847423d07e723964f03d8caa85d14523d5ac342995f2ef636895e5f0d6e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38359",
+					"10.65.0.27:38359",
+					"172.17.0.1:38359",
+					"172.18.0.1:38359",
+					"172.19.0.1:38359"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:52:29.929902408Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2162014968835529,
+				"StableID":   "niRmK6UBtH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a500226877487a7c409c3701b5f7e7db9e3ee5e8437756d705280747e4b8a6f",
+				"DiscoKey":   "discokey:b9cc07e45a1fb2e06d9392ce347aad2dad3af5c43c871814daf89e5facb47566",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42328",
+					"10.65.0.27:42328",
+					"172.17.0.1:42328",
+					"172.18.0.1:42328",
+					"172.19.0.1:42328"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:52:30.515991067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6704035779830000,
+				"StableID":   "nRMMyoeGMu11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f074cc8984de067e38e5c898c63f96ade37d719a20ebc7eb3200c50c0fde1c35",
+				"DiscoKey":   "discokey:3f3d642bcd8820b60a2445e9b53fd945fdedfc386738e4029073b064b8781d0f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47324",
+					"10.65.0.27:47324",
+					"172.17.0.1:47324",
+					"172.18.0.1:47324",
+					"172.19.0.1:47324"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:52:31.010533712Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1415764837397018,
+				"StableID":   "nfu4d1kC4C11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a2fb3f1ea5c159fd6d0e07fb200fc0d6724a637a93e38d6a7dc4d4278746c27d",
+				"KeyExpiry":  "2026-11-08T21:52:31Z",
+				"DiscoKey":   "discokey:55af747d47ba3d00676ecb7d951c060930babb53891ec6b8d4a17ed738b74008",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52384",
+					"10.65.0.27:52384",
+					"172.17.0.1:52384",
+					"172.18.0.1:52384",
+					"172.19.0.1:52384"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:52:31.580694753Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7269730603186265,
+				"StableID":   "nJV5PkVUmy11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b703bee326c0c54e09bebeb1901b01e9c330928178e6fe2a0f80b99784b99561",
+				"KeyExpiry":  "2026-11-08T21:52:32Z",
+				"DiscoKey":   "discokey:f57df15cc665ce3cf4830de0a362e246d9b575f7db817a8ed1ce8e307253b663",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50595",
+					"10.65.0.27:50595",
+					"172.17.0.1:50595",
+					"172.18.0.1:50595",
+					"172.19.0.1:50595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:52:32.104077102Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3574989046928154,
+				"StableID":   "nTjv6Du7vU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7786be5ee86a446d73b1c09a05f83483944163c703d9f1ac75fa8ea92410c375",
+				"KeyExpiry":  "2026-11-08T21:52:32Z",
+				"DiscoKey":   "discokey:ccf5277a82b195f1fc6f4672b0b8258d337339b0fac2e309fcff85b284753f38",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:43607",
+					"10.65.0.27:43607",
+					"172.17.0.1:43607",
+					"172.18.0.1:43607",
+					"172.19.0.1:43607"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:52:32.637445732Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5336743594628542": {
+				"ID":          5336743594628542,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4894805468870921,
+				"StableID":   "npgzotEsDf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       4894805468870921,
+				"Key":        "nodekey:8815bb6fd1367e7b3fb2827c8a64c20f385f3b66ca40d124931686fb53c0eb65",
+				"DiscoKey":   "discokey:ccb7ddfb790f135f8533768289d8dea0bec6a3aa1bd826a290726d4a0f716141",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38997",
+					"10.65.0.27:38997",
+					"172.17.0.1:38997",
+					"172.18.0.1:38997",
+					"172.19.0.1:38997"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:52:27.249206735Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8815bb6fd1367e7b3fb2827c8a64c20f385f3b66ca40d124931686fb53c0eb65",
+			"MachineKey": "mkey:cc29884f8849b62075de8b33cae51f719d09d2f41711daf88d22d596d0b7b149",
+			"Peers": [{
+				"ID":         5336743594628542,
+				"StableID":   "nqLydsC2gi11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26ac58a77b2156bd4619c1b8c041d3315892de9247abb0523afb1e1547098618",
+				"DiscoKey":   "discokey:904d3ec64780e7e40556d21045966dfd32ddd5d4e6a98ebc72984b7bbd117d1f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:37908",
+					"10.65.0.27:37908",
+					"172.17.0.1:37908",
+					"172.18.0.1:37908",
+					"172.19.0.1:37908"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:52:25.107245782Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1388943353778738,
+				"StableID":   "nhehxpB4rB11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8c2675ae0569f34d9a313c69691b1e319722b3d094dc21def96c03b505c8129",
+				"DiscoKey":   "discokey:fcafc2fb0a87d63cca6b050946107a4d715afd74448cf9c6da5081ae7ba0e267",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:57209",
+					"10.65.0.27:57209",
+					"172.17.0.1:57209",
+					"172.18.0.1:57209",
+					"172.19.0.1:57209"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:52:25.604523299Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7063401917802150,
+				"StableID":   "nyEazGb2Ax11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:223f4272749196af577b225a7a488610532cce356bf3a9ef8aec33a732e7d920",
+				"DiscoKey":   "discokey:34e83f38efebb14ddbc68acda1c72655c9e535465f8659c4bab1ce374199a442",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:38553",
+					"10.65.0.27:38553",
+					"172.17.0.1:38553",
+					"172.18.0.1:38553",
+					"172.19.0.1:38553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:52:26.149992802Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3197928985796109,
+				"StableID":   "n4SXgxAMyR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:642e7824806b8d06f25632a58b0300762b847fdb9f45e2c96afc6d5ebe9c7d16",
+				"DiscoKey":   "discokey:c99cff6692c3e4230abeb4c21a72307ed8ea4b12fcf7568fc7697d11e49b6c19",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49441",
+					"10.65.0.27:49441",
+					"172.17.0.1:49441",
+					"172.18.0.1:49441",
+					"172.19.0.1:49441"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:52:26.686954215Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1628686280806333,
+				"StableID":   "nnoiTxpdiD11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36d642e7af7d50ac8fd9d02a46fb66fd669914079967945a86bd5eb18c1ae021",
+				"DiscoKey":   "discokey:dea8201be35ee0d8f039d5304fc9eb32e680350de08b2ad2f60bee092b1add4f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39925",
+					"10.65.0.27:39925",
+					"172.17.0.1:39925",
+					"172.18.0.1:39925",
+					"172.19.0.1:39925"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:52:27.770269562Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         482423346820269,
+				"StableID":   "nJfHBiSVm411CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b891c764ae0185ebd75bc03f9813d8b1026185bec3366cd00b79bcb7ba86fa3b",
+				"DiscoKey":   "discokey:e41c116c21b3acb560340a6f7ec790312d66bb78a112eb66249afbaa4341f86c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57372",
+					"10.65.0.27:57372",
+					"172.17.0.1:57372",
+					"172.18.0.1:57372",
+					"172.19.0.1:57372"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:52:28.304998679Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5908298984831681,
+				"StableID":   "nJyfGkzs8o11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc9491e039887d5166e1abf3cce0d056baf550e0477367d054bbe9dea2afee61",
+				"DiscoKey":   "discokey:c3a139b292d4bcae4414eb364e4f8d0156a67a267cb48a44fd236c0ccb8cde11",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:44308",
+					"10.65.0.27:44308",
+					"172.17.0.1:44308",
+					"172.18.0.1:44308",
+					"172.19.0.1:44308"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:52:28.84662133Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         338363147555957,
+				"StableID":   "nSMQg7EFe311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7261332eca0497d23625c1d6e05a40c3abbcd586ffecbd92dd75c8bc63af573e",
+				"DiscoKey":   "discokey:9264de6ae10d5ebd6c4c08a3df227df02accadb4646181181f6f625f7ca7dc54",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44522",
+					"10.65.0.27:44522",
+					"172.17.0.1:44522",
+					"172.18.0.1:44522",
+					"172.19.0.1:44522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:52:29.387544549Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5882942605188778,
+				"StableID":   "nu89qjvPwn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ad000e396248db10eaa3cec51f475b8beca1f2411d4aff38f7bad70b774a543",
+				"DiscoKey":   "discokey:1a5bd847423d07e723964f03d8caa85d14523d5ac342995f2ef636895e5f0d6e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38359",
+					"10.65.0.27:38359",
+					"172.17.0.1:38359",
+					"172.18.0.1:38359",
+					"172.19.0.1:38359"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:52:29.929902408Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2162014968835529,
+				"StableID":   "niRmK6UBtH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a500226877487a7c409c3701b5f7e7db9e3ee5e8437756d705280747e4b8a6f",
+				"DiscoKey":   "discokey:b9cc07e45a1fb2e06d9392ce347aad2dad3af5c43c871814daf89e5facb47566",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42328",
+					"10.65.0.27:42328",
+					"172.17.0.1:42328",
+					"172.18.0.1:42328",
+					"172.19.0.1:42328"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:52:30.515991067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6704035779830000,
+				"StableID":   "nRMMyoeGMu11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f074cc8984de067e38e5c898c63f96ade37d719a20ebc7eb3200c50c0fde1c35",
+				"DiscoKey":   "discokey:3f3d642bcd8820b60a2445e9b53fd945fdedfc386738e4029073b064b8781d0f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47324",
+					"10.65.0.27:47324",
+					"172.17.0.1:47324",
+					"172.18.0.1:47324",
+					"172.19.0.1:47324"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:52:31.010533712Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1415764837397018,
+				"StableID":   "nfu4d1kC4C11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a2fb3f1ea5c159fd6d0e07fb200fc0d6724a637a93e38d6a7dc4d4278746c27d",
+				"KeyExpiry":  "2026-11-08T21:52:31Z",
+				"DiscoKey":   "discokey:55af747d47ba3d00676ecb7d951c060930babb53891ec6b8d4a17ed738b74008",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52384",
+					"10.65.0.27:52384",
+					"172.17.0.1:52384",
+					"172.18.0.1:52384",
+					"172.19.0.1:52384"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:52:31.580694753Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7269730603186265,
+				"StableID":   "nJV5PkVUmy11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b703bee326c0c54e09bebeb1901b01e9c330928178e6fe2a0f80b99784b99561",
+				"KeyExpiry":  "2026-11-08T21:52:32Z",
+				"DiscoKey":   "discokey:f57df15cc665ce3cf4830de0a362e246d9b575f7db817a8ed1ce8e307253b663",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50595",
+					"10.65.0.27:50595",
+					"172.17.0.1:50595",
+					"172.18.0.1:50595",
+					"172.19.0.1:50595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:52:32.104077102Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3574989046928154,
+				"StableID":   "nTjv6Du7vU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7786be5ee86a446d73b1c09a05f83483944163c703d9f1ac75fa8ea92410c375",
+				"KeyExpiry":  "2026-11-08T21:52:32Z",
+				"DiscoKey":   "discokey:ccf5277a82b195f1fc6f4672b0b8258d337339b0fac2e309fcff85b284753f38",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:43607",
+					"10.65.0.27:43607",
+					"172.17.0.1:43607",
+					"172.18.0.1:43607",
+					"172.19.0.1:43607"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:52:32.637445732Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4894805468870921": {
+				"ID":          4894805468870921,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3197928985796109,
+				"StableID":   "n4SXgxAMyR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       3197928985796109,
+				"Key":        "nodekey:642e7824806b8d06f25632a58b0300762b847fdb9f45e2c96afc6d5ebe9c7d16",
+				"DiscoKey":   "discokey:c99cff6692c3e4230abeb4c21a72307ed8ea4b12fcf7568fc7697d11e49b6c19",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49441",
+					"10.65.0.27:49441",
+					"172.17.0.1:49441",
+					"172.18.0.1:49441",
+					"172.19.0.1:49441"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:52:26.686954215Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:642e7824806b8d06f25632a58b0300762b847fdb9f45e2c96afc6d5ebe9c7d16",
+			"MachineKey": "mkey:8a9b740ad09f4ceed368bef51e160b75ec1974a9ec6e1e3a7abd33b6af6b6a0f",
+			"Peers": [{
+				"ID":         5336743594628542,
+				"StableID":   "nqLydsC2gi11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26ac58a77b2156bd4619c1b8c041d3315892de9247abb0523afb1e1547098618",
+				"DiscoKey":   "discokey:904d3ec64780e7e40556d21045966dfd32ddd5d4e6a98ebc72984b7bbd117d1f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:37908",
+					"10.65.0.27:37908",
+					"172.17.0.1:37908",
+					"172.18.0.1:37908",
+					"172.19.0.1:37908"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:52:25.107245782Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1388943353778738,
+				"StableID":   "nhehxpB4rB11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8c2675ae0569f34d9a313c69691b1e319722b3d094dc21def96c03b505c8129",
+				"DiscoKey":   "discokey:fcafc2fb0a87d63cca6b050946107a4d715afd74448cf9c6da5081ae7ba0e267",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:57209",
+					"10.65.0.27:57209",
+					"172.17.0.1:57209",
+					"172.18.0.1:57209",
+					"172.19.0.1:57209"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:52:25.604523299Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7063401917802150,
+				"StableID":   "nyEazGb2Ax11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:223f4272749196af577b225a7a488610532cce356bf3a9ef8aec33a732e7d920",
+				"DiscoKey":   "discokey:34e83f38efebb14ddbc68acda1c72655c9e535465f8659c4bab1ce374199a442",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:38553",
+					"10.65.0.27:38553",
+					"172.17.0.1:38553",
+					"172.18.0.1:38553",
+					"172.19.0.1:38553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:52:26.149992802Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4894805468870921,
+				"StableID":   "npgzotEsDf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8815bb6fd1367e7b3fb2827c8a64c20f385f3b66ca40d124931686fb53c0eb65",
+				"DiscoKey":   "discokey:ccb7ddfb790f135f8533768289d8dea0bec6a3aa1bd826a290726d4a0f716141",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38997",
+					"10.65.0.27:38997",
+					"172.17.0.1:38997",
+					"172.18.0.1:38997",
+					"172.19.0.1:38997"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:52:27.249206735Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1628686280806333,
+				"StableID":   "nnoiTxpdiD11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36d642e7af7d50ac8fd9d02a46fb66fd669914079967945a86bd5eb18c1ae021",
+				"DiscoKey":   "discokey:dea8201be35ee0d8f039d5304fc9eb32e680350de08b2ad2f60bee092b1add4f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39925",
+					"10.65.0.27:39925",
+					"172.17.0.1:39925",
+					"172.18.0.1:39925",
+					"172.19.0.1:39925"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:52:27.770269562Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         482423346820269,
+				"StableID":   "nJfHBiSVm411CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b891c764ae0185ebd75bc03f9813d8b1026185bec3366cd00b79bcb7ba86fa3b",
+				"DiscoKey":   "discokey:e41c116c21b3acb560340a6f7ec790312d66bb78a112eb66249afbaa4341f86c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57372",
+					"10.65.0.27:57372",
+					"172.17.0.1:57372",
+					"172.18.0.1:57372",
+					"172.19.0.1:57372"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:52:28.304998679Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5908298984831681,
+				"StableID":   "nJyfGkzs8o11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc9491e039887d5166e1abf3cce0d056baf550e0477367d054bbe9dea2afee61",
+				"DiscoKey":   "discokey:c3a139b292d4bcae4414eb364e4f8d0156a67a267cb48a44fd236c0ccb8cde11",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:44308",
+					"10.65.0.27:44308",
+					"172.17.0.1:44308",
+					"172.18.0.1:44308",
+					"172.19.0.1:44308"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:52:28.84662133Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         338363147555957,
+				"StableID":   "nSMQg7EFe311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7261332eca0497d23625c1d6e05a40c3abbcd586ffecbd92dd75c8bc63af573e",
+				"DiscoKey":   "discokey:9264de6ae10d5ebd6c4c08a3df227df02accadb4646181181f6f625f7ca7dc54",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44522",
+					"10.65.0.27:44522",
+					"172.17.0.1:44522",
+					"172.18.0.1:44522",
+					"172.19.0.1:44522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:52:29.387544549Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5882942605188778,
+				"StableID":   "nu89qjvPwn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ad000e396248db10eaa3cec51f475b8beca1f2411d4aff38f7bad70b774a543",
+				"DiscoKey":   "discokey:1a5bd847423d07e723964f03d8caa85d14523d5ac342995f2ef636895e5f0d6e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38359",
+					"10.65.0.27:38359",
+					"172.17.0.1:38359",
+					"172.18.0.1:38359",
+					"172.19.0.1:38359"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:52:29.929902408Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2162014968835529,
+				"StableID":   "niRmK6UBtH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a500226877487a7c409c3701b5f7e7db9e3ee5e8437756d705280747e4b8a6f",
+				"DiscoKey":   "discokey:b9cc07e45a1fb2e06d9392ce347aad2dad3af5c43c871814daf89e5facb47566",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42328",
+					"10.65.0.27:42328",
+					"172.17.0.1:42328",
+					"172.18.0.1:42328",
+					"172.19.0.1:42328"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:52:30.515991067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6704035779830000,
+				"StableID":   "nRMMyoeGMu11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f074cc8984de067e38e5c898c63f96ade37d719a20ebc7eb3200c50c0fde1c35",
+				"DiscoKey":   "discokey:3f3d642bcd8820b60a2445e9b53fd945fdedfc386738e4029073b064b8781d0f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47324",
+					"10.65.0.27:47324",
+					"172.17.0.1:47324",
+					"172.18.0.1:47324",
+					"172.19.0.1:47324"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:52:31.010533712Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1415764837397018,
+				"StableID":   "nfu4d1kC4C11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a2fb3f1ea5c159fd6d0e07fb200fc0d6724a637a93e38d6a7dc4d4278746c27d",
+				"KeyExpiry":  "2026-11-08T21:52:31Z",
+				"DiscoKey":   "discokey:55af747d47ba3d00676ecb7d951c060930babb53891ec6b8d4a17ed738b74008",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52384",
+					"10.65.0.27:52384",
+					"172.17.0.1:52384",
+					"172.18.0.1:52384",
+					"172.19.0.1:52384"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:52:31.580694753Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7269730603186265,
+				"StableID":   "nJV5PkVUmy11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b703bee326c0c54e09bebeb1901b01e9c330928178e6fe2a0f80b99784b99561",
+				"KeyExpiry":  "2026-11-08T21:52:32Z",
+				"DiscoKey":   "discokey:f57df15cc665ce3cf4830de0a362e246d9b575f7db817a8ed1ce8e307253b663",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50595",
+					"10.65.0.27:50595",
+					"172.17.0.1:50595",
+					"172.18.0.1:50595",
+					"172.19.0.1:50595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:52:32.104077102Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3574989046928154,
+				"StableID":   "nTjv6Du7vU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7786be5ee86a446d73b1c09a05f83483944163c703d9f1ac75fa8ea92410c375",
+				"KeyExpiry":  "2026-11-08T21:52:32Z",
+				"DiscoKey":   "discokey:ccf5277a82b195f1fc6f4672b0b8258d337339b0fac2e309fcff85b284753f38",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:43607",
+					"10.65.0.27:43607",
+					"172.17.0.1:43607",
+					"172.18.0.1:43607",
+					"172.19.0.1:43607"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:52:32.637445732Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3197928985796109": {
+				"ID":          3197928985796109,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         482423346820269,
+				"StableID":   "nJfHBiSVm411CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       482423346820269,
+				"Key":        "nodekey:b891c764ae0185ebd75bc03f9813d8b1026185bec3366cd00b79bcb7ba86fa3b",
+				"DiscoKey":   "discokey:e41c116c21b3acb560340a6f7ec790312d66bb78a112eb66249afbaa4341f86c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57372",
+					"10.65.0.27:57372",
+					"172.17.0.1:57372",
+					"172.18.0.1:57372",
+					"172.19.0.1:57372"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:52:28.304998679Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b891c764ae0185ebd75bc03f9813d8b1026185bec3366cd00b79bcb7ba86fa3b",
+			"MachineKey": "mkey:543728783d95b77d90515fb7b7f78279d339b43abd19c388817be6b8b105db36",
+			"Peers": [{
+				"ID":         5336743594628542,
+				"StableID":   "nqLydsC2gi11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26ac58a77b2156bd4619c1b8c041d3315892de9247abb0523afb1e1547098618",
+				"DiscoKey":   "discokey:904d3ec64780e7e40556d21045966dfd32ddd5d4e6a98ebc72984b7bbd117d1f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:37908",
+					"10.65.0.27:37908",
+					"172.17.0.1:37908",
+					"172.18.0.1:37908",
+					"172.19.0.1:37908"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:52:25.107245782Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1388943353778738,
+				"StableID":   "nhehxpB4rB11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8c2675ae0569f34d9a313c69691b1e319722b3d094dc21def96c03b505c8129",
+				"DiscoKey":   "discokey:fcafc2fb0a87d63cca6b050946107a4d715afd74448cf9c6da5081ae7ba0e267",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:57209",
+					"10.65.0.27:57209",
+					"172.17.0.1:57209",
+					"172.18.0.1:57209",
+					"172.19.0.1:57209"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:52:25.604523299Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7063401917802150,
+				"StableID":   "nyEazGb2Ax11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:223f4272749196af577b225a7a488610532cce356bf3a9ef8aec33a732e7d920",
+				"DiscoKey":   "discokey:34e83f38efebb14ddbc68acda1c72655c9e535465f8659c4bab1ce374199a442",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:38553",
+					"10.65.0.27:38553",
+					"172.17.0.1:38553",
+					"172.18.0.1:38553",
+					"172.19.0.1:38553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:52:26.149992802Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3197928985796109,
+				"StableID":   "n4SXgxAMyR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:642e7824806b8d06f25632a58b0300762b847fdb9f45e2c96afc6d5ebe9c7d16",
+				"DiscoKey":   "discokey:c99cff6692c3e4230abeb4c21a72307ed8ea4b12fcf7568fc7697d11e49b6c19",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49441",
+					"10.65.0.27:49441",
+					"172.17.0.1:49441",
+					"172.18.0.1:49441",
+					"172.19.0.1:49441"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:52:26.686954215Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4894805468870921,
+				"StableID":   "npgzotEsDf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8815bb6fd1367e7b3fb2827c8a64c20f385f3b66ca40d124931686fb53c0eb65",
+				"DiscoKey":   "discokey:ccb7ddfb790f135f8533768289d8dea0bec6a3aa1bd826a290726d4a0f716141",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38997",
+					"10.65.0.27:38997",
+					"172.17.0.1:38997",
+					"172.18.0.1:38997",
+					"172.19.0.1:38997"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:52:27.249206735Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1628686280806333,
+				"StableID":   "nnoiTxpdiD11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36d642e7af7d50ac8fd9d02a46fb66fd669914079967945a86bd5eb18c1ae021",
+				"DiscoKey":   "discokey:dea8201be35ee0d8f039d5304fc9eb32e680350de08b2ad2f60bee092b1add4f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39925",
+					"10.65.0.27:39925",
+					"172.17.0.1:39925",
+					"172.18.0.1:39925",
+					"172.19.0.1:39925"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:52:27.770269562Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5908298984831681,
+				"StableID":   "nJyfGkzs8o11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc9491e039887d5166e1abf3cce0d056baf550e0477367d054bbe9dea2afee61",
+				"DiscoKey":   "discokey:c3a139b292d4bcae4414eb364e4f8d0156a67a267cb48a44fd236c0ccb8cde11",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:44308",
+					"10.65.0.27:44308",
+					"172.17.0.1:44308",
+					"172.18.0.1:44308",
+					"172.19.0.1:44308"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:52:28.84662133Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         338363147555957,
+				"StableID":   "nSMQg7EFe311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7261332eca0497d23625c1d6e05a40c3abbcd586ffecbd92dd75c8bc63af573e",
+				"DiscoKey":   "discokey:9264de6ae10d5ebd6c4c08a3df227df02accadb4646181181f6f625f7ca7dc54",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44522",
+					"10.65.0.27:44522",
+					"172.17.0.1:44522",
+					"172.18.0.1:44522",
+					"172.19.0.1:44522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:52:29.387544549Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5882942605188778,
+				"StableID":   "nu89qjvPwn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ad000e396248db10eaa3cec51f475b8beca1f2411d4aff38f7bad70b774a543",
+				"DiscoKey":   "discokey:1a5bd847423d07e723964f03d8caa85d14523d5ac342995f2ef636895e5f0d6e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38359",
+					"10.65.0.27:38359",
+					"172.17.0.1:38359",
+					"172.18.0.1:38359",
+					"172.19.0.1:38359"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:52:29.929902408Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2162014968835529,
+				"StableID":   "niRmK6UBtH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a500226877487a7c409c3701b5f7e7db9e3ee5e8437756d705280747e4b8a6f",
+				"DiscoKey":   "discokey:b9cc07e45a1fb2e06d9392ce347aad2dad3af5c43c871814daf89e5facb47566",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42328",
+					"10.65.0.27:42328",
+					"172.17.0.1:42328",
+					"172.18.0.1:42328",
+					"172.19.0.1:42328"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:52:30.515991067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6704035779830000,
+				"StableID":   "nRMMyoeGMu11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f074cc8984de067e38e5c898c63f96ade37d719a20ebc7eb3200c50c0fde1c35",
+				"DiscoKey":   "discokey:3f3d642bcd8820b60a2445e9b53fd945fdedfc386738e4029073b064b8781d0f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47324",
+					"10.65.0.27:47324",
+					"172.17.0.1:47324",
+					"172.18.0.1:47324",
+					"172.19.0.1:47324"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:52:31.010533712Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1415764837397018,
+				"StableID":   "nfu4d1kC4C11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a2fb3f1ea5c159fd6d0e07fb200fc0d6724a637a93e38d6a7dc4d4278746c27d",
+				"KeyExpiry":  "2026-11-08T21:52:31Z",
+				"DiscoKey":   "discokey:55af747d47ba3d00676ecb7d951c060930babb53891ec6b8d4a17ed738b74008",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52384",
+					"10.65.0.27:52384",
+					"172.17.0.1:52384",
+					"172.18.0.1:52384",
+					"172.19.0.1:52384"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:52:31.580694753Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7269730603186265,
+				"StableID":   "nJV5PkVUmy11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b703bee326c0c54e09bebeb1901b01e9c330928178e6fe2a0f80b99784b99561",
+				"KeyExpiry":  "2026-11-08T21:52:32Z",
+				"DiscoKey":   "discokey:f57df15cc665ce3cf4830de0a362e246d9b575f7db817a8ed1ce8e307253b663",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50595",
+					"10.65.0.27:50595",
+					"172.17.0.1:50595",
+					"172.18.0.1:50595",
+					"172.19.0.1:50595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:52:32.104077102Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3574989046928154,
+				"StableID":   "nTjv6Du7vU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7786be5ee86a446d73b1c09a05f83483944163c703d9f1ac75fa8ea92410c375",
+				"KeyExpiry":  "2026-11-08T21:52:32Z",
+				"DiscoKey":   "discokey:ccf5277a82b195f1fc6f4672b0b8258d337339b0fac2e309fcff85b284753f38",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:43607",
+					"10.65.0.27:43607",
+					"172.17.0.1:43607",
+					"172.18.0.1:43607",
+					"172.19.0.1:43607"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:52:32.637445732Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "482423346820269": {
+				"ID":          482423346820269,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         338363147555957,
+				"StableID":   "nSMQg7EFe311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       338363147555957,
+				"Key":        "nodekey:7261332eca0497d23625c1d6e05a40c3abbcd586ffecbd92dd75c8bc63af573e",
+				"DiscoKey":   "discokey:9264de6ae10d5ebd6c4c08a3df227df02accadb4646181181f6f625f7ca7dc54",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44522",
+					"10.65.0.27:44522",
+					"172.17.0.1:44522",
+					"172.18.0.1:44522",
+					"172.19.0.1:44522"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:52:29.387544549Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7261332eca0497d23625c1d6e05a40c3abbcd586ffecbd92dd75c8bc63af573e",
+			"MachineKey": "mkey:5dbe606386baa5149abef1e355f6454d7d1818c35e78ba673d1811865768f630",
+			"Peers": [{
+				"ID":         5336743594628542,
+				"StableID":   "nqLydsC2gi11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26ac58a77b2156bd4619c1b8c041d3315892de9247abb0523afb1e1547098618",
+				"DiscoKey":   "discokey:904d3ec64780e7e40556d21045966dfd32ddd5d4e6a98ebc72984b7bbd117d1f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:37908",
+					"10.65.0.27:37908",
+					"172.17.0.1:37908",
+					"172.18.0.1:37908",
+					"172.19.0.1:37908"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:52:25.107245782Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1388943353778738,
+				"StableID":   "nhehxpB4rB11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8c2675ae0569f34d9a313c69691b1e319722b3d094dc21def96c03b505c8129",
+				"DiscoKey":   "discokey:fcafc2fb0a87d63cca6b050946107a4d715afd74448cf9c6da5081ae7ba0e267",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:57209",
+					"10.65.0.27:57209",
+					"172.17.0.1:57209",
+					"172.18.0.1:57209",
+					"172.19.0.1:57209"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:52:25.604523299Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7063401917802150,
+				"StableID":   "nyEazGb2Ax11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:223f4272749196af577b225a7a488610532cce356bf3a9ef8aec33a732e7d920",
+				"DiscoKey":   "discokey:34e83f38efebb14ddbc68acda1c72655c9e535465f8659c4bab1ce374199a442",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:38553",
+					"10.65.0.27:38553",
+					"172.17.0.1:38553",
+					"172.18.0.1:38553",
+					"172.19.0.1:38553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:52:26.149992802Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3197928985796109,
+				"StableID":   "n4SXgxAMyR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:642e7824806b8d06f25632a58b0300762b847fdb9f45e2c96afc6d5ebe9c7d16",
+				"DiscoKey":   "discokey:c99cff6692c3e4230abeb4c21a72307ed8ea4b12fcf7568fc7697d11e49b6c19",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49441",
+					"10.65.0.27:49441",
+					"172.17.0.1:49441",
+					"172.18.0.1:49441",
+					"172.19.0.1:49441"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:52:26.686954215Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4894805468870921,
+				"StableID":   "npgzotEsDf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8815bb6fd1367e7b3fb2827c8a64c20f385f3b66ca40d124931686fb53c0eb65",
+				"DiscoKey":   "discokey:ccb7ddfb790f135f8533768289d8dea0bec6a3aa1bd826a290726d4a0f716141",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38997",
+					"10.65.0.27:38997",
+					"172.17.0.1:38997",
+					"172.18.0.1:38997",
+					"172.19.0.1:38997"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:52:27.249206735Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1628686280806333,
+				"StableID":   "nnoiTxpdiD11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36d642e7af7d50ac8fd9d02a46fb66fd669914079967945a86bd5eb18c1ae021",
+				"DiscoKey":   "discokey:dea8201be35ee0d8f039d5304fc9eb32e680350de08b2ad2f60bee092b1add4f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39925",
+					"10.65.0.27:39925",
+					"172.17.0.1:39925",
+					"172.18.0.1:39925",
+					"172.19.0.1:39925"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:52:27.770269562Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         482423346820269,
+				"StableID":   "nJfHBiSVm411CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b891c764ae0185ebd75bc03f9813d8b1026185bec3366cd00b79bcb7ba86fa3b",
+				"DiscoKey":   "discokey:e41c116c21b3acb560340a6f7ec790312d66bb78a112eb66249afbaa4341f86c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57372",
+					"10.65.0.27:57372",
+					"172.17.0.1:57372",
+					"172.18.0.1:57372",
+					"172.19.0.1:57372"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:52:28.304998679Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5908298984831681,
+				"StableID":   "nJyfGkzs8o11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc9491e039887d5166e1abf3cce0d056baf550e0477367d054bbe9dea2afee61",
+				"DiscoKey":   "discokey:c3a139b292d4bcae4414eb364e4f8d0156a67a267cb48a44fd236c0ccb8cde11",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:44308",
+					"10.65.0.27:44308",
+					"172.17.0.1:44308",
+					"172.18.0.1:44308",
+					"172.19.0.1:44308"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:52:28.84662133Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5882942605188778,
+				"StableID":   "nu89qjvPwn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ad000e396248db10eaa3cec51f475b8beca1f2411d4aff38f7bad70b774a543",
+				"DiscoKey":   "discokey:1a5bd847423d07e723964f03d8caa85d14523d5ac342995f2ef636895e5f0d6e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38359",
+					"10.65.0.27:38359",
+					"172.17.0.1:38359",
+					"172.18.0.1:38359",
+					"172.19.0.1:38359"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:52:29.929902408Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2162014968835529,
+				"StableID":   "niRmK6UBtH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a500226877487a7c409c3701b5f7e7db9e3ee5e8437756d705280747e4b8a6f",
+				"DiscoKey":   "discokey:b9cc07e45a1fb2e06d9392ce347aad2dad3af5c43c871814daf89e5facb47566",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42328",
+					"10.65.0.27:42328",
+					"172.17.0.1:42328",
+					"172.18.0.1:42328",
+					"172.19.0.1:42328"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:52:30.515991067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6704035779830000,
+				"StableID":   "nRMMyoeGMu11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f074cc8984de067e38e5c898c63f96ade37d719a20ebc7eb3200c50c0fde1c35",
+				"DiscoKey":   "discokey:3f3d642bcd8820b60a2445e9b53fd945fdedfc386738e4029073b064b8781d0f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47324",
+					"10.65.0.27:47324",
+					"172.17.0.1:47324",
+					"172.18.0.1:47324",
+					"172.19.0.1:47324"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:52:31.010533712Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1415764837397018,
+				"StableID":   "nfu4d1kC4C11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a2fb3f1ea5c159fd6d0e07fb200fc0d6724a637a93e38d6a7dc4d4278746c27d",
+				"KeyExpiry":  "2026-11-08T21:52:31Z",
+				"DiscoKey":   "discokey:55af747d47ba3d00676ecb7d951c060930babb53891ec6b8d4a17ed738b74008",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52384",
+					"10.65.0.27:52384",
+					"172.17.0.1:52384",
+					"172.18.0.1:52384",
+					"172.19.0.1:52384"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:52:31.580694753Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7269730603186265,
+				"StableID":   "nJV5PkVUmy11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b703bee326c0c54e09bebeb1901b01e9c330928178e6fe2a0f80b99784b99561",
+				"KeyExpiry":  "2026-11-08T21:52:32Z",
+				"DiscoKey":   "discokey:f57df15cc665ce3cf4830de0a362e246d9b575f7db817a8ed1ce8e307253b663",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50595",
+					"10.65.0.27:50595",
+					"172.17.0.1:50595",
+					"172.18.0.1:50595",
+					"172.19.0.1:50595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:52:32.104077102Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3574989046928154,
+				"StableID":   "nTjv6Du7vU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7786be5ee86a446d73b1c09a05f83483944163c703d9f1ac75fa8ea92410c375",
+				"KeyExpiry":  "2026-11-08T21:52:32Z",
+				"DiscoKey":   "discokey:ccf5277a82b195f1fc6f4672b0b8258d337339b0fac2e309fcff85b284753f38",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:43607",
+					"10.65.0.27:43607",
+					"172.17.0.1:43607",
+					"172.18.0.1:43607",
+					"172.19.0.1:43607"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:52:32.637445732Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "338363147555957": {
+				"ID":          338363147555957,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7269730603186265,
+				"StableID":   "nJV5PkVUmy11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b703bee326c0c54e09bebeb1901b01e9c330928178e6fe2a0f80b99784b99561",
+				"KeyExpiry":  "2026-11-08T21:52:32Z",
+				"DiscoKey":   "discokey:f57df15cc665ce3cf4830de0a362e246d9b575f7db817a8ed1ce8e307253b663",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50595",
+					"10.65.0.27:50595",
+					"172.17.0.1:50595",
+					"172.18.0.1:50595",
+					"172.19.0.1:50595"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:52:32.104077102Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b703bee326c0c54e09bebeb1901b01e9c330928178e6fe2a0f80b99784b99561",
+			"MachineKey": "mkey:ecbe55a6e38e6265e4488f20ad9c284d864835c1b5ed48e66e392db602712938",
+			"Peers": [{
+				"ID":         5336743594628542,
+				"StableID":   "nqLydsC2gi11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26ac58a77b2156bd4619c1b8c041d3315892de9247abb0523afb1e1547098618",
+				"DiscoKey":   "discokey:904d3ec64780e7e40556d21045966dfd32ddd5d4e6a98ebc72984b7bbd117d1f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:37908",
+					"10.65.0.27:37908",
+					"172.17.0.1:37908",
+					"172.18.0.1:37908",
+					"172.19.0.1:37908"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:52:25.107245782Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1388943353778738,
+				"StableID":   "nhehxpB4rB11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8c2675ae0569f34d9a313c69691b1e319722b3d094dc21def96c03b505c8129",
+				"DiscoKey":   "discokey:fcafc2fb0a87d63cca6b050946107a4d715afd74448cf9c6da5081ae7ba0e267",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:57209",
+					"10.65.0.27:57209",
+					"172.17.0.1:57209",
+					"172.18.0.1:57209",
+					"172.19.0.1:57209"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:52:25.604523299Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7063401917802150,
+				"StableID":   "nyEazGb2Ax11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:223f4272749196af577b225a7a488610532cce356bf3a9ef8aec33a732e7d920",
+				"DiscoKey":   "discokey:34e83f38efebb14ddbc68acda1c72655c9e535465f8659c4bab1ce374199a442",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:38553",
+					"10.65.0.27:38553",
+					"172.17.0.1:38553",
+					"172.18.0.1:38553",
+					"172.19.0.1:38553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:52:26.149992802Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3197928985796109,
+				"StableID":   "n4SXgxAMyR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:642e7824806b8d06f25632a58b0300762b847fdb9f45e2c96afc6d5ebe9c7d16",
+				"DiscoKey":   "discokey:c99cff6692c3e4230abeb4c21a72307ed8ea4b12fcf7568fc7697d11e49b6c19",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49441",
+					"10.65.0.27:49441",
+					"172.17.0.1:49441",
+					"172.18.0.1:49441",
+					"172.19.0.1:49441"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:52:26.686954215Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4894805468870921,
+				"StableID":   "npgzotEsDf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8815bb6fd1367e7b3fb2827c8a64c20f385f3b66ca40d124931686fb53c0eb65",
+				"DiscoKey":   "discokey:ccb7ddfb790f135f8533768289d8dea0bec6a3aa1bd826a290726d4a0f716141",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38997",
+					"10.65.0.27:38997",
+					"172.17.0.1:38997",
+					"172.18.0.1:38997",
+					"172.19.0.1:38997"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:52:27.249206735Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1628686280806333,
+				"StableID":   "nnoiTxpdiD11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36d642e7af7d50ac8fd9d02a46fb66fd669914079967945a86bd5eb18c1ae021",
+				"DiscoKey":   "discokey:dea8201be35ee0d8f039d5304fc9eb32e680350de08b2ad2f60bee092b1add4f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39925",
+					"10.65.0.27:39925",
+					"172.17.0.1:39925",
+					"172.18.0.1:39925",
+					"172.19.0.1:39925"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:52:27.770269562Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         482423346820269,
+				"StableID":   "nJfHBiSVm411CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b891c764ae0185ebd75bc03f9813d8b1026185bec3366cd00b79bcb7ba86fa3b",
+				"DiscoKey":   "discokey:e41c116c21b3acb560340a6f7ec790312d66bb78a112eb66249afbaa4341f86c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57372",
+					"10.65.0.27:57372",
+					"172.17.0.1:57372",
+					"172.18.0.1:57372",
+					"172.19.0.1:57372"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:52:28.304998679Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5908298984831681,
+				"StableID":   "nJyfGkzs8o11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc9491e039887d5166e1abf3cce0d056baf550e0477367d054bbe9dea2afee61",
+				"DiscoKey":   "discokey:c3a139b292d4bcae4414eb364e4f8d0156a67a267cb48a44fd236c0ccb8cde11",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:44308",
+					"10.65.0.27:44308",
+					"172.17.0.1:44308",
+					"172.18.0.1:44308",
+					"172.19.0.1:44308"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:52:28.84662133Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         338363147555957,
+				"StableID":   "nSMQg7EFe311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7261332eca0497d23625c1d6e05a40c3abbcd586ffecbd92dd75c8bc63af573e",
+				"DiscoKey":   "discokey:9264de6ae10d5ebd6c4c08a3df227df02accadb4646181181f6f625f7ca7dc54",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44522",
+					"10.65.0.27:44522",
+					"172.17.0.1:44522",
+					"172.18.0.1:44522",
+					"172.19.0.1:44522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:52:29.387544549Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5882942605188778,
+				"StableID":   "nu89qjvPwn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ad000e396248db10eaa3cec51f475b8beca1f2411d4aff38f7bad70b774a543",
+				"DiscoKey":   "discokey:1a5bd847423d07e723964f03d8caa85d14523d5ac342995f2ef636895e5f0d6e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38359",
+					"10.65.0.27:38359",
+					"172.17.0.1:38359",
+					"172.18.0.1:38359",
+					"172.19.0.1:38359"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:52:29.929902408Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2162014968835529,
+				"StableID":   "niRmK6UBtH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a500226877487a7c409c3701b5f7e7db9e3ee5e8437756d705280747e4b8a6f",
+				"DiscoKey":   "discokey:b9cc07e45a1fb2e06d9392ce347aad2dad3af5c43c871814daf89e5facb47566",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42328",
+					"10.65.0.27:42328",
+					"172.17.0.1:42328",
+					"172.18.0.1:42328",
+					"172.19.0.1:42328"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:52:30.515991067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6704035779830000,
+				"StableID":   "nRMMyoeGMu11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f074cc8984de067e38e5c898c63f96ade37d719a20ebc7eb3200c50c0fde1c35",
+				"DiscoKey":   "discokey:3f3d642bcd8820b60a2445e9b53fd945fdedfc386738e4029073b064b8781d0f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47324",
+					"10.65.0.27:47324",
+					"172.17.0.1:47324",
+					"172.18.0.1:47324",
+					"172.19.0.1:47324"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:52:31.010533712Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1415764837397018,
+				"StableID":   "nfu4d1kC4C11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a2fb3f1ea5c159fd6d0e07fb200fc0d6724a637a93e38d6a7dc4d4278746c27d",
+				"KeyExpiry":  "2026-11-08T21:52:31Z",
+				"DiscoKey":   "discokey:55af747d47ba3d00676ecb7d951c060930babb53891ec6b8d4a17ed738b74008",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52384",
+					"10.65.0.27:52384",
+					"172.17.0.1:52384",
+					"172.18.0.1:52384",
+					"172.19.0.1:52384"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:52:31.580694753Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3574989046928154,
+				"StableID":   "nTjv6Du7vU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7786be5ee86a446d73b1c09a05f83483944163c703d9f1ac75fa8ea92410c375",
+				"KeyExpiry":  "2026-11-08T21:52:32Z",
+				"DiscoKey":   "discokey:ccf5277a82b195f1fc6f4672b0b8258d337339b0fac2e309fcff85b284753f38",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:43607",
+					"10.65.0.27:43607",
+					"172.17.0.1:43607",
+					"172.18.0.1:43607",
+					"172.19.0.1:43607"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:52:32.637445732Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5882942605188778,
+				"StableID":   "nu89qjvPwn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       5882942605188778,
+				"Key":        "nodekey:7ad000e396248db10eaa3cec51f475b8beca1f2411d4aff38f7bad70b774a543",
+				"DiscoKey":   "discokey:1a5bd847423d07e723964f03d8caa85d14523d5ac342995f2ef636895e5f0d6e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38359",
+					"10.65.0.27:38359",
+					"172.17.0.1:38359",
+					"172.18.0.1:38359",
+					"172.19.0.1:38359"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:52:29.929902408Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7ad000e396248db10eaa3cec51f475b8beca1f2411d4aff38f7bad70b774a543",
+			"MachineKey": "mkey:310dada427877671830480d87b15de9eb0e80403e41348c4803f6e37edf3f402",
+			"Peers": [{
+				"ID":         5336743594628542,
+				"StableID":   "nqLydsC2gi11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26ac58a77b2156bd4619c1b8c041d3315892de9247abb0523afb1e1547098618",
+				"DiscoKey":   "discokey:904d3ec64780e7e40556d21045966dfd32ddd5d4e6a98ebc72984b7bbd117d1f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:37908",
+					"10.65.0.27:37908",
+					"172.17.0.1:37908",
+					"172.18.0.1:37908",
+					"172.19.0.1:37908"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:52:25.107245782Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1388943353778738,
+				"StableID":   "nhehxpB4rB11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8c2675ae0569f34d9a313c69691b1e319722b3d094dc21def96c03b505c8129",
+				"DiscoKey":   "discokey:fcafc2fb0a87d63cca6b050946107a4d715afd74448cf9c6da5081ae7ba0e267",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:57209",
+					"10.65.0.27:57209",
+					"172.17.0.1:57209",
+					"172.18.0.1:57209",
+					"172.19.0.1:57209"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:52:25.604523299Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7063401917802150,
+				"StableID":   "nyEazGb2Ax11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:223f4272749196af577b225a7a488610532cce356bf3a9ef8aec33a732e7d920",
+				"DiscoKey":   "discokey:34e83f38efebb14ddbc68acda1c72655c9e535465f8659c4bab1ce374199a442",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:38553",
+					"10.65.0.27:38553",
+					"172.17.0.1:38553",
+					"172.18.0.1:38553",
+					"172.19.0.1:38553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:52:26.149992802Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3197928985796109,
+				"StableID":   "n4SXgxAMyR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:642e7824806b8d06f25632a58b0300762b847fdb9f45e2c96afc6d5ebe9c7d16",
+				"DiscoKey":   "discokey:c99cff6692c3e4230abeb4c21a72307ed8ea4b12fcf7568fc7697d11e49b6c19",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49441",
+					"10.65.0.27:49441",
+					"172.17.0.1:49441",
+					"172.18.0.1:49441",
+					"172.19.0.1:49441"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:52:26.686954215Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4894805468870921,
+				"StableID":   "npgzotEsDf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8815bb6fd1367e7b3fb2827c8a64c20f385f3b66ca40d124931686fb53c0eb65",
+				"DiscoKey":   "discokey:ccb7ddfb790f135f8533768289d8dea0bec6a3aa1bd826a290726d4a0f716141",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38997",
+					"10.65.0.27:38997",
+					"172.17.0.1:38997",
+					"172.18.0.1:38997",
+					"172.19.0.1:38997"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:52:27.249206735Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1628686280806333,
+				"StableID":   "nnoiTxpdiD11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36d642e7af7d50ac8fd9d02a46fb66fd669914079967945a86bd5eb18c1ae021",
+				"DiscoKey":   "discokey:dea8201be35ee0d8f039d5304fc9eb32e680350de08b2ad2f60bee092b1add4f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39925",
+					"10.65.0.27:39925",
+					"172.17.0.1:39925",
+					"172.18.0.1:39925",
+					"172.19.0.1:39925"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:52:27.770269562Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         482423346820269,
+				"StableID":   "nJfHBiSVm411CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b891c764ae0185ebd75bc03f9813d8b1026185bec3366cd00b79bcb7ba86fa3b",
+				"DiscoKey":   "discokey:e41c116c21b3acb560340a6f7ec790312d66bb78a112eb66249afbaa4341f86c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57372",
+					"10.65.0.27:57372",
+					"172.17.0.1:57372",
+					"172.18.0.1:57372",
+					"172.19.0.1:57372"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:52:28.304998679Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5908298984831681,
+				"StableID":   "nJyfGkzs8o11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc9491e039887d5166e1abf3cce0d056baf550e0477367d054bbe9dea2afee61",
+				"DiscoKey":   "discokey:c3a139b292d4bcae4414eb364e4f8d0156a67a267cb48a44fd236c0ccb8cde11",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:44308",
+					"10.65.0.27:44308",
+					"172.17.0.1:44308",
+					"172.18.0.1:44308",
+					"172.19.0.1:44308"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:52:28.84662133Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         338363147555957,
+				"StableID":   "nSMQg7EFe311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7261332eca0497d23625c1d6e05a40c3abbcd586ffecbd92dd75c8bc63af573e",
+				"DiscoKey":   "discokey:9264de6ae10d5ebd6c4c08a3df227df02accadb4646181181f6f625f7ca7dc54",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44522",
+					"10.65.0.27:44522",
+					"172.17.0.1:44522",
+					"172.18.0.1:44522",
+					"172.19.0.1:44522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:52:29.387544549Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2162014968835529,
+				"StableID":   "niRmK6UBtH11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a500226877487a7c409c3701b5f7e7db9e3ee5e8437756d705280747e4b8a6f",
+				"DiscoKey":   "discokey:b9cc07e45a1fb2e06d9392ce347aad2dad3af5c43c871814daf89e5facb47566",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42328",
+					"10.65.0.27:42328",
+					"172.17.0.1:42328",
+					"172.18.0.1:42328",
+					"172.19.0.1:42328"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:52:30.515991067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6704035779830000,
+				"StableID":   "nRMMyoeGMu11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f074cc8984de067e38e5c898c63f96ade37d719a20ebc7eb3200c50c0fde1c35",
+				"DiscoKey":   "discokey:3f3d642bcd8820b60a2445e9b53fd945fdedfc386738e4029073b064b8781d0f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47324",
+					"10.65.0.27:47324",
+					"172.17.0.1:47324",
+					"172.18.0.1:47324",
+					"172.19.0.1:47324"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:52:31.010533712Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1415764837397018,
+				"StableID":   "nfu4d1kC4C11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a2fb3f1ea5c159fd6d0e07fb200fc0d6724a637a93e38d6a7dc4d4278746c27d",
+				"KeyExpiry":  "2026-11-08T21:52:31Z",
+				"DiscoKey":   "discokey:55af747d47ba3d00676ecb7d951c060930babb53891ec6b8d4a17ed738b74008",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52384",
+					"10.65.0.27:52384",
+					"172.17.0.1:52384",
+					"172.18.0.1:52384",
+					"172.19.0.1:52384"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:52:31.580694753Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7269730603186265,
+				"StableID":   "nJV5PkVUmy11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b703bee326c0c54e09bebeb1901b01e9c330928178e6fe2a0f80b99784b99561",
+				"KeyExpiry":  "2026-11-08T21:52:32Z",
+				"DiscoKey":   "discokey:f57df15cc665ce3cf4830de0a362e246d9b575f7db817a8ed1ce8e307253b663",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50595",
+					"10.65.0.27:50595",
+					"172.17.0.1:50595",
+					"172.18.0.1:50595",
+					"172.19.0.1:50595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:52:32.104077102Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3574989046928154,
+				"StableID":   "nTjv6Du7vU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7786be5ee86a446d73b1c09a05f83483944163c703d9f1ac75fa8ea92410c375",
+				"KeyExpiry":  "2026-11-08T21:52:32Z",
+				"DiscoKey":   "discokey:ccf5277a82b195f1fc6f4672b0b8258d337339b0fac2e309fcff85b284753f38",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:43607",
+					"10.65.0.27:43607",
+					"172.17.0.1:43607",
+					"172.18.0.1:43607",
+					"172.19.0.1:43607"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:52:32.637445732Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5882942605188778": {
+				"ID":          5882942605188778,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-action-mixedcase.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-action-mixedcase.hujson
@@ -1,0 +1,20081 @@
+// ssh-malformed-action-mixedcase
+//
+// ssh action mixed case
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-13T07:26:08Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-malformed-action-mixedcase",
+	"description":    "ssh action mixed case",
+	"category":       "ssh",
+	"captured_at":    "2026-05-13T07:26:08.357564482Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "\"Accept\" is not a valid action"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                 \n  \n                                                                        \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh action mixed case\",\n\t\"id\":          \"ssh-malformed-action-mixedcase\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"Accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"autogroup:member\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-edge/ssh-malformed-action-mixedcase.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "Accept",
+				"dst":    ["tag:server"],
+				"src":    ["autogroup:member"],
+				"users":  ["root"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7455186368303287,
+				"StableID":   "n6xGH37UD121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       7455186368303287,
+				"Key":        "nodekey:294663b0b5f7ba1ee2227009d3fb406868a072a64a3d0bd88cab5eda31d27222",
+				"DiscoKey":   "discokey:c76e5dd5e057ce11c48096fb4fcb8c274426a789e8975b83382dcce63851ff20",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54605",
+					"10.65.0.27:54605",
+					"172.17.0.1:54605",
+					"172.18.0.1:54605",
+					"172.19.0.1:54605"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:26:16.857445165Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:294663b0b5f7ba1ee2227009d3fb406868a072a64a3d0bd88cab5eda31d27222",
+			"MachineKey": "mkey:5eed57e1850988ac081fe68343efebd8cc4ee59ac5416c4c9ac9c010821d3410",
+			"Peers": [{
+				"ID":         3922698761091064,
+				"StableID":   "nmqGsPebdX11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6f914d5564e0c688d3e036904c3e9dea1d722b87fc02c5d9a880a8a0534ed464",
+				"DiscoKey":   "discokey:46529347afdae91b8dad477a76105777cfa27c1d4c52685c0cad084a247f3b19",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35426",
+					"10.65.0.27:35426",
+					"172.17.0.1:35426",
+					"172.18.0.1:35426",
+					"172.19.0.1:35426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:26:10.976975248Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4406294529692090,
+				"StableID":   "noMewMtcQb11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10871915c211c16333b33b320bff410f66cda07a760985a8fded20535f5f5c49",
+				"DiscoKey":   "discokey:f78f2f29f422eb844812ecdaccf1c5a000f167f68399075bd4aa4113ed0edb56",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44756",
+					"10.65.0.27:44756",
+					"172.17.0.1:44756",
+					"172.18.0.1:44756",
+					"172.19.0.1:44756"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:26:11.454274662Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8729599415940745,
+				"StableID":   "n4k7HtmeAB21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:67753b1f23a452a94efdf01e17001258c23b7ccb308395c7013fe6fa87ffe167",
+				"DiscoKey":   "discokey:7e6c6b7a33e8a49233af5370adf399c243608561ecd723a23a78297b12f5807c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34501",
+					"10.65.0.27:34501",
+					"172.17.0.1:34501",
+					"172.18.0.1:34501",
+					"172.19.0.1:34501"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:26:11.992719645Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4487685099469864,
+				"StableID":   "nVRJtusU3c11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc136313d4088b5eaf35796602ae589141f51c6233b04404e339a6922e82872e",
+				"DiscoKey":   "discokey:88b6822ed6132ded97e2cd51dadb5e6361010cf57c91966d19280d57db97eb1f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58706",
+					"10.65.0.27:58706",
+					"172.17.0.1:58706",
+					"172.18.0.1:58706",
+					"172.19.0.1:58706"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:26:12.528642995Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8577452833475303,
+				"StableID":   "ni6enB9ky921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:57be61187942ff8839a890040b4138ecfbcf38fef2c351d6b7cc8aa03082bc7e",
+				"DiscoKey":   "discokey:960b27038dcf4188852eb8283bb434968725922cd3ce0c6b040f8b5757ddd435",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42728",
+					"10.65.0.27:42728",
+					"172.17.0.1:42728",
+					"172.18.0.1:42728",
+					"172.19.0.1:42728"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:26:13.060337024Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         929445925349060,
+				"StableID":   "nbWjgAywF811CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e785db439d1a9e7463c4982c6e311857828f9d12f042db917d3036abd12ccf09",
+				"DiscoKey":   "discokey:24c5752a6f1943c028613055f54b4eeb36e40fb8b8fdeeeb1ac5e2e1d8c26b17",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37910",
+					"10.65.0.27:37910",
+					"172.17.0.1:37910",
+					"172.18.0.1:37910",
+					"172.19.0.1:37910"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:26:13.591886388Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7976552733572839,
+				"StableID":   "nECNeqWbH521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fd5e3e150b855d608bea527fa3f1d22bdf91e163030bc047872618a6d0ea032",
+				"DiscoKey":   "discokey:d779500d32cd2ab2c6ee33347cf09ea457b3b5947255d565b00d36390cb10845",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54450",
+					"10.65.0.27:54450",
+					"172.17.0.1:54450",
+					"172.18.0.1:54450",
+					"172.19.0.1:54450"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:26:14.144258373Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1453856919110886,
+				"StableID":   "n7FgSeMTMC11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:648f74443643fe40ae55a6cf8724022fe292e0124617b3c0d19b203e8fcec90d",
+				"DiscoKey":   "discokey:2ee942ea9a27db219d74afe0848f060b36f20947f13fcd0ba588942c88369c40",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:35581",
+					"10.65.0.27:35581",
+					"172.17.0.1:35581",
+					"172.18.0.1:35581",
+					"172.19.0.1:35581"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:26:14.683922946Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8156323941706304,
+				"StableID":   "nFS9iMo1h621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e79cf519506639525b0b6fb0c0338c46b13e00f8c8fadd4b034dcf4728d6765",
+				"DiscoKey":   "discokey:1a3f91e13d4434153f10e7e52e0dc7291c5d5bcafe3135991155e1027765e32e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56992",
+					"10.65.0.27:56992",
+					"172.17.0.1:56992",
+					"172.18.0.1:56992",
+					"172.19.0.1:56992"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:26:15.226010914Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2188832929173675,
+				"StableID":   "nUFQeuvK6J11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6a66fa3f81c6d57a7dd3292707473a69944e2759166dd347c8af689c35aa414b",
+				"DiscoKey":   "discokey:4cb93e0a0cfb7f2d8f2075415c693f100b99ed6bf2829acb1cec3984962f6551",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33142",
+					"10.65.0.27:33142",
+					"172.17.0.1:33142",
+					"172.18.0.1:33142",
+					"172.19.0.1:33142"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:26:15.764283904Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2220056418692597,
+				"StableID":   "nnBeVp7ULJ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cfa65570339388567923ea44e46ae1a04de2c6a9da6b287c97a9929899504902",
+				"DiscoKey":   "discokey:6369f4878b14b6103bc69fce6146f83dde4766771d89021aa4516de02773320e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53390",
+					"10.65.0.27:53390",
+					"172.17.0.1:53390",
+					"172.18.0.1:53390",
+					"172.19.0.1:53390"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:26:16.313865207Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5338333051349764,
+				"StableID":   "noi8VWxjgi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bd3eaca53faed7bea73992582fb18404d8b93ca3180e9157ea73cda635413525",
+				"KeyExpiry":  "2026-11-09T07:26:17Z",
+				"DiscoKey":   "discokey:caafd01f4ec17355491f0bec6109e51556619ab6f2e648f689eca8c4e024f811",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50620",
+					"10.65.0.27:50620",
+					"172.17.0.1:50620",
+					"172.18.0.1:50620",
+					"172.19.0.1:50620"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:26:17.383458171Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6030978903928173,
+				"StableID":   "nLA9dAbS6p11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ff31a6529f4f1ceb4d62f6dbd573693dadfd8b95685111b4490cc8300019536b",
+				"KeyExpiry":  "2026-11-09T07:26:17Z",
+				"DiscoKey":   "discokey:32853d2bafb9288dfa544e8f4ace90888be551167e02d31d1ece224bc6b5ee6f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48480",
+					"10.65.0.27:48480",
+					"172.17.0.1:48480",
+					"172.18.0.1:48480",
+					"172.19.0.1:48480"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:26:17.935899015Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7379662858071522,
+				"StableID":   "nXdNJKEGdz11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:613c1b30f06a2371e917dab10ea73560ec6d99637bebcd6341da1168647dd867",
+				"KeyExpiry":  "2026-11-09T07:26:18Z",
+				"DiscoKey":   "discokey:e9e440c3073a7ca4c3cd74ea3d9dd61cc19d0d653f73c77eb2a39add0d24af50",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55977",
+					"10.65.0.27:55977",
+					"172.17.0.1:55977",
+					"172.18.0.1:55977",
+					"172.19.0.1:55977"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:26:18.47443624Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7455186368303287": {
+				"ID":          7455186368303287,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         929445925349060,
+				"StableID":   "nbWjgAywF811CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       929445925349060,
+				"Key":        "nodekey:e785db439d1a9e7463c4982c6e311857828f9d12f042db917d3036abd12ccf09",
+				"DiscoKey":   "discokey:24c5752a6f1943c028613055f54b4eeb36e40fb8b8fdeeeb1ac5e2e1d8c26b17",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37910",
+					"10.65.0.27:37910",
+					"172.17.0.1:37910",
+					"172.18.0.1:37910",
+					"172.19.0.1:37910"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:26:13.591886388Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e785db439d1a9e7463c4982c6e311857828f9d12f042db917d3036abd12ccf09",
+			"MachineKey": "mkey:36482739082a844f2f511e7dd22e189e54ff437370dc7d8f0680fa0421bcd655",
+			"Peers": [{
+				"ID":         3922698761091064,
+				"StableID":   "nmqGsPebdX11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6f914d5564e0c688d3e036904c3e9dea1d722b87fc02c5d9a880a8a0534ed464",
+				"DiscoKey":   "discokey:46529347afdae91b8dad477a76105777cfa27c1d4c52685c0cad084a247f3b19",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35426",
+					"10.65.0.27:35426",
+					"172.17.0.1:35426",
+					"172.18.0.1:35426",
+					"172.19.0.1:35426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:26:10.976975248Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4406294529692090,
+				"StableID":   "noMewMtcQb11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10871915c211c16333b33b320bff410f66cda07a760985a8fded20535f5f5c49",
+				"DiscoKey":   "discokey:f78f2f29f422eb844812ecdaccf1c5a000f167f68399075bd4aa4113ed0edb56",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44756",
+					"10.65.0.27:44756",
+					"172.17.0.1:44756",
+					"172.18.0.1:44756",
+					"172.19.0.1:44756"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:26:11.454274662Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8729599415940745,
+				"StableID":   "n4k7HtmeAB21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:67753b1f23a452a94efdf01e17001258c23b7ccb308395c7013fe6fa87ffe167",
+				"DiscoKey":   "discokey:7e6c6b7a33e8a49233af5370adf399c243608561ecd723a23a78297b12f5807c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34501",
+					"10.65.0.27:34501",
+					"172.17.0.1:34501",
+					"172.18.0.1:34501",
+					"172.19.0.1:34501"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:26:11.992719645Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4487685099469864,
+				"StableID":   "nVRJtusU3c11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc136313d4088b5eaf35796602ae589141f51c6233b04404e339a6922e82872e",
+				"DiscoKey":   "discokey:88b6822ed6132ded97e2cd51dadb5e6361010cf57c91966d19280d57db97eb1f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58706",
+					"10.65.0.27:58706",
+					"172.17.0.1:58706",
+					"172.18.0.1:58706",
+					"172.19.0.1:58706"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:26:12.528642995Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8577452833475303,
+				"StableID":   "ni6enB9ky921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:57be61187942ff8839a890040b4138ecfbcf38fef2c351d6b7cc8aa03082bc7e",
+				"DiscoKey":   "discokey:960b27038dcf4188852eb8283bb434968725922cd3ce0c6b040f8b5757ddd435",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42728",
+					"10.65.0.27:42728",
+					"172.17.0.1:42728",
+					"172.18.0.1:42728",
+					"172.19.0.1:42728"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:26:13.060337024Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7976552733572839,
+				"StableID":   "nECNeqWbH521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fd5e3e150b855d608bea527fa3f1d22bdf91e163030bc047872618a6d0ea032",
+				"DiscoKey":   "discokey:d779500d32cd2ab2c6ee33347cf09ea457b3b5947255d565b00d36390cb10845",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54450",
+					"10.65.0.27:54450",
+					"172.17.0.1:54450",
+					"172.18.0.1:54450",
+					"172.19.0.1:54450"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:26:14.144258373Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1453856919110886,
+				"StableID":   "n7FgSeMTMC11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:648f74443643fe40ae55a6cf8724022fe292e0124617b3c0d19b203e8fcec90d",
+				"DiscoKey":   "discokey:2ee942ea9a27db219d74afe0848f060b36f20947f13fcd0ba588942c88369c40",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:35581",
+					"10.65.0.27:35581",
+					"172.17.0.1:35581",
+					"172.18.0.1:35581",
+					"172.19.0.1:35581"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:26:14.683922946Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8156323941706304,
+				"StableID":   "nFS9iMo1h621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e79cf519506639525b0b6fb0c0338c46b13e00f8c8fadd4b034dcf4728d6765",
+				"DiscoKey":   "discokey:1a3f91e13d4434153f10e7e52e0dc7291c5d5bcafe3135991155e1027765e32e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56992",
+					"10.65.0.27:56992",
+					"172.17.0.1:56992",
+					"172.18.0.1:56992",
+					"172.19.0.1:56992"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:26:15.226010914Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2188832929173675,
+				"StableID":   "nUFQeuvK6J11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6a66fa3f81c6d57a7dd3292707473a69944e2759166dd347c8af689c35aa414b",
+				"DiscoKey":   "discokey:4cb93e0a0cfb7f2d8f2075415c693f100b99ed6bf2829acb1cec3984962f6551",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33142",
+					"10.65.0.27:33142",
+					"172.17.0.1:33142",
+					"172.18.0.1:33142",
+					"172.19.0.1:33142"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:26:15.764283904Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2220056418692597,
+				"StableID":   "nnBeVp7ULJ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cfa65570339388567923ea44e46ae1a04de2c6a9da6b287c97a9929899504902",
+				"DiscoKey":   "discokey:6369f4878b14b6103bc69fce6146f83dde4766771d89021aa4516de02773320e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53390",
+					"10.65.0.27:53390",
+					"172.17.0.1:53390",
+					"172.18.0.1:53390",
+					"172.19.0.1:53390"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:26:16.313865207Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7455186368303287,
+				"StableID":   "n6xGH37UD121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:294663b0b5f7ba1ee2227009d3fb406868a072a64a3d0bd88cab5eda31d27222",
+				"DiscoKey":   "discokey:c76e5dd5e057ce11c48096fb4fcb8c274426a789e8975b83382dcce63851ff20",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54605",
+					"10.65.0.27:54605",
+					"172.17.0.1:54605",
+					"172.18.0.1:54605",
+					"172.19.0.1:54605"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:26:16.857445165Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5338333051349764,
+				"StableID":   "noi8VWxjgi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bd3eaca53faed7bea73992582fb18404d8b93ca3180e9157ea73cda635413525",
+				"KeyExpiry":  "2026-11-09T07:26:17Z",
+				"DiscoKey":   "discokey:caafd01f4ec17355491f0bec6109e51556619ab6f2e648f689eca8c4e024f811",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50620",
+					"10.65.0.27:50620",
+					"172.17.0.1:50620",
+					"172.18.0.1:50620",
+					"172.19.0.1:50620"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:26:17.383458171Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6030978903928173,
+				"StableID":   "nLA9dAbS6p11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ff31a6529f4f1ceb4d62f6dbd573693dadfd8b95685111b4490cc8300019536b",
+				"KeyExpiry":  "2026-11-09T07:26:17Z",
+				"DiscoKey":   "discokey:32853d2bafb9288dfa544e8f4ace90888be551167e02d31d1ece224bc6b5ee6f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48480",
+					"10.65.0.27:48480",
+					"172.17.0.1:48480",
+					"172.18.0.1:48480",
+					"172.19.0.1:48480"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:26:17.935899015Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7379662858071522,
+				"StableID":   "nXdNJKEGdz11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:613c1b30f06a2371e917dab10ea73560ec6d99637bebcd6341da1168647dd867",
+				"KeyExpiry":  "2026-11-09T07:26:18Z",
+				"DiscoKey":   "discokey:e9e440c3073a7ca4c3cd74ea3d9dd61cc19d0d653f73c77eb2a39add0d24af50",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55977",
+					"10.65.0.27:55977",
+					"172.17.0.1:55977",
+					"172.18.0.1:55977",
+					"172.19.0.1:55977"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:26:18.47443624Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "929445925349060": {
+				"ID":          929445925349060,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7379662858071522,
+				"StableID":   "nXdNJKEGdz11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:613c1b30f06a2371e917dab10ea73560ec6d99637bebcd6341da1168647dd867",
+				"KeyExpiry":  "2026-11-09T07:26:18Z",
+				"DiscoKey":   "discokey:e9e440c3073a7ca4c3cd74ea3d9dd61cc19d0d653f73c77eb2a39add0d24af50",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55977",
+					"10.65.0.27:55977",
+					"172.17.0.1:55977",
+					"172.18.0.1:55977",
+					"172.19.0.1:55977"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:26:18.47443624Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:613c1b30f06a2371e917dab10ea73560ec6d99637bebcd6341da1168647dd867",
+			"MachineKey": "mkey:88fa8d634f9cf34c31dfd04764be88d571a5d4a4ef4d3dd992bb1a11d9e28969",
+			"Peers": [{
+				"ID":         3922698761091064,
+				"StableID":   "nmqGsPebdX11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6f914d5564e0c688d3e036904c3e9dea1d722b87fc02c5d9a880a8a0534ed464",
+				"DiscoKey":   "discokey:46529347afdae91b8dad477a76105777cfa27c1d4c52685c0cad084a247f3b19",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35426",
+					"10.65.0.27:35426",
+					"172.17.0.1:35426",
+					"172.18.0.1:35426",
+					"172.19.0.1:35426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:26:10.976975248Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4406294529692090,
+				"StableID":   "noMewMtcQb11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10871915c211c16333b33b320bff410f66cda07a760985a8fded20535f5f5c49",
+				"DiscoKey":   "discokey:f78f2f29f422eb844812ecdaccf1c5a000f167f68399075bd4aa4113ed0edb56",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44756",
+					"10.65.0.27:44756",
+					"172.17.0.1:44756",
+					"172.18.0.1:44756",
+					"172.19.0.1:44756"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:26:11.454274662Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8729599415940745,
+				"StableID":   "n4k7HtmeAB21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:67753b1f23a452a94efdf01e17001258c23b7ccb308395c7013fe6fa87ffe167",
+				"DiscoKey":   "discokey:7e6c6b7a33e8a49233af5370adf399c243608561ecd723a23a78297b12f5807c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34501",
+					"10.65.0.27:34501",
+					"172.17.0.1:34501",
+					"172.18.0.1:34501",
+					"172.19.0.1:34501"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:26:11.992719645Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4487685099469864,
+				"StableID":   "nVRJtusU3c11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc136313d4088b5eaf35796602ae589141f51c6233b04404e339a6922e82872e",
+				"DiscoKey":   "discokey:88b6822ed6132ded97e2cd51dadb5e6361010cf57c91966d19280d57db97eb1f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58706",
+					"10.65.0.27:58706",
+					"172.17.0.1:58706",
+					"172.18.0.1:58706",
+					"172.19.0.1:58706"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:26:12.528642995Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8577452833475303,
+				"StableID":   "ni6enB9ky921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:57be61187942ff8839a890040b4138ecfbcf38fef2c351d6b7cc8aa03082bc7e",
+				"DiscoKey":   "discokey:960b27038dcf4188852eb8283bb434968725922cd3ce0c6b040f8b5757ddd435",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42728",
+					"10.65.0.27:42728",
+					"172.17.0.1:42728",
+					"172.18.0.1:42728",
+					"172.19.0.1:42728"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:26:13.060337024Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         929445925349060,
+				"StableID":   "nbWjgAywF811CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e785db439d1a9e7463c4982c6e311857828f9d12f042db917d3036abd12ccf09",
+				"DiscoKey":   "discokey:24c5752a6f1943c028613055f54b4eeb36e40fb8b8fdeeeb1ac5e2e1d8c26b17",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37910",
+					"10.65.0.27:37910",
+					"172.17.0.1:37910",
+					"172.18.0.1:37910",
+					"172.19.0.1:37910"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:26:13.591886388Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7976552733572839,
+				"StableID":   "nECNeqWbH521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fd5e3e150b855d608bea527fa3f1d22bdf91e163030bc047872618a6d0ea032",
+				"DiscoKey":   "discokey:d779500d32cd2ab2c6ee33347cf09ea457b3b5947255d565b00d36390cb10845",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54450",
+					"10.65.0.27:54450",
+					"172.17.0.1:54450",
+					"172.18.0.1:54450",
+					"172.19.0.1:54450"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:26:14.144258373Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1453856919110886,
+				"StableID":   "n7FgSeMTMC11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:648f74443643fe40ae55a6cf8724022fe292e0124617b3c0d19b203e8fcec90d",
+				"DiscoKey":   "discokey:2ee942ea9a27db219d74afe0848f060b36f20947f13fcd0ba588942c88369c40",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:35581",
+					"10.65.0.27:35581",
+					"172.17.0.1:35581",
+					"172.18.0.1:35581",
+					"172.19.0.1:35581"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:26:14.683922946Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8156323941706304,
+				"StableID":   "nFS9iMo1h621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e79cf519506639525b0b6fb0c0338c46b13e00f8c8fadd4b034dcf4728d6765",
+				"DiscoKey":   "discokey:1a3f91e13d4434153f10e7e52e0dc7291c5d5bcafe3135991155e1027765e32e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56992",
+					"10.65.0.27:56992",
+					"172.17.0.1:56992",
+					"172.18.0.1:56992",
+					"172.19.0.1:56992"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:26:15.226010914Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2188832929173675,
+				"StableID":   "nUFQeuvK6J11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6a66fa3f81c6d57a7dd3292707473a69944e2759166dd347c8af689c35aa414b",
+				"DiscoKey":   "discokey:4cb93e0a0cfb7f2d8f2075415c693f100b99ed6bf2829acb1cec3984962f6551",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33142",
+					"10.65.0.27:33142",
+					"172.17.0.1:33142",
+					"172.18.0.1:33142",
+					"172.19.0.1:33142"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:26:15.764283904Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2220056418692597,
+				"StableID":   "nnBeVp7ULJ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cfa65570339388567923ea44e46ae1a04de2c6a9da6b287c97a9929899504902",
+				"DiscoKey":   "discokey:6369f4878b14b6103bc69fce6146f83dde4766771d89021aa4516de02773320e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53390",
+					"10.65.0.27:53390",
+					"172.17.0.1:53390",
+					"172.18.0.1:53390",
+					"172.19.0.1:53390"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:26:16.313865207Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7455186368303287,
+				"StableID":   "n6xGH37UD121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:294663b0b5f7ba1ee2227009d3fb406868a072a64a3d0bd88cab5eda31d27222",
+				"DiscoKey":   "discokey:c76e5dd5e057ce11c48096fb4fcb8c274426a789e8975b83382dcce63851ff20",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54605",
+					"10.65.0.27:54605",
+					"172.17.0.1:54605",
+					"172.18.0.1:54605",
+					"172.19.0.1:54605"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:26:16.857445165Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5338333051349764,
+				"StableID":   "noi8VWxjgi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bd3eaca53faed7bea73992582fb18404d8b93ca3180e9157ea73cda635413525",
+				"KeyExpiry":  "2026-11-09T07:26:17Z",
+				"DiscoKey":   "discokey:caafd01f4ec17355491f0bec6109e51556619ab6f2e648f689eca8c4e024f811",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50620",
+					"10.65.0.27:50620",
+					"172.17.0.1:50620",
+					"172.18.0.1:50620",
+					"172.19.0.1:50620"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:26:17.383458171Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6030978903928173,
+				"StableID":   "nLA9dAbS6p11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ff31a6529f4f1ceb4d62f6dbd573693dadfd8b95685111b4490cc8300019536b",
+				"KeyExpiry":  "2026-11-09T07:26:17Z",
+				"DiscoKey":   "discokey:32853d2bafb9288dfa544e8f4ace90888be551167e02d31d1ece224bc6b5ee6f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48480",
+					"10.65.0.27:48480",
+					"172.17.0.1:48480",
+					"172.18.0.1:48480",
+					"172.19.0.1:48480"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:26:17.935899015Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8729599415940745,
+				"StableID":   "n4k7HtmeAB21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       8729599415940745,
+				"Key":        "nodekey:67753b1f23a452a94efdf01e17001258c23b7ccb308395c7013fe6fa87ffe167",
+				"DiscoKey":   "discokey:7e6c6b7a33e8a49233af5370adf399c243608561ecd723a23a78297b12f5807c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34501",
+					"10.65.0.27:34501",
+					"172.17.0.1:34501",
+					"172.18.0.1:34501",
+					"172.19.0.1:34501"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:26:11.992719645Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:67753b1f23a452a94efdf01e17001258c23b7ccb308395c7013fe6fa87ffe167",
+			"MachineKey": "mkey:05d7e79473a92ee8dae7890a75710263b116e8c864af8ae9e4f234613e27ad09",
+			"Peers": [{
+				"ID":         3922698761091064,
+				"StableID":   "nmqGsPebdX11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6f914d5564e0c688d3e036904c3e9dea1d722b87fc02c5d9a880a8a0534ed464",
+				"DiscoKey":   "discokey:46529347afdae91b8dad477a76105777cfa27c1d4c52685c0cad084a247f3b19",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35426",
+					"10.65.0.27:35426",
+					"172.17.0.1:35426",
+					"172.18.0.1:35426",
+					"172.19.0.1:35426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:26:10.976975248Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4406294529692090,
+				"StableID":   "noMewMtcQb11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10871915c211c16333b33b320bff410f66cda07a760985a8fded20535f5f5c49",
+				"DiscoKey":   "discokey:f78f2f29f422eb844812ecdaccf1c5a000f167f68399075bd4aa4113ed0edb56",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44756",
+					"10.65.0.27:44756",
+					"172.17.0.1:44756",
+					"172.18.0.1:44756",
+					"172.19.0.1:44756"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:26:11.454274662Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4487685099469864,
+				"StableID":   "nVRJtusU3c11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc136313d4088b5eaf35796602ae589141f51c6233b04404e339a6922e82872e",
+				"DiscoKey":   "discokey:88b6822ed6132ded97e2cd51dadb5e6361010cf57c91966d19280d57db97eb1f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58706",
+					"10.65.0.27:58706",
+					"172.17.0.1:58706",
+					"172.18.0.1:58706",
+					"172.19.0.1:58706"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:26:12.528642995Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8577452833475303,
+				"StableID":   "ni6enB9ky921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:57be61187942ff8839a890040b4138ecfbcf38fef2c351d6b7cc8aa03082bc7e",
+				"DiscoKey":   "discokey:960b27038dcf4188852eb8283bb434968725922cd3ce0c6b040f8b5757ddd435",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42728",
+					"10.65.0.27:42728",
+					"172.17.0.1:42728",
+					"172.18.0.1:42728",
+					"172.19.0.1:42728"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:26:13.060337024Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         929445925349060,
+				"StableID":   "nbWjgAywF811CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e785db439d1a9e7463c4982c6e311857828f9d12f042db917d3036abd12ccf09",
+				"DiscoKey":   "discokey:24c5752a6f1943c028613055f54b4eeb36e40fb8b8fdeeeb1ac5e2e1d8c26b17",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37910",
+					"10.65.0.27:37910",
+					"172.17.0.1:37910",
+					"172.18.0.1:37910",
+					"172.19.0.1:37910"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:26:13.591886388Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7976552733572839,
+				"StableID":   "nECNeqWbH521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fd5e3e150b855d608bea527fa3f1d22bdf91e163030bc047872618a6d0ea032",
+				"DiscoKey":   "discokey:d779500d32cd2ab2c6ee33347cf09ea457b3b5947255d565b00d36390cb10845",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54450",
+					"10.65.0.27:54450",
+					"172.17.0.1:54450",
+					"172.18.0.1:54450",
+					"172.19.0.1:54450"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:26:14.144258373Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1453856919110886,
+				"StableID":   "n7FgSeMTMC11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:648f74443643fe40ae55a6cf8724022fe292e0124617b3c0d19b203e8fcec90d",
+				"DiscoKey":   "discokey:2ee942ea9a27db219d74afe0848f060b36f20947f13fcd0ba588942c88369c40",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:35581",
+					"10.65.0.27:35581",
+					"172.17.0.1:35581",
+					"172.18.0.1:35581",
+					"172.19.0.1:35581"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:26:14.683922946Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8156323941706304,
+				"StableID":   "nFS9iMo1h621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e79cf519506639525b0b6fb0c0338c46b13e00f8c8fadd4b034dcf4728d6765",
+				"DiscoKey":   "discokey:1a3f91e13d4434153f10e7e52e0dc7291c5d5bcafe3135991155e1027765e32e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56992",
+					"10.65.0.27:56992",
+					"172.17.0.1:56992",
+					"172.18.0.1:56992",
+					"172.19.0.1:56992"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:26:15.226010914Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2188832929173675,
+				"StableID":   "nUFQeuvK6J11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6a66fa3f81c6d57a7dd3292707473a69944e2759166dd347c8af689c35aa414b",
+				"DiscoKey":   "discokey:4cb93e0a0cfb7f2d8f2075415c693f100b99ed6bf2829acb1cec3984962f6551",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33142",
+					"10.65.0.27:33142",
+					"172.17.0.1:33142",
+					"172.18.0.1:33142",
+					"172.19.0.1:33142"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:26:15.764283904Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2220056418692597,
+				"StableID":   "nnBeVp7ULJ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cfa65570339388567923ea44e46ae1a04de2c6a9da6b287c97a9929899504902",
+				"DiscoKey":   "discokey:6369f4878b14b6103bc69fce6146f83dde4766771d89021aa4516de02773320e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53390",
+					"10.65.0.27:53390",
+					"172.17.0.1:53390",
+					"172.18.0.1:53390",
+					"172.19.0.1:53390"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:26:16.313865207Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7455186368303287,
+				"StableID":   "n6xGH37UD121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:294663b0b5f7ba1ee2227009d3fb406868a072a64a3d0bd88cab5eda31d27222",
+				"DiscoKey":   "discokey:c76e5dd5e057ce11c48096fb4fcb8c274426a789e8975b83382dcce63851ff20",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54605",
+					"10.65.0.27:54605",
+					"172.17.0.1:54605",
+					"172.18.0.1:54605",
+					"172.19.0.1:54605"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:26:16.857445165Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5338333051349764,
+				"StableID":   "noi8VWxjgi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bd3eaca53faed7bea73992582fb18404d8b93ca3180e9157ea73cda635413525",
+				"KeyExpiry":  "2026-11-09T07:26:17Z",
+				"DiscoKey":   "discokey:caafd01f4ec17355491f0bec6109e51556619ab6f2e648f689eca8c4e024f811",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50620",
+					"10.65.0.27:50620",
+					"172.17.0.1:50620",
+					"172.18.0.1:50620",
+					"172.19.0.1:50620"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:26:17.383458171Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6030978903928173,
+				"StableID":   "nLA9dAbS6p11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ff31a6529f4f1ceb4d62f6dbd573693dadfd8b95685111b4490cc8300019536b",
+				"KeyExpiry":  "2026-11-09T07:26:17Z",
+				"DiscoKey":   "discokey:32853d2bafb9288dfa544e8f4ace90888be551167e02d31d1ece224bc6b5ee6f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48480",
+					"10.65.0.27:48480",
+					"172.17.0.1:48480",
+					"172.18.0.1:48480",
+					"172.19.0.1:48480"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:26:17.935899015Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7379662858071522,
+				"StableID":   "nXdNJKEGdz11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:613c1b30f06a2371e917dab10ea73560ec6d99637bebcd6341da1168647dd867",
+				"KeyExpiry":  "2026-11-09T07:26:18Z",
+				"DiscoKey":   "discokey:e9e440c3073a7ca4c3cd74ea3d9dd61cc19d0d653f73c77eb2a39add0d24af50",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55977",
+					"10.65.0.27:55977",
+					"172.17.0.1:55977",
+					"172.18.0.1:55977",
+					"172.19.0.1:55977"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:26:18.47443624Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8729599415940745": {
+				"ID":          8729599415940745,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1453856919110886,
+				"StableID":   "n7FgSeMTMC11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1453856919110886,
+				"Key":        "nodekey:648f74443643fe40ae55a6cf8724022fe292e0124617b3c0d19b203e8fcec90d",
+				"DiscoKey":   "discokey:2ee942ea9a27db219d74afe0848f060b36f20947f13fcd0ba588942c88369c40",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:35581",
+					"10.65.0.27:35581",
+					"172.17.0.1:35581",
+					"172.18.0.1:35581",
+					"172.19.0.1:35581"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:26:14.683922946Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:648f74443643fe40ae55a6cf8724022fe292e0124617b3c0d19b203e8fcec90d",
+			"MachineKey": "mkey:434db964d396fa0e7c498491d9a554194c7c3a2ee7e305a9706744e68d7fe252",
+			"Peers": [{
+				"ID":         3922698761091064,
+				"StableID":   "nmqGsPebdX11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6f914d5564e0c688d3e036904c3e9dea1d722b87fc02c5d9a880a8a0534ed464",
+				"DiscoKey":   "discokey:46529347afdae91b8dad477a76105777cfa27c1d4c52685c0cad084a247f3b19",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35426",
+					"10.65.0.27:35426",
+					"172.17.0.1:35426",
+					"172.18.0.1:35426",
+					"172.19.0.1:35426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:26:10.976975248Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4406294529692090,
+				"StableID":   "noMewMtcQb11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10871915c211c16333b33b320bff410f66cda07a760985a8fded20535f5f5c49",
+				"DiscoKey":   "discokey:f78f2f29f422eb844812ecdaccf1c5a000f167f68399075bd4aa4113ed0edb56",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44756",
+					"10.65.0.27:44756",
+					"172.17.0.1:44756",
+					"172.18.0.1:44756",
+					"172.19.0.1:44756"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:26:11.454274662Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8729599415940745,
+				"StableID":   "n4k7HtmeAB21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:67753b1f23a452a94efdf01e17001258c23b7ccb308395c7013fe6fa87ffe167",
+				"DiscoKey":   "discokey:7e6c6b7a33e8a49233af5370adf399c243608561ecd723a23a78297b12f5807c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34501",
+					"10.65.0.27:34501",
+					"172.17.0.1:34501",
+					"172.18.0.1:34501",
+					"172.19.0.1:34501"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:26:11.992719645Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4487685099469864,
+				"StableID":   "nVRJtusU3c11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc136313d4088b5eaf35796602ae589141f51c6233b04404e339a6922e82872e",
+				"DiscoKey":   "discokey:88b6822ed6132ded97e2cd51dadb5e6361010cf57c91966d19280d57db97eb1f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58706",
+					"10.65.0.27:58706",
+					"172.17.0.1:58706",
+					"172.18.0.1:58706",
+					"172.19.0.1:58706"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:26:12.528642995Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8577452833475303,
+				"StableID":   "ni6enB9ky921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:57be61187942ff8839a890040b4138ecfbcf38fef2c351d6b7cc8aa03082bc7e",
+				"DiscoKey":   "discokey:960b27038dcf4188852eb8283bb434968725922cd3ce0c6b040f8b5757ddd435",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42728",
+					"10.65.0.27:42728",
+					"172.17.0.1:42728",
+					"172.18.0.1:42728",
+					"172.19.0.1:42728"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:26:13.060337024Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         929445925349060,
+				"StableID":   "nbWjgAywF811CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e785db439d1a9e7463c4982c6e311857828f9d12f042db917d3036abd12ccf09",
+				"DiscoKey":   "discokey:24c5752a6f1943c028613055f54b4eeb36e40fb8b8fdeeeb1ac5e2e1d8c26b17",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37910",
+					"10.65.0.27:37910",
+					"172.17.0.1:37910",
+					"172.18.0.1:37910",
+					"172.19.0.1:37910"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:26:13.591886388Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7976552733572839,
+				"StableID":   "nECNeqWbH521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fd5e3e150b855d608bea527fa3f1d22bdf91e163030bc047872618a6d0ea032",
+				"DiscoKey":   "discokey:d779500d32cd2ab2c6ee33347cf09ea457b3b5947255d565b00d36390cb10845",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54450",
+					"10.65.0.27:54450",
+					"172.17.0.1:54450",
+					"172.18.0.1:54450",
+					"172.19.0.1:54450"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:26:14.144258373Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8156323941706304,
+				"StableID":   "nFS9iMo1h621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e79cf519506639525b0b6fb0c0338c46b13e00f8c8fadd4b034dcf4728d6765",
+				"DiscoKey":   "discokey:1a3f91e13d4434153f10e7e52e0dc7291c5d5bcafe3135991155e1027765e32e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56992",
+					"10.65.0.27:56992",
+					"172.17.0.1:56992",
+					"172.18.0.1:56992",
+					"172.19.0.1:56992"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:26:15.226010914Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2188832929173675,
+				"StableID":   "nUFQeuvK6J11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6a66fa3f81c6d57a7dd3292707473a69944e2759166dd347c8af689c35aa414b",
+				"DiscoKey":   "discokey:4cb93e0a0cfb7f2d8f2075415c693f100b99ed6bf2829acb1cec3984962f6551",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33142",
+					"10.65.0.27:33142",
+					"172.17.0.1:33142",
+					"172.18.0.1:33142",
+					"172.19.0.1:33142"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:26:15.764283904Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2220056418692597,
+				"StableID":   "nnBeVp7ULJ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cfa65570339388567923ea44e46ae1a04de2c6a9da6b287c97a9929899504902",
+				"DiscoKey":   "discokey:6369f4878b14b6103bc69fce6146f83dde4766771d89021aa4516de02773320e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53390",
+					"10.65.0.27:53390",
+					"172.17.0.1:53390",
+					"172.18.0.1:53390",
+					"172.19.0.1:53390"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:26:16.313865207Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7455186368303287,
+				"StableID":   "n6xGH37UD121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:294663b0b5f7ba1ee2227009d3fb406868a072a64a3d0bd88cab5eda31d27222",
+				"DiscoKey":   "discokey:c76e5dd5e057ce11c48096fb4fcb8c274426a789e8975b83382dcce63851ff20",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54605",
+					"10.65.0.27:54605",
+					"172.17.0.1:54605",
+					"172.18.0.1:54605",
+					"172.19.0.1:54605"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:26:16.857445165Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5338333051349764,
+				"StableID":   "noi8VWxjgi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bd3eaca53faed7bea73992582fb18404d8b93ca3180e9157ea73cda635413525",
+				"KeyExpiry":  "2026-11-09T07:26:17Z",
+				"DiscoKey":   "discokey:caafd01f4ec17355491f0bec6109e51556619ab6f2e648f689eca8c4e024f811",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50620",
+					"10.65.0.27:50620",
+					"172.17.0.1:50620",
+					"172.18.0.1:50620",
+					"172.19.0.1:50620"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:26:17.383458171Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6030978903928173,
+				"StableID":   "nLA9dAbS6p11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ff31a6529f4f1ceb4d62f6dbd573693dadfd8b95685111b4490cc8300019536b",
+				"KeyExpiry":  "2026-11-09T07:26:17Z",
+				"DiscoKey":   "discokey:32853d2bafb9288dfa544e8f4ace90888be551167e02d31d1ece224bc6b5ee6f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48480",
+					"10.65.0.27:48480",
+					"172.17.0.1:48480",
+					"172.18.0.1:48480",
+					"172.19.0.1:48480"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:26:17.935899015Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7379662858071522,
+				"StableID":   "nXdNJKEGdz11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:613c1b30f06a2371e917dab10ea73560ec6d99637bebcd6341da1168647dd867",
+				"KeyExpiry":  "2026-11-09T07:26:18Z",
+				"DiscoKey":   "discokey:e9e440c3073a7ca4c3cd74ea3d9dd61cc19d0d653f73c77eb2a39add0d24af50",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55977",
+					"10.65.0.27:55977",
+					"172.17.0.1:55977",
+					"172.18.0.1:55977",
+					"172.19.0.1:55977"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:26:18.47443624Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1453856919110886": {
+				"ID":          1453856919110886,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5338333051349764,
+				"StableID":   "noi8VWxjgi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bd3eaca53faed7bea73992582fb18404d8b93ca3180e9157ea73cda635413525",
+				"KeyExpiry":  "2026-11-09T07:26:17Z",
+				"DiscoKey":   "discokey:caafd01f4ec17355491f0bec6109e51556619ab6f2e648f689eca8c4e024f811",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50620",
+					"10.65.0.27:50620",
+					"172.17.0.1:50620",
+					"172.18.0.1:50620",
+					"172.19.0.1:50620"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:26:17.383458171Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:bd3eaca53faed7bea73992582fb18404d8b93ca3180e9157ea73cda635413525",
+			"MachineKey": "mkey:853b3eaf59f659079ce3f359bef73197fb1cb8c84ed0a9ba0449591b223e6504",
+			"Peers": [{
+				"ID":         3922698761091064,
+				"StableID":   "nmqGsPebdX11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6f914d5564e0c688d3e036904c3e9dea1d722b87fc02c5d9a880a8a0534ed464",
+				"DiscoKey":   "discokey:46529347afdae91b8dad477a76105777cfa27c1d4c52685c0cad084a247f3b19",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35426",
+					"10.65.0.27:35426",
+					"172.17.0.1:35426",
+					"172.18.0.1:35426",
+					"172.19.0.1:35426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:26:10.976975248Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4406294529692090,
+				"StableID":   "noMewMtcQb11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10871915c211c16333b33b320bff410f66cda07a760985a8fded20535f5f5c49",
+				"DiscoKey":   "discokey:f78f2f29f422eb844812ecdaccf1c5a000f167f68399075bd4aa4113ed0edb56",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44756",
+					"10.65.0.27:44756",
+					"172.17.0.1:44756",
+					"172.18.0.1:44756",
+					"172.19.0.1:44756"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:26:11.454274662Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8729599415940745,
+				"StableID":   "n4k7HtmeAB21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:67753b1f23a452a94efdf01e17001258c23b7ccb308395c7013fe6fa87ffe167",
+				"DiscoKey":   "discokey:7e6c6b7a33e8a49233af5370adf399c243608561ecd723a23a78297b12f5807c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34501",
+					"10.65.0.27:34501",
+					"172.17.0.1:34501",
+					"172.18.0.1:34501",
+					"172.19.0.1:34501"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:26:11.992719645Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4487685099469864,
+				"StableID":   "nVRJtusU3c11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc136313d4088b5eaf35796602ae589141f51c6233b04404e339a6922e82872e",
+				"DiscoKey":   "discokey:88b6822ed6132ded97e2cd51dadb5e6361010cf57c91966d19280d57db97eb1f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58706",
+					"10.65.0.27:58706",
+					"172.17.0.1:58706",
+					"172.18.0.1:58706",
+					"172.19.0.1:58706"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:26:12.528642995Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8577452833475303,
+				"StableID":   "ni6enB9ky921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:57be61187942ff8839a890040b4138ecfbcf38fef2c351d6b7cc8aa03082bc7e",
+				"DiscoKey":   "discokey:960b27038dcf4188852eb8283bb434968725922cd3ce0c6b040f8b5757ddd435",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42728",
+					"10.65.0.27:42728",
+					"172.17.0.1:42728",
+					"172.18.0.1:42728",
+					"172.19.0.1:42728"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:26:13.060337024Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         929445925349060,
+				"StableID":   "nbWjgAywF811CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e785db439d1a9e7463c4982c6e311857828f9d12f042db917d3036abd12ccf09",
+				"DiscoKey":   "discokey:24c5752a6f1943c028613055f54b4eeb36e40fb8b8fdeeeb1ac5e2e1d8c26b17",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37910",
+					"10.65.0.27:37910",
+					"172.17.0.1:37910",
+					"172.18.0.1:37910",
+					"172.19.0.1:37910"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:26:13.591886388Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7976552733572839,
+				"StableID":   "nECNeqWbH521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fd5e3e150b855d608bea527fa3f1d22bdf91e163030bc047872618a6d0ea032",
+				"DiscoKey":   "discokey:d779500d32cd2ab2c6ee33347cf09ea457b3b5947255d565b00d36390cb10845",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54450",
+					"10.65.0.27:54450",
+					"172.17.0.1:54450",
+					"172.18.0.1:54450",
+					"172.19.0.1:54450"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:26:14.144258373Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1453856919110886,
+				"StableID":   "n7FgSeMTMC11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:648f74443643fe40ae55a6cf8724022fe292e0124617b3c0d19b203e8fcec90d",
+				"DiscoKey":   "discokey:2ee942ea9a27db219d74afe0848f060b36f20947f13fcd0ba588942c88369c40",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:35581",
+					"10.65.0.27:35581",
+					"172.17.0.1:35581",
+					"172.18.0.1:35581",
+					"172.19.0.1:35581"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:26:14.683922946Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8156323941706304,
+				"StableID":   "nFS9iMo1h621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e79cf519506639525b0b6fb0c0338c46b13e00f8c8fadd4b034dcf4728d6765",
+				"DiscoKey":   "discokey:1a3f91e13d4434153f10e7e52e0dc7291c5d5bcafe3135991155e1027765e32e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56992",
+					"10.65.0.27:56992",
+					"172.17.0.1:56992",
+					"172.18.0.1:56992",
+					"172.19.0.1:56992"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:26:15.226010914Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2188832929173675,
+				"StableID":   "nUFQeuvK6J11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6a66fa3f81c6d57a7dd3292707473a69944e2759166dd347c8af689c35aa414b",
+				"DiscoKey":   "discokey:4cb93e0a0cfb7f2d8f2075415c693f100b99ed6bf2829acb1cec3984962f6551",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33142",
+					"10.65.0.27:33142",
+					"172.17.0.1:33142",
+					"172.18.0.1:33142",
+					"172.19.0.1:33142"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:26:15.764283904Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2220056418692597,
+				"StableID":   "nnBeVp7ULJ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cfa65570339388567923ea44e46ae1a04de2c6a9da6b287c97a9929899504902",
+				"DiscoKey":   "discokey:6369f4878b14b6103bc69fce6146f83dde4766771d89021aa4516de02773320e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53390",
+					"10.65.0.27:53390",
+					"172.17.0.1:53390",
+					"172.18.0.1:53390",
+					"172.19.0.1:53390"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:26:16.313865207Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7455186368303287,
+				"StableID":   "n6xGH37UD121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:294663b0b5f7ba1ee2227009d3fb406868a072a64a3d0bd88cab5eda31d27222",
+				"DiscoKey":   "discokey:c76e5dd5e057ce11c48096fb4fcb8c274426a789e8975b83382dcce63851ff20",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54605",
+					"10.65.0.27:54605",
+					"172.17.0.1:54605",
+					"172.18.0.1:54605",
+					"172.19.0.1:54605"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:26:16.857445165Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6030978903928173,
+				"StableID":   "nLA9dAbS6p11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ff31a6529f4f1ceb4d62f6dbd573693dadfd8b95685111b4490cc8300019536b",
+				"KeyExpiry":  "2026-11-09T07:26:17Z",
+				"DiscoKey":   "discokey:32853d2bafb9288dfa544e8f4ace90888be551167e02d31d1ece224bc6b5ee6f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48480",
+					"10.65.0.27:48480",
+					"172.17.0.1:48480",
+					"172.18.0.1:48480",
+					"172.19.0.1:48480"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:26:17.935899015Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7379662858071522,
+				"StableID":   "nXdNJKEGdz11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:613c1b30f06a2371e917dab10ea73560ec6d99637bebcd6341da1168647dd867",
+				"KeyExpiry":  "2026-11-09T07:26:18Z",
+				"DiscoKey":   "discokey:e9e440c3073a7ca4c3cd74ea3d9dd61cc19d0d653f73c77eb2a39add0d24af50",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55977",
+					"10.65.0.27:55977",
+					"172.17.0.1:55977",
+					"172.18.0.1:55977",
+					"172.19.0.1:55977"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:26:18.47443624Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2220056418692597,
+				"StableID":   "nnBeVp7ULJ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       2220056418692597,
+				"Key":        "nodekey:cfa65570339388567923ea44e46ae1a04de2c6a9da6b287c97a9929899504902",
+				"DiscoKey":   "discokey:6369f4878b14b6103bc69fce6146f83dde4766771d89021aa4516de02773320e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53390",
+					"10.65.0.27:53390",
+					"172.17.0.1:53390",
+					"172.18.0.1:53390",
+					"172.19.0.1:53390"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:26:16.313865207Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:cfa65570339388567923ea44e46ae1a04de2c6a9da6b287c97a9929899504902",
+			"MachineKey": "mkey:a8c376fc081a3b3bec852b83497d320b7f8c91991048785e71dbd039ea568947",
+			"Peers": [{
+				"ID":         3922698761091064,
+				"StableID":   "nmqGsPebdX11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6f914d5564e0c688d3e036904c3e9dea1d722b87fc02c5d9a880a8a0534ed464",
+				"DiscoKey":   "discokey:46529347afdae91b8dad477a76105777cfa27c1d4c52685c0cad084a247f3b19",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35426",
+					"10.65.0.27:35426",
+					"172.17.0.1:35426",
+					"172.18.0.1:35426",
+					"172.19.0.1:35426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:26:10.976975248Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4406294529692090,
+				"StableID":   "noMewMtcQb11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10871915c211c16333b33b320bff410f66cda07a760985a8fded20535f5f5c49",
+				"DiscoKey":   "discokey:f78f2f29f422eb844812ecdaccf1c5a000f167f68399075bd4aa4113ed0edb56",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44756",
+					"10.65.0.27:44756",
+					"172.17.0.1:44756",
+					"172.18.0.1:44756",
+					"172.19.0.1:44756"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:26:11.454274662Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8729599415940745,
+				"StableID":   "n4k7HtmeAB21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:67753b1f23a452a94efdf01e17001258c23b7ccb308395c7013fe6fa87ffe167",
+				"DiscoKey":   "discokey:7e6c6b7a33e8a49233af5370adf399c243608561ecd723a23a78297b12f5807c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34501",
+					"10.65.0.27:34501",
+					"172.17.0.1:34501",
+					"172.18.0.1:34501",
+					"172.19.0.1:34501"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:26:11.992719645Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4487685099469864,
+				"StableID":   "nVRJtusU3c11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc136313d4088b5eaf35796602ae589141f51c6233b04404e339a6922e82872e",
+				"DiscoKey":   "discokey:88b6822ed6132ded97e2cd51dadb5e6361010cf57c91966d19280d57db97eb1f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58706",
+					"10.65.0.27:58706",
+					"172.17.0.1:58706",
+					"172.18.0.1:58706",
+					"172.19.0.1:58706"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:26:12.528642995Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8577452833475303,
+				"StableID":   "ni6enB9ky921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:57be61187942ff8839a890040b4138ecfbcf38fef2c351d6b7cc8aa03082bc7e",
+				"DiscoKey":   "discokey:960b27038dcf4188852eb8283bb434968725922cd3ce0c6b040f8b5757ddd435",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42728",
+					"10.65.0.27:42728",
+					"172.17.0.1:42728",
+					"172.18.0.1:42728",
+					"172.19.0.1:42728"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:26:13.060337024Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         929445925349060,
+				"StableID":   "nbWjgAywF811CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e785db439d1a9e7463c4982c6e311857828f9d12f042db917d3036abd12ccf09",
+				"DiscoKey":   "discokey:24c5752a6f1943c028613055f54b4eeb36e40fb8b8fdeeeb1ac5e2e1d8c26b17",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37910",
+					"10.65.0.27:37910",
+					"172.17.0.1:37910",
+					"172.18.0.1:37910",
+					"172.19.0.1:37910"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:26:13.591886388Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7976552733572839,
+				"StableID":   "nECNeqWbH521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fd5e3e150b855d608bea527fa3f1d22bdf91e163030bc047872618a6d0ea032",
+				"DiscoKey":   "discokey:d779500d32cd2ab2c6ee33347cf09ea457b3b5947255d565b00d36390cb10845",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54450",
+					"10.65.0.27:54450",
+					"172.17.0.1:54450",
+					"172.18.0.1:54450",
+					"172.19.0.1:54450"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:26:14.144258373Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1453856919110886,
+				"StableID":   "n7FgSeMTMC11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:648f74443643fe40ae55a6cf8724022fe292e0124617b3c0d19b203e8fcec90d",
+				"DiscoKey":   "discokey:2ee942ea9a27db219d74afe0848f060b36f20947f13fcd0ba588942c88369c40",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:35581",
+					"10.65.0.27:35581",
+					"172.17.0.1:35581",
+					"172.18.0.1:35581",
+					"172.19.0.1:35581"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:26:14.683922946Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8156323941706304,
+				"StableID":   "nFS9iMo1h621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e79cf519506639525b0b6fb0c0338c46b13e00f8c8fadd4b034dcf4728d6765",
+				"DiscoKey":   "discokey:1a3f91e13d4434153f10e7e52e0dc7291c5d5bcafe3135991155e1027765e32e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56992",
+					"10.65.0.27:56992",
+					"172.17.0.1:56992",
+					"172.18.0.1:56992",
+					"172.19.0.1:56992"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:26:15.226010914Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2188832929173675,
+				"StableID":   "nUFQeuvK6J11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6a66fa3f81c6d57a7dd3292707473a69944e2759166dd347c8af689c35aa414b",
+				"DiscoKey":   "discokey:4cb93e0a0cfb7f2d8f2075415c693f100b99ed6bf2829acb1cec3984962f6551",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33142",
+					"10.65.0.27:33142",
+					"172.17.0.1:33142",
+					"172.18.0.1:33142",
+					"172.19.0.1:33142"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:26:15.764283904Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7455186368303287,
+				"StableID":   "n6xGH37UD121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:294663b0b5f7ba1ee2227009d3fb406868a072a64a3d0bd88cab5eda31d27222",
+				"DiscoKey":   "discokey:c76e5dd5e057ce11c48096fb4fcb8c274426a789e8975b83382dcce63851ff20",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54605",
+					"10.65.0.27:54605",
+					"172.17.0.1:54605",
+					"172.18.0.1:54605",
+					"172.19.0.1:54605"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:26:16.857445165Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5338333051349764,
+				"StableID":   "noi8VWxjgi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bd3eaca53faed7bea73992582fb18404d8b93ca3180e9157ea73cda635413525",
+				"KeyExpiry":  "2026-11-09T07:26:17Z",
+				"DiscoKey":   "discokey:caafd01f4ec17355491f0bec6109e51556619ab6f2e648f689eca8c4e024f811",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50620",
+					"10.65.0.27:50620",
+					"172.17.0.1:50620",
+					"172.18.0.1:50620",
+					"172.19.0.1:50620"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:26:17.383458171Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6030978903928173,
+				"StableID":   "nLA9dAbS6p11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ff31a6529f4f1ceb4d62f6dbd573693dadfd8b95685111b4490cc8300019536b",
+				"KeyExpiry":  "2026-11-09T07:26:17Z",
+				"DiscoKey":   "discokey:32853d2bafb9288dfa544e8f4ace90888be551167e02d31d1ece224bc6b5ee6f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48480",
+					"10.65.0.27:48480",
+					"172.17.0.1:48480",
+					"172.18.0.1:48480",
+					"172.19.0.1:48480"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:26:17.935899015Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7379662858071522,
+				"StableID":   "nXdNJKEGdz11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:613c1b30f06a2371e917dab10ea73560ec6d99637bebcd6341da1168647dd867",
+				"KeyExpiry":  "2026-11-09T07:26:18Z",
+				"DiscoKey":   "discokey:e9e440c3073a7ca4c3cd74ea3d9dd61cc19d0d653f73c77eb2a39add0d24af50",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55977",
+					"10.65.0.27:55977",
+					"172.17.0.1:55977",
+					"172.18.0.1:55977",
+					"172.19.0.1:55977"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:26:18.47443624Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2220056418692597": {
+				"ID":          2220056418692597,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4406294529692090,
+				"StableID":   "noMewMtcQb11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       4406294529692090,
+				"Key":        "nodekey:10871915c211c16333b33b320bff410f66cda07a760985a8fded20535f5f5c49",
+				"DiscoKey":   "discokey:f78f2f29f422eb844812ecdaccf1c5a000f167f68399075bd4aa4113ed0edb56",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44756",
+					"10.65.0.27:44756",
+					"172.17.0.1:44756",
+					"172.18.0.1:44756",
+					"172.19.0.1:44756"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:26:11.454274662Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:10871915c211c16333b33b320bff410f66cda07a760985a8fded20535f5f5c49",
+			"MachineKey": "mkey:e5112630c7f93d3388dcb4af299746930c9a3089a0828a701374d5f45fe22602",
+			"Peers": [{
+				"ID":         3922698761091064,
+				"StableID":   "nmqGsPebdX11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6f914d5564e0c688d3e036904c3e9dea1d722b87fc02c5d9a880a8a0534ed464",
+				"DiscoKey":   "discokey:46529347afdae91b8dad477a76105777cfa27c1d4c52685c0cad084a247f3b19",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35426",
+					"10.65.0.27:35426",
+					"172.17.0.1:35426",
+					"172.18.0.1:35426",
+					"172.19.0.1:35426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:26:10.976975248Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8729599415940745,
+				"StableID":   "n4k7HtmeAB21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:67753b1f23a452a94efdf01e17001258c23b7ccb308395c7013fe6fa87ffe167",
+				"DiscoKey":   "discokey:7e6c6b7a33e8a49233af5370adf399c243608561ecd723a23a78297b12f5807c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34501",
+					"10.65.0.27:34501",
+					"172.17.0.1:34501",
+					"172.18.0.1:34501",
+					"172.19.0.1:34501"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:26:11.992719645Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4487685099469864,
+				"StableID":   "nVRJtusU3c11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc136313d4088b5eaf35796602ae589141f51c6233b04404e339a6922e82872e",
+				"DiscoKey":   "discokey:88b6822ed6132ded97e2cd51dadb5e6361010cf57c91966d19280d57db97eb1f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58706",
+					"10.65.0.27:58706",
+					"172.17.0.1:58706",
+					"172.18.0.1:58706",
+					"172.19.0.1:58706"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:26:12.528642995Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8577452833475303,
+				"StableID":   "ni6enB9ky921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:57be61187942ff8839a890040b4138ecfbcf38fef2c351d6b7cc8aa03082bc7e",
+				"DiscoKey":   "discokey:960b27038dcf4188852eb8283bb434968725922cd3ce0c6b040f8b5757ddd435",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42728",
+					"10.65.0.27:42728",
+					"172.17.0.1:42728",
+					"172.18.0.1:42728",
+					"172.19.0.1:42728"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:26:13.060337024Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         929445925349060,
+				"StableID":   "nbWjgAywF811CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e785db439d1a9e7463c4982c6e311857828f9d12f042db917d3036abd12ccf09",
+				"DiscoKey":   "discokey:24c5752a6f1943c028613055f54b4eeb36e40fb8b8fdeeeb1ac5e2e1d8c26b17",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37910",
+					"10.65.0.27:37910",
+					"172.17.0.1:37910",
+					"172.18.0.1:37910",
+					"172.19.0.1:37910"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:26:13.591886388Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7976552733572839,
+				"StableID":   "nECNeqWbH521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fd5e3e150b855d608bea527fa3f1d22bdf91e163030bc047872618a6d0ea032",
+				"DiscoKey":   "discokey:d779500d32cd2ab2c6ee33347cf09ea457b3b5947255d565b00d36390cb10845",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54450",
+					"10.65.0.27:54450",
+					"172.17.0.1:54450",
+					"172.18.0.1:54450",
+					"172.19.0.1:54450"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:26:14.144258373Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1453856919110886,
+				"StableID":   "n7FgSeMTMC11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:648f74443643fe40ae55a6cf8724022fe292e0124617b3c0d19b203e8fcec90d",
+				"DiscoKey":   "discokey:2ee942ea9a27db219d74afe0848f060b36f20947f13fcd0ba588942c88369c40",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:35581",
+					"10.65.0.27:35581",
+					"172.17.0.1:35581",
+					"172.18.0.1:35581",
+					"172.19.0.1:35581"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:26:14.683922946Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8156323941706304,
+				"StableID":   "nFS9iMo1h621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e79cf519506639525b0b6fb0c0338c46b13e00f8c8fadd4b034dcf4728d6765",
+				"DiscoKey":   "discokey:1a3f91e13d4434153f10e7e52e0dc7291c5d5bcafe3135991155e1027765e32e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56992",
+					"10.65.0.27:56992",
+					"172.17.0.1:56992",
+					"172.18.0.1:56992",
+					"172.19.0.1:56992"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:26:15.226010914Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2188832929173675,
+				"StableID":   "nUFQeuvK6J11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6a66fa3f81c6d57a7dd3292707473a69944e2759166dd347c8af689c35aa414b",
+				"DiscoKey":   "discokey:4cb93e0a0cfb7f2d8f2075415c693f100b99ed6bf2829acb1cec3984962f6551",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33142",
+					"10.65.0.27:33142",
+					"172.17.0.1:33142",
+					"172.18.0.1:33142",
+					"172.19.0.1:33142"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:26:15.764283904Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2220056418692597,
+				"StableID":   "nnBeVp7ULJ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cfa65570339388567923ea44e46ae1a04de2c6a9da6b287c97a9929899504902",
+				"DiscoKey":   "discokey:6369f4878b14b6103bc69fce6146f83dde4766771d89021aa4516de02773320e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53390",
+					"10.65.0.27:53390",
+					"172.17.0.1:53390",
+					"172.18.0.1:53390",
+					"172.19.0.1:53390"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:26:16.313865207Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7455186368303287,
+				"StableID":   "n6xGH37UD121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:294663b0b5f7ba1ee2227009d3fb406868a072a64a3d0bd88cab5eda31d27222",
+				"DiscoKey":   "discokey:c76e5dd5e057ce11c48096fb4fcb8c274426a789e8975b83382dcce63851ff20",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54605",
+					"10.65.0.27:54605",
+					"172.17.0.1:54605",
+					"172.18.0.1:54605",
+					"172.19.0.1:54605"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:26:16.857445165Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5338333051349764,
+				"StableID":   "noi8VWxjgi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bd3eaca53faed7bea73992582fb18404d8b93ca3180e9157ea73cda635413525",
+				"KeyExpiry":  "2026-11-09T07:26:17Z",
+				"DiscoKey":   "discokey:caafd01f4ec17355491f0bec6109e51556619ab6f2e648f689eca8c4e024f811",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50620",
+					"10.65.0.27:50620",
+					"172.17.0.1:50620",
+					"172.18.0.1:50620",
+					"172.19.0.1:50620"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:26:17.383458171Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6030978903928173,
+				"StableID":   "nLA9dAbS6p11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ff31a6529f4f1ceb4d62f6dbd573693dadfd8b95685111b4490cc8300019536b",
+				"KeyExpiry":  "2026-11-09T07:26:17Z",
+				"DiscoKey":   "discokey:32853d2bafb9288dfa544e8f4ace90888be551167e02d31d1ece224bc6b5ee6f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48480",
+					"10.65.0.27:48480",
+					"172.17.0.1:48480",
+					"172.18.0.1:48480",
+					"172.19.0.1:48480"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:26:17.935899015Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7379662858071522,
+				"StableID":   "nXdNJKEGdz11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:613c1b30f06a2371e917dab10ea73560ec6d99637bebcd6341da1168647dd867",
+				"KeyExpiry":  "2026-11-09T07:26:18Z",
+				"DiscoKey":   "discokey:e9e440c3073a7ca4c3cd74ea3d9dd61cc19d0d653f73c77eb2a39add0d24af50",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55977",
+					"10.65.0.27:55977",
+					"172.17.0.1:55977",
+					"172.18.0.1:55977",
+					"172.19.0.1:55977"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:26:18.47443624Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4406294529692090": {
+				"ID":          4406294529692090,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3922698761091064,
+				"StableID":   "nmqGsPebdX11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       3922698761091064,
+				"Key":        "nodekey:6f914d5564e0c688d3e036904c3e9dea1d722b87fc02c5d9a880a8a0534ed464",
+				"DiscoKey":   "discokey:46529347afdae91b8dad477a76105777cfa27c1d4c52685c0cad084a247f3b19",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35426",
+					"10.65.0.27:35426",
+					"172.17.0.1:35426",
+					"172.18.0.1:35426",
+					"172.19.0.1:35426"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:26:10.976975248Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6f914d5564e0c688d3e036904c3e9dea1d722b87fc02c5d9a880a8a0534ed464",
+			"MachineKey": "mkey:a7d3c5b3f38beef1d520991138ae32e1205f3a7aec5b9b79b289e58647743573",
+			"Peers": [{
+				"ID":         4406294529692090,
+				"StableID":   "noMewMtcQb11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10871915c211c16333b33b320bff410f66cda07a760985a8fded20535f5f5c49",
+				"DiscoKey":   "discokey:f78f2f29f422eb844812ecdaccf1c5a000f167f68399075bd4aa4113ed0edb56",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44756",
+					"10.65.0.27:44756",
+					"172.17.0.1:44756",
+					"172.18.0.1:44756",
+					"172.19.0.1:44756"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:26:11.454274662Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8729599415940745,
+				"StableID":   "n4k7HtmeAB21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:67753b1f23a452a94efdf01e17001258c23b7ccb308395c7013fe6fa87ffe167",
+				"DiscoKey":   "discokey:7e6c6b7a33e8a49233af5370adf399c243608561ecd723a23a78297b12f5807c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34501",
+					"10.65.0.27:34501",
+					"172.17.0.1:34501",
+					"172.18.0.1:34501",
+					"172.19.0.1:34501"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:26:11.992719645Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4487685099469864,
+				"StableID":   "nVRJtusU3c11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc136313d4088b5eaf35796602ae589141f51c6233b04404e339a6922e82872e",
+				"DiscoKey":   "discokey:88b6822ed6132ded97e2cd51dadb5e6361010cf57c91966d19280d57db97eb1f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58706",
+					"10.65.0.27:58706",
+					"172.17.0.1:58706",
+					"172.18.0.1:58706",
+					"172.19.0.1:58706"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:26:12.528642995Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8577452833475303,
+				"StableID":   "ni6enB9ky921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:57be61187942ff8839a890040b4138ecfbcf38fef2c351d6b7cc8aa03082bc7e",
+				"DiscoKey":   "discokey:960b27038dcf4188852eb8283bb434968725922cd3ce0c6b040f8b5757ddd435",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42728",
+					"10.65.0.27:42728",
+					"172.17.0.1:42728",
+					"172.18.0.1:42728",
+					"172.19.0.1:42728"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:26:13.060337024Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         929445925349060,
+				"StableID":   "nbWjgAywF811CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e785db439d1a9e7463c4982c6e311857828f9d12f042db917d3036abd12ccf09",
+				"DiscoKey":   "discokey:24c5752a6f1943c028613055f54b4eeb36e40fb8b8fdeeeb1ac5e2e1d8c26b17",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37910",
+					"10.65.0.27:37910",
+					"172.17.0.1:37910",
+					"172.18.0.1:37910",
+					"172.19.0.1:37910"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:26:13.591886388Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7976552733572839,
+				"StableID":   "nECNeqWbH521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fd5e3e150b855d608bea527fa3f1d22bdf91e163030bc047872618a6d0ea032",
+				"DiscoKey":   "discokey:d779500d32cd2ab2c6ee33347cf09ea457b3b5947255d565b00d36390cb10845",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54450",
+					"10.65.0.27:54450",
+					"172.17.0.1:54450",
+					"172.18.0.1:54450",
+					"172.19.0.1:54450"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:26:14.144258373Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1453856919110886,
+				"StableID":   "n7FgSeMTMC11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:648f74443643fe40ae55a6cf8724022fe292e0124617b3c0d19b203e8fcec90d",
+				"DiscoKey":   "discokey:2ee942ea9a27db219d74afe0848f060b36f20947f13fcd0ba588942c88369c40",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:35581",
+					"10.65.0.27:35581",
+					"172.17.0.1:35581",
+					"172.18.0.1:35581",
+					"172.19.0.1:35581"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:26:14.683922946Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8156323941706304,
+				"StableID":   "nFS9iMo1h621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e79cf519506639525b0b6fb0c0338c46b13e00f8c8fadd4b034dcf4728d6765",
+				"DiscoKey":   "discokey:1a3f91e13d4434153f10e7e52e0dc7291c5d5bcafe3135991155e1027765e32e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56992",
+					"10.65.0.27:56992",
+					"172.17.0.1:56992",
+					"172.18.0.1:56992",
+					"172.19.0.1:56992"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:26:15.226010914Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2188832929173675,
+				"StableID":   "nUFQeuvK6J11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6a66fa3f81c6d57a7dd3292707473a69944e2759166dd347c8af689c35aa414b",
+				"DiscoKey":   "discokey:4cb93e0a0cfb7f2d8f2075415c693f100b99ed6bf2829acb1cec3984962f6551",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33142",
+					"10.65.0.27:33142",
+					"172.17.0.1:33142",
+					"172.18.0.1:33142",
+					"172.19.0.1:33142"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:26:15.764283904Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2220056418692597,
+				"StableID":   "nnBeVp7ULJ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cfa65570339388567923ea44e46ae1a04de2c6a9da6b287c97a9929899504902",
+				"DiscoKey":   "discokey:6369f4878b14b6103bc69fce6146f83dde4766771d89021aa4516de02773320e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53390",
+					"10.65.0.27:53390",
+					"172.17.0.1:53390",
+					"172.18.0.1:53390",
+					"172.19.0.1:53390"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:26:16.313865207Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7455186368303287,
+				"StableID":   "n6xGH37UD121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:294663b0b5f7ba1ee2227009d3fb406868a072a64a3d0bd88cab5eda31d27222",
+				"DiscoKey":   "discokey:c76e5dd5e057ce11c48096fb4fcb8c274426a789e8975b83382dcce63851ff20",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54605",
+					"10.65.0.27:54605",
+					"172.17.0.1:54605",
+					"172.18.0.1:54605",
+					"172.19.0.1:54605"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:26:16.857445165Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5338333051349764,
+				"StableID":   "noi8VWxjgi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bd3eaca53faed7bea73992582fb18404d8b93ca3180e9157ea73cda635413525",
+				"KeyExpiry":  "2026-11-09T07:26:17Z",
+				"DiscoKey":   "discokey:caafd01f4ec17355491f0bec6109e51556619ab6f2e648f689eca8c4e024f811",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50620",
+					"10.65.0.27:50620",
+					"172.17.0.1:50620",
+					"172.18.0.1:50620",
+					"172.19.0.1:50620"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:26:17.383458171Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6030978903928173,
+				"StableID":   "nLA9dAbS6p11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ff31a6529f4f1ceb4d62f6dbd573693dadfd8b95685111b4490cc8300019536b",
+				"KeyExpiry":  "2026-11-09T07:26:17Z",
+				"DiscoKey":   "discokey:32853d2bafb9288dfa544e8f4ace90888be551167e02d31d1ece224bc6b5ee6f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48480",
+					"10.65.0.27:48480",
+					"172.17.0.1:48480",
+					"172.18.0.1:48480",
+					"172.19.0.1:48480"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:26:17.935899015Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7379662858071522,
+				"StableID":   "nXdNJKEGdz11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:613c1b30f06a2371e917dab10ea73560ec6d99637bebcd6341da1168647dd867",
+				"KeyExpiry":  "2026-11-09T07:26:18Z",
+				"DiscoKey":   "discokey:e9e440c3073a7ca4c3cd74ea3d9dd61cc19d0d653f73c77eb2a39add0d24af50",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55977",
+					"10.65.0.27:55977",
+					"172.17.0.1:55977",
+					"172.18.0.1:55977",
+					"172.19.0.1:55977"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:26:18.47443624Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3922698761091064": {
+				"ID":          3922698761091064,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8577452833475303,
+				"StableID":   "ni6enB9ky921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       8577452833475303,
+				"Key":        "nodekey:57be61187942ff8839a890040b4138ecfbcf38fef2c351d6b7cc8aa03082bc7e",
+				"DiscoKey":   "discokey:960b27038dcf4188852eb8283bb434968725922cd3ce0c6b040f8b5757ddd435",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42728",
+					"10.65.0.27:42728",
+					"172.17.0.1:42728",
+					"172.18.0.1:42728",
+					"172.19.0.1:42728"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:26:13.060337024Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:57be61187942ff8839a890040b4138ecfbcf38fef2c351d6b7cc8aa03082bc7e",
+			"MachineKey": "mkey:f737766a9b4d6ddd9466439c8e8b4abfd4d929233a90f54b31f348db91b89473",
+			"Peers": [{
+				"ID":         3922698761091064,
+				"StableID":   "nmqGsPebdX11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6f914d5564e0c688d3e036904c3e9dea1d722b87fc02c5d9a880a8a0534ed464",
+				"DiscoKey":   "discokey:46529347afdae91b8dad477a76105777cfa27c1d4c52685c0cad084a247f3b19",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35426",
+					"10.65.0.27:35426",
+					"172.17.0.1:35426",
+					"172.18.0.1:35426",
+					"172.19.0.1:35426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:26:10.976975248Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4406294529692090,
+				"StableID":   "noMewMtcQb11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10871915c211c16333b33b320bff410f66cda07a760985a8fded20535f5f5c49",
+				"DiscoKey":   "discokey:f78f2f29f422eb844812ecdaccf1c5a000f167f68399075bd4aa4113ed0edb56",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44756",
+					"10.65.0.27:44756",
+					"172.17.0.1:44756",
+					"172.18.0.1:44756",
+					"172.19.0.1:44756"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:26:11.454274662Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8729599415940745,
+				"StableID":   "n4k7HtmeAB21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:67753b1f23a452a94efdf01e17001258c23b7ccb308395c7013fe6fa87ffe167",
+				"DiscoKey":   "discokey:7e6c6b7a33e8a49233af5370adf399c243608561ecd723a23a78297b12f5807c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34501",
+					"10.65.0.27:34501",
+					"172.17.0.1:34501",
+					"172.18.0.1:34501",
+					"172.19.0.1:34501"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:26:11.992719645Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4487685099469864,
+				"StableID":   "nVRJtusU3c11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc136313d4088b5eaf35796602ae589141f51c6233b04404e339a6922e82872e",
+				"DiscoKey":   "discokey:88b6822ed6132ded97e2cd51dadb5e6361010cf57c91966d19280d57db97eb1f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58706",
+					"10.65.0.27:58706",
+					"172.17.0.1:58706",
+					"172.18.0.1:58706",
+					"172.19.0.1:58706"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:26:12.528642995Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         929445925349060,
+				"StableID":   "nbWjgAywF811CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e785db439d1a9e7463c4982c6e311857828f9d12f042db917d3036abd12ccf09",
+				"DiscoKey":   "discokey:24c5752a6f1943c028613055f54b4eeb36e40fb8b8fdeeeb1ac5e2e1d8c26b17",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37910",
+					"10.65.0.27:37910",
+					"172.17.0.1:37910",
+					"172.18.0.1:37910",
+					"172.19.0.1:37910"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:26:13.591886388Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7976552733572839,
+				"StableID":   "nECNeqWbH521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fd5e3e150b855d608bea527fa3f1d22bdf91e163030bc047872618a6d0ea032",
+				"DiscoKey":   "discokey:d779500d32cd2ab2c6ee33347cf09ea457b3b5947255d565b00d36390cb10845",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54450",
+					"10.65.0.27:54450",
+					"172.17.0.1:54450",
+					"172.18.0.1:54450",
+					"172.19.0.1:54450"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:26:14.144258373Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1453856919110886,
+				"StableID":   "n7FgSeMTMC11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:648f74443643fe40ae55a6cf8724022fe292e0124617b3c0d19b203e8fcec90d",
+				"DiscoKey":   "discokey:2ee942ea9a27db219d74afe0848f060b36f20947f13fcd0ba588942c88369c40",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:35581",
+					"10.65.0.27:35581",
+					"172.17.0.1:35581",
+					"172.18.0.1:35581",
+					"172.19.0.1:35581"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:26:14.683922946Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8156323941706304,
+				"StableID":   "nFS9iMo1h621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e79cf519506639525b0b6fb0c0338c46b13e00f8c8fadd4b034dcf4728d6765",
+				"DiscoKey":   "discokey:1a3f91e13d4434153f10e7e52e0dc7291c5d5bcafe3135991155e1027765e32e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56992",
+					"10.65.0.27:56992",
+					"172.17.0.1:56992",
+					"172.18.0.1:56992",
+					"172.19.0.1:56992"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:26:15.226010914Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2188832929173675,
+				"StableID":   "nUFQeuvK6J11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6a66fa3f81c6d57a7dd3292707473a69944e2759166dd347c8af689c35aa414b",
+				"DiscoKey":   "discokey:4cb93e0a0cfb7f2d8f2075415c693f100b99ed6bf2829acb1cec3984962f6551",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33142",
+					"10.65.0.27:33142",
+					"172.17.0.1:33142",
+					"172.18.0.1:33142",
+					"172.19.0.1:33142"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:26:15.764283904Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2220056418692597,
+				"StableID":   "nnBeVp7ULJ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cfa65570339388567923ea44e46ae1a04de2c6a9da6b287c97a9929899504902",
+				"DiscoKey":   "discokey:6369f4878b14b6103bc69fce6146f83dde4766771d89021aa4516de02773320e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53390",
+					"10.65.0.27:53390",
+					"172.17.0.1:53390",
+					"172.18.0.1:53390",
+					"172.19.0.1:53390"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:26:16.313865207Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7455186368303287,
+				"StableID":   "n6xGH37UD121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:294663b0b5f7ba1ee2227009d3fb406868a072a64a3d0bd88cab5eda31d27222",
+				"DiscoKey":   "discokey:c76e5dd5e057ce11c48096fb4fcb8c274426a789e8975b83382dcce63851ff20",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54605",
+					"10.65.0.27:54605",
+					"172.17.0.1:54605",
+					"172.18.0.1:54605",
+					"172.19.0.1:54605"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:26:16.857445165Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5338333051349764,
+				"StableID":   "noi8VWxjgi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bd3eaca53faed7bea73992582fb18404d8b93ca3180e9157ea73cda635413525",
+				"KeyExpiry":  "2026-11-09T07:26:17Z",
+				"DiscoKey":   "discokey:caafd01f4ec17355491f0bec6109e51556619ab6f2e648f689eca8c4e024f811",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50620",
+					"10.65.0.27:50620",
+					"172.17.0.1:50620",
+					"172.18.0.1:50620",
+					"172.19.0.1:50620"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:26:17.383458171Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6030978903928173,
+				"StableID":   "nLA9dAbS6p11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ff31a6529f4f1ceb4d62f6dbd573693dadfd8b95685111b4490cc8300019536b",
+				"KeyExpiry":  "2026-11-09T07:26:17Z",
+				"DiscoKey":   "discokey:32853d2bafb9288dfa544e8f4ace90888be551167e02d31d1ece224bc6b5ee6f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48480",
+					"10.65.0.27:48480",
+					"172.17.0.1:48480",
+					"172.18.0.1:48480",
+					"172.19.0.1:48480"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:26:17.935899015Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7379662858071522,
+				"StableID":   "nXdNJKEGdz11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:613c1b30f06a2371e917dab10ea73560ec6d99637bebcd6341da1168647dd867",
+				"KeyExpiry":  "2026-11-09T07:26:18Z",
+				"DiscoKey":   "discokey:e9e440c3073a7ca4c3cd74ea3d9dd61cc19d0d653f73c77eb2a39add0d24af50",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55977",
+					"10.65.0.27:55977",
+					"172.17.0.1:55977",
+					"172.18.0.1:55977",
+					"172.19.0.1:55977"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:26:18.47443624Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8577452833475303": {
+				"ID":          8577452833475303,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4487685099469864,
+				"StableID":   "nVRJtusU3c11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       4487685099469864,
+				"Key":        "nodekey:dc136313d4088b5eaf35796602ae589141f51c6233b04404e339a6922e82872e",
+				"DiscoKey":   "discokey:88b6822ed6132ded97e2cd51dadb5e6361010cf57c91966d19280d57db97eb1f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58706",
+					"10.65.0.27:58706",
+					"172.17.0.1:58706",
+					"172.18.0.1:58706",
+					"172.19.0.1:58706"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:26:12.528642995Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:dc136313d4088b5eaf35796602ae589141f51c6233b04404e339a6922e82872e",
+			"MachineKey": "mkey:61ec486ab1bddd0d817903a03fbb7a6b066bd670c06f3ba0048be1d61276f80a",
+			"Peers": [{
+				"ID":         3922698761091064,
+				"StableID":   "nmqGsPebdX11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6f914d5564e0c688d3e036904c3e9dea1d722b87fc02c5d9a880a8a0534ed464",
+				"DiscoKey":   "discokey:46529347afdae91b8dad477a76105777cfa27c1d4c52685c0cad084a247f3b19",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35426",
+					"10.65.0.27:35426",
+					"172.17.0.1:35426",
+					"172.18.0.1:35426",
+					"172.19.0.1:35426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:26:10.976975248Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4406294529692090,
+				"StableID":   "noMewMtcQb11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10871915c211c16333b33b320bff410f66cda07a760985a8fded20535f5f5c49",
+				"DiscoKey":   "discokey:f78f2f29f422eb844812ecdaccf1c5a000f167f68399075bd4aa4113ed0edb56",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44756",
+					"10.65.0.27:44756",
+					"172.17.0.1:44756",
+					"172.18.0.1:44756",
+					"172.19.0.1:44756"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:26:11.454274662Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8729599415940745,
+				"StableID":   "n4k7HtmeAB21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:67753b1f23a452a94efdf01e17001258c23b7ccb308395c7013fe6fa87ffe167",
+				"DiscoKey":   "discokey:7e6c6b7a33e8a49233af5370adf399c243608561ecd723a23a78297b12f5807c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34501",
+					"10.65.0.27:34501",
+					"172.17.0.1:34501",
+					"172.18.0.1:34501",
+					"172.19.0.1:34501"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:26:11.992719645Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8577452833475303,
+				"StableID":   "ni6enB9ky921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:57be61187942ff8839a890040b4138ecfbcf38fef2c351d6b7cc8aa03082bc7e",
+				"DiscoKey":   "discokey:960b27038dcf4188852eb8283bb434968725922cd3ce0c6b040f8b5757ddd435",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42728",
+					"10.65.0.27:42728",
+					"172.17.0.1:42728",
+					"172.18.0.1:42728",
+					"172.19.0.1:42728"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:26:13.060337024Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         929445925349060,
+				"StableID":   "nbWjgAywF811CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e785db439d1a9e7463c4982c6e311857828f9d12f042db917d3036abd12ccf09",
+				"DiscoKey":   "discokey:24c5752a6f1943c028613055f54b4eeb36e40fb8b8fdeeeb1ac5e2e1d8c26b17",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37910",
+					"10.65.0.27:37910",
+					"172.17.0.1:37910",
+					"172.18.0.1:37910",
+					"172.19.0.1:37910"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:26:13.591886388Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7976552733572839,
+				"StableID":   "nECNeqWbH521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fd5e3e150b855d608bea527fa3f1d22bdf91e163030bc047872618a6d0ea032",
+				"DiscoKey":   "discokey:d779500d32cd2ab2c6ee33347cf09ea457b3b5947255d565b00d36390cb10845",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54450",
+					"10.65.0.27:54450",
+					"172.17.0.1:54450",
+					"172.18.0.1:54450",
+					"172.19.0.1:54450"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:26:14.144258373Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1453856919110886,
+				"StableID":   "n7FgSeMTMC11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:648f74443643fe40ae55a6cf8724022fe292e0124617b3c0d19b203e8fcec90d",
+				"DiscoKey":   "discokey:2ee942ea9a27db219d74afe0848f060b36f20947f13fcd0ba588942c88369c40",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:35581",
+					"10.65.0.27:35581",
+					"172.17.0.1:35581",
+					"172.18.0.1:35581",
+					"172.19.0.1:35581"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:26:14.683922946Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8156323941706304,
+				"StableID":   "nFS9iMo1h621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e79cf519506639525b0b6fb0c0338c46b13e00f8c8fadd4b034dcf4728d6765",
+				"DiscoKey":   "discokey:1a3f91e13d4434153f10e7e52e0dc7291c5d5bcafe3135991155e1027765e32e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56992",
+					"10.65.0.27:56992",
+					"172.17.0.1:56992",
+					"172.18.0.1:56992",
+					"172.19.0.1:56992"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:26:15.226010914Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2188832929173675,
+				"StableID":   "nUFQeuvK6J11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6a66fa3f81c6d57a7dd3292707473a69944e2759166dd347c8af689c35aa414b",
+				"DiscoKey":   "discokey:4cb93e0a0cfb7f2d8f2075415c693f100b99ed6bf2829acb1cec3984962f6551",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33142",
+					"10.65.0.27:33142",
+					"172.17.0.1:33142",
+					"172.18.0.1:33142",
+					"172.19.0.1:33142"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:26:15.764283904Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2220056418692597,
+				"StableID":   "nnBeVp7ULJ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cfa65570339388567923ea44e46ae1a04de2c6a9da6b287c97a9929899504902",
+				"DiscoKey":   "discokey:6369f4878b14b6103bc69fce6146f83dde4766771d89021aa4516de02773320e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53390",
+					"10.65.0.27:53390",
+					"172.17.0.1:53390",
+					"172.18.0.1:53390",
+					"172.19.0.1:53390"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:26:16.313865207Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7455186368303287,
+				"StableID":   "n6xGH37UD121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:294663b0b5f7ba1ee2227009d3fb406868a072a64a3d0bd88cab5eda31d27222",
+				"DiscoKey":   "discokey:c76e5dd5e057ce11c48096fb4fcb8c274426a789e8975b83382dcce63851ff20",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54605",
+					"10.65.0.27:54605",
+					"172.17.0.1:54605",
+					"172.18.0.1:54605",
+					"172.19.0.1:54605"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:26:16.857445165Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5338333051349764,
+				"StableID":   "noi8VWxjgi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bd3eaca53faed7bea73992582fb18404d8b93ca3180e9157ea73cda635413525",
+				"KeyExpiry":  "2026-11-09T07:26:17Z",
+				"DiscoKey":   "discokey:caafd01f4ec17355491f0bec6109e51556619ab6f2e648f689eca8c4e024f811",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50620",
+					"10.65.0.27:50620",
+					"172.17.0.1:50620",
+					"172.18.0.1:50620",
+					"172.19.0.1:50620"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:26:17.383458171Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6030978903928173,
+				"StableID":   "nLA9dAbS6p11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ff31a6529f4f1ceb4d62f6dbd573693dadfd8b95685111b4490cc8300019536b",
+				"KeyExpiry":  "2026-11-09T07:26:17Z",
+				"DiscoKey":   "discokey:32853d2bafb9288dfa544e8f4ace90888be551167e02d31d1ece224bc6b5ee6f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48480",
+					"10.65.0.27:48480",
+					"172.17.0.1:48480",
+					"172.18.0.1:48480",
+					"172.19.0.1:48480"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:26:17.935899015Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7379662858071522,
+				"StableID":   "nXdNJKEGdz11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:613c1b30f06a2371e917dab10ea73560ec6d99637bebcd6341da1168647dd867",
+				"KeyExpiry":  "2026-11-09T07:26:18Z",
+				"DiscoKey":   "discokey:e9e440c3073a7ca4c3cd74ea3d9dd61cc19d0d653f73c77eb2a39add0d24af50",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55977",
+					"10.65.0.27:55977",
+					"172.17.0.1:55977",
+					"172.18.0.1:55977",
+					"172.19.0.1:55977"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:26:18.47443624Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4487685099469864": {
+				"ID":          4487685099469864,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7976552733572839,
+				"StableID":   "nECNeqWbH521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       7976552733572839,
+				"Key":        "nodekey:5fd5e3e150b855d608bea527fa3f1d22bdf91e163030bc047872618a6d0ea032",
+				"DiscoKey":   "discokey:d779500d32cd2ab2c6ee33347cf09ea457b3b5947255d565b00d36390cb10845",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54450",
+					"10.65.0.27:54450",
+					"172.17.0.1:54450",
+					"172.18.0.1:54450",
+					"172.19.0.1:54450"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:26:14.144258373Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5fd5e3e150b855d608bea527fa3f1d22bdf91e163030bc047872618a6d0ea032",
+			"MachineKey": "mkey:2b1876a6e97624514cefd38f890dbd821ff956a35c195dbbffeacc4019ae944e",
+			"Peers": [{
+				"ID":         3922698761091064,
+				"StableID":   "nmqGsPebdX11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6f914d5564e0c688d3e036904c3e9dea1d722b87fc02c5d9a880a8a0534ed464",
+				"DiscoKey":   "discokey:46529347afdae91b8dad477a76105777cfa27c1d4c52685c0cad084a247f3b19",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35426",
+					"10.65.0.27:35426",
+					"172.17.0.1:35426",
+					"172.18.0.1:35426",
+					"172.19.0.1:35426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:26:10.976975248Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4406294529692090,
+				"StableID":   "noMewMtcQb11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10871915c211c16333b33b320bff410f66cda07a760985a8fded20535f5f5c49",
+				"DiscoKey":   "discokey:f78f2f29f422eb844812ecdaccf1c5a000f167f68399075bd4aa4113ed0edb56",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44756",
+					"10.65.0.27:44756",
+					"172.17.0.1:44756",
+					"172.18.0.1:44756",
+					"172.19.0.1:44756"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:26:11.454274662Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8729599415940745,
+				"StableID":   "n4k7HtmeAB21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:67753b1f23a452a94efdf01e17001258c23b7ccb308395c7013fe6fa87ffe167",
+				"DiscoKey":   "discokey:7e6c6b7a33e8a49233af5370adf399c243608561ecd723a23a78297b12f5807c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34501",
+					"10.65.0.27:34501",
+					"172.17.0.1:34501",
+					"172.18.0.1:34501",
+					"172.19.0.1:34501"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:26:11.992719645Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4487685099469864,
+				"StableID":   "nVRJtusU3c11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc136313d4088b5eaf35796602ae589141f51c6233b04404e339a6922e82872e",
+				"DiscoKey":   "discokey:88b6822ed6132ded97e2cd51dadb5e6361010cf57c91966d19280d57db97eb1f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58706",
+					"10.65.0.27:58706",
+					"172.17.0.1:58706",
+					"172.18.0.1:58706",
+					"172.19.0.1:58706"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:26:12.528642995Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8577452833475303,
+				"StableID":   "ni6enB9ky921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:57be61187942ff8839a890040b4138ecfbcf38fef2c351d6b7cc8aa03082bc7e",
+				"DiscoKey":   "discokey:960b27038dcf4188852eb8283bb434968725922cd3ce0c6b040f8b5757ddd435",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42728",
+					"10.65.0.27:42728",
+					"172.17.0.1:42728",
+					"172.18.0.1:42728",
+					"172.19.0.1:42728"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:26:13.060337024Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         929445925349060,
+				"StableID":   "nbWjgAywF811CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e785db439d1a9e7463c4982c6e311857828f9d12f042db917d3036abd12ccf09",
+				"DiscoKey":   "discokey:24c5752a6f1943c028613055f54b4eeb36e40fb8b8fdeeeb1ac5e2e1d8c26b17",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37910",
+					"10.65.0.27:37910",
+					"172.17.0.1:37910",
+					"172.18.0.1:37910",
+					"172.19.0.1:37910"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:26:13.591886388Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1453856919110886,
+				"StableID":   "n7FgSeMTMC11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:648f74443643fe40ae55a6cf8724022fe292e0124617b3c0d19b203e8fcec90d",
+				"DiscoKey":   "discokey:2ee942ea9a27db219d74afe0848f060b36f20947f13fcd0ba588942c88369c40",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:35581",
+					"10.65.0.27:35581",
+					"172.17.0.1:35581",
+					"172.18.0.1:35581",
+					"172.19.0.1:35581"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:26:14.683922946Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8156323941706304,
+				"StableID":   "nFS9iMo1h621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e79cf519506639525b0b6fb0c0338c46b13e00f8c8fadd4b034dcf4728d6765",
+				"DiscoKey":   "discokey:1a3f91e13d4434153f10e7e52e0dc7291c5d5bcafe3135991155e1027765e32e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56992",
+					"10.65.0.27:56992",
+					"172.17.0.1:56992",
+					"172.18.0.1:56992",
+					"172.19.0.1:56992"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:26:15.226010914Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2188832929173675,
+				"StableID":   "nUFQeuvK6J11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6a66fa3f81c6d57a7dd3292707473a69944e2759166dd347c8af689c35aa414b",
+				"DiscoKey":   "discokey:4cb93e0a0cfb7f2d8f2075415c693f100b99ed6bf2829acb1cec3984962f6551",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33142",
+					"10.65.0.27:33142",
+					"172.17.0.1:33142",
+					"172.18.0.1:33142",
+					"172.19.0.1:33142"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:26:15.764283904Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2220056418692597,
+				"StableID":   "nnBeVp7ULJ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cfa65570339388567923ea44e46ae1a04de2c6a9da6b287c97a9929899504902",
+				"DiscoKey":   "discokey:6369f4878b14b6103bc69fce6146f83dde4766771d89021aa4516de02773320e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53390",
+					"10.65.0.27:53390",
+					"172.17.0.1:53390",
+					"172.18.0.1:53390",
+					"172.19.0.1:53390"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:26:16.313865207Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7455186368303287,
+				"StableID":   "n6xGH37UD121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:294663b0b5f7ba1ee2227009d3fb406868a072a64a3d0bd88cab5eda31d27222",
+				"DiscoKey":   "discokey:c76e5dd5e057ce11c48096fb4fcb8c274426a789e8975b83382dcce63851ff20",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54605",
+					"10.65.0.27:54605",
+					"172.17.0.1:54605",
+					"172.18.0.1:54605",
+					"172.19.0.1:54605"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:26:16.857445165Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5338333051349764,
+				"StableID":   "noi8VWxjgi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bd3eaca53faed7bea73992582fb18404d8b93ca3180e9157ea73cda635413525",
+				"KeyExpiry":  "2026-11-09T07:26:17Z",
+				"DiscoKey":   "discokey:caafd01f4ec17355491f0bec6109e51556619ab6f2e648f689eca8c4e024f811",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50620",
+					"10.65.0.27:50620",
+					"172.17.0.1:50620",
+					"172.18.0.1:50620",
+					"172.19.0.1:50620"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:26:17.383458171Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6030978903928173,
+				"StableID":   "nLA9dAbS6p11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ff31a6529f4f1ceb4d62f6dbd573693dadfd8b95685111b4490cc8300019536b",
+				"KeyExpiry":  "2026-11-09T07:26:17Z",
+				"DiscoKey":   "discokey:32853d2bafb9288dfa544e8f4ace90888be551167e02d31d1ece224bc6b5ee6f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48480",
+					"10.65.0.27:48480",
+					"172.17.0.1:48480",
+					"172.18.0.1:48480",
+					"172.19.0.1:48480"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:26:17.935899015Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7379662858071522,
+				"StableID":   "nXdNJKEGdz11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:613c1b30f06a2371e917dab10ea73560ec6d99637bebcd6341da1168647dd867",
+				"KeyExpiry":  "2026-11-09T07:26:18Z",
+				"DiscoKey":   "discokey:e9e440c3073a7ca4c3cd74ea3d9dd61cc19d0d653f73c77eb2a39add0d24af50",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55977",
+					"10.65.0.27:55977",
+					"172.17.0.1:55977",
+					"172.18.0.1:55977",
+					"172.19.0.1:55977"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:26:18.47443624Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7976552733572839": {
+				"ID":          7976552733572839,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8156323941706304,
+				"StableID":   "nFS9iMo1h621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       8156323941706304,
+				"Key":        "nodekey:0e79cf519506639525b0b6fb0c0338c46b13e00f8c8fadd4b034dcf4728d6765",
+				"DiscoKey":   "discokey:1a3f91e13d4434153f10e7e52e0dc7291c5d5bcafe3135991155e1027765e32e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56992",
+					"10.65.0.27:56992",
+					"172.17.0.1:56992",
+					"172.18.0.1:56992",
+					"172.19.0.1:56992"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:26:15.226010914Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0e79cf519506639525b0b6fb0c0338c46b13e00f8c8fadd4b034dcf4728d6765",
+			"MachineKey": "mkey:2af8a33bc69bccbf1b4f3139e299fcc823f293dfb820afc9cf65006da181ad0b",
+			"Peers": [{
+				"ID":         3922698761091064,
+				"StableID":   "nmqGsPebdX11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6f914d5564e0c688d3e036904c3e9dea1d722b87fc02c5d9a880a8a0534ed464",
+				"DiscoKey":   "discokey:46529347afdae91b8dad477a76105777cfa27c1d4c52685c0cad084a247f3b19",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35426",
+					"10.65.0.27:35426",
+					"172.17.0.1:35426",
+					"172.18.0.1:35426",
+					"172.19.0.1:35426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:26:10.976975248Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4406294529692090,
+				"StableID":   "noMewMtcQb11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10871915c211c16333b33b320bff410f66cda07a760985a8fded20535f5f5c49",
+				"DiscoKey":   "discokey:f78f2f29f422eb844812ecdaccf1c5a000f167f68399075bd4aa4113ed0edb56",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44756",
+					"10.65.0.27:44756",
+					"172.17.0.1:44756",
+					"172.18.0.1:44756",
+					"172.19.0.1:44756"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:26:11.454274662Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8729599415940745,
+				"StableID":   "n4k7HtmeAB21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:67753b1f23a452a94efdf01e17001258c23b7ccb308395c7013fe6fa87ffe167",
+				"DiscoKey":   "discokey:7e6c6b7a33e8a49233af5370adf399c243608561ecd723a23a78297b12f5807c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34501",
+					"10.65.0.27:34501",
+					"172.17.0.1:34501",
+					"172.18.0.1:34501",
+					"172.19.0.1:34501"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:26:11.992719645Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4487685099469864,
+				"StableID":   "nVRJtusU3c11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc136313d4088b5eaf35796602ae589141f51c6233b04404e339a6922e82872e",
+				"DiscoKey":   "discokey:88b6822ed6132ded97e2cd51dadb5e6361010cf57c91966d19280d57db97eb1f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58706",
+					"10.65.0.27:58706",
+					"172.17.0.1:58706",
+					"172.18.0.1:58706",
+					"172.19.0.1:58706"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:26:12.528642995Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8577452833475303,
+				"StableID":   "ni6enB9ky921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:57be61187942ff8839a890040b4138ecfbcf38fef2c351d6b7cc8aa03082bc7e",
+				"DiscoKey":   "discokey:960b27038dcf4188852eb8283bb434968725922cd3ce0c6b040f8b5757ddd435",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42728",
+					"10.65.0.27:42728",
+					"172.17.0.1:42728",
+					"172.18.0.1:42728",
+					"172.19.0.1:42728"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:26:13.060337024Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         929445925349060,
+				"StableID":   "nbWjgAywF811CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e785db439d1a9e7463c4982c6e311857828f9d12f042db917d3036abd12ccf09",
+				"DiscoKey":   "discokey:24c5752a6f1943c028613055f54b4eeb36e40fb8b8fdeeeb1ac5e2e1d8c26b17",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37910",
+					"10.65.0.27:37910",
+					"172.17.0.1:37910",
+					"172.18.0.1:37910",
+					"172.19.0.1:37910"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:26:13.591886388Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7976552733572839,
+				"StableID":   "nECNeqWbH521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fd5e3e150b855d608bea527fa3f1d22bdf91e163030bc047872618a6d0ea032",
+				"DiscoKey":   "discokey:d779500d32cd2ab2c6ee33347cf09ea457b3b5947255d565b00d36390cb10845",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54450",
+					"10.65.0.27:54450",
+					"172.17.0.1:54450",
+					"172.18.0.1:54450",
+					"172.19.0.1:54450"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:26:14.144258373Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1453856919110886,
+				"StableID":   "n7FgSeMTMC11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:648f74443643fe40ae55a6cf8724022fe292e0124617b3c0d19b203e8fcec90d",
+				"DiscoKey":   "discokey:2ee942ea9a27db219d74afe0848f060b36f20947f13fcd0ba588942c88369c40",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:35581",
+					"10.65.0.27:35581",
+					"172.17.0.1:35581",
+					"172.18.0.1:35581",
+					"172.19.0.1:35581"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:26:14.683922946Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2188832929173675,
+				"StableID":   "nUFQeuvK6J11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6a66fa3f81c6d57a7dd3292707473a69944e2759166dd347c8af689c35aa414b",
+				"DiscoKey":   "discokey:4cb93e0a0cfb7f2d8f2075415c693f100b99ed6bf2829acb1cec3984962f6551",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33142",
+					"10.65.0.27:33142",
+					"172.17.0.1:33142",
+					"172.18.0.1:33142",
+					"172.19.0.1:33142"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:26:15.764283904Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2220056418692597,
+				"StableID":   "nnBeVp7ULJ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cfa65570339388567923ea44e46ae1a04de2c6a9da6b287c97a9929899504902",
+				"DiscoKey":   "discokey:6369f4878b14b6103bc69fce6146f83dde4766771d89021aa4516de02773320e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53390",
+					"10.65.0.27:53390",
+					"172.17.0.1:53390",
+					"172.18.0.1:53390",
+					"172.19.0.1:53390"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:26:16.313865207Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7455186368303287,
+				"StableID":   "n6xGH37UD121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:294663b0b5f7ba1ee2227009d3fb406868a072a64a3d0bd88cab5eda31d27222",
+				"DiscoKey":   "discokey:c76e5dd5e057ce11c48096fb4fcb8c274426a789e8975b83382dcce63851ff20",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54605",
+					"10.65.0.27:54605",
+					"172.17.0.1:54605",
+					"172.18.0.1:54605",
+					"172.19.0.1:54605"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:26:16.857445165Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5338333051349764,
+				"StableID":   "noi8VWxjgi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bd3eaca53faed7bea73992582fb18404d8b93ca3180e9157ea73cda635413525",
+				"KeyExpiry":  "2026-11-09T07:26:17Z",
+				"DiscoKey":   "discokey:caafd01f4ec17355491f0bec6109e51556619ab6f2e648f689eca8c4e024f811",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50620",
+					"10.65.0.27:50620",
+					"172.17.0.1:50620",
+					"172.18.0.1:50620",
+					"172.19.0.1:50620"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:26:17.383458171Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6030978903928173,
+				"StableID":   "nLA9dAbS6p11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ff31a6529f4f1ceb4d62f6dbd573693dadfd8b95685111b4490cc8300019536b",
+				"KeyExpiry":  "2026-11-09T07:26:17Z",
+				"DiscoKey":   "discokey:32853d2bafb9288dfa544e8f4ace90888be551167e02d31d1ece224bc6b5ee6f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48480",
+					"10.65.0.27:48480",
+					"172.17.0.1:48480",
+					"172.18.0.1:48480",
+					"172.19.0.1:48480"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:26:17.935899015Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7379662858071522,
+				"StableID":   "nXdNJKEGdz11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:613c1b30f06a2371e917dab10ea73560ec6d99637bebcd6341da1168647dd867",
+				"KeyExpiry":  "2026-11-09T07:26:18Z",
+				"DiscoKey":   "discokey:e9e440c3073a7ca4c3cd74ea3d9dd61cc19d0d653f73c77eb2a39add0d24af50",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55977",
+					"10.65.0.27:55977",
+					"172.17.0.1:55977",
+					"172.18.0.1:55977",
+					"172.19.0.1:55977"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:26:18.47443624Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8156323941706304": {
+				"ID":          8156323941706304,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6030978903928173,
+				"StableID":   "nLA9dAbS6p11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ff31a6529f4f1ceb4d62f6dbd573693dadfd8b95685111b4490cc8300019536b",
+				"KeyExpiry":  "2026-11-09T07:26:17Z",
+				"DiscoKey":   "discokey:32853d2bafb9288dfa544e8f4ace90888be551167e02d31d1ece224bc6b5ee6f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48480",
+					"10.65.0.27:48480",
+					"172.17.0.1:48480",
+					"172.18.0.1:48480",
+					"172.19.0.1:48480"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:26:17.935899015Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ff31a6529f4f1ceb4d62f6dbd573693dadfd8b95685111b4490cc8300019536b",
+			"MachineKey": "mkey:fe8c251dbcbea333907c0a986f553b1d230822e29b660495da72b5e5ef34f31a",
+			"Peers": [{
+				"ID":         3922698761091064,
+				"StableID":   "nmqGsPebdX11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6f914d5564e0c688d3e036904c3e9dea1d722b87fc02c5d9a880a8a0534ed464",
+				"DiscoKey":   "discokey:46529347afdae91b8dad477a76105777cfa27c1d4c52685c0cad084a247f3b19",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35426",
+					"10.65.0.27:35426",
+					"172.17.0.1:35426",
+					"172.18.0.1:35426",
+					"172.19.0.1:35426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:26:10.976975248Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4406294529692090,
+				"StableID":   "noMewMtcQb11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10871915c211c16333b33b320bff410f66cda07a760985a8fded20535f5f5c49",
+				"DiscoKey":   "discokey:f78f2f29f422eb844812ecdaccf1c5a000f167f68399075bd4aa4113ed0edb56",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44756",
+					"10.65.0.27:44756",
+					"172.17.0.1:44756",
+					"172.18.0.1:44756",
+					"172.19.0.1:44756"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:26:11.454274662Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8729599415940745,
+				"StableID":   "n4k7HtmeAB21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:67753b1f23a452a94efdf01e17001258c23b7ccb308395c7013fe6fa87ffe167",
+				"DiscoKey":   "discokey:7e6c6b7a33e8a49233af5370adf399c243608561ecd723a23a78297b12f5807c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34501",
+					"10.65.0.27:34501",
+					"172.17.0.1:34501",
+					"172.18.0.1:34501",
+					"172.19.0.1:34501"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:26:11.992719645Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4487685099469864,
+				"StableID":   "nVRJtusU3c11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc136313d4088b5eaf35796602ae589141f51c6233b04404e339a6922e82872e",
+				"DiscoKey":   "discokey:88b6822ed6132ded97e2cd51dadb5e6361010cf57c91966d19280d57db97eb1f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58706",
+					"10.65.0.27:58706",
+					"172.17.0.1:58706",
+					"172.18.0.1:58706",
+					"172.19.0.1:58706"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:26:12.528642995Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8577452833475303,
+				"StableID":   "ni6enB9ky921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:57be61187942ff8839a890040b4138ecfbcf38fef2c351d6b7cc8aa03082bc7e",
+				"DiscoKey":   "discokey:960b27038dcf4188852eb8283bb434968725922cd3ce0c6b040f8b5757ddd435",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42728",
+					"10.65.0.27:42728",
+					"172.17.0.1:42728",
+					"172.18.0.1:42728",
+					"172.19.0.1:42728"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:26:13.060337024Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         929445925349060,
+				"StableID":   "nbWjgAywF811CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e785db439d1a9e7463c4982c6e311857828f9d12f042db917d3036abd12ccf09",
+				"DiscoKey":   "discokey:24c5752a6f1943c028613055f54b4eeb36e40fb8b8fdeeeb1ac5e2e1d8c26b17",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37910",
+					"10.65.0.27:37910",
+					"172.17.0.1:37910",
+					"172.18.0.1:37910",
+					"172.19.0.1:37910"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:26:13.591886388Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7976552733572839,
+				"StableID":   "nECNeqWbH521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fd5e3e150b855d608bea527fa3f1d22bdf91e163030bc047872618a6d0ea032",
+				"DiscoKey":   "discokey:d779500d32cd2ab2c6ee33347cf09ea457b3b5947255d565b00d36390cb10845",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54450",
+					"10.65.0.27:54450",
+					"172.17.0.1:54450",
+					"172.18.0.1:54450",
+					"172.19.0.1:54450"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:26:14.144258373Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1453856919110886,
+				"StableID":   "n7FgSeMTMC11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:648f74443643fe40ae55a6cf8724022fe292e0124617b3c0d19b203e8fcec90d",
+				"DiscoKey":   "discokey:2ee942ea9a27db219d74afe0848f060b36f20947f13fcd0ba588942c88369c40",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:35581",
+					"10.65.0.27:35581",
+					"172.17.0.1:35581",
+					"172.18.0.1:35581",
+					"172.19.0.1:35581"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:26:14.683922946Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8156323941706304,
+				"StableID":   "nFS9iMo1h621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e79cf519506639525b0b6fb0c0338c46b13e00f8c8fadd4b034dcf4728d6765",
+				"DiscoKey":   "discokey:1a3f91e13d4434153f10e7e52e0dc7291c5d5bcafe3135991155e1027765e32e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56992",
+					"10.65.0.27:56992",
+					"172.17.0.1:56992",
+					"172.18.0.1:56992",
+					"172.19.0.1:56992"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:26:15.226010914Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2188832929173675,
+				"StableID":   "nUFQeuvK6J11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6a66fa3f81c6d57a7dd3292707473a69944e2759166dd347c8af689c35aa414b",
+				"DiscoKey":   "discokey:4cb93e0a0cfb7f2d8f2075415c693f100b99ed6bf2829acb1cec3984962f6551",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33142",
+					"10.65.0.27:33142",
+					"172.17.0.1:33142",
+					"172.18.0.1:33142",
+					"172.19.0.1:33142"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:26:15.764283904Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2220056418692597,
+				"StableID":   "nnBeVp7ULJ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cfa65570339388567923ea44e46ae1a04de2c6a9da6b287c97a9929899504902",
+				"DiscoKey":   "discokey:6369f4878b14b6103bc69fce6146f83dde4766771d89021aa4516de02773320e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53390",
+					"10.65.0.27:53390",
+					"172.17.0.1:53390",
+					"172.18.0.1:53390",
+					"172.19.0.1:53390"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:26:16.313865207Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7455186368303287,
+				"StableID":   "n6xGH37UD121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:294663b0b5f7ba1ee2227009d3fb406868a072a64a3d0bd88cab5eda31d27222",
+				"DiscoKey":   "discokey:c76e5dd5e057ce11c48096fb4fcb8c274426a789e8975b83382dcce63851ff20",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54605",
+					"10.65.0.27:54605",
+					"172.17.0.1:54605",
+					"172.18.0.1:54605",
+					"172.19.0.1:54605"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:26:16.857445165Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5338333051349764,
+				"StableID":   "noi8VWxjgi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bd3eaca53faed7bea73992582fb18404d8b93ca3180e9157ea73cda635413525",
+				"KeyExpiry":  "2026-11-09T07:26:17Z",
+				"DiscoKey":   "discokey:caafd01f4ec17355491f0bec6109e51556619ab6f2e648f689eca8c4e024f811",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50620",
+					"10.65.0.27:50620",
+					"172.17.0.1:50620",
+					"172.18.0.1:50620",
+					"172.19.0.1:50620"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:26:17.383458171Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7379662858071522,
+				"StableID":   "nXdNJKEGdz11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:613c1b30f06a2371e917dab10ea73560ec6d99637bebcd6341da1168647dd867",
+				"KeyExpiry":  "2026-11-09T07:26:18Z",
+				"DiscoKey":   "discokey:e9e440c3073a7ca4c3cd74ea3d9dd61cc19d0d653f73c77eb2a39add0d24af50",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55977",
+					"10.65.0.27:55977",
+					"172.17.0.1:55977",
+					"172.18.0.1:55977",
+					"172.19.0.1:55977"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:26:18.47443624Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2188832929173675,
+				"StableID":   "nUFQeuvK6J11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       2188832929173675,
+				"Key":        "nodekey:6a66fa3f81c6d57a7dd3292707473a69944e2759166dd347c8af689c35aa414b",
+				"DiscoKey":   "discokey:4cb93e0a0cfb7f2d8f2075415c693f100b99ed6bf2829acb1cec3984962f6551",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33142",
+					"10.65.0.27:33142",
+					"172.17.0.1:33142",
+					"172.18.0.1:33142",
+					"172.19.0.1:33142"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:26:15.764283904Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6a66fa3f81c6d57a7dd3292707473a69944e2759166dd347c8af689c35aa414b",
+			"MachineKey": "mkey:8e6ef4d8899042617f6f870d9b2b3beafec618766fed37ba0911ab8a7a98dd36",
+			"Peers": [{
+				"ID":         3922698761091064,
+				"StableID":   "nmqGsPebdX11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6f914d5564e0c688d3e036904c3e9dea1d722b87fc02c5d9a880a8a0534ed464",
+				"DiscoKey":   "discokey:46529347afdae91b8dad477a76105777cfa27c1d4c52685c0cad084a247f3b19",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35426",
+					"10.65.0.27:35426",
+					"172.17.0.1:35426",
+					"172.18.0.1:35426",
+					"172.19.0.1:35426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:26:10.976975248Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4406294529692090,
+				"StableID":   "noMewMtcQb11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10871915c211c16333b33b320bff410f66cda07a760985a8fded20535f5f5c49",
+				"DiscoKey":   "discokey:f78f2f29f422eb844812ecdaccf1c5a000f167f68399075bd4aa4113ed0edb56",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44756",
+					"10.65.0.27:44756",
+					"172.17.0.1:44756",
+					"172.18.0.1:44756",
+					"172.19.0.1:44756"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:26:11.454274662Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8729599415940745,
+				"StableID":   "n4k7HtmeAB21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:67753b1f23a452a94efdf01e17001258c23b7ccb308395c7013fe6fa87ffe167",
+				"DiscoKey":   "discokey:7e6c6b7a33e8a49233af5370adf399c243608561ecd723a23a78297b12f5807c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34501",
+					"10.65.0.27:34501",
+					"172.17.0.1:34501",
+					"172.18.0.1:34501",
+					"172.19.0.1:34501"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:26:11.992719645Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4487685099469864,
+				"StableID":   "nVRJtusU3c11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc136313d4088b5eaf35796602ae589141f51c6233b04404e339a6922e82872e",
+				"DiscoKey":   "discokey:88b6822ed6132ded97e2cd51dadb5e6361010cf57c91966d19280d57db97eb1f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58706",
+					"10.65.0.27:58706",
+					"172.17.0.1:58706",
+					"172.18.0.1:58706",
+					"172.19.0.1:58706"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:26:12.528642995Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8577452833475303,
+				"StableID":   "ni6enB9ky921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:57be61187942ff8839a890040b4138ecfbcf38fef2c351d6b7cc8aa03082bc7e",
+				"DiscoKey":   "discokey:960b27038dcf4188852eb8283bb434968725922cd3ce0c6b040f8b5757ddd435",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42728",
+					"10.65.0.27:42728",
+					"172.17.0.1:42728",
+					"172.18.0.1:42728",
+					"172.19.0.1:42728"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:26:13.060337024Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         929445925349060,
+				"StableID":   "nbWjgAywF811CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e785db439d1a9e7463c4982c6e311857828f9d12f042db917d3036abd12ccf09",
+				"DiscoKey":   "discokey:24c5752a6f1943c028613055f54b4eeb36e40fb8b8fdeeeb1ac5e2e1d8c26b17",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37910",
+					"10.65.0.27:37910",
+					"172.17.0.1:37910",
+					"172.18.0.1:37910",
+					"172.19.0.1:37910"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:26:13.591886388Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7976552733572839,
+				"StableID":   "nECNeqWbH521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fd5e3e150b855d608bea527fa3f1d22bdf91e163030bc047872618a6d0ea032",
+				"DiscoKey":   "discokey:d779500d32cd2ab2c6ee33347cf09ea457b3b5947255d565b00d36390cb10845",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54450",
+					"10.65.0.27:54450",
+					"172.17.0.1:54450",
+					"172.18.0.1:54450",
+					"172.19.0.1:54450"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:26:14.144258373Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1453856919110886,
+				"StableID":   "n7FgSeMTMC11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:648f74443643fe40ae55a6cf8724022fe292e0124617b3c0d19b203e8fcec90d",
+				"DiscoKey":   "discokey:2ee942ea9a27db219d74afe0848f060b36f20947f13fcd0ba588942c88369c40",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:35581",
+					"10.65.0.27:35581",
+					"172.17.0.1:35581",
+					"172.18.0.1:35581",
+					"172.19.0.1:35581"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:26:14.683922946Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8156323941706304,
+				"StableID":   "nFS9iMo1h621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e79cf519506639525b0b6fb0c0338c46b13e00f8c8fadd4b034dcf4728d6765",
+				"DiscoKey":   "discokey:1a3f91e13d4434153f10e7e52e0dc7291c5d5bcafe3135991155e1027765e32e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56992",
+					"10.65.0.27:56992",
+					"172.17.0.1:56992",
+					"172.18.0.1:56992",
+					"172.19.0.1:56992"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:26:15.226010914Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2220056418692597,
+				"StableID":   "nnBeVp7ULJ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cfa65570339388567923ea44e46ae1a04de2c6a9da6b287c97a9929899504902",
+				"DiscoKey":   "discokey:6369f4878b14b6103bc69fce6146f83dde4766771d89021aa4516de02773320e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53390",
+					"10.65.0.27:53390",
+					"172.17.0.1:53390",
+					"172.18.0.1:53390",
+					"172.19.0.1:53390"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:26:16.313865207Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7455186368303287,
+				"StableID":   "n6xGH37UD121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:294663b0b5f7ba1ee2227009d3fb406868a072a64a3d0bd88cab5eda31d27222",
+				"DiscoKey":   "discokey:c76e5dd5e057ce11c48096fb4fcb8c274426a789e8975b83382dcce63851ff20",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54605",
+					"10.65.0.27:54605",
+					"172.17.0.1:54605",
+					"172.18.0.1:54605",
+					"172.19.0.1:54605"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:26:16.857445165Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5338333051349764,
+				"StableID":   "noi8VWxjgi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bd3eaca53faed7bea73992582fb18404d8b93ca3180e9157ea73cda635413525",
+				"KeyExpiry":  "2026-11-09T07:26:17Z",
+				"DiscoKey":   "discokey:caafd01f4ec17355491f0bec6109e51556619ab6f2e648f689eca8c4e024f811",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50620",
+					"10.65.0.27:50620",
+					"172.17.0.1:50620",
+					"172.18.0.1:50620",
+					"172.19.0.1:50620"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:26:17.383458171Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6030978903928173,
+				"StableID":   "nLA9dAbS6p11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ff31a6529f4f1ceb4d62f6dbd573693dadfd8b95685111b4490cc8300019536b",
+				"KeyExpiry":  "2026-11-09T07:26:17Z",
+				"DiscoKey":   "discokey:32853d2bafb9288dfa544e8f4ace90888be551167e02d31d1ece224bc6b5ee6f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48480",
+					"10.65.0.27:48480",
+					"172.17.0.1:48480",
+					"172.18.0.1:48480",
+					"172.19.0.1:48480"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:26:17.935899015Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7379662858071522,
+				"StableID":   "nXdNJKEGdz11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:613c1b30f06a2371e917dab10ea73560ec6d99637bebcd6341da1168647dd867",
+				"KeyExpiry":  "2026-11-09T07:26:18Z",
+				"DiscoKey":   "discokey:e9e440c3073a7ca4c3cd74ea3d9dd61cc19d0d653f73c77eb2a39add0d24af50",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55977",
+					"10.65.0.27:55977",
+					"172.17.0.1:55977",
+					"172.18.0.1:55977",
+					"172.19.0.1:55977"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:26:18.47443624Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2188832929173675": {
+				"ID":          2188832929173675,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-action-uppercase.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-action-uppercase.hujson
@@ -1,0 +1,20081 @@
+// ssh-malformed-action-uppercase
+//
+// ssh action uppercase
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-13T07:26:54Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-malformed-action-uppercase",
+	"description":    "ssh action uppercase",
+	"category":       "ssh",
+	"captured_at":    "2026-05-13T07:26:54.488282299Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "\"ACCEPT\" is not a valid action"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                 \n  \n                                                                      \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh action uppercase\",\n\t\"id\":          \"ssh-malformed-action-uppercase\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"ACCEPT\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"autogroup:member\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-edge/ssh-malformed-action-uppercase.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "ACCEPT",
+				"dst":    ["tag:server"],
+				"src":    ["autogroup:member"],
+				"users":  ["root"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5403428179624782,
+				"StableID":   "nwfe4xtDCj11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       5403428179624782,
+				"Key":        "nodekey:97356b4b7940089468c4f81076a3eab9940641d95c257df1b64feadf66ef1e56",
+				"DiscoKey":   "discokey:b1edefc8df04ed9768b257b92e20f51a6843dfda822911dcdec17d88d2534c37",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45145",
+					"10.65.0.27:45145",
+					"172.17.0.1:45145",
+					"172.18.0.1:45145",
+					"172.19.0.1:45145"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:27:02.931043851Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:97356b4b7940089468c4f81076a3eab9940641d95c257df1b64feadf66ef1e56",
+			"MachineKey": "mkey:4eb2c11db5cb68b2a9d4f3f422ef1b82c67dfce08b56d4dcc7ef3c1c4821163a",
+			"Peers": [{
+				"ID":         4300355520635176,
+				"StableID":   "nVP1Vk3eaa11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a61f5a1ff97ecf2aea16bb88b5f41541d530d86b48910b8e37174dc51d809c62",
+				"DiscoKey":   "discokey:81b10f11a5f07eb67e9dc816bfb80a26acf36eaeb6e5a650e82b4777a0f9be52",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36665",
+					"10.65.0.27:36665",
+					"172.17.0.1:36665",
+					"172.18.0.1:36665",
+					"172.19.0.1:36665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:26:57.003292739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5856057653412839,
+				"StableID":   "ncoshrhDjn11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ead443776fde1a0f7a3bfe0ca8702866d2ca969e84f2597f829dd7bf7dc0d33a",
+				"DiscoKey":   "discokey:2e9deedbff60feed8a4f5eb1b2cd13e64fa0e1fbf51c3dece8db4a855b8ec320",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59791",
+					"10.65.0.27:59791",
+					"172.17.0.1:59791",
+					"172.18.0.1:59791",
+					"172.19.0.1:59791"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:26:57.523390736Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3179727635831357,
+				"StableID":   "nSRLi547qR11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93873a6f265369516b791b31da43ee7c380190707090d14a550a0a046d505556",
+				"DiscoKey":   "discokey:03fb81b74f8d517e056a4f8d1aa3522a4adb2094d1f61fa2dacbaa6525af1565",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59237",
+					"10.65.0.27:59237",
+					"172.17.0.1:59237",
+					"172.18.0.1:59237",
+					"172.19.0.1:59237"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:26:58.059202864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8962288194634897,
+				"StableID":   "npC4ra73zC21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:621bec1f2046b31a5e2a33f948386d37f3d7c91ed2c8eaa801d486ff858f672d",
+				"DiscoKey":   "discokey:d36a0d8a70645292ed9210fea89626ae265600dccc466ffb9c365eb4d69b2140",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43022",
+					"10.65.0.27:43022",
+					"172.17.0.1:43022",
+					"172.18.0.1:43022",
+					"172.19.0.1:43022"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:26:58.596366511Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1567973378065028,
+				"StableID":   "nsaX9719FD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f2416fd8a0d9765d31f5070326169834973024c10bce7a31ab05a8bcc4534524",
+				"DiscoKey":   "discokey:683485c665d2db159ab205e07d8c53e0aab258dce4929d97be7fc1712b2ce77d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57727",
+					"10.65.0.27:57727",
+					"172.17.0.1:57727",
+					"172.18.0.1:57727",
+					"172.19.0.1:57727"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:26:59.141229457Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3016134210607158,
+				"StableID":   "nVcevQj1ZQ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f4fc7cbdaabee95996343c27024bf620c999aa8c032a3a9356a65004cb48e22",
+				"DiscoKey":   "discokey:efb4ece44054a5587b590cf87cfed9ce63ac39e49a6dfd0fd4eec36d04201e63",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:45813",
+					"10.65.0.27:45813",
+					"172.17.0.1:45813",
+					"172.18.0.1:45813",
+					"172.19.0.1:45813"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:26:59.680343044Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3973102316283284,
+				"StableID":   "njzXSKfR2Y11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6d59e828bd1ec4406027305043ec4681871778203de510295195c5fb0f8ef0b",
+				"DiscoKey":   "discokey:7a725f7db4ffc2294f03ad0e455eb2f558b1aec50079efd82b13eed3bd5a196b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49912",
+					"10.65.0.27:49912",
+					"172.17.0.1:49912",
+					"172.18.0.1:49912",
+					"172.19.0.1:49912"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:27:00.213210359Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         235565068263781,
+				"StableID":   "n86pRutgq211CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80e631a597e3db49772f3290ded999c22b21ea495de69012e934b7e408975f69",
+				"DiscoKey":   "discokey:b95030eef52e66b64b8dd4fc53e3c48ff855c33fce3f6b78a46b7bdd3080b504",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33453",
+					"10.65.0.27:33453",
+					"172.17.0.1:33453",
+					"172.18.0.1:33453",
+					"172.19.0.1:33453"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:27:00.753039236Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6791068477030203,
+				"StableID":   "nWLqPVrg2v11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0d4250e80aa04b003dbcf01dfc364cac29bf1c1bfb954664b3a6db0e2b2f230",
+				"DiscoKey":   "discokey:f54d4791b90bd244fdcdc6fdae6ec7c5834befb57ec2d094e9b7730e06be523d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52371",
+					"10.65.0.27:52371",
+					"172.17.0.1:52371",
+					"172.18.0.1:52371",
+					"172.19.0.1:52371"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:27:01.312466099Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8499398043976277,
+				"StableID":   "nt4rKumPN921CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1175f18a732bca77b79a3613d5170311e610a07ce18109d85b10fe9ca5850517",
+				"DiscoKey":   "discokey:c088813373a00a575c3c71ba23819ba4bb794a8be9808cd5fb09d92f9193f940",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:48977",
+					"10.65.0.27:48977",
+					"172.17.0.1:48977",
+					"172.18.0.1:48977",
+					"172.19.0.1:48977"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:27:01.84587771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7854343063047086,
+				"StableID":   "nTsjYsGFL421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f7dcd979d4bc0aa8458654b069096fd7888a661026053c57c003dbed72adc4c",
+				"DiscoKey":   "discokey:711b65738573fb67a2b4f5ee2d621af5493ae49317515c2614ad5098225ee97e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51364",
+					"10.65.0.27:51364",
+					"172.17.0.1:51364",
+					"172.18.0.1:51364",
+					"172.19.0.1:51364"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:27:02.393646415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         195110116993013,
+				"StableID":   "nJd6vHDNX211CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e05e86118037ecb9d1b8c69598d8555137c0660906164c987abb9a0a590b3462",
+				"KeyExpiry":  "2026-11-09T07:27:03Z",
+				"DiscoKey":   "discokey:d4fef671d7833309d09aeb6367618aba4f60348374d4ea1262024bf8c011f744",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49924",
+					"10.65.0.27:49924",
+					"172.17.0.1:49924",
+					"172.18.0.1:49924",
+					"172.19.0.1:49924"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:27:03.46824726Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1106395205696899,
+				"StableID":   "nEazeJ86e911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3f9f603fee398520b30fe26c0d495861d81435ab17a14d022974b8d839e6480c",
+				"KeyExpiry":  "2026-11-09T07:27:04Z",
+				"DiscoKey":   "discokey:9747a5c1073002cae69cf040f872f2bf13c50d30b8335f300cd7781cf3392c73",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54811",
+					"10.65.0.27:54811",
+					"172.17.0.1:54811",
+					"172.18.0.1:54811",
+					"172.19.0.1:54811"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:27:04.007909784Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5546769760379673,
+				"StableID":   "nSRqhgE9Kk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c31c870b3855ecc7686e1e16dd15135511194115d1bfafdc71930e15988bb37f",
+				"KeyExpiry":  "2026-11-09T07:27:04Z",
+				"DiscoKey":   "discokey:ca07f79f6295772d2daf95472f0541cf641f122546a39103ad3e985df591b459",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57507",
+					"10.65.0.27:57507",
+					"172.17.0.1:57507",
+					"172.18.0.1:57507",
+					"172.19.0.1:57507"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:27:04.557797193Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5403428179624782": {
+				"ID":          5403428179624782,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3016134210607158,
+				"StableID":   "nVcevQj1ZQ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       3016134210607158,
+				"Key":        "nodekey:5f4fc7cbdaabee95996343c27024bf620c999aa8c032a3a9356a65004cb48e22",
+				"DiscoKey":   "discokey:efb4ece44054a5587b590cf87cfed9ce63ac39e49a6dfd0fd4eec36d04201e63",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:45813",
+					"10.65.0.27:45813",
+					"172.17.0.1:45813",
+					"172.18.0.1:45813",
+					"172.19.0.1:45813"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:26:59.680343044Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5f4fc7cbdaabee95996343c27024bf620c999aa8c032a3a9356a65004cb48e22",
+			"MachineKey": "mkey:44d4f4b411fab9e4ae4fa07f159bdd4483a0c782ad89805dbfd226f44cfbf64c",
+			"Peers": [{
+				"ID":         4300355520635176,
+				"StableID":   "nVP1Vk3eaa11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a61f5a1ff97ecf2aea16bb88b5f41541d530d86b48910b8e37174dc51d809c62",
+				"DiscoKey":   "discokey:81b10f11a5f07eb67e9dc816bfb80a26acf36eaeb6e5a650e82b4777a0f9be52",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36665",
+					"10.65.0.27:36665",
+					"172.17.0.1:36665",
+					"172.18.0.1:36665",
+					"172.19.0.1:36665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:26:57.003292739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5856057653412839,
+				"StableID":   "ncoshrhDjn11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ead443776fde1a0f7a3bfe0ca8702866d2ca969e84f2597f829dd7bf7dc0d33a",
+				"DiscoKey":   "discokey:2e9deedbff60feed8a4f5eb1b2cd13e64fa0e1fbf51c3dece8db4a855b8ec320",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59791",
+					"10.65.0.27:59791",
+					"172.17.0.1:59791",
+					"172.18.0.1:59791",
+					"172.19.0.1:59791"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:26:57.523390736Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3179727635831357,
+				"StableID":   "nSRLi547qR11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93873a6f265369516b791b31da43ee7c380190707090d14a550a0a046d505556",
+				"DiscoKey":   "discokey:03fb81b74f8d517e056a4f8d1aa3522a4adb2094d1f61fa2dacbaa6525af1565",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59237",
+					"10.65.0.27:59237",
+					"172.17.0.1:59237",
+					"172.18.0.1:59237",
+					"172.19.0.1:59237"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:26:58.059202864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8962288194634897,
+				"StableID":   "npC4ra73zC21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:621bec1f2046b31a5e2a33f948386d37f3d7c91ed2c8eaa801d486ff858f672d",
+				"DiscoKey":   "discokey:d36a0d8a70645292ed9210fea89626ae265600dccc466ffb9c365eb4d69b2140",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43022",
+					"10.65.0.27:43022",
+					"172.17.0.1:43022",
+					"172.18.0.1:43022",
+					"172.19.0.1:43022"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:26:58.596366511Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1567973378065028,
+				"StableID":   "nsaX9719FD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f2416fd8a0d9765d31f5070326169834973024c10bce7a31ab05a8bcc4534524",
+				"DiscoKey":   "discokey:683485c665d2db159ab205e07d8c53e0aab258dce4929d97be7fc1712b2ce77d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57727",
+					"10.65.0.27:57727",
+					"172.17.0.1:57727",
+					"172.18.0.1:57727",
+					"172.19.0.1:57727"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:26:59.141229457Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3973102316283284,
+				"StableID":   "njzXSKfR2Y11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6d59e828bd1ec4406027305043ec4681871778203de510295195c5fb0f8ef0b",
+				"DiscoKey":   "discokey:7a725f7db4ffc2294f03ad0e455eb2f558b1aec50079efd82b13eed3bd5a196b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49912",
+					"10.65.0.27:49912",
+					"172.17.0.1:49912",
+					"172.18.0.1:49912",
+					"172.19.0.1:49912"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:27:00.213210359Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         235565068263781,
+				"StableID":   "n86pRutgq211CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80e631a597e3db49772f3290ded999c22b21ea495de69012e934b7e408975f69",
+				"DiscoKey":   "discokey:b95030eef52e66b64b8dd4fc53e3c48ff855c33fce3f6b78a46b7bdd3080b504",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33453",
+					"10.65.0.27:33453",
+					"172.17.0.1:33453",
+					"172.18.0.1:33453",
+					"172.19.0.1:33453"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:27:00.753039236Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6791068477030203,
+				"StableID":   "nWLqPVrg2v11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0d4250e80aa04b003dbcf01dfc364cac29bf1c1bfb954664b3a6db0e2b2f230",
+				"DiscoKey":   "discokey:f54d4791b90bd244fdcdc6fdae6ec7c5834befb57ec2d094e9b7730e06be523d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52371",
+					"10.65.0.27:52371",
+					"172.17.0.1:52371",
+					"172.18.0.1:52371",
+					"172.19.0.1:52371"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:27:01.312466099Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8499398043976277,
+				"StableID":   "nt4rKumPN921CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1175f18a732bca77b79a3613d5170311e610a07ce18109d85b10fe9ca5850517",
+				"DiscoKey":   "discokey:c088813373a00a575c3c71ba23819ba4bb794a8be9808cd5fb09d92f9193f940",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:48977",
+					"10.65.0.27:48977",
+					"172.17.0.1:48977",
+					"172.18.0.1:48977",
+					"172.19.0.1:48977"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:27:01.84587771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7854343063047086,
+				"StableID":   "nTsjYsGFL421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f7dcd979d4bc0aa8458654b069096fd7888a661026053c57c003dbed72adc4c",
+				"DiscoKey":   "discokey:711b65738573fb67a2b4f5ee2d621af5493ae49317515c2614ad5098225ee97e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51364",
+					"10.65.0.27:51364",
+					"172.17.0.1:51364",
+					"172.18.0.1:51364",
+					"172.19.0.1:51364"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:27:02.393646415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5403428179624782,
+				"StableID":   "nwfe4xtDCj11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97356b4b7940089468c4f81076a3eab9940641d95c257df1b64feadf66ef1e56",
+				"DiscoKey":   "discokey:b1edefc8df04ed9768b257b92e20f51a6843dfda822911dcdec17d88d2534c37",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45145",
+					"10.65.0.27:45145",
+					"172.17.0.1:45145",
+					"172.18.0.1:45145",
+					"172.19.0.1:45145"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:27:02.931043851Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         195110116993013,
+				"StableID":   "nJd6vHDNX211CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e05e86118037ecb9d1b8c69598d8555137c0660906164c987abb9a0a590b3462",
+				"KeyExpiry":  "2026-11-09T07:27:03Z",
+				"DiscoKey":   "discokey:d4fef671d7833309d09aeb6367618aba4f60348374d4ea1262024bf8c011f744",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49924",
+					"10.65.0.27:49924",
+					"172.17.0.1:49924",
+					"172.18.0.1:49924",
+					"172.19.0.1:49924"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:27:03.46824726Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1106395205696899,
+				"StableID":   "nEazeJ86e911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3f9f603fee398520b30fe26c0d495861d81435ab17a14d022974b8d839e6480c",
+				"KeyExpiry":  "2026-11-09T07:27:04Z",
+				"DiscoKey":   "discokey:9747a5c1073002cae69cf040f872f2bf13c50d30b8335f300cd7781cf3392c73",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54811",
+					"10.65.0.27:54811",
+					"172.17.0.1:54811",
+					"172.18.0.1:54811",
+					"172.19.0.1:54811"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:27:04.007909784Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5546769760379673,
+				"StableID":   "nSRqhgE9Kk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c31c870b3855ecc7686e1e16dd15135511194115d1bfafdc71930e15988bb37f",
+				"KeyExpiry":  "2026-11-09T07:27:04Z",
+				"DiscoKey":   "discokey:ca07f79f6295772d2daf95472f0541cf641f122546a39103ad3e985df591b459",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57507",
+					"10.65.0.27:57507",
+					"172.17.0.1:57507",
+					"172.18.0.1:57507",
+					"172.19.0.1:57507"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:27:04.557797193Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3016134210607158": {
+				"ID":          3016134210607158,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5546769760379673,
+				"StableID":   "nSRqhgE9Kk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c31c870b3855ecc7686e1e16dd15135511194115d1bfafdc71930e15988bb37f",
+				"KeyExpiry":  "2026-11-09T07:27:04Z",
+				"DiscoKey":   "discokey:ca07f79f6295772d2daf95472f0541cf641f122546a39103ad3e985df591b459",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57507",
+					"10.65.0.27:57507",
+					"172.17.0.1:57507",
+					"172.18.0.1:57507",
+					"172.19.0.1:57507"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:27:04.557797193Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c31c870b3855ecc7686e1e16dd15135511194115d1bfafdc71930e15988bb37f",
+			"MachineKey": "mkey:5ccf7e003b818cf754a5689421c719a049a0688be96396b50ff5b4d972a4bf1d",
+			"Peers": [{
+				"ID":         4300355520635176,
+				"StableID":   "nVP1Vk3eaa11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a61f5a1ff97ecf2aea16bb88b5f41541d530d86b48910b8e37174dc51d809c62",
+				"DiscoKey":   "discokey:81b10f11a5f07eb67e9dc816bfb80a26acf36eaeb6e5a650e82b4777a0f9be52",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36665",
+					"10.65.0.27:36665",
+					"172.17.0.1:36665",
+					"172.18.0.1:36665",
+					"172.19.0.1:36665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:26:57.003292739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5856057653412839,
+				"StableID":   "ncoshrhDjn11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ead443776fde1a0f7a3bfe0ca8702866d2ca969e84f2597f829dd7bf7dc0d33a",
+				"DiscoKey":   "discokey:2e9deedbff60feed8a4f5eb1b2cd13e64fa0e1fbf51c3dece8db4a855b8ec320",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59791",
+					"10.65.0.27:59791",
+					"172.17.0.1:59791",
+					"172.18.0.1:59791",
+					"172.19.0.1:59791"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:26:57.523390736Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3179727635831357,
+				"StableID":   "nSRLi547qR11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93873a6f265369516b791b31da43ee7c380190707090d14a550a0a046d505556",
+				"DiscoKey":   "discokey:03fb81b74f8d517e056a4f8d1aa3522a4adb2094d1f61fa2dacbaa6525af1565",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59237",
+					"10.65.0.27:59237",
+					"172.17.0.1:59237",
+					"172.18.0.1:59237",
+					"172.19.0.1:59237"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:26:58.059202864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8962288194634897,
+				"StableID":   "npC4ra73zC21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:621bec1f2046b31a5e2a33f948386d37f3d7c91ed2c8eaa801d486ff858f672d",
+				"DiscoKey":   "discokey:d36a0d8a70645292ed9210fea89626ae265600dccc466ffb9c365eb4d69b2140",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43022",
+					"10.65.0.27:43022",
+					"172.17.0.1:43022",
+					"172.18.0.1:43022",
+					"172.19.0.1:43022"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:26:58.596366511Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1567973378065028,
+				"StableID":   "nsaX9719FD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f2416fd8a0d9765d31f5070326169834973024c10bce7a31ab05a8bcc4534524",
+				"DiscoKey":   "discokey:683485c665d2db159ab205e07d8c53e0aab258dce4929d97be7fc1712b2ce77d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57727",
+					"10.65.0.27:57727",
+					"172.17.0.1:57727",
+					"172.18.0.1:57727",
+					"172.19.0.1:57727"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:26:59.141229457Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3016134210607158,
+				"StableID":   "nVcevQj1ZQ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f4fc7cbdaabee95996343c27024bf620c999aa8c032a3a9356a65004cb48e22",
+				"DiscoKey":   "discokey:efb4ece44054a5587b590cf87cfed9ce63ac39e49a6dfd0fd4eec36d04201e63",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:45813",
+					"10.65.0.27:45813",
+					"172.17.0.1:45813",
+					"172.18.0.1:45813",
+					"172.19.0.1:45813"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:26:59.680343044Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3973102316283284,
+				"StableID":   "njzXSKfR2Y11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6d59e828bd1ec4406027305043ec4681871778203de510295195c5fb0f8ef0b",
+				"DiscoKey":   "discokey:7a725f7db4ffc2294f03ad0e455eb2f558b1aec50079efd82b13eed3bd5a196b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49912",
+					"10.65.0.27:49912",
+					"172.17.0.1:49912",
+					"172.18.0.1:49912",
+					"172.19.0.1:49912"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:27:00.213210359Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         235565068263781,
+				"StableID":   "n86pRutgq211CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80e631a597e3db49772f3290ded999c22b21ea495de69012e934b7e408975f69",
+				"DiscoKey":   "discokey:b95030eef52e66b64b8dd4fc53e3c48ff855c33fce3f6b78a46b7bdd3080b504",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33453",
+					"10.65.0.27:33453",
+					"172.17.0.1:33453",
+					"172.18.0.1:33453",
+					"172.19.0.1:33453"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:27:00.753039236Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6791068477030203,
+				"StableID":   "nWLqPVrg2v11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0d4250e80aa04b003dbcf01dfc364cac29bf1c1bfb954664b3a6db0e2b2f230",
+				"DiscoKey":   "discokey:f54d4791b90bd244fdcdc6fdae6ec7c5834befb57ec2d094e9b7730e06be523d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52371",
+					"10.65.0.27:52371",
+					"172.17.0.1:52371",
+					"172.18.0.1:52371",
+					"172.19.0.1:52371"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:27:01.312466099Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8499398043976277,
+				"StableID":   "nt4rKumPN921CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1175f18a732bca77b79a3613d5170311e610a07ce18109d85b10fe9ca5850517",
+				"DiscoKey":   "discokey:c088813373a00a575c3c71ba23819ba4bb794a8be9808cd5fb09d92f9193f940",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:48977",
+					"10.65.0.27:48977",
+					"172.17.0.1:48977",
+					"172.18.0.1:48977",
+					"172.19.0.1:48977"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:27:01.84587771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7854343063047086,
+				"StableID":   "nTsjYsGFL421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f7dcd979d4bc0aa8458654b069096fd7888a661026053c57c003dbed72adc4c",
+				"DiscoKey":   "discokey:711b65738573fb67a2b4f5ee2d621af5493ae49317515c2614ad5098225ee97e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51364",
+					"10.65.0.27:51364",
+					"172.17.0.1:51364",
+					"172.18.0.1:51364",
+					"172.19.0.1:51364"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:27:02.393646415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5403428179624782,
+				"StableID":   "nwfe4xtDCj11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97356b4b7940089468c4f81076a3eab9940641d95c257df1b64feadf66ef1e56",
+				"DiscoKey":   "discokey:b1edefc8df04ed9768b257b92e20f51a6843dfda822911dcdec17d88d2534c37",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45145",
+					"10.65.0.27:45145",
+					"172.17.0.1:45145",
+					"172.18.0.1:45145",
+					"172.19.0.1:45145"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:27:02.931043851Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         195110116993013,
+				"StableID":   "nJd6vHDNX211CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e05e86118037ecb9d1b8c69598d8555137c0660906164c987abb9a0a590b3462",
+				"KeyExpiry":  "2026-11-09T07:27:03Z",
+				"DiscoKey":   "discokey:d4fef671d7833309d09aeb6367618aba4f60348374d4ea1262024bf8c011f744",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49924",
+					"10.65.0.27:49924",
+					"172.17.0.1:49924",
+					"172.18.0.1:49924",
+					"172.19.0.1:49924"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:27:03.46824726Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1106395205696899,
+				"StableID":   "nEazeJ86e911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3f9f603fee398520b30fe26c0d495861d81435ab17a14d022974b8d839e6480c",
+				"KeyExpiry":  "2026-11-09T07:27:04Z",
+				"DiscoKey":   "discokey:9747a5c1073002cae69cf040f872f2bf13c50d30b8335f300cd7781cf3392c73",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54811",
+					"10.65.0.27:54811",
+					"172.17.0.1:54811",
+					"172.18.0.1:54811",
+					"172.19.0.1:54811"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:27:04.007909784Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3179727635831357,
+				"StableID":   "nSRLi547qR11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       3179727635831357,
+				"Key":        "nodekey:93873a6f265369516b791b31da43ee7c380190707090d14a550a0a046d505556",
+				"DiscoKey":   "discokey:03fb81b74f8d517e056a4f8d1aa3522a4adb2094d1f61fa2dacbaa6525af1565",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59237",
+					"10.65.0.27:59237",
+					"172.17.0.1:59237",
+					"172.18.0.1:59237",
+					"172.19.0.1:59237"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:26:58.059202864Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:93873a6f265369516b791b31da43ee7c380190707090d14a550a0a046d505556",
+			"MachineKey": "mkey:03fc8b2c56706d99ad2d950b945157bc967caa133fc9b324ed0ff8b8c0af0813",
+			"Peers": [{
+				"ID":         4300355520635176,
+				"StableID":   "nVP1Vk3eaa11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a61f5a1ff97ecf2aea16bb88b5f41541d530d86b48910b8e37174dc51d809c62",
+				"DiscoKey":   "discokey:81b10f11a5f07eb67e9dc816bfb80a26acf36eaeb6e5a650e82b4777a0f9be52",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36665",
+					"10.65.0.27:36665",
+					"172.17.0.1:36665",
+					"172.18.0.1:36665",
+					"172.19.0.1:36665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:26:57.003292739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5856057653412839,
+				"StableID":   "ncoshrhDjn11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ead443776fde1a0f7a3bfe0ca8702866d2ca969e84f2597f829dd7bf7dc0d33a",
+				"DiscoKey":   "discokey:2e9deedbff60feed8a4f5eb1b2cd13e64fa0e1fbf51c3dece8db4a855b8ec320",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59791",
+					"10.65.0.27:59791",
+					"172.17.0.1:59791",
+					"172.18.0.1:59791",
+					"172.19.0.1:59791"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:26:57.523390736Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8962288194634897,
+				"StableID":   "npC4ra73zC21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:621bec1f2046b31a5e2a33f948386d37f3d7c91ed2c8eaa801d486ff858f672d",
+				"DiscoKey":   "discokey:d36a0d8a70645292ed9210fea89626ae265600dccc466ffb9c365eb4d69b2140",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43022",
+					"10.65.0.27:43022",
+					"172.17.0.1:43022",
+					"172.18.0.1:43022",
+					"172.19.0.1:43022"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:26:58.596366511Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1567973378065028,
+				"StableID":   "nsaX9719FD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f2416fd8a0d9765d31f5070326169834973024c10bce7a31ab05a8bcc4534524",
+				"DiscoKey":   "discokey:683485c665d2db159ab205e07d8c53e0aab258dce4929d97be7fc1712b2ce77d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57727",
+					"10.65.0.27:57727",
+					"172.17.0.1:57727",
+					"172.18.0.1:57727",
+					"172.19.0.1:57727"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:26:59.141229457Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3016134210607158,
+				"StableID":   "nVcevQj1ZQ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f4fc7cbdaabee95996343c27024bf620c999aa8c032a3a9356a65004cb48e22",
+				"DiscoKey":   "discokey:efb4ece44054a5587b590cf87cfed9ce63ac39e49a6dfd0fd4eec36d04201e63",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:45813",
+					"10.65.0.27:45813",
+					"172.17.0.1:45813",
+					"172.18.0.1:45813",
+					"172.19.0.1:45813"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:26:59.680343044Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3973102316283284,
+				"StableID":   "njzXSKfR2Y11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6d59e828bd1ec4406027305043ec4681871778203de510295195c5fb0f8ef0b",
+				"DiscoKey":   "discokey:7a725f7db4ffc2294f03ad0e455eb2f558b1aec50079efd82b13eed3bd5a196b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49912",
+					"10.65.0.27:49912",
+					"172.17.0.1:49912",
+					"172.18.0.1:49912",
+					"172.19.0.1:49912"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:27:00.213210359Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         235565068263781,
+				"StableID":   "n86pRutgq211CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80e631a597e3db49772f3290ded999c22b21ea495de69012e934b7e408975f69",
+				"DiscoKey":   "discokey:b95030eef52e66b64b8dd4fc53e3c48ff855c33fce3f6b78a46b7bdd3080b504",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33453",
+					"10.65.0.27:33453",
+					"172.17.0.1:33453",
+					"172.18.0.1:33453",
+					"172.19.0.1:33453"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:27:00.753039236Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6791068477030203,
+				"StableID":   "nWLqPVrg2v11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0d4250e80aa04b003dbcf01dfc364cac29bf1c1bfb954664b3a6db0e2b2f230",
+				"DiscoKey":   "discokey:f54d4791b90bd244fdcdc6fdae6ec7c5834befb57ec2d094e9b7730e06be523d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52371",
+					"10.65.0.27:52371",
+					"172.17.0.1:52371",
+					"172.18.0.1:52371",
+					"172.19.0.1:52371"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:27:01.312466099Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8499398043976277,
+				"StableID":   "nt4rKumPN921CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1175f18a732bca77b79a3613d5170311e610a07ce18109d85b10fe9ca5850517",
+				"DiscoKey":   "discokey:c088813373a00a575c3c71ba23819ba4bb794a8be9808cd5fb09d92f9193f940",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:48977",
+					"10.65.0.27:48977",
+					"172.17.0.1:48977",
+					"172.18.0.1:48977",
+					"172.19.0.1:48977"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:27:01.84587771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7854343063047086,
+				"StableID":   "nTsjYsGFL421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f7dcd979d4bc0aa8458654b069096fd7888a661026053c57c003dbed72adc4c",
+				"DiscoKey":   "discokey:711b65738573fb67a2b4f5ee2d621af5493ae49317515c2614ad5098225ee97e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51364",
+					"10.65.0.27:51364",
+					"172.17.0.1:51364",
+					"172.18.0.1:51364",
+					"172.19.0.1:51364"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:27:02.393646415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5403428179624782,
+				"StableID":   "nwfe4xtDCj11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97356b4b7940089468c4f81076a3eab9940641d95c257df1b64feadf66ef1e56",
+				"DiscoKey":   "discokey:b1edefc8df04ed9768b257b92e20f51a6843dfda822911dcdec17d88d2534c37",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45145",
+					"10.65.0.27:45145",
+					"172.17.0.1:45145",
+					"172.18.0.1:45145",
+					"172.19.0.1:45145"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:27:02.931043851Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         195110116993013,
+				"StableID":   "nJd6vHDNX211CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e05e86118037ecb9d1b8c69598d8555137c0660906164c987abb9a0a590b3462",
+				"KeyExpiry":  "2026-11-09T07:27:03Z",
+				"DiscoKey":   "discokey:d4fef671d7833309d09aeb6367618aba4f60348374d4ea1262024bf8c011f744",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49924",
+					"10.65.0.27:49924",
+					"172.17.0.1:49924",
+					"172.18.0.1:49924",
+					"172.19.0.1:49924"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:27:03.46824726Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1106395205696899,
+				"StableID":   "nEazeJ86e911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3f9f603fee398520b30fe26c0d495861d81435ab17a14d022974b8d839e6480c",
+				"KeyExpiry":  "2026-11-09T07:27:04Z",
+				"DiscoKey":   "discokey:9747a5c1073002cae69cf040f872f2bf13c50d30b8335f300cd7781cf3392c73",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54811",
+					"10.65.0.27:54811",
+					"172.17.0.1:54811",
+					"172.18.0.1:54811",
+					"172.19.0.1:54811"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:27:04.007909784Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5546769760379673,
+				"StableID":   "nSRqhgE9Kk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c31c870b3855ecc7686e1e16dd15135511194115d1bfafdc71930e15988bb37f",
+				"KeyExpiry":  "2026-11-09T07:27:04Z",
+				"DiscoKey":   "discokey:ca07f79f6295772d2daf95472f0541cf641f122546a39103ad3e985df591b459",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57507",
+					"10.65.0.27:57507",
+					"172.17.0.1:57507",
+					"172.18.0.1:57507",
+					"172.19.0.1:57507"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:27:04.557797193Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3179727635831357": {
+				"ID":          3179727635831357,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         235565068263781,
+				"StableID":   "n86pRutgq211CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       235565068263781,
+				"Key":        "nodekey:80e631a597e3db49772f3290ded999c22b21ea495de69012e934b7e408975f69",
+				"DiscoKey":   "discokey:b95030eef52e66b64b8dd4fc53e3c48ff855c33fce3f6b78a46b7bdd3080b504",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33453",
+					"10.65.0.27:33453",
+					"172.17.0.1:33453",
+					"172.18.0.1:33453",
+					"172.19.0.1:33453"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:27:00.753039236Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:80e631a597e3db49772f3290ded999c22b21ea495de69012e934b7e408975f69",
+			"MachineKey": "mkey:dafa422e2e804d427fe1b0ebb444bf6e0aaac8914ad1e7e09678079bbd361c30",
+			"Peers": [{
+				"ID":         4300355520635176,
+				"StableID":   "nVP1Vk3eaa11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a61f5a1ff97ecf2aea16bb88b5f41541d530d86b48910b8e37174dc51d809c62",
+				"DiscoKey":   "discokey:81b10f11a5f07eb67e9dc816bfb80a26acf36eaeb6e5a650e82b4777a0f9be52",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36665",
+					"10.65.0.27:36665",
+					"172.17.0.1:36665",
+					"172.18.0.1:36665",
+					"172.19.0.1:36665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:26:57.003292739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5856057653412839,
+				"StableID":   "ncoshrhDjn11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ead443776fde1a0f7a3bfe0ca8702866d2ca969e84f2597f829dd7bf7dc0d33a",
+				"DiscoKey":   "discokey:2e9deedbff60feed8a4f5eb1b2cd13e64fa0e1fbf51c3dece8db4a855b8ec320",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59791",
+					"10.65.0.27:59791",
+					"172.17.0.1:59791",
+					"172.18.0.1:59791",
+					"172.19.0.1:59791"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:26:57.523390736Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3179727635831357,
+				"StableID":   "nSRLi547qR11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93873a6f265369516b791b31da43ee7c380190707090d14a550a0a046d505556",
+				"DiscoKey":   "discokey:03fb81b74f8d517e056a4f8d1aa3522a4adb2094d1f61fa2dacbaa6525af1565",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59237",
+					"10.65.0.27:59237",
+					"172.17.0.1:59237",
+					"172.18.0.1:59237",
+					"172.19.0.1:59237"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:26:58.059202864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8962288194634897,
+				"StableID":   "npC4ra73zC21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:621bec1f2046b31a5e2a33f948386d37f3d7c91ed2c8eaa801d486ff858f672d",
+				"DiscoKey":   "discokey:d36a0d8a70645292ed9210fea89626ae265600dccc466ffb9c365eb4d69b2140",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43022",
+					"10.65.0.27:43022",
+					"172.17.0.1:43022",
+					"172.18.0.1:43022",
+					"172.19.0.1:43022"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:26:58.596366511Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1567973378065028,
+				"StableID":   "nsaX9719FD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f2416fd8a0d9765d31f5070326169834973024c10bce7a31ab05a8bcc4534524",
+				"DiscoKey":   "discokey:683485c665d2db159ab205e07d8c53e0aab258dce4929d97be7fc1712b2ce77d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57727",
+					"10.65.0.27:57727",
+					"172.17.0.1:57727",
+					"172.18.0.1:57727",
+					"172.19.0.1:57727"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:26:59.141229457Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3016134210607158,
+				"StableID":   "nVcevQj1ZQ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f4fc7cbdaabee95996343c27024bf620c999aa8c032a3a9356a65004cb48e22",
+				"DiscoKey":   "discokey:efb4ece44054a5587b590cf87cfed9ce63ac39e49a6dfd0fd4eec36d04201e63",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:45813",
+					"10.65.0.27:45813",
+					"172.17.0.1:45813",
+					"172.18.0.1:45813",
+					"172.19.0.1:45813"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:26:59.680343044Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3973102316283284,
+				"StableID":   "njzXSKfR2Y11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6d59e828bd1ec4406027305043ec4681871778203de510295195c5fb0f8ef0b",
+				"DiscoKey":   "discokey:7a725f7db4ffc2294f03ad0e455eb2f558b1aec50079efd82b13eed3bd5a196b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49912",
+					"10.65.0.27:49912",
+					"172.17.0.1:49912",
+					"172.18.0.1:49912",
+					"172.19.0.1:49912"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:27:00.213210359Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6791068477030203,
+				"StableID":   "nWLqPVrg2v11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0d4250e80aa04b003dbcf01dfc364cac29bf1c1bfb954664b3a6db0e2b2f230",
+				"DiscoKey":   "discokey:f54d4791b90bd244fdcdc6fdae6ec7c5834befb57ec2d094e9b7730e06be523d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52371",
+					"10.65.0.27:52371",
+					"172.17.0.1:52371",
+					"172.18.0.1:52371",
+					"172.19.0.1:52371"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:27:01.312466099Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8499398043976277,
+				"StableID":   "nt4rKumPN921CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1175f18a732bca77b79a3613d5170311e610a07ce18109d85b10fe9ca5850517",
+				"DiscoKey":   "discokey:c088813373a00a575c3c71ba23819ba4bb794a8be9808cd5fb09d92f9193f940",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:48977",
+					"10.65.0.27:48977",
+					"172.17.0.1:48977",
+					"172.18.0.1:48977",
+					"172.19.0.1:48977"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:27:01.84587771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7854343063047086,
+				"StableID":   "nTsjYsGFL421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f7dcd979d4bc0aa8458654b069096fd7888a661026053c57c003dbed72adc4c",
+				"DiscoKey":   "discokey:711b65738573fb67a2b4f5ee2d621af5493ae49317515c2614ad5098225ee97e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51364",
+					"10.65.0.27:51364",
+					"172.17.0.1:51364",
+					"172.18.0.1:51364",
+					"172.19.0.1:51364"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:27:02.393646415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5403428179624782,
+				"StableID":   "nwfe4xtDCj11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97356b4b7940089468c4f81076a3eab9940641d95c257df1b64feadf66ef1e56",
+				"DiscoKey":   "discokey:b1edefc8df04ed9768b257b92e20f51a6843dfda822911dcdec17d88d2534c37",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45145",
+					"10.65.0.27:45145",
+					"172.17.0.1:45145",
+					"172.18.0.1:45145",
+					"172.19.0.1:45145"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:27:02.931043851Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         195110116993013,
+				"StableID":   "nJd6vHDNX211CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e05e86118037ecb9d1b8c69598d8555137c0660906164c987abb9a0a590b3462",
+				"KeyExpiry":  "2026-11-09T07:27:03Z",
+				"DiscoKey":   "discokey:d4fef671d7833309d09aeb6367618aba4f60348374d4ea1262024bf8c011f744",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49924",
+					"10.65.0.27:49924",
+					"172.17.0.1:49924",
+					"172.18.0.1:49924",
+					"172.19.0.1:49924"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:27:03.46824726Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1106395205696899,
+				"StableID":   "nEazeJ86e911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3f9f603fee398520b30fe26c0d495861d81435ab17a14d022974b8d839e6480c",
+				"KeyExpiry":  "2026-11-09T07:27:04Z",
+				"DiscoKey":   "discokey:9747a5c1073002cae69cf040f872f2bf13c50d30b8335f300cd7781cf3392c73",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54811",
+					"10.65.0.27:54811",
+					"172.17.0.1:54811",
+					"172.18.0.1:54811",
+					"172.19.0.1:54811"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:27:04.007909784Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5546769760379673,
+				"StableID":   "nSRqhgE9Kk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c31c870b3855ecc7686e1e16dd15135511194115d1bfafdc71930e15988bb37f",
+				"KeyExpiry":  "2026-11-09T07:27:04Z",
+				"DiscoKey":   "discokey:ca07f79f6295772d2daf95472f0541cf641f122546a39103ad3e985df591b459",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57507",
+					"10.65.0.27:57507",
+					"172.17.0.1:57507",
+					"172.18.0.1:57507",
+					"172.19.0.1:57507"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:27:04.557797193Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "235565068263781": {
+				"ID":          235565068263781,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         195110116993013,
+				"StableID":   "nJd6vHDNX211CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e05e86118037ecb9d1b8c69598d8555137c0660906164c987abb9a0a590b3462",
+				"KeyExpiry":  "2026-11-09T07:27:03Z",
+				"DiscoKey":   "discokey:d4fef671d7833309d09aeb6367618aba4f60348374d4ea1262024bf8c011f744",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49924",
+					"10.65.0.27:49924",
+					"172.17.0.1:49924",
+					"172.18.0.1:49924",
+					"172.19.0.1:49924"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:27:03.46824726Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e05e86118037ecb9d1b8c69598d8555137c0660906164c987abb9a0a590b3462",
+			"MachineKey": "mkey:f3f7c0683c6091efcaaedc0847a5af983548d58813e3e438621979fbd5b04116",
+			"Peers": [{
+				"ID":         4300355520635176,
+				"StableID":   "nVP1Vk3eaa11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a61f5a1ff97ecf2aea16bb88b5f41541d530d86b48910b8e37174dc51d809c62",
+				"DiscoKey":   "discokey:81b10f11a5f07eb67e9dc816bfb80a26acf36eaeb6e5a650e82b4777a0f9be52",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36665",
+					"10.65.0.27:36665",
+					"172.17.0.1:36665",
+					"172.18.0.1:36665",
+					"172.19.0.1:36665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:26:57.003292739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5856057653412839,
+				"StableID":   "ncoshrhDjn11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ead443776fde1a0f7a3bfe0ca8702866d2ca969e84f2597f829dd7bf7dc0d33a",
+				"DiscoKey":   "discokey:2e9deedbff60feed8a4f5eb1b2cd13e64fa0e1fbf51c3dece8db4a855b8ec320",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59791",
+					"10.65.0.27:59791",
+					"172.17.0.1:59791",
+					"172.18.0.1:59791",
+					"172.19.0.1:59791"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:26:57.523390736Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3179727635831357,
+				"StableID":   "nSRLi547qR11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93873a6f265369516b791b31da43ee7c380190707090d14a550a0a046d505556",
+				"DiscoKey":   "discokey:03fb81b74f8d517e056a4f8d1aa3522a4adb2094d1f61fa2dacbaa6525af1565",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59237",
+					"10.65.0.27:59237",
+					"172.17.0.1:59237",
+					"172.18.0.1:59237",
+					"172.19.0.1:59237"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:26:58.059202864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8962288194634897,
+				"StableID":   "npC4ra73zC21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:621bec1f2046b31a5e2a33f948386d37f3d7c91ed2c8eaa801d486ff858f672d",
+				"DiscoKey":   "discokey:d36a0d8a70645292ed9210fea89626ae265600dccc466ffb9c365eb4d69b2140",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43022",
+					"10.65.0.27:43022",
+					"172.17.0.1:43022",
+					"172.18.0.1:43022",
+					"172.19.0.1:43022"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:26:58.596366511Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1567973378065028,
+				"StableID":   "nsaX9719FD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f2416fd8a0d9765d31f5070326169834973024c10bce7a31ab05a8bcc4534524",
+				"DiscoKey":   "discokey:683485c665d2db159ab205e07d8c53e0aab258dce4929d97be7fc1712b2ce77d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57727",
+					"10.65.0.27:57727",
+					"172.17.0.1:57727",
+					"172.18.0.1:57727",
+					"172.19.0.1:57727"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:26:59.141229457Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3016134210607158,
+				"StableID":   "nVcevQj1ZQ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f4fc7cbdaabee95996343c27024bf620c999aa8c032a3a9356a65004cb48e22",
+				"DiscoKey":   "discokey:efb4ece44054a5587b590cf87cfed9ce63ac39e49a6dfd0fd4eec36d04201e63",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:45813",
+					"10.65.0.27:45813",
+					"172.17.0.1:45813",
+					"172.18.0.1:45813",
+					"172.19.0.1:45813"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:26:59.680343044Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3973102316283284,
+				"StableID":   "njzXSKfR2Y11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6d59e828bd1ec4406027305043ec4681871778203de510295195c5fb0f8ef0b",
+				"DiscoKey":   "discokey:7a725f7db4ffc2294f03ad0e455eb2f558b1aec50079efd82b13eed3bd5a196b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49912",
+					"10.65.0.27:49912",
+					"172.17.0.1:49912",
+					"172.18.0.1:49912",
+					"172.19.0.1:49912"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:27:00.213210359Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         235565068263781,
+				"StableID":   "n86pRutgq211CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80e631a597e3db49772f3290ded999c22b21ea495de69012e934b7e408975f69",
+				"DiscoKey":   "discokey:b95030eef52e66b64b8dd4fc53e3c48ff855c33fce3f6b78a46b7bdd3080b504",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33453",
+					"10.65.0.27:33453",
+					"172.17.0.1:33453",
+					"172.18.0.1:33453",
+					"172.19.0.1:33453"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:27:00.753039236Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6791068477030203,
+				"StableID":   "nWLqPVrg2v11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0d4250e80aa04b003dbcf01dfc364cac29bf1c1bfb954664b3a6db0e2b2f230",
+				"DiscoKey":   "discokey:f54d4791b90bd244fdcdc6fdae6ec7c5834befb57ec2d094e9b7730e06be523d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52371",
+					"10.65.0.27:52371",
+					"172.17.0.1:52371",
+					"172.18.0.1:52371",
+					"172.19.0.1:52371"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:27:01.312466099Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8499398043976277,
+				"StableID":   "nt4rKumPN921CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1175f18a732bca77b79a3613d5170311e610a07ce18109d85b10fe9ca5850517",
+				"DiscoKey":   "discokey:c088813373a00a575c3c71ba23819ba4bb794a8be9808cd5fb09d92f9193f940",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:48977",
+					"10.65.0.27:48977",
+					"172.17.0.1:48977",
+					"172.18.0.1:48977",
+					"172.19.0.1:48977"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:27:01.84587771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7854343063047086,
+				"StableID":   "nTsjYsGFL421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f7dcd979d4bc0aa8458654b069096fd7888a661026053c57c003dbed72adc4c",
+				"DiscoKey":   "discokey:711b65738573fb67a2b4f5ee2d621af5493ae49317515c2614ad5098225ee97e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51364",
+					"10.65.0.27:51364",
+					"172.17.0.1:51364",
+					"172.18.0.1:51364",
+					"172.19.0.1:51364"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:27:02.393646415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5403428179624782,
+				"StableID":   "nwfe4xtDCj11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97356b4b7940089468c4f81076a3eab9940641d95c257df1b64feadf66ef1e56",
+				"DiscoKey":   "discokey:b1edefc8df04ed9768b257b92e20f51a6843dfda822911dcdec17d88d2534c37",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45145",
+					"10.65.0.27:45145",
+					"172.17.0.1:45145",
+					"172.18.0.1:45145",
+					"172.19.0.1:45145"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:27:02.931043851Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1106395205696899,
+				"StableID":   "nEazeJ86e911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3f9f603fee398520b30fe26c0d495861d81435ab17a14d022974b8d839e6480c",
+				"KeyExpiry":  "2026-11-09T07:27:04Z",
+				"DiscoKey":   "discokey:9747a5c1073002cae69cf040f872f2bf13c50d30b8335f300cd7781cf3392c73",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54811",
+					"10.65.0.27:54811",
+					"172.17.0.1:54811",
+					"172.18.0.1:54811",
+					"172.19.0.1:54811"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:27:04.007909784Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5546769760379673,
+				"StableID":   "nSRqhgE9Kk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c31c870b3855ecc7686e1e16dd15135511194115d1bfafdc71930e15988bb37f",
+				"KeyExpiry":  "2026-11-09T07:27:04Z",
+				"DiscoKey":   "discokey:ca07f79f6295772d2daf95472f0541cf641f122546a39103ad3e985df591b459",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57507",
+					"10.65.0.27:57507",
+					"172.17.0.1:57507",
+					"172.18.0.1:57507",
+					"172.19.0.1:57507"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:27:04.557797193Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7854343063047086,
+				"StableID":   "nTsjYsGFL421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       7854343063047086,
+				"Key":        "nodekey:0f7dcd979d4bc0aa8458654b069096fd7888a661026053c57c003dbed72adc4c",
+				"DiscoKey":   "discokey:711b65738573fb67a2b4f5ee2d621af5493ae49317515c2614ad5098225ee97e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51364",
+					"10.65.0.27:51364",
+					"172.17.0.1:51364",
+					"172.18.0.1:51364",
+					"172.19.0.1:51364"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:27:02.393646415Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0f7dcd979d4bc0aa8458654b069096fd7888a661026053c57c003dbed72adc4c",
+			"MachineKey": "mkey:fe9e3d946bb77ed9c363d8d0af67b2726706ab2dd8a2e7a8f7d8f90e7d6c8713",
+			"Peers": [{
+				"ID":         4300355520635176,
+				"StableID":   "nVP1Vk3eaa11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a61f5a1ff97ecf2aea16bb88b5f41541d530d86b48910b8e37174dc51d809c62",
+				"DiscoKey":   "discokey:81b10f11a5f07eb67e9dc816bfb80a26acf36eaeb6e5a650e82b4777a0f9be52",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36665",
+					"10.65.0.27:36665",
+					"172.17.0.1:36665",
+					"172.18.0.1:36665",
+					"172.19.0.1:36665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:26:57.003292739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5856057653412839,
+				"StableID":   "ncoshrhDjn11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ead443776fde1a0f7a3bfe0ca8702866d2ca969e84f2597f829dd7bf7dc0d33a",
+				"DiscoKey":   "discokey:2e9deedbff60feed8a4f5eb1b2cd13e64fa0e1fbf51c3dece8db4a855b8ec320",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59791",
+					"10.65.0.27:59791",
+					"172.17.0.1:59791",
+					"172.18.0.1:59791",
+					"172.19.0.1:59791"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:26:57.523390736Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3179727635831357,
+				"StableID":   "nSRLi547qR11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93873a6f265369516b791b31da43ee7c380190707090d14a550a0a046d505556",
+				"DiscoKey":   "discokey:03fb81b74f8d517e056a4f8d1aa3522a4adb2094d1f61fa2dacbaa6525af1565",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59237",
+					"10.65.0.27:59237",
+					"172.17.0.1:59237",
+					"172.18.0.1:59237",
+					"172.19.0.1:59237"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:26:58.059202864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8962288194634897,
+				"StableID":   "npC4ra73zC21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:621bec1f2046b31a5e2a33f948386d37f3d7c91ed2c8eaa801d486ff858f672d",
+				"DiscoKey":   "discokey:d36a0d8a70645292ed9210fea89626ae265600dccc466ffb9c365eb4d69b2140",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43022",
+					"10.65.0.27:43022",
+					"172.17.0.1:43022",
+					"172.18.0.1:43022",
+					"172.19.0.1:43022"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:26:58.596366511Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1567973378065028,
+				"StableID":   "nsaX9719FD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f2416fd8a0d9765d31f5070326169834973024c10bce7a31ab05a8bcc4534524",
+				"DiscoKey":   "discokey:683485c665d2db159ab205e07d8c53e0aab258dce4929d97be7fc1712b2ce77d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57727",
+					"10.65.0.27:57727",
+					"172.17.0.1:57727",
+					"172.18.0.1:57727",
+					"172.19.0.1:57727"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:26:59.141229457Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3016134210607158,
+				"StableID":   "nVcevQj1ZQ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f4fc7cbdaabee95996343c27024bf620c999aa8c032a3a9356a65004cb48e22",
+				"DiscoKey":   "discokey:efb4ece44054a5587b590cf87cfed9ce63ac39e49a6dfd0fd4eec36d04201e63",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:45813",
+					"10.65.0.27:45813",
+					"172.17.0.1:45813",
+					"172.18.0.1:45813",
+					"172.19.0.1:45813"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:26:59.680343044Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3973102316283284,
+				"StableID":   "njzXSKfR2Y11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6d59e828bd1ec4406027305043ec4681871778203de510295195c5fb0f8ef0b",
+				"DiscoKey":   "discokey:7a725f7db4ffc2294f03ad0e455eb2f558b1aec50079efd82b13eed3bd5a196b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49912",
+					"10.65.0.27:49912",
+					"172.17.0.1:49912",
+					"172.18.0.1:49912",
+					"172.19.0.1:49912"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:27:00.213210359Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         235565068263781,
+				"StableID":   "n86pRutgq211CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80e631a597e3db49772f3290ded999c22b21ea495de69012e934b7e408975f69",
+				"DiscoKey":   "discokey:b95030eef52e66b64b8dd4fc53e3c48ff855c33fce3f6b78a46b7bdd3080b504",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33453",
+					"10.65.0.27:33453",
+					"172.17.0.1:33453",
+					"172.18.0.1:33453",
+					"172.19.0.1:33453"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:27:00.753039236Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6791068477030203,
+				"StableID":   "nWLqPVrg2v11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0d4250e80aa04b003dbcf01dfc364cac29bf1c1bfb954664b3a6db0e2b2f230",
+				"DiscoKey":   "discokey:f54d4791b90bd244fdcdc6fdae6ec7c5834befb57ec2d094e9b7730e06be523d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52371",
+					"10.65.0.27:52371",
+					"172.17.0.1:52371",
+					"172.18.0.1:52371",
+					"172.19.0.1:52371"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:27:01.312466099Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8499398043976277,
+				"StableID":   "nt4rKumPN921CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1175f18a732bca77b79a3613d5170311e610a07ce18109d85b10fe9ca5850517",
+				"DiscoKey":   "discokey:c088813373a00a575c3c71ba23819ba4bb794a8be9808cd5fb09d92f9193f940",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:48977",
+					"10.65.0.27:48977",
+					"172.17.0.1:48977",
+					"172.18.0.1:48977",
+					"172.19.0.1:48977"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:27:01.84587771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5403428179624782,
+				"StableID":   "nwfe4xtDCj11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97356b4b7940089468c4f81076a3eab9940641d95c257df1b64feadf66ef1e56",
+				"DiscoKey":   "discokey:b1edefc8df04ed9768b257b92e20f51a6843dfda822911dcdec17d88d2534c37",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45145",
+					"10.65.0.27:45145",
+					"172.17.0.1:45145",
+					"172.18.0.1:45145",
+					"172.19.0.1:45145"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:27:02.931043851Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         195110116993013,
+				"StableID":   "nJd6vHDNX211CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e05e86118037ecb9d1b8c69598d8555137c0660906164c987abb9a0a590b3462",
+				"KeyExpiry":  "2026-11-09T07:27:03Z",
+				"DiscoKey":   "discokey:d4fef671d7833309d09aeb6367618aba4f60348374d4ea1262024bf8c011f744",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49924",
+					"10.65.0.27:49924",
+					"172.17.0.1:49924",
+					"172.18.0.1:49924",
+					"172.19.0.1:49924"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:27:03.46824726Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1106395205696899,
+				"StableID":   "nEazeJ86e911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3f9f603fee398520b30fe26c0d495861d81435ab17a14d022974b8d839e6480c",
+				"KeyExpiry":  "2026-11-09T07:27:04Z",
+				"DiscoKey":   "discokey:9747a5c1073002cae69cf040f872f2bf13c50d30b8335f300cd7781cf3392c73",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54811",
+					"10.65.0.27:54811",
+					"172.17.0.1:54811",
+					"172.18.0.1:54811",
+					"172.19.0.1:54811"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:27:04.007909784Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5546769760379673,
+				"StableID":   "nSRqhgE9Kk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c31c870b3855ecc7686e1e16dd15135511194115d1bfafdc71930e15988bb37f",
+				"KeyExpiry":  "2026-11-09T07:27:04Z",
+				"DiscoKey":   "discokey:ca07f79f6295772d2daf95472f0541cf641f122546a39103ad3e985df591b459",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57507",
+					"10.65.0.27:57507",
+					"172.17.0.1:57507",
+					"172.18.0.1:57507",
+					"172.19.0.1:57507"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:27:04.557797193Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7854343063047086": {
+				"ID":          7854343063047086,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5856057653412839,
+				"StableID":   "ncoshrhDjn11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       5856057653412839,
+				"Key":        "nodekey:ead443776fde1a0f7a3bfe0ca8702866d2ca969e84f2597f829dd7bf7dc0d33a",
+				"DiscoKey":   "discokey:2e9deedbff60feed8a4f5eb1b2cd13e64fa0e1fbf51c3dece8db4a855b8ec320",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59791",
+					"10.65.0.27:59791",
+					"172.17.0.1:59791",
+					"172.18.0.1:59791",
+					"172.19.0.1:59791"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:26:57.523390736Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ead443776fde1a0f7a3bfe0ca8702866d2ca969e84f2597f829dd7bf7dc0d33a",
+			"MachineKey": "mkey:39779adcbb4b2f534915e64fb4c1de3ec4da45e3c9e926a0f160bb4fd9f8397a",
+			"Peers": [{
+				"ID":         4300355520635176,
+				"StableID":   "nVP1Vk3eaa11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a61f5a1ff97ecf2aea16bb88b5f41541d530d86b48910b8e37174dc51d809c62",
+				"DiscoKey":   "discokey:81b10f11a5f07eb67e9dc816bfb80a26acf36eaeb6e5a650e82b4777a0f9be52",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36665",
+					"10.65.0.27:36665",
+					"172.17.0.1:36665",
+					"172.18.0.1:36665",
+					"172.19.0.1:36665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:26:57.003292739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3179727635831357,
+				"StableID":   "nSRLi547qR11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93873a6f265369516b791b31da43ee7c380190707090d14a550a0a046d505556",
+				"DiscoKey":   "discokey:03fb81b74f8d517e056a4f8d1aa3522a4adb2094d1f61fa2dacbaa6525af1565",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59237",
+					"10.65.0.27:59237",
+					"172.17.0.1:59237",
+					"172.18.0.1:59237",
+					"172.19.0.1:59237"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:26:58.059202864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8962288194634897,
+				"StableID":   "npC4ra73zC21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:621bec1f2046b31a5e2a33f948386d37f3d7c91ed2c8eaa801d486ff858f672d",
+				"DiscoKey":   "discokey:d36a0d8a70645292ed9210fea89626ae265600dccc466ffb9c365eb4d69b2140",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43022",
+					"10.65.0.27:43022",
+					"172.17.0.1:43022",
+					"172.18.0.1:43022",
+					"172.19.0.1:43022"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:26:58.596366511Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1567973378065028,
+				"StableID":   "nsaX9719FD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f2416fd8a0d9765d31f5070326169834973024c10bce7a31ab05a8bcc4534524",
+				"DiscoKey":   "discokey:683485c665d2db159ab205e07d8c53e0aab258dce4929d97be7fc1712b2ce77d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57727",
+					"10.65.0.27:57727",
+					"172.17.0.1:57727",
+					"172.18.0.1:57727",
+					"172.19.0.1:57727"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:26:59.141229457Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3016134210607158,
+				"StableID":   "nVcevQj1ZQ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f4fc7cbdaabee95996343c27024bf620c999aa8c032a3a9356a65004cb48e22",
+				"DiscoKey":   "discokey:efb4ece44054a5587b590cf87cfed9ce63ac39e49a6dfd0fd4eec36d04201e63",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:45813",
+					"10.65.0.27:45813",
+					"172.17.0.1:45813",
+					"172.18.0.1:45813",
+					"172.19.0.1:45813"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:26:59.680343044Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3973102316283284,
+				"StableID":   "njzXSKfR2Y11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6d59e828bd1ec4406027305043ec4681871778203de510295195c5fb0f8ef0b",
+				"DiscoKey":   "discokey:7a725f7db4ffc2294f03ad0e455eb2f558b1aec50079efd82b13eed3bd5a196b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49912",
+					"10.65.0.27:49912",
+					"172.17.0.1:49912",
+					"172.18.0.1:49912",
+					"172.19.0.1:49912"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:27:00.213210359Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         235565068263781,
+				"StableID":   "n86pRutgq211CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80e631a597e3db49772f3290ded999c22b21ea495de69012e934b7e408975f69",
+				"DiscoKey":   "discokey:b95030eef52e66b64b8dd4fc53e3c48ff855c33fce3f6b78a46b7bdd3080b504",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33453",
+					"10.65.0.27:33453",
+					"172.17.0.1:33453",
+					"172.18.0.1:33453",
+					"172.19.0.1:33453"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:27:00.753039236Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6791068477030203,
+				"StableID":   "nWLqPVrg2v11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0d4250e80aa04b003dbcf01dfc364cac29bf1c1bfb954664b3a6db0e2b2f230",
+				"DiscoKey":   "discokey:f54d4791b90bd244fdcdc6fdae6ec7c5834befb57ec2d094e9b7730e06be523d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52371",
+					"10.65.0.27:52371",
+					"172.17.0.1:52371",
+					"172.18.0.1:52371",
+					"172.19.0.1:52371"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:27:01.312466099Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8499398043976277,
+				"StableID":   "nt4rKumPN921CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1175f18a732bca77b79a3613d5170311e610a07ce18109d85b10fe9ca5850517",
+				"DiscoKey":   "discokey:c088813373a00a575c3c71ba23819ba4bb794a8be9808cd5fb09d92f9193f940",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:48977",
+					"10.65.0.27:48977",
+					"172.17.0.1:48977",
+					"172.18.0.1:48977",
+					"172.19.0.1:48977"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:27:01.84587771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7854343063047086,
+				"StableID":   "nTsjYsGFL421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f7dcd979d4bc0aa8458654b069096fd7888a661026053c57c003dbed72adc4c",
+				"DiscoKey":   "discokey:711b65738573fb67a2b4f5ee2d621af5493ae49317515c2614ad5098225ee97e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51364",
+					"10.65.0.27:51364",
+					"172.17.0.1:51364",
+					"172.18.0.1:51364",
+					"172.19.0.1:51364"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:27:02.393646415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5403428179624782,
+				"StableID":   "nwfe4xtDCj11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97356b4b7940089468c4f81076a3eab9940641d95c257df1b64feadf66ef1e56",
+				"DiscoKey":   "discokey:b1edefc8df04ed9768b257b92e20f51a6843dfda822911dcdec17d88d2534c37",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45145",
+					"10.65.0.27:45145",
+					"172.17.0.1:45145",
+					"172.18.0.1:45145",
+					"172.19.0.1:45145"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:27:02.931043851Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         195110116993013,
+				"StableID":   "nJd6vHDNX211CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e05e86118037ecb9d1b8c69598d8555137c0660906164c987abb9a0a590b3462",
+				"KeyExpiry":  "2026-11-09T07:27:03Z",
+				"DiscoKey":   "discokey:d4fef671d7833309d09aeb6367618aba4f60348374d4ea1262024bf8c011f744",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49924",
+					"10.65.0.27:49924",
+					"172.17.0.1:49924",
+					"172.18.0.1:49924",
+					"172.19.0.1:49924"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:27:03.46824726Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1106395205696899,
+				"StableID":   "nEazeJ86e911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3f9f603fee398520b30fe26c0d495861d81435ab17a14d022974b8d839e6480c",
+				"KeyExpiry":  "2026-11-09T07:27:04Z",
+				"DiscoKey":   "discokey:9747a5c1073002cae69cf040f872f2bf13c50d30b8335f300cd7781cf3392c73",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54811",
+					"10.65.0.27:54811",
+					"172.17.0.1:54811",
+					"172.18.0.1:54811",
+					"172.19.0.1:54811"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:27:04.007909784Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5546769760379673,
+				"StableID":   "nSRqhgE9Kk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c31c870b3855ecc7686e1e16dd15135511194115d1bfafdc71930e15988bb37f",
+				"KeyExpiry":  "2026-11-09T07:27:04Z",
+				"DiscoKey":   "discokey:ca07f79f6295772d2daf95472f0541cf641f122546a39103ad3e985df591b459",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57507",
+					"10.65.0.27:57507",
+					"172.17.0.1:57507",
+					"172.18.0.1:57507",
+					"172.19.0.1:57507"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:27:04.557797193Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5856057653412839": {
+				"ID":          5856057653412839,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4300355520635176,
+				"StableID":   "nVP1Vk3eaa11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       4300355520635176,
+				"Key":        "nodekey:a61f5a1ff97ecf2aea16bb88b5f41541d530d86b48910b8e37174dc51d809c62",
+				"DiscoKey":   "discokey:81b10f11a5f07eb67e9dc816bfb80a26acf36eaeb6e5a650e82b4777a0f9be52",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36665",
+					"10.65.0.27:36665",
+					"172.17.0.1:36665",
+					"172.18.0.1:36665",
+					"172.19.0.1:36665"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:26:57.003292739Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a61f5a1ff97ecf2aea16bb88b5f41541d530d86b48910b8e37174dc51d809c62",
+			"MachineKey": "mkey:74edc9b32db9fc30a4518904a88b2bf488eff6d927c6b8505ef32ec8ec655c7e",
+			"Peers": [{
+				"ID":         5856057653412839,
+				"StableID":   "ncoshrhDjn11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ead443776fde1a0f7a3bfe0ca8702866d2ca969e84f2597f829dd7bf7dc0d33a",
+				"DiscoKey":   "discokey:2e9deedbff60feed8a4f5eb1b2cd13e64fa0e1fbf51c3dece8db4a855b8ec320",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59791",
+					"10.65.0.27:59791",
+					"172.17.0.1:59791",
+					"172.18.0.1:59791",
+					"172.19.0.1:59791"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:26:57.523390736Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3179727635831357,
+				"StableID":   "nSRLi547qR11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93873a6f265369516b791b31da43ee7c380190707090d14a550a0a046d505556",
+				"DiscoKey":   "discokey:03fb81b74f8d517e056a4f8d1aa3522a4adb2094d1f61fa2dacbaa6525af1565",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59237",
+					"10.65.0.27:59237",
+					"172.17.0.1:59237",
+					"172.18.0.1:59237",
+					"172.19.0.1:59237"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:26:58.059202864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8962288194634897,
+				"StableID":   "npC4ra73zC21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:621bec1f2046b31a5e2a33f948386d37f3d7c91ed2c8eaa801d486ff858f672d",
+				"DiscoKey":   "discokey:d36a0d8a70645292ed9210fea89626ae265600dccc466ffb9c365eb4d69b2140",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43022",
+					"10.65.0.27:43022",
+					"172.17.0.1:43022",
+					"172.18.0.1:43022",
+					"172.19.0.1:43022"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:26:58.596366511Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1567973378065028,
+				"StableID":   "nsaX9719FD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f2416fd8a0d9765d31f5070326169834973024c10bce7a31ab05a8bcc4534524",
+				"DiscoKey":   "discokey:683485c665d2db159ab205e07d8c53e0aab258dce4929d97be7fc1712b2ce77d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57727",
+					"10.65.0.27:57727",
+					"172.17.0.1:57727",
+					"172.18.0.1:57727",
+					"172.19.0.1:57727"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:26:59.141229457Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3016134210607158,
+				"StableID":   "nVcevQj1ZQ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f4fc7cbdaabee95996343c27024bf620c999aa8c032a3a9356a65004cb48e22",
+				"DiscoKey":   "discokey:efb4ece44054a5587b590cf87cfed9ce63ac39e49a6dfd0fd4eec36d04201e63",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:45813",
+					"10.65.0.27:45813",
+					"172.17.0.1:45813",
+					"172.18.0.1:45813",
+					"172.19.0.1:45813"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:26:59.680343044Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3973102316283284,
+				"StableID":   "njzXSKfR2Y11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6d59e828bd1ec4406027305043ec4681871778203de510295195c5fb0f8ef0b",
+				"DiscoKey":   "discokey:7a725f7db4ffc2294f03ad0e455eb2f558b1aec50079efd82b13eed3bd5a196b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49912",
+					"10.65.0.27:49912",
+					"172.17.0.1:49912",
+					"172.18.0.1:49912",
+					"172.19.0.1:49912"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:27:00.213210359Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         235565068263781,
+				"StableID":   "n86pRutgq211CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80e631a597e3db49772f3290ded999c22b21ea495de69012e934b7e408975f69",
+				"DiscoKey":   "discokey:b95030eef52e66b64b8dd4fc53e3c48ff855c33fce3f6b78a46b7bdd3080b504",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33453",
+					"10.65.0.27:33453",
+					"172.17.0.1:33453",
+					"172.18.0.1:33453",
+					"172.19.0.1:33453"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:27:00.753039236Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6791068477030203,
+				"StableID":   "nWLqPVrg2v11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0d4250e80aa04b003dbcf01dfc364cac29bf1c1bfb954664b3a6db0e2b2f230",
+				"DiscoKey":   "discokey:f54d4791b90bd244fdcdc6fdae6ec7c5834befb57ec2d094e9b7730e06be523d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52371",
+					"10.65.0.27:52371",
+					"172.17.0.1:52371",
+					"172.18.0.1:52371",
+					"172.19.0.1:52371"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:27:01.312466099Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8499398043976277,
+				"StableID":   "nt4rKumPN921CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1175f18a732bca77b79a3613d5170311e610a07ce18109d85b10fe9ca5850517",
+				"DiscoKey":   "discokey:c088813373a00a575c3c71ba23819ba4bb794a8be9808cd5fb09d92f9193f940",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:48977",
+					"10.65.0.27:48977",
+					"172.17.0.1:48977",
+					"172.18.0.1:48977",
+					"172.19.0.1:48977"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:27:01.84587771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7854343063047086,
+				"StableID":   "nTsjYsGFL421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f7dcd979d4bc0aa8458654b069096fd7888a661026053c57c003dbed72adc4c",
+				"DiscoKey":   "discokey:711b65738573fb67a2b4f5ee2d621af5493ae49317515c2614ad5098225ee97e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51364",
+					"10.65.0.27:51364",
+					"172.17.0.1:51364",
+					"172.18.0.1:51364",
+					"172.19.0.1:51364"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:27:02.393646415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5403428179624782,
+				"StableID":   "nwfe4xtDCj11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97356b4b7940089468c4f81076a3eab9940641d95c257df1b64feadf66ef1e56",
+				"DiscoKey":   "discokey:b1edefc8df04ed9768b257b92e20f51a6843dfda822911dcdec17d88d2534c37",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45145",
+					"10.65.0.27:45145",
+					"172.17.0.1:45145",
+					"172.18.0.1:45145",
+					"172.19.0.1:45145"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:27:02.931043851Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         195110116993013,
+				"StableID":   "nJd6vHDNX211CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e05e86118037ecb9d1b8c69598d8555137c0660906164c987abb9a0a590b3462",
+				"KeyExpiry":  "2026-11-09T07:27:03Z",
+				"DiscoKey":   "discokey:d4fef671d7833309d09aeb6367618aba4f60348374d4ea1262024bf8c011f744",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49924",
+					"10.65.0.27:49924",
+					"172.17.0.1:49924",
+					"172.18.0.1:49924",
+					"172.19.0.1:49924"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:27:03.46824726Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1106395205696899,
+				"StableID":   "nEazeJ86e911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3f9f603fee398520b30fe26c0d495861d81435ab17a14d022974b8d839e6480c",
+				"KeyExpiry":  "2026-11-09T07:27:04Z",
+				"DiscoKey":   "discokey:9747a5c1073002cae69cf040f872f2bf13c50d30b8335f300cd7781cf3392c73",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54811",
+					"10.65.0.27:54811",
+					"172.17.0.1:54811",
+					"172.18.0.1:54811",
+					"172.19.0.1:54811"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:27:04.007909784Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5546769760379673,
+				"StableID":   "nSRqhgE9Kk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c31c870b3855ecc7686e1e16dd15135511194115d1bfafdc71930e15988bb37f",
+				"KeyExpiry":  "2026-11-09T07:27:04Z",
+				"DiscoKey":   "discokey:ca07f79f6295772d2daf95472f0541cf641f122546a39103ad3e985df591b459",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57507",
+					"10.65.0.27:57507",
+					"172.17.0.1:57507",
+					"172.18.0.1:57507",
+					"172.19.0.1:57507"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:27:04.557797193Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4300355520635176": {
+				"ID":          4300355520635176,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1567973378065028,
+				"StableID":   "nsaX9719FD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1567973378065028,
+				"Key":        "nodekey:f2416fd8a0d9765d31f5070326169834973024c10bce7a31ab05a8bcc4534524",
+				"DiscoKey":   "discokey:683485c665d2db159ab205e07d8c53e0aab258dce4929d97be7fc1712b2ce77d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57727",
+					"10.65.0.27:57727",
+					"172.17.0.1:57727",
+					"172.18.0.1:57727",
+					"172.19.0.1:57727"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:26:59.141229457Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f2416fd8a0d9765d31f5070326169834973024c10bce7a31ab05a8bcc4534524",
+			"MachineKey": "mkey:fddf4ba1a45c6ce11c12d3774bc5ee6491ef98b1027ee25f7ed04c4a953d092b",
+			"Peers": [{
+				"ID":         4300355520635176,
+				"StableID":   "nVP1Vk3eaa11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a61f5a1ff97ecf2aea16bb88b5f41541d530d86b48910b8e37174dc51d809c62",
+				"DiscoKey":   "discokey:81b10f11a5f07eb67e9dc816bfb80a26acf36eaeb6e5a650e82b4777a0f9be52",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36665",
+					"10.65.0.27:36665",
+					"172.17.0.1:36665",
+					"172.18.0.1:36665",
+					"172.19.0.1:36665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:26:57.003292739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5856057653412839,
+				"StableID":   "ncoshrhDjn11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ead443776fde1a0f7a3bfe0ca8702866d2ca969e84f2597f829dd7bf7dc0d33a",
+				"DiscoKey":   "discokey:2e9deedbff60feed8a4f5eb1b2cd13e64fa0e1fbf51c3dece8db4a855b8ec320",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59791",
+					"10.65.0.27:59791",
+					"172.17.0.1:59791",
+					"172.18.0.1:59791",
+					"172.19.0.1:59791"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:26:57.523390736Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3179727635831357,
+				"StableID":   "nSRLi547qR11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93873a6f265369516b791b31da43ee7c380190707090d14a550a0a046d505556",
+				"DiscoKey":   "discokey:03fb81b74f8d517e056a4f8d1aa3522a4adb2094d1f61fa2dacbaa6525af1565",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59237",
+					"10.65.0.27:59237",
+					"172.17.0.1:59237",
+					"172.18.0.1:59237",
+					"172.19.0.1:59237"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:26:58.059202864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8962288194634897,
+				"StableID":   "npC4ra73zC21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:621bec1f2046b31a5e2a33f948386d37f3d7c91ed2c8eaa801d486ff858f672d",
+				"DiscoKey":   "discokey:d36a0d8a70645292ed9210fea89626ae265600dccc466ffb9c365eb4d69b2140",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43022",
+					"10.65.0.27:43022",
+					"172.17.0.1:43022",
+					"172.18.0.1:43022",
+					"172.19.0.1:43022"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:26:58.596366511Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3016134210607158,
+				"StableID":   "nVcevQj1ZQ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f4fc7cbdaabee95996343c27024bf620c999aa8c032a3a9356a65004cb48e22",
+				"DiscoKey":   "discokey:efb4ece44054a5587b590cf87cfed9ce63ac39e49a6dfd0fd4eec36d04201e63",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:45813",
+					"10.65.0.27:45813",
+					"172.17.0.1:45813",
+					"172.18.0.1:45813",
+					"172.19.0.1:45813"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:26:59.680343044Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3973102316283284,
+				"StableID":   "njzXSKfR2Y11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6d59e828bd1ec4406027305043ec4681871778203de510295195c5fb0f8ef0b",
+				"DiscoKey":   "discokey:7a725f7db4ffc2294f03ad0e455eb2f558b1aec50079efd82b13eed3bd5a196b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49912",
+					"10.65.0.27:49912",
+					"172.17.0.1:49912",
+					"172.18.0.1:49912",
+					"172.19.0.1:49912"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:27:00.213210359Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         235565068263781,
+				"StableID":   "n86pRutgq211CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80e631a597e3db49772f3290ded999c22b21ea495de69012e934b7e408975f69",
+				"DiscoKey":   "discokey:b95030eef52e66b64b8dd4fc53e3c48ff855c33fce3f6b78a46b7bdd3080b504",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33453",
+					"10.65.0.27:33453",
+					"172.17.0.1:33453",
+					"172.18.0.1:33453",
+					"172.19.0.1:33453"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:27:00.753039236Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6791068477030203,
+				"StableID":   "nWLqPVrg2v11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0d4250e80aa04b003dbcf01dfc364cac29bf1c1bfb954664b3a6db0e2b2f230",
+				"DiscoKey":   "discokey:f54d4791b90bd244fdcdc6fdae6ec7c5834befb57ec2d094e9b7730e06be523d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52371",
+					"10.65.0.27:52371",
+					"172.17.0.1:52371",
+					"172.18.0.1:52371",
+					"172.19.0.1:52371"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:27:01.312466099Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8499398043976277,
+				"StableID":   "nt4rKumPN921CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1175f18a732bca77b79a3613d5170311e610a07ce18109d85b10fe9ca5850517",
+				"DiscoKey":   "discokey:c088813373a00a575c3c71ba23819ba4bb794a8be9808cd5fb09d92f9193f940",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:48977",
+					"10.65.0.27:48977",
+					"172.17.0.1:48977",
+					"172.18.0.1:48977",
+					"172.19.0.1:48977"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:27:01.84587771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7854343063047086,
+				"StableID":   "nTsjYsGFL421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f7dcd979d4bc0aa8458654b069096fd7888a661026053c57c003dbed72adc4c",
+				"DiscoKey":   "discokey:711b65738573fb67a2b4f5ee2d621af5493ae49317515c2614ad5098225ee97e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51364",
+					"10.65.0.27:51364",
+					"172.17.0.1:51364",
+					"172.18.0.1:51364",
+					"172.19.0.1:51364"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:27:02.393646415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5403428179624782,
+				"StableID":   "nwfe4xtDCj11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97356b4b7940089468c4f81076a3eab9940641d95c257df1b64feadf66ef1e56",
+				"DiscoKey":   "discokey:b1edefc8df04ed9768b257b92e20f51a6843dfda822911dcdec17d88d2534c37",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45145",
+					"10.65.0.27:45145",
+					"172.17.0.1:45145",
+					"172.18.0.1:45145",
+					"172.19.0.1:45145"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:27:02.931043851Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         195110116993013,
+				"StableID":   "nJd6vHDNX211CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e05e86118037ecb9d1b8c69598d8555137c0660906164c987abb9a0a590b3462",
+				"KeyExpiry":  "2026-11-09T07:27:03Z",
+				"DiscoKey":   "discokey:d4fef671d7833309d09aeb6367618aba4f60348374d4ea1262024bf8c011f744",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49924",
+					"10.65.0.27:49924",
+					"172.17.0.1:49924",
+					"172.18.0.1:49924",
+					"172.19.0.1:49924"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:27:03.46824726Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1106395205696899,
+				"StableID":   "nEazeJ86e911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3f9f603fee398520b30fe26c0d495861d81435ab17a14d022974b8d839e6480c",
+				"KeyExpiry":  "2026-11-09T07:27:04Z",
+				"DiscoKey":   "discokey:9747a5c1073002cae69cf040f872f2bf13c50d30b8335f300cd7781cf3392c73",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54811",
+					"10.65.0.27:54811",
+					"172.17.0.1:54811",
+					"172.18.0.1:54811",
+					"172.19.0.1:54811"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:27:04.007909784Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5546769760379673,
+				"StableID":   "nSRqhgE9Kk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c31c870b3855ecc7686e1e16dd15135511194115d1bfafdc71930e15988bb37f",
+				"KeyExpiry":  "2026-11-09T07:27:04Z",
+				"DiscoKey":   "discokey:ca07f79f6295772d2daf95472f0541cf641f122546a39103ad3e985df591b459",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57507",
+					"10.65.0.27:57507",
+					"172.17.0.1:57507",
+					"172.18.0.1:57507",
+					"172.19.0.1:57507"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:27:04.557797193Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1567973378065028": {
+				"ID":          1567973378065028,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8962288194634897,
+				"StableID":   "npC4ra73zC21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       8962288194634897,
+				"Key":        "nodekey:621bec1f2046b31a5e2a33f948386d37f3d7c91ed2c8eaa801d486ff858f672d",
+				"DiscoKey":   "discokey:d36a0d8a70645292ed9210fea89626ae265600dccc466ffb9c365eb4d69b2140",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43022",
+					"10.65.0.27:43022",
+					"172.17.0.1:43022",
+					"172.18.0.1:43022",
+					"172.19.0.1:43022"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:26:58.596366511Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:621bec1f2046b31a5e2a33f948386d37f3d7c91ed2c8eaa801d486ff858f672d",
+			"MachineKey": "mkey:dcfdb971a40c6e798e50180ccab636d0619df4270cffb8d55e198176160b6e34",
+			"Peers": [{
+				"ID":         4300355520635176,
+				"StableID":   "nVP1Vk3eaa11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a61f5a1ff97ecf2aea16bb88b5f41541d530d86b48910b8e37174dc51d809c62",
+				"DiscoKey":   "discokey:81b10f11a5f07eb67e9dc816bfb80a26acf36eaeb6e5a650e82b4777a0f9be52",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36665",
+					"10.65.0.27:36665",
+					"172.17.0.1:36665",
+					"172.18.0.1:36665",
+					"172.19.0.1:36665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:26:57.003292739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5856057653412839,
+				"StableID":   "ncoshrhDjn11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ead443776fde1a0f7a3bfe0ca8702866d2ca969e84f2597f829dd7bf7dc0d33a",
+				"DiscoKey":   "discokey:2e9deedbff60feed8a4f5eb1b2cd13e64fa0e1fbf51c3dece8db4a855b8ec320",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59791",
+					"10.65.0.27:59791",
+					"172.17.0.1:59791",
+					"172.18.0.1:59791",
+					"172.19.0.1:59791"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:26:57.523390736Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3179727635831357,
+				"StableID":   "nSRLi547qR11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93873a6f265369516b791b31da43ee7c380190707090d14a550a0a046d505556",
+				"DiscoKey":   "discokey:03fb81b74f8d517e056a4f8d1aa3522a4adb2094d1f61fa2dacbaa6525af1565",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59237",
+					"10.65.0.27:59237",
+					"172.17.0.1:59237",
+					"172.18.0.1:59237",
+					"172.19.0.1:59237"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:26:58.059202864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1567973378065028,
+				"StableID":   "nsaX9719FD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f2416fd8a0d9765d31f5070326169834973024c10bce7a31ab05a8bcc4534524",
+				"DiscoKey":   "discokey:683485c665d2db159ab205e07d8c53e0aab258dce4929d97be7fc1712b2ce77d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57727",
+					"10.65.0.27:57727",
+					"172.17.0.1:57727",
+					"172.18.0.1:57727",
+					"172.19.0.1:57727"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:26:59.141229457Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3016134210607158,
+				"StableID":   "nVcevQj1ZQ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f4fc7cbdaabee95996343c27024bf620c999aa8c032a3a9356a65004cb48e22",
+				"DiscoKey":   "discokey:efb4ece44054a5587b590cf87cfed9ce63ac39e49a6dfd0fd4eec36d04201e63",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:45813",
+					"10.65.0.27:45813",
+					"172.17.0.1:45813",
+					"172.18.0.1:45813",
+					"172.19.0.1:45813"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:26:59.680343044Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3973102316283284,
+				"StableID":   "njzXSKfR2Y11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6d59e828bd1ec4406027305043ec4681871778203de510295195c5fb0f8ef0b",
+				"DiscoKey":   "discokey:7a725f7db4ffc2294f03ad0e455eb2f558b1aec50079efd82b13eed3bd5a196b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49912",
+					"10.65.0.27:49912",
+					"172.17.0.1:49912",
+					"172.18.0.1:49912",
+					"172.19.0.1:49912"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:27:00.213210359Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         235565068263781,
+				"StableID":   "n86pRutgq211CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80e631a597e3db49772f3290ded999c22b21ea495de69012e934b7e408975f69",
+				"DiscoKey":   "discokey:b95030eef52e66b64b8dd4fc53e3c48ff855c33fce3f6b78a46b7bdd3080b504",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33453",
+					"10.65.0.27:33453",
+					"172.17.0.1:33453",
+					"172.18.0.1:33453",
+					"172.19.0.1:33453"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:27:00.753039236Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6791068477030203,
+				"StableID":   "nWLqPVrg2v11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0d4250e80aa04b003dbcf01dfc364cac29bf1c1bfb954664b3a6db0e2b2f230",
+				"DiscoKey":   "discokey:f54d4791b90bd244fdcdc6fdae6ec7c5834befb57ec2d094e9b7730e06be523d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52371",
+					"10.65.0.27:52371",
+					"172.17.0.1:52371",
+					"172.18.0.1:52371",
+					"172.19.0.1:52371"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:27:01.312466099Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8499398043976277,
+				"StableID":   "nt4rKumPN921CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1175f18a732bca77b79a3613d5170311e610a07ce18109d85b10fe9ca5850517",
+				"DiscoKey":   "discokey:c088813373a00a575c3c71ba23819ba4bb794a8be9808cd5fb09d92f9193f940",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:48977",
+					"10.65.0.27:48977",
+					"172.17.0.1:48977",
+					"172.18.0.1:48977",
+					"172.19.0.1:48977"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:27:01.84587771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7854343063047086,
+				"StableID":   "nTsjYsGFL421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f7dcd979d4bc0aa8458654b069096fd7888a661026053c57c003dbed72adc4c",
+				"DiscoKey":   "discokey:711b65738573fb67a2b4f5ee2d621af5493ae49317515c2614ad5098225ee97e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51364",
+					"10.65.0.27:51364",
+					"172.17.0.1:51364",
+					"172.18.0.1:51364",
+					"172.19.0.1:51364"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:27:02.393646415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5403428179624782,
+				"StableID":   "nwfe4xtDCj11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97356b4b7940089468c4f81076a3eab9940641d95c257df1b64feadf66ef1e56",
+				"DiscoKey":   "discokey:b1edefc8df04ed9768b257b92e20f51a6843dfda822911dcdec17d88d2534c37",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45145",
+					"10.65.0.27:45145",
+					"172.17.0.1:45145",
+					"172.18.0.1:45145",
+					"172.19.0.1:45145"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:27:02.931043851Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         195110116993013,
+				"StableID":   "nJd6vHDNX211CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e05e86118037ecb9d1b8c69598d8555137c0660906164c987abb9a0a590b3462",
+				"KeyExpiry":  "2026-11-09T07:27:03Z",
+				"DiscoKey":   "discokey:d4fef671d7833309d09aeb6367618aba4f60348374d4ea1262024bf8c011f744",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49924",
+					"10.65.0.27:49924",
+					"172.17.0.1:49924",
+					"172.18.0.1:49924",
+					"172.19.0.1:49924"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:27:03.46824726Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1106395205696899,
+				"StableID":   "nEazeJ86e911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3f9f603fee398520b30fe26c0d495861d81435ab17a14d022974b8d839e6480c",
+				"KeyExpiry":  "2026-11-09T07:27:04Z",
+				"DiscoKey":   "discokey:9747a5c1073002cae69cf040f872f2bf13c50d30b8335f300cd7781cf3392c73",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54811",
+					"10.65.0.27:54811",
+					"172.17.0.1:54811",
+					"172.18.0.1:54811",
+					"172.19.0.1:54811"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:27:04.007909784Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5546769760379673,
+				"StableID":   "nSRqhgE9Kk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c31c870b3855ecc7686e1e16dd15135511194115d1bfafdc71930e15988bb37f",
+				"KeyExpiry":  "2026-11-09T07:27:04Z",
+				"DiscoKey":   "discokey:ca07f79f6295772d2daf95472f0541cf641f122546a39103ad3e985df591b459",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57507",
+					"10.65.0.27:57507",
+					"172.17.0.1:57507",
+					"172.18.0.1:57507",
+					"172.19.0.1:57507"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:27:04.557797193Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8962288194634897": {
+				"ID":          8962288194634897,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3973102316283284,
+				"StableID":   "njzXSKfR2Y11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       3973102316283284,
+				"Key":        "nodekey:b6d59e828bd1ec4406027305043ec4681871778203de510295195c5fb0f8ef0b",
+				"DiscoKey":   "discokey:7a725f7db4ffc2294f03ad0e455eb2f558b1aec50079efd82b13eed3bd5a196b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49912",
+					"10.65.0.27:49912",
+					"172.17.0.1:49912",
+					"172.18.0.1:49912",
+					"172.19.0.1:49912"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:27:00.213210359Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b6d59e828bd1ec4406027305043ec4681871778203de510295195c5fb0f8ef0b",
+			"MachineKey": "mkey:143d2e6e4edc1284a18e2cdc72fa48dd909c45eeba84d6b9368f801234946c6a",
+			"Peers": [{
+				"ID":         4300355520635176,
+				"StableID":   "nVP1Vk3eaa11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a61f5a1ff97ecf2aea16bb88b5f41541d530d86b48910b8e37174dc51d809c62",
+				"DiscoKey":   "discokey:81b10f11a5f07eb67e9dc816bfb80a26acf36eaeb6e5a650e82b4777a0f9be52",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36665",
+					"10.65.0.27:36665",
+					"172.17.0.1:36665",
+					"172.18.0.1:36665",
+					"172.19.0.1:36665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:26:57.003292739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5856057653412839,
+				"StableID":   "ncoshrhDjn11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ead443776fde1a0f7a3bfe0ca8702866d2ca969e84f2597f829dd7bf7dc0d33a",
+				"DiscoKey":   "discokey:2e9deedbff60feed8a4f5eb1b2cd13e64fa0e1fbf51c3dece8db4a855b8ec320",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59791",
+					"10.65.0.27:59791",
+					"172.17.0.1:59791",
+					"172.18.0.1:59791",
+					"172.19.0.1:59791"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:26:57.523390736Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3179727635831357,
+				"StableID":   "nSRLi547qR11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93873a6f265369516b791b31da43ee7c380190707090d14a550a0a046d505556",
+				"DiscoKey":   "discokey:03fb81b74f8d517e056a4f8d1aa3522a4adb2094d1f61fa2dacbaa6525af1565",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59237",
+					"10.65.0.27:59237",
+					"172.17.0.1:59237",
+					"172.18.0.1:59237",
+					"172.19.0.1:59237"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:26:58.059202864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8962288194634897,
+				"StableID":   "npC4ra73zC21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:621bec1f2046b31a5e2a33f948386d37f3d7c91ed2c8eaa801d486ff858f672d",
+				"DiscoKey":   "discokey:d36a0d8a70645292ed9210fea89626ae265600dccc466ffb9c365eb4d69b2140",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43022",
+					"10.65.0.27:43022",
+					"172.17.0.1:43022",
+					"172.18.0.1:43022",
+					"172.19.0.1:43022"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:26:58.596366511Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1567973378065028,
+				"StableID":   "nsaX9719FD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f2416fd8a0d9765d31f5070326169834973024c10bce7a31ab05a8bcc4534524",
+				"DiscoKey":   "discokey:683485c665d2db159ab205e07d8c53e0aab258dce4929d97be7fc1712b2ce77d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57727",
+					"10.65.0.27:57727",
+					"172.17.0.1:57727",
+					"172.18.0.1:57727",
+					"172.19.0.1:57727"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:26:59.141229457Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3016134210607158,
+				"StableID":   "nVcevQj1ZQ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f4fc7cbdaabee95996343c27024bf620c999aa8c032a3a9356a65004cb48e22",
+				"DiscoKey":   "discokey:efb4ece44054a5587b590cf87cfed9ce63ac39e49a6dfd0fd4eec36d04201e63",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:45813",
+					"10.65.0.27:45813",
+					"172.17.0.1:45813",
+					"172.18.0.1:45813",
+					"172.19.0.1:45813"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:26:59.680343044Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         235565068263781,
+				"StableID":   "n86pRutgq211CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80e631a597e3db49772f3290ded999c22b21ea495de69012e934b7e408975f69",
+				"DiscoKey":   "discokey:b95030eef52e66b64b8dd4fc53e3c48ff855c33fce3f6b78a46b7bdd3080b504",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33453",
+					"10.65.0.27:33453",
+					"172.17.0.1:33453",
+					"172.18.0.1:33453",
+					"172.19.0.1:33453"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:27:00.753039236Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6791068477030203,
+				"StableID":   "nWLqPVrg2v11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0d4250e80aa04b003dbcf01dfc364cac29bf1c1bfb954664b3a6db0e2b2f230",
+				"DiscoKey":   "discokey:f54d4791b90bd244fdcdc6fdae6ec7c5834befb57ec2d094e9b7730e06be523d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52371",
+					"10.65.0.27:52371",
+					"172.17.0.1:52371",
+					"172.18.0.1:52371",
+					"172.19.0.1:52371"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:27:01.312466099Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8499398043976277,
+				"StableID":   "nt4rKumPN921CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1175f18a732bca77b79a3613d5170311e610a07ce18109d85b10fe9ca5850517",
+				"DiscoKey":   "discokey:c088813373a00a575c3c71ba23819ba4bb794a8be9808cd5fb09d92f9193f940",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:48977",
+					"10.65.0.27:48977",
+					"172.17.0.1:48977",
+					"172.18.0.1:48977",
+					"172.19.0.1:48977"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:27:01.84587771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7854343063047086,
+				"StableID":   "nTsjYsGFL421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f7dcd979d4bc0aa8458654b069096fd7888a661026053c57c003dbed72adc4c",
+				"DiscoKey":   "discokey:711b65738573fb67a2b4f5ee2d621af5493ae49317515c2614ad5098225ee97e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51364",
+					"10.65.0.27:51364",
+					"172.17.0.1:51364",
+					"172.18.0.1:51364",
+					"172.19.0.1:51364"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:27:02.393646415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5403428179624782,
+				"StableID":   "nwfe4xtDCj11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97356b4b7940089468c4f81076a3eab9940641d95c257df1b64feadf66ef1e56",
+				"DiscoKey":   "discokey:b1edefc8df04ed9768b257b92e20f51a6843dfda822911dcdec17d88d2534c37",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45145",
+					"10.65.0.27:45145",
+					"172.17.0.1:45145",
+					"172.18.0.1:45145",
+					"172.19.0.1:45145"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:27:02.931043851Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         195110116993013,
+				"StableID":   "nJd6vHDNX211CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e05e86118037ecb9d1b8c69598d8555137c0660906164c987abb9a0a590b3462",
+				"KeyExpiry":  "2026-11-09T07:27:03Z",
+				"DiscoKey":   "discokey:d4fef671d7833309d09aeb6367618aba4f60348374d4ea1262024bf8c011f744",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49924",
+					"10.65.0.27:49924",
+					"172.17.0.1:49924",
+					"172.18.0.1:49924",
+					"172.19.0.1:49924"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:27:03.46824726Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1106395205696899,
+				"StableID":   "nEazeJ86e911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3f9f603fee398520b30fe26c0d495861d81435ab17a14d022974b8d839e6480c",
+				"KeyExpiry":  "2026-11-09T07:27:04Z",
+				"DiscoKey":   "discokey:9747a5c1073002cae69cf040f872f2bf13c50d30b8335f300cd7781cf3392c73",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54811",
+					"10.65.0.27:54811",
+					"172.17.0.1:54811",
+					"172.18.0.1:54811",
+					"172.19.0.1:54811"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:27:04.007909784Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5546769760379673,
+				"StableID":   "nSRqhgE9Kk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c31c870b3855ecc7686e1e16dd15135511194115d1bfafdc71930e15988bb37f",
+				"KeyExpiry":  "2026-11-09T07:27:04Z",
+				"DiscoKey":   "discokey:ca07f79f6295772d2daf95472f0541cf641f122546a39103ad3e985df591b459",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57507",
+					"10.65.0.27:57507",
+					"172.17.0.1:57507",
+					"172.18.0.1:57507",
+					"172.19.0.1:57507"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:27:04.557797193Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3973102316283284": {
+				"ID":          3973102316283284,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6791068477030203,
+				"StableID":   "nWLqPVrg2v11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       6791068477030203,
+				"Key":        "nodekey:b0d4250e80aa04b003dbcf01dfc364cac29bf1c1bfb954664b3a6db0e2b2f230",
+				"DiscoKey":   "discokey:f54d4791b90bd244fdcdc6fdae6ec7c5834befb57ec2d094e9b7730e06be523d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52371",
+					"10.65.0.27:52371",
+					"172.17.0.1:52371",
+					"172.18.0.1:52371",
+					"172.19.0.1:52371"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:27:01.312466099Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b0d4250e80aa04b003dbcf01dfc364cac29bf1c1bfb954664b3a6db0e2b2f230",
+			"MachineKey": "mkey:eb2dd8dc1b22442dde2a95ee48a48ff41962c7b975647a9a08681dbcbb7b2137",
+			"Peers": [{
+				"ID":         4300355520635176,
+				"StableID":   "nVP1Vk3eaa11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a61f5a1ff97ecf2aea16bb88b5f41541d530d86b48910b8e37174dc51d809c62",
+				"DiscoKey":   "discokey:81b10f11a5f07eb67e9dc816bfb80a26acf36eaeb6e5a650e82b4777a0f9be52",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36665",
+					"10.65.0.27:36665",
+					"172.17.0.1:36665",
+					"172.18.0.1:36665",
+					"172.19.0.1:36665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:26:57.003292739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5856057653412839,
+				"StableID":   "ncoshrhDjn11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ead443776fde1a0f7a3bfe0ca8702866d2ca969e84f2597f829dd7bf7dc0d33a",
+				"DiscoKey":   "discokey:2e9deedbff60feed8a4f5eb1b2cd13e64fa0e1fbf51c3dece8db4a855b8ec320",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59791",
+					"10.65.0.27:59791",
+					"172.17.0.1:59791",
+					"172.18.0.1:59791",
+					"172.19.0.1:59791"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:26:57.523390736Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3179727635831357,
+				"StableID":   "nSRLi547qR11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93873a6f265369516b791b31da43ee7c380190707090d14a550a0a046d505556",
+				"DiscoKey":   "discokey:03fb81b74f8d517e056a4f8d1aa3522a4adb2094d1f61fa2dacbaa6525af1565",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59237",
+					"10.65.0.27:59237",
+					"172.17.0.1:59237",
+					"172.18.0.1:59237",
+					"172.19.0.1:59237"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:26:58.059202864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8962288194634897,
+				"StableID":   "npC4ra73zC21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:621bec1f2046b31a5e2a33f948386d37f3d7c91ed2c8eaa801d486ff858f672d",
+				"DiscoKey":   "discokey:d36a0d8a70645292ed9210fea89626ae265600dccc466ffb9c365eb4d69b2140",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43022",
+					"10.65.0.27:43022",
+					"172.17.0.1:43022",
+					"172.18.0.1:43022",
+					"172.19.0.1:43022"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:26:58.596366511Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1567973378065028,
+				"StableID":   "nsaX9719FD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f2416fd8a0d9765d31f5070326169834973024c10bce7a31ab05a8bcc4534524",
+				"DiscoKey":   "discokey:683485c665d2db159ab205e07d8c53e0aab258dce4929d97be7fc1712b2ce77d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57727",
+					"10.65.0.27:57727",
+					"172.17.0.1:57727",
+					"172.18.0.1:57727",
+					"172.19.0.1:57727"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:26:59.141229457Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3016134210607158,
+				"StableID":   "nVcevQj1ZQ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f4fc7cbdaabee95996343c27024bf620c999aa8c032a3a9356a65004cb48e22",
+				"DiscoKey":   "discokey:efb4ece44054a5587b590cf87cfed9ce63ac39e49a6dfd0fd4eec36d04201e63",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:45813",
+					"10.65.0.27:45813",
+					"172.17.0.1:45813",
+					"172.18.0.1:45813",
+					"172.19.0.1:45813"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:26:59.680343044Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3973102316283284,
+				"StableID":   "njzXSKfR2Y11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6d59e828bd1ec4406027305043ec4681871778203de510295195c5fb0f8ef0b",
+				"DiscoKey":   "discokey:7a725f7db4ffc2294f03ad0e455eb2f558b1aec50079efd82b13eed3bd5a196b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49912",
+					"10.65.0.27:49912",
+					"172.17.0.1:49912",
+					"172.18.0.1:49912",
+					"172.19.0.1:49912"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:27:00.213210359Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         235565068263781,
+				"StableID":   "n86pRutgq211CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80e631a597e3db49772f3290ded999c22b21ea495de69012e934b7e408975f69",
+				"DiscoKey":   "discokey:b95030eef52e66b64b8dd4fc53e3c48ff855c33fce3f6b78a46b7bdd3080b504",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33453",
+					"10.65.0.27:33453",
+					"172.17.0.1:33453",
+					"172.18.0.1:33453",
+					"172.19.0.1:33453"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:27:00.753039236Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8499398043976277,
+				"StableID":   "nt4rKumPN921CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1175f18a732bca77b79a3613d5170311e610a07ce18109d85b10fe9ca5850517",
+				"DiscoKey":   "discokey:c088813373a00a575c3c71ba23819ba4bb794a8be9808cd5fb09d92f9193f940",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:48977",
+					"10.65.0.27:48977",
+					"172.17.0.1:48977",
+					"172.18.0.1:48977",
+					"172.19.0.1:48977"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:27:01.84587771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7854343063047086,
+				"StableID":   "nTsjYsGFL421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f7dcd979d4bc0aa8458654b069096fd7888a661026053c57c003dbed72adc4c",
+				"DiscoKey":   "discokey:711b65738573fb67a2b4f5ee2d621af5493ae49317515c2614ad5098225ee97e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51364",
+					"10.65.0.27:51364",
+					"172.17.0.1:51364",
+					"172.18.0.1:51364",
+					"172.19.0.1:51364"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:27:02.393646415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5403428179624782,
+				"StableID":   "nwfe4xtDCj11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97356b4b7940089468c4f81076a3eab9940641d95c257df1b64feadf66ef1e56",
+				"DiscoKey":   "discokey:b1edefc8df04ed9768b257b92e20f51a6843dfda822911dcdec17d88d2534c37",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45145",
+					"10.65.0.27:45145",
+					"172.17.0.1:45145",
+					"172.18.0.1:45145",
+					"172.19.0.1:45145"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:27:02.931043851Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         195110116993013,
+				"StableID":   "nJd6vHDNX211CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e05e86118037ecb9d1b8c69598d8555137c0660906164c987abb9a0a590b3462",
+				"KeyExpiry":  "2026-11-09T07:27:03Z",
+				"DiscoKey":   "discokey:d4fef671d7833309d09aeb6367618aba4f60348374d4ea1262024bf8c011f744",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49924",
+					"10.65.0.27:49924",
+					"172.17.0.1:49924",
+					"172.18.0.1:49924",
+					"172.19.0.1:49924"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:27:03.46824726Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1106395205696899,
+				"StableID":   "nEazeJ86e911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3f9f603fee398520b30fe26c0d495861d81435ab17a14d022974b8d839e6480c",
+				"KeyExpiry":  "2026-11-09T07:27:04Z",
+				"DiscoKey":   "discokey:9747a5c1073002cae69cf040f872f2bf13c50d30b8335f300cd7781cf3392c73",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54811",
+					"10.65.0.27:54811",
+					"172.17.0.1:54811",
+					"172.18.0.1:54811",
+					"172.19.0.1:54811"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:27:04.007909784Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5546769760379673,
+				"StableID":   "nSRqhgE9Kk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c31c870b3855ecc7686e1e16dd15135511194115d1bfafdc71930e15988bb37f",
+				"KeyExpiry":  "2026-11-09T07:27:04Z",
+				"DiscoKey":   "discokey:ca07f79f6295772d2daf95472f0541cf641f122546a39103ad3e985df591b459",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57507",
+					"10.65.0.27:57507",
+					"172.17.0.1:57507",
+					"172.18.0.1:57507",
+					"172.19.0.1:57507"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:27:04.557797193Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6791068477030203": {
+				"ID":          6791068477030203,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1106395205696899,
+				"StableID":   "nEazeJ86e911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3f9f603fee398520b30fe26c0d495861d81435ab17a14d022974b8d839e6480c",
+				"KeyExpiry":  "2026-11-09T07:27:04Z",
+				"DiscoKey":   "discokey:9747a5c1073002cae69cf040f872f2bf13c50d30b8335f300cd7781cf3392c73",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54811",
+					"10.65.0.27:54811",
+					"172.17.0.1:54811",
+					"172.18.0.1:54811",
+					"172.19.0.1:54811"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:27:04.007909784Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3f9f603fee398520b30fe26c0d495861d81435ab17a14d022974b8d839e6480c",
+			"MachineKey": "mkey:2873f6e8956317eb3fcf5972a1d563b9326f18635f193025e59944c5e67cd86c",
+			"Peers": [{
+				"ID":         4300355520635176,
+				"StableID":   "nVP1Vk3eaa11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a61f5a1ff97ecf2aea16bb88b5f41541d530d86b48910b8e37174dc51d809c62",
+				"DiscoKey":   "discokey:81b10f11a5f07eb67e9dc816bfb80a26acf36eaeb6e5a650e82b4777a0f9be52",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36665",
+					"10.65.0.27:36665",
+					"172.17.0.1:36665",
+					"172.18.0.1:36665",
+					"172.19.0.1:36665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:26:57.003292739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5856057653412839,
+				"StableID":   "ncoshrhDjn11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ead443776fde1a0f7a3bfe0ca8702866d2ca969e84f2597f829dd7bf7dc0d33a",
+				"DiscoKey":   "discokey:2e9deedbff60feed8a4f5eb1b2cd13e64fa0e1fbf51c3dece8db4a855b8ec320",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59791",
+					"10.65.0.27:59791",
+					"172.17.0.1:59791",
+					"172.18.0.1:59791",
+					"172.19.0.1:59791"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:26:57.523390736Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3179727635831357,
+				"StableID":   "nSRLi547qR11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93873a6f265369516b791b31da43ee7c380190707090d14a550a0a046d505556",
+				"DiscoKey":   "discokey:03fb81b74f8d517e056a4f8d1aa3522a4adb2094d1f61fa2dacbaa6525af1565",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59237",
+					"10.65.0.27:59237",
+					"172.17.0.1:59237",
+					"172.18.0.1:59237",
+					"172.19.0.1:59237"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:26:58.059202864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8962288194634897,
+				"StableID":   "npC4ra73zC21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:621bec1f2046b31a5e2a33f948386d37f3d7c91ed2c8eaa801d486ff858f672d",
+				"DiscoKey":   "discokey:d36a0d8a70645292ed9210fea89626ae265600dccc466ffb9c365eb4d69b2140",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43022",
+					"10.65.0.27:43022",
+					"172.17.0.1:43022",
+					"172.18.0.1:43022",
+					"172.19.0.1:43022"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:26:58.596366511Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1567973378065028,
+				"StableID":   "nsaX9719FD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f2416fd8a0d9765d31f5070326169834973024c10bce7a31ab05a8bcc4534524",
+				"DiscoKey":   "discokey:683485c665d2db159ab205e07d8c53e0aab258dce4929d97be7fc1712b2ce77d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57727",
+					"10.65.0.27:57727",
+					"172.17.0.1:57727",
+					"172.18.0.1:57727",
+					"172.19.0.1:57727"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:26:59.141229457Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3016134210607158,
+				"StableID":   "nVcevQj1ZQ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f4fc7cbdaabee95996343c27024bf620c999aa8c032a3a9356a65004cb48e22",
+				"DiscoKey":   "discokey:efb4ece44054a5587b590cf87cfed9ce63ac39e49a6dfd0fd4eec36d04201e63",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:45813",
+					"10.65.0.27:45813",
+					"172.17.0.1:45813",
+					"172.18.0.1:45813",
+					"172.19.0.1:45813"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:26:59.680343044Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3973102316283284,
+				"StableID":   "njzXSKfR2Y11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6d59e828bd1ec4406027305043ec4681871778203de510295195c5fb0f8ef0b",
+				"DiscoKey":   "discokey:7a725f7db4ffc2294f03ad0e455eb2f558b1aec50079efd82b13eed3bd5a196b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49912",
+					"10.65.0.27:49912",
+					"172.17.0.1:49912",
+					"172.18.0.1:49912",
+					"172.19.0.1:49912"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:27:00.213210359Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         235565068263781,
+				"StableID":   "n86pRutgq211CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80e631a597e3db49772f3290ded999c22b21ea495de69012e934b7e408975f69",
+				"DiscoKey":   "discokey:b95030eef52e66b64b8dd4fc53e3c48ff855c33fce3f6b78a46b7bdd3080b504",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33453",
+					"10.65.0.27:33453",
+					"172.17.0.1:33453",
+					"172.18.0.1:33453",
+					"172.19.0.1:33453"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:27:00.753039236Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6791068477030203,
+				"StableID":   "nWLqPVrg2v11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0d4250e80aa04b003dbcf01dfc364cac29bf1c1bfb954664b3a6db0e2b2f230",
+				"DiscoKey":   "discokey:f54d4791b90bd244fdcdc6fdae6ec7c5834befb57ec2d094e9b7730e06be523d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52371",
+					"10.65.0.27:52371",
+					"172.17.0.1:52371",
+					"172.18.0.1:52371",
+					"172.19.0.1:52371"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:27:01.312466099Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8499398043976277,
+				"StableID":   "nt4rKumPN921CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1175f18a732bca77b79a3613d5170311e610a07ce18109d85b10fe9ca5850517",
+				"DiscoKey":   "discokey:c088813373a00a575c3c71ba23819ba4bb794a8be9808cd5fb09d92f9193f940",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:48977",
+					"10.65.0.27:48977",
+					"172.17.0.1:48977",
+					"172.18.0.1:48977",
+					"172.19.0.1:48977"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:27:01.84587771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7854343063047086,
+				"StableID":   "nTsjYsGFL421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f7dcd979d4bc0aa8458654b069096fd7888a661026053c57c003dbed72adc4c",
+				"DiscoKey":   "discokey:711b65738573fb67a2b4f5ee2d621af5493ae49317515c2614ad5098225ee97e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51364",
+					"10.65.0.27:51364",
+					"172.17.0.1:51364",
+					"172.18.0.1:51364",
+					"172.19.0.1:51364"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:27:02.393646415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5403428179624782,
+				"StableID":   "nwfe4xtDCj11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97356b4b7940089468c4f81076a3eab9940641d95c257df1b64feadf66ef1e56",
+				"DiscoKey":   "discokey:b1edefc8df04ed9768b257b92e20f51a6843dfda822911dcdec17d88d2534c37",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45145",
+					"10.65.0.27:45145",
+					"172.17.0.1:45145",
+					"172.18.0.1:45145",
+					"172.19.0.1:45145"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:27:02.931043851Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         195110116993013,
+				"StableID":   "nJd6vHDNX211CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e05e86118037ecb9d1b8c69598d8555137c0660906164c987abb9a0a590b3462",
+				"KeyExpiry":  "2026-11-09T07:27:03Z",
+				"DiscoKey":   "discokey:d4fef671d7833309d09aeb6367618aba4f60348374d4ea1262024bf8c011f744",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49924",
+					"10.65.0.27:49924",
+					"172.17.0.1:49924",
+					"172.18.0.1:49924",
+					"172.19.0.1:49924"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:27:03.46824726Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5546769760379673,
+				"StableID":   "nSRqhgE9Kk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c31c870b3855ecc7686e1e16dd15135511194115d1bfafdc71930e15988bb37f",
+				"KeyExpiry":  "2026-11-09T07:27:04Z",
+				"DiscoKey":   "discokey:ca07f79f6295772d2daf95472f0541cf641f122546a39103ad3e985df591b459",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57507",
+					"10.65.0.27:57507",
+					"172.17.0.1:57507",
+					"172.18.0.1:57507",
+					"172.19.0.1:57507"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:27:04.557797193Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8499398043976277,
+				"StableID":   "nt4rKumPN921CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       8499398043976277,
+				"Key":        "nodekey:1175f18a732bca77b79a3613d5170311e610a07ce18109d85b10fe9ca5850517",
+				"DiscoKey":   "discokey:c088813373a00a575c3c71ba23819ba4bb794a8be9808cd5fb09d92f9193f940",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:48977",
+					"10.65.0.27:48977",
+					"172.17.0.1:48977",
+					"172.18.0.1:48977",
+					"172.19.0.1:48977"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:27:01.84587771Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1175f18a732bca77b79a3613d5170311e610a07ce18109d85b10fe9ca5850517",
+			"MachineKey": "mkey:e547913d8fbcbd0830a61ab017ace677c20a4f2944cf3382ee410b989d1b1d13",
+			"Peers": [{
+				"ID":         4300355520635176,
+				"StableID":   "nVP1Vk3eaa11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a61f5a1ff97ecf2aea16bb88b5f41541d530d86b48910b8e37174dc51d809c62",
+				"DiscoKey":   "discokey:81b10f11a5f07eb67e9dc816bfb80a26acf36eaeb6e5a650e82b4777a0f9be52",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36665",
+					"10.65.0.27:36665",
+					"172.17.0.1:36665",
+					"172.18.0.1:36665",
+					"172.19.0.1:36665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:26:57.003292739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5856057653412839,
+				"StableID":   "ncoshrhDjn11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ead443776fde1a0f7a3bfe0ca8702866d2ca969e84f2597f829dd7bf7dc0d33a",
+				"DiscoKey":   "discokey:2e9deedbff60feed8a4f5eb1b2cd13e64fa0e1fbf51c3dece8db4a855b8ec320",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59791",
+					"10.65.0.27:59791",
+					"172.17.0.1:59791",
+					"172.18.0.1:59791",
+					"172.19.0.1:59791"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:26:57.523390736Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3179727635831357,
+				"StableID":   "nSRLi547qR11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93873a6f265369516b791b31da43ee7c380190707090d14a550a0a046d505556",
+				"DiscoKey":   "discokey:03fb81b74f8d517e056a4f8d1aa3522a4adb2094d1f61fa2dacbaa6525af1565",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59237",
+					"10.65.0.27:59237",
+					"172.17.0.1:59237",
+					"172.18.0.1:59237",
+					"172.19.0.1:59237"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:26:58.059202864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8962288194634897,
+				"StableID":   "npC4ra73zC21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:621bec1f2046b31a5e2a33f948386d37f3d7c91ed2c8eaa801d486ff858f672d",
+				"DiscoKey":   "discokey:d36a0d8a70645292ed9210fea89626ae265600dccc466ffb9c365eb4d69b2140",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43022",
+					"10.65.0.27:43022",
+					"172.17.0.1:43022",
+					"172.18.0.1:43022",
+					"172.19.0.1:43022"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:26:58.596366511Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1567973378065028,
+				"StableID":   "nsaX9719FD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f2416fd8a0d9765d31f5070326169834973024c10bce7a31ab05a8bcc4534524",
+				"DiscoKey":   "discokey:683485c665d2db159ab205e07d8c53e0aab258dce4929d97be7fc1712b2ce77d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57727",
+					"10.65.0.27:57727",
+					"172.17.0.1:57727",
+					"172.18.0.1:57727",
+					"172.19.0.1:57727"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:26:59.141229457Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3016134210607158,
+				"StableID":   "nVcevQj1ZQ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f4fc7cbdaabee95996343c27024bf620c999aa8c032a3a9356a65004cb48e22",
+				"DiscoKey":   "discokey:efb4ece44054a5587b590cf87cfed9ce63ac39e49a6dfd0fd4eec36d04201e63",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:45813",
+					"10.65.0.27:45813",
+					"172.17.0.1:45813",
+					"172.18.0.1:45813",
+					"172.19.0.1:45813"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:26:59.680343044Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3973102316283284,
+				"StableID":   "njzXSKfR2Y11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6d59e828bd1ec4406027305043ec4681871778203de510295195c5fb0f8ef0b",
+				"DiscoKey":   "discokey:7a725f7db4ffc2294f03ad0e455eb2f558b1aec50079efd82b13eed3bd5a196b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49912",
+					"10.65.0.27:49912",
+					"172.17.0.1:49912",
+					"172.18.0.1:49912",
+					"172.19.0.1:49912"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:27:00.213210359Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         235565068263781,
+				"StableID":   "n86pRutgq211CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80e631a597e3db49772f3290ded999c22b21ea495de69012e934b7e408975f69",
+				"DiscoKey":   "discokey:b95030eef52e66b64b8dd4fc53e3c48ff855c33fce3f6b78a46b7bdd3080b504",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33453",
+					"10.65.0.27:33453",
+					"172.17.0.1:33453",
+					"172.18.0.1:33453",
+					"172.19.0.1:33453"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:27:00.753039236Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6791068477030203,
+				"StableID":   "nWLqPVrg2v11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0d4250e80aa04b003dbcf01dfc364cac29bf1c1bfb954664b3a6db0e2b2f230",
+				"DiscoKey":   "discokey:f54d4791b90bd244fdcdc6fdae6ec7c5834befb57ec2d094e9b7730e06be523d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52371",
+					"10.65.0.27:52371",
+					"172.17.0.1:52371",
+					"172.18.0.1:52371",
+					"172.19.0.1:52371"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:27:01.312466099Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7854343063047086,
+				"StableID":   "nTsjYsGFL421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f7dcd979d4bc0aa8458654b069096fd7888a661026053c57c003dbed72adc4c",
+				"DiscoKey":   "discokey:711b65738573fb67a2b4f5ee2d621af5493ae49317515c2614ad5098225ee97e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51364",
+					"10.65.0.27:51364",
+					"172.17.0.1:51364",
+					"172.18.0.1:51364",
+					"172.19.0.1:51364"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:27:02.393646415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5403428179624782,
+				"StableID":   "nwfe4xtDCj11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97356b4b7940089468c4f81076a3eab9940641d95c257df1b64feadf66ef1e56",
+				"DiscoKey":   "discokey:b1edefc8df04ed9768b257b92e20f51a6843dfda822911dcdec17d88d2534c37",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45145",
+					"10.65.0.27:45145",
+					"172.17.0.1:45145",
+					"172.18.0.1:45145",
+					"172.19.0.1:45145"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:27:02.931043851Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         195110116993013,
+				"StableID":   "nJd6vHDNX211CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e05e86118037ecb9d1b8c69598d8555137c0660906164c987abb9a0a590b3462",
+				"KeyExpiry":  "2026-11-09T07:27:03Z",
+				"DiscoKey":   "discokey:d4fef671d7833309d09aeb6367618aba4f60348374d4ea1262024bf8c011f744",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49924",
+					"10.65.0.27:49924",
+					"172.17.0.1:49924",
+					"172.18.0.1:49924",
+					"172.19.0.1:49924"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:27:03.46824726Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1106395205696899,
+				"StableID":   "nEazeJ86e911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3f9f603fee398520b30fe26c0d495861d81435ab17a14d022974b8d839e6480c",
+				"KeyExpiry":  "2026-11-09T07:27:04Z",
+				"DiscoKey":   "discokey:9747a5c1073002cae69cf040f872f2bf13c50d30b8335f300cd7781cf3392c73",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54811",
+					"10.65.0.27:54811",
+					"172.17.0.1:54811",
+					"172.18.0.1:54811",
+					"172.19.0.1:54811"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:27:04.007909784Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5546769760379673,
+				"StableID":   "nSRqhgE9Kk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c31c870b3855ecc7686e1e16dd15135511194115d1bfafdc71930e15988bb37f",
+				"KeyExpiry":  "2026-11-09T07:27:04Z",
+				"DiscoKey":   "discokey:ca07f79f6295772d2daf95472f0541cf641f122546a39103ad3e985df591b459",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57507",
+					"10.65.0.27:57507",
+					"172.17.0.1:57507",
+					"172.18.0.1:57507",
+					"172.19.0.1:57507"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:27:04.557797193Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8499398043976277": {
+				"ID":          8499398043976277,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-action-whitespace.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-action-whitespace.hujson
@@ -1,0 +1,20104 @@
+// ssh-malformed-action-whitespace
+//
+// ssh action with leading whitespace
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-13T07:27:40Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-malformed-action-whitespace",
+	"description":    "ssh action with leading whitespace",
+	"category":       "ssh",
+	"captured_at":    "2026-05-13T07:27:40.581224474Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                  \n  \n                                                                 \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh action with leading whitespace\",\n\t\"id\":          \"ssh-malformed-action-whitespace\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \" accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"autogroup:member\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-edge/ssh-malformed-action-whitespace.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": " accept",
+				"dst":    ["tag:server"],
+				"src":    ["autogroup:member"],
+				"users":  ["root"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5754078637829449,
+				"StableID":   "npQtJYt2wm11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       5754078637829449,
+				"Key":        "nodekey:89e9278cff4ffd35726275e2f33cc435cf178f19d1f308ee49733f5b7b2d2a4e",
+				"DiscoKey":   "discokey:71d738fdb8ec362b475791cff47c068af4a60dca6d9b6aa601cd88bf122a942d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52491",
+					"10.65.0.27:52491",
+					"172.17.0.1:52491",
+					"172.18.0.1:52491",
+					"172.19.0.1:52491"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:27:49.108563037Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:89e9278cff4ffd35726275e2f33cc435cf178f19d1f308ee49733f5b7b2d2a4e",
+			"MachineKey": "mkey:fdba218f323df3be0835620ed800d9e5aa657910b0af84e872356c0a98329769",
+			"Peers": [{
+				"ID":         861188056879115,
+				"StableID":   "nep1b6x2j711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5aae13a99589250ac3d1c06e3f26b7fd4a4a7376855b8105f5d0ac4a5f836078",
+				"DiscoKey":   "discokey:b0f4876c78433341521539cab25b0294b9d51eab808453fcd7caa156b89e410b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33599",
+					"10.65.0.27:33599",
+					"172.17.0.1:33599",
+					"172.18.0.1:33599",
+					"172.19.0.1:33599"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:27:43.135263897Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8680699854276825,
+				"StableID":   "npCpTPGWnA21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca8a6a98d72a7299ae22c8fbe3c309802fa6bfad81f34ae4b6ab68e567ec0077",
+				"DiscoKey":   "discokey:3a8c1193f3f7b30ee3253786e153ec7a6caea9c3e45fec0f9e8edf096abb8636",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47028",
+					"10.65.0.27:47028",
+					"172.17.0.1:47028",
+					"172.18.0.1:47028",
+					"172.19.0.1:47028"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:27:43.669011539Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7141861004647675,
+				"StableID":   "nxswpXaZmx11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:101a448995c3d6088408b6d310d2c246b8cb108e313f458a60494d6ba3b8f649",
+				"DiscoKey":   "discokey:04e1b3ea416ffabc3361e318906a44424b26046b1dab688e41d76a4471018817",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:55525",
+					"10.65.0.27:55525",
+					"172.17.0.1:55525",
+					"172.18.0.1:55525",
+					"172.19.0.1:55525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:27:44.207628464Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4724336270747769,
+				"StableID":   "nEMxWZJftd11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30f892f7bf584cc6bf53e6d1d8472cd1ad358778d8d54ca0a4d5e8900d6a6e5e",
+				"DiscoKey":   "discokey:8417d86473fc456799814fdd6faaf71e51b532007083044189e3d101e5efd52d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:57107",
+					"10.65.0.27:57107",
+					"172.17.0.1:57107",
+					"172.18.0.1:57107",
+					"172.19.0.1:57107"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:27:44.734810873Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8306001689644191,
+				"StableID":   "nYwLkdaor721CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a5e228e792c32bfea34fa4add85183afa63867b171f98fa3737b2222757354e",
+				"DiscoKey":   "discokey:6e021862e7bef2bfada8f496e1eeee9bf708020843199a6c84e803460a8e8507",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:32931",
+					"10.65.0.27:32931",
+					"172.17.0.1:32931",
+					"172.18.0.1:32931",
+					"172.19.0.1:32931"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:27:45.286098032Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3139804488792044,
+				"StableID":   "nyBKvhL2XR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38b2d8f4c228100b4a011eb21dda558b54b3b965a993400049da04ce6b21a167",
+				"DiscoKey":   "discokey:a9f091671070ace677a8b44946c1f04c47f21ba55ea77c22e9d451f53c1f9c46",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:47293",
+					"10.65.0.27:47293",
+					"172.17.0.1:47293",
+					"172.18.0.1:47293",
+					"172.19.0.1:47293"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:27:45.822145352Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7714839673165703,
+				"StableID":   "ncF3hrk4F321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25f4b5e0d6d381db768cd6c224a14353b8f4e70717ed107f3698bcf79e14f345",
+				"DiscoKey":   "discokey:998a0eaf6711bf018a4e6bc3c8691c9be4f62ec36ca79ebdd3f0d6e03526900a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53262",
+					"10.65.0.27:53262",
+					"172.17.0.1:53262",
+					"172.18.0.1:53262",
+					"172.19.0.1:53262"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:27:46.347864423Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6279102083833834,
+				"StableID":   "nmLfN8Np2r11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a2c8fddb2040b36249ef35875b968a36e0d9f46bb98f551e669c3547ca64d67",
+				"DiscoKey":   "discokey:be9cb3dd5314fc78543a7c84b45a849cc35c9610cc3e5761410906f55dc31a5a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55607",
+					"10.65.0.27:55607",
+					"172.17.0.1:55607",
+					"172.18.0.1:55607",
+					"172.19.0.1:55607"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:27:46.885923527Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7616952318553386,
+				"StableID":   "nRE3NSRjU221CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:101f3079531b10e63df90059a27f87c5c9a7dd5cd4725c2be86964b3130a2d3c",
+				"DiscoKey":   "discokey:aa1e16a303c85bc9f783441b1ca3082d148c350a1b4a555fc670bbab4644943b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37144",
+					"10.65.0.27:37144",
+					"172.17.0.1:37144",
+					"172.18.0.1:37144",
+					"172.19.0.1:37144"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:27:47.444165724Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6651177415959720,
+				"StableID":   "nhTxMq9Lwt11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e950c14af2a4aa67da69905cf19eaf45e9e16e2e206dc35bf6a0c98f122ed47e",
+				"DiscoKey":   "discokey:36feeedc7ce8198432f592577904564eea8d33e82a2fd50b87dc88e6e613e24b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35894",
+					"10.65.0.27:35894",
+					"172.17.0.1:35894",
+					"172.18.0.1:35894",
+					"172.19.0.1:35894"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:27:47.978293846Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2385266244843678,
+				"StableID":   "nhza6BuHdK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90ef1125fc078609ce1ceaa9a653d30d54d7ec45ee7e36f2075acf2fdcfe557d",
+				"DiscoKey":   "discokey:a10078731b5d6c055f2b8961088bb384d01ab8c32283c666984c264bce94290c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:33798",
+					"10.65.0.27:33798",
+					"172.17.0.1:33798",
+					"172.18.0.1:33798",
+					"172.19.0.1:33798"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:27:48.528549031Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1275044730199096,
+				"StableID":   "nus5dFGUxA11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7e9f4f0d500c03579fb1407e64095477a38852f73331366cd2e720f7a3fdbe33",
+				"KeyExpiry":  "2026-11-09T07:27:49Z",
+				"DiscoKey":   "discokey:dbd96448f403b268cf76693a04e0de5abfc8bbe992261f5d1bb178c855eb450e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35822",
+					"10.65.0.27:35822",
+					"172.17.0.1:35822",
+					"172.18.0.1:35822",
+					"172.19.0.1:35822"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:27:49.593623884Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7728681379644409,
+				"StableID":   "nSZotYMLM321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:da34f20900d2b203364376c411053a021df11d51a5388655ada04c63cbe63e16",
+				"KeyExpiry":  "2026-11-09T07:27:50Z",
+				"DiscoKey":   "discokey:d5fcb861f1f70ba56e89b846a13fa0ec331c83ce8d3c7b5ffbd669d28369cb7c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57163",
+					"10.65.0.27:57163",
+					"172.17.0.1:57163",
+					"172.18.0.1:57163",
+					"172.19.0.1:57163"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:27:50.14121441Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1395127351755263,
+				"StableID":   "nNpkgXdrtB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bb380a4b82bc4518c49bd400b2ed47acba9ac6836b6d37444852094610d13859",
+				"KeyExpiry":  "2026-11-09T07:27:50Z",
+				"DiscoKey":   "discokey:034a16542b75207a9ed5d8bd65c0ae29a7aea5f56839a655d79193d768e02a1e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49991",
+					"10.65.0.27:49991",
+					"172.17.0.1:49991",
+					"172.18.0.1:49991",
+					"172.19.0.1:49991"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:27:50.681748161Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{"principals": [
+				{"nodeIP": "100.64.0.17"},
+				{"nodeIP": "100.64.0.18"},
+				{"nodeIP": "100.64.0.19"},
+				{"nodeIP": "fd7a:115c:a1e0::13"},
+				{"nodeIP": "fd7a:115c:a1e0::11"},
+				{"nodeIP": "fd7a:115c:a1e0::12"}
+			], "sshUsers": {"root": "root"}, "action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5754078637829449": {
+				"ID":          5754078637829449,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		},
+		"ssh_rules": [{"principals": [
+			{"nodeIP": "100.64.0.17"},
+			{"nodeIP": "100.64.0.18"},
+			{"nodeIP": "100.64.0.19"},
+			{"nodeIP": "fd7a:115c:a1e0::13"},
+			{"nodeIP": "fd7a:115c:a1e0::11"},
+			{"nodeIP": "fd7a:115c:a1e0::12"}
+		], "sshUsers": {"root": "root"}, "action": {
+			"accept":                    true,
+			"allowAgentForwarding":      true,
+			"allowLocalPortForwarding":  true,
+			"allowRemotePortForwarding": true
+		}}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3139804488792044,
+				"StableID":   "nyBKvhL2XR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       3139804488792044,
+				"Key":        "nodekey:38b2d8f4c228100b4a011eb21dda558b54b3b965a993400049da04ce6b21a167",
+				"DiscoKey":   "discokey:a9f091671070ace677a8b44946c1f04c47f21ba55ea77c22e9d451f53c1f9c46",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:47293",
+					"10.65.0.27:47293",
+					"172.17.0.1:47293",
+					"172.18.0.1:47293",
+					"172.19.0.1:47293"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:27:45.822145352Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:38b2d8f4c228100b4a011eb21dda558b54b3b965a993400049da04ce6b21a167",
+			"MachineKey": "mkey:dfe921ac10bec6d36a0496dc536b3d2776de66457cf6523680229acf4ed08059",
+			"Peers": [{
+				"ID":         861188056879115,
+				"StableID":   "nep1b6x2j711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5aae13a99589250ac3d1c06e3f26b7fd4a4a7376855b8105f5d0ac4a5f836078",
+				"DiscoKey":   "discokey:b0f4876c78433341521539cab25b0294b9d51eab808453fcd7caa156b89e410b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33599",
+					"10.65.0.27:33599",
+					"172.17.0.1:33599",
+					"172.18.0.1:33599",
+					"172.19.0.1:33599"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:27:43.135263897Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8680699854276825,
+				"StableID":   "npCpTPGWnA21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca8a6a98d72a7299ae22c8fbe3c309802fa6bfad81f34ae4b6ab68e567ec0077",
+				"DiscoKey":   "discokey:3a8c1193f3f7b30ee3253786e153ec7a6caea9c3e45fec0f9e8edf096abb8636",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47028",
+					"10.65.0.27:47028",
+					"172.17.0.1:47028",
+					"172.18.0.1:47028",
+					"172.19.0.1:47028"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:27:43.669011539Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7141861004647675,
+				"StableID":   "nxswpXaZmx11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:101a448995c3d6088408b6d310d2c246b8cb108e313f458a60494d6ba3b8f649",
+				"DiscoKey":   "discokey:04e1b3ea416ffabc3361e318906a44424b26046b1dab688e41d76a4471018817",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:55525",
+					"10.65.0.27:55525",
+					"172.17.0.1:55525",
+					"172.18.0.1:55525",
+					"172.19.0.1:55525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:27:44.207628464Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4724336270747769,
+				"StableID":   "nEMxWZJftd11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30f892f7bf584cc6bf53e6d1d8472cd1ad358778d8d54ca0a4d5e8900d6a6e5e",
+				"DiscoKey":   "discokey:8417d86473fc456799814fdd6faaf71e51b532007083044189e3d101e5efd52d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:57107",
+					"10.65.0.27:57107",
+					"172.17.0.1:57107",
+					"172.18.0.1:57107",
+					"172.19.0.1:57107"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:27:44.734810873Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8306001689644191,
+				"StableID":   "nYwLkdaor721CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a5e228e792c32bfea34fa4add85183afa63867b171f98fa3737b2222757354e",
+				"DiscoKey":   "discokey:6e021862e7bef2bfada8f496e1eeee9bf708020843199a6c84e803460a8e8507",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:32931",
+					"10.65.0.27:32931",
+					"172.17.0.1:32931",
+					"172.18.0.1:32931",
+					"172.19.0.1:32931"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:27:45.286098032Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7714839673165703,
+				"StableID":   "ncF3hrk4F321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25f4b5e0d6d381db768cd6c224a14353b8f4e70717ed107f3698bcf79e14f345",
+				"DiscoKey":   "discokey:998a0eaf6711bf018a4e6bc3c8691c9be4f62ec36ca79ebdd3f0d6e03526900a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53262",
+					"10.65.0.27:53262",
+					"172.17.0.1:53262",
+					"172.18.0.1:53262",
+					"172.19.0.1:53262"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:27:46.347864423Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6279102083833834,
+				"StableID":   "nmLfN8Np2r11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a2c8fddb2040b36249ef35875b968a36e0d9f46bb98f551e669c3547ca64d67",
+				"DiscoKey":   "discokey:be9cb3dd5314fc78543a7c84b45a849cc35c9610cc3e5761410906f55dc31a5a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55607",
+					"10.65.0.27:55607",
+					"172.17.0.1:55607",
+					"172.18.0.1:55607",
+					"172.19.0.1:55607"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:27:46.885923527Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7616952318553386,
+				"StableID":   "nRE3NSRjU221CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:101f3079531b10e63df90059a27f87c5c9a7dd5cd4725c2be86964b3130a2d3c",
+				"DiscoKey":   "discokey:aa1e16a303c85bc9f783441b1ca3082d148c350a1b4a555fc670bbab4644943b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37144",
+					"10.65.0.27:37144",
+					"172.17.0.1:37144",
+					"172.18.0.1:37144",
+					"172.19.0.1:37144"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:27:47.444165724Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6651177415959720,
+				"StableID":   "nhTxMq9Lwt11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e950c14af2a4aa67da69905cf19eaf45e9e16e2e206dc35bf6a0c98f122ed47e",
+				"DiscoKey":   "discokey:36feeedc7ce8198432f592577904564eea8d33e82a2fd50b87dc88e6e613e24b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35894",
+					"10.65.0.27:35894",
+					"172.17.0.1:35894",
+					"172.18.0.1:35894",
+					"172.19.0.1:35894"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:27:47.978293846Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2385266244843678,
+				"StableID":   "nhza6BuHdK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90ef1125fc078609ce1ceaa9a653d30d54d7ec45ee7e36f2075acf2fdcfe557d",
+				"DiscoKey":   "discokey:a10078731b5d6c055f2b8961088bb384d01ab8c32283c666984c264bce94290c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:33798",
+					"10.65.0.27:33798",
+					"172.17.0.1:33798",
+					"172.18.0.1:33798",
+					"172.19.0.1:33798"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:27:48.528549031Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5754078637829449,
+				"StableID":   "npQtJYt2wm11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89e9278cff4ffd35726275e2f33cc435cf178f19d1f308ee49733f5b7b2d2a4e",
+				"DiscoKey":   "discokey:71d738fdb8ec362b475791cff47c068af4a60dca6d9b6aa601cd88bf122a942d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52491",
+					"10.65.0.27:52491",
+					"172.17.0.1:52491",
+					"172.18.0.1:52491",
+					"172.19.0.1:52491"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:27:49.108563037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1275044730199096,
+				"StableID":   "nus5dFGUxA11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7e9f4f0d500c03579fb1407e64095477a38852f73331366cd2e720f7a3fdbe33",
+				"KeyExpiry":  "2026-11-09T07:27:49Z",
+				"DiscoKey":   "discokey:dbd96448f403b268cf76693a04e0de5abfc8bbe992261f5d1bb178c855eb450e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35822",
+					"10.65.0.27:35822",
+					"172.17.0.1:35822",
+					"172.18.0.1:35822",
+					"172.19.0.1:35822"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:27:49.593623884Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7728681379644409,
+				"StableID":   "nSZotYMLM321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:da34f20900d2b203364376c411053a021df11d51a5388655ada04c63cbe63e16",
+				"KeyExpiry":  "2026-11-09T07:27:50Z",
+				"DiscoKey":   "discokey:d5fcb861f1f70ba56e89b846a13fa0ec331c83ce8d3c7b5ffbd669d28369cb7c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57163",
+					"10.65.0.27:57163",
+					"172.17.0.1:57163",
+					"172.18.0.1:57163",
+					"172.19.0.1:57163"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:27:50.14121441Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1395127351755263,
+				"StableID":   "nNpkgXdrtB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bb380a4b82bc4518c49bd400b2ed47acba9ac6836b6d37444852094610d13859",
+				"KeyExpiry":  "2026-11-09T07:27:50Z",
+				"DiscoKey":   "discokey:034a16542b75207a9ed5d8bd65c0ae29a7aea5f56839a655d79193d768e02a1e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49991",
+					"10.65.0.27:49991",
+					"172.17.0.1:49991",
+					"172.18.0.1:49991",
+					"172.19.0.1:49991"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:27:50.681748161Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3139804488792044": {
+				"ID":          3139804488792044,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1395127351755263,
+				"StableID":   "nNpkgXdrtB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bb380a4b82bc4518c49bd400b2ed47acba9ac6836b6d37444852094610d13859",
+				"KeyExpiry":  "2026-11-09T07:27:50Z",
+				"DiscoKey":   "discokey:034a16542b75207a9ed5d8bd65c0ae29a7aea5f56839a655d79193d768e02a1e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49991",
+					"10.65.0.27:49991",
+					"172.17.0.1:49991",
+					"172.18.0.1:49991",
+					"172.19.0.1:49991"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:27:50.681748161Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:bb380a4b82bc4518c49bd400b2ed47acba9ac6836b6d37444852094610d13859",
+			"MachineKey": "mkey:ffaf10f97c5f231123d9e4c8c42e516d89a1ee0d303f59530cc740ba85e76838",
+			"Peers": [{
+				"ID":         861188056879115,
+				"StableID":   "nep1b6x2j711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5aae13a99589250ac3d1c06e3f26b7fd4a4a7376855b8105f5d0ac4a5f836078",
+				"DiscoKey":   "discokey:b0f4876c78433341521539cab25b0294b9d51eab808453fcd7caa156b89e410b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33599",
+					"10.65.0.27:33599",
+					"172.17.0.1:33599",
+					"172.18.0.1:33599",
+					"172.19.0.1:33599"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:27:43.135263897Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8680699854276825,
+				"StableID":   "npCpTPGWnA21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca8a6a98d72a7299ae22c8fbe3c309802fa6bfad81f34ae4b6ab68e567ec0077",
+				"DiscoKey":   "discokey:3a8c1193f3f7b30ee3253786e153ec7a6caea9c3e45fec0f9e8edf096abb8636",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47028",
+					"10.65.0.27:47028",
+					"172.17.0.1:47028",
+					"172.18.0.1:47028",
+					"172.19.0.1:47028"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:27:43.669011539Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7141861004647675,
+				"StableID":   "nxswpXaZmx11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:101a448995c3d6088408b6d310d2c246b8cb108e313f458a60494d6ba3b8f649",
+				"DiscoKey":   "discokey:04e1b3ea416ffabc3361e318906a44424b26046b1dab688e41d76a4471018817",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:55525",
+					"10.65.0.27:55525",
+					"172.17.0.1:55525",
+					"172.18.0.1:55525",
+					"172.19.0.1:55525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:27:44.207628464Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4724336270747769,
+				"StableID":   "nEMxWZJftd11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30f892f7bf584cc6bf53e6d1d8472cd1ad358778d8d54ca0a4d5e8900d6a6e5e",
+				"DiscoKey":   "discokey:8417d86473fc456799814fdd6faaf71e51b532007083044189e3d101e5efd52d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:57107",
+					"10.65.0.27:57107",
+					"172.17.0.1:57107",
+					"172.18.0.1:57107",
+					"172.19.0.1:57107"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:27:44.734810873Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8306001689644191,
+				"StableID":   "nYwLkdaor721CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a5e228e792c32bfea34fa4add85183afa63867b171f98fa3737b2222757354e",
+				"DiscoKey":   "discokey:6e021862e7bef2bfada8f496e1eeee9bf708020843199a6c84e803460a8e8507",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:32931",
+					"10.65.0.27:32931",
+					"172.17.0.1:32931",
+					"172.18.0.1:32931",
+					"172.19.0.1:32931"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:27:45.286098032Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3139804488792044,
+				"StableID":   "nyBKvhL2XR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38b2d8f4c228100b4a011eb21dda558b54b3b965a993400049da04ce6b21a167",
+				"DiscoKey":   "discokey:a9f091671070ace677a8b44946c1f04c47f21ba55ea77c22e9d451f53c1f9c46",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:47293",
+					"10.65.0.27:47293",
+					"172.17.0.1:47293",
+					"172.18.0.1:47293",
+					"172.19.0.1:47293"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:27:45.822145352Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7714839673165703,
+				"StableID":   "ncF3hrk4F321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25f4b5e0d6d381db768cd6c224a14353b8f4e70717ed107f3698bcf79e14f345",
+				"DiscoKey":   "discokey:998a0eaf6711bf018a4e6bc3c8691c9be4f62ec36ca79ebdd3f0d6e03526900a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53262",
+					"10.65.0.27:53262",
+					"172.17.0.1:53262",
+					"172.18.0.1:53262",
+					"172.19.0.1:53262"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:27:46.347864423Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6279102083833834,
+				"StableID":   "nmLfN8Np2r11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a2c8fddb2040b36249ef35875b968a36e0d9f46bb98f551e669c3547ca64d67",
+				"DiscoKey":   "discokey:be9cb3dd5314fc78543a7c84b45a849cc35c9610cc3e5761410906f55dc31a5a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55607",
+					"10.65.0.27:55607",
+					"172.17.0.1:55607",
+					"172.18.0.1:55607",
+					"172.19.0.1:55607"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:27:46.885923527Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7616952318553386,
+				"StableID":   "nRE3NSRjU221CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:101f3079531b10e63df90059a27f87c5c9a7dd5cd4725c2be86964b3130a2d3c",
+				"DiscoKey":   "discokey:aa1e16a303c85bc9f783441b1ca3082d148c350a1b4a555fc670bbab4644943b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37144",
+					"10.65.0.27:37144",
+					"172.17.0.1:37144",
+					"172.18.0.1:37144",
+					"172.19.0.1:37144"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:27:47.444165724Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6651177415959720,
+				"StableID":   "nhTxMq9Lwt11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e950c14af2a4aa67da69905cf19eaf45e9e16e2e206dc35bf6a0c98f122ed47e",
+				"DiscoKey":   "discokey:36feeedc7ce8198432f592577904564eea8d33e82a2fd50b87dc88e6e613e24b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35894",
+					"10.65.0.27:35894",
+					"172.17.0.1:35894",
+					"172.18.0.1:35894",
+					"172.19.0.1:35894"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:27:47.978293846Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2385266244843678,
+				"StableID":   "nhza6BuHdK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90ef1125fc078609ce1ceaa9a653d30d54d7ec45ee7e36f2075acf2fdcfe557d",
+				"DiscoKey":   "discokey:a10078731b5d6c055f2b8961088bb384d01ab8c32283c666984c264bce94290c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:33798",
+					"10.65.0.27:33798",
+					"172.17.0.1:33798",
+					"172.18.0.1:33798",
+					"172.19.0.1:33798"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:27:48.528549031Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5754078637829449,
+				"StableID":   "npQtJYt2wm11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89e9278cff4ffd35726275e2f33cc435cf178f19d1f308ee49733f5b7b2d2a4e",
+				"DiscoKey":   "discokey:71d738fdb8ec362b475791cff47c068af4a60dca6d9b6aa601cd88bf122a942d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52491",
+					"10.65.0.27:52491",
+					"172.17.0.1:52491",
+					"172.18.0.1:52491",
+					"172.19.0.1:52491"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:27:49.108563037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1275044730199096,
+				"StableID":   "nus5dFGUxA11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7e9f4f0d500c03579fb1407e64095477a38852f73331366cd2e720f7a3fdbe33",
+				"KeyExpiry":  "2026-11-09T07:27:49Z",
+				"DiscoKey":   "discokey:dbd96448f403b268cf76693a04e0de5abfc8bbe992261f5d1bb178c855eb450e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35822",
+					"10.65.0.27:35822",
+					"172.17.0.1:35822",
+					"172.18.0.1:35822",
+					"172.19.0.1:35822"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:27:49.593623884Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7728681379644409,
+				"StableID":   "nSZotYMLM321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:da34f20900d2b203364376c411053a021df11d51a5388655ada04c63cbe63e16",
+				"KeyExpiry":  "2026-11-09T07:27:50Z",
+				"DiscoKey":   "discokey:d5fcb861f1f70ba56e89b846a13fa0ec331c83ce8d3c7b5ffbd669d28369cb7c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57163",
+					"10.65.0.27:57163",
+					"172.17.0.1:57163",
+					"172.18.0.1:57163",
+					"172.19.0.1:57163"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:27:50.14121441Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7141861004647675,
+				"StableID":   "nxswpXaZmx11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       7141861004647675,
+				"Key":        "nodekey:101a448995c3d6088408b6d310d2c246b8cb108e313f458a60494d6ba3b8f649",
+				"DiscoKey":   "discokey:04e1b3ea416ffabc3361e318906a44424b26046b1dab688e41d76a4471018817",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:55525",
+					"10.65.0.27:55525",
+					"172.17.0.1:55525",
+					"172.18.0.1:55525",
+					"172.19.0.1:55525"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:27:44.207628464Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:101a448995c3d6088408b6d310d2c246b8cb108e313f458a60494d6ba3b8f649",
+			"MachineKey": "mkey:7272ce3c351f1befc2237b8159ef05bf7dbde0d4059bf4939b4919aff6f3ff33",
+			"Peers": [{
+				"ID":         861188056879115,
+				"StableID":   "nep1b6x2j711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5aae13a99589250ac3d1c06e3f26b7fd4a4a7376855b8105f5d0ac4a5f836078",
+				"DiscoKey":   "discokey:b0f4876c78433341521539cab25b0294b9d51eab808453fcd7caa156b89e410b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33599",
+					"10.65.0.27:33599",
+					"172.17.0.1:33599",
+					"172.18.0.1:33599",
+					"172.19.0.1:33599"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:27:43.135263897Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8680699854276825,
+				"StableID":   "npCpTPGWnA21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca8a6a98d72a7299ae22c8fbe3c309802fa6bfad81f34ae4b6ab68e567ec0077",
+				"DiscoKey":   "discokey:3a8c1193f3f7b30ee3253786e153ec7a6caea9c3e45fec0f9e8edf096abb8636",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47028",
+					"10.65.0.27:47028",
+					"172.17.0.1:47028",
+					"172.18.0.1:47028",
+					"172.19.0.1:47028"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:27:43.669011539Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4724336270747769,
+				"StableID":   "nEMxWZJftd11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30f892f7bf584cc6bf53e6d1d8472cd1ad358778d8d54ca0a4d5e8900d6a6e5e",
+				"DiscoKey":   "discokey:8417d86473fc456799814fdd6faaf71e51b532007083044189e3d101e5efd52d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:57107",
+					"10.65.0.27:57107",
+					"172.17.0.1:57107",
+					"172.18.0.1:57107",
+					"172.19.0.1:57107"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:27:44.734810873Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8306001689644191,
+				"StableID":   "nYwLkdaor721CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a5e228e792c32bfea34fa4add85183afa63867b171f98fa3737b2222757354e",
+				"DiscoKey":   "discokey:6e021862e7bef2bfada8f496e1eeee9bf708020843199a6c84e803460a8e8507",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:32931",
+					"10.65.0.27:32931",
+					"172.17.0.1:32931",
+					"172.18.0.1:32931",
+					"172.19.0.1:32931"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:27:45.286098032Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3139804488792044,
+				"StableID":   "nyBKvhL2XR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38b2d8f4c228100b4a011eb21dda558b54b3b965a993400049da04ce6b21a167",
+				"DiscoKey":   "discokey:a9f091671070ace677a8b44946c1f04c47f21ba55ea77c22e9d451f53c1f9c46",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:47293",
+					"10.65.0.27:47293",
+					"172.17.0.1:47293",
+					"172.18.0.1:47293",
+					"172.19.0.1:47293"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:27:45.822145352Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7714839673165703,
+				"StableID":   "ncF3hrk4F321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25f4b5e0d6d381db768cd6c224a14353b8f4e70717ed107f3698bcf79e14f345",
+				"DiscoKey":   "discokey:998a0eaf6711bf018a4e6bc3c8691c9be4f62ec36ca79ebdd3f0d6e03526900a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53262",
+					"10.65.0.27:53262",
+					"172.17.0.1:53262",
+					"172.18.0.1:53262",
+					"172.19.0.1:53262"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:27:46.347864423Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6279102083833834,
+				"StableID":   "nmLfN8Np2r11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a2c8fddb2040b36249ef35875b968a36e0d9f46bb98f551e669c3547ca64d67",
+				"DiscoKey":   "discokey:be9cb3dd5314fc78543a7c84b45a849cc35c9610cc3e5761410906f55dc31a5a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55607",
+					"10.65.0.27:55607",
+					"172.17.0.1:55607",
+					"172.18.0.1:55607",
+					"172.19.0.1:55607"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:27:46.885923527Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7616952318553386,
+				"StableID":   "nRE3NSRjU221CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:101f3079531b10e63df90059a27f87c5c9a7dd5cd4725c2be86964b3130a2d3c",
+				"DiscoKey":   "discokey:aa1e16a303c85bc9f783441b1ca3082d148c350a1b4a555fc670bbab4644943b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37144",
+					"10.65.0.27:37144",
+					"172.17.0.1:37144",
+					"172.18.0.1:37144",
+					"172.19.0.1:37144"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:27:47.444165724Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6651177415959720,
+				"StableID":   "nhTxMq9Lwt11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e950c14af2a4aa67da69905cf19eaf45e9e16e2e206dc35bf6a0c98f122ed47e",
+				"DiscoKey":   "discokey:36feeedc7ce8198432f592577904564eea8d33e82a2fd50b87dc88e6e613e24b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35894",
+					"10.65.0.27:35894",
+					"172.17.0.1:35894",
+					"172.18.0.1:35894",
+					"172.19.0.1:35894"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:27:47.978293846Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2385266244843678,
+				"StableID":   "nhza6BuHdK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90ef1125fc078609ce1ceaa9a653d30d54d7ec45ee7e36f2075acf2fdcfe557d",
+				"DiscoKey":   "discokey:a10078731b5d6c055f2b8961088bb384d01ab8c32283c666984c264bce94290c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:33798",
+					"10.65.0.27:33798",
+					"172.17.0.1:33798",
+					"172.18.0.1:33798",
+					"172.19.0.1:33798"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:27:48.528549031Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5754078637829449,
+				"StableID":   "npQtJYt2wm11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89e9278cff4ffd35726275e2f33cc435cf178f19d1f308ee49733f5b7b2d2a4e",
+				"DiscoKey":   "discokey:71d738fdb8ec362b475791cff47c068af4a60dca6d9b6aa601cd88bf122a942d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52491",
+					"10.65.0.27:52491",
+					"172.17.0.1:52491",
+					"172.18.0.1:52491",
+					"172.19.0.1:52491"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:27:49.108563037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1275044730199096,
+				"StableID":   "nus5dFGUxA11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7e9f4f0d500c03579fb1407e64095477a38852f73331366cd2e720f7a3fdbe33",
+				"KeyExpiry":  "2026-11-09T07:27:49Z",
+				"DiscoKey":   "discokey:dbd96448f403b268cf76693a04e0de5abfc8bbe992261f5d1bb178c855eb450e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35822",
+					"10.65.0.27:35822",
+					"172.17.0.1:35822",
+					"172.18.0.1:35822",
+					"172.19.0.1:35822"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:27:49.593623884Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7728681379644409,
+				"StableID":   "nSZotYMLM321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:da34f20900d2b203364376c411053a021df11d51a5388655ada04c63cbe63e16",
+				"KeyExpiry":  "2026-11-09T07:27:50Z",
+				"DiscoKey":   "discokey:d5fcb861f1f70ba56e89b846a13fa0ec331c83ce8d3c7b5ffbd669d28369cb7c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57163",
+					"10.65.0.27:57163",
+					"172.17.0.1:57163",
+					"172.18.0.1:57163",
+					"172.19.0.1:57163"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:27:50.14121441Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1395127351755263,
+				"StableID":   "nNpkgXdrtB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bb380a4b82bc4518c49bd400b2ed47acba9ac6836b6d37444852094610d13859",
+				"KeyExpiry":  "2026-11-09T07:27:50Z",
+				"DiscoKey":   "discokey:034a16542b75207a9ed5d8bd65c0ae29a7aea5f56839a655d79193d768e02a1e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49991",
+					"10.65.0.27:49991",
+					"172.17.0.1:49991",
+					"172.18.0.1:49991",
+					"172.19.0.1:49991"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:27:50.681748161Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7141861004647675": {
+				"ID":          7141861004647675,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6279102083833834,
+				"StableID":   "nmLfN8Np2r11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       6279102083833834,
+				"Key":        "nodekey:3a2c8fddb2040b36249ef35875b968a36e0d9f46bb98f551e669c3547ca64d67",
+				"DiscoKey":   "discokey:be9cb3dd5314fc78543a7c84b45a849cc35c9610cc3e5761410906f55dc31a5a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55607",
+					"10.65.0.27:55607",
+					"172.17.0.1:55607",
+					"172.18.0.1:55607",
+					"172.19.0.1:55607"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:27:46.885923527Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3a2c8fddb2040b36249ef35875b968a36e0d9f46bb98f551e669c3547ca64d67",
+			"MachineKey": "mkey:bd74227629135faede8997910c554007f4b10d4ddb53f64f675af79feac0b03f",
+			"Peers": [{
+				"ID":         861188056879115,
+				"StableID":   "nep1b6x2j711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5aae13a99589250ac3d1c06e3f26b7fd4a4a7376855b8105f5d0ac4a5f836078",
+				"DiscoKey":   "discokey:b0f4876c78433341521539cab25b0294b9d51eab808453fcd7caa156b89e410b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33599",
+					"10.65.0.27:33599",
+					"172.17.0.1:33599",
+					"172.18.0.1:33599",
+					"172.19.0.1:33599"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:27:43.135263897Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8680699854276825,
+				"StableID":   "npCpTPGWnA21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca8a6a98d72a7299ae22c8fbe3c309802fa6bfad81f34ae4b6ab68e567ec0077",
+				"DiscoKey":   "discokey:3a8c1193f3f7b30ee3253786e153ec7a6caea9c3e45fec0f9e8edf096abb8636",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47028",
+					"10.65.0.27:47028",
+					"172.17.0.1:47028",
+					"172.18.0.1:47028",
+					"172.19.0.1:47028"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:27:43.669011539Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7141861004647675,
+				"StableID":   "nxswpXaZmx11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:101a448995c3d6088408b6d310d2c246b8cb108e313f458a60494d6ba3b8f649",
+				"DiscoKey":   "discokey:04e1b3ea416ffabc3361e318906a44424b26046b1dab688e41d76a4471018817",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:55525",
+					"10.65.0.27:55525",
+					"172.17.0.1:55525",
+					"172.18.0.1:55525",
+					"172.19.0.1:55525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:27:44.207628464Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4724336270747769,
+				"StableID":   "nEMxWZJftd11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30f892f7bf584cc6bf53e6d1d8472cd1ad358778d8d54ca0a4d5e8900d6a6e5e",
+				"DiscoKey":   "discokey:8417d86473fc456799814fdd6faaf71e51b532007083044189e3d101e5efd52d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:57107",
+					"10.65.0.27:57107",
+					"172.17.0.1:57107",
+					"172.18.0.1:57107",
+					"172.19.0.1:57107"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:27:44.734810873Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8306001689644191,
+				"StableID":   "nYwLkdaor721CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a5e228e792c32bfea34fa4add85183afa63867b171f98fa3737b2222757354e",
+				"DiscoKey":   "discokey:6e021862e7bef2bfada8f496e1eeee9bf708020843199a6c84e803460a8e8507",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:32931",
+					"10.65.0.27:32931",
+					"172.17.0.1:32931",
+					"172.18.0.1:32931",
+					"172.19.0.1:32931"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:27:45.286098032Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3139804488792044,
+				"StableID":   "nyBKvhL2XR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38b2d8f4c228100b4a011eb21dda558b54b3b965a993400049da04ce6b21a167",
+				"DiscoKey":   "discokey:a9f091671070ace677a8b44946c1f04c47f21ba55ea77c22e9d451f53c1f9c46",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:47293",
+					"10.65.0.27:47293",
+					"172.17.0.1:47293",
+					"172.18.0.1:47293",
+					"172.19.0.1:47293"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:27:45.822145352Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7714839673165703,
+				"StableID":   "ncF3hrk4F321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25f4b5e0d6d381db768cd6c224a14353b8f4e70717ed107f3698bcf79e14f345",
+				"DiscoKey":   "discokey:998a0eaf6711bf018a4e6bc3c8691c9be4f62ec36ca79ebdd3f0d6e03526900a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53262",
+					"10.65.0.27:53262",
+					"172.17.0.1:53262",
+					"172.18.0.1:53262",
+					"172.19.0.1:53262"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:27:46.347864423Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7616952318553386,
+				"StableID":   "nRE3NSRjU221CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:101f3079531b10e63df90059a27f87c5c9a7dd5cd4725c2be86964b3130a2d3c",
+				"DiscoKey":   "discokey:aa1e16a303c85bc9f783441b1ca3082d148c350a1b4a555fc670bbab4644943b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37144",
+					"10.65.0.27:37144",
+					"172.17.0.1:37144",
+					"172.18.0.1:37144",
+					"172.19.0.1:37144"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:27:47.444165724Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6651177415959720,
+				"StableID":   "nhTxMq9Lwt11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e950c14af2a4aa67da69905cf19eaf45e9e16e2e206dc35bf6a0c98f122ed47e",
+				"DiscoKey":   "discokey:36feeedc7ce8198432f592577904564eea8d33e82a2fd50b87dc88e6e613e24b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35894",
+					"10.65.0.27:35894",
+					"172.17.0.1:35894",
+					"172.18.0.1:35894",
+					"172.19.0.1:35894"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:27:47.978293846Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2385266244843678,
+				"StableID":   "nhza6BuHdK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90ef1125fc078609ce1ceaa9a653d30d54d7ec45ee7e36f2075acf2fdcfe557d",
+				"DiscoKey":   "discokey:a10078731b5d6c055f2b8961088bb384d01ab8c32283c666984c264bce94290c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:33798",
+					"10.65.0.27:33798",
+					"172.17.0.1:33798",
+					"172.18.0.1:33798",
+					"172.19.0.1:33798"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:27:48.528549031Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5754078637829449,
+				"StableID":   "npQtJYt2wm11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89e9278cff4ffd35726275e2f33cc435cf178f19d1f308ee49733f5b7b2d2a4e",
+				"DiscoKey":   "discokey:71d738fdb8ec362b475791cff47c068af4a60dca6d9b6aa601cd88bf122a942d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52491",
+					"10.65.0.27:52491",
+					"172.17.0.1:52491",
+					"172.18.0.1:52491",
+					"172.19.0.1:52491"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:27:49.108563037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1275044730199096,
+				"StableID":   "nus5dFGUxA11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7e9f4f0d500c03579fb1407e64095477a38852f73331366cd2e720f7a3fdbe33",
+				"KeyExpiry":  "2026-11-09T07:27:49Z",
+				"DiscoKey":   "discokey:dbd96448f403b268cf76693a04e0de5abfc8bbe992261f5d1bb178c855eb450e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35822",
+					"10.65.0.27:35822",
+					"172.17.0.1:35822",
+					"172.18.0.1:35822",
+					"172.19.0.1:35822"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:27:49.593623884Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7728681379644409,
+				"StableID":   "nSZotYMLM321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:da34f20900d2b203364376c411053a021df11d51a5388655ada04c63cbe63e16",
+				"KeyExpiry":  "2026-11-09T07:27:50Z",
+				"DiscoKey":   "discokey:d5fcb861f1f70ba56e89b846a13fa0ec331c83ce8d3c7b5ffbd669d28369cb7c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57163",
+					"10.65.0.27:57163",
+					"172.17.0.1:57163",
+					"172.18.0.1:57163",
+					"172.19.0.1:57163"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:27:50.14121441Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1395127351755263,
+				"StableID":   "nNpkgXdrtB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bb380a4b82bc4518c49bd400b2ed47acba9ac6836b6d37444852094610d13859",
+				"KeyExpiry":  "2026-11-09T07:27:50Z",
+				"DiscoKey":   "discokey:034a16542b75207a9ed5d8bd65c0ae29a7aea5f56839a655d79193d768e02a1e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49991",
+					"10.65.0.27:49991",
+					"172.17.0.1:49991",
+					"172.18.0.1:49991",
+					"172.19.0.1:49991"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:27:50.681748161Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6279102083833834": {
+				"ID":          6279102083833834,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1275044730199096,
+				"StableID":   "nus5dFGUxA11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7e9f4f0d500c03579fb1407e64095477a38852f73331366cd2e720f7a3fdbe33",
+				"KeyExpiry":  "2026-11-09T07:27:49Z",
+				"DiscoKey":   "discokey:dbd96448f403b268cf76693a04e0de5abfc8bbe992261f5d1bb178c855eb450e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35822",
+					"10.65.0.27:35822",
+					"172.17.0.1:35822",
+					"172.18.0.1:35822",
+					"172.19.0.1:35822"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:27:49.593623884Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7e9f4f0d500c03579fb1407e64095477a38852f73331366cd2e720f7a3fdbe33",
+			"MachineKey": "mkey:f64a64e2ccf54363f4e3458cdc4d7a7c681bd6b2c4d2b5bcbe0b058e04ac3a55",
+			"Peers": [{
+				"ID":         861188056879115,
+				"StableID":   "nep1b6x2j711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5aae13a99589250ac3d1c06e3f26b7fd4a4a7376855b8105f5d0ac4a5f836078",
+				"DiscoKey":   "discokey:b0f4876c78433341521539cab25b0294b9d51eab808453fcd7caa156b89e410b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33599",
+					"10.65.0.27:33599",
+					"172.17.0.1:33599",
+					"172.18.0.1:33599",
+					"172.19.0.1:33599"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:27:43.135263897Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8680699854276825,
+				"StableID":   "npCpTPGWnA21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca8a6a98d72a7299ae22c8fbe3c309802fa6bfad81f34ae4b6ab68e567ec0077",
+				"DiscoKey":   "discokey:3a8c1193f3f7b30ee3253786e153ec7a6caea9c3e45fec0f9e8edf096abb8636",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47028",
+					"10.65.0.27:47028",
+					"172.17.0.1:47028",
+					"172.18.0.1:47028",
+					"172.19.0.1:47028"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:27:43.669011539Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7141861004647675,
+				"StableID":   "nxswpXaZmx11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:101a448995c3d6088408b6d310d2c246b8cb108e313f458a60494d6ba3b8f649",
+				"DiscoKey":   "discokey:04e1b3ea416ffabc3361e318906a44424b26046b1dab688e41d76a4471018817",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:55525",
+					"10.65.0.27:55525",
+					"172.17.0.1:55525",
+					"172.18.0.1:55525",
+					"172.19.0.1:55525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:27:44.207628464Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4724336270747769,
+				"StableID":   "nEMxWZJftd11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30f892f7bf584cc6bf53e6d1d8472cd1ad358778d8d54ca0a4d5e8900d6a6e5e",
+				"DiscoKey":   "discokey:8417d86473fc456799814fdd6faaf71e51b532007083044189e3d101e5efd52d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:57107",
+					"10.65.0.27:57107",
+					"172.17.0.1:57107",
+					"172.18.0.1:57107",
+					"172.19.0.1:57107"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:27:44.734810873Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8306001689644191,
+				"StableID":   "nYwLkdaor721CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a5e228e792c32bfea34fa4add85183afa63867b171f98fa3737b2222757354e",
+				"DiscoKey":   "discokey:6e021862e7bef2bfada8f496e1eeee9bf708020843199a6c84e803460a8e8507",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:32931",
+					"10.65.0.27:32931",
+					"172.17.0.1:32931",
+					"172.18.0.1:32931",
+					"172.19.0.1:32931"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:27:45.286098032Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3139804488792044,
+				"StableID":   "nyBKvhL2XR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38b2d8f4c228100b4a011eb21dda558b54b3b965a993400049da04ce6b21a167",
+				"DiscoKey":   "discokey:a9f091671070ace677a8b44946c1f04c47f21ba55ea77c22e9d451f53c1f9c46",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:47293",
+					"10.65.0.27:47293",
+					"172.17.0.1:47293",
+					"172.18.0.1:47293",
+					"172.19.0.1:47293"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:27:45.822145352Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7714839673165703,
+				"StableID":   "ncF3hrk4F321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25f4b5e0d6d381db768cd6c224a14353b8f4e70717ed107f3698bcf79e14f345",
+				"DiscoKey":   "discokey:998a0eaf6711bf018a4e6bc3c8691c9be4f62ec36ca79ebdd3f0d6e03526900a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53262",
+					"10.65.0.27:53262",
+					"172.17.0.1:53262",
+					"172.18.0.1:53262",
+					"172.19.0.1:53262"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:27:46.347864423Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6279102083833834,
+				"StableID":   "nmLfN8Np2r11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a2c8fddb2040b36249ef35875b968a36e0d9f46bb98f551e669c3547ca64d67",
+				"DiscoKey":   "discokey:be9cb3dd5314fc78543a7c84b45a849cc35c9610cc3e5761410906f55dc31a5a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55607",
+					"10.65.0.27:55607",
+					"172.17.0.1:55607",
+					"172.18.0.1:55607",
+					"172.19.0.1:55607"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:27:46.885923527Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7616952318553386,
+				"StableID":   "nRE3NSRjU221CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:101f3079531b10e63df90059a27f87c5c9a7dd5cd4725c2be86964b3130a2d3c",
+				"DiscoKey":   "discokey:aa1e16a303c85bc9f783441b1ca3082d148c350a1b4a555fc670bbab4644943b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37144",
+					"10.65.0.27:37144",
+					"172.17.0.1:37144",
+					"172.18.0.1:37144",
+					"172.19.0.1:37144"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:27:47.444165724Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6651177415959720,
+				"StableID":   "nhTxMq9Lwt11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e950c14af2a4aa67da69905cf19eaf45e9e16e2e206dc35bf6a0c98f122ed47e",
+				"DiscoKey":   "discokey:36feeedc7ce8198432f592577904564eea8d33e82a2fd50b87dc88e6e613e24b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35894",
+					"10.65.0.27:35894",
+					"172.17.0.1:35894",
+					"172.18.0.1:35894",
+					"172.19.0.1:35894"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:27:47.978293846Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2385266244843678,
+				"StableID":   "nhza6BuHdK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90ef1125fc078609ce1ceaa9a653d30d54d7ec45ee7e36f2075acf2fdcfe557d",
+				"DiscoKey":   "discokey:a10078731b5d6c055f2b8961088bb384d01ab8c32283c666984c264bce94290c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:33798",
+					"10.65.0.27:33798",
+					"172.17.0.1:33798",
+					"172.18.0.1:33798",
+					"172.19.0.1:33798"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:27:48.528549031Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5754078637829449,
+				"StableID":   "npQtJYt2wm11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89e9278cff4ffd35726275e2f33cc435cf178f19d1f308ee49733f5b7b2d2a4e",
+				"DiscoKey":   "discokey:71d738fdb8ec362b475791cff47c068af4a60dca6d9b6aa601cd88bf122a942d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52491",
+					"10.65.0.27:52491",
+					"172.17.0.1:52491",
+					"172.18.0.1:52491",
+					"172.19.0.1:52491"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:27:49.108563037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7728681379644409,
+				"StableID":   "nSZotYMLM321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:da34f20900d2b203364376c411053a021df11d51a5388655ada04c63cbe63e16",
+				"KeyExpiry":  "2026-11-09T07:27:50Z",
+				"DiscoKey":   "discokey:d5fcb861f1f70ba56e89b846a13fa0ec331c83ce8d3c7b5ffbd669d28369cb7c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57163",
+					"10.65.0.27:57163",
+					"172.17.0.1:57163",
+					"172.18.0.1:57163",
+					"172.19.0.1:57163"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:27:50.14121441Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1395127351755263,
+				"StableID":   "nNpkgXdrtB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bb380a4b82bc4518c49bd400b2ed47acba9ac6836b6d37444852094610d13859",
+				"KeyExpiry":  "2026-11-09T07:27:50Z",
+				"DiscoKey":   "discokey:034a16542b75207a9ed5d8bd65c0ae29a7aea5f56839a655d79193d768e02a1e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49991",
+					"10.65.0.27:49991",
+					"172.17.0.1:49991",
+					"172.18.0.1:49991",
+					"172.19.0.1:49991"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:27:50.681748161Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2385266244843678,
+				"StableID":   "nhza6BuHdK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       2385266244843678,
+				"Key":        "nodekey:90ef1125fc078609ce1ceaa9a653d30d54d7ec45ee7e36f2075acf2fdcfe557d",
+				"DiscoKey":   "discokey:a10078731b5d6c055f2b8961088bb384d01ab8c32283c666984c264bce94290c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:33798",
+					"10.65.0.27:33798",
+					"172.17.0.1:33798",
+					"172.18.0.1:33798",
+					"172.19.0.1:33798"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:27:48.528549031Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:90ef1125fc078609ce1ceaa9a653d30d54d7ec45ee7e36f2075acf2fdcfe557d",
+			"MachineKey": "mkey:1fd340ed06774d55796b9a9687457cfc3ca4402695498c965b8d309bde32e229",
+			"Peers": [{
+				"ID":         861188056879115,
+				"StableID":   "nep1b6x2j711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5aae13a99589250ac3d1c06e3f26b7fd4a4a7376855b8105f5d0ac4a5f836078",
+				"DiscoKey":   "discokey:b0f4876c78433341521539cab25b0294b9d51eab808453fcd7caa156b89e410b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33599",
+					"10.65.0.27:33599",
+					"172.17.0.1:33599",
+					"172.18.0.1:33599",
+					"172.19.0.1:33599"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:27:43.135263897Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8680699854276825,
+				"StableID":   "npCpTPGWnA21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca8a6a98d72a7299ae22c8fbe3c309802fa6bfad81f34ae4b6ab68e567ec0077",
+				"DiscoKey":   "discokey:3a8c1193f3f7b30ee3253786e153ec7a6caea9c3e45fec0f9e8edf096abb8636",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47028",
+					"10.65.0.27:47028",
+					"172.17.0.1:47028",
+					"172.18.0.1:47028",
+					"172.19.0.1:47028"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:27:43.669011539Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7141861004647675,
+				"StableID":   "nxswpXaZmx11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:101a448995c3d6088408b6d310d2c246b8cb108e313f458a60494d6ba3b8f649",
+				"DiscoKey":   "discokey:04e1b3ea416ffabc3361e318906a44424b26046b1dab688e41d76a4471018817",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:55525",
+					"10.65.0.27:55525",
+					"172.17.0.1:55525",
+					"172.18.0.1:55525",
+					"172.19.0.1:55525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:27:44.207628464Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4724336270747769,
+				"StableID":   "nEMxWZJftd11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30f892f7bf584cc6bf53e6d1d8472cd1ad358778d8d54ca0a4d5e8900d6a6e5e",
+				"DiscoKey":   "discokey:8417d86473fc456799814fdd6faaf71e51b532007083044189e3d101e5efd52d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:57107",
+					"10.65.0.27:57107",
+					"172.17.0.1:57107",
+					"172.18.0.1:57107",
+					"172.19.0.1:57107"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:27:44.734810873Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8306001689644191,
+				"StableID":   "nYwLkdaor721CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a5e228e792c32bfea34fa4add85183afa63867b171f98fa3737b2222757354e",
+				"DiscoKey":   "discokey:6e021862e7bef2bfada8f496e1eeee9bf708020843199a6c84e803460a8e8507",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:32931",
+					"10.65.0.27:32931",
+					"172.17.0.1:32931",
+					"172.18.0.1:32931",
+					"172.19.0.1:32931"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:27:45.286098032Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3139804488792044,
+				"StableID":   "nyBKvhL2XR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38b2d8f4c228100b4a011eb21dda558b54b3b965a993400049da04ce6b21a167",
+				"DiscoKey":   "discokey:a9f091671070ace677a8b44946c1f04c47f21ba55ea77c22e9d451f53c1f9c46",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:47293",
+					"10.65.0.27:47293",
+					"172.17.0.1:47293",
+					"172.18.0.1:47293",
+					"172.19.0.1:47293"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:27:45.822145352Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7714839673165703,
+				"StableID":   "ncF3hrk4F321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25f4b5e0d6d381db768cd6c224a14353b8f4e70717ed107f3698bcf79e14f345",
+				"DiscoKey":   "discokey:998a0eaf6711bf018a4e6bc3c8691c9be4f62ec36ca79ebdd3f0d6e03526900a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53262",
+					"10.65.0.27:53262",
+					"172.17.0.1:53262",
+					"172.18.0.1:53262",
+					"172.19.0.1:53262"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:27:46.347864423Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6279102083833834,
+				"StableID":   "nmLfN8Np2r11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a2c8fddb2040b36249ef35875b968a36e0d9f46bb98f551e669c3547ca64d67",
+				"DiscoKey":   "discokey:be9cb3dd5314fc78543a7c84b45a849cc35c9610cc3e5761410906f55dc31a5a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55607",
+					"10.65.0.27:55607",
+					"172.17.0.1:55607",
+					"172.18.0.1:55607",
+					"172.19.0.1:55607"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:27:46.885923527Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7616952318553386,
+				"StableID":   "nRE3NSRjU221CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:101f3079531b10e63df90059a27f87c5c9a7dd5cd4725c2be86964b3130a2d3c",
+				"DiscoKey":   "discokey:aa1e16a303c85bc9f783441b1ca3082d148c350a1b4a555fc670bbab4644943b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37144",
+					"10.65.0.27:37144",
+					"172.17.0.1:37144",
+					"172.18.0.1:37144",
+					"172.19.0.1:37144"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:27:47.444165724Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6651177415959720,
+				"StableID":   "nhTxMq9Lwt11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e950c14af2a4aa67da69905cf19eaf45e9e16e2e206dc35bf6a0c98f122ed47e",
+				"DiscoKey":   "discokey:36feeedc7ce8198432f592577904564eea8d33e82a2fd50b87dc88e6e613e24b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35894",
+					"10.65.0.27:35894",
+					"172.17.0.1:35894",
+					"172.18.0.1:35894",
+					"172.19.0.1:35894"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:27:47.978293846Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5754078637829449,
+				"StableID":   "npQtJYt2wm11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89e9278cff4ffd35726275e2f33cc435cf178f19d1f308ee49733f5b7b2d2a4e",
+				"DiscoKey":   "discokey:71d738fdb8ec362b475791cff47c068af4a60dca6d9b6aa601cd88bf122a942d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52491",
+					"10.65.0.27:52491",
+					"172.17.0.1:52491",
+					"172.18.0.1:52491",
+					"172.19.0.1:52491"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:27:49.108563037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1275044730199096,
+				"StableID":   "nus5dFGUxA11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7e9f4f0d500c03579fb1407e64095477a38852f73331366cd2e720f7a3fdbe33",
+				"KeyExpiry":  "2026-11-09T07:27:49Z",
+				"DiscoKey":   "discokey:dbd96448f403b268cf76693a04e0de5abfc8bbe992261f5d1bb178c855eb450e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35822",
+					"10.65.0.27:35822",
+					"172.17.0.1:35822",
+					"172.18.0.1:35822",
+					"172.19.0.1:35822"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:27:49.593623884Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7728681379644409,
+				"StableID":   "nSZotYMLM321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:da34f20900d2b203364376c411053a021df11d51a5388655ada04c63cbe63e16",
+				"KeyExpiry":  "2026-11-09T07:27:50Z",
+				"DiscoKey":   "discokey:d5fcb861f1f70ba56e89b846a13fa0ec331c83ce8d3c7b5ffbd669d28369cb7c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57163",
+					"10.65.0.27:57163",
+					"172.17.0.1:57163",
+					"172.18.0.1:57163",
+					"172.19.0.1:57163"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:27:50.14121441Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1395127351755263,
+				"StableID":   "nNpkgXdrtB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bb380a4b82bc4518c49bd400b2ed47acba9ac6836b6d37444852094610d13859",
+				"KeyExpiry":  "2026-11-09T07:27:50Z",
+				"DiscoKey":   "discokey:034a16542b75207a9ed5d8bd65c0ae29a7aea5f56839a655d79193d768e02a1e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49991",
+					"10.65.0.27:49991",
+					"172.17.0.1:49991",
+					"172.18.0.1:49991",
+					"172.19.0.1:49991"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:27:50.681748161Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2385266244843678": {
+				"ID":          2385266244843678,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8680699854276825,
+				"StableID":   "npCpTPGWnA21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       8680699854276825,
+				"Key":        "nodekey:ca8a6a98d72a7299ae22c8fbe3c309802fa6bfad81f34ae4b6ab68e567ec0077",
+				"DiscoKey":   "discokey:3a8c1193f3f7b30ee3253786e153ec7a6caea9c3e45fec0f9e8edf096abb8636",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47028",
+					"10.65.0.27:47028",
+					"172.17.0.1:47028",
+					"172.18.0.1:47028",
+					"172.19.0.1:47028"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:27:43.669011539Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ca8a6a98d72a7299ae22c8fbe3c309802fa6bfad81f34ae4b6ab68e567ec0077",
+			"MachineKey": "mkey:35c3cbcdaddc6578480b2bee6792a7fe52b5ac0a5f9e38fb9bbc899a523f374c",
+			"Peers": [{
+				"ID":         861188056879115,
+				"StableID":   "nep1b6x2j711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5aae13a99589250ac3d1c06e3f26b7fd4a4a7376855b8105f5d0ac4a5f836078",
+				"DiscoKey":   "discokey:b0f4876c78433341521539cab25b0294b9d51eab808453fcd7caa156b89e410b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33599",
+					"10.65.0.27:33599",
+					"172.17.0.1:33599",
+					"172.18.0.1:33599",
+					"172.19.0.1:33599"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:27:43.135263897Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7141861004647675,
+				"StableID":   "nxswpXaZmx11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:101a448995c3d6088408b6d310d2c246b8cb108e313f458a60494d6ba3b8f649",
+				"DiscoKey":   "discokey:04e1b3ea416ffabc3361e318906a44424b26046b1dab688e41d76a4471018817",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:55525",
+					"10.65.0.27:55525",
+					"172.17.0.1:55525",
+					"172.18.0.1:55525",
+					"172.19.0.1:55525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:27:44.207628464Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4724336270747769,
+				"StableID":   "nEMxWZJftd11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30f892f7bf584cc6bf53e6d1d8472cd1ad358778d8d54ca0a4d5e8900d6a6e5e",
+				"DiscoKey":   "discokey:8417d86473fc456799814fdd6faaf71e51b532007083044189e3d101e5efd52d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:57107",
+					"10.65.0.27:57107",
+					"172.17.0.1:57107",
+					"172.18.0.1:57107",
+					"172.19.0.1:57107"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:27:44.734810873Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8306001689644191,
+				"StableID":   "nYwLkdaor721CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a5e228e792c32bfea34fa4add85183afa63867b171f98fa3737b2222757354e",
+				"DiscoKey":   "discokey:6e021862e7bef2bfada8f496e1eeee9bf708020843199a6c84e803460a8e8507",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:32931",
+					"10.65.0.27:32931",
+					"172.17.0.1:32931",
+					"172.18.0.1:32931",
+					"172.19.0.1:32931"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:27:45.286098032Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3139804488792044,
+				"StableID":   "nyBKvhL2XR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38b2d8f4c228100b4a011eb21dda558b54b3b965a993400049da04ce6b21a167",
+				"DiscoKey":   "discokey:a9f091671070ace677a8b44946c1f04c47f21ba55ea77c22e9d451f53c1f9c46",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:47293",
+					"10.65.0.27:47293",
+					"172.17.0.1:47293",
+					"172.18.0.1:47293",
+					"172.19.0.1:47293"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:27:45.822145352Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7714839673165703,
+				"StableID":   "ncF3hrk4F321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25f4b5e0d6d381db768cd6c224a14353b8f4e70717ed107f3698bcf79e14f345",
+				"DiscoKey":   "discokey:998a0eaf6711bf018a4e6bc3c8691c9be4f62ec36ca79ebdd3f0d6e03526900a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53262",
+					"10.65.0.27:53262",
+					"172.17.0.1:53262",
+					"172.18.0.1:53262",
+					"172.19.0.1:53262"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:27:46.347864423Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6279102083833834,
+				"StableID":   "nmLfN8Np2r11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a2c8fddb2040b36249ef35875b968a36e0d9f46bb98f551e669c3547ca64d67",
+				"DiscoKey":   "discokey:be9cb3dd5314fc78543a7c84b45a849cc35c9610cc3e5761410906f55dc31a5a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55607",
+					"10.65.0.27:55607",
+					"172.17.0.1:55607",
+					"172.18.0.1:55607",
+					"172.19.0.1:55607"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:27:46.885923527Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7616952318553386,
+				"StableID":   "nRE3NSRjU221CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:101f3079531b10e63df90059a27f87c5c9a7dd5cd4725c2be86964b3130a2d3c",
+				"DiscoKey":   "discokey:aa1e16a303c85bc9f783441b1ca3082d148c350a1b4a555fc670bbab4644943b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37144",
+					"10.65.0.27:37144",
+					"172.17.0.1:37144",
+					"172.18.0.1:37144",
+					"172.19.0.1:37144"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:27:47.444165724Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6651177415959720,
+				"StableID":   "nhTxMq9Lwt11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e950c14af2a4aa67da69905cf19eaf45e9e16e2e206dc35bf6a0c98f122ed47e",
+				"DiscoKey":   "discokey:36feeedc7ce8198432f592577904564eea8d33e82a2fd50b87dc88e6e613e24b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35894",
+					"10.65.0.27:35894",
+					"172.17.0.1:35894",
+					"172.18.0.1:35894",
+					"172.19.0.1:35894"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:27:47.978293846Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2385266244843678,
+				"StableID":   "nhza6BuHdK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90ef1125fc078609ce1ceaa9a653d30d54d7ec45ee7e36f2075acf2fdcfe557d",
+				"DiscoKey":   "discokey:a10078731b5d6c055f2b8961088bb384d01ab8c32283c666984c264bce94290c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:33798",
+					"10.65.0.27:33798",
+					"172.17.0.1:33798",
+					"172.18.0.1:33798",
+					"172.19.0.1:33798"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:27:48.528549031Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5754078637829449,
+				"StableID":   "npQtJYt2wm11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89e9278cff4ffd35726275e2f33cc435cf178f19d1f308ee49733f5b7b2d2a4e",
+				"DiscoKey":   "discokey:71d738fdb8ec362b475791cff47c068af4a60dca6d9b6aa601cd88bf122a942d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52491",
+					"10.65.0.27:52491",
+					"172.17.0.1:52491",
+					"172.18.0.1:52491",
+					"172.19.0.1:52491"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:27:49.108563037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1275044730199096,
+				"StableID":   "nus5dFGUxA11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7e9f4f0d500c03579fb1407e64095477a38852f73331366cd2e720f7a3fdbe33",
+				"KeyExpiry":  "2026-11-09T07:27:49Z",
+				"DiscoKey":   "discokey:dbd96448f403b268cf76693a04e0de5abfc8bbe992261f5d1bb178c855eb450e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35822",
+					"10.65.0.27:35822",
+					"172.17.0.1:35822",
+					"172.18.0.1:35822",
+					"172.19.0.1:35822"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:27:49.593623884Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7728681379644409,
+				"StableID":   "nSZotYMLM321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:da34f20900d2b203364376c411053a021df11d51a5388655ada04c63cbe63e16",
+				"KeyExpiry":  "2026-11-09T07:27:50Z",
+				"DiscoKey":   "discokey:d5fcb861f1f70ba56e89b846a13fa0ec331c83ce8d3c7b5ffbd669d28369cb7c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57163",
+					"10.65.0.27:57163",
+					"172.17.0.1:57163",
+					"172.18.0.1:57163",
+					"172.19.0.1:57163"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:27:50.14121441Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1395127351755263,
+				"StableID":   "nNpkgXdrtB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bb380a4b82bc4518c49bd400b2ed47acba9ac6836b6d37444852094610d13859",
+				"KeyExpiry":  "2026-11-09T07:27:50Z",
+				"DiscoKey":   "discokey:034a16542b75207a9ed5d8bd65c0ae29a7aea5f56839a655d79193d768e02a1e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49991",
+					"10.65.0.27:49991",
+					"172.17.0.1:49991",
+					"172.18.0.1:49991",
+					"172.19.0.1:49991"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:27:50.681748161Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8680699854276825": {
+				"ID":          8680699854276825,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         861188056879115,
+				"StableID":   "nep1b6x2j711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       861188056879115,
+				"Key":        "nodekey:5aae13a99589250ac3d1c06e3f26b7fd4a4a7376855b8105f5d0ac4a5f836078",
+				"DiscoKey":   "discokey:b0f4876c78433341521539cab25b0294b9d51eab808453fcd7caa156b89e410b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33599",
+					"10.65.0.27:33599",
+					"172.17.0.1:33599",
+					"172.18.0.1:33599",
+					"172.19.0.1:33599"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:27:43.135263897Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5aae13a99589250ac3d1c06e3f26b7fd4a4a7376855b8105f5d0ac4a5f836078",
+			"MachineKey": "mkey:f8b029a96a3efb25acb8bc0db6fda43a587741c5242a4c6ea1ae6182b1203006",
+			"Peers": [{
+				"ID":         8680699854276825,
+				"StableID":   "npCpTPGWnA21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca8a6a98d72a7299ae22c8fbe3c309802fa6bfad81f34ae4b6ab68e567ec0077",
+				"DiscoKey":   "discokey:3a8c1193f3f7b30ee3253786e153ec7a6caea9c3e45fec0f9e8edf096abb8636",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47028",
+					"10.65.0.27:47028",
+					"172.17.0.1:47028",
+					"172.18.0.1:47028",
+					"172.19.0.1:47028"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:27:43.669011539Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7141861004647675,
+				"StableID":   "nxswpXaZmx11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:101a448995c3d6088408b6d310d2c246b8cb108e313f458a60494d6ba3b8f649",
+				"DiscoKey":   "discokey:04e1b3ea416ffabc3361e318906a44424b26046b1dab688e41d76a4471018817",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:55525",
+					"10.65.0.27:55525",
+					"172.17.0.1:55525",
+					"172.18.0.1:55525",
+					"172.19.0.1:55525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:27:44.207628464Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4724336270747769,
+				"StableID":   "nEMxWZJftd11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30f892f7bf584cc6bf53e6d1d8472cd1ad358778d8d54ca0a4d5e8900d6a6e5e",
+				"DiscoKey":   "discokey:8417d86473fc456799814fdd6faaf71e51b532007083044189e3d101e5efd52d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:57107",
+					"10.65.0.27:57107",
+					"172.17.0.1:57107",
+					"172.18.0.1:57107",
+					"172.19.0.1:57107"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:27:44.734810873Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8306001689644191,
+				"StableID":   "nYwLkdaor721CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a5e228e792c32bfea34fa4add85183afa63867b171f98fa3737b2222757354e",
+				"DiscoKey":   "discokey:6e021862e7bef2bfada8f496e1eeee9bf708020843199a6c84e803460a8e8507",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:32931",
+					"10.65.0.27:32931",
+					"172.17.0.1:32931",
+					"172.18.0.1:32931",
+					"172.19.0.1:32931"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:27:45.286098032Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3139804488792044,
+				"StableID":   "nyBKvhL2XR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38b2d8f4c228100b4a011eb21dda558b54b3b965a993400049da04ce6b21a167",
+				"DiscoKey":   "discokey:a9f091671070ace677a8b44946c1f04c47f21ba55ea77c22e9d451f53c1f9c46",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:47293",
+					"10.65.0.27:47293",
+					"172.17.0.1:47293",
+					"172.18.0.1:47293",
+					"172.19.0.1:47293"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:27:45.822145352Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7714839673165703,
+				"StableID":   "ncF3hrk4F321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25f4b5e0d6d381db768cd6c224a14353b8f4e70717ed107f3698bcf79e14f345",
+				"DiscoKey":   "discokey:998a0eaf6711bf018a4e6bc3c8691c9be4f62ec36ca79ebdd3f0d6e03526900a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53262",
+					"10.65.0.27:53262",
+					"172.17.0.1:53262",
+					"172.18.0.1:53262",
+					"172.19.0.1:53262"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:27:46.347864423Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6279102083833834,
+				"StableID":   "nmLfN8Np2r11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a2c8fddb2040b36249ef35875b968a36e0d9f46bb98f551e669c3547ca64d67",
+				"DiscoKey":   "discokey:be9cb3dd5314fc78543a7c84b45a849cc35c9610cc3e5761410906f55dc31a5a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55607",
+					"10.65.0.27:55607",
+					"172.17.0.1:55607",
+					"172.18.0.1:55607",
+					"172.19.0.1:55607"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:27:46.885923527Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7616952318553386,
+				"StableID":   "nRE3NSRjU221CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:101f3079531b10e63df90059a27f87c5c9a7dd5cd4725c2be86964b3130a2d3c",
+				"DiscoKey":   "discokey:aa1e16a303c85bc9f783441b1ca3082d148c350a1b4a555fc670bbab4644943b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37144",
+					"10.65.0.27:37144",
+					"172.17.0.1:37144",
+					"172.18.0.1:37144",
+					"172.19.0.1:37144"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:27:47.444165724Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6651177415959720,
+				"StableID":   "nhTxMq9Lwt11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e950c14af2a4aa67da69905cf19eaf45e9e16e2e206dc35bf6a0c98f122ed47e",
+				"DiscoKey":   "discokey:36feeedc7ce8198432f592577904564eea8d33e82a2fd50b87dc88e6e613e24b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35894",
+					"10.65.0.27:35894",
+					"172.17.0.1:35894",
+					"172.18.0.1:35894",
+					"172.19.0.1:35894"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:27:47.978293846Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2385266244843678,
+				"StableID":   "nhza6BuHdK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90ef1125fc078609ce1ceaa9a653d30d54d7ec45ee7e36f2075acf2fdcfe557d",
+				"DiscoKey":   "discokey:a10078731b5d6c055f2b8961088bb384d01ab8c32283c666984c264bce94290c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:33798",
+					"10.65.0.27:33798",
+					"172.17.0.1:33798",
+					"172.18.0.1:33798",
+					"172.19.0.1:33798"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:27:48.528549031Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5754078637829449,
+				"StableID":   "npQtJYt2wm11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89e9278cff4ffd35726275e2f33cc435cf178f19d1f308ee49733f5b7b2d2a4e",
+				"DiscoKey":   "discokey:71d738fdb8ec362b475791cff47c068af4a60dca6d9b6aa601cd88bf122a942d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52491",
+					"10.65.0.27:52491",
+					"172.17.0.1:52491",
+					"172.18.0.1:52491",
+					"172.19.0.1:52491"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:27:49.108563037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1275044730199096,
+				"StableID":   "nus5dFGUxA11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7e9f4f0d500c03579fb1407e64095477a38852f73331366cd2e720f7a3fdbe33",
+				"KeyExpiry":  "2026-11-09T07:27:49Z",
+				"DiscoKey":   "discokey:dbd96448f403b268cf76693a04e0de5abfc8bbe992261f5d1bb178c855eb450e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35822",
+					"10.65.0.27:35822",
+					"172.17.0.1:35822",
+					"172.18.0.1:35822",
+					"172.19.0.1:35822"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:27:49.593623884Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7728681379644409,
+				"StableID":   "nSZotYMLM321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:da34f20900d2b203364376c411053a021df11d51a5388655ada04c63cbe63e16",
+				"KeyExpiry":  "2026-11-09T07:27:50Z",
+				"DiscoKey":   "discokey:d5fcb861f1f70ba56e89b846a13fa0ec331c83ce8d3c7b5ffbd669d28369cb7c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57163",
+					"10.65.0.27:57163",
+					"172.17.0.1:57163",
+					"172.18.0.1:57163",
+					"172.19.0.1:57163"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:27:50.14121441Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1395127351755263,
+				"StableID":   "nNpkgXdrtB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bb380a4b82bc4518c49bd400b2ed47acba9ac6836b6d37444852094610d13859",
+				"KeyExpiry":  "2026-11-09T07:27:50Z",
+				"DiscoKey":   "discokey:034a16542b75207a9ed5d8bd65c0ae29a7aea5f56839a655d79193d768e02a1e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49991",
+					"10.65.0.27:49991",
+					"172.17.0.1:49991",
+					"172.18.0.1:49991",
+					"172.19.0.1:49991"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:27:50.681748161Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "861188056879115": {
+				"ID":          861188056879115,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8306001689644191,
+				"StableID":   "nYwLkdaor721CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       8306001689644191,
+				"Key":        "nodekey:1a5e228e792c32bfea34fa4add85183afa63867b171f98fa3737b2222757354e",
+				"DiscoKey":   "discokey:6e021862e7bef2bfada8f496e1eeee9bf708020843199a6c84e803460a8e8507",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:32931",
+					"10.65.0.27:32931",
+					"172.17.0.1:32931",
+					"172.18.0.1:32931",
+					"172.19.0.1:32931"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:27:45.286098032Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1a5e228e792c32bfea34fa4add85183afa63867b171f98fa3737b2222757354e",
+			"MachineKey": "mkey:bd25c299b9544635b0b24ac704b9455cde1bb4d7643ec3b2105595fd871e991a",
+			"Peers": [{
+				"ID":         861188056879115,
+				"StableID":   "nep1b6x2j711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5aae13a99589250ac3d1c06e3f26b7fd4a4a7376855b8105f5d0ac4a5f836078",
+				"DiscoKey":   "discokey:b0f4876c78433341521539cab25b0294b9d51eab808453fcd7caa156b89e410b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33599",
+					"10.65.0.27:33599",
+					"172.17.0.1:33599",
+					"172.18.0.1:33599",
+					"172.19.0.1:33599"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:27:43.135263897Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8680699854276825,
+				"StableID":   "npCpTPGWnA21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca8a6a98d72a7299ae22c8fbe3c309802fa6bfad81f34ae4b6ab68e567ec0077",
+				"DiscoKey":   "discokey:3a8c1193f3f7b30ee3253786e153ec7a6caea9c3e45fec0f9e8edf096abb8636",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47028",
+					"10.65.0.27:47028",
+					"172.17.0.1:47028",
+					"172.18.0.1:47028",
+					"172.19.0.1:47028"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:27:43.669011539Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7141861004647675,
+				"StableID":   "nxswpXaZmx11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:101a448995c3d6088408b6d310d2c246b8cb108e313f458a60494d6ba3b8f649",
+				"DiscoKey":   "discokey:04e1b3ea416ffabc3361e318906a44424b26046b1dab688e41d76a4471018817",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:55525",
+					"10.65.0.27:55525",
+					"172.17.0.1:55525",
+					"172.18.0.1:55525",
+					"172.19.0.1:55525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:27:44.207628464Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4724336270747769,
+				"StableID":   "nEMxWZJftd11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30f892f7bf584cc6bf53e6d1d8472cd1ad358778d8d54ca0a4d5e8900d6a6e5e",
+				"DiscoKey":   "discokey:8417d86473fc456799814fdd6faaf71e51b532007083044189e3d101e5efd52d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:57107",
+					"10.65.0.27:57107",
+					"172.17.0.1:57107",
+					"172.18.0.1:57107",
+					"172.19.0.1:57107"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:27:44.734810873Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3139804488792044,
+				"StableID":   "nyBKvhL2XR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38b2d8f4c228100b4a011eb21dda558b54b3b965a993400049da04ce6b21a167",
+				"DiscoKey":   "discokey:a9f091671070ace677a8b44946c1f04c47f21ba55ea77c22e9d451f53c1f9c46",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:47293",
+					"10.65.0.27:47293",
+					"172.17.0.1:47293",
+					"172.18.0.1:47293",
+					"172.19.0.1:47293"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:27:45.822145352Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7714839673165703,
+				"StableID":   "ncF3hrk4F321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25f4b5e0d6d381db768cd6c224a14353b8f4e70717ed107f3698bcf79e14f345",
+				"DiscoKey":   "discokey:998a0eaf6711bf018a4e6bc3c8691c9be4f62ec36ca79ebdd3f0d6e03526900a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53262",
+					"10.65.0.27:53262",
+					"172.17.0.1:53262",
+					"172.18.0.1:53262",
+					"172.19.0.1:53262"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:27:46.347864423Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6279102083833834,
+				"StableID":   "nmLfN8Np2r11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a2c8fddb2040b36249ef35875b968a36e0d9f46bb98f551e669c3547ca64d67",
+				"DiscoKey":   "discokey:be9cb3dd5314fc78543a7c84b45a849cc35c9610cc3e5761410906f55dc31a5a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55607",
+					"10.65.0.27:55607",
+					"172.17.0.1:55607",
+					"172.18.0.1:55607",
+					"172.19.0.1:55607"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:27:46.885923527Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7616952318553386,
+				"StableID":   "nRE3NSRjU221CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:101f3079531b10e63df90059a27f87c5c9a7dd5cd4725c2be86964b3130a2d3c",
+				"DiscoKey":   "discokey:aa1e16a303c85bc9f783441b1ca3082d148c350a1b4a555fc670bbab4644943b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37144",
+					"10.65.0.27:37144",
+					"172.17.0.1:37144",
+					"172.18.0.1:37144",
+					"172.19.0.1:37144"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:27:47.444165724Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6651177415959720,
+				"StableID":   "nhTxMq9Lwt11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e950c14af2a4aa67da69905cf19eaf45e9e16e2e206dc35bf6a0c98f122ed47e",
+				"DiscoKey":   "discokey:36feeedc7ce8198432f592577904564eea8d33e82a2fd50b87dc88e6e613e24b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35894",
+					"10.65.0.27:35894",
+					"172.17.0.1:35894",
+					"172.18.0.1:35894",
+					"172.19.0.1:35894"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:27:47.978293846Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2385266244843678,
+				"StableID":   "nhza6BuHdK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90ef1125fc078609ce1ceaa9a653d30d54d7ec45ee7e36f2075acf2fdcfe557d",
+				"DiscoKey":   "discokey:a10078731b5d6c055f2b8961088bb384d01ab8c32283c666984c264bce94290c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:33798",
+					"10.65.0.27:33798",
+					"172.17.0.1:33798",
+					"172.18.0.1:33798",
+					"172.19.0.1:33798"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:27:48.528549031Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5754078637829449,
+				"StableID":   "npQtJYt2wm11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89e9278cff4ffd35726275e2f33cc435cf178f19d1f308ee49733f5b7b2d2a4e",
+				"DiscoKey":   "discokey:71d738fdb8ec362b475791cff47c068af4a60dca6d9b6aa601cd88bf122a942d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52491",
+					"10.65.0.27:52491",
+					"172.17.0.1:52491",
+					"172.18.0.1:52491",
+					"172.19.0.1:52491"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:27:49.108563037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1275044730199096,
+				"StableID":   "nus5dFGUxA11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7e9f4f0d500c03579fb1407e64095477a38852f73331366cd2e720f7a3fdbe33",
+				"KeyExpiry":  "2026-11-09T07:27:49Z",
+				"DiscoKey":   "discokey:dbd96448f403b268cf76693a04e0de5abfc8bbe992261f5d1bb178c855eb450e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35822",
+					"10.65.0.27:35822",
+					"172.17.0.1:35822",
+					"172.18.0.1:35822",
+					"172.19.0.1:35822"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:27:49.593623884Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7728681379644409,
+				"StableID":   "nSZotYMLM321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:da34f20900d2b203364376c411053a021df11d51a5388655ada04c63cbe63e16",
+				"KeyExpiry":  "2026-11-09T07:27:50Z",
+				"DiscoKey":   "discokey:d5fcb861f1f70ba56e89b846a13fa0ec331c83ce8d3c7b5ffbd669d28369cb7c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57163",
+					"10.65.0.27:57163",
+					"172.17.0.1:57163",
+					"172.18.0.1:57163",
+					"172.19.0.1:57163"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:27:50.14121441Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1395127351755263,
+				"StableID":   "nNpkgXdrtB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bb380a4b82bc4518c49bd400b2ed47acba9ac6836b6d37444852094610d13859",
+				"KeyExpiry":  "2026-11-09T07:27:50Z",
+				"DiscoKey":   "discokey:034a16542b75207a9ed5d8bd65c0ae29a7aea5f56839a655d79193d768e02a1e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49991",
+					"10.65.0.27:49991",
+					"172.17.0.1:49991",
+					"172.18.0.1:49991",
+					"172.19.0.1:49991"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:27:50.681748161Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8306001689644191": {
+				"ID":          8306001689644191,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4724336270747769,
+				"StableID":   "nEMxWZJftd11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       4724336270747769,
+				"Key":        "nodekey:30f892f7bf584cc6bf53e6d1d8472cd1ad358778d8d54ca0a4d5e8900d6a6e5e",
+				"DiscoKey":   "discokey:8417d86473fc456799814fdd6faaf71e51b532007083044189e3d101e5efd52d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:57107",
+					"10.65.0.27:57107",
+					"172.17.0.1:57107",
+					"172.18.0.1:57107",
+					"172.19.0.1:57107"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:27:44.734810873Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:30f892f7bf584cc6bf53e6d1d8472cd1ad358778d8d54ca0a4d5e8900d6a6e5e",
+			"MachineKey": "mkey:0ce91601af599e2ae365b6d0dbed699cb5a46ae1bc759b17fa0907620e32431b",
+			"Peers": [{
+				"ID":         861188056879115,
+				"StableID":   "nep1b6x2j711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5aae13a99589250ac3d1c06e3f26b7fd4a4a7376855b8105f5d0ac4a5f836078",
+				"DiscoKey":   "discokey:b0f4876c78433341521539cab25b0294b9d51eab808453fcd7caa156b89e410b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33599",
+					"10.65.0.27:33599",
+					"172.17.0.1:33599",
+					"172.18.0.1:33599",
+					"172.19.0.1:33599"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:27:43.135263897Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8680699854276825,
+				"StableID":   "npCpTPGWnA21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca8a6a98d72a7299ae22c8fbe3c309802fa6bfad81f34ae4b6ab68e567ec0077",
+				"DiscoKey":   "discokey:3a8c1193f3f7b30ee3253786e153ec7a6caea9c3e45fec0f9e8edf096abb8636",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47028",
+					"10.65.0.27:47028",
+					"172.17.0.1:47028",
+					"172.18.0.1:47028",
+					"172.19.0.1:47028"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:27:43.669011539Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7141861004647675,
+				"StableID":   "nxswpXaZmx11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:101a448995c3d6088408b6d310d2c246b8cb108e313f458a60494d6ba3b8f649",
+				"DiscoKey":   "discokey:04e1b3ea416ffabc3361e318906a44424b26046b1dab688e41d76a4471018817",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:55525",
+					"10.65.0.27:55525",
+					"172.17.0.1:55525",
+					"172.18.0.1:55525",
+					"172.19.0.1:55525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:27:44.207628464Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8306001689644191,
+				"StableID":   "nYwLkdaor721CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a5e228e792c32bfea34fa4add85183afa63867b171f98fa3737b2222757354e",
+				"DiscoKey":   "discokey:6e021862e7bef2bfada8f496e1eeee9bf708020843199a6c84e803460a8e8507",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:32931",
+					"10.65.0.27:32931",
+					"172.17.0.1:32931",
+					"172.18.0.1:32931",
+					"172.19.0.1:32931"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:27:45.286098032Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3139804488792044,
+				"StableID":   "nyBKvhL2XR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38b2d8f4c228100b4a011eb21dda558b54b3b965a993400049da04ce6b21a167",
+				"DiscoKey":   "discokey:a9f091671070ace677a8b44946c1f04c47f21ba55ea77c22e9d451f53c1f9c46",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:47293",
+					"10.65.0.27:47293",
+					"172.17.0.1:47293",
+					"172.18.0.1:47293",
+					"172.19.0.1:47293"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:27:45.822145352Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7714839673165703,
+				"StableID":   "ncF3hrk4F321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25f4b5e0d6d381db768cd6c224a14353b8f4e70717ed107f3698bcf79e14f345",
+				"DiscoKey":   "discokey:998a0eaf6711bf018a4e6bc3c8691c9be4f62ec36ca79ebdd3f0d6e03526900a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53262",
+					"10.65.0.27:53262",
+					"172.17.0.1:53262",
+					"172.18.0.1:53262",
+					"172.19.0.1:53262"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:27:46.347864423Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6279102083833834,
+				"StableID":   "nmLfN8Np2r11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a2c8fddb2040b36249ef35875b968a36e0d9f46bb98f551e669c3547ca64d67",
+				"DiscoKey":   "discokey:be9cb3dd5314fc78543a7c84b45a849cc35c9610cc3e5761410906f55dc31a5a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55607",
+					"10.65.0.27:55607",
+					"172.17.0.1:55607",
+					"172.18.0.1:55607",
+					"172.19.0.1:55607"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:27:46.885923527Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7616952318553386,
+				"StableID":   "nRE3NSRjU221CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:101f3079531b10e63df90059a27f87c5c9a7dd5cd4725c2be86964b3130a2d3c",
+				"DiscoKey":   "discokey:aa1e16a303c85bc9f783441b1ca3082d148c350a1b4a555fc670bbab4644943b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37144",
+					"10.65.0.27:37144",
+					"172.17.0.1:37144",
+					"172.18.0.1:37144",
+					"172.19.0.1:37144"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:27:47.444165724Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6651177415959720,
+				"StableID":   "nhTxMq9Lwt11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e950c14af2a4aa67da69905cf19eaf45e9e16e2e206dc35bf6a0c98f122ed47e",
+				"DiscoKey":   "discokey:36feeedc7ce8198432f592577904564eea8d33e82a2fd50b87dc88e6e613e24b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35894",
+					"10.65.0.27:35894",
+					"172.17.0.1:35894",
+					"172.18.0.1:35894",
+					"172.19.0.1:35894"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:27:47.978293846Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2385266244843678,
+				"StableID":   "nhza6BuHdK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90ef1125fc078609ce1ceaa9a653d30d54d7ec45ee7e36f2075acf2fdcfe557d",
+				"DiscoKey":   "discokey:a10078731b5d6c055f2b8961088bb384d01ab8c32283c666984c264bce94290c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:33798",
+					"10.65.0.27:33798",
+					"172.17.0.1:33798",
+					"172.18.0.1:33798",
+					"172.19.0.1:33798"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:27:48.528549031Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5754078637829449,
+				"StableID":   "npQtJYt2wm11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89e9278cff4ffd35726275e2f33cc435cf178f19d1f308ee49733f5b7b2d2a4e",
+				"DiscoKey":   "discokey:71d738fdb8ec362b475791cff47c068af4a60dca6d9b6aa601cd88bf122a942d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52491",
+					"10.65.0.27:52491",
+					"172.17.0.1:52491",
+					"172.18.0.1:52491",
+					"172.19.0.1:52491"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:27:49.108563037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1275044730199096,
+				"StableID":   "nus5dFGUxA11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7e9f4f0d500c03579fb1407e64095477a38852f73331366cd2e720f7a3fdbe33",
+				"KeyExpiry":  "2026-11-09T07:27:49Z",
+				"DiscoKey":   "discokey:dbd96448f403b268cf76693a04e0de5abfc8bbe992261f5d1bb178c855eb450e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35822",
+					"10.65.0.27:35822",
+					"172.17.0.1:35822",
+					"172.18.0.1:35822",
+					"172.19.0.1:35822"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:27:49.593623884Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7728681379644409,
+				"StableID":   "nSZotYMLM321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:da34f20900d2b203364376c411053a021df11d51a5388655ada04c63cbe63e16",
+				"KeyExpiry":  "2026-11-09T07:27:50Z",
+				"DiscoKey":   "discokey:d5fcb861f1f70ba56e89b846a13fa0ec331c83ce8d3c7b5ffbd669d28369cb7c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57163",
+					"10.65.0.27:57163",
+					"172.17.0.1:57163",
+					"172.18.0.1:57163",
+					"172.19.0.1:57163"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:27:50.14121441Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1395127351755263,
+				"StableID":   "nNpkgXdrtB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bb380a4b82bc4518c49bd400b2ed47acba9ac6836b6d37444852094610d13859",
+				"KeyExpiry":  "2026-11-09T07:27:50Z",
+				"DiscoKey":   "discokey:034a16542b75207a9ed5d8bd65c0ae29a7aea5f56839a655d79193d768e02a1e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49991",
+					"10.65.0.27:49991",
+					"172.17.0.1:49991",
+					"172.18.0.1:49991",
+					"172.19.0.1:49991"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:27:50.681748161Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4724336270747769": {
+				"ID":          4724336270747769,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7714839673165703,
+				"StableID":   "ncF3hrk4F321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       7714839673165703,
+				"Key":        "nodekey:25f4b5e0d6d381db768cd6c224a14353b8f4e70717ed107f3698bcf79e14f345",
+				"DiscoKey":   "discokey:998a0eaf6711bf018a4e6bc3c8691c9be4f62ec36ca79ebdd3f0d6e03526900a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53262",
+					"10.65.0.27:53262",
+					"172.17.0.1:53262",
+					"172.18.0.1:53262",
+					"172.19.0.1:53262"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:27:46.347864423Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:25f4b5e0d6d381db768cd6c224a14353b8f4e70717ed107f3698bcf79e14f345",
+			"MachineKey": "mkey:cf673e3bb31e0c1876c9cfc7b47f1393e609600bb97a1a4997dcac326e367803",
+			"Peers": [{
+				"ID":         861188056879115,
+				"StableID":   "nep1b6x2j711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5aae13a99589250ac3d1c06e3f26b7fd4a4a7376855b8105f5d0ac4a5f836078",
+				"DiscoKey":   "discokey:b0f4876c78433341521539cab25b0294b9d51eab808453fcd7caa156b89e410b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33599",
+					"10.65.0.27:33599",
+					"172.17.0.1:33599",
+					"172.18.0.1:33599",
+					"172.19.0.1:33599"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:27:43.135263897Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8680699854276825,
+				"StableID":   "npCpTPGWnA21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca8a6a98d72a7299ae22c8fbe3c309802fa6bfad81f34ae4b6ab68e567ec0077",
+				"DiscoKey":   "discokey:3a8c1193f3f7b30ee3253786e153ec7a6caea9c3e45fec0f9e8edf096abb8636",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47028",
+					"10.65.0.27:47028",
+					"172.17.0.1:47028",
+					"172.18.0.1:47028",
+					"172.19.0.1:47028"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:27:43.669011539Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7141861004647675,
+				"StableID":   "nxswpXaZmx11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:101a448995c3d6088408b6d310d2c246b8cb108e313f458a60494d6ba3b8f649",
+				"DiscoKey":   "discokey:04e1b3ea416ffabc3361e318906a44424b26046b1dab688e41d76a4471018817",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:55525",
+					"10.65.0.27:55525",
+					"172.17.0.1:55525",
+					"172.18.0.1:55525",
+					"172.19.0.1:55525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:27:44.207628464Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4724336270747769,
+				"StableID":   "nEMxWZJftd11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30f892f7bf584cc6bf53e6d1d8472cd1ad358778d8d54ca0a4d5e8900d6a6e5e",
+				"DiscoKey":   "discokey:8417d86473fc456799814fdd6faaf71e51b532007083044189e3d101e5efd52d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:57107",
+					"10.65.0.27:57107",
+					"172.17.0.1:57107",
+					"172.18.0.1:57107",
+					"172.19.0.1:57107"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:27:44.734810873Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8306001689644191,
+				"StableID":   "nYwLkdaor721CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a5e228e792c32bfea34fa4add85183afa63867b171f98fa3737b2222757354e",
+				"DiscoKey":   "discokey:6e021862e7bef2bfada8f496e1eeee9bf708020843199a6c84e803460a8e8507",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:32931",
+					"10.65.0.27:32931",
+					"172.17.0.1:32931",
+					"172.18.0.1:32931",
+					"172.19.0.1:32931"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:27:45.286098032Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3139804488792044,
+				"StableID":   "nyBKvhL2XR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38b2d8f4c228100b4a011eb21dda558b54b3b965a993400049da04ce6b21a167",
+				"DiscoKey":   "discokey:a9f091671070ace677a8b44946c1f04c47f21ba55ea77c22e9d451f53c1f9c46",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:47293",
+					"10.65.0.27:47293",
+					"172.17.0.1:47293",
+					"172.18.0.1:47293",
+					"172.19.0.1:47293"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:27:45.822145352Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6279102083833834,
+				"StableID":   "nmLfN8Np2r11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a2c8fddb2040b36249ef35875b968a36e0d9f46bb98f551e669c3547ca64d67",
+				"DiscoKey":   "discokey:be9cb3dd5314fc78543a7c84b45a849cc35c9610cc3e5761410906f55dc31a5a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55607",
+					"10.65.0.27:55607",
+					"172.17.0.1:55607",
+					"172.18.0.1:55607",
+					"172.19.0.1:55607"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:27:46.885923527Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7616952318553386,
+				"StableID":   "nRE3NSRjU221CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:101f3079531b10e63df90059a27f87c5c9a7dd5cd4725c2be86964b3130a2d3c",
+				"DiscoKey":   "discokey:aa1e16a303c85bc9f783441b1ca3082d148c350a1b4a555fc670bbab4644943b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37144",
+					"10.65.0.27:37144",
+					"172.17.0.1:37144",
+					"172.18.0.1:37144",
+					"172.19.0.1:37144"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:27:47.444165724Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6651177415959720,
+				"StableID":   "nhTxMq9Lwt11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e950c14af2a4aa67da69905cf19eaf45e9e16e2e206dc35bf6a0c98f122ed47e",
+				"DiscoKey":   "discokey:36feeedc7ce8198432f592577904564eea8d33e82a2fd50b87dc88e6e613e24b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35894",
+					"10.65.0.27:35894",
+					"172.17.0.1:35894",
+					"172.18.0.1:35894",
+					"172.19.0.1:35894"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:27:47.978293846Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2385266244843678,
+				"StableID":   "nhza6BuHdK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90ef1125fc078609ce1ceaa9a653d30d54d7ec45ee7e36f2075acf2fdcfe557d",
+				"DiscoKey":   "discokey:a10078731b5d6c055f2b8961088bb384d01ab8c32283c666984c264bce94290c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:33798",
+					"10.65.0.27:33798",
+					"172.17.0.1:33798",
+					"172.18.0.1:33798",
+					"172.19.0.1:33798"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:27:48.528549031Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5754078637829449,
+				"StableID":   "npQtJYt2wm11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89e9278cff4ffd35726275e2f33cc435cf178f19d1f308ee49733f5b7b2d2a4e",
+				"DiscoKey":   "discokey:71d738fdb8ec362b475791cff47c068af4a60dca6d9b6aa601cd88bf122a942d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52491",
+					"10.65.0.27:52491",
+					"172.17.0.1:52491",
+					"172.18.0.1:52491",
+					"172.19.0.1:52491"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:27:49.108563037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1275044730199096,
+				"StableID":   "nus5dFGUxA11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7e9f4f0d500c03579fb1407e64095477a38852f73331366cd2e720f7a3fdbe33",
+				"KeyExpiry":  "2026-11-09T07:27:49Z",
+				"DiscoKey":   "discokey:dbd96448f403b268cf76693a04e0de5abfc8bbe992261f5d1bb178c855eb450e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35822",
+					"10.65.0.27:35822",
+					"172.17.0.1:35822",
+					"172.18.0.1:35822",
+					"172.19.0.1:35822"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:27:49.593623884Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7728681379644409,
+				"StableID":   "nSZotYMLM321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:da34f20900d2b203364376c411053a021df11d51a5388655ada04c63cbe63e16",
+				"KeyExpiry":  "2026-11-09T07:27:50Z",
+				"DiscoKey":   "discokey:d5fcb861f1f70ba56e89b846a13fa0ec331c83ce8d3c7b5ffbd669d28369cb7c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57163",
+					"10.65.0.27:57163",
+					"172.17.0.1:57163",
+					"172.18.0.1:57163",
+					"172.19.0.1:57163"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:27:50.14121441Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1395127351755263,
+				"StableID":   "nNpkgXdrtB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bb380a4b82bc4518c49bd400b2ed47acba9ac6836b6d37444852094610d13859",
+				"KeyExpiry":  "2026-11-09T07:27:50Z",
+				"DiscoKey":   "discokey:034a16542b75207a9ed5d8bd65c0ae29a7aea5f56839a655d79193d768e02a1e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49991",
+					"10.65.0.27:49991",
+					"172.17.0.1:49991",
+					"172.18.0.1:49991",
+					"172.19.0.1:49991"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:27:50.681748161Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7714839673165703": {
+				"ID":          7714839673165703,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7616952318553386,
+				"StableID":   "nRE3NSRjU221CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       7616952318553386,
+				"Key":        "nodekey:101f3079531b10e63df90059a27f87c5c9a7dd5cd4725c2be86964b3130a2d3c",
+				"DiscoKey":   "discokey:aa1e16a303c85bc9f783441b1ca3082d148c350a1b4a555fc670bbab4644943b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37144",
+					"10.65.0.27:37144",
+					"172.17.0.1:37144",
+					"172.18.0.1:37144",
+					"172.19.0.1:37144"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:27:47.444165724Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:101f3079531b10e63df90059a27f87c5c9a7dd5cd4725c2be86964b3130a2d3c",
+			"MachineKey": "mkey:e9022f741ed89dc3b8ebab29382b78f3f1412977440f0ff8fde8ff6a1cd3eb2d",
+			"Peers": [{
+				"ID":         861188056879115,
+				"StableID":   "nep1b6x2j711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5aae13a99589250ac3d1c06e3f26b7fd4a4a7376855b8105f5d0ac4a5f836078",
+				"DiscoKey":   "discokey:b0f4876c78433341521539cab25b0294b9d51eab808453fcd7caa156b89e410b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33599",
+					"10.65.0.27:33599",
+					"172.17.0.1:33599",
+					"172.18.0.1:33599",
+					"172.19.0.1:33599"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:27:43.135263897Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8680699854276825,
+				"StableID":   "npCpTPGWnA21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca8a6a98d72a7299ae22c8fbe3c309802fa6bfad81f34ae4b6ab68e567ec0077",
+				"DiscoKey":   "discokey:3a8c1193f3f7b30ee3253786e153ec7a6caea9c3e45fec0f9e8edf096abb8636",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47028",
+					"10.65.0.27:47028",
+					"172.17.0.1:47028",
+					"172.18.0.1:47028",
+					"172.19.0.1:47028"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:27:43.669011539Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7141861004647675,
+				"StableID":   "nxswpXaZmx11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:101a448995c3d6088408b6d310d2c246b8cb108e313f458a60494d6ba3b8f649",
+				"DiscoKey":   "discokey:04e1b3ea416ffabc3361e318906a44424b26046b1dab688e41d76a4471018817",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:55525",
+					"10.65.0.27:55525",
+					"172.17.0.1:55525",
+					"172.18.0.1:55525",
+					"172.19.0.1:55525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:27:44.207628464Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4724336270747769,
+				"StableID":   "nEMxWZJftd11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30f892f7bf584cc6bf53e6d1d8472cd1ad358778d8d54ca0a4d5e8900d6a6e5e",
+				"DiscoKey":   "discokey:8417d86473fc456799814fdd6faaf71e51b532007083044189e3d101e5efd52d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:57107",
+					"10.65.0.27:57107",
+					"172.17.0.1:57107",
+					"172.18.0.1:57107",
+					"172.19.0.1:57107"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:27:44.734810873Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8306001689644191,
+				"StableID":   "nYwLkdaor721CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a5e228e792c32bfea34fa4add85183afa63867b171f98fa3737b2222757354e",
+				"DiscoKey":   "discokey:6e021862e7bef2bfada8f496e1eeee9bf708020843199a6c84e803460a8e8507",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:32931",
+					"10.65.0.27:32931",
+					"172.17.0.1:32931",
+					"172.18.0.1:32931",
+					"172.19.0.1:32931"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:27:45.286098032Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3139804488792044,
+				"StableID":   "nyBKvhL2XR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38b2d8f4c228100b4a011eb21dda558b54b3b965a993400049da04ce6b21a167",
+				"DiscoKey":   "discokey:a9f091671070ace677a8b44946c1f04c47f21ba55ea77c22e9d451f53c1f9c46",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:47293",
+					"10.65.0.27:47293",
+					"172.17.0.1:47293",
+					"172.18.0.1:47293",
+					"172.19.0.1:47293"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:27:45.822145352Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7714839673165703,
+				"StableID":   "ncF3hrk4F321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25f4b5e0d6d381db768cd6c224a14353b8f4e70717ed107f3698bcf79e14f345",
+				"DiscoKey":   "discokey:998a0eaf6711bf018a4e6bc3c8691c9be4f62ec36ca79ebdd3f0d6e03526900a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53262",
+					"10.65.0.27:53262",
+					"172.17.0.1:53262",
+					"172.18.0.1:53262",
+					"172.19.0.1:53262"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:27:46.347864423Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6279102083833834,
+				"StableID":   "nmLfN8Np2r11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a2c8fddb2040b36249ef35875b968a36e0d9f46bb98f551e669c3547ca64d67",
+				"DiscoKey":   "discokey:be9cb3dd5314fc78543a7c84b45a849cc35c9610cc3e5761410906f55dc31a5a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55607",
+					"10.65.0.27:55607",
+					"172.17.0.1:55607",
+					"172.18.0.1:55607",
+					"172.19.0.1:55607"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:27:46.885923527Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6651177415959720,
+				"StableID":   "nhTxMq9Lwt11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e950c14af2a4aa67da69905cf19eaf45e9e16e2e206dc35bf6a0c98f122ed47e",
+				"DiscoKey":   "discokey:36feeedc7ce8198432f592577904564eea8d33e82a2fd50b87dc88e6e613e24b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35894",
+					"10.65.0.27:35894",
+					"172.17.0.1:35894",
+					"172.18.0.1:35894",
+					"172.19.0.1:35894"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:27:47.978293846Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2385266244843678,
+				"StableID":   "nhza6BuHdK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90ef1125fc078609ce1ceaa9a653d30d54d7ec45ee7e36f2075acf2fdcfe557d",
+				"DiscoKey":   "discokey:a10078731b5d6c055f2b8961088bb384d01ab8c32283c666984c264bce94290c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:33798",
+					"10.65.0.27:33798",
+					"172.17.0.1:33798",
+					"172.18.0.1:33798",
+					"172.19.0.1:33798"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:27:48.528549031Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5754078637829449,
+				"StableID":   "npQtJYt2wm11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89e9278cff4ffd35726275e2f33cc435cf178f19d1f308ee49733f5b7b2d2a4e",
+				"DiscoKey":   "discokey:71d738fdb8ec362b475791cff47c068af4a60dca6d9b6aa601cd88bf122a942d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52491",
+					"10.65.0.27:52491",
+					"172.17.0.1:52491",
+					"172.18.0.1:52491",
+					"172.19.0.1:52491"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:27:49.108563037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1275044730199096,
+				"StableID":   "nus5dFGUxA11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7e9f4f0d500c03579fb1407e64095477a38852f73331366cd2e720f7a3fdbe33",
+				"KeyExpiry":  "2026-11-09T07:27:49Z",
+				"DiscoKey":   "discokey:dbd96448f403b268cf76693a04e0de5abfc8bbe992261f5d1bb178c855eb450e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35822",
+					"10.65.0.27:35822",
+					"172.17.0.1:35822",
+					"172.18.0.1:35822",
+					"172.19.0.1:35822"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:27:49.593623884Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7728681379644409,
+				"StableID":   "nSZotYMLM321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:da34f20900d2b203364376c411053a021df11d51a5388655ada04c63cbe63e16",
+				"KeyExpiry":  "2026-11-09T07:27:50Z",
+				"DiscoKey":   "discokey:d5fcb861f1f70ba56e89b846a13fa0ec331c83ce8d3c7b5ffbd669d28369cb7c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57163",
+					"10.65.0.27:57163",
+					"172.17.0.1:57163",
+					"172.18.0.1:57163",
+					"172.19.0.1:57163"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:27:50.14121441Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1395127351755263,
+				"StableID":   "nNpkgXdrtB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bb380a4b82bc4518c49bd400b2ed47acba9ac6836b6d37444852094610d13859",
+				"KeyExpiry":  "2026-11-09T07:27:50Z",
+				"DiscoKey":   "discokey:034a16542b75207a9ed5d8bd65c0ae29a7aea5f56839a655d79193d768e02a1e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49991",
+					"10.65.0.27:49991",
+					"172.17.0.1:49991",
+					"172.18.0.1:49991",
+					"172.19.0.1:49991"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:27:50.681748161Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7616952318553386": {
+				"ID":          7616952318553386,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7728681379644409,
+				"StableID":   "nSZotYMLM321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:da34f20900d2b203364376c411053a021df11d51a5388655ada04c63cbe63e16",
+				"KeyExpiry":  "2026-11-09T07:27:50Z",
+				"DiscoKey":   "discokey:d5fcb861f1f70ba56e89b846a13fa0ec331c83ce8d3c7b5ffbd669d28369cb7c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57163",
+					"10.65.0.27:57163",
+					"172.17.0.1:57163",
+					"172.18.0.1:57163",
+					"172.19.0.1:57163"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:27:50.14121441Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:da34f20900d2b203364376c411053a021df11d51a5388655ada04c63cbe63e16",
+			"MachineKey": "mkey:16a9eaf9c01167632a2383b497aae7d48f40ccb3562f45709b580d7ead330308",
+			"Peers": [{
+				"ID":         861188056879115,
+				"StableID":   "nep1b6x2j711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5aae13a99589250ac3d1c06e3f26b7fd4a4a7376855b8105f5d0ac4a5f836078",
+				"DiscoKey":   "discokey:b0f4876c78433341521539cab25b0294b9d51eab808453fcd7caa156b89e410b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33599",
+					"10.65.0.27:33599",
+					"172.17.0.1:33599",
+					"172.18.0.1:33599",
+					"172.19.0.1:33599"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:27:43.135263897Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8680699854276825,
+				"StableID":   "npCpTPGWnA21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca8a6a98d72a7299ae22c8fbe3c309802fa6bfad81f34ae4b6ab68e567ec0077",
+				"DiscoKey":   "discokey:3a8c1193f3f7b30ee3253786e153ec7a6caea9c3e45fec0f9e8edf096abb8636",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47028",
+					"10.65.0.27:47028",
+					"172.17.0.1:47028",
+					"172.18.0.1:47028",
+					"172.19.0.1:47028"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:27:43.669011539Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7141861004647675,
+				"StableID":   "nxswpXaZmx11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:101a448995c3d6088408b6d310d2c246b8cb108e313f458a60494d6ba3b8f649",
+				"DiscoKey":   "discokey:04e1b3ea416ffabc3361e318906a44424b26046b1dab688e41d76a4471018817",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:55525",
+					"10.65.0.27:55525",
+					"172.17.0.1:55525",
+					"172.18.0.1:55525",
+					"172.19.0.1:55525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:27:44.207628464Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4724336270747769,
+				"StableID":   "nEMxWZJftd11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30f892f7bf584cc6bf53e6d1d8472cd1ad358778d8d54ca0a4d5e8900d6a6e5e",
+				"DiscoKey":   "discokey:8417d86473fc456799814fdd6faaf71e51b532007083044189e3d101e5efd52d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:57107",
+					"10.65.0.27:57107",
+					"172.17.0.1:57107",
+					"172.18.0.1:57107",
+					"172.19.0.1:57107"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:27:44.734810873Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8306001689644191,
+				"StableID":   "nYwLkdaor721CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a5e228e792c32bfea34fa4add85183afa63867b171f98fa3737b2222757354e",
+				"DiscoKey":   "discokey:6e021862e7bef2bfada8f496e1eeee9bf708020843199a6c84e803460a8e8507",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:32931",
+					"10.65.0.27:32931",
+					"172.17.0.1:32931",
+					"172.18.0.1:32931",
+					"172.19.0.1:32931"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:27:45.286098032Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3139804488792044,
+				"StableID":   "nyBKvhL2XR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38b2d8f4c228100b4a011eb21dda558b54b3b965a993400049da04ce6b21a167",
+				"DiscoKey":   "discokey:a9f091671070ace677a8b44946c1f04c47f21ba55ea77c22e9d451f53c1f9c46",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:47293",
+					"10.65.0.27:47293",
+					"172.17.0.1:47293",
+					"172.18.0.1:47293",
+					"172.19.0.1:47293"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:27:45.822145352Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7714839673165703,
+				"StableID":   "ncF3hrk4F321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25f4b5e0d6d381db768cd6c224a14353b8f4e70717ed107f3698bcf79e14f345",
+				"DiscoKey":   "discokey:998a0eaf6711bf018a4e6bc3c8691c9be4f62ec36ca79ebdd3f0d6e03526900a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53262",
+					"10.65.0.27:53262",
+					"172.17.0.1:53262",
+					"172.18.0.1:53262",
+					"172.19.0.1:53262"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:27:46.347864423Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6279102083833834,
+				"StableID":   "nmLfN8Np2r11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a2c8fddb2040b36249ef35875b968a36e0d9f46bb98f551e669c3547ca64d67",
+				"DiscoKey":   "discokey:be9cb3dd5314fc78543a7c84b45a849cc35c9610cc3e5761410906f55dc31a5a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55607",
+					"10.65.0.27:55607",
+					"172.17.0.1:55607",
+					"172.18.0.1:55607",
+					"172.19.0.1:55607"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:27:46.885923527Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7616952318553386,
+				"StableID":   "nRE3NSRjU221CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:101f3079531b10e63df90059a27f87c5c9a7dd5cd4725c2be86964b3130a2d3c",
+				"DiscoKey":   "discokey:aa1e16a303c85bc9f783441b1ca3082d148c350a1b4a555fc670bbab4644943b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37144",
+					"10.65.0.27:37144",
+					"172.17.0.1:37144",
+					"172.18.0.1:37144",
+					"172.19.0.1:37144"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:27:47.444165724Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6651177415959720,
+				"StableID":   "nhTxMq9Lwt11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e950c14af2a4aa67da69905cf19eaf45e9e16e2e206dc35bf6a0c98f122ed47e",
+				"DiscoKey":   "discokey:36feeedc7ce8198432f592577904564eea8d33e82a2fd50b87dc88e6e613e24b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35894",
+					"10.65.0.27:35894",
+					"172.17.0.1:35894",
+					"172.18.0.1:35894",
+					"172.19.0.1:35894"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:27:47.978293846Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2385266244843678,
+				"StableID":   "nhza6BuHdK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90ef1125fc078609ce1ceaa9a653d30d54d7ec45ee7e36f2075acf2fdcfe557d",
+				"DiscoKey":   "discokey:a10078731b5d6c055f2b8961088bb384d01ab8c32283c666984c264bce94290c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:33798",
+					"10.65.0.27:33798",
+					"172.17.0.1:33798",
+					"172.18.0.1:33798",
+					"172.19.0.1:33798"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:27:48.528549031Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5754078637829449,
+				"StableID":   "npQtJYt2wm11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89e9278cff4ffd35726275e2f33cc435cf178f19d1f308ee49733f5b7b2d2a4e",
+				"DiscoKey":   "discokey:71d738fdb8ec362b475791cff47c068af4a60dca6d9b6aa601cd88bf122a942d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52491",
+					"10.65.0.27:52491",
+					"172.17.0.1:52491",
+					"172.18.0.1:52491",
+					"172.19.0.1:52491"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:27:49.108563037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1275044730199096,
+				"StableID":   "nus5dFGUxA11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7e9f4f0d500c03579fb1407e64095477a38852f73331366cd2e720f7a3fdbe33",
+				"KeyExpiry":  "2026-11-09T07:27:49Z",
+				"DiscoKey":   "discokey:dbd96448f403b268cf76693a04e0de5abfc8bbe992261f5d1bb178c855eb450e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35822",
+					"10.65.0.27:35822",
+					"172.17.0.1:35822",
+					"172.18.0.1:35822",
+					"172.19.0.1:35822"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:27:49.593623884Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1395127351755263,
+				"StableID":   "nNpkgXdrtB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bb380a4b82bc4518c49bd400b2ed47acba9ac6836b6d37444852094610d13859",
+				"KeyExpiry":  "2026-11-09T07:27:50Z",
+				"DiscoKey":   "discokey:034a16542b75207a9ed5d8bd65c0ae29a7aea5f56839a655d79193d768e02a1e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49991",
+					"10.65.0.27:49991",
+					"172.17.0.1:49991",
+					"172.18.0.1:49991",
+					"172.19.0.1:49991"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:27:50.681748161Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6651177415959720,
+				"StableID":   "nhTxMq9Lwt11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       6651177415959720,
+				"Key":        "nodekey:e950c14af2a4aa67da69905cf19eaf45e9e16e2e206dc35bf6a0c98f122ed47e",
+				"DiscoKey":   "discokey:36feeedc7ce8198432f592577904564eea8d33e82a2fd50b87dc88e6e613e24b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35894",
+					"10.65.0.27:35894",
+					"172.17.0.1:35894",
+					"172.18.0.1:35894",
+					"172.19.0.1:35894"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:27:47.978293846Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e950c14af2a4aa67da69905cf19eaf45e9e16e2e206dc35bf6a0c98f122ed47e",
+			"MachineKey": "mkey:1c50c4bcc83085f10f2fb427bd86e11a246e9f6abd5fe0c20c1c9d20314d610e",
+			"Peers": [{
+				"ID":         861188056879115,
+				"StableID":   "nep1b6x2j711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5aae13a99589250ac3d1c06e3f26b7fd4a4a7376855b8105f5d0ac4a5f836078",
+				"DiscoKey":   "discokey:b0f4876c78433341521539cab25b0294b9d51eab808453fcd7caa156b89e410b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33599",
+					"10.65.0.27:33599",
+					"172.17.0.1:33599",
+					"172.18.0.1:33599",
+					"172.19.0.1:33599"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:27:43.135263897Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8680699854276825,
+				"StableID":   "npCpTPGWnA21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca8a6a98d72a7299ae22c8fbe3c309802fa6bfad81f34ae4b6ab68e567ec0077",
+				"DiscoKey":   "discokey:3a8c1193f3f7b30ee3253786e153ec7a6caea9c3e45fec0f9e8edf096abb8636",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47028",
+					"10.65.0.27:47028",
+					"172.17.0.1:47028",
+					"172.18.0.1:47028",
+					"172.19.0.1:47028"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:27:43.669011539Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7141861004647675,
+				"StableID":   "nxswpXaZmx11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:101a448995c3d6088408b6d310d2c246b8cb108e313f458a60494d6ba3b8f649",
+				"DiscoKey":   "discokey:04e1b3ea416ffabc3361e318906a44424b26046b1dab688e41d76a4471018817",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:55525",
+					"10.65.0.27:55525",
+					"172.17.0.1:55525",
+					"172.18.0.1:55525",
+					"172.19.0.1:55525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:27:44.207628464Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4724336270747769,
+				"StableID":   "nEMxWZJftd11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30f892f7bf584cc6bf53e6d1d8472cd1ad358778d8d54ca0a4d5e8900d6a6e5e",
+				"DiscoKey":   "discokey:8417d86473fc456799814fdd6faaf71e51b532007083044189e3d101e5efd52d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:57107",
+					"10.65.0.27:57107",
+					"172.17.0.1:57107",
+					"172.18.0.1:57107",
+					"172.19.0.1:57107"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:27:44.734810873Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8306001689644191,
+				"StableID":   "nYwLkdaor721CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a5e228e792c32bfea34fa4add85183afa63867b171f98fa3737b2222757354e",
+				"DiscoKey":   "discokey:6e021862e7bef2bfada8f496e1eeee9bf708020843199a6c84e803460a8e8507",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:32931",
+					"10.65.0.27:32931",
+					"172.17.0.1:32931",
+					"172.18.0.1:32931",
+					"172.19.0.1:32931"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:27:45.286098032Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3139804488792044,
+				"StableID":   "nyBKvhL2XR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38b2d8f4c228100b4a011eb21dda558b54b3b965a993400049da04ce6b21a167",
+				"DiscoKey":   "discokey:a9f091671070ace677a8b44946c1f04c47f21ba55ea77c22e9d451f53c1f9c46",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:47293",
+					"10.65.0.27:47293",
+					"172.17.0.1:47293",
+					"172.18.0.1:47293",
+					"172.19.0.1:47293"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:27:45.822145352Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7714839673165703,
+				"StableID":   "ncF3hrk4F321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25f4b5e0d6d381db768cd6c224a14353b8f4e70717ed107f3698bcf79e14f345",
+				"DiscoKey":   "discokey:998a0eaf6711bf018a4e6bc3c8691c9be4f62ec36ca79ebdd3f0d6e03526900a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53262",
+					"10.65.0.27:53262",
+					"172.17.0.1:53262",
+					"172.18.0.1:53262",
+					"172.19.0.1:53262"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:27:46.347864423Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6279102083833834,
+				"StableID":   "nmLfN8Np2r11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a2c8fddb2040b36249ef35875b968a36e0d9f46bb98f551e669c3547ca64d67",
+				"DiscoKey":   "discokey:be9cb3dd5314fc78543a7c84b45a849cc35c9610cc3e5761410906f55dc31a5a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55607",
+					"10.65.0.27:55607",
+					"172.17.0.1:55607",
+					"172.18.0.1:55607",
+					"172.19.0.1:55607"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:27:46.885923527Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7616952318553386,
+				"StableID":   "nRE3NSRjU221CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:101f3079531b10e63df90059a27f87c5c9a7dd5cd4725c2be86964b3130a2d3c",
+				"DiscoKey":   "discokey:aa1e16a303c85bc9f783441b1ca3082d148c350a1b4a555fc670bbab4644943b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37144",
+					"10.65.0.27:37144",
+					"172.17.0.1:37144",
+					"172.18.0.1:37144",
+					"172.19.0.1:37144"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:27:47.444165724Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2385266244843678,
+				"StableID":   "nhza6BuHdK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90ef1125fc078609ce1ceaa9a653d30d54d7ec45ee7e36f2075acf2fdcfe557d",
+				"DiscoKey":   "discokey:a10078731b5d6c055f2b8961088bb384d01ab8c32283c666984c264bce94290c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:33798",
+					"10.65.0.27:33798",
+					"172.17.0.1:33798",
+					"172.18.0.1:33798",
+					"172.19.0.1:33798"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:27:48.528549031Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5754078637829449,
+				"StableID":   "npQtJYt2wm11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89e9278cff4ffd35726275e2f33cc435cf178f19d1f308ee49733f5b7b2d2a4e",
+				"DiscoKey":   "discokey:71d738fdb8ec362b475791cff47c068af4a60dca6d9b6aa601cd88bf122a942d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52491",
+					"10.65.0.27:52491",
+					"172.17.0.1:52491",
+					"172.18.0.1:52491",
+					"172.19.0.1:52491"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:27:49.108563037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1275044730199096,
+				"StableID":   "nus5dFGUxA11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:7e9f4f0d500c03579fb1407e64095477a38852f73331366cd2e720f7a3fdbe33",
+				"KeyExpiry":  "2026-11-09T07:27:49Z",
+				"DiscoKey":   "discokey:dbd96448f403b268cf76693a04e0de5abfc8bbe992261f5d1bb178c855eb450e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35822",
+					"10.65.0.27:35822",
+					"172.17.0.1:35822",
+					"172.18.0.1:35822",
+					"172.19.0.1:35822"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:27:49.593623884Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7728681379644409,
+				"StableID":   "nSZotYMLM321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:da34f20900d2b203364376c411053a021df11d51a5388655ada04c63cbe63e16",
+				"KeyExpiry":  "2026-11-09T07:27:50Z",
+				"DiscoKey":   "discokey:d5fcb861f1f70ba56e89b846a13fa0ec331c83ce8d3c7b5ffbd669d28369cb7c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57163",
+					"10.65.0.27:57163",
+					"172.17.0.1:57163",
+					"172.18.0.1:57163",
+					"172.19.0.1:57163"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:27:50.14121441Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1395127351755263,
+				"StableID":   "nNpkgXdrtB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bb380a4b82bc4518c49bd400b2ed47acba9ac6836b6d37444852094610d13859",
+				"KeyExpiry":  "2026-11-09T07:27:50Z",
+				"DiscoKey":   "discokey:034a16542b75207a9ed5d8bd65c0ae29a7aea5f56839a655d79193d768e02a1e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49991",
+					"10.65.0.27:49991",
+					"172.17.0.1:49991",
+					"172.18.0.1:49991",
+					"172.19.0.1:49991"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:27:50.681748161Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6651177415959720": {
+				"ID":          6651177415959720,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-checkperiod-exact-max.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-checkperiod-exact-max.hujson
@@ -1,0 +1,20099 @@
+// ssh-malformed-checkperiod-exact-max
+//
+// ssh checkPeriod exactly 168h
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-13T07:28:35Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-malformed-checkperiod-exact-max",
+	"description":    "ssh checkPeriod exactly 168h",
+	"category":       "ssh",
+	"captured_at":    "2026-05-13T07:28:35.976411279Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                      \n  \n                                                                      \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh checkPeriod exactly 168h\",\n\t\"id\":          \"ssh-malformed-checkperiod-exact-max\",\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\":      \"check\",\n\t\t\"checkPeriod\": \"168h\",\n\t\t\"dst\":         [\"tag:server\"],\n\t\t\"src\":         [\"autogroup:member\"],\n\t\t\"users\":       [\"root\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-edge/ssh-malformed-checkperiod-exact-max.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action":      "check",
+				"checkPeriod": "168h",
+				"dst":         ["tag:server"],
+				"src":         ["autogroup:member"],
+				"users":       ["root"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7688641748352734,
+				"StableID":   "nKMYnhaC3321CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       7688641748352734,
+				"Key":        "nodekey:21b54e4cc2c8be33880e1dc36070ab165ea0acb554c9a6893a7e48930d54821c",
+				"DiscoKey":   "discokey:9e01f493eb0abc86fbbbb3dd6db8737c2f17c057c52abc5529f36bc4edd1eb70",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45564",
+					"10.65.0.27:45564",
+					"172.17.0.1:45564",
+					"172.18.0.1:45564",
+					"172.19.0.1:45564"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:28:44.506627946Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:21b54e4cc2c8be33880e1dc36070ab165ea0acb554c9a6893a7e48930d54821c",
+			"MachineKey": "mkey:086333097aacd96650871fa8a39393c105405b4deec5bedd38bc32c2d39e6068",
+			"Peers": [{
+				"ID":         7268534454816808,
+				"StableID":   "n3S2rL5wky11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31f30caf38951768cd4a4c39d8805d6fe6ee48f7f741628e7f0864c93bf58b27",
+				"DiscoKey":   "discokey:67d9d08c37b6ef412e0604d5901ad81a11b9bfcf887f6ce581ffc218799eb27e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45950",
+					"10.65.0.27:45950",
+					"172.17.0.1:45950",
+					"172.18.0.1:45950",
+					"172.19.0.1:45950"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:28:38.564883436Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4466813085138409,
+				"StableID":   "nvj9T7c2tb11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:17d78a9efad19365637a65227445957b95e676983c2bd25eddef347135b01557",
+				"DiscoKey":   "discokey:0a9f663c8f3f777e25b0798b5b609aa00fa2561d7e759df0c1bddf15e50b1c14",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59788",
+					"10.65.0.27:59788",
+					"172.17.0.1:59788",
+					"172.18.0.1:59788",
+					"172.19.0.1:59788"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:28:39.103086612Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3480160245850418,
+				"StableID":   "ny8GgguABU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:71e1cb45d9f30e9f8b94d3e294ee11134c2d96cf412eeaec2e469604b1167b77",
+				"DiscoKey":   "discokey:bf5ba29bda1bf2ad684f424bc6c263362720e01f195622f4595a8b770697136f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:58537",
+					"10.65.0.27:58537",
+					"172.17.0.1:58537",
+					"172.18.0.1:58537",
+					"172.19.0.1:58537"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:28:39.649747534Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2133871054773266,
+				"StableID":   "nVxh17BSfH11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c8cb2e4d13ebd3b2fa9028e211198f50beac896e636fc5953dcb9a9426dbff3d",
+				"DiscoKey":   "discokey:c4a09c24bafcd497a5d7b21a66a31e2a6a320a4858ffbbd4b4ce1d0181e36b30",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49858",
+					"10.65.0.27:49858",
+					"172.17.0.1:49858",
+					"172.18.0.1:49858",
+					"172.19.0.1:49858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:28:40.194144492Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1506770714821847,
+				"StableID":   "nt9kN5KRmC11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f980c7ad0d89eaa2fe9c8ef67815497173c9af393e6c1247ba12266278cd4f6f",
+				"DiscoKey":   "discokey:2f9e46797bfd85747949649b9f9f7fb5c7a39ac81ba07f8da56c0642f1e0d079",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34842",
+					"10.65.0.27:34842",
+					"172.17.0.1:34842",
+					"172.18.0.1:34842",
+					"172.19.0.1:34842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:28:40.73561438Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         877582131656574,
+				"StableID":   "nyAUqUbTr711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4dc31e4a7b67b678b9e6812685f074a28475d9604723b891a4c13c30fe0c0478",
+				"DiscoKey":   "discokey:dc7904ff76aecebf786c71b06b75889b56960ac9cc73e4d998148bd4e8c2992a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39439",
+					"10.65.0.27:39439",
+					"172.17.0.1:39439",
+					"172.18.0.1:39439",
+					"172.19.0.1:39439"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:28:41.256529399Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1160340179479559,
+				"StableID":   "ngVDGoAX4A11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b07e3c3f65c0080dd3b5288b6980dd5e2f733af4f02a10d8cbae6ffe7211f65f",
+				"DiscoKey":   "discokey:847b32ac8c494d973e48c11d87fd0fbb18babe23f8ce1215cc13bd781c3c7b64",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35595",
+					"10.65.0.27:35595",
+					"172.17.0.1:35595",
+					"172.18.0.1:35595",
+					"172.19.0.1:35595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:28:41.796836638Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8189540296007182,
+				"StableID":   "nVgJCXL4x621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ebfda57148876ba029f73be8a1e4a0d7d49eec1686afad390aaa2ab3458b351",
+				"DiscoKey":   "discokey:2ac706d3ccfa666464d4c600068e7e44d6714bb58d7281baf5b06ff8e73ef939",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52413",
+					"10.65.0.27:52413",
+					"172.17.0.1:52413",
+					"172.18.0.1:52413",
+					"172.19.0.1:52413"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:28:42.339395371Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7901590941276499,
+				"StableID":   "nk7ikvPeh421CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2efd0ca1c9ce5a97f693cd355518b77027855cc57ff0a4bcfb19a9c90017581c",
+				"DiscoKey":   "discokey:e1d4ae41620de6d262defc40660a562497a5d31b818f3a202a575564d0b53f24",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43507",
+					"10.65.0.27:43507",
+					"172.17.0.1:43507",
+					"172.18.0.1:43507",
+					"172.19.0.1:43507"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:28:42.894545891Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         141095417123184,
+				"StableID":   "n9DTrZLu6211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b95747c5b9a2e7b04f70a72b6b99728d0b06961c0d1542b96e0d52c89998c879",
+				"DiscoKey":   "discokey:c904f484c8b09219674379a967639eb45a1c9cb44e20c1c7cc6944cefdab3452",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:43180",
+					"10.65.0.27:43180",
+					"172.17.0.1:43180",
+					"172.18.0.1:43180",
+					"172.19.0.1:43180"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:28:43.438954126Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3525047351717480,
+				"StableID":   "nb8oWx1WXU11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77376a0711dbb8247b0772db716ebbd007473feb11f6eeb4a53b6417b8d2a42c",
+				"DiscoKey":   "discokey:0c5f02fdbafe05c60d38501530f97fbcab5ff3023a08f1c20cfbacaa54078f33",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60502",
+					"10.65.0.27:60502",
+					"172.17.0.1:60502",
+					"172.18.0.1:60502",
+					"172.19.0.1:60502"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:28:43.9611266Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6098342714510689,
+				"StableID":   "niRVt58xcp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0855c7c44eecd1fcf92bae173de8fe354ea19c66019371f311b1c78e6def0152",
+				"KeyExpiry":  "2026-11-09T07:28:45Z",
+				"DiscoKey":   "discokey:488c752ba12c18897e232cbeb1ab4a2b2d61206d002e613ea1812f458bdb4f63",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41114",
+					"10.65.0.27:41114",
+					"172.17.0.1:41114",
+					"172.18.0.1:41114",
+					"172.19.0.1:41114"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:28:45.086530941Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8446860947057593,
+				"StableID":   "nW7ZyPibx821CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9c4c89f86d9afd1f228354570908472fa6b70c6826f9892da05c294c3a852e73",
+				"KeyExpiry":  "2026-11-09T07:28:45Z",
+				"DiscoKey":   "discokey:3620d9800c95b4e73a11b6d53b4b1e7112b99e17765cbf9b88014df1e6d64934",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41351",
+					"10.65.0.27:41351",
+					"172.17.0.1:41351",
+					"172.18.0.1:41351",
+					"172.19.0.1:41351"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:28:45.586430311Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5586116173836200,
+				"StableID":   "n5bVXNoxck11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:063e5855787b816ae06ae0c88f8c46cc85062a2f0aeaa752b350275e1c94b836",
+				"KeyExpiry":  "2026-11-09T07:28:46Z",
+				"DiscoKey":   "discokey:b5a8870188e5ee652642438a20571ab4397dfc0278f4c620d891ba775edcdb7a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33061",
+					"10.65.0.27:33061",
+					"172.17.0.1:33061",
+					"172.18.0.1:33061",
+					"172.19.0.1:33061"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:28:46.122283896Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{"principals": [
+				{"nodeIP": "100.64.0.17"},
+				{"nodeIP": "100.64.0.18"},
+				{"nodeIP": "100.64.0.19"},
+				{"nodeIP": "fd7a:115c:a1e0::13"},
+				{"nodeIP": "fd7a:115c:a1e0::12"},
+				{"nodeIP": "fd7a:115c:a1e0::11"}
+			], "sshUsers": {"root": "root"}, "action": {
+				"holdAndDelegate": "https://unused/machine/ssh/action/$SRC_NODE_ID/to/$DST_NODE_ID?local_user=$LOCAL_USER"
+			}}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7688641748352734": {
+				"ID":          7688641748352734,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		},
+		"ssh_rules": [{"principals": [
+			{"nodeIP": "100.64.0.17"},
+			{"nodeIP": "100.64.0.18"},
+			{"nodeIP": "100.64.0.19"},
+			{"nodeIP": "fd7a:115c:a1e0::13"},
+			{"nodeIP": "fd7a:115c:a1e0::12"},
+			{"nodeIP": "fd7a:115c:a1e0::11"}
+		], "sshUsers": {"root": "root"}, "action": {
+			"holdAndDelegate": "https://unused/machine/ssh/action/$SRC_NODE_ID/to/$DST_NODE_ID?local_user=$LOCAL_USER"
+		}}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         877582131656574,
+				"StableID":   "nyAUqUbTr711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       877582131656574,
+				"Key":        "nodekey:4dc31e4a7b67b678b9e6812685f074a28475d9604723b891a4c13c30fe0c0478",
+				"DiscoKey":   "discokey:dc7904ff76aecebf786c71b06b75889b56960ac9cc73e4d998148bd4e8c2992a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39439",
+					"10.65.0.27:39439",
+					"172.17.0.1:39439",
+					"172.18.0.1:39439",
+					"172.19.0.1:39439"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:28:41.256529399Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4dc31e4a7b67b678b9e6812685f074a28475d9604723b891a4c13c30fe0c0478",
+			"MachineKey": "mkey:4c6a37eb3a951b6ae887bfb6a9bdb0438874c192fe3920ae443965a20d630e34",
+			"Peers": [{
+				"ID":         7268534454816808,
+				"StableID":   "n3S2rL5wky11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31f30caf38951768cd4a4c39d8805d6fe6ee48f7f741628e7f0864c93bf58b27",
+				"DiscoKey":   "discokey:67d9d08c37b6ef412e0604d5901ad81a11b9bfcf887f6ce581ffc218799eb27e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45950",
+					"10.65.0.27:45950",
+					"172.17.0.1:45950",
+					"172.18.0.1:45950",
+					"172.19.0.1:45950"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:28:38.564883436Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4466813085138409,
+				"StableID":   "nvj9T7c2tb11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:17d78a9efad19365637a65227445957b95e676983c2bd25eddef347135b01557",
+				"DiscoKey":   "discokey:0a9f663c8f3f777e25b0798b5b609aa00fa2561d7e759df0c1bddf15e50b1c14",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59788",
+					"10.65.0.27:59788",
+					"172.17.0.1:59788",
+					"172.18.0.1:59788",
+					"172.19.0.1:59788"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:28:39.103086612Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3480160245850418,
+				"StableID":   "ny8GgguABU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:71e1cb45d9f30e9f8b94d3e294ee11134c2d96cf412eeaec2e469604b1167b77",
+				"DiscoKey":   "discokey:bf5ba29bda1bf2ad684f424bc6c263362720e01f195622f4595a8b770697136f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:58537",
+					"10.65.0.27:58537",
+					"172.17.0.1:58537",
+					"172.18.0.1:58537",
+					"172.19.0.1:58537"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:28:39.649747534Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2133871054773266,
+				"StableID":   "nVxh17BSfH11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c8cb2e4d13ebd3b2fa9028e211198f50beac896e636fc5953dcb9a9426dbff3d",
+				"DiscoKey":   "discokey:c4a09c24bafcd497a5d7b21a66a31e2a6a320a4858ffbbd4b4ce1d0181e36b30",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49858",
+					"10.65.0.27:49858",
+					"172.17.0.1:49858",
+					"172.18.0.1:49858",
+					"172.19.0.1:49858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:28:40.194144492Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1506770714821847,
+				"StableID":   "nt9kN5KRmC11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f980c7ad0d89eaa2fe9c8ef67815497173c9af393e6c1247ba12266278cd4f6f",
+				"DiscoKey":   "discokey:2f9e46797bfd85747949649b9f9f7fb5c7a39ac81ba07f8da56c0642f1e0d079",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34842",
+					"10.65.0.27:34842",
+					"172.17.0.1:34842",
+					"172.18.0.1:34842",
+					"172.19.0.1:34842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:28:40.73561438Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1160340179479559,
+				"StableID":   "ngVDGoAX4A11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b07e3c3f65c0080dd3b5288b6980dd5e2f733af4f02a10d8cbae6ffe7211f65f",
+				"DiscoKey":   "discokey:847b32ac8c494d973e48c11d87fd0fbb18babe23f8ce1215cc13bd781c3c7b64",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35595",
+					"10.65.0.27:35595",
+					"172.17.0.1:35595",
+					"172.18.0.1:35595",
+					"172.19.0.1:35595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:28:41.796836638Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8189540296007182,
+				"StableID":   "nVgJCXL4x621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ebfda57148876ba029f73be8a1e4a0d7d49eec1686afad390aaa2ab3458b351",
+				"DiscoKey":   "discokey:2ac706d3ccfa666464d4c600068e7e44d6714bb58d7281baf5b06ff8e73ef939",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52413",
+					"10.65.0.27:52413",
+					"172.17.0.1:52413",
+					"172.18.0.1:52413",
+					"172.19.0.1:52413"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:28:42.339395371Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7901590941276499,
+				"StableID":   "nk7ikvPeh421CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2efd0ca1c9ce5a97f693cd355518b77027855cc57ff0a4bcfb19a9c90017581c",
+				"DiscoKey":   "discokey:e1d4ae41620de6d262defc40660a562497a5d31b818f3a202a575564d0b53f24",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43507",
+					"10.65.0.27:43507",
+					"172.17.0.1:43507",
+					"172.18.0.1:43507",
+					"172.19.0.1:43507"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:28:42.894545891Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         141095417123184,
+				"StableID":   "n9DTrZLu6211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b95747c5b9a2e7b04f70a72b6b99728d0b06961c0d1542b96e0d52c89998c879",
+				"DiscoKey":   "discokey:c904f484c8b09219674379a967639eb45a1c9cb44e20c1c7cc6944cefdab3452",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:43180",
+					"10.65.0.27:43180",
+					"172.17.0.1:43180",
+					"172.18.0.1:43180",
+					"172.19.0.1:43180"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:28:43.438954126Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3525047351717480,
+				"StableID":   "nb8oWx1WXU11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77376a0711dbb8247b0772db716ebbd007473feb11f6eeb4a53b6417b8d2a42c",
+				"DiscoKey":   "discokey:0c5f02fdbafe05c60d38501530f97fbcab5ff3023a08f1c20cfbacaa54078f33",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60502",
+					"10.65.0.27:60502",
+					"172.17.0.1:60502",
+					"172.18.0.1:60502",
+					"172.19.0.1:60502"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:28:43.9611266Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7688641748352734,
+				"StableID":   "nKMYnhaC3321CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21b54e4cc2c8be33880e1dc36070ab165ea0acb554c9a6893a7e48930d54821c",
+				"DiscoKey":   "discokey:9e01f493eb0abc86fbbbb3dd6db8737c2f17c057c52abc5529f36bc4edd1eb70",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45564",
+					"10.65.0.27:45564",
+					"172.17.0.1:45564",
+					"172.18.0.1:45564",
+					"172.19.0.1:45564"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:28:44.506627946Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6098342714510689,
+				"StableID":   "niRVt58xcp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0855c7c44eecd1fcf92bae173de8fe354ea19c66019371f311b1c78e6def0152",
+				"KeyExpiry":  "2026-11-09T07:28:45Z",
+				"DiscoKey":   "discokey:488c752ba12c18897e232cbeb1ab4a2b2d61206d002e613ea1812f458bdb4f63",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41114",
+					"10.65.0.27:41114",
+					"172.17.0.1:41114",
+					"172.18.0.1:41114",
+					"172.19.0.1:41114"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:28:45.086530941Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8446860947057593,
+				"StableID":   "nW7ZyPibx821CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9c4c89f86d9afd1f228354570908472fa6b70c6826f9892da05c294c3a852e73",
+				"KeyExpiry":  "2026-11-09T07:28:45Z",
+				"DiscoKey":   "discokey:3620d9800c95b4e73a11b6d53b4b1e7112b99e17765cbf9b88014df1e6d64934",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41351",
+					"10.65.0.27:41351",
+					"172.17.0.1:41351",
+					"172.18.0.1:41351",
+					"172.19.0.1:41351"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:28:45.586430311Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5586116173836200,
+				"StableID":   "n5bVXNoxck11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:063e5855787b816ae06ae0c88f8c46cc85062a2f0aeaa752b350275e1c94b836",
+				"KeyExpiry":  "2026-11-09T07:28:46Z",
+				"DiscoKey":   "discokey:b5a8870188e5ee652642438a20571ab4397dfc0278f4c620d891ba775edcdb7a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33061",
+					"10.65.0.27:33061",
+					"172.17.0.1:33061",
+					"172.18.0.1:33061",
+					"172.19.0.1:33061"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:28:46.122283896Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "877582131656574": {
+				"ID":          877582131656574,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5586116173836200,
+				"StableID":   "n5bVXNoxck11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:063e5855787b816ae06ae0c88f8c46cc85062a2f0aeaa752b350275e1c94b836",
+				"KeyExpiry":  "2026-11-09T07:28:46Z",
+				"DiscoKey":   "discokey:b5a8870188e5ee652642438a20571ab4397dfc0278f4c620d891ba775edcdb7a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33061",
+					"10.65.0.27:33061",
+					"172.17.0.1:33061",
+					"172.18.0.1:33061",
+					"172.19.0.1:33061"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:28:46.122283896Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:063e5855787b816ae06ae0c88f8c46cc85062a2f0aeaa752b350275e1c94b836",
+			"MachineKey": "mkey:3ff4e168d4d2f6afc3b03bee6e12d08362cdb6b6e46c182790d9eedc9e999500",
+			"Peers": [{
+				"ID":         7268534454816808,
+				"StableID":   "n3S2rL5wky11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31f30caf38951768cd4a4c39d8805d6fe6ee48f7f741628e7f0864c93bf58b27",
+				"DiscoKey":   "discokey:67d9d08c37b6ef412e0604d5901ad81a11b9bfcf887f6ce581ffc218799eb27e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45950",
+					"10.65.0.27:45950",
+					"172.17.0.1:45950",
+					"172.18.0.1:45950",
+					"172.19.0.1:45950"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:28:38.564883436Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4466813085138409,
+				"StableID":   "nvj9T7c2tb11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:17d78a9efad19365637a65227445957b95e676983c2bd25eddef347135b01557",
+				"DiscoKey":   "discokey:0a9f663c8f3f777e25b0798b5b609aa00fa2561d7e759df0c1bddf15e50b1c14",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59788",
+					"10.65.0.27:59788",
+					"172.17.0.1:59788",
+					"172.18.0.1:59788",
+					"172.19.0.1:59788"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:28:39.103086612Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3480160245850418,
+				"StableID":   "ny8GgguABU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:71e1cb45d9f30e9f8b94d3e294ee11134c2d96cf412eeaec2e469604b1167b77",
+				"DiscoKey":   "discokey:bf5ba29bda1bf2ad684f424bc6c263362720e01f195622f4595a8b770697136f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:58537",
+					"10.65.0.27:58537",
+					"172.17.0.1:58537",
+					"172.18.0.1:58537",
+					"172.19.0.1:58537"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:28:39.649747534Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2133871054773266,
+				"StableID":   "nVxh17BSfH11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c8cb2e4d13ebd3b2fa9028e211198f50beac896e636fc5953dcb9a9426dbff3d",
+				"DiscoKey":   "discokey:c4a09c24bafcd497a5d7b21a66a31e2a6a320a4858ffbbd4b4ce1d0181e36b30",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49858",
+					"10.65.0.27:49858",
+					"172.17.0.1:49858",
+					"172.18.0.1:49858",
+					"172.19.0.1:49858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:28:40.194144492Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1506770714821847,
+				"StableID":   "nt9kN5KRmC11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f980c7ad0d89eaa2fe9c8ef67815497173c9af393e6c1247ba12266278cd4f6f",
+				"DiscoKey":   "discokey:2f9e46797bfd85747949649b9f9f7fb5c7a39ac81ba07f8da56c0642f1e0d079",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34842",
+					"10.65.0.27:34842",
+					"172.17.0.1:34842",
+					"172.18.0.1:34842",
+					"172.19.0.1:34842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:28:40.73561438Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         877582131656574,
+				"StableID":   "nyAUqUbTr711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4dc31e4a7b67b678b9e6812685f074a28475d9604723b891a4c13c30fe0c0478",
+				"DiscoKey":   "discokey:dc7904ff76aecebf786c71b06b75889b56960ac9cc73e4d998148bd4e8c2992a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39439",
+					"10.65.0.27:39439",
+					"172.17.0.1:39439",
+					"172.18.0.1:39439",
+					"172.19.0.1:39439"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:28:41.256529399Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1160340179479559,
+				"StableID":   "ngVDGoAX4A11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b07e3c3f65c0080dd3b5288b6980dd5e2f733af4f02a10d8cbae6ffe7211f65f",
+				"DiscoKey":   "discokey:847b32ac8c494d973e48c11d87fd0fbb18babe23f8ce1215cc13bd781c3c7b64",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35595",
+					"10.65.0.27:35595",
+					"172.17.0.1:35595",
+					"172.18.0.1:35595",
+					"172.19.0.1:35595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:28:41.796836638Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8189540296007182,
+				"StableID":   "nVgJCXL4x621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ebfda57148876ba029f73be8a1e4a0d7d49eec1686afad390aaa2ab3458b351",
+				"DiscoKey":   "discokey:2ac706d3ccfa666464d4c600068e7e44d6714bb58d7281baf5b06ff8e73ef939",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52413",
+					"10.65.0.27:52413",
+					"172.17.0.1:52413",
+					"172.18.0.1:52413",
+					"172.19.0.1:52413"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:28:42.339395371Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7901590941276499,
+				"StableID":   "nk7ikvPeh421CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2efd0ca1c9ce5a97f693cd355518b77027855cc57ff0a4bcfb19a9c90017581c",
+				"DiscoKey":   "discokey:e1d4ae41620de6d262defc40660a562497a5d31b818f3a202a575564d0b53f24",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43507",
+					"10.65.0.27:43507",
+					"172.17.0.1:43507",
+					"172.18.0.1:43507",
+					"172.19.0.1:43507"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:28:42.894545891Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         141095417123184,
+				"StableID":   "n9DTrZLu6211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b95747c5b9a2e7b04f70a72b6b99728d0b06961c0d1542b96e0d52c89998c879",
+				"DiscoKey":   "discokey:c904f484c8b09219674379a967639eb45a1c9cb44e20c1c7cc6944cefdab3452",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:43180",
+					"10.65.0.27:43180",
+					"172.17.0.1:43180",
+					"172.18.0.1:43180",
+					"172.19.0.1:43180"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:28:43.438954126Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3525047351717480,
+				"StableID":   "nb8oWx1WXU11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77376a0711dbb8247b0772db716ebbd007473feb11f6eeb4a53b6417b8d2a42c",
+				"DiscoKey":   "discokey:0c5f02fdbafe05c60d38501530f97fbcab5ff3023a08f1c20cfbacaa54078f33",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60502",
+					"10.65.0.27:60502",
+					"172.17.0.1:60502",
+					"172.18.0.1:60502",
+					"172.19.0.1:60502"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:28:43.9611266Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7688641748352734,
+				"StableID":   "nKMYnhaC3321CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21b54e4cc2c8be33880e1dc36070ab165ea0acb554c9a6893a7e48930d54821c",
+				"DiscoKey":   "discokey:9e01f493eb0abc86fbbbb3dd6db8737c2f17c057c52abc5529f36bc4edd1eb70",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45564",
+					"10.65.0.27:45564",
+					"172.17.0.1:45564",
+					"172.18.0.1:45564",
+					"172.19.0.1:45564"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:28:44.506627946Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6098342714510689,
+				"StableID":   "niRVt58xcp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0855c7c44eecd1fcf92bae173de8fe354ea19c66019371f311b1c78e6def0152",
+				"KeyExpiry":  "2026-11-09T07:28:45Z",
+				"DiscoKey":   "discokey:488c752ba12c18897e232cbeb1ab4a2b2d61206d002e613ea1812f458bdb4f63",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41114",
+					"10.65.0.27:41114",
+					"172.17.0.1:41114",
+					"172.18.0.1:41114",
+					"172.19.0.1:41114"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:28:45.086530941Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8446860947057593,
+				"StableID":   "nW7ZyPibx821CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9c4c89f86d9afd1f228354570908472fa6b70c6826f9892da05c294c3a852e73",
+				"KeyExpiry":  "2026-11-09T07:28:45Z",
+				"DiscoKey":   "discokey:3620d9800c95b4e73a11b6d53b4b1e7112b99e17765cbf9b88014df1e6d64934",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41351",
+					"10.65.0.27:41351",
+					"172.17.0.1:41351",
+					"172.18.0.1:41351",
+					"172.19.0.1:41351"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:28:45.586430311Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3480160245850418,
+				"StableID":   "ny8GgguABU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       3480160245850418,
+				"Key":        "nodekey:71e1cb45d9f30e9f8b94d3e294ee11134c2d96cf412eeaec2e469604b1167b77",
+				"DiscoKey":   "discokey:bf5ba29bda1bf2ad684f424bc6c263362720e01f195622f4595a8b770697136f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:58537",
+					"10.65.0.27:58537",
+					"172.17.0.1:58537",
+					"172.18.0.1:58537",
+					"172.19.0.1:58537"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:28:39.649747534Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:71e1cb45d9f30e9f8b94d3e294ee11134c2d96cf412eeaec2e469604b1167b77",
+			"MachineKey": "mkey:8cc06e01a8fd540bc5f998f66e8735aaac97ec9f3c7574a080674717d0502450",
+			"Peers": [{
+				"ID":         7268534454816808,
+				"StableID":   "n3S2rL5wky11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31f30caf38951768cd4a4c39d8805d6fe6ee48f7f741628e7f0864c93bf58b27",
+				"DiscoKey":   "discokey:67d9d08c37b6ef412e0604d5901ad81a11b9bfcf887f6ce581ffc218799eb27e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45950",
+					"10.65.0.27:45950",
+					"172.17.0.1:45950",
+					"172.18.0.1:45950",
+					"172.19.0.1:45950"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:28:38.564883436Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4466813085138409,
+				"StableID":   "nvj9T7c2tb11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:17d78a9efad19365637a65227445957b95e676983c2bd25eddef347135b01557",
+				"DiscoKey":   "discokey:0a9f663c8f3f777e25b0798b5b609aa00fa2561d7e759df0c1bddf15e50b1c14",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59788",
+					"10.65.0.27:59788",
+					"172.17.0.1:59788",
+					"172.18.0.1:59788",
+					"172.19.0.1:59788"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:28:39.103086612Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2133871054773266,
+				"StableID":   "nVxh17BSfH11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c8cb2e4d13ebd3b2fa9028e211198f50beac896e636fc5953dcb9a9426dbff3d",
+				"DiscoKey":   "discokey:c4a09c24bafcd497a5d7b21a66a31e2a6a320a4858ffbbd4b4ce1d0181e36b30",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49858",
+					"10.65.0.27:49858",
+					"172.17.0.1:49858",
+					"172.18.0.1:49858",
+					"172.19.0.1:49858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:28:40.194144492Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1506770714821847,
+				"StableID":   "nt9kN5KRmC11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f980c7ad0d89eaa2fe9c8ef67815497173c9af393e6c1247ba12266278cd4f6f",
+				"DiscoKey":   "discokey:2f9e46797bfd85747949649b9f9f7fb5c7a39ac81ba07f8da56c0642f1e0d079",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34842",
+					"10.65.0.27:34842",
+					"172.17.0.1:34842",
+					"172.18.0.1:34842",
+					"172.19.0.1:34842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:28:40.73561438Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         877582131656574,
+				"StableID":   "nyAUqUbTr711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4dc31e4a7b67b678b9e6812685f074a28475d9604723b891a4c13c30fe0c0478",
+				"DiscoKey":   "discokey:dc7904ff76aecebf786c71b06b75889b56960ac9cc73e4d998148bd4e8c2992a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39439",
+					"10.65.0.27:39439",
+					"172.17.0.1:39439",
+					"172.18.0.1:39439",
+					"172.19.0.1:39439"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:28:41.256529399Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1160340179479559,
+				"StableID":   "ngVDGoAX4A11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b07e3c3f65c0080dd3b5288b6980dd5e2f733af4f02a10d8cbae6ffe7211f65f",
+				"DiscoKey":   "discokey:847b32ac8c494d973e48c11d87fd0fbb18babe23f8ce1215cc13bd781c3c7b64",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35595",
+					"10.65.0.27:35595",
+					"172.17.0.1:35595",
+					"172.18.0.1:35595",
+					"172.19.0.1:35595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:28:41.796836638Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8189540296007182,
+				"StableID":   "nVgJCXL4x621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ebfda57148876ba029f73be8a1e4a0d7d49eec1686afad390aaa2ab3458b351",
+				"DiscoKey":   "discokey:2ac706d3ccfa666464d4c600068e7e44d6714bb58d7281baf5b06ff8e73ef939",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52413",
+					"10.65.0.27:52413",
+					"172.17.0.1:52413",
+					"172.18.0.1:52413",
+					"172.19.0.1:52413"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:28:42.339395371Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7901590941276499,
+				"StableID":   "nk7ikvPeh421CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2efd0ca1c9ce5a97f693cd355518b77027855cc57ff0a4bcfb19a9c90017581c",
+				"DiscoKey":   "discokey:e1d4ae41620de6d262defc40660a562497a5d31b818f3a202a575564d0b53f24",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43507",
+					"10.65.0.27:43507",
+					"172.17.0.1:43507",
+					"172.18.0.1:43507",
+					"172.19.0.1:43507"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:28:42.894545891Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         141095417123184,
+				"StableID":   "n9DTrZLu6211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b95747c5b9a2e7b04f70a72b6b99728d0b06961c0d1542b96e0d52c89998c879",
+				"DiscoKey":   "discokey:c904f484c8b09219674379a967639eb45a1c9cb44e20c1c7cc6944cefdab3452",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:43180",
+					"10.65.0.27:43180",
+					"172.17.0.1:43180",
+					"172.18.0.1:43180",
+					"172.19.0.1:43180"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:28:43.438954126Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3525047351717480,
+				"StableID":   "nb8oWx1WXU11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77376a0711dbb8247b0772db716ebbd007473feb11f6eeb4a53b6417b8d2a42c",
+				"DiscoKey":   "discokey:0c5f02fdbafe05c60d38501530f97fbcab5ff3023a08f1c20cfbacaa54078f33",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60502",
+					"10.65.0.27:60502",
+					"172.17.0.1:60502",
+					"172.18.0.1:60502",
+					"172.19.0.1:60502"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:28:43.9611266Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7688641748352734,
+				"StableID":   "nKMYnhaC3321CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21b54e4cc2c8be33880e1dc36070ab165ea0acb554c9a6893a7e48930d54821c",
+				"DiscoKey":   "discokey:9e01f493eb0abc86fbbbb3dd6db8737c2f17c057c52abc5529f36bc4edd1eb70",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45564",
+					"10.65.0.27:45564",
+					"172.17.0.1:45564",
+					"172.18.0.1:45564",
+					"172.19.0.1:45564"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:28:44.506627946Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6098342714510689,
+				"StableID":   "niRVt58xcp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0855c7c44eecd1fcf92bae173de8fe354ea19c66019371f311b1c78e6def0152",
+				"KeyExpiry":  "2026-11-09T07:28:45Z",
+				"DiscoKey":   "discokey:488c752ba12c18897e232cbeb1ab4a2b2d61206d002e613ea1812f458bdb4f63",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41114",
+					"10.65.0.27:41114",
+					"172.17.0.1:41114",
+					"172.18.0.1:41114",
+					"172.19.0.1:41114"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:28:45.086530941Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8446860947057593,
+				"StableID":   "nW7ZyPibx821CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9c4c89f86d9afd1f228354570908472fa6b70c6826f9892da05c294c3a852e73",
+				"KeyExpiry":  "2026-11-09T07:28:45Z",
+				"DiscoKey":   "discokey:3620d9800c95b4e73a11b6d53b4b1e7112b99e17765cbf9b88014df1e6d64934",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41351",
+					"10.65.0.27:41351",
+					"172.17.0.1:41351",
+					"172.18.0.1:41351",
+					"172.19.0.1:41351"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:28:45.586430311Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5586116173836200,
+				"StableID":   "n5bVXNoxck11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:063e5855787b816ae06ae0c88f8c46cc85062a2f0aeaa752b350275e1c94b836",
+				"KeyExpiry":  "2026-11-09T07:28:46Z",
+				"DiscoKey":   "discokey:b5a8870188e5ee652642438a20571ab4397dfc0278f4c620d891ba775edcdb7a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33061",
+					"10.65.0.27:33061",
+					"172.17.0.1:33061",
+					"172.18.0.1:33061",
+					"172.19.0.1:33061"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:28:46.122283896Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3480160245850418": {
+				"ID":          3480160245850418,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8189540296007182,
+				"StableID":   "nVgJCXL4x621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       8189540296007182,
+				"Key":        "nodekey:7ebfda57148876ba029f73be8a1e4a0d7d49eec1686afad390aaa2ab3458b351",
+				"DiscoKey":   "discokey:2ac706d3ccfa666464d4c600068e7e44d6714bb58d7281baf5b06ff8e73ef939",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52413",
+					"10.65.0.27:52413",
+					"172.17.0.1:52413",
+					"172.18.0.1:52413",
+					"172.19.0.1:52413"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:28:42.339395371Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7ebfda57148876ba029f73be8a1e4a0d7d49eec1686afad390aaa2ab3458b351",
+			"MachineKey": "mkey:33d97728e7871d28aa938c4a4286bfd38b83431a1a7931347e94b1ff402afb2d",
+			"Peers": [{
+				"ID":         7268534454816808,
+				"StableID":   "n3S2rL5wky11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31f30caf38951768cd4a4c39d8805d6fe6ee48f7f741628e7f0864c93bf58b27",
+				"DiscoKey":   "discokey:67d9d08c37b6ef412e0604d5901ad81a11b9bfcf887f6ce581ffc218799eb27e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45950",
+					"10.65.0.27:45950",
+					"172.17.0.1:45950",
+					"172.18.0.1:45950",
+					"172.19.0.1:45950"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:28:38.564883436Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4466813085138409,
+				"StableID":   "nvj9T7c2tb11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:17d78a9efad19365637a65227445957b95e676983c2bd25eddef347135b01557",
+				"DiscoKey":   "discokey:0a9f663c8f3f777e25b0798b5b609aa00fa2561d7e759df0c1bddf15e50b1c14",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59788",
+					"10.65.0.27:59788",
+					"172.17.0.1:59788",
+					"172.18.0.1:59788",
+					"172.19.0.1:59788"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:28:39.103086612Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3480160245850418,
+				"StableID":   "ny8GgguABU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:71e1cb45d9f30e9f8b94d3e294ee11134c2d96cf412eeaec2e469604b1167b77",
+				"DiscoKey":   "discokey:bf5ba29bda1bf2ad684f424bc6c263362720e01f195622f4595a8b770697136f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:58537",
+					"10.65.0.27:58537",
+					"172.17.0.1:58537",
+					"172.18.0.1:58537",
+					"172.19.0.1:58537"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:28:39.649747534Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2133871054773266,
+				"StableID":   "nVxh17BSfH11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c8cb2e4d13ebd3b2fa9028e211198f50beac896e636fc5953dcb9a9426dbff3d",
+				"DiscoKey":   "discokey:c4a09c24bafcd497a5d7b21a66a31e2a6a320a4858ffbbd4b4ce1d0181e36b30",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49858",
+					"10.65.0.27:49858",
+					"172.17.0.1:49858",
+					"172.18.0.1:49858",
+					"172.19.0.1:49858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:28:40.194144492Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1506770714821847,
+				"StableID":   "nt9kN5KRmC11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f980c7ad0d89eaa2fe9c8ef67815497173c9af393e6c1247ba12266278cd4f6f",
+				"DiscoKey":   "discokey:2f9e46797bfd85747949649b9f9f7fb5c7a39ac81ba07f8da56c0642f1e0d079",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34842",
+					"10.65.0.27:34842",
+					"172.17.0.1:34842",
+					"172.18.0.1:34842",
+					"172.19.0.1:34842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:28:40.73561438Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         877582131656574,
+				"StableID":   "nyAUqUbTr711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4dc31e4a7b67b678b9e6812685f074a28475d9604723b891a4c13c30fe0c0478",
+				"DiscoKey":   "discokey:dc7904ff76aecebf786c71b06b75889b56960ac9cc73e4d998148bd4e8c2992a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39439",
+					"10.65.0.27:39439",
+					"172.17.0.1:39439",
+					"172.18.0.1:39439",
+					"172.19.0.1:39439"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:28:41.256529399Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1160340179479559,
+				"StableID":   "ngVDGoAX4A11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b07e3c3f65c0080dd3b5288b6980dd5e2f733af4f02a10d8cbae6ffe7211f65f",
+				"DiscoKey":   "discokey:847b32ac8c494d973e48c11d87fd0fbb18babe23f8ce1215cc13bd781c3c7b64",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35595",
+					"10.65.0.27:35595",
+					"172.17.0.1:35595",
+					"172.18.0.1:35595",
+					"172.19.0.1:35595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:28:41.796836638Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7901590941276499,
+				"StableID":   "nk7ikvPeh421CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2efd0ca1c9ce5a97f693cd355518b77027855cc57ff0a4bcfb19a9c90017581c",
+				"DiscoKey":   "discokey:e1d4ae41620de6d262defc40660a562497a5d31b818f3a202a575564d0b53f24",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43507",
+					"10.65.0.27:43507",
+					"172.17.0.1:43507",
+					"172.18.0.1:43507",
+					"172.19.0.1:43507"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:28:42.894545891Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         141095417123184,
+				"StableID":   "n9DTrZLu6211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b95747c5b9a2e7b04f70a72b6b99728d0b06961c0d1542b96e0d52c89998c879",
+				"DiscoKey":   "discokey:c904f484c8b09219674379a967639eb45a1c9cb44e20c1c7cc6944cefdab3452",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:43180",
+					"10.65.0.27:43180",
+					"172.17.0.1:43180",
+					"172.18.0.1:43180",
+					"172.19.0.1:43180"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:28:43.438954126Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3525047351717480,
+				"StableID":   "nb8oWx1WXU11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77376a0711dbb8247b0772db716ebbd007473feb11f6eeb4a53b6417b8d2a42c",
+				"DiscoKey":   "discokey:0c5f02fdbafe05c60d38501530f97fbcab5ff3023a08f1c20cfbacaa54078f33",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60502",
+					"10.65.0.27:60502",
+					"172.17.0.1:60502",
+					"172.18.0.1:60502",
+					"172.19.0.1:60502"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:28:43.9611266Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7688641748352734,
+				"StableID":   "nKMYnhaC3321CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21b54e4cc2c8be33880e1dc36070ab165ea0acb554c9a6893a7e48930d54821c",
+				"DiscoKey":   "discokey:9e01f493eb0abc86fbbbb3dd6db8737c2f17c057c52abc5529f36bc4edd1eb70",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45564",
+					"10.65.0.27:45564",
+					"172.17.0.1:45564",
+					"172.18.0.1:45564",
+					"172.19.0.1:45564"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:28:44.506627946Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6098342714510689,
+				"StableID":   "niRVt58xcp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0855c7c44eecd1fcf92bae173de8fe354ea19c66019371f311b1c78e6def0152",
+				"KeyExpiry":  "2026-11-09T07:28:45Z",
+				"DiscoKey":   "discokey:488c752ba12c18897e232cbeb1ab4a2b2d61206d002e613ea1812f458bdb4f63",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41114",
+					"10.65.0.27:41114",
+					"172.17.0.1:41114",
+					"172.18.0.1:41114",
+					"172.19.0.1:41114"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:28:45.086530941Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8446860947057593,
+				"StableID":   "nW7ZyPibx821CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9c4c89f86d9afd1f228354570908472fa6b70c6826f9892da05c294c3a852e73",
+				"KeyExpiry":  "2026-11-09T07:28:45Z",
+				"DiscoKey":   "discokey:3620d9800c95b4e73a11b6d53b4b1e7112b99e17765cbf9b88014df1e6d64934",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41351",
+					"10.65.0.27:41351",
+					"172.17.0.1:41351",
+					"172.18.0.1:41351",
+					"172.19.0.1:41351"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:28:45.586430311Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5586116173836200,
+				"StableID":   "n5bVXNoxck11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:063e5855787b816ae06ae0c88f8c46cc85062a2f0aeaa752b350275e1c94b836",
+				"KeyExpiry":  "2026-11-09T07:28:46Z",
+				"DiscoKey":   "discokey:b5a8870188e5ee652642438a20571ab4397dfc0278f4c620d891ba775edcdb7a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33061",
+					"10.65.0.27:33061",
+					"172.17.0.1:33061",
+					"172.18.0.1:33061",
+					"172.19.0.1:33061"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:28:46.122283896Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8189540296007182": {
+				"ID":          8189540296007182,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6098342714510689,
+				"StableID":   "niRVt58xcp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0855c7c44eecd1fcf92bae173de8fe354ea19c66019371f311b1c78e6def0152",
+				"KeyExpiry":  "2026-11-09T07:28:45Z",
+				"DiscoKey":   "discokey:488c752ba12c18897e232cbeb1ab4a2b2d61206d002e613ea1812f458bdb4f63",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41114",
+					"10.65.0.27:41114",
+					"172.17.0.1:41114",
+					"172.18.0.1:41114",
+					"172.19.0.1:41114"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:28:45.086530941Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0855c7c44eecd1fcf92bae173de8fe354ea19c66019371f311b1c78e6def0152",
+			"MachineKey": "mkey:3033cc1864b6d77e29b556cd37b7b49ef734089e878bb884b943936b50cb4707",
+			"Peers": [{
+				"ID":         7268534454816808,
+				"StableID":   "n3S2rL5wky11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31f30caf38951768cd4a4c39d8805d6fe6ee48f7f741628e7f0864c93bf58b27",
+				"DiscoKey":   "discokey:67d9d08c37b6ef412e0604d5901ad81a11b9bfcf887f6ce581ffc218799eb27e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45950",
+					"10.65.0.27:45950",
+					"172.17.0.1:45950",
+					"172.18.0.1:45950",
+					"172.19.0.1:45950"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:28:38.564883436Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4466813085138409,
+				"StableID":   "nvj9T7c2tb11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:17d78a9efad19365637a65227445957b95e676983c2bd25eddef347135b01557",
+				"DiscoKey":   "discokey:0a9f663c8f3f777e25b0798b5b609aa00fa2561d7e759df0c1bddf15e50b1c14",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59788",
+					"10.65.0.27:59788",
+					"172.17.0.1:59788",
+					"172.18.0.1:59788",
+					"172.19.0.1:59788"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:28:39.103086612Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3480160245850418,
+				"StableID":   "ny8GgguABU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:71e1cb45d9f30e9f8b94d3e294ee11134c2d96cf412eeaec2e469604b1167b77",
+				"DiscoKey":   "discokey:bf5ba29bda1bf2ad684f424bc6c263362720e01f195622f4595a8b770697136f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:58537",
+					"10.65.0.27:58537",
+					"172.17.0.1:58537",
+					"172.18.0.1:58537",
+					"172.19.0.1:58537"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:28:39.649747534Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2133871054773266,
+				"StableID":   "nVxh17BSfH11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c8cb2e4d13ebd3b2fa9028e211198f50beac896e636fc5953dcb9a9426dbff3d",
+				"DiscoKey":   "discokey:c4a09c24bafcd497a5d7b21a66a31e2a6a320a4858ffbbd4b4ce1d0181e36b30",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49858",
+					"10.65.0.27:49858",
+					"172.17.0.1:49858",
+					"172.18.0.1:49858",
+					"172.19.0.1:49858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:28:40.194144492Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1506770714821847,
+				"StableID":   "nt9kN5KRmC11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f980c7ad0d89eaa2fe9c8ef67815497173c9af393e6c1247ba12266278cd4f6f",
+				"DiscoKey":   "discokey:2f9e46797bfd85747949649b9f9f7fb5c7a39ac81ba07f8da56c0642f1e0d079",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34842",
+					"10.65.0.27:34842",
+					"172.17.0.1:34842",
+					"172.18.0.1:34842",
+					"172.19.0.1:34842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:28:40.73561438Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         877582131656574,
+				"StableID":   "nyAUqUbTr711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4dc31e4a7b67b678b9e6812685f074a28475d9604723b891a4c13c30fe0c0478",
+				"DiscoKey":   "discokey:dc7904ff76aecebf786c71b06b75889b56960ac9cc73e4d998148bd4e8c2992a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39439",
+					"10.65.0.27:39439",
+					"172.17.0.1:39439",
+					"172.18.0.1:39439",
+					"172.19.0.1:39439"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:28:41.256529399Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1160340179479559,
+				"StableID":   "ngVDGoAX4A11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b07e3c3f65c0080dd3b5288b6980dd5e2f733af4f02a10d8cbae6ffe7211f65f",
+				"DiscoKey":   "discokey:847b32ac8c494d973e48c11d87fd0fbb18babe23f8ce1215cc13bd781c3c7b64",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35595",
+					"10.65.0.27:35595",
+					"172.17.0.1:35595",
+					"172.18.0.1:35595",
+					"172.19.0.1:35595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:28:41.796836638Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8189540296007182,
+				"StableID":   "nVgJCXL4x621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ebfda57148876ba029f73be8a1e4a0d7d49eec1686afad390aaa2ab3458b351",
+				"DiscoKey":   "discokey:2ac706d3ccfa666464d4c600068e7e44d6714bb58d7281baf5b06ff8e73ef939",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52413",
+					"10.65.0.27:52413",
+					"172.17.0.1:52413",
+					"172.18.0.1:52413",
+					"172.19.0.1:52413"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:28:42.339395371Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7901590941276499,
+				"StableID":   "nk7ikvPeh421CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2efd0ca1c9ce5a97f693cd355518b77027855cc57ff0a4bcfb19a9c90017581c",
+				"DiscoKey":   "discokey:e1d4ae41620de6d262defc40660a562497a5d31b818f3a202a575564d0b53f24",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43507",
+					"10.65.0.27:43507",
+					"172.17.0.1:43507",
+					"172.18.0.1:43507",
+					"172.19.0.1:43507"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:28:42.894545891Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         141095417123184,
+				"StableID":   "n9DTrZLu6211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b95747c5b9a2e7b04f70a72b6b99728d0b06961c0d1542b96e0d52c89998c879",
+				"DiscoKey":   "discokey:c904f484c8b09219674379a967639eb45a1c9cb44e20c1c7cc6944cefdab3452",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:43180",
+					"10.65.0.27:43180",
+					"172.17.0.1:43180",
+					"172.18.0.1:43180",
+					"172.19.0.1:43180"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:28:43.438954126Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3525047351717480,
+				"StableID":   "nb8oWx1WXU11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77376a0711dbb8247b0772db716ebbd007473feb11f6eeb4a53b6417b8d2a42c",
+				"DiscoKey":   "discokey:0c5f02fdbafe05c60d38501530f97fbcab5ff3023a08f1c20cfbacaa54078f33",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60502",
+					"10.65.0.27:60502",
+					"172.17.0.1:60502",
+					"172.18.0.1:60502",
+					"172.19.0.1:60502"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:28:43.9611266Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7688641748352734,
+				"StableID":   "nKMYnhaC3321CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21b54e4cc2c8be33880e1dc36070ab165ea0acb554c9a6893a7e48930d54821c",
+				"DiscoKey":   "discokey:9e01f493eb0abc86fbbbb3dd6db8737c2f17c057c52abc5529f36bc4edd1eb70",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45564",
+					"10.65.0.27:45564",
+					"172.17.0.1:45564",
+					"172.18.0.1:45564",
+					"172.19.0.1:45564"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:28:44.506627946Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8446860947057593,
+				"StableID":   "nW7ZyPibx821CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9c4c89f86d9afd1f228354570908472fa6b70c6826f9892da05c294c3a852e73",
+				"KeyExpiry":  "2026-11-09T07:28:45Z",
+				"DiscoKey":   "discokey:3620d9800c95b4e73a11b6d53b4b1e7112b99e17765cbf9b88014df1e6d64934",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41351",
+					"10.65.0.27:41351",
+					"172.17.0.1:41351",
+					"172.18.0.1:41351",
+					"172.19.0.1:41351"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:28:45.586430311Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5586116173836200,
+				"StableID":   "n5bVXNoxck11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:063e5855787b816ae06ae0c88f8c46cc85062a2f0aeaa752b350275e1c94b836",
+				"KeyExpiry":  "2026-11-09T07:28:46Z",
+				"DiscoKey":   "discokey:b5a8870188e5ee652642438a20571ab4397dfc0278f4c620d891ba775edcdb7a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33061",
+					"10.65.0.27:33061",
+					"172.17.0.1:33061",
+					"172.18.0.1:33061",
+					"172.19.0.1:33061"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:28:46.122283896Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3525047351717480,
+				"StableID":   "nb8oWx1WXU11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       3525047351717480,
+				"Key":        "nodekey:77376a0711dbb8247b0772db716ebbd007473feb11f6eeb4a53b6417b8d2a42c",
+				"DiscoKey":   "discokey:0c5f02fdbafe05c60d38501530f97fbcab5ff3023a08f1c20cfbacaa54078f33",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60502",
+					"10.65.0.27:60502",
+					"172.17.0.1:60502",
+					"172.18.0.1:60502",
+					"172.19.0.1:60502"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:28:43.9611266Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:77376a0711dbb8247b0772db716ebbd007473feb11f6eeb4a53b6417b8d2a42c",
+			"MachineKey": "mkey:03ca1553335aa48f0d227ac19ace040b3cb555f72e0f0e4e5225752ec047ff6a",
+			"Peers": [{
+				"ID":         7268534454816808,
+				"StableID":   "n3S2rL5wky11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31f30caf38951768cd4a4c39d8805d6fe6ee48f7f741628e7f0864c93bf58b27",
+				"DiscoKey":   "discokey:67d9d08c37b6ef412e0604d5901ad81a11b9bfcf887f6ce581ffc218799eb27e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45950",
+					"10.65.0.27:45950",
+					"172.17.0.1:45950",
+					"172.18.0.1:45950",
+					"172.19.0.1:45950"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:28:38.564883436Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4466813085138409,
+				"StableID":   "nvj9T7c2tb11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:17d78a9efad19365637a65227445957b95e676983c2bd25eddef347135b01557",
+				"DiscoKey":   "discokey:0a9f663c8f3f777e25b0798b5b609aa00fa2561d7e759df0c1bddf15e50b1c14",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59788",
+					"10.65.0.27:59788",
+					"172.17.0.1:59788",
+					"172.18.0.1:59788",
+					"172.19.0.1:59788"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:28:39.103086612Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3480160245850418,
+				"StableID":   "ny8GgguABU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:71e1cb45d9f30e9f8b94d3e294ee11134c2d96cf412eeaec2e469604b1167b77",
+				"DiscoKey":   "discokey:bf5ba29bda1bf2ad684f424bc6c263362720e01f195622f4595a8b770697136f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:58537",
+					"10.65.0.27:58537",
+					"172.17.0.1:58537",
+					"172.18.0.1:58537",
+					"172.19.0.1:58537"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:28:39.649747534Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2133871054773266,
+				"StableID":   "nVxh17BSfH11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c8cb2e4d13ebd3b2fa9028e211198f50beac896e636fc5953dcb9a9426dbff3d",
+				"DiscoKey":   "discokey:c4a09c24bafcd497a5d7b21a66a31e2a6a320a4858ffbbd4b4ce1d0181e36b30",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49858",
+					"10.65.0.27:49858",
+					"172.17.0.1:49858",
+					"172.18.0.1:49858",
+					"172.19.0.1:49858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:28:40.194144492Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1506770714821847,
+				"StableID":   "nt9kN5KRmC11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f980c7ad0d89eaa2fe9c8ef67815497173c9af393e6c1247ba12266278cd4f6f",
+				"DiscoKey":   "discokey:2f9e46797bfd85747949649b9f9f7fb5c7a39ac81ba07f8da56c0642f1e0d079",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34842",
+					"10.65.0.27:34842",
+					"172.17.0.1:34842",
+					"172.18.0.1:34842",
+					"172.19.0.1:34842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:28:40.73561438Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         877582131656574,
+				"StableID":   "nyAUqUbTr711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4dc31e4a7b67b678b9e6812685f074a28475d9604723b891a4c13c30fe0c0478",
+				"DiscoKey":   "discokey:dc7904ff76aecebf786c71b06b75889b56960ac9cc73e4d998148bd4e8c2992a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39439",
+					"10.65.0.27:39439",
+					"172.17.0.1:39439",
+					"172.18.0.1:39439",
+					"172.19.0.1:39439"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:28:41.256529399Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1160340179479559,
+				"StableID":   "ngVDGoAX4A11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b07e3c3f65c0080dd3b5288b6980dd5e2f733af4f02a10d8cbae6ffe7211f65f",
+				"DiscoKey":   "discokey:847b32ac8c494d973e48c11d87fd0fbb18babe23f8ce1215cc13bd781c3c7b64",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35595",
+					"10.65.0.27:35595",
+					"172.17.0.1:35595",
+					"172.18.0.1:35595",
+					"172.19.0.1:35595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:28:41.796836638Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8189540296007182,
+				"StableID":   "nVgJCXL4x621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ebfda57148876ba029f73be8a1e4a0d7d49eec1686afad390aaa2ab3458b351",
+				"DiscoKey":   "discokey:2ac706d3ccfa666464d4c600068e7e44d6714bb58d7281baf5b06ff8e73ef939",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52413",
+					"10.65.0.27:52413",
+					"172.17.0.1:52413",
+					"172.18.0.1:52413",
+					"172.19.0.1:52413"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:28:42.339395371Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7901590941276499,
+				"StableID":   "nk7ikvPeh421CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2efd0ca1c9ce5a97f693cd355518b77027855cc57ff0a4bcfb19a9c90017581c",
+				"DiscoKey":   "discokey:e1d4ae41620de6d262defc40660a562497a5d31b818f3a202a575564d0b53f24",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43507",
+					"10.65.0.27:43507",
+					"172.17.0.1:43507",
+					"172.18.0.1:43507",
+					"172.19.0.1:43507"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:28:42.894545891Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         141095417123184,
+				"StableID":   "n9DTrZLu6211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b95747c5b9a2e7b04f70a72b6b99728d0b06961c0d1542b96e0d52c89998c879",
+				"DiscoKey":   "discokey:c904f484c8b09219674379a967639eb45a1c9cb44e20c1c7cc6944cefdab3452",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:43180",
+					"10.65.0.27:43180",
+					"172.17.0.1:43180",
+					"172.18.0.1:43180",
+					"172.19.0.1:43180"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:28:43.438954126Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7688641748352734,
+				"StableID":   "nKMYnhaC3321CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21b54e4cc2c8be33880e1dc36070ab165ea0acb554c9a6893a7e48930d54821c",
+				"DiscoKey":   "discokey:9e01f493eb0abc86fbbbb3dd6db8737c2f17c057c52abc5529f36bc4edd1eb70",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45564",
+					"10.65.0.27:45564",
+					"172.17.0.1:45564",
+					"172.18.0.1:45564",
+					"172.19.0.1:45564"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:28:44.506627946Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6098342714510689,
+				"StableID":   "niRVt58xcp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0855c7c44eecd1fcf92bae173de8fe354ea19c66019371f311b1c78e6def0152",
+				"KeyExpiry":  "2026-11-09T07:28:45Z",
+				"DiscoKey":   "discokey:488c752ba12c18897e232cbeb1ab4a2b2d61206d002e613ea1812f458bdb4f63",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41114",
+					"10.65.0.27:41114",
+					"172.17.0.1:41114",
+					"172.18.0.1:41114",
+					"172.19.0.1:41114"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:28:45.086530941Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8446860947057593,
+				"StableID":   "nW7ZyPibx821CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9c4c89f86d9afd1f228354570908472fa6b70c6826f9892da05c294c3a852e73",
+				"KeyExpiry":  "2026-11-09T07:28:45Z",
+				"DiscoKey":   "discokey:3620d9800c95b4e73a11b6d53b4b1e7112b99e17765cbf9b88014df1e6d64934",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41351",
+					"10.65.0.27:41351",
+					"172.17.0.1:41351",
+					"172.18.0.1:41351",
+					"172.19.0.1:41351"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:28:45.586430311Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5586116173836200,
+				"StableID":   "n5bVXNoxck11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:063e5855787b816ae06ae0c88f8c46cc85062a2f0aeaa752b350275e1c94b836",
+				"KeyExpiry":  "2026-11-09T07:28:46Z",
+				"DiscoKey":   "discokey:b5a8870188e5ee652642438a20571ab4397dfc0278f4c620d891ba775edcdb7a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33061",
+					"10.65.0.27:33061",
+					"172.17.0.1:33061",
+					"172.18.0.1:33061",
+					"172.19.0.1:33061"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:28:46.122283896Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3525047351717480": {
+				"ID":          3525047351717480,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4466813085138409,
+				"StableID":   "nvj9T7c2tb11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       4466813085138409,
+				"Key":        "nodekey:17d78a9efad19365637a65227445957b95e676983c2bd25eddef347135b01557",
+				"DiscoKey":   "discokey:0a9f663c8f3f777e25b0798b5b609aa00fa2561d7e759df0c1bddf15e50b1c14",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59788",
+					"10.65.0.27:59788",
+					"172.17.0.1:59788",
+					"172.18.0.1:59788",
+					"172.19.0.1:59788"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:28:39.103086612Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:17d78a9efad19365637a65227445957b95e676983c2bd25eddef347135b01557",
+			"MachineKey": "mkey:f315686a07c396dbcb01a80253c8b7c3490fe80a0d064deefb242e13604ffc1f",
+			"Peers": [{
+				"ID":         7268534454816808,
+				"StableID":   "n3S2rL5wky11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31f30caf38951768cd4a4c39d8805d6fe6ee48f7f741628e7f0864c93bf58b27",
+				"DiscoKey":   "discokey:67d9d08c37b6ef412e0604d5901ad81a11b9bfcf887f6ce581ffc218799eb27e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45950",
+					"10.65.0.27:45950",
+					"172.17.0.1:45950",
+					"172.18.0.1:45950",
+					"172.19.0.1:45950"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:28:38.564883436Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3480160245850418,
+				"StableID":   "ny8GgguABU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:71e1cb45d9f30e9f8b94d3e294ee11134c2d96cf412eeaec2e469604b1167b77",
+				"DiscoKey":   "discokey:bf5ba29bda1bf2ad684f424bc6c263362720e01f195622f4595a8b770697136f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:58537",
+					"10.65.0.27:58537",
+					"172.17.0.1:58537",
+					"172.18.0.1:58537",
+					"172.19.0.1:58537"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:28:39.649747534Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2133871054773266,
+				"StableID":   "nVxh17BSfH11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c8cb2e4d13ebd3b2fa9028e211198f50beac896e636fc5953dcb9a9426dbff3d",
+				"DiscoKey":   "discokey:c4a09c24bafcd497a5d7b21a66a31e2a6a320a4858ffbbd4b4ce1d0181e36b30",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49858",
+					"10.65.0.27:49858",
+					"172.17.0.1:49858",
+					"172.18.0.1:49858",
+					"172.19.0.1:49858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:28:40.194144492Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1506770714821847,
+				"StableID":   "nt9kN5KRmC11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f980c7ad0d89eaa2fe9c8ef67815497173c9af393e6c1247ba12266278cd4f6f",
+				"DiscoKey":   "discokey:2f9e46797bfd85747949649b9f9f7fb5c7a39ac81ba07f8da56c0642f1e0d079",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34842",
+					"10.65.0.27:34842",
+					"172.17.0.1:34842",
+					"172.18.0.1:34842",
+					"172.19.0.1:34842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:28:40.73561438Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         877582131656574,
+				"StableID":   "nyAUqUbTr711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4dc31e4a7b67b678b9e6812685f074a28475d9604723b891a4c13c30fe0c0478",
+				"DiscoKey":   "discokey:dc7904ff76aecebf786c71b06b75889b56960ac9cc73e4d998148bd4e8c2992a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39439",
+					"10.65.0.27:39439",
+					"172.17.0.1:39439",
+					"172.18.0.1:39439",
+					"172.19.0.1:39439"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:28:41.256529399Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1160340179479559,
+				"StableID":   "ngVDGoAX4A11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b07e3c3f65c0080dd3b5288b6980dd5e2f733af4f02a10d8cbae6ffe7211f65f",
+				"DiscoKey":   "discokey:847b32ac8c494d973e48c11d87fd0fbb18babe23f8ce1215cc13bd781c3c7b64",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35595",
+					"10.65.0.27:35595",
+					"172.17.0.1:35595",
+					"172.18.0.1:35595",
+					"172.19.0.1:35595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:28:41.796836638Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8189540296007182,
+				"StableID":   "nVgJCXL4x621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ebfda57148876ba029f73be8a1e4a0d7d49eec1686afad390aaa2ab3458b351",
+				"DiscoKey":   "discokey:2ac706d3ccfa666464d4c600068e7e44d6714bb58d7281baf5b06ff8e73ef939",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52413",
+					"10.65.0.27:52413",
+					"172.17.0.1:52413",
+					"172.18.0.1:52413",
+					"172.19.0.1:52413"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:28:42.339395371Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7901590941276499,
+				"StableID":   "nk7ikvPeh421CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2efd0ca1c9ce5a97f693cd355518b77027855cc57ff0a4bcfb19a9c90017581c",
+				"DiscoKey":   "discokey:e1d4ae41620de6d262defc40660a562497a5d31b818f3a202a575564d0b53f24",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43507",
+					"10.65.0.27:43507",
+					"172.17.0.1:43507",
+					"172.18.0.1:43507",
+					"172.19.0.1:43507"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:28:42.894545891Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         141095417123184,
+				"StableID":   "n9DTrZLu6211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b95747c5b9a2e7b04f70a72b6b99728d0b06961c0d1542b96e0d52c89998c879",
+				"DiscoKey":   "discokey:c904f484c8b09219674379a967639eb45a1c9cb44e20c1c7cc6944cefdab3452",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:43180",
+					"10.65.0.27:43180",
+					"172.17.0.1:43180",
+					"172.18.0.1:43180",
+					"172.19.0.1:43180"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:28:43.438954126Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3525047351717480,
+				"StableID":   "nb8oWx1WXU11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77376a0711dbb8247b0772db716ebbd007473feb11f6eeb4a53b6417b8d2a42c",
+				"DiscoKey":   "discokey:0c5f02fdbafe05c60d38501530f97fbcab5ff3023a08f1c20cfbacaa54078f33",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60502",
+					"10.65.0.27:60502",
+					"172.17.0.1:60502",
+					"172.18.0.1:60502",
+					"172.19.0.1:60502"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:28:43.9611266Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7688641748352734,
+				"StableID":   "nKMYnhaC3321CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21b54e4cc2c8be33880e1dc36070ab165ea0acb554c9a6893a7e48930d54821c",
+				"DiscoKey":   "discokey:9e01f493eb0abc86fbbbb3dd6db8737c2f17c057c52abc5529f36bc4edd1eb70",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45564",
+					"10.65.0.27:45564",
+					"172.17.0.1:45564",
+					"172.18.0.1:45564",
+					"172.19.0.1:45564"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:28:44.506627946Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6098342714510689,
+				"StableID":   "niRVt58xcp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0855c7c44eecd1fcf92bae173de8fe354ea19c66019371f311b1c78e6def0152",
+				"KeyExpiry":  "2026-11-09T07:28:45Z",
+				"DiscoKey":   "discokey:488c752ba12c18897e232cbeb1ab4a2b2d61206d002e613ea1812f458bdb4f63",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41114",
+					"10.65.0.27:41114",
+					"172.17.0.1:41114",
+					"172.18.0.1:41114",
+					"172.19.0.1:41114"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:28:45.086530941Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8446860947057593,
+				"StableID":   "nW7ZyPibx821CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9c4c89f86d9afd1f228354570908472fa6b70c6826f9892da05c294c3a852e73",
+				"KeyExpiry":  "2026-11-09T07:28:45Z",
+				"DiscoKey":   "discokey:3620d9800c95b4e73a11b6d53b4b1e7112b99e17765cbf9b88014df1e6d64934",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41351",
+					"10.65.0.27:41351",
+					"172.17.0.1:41351",
+					"172.18.0.1:41351",
+					"172.19.0.1:41351"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:28:45.586430311Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5586116173836200,
+				"StableID":   "n5bVXNoxck11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:063e5855787b816ae06ae0c88f8c46cc85062a2f0aeaa752b350275e1c94b836",
+				"KeyExpiry":  "2026-11-09T07:28:46Z",
+				"DiscoKey":   "discokey:b5a8870188e5ee652642438a20571ab4397dfc0278f4c620d891ba775edcdb7a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33061",
+					"10.65.0.27:33061",
+					"172.17.0.1:33061",
+					"172.18.0.1:33061",
+					"172.19.0.1:33061"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:28:46.122283896Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4466813085138409": {
+				"ID":          4466813085138409,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7268534454816808,
+				"StableID":   "n3S2rL5wky11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       7268534454816808,
+				"Key":        "nodekey:31f30caf38951768cd4a4c39d8805d6fe6ee48f7f741628e7f0864c93bf58b27",
+				"DiscoKey":   "discokey:67d9d08c37b6ef412e0604d5901ad81a11b9bfcf887f6ce581ffc218799eb27e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45950",
+					"10.65.0.27:45950",
+					"172.17.0.1:45950",
+					"172.18.0.1:45950",
+					"172.19.0.1:45950"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:28:38.564883436Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:31f30caf38951768cd4a4c39d8805d6fe6ee48f7f741628e7f0864c93bf58b27",
+			"MachineKey": "mkey:08488b0ef463904866947981ca67c92e4cbc1034ccb332834a66f7872c26ca30",
+			"Peers": [{
+				"ID":         4466813085138409,
+				"StableID":   "nvj9T7c2tb11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:17d78a9efad19365637a65227445957b95e676983c2bd25eddef347135b01557",
+				"DiscoKey":   "discokey:0a9f663c8f3f777e25b0798b5b609aa00fa2561d7e759df0c1bddf15e50b1c14",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59788",
+					"10.65.0.27:59788",
+					"172.17.0.1:59788",
+					"172.18.0.1:59788",
+					"172.19.0.1:59788"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:28:39.103086612Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3480160245850418,
+				"StableID":   "ny8GgguABU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:71e1cb45d9f30e9f8b94d3e294ee11134c2d96cf412eeaec2e469604b1167b77",
+				"DiscoKey":   "discokey:bf5ba29bda1bf2ad684f424bc6c263362720e01f195622f4595a8b770697136f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:58537",
+					"10.65.0.27:58537",
+					"172.17.0.1:58537",
+					"172.18.0.1:58537",
+					"172.19.0.1:58537"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:28:39.649747534Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2133871054773266,
+				"StableID":   "nVxh17BSfH11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c8cb2e4d13ebd3b2fa9028e211198f50beac896e636fc5953dcb9a9426dbff3d",
+				"DiscoKey":   "discokey:c4a09c24bafcd497a5d7b21a66a31e2a6a320a4858ffbbd4b4ce1d0181e36b30",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49858",
+					"10.65.0.27:49858",
+					"172.17.0.1:49858",
+					"172.18.0.1:49858",
+					"172.19.0.1:49858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:28:40.194144492Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1506770714821847,
+				"StableID":   "nt9kN5KRmC11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f980c7ad0d89eaa2fe9c8ef67815497173c9af393e6c1247ba12266278cd4f6f",
+				"DiscoKey":   "discokey:2f9e46797bfd85747949649b9f9f7fb5c7a39ac81ba07f8da56c0642f1e0d079",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34842",
+					"10.65.0.27:34842",
+					"172.17.0.1:34842",
+					"172.18.0.1:34842",
+					"172.19.0.1:34842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:28:40.73561438Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         877582131656574,
+				"StableID":   "nyAUqUbTr711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4dc31e4a7b67b678b9e6812685f074a28475d9604723b891a4c13c30fe0c0478",
+				"DiscoKey":   "discokey:dc7904ff76aecebf786c71b06b75889b56960ac9cc73e4d998148bd4e8c2992a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39439",
+					"10.65.0.27:39439",
+					"172.17.0.1:39439",
+					"172.18.0.1:39439",
+					"172.19.0.1:39439"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:28:41.256529399Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1160340179479559,
+				"StableID":   "ngVDGoAX4A11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b07e3c3f65c0080dd3b5288b6980dd5e2f733af4f02a10d8cbae6ffe7211f65f",
+				"DiscoKey":   "discokey:847b32ac8c494d973e48c11d87fd0fbb18babe23f8ce1215cc13bd781c3c7b64",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35595",
+					"10.65.0.27:35595",
+					"172.17.0.1:35595",
+					"172.18.0.1:35595",
+					"172.19.0.1:35595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:28:41.796836638Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8189540296007182,
+				"StableID":   "nVgJCXL4x621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ebfda57148876ba029f73be8a1e4a0d7d49eec1686afad390aaa2ab3458b351",
+				"DiscoKey":   "discokey:2ac706d3ccfa666464d4c600068e7e44d6714bb58d7281baf5b06ff8e73ef939",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52413",
+					"10.65.0.27:52413",
+					"172.17.0.1:52413",
+					"172.18.0.1:52413",
+					"172.19.0.1:52413"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:28:42.339395371Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7901590941276499,
+				"StableID":   "nk7ikvPeh421CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2efd0ca1c9ce5a97f693cd355518b77027855cc57ff0a4bcfb19a9c90017581c",
+				"DiscoKey":   "discokey:e1d4ae41620de6d262defc40660a562497a5d31b818f3a202a575564d0b53f24",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43507",
+					"10.65.0.27:43507",
+					"172.17.0.1:43507",
+					"172.18.0.1:43507",
+					"172.19.0.1:43507"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:28:42.894545891Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         141095417123184,
+				"StableID":   "n9DTrZLu6211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b95747c5b9a2e7b04f70a72b6b99728d0b06961c0d1542b96e0d52c89998c879",
+				"DiscoKey":   "discokey:c904f484c8b09219674379a967639eb45a1c9cb44e20c1c7cc6944cefdab3452",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:43180",
+					"10.65.0.27:43180",
+					"172.17.0.1:43180",
+					"172.18.0.1:43180",
+					"172.19.0.1:43180"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:28:43.438954126Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3525047351717480,
+				"StableID":   "nb8oWx1WXU11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77376a0711dbb8247b0772db716ebbd007473feb11f6eeb4a53b6417b8d2a42c",
+				"DiscoKey":   "discokey:0c5f02fdbafe05c60d38501530f97fbcab5ff3023a08f1c20cfbacaa54078f33",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60502",
+					"10.65.0.27:60502",
+					"172.17.0.1:60502",
+					"172.18.0.1:60502",
+					"172.19.0.1:60502"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:28:43.9611266Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7688641748352734,
+				"StableID":   "nKMYnhaC3321CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21b54e4cc2c8be33880e1dc36070ab165ea0acb554c9a6893a7e48930d54821c",
+				"DiscoKey":   "discokey:9e01f493eb0abc86fbbbb3dd6db8737c2f17c057c52abc5529f36bc4edd1eb70",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45564",
+					"10.65.0.27:45564",
+					"172.17.0.1:45564",
+					"172.18.0.1:45564",
+					"172.19.0.1:45564"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:28:44.506627946Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6098342714510689,
+				"StableID":   "niRVt58xcp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0855c7c44eecd1fcf92bae173de8fe354ea19c66019371f311b1c78e6def0152",
+				"KeyExpiry":  "2026-11-09T07:28:45Z",
+				"DiscoKey":   "discokey:488c752ba12c18897e232cbeb1ab4a2b2d61206d002e613ea1812f458bdb4f63",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41114",
+					"10.65.0.27:41114",
+					"172.17.0.1:41114",
+					"172.18.0.1:41114",
+					"172.19.0.1:41114"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:28:45.086530941Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8446860947057593,
+				"StableID":   "nW7ZyPibx821CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9c4c89f86d9afd1f228354570908472fa6b70c6826f9892da05c294c3a852e73",
+				"KeyExpiry":  "2026-11-09T07:28:45Z",
+				"DiscoKey":   "discokey:3620d9800c95b4e73a11b6d53b4b1e7112b99e17765cbf9b88014df1e6d64934",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41351",
+					"10.65.0.27:41351",
+					"172.17.0.1:41351",
+					"172.18.0.1:41351",
+					"172.19.0.1:41351"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:28:45.586430311Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5586116173836200,
+				"StableID":   "n5bVXNoxck11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:063e5855787b816ae06ae0c88f8c46cc85062a2f0aeaa752b350275e1c94b836",
+				"KeyExpiry":  "2026-11-09T07:28:46Z",
+				"DiscoKey":   "discokey:b5a8870188e5ee652642438a20571ab4397dfc0278f4c620d891ba775edcdb7a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33061",
+					"10.65.0.27:33061",
+					"172.17.0.1:33061",
+					"172.18.0.1:33061",
+					"172.19.0.1:33061"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:28:46.122283896Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7268534454816808": {
+				"ID":          7268534454816808,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1506770714821847,
+				"StableID":   "nt9kN5KRmC11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1506770714821847,
+				"Key":        "nodekey:f980c7ad0d89eaa2fe9c8ef67815497173c9af393e6c1247ba12266278cd4f6f",
+				"DiscoKey":   "discokey:2f9e46797bfd85747949649b9f9f7fb5c7a39ac81ba07f8da56c0642f1e0d079",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34842",
+					"10.65.0.27:34842",
+					"172.17.0.1:34842",
+					"172.18.0.1:34842",
+					"172.19.0.1:34842"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:28:40.73561438Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f980c7ad0d89eaa2fe9c8ef67815497173c9af393e6c1247ba12266278cd4f6f",
+			"MachineKey": "mkey:27eb9f131cb3938fd57828c1d2965886492ed3622b5c44499f21b981d974dd75",
+			"Peers": [{
+				"ID":         7268534454816808,
+				"StableID":   "n3S2rL5wky11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31f30caf38951768cd4a4c39d8805d6fe6ee48f7f741628e7f0864c93bf58b27",
+				"DiscoKey":   "discokey:67d9d08c37b6ef412e0604d5901ad81a11b9bfcf887f6ce581ffc218799eb27e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45950",
+					"10.65.0.27:45950",
+					"172.17.0.1:45950",
+					"172.18.0.1:45950",
+					"172.19.0.1:45950"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:28:38.564883436Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4466813085138409,
+				"StableID":   "nvj9T7c2tb11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:17d78a9efad19365637a65227445957b95e676983c2bd25eddef347135b01557",
+				"DiscoKey":   "discokey:0a9f663c8f3f777e25b0798b5b609aa00fa2561d7e759df0c1bddf15e50b1c14",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59788",
+					"10.65.0.27:59788",
+					"172.17.0.1:59788",
+					"172.18.0.1:59788",
+					"172.19.0.1:59788"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:28:39.103086612Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3480160245850418,
+				"StableID":   "ny8GgguABU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:71e1cb45d9f30e9f8b94d3e294ee11134c2d96cf412eeaec2e469604b1167b77",
+				"DiscoKey":   "discokey:bf5ba29bda1bf2ad684f424bc6c263362720e01f195622f4595a8b770697136f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:58537",
+					"10.65.0.27:58537",
+					"172.17.0.1:58537",
+					"172.18.0.1:58537",
+					"172.19.0.1:58537"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:28:39.649747534Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2133871054773266,
+				"StableID":   "nVxh17BSfH11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c8cb2e4d13ebd3b2fa9028e211198f50beac896e636fc5953dcb9a9426dbff3d",
+				"DiscoKey":   "discokey:c4a09c24bafcd497a5d7b21a66a31e2a6a320a4858ffbbd4b4ce1d0181e36b30",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49858",
+					"10.65.0.27:49858",
+					"172.17.0.1:49858",
+					"172.18.0.1:49858",
+					"172.19.0.1:49858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:28:40.194144492Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         877582131656574,
+				"StableID":   "nyAUqUbTr711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4dc31e4a7b67b678b9e6812685f074a28475d9604723b891a4c13c30fe0c0478",
+				"DiscoKey":   "discokey:dc7904ff76aecebf786c71b06b75889b56960ac9cc73e4d998148bd4e8c2992a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39439",
+					"10.65.0.27:39439",
+					"172.17.0.1:39439",
+					"172.18.0.1:39439",
+					"172.19.0.1:39439"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:28:41.256529399Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1160340179479559,
+				"StableID":   "ngVDGoAX4A11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b07e3c3f65c0080dd3b5288b6980dd5e2f733af4f02a10d8cbae6ffe7211f65f",
+				"DiscoKey":   "discokey:847b32ac8c494d973e48c11d87fd0fbb18babe23f8ce1215cc13bd781c3c7b64",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35595",
+					"10.65.0.27:35595",
+					"172.17.0.1:35595",
+					"172.18.0.1:35595",
+					"172.19.0.1:35595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:28:41.796836638Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8189540296007182,
+				"StableID":   "nVgJCXL4x621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ebfda57148876ba029f73be8a1e4a0d7d49eec1686afad390aaa2ab3458b351",
+				"DiscoKey":   "discokey:2ac706d3ccfa666464d4c600068e7e44d6714bb58d7281baf5b06ff8e73ef939",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52413",
+					"10.65.0.27:52413",
+					"172.17.0.1:52413",
+					"172.18.0.1:52413",
+					"172.19.0.1:52413"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:28:42.339395371Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7901590941276499,
+				"StableID":   "nk7ikvPeh421CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2efd0ca1c9ce5a97f693cd355518b77027855cc57ff0a4bcfb19a9c90017581c",
+				"DiscoKey":   "discokey:e1d4ae41620de6d262defc40660a562497a5d31b818f3a202a575564d0b53f24",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43507",
+					"10.65.0.27:43507",
+					"172.17.0.1:43507",
+					"172.18.0.1:43507",
+					"172.19.0.1:43507"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:28:42.894545891Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         141095417123184,
+				"StableID":   "n9DTrZLu6211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b95747c5b9a2e7b04f70a72b6b99728d0b06961c0d1542b96e0d52c89998c879",
+				"DiscoKey":   "discokey:c904f484c8b09219674379a967639eb45a1c9cb44e20c1c7cc6944cefdab3452",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:43180",
+					"10.65.0.27:43180",
+					"172.17.0.1:43180",
+					"172.18.0.1:43180",
+					"172.19.0.1:43180"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:28:43.438954126Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3525047351717480,
+				"StableID":   "nb8oWx1WXU11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77376a0711dbb8247b0772db716ebbd007473feb11f6eeb4a53b6417b8d2a42c",
+				"DiscoKey":   "discokey:0c5f02fdbafe05c60d38501530f97fbcab5ff3023a08f1c20cfbacaa54078f33",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60502",
+					"10.65.0.27:60502",
+					"172.17.0.1:60502",
+					"172.18.0.1:60502",
+					"172.19.0.1:60502"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:28:43.9611266Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7688641748352734,
+				"StableID":   "nKMYnhaC3321CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21b54e4cc2c8be33880e1dc36070ab165ea0acb554c9a6893a7e48930d54821c",
+				"DiscoKey":   "discokey:9e01f493eb0abc86fbbbb3dd6db8737c2f17c057c52abc5529f36bc4edd1eb70",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45564",
+					"10.65.0.27:45564",
+					"172.17.0.1:45564",
+					"172.18.0.1:45564",
+					"172.19.0.1:45564"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:28:44.506627946Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6098342714510689,
+				"StableID":   "niRVt58xcp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0855c7c44eecd1fcf92bae173de8fe354ea19c66019371f311b1c78e6def0152",
+				"KeyExpiry":  "2026-11-09T07:28:45Z",
+				"DiscoKey":   "discokey:488c752ba12c18897e232cbeb1ab4a2b2d61206d002e613ea1812f458bdb4f63",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41114",
+					"10.65.0.27:41114",
+					"172.17.0.1:41114",
+					"172.18.0.1:41114",
+					"172.19.0.1:41114"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:28:45.086530941Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8446860947057593,
+				"StableID":   "nW7ZyPibx821CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9c4c89f86d9afd1f228354570908472fa6b70c6826f9892da05c294c3a852e73",
+				"KeyExpiry":  "2026-11-09T07:28:45Z",
+				"DiscoKey":   "discokey:3620d9800c95b4e73a11b6d53b4b1e7112b99e17765cbf9b88014df1e6d64934",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41351",
+					"10.65.0.27:41351",
+					"172.17.0.1:41351",
+					"172.18.0.1:41351",
+					"172.19.0.1:41351"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:28:45.586430311Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5586116173836200,
+				"StableID":   "n5bVXNoxck11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:063e5855787b816ae06ae0c88f8c46cc85062a2f0aeaa752b350275e1c94b836",
+				"KeyExpiry":  "2026-11-09T07:28:46Z",
+				"DiscoKey":   "discokey:b5a8870188e5ee652642438a20571ab4397dfc0278f4c620d891ba775edcdb7a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33061",
+					"10.65.0.27:33061",
+					"172.17.0.1:33061",
+					"172.18.0.1:33061",
+					"172.19.0.1:33061"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:28:46.122283896Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1506770714821847": {
+				"ID":          1506770714821847,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2133871054773266,
+				"StableID":   "nVxh17BSfH11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       2133871054773266,
+				"Key":        "nodekey:c8cb2e4d13ebd3b2fa9028e211198f50beac896e636fc5953dcb9a9426dbff3d",
+				"DiscoKey":   "discokey:c4a09c24bafcd497a5d7b21a66a31e2a6a320a4858ffbbd4b4ce1d0181e36b30",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49858",
+					"10.65.0.27:49858",
+					"172.17.0.1:49858",
+					"172.18.0.1:49858",
+					"172.19.0.1:49858"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:28:40.194144492Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c8cb2e4d13ebd3b2fa9028e211198f50beac896e636fc5953dcb9a9426dbff3d",
+			"MachineKey": "mkey:0292cc24f1c7ec17f096306b0f7457b697c8a00c9b9b9772191a0353d13ca17f",
+			"Peers": [{
+				"ID":         7268534454816808,
+				"StableID":   "n3S2rL5wky11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31f30caf38951768cd4a4c39d8805d6fe6ee48f7f741628e7f0864c93bf58b27",
+				"DiscoKey":   "discokey:67d9d08c37b6ef412e0604d5901ad81a11b9bfcf887f6ce581ffc218799eb27e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45950",
+					"10.65.0.27:45950",
+					"172.17.0.1:45950",
+					"172.18.0.1:45950",
+					"172.19.0.1:45950"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:28:38.564883436Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4466813085138409,
+				"StableID":   "nvj9T7c2tb11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:17d78a9efad19365637a65227445957b95e676983c2bd25eddef347135b01557",
+				"DiscoKey":   "discokey:0a9f663c8f3f777e25b0798b5b609aa00fa2561d7e759df0c1bddf15e50b1c14",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59788",
+					"10.65.0.27:59788",
+					"172.17.0.1:59788",
+					"172.18.0.1:59788",
+					"172.19.0.1:59788"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:28:39.103086612Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3480160245850418,
+				"StableID":   "ny8GgguABU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:71e1cb45d9f30e9f8b94d3e294ee11134c2d96cf412eeaec2e469604b1167b77",
+				"DiscoKey":   "discokey:bf5ba29bda1bf2ad684f424bc6c263362720e01f195622f4595a8b770697136f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:58537",
+					"10.65.0.27:58537",
+					"172.17.0.1:58537",
+					"172.18.0.1:58537",
+					"172.19.0.1:58537"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:28:39.649747534Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1506770714821847,
+				"StableID":   "nt9kN5KRmC11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f980c7ad0d89eaa2fe9c8ef67815497173c9af393e6c1247ba12266278cd4f6f",
+				"DiscoKey":   "discokey:2f9e46797bfd85747949649b9f9f7fb5c7a39ac81ba07f8da56c0642f1e0d079",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34842",
+					"10.65.0.27:34842",
+					"172.17.0.1:34842",
+					"172.18.0.1:34842",
+					"172.19.0.1:34842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:28:40.73561438Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         877582131656574,
+				"StableID":   "nyAUqUbTr711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4dc31e4a7b67b678b9e6812685f074a28475d9604723b891a4c13c30fe0c0478",
+				"DiscoKey":   "discokey:dc7904ff76aecebf786c71b06b75889b56960ac9cc73e4d998148bd4e8c2992a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39439",
+					"10.65.0.27:39439",
+					"172.17.0.1:39439",
+					"172.18.0.1:39439",
+					"172.19.0.1:39439"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:28:41.256529399Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1160340179479559,
+				"StableID":   "ngVDGoAX4A11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b07e3c3f65c0080dd3b5288b6980dd5e2f733af4f02a10d8cbae6ffe7211f65f",
+				"DiscoKey":   "discokey:847b32ac8c494d973e48c11d87fd0fbb18babe23f8ce1215cc13bd781c3c7b64",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35595",
+					"10.65.0.27:35595",
+					"172.17.0.1:35595",
+					"172.18.0.1:35595",
+					"172.19.0.1:35595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:28:41.796836638Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8189540296007182,
+				"StableID":   "nVgJCXL4x621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ebfda57148876ba029f73be8a1e4a0d7d49eec1686afad390aaa2ab3458b351",
+				"DiscoKey":   "discokey:2ac706d3ccfa666464d4c600068e7e44d6714bb58d7281baf5b06ff8e73ef939",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52413",
+					"10.65.0.27:52413",
+					"172.17.0.1:52413",
+					"172.18.0.1:52413",
+					"172.19.0.1:52413"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:28:42.339395371Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7901590941276499,
+				"StableID":   "nk7ikvPeh421CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2efd0ca1c9ce5a97f693cd355518b77027855cc57ff0a4bcfb19a9c90017581c",
+				"DiscoKey":   "discokey:e1d4ae41620de6d262defc40660a562497a5d31b818f3a202a575564d0b53f24",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43507",
+					"10.65.0.27:43507",
+					"172.17.0.1:43507",
+					"172.18.0.1:43507",
+					"172.19.0.1:43507"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:28:42.894545891Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         141095417123184,
+				"StableID":   "n9DTrZLu6211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b95747c5b9a2e7b04f70a72b6b99728d0b06961c0d1542b96e0d52c89998c879",
+				"DiscoKey":   "discokey:c904f484c8b09219674379a967639eb45a1c9cb44e20c1c7cc6944cefdab3452",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:43180",
+					"10.65.0.27:43180",
+					"172.17.0.1:43180",
+					"172.18.0.1:43180",
+					"172.19.0.1:43180"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:28:43.438954126Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3525047351717480,
+				"StableID":   "nb8oWx1WXU11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77376a0711dbb8247b0772db716ebbd007473feb11f6eeb4a53b6417b8d2a42c",
+				"DiscoKey":   "discokey:0c5f02fdbafe05c60d38501530f97fbcab5ff3023a08f1c20cfbacaa54078f33",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60502",
+					"10.65.0.27:60502",
+					"172.17.0.1:60502",
+					"172.18.0.1:60502",
+					"172.19.0.1:60502"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:28:43.9611266Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7688641748352734,
+				"StableID":   "nKMYnhaC3321CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21b54e4cc2c8be33880e1dc36070ab165ea0acb554c9a6893a7e48930d54821c",
+				"DiscoKey":   "discokey:9e01f493eb0abc86fbbbb3dd6db8737c2f17c057c52abc5529f36bc4edd1eb70",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45564",
+					"10.65.0.27:45564",
+					"172.17.0.1:45564",
+					"172.18.0.1:45564",
+					"172.19.0.1:45564"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:28:44.506627946Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6098342714510689,
+				"StableID":   "niRVt58xcp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0855c7c44eecd1fcf92bae173de8fe354ea19c66019371f311b1c78e6def0152",
+				"KeyExpiry":  "2026-11-09T07:28:45Z",
+				"DiscoKey":   "discokey:488c752ba12c18897e232cbeb1ab4a2b2d61206d002e613ea1812f458bdb4f63",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41114",
+					"10.65.0.27:41114",
+					"172.17.0.1:41114",
+					"172.18.0.1:41114",
+					"172.19.0.1:41114"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:28:45.086530941Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8446860947057593,
+				"StableID":   "nW7ZyPibx821CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9c4c89f86d9afd1f228354570908472fa6b70c6826f9892da05c294c3a852e73",
+				"KeyExpiry":  "2026-11-09T07:28:45Z",
+				"DiscoKey":   "discokey:3620d9800c95b4e73a11b6d53b4b1e7112b99e17765cbf9b88014df1e6d64934",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41351",
+					"10.65.0.27:41351",
+					"172.17.0.1:41351",
+					"172.18.0.1:41351",
+					"172.19.0.1:41351"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:28:45.586430311Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5586116173836200,
+				"StableID":   "n5bVXNoxck11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:063e5855787b816ae06ae0c88f8c46cc85062a2f0aeaa752b350275e1c94b836",
+				"KeyExpiry":  "2026-11-09T07:28:46Z",
+				"DiscoKey":   "discokey:b5a8870188e5ee652642438a20571ab4397dfc0278f4c620d891ba775edcdb7a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33061",
+					"10.65.0.27:33061",
+					"172.17.0.1:33061",
+					"172.18.0.1:33061",
+					"172.19.0.1:33061"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:28:46.122283896Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2133871054773266": {
+				"ID":          2133871054773266,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1160340179479559,
+				"StableID":   "ngVDGoAX4A11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1160340179479559,
+				"Key":        "nodekey:b07e3c3f65c0080dd3b5288b6980dd5e2f733af4f02a10d8cbae6ffe7211f65f",
+				"DiscoKey":   "discokey:847b32ac8c494d973e48c11d87fd0fbb18babe23f8ce1215cc13bd781c3c7b64",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35595",
+					"10.65.0.27:35595",
+					"172.17.0.1:35595",
+					"172.18.0.1:35595",
+					"172.19.0.1:35595"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:28:41.796836638Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b07e3c3f65c0080dd3b5288b6980dd5e2f733af4f02a10d8cbae6ffe7211f65f",
+			"MachineKey": "mkey:ee6bb559ad035ea1b026a67655a2b187d1e3bbbd29f496d9e431c3b6a87c3b28",
+			"Peers": [{
+				"ID":         7268534454816808,
+				"StableID":   "n3S2rL5wky11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31f30caf38951768cd4a4c39d8805d6fe6ee48f7f741628e7f0864c93bf58b27",
+				"DiscoKey":   "discokey:67d9d08c37b6ef412e0604d5901ad81a11b9bfcf887f6ce581ffc218799eb27e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45950",
+					"10.65.0.27:45950",
+					"172.17.0.1:45950",
+					"172.18.0.1:45950",
+					"172.19.0.1:45950"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:28:38.564883436Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4466813085138409,
+				"StableID":   "nvj9T7c2tb11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:17d78a9efad19365637a65227445957b95e676983c2bd25eddef347135b01557",
+				"DiscoKey":   "discokey:0a9f663c8f3f777e25b0798b5b609aa00fa2561d7e759df0c1bddf15e50b1c14",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59788",
+					"10.65.0.27:59788",
+					"172.17.0.1:59788",
+					"172.18.0.1:59788",
+					"172.19.0.1:59788"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:28:39.103086612Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3480160245850418,
+				"StableID":   "ny8GgguABU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:71e1cb45d9f30e9f8b94d3e294ee11134c2d96cf412eeaec2e469604b1167b77",
+				"DiscoKey":   "discokey:bf5ba29bda1bf2ad684f424bc6c263362720e01f195622f4595a8b770697136f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:58537",
+					"10.65.0.27:58537",
+					"172.17.0.1:58537",
+					"172.18.0.1:58537",
+					"172.19.0.1:58537"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:28:39.649747534Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2133871054773266,
+				"StableID":   "nVxh17BSfH11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c8cb2e4d13ebd3b2fa9028e211198f50beac896e636fc5953dcb9a9426dbff3d",
+				"DiscoKey":   "discokey:c4a09c24bafcd497a5d7b21a66a31e2a6a320a4858ffbbd4b4ce1d0181e36b30",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49858",
+					"10.65.0.27:49858",
+					"172.17.0.1:49858",
+					"172.18.0.1:49858",
+					"172.19.0.1:49858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:28:40.194144492Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1506770714821847,
+				"StableID":   "nt9kN5KRmC11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f980c7ad0d89eaa2fe9c8ef67815497173c9af393e6c1247ba12266278cd4f6f",
+				"DiscoKey":   "discokey:2f9e46797bfd85747949649b9f9f7fb5c7a39ac81ba07f8da56c0642f1e0d079",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34842",
+					"10.65.0.27:34842",
+					"172.17.0.1:34842",
+					"172.18.0.1:34842",
+					"172.19.0.1:34842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:28:40.73561438Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         877582131656574,
+				"StableID":   "nyAUqUbTr711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4dc31e4a7b67b678b9e6812685f074a28475d9604723b891a4c13c30fe0c0478",
+				"DiscoKey":   "discokey:dc7904ff76aecebf786c71b06b75889b56960ac9cc73e4d998148bd4e8c2992a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39439",
+					"10.65.0.27:39439",
+					"172.17.0.1:39439",
+					"172.18.0.1:39439",
+					"172.19.0.1:39439"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:28:41.256529399Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8189540296007182,
+				"StableID":   "nVgJCXL4x621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ebfda57148876ba029f73be8a1e4a0d7d49eec1686afad390aaa2ab3458b351",
+				"DiscoKey":   "discokey:2ac706d3ccfa666464d4c600068e7e44d6714bb58d7281baf5b06ff8e73ef939",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52413",
+					"10.65.0.27:52413",
+					"172.17.0.1:52413",
+					"172.18.0.1:52413",
+					"172.19.0.1:52413"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:28:42.339395371Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7901590941276499,
+				"StableID":   "nk7ikvPeh421CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2efd0ca1c9ce5a97f693cd355518b77027855cc57ff0a4bcfb19a9c90017581c",
+				"DiscoKey":   "discokey:e1d4ae41620de6d262defc40660a562497a5d31b818f3a202a575564d0b53f24",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43507",
+					"10.65.0.27:43507",
+					"172.17.0.1:43507",
+					"172.18.0.1:43507",
+					"172.19.0.1:43507"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:28:42.894545891Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         141095417123184,
+				"StableID":   "n9DTrZLu6211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b95747c5b9a2e7b04f70a72b6b99728d0b06961c0d1542b96e0d52c89998c879",
+				"DiscoKey":   "discokey:c904f484c8b09219674379a967639eb45a1c9cb44e20c1c7cc6944cefdab3452",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:43180",
+					"10.65.0.27:43180",
+					"172.17.0.1:43180",
+					"172.18.0.1:43180",
+					"172.19.0.1:43180"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:28:43.438954126Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3525047351717480,
+				"StableID":   "nb8oWx1WXU11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77376a0711dbb8247b0772db716ebbd007473feb11f6eeb4a53b6417b8d2a42c",
+				"DiscoKey":   "discokey:0c5f02fdbafe05c60d38501530f97fbcab5ff3023a08f1c20cfbacaa54078f33",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60502",
+					"10.65.0.27:60502",
+					"172.17.0.1:60502",
+					"172.18.0.1:60502",
+					"172.19.0.1:60502"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:28:43.9611266Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7688641748352734,
+				"StableID":   "nKMYnhaC3321CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21b54e4cc2c8be33880e1dc36070ab165ea0acb554c9a6893a7e48930d54821c",
+				"DiscoKey":   "discokey:9e01f493eb0abc86fbbbb3dd6db8737c2f17c057c52abc5529f36bc4edd1eb70",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45564",
+					"10.65.0.27:45564",
+					"172.17.0.1:45564",
+					"172.18.0.1:45564",
+					"172.19.0.1:45564"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:28:44.506627946Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6098342714510689,
+				"StableID":   "niRVt58xcp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0855c7c44eecd1fcf92bae173de8fe354ea19c66019371f311b1c78e6def0152",
+				"KeyExpiry":  "2026-11-09T07:28:45Z",
+				"DiscoKey":   "discokey:488c752ba12c18897e232cbeb1ab4a2b2d61206d002e613ea1812f458bdb4f63",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41114",
+					"10.65.0.27:41114",
+					"172.17.0.1:41114",
+					"172.18.0.1:41114",
+					"172.19.0.1:41114"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:28:45.086530941Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8446860947057593,
+				"StableID":   "nW7ZyPibx821CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9c4c89f86d9afd1f228354570908472fa6b70c6826f9892da05c294c3a852e73",
+				"KeyExpiry":  "2026-11-09T07:28:45Z",
+				"DiscoKey":   "discokey:3620d9800c95b4e73a11b6d53b4b1e7112b99e17765cbf9b88014df1e6d64934",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41351",
+					"10.65.0.27:41351",
+					"172.17.0.1:41351",
+					"172.18.0.1:41351",
+					"172.19.0.1:41351"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:28:45.586430311Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5586116173836200,
+				"StableID":   "n5bVXNoxck11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:063e5855787b816ae06ae0c88f8c46cc85062a2f0aeaa752b350275e1c94b836",
+				"KeyExpiry":  "2026-11-09T07:28:46Z",
+				"DiscoKey":   "discokey:b5a8870188e5ee652642438a20571ab4397dfc0278f4c620d891ba775edcdb7a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33061",
+					"10.65.0.27:33061",
+					"172.17.0.1:33061",
+					"172.18.0.1:33061",
+					"172.19.0.1:33061"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:28:46.122283896Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1160340179479559": {
+				"ID":          1160340179479559,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}, "1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7901590941276499,
+				"StableID":   "nk7ikvPeh421CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       7901590941276499,
+				"Key":        "nodekey:2efd0ca1c9ce5a97f693cd355518b77027855cc57ff0a4bcfb19a9c90017581c",
+				"DiscoKey":   "discokey:e1d4ae41620de6d262defc40660a562497a5d31b818f3a202a575564d0b53f24",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43507",
+					"10.65.0.27:43507",
+					"172.17.0.1:43507",
+					"172.18.0.1:43507",
+					"172.19.0.1:43507"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:28:42.894545891Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2efd0ca1c9ce5a97f693cd355518b77027855cc57ff0a4bcfb19a9c90017581c",
+			"MachineKey": "mkey:517cac0d1c553bcdf3e15e64828d1de2e452e96337ffe7332796a4b88507852f",
+			"Peers": [{
+				"ID":         7268534454816808,
+				"StableID":   "n3S2rL5wky11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31f30caf38951768cd4a4c39d8805d6fe6ee48f7f741628e7f0864c93bf58b27",
+				"DiscoKey":   "discokey:67d9d08c37b6ef412e0604d5901ad81a11b9bfcf887f6ce581ffc218799eb27e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45950",
+					"10.65.0.27:45950",
+					"172.17.0.1:45950",
+					"172.18.0.1:45950",
+					"172.19.0.1:45950"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:28:38.564883436Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4466813085138409,
+				"StableID":   "nvj9T7c2tb11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:17d78a9efad19365637a65227445957b95e676983c2bd25eddef347135b01557",
+				"DiscoKey":   "discokey:0a9f663c8f3f777e25b0798b5b609aa00fa2561d7e759df0c1bddf15e50b1c14",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59788",
+					"10.65.0.27:59788",
+					"172.17.0.1:59788",
+					"172.18.0.1:59788",
+					"172.19.0.1:59788"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:28:39.103086612Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3480160245850418,
+				"StableID":   "ny8GgguABU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:71e1cb45d9f30e9f8b94d3e294ee11134c2d96cf412eeaec2e469604b1167b77",
+				"DiscoKey":   "discokey:bf5ba29bda1bf2ad684f424bc6c263362720e01f195622f4595a8b770697136f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:58537",
+					"10.65.0.27:58537",
+					"172.17.0.1:58537",
+					"172.18.0.1:58537",
+					"172.19.0.1:58537"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:28:39.649747534Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2133871054773266,
+				"StableID":   "nVxh17BSfH11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c8cb2e4d13ebd3b2fa9028e211198f50beac896e636fc5953dcb9a9426dbff3d",
+				"DiscoKey":   "discokey:c4a09c24bafcd497a5d7b21a66a31e2a6a320a4858ffbbd4b4ce1d0181e36b30",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49858",
+					"10.65.0.27:49858",
+					"172.17.0.1:49858",
+					"172.18.0.1:49858",
+					"172.19.0.1:49858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:28:40.194144492Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1506770714821847,
+				"StableID":   "nt9kN5KRmC11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f980c7ad0d89eaa2fe9c8ef67815497173c9af393e6c1247ba12266278cd4f6f",
+				"DiscoKey":   "discokey:2f9e46797bfd85747949649b9f9f7fb5c7a39ac81ba07f8da56c0642f1e0d079",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34842",
+					"10.65.0.27:34842",
+					"172.17.0.1:34842",
+					"172.18.0.1:34842",
+					"172.19.0.1:34842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:28:40.73561438Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         877582131656574,
+				"StableID":   "nyAUqUbTr711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4dc31e4a7b67b678b9e6812685f074a28475d9604723b891a4c13c30fe0c0478",
+				"DiscoKey":   "discokey:dc7904ff76aecebf786c71b06b75889b56960ac9cc73e4d998148bd4e8c2992a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39439",
+					"10.65.0.27:39439",
+					"172.17.0.1:39439",
+					"172.18.0.1:39439",
+					"172.19.0.1:39439"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:28:41.256529399Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1160340179479559,
+				"StableID":   "ngVDGoAX4A11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b07e3c3f65c0080dd3b5288b6980dd5e2f733af4f02a10d8cbae6ffe7211f65f",
+				"DiscoKey":   "discokey:847b32ac8c494d973e48c11d87fd0fbb18babe23f8ce1215cc13bd781c3c7b64",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35595",
+					"10.65.0.27:35595",
+					"172.17.0.1:35595",
+					"172.18.0.1:35595",
+					"172.19.0.1:35595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:28:41.796836638Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8189540296007182,
+				"StableID":   "nVgJCXL4x621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ebfda57148876ba029f73be8a1e4a0d7d49eec1686afad390aaa2ab3458b351",
+				"DiscoKey":   "discokey:2ac706d3ccfa666464d4c600068e7e44d6714bb58d7281baf5b06ff8e73ef939",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52413",
+					"10.65.0.27:52413",
+					"172.17.0.1:52413",
+					"172.18.0.1:52413",
+					"172.19.0.1:52413"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:28:42.339395371Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         141095417123184,
+				"StableID":   "n9DTrZLu6211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b95747c5b9a2e7b04f70a72b6b99728d0b06961c0d1542b96e0d52c89998c879",
+				"DiscoKey":   "discokey:c904f484c8b09219674379a967639eb45a1c9cb44e20c1c7cc6944cefdab3452",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:43180",
+					"10.65.0.27:43180",
+					"172.17.0.1:43180",
+					"172.18.0.1:43180",
+					"172.19.0.1:43180"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:28:43.438954126Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3525047351717480,
+				"StableID":   "nb8oWx1WXU11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77376a0711dbb8247b0772db716ebbd007473feb11f6eeb4a53b6417b8d2a42c",
+				"DiscoKey":   "discokey:0c5f02fdbafe05c60d38501530f97fbcab5ff3023a08f1c20cfbacaa54078f33",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60502",
+					"10.65.0.27:60502",
+					"172.17.0.1:60502",
+					"172.18.0.1:60502",
+					"172.19.0.1:60502"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:28:43.9611266Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7688641748352734,
+				"StableID":   "nKMYnhaC3321CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21b54e4cc2c8be33880e1dc36070ab165ea0acb554c9a6893a7e48930d54821c",
+				"DiscoKey":   "discokey:9e01f493eb0abc86fbbbb3dd6db8737c2f17c057c52abc5529f36bc4edd1eb70",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45564",
+					"10.65.0.27:45564",
+					"172.17.0.1:45564",
+					"172.18.0.1:45564",
+					"172.19.0.1:45564"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:28:44.506627946Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6098342714510689,
+				"StableID":   "niRVt58xcp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0855c7c44eecd1fcf92bae173de8fe354ea19c66019371f311b1c78e6def0152",
+				"KeyExpiry":  "2026-11-09T07:28:45Z",
+				"DiscoKey":   "discokey:488c752ba12c18897e232cbeb1ab4a2b2d61206d002e613ea1812f458bdb4f63",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41114",
+					"10.65.0.27:41114",
+					"172.17.0.1:41114",
+					"172.18.0.1:41114",
+					"172.19.0.1:41114"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:28:45.086530941Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8446860947057593,
+				"StableID":   "nW7ZyPibx821CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9c4c89f86d9afd1f228354570908472fa6b70c6826f9892da05c294c3a852e73",
+				"KeyExpiry":  "2026-11-09T07:28:45Z",
+				"DiscoKey":   "discokey:3620d9800c95b4e73a11b6d53b4b1e7112b99e17765cbf9b88014df1e6d64934",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41351",
+					"10.65.0.27:41351",
+					"172.17.0.1:41351",
+					"172.18.0.1:41351",
+					"172.19.0.1:41351"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:28:45.586430311Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5586116173836200,
+				"StableID":   "n5bVXNoxck11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:063e5855787b816ae06ae0c88f8c46cc85062a2f0aeaa752b350275e1c94b836",
+				"KeyExpiry":  "2026-11-09T07:28:46Z",
+				"DiscoKey":   "discokey:b5a8870188e5ee652642438a20571ab4397dfc0278f4c620d891ba775edcdb7a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33061",
+					"10.65.0.27:33061",
+					"172.17.0.1:33061",
+					"172.18.0.1:33061",
+					"172.19.0.1:33061"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:28:46.122283896Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7901590941276499": {
+				"ID":          7901590941276499,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8446860947057593,
+				"StableID":   "nW7ZyPibx821CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9c4c89f86d9afd1f228354570908472fa6b70c6826f9892da05c294c3a852e73",
+				"KeyExpiry":  "2026-11-09T07:28:45Z",
+				"DiscoKey":   "discokey:3620d9800c95b4e73a11b6d53b4b1e7112b99e17765cbf9b88014df1e6d64934",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41351",
+					"10.65.0.27:41351",
+					"172.17.0.1:41351",
+					"172.18.0.1:41351",
+					"172.19.0.1:41351"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:28:45.586430311Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9c4c89f86d9afd1f228354570908472fa6b70c6826f9892da05c294c3a852e73",
+			"MachineKey": "mkey:7a55675111b8a00f23a0e9148674c15d8944a5ad31b585278300f92d74eed874",
+			"Peers": [{
+				"ID":         7268534454816808,
+				"StableID":   "n3S2rL5wky11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31f30caf38951768cd4a4c39d8805d6fe6ee48f7f741628e7f0864c93bf58b27",
+				"DiscoKey":   "discokey:67d9d08c37b6ef412e0604d5901ad81a11b9bfcf887f6ce581ffc218799eb27e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45950",
+					"10.65.0.27:45950",
+					"172.17.0.1:45950",
+					"172.18.0.1:45950",
+					"172.19.0.1:45950"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:28:38.564883436Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4466813085138409,
+				"StableID":   "nvj9T7c2tb11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:17d78a9efad19365637a65227445957b95e676983c2bd25eddef347135b01557",
+				"DiscoKey":   "discokey:0a9f663c8f3f777e25b0798b5b609aa00fa2561d7e759df0c1bddf15e50b1c14",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59788",
+					"10.65.0.27:59788",
+					"172.17.0.1:59788",
+					"172.18.0.1:59788",
+					"172.19.0.1:59788"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:28:39.103086612Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3480160245850418,
+				"StableID":   "ny8GgguABU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:71e1cb45d9f30e9f8b94d3e294ee11134c2d96cf412eeaec2e469604b1167b77",
+				"DiscoKey":   "discokey:bf5ba29bda1bf2ad684f424bc6c263362720e01f195622f4595a8b770697136f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:58537",
+					"10.65.0.27:58537",
+					"172.17.0.1:58537",
+					"172.18.0.1:58537",
+					"172.19.0.1:58537"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:28:39.649747534Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2133871054773266,
+				"StableID":   "nVxh17BSfH11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c8cb2e4d13ebd3b2fa9028e211198f50beac896e636fc5953dcb9a9426dbff3d",
+				"DiscoKey":   "discokey:c4a09c24bafcd497a5d7b21a66a31e2a6a320a4858ffbbd4b4ce1d0181e36b30",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49858",
+					"10.65.0.27:49858",
+					"172.17.0.1:49858",
+					"172.18.0.1:49858",
+					"172.19.0.1:49858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:28:40.194144492Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1506770714821847,
+				"StableID":   "nt9kN5KRmC11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f980c7ad0d89eaa2fe9c8ef67815497173c9af393e6c1247ba12266278cd4f6f",
+				"DiscoKey":   "discokey:2f9e46797bfd85747949649b9f9f7fb5c7a39ac81ba07f8da56c0642f1e0d079",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34842",
+					"10.65.0.27:34842",
+					"172.17.0.1:34842",
+					"172.18.0.1:34842",
+					"172.19.0.1:34842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:28:40.73561438Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         877582131656574,
+				"StableID":   "nyAUqUbTr711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4dc31e4a7b67b678b9e6812685f074a28475d9604723b891a4c13c30fe0c0478",
+				"DiscoKey":   "discokey:dc7904ff76aecebf786c71b06b75889b56960ac9cc73e4d998148bd4e8c2992a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39439",
+					"10.65.0.27:39439",
+					"172.17.0.1:39439",
+					"172.18.0.1:39439",
+					"172.19.0.1:39439"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:28:41.256529399Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1160340179479559,
+				"StableID":   "ngVDGoAX4A11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b07e3c3f65c0080dd3b5288b6980dd5e2f733af4f02a10d8cbae6ffe7211f65f",
+				"DiscoKey":   "discokey:847b32ac8c494d973e48c11d87fd0fbb18babe23f8ce1215cc13bd781c3c7b64",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35595",
+					"10.65.0.27:35595",
+					"172.17.0.1:35595",
+					"172.18.0.1:35595",
+					"172.19.0.1:35595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:28:41.796836638Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8189540296007182,
+				"StableID":   "nVgJCXL4x621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ebfda57148876ba029f73be8a1e4a0d7d49eec1686afad390aaa2ab3458b351",
+				"DiscoKey":   "discokey:2ac706d3ccfa666464d4c600068e7e44d6714bb58d7281baf5b06ff8e73ef939",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52413",
+					"10.65.0.27:52413",
+					"172.17.0.1:52413",
+					"172.18.0.1:52413",
+					"172.19.0.1:52413"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:28:42.339395371Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7901590941276499,
+				"StableID":   "nk7ikvPeh421CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2efd0ca1c9ce5a97f693cd355518b77027855cc57ff0a4bcfb19a9c90017581c",
+				"DiscoKey":   "discokey:e1d4ae41620de6d262defc40660a562497a5d31b818f3a202a575564d0b53f24",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43507",
+					"10.65.0.27:43507",
+					"172.17.0.1:43507",
+					"172.18.0.1:43507",
+					"172.19.0.1:43507"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:28:42.894545891Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         141095417123184,
+				"StableID":   "n9DTrZLu6211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b95747c5b9a2e7b04f70a72b6b99728d0b06961c0d1542b96e0d52c89998c879",
+				"DiscoKey":   "discokey:c904f484c8b09219674379a967639eb45a1c9cb44e20c1c7cc6944cefdab3452",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:43180",
+					"10.65.0.27:43180",
+					"172.17.0.1:43180",
+					"172.18.0.1:43180",
+					"172.19.0.1:43180"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:28:43.438954126Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3525047351717480,
+				"StableID":   "nb8oWx1WXU11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77376a0711dbb8247b0772db716ebbd007473feb11f6eeb4a53b6417b8d2a42c",
+				"DiscoKey":   "discokey:0c5f02fdbafe05c60d38501530f97fbcab5ff3023a08f1c20cfbacaa54078f33",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60502",
+					"10.65.0.27:60502",
+					"172.17.0.1:60502",
+					"172.18.0.1:60502",
+					"172.19.0.1:60502"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:28:43.9611266Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7688641748352734,
+				"StableID":   "nKMYnhaC3321CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21b54e4cc2c8be33880e1dc36070ab165ea0acb554c9a6893a7e48930d54821c",
+				"DiscoKey":   "discokey:9e01f493eb0abc86fbbbb3dd6db8737c2f17c057c52abc5529f36bc4edd1eb70",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45564",
+					"10.65.0.27:45564",
+					"172.17.0.1:45564",
+					"172.18.0.1:45564",
+					"172.19.0.1:45564"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:28:44.506627946Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6098342714510689,
+				"StableID":   "niRVt58xcp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0855c7c44eecd1fcf92bae173de8fe354ea19c66019371f311b1c78e6def0152",
+				"KeyExpiry":  "2026-11-09T07:28:45Z",
+				"DiscoKey":   "discokey:488c752ba12c18897e232cbeb1ab4a2b2d61206d002e613ea1812f458bdb4f63",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41114",
+					"10.65.0.27:41114",
+					"172.17.0.1:41114",
+					"172.18.0.1:41114",
+					"172.19.0.1:41114"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:28:45.086530941Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5586116173836200,
+				"StableID":   "n5bVXNoxck11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:063e5855787b816ae06ae0c88f8c46cc85062a2f0aeaa752b350275e1c94b836",
+				"KeyExpiry":  "2026-11-09T07:28:46Z",
+				"DiscoKey":   "discokey:b5a8870188e5ee652642438a20571ab4397dfc0278f4c620d891ba775edcdb7a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33061",
+					"10.65.0.27:33061",
+					"172.17.0.1:33061",
+					"172.18.0.1:33061",
+					"172.19.0.1:33061"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:28:46.122283896Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         141095417123184,
+				"StableID":   "n9DTrZLu6211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       141095417123184,
+				"Key":        "nodekey:b95747c5b9a2e7b04f70a72b6b99728d0b06961c0d1542b96e0d52c89998c879",
+				"DiscoKey":   "discokey:c904f484c8b09219674379a967639eb45a1c9cb44e20c1c7cc6944cefdab3452",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:43180",
+					"10.65.0.27:43180",
+					"172.17.0.1:43180",
+					"172.18.0.1:43180",
+					"172.19.0.1:43180"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:28:43.438954126Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b95747c5b9a2e7b04f70a72b6b99728d0b06961c0d1542b96e0d52c89998c879",
+			"MachineKey": "mkey:1bc0b61393168f9d39e7c6c2570fd47bfdda450325197c984d0b27b3e7be383a",
+			"Peers": [{
+				"ID":         7268534454816808,
+				"StableID":   "n3S2rL5wky11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31f30caf38951768cd4a4c39d8805d6fe6ee48f7f741628e7f0864c93bf58b27",
+				"DiscoKey":   "discokey:67d9d08c37b6ef412e0604d5901ad81a11b9bfcf887f6ce581ffc218799eb27e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45950",
+					"10.65.0.27:45950",
+					"172.17.0.1:45950",
+					"172.18.0.1:45950",
+					"172.19.0.1:45950"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:28:38.564883436Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4466813085138409,
+				"StableID":   "nvj9T7c2tb11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:17d78a9efad19365637a65227445957b95e676983c2bd25eddef347135b01557",
+				"DiscoKey":   "discokey:0a9f663c8f3f777e25b0798b5b609aa00fa2561d7e759df0c1bddf15e50b1c14",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59788",
+					"10.65.0.27:59788",
+					"172.17.0.1:59788",
+					"172.18.0.1:59788",
+					"172.19.0.1:59788"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:28:39.103086612Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3480160245850418,
+				"StableID":   "ny8GgguABU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:71e1cb45d9f30e9f8b94d3e294ee11134c2d96cf412eeaec2e469604b1167b77",
+				"DiscoKey":   "discokey:bf5ba29bda1bf2ad684f424bc6c263362720e01f195622f4595a8b770697136f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:58537",
+					"10.65.0.27:58537",
+					"172.17.0.1:58537",
+					"172.18.0.1:58537",
+					"172.19.0.1:58537"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:28:39.649747534Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2133871054773266,
+				"StableID":   "nVxh17BSfH11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c8cb2e4d13ebd3b2fa9028e211198f50beac896e636fc5953dcb9a9426dbff3d",
+				"DiscoKey":   "discokey:c4a09c24bafcd497a5d7b21a66a31e2a6a320a4858ffbbd4b4ce1d0181e36b30",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49858",
+					"10.65.0.27:49858",
+					"172.17.0.1:49858",
+					"172.18.0.1:49858",
+					"172.19.0.1:49858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:28:40.194144492Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1506770714821847,
+				"StableID":   "nt9kN5KRmC11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f980c7ad0d89eaa2fe9c8ef67815497173c9af393e6c1247ba12266278cd4f6f",
+				"DiscoKey":   "discokey:2f9e46797bfd85747949649b9f9f7fb5c7a39ac81ba07f8da56c0642f1e0d079",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34842",
+					"10.65.0.27:34842",
+					"172.17.0.1:34842",
+					"172.18.0.1:34842",
+					"172.19.0.1:34842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:28:40.73561438Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         877582131656574,
+				"StableID":   "nyAUqUbTr711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4dc31e4a7b67b678b9e6812685f074a28475d9604723b891a4c13c30fe0c0478",
+				"DiscoKey":   "discokey:dc7904ff76aecebf786c71b06b75889b56960ac9cc73e4d998148bd4e8c2992a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39439",
+					"10.65.0.27:39439",
+					"172.17.0.1:39439",
+					"172.18.0.1:39439",
+					"172.19.0.1:39439"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:28:41.256529399Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1160340179479559,
+				"StableID":   "ngVDGoAX4A11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b07e3c3f65c0080dd3b5288b6980dd5e2f733af4f02a10d8cbae6ffe7211f65f",
+				"DiscoKey":   "discokey:847b32ac8c494d973e48c11d87fd0fbb18babe23f8ce1215cc13bd781c3c7b64",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35595",
+					"10.65.0.27:35595",
+					"172.17.0.1:35595",
+					"172.18.0.1:35595",
+					"172.19.0.1:35595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:28:41.796836638Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8189540296007182,
+				"StableID":   "nVgJCXL4x621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ebfda57148876ba029f73be8a1e4a0d7d49eec1686afad390aaa2ab3458b351",
+				"DiscoKey":   "discokey:2ac706d3ccfa666464d4c600068e7e44d6714bb58d7281baf5b06ff8e73ef939",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52413",
+					"10.65.0.27:52413",
+					"172.17.0.1:52413",
+					"172.18.0.1:52413",
+					"172.19.0.1:52413"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:28:42.339395371Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7901590941276499,
+				"StableID":   "nk7ikvPeh421CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2efd0ca1c9ce5a97f693cd355518b77027855cc57ff0a4bcfb19a9c90017581c",
+				"DiscoKey":   "discokey:e1d4ae41620de6d262defc40660a562497a5d31b818f3a202a575564d0b53f24",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43507",
+					"10.65.0.27:43507",
+					"172.17.0.1:43507",
+					"172.18.0.1:43507",
+					"172.19.0.1:43507"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:28:42.894545891Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3525047351717480,
+				"StableID":   "nb8oWx1WXU11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77376a0711dbb8247b0772db716ebbd007473feb11f6eeb4a53b6417b8d2a42c",
+				"DiscoKey":   "discokey:0c5f02fdbafe05c60d38501530f97fbcab5ff3023a08f1c20cfbacaa54078f33",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60502",
+					"10.65.0.27:60502",
+					"172.17.0.1:60502",
+					"172.18.0.1:60502",
+					"172.19.0.1:60502"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:28:43.9611266Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7688641748352734,
+				"StableID":   "nKMYnhaC3321CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21b54e4cc2c8be33880e1dc36070ab165ea0acb554c9a6893a7e48930d54821c",
+				"DiscoKey":   "discokey:9e01f493eb0abc86fbbbb3dd6db8737c2f17c057c52abc5529f36bc4edd1eb70",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45564",
+					"10.65.0.27:45564",
+					"172.17.0.1:45564",
+					"172.18.0.1:45564",
+					"172.19.0.1:45564"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:28:44.506627946Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6098342714510689,
+				"StableID":   "niRVt58xcp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0855c7c44eecd1fcf92bae173de8fe354ea19c66019371f311b1c78e6def0152",
+				"KeyExpiry":  "2026-11-09T07:28:45Z",
+				"DiscoKey":   "discokey:488c752ba12c18897e232cbeb1ab4a2b2d61206d002e613ea1812f458bdb4f63",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41114",
+					"10.65.0.27:41114",
+					"172.17.0.1:41114",
+					"172.18.0.1:41114",
+					"172.19.0.1:41114"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:28:45.086530941Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8446860947057593,
+				"StableID":   "nW7ZyPibx821CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9c4c89f86d9afd1f228354570908472fa6b70c6826f9892da05c294c3a852e73",
+				"KeyExpiry":  "2026-11-09T07:28:45Z",
+				"DiscoKey":   "discokey:3620d9800c95b4e73a11b6d53b4b1e7112b99e17765cbf9b88014df1e6d64934",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41351",
+					"10.65.0.27:41351",
+					"172.17.0.1:41351",
+					"172.18.0.1:41351",
+					"172.19.0.1:41351"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:28:45.586430311Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5586116173836200,
+				"StableID":   "n5bVXNoxck11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:063e5855787b816ae06ae0c88f8c46cc85062a2f0aeaa752b350275e1c94b836",
+				"KeyExpiry":  "2026-11-09T07:28:46Z",
+				"DiscoKey":   "discokey:b5a8870188e5ee652642438a20571ab4397dfc0278f4c620d891ba775edcdb7a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33061",
+					"10.65.0.27:33061",
+					"172.17.0.1:33061",
+					"172.18.0.1:33061",
+					"172.19.0.1:33061"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:28:46.122283896Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "141095417123184": {
+				"ID":          141095417123184,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-checkperiod-malformed.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-checkperiod-malformed.hujson
@@ -1,0 +1,20082 @@
+// ssh-malformed-checkperiod-malformed
+//
+// ssh checkPeriod unparseable duration is rejected
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T21:53:08Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-malformed-checkperiod-malformed",
+	"description":    "ssh checkPeriod unparseable duration is rejected",
+	"category":       "ssh",
+	"captured_at":    "2026-05-12T21:53:08.68685322Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "time: invalid duration \"abc\""},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                      \n  \n                                                  \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh checkPeriod unparseable duration is rejected\",\n\t\"id\":          \"ssh-malformed-checkperiod-malformed\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\":      \"check\",\n\t\t\"checkPeriod\": \"abc\",\n\t\t\"dst\":         [\"tag:server\"],\n\t\t\"src\":         [\"autogroup:member\"],\n\t\t\"users\":       [\"root\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-malformed/ssh-malformed-checkperiod-malformed.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action":      "check",
+				"checkPeriod": "abc",
+				"dst":         ["tag:server"],
+				"src":         ["autogroup:member"],
+				"users":       ["root"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7974220851558896,
+				"StableID":   "nszWD5GYG521CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       7974220851558896,
+				"Key":        "nodekey:4e4ae00825cf9b00635352d541d46b4d03244f862d26e08b0cbae83ac33d2064",
+				"DiscoKey":   "discokey:0fe95cb2bb9e00f63e6e01817e7839f41c77e82486721fef0a2aaaff485d3101",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46471",
+					"10.65.0.27:46471",
+					"172.17.0.1:46471",
+					"172.18.0.1:46471",
+					"172.19.0.1:46471"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:53:17.171796369Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4e4ae00825cf9b00635352d541d46b4d03244f862d26e08b0cbae83ac33d2064",
+			"MachineKey": "mkey:b056e8f1e3b287d08ad415211b44d257ae85ad60de42442ac736582ccb9a2f2b",
+			"Peers": [{
+				"ID":         884839837843811,
+				"StableID":   "nAxkU3Fku711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d01b1aa3fb1f2459e69d332d4d3ec9b10ea2b4b833b2aea625fa2fbaabf9e1f",
+				"DiscoKey":   "discokey:3e951148bb7fafb746fa64807803ccf37b033ce354563d89a7ec98991648aa52",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33030",
+					"10.65.0.27:33030",
+					"172.17.0.1:33030",
+					"172.18.0.1:33030",
+					"172.19.0.1:33030"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:53:11.234882939Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5121850593450720,
+				"StableID":   "nduQz8Lhzg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d486392a39ffe96af7c8b980a44c3a3ec7ac7034f5f18ed32f05af8b283dc159",
+				"DiscoKey":   "discokey:f91ef00a03bc65b87fc281a2d15f5d7bd183dae5b53e7af90f60bf83acb01c58",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50572",
+					"10.65.0.27:50572",
+					"172.17.0.1:50572",
+					"172.18.0.1:50572",
+					"172.19.0.1:50572"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:53:11.763327396Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2162159437425437,
+				"StableID":   "nkz3XCGFtH11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f72a4e017de1b91028407ad7de4223ceaadf0aeafe5034b50f1456baf0187e33",
+				"DiscoKey":   "discokey:b1fc57c7a0211597fba45c310c155b61c431980b927662e800e3ce27b59f3118",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33602",
+					"10.65.0.27:33602",
+					"172.17.0.1:33602",
+					"172.18.0.1:33602",
+					"172.19.0.1:33602"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:53:12.295257227Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8094170429721881,
+				"StableID":   "nkJ2he8sC621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:142f6ff7f9835024bb7c55a5342f82e6a5571f1425c1e47395b71757d10d2e07",
+				"DiscoKey":   "discokey:f3bc18e05531b29ff92e5f777edb1bc3f2577b679fe34564557f2a4d7226306f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43044",
+					"10.65.0.27:43044",
+					"172.17.0.1:43044",
+					"172.18.0.1:43044",
+					"172.19.0.1:43044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:53:12.83614961Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         400553619704474,
+				"StableID":   "nTb2k8sQ8411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f8ad3094de8b0ab1e4f742316ca0dda2f9c898d9ac45a481c9e7e07b2ac6125",
+				"DiscoKey":   "discokey:3320c1527557cfe82f792f2f7c754dc3ca4975644be20f458266c02ee8a71b5a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57048",
+					"10.65.0.27:57048",
+					"172.17.0.1:57048",
+					"172.18.0.1:57048",
+					"172.19.0.1:57048"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:53:13.384661116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8060234399958885,
+				"StableID":   "nnH1x1hVw521CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:845ffdfed4eb0b79a76d13732fa1043ffe51dd16062dabe3d7b2c6175addaf73",
+				"DiscoKey":   "discokey:0d95058e6981d401f73613b09e8c702d793036e63ce698ffa06c7d62f4621d01",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53883",
+					"10.65.0.27:53883",
+					"172.17.0.1:53883",
+					"172.18.0.1:53883",
+					"172.19.0.1:53883"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:53:13.92257343Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3979154462050877,
+				"StableID":   "nJ7Zq8eA5Y11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c0482feab48384f62ceb3cf0e0357b0d18b7a988d3cc4c1b7c1df5a9eed8d24a",
+				"DiscoKey":   "discokey:2ed617110eae9697b77d92d9dcb757f9f7cf5a601c1599ed33fcd5753fac225c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54851",
+					"10.65.0.27:54851",
+					"172.17.0.1:54851",
+					"172.18.0.1:54851",
+					"172.19.0.1:54851"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:53:14.461921611Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6190654681495652,
+				"StableID":   "nVRZJ41mLq11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f2dde100287742dcfef89325a0dc820135505785c58f76eda06ee999a05a220f",
+				"DiscoKey":   "discokey:d810dcd5a6694432827bc65720ebeec4b958cfd6ab7a9f64a9f6be08953e8679",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58510",
+					"10.65.0.27:58510",
+					"172.17.0.1:58510",
+					"172.18.0.1:58510",
+					"172.19.0.1:58510"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:53:15.031556524Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         767453331655996,
+				"StableID":   "num5uThaz611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:451d69c8db54f124e091ab84d6b7e9cbc4b4e926e6e7514a7e73360ddd88cb7a",
+				"DiscoKey":   "discokey:d086f5f0dec8616426bd956162e84008795497dc378cc0b6d5935f6c7cbe8740",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:50877",
+					"10.65.0.27:50877",
+					"172.17.0.1:50877",
+					"172.18.0.1:50877",
+					"172.19.0.1:50877"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:53:15.535860367Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7241594842877954,
+				"StableID":   "nmz8bBRjYy11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1efbf5403be0ec53d9d2f8df3743c52cae169224ca2c42cf582023299d6042b",
+				"DiscoKey":   "discokey:ae2ea0ae798fa4955041d288f309ce01c35adbccbef557d98760d98f6720b97a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40710",
+					"10.65.0.27:40710",
+					"172.17.0.1:40710",
+					"172.18.0.1:40710",
+					"172.19.0.1:40710"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:53:16.08232304Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8572727664789590,
+				"StableID":   "nyE2p62cw921CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15c267a3b83de191d712d4e7bb374f53a4a6991d0ed8c928d147486f7ff8f353",
+				"DiscoKey":   "discokey:8fe51e8ae52634e6d49f8224e8f95876de264d055406cd5c97136868ee00cd59",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50223",
+					"10.65.0.27:50223",
+					"172.17.0.1:50223",
+					"172.18.0.1:50223",
+					"172.19.0.1:50223"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:53:16.630510647Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8669461418029847,
+				"StableID":   "nYDTLw3RhA21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:00e5961df8ba4198e09cbd8fd9b7c83dfbe644fd17117646434be1aa074a8161",
+				"KeyExpiry":  "2026-11-08T21:53:17Z",
+				"DiscoKey":   "discokey:dcb428b3caeb1a52c5b04113b51cff70f3d0f001afcef6d15661261c9fb1202d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:60481",
+					"10.65.0.27:60481",
+					"172.17.0.1:60481",
+					"172.18.0.1:60481",
+					"172.19.0.1:60481"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:53:17.708462216Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2151744728930910,
+				"StableID":   "nwZjPkgXoH11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:193991aaaf06410684c146b6e889dc36865a92a03f4e4b8a49e2b7ef21079f4d",
+				"KeyExpiry":  "2026-11-08T21:53:18Z",
+				"DiscoKey":   "discokey:cd4610dcf7fc0b635bf0bbd361c94a8fbe6aa59dcc593ff86122f4912e5bff14",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46564",
+					"10.65.0.27:46564",
+					"172.17.0.1:46564",
+					"172.18.0.1:46564",
+					"172.19.0.1:46564"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:53:18.288272357Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1408541625136421,
+				"StableID":   "namA611wzB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:6bb0d194d75e39e3a7ee34597d22ec3a2ca59d8ed4427deb913be1dbe2f76064",
+				"KeyExpiry":  "2026-11-08T21:53:18Z",
+				"DiscoKey":   "discokey:85cf58118249b4acebbdc01cd421c639400811cdad67d1695cb450616c837c40",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:37963",
+					"10.65.0.27:37963",
+					"172.17.0.1:37963",
+					"172.18.0.1:37963",
+					"172.19.0.1:37963"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:53:18.798546704Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7974220851558896": {
+				"ID":          7974220851558896,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8060234399958885,
+				"StableID":   "nnH1x1hVw521CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       8060234399958885,
+				"Key":        "nodekey:845ffdfed4eb0b79a76d13732fa1043ffe51dd16062dabe3d7b2c6175addaf73",
+				"DiscoKey":   "discokey:0d95058e6981d401f73613b09e8c702d793036e63ce698ffa06c7d62f4621d01",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53883",
+					"10.65.0.27:53883",
+					"172.17.0.1:53883",
+					"172.18.0.1:53883",
+					"172.19.0.1:53883"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:53:13.92257343Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:845ffdfed4eb0b79a76d13732fa1043ffe51dd16062dabe3d7b2c6175addaf73",
+			"MachineKey": "mkey:0522f171e12caf5f8868e97fd3ca8241191d39254a383afe4e1cf3c0929aad5a",
+			"Peers": [{
+				"ID":         884839837843811,
+				"StableID":   "nAxkU3Fku711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d01b1aa3fb1f2459e69d332d4d3ec9b10ea2b4b833b2aea625fa2fbaabf9e1f",
+				"DiscoKey":   "discokey:3e951148bb7fafb746fa64807803ccf37b033ce354563d89a7ec98991648aa52",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33030",
+					"10.65.0.27:33030",
+					"172.17.0.1:33030",
+					"172.18.0.1:33030",
+					"172.19.0.1:33030"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:53:11.234882939Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5121850593450720,
+				"StableID":   "nduQz8Lhzg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d486392a39ffe96af7c8b980a44c3a3ec7ac7034f5f18ed32f05af8b283dc159",
+				"DiscoKey":   "discokey:f91ef00a03bc65b87fc281a2d15f5d7bd183dae5b53e7af90f60bf83acb01c58",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50572",
+					"10.65.0.27:50572",
+					"172.17.0.1:50572",
+					"172.18.0.1:50572",
+					"172.19.0.1:50572"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:53:11.763327396Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2162159437425437,
+				"StableID":   "nkz3XCGFtH11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f72a4e017de1b91028407ad7de4223ceaadf0aeafe5034b50f1456baf0187e33",
+				"DiscoKey":   "discokey:b1fc57c7a0211597fba45c310c155b61c431980b927662e800e3ce27b59f3118",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33602",
+					"10.65.0.27:33602",
+					"172.17.0.1:33602",
+					"172.18.0.1:33602",
+					"172.19.0.1:33602"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:53:12.295257227Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8094170429721881,
+				"StableID":   "nkJ2he8sC621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:142f6ff7f9835024bb7c55a5342f82e6a5571f1425c1e47395b71757d10d2e07",
+				"DiscoKey":   "discokey:f3bc18e05531b29ff92e5f777edb1bc3f2577b679fe34564557f2a4d7226306f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43044",
+					"10.65.0.27:43044",
+					"172.17.0.1:43044",
+					"172.18.0.1:43044",
+					"172.19.0.1:43044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:53:12.83614961Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         400553619704474,
+				"StableID":   "nTb2k8sQ8411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f8ad3094de8b0ab1e4f742316ca0dda2f9c898d9ac45a481c9e7e07b2ac6125",
+				"DiscoKey":   "discokey:3320c1527557cfe82f792f2f7c754dc3ca4975644be20f458266c02ee8a71b5a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57048",
+					"10.65.0.27:57048",
+					"172.17.0.1:57048",
+					"172.18.0.1:57048",
+					"172.19.0.1:57048"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:53:13.384661116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3979154462050877,
+				"StableID":   "nJ7Zq8eA5Y11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c0482feab48384f62ceb3cf0e0357b0d18b7a988d3cc4c1b7c1df5a9eed8d24a",
+				"DiscoKey":   "discokey:2ed617110eae9697b77d92d9dcb757f9f7cf5a601c1599ed33fcd5753fac225c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54851",
+					"10.65.0.27:54851",
+					"172.17.0.1:54851",
+					"172.18.0.1:54851",
+					"172.19.0.1:54851"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:53:14.461921611Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6190654681495652,
+				"StableID":   "nVRZJ41mLq11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f2dde100287742dcfef89325a0dc820135505785c58f76eda06ee999a05a220f",
+				"DiscoKey":   "discokey:d810dcd5a6694432827bc65720ebeec4b958cfd6ab7a9f64a9f6be08953e8679",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58510",
+					"10.65.0.27:58510",
+					"172.17.0.1:58510",
+					"172.18.0.1:58510",
+					"172.19.0.1:58510"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:53:15.031556524Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         767453331655996,
+				"StableID":   "num5uThaz611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:451d69c8db54f124e091ab84d6b7e9cbc4b4e926e6e7514a7e73360ddd88cb7a",
+				"DiscoKey":   "discokey:d086f5f0dec8616426bd956162e84008795497dc378cc0b6d5935f6c7cbe8740",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:50877",
+					"10.65.0.27:50877",
+					"172.17.0.1:50877",
+					"172.18.0.1:50877",
+					"172.19.0.1:50877"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:53:15.535860367Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7241594842877954,
+				"StableID":   "nmz8bBRjYy11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1efbf5403be0ec53d9d2f8df3743c52cae169224ca2c42cf582023299d6042b",
+				"DiscoKey":   "discokey:ae2ea0ae798fa4955041d288f309ce01c35adbccbef557d98760d98f6720b97a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40710",
+					"10.65.0.27:40710",
+					"172.17.0.1:40710",
+					"172.18.0.1:40710",
+					"172.19.0.1:40710"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:53:16.08232304Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8572727664789590,
+				"StableID":   "nyE2p62cw921CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15c267a3b83de191d712d4e7bb374f53a4a6991d0ed8c928d147486f7ff8f353",
+				"DiscoKey":   "discokey:8fe51e8ae52634e6d49f8224e8f95876de264d055406cd5c97136868ee00cd59",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50223",
+					"10.65.0.27:50223",
+					"172.17.0.1:50223",
+					"172.18.0.1:50223",
+					"172.19.0.1:50223"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:53:16.630510647Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7974220851558896,
+				"StableID":   "nszWD5GYG521CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e4ae00825cf9b00635352d541d46b4d03244f862d26e08b0cbae83ac33d2064",
+				"DiscoKey":   "discokey:0fe95cb2bb9e00f63e6e01817e7839f41c77e82486721fef0a2aaaff485d3101",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46471",
+					"10.65.0.27:46471",
+					"172.17.0.1:46471",
+					"172.18.0.1:46471",
+					"172.19.0.1:46471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:53:17.171796369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8669461418029847,
+				"StableID":   "nYDTLw3RhA21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:00e5961df8ba4198e09cbd8fd9b7c83dfbe644fd17117646434be1aa074a8161",
+				"KeyExpiry":  "2026-11-08T21:53:17Z",
+				"DiscoKey":   "discokey:dcb428b3caeb1a52c5b04113b51cff70f3d0f001afcef6d15661261c9fb1202d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:60481",
+					"10.65.0.27:60481",
+					"172.17.0.1:60481",
+					"172.18.0.1:60481",
+					"172.19.0.1:60481"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:53:17.708462216Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2151744728930910,
+				"StableID":   "nwZjPkgXoH11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:193991aaaf06410684c146b6e889dc36865a92a03f4e4b8a49e2b7ef21079f4d",
+				"KeyExpiry":  "2026-11-08T21:53:18Z",
+				"DiscoKey":   "discokey:cd4610dcf7fc0b635bf0bbd361c94a8fbe6aa59dcc593ff86122f4912e5bff14",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46564",
+					"10.65.0.27:46564",
+					"172.17.0.1:46564",
+					"172.18.0.1:46564",
+					"172.19.0.1:46564"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:53:18.288272357Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1408541625136421,
+				"StableID":   "namA611wzB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:6bb0d194d75e39e3a7ee34597d22ec3a2ca59d8ed4427deb913be1dbe2f76064",
+				"KeyExpiry":  "2026-11-08T21:53:18Z",
+				"DiscoKey":   "discokey:85cf58118249b4acebbdc01cd421c639400811cdad67d1695cb450616c837c40",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:37963",
+					"10.65.0.27:37963",
+					"172.17.0.1:37963",
+					"172.18.0.1:37963",
+					"172.19.0.1:37963"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:53:18.798546704Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8060234399958885": {
+				"ID":          8060234399958885,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1408541625136421,
+				"StableID":   "namA611wzB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:6bb0d194d75e39e3a7ee34597d22ec3a2ca59d8ed4427deb913be1dbe2f76064",
+				"KeyExpiry":  "2026-11-08T21:53:18Z",
+				"DiscoKey":   "discokey:85cf58118249b4acebbdc01cd421c639400811cdad67d1695cb450616c837c40",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:37963",
+					"10.65.0.27:37963",
+					"172.17.0.1:37963",
+					"172.18.0.1:37963",
+					"172.19.0.1:37963"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:53:18.798546704Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6bb0d194d75e39e3a7ee34597d22ec3a2ca59d8ed4427deb913be1dbe2f76064",
+			"MachineKey": "mkey:5e3fcad5f97a7f272969d5e7f8f277ea0c1fd61fe1a5a6d20ebc8d5db615ca02",
+			"Peers": [{
+				"ID":         884839837843811,
+				"StableID":   "nAxkU3Fku711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d01b1aa3fb1f2459e69d332d4d3ec9b10ea2b4b833b2aea625fa2fbaabf9e1f",
+				"DiscoKey":   "discokey:3e951148bb7fafb746fa64807803ccf37b033ce354563d89a7ec98991648aa52",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33030",
+					"10.65.0.27:33030",
+					"172.17.0.1:33030",
+					"172.18.0.1:33030",
+					"172.19.0.1:33030"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:53:11.234882939Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5121850593450720,
+				"StableID":   "nduQz8Lhzg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d486392a39ffe96af7c8b980a44c3a3ec7ac7034f5f18ed32f05af8b283dc159",
+				"DiscoKey":   "discokey:f91ef00a03bc65b87fc281a2d15f5d7bd183dae5b53e7af90f60bf83acb01c58",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50572",
+					"10.65.0.27:50572",
+					"172.17.0.1:50572",
+					"172.18.0.1:50572",
+					"172.19.0.1:50572"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:53:11.763327396Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2162159437425437,
+				"StableID":   "nkz3XCGFtH11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f72a4e017de1b91028407ad7de4223ceaadf0aeafe5034b50f1456baf0187e33",
+				"DiscoKey":   "discokey:b1fc57c7a0211597fba45c310c155b61c431980b927662e800e3ce27b59f3118",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33602",
+					"10.65.0.27:33602",
+					"172.17.0.1:33602",
+					"172.18.0.1:33602",
+					"172.19.0.1:33602"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:53:12.295257227Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8094170429721881,
+				"StableID":   "nkJ2he8sC621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:142f6ff7f9835024bb7c55a5342f82e6a5571f1425c1e47395b71757d10d2e07",
+				"DiscoKey":   "discokey:f3bc18e05531b29ff92e5f777edb1bc3f2577b679fe34564557f2a4d7226306f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43044",
+					"10.65.0.27:43044",
+					"172.17.0.1:43044",
+					"172.18.0.1:43044",
+					"172.19.0.1:43044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:53:12.83614961Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         400553619704474,
+				"StableID":   "nTb2k8sQ8411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f8ad3094de8b0ab1e4f742316ca0dda2f9c898d9ac45a481c9e7e07b2ac6125",
+				"DiscoKey":   "discokey:3320c1527557cfe82f792f2f7c754dc3ca4975644be20f458266c02ee8a71b5a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57048",
+					"10.65.0.27:57048",
+					"172.17.0.1:57048",
+					"172.18.0.1:57048",
+					"172.19.0.1:57048"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:53:13.384661116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8060234399958885,
+				"StableID":   "nnH1x1hVw521CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:845ffdfed4eb0b79a76d13732fa1043ffe51dd16062dabe3d7b2c6175addaf73",
+				"DiscoKey":   "discokey:0d95058e6981d401f73613b09e8c702d793036e63ce698ffa06c7d62f4621d01",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53883",
+					"10.65.0.27:53883",
+					"172.17.0.1:53883",
+					"172.18.0.1:53883",
+					"172.19.0.1:53883"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:53:13.92257343Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3979154462050877,
+				"StableID":   "nJ7Zq8eA5Y11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c0482feab48384f62ceb3cf0e0357b0d18b7a988d3cc4c1b7c1df5a9eed8d24a",
+				"DiscoKey":   "discokey:2ed617110eae9697b77d92d9dcb757f9f7cf5a601c1599ed33fcd5753fac225c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54851",
+					"10.65.0.27:54851",
+					"172.17.0.1:54851",
+					"172.18.0.1:54851",
+					"172.19.0.1:54851"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:53:14.461921611Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6190654681495652,
+				"StableID":   "nVRZJ41mLq11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f2dde100287742dcfef89325a0dc820135505785c58f76eda06ee999a05a220f",
+				"DiscoKey":   "discokey:d810dcd5a6694432827bc65720ebeec4b958cfd6ab7a9f64a9f6be08953e8679",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58510",
+					"10.65.0.27:58510",
+					"172.17.0.1:58510",
+					"172.18.0.1:58510",
+					"172.19.0.1:58510"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:53:15.031556524Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         767453331655996,
+				"StableID":   "num5uThaz611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:451d69c8db54f124e091ab84d6b7e9cbc4b4e926e6e7514a7e73360ddd88cb7a",
+				"DiscoKey":   "discokey:d086f5f0dec8616426bd956162e84008795497dc378cc0b6d5935f6c7cbe8740",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:50877",
+					"10.65.0.27:50877",
+					"172.17.0.1:50877",
+					"172.18.0.1:50877",
+					"172.19.0.1:50877"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:53:15.535860367Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7241594842877954,
+				"StableID":   "nmz8bBRjYy11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1efbf5403be0ec53d9d2f8df3743c52cae169224ca2c42cf582023299d6042b",
+				"DiscoKey":   "discokey:ae2ea0ae798fa4955041d288f309ce01c35adbccbef557d98760d98f6720b97a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40710",
+					"10.65.0.27:40710",
+					"172.17.0.1:40710",
+					"172.18.0.1:40710",
+					"172.19.0.1:40710"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:53:16.08232304Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8572727664789590,
+				"StableID":   "nyE2p62cw921CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15c267a3b83de191d712d4e7bb374f53a4a6991d0ed8c928d147486f7ff8f353",
+				"DiscoKey":   "discokey:8fe51e8ae52634e6d49f8224e8f95876de264d055406cd5c97136868ee00cd59",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50223",
+					"10.65.0.27:50223",
+					"172.17.0.1:50223",
+					"172.18.0.1:50223",
+					"172.19.0.1:50223"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:53:16.630510647Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7974220851558896,
+				"StableID":   "nszWD5GYG521CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e4ae00825cf9b00635352d541d46b4d03244f862d26e08b0cbae83ac33d2064",
+				"DiscoKey":   "discokey:0fe95cb2bb9e00f63e6e01817e7839f41c77e82486721fef0a2aaaff485d3101",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46471",
+					"10.65.0.27:46471",
+					"172.17.0.1:46471",
+					"172.18.0.1:46471",
+					"172.19.0.1:46471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:53:17.171796369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8669461418029847,
+				"StableID":   "nYDTLw3RhA21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:00e5961df8ba4198e09cbd8fd9b7c83dfbe644fd17117646434be1aa074a8161",
+				"KeyExpiry":  "2026-11-08T21:53:17Z",
+				"DiscoKey":   "discokey:dcb428b3caeb1a52c5b04113b51cff70f3d0f001afcef6d15661261c9fb1202d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:60481",
+					"10.65.0.27:60481",
+					"172.17.0.1:60481",
+					"172.18.0.1:60481",
+					"172.19.0.1:60481"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:53:17.708462216Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2151744728930910,
+				"StableID":   "nwZjPkgXoH11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:193991aaaf06410684c146b6e889dc36865a92a03f4e4b8a49e2b7ef21079f4d",
+				"KeyExpiry":  "2026-11-08T21:53:18Z",
+				"DiscoKey":   "discokey:cd4610dcf7fc0b635bf0bbd361c94a8fbe6aa59dcc593ff86122f4912e5bff14",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46564",
+					"10.65.0.27:46564",
+					"172.17.0.1:46564",
+					"172.18.0.1:46564",
+					"172.19.0.1:46564"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:53:18.288272357Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2162159437425437,
+				"StableID":   "nkz3XCGFtH11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       2162159437425437,
+				"Key":        "nodekey:f72a4e017de1b91028407ad7de4223ceaadf0aeafe5034b50f1456baf0187e33",
+				"DiscoKey":   "discokey:b1fc57c7a0211597fba45c310c155b61c431980b927662e800e3ce27b59f3118",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33602",
+					"10.65.0.27:33602",
+					"172.17.0.1:33602",
+					"172.18.0.1:33602",
+					"172.19.0.1:33602"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:53:12.295257227Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f72a4e017de1b91028407ad7de4223ceaadf0aeafe5034b50f1456baf0187e33",
+			"MachineKey": "mkey:38cca28398230843d49bc43b1f164c63616ae20f29c18f1ad2ee493f0f03da27",
+			"Peers": [{
+				"ID":         884839837843811,
+				"StableID":   "nAxkU3Fku711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d01b1aa3fb1f2459e69d332d4d3ec9b10ea2b4b833b2aea625fa2fbaabf9e1f",
+				"DiscoKey":   "discokey:3e951148bb7fafb746fa64807803ccf37b033ce354563d89a7ec98991648aa52",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33030",
+					"10.65.0.27:33030",
+					"172.17.0.1:33030",
+					"172.18.0.1:33030",
+					"172.19.0.1:33030"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:53:11.234882939Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5121850593450720,
+				"StableID":   "nduQz8Lhzg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d486392a39ffe96af7c8b980a44c3a3ec7ac7034f5f18ed32f05af8b283dc159",
+				"DiscoKey":   "discokey:f91ef00a03bc65b87fc281a2d15f5d7bd183dae5b53e7af90f60bf83acb01c58",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50572",
+					"10.65.0.27:50572",
+					"172.17.0.1:50572",
+					"172.18.0.1:50572",
+					"172.19.0.1:50572"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:53:11.763327396Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8094170429721881,
+				"StableID":   "nkJ2he8sC621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:142f6ff7f9835024bb7c55a5342f82e6a5571f1425c1e47395b71757d10d2e07",
+				"DiscoKey":   "discokey:f3bc18e05531b29ff92e5f777edb1bc3f2577b679fe34564557f2a4d7226306f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43044",
+					"10.65.0.27:43044",
+					"172.17.0.1:43044",
+					"172.18.0.1:43044",
+					"172.19.0.1:43044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:53:12.83614961Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         400553619704474,
+				"StableID":   "nTb2k8sQ8411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f8ad3094de8b0ab1e4f742316ca0dda2f9c898d9ac45a481c9e7e07b2ac6125",
+				"DiscoKey":   "discokey:3320c1527557cfe82f792f2f7c754dc3ca4975644be20f458266c02ee8a71b5a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57048",
+					"10.65.0.27:57048",
+					"172.17.0.1:57048",
+					"172.18.0.1:57048",
+					"172.19.0.1:57048"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:53:13.384661116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8060234399958885,
+				"StableID":   "nnH1x1hVw521CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:845ffdfed4eb0b79a76d13732fa1043ffe51dd16062dabe3d7b2c6175addaf73",
+				"DiscoKey":   "discokey:0d95058e6981d401f73613b09e8c702d793036e63ce698ffa06c7d62f4621d01",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53883",
+					"10.65.0.27:53883",
+					"172.17.0.1:53883",
+					"172.18.0.1:53883",
+					"172.19.0.1:53883"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:53:13.92257343Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3979154462050877,
+				"StableID":   "nJ7Zq8eA5Y11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c0482feab48384f62ceb3cf0e0357b0d18b7a988d3cc4c1b7c1df5a9eed8d24a",
+				"DiscoKey":   "discokey:2ed617110eae9697b77d92d9dcb757f9f7cf5a601c1599ed33fcd5753fac225c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54851",
+					"10.65.0.27:54851",
+					"172.17.0.1:54851",
+					"172.18.0.1:54851",
+					"172.19.0.1:54851"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:53:14.461921611Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6190654681495652,
+				"StableID":   "nVRZJ41mLq11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f2dde100287742dcfef89325a0dc820135505785c58f76eda06ee999a05a220f",
+				"DiscoKey":   "discokey:d810dcd5a6694432827bc65720ebeec4b958cfd6ab7a9f64a9f6be08953e8679",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58510",
+					"10.65.0.27:58510",
+					"172.17.0.1:58510",
+					"172.18.0.1:58510",
+					"172.19.0.1:58510"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:53:15.031556524Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         767453331655996,
+				"StableID":   "num5uThaz611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:451d69c8db54f124e091ab84d6b7e9cbc4b4e926e6e7514a7e73360ddd88cb7a",
+				"DiscoKey":   "discokey:d086f5f0dec8616426bd956162e84008795497dc378cc0b6d5935f6c7cbe8740",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:50877",
+					"10.65.0.27:50877",
+					"172.17.0.1:50877",
+					"172.18.0.1:50877",
+					"172.19.0.1:50877"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:53:15.535860367Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7241594842877954,
+				"StableID":   "nmz8bBRjYy11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1efbf5403be0ec53d9d2f8df3743c52cae169224ca2c42cf582023299d6042b",
+				"DiscoKey":   "discokey:ae2ea0ae798fa4955041d288f309ce01c35adbccbef557d98760d98f6720b97a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40710",
+					"10.65.0.27:40710",
+					"172.17.0.1:40710",
+					"172.18.0.1:40710",
+					"172.19.0.1:40710"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:53:16.08232304Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8572727664789590,
+				"StableID":   "nyE2p62cw921CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15c267a3b83de191d712d4e7bb374f53a4a6991d0ed8c928d147486f7ff8f353",
+				"DiscoKey":   "discokey:8fe51e8ae52634e6d49f8224e8f95876de264d055406cd5c97136868ee00cd59",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50223",
+					"10.65.0.27:50223",
+					"172.17.0.1:50223",
+					"172.18.0.1:50223",
+					"172.19.0.1:50223"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:53:16.630510647Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7974220851558896,
+				"StableID":   "nszWD5GYG521CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e4ae00825cf9b00635352d541d46b4d03244f862d26e08b0cbae83ac33d2064",
+				"DiscoKey":   "discokey:0fe95cb2bb9e00f63e6e01817e7839f41c77e82486721fef0a2aaaff485d3101",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46471",
+					"10.65.0.27:46471",
+					"172.17.0.1:46471",
+					"172.18.0.1:46471",
+					"172.19.0.1:46471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:53:17.171796369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8669461418029847,
+				"StableID":   "nYDTLw3RhA21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:00e5961df8ba4198e09cbd8fd9b7c83dfbe644fd17117646434be1aa074a8161",
+				"KeyExpiry":  "2026-11-08T21:53:17Z",
+				"DiscoKey":   "discokey:dcb428b3caeb1a52c5b04113b51cff70f3d0f001afcef6d15661261c9fb1202d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:60481",
+					"10.65.0.27:60481",
+					"172.17.0.1:60481",
+					"172.18.0.1:60481",
+					"172.19.0.1:60481"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:53:17.708462216Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2151744728930910,
+				"StableID":   "nwZjPkgXoH11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:193991aaaf06410684c146b6e889dc36865a92a03f4e4b8a49e2b7ef21079f4d",
+				"KeyExpiry":  "2026-11-08T21:53:18Z",
+				"DiscoKey":   "discokey:cd4610dcf7fc0b635bf0bbd361c94a8fbe6aa59dcc593ff86122f4912e5bff14",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46564",
+					"10.65.0.27:46564",
+					"172.17.0.1:46564",
+					"172.18.0.1:46564",
+					"172.19.0.1:46564"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:53:18.288272357Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1408541625136421,
+				"StableID":   "namA611wzB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:6bb0d194d75e39e3a7ee34597d22ec3a2ca59d8ed4427deb913be1dbe2f76064",
+				"KeyExpiry":  "2026-11-08T21:53:18Z",
+				"DiscoKey":   "discokey:85cf58118249b4acebbdc01cd421c639400811cdad67d1695cb450616c837c40",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:37963",
+					"10.65.0.27:37963",
+					"172.17.0.1:37963",
+					"172.18.0.1:37963",
+					"172.19.0.1:37963"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:53:18.798546704Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2162159437425437": {
+				"ID":          2162159437425437,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6190654681495652,
+				"StableID":   "nVRZJ41mLq11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       6190654681495652,
+				"Key":        "nodekey:f2dde100287742dcfef89325a0dc820135505785c58f76eda06ee999a05a220f",
+				"DiscoKey":   "discokey:d810dcd5a6694432827bc65720ebeec4b958cfd6ab7a9f64a9f6be08953e8679",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58510",
+					"10.65.0.27:58510",
+					"172.17.0.1:58510",
+					"172.18.0.1:58510",
+					"172.19.0.1:58510"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:53:15.031556524Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f2dde100287742dcfef89325a0dc820135505785c58f76eda06ee999a05a220f",
+			"MachineKey": "mkey:ee027952f5e6975a84afd07814ea32201d3f6f35d8e6dd7abab2e06296ad2803",
+			"Peers": [{
+				"ID":         884839837843811,
+				"StableID":   "nAxkU3Fku711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d01b1aa3fb1f2459e69d332d4d3ec9b10ea2b4b833b2aea625fa2fbaabf9e1f",
+				"DiscoKey":   "discokey:3e951148bb7fafb746fa64807803ccf37b033ce354563d89a7ec98991648aa52",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33030",
+					"10.65.0.27:33030",
+					"172.17.0.1:33030",
+					"172.18.0.1:33030",
+					"172.19.0.1:33030"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:53:11.234882939Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5121850593450720,
+				"StableID":   "nduQz8Lhzg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d486392a39ffe96af7c8b980a44c3a3ec7ac7034f5f18ed32f05af8b283dc159",
+				"DiscoKey":   "discokey:f91ef00a03bc65b87fc281a2d15f5d7bd183dae5b53e7af90f60bf83acb01c58",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50572",
+					"10.65.0.27:50572",
+					"172.17.0.1:50572",
+					"172.18.0.1:50572",
+					"172.19.0.1:50572"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:53:11.763327396Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2162159437425437,
+				"StableID":   "nkz3XCGFtH11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f72a4e017de1b91028407ad7de4223ceaadf0aeafe5034b50f1456baf0187e33",
+				"DiscoKey":   "discokey:b1fc57c7a0211597fba45c310c155b61c431980b927662e800e3ce27b59f3118",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33602",
+					"10.65.0.27:33602",
+					"172.17.0.1:33602",
+					"172.18.0.1:33602",
+					"172.19.0.1:33602"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:53:12.295257227Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8094170429721881,
+				"StableID":   "nkJ2he8sC621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:142f6ff7f9835024bb7c55a5342f82e6a5571f1425c1e47395b71757d10d2e07",
+				"DiscoKey":   "discokey:f3bc18e05531b29ff92e5f777edb1bc3f2577b679fe34564557f2a4d7226306f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43044",
+					"10.65.0.27:43044",
+					"172.17.0.1:43044",
+					"172.18.0.1:43044",
+					"172.19.0.1:43044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:53:12.83614961Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         400553619704474,
+				"StableID":   "nTb2k8sQ8411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f8ad3094de8b0ab1e4f742316ca0dda2f9c898d9ac45a481c9e7e07b2ac6125",
+				"DiscoKey":   "discokey:3320c1527557cfe82f792f2f7c754dc3ca4975644be20f458266c02ee8a71b5a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57048",
+					"10.65.0.27:57048",
+					"172.17.0.1:57048",
+					"172.18.0.1:57048",
+					"172.19.0.1:57048"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:53:13.384661116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8060234399958885,
+				"StableID":   "nnH1x1hVw521CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:845ffdfed4eb0b79a76d13732fa1043ffe51dd16062dabe3d7b2c6175addaf73",
+				"DiscoKey":   "discokey:0d95058e6981d401f73613b09e8c702d793036e63ce698ffa06c7d62f4621d01",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53883",
+					"10.65.0.27:53883",
+					"172.17.0.1:53883",
+					"172.18.0.1:53883",
+					"172.19.0.1:53883"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:53:13.92257343Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3979154462050877,
+				"StableID":   "nJ7Zq8eA5Y11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c0482feab48384f62ceb3cf0e0357b0d18b7a988d3cc4c1b7c1df5a9eed8d24a",
+				"DiscoKey":   "discokey:2ed617110eae9697b77d92d9dcb757f9f7cf5a601c1599ed33fcd5753fac225c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54851",
+					"10.65.0.27:54851",
+					"172.17.0.1:54851",
+					"172.18.0.1:54851",
+					"172.19.0.1:54851"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:53:14.461921611Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         767453331655996,
+				"StableID":   "num5uThaz611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:451d69c8db54f124e091ab84d6b7e9cbc4b4e926e6e7514a7e73360ddd88cb7a",
+				"DiscoKey":   "discokey:d086f5f0dec8616426bd956162e84008795497dc378cc0b6d5935f6c7cbe8740",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:50877",
+					"10.65.0.27:50877",
+					"172.17.0.1:50877",
+					"172.18.0.1:50877",
+					"172.19.0.1:50877"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:53:15.535860367Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7241594842877954,
+				"StableID":   "nmz8bBRjYy11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1efbf5403be0ec53d9d2f8df3743c52cae169224ca2c42cf582023299d6042b",
+				"DiscoKey":   "discokey:ae2ea0ae798fa4955041d288f309ce01c35adbccbef557d98760d98f6720b97a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40710",
+					"10.65.0.27:40710",
+					"172.17.0.1:40710",
+					"172.18.0.1:40710",
+					"172.19.0.1:40710"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:53:16.08232304Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8572727664789590,
+				"StableID":   "nyE2p62cw921CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15c267a3b83de191d712d4e7bb374f53a4a6991d0ed8c928d147486f7ff8f353",
+				"DiscoKey":   "discokey:8fe51e8ae52634e6d49f8224e8f95876de264d055406cd5c97136868ee00cd59",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50223",
+					"10.65.0.27:50223",
+					"172.17.0.1:50223",
+					"172.18.0.1:50223",
+					"172.19.0.1:50223"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:53:16.630510647Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7974220851558896,
+				"StableID":   "nszWD5GYG521CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e4ae00825cf9b00635352d541d46b4d03244f862d26e08b0cbae83ac33d2064",
+				"DiscoKey":   "discokey:0fe95cb2bb9e00f63e6e01817e7839f41c77e82486721fef0a2aaaff485d3101",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46471",
+					"10.65.0.27:46471",
+					"172.17.0.1:46471",
+					"172.18.0.1:46471",
+					"172.19.0.1:46471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:53:17.171796369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8669461418029847,
+				"StableID":   "nYDTLw3RhA21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:00e5961df8ba4198e09cbd8fd9b7c83dfbe644fd17117646434be1aa074a8161",
+				"KeyExpiry":  "2026-11-08T21:53:17Z",
+				"DiscoKey":   "discokey:dcb428b3caeb1a52c5b04113b51cff70f3d0f001afcef6d15661261c9fb1202d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:60481",
+					"10.65.0.27:60481",
+					"172.17.0.1:60481",
+					"172.18.0.1:60481",
+					"172.19.0.1:60481"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:53:17.708462216Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2151744728930910,
+				"StableID":   "nwZjPkgXoH11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:193991aaaf06410684c146b6e889dc36865a92a03f4e4b8a49e2b7ef21079f4d",
+				"KeyExpiry":  "2026-11-08T21:53:18Z",
+				"DiscoKey":   "discokey:cd4610dcf7fc0b635bf0bbd361c94a8fbe6aa59dcc593ff86122f4912e5bff14",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46564",
+					"10.65.0.27:46564",
+					"172.17.0.1:46564",
+					"172.18.0.1:46564",
+					"172.19.0.1:46564"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:53:18.288272357Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1408541625136421,
+				"StableID":   "namA611wzB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:6bb0d194d75e39e3a7ee34597d22ec3a2ca59d8ed4427deb913be1dbe2f76064",
+				"KeyExpiry":  "2026-11-08T21:53:18Z",
+				"DiscoKey":   "discokey:85cf58118249b4acebbdc01cd421c639400811cdad67d1695cb450616c837c40",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:37963",
+					"10.65.0.27:37963",
+					"172.17.0.1:37963",
+					"172.18.0.1:37963",
+					"172.19.0.1:37963"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:53:18.798546704Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6190654681495652": {
+				"ID":          6190654681495652,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8669461418029847,
+				"StableID":   "nYDTLw3RhA21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:00e5961df8ba4198e09cbd8fd9b7c83dfbe644fd17117646434be1aa074a8161",
+				"KeyExpiry":  "2026-11-08T21:53:17Z",
+				"DiscoKey":   "discokey:dcb428b3caeb1a52c5b04113b51cff70f3d0f001afcef6d15661261c9fb1202d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:60481",
+					"10.65.0.27:60481",
+					"172.17.0.1:60481",
+					"172.18.0.1:60481",
+					"172.19.0.1:60481"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:53:17.708462216Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:00e5961df8ba4198e09cbd8fd9b7c83dfbe644fd17117646434be1aa074a8161",
+			"MachineKey": "mkey:3c4a722e27e98d94b004ba8ea5587180b140e6bc9cfa51a0e02959749bdb4c66",
+			"Peers": [{
+				"ID":         884839837843811,
+				"StableID":   "nAxkU3Fku711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d01b1aa3fb1f2459e69d332d4d3ec9b10ea2b4b833b2aea625fa2fbaabf9e1f",
+				"DiscoKey":   "discokey:3e951148bb7fafb746fa64807803ccf37b033ce354563d89a7ec98991648aa52",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33030",
+					"10.65.0.27:33030",
+					"172.17.0.1:33030",
+					"172.18.0.1:33030",
+					"172.19.0.1:33030"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:53:11.234882939Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5121850593450720,
+				"StableID":   "nduQz8Lhzg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d486392a39ffe96af7c8b980a44c3a3ec7ac7034f5f18ed32f05af8b283dc159",
+				"DiscoKey":   "discokey:f91ef00a03bc65b87fc281a2d15f5d7bd183dae5b53e7af90f60bf83acb01c58",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50572",
+					"10.65.0.27:50572",
+					"172.17.0.1:50572",
+					"172.18.0.1:50572",
+					"172.19.0.1:50572"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:53:11.763327396Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2162159437425437,
+				"StableID":   "nkz3XCGFtH11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f72a4e017de1b91028407ad7de4223ceaadf0aeafe5034b50f1456baf0187e33",
+				"DiscoKey":   "discokey:b1fc57c7a0211597fba45c310c155b61c431980b927662e800e3ce27b59f3118",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33602",
+					"10.65.0.27:33602",
+					"172.17.0.1:33602",
+					"172.18.0.1:33602",
+					"172.19.0.1:33602"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:53:12.295257227Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8094170429721881,
+				"StableID":   "nkJ2he8sC621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:142f6ff7f9835024bb7c55a5342f82e6a5571f1425c1e47395b71757d10d2e07",
+				"DiscoKey":   "discokey:f3bc18e05531b29ff92e5f777edb1bc3f2577b679fe34564557f2a4d7226306f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43044",
+					"10.65.0.27:43044",
+					"172.17.0.1:43044",
+					"172.18.0.1:43044",
+					"172.19.0.1:43044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:53:12.83614961Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         400553619704474,
+				"StableID":   "nTb2k8sQ8411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f8ad3094de8b0ab1e4f742316ca0dda2f9c898d9ac45a481c9e7e07b2ac6125",
+				"DiscoKey":   "discokey:3320c1527557cfe82f792f2f7c754dc3ca4975644be20f458266c02ee8a71b5a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57048",
+					"10.65.0.27:57048",
+					"172.17.0.1:57048",
+					"172.18.0.1:57048",
+					"172.19.0.1:57048"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:53:13.384661116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8060234399958885,
+				"StableID":   "nnH1x1hVw521CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:845ffdfed4eb0b79a76d13732fa1043ffe51dd16062dabe3d7b2c6175addaf73",
+				"DiscoKey":   "discokey:0d95058e6981d401f73613b09e8c702d793036e63ce698ffa06c7d62f4621d01",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53883",
+					"10.65.0.27:53883",
+					"172.17.0.1:53883",
+					"172.18.0.1:53883",
+					"172.19.0.1:53883"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:53:13.92257343Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3979154462050877,
+				"StableID":   "nJ7Zq8eA5Y11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c0482feab48384f62ceb3cf0e0357b0d18b7a988d3cc4c1b7c1df5a9eed8d24a",
+				"DiscoKey":   "discokey:2ed617110eae9697b77d92d9dcb757f9f7cf5a601c1599ed33fcd5753fac225c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54851",
+					"10.65.0.27:54851",
+					"172.17.0.1:54851",
+					"172.18.0.1:54851",
+					"172.19.0.1:54851"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:53:14.461921611Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6190654681495652,
+				"StableID":   "nVRZJ41mLq11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f2dde100287742dcfef89325a0dc820135505785c58f76eda06ee999a05a220f",
+				"DiscoKey":   "discokey:d810dcd5a6694432827bc65720ebeec4b958cfd6ab7a9f64a9f6be08953e8679",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58510",
+					"10.65.0.27:58510",
+					"172.17.0.1:58510",
+					"172.18.0.1:58510",
+					"172.19.0.1:58510"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:53:15.031556524Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         767453331655996,
+				"StableID":   "num5uThaz611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:451d69c8db54f124e091ab84d6b7e9cbc4b4e926e6e7514a7e73360ddd88cb7a",
+				"DiscoKey":   "discokey:d086f5f0dec8616426bd956162e84008795497dc378cc0b6d5935f6c7cbe8740",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:50877",
+					"10.65.0.27:50877",
+					"172.17.0.1:50877",
+					"172.18.0.1:50877",
+					"172.19.0.1:50877"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:53:15.535860367Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7241594842877954,
+				"StableID":   "nmz8bBRjYy11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1efbf5403be0ec53d9d2f8df3743c52cae169224ca2c42cf582023299d6042b",
+				"DiscoKey":   "discokey:ae2ea0ae798fa4955041d288f309ce01c35adbccbef557d98760d98f6720b97a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40710",
+					"10.65.0.27:40710",
+					"172.17.0.1:40710",
+					"172.18.0.1:40710",
+					"172.19.0.1:40710"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:53:16.08232304Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8572727664789590,
+				"StableID":   "nyE2p62cw921CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15c267a3b83de191d712d4e7bb374f53a4a6991d0ed8c928d147486f7ff8f353",
+				"DiscoKey":   "discokey:8fe51e8ae52634e6d49f8224e8f95876de264d055406cd5c97136868ee00cd59",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50223",
+					"10.65.0.27:50223",
+					"172.17.0.1:50223",
+					"172.18.0.1:50223",
+					"172.19.0.1:50223"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:53:16.630510647Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7974220851558896,
+				"StableID":   "nszWD5GYG521CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e4ae00825cf9b00635352d541d46b4d03244f862d26e08b0cbae83ac33d2064",
+				"DiscoKey":   "discokey:0fe95cb2bb9e00f63e6e01817e7839f41c77e82486721fef0a2aaaff485d3101",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46471",
+					"10.65.0.27:46471",
+					"172.17.0.1:46471",
+					"172.18.0.1:46471",
+					"172.19.0.1:46471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:53:17.171796369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2151744728930910,
+				"StableID":   "nwZjPkgXoH11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:193991aaaf06410684c146b6e889dc36865a92a03f4e4b8a49e2b7ef21079f4d",
+				"KeyExpiry":  "2026-11-08T21:53:18Z",
+				"DiscoKey":   "discokey:cd4610dcf7fc0b635bf0bbd361c94a8fbe6aa59dcc593ff86122f4912e5bff14",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46564",
+					"10.65.0.27:46564",
+					"172.17.0.1:46564",
+					"172.18.0.1:46564",
+					"172.19.0.1:46564"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:53:18.288272357Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1408541625136421,
+				"StableID":   "namA611wzB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:6bb0d194d75e39e3a7ee34597d22ec3a2ca59d8ed4427deb913be1dbe2f76064",
+				"KeyExpiry":  "2026-11-08T21:53:18Z",
+				"DiscoKey":   "discokey:85cf58118249b4acebbdc01cd421c639400811cdad67d1695cb450616c837c40",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:37963",
+					"10.65.0.27:37963",
+					"172.17.0.1:37963",
+					"172.18.0.1:37963",
+					"172.19.0.1:37963"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:53:18.798546704Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8572727664789590,
+				"StableID":   "nyE2p62cw921CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       8572727664789590,
+				"Key":        "nodekey:15c267a3b83de191d712d4e7bb374f53a4a6991d0ed8c928d147486f7ff8f353",
+				"DiscoKey":   "discokey:8fe51e8ae52634e6d49f8224e8f95876de264d055406cd5c97136868ee00cd59",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50223",
+					"10.65.0.27:50223",
+					"172.17.0.1:50223",
+					"172.18.0.1:50223",
+					"172.19.0.1:50223"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:53:16.630510647Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:15c267a3b83de191d712d4e7bb374f53a4a6991d0ed8c928d147486f7ff8f353",
+			"MachineKey": "mkey:f5742208b7e009e307a309a859125eab43968355145913fc9844f3726d6e504e",
+			"Peers": [{
+				"ID":         884839837843811,
+				"StableID":   "nAxkU3Fku711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d01b1aa3fb1f2459e69d332d4d3ec9b10ea2b4b833b2aea625fa2fbaabf9e1f",
+				"DiscoKey":   "discokey:3e951148bb7fafb746fa64807803ccf37b033ce354563d89a7ec98991648aa52",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33030",
+					"10.65.0.27:33030",
+					"172.17.0.1:33030",
+					"172.18.0.1:33030",
+					"172.19.0.1:33030"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:53:11.234882939Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5121850593450720,
+				"StableID":   "nduQz8Lhzg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d486392a39ffe96af7c8b980a44c3a3ec7ac7034f5f18ed32f05af8b283dc159",
+				"DiscoKey":   "discokey:f91ef00a03bc65b87fc281a2d15f5d7bd183dae5b53e7af90f60bf83acb01c58",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50572",
+					"10.65.0.27:50572",
+					"172.17.0.1:50572",
+					"172.18.0.1:50572",
+					"172.19.0.1:50572"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:53:11.763327396Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2162159437425437,
+				"StableID":   "nkz3XCGFtH11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f72a4e017de1b91028407ad7de4223ceaadf0aeafe5034b50f1456baf0187e33",
+				"DiscoKey":   "discokey:b1fc57c7a0211597fba45c310c155b61c431980b927662e800e3ce27b59f3118",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33602",
+					"10.65.0.27:33602",
+					"172.17.0.1:33602",
+					"172.18.0.1:33602",
+					"172.19.0.1:33602"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:53:12.295257227Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8094170429721881,
+				"StableID":   "nkJ2he8sC621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:142f6ff7f9835024bb7c55a5342f82e6a5571f1425c1e47395b71757d10d2e07",
+				"DiscoKey":   "discokey:f3bc18e05531b29ff92e5f777edb1bc3f2577b679fe34564557f2a4d7226306f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43044",
+					"10.65.0.27:43044",
+					"172.17.0.1:43044",
+					"172.18.0.1:43044",
+					"172.19.0.1:43044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:53:12.83614961Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         400553619704474,
+				"StableID":   "nTb2k8sQ8411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f8ad3094de8b0ab1e4f742316ca0dda2f9c898d9ac45a481c9e7e07b2ac6125",
+				"DiscoKey":   "discokey:3320c1527557cfe82f792f2f7c754dc3ca4975644be20f458266c02ee8a71b5a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57048",
+					"10.65.0.27:57048",
+					"172.17.0.1:57048",
+					"172.18.0.1:57048",
+					"172.19.0.1:57048"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:53:13.384661116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8060234399958885,
+				"StableID":   "nnH1x1hVw521CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:845ffdfed4eb0b79a76d13732fa1043ffe51dd16062dabe3d7b2c6175addaf73",
+				"DiscoKey":   "discokey:0d95058e6981d401f73613b09e8c702d793036e63ce698ffa06c7d62f4621d01",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53883",
+					"10.65.0.27:53883",
+					"172.17.0.1:53883",
+					"172.18.0.1:53883",
+					"172.19.0.1:53883"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:53:13.92257343Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3979154462050877,
+				"StableID":   "nJ7Zq8eA5Y11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c0482feab48384f62ceb3cf0e0357b0d18b7a988d3cc4c1b7c1df5a9eed8d24a",
+				"DiscoKey":   "discokey:2ed617110eae9697b77d92d9dcb757f9f7cf5a601c1599ed33fcd5753fac225c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54851",
+					"10.65.0.27:54851",
+					"172.17.0.1:54851",
+					"172.18.0.1:54851",
+					"172.19.0.1:54851"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:53:14.461921611Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6190654681495652,
+				"StableID":   "nVRZJ41mLq11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f2dde100287742dcfef89325a0dc820135505785c58f76eda06ee999a05a220f",
+				"DiscoKey":   "discokey:d810dcd5a6694432827bc65720ebeec4b958cfd6ab7a9f64a9f6be08953e8679",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58510",
+					"10.65.0.27:58510",
+					"172.17.0.1:58510",
+					"172.18.0.1:58510",
+					"172.19.0.1:58510"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:53:15.031556524Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         767453331655996,
+				"StableID":   "num5uThaz611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:451d69c8db54f124e091ab84d6b7e9cbc4b4e926e6e7514a7e73360ddd88cb7a",
+				"DiscoKey":   "discokey:d086f5f0dec8616426bd956162e84008795497dc378cc0b6d5935f6c7cbe8740",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:50877",
+					"10.65.0.27:50877",
+					"172.17.0.1:50877",
+					"172.18.0.1:50877",
+					"172.19.0.1:50877"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:53:15.535860367Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7241594842877954,
+				"StableID":   "nmz8bBRjYy11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1efbf5403be0ec53d9d2f8df3743c52cae169224ca2c42cf582023299d6042b",
+				"DiscoKey":   "discokey:ae2ea0ae798fa4955041d288f309ce01c35adbccbef557d98760d98f6720b97a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40710",
+					"10.65.0.27:40710",
+					"172.17.0.1:40710",
+					"172.18.0.1:40710",
+					"172.19.0.1:40710"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:53:16.08232304Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7974220851558896,
+				"StableID":   "nszWD5GYG521CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e4ae00825cf9b00635352d541d46b4d03244f862d26e08b0cbae83ac33d2064",
+				"DiscoKey":   "discokey:0fe95cb2bb9e00f63e6e01817e7839f41c77e82486721fef0a2aaaff485d3101",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46471",
+					"10.65.0.27:46471",
+					"172.17.0.1:46471",
+					"172.18.0.1:46471",
+					"172.19.0.1:46471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:53:17.171796369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8669461418029847,
+				"StableID":   "nYDTLw3RhA21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:00e5961df8ba4198e09cbd8fd9b7c83dfbe644fd17117646434be1aa074a8161",
+				"KeyExpiry":  "2026-11-08T21:53:17Z",
+				"DiscoKey":   "discokey:dcb428b3caeb1a52c5b04113b51cff70f3d0f001afcef6d15661261c9fb1202d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:60481",
+					"10.65.0.27:60481",
+					"172.17.0.1:60481",
+					"172.18.0.1:60481",
+					"172.19.0.1:60481"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:53:17.708462216Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2151744728930910,
+				"StableID":   "nwZjPkgXoH11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:193991aaaf06410684c146b6e889dc36865a92a03f4e4b8a49e2b7ef21079f4d",
+				"KeyExpiry":  "2026-11-08T21:53:18Z",
+				"DiscoKey":   "discokey:cd4610dcf7fc0b635bf0bbd361c94a8fbe6aa59dcc593ff86122f4912e5bff14",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46564",
+					"10.65.0.27:46564",
+					"172.17.0.1:46564",
+					"172.18.0.1:46564",
+					"172.19.0.1:46564"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:53:18.288272357Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1408541625136421,
+				"StableID":   "namA611wzB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:6bb0d194d75e39e3a7ee34597d22ec3a2ca59d8ed4427deb913be1dbe2f76064",
+				"KeyExpiry":  "2026-11-08T21:53:18Z",
+				"DiscoKey":   "discokey:85cf58118249b4acebbdc01cd421c639400811cdad67d1695cb450616c837c40",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:37963",
+					"10.65.0.27:37963",
+					"172.17.0.1:37963",
+					"172.18.0.1:37963",
+					"172.19.0.1:37963"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:53:18.798546704Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8572727664789590": {
+				"ID":          8572727664789590,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5121850593450720,
+				"StableID":   "nduQz8Lhzg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       5121850593450720,
+				"Key":        "nodekey:d486392a39ffe96af7c8b980a44c3a3ec7ac7034f5f18ed32f05af8b283dc159",
+				"DiscoKey":   "discokey:f91ef00a03bc65b87fc281a2d15f5d7bd183dae5b53e7af90f60bf83acb01c58",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50572",
+					"10.65.0.27:50572",
+					"172.17.0.1:50572",
+					"172.18.0.1:50572",
+					"172.19.0.1:50572"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:53:11.763327396Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d486392a39ffe96af7c8b980a44c3a3ec7ac7034f5f18ed32f05af8b283dc159",
+			"MachineKey": "mkey:cfff9bcb71fa9ab32cea258721c1f4387b176083b0af2406b0bca3cda21d5e54",
+			"Peers": [{
+				"ID":         884839837843811,
+				"StableID":   "nAxkU3Fku711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d01b1aa3fb1f2459e69d332d4d3ec9b10ea2b4b833b2aea625fa2fbaabf9e1f",
+				"DiscoKey":   "discokey:3e951148bb7fafb746fa64807803ccf37b033ce354563d89a7ec98991648aa52",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33030",
+					"10.65.0.27:33030",
+					"172.17.0.1:33030",
+					"172.18.0.1:33030",
+					"172.19.0.1:33030"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:53:11.234882939Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2162159437425437,
+				"StableID":   "nkz3XCGFtH11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f72a4e017de1b91028407ad7de4223ceaadf0aeafe5034b50f1456baf0187e33",
+				"DiscoKey":   "discokey:b1fc57c7a0211597fba45c310c155b61c431980b927662e800e3ce27b59f3118",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33602",
+					"10.65.0.27:33602",
+					"172.17.0.1:33602",
+					"172.18.0.1:33602",
+					"172.19.0.1:33602"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:53:12.295257227Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8094170429721881,
+				"StableID":   "nkJ2he8sC621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:142f6ff7f9835024bb7c55a5342f82e6a5571f1425c1e47395b71757d10d2e07",
+				"DiscoKey":   "discokey:f3bc18e05531b29ff92e5f777edb1bc3f2577b679fe34564557f2a4d7226306f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43044",
+					"10.65.0.27:43044",
+					"172.17.0.1:43044",
+					"172.18.0.1:43044",
+					"172.19.0.1:43044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:53:12.83614961Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         400553619704474,
+				"StableID":   "nTb2k8sQ8411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f8ad3094de8b0ab1e4f742316ca0dda2f9c898d9ac45a481c9e7e07b2ac6125",
+				"DiscoKey":   "discokey:3320c1527557cfe82f792f2f7c754dc3ca4975644be20f458266c02ee8a71b5a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57048",
+					"10.65.0.27:57048",
+					"172.17.0.1:57048",
+					"172.18.0.1:57048",
+					"172.19.0.1:57048"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:53:13.384661116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8060234399958885,
+				"StableID":   "nnH1x1hVw521CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:845ffdfed4eb0b79a76d13732fa1043ffe51dd16062dabe3d7b2c6175addaf73",
+				"DiscoKey":   "discokey:0d95058e6981d401f73613b09e8c702d793036e63ce698ffa06c7d62f4621d01",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53883",
+					"10.65.0.27:53883",
+					"172.17.0.1:53883",
+					"172.18.0.1:53883",
+					"172.19.0.1:53883"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:53:13.92257343Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3979154462050877,
+				"StableID":   "nJ7Zq8eA5Y11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c0482feab48384f62ceb3cf0e0357b0d18b7a988d3cc4c1b7c1df5a9eed8d24a",
+				"DiscoKey":   "discokey:2ed617110eae9697b77d92d9dcb757f9f7cf5a601c1599ed33fcd5753fac225c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54851",
+					"10.65.0.27:54851",
+					"172.17.0.1:54851",
+					"172.18.0.1:54851",
+					"172.19.0.1:54851"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:53:14.461921611Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6190654681495652,
+				"StableID":   "nVRZJ41mLq11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f2dde100287742dcfef89325a0dc820135505785c58f76eda06ee999a05a220f",
+				"DiscoKey":   "discokey:d810dcd5a6694432827bc65720ebeec4b958cfd6ab7a9f64a9f6be08953e8679",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58510",
+					"10.65.0.27:58510",
+					"172.17.0.1:58510",
+					"172.18.0.1:58510",
+					"172.19.0.1:58510"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:53:15.031556524Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         767453331655996,
+				"StableID":   "num5uThaz611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:451d69c8db54f124e091ab84d6b7e9cbc4b4e926e6e7514a7e73360ddd88cb7a",
+				"DiscoKey":   "discokey:d086f5f0dec8616426bd956162e84008795497dc378cc0b6d5935f6c7cbe8740",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:50877",
+					"10.65.0.27:50877",
+					"172.17.0.1:50877",
+					"172.18.0.1:50877",
+					"172.19.0.1:50877"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:53:15.535860367Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7241594842877954,
+				"StableID":   "nmz8bBRjYy11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1efbf5403be0ec53d9d2f8df3743c52cae169224ca2c42cf582023299d6042b",
+				"DiscoKey":   "discokey:ae2ea0ae798fa4955041d288f309ce01c35adbccbef557d98760d98f6720b97a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40710",
+					"10.65.0.27:40710",
+					"172.17.0.1:40710",
+					"172.18.0.1:40710",
+					"172.19.0.1:40710"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:53:16.08232304Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8572727664789590,
+				"StableID":   "nyE2p62cw921CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15c267a3b83de191d712d4e7bb374f53a4a6991d0ed8c928d147486f7ff8f353",
+				"DiscoKey":   "discokey:8fe51e8ae52634e6d49f8224e8f95876de264d055406cd5c97136868ee00cd59",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50223",
+					"10.65.0.27:50223",
+					"172.17.0.1:50223",
+					"172.18.0.1:50223",
+					"172.19.0.1:50223"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:53:16.630510647Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7974220851558896,
+				"StableID":   "nszWD5GYG521CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e4ae00825cf9b00635352d541d46b4d03244f862d26e08b0cbae83ac33d2064",
+				"DiscoKey":   "discokey:0fe95cb2bb9e00f63e6e01817e7839f41c77e82486721fef0a2aaaff485d3101",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46471",
+					"10.65.0.27:46471",
+					"172.17.0.1:46471",
+					"172.18.0.1:46471",
+					"172.19.0.1:46471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:53:17.171796369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8669461418029847,
+				"StableID":   "nYDTLw3RhA21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:00e5961df8ba4198e09cbd8fd9b7c83dfbe644fd17117646434be1aa074a8161",
+				"KeyExpiry":  "2026-11-08T21:53:17Z",
+				"DiscoKey":   "discokey:dcb428b3caeb1a52c5b04113b51cff70f3d0f001afcef6d15661261c9fb1202d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:60481",
+					"10.65.0.27:60481",
+					"172.17.0.1:60481",
+					"172.18.0.1:60481",
+					"172.19.0.1:60481"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:53:17.708462216Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2151744728930910,
+				"StableID":   "nwZjPkgXoH11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:193991aaaf06410684c146b6e889dc36865a92a03f4e4b8a49e2b7ef21079f4d",
+				"KeyExpiry":  "2026-11-08T21:53:18Z",
+				"DiscoKey":   "discokey:cd4610dcf7fc0b635bf0bbd361c94a8fbe6aa59dcc593ff86122f4912e5bff14",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46564",
+					"10.65.0.27:46564",
+					"172.17.0.1:46564",
+					"172.18.0.1:46564",
+					"172.19.0.1:46564"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:53:18.288272357Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1408541625136421,
+				"StableID":   "namA611wzB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:6bb0d194d75e39e3a7ee34597d22ec3a2ca59d8ed4427deb913be1dbe2f76064",
+				"KeyExpiry":  "2026-11-08T21:53:18Z",
+				"DiscoKey":   "discokey:85cf58118249b4acebbdc01cd421c639400811cdad67d1695cb450616c837c40",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:37963",
+					"10.65.0.27:37963",
+					"172.17.0.1:37963",
+					"172.18.0.1:37963",
+					"172.19.0.1:37963"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:53:18.798546704Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5121850593450720": {
+				"ID":          5121850593450720,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         884839837843811,
+				"StableID":   "nAxkU3Fku711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       884839837843811,
+				"Key":        "nodekey:5d01b1aa3fb1f2459e69d332d4d3ec9b10ea2b4b833b2aea625fa2fbaabf9e1f",
+				"DiscoKey":   "discokey:3e951148bb7fafb746fa64807803ccf37b033ce354563d89a7ec98991648aa52",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33030",
+					"10.65.0.27:33030",
+					"172.17.0.1:33030",
+					"172.18.0.1:33030",
+					"172.19.0.1:33030"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:53:11.234882939Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5d01b1aa3fb1f2459e69d332d4d3ec9b10ea2b4b833b2aea625fa2fbaabf9e1f",
+			"MachineKey": "mkey:c6d60163fa8eb5203077b672164cba5e017fb2d94a17fbcb2841d26c1bc46028",
+			"Peers": [{
+				"ID":         5121850593450720,
+				"StableID":   "nduQz8Lhzg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d486392a39ffe96af7c8b980a44c3a3ec7ac7034f5f18ed32f05af8b283dc159",
+				"DiscoKey":   "discokey:f91ef00a03bc65b87fc281a2d15f5d7bd183dae5b53e7af90f60bf83acb01c58",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50572",
+					"10.65.0.27:50572",
+					"172.17.0.1:50572",
+					"172.18.0.1:50572",
+					"172.19.0.1:50572"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:53:11.763327396Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2162159437425437,
+				"StableID":   "nkz3XCGFtH11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f72a4e017de1b91028407ad7de4223ceaadf0aeafe5034b50f1456baf0187e33",
+				"DiscoKey":   "discokey:b1fc57c7a0211597fba45c310c155b61c431980b927662e800e3ce27b59f3118",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33602",
+					"10.65.0.27:33602",
+					"172.17.0.1:33602",
+					"172.18.0.1:33602",
+					"172.19.0.1:33602"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:53:12.295257227Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8094170429721881,
+				"StableID":   "nkJ2he8sC621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:142f6ff7f9835024bb7c55a5342f82e6a5571f1425c1e47395b71757d10d2e07",
+				"DiscoKey":   "discokey:f3bc18e05531b29ff92e5f777edb1bc3f2577b679fe34564557f2a4d7226306f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43044",
+					"10.65.0.27:43044",
+					"172.17.0.1:43044",
+					"172.18.0.1:43044",
+					"172.19.0.1:43044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:53:12.83614961Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         400553619704474,
+				"StableID":   "nTb2k8sQ8411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f8ad3094de8b0ab1e4f742316ca0dda2f9c898d9ac45a481c9e7e07b2ac6125",
+				"DiscoKey":   "discokey:3320c1527557cfe82f792f2f7c754dc3ca4975644be20f458266c02ee8a71b5a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57048",
+					"10.65.0.27:57048",
+					"172.17.0.1:57048",
+					"172.18.0.1:57048",
+					"172.19.0.1:57048"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:53:13.384661116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8060234399958885,
+				"StableID":   "nnH1x1hVw521CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:845ffdfed4eb0b79a76d13732fa1043ffe51dd16062dabe3d7b2c6175addaf73",
+				"DiscoKey":   "discokey:0d95058e6981d401f73613b09e8c702d793036e63ce698ffa06c7d62f4621d01",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53883",
+					"10.65.0.27:53883",
+					"172.17.0.1:53883",
+					"172.18.0.1:53883",
+					"172.19.0.1:53883"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:53:13.92257343Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3979154462050877,
+				"StableID":   "nJ7Zq8eA5Y11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c0482feab48384f62ceb3cf0e0357b0d18b7a988d3cc4c1b7c1df5a9eed8d24a",
+				"DiscoKey":   "discokey:2ed617110eae9697b77d92d9dcb757f9f7cf5a601c1599ed33fcd5753fac225c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54851",
+					"10.65.0.27:54851",
+					"172.17.0.1:54851",
+					"172.18.0.1:54851",
+					"172.19.0.1:54851"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:53:14.461921611Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6190654681495652,
+				"StableID":   "nVRZJ41mLq11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f2dde100287742dcfef89325a0dc820135505785c58f76eda06ee999a05a220f",
+				"DiscoKey":   "discokey:d810dcd5a6694432827bc65720ebeec4b958cfd6ab7a9f64a9f6be08953e8679",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58510",
+					"10.65.0.27:58510",
+					"172.17.0.1:58510",
+					"172.18.0.1:58510",
+					"172.19.0.1:58510"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:53:15.031556524Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         767453331655996,
+				"StableID":   "num5uThaz611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:451d69c8db54f124e091ab84d6b7e9cbc4b4e926e6e7514a7e73360ddd88cb7a",
+				"DiscoKey":   "discokey:d086f5f0dec8616426bd956162e84008795497dc378cc0b6d5935f6c7cbe8740",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:50877",
+					"10.65.0.27:50877",
+					"172.17.0.1:50877",
+					"172.18.0.1:50877",
+					"172.19.0.1:50877"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:53:15.535860367Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7241594842877954,
+				"StableID":   "nmz8bBRjYy11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1efbf5403be0ec53d9d2f8df3743c52cae169224ca2c42cf582023299d6042b",
+				"DiscoKey":   "discokey:ae2ea0ae798fa4955041d288f309ce01c35adbccbef557d98760d98f6720b97a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40710",
+					"10.65.0.27:40710",
+					"172.17.0.1:40710",
+					"172.18.0.1:40710",
+					"172.19.0.1:40710"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:53:16.08232304Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8572727664789590,
+				"StableID":   "nyE2p62cw921CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15c267a3b83de191d712d4e7bb374f53a4a6991d0ed8c928d147486f7ff8f353",
+				"DiscoKey":   "discokey:8fe51e8ae52634e6d49f8224e8f95876de264d055406cd5c97136868ee00cd59",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50223",
+					"10.65.0.27:50223",
+					"172.17.0.1:50223",
+					"172.18.0.1:50223",
+					"172.19.0.1:50223"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:53:16.630510647Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7974220851558896,
+				"StableID":   "nszWD5GYG521CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e4ae00825cf9b00635352d541d46b4d03244f862d26e08b0cbae83ac33d2064",
+				"DiscoKey":   "discokey:0fe95cb2bb9e00f63e6e01817e7839f41c77e82486721fef0a2aaaff485d3101",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46471",
+					"10.65.0.27:46471",
+					"172.17.0.1:46471",
+					"172.18.0.1:46471",
+					"172.19.0.1:46471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:53:17.171796369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8669461418029847,
+				"StableID":   "nYDTLw3RhA21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:00e5961df8ba4198e09cbd8fd9b7c83dfbe644fd17117646434be1aa074a8161",
+				"KeyExpiry":  "2026-11-08T21:53:17Z",
+				"DiscoKey":   "discokey:dcb428b3caeb1a52c5b04113b51cff70f3d0f001afcef6d15661261c9fb1202d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:60481",
+					"10.65.0.27:60481",
+					"172.17.0.1:60481",
+					"172.18.0.1:60481",
+					"172.19.0.1:60481"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:53:17.708462216Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2151744728930910,
+				"StableID":   "nwZjPkgXoH11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:193991aaaf06410684c146b6e889dc36865a92a03f4e4b8a49e2b7ef21079f4d",
+				"KeyExpiry":  "2026-11-08T21:53:18Z",
+				"DiscoKey":   "discokey:cd4610dcf7fc0b635bf0bbd361c94a8fbe6aa59dcc593ff86122f4912e5bff14",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46564",
+					"10.65.0.27:46564",
+					"172.17.0.1:46564",
+					"172.18.0.1:46564",
+					"172.19.0.1:46564"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:53:18.288272357Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1408541625136421,
+				"StableID":   "namA611wzB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:6bb0d194d75e39e3a7ee34597d22ec3a2ca59d8ed4427deb913be1dbe2f76064",
+				"KeyExpiry":  "2026-11-08T21:53:18Z",
+				"DiscoKey":   "discokey:85cf58118249b4acebbdc01cd421c639400811cdad67d1695cb450616c837c40",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:37963",
+					"10.65.0.27:37963",
+					"172.17.0.1:37963",
+					"172.18.0.1:37963",
+					"172.19.0.1:37963"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:53:18.798546704Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "884839837843811": {
+				"ID":          884839837843811,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         400553619704474,
+				"StableID":   "nTb2k8sQ8411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       400553619704474,
+				"Key":        "nodekey:7f8ad3094de8b0ab1e4f742316ca0dda2f9c898d9ac45a481c9e7e07b2ac6125",
+				"DiscoKey":   "discokey:3320c1527557cfe82f792f2f7c754dc3ca4975644be20f458266c02ee8a71b5a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57048",
+					"10.65.0.27:57048",
+					"172.17.0.1:57048",
+					"172.18.0.1:57048",
+					"172.19.0.1:57048"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:53:13.384661116Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7f8ad3094de8b0ab1e4f742316ca0dda2f9c898d9ac45a481c9e7e07b2ac6125",
+			"MachineKey": "mkey:cff73c6815ca12a91c3e75a7c66ef2fa7508f2f328c9b798c8a725c1953e403d",
+			"Peers": [{
+				"ID":         884839837843811,
+				"StableID":   "nAxkU3Fku711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d01b1aa3fb1f2459e69d332d4d3ec9b10ea2b4b833b2aea625fa2fbaabf9e1f",
+				"DiscoKey":   "discokey:3e951148bb7fafb746fa64807803ccf37b033ce354563d89a7ec98991648aa52",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33030",
+					"10.65.0.27:33030",
+					"172.17.0.1:33030",
+					"172.18.0.1:33030",
+					"172.19.0.1:33030"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:53:11.234882939Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5121850593450720,
+				"StableID":   "nduQz8Lhzg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d486392a39ffe96af7c8b980a44c3a3ec7ac7034f5f18ed32f05af8b283dc159",
+				"DiscoKey":   "discokey:f91ef00a03bc65b87fc281a2d15f5d7bd183dae5b53e7af90f60bf83acb01c58",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50572",
+					"10.65.0.27:50572",
+					"172.17.0.1:50572",
+					"172.18.0.1:50572",
+					"172.19.0.1:50572"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:53:11.763327396Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2162159437425437,
+				"StableID":   "nkz3XCGFtH11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f72a4e017de1b91028407ad7de4223ceaadf0aeafe5034b50f1456baf0187e33",
+				"DiscoKey":   "discokey:b1fc57c7a0211597fba45c310c155b61c431980b927662e800e3ce27b59f3118",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33602",
+					"10.65.0.27:33602",
+					"172.17.0.1:33602",
+					"172.18.0.1:33602",
+					"172.19.0.1:33602"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:53:12.295257227Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8094170429721881,
+				"StableID":   "nkJ2he8sC621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:142f6ff7f9835024bb7c55a5342f82e6a5571f1425c1e47395b71757d10d2e07",
+				"DiscoKey":   "discokey:f3bc18e05531b29ff92e5f777edb1bc3f2577b679fe34564557f2a4d7226306f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43044",
+					"10.65.0.27:43044",
+					"172.17.0.1:43044",
+					"172.18.0.1:43044",
+					"172.19.0.1:43044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:53:12.83614961Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8060234399958885,
+				"StableID":   "nnH1x1hVw521CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:845ffdfed4eb0b79a76d13732fa1043ffe51dd16062dabe3d7b2c6175addaf73",
+				"DiscoKey":   "discokey:0d95058e6981d401f73613b09e8c702d793036e63ce698ffa06c7d62f4621d01",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53883",
+					"10.65.0.27:53883",
+					"172.17.0.1:53883",
+					"172.18.0.1:53883",
+					"172.19.0.1:53883"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:53:13.92257343Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3979154462050877,
+				"StableID":   "nJ7Zq8eA5Y11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c0482feab48384f62ceb3cf0e0357b0d18b7a988d3cc4c1b7c1df5a9eed8d24a",
+				"DiscoKey":   "discokey:2ed617110eae9697b77d92d9dcb757f9f7cf5a601c1599ed33fcd5753fac225c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54851",
+					"10.65.0.27:54851",
+					"172.17.0.1:54851",
+					"172.18.0.1:54851",
+					"172.19.0.1:54851"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:53:14.461921611Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6190654681495652,
+				"StableID":   "nVRZJ41mLq11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f2dde100287742dcfef89325a0dc820135505785c58f76eda06ee999a05a220f",
+				"DiscoKey":   "discokey:d810dcd5a6694432827bc65720ebeec4b958cfd6ab7a9f64a9f6be08953e8679",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58510",
+					"10.65.0.27:58510",
+					"172.17.0.1:58510",
+					"172.18.0.1:58510",
+					"172.19.0.1:58510"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:53:15.031556524Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         767453331655996,
+				"StableID":   "num5uThaz611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:451d69c8db54f124e091ab84d6b7e9cbc4b4e926e6e7514a7e73360ddd88cb7a",
+				"DiscoKey":   "discokey:d086f5f0dec8616426bd956162e84008795497dc378cc0b6d5935f6c7cbe8740",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:50877",
+					"10.65.0.27:50877",
+					"172.17.0.1:50877",
+					"172.18.0.1:50877",
+					"172.19.0.1:50877"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:53:15.535860367Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7241594842877954,
+				"StableID":   "nmz8bBRjYy11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1efbf5403be0ec53d9d2f8df3743c52cae169224ca2c42cf582023299d6042b",
+				"DiscoKey":   "discokey:ae2ea0ae798fa4955041d288f309ce01c35adbccbef557d98760d98f6720b97a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40710",
+					"10.65.0.27:40710",
+					"172.17.0.1:40710",
+					"172.18.0.1:40710",
+					"172.19.0.1:40710"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:53:16.08232304Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8572727664789590,
+				"StableID":   "nyE2p62cw921CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15c267a3b83de191d712d4e7bb374f53a4a6991d0ed8c928d147486f7ff8f353",
+				"DiscoKey":   "discokey:8fe51e8ae52634e6d49f8224e8f95876de264d055406cd5c97136868ee00cd59",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50223",
+					"10.65.0.27:50223",
+					"172.17.0.1:50223",
+					"172.18.0.1:50223",
+					"172.19.0.1:50223"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:53:16.630510647Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7974220851558896,
+				"StableID":   "nszWD5GYG521CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e4ae00825cf9b00635352d541d46b4d03244f862d26e08b0cbae83ac33d2064",
+				"DiscoKey":   "discokey:0fe95cb2bb9e00f63e6e01817e7839f41c77e82486721fef0a2aaaff485d3101",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46471",
+					"10.65.0.27:46471",
+					"172.17.0.1:46471",
+					"172.18.0.1:46471",
+					"172.19.0.1:46471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:53:17.171796369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8669461418029847,
+				"StableID":   "nYDTLw3RhA21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:00e5961df8ba4198e09cbd8fd9b7c83dfbe644fd17117646434be1aa074a8161",
+				"KeyExpiry":  "2026-11-08T21:53:17Z",
+				"DiscoKey":   "discokey:dcb428b3caeb1a52c5b04113b51cff70f3d0f001afcef6d15661261c9fb1202d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:60481",
+					"10.65.0.27:60481",
+					"172.17.0.1:60481",
+					"172.18.0.1:60481",
+					"172.19.0.1:60481"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:53:17.708462216Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2151744728930910,
+				"StableID":   "nwZjPkgXoH11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:193991aaaf06410684c146b6e889dc36865a92a03f4e4b8a49e2b7ef21079f4d",
+				"KeyExpiry":  "2026-11-08T21:53:18Z",
+				"DiscoKey":   "discokey:cd4610dcf7fc0b635bf0bbd361c94a8fbe6aa59dcc593ff86122f4912e5bff14",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46564",
+					"10.65.0.27:46564",
+					"172.17.0.1:46564",
+					"172.18.0.1:46564",
+					"172.19.0.1:46564"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:53:18.288272357Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1408541625136421,
+				"StableID":   "namA611wzB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:6bb0d194d75e39e3a7ee34597d22ec3a2ca59d8ed4427deb913be1dbe2f76064",
+				"KeyExpiry":  "2026-11-08T21:53:18Z",
+				"DiscoKey":   "discokey:85cf58118249b4acebbdc01cd421c639400811cdad67d1695cb450616c837c40",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:37963",
+					"10.65.0.27:37963",
+					"172.17.0.1:37963",
+					"172.18.0.1:37963",
+					"172.19.0.1:37963"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:53:18.798546704Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "400553619704474": {
+				"ID":          400553619704474,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8094170429721881,
+				"StableID":   "nkJ2he8sC621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       8094170429721881,
+				"Key":        "nodekey:142f6ff7f9835024bb7c55a5342f82e6a5571f1425c1e47395b71757d10d2e07",
+				"DiscoKey":   "discokey:f3bc18e05531b29ff92e5f777edb1bc3f2577b679fe34564557f2a4d7226306f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43044",
+					"10.65.0.27:43044",
+					"172.17.0.1:43044",
+					"172.18.0.1:43044",
+					"172.19.0.1:43044"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:53:12.83614961Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:142f6ff7f9835024bb7c55a5342f82e6a5571f1425c1e47395b71757d10d2e07",
+			"MachineKey": "mkey:55787f5bf9ea8e1734d386e45499413cced479af0d439c21d30aa2199346f77d",
+			"Peers": [{
+				"ID":         884839837843811,
+				"StableID":   "nAxkU3Fku711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d01b1aa3fb1f2459e69d332d4d3ec9b10ea2b4b833b2aea625fa2fbaabf9e1f",
+				"DiscoKey":   "discokey:3e951148bb7fafb746fa64807803ccf37b033ce354563d89a7ec98991648aa52",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33030",
+					"10.65.0.27:33030",
+					"172.17.0.1:33030",
+					"172.18.0.1:33030",
+					"172.19.0.1:33030"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:53:11.234882939Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5121850593450720,
+				"StableID":   "nduQz8Lhzg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d486392a39ffe96af7c8b980a44c3a3ec7ac7034f5f18ed32f05af8b283dc159",
+				"DiscoKey":   "discokey:f91ef00a03bc65b87fc281a2d15f5d7bd183dae5b53e7af90f60bf83acb01c58",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50572",
+					"10.65.0.27:50572",
+					"172.17.0.1:50572",
+					"172.18.0.1:50572",
+					"172.19.0.1:50572"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:53:11.763327396Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2162159437425437,
+				"StableID":   "nkz3XCGFtH11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f72a4e017de1b91028407ad7de4223ceaadf0aeafe5034b50f1456baf0187e33",
+				"DiscoKey":   "discokey:b1fc57c7a0211597fba45c310c155b61c431980b927662e800e3ce27b59f3118",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33602",
+					"10.65.0.27:33602",
+					"172.17.0.1:33602",
+					"172.18.0.1:33602",
+					"172.19.0.1:33602"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:53:12.295257227Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         400553619704474,
+				"StableID":   "nTb2k8sQ8411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f8ad3094de8b0ab1e4f742316ca0dda2f9c898d9ac45a481c9e7e07b2ac6125",
+				"DiscoKey":   "discokey:3320c1527557cfe82f792f2f7c754dc3ca4975644be20f458266c02ee8a71b5a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57048",
+					"10.65.0.27:57048",
+					"172.17.0.1:57048",
+					"172.18.0.1:57048",
+					"172.19.0.1:57048"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:53:13.384661116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8060234399958885,
+				"StableID":   "nnH1x1hVw521CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:845ffdfed4eb0b79a76d13732fa1043ffe51dd16062dabe3d7b2c6175addaf73",
+				"DiscoKey":   "discokey:0d95058e6981d401f73613b09e8c702d793036e63ce698ffa06c7d62f4621d01",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53883",
+					"10.65.0.27:53883",
+					"172.17.0.1:53883",
+					"172.18.0.1:53883",
+					"172.19.0.1:53883"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:53:13.92257343Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3979154462050877,
+				"StableID":   "nJ7Zq8eA5Y11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c0482feab48384f62ceb3cf0e0357b0d18b7a988d3cc4c1b7c1df5a9eed8d24a",
+				"DiscoKey":   "discokey:2ed617110eae9697b77d92d9dcb757f9f7cf5a601c1599ed33fcd5753fac225c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54851",
+					"10.65.0.27:54851",
+					"172.17.0.1:54851",
+					"172.18.0.1:54851",
+					"172.19.0.1:54851"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:53:14.461921611Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6190654681495652,
+				"StableID":   "nVRZJ41mLq11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f2dde100287742dcfef89325a0dc820135505785c58f76eda06ee999a05a220f",
+				"DiscoKey":   "discokey:d810dcd5a6694432827bc65720ebeec4b958cfd6ab7a9f64a9f6be08953e8679",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58510",
+					"10.65.0.27:58510",
+					"172.17.0.1:58510",
+					"172.18.0.1:58510",
+					"172.19.0.1:58510"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:53:15.031556524Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         767453331655996,
+				"StableID":   "num5uThaz611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:451d69c8db54f124e091ab84d6b7e9cbc4b4e926e6e7514a7e73360ddd88cb7a",
+				"DiscoKey":   "discokey:d086f5f0dec8616426bd956162e84008795497dc378cc0b6d5935f6c7cbe8740",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:50877",
+					"10.65.0.27:50877",
+					"172.17.0.1:50877",
+					"172.18.0.1:50877",
+					"172.19.0.1:50877"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:53:15.535860367Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7241594842877954,
+				"StableID":   "nmz8bBRjYy11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1efbf5403be0ec53d9d2f8df3743c52cae169224ca2c42cf582023299d6042b",
+				"DiscoKey":   "discokey:ae2ea0ae798fa4955041d288f309ce01c35adbccbef557d98760d98f6720b97a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40710",
+					"10.65.0.27:40710",
+					"172.17.0.1:40710",
+					"172.18.0.1:40710",
+					"172.19.0.1:40710"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:53:16.08232304Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8572727664789590,
+				"StableID":   "nyE2p62cw921CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15c267a3b83de191d712d4e7bb374f53a4a6991d0ed8c928d147486f7ff8f353",
+				"DiscoKey":   "discokey:8fe51e8ae52634e6d49f8224e8f95876de264d055406cd5c97136868ee00cd59",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50223",
+					"10.65.0.27:50223",
+					"172.17.0.1:50223",
+					"172.18.0.1:50223",
+					"172.19.0.1:50223"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:53:16.630510647Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7974220851558896,
+				"StableID":   "nszWD5GYG521CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e4ae00825cf9b00635352d541d46b4d03244f862d26e08b0cbae83ac33d2064",
+				"DiscoKey":   "discokey:0fe95cb2bb9e00f63e6e01817e7839f41c77e82486721fef0a2aaaff485d3101",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46471",
+					"10.65.0.27:46471",
+					"172.17.0.1:46471",
+					"172.18.0.1:46471",
+					"172.19.0.1:46471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:53:17.171796369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8669461418029847,
+				"StableID":   "nYDTLw3RhA21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:00e5961df8ba4198e09cbd8fd9b7c83dfbe644fd17117646434be1aa074a8161",
+				"KeyExpiry":  "2026-11-08T21:53:17Z",
+				"DiscoKey":   "discokey:dcb428b3caeb1a52c5b04113b51cff70f3d0f001afcef6d15661261c9fb1202d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:60481",
+					"10.65.0.27:60481",
+					"172.17.0.1:60481",
+					"172.18.0.1:60481",
+					"172.19.0.1:60481"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:53:17.708462216Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2151744728930910,
+				"StableID":   "nwZjPkgXoH11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:193991aaaf06410684c146b6e889dc36865a92a03f4e4b8a49e2b7ef21079f4d",
+				"KeyExpiry":  "2026-11-08T21:53:18Z",
+				"DiscoKey":   "discokey:cd4610dcf7fc0b635bf0bbd361c94a8fbe6aa59dcc593ff86122f4912e5bff14",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46564",
+					"10.65.0.27:46564",
+					"172.17.0.1:46564",
+					"172.18.0.1:46564",
+					"172.19.0.1:46564"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:53:18.288272357Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1408541625136421,
+				"StableID":   "namA611wzB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:6bb0d194d75e39e3a7ee34597d22ec3a2ca59d8ed4427deb913be1dbe2f76064",
+				"KeyExpiry":  "2026-11-08T21:53:18Z",
+				"DiscoKey":   "discokey:85cf58118249b4acebbdc01cd421c639400811cdad67d1695cb450616c837c40",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:37963",
+					"10.65.0.27:37963",
+					"172.17.0.1:37963",
+					"172.18.0.1:37963",
+					"172.19.0.1:37963"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:53:18.798546704Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8094170429721881": {
+				"ID":          8094170429721881,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3979154462050877,
+				"StableID":   "nJ7Zq8eA5Y11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       3979154462050877,
+				"Key":        "nodekey:c0482feab48384f62ceb3cf0e0357b0d18b7a988d3cc4c1b7c1df5a9eed8d24a",
+				"DiscoKey":   "discokey:2ed617110eae9697b77d92d9dcb757f9f7cf5a601c1599ed33fcd5753fac225c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54851",
+					"10.65.0.27:54851",
+					"172.17.0.1:54851",
+					"172.18.0.1:54851",
+					"172.19.0.1:54851"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:53:14.461921611Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c0482feab48384f62ceb3cf0e0357b0d18b7a988d3cc4c1b7c1df5a9eed8d24a",
+			"MachineKey": "mkey:42d5205cad268b68ff147ffda69c271c875e760bd5478078ef0ac157ac990824",
+			"Peers": [{
+				"ID":         884839837843811,
+				"StableID":   "nAxkU3Fku711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d01b1aa3fb1f2459e69d332d4d3ec9b10ea2b4b833b2aea625fa2fbaabf9e1f",
+				"DiscoKey":   "discokey:3e951148bb7fafb746fa64807803ccf37b033ce354563d89a7ec98991648aa52",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33030",
+					"10.65.0.27:33030",
+					"172.17.0.1:33030",
+					"172.18.0.1:33030",
+					"172.19.0.1:33030"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:53:11.234882939Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5121850593450720,
+				"StableID":   "nduQz8Lhzg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d486392a39ffe96af7c8b980a44c3a3ec7ac7034f5f18ed32f05af8b283dc159",
+				"DiscoKey":   "discokey:f91ef00a03bc65b87fc281a2d15f5d7bd183dae5b53e7af90f60bf83acb01c58",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50572",
+					"10.65.0.27:50572",
+					"172.17.0.1:50572",
+					"172.18.0.1:50572",
+					"172.19.0.1:50572"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:53:11.763327396Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2162159437425437,
+				"StableID":   "nkz3XCGFtH11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f72a4e017de1b91028407ad7de4223ceaadf0aeafe5034b50f1456baf0187e33",
+				"DiscoKey":   "discokey:b1fc57c7a0211597fba45c310c155b61c431980b927662e800e3ce27b59f3118",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33602",
+					"10.65.0.27:33602",
+					"172.17.0.1:33602",
+					"172.18.0.1:33602",
+					"172.19.0.1:33602"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:53:12.295257227Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8094170429721881,
+				"StableID":   "nkJ2he8sC621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:142f6ff7f9835024bb7c55a5342f82e6a5571f1425c1e47395b71757d10d2e07",
+				"DiscoKey":   "discokey:f3bc18e05531b29ff92e5f777edb1bc3f2577b679fe34564557f2a4d7226306f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43044",
+					"10.65.0.27:43044",
+					"172.17.0.1:43044",
+					"172.18.0.1:43044",
+					"172.19.0.1:43044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:53:12.83614961Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         400553619704474,
+				"StableID":   "nTb2k8sQ8411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f8ad3094de8b0ab1e4f742316ca0dda2f9c898d9ac45a481c9e7e07b2ac6125",
+				"DiscoKey":   "discokey:3320c1527557cfe82f792f2f7c754dc3ca4975644be20f458266c02ee8a71b5a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57048",
+					"10.65.0.27:57048",
+					"172.17.0.1:57048",
+					"172.18.0.1:57048",
+					"172.19.0.1:57048"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:53:13.384661116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8060234399958885,
+				"StableID":   "nnH1x1hVw521CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:845ffdfed4eb0b79a76d13732fa1043ffe51dd16062dabe3d7b2c6175addaf73",
+				"DiscoKey":   "discokey:0d95058e6981d401f73613b09e8c702d793036e63ce698ffa06c7d62f4621d01",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53883",
+					"10.65.0.27:53883",
+					"172.17.0.1:53883",
+					"172.18.0.1:53883",
+					"172.19.0.1:53883"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:53:13.92257343Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6190654681495652,
+				"StableID":   "nVRZJ41mLq11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f2dde100287742dcfef89325a0dc820135505785c58f76eda06ee999a05a220f",
+				"DiscoKey":   "discokey:d810dcd5a6694432827bc65720ebeec4b958cfd6ab7a9f64a9f6be08953e8679",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58510",
+					"10.65.0.27:58510",
+					"172.17.0.1:58510",
+					"172.18.0.1:58510",
+					"172.19.0.1:58510"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:53:15.031556524Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         767453331655996,
+				"StableID":   "num5uThaz611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:451d69c8db54f124e091ab84d6b7e9cbc4b4e926e6e7514a7e73360ddd88cb7a",
+				"DiscoKey":   "discokey:d086f5f0dec8616426bd956162e84008795497dc378cc0b6d5935f6c7cbe8740",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:50877",
+					"10.65.0.27:50877",
+					"172.17.0.1:50877",
+					"172.18.0.1:50877",
+					"172.19.0.1:50877"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:53:15.535860367Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7241594842877954,
+				"StableID":   "nmz8bBRjYy11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1efbf5403be0ec53d9d2f8df3743c52cae169224ca2c42cf582023299d6042b",
+				"DiscoKey":   "discokey:ae2ea0ae798fa4955041d288f309ce01c35adbccbef557d98760d98f6720b97a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40710",
+					"10.65.0.27:40710",
+					"172.17.0.1:40710",
+					"172.18.0.1:40710",
+					"172.19.0.1:40710"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:53:16.08232304Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8572727664789590,
+				"StableID":   "nyE2p62cw921CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15c267a3b83de191d712d4e7bb374f53a4a6991d0ed8c928d147486f7ff8f353",
+				"DiscoKey":   "discokey:8fe51e8ae52634e6d49f8224e8f95876de264d055406cd5c97136868ee00cd59",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50223",
+					"10.65.0.27:50223",
+					"172.17.0.1:50223",
+					"172.18.0.1:50223",
+					"172.19.0.1:50223"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:53:16.630510647Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7974220851558896,
+				"StableID":   "nszWD5GYG521CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e4ae00825cf9b00635352d541d46b4d03244f862d26e08b0cbae83ac33d2064",
+				"DiscoKey":   "discokey:0fe95cb2bb9e00f63e6e01817e7839f41c77e82486721fef0a2aaaff485d3101",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46471",
+					"10.65.0.27:46471",
+					"172.17.0.1:46471",
+					"172.18.0.1:46471",
+					"172.19.0.1:46471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:53:17.171796369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8669461418029847,
+				"StableID":   "nYDTLw3RhA21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:00e5961df8ba4198e09cbd8fd9b7c83dfbe644fd17117646434be1aa074a8161",
+				"KeyExpiry":  "2026-11-08T21:53:17Z",
+				"DiscoKey":   "discokey:dcb428b3caeb1a52c5b04113b51cff70f3d0f001afcef6d15661261c9fb1202d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:60481",
+					"10.65.0.27:60481",
+					"172.17.0.1:60481",
+					"172.18.0.1:60481",
+					"172.19.0.1:60481"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:53:17.708462216Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2151744728930910,
+				"StableID":   "nwZjPkgXoH11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:193991aaaf06410684c146b6e889dc36865a92a03f4e4b8a49e2b7ef21079f4d",
+				"KeyExpiry":  "2026-11-08T21:53:18Z",
+				"DiscoKey":   "discokey:cd4610dcf7fc0b635bf0bbd361c94a8fbe6aa59dcc593ff86122f4912e5bff14",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46564",
+					"10.65.0.27:46564",
+					"172.17.0.1:46564",
+					"172.18.0.1:46564",
+					"172.19.0.1:46564"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:53:18.288272357Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1408541625136421,
+				"StableID":   "namA611wzB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:6bb0d194d75e39e3a7ee34597d22ec3a2ca59d8ed4427deb913be1dbe2f76064",
+				"KeyExpiry":  "2026-11-08T21:53:18Z",
+				"DiscoKey":   "discokey:85cf58118249b4acebbdc01cd421c639400811cdad67d1695cb450616c837c40",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:37963",
+					"10.65.0.27:37963",
+					"172.17.0.1:37963",
+					"172.18.0.1:37963",
+					"172.19.0.1:37963"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:53:18.798546704Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3979154462050877": {
+				"ID":          3979154462050877,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         767453331655996,
+				"StableID":   "num5uThaz611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       767453331655996,
+				"Key":        "nodekey:451d69c8db54f124e091ab84d6b7e9cbc4b4e926e6e7514a7e73360ddd88cb7a",
+				"DiscoKey":   "discokey:d086f5f0dec8616426bd956162e84008795497dc378cc0b6d5935f6c7cbe8740",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:50877",
+					"10.65.0.27:50877",
+					"172.17.0.1:50877",
+					"172.18.0.1:50877",
+					"172.19.0.1:50877"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:53:15.535860367Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:451d69c8db54f124e091ab84d6b7e9cbc4b4e926e6e7514a7e73360ddd88cb7a",
+			"MachineKey": "mkey:5a7bfae28fd8ec119f491b6efc517f7e4a1c32c60030d8ad7277601e648aa411",
+			"Peers": [{
+				"ID":         884839837843811,
+				"StableID":   "nAxkU3Fku711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d01b1aa3fb1f2459e69d332d4d3ec9b10ea2b4b833b2aea625fa2fbaabf9e1f",
+				"DiscoKey":   "discokey:3e951148bb7fafb746fa64807803ccf37b033ce354563d89a7ec98991648aa52",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33030",
+					"10.65.0.27:33030",
+					"172.17.0.1:33030",
+					"172.18.0.1:33030",
+					"172.19.0.1:33030"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:53:11.234882939Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5121850593450720,
+				"StableID":   "nduQz8Lhzg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d486392a39ffe96af7c8b980a44c3a3ec7ac7034f5f18ed32f05af8b283dc159",
+				"DiscoKey":   "discokey:f91ef00a03bc65b87fc281a2d15f5d7bd183dae5b53e7af90f60bf83acb01c58",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50572",
+					"10.65.0.27:50572",
+					"172.17.0.1:50572",
+					"172.18.0.1:50572",
+					"172.19.0.1:50572"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:53:11.763327396Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2162159437425437,
+				"StableID":   "nkz3XCGFtH11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f72a4e017de1b91028407ad7de4223ceaadf0aeafe5034b50f1456baf0187e33",
+				"DiscoKey":   "discokey:b1fc57c7a0211597fba45c310c155b61c431980b927662e800e3ce27b59f3118",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33602",
+					"10.65.0.27:33602",
+					"172.17.0.1:33602",
+					"172.18.0.1:33602",
+					"172.19.0.1:33602"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:53:12.295257227Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8094170429721881,
+				"StableID":   "nkJ2he8sC621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:142f6ff7f9835024bb7c55a5342f82e6a5571f1425c1e47395b71757d10d2e07",
+				"DiscoKey":   "discokey:f3bc18e05531b29ff92e5f777edb1bc3f2577b679fe34564557f2a4d7226306f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43044",
+					"10.65.0.27:43044",
+					"172.17.0.1:43044",
+					"172.18.0.1:43044",
+					"172.19.0.1:43044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:53:12.83614961Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         400553619704474,
+				"StableID":   "nTb2k8sQ8411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f8ad3094de8b0ab1e4f742316ca0dda2f9c898d9ac45a481c9e7e07b2ac6125",
+				"DiscoKey":   "discokey:3320c1527557cfe82f792f2f7c754dc3ca4975644be20f458266c02ee8a71b5a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57048",
+					"10.65.0.27:57048",
+					"172.17.0.1:57048",
+					"172.18.0.1:57048",
+					"172.19.0.1:57048"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:53:13.384661116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8060234399958885,
+				"StableID":   "nnH1x1hVw521CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:845ffdfed4eb0b79a76d13732fa1043ffe51dd16062dabe3d7b2c6175addaf73",
+				"DiscoKey":   "discokey:0d95058e6981d401f73613b09e8c702d793036e63ce698ffa06c7d62f4621d01",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53883",
+					"10.65.0.27:53883",
+					"172.17.0.1:53883",
+					"172.18.0.1:53883",
+					"172.19.0.1:53883"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:53:13.92257343Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3979154462050877,
+				"StableID":   "nJ7Zq8eA5Y11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c0482feab48384f62ceb3cf0e0357b0d18b7a988d3cc4c1b7c1df5a9eed8d24a",
+				"DiscoKey":   "discokey:2ed617110eae9697b77d92d9dcb757f9f7cf5a601c1599ed33fcd5753fac225c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54851",
+					"10.65.0.27:54851",
+					"172.17.0.1:54851",
+					"172.18.0.1:54851",
+					"172.19.0.1:54851"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:53:14.461921611Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6190654681495652,
+				"StableID":   "nVRZJ41mLq11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f2dde100287742dcfef89325a0dc820135505785c58f76eda06ee999a05a220f",
+				"DiscoKey":   "discokey:d810dcd5a6694432827bc65720ebeec4b958cfd6ab7a9f64a9f6be08953e8679",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58510",
+					"10.65.0.27:58510",
+					"172.17.0.1:58510",
+					"172.18.0.1:58510",
+					"172.19.0.1:58510"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:53:15.031556524Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7241594842877954,
+				"StableID":   "nmz8bBRjYy11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1efbf5403be0ec53d9d2f8df3743c52cae169224ca2c42cf582023299d6042b",
+				"DiscoKey":   "discokey:ae2ea0ae798fa4955041d288f309ce01c35adbccbef557d98760d98f6720b97a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40710",
+					"10.65.0.27:40710",
+					"172.17.0.1:40710",
+					"172.18.0.1:40710",
+					"172.19.0.1:40710"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:53:16.08232304Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8572727664789590,
+				"StableID":   "nyE2p62cw921CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15c267a3b83de191d712d4e7bb374f53a4a6991d0ed8c928d147486f7ff8f353",
+				"DiscoKey":   "discokey:8fe51e8ae52634e6d49f8224e8f95876de264d055406cd5c97136868ee00cd59",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50223",
+					"10.65.0.27:50223",
+					"172.17.0.1:50223",
+					"172.18.0.1:50223",
+					"172.19.0.1:50223"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:53:16.630510647Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7974220851558896,
+				"StableID":   "nszWD5GYG521CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e4ae00825cf9b00635352d541d46b4d03244f862d26e08b0cbae83ac33d2064",
+				"DiscoKey":   "discokey:0fe95cb2bb9e00f63e6e01817e7839f41c77e82486721fef0a2aaaff485d3101",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46471",
+					"10.65.0.27:46471",
+					"172.17.0.1:46471",
+					"172.18.0.1:46471",
+					"172.19.0.1:46471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:53:17.171796369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8669461418029847,
+				"StableID":   "nYDTLw3RhA21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:00e5961df8ba4198e09cbd8fd9b7c83dfbe644fd17117646434be1aa074a8161",
+				"KeyExpiry":  "2026-11-08T21:53:17Z",
+				"DiscoKey":   "discokey:dcb428b3caeb1a52c5b04113b51cff70f3d0f001afcef6d15661261c9fb1202d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:60481",
+					"10.65.0.27:60481",
+					"172.17.0.1:60481",
+					"172.18.0.1:60481",
+					"172.19.0.1:60481"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:53:17.708462216Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2151744728930910,
+				"StableID":   "nwZjPkgXoH11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:193991aaaf06410684c146b6e889dc36865a92a03f4e4b8a49e2b7ef21079f4d",
+				"KeyExpiry":  "2026-11-08T21:53:18Z",
+				"DiscoKey":   "discokey:cd4610dcf7fc0b635bf0bbd361c94a8fbe6aa59dcc593ff86122f4912e5bff14",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46564",
+					"10.65.0.27:46564",
+					"172.17.0.1:46564",
+					"172.18.0.1:46564",
+					"172.19.0.1:46564"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:53:18.288272357Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1408541625136421,
+				"StableID":   "namA611wzB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:6bb0d194d75e39e3a7ee34597d22ec3a2ca59d8ed4427deb913be1dbe2f76064",
+				"KeyExpiry":  "2026-11-08T21:53:18Z",
+				"DiscoKey":   "discokey:85cf58118249b4acebbdc01cd421c639400811cdad67d1695cb450616c837c40",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:37963",
+					"10.65.0.27:37963",
+					"172.17.0.1:37963",
+					"172.18.0.1:37963",
+					"172.19.0.1:37963"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:53:18.798546704Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "767453331655996": {
+				"ID":          767453331655996,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2151744728930910,
+				"StableID":   "nwZjPkgXoH11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:193991aaaf06410684c146b6e889dc36865a92a03f4e4b8a49e2b7ef21079f4d",
+				"KeyExpiry":  "2026-11-08T21:53:18Z",
+				"DiscoKey":   "discokey:cd4610dcf7fc0b635bf0bbd361c94a8fbe6aa59dcc593ff86122f4912e5bff14",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46564",
+					"10.65.0.27:46564",
+					"172.17.0.1:46564",
+					"172.18.0.1:46564",
+					"172.19.0.1:46564"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:53:18.288272357Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:193991aaaf06410684c146b6e889dc36865a92a03f4e4b8a49e2b7ef21079f4d",
+			"MachineKey": "mkey:859331b832adc6f654e60d9639a0fea8cdcf57cdc3f493ef415a8eb797e2921c",
+			"Peers": [{
+				"ID":         884839837843811,
+				"StableID":   "nAxkU3Fku711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d01b1aa3fb1f2459e69d332d4d3ec9b10ea2b4b833b2aea625fa2fbaabf9e1f",
+				"DiscoKey":   "discokey:3e951148bb7fafb746fa64807803ccf37b033ce354563d89a7ec98991648aa52",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33030",
+					"10.65.0.27:33030",
+					"172.17.0.1:33030",
+					"172.18.0.1:33030",
+					"172.19.0.1:33030"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:53:11.234882939Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5121850593450720,
+				"StableID":   "nduQz8Lhzg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d486392a39ffe96af7c8b980a44c3a3ec7ac7034f5f18ed32f05af8b283dc159",
+				"DiscoKey":   "discokey:f91ef00a03bc65b87fc281a2d15f5d7bd183dae5b53e7af90f60bf83acb01c58",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50572",
+					"10.65.0.27:50572",
+					"172.17.0.1:50572",
+					"172.18.0.1:50572",
+					"172.19.0.1:50572"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:53:11.763327396Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2162159437425437,
+				"StableID":   "nkz3XCGFtH11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f72a4e017de1b91028407ad7de4223ceaadf0aeafe5034b50f1456baf0187e33",
+				"DiscoKey":   "discokey:b1fc57c7a0211597fba45c310c155b61c431980b927662e800e3ce27b59f3118",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33602",
+					"10.65.0.27:33602",
+					"172.17.0.1:33602",
+					"172.18.0.1:33602",
+					"172.19.0.1:33602"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:53:12.295257227Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8094170429721881,
+				"StableID":   "nkJ2he8sC621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:142f6ff7f9835024bb7c55a5342f82e6a5571f1425c1e47395b71757d10d2e07",
+				"DiscoKey":   "discokey:f3bc18e05531b29ff92e5f777edb1bc3f2577b679fe34564557f2a4d7226306f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43044",
+					"10.65.0.27:43044",
+					"172.17.0.1:43044",
+					"172.18.0.1:43044",
+					"172.19.0.1:43044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:53:12.83614961Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         400553619704474,
+				"StableID":   "nTb2k8sQ8411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f8ad3094de8b0ab1e4f742316ca0dda2f9c898d9ac45a481c9e7e07b2ac6125",
+				"DiscoKey":   "discokey:3320c1527557cfe82f792f2f7c754dc3ca4975644be20f458266c02ee8a71b5a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57048",
+					"10.65.0.27:57048",
+					"172.17.0.1:57048",
+					"172.18.0.1:57048",
+					"172.19.0.1:57048"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:53:13.384661116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8060234399958885,
+				"StableID":   "nnH1x1hVw521CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:845ffdfed4eb0b79a76d13732fa1043ffe51dd16062dabe3d7b2c6175addaf73",
+				"DiscoKey":   "discokey:0d95058e6981d401f73613b09e8c702d793036e63ce698ffa06c7d62f4621d01",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53883",
+					"10.65.0.27:53883",
+					"172.17.0.1:53883",
+					"172.18.0.1:53883",
+					"172.19.0.1:53883"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:53:13.92257343Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3979154462050877,
+				"StableID":   "nJ7Zq8eA5Y11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c0482feab48384f62ceb3cf0e0357b0d18b7a988d3cc4c1b7c1df5a9eed8d24a",
+				"DiscoKey":   "discokey:2ed617110eae9697b77d92d9dcb757f9f7cf5a601c1599ed33fcd5753fac225c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54851",
+					"10.65.0.27:54851",
+					"172.17.0.1:54851",
+					"172.18.0.1:54851",
+					"172.19.0.1:54851"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:53:14.461921611Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6190654681495652,
+				"StableID":   "nVRZJ41mLq11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f2dde100287742dcfef89325a0dc820135505785c58f76eda06ee999a05a220f",
+				"DiscoKey":   "discokey:d810dcd5a6694432827bc65720ebeec4b958cfd6ab7a9f64a9f6be08953e8679",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58510",
+					"10.65.0.27:58510",
+					"172.17.0.1:58510",
+					"172.18.0.1:58510",
+					"172.19.0.1:58510"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:53:15.031556524Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         767453331655996,
+				"StableID":   "num5uThaz611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:451d69c8db54f124e091ab84d6b7e9cbc4b4e926e6e7514a7e73360ddd88cb7a",
+				"DiscoKey":   "discokey:d086f5f0dec8616426bd956162e84008795497dc378cc0b6d5935f6c7cbe8740",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:50877",
+					"10.65.0.27:50877",
+					"172.17.0.1:50877",
+					"172.18.0.1:50877",
+					"172.19.0.1:50877"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:53:15.535860367Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7241594842877954,
+				"StableID":   "nmz8bBRjYy11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1efbf5403be0ec53d9d2f8df3743c52cae169224ca2c42cf582023299d6042b",
+				"DiscoKey":   "discokey:ae2ea0ae798fa4955041d288f309ce01c35adbccbef557d98760d98f6720b97a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40710",
+					"10.65.0.27:40710",
+					"172.17.0.1:40710",
+					"172.18.0.1:40710",
+					"172.19.0.1:40710"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:53:16.08232304Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8572727664789590,
+				"StableID":   "nyE2p62cw921CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15c267a3b83de191d712d4e7bb374f53a4a6991d0ed8c928d147486f7ff8f353",
+				"DiscoKey":   "discokey:8fe51e8ae52634e6d49f8224e8f95876de264d055406cd5c97136868ee00cd59",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50223",
+					"10.65.0.27:50223",
+					"172.17.0.1:50223",
+					"172.18.0.1:50223",
+					"172.19.0.1:50223"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:53:16.630510647Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7974220851558896,
+				"StableID":   "nszWD5GYG521CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e4ae00825cf9b00635352d541d46b4d03244f862d26e08b0cbae83ac33d2064",
+				"DiscoKey":   "discokey:0fe95cb2bb9e00f63e6e01817e7839f41c77e82486721fef0a2aaaff485d3101",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46471",
+					"10.65.0.27:46471",
+					"172.17.0.1:46471",
+					"172.18.0.1:46471",
+					"172.19.0.1:46471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:53:17.171796369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8669461418029847,
+				"StableID":   "nYDTLw3RhA21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:00e5961df8ba4198e09cbd8fd9b7c83dfbe644fd17117646434be1aa074a8161",
+				"KeyExpiry":  "2026-11-08T21:53:17Z",
+				"DiscoKey":   "discokey:dcb428b3caeb1a52c5b04113b51cff70f3d0f001afcef6d15661261c9fb1202d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:60481",
+					"10.65.0.27:60481",
+					"172.17.0.1:60481",
+					"172.18.0.1:60481",
+					"172.19.0.1:60481"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:53:17.708462216Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1408541625136421,
+				"StableID":   "namA611wzB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:6bb0d194d75e39e3a7ee34597d22ec3a2ca59d8ed4427deb913be1dbe2f76064",
+				"KeyExpiry":  "2026-11-08T21:53:18Z",
+				"DiscoKey":   "discokey:85cf58118249b4acebbdc01cd421c639400811cdad67d1695cb450616c837c40",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:37963",
+					"10.65.0.27:37963",
+					"172.17.0.1:37963",
+					"172.18.0.1:37963",
+					"172.19.0.1:37963"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:53:18.798546704Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7241594842877954,
+				"StableID":   "nmz8bBRjYy11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       7241594842877954,
+				"Key":        "nodekey:d1efbf5403be0ec53d9d2f8df3743c52cae169224ca2c42cf582023299d6042b",
+				"DiscoKey":   "discokey:ae2ea0ae798fa4955041d288f309ce01c35adbccbef557d98760d98f6720b97a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40710",
+					"10.65.0.27:40710",
+					"172.17.0.1:40710",
+					"172.18.0.1:40710",
+					"172.19.0.1:40710"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:53:16.08232304Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d1efbf5403be0ec53d9d2f8df3743c52cae169224ca2c42cf582023299d6042b",
+			"MachineKey": "mkey:fa84721b44b7a090213475b77099a9429f4eddedbe0ad7f77b541a401a498457",
+			"Peers": [{
+				"ID":         884839837843811,
+				"StableID":   "nAxkU3Fku711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d01b1aa3fb1f2459e69d332d4d3ec9b10ea2b4b833b2aea625fa2fbaabf9e1f",
+				"DiscoKey":   "discokey:3e951148bb7fafb746fa64807803ccf37b033ce354563d89a7ec98991648aa52",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33030",
+					"10.65.0.27:33030",
+					"172.17.0.1:33030",
+					"172.18.0.1:33030",
+					"172.19.0.1:33030"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:53:11.234882939Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5121850593450720,
+				"StableID":   "nduQz8Lhzg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d486392a39ffe96af7c8b980a44c3a3ec7ac7034f5f18ed32f05af8b283dc159",
+				"DiscoKey":   "discokey:f91ef00a03bc65b87fc281a2d15f5d7bd183dae5b53e7af90f60bf83acb01c58",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50572",
+					"10.65.0.27:50572",
+					"172.17.0.1:50572",
+					"172.18.0.1:50572",
+					"172.19.0.1:50572"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:53:11.763327396Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2162159437425437,
+				"StableID":   "nkz3XCGFtH11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f72a4e017de1b91028407ad7de4223ceaadf0aeafe5034b50f1456baf0187e33",
+				"DiscoKey":   "discokey:b1fc57c7a0211597fba45c310c155b61c431980b927662e800e3ce27b59f3118",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33602",
+					"10.65.0.27:33602",
+					"172.17.0.1:33602",
+					"172.18.0.1:33602",
+					"172.19.0.1:33602"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:53:12.295257227Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8094170429721881,
+				"StableID":   "nkJ2he8sC621CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:142f6ff7f9835024bb7c55a5342f82e6a5571f1425c1e47395b71757d10d2e07",
+				"DiscoKey":   "discokey:f3bc18e05531b29ff92e5f777edb1bc3f2577b679fe34564557f2a4d7226306f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43044",
+					"10.65.0.27:43044",
+					"172.17.0.1:43044",
+					"172.18.0.1:43044",
+					"172.19.0.1:43044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:53:12.83614961Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         400553619704474,
+				"StableID":   "nTb2k8sQ8411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f8ad3094de8b0ab1e4f742316ca0dda2f9c898d9ac45a481c9e7e07b2ac6125",
+				"DiscoKey":   "discokey:3320c1527557cfe82f792f2f7c754dc3ca4975644be20f458266c02ee8a71b5a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57048",
+					"10.65.0.27:57048",
+					"172.17.0.1:57048",
+					"172.18.0.1:57048",
+					"172.19.0.1:57048"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:53:13.384661116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8060234399958885,
+				"StableID":   "nnH1x1hVw521CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:845ffdfed4eb0b79a76d13732fa1043ffe51dd16062dabe3d7b2c6175addaf73",
+				"DiscoKey":   "discokey:0d95058e6981d401f73613b09e8c702d793036e63ce698ffa06c7d62f4621d01",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53883",
+					"10.65.0.27:53883",
+					"172.17.0.1:53883",
+					"172.18.0.1:53883",
+					"172.19.0.1:53883"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:53:13.92257343Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3979154462050877,
+				"StableID":   "nJ7Zq8eA5Y11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c0482feab48384f62ceb3cf0e0357b0d18b7a988d3cc4c1b7c1df5a9eed8d24a",
+				"DiscoKey":   "discokey:2ed617110eae9697b77d92d9dcb757f9f7cf5a601c1599ed33fcd5753fac225c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54851",
+					"10.65.0.27:54851",
+					"172.17.0.1:54851",
+					"172.18.0.1:54851",
+					"172.19.0.1:54851"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:53:14.461921611Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6190654681495652,
+				"StableID":   "nVRZJ41mLq11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f2dde100287742dcfef89325a0dc820135505785c58f76eda06ee999a05a220f",
+				"DiscoKey":   "discokey:d810dcd5a6694432827bc65720ebeec4b958cfd6ab7a9f64a9f6be08953e8679",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:58510",
+					"10.65.0.27:58510",
+					"172.17.0.1:58510",
+					"172.18.0.1:58510",
+					"172.19.0.1:58510"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:53:15.031556524Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         767453331655996,
+				"StableID":   "num5uThaz611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:451d69c8db54f124e091ab84d6b7e9cbc4b4e926e6e7514a7e73360ddd88cb7a",
+				"DiscoKey":   "discokey:d086f5f0dec8616426bd956162e84008795497dc378cc0b6d5935f6c7cbe8740",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:50877",
+					"10.65.0.27:50877",
+					"172.17.0.1:50877",
+					"172.18.0.1:50877",
+					"172.19.0.1:50877"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:53:15.535860367Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8572727664789590,
+				"StableID":   "nyE2p62cw921CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15c267a3b83de191d712d4e7bb374f53a4a6991d0ed8c928d147486f7ff8f353",
+				"DiscoKey":   "discokey:8fe51e8ae52634e6d49f8224e8f95876de264d055406cd5c97136868ee00cd59",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50223",
+					"10.65.0.27:50223",
+					"172.17.0.1:50223",
+					"172.18.0.1:50223",
+					"172.19.0.1:50223"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:53:16.630510647Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7974220851558896,
+				"StableID":   "nszWD5GYG521CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e4ae00825cf9b00635352d541d46b4d03244f862d26e08b0cbae83ac33d2064",
+				"DiscoKey":   "discokey:0fe95cb2bb9e00f63e6e01817e7839f41c77e82486721fef0a2aaaff485d3101",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46471",
+					"10.65.0.27:46471",
+					"172.17.0.1:46471",
+					"172.18.0.1:46471",
+					"172.19.0.1:46471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:53:17.171796369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8669461418029847,
+				"StableID":   "nYDTLw3RhA21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:00e5961df8ba4198e09cbd8fd9b7c83dfbe644fd17117646434be1aa074a8161",
+				"KeyExpiry":  "2026-11-08T21:53:17Z",
+				"DiscoKey":   "discokey:dcb428b3caeb1a52c5b04113b51cff70f3d0f001afcef6d15661261c9fb1202d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:60481",
+					"10.65.0.27:60481",
+					"172.17.0.1:60481",
+					"172.18.0.1:60481",
+					"172.19.0.1:60481"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:53:17.708462216Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2151744728930910,
+				"StableID":   "nwZjPkgXoH11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:193991aaaf06410684c146b6e889dc36865a92a03f4e4b8a49e2b7ef21079f4d",
+				"KeyExpiry":  "2026-11-08T21:53:18Z",
+				"DiscoKey":   "discokey:cd4610dcf7fc0b635bf0bbd361c94a8fbe6aa59dcc593ff86122f4912e5bff14",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46564",
+					"10.65.0.27:46564",
+					"172.17.0.1:46564",
+					"172.18.0.1:46564",
+					"172.19.0.1:46564"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:53:18.288272357Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1408541625136421,
+				"StableID":   "namA611wzB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:6bb0d194d75e39e3a7ee34597d22ec3a2ca59d8ed4427deb913be1dbe2f76064",
+				"KeyExpiry":  "2026-11-08T21:53:18Z",
+				"DiscoKey":   "discokey:85cf58118249b4acebbdc01cd421c639400811cdad67d1695cb450616c837c40",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:37963",
+					"10.65.0.27:37963",
+					"172.17.0.1:37963",
+					"172.18.0.1:37963",
+					"172.19.0.1:37963"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:53:18.798546704Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7241594842877954": {
+				"ID":          7241594842877954,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-checkperiod-negative.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-checkperiod-negative.hujson
@@ -1,0 +1,20082 @@
+// ssh-malformed-checkperiod-negative
+//
+// ssh checkPeriod negative
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-13T07:29:31Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-malformed-checkperiod-negative",
+	"description":    "ssh checkPeriod negative",
+	"category":       "ssh",
+	"captured_at":    "2026-05-13T07:29:31.396432336Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "checkPeriod -1m0s must be a positive duration"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                     \n  \n                                                                      \n        \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh checkPeriod negative\",\n\t\"id\":          \"ssh-malformed-checkperiod-negative\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\":      \"check\",\n\t\t\"checkPeriod\": \"-1m\",\n\t\t\"dst\":         [\"tag:server\"],\n\t\t\"src\":         [\"autogroup:member\"],\n\t\t\"users\":       [\"root\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-edge/ssh-malformed-checkperiod-negative.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action":      "check",
+				"checkPeriod": "-1m",
+				"dst":         ["tag:server"],
+				"src":         ["autogroup:member"],
+				"users":       ["root"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3992576385851876,
+				"StableID":   "nsLNHGDFBY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       3992576385851876,
+				"Key":        "nodekey:b25516bc05623bd81b54313fcb762a6e76d2187518eed34ee5a76047c56e017a",
+				"DiscoKey":   "discokey:85eaeca4890b27c4d1be87c7ffdebcba40736c8fbc971024b137f97a0ecd5f5b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49767",
+					"10.65.0.27:49767",
+					"172.17.0.1:49767",
+					"172.18.0.1:49767",
+					"172.19.0.1:49767"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:29:39.981269119Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b25516bc05623bd81b54313fcb762a6e76d2187518eed34ee5a76047c56e017a",
+			"MachineKey": "mkey:ac5e9bdfb2de0348364dae544e7fcc14871d45a7070c206709fe9b4fd571e623",
+			"Peers": [{
+				"ID":         3415573450443127,
+				"StableID":   "nEiZjiKvfT11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:645e0d46df8060d6e5ea506423a859112f80419e5cc84f9360c338d7fcd46279",
+				"DiscoKey":   "discokey:e914d339d0f442de4aaa77f7d79237965edf235901a211a666d2305875f8bb2a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50978",
+					"10.65.0.27:50978",
+					"172.17.0.1:50978",
+					"172.18.0.1:50978",
+					"172.19.0.1:50978"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:29:34.07947452Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6768834286965882,
+				"StableID":   "nFmz9Locru11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97446871666b03011c68cc252748ee8429e04ed9ded08ab0a20073b4535c4d3c",
+				"DiscoKey":   "discokey:07b754c22ca9e4a0bccb5db9af456c6d8c82ce21fa82d80fb6bcb17bfb056c16",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35460",
+					"10.65.0.27:35460",
+					"172.17.0.1:35460",
+					"172.18.0.1:35460",
+					"172.19.0.1:35460"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:29:34.562430123Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7975479763524383,
+				"StableID":   "nAWQx6L7H521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f66452092f25dfa5b179582795a5a82c04441eb2b1490028cd2e4fa7487f864d",
+				"DiscoKey":   "discokey:24ff006dc6c1cd36a3d831c503368076599c8982aadc33d3c419f399d7c0a228",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53502",
+					"10.65.0.27:53502",
+					"172.17.0.1:53502",
+					"172.18.0.1:53502",
+					"172.19.0.1:53502"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:29:35.115765782Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4907521742976237,
+				"StableID":   "ntrfQvGdKf11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c781b50d877b7bfb397cd97b3a5a379b98cfa39008d8ec08a2b055f6e7ba5b1a",
+				"DiscoKey":   "discokey:dee57ee9a4c835dfb46a1767d60de77d126e52c8d813224f1961996a1a635d54",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43761",
+					"10.65.0.27:43761",
+					"172.17.0.1:43761",
+					"172.18.0.1:43761",
+					"172.19.0.1:43761"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:29:35.649076609Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4234057264648330,
+				"StableID":   "nw3VdGWc4a11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:568f8b2b976a6bf3caa4da47cbc739d02745cc65b1d1b29fe7305586ebedcc74",
+				"DiscoKey":   "discokey:b6f21f3a778ac99ccb20c29eb65ee2bdaf0f8e8c3e1c9607858a197d65951f34",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58206",
+					"10.65.0.27:58206",
+					"172.17.0.1:58206",
+					"172.18.0.1:58206",
+					"172.19.0.1:58206"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:29:36.189469306Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8499490687800161,
+				"StableID":   "nEFfw3DSN921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10f6b20c5afcae12f831e8959a67472a7663e195f0eb65c792294695922a2613",
+				"DiscoKey":   "discokey:77b85fd9e9a0227ce074c82d47cb50269a146e4451b552f5035470675d43bc5e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:59317",
+					"10.65.0.27:59317",
+					"172.17.0.1:59317",
+					"172.18.0.1:59317",
+					"172.19.0.1:59317"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:29:36.751207445Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4104837855141772,
+				"StableID":   "nbNKuX864Z11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:538e8d925ac4162b3ab8a8e30adda987b07a2824ffa3a33fb2734e8478815874",
+				"DiscoKey":   "discokey:ca84eefd1cd14f8fe248ee9a2079a9dd3ba3a1639255e9ea6afbfec68e2c4372",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52720",
+					"10.65.0.27:52720",
+					"172.17.0.1:52720",
+					"172.18.0.1:52720",
+					"172.19.0.1:52720"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:29:37.275266956Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8552463539352528,
+				"StableID":   "nBLMSTiRn921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc3410d79a3df833abb3b9ec073e211f4e7b196f00bbbfc6e4a039526d753b15",
+				"DiscoKey":   "discokey:1c4109ee9e16ca173791ae4ee2a33044bdd1551b32963018f017d391252b0739",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:53819",
+					"10.65.0.27:53819",
+					"172.17.0.1:53819",
+					"172.18.0.1:53819",
+					"172.19.0.1:53819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:29:37.813723468Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8086496749270642,
+				"StableID":   "nZAupKZP9621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e471126c3e15583577178f0ed9f0429f46e971f5c65e584b964b03a6f939745",
+				"DiscoKey":   "discokey:9a45130468b7fd8ffe67c48b238aaa609eb8b31e715eb7b9a81b343e526db53e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37852",
+					"10.65.0.27:37852",
+					"172.17.0.1:37852",
+					"172.18.0.1:37852",
+					"172.19.0.1:37852"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:29:38.34164349Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4244822918924449,
+				"StableID":   "nYafdQJV9a11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:770ef7532cbe3abfa2c99938af53dc6b265e9be6a205d0790dc6ab89b36bd228",
+				"DiscoKey":   "discokey:0f2b1289d48f050abe627e1810cfe51b1bcea41570469c9818cf7ec96ce0f945",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35570",
+					"10.65.0.27:35570",
+					"172.17.0.1:35570",
+					"172.18.0.1:35570",
+					"172.19.0.1:35570"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:29:38.887805857Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5117919993759737,
+				"StableID":   "nGpaMd5vxg11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6fd070953b5603d7e03824fab99d058bdebe99e63a395366e68f0ef80a26950c",
+				"DiscoKey":   "discokey:1f29d3cb392af9b83fc86d1918a232d7d25da11337c52db87a592abe7ae4ee38",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58635",
+					"10.65.0.27:58635",
+					"172.17.0.1:58635",
+					"172.18.0.1:58635",
+					"172.19.0.1:58635"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:29:39.427304835Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8022370605821472,
+				"StableID":   "nq1u7C5Me521CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a7b6d8d3045bdb4161662580b81112373410f664f03bdf5e137c64589071cf3e",
+				"KeyExpiry":  "2026-11-09T07:29:40Z",
+				"DiscoKey":   "discokey:be1a28717bcc9157d3c568afae0f2de8e8c4323c99fa540907fd1c541dc97813",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40597",
+					"10.65.0.27:40597",
+					"172.17.0.1:40597",
+					"172.18.0.1:40597",
+					"172.19.0.1:40597"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:29:40.544985594Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1801875216653520,
+				"StableID":   "n7GWfyC55F11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bd9a6e56105d92842c32b9a6009072850d100375f7acd0b1b46c456b8d445369",
+				"KeyExpiry":  "2026-11-09T07:29:41Z",
+				"DiscoKey":   "discokey:3009d612c837523a78b19b7ffec196dbcc347c96f9b31580de848b43a65ed87f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49952",
+					"10.65.0.27:49952",
+					"172.17.0.1:49952",
+					"172.18.0.1:49952",
+					"172.19.0.1:49952"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:29:41.069067345Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1455722126108991,
+				"StableID":   "nkw5QQMJNC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:cc71889d9666696413bd095fe170bccb48d96c81df17cfe8e235875420aed702",
+				"KeyExpiry":  "2026-11-09T07:29:41Z",
+				"DiscoKey":   "discokey:d2187afe7ee06f5480713a8feaecc418a40a690ec8465421c885706e9fda6059",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50159",
+					"10.65.0.27:50159",
+					"172.17.0.1:50159",
+					"172.18.0.1:50159",
+					"172.19.0.1:50159"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:29:41.607585598Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "3992576385851876": {
+				"ID":          3992576385851876,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8499490687800161,
+				"StableID":   "nEFfw3DSN921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       8499490687800161,
+				"Key":        "nodekey:10f6b20c5afcae12f831e8959a67472a7663e195f0eb65c792294695922a2613",
+				"DiscoKey":   "discokey:77b85fd9e9a0227ce074c82d47cb50269a146e4451b552f5035470675d43bc5e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:59317",
+					"10.65.0.27:59317",
+					"172.17.0.1:59317",
+					"172.18.0.1:59317",
+					"172.19.0.1:59317"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:29:36.751207445Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:10f6b20c5afcae12f831e8959a67472a7663e195f0eb65c792294695922a2613",
+			"MachineKey": "mkey:4d593b34a800053018aef580ea97e244d75991d4bf91d30660daa85621938c39",
+			"Peers": [{
+				"ID":         3415573450443127,
+				"StableID":   "nEiZjiKvfT11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:645e0d46df8060d6e5ea506423a859112f80419e5cc84f9360c338d7fcd46279",
+				"DiscoKey":   "discokey:e914d339d0f442de4aaa77f7d79237965edf235901a211a666d2305875f8bb2a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50978",
+					"10.65.0.27:50978",
+					"172.17.0.1:50978",
+					"172.18.0.1:50978",
+					"172.19.0.1:50978"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:29:34.07947452Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6768834286965882,
+				"StableID":   "nFmz9Locru11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97446871666b03011c68cc252748ee8429e04ed9ded08ab0a20073b4535c4d3c",
+				"DiscoKey":   "discokey:07b754c22ca9e4a0bccb5db9af456c6d8c82ce21fa82d80fb6bcb17bfb056c16",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35460",
+					"10.65.0.27:35460",
+					"172.17.0.1:35460",
+					"172.18.0.1:35460",
+					"172.19.0.1:35460"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:29:34.562430123Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7975479763524383,
+				"StableID":   "nAWQx6L7H521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f66452092f25dfa5b179582795a5a82c04441eb2b1490028cd2e4fa7487f864d",
+				"DiscoKey":   "discokey:24ff006dc6c1cd36a3d831c503368076599c8982aadc33d3c419f399d7c0a228",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53502",
+					"10.65.0.27:53502",
+					"172.17.0.1:53502",
+					"172.18.0.1:53502",
+					"172.19.0.1:53502"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:29:35.115765782Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4907521742976237,
+				"StableID":   "ntrfQvGdKf11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c781b50d877b7bfb397cd97b3a5a379b98cfa39008d8ec08a2b055f6e7ba5b1a",
+				"DiscoKey":   "discokey:dee57ee9a4c835dfb46a1767d60de77d126e52c8d813224f1961996a1a635d54",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43761",
+					"10.65.0.27:43761",
+					"172.17.0.1:43761",
+					"172.18.0.1:43761",
+					"172.19.0.1:43761"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:29:35.649076609Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4234057264648330,
+				"StableID":   "nw3VdGWc4a11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:568f8b2b976a6bf3caa4da47cbc739d02745cc65b1d1b29fe7305586ebedcc74",
+				"DiscoKey":   "discokey:b6f21f3a778ac99ccb20c29eb65ee2bdaf0f8e8c3e1c9607858a197d65951f34",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58206",
+					"10.65.0.27:58206",
+					"172.17.0.1:58206",
+					"172.18.0.1:58206",
+					"172.19.0.1:58206"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:29:36.189469306Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4104837855141772,
+				"StableID":   "nbNKuX864Z11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:538e8d925ac4162b3ab8a8e30adda987b07a2824ffa3a33fb2734e8478815874",
+				"DiscoKey":   "discokey:ca84eefd1cd14f8fe248ee9a2079a9dd3ba3a1639255e9ea6afbfec68e2c4372",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52720",
+					"10.65.0.27:52720",
+					"172.17.0.1:52720",
+					"172.18.0.1:52720",
+					"172.19.0.1:52720"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:29:37.275266956Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8552463539352528,
+				"StableID":   "nBLMSTiRn921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc3410d79a3df833abb3b9ec073e211f4e7b196f00bbbfc6e4a039526d753b15",
+				"DiscoKey":   "discokey:1c4109ee9e16ca173791ae4ee2a33044bdd1551b32963018f017d391252b0739",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:53819",
+					"10.65.0.27:53819",
+					"172.17.0.1:53819",
+					"172.18.0.1:53819",
+					"172.19.0.1:53819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:29:37.813723468Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8086496749270642,
+				"StableID":   "nZAupKZP9621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e471126c3e15583577178f0ed9f0429f46e971f5c65e584b964b03a6f939745",
+				"DiscoKey":   "discokey:9a45130468b7fd8ffe67c48b238aaa609eb8b31e715eb7b9a81b343e526db53e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37852",
+					"10.65.0.27:37852",
+					"172.17.0.1:37852",
+					"172.18.0.1:37852",
+					"172.19.0.1:37852"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:29:38.34164349Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4244822918924449,
+				"StableID":   "nYafdQJV9a11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:770ef7532cbe3abfa2c99938af53dc6b265e9be6a205d0790dc6ab89b36bd228",
+				"DiscoKey":   "discokey:0f2b1289d48f050abe627e1810cfe51b1bcea41570469c9818cf7ec96ce0f945",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35570",
+					"10.65.0.27:35570",
+					"172.17.0.1:35570",
+					"172.18.0.1:35570",
+					"172.19.0.1:35570"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:29:38.887805857Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5117919993759737,
+				"StableID":   "nGpaMd5vxg11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6fd070953b5603d7e03824fab99d058bdebe99e63a395366e68f0ef80a26950c",
+				"DiscoKey":   "discokey:1f29d3cb392af9b83fc86d1918a232d7d25da11337c52db87a592abe7ae4ee38",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58635",
+					"10.65.0.27:58635",
+					"172.17.0.1:58635",
+					"172.18.0.1:58635",
+					"172.19.0.1:58635"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:29:39.427304835Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3992576385851876,
+				"StableID":   "nsLNHGDFBY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b25516bc05623bd81b54313fcb762a6e76d2187518eed34ee5a76047c56e017a",
+				"DiscoKey":   "discokey:85eaeca4890b27c4d1be87c7ffdebcba40736c8fbc971024b137f97a0ecd5f5b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49767",
+					"10.65.0.27:49767",
+					"172.17.0.1:49767",
+					"172.18.0.1:49767",
+					"172.19.0.1:49767"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:29:39.981269119Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8022370605821472,
+				"StableID":   "nq1u7C5Me521CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a7b6d8d3045bdb4161662580b81112373410f664f03bdf5e137c64589071cf3e",
+				"KeyExpiry":  "2026-11-09T07:29:40Z",
+				"DiscoKey":   "discokey:be1a28717bcc9157d3c568afae0f2de8e8c4323c99fa540907fd1c541dc97813",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40597",
+					"10.65.0.27:40597",
+					"172.17.0.1:40597",
+					"172.18.0.1:40597",
+					"172.19.0.1:40597"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:29:40.544985594Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1801875216653520,
+				"StableID":   "n7GWfyC55F11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bd9a6e56105d92842c32b9a6009072850d100375f7acd0b1b46c456b8d445369",
+				"KeyExpiry":  "2026-11-09T07:29:41Z",
+				"DiscoKey":   "discokey:3009d612c837523a78b19b7ffec196dbcc347c96f9b31580de848b43a65ed87f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49952",
+					"10.65.0.27:49952",
+					"172.17.0.1:49952",
+					"172.18.0.1:49952",
+					"172.19.0.1:49952"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:29:41.069067345Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1455722126108991,
+				"StableID":   "nkw5QQMJNC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:cc71889d9666696413bd095fe170bccb48d96c81df17cfe8e235875420aed702",
+				"KeyExpiry":  "2026-11-09T07:29:41Z",
+				"DiscoKey":   "discokey:d2187afe7ee06f5480713a8feaecc418a40a690ec8465421c885706e9fda6059",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50159",
+					"10.65.0.27:50159",
+					"172.17.0.1:50159",
+					"172.18.0.1:50159",
+					"172.19.0.1:50159"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:29:41.607585598Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8499490687800161": {
+				"ID":          8499490687800161,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1455722126108991,
+				"StableID":   "nkw5QQMJNC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:cc71889d9666696413bd095fe170bccb48d96c81df17cfe8e235875420aed702",
+				"KeyExpiry":  "2026-11-09T07:29:41Z",
+				"DiscoKey":   "discokey:d2187afe7ee06f5480713a8feaecc418a40a690ec8465421c885706e9fda6059",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50159",
+					"10.65.0.27:50159",
+					"172.17.0.1:50159",
+					"172.18.0.1:50159",
+					"172.19.0.1:50159"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:29:41.607585598Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:cc71889d9666696413bd095fe170bccb48d96c81df17cfe8e235875420aed702",
+			"MachineKey": "mkey:97287157fff9564d44c9d124d9f7ec1ef1454050ae457933e60689dde564027c",
+			"Peers": [{
+				"ID":         3415573450443127,
+				"StableID":   "nEiZjiKvfT11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:645e0d46df8060d6e5ea506423a859112f80419e5cc84f9360c338d7fcd46279",
+				"DiscoKey":   "discokey:e914d339d0f442de4aaa77f7d79237965edf235901a211a666d2305875f8bb2a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50978",
+					"10.65.0.27:50978",
+					"172.17.0.1:50978",
+					"172.18.0.1:50978",
+					"172.19.0.1:50978"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:29:34.07947452Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6768834286965882,
+				"StableID":   "nFmz9Locru11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97446871666b03011c68cc252748ee8429e04ed9ded08ab0a20073b4535c4d3c",
+				"DiscoKey":   "discokey:07b754c22ca9e4a0bccb5db9af456c6d8c82ce21fa82d80fb6bcb17bfb056c16",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35460",
+					"10.65.0.27:35460",
+					"172.17.0.1:35460",
+					"172.18.0.1:35460",
+					"172.19.0.1:35460"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:29:34.562430123Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7975479763524383,
+				"StableID":   "nAWQx6L7H521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f66452092f25dfa5b179582795a5a82c04441eb2b1490028cd2e4fa7487f864d",
+				"DiscoKey":   "discokey:24ff006dc6c1cd36a3d831c503368076599c8982aadc33d3c419f399d7c0a228",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53502",
+					"10.65.0.27:53502",
+					"172.17.0.1:53502",
+					"172.18.0.1:53502",
+					"172.19.0.1:53502"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:29:35.115765782Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4907521742976237,
+				"StableID":   "ntrfQvGdKf11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c781b50d877b7bfb397cd97b3a5a379b98cfa39008d8ec08a2b055f6e7ba5b1a",
+				"DiscoKey":   "discokey:dee57ee9a4c835dfb46a1767d60de77d126e52c8d813224f1961996a1a635d54",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43761",
+					"10.65.0.27:43761",
+					"172.17.0.1:43761",
+					"172.18.0.1:43761",
+					"172.19.0.1:43761"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:29:35.649076609Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4234057264648330,
+				"StableID":   "nw3VdGWc4a11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:568f8b2b976a6bf3caa4da47cbc739d02745cc65b1d1b29fe7305586ebedcc74",
+				"DiscoKey":   "discokey:b6f21f3a778ac99ccb20c29eb65ee2bdaf0f8e8c3e1c9607858a197d65951f34",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58206",
+					"10.65.0.27:58206",
+					"172.17.0.1:58206",
+					"172.18.0.1:58206",
+					"172.19.0.1:58206"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:29:36.189469306Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8499490687800161,
+				"StableID":   "nEFfw3DSN921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10f6b20c5afcae12f831e8959a67472a7663e195f0eb65c792294695922a2613",
+				"DiscoKey":   "discokey:77b85fd9e9a0227ce074c82d47cb50269a146e4451b552f5035470675d43bc5e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:59317",
+					"10.65.0.27:59317",
+					"172.17.0.1:59317",
+					"172.18.0.1:59317",
+					"172.19.0.1:59317"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:29:36.751207445Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4104837855141772,
+				"StableID":   "nbNKuX864Z11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:538e8d925ac4162b3ab8a8e30adda987b07a2824ffa3a33fb2734e8478815874",
+				"DiscoKey":   "discokey:ca84eefd1cd14f8fe248ee9a2079a9dd3ba3a1639255e9ea6afbfec68e2c4372",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52720",
+					"10.65.0.27:52720",
+					"172.17.0.1:52720",
+					"172.18.0.1:52720",
+					"172.19.0.1:52720"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:29:37.275266956Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8552463539352528,
+				"StableID":   "nBLMSTiRn921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc3410d79a3df833abb3b9ec073e211f4e7b196f00bbbfc6e4a039526d753b15",
+				"DiscoKey":   "discokey:1c4109ee9e16ca173791ae4ee2a33044bdd1551b32963018f017d391252b0739",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:53819",
+					"10.65.0.27:53819",
+					"172.17.0.1:53819",
+					"172.18.0.1:53819",
+					"172.19.0.1:53819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:29:37.813723468Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8086496749270642,
+				"StableID":   "nZAupKZP9621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e471126c3e15583577178f0ed9f0429f46e971f5c65e584b964b03a6f939745",
+				"DiscoKey":   "discokey:9a45130468b7fd8ffe67c48b238aaa609eb8b31e715eb7b9a81b343e526db53e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37852",
+					"10.65.0.27:37852",
+					"172.17.0.1:37852",
+					"172.18.0.1:37852",
+					"172.19.0.1:37852"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:29:38.34164349Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4244822918924449,
+				"StableID":   "nYafdQJV9a11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:770ef7532cbe3abfa2c99938af53dc6b265e9be6a205d0790dc6ab89b36bd228",
+				"DiscoKey":   "discokey:0f2b1289d48f050abe627e1810cfe51b1bcea41570469c9818cf7ec96ce0f945",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35570",
+					"10.65.0.27:35570",
+					"172.17.0.1:35570",
+					"172.18.0.1:35570",
+					"172.19.0.1:35570"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:29:38.887805857Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5117919993759737,
+				"StableID":   "nGpaMd5vxg11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6fd070953b5603d7e03824fab99d058bdebe99e63a395366e68f0ef80a26950c",
+				"DiscoKey":   "discokey:1f29d3cb392af9b83fc86d1918a232d7d25da11337c52db87a592abe7ae4ee38",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58635",
+					"10.65.0.27:58635",
+					"172.17.0.1:58635",
+					"172.18.0.1:58635",
+					"172.19.0.1:58635"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:29:39.427304835Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3992576385851876,
+				"StableID":   "nsLNHGDFBY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b25516bc05623bd81b54313fcb762a6e76d2187518eed34ee5a76047c56e017a",
+				"DiscoKey":   "discokey:85eaeca4890b27c4d1be87c7ffdebcba40736c8fbc971024b137f97a0ecd5f5b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49767",
+					"10.65.0.27:49767",
+					"172.17.0.1:49767",
+					"172.18.0.1:49767",
+					"172.19.0.1:49767"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:29:39.981269119Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8022370605821472,
+				"StableID":   "nq1u7C5Me521CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a7b6d8d3045bdb4161662580b81112373410f664f03bdf5e137c64589071cf3e",
+				"KeyExpiry":  "2026-11-09T07:29:40Z",
+				"DiscoKey":   "discokey:be1a28717bcc9157d3c568afae0f2de8e8c4323c99fa540907fd1c541dc97813",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40597",
+					"10.65.0.27:40597",
+					"172.17.0.1:40597",
+					"172.18.0.1:40597",
+					"172.19.0.1:40597"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:29:40.544985594Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1801875216653520,
+				"StableID":   "n7GWfyC55F11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bd9a6e56105d92842c32b9a6009072850d100375f7acd0b1b46c456b8d445369",
+				"KeyExpiry":  "2026-11-09T07:29:41Z",
+				"DiscoKey":   "discokey:3009d612c837523a78b19b7ffec196dbcc347c96f9b31580de848b43a65ed87f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49952",
+					"10.65.0.27:49952",
+					"172.17.0.1:49952",
+					"172.18.0.1:49952",
+					"172.19.0.1:49952"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:29:41.069067345Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7975479763524383,
+				"StableID":   "nAWQx6L7H521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       7975479763524383,
+				"Key":        "nodekey:f66452092f25dfa5b179582795a5a82c04441eb2b1490028cd2e4fa7487f864d",
+				"DiscoKey":   "discokey:24ff006dc6c1cd36a3d831c503368076599c8982aadc33d3c419f399d7c0a228",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53502",
+					"10.65.0.27:53502",
+					"172.17.0.1:53502",
+					"172.18.0.1:53502",
+					"172.19.0.1:53502"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:29:35.115765782Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f66452092f25dfa5b179582795a5a82c04441eb2b1490028cd2e4fa7487f864d",
+			"MachineKey": "mkey:2c090623ad49a7658a45151dcf2bc6604bc15d859f046d8f1fc9606fefb01126",
+			"Peers": [{
+				"ID":         3415573450443127,
+				"StableID":   "nEiZjiKvfT11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:645e0d46df8060d6e5ea506423a859112f80419e5cc84f9360c338d7fcd46279",
+				"DiscoKey":   "discokey:e914d339d0f442de4aaa77f7d79237965edf235901a211a666d2305875f8bb2a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50978",
+					"10.65.0.27:50978",
+					"172.17.0.1:50978",
+					"172.18.0.1:50978",
+					"172.19.0.1:50978"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:29:34.07947452Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6768834286965882,
+				"StableID":   "nFmz9Locru11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97446871666b03011c68cc252748ee8429e04ed9ded08ab0a20073b4535c4d3c",
+				"DiscoKey":   "discokey:07b754c22ca9e4a0bccb5db9af456c6d8c82ce21fa82d80fb6bcb17bfb056c16",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35460",
+					"10.65.0.27:35460",
+					"172.17.0.1:35460",
+					"172.18.0.1:35460",
+					"172.19.0.1:35460"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:29:34.562430123Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4907521742976237,
+				"StableID":   "ntrfQvGdKf11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c781b50d877b7bfb397cd97b3a5a379b98cfa39008d8ec08a2b055f6e7ba5b1a",
+				"DiscoKey":   "discokey:dee57ee9a4c835dfb46a1767d60de77d126e52c8d813224f1961996a1a635d54",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43761",
+					"10.65.0.27:43761",
+					"172.17.0.1:43761",
+					"172.18.0.1:43761",
+					"172.19.0.1:43761"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:29:35.649076609Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4234057264648330,
+				"StableID":   "nw3VdGWc4a11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:568f8b2b976a6bf3caa4da47cbc739d02745cc65b1d1b29fe7305586ebedcc74",
+				"DiscoKey":   "discokey:b6f21f3a778ac99ccb20c29eb65ee2bdaf0f8e8c3e1c9607858a197d65951f34",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58206",
+					"10.65.0.27:58206",
+					"172.17.0.1:58206",
+					"172.18.0.1:58206",
+					"172.19.0.1:58206"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:29:36.189469306Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8499490687800161,
+				"StableID":   "nEFfw3DSN921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10f6b20c5afcae12f831e8959a67472a7663e195f0eb65c792294695922a2613",
+				"DiscoKey":   "discokey:77b85fd9e9a0227ce074c82d47cb50269a146e4451b552f5035470675d43bc5e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:59317",
+					"10.65.0.27:59317",
+					"172.17.0.1:59317",
+					"172.18.0.1:59317",
+					"172.19.0.1:59317"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:29:36.751207445Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4104837855141772,
+				"StableID":   "nbNKuX864Z11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:538e8d925ac4162b3ab8a8e30adda987b07a2824ffa3a33fb2734e8478815874",
+				"DiscoKey":   "discokey:ca84eefd1cd14f8fe248ee9a2079a9dd3ba3a1639255e9ea6afbfec68e2c4372",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52720",
+					"10.65.0.27:52720",
+					"172.17.0.1:52720",
+					"172.18.0.1:52720",
+					"172.19.0.1:52720"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:29:37.275266956Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8552463539352528,
+				"StableID":   "nBLMSTiRn921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc3410d79a3df833abb3b9ec073e211f4e7b196f00bbbfc6e4a039526d753b15",
+				"DiscoKey":   "discokey:1c4109ee9e16ca173791ae4ee2a33044bdd1551b32963018f017d391252b0739",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:53819",
+					"10.65.0.27:53819",
+					"172.17.0.1:53819",
+					"172.18.0.1:53819",
+					"172.19.0.1:53819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:29:37.813723468Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8086496749270642,
+				"StableID":   "nZAupKZP9621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e471126c3e15583577178f0ed9f0429f46e971f5c65e584b964b03a6f939745",
+				"DiscoKey":   "discokey:9a45130468b7fd8ffe67c48b238aaa609eb8b31e715eb7b9a81b343e526db53e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37852",
+					"10.65.0.27:37852",
+					"172.17.0.1:37852",
+					"172.18.0.1:37852",
+					"172.19.0.1:37852"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:29:38.34164349Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4244822918924449,
+				"StableID":   "nYafdQJV9a11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:770ef7532cbe3abfa2c99938af53dc6b265e9be6a205d0790dc6ab89b36bd228",
+				"DiscoKey":   "discokey:0f2b1289d48f050abe627e1810cfe51b1bcea41570469c9818cf7ec96ce0f945",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35570",
+					"10.65.0.27:35570",
+					"172.17.0.1:35570",
+					"172.18.0.1:35570",
+					"172.19.0.1:35570"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:29:38.887805857Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5117919993759737,
+				"StableID":   "nGpaMd5vxg11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6fd070953b5603d7e03824fab99d058bdebe99e63a395366e68f0ef80a26950c",
+				"DiscoKey":   "discokey:1f29d3cb392af9b83fc86d1918a232d7d25da11337c52db87a592abe7ae4ee38",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58635",
+					"10.65.0.27:58635",
+					"172.17.0.1:58635",
+					"172.18.0.1:58635",
+					"172.19.0.1:58635"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:29:39.427304835Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3992576385851876,
+				"StableID":   "nsLNHGDFBY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b25516bc05623bd81b54313fcb762a6e76d2187518eed34ee5a76047c56e017a",
+				"DiscoKey":   "discokey:85eaeca4890b27c4d1be87c7ffdebcba40736c8fbc971024b137f97a0ecd5f5b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49767",
+					"10.65.0.27:49767",
+					"172.17.0.1:49767",
+					"172.18.0.1:49767",
+					"172.19.0.1:49767"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:29:39.981269119Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8022370605821472,
+				"StableID":   "nq1u7C5Me521CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a7b6d8d3045bdb4161662580b81112373410f664f03bdf5e137c64589071cf3e",
+				"KeyExpiry":  "2026-11-09T07:29:40Z",
+				"DiscoKey":   "discokey:be1a28717bcc9157d3c568afae0f2de8e8c4323c99fa540907fd1c541dc97813",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40597",
+					"10.65.0.27:40597",
+					"172.17.0.1:40597",
+					"172.18.0.1:40597",
+					"172.19.0.1:40597"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:29:40.544985594Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1801875216653520,
+				"StableID":   "n7GWfyC55F11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bd9a6e56105d92842c32b9a6009072850d100375f7acd0b1b46c456b8d445369",
+				"KeyExpiry":  "2026-11-09T07:29:41Z",
+				"DiscoKey":   "discokey:3009d612c837523a78b19b7ffec196dbcc347c96f9b31580de848b43a65ed87f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49952",
+					"10.65.0.27:49952",
+					"172.17.0.1:49952",
+					"172.18.0.1:49952",
+					"172.19.0.1:49952"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:29:41.069067345Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1455722126108991,
+				"StableID":   "nkw5QQMJNC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:cc71889d9666696413bd095fe170bccb48d96c81df17cfe8e235875420aed702",
+				"KeyExpiry":  "2026-11-09T07:29:41Z",
+				"DiscoKey":   "discokey:d2187afe7ee06f5480713a8feaecc418a40a690ec8465421c885706e9fda6059",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50159",
+					"10.65.0.27:50159",
+					"172.17.0.1:50159",
+					"172.18.0.1:50159",
+					"172.19.0.1:50159"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:29:41.607585598Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7975479763524383": {
+				"ID":          7975479763524383,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8552463539352528,
+				"StableID":   "nBLMSTiRn921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       8552463539352528,
+				"Key":        "nodekey:cc3410d79a3df833abb3b9ec073e211f4e7b196f00bbbfc6e4a039526d753b15",
+				"DiscoKey":   "discokey:1c4109ee9e16ca173791ae4ee2a33044bdd1551b32963018f017d391252b0739",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:53819",
+					"10.65.0.27:53819",
+					"172.17.0.1:53819",
+					"172.18.0.1:53819",
+					"172.19.0.1:53819"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:29:37.813723468Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:cc3410d79a3df833abb3b9ec073e211f4e7b196f00bbbfc6e4a039526d753b15",
+			"MachineKey": "mkey:ef5ae25d172a88eb8338027b2034af1d88030ab48a186e612de7655128b4b921",
+			"Peers": [{
+				"ID":         3415573450443127,
+				"StableID":   "nEiZjiKvfT11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:645e0d46df8060d6e5ea506423a859112f80419e5cc84f9360c338d7fcd46279",
+				"DiscoKey":   "discokey:e914d339d0f442de4aaa77f7d79237965edf235901a211a666d2305875f8bb2a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50978",
+					"10.65.0.27:50978",
+					"172.17.0.1:50978",
+					"172.18.0.1:50978",
+					"172.19.0.1:50978"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:29:34.07947452Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6768834286965882,
+				"StableID":   "nFmz9Locru11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97446871666b03011c68cc252748ee8429e04ed9ded08ab0a20073b4535c4d3c",
+				"DiscoKey":   "discokey:07b754c22ca9e4a0bccb5db9af456c6d8c82ce21fa82d80fb6bcb17bfb056c16",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35460",
+					"10.65.0.27:35460",
+					"172.17.0.1:35460",
+					"172.18.0.1:35460",
+					"172.19.0.1:35460"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:29:34.562430123Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7975479763524383,
+				"StableID":   "nAWQx6L7H521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f66452092f25dfa5b179582795a5a82c04441eb2b1490028cd2e4fa7487f864d",
+				"DiscoKey":   "discokey:24ff006dc6c1cd36a3d831c503368076599c8982aadc33d3c419f399d7c0a228",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53502",
+					"10.65.0.27:53502",
+					"172.17.0.1:53502",
+					"172.18.0.1:53502",
+					"172.19.0.1:53502"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:29:35.115765782Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4907521742976237,
+				"StableID":   "ntrfQvGdKf11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c781b50d877b7bfb397cd97b3a5a379b98cfa39008d8ec08a2b055f6e7ba5b1a",
+				"DiscoKey":   "discokey:dee57ee9a4c835dfb46a1767d60de77d126e52c8d813224f1961996a1a635d54",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43761",
+					"10.65.0.27:43761",
+					"172.17.0.1:43761",
+					"172.18.0.1:43761",
+					"172.19.0.1:43761"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:29:35.649076609Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4234057264648330,
+				"StableID":   "nw3VdGWc4a11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:568f8b2b976a6bf3caa4da47cbc739d02745cc65b1d1b29fe7305586ebedcc74",
+				"DiscoKey":   "discokey:b6f21f3a778ac99ccb20c29eb65ee2bdaf0f8e8c3e1c9607858a197d65951f34",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58206",
+					"10.65.0.27:58206",
+					"172.17.0.1:58206",
+					"172.18.0.1:58206",
+					"172.19.0.1:58206"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:29:36.189469306Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8499490687800161,
+				"StableID":   "nEFfw3DSN921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10f6b20c5afcae12f831e8959a67472a7663e195f0eb65c792294695922a2613",
+				"DiscoKey":   "discokey:77b85fd9e9a0227ce074c82d47cb50269a146e4451b552f5035470675d43bc5e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:59317",
+					"10.65.0.27:59317",
+					"172.17.0.1:59317",
+					"172.18.0.1:59317",
+					"172.19.0.1:59317"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:29:36.751207445Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4104837855141772,
+				"StableID":   "nbNKuX864Z11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:538e8d925ac4162b3ab8a8e30adda987b07a2824ffa3a33fb2734e8478815874",
+				"DiscoKey":   "discokey:ca84eefd1cd14f8fe248ee9a2079a9dd3ba3a1639255e9ea6afbfec68e2c4372",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52720",
+					"10.65.0.27:52720",
+					"172.17.0.1:52720",
+					"172.18.0.1:52720",
+					"172.19.0.1:52720"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:29:37.275266956Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8086496749270642,
+				"StableID":   "nZAupKZP9621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e471126c3e15583577178f0ed9f0429f46e971f5c65e584b964b03a6f939745",
+				"DiscoKey":   "discokey:9a45130468b7fd8ffe67c48b238aaa609eb8b31e715eb7b9a81b343e526db53e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37852",
+					"10.65.0.27:37852",
+					"172.17.0.1:37852",
+					"172.18.0.1:37852",
+					"172.19.0.1:37852"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:29:38.34164349Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4244822918924449,
+				"StableID":   "nYafdQJV9a11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:770ef7532cbe3abfa2c99938af53dc6b265e9be6a205d0790dc6ab89b36bd228",
+				"DiscoKey":   "discokey:0f2b1289d48f050abe627e1810cfe51b1bcea41570469c9818cf7ec96ce0f945",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35570",
+					"10.65.0.27:35570",
+					"172.17.0.1:35570",
+					"172.18.0.1:35570",
+					"172.19.0.1:35570"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:29:38.887805857Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5117919993759737,
+				"StableID":   "nGpaMd5vxg11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6fd070953b5603d7e03824fab99d058bdebe99e63a395366e68f0ef80a26950c",
+				"DiscoKey":   "discokey:1f29d3cb392af9b83fc86d1918a232d7d25da11337c52db87a592abe7ae4ee38",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58635",
+					"10.65.0.27:58635",
+					"172.17.0.1:58635",
+					"172.18.0.1:58635",
+					"172.19.0.1:58635"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:29:39.427304835Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3992576385851876,
+				"StableID":   "nsLNHGDFBY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b25516bc05623bd81b54313fcb762a6e76d2187518eed34ee5a76047c56e017a",
+				"DiscoKey":   "discokey:85eaeca4890b27c4d1be87c7ffdebcba40736c8fbc971024b137f97a0ecd5f5b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49767",
+					"10.65.0.27:49767",
+					"172.17.0.1:49767",
+					"172.18.0.1:49767",
+					"172.19.0.1:49767"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:29:39.981269119Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8022370605821472,
+				"StableID":   "nq1u7C5Me521CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a7b6d8d3045bdb4161662580b81112373410f664f03bdf5e137c64589071cf3e",
+				"KeyExpiry":  "2026-11-09T07:29:40Z",
+				"DiscoKey":   "discokey:be1a28717bcc9157d3c568afae0f2de8e8c4323c99fa540907fd1c541dc97813",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40597",
+					"10.65.0.27:40597",
+					"172.17.0.1:40597",
+					"172.18.0.1:40597",
+					"172.19.0.1:40597"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:29:40.544985594Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1801875216653520,
+				"StableID":   "n7GWfyC55F11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bd9a6e56105d92842c32b9a6009072850d100375f7acd0b1b46c456b8d445369",
+				"KeyExpiry":  "2026-11-09T07:29:41Z",
+				"DiscoKey":   "discokey:3009d612c837523a78b19b7ffec196dbcc347c96f9b31580de848b43a65ed87f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49952",
+					"10.65.0.27:49952",
+					"172.17.0.1:49952",
+					"172.18.0.1:49952",
+					"172.19.0.1:49952"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:29:41.069067345Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1455722126108991,
+				"StableID":   "nkw5QQMJNC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:cc71889d9666696413bd095fe170bccb48d96c81df17cfe8e235875420aed702",
+				"KeyExpiry":  "2026-11-09T07:29:41Z",
+				"DiscoKey":   "discokey:d2187afe7ee06f5480713a8feaecc418a40a690ec8465421c885706e9fda6059",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50159",
+					"10.65.0.27:50159",
+					"172.17.0.1:50159",
+					"172.18.0.1:50159",
+					"172.19.0.1:50159"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:29:41.607585598Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8552463539352528": {
+				"ID":          8552463539352528,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8022370605821472,
+				"StableID":   "nq1u7C5Me521CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a7b6d8d3045bdb4161662580b81112373410f664f03bdf5e137c64589071cf3e",
+				"KeyExpiry":  "2026-11-09T07:29:40Z",
+				"DiscoKey":   "discokey:be1a28717bcc9157d3c568afae0f2de8e8c4323c99fa540907fd1c541dc97813",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40597",
+					"10.65.0.27:40597",
+					"172.17.0.1:40597",
+					"172.18.0.1:40597",
+					"172.19.0.1:40597"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:29:40.544985594Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a7b6d8d3045bdb4161662580b81112373410f664f03bdf5e137c64589071cf3e",
+			"MachineKey": "mkey:da8cd00884cfdbfd54e628b7b843a7ae9e375bf2635617b7e8c908290303e45d",
+			"Peers": [{
+				"ID":         3415573450443127,
+				"StableID":   "nEiZjiKvfT11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:645e0d46df8060d6e5ea506423a859112f80419e5cc84f9360c338d7fcd46279",
+				"DiscoKey":   "discokey:e914d339d0f442de4aaa77f7d79237965edf235901a211a666d2305875f8bb2a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50978",
+					"10.65.0.27:50978",
+					"172.17.0.1:50978",
+					"172.18.0.1:50978",
+					"172.19.0.1:50978"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:29:34.07947452Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6768834286965882,
+				"StableID":   "nFmz9Locru11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97446871666b03011c68cc252748ee8429e04ed9ded08ab0a20073b4535c4d3c",
+				"DiscoKey":   "discokey:07b754c22ca9e4a0bccb5db9af456c6d8c82ce21fa82d80fb6bcb17bfb056c16",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35460",
+					"10.65.0.27:35460",
+					"172.17.0.1:35460",
+					"172.18.0.1:35460",
+					"172.19.0.1:35460"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:29:34.562430123Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7975479763524383,
+				"StableID":   "nAWQx6L7H521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f66452092f25dfa5b179582795a5a82c04441eb2b1490028cd2e4fa7487f864d",
+				"DiscoKey":   "discokey:24ff006dc6c1cd36a3d831c503368076599c8982aadc33d3c419f399d7c0a228",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53502",
+					"10.65.0.27:53502",
+					"172.17.0.1:53502",
+					"172.18.0.1:53502",
+					"172.19.0.1:53502"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:29:35.115765782Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4907521742976237,
+				"StableID":   "ntrfQvGdKf11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c781b50d877b7bfb397cd97b3a5a379b98cfa39008d8ec08a2b055f6e7ba5b1a",
+				"DiscoKey":   "discokey:dee57ee9a4c835dfb46a1767d60de77d126e52c8d813224f1961996a1a635d54",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43761",
+					"10.65.0.27:43761",
+					"172.17.0.1:43761",
+					"172.18.0.1:43761",
+					"172.19.0.1:43761"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:29:35.649076609Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4234057264648330,
+				"StableID":   "nw3VdGWc4a11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:568f8b2b976a6bf3caa4da47cbc739d02745cc65b1d1b29fe7305586ebedcc74",
+				"DiscoKey":   "discokey:b6f21f3a778ac99ccb20c29eb65ee2bdaf0f8e8c3e1c9607858a197d65951f34",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58206",
+					"10.65.0.27:58206",
+					"172.17.0.1:58206",
+					"172.18.0.1:58206",
+					"172.19.0.1:58206"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:29:36.189469306Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8499490687800161,
+				"StableID":   "nEFfw3DSN921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10f6b20c5afcae12f831e8959a67472a7663e195f0eb65c792294695922a2613",
+				"DiscoKey":   "discokey:77b85fd9e9a0227ce074c82d47cb50269a146e4451b552f5035470675d43bc5e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:59317",
+					"10.65.0.27:59317",
+					"172.17.0.1:59317",
+					"172.18.0.1:59317",
+					"172.19.0.1:59317"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:29:36.751207445Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4104837855141772,
+				"StableID":   "nbNKuX864Z11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:538e8d925ac4162b3ab8a8e30adda987b07a2824ffa3a33fb2734e8478815874",
+				"DiscoKey":   "discokey:ca84eefd1cd14f8fe248ee9a2079a9dd3ba3a1639255e9ea6afbfec68e2c4372",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52720",
+					"10.65.0.27:52720",
+					"172.17.0.1:52720",
+					"172.18.0.1:52720",
+					"172.19.0.1:52720"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:29:37.275266956Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8552463539352528,
+				"StableID":   "nBLMSTiRn921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc3410d79a3df833abb3b9ec073e211f4e7b196f00bbbfc6e4a039526d753b15",
+				"DiscoKey":   "discokey:1c4109ee9e16ca173791ae4ee2a33044bdd1551b32963018f017d391252b0739",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:53819",
+					"10.65.0.27:53819",
+					"172.17.0.1:53819",
+					"172.18.0.1:53819",
+					"172.19.0.1:53819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:29:37.813723468Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8086496749270642,
+				"StableID":   "nZAupKZP9621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e471126c3e15583577178f0ed9f0429f46e971f5c65e584b964b03a6f939745",
+				"DiscoKey":   "discokey:9a45130468b7fd8ffe67c48b238aaa609eb8b31e715eb7b9a81b343e526db53e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37852",
+					"10.65.0.27:37852",
+					"172.17.0.1:37852",
+					"172.18.0.1:37852",
+					"172.19.0.1:37852"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:29:38.34164349Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4244822918924449,
+				"StableID":   "nYafdQJV9a11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:770ef7532cbe3abfa2c99938af53dc6b265e9be6a205d0790dc6ab89b36bd228",
+				"DiscoKey":   "discokey:0f2b1289d48f050abe627e1810cfe51b1bcea41570469c9818cf7ec96ce0f945",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35570",
+					"10.65.0.27:35570",
+					"172.17.0.1:35570",
+					"172.18.0.1:35570",
+					"172.19.0.1:35570"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:29:38.887805857Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5117919993759737,
+				"StableID":   "nGpaMd5vxg11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6fd070953b5603d7e03824fab99d058bdebe99e63a395366e68f0ef80a26950c",
+				"DiscoKey":   "discokey:1f29d3cb392af9b83fc86d1918a232d7d25da11337c52db87a592abe7ae4ee38",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58635",
+					"10.65.0.27:58635",
+					"172.17.0.1:58635",
+					"172.18.0.1:58635",
+					"172.19.0.1:58635"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:29:39.427304835Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3992576385851876,
+				"StableID":   "nsLNHGDFBY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b25516bc05623bd81b54313fcb762a6e76d2187518eed34ee5a76047c56e017a",
+				"DiscoKey":   "discokey:85eaeca4890b27c4d1be87c7ffdebcba40736c8fbc971024b137f97a0ecd5f5b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49767",
+					"10.65.0.27:49767",
+					"172.17.0.1:49767",
+					"172.18.0.1:49767",
+					"172.19.0.1:49767"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:29:39.981269119Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1801875216653520,
+				"StableID":   "n7GWfyC55F11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bd9a6e56105d92842c32b9a6009072850d100375f7acd0b1b46c456b8d445369",
+				"KeyExpiry":  "2026-11-09T07:29:41Z",
+				"DiscoKey":   "discokey:3009d612c837523a78b19b7ffec196dbcc347c96f9b31580de848b43a65ed87f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49952",
+					"10.65.0.27:49952",
+					"172.17.0.1:49952",
+					"172.18.0.1:49952",
+					"172.19.0.1:49952"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:29:41.069067345Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1455722126108991,
+				"StableID":   "nkw5QQMJNC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:cc71889d9666696413bd095fe170bccb48d96c81df17cfe8e235875420aed702",
+				"KeyExpiry":  "2026-11-09T07:29:41Z",
+				"DiscoKey":   "discokey:d2187afe7ee06f5480713a8feaecc418a40a690ec8465421c885706e9fda6059",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50159",
+					"10.65.0.27:50159",
+					"172.17.0.1:50159",
+					"172.18.0.1:50159",
+					"172.19.0.1:50159"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:29:41.607585598Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5117919993759737,
+				"StableID":   "nGpaMd5vxg11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       5117919993759737,
+				"Key":        "nodekey:6fd070953b5603d7e03824fab99d058bdebe99e63a395366e68f0ef80a26950c",
+				"DiscoKey":   "discokey:1f29d3cb392af9b83fc86d1918a232d7d25da11337c52db87a592abe7ae4ee38",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58635",
+					"10.65.0.27:58635",
+					"172.17.0.1:58635",
+					"172.18.0.1:58635",
+					"172.19.0.1:58635"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:29:39.427304835Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6fd070953b5603d7e03824fab99d058bdebe99e63a395366e68f0ef80a26950c",
+			"MachineKey": "mkey:4f5e1a9d5eadc011ab05fa763d7109517f1184e0d7362ace5610791491e2ea2a",
+			"Peers": [{
+				"ID":         3415573450443127,
+				"StableID":   "nEiZjiKvfT11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:645e0d46df8060d6e5ea506423a859112f80419e5cc84f9360c338d7fcd46279",
+				"DiscoKey":   "discokey:e914d339d0f442de4aaa77f7d79237965edf235901a211a666d2305875f8bb2a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50978",
+					"10.65.0.27:50978",
+					"172.17.0.1:50978",
+					"172.18.0.1:50978",
+					"172.19.0.1:50978"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:29:34.07947452Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6768834286965882,
+				"StableID":   "nFmz9Locru11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97446871666b03011c68cc252748ee8429e04ed9ded08ab0a20073b4535c4d3c",
+				"DiscoKey":   "discokey:07b754c22ca9e4a0bccb5db9af456c6d8c82ce21fa82d80fb6bcb17bfb056c16",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35460",
+					"10.65.0.27:35460",
+					"172.17.0.1:35460",
+					"172.18.0.1:35460",
+					"172.19.0.1:35460"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:29:34.562430123Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7975479763524383,
+				"StableID":   "nAWQx6L7H521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f66452092f25dfa5b179582795a5a82c04441eb2b1490028cd2e4fa7487f864d",
+				"DiscoKey":   "discokey:24ff006dc6c1cd36a3d831c503368076599c8982aadc33d3c419f399d7c0a228",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53502",
+					"10.65.0.27:53502",
+					"172.17.0.1:53502",
+					"172.18.0.1:53502",
+					"172.19.0.1:53502"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:29:35.115765782Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4907521742976237,
+				"StableID":   "ntrfQvGdKf11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c781b50d877b7bfb397cd97b3a5a379b98cfa39008d8ec08a2b055f6e7ba5b1a",
+				"DiscoKey":   "discokey:dee57ee9a4c835dfb46a1767d60de77d126e52c8d813224f1961996a1a635d54",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43761",
+					"10.65.0.27:43761",
+					"172.17.0.1:43761",
+					"172.18.0.1:43761",
+					"172.19.0.1:43761"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:29:35.649076609Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4234057264648330,
+				"StableID":   "nw3VdGWc4a11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:568f8b2b976a6bf3caa4da47cbc739d02745cc65b1d1b29fe7305586ebedcc74",
+				"DiscoKey":   "discokey:b6f21f3a778ac99ccb20c29eb65ee2bdaf0f8e8c3e1c9607858a197d65951f34",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58206",
+					"10.65.0.27:58206",
+					"172.17.0.1:58206",
+					"172.18.0.1:58206",
+					"172.19.0.1:58206"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:29:36.189469306Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8499490687800161,
+				"StableID":   "nEFfw3DSN921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10f6b20c5afcae12f831e8959a67472a7663e195f0eb65c792294695922a2613",
+				"DiscoKey":   "discokey:77b85fd9e9a0227ce074c82d47cb50269a146e4451b552f5035470675d43bc5e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:59317",
+					"10.65.0.27:59317",
+					"172.17.0.1:59317",
+					"172.18.0.1:59317",
+					"172.19.0.1:59317"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:29:36.751207445Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4104837855141772,
+				"StableID":   "nbNKuX864Z11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:538e8d925ac4162b3ab8a8e30adda987b07a2824ffa3a33fb2734e8478815874",
+				"DiscoKey":   "discokey:ca84eefd1cd14f8fe248ee9a2079a9dd3ba3a1639255e9ea6afbfec68e2c4372",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52720",
+					"10.65.0.27:52720",
+					"172.17.0.1:52720",
+					"172.18.0.1:52720",
+					"172.19.0.1:52720"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:29:37.275266956Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8552463539352528,
+				"StableID":   "nBLMSTiRn921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc3410d79a3df833abb3b9ec073e211f4e7b196f00bbbfc6e4a039526d753b15",
+				"DiscoKey":   "discokey:1c4109ee9e16ca173791ae4ee2a33044bdd1551b32963018f017d391252b0739",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:53819",
+					"10.65.0.27:53819",
+					"172.17.0.1:53819",
+					"172.18.0.1:53819",
+					"172.19.0.1:53819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:29:37.813723468Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8086496749270642,
+				"StableID":   "nZAupKZP9621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e471126c3e15583577178f0ed9f0429f46e971f5c65e584b964b03a6f939745",
+				"DiscoKey":   "discokey:9a45130468b7fd8ffe67c48b238aaa609eb8b31e715eb7b9a81b343e526db53e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37852",
+					"10.65.0.27:37852",
+					"172.17.0.1:37852",
+					"172.18.0.1:37852",
+					"172.19.0.1:37852"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:29:38.34164349Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4244822918924449,
+				"StableID":   "nYafdQJV9a11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:770ef7532cbe3abfa2c99938af53dc6b265e9be6a205d0790dc6ab89b36bd228",
+				"DiscoKey":   "discokey:0f2b1289d48f050abe627e1810cfe51b1bcea41570469c9818cf7ec96ce0f945",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35570",
+					"10.65.0.27:35570",
+					"172.17.0.1:35570",
+					"172.18.0.1:35570",
+					"172.19.0.1:35570"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:29:38.887805857Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3992576385851876,
+				"StableID":   "nsLNHGDFBY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b25516bc05623bd81b54313fcb762a6e76d2187518eed34ee5a76047c56e017a",
+				"DiscoKey":   "discokey:85eaeca4890b27c4d1be87c7ffdebcba40736c8fbc971024b137f97a0ecd5f5b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49767",
+					"10.65.0.27:49767",
+					"172.17.0.1:49767",
+					"172.18.0.1:49767",
+					"172.19.0.1:49767"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:29:39.981269119Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8022370605821472,
+				"StableID":   "nq1u7C5Me521CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a7b6d8d3045bdb4161662580b81112373410f664f03bdf5e137c64589071cf3e",
+				"KeyExpiry":  "2026-11-09T07:29:40Z",
+				"DiscoKey":   "discokey:be1a28717bcc9157d3c568afae0f2de8e8c4323c99fa540907fd1c541dc97813",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40597",
+					"10.65.0.27:40597",
+					"172.17.0.1:40597",
+					"172.18.0.1:40597",
+					"172.19.0.1:40597"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:29:40.544985594Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1801875216653520,
+				"StableID":   "n7GWfyC55F11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bd9a6e56105d92842c32b9a6009072850d100375f7acd0b1b46c456b8d445369",
+				"KeyExpiry":  "2026-11-09T07:29:41Z",
+				"DiscoKey":   "discokey:3009d612c837523a78b19b7ffec196dbcc347c96f9b31580de848b43a65ed87f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49952",
+					"10.65.0.27:49952",
+					"172.17.0.1:49952",
+					"172.18.0.1:49952",
+					"172.19.0.1:49952"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:29:41.069067345Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1455722126108991,
+				"StableID":   "nkw5QQMJNC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:cc71889d9666696413bd095fe170bccb48d96c81df17cfe8e235875420aed702",
+				"KeyExpiry":  "2026-11-09T07:29:41Z",
+				"DiscoKey":   "discokey:d2187afe7ee06f5480713a8feaecc418a40a690ec8465421c885706e9fda6059",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50159",
+					"10.65.0.27:50159",
+					"172.17.0.1:50159",
+					"172.18.0.1:50159",
+					"172.19.0.1:50159"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:29:41.607585598Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5117919993759737": {
+				"ID":          5117919993759737,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6768834286965882,
+				"StableID":   "nFmz9Locru11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       6768834286965882,
+				"Key":        "nodekey:97446871666b03011c68cc252748ee8429e04ed9ded08ab0a20073b4535c4d3c",
+				"DiscoKey":   "discokey:07b754c22ca9e4a0bccb5db9af456c6d8c82ce21fa82d80fb6bcb17bfb056c16",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35460",
+					"10.65.0.27:35460",
+					"172.17.0.1:35460",
+					"172.18.0.1:35460",
+					"172.19.0.1:35460"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:29:34.562430123Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:97446871666b03011c68cc252748ee8429e04ed9ded08ab0a20073b4535c4d3c",
+			"MachineKey": "mkey:dbf94c70b58394c63a2e94ad1b52dddb3742e2b37b50831cb0950040d233253e",
+			"Peers": [{
+				"ID":         3415573450443127,
+				"StableID":   "nEiZjiKvfT11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:645e0d46df8060d6e5ea506423a859112f80419e5cc84f9360c338d7fcd46279",
+				"DiscoKey":   "discokey:e914d339d0f442de4aaa77f7d79237965edf235901a211a666d2305875f8bb2a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50978",
+					"10.65.0.27:50978",
+					"172.17.0.1:50978",
+					"172.18.0.1:50978",
+					"172.19.0.1:50978"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:29:34.07947452Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7975479763524383,
+				"StableID":   "nAWQx6L7H521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f66452092f25dfa5b179582795a5a82c04441eb2b1490028cd2e4fa7487f864d",
+				"DiscoKey":   "discokey:24ff006dc6c1cd36a3d831c503368076599c8982aadc33d3c419f399d7c0a228",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53502",
+					"10.65.0.27:53502",
+					"172.17.0.1:53502",
+					"172.18.0.1:53502",
+					"172.19.0.1:53502"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:29:35.115765782Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4907521742976237,
+				"StableID":   "ntrfQvGdKf11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c781b50d877b7bfb397cd97b3a5a379b98cfa39008d8ec08a2b055f6e7ba5b1a",
+				"DiscoKey":   "discokey:dee57ee9a4c835dfb46a1767d60de77d126e52c8d813224f1961996a1a635d54",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43761",
+					"10.65.0.27:43761",
+					"172.17.0.1:43761",
+					"172.18.0.1:43761",
+					"172.19.0.1:43761"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:29:35.649076609Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4234057264648330,
+				"StableID":   "nw3VdGWc4a11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:568f8b2b976a6bf3caa4da47cbc739d02745cc65b1d1b29fe7305586ebedcc74",
+				"DiscoKey":   "discokey:b6f21f3a778ac99ccb20c29eb65ee2bdaf0f8e8c3e1c9607858a197d65951f34",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58206",
+					"10.65.0.27:58206",
+					"172.17.0.1:58206",
+					"172.18.0.1:58206",
+					"172.19.0.1:58206"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:29:36.189469306Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8499490687800161,
+				"StableID":   "nEFfw3DSN921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10f6b20c5afcae12f831e8959a67472a7663e195f0eb65c792294695922a2613",
+				"DiscoKey":   "discokey:77b85fd9e9a0227ce074c82d47cb50269a146e4451b552f5035470675d43bc5e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:59317",
+					"10.65.0.27:59317",
+					"172.17.0.1:59317",
+					"172.18.0.1:59317",
+					"172.19.0.1:59317"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:29:36.751207445Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4104837855141772,
+				"StableID":   "nbNKuX864Z11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:538e8d925ac4162b3ab8a8e30adda987b07a2824ffa3a33fb2734e8478815874",
+				"DiscoKey":   "discokey:ca84eefd1cd14f8fe248ee9a2079a9dd3ba3a1639255e9ea6afbfec68e2c4372",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52720",
+					"10.65.0.27:52720",
+					"172.17.0.1:52720",
+					"172.18.0.1:52720",
+					"172.19.0.1:52720"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:29:37.275266956Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8552463539352528,
+				"StableID":   "nBLMSTiRn921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc3410d79a3df833abb3b9ec073e211f4e7b196f00bbbfc6e4a039526d753b15",
+				"DiscoKey":   "discokey:1c4109ee9e16ca173791ae4ee2a33044bdd1551b32963018f017d391252b0739",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:53819",
+					"10.65.0.27:53819",
+					"172.17.0.1:53819",
+					"172.18.0.1:53819",
+					"172.19.0.1:53819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:29:37.813723468Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8086496749270642,
+				"StableID":   "nZAupKZP9621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e471126c3e15583577178f0ed9f0429f46e971f5c65e584b964b03a6f939745",
+				"DiscoKey":   "discokey:9a45130468b7fd8ffe67c48b238aaa609eb8b31e715eb7b9a81b343e526db53e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37852",
+					"10.65.0.27:37852",
+					"172.17.0.1:37852",
+					"172.18.0.1:37852",
+					"172.19.0.1:37852"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:29:38.34164349Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4244822918924449,
+				"StableID":   "nYafdQJV9a11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:770ef7532cbe3abfa2c99938af53dc6b265e9be6a205d0790dc6ab89b36bd228",
+				"DiscoKey":   "discokey:0f2b1289d48f050abe627e1810cfe51b1bcea41570469c9818cf7ec96ce0f945",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35570",
+					"10.65.0.27:35570",
+					"172.17.0.1:35570",
+					"172.18.0.1:35570",
+					"172.19.0.1:35570"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:29:38.887805857Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5117919993759737,
+				"StableID":   "nGpaMd5vxg11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6fd070953b5603d7e03824fab99d058bdebe99e63a395366e68f0ef80a26950c",
+				"DiscoKey":   "discokey:1f29d3cb392af9b83fc86d1918a232d7d25da11337c52db87a592abe7ae4ee38",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58635",
+					"10.65.0.27:58635",
+					"172.17.0.1:58635",
+					"172.18.0.1:58635",
+					"172.19.0.1:58635"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:29:39.427304835Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3992576385851876,
+				"StableID":   "nsLNHGDFBY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b25516bc05623bd81b54313fcb762a6e76d2187518eed34ee5a76047c56e017a",
+				"DiscoKey":   "discokey:85eaeca4890b27c4d1be87c7ffdebcba40736c8fbc971024b137f97a0ecd5f5b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49767",
+					"10.65.0.27:49767",
+					"172.17.0.1:49767",
+					"172.18.0.1:49767",
+					"172.19.0.1:49767"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:29:39.981269119Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8022370605821472,
+				"StableID":   "nq1u7C5Me521CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a7b6d8d3045bdb4161662580b81112373410f664f03bdf5e137c64589071cf3e",
+				"KeyExpiry":  "2026-11-09T07:29:40Z",
+				"DiscoKey":   "discokey:be1a28717bcc9157d3c568afae0f2de8e8c4323c99fa540907fd1c541dc97813",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40597",
+					"10.65.0.27:40597",
+					"172.17.0.1:40597",
+					"172.18.0.1:40597",
+					"172.19.0.1:40597"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:29:40.544985594Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1801875216653520,
+				"StableID":   "n7GWfyC55F11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bd9a6e56105d92842c32b9a6009072850d100375f7acd0b1b46c456b8d445369",
+				"KeyExpiry":  "2026-11-09T07:29:41Z",
+				"DiscoKey":   "discokey:3009d612c837523a78b19b7ffec196dbcc347c96f9b31580de848b43a65ed87f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49952",
+					"10.65.0.27:49952",
+					"172.17.0.1:49952",
+					"172.18.0.1:49952",
+					"172.19.0.1:49952"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:29:41.069067345Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1455722126108991,
+				"StableID":   "nkw5QQMJNC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:cc71889d9666696413bd095fe170bccb48d96c81df17cfe8e235875420aed702",
+				"KeyExpiry":  "2026-11-09T07:29:41Z",
+				"DiscoKey":   "discokey:d2187afe7ee06f5480713a8feaecc418a40a690ec8465421c885706e9fda6059",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50159",
+					"10.65.0.27:50159",
+					"172.17.0.1:50159",
+					"172.18.0.1:50159",
+					"172.19.0.1:50159"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:29:41.607585598Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6768834286965882": {
+				"ID":          6768834286965882,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3415573450443127,
+				"StableID":   "nEiZjiKvfT11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       3415573450443127,
+				"Key":        "nodekey:645e0d46df8060d6e5ea506423a859112f80419e5cc84f9360c338d7fcd46279",
+				"DiscoKey":   "discokey:e914d339d0f442de4aaa77f7d79237965edf235901a211a666d2305875f8bb2a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50978",
+					"10.65.0.27:50978",
+					"172.17.0.1:50978",
+					"172.18.0.1:50978",
+					"172.19.0.1:50978"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:29:34.07947452Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:645e0d46df8060d6e5ea506423a859112f80419e5cc84f9360c338d7fcd46279",
+			"MachineKey": "mkey:e256fdeb621c401a9c838b1aba68520b4000cb28d3d34a865f97e34379b07318",
+			"Peers": [{
+				"ID":         6768834286965882,
+				"StableID":   "nFmz9Locru11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97446871666b03011c68cc252748ee8429e04ed9ded08ab0a20073b4535c4d3c",
+				"DiscoKey":   "discokey:07b754c22ca9e4a0bccb5db9af456c6d8c82ce21fa82d80fb6bcb17bfb056c16",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35460",
+					"10.65.0.27:35460",
+					"172.17.0.1:35460",
+					"172.18.0.1:35460",
+					"172.19.0.1:35460"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:29:34.562430123Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7975479763524383,
+				"StableID":   "nAWQx6L7H521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f66452092f25dfa5b179582795a5a82c04441eb2b1490028cd2e4fa7487f864d",
+				"DiscoKey":   "discokey:24ff006dc6c1cd36a3d831c503368076599c8982aadc33d3c419f399d7c0a228",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53502",
+					"10.65.0.27:53502",
+					"172.17.0.1:53502",
+					"172.18.0.1:53502",
+					"172.19.0.1:53502"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:29:35.115765782Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4907521742976237,
+				"StableID":   "ntrfQvGdKf11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c781b50d877b7bfb397cd97b3a5a379b98cfa39008d8ec08a2b055f6e7ba5b1a",
+				"DiscoKey":   "discokey:dee57ee9a4c835dfb46a1767d60de77d126e52c8d813224f1961996a1a635d54",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43761",
+					"10.65.0.27:43761",
+					"172.17.0.1:43761",
+					"172.18.0.1:43761",
+					"172.19.0.1:43761"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:29:35.649076609Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4234057264648330,
+				"StableID":   "nw3VdGWc4a11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:568f8b2b976a6bf3caa4da47cbc739d02745cc65b1d1b29fe7305586ebedcc74",
+				"DiscoKey":   "discokey:b6f21f3a778ac99ccb20c29eb65ee2bdaf0f8e8c3e1c9607858a197d65951f34",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58206",
+					"10.65.0.27:58206",
+					"172.17.0.1:58206",
+					"172.18.0.1:58206",
+					"172.19.0.1:58206"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:29:36.189469306Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8499490687800161,
+				"StableID":   "nEFfw3DSN921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10f6b20c5afcae12f831e8959a67472a7663e195f0eb65c792294695922a2613",
+				"DiscoKey":   "discokey:77b85fd9e9a0227ce074c82d47cb50269a146e4451b552f5035470675d43bc5e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:59317",
+					"10.65.0.27:59317",
+					"172.17.0.1:59317",
+					"172.18.0.1:59317",
+					"172.19.0.1:59317"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:29:36.751207445Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4104837855141772,
+				"StableID":   "nbNKuX864Z11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:538e8d925ac4162b3ab8a8e30adda987b07a2824ffa3a33fb2734e8478815874",
+				"DiscoKey":   "discokey:ca84eefd1cd14f8fe248ee9a2079a9dd3ba3a1639255e9ea6afbfec68e2c4372",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52720",
+					"10.65.0.27:52720",
+					"172.17.0.1:52720",
+					"172.18.0.1:52720",
+					"172.19.0.1:52720"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:29:37.275266956Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8552463539352528,
+				"StableID":   "nBLMSTiRn921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc3410d79a3df833abb3b9ec073e211f4e7b196f00bbbfc6e4a039526d753b15",
+				"DiscoKey":   "discokey:1c4109ee9e16ca173791ae4ee2a33044bdd1551b32963018f017d391252b0739",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:53819",
+					"10.65.0.27:53819",
+					"172.17.0.1:53819",
+					"172.18.0.1:53819",
+					"172.19.0.1:53819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:29:37.813723468Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8086496749270642,
+				"StableID":   "nZAupKZP9621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e471126c3e15583577178f0ed9f0429f46e971f5c65e584b964b03a6f939745",
+				"DiscoKey":   "discokey:9a45130468b7fd8ffe67c48b238aaa609eb8b31e715eb7b9a81b343e526db53e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37852",
+					"10.65.0.27:37852",
+					"172.17.0.1:37852",
+					"172.18.0.1:37852",
+					"172.19.0.1:37852"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:29:38.34164349Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4244822918924449,
+				"StableID":   "nYafdQJV9a11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:770ef7532cbe3abfa2c99938af53dc6b265e9be6a205d0790dc6ab89b36bd228",
+				"DiscoKey":   "discokey:0f2b1289d48f050abe627e1810cfe51b1bcea41570469c9818cf7ec96ce0f945",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35570",
+					"10.65.0.27:35570",
+					"172.17.0.1:35570",
+					"172.18.0.1:35570",
+					"172.19.0.1:35570"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:29:38.887805857Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5117919993759737,
+				"StableID":   "nGpaMd5vxg11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6fd070953b5603d7e03824fab99d058bdebe99e63a395366e68f0ef80a26950c",
+				"DiscoKey":   "discokey:1f29d3cb392af9b83fc86d1918a232d7d25da11337c52db87a592abe7ae4ee38",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58635",
+					"10.65.0.27:58635",
+					"172.17.0.1:58635",
+					"172.18.0.1:58635",
+					"172.19.0.1:58635"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:29:39.427304835Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3992576385851876,
+				"StableID":   "nsLNHGDFBY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b25516bc05623bd81b54313fcb762a6e76d2187518eed34ee5a76047c56e017a",
+				"DiscoKey":   "discokey:85eaeca4890b27c4d1be87c7ffdebcba40736c8fbc971024b137f97a0ecd5f5b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49767",
+					"10.65.0.27:49767",
+					"172.17.0.1:49767",
+					"172.18.0.1:49767",
+					"172.19.0.1:49767"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:29:39.981269119Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8022370605821472,
+				"StableID":   "nq1u7C5Me521CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a7b6d8d3045bdb4161662580b81112373410f664f03bdf5e137c64589071cf3e",
+				"KeyExpiry":  "2026-11-09T07:29:40Z",
+				"DiscoKey":   "discokey:be1a28717bcc9157d3c568afae0f2de8e8c4323c99fa540907fd1c541dc97813",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40597",
+					"10.65.0.27:40597",
+					"172.17.0.1:40597",
+					"172.18.0.1:40597",
+					"172.19.0.1:40597"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:29:40.544985594Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1801875216653520,
+				"StableID":   "n7GWfyC55F11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bd9a6e56105d92842c32b9a6009072850d100375f7acd0b1b46c456b8d445369",
+				"KeyExpiry":  "2026-11-09T07:29:41Z",
+				"DiscoKey":   "discokey:3009d612c837523a78b19b7ffec196dbcc347c96f9b31580de848b43a65ed87f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49952",
+					"10.65.0.27:49952",
+					"172.17.0.1:49952",
+					"172.18.0.1:49952",
+					"172.19.0.1:49952"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:29:41.069067345Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1455722126108991,
+				"StableID":   "nkw5QQMJNC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:cc71889d9666696413bd095fe170bccb48d96c81df17cfe8e235875420aed702",
+				"KeyExpiry":  "2026-11-09T07:29:41Z",
+				"DiscoKey":   "discokey:d2187afe7ee06f5480713a8feaecc418a40a690ec8465421c885706e9fda6059",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50159",
+					"10.65.0.27:50159",
+					"172.17.0.1:50159",
+					"172.18.0.1:50159",
+					"172.19.0.1:50159"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:29:41.607585598Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3415573450443127": {
+				"ID":          3415573450443127,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4234057264648330,
+				"StableID":   "nw3VdGWc4a11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       4234057264648330,
+				"Key":        "nodekey:568f8b2b976a6bf3caa4da47cbc739d02745cc65b1d1b29fe7305586ebedcc74",
+				"DiscoKey":   "discokey:b6f21f3a778ac99ccb20c29eb65ee2bdaf0f8e8c3e1c9607858a197d65951f34",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58206",
+					"10.65.0.27:58206",
+					"172.17.0.1:58206",
+					"172.18.0.1:58206",
+					"172.19.0.1:58206"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:29:36.189469306Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:568f8b2b976a6bf3caa4da47cbc739d02745cc65b1d1b29fe7305586ebedcc74",
+			"MachineKey": "mkey:cba6139001c1dab232e5afc335ce56fda3a90e65c83bed7007347b1daa56950c",
+			"Peers": [{
+				"ID":         3415573450443127,
+				"StableID":   "nEiZjiKvfT11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:645e0d46df8060d6e5ea506423a859112f80419e5cc84f9360c338d7fcd46279",
+				"DiscoKey":   "discokey:e914d339d0f442de4aaa77f7d79237965edf235901a211a666d2305875f8bb2a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50978",
+					"10.65.0.27:50978",
+					"172.17.0.1:50978",
+					"172.18.0.1:50978",
+					"172.19.0.1:50978"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:29:34.07947452Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6768834286965882,
+				"StableID":   "nFmz9Locru11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97446871666b03011c68cc252748ee8429e04ed9ded08ab0a20073b4535c4d3c",
+				"DiscoKey":   "discokey:07b754c22ca9e4a0bccb5db9af456c6d8c82ce21fa82d80fb6bcb17bfb056c16",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35460",
+					"10.65.0.27:35460",
+					"172.17.0.1:35460",
+					"172.18.0.1:35460",
+					"172.19.0.1:35460"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:29:34.562430123Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7975479763524383,
+				"StableID":   "nAWQx6L7H521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f66452092f25dfa5b179582795a5a82c04441eb2b1490028cd2e4fa7487f864d",
+				"DiscoKey":   "discokey:24ff006dc6c1cd36a3d831c503368076599c8982aadc33d3c419f399d7c0a228",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53502",
+					"10.65.0.27:53502",
+					"172.17.0.1:53502",
+					"172.18.0.1:53502",
+					"172.19.0.1:53502"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:29:35.115765782Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4907521742976237,
+				"StableID":   "ntrfQvGdKf11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c781b50d877b7bfb397cd97b3a5a379b98cfa39008d8ec08a2b055f6e7ba5b1a",
+				"DiscoKey":   "discokey:dee57ee9a4c835dfb46a1767d60de77d126e52c8d813224f1961996a1a635d54",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43761",
+					"10.65.0.27:43761",
+					"172.17.0.1:43761",
+					"172.18.0.1:43761",
+					"172.19.0.1:43761"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:29:35.649076609Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8499490687800161,
+				"StableID":   "nEFfw3DSN921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10f6b20c5afcae12f831e8959a67472a7663e195f0eb65c792294695922a2613",
+				"DiscoKey":   "discokey:77b85fd9e9a0227ce074c82d47cb50269a146e4451b552f5035470675d43bc5e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:59317",
+					"10.65.0.27:59317",
+					"172.17.0.1:59317",
+					"172.18.0.1:59317",
+					"172.19.0.1:59317"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:29:36.751207445Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4104837855141772,
+				"StableID":   "nbNKuX864Z11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:538e8d925ac4162b3ab8a8e30adda987b07a2824ffa3a33fb2734e8478815874",
+				"DiscoKey":   "discokey:ca84eefd1cd14f8fe248ee9a2079a9dd3ba3a1639255e9ea6afbfec68e2c4372",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52720",
+					"10.65.0.27:52720",
+					"172.17.0.1:52720",
+					"172.18.0.1:52720",
+					"172.19.0.1:52720"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:29:37.275266956Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8552463539352528,
+				"StableID":   "nBLMSTiRn921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc3410d79a3df833abb3b9ec073e211f4e7b196f00bbbfc6e4a039526d753b15",
+				"DiscoKey":   "discokey:1c4109ee9e16ca173791ae4ee2a33044bdd1551b32963018f017d391252b0739",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:53819",
+					"10.65.0.27:53819",
+					"172.17.0.1:53819",
+					"172.18.0.1:53819",
+					"172.19.0.1:53819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:29:37.813723468Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8086496749270642,
+				"StableID":   "nZAupKZP9621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e471126c3e15583577178f0ed9f0429f46e971f5c65e584b964b03a6f939745",
+				"DiscoKey":   "discokey:9a45130468b7fd8ffe67c48b238aaa609eb8b31e715eb7b9a81b343e526db53e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37852",
+					"10.65.0.27:37852",
+					"172.17.0.1:37852",
+					"172.18.0.1:37852",
+					"172.19.0.1:37852"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:29:38.34164349Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4244822918924449,
+				"StableID":   "nYafdQJV9a11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:770ef7532cbe3abfa2c99938af53dc6b265e9be6a205d0790dc6ab89b36bd228",
+				"DiscoKey":   "discokey:0f2b1289d48f050abe627e1810cfe51b1bcea41570469c9818cf7ec96ce0f945",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35570",
+					"10.65.0.27:35570",
+					"172.17.0.1:35570",
+					"172.18.0.1:35570",
+					"172.19.0.1:35570"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:29:38.887805857Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5117919993759737,
+				"StableID":   "nGpaMd5vxg11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6fd070953b5603d7e03824fab99d058bdebe99e63a395366e68f0ef80a26950c",
+				"DiscoKey":   "discokey:1f29d3cb392af9b83fc86d1918a232d7d25da11337c52db87a592abe7ae4ee38",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58635",
+					"10.65.0.27:58635",
+					"172.17.0.1:58635",
+					"172.18.0.1:58635",
+					"172.19.0.1:58635"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:29:39.427304835Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3992576385851876,
+				"StableID":   "nsLNHGDFBY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b25516bc05623bd81b54313fcb762a6e76d2187518eed34ee5a76047c56e017a",
+				"DiscoKey":   "discokey:85eaeca4890b27c4d1be87c7ffdebcba40736c8fbc971024b137f97a0ecd5f5b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49767",
+					"10.65.0.27:49767",
+					"172.17.0.1:49767",
+					"172.18.0.1:49767",
+					"172.19.0.1:49767"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:29:39.981269119Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8022370605821472,
+				"StableID":   "nq1u7C5Me521CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a7b6d8d3045bdb4161662580b81112373410f664f03bdf5e137c64589071cf3e",
+				"KeyExpiry":  "2026-11-09T07:29:40Z",
+				"DiscoKey":   "discokey:be1a28717bcc9157d3c568afae0f2de8e8c4323c99fa540907fd1c541dc97813",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40597",
+					"10.65.0.27:40597",
+					"172.17.0.1:40597",
+					"172.18.0.1:40597",
+					"172.19.0.1:40597"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:29:40.544985594Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1801875216653520,
+				"StableID":   "n7GWfyC55F11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bd9a6e56105d92842c32b9a6009072850d100375f7acd0b1b46c456b8d445369",
+				"KeyExpiry":  "2026-11-09T07:29:41Z",
+				"DiscoKey":   "discokey:3009d612c837523a78b19b7ffec196dbcc347c96f9b31580de848b43a65ed87f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49952",
+					"10.65.0.27:49952",
+					"172.17.0.1:49952",
+					"172.18.0.1:49952",
+					"172.19.0.1:49952"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:29:41.069067345Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1455722126108991,
+				"StableID":   "nkw5QQMJNC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:cc71889d9666696413bd095fe170bccb48d96c81df17cfe8e235875420aed702",
+				"KeyExpiry":  "2026-11-09T07:29:41Z",
+				"DiscoKey":   "discokey:d2187afe7ee06f5480713a8feaecc418a40a690ec8465421c885706e9fda6059",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50159",
+					"10.65.0.27:50159",
+					"172.17.0.1:50159",
+					"172.18.0.1:50159",
+					"172.19.0.1:50159"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:29:41.607585598Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4234057264648330": {
+				"ID":          4234057264648330,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4907521742976237,
+				"StableID":   "ntrfQvGdKf11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       4907521742976237,
+				"Key":        "nodekey:c781b50d877b7bfb397cd97b3a5a379b98cfa39008d8ec08a2b055f6e7ba5b1a",
+				"DiscoKey":   "discokey:dee57ee9a4c835dfb46a1767d60de77d126e52c8d813224f1961996a1a635d54",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43761",
+					"10.65.0.27:43761",
+					"172.17.0.1:43761",
+					"172.18.0.1:43761",
+					"172.19.0.1:43761"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:29:35.649076609Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c781b50d877b7bfb397cd97b3a5a379b98cfa39008d8ec08a2b055f6e7ba5b1a",
+			"MachineKey": "mkey:1a0bdde2cada190dc690b7acacc9babb162fc4a79a962f04810009fc4e9de930",
+			"Peers": [{
+				"ID":         3415573450443127,
+				"StableID":   "nEiZjiKvfT11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:645e0d46df8060d6e5ea506423a859112f80419e5cc84f9360c338d7fcd46279",
+				"DiscoKey":   "discokey:e914d339d0f442de4aaa77f7d79237965edf235901a211a666d2305875f8bb2a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50978",
+					"10.65.0.27:50978",
+					"172.17.0.1:50978",
+					"172.18.0.1:50978",
+					"172.19.0.1:50978"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:29:34.07947452Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6768834286965882,
+				"StableID":   "nFmz9Locru11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97446871666b03011c68cc252748ee8429e04ed9ded08ab0a20073b4535c4d3c",
+				"DiscoKey":   "discokey:07b754c22ca9e4a0bccb5db9af456c6d8c82ce21fa82d80fb6bcb17bfb056c16",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35460",
+					"10.65.0.27:35460",
+					"172.17.0.1:35460",
+					"172.18.0.1:35460",
+					"172.19.0.1:35460"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:29:34.562430123Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7975479763524383,
+				"StableID":   "nAWQx6L7H521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f66452092f25dfa5b179582795a5a82c04441eb2b1490028cd2e4fa7487f864d",
+				"DiscoKey":   "discokey:24ff006dc6c1cd36a3d831c503368076599c8982aadc33d3c419f399d7c0a228",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53502",
+					"10.65.0.27:53502",
+					"172.17.0.1:53502",
+					"172.18.0.1:53502",
+					"172.19.0.1:53502"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:29:35.115765782Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4234057264648330,
+				"StableID":   "nw3VdGWc4a11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:568f8b2b976a6bf3caa4da47cbc739d02745cc65b1d1b29fe7305586ebedcc74",
+				"DiscoKey":   "discokey:b6f21f3a778ac99ccb20c29eb65ee2bdaf0f8e8c3e1c9607858a197d65951f34",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58206",
+					"10.65.0.27:58206",
+					"172.17.0.1:58206",
+					"172.18.0.1:58206",
+					"172.19.0.1:58206"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:29:36.189469306Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8499490687800161,
+				"StableID":   "nEFfw3DSN921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10f6b20c5afcae12f831e8959a67472a7663e195f0eb65c792294695922a2613",
+				"DiscoKey":   "discokey:77b85fd9e9a0227ce074c82d47cb50269a146e4451b552f5035470675d43bc5e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:59317",
+					"10.65.0.27:59317",
+					"172.17.0.1:59317",
+					"172.18.0.1:59317",
+					"172.19.0.1:59317"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:29:36.751207445Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4104837855141772,
+				"StableID":   "nbNKuX864Z11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:538e8d925ac4162b3ab8a8e30adda987b07a2824ffa3a33fb2734e8478815874",
+				"DiscoKey":   "discokey:ca84eefd1cd14f8fe248ee9a2079a9dd3ba3a1639255e9ea6afbfec68e2c4372",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52720",
+					"10.65.0.27:52720",
+					"172.17.0.1:52720",
+					"172.18.0.1:52720",
+					"172.19.0.1:52720"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:29:37.275266956Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8552463539352528,
+				"StableID":   "nBLMSTiRn921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc3410d79a3df833abb3b9ec073e211f4e7b196f00bbbfc6e4a039526d753b15",
+				"DiscoKey":   "discokey:1c4109ee9e16ca173791ae4ee2a33044bdd1551b32963018f017d391252b0739",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:53819",
+					"10.65.0.27:53819",
+					"172.17.0.1:53819",
+					"172.18.0.1:53819",
+					"172.19.0.1:53819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:29:37.813723468Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8086496749270642,
+				"StableID":   "nZAupKZP9621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e471126c3e15583577178f0ed9f0429f46e971f5c65e584b964b03a6f939745",
+				"DiscoKey":   "discokey:9a45130468b7fd8ffe67c48b238aaa609eb8b31e715eb7b9a81b343e526db53e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37852",
+					"10.65.0.27:37852",
+					"172.17.0.1:37852",
+					"172.18.0.1:37852",
+					"172.19.0.1:37852"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:29:38.34164349Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4244822918924449,
+				"StableID":   "nYafdQJV9a11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:770ef7532cbe3abfa2c99938af53dc6b265e9be6a205d0790dc6ab89b36bd228",
+				"DiscoKey":   "discokey:0f2b1289d48f050abe627e1810cfe51b1bcea41570469c9818cf7ec96ce0f945",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35570",
+					"10.65.0.27:35570",
+					"172.17.0.1:35570",
+					"172.18.0.1:35570",
+					"172.19.0.1:35570"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:29:38.887805857Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5117919993759737,
+				"StableID":   "nGpaMd5vxg11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6fd070953b5603d7e03824fab99d058bdebe99e63a395366e68f0ef80a26950c",
+				"DiscoKey":   "discokey:1f29d3cb392af9b83fc86d1918a232d7d25da11337c52db87a592abe7ae4ee38",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58635",
+					"10.65.0.27:58635",
+					"172.17.0.1:58635",
+					"172.18.0.1:58635",
+					"172.19.0.1:58635"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:29:39.427304835Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3992576385851876,
+				"StableID":   "nsLNHGDFBY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b25516bc05623bd81b54313fcb762a6e76d2187518eed34ee5a76047c56e017a",
+				"DiscoKey":   "discokey:85eaeca4890b27c4d1be87c7ffdebcba40736c8fbc971024b137f97a0ecd5f5b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49767",
+					"10.65.0.27:49767",
+					"172.17.0.1:49767",
+					"172.18.0.1:49767",
+					"172.19.0.1:49767"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:29:39.981269119Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8022370605821472,
+				"StableID":   "nq1u7C5Me521CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a7b6d8d3045bdb4161662580b81112373410f664f03bdf5e137c64589071cf3e",
+				"KeyExpiry":  "2026-11-09T07:29:40Z",
+				"DiscoKey":   "discokey:be1a28717bcc9157d3c568afae0f2de8e8c4323c99fa540907fd1c541dc97813",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40597",
+					"10.65.0.27:40597",
+					"172.17.0.1:40597",
+					"172.18.0.1:40597",
+					"172.19.0.1:40597"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:29:40.544985594Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1801875216653520,
+				"StableID":   "n7GWfyC55F11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bd9a6e56105d92842c32b9a6009072850d100375f7acd0b1b46c456b8d445369",
+				"KeyExpiry":  "2026-11-09T07:29:41Z",
+				"DiscoKey":   "discokey:3009d612c837523a78b19b7ffec196dbcc347c96f9b31580de848b43a65ed87f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49952",
+					"10.65.0.27:49952",
+					"172.17.0.1:49952",
+					"172.18.0.1:49952",
+					"172.19.0.1:49952"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:29:41.069067345Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1455722126108991,
+				"StableID":   "nkw5QQMJNC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:cc71889d9666696413bd095fe170bccb48d96c81df17cfe8e235875420aed702",
+				"KeyExpiry":  "2026-11-09T07:29:41Z",
+				"DiscoKey":   "discokey:d2187afe7ee06f5480713a8feaecc418a40a690ec8465421c885706e9fda6059",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50159",
+					"10.65.0.27:50159",
+					"172.17.0.1:50159",
+					"172.18.0.1:50159",
+					"172.19.0.1:50159"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:29:41.607585598Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4907521742976237": {
+				"ID":          4907521742976237,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4104837855141772,
+				"StableID":   "nbNKuX864Z11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       4104837855141772,
+				"Key":        "nodekey:538e8d925ac4162b3ab8a8e30adda987b07a2824ffa3a33fb2734e8478815874",
+				"DiscoKey":   "discokey:ca84eefd1cd14f8fe248ee9a2079a9dd3ba3a1639255e9ea6afbfec68e2c4372",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52720",
+					"10.65.0.27:52720",
+					"172.17.0.1:52720",
+					"172.18.0.1:52720",
+					"172.19.0.1:52720"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:29:37.275266956Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:538e8d925ac4162b3ab8a8e30adda987b07a2824ffa3a33fb2734e8478815874",
+			"MachineKey": "mkey:35760354677ff58267625d6a25101ba8e08ef02eaa2ef2f135f8de24c7a4e162",
+			"Peers": [{
+				"ID":         3415573450443127,
+				"StableID":   "nEiZjiKvfT11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:645e0d46df8060d6e5ea506423a859112f80419e5cc84f9360c338d7fcd46279",
+				"DiscoKey":   "discokey:e914d339d0f442de4aaa77f7d79237965edf235901a211a666d2305875f8bb2a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50978",
+					"10.65.0.27:50978",
+					"172.17.0.1:50978",
+					"172.18.0.1:50978",
+					"172.19.0.1:50978"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:29:34.07947452Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6768834286965882,
+				"StableID":   "nFmz9Locru11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97446871666b03011c68cc252748ee8429e04ed9ded08ab0a20073b4535c4d3c",
+				"DiscoKey":   "discokey:07b754c22ca9e4a0bccb5db9af456c6d8c82ce21fa82d80fb6bcb17bfb056c16",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35460",
+					"10.65.0.27:35460",
+					"172.17.0.1:35460",
+					"172.18.0.1:35460",
+					"172.19.0.1:35460"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:29:34.562430123Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7975479763524383,
+				"StableID":   "nAWQx6L7H521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f66452092f25dfa5b179582795a5a82c04441eb2b1490028cd2e4fa7487f864d",
+				"DiscoKey":   "discokey:24ff006dc6c1cd36a3d831c503368076599c8982aadc33d3c419f399d7c0a228",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53502",
+					"10.65.0.27:53502",
+					"172.17.0.1:53502",
+					"172.18.0.1:53502",
+					"172.19.0.1:53502"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:29:35.115765782Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4907521742976237,
+				"StableID":   "ntrfQvGdKf11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c781b50d877b7bfb397cd97b3a5a379b98cfa39008d8ec08a2b055f6e7ba5b1a",
+				"DiscoKey":   "discokey:dee57ee9a4c835dfb46a1767d60de77d126e52c8d813224f1961996a1a635d54",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43761",
+					"10.65.0.27:43761",
+					"172.17.0.1:43761",
+					"172.18.0.1:43761",
+					"172.19.0.1:43761"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:29:35.649076609Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4234057264648330,
+				"StableID":   "nw3VdGWc4a11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:568f8b2b976a6bf3caa4da47cbc739d02745cc65b1d1b29fe7305586ebedcc74",
+				"DiscoKey":   "discokey:b6f21f3a778ac99ccb20c29eb65ee2bdaf0f8e8c3e1c9607858a197d65951f34",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58206",
+					"10.65.0.27:58206",
+					"172.17.0.1:58206",
+					"172.18.0.1:58206",
+					"172.19.0.1:58206"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:29:36.189469306Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8499490687800161,
+				"StableID":   "nEFfw3DSN921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10f6b20c5afcae12f831e8959a67472a7663e195f0eb65c792294695922a2613",
+				"DiscoKey":   "discokey:77b85fd9e9a0227ce074c82d47cb50269a146e4451b552f5035470675d43bc5e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:59317",
+					"10.65.0.27:59317",
+					"172.17.0.1:59317",
+					"172.18.0.1:59317",
+					"172.19.0.1:59317"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:29:36.751207445Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8552463539352528,
+				"StableID":   "nBLMSTiRn921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc3410d79a3df833abb3b9ec073e211f4e7b196f00bbbfc6e4a039526d753b15",
+				"DiscoKey":   "discokey:1c4109ee9e16ca173791ae4ee2a33044bdd1551b32963018f017d391252b0739",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:53819",
+					"10.65.0.27:53819",
+					"172.17.0.1:53819",
+					"172.18.0.1:53819",
+					"172.19.0.1:53819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:29:37.813723468Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8086496749270642,
+				"StableID":   "nZAupKZP9621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e471126c3e15583577178f0ed9f0429f46e971f5c65e584b964b03a6f939745",
+				"DiscoKey":   "discokey:9a45130468b7fd8ffe67c48b238aaa609eb8b31e715eb7b9a81b343e526db53e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37852",
+					"10.65.0.27:37852",
+					"172.17.0.1:37852",
+					"172.18.0.1:37852",
+					"172.19.0.1:37852"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:29:38.34164349Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4244822918924449,
+				"StableID":   "nYafdQJV9a11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:770ef7532cbe3abfa2c99938af53dc6b265e9be6a205d0790dc6ab89b36bd228",
+				"DiscoKey":   "discokey:0f2b1289d48f050abe627e1810cfe51b1bcea41570469c9818cf7ec96ce0f945",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35570",
+					"10.65.0.27:35570",
+					"172.17.0.1:35570",
+					"172.18.0.1:35570",
+					"172.19.0.1:35570"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:29:38.887805857Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5117919993759737,
+				"StableID":   "nGpaMd5vxg11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6fd070953b5603d7e03824fab99d058bdebe99e63a395366e68f0ef80a26950c",
+				"DiscoKey":   "discokey:1f29d3cb392af9b83fc86d1918a232d7d25da11337c52db87a592abe7ae4ee38",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58635",
+					"10.65.0.27:58635",
+					"172.17.0.1:58635",
+					"172.18.0.1:58635",
+					"172.19.0.1:58635"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:29:39.427304835Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3992576385851876,
+				"StableID":   "nsLNHGDFBY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b25516bc05623bd81b54313fcb762a6e76d2187518eed34ee5a76047c56e017a",
+				"DiscoKey":   "discokey:85eaeca4890b27c4d1be87c7ffdebcba40736c8fbc971024b137f97a0ecd5f5b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49767",
+					"10.65.0.27:49767",
+					"172.17.0.1:49767",
+					"172.18.0.1:49767",
+					"172.19.0.1:49767"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:29:39.981269119Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8022370605821472,
+				"StableID":   "nq1u7C5Me521CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a7b6d8d3045bdb4161662580b81112373410f664f03bdf5e137c64589071cf3e",
+				"KeyExpiry":  "2026-11-09T07:29:40Z",
+				"DiscoKey":   "discokey:be1a28717bcc9157d3c568afae0f2de8e8c4323c99fa540907fd1c541dc97813",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40597",
+					"10.65.0.27:40597",
+					"172.17.0.1:40597",
+					"172.18.0.1:40597",
+					"172.19.0.1:40597"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:29:40.544985594Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1801875216653520,
+				"StableID":   "n7GWfyC55F11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bd9a6e56105d92842c32b9a6009072850d100375f7acd0b1b46c456b8d445369",
+				"KeyExpiry":  "2026-11-09T07:29:41Z",
+				"DiscoKey":   "discokey:3009d612c837523a78b19b7ffec196dbcc347c96f9b31580de848b43a65ed87f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49952",
+					"10.65.0.27:49952",
+					"172.17.0.1:49952",
+					"172.18.0.1:49952",
+					"172.19.0.1:49952"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:29:41.069067345Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1455722126108991,
+				"StableID":   "nkw5QQMJNC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:cc71889d9666696413bd095fe170bccb48d96c81df17cfe8e235875420aed702",
+				"KeyExpiry":  "2026-11-09T07:29:41Z",
+				"DiscoKey":   "discokey:d2187afe7ee06f5480713a8feaecc418a40a690ec8465421c885706e9fda6059",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50159",
+					"10.65.0.27:50159",
+					"172.17.0.1:50159",
+					"172.18.0.1:50159",
+					"172.19.0.1:50159"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:29:41.607585598Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4104837855141772": {
+				"ID":          4104837855141772,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8086496749270642,
+				"StableID":   "nZAupKZP9621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       8086496749270642,
+				"Key":        "nodekey:4e471126c3e15583577178f0ed9f0429f46e971f5c65e584b964b03a6f939745",
+				"DiscoKey":   "discokey:9a45130468b7fd8ffe67c48b238aaa609eb8b31e715eb7b9a81b343e526db53e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37852",
+					"10.65.0.27:37852",
+					"172.17.0.1:37852",
+					"172.18.0.1:37852",
+					"172.19.0.1:37852"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:29:38.34164349Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4e471126c3e15583577178f0ed9f0429f46e971f5c65e584b964b03a6f939745",
+			"MachineKey": "mkey:9c671527b6a63c41eb725cb0d15664ec7f4dff15a31d6b893a96a64020721b1f",
+			"Peers": [{
+				"ID":         3415573450443127,
+				"StableID":   "nEiZjiKvfT11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:645e0d46df8060d6e5ea506423a859112f80419e5cc84f9360c338d7fcd46279",
+				"DiscoKey":   "discokey:e914d339d0f442de4aaa77f7d79237965edf235901a211a666d2305875f8bb2a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50978",
+					"10.65.0.27:50978",
+					"172.17.0.1:50978",
+					"172.18.0.1:50978",
+					"172.19.0.1:50978"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:29:34.07947452Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6768834286965882,
+				"StableID":   "nFmz9Locru11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97446871666b03011c68cc252748ee8429e04ed9ded08ab0a20073b4535c4d3c",
+				"DiscoKey":   "discokey:07b754c22ca9e4a0bccb5db9af456c6d8c82ce21fa82d80fb6bcb17bfb056c16",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35460",
+					"10.65.0.27:35460",
+					"172.17.0.1:35460",
+					"172.18.0.1:35460",
+					"172.19.0.1:35460"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:29:34.562430123Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7975479763524383,
+				"StableID":   "nAWQx6L7H521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f66452092f25dfa5b179582795a5a82c04441eb2b1490028cd2e4fa7487f864d",
+				"DiscoKey":   "discokey:24ff006dc6c1cd36a3d831c503368076599c8982aadc33d3c419f399d7c0a228",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53502",
+					"10.65.0.27:53502",
+					"172.17.0.1:53502",
+					"172.18.0.1:53502",
+					"172.19.0.1:53502"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:29:35.115765782Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4907521742976237,
+				"StableID":   "ntrfQvGdKf11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c781b50d877b7bfb397cd97b3a5a379b98cfa39008d8ec08a2b055f6e7ba5b1a",
+				"DiscoKey":   "discokey:dee57ee9a4c835dfb46a1767d60de77d126e52c8d813224f1961996a1a635d54",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43761",
+					"10.65.0.27:43761",
+					"172.17.0.1:43761",
+					"172.18.0.1:43761",
+					"172.19.0.1:43761"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:29:35.649076609Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4234057264648330,
+				"StableID":   "nw3VdGWc4a11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:568f8b2b976a6bf3caa4da47cbc739d02745cc65b1d1b29fe7305586ebedcc74",
+				"DiscoKey":   "discokey:b6f21f3a778ac99ccb20c29eb65ee2bdaf0f8e8c3e1c9607858a197d65951f34",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58206",
+					"10.65.0.27:58206",
+					"172.17.0.1:58206",
+					"172.18.0.1:58206",
+					"172.19.0.1:58206"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:29:36.189469306Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8499490687800161,
+				"StableID":   "nEFfw3DSN921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10f6b20c5afcae12f831e8959a67472a7663e195f0eb65c792294695922a2613",
+				"DiscoKey":   "discokey:77b85fd9e9a0227ce074c82d47cb50269a146e4451b552f5035470675d43bc5e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:59317",
+					"10.65.0.27:59317",
+					"172.17.0.1:59317",
+					"172.18.0.1:59317",
+					"172.19.0.1:59317"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:29:36.751207445Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4104837855141772,
+				"StableID":   "nbNKuX864Z11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:538e8d925ac4162b3ab8a8e30adda987b07a2824ffa3a33fb2734e8478815874",
+				"DiscoKey":   "discokey:ca84eefd1cd14f8fe248ee9a2079a9dd3ba3a1639255e9ea6afbfec68e2c4372",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52720",
+					"10.65.0.27:52720",
+					"172.17.0.1:52720",
+					"172.18.0.1:52720",
+					"172.19.0.1:52720"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:29:37.275266956Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8552463539352528,
+				"StableID":   "nBLMSTiRn921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc3410d79a3df833abb3b9ec073e211f4e7b196f00bbbfc6e4a039526d753b15",
+				"DiscoKey":   "discokey:1c4109ee9e16ca173791ae4ee2a33044bdd1551b32963018f017d391252b0739",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:53819",
+					"10.65.0.27:53819",
+					"172.17.0.1:53819",
+					"172.18.0.1:53819",
+					"172.19.0.1:53819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:29:37.813723468Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4244822918924449,
+				"StableID":   "nYafdQJV9a11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:770ef7532cbe3abfa2c99938af53dc6b265e9be6a205d0790dc6ab89b36bd228",
+				"DiscoKey":   "discokey:0f2b1289d48f050abe627e1810cfe51b1bcea41570469c9818cf7ec96ce0f945",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35570",
+					"10.65.0.27:35570",
+					"172.17.0.1:35570",
+					"172.18.0.1:35570",
+					"172.19.0.1:35570"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:29:38.887805857Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5117919993759737,
+				"StableID":   "nGpaMd5vxg11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6fd070953b5603d7e03824fab99d058bdebe99e63a395366e68f0ef80a26950c",
+				"DiscoKey":   "discokey:1f29d3cb392af9b83fc86d1918a232d7d25da11337c52db87a592abe7ae4ee38",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58635",
+					"10.65.0.27:58635",
+					"172.17.0.1:58635",
+					"172.18.0.1:58635",
+					"172.19.0.1:58635"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:29:39.427304835Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3992576385851876,
+				"StableID":   "nsLNHGDFBY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b25516bc05623bd81b54313fcb762a6e76d2187518eed34ee5a76047c56e017a",
+				"DiscoKey":   "discokey:85eaeca4890b27c4d1be87c7ffdebcba40736c8fbc971024b137f97a0ecd5f5b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49767",
+					"10.65.0.27:49767",
+					"172.17.0.1:49767",
+					"172.18.0.1:49767",
+					"172.19.0.1:49767"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:29:39.981269119Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8022370605821472,
+				"StableID":   "nq1u7C5Me521CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a7b6d8d3045bdb4161662580b81112373410f664f03bdf5e137c64589071cf3e",
+				"KeyExpiry":  "2026-11-09T07:29:40Z",
+				"DiscoKey":   "discokey:be1a28717bcc9157d3c568afae0f2de8e8c4323c99fa540907fd1c541dc97813",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40597",
+					"10.65.0.27:40597",
+					"172.17.0.1:40597",
+					"172.18.0.1:40597",
+					"172.19.0.1:40597"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:29:40.544985594Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1801875216653520,
+				"StableID":   "n7GWfyC55F11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bd9a6e56105d92842c32b9a6009072850d100375f7acd0b1b46c456b8d445369",
+				"KeyExpiry":  "2026-11-09T07:29:41Z",
+				"DiscoKey":   "discokey:3009d612c837523a78b19b7ffec196dbcc347c96f9b31580de848b43a65ed87f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49952",
+					"10.65.0.27:49952",
+					"172.17.0.1:49952",
+					"172.18.0.1:49952",
+					"172.19.0.1:49952"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:29:41.069067345Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1455722126108991,
+				"StableID":   "nkw5QQMJNC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:cc71889d9666696413bd095fe170bccb48d96c81df17cfe8e235875420aed702",
+				"KeyExpiry":  "2026-11-09T07:29:41Z",
+				"DiscoKey":   "discokey:d2187afe7ee06f5480713a8feaecc418a40a690ec8465421c885706e9fda6059",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50159",
+					"10.65.0.27:50159",
+					"172.17.0.1:50159",
+					"172.18.0.1:50159",
+					"172.19.0.1:50159"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:29:41.607585598Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8086496749270642": {
+				"ID":          8086496749270642,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1801875216653520,
+				"StableID":   "n7GWfyC55F11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bd9a6e56105d92842c32b9a6009072850d100375f7acd0b1b46c456b8d445369",
+				"KeyExpiry":  "2026-11-09T07:29:41Z",
+				"DiscoKey":   "discokey:3009d612c837523a78b19b7ffec196dbcc347c96f9b31580de848b43a65ed87f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49952",
+					"10.65.0.27:49952",
+					"172.17.0.1:49952",
+					"172.18.0.1:49952",
+					"172.19.0.1:49952"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:29:41.069067345Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:bd9a6e56105d92842c32b9a6009072850d100375f7acd0b1b46c456b8d445369",
+			"MachineKey": "mkey:99bc7d5aab01d6b87cfc3adee311c800f5cb1cc3aba8c14e9151d4d0ecd08501",
+			"Peers": [{
+				"ID":         3415573450443127,
+				"StableID":   "nEiZjiKvfT11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:645e0d46df8060d6e5ea506423a859112f80419e5cc84f9360c338d7fcd46279",
+				"DiscoKey":   "discokey:e914d339d0f442de4aaa77f7d79237965edf235901a211a666d2305875f8bb2a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50978",
+					"10.65.0.27:50978",
+					"172.17.0.1:50978",
+					"172.18.0.1:50978",
+					"172.19.0.1:50978"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:29:34.07947452Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6768834286965882,
+				"StableID":   "nFmz9Locru11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97446871666b03011c68cc252748ee8429e04ed9ded08ab0a20073b4535c4d3c",
+				"DiscoKey":   "discokey:07b754c22ca9e4a0bccb5db9af456c6d8c82ce21fa82d80fb6bcb17bfb056c16",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35460",
+					"10.65.0.27:35460",
+					"172.17.0.1:35460",
+					"172.18.0.1:35460",
+					"172.19.0.1:35460"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:29:34.562430123Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7975479763524383,
+				"StableID":   "nAWQx6L7H521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f66452092f25dfa5b179582795a5a82c04441eb2b1490028cd2e4fa7487f864d",
+				"DiscoKey":   "discokey:24ff006dc6c1cd36a3d831c503368076599c8982aadc33d3c419f399d7c0a228",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53502",
+					"10.65.0.27:53502",
+					"172.17.0.1:53502",
+					"172.18.0.1:53502",
+					"172.19.0.1:53502"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:29:35.115765782Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4907521742976237,
+				"StableID":   "ntrfQvGdKf11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c781b50d877b7bfb397cd97b3a5a379b98cfa39008d8ec08a2b055f6e7ba5b1a",
+				"DiscoKey":   "discokey:dee57ee9a4c835dfb46a1767d60de77d126e52c8d813224f1961996a1a635d54",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43761",
+					"10.65.0.27:43761",
+					"172.17.0.1:43761",
+					"172.18.0.1:43761",
+					"172.19.0.1:43761"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:29:35.649076609Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4234057264648330,
+				"StableID":   "nw3VdGWc4a11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:568f8b2b976a6bf3caa4da47cbc739d02745cc65b1d1b29fe7305586ebedcc74",
+				"DiscoKey":   "discokey:b6f21f3a778ac99ccb20c29eb65ee2bdaf0f8e8c3e1c9607858a197d65951f34",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58206",
+					"10.65.0.27:58206",
+					"172.17.0.1:58206",
+					"172.18.0.1:58206",
+					"172.19.0.1:58206"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:29:36.189469306Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8499490687800161,
+				"StableID":   "nEFfw3DSN921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10f6b20c5afcae12f831e8959a67472a7663e195f0eb65c792294695922a2613",
+				"DiscoKey":   "discokey:77b85fd9e9a0227ce074c82d47cb50269a146e4451b552f5035470675d43bc5e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:59317",
+					"10.65.0.27:59317",
+					"172.17.0.1:59317",
+					"172.18.0.1:59317",
+					"172.19.0.1:59317"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:29:36.751207445Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4104837855141772,
+				"StableID":   "nbNKuX864Z11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:538e8d925ac4162b3ab8a8e30adda987b07a2824ffa3a33fb2734e8478815874",
+				"DiscoKey":   "discokey:ca84eefd1cd14f8fe248ee9a2079a9dd3ba3a1639255e9ea6afbfec68e2c4372",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52720",
+					"10.65.0.27:52720",
+					"172.17.0.1:52720",
+					"172.18.0.1:52720",
+					"172.19.0.1:52720"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:29:37.275266956Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8552463539352528,
+				"StableID":   "nBLMSTiRn921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc3410d79a3df833abb3b9ec073e211f4e7b196f00bbbfc6e4a039526d753b15",
+				"DiscoKey":   "discokey:1c4109ee9e16ca173791ae4ee2a33044bdd1551b32963018f017d391252b0739",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:53819",
+					"10.65.0.27:53819",
+					"172.17.0.1:53819",
+					"172.18.0.1:53819",
+					"172.19.0.1:53819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:29:37.813723468Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8086496749270642,
+				"StableID":   "nZAupKZP9621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e471126c3e15583577178f0ed9f0429f46e971f5c65e584b964b03a6f939745",
+				"DiscoKey":   "discokey:9a45130468b7fd8ffe67c48b238aaa609eb8b31e715eb7b9a81b343e526db53e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37852",
+					"10.65.0.27:37852",
+					"172.17.0.1:37852",
+					"172.18.0.1:37852",
+					"172.19.0.1:37852"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:29:38.34164349Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4244822918924449,
+				"StableID":   "nYafdQJV9a11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:770ef7532cbe3abfa2c99938af53dc6b265e9be6a205d0790dc6ab89b36bd228",
+				"DiscoKey":   "discokey:0f2b1289d48f050abe627e1810cfe51b1bcea41570469c9818cf7ec96ce0f945",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35570",
+					"10.65.0.27:35570",
+					"172.17.0.1:35570",
+					"172.18.0.1:35570",
+					"172.19.0.1:35570"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:29:38.887805857Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5117919993759737,
+				"StableID":   "nGpaMd5vxg11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6fd070953b5603d7e03824fab99d058bdebe99e63a395366e68f0ef80a26950c",
+				"DiscoKey":   "discokey:1f29d3cb392af9b83fc86d1918a232d7d25da11337c52db87a592abe7ae4ee38",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58635",
+					"10.65.0.27:58635",
+					"172.17.0.1:58635",
+					"172.18.0.1:58635",
+					"172.19.0.1:58635"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:29:39.427304835Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3992576385851876,
+				"StableID":   "nsLNHGDFBY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b25516bc05623bd81b54313fcb762a6e76d2187518eed34ee5a76047c56e017a",
+				"DiscoKey":   "discokey:85eaeca4890b27c4d1be87c7ffdebcba40736c8fbc971024b137f97a0ecd5f5b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49767",
+					"10.65.0.27:49767",
+					"172.17.0.1:49767",
+					"172.18.0.1:49767",
+					"172.19.0.1:49767"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:29:39.981269119Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8022370605821472,
+				"StableID":   "nq1u7C5Me521CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a7b6d8d3045bdb4161662580b81112373410f664f03bdf5e137c64589071cf3e",
+				"KeyExpiry":  "2026-11-09T07:29:40Z",
+				"DiscoKey":   "discokey:be1a28717bcc9157d3c568afae0f2de8e8c4323c99fa540907fd1c541dc97813",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40597",
+					"10.65.0.27:40597",
+					"172.17.0.1:40597",
+					"172.18.0.1:40597",
+					"172.19.0.1:40597"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:29:40.544985594Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1455722126108991,
+				"StableID":   "nkw5QQMJNC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:cc71889d9666696413bd095fe170bccb48d96c81df17cfe8e235875420aed702",
+				"KeyExpiry":  "2026-11-09T07:29:41Z",
+				"DiscoKey":   "discokey:d2187afe7ee06f5480713a8feaecc418a40a690ec8465421c885706e9fda6059",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50159",
+					"10.65.0.27:50159",
+					"172.17.0.1:50159",
+					"172.18.0.1:50159",
+					"172.19.0.1:50159"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:29:41.607585598Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4244822918924449,
+				"StableID":   "nYafdQJV9a11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       4244822918924449,
+				"Key":        "nodekey:770ef7532cbe3abfa2c99938af53dc6b265e9be6a205d0790dc6ab89b36bd228",
+				"DiscoKey":   "discokey:0f2b1289d48f050abe627e1810cfe51b1bcea41570469c9818cf7ec96ce0f945",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35570",
+					"10.65.0.27:35570",
+					"172.17.0.1:35570",
+					"172.18.0.1:35570",
+					"172.19.0.1:35570"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:29:38.887805857Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:770ef7532cbe3abfa2c99938af53dc6b265e9be6a205d0790dc6ab89b36bd228",
+			"MachineKey": "mkey:d6ff168fb57a6f6f88a55090c678f2386ea5a52e931a3515cbf233b4f4a34e64",
+			"Peers": [{
+				"ID":         3415573450443127,
+				"StableID":   "nEiZjiKvfT11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:645e0d46df8060d6e5ea506423a859112f80419e5cc84f9360c338d7fcd46279",
+				"DiscoKey":   "discokey:e914d339d0f442de4aaa77f7d79237965edf235901a211a666d2305875f8bb2a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50978",
+					"10.65.0.27:50978",
+					"172.17.0.1:50978",
+					"172.18.0.1:50978",
+					"172.19.0.1:50978"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:29:34.07947452Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6768834286965882,
+				"StableID":   "nFmz9Locru11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97446871666b03011c68cc252748ee8429e04ed9ded08ab0a20073b4535c4d3c",
+				"DiscoKey":   "discokey:07b754c22ca9e4a0bccb5db9af456c6d8c82ce21fa82d80fb6bcb17bfb056c16",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35460",
+					"10.65.0.27:35460",
+					"172.17.0.1:35460",
+					"172.18.0.1:35460",
+					"172.19.0.1:35460"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:29:34.562430123Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7975479763524383,
+				"StableID":   "nAWQx6L7H521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f66452092f25dfa5b179582795a5a82c04441eb2b1490028cd2e4fa7487f864d",
+				"DiscoKey":   "discokey:24ff006dc6c1cd36a3d831c503368076599c8982aadc33d3c419f399d7c0a228",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53502",
+					"10.65.0.27:53502",
+					"172.17.0.1:53502",
+					"172.18.0.1:53502",
+					"172.19.0.1:53502"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:29:35.115765782Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4907521742976237,
+				"StableID":   "ntrfQvGdKf11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c781b50d877b7bfb397cd97b3a5a379b98cfa39008d8ec08a2b055f6e7ba5b1a",
+				"DiscoKey":   "discokey:dee57ee9a4c835dfb46a1767d60de77d126e52c8d813224f1961996a1a635d54",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43761",
+					"10.65.0.27:43761",
+					"172.17.0.1:43761",
+					"172.18.0.1:43761",
+					"172.19.0.1:43761"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:29:35.649076609Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4234057264648330,
+				"StableID":   "nw3VdGWc4a11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:568f8b2b976a6bf3caa4da47cbc739d02745cc65b1d1b29fe7305586ebedcc74",
+				"DiscoKey":   "discokey:b6f21f3a778ac99ccb20c29eb65ee2bdaf0f8e8c3e1c9607858a197d65951f34",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58206",
+					"10.65.0.27:58206",
+					"172.17.0.1:58206",
+					"172.18.0.1:58206",
+					"172.19.0.1:58206"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:29:36.189469306Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8499490687800161,
+				"StableID":   "nEFfw3DSN921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10f6b20c5afcae12f831e8959a67472a7663e195f0eb65c792294695922a2613",
+				"DiscoKey":   "discokey:77b85fd9e9a0227ce074c82d47cb50269a146e4451b552f5035470675d43bc5e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:59317",
+					"10.65.0.27:59317",
+					"172.17.0.1:59317",
+					"172.18.0.1:59317",
+					"172.19.0.1:59317"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:29:36.751207445Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4104837855141772,
+				"StableID":   "nbNKuX864Z11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:538e8d925ac4162b3ab8a8e30adda987b07a2824ffa3a33fb2734e8478815874",
+				"DiscoKey":   "discokey:ca84eefd1cd14f8fe248ee9a2079a9dd3ba3a1639255e9ea6afbfec68e2c4372",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52720",
+					"10.65.0.27:52720",
+					"172.17.0.1:52720",
+					"172.18.0.1:52720",
+					"172.19.0.1:52720"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:29:37.275266956Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8552463539352528,
+				"StableID":   "nBLMSTiRn921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc3410d79a3df833abb3b9ec073e211f4e7b196f00bbbfc6e4a039526d753b15",
+				"DiscoKey":   "discokey:1c4109ee9e16ca173791ae4ee2a33044bdd1551b32963018f017d391252b0739",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:53819",
+					"10.65.0.27:53819",
+					"172.17.0.1:53819",
+					"172.18.0.1:53819",
+					"172.19.0.1:53819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:29:37.813723468Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8086496749270642,
+				"StableID":   "nZAupKZP9621CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e471126c3e15583577178f0ed9f0429f46e971f5c65e584b964b03a6f939745",
+				"DiscoKey":   "discokey:9a45130468b7fd8ffe67c48b238aaa609eb8b31e715eb7b9a81b343e526db53e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37852",
+					"10.65.0.27:37852",
+					"172.17.0.1:37852",
+					"172.18.0.1:37852",
+					"172.19.0.1:37852"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:29:38.34164349Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5117919993759737,
+				"StableID":   "nGpaMd5vxg11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6fd070953b5603d7e03824fab99d058bdebe99e63a395366e68f0ef80a26950c",
+				"DiscoKey":   "discokey:1f29d3cb392af9b83fc86d1918a232d7d25da11337c52db87a592abe7ae4ee38",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58635",
+					"10.65.0.27:58635",
+					"172.17.0.1:58635",
+					"172.18.0.1:58635",
+					"172.19.0.1:58635"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:29:39.427304835Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3992576385851876,
+				"StableID":   "nsLNHGDFBY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b25516bc05623bd81b54313fcb762a6e76d2187518eed34ee5a76047c56e017a",
+				"DiscoKey":   "discokey:85eaeca4890b27c4d1be87c7ffdebcba40736c8fbc971024b137f97a0ecd5f5b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49767",
+					"10.65.0.27:49767",
+					"172.17.0.1:49767",
+					"172.18.0.1:49767",
+					"172.19.0.1:49767"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:29:39.981269119Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8022370605821472,
+				"StableID":   "nq1u7C5Me521CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a7b6d8d3045bdb4161662580b81112373410f664f03bdf5e137c64589071cf3e",
+				"KeyExpiry":  "2026-11-09T07:29:40Z",
+				"DiscoKey":   "discokey:be1a28717bcc9157d3c568afae0f2de8e8c4323c99fa540907fd1c541dc97813",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40597",
+					"10.65.0.27:40597",
+					"172.17.0.1:40597",
+					"172.18.0.1:40597",
+					"172.19.0.1:40597"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:29:40.544985594Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1801875216653520,
+				"StableID":   "n7GWfyC55F11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bd9a6e56105d92842c32b9a6009072850d100375f7acd0b1b46c456b8d445369",
+				"KeyExpiry":  "2026-11-09T07:29:41Z",
+				"DiscoKey":   "discokey:3009d612c837523a78b19b7ffec196dbcc347c96f9b31580de848b43a65ed87f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49952",
+					"10.65.0.27:49952",
+					"172.17.0.1:49952",
+					"172.18.0.1:49952",
+					"172.19.0.1:49952"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:29:41.069067345Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1455722126108991,
+				"StableID":   "nkw5QQMJNC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:cc71889d9666696413bd095fe170bccb48d96c81df17cfe8e235875420aed702",
+				"KeyExpiry":  "2026-11-09T07:29:41Z",
+				"DiscoKey":   "discokey:d2187afe7ee06f5480713a8feaecc418a40a690ec8465421c885706e9fda6059",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50159",
+					"10.65.0.27:50159",
+					"172.17.0.1:50159",
+					"172.18.0.1:50159",
+					"172.19.0.1:50159"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:29:41.607585598Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4244822918924449": {
+				"ID":          4244822918924449,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-checkperiod-over-max-by-1s.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-checkperiod-over-max-by-1s.hujson
@@ -1,0 +1,20082 @@
+// ssh-malformed-checkperiod-over-max-by-1s
+//
+// ssh checkPeriod 1 second over max
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-13T07:30:17Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-malformed-checkperiod-over-max-by-1s",
+	"description":    "ssh checkPeriod 1 second over max",
+	"category":       "ssh",
+	"captured_at":    "2026-05-13T07:30:17.619447675Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "checkPeriod 168h0m1s is above the max (168h)"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                           \n  \n                                                                      \n          \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh checkPeriod 1 second over max\",\n\t\"id\":          \"ssh-malformed-checkperiod-over-max-by-1s\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\":      \"check\",\n\t\t\"checkPeriod\": \"168h0m1s\",\n\t\t\"dst\":         [\"tag:server\"],\n\t\t\"src\":         [\"autogroup:member\"],\n\t\t\"users\":       [\"root\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-edge/ssh-malformed-checkperiod-over-max-by-1s.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action":      "check",
+				"checkPeriod": "168h0m1s",
+				"dst":         ["tag:server"],
+				"src":         ["autogroup:member"],
+				"users":       ["root"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5575515825480772,
+				"StableID":   "nM7N36MAYk11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       5575515825480772,
+				"Key":        "nodekey:22f23d1aef122a38aff753a4dcc1ca1a306a1c4c8881e4ffcdf4d11d3aaf5605",
+				"DiscoKey":   "discokey:42c40123e92f4a7fa35727fde5e3d50d543f36e4374ebac8c09f5d2f18e95e0d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44034",
+					"10.65.0.27:44034",
+					"172.17.0.1:44034",
+					"172.18.0.1:44034",
+					"172.19.0.1:44034"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:30:26.266481848Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:22f23d1aef122a38aff753a4dcc1ca1a306a1c4c8881e4ffcdf4d11d3aaf5605",
+			"MachineKey": "mkey:0a2ab8ebb8d0a975005f52e826838dbd291163621552ffdb90b9e3d48dd32106",
+			"Peers": [{
+				"ID":         3164653122742097,
+				"StableID":   "nk8Tc85HiR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab04e30f70501875b9c5b5e1d82f21ddb04bb5ccd61242d2ba7781f755d3a12e",
+				"DiscoKey":   "discokey:e6b5d77ffb8873dbb3c2c68787c1e9b9245864148a5497e10525eda5b231823e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45744",
+					"10.65.0.27:45744",
+					"172.17.0.1:45744",
+					"172.18.0.1:45744",
+					"172.19.0.1:45744"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:30:20.294925753Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6366135317912794,
+				"StableID":   "n9gnEdaEir11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:02ba7fa414f6cbfc2c4583b210b0cf5b7451e524b5cd869cbe0bfe373be19a51",
+				"DiscoKey":   "discokey:97abad92a3e31a044e3bc0370708a83ad533ffb308918d7cd443648e1ae65a0a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34283",
+					"10.65.0.27:34283",
+					"172.17.0.1:34283",
+					"172.18.0.1:34283",
+					"172.19.0.1:34283"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:30:20.792200822Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3830844946326826,
+				"StableID":   "nPH6oSozuW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b69d5fab1f0b095ec70aa46ca53bd056781363a28888a423801a489254b2ac52",
+				"DiscoKey":   "discokey:27acdd51e51a44c4206d1c586b738dfe03cd00d8c9ac88553d3f8f0e50717b29",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60082",
+					"10.65.0.27:60082",
+					"172.17.0.1:60082",
+					"172.18.0.1:60082",
+					"172.19.0.1:60082"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:30:21.339080373Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6776706978776085,
+				"StableID":   "nQUMyrbBvu11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d43fe02739ee5b99822d3d4a54fb69788ec4006ef9af7094c1fbe3d39f518e4e",
+				"DiscoKey":   "discokey:b68e46dec8be212a99e2f1b6a6221ceb90f9e80968dac80a3a5ae878730a0f4a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:44762",
+					"10.65.0.27:44762",
+					"172.17.0.1:44762",
+					"172.18.0.1:44762",
+					"172.19.0.1:44762"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:30:21.902224732Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1005304979881960,
+				"StableID":   "nTNtZ7fJr811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:92d9452ce371b4c90c7617fe71f6f48613fe1bb2cb9dd379e08337ce16d9ff47",
+				"DiscoKey":   "discokey:a2cfbf2f8b46fc59bd33d8c443bd8c6be2a87b263d41b5bdb1430fb1ad54fb0b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52244",
+					"10.65.0.27:52244",
+					"172.17.0.1:52244",
+					"172.18.0.1:52244",
+					"172.19.0.1:52244"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:30:22.43445845Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8489061735454324,
+				"StableID":   "n95t8uFiH921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c62b86931e6b622b34bfc717924936b0c2231ac2e19b4b331204a45e4ada27",
+				"DiscoKey":   "discokey:776022425aecc87acb45053277dff54c08003fff153d3b55ebabb73d68d6352c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38195",
+					"10.65.0.27:38195",
+					"172.17.0.1:38195",
+					"172.18.0.1:38195",
+					"172.19.0.1:38195"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:30:22.961115111Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2394680142011296,
+				"StableID":   "nBgFxpBZhK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80aec655a8cc49c80e1ba3e8c352ec13cb1cbd9274e57002bb5f5b1c51851e07",
+				"DiscoKey":   "discokey:74db6cb0c770b0739fe07f2efd42c6d2984f699938fbc421b66f22b63b68be61",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57820",
+					"10.65.0.27:57820",
+					"172.17.0.1:57820",
+					"172.18.0.1:57820",
+					"172.19.0.1:57820"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:30:23.51321532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         766763268033513,
+				"StableID":   "nQGeL7aGz611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:66e22ff199441d463dedf0c50b830dec510fd1a5f08abda4e22cf225e4741e01",
+				"DiscoKey":   "discokey:d82c16f2643e512dfa7449e2484f26d853b321594beeb7ece70b738036575a6c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:60755",
+					"10.65.0.27:60755",
+					"172.17.0.1:60755",
+					"172.18.0.1:60755",
+					"172.19.0.1:60755"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:30:24.059962501Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2251594598435450,
+				"StableID":   "n94YSBakaJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a829dfba8699f24fe83d00c4a279b046831b751fd1e966353d7e5b3fc167ea6e",
+				"DiscoKey":   "discokey:c006bd6fb6c1b0d06e567c089f3178c48f8ad5103d0e7afacff0ff2ca2f6b06e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41450",
+					"10.65.0.27:41450",
+					"172.17.0.1:41450",
+					"172.18.0.1:41450",
+					"172.19.0.1:41450"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:30:24.595253469Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4816476707442839,
+				"StableID":   "nkBTPCgPce11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5b9eb4138628045a22c62402aebcc9c6835cce155bcdd0f0533fb214b7ff15f",
+				"DiscoKey":   "discokey:6fb532b65fa744aa1c90b3b89b26b530df389725630c419d3aa58e3259060704",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:45681",
+					"10.65.0.27:45681",
+					"172.17.0.1:45681",
+					"172.18.0.1:45681",
+					"172.19.0.1:45681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:30:25.139879467Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5786760251953305,
+				"StableID":   "nY6sdzNqBn11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a50de24d35d34bb9fe585388ee3e1b9e66a586807d4dc1b5b1270841c76edc3c",
+				"DiscoKey":   "discokey:58ed0fdadead5e4eb9f2f7331145e6c638e35c6c2df7f2a4fd5aeefff7f3b107",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37192",
+					"10.65.0.27:37192",
+					"172.17.0.1:37192",
+					"172.18.0.1:37192",
+					"172.19.0.1:37192"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:30:25.691602268Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5311293380078928,
+				"StableID":   "nHu1LufVUi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e18bfb7aa84dad4f4704bdb2487ee9af863ea3b3808e7cd62b0657e426804e2c",
+				"KeyExpiry":  "2026-11-09T07:30:26Z",
+				"DiscoKey":   "discokey:a6cb7ce052f6ec9c272762f1833dcab23942fee8efd11650ff8df2840879014e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46993",
+					"10.65.0.27:46993",
+					"172.17.0.1:46993",
+					"172.18.0.1:46993",
+					"172.19.0.1:46993"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:30:26.748974425Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3323207611793525,
+				"StableID":   "nLg8sf26xS11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:f1913735a8418130e2a7eefc0f60ec361b8c578095fea9ef283b91d86825954a",
+				"KeyExpiry":  "2026-11-09T07:30:27Z",
+				"DiscoKey":   "discokey:7d0f7630074002017a70edc672bcf78430971ab2e52e6f84145ba3e887811a54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57210",
+					"10.65.0.27:57210",
+					"172.17.0.1:57210",
+					"172.18.0.1:57210",
+					"172.19.0.1:57210"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:30:27.288549736Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6311515598068846,
+				"StableID":   "nsXdd7pVHr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a788a78d6bd7d8c1c1e75c201b74708f9fd19e670752963691f48038dfcd9c33",
+				"KeyExpiry":  "2026-11-09T07:30:27Z",
+				"DiscoKey":   "discokey:ab99184e7b0e520ce990100afb94c48331a0ef6c4f5ad51bcd459cc66fe8442a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59113",
+					"10.65.0.27:59113",
+					"172.17.0.1:59113",
+					"172.18.0.1:59113",
+					"172.19.0.1:59113"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:30:27.83146134Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5575515825480772": {
+				"ID":          5575515825480772,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8489061735454324,
+				"StableID":   "n95t8uFiH921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       8489061735454324,
+				"Key":        "nodekey:07c62b86931e6b622b34bfc717924936b0c2231ac2e19b4b331204a45e4ada27",
+				"DiscoKey":   "discokey:776022425aecc87acb45053277dff54c08003fff153d3b55ebabb73d68d6352c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38195",
+					"10.65.0.27:38195",
+					"172.17.0.1:38195",
+					"172.18.0.1:38195",
+					"172.19.0.1:38195"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:30:22.961115111Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:07c62b86931e6b622b34bfc717924936b0c2231ac2e19b4b331204a45e4ada27",
+			"MachineKey": "mkey:f16a7b05c438a4d8b08d821f20ec5e72ff0e2f2f392f32a31eb22b4ef50e7e2b",
+			"Peers": [{
+				"ID":         3164653122742097,
+				"StableID":   "nk8Tc85HiR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab04e30f70501875b9c5b5e1d82f21ddb04bb5ccd61242d2ba7781f755d3a12e",
+				"DiscoKey":   "discokey:e6b5d77ffb8873dbb3c2c68787c1e9b9245864148a5497e10525eda5b231823e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45744",
+					"10.65.0.27:45744",
+					"172.17.0.1:45744",
+					"172.18.0.1:45744",
+					"172.19.0.1:45744"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:30:20.294925753Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6366135317912794,
+				"StableID":   "n9gnEdaEir11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:02ba7fa414f6cbfc2c4583b210b0cf5b7451e524b5cd869cbe0bfe373be19a51",
+				"DiscoKey":   "discokey:97abad92a3e31a044e3bc0370708a83ad533ffb308918d7cd443648e1ae65a0a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34283",
+					"10.65.0.27:34283",
+					"172.17.0.1:34283",
+					"172.18.0.1:34283",
+					"172.19.0.1:34283"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:30:20.792200822Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3830844946326826,
+				"StableID":   "nPH6oSozuW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b69d5fab1f0b095ec70aa46ca53bd056781363a28888a423801a489254b2ac52",
+				"DiscoKey":   "discokey:27acdd51e51a44c4206d1c586b738dfe03cd00d8c9ac88553d3f8f0e50717b29",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60082",
+					"10.65.0.27:60082",
+					"172.17.0.1:60082",
+					"172.18.0.1:60082",
+					"172.19.0.1:60082"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:30:21.339080373Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6776706978776085,
+				"StableID":   "nQUMyrbBvu11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d43fe02739ee5b99822d3d4a54fb69788ec4006ef9af7094c1fbe3d39f518e4e",
+				"DiscoKey":   "discokey:b68e46dec8be212a99e2f1b6a6221ceb90f9e80968dac80a3a5ae878730a0f4a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:44762",
+					"10.65.0.27:44762",
+					"172.17.0.1:44762",
+					"172.18.0.1:44762",
+					"172.19.0.1:44762"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:30:21.902224732Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1005304979881960,
+				"StableID":   "nTNtZ7fJr811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:92d9452ce371b4c90c7617fe71f6f48613fe1bb2cb9dd379e08337ce16d9ff47",
+				"DiscoKey":   "discokey:a2cfbf2f8b46fc59bd33d8c443bd8c6be2a87b263d41b5bdb1430fb1ad54fb0b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52244",
+					"10.65.0.27:52244",
+					"172.17.0.1:52244",
+					"172.18.0.1:52244",
+					"172.19.0.1:52244"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:30:22.43445845Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2394680142011296,
+				"StableID":   "nBgFxpBZhK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80aec655a8cc49c80e1ba3e8c352ec13cb1cbd9274e57002bb5f5b1c51851e07",
+				"DiscoKey":   "discokey:74db6cb0c770b0739fe07f2efd42c6d2984f699938fbc421b66f22b63b68be61",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57820",
+					"10.65.0.27:57820",
+					"172.17.0.1:57820",
+					"172.18.0.1:57820",
+					"172.19.0.1:57820"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:30:23.51321532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         766763268033513,
+				"StableID":   "nQGeL7aGz611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:66e22ff199441d463dedf0c50b830dec510fd1a5f08abda4e22cf225e4741e01",
+				"DiscoKey":   "discokey:d82c16f2643e512dfa7449e2484f26d853b321594beeb7ece70b738036575a6c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:60755",
+					"10.65.0.27:60755",
+					"172.17.0.1:60755",
+					"172.18.0.1:60755",
+					"172.19.0.1:60755"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:30:24.059962501Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2251594598435450,
+				"StableID":   "n94YSBakaJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a829dfba8699f24fe83d00c4a279b046831b751fd1e966353d7e5b3fc167ea6e",
+				"DiscoKey":   "discokey:c006bd6fb6c1b0d06e567c089f3178c48f8ad5103d0e7afacff0ff2ca2f6b06e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41450",
+					"10.65.0.27:41450",
+					"172.17.0.1:41450",
+					"172.18.0.1:41450",
+					"172.19.0.1:41450"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:30:24.595253469Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4816476707442839,
+				"StableID":   "nkBTPCgPce11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5b9eb4138628045a22c62402aebcc9c6835cce155bcdd0f0533fb214b7ff15f",
+				"DiscoKey":   "discokey:6fb532b65fa744aa1c90b3b89b26b530df389725630c419d3aa58e3259060704",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:45681",
+					"10.65.0.27:45681",
+					"172.17.0.1:45681",
+					"172.18.0.1:45681",
+					"172.19.0.1:45681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:30:25.139879467Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5786760251953305,
+				"StableID":   "nY6sdzNqBn11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a50de24d35d34bb9fe585388ee3e1b9e66a586807d4dc1b5b1270841c76edc3c",
+				"DiscoKey":   "discokey:58ed0fdadead5e4eb9f2f7331145e6c638e35c6c2df7f2a4fd5aeefff7f3b107",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37192",
+					"10.65.0.27:37192",
+					"172.17.0.1:37192",
+					"172.18.0.1:37192",
+					"172.19.0.1:37192"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:30:25.691602268Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5575515825480772,
+				"StableID":   "nM7N36MAYk11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22f23d1aef122a38aff753a4dcc1ca1a306a1c4c8881e4ffcdf4d11d3aaf5605",
+				"DiscoKey":   "discokey:42c40123e92f4a7fa35727fde5e3d50d543f36e4374ebac8c09f5d2f18e95e0d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44034",
+					"10.65.0.27:44034",
+					"172.17.0.1:44034",
+					"172.18.0.1:44034",
+					"172.19.0.1:44034"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:30:26.266481848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5311293380078928,
+				"StableID":   "nHu1LufVUi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e18bfb7aa84dad4f4704bdb2487ee9af863ea3b3808e7cd62b0657e426804e2c",
+				"KeyExpiry":  "2026-11-09T07:30:26Z",
+				"DiscoKey":   "discokey:a6cb7ce052f6ec9c272762f1833dcab23942fee8efd11650ff8df2840879014e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46993",
+					"10.65.0.27:46993",
+					"172.17.0.1:46993",
+					"172.18.0.1:46993",
+					"172.19.0.1:46993"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:30:26.748974425Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3323207611793525,
+				"StableID":   "nLg8sf26xS11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:f1913735a8418130e2a7eefc0f60ec361b8c578095fea9ef283b91d86825954a",
+				"KeyExpiry":  "2026-11-09T07:30:27Z",
+				"DiscoKey":   "discokey:7d0f7630074002017a70edc672bcf78430971ab2e52e6f84145ba3e887811a54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57210",
+					"10.65.0.27:57210",
+					"172.17.0.1:57210",
+					"172.18.0.1:57210",
+					"172.19.0.1:57210"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:30:27.288549736Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6311515598068846,
+				"StableID":   "nsXdd7pVHr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a788a78d6bd7d8c1c1e75c201b74708f9fd19e670752963691f48038dfcd9c33",
+				"KeyExpiry":  "2026-11-09T07:30:27Z",
+				"DiscoKey":   "discokey:ab99184e7b0e520ce990100afb94c48331a0ef6c4f5ad51bcd459cc66fe8442a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59113",
+					"10.65.0.27:59113",
+					"172.17.0.1:59113",
+					"172.18.0.1:59113",
+					"172.19.0.1:59113"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:30:27.83146134Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8489061735454324": {
+				"ID":          8489061735454324,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6311515598068846,
+				"StableID":   "nsXdd7pVHr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a788a78d6bd7d8c1c1e75c201b74708f9fd19e670752963691f48038dfcd9c33",
+				"KeyExpiry":  "2026-11-09T07:30:27Z",
+				"DiscoKey":   "discokey:ab99184e7b0e520ce990100afb94c48331a0ef6c4f5ad51bcd459cc66fe8442a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59113",
+					"10.65.0.27:59113",
+					"172.17.0.1:59113",
+					"172.18.0.1:59113",
+					"172.19.0.1:59113"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:30:27.83146134Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a788a78d6bd7d8c1c1e75c201b74708f9fd19e670752963691f48038dfcd9c33",
+			"MachineKey": "mkey:96b9c232c17460f93d85626d68cee4fafcfd6ff7a357939b787606a0b233430a",
+			"Peers": [{
+				"ID":         3164653122742097,
+				"StableID":   "nk8Tc85HiR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab04e30f70501875b9c5b5e1d82f21ddb04bb5ccd61242d2ba7781f755d3a12e",
+				"DiscoKey":   "discokey:e6b5d77ffb8873dbb3c2c68787c1e9b9245864148a5497e10525eda5b231823e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45744",
+					"10.65.0.27:45744",
+					"172.17.0.1:45744",
+					"172.18.0.1:45744",
+					"172.19.0.1:45744"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:30:20.294925753Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6366135317912794,
+				"StableID":   "n9gnEdaEir11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:02ba7fa414f6cbfc2c4583b210b0cf5b7451e524b5cd869cbe0bfe373be19a51",
+				"DiscoKey":   "discokey:97abad92a3e31a044e3bc0370708a83ad533ffb308918d7cd443648e1ae65a0a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34283",
+					"10.65.0.27:34283",
+					"172.17.0.1:34283",
+					"172.18.0.1:34283",
+					"172.19.0.1:34283"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:30:20.792200822Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3830844946326826,
+				"StableID":   "nPH6oSozuW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b69d5fab1f0b095ec70aa46ca53bd056781363a28888a423801a489254b2ac52",
+				"DiscoKey":   "discokey:27acdd51e51a44c4206d1c586b738dfe03cd00d8c9ac88553d3f8f0e50717b29",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60082",
+					"10.65.0.27:60082",
+					"172.17.0.1:60082",
+					"172.18.0.1:60082",
+					"172.19.0.1:60082"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:30:21.339080373Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6776706978776085,
+				"StableID":   "nQUMyrbBvu11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d43fe02739ee5b99822d3d4a54fb69788ec4006ef9af7094c1fbe3d39f518e4e",
+				"DiscoKey":   "discokey:b68e46dec8be212a99e2f1b6a6221ceb90f9e80968dac80a3a5ae878730a0f4a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:44762",
+					"10.65.0.27:44762",
+					"172.17.0.1:44762",
+					"172.18.0.1:44762",
+					"172.19.0.1:44762"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:30:21.902224732Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1005304979881960,
+				"StableID":   "nTNtZ7fJr811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:92d9452ce371b4c90c7617fe71f6f48613fe1bb2cb9dd379e08337ce16d9ff47",
+				"DiscoKey":   "discokey:a2cfbf2f8b46fc59bd33d8c443bd8c6be2a87b263d41b5bdb1430fb1ad54fb0b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52244",
+					"10.65.0.27:52244",
+					"172.17.0.1:52244",
+					"172.18.0.1:52244",
+					"172.19.0.1:52244"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:30:22.43445845Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8489061735454324,
+				"StableID":   "n95t8uFiH921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c62b86931e6b622b34bfc717924936b0c2231ac2e19b4b331204a45e4ada27",
+				"DiscoKey":   "discokey:776022425aecc87acb45053277dff54c08003fff153d3b55ebabb73d68d6352c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38195",
+					"10.65.0.27:38195",
+					"172.17.0.1:38195",
+					"172.18.0.1:38195",
+					"172.19.0.1:38195"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:30:22.961115111Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2394680142011296,
+				"StableID":   "nBgFxpBZhK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80aec655a8cc49c80e1ba3e8c352ec13cb1cbd9274e57002bb5f5b1c51851e07",
+				"DiscoKey":   "discokey:74db6cb0c770b0739fe07f2efd42c6d2984f699938fbc421b66f22b63b68be61",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57820",
+					"10.65.0.27:57820",
+					"172.17.0.1:57820",
+					"172.18.0.1:57820",
+					"172.19.0.1:57820"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:30:23.51321532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         766763268033513,
+				"StableID":   "nQGeL7aGz611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:66e22ff199441d463dedf0c50b830dec510fd1a5f08abda4e22cf225e4741e01",
+				"DiscoKey":   "discokey:d82c16f2643e512dfa7449e2484f26d853b321594beeb7ece70b738036575a6c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:60755",
+					"10.65.0.27:60755",
+					"172.17.0.1:60755",
+					"172.18.0.1:60755",
+					"172.19.0.1:60755"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:30:24.059962501Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2251594598435450,
+				"StableID":   "n94YSBakaJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a829dfba8699f24fe83d00c4a279b046831b751fd1e966353d7e5b3fc167ea6e",
+				"DiscoKey":   "discokey:c006bd6fb6c1b0d06e567c089f3178c48f8ad5103d0e7afacff0ff2ca2f6b06e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41450",
+					"10.65.0.27:41450",
+					"172.17.0.1:41450",
+					"172.18.0.1:41450",
+					"172.19.0.1:41450"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:30:24.595253469Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4816476707442839,
+				"StableID":   "nkBTPCgPce11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5b9eb4138628045a22c62402aebcc9c6835cce155bcdd0f0533fb214b7ff15f",
+				"DiscoKey":   "discokey:6fb532b65fa744aa1c90b3b89b26b530df389725630c419d3aa58e3259060704",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:45681",
+					"10.65.0.27:45681",
+					"172.17.0.1:45681",
+					"172.18.0.1:45681",
+					"172.19.0.1:45681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:30:25.139879467Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5786760251953305,
+				"StableID":   "nY6sdzNqBn11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a50de24d35d34bb9fe585388ee3e1b9e66a586807d4dc1b5b1270841c76edc3c",
+				"DiscoKey":   "discokey:58ed0fdadead5e4eb9f2f7331145e6c638e35c6c2df7f2a4fd5aeefff7f3b107",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37192",
+					"10.65.0.27:37192",
+					"172.17.0.1:37192",
+					"172.18.0.1:37192",
+					"172.19.0.1:37192"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:30:25.691602268Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5575515825480772,
+				"StableID":   "nM7N36MAYk11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22f23d1aef122a38aff753a4dcc1ca1a306a1c4c8881e4ffcdf4d11d3aaf5605",
+				"DiscoKey":   "discokey:42c40123e92f4a7fa35727fde5e3d50d543f36e4374ebac8c09f5d2f18e95e0d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44034",
+					"10.65.0.27:44034",
+					"172.17.0.1:44034",
+					"172.18.0.1:44034",
+					"172.19.0.1:44034"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:30:26.266481848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5311293380078928,
+				"StableID":   "nHu1LufVUi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e18bfb7aa84dad4f4704bdb2487ee9af863ea3b3808e7cd62b0657e426804e2c",
+				"KeyExpiry":  "2026-11-09T07:30:26Z",
+				"DiscoKey":   "discokey:a6cb7ce052f6ec9c272762f1833dcab23942fee8efd11650ff8df2840879014e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46993",
+					"10.65.0.27:46993",
+					"172.17.0.1:46993",
+					"172.18.0.1:46993",
+					"172.19.0.1:46993"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:30:26.748974425Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3323207611793525,
+				"StableID":   "nLg8sf26xS11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:f1913735a8418130e2a7eefc0f60ec361b8c578095fea9ef283b91d86825954a",
+				"KeyExpiry":  "2026-11-09T07:30:27Z",
+				"DiscoKey":   "discokey:7d0f7630074002017a70edc672bcf78430971ab2e52e6f84145ba3e887811a54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57210",
+					"10.65.0.27:57210",
+					"172.17.0.1:57210",
+					"172.18.0.1:57210",
+					"172.19.0.1:57210"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:30:27.288549736Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3830844946326826,
+				"StableID":   "nPH6oSozuW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       3830844946326826,
+				"Key":        "nodekey:b69d5fab1f0b095ec70aa46ca53bd056781363a28888a423801a489254b2ac52",
+				"DiscoKey":   "discokey:27acdd51e51a44c4206d1c586b738dfe03cd00d8c9ac88553d3f8f0e50717b29",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60082",
+					"10.65.0.27:60082",
+					"172.17.0.1:60082",
+					"172.18.0.1:60082",
+					"172.19.0.1:60082"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:30:21.339080373Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b69d5fab1f0b095ec70aa46ca53bd056781363a28888a423801a489254b2ac52",
+			"MachineKey": "mkey:6c0e38a0860277293a09cd96195b9638c9d0f1f4a07f1df6d263b0dd080ed953",
+			"Peers": [{
+				"ID":         3164653122742097,
+				"StableID":   "nk8Tc85HiR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab04e30f70501875b9c5b5e1d82f21ddb04bb5ccd61242d2ba7781f755d3a12e",
+				"DiscoKey":   "discokey:e6b5d77ffb8873dbb3c2c68787c1e9b9245864148a5497e10525eda5b231823e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45744",
+					"10.65.0.27:45744",
+					"172.17.0.1:45744",
+					"172.18.0.1:45744",
+					"172.19.0.1:45744"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:30:20.294925753Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6366135317912794,
+				"StableID":   "n9gnEdaEir11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:02ba7fa414f6cbfc2c4583b210b0cf5b7451e524b5cd869cbe0bfe373be19a51",
+				"DiscoKey":   "discokey:97abad92a3e31a044e3bc0370708a83ad533ffb308918d7cd443648e1ae65a0a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34283",
+					"10.65.0.27:34283",
+					"172.17.0.1:34283",
+					"172.18.0.1:34283",
+					"172.19.0.1:34283"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:30:20.792200822Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6776706978776085,
+				"StableID":   "nQUMyrbBvu11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d43fe02739ee5b99822d3d4a54fb69788ec4006ef9af7094c1fbe3d39f518e4e",
+				"DiscoKey":   "discokey:b68e46dec8be212a99e2f1b6a6221ceb90f9e80968dac80a3a5ae878730a0f4a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:44762",
+					"10.65.0.27:44762",
+					"172.17.0.1:44762",
+					"172.18.0.1:44762",
+					"172.19.0.1:44762"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:30:21.902224732Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1005304979881960,
+				"StableID":   "nTNtZ7fJr811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:92d9452ce371b4c90c7617fe71f6f48613fe1bb2cb9dd379e08337ce16d9ff47",
+				"DiscoKey":   "discokey:a2cfbf2f8b46fc59bd33d8c443bd8c6be2a87b263d41b5bdb1430fb1ad54fb0b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52244",
+					"10.65.0.27:52244",
+					"172.17.0.1:52244",
+					"172.18.0.1:52244",
+					"172.19.0.1:52244"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:30:22.43445845Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8489061735454324,
+				"StableID":   "n95t8uFiH921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c62b86931e6b622b34bfc717924936b0c2231ac2e19b4b331204a45e4ada27",
+				"DiscoKey":   "discokey:776022425aecc87acb45053277dff54c08003fff153d3b55ebabb73d68d6352c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38195",
+					"10.65.0.27:38195",
+					"172.17.0.1:38195",
+					"172.18.0.1:38195",
+					"172.19.0.1:38195"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:30:22.961115111Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2394680142011296,
+				"StableID":   "nBgFxpBZhK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80aec655a8cc49c80e1ba3e8c352ec13cb1cbd9274e57002bb5f5b1c51851e07",
+				"DiscoKey":   "discokey:74db6cb0c770b0739fe07f2efd42c6d2984f699938fbc421b66f22b63b68be61",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57820",
+					"10.65.0.27:57820",
+					"172.17.0.1:57820",
+					"172.18.0.1:57820",
+					"172.19.0.1:57820"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:30:23.51321532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         766763268033513,
+				"StableID":   "nQGeL7aGz611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:66e22ff199441d463dedf0c50b830dec510fd1a5f08abda4e22cf225e4741e01",
+				"DiscoKey":   "discokey:d82c16f2643e512dfa7449e2484f26d853b321594beeb7ece70b738036575a6c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:60755",
+					"10.65.0.27:60755",
+					"172.17.0.1:60755",
+					"172.18.0.1:60755",
+					"172.19.0.1:60755"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:30:24.059962501Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2251594598435450,
+				"StableID":   "n94YSBakaJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a829dfba8699f24fe83d00c4a279b046831b751fd1e966353d7e5b3fc167ea6e",
+				"DiscoKey":   "discokey:c006bd6fb6c1b0d06e567c089f3178c48f8ad5103d0e7afacff0ff2ca2f6b06e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41450",
+					"10.65.0.27:41450",
+					"172.17.0.1:41450",
+					"172.18.0.1:41450",
+					"172.19.0.1:41450"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:30:24.595253469Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4816476707442839,
+				"StableID":   "nkBTPCgPce11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5b9eb4138628045a22c62402aebcc9c6835cce155bcdd0f0533fb214b7ff15f",
+				"DiscoKey":   "discokey:6fb532b65fa744aa1c90b3b89b26b530df389725630c419d3aa58e3259060704",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:45681",
+					"10.65.0.27:45681",
+					"172.17.0.1:45681",
+					"172.18.0.1:45681",
+					"172.19.0.1:45681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:30:25.139879467Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5786760251953305,
+				"StableID":   "nY6sdzNqBn11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a50de24d35d34bb9fe585388ee3e1b9e66a586807d4dc1b5b1270841c76edc3c",
+				"DiscoKey":   "discokey:58ed0fdadead5e4eb9f2f7331145e6c638e35c6c2df7f2a4fd5aeefff7f3b107",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37192",
+					"10.65.0.27:37192",
+					"172.17.0.1:37192",
+					"172.18.0.1:37192",
+					"172.19.0.1:37192"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:30:25.691602268Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5575515825480772,
+				"StableID":   "nM7N36MAYk11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22f23d1aef122a38aff753a4dcc1ca1a306a1c4c8881e4ffcdf4d11d3aaf5605",
+				"DiscoKey":   "discokey:42c40123e92f4a7fa35727fde5e3d50d543f36e4374ebac8c09f5d2f18e95e0d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44034",
+					"10.65.0.27:44034",
+					"172.17.0.1:44034",
+					"172.18.0.1:44034",
+					"172.19.0.1:44034"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:30:26.266481848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5311293380078928,
+				"StableID":   "nHu1LufVUi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e18bfb7aa84dad4f4704bdb2487ee9af863ea3b3808e7cd62b0657e426804e2c",
+				"KeyExpiry":  "2026-11-09T07:30:26Z",
+				"DiscoKey":   "discokey:a6cb7ce052f6ec9c272762f1833dcab23942fee8efd11650ff8df2840879014e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46993",
+					"10.65.0.27:46993",
+					"172.17.0.1:46993",
+					"172.18.0.1:46993",
+					"172.19.0.1:46993"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:30:26.748974425Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3323207611793525,
+				"StableID":   "nLg8sf26xS11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:f1913735a8418130e2a7eefc0f60ec361b8c578095fea9ef283b91d86825954a",
+				"KeyExpiry":  "2026-11-09T07:30:27Z",
+				"DiscoKey":   "discokey:7d0f7630074002017a70edc672bcf78430971ab2e52e6f84145ba3e887811a54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57210",
+					"10.65.0.27:57210",
+					"172.17.0.1:57210",
+					"172.18.0.1:57210",
+					"172.19.0.1:57210"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:30:27.288549736Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6311515598068846,
+				"StableID":   "nsXdd7pVHr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a788a78d6bd7d8c1c1e75c201b74708f9fd19e670752963691f48038dfcd9c33",
+				"KeyExpiry":  "2026-11-09T07:30:27Z",
+				"DiscoKey":   "discokey:ab99184e7b0e520ce990100afb94c48331a0ef6c4f5ad51bcd459cc66fe8442a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59113",
+					"10.65.0.27:59113",
+					"172.17.0.1:59113",
+					"172.18.0.1:59113",
+					"172.19.0.1:59113"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:30:27.83146134Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3830844946326826": {
+				"ID":          3830844946326826,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         766763268033513,
+				"StableID":   "nQGeL7aGz611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       766763268033513,
+				"Key":        "nodekey:66e22ff199441d463dedf0c50b830dec510fd1a5f08abda4e22cf225e4741e01",
+				"DiscoKey":   "discokey:d82c16f2643e512dfa7449e2484f26d853b321594beeb7ece70b738036575a6c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:60755",
+					"10.65.0.27:60755",
+					"172.17.0.1:60755",
+					"172.18.0.1:60755",
+					"172.19.0.1:60755"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:30:24.059962501Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:66e22ff199441d463dedf0c50b830dec510fd1a5f08abda4e22cf225e4741e01",
+			"MachineKey": "mkey:6e92538444708808ab59131b51601fcd275f6ac0c08ae8436fabfb85edd98e5b",
+			"Peers": [{
+				"ID":         3164653122742097,
+				"StableID":   "nk8Tc85HiR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab04e30f70501875b9c5b5e1d82f21ddb04bb5ccd61242d2ba7781f755d3a12e",
+				"DiscoKey":   "discokey:e6b5d77ffb8873dbb3c2c68787c1e9b9245864148a5497e10525eda5b231823e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45744",
+					"10.65.0.27:45744",
+					"172.17.0.1:45744",
+					"172.18.0.1:45744",
+					"172.19.0.1:45744"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:30:20.294925753Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6366135317912794,
+				"StableID":   "n9gnEdaEir11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:02ba7fa414f6cbfc2c4583b210b0cf5b7451e524b5cd869cbe0bfe373be19a51",
+				"DiscoKey":   "discokey:97abad92a3e31a044e3bc0370708a83ad533ffb308918d7cd443648e1ae65a0a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34283",
+					"10.65.0.27:34283",
+					"172.17.0.1:34283",
+					"172.18.0.1:34283",
+					"172.19.0.1:34283"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:30:20.792200822Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3830844946326826,
+				"StableID":   "nPH6oSozuW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b69d5fab1f0b095ec70aa46ca53bd056781363a28888a423801a489254b2ac52",
+				"DiscoKey":   "discokey:27acdd51e51a44c4206d1c586b738dfe03cd00d8c9ac88553d3f8f0e50717b29",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60082",
+					"10.65.0.27:60082",
+					"172.17.0.1:60082",
+					"172.18.0.1:60082",
+					"172.19.0.1:60082"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:30:21.339080373Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6776706978776085,
+				"StableID":   "nQUMyrbBvu11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d43fe02739ee5b99822d3d4a54fb69788ec4006ef9af7094c1fbe3d39f518e4e",
+				"DiscoKey":   "discokey:b68e46dec8be212a99e2f1b6a6221ceb90f9e80968dac80a3a5ae878730a0f4a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:44762",
+					"10.65.0.27:44762",
+					"172.17.0.1:44762",
+					"172.18.0.1:44762",
+					"172.19.0.1:44762"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:30:21.902224732Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1005304979881960,
+				"StableID":   "nTNtZ7fJr811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:92d9452ce371b4c90c7617fe71f6f48613fe1bb2cb9dd379e08337ce16d9ff47",
+				"DiscoKey":   "discokey:a2cfbf2f8b46fc59bd33d8c443bd8c6be2a87b263d41b5bdb1430fb1ad54fb0b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52244",
+					"10.65.0.27:52244",
+					"172.17.0.1:52244",
+					"172.18.0.1:52244",
+					"172.19.0.1:52244"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:30:22.43445845Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8489061735454324,
+				"StableID":   "n95t8uFiH921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c62b86931e6b622b34bfc717924936b0c2231ac2e19b4b331204a45e4ada27",
+				"DiscoKey":   "discokey:776022425aecc87acb45053277dff54c08003fff153d3b55ebabb73d68d6352c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38195",
+					"10.65.0.27:38195",
+					"172.17.0.1:38195",
+					"172.18.0.1:38195",
+					"172.19.0.1:38195"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:30:22.961115111Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2394680142011296,
+				"StableID":   "nBgFxpBZhK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80aec655a8cc49c80e1ba3e8c352ec13cb1cbd9274e57002bb5f5b1c51851e07",
+				"DiscoKey":   "discokey:74db6cb0c770b0739fe07f2efd42c6d2984f699938fbc421b66f22b63b68be61",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57820",
+					"10.65.0.27:57820",
+					"172.17.0.1:57820",
+					"172.18.0.1:57820",
+					"172.19.0.1:57820"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:30:23.51321532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2251594598435450,
+				"StableID":   "n94YSBakaJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a829dfba8699f24fe83d00c4a279b046831b751fd1e966353d7e5b3fc167ea6e",
+				"DiscoKey":   "discokey:c006bd6fb6c1b0d06e567c089f3178c48f8ad5103d0e7afacff0ff2ca2f6b06e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41450",
+					"10.65.0.27:41450",
+					"172.17.0.1:41450",
+					"172.18.0.1:41450",
+					"172.19.0.1:41450"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:30:24.595253469Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4816476707442839,
+				"StableID":   "nkBTPCgPce11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5b9eb4138628045a22c62402aebcc9c6835cce155bcdd0f0533fb214b7ff15f",
+				"DiscoKey":   "discokey:6fb532b65fa744aa1c90b3b89b26b530df389725630c419d3aa58e3259060704",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:45681",
+					"10.65.0.27:45681",
+					"172.17.0.1:45681",
+					"172.18.0.1:45681",
+					"172.19.0.1:45681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:30:25.139879467Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5786760251953305,
+				"StableID":   "nY6sdzNqBn11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a50de24d35d34bb9fe585388ee3e1b9e66a586807d4dc1b5b1270841c76edc3c",
+				"DiscoKey":   "discokey:58ed0fdadead5e4eb9f2f7331145e6c638e35c6c2df7f2a4fd5aeefff7f3b107",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37192",
+					"10.65.0.27:37192",
+					"172.17.0.1:37192",
+					"172.18.0.1:37192",
+					"172.19.0.1:37192"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:30:25.691602268Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5575515825480772,
+				"StableID":   "nM7N36MAYk11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22f23d1aef122a38aff753a4dcc1ca1a306a1c4c8881e4ffcdf4d11d3aaf5605",
+				"DiscoKey":   "discokey:42c40123e92f4a7fa35727fde5e3d50d543f36e4374ebac8c09f5d2f18e95e0d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44034",
+					"10.65.0.27:44034",
+					"172.17.0.1:44034",
+					"172.18.0.1:44034",
+					"172.19.0.1:44034"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:30:26.266481848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5311293380078928,
+				"StableID":   "nHu1LufVUi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e18bfb7aa84dad4f4704bdb2487ee9af863ea3b3808e7cd62b0657e426804e2c",
+				"KeyExpiry":  "2026-11-09T07:30:26Z",
+				"DiscoKey":   "discokey:a6cb7ce052f6ec9c272762f1833dcab23942fee8efd11650ff8df2840879014e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46993",
+					"10.65.0.27:46993",
+					"172.17.0.1:46993",
+					"172.18.0.1:46993",
+					"172.19.0.1:46993"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:30:26.748974425Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3323207611793525,
+				"StableID":   "nLg8sf26xS11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:f1913735a8418130e2a7eefc0f60ec361b8c578095fea9ef283b91d86825954a",
+				"KeyExpiry":  "2026-11-09T07:30:27Z",
+				"DiscoKey":   "discokey:7d0f7630074002017a70edc672bcf78430971ab2e52e6f84145ba3e887811a54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57210",
+					"10.65.0.27:57210",
+					"172.17.0.1:57210",
+					"172.18.0.1:57210",
+					"172.19.0.1:57210"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:30:27.288549736Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6311515598068846,
+				"StableID":   "nsXdd7pVHr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a788a78d6bd7d8c1c1e75c201b74708f9fd19e670752963691f48038dfcd9c33",
+				"KeyExpiry":  "2026-11-09T07:30:27Z",
+				"DiscoKey":   "discokey:ab99184e7b0e520ce990100afb94c48331a0ef6c4f5ad51bcd459cc66fe8442a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59113",
+					"10.65.0.27:59113",
+					"172.17.0.1:59113",
+					"172.18.0.1:59113",
+					"172.19.0.1:59113"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:30:27.83146134Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "766763268033513": {
+				"ID":          766763268033513,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5311293380078928,
+				"StableID":   "nHu1LufVUi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e18bfb7aa84dad4f4704bdb2487ee9af863ea3b3808e7cd62b0657e426804e2c",
+				"KeyExpiry":  "2026-11-09T07:30:26Z",
+				"DiscoKey":   "discokey:a6cb7ce052f6ec9c272762f1833dcab23942fee8efd11650ff8df2840879014e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46993",
+					"10.65.0.27:46993",
+					"172.17.0.1:46993",
+					"172.18.0.1:46993",
+					"172.19.0.1:46993"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:30:26.748974425Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e18bfb7aa84dad4f4704bdb2487ee9af863ea3b3808e7cd62b0657e426804e2c",
+			"MachineKey": "mkey:418d965e07a40b8ec762a2c7182ef368e3e7c57b430956fce938674d903d705f",
+			"Peers": [{
+				"ID":         3164653122742097,
+				"StableID":   "nk8Tc85HiR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab04e30f70501875b9c5b5e1d82f21ddb04bb5ccd61242d2ba7781f755d3a12e",
+				"DiscoKey":   "discokey:e6b5d77ffb8873dbb3c2c68787c1e9b9245864148a5497e10525eda5b231823e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45744",
+					"10.65.0.27:45744",
+					"172.17.0.1:45744",
+					"172.18.0.1:45744",
+					"172.19.0.1:45744"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:30:20.294925753Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6366135317912794,
+				"StableID":   "n9gnEdaEir11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:02ba7fa414f6cbfc2c4583b210b0cf5b7451e524b5cd869cbe0bfe373be19a51",
+				"DiscoKey":   "discokey:97abad92a3e31a044e3bc0370708a83ad533ffb308918d7cd443648e1ae65a0a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34283",
+					"10.65.0.27:34283",
+					"172.17.0.1:34283",
+					"172.18.0.1:34283",
+					"172.19.0.1:34283"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:30:20.792200822Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3830844946326826,
+				"StableID":   "nPH6oSozuW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b69d5fab1f0b095ec70aa46ca53bd056781363a28888a423801a489254b2ac52",
+				"DiscoKey":   "discokey:27acdd51e51a44c4206d1c586b738dfe03cd00d8c9ac88553d3f8f0e50717b29",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60082",
+					"10.65.0.27:60082",
+					"172.17.0.1:60082",
+					"172.18.0.1:60082",
+					"172.19.0.1:60082"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:30:21.339080373Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6776706978776085,
+				"StableID":   "nQUMyrbBvu11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d43fe02739ee5b99822d3d4a54fb69788ec4006ef9af7094c1fbe3d39f518e4e",
+				"DiscoKey":   "discokey:b68e46dec8be212a99e2f1b6a6221ceb90f9e80968dac80a3a5ae878730a0f4a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:44762",
+					"10.65.0.27:44762",
+					"172.17.0.1:44762",
+					"172.18.0.1:44762",
+					"172.19.0.1:44762"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:30:21.902224732Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1005304979881960,
+				"StableID":   "nTNtZ7fJr811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:92d9452ce371b4c90c7617fe71f6f48613fe1bb2cb9dd379e08337ce16d9ff47",
+				"DiscoKey":   "discokey:a2cfbf2f8b46fc59bd33d8c443bd8c6be2a87b263d41b5bdb1430fb1ad54fb0b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52244",
+					"10.65.0.27:52244",
+					"172.17.0.1:52244",
+					"172.18.0.1:52244",
+					"172.19.0.1:52244"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:30:22.43445845Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8489061735454324,
+				"StableID":   "n95t8uFiH921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c62b86931e6b622b34bfc717924936b0c2231ac2e19b4b331204a45e4ada27",
+				"DiscoKey":   "discokey:776022425aecc87acb45053277dff54c08003fff153d3b55ebabb73d68d6352c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38195",
+					"10.65.0.27:38195",
+					"172.17.0.1:38195",
+					"172.18.0.1:38195",
+					"172.19.0.1:38195"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:30:22.961115111Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2394680142011296,
+				"StableID":   "nBgFxpBZhK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80aec655a8cc49c80e1ba3e8c352ec13cb1cbd9274e57002bb5f5b1c51851e07",
+				"DiscoKey":   "discokey:74db6cb0c770b0739fe07f2efd42c6d2984f699938fbc421b66f22b63b68be61",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57820",
+					"10.65.0.27:57820",
+					"172.17.0.1:57820",
+					"172.18.0.1:57820",
+					"172.19.0.1:57820"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:30:23.51321532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         766763268033513,
+				"StableID":   "nQGeL7aGz611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:66e22ff199441d463dedf0c50b830dec510fd1a5f08abda4e22cf225e4741e01",
+				"DiscoKey":   "discokey:d82c16f2643e512dfa7449e2484f26d853b321594beeb7ece70b738036575a6c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:60755",
+					"10.65.0.27:60755",
+					"172.17.0.1:60755",
+					"172.18.0.1:60755",
+					"172.19.0.1:60755"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:30:24.059962501Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2251594598435450,
+				"StableID":   "n94YSBakaJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a829dfba8699f24fe83d00c4a279b046831b751fd1e966353d7e5b3fc167ea6e",
+				"DiscoKey":   "discokey:c006bd6fb6c1b0d06e567c089f3178c48f8ad5103d0e7afacff0ff2ca2f6b06e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41450",
+					"10.65.0.27:41450",
+					"172.17.0.1:41450",
+					"172.18.0.1:41450",
+					"172.19.0.1:41450"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:30:24.595253469Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4816476707442839,
+				"StableID":   "nkBTPCgPce11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5b9eb4138628045a22c62402aebcc9c6835cce155bcdd0f0533fb214b7ff15f",
+				"DiscoKey":   "discokey:6fb532b65fa744aa1c90b3b89b26b530df389725630c419d3aa58e3259060704",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:45681",
+					"10.65.0.27:45681",
+					"172.17.0.1:45681",
+					"172.18.0.1:45681",
+					"172.19.0.1:45681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:30:25.139879467Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5786760251953305,
+				"StableID":   "nY6sdzNqBn11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a50de24d35d34bb9fe585388ee3e1b9e66a586807d4dc1b5b1270841c76edc3c",
+				"DiscoKey":   "discokey:58ed0fdadead5e4eb9f2f7331145e6c638e35c6c2df7f2a4fd5aeefff7f3b107",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37192",
+					"10.65.0.27:37192",
+					"172.17.0.1:37192",
+					"172.18.0.1:37192",
+					"172.19.0.1:37192"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:30:25.691602268Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5575515825480772,
+				"StableID":   "nM7N36MAYk11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22f23d1aef122a38aff753a4dcc1ca1a306a1c4c8881e4ffcdf4d11d3aaf5605",
+				"DiscoKey":   "discokey:42c40123e92f4a7fa35727fde5e3d50d543f36e4374ebac8c09f5d2f18e95e0d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44034",
+					"10.65.0.27:44034",
+					"172.17.0.1:44034",
+					"172.18.0.1:44034",
+					"172.19.0.1:44034"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:30:26.266481848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3323207611793525,
+				"StableID":   "nLg8sf26xS11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:f1913735a8418130e2a7eefc0f60ec361b8c578095fea9ef283b91d86825954a",
+				"KeyExpiry":  "2026-11-09T07:30:27Z",
+				"DiscoKey":   "discokey:7d0f7630074002017a70edc672bcf78430971ab2e52e6f84145ba3e887811a54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57210",
+					"10.65.0.27:57210",
+					"172.17.0.1:57210",
+					"172.18.0.1:57210",
+					"172.19.0.1:57210"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:30:27.288549736Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6311515598068846,
+				"StableID":   "nsXdd7pVHr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a788a78d6bd7d8c1c1e75c201b74708f9fd19e670752963691f48038dfcd9c33",
+				"KeyExpiry":  "2026-11-09T07:30:27Z",
+				"DiscoKey":   "discokey:ab99184e7b0e520ce990100afb94c48331a0ef6c4f5ad51bcd459cc66fe8442a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59113",
+					"10.65.0.27:59113",
+					"172.17.0.1:59113",
+					"172.18.0.1:59113",
+					"172.19.0.1:59113"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:30:27.83146134Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5786760251953305,
+				"StableID":   "nY6sdzNqBn11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       5786760251953305,
+				"Key":        "nodekey:a50de24d35d34bb9fe585388ee3e1b9e66a586807d4dc1b5b1270841c76edc3c",
+				"DiscoKey":   "discokey:58ed0fdadead5e4eb9f2f7331145e6c638e35c6c2df7f2a4fd5aeefff7f3b107",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37192",
+					"10.65.0.27:37192",
+					"172.17.0.1:37192",
+					"172.18.0.1:37192",
+					"172.19.0.1:37192"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:30:25.691602268Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a50de24d35d34bb9fe585388ee3e1b9e66a586807d4dc1b5b1270841c76edc3c",
+			"MachineKey": "mkey:6cbdbafc12ff81ae43533be3ce8c6c3790dd7fafe8effefb67439f170c3bb753",
+			"Peers": [{
+				"ID":         3164653122742097,
+				"StableID":   "nk8Tc85HiR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab04e30f70501875b9c5b5e1d82f21ddb04bb5ccd61242d2ba7781f755d3a12e",
+				"DiscoKey":   "discokey:e6b5d77ffb8873dbb3c2c68787c1e9b9245864148a5497e10525eda5b231823e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45744",
+					"10.65.0.27:45744",
+					"172.17.0.1:45744",
+					"172.18.0.1:45744",
+					"172.19.0.1:45744"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:30:20.294925753Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6366135317912794,
+				"StableID":   "n9gnEdaEir11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:02ba7fa414f6cbfc2c4583b210b0cf5b7451e524b5cd869cbe0bfe373be19a51",
+				"DiscoKey":   "discokey:97abad92a3e31a044e3bc0370708a83ad533ffb308918d7cd443648e1ae65a0a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34283",
+					"10.65.0.27:34283",
+					"172.17.0.1:34283",
+					"172.18.0.1:34283",
+					"172.19.0.1:34283"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:30:20.792200822Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3830844946326826,
+				"StableID":   "nPH6oSozuW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b69d5fab1f0b095ec70aa46ca53bd056781363a28888a423801a489254b2ac52",
+				"DiscoKey":   "discokey:27acdd51e51a44c4206d1c586b738dfe03cd00d8c9ac88553d3f8f0e50717b29",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60082",
+					"10.65.0.27:60082",
+					"172.17.0.1:60082",
+					"172.18.0.1:60082",
+					"172.19.0.1:60082"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:30:21.339080373Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6776706978776085,
+				"StableID":   "nQUMyrbBvu11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d43fe02739ee5b99822d3d4a54fb69788ec4006ef9af7094c1fbe3d39f518e4e",
+				"DiscoKey":   "discokey:b68e46dec8be212a99e2f1b6a6221ceb90f9e80968dac80a3a5ae878730a0f4a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:44762",
+					"10.65.0.27:44762",
+					"172.17.0.1:44762",
+					"172.18.0.1:44762",
+					"172.19.0.1:44762"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:30:21.902224732Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1005304979881960,
+				"StableID":   "nTNtZ7fJr811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:92d9452ce371b4c90c7617fe71f6f48613fe1bb2cb9dd379e08337ce16d9ff47",
+				"DiscoKey":   "discokey:a2cfbf2f8b46fc59bd33d8c443bd8c6be2a87b263d41b5bdb1430fb1ad54fb0b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52244",
+					"10.65.0.27:52244",
+					"172.17.0.1:52244",
+					"172.18.0.1:52244",
+					"172.19.0.1:52244"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:30:22.43445845Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8489061735454324,
+				"StableID":   "n95t8uFiH921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c62b86931e6b622b34bfc717924936b0c2231ac2e19b4b331204a45e4ada27",
+				"DiscoKey":   "discokey:776022425aecc87acb45053277dff54c08003fff153d3b55ebabb73d68d6352c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38195",
+					"10.65.0.27:38195",
+					"172.17.0.1:38195",
+					"172.18.0.1:38195",
+					"172.19.0.1:38195"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:30:22.961115111Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2394680142011296,
+				"StableID":   "nBgFxpBZhK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80aec655a8cc49c80e1ba3e8c352ec13cb1cbd9274e57002bb5f5b1c51851e07",
+				"DiscoKey":   "discokey:74db6cb0c770b0739fe07f2efd42c6d2984f699938fbc421b66f22b63b68be61",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57820",
+					"10.65.0.27:57820",
+					"172.17.0.1:57820",
+					"172.18.0.1:57820",
+					"172.19.0.1:57820"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:30:23.51321532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         766763268033513,
+				"StableID":   "nQGeL7aGz611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:66e22ff199441d463dedf0c50b830dec510fd1a5f08abda4e22cf225e4741e01",
+				"DiscoKey":   "discokey:d82c16f2643e512dfa7449e2484f26d853b321594beeb7ece70b738036575a6c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:60755",
+					"10.65.0.27:60755",
+					"172.17.0.1:60755",
+					"172.18.0.1:60755",
+					"172.19.0.1:60755"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:30:24.059962501Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2251594598435450,
+				"StableID":   "n94YSBakaJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a829dfba8699f24fe83d00c4a279b046831b751fd1e966353d7e5b3fc167ea6e",
+				"DiscoKey":   "discokey:c006bd6fb6c1b0d06e567c089f3178c48f8ad5103d0e7afacff0ff2ca2f6b06e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41450",
+					"10.65.0.27:41450",
+					"172.17.0.1:41450",
+					"172.18.0.1:41450",
+					"172.19.0.1:41450"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:30:24.595253469Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4816476707442839,
+				"StableID":   "nkBTPCgPce11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5b9eb4138628045a22c62402aebcc9c6835cce155bcdd0f0533fb214b7ff15f",
+				"DiscoKey":   "discokey:6fb532b65fa744aa1c90b3b89b26b530df389725630c419d3aa58e3259060704",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:45681",
+					"10.65.0.27:45681",
+					"172.17.0.1:45681",
+					"172.18.0.1:45681",
+					"172.19.0.1:45681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:30:25.139879467Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5575515825480772,
+				"StableID":   "nM7N36MAYk11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22f23d1aef122a38aff753a4dcc1ca1a306a1c4c8881e4ffcdf4d11d3aaf5605",
+				"DiscoKey":   "discokey:42c40123e92f4a7fa35727fde5e3d50d543f36e4374ebac8c09f5d2f18e95e0d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44034",
+					"10.65.0.27:44034",
+					"172.17.0.1:44034",
+					"172.18.0.1:44034",
+					"172.19.0.1:44034"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:30:26.266481848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5311293380078928,
+				"StableID":   "nHu1LufVUi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e18bfb7aa84dad4f4704bdb2487ee9af863ea3b3808e7cd62b0657e426804e2c",
+				"KeyExpiry":  "2026-11-09T07:30:26Z",
+				"DiscoKey":   "discokey:a6cb7ce052f6ec9c272762f1833dcab23942fee8efd11650ff8df2840879014e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46993",
+					"10.65.0.27:46993",
+					"172.17.0.1:46993",
+					"172.18.0.1:46993",
+					"172.19.0.1:46993"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:30:26.748974425Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3323207611793525,
+				"StableID":   "nLg8sf26xS11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:f1913735a8418130e2a7eefc0f60ec361b8c578095fea9ef283b91d86825954a",
+				"KeyExpiry":  "2026-11-09T07:30:27Z",
+				"DiscoKey":   "discokey:7d0f7630074002017a70edc672bcf78430971ab2e52e6f84145ba3e887811a54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57210",
+					"10.65.0.27:57210",
+					"172.17.0.1:57210",
+					"172.18.0.1:57210",
+					"172.19.0.1:57210"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:30:27.288549736Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6311515598068846,
+				"StableID":   "nsXdd7pVHr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a788a78d6bd7d8c1c1e75c201b74708f9fd19e670752963691f48038dfcd9c33",
+				"KeyExpiry":  "2026-11-09T07:30:27Z",
+				"DiscoKey":   "discokey:ab99184e7b0e520ce990100afb94c48331a0ef6c4f5ad51bcd459cc66fe8442a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59113",
+					"10.65.0.27:59113",
+					"172.17.0.1:59113",
+					"172.18.0.1:59113",
+					"172.19.0.1:59113"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:30:27.83146134Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5786760251953305": {
+				"ID":          5786760251953305,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6366135317912794,
+				"StableID":   "n9gnEdaEir11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       6366135317912794,
+				"Key":        "nodekey:02ba7fa414f6cbfc2c4583b210b0cf5b7451e524b5cd869cbe0bfe373be19a51",
+				"DiscoKey":   "discokey:97abad92a3e31a044e3bc0370708a83ad533ffb308918d7cd443648e1ae65a0a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34283",
+					"10.65.0.27:34283",
+					"172.17.0.1:34283",
+					"172.18.0.1:34283",
+					"172.19.0.1:34283"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:30:20.792200822Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:02ba7fa414f6cbfc2c4583b210b0cf5b7451e524b5cd869cbe0bfe373be19a51",
+			"MachineKey": "mkey:6066287483078e7808dbebf4253017bc1435057d0ab416280d85fd1fe0967b10",
+			"Peers": [{
+				"ID":         3164653122742097,
+				"StableID":   "nk8Tc85HiR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab04e30f70501875b9c5b5e1d82f21ddb04bb5ccd61242d2ba7781f755d3a12e",
+				"DiscoKey":   "discokey:e6b5d77ffb8873dbb3c2c68787c1e9b9245864148a5497e10525eda5b231823e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45744",
+					"10.65.0.27:45744",
+					"172.17.0.1:45744",
+					"172.18.0.1:45744",
+					"172.19.0.1:45744"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:30:20.294925753Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3830844946326826,
+				"StableID":   "nPH6oSozuW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b69d5fab1f0b095ec70aa46ca53bd056781363a28888a423801a489254b2ac52",
+				"DiscoKey":   "discokey:27acdd51e51a44c4206d1c586b738dfe03cd00d8c9ac88553d3f8f0e50717b29",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60082",
+					"10.65.0.27:60082",
+					"172.17.0.1:60082",
+					"172.18.0.1:60082",
+					"172.19.0.1:60082"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:30:21.339080373Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6776706978776085,
+				"StableID":   "nQUMyrbBvu11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d43fe02739ee5b99822d3d4a54fb69788ec4006ef9af7094c1fbe3d39f518e4e",
+				"DiscoKey":   "discokey:b68e46dec8be212a99e2f1b6a6221ceb90f9e80968dac80a3a5ae878730a0f4a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:44762",
+					"10.65.0.27:44762",
+					"172.17.0.1:44762",
+					"172.18.0.1:44762",
+					"172.19.0.1:44762"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:30:21.902224732Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1005304979881960,
+				"StableID":   "nTNtZ7fJr811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:92d9452ce371b4c90c7617fe71f6f48613fe1bb2cb9dd379e08337ce16d9ff47",
+				"DiscoKey":   "discokey:a2cfbf2f8b46fc59bd33d8c443bd8c6be2a87b263d41b5bdb1430fb1ad54fb0b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52244",
+					"10.65.0.27:52244",
+					"172.17.0.1:52244",
+					"172.18.0.1:52244",
+					"172.19.0.1:52244"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:30:22.43445845Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8489061735454324,
+				"StableID":   "n95t8uFiH921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c62b86931e6b622b34bfc717924936b0c2231ac2e19b4b331204a45e4ada27",
+				"DiscoKey":   "discokey:776022425aecc87acb45053277dff54c08003fff153d3b55ebabb73d68d6352c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38195",
+					"10.65.0.27:38195",
+					"172.17.0.1:38195",
+					"172.18.0.1:38195",
+					"172.19.0.1:38195"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:30:22.961115111Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2394680142011296,
+				"StableID":   "nBgFxpBZhK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80aec655a8cc49c80e1ba3e8c352ec13cb1cbd9274e57002bb5f5b1c51851e07",
+				"DiscoKey":   "discokey:74db6cb0c770b0739fe07f2efd42c6d2984f699938fbc421b66f22b63b68be61",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57820",
+					"10.65.0.27:57820",
+					"172.17.0.1:57820",
+					"172.18.0.1:57820",
+					"172.19.0.1:57820"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:30:23.51321532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         766763268033513,
+				"StableID":   "nQGeL7aGz611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:66e22ff199441d463dedf0c50b830dec510fd1a5f08abda4e22cf225e4741e01",
+				"DiscoKey":   "discokey:d82c16f2643e512dfa7449e2484f26d853b321594beeb7ece70b738036575a6c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:60755",
+					"10.65.0.27:60755",
+					"172.17.0.1:60755",
+					"172.18.0.1:60755",
+					"172.19.0.1:60755"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:30:24.059962501Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2251594598435450,
+				"StableID":   "n94YSBakaJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a829dfba8699f24fe83d00c4a279b046831b751fd1e966353d7e5b3fc167ea6e",
+				"DiscoKey":   "discokey:c006bd6fb6c1b0d06e567c089f3178c48f8ad5103d0e7afacff0ff2ca2f6b06e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41450",
+					"10.65.0.27:41450",
+					"172.17.0.1:41450",
+					"172.18.0.1:41450",
+					"172.19.0.1:41450"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:30:24.595253469Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4816476707442839,
+				"StableID":   "nkBTPCgPce11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5b9eb4138628045a22c62402aebcc9c6835cce155bcdd0f0533fb214b7ff15f",
+				"DiscoKey":   "discokey:6fb532b65fa744aa1c90b3b89b26b530df389725630c419d3aa58e3259060704",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:45681",
+					"10.65.0.27:45681",
+					"172.17.0.1:45681",
+					"172.18.0.1:45681",
+					"172.19.0.1:45681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:30:25.139879467Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5786760251953305,
+				"StableID":   "nY6sdzNqBn11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a50de24d35d34bb9fe585388ee3e1b9e66a586807d4dc1b5b1270841c76edc3c",
+				"DiscoKey":   "discokey:58ed0fdadead5e4eb9f2f7331145e6c638e35c6c2df7f2a4fd5aeefff7f3b107",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37192",
+					"10.65.0.27:37192",
+					"172.17.0.1:37192",
+					"172.18.0.1:37192",
+					"172.19.0.1:37192"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:30:25.691602268Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5575515825480772,
+				"StableID":   "nM7N36MAYk11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22f23d1aef122a38aff753a4dcc1ca1a306a1c4c8881e4ffcdf4d11d3aaf5605",
+				"DiscoKey":   "discokey:42c40123e92f4a7fa35727fde5e3d50d543f36e4374ebac8c09f5d2f18e95e0d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44034",
+					"10.65.0.27:44034",
+					"172.17.0.1:44034",
+					"172.18.0.1:44034",
+					"172.19.0.1:44034"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:30:26.266481848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5311293380078928,
+				"StableID":   "nHu1LufVUi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e18bfb7aa84dad4f4704bdb2487ee9af863ea3b3808e7cd62b0657e426804e2c",
+				"KeyExpiry":  "2026-11-09T07:30:26Z",
+				"DiscoKey":   "discokey:a6cb7ce052f6ec9c272762f1833dcab23942fee8efd11650ff8df2840879014e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46993",
+					"10.65.0.27:46993",
+					"172.17.0.1:46993",
+					"172.18.0.1:46993",
+					"172.19.0.1:46993"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:30:26.748974425Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3323207611793525,
+				"StableID":   "nLg8sf26xS11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:f1913735a8418130e2a7eefc0f60ec361b8c578095fea9ef283b91d86825954a",
+				"KeyExpiry":  "2026-11-09T07:30:27Z",
+				"DiscoKey":   "discokey:7d0f7630074002017a70edc672bcf78430971ab2e52e6f84145ba3e887811a54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57210",
+					"10.65.0.27:57210",
+					"172.17.0.1:57210",
+					"172.18.0.1:57210",
+					"172.19.0.1:57210"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:30:27.288549736Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6311515598068846,
+				"StableID":   "nsXdd7pVHr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a788a78d6bd7d8c1c1e75c201b74708f9fd19e670752963691f48038dfcd9c33",
+				"KeyExpiry":  "2026-11-09T07:30:27Z",
+				"DiscoKey":   "discokey:ab99184e7b0e520ce990100afb94c48331a0ef6c4f5ad51bcd459cc66fe8442a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59113",
+					"10.65.0.27:59113",
+					"172.17.0.1:59113",
+					"172.18.0.1:59113",
+					"172.19.0.1:59113"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:30:27.83146134Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6366135317912794": {
+				"ID":          6366135317912794,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3164653122742097,
+				"StableID":   "nk8Tc85HiR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       3164653122742097,
+				"Key":        "nodekey:ab04e30f70501875b9c5b5e1d82f21ddb04bb5ccd61242d2ba7781f755d3a12e",
+				"DiscoKey":   "discokey:e6b5d77ffb8873dbb3c2c68787c1e9b9245864148a5497e10525eda5b231823e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45744",
+					"10.65.0.27:45744",
+					"172.17.0.1:45744",
+					"172.18.0.1:45744",
+					"172.19.0.1:45744"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:30:20.294925753Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ab04e30f70501875b9c5b5e1d82f21ddb04bb5ccd61242d2ba7781f755d3a12e",
+			"MachineKey": "mkey:769de555d82c4aca39952678d9c21a721c5fc6edf8c66fa08e51754ddbaa986e",
+			"Peers": [{
+				"ID":         6366135317912794,
+				"StableID":   "n9gnEdaEir11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:02ba7fa414f6cbfc2c4583b210b0cf5b7451e524b5cd869cbe0bfe373be19a51",
+				"DiscoKey":   "discokey:97abad92a3e31a044e3bc0370708a83ad533ffb308918d7cd443648e1ae65a0a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34283",
+					"10.65.0.27:34283",
+					"172.17.0.1:34283",
+					"172.18.0.1:34283",
+					"172.19.0.1:34283"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:30:20.792200822Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3830844946326826,
+				"StableID":   "nPH6oSozuW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b69d5fab1f0b095ec70aa46ca53bd056781363a28888a423801a489254b2ac52",
+				"DiscoKey":   "discokey:27acdd51e51a44c4206d1c586b738dfe03cd00d8c9ac88553d3f8f0e50717b29",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60082",
+					"10.65.0.27:60082",
+					"172.17.0.1:60082",
+					"172.18.0.1:60082",
+					"172.19.0.1:60082"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:30:21.339080373Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6776706978776085,
+				"StableID":   "nQUMyrbBvu11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d43fe02739ee5b99822d3d4a54fb69788ec4006ef9af7094c1fbe3d39f518e4e",
+				"DiscoKey":   "discokey:b68e46dec8be212a99e2f1b6a6221ceb90f9e80968dac80a3a5ae878730a0f4a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:44762",
+					"10.65.0.27:44762",
+					"172.17.0.1:44762",
+					"172.18.0.1:44762",
+					"172.19.0.1:44762"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:30:21.902224732Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1005304979881960,
+				"StableID":   "nTNtZ7fJr811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:92d9452ce371b4c90c7617fe71f6f48613fe1bb2cb9dd379e08337ce16d9ff47",
+				"DiscoKey":   "discokey:a2cfbf2f8b46fc59bd33d8c443bd8c6be2a87b263d41b5bdb1430fb1ad54fb0b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52244",
+					"10.65.0.27:52244",
+					"172.17.0.1:52244",
+					"172.18.0.1:52244",
+					"172.19.0.1:52244"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:30:22.43445845Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8489061735454324,
+				"StableID":   "n95t8uFiH921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c62b86931e6b622b34bfc717924936b0c2231ac2e19b4b331204a45e4ada27",
+				"DiscoKey":   "discokey:776022425aecc87acb45053277dff54c08003fff153d3b55ebabb73d68d6352c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38195",
+					"10.65.0.27:38195",
+					"172.17.0.1:38195",
+					"172.18.0.1:38195",
+					"172.19.0.1:38195"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:30:22.961115111Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2394680142011296,
+				"StableID":   "nBgFxpBZhK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80aec655a8cc49c80e1ba3e8c352ec13cb1cbd9274e57002bb5f5b1c51851e07",
+				"DiscoKey":   "discokey:74db6cb0c770b0739fe07f2efd42c6d2984f699938fbc421b66f22b63b68be61",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57820",
+					"10.65.0.27:57820",
+					"172.17.0.1:57820",
+					"172.18.0.1:57820",
+					"172.19.0.1:57820"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:30:23.51321532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         766763268033513,
+				"StableID":   "nQGeL7aGz611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:66e22ff199441d463dedf0c50b830dec510fd1a5f08abda4e22cf225e4741e01",
+				"DiscoKey":   "discokey:d82c16f2643e512dfa7449e2484f26d853b321594beeb7ece70b738036575a6c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:60755",
+					"10.65.0.27:60755",
+					"172.17.0.1:60755",
+					"172.18.0.1:60755",
+					"172.19.0.1:60755"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:30:24.059962501Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2251594598435450,
+				"StableID":   "n94YSBakaJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a829dfba8699f24fe83d00c4a279b046831b751fd1e966353d7e5b3fc167ea6e",
+				"DiscoKey":   "discokey:c006bd6fb6c1b0d06e567c089f3178c48f8ad5103d0e7afacff0ff2ca2f6b06e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41450",
+					"10.65.0.27:41450",
+					"172.17.0.1:41450",
+					"172.18.0.1:41450",
+					"172.19.0.1:41450"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:30:24.595253469Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4816476707442839,
+				"StableID":   "nkBTPCgPce11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5b9eb4138628045a22c62402aebcc9c6835cce155bcdd0f0533fb214b7ff15f",
+				"DiscoKey":   "discokey:6fb532b65fa744aa1c90b3b89b26b530df389725630c419d3aa58e3259060704",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:45681",
+					"10.65.0.27:45681",
+					"172.17.0.1:45681",
+					"172.18.0.1:45681",
+					"172.19.0.1:45681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:30:25.139879467Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5786760251953305,
+				"StableID":   "nY6sdzNqBn11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a50de24d35d34bb9fe585388ee3e1b9e66a586807d4dc1b5b1270841c76edc3c",
+				"DiscoKey":   "discokey:58ed0fdadead5e4eb9f2f7331145e6c638e35c6c2df7f2a4fd5aeefff7f3b107",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37192",
+					"10.65.0.27:37192",
+					"172.17.0.1:37192",
+					"172.18.0.1:37192",
+					"172.19.0.1:37192"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:30:25.691602268Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5575515825480772,
+				"StableID":   "nM7N36MAYk11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22f23d1aef122a38aff753a4dcc1ca1a306a1c4c8881e4ffcdf4d11d3aaf5605",
+				"DiscoKey":   "discokey:42c40123e92f4a7fa35727fde5e3d50d543f36e4374ebac8c09f5d2f18e95e0d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44034",
+					"10.65.0.27:44034",
+					"172.17.0.1:44034",
+					"172.18.0.1:44034",
+					"172.19.0.1:44034"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:30:26.266481848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5311293380078928,
+				"StableID":   "nHu1LufVUi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e18bfb7aa84dad4f4704bdb2487ee9af863ea3b3808e7cd62b0657e426804e2c",
+				"KeyExpiry":  "2026-11-09T07:30:26Z",
+				"DiscoKey":   "discokey:a6cb7ce052f6ec9c272762f1833dcab23942fee8efd11650ff8df2840879014e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46993",
+					"10.65.0.27:46993",
+					"172.17.0.1:46993",
+					"172.18.0.1:46993",
+					"172.19.0.1:46993"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:30:26.748974425Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3323207611793525,
+				"StableID":   "nLg8sf26xS11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:f1913735a8418130e2a7eefc0f60ec361b8c578095fea9ef283b91d86825954a",
+				"KeyExpiry":  "2026-11-09T07:30:27Z",
+				"DiscoKey":   "discokey:7d0f7630074002017a70edc672bcf78430971ab2e52e6f84145ba3e887811a54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57210",
+					"10.65.0.27:57210",
+					"172.17.0.1:57210",
+					"172.18.0.1:57210",
+					"172.19.0.1:57210"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:30:27.288549736Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6311515598068846,
+				"StableID":   "nsXdd7pVHr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a788a78d6bd7d8c1c1e75c201b74708f9fd19e670752963691f48038dfcd9c33",
+				"KeyExpiry":  "2026-11-09T07:30:27Z",
+				"DiscoKey":   "discokey:ab99184e7b0e520ce990100afb94c48331a0ef6c4f5ad51bcd459cc66fe8442a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59113",
+					"10.65.0.27:59113",
+					"172.17.0.1:59113",
+					"172.18.0.1:59113",
+					"172.19.0.1:59113"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:30:27.83146134Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3164653122742097": {
+				"ID":          3164653122742097,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1005304979881960,
+				"StableID":   "nTNtZ7fJr811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1005304979881960,
+				"Key":        "nodekey:92d9452ce371b4c90c7617fe71f6f48613fe1bb2cb9dd379e08337ce16d9ff47",
+				"DiscoKey":   "discokey:a2cfbf2f8b46fc59bd33d8c443bd8c6be2a87b263d41b5bdb1430fb1ad54fb0b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52244",
+					"10.65.0.27:52244",
+					"172.17.0.1:52244",
+					"172.18.0.1:52244",
+					"172.19.0.1:52244"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:30:22.43445845Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:92d9452ce371b4c90c7617fe71f6f48613fe1bb2cb9dd379e08337ce16d9ff47",
+			"MachineKey": "mkey:ccdfeede0a34861a082fce6ab7180902f01443b1e68cd78db67df8def14a5176",
+			"Peers": [{
+				"ID":         3164653122742097,
+				"StableID":   "nk8Tc85HiR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab04e30f70501875b9c5b5e1d82f21ddb04bb5ccd61242d2ba7781f755d3a12e",
+				"DiscoKey":   "discokey:e6b5d77ffb8873dbb3c2c68787c1e9b9245864148a5497e10525eda5b231823e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45744",
+					"10.65.0.27:45744",
+					"172.17.0.1:45744",
+					"172.18.0.1:45744",
+					"172.19.0.1:45744"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:30:20.294925753Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6366135317912794,
+				"StableID":   "n9gnEdaEir11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:02ba7fa414f6cbfc2c4583b210b0cf5b7451e524b5cd869cbe0bfe373be19a51",
+				"DiscoKey":   "discokey:97abad92a3e31a044e3bc0370708a83ad533ffb308918d7cd443648e1ae65a0a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34283",
+					"10.65.0.27:34283",
+					"172.17.0.1:34283",
+					"172.18.0.1:34283",
+					"172.19.0.1:34283"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:30:20.792200822Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3830844946326826,
+				"StableID":   "nPH6oSozuW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b69d5fab1f0b095ec70aa46ca53bd056781363a28888a423801a489254b2ac52",
+				"DiscoKey":   "discokey:27acdd51e51a44c4206d1c586b738dfe03cd00d8c9ac88553d3f8f0e50717b29",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60082",
+					"10.65.0.27:60082",
+					"172.17.0.1:60082",
+					"172.18.0.1:60082",
+					"172.19.0.1:60082"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:30:21.339080373Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6776706978776085,
+				"StableID":   "nQUMyrbBvu11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d43fe02739ee5b99822d3d4a54fb69788ec4006ef9af7094c1fbe3d39f518e4e",
+				"DiscoKey":   "discokey:b68e46dec8be212a99e2f1b6a6221ceb90f9e80968dac80a3a5ae878730a0f4a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:44762",
+					"10.65.0.27:44762",
+					"172.17.0.1:44762",
+					"172.18.0.1:44762",
+					"172.19.0.1:44762"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:30:21.902224732Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8489061735454324,
+				"StableID":   "n95t8uFiH921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c62b86931e6b622b34bfc717924936b0c2231ac2e19b4b331204a45e4ada27",
+				"DiscoKey":   "discokey:776022425aecc87acb45053277dff54c08003fff153d3b55ebabb73d68d6352c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38195",
+					"10.65.0.27:38195",
+					"172.17.0.1:38195",
+					"172.18.0.1:38195",
+					"172.19.0.1:38195"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:30:22.961115111Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2394680142011296,
+				"StableID":   "nBgFxpBZhK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80aec655a8cc49c80e1ba3e8c352ec13cb1cbd9274e57002bb5f5b1c51851e07",
+				"DiscoKey":   "discokey:74db6cb0c770b0739fe07f2efd42c6d2984f699938fbc421b66f22b63b68be61",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57820",
+					"10.65.0.27:57820",
+					"172.17.0.1:57820",
+					"172.18.0.1:57820",
+					"172.19.0.1:57820"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:30:23.51321532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         766763268033513,
+				"StableID":   "nQGeL7aGz611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:66e22ff199441d463dedf0c50b830dec510fd1a5f08abda4e22cf225e4741e01",
+				"DiscoKey":   "discokey:d82c16f2643e512dfa7449e2484f26d853b321594beeb7ece70b738036575a6c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:60755",
+					"10.65.0.27:60755",
+					"172.17.0.1:60755",
+					"172.18.0.1:60755",
+					"172.19.0.1:60755"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:30:24.059962501Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2251594598435450,
+				"StableID":   "n94YSBakaJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a829dfba8699f24fe83d00c4a279b046831b751fd1e966353d7e5b3fc167ea6e",
+				"DiscoKey":   "discokey:c006bd6fb6c1b0d06e567c089f3178c48f8ad5103d0e7afacff0ff2ca2f6b06e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41450",
+					"10.65.0.27:41450",
+					"172.17.0.1:41450",
+					"172.18.0.1:41450",
+					"172.19.0.1:41450"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:30:24.595253469Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4816476707442839,
+				"StableID":   "nkBTPCgPce11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5b9eb4138628045a22c62402aebcc9c6835cce155bcdd0f0533fb214b7ff15f",
+				"DiscoKey":   "discokey:6fb532b65fa744aa1c90b3b89b26b530df389725630c419d3aa58e3259060704",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:45681",
+					"10.65.0.27:45681",
+					"172.17.0.1:45681",
+					"172.18.0.1:45681",
+					"172.19.0.1:45681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:30:25.139879467Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5786760251953305,
+				"StableID":   "nY6sdzNqBn11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a50de24d35d34bb9fe585388ee3e1b9e66a586807d4dc1b5b1270841c76edc3c",
+				"DiscoKey":   "discokey:58ed0fdadead5e4eb9f2f7331145e6c638e35c6c2df7f2a4fd5aeefff7f3b107",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37192",
+					"10.65.0.27:37192",
+					"172.17.0.1:37192",
+					"172.18.0.1:37192",
+					"172.19.0.1:37192"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:30:25.691602268Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5575515825480772,
+				"StableID":   "nM7N36MAYk11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22f23d1aef122a38aff753a4dcc1ca1a306a1c4c8881e4ffcdf4d11d3aaf5605",
+				"DiscoKey":   "discokey:42c40123e92f4a7fa35727fde5e3d50d543f36e4374ebac8c09f5d2f18e95e0d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44034",
+					"10.65.0.27:44034",
+					"172.17.0.1:44034",
+					"172.18.0.1:44034",
+					"172.19.0.1:44034"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:30:26.266481848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5311293380078928,
+				"StableID":   "nHu1LufVUi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e18bfb7aa84dad4f4704bdb2487ee9af863ea3b3808e7cd62b0657e426804e2c",
+				"KeyExpiry":  "2026-11-09T07:30:26Z",
+				"DiscoKey":   "discokey:a6cb7ce052f6ec9c272762f1833dcab23942fee8efd11650ff8df2840879014e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46993",
+					"10.65.0.27:46993",
+					"172.17.0.1:46993",
+					"172.18.0.1:46993",
+					"172.19.0.1:46993"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:30:26.748974425Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3323207611793525,
+				"StableID":   "nLg8sf26xS11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:f1913735a8418130e2a7eefc0f60ec361b8c578095fea9ef283b91d86825954a",
+				"KeyExpiry":  "2026-11-09T07:30:27Z",
+				"DiscoKey":   "discokey:7d0f7630074002017a70edc672bcf78430971ab2e52e6f84145ba3e887811a54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57210",
+					"10.65.0.27:57210",
+					"172.17.0.1:57210",
+					"172.18.0.1:57210",
+					"172.19.0.1:57210"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:30:27.288549736Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6311515598068846,
+				"StableID":   "nsXdd7pVHr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a788a78d6bd7d8c1c1e75c201b74708f9fd19e670752963691f48038dfcd9c33",
+				"KeyExpiry":  "2026-11-09T07:30:27Z",
+				"DiscoKey":   "discokey:ab99184e7b0e520ce990100afb94c48331a0ef6c4f5ad51bcd459cc66fe8442a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59113",
+					"10.65.0.27:59113",
+					"172.17.0.1:59113",
+					"172.18.0.1:59113",
+					"172.19.0.1:59113"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:30:27.83146134Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1005304979881960": {
+				"ID":          1005304979881960,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}, "1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6776706978776085,
+				"StableID":   "nQUMyrbBvu11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       6776706978776085,
+				"Key":        "nodekey:d43fe02739ee5b99822d3d4a54fb69788ec4006ef9af7094c1fbe3d39f518e4e",
+				"DiscoKey":   "discokey:b68e46dec8be212a99e2f1b6a6221ceb90f9e80968dac80a3a5ae878730a0f4a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:44762",
+					"10.65.0.27:44762",
+					"172.17.0.1:44762",
+					"172.18.0.1:44762",
+					"172.19.0.1:44762"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:30:21.902224732Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d43fe02739ee5b99822d3d4a54fb69788ec4006ef9af7094c1fbe3d39f518e4e",
+			"MachineKey": "mkey:bdc4ec0080971506597e44804eded4283e5a1beb44eb40ea273855282ffcfd25",
+			"Peers": [{
+				"ID":         3164653122742097,
+				"StableID":   "nk8Tc85HiR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab04e30f70501875b9c5b5e1d82f21ddb04bb5ccd61242d2ba7781f755d3a12e",
+				"DiscoKey":   "discokey:e6b5d77ffb8873dbb3c2c68787c1e9b9245864148a5497e10525eda5b231823e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45744",
+					"10.65.0.27:45744",
+					"172.17.0.1:45744",
+					"172.18.0.1:45744",
+					"172.19.0.1:45744"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:30:20.294925753Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6366135317912794,
+				"StableID":   "n9gnEdaEir11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:02ba7fa414f6cbfc2c4583b210b0cf5b7451e524b5cd869cbe0bfe373be19a51",
+				"DiscoKey":   "discokey:97abad92a3e31a044e3bc0370708a83ad533ffb308918d7cd443648e1ae65a0a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34283",
+					"10.65.0.27:34283",
+					"172.17.0.1:34283",
+					"172.18.0.1:34283",
+					"172.19.0.1:34283"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:30:20.792200822Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3830844946326826,
+				"StableID":   "nPH6oSozuW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b69d5fab1f0b095ec70aa46ca53bd056781363a28888a423801a489254b2ac52",
+				"DiscoKey":   "discokey:27acdd51e51a44c4206d1c586b738dfe03cd00d8c9ac88553d3f8f0e50717b29",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60082",
+					"10.65.0.27:60082",
+					"172.17.0.1:60082",
+					"172.18.0.1:60082",
+					"172.19.0.1:60082"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:30:21.339080373Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1005304979881960,
+				"StableID":   "nTNtZ7fJr811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:92d9452ce371b4c90c7617fe71f6f48613fe1bb2cb9dd379e08337ce16d9ff47",
+				"DiscoKey":   "discokey:a2cfbf2f8b46fc59bd33d8c443bd8c6be2a87b263d41b5bdb1430fb1ad54fb0b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52244",
+					"10.65.0.27:52244",
+					"172.17.0.1:52244",
+					"172.18.0.1:52244",
+					"172.19.0.1:52244"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:30:22.43445845Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8489061735454324,
+				"StableID":   "n95t8uFiH921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c62b86931e6b622b34bfc717924936b0c2231ac2e19b4b331204a45e4ada27",
+				"DiscoKey":   "discokey:776022425aecc87acb45053277dff54c08003fff153d3b55ebabb73d68d6352c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38195",
+					"10.65.0.27:38195",
+					"172.17.0.1:38195",
+					"172.18.0.1:38195",
+					"172.19.0.1:38195"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:30:22.961115111Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2394680142011296,
+				"StableID":   "nBgFxpBZhK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80aec655a8cc49c80e1ba3e8c352ec13cb1cbd9274e57002bb5f5b1c51851e07",
+				"DiscoKey":   "discokey:74db6cb0c770b0739fe07f2efd42c6d2984f699938fbc421b66f22b63b68be61",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57820",
+					"10.65.0.27:57820",
+					"172.17.0.1:57820",
+					"172.18.0.1:57820",
+					"172.19.0.1:57820"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:30:23.51321532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         766763268033513,
+				"StableID":   "nQGeL7aGz611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:66e22ff199441d463dedf0c50b830dec510fd1a5f08abda4e22cf225e4741e01",
+				"DiscoKey":   "discokey:d82c16f2643e512dfa7449e2484f26d853b321594beeb7ece70b738036575a6c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:60755",
+					"10.65.0.27:60755",
+					"172.17.0.1:60755",
+					"172.18.0.1:60755",
+					"172.19.0.1:60755"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:30:24.059962501Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2251594598435450,
+				"StableID":   "n94YSBakaJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a829dfba8699f24fe83d00c4a279b046831b751fd1e966353d7e5b3fc167ea6e",
+				"DiscoKey":   "discokey:c006bd6fb6c1b0d06e567c089f3178c48f8ad5103d0e7afacff0ff2ca2f6b06e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41450",
+					"10.65.0.27:41450",
+					"172.17.0.1:41450",
+					"172.18.0.1:41450",
+					"172.19.0.1:41450"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:30:24.595253469Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4816476707442839,
+				"StableID":   "nkBTPCgPce11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5b9eb4138628045a22c62402aebcc9c6835cce155bcdd0f0533fb214b7ff15f",
+				"DiscoKey":   "discokey:6fb532b65fa744aa1c90b3b89b26b530df389725630c419d3aa58e3259060704",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:45681",
+					"10.65.0.27:45681",
+					"172.17.0.1:45681",
+					"172.18.0.1:45681",
+					"172.19.0.1:45681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:30:25.139879467Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5786760251953305,
+				"StableID":   "nY6sdzNqBn11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a50de24d35d34bb9fe585388ee3e1b9e66a586807d4dc1b5b1270841c76edc3c",
+				"DiscoKey":   "discokey:58ed0fdadead5e4eb9f2f7331145e6c638e35c6c2df7f2a4fd5aeefff7f3b107",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37192",
+					"10.65.0.27:37192",
+					"172.17.0.1:37192",
+					"172.18.0.1:37192",
+					"172.19.0.1:37192"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:30:25.691602268Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5575515825480772,
+				"StableID":   "nM7N36MAYk11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22f23d1aef122a38aff753a4dcc1ca1a306a1c4c8881e4ffcdf4d11d3aaf5605",
+				"DiscoKey":   "discokey:42c40123e92f4a7fa35727fde5e3d50d543f36e4374ebac8c09f5d2f18e95e0d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44034",
+					"10.65.0.27:44034",
+					"172.17.0.1:44034",
+					"172.18.0.1:44034",
+					"172.19.0.1:44034"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:30:26.266481848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5311293380078928,
+				"StableID":   "nHu1LufVUi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e18bfb7aa84dad4f4704bdb2487ee9af863ea3b3808e7cd62b0657e426804e2c",
+				"KeyExpiry":  "2026-11-09T07:30:26Z",
+				"DiscoKey":   "discokey:a6cb7ce052f6ec9c272762f1833dcab23942fee8efd11650ff8df2840879014e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46993",
+					"10.65.0.27:46993",
+					"172.17.0.1:46993",
+					"172.18.0.1:46993",
+					"172.19.0.1:46993"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:30:26.748974425Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3323207611793525,
+				"StableID":   "nLg8sf26xS11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:f1913735a8418130e2a7eefc0f60ec361b8c578095fea9ef283b91d86825954a",
+				"KeyExpiry":  "2026-11-09T07:30:27Z",
+				"DiscoKey":   "discokey:7d0f7630074002017a70edc672bcf78430971ab2e52e6f84145ba3e887811a54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57210",
+					"10.65.0.27:57210",
+					"172.17.0.1:57210",
+					"172.18.0.1:57210",
+					"172.19.0.1:57210"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:30:27.288549736Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6311515598068846,
+				"StableID":   "nsXdd7pVHr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a788a78d6bd7d8c1c1e75c201b74708f9fd19e670752963691f48038dfcd9c33",
+				"KeyExpiry":  "2026-11-09T07:30:27Z",
+				"DiscoKey":   "discokey:ab99184e7b0e520ce990100afb94c48331a0ef6c4f5ad51bcd459cc66fe8442a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59113",
+					"10.65.0.27:59113",
+					"172.17.0.1:59113",
+					"172.18.0.1:59113",
+					"172.19.0.1:59113"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:30:27.83146134Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6776706978776085": {
+				"ID":          6776706978776085,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2394680142011296,
+				"StableID":   "nBgFxpBZhK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       2394680142011296,
+				"Key":        "nodekey:80aec655a8cc49c80e1ba3e8c352ec13cb1cbd9274e57002bb5f5b1c51851e07",
+				"DiscoKey":   "discokey:74db6cb0c770b0739fe07f2efd42c6d2984f699938fbc421b66f22b63b68be61",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57820",
+					"10.65.0.27:57820",
+					"172.17.0.1:57820",
+					"172.18.0.1:57820",
+					"172.19.0.1:57820"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:30:23.51321532Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:80aec655a8cc49c80e1ba3e8c352ec13cb1cbd9274e57002bb5f5b1c51851e07",
+			"MachineKey": "mkey:200272f3ea030a11a1c02d527fb7e64e2907bb972f889068d9aa5049a2e29f61",
+			"Peers": [{
+				"ID":         3164653122742097,
+				"StableID":   "nk8Tc85HiR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab04e30f70501875b9c5b5e1d82f21ddb04bb5ccd61242d2ba7781f755d3a12e",
+				"DiscoKey":   "discokey:e6b5d77ffb8873dbb3c2c68787c1e9b9245864148a5497e10525eda5b231823e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45744",
+					"10.65.0.27:45744",
+					"172.17.0.1:45744",
+					"172.18.0.1:45744",
+					"172.19.0.1:45744"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:30:20.294925753Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6366135317912794,
+				"StableID":   "n9gnEdaEir11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:02ba7fa414f6cbfc2c4583b210b0cf5b7451e524b5cd869cbe0bfe373be19a51",
+				"DiscoKey":   "discokey:97abad92a3e31a044e3bc0370708a83ad533ffb308918d7cd443648e1ae65a0a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34283",
+					"10.65.0.27:34283",
+					"172.17.0.1:34283",
+					"172.18.0.1:34283",
+					"172.19.0.1:34283"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:30:20.792200822Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3830844946326826,
+				"StableID":   "nPH6oSozuW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b69d5fab1f0b095ec70aa46ca53bd056781363a28888a423801a489254b2ac52",
+				"DiscoKey":   "discokey:27acdd51e51a44c4206d1c586b738dfe03cd00d8c9ac88553d3f8f0e50717b29",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60082",
+					"10.65.0.27:60082",
+					"172.17.0.1:60082",
+					"172.18.0.1:60082",
+					"172.19.0.1:60082"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:30:21.339080373Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6776706978776085,
+				"StableID":   "nQUMyrbBvu11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d43fe02739ee5b99822d3d4a54fb69788ec4006ef9af7094c1fbe3d39f518e4e",
+				"DiscoKey":   "discokey:b68e46dec8be212a99e2f1b6a6221ceb90f9e80968dac80a3a5ae878730a0f4a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:44762",
+					"10.65.0.27:44762",
+					"172.17.0.1:44762",
+					"172.18.0.1:44762",
+					"172.19.0.1:44762"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:30:21.902224732Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1005304979881960,
+				"StableID":   "nTNtZ7fJr811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:92d9452ce371b4c90c7617fe71f6f48613fe1bb2cb9dd379e08337ce16d9ff47",
+				"DiscoKey":   "discokey:a2cfbf2f8b46fc59bd33d8c443bd8c6be2a87b263d41b5bdb1430fb1ad54fb0b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52244",
+					"10.65.0.27:52244",
+					"172.17.0.1:52244",
+					"172.18.0.1:52244",
+					"172.19.0.1:52244"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:30:22.43445845Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8489061735454324,
+				"StableID":   "n95t8uFiH921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c62b86931e6b622b34bfc717924936b0c2231ac2e19b4b331204a45e4ada27",
+				"DiscoKey":   "discokey:776022425aecc87acb45053277dff54c08003fff153d3b55ebabb73d68d6352c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38195",
+					"10.65.0.27:38195",
+					"172.17.0.1:38195",
+					"172.18.0.1:38195",
+					"172.19.0.1:38195"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:30:22.961115111Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         766763268033513,
+				"StableID":   "nQGeL7aGz611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:66e22ff199441d463dedf0c50b830dec510fd1a5f08abda4e22cf225e4741e01",
+				"DiscoKey":   "discokey:d82c16f2643e512dfa7449e2484f26d853b321594beeb7ece70b738036575a6c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:60755",
+					"10.65.0.27:60755",
+					"172.17.0.1:60755",
+					"172.18.0.1:60755",
+					"172.19.0.1:60755"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:30:24.059962501Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2251594598435450,
+				"StableID":   "n94YSBakaJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a829dfba8699f24fe83d00c4a279b046831b751fd1e966353d7e5b3fc167ea6e",
+				"DiscoKey":   "discokey:c006bd6fb6c1b0d06e567c089f3178c48f8ad5103d0e7afacff0ff2ca2f6b06e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41450",
+					"10.65.0.27:41450",
+					"172.17.0.1:41450",
+					"172.18.0.1:41450",
+					"172.19.0.1:41450"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:30:24.595253469Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4816476707442839,
+				"StableID":   "nkBTPCgPce11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5b9eb4138628045a22c62402aebcc9c6835cce155bcdd0f0533fb214b7ff15f",
+				"DiscoKey":   "discokey:6fb532b65fa744aa1c90b3b89b26b530df389725630c419d3aa58e3259060704",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:45681",
+					"10.65.0.27:45681",
+					"172.17.0.1:45681",
+					"172.18.0.1:45681",
+					"172.19.0.1:45681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:30:25.139879467Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5786760251953305,
+				"StableID":   "nY6sdzNqBn11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a50de24d35d34bb9fe585388ee3e1b9e66a586807d4dc1b5b1270841c76edc3c",
+				"DiscoKey":   "discokey:58ed0fdadead5e4eb9f2f7331145e6c638e35c6c2df7f2a4fd5aeefff7f3b107",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37192",
+					"10.65.0.27:37192",
+					"172.17.0.1:37192",
+					"172.18.0.1:37192",
+					"172.19.0.1:37192"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:30:25.691602268Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5575515825480772,
+				"StableID":   "nM7N36MAYk11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22f23d1aef122a38aff753a4dcc1ca1a306a1c4c8881e4ffcdf4d11d3aaf5605",
+				"DiscoKey":   "discokey:42c40123e92f4a7fa35727fde5e3d50d543f36e4374ebac8c09f5d2f18e95e0d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44034",
+					"10.65.0.27:44034",
+					"172.17.0.1:44034",
+					"172.18.0.1:44034",
+					"172.19.0.1:44034"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:30:26.266481848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5311293380078928,
+				"StableID":   "nHu1LufVUi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e18bfb7aa84dad4f4704bdb2487ee9af863ea3b3808e7cd62b0657e426804e2c",
+				"KeyExpiry":  "2026-11-09T07:30:26Z",
+				"DiscoKey":   "discokey:a6cb7ce052f6ec9c272762f1833dcab23942fee8efd11650ff8df2840879014e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46993",
+					"10.65.0.27:46993",
+					"172.17.0.1:46993",
+					"172.18.0.1:46993",
+					"172.19.0.1:46993"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:30:26.748974425Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3323207611793525,
+				"StableID":   "nLg8sf26xS11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:f1913735a8418130e2a7eefc0f60ec361b8c578095fea9ef283b91d86825954a",
+				"KeyExpiry":  "2026-11-09T07:30:27Z",
+				"DiscoKey":   "discokey:7d0f7630074002017a70edc672bcf78430971ab2e52e6f84145ba3e887811a54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57210",
+					"10.65.0.27:57210",
+					"172.17.0.1:57210",
+					"172.18.0.1:57210",
+					"172.19.0.1:57210"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:30:27.288549736Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6311515598068846,
+				"StableID":   "nsXdd7pVHr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a788a78d6bd7d8c1c1e75c201b74708f9fd19e670752963691f48038dfcd9c33",
+				"KeyExpiry":  "2026-11-09T07:30:27Z",
+				"DiscoKey":   "discokey:ab99184e7b0e520ce990100afb94c48331a0ef6c4f5ad51bcd459cc66fe8442a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59113",
+					"10.65.0.27:59113",
+					"172.17.0.1:59113",
+					"172.18.0.1:59113",
+					"172.19.0.1:59113"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:30:27.83146134Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2394680142011296": {
+				"ID":          2394680142011296,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2251594598435450,
+				"StableID":   "n94YSBakaJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       2251594598435450,
+				"Key":        "nodekey:a829dfba8699f24fe83d00c4a279b046831b751fd1e966353d7e5b3fc167ea6e",
+				"DiscoKey":   "discokey:c006bd6fb6c1b0d06e567c089f3178c48f8ad5103d0e7afacff0ff2ca2f6b06e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41450",
+					"10.65.0.27:41450",
+					"172.17.0.1:41450",
+					"172.18.0.1:41450",
+					"172.19.0.1:41450"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:30:24.595253469Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a829dfba8699f24fe83d00c4a279b046831b751fd1e966353d7e5b3fc167ea6e",
+			"MachineKey": "mkey:3c922eebbc639c22842534619675aa48a818189a5135ba2be9db012021a7255e",
+			"Peers": [{
+				"ID":         3164653122742097,
+				"StableID":   "nk8Tc85HiR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab04e30f70501875b9c5b5e1d82f21ddb04bb5ccd61242d2ba7781f755d3a12e",
+				"DiscoKey":   "discokey:e6b5d77ffb8873dbb3c2c68787c1e9b9245864148a5497e10525eda5b231823e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45744",
+					"10.65.0.27:45744",
+					"172.17.0.1:45744",
+					"172.18.0.1:45744",
+					"172.19.0.1:45744"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:30:20.294925753Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6366135317912794,
+				"StableID":   "n9gnEdaEir11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:02ba7fa414f6cbfc2c4583b210b0cf5b7451e524b5cd869cbe0bfe373be19a51",
+				"DiscoKey":   "discokey:97abad92a3e31a044e3bc0370708a83ad533ffb308918d7cd443648e1ae65a0a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34283",
+					"10.65.0.27:34283",
+					"172.17.0.1:34283",
+					"172.18.0.1:34283",
+					"172.19.0.1:34283"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:30:20.792200822Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3830844946326826,
+				"StableID":   "nPH6oSozuW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b69d5fab1f0b095ec70aa46ca53bd056781363a28888a423801a489254b2ac52",
+				"DiscoKey":   "discokey:27acdd51e51a44c4206d1c586b738dfe03cd00d8c9ac88553d3f8f0e50717b29",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60082",
+					"10.65.0.27:60082",
+					"172.17.0.1:60082",
+					"172.18.0.1:60082",
+					"172.19.0.1:60082"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:30:21.339080373Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6776706978776085,
+				"StableID":   "nQUMyrbBvu11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d43fe02739ee5b99822d3d4a54fb69788ec4006ef9af7094c1fbe3d39f518e4e",
+				"DiscoKey":   "discokey:b68e46dec8be212a99e2f1b6a6221ceb90f9e80968dac80a3a5ae878730a0f4a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:44762",
+					"10.65.0.27:44762",
+					"172.17.0.1:44762",
+					"172.18.0.1:44762",
+					"172.19.0.1:44762"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:30:21.902224732Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1005304979881960,
+				"StableID":   "nTNtZ7fJr811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:92d9452ce371b4c90c7617fe71f6f48613fe1bb2cb9dd379e08337ce16d9ff47",
+				"DiscoKey":   "discokey:a2cfbf2f8b46fc59bd33d8c443bd8c6be2a87b263d41b5bdb1430fb1ad54fb0b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52244",
+					"10.65.0.27:52244",
+					"172.17.0.1:52244",
+					"172.18.0.1:52244",
+					"172.19.0.1:52244"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:30:22.43445845Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8489061735454324,
+				"StableID":   "n95t8uFiH921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c62b86931e6b622b34bfc717924936b0c2231ac2e19b4b331204a45e4ada27",
+				"DiscoKey":   "discokey:776022425aecc87acb45053277dff54c08003fff153d3b55ebabb73d68d6352c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38195",
+					"10.65.0.27:38195",
+					"172.17.0.1:38195",
+					"172.18.0.1:38195",
+					"172.19.0.1:38195"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:30:22.961115111Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2394680142011296,
+				"StableID":   "nBgFxpBZhK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80aec655a8cc49c80e1ba3e8c352ec13cb1cbd9274e57002bb5f5b1c51851e07",
+				"DiscoKey":   "discokey:74db6cb0c770b0739fe07f2efd42c6d2984f699938fbc421b66f22b63b68be61",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57820",
+					"10.65.0.27:57820",
+					"172.17.0.1:57820",
+					"172.18.0.1:57820",
+					"172.19.0.1:57820"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:30:23.51321532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         766763268033513,
+				"StableID":   "nQGeL7aGz611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:66e22ff199441d463dedf0c50b830dec510fd1a5f08abda4e22cf225e4741e01",
+				"DiscoKey":   "discokey:d82c16f2643e512dfa7449e2484f26d853b321594beeb7ece70b738036575a6c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:60755",
+					"10.65.0.27:60755",
+					"172.17.0.1:60755",
+					"172.18.0.1:60755",
+					"172.19.0.1:60755"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:30:24.059962501Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4816476707442839,
+				"StableID":   "nkBTPCgPce11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5b9eb4138628045a22c62402aebcc9c6835cce155bcdd0f0533fb214b7ff15f",
+				"DiscoKey":   "discokey:6fb532b65fa744aa1c90b3b89b26b530df389725630c419d3aa58e3259060704",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:45681",
+					"10.65.0.27:45681",
+					"172.17.0.1:45681",
+					"172.18.0.1:45681",
+					"172.19.0.1:45681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:30:25.139879467Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5786760251953305,
+				"StableID":   "nY6sdzNqBn11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a50de24d35d34bb9fe585388ee3e1b9e66a586807d4dc1b5b1270841c76edc3c",
+				"DiscoKey":   "discokey:58ed0fdadead5e4eb9f2f7331145e6c638e35c6c2df7f2a4fd5aeefff7f3b107",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37192",
+					"10.65.0.27:37192",
+					"172.17.0.1:37192",
+					"172.18.0.1:37192",
+					"172.19.0.1:37192"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:30:25.691602268Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5575515825480772,
+				"StableID":   "nM7N36MAYk11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22f23d1aef122a38aff753a4dcc1ca1a306a1c4c8881e4ffcdf4d11d3aaf5605",
+				"DiscoKey":   "discokey:42c40123e92f4a7fa35727fde5e3d50d543f36e4374ebac8c09f5d2f18e95e0d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44034",
+					"10.65.0.27:44034",
+					"172.17.0.1:44034",
+					"172.18.0.1:44034",
+					"172.19.0.1:44034"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:30:26.266481848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5311293380078928,
+				"StableID":   "nHu1LufVUi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e18bfb7aa84dad4f4704bdb2487ee9af863ea3b3808e7cd62b0657e426804e2c",
+				"KeyExpiry":  "2026-11-09T07:30:26Z",
+				"DiscoKey":   "discokey:a6cb7ce052f6ec9c272762f1833dcab23942fee8efd11650ff8df2840879014e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46993",
+					"10.65.0.27:46993",
+					"172.17.0.1:46993",
+					"172.18.0.1:46993",
+					"172.19.0.1:46993"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:30:26.748974425Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3323207611793525,
+				"StableID":   "nLg8sf26xS11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:f1913735a8418130e2a7eefc0f60ec361b8c578095fea9ef283b91d86825954a",
+				"KeyExpiry":  "2026-11-09T07:30:27Z",
+				"DiscoKey":   "discokey:7d0f7630074002017a70edc672bcf78430971ab2e52e6f84145ba3e887811a54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57210",
+					"10.65.0.27:57210",
+					"172.17.0.1:57210",
+					"172.18.0.1:57210",
+					"172.19.0.1:57210"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:30:27.288549736Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6311515598068846,
+				"StableID":   "nsXdd7pVHr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a788a78d6bd7d8c1c1e75c201b74708f9fd19e670752963691f48038dfcd9c33",
+				"KeyExpiry":  "2026-11-09T07:30:27Z",
+				"DiscoKey":   "discokey:ab99184e7b0e520ce990100afb94c48331a0ef6c4f5ad51bcd459cc66fe8442a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59113",
+					"10.65.0.27:59113",
+					"172.17.0.1:59113",
+					"172.18.0.1:59113",
+					"172.19.0.1:59113"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:30:27.83146134Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2251594598435450": {
+				"ID":          2251594598435450,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3323207611793525,
+				"StableID":   "nLg8sf26xS11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:f1913735a8418130e2a7eefc0f60ec361b8c578095fea9ef283b91d86825954a",
+				"KeyExpiry":  "2026-11-09T07:30:27Z",
+				"DiscoKey":   "discokey:7d0f7630074002017a70edc672bcf78430971ab2e52e6f84145ba3e887811a54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57210",
+					"10.65.0.27:57210",
+					"172.17.0.1:57210",
+					"172.18.0.1:57210",
+					"172.19.0.1:57210"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:30:27.288549736Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f1913735a8418130e2a7eefc0f60ec361b8c578095fea9ef283b91d86825954a",
+			"MachineKey": "mkey:b79dafd325cccebbcca8734e9727f471b18a334a63b2a9ee88a448df4abe2a57",
+			"Peers": [{
+				"ID":         3164653122742097,
+				"StableID":   "nk8Tc85HiR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab04e30f70501875b9c5b5e1d82f21ddb04bb5ccd61242d2ba7781f755d3a12e",
+				"DiscoKey":   "discokey:e6b5d77ffb8873dbb3c2c68787c1e9b9245864148a5497e10525eda5b231823e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45744",
+					"10.65.0.27:45744",
+					"172.17.0.1:45744",
+					"172.18.0.1:45744",
+					"172.19.0.1:45744"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:30:20.294925753Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6366135317912794,
+				"StableID":   "n9gnEdaEir11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:02ba7fa414f6cbfc2c4583b210b0cf5b7451e524b5cd869cbe0bfe373be19a51",
+				"DiscoKey":   "discokey:97abad92a3e31a044e3bc0370708a83ad533ffb308918d7cd443648e1ae65a0a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34283",
+					"10.65.0.27:34283",
+					"172.17.0.1:34283",
+					"172.18.0.1:34283",
+					"172.19.0.1:34283"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:30:20.792200822Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3830844946326826,
+				"StableID":   "nPH6oSozuW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b69d5fab1f0b095ec70aa46ca53bd056781363a28888a423801a489254b2ac52",
+				"DiscoKey":   "discokey:27acdd51e51a44c4206d1c586b738dfe03cd00d8c9ac88553d3f8f0e50717b29",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60082",
+					"10.65.0.27:60082",
+					"172.17.0.1:60082",
+					"172.18.0.1:60082",
+					"172.19.0.1:60082"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:30:21.339080373Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6776706978776085,
+				"StableID":   "nQUMyrbBvu11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d43fe02739ee5b99822d3d4a54fb69788ec4006ef9af7094c1fbe3d39f518e4e",
+				"DiscoKey":   "discokey:b68e46dec8be212a99e2f1b6a6221ceb90f9e80968dac80a3a5ae878730a0f4a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:44762",
+					"10.65.0.27:44762",
+					"172.17.0.1:44762",
+					"172.18.0.1:44762",
+					"172.19.0.1:44762"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:30:21.902224732Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1005304979881960,
+				"StableID":   "nTNtZ7fJr811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:92d9452ce371b4c90c7617fe71f6f48613fe1bb2cb9dd379e08337ce16d9ff47",
+				"DiscoKey":   "discokey:a2cfbf2f8b46fc59bd33d8c443bd8c6be2a87b263d41b5bdb1430fb1ad54fb0b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52244",
+					"10.65.0.27:52244",
+					"172.17.0.1:52244",
+					"172.18.0.1:52244",
+					"172.19.0.1:52244"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:30:22.43445845Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8489061735454324,
+				"StableID":   "n95t8uFiH921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c62b86931e6b622b34bfc717924936b0c2231ac2e19b4b331204a45e4ada27",
+				"DiscoKey":   "discokey:776022425aecc87acb45053277dff54c08003fff153d3b55ebabb73d68d6352c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38195",
+					"10.65.0.27:38195",
+					"172.17.0.1:38195",
+					"172.18.0.1:38195",
+					"172.19.0.1:38195"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:30:22.961115111Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2394680142011296,
+				"StableID":   "nBgFxpBZhK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80aec655a8cc49c80e1ba3e8c352ec13cb1cbd9274e57002bb5f5b1c51851e07",
+				"DiscoKey":   "discokey:74db6cb0c770b0739fe07f2efd42c6d2984f699938fbc421b66f22b63b68be61",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57820",
+					"10.65.0.27:57820",
+					"172.17.0.1:57820",
+					"172.18.0.1:57820",
+					"172.19.0.1:57820"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:30:23.51321532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         766763268033513,
+				"StableID":   "nQGeL7aGz611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:66e22ff199441d463dedf0c50b830dec510fd1a5f08abda4e22cf225e4741e01",
+				"DiscoKey":   "discokey:d82c16f2643e512dfa7449e2484f26d853b321594beeb7ece70b738036575a6c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:60755",
+					"10.65.0.27:60755",
+					"172.17.0.1:60755",
+					"172.18.0.1:60755",
+					"172.19.0.1:60755"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:30:24.059962501Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2251594598435450,
+				"StableID":   "n94YSBakaJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a829dfba8699f24fe83d00c4a279b046831b751fd1e966353d7e5b3fc167ea6e",
+				"DiscoKey":   "discokey:c006bd6fb6c1b0d06e567c089f3178c48f8ad5103d0e7afacff0ff2ca2f6b06e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41450",
+					"10.65.0.27:41450",
+					"172.17.0.1:41450",
+					"172.18.0.1:41450",
+					"172.19.0.1:41450"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:30:24.595253469Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4816476707442839,
+				"StableID":   "nkBTPCgPce11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5b9eb4138628045a22c62402aebcc9c6835cce155bcdd0f0533fb214b7ff15f",
+				"DiscoKey":   "discokey:6fb532b65fa744aa1c90b3b89b26b530df389725630c419d3aa58e3259060704",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:45681",
+					"10.65.0.27:45681",
+					"172.17.0.1:45681",
+					"172.18.0.1:45681",
+					"172.19.0.1:45681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:30:25.139879467Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5786760251953305,
+				"StableID":   "nY6sdzNqBn11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a50de24d35d34bb9fe585388ee3e1b9e66a586807d4dc1b5b1270841c76edc3c",
+				"DiscoKey":   "discokey:58ed0fdadead5e4eb9f2f7331145e6c638e35c6c2df7f2a4fd5aeefff7f3b107",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37192",
+					"10.65.0.27:37192",
+					"172.17.0.1:37192",
+					"172.18.0.1:37192",
+					"172.19.0.1:37192"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:30:25.691602268Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5575515825480772,
+				"StableID":   "nM7N36MAYk11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22f23d1aef122a38aff753a4dcc1ca1a306a1c4c8881e4ffcdf4d11d3aaf5605",
+				"DiscoKey":   "discokey:42c40123e92f4a7fa35727fde5e3d50d543f36e4374ebac8c09f5d2f18e95e0d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44034",
+					"10.65.0.27:44034",
+					"172.17.0.1:44034",
+					"172.18.0.1:44034",
+					"172.19.0.1:44034"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:30:26.266481848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5311293380078928,
+				"StableID":   "nHu1LufVUi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e18bfb7aa84dad4f4704bdb2487ee9af863ea3b3808e7cd62b0657e426804e2c",
+				"KeyExpiry":  "2026-11-09T07:30:26Z",
+				"DiscoKey":   "discokey:a6cb7ce052f6ec9c272762f1833dcab23942fee8efd11650ff8df2840879014e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46993",
+					"10.65.0.27:46993",
+					"172.17.0.1:46993",
+					"172.18.0.1:46993",
+					"172.19.0.1:46993"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:30:26.748974425Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6311515598068846,
+				"StableID":   "nsXdd7pVHr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a788a78d6bd7d8c1c1e75c201b74708f9fd19e670752963691f48038dfcd9c33",
+				"KeyExpiry":  "2026-11-09T07:30:27Z",
+				"DiscoKey":   "discokey:ab99184e7b0e520ce990100afb94c48331a0ef6c4f5ad51bcd459cc66fe8442a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59113",
+					"10.65.0.27:59113",
+					"172.17.0.1:59113",
+					"172.18.0.1:59113",
+					"172.19.0.1:59113"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:30:27.83146134Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4816476707442839,
+				"StableID":   "nkBTPCgPce11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       4816476707442839,
+				"Key":        "nodekey:c5b9eb4138628045a22c62402aebcc9c6835cce155bcdd0f0533fb214b7ff15f",
+				"DiscoKey":   "discokey:6fb532b65fa744aa1c90b3b89b26b530df389725630c419d3aa58e3259060704",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:45681",
+					"10.65.0.27:45681",
+					"172.17.0.1:45681",
+					"172.18.0.1:45681",
+					"172.19.0.1:45681"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:30:25.139879467Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c5b9eb4138628045a22c62402aebcc9c6835cce155bcdd0f0533fb214b7ff15f",
+			"MachineKey": "mkey:4d803372406a0067ca7b221481a4777d5b32e75c04c965ffe0674f8ab325e324",
+			"Peers": [{
+				"ID":         3164653122742097,
+				"StableID":   "nk8Tc85HiR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab04e30f70501875b9c5b5e1d82f21ddb04bb5ccd61242d2ba7781f755d3a12e",
+				"DiscoKey":   "discokey:e6b5d77ffb8873dbb3c2c68787c1e9b9245864148a5497e10525eda5b231823e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45744",
+					"10.65.0.27:45744",
+					"172.17.0.1:45744",
+					"172.18.0.1:45744",
+					"172.19.0.1:45744"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:30:20.294925753Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6366135317912794,
+				"StableID":   "n9gnEdaEir11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:02ba7fa414f6cbfc2c4583b210b0cf5b7451e524b5cd869cbe0bfe373be19a51",
+				"DiscoKey":   "discokey:97abad92a3e31a044e3bc0370708a83ad533ffb308918d7cd443648e1ae65a0a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34283",
+					"10.65.0.27:34283",
+					"172.17.0.1:34283",
+					"172.18.0.1:34283",
+					"172.19.0.1:34283"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:30:20.792200822Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3830844946326826,
+				"StableID":   "nPH6oSozuW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b69d5fab1f0b095ec70aa46ca53bd056781363a28888a423801a489254b2ac52",
+				"DiscoKey":   "discokey:27acdd51e51a44c4206d1c586b738dfe03cd00d8c9ac88553d3f8f0e50717b29",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60082",
+					"10.65.0.27:60082",
+					"172.17.0.1:60082",
+					"172.18.0.1:60082",
+					"172.19.0.1:60082"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:30:21.339080373Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6776706978776085,
+				"StableID":   "nQUMyrbBvu11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d43fe02739ee5b99822d3d4a54fb69788ec4006ef9af7094c1fbe3d39f518e4e",
+				"DiscoKey":   "discokey:b68e46dec8be212a99e2f1b6a6221ceb90f9e80968dac80a3a5ae878730a0f4a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:44762",
+					"10.65.0.27:44762",
+					"172.17.0.1:44762",
+					"172.18.0.1:44762",
+					"172.19.0.1:44762"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:30:21.902224732Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1005304979881960,
+				"StableID":   "nTNtZ7fJr811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:92d9452ce371b4c90c7617fe71f6f48613fe1bb2cb9dd379e08337ce16d9ff47",
+				"DiscoKey":   "discokey:a2cfbf2f8b46fc59bd33d8c443bd8c6be2a87b263d41b5bdb1430fb1ad54fb0b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52244",
+					"10.65.0.27:52244",
+					"172.17.0.1:52244",
+					"172.18.0.1:52244",
+					"172.19.0.1:52244"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:30:22.43445845Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8489061735454324,
+				"StableID":   "n95t8uFiH921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c62b86931e6b622b34bfc717924936b0c2231ac2e19b4b331204a45e4ada27",
+				"DiscoKey":   "discokey:776022425aecc87acb45053277dff54c08003fff153d3b55ebabb73d68d6352c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38195",
+					"10.65.0.27:38195",
+					"172.17.0.1:38195",
+					"172.18.0.1:38195",
+					"172.19.0.1:38195"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:30:22.961115111Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2394680142011296,
+				"StableID":   "nBgFxpBZhK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80aec655a8cc49c80e1ba3e8c352ec13cb1cbd9274e57002bb5f5b1c51851e07",
+				"DiscoKey":   "discokey:74db6cb0c770b0739fe07f2efd42c6d2984f699938fbc421b66f22b63b68be61",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:57820",
+					"10.65.0.27:57820",
+					"172.17.0.1:57820",
+					"172.18.0.1:57820",
+					"172.19.0.1:57820"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:30:23.51321532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         766763268033513,
+				"StableID":   "nQGeL7aGz611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:66e22ff199441d463dedf0c50b830dec510fd1a5f08abda4e22cf225e4741e01",
+				"DiscoKey":   "discokey:d82c16f2643e512dfa7449e2484f26d853b321594beeb7ece70b738036575a6c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:60755",
+					"10.65.0.27:60755",
+					"172.17.0.1:60755",
+					"172.18.0.1:60755",
+					"172.19.0.1:60755"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:30:24.059962501Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2251594598435450,
+				"StableID":   "n94YSBakaJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a829dfba8699f24fe83d00c4a279b046831b751fd1e966353d7e5b3fc167ea6e",
+				"DiscoKey":   "discokey:c006bd6fb6c1b0d06e567c089f3178c48f8ad5103d0e7afacff0ff2ca2f6b06e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41450",
+					"10.65.0.27:41450",
+					"172.17.0.1:41450",
+					"172.18.0.1:41450",
+					"172.19.0.1:41450"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:30:24.595253469Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5786760251953305,
+				"StableID":   "nY6sdzNqBn11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a50de24d35d34bb9fe585388ee3e1b9e66a586807d4dc1b5b1270841c76edc3c",
+				"DiscoKey":   "discokey:58ed0fdadead5e4eb9f2f7331145e6c638e35c6c2df7f2a4fd5aeefff7f3b107",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37192",
+					"10.65.0.27:37192",
+					"172.17.0.1:37192",
+					"172.18.0.1:37192",
+					"172.19.0.1:37192"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:30:25.691602268Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5575515825480772,
+				"StableID":   "nM7N36MAYk11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22f23d1aef122a38aff753a4dcc1ca1a306a1c4c8881e4ffcdf4d11d3aaf5605",
+				"DiscoKey":   "discokey:42c40123e92f4a7fa35727fde5e3d50d543f36e4374ebac8c09f5d2f18e95e0d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44034",
+					"10.65.0.27:44034",
+					"172.17.0.1:44034",
+					"172.18.0.1:44034",
+					"172.19.0.1:44034"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:30:26.266481848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5311293380078928,
+				"StableID":   "nHu1LufVUi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e18bfb7aa84dad4f4704bdb2487ee9af863ea3b3808e7cd62b0657e426804e2c",
+				"KeyExpiry":  "2026-11-09T07:30:26Z",
+				"DiscoKey":   "discokey:a6cb7ce052f6ec9c272762f1833dcab23942fee8efd11650ff8df2840879014e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46993",
+					"10.65.0.27:46993",
+					"172.17.0.1:46993",
+					"172.18.0.1:46993",
+					"172.19.0.1:46993"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:30:26.748974425Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3323207611793525,
+				"StableID":   "nLg8sf26xS11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:f1913735a8418130e2a7eefc0f60ec361b8c578095fea9ef283b91d86825954a",
+				"KeyExpiry":  "2026-11-09T07:30:27Z",
+				"DiscoKey":   "discokey:7d0f7630074002017a70edc672bcf78430971ab2e52e6f84145ba3e887811a54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57210",
+					"10.65.0.27:57210",
+					"172.17.0.1:57210",
+					"172.18.0.1:57210",
+					"172.19.0.1:57210"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:30:27.288549736Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6311515598068846,
+				"StableID":   "nsXdd7pVHr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a788a78d6bd7d8c1c1e75c201b74708f9fd19e670752963691f48038dfcd9c33",
+				"KeyExpiry":  "2026-11-09T07:30:27Z",
+				"DiscoKey":   "discokey:ab99184e7b0e520ce990100afb94c48331a0ef6c4f5ad51bcd459cc66fe8442a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59113",
+					"10.65.0.27:59113",
+					"172.17.0.1:59113",
+					"172.18.0.1:59113",
+					"172.19.0.1:59113"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:30:27.83146134Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4816476707442839": {
+				"ID":          4816476707442839,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-checkperiod-too-long.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-checkperiod-too-long.hujson
@@ -1,0 +1,20082 @@
+// ssh-malformed-checkperiod-too-long
+//
+// ssh checkPeriod 200h is rejected
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T21:53:54Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-malformed-checkperiod-too-long",
+	"description":    "ssh checkPeriod 200h is rejected",
+	"category":       "ssh",
+	"captured_at":    "2026-05-12T21:53:54.833653284Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "checkPeriod 200h0m0s is above the max (168h)"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                     \n  \n                                                           \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh checkPeriod 200h is rejected\",\n\t\"id\":          \"ssh-malformed-checkperiod-too-long\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\":      \"check\",\n\t\t\"checkPeriod\": \"200h\",\n\t\t\"dst\":         [\"tag:server\"],\n\t\t\"src\":         [\"autogroup:member\"],\n\t\t\"users\":       [\"root\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-malformed/ssh-malformed-checkperiod-too-long.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action":      "check",
+				"checkPeriod": "200h",
+				"dst":         ["tag:server"],
+				"src":         ["autogroup:member"],
+				"users":       ["root"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6272805259170820,
+				"StableID":   "n17MYXxxyq11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       6272805259170820,
+				"Key":        "nodekey:ae49dd35238f5dbc743f14cb45b9ebfb966433a3f862086d6de210c123c74e4c",
+				"DiscoKey":   "discokey:645533b4d90d4595cdce08cec38aba3ee21c45c80bad753985c6710b32c7e268",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39184",
+					"10.65.0.27:39184",
+					"172.17.0.1:39184",
+					"172.18.0.1:39184",
+					"172.19.0.1:39184"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:54:03.268609688Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ae49dd35238f5dbc743f14cb45b9ebfb966433a3f862086d6de210c123c74e4c",
+			"MachineKey": "mkey:3ea8d8c34fbd4d9080cb44bfa3e968f4b55d2f79811ebdb3657f1ea3a77e2461",
+			"Peers": [{
+				"ID":         1536628455110871,
+				"StableID":   "ni2CeBdwzC11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d801f81be1dc9f7582326e1687d2e1cdc5c8c16a906be0f84a9e152dfd93933",
+				"DiscoKey":   "discokey:6c6d483bb012c7d13abbad74947482985f479a178fc4c6b80e4a953ab4be5944",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40799",
+					"10.65.0.27:40799",
+					"172.17.0.1:40799",
+					"172.18.0.1:40799",
+					"172.19.0.1:40799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:53:57.359941984Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8091269229655474,
+				"StableID":   "ndrLaVvYB621CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6ee633723992353e99d790191c66572bfe9b28d7167e91f88084324d36368e56",
+				"DiscoKey":   "discokey:53cf9053055eb002a4a4f68e88fa500e35960082f72a2b768d99773794a49552",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55163",
+					"10.65.0.27:55163",
+					"172.17.0.1:55163",
+					"172.18.0.1:55163",
+					"172.19.0.1:55163"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:53:57.885709819Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1782745046409962,
+				"StableID":   "nTyb2zgQvE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:786a259ef2b7f75fb384231f6eb3e8d12ffd59631db96fc62f05b69be6072147",
+				"DiscoKey":   "discokey:3a21d33f2b4ec6b2f90d5698f5a65ceed1a5dee28e1352ec24ba79d596927736",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45940",
+					"10.65.0.27:45940",
+					"172.17.0.1:45940",
+					"172.18.0.1:45940",
+					"172.19.0.1:45940"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:53:58.42512068Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1397030307467552,
+				"StableID":   "nj6CNociuB11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:43c950347e3eaad96ab2bc6fd566485f10397d218ac1a123780d5010cadbf53a",
+				"DiscoKey":   "discokey:dd4f86a0b2f420a750dc2bf362a56c2c53e1941662c150fbea6ad128c3836629",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40628",
+					"10.65.0.27:40628",
+					"172.17.0.1:40628",
+					"172.18.0.1:40628",
+					"172.19.0.1:40628"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:53:58.964308415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7212115613438684,
+				"StableID":   "nddj2m3PKy11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0d06cf8a92e9547f56e75f191ed5ce83ea230d72dc7651fd22ed268acb87f73",
+				"DiscoKey":   "discokey:ad9f8f247f4ec22d92bbc797cb1f4c2b5f9f67b608f617dae1e4fc00ae97d50b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40065",
+					"10.65.0.27:40065",
+					"172.17.0.1:40065",
+					"172.18.0.1:40065",
+					"172.19.0.1:40065"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:53:59.505615716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7180388874568491,
+				"StableID":   "nNW2m7e15y11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6da83e3ee3af8bb085b5e9695bb2efcc29692add83b6dd8bbeaeff46def9d51d",
+				"DiscoKey":   "discokey:d4b3f12e6eb725606998427b84074bee2d130051e5ac9cd146029d5d9220b30b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41996",
+					"10.65.0.27:41996",
+					"172.17.0.1:41996",
+					"172.18.0.1:41996",
+					"172.19.0.1:41996"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:54:00.039394051Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2366105036725447,
+				"StableID":   "npuTktZcUK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f91e7ae73ad63c3412dbb8151c79b1416d2a27c9d890a59fe24b58c3ab81e4d",
+				"DiscoKey":   "discokey:c7b428c382ca21de2bd0f787efaf23e65827c0b5a1529a4a8358f807446b5027",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:36734",
+					"10.65.0.27:36734",
+					"172.17.0.1:36734",
+					"172.18.0.1:36734",
+					"172.19.0.1:36734"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:54:00.574150708Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1866704879042162,
+				"StableID":   "nHtxvxASaF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:02c4988687d49efb699aa1f613ac8911ecdb6f6897e8768612558fe94393933f",
+				"DiscoKey":   "discokey:760282c8e21478911f8ce05ea377c56d788c1456a4a4786c48e2dd053f95db41",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45325",
+					"10.65.0.27:45325",
+					"172.17.0.1:45325",
+					"172.18.0.1:45325",
+					"172.19.0.1:45325"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:54:01.1120868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6517402740667875,
+				"StableID":   "nntwPs7kts11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4de83ba23259a2997405f59b6cac79d31c79b13374e140e839d9df19dad8df5f",
+				"DiscoKey":   "discokey:34022403bded2aabe79cfaeabbef4b450f62d81b015ff3ee7db2a4fda7d96c3b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41670",
+					"10.65.0.27:41670",
+					"172.17.0.1:41670",
+					"172.18.0.1:41670",
+					"172.19.0.1:41670"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:54:01.658004765Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5102420916393928,
+				"StableID":   "nyhoxpwtqg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0fd979a1f08dd6f1f6f47e954df44f06fdee1806dce44095f37feb3f65235325",
+				"DiscoKey":   "discokey:6b648a64505d2eceb72a34efd4969dddbd55f3f506c1134dcde1e1c7ce933a18",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58924",
+					"10.65.0.27:58924",
+					"172.17.0.1:58924",
+					"172.18.0.1:58924",
+					"172.19.0.1:58924"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:54:02.217359202Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1644746421818531,
+				"StableID":   "nipL8ahuqD11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e0224aa7a9a34bee548fc638bfe50009218ac599bc0302278d577b71fbc0864",
+				"DiscoKey":   "discokey:864449688a58b9d8bf83579e87c463ed415da04e5f4c93c1e48d0dd210f5694d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57907",
+					"10.65.0.27:57907",
+					"172.17.0.1:57907",
+					"172.18.0.1:57907",
+					"172.19.0.1:57907"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:54:02.726209007Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2029343697476936,
+				"StableID":   "nXCLPER6rG11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8371bef1f4960f93dabc72dd1539b23034873f9d4a362d24876f11981c82251c",
+				"KeyExpiry":  "2026-11-08T21:54:03Z",
+				"DiscoKey":   "discokey:a9f2dde092304a32eee85d4b47bd75048c49bea8ca4bf586b9b2af4026696e3b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51515",
+					"10.65.0.27:51515",
+					"172.17.0.1:51515",
+					"172.18.0.1:51515",
+					"172.19.0.1:51515"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:54:03.81070494Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3420614081054452,
+				"StableID":   "nRX11SjCiT11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:312845ba3ecdfe2085399c443266a393e1ff1d04b141eaa24299936e8ee0dc78",
+				"KeyExpiry":  "2026-11-08T21:54:05Z",
+				"DiscoKey":   "discokey:421c8a0231d57ce03a2af24281263edb51e23f05f66010b01daeb0d8929d2209",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34384",
+					"10.65.0.27:34384",
+					"172.17.0.1:34384",
+					"172.18.0.1:34384",
+					"172.19.0.1:34384"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:54:05.124503251Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8819234930411957,
+				"StableID":   "n8cTk7MFsB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5d8b9ac31c5a5da06cff42bdb9f20a70ed63881c5b6ed493854c477d7a1ffe7b",
+				"KeyExpiry":  "2026-11-08T21:54:05Z",
+				"DiscoKey":   "discokey:31d9e818710e3c4f7c3eb0b4ce21747eae9592913daef50cabd37a60aae6fb0e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:35344",
+					"10.65.0.27:35344",
+					"172.17.0.1:35344",
+					"172.18.0.1:35344",
+					"172.19.0.1:35344"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:54:05.649149464Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6272805259170820": {
+				"ID":          6272805259170820,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7180388874568491,
+				"StableID":   "nNW2m7e15y11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       7180388874568491,
+				"Key":        "nodekey:6da83e3ee3af8bb085b5e9695bb2efcc29692add83b6dd8bbeaeff46def9d51d",
+				"DiscoKey":   "discokey:d4b3f12e6eb725606998427b84074bee2d130051e5ac9cd146029d5d9220b30b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41996",
+					"10.65.0.27:41996",
+					"172.17.0.1:41996",
+					"172.18.0.1:41996",
+					"172.19.0.1:41996"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:54:00.039394051Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6da83e3ee3af8bb085b5e9695bb2efcc29692add83b6dd8bbeaeff46def9d51d",
+			"MachineKey": "mkey:5fd324358a90f24224f1037b771346e12c18853f47ede3ada161ffd2f39d4a16",
+			"Peers": [{
+				"ID":         1536628455110871,
+				"StableID":   "ni2CeBdwzC11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d801f81be1dc9f7582326e1687d2e1cdc5c8c16a906be0f84a9e152dfd93933",
+				"DiscoKey":   "discokey:6c6d483bb012c7d13abbad74947482985f479a178fc4c6b80e4a953ab4be5944",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40799",
+					"10.65.0.27:40799",
+					"172.17.0.1:40799",
+					"172.18.0.1:40799",
+					"172.19.0.1:40799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:53:57.359941984Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8091269229655474,
+				"StableID":   "ndrLaVvYB621CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6ee633723992353e99d790191c66572bfe9b28d7167e91f88084324d36368e56",
+				"DiscoKey":   "discokey:53cf9053055eb002a4a4f68e88fa500e35960082f72a2b768d99773794a49552",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55163",
+					"10.65.0.27:55163",
+					"172.17.0.1:55163",
+					"172.18.0.1:55163",
+					"172.19.0.1:55163"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:53:57.885709819Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1782745046409962,
+				"StableID":   "nTyb2zgQvE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:786a259ef2b7f75fb384231f6eb3e8d12ffd59631db96fc62f05b69be6072147",
+				"DiscoKey":   "discokey:3a21d33f2b4ec6b2f90d5698f5a65ceed1a5dee28e1352ec24ba79d596927736",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45940",
+					"10.65.0.27:45940",
+					"172.17.0.1:45940",
+					"172.18.0.1:45940",
+					"172.19.0.1:45940"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:53:58.42512068Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1397030307467552,
+				"StableID":   "nj6CNociuB11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:43c950347e3eaad96ab2bc6fd566485f10397d218ac1a123780d5010cadbf53a",
+				"DiscoKey":   "discokey:dd4f86a0b2f420a750dc2bf362a56c2c53e1941662c150fbea6ad128c3836629",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40628",
+					"10.65.0.27:40628",
+					"172.17.0.1:40628",
+					"172.18.0.1:40628",
+					"172.19.0.1:40628"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:53:58.964308415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7212115613438684,
+				"StableID":   "nddj2m3PKy11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0d06cf8a92e9547f56e75f191ed5ce83ea230d72dc7651fd22ed268acb87f73",
+				"DiscoKey":   "discokey:ad9f8f247f4ec22d92bbc797cb1f4c2b5f9f67b608f617dae1e4fc00ae97d50b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40065",
+					"10.65.0.27:40065",
+					"172.17.0.1:40065",
+					"172.18.0.1:40065",
+					"172.19.0.1:40065"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:53:59.505615716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2366105036725447,
+				"StableID":   "npuTktZcUK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f91e7ae73ad63c3412dbb8151c79b1416d2a27c9d890a59fe24b58c3ab81e4d",
+				"DiscoKey":   "discokey:c7b428c382ca21de2bd0f787efaf23e65827c0b5a1529a4a8358f807446b5027",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:36734",
+					"10.65.0.27:36734",
+					"172.17.0.1:36734",
+					"172.18.0.1:36734",
+					"172.19.0.1:36734"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:54:00.574150708Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1866704879042162,
+				"StableID":   "nHtxvxASaF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:02c4988687d49efb699aa1f613ac8911ecdb6f6897e8768612558fe94393933f",
+				"DiscoKey":   "discokey:760282c8e21478911f8ce05ea377c56d788c1456a4a4786c48e2dd053f95db41",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45325",
+					"10.65.0.27:45325",
+					"172.17.0.1:45325",
+					"172.18.0.1:45325",
+					"172.19.0.1:45325"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:54:01.1120868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6517402740667875,
+				"StableID":   "nntwPs7kts11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4de83ba23259a2997405f59b6cac79d31c79b13374e140e839d9df19dad8df5f",
+				"DiscoKey":   "discokey:34022403bded2aabe79cfaeabbef4b450f62d81b015ff3ee7db2a4fda7d96c3b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41670",
+					"10.65.0.27:41670",
+					"172.17.0.1:41670",
+					"172.18.0.1:41670",
+					"172.19.0.1:41670"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:54:01.658004765Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5102420916393928,
+				"StableID":   "nyhoxpwtqg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0fd979a1f08dd6f1f6f47e954df44f06fdee1806dce44095f37feb3f65235325",
+				"DiscoKey":   "discokey:6b648a64505d2eceb72a34efd4969dddbd55f3f506c1134dcde1e1c7ce933a18",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58924",
+					"10.65.0.27:58924",
+					"172.17.0.1:58924",
+					"172.18.0.1:58924",
+					"172.19.0.1:58924"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:54:02.217359202Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1644746421818531,
+				"StableID":   "nipL8ahuqD11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e0224aa7a9a34bee548fc638bfe50009218ac599bc0302278d577b71fbc0864",
+				"DiscoKey":   "discokey:864449688a58b9d8bf83579e87c463ed415da04e5f4c93c1e48d0dd210f5694d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57907",
+					"10.65.0.27:57907",
+					"172.17.0.1:57907",
+					"172.18.0.1:57907",
+					"172.19.0.1:57907"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:54:02.726209007Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6272805259170820,
+				"StableID":   "n17MYXxxyq11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae49dd35238f5dbc743f14cb45b9ebfb966433a3f862086d6de210c123c74e4c",
+				"DiscoKey":   "discokey:645533b4d90d4595cdce08cec38aba3ee21c45c80bad753985c6710b32c7e268",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39184",
+					"10.65.0.27:39184",
+					"172.17.0.1:39184",
+					"172.18.0.1:39184",
+					"172.19.0.1:39184"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:54:03.268609688Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2029343697476936,
+				"StableID":   "nXCLPER6rG11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8371bef1f4960f93dabc72dd1539b23034873f9d4a362d24876f11981c82251c",
+				"KeyExpiry":  "2026-11-08T21:54:03Z",
+				"DiscoKey":   "discokey:a9f2dde092304a32eee85d4b47bd75048c49bea8ca4bf586b9b2af4026696e3b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51515",
+					"10.65.0.27:51515",
+					"172.17.0.1:51515",
+					"172.18.0.1:51515",
+					"172.19.0.1:51515"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:54:03.81070494Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3420614081054452,
+				"StableID":   "nRX11SjCiT11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:312845ba3ecdfe2085399c443266a393e1ff1d04b141eaa24299936e8ee0dc78",
+				"KeyExpiry":  "2026-11-08T21:54:05Z",
+				"DiscoKey":   "discokey:421c8a0231d57ce03a2af24281263edb51e23f05f66010b01daeb0d8929d2209",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34384",
+					"10.65.0.27:34384",
+					"172.17.0.1:34384",
+					"172.18.0.1:34384",
+					"172.19.0.1:34384"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:54:05.124503251Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8819234930411957,
+				"StableID":   "n8cTk7MFsB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5d8b9ac31c5a5da06cff42bdb9f20a70ed63881c5b6ed493854c477d7a1ffe7b",
+				"KeyExpiry":  "2026-11-08T21:54:05Z",
+				"DiscoKey":   "discokey:31d9e818710e3c4f7c3eb0b4ce21747eae9592913daef50cabd37a60aae6fb0e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:35344",
+					"10.65.0.27:35344",
+					"172.17.0.1:35344",
+					"172.18.0.1:35344",
+					"172.19.0.1:35344"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:54:05.649149464Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7180388874568491": {
+				"ID":          7180388874568491,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8819234930411957,
+				"StableID":   "n8cTk7MFsB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5d8b9ac31c5a5da06cff42bdb9f20a70ed63881c5b6ed493854c477d7a1ffe7b",
+				"KeyExpiry":  "2026-11-08T21:54:05Z",
+				"DiscoKey":   "discokey:31d9e818710e3c4f7c3eb0b4ce21747eae9592913daef50cabd37a60aae6fb0e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:35344",
+					"10.65.0.27:35344",
+					"172.17.0.1:35344",
+					"172.18.0.1:35344",
+					"172.19.0.1:35344"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:54:05.649149464Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5d8b9ac31c5a5da06cff42bdb9f20a70ed63881c5b6ed493854c477d7a1ffe7b",
+			"MachineKey": "mkey:70eb69d56664b23f7eb6588c4c2c6e95f0bfdfb9bd7c55f1d3ccbb0cb6f51b07",
+			"Peers": [{
+				"ID":         1536628455110871,
+				"StableID":   "ni2CeBdwzC11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d801f81be1dc9f7582326e1687d2e1cdc5c8c16a906be0f84a9e152dfd93933",
+				"DiscoKey":   "discokey:6c6d483bb012c7d13abbad74947482985f479a178fc4c6b80e4a953ab4be5944",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40799",
+					"10.65.0.27:40799",
+					"172.17.0.1:40799",
+					"172.18.0.1:40799",
+					"172.19.0.1:40799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:53:57.359941984Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8091269229655474,
+				"StableID":   "ndrLaVvYB621CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6ee633723992353e99d790191c66572bfe9b28d7167e91f88084324d36368e56",
+				"DiscoKey":   "discokey:53cf9053055eb002a4a4f68e88fa500e35960082f72a2b768d99773794a49552",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55163",
+					"10.65.0.27:55163",
+					"172.17.0.1:55163",
+					"172.18.0.1:55163",
+					"172.19.0.1:55163"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:53:57.885709819Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1782745046409962,
+				"StableID":   "nTyb2zgQvE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:786a259ef2b7f75fb384231f6eb3e8d12ffd59631db96fc62f05b69be6072147",
+				"DiscoKey":   "discokey:3a21d33f2b4ec6b2f90d5698f5a65ceed1a5dee28e1352ec24ba79d596927736",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45940",
+					"10.65.0.27:45940",
+					"172.17.0.1:45940",
+					"172.18.0.1:45940",
+					"172.19.0.1:45940"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:53:58.42512068Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1397030307467552,
+				"StableID":   "nj6CNociuB11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:43c950347e3eaad96ab2bc6fd566485f10397d218ac1a123780d5010cadbf53a",
+				"DiscoKey":   "discokey:dd4f86a0b2f420a750dc2bf362a56c2c53e1941662c150fbea6ad128c3836629",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40628",
+					"10.65.0.27:40628",
+					"172.17.0.1:40628",
+					"172.18.0.1:40628",
+					"172.19.0.1:40628"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:53:58.964308415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7212115613438684,
+				"StableID":   "nddj2m3PKy11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0d06cf8a92e9547f56e75f191ed5ce83ea230d72dc7651fd22ed268acb87f73",
+				"DiscoKey":   "discokey:ad9f8f247f4ec22d92bbc797cb1f4c2b5f9f67b608f617dae1e4fc00ae97d50b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40065",
+					"10.65.0.27:40065",
+					"172.17.0.1:40065",
+					"172.18.0.1:40065",
+					"172.19.0.1:40065"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:53:59.505615716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7180388874568491,
+				"StableID":   "nNW2m7e15y11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6da83e3ee3af8bb085b5e9695bb2efcc29692add83b6dd8bbeaeff46def9d51d",
+				"DiscoKey":   "discokey:d4b3f12e6eb725606998427b84074bee2d130051e5ac9cd146029d5d9220b30b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41996",
+					"10.65.0.27:41996",
+					"172.17.0.1:41996",
+					"172.18.0.1:41996",
+					"172.19.0.1:41996"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:54:00.039394051Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2366105036725447,
+				"StableID":   "npuTktZcUK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f91e7ae73ad63c3412dbb8151c79b1416d2a27c9d890a59fe24b58c3ab81e4d",
+				"DiscoKey":   "discokey:c7b428c382ca21de2bd0f787efaf23e65827c0b5a1529a4a8358f807446b5027",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:36734",
+					"10.65.0.27:36734",
+					"172.17.0.1:36734",
+					"172.18.0.1:36734",
+					"172.19.0.1:36734"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:54:00.574150708Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1866704879042162,
+				"StableID":   "nHtxvxASaF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:02c4988687d49efb699aa1f613ac8911ecdb6f6897e8768612558fe94393933f",
+				"DiscoKey":   "discokey:760282c8e21478911f8ce05ea377c56d788c1456a4a4786c48e2dd053f95db41",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45325",
+					"10.65.0.27:45325",
+					"172.17.0.1:45325",
+					"172.18.0.1:45325",
+					"172.19.0.1:45325"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:54:01.1120868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6517402740667875,
+				"StableID":   "nntwPs7kts11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4de83ba23259a2997405f59b6cac79d31c79b13374e140e839d9df19dad8df5f",
+				"DiscoKey":   "discokey:34022403bded2aabe79cfaeabbef4b450f62d81b015ff3ee7db2a4fda7d96c3b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41670",
+					"10.65.0.27:41670",
+					"172.17.0.1:41670",
+					"172.18.0.1:41670",
+					"172.19.0.1:41670"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:54:01.658004765Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5102420916393928,
+				"StableID":   "nyhoxpwtqg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0fd979a1f08dd6f1f6f47e954df44f06fdee1806dce44095f37feb3f65235325",
+				"DiscoKey":   "discokey:6b648a64505d2eceb72a34efd4969dddbd55f3f506c1134dcde1e1c7ce933a18",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58924",
+					"10.65.0.27:58924",
+					"172.17.0.1:58924",
+					"172.18.0.1:58924",
+					"172.19.0.1:58924"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:54:02.217359202Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1644746421818531,
+				"StableID":   "nipL8ahuqD11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e0224aa7a9a34bee548fc638bfe50009218ac599bc0302278d577b71fbc0864",
+				"DiscoKey":   "discokey:864449688a58b9d8bf83579e87c463ed415da04e5f4c93c1e48d0dd210f5694d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57907",
+					"10.65.0.27:57907",
+					"172.17.0.1:57907",
+					"172.18.0.1:57907",
+					"172.19.0.1:57907"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:54:02.726209007Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6272805259170820,
+				"StableID":   "n17MYXxxyq11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae49dd35238f5dbc743f14cb45b9ebfb966433a3f862086d6de210c123c74e4c",
+				"DiscoKey":   "discokey:645533b4d90d4595cdce08cec38aba3ee21c45c80bad753985c6710b32c7e268",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39184",
+					"10.65.0.27:39184",
+					"172.17.0.1:39184",
+					"172.18.0.1:39184",
+					"172.19.0.1:39184"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:54:03.268609688Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2029343697476936,
+				"StableID":   "nXCLPER6rG11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8371bef1f4960f93dabc72dd1539b23034873f9d4a362d24876f11981c82251c",
+				"KeyExpiry":  "2026-11-08T21:54:03Z",
+				"DiscoKey":   "discokey:a9f2dde092304a32eee85d4b47bd75048c49bea8ca4bf586b9b2af4026696e3b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51515",
+					"10.65.0.27:51515",
+					"172.17.0.1:51515",
+					"172.18.0.1:51515",
+					"172.19.0.1:51515"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:54:03.81070494Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3420614081054452,
+				"StableID":   "nRX11SjCiT11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:312845ba3ecdfe2085399c443266a393e1ff1d04b141eaa24299936e8ee0dc78",
+				"KeyExpiry":  "2026-11-08T21:54:05Z",
+				"DiscoKey":   "discokey:421c8a0231d57ce03a2af24281263edb51e23f05f66010b01daeb0d8929d2209",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34384",
+					"10.65.0.27:34384",
+					"172.17.0.1:34384",
+					"172.18.0.1:34384",
+					"172.19.0.1:34384"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:54:05.124503251Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1782745046409962,
+				"StableID":   "nTyb2zgQvE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1782745046409962,
+				"Key":        "nodekey:786a259ef2b7f75fb384231f6eb3e8d12ffd59631db96fc62f05b69be6072147",
+				"DiscoKey":   "discokey:3a21d33f2b4ec6b2f90d5698f5a65ceed1a5dee28e1352ec24ba79d596927736",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45940",
+					"10.65.0.27:45940",
+					"172.17.0.1:45940",
+					"172.18.0.1:45940",
+					"172.19.0.1:45940"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:53:58.42512068Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:786a259ef2b7f75fb384231f6eb3e8d12ffd59631db96fc62f05b69be6072147",
+			"MachineKey": "mkey:86d09454952ea0f62ae073f0dc534563b02c609aea394b13dfd21bd9bad32e26",
+			"Peers": [{
+				"ID":         1536628455110871,
+				"StableID":   "ni2CeBdwzC11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d801f81be1dc9f7582326e1687d2e1cdc5c8c16a906be0f84a9e152dfd93933",
+				"DiscoKey":   "discokey:6c6d483bb012c7d13abbad74947482985f479a178fc4c6b80e4a953ab4be5944",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40799",
+					"10.65.0.27:40799",
+					"172.17.0.1:40799",
+					"172.18.0.1:40799",
+					"172.19.0.1:40799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:53:57.359941984Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8091269229655474,
+				"StableID":   "ndrLaVvYB621CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6ee633723992353e99d790191c66572bfe9b28d7167e91f88084324d36368e56",
+				"DiscoKey":   "discokey:53cf9053055eb002a4a4f68e88fa500e35960082f72a2b768d99773794a49552",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55163",
+					"10.65.0.27:55163",
+					"172.17.0.1:55163",
+					"172.18.0.1:55163",
+					"172.19.0.1:55163"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:53:57.885709819Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1397030307467552,
+				"StableID":   "nj6CNociuB11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:43c950347e3eaad96ab2bc6fd566485f10397d218ac1a123780d5010cadbf53a",
+				"DiscoKey":   "discokey:dd4f86a0b2f420a750dc2bf362a56c2c53e1941662c150fbea6ad128c3836629",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40628",
+					"10.65.0.27:40628",
+					"172.17.0.1:40628",
+					"172.18.0.1:40628",
+					"172.19.0.1:40628"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:53:58.964308415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7212115613438684,
+				"StableID":   "nddj2m3PKy11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0d06cf8a92e9547f56e75f191ed5ce83ea230d72dc7651fd22ed268acb87f73",
+				"DiscoKey":   "discokey:ad9f8f247f4ec22d92bbc797cb1f4c2b5f9f67b608f617dae1e4fc00ae97d50b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40065",
+					"10.65.0.27:40065",
+					"172.17.0.1:40065",
+					"172.18.0.1:40065",
+					"172.19.0.1:40065"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:53:59.505615716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7180388874568491,
+				"StableID":   "nNW2m7e15y11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6da83e3ee3af8bb085b5e9695bb2efcc29692add83b6dd8bbeaeff46def9d51d",
+				"DiscoKey":   "discokey:d4b3f12e6eb725606998427b84074bee2d130051e5ac9cd146029d5d9220b30b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41996",
+					"10.65.0.27:41996",
+					"172.17.0.1:41996",
+					"172.18.0.1:41996",
+					"172.19.0.1:41996"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:54:00.039394051Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2366105036725447,
+				"StableID":   "npuTktZcUK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f91e7ae73ad63c3412dbb8151c79b1416d2a27c9d890a59fe24b58c3ab81e4d",
+				"DiscoKey":   "discokey:c7b428c382ca21de2bd0f787efaf23e65827c0b5a1529a4a8358f807446b5027",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:36734",
+					"10.65.0.27:36734",
+					"172.17.0.1:36734",
+					"172.18.0.1:36734",
+					"172.19.0.1:36734"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:54:00.574150708Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1866704879042162,
+				"StableID":   "nHtxvxASaF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:02c4988687d49efb699aa1f613ac8911ecdb6f6897e8768612558fe94393933f",
+				"DiscoKey":   "discokey:760282c8e21478911f8ce05ea377c56d788c1456a4a4786c48e2dd053f95db41",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45325",
+					"10.65.0.27:45325",
+					"172.17.0.1:45325",
+					"172.18.0.1:45325",
+					"172.19.0.1:45325"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:54:01.1120868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6517402740667875,
+				"StableID":   "nntwPs7kts11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4de83ba23259a2997405f59b6cac79d31c79b13374e140e839d9df19dad8df5f",
+				"DiscoKey":   "discokey:34022403bded2aabe79cfaeabbef4b450f62d81b015ff3ee7db2a4fda7d96c3b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41670",
+					"10.65.0.27:41670",
+					"172.17.0.1:41670",
+					"172.18.0.1:41670",
+					"172.19.0.1:41670"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:54:01.658004765Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5102420916393928,
+				"StableID":   "nyhoxpwtqg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0fd979a1f08dd6f1f6f47e954df44f06fdee1806dce44095f37feb3f65235325",
+				"DiscoKey":   "discokey:6b648a64505d2eceb72a34efd4969dddbd55f3f506c1134dcde1e1c7ce933a18",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58924",
+					"10.65.0.27:58924",
+					"172.17.0.1:58924",
+					"172.18.0.1:58924",
+					"172.19.0.1:58924"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:54:02.217359202Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1644746421818531,
+				"StableID":   "nipL8ahuqD11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e0224aa7a9a34bee548fc638bfe50009218ac599bc0302278d577b71fbc0864",
+				"DiscoKey":   "discokey:864449688a58b9d8bf83579e87c463ed415da04e5f4c93c1e48d0dd210f5694d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57907",
+					"10.65.0.27:57907",
+					"172.17.0.1:57907",
+					"172.18.0.1:57907",
+					"172.19.0.1:57907"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:54:02.726209007Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6272805259170820,
+				"StableID":   "n17MYXxxyq11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae49dd35238f5dbc743f14cb45b9ebfb966433a3f862086d6de210c123c74e4c",
+				"DiscoKey":   "discokey:645533b4d90d4595cdce08cec38aba3ee21c45c80bad753985c6710b32c7e268",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39184",
+					"10.65.0.27:39184",
+					"172.17.0.1:39184",
+					"172.18.0.1:39184",
+					"172.19.0.1:39184"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:54:03.268609688Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2029343697476936,
+				"StableID":   "nXCLPER6rG11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8371bef1f4960f93dabc72dd1539b23034873f9d4a362d24876f11981c82251c",
+				"KeyExpiry":  "2026-11-08T21:54:03Z",
+				"DiscoKey":   "discokey:a9f2dde092304a32eee85d4b47bd75048c49bea8ca4bf586b9b2af4026696e3b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51515",
+					"10.65.0.27:51515",
+					"172.17.0.1:51515",
+					"172.18.0.1:51515",
+					"172.19.0.1:51515"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:54:03.81070494Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3420614081054452,
+				"StableID":   "nRX11SjCiT11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:312845ba3ecdfe2085399c443266a393e1ff1d04b141eaa24299936e8ee0dc78",
+				"KeyExpiry":  "2026-11-08T21:54:05Z",
+				"DiscoKey":   "discokey:421c8a0231d57ce03a2af24281263edb51e23f05f66010b01daeb0d8929d2209",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34384",
+					"10.65.0.27:34384",
+					"172.17.0.1:34384",
+					"172.18.0.1:34384",
+					"172.19.0.1:34384"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:54:05.124503251Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8819234930411957,
+				"StableID":   "n8cTk7MFsB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5d8b9ac31c5a5da06cff42bdb9f20a70ed63881c5b6ed493854c477d7a1ffe7b",
+				"KeyExpiry":  "2026-11-08T21:54:05Z",
+				"DiscoKey":   "discokey:31d9e818710e3c4f7c3eb0b4ce21747eae9592913daef50cabd37a60aae6fb0e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:35344",
+					"10.65.0.27:35344",
+					"172.17.0.1:35344",
+					"172.18.0.1:35344",
+					"172.19.0.1:35344"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:54:05.649149464Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1782745046409962": {
+				"ID":          1782745046409962,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1866704879042162,
+				"StableID":   "nHtxvxASaF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1866704879042162,
+				"Key":        "nodekey:02c4988687d49efb699aa1f613ac8911ecdb6f6897e8768612558fe94393933f",
+				"DiscoKey":   "discokey:760282c8e21478911f8ce05ea377c56d788c1456a4a4786c48e2dd053f95db41",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45325",
+					"10.65.0.27:45325",
+					"172.17.0.1:45325",
+					"172.18.0.1:45325",
+					"172.19.0.1:45325"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:54:01.1120868Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:02c4988687d49efb699aa1f613ac8911ecdb6f6897e8768612558fe94393933f",
+			"MachineKey": "mkey:d6706dcaee79e266f5d87910408e99a301a114d894628c9b78c2556e109a371c",
+			"Peers": [{
+				"ID":         1536628455110871,
+				"StableID":   "ni2CeBdwzC11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d801f81be1dc9f7582326e1687d2e1cdc5c8c16a906be0f84a9e152dfd93933",
+				"DiscoKey":   "discokey:6c6d483bb012c7d13abbad74947482985f479a178fc4c6b80e4a953ab4be5944",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40799",
+					"10.65.0.27:40799",
+					"172.17.0.1:40799",
+					"172.18.0.1:40799",
+					"172.19.0.1:40799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:53:57.359941984Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8091269229655474,
+				"StableID":   "ndrLaVvYB621CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6ee633723992353e99d790191c66572bfe9b28d7167e91f88084324d36368e56",
+				"DiscoKey":   "discokey:53cf9053055eb002a4a4f68e88fa500e35960082f72a2b768d99773794a49552",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55163",
+					"10.65.0.27:55163",
+					"172.17.0.1:55163",
+					"172.18.0.1:55163",
+					"172.19.0.1:55163"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:53:57.885709819Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1782745046409962,
+				"StableID":   "nTyb2zgQvE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:786a259ef2b7f75fb384231f6eb3e8d12ffd59631db96fc62f05b69be6072147",
+				"DiscoKey":   "discokey:3a21d33f2b4ec6b2f90d5698f5a65ceed1a5dee28e1352ec24ba79d596927736",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45940",
+					"10.65.0.27:45940",
+					"172.17.0.1:45940",
+					"172.18.0.1:45940",
+					"172.19.0.1:45940"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:53:58.42512068Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1397030307467552,
+				"StableID":   "nj6CNociuB11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:43c950347e3eaad96ab2bc6fd566485f10397d218ac1a123780d5010cadbf53a",
+				"DiscoKey":   "discokey:dd4f86a0b2f420a750dc2bf362a56c2c53e1941662c150fbea6ad128c3836629",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40628",
+					"10.65.0.27:40628",
+					"172.17.0.1:40628",
+					"172.18.0.1:40628",
+					"172.19.0.1:40628"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:53:58.964308415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7212115613438684,
+				"StableID":   "nddj2m3PKy11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0d06cf8a92e9547f56e75f191ed5ce83ea230d72dc7651fd22ed268acb87f73",
+				"DiscoKey":   "discokey:ad9f8f247f4ec22d92bbc797cb1f4c2b5f9f67b608f617dae1e4fc00ae97d50b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40065",
+					"10.65.0.27:40065",
+					"172.17.0.1:40065",
+					"172.18.0.1:40065",
+					"172.19.0.1:40065"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:53:59.505615716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7180388874568491,
+				"StableID":   "nNW2m7e15y11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6da83e3ee3af8bb085b5e9695bb2efcc29692add83b6dd8bbeaeff46def9d51d",
+				"DiscoKey":   "discokey:d4b3f12e6eb725606998427b84074bee2d130051e5ac9cd146029d5d9220b30b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41996",
+					"10.65.0.27:41996",
+					"172.17.0.1:41996",
+					"172.18.0.1:41996",
+					"172.19.0.1:41996"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:54:00.039394051Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2366105036725447,
+				"StableID":   "npuTktZcUK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f91e7ae73ad63c3412dbb8151c79b1416d2a27c9d890a59fe24b58c3ab81e4d",
+				"DiscoKey":   "discokey:c7b428c382ca21de2bd0f787efaf23e65827c0b5a1529a4a8358f807446b5027",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:36734",
+					"10.65.0.27:36734",
+					"172.17.0.1:36734",
+					"172.18.0.1:36734",
+					"172.19.0.1:36734"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:54:00.574150708Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6517402740667875,
+				"StableID":   "nntwPs7kts11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4de83ba23259a2997405f59b6cac79d31c79b13374e140e839d9df19dad8df5f",
+				"DiscoKey":   "discokey:34022403bded2aabe79cfaeabbef4b450f62d81b015ff3ee7db2a4fda7d96c3b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41670",
+					"10.65.0.27:41670",
+					"172.17.0.1:41670",
+					"172.18.0.1:41670",
+					"172.19.0.1:41670"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:54:01.658004765Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5102420916393928,
+				"StableID":   "nyhoxpwtqg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0fd979a1f08dd6f1f6f47e954df44f06fdee1806dce44095f37feb3f65235325",
+				"DiscoKey":   "discokey:6b648a64505d2eceb72a34efd4969dddbd55f3f506c1134dcde1e1c7ce933a18",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58924",
+					"10.65.0.27:58924",
+					"172.17.0.1:58924",
+					"172.18.0.1:58924",
+					"172.19.0.1:58924"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:54:02.217359202Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1644746421818531,
+				"StableID":   "nipL8ahuqD11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e0224aa7a9a34bee548fc638bfe50009218ac599bc0302278d577b71fbc0864",
+				"DiscoKey":   "discokey:864449688a58b9d8bf83579e87c463ed415da04e5f4c93c1e48d0dd210f5694d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57907",
+					"10.65.0.27:57907",
+					"172.17.0.1:57907",
+					"172.18.0.1:57907",
+					"172.19.0.1:57907"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:54:02.726209007Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6272805259170820,
+				"StableID":   "n17MYXxxyq11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae49dd35238f5dbc743f14cb45b9ebfb966433a3f862086d6de210c123c74e4c",
+				"DiscoKey":   "discokey:645533b4d90d4595cdce08cec38aba3ee21c45c80bad753985c6710b32c7e268",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39184",
+					"10.65.0.27:39184",
+					"172.17.0.1:39184",
+					"172.18.0.1:39184",
+					"172.19.0.1:39184"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:54:03.268609688Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2029343697476936,
+				"StableID":   "nXCLPER6rG11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8371bef1f4960f93dabc72dd1539b23034873f9d4a362d24876f11981c82251c",
+				"KeyExpiry":  "2026-11-08T21:54:03Z",
+				"DiscoKey":   "discokey:a9f2dde092304a32eee85d4b47bd75048c49bea8ca4bf586b9b2af4026696e3b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51515",
+					"10.65.0.27:51515",
+					"172.17.0.1:51515",
+					"172.18.0.1:51515",
+					"172.19.0.1:51515"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:54:03.81070494Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3420614081054452,
+				"StableID":   "nRX11SjCiT11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:312845ba3ecdfe2085399c443266a393e1ff1d04b141eaa24299936e8ee0dc78",
+				"KeyExpiry":  "2026-11-08T21:54:05Z",
+				"DiscoKey":   "discokey:421c8a0231d57ce03a2af24281263edb51e23f05f66010b01daeb0d8929d2209",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34384",
+					"10.65.0.27:34384",
+					"172.17.0.1:34384",
+					"172.18.0.1:34384",
+					"172.19.0.1:34384"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:54:05.124503251Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8819234930411957,
+				"StableID":   "n8cTk7MFsB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5d8b9ac31c5a5da06cff42bdb9f20a70ed63881c5b6ed493854c477d7a1ffe7b",
+				"KeyExpiry":  "2026-11-08T21:54:05Z",
+				"DiscoKey":   "discokey:31d9e818710e3c4f7c3eb0b4ce21747eae9592913daef50cabd37a60aae6fb0e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:35344",
+					"10.65.0.27:35344",
+					"172.17.0.1:35344",
+					"172.18.0.1:35344",
+					"172.19.0.1:35344"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:54:05.649149464Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1866704879042162": {
+				"ID":          1866704879042162,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2029343697476936,
+				"StableID":   "nXCLPER6rG11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8371bef1f4960f93dabc72dd1539b23034873f9d4a362d24876f11981c82251c",
+				"KeyExpiry":  "2026-11-08T21:54:03Z",
+				"DiscoKey":   "discokey:a9f2dde092304a32eee85d4b47bd75048c49bea8ca4bf586b9b2af4026696e3b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51515",
+					"10.65.0.27:51515",
+					"172.17.0.1:51515",
+					"172.18.0.1:51515",
+					"172.19.0.1:51515"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:54:03.81070494Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8371bef1f4960f93dabc72dd1539b23034873f9d4a362d24876f11981c82251c",
+			"MachineKey": "mkey:cabe6a4918923702aa5c8753e2248a1432840e8a9a87ccf0e6a070fd18fa2266",
+			"Peers": [{
+				"ID":         1536628455110871,
+				"StableID":   "ni2CeBdwzC11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d801f81be1dc9f7582326e1687d2e1cdc5c8c16a906be0f84a9e152dfd93933",
+				"DiscoKey":   "discokey:6c6d483bb012c7d13abbad74947482985f479a178fc4c6b80e4a953ab4be5944",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40799",
+					"10.65.0.27:40799",
+					"172.17.0.1:40799",
+					"172.18.0.1:40799",
+					"172.19.0.1:40799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:53:57.359941984Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8091269229655474,
+				"StableID":   "ndrLaVvYB621CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6ee633723992353e99d790191c66572bfe9b28d7167e91f88084324d36368e56",
+				"DiscoKey":   "discokey:53cf9053055eb002a4a4f68e88fa500e35960082f72a2b768d99773794a49552",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55163",
+					"10.65.0.27:55163",
+					"172.17.0.1:55163",
+					"172.18.0.1:55163",
+					"172.19.0.1:55163"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:53:57.885709819Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1782745046409962,
+				"StableID":   "nTyb2zgQvE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:786a259ef2b7f75fb384231f6eb3e8d12ffd59631db96fc62f05b69be6072147",
+				"DiscoKey":   "discokey:3a21d33f2b4ec6b2f90d5698f5a65ceed1a5dee28e1352ec24ba79d596927736",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45940",
+					"10.65.0.27:45940",
+					"172.17.0.1:45940",
+					"172.18.0.1:45940",
+					"172.19.0.1:45940"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:53:58.42512068Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1397030307467552,
+				"StableID":   "nj6CNociuB11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:43c950347e3eaad96ab2bc6fd566485f10397d218ac1a123780d5010cadbf53a",
+				"DiscoKey":   "discokey:dd4f86a0b2f420a750dc2bf362a56c2c53e1941662c150fbea6ad128c3836629",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40628",
+					"10.65.0.27:40628",
+					"172.17.0.1:40628",
+					"172.18.0.1:40628",
+					"172.19.0.1:40628"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:53:58.964308415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7212115613438684,
+				"StableID":   "nddj2m3PKy11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0d06cf8a92e9547f56e75f191ed5ce83ea230d72dc7651fd22ed268acb87f73",
+				"DiscoKey":   "discokey:ad9f8f247f4ec22d92bbc797cb1f4c2b5f9f67b608f617dae1e4fc00ae97d50b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40065",
+					"10.65.0.27:40065",
+					"172.17.0.1:40065",
+					"172.18.0.1:40065",
+					"172.19.0.1:40065"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:53:59.505615716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7180388874568491,
+				"StableID":   "nNW2m7e15y11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6da83e3ee3af8bb085b5e9695bb2efcc29692add83b6dd8bbeaeff46def9d51d",
+				"DiscoKey":   "discokey:d4b3f12e6eb725606998427b84074bee2d130051e5ac9cd146029d5d9220b30b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41996",
+					"10.65.0.27:41996",
+					"172.17.0.1:41996",
+					"172.18.0.1:41996",
+					"172.19.0.1:41996"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:54:00.039394051Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2366105036725447,
+				"StableID":   "npuTktZcUK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f91e7ae73ad63c3412dbb8151c79b1416d2a27c9d890a59fe24b58c3ab81e4d",
+				"DiscoKey":   "discokey:c7b428c382ca21de2bd0f787efaf23e65827c0b5a1529a4a8358f807446b5027",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:36734",
+					"10.65.0.27:36734",
+					"172.17.0.1:36734",
+					"172.18.0.1:36734",
+					"172.19.0.1:36734"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:54:00.574150708Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1866704879042162,
+				"StableID":   "nHtxvxASaF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:02c4988687d49efb699aa1f613ac8911ecdb6f6897e8768612558fe94393933f",
+				"DiscoKey":   "discokey:760282c8e21478911f8ce05ea377c56d788c1456a4a4786c48e2dd053f95db41",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45325",
+					"10.65.0.27:45325",
+					"172.17.0.1:45325",
+					"172.18.0.1:45325",
+					"172.19.0.1:45325"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:54:01.1120868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6517402740667875,
+				"StableID":   "nntwPs7kts11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4de83ba23259a2997405f59b6cac79d31c79b13374e140e839d9df19dad8df5f",
+				"DiscoKey":   "discokey:34022403bded2aabe79cfaeabbef4b450f62d81b015ff3ee7db2a4fda7d96c3b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41670",
+					"10.65.0.27:41670",
+					"172.17.0.1:41670",
+					"172.18.0.1:41670",
+					"172.19.0.1:41670"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:54:01.658004765Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5102420916393928,
+				"StableID":   "nyhoxpwtqg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0fd979a1f08dd6f1f6f47e954df44f06fdee1806dce44095f37feb3f65235325",
+				"DiscoKey":   "discokey:6b648a64505d2eceb72a34efd4969dddbd55f3f506c1134dcde1e1c7ce933a18",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58924",
+					"10.65.0.27:58924",
+					"172.17.0.1:58924",
+					"172.18.0.1:58924",
+					"172.19.0.1:58924"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:54:02.217359202Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1644746421818531,
+				"StableID":   "nipL8ahuqD11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e0224aa7a9a34bee548fc638bfe50009218ac599bc0302278d577b71fbc0864",
+				"DiscoKey":   "discokey:864449688a58b9d8bf83579e87c463ed415da04e5f4c93c1e48d0dd210f5694d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57907",
+					"10.65.0.27:57907",
+					"172.17.0.1:57907",
+					"172.18.0.1:57907",
+					"172.19.0.1:57907"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:54:02.726209007Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6272805259170820,
+				"StableID":   "n17MYXxxyq11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae49dd35238f5dbc743f14cb45b9ebfb966433a3f862086d6de210c123c74e4c",
+				"DiscoKey":   "discokey:645533b4d90d4595cdce08cec38aba3ee21c45c80bad753985c6710b32c7e268",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39184",
+					"10.65.0.27:39184",
+					"172.17.0.1:39184",
+					"172.18.0.1:39184",
+					"172.19.0.1:39184"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:54:03.268609688Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3420614081054452,
+				"StableID":   "nRX11SjCiT11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:312845ba3ecdfe2085399c443266a393e1ff1d04b141eaa24299936e8ee0dc78",
+				"KeyExpiry":  "2026-11-08T21:54:05Z",
+				"DiscoKey":   "discokey:421c8a0231d57ce03a2af24281263edb51e23f05f66010b01daeb0d8929d2209",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34384",
+					"10.65.0.27:34384",
+					"172.17.0.1:34384",
+					"172.18.0.1:34384",
+					"172.19.0.1:34384"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:54:05.124503251Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8819234930411957,
+				"StableID":   "n8cTk7MFsB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5d8b9ac31c5a5da06cff42bdb9f20a70ed63881c5b6ed493854c477d7a1ffe7b",
+				"KeyExpiry":  "2026-11-08T21:54:05Z",
+				"DiscoKey":   "discokey:31d9e818710e3c4f7c3eb0b4ce21747eae9592913daef50cabd37a60aae6fb0e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:35344",
+					"10.65.0.27:35344",
+					"172.17.0.1:35344",
+					"172.18.0.1:35344",
+					"172.19.0.1:35344"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:54:05.649149464Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1644746421818531,
+				"StableID":   "nipL8ahuqD11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1644746421818531,
+				"Key":        "nodekey:0e0224aa7a9a34bee548fc638bfe50009218ac599bc0302278d577b71fbc0864",
+				"DiscoKey":   "discokey:864449688a58b9d8bf83579e87c463ed415da04e5f4c93c1e48d0dd210f5694d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57907",
+					"10.65.0.27:57907",
+					"172.17.0.1:57907",
+					"172.18.0.1:57907",
+					"172.19.0.1:57907"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:54:02.726209007Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0e0224aa7a9a34bee548fc638bfe50009218ac599bc0302278d577b71fbc0864",
+			"MachineKey": "mkey:320e120ee48b3434b93ef5e0feb5919015d3d6f8245ac9a2f50ed38ce9c97e03",
+			"Peers": [{
+				"ID":         1536628455110871,
+				"StableID":   "ni2CeBdwzC11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d801f81be1dc9f7582326e1687d2e1cdc5c8c16a906be0f84a9e152dfd93933",
+				"DiscoKey":   "discokey:6c6d483bb012c7d13abbad74947482985f479a178fc4c6b80e4a953ab4be5944",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40799",
+					"10.65.0.27:40799",
+					"172.17.0.1:40799",
+					"172.18.0.1:40799",
+					"172.19.0.1:40799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:53:57.359941984Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8091269229655474,
+				"StableID":   "ndrLaVvYB621CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6ee633723992353e99d790191c66572bfe9b28d7167e91f88084324d36368e56",
+				"DiscoKey":   "discokey:53cf9053055eb002a4a4f68e88fa500e35960082f72a2b768d99773794a49552",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55163",
+					"10.65.0.27:55163",
+					"172.17.0.1:55163",
+					"172.18.0.1:55163",
+					"172.19.0.1:55163"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:53:57.885709819Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1782745046409962,
+				"StableID":   "nTyb2zgQvE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:786a259ef2b7f75fb384231f6eb3e8d12ffd59631db96fc62f05b69be6072147",
+				"DiscoKey":   "discokey:3a21d33f2b4ec6b2f90d5698f5a65ceed1a5dee28e1352ec24ba79d596927736",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45940",
+					"10.65.0.27:45940",
+					"172.17.0.1:45940",
+					"172.18.0.1:45940",
+					"172.19.0.1:45940"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:53:58.42512068Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1397030307467552,
+				"StableID":   "nj6CNociuB11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:43c950347e3eaad96ab2bc6fd566485f10397d218ac1a123780d5010cadbf53a",
+				"DiscoKey":   "discokey:dd4f86a0b2f420a750dc2bf362a56c2c53e1941662c150fbea6ad128c3836629",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40628",
+					"10.65.0.27:40628",
+					"172.17.0.1:40628",
+					"172.18.0.1:40628",
+					"172.19.0.1:40628"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:53:58.964308415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7212115613438684,
+				"StableID":   "nddj2m3PKy11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0d06cf8a92e9547f56e75f191ed5ce83ea230d72dc7651fd22ed268acb87f73",
+				"DiscoKey":   "discokey:ad9f8f247f4ec22d92bbc797cb1f4c2b5f9f67b608f617dae1e4fc00ae97d50b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40065",
+					"10.65.0.27:40065",
+					"172.17.0.1:40065",
+					"172.18.0.1:40065",
+					"172.19.0.1:40065"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:53:59.505615716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7180388874568491,
+				"StableID":   "nNW2m7e15y11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6da83e3ee3af8bb085b5e9695bb2efcc29692add83b6dd8bbeaeff46def9d51d",
+				"DiscoKey":   "discokey:d4b3f12e6eb725606998427b84074bee2d130051e5ac9cd146029d5d9220b30b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41996",
+					"10.65.0.27:41996",
+					"172.17.0.1:41996",
+					"172.18.0.1:41996",
+					"172.19.0.1:41996"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:54:00.039394051Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2366105036725447,
+				"StableID":   "npuTktZcUK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f91e7ae73ad63c3412dbb8151c79b1416d2a27c9d890a59fe24b58c3ab81e4d",
+				"DiscoKey":   "discokey:c7b428c382ca21de2bd0f787efaf23e65827c0b5a1529a4a8358f807446b5027",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:36734",
+					"10.65.0.27:36734",
+					"172.17.0.1:36734",
+					"172.18.0.1:36734",
+					"172.19.0.1:36734"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:54:00.574150708Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1866704879042162,
+				"StableID":   "nHtxvxASaF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:02c4988687d49efb699aa1f613ac8911ecdb6f6897e8768612558fe94393933f",
+				"DiscoKey":   "discokey:760282c8e21478911f8ce05ea377c56d788c1456a4a4786c48e2dd053f95db41",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45325",
+					"10.65.0.27:45325",
+					"172.17.0.1:45325",
+					"172.18.0.1:45325",
+					"172.19.0.1:45325"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:54:01.1120868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6517402740667875,
+				"StableID":   "nntwPs7kts11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4de83ba23259a2997405f59b6cac79d31c79b13374e140e839d9df19dad8df5f",
+				"DiscoKey":   "discokey:34022403bded2aabe79cfaeabbef4b450f62d81b015ff3ee7db2a4fda7d96c3b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41670",
+					"10.65.0.27:41670",
+					"172.17.0.1:41670",
+					"172.18.0.1:41670",
+					"172.19.0.1:41670"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:54:01.658004765Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5102420916393928,
+				"StableID":   "nyhoxpwtqg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0fd979a1f08dd6f1f6f47e954df44f06fdee1806dce44095f37feb3f65235325",
+				"DiscoKey":   "discokey:6b648a64505d2eceb72a34efd4969dddbd55f3f506c1134dcde1e1c7ce933a18",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58924",
+					"10.65.0.27:58924",
+					"172.17.0.1:58924",
+					"172.18.0.1:58924",
+					"172.19.0.1:58924"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:54:02.217359202Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6272805259170820,
+				"StableID":   "n17MYXxxyq11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae49dd35238f5dbc743f14cb45b9ebfb966433a3f862086d6de210c123c74e4c",
+				"DiscoKey":   "discokey:645533b4d90d4595cdce08cec38aba3ee21c45c80bad753985c6710b32c7e268",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39184",
+					"10.65.0.27:39184",
+					"172.17.0.1:39184",
+					"172.18.0.1:39184",
+					"172.19.0.1:39184"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:54:03.268609688Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2029343697476936,
+				"StableID":   "nXCLPER6rG11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8371bef1f4960f93dabc72dd1539b23034873f9d4a362d24876f11981c82251c",
+				"KeyExpiry":  "2026-11-08T21:54:03Z",
+				"DiscoKey":   "discokey:a9f2dde092304a32eee85d4b47bd75048c49bea8ca4bf586b9b2af4026696e3b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51515",
+					"10.65.0.27:51515",
+					"172.17.0.1:51515",
+					"172.18.0.1:51515",
+					"172.19.0.1:51515"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:54:03.81070494Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3420614081054452,
+				"StableID":   "nRX11SjCiT11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:312845ba3ecdfe2085399c443266a393e1ff1d04b141eaa24299936e8ee0dc78",
+				"KeyExpiry":  "2026-11-08T21:54:05Z",
+				"DiscoKey":   "discokey:421c8a0231d57ce03a2af24281263edb51e23f05f66010b01daeb0d8929d2209",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34384",
+					"10.65.0.27:34384",
+					"172.17.0.1:34384",
+					"172.18.0.1:34384",
+					"172.19.0.1:34384"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:54:05.124503251Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8819234930411957,
+				"StableID":   "n8cTk7MFsB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5d8b9ac31c5a5da06cff42bdb9f20a70ed63881c5b6ed493854c477d7a1ffe7b",
+				"KeyExpiry":  "2026-11-08T21:54:05Z",
+				"DiscoKey":   "discokey:31d9e818710e3c4f7c3eb0b4ce21747eae9592913daef50cabd37a60aae6fb0e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:35344",
+					"10.65.0.27:35344",
+					"172.17.0.1:35344",
+					"172.18.0.1:35344",
+					"172.19.0.1:35344"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:54:05.649149464Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1644746421818531": {
+				"ID":          1644746421818531,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8091269229655474,
+				"StableID":   "ndrLaVvYB621CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       8091269229655474,
+				"Key":        "nodekey:6ee633723992353e99d790191c66572bfe9b28d7167e91f88084324d36368e56",
+				"DiscoKey":   "discokey:53cf9053055eb002a4a4f68e88fa500e35960082f72a2b768d99773794a49552",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55163",
+					"10.65.0.27:55163",
+					"172.17.0.1:55163",
+					"172.18.0.1:55163",
+					"172.19.0.1:55163"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:53:57.885709819Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6ee633723992353e99d790191c66572bfe9b28d7167e91f88084324d36368e56",
+			"MachineKey": "mkey:ee98165276822978240ba97fc1a29d24c3f74adffc37a6470e9c7ba385977571",
+			"Peers": [{
+				"ID":         1536628455110871,
+				"StableID":   "ni2CeBdwzC11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d801f81be1dc9f7582326e1687d2e1cdc5c8c16a906be0f84a9e152dfd93933",
+				"DiscoKey":   "discokey:6c6d483bb012c7d13abbad74947482985f479a178fc4c6b80e4a953ab4be5944",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40799",
+					"10.65.0.27:40799",
+					"172.17.0.1:40799",
+					"172.18.0.1:40799",
+					"172.19.0.1:40799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:53:57.359941984Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1782745046409962,
+				"StableID":   "nTyb2zgQvE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:786a259ef2b7f75fb384231f6eb3e8d12ffd59631db96fc62f05b69be6072147",
+				"DiscoKey":   "discokey:3a21d33f2b4ec6b2f90d5698f5a65ceed1a5dee28e1352ec24ba79d596927736",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45940",
+					"10.65.0.27:45940",
+					"172.17.0.1:45940",
+					"172.18.0.1:45940",
+					"172.19.0.1:45940"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:53:58.42512068Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1397030307467552,
+				"StableID":   "nj6CNociuB11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:43c950347e3eaad96ab2bc6fd566485f10397d218ac1a123780d5010cadbf53a",
+				"DiscoKey":   "discokey:dd4f86a0b2f420a750dc2bf362a56c2c53e1941662c150fbea6ad128c3836629",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40628",
+					"10.65.0.27:40628",
+					"172.17.0.1:40628",
+					"172.18.0.1:40628",
+					"172.19.0.1:40628"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:53:58.964308415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7212115613438684,
+				"StableID":   "nddj2m3PKy11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0d06cf8a92e9547f56e75f191ed5ce83ea230d72dc7651fd22ed268acb87f73",
+				"DiscoKey":   "discokey:ad9f8f247f4ec22d92bbc797cb1f4c2b5f9f67b608f617dae1e4fc00ae97d50b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40065",
+					"10.65.0.27:40065",
+					"172.17.0.1:40065",
+					"172.18.0.1:40065",
+					"172.19.0.1:40065"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:53:59.505615716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7180388874568491,
+				"StableID":   "nNW2m7e15y11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6da83e3ee3af8bb085b5e9695bb2efcc29692add83b6dd8bbeaeff46def9d51d",
+				"DiscoKey":   "discokey:d4b3f12e6eb725606998427b84074bee2d130051e5ac9cd146029d5d9220b30b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41996",
+					"10.65.0.27:41996",
+					"172.17.0.1:41996",
+					"172.18.0.1:41996",
+					"172.19.0.1:41996"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:54:00.039394051Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2366105036725447,
+				"StableID":   "npuTktZcUK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f91e7ae73ad63c3412dbb8151c79b1416d2a27c9d890a59fe24b58c3ab81e4d",
+				"DiscoKey":   "discokey:c7b428c382ca21de2bd0f787efaf23e65827c0b5a1529a4a8358f807446b5027",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:36734",
+					"10.65.0.27:36734",
+					"172.17.0.1:36734",
+					"172.18.0.1:36734",
+					"172.19.0.1:36734"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:54:00.574150708Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1866704879042162,
+				"StableID":   "nHtxvxASaF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:02c4988687d49efb699aa1f613ac8911ecdb6f6897e8768612558fe94393933f",
+				"DiscoKey":   "discokey:760282c8e21478911f8ce05ea377c56d788c1456a4a4786c48e2dd053f95db41",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45325",
+					"10.65.0.27:45325",
+					"172.17.0.1:45325",
+					"172.18.0.1:45325",
+					"172.19.0.1:45325"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:54:01.1120868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6517402740667875,
+				"StableID":   "nntwPs7kts11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4de83ba23259a2997405f59b6cac79d31c79b13374e140e839d9df19dad8df5f",
+				"DiscoKey":   "discokey:34022403bded2aabe79cfaeabbef4b450f62d81b015ff3ee7db2a4fda7d96c3b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41670",
+					"10.65.0.27:41670",
+					"172.17.0.1:41670",
+					"172.18.0.1:41670",
+					"172.19.0.1:41670"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:54:01.658004765Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5102420916393928,
+				"StableID":   "nyhoxpwtqg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0fd979a1f08dd6f1f6f47e954df44f06fdee1806dce44095f37feb3f65235325",
+				"DiscoKey":   "discokey:6b648a64505d2eceb72a34efd4969dddbd55f3f506c1134dcde1e1c7ce933a18",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58924",
+					"10.65.0.27:58924",
+					"172.17.0.1:58924",
+					"172.18.0.1:58924",
+					"172.19.0.1:58924"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:54:02.217359202Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1644746421818531,
+				"StableID":   "nipL8ahuqD11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e0224aa7a9a34bee548fc638bfe50009218ac599bc0302278d577b71fbc0864",
+				"DiscoKey":   "discokey:864449688a58b9d8bf83579e87c463ed415da04e5f4c93c1e48d0dd210f5694d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57907",
+					"10.65.0.27:57907",
+					"172.17.0.1:57907",
+					"172.18.0.1:57907",
+					"172.19.0.1:57907"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:54:02.726209007Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6272805259170820,
+				"StableID":   "n17MYXxxyq11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae49dd35238f5dbc743f14cb45b9ebfb966433a3f862086d6de210c123c74e4c",
+				"DiscoKey":   "discokey:645533b4d90d4595cdce08cec38aba3ee21c45c80bad753985c6710b32c7e268",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39184",
+					"10.65.0.27:39184",
+					"172.17.0.1:39184",
+					"172.18.0.1:39184",
+					"172.19.0.1:39184"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:54:03.268609688Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2029343697476936,
+				"StableID":   "nXCLPER6rG11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8371bef1f4960f93dabc72dd1539b23034873f9d4a362d24876f11981c82251c",
+				"KeyExpiry":  "2026-11-08T21:54:03Z",
+				"DiscoKey":   "discokey:a9f2dde092304a32eee85d4b47bd75048c49bea8ca4bf586b9b2af4026696e3b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51515",
+					"10.65.0.27:51515",
+					"172.17.0.1:51515",
+					"172.18.0.1:51515",
+					"172.19.0.1:51515"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:54:03.81070494Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3420614081054452,
+				"StableID":   "nRX11SjCiT11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:312845ba3ecdfe2085399c443266a393e1ff1d04b141eaa24299936e8ee0dc78",
+				"KeyExpiry":  "2026-11-08T21:54:05Z",
+				"DiscoKey":   "discokey:421c8a0231d57ce03a2af24281263edb51e23f05f66010b01daeb0d8929d2209",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34384",
+					"10.65.0.27:34384",
+					"172.17.0.1:34384",
+					"172.18.0.1:34384",
+					"172.19.0.1:34384"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:54:05.124503251Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8819234930411957,
+				"StableID":   "n8cTk7MFsB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5d8b9ac31c5a5da06cff42bdb9f20a70ed63881c5b6ed493854c477d7a1ffe7b",
+				"KeyExpiry":  "2026-11-08T21:54:05Z",
+				"DiscoKey":   "discokey:31d9e818710e3c4f7c3eb0b4ce21747eae9592913daef50cabd37a60aae6fb0e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:35344",
+					"10.65.0.27:35344",
+					"172.17.0.1:35344",
+					"172.18.0.1:35344",
+					"172.19.0.1:35344"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:54:05.649149464Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8091269229655474": {
+				"ID":          8091269229655474,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1536628455110871,
+				"StableID":   "ni2CeBdwzC11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1536628455110871,
+				"Key":        "nodekey:9d801f81be1dc9f7582326e1687d2e1cdc5c8c16a906be0f84a9e152dfd93933",
+				"DiscoKey":   "discokey:6c6d483bb012c7d13abbad74947482985f479a178fc4c6b80e4a953ab4be5944",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40799",
+					"10.65.0.27:40799",
+					"172.17.0.1:40799",
+					"172.18.0.1:40799",
+					"172.19.0.1:40799"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:53:57.359941984Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9d801f81be1dc9f7582326e1687d2e1cdc5c8c16a906be0f84a9e152dfd93933",
+			"MachineKey": "mkey:968083165a1312b9a8d9654e360c4af2587b57faf7a6ad22004b92c1963aa16e",
+			"Peers": [{
+				"ID":         8091269229655474,
+				"StableID":   "ndrLaVvYB621CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6ee633723992353e99d790191c66572bfe9b28d7167e91f88084324d36368e56",
+				"DiscoKey":   "discokey:53cf9053055eb002a4a4f68e88fa500e35960082f72a2b768d99773794a49552",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55163",
+					"10.65.0.27:55163",
+					"172.17.0.1:55163",
+					"172.18.0.1:55163",
+					"172.19.0.1:55163"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:53:57.885709819Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1782745046409962,
+				"StableID":   "nTyb2zgQvE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:786a259ef2b7f75fb384231f6eb3e8d12ffd59631db96fc62f05b69be6072147",
+				"DiscoKey":   "discokey:3a21d33f2b4ec6b2f90d5698f5a65ceed1a5dee28e1352ec24ba79d596927736",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45940",
+					"10.65.0.27:45940",
+					"172.17.0.1:45940",
+					"172.18.0.1:45940",
+					"172.19.0.1:45940"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:53:58.42512068Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1397030307467552,
+				"StableID":   "nj6CNociuB11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:43c950347e3eaad96ab2bc6fd566485f10397d218ac1a123780d5010cadbf53a",
+				"DiscoKey":   "discokey:dd4f86a0b2f420a750dc2bf362a56c2c53e1941662c150fbea6ad128c3836629",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40628",
+					"10.65.0.27:40628",
+					"172.17.0.1:40628",
+					"172.18.0.1:40628",
+					"172.19.0.1:40628"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:53:58.964308415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7212115613438684,
+				"StableID":   "nddj2m3PKy11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0d06cf8a92e9547f56e75f191ed5ce83ea230d72dc7651fd22ed268acb87f73",
+				"DiscoKey":   "discokey:ad9f8f247f4ec22d92bbc797cb1f4c2b5f9f67b608f617dae1e4fc00ae97d50b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40065",
+					"10.65.0.27:40065",
+					"172.17.0.1:40065",
+					"172.18.0.1:40065",
+					"172.19.0.1:40065"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:53:59.505615716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7180388874568491,
+				"StableID":   "nNW2m7e15y11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6da83e3ee3af8bb085b5e9695bb2efcc29692add83b6dd8bbeaeff46def9d51d",
+				"DiscoKey":   "discokey:d4b3f12e6eb725606998427b84074bee2d130051e5ac9cd146029d5d9220b30b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41996",
+					"10.65.0.27:41996",
+					"172.17.0.1:41996",
+					"172.18.0.1:41996",
+					"172.19.0.1:41996"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:54:00.039394051Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2366105036725447,
+				"StableID":   "npuTktZcUK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f91e7ae73ad63c3412dbb8151c79b1416d2a27c9d890a59fe24b58c3ab81e4d",
+				"DiscoKey":   "discokey:c7b428c382ca21de2bd0f787efaf23e65827c0b5a1529a4a8358f807446b5027",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:36734",
+					"10.65.0.27:36734",
+					"172.17.0.1:36734",
+					"172.18.0.1:36734",
+					"172.19.0.1:36734"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:54:00.574150708Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1866704879042162,
+				"StableID":   "nHtxvxASaF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:02c4988687d49efb699aa1f613ac8911ecdb6f6897e8768612558fe94393933f",
+				"DiscoKey":   "discokey:760282c8e21478911f8ce05ea377c56d788c1456a4a4786c48e2dd053f95db41",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45325",
+					"10.65.0.27:45325",
+					"172.17.0.1:45325",
+					"172.18.0.1:45325",
+					"172.19.0.1:45325"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:54:01.1120868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6517402740667875,
+				"StableID":   "nntwPs7kts11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4de83ba23259a2997405f59b6cac79d31c79b13374e140e839d9df19dad8df5f",
+				"DiscoKey":   "discokey:34022403bded2aabe79cfaeabbef4b450f62d81b015ff3ee7db2a4fda7d96c3b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41670",
+					"10.65.0.27:41670",
+					"172.17.0.1:41670",
+					"172.18.0.1:41670",
+					"172.19.0.1:41670"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:54:01.658004765Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5102420916393928,
+				"StableID":   "nyhoxpwtqg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0fd979a1f08dd6f1f6f47e954df44f06fdee1806dce44095f37feb3f65235325",
+				"DiscoKey":   "discokey:6b648a64505d2eceb72a34efd4969dddbd55f3f506c1134dcde1e1c7ce933a18",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58924",
+					"10.65.0.27:58924",
+					"172.17.0.1:58924",
+					"172.18.0.1:58924",
+					"172.19.0.1:58924"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:54:02.217359202Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1644746421818531,
+				"StableID":   "nipL8ahuqD11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e0224aa7a9a34bee548fc638bfe50009218ac599bc0302278d577b71fbc0864",
+				"DiscoKey":   "discokey:864449688a58b9d8bf83579e87c463ed415da04e5f4c93c1e48d0dd210f5694d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57907",
+					"10.65.0.27:57907",
+					"172.17.0.1:57907",
+					"172.18.0.1:57907",
+					"172.19.0.1:57907"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:54:02.726209007Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6272805259170820,
+				"StableID":   "n17MYXxxyq11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae49dd35238f5dbc743f14cb45b9ebfb966433a3f862086d6de210c123c74e4c",
+				"DiscoKey":   "discokey:645533b4d90d4595cdce08cec38aba3ee21c45c80bad753985c6710b32c7e268",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39184",
+					"10.65.0.27:39184",
+					"172.17.0.1:39184",
+					"172.18.0.1:39184",
+					"172.19.0.1:39184"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:54:03.268609688Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2029343697476936,
+				"StableID":   "nXCLPER6rG11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8371bef1f4960f93dabc72dd1539b23034873f9d4a362d24876f11981c82251c",
+				"KeyExpiry":  "2026-11-08T21:54:03Z",
+				"DiscoKey":   "discokey:a9f2dde092304a32eee85d4b47bd75048c49bea8ca4bf586b9b2af4026696e3b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51515",
+					"10.65.0.27:51515",
+					"172.17.0.1:51515",
+					"172.18.0.1:51515",
+					"172.19.0.1:51515"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:54:03.81070494Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3420614081054452,
+				"StableID":   "nRX11SjCiT11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:312845ba3ecdfe2085399c443266a393e1ff1d04b141eaa24299936e8ee0dc78",
+				"KeyExpiry":  "2026-11-08T21:54:05Z",
+				"DiscoKey":   "discokey:421c8a0231d57ce03a2af24281263edb51e23f05f66010b01daeb0d8929d2209",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34384",
+					"10.65.0.27:34384",
+					"172.17.0.1:34384",
+					"172.18.0.1:34384",
+					"172.19.0.1:34384"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:54:05.124503251Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8819234930411957,
+				"StableID":   "n8cTk7MFsB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5d8b9ac31c5a5da06cff42bdb9f20a70ed63881c5b6ed493854c477d7a1ffe7b",
+				"KeyExpiry":  "2026-11-08T21:54:05Z",
+				"DiscoKey":   "discokey:31d9e818710e3c4f7c3eb0b4ce21747eae9592913daef50cabd37a60aae6fb0e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:35344",
+					"10.65.0.27:35344",
+					"172.17.0.1:35344",
+					"172.18.0.1:35344",
+					"172.19.0.1:35344"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:54:05.649149464Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1536628455110871": {
+				"ID":          1536628455110871,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7212115613438684,
+				"StableID":   "nddj2m3PKy11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       7212115613438684,
+				"Key":        "nodekey:a0d06cf8a92e9547f56e75f191ed5ce83ea230d72dc7651fd22ed268acb87f73",
+				"DiscoKey":   "discokey:ad9f8f247f4ec22d92bbc797cb1f4c2b5f9f67b608f617dae1e4fc00ae97d50b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40065",
+					"10.65.0.27:40065",
+					"172.17.0.1:40065",
+					"172.18.0.1:40065",
+					"172.19.0.1:40065"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:53:59.505615716Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a0d06cf8a92e9547f56e75f191ed5ce83ea230d72dc7651fd22ed268acb87f73",
+			"MachineKey": "mkey:d768155167556725458f8821ee62aa4d0383b8346084ca80d62272f5be0b9337",
+			"Peers": [{
+				"ID":         1536628455110871,
+				"StableID":   "ni2CeBdwzC11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d801f81be1dc9f7582326e1687d2e1cdc5c8c16a906be0f84a9e152dfd93933",
+				"DiscoKey":   "discokey:6c6d483bb012c7d13abbad74947482985f479a178fc4c6b80e4a953ab4be5944",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40799",
+					"10.65.0.27:40799",
+					"172.17.0.1:40799",
+					"172.18.0.1:40799",
+					"172.19.0.1:40799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:53:57.359941984Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8091269229655474,
+				"StableID":   "ndrLaVvYB621CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6ee633723992353e99d790191c66572bfe9b28d7167e91f88084324d36368e56",
+				"DiscoKey":   "discokey:53cf9053055eb002a4a4f68e88fa500e35960082f72a2b768d99773794a49552",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55163",
+					"10.65.0.27:55163",
+					"172.17.0.1:55163",
+					"172.18.0.1:55163",
+					"172.19.0.1:55163"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:53:57.885709819Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1782745046409962,
+				"StableID":   "nTyb2zgQvE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:786a259ef2b7f75fb384231f6eb3e8d12ffd59631db96fc62f05b69be6072147",
+				"DiscoKey":   "discokey:3a21d33f2b4ec6b2f90d5698f5a65ceed1a5dee28e1352ec24ba79d596927736",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45940",
+					"10.65.0.27:45940",
+					"172.17.0.1:45940",
+					"172.18.0.1:45940",
+					"172.19.0.1:45940"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:53:58.42512068Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1397030307467552,
+				"StableID":   "nj6CNociuB11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:43c950347e3eaad96ab2bc6fd566485f10397d218ac1a123780d5010cadbf53a",
+				"DiscoKey":   "discokey:dd4f86a0b2f420a750dc2bf362a56c2c53e1941662c150fbea6ad128c3836629",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40628",
+					"10.65.0.27:40628",
+					"172.17.0.1:40628",
+					"172.18.0.1:40628",
+					"172.19.0.1:40628"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:53:58.964308415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7180388874568491,
+				"StableID":   "nNW2m7e15y11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6da83e3ee3af8bb085b5e9695bb2efcc29692add83b6dd8bbeaeff46def9d51d",
+				"DiscoKey":   "discokey:d4b3f12e6eb725606998427b84074bee2d130051e5ac9cd146029d5d9220b30b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41996",
+					"10.65.0.27:41996",
+					"172.17.0.1:41996",
+					"172.18.0.1:41996",
+					"172.19.0.1:41996"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:54:00.039394051Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2366105036725447,
+				"StableID":   "npuTktZcUK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f91e7ae73ad63c3412dbb8151c79b1416d2a27c9d890a59fe24b58c3ab81e4d",
+				"DiscoKey":   "discokey:c7b428c382ca21de2bd0f787efaf23e65827c0b5a1529a4a8358f807446b5027",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:36734",
+					"10.65.0.27:36734",
+					"172.17.0.1:36734",
+					"172.18.0.1:36734",
+					"172.19.0.1:36734"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:54:00.574150708Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1866704879042162,
+				"StableID":   "nHtxvxASaF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:02c4988687d49efb699aa1f613ac8911ecdb6f6897e8768612558fe94393933f",
+				"DiscoKey":   "discokey:760282c8e21478911f8ce05ea377c56d788c1456a4a4786c48e2dd053f95db41",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45325",
+					"10.65.0.27:45325",
+					"172.17.0.1:45325",
+					"172.18.0.1:45325",
+					"172.19.0.1:45325"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:54:01.1120868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6517402740667875,
+				"StableID":   "nntwPs7kts11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4de83ba23259a2997405f59b6cac79d31c79b13374e140e839d9df19dad8df5f",
+				"DiscoKey":   "discokey:34022403bded2aabe79cfaeabbef4b450f62d81b015ff3ee7db2a4fda7d96c3b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41670",
+					"10.65.0.27:41670",
+					"172.17.0.1:41670",
+					"172.18.0.1:41670",
+					"172.19.0.1:41670"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:54:01.658004765Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5102420916393928,
+				"StableID":   "nyhoxpwtqg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0fd979a1f08dd6f1f6f47e954df44f06fdee1806dce44095f37feb3f65235325",
+				"DiscoKey":   "discokey:6b648a64505d2eceb72a34efd4969dddbd55f3f506c1134dcde1e1c7ce933a18",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58924",
+					"10.65.0.27:58924",
+					"172.17.0.1:58924",
+					"172.18.0.1:58924",
+					"172.19.0.1:58924"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:54:02.217359202Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1644746421818531,
+				"StableID":   "nipL8ahuqD11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e0224aa7a9a34bee548fc638bfe50009218ac599bc0302278d577b71fbc0864",
+				"DiscoKey":   "discokey:864449688a58b9d8bf83579e87c463ed415da04e5f4c93c1e48d0dd210f5694d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57907",
+					"10.65.0.27:57907",
+					"172.17.0.1:57907",
+					"172.18.0.1:57907",
+					"172.19.0.1:57907"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:54:02.726209007Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6272805259170820,
+				"StableID":   "n17MYXxxyq11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae49dd35238f5dbc743f14cb45b9ebfb966433a3f862086d6de210c123c74e4c",
+				"DiscoKey":   "discokey:645533b4d90d4595cdce08cec38aba3ee21c45c80bad753985c6710b32c7e268",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39184",
+					"10.65.0.27:39184",
+					"172.17.0.1:39184",
+					"172.18.0.1:39184",
+					"172.19.0.1:39184"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:54:03.268609688Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2029343697476936,
+				"StableID":   "nXCLPER6rG11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8371bef1f4960f93dabc72dd1539b23034873f9d4a362d24876f11981c82251c",
+				"KeyExpiry":  "2026-11-08T21:54:03Z",
+				"DiscoKey":   "discokey:a9f2dde092304a32eee85d4b47bd75048c49bea8ca4bf586b9b2af4026696e3b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51515",
+					"10.65.0.27:51515",
+					"172.17.0.1:51515",
+					"172.18.0.1:51515",
+					"172.19.0.1:51515"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:54:03.81070494Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3420614081054452,
+				"StableID":   "nRX11SjCiT11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:312845ba3ecdfe2085399c443266a393e1ff1d04b141eaa24299936e8ee0dc78",
+				"KeyExpiry":  "2026-11-08T21:54:05Z",
+				"DiscoKey":   "discokey:421c8a0231d57ce03a2af24281263edb51e23f05f66010b01daeb0d8929d2209",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34384",
+					"10.65.0.27:34384",
+					"172.17.0.1:34384",
+					"172.18.0.1:34384",
+					"172.19.0.1:34384"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:54:05.124503251Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8819234930411957,
+				"StableID":   "n8cTk7MFsB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5d8b9ac31c5a5da06cff42bdb9f20a70ed63881c5b6ed493854c477d7a1ffe7b",
+				"KeyExpiry":  "2026-11-08T21:54:05Z",
+				"DiscoKey":   "discokey:31d9e818710e3c4f7c3eb0b4ce21747eae9592913daef50cabd37a60aae6fb0e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:35344",
+					"10.65.0.27:35344",
+					"172.17.0.1:35344",
+					"172.18.0.1:35344",
+					"172.19.0.1:35344"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:54:05.649149464Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7212115613438684": {
+				"ID":          7212115613438684,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1397030307467552,
+				"StableID":   "nj6CNociuB11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1397030307467552,
+				"Key":        "nodekey:43c950347e3eaad96ab2bc6fd566485f10397d218ac1a123780d5010cadbf53a",
+				"DiscoKey":   "discokey:dd4f86a0b2f420a750dc2bf362a56c2c53e1941662c150fbea6ad128c3836629",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40628",
+					"10.65.0.27:40628",
+					"172.17.0.1:40628",
+					"172.18.0.1:40628",
+					"172.19.0.1:40628"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:53:58.964308415Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:43c950347e3eaad96ab2bc6fd566485f10397d218ac1a123780d5010cadbf53a",
+			"MachineKey": "mkey:4bec968fda344cddd6227c09ffd5dbe3cb5a3789ad55553351cd4e44cf60d324",
+			"Peers": [{
+				"ID":         1536628455110871,
+				"StableID":   "ni2CeBdwzC11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d801f81be1dc9f7582326e1687d2e1cdc5c8c16a906be0f84a9e152dfd93933",
+				"DiscoKey":   "discokey:6c6d483bb012c7d13abbad74947482985f479a178fc4c6b80e4a953ab4be5944",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40799",
+					"10.65.0.27:40799",
+					"172.17.0.1:40799",
+					"172.18.0.1:40799",
+					"172.19.0.1:40799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:53:57.359941984Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8091269229655474,
+				"StableID":   "ndrLaVvYB621CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6ee633723992353e99d790191c66572bfe9b28d7167e91f88084324d36368e56",
+				"DiscoKey":   "discokey:53cf9053055eb002a4a4f68e88fa500e35960082f72a2b768d99773794a49552",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55163",
+					"10.65.0.27:55163",
+					"172.17.0.1:55163",
+					"172.18.0.1:55163",
+					"172.19.0.1:55163"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:53:57.885709819Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1782745046409962,
+				"StableID":   "nTyb2zgQvE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:786a259ef2b7f75fb384231f6eb3e8d12ffd59631db96fc62f05b69be6072147",
+				"DiscoKey":   "discokey:3a21d33f2b4ec6b2f90d5698f5a65ceed1a5dee28e1352ec24ba79d596927736",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45940",
+					"10.65.0.27:45940",
+					"172.17.0.1:45940",
+					"172.18.0.1:45940",
+					"172.19.0.1:45940"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:53:58.42512068Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7212115613438684,
+				"StableID":   "nddj2m3PKy11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0d06cf8a92e9547f56e75f191ed5ce83ea230d72dc7651fd22ed268acb87f73",
+				"DiscoKey":   "discokey:ad9f8f247f4ec22d92bbc797cb1f4c2b5f9f67b608f617dae1e4fc00ae97d50b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40065",
+					"10.65.0.27:40065",
+					"172.17.0.1:40065",
+					"172.18.0.1:40065",
+					"172.19.0.1:40065"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:53:59.505615716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7180388874568491,
+				"StableID":   "nNW2m7e15y11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6da83e3ee3af8bb085b5e9695bb2efcc29692add83b6dd8bbeaeff46def9d51d",
+				"DiscoKey":   "discokey:d4b3f12e6eb725606998427b84074bee2d130051e5ac9cd146029d5d9220b30b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41996",
+					"10.65.0.27:41996",
+					"172.17.0.1:41996",
+					"172.18.0.1:41996",
+					"172.19.0.1:41996"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:54:00.039394051Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2366105036725447,
+				"StableID":   "npuTktZcUK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f91e7ae73ad63c3412dbb8151c79b1416d2a27c9d890a59fe24b58c3ab81e4d",
+				"DiscoKey":   "discokey:c7b428c382ca21de2bd0f787efaf23e65827c0b5a1529a4a8358f807446b5027",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:36734",
+					"10.65.0.27:36734",
+					"172.17.0.1:36734",
+					"172.18.0.1:36734",
+					"172.19.0.1:36734"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:54:00.574150708Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1866704879042162,
+				"StableID":   "nHtxvxASaF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:02c4988687d49efb699aa1f613ac8911ecdb6f6897e8768612558fe94393933f",
+				"DiscoKey":   "discokey:760282c8e21478911f8ce05ea377c56d788c1456a4a4786c48e2dd053f95db41",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45325",
+					"10.65.0.27:45325",
+					"172.17.0.1:45325",
+					"172.18.0.1:45325",
+					"172.19.0.1:45325"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:54:01.1120868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6517402740667875,
+				"StableID":   "nntwPs7kts11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4de83ba23259a2997405f59b6cac79d31c79b13374e140e839d9df19dad8df5f",
+				"DiscoKey":   "discokey:34022403bded2aabe79cfaeabbef4b450f62d81b015ff3ee7db2a4fda7d96c3b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41670",
+					"10.65.0.27:41670",
+					"172.17.0.1:41670",
+					"172.18.0.1:41670",
+					"172.19.0.1:41670"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:54:01.658004765Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5102420916393928,
+				"StableID":   "nyhoxpwtqg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0fd979a1f08dd6f1f6f47e954df44f06fdee1806dce44095f37feb3f65235325",
+				"DiscoKey":   "discokey:6b648a64505d2eceb72a34efd4969dddbd55f3f506c1134dcde1e1c7ce933a18",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58924",
+					"10.65.0.27:58924",
+					"172.17.0.1:58924",
+					"172.18.0.1:58924",
+					"172.19.0.1:58924"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:54:02.217359202Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1644746421818531,
+				"StableID":   "nipL8ahuqD11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e0224aa7a9a34bee548fc638bfe50009218ac599bc0302278d577b71fbc0864",
+				"DiscoKey":   "discokey:864449688a58b9d8bf83579e87c463ed415da04e5f4c93c1e48d0dd210f5694d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57907",
+					"10.65.0.27:57907",
+					"172.17.0.1:57907",
+					"172.18.0.1:57907",
+					"172.19.0.1:57907"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:54:02.726209007Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6272805259170820,
+				"StableID":   "n17MYXxxyq11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae49dd35238f5dbc743f14cb45b9ebfb966433a3f862086d6de210c123c74e4c",
+				"DiscoKey":   "discokey:645533b4d90d4595cdce08cec38aba3ee21c45c80bad753985c6710b32c7e268",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39184",
+					"10.65.0.27:39184",
+					"172.17.0.1:39184",
+					"172.18.0.1:39184",
+					"172.19.0.1:39184"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:54:03.268609688Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2029343697476936,
+				"StableID":   "nXCLPER6rG11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8371bef1f4960f93dabc72dd1539b23034873f9d4a362d24876f11981c82251c",
+				"KeyExpiry":  "2026-11-08T21:54:03Z",
+				"DiscoKey":   "discokey:a9f2dde092304a32eee85d4b47bd75048c49bea8ca4bf586b9b2af4026696e3b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51515",
+					"10.65.0.27:51515",
+					"172.17.0.1:51515",
+					"172.18.0.1:51515",
+					"172.19.0.1:51515"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:54:03.81070494Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3420614081054452,
+				"StableID":   "nRX11SjCiT11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:312845ba3ecdfe2085399c443266a393e1ff1d04b141eaa24299936e8ee0dc78",
+				"KeyExpiry":  "2026-11-08T21:54:05Z",
+				"DiscoKey":   "discokey:421c8a0231d57ce03a2af24281263edb51e23f05f66010b01daeb0d8929d2209",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34384",
+					"10.65.0.27:34384",
+					"172.17.0.1:34384",
+					"172.18.0.1:34384",
+					"172.19.0.1:34384"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:54:05.124503251Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8819234930411957,
+				"StableID":   "n8cTk7MFsB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5d8b9ac31c5a5da06cff42bdb9f20a70ed63881c5b6ed493854c477d7a1ffe7b",
+				"KeyExpiry":  "2026-11-08T21:54:05Z",
+				"DiscoKey":   "discokey:31d9e818710e3c4f7c3eb0b4ce21747eae9592913daef50cabd37a60aae6fb0e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:35344",
+					"10.65.0.27:35344",
+					"172.17.0.1:35344",
+					"172.18.0.1:35344",
+					"172.19.0.1:35344"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:54:05.649149464Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1397030307467552": {
+				"ID":          1397030307467552,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2366105036725447,
+				"StableID":   "npuTktZcUK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       2366105036725447,
+				"Key":        "nodekey:7f91e7ae73ad63c3412dbb8151c79b1416d2a27c9d890a59fe24b58c3ab81e4d",
+				"DiscoKey":   "discokey:c7b428c382ca21de2bd0f787efaf23e65827c0b5a1529a4a8358f807446b5027",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:36734",
+					"10.65.0.27:36734",
+					"172.17.0.1:36734",
+					"172.18.0.1:36734",
+					"172.19.0.1:36734"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:54:00.574150708Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7f91e7ae73ad63c3412dbb8151c79b1416d2a27c9d890a59fe24b58c3ab81e4d",
+			"MachineKey": "mkey:55dde2bd53e80104dada9c9f92caed6eabd98820ba1f86fe4ee34661b4d90f50",
+			"Peers": [{
+				"ID":         1536628455110871,
+				"StableID":   "ni2CeBdwzC11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d801f81be1dc9f7582326e1687d2e1cdc5c8c16a906be0f84a9e152dfd93933",
+				"DiscoKey":   "discokey:6c6d483bb012c7d13abbad74947482985f479a178fc4c6b80e4a953ab4be5944",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40799",
+					"10.65.0.27:40799",
+					"172.17.0.1:40799",
+					"172.18.0.1:40799",
+					"172.19.0.1:40799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:53:57.359941984Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8091269229655474,
+				"StableID":   "ndrLaVvYB621CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6ee633723992353e99d790191c66572bfe9b28d7167e91f88084324d36368e56",
+				"DiscoKey":   "discokey:53cf9053055eb002a4a4f68e88fa500e35960082f72a2b768d99773794a49552",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55163",
+					"10.65.0.27:55163",
+					"172.17.0.1:55163",
+					"172.18.0.1:55163",
+					"172.19.0.1:55163"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:53:57.885709819Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1782745046409962,
+				"StableID":   "nTyb2zgQvE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:786a259ef2b7f75fb384231f6eb3e8d12ffd59631db96fc62f05b69be6072147",
+				"DiscoKey":   "discokey:3a21d33f2b4ec6b2f90d5698f5a65ceed1a5dee28e1352ec24ba79d596927736",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45940",
+					"10.65.0.27:45940",
+					"172.17.0.1:45940",
+					"172.18.0.1:45940",
+					"172.19.0.1:45940"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:53:58.42512068Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1397030307467552,
+				"StableID":   "nj6CNociuB11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:43c950347e3eaad96ab2bc6fd566485f10397d218ac1a123780d5010cadbf53a",
+				"DiscoKey":   "discokey:dd4f86a0b2f420a750dc2bf362a56c2c53e1941662c150fbea6ad128c3836629",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40628",
+					"10.65.0.27:40628",
+					"172.17.0.1:40628",
+					"172.18.0.1:40628",
+					"172.19.0.1:40628"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:53:58.964308415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7212115613438684,
+				"StableID":   "nddj2m3PKy11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0d06cf8a92e9547f56e75f191ed5ce83ea230d72dc7651fd22ed268acb87f73",
+				"DiscoKey":   "discokey:ad9f8f247f4ec22d92bbc797cb1f4c2b5f9f67b608f617dae1e4fc00ae97d50b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40065",
+					"10.65.0.27:40065",
+					"172.17.0.1:40065",
+					"172.18.0.1:40065",
+					"172.19.0.1:40065"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:53:59.505615716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7180388874568491,
+				"StableID":   "nNW2m7e15y11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6da83e3ee3af8bb085b5e9695bb2efcc29692add83b6dd8bbeaeff46def9d51d",
+				"DiscoKey":   "discokey:d4b3f12e6eb725606998427b84074bee2d130051e5ac9cd146029d5d9220b30b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41996",
+					"10.65.0.27:41996",
+					"172.17.0.1:41996",
+					"172.18.0.1:41996",
+					"172.19.0.1:41996"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:54:00.039394051Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1866704879042162,
+				"StableID":   "nHtxvxASaF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:02c4988687d49efb699aa1f613ac8911ecdb6f6897e8768612558fe94393933f",
+				"DiscoKey":   "discokey:760282c8e21478911f8ce05ea377c56d788c1456a4a4786c48e2dd053f95db41",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45325",
+					"10.65.0.27:45325",
+					"172.17.0.1:45325",
+					"172.18.0.1:45325",
+					"172.19.0.1:45325"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:54:01.1120868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6517402740667875,
+				"StableID":   "nntwPs7kts11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4de83ba23259a2997405f59b6cac79d31c79b13374e140e839d9df19dad8df5f",
+				"DiscoKey":   "discokey:34022403bded2aabe79cfaeabbef4b450f62d81b015ff3ee7db2a4fda7d96c3b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41670",
+					"10.65.0.27:41670",
+					"172.17.0.1:41670",
+					"172.18.0.1:41670",
+					"172.19.0.1:41670"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:54:01.658004765Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5102420916393928,
+				"StableID":   "nyhoxpwtqg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0fd979a1f08dd6f1f6f47e954df44f06fdee1806dce44095f37feb3f65235325",
+				"DiscoKey":   "discokey:6b648a64505d2eceb72a34efd4969dddbd55f3f506c1134dcde1e1c7ce933a18",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58924",
+					"10.65.0.27:58924",
+					"172.17.0.1:58924",
+					"172.18.0.1:58924",
+					"172.19.0.1:58924"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:54:02.217359202Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1644746421818531,
+				"StableID":   "nipL8ahuqD11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e0224aa7a9a34bee548fc638bfe50009218ac599bc0302278d577b71fbc0864",
+				"DiscoKey":   "discokey:864449688a58b9d8bf83579e87c463ed415da04e5f4c93c1e48d0dd210f5694d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57907",
+					"10.65.0.27:57907",
+					"172.17.0.1:57907",
+					"172.18.0.1:57907",
+					"172.19.0.1:57907"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:54:02.726209007Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6272805259170820,
+				"StableID":   "n17MYXxxyq11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae49dd35238f5dbc743f14cb45b9ebfb966433a3f862086d6de210c123c74e4c",
+				"DiscoKey":   "discokey:645533b4d90d4595cdce08cec38aba3ee21c45c80bad753985c6710b32c7e268",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39184",
+					"10.65.0.27:39184",
+					"172.17.0.1:39184",
+					"172.18.0.1:39184",
+					"172.19.0.1:39184"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:54:03.268609688Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2029343697476936,
+				"StableID":   "nXCLPER6rG11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8371bef1f4960f93dabc72dd1539b23034873f9d4a362d24876f11981c82251c",
+				"KeyExpiry":  "2026-11-08T21:54:03Z",
+				"DiscoKey":   "discokey:a9f2dde092304a32eee85d4b47bd75048c49bea8ca4bf586b9b2af4026696e3b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51515",
+					"10.65.0.27:51515",
+					"172.17.0.1:51515",
+					"172.18.0.1:51515",
+					"172.19.0.1:51515"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:54:03.81070494Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3420614081054452,
+				"StableID":   "nRX11SjCiT11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:312845ba3ecdfe2085399c443266a393e1ff1d04b141eaa24299936e8ee0dc78",
+				"KeyExpiry":  "2026-11-08T21:54:05Z",
+				"DiscoKey":   "discokey:421c8a0231d57ce03a2af24281263edb51e23f05f66010b01daeb0d8929d2209",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34384",
+					"10.65.0.27:34384",
+					"172.17.0.1:34384",
+					"172.18.0.1:34384",
+					"172.19.0.1:34384"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:54:05.124503251Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8819234930411957,
+				"StableID":   "n8cTk7MFsB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5d8b9ac31c5a5da06cff42bdb9f20a70ed63881c5b6ed493854c477d7a1ffe7b",
+				"KeyExpiry":  "2026-11-08T21:54:05Z",
+				"DiscoKey":   "discokey:31d9e818710e3c4f7c3eb0b4ce21747eae9592913daef50cabd37a60aae6fb0e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:35344",
+					"10.65.0.27:35344",
+					"172.17.0.1:35344",
+					"172.18.0.1:35344",
+					"172.19.0.1:35344"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:54:05.649149464Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2366105036725447": {
+				"ID":          2366105036725447,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6517402740667875,
+				"StableID":   "nntwPs7kts11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       6517402740667875,
+				"Key":        "nodekey:4de83ba23259a2997405f59b6cac79d31c79b13374e140e839d9df19dad8df5f",
+				"DiscoKey":   "discokey:34022403bded2aabe79cfaeabbef4b450f62d81b015ff3ee7db2a4fda7d96c3b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41670",
+					"10.65.0.27:41670",
+					"172.17.0.1:41670",
+					"172.18.0.1:41670",
+					"172.19.0.1:41670"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:54:01.658004765Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4de83ba23259a2997405f59b6cac79d31c79b13374e140e839d9df19dad8df5f",
+			"MachineKey": "mkey:268012e477518b2fcf8120e49e71a9e9cdcbb1859cb2125e9cbc3b2fa860be7e",
+			"Peers": [{
+				"ID":         1536628455110871,
+				"StableID":   "ni2CeBdwzC11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d801f81be1dc9f7582326e1687d2e1cdc5c8c16a906be0f84a9e152dfd93933",
+				"DiscoKey":   "discokey:6c6d483bb012c7d13abbad74947482985f479a178fc4c6b80e4a953ab4be5944",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40799",
+					"10.65.0.27:40799",
+					"172.17.0.1:40799",
+					"172.18.0.1:40799",
+					"172.19.0.1:40799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:53:57.359941984Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8091269229655474,
+				"StableID":   "ndrLaVvYB621CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6ee633723992353e99d790191c66572bfe9b28d7167e91f88084324d36368e56",
+				"DiscoKey":   "discokey:53cf9053055eb002a4a4f68e88fa500e35960082f72a2b768d99773794a49552",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55163",
+					"10.65.0.27:55163",
+					"172.17.0.1:55163",
+					"172.18.0.1:55163",
+					"172.19.0.1:55163"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:53:57.885709819Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1782745046409962,
+				"StableID":   "nTyb2zgQvE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:786a259ef2b7f75fb384231f6eb3e8d12ffd59631db96fc62f05b69be6072147",
+				"DiscoKey":   "discokey:3a21d33f2b4ec6b2f90d5698f5a65ceed1a5dee28e1352ec24ba79d596927736",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45940",
+					"10.65.0.27:45940",
+					"172.17.0.1:45940",
+					"172.18.0.1:45940",
+					"172.19.0.1:45940"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:53:58.42512068Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1397030307467552,
+				"StableID":   "nj6CNociuB11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:43c950347e3eaad96ab2bc6fd566485f10397d218ac1a123780d5010cadbf53a",
+				"DiscoKey":   "discokey:dd4f86a0b2f420a750dc2bf362a56c2c53e1941662c150fbea6ad128c3836629",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40628",
+					"10.65.0.27:40628",
+					"172.17.0.1:40628",
+					"172.18.0.1:40628",
+					"172.19.0.1:40628"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:53:58.964308415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7212115613438684,
+				"StableID":   "nddj2m3PKy11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0d06cf8a92e9547f56e75f191ed5ce83ea230d72dc7651fd22ed268acb87f73",
+				"DiscoKey":   "discokey:ad9f8f247f4ec22d92bbc797cb1f4c2b5f9f67b608f617dae1e4fc00ae97d50b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40065",
+					"10.65.0.27:40065",
+					"172.17.0.1:40065",
+					"172.18.0.1:40065",
+					"172.19.0.1:40065"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:53:59.505615716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7180388874568491,
+				"StableID":   "nNW2m7e15y11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6da83e3ee3af8bb085b5e9695bb2efcc29692add83b6dd8bbeaeff46def9d51d",
+				"DiscoKey":   "discokey:d4b3f12e6eb725606998427b84074bee2d130051e5ac9cd146029d5d9220b30b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41996",
+					"10.65.0.27:41996",
+					"172.17.0.1:41996",
+					"172.18.0.1:41996",
+					"172.19.0.1:41996"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:54:00.039394051Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2366105036725447,
+				"StableID":   "npuTktZcUK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f91e7ae73ad63c3412dbb8151c79b1416d2a27c9d890a59fe24b58c3ab81e4d",
+				"DiscoKey":   "discokey:c7b428c382ca21de2bd0f787efaf23e65827c0b5a1529a4a8358f807446b5027",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:36734",
+					"10.65.0.27:36734",
+					"172.17.0.1:36734",
+					"172.18.0.1:36734",
+					"172.19.0.1:36734"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:54:00.574150708Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1866704879042162,
+				"StableID":   "nHtxvxASaF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:02c4988687d49efb699aa1f613ac8911ecdb6f6897e8768612558fe94393933f",
+				"DiscoKey":   "discokey:760282c8e21478911f8ce05ea377c56d788c1456a4a4786c48e2dd053f95db41",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45325",
+					"10.65.0.27:45325",
+					"172.17.0.1:45325",
+					"172.18.0.1:45325",
+					"172.19.0.1:45325"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:54:01.1120868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5102420916393928,
+				"StableID":   "nyhoxpwtqg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0fd979a1f08dd6f1f6f47e954df44f06fdee1806dce44095f37feb3f65235325",
+				"DiscoKey":   "discokey:6b648a64505d2eceb72a34efd4969dddbd55f3f506c1134dcde1e1c7ce933a18",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58924",
+					"10.65.0.27:58924",
+					"172.17.0.1:58924",
+					"172.18.0.1:58924",
+					"172.19.0.1:58924"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:54:02.217359202Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1644746421818531,
+				"StableID":   "nipL8ahuqD11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e0224aa7a9a34bee548fc638bfe50009218ac599bc0302278d577b71fbc0864",
+				"DiscoKey":   "discokey:864449688a58b9d8bf83579e87c463ed415da04e5f4c93c1e48d0dd210f5694d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57907",
+					"10.65.0.27:57907",
+					"172.17.0.1:57907",
+					"172.18.0.1:57907",
+					"172.19.0.1:57907"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:54:02.726209007Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6272805259170820,
+				"StableID":   "n17MYXxxyq11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae49dd35238f5dbc743f14cb45b9ebfb966433a3f862086d6de210c123c74e4c",
+				"DiscoKey":   "discokey:645533b4d90d4595cdce08cec38aba3ee21c45c80bad753985c6710b32c7e268",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39184",
+					"10.65.0.27:39184",
+					"172.17.0.1:39184",
+					"172.18.0.1:39184",
+					"172.19.0.1:39184"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:54:03.268609688Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2029343697476936,
+				"StableID":   "nXCLPER6rG11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8371bef1f4960f93dabc72dd1539b23034873f9d4a362d24876f11981c82251c",
+				"KeyExpiry":  "2026-11-08T21:54:03Z",
+				"DiscoKey":   "discokey:a9f2dde092304a32eee85d4b47bd75048c49bea8ca4bf586b9b2af4026696e3b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51515",
+					"10.65.0.27:51515",
+					"172.17.0.1:51515",
+					"172.18.0.1:51515",
+					"172.19.0.1:51515"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:54:03.81070494Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3420614081054452,
+				"StableID":   "nRX11SjCiT11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:312845ba3ecdfe2085399c443266a393e1ff1d04b141eaa24299936e8ee0dc78",
+				"KeyExpiry":  "2026-11-08T21:54:05Z",
+				"DiscoKey":   "discokey:421c8a0231d57ce03a2af24281263edb51e23f05f66010b01daeb0d8929d2209",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34384",
+					"10.65.0.27:34384",
+					"172.17.0.1:34384",
+					"172.18.0.1:34384",
+					"172.19.0.1:34384"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:54:05.124503251Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8819234930411957,
+				"StableID":   "n8cTk7MFsB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5d8b9ac31c5a5da06cff42bdb9f20a70ed63881c5b6ed493854c477d7a1ffe7b",
+				"KeyExpiry":  "2026-11-08T21:54:05Z",
+				"DiscoKey":   "discokey:31d9e818710e3c4f7c3eb0b4ce21747eae9592913daef50cabd37a60aae6fb0e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:35344",
+					"10.65.0.27:35344",
+					"172.17.0.1:35344",
+					"172.18.0.1:35344",
+					"172.19.0.1:35344"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:54:05.649149464Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6517402740667875": {
+				"ID":          6517402740667875,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3420614081054452,
+				"StableID":   "nRX11SjCiT11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:312845ba3ecdfe2085399c443266a393e1ff1d04b141eaa24299936e8ee0dc78",
+				"KeyExpiry":  "2026-11-08T21:54:05Z",
+				"DiscoKey":   "discokey:421c8a0231d57ce03a2af24281263edb51e23f05f66010b01daeb0d8929d2209",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34384",
+					"10.65.0.27:34384",
+					"172.17.0.1:34384",
+					"172.18.0.1:34384",
+					"172.19.0.1:34384"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:54:05.124503251Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:312845ba3ecdfe2085399c443266a393e1ff1d04b141eaa24299936e8ee0dc78",
+			"MachineKey": "mkey:5450318421f87f2801b428f0ccd9b73202f5a0bb4f1516c8ab0782f0597f0167",
+			"Peers": [{
+				"ID":         1536628455110871,
+				"StableID":   "ni2CeBdwzC11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d801f81be1dc9f7582326e1687d2e1cdc5c8c16a906be0f84a9e152dfd93933",
+				"DiscoKey":   "discokey:6c6d483bb012c7d13abbad74947482985f479a178fc4c6b80e4a953ab4be5944",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40799",
+					"10.65.0.27:40799",
+					"172.17.0.1:40799",
+					"172.18.0.1:40799",
+					"172.19.0.1:40799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:53:57.359941984Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8091269229655474,
+				"StableID":   "ndrLaVvYB621CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6ee633723992353e99d790191c66572bfe9b28d7167e91f88084324d36368e56",
+				"DiscoKey":   "discokey:53cf9053055eb002a4a4f68e88fa500e35960082f72a2b768d99773794a49552",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55163",
+					"10.65.0.27:55163",
+					"172.17.0.1:55163",
+					"172.18.0.1:55163",
+					"172.19.0.1:55163"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:53:57.885709819Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1782745046409962,
+				"StableID":   "nTyb2zgQvE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:786a259ef2b7f75fb384231f6eb3e8d12ffd59631db96fc62f05b69be6072147",
+				"DiscoKey":   "discokey:3a21d33f2b4ec6b2f90d5698f5a65ceed1a5dee28e1352ec24ba79d596927736",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45940",
+					"10.65.0.27:45940",
+					"172.17.0.1:45940",
+					"172.18.0.1:45940",
+					"172.19.0.1:45940"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:53:58.42512068Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1397030307467552,
+				"StableID":   "nj6CNociuB11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:43c950347e3eaad96ab2bc6fd566485f10397d218ac1a123780d5010cadbf53a",
+				"DiscoKey":   "discokey:dd4f86a0b2f420a750dc2bf362a56c2c53e1941662c150fbea6ad128c3836629",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40628",
+					"10.65.0.27:40628",
+					"172.17.0.1:40628",
+					"172.18.0.1:40628",
+					"172.19.0.1:40628"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:53:58.964308415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7212115613438684,
+				"StableID":   "nddj2m3PKy11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0d06cf8a92e9547f56e75f191ed5ce83ea230d72dc7651fd22ed268acb87f73",
+				"DiscoKey":   "discokey:ad9f8f247f4ec22d92bbc797cb1f4c2b5f9f67b608f617dae1e4fc00ae97d50b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40065",
+					"10.65.0.27:40065",
+					"172.17.0.1:40065",
+					"172.18.0.1:40065",
+					"172.19.0.1:40065"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:53:59.505615716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7180388874568491,
+				"StableID":   "nNW2m7e15y11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6da83e3ee3af8bb085b5e9695bb2efcc29692add83b6dd8bbeaeff46def9d51d",
+				"DiscoKey":   "discokey:d4b3f12e6eb725606998427b84074bee2d130051e5ac9cd146029d5d9220b30b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41996",
+					"10.65.0.27:41996",
+					"172.17.0.1:41996",
+					"172.18.0.1:41996",
+					"172.19.0.1:41996"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:54:00.039394051Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2366105036725447,
+				"StableID":   "npuTktZcUK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f91e7ae73ad63c3412dbb8151c79b1416d2a27c9d890a59fe24b58c3ab81e4d",
+				"DiscoKey":   "discokey:c7b428c382ca21de2bd0f787efaf23e65827c0b5a1529a4a8358f807446b5027",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:36734",
+					"10.65.0.27:36734",
+					"172.17.0.1:36734",
+					"172.18.0.1:36734",
+					"172.19.0.1:36734"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:54:00.574150708Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1866704879042162,
+				"StableID":   "nHtxvxASaF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:02c4988687d49efb699aa1f613ac8911ecdb6f6897e8768612558fe94393933f",
+				"DiscoKey":   "discokey:760282c8e21478911f8ce05ea377c56d788c1456a4a4786c48e2dd053f95db41",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45325",
+					"10.65.0.27:45325",
+					"172.17.0.1:45325",
+					"172.18.0.1:45325",
+					"172.19.0.1:45325"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:54:01.1120868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6517402740667875,
+				"StableID":   "nntwPs7kts11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4de83ba23259a2997405f59b6cac79d31c79b13374e140e839d9df19dad8df5f",
+				"DiscoKey":   "discokey:34022403bded2aabe79cfaeabbef4b450f62d81b015ff3ee7db2a4fda7d96c3b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41670",
+					"10.65.0.27:41670",
+					"172.17.0.1:41670",
+					"172.18.0.1:41670",
+					"172.19.0.1:41670"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:54:01.658004765Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5102420916393928,
+				"StableID":   "nyhoxpwtqg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0fd979a1f08dd6f1f6f47e954df44f06fdee1806dce44095f37feb3f65235325",
+				"DiscoKey":   "discokey:6b648a64505d2eceb72a34efd4969dddbd55f3f506c1134dcde1e1c7ce933a18",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58924",
+					"10.65.0.27:58924",
+					"172.17.0.1:58924",
+					"172.18.0.1:58924",
+					"172.19.0.1:58924"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:54:02.217359202Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1644746421818531,
+				"StableID":   "nipL8ahuqD11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e0224aa7a9a34bee548fc638bfe50009218ac599bc0302278d577b71fbc0864",
+				"DiscoKey":   "discokey:864449688a58b9d8bf83579e87c463ed415da04e5f4c93c1e48d0dd210f5694d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57907",
+					"10.65.0.27:57907",
+					"172.17.0.1:57907",
+					"172.18.0.1:57907",
+					"172.19.0.1:57907"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:54:02.726209007Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6272805259170820,
+				"StableID":   "n17MYXxxyq11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae49dd35238f5dbc743f14cb45b9ebfb966433a3f862086d6de210c123c74e4c",
+				"DiscoKey":   "discokey:645533b4d90d4595cdce08cec38aba3ee21c45c80bad753985c6710b32c7e268",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39184",
+					"10.65.0.27:39184",
+					"172.17.0.1:39184",
+					"172.18.0.1:39184",
+					"172.19.0.1:39184"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:54:03.268609688Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2029343697476936,
+				"StableID":   "nXCLPER6rG11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8371bef1f4960f93dabc72dd1539b23034873f9d4a362d24876f11981c82251c",
+				"KeyExpiry":  "2026-11-08T21:54:03Z",
+				"DiscoKey":   "discokey:a9f2dde092304a32eee85d4b47bd75048c49bea8ca4bf586b9b2af4026696e3b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51515",
+					"10.65.0.27:51515",
+					"172.17.0.1:51515",
+					"172.18.0.1:51515",
+					"172.19.0.1:51515"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:54:03.81070494Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8819234930411957,
+				"StableID":   "n8cTk7MFsB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5d8b9ac31c5a5da06cff42bdb9f20a70ed63881c5b6ed493854c477d7a1ffe7b",
+				"KeyExpiry":  "2026-11-08T21:54:05Z",
+				"DiscoKey":   "discokey:31d9e818710e3c4f7c3eb0b4ce21747eae9592913daef50cabd37a60aae6fb0e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:35344",
+					"10.65.0.27:35344",
+					"172.17.0.1:35344",
+					"172.18.0.1:35344",
+					"172.19.0.1:35344"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:54:05.649149464Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5102420916393928,
+				"StableID":   "nyhoxpwtqg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       5102420916393928,
+				"Key":        "nodekey:0fd979a1f08dd6f1f6f47e954df44f06fdee1806dce44095f37feb3f65235325",
+				"DiscoKey":   "discokey:6b648a64505d2eceb72a34efd4969dddbd55f3f506c1134dcde1e1c7ce933a18",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58924",
+					"10.65.0.27:58924",
+					"172.17.0.1:58924",
+					"172.18.0.1:58924",
+					"172.19.0.1:58924"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:54:02.217359202Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0fd979a1f08dd6f1f6f47e954df44f06fdee1806dce44095f37feb3f65235325",
+			"MachineKey": "mkey:db0c7e32c347ac41fa98eb4408528eeaf41e3c3c0f364e8a7e8c83575de0d532",
+			"Peers": [{
+				"ID":         1536628455110871,
+				"StableID":   "ni2CeBdwzC11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d801f81be1dc9f7582326e1687d2e1cdc5c8c16a906be0f84a9e152dfd93933",
+				"DiscoKey":   "discokey:6c6d483bb012c7d13abbad74947482985f479a178fc4c6b80e4a953ab4be5944",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40799",
+					"10.65.0.27:40799",
+					"172.17.0.1:40799",
+					"172.18.0.1:40799",
+					"172.19.0.1:40799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:53:57.359941984Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8091269229655474,
+				"StableID":   "ndrLaVvYB621CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6ee633723992353e99d790191c66572bfe9b28d7167e91f88084324d36368e56",
+				"DiscoKey":   "discokey:53cf9053055eb002a4a4f68e88fa500e35960082f72a2b768d99773794a49552",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55163",
+					"10.65.0.27:55163",
+					"172.17.0.1:55163",
+					"172.18.0.1:55163",
+					"172.19.0.1:55163"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:53:57.885709819Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1782745046409962,
+				"StableID":   "nTyb2zgQvE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:786a259ef2b7f75fb384231f6eb3e8d12ffd59631db96fc62f05b69be6072147",
+				"DiscoKey":   "discokey:3a21d33f2b4ec6b2f90d5698f5a65ceed1a5dee28e1352ec24ba79d596927736",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45940",
+					"10.65.0.27:45940",
+					"172.17.0.1:45940",
+					"172.18.0.1:45940",
+					"172.19.0.1:45940"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:53:58.42512068Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1397030307467552,
+				"StableID":   "nj6CNociuB11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:43c950347e3eaad96ab2bc6fd566485f10397d218ac1a123780d5010cadbf53a",
+				"DiscoKey":   "discokey:dd4f86a0b2f420a750dc2bf362a56c2c53e1941662c150fbea6ad128c3836629",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40628",
+					"10.65.0.27:40628",
+					"172.17.0.1:40628",
+					"172.18.0.1:40628",
+					"172.19.0.1:40628"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:53:58.964308415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7212115613438684,
+				"StableID":   "nddj2m3PKy11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0d06cf8a92e9547f56e75f191ed5ce83ea230d72dc7651fd22ed268acb87f73",
+				"DiscoKey":   "discokey:ad9f8f247f4ec22d92bbc797cb1f4c2b5f9f67b608f617dae1e4fc00ae97d50b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40065",
+					"10.65.0.27:40065",
+					"172.17.0.1:40065",
+					"172.18.0.1:40065",
+					"172.19.0.1:40065"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:53:59.505615716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7180388874568491,
+				"StableID":   "nNW2m7e15y11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6da83e3ee3af8bb085b5e9695bb2efcc29692add83b6dd8bbeaeff46def9d51d",
+				"DiscoKey":   "discokey:d4b3f12e6eb725606998427b84074bee2d130051e5ac9cd146029d5d9220b30b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41996",
+					"10.65.0.27:41996",
+					"172.17.0.1:41996",
+					"172.18.0.1:41996",
+					"172.19.0.1:41996"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:54:00.039394051Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2366105036725447,
+				"StableID":   "npuTktZcUK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f91e7ae73ad63c3412dbb8151c79b1416d2a27c9d890a59fe24b58c3ab81e4d",
+				"DiscoKey":   "discokey:c7b428c382ca21de2bd0f787efaf23e65827c0b5a1529a4a8358f807446b5027",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:36734",
+					"10.65.0.27:36734",
+					"172.17.0.1:36734",
+					"172.18.0.1:36734",
+					"172.19.0.1:36734"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:54:00.574150708Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1866704879042162,
+				"StableID":   "nHtxvxASaF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:02c4988687d49efb699aa1f613ac8911ecdb6f6897e8768612558fe94393933f",
+				"DiscoKey":   "discokey:760282c8e21478911f8ce05ea377c56d788c1456a4a4786c48e2dd053f95db41",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45325",
+					"10.65.0.27:45325",
+					"172.17.0.1:45325",
+					"172.18.0.1:45325",
+					"172.19.0.1:45325"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:54:01.1120868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6517402740667875,
+				"StableID":   "nntwPs7kts11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4de83ba23259a2997405f59b6cac79d31c79b13374e140e839d9df19dad8df5f",
+				"DiscoKey":   "discokey:34022403bded2aabe79cfaeabbef4b450f62d81b015ff3ee7db2a4fda7d96c3b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41670",
+					"10.65.0.27:41670",
+					"172.17.0.1:41670",
+					"172.18.0.1:41670",
+					"172.19.0.1:41670"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:54:01.658004765Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1644746421818531,
+				"StableID":   "nipL8ahuqD11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e0224aa7a9a34bee548fc638bfe50009218ac599bc0302278d577b71fbc0864",
+				"DiscoKey":   "discokey:864449688a58b9d8bf83579e87c463ed415da04e5f4c93c1e48d0dd210f5694d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57907",
+					"10.65.0.27:57907",
+					"172.17.0.1:57907",
+					"172.18.0.1:57907",
+					"172.19.0.1:57907"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:54:02.726209007Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6272805259170820,
+				"StableID":   "n17MYXxxyq11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae49dd35238f5dbc743f14cb45b9ebfb966433a3f862086d6de210c123c74e4c",
+				"DiscoKey":   "discokey:645533b4d90d4595cdce08cec38aba3ee21c45c80bad753985c6710b32c7e268",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39184",
+					"10.65.0.27:39184",
+					"172.17.0.1:39184",
+					"172.18.0.1:39184",
+					"172.19.0.1:39184"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:54:03.268609688Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2029343697476936,
+				"StableID":   "nXCLPER6rG11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8371bef1f4960f93dabc72dd1539b23034873f9d4a362d24876f11981c82251c",
+				"KeyExpiry":  "2026-11-08T21:54:03Z",
+				"DiscoKey":   "discokey:a9f2dde092304a32eee85d4b47bd75048c49bea8ca4bf586b9b2af4026696e3b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51515",
+					"10.65.0.27:51515",
+					"172.17.0.1:51515",
+					"172.18.0.1:51515",
+					"172.19.0.1:51515"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:54:03.81070494Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3420614081054452,
+				"StableID":   "nRX11SjCiT11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:312845ba3ecdfe2085399c443266a393e1ff1d04b141eaa24299936e8ee0dc78",
+				"KeyExpiry":  "2026-11-08T21:54:05Z",
+				"DiscoKey":   "discokey:421c8a0231d57ce03a2af24281263edb51e23f05f66010b01daeb0d8929d2209",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34384",
+					"10.65.0.27:34384",
+					"172.17.0.1:34384",
+					"172.18.0.1:34384",
+					"172.19.0.1:34384"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:54:05.124503251Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8819234930411957,
+				"StableID":   "n8cTk7MFsB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5d8b9ac31c5a5da06cff42bdb9f20a70ed63881c5b6ed493854c477d7a1ffe7b",
+				"KeyExpiry":  "2026-11-08T21:54:05Z",
+				"DiscoKey":   "discokey:31d9e818710e3c4f7c3eb0b4ce21747eae9592913daef50cabd37a60aae6fb0e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:35344",
+					"10.65.0.27:35344",
+					"172.17.0.1:35344",
+					"172.18.0.1:35344",
+					"172.19.0.1:35344"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:54:05.649149464Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5102420916393928": {
+				"ID":          5102420916393928,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-checkperiod-too-short.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-checkperiod-too-short.hujson
@@ -1,0 +1,20099 @@
+// ssh-malformed-checkperiod-too-short
+//
+// ssh checkPeriod 30s is rejected
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T21:54:41Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-malformed-checkperiod-too-short",
+	"description":    "ssh checkPeriod 30s is rejected",
+	"category":       "ssh",
+	"captured_at":    "2026-05-12T21:54:41.700447209Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                      \n  \n                                                          \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh checkPeriod 30s is rejected\",\n\t\"id\":          \"ssh-malformed-checkperiod-too-short\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\":      \"check\",\n\t\t\"checkPeriod\": \"30s\",\n\t\t\"dst\":         [\"tag:server\"],\n\t\t\"src\":         [\"autogroup:member\"],\n\t\t\"users\":       [\"root\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-malformed/ssh-malformed-checkperiod-too-short.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action":      "check",
+				"checkPeriod": "30s",
+				"dst":         ["tag:server"],
+				"src":         ["autogroup:member"],
+				"users":       ["root"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8342766022519100,
+				"StableID":   "ndX6xMKT9821CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       8342766022519100,
+				"Key":        "nodekey:af6cd36a8e16ebf314067d20f2a6b1b13dbf5d24914597474e01a8d195ce743a",
+				"DiscoKey":   "discokey:89be47efad01197aa89be9495ee492813a6ba22ed8704a8c8d01db6005f6390a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54697",
+					"10.65.0.27:54697",
+					"172.17.0.1:54697",
+					"172.18.0.1:54697",
+					"172.19.0.1:54697"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:54:50.124379505Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:af6cd36a8e16ebf314067d20f2a6b1b13dbf5d24914597474e01a8d195ce743a",
+			"MachineKey": "mkey:30e604e610d47fd56d6106abf3ab9a154c06beb396b6734074454c60791d462f",
+			"Peers": [{
+				"ID":         6708476977342399,
+				"StableID":   "nrnUPFKHPu11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25ef16da8ee3c0cb8ba8f35b1b740b4a9204517b5dba6b4f47f4890f97509e12",
+				"DiscoKey":   "discokey:967456f27800038abf355e283a666db624762f01ea430ac2bf068a18d5f7a12d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38634",
+					"10.65.0.27:38634",
+					"172.17.0.1:38634",
+					"172.18.0.1:38634",
+					"172.19.0.1:38634"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:54:44.165211721Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7921608609484589,
+				"StableID":   "n4JfY5Eir421CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4b8baa008b974739d41e3705c12e0a94b1c378ed48f5e00f7b92a6c45c7d606",
+				"DiscoKey":   "discokey:61d05f24c81540b03909839e649377974b50c468c70ca39e8eced830fb8cdf66",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39861",
+					"10.65.0.27:39861",
+					"172.17.0.1:39861",
+					"172.18.0.1:39861",
+					"172.19.0.1:39861"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:54:44.704212761Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         806411973373045,
+				"StableID":   "nNZDfM5EJ711CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bd083315b385abb6a117551bb592dde3fad824801f1d9401ad30817592526960",
+				"DiscoKey":   "discokey:b2b05808a0d7d43c6f5a24640c15d555b408471dfafe76e9be4da877832c7b6a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45556",
+					"10.65.0.27:45556",
+					"172.17.0.1:45556",
+					"172.18.0.1:45556",
+					"172.19.0.1:45556"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:54:45.244164136Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         923959993762591,
+				"StableID":   "ngqPh1sTD811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb7a3fe5cc632dbfe60b122161654e94f8fd0bf9fc6d82e31139f1845592da6b",
+				"DiscoKey":   "discokey:6e917cd2d0323786c1b38cdb1c4987b79b624332fc397a5c9afb5d88346ce30e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43945",
+					"10.65.0.27:43945",
+					"172.17.0.1:43945",
+					"172.18.0.1:43945",
+					"172.19.0.1:43945"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:54:45.791036301Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2404026779408634,
+				"StableID":   "nww1J1inmK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c76589ecc21c10277de97866851ef54a5c8f57a650b608bf7dd2831493b89135",
+				"DiscoKey":   "discokey:8920053af52ece35a6210768fee7b6342a4d03266ea134fd7874339737553909",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48797",
+					"10.65.0.27:48797",
+					"172.17.0.1:48797",
+					"172.18.0.1:48797",
+					"172.19.0.1:48797"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:54:46.327708216Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8522787932556383,
+				"StableID":   "nCTfgqBzY921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:095267b8a47216c7686cd87013d451d8bb48e6f557dfe1ba108dcae12ef92e2d",
+				"DiscoKey":   "discokey:6424cef4df53b2706ff677294f4ac0e2edaeb22d66a9e01145e1558add27202d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58398",
+					"10.65.0.27:58398",
+					"172.17.0.1:58398",
+					"172.18.0.1:58398",
+					"172.19.0.1:58398"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:54:46.880570868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4118120628729601,
+				"StableID":   "nn9v7f37AZ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6995bda0aa2797f262f1ac27a6efd680d2858421981da4ba0c665a443b325f53",
+				"DiscoKey":   "discokey:f96f1c6230e8a117843b0382ee247aff2e9361abac3735780a5237883344060e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53027",
+					"10.65.0.27:53027",
+					"172.17.0.1:53027",
+					"172.18.0.1:53027",
+					"172.19.0.1:53027"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:54:47.419231344Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7167045770133854,
+				"StableID":   "nFs4K59yxx11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:81a6d50f902fbdd66e8b59160985b18e33007ae142573fb2941f4cfccf15f339",
+				"DiscoKey":   "discokey:7ac635c12170a309df8c19414419fe7b640bcb7d1bf57023311878e0c6004b05",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50041",
+					"10.65.0.27:50041",
+					"172.17.0.1:50041",
+					"172.18.0.1:50041",
+					"172.19.0.1:50041"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:54:47.965245739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2766110188859020,
+				"StableID":   "nwzpHQ2nbN11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:793b49819227f1193028deba6d98ae240a42aa002a969e52dec3bea8ab86c41a",
+				"DiscoKey":   "discokey:86f67229e3460e0f9f6decc51a158d0adfe8c912b4762ee8099c0a2824e3fd57",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42585",
+					"10.65.0.27:42585",
+					"172.17.0.1:42585",
+					"172.18.0.1:42585",
+					"172.19.0.1:42585"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:54:48.550377379Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4554468133124430,
+				"StableID":   "nPy5ty9jZc11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cf8fe672ab4f399aac1b8245c2c9219609cb0e4cd258d7036d9f121798bdaf21",
+				"DiscoKey":   "discokey:825d316b3d033e23516939fd3bed07c70c72309576e38470be655113ce4ee946",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:37185",
+					"10.65.0.27:37185",
+					"172.17.0.1:37185",
+					"172.18.0.1:37185",
+					"172.19.0.1:37185"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:54:49.052910101Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4550344175997301,
+				"StableID":   "nxarusprXc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:549152e2e5b0adeb7a0bb8c63cc65c3b9f9817a9a509ea3d6024d831c4d1e34e",
+				"DiscoKey":   "discokey:cb3dda3df0a6e8bfd9a3a328316b0e3f2314b7b034c6c695383116e75681413d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53040",
+					"10.65.0.27:53040",
+					"172.17.0.1:53040",
+					"172.18.0.1:53040",
+					"172.19.0.1:53040"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:54:49.589710743Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6388209201687836,
+				"StableID":   "n7SzkYREtr11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:807171813aed5bb55fc6aa6857e5ac6ba7ea0d29f2671cac4163b10cb6004570",
+				"KeyExpiry":  "2026-11-08T21:54:50Z",
+				"DiscoKey":   "discokey:6f42339e183cf1aee1368c8c1ab0bdd0964a4651370d99631d9b40faa47ec707",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51709",
+					"10.65.0.27:51709",
+					"172.17.0.1:51709",
+					"172.18.0.1:51709",
+					"172.19.0.1:51709"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:54:50.665229272Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6374005258283336,
+				"StableID":   "nTEJvxJomr11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5ca6160867f6edbb9ef36e482f12692fc40b1c2ffe939ba4ce67e8514614581b",
+				"KeyExpiry":  "2026-11-08T21:54:51Z",
+				"DiscoKey":   "discokey:1d39749cea015986b56e976c3026383e13bf3895e166a00ddc2db84eb0022423",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58540",
+					"10.65.0.27:58540",
+					"172.17.0.1:58540",
+					"172.18.0.1:58540",
+					"172.19.0.1:58540"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:54:51.205420321Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2482664812023528,
+				"StableID":   "nbSExtPQPL11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:61e559c2ea54e487f2cc431edd33b381d64c49628dcc740471d5fa563ab6a960",
+				"KeyExpiry":  "2026-11-08T21:54:51Z",
+				"DiscoKey":   "discokey:145526d72dfae31389bd7433ae48c3c20d48039ce453365765d434c4222baa40",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55810",
+					"10.65.0.27:55810",
+					"172.17.0.1:55810",
+					"172.18.0.1:55810",
+					"172.19.0.1:55810"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:54:51.741564783Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{"principals": [
+				{"nodeIP": "100.64.0.17"},
+				{"nodeIP": "100.64.0.18"},
+				{"nodeIP": "100.64.0.19"},
+				{"nodeIP": "fd7a:115c:a1e0::13"},
+				{"nodeIP": "fd7a:115c:a1e0::12"},
+				{"nodeIP": "fd7a:115c:a1e0::11"}
+			], "sshUsers": {"root": "root"}, "action": {
+				"holdAndDelegate": "https://unused/machine/ssh/action/$SRC_NODE_ID/to/$DST_NODE_ID?local_user=$LOCAL_USER"
+			}}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8342766022519100": {
+				"ID":          8342766022519100,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		},
+		"ssh_rules": [{"principals": [
+			{"nodeIP": "100.64.0.17"},
+			{"nodeIP": "100.64.0.18"},
+			{"nodeIP": "100.64.0.19"},
+			{"nodeIP": "fd7a:115c:a1e0::13"},
+			{"nodeIP": "fd7a:115c:a1e0::12"},
+			{"nodeIP": "fd7a:115c:a1e0::11"}
+		], "sshUsers": {"root": "root"}, "action": {
+			"holdAndDelegate": "https://unused/machine/ssh/action/$SRC_NODE_ID/to/$DST_NODE_ID?local_user=$LOCAL_USER"
+		}}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8522787932556383,
+				"StableID":   "nCTfgqBzY921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       8522787932556383,
+				"Key":        "nodekey:095267b8a47216c7686cd87013d451d8bb48e6f557dfe1ba108dcae12ef92e2d",
+				"DiscoKey":   "discokey:6424cef4df53b2706ff677294f4ac0e2edaeb22d66a9e01145e1558add27202d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58398",
+					"10.65.0.27:58398",
+					"172.17.0.1:58398",
+					"172.18.0.1:58398",
+					"172.19.0.1:58398"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:54:46.880570868Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:095267b8a47216c7686cd87013d451d8bb48e6f557dfe1ba108dcae12ef92e2d",
+			"MachineKey": "mkey:f3e51345bea676e9206c46318700d9d818126141e935f7463cd7e14055766a7f",
+			"Peers": [{
+				"ID":         6708476977342399,
+				"StableID":   "nrnUPFKHPu11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25ef16da8ee3c0cb8ba8f35b1b740b4a9204517b5dba6b4f47f4890f97509e12",
+				"DiscoKey":   "discokey:967456f27800038abf355e283a666db624762f01ea430ac2bf068a18d5f7a12d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38634",
+					"10.65.0.27:38634",
+					"172.17.0.1:38634",
+					"172.18.0.1:38634",
+					"172.19.0.1:38634"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:54:44.165211721Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7921608609484589,
+				"StableID":   "n4JfY5Eir421CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4b8baa008b974739d41e3705c12e0a94b1c378ed48f5e00f7b92a6c45c7d606",
+				"DiscoKey":   "discokey:61d05f24c81540b03909839e649377974b50c468c70ca39e8eced830fb8cdf66",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39861",
+					"10.65.0.27:39861",
+					"172.17.0.1:39861",
+					"172.18.0.1:39861",
+					"172.19.0.1:39861"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:54:44.704212761Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         806411973373045,
+				"StableID":   "nNZDfM5EJ711CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bd083315b385abb6a117551bb592dde3fad824801f1d9401ad30817592526960",
+				"DiscoKey":   "discokey:b2b05808a0d7d43c6f5a24640c15d555b408471dfafe76e9be4da877832c7b6a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45556",
+					"10.65.0.27:45556",
+					"172.17.0.1:45556",
+					"172.18.0.1:45556",
+					"172.19.0.1:45556"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:54:45.244164136Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         923959993762591,
+				"StableID":   "ngqPh1sTD811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb7a3fe5cc632dbfe60b122161654e94f8fd0bf9fc6d82e31139f1845592da6b",
+				"DiscoKey":   "discokey:6e917cd2d0323786c1b38cdb1c4987b79b624332fc397a5c9afb5d88346ce30e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43945",
+					"10.65.0.27:43945",
+					"172.17.0.1:43945",
+					"172.18.0.1:43945",
+					"172.19.0.1:43945"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:54:45.791036301Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2404026779408634,
+				"StableID":   "nww1J1inmK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c76589ecc21c10277de97866851ef54a5c8f57a650b608bf7dd2831493b89135",
+				"DiscoKey":   "discokey:8920053af52ece35a6210768fee7b6342a4d03266ea134fd7874339737553909",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48797",
+					"10.65.0.27:48797",
+					"172.17.0.1:48797",
+					"172.18.0.1:48797",
+					"172.19.0.1:48797"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:54:46.327708216Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4118120628729601,
+				"StableID":   "nn9v7f37AZ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6995bda0aa2797f262f1ac27a6efd680d2858421981da4ba0c665a443b325f53",
+				"DiscoKey":   "discokey:f96f1c6230e8a117843b0382ee247aff2e9361abac3735780a5237883344060e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53027",
+					"10.65.0.27:53027",
+					"172.17.0.1:53027",
+					"172.18.0.1:53027",
+					"172.19.0.1:53027"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:54:47.419231344Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7167045770133854,
+				"StableID":   "nFs4K59yxx11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:81a6d50f902fbdd66e8b59160985b18e33007ae142573fb2941f4cfccf15f339",
+				"DiscoKey":   "discokey:7ac635c12170a309df8c19414419fe7b640bcb7d1bf57023311878e0c6004b05",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50041",
+					"10.65.0.27:50041",
+					"172.17.0.1:50041",
+					"172.18.0.1:50041",
+					"172.19.0.1:50041"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:54:47.965245739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2766110188859020,
+				"StableID":   "nwzpHQ2nbN11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:793b49819227f1193028deba6d98ae240a42aa002a969e52dec3bea8ab86c41a",
+				"DiscoKey":   "discokey:86f67229e3460e0f9f6decc51a158d0adfe8c912b4762ee8099c0a2824e3fd57",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42585",
+					"10.65.0.27:42585",
+					"172.17.0.1:42585",
+					"172.18.0.1:42585",
+					"172.19.0.1:42585"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:54:48.550377379Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4554468133124430,
+				"StableID":   "nPy5ty9jZc11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cf8fe672ab4f399aac1b8245c2c9219609cb0e4cd258d7036d9f121798bdaf21",
+				"DiscoKey":   "discokey:825d316b3d033e23516939fd3bed07c70c72309576e38470be655113ce4ee946",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:37185",
+					"10.65.0.27:37185",
+					"172.17.0.1:37185",
+					"172.18.0.1:37185",
+					"172.19.0.1:37185"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:54:49.052910101Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4550344175997301,
+				"StableID":   "nxarusprXc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:549152e2e5b0adeb7a0bb8c63cc65c3b9f9817a9a509ea3d6024d831c4d1e34e",
+				"DiscoKey":   "discokey:cb3dda3df0a6e8bfd9a3a328316b0e3f2314b7b034c6c695383116e75681413d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53040",
+					"10.65.0.27:53040",
+					"172.17.0.1:53040",
+					"172.18.0.1:53040",
+					"172.19.0.1:53040"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:54:49.589710743Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8342766022519100,
+				"StableID":   "ndX6xMKT9821CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af6cd36a8e16ebf314067d20f2a6b1b13dbf5d24914597474e01a8d195ce743a",
+				"DiscoKey":   "discokey:89be47efad01197aa89be9495ee492813a6ba22ed8704a8c8d01db6005f6390a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54697",
+					"10.65.0.27:54697",
+					"172.17.0.1:54697",
+					"172.18.0.1:54697",
+					"172.19.0.1:54697"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:54:50.124379505Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6388209201687836,
+				"StableID":   "n7SzkYREtr11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:807171813aed5bb55fc6aa6857e5ac6ba7ea0d29f2671cac4163b10cb6004570",
+				"KeyExpiry":  "2026-11-08T21:54:50Z",
+				"DiscoKey":   "discokey:6f42339e183cf1aee1368c8c1ab0bdd0964a4651370d99631d9b40faa47ec707",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51709",
+					"10.65.0.27:51709",
+					"172.17.0.1:51709",
+					"172.18.0.1:51709",
+					"172.19.0.1:51709"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:54:50.665229272Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6374005258283336,
+				"StableID":   "nTEJvxJomr11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5ca6160867f6edbb9ef36e482f12692fc40b1c2ffe939ba4ce67e8514614581b",
+				"KeyExpiry":  "2026-11-08T21:54:51Z",
+				"DiscoKey":   "discokey:1d39749cea015986b56e976c3026383e13bf3895e166a00ddc2db84eb0022423",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58540",
+					"10.65.0.27:58540",
+					"172.17.0.1:58540",
+					"172.18.0.1:58540",
+					"172.19.0.1:58540"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:54:51.205420321Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2482664812023528,
+				"StableID":   "nbSExtPQPL11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:61e559c2ea54e487f2cc431edd33b381d64c49628dcc740471d5fa563ab6a960",
+				"KeyExpiry":  "2026-11-08T21:54:51Z",
+				"DiscoKey":   "discokey:145526d72dfae31389bd7433ae48c3c20d48039ce453365765d434c4222baa40",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55810",
+					"10.65.0.27:55810",
+					"172.17.0.1:55810",
+					"172.18.0.1:55810",
+					"172.19.0.1:55810"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:54:51.741564783Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8522787932556383": {
+				"ID":          8522787932556383,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2482664812023528,
+				"StableID":   "nbSExtPQPL11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:61e559c2ea54e487f2cc431edd33b381d64c49628dcc740471d5fa563ab6a960",
+				"KeyExpiry":  "2026-11-08T21:54:51Z",
+				"DiscoKey":   "discokey:145526d72dfae31389bd7433ae48c3c20d48039ce453365765d434c4222baa40",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55810",
+					"10.65.0.27:55810",
+					"172.17.0.1:55810",
+					"172.18.0.1:55810",
+					"172.19.0.1:55810"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:54:51.741564783Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:61e559c2ea54e487f2cc431edd33b381d64c49628dcc740471d5fa563ab6a960",
+			"MachineKey": "mkey:88c703f88134d19779af2097e4e5a27ecf50c8500739f5376fa903f341e18a2f",
+			"Peers": [{
+				"ID":         6708476977342399,
+				"StableID":   "nrnUPFKHPu11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25ef16da8ee3c0cb8ba8f35b1b740b4a9204517b5dba6b4f47f4890f97509e12",
+				"DiscoKey":   "discokey:967456f27800038abf355e283a666db624762f01ea430ac2bf068a18d5f7a12d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38634",
+					"10.65.0.27:38634",
+					"172.17.0.1:38634",
+					"172.18.0.1:38634",
+					"172.19.0.1:38634"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:54:44.165211721Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7921608609484589,
+				"StableID":   "n4JfY5Eir421CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4b8baa008b974739d41e3705c12e0a94b1c378ed48f5e00f7b92a6c45c7d606",
+				"DiscoKey":   "discokey:61d05f24c81540b03909839e649377974b50c468c70ca39e8eced830fb8cdf66",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39861",
+					"10.65.0.27:39861",
+					"172.17.0.1:39861",
+					"172.18.0.1:39861",
+					"172.19.0.1:39861"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:54:44.704212761Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         806411973373045,
+				"StableID":   "nNZDfM5EJ711CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bd083315b385abb6a117551bb592dde3fad824801f1d9401ad30817592526960",
+				"DiscoKey":   "discokey:b2b05808a0d7d43c6f5a24640c15d555b408471dfafe76e9be4da877832c7b6a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45556",
+					"10.65.0.27:45556",
+					"172.17.0.1:45556",
+					"172.18.0.1:45556",
+					"172.19.0.1:45556"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:54:45.244164136Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         923959993762591,
+				"StableID":   "ngqPh1sTD811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb7a3fe5cc632dbfe60b122161654e94f8fd0bf9fc6d82e31139f1845592da6b",
+				"DiscoKey":   "discokey:6e917cd2d0323786c1b38cdb1c4987b79b624332fc397a5c9afb5d88346ce30e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43945",
+					"10.65.0.27:43945",
+					"172.17.0.1:43945",
+					"172.18.0.1:43945",
+					"172.19.0.1:43945"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:54:45.791036301Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2404026779408634,
+				"StableID":   "nww1J1inmK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c76589ecc21c10277de97866851ef54a5c8f57a650b608bf7dd2831493b89135",
+				"DiscoKey":   "discokey:8920053af52ece35a6210768fee7b6342a4d03266ea134fd7874339737553909",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48797",
+					"10.65.0.27:48797",
+					"172.17.0.1:48797",
+					"172.18.0.1:48797",
+					"172.19.0.1:48797"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:54:46.327708216Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8522787932556383,
+				"StableID":   "nCTfgqBzY921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:095267b8a47216c7686cd87013d451d8bb48e6f557dfe1ba108dcae12ef92e2d",
+				"DiscoKey":   "discokey:6424cef4df53b2706ff677294f4ac0e2edaeb22d66a9e01145e1558add27202d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58398",
+					"10.65.0.27:58398",
+					"172.17.0.1:58398",
+					"172.18.0.1:58398",
+					"172.19.0.1:58398"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:54:46.880570868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4118120628729601,
+				"StableID":   "nn9v7f37AZ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6995bda0aa2797f262f1ac27a6efd680d2858421981da4ba0c665a443b325f53",
+				"DiscoKey":   "discokey:f96f1c6230e8a117843b0382ee247aff2e9361abac3735780a5237883344060e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53027",
+					"10.65.0.27:53027",
+					"172.17.0.1:53027",
+					"172.18.0.1:53027",
+					"172.19.0.1:53027"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:54:47.419231344Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7167045770133854,
+				"StableID":   "nFs4K59yxx11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:81a6d50f902fbdd66e8b59160985b18e33007ae142573fb2941f4cfccf15f339",
+				"DiscoKey":   "discokey:7ac635c12170a309df8c19414419fe7b640bcb7d1bf57023311878e0c6004b05",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50041",
+					"10.65.0.27:50041",
+					"172.17.0.1:50041",
+					"172.18.0.1:50041",
+					"172.19.0.1:50041"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:54:47.965245739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2766110188859020,
+				"StableID":   "nwzpHQ2nbN11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:793b49819227f1193028deba6d98ae240a42aa002a969e52dec3bea8ab86c41a",
+				"DiscoKey":   "discokey:86f67229e3460e0f9f6decc51a158d0adfe8c912b4762ee8099c0a2824e3fd57",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42585",
+					"10.65.0.27:42585",
+					"172.17.0.1:42585",
+					"172.18.0.1:42585",
+					"172.19.0.1:42585"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:54:48.550377379Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4554468133124430,
+				"StableID":   "nPy5ty9jZc11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cf8fe672ab4f399aac1b8245c2c9219609cb0e4cd258d7036d9f121798bdaf21",
+				"DiscoKey":   "discokey:825d316b3d033e23516939fd3bed07c70c72309576e38470be655113ce4ee946",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:37185",
+					"10.65.0.27:37185",
+					"172.17.0.1:37185",
+					"172.18.0.1:37185",
+					"172.19.0.1:37185"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:54:49.052910101Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4550344175997301,
+				"StableID":   "nxarusprXc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:549152e2e5b0adeb7a0bb8c63cc65c3b9f9817a9a509ea3d6024d831c4d1e34e",
+				"DiscoKey":   "discokey:cb3dda3df0a6e8bfd9a3a328316b0e3f2314b7b034c6c695383116e75681413d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53040",
+					"10.65.0.27:53040",
+					"172.17.0.1:53040",
+					"172.18.0.1:53040",
+					"172.19.0.1:53040"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:54:49.589710743Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8342766022519100,
+				"StableID":   "ndX6xMKT9821CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af6cd36a8e16ebf314067d20f2a6b1b13dbf5d24914597474e01a8d195ce743a",
+				"DiscoKey":   "discokey:89be47efad01197aa89be9495ee492813a6ba22ed8704a8c8d01db6005f6390a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54697",
+					"10.65.0.27:54697",
+					"172.17.0.1:54697",
+					"172.18.0.1:54697",
+					"172.19.0.1:54697"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:54:50.124379505Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6388209201687836,
+				"StableID":   "n7SzkYREtr11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:807171813aed5bb55fc6aa6857e5ac6ba7ea0d29f2671cac4163b10cb6004570",
+				"KeyExpiry":  "2026-11-08T21:54:50Z",
+				"DiscoKey":   "discokey:6f42339e183cf1aee1368c8c1ab0bdd0964a4651370d99631d9b40faa47ec707",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51709",
+					"10.65.0.27:51709",
+					"172.17.0.1:51709",
+					"172.18.0.1:51709",
+					"172.19.0.1:51709"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:54:50.665229272Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6374005258283336,
+				"StableID":   "nTEJvxJomr11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5ca6160867f6edbb9ef36e482f12692fc40b1c2ffe939ba4ce67e8514614581b",
+				"KeyExpiry":  "2026-11-08T21:54:51Z",
+				"DiscoKey":   "discokey:1d39749cea015986b56e976c3026383e13bf3895e166a00ddc2db84eb0022423",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58540",
+					"10.65.0.27:58540",
+					"172.17.0.1:58540",
+					"172.18.0.1:58540",
+					"172.19.0.1:58540"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:54:51.205420321Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         806411973373045,
+				"StableID":   "nNZDfM5EJ711CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       806411973373045,
+				"Key":        "nodekey:bd083315b385abb6a117551bb592dde3fad824801f1d9401ad30817592526960",
+				"DiscoKey":   "discokey:b2b05808a0d7d43c6f5a24640c15d555b408471dfafe76e9be4da877832c7b6a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45556",
+					"10.65.0.27:45556",
+					"172.17.0.1:45556",
+					"172.18.0.1:45556",
+					"172.19.0.1:45556"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:54:45.244164136Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:bd083315b385abb6a117551bb592dde3fad824801f1d9401ad30817592526960",
+			"MachineKey": "mkey:f6a82600011f2eb9acc9ec0b0dc5f1a7bc6419ce7f8487b2d3d777b654507a0c",
+			"Peers": [{
+				"ID":         6708476977342399,
+				"StableID":   "nrnUPFKHPu11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25ef16da8ee3c0cb8ba8f35b1b740b4a9204517b5dba6b4f47f4890f97509e12",
+				"DiscoKey":   "discokey:967456f27800038abf355e283a666db624762f01ea430ac2bf068a18d5f7a12d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38634",
+					"10.65.0.27:38634",
+					"172.17.0.1:38634",
+					"172.18.0.1:38634",
+					"172.19.0.1:38634"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:54:44.165211721Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7921608609484589,
+				"StableID":   "n4JfY5Eir421CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4b8baa008b974739d41e3705c12e0a94b1c378ed48f5e00f7b92a6c45c7d606",
+				"DiscoKey":   "discokey:61d05f24c81540b03909839e649377974b50c468c70ca39e8eced830fb8cdf66",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39861",
+					"10.65.0.27:39861",
+					"172.17.0.1:39861",
+					"172.18.0.1:39861",
+					"172.19.0.1:39861"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:54:44.704212761Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         923959993762591,
+				"StableID":   "ngqPh1sTD811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb7a3fe5cc632dbfe60b122161654e94f8fd0bf9fc6d82e31139f1845592da6b",
+				"DiscoKey":   "discokey:6e917cd2d0323786c1b38cdb1c4987b79b624332fc397a5c9afb5d88346ce30e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43945",
+					"10.65.0.27:43945",
+					"172.17.0.1:43945",
+					"172.18.0.1:43945",
+					"172.19.0.1:43945"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:54:45.791036301Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2404026779408634,
+				"StableID":   "nww1J1inmK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c76589ecc21c10277de97866851ef54a5c8f57a650b608bf7dd2831493b89135",
+				"DiscoKey":   "discokey:8920053af52ece35a6210768fee7b6342a4d03266ea134fd7874339737553909",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48797",
+					"10.65.0.27:48797",
+					"172.17.0.1:48797",
+					"172.18.0.1:48797",
+					"172.19.0.1:48797"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:54:46.327708216Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8522787932556383,
+				"StableID":   "nCTfgqBzY921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:095267b8a47216c7686cd87013d451d8bb48e6f557dfe1ba108dcae12ef92e2d",
+				"DiscoKey":   "discokey:6424cef4df53b2706ff677294f4ac0e2edaeb22d66a9e01145e1558add27202d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58398",
+					"10.65.0.27:58398",
+					"172.17.0.1:58398",
+					"172.18.0.1:58398",
+					"172.19.0.1:58398"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:54:46.880570868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4118120628729601,
+				"StableID":   "nn9v7f37AZ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6995bda0aa2797f262f1ac27a6efd680d2858421981da4ba0c665a443b325f53",
+				"DiscoKey":   "discokey:f96f1c6230e8a117843b0382ee247aff2e9361abac3735780a5237883344060e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53027",
+					"10.65.0.27:53027",
+					"172.17.0.1:53027",
+					"172.18.0.1:53027",
+					"172.19.0.1:53027"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:54:47.419231344Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7167045770133854,
+				"StableID":   "nFs4K59yxx11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:81a6d50f902fbdd66e8b59160985b18e33007ae142573fb2941f4cfccf15f339",
+				"DiscoKey":   "discokey:7ac635c12170a309df8c19414419fe7b640bcb7d1bf57023311878e0c6004b05",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50041",
+					"10.65.0.27:50041",
+					"172.17.0.1:50041",
+					"172.18.0.1:50041",
+					"172.19.0.1:50041"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:54:47.965245739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2766110188859020,
+				"StableID":   "nwzpHQ2nbN11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:793b49819227f1193028deba6d98ae240a42aa002a969e52dec3bea8ab86c41a",
+				"DiscoKey":   "discokey:86f67229e3460e0f9f6decc51a158d0adfe8c912b4762ee8099c0a2824e3fd57",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42585",
+					"10.65.0.27:42585",
+					"172.17.0.1:42585",
+					"172.18.0.1:42585",
+					"172.19.0.1:42585"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:54:48.550377379Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4554468133124430,
+				"StableID":   "nPy5ty9jZc11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cf8fe672ab4f399aac1b8245c2c9219609cb0e4cd258d7036d9f121798bdaf21",
+				"DiscoKey":   "discokey:825d316b3d033e23516939fd3bed07c70c72309576e38470be655113ce4ee946",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:37185",
+					"10.65.0.27:37185",
+					"172.17.0.1:37185",
+					"172.18.0.1:37185",
+					"172.19.0.1:37185"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:54:49.052910101Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4550344175997301,
+				"StableID":   "nxarusprXc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:549152e2e5b0adeb7a0bb8c63cc65c3b9f9817a9a509ea3d6024d831c4d1e34e",
+				"DiscoKey":   "discokey:cb3dda3df0a6e8bfd9a3a328316b0e3f2314b7b034c6c695383116e75681413d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53040",
+					"10.65.0.27:53040",
+					"172.17.0.1:53040",
+					"172.18.0.1:53040",
+					"172.19.0.1:53040"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:54:49.589710743Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8342766022519100,
+				"StableID":   "ndX6xMKT9821CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af6cd36a8e16ebf314067d20f2a6b1b13dbf5d24914597474e01a8d195ce743a",
+				"DiscoKey":   "discokey:89be47efad01197aa89be9495ee492813a6ba22ed8704a8c8d01db6005f6390a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54697",
+					"10.65.0.27:54697",
+					"172.17.0.1:54697",
+					"172.18.0.1:54697",
+					"172.19.0.1:54697"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:54:50.124379505Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6388209201687836,
+				"StableID":   "n7SzkYREtr11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:807171813aed5bb55fc6aa6857e5ac6ba7ea0d29f2671cac4163b10cb6004570",
+				"KeyExpiry":  "2026-11-08T21:54:50Z",
+				"DiscoKey":   "discokey:6f42339e183cf1aee1368c8c1ab0bdd0964a4651370d99631d9b40faa47ec707",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51709",
+					"10.65.0.27:51709",
+					"172.17.0.1:51709",
+					"172.18.0.1:51709",
+					"172.19.0.1:51709"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:54:50.665229272Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6374005258283336,
+				"StableID":   "nTEJvxJomr11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5ca6160867f6edbb9ef36e482f12692fc40b1c2ffe939ba4ce67e8514614581b",
+				"KeyExpiry":  "2026-11-08T21:54:51Z",
+				"DiscoKey":   "discokey:1d39749cea015986b56e976c3026383e13bf3895e166a00ddc2db84eb0022423",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58540",
+					"10.65.0.27:58540",
+					"172.17.0.1:58540",
+					"172.18.0.1:58540",
+					"172.19.0.1:58540"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:54:51.205420321Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2482664812023528,
+				"StableID":   "nbSExtPQPL11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:61e559c2ea54e487f2cc431edd33b381d64c49628dcc740471d5fa563ab6a960",
+				"KeyExpiry":  "2026-11-08T21:54:51Z",
+				"DiscoKey":   "discokey:145526d72dfae31389bd7433ae48c3c20d48039ce453365765d434c4222baa40",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55810",
+					"10.65.0.27:55810",
+					"172.17.0.1:55810",
+					"172.18.0.1:55810",
+					"172.19.0.1:55810"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:54:51.741564783Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "806411973373045": {
+				"ID":          806411973373045,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7167045770133854,
+				"StableID":   "nFs4K59yxx11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       7167045770133854,
+				"Key":        "nodekey:81a6d50f902fbdd66e8b59160985b18e33007ae142573fb2941f4cfccf15f339",
+				"DiscoKey":   "discokey:7ac635c12170a309df8c19414419fe7b640bcb7d1bf57023311878e0c6004b05",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50041",
+					"10.65.0.27:50041",
+					"172.17.0.1:50041",
+					"172.18.0.1:50041",
+					"172.19.0.1:50041"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:54:47.965245739Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:81a6d50f902fbdd66e8b59160985b18e33007ae142573fb2941f4cfccf15f339",
+			"MachineKey": "mkey:ebe51bf02b986897bcc5c7750af6ae7cc0d8029e22a6a49aebafa3bca88d0d0c",
+			"Peers": [{
+				"ID":         6708476977342399,
+				"StableID":   "nrnUPFKHPu11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25ef16da8ee3c0cb8ba8f35b1b740b4a9204517b5dba6b4f47f4890f97509e12",
+				"DiscoKey":   "discokey:967456f27800038abf355e283a666db624762f01ea430ac2bf068a18d5f7a12d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38634",
+					"10.65.0.27:38634",
+					"172.17.0.1:38634",
+					"172.18.0.1:38634",
+					"172.19.0.1:38634"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:54:44.165211721Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7921608609484589,
+				"StableID":   "n4JfY5Eir421CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4b8baa008b974739d41e3705c12e0a94b1c378ed48f5e00f7b92a6c45c7d606",
+				"DiscoKey":   "discokey:61d05f24c81540b03909839e649377974b50c468c70ca39e8eced830fb8cdf66",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39861",
+					"10.65.0.27:39861",
+					"172.17.0.1:39861",
+					"172.18.0.1:39861",
+					"172.19.0.1:39861"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:54:44.704212761Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         806411973373045,
+				"StableID":   "nNZDfM5EJ711CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bd083315b385abb6a117551bb592dde3fad824801f1d9401ad30817592526960",
+				"DiscoKey":   "discokey:b2b05808a0d7d43c6f5a24640c15d555b408471dfafe76e9be4da877832c7b6a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45556",
+					"10.65.0.27:45556",
+					"172.17.0.1:45556",
+					"172.18.0.1:45556",
+					"172.19.0.1:45556"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:54:45.244164136Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         923959993762591,
+				"StableID":   "ngqPh1sTD811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb7a3fe5cc632dbfe60b122161654e94f8fd0bf9fc6d82e31139f1845592da6b",
+				"DiscoKey":   "discokey:6e917cd2d0323786c1b38cdb1c4987b79b624332fc397a5c9afb5d88346ce30e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43945",
+					"10.65.0.27:43945",
+					"172.17.0.1:43945",
+					"172.18.0.1:43945",
+					"172.19.0.1:43945"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:54:45.791036301Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2404026779408634,
+				"StableID":   "nww1J1inmK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c76589ecc21c10277de97866851ef54a5c8f57a650b608bf7dd2831493b89135",
+				"DiscoKey":   "discokey:8920053af52ece35a6210768fee7b6342a4d03266ea134fd7874339737553909",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48797",
+					"10.65.0.27:48797",
+					"172.17.0.1:48797",
+					"172.18.0.1:48797",
+					"172.19.0.1:48797"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:54:46.327708216Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8522787932556383,
+				"StableID":   "nCTfgqBzY921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:095267b8a47216c7686cd87013d451d8bb48e6f557dfe1ba108dcae12ef92e2d",
+				"DiscoKey":   "discokey:6424cef4df53b2706ff677294f4ac0e2edaeb22d66a9e01145e1558add27202d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58398",
+					"10.65.0.27:58398",
+					"172.17.0.1:58398",
+					"172.18.0.1:58398",
+					"172.19.0.1:58398"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:54:46.880570868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4118120628729601,
+				"StableID":   "nn9v7f37AZ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6995bda0aa2797f262f1ac27a6efd680d2858421981da4ba0c665a443b325f53",
+				"DiscoKey":   "discokey:f96f1c6230e8a117843b0382ee247aff2e9361abac3735780a5237883344060e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53027",
+					"10.65.0.27:53027",
+					"172.17.0.1:53027",
+					"172.18.0.1:53027",
+					"172.19.0.1:53027"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:54:47.419231344Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2766110188859020,
+				"StableID":   "nwzpHQ2nbN11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:793b49819227f1193028deba6d98ae240a42aa002a969e52dec3bea8ab86c41a",
+				"DiscoKey":   "discokey:86f67229e3460e0f9f6decc51a158d0adfe8c912b4762ee8099c0a2824e3fd57",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42585",
+					"10.65.0.27:42585",
+					"172.17.0.1:42585",
+					"172.18.0.1:42585",
+					"172.19.0.1:42585"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:54:48.550377379Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4554468133124430,
+				"StableID":   "nPy5ty9jZc11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cf8fe672ab4f399aac1b8245c2c9219609cb0e4cd258d7036d9f121798bdaf21",
+				"DiscoKey":   "discokey:825d316b3d033e23516939fd3bed07c70c72309576e38470be655113ce4ee946",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:37185",
+					"10.65.0.27:37185",
+					"172.17.0.1:37185",
+					"172.18.0.1:37185",
+					"172.19.0.1:37185"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:54:49.052910101Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4550344175997301,
+				"StableID":   "nxarusprXc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:549152e2e5b0adeb7a0bb8c63cc65c3b9f9817a9a509ea3d6024d831c4d1e34e",
+				"DiscoKey":   "discokey:cb3dda3df0a6e8bfd9a3a328316b0e3f2314b7b034c6c695383116e75681413d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53040",
+					"10.65.0.27:53040",
+					"172.17.0.1:53040",
+					"172.18.0.1:53040",
+					"172.19.0.1:53040"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:54:49.589710743Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8342766022519100,
+				"StableID":   "ndX6xMKT9821CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af6cd36a8e16ebf314067d20f2a6b1b13dbf5d24914597474e01a8d195ce743a",
+				"DiscoKey":   "discokey:89be47efad01197aa89be9495ee492813a6ba22ed8704a8c8d01db6005f6390a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54697",
+					"10.65.0.27:54697",
+					"172.17.0.1:54697",
+					"172.18.0.1:54697",
+					"172.19.0.1:54697"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:54:50.124379505Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6388209201687836,
+				"StableID":   "n7SzkYREtr11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:807171813aed5bb55fc6aa6857e5ac6ba7ea0d29f2671cac4163b10cb6004570",
+				"KeyExpiry":  "2026-11-08T21:54:50Z",
+				"DiscoKey":   "discokey:6f42339e183cf1aee1368c8c1ab0bdd0964a4651370d99631d9b40faa47ec707",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51709",
+					"10.65.0.27:51709",
+					"172.17.0.1:51709",
+					"172.18.0.1:51709",
+					"172.19.0.1:51709"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:54:50.665229272Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6374005258283336,
+				"StableID":   "nTEJvxJomr11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5ca6160867f6edbb9ef36e482f12692fc40b1c2ffe939ba4ce67e8514614581b",
+				"KeyExpiry":  "2026-11-08T21:54:51Z",
+				"DiscoKey":   "discokey:1d39749cea015986b56e976c3026383e13bf3895e166a00ddc2db84eb0022423",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58540",
+					"10.65.0.27:58540",
+					"172.17.0.1:58540",
+					"172.18.0.1:58540",
+					"172.19.0.1:58540"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:54:51.205420321Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2482664812023528,
+				"StableID":   "nbSExtPQPL11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:61e559c2ea54e487f2cc431edd33b381d64c49628dcc740471d5fa563ab6a960",
+				"KeyExpiry":  "2026-11-08T21:54:51Z",
+				"DiscoKey":   "discokey:145526d72dfae31389bd7433ae48c3c20d48039ce453365765d434c4222baa40",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55810",
+					"10.65.0.27:55810",
+					"172.17.0.1:55810",
+					"172.18.0.1:55810",
+					"172.19.0.1:55810"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:54:51.741564783Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7167045770133854": {
+				"ID":          7167045770133854,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6388209201687836,
+				"StableID":   "n7SzkYREtr11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:807171813aed5bb55fc6aa6857e5ac6ba7ea0d29f2671cac4163b10cb6004570",
+				"KeyExpiry":  "2026-11-08T21:54:50Z",
+				"DiscoKey":   "discokey:6f42339e183cf1aee1368c8c1ab0bdd0964a4651370d99631d9b40faa47ec707",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51709",
+					"10.65.0.27:51709",
+					"172.17.0.1:51709",
+					"172.18.0.1:51709",
+					"172.19.0.1:51709"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:54:50.665229272Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:807171813aed5bb55fc6aa6857e5ac6ba7ea0d29f2671cac4163b10cb6004570",
+			"MachineKey": "mkey:e216ee22867933fe70dad1631e52536ca277ae7624d70c27407847aa1b80a328",
+			"Peers": [{
+				"ID":         6708476977342399,
+				"StableID":   "nrnUPFKHPu11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25ef16da8ee3c0cb8ba8f35b1b740b4a9204517b5dba6b4f47f4890f97509e12",
+				"DiscoKey":   "discokey:967456f27800038abf355e283a666db624762f01ea430ac2bf068a18d5f7a12d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38634",
+					"10.65.0.27:38634",
+					"172.17.0.1:38634",
+					"172.18.0.1:38634",
+					"172.19.0.1:38634"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:54:44.165211721Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7921608609484589,
+				"StableID":   "n4JfY5Eir421CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4b8baa008b974739d41e3705c12e0a94b1c378ed48f5e00f7b92a6c45c7d606",
+				"DiscoKey":   "discokey:61d05f24c81540b03909839e649377974b50c468c70ca39e8eced830fb8cdf66",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39861",
+					"10.65.0.27:39861",
+					"172.17.0.1:39861",
+					"172.18.0.1:39861",
+					"172.19.0.1:39861"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:54:44.704212761Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         806411973373045,
+				"StableID":   "nNZDfM5EJ711CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bd083315b385abb6a117551bb592dde3fad824801f1d9401ad30817592526960",
+				"DiscoKey":   "discokey:b2b05808a0d7d43c6f5a24640c15d555b408471dfafe76e9be4da877832c7b6a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45556",
+					"10.65.0.27:45556",
+					"172.17.0.1:45556",
+					"172.18.0.1:45556",
+					"172.19.0.1:45556"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:54:45.244164136Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         923959993762591,
+				"StableID":   "ngqPh1sTD811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb7a3fe5cc632dbfe60b122161654e94f8fd0bf9fc6d82e31139f1845592da6b",
+				"DiscoKey":   "discokey:6e917cd2d0323786c1b38cdb1c4987b79b624332fc397a5c9afb5d88346ce30e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43945",
+					"10.65.0.27:43945",
+					"172.17.0.1:43945",
+					"172.18.0.1:43945",
+					"172.19.0.1:43945"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:54:45.791036301Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2404026779408634,
+				"StableID":   "nww1J1inmK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c76589ecc21c10277de97866851ef54a5c8f57a650b608bf7dd2831493b89135",
+				"DiscoKey":   "discokey:8920053af52ece35a6210768fee7b6342a4d03266ea134fd7874339737553909",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48797",
+					"10.65.0.27:48797",
+					"172.17.0.1:48797",
+					"172.18.0.1:48797",
+					"172.19.0.1:48797"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:54:46.327708216Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8522787932556383,
+				"StableID":   "nCTfgqBzY921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:095267b8a47216c7686cd87013d451d8bb48e6f557dfe1ba108dcae12ef92e2d",
+				"DiscoKey":   "discokey:6424cef4df53b2706ff677294f4ac0e2edaeb22d66a9e01145e1558add27202d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58398",
+					"10.65.0.27:58398",
+					"172.17.0.1:58398",
+					"172.18.0.1:58398",
+					"172.19.0.1:58398"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:54:46.880570868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4118120628729601,
+				"StableID":   "nn9v7f37AZ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6995bda0aa2797f262f1ac27a6efd680d2858421981da4ba0c665a443b325f53",
+				"DiscoKey":   "discokey:f96f1c6230e8a117843b0382ee247aff2e9361abac3735780a5237883344060e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53027",
+					"10.65.0.27:53027",
+					"172.17.0.1:53027",
+					"172.18.0.1:53027",
+					"172.19.0.1:53027"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:54:47.419231344Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7167045770133854,
+				"StableID":   "nFs4K59yxx11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:81a6d50f902fbdd66e8b59160985b18e33007ae142573fb2941f4cfccf15f339",
+				"DiscoKey":   "discokey:7ac635c12170a309df8c19414419fe7b640bcb7d1bf57023311878e0c6004b05",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50041",
+					"10.65.0.27:50041",
+					"172.17.0.1:50041",
+					"172.18.0.1:50041",
+					"172.19.0.1:50041"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:54:47.965245739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2766110188859020,
+				"StableID":   "nwzpHQ2nbN11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:793b49819227f1193028deba6d98ae240a42aa002a969e52dec3bea8ab86c41a",
+				"DiscoKey":   "discokey:86f67229e3460e0f9f6decc51a158d0adfe8c912b4762ee8099c0a2824e3fd57",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42585",
+					"10.65.0.27:42585",
+					"172.17.0.1:42585",
+					"172.18.0.1:42585",
+					"172.19.0.1:42585"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:54:48.550377379Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4554468133124430,
+				"StableID":   "nPy5ty9jZc11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cf8fe672ab4f399aac1b8245c2c9219609cb0e4cd258d7036d9f121798bdaf21",
+				"DiscoKey":   "discokey:825d316b3d033e23516939fd3bed07c70c72309576e38470be655113ce4ee946",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:37185",
+					"10.65.0.27:37185",
+					"172.17.0.1:37185",
+					"172.18.0.1:37185",
+					"172.19.0.1:37185"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:54:49.052910101Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4550344175997301,
+				"StableID":   "nxarusprXc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:549152e2e5b0adeb7a0bb8c63cc65c3b9f9817a9a509ea3d6024d831c4d1e34e",
+				"DiscoKey":   "discokey:cb3dda3df0a6e8bfd9a3a328316b0e3f2314b7b034c6c695383116e75681413d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53040",
+					"10.65.0.27:53040",
+					"172.17.0.1:53040",
+					"172.18.0.1:53040",
+					"172.19.0.1:53040"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:54:49.589710743Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8342766022519100,
+				"StableID":   "ndX6xMKT9821CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af6cd36a8e16ebf314067d20f2a6b1b13dbf5d24914597474e01a8d195ce743a",
+				"DiscoKey":   "discokey:89be47efad01197aa89be9495ee492813a6ba22ed8704a8c8d01db6005f6390a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54697",
+					"10.65.0.27:54697",
+					"172.17.0.1:54697",
+					"172.18.0.1:54697",
+					"172.19.0.1:54697"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:54:50.124379505Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6374005258283336,
+				"StableID":   "nTEJvxJomr11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5ca6160867f6edbb9ef36e482f12692fc40b1c2ffe939ba4ce67e8514614581b",
+				"KeyExpiry":  "2026-11-08T21:54:51Z",
+				"DiscoKey":   "discokey:1d39749cea015986b56e976c3026383e13bf3895e166a00ddc2db84eb0022423",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58540",
+					"10.65.0.27:58540",
+					"172.17.0.1:58540",
+					"172.18.0.1:58540",
+					"172.19.0.1:58540"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:54:51.205420321Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2482664812023528,
+				"StableID":   "nbSExtPQPL11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:61e559c2ea54e487f2cc431edd33b381d64c49628dcc740471d5fa563ab6a960",
+				"KeyExpiry":  "2026-11-08T21:54:51Z",
+				"DiscoKey":   "discokey:145526d72dfae31389bd7433ae48c3c20d48039ce453365765d434c4222baa40",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55810",
+					"10.65.0.27:55810",
+					"172.17.0.1:55810",
+					"172.18.0.1:55810",
+					"172.19.0.1:55810"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:54:51.741564783Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4550344175997301,
+				"StableID":   "nxarusprXc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       4550344175997301,
+				"Key":        "nodekey:549152e2e5b0adeb7a0bb8c63cc65c3b9f9817a9a509ea3d6024d831c4d1e34e",
+				"DiscoKey":   "discokey:cb3dda3df0a6e8bfd9a3a328316b0e3f2314b7b034c6c695383116e75681413d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53040",
+					"10.65.0.27:53040",
+					"172.17.0.1:53040",
+					"172.18.0.1:53040",
+					"172.19.0.1:53040"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:54:49.589710743Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:549152e2e5b0adeb7a0bb8c63cc65c3b9f9817a9a509ea3d6024d831c4d1e34e",
+			"MachineKey": "mkey:edcaa405d61796b44adcba748fb7380d1e7559d6ecdd80b0e83771e227573535",
+			"Peers": [{
+				"ID":         6708476977342399,
+				"StableID":   "nrnUPFKHPu11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25ef16da8ee3c0cb8ba8f35b1b740b4a9204517b5dba6b4f47f4890f97509e12",
+				"DiscoKey":   "discokey:967456f27800038abf355e283a666db624762f01ea430ac2bf068a18d5f7a12d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38634",
+					"10.65.0.27:38634",
+					"172.17.0.1:38634",
+					"172.18.0.1:38634",
+					"172.19.0.1:38634"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:54:44.165211721Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7921608609484589,
+				"StableID":   "n4JfY5Eir421CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4b8baa008b974739d41e3705c12e0a94b1c378ed48f5e00f7b92a6c45c7d606",
+				"DiscoKey":   "discokey:61d05f24c81540b03909839e649377974b50c468c70ca39e8eced830fb8cdf66",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39861",
+					"10.65.0.27:39861",
+					"172.17.0.1:39861",
+					"172.18.0.1:39861",
+					"172.19.0.1:39861"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:54:44.704212761Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         806411973373045,
+				"StableID":   "nNZDfM5EJ711CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bd083315b385abb6a117551bb592dde3fad824801f1d9401ad30817592526960",
+				"DiscoKey":   "discokey:b2b05808a0d7d43c6f5a24640c15d555b408471dfafe76e9be4da877832c7b6a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45556",
+					"10.65.0.27:45556",
+					"172.17.0.1:45556",
+					"172.18.0.1:45556",
+					"172.19.0.1:45556"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:54:45.244164136Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         923959993762591,
+				"StableID":   "ngqPh1sTD811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb7a3fe5cc632dbfe60b122161654e94f8fd0bf9fc6d82e31139f1845592da6b",
+				"DiscoKey":   "discokey:6e917cd2d0323786c1b38cdb1c4987b79b624332fc397a5c9afb5d88346ce30e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43945",
+					"10.65.0.27:43945",
+					"172.17.0.1:43945",
+					"172.18.0.1:43945",
+					"172.19.0.1:43945"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:54:45.791036301Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2404026779408634,
+				"StableID":   "nww1J1inmK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c76589ecc21c10277de97866851ef54a5c8f57a650b608bf7dd2831493b89135",
+				"DiscoKey":   "discokey:8920053af52ece35a6210768fee7b6342a4d03266ea134fd7874339737553909",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48797",
+					"10.65.0.27:48797",
+					"172.17.0.1:48797",
+					"172.18.0.1:48797",
+					"172.19.0.1:48797"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:54:46.327708216Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8522787932556383,
+				"StableID":   "nCTfgqBzY921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:095267b8a47216c7686cd87013d451d8bb48e6f557dfe1ba108dcae12ef92e2d",
+				"DiscoKey":   "discokey:6424cef4df53b2706ff677294f4ac0e2edaeb22d66a9e01145e1558add27202d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58398",
+					"10.65.0.27:58398",
+					"172.17.0.1:58398",
+					"172.18.0.1:58398",
+					"172.19.0.1:58398"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:54:46.880570868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4118120628729601,
+				"StableID":   "nn9v7f37AZ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6995bda0aa2797f262f1ac27a6efd680d2858421981da4ba0c665a443b325f53",
+				"DiscoKey":   "discokey:f96f1c6230e8a117843b0382ee247aff2e9361abac3735780a5237883344060e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53027",
+					"10.65.0.27:53027",
+					"172.17.0.1:53027",
+					"172.18.0.1:53027",
+					"172.19.0.1:53027"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:54:47.419231344Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7167045770133854,
+				"StableID":   "nFs4K59yxx11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:81a6d50f902fbdd66e8b59160985b18e33007ae142573fb2941f4cfccf15f339",
+				"DiscoKey":   "discokey:7ac635c12170a309df8c19414419fe7b640bcb7d1bf57023311878e0c6004b05",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50041",
+					"10.65.0.27:50041",
+					"172.17.0.1:50041",
+					"172.18.0.1:50041",
+					"172.19.0.1:50041"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:54:47.965245739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2766110188859020,
+				"StableID":   "nwzpHQ2nbN11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:793b49819227f1193028deba6d98ae240a42aa002a969e52dec3bea8ab86c41a",
+				"DiscoKey":   "discokey:86f67229e3460e0f9f6decc51a158d0adfe8c912b4762ee8099c0a2824e3fd57",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42585",
+					"10.65.0.27:42585",
+					"172.17.0.1:42585",
+					"172.18.0.1:42585",
+					"172.19.0.1:42585"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:54:48.550377379Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4554468133124430,
+				"StableID":   "nPy5ty9jZc11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cf8fe672ab4f399aac1b8245c2c9219609cb0e4cd258d7036d9f121798bdaf21",
+				"DiscoKey":   "discokey:825d316b3d033e23516939fd3bed07c70c72309576e38470be655113ce4ee946",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:37185",
+					"10.65.0.27:37185",
+					"172.17.0.1:37185",
+					"172.18.0.1:37185",
+					"172.19.0.1:37185"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:54:49.052910101Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8342766022519100,
+				"StableID":   "ndX6xMKT9821CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af6cd36a8e16ebf314067d20f2a6b1b13dbf5d24914597474e01a8d195ce743a",
+				"DiscoKey":   "discokey:89be47efad01197aa89be9495ee492813a6ba22ed8704a8c8d01db6005f6390a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54697",
+					"10.65.0.27:54697",
+					"172.17.0.1:54697",
+					"172.18.0.1:54697",
+					"172.19.0.1:54697"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:54:50.124379505Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6388209201687836,
+				"StableID":   "n7SzkYREtr11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:807171813aed5bb55fc6aa6857e5ac6ba7ea0d29f2671cac4163b10cb6004570",
+				"KeyExpiry":  "2026-11-08T21:54:50Z",
+				"DiscoKey":   "discokey:6f42339e183cf1aee1368c8c1ab0bdd0964a4651370d99631d9b40faa47ec707",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51709",
+					"10.65.0.27:51709",
+					"172.17.0.1:51709",
+					"172.18.0.1:51709",
+					"172.19.0.1:51709"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:54:50.665229272Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6374005258283336,
+				"StableID":   "nTEJvxJomr11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5ca6160867f6edbb9ef36e482f12692fc40b1c2ffe939ba4ce67e8514614581b",
+				"KeyExpiry":  "2026-11-08T21:54:51Z",
+				"DiscoKey":   "discokey:1d39749cea015986b56e976c3026383e13bf3895e166a00ddc2db84eb0022423",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58540",
+					"10.65.0.27:58540",
+					"172.17.0.1:58540",
+					"172.18.0.1:58540",
+					"172.19.0.1:58540"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:54:51.205420321Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2482664812023528,
+				"StableID":   "nbSExtPQPL11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:61e559c2ea54e487f2cc431edd33b381d64c49628dcc740471d5fa563ab6a960",
+				"KeyExpiry":  "2026-11-08T21:54:51Z",
+				"DiscoKey":   "discokey:145526d72dfae31389bd7433ae48c3c20d48039ce453365765d434c4222baa40",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55810",
+					"10.65.0.27:55810",
+					"172.17.0.1:55810",
+					"172.18.0.1:55810",
+					"172.19.0.1:55810"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:54:51.741564783Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4550344175997301": {
+				"ID":          4550344175997301,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7921608609484589,
+				"StableID":   "n4JfY5Eir421CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       7921608609484589,
+				"Key":        "nodekey:c4b8baa008b974739d41e3705c12e0a94b1c378ed48f5e00f7b92a6c45c7d606",
+				"DiscoKey":   "discokey:61d05f24c81540b03909839e649377974b50c468c70ca39e8eced830fb8cdf66",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39861",
+					"10.65.0.27:39861",
+					"172.17.0.1:39861",
+					"172.18.0.1:39861",
+					"172.19.0.1:39861"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:54:44.704212761Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c4b8baa008b974739d41e3705c12e0a94b1c378ed48f5e00f7b92a6c45c7d606",
+			"MachineKey": "mkey:602c0b02d1b81b952b48af6523224ba3446da7b2262c15ca5ba2167e0eca7077",
+			"Peers": [{
+				"ID":         6708476977342399,
+				"StableID":   "nrnUPFKHPu11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25ef16da8ee3c0cb8ba8f35b1b740b4a9204517b5dba6b4f47f4890f97509e12",
+				"DiscoKey":   "discokey:967456f27800038abf355e283a666db624762f01ea430ac2bf068a18d5f7a12d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38634",
+					"10.65.0.27:38634",
+					"172.17.0.1:38634",
+					"172.18.0.1:38634",
+					"172.19.0.1:38634"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:54:44.165211721Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         806411973373045,
+				"StableID":   "nNZDfM5EJ711CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bd083315b385abb6a117551bb592dde3fad824801f1d9401ad30817592526960",
+				"DiscoKey":   "discokey:b2b05808a0d7d43c6f5a24640c15d555b408471dfafe76e9be4da877832c7b6a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45556",
+					"10.65.0.27:45556",
+					"172.17.0.1:45556",
+					"172.18.0.1:45556",
+					"172.19.0.1:45556"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:54:45.244164136Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         923959993762591,
+				"StableID":   "ngqPh1sTD811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb7a3fe5cc632dbfe60b122161654e94f8fd0bf9fc6d82e31139f1845592da6b",
+				"DiscoKey":   "discokey:6e917cd2d0323786c1b38cdb1c4987b79b624332fc397a5c9afb5d88346ce30e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43945",
+					"10.65.0.27:43945",
+					"172.17.0.1:43945",
+					"172.18.0.1:43945",
+					"172.19.0.1:43945"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:54:45.791036301Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2404026779408634,
+				"StableID":   "nww1J1inmK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c76589ecc21c10277de97866851ef54a5c8f57a650b608bf7dd2831493b89135",
+				"DiscoKey":   "discokey:8920053af52ece35a6210768fee7b6342a4d03266ea134fd7874339737553909",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48797",
+					"10.65.0.27:48797",
+					"172.17.0.1:48797",
+					"172.18.0.1:48797",
+					"172.19.0.1:48797"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:54:46.327708216Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8522787932556383,
+				"StableID":   "nCTfgqBzY921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:095267b8a47216c7686cd87013d451d8bb48e6f557dfe1ba108dcae12ef92e2d",
+				"DiscoKey":   "discokey:6424cef4df53b2706ff677294f4ac0e2edaeb22d66a9e01145e1558add27202d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58398",
+					"10.65.0.27:58398",
+					"172.17.0.1:58398",
+					"172.18.0.1:58398",
+					"172.19.0.1:58398"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:54:46.880570868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4118120628729601,
+				"StableID":   "nn9v7f37AZ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6995bda0aa2797f262f1ac27a6efd680d2858421981da4ba0c665a443b325f53",
+				"DiscoKey":   "discokey:f96f1c6230e8a117843b0382ee247aff2e9361abac3735780a5237883344060e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53027",
+					"10.65.0.27:53027",
+					"172.17.0.1:53027",
+					"172.18.0.1:53027",
+					"172.19.0.1:53027"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:54:47.419231344Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7167045770133854,
+				"StableID":   "nFs4K59yxx11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:81a6d50f902fbdd66e8b59160985b18e33007ae142573fb2941f4cfccf15f339",
+				"DiscoKey":   "discokey:7ac635c12170a309df8c19414419fe7b640bcb7d1bf57023311878e0c6004b05",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50041",
+					"10.65.0.27:50041",
+					"172.17.0.1:50041",
+					"172.18.0.1:50041",
+					"172.19.0.1:50041"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:54:47.965245739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2766110188859020,
+				"StableID":   "nwzpHQ2nbN11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:793b49819227f1193028deba6d98ae240a42aa002a969e52dec3bea8ab86c41a",
+				"DiscoKey":   "discokey:86f67229e3460e0f9f6decc51a158d0adfe8c912b4762ee8099c0a2824e3fd57",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42585",
+					"10.65.0.27:42585",
+					"172.17.0.1:42585",
+					"172.18.0.1:42585",
+					"172.19.0.1:42585"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:54:48.550377379Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4554468133124430,
+				"StableID":   "nPy5ty9jZc11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cf8fe672ab4f399aac1b8245c2c9219609cb0e4cd258d7036d9f121798bdaf21",
+				"DiscoKey":   "discokey:825d316b3d033e23516939fd3bed07c70c72309576e38470be655113ce4ee946",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:37185",
+					"10.65.0.27:37185",
+					"172.17.0.1:37185",
+					"172.18.0.1:37185",
+					"172.19.0.1:37185"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:54:49.052910101Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4550344175997301,
+				"StableID":   "nxarusprXc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:549152e2e5b0adeb7a0bb8c63cc65c3b9f9817a9a509ea3d6024d831c4d1e34e",
+				"DiscoKey":   "discokey:cb3dda3df0a6e8bfd9a3a328316b0e3f2314b7b034c6c695383116e75681413d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53040",
+					"10.65.0.27:53040",
+					"172.17.0.1:53040",
+					"172.18.0.1:53040",
+					"172.19.0.1:53040"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:54:49.589710743Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8342766022519100,
+				"StableID":   "ndX6xMKT9821CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af6cd36a8e16ebf314067d20f2a6b1b13dbf5d24914597474e01a8d195ce743a",
+				"DiscoKey":   "discokey:89be47efad01197aa89be9495ee492813a6ba22ed8704a8c8d01db6005f6390a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54697",
+					"10.65.0.27:54697",
+					"172.17.0.1:54697",
+					"172.18.0.1:54697",
+					"172.19.0.1:54697"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:54:50.124379505Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6388209201687836,
+				"StableID":   "n7SzkYREtr11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:807171813aed5bb55fc6aa6857e5ac6ba7ea0d29f2671cac4163b10cb6004570",
+				"KeyExpiry":  "2026-11-08T21:54:50Z",
+				"DiscoKey":   "discokey:6f42339e183cf1aee1368c8c1ab0bdd0964a4651370d99631d9b40faa47ec707",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51709",
+					"10.65.0.27:51709",
+					"172.17.0.1:51709",
+					"172.18.0.1:51709",
+					"172.19.0.1:51709"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:54:50.665229272Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6374005258283336,
+				"StableID":   "nTEJvxJomr11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5ca6160867f6edbb9ef36e482f12692fc40b1c2ffe939ba4ce67e8514614581b",
+				"KeyExpiry":  "2026-11-08T21:54:51Z",
+				"DiscoKey":   "discokey:1d39749cea015986b56e976c3026383e13bf3895e166a00ddc2db84eb0022423",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58540",
+					"10.65.0.27:58540",
+					"172.17.0.1:58540",
+					"172.18.0.1:58540",
+					"172.19.0.1:58540"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:54:51.205420321Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2482664812023528,
+				"StableID":   "nbSExtPQPL11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:61e559c2ea54e487f2cc431edd33b381d64c49628dcc740471d5fa563ab6a960",
+				"KeyExpiry":  "2026-11-08T21:54:51Z",
+				"DiscoKey":   "discokey:145526d72dfae31389bd7433ae48c3c20d48039ce453365765d434c4222baa40",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55810",
+					"10.65.0.27:55810",
+					"172.17.0.1:55810",
+					"172.18.0.1:55810",
+					"172.19.0.1:55810"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:54:51.741564783Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7921608609484589": {
+				"ID":          7921608609484589,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6708476977342399,
+				"StableID":   "nrnUPFKHPu11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       6708476977342399,
+				"Key":        "nodekey:25ef16da8ee3c0cb8ba8f35b1b740b4a9204517b5dba6b4f47f4890f97509e12",
+				"DiscoKey":   "discokey:967456f27800038abf355e283a666db624762f01ea430ac2bf068a18d5f7a12d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38634",
+					"10.65.0.27:38634",
+					"172.17.0.1:38634",
+					"172.18.0.1:38634",
+					"172.19.0.1:38634"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:54:44.165211721Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:25ef16da8ee3c0cb8ba8f35b1b740b4a9204517b5dba6b4f47f4890f97509e12",
+			"MachineKey": "mkey:0b8770f0c3b5a8520400b7c34f08d4018a243b5f01d0169bd5434969cd21fb1e",
+			"Peers": [{
+				"ID":         7921608609484589,
+				"StableID":   "n4JfY5Eir421CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4b8baa008b974739d41e3705c12e0a94b1c378ed48f5e00f7b92a6c45c7d606",
+				"DiscoKey":   "discokey:61d05f24c81540b03909839e649377974b50c468c70ca39e8eced830fb8cdf66",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39861",
+					"10.65.0.27:39861",
+					"172.17.0.1:39861",
+					"172.18.0.1:39861",
+					"172.19.0.1:39861"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:54:44.704212761Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         806411973373045,
+				"StableID":   "nNZDfM5EJ711CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bd083315b385abb6a117551bb592dde3fad824801f1d9401ad30817592526960",
+				"DiscoKey":   "discokey:b2b05808a0d7d43c6f5a24640c15d555b408471dfafe76e9be4da877832c7b6a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45556",
+					"10.65.0.27:45556",
+					"172.17.0.1:45556",
+					"172.18.0.1:45556",
+					"172.19.0.1:45556"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:54:45.244164136Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         923959993762591,
+				"StableID":   "ngqPh1sTD811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb7a3fe5cc632dbfe60b122161654e94f8fd0bf9fc6d82e31139f1845592da6b",
+				"DiscoKey":   "discokey:6e917cd2d0323786c1b38cdb1c4987b79b624332fc397a5c9afb5d88346ce30e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43945",
+					"10.65.0.27:43945",
+					"172.17.0.1:43945",
+					"172.18.0.1:43945",
+					"172.19.0.1:43945"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:54:45.791036301Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2404026779408634,
+				"StableID":   "nww1J1inmK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c76589ecc21c10277de97866851ef54a5c8f57a650b608bf7dd2831493b89135",
+				"DiscoKey":   "discokey:8920053af52ece35a6210768fee7b6342a4d03266ea134fd7874339737553909",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48797",
+					"10.65.0.27:48797",
+					"172.17.0.1:48797",
+					"172.18.0.1:48797",
+					"172.19.0.1:48797"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:54:46.327708216Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8522787932556383,
+				"StableID":   "nCTfgqBzY921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:095267b8a47216c7686cd87013d451d8bb48e6f557dfe1ba108dcae12ef92e2d",
+				"DiscoKey":   "discokey:6424cef4df53b2706ff677294f4ac0e2edaeb22d66a9e01145e1558add27202d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58398",
+					"10.65.0.27:58398",
+					"172.17.0.1:58398",
+					"172.18.0.1:58398",
+					"172.19.0.1:58398"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:54:46.880570868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4118120628729601,
+				"StableID":   "nn9v7f37AZ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6995bda0aa2797f262f1ac27a6efd680d2858421981da4ba0c665a443b325f53",
+				"DiscoKey":   "discokey:f96f1c6230e8a117843b0382ee247aff2e9361abac3735780a5237883344060e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53027",
+					"10.65.0.27:53027",
+					"172.17.0.1:53027",
+					"172.18.0.1:53027",
+					"172.19.0.1:53027"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:54:47.419231344Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7167045770133854,
+				"StableID":   "nFs4K59yxx11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:81a6d50f902fbdd66e8b59160985b18e33007ae142573fb2941f4cfccf15f339",
+				"DiscoKey":   "discokey:7ac635c12170a309df8c19414419fe7b640bcb7d1bf57023311878e0c6004b05",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50041",
+					"10.65.0.27:50041",
+					"172.17.0.1:50041",
+					"172.18.0.1:50041",
+					"172.19.0.1:50041"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:54:47.965245739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2766110188859020,
+				"StableID":   "nwzpHQ2nbN11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:793b49819227f1193028deba6d98ae240a42aa002a969e52dec3bea8ab86c41a",
+				"DiscoKey":   "discokey:86f67229e3460e0f9f6decc51a158d0adfe8c912b4762ee8099c0a2824e3fd57",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42585",
+					"10.65.0.27:42585",
+					"172.17.0.1:42585",
+					"172.18.0.1:42585",
+					"172.19.0.1:42585"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:54:48.550377379Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4554468133124430,
+				"StableID":   "nPy5ty9jZc11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cf8fe672ab4f399aac1b8245c2c9219609cb0e4cd258d7036d9f121798bdaf21",
+				"DiscoKey":   "discokey:825d316b3d033e23516939fd3bed07c70c72309576e38470be655113ce4ee946",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:37185",
+					"10.65.0.27:37185",
+					"172.17.0.1:37185",
+					"172.18.0.1:37185",
+					"172.19.0.1:37185"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:54:49.052910101Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4550344175997301,
+				"StableID":   "nxarusprXc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:549152e2e5b0adeb7a0bb8c63cc65c3b9f9817a9a509ea3d6024d831c4d1e34e",
+				"DiscoKey":   "discokey:cb3dda3df0a6e8bfd9a3a328316b0e3f2314b7b034c6c695383116e75681413d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53040",
+					"10.65.0.27:53040",
+					"172.17.0.1:53040",
+					"172.18.0.1:53040",
+					"172.19.0.1:53040"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:54:49.589710743Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8342766022519100,
+				"StableID":   "ndX6xMKT9821CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af6cd36a8e16ebf314067d20f2a6b1b13dbf5d24914597474e01a8d195ce743a",
+				"DiscoKey":   "discokey:89be47efad01197aa89be9495ee492813a6ba22ed8704a8c8d01db6005f6390a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54697",
+					"10.65.0.27:54697",
+					"172.17.0.1:54697",
+					"172.18.0.1:54697",
+					"172.19.0.1:54697"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:54:50.124379505Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6388209201687836,
+				"StableID":   "n7SzkYREtr11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:807171813aed5bb55fc6aa6857e5ac6ba7ea0d29f2671cac4163b10cb6004570",
+				"KeyExpiry":  "2026-11-08T21:54:50Z",
+				"DiscoKey":   "discokey:6f42339e183cf1aee1368c8c1ab0bdd0964a4651370d99631d9b40faa47ec707",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51709",
+					"10.65.0.27:51709",
+					"172.17.0.1:51709",
+					"172.18.0.1:51709",
+					"172.19.0.1:51709"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:54:50.665229272Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6374005258283336,
+				"StableID":   "nTEJvxJomr11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5ca6160867f6edbb9ef36e482f12692fc40b1c2ffe939ba4ce67e8514614581b",
+				"KeyExpiry":  "2026-11-08T21:54:51Z",
+				"DiscoKey":   "discokey:1d39749cea015986b56e976c3026383e13bf3895e166a00ddc2db84eb0022423",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58540",
+					"10.65.0.27:58540",
+					"172.17.0.1:58540",
+					"172.18.0.1:58540",
+					"172.19.0.1:58540"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:54:51.205420321Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2482664812023528,
+				"StableID":   "nbSExtPQPL11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:61e559c2ea54e487f2cc431edd33b381d64c49628dcc740471d5fa563ab6a960",
+				"KeyExpiry":  "2026-11-08T21:54:51Z",
+				"DiscoKey":   "discokey:145526d72dfae31389bd7433ae48c3c20d48039ce453365765d434c4222baa40",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55810",
+					"10.65.0.27:55810",
+					"172.17.0.1:55810",
+					"172.18.0.1:55810",
+					"172.19.0.1:55810"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:54:51.741564783Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6708476977342399": {
+				"ID":          6708476977342399,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2404026779408634,
+				"StableID":   "nww1J1inmK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       2404026779408634,
+				"Key":        "nodekey:c76589ecc21c10277de97866851ef54a5c8f57a650b608bf7dd2831493b89135",
+				"DiscoKey":   "discokey:8920053af52ece35a6210768fee7b6342a4d03266ea134fd7874339737553909",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48797",
+					"10.65.0.27:48797",
+					"172.17.0.1:48797",
+					"172.18.0.1:48797",
+					"172.19.0.1:48797"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:54:46.327708216Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c76589ecc21c10277de97866851ef54a5c8f57a650b608bf7dd2831493b89135",
+			"MachineKey": "mkey:a61118bb9690f1d83a089c2ef2287bbc42b9a11f313636c832d8ca95761f4c18",
+			"Peers": [{
+				"ID":         6708476977342399,
+				"StableID":   "nrnUPFKHPu11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25ef16da8ee3c0cb8ba8f35b1b740b4a9204517b5dba6b4f47f4890f97509e12",
+				"DiscoKey":   "discokey:967456f27800038abf355e283a666db624762f01ea430ac2bf068a18d5f7a12d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38634",
+					"10.65.0.27:38634",
+					"172.17.0.1:38634",
+					"172.18.0.1:38634",
+					"172.19.0.1:38634"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:54:44.165211721Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7921608609484589,
+				"StableID":   "n4JfY5Eir421CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4b8baa008b974739d41e3705c12e0a94b1c378ed48f5e00f7b92a6c45c7d606",
+				"DiscoKey":   "discokey:61d05f24c81540b03909839e649377974b50c468c70ca39e8eced830fb8cdf66",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39861",
+					"10.65.0.27:39861",
+					"172.17.0.1:39861",
+					"172.18.0.1:39861",
+					"172.19.0.1:39861"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:54:44.704212761Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         806411973373045,
+				"StableID":   "nNZDfM5EJ711CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bd083315b385abb6a117551bb592dde3fad824801f1d9401ad30817592526960",
+				"DiscoKey":   "discokey:b2b05808a0d7d43c6f5a24640c15d555b408471dfafe76e9be4da877832c7b6a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45556",
+					"10.65.0.27:45556",
+					"172.17.0.1:45556",
+					"172.18.0.1:45556",
+					"172.19.0.1:45556"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:54:45.244164136Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         923959993762591,
+				"StableID":   "ngqPh1sTD811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb7a3fe5cc632dbfe60b122161654e94f8fd0bf9fc6d82e31139f1845592da6b",
+				"DiscoKey":   "discokey:6e917cd2d0323786c1b38cdb1c4987b79b624332fc397a5c9afb5d88346ce30e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43945",
+					"10.65.0.27:43945",
+					"172.17.0.1:43945",
+					"172.18.0.1:43945",
+					"172.19.0.1:43945"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:54:45.791036301Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8522787932556383,
+				"StableID":   "nCTfgqBzY921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:095267b8a47216c7686cd87013d451d8bb48e6f557dfe1ba108dcae12ef92e2d",
+				"DiscoKey":   "discokey:6424cef4df53b2706ff677294f4ac0e2edaeb22d66a9e01145e1558add27202d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58398",
+					"10.65.0.27:58398",
+					"172.17.0.1:58398",
+					"172.18.0.1:58398",
+					"172.19.0.1:58398"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:54:46.880570868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4118120628729601,
+				"StableID":   "nn9v7f37AZ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6995bda0aa2797f262f1ac27a6efd680d2858421981da4ba0c665a443b325f53",
+				"DiscoKey":   "discokey:f96f1c6230e8a117843b0382ee247aff2e9361abac3735780a5237883344060e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53027",
+					"10.65.0.27:53027",
+					"172.17.0.1:53027",
+					"172.18.0.1:53027",
+					"172.19.0.1:53027"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:54:47.419231344Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7167045770133854,
+				"StableID":   "nFs4K59yxx11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:81a6d50f902fbdd66e8b59160985b18e33007ae142573fb2941f4cfccf15f339",
+				"DiscoKey":   "discokey:7ac635c12170a309df8c19414419fe7b640bcb7d1bf57023311878e0c6004b05",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50041",
+					"10.65.0.27:50041",
+					"172.17.0.1:50041",
+					"172.18.0.1:50041",
+					"172.19.0.1:50041"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:54:47.965245739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2766110188859020,
+				"StableID":   "nwzpHQ2nbN11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:793b49819227f1193028deba6d98ae240a42aa002a969e52dec3bea8ab86c41a",
+				"DiscoKey":   "discokey:86f67229e3460e0f9f6decc51a158d0adfe8c912b4762ee8099c0a2824e3fd57",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42585",
+					"10.65.0.27:42585",
+					"172.17.0.1:42585",
+					"172.18.0.1:42585",
+					"172.19.0.1:42585"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:54:48.550377379Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4554468133124430,
+				"StableID":   "nPy5ty9jZc11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cf8fe672ab4f399aac1b8245c2c9219609cb0e4cd258d7036d9f121798bdaf21",
+				"DiscoKey":   "discokey:825d316b3d033e23516939fd3bed07c70c72309576e38470be655113ce4ee946",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:37185",
+					"10.65.0.27:37185",
+					"172.17.0.1:37185",
+					"172.18.0.1:37185",
+					"172.19.0.1:37185"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:54:49.052910101Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4550344175997301,
+				"StableID":   "nxarusprXc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:549152e2e5b0adeb7a0bb8c63cc65c3b9f9817a9a509ea3d6024d831c4d1e34e",
+				"DiscoKey":   "discokey:cb3dda3df0a6e8bfd9a3a328316b0e3f2314b7b034c6c695383116e75681413d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53040",
+					"10.65.0.27:53040",
+					"172.17.0.1:53040",
+					"172.18.0.1:53040",
+					"172.19.0.1:53040"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:54:49.589710743Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8342766022519100,
+				"StableID":   "ndX6xMKT9821CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af6cd36a8e16ebf314067d20f2a6b1b13dbf5d24914597474e01a8d195ce743a",
+				"DiscoKey":   "discokey:89be47efad01197aa89be9495ee492813a6ba22ed8704a8c8d01db6005f6390a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54697",
+					"10.65.0.27:54697",
+					"172.17.0.1:54697",
+					"172.18.0.1:54697",
+					"172.19.0.1:54697"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:54:50.124379505Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6388209201687836,
+				"StableID":   "n7SzkYREtr11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:807171813aed5bb55fc6aa6857e5ac6ba7ea0d29f2671cac4163b10cb6004570",
+				"KeyExpiry":  "2026-11-08T21:54:50Z",
+				"DiscoKey":   "discokey:6f42339e183cf1aee1368c8c1ab0bdd0964a4651370d99631d9b40faa47ec707",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51709",
+					"10.65.0.27:51709",
+					"172.17.0.1:51709",
+					"172.18.0.1:51709",
+					"172.19.0.1:51709"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:54:50.665229272Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6374005258283336,
+				"StableID":   "nTEJvxJomr11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5ca6160867f6edbb9ef36e482f12692fc40b1c2ffe939ba4ce67e8514614581b",
+				"KeyExpiry":  "2026-11-08T21:54:51Z",
+				"DiscoKey":   "discokey:1d39749cea015986b56e976c3026383e13bf3895e166a00ddc2db84eb0022423",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58540",
+					"10.65.0.27:58540",
+					"172.17.0.1:58540",
+					"172.18.0.1:58540",
+					"172.19.0.1:58540"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:54:51.205420321Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2482664812023528,
+				"StableID":   "nbSExtPQPL11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:61e559c2ea54e487f2cc431edd33b381d64c49628dcc740471d5fa563ab6a960",
+				"KeyExpiry":  "2026-11-08T21:54:51Z",
+				"DiscoKey":   "discokey:145526d72dfae31389bd7433ae48c3c20d48039ce453365765d434c4222baa40",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55810",
+					"10.65.0.27:55810",
+					"172.17.0.1:55810",
+					"172.18.0.1:55810",
+					"172.19.0.1:55810"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:54:51.741564783Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2404026779408634": {
+				"ID":          2404026779408634,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         923959993762591,
+				"StableID":   "ngqPh1sTD811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       923959993762591,
+				"Key":        "nodekey:fb7a3fe5cc632dbfe60b122161654e94f8fd0bf9fc6d82e31139f1845592da6b",
+				"DiscoKey":   "discokey:6e917cd2d0323786c1b38cdb1c4987b79b624332fc397a5c9afb5d88346ce30e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43945",
+					"10.65.0.27:43945",
+					"172.17.0.1:43945",
+					"172.18.0.1:43945",
+					"172.19.0.1:43945"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:54:45.791036301Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:fb7a3fe5cc632dbfe60b122161654e94f8fd0bf9fc6d82e31139f1845592da6b",
+			"MachineKey": "mkey:479786569d190528624730358f51c6fe1b09bb881d3d063c8fff48b19a3bb110",
+			"Peers": [{
+				"ID":         6708476977342399,
+				"StableID":   "nrnUPFKHPu11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25ef16da8ee3c0cb8ba8f35b1b740b4a9204517b5dba6b4f47f4890f97509e12",
+				"DiscoKey":   "discokey:967456f27800038abf355e283a666db624762f01ea430ac2bf068a18d5f7a12d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38634",
+					"10.65.0.27:38634",
+					"172.17.0.1:38634",
+					"172.18.0.1:38634",
+					"172.19.0.1:38634"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:54:44.165211721Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7921608609484589,
+				"StableID":   "n4JfY5Eir421CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4b8baa008b974739d41e3705c12e0a94b1c378ed48f5e00f7b92a6c45c7d606",
+				"DiscoKey":   "discokey:61d05f24c81540b03909839e649377974b50c468c70ca39e8eced830fb8cdf66",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39861",
+					"10.65.0.27:39861",
+					"172.17.0.1:39861",
+					"172.18.0.1:39861",
+					"172.19.0.1:39861"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:54:44.704212761Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         806411973373045,
+				"StableID":   "nNZDfM5EJ711CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bd083315b385abb6a117551bb592dde3fad824801f1d9401ad30817592526960",
+				"DiscoKey":   "discokey:b2b05808a0d7d43c6f5a24640c15d555b408471dfafe76e9be4da877832c7b6a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45556",
+					"10.65.0.27:45556",
+					"172.17.0.1:45556",
+					"172.18.0.1:45556",
+					"172.19.0.1:45556"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:54:45.244164136Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2404026779408634,
+				"StableID":   "nww1J1inmK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c76589ecc21c10277de97866851ef54a5c8f57a650b608bf7dd2831493b89135",
+				"DiscoKey":   "discokey:8920053af52ece35a6210768fee7b6342a4d03266ea134fd7874339737553909",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48797",
+					"10.65.0.27:48797",
+					"172.17.0.1:48797",
+					"172.18.0.1:48797",
+					"172.19.0.1:48797"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:54:46.327708216Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8522787932556383,
+				"StableID":   "nCTfgqBzY921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:095267b8a47216c7686cd87013d451d8bb48e6f557dfe1ba108dcae12ef92e2d",
+				"DiscoKey":   "discokey:6424cef4df53b2706ff677294f4ac0e2edaeb22d66a9e01145e1558add27202d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58398",
+					"10.65.0.27:58398",
+					"172.17.0.1:58398",
+					"172.18.0.1:58398",
+					"172.19.0.1:58398"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:54:46.880570868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4118120628729601,
+				"StableID":   "nn9v7f37AZ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6995bda0aa2797f262f1ac27a6efd680d2858421981da4ba0c665a443b325f53",
+				"DiscoKey":   "discokey:f96f1c6230e8a117843b0382ee247aff2e9361abac3735780a5237883344060e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53027",
+					"10.65.0.27:53027",
+					"172.17.0.1:53027",
+					"172.18.0.1:53027",
+					"172.19.0.1:53027"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:54:47.419231344Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7167045770133854,
+				"StableID":   "nFs4K59yxx11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:81a6d50f902fbdd66e8b59160985b18e33007ae142573fb2941f4cfccf15f339",
+				"DiscoKey":   "discokey:7ac635c12170a309df8c19414419fe7b640bcb7d1bf57023311878e0c6004b05",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50041",
+					"10.65.0.27:50041",
+					"172.17.0.1:50041",
+					"172.18.0.1:50041",
+					"172.19.0.1:50041"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:54:47.965245739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2766110188859020,
+				"StableID":   "nwzpHQ2nbN11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:793b49819227f1193028deba6d98ae240a42aa002a969e52dec3bea8ab86c41a",
+				"DiscoKey":   "discokey:86f67229e3460e0f9f6decc51a158d0adfe8c912b4762ee8099c0a2824e3fd57",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42585",
+					"10.65.0.27:42585",
+					"172.17.0.1:42585",
+					"172.18.0.1:42585",
+					"172.19.0.1:42585"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:54:48.550377379Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4554468133124430,
+				"StableID":   "nPy5ty9jZc11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cf8fe672ab4f399aac1b8245c2c9219609cb0e4cd258d7036d9f121798bdaf21",
+				"DiscoKey":   "discokey:825d316b3d033e23516939fd3bed07c70c72309576e38470be655113ce4ee946",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:37185",
+					"10.65.0.27:37185",
+					"172.17.0.1:37185",
+					"172.18.0.1:37185",
+					"172.19.0.1:37185"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:54:49.052910101Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4550344175997301,
+				"StableID":   "nxarusprXc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:549152e2e5b0adeb7a0bb8c63cc65c3b9f9817a9a509ea3d6024d831c4d1e34e",
+				"DiscoKey":   "discokey:cb3dda3df0a6e8bfd9a3a328316b0e3f2314b7b034c6c695383116e75681413d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53040",
+					"10.65.0.27:53040",
+					"172.17.0.1:53040",
+					"172.18.0.1:53040",
+					"172.19.0.1:53040"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:54:49.589710743Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8342766022519100,
+				"StableID":   "ndX6xMKT9821CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af6cd36a8e16ebf314067d20f2a6b1b13dbf5d24914597474e01a8d195ce743a",
+				"DiscoKey":   "discokey:89be47efad01197aa89be9495ee492813a6ba22ed8704a8c8d01db6005f6390a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54697",
+					"10.65.0.27:54697",
+					"172.17.0.1:54697",
+					"172.18.0.1:54697",
+					"172.19.0.1:54697"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:54:50.124379505Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6388209201687836,
+				"StableID":   "n7SzkYREtr11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:807171813aed5bb55fc6aa6857e5ac6ba7ea0d29f2671cac4163b10cb6004570",
+				"KeyExpiry":  "2026-11-08T21:54:50Z",
+				"DiscoKey":   "discokey:6f42339e183cf1aee1368c8c1ab0bdd0964a4651370d99631d9b40faa47ec707",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51709",
+					"10.65.0.27:51709",
+					"172.17.0.1:51709",
+					"172.18.0.1:51709",
+					"172.19.0.1:51709"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:54:50.665229272Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6374005258283336,
+				"StableID":   "nTEJvxJomr11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5ca6160867f6edbb9ef36e482f12692fc40b1c2ffe939ba4ce67e8514614581b",
+				"KeyExpiry":  "2026-11-08T21:54:51Z",
+				"DiscoKey":   "discokey:1d39749cea015986b56e976c3026383e13bf3895e166a00ddc2db84eb0022423",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58540",
+					"10.65.0.27:58540",
+					"172.17.0.1:58540",
+					"172.18.0.1:58540",
+					"172.19.0.1:58540"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:54:51.205420321Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2482664812023528,
+				"StableID":   "nbSExtPQPL11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:61e559c2ea54e487f2cc431edd33b381d64c49628dcc740471d5fa563ab6a960",
+				"KeyExpiry":  "2026-11-08T21:54:51Z",
+				"DiscoKey":   "discokey:145526d72dfae31389bd7433ae48c3c20d48039ce453365765d434c4222baa40",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55810",
+					"10.65.0.27:55810",
+					"172.17.0.1:55810",
+					"172.18.0.1:55810",
+					"172.19.0.1:55810"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:54:51.741564783Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "923959993762591": {
+				"ID":          923959993762591,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4118120628729601,
+				"StableID":   "nn9v7f37AZ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       4118120628729601,
+				"Key":        "nodekey:6995bda0aa2797f262f1ac27a6efd680d2858421981da4ba0c665a443b325f53",
+				"DiscoKey":   "discokey:f96f1c6230e8a117843b0382ee247aff2e9361abac3735780a5237883344060e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53027",
+					"10.65.0.27:53027",
+					"172.17.0.1:53027",
+					"172.18.0.1:53027",
+					"172.19.0.1:53027"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:54:47.419231344Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6995bda0aa2797f262f1ac27a6efd680d2858421981da4ba0c665a443b325f53",
+			"MachineKey": "mkey:c606dd215f25c202770c905fd753f558d2c4c093e0f1f9a90289bd507275e340",
+			"Peers": [{
+				"ID":         6708476977342399,
+				"StableID":   "nrnUPFKHPu11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25ef16da8ee3c0cb8ba8f35b1b740b4a9204517b5dba6b4f47f4890f97509e12",
+				"DiscoKey":   "discokey:967456f27800038abf355e283a666db624762f01ea430ac2bf068a18d5f7a12d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38634",
+					"10.65.0.27:38634",
+					"172.17.0.1:38634",
+					"172.18.0.1:38634",
+					"172.19.0.1:38634"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:54:44.165211721Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7921608609484589,
+				"StableID":   "n4JfY5Eir421CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4b8baa008b974739d41e3705c12e0a94b1c378ed48f5e00f7b92a6c45c7d606",
+				"DiscoKey":   "discokey:61d05f24c81540b03909839e649377974b50c468c70ca39e8eced830fb8cdf66",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39861",
+					"10.65.0.27:39861",
+					"172.17.0.1:39861",
+					"172.18.0.1:39861",
+					"172.19.0.1:39861"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:54:44.704212761Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         806411973373045,
+				"StableID":   "nNZDfM5EJ711CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bd083315b385abb6a117551bb592dde3fad824801f1d9401ad30817592526960",
+				"DiscoKey":   "discokey:b2b05808a0d7d43c6f5a24640c15d555b408471dfafe76e9be4da877832c7b6a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45556",
+					"10.65.0.27:45556",
+					"172.17.0.1:45556",
+					"172.18.0.1:45556",
+					"172.19.0.1:45556"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:54:45.244164136Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         923959993762591,
+				"StableID":   "ngqPh1sTD811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb7a3fe5cc632dbfe60b122161654e94f8fd0bf9fc6d82e31139f1845592da6b",
+				"DiscoKey":   "discokey:6e917cd2d0323786c1b38cdb1c4987b79b624332fc397a5c9afb5d88346ce30e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43945",
+					"10.65.0.27:43945",
+					"172.17.0.1:43945",
+					"172.18.0.1:43945",
+					"172.19.0.1:43945"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:54:45.791036301Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2404026779408634,
+				"StableID":   "nww1J1inmK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c76589ecc21c10277de97866851ef54a5c8f57a650b608bf7dd2831493b89135",
+				"DiscoKey":   "discokey:8920053af52ece35a6210768fee7b6342a4d03266ea134fd7874339737553909",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48797",
+					"10.65.0.27:48797",
+					"172.17.0.1:48797",
+					"172.18.0.1:48797",
+					"172.19.0.1:48797"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:54:46.327708216Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8522787932556383,
+				"StableID":   "nCTfgqBzY921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:095267b8a47216c7686cd87013d451d8bb48e6f557dfe1ba108dcae12ef92e2d",
+				"DiscoKey":   "discokey:6424cef4df53b2706ff677294f4ac0e2edaeb22d66a9e01145e1558add27202d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58398",
+					"10.65.0.27:58398",
+					"172.17.0.1:58398",
+					"172.18.0.1:58398",
+					"172.19.0.1:58398"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:54:46.880570868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7167045770133854,
+				"StableID":   "nFs4K59yxx11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:81a6d50f902fbdd66e8b59160985b18e33007ae142573fb2941f4cfccf15f339",
+				"DiscoKey":   "discokey:7ac635c12170a309df8c19414419fe7b640bcb7d1bf57023311878e0c6004b05",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50041",
+					"10.65.0.27:50041",
+					"172.17.0.1:50041",
+					"172.18.0.1:50041",
+					"172.19.0.1:50041"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:54:47.965245739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2766110188859020,
+				"StableID":   "nwzpHQ2nbN11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:793b49819227f1193028deba6d98ae240a42aa002a969e52dec3bea8ab86c41a",
+				"DiscoKey":   "discokey:86f67229e3460e0f9f6decc51a158d0adfe8c912b4762ee8099c0a2824e3fd57",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42585",
+					"10.65.0.27:42585",
+					"172.17.0.1:42585",
+					"172.18.0.1:42585",
+					"172.19.0.1:42585"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:54:48.550377379Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4554468133124430,
+				"StableID":   "nPy5ty9jZc11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cf8fe672ab4f399aac1b8245c2c9219609cb0e4cd258d7036d9f121798bdaf21",
+				"DiscoKey":   "discokey:825d316b3d033e23516939fd3bed07c70c72309576e38470be655113ce4ee946",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:37185",
+					"10.65.0.27:37185",
+					"172.17.0.1:37185",
+					"172.18.0.1:37185",
+					"172.19.0.1:37185"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:54:49.052910101Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4550344175997301,
+				"StableID":   "nxarusprXc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:549152e2e5b0adeb7a0bb8c63cc65c3b9f9817a9a509ea3d6024d831c4d1e34e",
+				"DiscoKey":   "discokey:cb3dda3df0a6e8bfd9a3a328316b0e3f2314b7b034c6c695383116e75681413d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53040",
+					"10.65.0.27:53040",
+					"172.17.0.1:53040",
+					"172.18.0.1:53040",
+					"172.19.0.1:53040"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:54:49.589710743Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8342766022519100,
+				"StableID":   "ndX6xMKT9821CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af6cd36a8e16ebf314067d20f2a6b1b13dbf5d24914597474e01a8d195ce743a",
+				"DiscoKey":   "discokey:89be47efad01197aa89be9495ee492813a6ba22ed8704a8c8d01db6005f6390a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54697",
+					"10.65.0.27:54697",
+					"172.17.0.1:54697",
+					"172.18.0.1:54697",
+					"172.19.0.1:54697"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:54:50.124379505Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6388209201687836,
+				"StableID":   "n7SzkYREtr11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:807171813aed5bb55fc6aa6857e5ac6ba7ea0d29f2671cac4163b10cb6004570",
+				"KeyExpiry":  "2026-11-08T21:54:50Z",
+				"DiscoKey":   "discokey:6f42339e183cf1aee1368c8c1ab0bdd0964a4651370d99631d9b40faa47ec707",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51709",
+					"10.65.0.27:51709",
+					"172.17.0.1:51709",
+					"172.18.0.1:51709",
+					"172.19.0.1:51709"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:54:50.665229272Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6374005258283336,
+				"StableID":   "nTEJvxJomr11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5ca6160867f6edbb9ef36e482f12692fc40b1c2ffe939ba4ce67e8514614581b",
+				"KeyExpiry":  "2026-11-08T21:54:51Z",
+				"DiscoKey":   "discokey:1d39749cea015986b56e976c3026383e13bf3895e166a00ddc2db84eb0022423",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58540",
+					"10.65.0.27:58540",
+					"172.17.0.1:58540",
+					"172.18.0.1:58540",
+					"172.19.0.1:58540"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:54:51.205420321Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2482664812023528,
+				"StableID":   "nbSExtPQPL11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:61e559c2ea54e487f2cc431edd33b381d64c49628dcc740471d5fa563ab6a960",
+				"KeyExpiry":  "2026-11-08T21:54:51Z",
+				"DiscoKey":   "discokey:145526d72dfae31389bd7433ae48c3c20d48039ce453365765d434c4222baa40",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55810",
+					"10.65.0.27:55810",
+					"172.17.0.1:55810",
+					"172.18.0.1:55810",
+					"172.19.0.1:55810"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:54:51.741564783Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4118120628729601": {
+				"ID":          4118120628729601,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2766110188859020,
+				"StableID":   "nwzpHQ2nbN11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       2766110188859020,
+				"Key":        "nodekey:793b49819227f1193028deba6d98ae240a42aa002a969e52dec3bea8ab86c41a",
+				"DiscoKey":   "discokey:86f67229e3460e0f9f6decc51a158d0adfe8c912b4762ee8099c0a2824e3fd57",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42585",
+					"10.65.0.27:42585",
+					"172.17.0.1:42585",
+					"172.18.0.1:42585",
+					"172.19.0.1:42585"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:54:48.550377379Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:793b49819227f1193028deba6d98ae240a42aa002a969e52dec3bea8ab86c41a",
+			"MachineKey": "mkey:d45029932d0e2abb25cee87d99f6374a37f7118e4ef04fe4c8e46e0d1910ef76",
+			"Peers": [{
+				"ID":         6708476977342399,
+				"StableID":   "nrnUPFKHPu11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25ef16da8ee3c0cb8ba8f35b1b740b4a9204517b5dba6b4f47f4890f97509e12",
+				"DiscoKey":   "discokey:967456f27800038abf355e283a666db624762f01ea430ac2bf068a18d5f7a12d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38634",
+					"10.65.0.27:38634",
+					"172.17.0.1:38634",
+					"172.18.0.1:38634",
+					"172.19.0.1:38634"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:54:44.165211721Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7921608609484589,
+				"StableID":   "n4JfY5Eir421CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4b8baa008b974739d41e3705c12e0a94b1c378ed48f5e00f7b92a6c45c7d606",
+				"DiscoKey":   "discokey:61d05f24c81540b03909839e649377974b50c468c70ca39e8eced830fb8cdf66",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39861",
+					"10.65.0.27:39861",
+					"172.17.0.1:39861",
+					"172.18.0.1:39861",
+					"172.19.0.1:39861"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:54:44.704212761Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         806411973373045,
+				"StableID":   "nNZDfM5EJ711CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bd083315b385abb6a117551bb592dde3fad824801f1d9401ad30817592526960",
+				"DiscoKey":   "discokey:b2b05808a0d7d43c6f5a24640c15d555b408471dfafe76e9be4da877832c7b6a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45556",
+					"10.65.0.27:45556",
+					"172.17.0.1:45556",
+					"172.18.0.1:45556",
+					"172.19.0.1:45556"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:54:45.244164136Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         923959993762591,
+				"StableID":   "ngqPh1sTD811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb7a3fe5cc632dbfe60b122161654e94f8fd0bf9fc6d82e31139f1845592da6b",
+				"DiscoKey":   "discokey:6e917cd2d0323786c1b38cdb1c4987b79b624332fc397a5c9afb5d88346ce30e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43945",
+					"10.65.0.27:43945",
+					"172.17.0.1:43945",
+					"172.18.0.1:43945",
+					"172.19.0.1:43945"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:54:45.791036301Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2404026779408634,
+				"StableID":   "nww1J1inmK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c76589ecc21c10277de97866851ef54a5c8f57a650b608bf7dd2831493b89135",
+				"DiscoKey":   "discokey:8920053af52ece35a6210768fee7b6342a4d03266ea134fd7874339737553909",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48797",
+					"10.65.0.27:48797",
+					"172.17.0.1:48797",
+					"172.18.0.1:48797",
+					"172.19.0.1:48797"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:54:46.327708216Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8522787932556383,
+				"StableID":   "nCTfgqBzY921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:095267b8a47216c7686cd87013d451d8bb48e6f557dfe1ba108dcae12ef92e2d",
+				"DiscoKey":   "discokey:6424cef4df53b2706ff677294f4ac0e2edaeb22d66a9e01145e1558add27202d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58398",
+					"10.65.0.27:58398",
+					"172.17.0.1:58398",
+					"172.18.0.1:58398",
+					"172.19.0.1:58398"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:54:46.880570868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4118120628729601,
+				"StableID":   "nn9v7f37AZ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6995bda0aa2797f262f1ac27a6efd680d2858421981da4ba0c665a443b325f53",
+				"DiscoKey":   "discokey:f96f1c6230e8a117843b0382ee247aff2e9361abac3735780a5237883344060e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53027",
+					"10.65.0.27:53027",
+					"172.17.0.1:53027",
+					"172.18.0.1:53027",
+					"172.19.0.1:53027"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:54:47.419231344Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7167045770133854,
+				"StableID":   "nFs4K59yxx11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:81a6d50f902fbdd66e8b59160985b18e33007ae142573fb2941f4cfccf15f339",
+				"DiscoKey":   "discokey:7ac635c12170a309df8c19414419fe7b640bcb7d1bf57023311878e0c6004b05",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50041",
+					"10.65.0.27:50041",
+					"172.17.0.1:50041",
+					"172.18.0.1:50041",
+					"172.19.0.1:50041"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:54:47.965245739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4554468133124430,
+				"StableID":   "nPy5ty9jZc11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cf8fe672ab4f399aac1b8245c2c9219609cb0e4cd258d7036d9f121798bdaf21",
+				"DiscoKey":   "discokey:825d316b3d033e23516939fd3bed07c70c72309576e38470be655113ce4ee946",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:37185",
+					"10.65.0.27:37185",
+					"172.17.0.1:37185",
+					"172.18.0.1:37185",
+					"172.19.0.1:37185"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:54:49.052910101Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4550344175997301,
+				"StableID":   "nxarusprXc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:549152e2e5b0adeb7a0bb8c63cc65c3b9f9817a9a509ea3d6024d831c4d1e34e",
+				"DiscoKey":   "discokey:cb3dda3df0a6e8bfd9a3a328316b0e3f2314b7b034c6c695383116e75681413d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53040",
+					"10.65.0.27:53040",
+					"172.17.0.1:53040",
+					"172.18.0.1:53040",
+					"172.19.0.1:53040"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:54:49.589710743Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8342766022519100,
+				"StableID":   "ndX6xMKT9821CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af6cd36a8e16ebf314067d20f2a6b1b13dbf5d24914597474e01a8d195ce743a",
+				"DiscoKey":   "discokey:89be47efad01197aa89be9495ee492813a6ba22ed8704a8c8d01db6005f6390a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54697",
+					"10.65.0.27:54697",
+					"172.17.0.1:54697",
+					"172.18.0.1:54697",
+					"172.19.0.1:54697"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:54:50.124379505Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6388209201687836,
+				"StableID":   "n7SzkYREtr11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:807171813aed5bb55fc6aa6857e5ac6ba7ea0d29f2671cac4163b10cb6004570",
+				"KeyExpiry":  "2026-11-08T21:54:50Z",
+				"DiscoKey":   "discokey:6f42339e183cf1aee1368c8c1ab0bdd0964a4651370d99631d9b40faa47ec707",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51709",
+					"10.65.0.27:51709",
+					"172.17.0.1:51709",
+					"172.18.0.1:51709",
+					"172.19.0.1:51709"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:54:50.665229272Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6374005258283336,
+				"StableID":   "nTEJvxJomr11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5ca6160867f6edbb9ef36e482f12692fc40b1c2ffe939ba4ce67e8514614581b",
+				"KeyExpiry":  "2026-11-08T21:54:51Z",
+				"DiscoKey":   "discokey:1d39749cea015986b56e976c3026383e13bf3895e166a00ddc2db84eb0022423",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58540",
+					"10.65.0.27:58540",
+					"172.17.0.1:58540",
+					"172.18.0.1:58540",
+					"172.19.0.1:58540"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:54:51.205420321Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2482664812023528,
+				"StableID":   "nbSExtPQPL11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:61e559c2ea54e487f2cc431edd33b381d64c49628dcc740471d5fa563ab6a960",
+				"KeyExpiry":  "2026-11-08T21:54:51Z",
+				"DiscoKey":   "discokey:145526d72dfae31389bd7433ae48c3c20d48039ce453365765d434c4222baa40",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55810",
+					"10.65.0.27:55810",
+					"172.17.0.1:55810",
+					"172.18.0.1:55810",
+					"172.19.0.1:55810"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:54:51.741564783Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2766110188859020": {
+				"ID":          2766110188859020,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6374005258283336,
+				"StableID":   "nTEJvxJomr11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5ca6160867f6edbb9ef36e482f12692fc40b1c2ffe939ba4ce67e8514614581b",
+				"KeyExpiry":  "2026-11-08T21:54:51Z",
+				"DiscoKey":   "discokey:1d39749cea015986b56e976c3026383e13bf3895e166a00ddc2db84eb0022423",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58540",
+					"10.65.0.27:58540",
+					"172.17.0.1:58540",
+					"172.18.0.1:58540",
+					"172.19.0.1:58540"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:54:51.205420321Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5ca6160867f6edbb9ef36e482f12692fc40b1c2ffe939ba4ce67e8514614581b",
+			"MachineKey": "mkey:e2f1f6ab95792288abbcdc93dd3f29bf975899ada51e40ee698f46b882cb0349",
+			"Peers": [{
+				"ID":         6708476977342399,
+				"StableID":   "nrnUPFKHPu11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25ef16da8ee3c0cb8ba8f35b1b740b4a9204517b5dba6b4f47f4890f97509e12",
+				"DiscoKey":   "discokey:967456f27800038abf355e283a666db624762f01ea430ac2bf068a18d5f7a12d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38634",
+					"10.65.0.27:38634",
+					"172.17.0.1:38634",
+					"172.18.0.1:38634",
+					"172.19.0.1:38634"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:54:44.165211721Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7921608609484589,
+				"StableID":   "n4JfY5Eir421CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4b8baa008b974739d41e3705c12e0a94b1c378ed48f5e00f7b92a6c45c7d606",
+				"DiscoKey":   "discokey:61d05f24c81540b03909839e649377974b50c468c70ca39e8eced830fb8cdf66",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39861",
+					"10.65.0.27:39861",
+					"172.17.0.1:39861",
+					"172.18.0.1:39861",
+					"172.19.0.1:39861"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:54:44.704212761Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         806411973373045,
+				"StableID":   "nNZDfM5EJ711CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bd083315b385abb6a117551bb592dde3fad824801f1d9401ad30817592526960",
+				"DiscoKey":   "discokey:b2b05808a0d7d43c6f5a24640c15d555b408471dfafe76e9be4da877832c7b6a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45556",
+					"10.65.0.27:45556",
+					"172.17.0.1:45556",
+					"172.18.0.1:45556",
+					"172.19.0.1:45556"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:54:45.244164136Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         923959993762591,
+				"StableID":   "ngqPh1sTD811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb7a3fe5cc632dbfe60b122161654e94f8fd0bf9fc6d82e31139f1845592da6b",
+				"DiscoKey":   "discokey:6e917cd2d0323786c1b38cdb1c4987b79b624332fc397a5c9afb5d88346ce30e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43945",
+					"10.65.0.27:43945",
+					"172.17.0.1:43945",
+					"172.18.0.1:43945",
+					"172.19.0.1:43945"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:54:45.791036301Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2404026779408634,
+				"StableID":   "nww1J1inmK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c76589ecc21c10277de97866851ef54a5c8f57a650b608bf7dd2831493b89135",
+				"DiscoKey":   "discokey:8920053af52ece35a6210768fee7b6342a4d03266ea134fd7874339737553909",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48797",
+					"10.65.0.27:48797",
+					"172.17.0.1:48797",
+					"172.18.0.1:48797",
+					"172.19.0.1:48797"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:54:46.327708216Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8522787932556383,
+				"StableID":   "nCTfgqBzY921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:095267b8a47216c7686cd87013d451d8bb48e6f557dfe1ba108dcae12ef92e2d",
+				"DiscoKey":   "discokey:6424cef4df53b2706ff677294f4ac0e2edaeb22d66a9e01145e1558add27202d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58398",
+					"10.65.0.27:58398",
+					"172.17.0.1:58398",
+					"172.18.0.1:58398",
+					"172.19.0.1:58398"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:54:46.880570868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4118120628729601,
+				"StableID":   "nn9v7f37AZ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6995bda0aa2797f262f1ac27a6efd680d2858421981da4ba0c665a443b325f53",
+				"DiscoKey":   "discokey:f96f1c6230e8a117843b0382ee247aff2e9361abac3735780a5237883344060e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53027",
+					"10.65.0.27:53027",
+					"172.17.0.1:53027",
+					"172.18.0.1:53027",
+					"172.19.0.1:53027"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:54:47.419231344Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7167045770133854,
+				"StableID":   "nFs4K59yxx11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:81a6d50f902fbdd66e8b59160985b18e33007ae142573fb2941f4cfccf15f339",
+				"DiscoKey":   "discokey:7ac635c12170a309df8c19414419fe7b640bcb7d1bf57023311878e0c6004b05",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50041",
+					"10.65.0.27:50041",
+					"172.17.0.1:50041",
+					"172.18.0.1:50041",
+					"172.19.0.1:50041"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:54:47.965245739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2766110188859020,
+				"StableID":   "nwzpHQ2nbN11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:793b49819227f1193028deba6d98ae240a42aa002a969e52dec3bea8ab86c41a",
+				"DiscoKey":   "discokey:86f67229e3460e0f9f6decc51a158d0adfe8c912b4762ee8099c0a2824e3fd57",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42585",
+					"10.65.0.27:42585",
+					"172.17.0.1:42585",
+					"172.18.0.1:42585",
+					"172.19.0.1:42585"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:54:48.550377379Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4554468133124430,
+				"StableID":   "nPy5ty9jZc11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cf8fe672ab4f399aac1b8245c2c9219609cb0e4cd258d7036d9f121798bdaf21",
+				"DiscoKey":   "discokey:825d316b3d033e23516939fd3bed07c70c72309576e38470be655113ce4ee946",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:37185",
+					"10.65.0.27:37185",
+					"172.17.0.1:37185",
+					"172.18.0.1:37185",
+					"172.19.0.1:37185"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:54:49.052910101Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4550344175997301,
+				"StableID":   "nxarusprXc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:549152e2e5b0adeb7a0bb8c63cc65c3b9f9817a9a509ea3d6024d831c4d1e34e",
+				"DiscoKey":   "discokey:cb3dda3df0a6e8bfd9a3a328316b0e3f2314b7b034c6c695383116e75681413d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53040",
+					"10.65.0.27:53040",
+					"172.17.0.1:53040",
+					"172.18.0.1:53040",
+					"172.19.0.1:53040"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:54:49.589710743Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8342766022519100,
+				"StableID":   "ndX6xMKT9821CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af6cd36a8e16ebf314067d20f2a6b1b13dbf5d24914597474e01a8d195ce743a",
+				"DiscoKey":   "discokey:89be47efad01197aa89be9495ee492813a6ba22ed8704a8c8d01db6005f6390a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54697",
+					"10.65.0.27:54697",
+					"172.17.0.1:54697",
+					"172.18.0.1:54697",
+					"172.19.0.1:54697"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:54:50.124379505Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6388209201687836,
+				"StableID":   "n7SzkYREtr11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:807171813aed5bb55fc6aa6857e5ac6ba7ea0d29f2671cac4163b10cb6004570",
+				"KeyExpiry":  "2026-11-08T21:54:50Z",
+				"DiscoKey":   "discokey:6f42339e183cf1aee1368c8c1ab0bdd0964a4651370d99631d9b40faa47ec707",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51709",
+					"10.65.0.27:51709",
+					"172.17.0.1:51709",
+					"172.18.0.1:51709",
+					"172.19.0.1:51709"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:54:50.665229272Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2482664812023528,
+				"StableID":   "nbSExtPQPL11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:61e559c2ea54e487f2cc431edd33b381d64c49628dcc740471d5fa563ab6a960",
+				"KeyExpiry":  "2026-11-08T21:54:51Z",
+				"DiscoKey":   "discokey:145526d72dfae31389bd7433ae48c3c20d48039ce453365765d434c4222baa40",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55810",
+					"10.65.0.27:55810",
+					"172.17.0.1:55810",
+					"172.18.0.1:55810",
+					"172.19.0.1:55810"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:54:51.741564783Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4554468133124430,
+				"StableID":   "nPy5ty9jZc11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       4554468133124430,
+				"Key":        "nodekey:cf8fe672ab4f399aac1b8245c2c9219609cb0e4cd258d7036d9f121798bdaf21",
+				"DiscoKey":   "discokey:825d316b3d033e23516939fd3bed07c70c72309576e38470be655113ce4ee946",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:37185",
+					"10.65.0.27:37185",
+					"172.17.0.1:37185",
+					"172.18.0.1:37185",
+					"172.19.0.1:37185"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:54:49.052910101Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:cf8fe672ab4f399aac1b8245c2c9219609cb0e4cd258d7036d9f121798bdaf21",
+			"MachineKey": "mkey:6d368e7eed2c4cc8d95d01f5670d529602af1864c5608c5d0f1d06d0ab25515f",
+			"Peers": [{
+				"ID":         6708476977342399,
+				"StableID":   "nrnUPFKHPu11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25ef16da8ee3c0cb8ba8f35b1b740b4a9204517b5dba6b4f47f4890f97509e12",
+				"DiscoKey":   "discokey:967456f27800038abf355e283a666db624762f01ea430ac2bf068a18d5f7a12d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38634",
+					"10.65.0.27:38634",
+					"172.17.0.1:38634",
+					"172.18.0.1:38634",
+					"172.19.0.1:38634"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:54:44.165211721Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7921608609484589,
+				"StableID":   "n4JfY5Eir421CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4b8baa008b974739d41e3705c12e0a94b1c378ed48f5e00f7b92a6c45c7d606",
+				"DiscoKey":   "discokey:61d05f24c81540b03909839e649377974b50c468c70ca39e8eced830fb8cdf66",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39861",
+					"10.65.0.27:39861",
+					"172.17.0.1:39861",
+					"172.18.0.1:39861",
+					"172.19.0.1:39861"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:54:44.704212761Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         806411973373045,
+				"StableID":   "nNZDfM5EJ711CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bd083315b385abb6a117551bb592dde3fad824801f1d9401ad30817592526960",
+				"DiscoKey":   "discokey:b2b05808a0d7d43c6f5a24640c15d555b408471dfafe76e9be4da877832c7b6a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45556",
+					"10.65.0.27:45556",
+					"172.17.0.1:45556",
+					"172.18.0.1:45556",
+					"172.19.0.1:45556"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:54:45.244164136Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         923959993762591,
+				"StableID":   "ngqPh1sTD811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb7a3fe5cc632dbfe60b122161654e94f8fd0bf9fc6d82e31139f1845592da6b",
+				"DiscoKey":   "discokey:6e917cd2d0323786c1b38cdb1c4987b79b624332fc397a5c9afb5d88346ce30e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43945",
+					"10.65.0.27:43945",
+					"172.17.0.1:43945",
+					"172.18.0.1:43945",
+					"172.19.0.1:43945"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:54:45.791036301Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2404026779408634,
+				"StableID":   "nww1J1inmK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c76589ecc21c10277de97866851ef54a5c8f57a650b608bf7dd2831493b89135",
+				"DiscoKey":   "discokey:8920053af52ece35a6210768fee7b6342a4d03266ea134fd7874339737553909",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48797",
+					"10.65.0.27:48797",
+					"172.17.0.1:48797",
+					"172.18.0.1:48797",
+					"172.19.0.1:48797"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:54:46.327708216Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8522787932556383,
+				"StableID":   "nCTfgqBzY921CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:095267b8a47216c7686cd87013d451d8bb48e6f557dfe1ba108dcae12ef92e2d",
+				"DiscoKey":   "discokey:6424cef4df53b2706ff677294f4ac0e2edaeb22d66a9e01145e1558add27202d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58398",
+					"10.65.0.27:58398",
+					"172.17.0.1:58398",
+					"172.18.0.1:58398",
+					"172.19.0.1:58398"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:54:46.880570868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4118120628729601,
+				"StableID":   "nn9v7f37AZ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6995bda0aa2797f262f1ac27a6efd680d2858421981da4ba0c665a443b325f53",
+				"DiscoKey":   "discokey:f96f1c6230e8a117843b0382ee247aff2e9361abac3735780a5237883344060e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53027",
+					"10.65.0.27:53027",
+					"172.17.0.1:53027",
+					"172.18.0.1:53027",
+					"172.19.0.1:53027"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:54:47.419231344Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7167045770133854,
+				"StableID":   "nFs4K59yxx11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:81a6d50f902fbdd66e8b59160985b18e33007ae142573fb2941f4cfccf15f339",
+				"DiscoKey":   "discokey:7ac635c12170a309df8c19414419fe7b640bcb7d1bf57023311878e0c6004b05",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50041",
+					"10.65.0.27:50041",
+					"172.17.0.1:50041",
+					"172.18.0.1:50041",
+					"172.19.0.1:50041"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:54:47.965245739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2766110188859020,
+				"StableID":   "nwzpHQ2nbN11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:793b49819227f1193028deba6d98ae240a42aa002a969e52dec3bea8ab86c41a",
+				"DiscoKey":   "discokey:86f67229e3460e0f9f6decc51a158d0adfe8c912b4762ee8099c0a2824e3fd57",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42585",
+					"10.65.0.27:42585",
+					"172.17.0.1:42585",
+					"172.18.0.1:42585",
+					"172.19.0.1:42585"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:54:48.550377379Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4550344175997301,
+				"StableID":   "nxarusprXc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:549152e2e5b0adeb7a0bb8c63cc65c3b9f9817a9a509ea3d6024d831c4d1e34e",
+				"DiscoKey":   "discokey:cb3dda3df0a6e8bfd9a3a328316b0e3f2314b7b034c6c695383116e75681413d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53040",
+					"10.65.0.27:53040",
+					"172.17.0.1:53040",
+					"172.18.0.1:53040",
+					"172.19.0.1:53040"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:54:49.589710743Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8342766022519100,
+				"StableID":   "ndX6xMKT9821CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af6cd36a8e16ebf314067d20f2a6b1b13dbf5d24914597474e01a8d195ce743a",
+				"DiscoKey":   "discokey:89be47efad01197aa89be9495ee492813a6ba22ed8704a8c8d01db6005f6390a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54697",
+					"10.65.0.27:54697",
+					"172.17.0.1:54697",
+					"172.18.0.1:54697",
+					"172.19.0.1:54697"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:54:50.124379505Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6388209201687836,
+				"StableID":   "n7SzkYREtr11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:807171813aed5bb55fc6aa6857e5ac6ba7ea0d29f2671cac4163b10cb6004570",
+				"KeyExpiry":  "2026-11-08T21:54:50Z",
+				"DiscoKey":   "discokey:6f42339e183cf1aee1368c8c1ab0bdd0964a4651370d99631d9b40faa47ec707",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51709",
+					"10.65.0.27:51709",
+					"172.17.0.1:51709",
+					"172.18.0.1:51709",
+					"172.19.0.1:51709"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:54:50.665229272Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6374005258283336,
+				"StableID":   "nTEJvxJomr11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5ca6160867f6edbb9ef36e482f12692fc40b1c2ffe939ba4ce67e8514614581b",
+				"KeyExpiry":  "2026-11-08T21:54:51Z",
+				"DiscoKey":   "discokey:1d39749cea015986b56e976c3026383e13bf3895e166a00ddc2db84eb0022423",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58540",
+					"10.65.0.27:58540",
+					"172.17.0.1:58540",
+					"172.18.0.1:58540",
+					"172.19.0.1:58540"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:54:51.205420321Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2482664812023528,
+				"StableID":   "nbSExtPQPL11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:61e559c2ea54e487f2cc431edd33b381d64c49628dcc740471d5fa563ab6a960",
+				"KeyExpiry":  "2026-11-08T21:54:51Z",
+				"DiscoKey":   "discokey:145526d72dfae31389bd7433ae48c3c20d48039ce453365765d434c4222baa40",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55810",
+					"10.65.0.27:55810",
+					"172.17.0.1:55810",
+					"172.18.0.1:55810",
+					"172.19.0.1:55810"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:54:51.741564783Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4554468133124430": {
+				"ID":          4554468133124430,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-checkperiod-zero.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-checkperiod-zero.hujson
@@ -1,0 +1,20099 @@
+// ssh-malformed-checkperiod-zero
+//
+// ssh checkPeriod 0s is rejected
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T21:55:37Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-malformed-checkperiod-zero",
+	"description":    "ssh checkPeriod 0s is rejected",
+	"category":       "ssh",
+	"captured_at":    "2026-05-12T21:55:37.075382745Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                 \n  \n                                                        \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh checkPeriod 0s is rejected\",\n\t\"id\":          \"ssh-malformed-checkperiod-zero\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\":      \"check\",\n\t\t\"checkPeriod\": \"0s\",\n\t\t\"dst\":         [\"tag:server\"],\n\t\t\"src\":         [\"autogroup:member\"],\n\t\t\"users\":       [\"root\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-malformed/ssh-malformed-checkperiod-zero.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action":      "check",
+				"checkPeriod": "0s",
+				"dst":         ["tag:server"],
+				"src":         ["autogroup:member"],
+				"users":       ["root"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4294369728739762,
+				"StableID":   "nsjvY2pvXa11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       4294369728739762,
+				"Key":        "nodekey:e961eb4cf72d39bbac6a456646cfbc704fe2b1ecf903839d7df63a9d0a4c5911",
+				"DiscoKey":   "discokey:91aa1369ff4114dac10baf07d7905013fc852b3f362ea53c6384f73568428a45",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48236",
+					"10.65.0.27:48236",
+					"172.17.0.1:48236",
+					"172.18.0.1:48236",
+					"172.19.0.1:48236"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:55:45.605607837Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e961eb4cf72d39bbac6a456646cfbc704fe2b1ecf903839d7df63a9d0a4c5911",
+			"MachineKey": "mkey:85b5b1f54f27e720a9b0437e9bea38c40179e91461d99b41b56d162fe5d3191d",
+			"Peers": [{
+				"ID":         2132112232116195,
+				"StableID":   "nJUrsRydeH11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7bdd423d434e43abbf796cd12a165b5953389a16147bfefcb99e049f46a90f3a",
+				"DiscoKey":   "discokey:854fe607ee959d44ae2a4e01c14888d8630e3d42e899ee18926d8d41ba2bce67",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44016",
+					"10.65.0.27:44016",
+					"172.17.0.1:44016",
+					"172.18.0.1:44016",
+					"172.19.0.1:44016"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:55:39.698686052Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4336320486250097,
+				"StableID":   "nr7cLbnvra11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3d54a12ba3b2463dd18b59b73ebab7bdb784761f6bbdd67e2e28842eda6f34b",
+				"DiscoKey":   "discokey:100042ec3269a61e0e89dfda2efef78f3b71be1983b5cac4f7ee6c210aedd873",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50831",
+					"10.65.0.27:50831",
+					"172.17.0.1:50831",
+					"172.18.0.1:50831",
+					"172.19.0.1:50831"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:55:40.226591347Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3741301672973853,
+				"StableID":   "ntEbMkeSDW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3f3d7e0af39fa685771a5fadf4eefedda78fda9f1805f08dcb0f5a5bb3b8cc56",
+				"DiscoKey":   "discokey:01c267d3724254e1111e3e14e3cb473684067e178f50d0aa45470620db9b0824",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57706",
+					"10.65.0.27:57706",
+					"172.17.0.1:57706",
+					"172.18.0.1:57706",
+					"172.19.0.1:57706"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:55:40.771840987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5394370143918161,
+				"StableID":   "nSKzTUx78j11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c3e0b2cd72a3122fbe6621fc75a7447a586833cbcf65f6dab21f1a804eafc01",
+				"DiscoKey":   "discokey:bcd15c7ad4dc1556c116d9d902251f62598ccd27af22d343c58760ef8fcad54f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42134",
+					"10.65.0.27:42134",
+					"172.17.0.1:42134",
+					"172.18.0.1:42134",
+					"172.19.0.1:42134"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:55:41.303990369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1927300156723223,
+				"StableID":   "n8hy7cus3G11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:189b619364d3d6d3004bc847844d0436660a9bb855090fdbc4444b6d09562068",
+				"DiscoKey":   "discokey:9445c6e04cc897e23292586bd9c55a0eb4937a0af0836b6dcba8ffe360a7984e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53383",
+					"10.65.0.27:53383",
+					"172.17.0.1:53383",
+					"172.18.0.1:53383",
+					"172.19.0.1:53383"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:55:41.841879201Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         439650908341143,
+				"StableID":   "nJCsFGt7S411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9187b6935a7f5a2955d457da066d16bec150d85f25002861ddac225194877f32",
+				"DiscoKey":   "discokey:fc8d91c13f05343f595daf2a52d78e6e64abe4971f3e3ded5088a169f09d8633",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41382",
+					"10.65.0.27:41382",
+					"172.17.0.1:41382",
+					"172.18.0.1:41382",
+					"172.19.0.1:41382"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:55:42.370384886Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1290217121610877,
+				"StableID":   "nSRxtKpL5B11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d284444294f36b421768b987b62fe6b03307f56f233ae6d854814829e39a755",
+				"DiscoKey":   "discokey:5923aeff60127e1f66028f50952bf3c2c972ede9e78f6c559015e56b964e2616",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43819",
+					"10.65.0.27:43819",
+					"172.17.0.1:43819",
+					"172.18.0.1:43819",
+					"172.19.0.1:43819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:55:42.908263303Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8624285660216814,
+				"StableID":   "nmAFKtMxLA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ebf02a7aa5aa85c6968b649e2fdebb1aee88acc64a8479e9988788946480706c",
+				"DiscoKey":   "discokey:f592f6483412a50c44ae0465a6807449d5404279addb598085a165e01306c426",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42072",
+					"10.65.0.27:42072",
+					"172.17.0.1:42072",
+					"172.18.0.1:42072",
+					"172.19.0.1:42072"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:55:43.444763987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2303406886056769,
+				"StableID":   "nzsisPbDzJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d90fe5950a4662dee384235546263c96a392bc4f8ab284e4258caae05f9d462",
+				"DiscoKey":   "discokey:92d16765039f7b98f91926c6a31731cd992d5c97f5de0e57f7d6c498cf605f12",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39876",
+					"10.65.0.27:39876",
+					"172.17.0.1:39876",
+					"172.18.0.1:39876",
+					"172.19.0.1:39876"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:55:43.9799932Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6392821879123614,
+				"StableID":   "ndpYGFbKvr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b7d9d32b7ea659275d316f9760a9d37aa6d181e07fc6538f1fb14f9318a31b13",
+				"DiscoKey":   "discokey:7db39b748e818981c1997c6ebcee20f149985c2a8060e0f2be4eda3a9019545c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50063",
+					"10.65.0.27:50063",
+					"172.17.0.1:50063",
+					"172.18.0.1:50063",
+					"172.19.0.1:50063"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:55:44.524467076Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2393276862151458,
+				"StableID":   "n9tAvqKvgK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fd1726462aef22d065170d4dbfccab593cd48e5d3b155b015b3fe98f5c8a1e0d",
+				"DiscoKey":   "discokey:9d46b7f634a519d581941a59353decde2ae9234d610afd1434fe477a339e123b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:49307",
+					"10.65.0.27:49307",
+					"172.17.0.1:49307",
+					"172.18.0.1:49307",
+					"172.19.0.1:49307"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:55:45.073999116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3663638698618420,
+				"StableID":   "nHmpFRaGcV11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:edf9559d3938e9530b86321c6e10c49f367d457655f02e4e7653c008bfc74070",
+				"KeyExpiry":  "2026-11-08T21:55:46Z",
+				"DiscoKey":   "discokey:9bbc122047ca08b148211c091725beecd7934131d82d6180e598bb2b889cc007",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:58676",
+					"10.65.0.27:58676",
+					"172.17.0.1:58676",
+					"172.18.0.1:58676",
+					"172.19.0.1:58676"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:55:46.147618174Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8354902190844601,
+				"StableID":   "nnw1bZ7xE821CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ffb380ef172c63d8675ef384cb1aa23376dae13d0562a71e4925b8c4900ff94b",
+				"KeyExpiry":  "2026-11-08T21:55:46Z",
+				"DiscoKey":   "discokey:f760ccafef0f31af01190dc297e10ea4fff59582758237c82e90e1cd23316b08",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51903",
+					"10.65.0.27:51903",
+					"172.17.0.1:51903",
+					"172.18.0.1:51903",
+					"172.19.0.1:51903"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:55:46.689299341Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6344020514535147,
+				"StableID":   "nSgvnMfDYr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:4c0ba639676a594cb1180dc2bf58a318328408e53c4af37afb9d081f518e8450",
+				"KeyExpiry":  "2026-11-08T21:55:47Z",
+				"DiscoKey":   "discokey:f801630498725d8f04d852d3648a9d3b4451ebe38289defe8590416206f0b11e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53570",
+					"10.65.0.27:53570",
+					"172.17.0.1:53570",
+					"172.18.0.1:53570",
+					"172.19.0.1:53570"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:55:47.236375997Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{"principals": [
+				{"nodeIP": "100.64.0.17"},
+				{"nodeIP": "100.64.0.18"},
+				{"nodeIP": "100.64.0.19"},
+				{"nodeIP": "fd7a:115c:a1e0::13"},
+				{"nodeIP": "fd7a:115c:a1e0::12"},
+				{"nodeIP": "fd7a:115c:a1e0::11"}
+			], "sshUsers": {"root": "root"}, "action": {
+				"holdAndDelegate": "https://unused/machine/ssh/action/$SRC_NODE_ID/to/$DST_NODE_ID?local_user=$LOCAL_USER"
+			}}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4294369728739762": {
+				"ID":          4294369728739762,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		},
+		"ssh_rules": [{"principals": [
+			{"nodeIP": "100.64.0.17"},
+			{"nodeIP": "100.64.0.18"},
+			{"nodeIP": "100.64.0.19"},
+			{"nodeIP": "fd7a:115c:a1e0::13"},
+			{"nodeIP": "fd7a:115c:a1e0::12"},
+			{"nodeIP": "fd7a:115c:a1e0::11"}
+		], "sshUsers": {"root": "root"}, "action": {
+			"holdAndDelegate": "https://unused/machine/ssh/action/$SRC_NODE_ID/to/$DST_NODE_ID?local_user=$LOCAL_USER"
+		}}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         439650908341143,
+				"StableID":   "nJCsFGt7S411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       439650908341143,
+				"Key":        "nodekey:9187b6935a7f5a2955d457da066d16bec150d85f25002861ddac225194877f32",
+				"DiscoKey":   "discokey:fc8d91c13f05343f595daf2a52d78e6e64abe4971f3e3ded5088a169f09d8633",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41382",
+					"10.65.0.27:41382",
+					"172.17.0.1:41382",
+					"172.18.0.1:41382",
+					"172.19.0.1:41382"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:55:42.370384886Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9187b6935a7f5a2955d457da066d16bec150d85f25002861ddac225194877f32",
+			"MachineKey": "mkey:bf84633bc0858c72703d0f8272d3e20a88b1e6b343214838a48e7a5ea3f3b71b",
+			"Peers": [{
+				"ID":         2132112232116195,
+				"StableID":   "nJUrsRydeH11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7bdd423d434e43abbf796cd12a165b5953389a16147bfefcb99e049f46a90f3a",
+				"DiscoKey":   "discokey:854fe607ee959d44ae2a4e01c14888d8630e3d42e899ee18926d8d41ba2bce67",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44016",
+					"10.65.0.27:44016",
+					"172.17.0.1:44016",
+					"172.18.0.1:44016",
+					"172.19.0.1:44016"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:55:39.698686052Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4336320486250097,
+				"StableID":   "nr7cLbnvra11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3d54a12ba3b2463dd18b59b73ebab7bdb784761f6bbdd67e2e28842eda6f34b",
+				"DiscoKey":   "discokey:100042ec3269a61e0e89dfda2efef78f3b71be1983b5cac4f7ee6c210aedd873",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50831",
+					"10.65.0.27:50831",
+					"172.17.0.1:50831",
+					"172.18.0.1:50831",
+					"172.19.0.1:50831"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:55:40.226591347Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3741301672973853,
+				"StableID":   "ntEbMkeSDW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3f3d7e0af39fa685771a5fadf4eefedda78fda9f1805f08dcb0f5a5bb3b8cc56",
+				"DiscoKey":   "discokey:01c267d3724254e1111e3e14e3cb473684067e178f50d0aa45470620db9b0824",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57706",
+					"10.65.0.27:57706",
+					"172.17.0.1:57706",
+					"172.18.0.1:57706",
+					"172.19.0.1:57706"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:55:40.771840987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5394370143918161,
+				"StableID":   "nSKzTUx78j11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c3e0b2cd72a3122fbe6621fc75a7447a586833cbcf65f6dab21f1a804eafc01",
+				"DiscoKey":   "discokey:bcd15c7ad4dc1556c116d9d902251f62598ccd27af22d343c58760ef8fcad54f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42134",
+					"10.65.0.27:42134",
+					"172.17.0.1:42134",
+					"172.18.0.1:42134",
+					"172.19.0.1:42134"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:55:41.303990369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1927300156723223,
+				"StableID":   "n8hy7cus3G11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:189b619364d3d6d3004bc847844d0436660a9bb855090fdbc4444b6d09562068",
+				"DiscoKey":   "discokey:9445c6e04cc897e23292586bd9c55a0eb4937a0af0836b6dcba8ffe360a7984e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53383",
+					"10.65.0.27:53383",
+					"172.17.0.1:53383",
+					"172.18.0.1:53383",
+					"172.19.0.1:53383"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:55:41.841879201Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1290217121610877,
+				"StableID":   "nSRxtKpL5B11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d284444294f36b421768b987b62fe6b03307f56f233ae6d854814829e39a755",
+				"DiscoKey":   "discokey:5923aeff60127e1f66028f50952bf3c2c972ede9e78f6c559015e56b964e2616",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43819",
+					"10.65.0.27:43819",
+					"172.17.0.1:43819",
+					"172.18.0.1:43819",
+					"172.19.0.1:43819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:55:42.908263303Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8624285660216814,
+				"StableID":   "nmAFKtMxLA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ebf02a7aa5aa85c6968b649e2fdebb1aee88acc64a8479e9988788946480706c",
+				"DiscoKey":   "discokey:f592f6483412a50c44ae0465a6807449d5404279addb598085a165e01306c426",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42072",
+					"10.65.0.27:42072",
+					"172.17.0.1:42072",
+					"172.18.0.1:42072",
+					"172.19.0.1:42072"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:55:43.444763987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2303406886056769,
+				"StableID":   "nzsisPbDzJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d90fe5950a4662dee384235546263c96a392bc4f8ab284e4258caae05f9d462",
+				"DiscoKey":   "discokey:92d16765039f7b98f91926c6a31731cd992d5c97f5de0e57f7d6c498cf605f12",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39876",
+					"10.65.0.27:39876",
+					"172.17.0.1:39876",
+					"172.18.0.1:39876",
+					"172.19.0.1:39876"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:55:43.9799932Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6392821879123614,
+				"StableID":   "ndpYGFbKvr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b7d9d32b7ea659275d316f9760a9d37aa6d181e07fc6538f1fb14f9318a31b13",
+				"DiscoKey":   "discokey:7db39b748e818981c1997c6ebcee20f149985c2a8060e0f2be4eda3a9019545c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50063",
+					"10.65.0.27:50063",
+					"172.17.0.1:50063",
+					"172.18.0.1:50063",
+					"172.19.0.1:50063"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:55:44.524467076Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2393276862151458,
+				"StableID":   "n9tAvqKvgK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fd1726462aef22d065170d4dbfccab593cd48e5d3b155b015b3fe98f5c8a1e0d",
+				"DiscoKey":   "discokey:9d46b7f634a519d581941a59353decde2ae9234d610afd1434fe477a339e123b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:49307",
+					"10.65.0.27:49307",
+					"172.17.0.1:49307",
+					"172.18.0.1:49307",
+					"172.19.0.1:49307"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:55:45.073999116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4294369728739762,
+				"StableID":   "nsjvY2pvXa11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e961eb4cf72d39bbac6a456646cfbc704fe2b1ecf903839d7df63a9d0a4c5911",
+				"DiscoKey":   "discokey:91aa1369ff4114dac10baf07d7905013fc852b3f362ea53c6384f73568428a45",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48236",
+					"10.65.0.27:48236",
+					"172.17.0.1:48236",
+					"172.18.0.1:48236",
+					"172.19.0.1:48236"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:55:45.605607837Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3663638698618420,
+				"StableID":   "nHmpFRaGcV11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:edf9559d3938e9530b86321c6e10c49f367d457655f02e4e7653c008bfc74070",
+				"KeyExpiry":  "2026-11-08T21:55:46Z",
+				"DiscoKey":   "discokey:9bbc122047ca08b148211c091725beecd7934131d82d6180e598bb2b889cc007",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:58676",
+					"10.65.0.27:58676",
+					"172.17.0.1:58676",
+					"172.18.0.1:58676",
+					"172.19.0.1:58676"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:55:46.147618174Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8354902190844601,
+				"StableID":   "nnw1bZ7xE821CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ffb380ef172c63d8675ef384cb1aa23376dae13d0562a71e4925b8c4900ff94b",
+				"KeyExpiry":  "2026-11-08T21:55:46Z",
+				"DiscoKey":   "discokey:f760ccafef0f31af01190dc297e10ea4fff59582758237c82e90e1cd23316b08",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51903",
+					"10.65.0.27:51903",
+					"172.17.0.1:51903",
+					"172.18.0.1:51903",
+					"172.19.0.1:51903"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:55:46.689299341Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6344020514535147,
+				"StableID":   "nSgvnMfDYr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:4c0ba639676a594cb1180dc2bf58a318328408e53c4af37afb9d081f518e8450",
+				"KeyExpiry":  "2026-11-08T21:55:47Z",
+				"DiscoKey":   "discokey:f801630498725d8f04d852d3648a9d3b4451ebe38289defe8590416206f0b11e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53570",
+					"10.65.0.27:53570",
+					"172.17.0.1:53570",
+					"172.18.0.1:53570",
+					"172.19.0.1:53570"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:55:47.236375997Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "439650908341143": {
+				"ID":          439650908341143,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6344020514535147,
+				"StableID":   "nSgvnMfDYr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:4c0ba639676a594cb1180dc2bf58a318328408e53c4af37afb9d081f518e8450",
+				"KeyExpiry":  "2026-11-08T21:55:47Z",
+				"DiscoKey":   "discokey:f801630498725d8f04d852d3648a9d3b4451ebe38289defe8590416206f0b11e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53570",
+					"10.65.0.27:53570",
+					"172.17.0.1:53570",
+					"172.18.0.1:53570",
+					"172.19.0.1:53570"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:55:47.236375997Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4c0ba639676a594cb1180dc2bf58a318328408e53c4af37afb9d081f518e8450",
+			"MachineKey": "mkey:c311c999f82504ac563403058c37de70f794090531941febc43cf593d5fd843d",
+			"Peers": [{
+				"ID":         2132112232116195,
+				"StableID":   "nJUrsRydeH11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7bdd423d434e43abbf796cd12a165b5953389a16147bfefcb99e049f46a90f3a",
+				"DiscoKey":   "discokey:854fe607ee959d44ae2a4e01c14888d8630e3d42e899ee18926d8d41ba2bce67",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44016",
+					"10.65.0.27:44016",
+					"172.17.0.1:44016",
+					"172.18.0.1:44016",
+					"172.19.0.1:44016"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:55:39.698686052Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4336320486250097,
+				"StableID":   "nr7cLbnvra11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3d54a12ba3b2463dd18b59b73ebab7bdb784761f6bbdd67e2e28842eda6f34b",
+				"DiscoKey":   "discokey:100042ec3269a61e0e89dfda2efef78f3b71be1983b5cac4f7ee6c210aedd873",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50831",
+					"10.65.0.27:50831",
+					"172.17.0.1:50831",
+					"172.18.0.1:50831",
+					"172.19.0.1:50831"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:55:40.226591347Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3741301672973853,
+				"StableID":   "ntEbMkeSDW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3f3d7e0af39fa685771a5fadf4eefedda78fda9f1805f08dcb0f5a5bb3b8cc56",
+				"DiscoKey":   "discokey:01c267d3724254e1111e3e14e3cb473684067e178f50d0aa45470620db9b0824",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57706",
+					"10.65.0.27:57706",
+					"172.17.0.1:57706",
+					"172.18.0.1:57706",
+					"172.19.0.1:57706"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:55:40.771840987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5394370143918161,
+				"StableID":   "nSKzTUx78j11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c3e0b2cd72a3122fbe6621fc75a7447a586833cbcf65f6dab21f1a804eafc01",
+				"DiscoKey":   "discokey:bcd15c7ad4dc1556c116d9d902251f62598ccd27af22d343c58760ef8fcad54f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42134",
+					"10.65.0.27:42134",
+					"172.17.0.1:42134",
+					"172.18.0.1:42134",
+					"172.19.0.1:42134"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:55:41.303990369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1927300156723223,
+				"StableID":   "n8hy7cus3G11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:189b619364d3d6d3004bc847844d0436660a9bb855090fdbc4444b6d09562068",
+				"DiscoKey":   "discokey:9445c6e04cc897e23292586bd9c55a0eb4937a0af0836b6dcba8ffe360a7984e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53383",
+					"10.65.0.27:53383",
+					"172.17.0.1:53383",
+					"172.18.0.1:53383",
+					"172.19.0.1:53383"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:55:41.841879201Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         439650908341143,
+				"StableID":   "nJCsFGt7S411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9187b6935a7f5a2955d457da066d16bec150d85f25002861ddac225194877f32",
+				"DiscoKey":   "discokey:fc8d91c13f05343f595daf2a52d78e6e64abe4971f3e3ded5088a169f09d8633",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41382",
+					"10.65.0.27:41382",
+					"172.17.0.1:41382",
+					"172.18.0.1:41382",
+					"172.19.0.1:41382"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:55:42.370384886Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1290217121610877,
+				"StableID":   "nSRxtKpL5B11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d284444294f36b421768b987b62fe6b03307f56f233ae6d854814829e39a755",
+				"DiscoKey":   "discokey:5923aeff60127e1f66028f50952bf3c2c972ede9e78f6c559015e56b964e2616",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43819",
+					"10.65.0.27:43819",
+					"172.17.0.1:43819",
+					"172.18.0.1:43819",
+					"172.19.0.1:43819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:55:42.908263303Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8624285660216814,
+				"StableID":   "nmAFKtMxLA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ebf02a7aa5aa85c6968b649e2fdebb1aee88acc64a8479e9988788946480706c",
+				"DiscoKey":   "discokey:f592f6483412a50c44ae0465a6807449d5404279addb598085a165e01306c426",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42072",
+					"10.65.0.27:42072",
+					"172.17.0.1:42072",
+					"172.18.0.1:42072",
+					"172.19.0.1:42072"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:55:43.444763987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2303406886056769,
+				"StableID":   "nzsisPbDzJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d90fe5950a4662dee384235546263c96a392bc4f8ab284e4258caae05f9d462",
+				"DiscoKey":   "discokey:92d16765039f7b98f91926c6a31731cd992d5c97f5de0e57f7d6c498cf605f12",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39876",
+					"10.65.0.27:39876",
+					"172.17.0.1:39876",
+					"172.18.0.1:39876",
+					"172.19.0.1:39876"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:55:43.9799932Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6392821879123614,
+				"StableID":   "ndpYGFbKvr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b7d9d32b7ea659275d316f9760a9d37aa6d181e07fc6538f1fb14f9318a31b13",
+				"DiscoKey":   "discokey:7db39b748e818981c1997c6ebcee20f149985c2a8060e0f2be4eda3a9019545c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50063",
+					"10.65.0.27:50063",
+					"172.17.0.1:50063",
+					"172.18.0.1:50063",
+					"172.19.0.1:50063"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:55:44.524467076Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2393276862151458,
+				"StableID":   "n9tAvqKvgK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fd1726462aef22d065170d4dbfccab593cd48e5d3b155b015b3fe98f5c8a1e0d",
+				"DiscoKey":   "discokey:9d46b7f634a519d581941a59353decde2ae9234d610afd1434fe477a339e123b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:49307",
+					"10.65.0.27:49307",
+					"172.17.0.1:49307",
+					"172.18.0.1:49307",
+					"172.19.0.1:49307"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:55:45.073999116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4294369728739762,
+				"StableID":   "nsjvY2pvXa11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e961eb4cf72d39bbac6a456646cfbc704fe2b1ecf903839d7df63a9d0a4c5911",
+				"DiscoKey":   "discokey:91aa1369ff4114dac10baf07d7905013fc852b3f362ea53c6384f73568428a45",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48236",
+					"10.65.0.27:48236",
+					"172.17.0.1:48236",
+					"172.18.0.1:48236",
+					"172.19.0.1:48236"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:55:45.605607837Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3663638698618420,
+				"StableID":   "nHmpFRaGcV11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:edf9559d3938e9530b86321c6e10c49f367d457655f02e4e7653c008bfc74070",
+				"KeyExpiry":  "2026-11-08T21:55:46Z",
+				"DiscoKey":   "discokey:9bbc122047ca08b148211c091725beecd7934131d82d6180e598bb2b889cc007",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:58676",
+					"10.65.0.27:58676",
+					"172.17.0.1:58676",
+					"172.18.0.1:58676",
+					"172.19.0.1:58676"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:55:46.147618174Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8354902190844601,
+				"StableID":   "nnw1bZ7xE821CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ffb380ef172c63d8675ef384cb1aa23376dae13d0562a71e4925b8c4900ff94b",
+				"KeyExpiry":  "2026-11-08T21:55:46Z",
+				"DiscoKey":   "discokey:f760ccafef0f31af01190dc297e10ea4fff59582758237c82e90e1cd23316b08",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51903",
+					"10.65.0.27:51903",
+					"172.17.0.1:51903",
+					"172.18.0.1:51903",
+					"172.19.0.1:51903"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:55:46.689299341Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3741301672973853,
+				"StableID":   "ntEbMkeSDW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       3741301672973853,
+				"Key":        "nodekey:3f3d7e0af39fa685771a5fadf4eefedda78fda9f1805f08dcb0f5a5bb3b8cc56",
+				"DiscoKey":   "discokey:01c267d3724254e1111e3e14e3cb473684067e178f50d0aa45470620db9b0824",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57706",
+					"10.65.0.27:57706",
+					"172.17.0.1:57706",
+					"172.18.0.1:57706",
+					"172.19.0.1:57706"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:55:40.771840987Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3f3d7e0af39fa685771a5fadf4eefedda78fda9f1805f08dcb0f5a5bb3b8cc56",
+			"MachineKey": "mkey:43e519fda52763e5db69ecd14cbe3ad943ffffc2683b95511d8b636b503ac113",
+			"Peers": [{
+				"ID":         2132112232116195,
+				"StableID":   "nJUrsRydeH11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7bdd423d434e43abbf796cd12a165b5953389a16147bfefcb99e049f46a90f3a",
+				"DiscoKey":   "discokey:854fe607ee959d44ae2a4e01c14888d8630e3d42e899ee18926d8d41ba2bce67",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44016",
+					"10.65.0.27:44016",
+					"172.17.0.1:44016",
+					"172.18.0.1:44016",
+					"172.19.0.1:44016"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:55:39.698686052Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4336320486250097,
+				"StableID":   "nr7cLbnvra11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3d54a12ba3b2463dd18b59b73ebab7bdb784761f6bbdd67e2e28842eda6f34b",
+				"DiscoKey":   "discokey:100042ec3269a61e0e89dfda2efef78f3b71be1983b5cac4f7ee6c210aedd873",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50831",
+					"10.65.0.27:50831",
+					"172.17.0.1:50831",
+					"172.18.0.1:50831",
+					"172.19.0.1:50831"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:55:40.226591347Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5394370143918161,
+				"StableID":   "nSKzTUx78j11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c3e0b2cd72a3122fbe6621fc75a7447a586833cbcf65f6dab21f1a804eafc01",
+				"DiscoKey":   "discokey:bcd15c7ad4dc1556c116d9d902251f62598ccd27af22d343c58760ef8fcad54f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42134",
+					"10.65.0.27:42134",
+					"172.17.0.1:42134",
+					"172.18.0.1:42134",
+					"172.19.0.1:42134"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:55:41.303990369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1927300156723223,
+				"StableID":   "n8hy7cus3G11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:189b619364d3d6d3004bc847844d0436660a9bb855090fdbc4444b6d09562068",
+				"DiscoKey":   "discokey:9445c6e04cc897e23292586bd9c55a0eb4937a0af0836b6dcba8ffe360a7984e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53383",
+					"10.65.0.27:53383",
+					"172.17.0.1:53383",
+					"172.18.0.1:53383",
+					"172.19.0.1:53383"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:55:41.841879201Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         439650908341143,
+				"StableID":   "nJCsFGt7S411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9187b6935a7f5a2955d457da066d16bec150d85f25002861ddac225194877f32",
+				"DiscoKey":   "discokey:fc8d91c13f05343f595daf2a52d78e6e64abe4971f3e3ded5088a169f09d8633",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41382",
+					"10.65.0.27:41382",
+					"172.17.0.1:41382",
+					"172.18.0.1:41382",
+					"172.19.0.1:41382"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:55:42.370384886Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1290217121610877,
+				"StableID":   "nSRxtKpL5B11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d284444294f36b421768b987b62fe6b03307f56f233ae6d854814829e39a755",
+				"DiscoKey":   "discokey:5923aeff60127e1f66028f50952bf3c2c972ede9e78f6c559015e56b964e2616",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43819",
+					"10.65.0.27:43819",
+					"172.17.0.1:43819",
+					"172.18.0.1:43819",
+					"172.19.0.1:43819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:55:42.908263303Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8624285660216814,
+				"StableID":   "nmAFKtMxLA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ebf02a7aa5aa85c6968b649e2fdebb1aee88acc64a8479e9988788946480706c",
+				"DiscoKey":   "discokey:f592f6483412a50c44ae0465a6807449d5404279addb598085a165e01306c426",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42072",
+					"10.65.0.27:42072",
+					"172.17.0.1:42072",
+					"172.18.0.1:42072",
+					"172.19.0.1:42072"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:55:43.444763987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2303406886056769,
+				"StableID":   "nzsisPbDzJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d90fe5950a4662dee384235546263c96a392bc4f8ab284e4258caae05f9d462",
+				"DiscoKey":   "discokey:92d16765039f7b98f91926c6a31731cd992d5c97f5de0e57f7d6c498cf605f12",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39876",
+					"10.65.0.27:39876",
+					"172.17.0.1:39876",
+					"172.18.0.1:39876",
+					"172.19.0.1:39876"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:55:43.9799932Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6392821879123614,
+				"StableID":   "ndpYGFbKvr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b7d9d32b7ea659275d316f9760a9d37aa6d181e07fc6538f1fb14f9318a31b13",
+				"DiscoKey":   "discokey:7db39b748e818981c1997c6ebcee20f149985c2a8060e0f2be4eda3a9019545c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50063",
+					"10.65.0.27:50063",
+					"172.17.0.1:50063",
+					"172.18.0.1:50063",
+					"172.19.0.1:50063"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:55:44.524467076Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2393276862151458,
+				"StableID":   "n9tAvqKvgK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fd1726462aef22d065170d4dbfccab593cd48e5d3b155b015b3fe98f5c8a1e0d",
+				"DiscoKey":   "discokey:9d46b7f634a519d581941a59353decde2ae9234d610afd1434fe477a339e123b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:49307",
+					"10.65.0.27:49307",
+					"172.17.0.1:49307",
+					"172.18.0.1:49307",
+					"172.19.0.1:49307"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:55:45.073999116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4294369728739762,
+				"StableID":   "nsjvY2pvXa11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e961eb4cf72d39bbac6a456646cfbc704fe2b1ecf903839d7df63a9d0a4c5911",
+				"DiscoKey":   "discokey:91aa1369ff4114dac10baf07d7905013fc852b3f362ea53c6384f73568428a45",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48236",
+					"10.65.0.27:48236",
+					"172.17.0.1:48236",
+					"172.18.0.1:48236",
+					"172.19.0.1:48236"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:55:45.605607837Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3663638698618420,
+				"StableID":   "nHmpFRaGcV11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:edf9559d3938e9530b86321c6e10c49f367d457655f02e4e7653c008bfc74070",
+				"KeyExpiry":  "2026-11-08T21:55:46Z",
+				"DiscoKey":   "discokey:9bbc122047ca08b148211c091725beecd7934131d82d6180e598bb2b889cc007",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:58676",
+					"10.65.0.27:58676",
+					"172.17.0.1:58676",
+					"172.18.0.1:58676",
+					"172.19.0.1:58676"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:55:46.147618174Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8354902190844601,
+				"StableID":   "nnw1bZ7xE821CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ffb380ef172c63d8675ef384cb1aa23376dae13d0562a71e4925b8c4900ff94b",
+				"KeyExpiry":  "2026-11-08T21:55:46Z",
+				"DiscoKey":   "discokey:f760ccafef0f31af01190dc297e10ea4fff59582758237c82e90e1cd23316b08",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51903",
+					"10.65.0.27:51903",
+					"172.17.0.1:51903",
+					"172.18.0.1:51903",
+					"172.19.0.1:51903"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:55:46.689299341Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6344020514535147,
+				"StableID":   "nSgvnMfDYr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:4c0ba639676a594cb1180dc2bf58a318328408e53c4af37afb9d081f518e8450",
+				"KeyExpiry":  "2026-11-08T21:55:47Z",
+				"DiscoKey":   "discokey:f801630498725d8f04d852d3648a9d3b4451ebe38289defe8590416206f0b11e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53570",
+					"10.65.0.27:53570",
+					"172.17.0.1:53570",
+					"172.18.0.1:53570",
+					"172.19.0.1:53570"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:55:47.236375997Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3741301672973853": {
+				"ID":          3741301672973853,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8624285660216814,
+				"StableID":   "nmAFKtMxLA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       8624285660216814,
+				"Key":        "nodekey:ebf02a7aa5aa85c6968b649e2fdebb1aee88acc64a8479e9988788946480706c",
+				"DiscoKey":   "discokey:f592f6483412a50c44ae0465a6807449d5404279addb598085a165e01306c426",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42072",
+					"10.65.0.27:42072",
+					"172.17.0.1:42072",
+					"172.18.0.1:42072",
+					"172.19.0.1:42072"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:55:43.444763987Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ebf02a7aa5aa85c6968b649e2fdebb1aee88acc64a8479e9988788946480706c",
+			"MachineKey": "mkey:cd5c3e6f666173992fe51b72a6f805a75cb4866229d61951ada1bdf1738d7c4a",
+			"Peers": [{
+				"ID":         2132112232116195,
+				"StableID":   "nJUrsRydeH11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7bdd423d434e43abbf796cd12a165b5953389a16147bfefcb99e049f46a90f3a",
+				"DiscoKey":   "discokey:854fe607ee959d44ae2a4e01c14888d8630e3d42e899ee18926d8d41ba2bce67",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44016",
+					"10.65.0.27:44016",
+					"172.17.0.1:44016",
+					"172.18.0.1:44016",
+					"172.19.0.1:44016"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:55:39.698686052Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4336320486250097,
+				"StableID":   "nr7cLbnvra11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3d54a12ba3b2463dd18b59b73ebab7bdb784761f6bbdd67e2e28842eda6f34b",
+				"DiscoKey":   "discokey:100042ec3269a61e0e89dfda2efef78f3b71be1983b5cac4f7ee6c210aedd873",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50831",
+					"10.65.0.27:50831",
+					"172.17.0.1:50831",
+					"172.18.0.1:50831",
+					"172.19.0.1:50831"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:55:40.226591347Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3741301672973853,
+				"StableID":   "ntEbMkeSDW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3f3d7e0af39fa685771a5fadf4eefedda78fda9f1805f08dcb0f5a5bb3b8cc56",
+				"DiscoKey":   "discokey:01c267d3724254e1111e3e14e3cb473684067e178f50d0aa45470620db9b0824",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57706",
+					"10.65.0.27:57706",
+					"172.17.0.1:57706",
+					"172.18.0.1:57706",
+					"172.19.0.1:57706"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:55:40.771840987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5394370143918161,
+				"StableID":   "nSKzTUx78j11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c3e0b2cd72a3122fbe6621fc75a7447a586833cbcf65f6dab21f1a804eafc01",
+				"DiscoKey":   "discokey:bcd15c7ad4dc1556c116d9d902251f62598ccd27af22d343c58760ef8fcad54f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42134",
+					"10.65.0.27:42134",
+					"172.17.0.1:42134",
+					"172.18.0.1:42134",
+					"172.19.0.1:42134"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:55:41.303990369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1927300156723223,
+				"StableID":   "n8hy7cus3G11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:189b619364d3d6d3004bc847844d0436660a9bb855090fdbc4444b6d09562068",
+				"DiscoKey":   "discokey:9445c6e04cc897e23292586bd9c55a0eb4937a0af0836b6dcba8ffe360a7984e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53383",
+					"10.65.0.27:53383",
+					"172.17.0.1:53383",
+					"172.18.0.1:53383",
+					"172.19.0.1:53383"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:55:41.841879201Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         439650908341143,
+				"StableID":   "nJCsFGt7S411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9187b6935a7f5a2955d457da066d16bec150d85f25002861ddac225194877f32",
+				"DiscoKey":   "discokey:fc8d91c13f05343f595daf2a52d78e6e64abe4971f3e3ded5088a169f09d8633",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41382",
+					"10.65.0.27:41382",
+					"172.17.0.1:41382",
+					"172.18.0.1:41382",
+					"172.19.0.1:41382"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:55:42.370384886Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1290217121610877,
+				"StableID":   "nSRxtKpL5B11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d284444294f36b421768b987b62fe6b03307f56f233ae6d854814829e39a755",
+				"DiscoKey":   "discokey:5923aeff60127e1f66028f50952bf3c2c972ede9e78f6c559015e56b964e2616",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43819",
+					"10.65.0.27:43819",
+					"172.17.0.1:43819",
+					"172.18.0.1:43819",
+					"172.19.0.1:43819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:55:42.908263303Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2303406886056769,
+				"StableID":   "nzsisPbDzJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d90fe5950a4662dee384235546263c96a392bc4f8ab284e4258caae05f9d462",
+				"DiscoKey":   "discokey:92d16765039f7b98f91926c6a31731cd992d5c97f5de0e57f7d6c498cf605f12",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39876",
+					"10.65.0.27:39876",
+					"172.17.0.1:39876",
+					"172.18.0.1:39876",
+					"172.19.0.1:39876"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:55:43.9799932Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6392821879123614,
+				"StableID":   "ndpYGFbKvr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b7d9d32b7ea659275d316f9760a9d37aa6d181e07fc6538f1fb14f9318a31b13",
+				"DiscoKey":   "discokey:7db39b748e818981c1997c6ebcee20f149985c2a8060e0f2be4eda3a9019545c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50063",
+					"10.65.0.27:50063",
+					"172.17.0.1:50063",
+					"172.18.0.1:50063",
+					"172.19.0.1:50063"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:55:44.524467076Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2393276862151458,
+				"StableID":   "n9tAvqKvgK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fd1726462aef22d065170d4dbfccab593cd48e5d3b155b015b3fe98f5c8a1e0d",
+				"DiscoKey":   "discokey:9d46b7f634a519d581941a59353decde2ae9234d610afd1434fe477a339e123b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:49307",
+					"10.65.0.27:49307",
+					"172.17.0.1:49307",
+					"172.18.0.1:49307",
+					"172.19.0.1:49307"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:55:45.073999116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4294369728739762,
+				"StableID":   "nsjvY2pvXa11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e961eb4cf72d39bbac6a456646cfbc704fe2b1ecf903839d7df63a9d0a4c5911",
+				"DiscoKey":   "discokey:91aa1369ff4114dac10baf07d7905013fc852b3f362ea53c6384f73568428a45",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48236",
+					"10.65.0.27:48236",
+					"172.17.0.1:48236",
+					"172.18.0.1:48236",
+					"172.19.0.1:48236"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:55:45.605607837Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3663638698618420,
+				"StableID":   "nHmpFRaGcV11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:edf9559d3938e9530b86321c6e10c49f367d457655f02e4e7653c008bfc74070",
+				"KeyExpiry":  "2026-11-08T21:55:46Z",
+				"DiscoKey":   "discokey:9bbc122047ca08b148211c091725beecd7934131d82d6180e598bb2b889cc007",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:58676",
+					"10.65.0.27:58676",
+					"172.17.0.1:58676",
+					"172.18.0.1:58676",
+					"172.19.0.1:58676"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:55:46.147618174Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8354902190844601,
+				"StableID":   "nnw1bZ7xE821CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ffb380ef172c63d8675ef384cb1aa23376dae13d0562a71e4925b8c4900ff94b",
+				"KeyExpiry":  "2026-11-08T21:55:46Z",
+				"DiscoKey":   "discokey:f760ccafef0f31af01190dc297e10ea4fff59582758237c82e90e1cd23316b08",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51903",
+					"10.65.0.27:51903",
+					"172.17.0.1:51903",
+					"172.18.0.1:51903",
+					"172.19.0.1:51903"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:55:46.689299341Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6344020514535147,
+				"StableID":   "nSgvnMfDYr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:4c0ba639676a594cb1180dc2bf58a318328408e53c4af37afb9d081f518e8450",
+				"KeyExpiry":  "2026-11-08T21:55:47Z",
+				"DiscoKey":   "discokey:f801630498725d8f04d852d3648a9d3b4451ebe38289defe8590416206f0b11e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53570",
+					"10.65.0.27:53570",
+					"172.17.0.1:53570",
+					"172.18.0.1:53570",
+					"172.19.0.1:53570"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:55:47.236375997Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8624285660216814": {
+				"ID":          8624285660216814,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3663638698618420,
+				"StableID":   "nHmpFRaGcV11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:edf9559d3938e9530b86321c6e10c49f367d457655f02e4e7653c008bfc74070",
+				"KeyExpiry":  "2026-11-08T21:55:46Z",
+				"DiscoKey":   "discokey:9bbc122047ca08b148211c091725beecd7934131d82d6180e598bb2b889cc007",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:58676",
+					"10.65.0.27:58676",
+					"172.17.0.1:58676",
+					"172.18.0.1:58676",
+					"172.19.0.1:58676"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:55:46.147618174Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:edf9559d3938e9530b86321c6e10c49f367d457655f02e4e7653c008bfc74070",
+			"MachineKey": "mkey:88754d6c9be83a0f3affbca401986230b14dfd24b911349eb44055748c02ab53",
+			"Peers": [{
+				"ID":         2132112232116195,
+				"StableID":   "nJUrsRydeH11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7bdd423d434e43abbf796cd12a165b5953389a16147bfefcb99e049f46a90f3a",
+				"DiscoKey":   "discokey:854fe607ee959d44ae2a4e01c14888d8630e3d42e899ee18926d8d41ba2bce67",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44016",
+					"10.65.0.27:44016",
+					"172.17.0.1:44016",
+					"172.18.0.1:44016",
+					"172.19.0.1:44016"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:55:39.698686052Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4336320486250097,
+				"StableID":   "nr7cLbnvra11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3d54a12ba3b2463dd18b59b73ebab7bdb784761f6bbdd67e2e28842eda6f34b",
+				"DiscoKey":   "discokey:100042ec3269a61e0e89dfda2efef78f3b71be1983b5cac4f7ee6c210aedd873",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50831",
+					"10.65.0.27:50831",
+					"172.17.0.1:50831",
+					"172.18.0.1:50831",
+					"172.19.0.1:50831"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:55:40.226591347Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3741301672973853,
+				"StableID":   "ntEbMkeSDW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3f3d7e0af39fa685771a5fadf4eefedda78fda9f1805f08dcb0f5a5bb3b8cc56",
+				"DiscoKey":   "discokey:01c267d3724254e1111e3e14e3cb473684067e178f50d0aa45470620db9b0824",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57706",
+					"10.65.0.27:57706",
+					"172.17.0.1:57706",
+					"172.18.0.1:57706",
+					"172.19.0.1:57706"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:55:40.771840987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5394370143918161,
+				"StableID":   "nSKzTUx78j11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c3e0b2cd72a3122fbe6621fc75a7447a586833cbcf65f6dab21f1a804eafc01",
+				"DiscoKey":   "discokey:bcd15c7ad4dc1556c116d9d902251f62598ccd27af22d343c58760ef8fcad54f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42134",
+					"10.65.0.27:42134",
+					"172.17.0.1:42134",
+					"172.18.0.1:42134",
+					"172.19.0.1:42134"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:55:41.303990369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1927300156723223,
+				"StableID":   "n8hy7cus3G11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:189b619364d3d6d3004bc847844d0436660a9bb855090fdbc4444b6d09562068",
+				"DiscoKey":   "discokey:9445c6e04cc897e23292586bd9c55a0eb4937a0af0836b6dcba8ffe360a7984e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53383",
+					"10.65.0.27:53383",
+					"172.17.0.1:53383",
+					"172.18.0.1:53383",
+					"172.19.0.1:53383"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:55:41.841879201Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         439650908341143,
+				"StableID":   "nJCsFGt7S411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9187b6935a7f5a2955d457da066d16bec150d85f25002861ddac225194877f32",
+				"DiscoKey":   "discokey:fc8d91c13f05343f595daf2a52d78e6e64abe4971f3e3ded5088a169f09d8633",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41382",
+					"10.65.0.27:41382",
+					"172.17.0.1:41382",
+					"172.18.0.1:41382",
+					"172.19.0.1:41382"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:55:42.370384886Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1290217121610877,
+				"StableID":   "nSRxtKpL5B11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d284444294f36b421768b987b62fe6b03307f56f233ae6d854814829e39a755",
+				"DiscoKey":   "discokey:5923aeff60127e1f66028f50952bf3c2c972ede9e78f6c559015e56b964e2616",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43819",
+					"10.65.0.27:43819",
+					"172.17.0.1:43819",
+					"172.18.0.1:43819",
+					"172.19.0.1:43819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:55:42.908263303Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8624285660216814,
+				"StableID":   "nmAFKtMxLA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ebf02a7aa5aa85c6968b649e2fdebb1aee88acc64a8479e9988788946480706c",
+				"DiscoKey":   "discokey:f592f6483412a50c44ae0465a6807449d5404279addb598085a165e01306c426",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42072",
+					"10.65.0.27:42072",
+					"172.17.0.1:42072",
+					"172.18.0.1:42072",
+					"172.19.0.1:42072"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:55:43.444763987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2303406886056769,
+				"StableID":   "nzsisPbDzJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d90fe5950a4662dee384235546263c96a392bc4f8ab284e4258caae05f9d462",
+				"DiscoKey":   "discokey:92d16765039f7b98f91926c6a31731cd992d5c97f5de0e57f7d6c498cf605f12",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39876",
+					"10.65.0.27:39876",
+					"172.17.0.1:39876",
+					"172.18.0.1:39876",
+					"172.19.0.1:39876"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:55:43.9799932Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6392821879123614,
+				"StableID":   "ndpYGFbKvr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b7d9d32b7ea659275d316f9760a9d37aa6d181e07fc6538f1fb14f9318a31b13",
+				"DiscoKey":   "discokey:7db39b748e818981c1997c6ebcee20f149985c2a8060e0f2be4eda3a9019545c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50063",
+					"10.65.0.27:50063",
+					"172.17.0.1:50063",
+					"172.18.0.1:50063",
+					"172.19.0.1:50063"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:55:44.524467076Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2393276862151458,
+				"StableID":   "n9tAvqKvgK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fd1726462aef22d065170d4dbfccab593cd48e5d3b155b015b3fe98f5c8a1e0d",
+				"DiscoKey":   "discokey:9d46b7f634a519d581941a59353decde2ae9234d610afd1434fe477a339e123b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:49307",
+					"10.65.0.27:49307",
+					"172.17.0.1:49307",
+					"172.18.0.1:49307",
+					"172.19.0.1:49307"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:55:45.073999116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4294369728739762,
+				"StableID":   "nsjvY2pvXa11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e961eb4cf72d39bbac6a456646cfbc704fe2b1ecf903839d7df63a9d0a4c5911",
+				"DiscoKey":   "discokey:91aa1369ff4114dac10baf07d7905013fc852b3f362ea53c6384f73568428a45",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48236",
+					"10.65.0.27:48236",
+					"172.17.0.1:48236",
+					"172.18.0.1:48236",
+					"172.19.0.1:48236"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:55:45.605607837Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8354902190844601,
+				"StableID":   "nnw1bZ7xE821CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ffb380ef172c63d8675ef384cb1aa23376dae13d0562a71e4925b8c4900ff94b",
+				"KeyExpiry":  "2026-11-08T21:55:46Z",
+				"DiscoKey":   "discokey:f760ccafef0f31af01190dc297e10ea4fff59582758237c82e90e1cd23316b08",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51903",
+					"10.65.0.27:51903",
+					"172.17.0.1:51903",
+					"172.18.0.1:51903",
+					"172.19.0.1:51903"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:55:46.689299341Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6344020514535147,
+				"StableID":   "nSgvnMfDYr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:4c0ba639676a594cb1180dc2bf58a318328408e53c4af37afb9d081f518e8450",
+				"KeyExpiry":  "2026-11-08T21:55:47Z",
+				"DiscoKey":   "discokey:f801630498725d8f04d852d3648a9d3b4451ebe38289defe8590416206f0b11e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53570",
+					"10.65.0.27:53570",
+					"172.17.0.1:53570",
+					"172.18.0.1:53570",
+					"172.19.0.1:53570"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:55:47.236375997Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2393276862151458,
+				"StableID":   "n9tAvqKvgK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       2393276862151458,
+				"Key":        "nodekey:fd1726462aef22d065170d4dbfccab593cd48e5d3b155b015b3fe98f5c8a1e0d",
+				"DiscoKey":   "discokey:9d46b7f634a519d581941a59353decde2ae9234d610afd1434fe477a339e123b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:49307",
+					"10.65.0.27:49307",
+					"172.17.0.1:49307",
+					"172.18.0.1:49307",
+					"172.19.0.1:49307"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:55:45.073999116Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:fd1726462aef22d065170d4dbfccab593cd48e5d3b155b015b3fe98f5c8a1e0d",
+			"MachineKey": "mkey:0c11980d7787e0dc7560e5544b63f19e852ed8b6d1fcfca6b60220e4b59ffa66",
+			"Peers": [{
+				"ID":         2132112232116195,
+				"StableID":   "nJUrsRydeH11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7bdd423d434e43abbf796cd12a165b5953389a16147bfefcb99e049f46a90f3a",
+				"DiscoKey":   "discokey:854fe607ee959d44ae2a4e01c14888d8630e3d42e899ee18926d8d41ba2bce67",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44016",
+					"10.65.0.27:44016",
+					"172.17.0.1:44016",
+					"172.18.0.1:44016",
+					"172.19.0.1:44016"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:55:39.698686052Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4336320486250097,
+				"StableID":   "nr7cLbnvra11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3d54a12ba3b2463dd18b59b73ebab7bdb784761f6bbdd67e2e28842eda6f34b",
+				"DiscoKey":   "discokey:100042ec3269a61e0e89dfda2efef78f3b71be1983b5cac4f7ee6c210aedd873",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50831",
+					"10.65.0.27:50831",
+					"172.17.0.1:50831",
+					"172.18.0.1:50831",
+					"172.19.0.1:50831"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:55:40.226591347Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3741301672973853,
+				"StableID":   "ntEbMkeSDW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3f3d7e0af39fa685771a5fadf4eefedda78fda9f1805f08dcb0f5a5bb3b8cc56",
+				"DiscoKey":   "discokey:01c267d3724254e1111e3e14e3cb473684067e178f50d0aa45470620db9b0824",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57706",
+					"10.65.0.27:57706",
+					"172.17.0.1:57706",
+					"172.18.0.1:57706",
+					"172.19.0.1:57706"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:55:40.771840987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5394370143918161,
+				"StableID":   "nSKzTUx78j11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c3e0b2cd72a3122fbe6621fc75a7447a586833cbcf65f6dab21f1a804eafc01",
+				"DiscoKey":   "discokey:bcd15c7ad4dc1556c116d9d902251f62598ccd27af22d343c58760ef8fcad54f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42134",
+					"10.65.0.27:42134",
+					"172.17.0.1:42134",
+					"172.18.0.1:42134",
+					"172.19.0.1:42134"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:55:41.303990369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1927300156723223,
+				"StableID":   "n8hy7cus3G11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:189b619364d3d6d3004bc847844d0436660a9bb855090fdbc4444b6d09562068",
+				"DiscoKey":   "discokey:9445c6e04cc897e23292586bd9c55a0eb4937a0af0836b6dcba8ffe360a7984e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53383",
+					"10.65.0.27:53383",
+					"172.17.0.1:53383",
+					"172.18.0.1:53383",
+					"172.19.0.1:53383"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:55:41.841879201Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         439650908341143,
+				"StableID":   "nJCsFGt7S411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9187b6935a7f5a2955d457da066d16bec150d85f25002861ddac225194877f32",
+				"DiscoKey":   "discokey:fc8d91c13f05343f595daf2a52d78e6e64abe4971f3e3ded5088a169f09d8633",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41382",
+					"10.65.0.27:41382",
+					"172.17.0.1:41382",
+					"172.18.0.1:41382",
+					"172.19.0.1:41382"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:55:42.370384886Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1290217121610877,
+				"StableID":   "nSRxtKpL5B11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d284444294f36b421768b987b62fe6b03307f56f233ae6d854814829e39a755",
+				"DiscoKey":   "discokey:5923aeff60127e1f66028f50952bf3c2c972ede9e78f6c559015e56b964e2616",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43819",
+					"10.65.0.27:43819",
+					"172.17.0.1:43819",
+					"172.18.0.1:43819",
+					"172.19.0.1:43819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:55:42.908263303Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8624285660216814,
+				"StableID":   "nmAFKtMxLA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ebf02a7aa5aa85c6968b649e2fdebb1aee88acc64a8479e9988788946480706c",
+				"DiscoKey":   "discokey:f592f6483412a50c44ae0465a6807449d5404279addb598085a165e01306c426",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42072",
+					"10.65.0.27:42072",
+					"172.17.0.1:42072",
+					"172.18.0.1:42072",
+					"172.19.0.1:42072"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:55:43.444763987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2303406886056769,
+				"StableID":   "nzsisPbDzJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d90fe5950a4662dee384235546263c96a392bc4f8ab284e4258caae05f9d462",
+				"DiscoKey":   "discokey:92d16765039f7b98f91926c6a31731cd992d5c97f5de0e57f7d6c498cf605f12",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39876",
+					"10.65.0.27:39876",
+					"172.17.0.1:39876",
+					"172.18.0.1:39876",
+					"172.19.0.1:39876"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:55:43.9799932Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6392821879123614,
+				"StableID":   "ndpYGFbKvr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b7d9d32b7ea659275d316f9760a9d37aa6d181e07fc6538f1fb14f9318a31b13",
+				"DiscoKey":   "discokey:7db39b748e818981c1997c6ebcee20f149985c2a8060e0f2be4eda3a9019545c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50063",
+					"10.65.0.27:50063",
+					"172.17.0.1:50063",
+					"172.18.0.1:50063",
+					"172.19.0.1:50063"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:55:44.524467076Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4294369728739762,
+				"StableID":   "nsjvY2pvXa11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e961eb4cf72d39bbac6a456646cfbc704fe2b1ecf903839d7df63a9d0a4c5911",
+				"DiscoKey":   "discokey:91aa1369ff4114dac10baf07d7905013fc852b3f362ea53c6384f73568428a45",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48236",
+					"10.65.0.27:48236",
+					"172.17.0.1:48236",
+					"172.18.0.1:48236",
+					"172.19.0.1:48236"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:55:45.605607837Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3663638698618420,
+				"StableID":   "nHmpFRaGcV11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:edf9559d3938e9530b86321c6e10c49f367d457655f02e4e7653c008bfc74070",
+				"KeyExpiry":  "2026-11-08T21:55:46Z",
+				"DiscoKey":   "discokey:9bbc122047ca08b148211c091725beecd7934131d82d6180e598bb2b889cc007",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:58676",
+					"10.65.0.27:58676",
+					"172.17.0.1:58676",
+					"172.18.0.1:58676",
+					"172.19.0.1:58676"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:55:46.147618174Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8354902190844601,
+				"StableID":   "nnw1bZ7xE821CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ffb380ef172c63d8675ef384cb1aa23376dae13d0562a71e4925b8c4900ff94b",
+				"KeyExpiry":  "2026-11-08T21:55:46Z",
+				"DiscoKey":   "discokey:f760ccafef0f31af01190dc297e10ea4fff59582758237c82e90e1cd23316b08",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51903",
+					"10.65.0.27:51903",
+					"172.17.0.1:51903",
+					"172.18.0.1:51903",
+					"172.19.0.1:51903"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:55:46.689299341Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6344020514535147,
+				"StableID":   "nSgvnMfDYr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:4c0ba639676a594cb1180dc2bf58a318328408e53c4af37afb9d081f518e8450",
+				"KeyExpiry":  "2026-11-08T21:55:47Z",
+				"DiscoKey":   "discokey:f801630498725d8f04d852d3648a9d3b4451ebe38289defe8590416206f0b11e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53570",
+					"10.65.0.27:53570",
+					"172.17.0.1:53570",
+					"172.18.0.1:53570",
+					"172.19.0.1:53570"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:55:47.236375997Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2393276862151458": {
+				"ID":          2393276862151458,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4336320486250097,
+				"StableID":   "nr7cLbnvra11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       4336320486250097,
+				"Key":        "nodekey:e3d54a12ba3b2463dd18b59b73ebab7bdb784761f6bbdd67e2e28842eda6f34b",
+				"DiscoKey":   "discokey:100042ec3269a61e0e89dfda2efef78f3b71be1983b5cac4f7ee6c210aedd873",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50831",
+					"10.65.0.27:50831",
+					"172.17.0.1:50831",
+					"172.18.0.1:50831",
+					"172.19.0.1:50831"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:55:40.226591347Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e3d54a12ba3b2463dd18b59b73ebab7bdb784761f6bbdd67e2e28842eda6f34b",
+			"MachineKey": "mkey:2107dc6e1c12dedb6473be584f77dc30f9089f8cb1e31098025ec35f3829df3f",
+			"Peers": [{
+				"ID":         2132112232116195,
+				"StableID":   "nJUrsRydeH11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7bdd423d434e43abbf796cd12a165b5953389a16147bfefcb99e049f46a90f3a",
+				"DiscoKey":   "discokey:854fe607ee959d44ae2a4e01c14888d8630e3d42e899ee18926d8d41ba2bce67",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44016",
+					"10.65.0.27:44016",
+					"172.17.0.1:44016",
+					"172.18.0.1:44016",
+					"172.19.0.1:44016"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:55:39.698686052Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3741301672973853,
+				"StableID":   "ntEbMkeSDW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3f3d7e0af39fa685771a5fadf4eefedda78fda9f1805f08dcb0f5a5bb3b8cc56",
+				"DiscoKey":   "discokey:01c267d3724254e1111e3e14e3cb473684067e178f50d0aa45470620db9b0824",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57706",
+					"10.65.0.27:57706",
+					"172.17.0.1:57706",
+					"172.18.0.1:57706",
+					"172.19.0.1:57706"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:55:40.771840987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5394370143918161,
+				"StableID":   "nSKzTUx78j11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c3e0b2cd72a3122fbe6621fc75a7447a586833cbcf65f6dab21f1a804eafc01",
+				"DiscoKey":   "discokey:bcd15c7ad4dc1556c116d9d902251f62598ccd27af22d343c58760ef8fcad54f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42134",
+					"10.65.0.27:42134",
+					"172.17.0.1:42134",
+					"172.18.0.1:42134",
+					"172.19.0.1:42134"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:55:41.303990369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1927300156723223,
+				"StableID":   "n8hy7cus3G11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:189b619364d3d6d3004bc847844d0436660a9bb855090fdbc4444b6d09562068",
+				"DiscoKey":   "discokey:9445c6e04cc897e23292586bd9c55a0eb4937a0af0836b6dcba8ffe360a7984e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53383",
+					"10.65.0.27:53383",
+					"172.17.0.1:53383",
+					"172.18.0.1:53383",
+					"172.19.0.1:53383"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:55:41.841879201Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         439650908341143,
+				"StableID":   "nJCsFGt7S411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9187b6935a7f5a2955d457da066d16bec150d85f25002861ddac225194877f32",
+				"DiscoKey":   "discokey:fc8d91c13f05343f595daf2a52d78e6e64abe4971f3e3ded5088a169f09d8633",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41382",
+					"10.65.0.27:41382",
+					"172.17.0.1:41382",
+					"172.18.0.1:41382",
+					"172.19.0.1:41382"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:55:42.370384886Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1290217121610877,
+				"StableID":   "nSRxtKpL5B11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d284444294f36b421768b987b62fe6b03307f56f233ae6d854814829e39a755",
+				"DiscoKey":   "discokey:5923aeff60127e1f66028f50952bf3c2c972ede9e78f6c559015e56b964e2616",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43819",
+					"10.65.0.27:43819",
+					"172.17.0.1:43819",
+					"172.18.0.1:43819",
+					"172.19.0.1:43819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:55:42.908263303Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8624285660216814,
+				"StableID":   "nmAFKtMxLA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ebf02a7aa5aa85c6968b649e2fdebb1aee88acc64a8479e9988788946480706c",
+				"DiscoKey":   "discokey:f592f6483412a50c44ae0465a6807449d5404279addb598085a165e01306c426",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42072",
+					"10.65.0.27:42072",
+					"172.17.0.1:42072",
+					"172.18.0.1:42072",
+					"172.19.0.1:42072"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:55:43.444763987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2303406886056769,
+				"StableID":   "nzsisPbDzJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d90fe5950a4662dee384235546263c96a392bc4f8ab284e4258caae05f9d462",
+				"DiscoKey":   "discokey:92d16765039f7b98f91926c6a31731cd992d5c97f5de0e57f7d6c498cf605f12",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39876",
+					"10.65.0.27:39876",
+					"172.17.0.1:39876",
+					"172.18.0.1:39876",
+					"172.19.0.1:39876"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:55:43.9799932Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6392821879123614,
+				"StableID":   "ndpYGFbKvr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b7d9d32b7ea659275d316f9760a9d37aa6d181e07fc6538f1fb14f9318a31b13",
+				"DiscoKey":   "discokey:7db39b748e818981c1997c6ebcee20f149985c2a8060e0f2be4eda3a9019545c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50063",
+					"10.65.0.27:50063",
+					"172.17.0.1:50063",
+					"172.18.0.1:50063",
+					"172.19.0.1:50063"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:55:44.524467076Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2393276862151458,
+				"StableID":   "n9tAvqKvgK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fd1726462aef22d065170d4dbfccab593cd48e5d3b155b015b3fe98f5c8a1e0d",
+				"DiscoKey":   "discokey:9d46b7f634a519d581941a59353decde2ae9234d610afd1434fe477a339e123b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:49307",
+					"10.65.0.27:49307",
+					"172.17.0.1:49307",
+					"172.18.0.1:49307",
+					"172.19.0.1:49307"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:55:45.073999116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4294369728739762,
+				"StableID":   "nsjvY2pvXa11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e961eb4cf72d39bbac6a456646cfbc704fe2b1ecf903839d7df63a9d0a4c5911",
+				"DiscoKey":   "discokey:91aa1369ff4114dac10baf07d7905013fc852b3f362ea53c6384f73568428a45",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48236",
+					"10.65.0.27:48236",
+					"172.17.0.1:48236",
+					"172.18.0.1:48236",
+					"172.19.0.1:48236"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:55:45.605607837Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3663638698618420,
+				"StableID":   "nHmpFRaGcV11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:edf9559d3938e9530b86321c6e10c49f367d457655f02e4e7653c008bfc74070",
+				"KeyExpiry":  "2026-11-08T21:55:46Z",
+				"DiscoKey":   "discokey:9bbc122047ca08b148211c091725beecd7934131d82d6180e598bb2b889cc007",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:58676",
+					"10.65.0.27:58676",
+					"172.17.0.1:58676",
+					"172.18.0.1:58676",
+					"172.19.0.1:58676"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:55:46.147618174Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8354902190844601,
+				"StableID":   "nnw1bZ7xE821CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ffb380ef172c63d8675ef384cb1aa23376dae13d0562a71e4925b8c4900ff94b",
+				"KeyExpiry":  "2026-11-08T21:55:46Z",
+				"DiscoKey":   "discokey:f760ccafef0f31af01190dc297e10ea4fff59582758237c82e90e1cd23316b08",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51903",
+					"10.65.0.27:51903",
+					"172.17.0.1:51903",
+					"172.18.0.1:51903",
+					"172.19.0.1:51903"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:55:46.689299341Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6344020514535147,
+				"StableID":   "nSgvnMfDYr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:4c0ba639676a594cb1180dc2bf58a318328408e53c4af37afb9d081f518e8450",
+				"KeyExpiry":  "2026-11-08T21:55:47Z",
+				"DiscoKey":   "discokey:f801630498725d8f04d852d3648a9d3b4451ebe38289defe8590416206f0b11e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53570",
+					"10.65.0.27:53570",
+					"172.17.0.1:53570",
+					"172.18.0.1:53570",
+					"172.19.0.1:53570"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:55:47.236375997Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4336320486250097": {
+				"ID":          4336320486250097,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2132112232116195,
+				"StableID":   "nJUrsRydeH11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       2132112232116195,
+				"Key":        "nodekey:7bdd423d434e43abbf796cd12a165b5953389a16147bfefcb99e049f46a90f3a",
+				"DiscoKey":   "discokey:854fe607ee959d44ae2a4e01c14888d8630e3d42e899ee18926d8d41ba2bce67",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44016",
+					"10.65.0.27:44016",
+					"172.17.0.1:44016",
+					"172.18.0.1:44016",
+					"172.19.0.1:44016"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:55:39.698686052Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7bdd423d434e43abbf796cd12a165b5953389a16147bfefcb99e049f46a90f3a",
+			"MachineKey": "mkey:628767886e4ac46704658c9a20bdbd8f1876e1d65a4153313dc71b1dd9d7c33b",
+			"Peers": [{
+				"ID":         4336320486250097,
+				"StableID":   "nr7cLbnvra11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3d54a12ba3b2463dd18b59b73ebab7bdb784761f6bbdd67e2e28842eda6f34b",
+				"DiscoKey":   "discokey:100042ec3269a61e0e89dfda2efef78f3b71be1983b5cac4f7ee6c210aedd873",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50831",
+					"10.65.0.27:50831",
+					"172.17.0.1:50831",
+					"172.18.0.1:50831",
+					"172.19.0.1:50831"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:55:40.226591347Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3741301672973853,
+				"StableID":   "ntEbMkeSDW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3f3d7e0af39fa685771a5fadf4eefedda78fda9f1805f08dcb0f5a5bb3b8cc56",
+				"DiscoKey":   "discokey:01c267d3724254e1111e3e14e3cb473684067e178f50d0aa45470620db9b0824",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57706",
+					"10.65.0.27:57706",
+					"172.17.0.1:57706",
+					"172.18.0.1:57706",
+					"172.19.0.1:57706"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:55:40.771840987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5394370143918161,
+				"StableID":   "nSKzTUx78j11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c3e0b2cd72a3122fbe6621fc75a7447a586833cbcf65f6dab21f1a804eafc01",
+				"DiscoKey":   "discokey:bcd15c7ad4dc1556c116d9d902251f62598ccd27af22d343c58760ef8fcad54f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42134",
+					"10.65.0.27:42134",
+					"172.17.0.1:42134",
+					"172.18.0.1:42134",
+					"172.19.0.1:42134"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:55:41.303990369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1927300156723223,
+				"StableID":   "n8hy7cus3G11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:189b619364d3d6d3004bc847844d0436660a9bb855090fdbc4444b6d09562068",
+				"DiscoKey":   "discokey:9445c6e04cc897e23292586bd9c55a0eb4937a0af0836b6dcba8ffe360a7984e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53383",
+					"10.65.0.27:53383",
+					"172.17.0.1:53383",
+					"172.18.0.1:53383",
+					"172.19.0.1:53383"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:55:41.841879201Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         439650908341143,
+				"StableID":   "nJCsFGt7S411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9187b6935a7f5a2955d457da066d16bec150d85f25002861ddac225194877f32",
+				"DiscoKey":   "discokey:fc8d91c13f05343f595daf2a52d78e6e64abe4971f3e3ded5088a169f09d8633",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41382",
+					"10.65.0.27:41382",
+					"172.17.0.1:41382",
+					"172.18.0.1:41382",
+					"172.19.0.1:41382"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:55:42.370384886Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1290217121610877,
+				"StableID":   "nSRxtKpL5B11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d284444294f36b421768b987b62fe6b03307f56f233ae6d854814829e39a755",
+				"DiscoKey":   "discokey:5923aeff60127e1f66028f50952bf3c2c972ede9e78f6c559015e56b964e2616",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43819",
+					"10.65.0.27:43819",
+					"172.17.0.1:43819",
+					"172.18.0.1:43819",
+					"172.19.0.1:43819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:55:42.908263303Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8624285660216814,
+				"StableID":   "nmAFKtMxLA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ebf02a7aa5aa85c6968b649e2fdebb1aee88acc64a8479e9988788946480706c",
+				"DiscoKey":   "discokey:f592f6483412a50c44ae0465a6807449d5404279addb598085a165e01306c426",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42072",
+					"10.65.0.27:42072",
+					"172.17.0.1:42072",
+					"172.18.0.1:42072",
+					"172.19.0.1:42072"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:55:43.444763987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2303406886056769,
+				"StableID":   "nzsisPbDzJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d90fe5950a4662dee384235546263c96a392bc4f8ab284e4258caae05f9d462",
+				"DiscoKey":   "discokey:92d16765039f7b98f91926c6a31731cd992d5c97f5de0e57f7d6c498cf605f12",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39876",
+					"10.65.0.27:39876",
+					"172.17.0.1:39876",
+					"172.18.0.1:39876",
+					"172.19.0.1:39876"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:55:43.9799932Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6392821879123614,
+				"StableID":   "ndpYGFbKvr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b7d9d32b7ea659275d316f9760a9d37aa6d181e07fc6538f1fb14f9318a31b13",
+				"DiscoKey":   "discokey:7db39b748e818981c1997c6ebcee20f149985c2a8060e0f2be4eda3a9019545c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50063",
+					"10.65.0.27:50063",
+					"172.17.0.1:50063",
+					"172.18.0.1:50063",
+					"172.19.0.1:50063"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:55:44.524467076Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2393276862151458,
+				"StableID":   "n9tAvqKvgK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fd1726462aef22d065170d4dbfccab593cd48e5d3b155b015b3fe98f5c8a1e0d",
+				"DiscoKey":   "discokey:9d46b7f634a519d581941a59353decde2ae9234d610afd1434fe477a339e123b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:49307",
+					"10.65.0.27:49307",
+					"172.17.0.1:49307",
+					"172.18.0.1:49307",
+					"172.19.0.1:49307"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:55:45.073999116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4294369728739762,
+				"StableID":   "nsjvY2pvXa11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e961eb4cf72d39bbac6a456646cfbc704fe2b1ecf903839d7df63a9d0a4c5911",
+				"DiscoKey":   "discokey:91aa1369ff4114dac10baf07d7905013fc852b3f362ea53c6384f73568428a45",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48236",
+					"10.65.0.27:48236",
+					"172.17.0.1:48236",
+					"172.18.0.1:48236",
+					"172.19.0.1:48236"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:55:45.605607837Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3663638698618420,
+				"StableID":   "nHmpFRaGcV11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:edf9559d3938e9530b86321c6e10c49f367d457655f02e4e7653c008bfc74070",
+				"KeyExpiry":  "2026-11-08T21:55:46Z",
+				"DiscoKey":   "discokey:9bbc122047ca08b148211c091725beecd7934131d82d6180e598bb2b889cc007",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:58676",
+					"10.65.0.27:58676",
+					"172.17.0.1:58676",
+					"172.18.0.1:58676",
+					"172.19.0.1:58676"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:55:46.147618174Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8354902190844601,
+				"StableID":   "nnw1bZ7xE821CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ffb380ef172c63d8675ef384cb1aa23376dae13d0562a71e4925b8c4900ff94b",
+				"KeyExpiry":  "2026-11-08T21:55:46Z",
+				"DiscoKey":   "discokey:f760ccafef0f31af01190dc297e10ea4fff59582758237c82e90e1cd23316b08",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51903",
+					"10.65.0.27:51903",
+					"172.17.0.1:51903",
+					"172.18.0.1:51903",
+					"172.19.0.1:51903"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:55:46.689299341Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6344020514535147,
+				"StableID":   "nSgvnMfDYr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:4c0ba639676a594cb1180dc2bf58a318328408e53c4af37afb9d081f518e8450",
+				"KeyExpiry":  "2026-11-08T21:55:47Z",
+				"DiscoKey":   "discokey:f801630498725d8f04d852d3648a9d3b4451ebe38289defe8590416206f0b11e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53570",
+					"10.65.0.27:53570",
+					"172.17.0.1:53570",
+					"172.18.0.1:53570",
+					"172.19.0.1:53570"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:55:47.236375997Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2132112232116195": {
+				"ID":          2132112232116195,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1927300156723223,
+				"StableID":   "n8hy7cus3G11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1927300156723223,
+				"Key":        "nodekey:189b619364d3d6d3004bc847844d0436660a9bb855090fdbc4444b6d09562068",
+				"DiscoKey":   "discokey:9445c6e04cc897e23292586bd9c55a0eb4937a0af0836b6dcba8ffe360a7984e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53383",
+					"10.65.0.27:53383",
+					"172.17.0.1:53383",
+					"172.18.0.1:53383",
+					"172.19.0.1:53383"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:55:41.841879201Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:189b619364d3d6d3004bc847844d0436660a9bb855090fdbc4444b6d09562068",
+			"MachineKey": "mkey:90b71992326cecc11870dd61db26ff308bf26d8d96bab60e3b09f28598e3966f",
+			"Peers": [{
+				"ID":         2132112232116195,
+				"StableID":   "nJUrsRydeH11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7bdd423d434e43abbf796cd12a165b5953389a16147bfefcb99e049f46a90f3a",
+				"DiscoKey":   "discokey:854fe607ee959d44ae2a4e01c14888d8630e3d42e899ee18926d8d41ba2bce67",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44016",
+					"10.65.0.27:44016",
+					"172.17.0.1:44016",
+					"172.18.0.1:44016",
+					"172.19.0.1:44016"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:55:39.698686052Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4336320486250097,
+				"StableID":   "nr7cLbnvra11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3d54a12ba3b2463dd18b59b73ebab7bdb784761f6bbdd67e2e28842eda6f34b",
+				"DiscoKey":   "discokey:100042ec3269a61e0e89dfda2efef78f3b71be1983b5cac4f7ee6c210aedd873",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50831",
+					"10.65.0.27:50831",
+					"172.17.0.1:50831",
+					"172.18.0.1:50831",
+					"172.19.0.1:50831"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:55:40.226591347Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3741301672973853,
+				"StableID":   "ntEbMkeSDW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3f3d7e0af39fa685771a5fadf4eefedda78fda9f1805f08dcb0f5a5bb3b8cc56",
+				"DiscoKey":   "discokey:01c267d3724254e1111e3e14e3cb473684067e178f50d0aa45470620db9b0824",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57706",
+					"10.65.0.27:57706",
+					"172.17.0.1:57706",
+					"172.18.0.1:57706",
+					"172.19.0.1:57706"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:55:40.771840987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5394370143918161,
+				"StableID":   "nSKzTUx78j11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c3e0b2cd72a3122fbe6621fc75a7447a586833cbcf65f6dab21f1a804eafc01",
+				"DiscoKey":   "discokey:bcd15c7ad4dc1556c116d9d902251f62598ccd27af22d343c58760ef8fcad54f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42134",
+					"10.65.0.27:42134",
+					"172.17.0.1:42134",
+					"172.18.0.1:42134",
+					"172.19.0.1:42134"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:55:41.303990369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         439650908341143,
+				"StableID":   "nJCsFGt7S411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9187b6935a7f5a2955d457da066d16bec150d85f25002861ddac225194877f32",
+				"DiscoKey":   "discokey:fc8d91c13f05343f595daf2a52d78e6e64abe4971f3e3ded5088a169f09d8633",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41382",
+					"10.65.0.27:41382",
+					"172.17.0.1:41382",
+					"172.18.0.1:41382",
+					"172.19.0.1:41382"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:55:42.370384886Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1290217121610877,
+				"StableID":   "nSRxtKpL5B11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d284444294f36b421768b987b62fe6b03307f56f233ae6d854814829e39a755",
+				"DiscoKey":   "discokey:5923aeff60127e1f66028f50952bf3c2c972ede9e78f6c559015e56b964e2616",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43819",
+					"10.65.0.27:43819",
+					"172.17.0.1:43819",
+					"172.18.0.1:43819",
+					"172.19.0.1:43819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:55:42.908263303Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8624285660216814,
+				"StableID":   "nmAFKtMxLA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ebf02a7aa5aa85c6968b649e2fdebb1aee88acc64a8479e9988788946480706c",
+				"DiscoKey":   "discokey:f592f6483412a50c44ae0465a6807449d5404279addb598085a165e01306c426",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42072",
+					"10.65.0.27:42072",
+					"172.17.0.1:42072",
+					"172.18.0.1:42072",
+					"172.19.0.1:42072"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:55:43.444763987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2303406886056769,
+				"StableID":   "nzsisPbDzJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d90fe5950a4662dee384235546263c96a392bc4f8ab284e4258caae05f9d462",
+				"DiscoKey":   "discokey:92d16765039f7b98f91926c6a31731cd992d5c97f5de0e57f7d6c498cf605f12",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39876",
+					"10.65.0.27:39876",
+					"172.17.0.1:39876",
+					"172.18.0.1:39876",
+					"172.19.0.1:39876"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:55:43.9799932Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6392821879123614,
+				"StableID":   "ndpYGFbKvr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b7d9d32b7ea659275d316f9760a9d37aa6d181e07fc6538f1fb14f9318a31b13",
+				"DiscoKey":   "discokey:7db39b748e818981c1997c6ebcee20f149985c2a8060e0f2be4eda3a9019545c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50063",
+					"10.65.0.27:50063",
+					"172.17.0.1:50063",
+					"172.18.0.1:50063",
+					"172.19.0.1:50063"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:55:44.524467076Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2393276862151458,
+				"StableID":   "n9tAvqKvgK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fd1726462aef22d065170d4dbfccab593cd48e5d3b155b015b3fe98f5c8a1e0d",
+				"DiscoKey":   "discokey:9d46b7f634a519d581941a59353decde2ae9234d610afd1434fe477a339e123b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:49307",
+					"10.65.0.27:49307",
+					"172.17.0.1:49307",
+					"172.18.0.1:49307",
+					"172.19.0.1:49307"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:55:45.073999116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4294369728739762,
+				"StableID":   "nsjvY2pvXa11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e961eb4cf72d39bbac6a456646cfbc704fe2b1ecf903839d7df63a9d0a4c5911",
+				"DiscoKey":   "discokey:91aa1369ff4114dac10baf07d7905013fc852b3f362ea53c6384f73568428a45",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48236",
+					"10.65.0.27:48236",
+					"172.17.0.1:48236",
+					"172.18.0.1:48236",
+					"172.19.0.1:48236"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:55:45.605607837Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3663638698618420,
+				"StableID":   "nHmpFRaGcV11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:edf9559d3938e9530b86321c6e10c49f367d457655f02e4e7653c008bfc74070",
+				"KeyExpiry":  "2026-11-08T21:55:46Z",
+				"DiscoKey":   "discokey:9bbc122047ca08b148211c091725beecd7934131d82d6180e598bb2b889cc007",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:58676",
+					"10.65.0.27:58676",
+					"172.17.0.1:58676",
+					"172.18.0.1:58676",
+					"172.19.0.1:58676"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:55:46.147618174Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8354902190844601,
+				"StableID":   "nnw1bZ7xE821CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ffb380ef172c63d8675ef384cb1aa23376dae13d0562a71e4925b8c4900ff94b",
+				"KeyExpiry":  "2026-11-08T21:55:46Z",
+				"DiscoKey":   "discokey:f760ccafef0f31af01190dc297e10ea4fff59582758237c82e90e1cd23316b08",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51903",
+					"10.65.0.27:51903",
+					"172.17.0.1:51903",
+					"172.18.0.1:51903",
+					"172.19.0.1:51903"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:55:46.689299341Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6344020514535147,
+				"StableID":   "nSgvnMfDYr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:4c0ba639676a594cb1180dc2bf58a318328408e53c4af37afb9d081f518e8450",
+				"KeyExpiry":  "2026-11-08T21:55:47Z",
+				"DiscoKey":   "discokey:f801630498725d8f04d852d3648a9d3b4451ebe38289defe8590416206f0b11e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53570",
+					"10.65.0.27:53570",
+					"172.17.0.1:53570",
+					"172.18.0.1:53570",
+					"172.19.0.1:53570"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:55:47.236375997Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1927300156723223": {
+				"ID":          1927300156723223,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5394370143918161,
+				"StableID":   "nSKzTUx78j11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       5394370143918161,
+				"Key":        "nodekey:5c3e0b2cd72a3122fbe6621fc75a7447a586833cbcf65f6dab21f1a804eafc01",
+				"DiscoKey":   "discokey:bcd15c7ad4dc1556c116d9d902251f62598ccd27af22d343c58760ef8fcad54f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42134",
+					"10.65.0.27:42134",
+					"172.17.0.1:42134",
+					"172.18.0.1:42134",
+					"172.19.0.1:42134"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:55:41.303990369Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5c3e0b2cd72a3122fbe6621fc75a7447a586833cbcf65f6dab21f1a804eafc01",
+			"MachineKey": "mkey:f65d9b13dcc49e1d4a6b0cfe78d5f9444980767cfbeb07f9b734624ea98a921d",
+			"Peers": [{
+				"ID":         2132112232116195,
+				"StableID":   "nJUrsRydeH11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7bdd423d434e43abbf796cd12a165b5953389a16147bfefcb99e049f46a90f3a",
+				"DiscoKey":   "discokey:854fe607ee959d44ae2a4e01c14888d8630e3d42e899ee18926d8d41ba2bce67",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44016",
+					"10.65.0.27:44016",
+					"172.17.0.1:44016",
+					"172.18.0.1:44016",
+					"172.19.0.1:44016"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:55:39.698686052Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4336320486250097,
+				"StableID":   "nr7cLbnvra11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3d54a12ba3b2463dd18b59b73ebab7bdb784761f6bbdd67e2e28842eda6f34b",
+				"DiscoKey":   "discokey:100042ec3269a61e0e89dfda2efef78f3b71be1983b5cac4f7ee6c210aedd873",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50831",
+					"10.65.0.27:50831",
+					"172.17.0.1:50831",
+					"172.18.0.1:50831",
+					"172.19.0.1:50831"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:55:40.226591347Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3741301672973853,
+				"StableID":   "ntEbMkeSDW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3f3d7e0af39fa685771a5fadf4eefedda78fda9f1805f08dcb0f5a5bb3b8cc56",
+				"DiscoKey":   "discokey:01c267d3724254e1111e3e14e3cb473684067e178f50d0aa45470620db9b0824",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57706",
+					"10.65.0.27:57706",
+					"172.17.0.1:57706",
+					"172.18.0.1:57706",
+					"172.19.0.1:57706"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:55:40.771840987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1927300156723223,
+				"StableID":   "n8hy7cus3G11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:189b619364d3d6d3004bc847844d0436660a9bb855090fdbc4444b6d09562068",
+				"DiscoKey":   "discokey:9445c6e04cc897e23292586bd9c55a0eb4937a0af0836b6dcba8ffe360a7984e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53383",
+					"10.65.0.27:53383",
+					"172.17.0.1:53383",
+					"172.18.0.1:53383",
+					"172.19.0.1:53383"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:55:41.841879201Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         439650908341143,
+				"StableID":   "nJCsFGt7S411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9187b6935a7f5a2955d457da066d16bec150d85f25002861ddac225194877f32",
+				"DiscoKey":   "discokey:fc8d91c13f05343f595daf2a52d78e6e64abe4971f3e3ded5088a169f09d8633",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41382",
+					"10.65.0.27:41382",
+					"172.17.0.1:41382",
+					"172.18.0.1:41382",
+					"172.19.0.1:41382"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:55:42.370384886Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1290217121610877,
+				"StableID":   "nSRxtKpL5B11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d284444294f36b421768b987b62fe6b03307f56f233ae6d854814829e39a755",
+				"DiscoKey":   "discokey:5923aeff60127e1f66028f50952bf3c2c972ede9e78f6c559015e56b964e2616",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43819",
+					"10.65.0.27:43819",
+					"172.17.0.1:43819",
+					"172.18.0.1:43819",
+					"172.19.0.1:43819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:55:42.908263303Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8624285660216814,
+				"StableID":   "nmAFKtMxLA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ebf02a7aa5aa85c6968b649e2fdebb1aee88acc64a8479e9988788946480706c",
+				"DiscoKey":   "discokey:f592f6483412a50c44ae0465a6807449d5404279addb598085a165e01306c426",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42072",
+					"10.65.0.27:42072",
+					"172.17.0.1:42072",
+					"172.18.0.1:42072",
+					"172.19.0.1:42072"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:55:43.444763987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2303406886056769,
+				"StableID":   "nzsisPbDzJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d90fe5950a4662dee384235546263c96a392bc4f8ab284e4258caae05f9d462",
+				"DiscoKey":   "discokey:92d16765039f7b98f91926c6a31731cd992d5c97f5de0e57f7d6c498cf605f12",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39876",
+					"10.65.0.27:39876",
+					"172.17.0.1:39876",
+					"172.18.0.1:39876",
+					"172.19.0.1:39876"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:55:43.9799932Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6392821879123614,
+				"StableID":   "ndpYGFbKvr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b7d9d32b7ea659275d316f9760a9d37aa6d181e07fc6538f1fb14f9318a31b13",
+				"DiscoKey":   "discokey:7db39b748e818981c1997c6ebcee20f149985c2a8060e0f2be4eda3a9019545c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50063",
+					"10.65.0.27:50063",
+					"172.17.0.1:50063",
+					"172.18.0.1:50063",
+					"172.19.0.1:50063"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:55:44.524467076Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2393276862151458,
+				"StableID":   "n9tAvqKvgK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fd1726462aef22d065170d4dbfccab593cd48e5d3b155b015b3fe98f5c8a1e0d",
+				"DiscoKey":   "discokey:9d46b7f634a519d581941a59353decde2ae9234d610afd1434fe477a339e123b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:49307",
+					"10.65.0.27:49307",
+					"172.17.0.1:49307",
+					"172.18.0.1:49307",
+					"172.19.0.1:49307"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:55:45.073999116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4294369728739762,
+				"StableID":   "nsjvY2pvXa11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e961eb4cf72d39bbac6a456646cfbc704fe2b1ecf903839d7df63a9d0a4c5911",
+				"DiscoKey":   "discokey:91aa1369ff4114dac10baf07d7905013fc852b3f362ea53c6384f73568428a45",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48236",
+					"10.65.0.27:48236",
+					"172.17.0.1:48236",
+					"172.18.0.1:48236",
+					"172.19.0.1:48236"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:55:45.605607837Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3663638698618420,
+				"StableID":   "nHmpFRaGcV11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:edf9559d3938e9530b86321c6e10c49f367d457655f02e4e7653c008bfc74070",
+				"KeyExpiry":  "2026-11-08T21:55:46Z",
+				"DiscoKey":   "discokey:9bbc122047ca08b148211c091725beecd7934131d82d6180e598bb2b889cc007",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:58676",
+					"10.65.0.27:58676",
+					"172.17.0.1:58676",
+					"172.18.0.1:58676",
+					"172.19.0.1:58676"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:55:46.147618174Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8354902190844601,
+				"StableID":   "nnw1bZ7xE821CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ffb380ef172c63d8675ef384cb1aa23376dae13d0562a71e4925b8c4900ff94b",
+				"KeyExpiry":  "2026-11-08T21:55:46Z",
+				"DiscoKey":   "discokey:f760ccafef0f31af01190dc297e10ea4fff59582758237c82e90e1cd23316b08",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51903",
+					"10.65.0.27:51903",
+					"172.17.0.1:51903",
+					"172.18.0.1:51903",
+					"172.19.0.1:51903"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:55:46.689299341Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6344020514535147,
+				"StableID":   "nSgvnMfDYr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:4c0ba639676a594cb1180dc2bf58a318328408e53c4af37afb9d081f518e8450",
+				"KeyExpiry":  "2026-11-08T21:55:47Z",
+				"DiscoKey":   "discokey:f801630498725d8f04d852d3648a9d3b4451ebe38289defe8590416206f0b11e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53570",
+					"10.65.0.27:53570",
+					"172.17.0.1:53570",
+					"172.18.0.1:53570",
+					"172.19.0.1:53570"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:55:47.236375997Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5394370143918161": {
+				"ID":          5394370143918161,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1290217121610877,
+				"StableID":   "nSRxtKpL5B11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1290217121610877,
+				"Key":        "nodekey:5d284444294f36b421768b987b62fe6b03307f56f233ae6d854814829e39a755",
+				"DiscoKey":   "discokey:5923aeff60127e1f66028f50952bf3c2c972ede9e78f6c559015e56b964e2616",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43819",
+					"10.65.0.27:43819",
+					"172.17.0.1:43819",
+					"172.18.0.1:43819",
+					"172.19.0.1:43819"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:55:42.908263303Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5d284444294f36b421768b987b62fe6b03307f56f233ae6d854814829e39a755",
+			"MachineKey": "mkey:ac705ba105552dd872b5fbec8d719cf641b90180786a270864a20333a2bab048",
+			"Peers": [{
+				"ID":         2132112232116195,
+				"StableID":   "nJUrsRydeH11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7bdd423d434e43abbf796cd12a165b5953389a16147bfefcb99e049f46a90f3a",
+				"DiscoKey":   "discokey:854fe607ee959d44ae2a4e01c14888d8630e3d42e899ee18926d8d41ba2bce67",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44016",
+					"10.65.0.27:44016",
+					"172.17.0.1:44016",
+					"172.18.0.1:44016",
+					"172.19.0.1:44016"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:55:39.698686052Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4336320486250097,
+				"StableID":   "nr7cLbnvra11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3d54a12ba3b2463dd18b59b73ebab7bdb784761f6bbdd67e2e28842eda6f34b",
+				"DiscoKey":   "discokey:100042ec3269a61e0e89dfda2efef78f3b71be1983b5cac4f7ee6c210aedd873",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50831",
+					"10.65.0.27:50831",
+					"172.17.0.1:50831",
+					"172.18.0.1:50831",
+					"172.19.0.1:50831"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:55:40.226591347Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3741301672973853,
+				"StableID":   "ntEbMkeSDW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3f3d7e0af39fa685771a5fadf4eefedda78fda9f1805f08dcb0f5a5bb3b8cc56",
+				"DiscoKey":   "discokey:01c267d3724254e1111e3e14e3cb473684067e178f50d0aa45470620db9b0824",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57706",
+					"10.65.0.27:57706",
+					"172.17.0.1:57706",
+					"172.18.0.1:57706",
+					"172.19.0.1:57706"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:55:40.771840987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5394370143918161,
+				"StableID":   "nSKzTUx78j11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c3e0b2cd72a3122fbe6621fc75a7447a586833cbcf65f6dab21f1a804eafc01",
+				"DiscoKey":   "discokey:bcd15c7ad4dc1556c116d9d902251f62598ccd27af22d343c58760ef8fcad54f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42134",
+					"10.65.0.27:42134",
+					"172.17.0.1:42134",
+					"172.18.0.1:42134",
+					"172.19.0.1:42134"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:55:41.303990369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1927300156723223,
+				"StableID":   "n8hy7cus3G11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:189b619364d3d6d3004bc847844d0436660a9bb855090fdbc4444b6d09562068",
+				"DiscoKey":   "discokey:9445c6e04cc897e23292586bd9c55a0eb4937a0af0836b6dcba8ffe360a7984e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53383",
+					"10.65.0.27:53383",
+					"172.17.0.1:53383",
+					"172.18.0.1:53383",
+					"172.19.0.1:53383"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:55:41.841879201Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         439650908341143,
+				"StableID":   "nJCsFGt7S411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9187b6935a7f5a2955d457da066d16bec150d85f25002861ddac225194877f32",
+				"DiscoKey":   "discokey:fc8d91c13f05343f595daf2a52d78e6e64abe4971f3e3ded5088a169f09d8633",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41382",
+					"10.65.0.27:41382",
+					"172.17.0.1:41382",
+					"172.18.0.1:41382",
+					"172.19.0.1:41382"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:55:42.370384886Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8624285660216814,
+				"StableID":   "nmAFKtMxLA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ebf02a7aa5aa85c6968b649e2fdebb1aee88acc64a8479e9988788946480706c",
+				"DiscoKey":   "discokey:f592f6483412a50c44ae0465a6807449d5404279addb598085a165e01306c426",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42072",
+					"10.65.0.27:42072",
+					"172.17.0.1:42072",
+					"172.18.0.1:42072",
+					"172.19.0.1:42072"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:55:43.444763987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2303406886056769,
+				"StableID":   "nzsisPbDzJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d90fe5950a4662dee384235546263c96a392bc4f8ab284e4258caae05f9d462",
+				"DiscoKey":   "discokey:92d16765039f7b98f91926c6a31731cd992d5c97f5de0e57f7d6c498cf605f12",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39876",
+					"10.65.0.27:39876",
+					"172.17.0.1:39876",
+					"172.18.0.1:39876",
+					"172.19.0.1:39876"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:55:43.9799932Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6392821879123614,
+				"StableID":   "ndpYGFbKvr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b7d9d32b7ea659275d316f9760a9d37aa6d181e07fc6538f1fb14f9318a31b13",
+				"DiscoKey":   "discokey:7db39b748e818981c1997c6ebcee20f149985c2a8060e0f2be4eda3a9019545c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50063",
+					"10.65.0.27:50063",
+					"172.17.0.1:50063",
+					"172.18.0.1:50063",
+					"172.19.0.1:50063"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:55:44.524467076Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2393276862151458,
+				"StableID":   "n9tAvqKvgK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fd1726462aef22d065170d4dbfccab593cd48e5d3b155b015b3fe98f5c8a1e0d",
+				"DiscoKey":   "discokey:9d46b7f634a519d581941a59353decde2ae9234d610afd1434fe477a339e123b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:49307",
+					"10.65.0.27:49307",
+					"172.17.0.1:49307",
+					"172.18.0.1:49307",
+					"172.19.0.1:49307"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:55:45.073999116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4294369728739762,
+				"StableID":   "nsjvY2pvXa11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e961eb4cf72d39bbac6a456646cfbc704fe2b1ecf903839d7df63a9d0a4c5911",
+				"DiscoKey":   "discokey:91aa1369ff4114dac10baf07d7905013fc852b3f362ea53c6384f73568428a45",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48236",
+					"10.65.0.27:48236",
+					"172.17.0.1:48236",
+					"172.18.0.1:48236",
+					"172.19.0.1:48236"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:55:45.605607837Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3663638698618420,
+				"StableID":   "nHmpFRaGcV11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:edf9559d3938e9530b86321c6e10c49f367d457655f02e4e7653c008bfc74070",
+				"KeyExpiry":  "2026-11-08T21:55:46Z",
+				"DiscoKey":   "discokey:9bbc122047ca08b148211c091725beecd7934131d82d6180e598bb2b889cc007",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:58676",
+					"10.65.0.27:58676",
+					"172.17.0.1:58676",
+					"172.18.0.1:58676",
+					"172.19.0.1:58676"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:55:46.147618174Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8354902190844601,
+				"StableID":   "nnw1bZ7xE821CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ffb380ef172c63d8675ef384cb1aa23376dae13d0562a71e4925b8c4900ff94b",
+				"KeyExpiry":  "2026-11-08T21:55:46Z",
+				"DiscoKey":   "discokey:f760ccafef0f31af01190dc297e10ea4fff59582758237c82e90e1cd23316b08",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51903",
+					"10.65.0.27:51903",
+					"172.17.0.1:51903",
+					"172.18.0.1:51903",
+					"172.19.0.1:51903"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:55:46.689299341Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6344020514535147,
+				"StableID":   "nSgvnMfDYr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:4c0ba639676a594cb1180dc2bf58a318328408e53c4af37afb9d081f518e8450",
+				"KeyExpiry":  "2026-11-08T21:55:47Z",
+				"DiscoKey":   "discokey:f801630498725d8f04d852d3648a9d3b4451ebe38289defe8590416206f0b11e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53570",
+					"10.65.0.27:53570",
+					"172.17.0.1:53570",
+					"172.18.0.1:53570",
+					"172.19.0.1:53570"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:55:47.236375997Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1290217121610877": {
+				"ID":          1290217121610877,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2303406886056769,
+				"StableID":   "nzsisPbDzJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       2303406886056769,
+				"Key":        "nodekey:3d90fe5950a4662dee384235546263c96a392bc4f8ab284e4258caae05f9d462",
+				"DiscoKey":   "discokey:92d16765039f7b98f91926c6a31731cd992d5c97f5de0e57f7d6c498cf605f12",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39876",
+					"10.65.0.27:39876",
+					"172.17.0.1:39876",
+					"172.18.0.1:39876",
+					"172.19.0.1:39876"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:55:43.9799932Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3d90fe5950a4662dee384235546263c96a392bc4f8ab284e4258caae05f9d462",
+			"MachineKey": "mkey:f45dc71cb9fd520966f7a49417128840e68838a5af4c84b6c44599155378e65e",
+			"Peers": [{
+				"ID":         2132112232116195,
+				"StableID":   "nJUrsRydeH11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7bdd423d434e43abbf796cd12a165b5953389a16147bfefcb99e049f46a90f3a",
+				"DiscoKey":   "discokey:854fe607ee959d44ae2a4e01c14888d8630e3d42e899ee18926d8d41ba2bce67",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44016",
+					"10.65.0.27:44016",
+					"172.17.0.1:44016",
+					"172.18.0.1:44016",
+					"172.19.0.1:44016"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:55:39.698686052Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4336320486250097,
+				"StableID":   "nr7cLbnvra11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3d54a12ba3b2463dd18b59b73ebab7bdb784761f6bbdd67e2e28842eda6f34b",
+				"DiscoKey":   "discokey:100042ec3269a61e0e89dfda2efef78f3b71be1983b5cac4f7ee6c210aedd873",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50831",
+					"10.65.0.27:50831",
+					"172.17.0.1:50831",
+					"172.18.0.1:50831",
+					"172.19.0.1:50831"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:55:40.226591347Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3741301672973853,
+				"StableID":   "ntEbMkeSDW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3f3d7e0af39fa685771a5fadf4eefedda78fda9f1805f08dcb0f5a5bb3b8cc56",
+				"DiscoKey":   "discokey:01c267d3724254e1111e3e14e3cb473684067e178f50d0aa45470620db9b0824",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57706",
+					"10.65.0.27:57706",
+					"172.17.0.1:57706",
+					"172.18.0.1:57706",
+					"172.19.0.1:57706"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:55:40.771840987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5394370143918161,
+				"StableID":   "nSKzTUx78j11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c3e0b2cd72a3122fbe6621fc75a7447a586833cbcf65f6dab21f1a804eafc01",
+				"DiscoKey":   "discokey:bcd15c7ad4dc1556c116d9d902251f62598ccd27af22d343c58760ef8fcad54f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42134",
+					"10.65.0.27:42134",
+					"172.17.0.1:42134",
+					"172.18.0.1:42134",
+					"172.19.0.1:42134"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:55:41.303990369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1927300156723223,
+				"StableID":   "n8hy7cus3G11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:189b619364d3d6d3004bc847844d0436660a9bb855090fdbc4444b6d09562068",
+				"DiscoKey":   "discokey:9445c6e04cc897e23292586bd9c55a0eb4937a0af0836b6dcba8ffe360a7984e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53383",
+					"10.65.0.27:53383",
+					"172.17.0.1:53383",
+					"172.18.0.1:53383",
+					"172.19.0.1:53383"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:55:41.841879201Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         439650908341143,
+				"StableID":   "nJCsFGt7S411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9187b6935a7f5a2955d457da066d16bec150d85f25002861ddac225194877f32",
+				"DiscoKey":   "discokey:fc8d91c13f05343f595daf2a52d78e6e64abe4971f3e3ded5088a169f09d8633",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41382",
+					"10.65.0.27:41382",
+					"172.17.0.1:41382",
+					"172.18.0.1:41382",
+					"172.19.0.1:41382"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:55:42.370384886Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1290217121610877,
+				"StableID":   "nSRxtKpL5B11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d284444294f36b421768b987b62fe6b03307f56f233ae6d854814829e39a755",
+				"DiscoKey":   "discokey:5923aeff60127e1f66028f50952bf3c2c972ede9e78f6c559015e56b964e2616",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43819",
+					"10.65.0.27:43819",
+					"172.17.0.1:43819",
+					"172.18.0.1:43819",
+					"172.19.0.1:43819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:55:42.908263303Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8624285660216814,
+				"StableID":   "nmAFKtMxLA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ebf02a7aa5aa85c6968b649e2fdebb1aee88acc64a8479e9988788946480706c",
+				"DiscoKey":   "discokey:f592f6483412a50c44ae0465a6807449d5404279addb598085a165e01306c426",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42072",
+					"10.65.0.27:42072",
+					"172.17.0.1:42072",
+					"172.18.0.1:42072",
+					"172.19.0.1:42072"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:55:43.444763987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6392821879123614,
+				"StableID":   "ndpYGFbKvr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b7d9d32b7ea659275d316f9760a9d37aa6d181e07fc6538f1fb14f9318a31b13",
+				"DiscoKey":   "discokey:7db39b748e818981c1997c6ebcee20f149985c2a8060e0f2be4eda3a9019545c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50063",
+					"10.65.0.27:50063",
+					"172.17.0.1:50063",
+					"172.18.0.1:50063",
+					"172.19.0.1:50063"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:55:44.524467076Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2393276862151458,
+				"StableID":   "n9tAvqKvgK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fd1726462aef22d065170d4dbfccab593cd48e5d3b155b015b3fe98f5c8a1e0d",
+				"DiscoKey":   "discokey:9d46b7f634a519d581941a59353decde2ae9234d610afd1434fe477a339e123b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:49307",
+					"10.65.0.27:49307",
+					"172.17.0.1:49307",
+					"172.18.0.1:49307",
+					"172.19.0.1:49307"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:55:45.073999116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4294369728739762,
+				"StableID":   "nsjvY2pvXa11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e961eb4cf72d39bbac6a456646cfbc704fe2b1ecf903839d7df63a9d0a4c5911",
+				"DiscoKey":   "discokey:91aa1369ff4114dac10baf07d7905013fc852b3f362ea53c6384f73568428a45",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48236",
+					"10.65.0.27:48236",
+					"172.17.0.1:48236",
+					"172.18.0.1:48236",
+					"172.19.0.1:48236"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:55:45.605607837Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3663638698618420,
+				"StableID":   "nHmpFRaGcV11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:edf9559d3938e9530b86321c6e10c49f367d457655f02e4e7653c008bfc74070",
+				"KeyExpiry":  "2026-11-08T21:55:46Z",
+				"DiscoKey":   "discokey:9bbc122047ca08b148211c091725beecd7934131d82d6180e598bb2b889cc007",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:58676",
+					"10.65.0.27:58676",
+					"172.17.0.1:58676",
+					"172.18.0.1:58676",
+					"172.19.0.1:58676"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:55:46.147618174Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8354902190844601,
+				"StableID":   "nnw1bZ7xE821CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ffb380ef172c63d8675ef384cb1aa23376dae13d0562a71e4925b8c4900ff94b",
+				"KeyExpiry":  "2026-11-08T21:55:46Z",
+				"DiscoKey":   "discokey:f760ccafef0f31af01190dc297e10ea4fff59582758237c82e90e1cd23316b08",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51903",
+					"10.65.0.27:51903",
+					"172.17.0.1:51903",
+					"172.18.0.1:51903",
+					"172.19.0.1:51903"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:55:46.689299341Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6344020514535147,
+				"StableID":   "nSgvnMfDYr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:4c0ba639676a594cb1180dc2bf58a318328408e53c4af37afb9d081f518e8450",
+				"KeyExpiry":  "2026-11-08T21:55:47Z",
+				"DiscoKey":   "discokey:f801630498725d8f04d852d3648a9d3b4451ebe38289defe8590416206f0b11e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53570",
+					"10.65.0.27:53570",
+					"172.17.0.1:53570",
+					"172.18.0.1:53570",
+					"172.19.0.1:53570"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:55:47.236375997Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2303406886056769": {
+				"ID":          2303406886056769,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8354902190844601,
+				"StableID":   "nnw1bZ7xE821CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ffb380ef172c63d8675ef384cb1aa23376dae13d0562a71e4925b8c4900ff94b",
+				"KeyExpiry":  "2026-11-08T21:55:46Z",
+				"DiscoKey":   "discokey:f760ccafef0f31af01190dc297e10ea4fff59582758237c82e90e1cd23316b08",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51903",
+					"10.65.0.27:51903",
+					"172.17.0.1:51903",
+					"172.18.0.1:51903",
+					"172.19.0.1:51903"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:55:46.689299341Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ffb380ef172c63d8675ef384cb1aa23376dae13d0562a71e4925b8c4900ff94b",
+			"MachineKey": "mkey:5c07eb0d8672e4f103c97d6f2fb4114e0db05b33f8f79edb7d7e3cec90273d7e",
+			"Peers": [{
+				"ID":         2132112232116195,
+				"StableID":   "nJUrsRydeH11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7bdd423d434e43abbf796cd12a165b5953389a16147bfefcb99e049f46a90f3a",
+				"DiscoKey":   "discokey:854fe607ee959d44ae2a4e01c14888d8630e3d42e899ee18926d8d41ba2bce67",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44016",
+					"10.65.0.27:44016",
+					"172.17.0.1:44016",
+					"172.18.0.1:44016",
+					"172.19.0.1:44016"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:55:39.698686052Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4336320486250097,
+				"StableID":   "nr7cLbnvra11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3d54a12ba3b2463dd18b59b73ebab7bdb784761f6bbdd67e2e28842eda6f34b",
+				"DiscoKey":   "discokey:100042ec3269a61e0e89dfda2efef78f3b71be1983b5cac4f7ee6c210aedd873",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50831",
+					"10.65.0.27:50831",
+					"172.17.0.1:50831",
+					"172.18.0.1:50831",
+					"172.19.0.1:50831"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:55:40.226591347Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3741301672973853,
+				"StableID":   "ntEbMkeSDW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3f3d7e0af39fa685771a5fadf4eefedda78fda9f1805f08dcb0f5a5bb3b8cc56",
+				"DiscoKey":   "discokey:01c267d3724254e1111e3e14e3cb473684067e178f50d0aa45470620db9b0824",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57706",
+					"10.65.0.27:57706",
+					"172.17.0.1:57706",
+					"172.18.0.1:57706",
+					"172.19.0.1:57706"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:55:40.771840987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5394370143918161,
+				"StableID":   "nSKzTUx78j11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c3e0b2cd72a3122fbe6621fc75a7447a586833cbcf65f6dab21f1a804eafc01",
+				"DiscoKey":   "discokey:bcd15c7ad4dc1556c116d9d902251f62598ccd27af22d343c58760ef8fcad54f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42134",
+					"10.65.0.27:42134",
+					"172.17.0.1:42134",
+					"172.18.0.1:42134",
+					"172.19.0.1:42134"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:55:41.303990369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1927300156723223,
+				"StableID":   "n8hy7cus3G11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:189b619364d3d6d3004bc847844d0436660a9bb855090fdbc4444b6d09562068",
+				"DiscoKey":   "discokey:9445c6e04cc897e23292586bd9c55a0eb4937a0af0836b6dcba8ffe360a7984e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53383",
+					"10.65.0.27:53383",
+					"172.17.0.1:53383",
+					"172.18.0.1:53383",
+					"172.19.0.1:53383"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:55:41.841879201Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         439650908341143,
+				"StableID":   "nJCsFGt7S411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9187b6935a7f5a2955d457da066d16bec150d85f25002861ddac225194877f32",
+				"DiscoKey":   "discokey:fc8d91c13f05343f595daf2a52d78e6e64abe4971f3e3ded5088a169f09d8633",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41382",
+					"10.65.0.27:41382",
+					"172.17.0.1:41382",
+					"172.18.0.1:41382",
+					"172.19.0.1:41382"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:55:42.370384886Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1290217121610877,
+				"StableID":   "nSRxtKpL5B11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d284444294f36b421768b987b62fe6b03307f56f233ae6d854814829e39a755",
+				"DiscoKey":   "discokey:5923aeff60127e1f66028f50952bf3c2c972ede9e78f6c559015e56b964e2616",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43819",
+					"10.65.0.27:43819",
+					"172.17.0.1:43819",
+					"172.18.0.1:43819",
+					"172.19.0.1:43819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:55:42.908263303Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8624285660216814,
+				"StableID":   "nmAFKtMxLA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ebf02a7aa5aa85c6968b649e2fdebb1aee88acc64a8479e9988788946480706c",
+				"DiscoKey":   "discokey:f592f6483412a50c44ae0465a6807449d5404279addb598085a165e01306c426",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42072",
+					"10.65.0.27:42072",
+					"172.17.0.1:42072",
+					"172.18.0.1:42072",
+					"172.19.0.1:42072"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:55:43.444763987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2303406886056769,
+				"StableID":   "nzsisPbDzJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d90fe5950a4662dee384235546263c96a392bc4f8ab284e4258caae05f9d462",
+				"DiscoKey":   "discokey:92d16765039f7b98f91926c6a31731cd992d5c97f5de0e57f7d6c498cf605f12",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39876",
+					"10.65.0.27:39876",
+					"172.17.0.1:39876",
+					"172.18.0.1:39876",
+					"172.19.0.1:39876"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:55:43.9799932Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6392821879123614,
+				"StableID":   "ndpYGFbKvr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b7d9d32b7ea659275d316f9760a9d37aa6d181e07fc6538f1fb14f9318a31b13",
+				"DiscoKey":   "discokey:7db39b748e818981c1997c6ebcee20f149985c2a8060e0f2be4eda3a9019545c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50063",
+					"10.65.0.27:50063",
+					"172.17.0.1:50063",
+					"172.18.0.1:50063",
+					"172.19.0.1:50063"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:55:44.524467076Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2393276862151458,
+				"StableID":   "n9tAvqKvgK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fd1726462aef22d065170d4dbfccab593cd48e5d3b155b015b3fe98f5c8a1e0d",
+				"DiscoKey":   "discokey:9d46b7f634a519d581941a59353decde2ae9234d610afd1434fe477a339e123b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:49307",
+					"10.65.0.27:49307",
+					"172.17.0.1:49307",
+					"172.18.0.1:49307",
+					"172.19.0.1:49307"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:55:45.073999116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4294369728739762,
+				"StableID":   "nsjvY2pvXa11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e961eb4cf72d39bbac6a456646cfbc704fe2b1ecf903839d7df63a9d0a4c5911",
+				"DiscoKey":   "discokey:91aa1369ff4114dac10baf07d7905013fc852b3f362ea53c6384f73568428a45",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48236",
+					"10.65.0.27:48236",
+					"172.17.0.1:48236",
+					"172.18.0.1:48236",
+					"172.19.0.1:48236"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:55:45.605607837Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3663638698618420,
+				"StableID":   "nHmpFRaGcV11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:edf9559d3938e9530b86321c6e10c49f367d457655f02e4e7653c008bfc74070",
+				"KeyExpiry":  "2026-11-08T21:55:46Z",
+				"DiscoKey":   "discokey:9bbc122047ca08b148211c091725beecd7934131d82d6180e598bb2b889cc007",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:58676",
+					"10.65.0.27:58676",
+					"172.17.0.1:58676",
+					"172.18.0.1:58676",
+					"172.19.0.1:58676"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:55:46.147618174Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6344020514535147,
+				"StableID":   "nSgvnMfDYr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:4c0ba639676a594cb1180dc2bf58a318328408e53c4af37afb9d081f518e8450",
+				"KeyExpiry":  "2026-11-08T21:55:47Z",
+				"DiscoKey":   "discokey:f801630498725d8f04d852d3648a9d3b4451ebe38289defe8590416206f0b11e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53570",
+					"10.65.0.27:53570",
+					"172.17.0.1:53570",
+					"172.18.0.1:53570",
+					"172.19.0.1:53570"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:55:47.236375997Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6392821879123614,
+				"StableID":   "ndpYGFbKvr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       6392821879123614,
+				"Key":        "nodekey:b7d9d32b7ea659275d316f9760a9d37aa6d181e07fc6538f1fb14f9318a31b13",
+				"DiscoKey":   "discokey:7db39b748e818981c1997c6ebcee20f149985c2a8060e0f2be4eda3a9019545c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50063",
+					"10.65.0.27:50063",
+					"172.17.0.1:50063",
+					"172.18.0.1:50063",
+					"172.19.0.1:50063"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:55:44.524467076Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b7d9d32b7ea659275d316f9760a9d37aa6d181e07fc6538f1fb14f9318a31b13",
+			"MachineKey": "mkey:8d9ce6619178b9063519dca4bdf7a970a80fed2ad128bf7b4fe4fb02a9dffe47",
+			"Peers": [{
+				"ID":         2132112232116195,
+				"StableID":   "nJUrsRydeH11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7bdd423d434e43abbf796cd12a165b5953389a16147bfefcb99e049f46a90f3a",
+				"DiscoKey":   "discokey:854fe607ee959d44ae2a4e01c14888d8630e3d42e899ee18926d8d41ba2bce67",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44016",
+					"10.65.0.27:44016",
+					"172.17.0.1:44016",
+					"172.18.0.1:44016",
+					"172.19.0.1:44016"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:55:39.698686052Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4336320486250097,
+				"StableID":   "nr7cLbnvra11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3d54a12ba3b2463dd18b59b73ebab7bdb784761f6bbdd67e2e28842eda6f34b",
+				"DiscoKey":   "discokey:100042ec3269a61e0e89dfda2efef78f3b71be1983b5cac4f7ee6c210aedd873",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50831",
+					"10.65.0.27:50831",
+					"172.17.0.1:50831",
+					"172.18.0.1:50831",
+					"172.19.0.1:50831"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:55:40.226591347Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3741301672973853,
+				"StableID":   "ntEbMkeSDW11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3f3d7e0af39fa685771a5fadf4eefedda78fda9f1805f08dcb0f5a5bb3b8cc56",
+				"DiscoKey":   "discokey:01c267d3724254e1111e3e14e3cb473684067e178f50d0aa45470620db9b0824",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57706",
+					"10.65.0.27:57706",
+					"172.17.0.1:57706",
+					"172.18.0.1:57706",
+					"172.19.0.1:57706"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:55:40.771840987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5394370143918161,
+				"StableID":   "nSKzTUx78j11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c3e0b2cd72a3122fbe6621fc75a7447a586833cbcf65f6dab21f1a804eafc01",
+				"DiscoKey":   "discokey:bcd15c7ad4dc1556c116d9d902251f62598ccd27af22d343c58760ef8fcad54f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42134",
+					"10.65.0.27:42134",
+					"172.17.0.1:42134",
+					"172.18.0.1:42134",
+					"172.19.0.1:42134"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:55:41.303990369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1927300156723223,
+				"StableID":   "n8hy7cus3G11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:189b619364d3d6d3004bc847844d0436660a9bb855090fdbc4444b6d09562068",
+				"DiscoKey":   "discokey:9445c6e04cc897e23292586bd9c55a0eb4937a0af0836b6dcba8ffe360a7984e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53383",
+					"10.65.0.27:53383",
+					"172.17.0.1:53383",
+					"172.18.0.1:53383",
+					"172.19.0.1:53383"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:55:41.841879201Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         439650908341143,
+				"StableID":   "nJCsFGt7S411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9187b6935a7f5a2955d457da066d16bec150d85f25002861ddac225194877f32",
+				"DiscoKey":   "discokey:fc8d91c13f05343f595daf2a52d78e6e64abe4971f3e3ded5088a169f09d8633",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41382",
+					"10.65.0.27:41382",
+					"172.17.0.1:41382",
+					"172.18.0.1:41382",
+					"172.19.0.1:41382"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:55:42.370384886Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1290217121610877,
+				"StableID":   "nSRxtKpL5B11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d284444294f36b421768b987b62fe6b03307f56f233ae6d854814829e39a755",
+				"DiscoKey":   "discokey:5923aeff60127e1f66028f50952bf3c2c972ede9e78f6c559015e56b964e2616",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43819",
+					"10.65.0.27:43819",
+					"172.17.0.1:43819",
+					"172.18.0.1:43819",
+					"172.19.0.1:43819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:55:42.908263303Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8624285660216814,
+				"StableID":   "nmAFKtMxLA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ebf02a7aa5aa85c6968b649e2fdebb1aee88acc64a8479e9988788946480706c",
+				"DiscoKey":   "discokey:f592f6483412a50c44ae0465a6807449d5404279addb598085a165e01306c426",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42072",
+					"10.65.0.27:42072",
+					"172.17.0.1:42072",
+					"172.18.0.1:42072",
+					"172.19.0.1:42072"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:55:43.444763987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2303406886056769,
+				"StableID":   "nzsisPbDzJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d90fe5950a4662dee384235546263c96a392bc4f8ab284e4258caae05f9d462",
+				"DiscoKey":   "discokey:92d16765039f7b98f91926c6a31731cd992d5c97f5de0e57f7d6c498cf605f12",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39876",
+					"10.65.0.27:39876",
+					"172.17.0.1:39876",
+					"172.18.0.1:39876",
+					"172.19.0.1:39876"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:55:43.9799932Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2393276862151458,
+				"StableID":   "n9tAvqKvgK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fd1726462aef22d065170d4dbfccab593cd48e5d3b155b015b3fe98f5c8a1e0d",
+				"DiscoKey":   "discokey:9d46b7f634a519d581941a59353decde2ae9234d610afd1434fe477a339e123b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:49307",
+					"10.65.0.27:49307",
+					"172.17.0.1:49307",
+					"172.18.0.1:49307",
+					"172.19.0.1:49307"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:55:45.073999116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4294369728739762,
+				"StableID":   "nsjvY2pvXa11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e961eb4cf72d39bbac6a456646cfbc704fe2b1ecf903839d7df63a9d0a4c5911",
+				"DiscoKey":   "discokey:91aa1369ff4114dac10baf07d7905013fc852b3f362ea53c6384f73568428a45",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48236",
+					"10.65.0.27:48236",
+					"172.17.0.1:48236",
+					"172.18.0.1:48236",
+					"172.19.0.1:48236"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:55:45.605607837Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3663638698618420,
+				"StableID":   "nHmpFRaGcV11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:edf9559d3938e9530b86321c6e10c49f367d457655f02e4e7653c008bfc74070",
+				"KeyExpiry":  "2026-11-08T21:55:46Z",
+				"DiscoKey":   "discokey:9bbc122047ca08b148211c091725beecd7934131d82d6180e598bb2b889cc007",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:58676",
+					"10.65.0.27:58676",
+					"172.17.0.1:58676",
+					"172.18.0.1:58676",
+					"172.19.0.1:58676"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:55:46.147618174Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8354902190844601,
+				"StableID":   "nnw1bZ7xE821CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ffb380ef172c63d8675ef384cb1aa23376dae13d0562a71e4925b8c4900ff94b",
+				"KeyExpiry":  "2026-11-08T21:55:46Z",
+				"DiscoKey":   "discokey:f760ccafef0f31af01190dc297e10ea4fff59582758237c82e90e1cd23316b08",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51903",
+					"10.65.0.27:51903",
+					"172.17.0.1:51903",
+					"172.18.0.1:51903",
+					"172.19.0.1:51903"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:55:46.689299341Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6344020514535147,
+				"StableID":   "nSgvnMfDYr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:4c0ba639676a594cb1180dc2bf58a318328408e53c4af37afb9d081f518e8450",
+				"KeyExpiry":  "2026-11-08T21:55:47Z",
+				"DiscoKey":   "discokey:f801630498725d8f04d852d3648a9d3b4451ebe38289defe8590416206f0b11e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53570",
+					"10.65.0.27:53570",
+					"172.17.0.1:53570",
+					"172.18.0.1:53570",
+					"172.19.0.1:53570"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:55:47.236375997Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6392821879123614": {
+				"ID":          6392821879123614,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-dst-empty.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-dst-empty.hujson
@@ -1,0 +1,20079 @@
+// ssh-malformed-dst-empty
+//
+// ssh dst empty array is rejected
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T21:56:32Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-malformed-dst-empty",
+	"description":    "ssh dst empty array is rejected",
+	"category":       "ssh",
+	"captured_at":    "2026-05-12T21:56:32.510506266Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                          \n  \n                                                                  \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh dst empty array is rejected\",\n\t\"id\":          \"ssh-malformed-dst-empty\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [],\n\t\t\"src\":    [\"autogroup:member\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-malformed/ssh-malformed-dst-empty.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    [],
+				"src":    ["autogroup:member"],
+				"users":  ["root"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4214140041663774,
+				"StableID":   "nVNZq9KbuZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       4214140041663774,
+				"Key":        "nodekey:3cff5cb5fed67b8754c265504d491843bcbecf2d48ddc4e4734ebe7423d7e371",
+				"DiscoKey":   "discokey:aad73dc492b86d0623c7859c11f82ca03e875e54911a38704088d5ee36e5302d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52052",
+					"10.65.0.27:52052",
+					"172.17.0.1:52052",
+					"172.18.0.1:52052",
+					"172.19.0.1:52052"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:56:41.093148508Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3cff5cb5fed67b8754c265504d491843bcbecf2d48ddc4e4734ebe7423d7e371",
+			"MachineKey": "mkey:ddb1d3481dfbb7460e450c07a2eccedeb50801881879f664f288c27bc28dbb7b",
+			"Peers": [{
+				"ID":         3150160007219167,
+				"StableID":   "nGj4dyMibR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:11bd30899774a1584c03b2c93e173c30613d05da77c4d1befdab72b65f78897f",
+				"DiscoKey":   "discokey:ddbe6ba2b3cca3dbc918a05d91ea629b90ff525a9479e64fe514390750f1b872",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43130",
+					"10.65.0.27:43130",
+					"172.17.0.1:43130",
+					"172.18.0.1:43130",
+					"172.19.0.1:43130"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:56:35.148028712Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1537812876222173,
+				"StableID":   "nroysijU1D11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba4404971d7db7285d2807b44b752d7cea050bd5dc7feb72008343802231f868",
+				"DiscoKey":   "discokey:485963c2c1bfd113ebd6bd5a3062b9ed8ca77ed68345e80a98409b9cc1117675",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47411",
+					"10.65.0.27:47411",
+					"172.17.0.1:47411",
+					"172.18.0.1:47411",
+					"172.19.0.1:47411"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:56:35.633476077Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4115616679561979,
+				"StableID":   "nztvhjGy8Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77e3cf13220e01c2efc1a98f5ca00fcfc1f12adf31fb63ceed54a0264bdd2f3a",
+				"DiscoKey":   "discokey:a0761de0abe58a620876fd4acbe7e2e32db5a76f53b1294ea646ca747938d444",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:38404",
+					"10.65.0.27:38404",
+					"172.17.0.1:38404",
+					"172.18.0.1:38404",
+					"172.19.0.1:38404"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:56:36.179688294Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5060802230299789,
+				"StableID":   "nkAwBCh3Xg11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d0bfbe2e4b8ec1e747d4dbce72ccd648c7c7214640c1fbda80014fa90cbce45",
+				"DiscoKey":   "discokey:0ca384f1a19cfa4e70efec7bb3451564bbb4b6e8f9ede66acfdfd1c26771fd15",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42615",
+					"10.65.0.27:42615",
+					"172.17.0.1:42615",
+					"172.18.0.1:42615",
+					"172.19.0.1:42615"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:56:36.724387675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6300022466880106,
+				"StableID":   "nFo7zcuHCr11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5034baebe962f21cf63bffb91bdc7c1564e13b74d43f3c14341495ff0c48dc16",
+				"DiscoKey":   "discokey:17799be886739b260376ca9bd02bd705553ddd43bcd23f5bd2ef74cc102de132",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38001",
+					"10.65.0.27:38001",
+					"172.17.0.1:38001",
+					"172.18.0.1:38001",
+					"172.19.0.1:38001"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:56:37.265875795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5508977588131013,
+				"StableID":   "nQQdryV22k11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d4a3853c83ba4685fe8da4c7894c6bbc605e305f04529338ff8b324197cda762",
+				"DiscoKey":   "discokey:c25bab72a5f4a01f56bea1018aa4f5c4fbc8151a977226c2f4d0dc3faae08f3a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54399",
+					"10.65.0.27:54399",
+					"172.17.0.1:54399",
+					"172.18.0.1:54399",
+					"172.19.0.1:54399"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:56:37.801058781Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6521708764191291,
+				"StableID":   "nGo3xMEhvs11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6d25939ff5b79a2147d87cf022f98420c6be0b8034505f918d6409e9dc00102",
+				"DiscoKey":   "discokey:eb3316b71cf41e6cafbd650eccd460c42d07130440aeae088d425efc83540459",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40816",
+					"10.65.0.27:40816",
+					"172.17.0.1:40816",
+					"172.18.0.1:40816",
+					"172.19.0.1:40816"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:56:38.34041511Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7074662734861201,
+				"StableID":   "nUvSqpP8Fx11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f99a98f287fc33e9ebb1365acb8cfce91aacef55b073507fd48b8bf1075ee07",
+				"DiscoKey":   "discokey:6b4ed548f39e1fe9e65e9a505864c0beab5e5d3a6ddf8463f8b49bfd4710321d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48836",
+					"10.65.0.27:48836",
+					"172.17.0.1:48836",
+					"172.18.0.1:48836",
+					"172.19.0.1:48836"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:56:38.879676799Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4087677950865253,
+				"StableID":   "nv3WvMNKvY11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:408ffaf1d8c7705334109e05eac034f6ecd76d3154590ee7960abc53402dc24d",
+				"DiscoKey":   "discokey:ba7a7755c1873b8c8c3f7b516f8911cbd6ce4b1b5fabdb16e1c55d734c25991f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42425",
+					"10.65.0.27:42425",
+					"172.17.0.1:42425",
+					"172.18.0.1:42425",
+					"172.19.0.1:42425"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:56:39.420814112Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         902388889648420,
+				"StableID":   "nKgN67Eh3811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10ab96470f5eb80dbd607e24641144457b74cca51e2822057de9981374b2c34a",
+				"DiscoKey":   "discokey:567df3bd1dec07a96d6febff96ccc43068227aa847eca960778719f506fc1439",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51516",
+					"10.65.0.27:51516",
+					"172.17.0.1:51516",
+					"172.18.0.1:51516",
+					"172.19.0.1:51516"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:56:39.96937601Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7439359279607131,
+				"StableID":   "nC5heVMJ6121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6ff0b8255a92eef67d27f6139d730019684643dd605c16b5f344b68e927ad55",
+				"DiscoKey":   "discokey:eefeee74bdbf4e0db43cb978b9cf257948b67926ee9e5d3cda3d1f4c432fcd6c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48488",
+					"10.65.0.27:48488",
+					"172.17.0.1:48488",
+					"172.18.0.1:48488",
+					"172.19.0.1:48488"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:56:40.50994684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1280396427235372,
+				"StableID":   "nPSGmtqtzA11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:69d576d470a0f18fc3e8a2346dde64c6af1dc577ee58602c9129412f94879d3d",
+				"KeyExpiry":  "2026-11-08T21:56:41Z",
+				"DiscoKey":   "discokey:acb4265f67c4613c3f693d1d3a68a49dc9f85042a0f1b799547d34be96d1760e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:60475",
+					"10.65.0.27:60475",
+					"172.17.0.1:60475",
+					"172.18.0.1:60475",
+					"172.19.0.1:60475"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:56:41.595650817Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6212120508583290,
+				"StableID":   "njPJwZsUWq11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:080081dc68305e2a30346ab37d0143f68fd7a3c2fc4f35cd761511b010efca6f",
+				"KeyExpiry":  "2026-11-08T21:56:42Z",
+				"DiscoKey":   "discokey:822888fd2f30a174c341730597269dc69cff3ee43e6abeef67dc724133b41a55",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:45759",
+					"10.65.0.27:45759",
+					"172.17.0.1:45759",
+					"172.18.0.1:45759",
+					"172.19.0.1:45759"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:56:42.135615167Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1789215464978962,
+				"StableID":   "nHY4m4fLyE11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5bfdb12107324fa999868dec6a51398b801bb25a146d05737f54843328ed441f",
+				"KeyExpiry":  "2026-11-08T21:56:42Z",
+				"DiscoKey":   "discokey:76986d94ae87ab65bab49e1990e0b75a04eceaef3b76e371af6eca278b7ec476",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33237",
+					"10.65.0.27:33237",
+					"172.17.0.1:33237",
+					"172.18.0.1:33237",
+					"172.19.0.1:33237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:56:42.668573062Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4214140041663774": {
+				"ID":          4214140041663774,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5508977588131013,
+				"StableID":   "nQQdryV22k11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       5508977588131013,
+				"Key":        "nodekey:d4a3853c83ba4685fe8da4c7894c6bbc605e305f04529338ff8b324197cda762",
+				"DiscoKey":   "discokey:c25bab72a5f4a01f56bea1018aa4f5c4fbc8151a977226c2f4d0dc3faae08f3a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54399",
+					"10.65.0.27:54399",
+					"172.17.0.1:54399",
+					"172.18.0.1:54399",
+					"172.19.0.1:54399"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:56:37.801058781Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d4a3853c83ba4685fe8da4c7894c6bbc605e305f04529338ff8b324197cda762",
+			"MachineKey": "mkey:e66fef1f3bac99f91cf14c71c293bd3a9414c547243e56ef4ba79c2a1710bc00",
+			"Peers": [{
+				"ID":         3150160007219167,
+				"StableID":   "nGj4dyMibR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:11bd30899774a1584c03b2c93e173c30613d05da77c4d1befdab72b65f78897f",
+				"DiscoKey":   "discokey:ddbe6ba2b3cca3dbc918a05d91ea629b90ff525a9479e64fe514390750f1b872",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43130",
+					"10.65.0.27:43130",
+					"172.17.0.1:43130",
+					"172.18.0.1:43130",
+					"172.19.0.1:43130"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:56:35.148028712Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1537812876222173,
+				"StableID":   "nroysijU1D11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba4404971d7db7285d2807b44b752d7cea050bd5dc7feb72008343802231f868",
+				"DiscoKey":   "discokey:485963c2c1bfd113ebd6bd5a3062b9ed8ca77ed68345e80a98409b9cc1117675",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47411",
+					"10.65.0.27:47411",
+					"172.17.0.1:47411",
+					"172.18.0.1:47411",
+					"172.19.0.1:47411"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:56:35.633476077Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4115616679561979,
+				"StableID":   "nztvhjGy8Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77e3cf13220e01c2efc1a98f5ca00fcfc1f12adf31fb63ceed54a0264bdd2f3a",
+				"DiscoKey":   "discokey:a0761de0abe58a620876fd4acbe7e2e32db5a76f53b1294ea646ca747938d444",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:38404",
+					"10.65.0.27:38404",
+					"172.17.0.1:38404",
+					"172.18.0.1:38404",
+					"172.19.0.1:38404"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:56:36.179688294Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5060802230299789,
+				"StableID":   "nkAwBCh3Xg11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d0bfbe2e4b8ec1e747d4dbce72ccd648c7c7214640c1fbda80014fa90cbce45",
+				"DiscoKey":   "discokey:0ca384f1a19cfa4e70efec7bb3451564bbb4b6e8f9ede66acfdfd1c26771fd15",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42615",
+					"10.65.0.27:42615",
+					"172.17.0.1:42615",
+					"172.18.0.1:42615",
+					"172.19.0.1:42615"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:56:36.724387675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6300022466880106,
+				"StableID":   "nFo7zcuHCr11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5034baebe962f21cf63bffb91bdc7c1564e13b74d43f3c14341495ff0c48dc16",
+				"DiscoKey":   "discokey:17799be886739b260376ca9bd02bd705553ddd43bcd23f5bd2ef74cc102de132",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38001",
+					"10.65.0.27:38001",
+					"172.17.0.1:38001",
+					"172.18.0.1:38001",
+					"172.19.0.1:38001"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:56:37.265875795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6521708764191291,
+				"StableID":   "nGo3xMEhvs11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6d25939ff5b79a2147d87cf022f98420c6be0b8034505f918d6409e9dc00102",
+				"DiscoKey":   "discokey:eb3316b71cf41e6cafbd650eccd460c42d07130440aeae088d425efc83540459",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40816",
+					"10.65.0.27:40816",
+					"172.17.0.1:40816",
+					"172.18.0.1:40816",
+					"172.19.0.1:40816"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:56:38.34041511Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7074662734861201,
+				"StableID":   "nUvSqpP8Fx11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f99a98f287fc33e9ebb1365acb8cfce91aacef55b073507fd48b8bf1075ee07",
+				"DiscoKey":   "discokey:6b4ed548f39e1fe9e65e9a505864c0beab5e5d3a6ddf8463f8b49bfd4710321d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48836",
+					"10.65.0.27:48836",
+					"172.17.0.1:48836",
+					"172.18.0.1:48836",
+					"172.19.0.1:48836"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:56:38.879676799Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4087677950865253,
+				"StableID":   "nv3WvMNKvY11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:408ffaf1d8c7705334109e05eac034f6ecd76d3154590ee7960abc53402dc24d",
+				"DiscoKey":   "discokey:ba7a7755c1873b8c8c3f7b516f8911cbd6ce4b1b5fabdb16e1c55d734c25991f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42425",
+					"10.65.0.27:42425",
+					"172.17.0.1:42425",
+					"172.18.0.1:42425",
+					"172.19.0.1:42425"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:56:39.420814112Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         902388889648420,
+				"StableID":   "nKgN67Eh3811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10ab96470f5eb80dbd607e24641144457b74cca51e2822057de9981374b2c34a",
+				"DiscoKey":   "discokey:567df3bd1dec07a96d6febff96ccc43068227aa847eca960778719f506fc1439",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51516",
+					"10.65.0.27:51516",
+					"172.17.0.1:51516",
+					"172.18.0.1:51516",
+					"172.19.0.1:51516"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:56:39.96937601Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7439359279607131,
+				"StableID":   "nC5heVMJ6121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6ff0b8255a92eef67d27f6139d730019684643dd605c16b5f344b68e927ad55",
+				"DiscoKey":   "discokey:eefeee74bdbf4e0db43cb978b9cf257948b67926ee9e5d3cda3d1f4c432fcd6c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48488",
+					"10.65.0.27:48488",
+					"172.17.0.1:48488",
+					"172.18.0.1:48488",
+					"172.19.0.1:48488"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:56:40.50994684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4214140041663774,
+				"StableID":   "nVNZq9KbuZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3cff5cb5fed67b8754c265504d491843bcbecf2d48ddc4e4734ebe7423d7e371",
+				"DiscoKey":   "discokey:aad73dc492b86d0623c7859c11f82ca03e875e54911a38704088d5ee36e5302d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52052",
+					"10.65.0.27:52052",
+					"172.17.0.1:52052",
+					"172.18.0.1:52052",
+					"172.19.0.1:52052"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:56:41.093148508Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1280396427235372,
+				"StableID":   "nPSGmtqtzA11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:69d576d470a0f18fc3e8a2346dde64c6af1dc577ee58602c9129412f94879d3d",
+				"KeyExpiry":  "2026-11-08T21:56:41Z",
+				"DiscoKey":   "discokey:acb4265f67c4613c3f693d1d3a68a49dc9f85042a0f1b799547d34be96d1760e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:60475",
+					"10.65.0.27:60475",
+					"172.17.0.1:60475",
+					"172.18.0.1:60475",
+					"172.19.0.1:60475"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:56:41.595650817Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6212120508583290,
+				"StableID":   "njPJwZsUWq11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:080081dc68305e2a30346ab37d0143f68fd7a3c2fc4f35cd761511b010efca6f",
+				"KeyExpiry":  "2026-11-08T21:56:42Z",
+				"DiscoKey":   "discokey:822888fd2f30a174c341730597269dc69cff3ee43e6abeef67dc724133b41a55",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:45759",
+					"10.65.0.27:45759",
+					"172.17.0.1:45759",
+					"172.18.0.1:45759",
+					"172.19.0.1:45759"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:56:42.135615167Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1789215464978962,
+				"StableID":   "nHY4m4fLyE11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5bfdb12107324fa999868dec6a51398b801bb25a146d05737f54843328ed441f",
+				"KeyExpiry":  "2026-11-08T21:56:42Z",
+				"DiscoKey":   "discokey:76986d94ae87ab65bab49e1990e0b75a04eceaef3b76e371af6eca278b7ec476",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33237",
+					"10.65.0.27:33237",
+					"172.17.0.1:33237",
+					"172.18.0.1:33237",
+					"172.19.0.1:33237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:56:42.668573062Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5508977588131013": {
+				"ID":          5508977588131013,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1789215464978962,
+				"StableID":   "nHY4m4fLyE11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5bfdb12107324fa999868dec6a51398b801bb25a146d05737f54843328ed441f",
+				"KeyExpiry":  "2026-11-08T21:56:42Z",
+				"DiscoKey":   "discokey:76986d94ae87ab65bab49e1990e0b75a04eceaef3b76e371af6eca278b7ec476",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33237",
+					"10.65.0.27:33237",
+					"172.17.0.1:33237",
+					"172.18.0.1:33237",
+					"172.19.0.1:33237"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:56:42.668573062Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5bfdb12107324fa999868dec6a51398b801bb25a146d05737f54843328ed441f",
+			"MachineKey": "mkey:f30e233b95548794e14413b9ea53d14c5ec887d01e98b754e979f43c85a18d02",
+			"Peers": [{
+				"ID":         3150160007219167,
+				"StableID":   "nGj4dyMibR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:11bd30899774a1584c03b2c93e173c30613d05da77c4d1befdab72b65f78897f",
+				"DiscoKey":   "discokey:ddbe6ba2b3cca3dbc918a05d91ea629b90ff525a9479e64fe514390750f1b872",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43130",
+					"10.65.0.27:43130",
+					"172.17.0.1:43130",
+					"172.18.0.1:43130",
+					"172.19.0.1:43130"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:56:35.148028712Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1537812876222173,
+				"StableID":   "nroysijU1D11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba4404971d7db7285d2807b44b752d7cea050bd5dc7feb72008343802231f868",
+				"DiscoKey":   "discokey:485963c2c1bfd113ebd6bd5a3062b9ed8ca77ed68345e80a98409b9cc1117675",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47411",
+					"10.65.0.27:47411",
+					"172.17.0.1:47411",
+					"172.18.0.1:47411",
+					"172.19.0.1:47411"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:56:35.633476077Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4115616679561979,
+				"StableID":   "nztvhjGy8Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77e3cf13220e01c2efc1a98f5ca00fcfc1f12adf31fb63ceed54a0264bdd2f3a",
+				"DiscoKey":   "discokey:a0761de0abe58a620876fd4acbe7e2e32db5a76f53b1294ea646ca747938d444",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:38404",
+					"10.65.0.27:38404",
+					"172.17.0.1:38404",
+					"172.18.0.1:38404",
+					"172.19.0.1:38404"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:56:36.179688294Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5060802230299789,
+				"StableID":   "nkAwBCh3Xg11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d0bfbe2e4b8ec1e747d4dbce72ccd648c7c7214640c1fbda80014fa90cbce45",
+				"DiscoKey":   "discokey:0ca384f1a19cfa4e70efec7bb3451564bbb4b6e8f9ede66acfdfd1c26771fd15",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42615",
+					"10.65.0.27:42615",
+					"172.17.0.1:42615",
+					"172.18.0.1:42615",
+					"172.19.0.1:42615"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:56:36.724387675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6300022466880106,
+				"StableID":   "nFo7zcuHCr11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5034baebe962f21cf63bffb91bdc7c1564e13b74d43f3c14341495ff0c48dc16",
+				"DiscoKey":   "discokey:17799be886739b260376ca9bd02bd705553ddd43bcd23f5bd2ef74cc102de132",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38001",
+					"10.65.0.27:38001",
+					"172.17.0.1:38001",
+					"172.18.0.1:38001",
+					"172.19.0.1:38001"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:56:37.265875795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5508977588131013,
+				"StableID":   "nQQdryV22k11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d4a3853c83ba4685fe8da4c7894c6bbc605e305f04529338ff8b324197cda762",
+				"DiscoKey":   "discokey:c25bab72a5f4a01f56bea1018aa4f5c4fbc8151a977226c2f4d0dc3faae08f3a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54399",
+					"10.65.0.27:54399",
+					"172.17.0.1:54399",
+					"172.18.0.1:54399",
+					"172.19.0.1:54399"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:56:37.801058781Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6521708764191291,
+				"StableID":   "nGo3xMEhvs11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6d25939ff5b79a2147d87cf022f98420c6be0b8034505f918d6409e9dc00102",
+				"DiscoKey":   "discokey:eb3316b71cf41e6cafbd650eccd460c42d07130440aeae088d425efc83540459",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40816",
+					"10.65.0.27:40816",
+					"172.17.0.1:40816",
+					"172.18.0.1:40816",
+					"172.19.0.1:40816"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:56:38.34041511Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7074662734861201,
+				"StableID":   "nUvSqpP8Fx11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f99a98f287fc33e9ebb1365acb8cfce91aacef55b073507fd48b8bf1075ee07",
+				"DiscoKey":   "discokey:6b4ed548f39e1fe9e65e9a505864c0beab5e5d3a6ddf8463f8b49bfd4710321d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48836",
+					"10.65.0.27:48836",
+					"172.17.0.1:48836",
+					"172.18.0.1:48836",
+					"172.19.0.1:48836"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:56:38.879676799Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4087677950865253,
+				"StableID":   "nv3WvMNKvY11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:408ffaf1d8c7705334109e05eac034f6ecd76d3154590ee7960abc53402dc24d",
+				"DiscoKey":   "discokey:ba7a7755c1873b8c8c3f7b516f8911cbd6ce4b1b5fabdb16e1c55d734c25991f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42425",
+					"10.65.0.27:42425",
+					"172.17.0.1:42425",
+					"172.18.0.1:42425",
+					"172.19.0.1:42425"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:56:39.420814112Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         902388889648420,
+				"StableID":   "nKgN67Eh3811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10ab96470f5eb80dbd607e24641144457b74cca51e2822057de9981374b2c34a",
+				"DiscoKey":   "discokey:567df3bd1dec07a96d6febff96ccc43068227aa847eca960778719f506fc1439",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51516",
+					"10.65.0.27:51516",
+					"172.17.0.1:51516",
+					"172.18.0.1:51516",
+					"172.19.0.1:51516"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:56:39.96937601Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7439359279607131,
+				"StableID":   "nC5heVMJ6121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6ff0b8255a92eef67d27f6139d730019684643dd605c16b5f344b68e927ad55",
+				"DiscoKey":   "discokey:eefeee74bdbf4e0db43cb978b9cf257948b67926ee9e5d3cda3d1f4c432fcd6c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48488",
+					"10.65.0.27:48488",
+					"172.17.0.1:48488",
+					"172.18.0.1:48488",
+					"172.19.0.1:48488"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:56:40.50994684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4214140041663774,
+				"StableID":   "nVNZq9KbuZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3cff5cb5fed67b8754c265504d491843bcbecf2d48ddc4e4734ebe7423d7e371",
+				"DiscoKey":   "discokey:aad73dc492b86d0623c7859c11f82ca03e875e54911a38704088d5ee36e5302d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52052",
+					"10.65.0.27:52052",
+					"172.17.0.1:52052",
+					"172.18.0.1:52052",
+					"172.19.0.1:52052"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:56:41.093148508Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1280396427235372,
+				"StableID":   "nPSGmtqtzA11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:69d576d470a0f18fc3e8a2346dde64c6af1dc577ee58602c9129412f94879d3d",
+				"KeyExpiry":  "2026-11-08T21:56:41Z",
+				"DiscoKey":   "discokey:acb4265f67c4613c3f693d1d3a68a49dc9f85042a0f1b799547d34be96d1760e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:60475",
+					"10.65.0.27:60475",
+					"172.17.0.1:60475",
+					"172.18.0.1:60475",
+					"172.19.0.1:60475"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:56:41.595650817Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6212120508583290,
+				"StableID":   "njPJwZsUWq11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:080081dc68305e2a30346ab37d0143f68fd7a3c2fc4f35cd761511b010efca6f",
+				"KeyExpiry":  "2026-11-08T21:56:42Z",
+				"DiscoKey":   "discokey:822888fd2f30a174c341730597269dc69cff3ee43e6abeef67dc724133b41a55",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:45759",
+					"10.65.0.27:45759",
+					"172.17.0.1:45759",
+					"172.18.0.1:45759",
+					"172.19.0.1:45759"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:56:42.135615167Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4115616679561979,
+				"StableID":   "nztvhjGy8Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       4115616679561979,
+				"Key":        "nodekey:77e3cf13220e01c2efc1a98f5ca00fcfc1f12adf31fb63ceed54a0264bdd2f3a",
+				"DiscoKey":   "discokey:a0761de0abe58a620876fd4acbe7e2e32db5a76f53b1294ea646ca747938d444",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:38404",
+					"10.65.0.27:38404",
+					"172.17.0.1:38404",
+					"172.18.0.1:38404",
+					"172.19.0.1:38404"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:56:36.179688294Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:77e3cf13220e01c2efc1a98f5ca00fcfc1f12adf31fb63ceed54a0264bdd2f3a",
+			"MachineKey": "mkey:773a74dad7d8a416eeca1b2ca4383b94cc1af821a491aa5d89ee161f0045e269",
+			"Peers": [{
+				"ID":         3150160007219167,
+				"StableID":   "nGj4dyMibR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:11bd30899774a1584c03b2c93e173c30613d05da77c4d1befdab72b65f78897f",
+				"DiscoKey":   "discokey:ddbe6ba2b3cca3dbc918a05d91ea629b90ff525a9479e64fe514390750f1b872",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43130",
+					"10.65.0.27:43130",
+					"172.17.0.1:43130",
+					"172.18.0.1:43130",
+					"172.19.0.1:43130"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:56:35.148028712Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1537812876222173,
+				"StableID":   "nroysijU1D11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba4404971d7db7285d2807b44b752d7cea050bd5dc7feb72008343802231f868",
+				"DiscoKey":   "discokey:485963c2c1bfd113ebd6bd5a3062b9ed8ca77ed68345e80a98409b9cc1117675",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47411",
+					"10.65.0.27:47411",
+					"172.17.0.1:47411",
+					"172.18.0.1:47411",
+					"172.19.0.1:47411"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:56:35.633476077Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5060802230299789,
+				"StableID":   "nkAwBCh3Xg11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d0bfbe2e4b8ec1e747d4dbce72ccd648c7c7214640c1fbda80014fa90cbce45",
+				"DiscoKey":   "discokey:0ca384f1a19cfa4e70efec7bb3451564bbb4b6e8f9ede66acfdfd1c26771fd15",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42615",
+					"10.65.0.27:42615",
+					"172.17.0.1:42615",
+					"172.18.0.1:42615",
+					"172.19.0.1:42615"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:56:36.724387675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6300022466880106,
+				"StableID":   "nFo7zcuHCr11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5034baebe962f21cf63bffb91bdc7c1564e13b74d43f3c14341495ff0c48dc16",
+				"DiscoKey":   "discokey:17799be886739b260376ca9bd02bd705553ddd43bcd23f5bd2ef74cc102de132",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38001",
+					"10.65.0.27:38001",
+					"172.17.0.1:38001",
+					"172.18.0.1:38001",
+					"172.19.0.1:38001"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:56:37.265875795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5508977588131013,
+				"StableID":   "nQQdryV22k11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d4a3853c83ba4685fe8da4c7894c6bbc605e305f04529338ff8b324197cda762",
+				"DiscoKey":   "discokey:c25bab72a5f4a01f56bea1018aa4f5c4fbc8151a977226c2f4d0dc3faae08f3a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54399",
+					"10.65.0.27:54399",
+					"172.17.0.1:54399",
+					"172.18.0.1:54399",
+					"172.19.0.1:54399"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:56:37.801058781Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6521708764191291,
+				"StableID":   "nGo3xMEhvs11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6d25939ff5b79a2147d87cf022f98420c6be0b8034505f918d6409e9dc00102",
+				"DiscoKey":   "discokey:eb3316b71cf41e6cafbd650eccd460c42d07130440aeae088d425efc83540459",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40816",
+					"10.65.0.27:40816",
+					"172.17.0.1:40816",
+					"172.18.0.1:40816",
+					"172.19.0.1:40816"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:56:38.34041511Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7074662734861201,
+				"StableID":   "nUvSqpP8Fx11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f99a98f287fc33e9ebb1365acb8cfce91aacef55b073507fd48b8bf1075ee07",
+				"DiscoKey":   "discokey:6b4ed548f39e1fe9e65e9a505864c0beab5e5d3a6ddf8463f8b49bfd4710321d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48836",
+					"10.65.0.27:48836",
+					"172.17.0.1:48836",
+					"172.18.0.1:48836",
+					"172.19.0.1:48836"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:56:38.879676799Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4087677950865253,
+				"StableID":   "nv3WvMNKvY11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:408ffaf1d8c7705334109e05eac034f6ecd76d3154590ee7960abc53402dc24d",
+				"DiscoKey":   "discokey:ba7a7755c1873b8c8c3f7b516f8911cbd6ce4b1b5fabdb16e1c55d734c25991f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42425",
+					"10.65.0.27:42425",
+					"172.17.0.1:42425",
+					"172.18.0.1:42425",
+					"172.19.0.1:42425"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:56:39.420814112Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         902388889648420,
+				"StableID":   "nKgN67Eh3811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10ab96470f5eb80dbd607e24641144457b74cca51e2822057de9981374b2c34a",
+				"DiscoKey":   "discokey:567df3bd1dec07a96d6febff96ccc43068227aa847eca960778719f506fc1439",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51516",
+					"10.65.0.27:51516",
+					"172.17.0.1:51516",
+					"172.18.0.1:51516",
+					"172.19.0.1:51516"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:56:39.96937601Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7439359279607131,
+				"StableID":   "nC5heVMJ6121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6ff0b8255a92eef67d27f6139d730019684643dd605c16b5f344b68e927ad55",
+				"DiscoKey":   "discokey:eefeee74bdbf4e0db43cb978b9cf257948b67926ee9e5d3cda3d1f4c432fcd6c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48488",
+					"10.65.0.27:48488",
+					"172.17.0.1:48488",
+					"172.18.0.1:48488",
+					"172.19.0.1:48488"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:56:40.50994684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4214140041663774,
+				"StableID":   "nVNZq9KbuZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3cff5cb5fed67b8754c265504d491843bcbecf2d48ddc4e4734ebe7423d7e371",
+				"DiscoKey":   "discokey:aad73dc492b86d0623c7859c11f82ca03e875e54911a38704088d5ee36e5302d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52052",
+					"10.65.0.27:52052",
+					"172.17.0.1:52052",
+					"172.18.0.1:52052",
+					"172.19.0.1:52052"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:56:41.093148508Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1280396427235372,
+				"StableID":   "nPSGmtqtzA11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:69d576d470a0f18fc3e8a2346dde64c6af1dc577ee58602c9129412f94879d3d",
+				"KeyExpiry":  "2026-11-08T21:56:41Z",
+				"DiscoKey":   "discokey:acb4265f67c4613c3f693d1d3a68a49dc9f85042a0f1b799547d34be96d1760e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:60475",
+					"10.65.0.27:60475",
+					"172.17.0.1:60475",
+					"172.18.0.1:60475",
+					"172.19.0.1:60475"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:56:41.595650817Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6212120508583290,
+				"StableID":   "njPJwZsUWq11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:080081dc68305e2a30346ab37d0143f68fd7a3c2fc4f35cd761511b010efca6f",
+				"KeyExpiry":  "2026-11-08T21:56:42Z",
+				"DiscoKey":   "discokey:822888fd2f30a174c341730597269dc69cff3ee43e6abeef67dc724133b41a55",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:45759",
+					"10.65.0.27:45759",
+					"172.17.0.1:45759",
+					"172.18.0.1:45759",
+					"172.19.0.1:45759"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:56:42.135615167Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1789215464978962,
+				"StableID":   "nHY4m4fLyE11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5bfdb12107324fa999868dec6a51398b801bb25a146d05737f54843328ed441f",
+				"KeyExpiry":  "2026-11-08T21:56:42Z",
+				"DiscoKey":   "discokey:76986d94ae87ab65bab49e1990e0b75a04eceaef3b76e371af6eca278b7ec476",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33237",
+					"10.65.0.27:33237",
+					"172.17.0.1:33237",
+					"172.18.0.1:33237",
+					"172.19.0.1:33237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:56:42.668573062Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4115616679561979": {
+				"ID":          4115616679561979,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7074662734861201,
+				"StableID":   "nUvSqpP8Fx11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       7074662734861201,
+				"Key":        "nodekey:7f99a98f287fc33e9ebb1365acb8cfce91aacef55b073507fd48b8bf1075ee07",
+				"DiscoKey":   "discokey:6b4ed548f39e1fe9e65e9a505864c0beab5e5d3a6ddf8463f8b49bfd4710321d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48836",
+					"10.65.0.27:48836",
+					"172.17.0.1:48836",
+					"172.18.0.1:48836",
+					"172.19.0.1:48836"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:56:38.879676799Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7f99a98f287fc33e9ebb1365acb8cfce91aacef55b073507fd48b8bf1075ee07",
+			"MachineKey": "mkey:2ca4fd8a5558d0d59e2b1a60f65b3b9308c19ede0a7c0457977174f04d99e157",
+			"Peers": [{
+				"ID":         3150160007219167,
+				"StableID":   "nGj4dyMibR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:11bd30899774a1584c03b2c93e173c30613d05da77c4d1befdab72b65f78897f",
+				"DiscoKey":   "discokey:ddbe6ba2b3cca3dbc918a05d91ea629b90ff525a9479e64fe514390750f1b872",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43130",
+					"10.65.0.27:43130",
+					"172.17.0.1:43130",
+					"172.18.0.1:43130",
+					"172.19.0.1:43130"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:56:35.148028712Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1537812876222173,
+				"StableID":   "nroysijU1D11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba4404971d7db7285d2807b44b752d7cea050bd5dc7feb72008343802231f868",
+				"DiscoKey":   "discokey:485963c2c1bfd113ebd6bd5a3062b9ed8ca77ed68345e80a98409b9cc1117675",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47411",
+					"10.65.0.27:47411",
+					"172.17.0.1:47411",
+					"172.18.0.1:47411",
+					"172.19.0.1:47411"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:56:35.633476077Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4115616679561979,
+				"StableID":   "nztvhjGy8Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77e3cf13220e01c2efc1a98f5ca00fcfc1f12adf31fb63ceed54a0264bdd2f3a",
+				"DiscoKey":   "discokey:a0761de0abe58a620876fd4acbe7e2e32db5a76f53b1294ea646ca747938d444",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:38404",
+					"10.65.0.27:38404",
+					"172.17.0.1:38404",
+					"172.18.0.1:38404",
+					"172.19.0.1:38404"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:56:36.179688294Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5060802230299789,
+				"StableID":   "nkAwBCh3Xg11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d0bfbe2e4b8ec1e747d4dbce72ccd648c7c7214640c1fbda80014fa90cbce45",
+				"DiscoKey":   "discokey:0ca384f1a19cfa4e70efec7bb3451564bbb4b6e8f9ede66acfdfd1c26771fd15",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42615",
+					"10.65.0.27:42615",
+					"172.17.0.1:42615",
+					"172.18.0.1:42615",
+					"172.19.0.1:42615"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:56:36.724387675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6300022466880106,
+				"StableID":   "nFo7zcuHCr11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5034baebe962f21cf63bffb91bdc7c1564e13b74d43f3c14341495ff0c48dc16",
+				"DiscoKey":   "discokey:17799be886739b260376ca9bd02bd705553ddd43bcd23f5bd2ef74cc102de132",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38001",
+					"10.65.0.27:38001",
+					"172.17.0.1:38001",
+					"172.18.0.1:38001",
+					"172.19.0.1:38001"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:56:37.265875795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5508977588131013,
+				"StableID":   "nQQdryV22k11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d4a3853c83ba4685fe8da4c7894c6bbc605e305f04529338ff8b324197cda762",
+				"DiscoKey":   "discokey:c25bab72a5f4a01f56bea1018aa4f5c4fbc8151a977226c2f4d0dc3faae08f3a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54399",
+					"10.65.0.27:54399",
+					"172.17.0.1:54399",
+					"172.18.0.1:54399",
+					"172.19.0.1:54399"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:56:37.801058781Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6521708764191291,
+				"StableID":   "nGo3xMEhvs11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6d25939ff5b79a2147d87cf022f98420c6be0b8034505f918d6409e9dc00102",
+				"DiscoKey":   "discokey:eb3316b71cf41e6cafbd650eccd460c42d07130440aeae088d425efc83540459",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40816",
+					"10.65.0.27:40816",
+					"172.17.0.1:40816",
+					"172.18.0.1:40816",
+					"172.19.0.1:40816"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:56:38.34041511Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4087677950865253,
+				"StableID":   "nv3WvMNKvY11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:408ffaf1d8c7705334109e05eac034f6ecd76d3154590ee7960abc53402dc24d",
+				"DiscoKey":   "discokey:ba7a7755c1873b8c8c3f7b516f8911cbd6ce4b1b5fabdb16e1c55d734c25991f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42425",
+					"10.65.0.27:42425",
+					"172.17.0.1:42425",
+					"172.18.0.1:42425",
+					"172.19.0.1:42425"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:56:39.420814112Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         902388889648420,
+				"StableID":   "nKgN67Eh3811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10ab96470f5eb80dbd607e24641144457b74cca51e2822057de9981374b2c34a",
+				"DiscoKey":   "discokey:567df3bd1dec07a96d6febff96ccc43068227aa847eca960778719f506fc1439",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51516",
+					"10.65.0.27:51516",
+					"172.17.0.1:51516",
+					"172.18.0.1:51516",
+					"172.19.0.1:51516"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:56:39.96937601Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7439359279607131,
+				"StableID":   "nC5heVMJ6121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6ff0b8255a92eef67d27f6139d730019684643dd605c16b5f344b68e927ad55",
+				"DiscoKey":   "discokey:eefeee74bdbf4e0db43cb978b9cf257948b67926ee9e5d3cda3d1f4c432fcd6c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48488",
+					"10.65.0.27:48488",
+					"172.17.0.1:48488",
+					"172.18.0.1:48488",
+					"172.19.0.1:48488"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:56:40.50994684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4214140041663774,
+				"StableID":   "nVNZq9KbuZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3cff5cb5fed67b8754c265504d491843bcbecf2d48ddc4e4734ebe7423d7e371",
+				"DiscoKey":   "discokey:aad73dc492b86d0623c7859c11f82ca03e875e54911a38704088d5ee36e5302d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52052",
+					"10.65.0.27:52052",
+					"172.17.0.1:52052",
+					"172.18.0.1:52052",
+					"172.19.0.1:52052"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:56:41.093148508Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1280396427235372,
+				"StableID":   "nPSGmtqtzA11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:69d576d470a0f18fc3e8a2346dde64c6af1dc577ee58602c9129412f94879d3d",
+				"KeyExpiry":  "2026-11-08T21:56:41Z",
+				"DiscoKey":   "discokey:acb4265f67c4613c3f693d1d3a68a49dc9f85042a0f1b799547d34be96d1760e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:60475",
+					"10.65.0.27:60475",
+					"172.17.0.1:60475",
+					"172.18.0.1:60475",
+					"172.19.0.1:60475"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:56:41.595650817Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6212120508583290,
+				"StableID":   "njPJwZsUWq11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:080081dc68305e2a30346ab37d0143f68fd7a3c2fc4f35cd761511b010efca6f",
+				"KeyExpiry":  "2026-11-08T21:56:42Z",
+				"DiscoKey":   "discokey:822888fd2f30a174c341730597269dc69cff3ee43e6abeef67dc724133b41a55",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:45759",
+					"10.65.0.27:45759",
+					"172.17.0.1:45759",
+					"172.18.0.1:45759",
+					"172.19.0.1:45759"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:56:42.135615167Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1789215464978962,
+				"StableID":   "nHY4m4fLyE11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5bfdb12107324fa999868dec6a51398b801bb25a146d05737f54843328ed441f",
+				"KeyExpiry":  "2026-11-08T21:56:42Z",
+				"DiscoKey":   "discokey:76986d94ae87ab65bab49e1990e0b75a04eceaef3b76e371af6eca278b7ec476",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33237",
+					"10.65.0.27:33237",
+					"172.17.0.1:33237",
+					"172.18.0.1:33237",
+					"172.19.0.1:33237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:56:42.668573062Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7074662734861201": {
+				"ID":          7074662734861201,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1280396427235372,
+				"StableID":   "nPSGmtqtzA11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:69d576d470a0f18fc3e8a2346dde64c6af1dc577ee58602c9129412f94879d3d",
+				"KeyExpiry":  "2026-11-08T21:56:41Z",
+				"DiscoKey":   "discokey:acb4265f67c4613c3f693d1d3a68a49dc9f85042a0f1b799547d34be96d1760e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:60475",
+					"10.65.0.27:60475",
+					"172.17.0.1:60475",
+					"172.18.0.1:60475",
+					"172.19.0.1:60475"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:56:41.595650817Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:69d576d470a0f18fc3e8a2346dde64c6af1dc577ee58602c9129412f94879d3d",
+			"MachineKey": "mkey:b3bd870ef481ad97fe8cfe4c85a9fa42a7e519f380d76ff7590f8bf7d45ebc34",
+			"Peers": [{
+				"ID":         3150160007219167,
+				"StableID":   "nGj4dyMibR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:11bd30899774a1584c03b2c93e173c30613d05da77c4d1befdab72b65f78897f",
+				"DiscoKey":   "discokey:ddbe6ba2b3cca3dbc918a05d91ea629b90ff525a9479e64fe514390750f1b872",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43130",
+					"10.65.0.27:43130",
+					"172.17.0.1:43130",
+					"172.18.0.1:43130",
+					"172.19.0.1:43130"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:56:35.148028712Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1537812876222173,
+				"StableID":   "nroysijU1D11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba4404971d7db7285d2807b44b752d7cea050bd5dc7feb72008343802231f868",
+				"DiscoKey":   "discokey:485963c2c1bfd113ebd6bd5a3062b9ed8ca77ed68345e80a98409b9cc1117675",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47411",
+					"10.65.0.27:47411",
+					"172.17.0.1:47411",
+					"172.18.0.1:47411",
+					"172.19.0.1:47411"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:56:35.633476077Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4115616679561979,
+				"StableID":   "nztvhjGy8Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77e3cf13220e01c2efc1a98f5ca00fcfc1f12adf31fb63ceed54a0264bdd2f3a",
+				"DiscoKey":   "discokey:a0761de0abe58a620876fd4acbe7e2e32db5a76f53b1294ea646ca747938d444",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:38404",
+					"10.65.0.27:38404",
+					"172.17.0.1:38404",
+					"172.18.0.1:38404",
+					"172.19.0.1:38404"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:56:36.179688294Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5060802230299789,
+				"StableID":   "nkAwBCh3Xg11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d0bfbe2e4b8ec1e747d4dbce72ccd648c7c7214640c1fbda80014fa90cbce45",
+				"DiscoKey":   "discokey:0ca384f1a19cfa4e70efec7bb3451564bbb4b6e8f9ede66acfdfd1c26771fd15",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42615",
+					"10.65.0.27:42615",
+					"172.17.0.1:42615",
+					"172.18.0.1:42615",
+					"172.19.0.1:42615"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:56:36.724387675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6300022466880106,
+				"StableID":   "nFo7zcuHCr11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5034baebe962f21cf63bffb91bdc7c1564e13b74d43f3c14341495ff0c48dc16",
+				"DiscoKey":   "discokey:17799be886739b260376ca9bd02bd705553ddd43bcd23f5bd2ef74cc102de132",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38001",
+					"10.65.0.27:38001",
+					"172.17.0.1:38001",
+					"172.18.0.1:38001",
+					"172.19.0.1:38001"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:56:37.265875795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5508977588131013,
+				"StableID":   "nQQdryV22k11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d4a3853c83ba4685fe8da4c7894c6bbc605e305f04529338ff8b324197cda762",
+				"DiscoKey":   "discokey:c25bab72a5f4a01f56bea1018aa4f5c4fbc8151a977226c2f4d0dc3faae08f3a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54399",
+					"10.65.0.27:54399",
+					"172.17.0.1:54399",
+					"172.18.0.1:54399",
+					"172.19.0.1:54399"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:56:37.801058781Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6521708764191291,
+				"StableID":   "nGo3xMEhvs11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6d25939ff5b79a2147d87cf022f98420c6be0b8034505f918d6409e9dc00102",
+				"DiscoKey":   "discokey:eb3316b71cf41e6cafbd650eccd460c42d07130440aeae088d425efc83540459",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40816",
+					"10.65.0.27:40816",
+					"172.17.0.1:40816",
+					"172.18.0.1:40816",
+					"172.19.0.1:40816"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:56:38.34041511Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7074662734861201,
+				"StableID":   "nUvSqpP8Fx11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f99a98f287fc33e9ebb1365acb8cfce91aacef55b073507fd48b8bf1075ee07",
+				"DiscoKey":   "discokey:6b4ed548f39e1fe9e65e9a505864c0beab5e5d3a6ddf8463f8b49bfd4710321d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48836",
+					"10.65.0.27:48836",
+					"172.17.0.1:48836",
+					"172.18.0.1:48836",
+					"172.19.0.1:48836"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:56:38.879676799Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4087677950865253,
+				"StableID":   "nv3WvMNKvY11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:408ffaf1d8c7705334109e05eac034f6ecd76d3154590ee7960abc53402dc24d",
+				"DiscoKey":   "discokey:ba7a7755c1873b8c8c3f7b516f8911cbd6ce4b1b5fabdb16e1c55d734c25991f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42425",
+					"10.65.0.27:42425",
+					"172.17.0.1:42425",
+					"172.18.0.1:42425",
+					"172.19.0.1:42425"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:56:39.420814112Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         902388889648420,
+				"StableID":   "nKgN67Eh3811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10ab96470f5eb80dbd607e24641144457b74cca51e2822057de9981374b2c34a",
+				"DiscoKey":   "discokey:567df3bd1dec07a96d6febff96ccc43068227aa847eca960778719f506fc1439",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51516",
+					"10.65.0.27:51516",
+					"172.17.0.1:51516",
+					"172.18.0.1:51516",
+					"172.19.0.1:51516"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:56:39.96937601Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7439359279607131,
+				"StableID":   "nC5heVMJ6121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6ff0b8255a92eef67d27f6139d730019684643dd605c16b5f344b68e927ad55",
+				"DiscoKey":   "discokey:eefeee74bdbf4e0db43cb978b9cf257948b67926ee9e5d3cda3d1f4c432fcd6c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48488",
+					"10.65.0.27:48488",
+					"172.17.0.1:48488",
+					"172.18.0.1:48488",
+					"172.19.0.1:48488"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:56:40.50994684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4214140041663774,
+				"StableID":   "nVNZq9KbuZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3cff5cb5fed67b8754c265504d491843bcbecf2d48ddc4e4734ebe7423d7e371",
+				"DiscoKey":   "discokey:aad73dc492b86d0623c7859c11f82ca03e875e54911a38704088d5ee36e5302d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52052",
+					"10.65.0.27:52052",
+					"172.17.0.1:52052",
+					"172.18.0.1:52052",
+					"172.19.0.1:52052"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:56:41.093148508Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6212120508583290,
+				"StableID":   "njPJwZsUWq11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:080081dc68305e2a30346ab37d0143f68fd7a3c2fc4f35cd761511b010efca6f",
+				"KeyExpiry":  "2026-11-08T21:56:42Z",
+				"DiscoKey":   "discokey:822888fd2f30a174c341730597269dc69cff3ee43e6abeef67dc724133b41a55",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:45759",
+					"10.65.0.27:45759",
+					"172.17.0.1:45759",
+					"172.18.0.1:45759",
+					"172.19.0.1:45759"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:56:42.135615167Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1789215464978962,
+				"StableID":   "nHY4m4fLyE11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5bfdb12107324fa999868dec6a51398b801bb25a146d05737f54843328ed441f",
+				"KeyExpiry":  "2026-11-08T21:56:42Z",
+				"DiscoKey":   "discokey:76986d94ae87ab65bab49e1990e0b75a04eceaef3b76e371af6eca278b7ec476",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33237",
+					"10.65.0.27:33237",
+					"172.17.0.1:33237",
+					"172.18.0.1:33237",
+					"172.19.0.1:33237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:56:42.668573062Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7439359279607131,
+				"StableID":   "nC5heVMJ6121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       7439359279607131,
+				"Key":        "nodekey:f6ff0b8255a92eef67d27f6139d730019684643dd605c16b5f344b68e927ad55",
+				"DiscoKey":   "discokey:eefeee74bdbf4e0db43cb978b9cf257948b67926ee9e5d3cda3d1f4c432fcd6c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48488",
+					"10.65.0.27:48488",
+					"172.17.0.1:48488",
+					"172.18.0.1:48488",
+					"172.19.0.1:48488"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:56:40.50994684Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f6ff0b8255a92eef67d27f6139d730019684643dd605c16b5f344b68e927ad55",
+			"MachineKey": "mkey:967f527cd5fb6a1a7bcf02f4b71acce4e52c7ca8886e3933fb4ba6d00d417d24",
+			"Peers": [{
+				"ID":         3150160007219167,
+				"StableID":   "nGj4dyMibR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:11bd30899774a1584c03b2c93e173c30613d05da77c4d1befdab72b65f78897f",
+				"DiscoKey":   "discokey:ddbe6ba2b3cca3dbc918a05d91ea629b90ff525a9479e64fe514390750f1b872",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43130",
+					"10.65.0.27:43130",
+					"172.17.0.1:43130",
+					"172.18.0.1:43130",
+					"172.19.0.1:43130"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:56:35.148028712Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1537812876222173,
+				"StableID":   "nroysijU1D11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba4404971d7db7285d2807b44b752d7cea050bd5dc7feb72008343802231f868",
+				"DiscoKey":   "discokey:485963c2c1bfd113ebd6bd5a3062b9ed8ca77ed68345e80a98409b9cc1117675",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47411",
+					"10.65.0.27:47411",
+					"172.17.0.1:47411",
+					"172.18.0.1:47411",
+					"172.19.0.1:47411"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:56:35.633476077Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4115616679561979,
+				"StableID":   "nztvhjGy8Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77e3cf13220e01c2efc1a98f5ca00fcfc1f12adf31fb63ceed54a0264bdd2f3a",
+				"DiscoKey":   "discokey:a0761de0abe58a620876fd4acbe7e2e32db5a76f53b1294ea646ca747938d444",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:38404",
+					"10.65.0.27:38404",
+					"172.17.0.1:38404",
+					"172.18.0.1:38404",
+					"172.19.0.1:38404"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:56:36.179688294Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5060802230299789,
+				"StableID":   "nkAwBCh3Xg11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d0bfbe2e4b8ec1e747d4dbce72ccd648c7c7214640c1fbda80014fa90cbce45",
+				"DiscoKey":   "discokey:0ca384f1a19cfa4e70efec7bb3451564bbb4b6e8f9ede66acfdfd1c26771fd15",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42615",
+					"10.65.0.27:42615",
+					"172.17.0.1:42615",
+					"172.18.0.1:42615",
+					"172.19.0.1:42615"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:56:36.724387675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6300022466880106,
+				"StableID":   "nFo7zcuHCr11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5034baebe962f21cf63bffb91bdc7c1564e13b74d43f3c14341495ff0c48dc16",
+				"DiscoKey":   "discokey:17799be886739b260376ca9bd02bd705553ddd43bcd23f5bd2ef74cc102de132",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38001",
+					"10.65.0.27:38001",
+					"172.17.0.1:38001",
+					"172.18.0.1:38001",
+					"172.19.0.1:38001"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:56:37.265875795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5508977588131013,
+				"StableID":   "nQQdryV22k11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d4a3853c83ba4685fe8da4c7894c6bbc605e305f04529338ff8b324197cda762",
+				"DiscoKey":   "discokey:c25bab72a5f4a01f56bea1018aa4f5c4fbc8151a977226c2f4d0dc3faae08f3a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54399",
+					"10.65.0.27:54399",
+					"172.17.0.1:54399",
+					"172.18.0.1:54399",
+					"172.19.0.1:54399"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:56:37.801058781Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6521708764191291,
+				"StableID":   "nGo3xMEhvs11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6d25939ff5b79a2147d87cf022f98420c6be0b8034505f918d6409e9dc00102",
+				"DiscoKey":   "discokey:eb3316b71cf41e6cafbd650eccd460c42d07130440aeae088d425efc83540459",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40816",
+					"10.65.0.27:40816",
+					"172.17.0.1:40816",
+					"172.18.0.1:40816",
+					"172.19.0.1:40816"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:56:38.34041511Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7074662734861201,
+				"StableID":   "nUvSqpP8Fx11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f99a98f287fc33e9ebb1365acb8cfce91aacef55b073507fd48b8bf1075ee07",
+				"DiscoKey":   "discokey:6b4ed548f39e1fe9e65e9a505864c0beab5e5d3a6ddf8463f8b49bfd4710321d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48836",
+					"10.65.0.27:48836",
+					"172.17.0.1:48836",
+					"172.18.0.1:48836",
+					"172.19.0.1:48836"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:56:38.879676799Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4087677950865253,
+				"StableID":   "nv3WvMNKvY11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:408ffaf1d8c7705334109e05eac034f6ecd76d3154590ee7960abc53402dc24d",
+				"DiscoKey":   "discokey:ba7a7755c1873b8c8c3f7b516f8911cbd6ce4b1b5fabdb16e1c55d734c25991f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42425",
+					"10.65.0.27:42425",
+					"172.17.0.1:42425",
+					"172.18.0.1:42425",
+					"172.19.0.1:42425"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:56:39.420814112Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         902388889648420,
+				"StableID":   "nKgN67Eh3811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10ab96470f5eb80dbd607e24641144457b74cca51e2822057de9981374b2c34a",
+				"DiscoKey":   "discokey:567df3bd1dec07a96d6febff96ccc43068227aa847eca960778719f506fc1439",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51516",
+					"10.65.0.27:51516",
+					"172.17.0.1:51516",
+					"172.18.0.1:51516",
+					"172.19.0.1:51516"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:56:39.96937601Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4214140041663774,
+				"StableID":   "nVNZq9KbuZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3cff5cb5fed67b8754c265504d491843bcbecf2d48ddc4e4734ebe7423d7e371",
+				"DiscoKey":   "discokey:aad73dc492b86d0623c7859c11f82ca03e875e54911a38704088d5ee36e5302d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52052",
+					"10.65.0.27:52052",
+					"172.17.0.1:52052",
+					"172.18.0.1:52052",
+					"172.19.0.1:52052"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:56:41.093148508Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1280396427235372,
+				"StableID":   "nPSGmtqtzA11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:69d576d470a0f18fc3e8a2346dde64c6af1dc577ee58602c9129412f94879d3d",
+				"KeyExpiry":  "2026-11-08T21:56:41Z",
+				"DiscoKey":   "discokey:acb4265f67c4613c3f693d1d3a68a49dc9f85042a0f1b799547d34be96d1760e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:60475",
+					"10.65.0.27:60475",
+					"172.17.0.1:60475",
+					"172.18.0.1:60475",
+					"172.19.0.1:60475"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:56:41.595650817Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6212120508583290,
+				"StableID":   "njPJwZsUWq11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:080081dc68305e2a30346ab37d0143f68fd7a3c2fc4f35cd761511b010efca6f",
+				"KeyExpiry":  "2026-11-08T21:56:42Z",
+				"DiscoKey":   "discokey:822888fd2f30a174c341730597269dc69cff3ee43e6abeef67dc724133b41a55",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:45759",
+					"10.65.0.27:45759",
+					"172.17.0.1:45759",
+					"172.18.0.1:45759",
+					"172.19.0.1:45759"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:56:42.135615167Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1789215464978962,
+				"StableID":   "nHY4m4fLyE11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5bfdb12107324fa999868dec6a51398b801bb25a146d05737f54843328ed441f",
+				"KeyExpiry":  "2026-11-08T21:56:42Z",
+				"DiscoKey":   "discokey:76986d94ae87ab65bab49e1990e0b75a04eceaef3b76e371af6eca278b7ec476",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33237",
+					"10.65.0.27:33237",
+					"172.17.0.1:33237",
+					"172.18.0.1:33237",
+					"172.19.0.1:33237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:56:42.668573062Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7439359279607131": {
+				"ID":          7439359279607131,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1537812876222173,
+				"StableID":   "nroysijU1D11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1537812876222173,
+				"Key":        "nodekey:ba4404971d7db7285d2807b44b752d7cea050bd5dc7feb72008343802231f868",
+				"DiscoKey":   "discokey:485963c2c1bfd113ebd6bd5a3062b9ed8ca77ed68345e80a98409b9cc1117675",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47411",
+					"10.65.0.27:47411",
+					"172.17.0.1:47411",
+					"172.18.0.1:47411",
+					"172.19.0.1:47411"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:56:35.633476077Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ba4404971d7db7285d2807b44b752d7cea050bd5dc7feb72008343802231f868",
+			"MachineKey": "mkey:5faba7bd64695e8e12ef75f3a9864a163256d8ba5aa8e3dd12dd9c7d8c076260",
+			"Peers": [{
+				"ID":         3150160007219167,
+				"StableID":   "nGj4dyMibR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:11bd30899774a1584c03b2c93e173c30613d05da77c4d1befdab72b65f78897f",
+				"DiscoKey":   "discokey:ddbe6ba2b3cca3dbc918a05d91ea629b90ff525a9479e64fe514390750f1b872",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43130",
+					"10.65.0.27:43130",
+					"172.17.0.1:43130",
+					"172.18.0.1:43130",
+					"172.19.0.1:43130"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:56:35.148028712Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4115616679561979,
+				"StableID":   "nztvhjGy8Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77e3cf13220e01c2efc1a98f5ca00fcfc1f12adf31fb63ceed54a0264bdd2f3a",
+				"DiscoKey":   "discokey:a0761de0abe58a620876fd4acbe7e2e32db5a76f53b1294ea646ca747938d444",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:38404",
+					"10.65.0.27:38404",
+					"172.17.0.1:38404",
+					"172.18.0.1:38404",
+					"172.19.0.1:38404"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:56:36.179688294Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5060802230299789,
+				"StableID":   "nkAwBCh3Xg11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d0bfbe2e4b8ec1e747d4dbce72ccd648c7c7214640c1fbda80014fa90cbce45",
+				"DiscoKey":   "discokey:0ca384f1a19cfa4e70efec7bb3451564bbb4b6e8f9ede66acfdfd1c26771fd15",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42615",
+					"10.65.0.27:42615",
+					"172.17.0.1:42615",
+					"172.18.0.1:42615",
+					"172.19.0.1:42615"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:56:36.724387675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6300022466880106,
+				"StableID":   "nFo7zcuHCr11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5034baebe962f21cf63bffb91bdc7c1564e13b74d43f3c14341495ff0c48dc16",
+				"DiscoKey":   "discokey:17799be886739b260376ca9bd02bd705553ddd43bcd23f5bd2ef74cc102de132",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38001",
+					"10.65.0.27:38001",
+					"172.17.0.1:38001",
+					"172.18.0.1:38001",
+					"172.19.0.1:38001"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:56:37.265875795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5508977588131013,
+				"StableID":   "nQQdryV22k11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d4a3853c83ba4685fe8da4c7894c6bbc605e305f04529338ff8b324197cda762",
+				"DiscoKey":   "discokey:c25bab72a5f4a01f56bea1018aa4f5c4fbc8151a977226c2f4d0dc3faae08f3a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54399",
+					"10.65.0.27:54399",
+					"172.17.0.1:54399",
+					"172.18.0.1:54399",
+					"172.19.0.1:54399"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:56:37.801058781Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6521708764191291,
+				"StableID":   "nGo3xMEhvs11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6d25939ff5b79a2147d87cf022f98420c6be0b8034505f918d6409e9dc00102",
+				"DiscoKey":   "discokey:eb3316b71cf41e6cafbd650eccd460c42d07130440aeae088d425efc83540459",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40816",
+					"10.65.0.27:40816",
+					"172.17.0.1:40816",
+					"172.18.0.1:40816",
+					"172.19.0.1:40816"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:56:38.34041511Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7074662734861201,
+				"StableID":   "nUvSqpP8Fx11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f99a98f287fc33e9ebb1365acb8cfce91aacef55b073507fd48b8bf1075ee07",
+				"DiscoKey":   "discokey:6b4ed548f39e1fe9e65e9a505864c0beab5e5d3a6ddf8463f8b49bfd4710321d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48836",
+					"10.65.0.27:48836",
+					"172.17.0.1:48836",
+					"172.18.0.1:48836",
+					"172.19.0.1:48836"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:56:38.879676799Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4087677950865253,
+				"StableID":   "nv3WvMNKvY11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:408ffaf1d8c7705334109e05eac034f6ecd76d3154590ee7960abc53402dc24d",
+				"DiscoKey":   "discokey:ba7a7755c1873b8c8c3f7b516f8911cbd6ce4b1b5fabdb16e1c55d734c25991f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42425",
+					"10.65.0.27:42425",
+					"172.17.0.1:42425",
+					"172.18.0.1:42425",
+					"172.19.0.1:42425"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:56:39.420814112Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         902388889648420,
+				"StableID":   "nKgN67Eh3811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10ab96470f5eb80dbd607e24641144457b74cca51e2822057de9981374b2c34a",
+				"DiscoKey":   "discokey:567df3bd1dec07a96d6febff96ccc43068227aa847eca960778719f506fc1439",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51516",
+					"10.65.0.27:51516",
+					"172.17.0.1:51516",
+					"172.18.0.1:51516",
+					"172.19.0.1:51516"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:56:39.96937601Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7439359279607131,
+				"StableID":   "nC5heVMJ6121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6ff0b8255a92eef67d27f6139d730019684643dd605c16b5f344b68e927ad55",
+				"DiscoKey":   "discokey:eefeee74bdbf4e0db43cb978b9cf257948b67926ee9e5d3cda3d1f4c432fcd6c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48488",
+					"10.65.0.27:48488",
+					"172.17.0.1:48488",
+					"172.18.0.1:48488",
+					"172.19.0.1:48488"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:56:40.50994684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4214140041663774,
+				"StableID":   "nVNZq9KbuZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3cff5cb5fed67b8754c265504d491843bcbecf2d48ddc4e4734ebe7423d7e371",
+				"DiscoKey":   "discokey:aad73dc492b86d0623c7859c11f82ca03e875e54911a38704088d5ee36e5302d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52052",
+					"10.65.0.27:52052",
+					"172.17.0.1:52052",
+					"172.18.0.1:52052",
+					"172.19.0.1:52052"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:56:41.093148508Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1280396427235372,
+				"StableID":   "nPSGmtqtzA11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:69d576d470a0f18fc3e8a2346dde64c6af1dc577ee58602c9129412f94879d3d",
+				"KeyExpiry":  "2026-11-08T21:56:41Z",
+				"DiscoKey":   "discokey:acb4265f67c4613c3f693d1d3a68a49dc9f85042a0f1b799547d34be96d1760e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:60475",
+					"10.65.0.27:60475",
+					"172.17.0.1:60475",
+					"172.18.0.1:60475",
+					"172.19.0.1:60475"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:56:41.595650817Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6212120508583290,
+				"StableID":   "njPJwZsUWq11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:080081dc68305e2a30346ab37d0143f68fd7a3c2fc4f35cd761511b010efca6f",
+				"KeyExpiry":  "2026-11-08T21:56:42Z",
+				"DiscoKey":   "discokey:822888fd2f30a174c341730597269dc69cff3ee43e6abeef67dc724133b41a55",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:45759",
+					"10.65.0.27:45759",
+					"172.17.0.1:45759",
+					"172.18.0.1:45759",
+					"172.19.0.1:45759"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:56:42.135615167Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1789215464978962,
+				"StableID":   "nHY4m4fLyE11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5bfdb12107324fa999868dec6a51398b801bb25a146d05737f54843328ed441f",
+				"KeyExpiry":  "2026-11-08T21:56:42Z",
+				"DiscoKey":   "discokey:76986d94ae87ab65bab49e1990e0b75a04eceaef3b76e371af6eca278b7ec476",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33237",
+					"10.65.0.27:33237",
+					"172.17.0.1:33237",
+					"172.18.0.1:33237",
+					"172.19.0.1:33237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:56:42.668573062Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1537812876222173": {
+				"ID":          1537812876222173,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3150160007219167,
+				"StableID":   "nGj4dyMibR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       3150160007219167,
+				"Key":        "nodekey:11bd30899774a1584c03b2c93e173c30613d05da77c4d1befdab72b65f78897f",
+				"DiscoKey":   "discokey:ddbe6ba2b3cca3dbc918a05d91ea629b90ff525a9479e64fe514390750f1b872",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43130",
+					"10.65.0.27:43130",
+					"172.17.0.1:43130",
+					"172.18.0.1:43130",
+					"172.19.0.1:43130"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:56:35.148028712Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:11bd30899774a1584c03b2c93e173c30613d05da77c4d1befdab72b65f78897f",
+			"MachineKey": "mkey:b7e141c02e8d331dda6b21643e9fcdb388187af6b3a0ff3617e1474b2456e57f",
+			"Peers": [{
+				"ID":         1537812876222173,
+				"StableID":   "nroysijU1D11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba4404971d7db7285d2807b44b752d7cea050bd5dc7feb72008343802231f868",
+				"DiscoKey":   "discokey:485963c2c1bfd113ebd6bd5a3062b9ed8ca77ed68345e80a98409b9cc1117675",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47411",
+					"10.65.0.27:47411",
+					"172.17.0.1:47411",
+					"172.18.0.1:47411",
+					"172.19.0.1:47411"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:56:35.633476077Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4115616679561979,
+				"StableID":   "nztvhjGy8Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77e3cf13220e01c2efc1a98f5ca00fcfc1f12adf31fb63ceed54a0264bdd2f3a",
+				"DiscoKey":   "discokey:a0761de0abe58a620876fd4acbe7e2e32db5a76f53b1294ea646ca747938d444",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:38404",
+					"10.65.0.27:38404",
+					"172.17.0.1:38404",
+					"172.18.0.1:38404",
+					"172.19.0.1:38404"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:56:36.179688294Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5060802230299789,
+				"StableID":   "nkAwBCh3Xg11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d0bfbe2e4b8ec1e747d4dbce72ccd648c7c7214640c1fbda80014fa90cbce45",
+				"DiscoKey":   "discokey:0ca384f1a19cfa4e70efec7bb3451564bbb4b6e8f9ede66acfdfd1c26771fd15",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42615",
+					"10.65.0.27:42615",
+					"172.17.0.1:42615",
+					"172.18.0.1:42615",
+					"172.19.0.1:42615"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:56:36.724387675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6300022466880106,
+				"StableID":   "nFo7zcuHCr11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5034baebe962f21cf63bffb91bdc7c1564e13b74d43f3c14341495ff0c48dc16",
+				"DiscoKey":   "discokey:17799be886739b260376ca9bd02bd705553ddd43bcd23f5bd2ef74cc102de132",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38001",
+					"10.65.0.27:38001",
+					"172.17.0.1:38001",
+					"172.18.0.1:38001",
+					"172.19.0.1:38001"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:56:37.265875795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5508977588131013,
+				"StableID":   "nQQdryV22k11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d4a3853c83ba4685fe8da4c7894c6bbc605e305f04529338ff8b324197cda762",
+				"DiscoKey":   "discokey:c25bab72a5f4a01f56bea1018aa4f5c4fbc8151a977226c2f4d0dc3faae08f3a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54399",
+					"10.65.0.27:54399",
+					"172.17.0.1:54399",
+					"172.18.0.1:54399",
+					"172.19.0.1:54399"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:56:37.801058781Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6521708764191291,
+				"StableID":   "nGo3xMEhvs11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6d25939ff5b79a2147d87cf022f98420c6be0b8034505f918d6409e9dc00102",
+				"DiscoKey":   "discokey:eb3316b71cf41e6cafbd650eccd460c42d07130440aeae088d425efc83540459",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40816",
+					"10.65.0.27:40816",
+					"172.17.0.1:40816",
+					"172.18.0.1:40816",
+					"172.19.0.1:40816"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:56:38.34041511Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7074662734861201,
+				"StableID":   "nUvSqpP8Fx11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f99a98f287fc33e9ebb1365acb8cfce91aacef55b073507fd48b8bf1075ee07",
+				"DiscoKey":   "discokey:6b4ed548f39e1fe9e65e9a505864c0beab5e5d3a6ddf8463f8b49bfd4710321d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48836",
+					"10.65.0.27:48836",
+					"172.17.0.1:48836",
+					"172.18.0.1:48836",
+					"172.19.0.1:48836"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:56:38.879676799Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4087677950865253,
+				"StableID":   "nv3WvMNKvY11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:408ffaf1d8c7705334109e05eac034f6ecd76d3154590ee7960abc53402dc24d",
+				"DiscoKey":   "discokey:ba7a7755c1873b8c8c3f7b516f8911cbd6ce4b1b5fabdb16e1c55d734c25991f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42425",
+					"10.65.0.27:42425",
+					"172.17.0.1:42425",
+					"172.18.0.1:42425",
+					"172.19.0.1:42425"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:56:39.420814112Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         902388889648420,
+				"StableID":   "nKgN67Eh3811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10ab96470f5eb80dbd607e24641144457b74cca51e2822057de9981374b2c34a",
+				"DiscoKey":   "discokey:567df3bd1dec07a96d6febff96ccc43068227aa847eca960778719f506fc1439",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51516",
+					"10.65.0.27:51516",
+					"172.17.0.1:51516",
+					"172.18.0.1:51516",
+					"172.19.0.1:51516"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:56:39.96937601Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7439359279607131,
+				"StableID":   "nC5heVMJ6121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6ff0b8255a92eef67d27f6139d730019684643dd605c16b5f344b68e927ad55",
+				"DiscoKey":   "discokey:eefeee74bdbf4e0db43cb978b9cf257948b67926ee9e5d3cda3d1f4c432fcd6c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48488",
+					"10.65.0.27:48488",
+					"172.17.0.1:48488",
+					"172.18.0.1:48488",
+					"172.19.0.1:48488"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:56:40.50994684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4214140041663774,
+				"StableID":   "nVNZq9KbuZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3cff5cb5fed67b8754c265504d491843bcbecf2d48ddc4e4734ebe7423d7e371",
+				"DiscoKey":   "discokey:aad73dc492b86d0623c7859c11f82ca03e875e54911a38704088d5ee36e5302d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52052",
+					"10.65.0.27:52052",
+					"172.17.0.1:52052",
+					"172.18.0.1:52052",
+					"172.19.0.1:52052"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:56:41.093148508Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1280396427235372,
+				"StableID":   "nPSGmtqtzA11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:69d576d470a0f18fc3e8a2346dde64c6af1dc577ee58602c9129412f94879d3d",
+				"KeyExpiry":  "2026-11-08T21:56:41Z",
+				"DiscoKey":   "discokey:acb4265f67c4613c3f693d1d3a68a49dc9f85042a0f1b799547d34be96d1760e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:60475",
+					"10.65.0.27:60475",
+					"172.17.0.1:60475",
+					"172.18.0.1:60475",
+					"172.19.0.1:60475"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:56:41.595650817Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6212120508583290,
+				"StableID":   "njPJwZsUWq11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:080081dc68305e2a30346ab37d0143f68fd7a3c2fc4f35cd761511b010efca6f",
+				"KeyExpiry":  "2026-11-08T21:56:42Z",
+				"DiscoKey":   "discokey:822888fd2f30a174c341730597269dc69cff3ee43e6abeef67dc724133b41a55",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:45759",
+					"10.65.0.27:45759",
+					"172.17.0.1:45759",
+					"172.18.0.1:45759",
+					"172.19.0.1:45759"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:56:42.135615167Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1789215464978962,
+				"StableID":   "nHY4m4fLyE11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5bfdb12107324fa999868dec6a51398b801bb25a146d05737f54843328ed441f",
+				"KeyExpiry":  "2026-11-08T21:56:42Z",
+				"DiscoKey":   "discokey:76986d94ae87ab65bab49e1990e0b75a04eceaef3b76e371af6eca278b7ec476",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33237",
+					"10.65.0.27:33237",
+					"172.17.0.1:33237",
+					"172.18.0.1:33237",
+					"172.19.0.1:33237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:56:42.668573062Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3150160007219167": {
+				"ID":          3150160007219167,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6300022466880106,
+				"StableID":   "nFo7zcuHCr11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       6300022466880106,
+				"Key":        "nodekey:5034baebe962f21cf63bffb91bdc7c1564e13b74d43f3c14341495ff0c48dc16",
+				"DiscoKey":   "discokey:17799be886739b260376ca9bd02bd705553ddd43bcd23f5bd2ef74cc102de132",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38001",
+					"10.65.0.27:38001",
+					"172.17.0.1:38001",
+					"172.18.0.1:38001",
+					"172.19.0.1:38001"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:56:37.265875795Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5034baebe962f21cf63bffb91bdc7c1564e13b74d43f3c14341495ff0c48dc16",
+			"MachineKey": "mkey:899c263071a97eb171453565b09e74f5cc0b4083c9e37417d94559b76a02af0d",
+			"Peers": [{
+				"ID":         3150160007219167,
+				"StableID":   "nGj4dyMibR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:11bd30899774a1584c03b2c93e173c30613d05da77c4d1befdab72b65f78897f",
+				"DiscoKey":   "discokey:ddbe6ba2b3cca3dbc918a05d91ea629b90ff525a9479e64fe514390750f1b872",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43130",
+					"10.65.0.27:43130",
+					"172.17.0.1:43130",
+					"172.18.0.1:43130",
+					"172.19.0.1:43130"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:56:35.148028712Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1537812876222173,
+				"StableID":   "nroysijU1D11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba4404971d7db7285d2807b44b752d7cea050bd5dc7feb72008343802231f868",
+				"DiscoKey":   "discokey:485963c2c1bfd113ebd6bd5a3062b9ed8ca77ed68345e80a98409b9cc1117675",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47411",
+					"10.65.0.27:47411",
+					"172.17.0.1:47411",
+					"172.18.0.1:47411",
+					"172.19.0.1:47411"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:56:35.633476077Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4115616679561979,
+				"StableID":   "nztvhjGy8Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77e3cf13220e01c2efc1a98f5ca00fcfc1f12adf31fb63ceed54a0264bdd2f3a",
+				"DiscoKey":   "discokey:a0761de0abe58a620876fd4acbe7e2e32db5a76f53b1294ea646ca747938d444",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:38404",
+					"10.65.0.27:38404",
+					"172.17.0.1:38404",
+					"172.18.0.1:38404",
+					"172.19.0.1:38404"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:56:36.179688294Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5060802230299789,
+				"StableID":   "nkAwBCh3Xg11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d0bfbe2e4b8ec1e747d4dbce72ccd648c7c7214640c1fbda80014fa90cbce45",
+				"DiscoKey":   "discokey:0ca384f1a19cfa4e70efec7bb3451564bbb4b6e8f9ede66acfdfd1c26771fd15",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42615",
+					"10.65.0.27:42615",
+					"172.17.0.1:42615",
+					"172.18.0.1:42615",
+					"172.19.0.1:42615"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:56:36.724387675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5508977588131013,
+				"StableID":   "nQQdryV22k11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d4a3853c83ba4685fe8da4c7894c6bbc605e305f04529338ff8b324197cda762",
+				"DiscoKey":   "discokey:c25bab72a5f4a01f56bea1018aa4f5c4fbc8151a977226c2f4d0dc3faae08f3a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54399",
+					"10.65.0.27:54399",
+					"172.17.0.1:54399",
+					"172.18.0.1:54399",
+					"172.19.0.1:54399"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:56:37.801058781Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6521708764191291,
+				"StableID":   "nGo3xMEhvs11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6d25939ff5b79a2147d87cf022f98420c6be0b8034505f918d6409e9dc00102",
+				"DiscoKey":   "discokey:eb3316b71cf41e6cafbd650eccd460c42d07130440aeae088d425efc83540459",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40816",
+					"10.65.0.27:40816",
+					"172.17.0.1:40816",
+					"172.18.0.1:40816",
+					"172.19.0.1:40816"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:56:38.34041511Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7074662734861201,
+				"StableID":   "nUvSqpP8Fx11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f99a98f287fc33e9ebb1365acb8cfce91aacef55b073507fd48b8bf1075ee07",
+				"DiscoKey":   "discokey:6b4ed548f39e1fe9e65e9a505864c0beab5e5d3a6ddf8463f8b49bfd4710321d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48836",
+					"10.65.0.27:48836",
+					"172.17.0.1:48836",
+					"172.18.0.1:48836",
+					"172.19.0.1:48836"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:56:38.879676799Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4087677950865253,
+				"StableID":   "nv3WvMNKvY11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:408ffaf1d8c7705334109e05eac034f6ecd76d3154590ee7960abc53402dc24d",
+				"DiscoKey":   "discokey:ba7a7755c1873b8c8c3f7b516f8911cbd6ce4b1b5fabdb16e1c55d734c25991f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42425",
+					"10.65.0.27:42425",
+					"172.17.0.1:42425",
+					"172.18.0.1:42425",
+					"172.19.0.1:42425"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:56:39.420814112Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         902388889648420,
+				"StableID":   "nKgN67Eh3811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10ab96470f5eb80dbd607e24641144457b74cca51e2822057de9981374b2c34a",
+				"DiscoKey":   "discokey:567df3bd1dec07a96d6febff96ccc43068227aa847eca960778719f506fc1439",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51516",
+					"10.65.0.27:51516",
+					"172.17.0.1:51516",
+					"172.18.0.1:51516",
+					"172.19.0.1:51516"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:56:39.96937601Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7439359279607131,
+				"StableID":   "nC5heVMJ6121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6ff0b8255a92eef67d27f6139d730019684643dd605c16b5f344b68e927ad55",
+				"DiscoKey":   "discokey:eefeee74bdbf4e0db43cb978b9cf257948b67926ee9e5d3cda3d1f4c432fcd6c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48488",
+					"10.65.0.27:48488",
+					"172.17.0.1:48488",
+					"172.18.0.1:48488",
+					"172.19.0.1:48488"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:56:40.50994684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4214140041663774,
+				"StableID":   "nVNZq9KbuZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3cff5cb5fed67b8754c265504d491843bcbecf2d48ddc4e4734ebe7423d7e371",
+				"DiscoKey":   "discokey:aad73dc492b86d0623c7859c11f82ca03e875e54911a38704088d5ee36e5302d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52052",
+					"10.65.0.27:52052",
+					"172.17.0.1:52052",
+					"172.18.0.1:52052",
+					"172.19.0.1:52052"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:56:41.093148508Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1280396427235372,
+				"StableID":   "nPSGmtqtzA11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:69d576d470a0f18fc3e8a2346dde64c6af1dc577ee58602c9129412f94879d3d",
+				"KeyExpiry":  "2026-11-08T21:56:41Z",
+				"DiscoKey":   "discokey:acb4265f67c4613c3f693d1d3a68a49dc9f85042a0f1b799547d34be96d1760e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:60475",
+					"10.65.0.27:60475",
+					"172.17.0.1:60475",
+					"172.18.0.1:60475",
+					"172.19.0.1:60475"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:56:41.595650817Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6212120508583290,
+				"StableID":   "njPJwZsUWq11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:080081dc68305e2a30346ab37d0143f68fd7a3c2fc4f35cd761511b010efca6f",
+				"KeyExpiry":  "2026-11-08T21:56:42Z",
+				"DiscoKey":   "discokey:822888fd2f30a174c341730597269dc69cff3ee43e6abeef67dc724133b41a55",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:45759",
+					"10.65.0.27:45759",
+					"172.17.0.1:45759",
+					"172.18.0.1:45759",
+					"172.19.0.1:45759"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:56:42.135615167Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1789215464978962,
+				"StableID":   "nHY4m4fLyE11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5bfdb12107324fa999868dec6a51398b801bb25a146d05737f54843328ed441f",
+				"KeyExpiry":  "2026-11-08T21:56:42Z",
+				"DiscoKey":   "discokey:76986d94ae87ab65bab49e1990e0b75a04eceaef3b76e371af6eca278b7ec476",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33237",
+					"10.65.0.27:33237",
+					"172.17.0.1:33237",
+					"172.18.0.1:33237",
+					"172.19.0.1:33237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:56:42.668573062Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6300022466880106": {
+				"ID":          6300022466880106,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5060802230299789,
+				"StableID":   "nkAwBCh3Xg11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       5060802230299789,
+				"Key":        "nodekey:5d0bfbe2e4b8ec1e747d4dbce72ccd648c7c7214640c1fbda80014fa90cbce45",
+				"DiscoKey":   "discokey:0ca384f1a19cfa4e70efec7bb3451564bbb4b6e8f9ede66acfdfd1c26771fd15",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42615",
+					"10.65.0.27:42615",
+					"172.17.0.1:42615",
+					"172.18.0.1:42615",
+					"172.19.0.1:42615"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:56:36.724387675Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5d0bfbe2e4b8ec1e747d4dbce72ccd648c7c7214640c1fbda80014fa90cbce45",
+			"MachineKey": "mkey:71f4c6e3846d35a66443e4c79c760e3fa3ff988d41f708f1600f5d032c5bd318",
+			"Peers": [{
+				"ID":         3150160007219167,
+				"StableID":   "nGj4dyMibR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:11bd30899774a1584c03b2c93e173c30613d05da77c4d1befdab72b65f78897f",
+				"DiscoKey":   "discokey:ddbe6ba2b3cca3dbc918a05d91ea629b90ff525a9479e64fe514390750f1b872",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43130",
+					"10.65.0.27:43130",
+					"172.17.0.1:43130",
+					"172.18.0.1:43130",
+					"172.19.0.1:43130"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:56:35.148028712Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1537812876222173,
+				"StableID":   "nroysijU1D11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba4404971d7db7285d2807b44b752d7cea050bd5dc7feb72008343802231f868",
+				"DiscoKey":   "discokey:485963c2c1bfd113ebd6bd5a3062b9ed8ca77ed68345e80a98409b9cc1117675",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47411",
+					"10.65.0.27:47411",
+					"172.17.0.1:47411",
+					"172.18.0.1:47411",
+					"172.19.0.1:47411"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:56:35.633476077Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4115616679561979,
+				"StableID":   "nztvhjGy8Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77e3cf13220e01c2efc1a98f5ca00fcfc1f12adf31fb63ceed54a0264bdd2f3a",
+				"DiscoKey":   "discokey:a0761de0abe58a620876fd4acbe7e2e32db5a76f53b1294ea646ca747938d444",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:38404",
+					"10.65.0.27:38404",
+					"172.17.0.1:38404",
+					"172.18.0.1:38404",
+					"172.19.0.1:38404"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:56:36.179688294Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6300022466880106,
+				"StableID":   "nFo7zcuHCr11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5034baebe962f21cf63bffb91bdc7c1564e13b74d43f3c14341495ff0c48dc16",
+				"DiscoKey":   "discokey:17799be886739b260376ca9bd02bd705553ddd43bcd23f5bd2ef74cc102de132",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38001",
+					"10.65.0.27:38001",
+					"172.17.0.1:38001",
+					"172.18.0.1:38001",
+					"172.19.0.1:38001"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:56:37.265875795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5508977588131013,
+				"StableID":   "nQQdryV22k11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d4a3853c83ba4685fe8da4c7894c6bbc605e305f04529338ff8b324197cda762",
+				"DiscoKey":   "discokey:c25bab72a5f4a01f56bea1018aa4f5c4fbc8151a977226c2f4d0dc3faae08f3a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54399",
+					"10.65.0.27:54399",
+					"172.17.0.1:54399",
+					"172.18.0.1:54399",
+					"172.19.0.1:54399"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:56:37.801058781Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6521708764191291,
+				"StableID":   "nGo3xMEhvs11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6d25939ff5b79a2147d87cf022f98420c6be0b8034505f918d6409e9dc00102",
+				"DiscoKey":   "discokey:eb3316b71cf41e6cafbd650eccd460c42d07130440aeae088d425efc83540459",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40816",
+					"10.65.0.27:40816",
+					"172.17.0.1:40816",
+					"172.18.0.1:40816",
+					"172.19.0.1:40816"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:56:38.34041511Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7074662734861201,
+				"StableID":   "nUvSqpP8Fx11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f99a98f287fc33e9ebb1365acb8cfce91aacef55b073507fd48b8bf1075ee07",
+				"DiscoKey":   "discokey:6b4ed548f39e1fe9e65e9a505864c0beab5e5d3a6ddf8463f8b49bfd4710321d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48836",
+					"10.65.0.27:48836",
+					"172.17.0.1:48836",
+					"172.18.0.1:48836",
+					"172.19.0.1:48836"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:56:38.879676799Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4087677950865253,
+				"StableID":   "nv3WvMNKvY11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:408ffaf1d8c7705334109e05eac034f6ecd76d3154590ee7960abc53402dc24d",
+				"DiscoKey":   "discokey:ba7a7755c1873b8c8c3f7b516f8911cbd6ce4b1b5fabdb16e1c55d734c25991f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42425",
+					"10.65.0.27:42425",
+					"172.17.0.1:42425",
+					"172.18.0.1:42425",
+					"172.19.0.1:42425"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:56:39.420814112Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         902388889648420,
+				"StableID":   "nKgN67Eh3811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10ab96470f5eb80dbd607e24641144457b74cca51e2822057de9981374b2c34a",
+				"DiscoKey":   "discokey:567df3bd1dec07a96d6febff96ccc43068227aa847eca960778719f506fc1439",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51516",
+					"10.65.0.27:51516",
+					"172.17.0.1:51516",
+					"172.18.0.1:51516",
+					"172.19.0.1:51516"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:56:39.96937601Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7439359279607131,
+				"StableID":   "nC5heVMJ6121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6ff0b8255a92eef67d27f6139d730019684643dd605c16b5f344b68e927ad55",
+				"DiscoKey":   "discokey:eefeee74bdbf4e0db43cb978b9cf257948b67926ee9e5d3cda3d1f4c432fcd6c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48488",
+					"10.65.0.27:48488",
+					"172.17.0.1:48488",
+					"172.18.0.1:48488",
+					"172.19.0.1:48488"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:56:40.50994684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4214140041663774,
+				"StableID":   "nVNZq9KbuZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3cff5cb5fed67b8754c265504d491843bcbecf2d48ddc4e4734ebe7423d7e371",
+				"DiscoKey":   "discokey:aad73dc492b86d0623c7859c11f82ca03e875e54911a38704088d5ee36e5302d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52052",
+					"10.65.0.27:52052",
+					"172.17.0.1:52052",
+					"172.18.0.1:52052",
+					"172.19.0.1:52052"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:56:41.093148508Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1280396427235372,
+				"StableID":   "nPSGmtqtzA11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:69d576d470a0f18fc3e8a2346dde64c6af1dc577ee58602c9129412f94879d3d",
+				"KeyExpiry":  "2026-11-08T21:56:41Z",
+				"DiscoKey":   "discokey:acb4265f67c4613c3f693d1d3a68a49dc9f85042a0f1b799547d34be96d1760e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:60475",
+					"10.65.0.27:60475",
+					"172.17.0.1:60475",
+					"172.18.0.1:60475",
+					"172.19.0.1:60475"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:56:41.595650817Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6212120508583290,
+				"StableID":   "njPJwZsUWq11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:080081dc68305e2a30346ab37d0143f68fd7a3c2fc4f35cd761511b010efca6f",
+				"KeyExpiry":  "2026-11-08T21:56:42Z",
+				"DiscoKey":   "discokey:822888fd2f30a174c341730597269dc69cff3ee43e6abeef67dc724133b41a55",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:45759",
+					"10.65.0.27:45759",
+					"172.17.0.1:45759",
+					"172.18.0.1:45759",
+					"172.19.0.1:45759"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:56:42.135615167Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1789215464978962,
+				"StableID":   "nHY4m4fLyE11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5bfdb12107324fa999868dec6a51398b801bb25a146d05737f54843328ed441f",
+				"KeyExpiry":  "2026-11-08T21:56:42Z",
+				"DiscoKey":   "discokey:76986d94ae87ab65bab49e1990e0b75a04eceaef3b76e371af6eca278b7ec476",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33237",
+					"10.65.0.27:33237",
+					"172.17.0.1:33237",
+					"172.18.0.1:33237",
+					"172.19.0.1:33237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:56:42.668573062Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5060802230299789": {
+				"ID":          5060802230299789,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6521708764191291,
+				"StableID":   "nGo3xMEhvs11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       6521708764191291,
+				"Key":        "nodekey:b6d25939ff5b79a2147d87cf022f98420c6be0b8034505f918d6409e9dc00102",
+				"DiscoKey":   "discokey:eb3316b71cf41e6cafbd650eccd460c42d07130440aeae088d425efc83540459",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40816",
+					"10.65.0.27:40816",
+					"172.17.0.1:40816",
+					"172.18.0.1:40816",
+					"172.19.0.1:40816"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:56:38.34041511Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b6d25939ff5b79a2147d87cf022f98420c6be0b8034505f918d6409e9dc00102",
+			"MachineKey": "mkey:4d8021cfa0c7e0a1d380e1c5d9b1db8be4f3a3f6e72be8e7eb558938939b560a",
+			"Peers": [{
+				"ID":         3150160007219167,
+				"StableID":   "nGj4dyMibR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:11bd30899774a1584c03b2c93e173c30613d05da77c4d1befdab72b65f78897f",
+				"DiscoKey":   "discokey:ddbe6ba2b3cca3dbc918a05d91ea629b90ff525a9479e64fe514390750f1b872",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43130",
+					"10.65.0.27:43130",
+					"172.17.0.1:43130",
+					"172.18.0.1:43130",
+					"172.19.0.1:43130"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:56:35.148028712Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1537812876222173,
+				"StableID":   "nroysijU1D11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba4404971d7db7285d2807b44b752d7cea050bd5dc7feb72008343802231f868",
+				"DiscoKey":   "discokey:485963c2c1bfd113ebd6bd5a3062b9ed8ca77ed68345e80a98409b9cc1117675",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47411",
+					"10.65.0.27:47411",
+					"172.17.0.1:47411",
+					"172.18.0.1:47411",
+					"172.19.0.1:47411"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:56:35.633476077Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4115616679561979,
+				"StableID":   "nztvhjGy8Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77e3cf13220e01c2efc1a98f5ca00fcfc1f12adf31fb63ceed54a0264bdd2f3a",
+				"DiscoKey":   "discokey:a0761de0abe58a620876fd4acbe7e2e32db5a76f53b1294ea646ca747938d444",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:38404",
+					"10.65.0.27:38404",
+					"172.17.0.1:38404",
+					"172.18.0.1:38404",
+					"172.19.0.1:38404"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:56:36.179688294Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5060802230299789,
+				"StableID":   "nkAwBCh3Xg11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d0bfbe2e4b8ec1e747d4dbce72ccd648c7c7214640c1fbda80014fa90cbce45",
+				"DiscoKey":   "discokey:0ca384f1a19cfa4e70efec7bb3451564bbb4b6e8f9ede66acfdfd1c26771fd15",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42615",
+					"10.65.0.27:42615",
+					"172.17.0.1:42615",
+					"172.18.0.1:42615",
+					"172.19.0.1:42615"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:56:36.724387675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6300022466880106,
+				"StableID":   "nFo7zcuHCr11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5034baebe962f21cf63bffb91bdc7c1564e13b74d43f3c14341495ff0c48dc16",
+				"DiscoKey":   "discokey:17799be886739b260376ca9bd02bd705553ddd43bcd23f5bd2ef74cc102de132",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38001",
+					"10.65.0.27:38001",
+					"172.17.0.1:38001",
+					"172.18.0.1:38001",
+					"172.19.0.1:38001"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:56:37.265875795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5508977588131013,
+				"StableID":   "nQQdryV22k11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d4a3853c83ba4685fe8da4c7894c6bbc605e305f04529338ff8b324197cda762",
+				"DiscoKey":   "discokey:c25bab72a5f4a01f56bea1018aa4f5c4fbc8151a977226c2f4d0dc3faae08f3a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54399",
+					"10.65.0.27:54399",
+					"172.17.0.1:54399",
+					"172.18.0.1:54399",
+					"172.19.0.1:54399"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:56:37.801058781Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7074662734861201,
+				"StableID":   "nUvSqpP8Fx11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f99a98f287fc33e9ebb1365acb8cfce91aacef55b073507fd48b8bf1075ee07",
+				"DiscoKey":   "discokey:6b4ed548f39e1fe9e65e9a505864c0beab5e5d3a6ddf8463f8b49bfd4710321d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48836",
+					"10.65.0.27:48836",
+					"172.17.0.1:48836",
+					"172.18.0.1:48836",
+					"172.19.0.1:48836"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:56:38.879676799Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4087677950865253,
+				"StableID":   "nv3WvMNKvY11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:408ffaf1d8c7705334109e05eac034f6ecd76d3154590ee7960abc53402dc24d",
+				"DiscoKey":   "discokey:ba7a7755c1873b8c8c3f7b516f8911cbd6ce4b1b5fabdb16e1c55d734c25991f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42425",
+					"10.65.0.27:42425",
+					"172.17.0.1:42425",
+					"172.18.0.1:42425",
+					"172.19.0.1:42425"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:56:39.420814112Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         902388889648420,
+				"StableID":   "nKgN67Eh3811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10ab96470f5eb80dbd607e24641144457b74cca51e2822057de9981374b2c34a",
+				"DiscoKey":   "discokey:567df3bd1dec07a96d6febff96ccc43068227aa847eca960778719f506fc1439",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51516",
+					"10.65.0.27:51516",
+					"172.17.0.1:51516",
+					"172.18.0.1:51516",
+					"172.19.0.1:51516"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:56:39.96937601Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7439359279607131,
+				"StableID":   "nC5heVMJ6121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6ff0b8255a92eef67d27f6139d730019684643dd605c16b5f344b68e927ad55",
+				"DiscoKey":   "discokey:eefeee74bdbf4e0db43cb978b9cf257948b67926ee9e5d3cda3d1f4c432fcd6c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48488",
+					"10.65.0.27:48488",
+					"172.17.0.1:48488",
+					"172.18.0.1:48488",
+					"172.19.0.1:48488"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:56:40.50994684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4214140041663774,
+				"StableID":   "nVNZq9KbuZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3cff5cb5fed67b8754c265504d491843bcbecf2d48ddc4e4734ebe7423d7e371",
+				"DiscoKey":   "discokey:aad73dc492b86d0623c7859c11f82ca03e875e54911a38704088d5ee36e5302d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52052",
+					"10.65.0.27:52052",
+					"172.17.0.1:52052",
+					"172.18.0.1:52052",
+					"172.19.0.1:52052"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:56:41.093148508Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1280396427235372,
+				"StableID":   "nPSGmtqtzA11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:69d576d470a0f18fc3e8a2346dde64c6af1dc577ee58602c9129412f94879d3d",
+				"KeyExpiry":  "2026-11-08T21:56:41Z",
+				"DiscoKey":   "discokey:acb4265f67c4613c3f693d1d3a68a49dc9f85042a0f1b799547d34be96d1760e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:60475",
+					"10.65.0.27:60475",
+					"172.17.0.1:60475",
+					"172.18.0.1:60475",
+					"172.19.0.1:60475"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:56:41.595650817Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6212120508583290,
+				"StableID":   "njPJwZsUWq11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:080081dc68305e2a30346ab37d0143f68fd7a3c2fc4f35cd761511b010efca6f",
+				"KeyExpiry":  "2026-11-08T21:56:42Z",
+				"DiscoKey":   "discokey:822888fd2f30a174c341730597269dc69cff3ee43e6abeef67dc724133b41a55",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:45759",
+					"10.65.0.27:45759",
+					"172.17.0.1:45759",
+					"172.18.0.1:45759",
+					"172.19.0.1:45759"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:56:42.135615167Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1789215464978962,
+				"StableID":   "nHY4m4fLyE11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5bfdb12107324fa999868dec6a51398b801bb25a146d05737f54843328ed441f",
+				"KeyExpiry":  "2026-11-08T21:56:42Z",
+				"DiscoKey":   "discokey:76986d94ae87ab65bab49e1990e0b75a04eceaef3b76e371af6eca278b7ec476",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33237",
+					"10.65.0.27:33237",
+					"172.17.0.1:33237",
+					"172.18.0.1:33237",
+					"172.19.0.1:33237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:56:42.668573062Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6521708764191291": {
+				"ID":          6521708764191291,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4087677950865253,
+				"StableID":   "nv3WvMNKvY11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       4087677950865253,
+				"Key":        "nodekey:408ffaf1d8c7705334109e05eac034f6ecd76d3154590ee7960abc53402dc24d",
+				"DiscoKey":   "discokey:ba7a7755c1873b8c8c3f7b516f8911cbd6ce4b1b5fabdb16e1c55d734c25991f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42425",
+					"10.65.0.27:42425",
+					"172.17.0.1:42425",
+					"172.18.0.1:42425",
+					"172.19.0.1:42425"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:56:39.420814112Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:408ffaf1d8c7705334109e05eac034f6ecd76d3154590ee7960abc53402dc24d",
+			"MachineKey": "mkey:62497170292b362ff76aec37ab88347fb8be4ec3f7152ba6152e594255a1ca04",
+			"Peers": [{
+				"ID":         3150160007219167,
+				"StableID":   "nGj4dyMibR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:11bd30899774a1584c03b2c93e173c30613d05da77c4d1befdab72b65f78897f",
+				"DiscoKey":   "discokey:ddbe6ba2b3cca3dbc918a05d91ea629b90ff525a9479e64fe514390750f1b872",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43130",
+					"10.65.0.27:43130",
+					"172.17.0.1:43130",
+					"172.18.0.1:43130",
+					"172.19.0.1:43130"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:56:35.148028712Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1537812876222173,
+				"StableID":   "nroysijU1D11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba4404971d7db7285d2807b44b752d7cea050bd5dc7feb72008343802231f868",
+				"DiscoKey":   "discokey:485963c2c1bfd113ebd6bd5a3062b9ed8ca77ed68345e80a98409b9cc1117675",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47411",
+					"10.65.0.27:47411",
+					"172.17.0.1:47411",
+					"172.18.0.1:47411",
+					"172.19.0.1:47411"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:56:35.633476077Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4115616679561979,
+				"StableID":   "nztvhjGy8Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77e3cf13220e01c2efc1a98f5ca00fcfc1f12adf31fb63ceed54a0264bdd2f3a",
+				"DiscoKey":   "discokey:a0761de0abe58a620876fd4acbe7e2e32db5a76f53b1294ea646ca747938d444",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:38404",
+					"10.65.0.27:38404",
+					"172.17.0.1:38404",
+					"172.18.0.1:38404",
+					"172.19.0.1:38404"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:56:36.179688294Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5060802230299789,
+				"StableID":   "nkAwBCh3Xg11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d0bfbe2e4b8ec1e747d4dbce72ccd648c7c7214640c1fbda80014fa90cbce45",
+				"DiscoKey":   "discokey:0ca384f1a19cfa4e70efec7bb3451564bbb4b6e8f9ede66acfdfd1c26771fd15",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42615",
+					"10.65.0.27:42615",
+					"172.17.0.1:42615",
+					"172.18.0.1:42615",
+					"172.19.0.1:42615"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:56:36.724387675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6300022466880106,
+				"StableID":   "nFo7zcuHCr11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5034baebe962f21cf63bffb91bdc7c1564e13b74d43f3c14341495ff0c48dc16",
+				"DiscoKey":   "discokey:17799be886739b260376ca9bd02bd705553ddd43bcd23f5bd2ef74cc102de132",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38001",
+					"10.65.0.27:38001",
+					"172.17.0.1:38001",
+					"172.18.0.1:38001",
+					"172.19.0.1:38001"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:56:37.265875795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5508977588131013,
+				"StableID":   "nQQdryV22k11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d4a3853c83ba4685fe8da4c7894c6bbc605e305f04529338ff8b324197cda762",
+				"DiscoKey":   "discokey:c25bab72a5f4a01f56bea1018aa4f5c4fbc8151a977226c2f4d0dc3faae08f3a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54399",
+					"10.65.0.27:54399",
+					"172.17.0.1:54399",
+					"172.18.0.1:54399",
+					"172.19.0.1:54399"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:56:37.801058781Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6521708764191291,
+				"StableID":   "nGo3xMEhvs11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6d25939ff5b79a2147d87cf022f98420c6be0b8034505f918d6409e9dc00102",
+				"DiscoKey":   "discokey:eb3316b71cf41e6cafbd650eccd460c42d07130440aeae088d425efc83540459",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40816",
+					"10.65.0.27:40816",
+					"172.17.0.1:40816",
+					"172.18.0.1:40816",
+					"172.19.0.1:40816"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:56:38.34041511Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7074662734861201,
+				"StableID":   "nUvSqpP8Fx11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f99a98f287fc33e9ebb1365acb8cfce91aacef55b073507fd48b8bf1075ee07",
+				"DiscoKey":   "discokey:6b4ed548f39e1fe9e65e9a505864c0beab5e5d3a6ddf8463f8b49bfd4710321d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48836",
+					"10.65.0.27:48836",
+					"172.17.0.1:48836",
+					"172.18.0.1:48836",
+					"172.19.0.1:48836"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:56:38.879676799Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         902388889648420,
+				"StableID":   "nKgN67Eh3811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10ab96470f5eb80dbd607e24641144457b74cca51e2822057de9981374b2c34a",
+				"DiscoKey":   "discokey:567df3bd1dec07a96d6febff96ccc43068227aa847eca960778719f506fc1439",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51516",
+					"10.65.0.27:51516",
+					"172.17.0.1:51516",
+					"172.18.0.1:51516",
+					"172.19.0.1:51516"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:56:39.96937601Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7439359279607131,
+				"StableID":   "nC5heVMJ6121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6ff0b8255a92eef67d27f6139d730019684643dd605c16b5f344b68e927ad55",
+				"DiscoKey":   "discokey:eefeee74bdbf4e0db43cb978b9cf257948b67926ee9e5d3cda3d1f4c432fcd6c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48488",
+					"10.65.0.27:48488",
+					"172.17.0.1:48488",
+					"172.18.0.1:48488",
+					"172.19.0.1:48488"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:56:40.50994684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4214140041663774,
+				"StableID":   "nVNZq9KbuZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3cff5cb5fed67b8754c265504d491843bcbecf2d48ddc4e4734ebe7423d7e371",
+				"DiscoKey":   "discokey:aad73dc492b86d0623c7859c11f82ca03e875e54911a38704088d5ee36e5302d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52052",
+					"10.65.0.27:52052",
+					"172.17.0.1:52052",
+					"172.18.0.1:52052",
+					"172.19.0.1:52052"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:56:41.093148508Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1280396427235372,
+				"StableID":   "nPSGmtqtzA11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:69d576d470a0f18fc3e8a2346dde64c6af1dc577ee58602c9129412f94879d3d",
+				"KeyExpiry":  "2026-11-08T21:56:41Z",
+				"DiscoKey":   "discokey:acb4265f67c4613c3f693d1d3a68a49dc9f85042a0f1b799547d34be96d1760e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:60475",
+					"10.65.0.27:60475",
+					"172.17.0.1:60475",
+					"172.18.0.1:60475",
+					"172.19.0.1:60475"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:56:41.595650817Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6212120508583290,
+				"StableID":   "njPJwZsUWq11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:080081dc68305e2a30346ab37d0143f68fd7a3c2fc4f35cd761511b010efca6f",
+				"KeyExpiry":  "2026-11-08T21:56:42Z",
+				"DiscoKey":   "discokey:822888fd2f30a174c341730597269dc69cff3ee43e6abeef67dc724133b41a55",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:45759",
+					"10.65.0.27:45759",
+					"172.17.0.1:45759",
+					"172.18.0.1:45759",
+					"172.19.0.1:45759"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:56:42.135615167Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1789215464978962,
+				"StableID":   "nHY4m4fLyE11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5bfdb12107324fa999868dec6a51398b801bb25a146d05737f54843328ed441f",
+				"KeyExpiry":  "2026-11-08T21:56:42Z",
+				"DiscoKey":   "discokey:76986d94ae87ab65bab49e1990e0b75a04eceaef3b76e371af6eca278b7ec476",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33237",
+					"10.65.0.27:33237",
+					"172.17.0.1:33237",
+					"172.18.0.1:33237",
+					"172.19.0.1:33237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:56:42.668573062Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4087677950865253": {
+				"ID":          4087677950865253,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6212120508583290,
+				"StableID":   "njPJwZsUWq11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:080081dc68305e2a30346ab37d0143f68fd7a3c2fc4f35cd761511b010efca6f",
+				"KeyExpiry":  "2026-11-08T21:56:42Z",
+				"DiscoKey":   "discokey:822888fd2f30a174c341730597269dc69cff3ee43e6abeef67dc724133b41a55",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:45759",
+					"10.65.0.27:45759",
+					"172.17.0.1:45759",
+					"172.18.0.1:45759",
+					"172.19.0.1:45759"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:56:42.135615167Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:080081dc68305e2a30346ab37d0143f68fd7a3c2fc4f35cd761511b010efca6f",
+			"MachineKey": "mkey:834a001322751d4baa8e950dbcd43b4ce3ad7e47b9a6b24ab24b46c7c9e4a474",
+			"Peers": [{
+				"ID":         3150160007219167,
+				"StableID":   "nGj4dyMibR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:11bd30899774a1584c03b2c93e173c30613d05da77c4d1befdab72b65f78897f",
+				"DiscoKey":   "discokey:ddbe6ba2b3cca3dbc918a05d91ea629b90ff525a9479e64fe514390750f1b872",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43130",
+					"10.65.0.27:43130",
+					"172.17.0.1:43130",
+					"172.18.0.1:43130",
+					"172.19.0.1:43130"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:56:35.148028712Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1537812876222173,
+				"StableID":   "nroysijU1D11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba4404971d7db7285d2807b44b752d7cea050bd5dc7feb72008343802231f868",
+				"DiscoKey":   "discokey:485963c2c1bfd113ebd6bd5a3062b9ed8ca77ed68345e80a98409b9cc1117675",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47411",
+					"10.65.0.27:47411",
+					"172.17.0.1:47411",
+					"172.18.0.1:47411",
+					"172.19.0.1:47411"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:56:35.633476077Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4115616679561979,
+				"StableID":   "nztvhjGy8Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77e3cf13220e01c2efc1a98f5ca00fcfc1f12adf31fb63ceed54a0264bdd2f3a",
+				"DiscoKey":   "discokey:a0761de0abe58a620876fd4acbe7e2e32db5a76f53b1294ea646ca747938d444",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:38404",
+					"10.65.0.27:38404",
+					"172.17.0.1:38404",
+					"172.18.0.1:38404",
+					"172.19.0.1:38404"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:56:36.179688294Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5060802230299789,
+				"StableID":   "nkAwBCh3Xg11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d0bfbe2e4b8ec1e747d4dbce72ccd648c7c7214640c1fbda80014fa90cbce45",
+				"DiscoKey":   "discokey:0ca384f1a19cfa4e70efec7bb3451564bbb4b6e8f9ede66acfdfd1c26771fd15",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42615",
+					"10.65.0.27:42615",
+					"172.17.0.1:42615",
+					"172.18.0.1:42615",
+					"172.19.0.1:42615"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:56:36.724387675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6300022466880106,
+				"StableID":   "nFo7zcuHCr11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5034baebe962f21cf63bffb91bdc7c1564e13b74d43f3c14341495ff0c48dc16",
+				"DiscoKey":   "discokey:17799be886739b260376ca9bd02bd705553ddd43bcd23f5bd2ef74cc102de132",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38001",
+					"10.65.0.27:38001",
+					"172.17.0.1:38001",
+					"172.18.0.1:38001",
+					"172.19.0.1:38001"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:56:37.265875795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5508977588131013,
+				"StableID":   "nQQdryV22k11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d4a3853c83ba4685fe8da4c7894c6bbc605e305f04529338ff8b324197cda762",
+				"DiscoKey":   "discokey:c25bab72a5f4a01f56bea1018aa4f5c4fbc8151a977226c2f4d0dc3faae08f3a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54399",
+					"10.65.0.27:54399",
+					"172.17.0.1:54399",
+					"172.18.0.1:54399",
+					"172.19.0.1:54399"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:56:37.801058781Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6521708764191291,
+				"StableID":   "nGo3xMEhvs11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6d25939ff5b79a2147d87cf022f98420c6be0b8034505f918d6409e9dc00102",
+				"DiscoKey":   "discokey:eb3316b71cf41e6cafbd650eccd460c42d07130440aeae088d425efc83540459",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40816",
+					"10.65.0.27:40816",
+					"172.17.0.1:40816",
+					"172.18.0.1:40816",
+					"172.19.0.1:40816"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:56:38.34041511Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7074662734861201,
+				"StableID":   "nUvSqpP8Fx11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f99a98f287fc33e9ebb1365acb8cfce91aacef55b073507fd48b8bf1075ee07",
+				"DiscoKey":   "discokey:6b4ed548f39e1fe9e65e9a505864c0beab5e5d3a6ddf8463f8b49bfd4710321d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48836",
+					"10.65.0.27:48836",
+					"172.17.0.1:48836",
+					"172.18.0.1:48836",
+					"172.19.0.1:48836"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:56:38.879676799Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4087677950865253,
+				"StableID":   "nv3WvMNKvY11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:408ffaf1d8c7705334109e05eac034f6ecd76d3154590ee7960abc53402dc24d",
+				"DiscoKey":   "discokey:ba7a7755c1873b8c8c3f7b516f8911cbd6ce4b1b5fabdb16e1c55d734c25991f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42425",
+					"10.65.0.27:42425",
+					"172.17.0.1:42425",
+					"172.18.0.1:42425",
+					"172.19.0.1:42425"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:56:39.420814112Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         902388889648420,
+				"StableID":   "nKgN67Eh3811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10ab96470f5eb80dbd607e24641144457b74cca51e2822057de9981374b2c34a",
+				"DiscoKey":   "discokey:567df3bd1dec07a96d6febff96ccc43068227aa847eca960778719f506fc1439",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51516",
+					"10.65.0.27:51516",
+					"172.17.0.1:51516",
+					"172.18.0.1:51516",
+					"172.19.0.1:51516"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:56:39.96937601Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7439359279607131,
+				"StableID":   "nC5heVMJ6121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6ff0b8255a92eef67d27f6139d730019684643dd605c16b5f344b68e927ad55",
+				"DiscoKey":   "discokey:eefeee74bdbf4e0db43cb978b9cf257948b67926ee9e5d3cda3d1f4c432fcd6c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48488",
+					"10.65.0.27:48488",
+					"172.17.0.1:48488",
+					"172.18.0.1:48488",
+					"172.19.0.1:48488"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:56:40.50994684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4214140041663774,
+				"StableID":   "nVNZq9KbuZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3cff5cb5fed67b8754c265504d491843bcbecf2d48ddc4e4734ebe7423d7e371",
+				"DiscoKey":   "discokey:aad73dc492b86d0623c7859c11f82ca03e875e54911a38704088d5ee36e5302d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52052",
+					"10.65.0.27:52052",
+					"172.17.0.1:52052",
+					"172.18.0.1:52052",
+					"172.19.0.1:52052"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:56:41.093148508Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1280396427235372,
+				"StableID":   "nPSGmtqtzA11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:69d576d470a0f18fc3e8a2346dde64c6af1dc577ee58602c9129412f94879d3d",
+				"KeyExpiry":  "2026-11-08T21:56:41Z",
+				"DiscoKey":   "discokey:acb4265f67c4613c3f693d1d3a68a49dc9f85042a0f1b799547d34be96d1760e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:60475",
+					"10.65.0.27:60475",
+					"172.17.0.1:60475",
+					"172.18.0.1:60475",
+					"172.19.0.1:60475"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:56:41.595650817Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1789215464978962,
+				"StableID":   "nHY4m4fLyE11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5bfdb12107324fa999868dec6a51398b801bb25a146d05737f54843328ed441f",
+				"KeyExpiry":  "2026-11-08T21:56:42Z",
+				"DiscoKey":   "discokey:76986d94ae87ab65bab49e1990e0b75a04eceaef3b76e371af6eca278b7ec476",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33237",
+					"10.65.0.27:33237",
+					"172.17.0.1:33237",
+					"172.18.0.1:33237",
+					"172.19.0.1:33237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:56:42.668573062Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         902388889648420,
+				"StableID":   "nKgN67Eh3811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       902388889648420,
+				"Key":        "nodekey:10ab96470f5eb80dbd607e24641144457b74cca51e2822057de9981374b2c34a",
+				"DiscoKey":   "discokey:567df3bd1dec07a96d6febff96ccc43068227aa847eca960778719f506fc1439",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51516",
+					"10.65.0.27:51516",
+					"172.17.0.1:51516",
+					"172.18.0.1:51516",
+					"172.19.0.1:51516"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:56:39.96937601Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:10ab96470f5eb80dbd607e24641144457b74cca51e2822057de9981374b2c34a",
+			"MachineKey": "mkey:16d1c87246a31c003e7e6cef26ed30a2e2d3f00d42c1522c3f4c0033fae3c54e",
+			"Peers": [{
+				"ID":         3150160007219167,
+				"StableID":   "nGj4dyMibR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:11bd30899774a1584c03b2c93e173c30613d05da77c4d1befdab72b65f78897f",
+				"DiscoKey":   "discokey:ddbe6ba2b3cca3dbc918a05d91ea629b90ff525a9479e64fe514390750f1b872",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43130",
+					"10.65.0.27:43130",
+					"172.17.0.1:43130",
+					"172.18.0.1:43130",
+					"172.19.0.1:43130"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:56:35.148028712Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1537812876222173,
+				"StableID":   "nroysijU1D11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba4404971d7db7285d2807b44b752d7cea050bd5dc7feb72008343802231f868",
+				"DiscoKey":   "discokey:485963c2c1bfd113ebd6bd5a3062b9ed8ca77ed68345e80a98409b9cc1117675",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47411",
+					"10.65.0.27:47411",
+					"172.17.0.1:47411",
+					"172.18.0.1:47411",
+					"172.19.0.1:47411"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:56:35.633476077Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4115616679561979,
+				"StableID":   "nztvhjGy8Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77e3cf13220e01c2efc1a98f5ca00fcfc1f12adf31fb63ceed54a0264bdd2f3a",
+				"DiscoKey":   "discokey:a0761de0abe58a620876fd4acbe7e2e32db5a76f53b1294ea646ca747938d444",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:38404",
+					"10.65.0.27:38404",
+					"172.17.0.1:38404",
+					"172.18.0.1:38404",
+					"172.19.0.1:38404"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:56:36.179688294Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5060802230299789,
+				"StableID":   "nkAwBCh3Xg11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5d0bfbe2e4b8ec1e747d4dbce72ccd648c7c7214640c1fbda80014fa90cbce45",
+				"DiscoKey":   "discokey:0ca384f1a19cfa4e70efec7bb3451564bbb4b6e8f9ede66acfdfd1c26771fd15",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42615",
+					"10.65.0.27:42615",
+					"172.17.0.1:42615",
+					"172.18.0.1:42615",
+					"172.19.0.1:42615"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:56:36.724387675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6300022466880106,
+				"StableID":   "nFo7zcuHCr11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5034baebe962f21cf63bffb91bdc7c1564e13b74d43f3c14341495ff0c48dc16",
+				"DiscoKey":   "discokey:17799be886739b260376ca9bd02bd705553ddd43bcd23f5bd2ef74cc102de132",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38001",
+					"10.65.0.27:38001",
+					"172.17.0.1:38001",
+					"172.18.0.1:38001",
+					"172.19.0.1:38001"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:56:37.265875795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5508977588131013,
+				"StableID":   "nQQdryV22k11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d4a3853c83ba4685fe8da4c7894c6bbc605e305f04529338ff8b324197cda762",
+				"DiscoKey":   "discokey:c25bab72a5f4a01f56bea1018aa4f5c4fbc8151a977226c2f4d0dc3faae08f3a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54399",
+					"10.65.0.27:54399",
+					"172.17.0.1:54399",
+					"172.18.0.1:54399",
+					"172.19.0.1:54399"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:56:37.801058781Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6521708764191291,
+				"StableID":   "nGo3xMEhvs11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6d25939ff5b79a2147d87cf022f98420c6be0b8034505f918d6409e9dc00102",
+				"DiscoKey":   "discokey:eb3316b71cf41e6cafbd650eccd460c42d07130440aeae088d425efc83540459",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40816",
+					"10.65.0.27:40816",
+					"172.17.0.1:40816",
+					"172.18.0.1:40816",
+					"172.19.0.1:40816"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:56:38.34041511Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7074662734861201,
+				"StableID":   "nUvSqpP8Fx11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7f99a98f287fc33e9ebb1365acb8cfce91aacef55b073507fd48b8bf1075ee07",
+				"DiscoKey":   "discokey:6b4ed548f39e1fe9e65e9a505864c0beab5e5d3a6ddf8463f8b49bfd4710321d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48836",
+					"10.65.0.27:48836",
+					"172.17.0.1:48836",
+					"172.18.0.1:48836",
+					"172.19.0.1:48836"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:56:38.879676799Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4087677950865253,
+				"StableID":   "nv3WvMNKvY11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:408ffaf1d8c7705334109e05eac034f6ecd76d3154590ee7960abc53402dc24d",
+				"DiscoKey":   "discokey:ba7a7755c1873b8c8c3f7b516f8911cbd6ce4b1b5fabdb16e1c55d734c25991f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42425",
+					"10.65.0.27:42425",
+					"172.17.0.1:42425",
+					"172.18.0.1:42425",
+					"172.19.0.1:42425"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:56:39.420814112Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7439359279607131,
+				"StableID":   "nC5heVMJ6121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6ff0b8255a92eef67d27f6139d730019684643dd605c16b5f344b68e927ad55",
+				"DiscoKey":   "discokey:eefeee74bdbf4e0db43cb978b9cf257948b67926ee9e5d3cda3d1f4c432fcd6c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48488",
+					"10.65.0.27:48488",
+					"172.17.0.1:48488",
+					"172.18.0.1:48488",
+					"172.19.0.1:48488"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:56:40.50994684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4214140041663774,
+				"StableID":   "nVNZq9KbuZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3cff5cb5fed67b8754c265504d491843bcbecf2d48ddc4e4734ebe7423d7e371",
+				"DiscoKey":   "discokey:aad73dc492b86d0623c7859c11f82ca03e875e54911a38704088d5ee36e5302d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52052",
+					"10.65.0.27:52052",
+					"172.17.0.1:52052",
+					"172.18.0.1:52052",
+					"172.19.0.1:52052"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:56:41.093148508Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1280396427235372,
+				"StableID":   "nPSGmtqtzA11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:69d576d470a0f18fc3e8a2346dde64c6af1dc577ee58602c9129412f94879d3d",
+				"KeyExpiry":  "2026-11-08T21:56:41Z",
+				"DiscoKey":   "discokey:acb4265f67c4613c3f693d1d3a68a49dc9f85042a0f1b799547d34be96d1760e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:60475",
+					"10.65.0.27:60475",
+					"172.17.0.1:60475",
+					"172.18.0.1:60475",
+					"172.19.0.1:60475"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:56:41.595650817Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6212120508583290,
+				"StableID":   "njPJwZsUWq11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:080081dc68305e2a30346ab37d0143f68fd7a3c2fc4f35cd761511b010efca6f",
+				"KeyExpiry":  "2026-11-08T21:56:42Z",
+				"DiscoKey":   "discokey:822888fd2f30a174c341730597269dc69cff3ee43e6abeef67dc724133b41a55",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:45759",
+					"10.65.0.27:45759",
+					"172.17.0.1:45759",
+					"172.18.0.1:45759",
+					"172.19.0.1:45759"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:56:42.135615167Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1789215464978962,
+				"StableID":   "nHY4m4fLyE11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5bfdb12107324fa999868dec6a51398b801bb25a146d05737f54843328ed441f",
+				"KeyExpiry":  "2026-11-08T21:56:42Z",
+				"DiscoKey":   "discokey:76986d94ae87ab65bab49e1990e0b75a04eceaef3b76e371af6eca278b7ec476",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33237",
+					"10.65.0.27:33237",
+					"172.17.0.1:33237",
+					"172.18.0.1:33237",
+					"172.19.0.1:33237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:56:42.668573062Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "902388889648420": {
+				"ID":          902388889648420,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-dst-missing.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-dst-missing.hujson
@@ -1,0 +1,20074 @@
+// ssh-malformed-dst-missing
+//
+// ssh dst field missing is rejected
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T21:57:28Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-malformed-dst-missing",
+	"description":    "ssh dst field missing is rejected",
+	"category":       "ssh",
+	"captured_at":    "2026-05-12T21:57:28.040698407Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                            \n  \n                              \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh dst field missing is rejected\",\n\t\"id\":          \"ssh-malformed-dst-missing\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"src\":    [\"autogroup:member\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-malformed/ssh-malformed-dst-missing.hujson",
+		"full_policy": {
+			"ssh":       [{"action": "accept", "src": ["autogroup:member"], "users": ["root"]}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2227141973893581,
+				"StableID":   "nLQ8k6FgPJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       2227141973893581,
+				"Key":        "nodekey:9bb28d9fee91694ba201f8fa9b892ecd159fc6b937eea230453bad9e36b13d41",
+				"DiscoKey":   "discokey:966a1158aed0bd3c575198d257ff1c98cfdbfa62275935ed5342c6a9b8647809",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39500",
+					"10.65.0.27:39500",
+					"172.17.0.1:39500",
+					"172.18.0.1:39500",
+					"172.19.0.1:39500"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:57:36.815555524Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9bb28d9fee91694ba201f8fa9b892ecd159fc6b937eea230453bad9e36b13d41",
+			"MachineKey": "mkey:54d474f899ccd344bb4914721c2266839cd1a3bf98e0e7d86c73bcbb259aa704",
+			"Peers": [{
+				"ID":         3835531544211222,
+				"StableID":   "nKhGQmu7xW11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80c57e643d7230cd83eadaca191c6f6b7c043f42bde739d1b44a44b690d99e13",
+				"DiscoKey":   "discokey:240f1b1d15dceaa89a2ac90a8153fd6ac5a445c9218370d87062dff433d33767",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53625",
+					"10.65.0.27:53625",
+					"172.17.0.1:53625",
+					"172.18.0.1:53625",
+					"172.19.0.1:53625"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:57:30.705218022Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5053400927919207,
+				"StableID":   "navcSrGhTg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4eec174e94e5265f894542e9da04120935ab085538a801eae554bb041f757e16",
+				"DiscoKey":   "discokey:3f0ba6808c3c266b17361c85ddec5d5ee2b7c361f5efbfa286dc8df64eb01419",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33460",
+					"10.65.0.27:33460",
+					"172.17.0.1:33460",
+					"172.18.0.1:33460",
+					"172.19.0.1:33460"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:57:31.403219717Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1431121711049801,
+				"StableID":   "nLSex99ABC11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80814e86f57a4e9bf8dca66adffee85900a2aa40b57e05121f6050e1d9250905",
+				"DiscoKey":   "discokey:499522d29734e7488beac4aeaf38dcad75cc62b3c787cacc3f0acf5411c77328",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45997",
+					"10.65.0.27:45997",
+					"172.17.0.1:45997",
+					"172.18.0.1:45997",
+					"172.19.0.1:45997"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:57:31.92698939Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8797679479375496,
+				"StableID":   "nw6ZM48VhB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f8d49b1db6da1d5b47360482a2a7b2e93549744cb002881af18f7f6a5d68e34b",
+				"DiscoKey":   "discokey:87234e1d0138ed6e7754a91e9aef88acfaf2462d96512d11eb836108a9d95a76",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49095",
+					"10.65.0.27:49095",
+					"172.17.0.1:49095",
+					"172.18.0.1:49095",
+					"172.19.0.1:49095"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:57:32.472097813Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1606803170757636,
+				"StableID":   "nBSjxgziYD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5023a4b650230fa5ed3cdfd47ba8dbfdaaf0bb97b62caf2e864da24a4740d142",
+				"DiscoKey":   "discokey:80b0a655bf22658c4a539a67b759e73817554d2c250fcf63f4c8a028e567581f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38626",
+					"10.65.0.27:38626",
+					"172.17.0.1:38626",
+					"172.18.0.1:38626",
+					"172.19.0.1:38626"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:57:33.013921556Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7301265108723252,
+				"StableID":   "nfxheWrk1z11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7f76ec09442dac1d3a4e0124abd64ae07dcf0af57dba76c192f9e110d1d6572",
+				"DiscoKey":   "discokey:7bec8a0503998bbb8dd13a3298ec1ce68f9d4bd13b34fa9a87a0194e20f0bd21",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:45039",
+					"10.65.0.27:45039",
+					"172.17.0.1:45039",
+					"172.18.0.1:45039",
+					"172.19.0.1:45039"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:57:33.556676054Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7725380831528287,
+				"StableID":   "nL1zkxeqK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:851076fbb17553ad3562c4e5068f75c8c4381e4529b5667e5bf16276b617982e",
+				"DiscoKey":   "discokey:2a127fbf2829965e5810d951e52e376a0e37b791a4e58e196bf769a9cf691e59",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33036",
+					"10.65.0.27:33036",
+					"172.17.0.1:33036",
+					"172.18.0.1:33036",
+					"172.19.0.1:33036"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:57:34.106654517Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3259390454342569,
+				"StableID":   "nQt8CJfBTS11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95202187441c2d29a8a67a988a8f873fe4516ef5b51c1ce3239b0d801ca26c50",
+				"DiscoKey":   "discokey:8f68be9a4cfaa2afa8f08425919e97b706ce2408627c81825ed4f15c921c1722",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36040",
+					"10.65.0.27:36040",
+					"172.17.0.1:36040",
+					"172.18.0.1:36040",
+					"172.19.0.1:36040"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:57:34.642811075Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7893841243265663,
+				"StableID":   "nJviUnp8e421CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f903c66613498ebdfde07b231095e507f4500edb7eb08ded59e385a3165a362",
+				"DiscoKey":   "discokey:42a70adb2d721921f2091a1d6c2534b53acd3a04a6fc4bdf793efaecc1998a54",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:47940",
+					"10.65.0.27:47940",
+					"172.17.0.1:47940",
+					"172.18.0.1:47940",
+					"172.19.0.1:47940"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:57:35.194847963Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1292193024696988,
+				"StableID":   "nZVkgjiE6B11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8b19730604edff2413168902acbeab862001d7c954de21fc8daca97e83734555",
+				"DiscoKey":   "discokey:5a25f973b0c17fc93ce312aa25baadf05916e369c639b43e64395e531e709926",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:36487",
+					"10.65.0.27:36487",
+					"172.17.0.1:36487",
+					"172.18.0.1:36487",
+					"172.19.0.1:36487"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:57:35.748214886Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8984390482213008,
+				"StableID":   "nM3BKnh3AD21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9c6c24a352339461850ed2b53d2ebf93fd12138b41517a536341f2e73f210306",
+				"DiscoKey":   "discokey:2429db307a1dfca0de2cf04b87bf5d02dd08fe4c164560a22d3962e18f7c1213",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60941",
+					"10.65.0.27:60941",
+					"172.17.0.1:60941",
+					"172.18.0.1:60941",
+					"172.19.0.1:60941"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:57:36.27728915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5423371860281803,
+				"StableID":   "n2c4qNnFMj11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0a157d2cc2596f9caf86b52c7e511998d96d8999c579c8010baf457506352d5b",
+				"KeyExpiry":  "2026-11-08T21:57:37Z",
+				"DiscoKey":   "discokey:b45ba750459a2080080ba7c6f620cdb02a7aa056e8a801542d2ad04fd767df31",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40381",
+					"10.65.0.27:40381",
+					"172.17.0.1:40381",
+					"172.18.0.1:40381",
+					"172.19.0.1:40381"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:57:37.357686069Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1566322499998607,
+				"StableID":   "naAvhtdPED11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:903291a17725d6633f8e81da69d8656e70e2bcdf0305b8c63d855f09b7012146",
+				"KeyExpiry":  "2026-11-08T21:57:37Z",
+				"DiscoKey":   "discokey:b8829f603a7316df1e9f95098e134662a0d42255d01002a3c2b5993622fcdb51",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57540",
+					"10.65.0.27:57540",
+					"172.17.0.1:57540",
+					"172.18.0.1:57540",
+					"172.19.0.1:57540"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:57:37.897261107Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5677837163419591,
+				"StableID":   "nWSuHx9WLm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c376bc389837b99f1d72af3f7f1fef59c1a876668e3faf33b34e060a67d6bb18",
+				"KeyExpiry":  "2026-11-08T21:57:38Z",
+				"DiscoKey":   "discokey:cd9991e667bf070794faa469d5885c3729fdd3c3b413d426efda8edb11bb1a19",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45826",
+					"10.65.0.27:45826",
+					"172.17.0.1:45826",
+					"172.18.0.1:45826",
+					"172.19.0.1:45826"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:57:38.466788824Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2227141973893581": {
+				"ID":          2227141973893581,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7301265108723252,
+				"StableID":   "nfxheWrk1z11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       7301265108723252,
+				"Key":        "nodekey:e7f76ec09442dac1d3a4e0124abd64ae07dcf0af57dba76c192f9e110d1d6572",
+				"DiscoKey":   "discokey:7bec8a0503998bbb8dd13a3298ec1ce68f9d4bd13b34fa9a87a0194e20f0bd21",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:45039",
+					"10.65.0.27:45039",
+					"172.17.0.1:45039",
+					"172.18.0.1:45039",
+					"172.19.0.1:45039"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:57:33.556676054Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e7f76ec09442dac1d3a4e0124abd64ae07dcf0af57dba76c192f9e110d1d6572",
+			"MachineKey": "mkey:4fdeed8e082c94c25359c4bd2e375cb4522f1e9c90488884db2f5000f4a02e63",
+			"Peers": [{
+				"ID":         3835531544211222,
+				"StableID":   "nKhGQmu7xW11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80c57e643d7230cd83eadaca191c6f6b7c043f42bde739d1b44a44b690d99e13",
+				"DiscoKey":   "discokey:240f1b1d15dceaa89a2ac90a8153fd6ac5a445c9218370d87062dff433d33767",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53625",
+					"10.65.0.27:53625",
+					"172.17.0.1:53625",
+					"172.18.0.1:53625",
+					"172.19.0.1:53625"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:57:30.705218022Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5053400927919207,
+				"StableID":   "navcSrGhTg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4eec174e94e5265f894542e9da04120935ab085538a801eae554bb041f757e16",
+				"DiscoKey":   "discokey:3f0ba6808c3c266b17361c85ddec5d5ee2b7c361f5efbfa286dc8df64eb01419",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33460",
+					"10.65.0.27:33460",
+					"172.17.0.1:33460",
+					"172.18.0.1:33460",
+					"172.19.0.1:33460"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:57:31.403219717Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1431121711049801,
+				"StableID":   "nLSex99ABC11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80814e86f57a4e9bf8dca66adffee85900a2aa40b57e05121f6050e1d9250905",
+				"DiscoKey":   "discokey:499522d29734e7488beac4aeaf38dcad75cc62b3c787cacc3f0acf5411c77328",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45997",
+					"10.65.0.27:45997",
+					"172.17.0.1:45997",
+					"172.18.0.1:45997",
+					"172.19.0.1:45997"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:57:31.92698939Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8797679479375496,
+				"StableID":   "nw6ZM48VhB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f8d49b1db6da1d5b47360482a2a7b2e93549744cb002881af18f7f6a5d68e34b",
+				"DiscoKey":   "discokey:87234e1d0138ed6e7754a91e9aef88acfaf2462d96512d11eb836108a9d95a76",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49095",
+					"10.65.0.27:49095",
+					"172.17.0.1:49095",
+					"172.18.0.1:49095",
+					"172.19.0.1:49095"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:57:32.472097813Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1606803170757636,
+				"StableID":   "nBSjxgziYD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5023a4b650230fa5ed3cdfd47ba8dbfdaaf0bb97b62caf2e864da24a4740d142",
+				"DiscoKey":   "discokey:80b0a655bf22658c4a539a67b759e73817554d2c250fcf63f4c8a028e567581f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38626",
+					"10.65.0.27:38626",
+					"172.17.0.1:38626",
+					"172.18.0.1:38626",
+					"172.19.0.1:38626"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:57:33.013921556Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7725380831528287,
+				"StableID":   "nL1zkxeqK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:851076fbb17553ad3562c4e5068f75c8c4381e4529b5667e5bf16276b617982e",
+				"DiscoKey":   "discokey:2a127fbf2829965e5810d951e52e376a0e37b791a4e58e196bf769a9cf691e59",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33036",
+					"10.65.0.27:33036",
+					"172.17.0.1:33036",
+					"172.18.0.1:33036",
+					"172.19.0.1:33036"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:57:34.106654517Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3259390454342569,
+				"StableID":   "nQt8CJfBTS11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95202187441c2d29a8a67a988a8f873fe4516ef5b51c1ce3239b0d801ca26c50",
+				"DiscoKey":   "discokey:8f68be9a4cfaa2afa8f08425919e97b706ce2408627c81825ed4f15c921c1722",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36040",
+					"10.65.0.27:36040",
+					"172.17.0.1:36040",
+					"172.18.0.1:36040",
+					"172.19.0.1:36040"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:57:34.642811075Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7893841243265663,
+				"StableID":   "nJviUnp8e421CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f903c66613498ebdfde07b231095e507f4500edb7eb08ded59e385a3165a362",
+				"DiscoKey":   "discokey:42a70adb2d721921f2091a1d6c2534b53acd3a04a6fc4bdf793efaecc1998a54",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:47940",
+					"10.65.0.27:47940",
+					"172.17.0.1:47940",
+					"172.18.0.1:47940",
+					"172.19.0.1:47940"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:57:35.194847963Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1292193024696988,
+				"StableID":   "nZVkgjiE6B11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8b19730604edff2413168902acbeab862001d7c954de21fc8daca97e83734555",
+				"DiscoKey":   "discokey:5a25f973b0c17fc93ce312aa25baadf05916e369c639b43e64395e531e709926",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:36487",
+					"10.65.0.27:36487",
+					"172.17.0.1:36487",
+					"172.18.0.1:36487",
+					"172.19.0.1:36487"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:57:35.748214886Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8984390482213008,
+				"StableID":   "nM3BKnh3AD21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9c6c24a352339461850ed2b53d2ebf93fd12138b41517a536341f2e73f210306",
+				"DiscoKey":   "discokey:2429db307a1dfca0de2cf04b87bf5d02dd08fe4c164560a22d3962e18f7c1213",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60941",
+					"10.65.0.27:60941",
+					"172.17.0.1:60941",
+					"172.18.0.1:60941",
+					"172.19.0.1:60941"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:57:36.27728915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2227141973893581,
+				"StableID":   "nLQ8k6FgPJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9bb28d9fee91694ba201f8fa9b892ecd159fc6b937eea230453bad9e36b13d41",
+				"DiscoKey":   "discokey:966a1158aed0bd3c575198d257ff1c98cfdbfa62275935ed5342c6a9b8647809",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39500",
+					"10.65.0.27:39500",
+					"172.17.0.1:39500",
+					"172.18.0.1:39500",
+					"172.19.0.1:39500"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:57:36.815555524Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5423371860281803,
+				"StableID":   "n2c4qNnFMj11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0a157d2cc2596f9caf86b52c7e511998d96d8999c579c8010baf457506352d5b",
+				"KeyExpiry":  "2026-11-08T21:57:37Z",
+				"DiscoKey":   "discokey:b45ba750459a2080080ba7c6f620cdb02a7aa056e8a801542d2ad04fd767df31",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40381",
+					"10.65.0.27:40381",
+					"172.17.0.1:40381",
+					"172.18.0.1:40381",
+					"172.19.0.1:40381"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:57:37.357686069Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1566322499998607,
+				"StableID":   "naAvhtdPED11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:903291a17725d6633f8e81da69d8656e70e2bcdf0305b8c63d855f09b7012146",
+				"KeyExpiry":  "2026-11-08T21:57:37Z",
+				"DiscoKey":   "discokey:b8829f603a7316df1e9f95098e134662a0d42255d01002a3c2b5993622fcdb51",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57540",
+					"10.65.0.27:57540",
+					"172.17.0.1:57540",
+					"172.18.0.1:57540",
+					"172.19.0.1:57540"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:57:37.897261107Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5677837163419591,
+				"StableID":   "nWSuHx9WLm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c376bc389837b99f1d72af3f7f1fef59c1a876668e3faf33b34e060a67d6bb18",
+				"KeyExpiry":  "2026-11-08T21:57:38Z",
+				"DiscoKey":   "discokey:cd9991e667bf070794faa469d5885c3729fdd3c3b413d426efda8edb11bb1a19",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45826",
+					"10.65.0.27:45826",
+					"172.17.0.1:45826",
+					"172.18.0.1:45826",
+					"172.19.0.1:45826"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:57:38.466788824Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7301265108723252": {
+				"ID":          7301265108723252,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5677837163419591,
+				"StableID":   "nWSuHx9WLm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c376bc389837b99f1d72af3f7f1fef59c1a876668e3faf33b34e060a67d6bb18",
+				"KeyExpiry":  "2026-11-08T21:57:38Z",
+				"DiscoKey":   "discokey:cd9991e667bf070794faa469d5885c3729fdd3c3b413d426efda8edb11bb1a19",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45826",
+					"10.65.0.27:45826",
+					"172.17.0.1:45826",
+					"172.18.0.1:45826",
+					"172.19.0.1:45826"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:57:38.466788824Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c376bc389837b99f1d72af3f7f1fef59c1a876668e3faf33b34e060a67d6bb18",
+			"MachineKey": "mkey:e5b1dd9bca28bdfa4a4147ac55923ecac84a0e877ae3ca926a1785b119ce1311",
+			"Peers": [{
+				"ID":         3835531544211222,
+				"StableID":   "nKhGQmu7xW11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80c57e643d7230cd83eadaca191c6f6b7c043f42bde739d1b44a44b690d99e13",
+				"DiscoKey":   "discokey:240f1b1d15dceaa89a2ac90a8153fd6ac5a445c9218370d87062dff433d33767",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53625",
+					"10.65.0.27:53625",
+					"172.17.0.1:53625",
+					"172.18.0.1:53625",
+					"172.19.0.1:53625"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:57:30.705218022Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5053400927919207,
+				"StableID":   "navcSrGhTg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4eec174e94e5265f894542e9da04120935ab085538a801eae554bb041f757e16",
+				"DiscoKey":   "discokey:3f0ba6808c3c266b17361c85ddec5d5ee2b7c361f5efbfa286dc8df64eb01419",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33460",
+					"10.65.0.27:33460",
+					"172.17.0.1:33460",
+					"172.18.0.1:33460",
+					"172.19.0.1:33460"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:57:31.403219717Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1431121711049801,
+				"StableID":   "nLSex99ABC11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80814e86f57a4e9bf8dca66adffee85900a2aa40b57e05121f6050e1d9250905",
+				"DiscoKey":   "discokey:499522d29734e7488beac4aeaf38dcad75cc62b3c787cacc3f0acf5411c77328",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45997",
+					"10.65.0.27:45997",
+					"172.17.0.1:45997",
+					"172.18.0.1:45997",
+					"172.19.0.1:45997"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:57:31.92698939Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8797679479375496,
+				"StableID":   "nw6ZM48VhB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f8d49b1db6da1d5b47360482a2a7b2e93549744cb002881af18f7f6a5d68e34b",
+				"DiscoKey":   "discokey:87234e1d0138ed6e7754a91e9aef88acfaf2462d96512d11eb836108a9d95a76",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49095",
+					"10.65.0.27:49095",
+					"172.17.0.1:49095",
+					"172.18.0.1:49095",
+					"172.19.0.1:49095"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:57:32.472097813Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1606803170757636,
+				"StableID":   "nBSjxgziYD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5023a4b650230fa5ed3cdfd47ba8dbfdaaf0bb97b62caf2e864da24a4740d142",
+				"DiscoKey":   "discokey:80b0a655bf22658c4a539a67b759e73817554d2c250fcf63f4c8a028e567581f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38626",
+					"10.65.0.27:38626",
+					"172.17.0.1:38626",
+					"172.18.0.1:38626",
+					"172.19.0.1:38626"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:57:33.013921556Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7301265108723252,
+				"StableID":   "nfxheWrk1z11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7f76ec09442dac1d3a4e0124abd64ae07dcf0af57dba76c192f9e110d1d6572",
+				"DiscoKey":   "discokey:7bec8a0503998bbb8dd13a3298ec1ce68f9d4bd13b34fa9a87a0194e20f0bd21",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:45039",
+					"10.65.0.27:45039",
+					"172.17.0.1:45039",
+					"172.18.0.1:45039",
+					"172.19.0.1:45039"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:57:33.556676054Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7725380831528287,
+				"StableID":   "nL1zkxeqK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:851076fbb17553ad3562c4e5068f75c8c4381e4529b5667e5bf16276b617982e",
+				"DiscoKey":   "discokey:2a127fbf2829965e5810d951e52e376a0e37b791a4e58e196bf769a9cf691e59",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33036",
+					"10.65.0.27:33036",
+					"172.17.0.1:33036",
+					"172.18.0.1:33036",
+					"172.19.0.1:33036"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:57:34.106654517Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3259390454342569,
+				"StableID":   "nQt8CJfBTS11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95202187441c2d29a8a67a988a8f873fe4516ef5b51c1ce3239b0d801ca26c50",
+				"DiscoKey":   "discokey:8f68be9a4cfaa2afa8f08425919e97b706ce2408627c81825ed4f15c921c1722",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36040",
+					"10.65.0.27:36040",
+					"172.17.0.1:36040",
+					"172.18.0.1:36040",
+					"172.19.0.1:36040"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:57:34.642811075Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7893841243265663,
+				"StableID":   "nJviUnp8e421CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f903c66613498ebdfde07b231095e507f4500edb7eb08ded59e385a3165a362",
+				"DiscoKey":   "discokey:42a70adb2d721921f2091a1d6c2534b53acd3a04a6fc4bdf793efaecc1998a54",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:47940",
+					"10.65.0.27:47940",
+					"172.17.0.1:47940",
+					"172.18.0.1:47940",
+					"172.19.0.1:47940"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:57:35.194847963Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1292193024696988,
+				"StableID":   "nZVkgjiE6B11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8b19730604edff2413168902acbeab862001d7c954de21fc8daca97e83734555",
+				"DiscoKey":   "discokey:5a25f973b0c17fc93ce312aa25baadf05916e369c639b43e64395e531e709926",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:36487",
+					"10.65.0.27:36487",
+					"172.17.0.1:36487",
+					"172.18.0.1:36487",
+					"172.19.0.1:36487"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:57:35.748214886Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8984390482213008,
+				"StableID":   "nM3BKnh3AD21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9c6c24a352339461850ed2b53d2ebf93fd12138b41517a536341f2e73f210306",
+				"DiscoKey":   "discokey:2429db307a1dfca0de2cf04b87bf5d02dd08fe4c164560a22d3962e18f7c1213",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60941",
+					"10.65.0.27:60941",
+					"172.17.0.1:60941",
+					"172.18.0.1:60941",
+					"172.19.0.1:60941"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:57:36.27728915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2227141973893581,
+				"StableID":   "nLQ8k6FgPJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9bb28d9fee91694ba201f8fa9b892ecd159fc6b937eea230453bad9e36b13d41",
+				"DiscoKey":   "discokey:966a1158aed0bd3c575198d257ff1c98cfdbfa62275935ed5342c6a9b8647809",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39500",
+					"10.65.0.27:39500",
+					"172.17.0.1:39500",
+					"172.18.0.1:39500",
+					"172.19.0.1:39500"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:57:36.815555524Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5423371860281803,
+				"StableID":   "n2c4qNnFMj11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0a157d2cc2596f9caf86b52c7e511998d96d8999c579c8010baf457506352d5b",
+				"KeyExpiry":  "2026-11-08T21:57:37Z",
+				"DiscoKey":   "discokey:b45ba750459a2080080ba7c6f620cdb02a7aa056e8a801542d2ad04fd767df31",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40381",
+					"10.65.0.27:40381",
+					"172.17.0.1:40381",
+					"172.18.0.1:40381",
+					"172.19.0.1:40381"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:57:37.357686069Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1566322499998607,
+				"StableID":   "naAvhtdPED11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:903291a17725d6633f8e81da69d8656e70e2bcdf0305b8c63d855f09b7012146",
+				"KeyExpiry":  "2026-11-08T21:57:37Z",
+				"DiscoKey":   "discokey:b8829f603a7316df1e9f95098e134662a0d42255d01002a3c2b5993622fcdb51",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57540",
+					"10.65.0.27:57540",
+					"172.17.0.1:57540",
+					"172.18.0.1:57540",
+					"172.19.0.1:57540"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:57:37.897261107Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1431121711049801,
+				"StableID":   "nLSex99ABC11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1431121711049801,
+				"Key":        "nodekey:80814e86f57a4e9bf8dca66adffee85900a2aa40b57e05121f6050e1d9250905",
+				"DiscoKey":   "discokey:499522d29734e7488beac4aeaf38dcad75cc62b3c787cacc3f0acf5411c77328",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45997",
+					"10.65.0.27:45997",
+					"172.17.0.1:45997",
+					"172.18.0.1:45997",
+					"172.19.0.1:45997"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:57:31.92698939Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:80814e86f57a4e9bf8dca66adffee85900a2aa40b57e05121f6050e1d9250905",
+			"MachineKey": "mkey:c82c903dd021dc2f86a5cc1a2e712157b49594ef7a7efafaf61c798d577f103f",
+			"Peers": [{
+				"ID":         3835531544211222,
+				"StableID":   "nKhGQmu7xW11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80c57e643d7230cd83eadaca191c6f6b7c043f42bde739d1b44a44b690d99e13",
+				"DiscoKey":   "discokey:240f1b1d15dceaa89a2ac90a8153fd6ac5a445c9218370d87062dff433d33767",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53625",
+					"10.65.0.27:53625",
+					"172.17.0.1:53625",
+					"172.18.0.1:53625",
+					"172.19.0.1:53625"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:57:30.705218022Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5053400927919207,
+				"StableID":   "navcSrGhTg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4eec174e94e5265f894542e9da04120935ab085538a801eae554bb041f757e16",
+				"DiscoKey":   "discokey:3f0ba6808c3c266b17361c85ddec5d5ee2b7c361f5efbfa286dc8df64eb01419",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33460",
+					"10.65.0.27:33460",
+					"172.17.0.1:33460",
+					"172.18.0.1:33460",
+					"172.19.0.1:33460"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:57:31.403219717Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8797679479375496,
+				"StableID":   "nw6ZM48VhB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f8d49b1db6da1d5b47360482a2a7b2e93549744cb002881af18f7f6a5d68e34b",
+				"DiscoKey":   "discokey:87234e1d0138ed6e7754a91e9aef88acfaf2462d96512d11eb836108a9d95a76",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49095",
+					"10.65.0.27:49095",
+					"172.17.0.1:49095",
+					"172.18.0.1:49095",
+					"172.19.0.1:49095"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:57:32.472097813Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1606803170757636,
+				"StableID":   "nBSjxgziYD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5023a4b650230fa5ed3cdfd47ba8dbfdaaf0bb97b62caf2e864da24a4740d142",
+				"DiscoKey":   "discokey:80b0a655bf22658c4a539a67b759e73817554d2c250fcf63f4c8a028e567581f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38626",
+					"10.65.0.27:38626",
+					"172.17.0.1:38626",
+					"172.18.0.1:38626",
+					"172.19.0.1:38626"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:57:33.013921556Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7301265108723252,
+				"StableID":   "nfxheWrk1z11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7f76ec09442dac1d3a4e0124abd64ae07dcf0af57dba76c192f9e110d1d6572",
+				"DiscoKey":   "discokey:7bec8a0503998bbb8dd13a3298ec1ce68f9d4bd13b34fa9a87a0194e20f0bd21",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:45039",
+					"10.65.0.27:45039",
+					"172.17.0.1:45039",
+					"172.18.0.1:45039",
+					"172.19.0.1:45039"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:57:33.556676054Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7725380831528287,
+				"StableID":   "nL1zkxeqK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:851076fbb17553ad3562c4e5068f75c8c4381e4529b5667e5bf16276b617982e",
+				"DiscoKey":   "discokey:2a127fbf2829965e5810d951e52e376a0e37b791a4e58e196bf769a9cf691e59",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33036",
+					"10.65.0.27:33036",
+					"172.17.0.1:33036",
+					"172.18.0.1:33036",
+					"172.19.0.1:33036"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:57:34.106654517Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3259390454342569,
+				"StableID":   "nQt8CJfBTS11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95202187441c2d29a8a67a988a8f873fe4516ef5b51c1ce3239b0d801ca26c50",
+				"DiscoKey":   "discokey:8f68be9a4cfaa2afa8f08425919e97b706ce2408627c81825ed4f15c921c1722",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36040",
+					"10.65.0.27:36040",
+					"172.17.0.1:36040",
+					"172.18.0.1:36040",
+					"172.19.0.1:36040"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:57:34.642811075Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7893841243265663,
+				"StableID":   "nJviUnp8e421CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f903c66613498ebdfde07b231095e507f4500edb7eb08ded59e385a3165a362",
+				"DiscoKey":   "discokey:42a70adb2d721921f2091a1d6c2534b53acd3a04a6fc4bdf793efaecc1998a54",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:47940",
+					"10.65.0.27:47940",
+					"172.17.0.1:47940",
+					"172.18.0.1:47940",
+					"172.19.0.1:47940"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:57:35.194847963Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1292193024696988,
+				"StableID":   "nZVkgjiE6B11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8b19730604edff2413168902acbeab862001d7c954de21fc8daca97e83734555",
+				"DiscoKey":   "discokey:5a25f973b0c17fc93ce312aa25baadf05916e369c639b43e64395e531e709926",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:36487",
+					"10.65.0.27:36487",
+					"172.17.0.1:36487",
+					"172.18.0.1:36487",
+					"172.19.0.1:36487"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:57:35.748214886Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8984390482213008,
+				"StableID":   "nM3BKnh3AD21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9c6c24a352339461850ed2b53d2ebf93fd12138b41517a536341f2e73f210306",
+				"DiscoKey":   "discokey:2429db307a1dfca0de2cf04b87bf5d02dd08fe4c164560a22d3962e18f7c1213",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60941",
+					"10.65.0.27:60941",
+					"172.17.0.1:60941",
+					"172.18.0.1:60941",
+					"172.19.0.1:60941"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:57:36.27728915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2227141973893581,
+				"StableID":   "nLQ8k6FgPJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9bb28d9fee91694ba201f8fa9b892ecd159fc6b937eea230453bad9e36b13d41",
+				"DiscoKey":   "discokey:966a1158aed0bd3c575198d257ff1c98cfdbfa62275935ed5342c6a9b8647809",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39500",
+					"10.65.0.27:39500",
+					"172.17.0.1:39500",
+					"172.18.0.1:39500",
+					"172.19.0.1:39500"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:57:36.815555524Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5423371860281803,
+				"StableID":   "n2c4qNnFMj11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0a157d2cc2596f9caf86b52c7e511998d96d8999c579c8010baf457506352d5b",
+				"KeyExpiry":  "2026-11-08T21:57:37Z",
+				"DiscoKey":   "discokey:b45ba750459a2080080ba7c6f620cdb02a7aa056e8a801542d2ad04fd767df31",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40381",
+					"10.65.0.27:40381",
+					"172.17.0.1:40381",
+					"172.18.0.1:40381",
+					"172.19.0.1:40381"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:57:37.357686069Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1566322499998607,
+				"StableID":   "naAvhtdPED11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:903291a17725d6633f8e81da69d8656e70e2bcdf0305b8c63d855f09b7012146",
+				"KeyExpiry":  "2026-11-08T21:57:37Z",
+				"DiscoKey":   "discokey:b8829f603a7316df1e9f95098e134662a0d42255d01002a3c2b5993622fcdb51",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57540",
+					"10.65.0.27:57540",
+					"172.17.0.1:57540",
+					"172.18.0.1:57540",
+					"172.19.0.1:57540"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:57:37.897261107Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5677837163419591,
+				"StableID":   "nWSuHx9WLm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c376bc389837b99f1d72af3f7f1fef59c1a876668e3faf33b34e060a67d6bb18",
+				"KeyExpiry":  "2026-11-08T21:57:38Z",
+				"DiscoKey":   "discokey:cd9991e667bf070794faa469d5885c3729fdd3c3b413d426efda8edb11bb1a19",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45826",
+					"10.65.0.27:45826",
+					"172.17.0.1:45826",
+					"172.18.0.1:45826",
+					"172.19.0.1:45826"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:57:38.466788824Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1431121711049801": {
+				"ID":          1431121711049801,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3259390454342569,
+				"StableID":   "nQt8CJfBTS11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       3259390454342569,
+				"Key":        "nodekey:95202187441c2d29a8a67a988a8f873fe4516ef5b51c1ce3239b0d801ca26c50",
+				"DiscoKey":   "discokey:8f68be9a4cfaa2afa8f08425919e97b706ce2408627c81825ed4f15c921c1722",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36040",
+					"10.65.0.27:36040",
+					"172.17.0.1:36040",
+					"172.18.0.1:36040",
+					"172.19.0.1:36040"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:57:34.642811075Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:95202187441c2d29a8a67a988a8f873fe4516ef5b51c1ce3239b0d801ca26c50",
+			"MachineKey": "mkey:0c2c33e2048a655012edab63288798bfe73b4ea94d2148e76b4a0af7b4ac575c",
+			"Peers": [{
+				"ID":         3835531544211222,
+				"StableID":   "nKhGQmu7xW11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80c57e643d7230cd83eadaca191c6f6b7c043f42bde739d1b44a44b690d99e13",
+				"DiscoKey":   "discokey:240f1b1d15dceaa89a2ac90a8153fd6ac5a445c9218370d87062dff433d33767",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53625",
+					"10.65.0.27:53625",
+					"172.17.0.1:53625",
+					"172.18.0.1:53625",
+					"172.19.0.1:53625"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:57:30.705218022Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5053400927919207,
+				"StableID":   "navcSrGhTg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4eec174e94e5265f894542e9da04120935ab085538a801eae554bb041f757e16",
+				"DiscoKey":   "discokey:3f0ba6808c3c266b17361c85ddec5d5ee2b7c361f5efbfa286dc8df64eb01419",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33460",
+					"10.65.0.27:33460",
+					"172.17.0.1:33460",
+					"172.18.0.1:33460",
+					"172.19.0.1:33460"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:57:31.403219717Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1431121711049801,
+				"StableID":   "nLSex99ABC11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80814e86f57a4e9bf8dca66adffee85900a2aa40b57e05121f6050e1d9250905",
+				"DiscoKey":   "discokey:499522d29734e7488beac4aeaf38dcad75cc62b3c787cacc3f0acf5411c77328",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45997",
+					"10.65.0.27:45997",
+					"172.17.0.1:45997",
+					"172.18.0.1:45997",
+					"172.19.0.1:45997"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:57:31.92698939Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8797679479375496,
+				"StableID":   "nw6ZM48VhB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f8d49b1db6da1d5b47360482a2a7b2e93549744cb002881af18f7f6a5d68e34b",
+				"DiscoKey":   "discokey:87234e1d0138ed6e7754a91e9aef88acfaf2462d96512d11eb836108a9d95a76",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49095",
+					"10.65.0.27:49095",
+					"172.17.0.1:49095",
+					"172.18.0.1:49095",
+					"172.19.0.1:49095"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:57:32.472097813Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1606803170757636,
+				"StableID":   "nBSjxgziYD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5023a4b650230fa5ed3cdfd47ba8dbfdaaf0bb97b62caf2e864da24a4740d142",
+				"DiscoKey":   "discokey:80b0a655bf22658c4a539a67b759e73817554d2c250fcf63f4c8a028e567581f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38626",
+					"10.65.0.27:38626",
+					"172.17.0.1:38626",
+					"172.18.0.1:38626",
+					"172.19.0.1:38626"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:57:33.013921556Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7301265108723252,
+				"StableID":   "nfxheWrk1z11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7f76ec09442dac1d3a4e0124abd64ae07dcf0af57dba76c192f9e110d1d6572",
+				"DiscoKey":   "discokey:7bec8a0503998bbb8dd13a3298ec1ce68f9d4bd13b34fa9a87a0194e20f0bd21",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:45039",
+					"10.65.0.27:45039",
+					"172.17.0.1:45039",
+					"172.18.0.1:45039",
+					"172.19.0.1:45039"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:57:33.556676054Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7725380831528287,
+				"StableID":   "nL1zkxeqK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:851076fbb17553ad3562c4e5068f75c8c4381e4529b5667e5bf16276b617982e",
+				"DiscoKey":   "discokey:2a127fbf2829965e5810d951e52e376a0e37b791a4e58e196bf769a9cf691e59",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33036",
+					"10.65.0.27:33036",
+					"172.17.0.1:33036",
+					"172.18.0.1:33036",
+					"172.19.0.1:33036"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:57:34.106654517Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7893841243265663,
+				"StableID":   "nJviUnp8e421CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f903c66613498ebdfde07b231095e507f4500edb7eb08ded59e385a3165a362",
+				"DiscoKey":   "discokey:42a70adb2d721921f2091a1d6c2534b53acd3a04a6fc4bdf793efaecc1998a54",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:47940",
+					"10.65.0.27:47940",
+					"172.17.0.1:47940",
+					"172.18.0.1:47940",
+					"172.19.0.1:47940"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:57:35.194847963Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1292193024696988,
+				"StableID":   "nZVkgjiE6B11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8b19730604edff2413168902acbeab862001d7c954de21fc8daca97e83734555",
+				"DiscoKey":   "discokey:5a25f973b0c17fc93ce312aa25baadf05916e369c639b43e64395e531e709926",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:36487",
+					"10.65.0.27:36487",
+					"172.17.0.1:36487",
+					"172.18.0.1:36487",
+					"172.19.0.1:36487"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:57:35.748214886Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8984390482213008,
+				"StableID":   "nM3BKnh3AD21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9c6c24a352339461850ed2b53d2ebf93fd12138b41517a536341f2e73f210306",
+				"DiscoKey":   "discokey:2429db307a1dfca0de2cf04b87bf5d02dd08fe4c164560a22d3962e18f7c1213",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60941",
+					"10.65.0.27:60941",
+					"172.17.0.1:60941",
+					"172.18.0.1:60941",
+					"172.19.0.1:60941"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:57:36.27728915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2227141973893581,
+				"StableID":   "nLQ8k6FgPJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9bb28d9fee91694ba201f8fa9b892ecd159fc6b937eea230453bad9e36b13d41",
+				"DiscoKey":   "discokey:966a1158aed0bd3c575198d257ff1c98cfdbfa62275935ed5342c6a9b8647809",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39500",
+					"10.65.0.27:39500",
+					"172.17.0.1:39500",
+					"172.18.0.1:39500",
+					"172.19.0.1:39500"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:57:36.815555524Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5423371860281803,
+				"StableID":   "n2c4qNnFMj11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0a157d2cc2596f9caf86b52c7e511998d96d8999c579c8010baf457506352d5b",
+				"KeyExpiry":  "2026-11-08T21:57:37Z",
+				"DiscoKey":   "discokey:b45ba750459a2080080ba7c6f620cdb02a7aa056e8a801542d2ad04fd767df31",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40381",
+					"10.65.0.27:40381",
+					"172.17.0.1:40381",
+					"172.18.0.1:40381",
+					"172.19.0.1:40381"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:57:37.357686069Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1566322499998607,
+				"StableID":   "naAvhtdPED11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:903291a17725d6633f8e81da69d8656e70e2bcdf0305b8c63d855f09b7012146",
+				"KeyExpiry":  "2026-11-08T21:57:37Z",
+				"DiscoKey":   "discokey:b8829f603a7316df1e9f95098e134662a0d42255d01002a3c2b5993622fcdb51",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57540",
+					"10.65.0.27:57540",
+					"172.17.0.1:57540",
+					"172.18.0.1:57540",
+					"172.19.0.1:57540"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:57:37.897261107Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5677837163419591,
+				"StableID":   "nWSuHx9WLm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c376bc389837b99f1d72af3f7f1fef59c1a876668e3faf33b34e060a67d6bb18",
+				"KeyExpiry":  "2026-11-08T21:57:38Z",
+				"DiscoKey":   "discokey:cd9991e667bf070794faa469d5885c3729fdd3c3b413d426efda8edb11bb1a19",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45826",
+					"10.65.0.27:45826",
+					"172.17.0.1:45826",
+					"172.18.0.1:45826",
+					"172.19.0.1:45826"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:57:38.466788824Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3259390454342569": {
+				"ID":          3259390454342569,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5423371860281803,
+				"StableID":   "n2c4qNnFMj11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0a157d2cc2596f9caf86b52c7e511998d96d8999c579c8010baf457506352d5b",
+				"KeyExpiry":  "2026-11-08T21:57:37Z",
+				"DiscoKey":   "discokey:b45ba750459a2080080ba7c6f620cdb02a7aa056e8a801542d2ad04fd767df31",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40381",
+					"10.65.0.27:40381",
+					"172.17.0.1:40381",
+					"172.18.0.1:40381",
+					"172.19.0.1:40381"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:57:37.357686069Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0a157d2cc2596f9caf86b52c7e511998d96d8999c579c8010baf457506352d5b",
+			"MachineKey": "mkey:e97231468e0df539547618a70f68bdcad1763c40492cb72efe33894688636873",
+			"Peers": [{
+				"ID":         3835531544211222,
+				"StableID":   "nKhGQmu7xW11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80c57e643d7230cd83eadaca191c6f6b7c043f42bde739d1b44a44b690d99e13",
+				"DiscoKey":   "discokey:240f1b1d15dceaa89a2ac90a8153fd6ac5a445c9218370d87062dff433d33767",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53625",
+					"10.65.0.27:53625",
+					"172.17.0.1:53625",
+					"172.18.0.1:53625",
+					"172.19.0.1:53625"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:57:30.705218022Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5053400927919207,
+				"StableID":   "navcSrGhTg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4eec174e94e5265f894542e9da04120935ab085538a801eae554bb041f757e16",
+				"DiscoKey":   "discokey:3f0ba6808c3c266b17361c85ddec5d5ee2b7c361f5efbfa286dc8df64eb01419",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33460",
+					"10.65.0.27:33460",
+					"172.17.0.1:33460",
+					"172.18.0.1:33460",
+					"172.19.0.1:33460"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:57:31.403219717Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1431121711049801,
+				"StableID":   "nLSex99ABC11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80814e86f57a4e9bf8dca66adffee85900a2aa40b57e05121f6050e1d9250905",
+				"DiscoKey":   "discokey:499522d29734e7488beac4aeaf38dcad75cc62b3c787cacc3f0acf5411c77328",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45997",
+					"10.65.0.27:45997",
+					"172.17.0.1:45997",
+					"172.18.0.1:45997",
+					"172.19.0.1:45997"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:57:31.92698939Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8797679479375496,
+				"StableID":   "nw6ZM48VhB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f8d49b1db6da1d5b47360482a2a7b2e93549744cb002881af18f7f6a5d68e34b",
+				"DiscoKey":   "discokey:87234e1d0138ed6e7754a91e9aef88acfaf2462d96512d11eb836108a9d95a76",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49095",
+					"10.65.0.27:49095",
+					"172.17.0.1:49095",
+					"172.18.0.1:49095",
+					"172.19.0.1:49095"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:57:32.472097813Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1606803170757636,
+				"StableID":   "nBSjxgziYD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5023a4b650230fa5ed3cdfd47ba8dbfdaaf0bb97b62caf2e864da24a4740d142",
+				"DiscoKey":   "discokey:80b0a655bf22658c4a539a67b759e73817554d2c250fcf63f4c8a028e567581f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38626",
+					"10.65.0.27:38626",
+					"172.17.0.1:38626",
+					"172.18.0.1:38626",
+					"172.19.0.1:38626"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:57:33.013921556Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7301265108723252,
+				"StableID":   "nfxheWrk1z11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7f76ec09442dac1d3a4e0124abd64ae07dcf0af57dba76c192f9e110d1d6572",
+				"DiscoKey":   "discokey:7bec8a0503998bbb8dd13a3298ec1ce68f9d4bd13b34fa9a87a0194e20f0bd21",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:45039",
+					"10.65.0.27:45039",
+					"172.17.0.1:45039",
+					"172.18.0.1:45039",
+					"172.19.0.1:45039"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:57:33.556676054Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7725380831528287,
+				"StableID":   "nL1zkxeqK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:851076fbb17553ad3562c4e5068f75c8c4381e4529b5667e5bf16276b617982e",
+				"DiscoKey":   "discokey:2a127fbf2829965e5810d951e52e376a0e37b791a4e58e196bf769a9cf691e59",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33036",
+					"10.65.0.27:33036",
+					"172.17.0.1:33036",
+					"172.18.0.1:33036",
+					"172.19.0.1:33036"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:57:34.106654517Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3259390454342569,
+				"StableID":   "nQt8CJfBTS11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95202187441c2d29a8a67a988a8f873fe4516ef5b51c1ce3239b0d801ca26c50",
+				"DiscoKey":   "discokey:8f68be9a4cfaa2afa8f08425919e97b706ce2408627c81825ed4f15c921c1722",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36040",
+					"10.65.0.27:36040",
+					"172.17.0.1:36040",
+					"172.18.0.1:36040",
+					"172.19.0.1:36040"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:57:34.642811075Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7893841243265663,
+				"StableID":   "nJviUnp8e421CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f903c66613498ebdfde07b231095e507f4500edb7eb08ded59e385a3165a362",
+				"DiscoKey":   "discokey:42a70adb2d721921f2091a1d6c2534b53acd3a04a6fc4bdf793efaecc1998a54",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:47940",
+					"10.65.0.27:47940",
+					"172.17.0.1:47940",
+					"172.18.0.1:47940",
+					"172.19.0.1:47940"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:57:35.194847963Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1292193024696988,
+				"StableID":   "nZVkgjiE6B11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8b19730604edff2413168902acbeab862001d7c954de21fc8daca97e83734555",
+				"DiscoKey":   "discokey:5a25f973b0c17fc93ce312aa25baadf05916e369c639b43e64395e531e709926",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:36487",
+					"10.65.0.27:36487",
+					"172.17.0.1:36487",
+					"172.18.0.1:36487",
+					"172.19.0.1:36487"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:57:35.748214886Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8984390482213008,
+				"StableID":   "nM3BKnh3AD21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9c6c24a352339461850ed2b53d2ebf93fd12138b41517a536341f2e73f210306",
+				"DiscoKey":   "discokey:2429db307a1dfca0de2cf04b87bf5d02dd08fe4c164560a22d3962e18f7c1213",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60941",
+					"10.65.0.27:60941",
+					"172.17.0.1:60941",
+					"172.18.0.1:60941",
+					"172.19.0.1:60941"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:57:36.27728915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2227141973893581,
+				"StableID":   "nLQ8k6FgPJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9bb28d9fee91694ba201f8fa9b892ecd159fc6b937eea230453bad9e36b13d41",
+				"DiscoKey":   "discokey:966a1158aed0bd3c575198d257ff1c98cfdbfa62275935ed5342c6a9b8647809",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39500",
+					"10.65.0.27:39500",
+					"172.17.0.1:39500",
+					"172.18.0.1:39500",
+					"172.19.0.1:39500"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:57:36.815555524Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1566322499998607,
+				"StableID":   "naAvhtdPED11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:903291a17725d6633f8e81da69d8656e70e2bcdf0305b8c63d855f09b7012146",
+				"KeyExpiry":  "2026-11-08T21:57:37Z",
+				"DiscoKey":   "discokey:b8829f603a7316df1e9f95098e134662a0d42255d01002a3c2b5993622fcdb51",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57540",
+					"10.65.0.27:57540",
+					"172.17.0.1:57540",
+					"172.18.0.1:57540",
+					"172.19.0.1:57540"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:57:37.897261107Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5677837163419591,
+				"StableID":   "nWSuHx9WLm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c376bc389837b99f1d72af3f7f1fef59c1a876668e3faf33b34e060a67d6bb18",
+				"KeyExpiry":  "2026-11-08T21:57:38Z",
+				"DiscoKey":   "discokey:cd9991e667bf070794faa469d5885c3729fdd3c3b413d426efda8edb11bb1a19",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45826",
+					"10.65.0.27:45826",
+					"172.17.0.1:45826",
+					"172.18.0.1:45826",
+					"172.19.0.1:45826"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:57:38.466788824Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8984390482213008,
+				"StableID":   "nM3BKnh3AD21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       8984390482213008,
+				"Key":        "nodekey:9c6c24a352339461850ed2b53d2ebf93fd12138b41517a536341f2e73f210306",
+				"DiscoKey":   "discokey:2429db307a1dfca0de2cf04b87bf5d02dd08fe4c164560a22d3962e18f7c1213",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60941",
+					"10.65.0.27:60941",
+					"172.17.0.1:60941",
+					"172.18.0.1:60941",
+					"172.19.0.1:60941"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:57:36.27728915Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9c6c24a352339461850ed2b53d2ebf93fd12138b41517a536341f2e73f210306",
+			"MachineKey": "mkey:8b46631a752fc7f2b944da2ac77f10da1a04e56038388854c0512a647c35f922",
+			"Peers": [{
+				"ID":         3835531544211222,
+				"StableID":   "nKhGQmu7xW11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80c57e643d7230cd83eadaca191c6f6b7c043f42bde739d1b44a44b690d99e13",
+				"DiscoKey":   "discokey:240f1b1d15dceaa89a2ac90a8153fd6ac5a445c9218370d87062dff433d33767",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53625",
+					"10.65.0.27:53625",
+					"172.17.0.1:53625",
+					"172.18.0.1:53625",
+					"172.19.0.1:53625"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:57:30.705218022Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5053400927919207,
+				"StableID":   "navcSrGhTg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4eec174e94e5265f894542e9da04120935ab085538a801eae554bb041f757e16",
+				"DiscoKey":   "discokey:3f0ba6808c3c266b17361c85ddec5d5ee2b7c361f5efbfa286dc8df64eb01419",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33460",
+					"10.65.0.27:33460",
+					"172.17.0.1:33460",
+					"172.18.0.1:33460",
+					"172.19.0.1:33460"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:57:31.403219717Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1431121711049801,
+				"StableID":   "nLSex99ABC11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80814e86f57a4e9bf8dca66adffee85900a2aa40b57e05121f6050e1d9250905",
+				"DiscoKey":   "discokey:499522d29734e7488beac4aeaf38dcad75cc62b3c787cacc3f0acf5411c77328",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45997",
+					"10.65.0.27:45997",
+					"172.17.0.1:45997",
+					"172.18.0.1:45997",
+					"172.19.0.1:45997"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:57:31.92698939Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8797679479375496,
+				"StableID":   "nw6ZM48VhB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f8d49b1db6da1d5b47360482a2a7b2e93549744cb002881af18f7f6a5d68e34b",
+				"DiscoKey":   "discokey:87234e1d0138ed6e7754a91e9aef88acfaf2462d96512d11eb836108a9d95a76",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49095",
+					"10.65.0.27:49095",
+					"172.17.0.1:49095",
+					"172.18.0.1:49095",
+					"172.19.0.1:49095"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:57:32.472097813Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1606803170757636,
+				"StableID":   "nBSjxgziYD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5023a4b650230fa5ed3cdfd47ba8dbfdaaf0bb97b62caf2e864da24a4740d142",
+				"DiscoKey":   "discokey:80b0a655bf22658c4a539a67b759e73817554d2c250fcf63f4c8a028e567581f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38626",
+					"10.65.0.27:38626",
+					"172.17.0.1:38626",
+					"172.18.0.1:38626",
+					"172.19.0.1:38626"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:57:33.013921556Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7301265108723252,
+				"StableID":   "nfxheWrk1z11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7f76ec09442dac1d3a4e0124abd64ae07dcf0af57dba76c192f9e110d1d6572",
+				"DiscoKey":   "discokey:7bec8a0503998bbb8dd13a3298ec1ce68f9d4bd13b34fa9a87a0194e20f0bd21",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:45039",
+					"10.65.0.27:45039",
+					"172.17.0.1:45039",
+					"172.18.0.1:45039",
+					"172.19.0.1:45039"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:57:33.556676054Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7725380831528287,
+				"StableID":   "nL1zkxeqK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:851076fbb17553ad3562c4e5068f75c8c4381e4529b5667e5bf16276b617982e",
+				"DiscoKey":   "discokey:2a127fbf2829965e5810d951e52e376a0e37b791a4e58e196bf769a9cf691e59",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33036",
+					"10.65.0.27:33036",
+					"172.17.0.1:33036",
+					"172.18.0.1:33036",
+					"172.19.0.1:33036"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:57:34.106654517Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3259390454342569,
+				"StableID":   "nQt8CJfBTS11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95202187441c2d29a8a67a988a8f873fe4516ef5b51c1ce3239b0d801ca26c50",
+				"DiscoKey":   "discokey:8f68be9a4cfaa2afa8f08425919e97b706ce2408627c81825ed4f15c921c1722",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36040",
+					"10.65.0.27:36040",
+					"172.17.0.1:36040",
+					"172.18.0.1:36040",
+					"172.19.0.1:36040"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:57:34.642811075Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7893841243265663,
+				"StableID":   "nJviUnp8e421CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f903c66613498ebdfde07b231095e507f4500edb7eb08ded59e385a3165a362",
+				"DiscoKey":   "discokey:42a70adb2d721921f2091a1d6c2534b53acd3a04a6fc4bdf793efaecc1998a54",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:47940",
+					"10.65.0.27:47940",
+					"172.17.0.1:47940",
+					"172.18.0.1:47940",
+					"172.19.0.1:47940"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:57:35.194847963Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1292193024696988,
+				"StableID":   "nZVkgjiE6B11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8b19730604edff2413168902acbeab862001d7c954de21fc8daca97e83734555",
+				"DiscoKey":   "discokey:5a25f973b0c17fc93ce312aa25baadf05916e369c639b43e64395e531e709926",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:36487",
+					"10.65.0.27:36487",
+					"172.17.0.1:36487",
+					"172.18.0.1:36487",
+					"172.19.0.1:36487"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:57:35.748214886Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2227141973893581,
+				"StableID":   "nLQ8k6FgPJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9bb28d9fee91694ba201f8fa9b892ecd159fc6b937eea230453bad9e36b13d41",
+				"DiscoKey":   "discokey:966a1158aed0bd3c575198d257ff1c98cfdbfa62275935ed5342c6a9b8647809",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39500",
+					"10.65.0.27:39500",
+					"172.17.0.1:39500",
+					"172.18.0.1:39500",
+					"172.19.0.1:39500"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:57:36.815555524Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5423371860281803,
+				"StableID":   "n2c4qNnFMj11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0a157d2cc2596f9caf86b52c7e511998d96d8999c579c8010baf457506352d5b",
+				"KeyExpiry":  "2026-11-08T21:57:37Z",
+				"DiscoKey":   "discokey:b45ba750459a2080080ba7c6f620cdb02a7aa056e8a801542d2ad04fd767df31",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40381",
+					"10.65.0.27:40381",
+					"172.17.0.1:40381",
+					"172.18.0.1:40381",
+					"172.19.0.1:40381"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:57:37.357686069Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1566322499998607,
+				"StableID":   "naAvhtdPED11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:903291a17725d6633f8e81da69d8656e70e2bcdf0305b8c63d855f09b7012146",
+				"KeyExpiry":  "2026-11-08T21:57:37Z",
+				"DiscoKey":   "discokey:b8829f603a7316df1e9f95098e134662a0d42255d01002a3c2b5993622fcdb51",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57540",
+					"10.65.0.27:57540",
+					"172.17.0.1:57540",
+					"172.18.0.1:57540",
+					"172.19.0.1:57540"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:57:37.897261107Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5677837163419591,
+				"StableID":   "nWSuHx9WLm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c376bc389837b99f1d72af3f7f1fef59c1a876668e3faf33b34e060a67d6bb18",
+				"KeyExpiry":  "2026-11-08T21:57:38Z",
+				"DiscoKey":   "discokey:cd9991e667bf070794faa469d5885c3729fdd3c3b413d426efda8edb11bb1a19",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45826",
+					"10.65.0.27:45826",
+					"172.17.0.1:45826",
+					"172.18.0.1:45826",
+					"172.19.0.1:45826"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:57:38.466788824Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8984390482213008": {
+				"ID":          8984390482213008,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5053400927919207,
+				"StableID":   "navcSrGhTg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       5053400927919207,
+				"Key":        "nodekey:4eec174e94e5265f894542e9da04120935ab085538a801eae554bb041f757e16",
+				"DiscoKey":   "discokey:3f0ba6808c3c266b17361c85ddec5d5ee2b7c361f5efbfa286dc8df64eb01419",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33460",
+					"10.65.0.27:33460",
+					"172.17.0.1:33460",
+					"172.18.0.1:33460",
+					"172.19.0.1:33460"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:57:31.403219717Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4eec174e94e5265f894542e9da04120935ab085538a801eae554bb041f757e16",
+			"MachineKey": "mkey:dee001422ba0da547a1f7138a4f76a4f29d4008e0109cfc326f3117bde240026",
+			"Peers": [{
+				"ID":         3835531544211222,
+				"StableID":   "nKhGQmu7xW11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80c57e643d7230cd83eadaca191c6f6b7c043f42bde739d1b44a44b690d99e13",
+				"DiscoKey":   "discokey:240f1b1d15dceaa89a2ac90a8153fd6ac5a445c9218370d87062dff433d33767",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53625",
+					"10.65.0.27:53625",
+					"172.17.0.1:53625",
+					"172.18.0.1:53625",
+					"172.19.0.1:53625"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:57:30.705218022Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1431121711049801,
+				"StableID":   "nLSex99ABC11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80814e86f57a4e9bf8dca66adffee85900a2aa40b57e05121f6050e1d9250905",
+				"DiscoKey":   "discokey:499522d29734e7488beac4aeaf38dcad75cc62b3c787cacc3f0acf5411c77328",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45997",
+					"10.65.0.27:45997",
+					"172.17.0.1:45997",
+					"172.18.0.1:45997",
+					"172.19.0.1:45997"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:57:31.92698939Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8797679479375496,
+				"StableID":   "nw6ZM48VhB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f8d49b1db6da1d5b47360482a2a7b2e93549744cb002881af18f7f6a5d68e34b",
+				"DiscoKey":   "discokey:87234e1d0138ed6e7754a91e9aef88acfaf2462d96512d11eb836108a9d95a76",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49095",
+					"10.65.0.27:49095",
+					"172.17.0.1:49095",
+					"172.18.0.1:49095",
+					"172.19.0.1:49095"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:57:32.472097813Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1606803170757636,
+				"StableID":   "nBSjxgziYD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5023a4b650230fa5ed3cdfd47ba8dbfdaaf0bb97b62caf2e864da24a4740d142",
+				"DiscoKey":   "discokey:80b0a655bf22658c4a539a67b759e73817554d2c250fcf63f4c8a028e567581f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38626",
+					"10.65.0.27:38626",
+					"172.17.0.1:38626",
+					"172.18.0.1:38626",
+					"172.19.0.1:38626"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:57:33.013921556Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7301265108723252,
+				"StableID":   "nfxheWrk1z11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7f76ec09442dac1d3a4e0124abd64ae07dcf0af57dba76c192f9e110d1d6572",
+				"DiscoKey":   "discokey:7bec8a0503998bbb8dd13a3298ec1ce68f9d4bd13b34fa9a87a0194e20f0bd21",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:45039",
+					"10.65.0.27:45039",
+					"172.17.0.1:45039",
+					"172.18.0.1:45039",
+					"172.19.0.1:45039"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:57:33.556676054Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7725380831528287,
+				"StableID":   "nL1zkxeqK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:851076fbb17553ad3562c4e5068f75c8c4381e4529b5667e5bf16276b617982e",
+				"DiscoKey":   "discokey:2a127fbf2829965e5810d951e52e376a0e37b791a4e58e196bf769a9cf691e59",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33036",
+					"10.65.0.27:33036",
+					"172.17.0.1:33036",
+					"172.18.0.1:33036",
+					"172.19.0.1:33036"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:57:34.106654517Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3259390454342569,
+				"StableID":   "nQt8CJfBTS11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95202187441c2d29a8a67a988a8f873fe4516ef5b51c1ce3239b0d801ca26c50",
+				"DiscoKey":   "discokey:8f68be9a4cfaa2afa8f08425919e97b706ce2408627c81825ed4f15c921c1722",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36040",
+					"10.65.0.27:36040",
+					"172.17.0.1:36040",
+					"172.18.0.1:36040",
+					"172.19.0.1:36040"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:57:34.642811075Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7893841243265663,
+				"StableID":   "nJviUnp8e421CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f903c66613498ebdfde07b231095e507f4500edb7eb08ded59e385a3165a362",
+				"DiscoKey":   "discokey:42a70adb2d721921f2091a1d6c2534b53acd3a04a6fc4bdf793efaecc1998a54",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:47940",
+					"10.65.0.27:47940",
+					"172.17.0.1:47940",
+					"172.18.0.1:47940",
+					"172.19.0.1:47940"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:57:35.194847963Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1292193024696988,
+				"StableID":   "nZVkgjiE6B11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8b19730604edff2413168902acbeab862001d7c954de21fc8daca97e83734555",
+				"DiscoKey":   "discokey:5a25f973b0c17fc93ce312aa25baadf05916e369c639b43e64395e531e709926",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:36487",
+					"10.65.0.27:36487",
+					"172.17.0.1:36487",
+					"172.18.0.1:36487",
+					"172.19.0.1:36487"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:57:35.748214886Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8984390482213008,
+				"StableID":   "nM3BKnh3AD21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9c6c24a352339461850ed2b53d2ebf93fd12138b41517a536341f2e73f210306",
+				"DiscoKey":   "discokey:2429db307a1dfca0de2cf04b87bf5d02dd08fe4c164560a22d3962e18f7c1213",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60941",
+					"10.65.0.27:60941",
+					"172.17.0.1:60941",
+					"172.18.0.1:60941",
+					"172.19.0.1:60941"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:57:36.27728915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2227141973893581,
+				"StableID":   "nLQ8k6FgPJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9bb28d9fee91694ba201f8fa9b892ecd159fc6b937eea230453bad9e36b13d41",
+				"DiscoKey":   "discokey:966a1158aed0bd3c575198d257ff1c98cfdbfa62275935ed5342c6a9b8647809",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39500",
+					"10.65.0.27:39500",
+					"172.17.0.1:39500",
+					"172.18.0.1:39500",
+					"172.19.0.1:39500"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:57:36.815555524Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5423371860281803,
+				"StableID":   "n2c4qNnFMj11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0a157d2cc2596f9caf86b52c7e511998d96d8999c579c8010baf457506352d5b",
+				"KeyExpiry":  "2026-11-08T21:57:37Z",
+				"DiscoKey":   "discokey:b45ba750459a2080080ba7c6f620cdb02a7aa056e8a801542d2ad04fd767df31",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40381",
+					"10.65.0.27:40381",
+					"172.17.0.1:40381",
+					"172.18.0.1:40381",
+					"172.19.0.1:40381"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:57:37.357686069Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1566322499998607,
+				"StableID":   "naAvhtdPED11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:903291a17725d6633f8e81da69d8656e70e2bcdf0305b8c63d855f09b7012146",
+				"KeyExpiry":  "2026-11-08T21:57:37Z",
+				"DiscoKey":   "discokey:b8829f603a7316df1e9f95098e134662a0d42255d01002a3c2b5993622fcdb51",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57540",
+					"10.65.0.27:57540",
+					"172.17.0.1:57540",
+					"172.18.0.1:57540",
+					"172.19.0.1:57540"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:57:37.897261107Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5677837163419591,
+				"StableID":   "nWSuHx9WLm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c376bc389837b99f1d72af3f7f1fef59c1a876668e3faf33b34e060a67d6bb18",
+				"KeyExpiry":  "2026-11-08T21:57:38Z",
+				"DiscoKey":   "discokey:cd9991e667bf070794faa469d5885c3729fdd3c3b413d426efda8edb11bb1a19",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45826",
+					"10.65.0.27:45826",
+					"172.17.0.1:45826",
+					"172.18.0.1:45826",
+					"172.19.0.1:45826"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:57:38.466788824Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5053400927919207": {
+				"ID":          5053400927919207,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3835531544211222,
+				"StableID":   "nKhGQmu7xW11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       3835531544211222,
+				"Key":        "nodekey:80c57e643d7230cd83eadaca191c6f6b7c043f42bde739d1b44a44b690d99e13",
+				"DiscoKey":   "discokey:240f1b1d15dceaa89a2ac90a8153fd6ac5a445c9218370d87062dff433d33767",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53625",
+					"10.65.0.27:53625",
+					"172.17.0.1:53625",
+					"172.18.0.1:53625",
+					"172.19.0.1:53625"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:57:30.705218022Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:80c57e643d7230cd83eadaca191c6f6b7c043f42bde739d1b44a44b690d99e13",
+			"MachineKey": "mkey:806ed2846672fb6b0d67479db2aa2be2b118f9e8cd3d7a390bac469e4ef8b771",
+			"Peers": [{
+				"ID":         5053400927919207,
+				"StableID":   "navcSrGhTg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4eec174e94e5265f894542e9da04120935ab085538a801eae554bb041f757e16",
+				"DiscoKey":   "discokey:3f0ba6808c3c266b17361c85ddec5d5ee2b7c361f5efbfa286dc8df64eb01419",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33460",
+					"10.65.0.27:33460",
+					"172.17.0.1:33460",
+					"172.18.0.1:33460",
+					"172.19.0.1:33460"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:57:31.403219717Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1431121711049801,
+				"StableID":   "nLSex99ABC11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80814e86f57a4e9bf8dca66adffee85900a2aa40b57e05121f6050e1d9250905",
+				"DiscoKey":   "discokey:499522d29734e7488beac4aeaf38dcad75cc62b3c787cacc3f0acf5411c77328",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45997",
+					"10.65.0.27:45997",
+					"172.17.0.1:45997",
+					"172.18.0.1:45997",
+					"172.19.0.1:45997"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:57:31.92698939Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8797679479375496,
+				"StableID":   "nw6ZM48VhB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f8d49b1db6da1d5b47360482a2a7b2e93549744cb002881af18f7f6a5d68e34b",
+				"DiscoKey":   "discokey:87234e1d0138ed6e7754a91e9aef88acfaf2462d96512d11eb836108a9d95a76",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49095",
+					"10.65.0.27:49095",
+					"172.17.0.1:49095",
+					"172.18.0.1:49095",
+					"172.19.0.1:49095"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:57:32.472097813Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1606803170757636,
+				"StableID":   "nBSjxgziYD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5023a4b650230fa5ed3cdfd47ba8dbfdaaf0bb97b62caf2e864da24a4740d142",
+				"DiscoKey":   "discokey:80b0a655bf22658c4a539a67b759e73817554d2c250fcf63f4c8a028e567581f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38626",
+					"10.65.0.27:38626",
+					"172.17.0.1:38626",
+					"172.18.0.1:38626",
+					"172.19.0.1:38626"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:57:33.013921556Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7301265108723252,
+				"StableID":   "nfxheWrk1z11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7f76ec09442dac1d3a4e0124abd64ae07dcf0af57dba76c192f9e110d1d6572",
+				"DiscoKey":   "discokey:7bec8a0503998bbb8dd13a3298ec1ce68f9d4bd13b34fa9a87a0194e20f0bd21",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:45039",
+					"10.65.0.27:45039",
+					"172.17.0.1:45039",
+					"172.18.0.1:45039",
+					"172.19.0.1:45039"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:57:33.556676054Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7725380831528287,
+				"StableID":   "nL1zkxeqK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:851076fbb17553ad3562c4e5068f75c8c4381e4529b5667e5bf16276b617982e",
+				"DiscoKey":   "discokey:2a127fbf2829965e5810d951e52e376a0e37b791a4e58e196bf769a9cf691e59",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33036",
+					"10.65.0.27:33036",
+					"172.17.0.1:33036",
+					"172.18.0.1:33036",
+					"172.19.0.1:33036"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:57:34.106654517Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3259390454342569,
+				"StableID":   "nQt8CJfBTS11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95202187441c2d29a8a67a988a8f873fe4516ef5b51c1ce3239b0d801ca26c50",
+				"DiscoKey":   "discokey:8f68be9a4cfaa2afa8f08425919e97b706ce2408627c81825ed4f15c921c1722",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36040",
+					"10.65.0.27:36040",
+					"172.17.0.1:36040",
+					"172.18.0.1:36040",
+					"172.19.0.1:36040"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:57:34.642811075Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7893841243265663,
+				"StableID":   "nJviUnp8e421CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f903c66613498ebdfde07b231095e507f4500edb7eb08ded59e385a3165a362",
+				"DiscoKey":   "discokey:42a70adb2d721921f2091a1d6c2534b53acd3a04a6fc4bdf793efaecc1998a54",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:47940",
+					"10.65.0.27:47940",
+					"172.17.0.1:47940",
+					"172.18.0.1:47940",
+					"172.19.0.1:47940"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:57:35.194847963Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1292193024696988,
+				"StableID":   "nZVkgjiE6B11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8b19730604edff2413168902acbeab862001d7c954de21fc8daca97e83734555",
+				"DiscoKey":   "discokey:5a25f973b0c17fc93ce312aa25baadf05916e369c639b43e64395e531e709926",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:36487",
+					"10.65.0.27:36487",
+					"172.17.0.1:36487",
+					"172.18.0.1:36487",
+					"172.19.0.1:36487"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:57:35.748214886Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8984390482213008,
+				"StableID":   "nM3BKnh3AD21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9c6c24a352339461850ed2b53d2ebf93fd12138b41517a536341f2e73f210306",
+				"DiscoKey":   "discokey:2429db307a1dfca0de2cf04b87bf5d02dd08fe4c164560a22d3962e18f7c1213",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60941",
+					"10.65.0.27:60941",
+					"172.17.0.1:60941",
+					"172.18.0.1:60941",
+					"172.19.0.1:60941"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:57:36.27728915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2227141973893581,
+				"StableID":   "nLQ8k6FgPJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9bb28d9fee91694ba201f8fa9b892ecd159fc6b937eea230453bad9e36b13d41",
+				"DiscoKey":   "discokey:966a1158aed0bd3c575198d257ff1c98cfdbfa62275935ed5342c6a9b8647809",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39500",
+					"10.65.0.27:39500",
+					"172.17.0.1:39500",
+					"172.18.0.1:39500",
+					"172.19.0.1:39500"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:57:36.815555524Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5423371860281803,
+				"StableID":   "n2c4qNnFMj11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0a157d2cc2596f9caf86b52c7e511998d96d8999c579c8010baf457506352d5b",
+				"KeyExpiry":  "2026-11-08T21:57:37Z",
+				"DiscoKey":   "discokey:b45ba750459a2080080ba7c6f620cdb02a7aa056e8a801542d2ad04fd767df31",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40381",
+					"10.65.0.27:40381",
+					"172.17.0.1:40381",
+					"172.18.0.1:40381",
+					"172.19.0.1:40381"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:57:37.357686069Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1566322499998607,
+				"StableID":   "naAvhtdPED11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:903291a17725d6633f8e81da69d8656e70e2bcdf0305b8c63d855f09b7012146",
+				"KeyExpiry":  "2026-11-08T21:57:37Z",
+				"DiscoKey":   "discokey:b8829f603a7316df1e9f95098e134662a0d42255d01002a3c2b5993622fcdb51",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57540",
+					"10.65.0.27:57540",
+					"172.17.0.1:57540",
+					"172.18.0.1:57540",
+					"172.19.0.1:57540"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:57:37.897261107Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5677837163419591,
+				"StableID":   "nWSuHx9WLm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c376bc389837b99f1d72af3f7f1fef59c1a876668e3faf33b34e060a67d6bb18",
+				"KeyExpiry":  "2026-11-08T21:57:38Z",
+				"DiscoKey":   "discokey:cd9991e667bf070794faa469d5885c3729fdd3c3b413d426efda8edb11bb1a19",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45826",
+					"10.65.0.27:45826",
+					"172.17.0.1:45826",
+					"172.18.0.1:45826",
+					"172.19.0.1:45826"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:57:38.466788824Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3835531544211222": {
+				"ID":          3835531544211222,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1606803170757636,
+				"StableID":   "nBSjxgziYD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1606803170757636,
+				"Key":        "nodekey:5023a4b650230fa5ed3cdfd47ba8dbfdaaf0bb97b62caf2e864da24a4740d142",
+				"DiscoKey":   "discokey:80b0a655bf22658c4a539a67b759e73817554d2c250fcf63f4c8a028e567581f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38626",
+					"10.65.0.27:38626",
+					"172.17.0.1:38626",
+					"172.18.0.1:38626",
+					"172.19.0.1:38626"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:57:33.013921556Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5023a4b650230fa5ed3cdfd47ba8dbfdaaf0bb97b62caf2e864da24a4740d142",
+			"MachineKey": "mkey:b6c06e5b187c5e6bffd0bb0041c9442e10ac65f5d1af5cf5c5e86ffac18b5d02",
+			"Peers": [{
+				"ID":         3835531544211222,
+				"StableID":   "nKhGQmu7xW11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80c57e643d7230cd83eadaca191c6f6b7c043f42bde739d1b44a44b690d99e13",
+				"DiscoKey":   "discokey:240f1b1d15dceaa89a2ac90a8153fd6ac5a445c9218370d87062dff433d33767",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53625",
+					"10.65.0.27:53625",
+					"172.17.0.1:53625",
+					"172.18.0.1:53625",
+					"172.19.0.1:53625"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:57:30.705218022Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5053400927919207,
+				"StableID":   "navcSrGhTg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4eec174e94e5265f894542e9da04120935ab085538a801eae554bb041f757e16",
+				"DiscoKey":   "discokey:3f0ba6808c3c266b17361c85ddec5d5ee2b7c361f5efbfa286dc8df64eb01419",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33460",
+					"10.65.0.27:33460",
+					"172.17.0.1:33460",
+					"172.18.0.1:33460",
+					"172.19.0.1:33460"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:57:31.403219717Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1431121711049801,
+				"StableID":   "nLSex99ABC11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80814e86f57a4e9bf8dca66adffee85900a2aa40b57e05121f6050e1d9250905",
+				"DiscoKey":   "discokey:499522d29734e7488beac4aeaf38dcad75cc62b3c787cacc3f0acf5411c77328",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45997",
+					"10.65.0.27:45997",
+					"172.17.0.1:45997",
+					"172.18.0.1:45997",
+					"172.19.0.1:45997"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:57:31.92698939Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8797679479375496,
+				"StableID":   "nw6ZM48VhB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f8d49b1db6da1d5b47360482a2a7b2e93549744cb002881af18f7f6a5d68e34b",
+				"DiscoKey":   "discokey:87234e1d0138ed6e7754a91e9aef88acfaf2462d96512d11eb836108a9d95a76",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49095",
+					"10.65.0.27:49095",
+					"172.17.0.1:49095",
+					"172.18.0.1:49095",
+					"172.19.0.1:49095"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:57:32.472097813Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7301265108723252,
+				"StableID":   "nfxheWrk1z11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7f76ec09442dac1d3a4e0124abd64ae07dcf0af57dba76c192f9e110d1d6572",
+				"DiscoKey":   "discokey:7bec8a0503998bbb8dd13a3298ec1ce68f9d4bd13b34fa9a87a0194e20f0bd21",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:45039",
+					"10.65.0.27:45039",
+					"172.17.0.1:45039",
+					"172.18.0.1:45039",
+					"172.19.0.1:45039"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:57:33.556676054Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7725380831528287,
+				"StableID":   "nL1zkxeqK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:851076fbb17553ad3562c4e5068f75c8c4381e4529b5667e5bf16276b617982e",
+				"DiscoKey":   "discokey:2a127fbf2829965e5810d951e52e376a0e37b791a4e58e196bf769a9cf691e59",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33036",
+					"10.65.0.27:33036",
+					"172.17.0.1:33036",
+					"172.18.0.1:33036",
+					"172.19.0.1:33036"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:57:34.106654517Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3259390454342569,
+				"StableID":   "nQt8CJfBTS11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95202187441c2d29a8a67a988a8f873fe4516ef5b51c1ce3239b0d801ca26c50",
+				"DiscoKey":   "discokey:8f68be9a4cfaa2afa8f08425919e97b706ce2408627c81825ed4f15c921c1722",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36040",
+					"10.65.0.27:36040",
+					"172.17.0.1:36040",
+					"172.18.0.1:36040",
+					"172.19.0.1:36040"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:57:34.642811075Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7893841243265663,
+				"StableID":   "nJviUnp8e421CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f903c66613498ebdfde07b231095e507f4500edb7eb08ded59e385a3165a362",
+				"DiscoKey":   "discokey:42a70adb2d721921f2091a1d6c2534b53acd3a04a6fc4bdf793efaecc1998a54",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:47940",
+					"10.65.0.27:47940",
+					"172.17.0.1:47940",
+					"172.18.0.1:47940",
+					"172.19.0.1:47940"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:57:35.194847963Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1292193024696988,
+				"StableID":   "nZVkgjiE6B11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8b19730604edff2413168902acbeab862001d7c954de21fc8daca97e83734555",
+				"DiscoKey":   "discokey:5a25f973b0c17fc93ce312aa25baadf05916e369c639b43e64395e531e709926",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:36487",
+					"10.65.0.27:36487",
+					"172.17.0.1:36487",
+					"172.18.0.1:36487",
+					"172.19.0.1:36487"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:57:35.748214886Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8984390482213008,
+				"StableID":   "nM3BKnh3AD21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9c6c24a352339461850ed2b53d2ebf93fd12138b41517a536341f2e73f210306",
+				"DiscoKey":   "discokey:2429db307a1dfca0de2cf04b87bf5d02dd08fe4c164560a22d3962e18f7c1213",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60941",
+					"10.65.0.27:60941",
+					"172.17.0.1:60941",
+					"172.18.0.1:60941",
+					"172.19.0.1:60941"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:57:36.27728915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2227141973893581,
+				"StableID":   "nLQ8k6FgPJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9bb28d9fee91694ba201f8fa9b892ecd159fc6b937eea230453bad9e36b13d41",
+				"DiscoKey":   "discokey:966a1158aed0bd3c575198d257ff1c98cfdbfa62275935ed5342c6a9b8647809",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39500",
+					"10.65.0.27:39500",
+					"172.17.0.1:39500",
+					"172.18.0.1:39500",
+					"172.19.0.1:39500"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:57:36.815555524Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5423371860281803,
+				"StableID":   "n2c4qNnFMj11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0a157d2cc2596f9caf86b52c7e511998d96d8999c579c8010baf457506352d5b",
+				"KeyExpiry":  "2026-11-08T21:57:37Z",
+				"DiscoKey":   "discokey:b45ba750459a2080080ba7c6f620cdb02a7aa056e8a801542d2ad04fd767df31",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40381",
+					"10.65.0.27:40381",
+					"172.17.0.1:40381",
+					"172.18.0.1:40381",
+					"172.19.0.1:40381"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:57:37.357686069Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1566322499998607,
+				"StableID":   "naAvhtdPED11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:903291a17725d6633f8e81da69d8656e70e2bcdf0305b8c63d855f09b7012146",
+				"KeyExpiry":  "2026-11-08T21:57:37Z",
+				"DiscoKey":   "discokey:b8829f603a7316df1e9f95098e134662a0d42255d01002a3c2b5993622fcdb51",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57540",
+					"10.65.0.27:57540",
+					"172.17.0.1:57540",
+					"172.18.0.1:57540",
+					"172.19.0.1:57540"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:57:37.897261107Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5677837163419591,
+				"StableID":   "nWSuHx9WLm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c376bc389837b99f1d72af3f7f1fef59c1a876668e3faf33b34e060a67d6bb18",
+				"KeyExpiry":  "2026-11-08T21:57:38Z",
+				"DiscoKey":   "discokey:cd9991e667bf070794faa469d5885c3729fdd3c3b413d426efda8edb11bb1a19",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45826",
+					"10.65.0.27:45826",
+					"172.17.0.1:45826",
+					"172.18.0.1:45826",
+					"172.19.0.1:45826"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:57:38.466788824Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1606803170757636": {
+				"ID":          1606803170757636,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8797679479375496,
+				"StableID":   "nw6ZM48VhB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       8797679479375496,
+				"Key":        "nodekey:f8d49b1db6da1d5b47360482a2a7b2e93549744cb002881af18f7f6a5d68e34b",
+				"DiscoKey":   "discokey:87234e1d0138ed6e7754a91e9aef88acfaf2462d96512d11eb836108a9d95a76",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49095",
+					"10.65.0.27:49095",
+					"172.17.0.1:49095",
+					"172.18.0.1:49095",
+					"172.19.0.1:49095"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:57:32.472097813Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f8d49b1db6da1d5b47360482a2a7b2e93549744cb002881af18f7f6a5d68e34b",
+			"MachineKey": "mkey:b0a970f347fa5f56840a64cde84f2a32007ede993d215703cb7467da0490f34b",
+			"Peers": [{
+				"ID":         3835531544211222,
+				"StableID":   "nKhGQmu7xW11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80c57e643d7230cd83eadaca191c6f6b7c043f42bde739d1b44a44b690d99e13",
+				"DiscoKey":   "discokey:240f1b1d15dceaa89a2ac90a8153fd6ac5a445c9218370d87062dff433d33767",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53625",
+					"10.65.0.27:53625",
+					"172.17.0.1:53625",
+					"172.18.0.1:53625",
+					"172.19.0.1:53625"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:57:30.705218022Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5053400927919207,
+				"StableID":   "navcSrGhTg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4eec174e94e5265f894542e9da04120935ab085538a801eae554bb041f757e16",
+				"DiscoKey":   "discokey:3f0ba6808c3c266b17361c85ddec5d5ee2b7c361f5efbfa286dc8df64eb01419",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33460",
+					"10.65.0.27:33460",
+					"172.17.0.1:33460",
+					"172.18.0.1:33460",
+					"172.19.0.1:33460"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:57:31.403219717Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1431121711049801,
+				"StableID":   "nLSex99ABC11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80814e86f57a4e9bf8dca66adffee85900a2aa40b57e05121f6050e1d9250905",
+				"DiscoKey":   "discokey:499522d29734e7488beac4aeaf38dcad75cc62b3c787cacc3f0acf5411c77328",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45997",
+					"10.65.0.27:45997",
+					"172.17.0.1:45997",
+					"172.18.0.1:45997",
+					"172.19.0.1:45997"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:57:31.92698939Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1606803170757636,
+				"StableID":   "nBSjxgziYD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5023a4b650230fa5ed3cdfd47ba8dbfdaaf0bb97b62caf2e864da24a4740d142",
+				"DiscoKey":   "discokey:80b0a655bf22658c4a539a67b759e73817554d2c250fcf63f4c8a028e567581f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38626",
+					"10.65.0.27:38626",
+					"172.17.0.1:38626",
+					"172.18.0.1:38626",
+					"172.19.0.1:38626"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:57:33.013921556Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7301265108723252,
+				"StableID":   "nfxheWrk1z11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7f76ec09442dac1d3a4e0124abd64ae07dcf0af57dba76c192f9e110d1d6572",
+				"DiscoKey":   "discokey:7bec8a0503998bbb8dd13a3298ec1ce68f9d4bd13b34fa9a87a0194e20f0bd21",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:45039",
+					"10.65.0.27:45039",
+					"172.17.0.1:45039",
+					"172.18.0.1:45039",
+					"172.19.0.1:45039"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:57:33.556676054Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7725380831528287,
+				"StableID":   "nL1zkxeqK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:851076fbb17553ad3562c4e5068f75c8c4381e4529b5667e5bf16276b617982e",
+				"DiscoKey":   "discokey:2a127fbf2829965e5810d951e52e376a0e37b791a4e58e196bf769a9cf691e59",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33036",
+					"10.65.0.27:33036",
+					"172.17.0.1:33036",
+					"172.18.0.1:33036",
+					"172.19.0.1:33036"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:57:34.106654517Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3259390454342569,
+				"StableID":   "nQt8CJfBTS11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95202187441c2d29a8a67a988a8f873fe4516ef5b51c1ce3239b0d801ca26c50",
+				"DiscoKey":   "discokey:8f68be9a4cfaa2afa8f08425919e97b706ce2408627c81825ed4f15c921c1722",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36040",
+					"10.65.0.27:36040",
+					"172.17.0.1:36040",
+					"172.18.0.1:36040",
+					"172.19.0.1:36040"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:57:34.642811075Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7893841243265663,
+				"StableID":   "nJviUnp8e421CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f903c66613498ebdfde07b231095e507f4500edb7eb08ded59e385a3165a362",
+				"DiscoKey":   "discokey:42a70adb2d721921f2091a1d6c2534b53acd3a04a6fc4bdf793efaecc1998a54",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:47940",
+					"10.65.0.27:47940",
+					"172.17.0.1:47940",
+					"172.18.0.1:47940",
+					"172.19.0.1:47940"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:57:35.194847963Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1292193024696988,
+				"StableID":   "nZVkgjiE6B11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8b19730604edff2413168902acbeab862001d7c954de21fc8daca97e83734555",
+				"DiscoKey":   "discokey:5a25f973b0c17fc93ce312aa25baadf05916e369c639b43e64395e531e709926",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:36487",
+					"10.65.0.27:36487",
+					"172.17.0.1:36487",
+					"172.18.0.1:36487",
+					"172.19.0.1:36487"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:57:35.748214886Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8984390482213008,
+				"StableID":   "nM3BKnh3AD21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9c6c24a352339461850ed2b53d2ebf93fd12138b41517a536341f2e73f210306",
+				"DiscoKey":   "discokey:2429db307a1dfca0de2cf04b87bf5d02dd08fe4c164560a22d3962e18f7c1213",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60941",
+					"10.65.0.27:60941",
+					"172.17.0.1:60941",
+					"172.18.0.1:60941",
+					"172.19.0.1:60941"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:57:36.27728915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2227141973893581,
+				"StableID":   "nLQ8k6FgPJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9bb28d9fee91694ba201f8fa9b892ecd159fc6b937eea230453bad9e36b13d41",
+				"DiscoKey":   "discokey:966a1158aed0bd3c575198d257ff1c98cfdbfa62275935ed5342c6a9b8647809",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39500",
+					"10.65.0.27:39500",
+					"172.17.0.1:39500",
+					"172.18.0.1:39500",
+					"172.19.0.1:39500"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:57:36.815555524Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5423371860281803,
+				"StableID":   "n2c4qNnFMj11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0a157d2cc2596f9caf86b52c7e511998d96d8999c579c8010baf457506352d5b",
+				"KeyExpiry":  "2026-11-08T21:57:37Z",
+				"DiscoKey":   "discokey:b45ba750459a2080080ba7c6f620cdb02a7aa056e8a801542d2ad04fd767df31",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40381",
+					"10.65.0.27:40381",
+					"172.17.0.1:40381",
+					"172.18.0.1:40381",
+					"172.19.0.1:40381"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:57:37.357686069Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1566322499998607,
+				"StableID":   "naAvhtdPED11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:903291a17725d6633f8e81da69d8656e70e2bcdf0305b8c63d855f09b7012146",
+				"KeyExpiry":  "2026-11-08T21:57:37Z",
+				"DiscoKey":   "discokey:b8829f603a7316df1e9f95098e134662a0d42255d01002a3c2b5993622fcdb51",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57540",
+					"10.65.0.27:57540",
+					"172.17.0.1:57540",
+					"172.18.0.1:57540",
+					"172.19.0.1:57540"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:57:37.897261107Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5677837163419591,
+				"StableID":   "nWSuHx9WLm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c376bc389837b99f1d72af3f7f1fef59c1a876668e3faf33b34e060a67d6bb18",
+				"KeyExpiry":  "2026-11-08T21:57:38Z",
+				"DiscoKey":   "discokey:cd9991e667bf070794faa469d5885c3729fdd3c3b413d426efda8edb11bb1a19",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45826",
+					"10.65.0.27:45826",
+					"172.17.0.1:45826",
+					"172.18.0.1:45826",
+					"172.19.0.1:45826"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:57:38.466788824Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8797679479375496": {
+				"ID":          8797679479375496,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7725380831528287,
+				"StableID":   "nL1zkxeqK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       7725380831528287,
+				"Key":        "nodekey:851076fbb17553ad3562c4e5068f75c8c4381e4529b5667e5bf16276b617982e",
+				"DiscoKey":   "discokey:2a127fbf2829965e5810d951e52e376a0e37b791a4e58e196bf769a9cf691e59",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33036",
+					"10.65.0.27:33036",
+					"172.17.0.1:33036",
+					"172.18.0.1:33036",
+					"172.19.0.1:33036"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:57:34.106654517Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:851076fbb17553ad3562c4e5068f75c8c4381e4529b5667e5bf16276b617982e",
+			"MachineKey": "mkey:fd046c11a40751ba9ac2141f9005a2061e6321073f0372f7bb9f731dc7500467",
+			"Peers": [{
+				"ID":         3835531544211222,
+				"StableID":   "nKhGQmu7xW11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80c57e643d7230cd83eadaca191c6f6b7c043f42bde739d1b44a44b690d99e13",
+				"DiscoKey":   "discokey:240f1b1d15dceaa89a2ac90a8153fd6ac5a445c9218370d87062dff433d33767",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53625",
+					"10.65.0.27:53625",
+					"172.17.0.1:53625",
+					"172.18.0.1:53625",
+					"172.19.0.1:53625"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:57:30.705218022Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5053400927919207,
+				"StableID":   "navcSrGhTg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4eec174e94e5265f894542e9da04120935ab085538a801eae554bb041f757e16",
+				"DiscoKey":   "discokey:3f0ba6808c3c266b17361c85ddec5d5ee2b7c361f5efbfa286dc8df64eb01419",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33460",
+					"10.65.0.27:33460",
+					"172.17.0.1:33460",
+					"172.18.0.1:33460",
+					"172.19.0.1:33460"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:57:31.403219717Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1431121711049801,
+				"StableID":   "nLSex99ABC11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80814e86f57a4e9bf8dca66adffee85900a2aa40b57e05121f6050e1d9250905",
+				"DiscoKey":   "discokey:499522d29734e7488beac4aeaf38dcad75cc62b3c787cacc3f0acf5411c77328",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45997",
+					"10.65.0.27:45997",
+					"172.17.0.1:45997",
+					"172.18.0.1:45997",
+					"172.19.0.1:45997"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:57:31.92698939Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8797679479375496,
+				"StableID":   "nw6ZM48VhB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f8d49b1db6da1d5b47360482a2a7b2e93549744cb002881af18f7f6a5d68e34b",
+				"DiscoKey":   "discokey:87234e1d0138ed6e7754a91e9aef88acfaf2462d96512d11eb836108a9d95a76",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49095",
+					"10.65.0.27:49095",
+					"172.17.0.1:49095",
+					"172.18.0.1:49095",
+					"172.19.0.1:49095"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:57:32.472097813Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1606803170757636,
+				"StableID":   "nBSjxgziYD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5023a4b650230fa5ed3cdfd47ba8dbfdaaf0bb97b62caf2e864da24a4740d142",
+				"DiscoKey":   "discokey:80b0a655bf22658c4a539a67b759e73817554d2c250fcf63f4c8a028e567581f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38626",
+					"10.65.0.27:38626",
+					"172.17.0.1:38626",
+					"172.18.0.1:38626",
+					"172.19.0.1:38626"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:57:33.013921556Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7301265108723252,
+				"StableID":   "nfxheWrk1z11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7f76ec09442dac1d3a4e0124abd64ae07dcf0af57dba76c192f9e110d1d6572",
+				"DiscoKey":   "discokey:7bec8a0503998bbb8dd13a3298ec1ce68f9d4bd13b34fa9a87a0194e20f0bd21",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:45039",
+					"10.65.0.27:45039",
+					"172.17.0.1:45039",
+					"172.18.0.1:45039",
+					"172.19.0.1:45039"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:57:33.556676054Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3259390454342569,
+				"StableID":   "nQt8CJfBTS11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95202187441c2d29a8a67a988a8f873fe4516ef5b51c1ce3239b0d801ca26c50",
+				"DiscoKey":   "discokey:8f68be9a4cfaa2afa8f08425919e97b706ce2408627c81825ed4f15c921c1722",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36040",
+					"10.65.0.27:36040",
+					"172.17.0.1:36040",
+					"172.18.0.1:36040",
+					"172.19.0.1:36040"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:57:34.642811075Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7893841243265663,
+				"StableID":   "nJviUnp8e421CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f903c66613498ebdfde07b231095e507f4500edb7eb08ded59e385a3165a362",
+				"DiscoKey":   "discokey:42a70adb2d721921f2091a1d6c2534b53acd3a04a6fc4bdf793efaecc1998a54",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:47940",
+					"10.65.0.27:47940",
+					"172.17.0.1:47940",
+					"172.18.0.1:47940",
+					"172.19.0.1:47940"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:57:35.194847963Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1292193024696988,
+				"StableID":   "nZVkgjiE6B11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8b19730604edff2413168902acbeab862001d7c954de21fc8daca97e83734555",
+				"DiscoKey":   "discokey:5a25f973b0c17fc93ce312aa25baadf05916e369c639b43e64395e531e709926",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:36487",
+					"10.65.0.27:36487",
+					"172.17.0.1:36487",
+					"172.18.0.1:36487",
+					"172.19.0.1:36487"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:57:35.748214886Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8984390482213008,
+				"StableID":   "nM3BKnh3AD21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9c6c24a352339461850ed2b53d2ebf93fd12138b41517a536341f2e73f210306",
+				"DiscoKey":   "discokey:2429db307a1dfca0de2cf04b87bf5d02dd08fe4c164560a22d3962e18f7c1213",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60941",
+					"10.65.0.27:60941",
+					"172.17.0.1:60941",
+					"172.18.0.1:60941",
+					"172.19.0.1:60941"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:57:36.27728915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2227141973893581,
+				"StableID":   "nLQ8k6FgPJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9bb28d9fee91694ba201f8fa9b892ecd159fc6b937eea230453bad9e36b13d41",
+				"DiscoKey":   "discokey:966a1158aed0bd3c575198d257ff1c98cfdbfa62275935ed5342c6a9b8647809",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39500",
+					"10.65.0.27:39500",
+					"172.17.0.1:39500",
+					"172.18.0.1:39500",
+					"172.19.0.1:39500"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:57:36.815555524Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5423371860281803,
+				"StableID":   "n2c4qNnFMj11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0a157d2cc2596f9caf86b52c7e511998d96d8999c579c8010baf457506352d5b",
+				"KeyExpiry":  "2026-11-08T21:57:37Z",
+				"DiscoKey":   "discokey:b45ba750459a2080080ba7c6f620cdb02a7aa056e8a801542d2ad04fd767df31",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40381",
+					"10.65.0.27:40381",
+					"172.17.0.1:40381",
+					"172.18.0.1:40381",
+					"172.19.0.1:40381"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:57:37.357686069Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1566322499998607,
+				"StableID":   "naAvhtdPED11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:903291a17725d6633f8e81da69d8656e70e2bcdf0305b8c63d855f09b7012146",
+				"KeyExpiry":  "2026-11-08T21:57:37Z",
+				"DiscoKey":   "discokey:b8829f603a7316df1e9f95098e134662a0d42255d01002a3c2b5993622fcdb51",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57540",
+					"10.65.0.27:57540",
+					"172.17.0.1:57540",
+					"172.18.0.1:57540",
+					"172.19.0.1:57540"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:57:37.897261107Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5677837163419591,
+				"StableID":   "nWSuHx9WLm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c376bc389837b99f1d72af3f7f1fef59c1a876668e3faf33b34e060a67d6bb18",
+				"KeyExpiry":  "2026-11-08T21:57:38Z",
+				"DiscoKey":   "discokey:cd9991e667bf070794faa469d5885c3729fdd3c3b413d426efda8edb11bb1a19",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45826",
+					"10.65.0.27:45826",
+					"172.17.0.1:45826",
+					"172.18.0.1:45826",
+					"172.19.0.1:45826"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:57:38.466788824Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7725380831528287": {
+				"ID":          7725380831528287,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7893841243265663,
+				"StableID":   "nJviUnp8e421CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       7893841243265663,
+				"Key":        "nodekey:0f903c66613498ebdfde07b231095e507f4500edb7eb08ded59e385a3165a362",
+				"DiscoKey":   "discokey:42a70adb2d721921f2091a1d6c2534b53acd3a04a6fc4bdf793efaecc1998a54",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:47940",
+					"10.65.0.27:47940",
+					"172.17.0.1:47940",
+					"172.18.0.1:47940",
+					"172.19.0.1:47940"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:57:35.194847963Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0f903c66613498ebdfde07b231095e507f4500edb7eb08ded59e385a3165a362",
+			"MachineKey": "mkey:8db57db797c35b8b22e1f0b4e669d761fad47e079fb305580ea04101292ecc50",
+			"Peers": [{
+				"ID":         3835531544211222,
+				"StableID":   "nKhGQmu7xW11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80c57e643d7230cd83eadaca191c6f6b7c043f42bde739d1b44a44b690d99e13",
+				"DiscoKey":   "discokey:240f1b1d15dceaa89a2ac90a8153fd6ac5a445c9218370d87062dff433d33767",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53625",
+					"10.65.0.27:53625",
+					"172.17.0.1:53625",
+					"172.18.0.1:53625",
+					"172.19.0.1:53625"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:57:30.705218022Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5053400927919207,
+				"StableID":   "navcSrGhTg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4eec174e94e5265f894542e9da04120935ab085538a801eae554bb041f757e16",
+				"DiscoKey":   "discokey:3f0ba6808c3c266b17361c85ddec5d5ee2b7c361f5efbfa286dc8df64eb01419",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33460",
+					"10.65.0.27:33460",
+					"172.17.0.1:33460",
+					"172.18.0.1:33460",
+					"172.19.0.1:33460"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:57:31.403219717Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1431121711049801,
+				"StableID":   "nLSex99ABC11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80814e86f57a4e9bf8dca66adffee85900a2aa40b57e05121f6050e1d9250905",
+				"DiscoKey":   "discokey:499522d29734e7488beac4aeaf38dcad75cc62b3c787cacc3f0acf5411c77328",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45997",
+					"10.65.0.27:45997",
+					"172.17.0.1:45997",
+					"172.18.0.1:45997",
+					"172.19.0.1:45997"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:57:31.92698939Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8797679479375496,
+				"StableID":   "nw6ZM48VhB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f8d49b1db6da1d5b47360482a2a7b2e93549744cb002881af18f7f6a5d68e34b",
+				"DiscoKey":   "discokey:87234e1d0138ed6e7754a91e9aef88acfaf2462d96512d11eb836108a9d95a76",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49095",
+					"10.65.0.27:49095",
+					"172.17.0.1:49095",
+					"172.18.0.1:49095",
+					"172.19.0.1:49095"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:57:32.472097813Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1606803170757636,
+				"StableID":   "nBSjxgziYD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5023a4b650230fa5ed3cdfd47ba8dbfdaaf0bb97b62caf2e864da24a4740d142",
+				"DiscoKey":   "discokey:80b0a655bf22658c4a539a67b759e73817554d2c250fcf63f4c8a028e567581f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38626",
+					"10.65.0.27:38626",
+					"172.17.0.1:38626",
+					"172.18.0.1:38626",
+					"172.19.0.1:38626"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:57:33.013921556Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7301265108723252,
+				"StableID":   "nfxheWrk1z11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7f76ec09442dac1d3a4e0124abd64ae07dcf0af57dba76c192f9e110d1d6572",
+				"DiscoKey":   "discokey:7bec8a0503998bbb8dd13a3298ec1ce68f9d4bd13b34fa9a87a0194e20f0bd21",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:45039",
+					"10.65.0.27:45039",
+					"172.17.0.1:45039",
+					"172.18.0.1:45039",
+					"172.19.0.1:45039"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:57:33.556676054Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7725380831528287,
+				"StableID":   "nL1zkxeqK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:851076fbb17553ad3562c4e5068f75c8c4381e4529b5667e5bf16276b617982e",
+				"DiscoKey":   "discokey:2a127fbf2829965e5810d951e52e376a0e37b791a4e58e196bf769a9cf691e59",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33036",
+					"10.65.0.27:33036",
+					"172.17.0.1:33036",
+					"172.18.0.1:33036",
+					"172.19.0.1:33036"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:57:34.106654517Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3259390454342569,
+				"StableID":   "nQt8CJfBTS11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95202187441c2d29a8a67a988a8f873fe4516ef5b51c1ce3239b0d801ca26c50",
+				"DiscoKey":   "discokey:8f68be9a4cfaa2afa8f08425919e97b706ce2408627c81825ed4f15c921c1722",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36040",
+					"10.65.0.27:36040",
+					"172.17.0.1:36040",
+					"172.18.0.1:36040",
+					"172.19.0.1:36040"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:57:34.642811075Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1292193024696988,
+				"StableID":   "nZVkgjiE6B11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8b19730604edff2413168902acbeab862001d7c954de21fc8daca97e83734555",
+				"DiscoKey":   "discokey:5a25f973b0c17fc93ce312aa25baadf05916e369c639b43e64395e531e709926",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:36487",
+					"10.65.0.27:36487",
+					"172.17.0.1:36487",
+					"172.18.0.1:36487",
+					"172.19.0.1:36487"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:57:35.748214886Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8984390482213008,
+				"StableID":   "nM3BKnh3AD21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9c6c24a352339461850ed2b53d2ebf93fd12138b41517a536341f2e73f210306",
+				"DiscoKey":   "discokey:2429db307a1dfca0de2cf04b87bf5d02dd08fe4c164560a22d3962e18f7c1213",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60941",
+					"10.65.0.27:60941",
+					"172.17.0.1:60941",
+					"172.18.0.1:60941",
+					"172.19.0.1:60941"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:57:36.27728915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2227141973893581,
+				"StableID":   "nLQ8k6FgPJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9bb28d9fee91694ba201f8fa9b892ecd159fc6b937eea230453bad9e36b13d41",
+				"DiscoKey":   "discokey:966a1158aed0bd3c575198d257ff1c98cfdbfa62275935ed5342c6a9b8647809",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39500",
+					"10.65.0.27:39500",
+					"172.17.0.1:39500",
+					"172.18.0.1:39500",
+					"172.19.0.1:39500"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:57:36.815555524Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5423371860281803,
+				"StableID":   "n2c4qNnFMj11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0a157d2cc2596f9caf86b52c7e511998d96d8999c579c8010baf457506352d5b",
+				"KeyExpiry":  "2026-11-08T21:57:37Z",
+				"DiscoKey":   "discokey:b45ba750459a2080080ba7c6f620cdb02a7aa056e8a801542d2ad04fd767df31",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40381",
+					"10.65.0.27:40381",
+					"172.17.0.1:40381",
+					"172.18.0.1:40381",
+					"172.19.0.1:40381"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:57:37.357686069Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1566322499998607,
+				"StableID":   "naAvhtdPED11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:903291a17725d6633f8e81da69d8656e70e2bcdf0305b8c63d855f09b7012146",
+				"KeyExpiry":  "2026-11-08T21:57:37Z",
+				"DiscoKey":   "discokey:b8829f603a7316df1e9f95098e134662a0d42255d01002a3c2b5993622fcdb51",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57540",
+					"10.65.0.27:57540",
+					"172.17.0.1:57540",
+					"172.18.0.1:57540",
+					"172.19.0.1:57540"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:57:37.897261107Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5677837163419591,
+				"StableID":   "nWSuHx9WLm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c376bc389837b99f1d72af3f7f1fef59c1a876668e3faf33b34e060a67d6bb18",
+				"KeyExpiry":  "2026-11-08T21:57:38Z",
+				"DiscoKey":   "discokey:cd9991e667bf070794faa469d5885c3729fdd3c3b413d426efda8edb11bb1a19",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45826",
+					"10.65.0.27:45826",
+					"172.17.0.1:45826",
+					"172.18.0.1:45826",
+					"172.19.0.1:45826"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:57:38.466788824Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7893841243265663": {
+				"ID":          7893841243265663,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1566322499998607,
+				"StableID":   "naAvhtdPED11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:903291a17725d6633f8e81da69d8656e70e2bcdf0305b8c63d855f09b7012146",
+				"KeyExpiry":  "2026-11-08T21:57:37Z",
+				"DiscoKey":   "discokey:b8829f603a7316df1e9f95098e134662a0d42255d01002a3c2b5993622fcdb51",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57540",
+					"10.65.0.27:57540",
+					"172.17.0.1:57540",
+					"172.18.0.1:57540",
+					"172.19.0.1:57540"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:57:37.897261107Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:903291a17725d6633f8e81da69d8656e70e2bcdf0305b8c63d855f09b7012146",
+			"MachineKey": "mkey:bae3080814cc1c48db951f98b9c220dd82fe78cdff9b88159424790de4fcdd3c",
+			"Peers": [{
+				"ID":         3835531544211222,
+				"StableID":   "nKhGQmu7xW11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80c57e643d7230cd83eadaca191c6f6b7c043f42bde739d1b44a44b690d99e13",
+				"DiscoKey":   "discokey:240f1b1d15dceaa89a2ac90a8153fd6ac5a445c9218370d87062dff433d33767",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53625",
+					"10.65.0.27:53625",
+					"172.17.0.1:53625",
+					"172.18.0.1:53625",
+					"172.19.0.1:53625"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:57:30.705218022Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5053400927919207,
+				"StableID":   "navcSrGhTg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4eec174e94e5265f894542e9da04120935ab085538a801eae554bb041f757e16",
+				"DiscoKey":   "discokey:3f0ba6808c3c266b17361c85ddec5d5ee2b7c361f5efbfa286dc8df64eb01419",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33460",
+					"10.65.0.27:33460",
+					"172.17.0.1:33460",
+					"172.18.0.1:33460",
+					"172.19.0.1:33460"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:57:31.403219717Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1431121711049801,
+				"StableID":   "nLSex99ABC11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80814e86f57a4e9bf8dca66adffee85900a2aa40b57e05121f6050e1d9250905",
+				"DiscoKey":   "discokey:499522d29734e7488beac4aeaf38dcad75cc62b3c787cacc3f0acf5411c77328",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45997",
+					"10.65.0.27:45997",
+					"172.17.0.1:45997",
+					"172.18.0.1:45997",
+					"172.19.0.1:45997"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:57:31.92698939Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8797679479375496,
+				"StableID":   "nw6ZM48VhB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f8d49b1db6da1d5b47360482a2a7b2e93549744cb002881af18f7f6a5d68e34b",
+				"DiscoKey":   "discokey:87234e1d0138ed6e7754a91e9aef88acfaf2462d96512d11eb836108a9d95a76",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49095",
+					"10.65.0.27:49095",
+					"172.17.0.1:49095",
+					"172.18.0.1:49095",
+					"172.19.0.1:49095"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:57:32.472097813Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1606803170757636,
+				"StableID":   "nBSjxgziYD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5023a4b650230fa5ed3cdfd47ba8dbfdaaf0bb97b62caf2e864da24a4740d142",
+				"DiscoKey":   "discokey:80b0a655bf22658c4a539a67b759e73817554d2c250fcf63f4c8a028e567581f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38626",
+					"10.65.0.27:38626",
+					"172.17.0.1:38626",
+					"172.18.0.1:38626",
+					"172.19.0.1:38626"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:57:33.013921556Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7301265108723252,
+				"StableID":   "nfxheWrk1z11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7f76ec09442dac1d3a4e0124abd64ae07dcf0af57dba76c192f9e110d1d6572",
+				"DiscoKey":   "discokey:7bec8a0503998bbb8dd13a3298ec1ce68f9d4bd13b34fa9a87a0194e20f0bd21",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:45039",
+					"10.65.0.27:45039",
+					"172.17.0.1:45039",
+					"172.18.0.1:45039",
+					"172.19.0.1:45039"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:57:33.556676054Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7725380831528287,
+				"StableID":   "nL1zkxeqK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:851076fbb17553ad3562c4e5068f75c8c4381e4529b5667e5bf16276b617982e",
+				"DiscoKey":   "discokey:2a127fbf2829965e5810d951e52e376a0e37b791a4e58e196bf769a9cf691e59",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33036",
+					"10.65.0.27:33036",
+					"172.17.0.1:33036",
+					"172.18.0.1:33036",
+					"172.19.0.1:33036"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:57:34.106654517Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3259390454342569,
+				"StableID":   "nQt8CJfBTS11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95202187441c2d29a8a67a988a8f873fe4516ef5b51c1ce3239b0d801ca26c50",
+				"DiscoKey":   "discokey:8f68be9a4cfaa2afa8f08425919e97b706ce2408627c81825ed4f15c921c1722",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36040",
+					"10.65.0.27:36040",
+					"172.17.0.1:36040",
+					"172.18.0.1:36040",
+					"172.19.0.1:36040"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:57:34.642811075Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7893841243265663,
+				"StableID":   "nJviUnp8e421CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f903c66613498ebdfde07b231095e507f4500edb7eb08ded59e385a3165a362",
+				"DiscoKey":   "discokey:42a70adb2d721921f2091a1d6c2534b53acd3a04a6fc4bdf793efaecc1998a54",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:47940",
+					"10.65.0.27:47940",
+					"172.17.0.1:47940",
+					"172.18.0.1:47940",
+					"172.19.0.1:47940"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:57:35.194847963Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1292193024696988,
+				"StableID":   "nZVkgjiE6B11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8b19730604edff2413168902acbeab862001d7c954de21fc8daca97e83734555",
+				"DiscoKey":   "discokey:5a25f973b0c17fc93ce312aa25baadf05916e369c639b43e64395e531e709926",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:36487",
+					"10.65.0.27:36487",
+					"172.17.0.1:36487",
+					"172.18.0.1:36487",
+					"172.19.0.1:36487"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:57:35.748214886Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8984390482213008,
+				"StableID":   "nM3BKnh3AD21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9c6c24a352339461850ed2b53d2ebf93fd12138b41517a536341f2e73f210306",
+				"DiscoKey":   "discokey:2429db307a1dfca0de2cf04b87bf5d02dd08fe4c164560a22d3962e18f7c1213",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60941",
+					"10.65.0.27:60941",
+					"172.17.0.1:60941",
+					"172.18.0.1:60941",
+					"172.19.0.1:60941"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:57:36.27728915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2227141973893581,
+				"StableID":   "nLQ8k6FgPJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9bb28d9fee91694ba201f8fa9b892ecd159fc6b937eea230453bad9e36b13d41",
+				"DiscoKey":   "discokey:966a1158aed0bd3c575198d257ff1c98cfdbfa62275935ed5342c6a9b8647809",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39500",
+					"10.65.0.27:39500",
+					"172.17.0.1:39500",
+					"172.18.0.1:39500",
+					"172.19.0.1:39500"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:57:36.815555524Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5423371860281803,
+				"StableID":   "n2c4qNnFMj11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0a157d2cc2596f9caf86b52c7e511998d96d8999c579c8010baf457506352d5b",
+				"KeyExpiry":  "2026-11-08T21:57:37Z",
+				"DiscoKey":   "discokey:b45ba750459a2080080ba7c6f620cdb02a7aa056e8a801542d2ad04fd767df31",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40381",
+					"10.65.0.27:40381",
+					"172.17.0.1:40381",
+					"172.18.0.1:40381",
+					"172.19.0.1:40381"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:57:37.357686069Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5677837163419591,
+				"StableID":   "nWSuHx9WLm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c376bc389837b99f1d72af3f7f1fef59c1a876668e3faf33b34e060a67d6bb18",
+				"KeyExpiry":  "2026-11-08T21:57:38Z",
+				"DiscoKey":   "discokey:cd9991e667bf070794faa469d5885c3729fdd3c3b413d426efda8edb11bb1a19",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45826",
+					"10.65.0.27:45826",
+					"172.17.0.1:45826",
+					"172.18.0.1:45826",
+					"172.19.0.1:45826"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:57:38.466788824Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1292193024696988,
+				"StableID":   "nZVkgjiE6B11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1292193024696988,
+				"Key":        "nodekey:8b19730604edff2413168902acbeab862001d7c954de21fc8daca97e83734555",
+				"DiscoKey":   "discokey:5a25f973b0c17fc93ce312aa25baadf05916e369c639b43e64395e531e709926",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:36487",
+					"10.65.0.27:36487",
+					"172.17.0.1:36487",
+					"172.18.0.1:36487",
+					"172.19.0.1:36487"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:57:35.748214886Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8b19730604edff2413168902acbeab862001d7c954de21fc8daca97e83734555",
+			"MachineKey": "mkey:bc2c01c7fceedc858a3c05352d72d99293b06b5b77fa207b75f48d916fd37706",
+			"Peers": [{
+				"ID":         3835531544211222,
+				"StableID":   "nKhGQmu7xW11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80c57e643d7230cd83eadaca191c6f6b7c043f42bde739d1b44a44b690d99e13",
+				"DiscoKey":   "discokey:240f1b1d15dceaa89a2ac90a8153fd6ac5a445c9218370d87062dff433d33767",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53625",
+					"10.65.0.27:53625",
+					"172.17.0.1:53625",
+					"172.18.0.1:53625",
+					"172.19.0.1:53625"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:57:30.705218022Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5053400927919207,
+				"StableID":   "navcSrGhTg11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4eec174e94e5265f894542e9da04120935ab085538a801eae554bb041f757e16",
+				"DiscoKey":   "discokey:3f0ba6808c3c266b17361c85ddec5d5ee2b7c361f5efbfa286dc8df64eb01419",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33460",
+					"10.65.0.27:33460",
+					"172.17.0.1:33460",
+					"172.18.0.1:33460",
+					"172.19.0.1:33460"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:57:31.403219717Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1431121711049801,
+				"StableID":   "nLSex99ABC11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80814e86f57a4e9bf8dca66adffee85900a2aa40b57e05121f6050e1d9250905",
+				"DiscoKey":   "discokey:499522d29734e7488beac4aeaf38dcad75cc62b3c787cacc3f0acf5411c77328",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45997",
+					"10.65.0.27:45997",
+					"172.17.0.1:45997",
+					"172.18.0.1:45997",
+					"172.19.0.1:45997"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:57:31.92698939Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8797679479375496,
+				"StableID":   "nw6ZM48VhB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f8d49b1db6da1d5b47360482a2a7b2e93549744cb002881af18f7f6a5d68e34b",
+				"DiscoKey":   "discokey:87234e1d0138ed6e7754a91e9aef88acfaf2462d96512d11eb836108a9d95a76",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49095",
+					"10.65.0.27:49095",
+					"172.17.0.1:49095",
+					"172.18.0.1:49095",
+					"172.19.0.1:49095"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:57:32.472097813Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1606803170757636,
+				"StableID":   "nBSjxgziYD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5023a4b650230fa5ed3cdfd47ba8dbfdaaf0bb97b62caf2e864da24a4740d142",
+				"DiscoKey":   "discokey:80b0a655bf22658c4a539a67b759e73817554d2c250fcf63f4c8a028e567581f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38626",
+					"10.65.0.27:38626",
+					"172.17.0.1:38626",
+					"172.18.0.1:38626",
+					"172.19.0.1:38626"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:57:33.013921556Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7301265108723252,
+				"StableID":   "nfxheWrk1z11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7f76ec09442dac1d3a4e0124abd64ae07dcf0af57dba76c192f9e110d1d6572",
+				"DiscoKey":   "discokey:7bec8a0503998bbb8dd13a3298ec1ce68f9d4bd13b34fa9a87a0194e20f0bd21",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:45039",
+					"10.65.0.27:45039",
+					"172.17.0.1:45039",
+					"172.18.0.1:45039",
+					"172.19.0.1:45039"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:57:33.556676054Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7725380831528287,
+				"StableID":   "nL1zkxeqK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:851076fbb17553ad3562c4e5068f75c8c4381e4529b5667e5bf16276b617982e",
+				"DiscoKey":   "discokey:2a127fbf2829965e5810d951e52e376a0e37b791a4e58e196bf769a9cf691e59",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33036",
+					"10.65.0.27:33036",
+					"172.17.0.1:33036",
+					"172.18.0.1:33036",
+					"172.19.0.1:33036"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:57:34.106654517Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3259390454342569,
+				"StableID":   "nQt8CJfBTS11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95202187441c2d29a8a67a988a8f873fe4516ef5b51c1ce3239b0d801ca26c50",
+				"DiscoKey":   "discokey:8f68be9a4cfaa2afa8f08425919e97b706ce2408627c81825ed4f15c921c1722",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36040",
+					"10.65.0.27:36040",
+					"172.17.0.1:36040",
+					"172.18.0.1:36040",
+					"172.19.0.1:36040"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:57:34.642811075Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7893841243265663,
+				"StableID":   "nJviUnp8e421CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f903c66613498ebdfde07b231095e507f4500edb7eb08ded59e385a3165a362",
+				"DiscoKey":   "discokey:42a70adb2d721921f2091a1d6c2534b53acd3a04a6fc4bdf793efaecc1998a54",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:47940",
+					"10.65.0.27:47940",
+					"172.17.0.1:47940",
+					"172.18.0.1:47940",
+					"172.19.0.1:47940"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:57:35.194847963Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8984390482213008,
+				"StableID":   "nM3BKnh3AD21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9c6c24a352339461850ed2b53d2ebf93fd12138b41517a536341f2e73f210306",
+				"DiscoKey":   "discokey:2429db307a1dfca0de2cf04b87bf5d02dd08fe4c164560a22d3962e18f7c1213",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60941",
+					"10.65.0.27:60941",
+					"172.17.0.1:60941",
+					"172.18.0.1:60941",
+					"172.19.0.1:60941"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:57:36.27728915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2227141973893581,
+				"StableID":   "nLQ8k6FgPJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9bb28d9fee91694ba201f8fa9b892ecd159fc6b937eea230453bad9e36b13d41",
+				"DiscoKey":   "discokey:966a1158aed0bd3c575198d257ff1c98cfdbfa62275935ed5342c6a9b8647809",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39500",
+					"10.65.0.27:39500",
+					"172.17.0.1:39500",
+					"172.18.0.1:39500",
+					"172.19.0.1:39500"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:57:36.815555524Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5423371860281803,
+				"StableID":   "n2c4qNnFMj11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0a157d2cc2596f9caf86b52c7e511998d96d8999c579c8010baf457506352d5b",
+				"KeyExpiry":  "2026-11-08T21:57:37Z",
+				"DiscoKey":   "discokey:b45ba750459a2080080ba7c6f620cdb02a7aa056e8a801542d2ad04fd767df31",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40381",
+					"10.65.0.27:40381",
+					"172.17.0.1:40381",
+					"172.18.0.1:40381",
+					"172.19.0.1:40381"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:57:37.357686069Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1566322499998607,
+				"StableID":   "naAvhtdPED11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:903291a17725d6633f8e81da69d8656e70e2bcdf0305b8c63d855f09b7012146",
+				"KeyExpiry":  "2026-11-08T21:57:37Z",
+				"DiscoKey":   "discokey:b8829f603a7316df1e9f95098e134662a0d42255d01002a3c2b5993622fcdb51",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57540",
+					"10.65.0.27:57540",
+					"172.17.0.1:57540",
+					"172.18.0.1:57540",
+					"172.19.0.1:57540"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:57:37.897261107Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5677837163419591,
+				"StableID":   "nWSuHx9WLm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c376bc389837b99f1d72af3f7f1fef59c1a876668e3faf33b34e060a67d6bb18",
+				"KeyExpiry":  "2026-11-08T21:57:38Z",
+				"DiscoKey":   "discokey:cd9991e667bf070794faa469d5885c3729fdd3c3b413d426efda8edb11bb1a19",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45826",
+					"10.65.0.27:45826",
+					"172.17.0.1:45826",
+					"172.18.0.1:45826",
+					"172.19.0.1:45826"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:57:38.466788824Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1292193024696988": {
+				"ID":          1292193024696988,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-src-empty.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-src-empty.hujson
@@ -1,0 +1,20076 @@
+// ssh-malformed-src-empty
+//
+// ssh src empty array is rejected
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T21:58:23Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-malformed-src-empty",
+	"description":    "ssh src empty array is rejected",
+	"category":       "ssh",
+	"captured_at":    "2026-05-12T21:58:23.729887483Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                          \n  \n                                                             \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh src empty array is rejected\",\n\t\"id\":          \"ssh-malformed-src-empty\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [],\n\t\t\"users\":  [\"root\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-malformed/ssh-malformed-src-empty.hujson",
+		"full_policy": {
+			"ssh": [
+				{"action": "accept", "dst": ["tag:server"], "src": [], "users": ["root"]}
+			],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6051058547127384,
+				"StableID":   "nK28wj3YFp11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       6051058547127384,
+				"Key":        "nodekey:8a09208d509976f62bd09f9ef233504ebe8a8f1ff70c8d2925ed01eb862d9f0d",
+				"DiscoKey":   "discokey:a2e8406808cbb07dec1609f2a3a9763798e3496af74cf250c7593ac9bba83342",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54660",
+					"10.65.0.27:54660",
+					"172.17.0.1:54660",
+					"172.18.0.1:54660",
+					"172.19.0.1:54660"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:58:32.281645116Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8a09208d509976f62bd09f9ef233504ebe8a8f1ff70c8d2925ed01eb862d9f0d",
+			"MachineKey": "mkey:3b7ab69bb3e933f6419ca6f70c21b587858071281f88ce69536f062f8c987a35",
+			"Peers": [{
+				"ID":         534499573604818,
+				"StableID":   "nFDg14Q5B511CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a295bb9d66ad435c1c863d60ff2c0eaa7bec1f4303dc51d7c0a90b2660b0c37d",
+				"DiscoKey":   "discokey:2e5d8e7dd0b12d0b15e62451c2ae8c5e653af1079984154c9559ecdfa965c47f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44264",
+					"10.65.0.27:44264",
+					"172.17.0.1:44264",
+					"172.18.0.1:44264",
+					"172.19.0.1:44264"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:58:26.341904369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4275649627261847,
+				"StableID":   "nztdHo4TPa11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26496ff07821536cf8faa23b0fd643702aa59ea884a3c1234f7ec40eb9ca3e16",
+				"DiscoKey":   "discokey:904c409d93b40a05bfa2e2d3ffdc6010036cc5b0acfb95f35bbc1976613b4f76",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42615",
+					"10.65.0.27:42615",
+					"172.17.0.1:42615",
+					"172.18.0.1:42615",
+					"172.19.0.1:42615"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:58:26.930448146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1742476355781486,
+				"StableID":   "nyENj9uAcE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fcdc746945849cc059b48882c7e421d5ba17242014b03121bf01b0de92a39028",
+				"DiscoKey":   "discokey:783a4300334e7f2d2d6b5f3bedf2aaaa085f3ec1cf7699484802486f52055754",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40969",
+					"10.65.0.27:40969",
+					"172.17.0.1:40969",
+					"172.18.0.1:40969",
+					"172.19.0.1:40969"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:58:27.423308868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         975863935373222,
+				"StableID":   "nZWEHsHyc811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1be5552a82ccc811e7f0e68adebee96005a93b10c92d2eb1990fdc31e5736a2d",
+				"DiscoKey":   "discokey:18554a005da60494ccfb50efd01867c6c6850d4d14a172b8663d8e6ab46de462",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34673",
+					"10.65.0.27:34673",
+					"172.17.0.1:34673",
+					"172.18.0.1:34673",
+					"172.19.0.1:34673"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:58:27.95517668Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5793056539786640,
+				"StableID":   "nBan2nmgEn11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1124cca0ea8b658e802f3a8c5461fdfc63a80a4319a4fa7b5a2c42b56210d02",
+				"DiscoKey":   "discokey:91144d49f8e60b955724fda6fa8e43f318a1728c3dae2b9ff1f0fb188f027c19",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55242",
+					"10.65.0.27:55242",
+					"172.17.0.1:55242",
+					"172.18.0.1:55242",
+					"172.19.0.1:55242"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:58:28.496770895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         217457670716385,
+				"StableID":   "nGWKiAFVh211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:957a5f80c833af535aa064af40a10697079fd8e489063c4aa657f029f2b01001",
+				"DiscoKey":   "discokey:3e1cac42808059f5363cf3fb70fcd38dbacd1ed48fa8440d9e2c5e8dbd10355d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53237",
+					"10.65.0.27:53237",
+					"172.17.0.1:53237",
+					"172.18.0.1:53237",
+					"172.19.0.1:53237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:58:29.035135257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         646345387390297,
+				"StableID":   "ntzWa3Qj3611CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cf3eb894b4e76e54ba6d173285658f0041da75d5f083b1bee556717e54d00046",
+				"DiscoKey":   "discokey:6496dffafcf54f08b725e033b9386234ff01f0e578669c0006400517ed417306",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:55237",
+					"10.65.0.27:55237",
+					"172.17.0.1:55237",
+					"172.18.0.1:55237",
+					"172.19.0.1:55237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:58:29.578822538Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4650834079454209,
+				"StableID":   "nSfxZSXNKd11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:598bfb66ea80b91fcb784add5a6ef993a9230b23fa2e83bf60020a003e585a6b",
+				"DiscoKey":   "discokey:16e38a2a8eba52bfbdb69e7524655fd6d34d91e63810686bdddd1efa362f3655",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46114",
+					"10.65.0.27:46114",
+					"172.17.0.1:46114",
+					"172.18.0.1:46114",
+					"172.19.0.1:46114"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:58:30.119427275Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7124341447155548,
+				"StableID":   "nogPXQNddx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4af93a2a2d2cfd72b8427c87a62eb1136c19e00b082a482cb571eaff0b26677",
+				"DiscoKey":   "discokey:2c563596b817d09a1178bfeb778c2c46ea34daa313d9cd1b52fdcf9eff3ce156",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:51270",
+					"10.65.0.27:51270",
+					"172.17.0.1:51270",
+					"172.18.0.1:51270",
+					"172.19.0.1:51270"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:58:30.667369819Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3593552533063828,
+				"StableID":   "nwieopXX4V11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6bced23ed7fc8d3ae99281126cafa685a4eff4158509ee7b45215e1ebfca047a",
+				"DiscoKey":   "discokey:8188dfceb4caad20e4f80bc6e7be8a97b3550d9967252dc704115196f8f91729",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42074",
+					"10.65.0.27:42074",
+					"172.17.0.1:42074",
+					"172.18.0.1:42074",
+					"172.19.0.1:42074"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:58:31.233293039Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2631683467103926,
+				"StableID":   "nBsFD1stYM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e35b4c85927fd5c0d00fa1b68763701fd3a7ec6f345d8da3b412a3bdb73ce02b",
+				"DiscoKey":   "discokey:a59f687863d4b13b7323652ffb2aa9c2358e8bba297b3ebc431abf9ff4287527",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42155",
+					"10.65.0.27:42155",
+					"172.17.0.1:42155",
+					"172.18.0.1:42155",
+					"172.19.0.1:42155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:58:31.739754289Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7628946014681444,
+				"StableID":   "nH1iDaUAa221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:072a3b14be7598b5879400be5bd6c1bbe09ff022bf8dbbaa4cf13d11ace0c454",
+				"KeyExpiry":  "2026-11-08T21:58:32Z",
+				"DiscoKey":   "discokey:9101ef5fe0de8cf89628cbaf7c4d82b08b0a85678528f829b45eec4faeb3b549",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44273",
+					"10.65.0.27:44273",
+					"172.17.0.1:44273",
+					"172.18.0.1:44273",
+					"172.19.0.1:44273"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:58:32.817902576Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8241289836823602,
+				"StableID":   "nZUiu8iVM721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:4f1fb67f448163694c66741a2f52d29197e41e64de9ff994b8140d4bf3f76972",
+				"KeyExpiry":  "2026-11-08T21:58:33Z",
+				"DiscoKey":   "discokey:0a0700b62f9a2957ef46da6d0457b1f44f509c5937fac31058ebba2203ba0542",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40365",
+					"10.65.0.27:40365",
+					"172.17.0.1:40365",
+					"172.18.0.1:40365",
+					"172.19.0.1:40365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:58:33.359731695Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1920759525508500,
+				"StableID":   "n1jMwY6vzF11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:6460aa7e4b52ac5118d804abab1c82aae16d452f5e3927f6daaa0a124eee9139",
+				"KeyExpiry":  "2026-11-08T21:58:33Z",
+				"DiscoKey":   "discokey:bc299dbce4c639d15aa4e02cf409b946d977e131126d40dd3531736fd46efe3a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42726",
+					"10.65.0.27:42726",
+					"172.17.0.1:42726",
+					"172.18.0.1:42726",
+					"172.19.0.1:42726"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:58:33.906179719Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6051058547127384": {
+				"ID":          6051058547127384,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         217457670716385,
+				"StableID":   "nGWKiAFVh211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       217457670716385,
+				"Key":        "nodekey:957a5f80c833af535aa064af40a10697079fd8e489063c4aa657f029f2b01001",
+				"DiscoKey":   "discokey:3e1cac42808059f5363cf3fb70fcd38dbacd1ed48fa8440d9e2c5e8dbd10355d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53237",
+					"10.65.0.27:53237",
+					"172.17.0.1:53237",
+					"172.18.0.1:53237",
+					"172.19.0.1:53237"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:58:29.035135257Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:957a5f80c833af535aa064af40a10697079fd8e489063c4aa657f029f2b01001",
+			"MachineKey": "mkey:8e1706e2162d5919e6cc04f2a086d4ce49d902e83d76be90b23a894523149d30",
+			"Peers": [{
+				"ID":         534499573604818,
+				"StableID":   "nFDg14Q5B511CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a295bb9d66ad435c1c863d60ff2c0eaa7bec1f4303dc51d7c0a90b2660b0c37d",
+				"DiscoKey":   "discokey:2e5d8e7dd0b12d0b15e62451c2ae8c5e653af1079984154c9559ecdfa965c47f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44264",
+					"10.65.0.27:44264",
+					"172.17.0.1:44264",
+					"172.18.0.1:44264",
+					"172.19.0.1:44264"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:58:26.341904369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4275649627261847,
+				"StableID":   "nztdHo4TPa11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26496ff07821536cf8faa23b0fd643702aa59ea884a3c1234f7ec40eb9ca3e16",
+				"DiscoKey":   "discokey:904c409d93b40a05bfa2e2d3ffdc6010036cc5b0acfb95f35bbc1976613b4f76",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42615",
+					"10.65.0.27:42615",
+					"172.17.0.1:42615",
+					"172.18.0.1:42615",
+					"172.19.0.1:42615"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:58:26.930448146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1742476355781486,
+				"StableID":   "nyENj9uAcE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fcdc746945849cc059b48882c7e421d5ba17242014b03121bf01b0de92a39028",
+				"DiscoKey":   "discokey:783a4300334e7f2d2d6b5f3bedf2aaaa085f3ec1cf7699484802486f52055754",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40969",
+					"10.65.0.27:40969",
+					"172.17.0.1:40969",
+					"172.18.0.1:40969",
+					"172.19.0.1:40969"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:58:27.423308868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         975863935373222,
+				"StableID":   "nZWEHsHyc811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1be5552a82ccc811e7f0e68adebee96005a93b10c92d2eb1990fdc31e5736a2d",
+				"DiscoKey":   "discokey:18554a005da60494ccfb50efd01867c6c6850d4d14a172b8663d8e6ab46de462",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34673",
+					"10.65.0.27:34673",
+					"172.17.0.1:34673",
+					"172.18.0.1:34673",
+					"172.19.0.1:34673"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:58:27.95517668Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5793056539786640,
+				"StableID":   "nBan2nmgEn11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1124cca0ea8b658e802f3a8c5461fdfc63a80a4319a4fa7b5a2c42b56210d02",
+				"DiscoKey":   "discokey:91144d49f8e60b955724fda6fa8e43f318a1728c3dae2b9ff1f0fb188f027c19",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55242",
+					"10.65.0.27:55242",
+					"172.17.0.1:55242",
+					"172.18.0.1:55242",
+					"172.19.0.1:55242"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:58:28.496770895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         646345387390297,
+				"StableID":   "ntzWa3Qj3611CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cf3eb894b4e76e54ba6d173285658f0041da75d5f083b1bee556717e54d00046",
+				"DiscoKey":   "discokey:6496dffafcf54f08b725e033b9386234ff01f0e578669c0006400517ed417306",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:55237",
+					"10.65.0.27:55237",
+					"172.17.0.1:55237",
+					"172.18.0.1:55237",
+					"172.19.0.1:55237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:58:29.578822538Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4650834079454209,
+				"StableID":   "nSfxZSXNKd11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:598bfb66ea80b91fcb784add5a6ef993a9230b23fa2e83bf60020a003e585a6b",
+				"DiscoKey":   "discokey:16e38a2a8eba52bfbdb69e7524655fd6d34d91e63810686bdddd1efa362f3655",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46114",
+					"10.65.0.27:46114",
+					"172.17.0.1:46114",
+					"172.18.0.1:46114",
+					"172.19.0.1:46114"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:58:30.119427275Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7124341447155548,
+				"StableID":   "nogPXQNddx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4af93a2a2d2cfd72b8427c87a62eb1136c19e00b082a482cb571eaff0b26677",
+				"DiscoKey":   "discokey:2c563596b817d09a1178bfeb778c2c46ea34daa313d9cd1b52fdcf9eff3ce156",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:51270",
+					"10.65.0.27:51270",
+					"172.17.0.1:51270",
+					"172.18.0.1:51270",
+					"172.19.0.1:51270"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:58:30.667369819Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3593552533063828,
+				"StableID":   "nwieopXX4V11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6bced23ed7fc8d3ae99281126cafa685a4eff4158509ee7b45215e1ebfca047a",
+				"DiscoKey":   "discokey:8188dfceb4caad20e4f80bc6e7be8a97b3550d9967252dc704115196f8f91729",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42074",
+					"10.65.0.27:42074",
+					"172.17.0.1:42074",
+					"172.18.0.1:42074",
+					"172.19.0.1:42074"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:58:31.233293039Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2631683467103926,
+				"StableID":   "nBsFD1stYM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e35b4c85927fd5c0d00fa1b68763701fd3a7ec6f345d8da3b412a3bdb73ce02b",
+				"DiscoKey":   "discokey:a59f687863d4b13b7323652ffb2aa9c2358e8bba297b3ebc431abf9ff4287527",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42155",
+					"10.65.0.27:42155",
+					"172.17.0.1:42155",
+					"172.18.0.1:42155",
+					"172.19.0.1:42155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:58:31.739754289Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6051058547127384,
+				"StableID":   "nK28wj3YFp11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a09208d509976f62bd09f9ef233504ebe8a8f1ff70c8d2925ed01eb862d9f0d",
+				"DiscoKey":   "discokey:a2e8406808cbb07dec1609f2a3a9763798e3496af74cf250c7593ac9bba83342",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54660",
+					"10.65.0.27:54660",
+					"172.17.0.1:54660",
+					"172.18.0.1:54660",
+					"172.19.0.1:54660"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:58:32.281645116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7628946014681444,
+				"StableID":   "nH1iDaUAa221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:072a3b14be7598b5879400be5bd6c1bbe09ff022bf8dbbaa4cf13d11ace0c454",
+				"KeyExpiry":  "2026-11-08T21:58:32Z",
+				"DiscoKey":   "discokey:9101ef5fe0de8cf89628cbaf7c4d82b08b0a85678528f829b45eec4faeb3b549",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44273",
+					"10.65.0.27:44273",
+					"172.17.0.1:44273",
+					"172.18.0.1:44273",
+					"172.19.0.1:44273"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:58:32.817902576Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8241289836823602,
+				"StableID":   "nZUiu8iVM721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:4f1fb67f448163694c66741a2f52d29197e41e64de9ff994b8140d4bf3f76972",
+				"KeyExpiry":  "2026-11-08T21:58:33Z",
+				"DiscoKey":   "discokey:0a0700b62f9a2957ef46da6d0457b1f44f509c5937fac31058ebba2203ba0542",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40365",
+					"10.65.0.27:40365",
+					"172.17.0.1:40365",
+					"172.18.0.1:40365",
+					"172.19.0.1:40365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:58:33.359731695Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1920759525508500,
+				"StableID":   "n1jMwY6vzF11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:6460aa7e4b52ac5118d804abab1c82aae16d452f5e3927f6daaa0a124eee9139",
+				"KeyExpiry":  "2026-11-08T21:58:33Z",
+				"DiscoKey":   "discokey:bc299dbce4c639d15aa4e02cf409b946d977e131126d40dd3531736fd46efe3a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42726",
+					"10.65.0.27:42726",
+					"172.17.0.1:42726",
+					"172.18.0.1:42726",
+					"172.19.0.1:42726"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:58:33.906179719Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "217457670716385": {
+				"ID":          217457670716385,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1920759525508500,
+				"StableID":   "n1jMwY6vzF11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:6460aa7e4b52ac5118d804abab1c82aae16d452f5e3927f6daaa0a124eee9139",
+				"KeyExpiry":  "2026-11-08T21:58:33Z",
+				"DiscoKey":   "discokey:bc299dbce4c639d15aa4e02cf409b946d977e131126d40dd3531736fd46efe3a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42726",
+					"10.65.0.27:42726",
+					"172.17.0.1:42726",
+					"172.18.0.1:42726",
+					"172.19.0.1:42726"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:58:33.906179719Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6460aa7e4b52ac5118d804abab1c82aae16d452f5e3927f6daaa0a124eee9139",
+			"MachineKey": "mkey:2cc0a0290fe304ea01cd56eff9bb5f4eec742f76fc5a3520a18f1d46d2c82745",
+			"Peers": [{
+				"ID":         534499573604818,
+				"StableID":   "nFDg14Q5B511CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a295bb9d66ad435c1c863d60ff2c0eaa7bec1f4303dc51d7c0a90b2660b0c37d",
+				"DiscoKey":   "discokey:2e5d8e7dd0b12d0b15e62451c2ae8c5e653af1079984154c9559ecdfa965c47f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44264",
+					"10.65.0.27:44264",
+					"172.17.0.1:44264",
+					"172.18.0.1:44264",
+					"172.19.0.1:44264"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:58:26.341904369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4275649627261847,
+				"StableID":   "nztdHo4TPa11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26496ff07821536cf8faa23b0fd643702aa59ea884a3c1234f7ec40eb9ca3e16",
+				"DiscoKey":   "discokey:904c409d93b40a05bfa2e2d3ffdc6010036cc5b0acfb95f35bbc1976613b4f76",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42615",
+					"10.65.0.27:42615",
+					"172.17.0.1:42615",
+					"172.18.0.1:42615",
+					"172.19.0.1:42615"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:58:26.930448146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1742476355781486,
+				"StableID":   "nyENj9uAcE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fcdc746945849cc059b48882c7e421d5ba17242014b03121bf01b0de92a39028",
+				"DiscoKey":   "discokey:783a4300334e7f2d2d6b5f3bedf2aaaa085f3ec1cf7699484802486f52055754",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40969",
+					"10.65.0.27:40969",
+					"172.17.0.1:40969",
+					"172.18.0.1:40969",
+					"172.19.0.1:40969"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:58:27.423308868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         975863935373222,
+				"StableID":   "nZWEHsHyc811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1be5552a82ccc811e7f0e68adebee96005a93b10c92d2eb1990fdc31e5736a2d",
+				"DiscoKey":   "discokey:18554a005da60494ccfb50efd01867c6c6850d4d14a172b8663d8e6ab46de462",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34673",
+					"10.65.0.27:34673",
+					"172.17.0.1:34673",
+					"172.18.0.1:34673",
+					"172.19.0.1:34673"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:58:27.95517668Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5793056539786640,
+				"StableID":   "nBan2nmgEn11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1124cca0ea8b658e802f3a8c5461fdfc63a80a4319a4fa7b5a2c42b56210d02",
+				"DiscoKey":   "discokey:91144d49f8e60b955724fda6fa8e43f318a1728c3dae2b9ff1f0fb188f027c19",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55242",
+					"10.65.0.27:55242",
+					"172.17.0.1:55242",
+					"172.18.0.1:55242",
+					"172.19.0.1:55242"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:58:28.496770895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         217457670716385,
+				"StableID":   "nGWKiAFVh211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:957a5f80c833af535aa064af40a10697079fd8e489063c4aa657f029f2b01001",
+				"DiscoKey":   "discokey:3e1cac42808059f5363cf3fb70fcd38dbacd1ed48fa8440d9e2c5e8dbd10355d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53237",
+					"10.65.0.27:53237",
+					"172.17.0.1:53237",
+					"172.18.0.1:53237",
+					"172.19.0.1:53237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:58:29.035135257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         646345387390297,
+				"StableID":   "ntzWa3Qj3611CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cf3eb894b4e76e54ba6d173285658f0041da75d5f083b1bee556717e54d00046",
+				"DiscoKey":   "discokey:6496dffafcf54f08b725e033b9386234ff01f0e578669c0006400517ed417306",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:55237",
+					"10.65.0.27:55237",
+					"172.17.0.1:55237",
+					"172.18.0.1:55237",
+					"172.19.0.1:55237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:58:29.578822538Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4650834079454209,
+				"StableID":   "nSfxZSXNKd11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:598bfb66ea80b91fcb784add5a6ef993a9230b23fa2e83bf60020a003e585a6b",
+				"DiscoKey":   "discokey:16e38a2a8eba52bfbdb69e7524655fd6d34d91e63810686bdddd1efa362f3655",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46114",
+					"10.65.0.27:46114",
+					"172.17.0.1:46114",
+					"172.18.0.1:46114",
+					"172.19.0.1:46114"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:58:30.119427275Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7124341447155548,
+				"StableID":   "nogPXQNddx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4af93a2a2d2cfd72b8427c87a62eb1136c19e00b082a482cb571eaff0b26677",
+				"DiscoKey":   "discokey:2c563596b817d09a1178bfeb778c2c46ea34daa313d9cd1b52fdcf9eff3ce156",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:51270",
+					"10.65.0.27:51270",
+					"172.17.0.1:51270",
+					"172.18.0.1:51270",
+					"172.19.0.1:51270"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:58:30.667369819Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3593552533063828,
+				"StableID":   "nwieopXX4V11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6bced23ed7fc8d3ae99281126cafa685a4eff4158509ee7b45215e1ebfca047a",
+				"DiscoKey":   "discokey:8188dfceb4caad20e4f80bc6e7be8a97b3550d9967252dc704115196f8f91729",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42074",
+					"10.65.0.27:42074",
+					"172.17.0.1:42074",
+					"172.18.0.1:42074",
+					"172.19.0.1:42074"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:58:31.233293039Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2631683467103926,
+				"StableID":   "nBsFD1stYM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e35b4c85927fd5c0d00fa1b68763701fd3a7ec6f345d8da3b412a3bdb73ce02b",
+				"DiscoKey":   "discokey:a59f687863d4b13b7323652ffb2aa9c2358e8bba297b3ebc431abf9ff4287527",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42155",
+					"10.65.0.27:42155",
+					"172.17.0.1:42155",
+					"172.18.0.1:42155",
+					"172.19.0.1:42155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:58:31.739754289Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6051058547127384,
+				"StableID":   "nK28wj3YFp11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a09208d509976f62bd09f9ef233504ebe8a8f1ff70c8d2925ed01eb862d9f0d",
+				"DiscoKey":   "discokey:a2e8406808cbb07dec1609f2a3a9763798e3496af74cf250c7593ac9bba83342",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54660",
+					"10.65.0.27:54660",
+					"172.17.0.1:54660",
+					"172.18.0.1:54660",
+					"172.19.0.1:54660"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:58:32.281645116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7628946014681444,
+				"StableID":   "nH1iDaUAa221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:072a3b14be7598b5879400be5bd6c1bbe09ff022bf8dbbaa4cf13d11ace0c454",
+				"KeyExpiry":  "2026-11-08T21:58:32Z",
+				"DiscoKey":   "discokey:9101ef5fe0de8cf89628cbaf7c4d82b08b0a85678528f829b45eec4faeb3b549",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44273",
+					"10.65.0.27:44273",
+					"172.17.0.1:44273",
+					"172.18.0.1:44273",
+					"172.19.0.1:44273"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:58:32.817902576Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8241289836823602,
+				"StableID":   "nZUiu8iVM721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:4f1fb67f448163694c66741a2f52d29197e41e64de9ff994b8140d4bf3f76972",
+				"KeyExpiry":  "2026-11-08T21:58:33Z",
+				"DiscoKey":   "discokey:0a0700b62f9a2957ef46da6d0457b1f44f509c5937fac31058ebba2203ba0542",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40365",
+					"10.65.0.27:40365",
+					"172.17.0.1:40365",
+					"172.18.0.1:40365",
+					"172.19.0.1:40365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:58:33.359731695Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1742476355781486,
+				"StableID":   "nyENj9uAcE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1742476355781486,
+				"Key":        "nodekey:fcdc746945849cc059b48882c7e421d5ba17242014b03121bf01b0de92a39028",
+				"DiscoKey":   "discokey:783a4300334e7f2d2d6b5f3bedf2aaaa085f3ec1cf7699484802486f52055754",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40969",
+					"10.65.0.27:40969",
+					"172.17.0.1:40969",
+					"172.18.0.1:40969",
+					"172.19.0.1:40969"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:58:27.423308868Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:fcdc746945849cc059b48882c7e421d5ba17242014b03121bf01b0de92a39028",
+			"MachineKey": "mkey:7674fd2561363b0e01997c8bb56e8d22024ea49fce607b7fab2a626b6ca66c5f",
+			"Peers": [{
+				"ID":         534499573604818,
+				"StableID":   "nFDg14Q5B511CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a295bb9d66ad435c1c863d60ff2c0eaa7bec1f4303dc51d7c0a90b2660b0c37d",
+				"DiscoKey":   "discokey:2e5d8e7dd0b12d0b15e62451c2ae8c5e653af1079984154c9559ecdfa965c47f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44264",
+					"10.65.0.27:44264",
+					"172.17.0.1:44264",
+					"172.18.0.1:44264",
+					"172.19.0.1:44264"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:58:26.341904369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4275649627261847,
+				"StableID":   "nztdHo4TPa11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26496ff07821536cf8faa23b0fd643702aa59ea884a3c1234f7ec40eb9ca3e16",
+				"DiscoKey":   "discokey:904c409d93b40a05bfa2e2d3ffdc6010036cc5b0acfb95f35bbc1976613b4f76",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42615",
+					"10.65.0.27:42615",
+					"172.17.0.1:42615",
+					"172.18.0.1:42615",
+					"172.19.0.1:42615"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:58:26.930448146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         975863935373222,
+				"StableID":   "nZWEHsHyc811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1be5552a82ccc811e7f0e68adebee96005a93b10c92d2eb1990fdc31e5736a2d",
+				"DiscoKey":   "discokey:18554a005da60494ccfb50efd01867c6c6850d4d14a172b8663d8e6ab46de462",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34673",
+					"10.65.0.27:34673",
+					"172.17.0.1:34673",
+					"172.18.0.1:34673",
+					"172.19.0.1:34673"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:58:27.95517668Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5793056539786640,
+				"StableID":   "nBan2nmgEn11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1124cca0ea8b658e802f3a8c5461fdfc63a80a4319a4fa7b5a2c42b56210d02",
+				"DiscoKey":   "discokey:91144d49f8e60b955724fda6fa8e43f318a1728c3dae2b9ff1f0fb188f027c19",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55242",
+					"10.65.0.27:55242",
+					"172.17.0.1:55242",
+					"172.18.0.1:55242",
+					"172.19.0.1:55242"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:58:28.496770895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         217457670716385,
+				"StableID":   "nGWKiAFVh211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:957a5f80c833af535aa064af40a10697079fd8e489063c4aa657f029f2b01001",
+				"DiscoKey":   "discokey:3e1cac42808059f5363cf3fb70fcd38dbacd1ed48fa8440d9e2c5e8dbd10355d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53237",
+					"10.65.0.27:53237",
+					"172.17.0.1:53237",
+					"172.18.0.1:53237",
+					"172.19.0.1:53237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:58:29.035135257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         646345387390297,
+				"StableID":   "ntzWa3Qj3611CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cf3eb894b4e76e54ba6d173285658f0041da75d5f083b1bee556717e54d00046",
+				"DiscoKey":   "discokey:6496dffafcf54f08b725e033b9386234ff01f0e578669c0006400517ed417306",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:55237",
+					"10.65.0.27:55237",
+					"172.17.0.1:55237",
+					"172.18.0.1:55237",
+					"172.19.0.1:55237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:58:29.578822538Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4650834079454209,
+				"StableID":   "nSfxZSXNKd11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:598bfb66ea80b91fcb784add5a6ef993a9230b23fa2e83bf60020a003e585a6b",
+				"DiscoKey":   "discokey:16e38a2a8eba52bfbdb69e7524655fd6d34d91e63810686bdddd1efa362f3655",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46114",
+					"10.65.0.27:46114",
+					"172.17.0.1:46114",
+					"172.18.0.1:46114",
+					"172.19.0.1:46114"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:58:30.119427275Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7124341447155548,
+				"StableID":   "nogPXQNddx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4af93a2a2d2cfd72b8427c87a62eb1136c19e00b082a482cb571eaff0b26677",
+				"DiscoKey":   "discokey:2c563596b817d09a1178bfeb778c2c46ea34daa313d9cd1b52fdcf9eff3ce156",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:51270",
+					"10.65.0.27:51270",
+					"172.17.0.1:51270",
+					"172.18.0.1:51270",
+					"172.19.0.1:51270"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:58:30.667369819Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3593552533063828,
+				"StableID":   "nwieopXX4V11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6bced23ed7fc8d3ae99281126cafa685a4eff4158509ee7b45215e1ebfca047a",
+				"DiscoKey":   "discokey:8188dfceb4caad20e4f80bc6e7be8a97b3550d9967252dc704115196f8f91729",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42074",
+					"10.65.0.27:42074",
+					"172.17.0.1:42074",
+					"172.18.0.1:42074",
+					"172.19.0.1:42074"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:58:31.233293039Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2631683467103926,
+				"StableID":   "nBsFD1stYM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e35b4c85927fd5c0d00fa1b68763701fd3a7ec6f345d8da3b412a3bdb73ce02b",
+				"DiscoKey":   "discokey:a59f687863d4b13b7323652ffb2aa9c2358e8bba297b3ebc431abf9ff4287527",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42155",
+					"10.65.0.27:42155",
+					"172.17.0.1:42155",
+					"172.18.0.1:42155",
+					"172.19.0.1:42155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:58:31.739754289Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6051058547127384,
+				"StableID":   "nK28wj3YFp11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a09208d509976f62bd09f9ef233504ebe8a8f1ff70c8d2925ed01eb862d9f0d",
+				"DiscoKey":   "discokey:a2e8406808cbb07dec1609f2a3a9763798e3496af74cf250c7593ac9bba83342",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54660",
+					"10.65.0.27:54660",
+					"172.17.0.1:54660",
+					"172.18.0.1:54660",
+					"172.19.0.1:54660"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:58:32.281645116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7628946014681444,
+				"StableID":   "nH1iDaUAa221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:072a3b14be7598b5879400be5bd6c1bbe09ff022bf8dbbaa4cf13d11ace0c454",
+				"KeyExpiry":  "2026-11-08T21:58:32Z",
+				"DiscoKey":   "discokey:9101ef5fe0de8cf89628cbaf7c4d82b08b0a85678528f829b45eec4faeb3b549",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44273",
+					"10.65.0.27:44273",
+					"172.17.0.1:44273",
+					"172.18.0.1:44273",
+					"172.19.0.1:44273"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:58:32.817902576Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8241289836823602,
+				"StableID":   "nZUiu8iVM721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:4f1fb67f448163694c66741a2f52d29197e41e64de9ff994b8140d4bf3f76972",
+				"KeyExpiry":  "2026-11-08T21:58:33Z",
+				"DiscoKey":   "discokey:0a0700b62f9a2957ef46da6d0457b1f44f509c5937fac31058ebba2203ba0542",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40365",
+					"10.65.0.27:40365",
+					"172.17.0.1:40365",
+					"172.18.0.1:40365",
+					"172.19.0.1:40365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:58:33.359731695Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1920759525508500,
+				"StableID":   "n1jMwY6vzF11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:6460aa7e4b52ac5118d804abab1c82aae16d452f5e3927f6daaa0a124eee9139",
+				"KeyExpiry":  "2026-11-08T21:58:33Z",
+				"DiscoKey":   "discokey:bc299dbce4c639d15aa4e02cf409b946d977e131126d40dd3531736fd46efe3a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42726",
+					"10.65.0.27:42726",
+					"172.17.0.1:42726",
+					"172.18.0.1:42726",
+					"172.19.0.1:42726"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:58:33.906179719Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1742476355781486": {
+				"ID":          1742476355781486,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4650834079454209,
+				"StableID":   "nSfxZSXNKd11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       4650834079454209,
+				"Key":        "nodekey:598bfb66ea80b91fcb784add5a6ef993a9230b23fa2e83bf60020a003e585a6b",
+				"DiscoKey":   "discokey:16e38a2a8eba52bfbdb69e7524655fd6d34d91e63810686bdddd1efa362f3655",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46114",
+					"10.65.0.27:46114",
+					"172.17.0.1:46114",
+					"172.18.0.1:46114",
+					"172.19.0.1:46114"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:58:30.119427275Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:598bfb66ea80b91fcb784add5a6ef993a9230b23fa2e83bf60020a003e585a6b",
+			"MachineKey": "mkey:758d57a4ac29c70b26ccaab22b1bfeb58281da385c817bd577f2d4da88372611",
+			"Peers": [{
+				"ID":         534499573604818,
+				"StableID":   "nFDg14Q5B511CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a295bb9d66ad435c1c863d60ff2c0eaa7bec1f4303dc51d7c0a90b2660b0c37d",
+				"DiscoKey":   "discokey:2e5d8e7dd0b12d0b15e62451c2ae8c5e653af1079984154c9559ecdfa965c47f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44264",
+					"10.65.0.27:44264",
+					"172.17.0.1:44264",
+					"172.18.0.1:44264",
+					"172.19.0.1:44264"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:58:26.341904369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4275649627261847,
+				"StableID":   "nztdHo4TPa11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26496ff07821536cf8faa23b0fd643702aa59ea884a3c1234f7ec40eb9ca3e16",
+				"DiscoKey":   "discokey:904c409d93b40a05bfa2e2d3ffdc6010036cc5b0acfb95f35bbc1976613b4f76",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42615",
+					"10.65.0.27:42615",
+					"172.17.0.1:42615",
+					"172.18.0.1:42615",
+					"172.19.0.1:42615"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:58:26.930448146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1742476355781486,
+				"StableID":   "nyENj9uAcE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fcdc746945849cc059b48882c7e421d5ba17242014b03121bf01b0de92a39028",
+				"DiscoKey":   "discokey:783a4300334e7f2d2d6b5f3bedf2aaaa085f3ec1cf7699484802486f52055754",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40969",
+					"10.65.0.27:40969",
+					"172.17.0.1:40969",
+					"172.18.0.1:40969",
+					"172.19.0.1:40969"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:58:27.423308868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         975863935373222,
+				"StableID":   "nZWEHsHyc811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1be5552a82ccc811e7f0e68adebee96005a93b10c92d2eb1990fdc31e5736a2d",
+				"DiscoKey":   "discokey:18554a005da60494ccfb50efd01867c6c6850d4d14a172b8663d8e6ab46de462",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34673",
+					"10.65.0.27:34673",
+					"172.17.0.1:34673",
+					"172.18.0.1:34673",
+					"172.19.0.1:34673"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:58:27.95517668Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5793056539786640,
+				"StableID":   "nBan2nmgEn11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1124cca0ea8b658e802f3a8c5461fdfc63a80a4319a4fa7b5a2c42b56210d02",
+				"DiscoKey":   "discokey:91144d49f8e60b955724fda6fa8e43f318a1728c3dae2b9ff1f0fb188f027c19",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55242",
+					"10.65.0.27:55242",
+					"172.17.0.1:55242",
+					"172.18.0.1:55242",
+					"172.19.0.1:55242"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:58:28.496770895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         217457670716385,
+				"StableID":   "nGWKiAFVh211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:957a5f80c833af535aa064af40a10697079fd8e489063c4aa657f029f2b01001",
+				"DiscoKey":   "discokey:3e1cac42808059f5363cf3fb70fcd38dbacd1ed48fa8440d9e2c5e8dbd10355d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53237",
+					"10.65.0.27:53237",
+					"172.17.0.1:53237",
+					"172.18.0.1:53237",
+					"172.19.0.1:53237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:58:29.035135257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         646345387390297,
+				"StableID":   "ntzWa3Qj3611CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cf3eb894b4e76e54ba6d173285658f0041da75d5f083b1bee556717e54d00046",
+				"DiscoKey":   "discokey:6496dffafcf54f08b725e033b9386234ff01f0e578669c0006400517ed417306",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:55237",
+					"10.65.0.27:55237",
+					"172.17.0.1:55237",
+					"172.18.0.1:55237",
+					"172.19.0.1:55237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:58:29.578822538Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7124341447155548,
+				"StableID":   "nogPXQNddx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4af93a2a2d2cfd72b8427c87a62eb1136c19e00b082a482cb571eaff0b26677",
+				"DiscoKey":   "discokey:2c563596b817d09a1178bfeb778c2c46ea34daa313d9cd1b52fdcf9eff3ce156",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:51270",
+					"10.65.0.27:51270",
+					"172.17.0.1:51270",
+					"172.18.0.1:51270",
+					"172.19.0.1:51270"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:58:30.667369819Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3593552533063828,
+				"StableID":   "nwieopXX4V11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6bced23ed7fc8d3ae99281126cafa685a4eff4158509ee7b45215e1ebfca047a",
+				"DiscoKey":   "discokey:8188dfceb4caad20e4f80bc6e7be8a97b3550d9967252dc704115196f8f91729",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42074",
+					"10.65.0.27:42074",
+					"172.17.0.1:42074",
+					"172.18.0.1:42074",
+					"172.19.0.1:42074"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:58:31.233293039Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2631683467103926,
+				"StableID":   "nBsFD1stYM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e35b4c85927fd5c0d00fa1b68763701fd3a7ec6f345d8da3b412a3bdb73ce02b",
+				"DiscoKey":   "discokey:a59f687863d4b13b7323652ffb2aa9c2358e8bba297b3ebc431abf9ff4287527",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42155",
+					"10.65.0.27:42155",
+					"172.17.0.1:42155",
+					"172.18.0.1:42155",
+					"172.19.0.1:42155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:58:31.739754289Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6051058547127384,
+				"StableID":   "nK28wj3YFp11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a09208d509976f62bd09f9ef233504ebe8a8f1ff70c8d2925ed01eb862d9f0d",
+				"DiscoKey":   "discokey:a2e8406808cbb07dec1609f2a3a9763798e3496af74cf250c7593ac9bba83342",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54660",
+					"10.65.0.27:54660",
+					"172.17.0.1:54660",
+					"172.18.0.1:54660",
+					"172.19.0.1:54660"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:58:32.281645116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7628946014681444,
+				"StableID":   "nH1iDaUAa221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:072a3b14be7598b5879400be5bd6c1bbe09ff022bf8dbbaa4cf13d11ace0c454",
+				"KeyExpiry":  "2026-11-08T21:58:32Z",
+				"DiscoKey":   "discokey:9101ef5fe0de8cf89628cbaf7c4d82b08b0a85678528f829b45eec4faeb3b549",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44273",
+					"10.65.0.27:44273",
+					"172.17.0.1:44273",
+					"172.18.0.1:44273",
+					"172.19.0.1:44273"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:58:32.817902576Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8241289836823602,
+				"StableID":   "nZUiu8iVM721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:4f1fb67f448163694c66741a2f52d29197e41e64de9ff994b8140d4bf3f76972",
+				"KeyExpiry":  "2026-11-08T21:58:33Z",
+				"DiscoKey":   "discokey:0a0700b62f9a2957ef46da6d0457b1f44f509c5937fac31058ebba2203ba0542",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40365",
+					"10.65.0.27:40365",
+					"172.17.0.1:40365",
+					"172.18.0.1:40365",
+					"172.19.0.1:40365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:58:33.359731695Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1920759525508500,
+				"StableID":   "n1jMwY6vzF11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:6460aa7e4b52ac5118d804abab1c82aae16d452f5e3927f6daaa0a124eee9139",
+				"KeyExpiry":  "2026-11-08T21:58:33Z",
+				"DiscoKey":   "discokey:bc299dbce4c639d15aa4e02cf409b946d977e131126d40dd3531736fd46efe3a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42726",
+					"10.65.0.27:42726",
+					"172.17.0.1:42726",
+					"172.18.0.1:42726",
+					"172.19.0.1:42726"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:58:33.906179719Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4650834079454209": {
+				"ID":          4650834079454209,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7628946014681444,
+				"StableID":   "nH1iDaUAa221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:072a3b14be7598b5879400be5bd6c1bbe09ff022bf8dbbaa4cf13d11ace0c454",
+				"KeyExpiry":  "2026-11-08T21:58:32Z",
+				"DiscoKey":   "discokey:9101ef5fe0de8cf89628cbaf7c4d82b08b0a85678528f829b45eec4faeb3b549",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44273",
+					"10.65.0.27:44273",
+					"172.17.0.1:44273",
+					"172.18.0.1:44273",
+					"172.19.0.1:44273"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:58:32.817902576Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:072a3b14be7598b5879400be5bd6c1bbe09ff022bf8dbbaa4cf13d11ace0c454",
+			"MachineKey": "mkey:69ad012a24d0aa82d63a362d89dbfc0496820a2337d1c77fe70a17888acffa55",
+			"Peers": [{
+				"ID":         534499573604818,
+				"StableID":   "nFDg14Q5B511CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a295bb9d66ad435c1c863d60ff2c0eaa7bec1f4303dc51d7c0a90b2660b0c37d",
+				"DiscoKey":   "discokey:2e5d8e7dd0b12d0b15e62451c2ae8c5e653af1079984154c9559ecdfa965c47f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44264",
+					"10.65.0.27:44264",
+					"172.17.0.1:44264",
+					"172.18.0.1:44264",
+					"172.19.0.1:44264"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:58:26.341904369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4275649627261847,
+				"StableID":   "nztdHo4TPa11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26496ff07821536cf8faa23b0fd643702aa59ea884a3c1234f7ec40eb9ca3e16",
+				"DiscoKey":   "discokey:904c409d93b40a05bfa2e2d3ffdc6010036cc5b0acfb95f35bbc1976613b4f76",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42615",
+					"10.65.0.27:42615",
+					"172.17.0.1:42615",
+					"172.18.0.1:42615",
+					"172.19.0.1:42615"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:58:26.930448146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1742476355781486,
+				"StableID":   "nyENj9uAcE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fcdc746945849cc059b48882c7e421d5ba17242014b03121bf01b0de92a39028",
+				"DiscoKey":   "discokey:783a4300334e7f2d2d6b5f3bedf2aaaa085f3ec1cf7699484802486f52055754",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40969",
+					"10.65.0.27:40969",
+					"172.17.0.1:40969",
+					"172.18.0.1:40969",
+					"172.19.0.1:40969"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:58:27.423308868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         975863935373222,
+				"StableID":   "nZWEHsHyc811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1be5552a82ccc811e7f0e68adebee96005a93b10c92d2eb1990fdc31e5736a2d",
+				"DiscoKey":   "discokey:18554a005da60494ccfb50efd01867c6c6850d4d14a172b8663d8e6ab46de462",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34673",
+					"10.65.0.27:34673",
+					"172.17.0.1:34673",
+					"172.18.0.1:34673",
+					"172.19.0.1:34673"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:58:27.95517668Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5793056539786640,
+				"StableID":   "nBan2nmgEn11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1124cca0ea8b658e802f3a8c5461fdfc63a80a4319a4fa7b5a2c42b56210d02",
+				"DiscoKey":   "discokey:91144d49f8e60b955724fda6fa8e43f318a1728c3dae2b9ff1f0fb188f027c19",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55242",
+					"10.65.0.27:55242",
+					"172.17.0.1:55242",
+					"172.18.0.1:55242",
+					"172.19.0.1:55242"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:58:28.496770895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         217457670716385,
+				"StableID":   "nGWKiAFVh211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:957a5f80c833af535aa064af40a10697079fd8e489063c4aa657f029f2b01001",
+				"DiscoKey":   "discokey:3e1cac42808059f5363cf3fb70fcd38dbacd1ed48fa8440d9e2c5e8dbd10355d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53237",
+					"10.65.0.27:53237",
+					"172.17.0.1:53237",
+					"172.18.0.1:53237",
+					"172.19.0.1:53237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:58:29.035135257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         646345387390297,
+				"StableID":   "ntzWa3Qj3611CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cf3eb894b4e76e54ba6d173285658f0041da75d5f083b1bee556717e54d00046",
+				"DiscoKey":   "discokey:6496dffafcf54f08b725e033b9386234ff01f0e578669c0006400517ed417306",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:55237",
+					"10.65.0.27:55237",
+					"172.17.0.1:55237",
+					"172.18.0.1:55237",
+					"172.19.0.1:55237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:58:29.578822538Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4650834079454209,
+				"StableID":   "nSfxZSXNKd11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:598bfb66ea80b91fcb784add5a6ef993a9230b23fa2e83bf60020a003e585a6b",
+				"DiscoKey":   "discokey:16e38a2a8eba52bfbdb69e7524655fd6d34d91e63810686bdddd1efa362f3655",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46114",
+					"10.65.0.27:46114",
+					"172.17.0.1:46114",
+					"172.18.0.1:46114",
+					"172.19.0.1:46114"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:58:30.119427275Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7124341447155548,
+				"StableID":   "nogPXQNddx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4af93a2a2d2cfd72b8427c87a62eb1136c19e00b082a482cb571eaff0b26677",
+				"DiscoKey":   "discokey:2c563596b817d09a1178bfeb778c2c46ea34daa313d9cd1b52fdcf9eff3ce156",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:51270",
+					"10.65.0.27:51270",
+					"172.17.0.1:51270",
+					"172.18.0.1:51270",
+					"172.19.0.1:51270"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:58:30.667369819Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3593552533063828,
+				"StableID":   "nwieopXX4V11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6bced23ed7fc8d3ae99281126cafa685a4eff4158509ee7b45215e1ebfca047a",
+				"DiscoKey":   "discokey:8188dfceb4caad20e4f80bc6e7be8a97b3550d9967252dc704115196f8f91729",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42074",
+					"10.65.0.27:42074",
+					"172.17.0.1:42074",
+					"172.18.0.1:42074",
+					"172.19.0.1:42074"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:58:31.233293039Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2631683467103926,
+				"StableID":   "nBsFD1stYM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e35b4c85927fd5c0d00fa1b68763701fd3a7ec6f345d8da3b412a3bdb73ce02b",
+				"DiscoKey":   "discokey:a59f687863d4b13b7323652ffb2aa9c2358e8bba297b3ebc431abf9ff4287527",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42155",
+					"10.65.0.27:42155",
+					"172.17.0.1:42155",
+					"172.18.0.1:42155",
+					"172.19.0.1:42155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:58:31.739754289Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6051058547127384,
+				"StableID":   "nK28wj3YFp11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a09208d509976f62bd09f9ef233504ebe8a8f1ff70c8d2925ed01eb862d9f0d",
+				"DiscoKey":   "discokey:a2e8406808cbb07dec1609f2a3a9763798e3496af74cf250c7593ac9bba83342",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54660",
+					"10.65.0.27:54660",
+					"172.17.0.1:54660",
+					"172.18.0.1:54660",
+					"172.19.0.1:54660"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:58:32.281645116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8241289836823602,
+				"StableID":   "nZUiu8iVM721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:4f1fb67f448163694c66741a2f52d29197e41e64de9ff994b8140d4bf3f76972",
+				"KeyExpiry":  "2026-11-08T21:58:33Z",
+				"DiscoKey":   "discokey:0a0700b62f9a2957ef46da6d0457b1f44f509c5937fac31058ebba2203ba0542",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40365",
+					"10.65.0.27:40365",
+					"172.17.0.1:40365",
+					"172.18.0.1:40365",
+					"172.19.0.1:40365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:58:33.359731695Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1920759525508500,
+				"StableID":   "n1jMwY6vzF11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:6460aa7e4b52ac5118d804abab1c82aae16d452f5e3927f6daaa0a124eee9139",
+				"KeyExpiry":  "2026-11-08T21:58:33Z",
+				"DiscoKey":   "discokey:bc299dbce4c639d15aa4e02cf409b946d977e131126d40dd3531736fd46efe3a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42726",
+					"10.65.0.27:42726",
+					"172.17.0.1:42726",
+					"172.18.0.1:42726",
+					"172.19.0.1:42726"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:58:33.906179719Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2631683467103926,
+				"StableID":   "nBsFD1stYM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       2631683467103926,
+				"Key":        "nodekey:e35b4c85927fd5c0d00fa1b68763701fd3a7ec6f345d8da3b412a3bdb73ce02b",
+				"DiscoKey":   "discokey:a59f687863d4b13b7323652ffb2aa9c2358e8bba297b3ebc431abf9ff4287527",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42155",
+					"10.65.0.27:42155",
+					"172.17.0.1:42155",
+					"172.18.0.1:42155",
+					"172.19.0.1:42155"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:58:31.739754289Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e35b4c85927fd5c0d00fa1b68763701fd3a7ec6f345d8da3b412a3bdb73ce02b",
+			"MachineKey": "mkey:311300ed9becb1d1a116c80f6feb2873af6de9e3fd1eb7da7a35b20548f86d3e",
+			"Peers": [{
+				"ID":         534499573604818,
+				"StableID":   "nFDg14Q5B511CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a295bb9d66ad435c1c863d60ff2c0eaa7bec1f4303dc51d7c0a90b2660b0c37d",
+				"DiscoKey":   "discokey:2e5d8e7dd0b12d0b15e62451c2ae8c5e653af1079984154c9559ecdfa965c47f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44264",
+					"10.65.0.27:44264",
+					"172.17.0.1:44264",
+					"172.18.0.1:44264",
+					"172.19.0.1:44264"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:58:26.341904369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4275649627261847,
+				"StableID":   "nztdHo4TPa11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26496ff07821536cf8faa23b0fd643702aa59ea884a3c1234f7ec40eb9ca3e16",
+				"DiscoKey":   "discokey:904c409d93b40a05bfa2e2d3ffdc6010036cc5b0acfb95f35bbc1976613b4f76",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42615",
+					"10.65.0.27:42615",
+					"172.17.0.1:42615",
+					"172.18.0.1:42615",
+					"172.19.0.1:42615"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:58:26.930448146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1742476355781486,
+				"StableID":   "nyENj9uAcE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fcdc746945849cc059b48882c7e421d5ba17242014b03121bf01b0de92a39028",
+				"DiscoKey":   "discokey:783a4300334e7f2d2d6b5f3bedf2aaaa085f3ec1cf7699484802486f52055754",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40969",
+					"10.65.0.27:40969",
+					"172.17.0.1:40969",
+					"172.18.0.1:40969",
+					"172.19.0.1:40969"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:58:27.423308868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         975863935373222,
+				"StableID":   "nZWEHsHyc811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1be5552a82ccc811e7f0e68adebee96005a93b10c92d2eb1990fdc31e5736a2d",
+				"DiscoKey":   "discokey:18554a005da60494ccfb50efd01867c6c6850d4d14a172b8663d8e6ab46de462",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34673",
+					"10.65.0.27:34673",
+					"172.17.0.1:34673",
+					"172.18.0.1:34673",
+					"172.19.0.1:34673"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:58:27.95517668Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5793056539786640,
+				"StableID":   "nBan2nmgEn11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1124cca0ea8b658e802f3a8c5461fdfc63a80a4319a4fa7b5a2c42b56210d02",
+				"DiscoKey":   "discokey:91144d49f8e60b955724fda6fa8e43f318a1728c3dae2b9ff1f0fb188f027c19",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55242",
+					"10.65.0.27:55242",
+					"172.17.0.1:55242",
+					"172.18.0.1:55242",
+					"172.19.0.1:55242"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:58:28.496770895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         217457670716385,
+				"StableID":   "nGWKiAFVh211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:957a5f80c833af535aa064af40a10697079fd8e489063c4aa657f029f2b01001",
+				"DiscoKey":   "discokey:3e1cac42808059f5363cf3fb70fcd38dbacd1ed48fa8440d9e2c5e8dbd10355d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53237",
+					"10.65.0.27:53237",
+					"172.17.0.1:53237",
+					"172.18.0.1:53237",
+					"172.19.0.1:53237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:58:29.035135257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         646345387390297,
+				"StableID":   "ntzWa3Qj3611CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cf3eb894b4e76e54ba6d173285658f0041da75d5f083b1bee556717e54d00046",
+				"DiscoKey":   "discokey:6496dffafcf54f08b725e033b9386234ff01f0e578669c0006400517ed417306",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:55237",
+					"10.65.0.27:55237",
+					"172.17.0.1:55237",
+					"172.18.0.1:55237",
+					"172.19.0.1:55237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:58:29.578822538Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4650834079454209,
+				"StableID":   "nSfxZSXNKd11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:598bfb66ea80b91fcb784add5a6ef993a9230b23fa2e83bf60020a003e585a6b",
+				"DiscoKey":   "discokey:16e38a2a8eba52bfbdb69e7524655fd6d34d91e63810686bdddd1efa362f3655",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46114",
+					"10.65.0.27:46114",
+					"172.17.0.1:46114",
+					"172.18.0.1:46114",
+					"172.19.0.1:46114"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:58:30.119427275Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7124341447155548,
+				"StableID":   "nogPXQNddx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4af93a2a2d2cfd72b8427c87a62eb1136c19e00b082a482cb571eaff0b26677",
+				"DiscoKey":   "discokey:2c563596b817d09a1178bfeb778c2c46ea34daa313d9cd1b52fdcf9eff3ce156",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:51270",
+					"10.65.0.27:51270",
+					"172.17.0.1:51270",
+					"172.18.0.1:51270",
+					"172.19.0.1:51270"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:58:30.667369819Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3593552533063828,
+				"StableID":   "nwieopXX4V11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6bced23ed7fc8d3ae99281126cafa685a4eff4158509ee7b45215e1ebfca047a",
+				"DiscoKey":   "discokey:8188dfceb4caad20e4f80bc6e7be8a97b3550d9967252dc704115196f8f91729",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42074",
+					"10.65.0.27:42074",
+					"172.17.0.1:42074",
+					"172.18.0.1:42074",
+					"172.19.0.1:42074"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:58:31.233293039Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6051058547127384,
+				"StableID":   "nK28wj3YFp11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a09208d509976f62bd09f9ef233504ebe8a8f1ff70c8d2925ed01eb862d9f0d",
+				"DiscoKey":   "discokey:a2e8406808cbb07dec1609f2a3a9763798e3496af74cf250c7593ac9bba83342",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54660",
+					"10.65.0.27:54660",
+					"172.17.0.1:54660",
+					"172.18.0.1:54660",
+					"172.19.0.1:54660"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:58:32.281645116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7628946014681444,
+				"StableID":   "nH1iDaUAa221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:072a3b14be7598b5879400be5bd6c1bbe09ff022bf8dbbaa4cf13d11ace0c454",
+				"KeyExpiry":  "2026-11-08T21:58:32Z",
+				"DiscoKey":   "discokey:9101ef5fe0de8cf89628cbaf7c4d82b08b0a85678528f829b45eec4faeb3b549",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44273",
+					"10.65.0.27:44273",
+					"172.17.0.1:44273",
+					"172.18.0.1:44273",
+					"172.19.0.1:44273"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:58:32.817902576Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8241289836823602,
+				"StableID":   "nZUiu8iVM721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:4f1fb67f448163694c66741a2f52d29197e41e64de9ff994b8140d4bf3f76972",
+				"KeyExpiry":  "2026-11-08T21:58:33Z",
+				"DiscoKey":   "discokey:0a0700b62f9a2957ef46da6d0457b1f44f509c5937fac31058ebba2203ba0542",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40365",
+					"10.65.0.27:40365",
+					"172.17.0.1:40365",
+					"172.18.0.1:40365",
+					"172.19.0.1:40365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:58:33.359731695Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1920759525508500,
+				"StableID":   "n1jMwY6vzF11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:6460aa7e4b52ac5118d804abab1c82aae16d452f5e3927f6daaa0a124eee9139",
+				"KeyExpiry":  "2026-11-08T21:58:33Z",
+				"DiscoKey":   "discokey:bc299dbce4c639d15aa4e02cf409b946d977e131126d40dd3531736fd46efe3a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42726",
+					"10.65.0.27:42726",
+					"172.17.0.1:42726",
+					"172.18.0.1:42726",
+					"172.19.0.1:42726"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:58:33.906179719Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2631683467103926": {
+				"ID":          2631683467103926,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4275649627261847,
+				"StableID":   "nztdHo4TPa11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       4275649627261847,
+				"Key":        "nodekey:26496ff07821536cf8faa23b0fd643702aa59ea884a3c1234f7ec40eb9ca3e16",
+				"DiscoKey":   "discokey:904c409d93b40a05bfa2e2d3ffdc6010036cc5b0acfb95f35bbc1976613b4f76",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42615",
+					"10.65.0.27:42615",
+					"172.17.0.1:42615",
+					"172.18.0.1:42615",
+					"172.19.0.1:42615"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:58:26.930448146Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:26496ff07821536cf8faa23b0fd643702aa59ea884a3c1234f7ec40eb9ca3e16",
+			"MachineKey": "mkey:ee440f6f17aaebd5355f105edf20d49dc65c67c2a6f44fb6485e84d38563e258",
+			"Peers": [{
+				"ID":         534499573604818,
+				"StableID":   "nFDg14Q5B511CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a295bb9d66ad435c1c863d60ff2c0eaa7bec1f4303dc51d7c0a90b2660b0c37d",
+				"DiscoKey":   "discokey:2e5d8e7dd0b12d0b15e62451c2ae8c5e653af1079984154c9559ecdfa965c47f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44264",
+					"10.65.0.27:44264",
+					"172.17.0.1:44264",
+					"172.18.0.1:44264",
+					"172.19.0.1:44264"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:58:26.341904369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1742476355781486,
+				"StableID":   "nyENj9uAcE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fcdc746945849cc059b48882c7e421d5ba17242014b03121bf01b0de92a39028",
+				"DiscoKey":   "discokey:783a4300334e7f2d2d6b5f3bedf2aaaa085f3ec1cf7699484802486f52055754",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40969",
+					"10.65.0.27:40969",
+					"172.17.0.1:40969",
+					"172.18.0.1:40969",
+					"172.19.0.1:40969"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:58:27.423308868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         975863935373222,
+				"StableID":   "nZWEHsHyc811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1be5552a82ccc811e7f0e68adebee96005a93b10c92d2eb1990fdc31e5736a2d",
+				"DiscoKey":   "discokey:18554a005da60494ccfb50efd01867c6c6850d4d14a172b8663d8e6ab46de462",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34673",
+					"10.65.0.27:34673",
+					"172.17.0.1:34673",
+					"172.18.0.1:34673",
+					"172.19.0.1:34673"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:58:27.95517668Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5793056539786640,
+				"StableID":   "nBan2nmgEn11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1124cca0ea8b658e802f3a8c5461fdfc63a80a4319a4fa7b5a2c42b56210d02",
+				"DiscoKey":   "discokey:91144d49f8e60b955724fda6fa8e43f318a1728c3dae2b9ff1f0fb188f027c19",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55242",
+					"10.65.0.27:55242",
+					"172.17.0.1:55242",
+					"172.18.0.1:55242",
+					"172.19.0.1:55242"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:58:28.496770895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         217457670716385,
+				"StableID":   "nGWKiAFVh211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:957a5f80c833af535aa064af40a10697079fd8e489063c4aa657f029f2b01001",
+				"DiscoKey":   "discokey:3e1cac42808059f5363cf3fb70fcd38dbacd1ed48fa8440d9e2c5e8dbd10355d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53237",
+					"10.65.0.27:53237",
+					"172.17.0.1:53237",
+					"172.18.0.1:53237",
+					"172.19.0.1:53237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:58:29.035135257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         646345387390297,
+				"StableID":   "ntzWa3Qj3611CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cf3eb894b4e76e54ba6d173285658f0041da75d5f083b1bee556717e54d00046",
+				"DiscoKey":   "discokey:6496dffafcf54f08b725e033b9386234ff01f0e578669c0006400517ed417306",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:55237",
+					"10.65.0.27:55237",
+					"172.17.0.1:55237",
+					"172.18.0.1:55237",
+					"172.19.0.1:55237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:58:29.578822538Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4650834079454209,
+				"StableID":   "nSfxZSXNKd11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:598bfb66ea80b91fcb784add5a6ef993a9230b23fa2e83bf60020a003e585a6b",
+				"DiscoKey":   "discokey:16e38a2a8eba52bfbdb69e7524655fd6d34d91e63810686bdddd1efa362f3655",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46114",
+					"10.65.0.27:46114",
+					"172.17.0.1:46114",
+					"172.18.0.1:46114",
+					"172.19.0.1:46114"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:58:30.119427275Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7124341447155548,
+				"StableID":   "nogPXQNddx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4af93a2a2d2cfd72b8427c87a62eb1136c19e00b082a482cb571eaff0b26677",
+				"DiscoKey":   "discokey:2c563596b817d09a1178bfeb778c2c46ea34daa313d9cd1b52fdcf9eff3ce156",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:51270",
+					"10.65.0.27:51270",
+					"172.17.0.1:51270",
+					"172.18.0.1:51270",
+					"172.19.0.1:51270"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:58:30.667369819Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3593552533063828,
+				"StableID":   "nwieopXX4V11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6bced23ed7fc8d3ae99281126cafa685a4eff4158509ee7b45215e1ebfca047a",
+				"DiscoKey":   "discokey:8188dfceb4caad20e4f80bc6e7be8a97b3550d9967252dc704115196f8f91729",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42074",
+					"10.65.0.27:42074",
+					"172.17.0.1:42074",
+					"172.18.0.1:42074",
+					"172.19.0.1:42074"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:58:31.233293039Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2631683467103926,
+				"StableID":   "nBsFD1stYM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e35b4c85927fd5c0d00fa1b68763701fd3a7ec6f345d8da3b412a3bdb73ce02b",
+				"DiscoKey":   "discokey:a59f687863d4b13b7323652ffb2aa9c2358e8bba297b3ebc431abf9ff4287527",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42155",
+					"10.65.0.27:42155",
+					"172.17.0.1:42155",
+					"172.18.0.1:42155",
+					"172.19.0.1:42155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:58:31.739754289Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6051058547127384,
+				"StableID":   "nK28wj3YFp11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a09208d509976f62bd09f9ef233504ebe8a8f1ff70c8d2925ed01eb862d9f0d",
+				"DiscoKey":   "discokey:a2e8406808cbb07dec1609f2a3a9763798e3496af74cf250c7593ac9bba83342",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54660",
+					"10.65.0.27:54660",
+					"172.17.0.1:54660",
+					"172.18.0.1:54660",
+					"172.19.0.1:54660"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:58:32.281645116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7628946014681444,
+				"StableID":   "nH1iDaUAa221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:072a3b14be7598b5879400be5bd6c1bbe09ff022bf8dbbaa4cf13d11ace0c454",
+				"KeyExpiry":  "2026-11-08T21:58:32Z",
+				"DiscoKey":   "discokey:9101ef5fe0de8cf89628cbaf7c4d82b08b0a85678528f829b45eec4faeb3b549",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44273",
+					"10.65.0.27:44273",
+					"172.17.0.1:44273",
+					"172.18.0.1:44273",
+					"172.19.0.1:44273"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:58:32.817902576Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8241289836823602,
+				"StableID":   "nZUiu8iVM721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:4f1fb67f448163694c66741a2f52d29197e41e64de9ff994b8140d4bf3f76972",
+				"KeyExpiry":  "2026-11-08T21:58:33Z",
+				"DiscoKey":   "discokey:0a0700b62f9a2957ef46da6d0457b1f44f509c5937fac31058ebba2203ba0542",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40365",
+					"10.65.0.27:40365",
+					"172.17.0.1:40365",
+					"172.18.0.1:40365",
+					"172.19.0.1:40365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:58:33.359731695Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1920759525508500,
+				"StableID":   "n1jMwY6vzF11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:6460aa7e4b52ac5118d804abab1c82aae16d452f5e3927f6daaa0a124eee9139",
+				"KeyExpiry":  "2026-11-08T21:58:33Z",
+				"DiscoKey":   "discokey:bc299dbce4c639d15aa4e02cf409b946d977e131126d40dd3531736fd46efe3a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42726",
+					"10.65.0.27:42726",
+					"172.17.0.1:42726",
+					"172.18.0.1:42726",
+					"172.19.0.1:42726"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:58:33.906179719Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4275649627261847": {
+				"ID":          4275649627261847,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         534499573604818,
+				"StableID":   "nFDg14Q5B511CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       534499573604818,
+				"Key":        "nodekey:a295bb9d66ad435c1c863d60ff2c0eaa7bec1f4303dc51d7c0a90b2660b0c37d",
+				"DiscoKey":   "discokey:2e5d8e7dd0b12d0b15e62451c2ae8c5e653af1079984154c9559ecdfa965c47f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44264",
+					"10.65.0.27:44264",
+					"172.17.0.1:44264",
+					"172.18.0.1:44264",
+					"172.19.0.1:44264"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:58:26.341904369Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a295bb9d66ad435c1c863d60ff2c0eaa7bec1f4303dc51d7c0a90b2660b0c37d",
+			"MachineKey": "mkey:8dff931c602948cf2ef8748b6f9264ee58a9a2d699388b5cccc05a7f8df1e520",
+			"Peers": [{
+				"ID":         4275649627261847,
+				"StableID":   "nztdHo4TPa11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26496ff07821536cf8faa23b0fd643702aa59ea884a3c1234f7ec40eb9ca3e16",
+				"DiscoKey":   "discokey:904c409d93b40a05bfa2e2d3ffdc6010036cc5b0acfb95f35bbc1976613b4f76",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42615",
+					"10.65.0.27:42615",
+					"172.17.0.1:42615",
+					"172.18.0.1:42615",
+					"172.19.0.1:42615"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:58:26.930448146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1742476355781486,
+				"StableID":   "nyENj9uAcE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fcdc746945849cc059b48882c7e421d5ba17242014b03121bf01b0de92a39028",
+				"DiscoKey":   "discokey:783a4300334e7f2d2d6b5f3bedf2aaaa085f3ec1cf7699484802486f52055754",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40969",
+					"10.65.0.27:40969",
+					"172.17.0.1:40969",
+					"172.18.0.1:40969",
+					"172.19.0.1:40969"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:58:27.423308868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         975863935373222,
+				"StableID":   "nZWEHsHyc811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1be5552a82ccc811e7f0e68adebee96005a93b10c92d2eb1990fdc31e5736a2d",
+				"DiscoKey":   "discokey:18554a005da60494ccfb50efd01867c6c6850d4d14a172b8663d8e6ab46de462",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34673",
+					"10.65.0.27:34673",
+					"172.17.0.1:34673",
+					"172.18.0.1:34673",
+					"172.19.0.1:34673"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:58:27.95517668Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5793056539786640,
+				"StableID":   "nBan2nmgEn11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1124cca0ea8b658e802f3a8c5461fdfc63a80a4319a4fa7b5a2c42b56210d02",
+				"DiscoKey":   "discokey:91144d49f8e60b955724fda6fa8e43f318a1728c3dae2b9ff1f0fb188f027c19",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55242",
+					"10.65.0.27:55242",
+					"172.17.0.1:55242",
+					"172.18.0.1:55242",
+					"172.19.0.1:55242"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:58:28.496770895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         217457670716385,
+				"StableID":   "nGWKiAFVh211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:957a5f80c833af535aa064af40a10697079fd8e489063c4aa657f029f2b01001",
+				"DiscoKey":   "discokey:3e1cac42808059f5363cf3fb70fcd38dbacd1ed48fa8440d9e2c5e8dbd10355d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53237",
+					"10.65.0.27:53237",
+					"172.17.0.1:53237",
+					"172.18.0.1:53237",
+					"172.19.0.1:53237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:58:29.035135257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         646345387390297,
+				"StableID":   "ntzWa3Qj3611CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cf3eb894b4e76e54ba6d173285658f0041da75d5f083b1bee556717e54d00046",
+				"DiscoKey":   "discokey:6496dffafcf54f08b725e033b9386234ff01f0e578669c0006400517ed417306",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:55237",
+					"10.65.0.27:55237",
+					"172.17.0.1:55237",
+					"172.18.0.1:55237",
+					"172.19.0.1:55237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:58:29.578822538Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4650834079454209,
+				"StableID":   "nSfxZSXNKd11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:598bfb66ea80b91fcb784add5a6ef993a9230b23fa2e83bf60020a003e585a6b",
+				"DiscoKey":   "discokey:16e38a2a8eba52bfbdb69e7524655fd6d34d91e63810686bdddd1efa362f3655",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46114",
+					"10.65.0.27:46114",
+					"172.17.0.1:46114",
+					"172.18.0.1:46114",
+					"172.19.0.1:46114"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:58:30.119427275Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7124341447155548,
+				"StableID":   "nogPXQNddx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4af93a2a2d2cfd72b8427c87a62eb1136c19e00b082a482cb571eaff0b26677",
+				"DiscoKey":   "discokey:2c563596b817d09a1178bfeb778c2c46ea34daa313d9cd1b52fdcf9eff3ce156",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:51270",
+					"10.65.0.27:51270",
+					"172.17.0.1:51270",
+					"172.18.0.1:51270",
+					"172.19.0.1:51270"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:58:30.667369819Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3593552533063828,
+				"StableID":   "nwieopXX4V11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6bced23ed7fc8d3ae99281126cafa685a4eff4158509ee7b45215e1ebfca047a",
+				"DiscoKey":   "discokey:8188dfceb4caad20e4f80bc6e7be8a97b3550d9967252dc704115196f8f91729",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42074",
+					"10.65.0.27:42074",
+					"172.17.0.1:42074",
+					"172.18.0.1:42074",
+					"172.19.0.1:42074"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:58:31.233293039Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2631683467103926,
+				"StableID":   "nBsFD1stYM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e35b4c85927fd5c0d00fa1b68763701fd3a7ec6f345d8da3b412a3bdb73ce02b",
+				"DiscoKey":   "discokey:a59f687863d4b13b7323652ffb2aa9c2358e8bba297b3ebc431abf9ff4287527",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42155",
+					"10.65.0.27:42155",
+					"172.17.0.1:42155",
+					"172.18.0.1:42155",
+					"172.19.0.1:42155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:58:31.739754289Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6051058547127384,
+				"StableID":   "nK28wj3YFp11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a09208d509976f62bd09f9ef233504ebe8a8f1ff70c8d2925ed01eb862d9f0d",
+				"DiscoKey":   "discokey:a2e8406808cbb07dec1609f2a3a9763798e3496af74cf250c7593ac9bba83342",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54660",
+					"10.65.0.27:54660",
+					"172.17.0.1:54660",
+					"172.18.0.1:54660",
+					"172.19.0.1:54660"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:58:32.281645116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7628946014681444,
+				"StableID":   "nH1iDaUAa221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:072a3b14be7598b5879400be5bd6c1bbe09ff022bf8dbbaa4cf13d11ace0c454",
+				"KeyExpiry":  "2026-11-08T21:58:32Z",
+				"DiscoKey":   "discokey:9101ef5fe0de8cf89628cbaf7c4d82b08b0a85678528f829b45eec4faeb3b549",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44273",
+					"10.65.0.27:44273",
+					"172.17.0.1:44273",
+					"172.18.0.1:44273",
+					"172.19.0.1:44273"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:58:32.817902576Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8241289836823602,
+				"StableID":   "nZUiu8iVM721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:4f1fb67f448163694c66741a2f52d29197e41e64de9ff994b8140d4bf3f76972",
+				"KeyExpiry":  "2026-11-08T21:58:33Z",
+				"DiscoKey":   "discokey:0a0700b62f9a2957ef46da6d0457b1f44f509c5937fac31058ebba2203ba0542",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40365",
+					"10.65.0.27:40365",
+					"172.17.0.1:40365",
+					"172.18.0.1:40365",
+					"172.19.0.1:40365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:58:33.359731695Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1920759525508500,
+				"StableID":   "n1jMwY6vzF11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:6460aa7e4b52ac5118d804abab1c82aae16d452f5e3927f6daaa0a124eee9139",
+				"KeyExpiry":  "2026-11-08T21:58:33Z",
+				"DiscoKey":   "discokey:bc299dbce4c639d15aa4e02cf409b946d977e131126d40dd3531736fd46efe3a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42726",
+					"10.65.0.27:42726",
+					"172.17.0.1:42726",
+					"172.18.0.1:42726",
+					"172.19.0.1:42726"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:58:33.906179719Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "534499573604818": {
+				"ID":          534499573604818,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5793056539786640,
+				"StableID":   "nBan2nmgEn11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       5793056539786640,
+				"Key":        "nodekey:c1124cca0ea8b658e802f3a8c5461fdfc63a80a4319a4fa7b5a2c42b56210d02",
+				"DiscoKey":   "discokey:91144d49f8e60b955724fda6fa8e43f318a1728c3dae2b9ff1f0fb188f027c19",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55242",
+					"10.65.0.27:55242",
+					"172.17.0.1:55242",
+					"172.18.0.1:55242",
+					"172.19.0.1:55242"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:58:28.496770895Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c1124cca0ea8b658e802f3a8c5461fdfc63a80a4319a4fa7b5a2c42b56210d02",
+			"MachineKey": "mkey:90b8533308a3dcba8a38ad895154d1a54956155c664aeee9c2fbb1db90489225",
+			"Peers": [{
+				"ID":         534499573604818,
+				"StableID":   "nFDg14Q5B511CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a295bb9d66ad435c1c863d60ff2c0eaa7bec1f4303dc51d7c0a90b2660b0c37d",
+				"DiscoKey":   "discokey:2e5d8e7dd0b12d0b15e62451c2ae8c5e653af1079984154c9559ecdfa965c47f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44264",
+					"10.65.0.27:44264",
+					"172.17.0.1:44264",
+					"172.18.0.1:44264",
+					"172.19.0.1:44264"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:58:26.341904369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4275649627261847,
+				"StableID":   "nztdHo4TPa11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26496ff07821536cf8faa23b0fd643702aa59ea884a3c1234f7ec40eb9ca3e16",
+				"DiscoKey":   "discokey:904c409d93b40a05bfa2e2d3ffdc6010036cc5b0acfb95f35bbc1976613b4f76",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42615",
+					"10.65.0.27:42615",
+					"172.17.0.1:42615",
+					"172.18.0.1:42615",
+					"172.19.0.1:42615"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:58:26.930448146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1742476355781486,
+				"StableID":   "nyENj9uAcE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fcdc746945849cc059b48882c7e421d5ba17242014b03121bf01b0de92a39028",
+				"DiscoKey":   "discokey:783a4300334e7f2d2d6b5f3bedf2aaaa085f3ec1cf7699484802486f52055754",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40969",
+					"10.65.0.27:40969",
+					"172.17.0.1:40969",
+					"172.18.0.1:40969",
+					"172.19.0.1:40969"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:58:27.423308868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         975863935373222,
+				"StableID":   "nZWEHsHyc811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1be5552a82ccc811e7f0e68adebee96005a93b10c92d2eb1990fdc31e5736a2d",
+				"DiscoKey":   "discokey:18554a005da60494ccfb50efd01867c6c6850d4d14a172b8663d8e6ab46de462",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34673",
+					"10.65.0.27:34673",
+					"172.17.0.1:34673",
+					"172.18.0.1:34673",
+					"172.19.0.1:34673"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:58:27.95517668Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         217457670716385,
+				"StableID":   "nGWKiAFVh211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:957a5f80c833af535aa064af40a10697079fd8e489063c4aa657f029f2b01001",
+				"DiscoKey":   "discokey:3e1cac42808059f5363cf3fb70fcd38dbacd1ed48fa8440d9e2c5e8dbd10355d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53237",
+					"10.65.0.27:53237",
+					"172.17.0.1:53237",
+					"172.18.0.1:53237",
+					"172.19.0.1:53237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:58:29.035135257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         646345387390297,
+				"StableID":   "ntzWa3Qj3611CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cf3eb894b4e76e54ba6d173285658f0041da75d5f083b1bee556717e54d00046",
+				"DiscoKey":   "discokey:6496dffafcf54f08b725e033b9386234ff01f0e578669c0006400517ed417306",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:55237",
+					"10.65.0.27:55237",
+					"172.17.0.1:55237",
+					"172.18.0.1:55237",
+					"172.19.0.1:55237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:58:29.578822538Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4650834079454209,
+				"StableID":   "nSfxZSXNKd11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:598bfb66ea80b91fcb784add5a6ef993a9230b23fa2e83bf60020a003e585a6b",
+				"DiscoKey":   "discokey:16e38a2a8eba52bfbdb69e7524655fd6d34d91e63810686bdddd1efa362f3655",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46114",
+					"10.65.0.27:46114",
+					"172.17.0.1:46114",
+					"172.18.0.1:46114",
+					"172.19.0.1:46114"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:58:30.119427275Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7124341447155548,
+				"StableID":   "nogPXQNddx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4af93a2a2d2cfd72b8427c87a62eb1136c19e00b082a482cb571eaff0b26677",
+				"DiscoKey":   "discokey:2c563596b817d09a1178bfeb778c2c46ea34daa313d9cd1b52fdcf9eff3ce156",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:51270",
+					"10.65.0.27:51270",
+					"172.17.0.1:51270",
+					"172.18.0.1:51270",
+					"172.19.0.1:51270"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:58:30.667369819Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3593552533063828,
+				"StableID":   "nwieopXX4V11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6bced23ed7fc8d3ae99281126cafa685a4eff4158509ee7b45215e1ebfca047a",
+				"DiscoKey":   "discokey:8188dfceb4caad20e4f80bc6e7be8a97b3550d9967252dc704115196f8f91729",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42074",
+					"10.65.0.27:42074",
+					"172.17.0.1:42074",
+					"172.18.0.1:42074",
+					"172.19.0.1:42074"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:58:31.233293039Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2631683467103926,
+				"StableID":   "nBsFD1stYM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e35b4c85927fd5c0d00fa1b68763701fd3a7ec6f345d8da3b412a3bdb73ce02b",
+				"DiscoKey":   "discokey:a59f687863d4b13b7323652ffb2aa9c2358e8bba297b3ebc431abf9ff4287527",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42155",
+					"10.65.0.27:42155",
+					"172.17.0.1:42155",
+					"172.18.0.1:42155",
+					"172.19.0.1:42155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:58:31.739754289Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6051058547127384,
+				"StableID":   "nK28wj3YFp11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a09208d509976f62bd09f9ef233504ebe8a8f1ff70c8d2925ed01eb862d9f0d",
+				"DiscoKey":   "discokey:a2e8406808cbb07dec1609f2a3a9763798e3496af74cf250c7593ac9bba83342",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54660",
+					"10.65.0.27:54660",
+					"172.17.0.1:54660",
+					"172.18.0.1:54660",
+					"172.19.0.1:54660"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:58:32.281645116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7628946014681444,
+				"StableID":   "nH1iDaUAa221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:072a3b14be7598b5879400be5bd6c1bbe09ff022bf8dbbaa4cf13d11ace0c454",
+				"KeyExpiry":  "2026-11-08T21:58:32Z",
+				"DiscoKey":   "discokey:9101ef5fe0de8cf89628cbaf7c4d82b08b0a85678528f829b45eec4faeb3b549",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44273",
+					"10.65.0.27:44273",
+					"172.17.0.1:44273",
+					"172.18.0.1:44273",
+					"172.19.0.1:44273"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:58:32.817902576Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8241289836823602,
+				"StableID":   "nZUiu8iVM721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:4f1fb67f448163694c66741a2f52d29197e41e64de9ff994b8140d4bf3f76972",
+				"KeyExpiry":  "2026-11-08T21:58:33Z",
+				"DiscoKey":   "discokey:0a0700b62f9a2957ef46da6d0457b1f44f509c5937fac31058ebba2203ba0542",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40365",
+					"10.65.0.27:40365",
+					"172.17.0.1:40365",
+					"172.18.0.1:40365",
+					"172.19.0.1:40365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:58:33.359731695Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1920759525508500,
+				"StableID":   "n1jMwY6vzF11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:6460aa7e4b52ac5118d804abab1c82aae16d452f5e3927f6daaa0a124eee9139",
+				"KeyExpiry":  "2026-11-08T21:58:33Z",
+				"DiscoKey":   "discokey:bc299dbce4c639d15aa4e02cf409b946d977e131126d40dd3531736fd46efe3a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42726",
+					"10.65.0.27:42726",
+					"172.17.0.1:42726",
+					"172.18.0.1:42726",
+					"172.19.0.1:42726"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:58:33.906179719Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5793056539786640": {
+				"ID":          5793056539786640,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         975863935373222,
+				"StableID":   "nZWEHsHyc811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       975863935373222,
+				"Key":        "nodekey:1be5552a82ccc811e7f0e68adebee96005a93b10c92d2eb1990fdc31e5736a2d",
+				"DiscoKey":   "discokey:18554a005da60494ccfb50efd01867c6c6850d4d14a172b8663d8e6ab46de462",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34673",
+					"10.65.0.27:34673",
+					"172.17.0.1:34673",
+					"172.18.0.1:34673",
+					"172.19.0.1:34673"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:58:27.95517668Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1be5552a82ccc811e7f0e68adebee96005a93b10c92d2eb1990fdc31e5736a2d",
+			"MachineKey": "mkey:97cd41ef207b6ec7b9c83e778863dc69bed557d07e10816abad13b1ece662460",
+			"Peers": [{
+				"ID":         534499573604818,
+				"StableID":   "nFDg14Q5B511CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a295bb9d66ad435c1c863d60ff2c0eaa7bec1f4303dc51d7c0a90b2660b0c37d",
+				"DiscoKey":   "discokey:2e5d8e7dd0b12d0b15e62451c2ae8c5e653af1079984154c9559ecdfa965c47f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44264",
+					"10.65.0.27:44264",
+					"172.17.0.1:44264",
+					"172.18.0.1:44264",
+					"172.19.0.1:44264"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:58:26.341904369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4275649627261847,
+				"StableID":   "nztdHo4TPa11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26496ff07821536cf8faa23b0fd643702aa59ea884a3c1234f7ec40eb9ca3e16",
+				"DiscoKey":   "discokey:904c409d93b40a05bfa2e2d3ffdc6010036cc5b0acfb95f35bbc1976613b4f76",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42615",
+					"10.65.0.27:42615",
+					"172.17.0.1:42615",
+					"172.18.0.1:42615",
+					"172.19.0.1:42615"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:58:26.930448146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1742476355781486,
+				"StableID":   "nyENj9uAcE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fcdc746945849cc059b48882c7e421d5ba17242014b03121bf01b0de92a39028",
+				"DiscoKey":   "discokey:783a4300334e7f2d2d6b5f3bedf2aaaa085f3ec1cf7699484802486f52055754",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40969",
+					"10.65.0.27:40969",
+					"172.17.0.1:40969",
+					"172.18.0.1:40969",
+					"172.19.0.1:40969"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:58:27.423308868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5793056539786640,
+				"StableID":   "nBan2nmgEn11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1124cca0ea8b658e802f3a8c5461fdfc63a80a4319a4fa7b5a2c42b56210d02",
+				"DiscoKey":   "discokey:91144d49f8e60b955724fda6fa8e43f318a1728c3dae2b9ff1f0fb188f027c19",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55242",
+					"10.65.0.27:55242",
+					"172.17.0.1:55242",
+					"172.18.0.1:55242",
+					"172.19.0.1:55242"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:58:28.496770895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         217457670716385,
+				"StableID":   "nGWKiAFVh211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:957a5f80c833af535aa064af40a10697079fd8e489063c4aa657f029f2b01001",
+				"DiscoKey":   "discokey:3e1cac42808059f5363cf3fb70fcd38dbacd1ed48fa8440d9e2c5e8dbd10355d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53237",
+					"10.65.0.27:53237",
+					"172.17.0.1:53237",
+					"172.18.0.1:53237",
+					"172.19.0.1:53237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:58:29.035135257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         646345387390297,
+				"StableID":   "ntzWa3Qj3611CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cf3eb894b4e76e54ba6d173285658f0041da75d5f083b1bee556717e54d00046",
+				"DiscoKey":   "discokey:6496dffafcf54f08b725e033b9386234ff01f0e578669c0006400517ed417306",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:55237",
+					"10.65.0.27:55237",
+					"172.17.0.1:55237",
+					"172.18.0.1:55237",
+					"172.19.0.1:55237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:58:29.578822538Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4650834079454209,
+				"StableID":   "nSfxZSXNKd11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:598bfb66ea80b91fcb784add5a6ef993a9230b23fa2e83bf60020a003e585a6b",
+				"DiscoKey":   "discokey:16e38a2a8eba52bfbdb69e7524655fd6d34d91e63810686bdddd1efa362f3655",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46114",
+					"10.65.0.27:46114",
+					"172.17.0.1:46114",
+					"172.18.0.1:46114",
+					"172.19.0.1:46114"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:58:30.119427275Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7124341447155548,
+				"StableID":   "nogPXQNddx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4af93a2a2d2cfd72b8427c87a62eb1136c19e00b082a482cb571eaff0b26677",
+				"DiscoKey":   "discokey:2c563596b817d09a1178bfeb778c2c46ea34daa313d9cd1b52fdcf9eff3ce156",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:51270",
+					"10.65.0.27:51270",
+					"172.17.0.1:51270",
+					"172.18.0.1:51270",
+					"172.19.0.1:51270"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:58:30.667369819Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3593552533063828,
+				"StableID":   "nwieopXX4V11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6bced23ed7fc8d3ae99281126cafa685a4eff4158509ee7b45215e1ebfca047a",
+				"DiscoKey":   "discokey:8188dfceb4caad20e4f80bc6e7be8a97b3550d9967252dc704115196f8f91729",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42074",
+					"10.65.0.27:42074",
+					"172.17.0.1:42074",
+					"172.18.0.1:42074",
+					"172.19.0.1:42074"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:58:31.233293039Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2631683467103926,
+				"StableID":   "nBsFD1stYM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e35b4c85927fd5c0d00fa1b68763701fd3a7ec6f345d8da3b412a3bdb73ce02b",
+				"DiscoKey":   "discokey:a59f687863d4b13b7323652ffb2aa9c2358e8bba297b3ebc431abf9ff4287527",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42155",
+					"10.65.0.27:42155",
+					"172.17.0.1:42155",
+					"172.18.0.1:42155",
+					"172.19.0.1:42155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:58:31.739754289Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6051058547127384,
+				"StableID":   "nK28wj3YFp11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a09208d509976f62bd09f9ef233504ebe8a8f1ff70c8d2925ed01eb862d9f0d",
+				"DiscoKey":   "discokey:a2e8406808cbb07dec1609f2a3a9763798e3496af74cf250c7593ac9bba83342",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54660",
+					"10.65.0.27:54660",
+					"172.17.0.1:54660",
+					"172.18.0.1:54660",
+					"172.19.0.1:54660"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:58:32.281645116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7628946014681444,
+				"StableID":   "nH1iDaUAa221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:072a3b14be7598b5879400be5bd6c1bbe09ff022bf8dbbaa4cf13d11ace0c454",
+				"KeyExpiry":  "2026-11-08T21:58:32Z",
+				"DiscoKey":   "discokey:9101ef5fe0de8cf89628cbaf7c4d82b08b0a85678528f829b45eec4faeb3b549",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44273",
+					"10.65.0.27:44273",
+					"172.17.0.1:44273",
+					"172.18.0.1:44273",
+					"172.19.0.1:44273"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:58:32.817902576Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8241289836823602,
+				"StableID":   "nZUiu8iVM721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:4f1fb67f448163694c66741a2f52d29197e41e64de9ff994b8140d4bf3f76972",
+				"KeyExpiry":  "2026-11-08T21:58:33Z",
+				"DiscoKey":   "discokey:0a0700b62f9a2957ef46da6d0457b1f44f509c5937fac31058ebba2203ba0542",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40365",
+					"10.65.0.27:40365",
+					"172.17.0.1:40365",
+					"172.18.0.1:40365",
+					"172.19.0.1:40365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:58:33.359731695Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1920759525508500,
+				"StableID":   "n1jMwY6vzF11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:6460aa7e4b52ac5118d804abab1c82aae16d452f5e3927f6daaa0a124eee9139",
+				"KeyExpiry":  "2026-11-08T21:58:33Z",
+				"DiscoKey":   "discokey:bc299dbce4c639d15aa4e02cf409b946d977e131126d40dd3531736fd46efe3a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42726",
+					"10.65.0.27:42726",
+					"172.17.0.1:42726",
+					"172.18.0.1:42726",
+					"172.19.0.1:42726"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:58:33.906179719Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "975863935373222": {
+				"ID":          975863935373222,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         646345387390297,
+				"StableID":   "ntzWa3Qj3611CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       646345387390297,
+				"Key":        "nodekey:cf3eb894b4e76e54ba6d173285658f0041da75d5f083b1bee556717e54d00046",
+				"DiscoKey":   "discokey:6496dffafcf54f08b725e033b9386234ff01f0e578669c0006400517ed417306",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:55237",
+					"10.65.0.27:55237",
+					"172.17.0.1:55237",
+					"172.18.0.1:55237",
+					"172.19.0.1:55237"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:58:29.578822538Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:cf3eb894b4e76e54ba6d173285658f0041da75d5f083b1bee556717e54d00046",
+			"MachineKey": "mkey:6d370d6cb9ab69cdf15a22fd357916ab5cc6584b1231b3605a199df2c8e57631",
+			"Peers": [{
+				"ID":         534499573604818,
+				"StableID":   "nFDg14Q5B511CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a295bb9d66ad435c1c863d60ff2c0eaa7bec1f4303dc51d7c0a90b2660b0c37d",
+				"DiscoKey":   "discokey:2e5d8e7dd0b12d0b15e62451c2ae8c5e653af1079984154c9559ecdfa965c47f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44264",
+					"10.65.0.27:44264",
+					"172.17.0.1:44264",
+					"172.18.0.1:44264",
+					"172.19.0.1:44264"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:58:26.341904369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4275649627261847,
+				"StableID":   "nztdHo4TPa11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26496ff07821536cf8faa23b0fd643702aa59ea884a3c1234f7ec40eb9ca3e16",
+				"DiscoKey":   "discokey:904c409d93b40a05bfa2e2d3ffdc6010036cc5b0acfb95f35bbc1976613b4f76",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42615",
+					"10.65.0.27:42615",
+					"172.17.0.1:42615",
+					"172.18.0.1:42615",
+					"172.19.0.1:42615"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:58:26.930448146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1742476355781486,
+				"StableID":   "nyENj9uAcE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fcdc746945849cc059b48882c7e421d5ba17242014b03121bf01b0de92a39028",
+				"DiscoKey":   "discokey:783a4300334e7f2d2d6b5f3bedf2aaaa085f3ec1cf7699484802486f52055754",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40969",
+					"10.65.0.27:40969",
+					"172.17.0.1:40969",
+					"172.18.0.1:40969",
+					"172.19.0.1:40969"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:58:27.423308868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         975863935373222,
+				"StableID":   "nZWEHsHyc811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1be5552a82ccc811e7f0e68adebee96005a93b10c92d2eb1990fdc31e5736a2d",
+				"DiscoKey":   "discokey:18554a005da60494ccfb50efd01867c6c6850d4d14a172b8663d8e6ab46de462",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34673",
+					"10.65.0.27:34673",
+					"172.17.0.1:34673",
+					"172.18.0.1:34673",
+					"172.19.0.1:34673"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:58:27.95517668Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5793056539786640,
+				"StableID":   "nBan2nmgEn11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1124cca0ea8b658e802f3a8c5461fdfc63a80a4319a4fa7b5a2c42b56210d02",
+				"DiscoKey":   "discokey:91144d49f8e60b955724fda6fa8e43f318a1728c3dae2b9ff1f0fb188f027c19",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55242",
+					"10.65.0.27:55242",
+					"172.17.0.1:55242",
+					"172.18.0.1:55242",
+					"172.19.0.1:55242"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:58:28.496770895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         217457670716385,
+				"StableID":   "nGWKiAFVh211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:957a5f80c833af535aa064af40a10697079fd8e489063c4aa657f029f2b01001",
+				"DiscoKey":   "discokey:3e1cac42808059f5363cf3fb70fcd38dbacd1ed48fa8440d9e2c5e8dbd10355d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53237",
+					"10.65.0.27:53237",
+					"172.17.0.1:53237",
+					"172.18.0.1:53237",
+					"172.19.0.1:53237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:58:29.035135257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4650834079454209,
+				"StableID":   "nSfxZSXNKd11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:598bfb66ea80b91fcb784add5a6ef993a9230b23fa2e83bf60020a003e585a6b",
+				"DiscoKey":   "discokey:16e38a2a8eba52bfbdb69e7524655fd6d34d91e63810686bdddd1efa362f3655",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46114",
+					"10.65.0.27:46114",
+					"172.17.0.1:46114",
+					"172.18.0.1:46114",
+					"172.19.0.1:46114"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:58:30.119427275Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7124341447155548,
+				"StableID":   "nogPXQNddx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4af93a2a2d2cfd72b8427c87a62eb1136c19e00b082a482cb571eaff0b26677",
+				"DiscoKey":   "discokey:2c563596b817d09a1178bfeb778c2c46ea34daa313d9cd1b52fdcf9eff3ce156",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:51270",
+					"10.65.0.27:51270",
+					"172.17.0.1:51270",
+					"172.18.0.1:51270",
+					"172.19.0.1:51270"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:58:30.667369819Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3593552533063828,
+				"StableID":   "nwieopXX4V11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6bced23ed7fc8d3ae99281126cafa685a4eff4158509ee7b45215e1ebfca047a",
+				"DiscoKey":   "discokey:8188dfceb4caad20e4f80bc6e7be8a97b3550d9967252dc704115196f8f91729",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42074",
+					"10.65.0.27:42074",
+					"172.17.0.1:42074",
+					"172.18.0.1:42074",
+					"172.19.0.1:42074"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:58:31.233293039Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2631683467103926,
+				"StableID":   "nBsFD1stYM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e35b4c85927fd5c0d00fa1b68763701fd3a7ec6f345d8da3b412a3bdb73ce02b",
+				"DiscoKey":   "discokey:a59f687863d4b13b7323652ffb2aa9c2358e8bba297b3ebc431abf9ff4287527",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42155",
+					"10.65.0.27:42155",
+					"172.17.0.1:42155",
+					"172.18.0.1:42155",
+					"172.19.0.1:42155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:58:31.739754289Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6051058547127384,
+				"StableID":   "nK28wj3YFp11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a09208d509976f62bd09f9ef233504ebe8a8f1ff70c8d2925ed01eb862d9f0d",
+				"DiscoKey":   "discokey:a2e8406808cbb07dec1609f2a3a9763798e3496af74cf250c7593ac9bba83342",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54660",
+					"10.65.0.27:54660",
+					"172.17.0.1:54660",
+					"172.18.0.1:54660",
+					"172.19.0.1:54660"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:58:32.281645116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7628946014681444,
+				"StableID":   "nH1iDaUAa221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:072a3b14be7598b5879400be5bd6c1bbe09ff022bf8dbbaa4cf13d11ace0c454",
+				"KeyExpiry":  "2026-11-08T21:58:32Z",
+				"DiscoKey":   "discokey:9101ef5fe0de8cf89628cbaf7c4d82b08b0a85678528f829b45eec4faeb3b549",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44273",
+					"10.65.0.27:44273",
+					"172.17.0.1:44273",
+					"172.18.0.1:44273",
+					"172.19.0.1:44273"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:58:32.817902576Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8241289836823602,
+				"StableID":   "nZUiu8iVM721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:4f1fb67f448163694c66741a2f52d29197e41e64de9ff994b8140d4bf3f76972",
+				"KeyExpiry":  "2026-11-08T21:58:33Z",
+				"DiscoKey":   "discokey:0a0700b62f9a2957ef46da6d0457b1f44f509c5937fac31058ebba2203ba0542",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40365",
+					"10.65.0.27:40365",
+					"172.17.0.1:40365",
+					"172.18.0.1:40365",
+					"172.19.0.1:40365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:58:33.359731695Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1920759525508500,
+				"StableID":   "n1jMwY6vzF11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:6460aa7e4b52ac5118d804abab1c82aae16d452f5e3927f6daaa0a124eee9139",
+				"KeyExpiry":  "2026-11-08T21:58:33Z",
+				"DiscoKey":   "discokey:bc299dbce4c639d15aa4e02cf409b946d977e131126d40dd3531736fd46efe3a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42726",
+					"10.65.0.27:42726",
+					"172.17.0.1:42726",
+					"172.18.0.1:42726",
+					"172.19.0.1:42726"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:58:33.906179719Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "646345387390297": {
+				"ID":          646345387390297,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7124341447155548,
+				"StableID":   "nogPXQNddx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       7124341447155548,
+				"Key":        "nodekey:e4af93a2a2d2cfd72b8427c87a62eb1136c19e00b082a482cb571eaff0b26677",
+				"DiscoKey":   "discokey:2c563596b817d09a1178bfeb778c2c46ea34daa313d9cd1b52fdcf9eff3ce156",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:51270",
+					"10.65.0.27:51270",
+					"172.17.0.1:51270",
+					"172.18.0.1:51270",
+					"172.19.0.1:51270"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:58:30.667369819Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e4af93a2a2d2cfd72b8427c87a62eb1136c19e00b082a482cb571eaff0b26677",
+			"MachineKey": "mkey:ba3764bfddfa6277fa25992b8ff2367e399e1381bcfe466657ced74a2bcd1c31",
+			"Peers": [{
+				"ID":         534499573604818,
+				"StableID":   "nFDg14Q5B511CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a295bb9d66ad435c1c863d60ff2c0eaa7bec1f4303dc51d7c0a90b2660b0c37d",
+				"DiscoKey":   "discokey:2e5d8e7dd0b12d0b15e62451c2ae8c5e653af1079984154c9559ecdfa965c47f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44264",
+					"10.65.0.27:44264",
+					"172.17.0.1:44264",
+					"172.18.0.1:44264",
+					"172.19.0.1:44264"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:58:26.341904369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4275649627261847,
+				"StableID":   "nztdHo4TPa11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26496ff07821536cf8faa23b0fd643702aa59ea884a3c1234f7ec40eb9ca3e16",
+				"DiscoKey":   "discokey:904c409d93b40a05bfa2e2d3ffdc6010036cc5b0acfb95f35bbc1976613b4f76",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42615",
+					"10.65.0.27:42615",
+					"172.17.0.1:42615",
+					"172.18.0.1:42615",
+					"172.19.0.1:42615"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:58:26.930448146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1742476355781486,
+				"StableID":   "nyENj9uAcE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fcdc746945849cc059b48882c7e421d5ba17242014b03121bf01b0de92a39028",
+				"DiscoKey":   "discokey:783a4300334e7f2d2d6b5f3bedf2aaaa085f3ec1cf7699484802486f52055754",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40969",
+					"10.65.0.27:40969",
+					"172.17.0.1:40969",
+					"172.18.0.1:40969",
+					"172.19.0.1:40969"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:58:27.423308868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         975863935373222,
+				"StableID":   "nZWEHsHyc811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1be5552a82ccc811e7f0e68adebee96005a93b10c92d2eb1990fdc31e5736a2d",
+				"DiscoKey":   "discokey:18554a005da60494ccfb50efd01867c6c6850d4d14a172b8663d8e6ab46de462",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34673",
+					"10.65.0.27:34673",
+					"172.17.0.1:34673",
+					"172.18.0.1:34673",
+					"172.19.0.1:34673"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:58:27.95517668Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5793056539786640,
+				"StableID":   "nBan2nmgEn11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1124cca0ea8b658e802f3a8c5461fdfc63a80a4319a4fa7b5a2c42b56210d02",
+				"DiscoKey":   "discokey:91144d49f8e60b955724fda6fa8e43f318a1728c3dae2b9ff1f0fb188f027c19",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55242",
+					"10.65.0.27:55242",
+					"172.17.0.1:55242",
+					"172.18.0.1:55242",
+					"172.19.0.1:55242"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:58:28.496770895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         217457670716385,
+				"StableID":   "nGWKiAFVh211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:957a5f80c833af535aa064af40a10697079fd8e489063c4aa657f029f2b01001",
+				"DiscoKey":   "discokey:3e1cac42808059f5363cf3fb70fcd38dbacd1ed48fa8440d9e2c5e8dbd10355d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53237",
+					"10.65.0.27:53237",
+					"172.17.0.1:53237",
+					"172.18.0.1:53237",
+					"172.19.0.1:53237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:58:29.035135257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         646345387390297,
+				"StableID":   "ntzWa3Qj3611CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cf3eb894b4e76e54ba6d173285658f0041da75d5f083b1bee556717e54d00046",
+				"DiscoKey":   "discokey:6496dffafcf54f08b725e033b9386234ff01f0e578669c0006400517ed417306",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:55237",
+					"10.65.0.27:55237",
+					"172.17.0.1:55237",
+					"172.18.0.1:55237",
+					"172.19.0.1:55237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:58:29.578822538Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4650834079454209,
+				"StableID":   "nSfxZSXNKd11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:598bfb66ea80b91fcb784add5a6ef993a9230b23fa2e83bf60020a003e585a6b",
+				"DiscoKey":   "discokey:16e38a2a8eba52bfbdb69e7524655fd6d34d91e63810686bdddd1efa362f3655",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46114",
+					"10.65.0.27:46114",
+					"172.17.0.1:46114",
+					"172.18.0.1:46114",
+					"172.19.0.1:46114"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:58:30.119427275Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3593552533063828,
+				"StableID":   "nwieopXX4V11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6bced23ed7fc8d3ae99281126cafa685a4eff4158509ee7b45215e1ebfca047a",
+				"DiscoKey":   "discokey:8188dfceb4caad20e4f80bc6e7be8a97b3550d9967252dc704115196f8f91729",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42074",
+					"10.65.0.27:42074",
+					"172.17.0.1:42074",
+					"172.18.0.1:42074",
+					"172.19.0.1:42074"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:58:31.233293039Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2631683467103926,
+				"StableID":   "nBsFD1stYM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e35b4c85927fd5c0d00fa1b68763701fd3a7ec6f345d8da3b412a3bdb73ce02b",
+				"DiscoKey":   "discokey:a59f687863d4b13b7323652ffb2aa9c2358e8bba297b3ebc431abf9ff4287527",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42155",
+					"10.65.0.27:42155",
+					"172.17.0.1:42155",
+					"172.18.0.1:42155",
+					"172.19.0.1:42155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:58:31.739754289Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6051058547127384,
+				"StableID":   "nK28wj3YFp11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a09208d509976f62bd09f9ef233504ebe8a8f1ff70c8d2925ed01eb862d9f0d",
+				"DiscoKey":   "discokey:a2e8406808cbb07dec1609f2a3a9763798e3496af74cf250c7593ac9bba83342",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54660",
+					"10.65.0.27:54660",
+					"172.17.0.1:54660",
+					"172.18.0.1:54660",
+					"172.19.0.1:54660"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:58:32.281645116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7628946014681444,
+				"StableID":   "nH1iDaUAa221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:072a3b14be7598b5879400be5bd6c1bbe09ff022bf8dbbaa4cf13d11ace0c454",
+				"KeyExpiry":  "2026-11-08T21:58:32Z",
+				"DiscoKey":   "discokey:9101ef5fe0de8cf89628cbaf7c4d82b08b0a85678528f829b45eec4faeb3b549",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44273",
+					"10.65.0.27:44273",
+					"172.17.0.1:44273",
+					"172.18.0.1:44273",
+					"172.19.0.1:44273"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:58:32.817902576Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8241289836823602,
+				"StableID":   "nZUiu8iVM721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:4f1fb67f448163694c66741a2f52d29197e41e64de9ff994b8140d4bf3f76972",
+				"KeyExpiry":  "2026-11-08T21:58:33Z",
+				"DiscoKey":   "discokey:0a0700b62f9a2957ef46da6d0457b1f44f509c5937fac31058ebba2203ba0542",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40365",
+					"10.65.0.27:40365",
+					"172.17.0.1:40365",
+					"172.18.0.1:40365",
+					"172.19.0.1:40365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:58:33.359731695Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1920759525508500,
+				"StableID":   "n1jMwY6vzF11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:6460aa7e4b52ac5118d804abab1c82aae16d452f5e3927f6daaa0a124eee9139",
+				"KeyExpiry":  "2026-11-08T21:58:33Z",
+				"DiscoKey":   "discokey:bc299dbce4c639d15aa4e02cf409b946d977e131126d40dd3531736fd46efe3a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42726",
+					"10.65.0.27:42726",
+					"172.17.0.1:42726",
+					"172.18.0.1:42726",
+					"172.19.0.1:42726"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:58:33.906179719Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7124341447155548": {
+				"ID":          7124341447155548,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8241289836823602,
+				"StableID":   "nZUiu8iVM721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:4f1fb67f448163694c66741a2f52d29197e41e64de9ff994b8140d4bf3f76972",
+				"KeyExpiry":  "2026-11-08T21:58:33Z",
+				"DiscoKey":   "discokey:0a0700b62f9a2957ef46da6d0457b1f44f509c5937fac31058ebba2203ba0542",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40365",
+					"10.65.0.27:40365",
+					"172.17.0.1:40365",
+					"172.18.0.1:40365",
+					"172.19.0.1:40365"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:58:33.359731695Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4f1fb67f448163694c66741a2f52d29197e41e64de9ff994b8140d4bf3f76972",
+			"MachineKey": "mkey:48d5adbadc35a05c935fc7f78426cfc4d40a93a9c0f501cf3d963a2109d95174",
+			"Peers": [{
+				"ID":         534499573604818,
+				"StableID":   "nFDg14Q5B511CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a295bb9d66ad435c1c863d60ff2c0eaa7bec1f4303dc51d7c0a90b2660b0c37d",
+				"DiscoKey":   "discokey:2e5d8e7dd0b12d0b15e62451c2ae8c5e653af1079984154c9559ecdfa965c47f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44264",
+					"10.65.0.27:44264",
+					"172.17.0.1:44264",
+					"172.18.0.1:44264",
+					"172.19.0.1:44264"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:58:26.341904369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4275649627261847,
+				"StableID":   "nztdHo4TPa11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26496ff07821536cf8faa23b0fd643702aa59ea884a3c1234f7ec40eb9ca3e16",
+				"DiscoKey":   "discokey:904c409d93b40a05bfa2e2d3ffdc6010036cc5b0acfb95f35bbc1976613b4f76",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42615",
+					"10.65.0.27:42615",
+					"172.17.0.1:42615",
+					"172.18.0.1:42615",
+					"172.19.0.1:42615"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:58:26.930448146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1742476355781486,
+				"StableID":   "nyENj9uAcE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fcdc746945849cc059b48882c7e421d5ba17242014b03121bf01b0de92a39028",
+				"DiscoKey":   "discokey:783a4300334e7f2d2d6b5f3bedf2aaaa085f3ec1cf7699484802486f52055754",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40969",
+					"10.65.0.27:40969",
+					"172.17.0.1:40969",
+					"172.18.0.1:40969",
+					"172.19.0.1:40969"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:58:27.423308868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         975863935373222,
+				"StableID":   "nZWEHsHyc811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1be5552a82ccc811e7f0e68adebee96005a93b10c92d2eb1990fdc31e5736a2d",
+				"DiscoKey":   "discokey:18554a005da60494ccfb50efd01867c6c6850d4d14a172b8663d8e6ab46de462",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34673",
+					"10.65.0.27:34673",
+					"172.17.0.1:34673",
+					"172.18.0.1:34673",
+					"172.19.0.1:34673"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:58:27.95517668Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5793056539786640,
+				"StableID":   "nBan2nmgEn11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1124cca0ea8b658e802f3a8c5461fdfc63a80a4319a4fa7b5a2c42b56210d02",
+				"DiscoKey":   "discokey:91144d49f8e60b955724fda6fa8e43f318a1728c3dae2b9ff1f0fb188f027c19",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55242",
+					"10.65.0.27:55242",
+					"172.17.0.1:55242",
+					"172.18.0.1:55242",
+					"172.19.0.1:55242"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:58:28.496770895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         217457670716385,
+				"StableID":   "nGWKiAFVh211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:957a5f80c833af535aa064af40a10697079fd8e489063c4aa657f029f2b01001",
+				"DiscoKey":   "discokey:3e1cac42808059f5363cf3fb70fcd38dbacd1ed48fa8440d9e2c5e8dbd10355d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53237",
+					"10.65.0.27:53237",
+					"172.17.0.1:53237",
+					"172.18.0.1:53237",
+					"172.19.0.1:53237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:58:29.035135257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         646345387390297,
+				"StableID":   "ntzWa3Qj3611CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cf3eb894b4e76e54ba6d173285658f0041da75d5f083b1bee556717e54d00046",
+				"DiscoKey":   "discokey:6496dffafcf54f08b725e033b9386234ff01f0e578669c0006400517ed417306",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:55237",
+					"10.65.0.27:55237",
+					"172.17.0.1:55237",
+					"172.18.0.1:55237",
+					"172.19.0.1:55237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:58:29.578822538Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4650834079454209,
+				"StableID":   "nSfxZSXNKd11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:598bfb66ea80b91fcb784add5a6ef993a9230b23fa2e83bf60020a003e585a6b",
+				"DiscoKey":   "discokey:16e38a2a8eba52bfbdb69e7524655fd6d34d91e63810686bdddd1efa362f3655",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46114",
+					"10.65.0.27:46114",
+					"172.17.0.1:46114",
+					"172.18.0.1:46114",
+					"172.19.0.1:46114"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:58:30.119427275Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7124341447155548,
+				"StableID":   "nogPXQNddx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4af93a2a2d2cfd72b8427c87a62eb1136c19e00b082a482cb571eaff0b26677",
+				"DiscoKey":   "discokey:2c563596b817d09a1178bfeb778c2c46ea34daa313d9cd1b52fdcf9eff3ce156",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:51270",
+					"10.65.0.27:51270",
+					"172.17.0.1:51270",
+					"172.18.0.1:51270",
+					"172.19.0.1:51270"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:58:30.667369819Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3593552533063828,
+				"StableID":   "nwieopXX4V11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6bced23ed7fc8d3ae99281126cafa685a4eff4158509ee7b45215e1ebfca047a",
+				"DiscoKey":   "discokey:8188dfceb4caad20e4f80bc6e7be8a97b3550d9967252dc704115196f8f91729",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42074",
+					"10.65.0.27:42074",
+					"172.17.0.1:42074",
+					"172.18.0.1:42074",
+					"172.19.0.1:42074"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:58:31.233293039Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2631683467103926,
+				"StableID":   "nBsFD1stYM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e35b4c85927fd5c0d00fa1b68763701fd3a7ec6f345d8da3b412a3bdb73ce02b",
+				"DiscoKey":   "discokey:a59f687863d4b13b7323652ffb2aa9c2358e8bba297b3ebc431abf9ff4287527",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42155",
+					"10.65.0.27:42155",
+					"172.17.0.1:42155",
+					"172.18.0.1:42155",
+					"172.19.0.1:42155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:58:31.739754289Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6051058547127384,
+				"StableID":   "nK28wj3YFp11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a09208d509976f62bd09f9ef233504ebe8a8f1ff70c8d2925ed01eb862d9f0d",
+				"DiscoKey":   "discokey:a2e8406808cbb07dec1609f2a3a9763798e3496af74cf250c7593ac9bba83342",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54660",
+					"10.65.0.27:54660",
+					"172.17.0.1:54660",
+					"172.18.0.1:54660",
+					"172.19.0.1:54660"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:58:32.281645116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7628946014681444,
+				"StableID":   "nH1iDaUAa221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:072a3b14be7598b5879400be5bd6c1bbe09ff022bf8dbbaa4cf13d11ace0c454",
+				"KeyExpiry":  "2026-11-08T21:58:32Z",
+				"DiscoKey":   "discokey:9101ef5fe0de8cf89628cbaf7c4d82b08b0a85678528f829b45eec4faeb3b549",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44273",
+					"10.65.0.27:44273",
+					"172.17.0.1:44273",
+					"172.18.0.1:44273",
+					"172.19.0.1:44273"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:58:32.817902576Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1920759525508500,
+				"StableID":   "n1jMwY6vzF11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:6460aa7e4b52ac5118d804abab1c82aae16d452f5e3927f6daaa0a124eee9139",
+				"KeyExpiry":  "2026-11-08T21:58:33Z",
+				"DiscoKey":   "discokey:bc299dbce4c639d15aa4e02cf409b946d977e131126d40dd3531736fd46efe3a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42726",
+					"10.65.0.27:42726",
+					"172.17.0.1:42726",
+					"172.18.0.1:42726",
+					"172.19.0.1:42726"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:58:33.906179719Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3593552533063828,
+				"StableID":   "nwieopXX4V11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       3593552533063828,
+				"Key":        "nodekey:6bced23ed7fc8d3ae99281126cafa685a4eff4158509ee7b45215e1ebfca047a",
+				"DiscoKey":   "discokey:8188dfceb4caad20e4f80bc6e7be8a97b3550d9967252dc704115196f8f91729",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42074",
+					"10.65.0.27:42074",
+					"172.17.0.1:42074",
+					"172.18.0.1:42074",
+					"172.19.0.1:42074"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:58:31.233293039Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6bced23ed7fc8d3ae99281126cafa685a4eff4158509ee7b45215e1ebfca047a",
+			"MachineKey": "mkey:2d176ccc7934540d33aabf1283d6728f9822e9f4dd0d1107427f1d6fcb4d6346",
+			"Peers": [{
+				"ID":         534499573604818,
+				"StableID":   "nFDg14Q5B511CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a295bb9d66ad435c1c863d60ff2c0eaa7bec1f4303dc51d7c0a90b2660b0c37d",
+				"DiscoKey":   "discokey:2e5d8e7dd0b12d0b15e62451c2ae8c5e653af1079984154c9559ecdfa965c47f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44264",
+					"10.65.0.27:44264",
+					"172.17.0.1:44264",
+					"172.18.0.1:44264",
+					"172.19.0.1:44264"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:58:26.341904369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4275649627261847,
+				"StableID":   "nztdHo4TPa11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26496ff07821536cf8faa23b0fd643702aa59ea884a3c1234f7ec40eb9ca3e16",
+				"DiscoKey":   "discokey:904c409d93b40a05bfa2e2d3ffdc6010036cc5b0acfb95f35bbc1976613b4f76",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42615",
+					"10.65.0.27:42615",
+					"172.17.0.1:42615",
+					"172.18.0.1:42615",
+					"172.19.0.1:42615"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:58:26.930448146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1742476355781486,
+				"StableID":   "nyENj9uAcE11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fcdc746945849cc059b48882c7e421d5ba17242014b03121bf01b0de92a39028",
+				"DiscoKey":   "discokey:783a4300334e7f2d2d6b5f3bedf2aaaa085f3ec1cf7699484802486f52055754",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40969",
+					"10.65.0.27:40969",
+					"172.17.0.1:40969",
+					"172.18.0.1:40969",
+					"172.19.0.1:40969"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:58:27.423308868Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         975863935373222,
+				"StableID":   "nZWEHsHyc811CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1be5552a82ccc811e7f0e68adebee96005a93b10c92d2eb1990fdc31e5736a2d",
+				"DiscoKey":   "discokey:18554a005da60494ccfb50efd01867c6c6850d4d14a172b8663d8e6ab46de462",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34673",
+					"10.65.0.27:34673",
+					"172.17.0.1:34673",
+					"172.18.0.1:34673",
+					"172.19.0.1:34673"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:58:27.95517668Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5793056539786640,
+				"StableID":   "nBan2nmgEn11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1124cca0ea8b658e802f3a8c5461fdfc63a80a4319a4fa7b5a2c42b56210d02",
+				"DiscoKey":   "discokey:91144d49f8e60b955724fda6fa8e43f318a1728c3dae2b9ff1f0fb188f027c19",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55242",
+					"10.65.0.27:55242",
+					"172.17.0.1:55242",
+					"172.18.0.1:55242",
+					"172.19.0.1:55242"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:58:28.496770895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         217457670716385,
+				"StableID":   "nGWKiAFVh211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:957a5f80c833af535aa064af40a10697079fd8e489063c4aa657f029f2b01001",
+				"DiscoKey":   "discokey:3e1cac42808059f5363cf3fb70fcd38dbacd1ed48fa8440d9e2c5e8dbd10355d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53237",
+					"10.65.0.27:53237",
+					"172.17.0.1:53237",
+					"172.18.0.1:53237",
+					"172.19.0.1:53237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:58:29.035135257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         646345387390297,
+				"StableID":   "ntzWa3Qj3611CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cf3eb894b4e76e54ba6d173285658f0041da75d5f083b1bee556717e54d00046",
+				"DiscoKey":   "discokey:6496dffafcf54f08b725e033b9386234ff01f0e578669c0006400517ed417306",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:55237",
+					"10.65.0.27:55237",
+					"172.17.0.1:55237",
+					"172.18.0.1:55237",
+					"172.19.0.1:55237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:58:29.578822538Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4650834079454209,
+				"StableID":   "nSfxZSXNKd11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:598bfb66ea80b91fcb784add5a6ef993a9230b23fa2e83bf60020a003e585a6b",
+				"DiscoKey":   "discokey:16e38a2a8eba52bfbdb69e7524655fd6d34d91e63810686bdddd1efa362f3655",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46114",
+					"10.65.0.27:46114",
+					"172.17.0.1:46114",
+					"172.18.0.1:46114",
+					"172.19.0.1:46114"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:58:30.119427275Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7124341447155548,
+				"StableID":   "nogPXQNddx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4af93a2a2d2cfd72b8427c87a62eb1136c19e00b082a482cb571eaff0b26677",
+				"DiscoKey":   "discokey:2c563596b817d09a1178bfeb778c2c46ea34daa313d9cd1b52fdcf9eff3ce156",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:51270",
+					"10.65.0.27:51270",
+					"172.17.0.1:51270",
+					"172.18.0.1:51270",
+					"172.19.0.1:51270"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:58:30.667369819Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2631683467103926,
+				"StableID":   "nBsFD1stYM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e35b4c85927fd5c0d00fa1b68763701fd3a7ec6f345d8da3b412a3bdb73ce02b",
+				"DiscoKey":   "discokey:a59f687863d4b13b7323652ffb2aa9c2358e8bba297b3ebc431abf9ff4287527",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42155",
+					"10.65.0.27:42155",
+					"172.17.0.1:42155",
+					"172.18.0.1:42155",
+					"172.19.0.1:42155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:58:31.739754289Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6051058547127384,
+				"StableID":   "nK28wj3YFp11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a09208d509976f62bd09f9ef233504ebe8a8f1ff70c8d2925ed01eb862d9f0d",
+				"DiscoKey":   "discokey:a2e8406808cbb07dec1609f2a3a9763798e3496af74cf250c7593ac9bba83342",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54660",
+					"10.65.0.27:54660",
+					"172.17.0.1:54660",
+					"172.18.0.1:54660",
+					"172.19.0.1:54660"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:58:32.281645116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7628946014681444,
+				"StableID":   "nH1iDaUAa221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:072a3b14be7598b5879400be5bd6c1bbe09ff022bf8dbbaa4cf13d11ace0c454",
+				"KeyExpiry":  "2026-11-08T21:58:32Z",
+				"DiscoKey":   "discokey:9101ef5fe0de8cf89628cbaf7c4d82b08b0a85678528f829b45eec4faeb3b549",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44273",
+					"10.65.0.27:44273",
+					"172.17.0.1:44273",
+					"172.18.0.1:44273",
+					"172.19.0.1:44273"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:58:32.817902576Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8241289836823602,
+				"StableID":   "nZUiu8iVM721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:4f1fb67f448163694c66741a2f52d29197e41e64de9ff994b8140d4bf3f76972",
+				"KeyExpiry":  "2026-11-08T21:58:33Z",
+				"DiscoKey":   "discokey:0a0700b62f9a2957ef46da6d0457b1f44f509c5937fac31058ebba2203ba0542",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40365",
+					"10.65.0.27:40365",
+					"172.17.0.1:40365",
+					"172.18.0.1:40365",
+					"172.19.0.1:40365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:58:33.359731695Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1920759525508500,
+				"StableID":   "n1jMwY6vzF11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:6460aa7e4b52ac5118d804abab1c82aae16d452f5e3927f6daaa0a124eee9139",
+				"KeyExpiry":  "2026-11-08T21:58:33Z",
+				"DiscoKey":   "discokey:bc299dbce4c639d15aa4e02cf409b946d977e131126d40dd3531736fd46efe3a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42726",
+					"10.65.0.27:42726",
+					"172.17.0.1:42726",
+					"172.18.0.1:42726",
+					"172.19.0.1:42726"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:58:33.906179719Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3593552533063828": {
+				"ID":          3593552533063828,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-src-missing.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-src-missing.hujson
@@ -1,0 +1,20074 @@
+// ssh-malformed-src-missing
+//
+// ssh src field missing is rejected
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T21:59:19Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-malformed-src-missing",
+	"description":    "ssh src field missing is rejected",
+	"category":       "ssh",
+	"captured_at":    "2026-05-12T21:59:19.187639997Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                            \n  \n                              \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh src field missing is rejected\",\n\t\"id\":          \"ssh-malformed-src-missing\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-malformed/ssh-malformed-src-missing.hujson",
+		"full_policy": {
+			"ssh":       [{"action": "accept", "dst": ["tag:server"], "users": ["root"]}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2606182753054042,
+				"StableID":   "nVNAS61MMM11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       2606182753054042,
+				"Key":        "nodekey:ff596cd59fb6b1fa98779794e6c6e834c8272cd13cffb02a80bed7d64373ab74",
+				"DiscoKey":   "discokey:72680374963bf354d06a02ad61c0e42965811afdb2c4ad4f3a674dbf373ce656",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59717",
+					"10.65.0.27:59717",
+					"172.17.0.1:59717",
+					"172.18.0.1:59717",
+					"172.19.0.1:59717"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:59:27.727424123Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ff596cd59fb6b1fa98779794e6c6e834c8272cd13cffb02a80bed7d64373ab74",
+			"MachineKey": "mkey:8ca72bb5756b45d5edf3d516af20834a9a8ba0539b06f3f14a6f276a07ad536a",
+			"Peers": [{
+				"ID":         4648533956705237,
+				"StableID":   "n4Ueb47LJd11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8cb3d8c3b9293c8f0bd73c67b8726184c19458df3b2fdc33edb5077577c87622",
+				"DiscoKey":   "discokey:1bf163abc8780df0d419db8dda0555b59cf4136e2c68aaa43f67f6f809254e5d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:59:21.846381466Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5359923902283198,
+				"StableID":   "nFHm3W7Xri11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0eb399846842feba08a6dda5ef7823c4487aed4dec3981146440356a988e430e",
+				"DiscoKey":   "discokey:71f827bbb63799a7efa635a8bb1defe36d8900d8e7a056a23fd0047adafab015",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55472",
+					"10.65.0.27:55472",
+					"172.17.0.1:55472",
+					"172.18.0.1:55472",
+					"172.19.0.1:55472"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:59:22.314946214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8587449604754225,
+				"StableID":   "nN3VEtjG4A21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25edb65560500f9a321085b121d46217f6e9ddeb9429ba3d675e46045a231c1d",
+				"DiscoKey":   "discokey:f0aafb9e69cf1f960f842d5fc104c86a1741de8b47efa58446cec9d649958952",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:51524",
+					"10.65.0.27:51524",
+					"172.17.0.1:51524",
+					"172.18.0.1:51524",
+					"172.19.0.1:51524"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:59:22.859445975Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7054301687383426,
+				"StableID":   "nD2znWYu5x11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95162b4593257a4c6e52fbe325c21b885d66a349e5c882220a097746eac1ac3c",
+				"DiscoKey":   "discokey:0722dedae894cdd0b6a712bfa976f0374a5fa96f20f345043b01b65047390b2c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:38761",
+					"10.65.0.27:38761",
+					"172.17.0.1:38761",
+					"172.18.0.1:38761",
+					"172.19.0.1:38761"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:59:23.401290302Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7056318023574034,
+				"StableID":   "nfP1XXWp6x11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21d65cc737295e080917b370c87747a9d018793dd416b536303735dc6f306051",
+				"DiscoKey":   "discokey:baf488a348decab0c1cf35e99d67e78df9345e9e238344b3e7ad7a813a83e011",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55402",
+					"10.65.0.27:55402",
+					"172.17.0.1:55402",
+					"172.18.0.1:55402",
+					"172.19.0.1:55402"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:59:23.936360042Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         886059625337608,
+				"StableID":   "nj6WvTHJv711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:047e0d1e2e947680396856cdb4d1d42d2984a8ec4a3ae53698096fad0dbefe04",
+				"DiscoKey":   "discokey:6c613824f7a16c27a6a088ad485f264c9af37392a4c62cf9090f4e9f75b4e07d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:51015",
+					"10.65.0.27:51015",
+					"172.17.0.1:51015",
+					"172.18.0.1:51015",
+					"172.19.0.1:51015"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:59:24.47557207Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6776690889447541,
+				"StableID":   "n8eLDMBBvu11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cde65f65683b62c06fd7c41133e3d2fdb002585c7bb6d4431808efc8ceccd933",
+				"DiscoKey":   "discokey:212a083b5851e815ded1034f3adf6c15c42e3bfe070e3ee000e454b5f094be10",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44730",
+					"10.65.0.27:44730",
+					"172.17.0.1:44730",
+					"172.18.0.1:44730",
+					"172.19.0.1:44730"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:59:25.02163734Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1237801995050189,
+				"StableID":   "ntWdeexbfA11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2cc2be5e44a40f493cf2f1f4a6b3983a2c16f7b0c6da094b79c39259cb90a872",
+				"DiscoKey":   "discokey:a5323deaa3cd2cec986a93fa19e4216f984232d69d0bf43505b0eaefbf136d76",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:43968",
+					"10.65.0.27:43968",
+					"172.17.0.1:43968",
+					"172.18.0.1:43968",
+					"172.19.0.1:43968"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:59:25.56222905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8292164462702578,
+				"StableID":   "nswNPm6Yk721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5be9189cc1fc669fdd923c3809f3d7ed06c48f649f2a0dffd5a9f072dbf49774",
+				"DiscoKey":   "discokey:d0e5ff756f482a43a49d6bbcbd803d7b732c5259f3f6ad50522774067a713505",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39022",
+					"10.65.0.27:39022",
+					"172.17.0.1:39022",
+					"172.18.0.1:39022",
+					"172.19.0.1:39022"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:59:26.109968189Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3121204059158801,
+				"StableID":   "nrTWeojbNR11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a57fcdb6fc0010c0797c51f6d8dbb58617e7e552e5b9e44e517d1b2da313481f",
+				"DiscoKey":   "discokey:84844b9fabbc49b802200b3bd6396f24767e5de9b04b14de8fa1811f14fbcc48",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42110",
+					"10.65.0.27:42110",
+					"172.17.0.1:42110",
+					"172.18.0.1:42110",
+					"172.19.0.1:42110"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:59:26.63695447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7041872035295936,
+				"StableID":   "nBz41B3Hzw11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f3aa6f154dd174a9e95375e014cb5ae34a1eda4a4d93818577c20404f6fe8200",
+				"DiscoKey":   "discokey:bb45c9a0b35f544e9627e41667720fe061a1a8326cb6eef430ea35bff1bb8427",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:45876",
+					"10.65.0.27:45876",
+					"172.17.0.1:45876",
+					"172.18.0.1:45876",
+					"172.19.0.1:45876"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:59:27.187881267Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7118128324010790,
+				"StableID":   "n9iE7LApax11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d8f96255f0e57ad1c818138e1d6c6acdc96e81c4e5be3921d1ca870047b34618",
+				"KeyExpiry":  "2026-11-08T21:59:28Z",
+				"DiscoKey":   "discokey:36c73842d286fad939852b4e379a87d49b6691638ca9b040278973af32110505",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52202",
+					"10.65.0.27:52202",
+					"172.17.0.1:52202",
+					"172.18.0.1:52202",
+					"172.19.0.1:52202"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:59:28.273370464Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5763425023509787,
+				"StableID":   "nJzXQLQG1n11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e2b91e8e6d60df05220502fbca6bdd832322b8b02f47117c88f8bf888e3b3052",
+				"KeyExpiry":  "2026-11-08T21:59:29Z",
+				"DiscoKey":   "discokey:ae8912110c60f9b1b87fa8a8d5cc6bbb4f4771dd6e45b39b66628d06e332f728",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59660",
+					"10.65.0.27:59660",
+					"172.17.0.1:59660",
+					"172.18.0.1:59660",
+					"172.19.0.1:59660"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:59:29.426749979Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3537737218491365,
+				"StableID":   "ntgzakMFdU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9e761383a57041c54c943a8b783a54fb40009c60b12ad57823dc04d5f537aa14",
+				"KeyExpiry":  "2026-11-08T21:59:30Z",
+				"DiscoKey":   "discokey:47b127cbf2b1c8a3217450b7303f0202801b6c35c65a78beabbbe636acd73028",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45403",
+					"10.65.0.27:45403",
+					"172.17.0.1:45403",
+					"172.18.0.1:45403",
+					"172.19.0.1:45403"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:59:30.113651377Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2606182753054042": {
+				"ID":          2606182753054042,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         886059625337608,
+				"StableID":   "nj6WvTHJv711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       886059625337608,
+				"Key":        "nodekey:047e0d1e2e947680396856cdb4d1d42d2984a8ec4a3ae53698096fad0dbefe04",
+				"DiscoKey":   "discokey:6c613824f7a16c27a6a088ad485f264c9af37392a4c62cf9090f4e9f75b4e07d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:51015",
+					"10.65.0.27:51015",
+					"172.17.0.1:51015",
+					"172.18.0.1:51015",
+					"172.19.0.1:51015"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:59:24.47557207Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:047e0d1e2e947680396856cdb4d1d42d2984a8ec4a3ae53698096fad0dbefe04",
+			"MachineKey": "mkey:aa6ee996b9cdae1aa862eac83215612283cd343c579217189cac231b1d693859",
+			"Peers": [{
+				"ID":         4648533956705237,
+				"StableID":   "n4Ueb47LJd11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8cb3d8c3b9293c8f0bd73c67b8726184c19458df3b2fdc33edb5077577c87622",
+				"DiscoKey":   "discokey:1bf163abc8780df0d419db8dda0555b59cf4136e2c68aaa43f67f6f809254e5d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:59:21.846381466Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5359923902283198,
+				"StableID":   "nFHm3W7Xri11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0eb399846842feba08a6dda5ef7823c4487aed4dec3981146440356a988e430e",
+				"DiscoKey":   "discokey:71f827bbb63799a7efa635a8bb1defe36d8900d8e7a056a23fd0047adafab015",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55472",
+					"10.65.0.27:55472",
+					"172.17.0.1:55472",
+					"172.18.0.1:55472",
+					"172.19.0.1:55472"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:59:22.314946214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8587449604754225,
+				"StableID":   "nN3VEtjG4A21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25edb65560500f9a321085b121d46217f6e9ddeb9429ba3d675e46045a231c1d",
+				"DiscoKey":   "discokey:f0aafb9e69cf1f960f842d5fc104c86a1741de8b47efa58446cec9d649958952",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:51524",
+					"10.65.0.27:51524",
+					"172.17.0.1:51524",
+					"172.18.0.1:51524",
+					"172.19.0.1:51524"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:59:22.859445975Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7054301687383426,
+				"StableID":   "nD2znWYu5x11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95162b4593257a4c6e52fbe325c21b885d66a349e5c882220a097746eac1ac3c",
+				"DiscoKey":   "discokey:0722dedae894cdd0b6a712bfa976f0374a5fa96f20f345043b01b65047390b2c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:38761",
+					"10.65.0.27:38761",
+					"172.17.0.1:38761",
+					"172.18.0.1:38761",
+					"172.19.0.1:38761"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:59:23.401290302Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7056318023574034,
+				"StableID":   "nfP1XXWp6x11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21d65cc737295e080917b370c87747a9d018793dd416b536303735dc6f306051",
+				"DiscoKey":   "discokey:baf488a348decab0c1cf35e99d67e78df9345e9e238344b3e7ad7a813a83e011",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55402",
+					"10.65.0.27:55402",
+					"172.17.0.1:55402",
+					"172.18.0.1:55402",
+					"172.19.0.1:55402"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:59:23.936360042Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6776690889447541,
+				"StableID":   "n8eLDMBBvu11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cde65f65683b62c06fd7c41133e3d2fdb002585c7bb6d4431808efc8ceccd933",
+				"DiscoKey":   "discokey:212a083b5851e815ded1034f3adf6c15c42e3bfe070e3ee000e454b5f094be10",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44730",
+					"10.65.0.27:44730",
+					"172.17.0.1:44730",
+					"172.18.0.1:44730",
+					"172.19.0.1:44730"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:59:25.02163734Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1237801995050189,
+				"StableID":   "ntWdeexbfA11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2cc2be5e44a40f493cf2f1f4a6b3983a2c16f7b0c6da094b79c39259cb90a872",
+				"DiscoKey":   "discokey:a5323deaa3cd2cec986a93fa19e4216f984232d69d0bf43505b0eaefbf136d76",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:43968",
+					"10.65.0.27:43968",
+					"172.17.0.1:43968",
+					"172.18.0.1:43968",
+					"172.19.0.1:43968"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:59:25.56222905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8292164462702578,
+				"StableID":   "nswNPm6Yk721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5be9189cc1fc669fdd923c3809f3d7ed06c48f649f2a0dffd5a9f072dbf49774",
+				"DiscoKey":   "discokey:d0e5ff756f482a43a49d6bbcbd803d7b732c5259f3f6ad50522774067a713505",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39022",
+					"10.65.0.27:39022",
+					"172.17.0.1:39022",
+					"172.18.0.1:39022",
+					"172.19.0.1:39022"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:59:26.109968189Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3121204059158801,
+				"StableID":   "nrTWeojbNR11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a57fcdb6fc0010c0797c51f6d8dbb58617e7e552e5b9e44e517d1b2da313481f",
+				"DiscoKey":   "discokey:84844b9fabbc49b802200b3bd6396f24767e5de9b04b14de8fa1811f14fbcc48",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42110",
+					"10.65.0.27:42110",
+					"172.17.0.1:42110",
+					"172.18.0.1:42110",
+					"172.19.0.1:42110"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:59:26.63695447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7041872035295936,
+				"StableID":   "nBz41B3Hzw11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f3aa6f154dd174a9e95375e014cb5ae34a1eda4a4d93818577c20404f6fe8200",
+				"DiscoKey":   "discokey:bb45c9a0b35f544e9627e41667720fe061a1a8326cb6eef430ea35bff1bb8427",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:45876",
+					"10.65.0.27:45876",
+					"172.17.0.1:45876",
+					"172.18.0.1:45876",
+					"172.19.0.1:45876"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:59:27.187881267Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2606182753054042,
+				"StableID":   "nVNAS61MMM11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ff596cd59fb6b1fa98779794e6c6e834c8272cd13cffb02a80bed7d64373ab74",
+				"DiscoKey":   "discokey:72680374963bf354d06a02ad61c0e42965811afdb2c4ad4f3a674dbf373ce656",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59717",
+					"10.65.0.27:59717",
+					"172.17.0.1:59717",
+					"172.18.0.1:59717",
+					"172.19.0.1:59717"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:59:27.727424123Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7118128324010790,
+				"StableID":   "n9iE7LApax11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d8f96255f0e57ad1c818138e1d6c6acdc96e81c4e5be3921d1ca870047b34618",
+				"KeyExpiry":  "2026-11-08T21:59:28Z",
+				"DiscoKey":   "discokey:36c73842d286fad939852b4e379a87d49b6691638ca9b040278973af32110505",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52202",
+					"10.65.0.27:52202",
+					"172.17.0.1:52202",
+					"172.18.0.1:52202",
+					"172.19.0.1:52202"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:59:28.273370464Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5763425023509787,
+				"StableID":   "nJzXQLQG1n11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e2b91e8e6d60df05220502fbca6bdd832322b8b02f47117c88f8bf888e3b3052",
+				"KeyExpiry":  "2026-11-08T21:59:29Z",
+				"DiscoKey":   "discokey:ae8912110c60f9b1b87fa8a8d5cc6bbb4f4771dd6e45b39b66628d06e332f728",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59660",
+					"10.65.0.27:59660",
+					"172.17.0.1:59660",
+					"172.18.0.1:59660",
+					"172.19.0.1:59660"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:59:29.426749979Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3537737218491365,
+				"StableID":   "ntgzakMFdU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9e761383a57041c54c943a8b783a54fb40009c60b12ad57823dc04d5f537aa14",
+				"KeyExpiry":  "2026-11-08T21:59:30Z",
+				"DiscoKey":   "discokey:47b127cbf2b1c8a3217450b7303f0202801b6c35c65a78beabbbe636acd73028",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45403",
+					"10.65.0.27:45403",
+					"172.17.0.1:45403",
+					"172.18.0.1:45403",
+					"172.19.0.1:45403"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:59:30.113651377Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "886059625337608": {
+				"ID":          886059625337608,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3537737218491365,
+				"StableID":   "ntgzakMFdU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9e761383a57041c54c943a8b783a54fb40009c60b12ad57823dc04d5f537aa14",
+				"KeyExpiry":  "2026-11-08T21:59:30Z",
+				"DiscoKey":   "discokey:47b127cbf2b1c8a3217450b7303f0202801b6c35c65a78beabbbe636acd73028",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45403",
+					"10.65.0.27:45403",
+					"172.17.0.1:45403",
+					"172.18.0.1:45403",
+					"172.19.0.1:45403"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:59:30.113651377Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9e761383a57041c54c943a8b783a54fb40009c60b12ad57823dc04d5f537aa14",
+			"MachineKey": "mkey:25987ebea0087e24159c842b4dd999e1e4855e8486546856e772eecf1f2a4e56",
+			"Peers": [{
+				"ID":         4648533956705237,
+				"StableID":   "n4Ueb47LJd11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8cb3d8c3b9293c8f0bd73c67b8726184c19458df3b2fdc33edb5077577c87622",
+				"DiscoKey":   "discokey:1bf163abc8780df0d419db8dda0555b59cf4136e2c68aaa43f67f6f809254e5d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:59:21.846381466Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5359923902283198,
+				"StableID":   "nFHm3W7Xri11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0eb399846842feba08a6dda5ef7823c4487aed4dec3981146440356a988e430e",
+				"DiscoKey":   "discokey:71f827bbb63799a7efa635a8bb1defe36d8900d8e7a056a23fd0047adafab015",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55472",
+					"10.65.0.27:55472",
+					"172.17.0.1:55472",
+					"172.18.0.1:55472",
+					"172.19.0.1:55472"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:59:22.314946214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8587449604754225,
+				"StableID":   "nN3VEtjG4A21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25edb65560500f9a321085b121d46217f6e9ddeb9429ba3d675e46045a231c1d",
+				"DiscoKey":   "discokey:f0aafb9e69cf1f960f842d5fc104c86a1741de8b47efa58446cec9d649958952",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:51524",
+					"10.65.0.27:51524",
+					"172.17.0.1:51524",
+					"172.18.0.1:51524",
+					"172.19.0.1:51524"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:59:22.859445975Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7054301687383426,
+				"StableID":   "nD2znWYu5x11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95162b4593257a4c6e52fbe325c21b885d66a349e5c882220a097746eac1ac3c",
+				"DiscoKey":   "discokey:0722dedae894cdd0b6a712bfa976f0374a5fa96f20f345043b01b65047390b2c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:38761",
+					"10.65.0.27:38761",
+					"172.17.0.1:38761",
+					"172.18.0.1:38761",
+					"172.19.0.1:38761"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:59:23.401290302Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7056318023574034,
+				"StableID":   "nfP1XXWp6x11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21d65cc737295e080917b370c87747a9d018793dd416b536303735dc6f306051",
+				"DiscoKey":   "discokey:baf488a348decab0c1cf35e99d67e78df9345e9e238344b3e7ad7a813a83e011",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55402",
+					"10.65.0.27:55402",
+					"172.17.0.1:55402",
+					"172.18.0.1:55402",
+					"172.19.0.1:55402"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:59:23.936360042Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         886059625337608,
+				"StableID":   "nj6WvTHJv711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:047e0d1e2e947680396856cdb4d1d42d2984a8ec4a3ae53698096fad0dbefe04",
+				"DiscoKey":   "discokey:6c613824f7a16c27a6a088ad485f264c9af37392a4c62cf9090f4e9f75b4e07d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:51015",
+					"10.65.0.27:51015",
+					"172.17.0.1:51015",
+					"172.18.0.1:51015",
+					"172.19.0.1:51015"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:59:24.47557207Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6776690889447541,
+				"StableID":   "n8eLDMBBvu11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cde65f65683b62c06fd7c41133e3d2fdb002585c7bb6d4431808efc8ceccd933",
+				"DiscoKey":   "discokey:212a083b5851e815ded1034f3adf6c15c42e3bfe070e3ee000e454b5f094be10",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44730",
+					"10.65.0.27:44730",
+					"172.17.0.1:44730",
+					"172.18.0.1:44730",
+					"172.19.0.1:44730"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:59:25.02163734Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1237801995050189,
+				"StableID":   "ntWdeexbfA11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2cc2be5e44a40f493cf2f1f4a6b3983a2c16f7b0c6da094b79c39259cb90a872",
+				"DiscoKey":   "discokey:a5323deaa3cd2cec986a93fa19e4216f984232d69d0bf43505b0eaefbf136d76",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:43968",
+					"10.65.0.27:43968",
+					"172.17.0.1:43968",
+					"172.18.0.1:43968",
+					"172.19.0.1:43968"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:59:25.56222905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8292164462702578,
+				"StableID":   "nswNPm6Yk721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5be9189cc1fc669fdd923c3809f3d7ed06c48f649f2a0dffd5a9f072dbf49774",
+				"DiscoKey":   "discokey:d0e5ff756f482a43a49d6bbcbd803d7b732c5259f3f6ad50522774067a713505",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39022",
+					"10.65.0.27:39022",
+					"172.17.0.1:39022",
+					"172.18.0.1:39022",
+					"172.19.0.1:39022"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:59:26.109968189Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3121204059158801,
+				"StableID":   "nrTWeojbNR11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a57fcdb6fc0010c0797c51f6d8dbb58617e7e552e5b9e44e517d1b2da313481f",
+				"DiscoKey":   "discokey:84844b9fabbc49b802200b3bd6396f24767e5de9b04b14de8fa1811f14fbcc48",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42110",
+					"10.65.0.27:42110",
+					"172.17.0.1:42110",
+					"172.18.0.1:42110",
+					"172.19.0.1:42110"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:59:26.63695447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7041872035295936,
+				"StableID":   "nBz41B3Hzw11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f3aa6f154dd174a9e95375e014cb5ae34a1eda4a4d93818577c20404f6fe8200",
+				"DiscoKey":   "discokey:bb45c9a0b35f544e9627e41667720fe061a1a8326cb6eef430ea35bff1bb8427",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:45876",
+					"10.65.0.27:45876",
+					"172.17.0.1:45876",
+					"172.18.0.1:45876",
+					"172.19.0.1:45876"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:59:27.187881267Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2606182753054042,
+				"StableID":   "nVNAS61MMM11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ff596cd59fb6b1fa98779794e6c6e834c8272cd13cffb02a80bed7d64373ab74",
+				"DiscoKey":   "discokey:72680374963bf354d06a02ad61c0e42965811afdb2c4ad4f3a674dbf373ce656",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59717",
+					"10.65.0.27:59717",
+					"172.17.0.1:59717",
+					"172.18.0.1:59717",
+					"172.19.0.1:59717"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:59:27.727424123Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7118128324010790,
+				"StableID":   "n9iE7LApax11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d8f96255f0e57ad1c818138e1d6c6acdc96e81c4e5be3921d1ca870047b34618",
+				"KeyExpiry":  "2026-11-08T21:59:28Z",
+				"DiscoKey":   "discokey:36c73842d286fad939852b4e379a87d49b6691638ca9b040278973af32110505",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52202",
+					"10.65.0.27:52202",
+					"172.17.0.1:52202",
+					"172.18.0.1:52202",
+					"172.19.0.1:52202"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:59:28.273370464Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5763425023509787,
+				"StableID":   "nJzXQLQG1n11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e2b91e8e6d60df05220502fbca6bdd832322b8b02f47117c88f8bf888e3b3052",
+				"KeyExpiry":  "2026-11-08T21:59:29Z",
+				"DiscoKey":   "discokey:ae8912110c60f9b1b87fa8a8d5cc6bbb4f4771dd6e45b39b66628d06e332f728",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59660",
+					"10.65.0.27:59660",
+					"172.17.0.1:59660",
+					"172.18.0.1:59660",
+					"172.19.0.1:59660"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:59:29.426749979Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8587449604754225,
+				"StableID":   "nN3VEtjG4A21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       8587449604754225,
+				"Key":        "nodekey:25edb65560500f9a321085b121d46217f6e9ddeb9429ba3d675e46045a231c1d",
+				"DiscoKey":   "discokey:f0aafb9e69cf1f960f842d5fc104c86a1741de8b47efa58446cec9d649958952",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:51524",
+					"10.65.0.27:51524",
+					"172.17.0.1:51524",
+					"172.18.0.1:51524",
+					"172.19.0.1:51524"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:59:22.859445975Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:25edb65560500f9a321085b121d46217f6e9ddeb9429ba3d675e46045a231c1d",
+			"MachineKey": "mkey:f9a894d8bfb0e45dda1b6b4397a28e9f9d64c6d0403326ba9c34a73af137840d",
+			"Peers": [{
+				"ID":         4648533956705237,
+				"StableID":   "n4Ueb47LJd11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8cb3d8c3b9293c8f0bd73c67b8726184c19458df3b2fdc33edb5077577c87622",
+				"DiscoKey":   "discokey:1bf163abc8780df0d419db8dda0555b59cf4136e2c68aaa43f67f6f809254e5d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:59:21.846381466Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5359923902283198,
+				"StableID":   "nFHm3W7Xri11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0eb399846842feba08a6dda5ef7823c4487aed4dec3981146440356a988e430e",
+				"DiscoKey":   "discokey:71f827bbb63799a7efa635a8bb1defe36d8900d8e7a056a23fd0047adafab015",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55472",
+					"10.65.0.27:55472",
+					"172.17.0.1:55472",
+					"172.18.0.1:55472",
+					"172.19.0.1:55472"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:59:22.314946214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7054301687383426,
+				"StableID":   "nD2znWYu5x11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95162b4593257a4c6e52fbe325c21b885d66a349e5c882220a097746eac1ac3c",
+				"DiscoKey":   "discokey:0722dedae894cdd0b6a712bfa976f0374a5fa96f20f345043b01b65047390b2c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:38761",
+					"10.65.0.27:38761",
+					"172.17.0.1:38761",
+					"172.18.0.1:38761",
+					"172.19.0.1:38761"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:59:23.401290302Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7056318023574034,
+				"StableID":   "nfP1XXWp6x11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21d65cc737295e080917b370c87747a9d018793dd416b536303735dc6f306051",
+				"DiscoKey":   "discokey:baf488a348decab0c1cf35e99d67e78df9345e9e238344b3e7ad7a813a83e011",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55402",
+					"10.65.0.27:55402",
+					"172.17.0.1:55402",
+					"172.18.0.1:55402",
+					"172.19.0.1:55402"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:59:23.936360042Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         886059625337608,
+				"StableID":   "nj6WvTHJv711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:047e0d1e2e947680396856cdb4d1d42d2984a8ec4a3ae53698096fad0dbefe04",
+				"DiscoKey":   "discokey:6c613824f7a16c27a6a088ad485f264c9af37392a4c62cf9090f4e9f75b4e07d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:51015",
+					"10.65.0.27:51015",
+					"172.17.0.1:51015",
+					"172.18.0.1:51015",
+					"172.19.0.1:51015"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:59:24.47557207Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6776690889447541,
+				"StableID":   "n8eLDMBBvu11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cde65f65683b62c06fd7c41133e3d2fdb002585c7bb6d4431808efc8ceccd933",
+				"DiscoKey":   "discokey:212a083b5851e815ded1034f3adf6c15c42e3bfe070e3ee000e454b5f094be10",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44730",
+					"10.65.0.27:44730",
+					"172.17.0.1:44730",
+					"172.18.0.1:44730",
+					"172.19.0.1:44730"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:59:25.02163734Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1237801995050189,
+				"StableID":   "ntWdeexbfA11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2cc2be5e44a40f493cf2f1f4a6b3983a2c16f7b0c6da094b79c39259cb90a872",
+				"DiscoKey":   "discokey:a5323deaa3cd2cec986a93fa19e4216f984232d69d0bf43505b0eaefbf136d76",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:43968",
+					"10.65.0.27:43968",
+					"172.17.0.1:43968",
+					"172.18.0.1:43968",
+					"172.19.0.1:43968"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:59:25.56222905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8292164462702578,
+				"StableID":   "nswNPm6Yk721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5be9189cc1fc669fdd923c3809f3d7ed06c48f649f2a0dffd5a9f072dbf49774",
+				"DiscoKey":   "discokey:d0e5ff756f482a43a49d6bbcbd803d7b732c5259f3f6ad50522774067a713505",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39022",
+					"10.65.0.27:39022",
+					"172.17.0.1:39022",
+					"172.18.0.1:39022",
+					"172.19.0.1:39022"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:59:26.109968189Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3121204059158801,
+				"StableID":   "nrTWeojbNR11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a57fcdb6fc0010c0797c51f6d8dbb58617e7e552e5b9e44e517d1b2da313481f",
+				"DiscoKey":   "discokey:84844b9fabbc49b802200b3bd6396f24767e5de9b04b14de8fa1811f14fbcc48",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42110",
+					"10.65.0.27:42110",
+					"172.17.0.1:42110",
+					"172.18.0.1:42110",
+					"172.19.0.1:42110"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:59:26.63695447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7041872035295936,
+				"StableID":   "nBz41B3Hzw11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f3aa6f154dd174a9e95375e014cb5ae34a1eda4a4d93818577c20404f6fe8200",
+				"DiscoKey":   "discokey:bb45c9a0b35f544e9627e41667720fe061a1a8326cb6eef430ea35bff1bb8427",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:45876",
+					"10.65.0.27:45876",
+					"172.17.0.1:45876",
+					"172.18.0.1:45876",
+					"172.19.0.1:45876"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:59:27.187881267Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2606182753054042,
+				"StableID":   "nVNAS61MMM11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ff596cd59fb6b1fa98779794e6c6e834c8272cd13cffb02a80bed7d64373ab74",
+				"DiscoKey":   "discokey:72680374963bf354d06a02ad61c0e42965811afdb2c4ad4f3a674dbf373ce656",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59717",
+					"10.65.0.27:59717",
+					"172.17.0.1:59717",
+					"172.18.0.1:59717",
+					"172.19.0.1:59717"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:59:27.727424123Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7118128324010790,
+				"StableID":   "n9iE7LApax11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d8f96255f0e57ad1c818138e1d6c6acdc96e81c4e5be3921d1ca870047b34618",
+				"KeyExpiry":  "2026-11-08T21:59:28Z",
+				"DiscoKey":   "discokey:36c73842d286fad939852b4e379a87d49b6691638ca9b040278973af32110505",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52202",
+					"10.65.0.27:52202",
+					"172.17.0.1:52202",
+					"172.18.0.1:52202",
+					"172.19.0.1:52202"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:59:28.273370464Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5763425023509787,
+				"StableID":   "nJzXQLQG1n11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e2b91e8e6d60df05220502fbca6bdd832322b8b02f47117c88f8bf888e3b3052",
+				"KeyExpiry":  "2026-11-08T21:59:29Z",
+				"DiscoKey":   "discokey:ae8912110c60f9b1b87fa8a8d5cc6bbb4f4771dd6e45b39b66628d06e332f728",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59660",
+					"10.65.0.27:59660",
+					"172.17.0.1:59660",
+					"172.18.0.1:59660",
+					"172.19.0.1:59660"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:59:29.426749979Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3537737218491365,
+				"StableID":   "ntgzakMFdU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9e761383a57041c54c943a8b783a54fb40009c60b12ad57823dc04d5f537aa14",
+				"KeyExpiry":  "2026-11-08T21:59:30Z",
+				"DiscoKey":   "discokey:47b127cbf2b1c8a3217450b7303f0202801b6c35c65a78beabbbe636acd73028",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45403",
+					"10.65.0.27:45403",
+					"172.17.0.1:45403",
+					"172.18.0.1:45403",
+					"172.19.0.1:45403"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:59:30.113651377Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8587449604754225": {
+				"ID":          8587449604754225,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1237801995050189,
+				"StableID":   "ntWdeexbfA11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1237801995050189,
+				"Key":        "nodekey:2cc2be5e44a40f493cf2f1f4a6b3983a2c16f7b0c6da094b79c39259cb90a872",
+				"DiscoKey":   "discokey:a5323deaa3cd2cec986a93fa19e4216f984232d69d0bf43505b0eaefbf136d76",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:43968",
+					"10.65.0.27:43968",
+					"172.17.0.1:43968",
+					"172.18.0.1:43968",
+					"172.19.0.1:43968"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:59:25.56222905Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2cc2be5e44a40f493cf2f1f4a6b3983a2c16f7b0c6da094b79c39259cb90a872",
+			"MachineKey": "mkey:979f4cef3e1fe1f0d6b771f473703e6e4d1c280563ec93d1a097f8849fe39203",
+			"Peers": [{
+				"ID":         4648533956705237,
+				"StableID":   "n4Ueb47LJd11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8cb3d8c3b9293c8f0bd73c67b8726184c19458df3b2fdc33edb5077577c87622",
+				"DiscoKey":   "discokey:1bf163abc8780df0d419db8dda0555b59cf4136e2c68aaa43f67f6f809254e5d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:59:21.846381466Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5359923902283198,
+				"StableID":   "nFHm3W7Xri11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0eb399846842feba08a6dda5ef7823c4487aed4dec3981146440356a988e430e",
+				"DiscoKey":   "discokey:71f827bbb63799a7efa635a8bb1defe36d8900d8e7a056a23fd0047adafab015",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55472",
+					"10.65.0.27:55472",
+					"172.17.0.1:55472",
+					"172.18.0.1:55472",
+					"172.19.0.1:55472"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:59:22.314946214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8587449604754225,
+				"StableID":   "nN3VEtjG4A21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25edb65560500f9a321085b121d46217f6e9ddeb9429ba3d675e46045a231c1d",
+				"DiscoKey":   "discokey:f0aafb9e69cf1f960f842d5fc104c86a1741de8b47efa58446cec9d649958952",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:51524",
+					"10.65.0.27:51524",
+					"172.17.0.1:51524",
+					"172.18.0.1:51524",
+					"172.19.0.1:51524"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:59:22.859445975Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7054301687383426,
+				"StableID":   "nD2znWYu5x11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95162b4593257a4c6e52fbe325c21b885d66a349e5c882220a097746eac1ac3c",
+				"DiscoKey":   "discokey:0722dedae894cdd0b6a712bfa976f0374a5fa96f20f345043b01b65047390b2c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:38761",
+					"10.65.0.27:38761",
+					"172.17.0.1:38761",
+					"172.18.0.1:38761",
+					"172.19.0.1:38761"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:59:23.401290302Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7056318023574034,
+				"StableID":   "nfP1XXWp6x11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21d65cc737295e080917b370c87747a9d018793dd416b536303735dc6f306051",
+				"DiscoKey":   "discokey:baf488a348decab0c1cf35e99d67e78df9345e9e238344b3e7ad7a813a83e011",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55402",
+					"10.65.0.27:55402",
+					"172.17.0.1:55402",
+					"172.18.0.1:55402",
+					"172.19.0.1:55402"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:59:23.936360042Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         886059625337608,
+				"StableID":   "nj6WvTHJv711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:047e0d1e2e947680396856cdb4d1d42d2984a8ec4a3ae53698096fad0dbefe04",
+				"DiscoKey":   "discokey:6c613824f7a16c27a6a088ad485f264c9af37392a4c62cf9090f4e9f75b4e07d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:51015",
+					"10.65.0.27:51015",
+					"172.17.0.1:51015",
+					"172.18.0.1:51015",
+					"172.19.0.1:51015"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:59:24.47557207Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6776690889447541,
+				"StableID":   "n8eLDMBBvu11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cde65f65683b62c06fd7c41133e3d2fdb002585c7bb6d4431808efc8ceccd933",
+				"DiscoKey":   "discokey:212a083b5851e815ded1034f3adf6c15c42e3bfe070e3ee000e454b5f094be10",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44730",
+					"10.65.0.27:44730",
+					"172.17.0.1:44730",
+					"172.18.0.1:44730",
+					"172.19.0.1:44730"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:59:25.02163734Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8292164462702578,
+				"StableID":   "nswNPm6Yk721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5be9189cc1fc669fdd923c3809f3d7ed06c48f649f2a0dffd5a9f072dbf49774",
+				"DiscoKey":   "discokey:d0e5ff756f482a43a49d6bbcbd803d7b732c5259f3f6ad50522774067a713505",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39022",
+					"10.65.0.27:39022",
+					"172.17.0.1:39022",
+					"172.18.0.1:39022",
+					"172.19.0.1:39022"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:59:26.109968189Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3121204059158801,
+				"StableID":   "nrTWeojbNR11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a57fcdb6fc0010c0797c51f6d8dbb58617e7e552e5b9e44e517d1b2da313481f",
+				"DiscoKey":   "discokey:84844b9fabbc49b802200b3bd6396f24767e5de9b04b14de8fa1811f14fbcc48",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42110",
+					"10.65.0.27:42110",
+					"172.17.0.1:42110",
+					"172.18.0.1:42110",
+					"172.19.0.1:42110"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:59:26.63695447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7041872035295936,
+				"StableID":   "nBz41B3Hzw11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f3aa6f154dd174a9e95375e014cb5ae34a1eda4a4d93818577c20404f6fe8200",
+				"DiscoKey":   "discokey:bb45c9a0b35f544e9627e41667720fe061a1a8326cb6eef430ea35bff1bb8427",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:45876",
+					"10.65.0.27:45876",
+					"172.17.0.1:45876",
+					"172.18.0.1:45876",
+					"172.19.0.1:45876"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:59:27.187881267Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2606182753054042,
+				"StableID":   "nVNAS61MMM11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ff596cd59fb6b1fa98779794e6c6e834c8272cd13cffb02a80bed7d64373ab74",
+				"DiscoKey":   "discokey:72680374963bf354d06a02ad61c0e42965811afdb2c4ad4f3a674dbf373ce656",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59717",
+					"10.65.0.27:59717",
+					"172.17.0.1:59717",
+					"172.18.0.1:59717",
+					"172.19.0.1:59717"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:59:27.727424123Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7118128324010790,
+				"StableID":   "n9iE7LApax11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d8f96255f0e57ad1c818138e1d6c6acdc96e81c4e5be3921d1ca870047b34618",
+				"KeyExpiry":  "2026-11-08T21:59:28Z",
+				"DiscoKey":   "discokey:36c73842d286fad939852b4e379a87d49b6691638ca9b040278973af32110505",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52202",
+					"10.65.0.27:52202",
+					"172.17.0.1:52202",
+					"172.18.0.1:52202",
+					"172.19.0.1:52202"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:59:28.273370464Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5763425023509787,
+				"StableID":   "nJzXQLQG1n11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e2b91e8e6d60df05220502fbca6bdd832322b8b02f47117c88f8bf888e3b3052",
+				"KeyExpiry":  "2026-11-08T21:59:29Z",
+				"DiscoKey":   "discokey:ae8912110c60f9b1b87fa8a8d5cc6bbb4f4771dd6e45b39b66628d06e332f728",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59660",
+					"10.65.0.27:59660",
+					"172.17.0.1:59660",
+					"172.18.0.1:59660",
+					"172.19.0.1:59660"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:59:29.426749979Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3537737218491365,
+				"StableID":   "ntgzakMFdU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9e761383a57041c54c943a8b783a54fb40009c60b12ad57823dc04d5f537aa14",
+				"KeyExpiry":  "2026-11-08T21:59:30Z",
+				"DiscoKey":   "discokey:47b127cbf2b1c8a3217450b7303f0202801b6c35c65a78beabbbe636acd73028",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45403",
+					"10.65.0.27:45403",
+					"172.17.0.1:45403",
+					"172.18.0.1:45403",
+					"172.19.0.1:45403"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:59:30.113651377Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1237801995050189": {
+				"ID":          1237801995050189,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7118128324010790,
+				"StableID":   "n9iE7LApax11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d8f96255f0e57ad1c818138e1d6c6acdc96e81c4e5be3921d1ca870047b34618",
+				"KeyExpiry":  "2026-11-08T21:59:28Z",
+				"DiscoKey":   "discokey:36c73842d286fad939852b4e379a87d49b6691638ca9b040278973af32110505",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52202",
+					"10.65.0.27:52202",
+					"172.17.0.1:52202",
+					"172.18.0.1:52202",
+					"172.19.0.1:52202"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:59:28.273370464Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d8f96255f0e57ad1c818138e1d6c6acdc96e81c4e5be3921d1ca870047b34618",
+			"MachineKey": "mkey:690b44ce9d22b077ef3b09c7633657e95eabc69b639d682c2a656288b2a78e2f",
+			"Peers": [{
+				"ID":         4648533956705237,
+				"StableID":   "n4Ueb47LJd11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8cb3d8c3b9293c8f0bd73c67b8726184c19458df3b2fdc33edb5077577c87622",
+				"DiscoKey":   "discokey:1bf163abc8780df0d419db8dda0555b59cf4136e2c68aaa43f67f6f809254e5d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:59:21.846381466Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5359923902283198,
+				"StableID":   "nFHm3W7Xri11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0eb399846842feba08a6dda5ef7823c4487aed4dec3981146440356a988e430e",
+				"DiscoKey":   "discokey:71f827bbb63799a7efa635a8bb1defe36d8900d8e7a056a23fd0047adafab015",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55472",
+					"10.65.0.27:55472",
+					"172.17.0.1:55472",
+					"172.18.0.1:55472",
+					"172.19.0.1:55472"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:59:22.314946214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8587449604754225,
+				"StableID":   "nN3VEtjG4A21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25edb65560500f9a321085b121d46217f6e9ddeb9429ba3d675e46045a231c1d",
+				"DiscoKey":   "discokey:f0aafb9e69cf1f960f842d5fc104c86a1741de8b47efa58446cec9d649958952",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:51524",
+					"10.65.0.27:51524",
+					"172.17.0.1:51524",
+					"172.18.0.1:51524",
+					"172.19.0.1:51524"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:59:22.859445975Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7054301687383426,
+				"StableID":   "nD2znWYu5x11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95162b4593257a4c6e52fbe325c21b885d66a349e5c882220a097746eac1ac3c",
+				"DiscoKey":   "discokey:0722dedae894cdd0b6a712bfa976f0374a5fa96f20f345043b01b65047390b2c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:38761",
+					"10.65.0.27:38761",
+					"172.17.0.1:38761",
+					"172.18.0.1:38761",
+					"172.19.0.1:38761"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:59:23.401290302Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7056318023574034,
+				"StableID":   "nfP1XXWp6x11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21d65cc737295e080917b370c87747a9d018793dd416b536303735dc6f306051",
+				"DiscoKey":   "discokey:baf488a348decab0c1cf35e99d67e78df9345e9e238344b3e7ad7a813a83e011",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55402",
+					"10.65.0.27:55402",
+					"172.17.0.1:55402",
+					"172.18.0.1:55402",
+					"172.19.0.1:55402"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:59:23.936360042Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         886059625337608,
+				"StableID":   "nj6WvTHJv711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:047e0d1e2e947680396856cdb4d1d42d2984a8ec4a3ae53698096fad0dbefe04",
+				"DiscoKey":   "discokey:6c613824f7a16c27a6a088ad485f264c9af37392a4c62cf9090f4e9f75b4e07d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:51015",
+					"10.65.0.27:51015",
+					"172.17.0.1:51015",
+					"172.18.0.1:51015",
+					"172.19.0.1:51015"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:59:24.47557207Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6776690889447541,
+				"StableID":   "n8eLDMBBvu11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cde65f65683b62c06fd7c41133e3d2fdb002585c7bb6d4431808efc8ceccd933",
+				"DiscoKey":   "discokey:212a083b5851e815ded1034f3adf6c15c42e3bfe070e3ee000e454b5f094be10",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44730",
+					"10.65.0.27:44730",
+					"172.17.0.1:44730",
+					"172.18.0.1:44730",
+					"172.19.0.1:44730"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:59:25.02163734Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1237801995050189,
+				"StableID":   "ntWdeexbfA11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2cc2be5e44a40f493cf2f1f4a6b3983a2c16f7b0c6da094b79c39259cb90a872",
+				"DiscoKey":   "discokey:a5323deaa3cd2cec986a93fa19e4216f984232d69d0bf43505b0eaefbf136d76",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:43968",
+					"10.65.0.27:43968",
+					"172.17.0.1:43968",
+					"172.18.0.1:43968",
+					"172.19.0.1:43968"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:59:25.56222905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8292164462702578,
+				"StableID":   "nswNPm6Yk721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5be9189cc1fc669fdd923c3809f3d7ed06c48f649f2a0dffd5a9f072dbf49774",
+				"DiscoKey":   "discokey:d0e5ff756f482a43a49d6bbcbd803d7b732c5259f3f6ad50522774067a713505",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39022",
+					"10.65.0.27:39022",
+					"172.17.0.1:39022",
+					"172.18.0.1:39022",
+					"172.19.0.1:39022"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:59:26.109968189Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3121204059158801,
+				"StableID":   "nrTWeojbNR11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a57fcdb6fc0010c0797c51f6d8dbb58617e7e552e5b9e44e517d1b2da313481f",
+				"DiscoKey":   "discokey:84844b9fabbc49b802200b3bd6396f24767e5de9b04b14de8fa1811f14fbcc48",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42110",
+					"10.65.0.27:42110",
+					"172.17.0.1:42110",
+					"172.18.0.1:42110",
+					"172.19.0.1:42110"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:59:26.63695447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7041872035295936,
+				"StableID":   "nBz41B3Hzw11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f3aa6f154dd174a9e95375e014cb5ae34a1eda4a4d93818577c20404f6fe8200",
+				"DiscoKey":   "discokey:bb45c9a0b35f544e9627e41667720fe061a1a8326cb6eef430ea35bff1bb8427",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:45876",
+					"10.65.0.27:45876",
+					"172.17.0.1:45876",
+					"172.18.0.1:45876",
+					"172.19.0.1:45876"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:59:27.187881267Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2606182753054042,
+				"StableID":   "nVNAS61MMM11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ff596cd59fb6b1fa98779794e6c6e834c8272cd13cffb02a80bed7d64373ab74",
+				"DiscoKey":   "discokey:72680374963bf354d06a02ad61c0e42965811afdb2c4ad4f3a674dbf373ce656",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59717",
+					"10.65.0.27:59717",
+					"172.17.0.1:59717",
+					"172.18.0.1:59717",
+					"172.19.0.1:59717"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:59:27.727424123Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5763425023509787,
+				"StableID":   "nJzXQLQG1n11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e2b91e8e6d60df05220502fbca6bdd832322b8b02f47117c88f8bf888e3b3052",
+				"KeyExpiry":  "2026-11-08T21:59:29Z",
+				"DiscoKey":   "discokey:ae8912110c60f9b1b87fa8a8d5cc6bbb4f4771dd6e45b39b66628d06e332f728",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59660",
+					"10.65.0.27:59660",
+					"172.17.0.1:59660",
+					"172.18.0.1:59660",
+					"172.19.0.1:59660"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:59:29.426749979Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3537737218491365,
+				"StableID":   "ntgzakMFdU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9e761383a57041c54c943a8b783a54fb40009c60b12ad57823dc04d5f537aa14",
+				"KeyExpiry":  "2026-11-08T21:59:30Z",
+				"DiscoKey":   "discokey:47b127cbf2b1c8a3217450b7303f0202801b6c35c65a78beabbbe636acd73028",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45403",
+					"10.65.0.27:45403",
+					"172.17.0.1:45403",
+					"172.18.0.1:45403",
+					"172.19.0.1:45403"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:59:30.113651377Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7041872035295936,
+				"StableID":   "nBz41B3Hzw11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       7041872035295936,
+				"Key":        "nodekey:f3aa6f154dd174a9e95375e014cb5ae34a1eda4a4d93818577c20404f6fe8200",
+				"DiscoKey":   "discokey:bb45c9a0b35f544e9627e41667720fe061a1a8326cb6eef430ea35bff1bb8427",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:45876",
+					"10.65.0.27:45876",
+					"172.17.0.1:45876",
+					"172.18.0.1:45876",
+					"172.19.0.1:45876"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:59:27.187881267Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f3aa6f154dd174a9e95375e014cb5ae34a1eda4a4d93818577c20404f6fe8200",
+			"MachineKey": "mkey:a46a62066c92602cfee31dd6fad0636facdff52dab16dba6bb33f04441968f30",
+			"Peers": [{
+				"ID":         4648533956705237,
+				"StableID":   "n4Ueb47LJd11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8cb3d8c3b9293c8f0bd73c67b8726184c19458df3b2fdc33edb5077577c87622",
+				"DiscoKey":   "discokey:1bf163abc8780df0d419db8dda0555b59cf4136e2c68aaa43f67f6f809254e5d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:59:21.846381466Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5359923902283198,
+				"StableID":   "nFHm3W7Xri11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0eb399846842feba08a6dda5ef7823c4487aed4dec3981146440356a988e430e",
+				"DiscoKey":   "discokey:71f827bbb63799a7efa635a8bb1defe36d8900d8e7a056a23fd0047adafab015",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55472",
+					"10.65.0.27:55472",
+					"172.17.0.1:55472",
+					"172.18.0.1:55472",
+					"172.19.0.1:55472"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:59:22.314946214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8587449604754225,
+				"StableID":   "nN3VEtjG4A21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25edb65560500f9a321085b121d46217f6e9ddeb9429ba3d675e46045a231c1d",
+				"DiscoKey":   "discokey:f0aafb9e69cf1f960f842d5fc104c86a1741de8b47efa58446cec9d649958952",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:51524",
+					"10.65.0.27:51524",
+					"172.17.0.1:51524",
+					"172.18.0.1:51524",
+					"172.19.0.1:51524"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:59:22.859445975Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7054301687383426,
+				"StableID":   "nD2znWYu5x11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95162b4593257a4c6e52fbe325c21b885d66a349e5c882220a097746eac1ac3c",
+				"DiscoKey":   "discokey:0722dedae894cdd0b6a712bfa976f0374a5fa96f20f345043b01b65047390b2c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:38761",
+					"10.65.0.27:38761",
+					"172.17.0.1:38761",
+					"172.18.0.1:38761",
+					"172.19.0.1:38761"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:59:23.401290302Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7056318023574034,
+				"StableID":   "nfP1XXWp6x11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21d65cc737295e080917b370c87747a9d018793dd416b536303735dc6f306051",
+				"DiscoKey":   "discokey:baf488a348decab0c1cf35e99d67e78df9345e9e238344b3e7ad7a813a83e011",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55402",
+					"10.65.0.27:55402",
+					"172.17.0.1:55402",
+					"172.18.0.1:55402",
+					"172.19.0.1:55402"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:59:23.936360042Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         886059625337608,
+				"StableID":   "nj6WvTHJv711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:047e0d1e2e947680396856cdb4d1d42d2984a8ec4a3ae53698096fad0dbefe04",
+				"DiscoKey":   "discokey:6c613824f7a16c27a6a088ad485f264c9af37392a4c62cf9090f4e9f75b4e07d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:51015",
+					"10.65.0.27:51015",
+					"172.17.0.1:51015",
+					"172.18.0.1:51015",
+					"172.19.0.1:51015"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:59:24.47557207Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6776690889447541,
+				"StableID":   "n8eLDMBBvu11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cde65f65683b62c06fd7c41133e3d2fdb002585c7bb6d4431808efc8ceccd933",
+				"DiscoKey":   "discokey:212a083b5851e815ded1034f3adf6c15c42e3bfe070e3ee000e454b5f094be10",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44730",
+					"10.65.0.27:44730",
+					"172.17.0.1:44730",
+					"172.18.0.1:44730",
+					"172.19.0.1:44730"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:59:25.02163734Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1237801995050189,
+				"StableID":   "ntWdeexbfA11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2cc2be5e44a40f493cf2f1f4a6b3983a2c16f7b0c6da094b79c39259cb90a872",
+				"DiscoKey":   "discokey:a5323deaa3cd2cec986a93fa19e4216f984232d69d0bf43505b0eaefbf136d76",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:43968",
+					"10.65.0.27:43968",
+					"172.17.0.1:43968",
+					"172.18.0.1:43968",
+					"172.19.0.1:43968"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:59:25.56222905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8292164462702578,
+				"StableID":   "nswNPm6Yk721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5be9189cc1fc669fdd923c3809f3d7ed06c48f649f2a0dffd5a9f072dbf49774",
+				"DiscoKey":   "discokey:d0e5ff756f482a43a49d6bbcbd803d7b732c5259f3f6ad50522774067a713505",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39022",
+					"10.65.0.27:39022",
+					"172.17.0.1:39022",
+					"172.18.0.1:39022",
+					"172.19.0.1:39022"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:59:26.109968189Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3121204059158801,
+				"StableID":   "nrTWeojbNR11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a57fcdb6fc0010c0797c51f6d8dbb58617e7e552e5b9e44e517d1b2da313481f",
+				"DiscoKey":   "discokey:84844b9fabbc49b802200b3bd6396f24767e5de9b04b14de8fa1811f14fbcc48",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42110",
+					"10.65.0.27:42110",
+					"172.17.0.1:42110",
+					"172.18.0.1:42110",
+					"172.19.0.1:42110"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:59:26.63695447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2606182753054042,
+				"StableID":   "nVNAS61MMM11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ff596cd59fb6b1fa98779794e6c6e834c8272cd13cffb02a80bed7d64373ab74",
+				"DiscoKey":   "discokey:72680374963bf354d06a02ad61c0e42965811afdb2c4ad4f3a674dbf373ce656",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59717",
+					"10.65.0.27:59717",
+					"172.17.0.1:59717",
+					"172.18.0.1:59717",
+					"172.19.0.1:59717"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:59:27.727424123Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7118128324010790,
+				"StableID":   "n9iE7LApax11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d8f96255f0e57ad1c818138e1d6c6acdc96e81c4e5be3921d1ca870047b34618",
+				"KeyExpiry":  "2026-11-08T21:59:28Z",
+				"DiscoKey":   "discokey:36c73842d286fad939852b4e379a87d49b6691638ca9b040278973af32110505",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52202",
+					"10.65.0.27:52202",
+					"172.17.0.1:52202",
+					"172.18.0.1:52202",
+					"172.19.0.1:52202"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:59:28.273370464Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5763425023509787,
+				"StableID":   "nJzXQLQG1n11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e2b91e8e6d60df05220502fbca6bdd832322b8b02f47117c88f8bf888e3b3052",
+				"KeyExpiry":  "2026-11-08T21:59:29Z",
+				"DiscoKey":   "discokey:ae8912110c60f9b1b87fa8a8d5cc6bbb4f4771dd6e45b39b66628d06e332f728",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59660",
+					"10.65.0.27:59660",
+					"172.17.0.1:59660",
+					"172.18.0.1:59660",
+					"172.19.0.1:59660"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:59:29.426749979Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3537737218491365,
+				"StableID":   "ntgzakMFdU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9e761383a57041c54c943a8b783a54fb40009c60b12ad57823dc04d5f537aa14",
+				"KeyExpiry":  "2026-11-08T21:59:30Z",
+				"DiscoKey":   "discokey:47b127cbf2b1c8a3217450b7303f0202801b6c35c65a78beabbbe636acd73028",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45403",
+					"10.65.0.27:45403",
+					"172.17.0.1:45403",
+					"172.18.0.1:45403",
+					"172.19.0.1:45403"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:59:30.113651377Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7041872035295936": {
+				"ID":          7041872035295936,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5359923902283198,
+				"StableID":   "nFHm3W7Xri11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       5359923902283198,
+				"Key":        "nodekey:0eb399846842feba08a6dda5ef7823c4487aed4dec3981146440356a988e430e",
+				"DiscoKey":   "discokey:71f827bbb63799a7efa635a8bb1defe36d8900d8e7a056a23fd0047adafab015",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55472",
+					"10.65.0.27:55472",
+					"172.17.0.1:55472",
+					"172.18.0.1:55472",
+					"172.19.0.1:55472"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:59:22.314946214Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0eb399846842feba08a6dda5ef7823c4487aed4dec3981146440356a988e430e",
+			"MachineKey": "mkey:df2b67cfef4b9f8ae1f89da594bf803ef81bef8d11b2dfc843e99b93f7270b06",
+			"Peers": [{
+				"ID":         4648533956705237,
+				"StableID":   "n4Ueb47LJd11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8cb3d8c3b9293c8f0bd73c67b8726184c19458df3b2fdc33edb5077577c87622",
+				"DiscoKey":   "discokey:1bf163abc8780df0d419db8dda0555b59cf4136e2c68aaa43f67f6f809254e5d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:59:21.846381466Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8587449604754225,
+				"StableID":   "nN3VEtjG4A21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25edb65560500f9a321085b121d46217f6e9ddeb9429ba3d675e46045a231c1d",
+				"DiscoKey":   "discokey:f0aafb9e69cf1f960f842d5fc104c86a1741de8b47efa58446cec9d649958952",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:51524",
+					"10.65.0.27:51524",
+					"172.17.0.1:51524",
+					"172.18.0.1:51524",
+					"172.19.0.1:51524"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:59:22.859445975Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7054301687383426,
+				"StableID":   "nD2znWYu5x11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95162b4593257a4c6e52fbe325c21b885d66a349e5c882220a097746eac1ac3c",
+				"DiscoKey":   "discokey:0722dedae894cdd0b6a712bfa976f0374a5fa96f20f345043b01b65047390b2c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:38761",
+					"10.65.0.27:38761",
+					"172.17.0.1:38761",
+					"172.18.0.1:38761",
+					"172.19.0.1:38761"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:59:23.401290302Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7056318023574034,
+				"StableID":   "nfP1XXWp6x11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21d65cc737295e080917b370c87747a9d018793dd416b536303735dc6f306051",
+				"DiscoKey":   "discokey:baf488a348decab0c1cf35e99d67e78df9345e9e238344b3e7ad7a813a83e011",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55402",
+					"10.65.0.27:55402",
+					"172.17.0.1:55402",
+					"172.18.0.1:55402",
+					"172.19.0.1:55402"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:59:23.936360042Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         886059625337608,
+				"StableID":   "nj6WvTHJv711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:047e0d1e2e947680396856cdb4d1d42d2984a8ec4a3ae53698096fad0dbefe04",
+				"DiscoKey":   "discokey:6c613824f7a16c27a6a088ad485f264c9af37392a4c62cf9090f4e9f75b4e07d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:51015",
+					"10.65.0.27:51015",
+					"172.17.0.1:51015",
+					"172.18.0.1:51015",
+					"172.19.0.1:51015"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:59:24.47557207Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6776690889447541,
+				"StableID":   "n8eLDMBBvu11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cde65f65683b62c06fd7c41133e3d2fdb002585c7bb6d4431808efc8ceccd933",
+				"DiscoKey":   "discokey:212a083b5851e815ded1034f3adf6c15c42e3bfe070e3ee000e454b5f094be10",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44730",
+					"10.65.0.27:44730",
+					"172.17.0.1:44730",
+					"172.18.0.1:44730",
+					"172.19.0.1:44730"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:59:25.02163734Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1237801995050189,
+				"StableID":   "ntWdeexbfA11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2cc2be5e44a40f493cf2f1f4a6b3983a2c16f7b0c6da094b79c39259cb90a872",
+				"DiscoKey":   "discokey:a5323deaa3cd2cec986a93fa19e4216f984232d69d0bf43505b0eaefbf136d76",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:43968",
+					"10.65.0.27:43968",
+					"172.17.0.1:43968",
+					"172.18.0.1:43968",
+					"172.19.0.1:43968"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:59:25.56222905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8292164462702578,
+				"StableID":   "nswNPm6Yk721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5be9189cc1fc669fdd923c3809f3d7ed06c48f649f2a0dffd5a9f072dbf49774",
+				"DiscoKey":   "discokey:d0e5ff756f482a43a49d6bbcbd803d7b732c5259f3f6ad50522774067a713505",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39022",
+					"10.65.0.27:39022",
+					"172.17.0.1:39022",
+					"172.18.0.1:39022",
+					"172.19.0.1:39022"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:59:26.109968189Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3121204059158801,
+				"StableID":   "nrTWeojbNR11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a57fcdb6fc0010c0797c51f6d8dbb58617e7e552e5b9e44e517d1b2da313481f",
+				"DiscoKey":   "discokey:84844b9fabbc49b802200b3bd6396f24767e5de9b04b14de8fa1811f14fbcc48",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42110",
+					"10.65.0.27:42110",
+					"172.17.0.1:42110",
+					"172.18.0.1:42110",
+					"172.19.0.1:42110"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:59:26.63695447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7041872035295936,
+				"StableID":   "nBz41B3Hzw11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f3aa6f154dd174a9e95375e014cb5ae34a1eda4a4d93818577c20404f6fe8200",
+				"DiscoKey":   "discokey:bb45c9a0b35f544e9627e41667720fe061a1a8326cb6eef430ea35bff1bb8427",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:45876",
+					"10.65.0.27:45876",
+					"172.17.0.1:45876",
+					"172.18.0.1:45876",
+					"172.19.0.1:45876"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:59:27.187881267Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2606182753054042,
+				"StableID":   "nVNAS61MMM11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ff596cd59fb6b1fa98779794e6c6e834c8272cd13cffb02a80bed7d64373ab74",
+				"DiscoKey":   "discokey:72680374963bf354d06a02ad61c0e42965811afdb2c4ad4f3a674dbf373ce656",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59717",
+					"10.65.0.27:59717",
+					"172.17.0.1:59717",
+					"172.18.0.1:59717",
+					"172.19.0.1:59717"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:59:27.727424123Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7118128324010790,
+				"StableID":   "n9iE7LApax11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d8f96255f0e57ad1c818138e1d6c6acdc96e81c4e5be3921d1ca870047b34618",
+				"KeyExpiry":  "2026-11-08T21:59:28Z",
+				"DiscoKey":   "discokey:36c73842d286fad939852b4e379a87d49b6691638ca9b040278973af32110505",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52202",
+					"10.65.0.27:52202",
+					"172.17.0.1:52202",
+					"172.18.0.1:52202",
+					"172.19.0.1:52202"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:59:28.273370464Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5763425023509787,
+				"StableID":   "nJzXQLQG1n11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e2b91e8e6d60df05220502fbca6bdd832322b8b02f47117c88f8bf888e3b3052",
+				"KeyExpiry":  "2026-11-08T21:59:29Z",
+				"DiscoKey":   "discokey:ae8912110c60f9b1b87fa8a8d5cc6bbb4f4771dd6e45b39b66628d06e332f728",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59660",
+					"10.65.0.27:59660",
+					"172.17.0.1:59660",
+					"172.18.0.1:59660",
+					"172.19.0.1:59660"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:59:29.426749979Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3537737218491365,
+				"StableID":   "ntgzakMFdU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9e761383a57041c54c943a8b783a54fb40009c60b12ad57823dc04d5f537aa14",
+				"KeyExpiry":  "2026-11-08T21:59:30Z",
+				"DiscoKey":   "discokey:47b127cbf2b1c8a3217450b7303f0202801b6c35c65a78beabbbe636acd73028",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45403",
+					"10.65.0.27:45403",
+					"172.17.0.1:45403",
+					"172.18.0.1:45403",
+					"172.19.0.1:45403"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:59:30.113651377Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5359923902283198": {
+				"ID":          5359923902283198,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4648533956705237,
+				"StableID":   "n4Ueb47LJd11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       4648533956705237,
+				"Key":        "nodekey:8cb3d8c3b9293c8f0bd73c67b8726184c19458df3b2fdc33edb5077577c87622",
+				"DiscoKey":   "discokey:1bf163abc8780df0d419db8dda0555b59cf4136e2c68aaa43f67f6f809254e5d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:59:21.846381466Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8cb3d8c3b9293c8f0bd73c67b8726184c19458df3b2fdc33edb5077577c87622",
+			"MachineKey": "mkey:8e7bb9e8ddc98e0e09ee7b1205c7baf20b7ae7b302bb597400bf761398f6da7d",
+			"Peers": [{
+				"ID":         5359923902283198,
+				"StableID":   "nFHm3W7Xri11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0eb399846842feba08a6dda5ef7823c4487aed4dec3981146440356a988e430e",
+				"DiscoKey":   "discokey:71f827bbb63799a7efa635a8bb1defe36d8900d8e7a056a23fd0047adafab015",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55472",
+					"10.65.0.27:55472",
+					"172.17.0.1:55472",
+					"172.18.0.1:55472",
+					"172.19.0.1:55472"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:59:22.314946214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8587449604754225,
+				"StableID":   "nN3VEtjG4A21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25edb65560500f9a321085b121d46217f6e9ddeb9429ba3d675e46045a231c1d",
+				"DiscoKey":   "discokey:f0aafb9e69cf1f960f842d5fc104c86a1741de8b47efa58446cec9d649958952",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:51524",
+					"10.65.0.27:51524",
+					"172.17.0.1:51524",
+					"172.18.0.1:51524",
+					"172.19.0.1:51524"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:59:22.859445975Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7054301687383426,
+				"StableID":   "nD2znWYu5x11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95162b4593257a4c6e52fbe325c21b885d66a349e5c882220a097746eac1ac3c",
+				"DiscoKey":   "discokey:0722dedae894cdd0b6a712bfa976f0374a5fa96f20f345043b01b65047390b2c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:38761",
+					"10.65.0.27:38761",
+					"172.17.0.1:38761",
+					"172.18.0.1:38761",
+					"172.19.0.1:38761"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:59:23.401290302Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7056318023574034,
+				"StableID":   "nfP1XXWp6x11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21d65cc737295e080917b370c87747a9d018793dd416b536303735dc6f306051",
+				"DiscoKey":   "discokey:baf488a348decab0c1cf35e99d67e78df9345e9e238344b3e7ad7a813a83e011",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55402",
+					"10.65.0.27:55402",
+					"172.17.0.1:55402",
+					"172.18.0.1:55402",
+					"172.19.0.1:55402"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:59:23.936360042Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         886059625337608,
+				"StableID":   "nj6WvTHJv711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:047e0d1e2e947680396856cdb4d1d42d2984a8ec4a3ae53698096fad0dbefe04",
+				"DiscoKey":   "discokey:6c613824f7a16c27a6a088ad485f264c9af37392a4c62cf9090f4e9f75b4e07d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:51015",
+					"10.65.0.27:51015",
+					"172.17.0.1:51015",
+					"172.18.0.1:51015",
+					"172.19.0.1:51015"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:59:24.47557207Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6776690889447541,
+				"StableID":   "n8eLDMBBvu11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cde65f65683b62c06fd7c41133e3d2fdb002585c7bb6d4431808efc8ceccd933",
+				"DiscoKey":   "discokey:212a083b5851e815ded1034f3adf6c15c42e3bfe070e3ee000e454b5f094be10",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44730",
+					"10.65.0.27:44730",
+					"172.17.0.1:44730",
+					"172.18.0.1:44730",
+					"172.19.0.1:44730"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:59:25.02163734Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1237801995050189,
+				"StableID":   "ntWdeexbfA11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2cc2be5e44a40f493cf2f1f4a6b3983a2c16f7b0c6da094b79c39259cb90a872",
+				"DiscoKey":   "discokey:a5323deaa3cd2cec986a93fa19e4216f984232d69d0bf43505b0eaefbf136d76",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:43968",
+					"10.65.0.27:43968",
+					"172.17.0.1:43968",
+					"172.18.0.1:43968",
+					"172.19.0.1:43968"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:59:25.56222905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8292164462702578,
+				"StableID":   "nswNPm6Yk721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5be9189cc1fc669fdd923c3809f3d7ed06c48f649f2a0dffd5a9f072dbf49774",
+				"DiscoKey":   "discokey:d0e5ff756f482a43a49d6bbcbd803d7b732c5259f3f6ad50522774067a713505",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39022",
+					"10.65.0.27:39022",
+					"172.17.0.1:39022",
+					"172.18.0.1:39022",
+					"172.19.0.1:39022"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:59:26.109968189Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3121204059158801,
+				"StableID":   "nrTWeojbNR11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a57fcdb6fc0010c0797c51f6d8dbb58617e7e552e5b9e44e517d1b2da313481f",
+				"DiscoKey":   "discokey:84844b9fabbc49b802200b3bd6396f24767e5de9b04b14de8fa1811f14fbcc48",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42110",
+					"10.65.0.27:42110",
+					"172.17.0.1:42110",
+					"172.18.0.1:42110",
+					"172.19.0.1:42110"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:59:26.63695447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7041872035295936,
+				"StableID":   "nBz41B3Hzw11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f3aa6f154dd174a9e95375e014cb5ae34a1eda4a4d93818577c20404f6fe8200",
+				"DiscoKey":   "discokey:bb45c9a0b35f544e9627e41667720fe061a1a8326cb6eef430ea35bff1bb8427",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:45876",
+					"10.65.0.27:45876",
+					"172.17.0.1:45876",
+					"172.18.0.1:45876",
+					"172.19.0.1:45876"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:59:27.187881267Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2606182753054042,
+				"StableID":   "nVNAS61MMM11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ff596cd59fb6b1fa98779794e6c6e834c8272cd13cffb02a80bed7d64373ab74",
+				"DiscoKey":   "discokey:72680374963bf354d06a02ad61c0e42965811afdb2c4ad4f3a674dbf373ce656",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59717",
+					"10.65.0.27:59717",
+					"172.17.0.1:59717",
+					"172.18.0.1:59717",
+					"172.19.0.1:59717"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:59:27.727424123Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7118128324010790,
+				"StableID":   "n9iE7LApax11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d8f96255f0e57ad1c818138e1d6c6acdc96e81c4e5be3921d1ca870047b34618",
+				"KeyExpiry":  "2026-11-08T21:59:28Z",
+				"DiscoKey":   "discokey:36c73842d286fad939852b4e379a87d49b6691638ca9b040278973af32110505",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52202",
+					"10.65.0.27:52202",
+					"172.17.0.1:52202",
+					"172.18.0.1:52202",
+					"172.19.0.1:52202"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:59:28.273370464Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5763425023509787,
+				"StableID":   "nJzXQLQG1n11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e2b91e8e6d60df05220502fbca6bdd832322b8b02f47117c88f8bf888e3b3052",
+				"KeyExpiry":  "2026-11-08T21:59:29Z",
+				"DiscoKey":   "discokey:ae8912110c60f9b1b87fa8a8d5cc6bbb4f4771dd6e45b39b66628d06e332f728",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59660",
+					"10.65.0.27:59660",
+					"172.17.0.1:59660",
+					"172.18.0.1:59660",
+					"172.19.0.1:59660"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:59:29.426749979Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3537737218491365,
+				"StableID":   "ntgzakMFdU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9e761383a57041c54c943a8b783a54fb40009c60b12ad57823dc04d5f537aa14",
+				"KeyExpiry":  "2026-11-08T21:59:30Z",
+				"DiscoKey":   "discokey:47b127cbf2b1c8a3217450b7303f0202801b6c35c65a78beabbbe636acd73028",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45403",
+					"10.65.0.27:45403",
+					"172.17.0.1:45403",
+					"172.18.0.1:45403",
+					"172.19.0.1:45403"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:59:30.113651377Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4648533956705237": {
+				"ID":          4648533956705237,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7056318023574034,
+				"StableID":   "nfP1XXWp6x11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       7056318023574034,
+				"Key":        "nodekey:21d65cc737295e080917b370c87747a9d018793dd416b536303735dc6f306051",
+				"DiscoKey":   "discokey:baf488a348decab0c1cf35e99d67e78df9345e9e238344b3e7ad7a813a83e011",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55402",
+					"10.65.0.27:55402",
+					"172.17.0.1:55402",
+					"172.18.0.1:55402",
+					"172.19.0.1:55402"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:59:23.936360042Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:21d65cc737295e080917b370c87747a9d018793dd416b536303735dc6f306051",
+			"MachineKey": "mkey:72b46830b62d93965f8da7ff4733cd0a25f2895583e4d9270da813fe7e393c0e",
+			"Peers": [{
+				"ID":         4648533956705237,
+				"StableID":   "n4Ueb47LJd11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8cb3d8c3b9293c8f0bd73c67b8726184c19458df3b2fdc33edb5077577c87622",
+				"DiscoKey":   "discokey:1bf163abc8780df0d419db8dda0555b59cf4136e2c68aaa43f67f6f809254e5d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:59:21.846381466Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5359923902283198,
+				"StableID":   "nFHm3W7Xri11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0eb399846842feba08a6dda5ef7823c4487aed4dec3981146440356a988e430e",
+				"DiscoKey":   "discokey:71f827bbb63799a7efa635a8bb1defe36d8900d8e7a056a23fd0047adafab015",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55472",
+					"10.65.0.27:55472",
+					"172.17.0.1:55472",
+					"172.18.0.1:55472",
+					"172.19.0.1:55472"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:59:22.314946214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8587449604754225,
+				"StableID":   "nN3VEtjG4A21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25edb65560500f9a321085b121d46217f6e9ddeb9429ba3d675e46045a231c1d",
+				"DiscoKey":   "discokey:f0aafb9e69cf1f960f842d5fc104c86a1741de8b47efa58446cec9d649958952",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:51524",
+					"10.65.0.27:51524",
+					"172.17.0.1:51524",
+					"172.18.0.1:51524",
+					"172.19.0.1:51524"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:59:22.859445975Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7054301687383426,
+				"StableID":   "nD2znWYu5x11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95162b4593257a4c6e52fbe325c21b885d66a349e5c882220a097746eac1ac3c",
+				"DiscoKey":   "discokey:0722dedae894cdd0b6a712bfa976f0374a5fa96f20f345043b01b65047390b2c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:38761",
+					"10.65.0.27:38761",
+					"172.17.0.1:38761",
+					"172.18.0.1:38761",
+					"172.19.0.1:38761"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:59:23.401290302Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         886059625337608,
+				"StableID":   "nj6WvTHJv711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:047e0d1e2e947680396856cdb4d1d42d2984a8ec4a3ae53698096fad0dbefe04",
+				"DiscoKey":   "discokey:6c613824f7a16c27a6a088ad485f264c9af37392a4c62cf9090f4e9f75b4e07d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:51015",
+					"10.65.0.27:51015",
+					"172.17.0.1:51015",
+					"172.18.0.1:51015",
+					"172.19.0.1:51015"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:59:24.47557207Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6776690889447541,
+				"StableID":   "n8eLDMBBvu11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cde65f65683b62c06fd7c41133e3d2fdb002585c7bb6d4431808efc8ceccd933",
+				"DiscoKey":   "discokey:212a083b5851e815ded1034f3adf6c15c42e3bfe070e3ee000e454b5f094be10",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44730",
+					"10.65.0.27:44730",
+					"172.17.0.1:44730",
+					"172.18.0.1:44730",
+					"172.19.0.1:44730"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:59:25.02163734Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1237801995050189,
+				"StableID":   "ntWdeexbfA11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2cc2be5e44a40f493cf2f1f4a6b3983a2c16f7b0c6da094b79c39259cb90a872",
+				"DiscoKey":   "discokey:a5323deaa3cd2cec986a93fa19e4216f984232d69d0bf43505b0eaefbf136d76",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:43968",
+					"10.65.0.27:43968",
+					"172.17.0.1:43968",
+					"172.18.0.1:43968",
+					"172.19.0.1:43968"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:59:25.56222905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8292164462702578,
+				"StableID":   "nswNPm6Yk721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5be9189cc1fc669fdd923c3809f3d7ed06c48f649f2a0dffd5a9f072dbf49774",
+				"DiscoKey":   "discokey:d0e5ff756f482a43a49d6bbcbd803d7b732c5259f3f6ad50522774067a713505",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39022",
+					"10.65.0.27:39022",
+					"172.17.0.1:39022",
+					"172.18.0.1:39022",
+					"172.19.0.1:39022"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:59:26.109968189Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3121204059158801,
+				"StableID":   "nrTWeojbNR11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a57fcdb6fc0010c0797c51f6d8dbb58617e7e552e5b9e44e517d1b2da313481f",
+				"DiscoKey":   "discokey:84844b9fabbc49b802200b3bd6396f24767e5de9b04b14de8fa1811f14fbcc48",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42110",
+					"10.65.0.27:42110",
+					"172.17.0.1:42110",
+					"172.18.0.1:42110",
+					"172.19.0.1:42110"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:59:26.63695447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7041872035295936,
+				"StableID":   "nBz41B3Hzw11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f3aa6f154dd174a9e95375e014cb5ae34a1eda4a4d93818577c20404f6fe8200",
+				"DiscoKey":   "discokey:bb45c9a0b35f544e9627e41667720fe061a1a8326cb6eef430ea35bff1bb8427",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:45876",
+					"10.65.0.27:45876",
+					"172.17.0.1:45876",
+					"172.18.0.1:45876",
+					"172.19.0.1:45876"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:59:27.187881267Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2606182753054042,
+				"StableID":   "nVNAS61MMM11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ff596cd59fb6b1fa98779794e6c6e834c8272cd13cffb02a80bed7d64373ab74",
+				"DiscoKey":   "discokey:72680374963bf354d06a02ad61c0e42965811afdb2c4ad4f3a674dbf373ce656",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59717",
+					"10.65.0.27:59717",
+					"172.17.0.1:59717",
+					"172.18.0.1:59717",
+					"172.19.0.1:59717"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:59:27.727424123Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7118128324010790,
+				"StableID":   "n9iE7LApax11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d8f96255f0e57ad1c818138e1d6c6acdc96e81c4e5be3921d1ca870047b34618",
+				"KeyExpiry":  "2026-11-08T21:59:28Z",
+				"DiscoKey":   "discokey:36c73842d286fad939852b4e379a87d49b6691638ca9b040278973af32110505",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52202",
+					"10.65.0.27:52202",
+					"172.17.0.1:52202",
+					"172.18.0.1:52202",
+					"172.19.0.1:52202"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:59:28.273370464Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5763425023509787,
+				"StableID":   "nJzXQLQG1n11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e2b91e8e6d60df05220502fbca6bdd832322b8b02f47117c88f8bf888e3b3052",
+				"KeyExpiry":  "2026-11-08T21:59:29Z",
+				"DiscoKey":   "discokey:ae8912110c60f9b1b87fa8a8d5cc6bbb4f4771dd6e45b39b66628d06e332f728",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59660",
+					"10.65.0.27:59660",
+					"172.17.0.1:59660",
+					"172.18.0.1:59660",
+					"172.19.0.1:59660"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:59:29.426749979Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3537737218491365,
+				"StableID":   "ntgzakMFdU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9e761383a57041c54c943a8b783a54fb40009c60b12ad57823dc04d5f537aa14",
+				"KeyExpiry":  "2026-11-08T21:59:30Z",
+				"DiscoKey":   "discokey:47b127cbf2b1c8a3217450b7303f0202801b6c35c65a78beabbbe636acd73028",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45403",
+					"10.65.0.27:45403",
+					"172.17.0.1:45403",
+					"172.18.0.1:45403",
+					"172.19.0.1:45403"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:59:30.113651377Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7056318023574034": {
+				"ID":          7056318023574034,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7054301687383426,
+				"StableID":   "nD2znWYu5x11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       7054301687383426,
+				"Key":        "nodekey:95162b4593257a4c6e52fbe325c21b885d66a349e5c882220a097746eac1ac3c",
+				"DiscoKey":   "discokey:0722dedae894cdd0b6a712bfa976f0374a5fa96f20f345043b01b65047390b2c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:38761",
+					"10.65.0.27:38761",
+					"172.17.0.1:38761",
+					"172.18.0.1:38761",
+					"172.19.0.1:38761"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:59:23.401290302Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:95162b4593257a4c6e52fbe325c21b885d66a349e5c882220a097746eac1ac3c",
+			"MachineKey": "mkey:87d2f115810d527090294b7ee8837e224ddc3a6203fcd09795c6af1bfbb2392f",
+			"Peers": [{
+				"ID":         4648533956705237,
+				"StableID":   "n4Ueb47LJd11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8cb3d8c3b9293c8f0bd73c67b8726184c19458df3b2fdc33edb5077577c87622",
+				"DiscoKey":   "discokey:1bf163abc8780df0d419db8dda0555b59cf4136e2c68aaa43f67f6f809254e5d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:59:21.846381466Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5359923902283198,
+				"StableID":   "nFHm3W7Xri11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0eb399846842feba08a6dda5ef7823c4487aed4dec3981146440356a988e430e",
+				"DiscoKey":   "discokey:71f827bbb63799a7efa635a8bb1defe36d8900d8e7a056a23fd0047adafab015",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55472",
+					"10.65.0.27:55472",
+					"172.17.0.1:55472",
+					"172.18.0.1:55472",
+					"172.19.0.1:55472"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:59:22.314946214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8587449604754225,
+				"StableID":   "nN3VEtjG4A21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25edb65560500f9a321085b121d46217f6e9ddeb9429ba3d675e46045a231c1d",
+				"DiscoKey":   "discokey:f0aafb9e69cf1f960f842d5fc104c86a1741de8b47efa58446cec9d649958952",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:51524",
+					"10.65.0.27:51524",
+					"172.17.0.1:51524",
+					"172.18.0.1:51524",
+					"172.19.0.1:51524"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:59:22.859445975Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7056318023574034,
+				"StableID":   "nfP1XXWp6x11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21d65cc737295e080917b370c87747a9d018793dd416b536303735dc6f306051",
+				"DiscoKey":   "discokey:baf488a348decab0c1cf35e99d67e78df9345e9e238344b3e7ad7a813a83e011",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55402",
+					"10.65.0.27:55402",
+					"172.17.0.1:55402",
+					"172.18.0.1:55402",
+					"172.19.0.1:55402"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:59:23.936360042Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         886059625337608,
+				"StableID":   "nj6WvTHJv711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:047e0d1e2e947680396856cdb4d1d42d2984a8ec4a3ae53698096fad0dbefe04",
+				"DiscoKey":   "discokey:6c613824f7a16c27a6a088ad485f264c9af37392a4c62cf9090f4e9f75b4e07d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:51015",
+					"10.65.0.27:51015",
+					"172.17.0.1:51015",
+					"172.18.0.1:51015",
+					"172.19.0.1:51015"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:59:24.47557207Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6776690889447541,
+				"StableID":   "n8eLDMBBvu11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cde65f65683b62c06fd7c41133e3d2fdb002585c7bb6d4431808efc8ceccd933",
+				"DiscoKey":   "discokey:212a083b5851e815ded1034f3adf6c15c42e3bfe070e3ee000e454b5f094be10",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44730",
+					"10.65.0.27:44730",
+					"172.17.0.1:44730",
+					"172.18.0.1:44730",
+					"172.19.0.1:44730"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:59:25.02163734Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1237801995050189,
+				"StableID":   "ntWdeexbfA11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2cc2be5e44a40f493cf2f1f4a6b3983a2c16f7b0c6da094b79c39259cb90a872",
+				"DiscoKey":   "discokey:a5323deaa3cd2cec986a93fa19e4216f984232d69d0bf43505b0eaefbf136d76",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:43968",
+					"10.65.0.27:43968",
+					"172.17.0.1:43968",
+					"172.18.0.1:43968",
+					"172.19.0.1:43968"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:59:25.56222905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8292164462702578,
+				"StableID":   "nswNPm6Yk721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5be9189cc1fc669fdd923c3809f3d7ed06c48f649f2a0dffd5a9f072dbf49774",
+				"DiscoKey":   "discokey:d0e5ff756f482a43a49d6bbcbd803d7b732c5259f3f6ad50522774067a713505",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39022",
+					"10.65.0.27:39022",
+					"172.17.0.1:39022",
+					"172.18.0.1:39022",
+					"172.19.0.1:39022"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:59:26.109968189Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3121204059158801,
+				"StableID":   "nrTWeojbNR11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a57fcdb6fc0010c0797c51f6d8dbb58617e7e552e5b9e44e517d1b2da313481f",
+				"DiscoKey":   "discokey:84844b9fabbc49b802200b3bd6396f24767e5de9b04b14de8fa1811f14fbcc48",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42110",
+					"10.65.0.27:42110",
+					"172.17.0.1:42110",
+					"172.18.0.1:42110",
+					"172.19.0.1:42110"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:59:26.63695447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7041872035295936,
+				"StableID":   "nBz41B3Hzw11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f3aa6f154dd174a9e95375e014cb5ae34a1eda4a4d93818577c20404f6fe8200",
+				"DiscoKey":   "discokey:bb45c9a0b35f544e9627e41667720fe061a1a8326cb6eef430ea35bff1bb8427",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:45876",
+					"10.65.0.27:45876",
+					"172.17.0.1:45876",
+					"172.18.0.1:45876",
+					"172.19.0.1:45876"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:59:27.187881267Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2606182753054042,
+				"StableID":   "nVNAS61MMM11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ff596cd59fb6b1fa98779794e6c6e834c8272cd13cffb02a80bed7d64373ab74",
+				"DiscoKey":   "discokey:72680374963bf354d06a02ad61c0e42965811afdb2c4ad4f3a674dbf373ce656",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59717",
+					"10.65.0.27:59717",
+					"172.17.0.1:59717",
+					"172.18.0.1:59717",
+					"172.19.0.1:59717"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:59:27.727424123Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7118128324010790,
+				"StableID":   "n9iE7LApax11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d8f96255f0e57ad1c818138e1d6c6acdc96e81c4e5be3921d1ca870047b34618",
+				"KeyExpiry":  "2026-11-08T21:59:28Z",
+				"DiscoKey":   "discokey:36c73842d286fad939852b4e379a87d49b6691638ca9b040278973af32110505",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52202",
+					"10.65.0.27:52202",
+					"172.17.0.1:52202",
+					"172.18.0.1:52202",
+					"172.19.0.1:52202"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:59:28.273370464Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5763425023509787,
+				"StableID":   "nJzXQLQG1n11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e2b91e8e6d60df05220502fbca6bdd832322b8b02f47117c88f8bf888e3b3052",
+				"KeyExpiry":  "2026-11-08T21:59:29Z",
+				"DiscoKey":   "discokey:ae8912110c60f9b1b87fa8a8d5cc6bbb4f4771dd6e45b39b66628d06e332f728",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59660",
+					"10.65.0.27:59660",
+					"172.17.0.1:59660",
+					"172.18.0.1:59660",
+					"172.19.0.1:59660"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:59:29.426749979Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3537737218491365,
+				"StableID":   "ntgzakMFdU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9e761383a57041c54c943a8b783a54fb40009c60b12ad57823dc04d5f537aa14",
+				"KeyExpiry":  "2026-11-08T21:59:30Z",
+				"DiscoKey":   "discokey:47b127cbf2b1c8a3217450b7303f0202801b6c35c65a78beabbbe636acd73028",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45403",
+					"10.65.0.27:45403",
+					"172.17.0.1:45403",
+					"172.18.0.1:45403",
+					"172.19.0.1:45403"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:59:30.113651377Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7054301687383426": {
+				"ID":          7054301687383426,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6776690889447541,
+				"StableID":   "n8eLDMBBvu11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       6776690889447541,
+				"Key":        "nodekey:cde65f65683b62c06fd7c41133e3d2fdb002585c7bb6d4431808efc8ceccd933",
+				"DiscoKey":   "discokey:212a083b5851e815ded1034f3adf6c15c42e3bfe070e3ee000e454b5f094be10",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44730",
+					"10.65.0.27:44730",
+					"172.17.0.1:44730",
+					"172.18.0.1:44730",
+					"172.19.0.1:44730"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:59:25.02163734Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:cde65f65683b62c06fd7c41133e3d2fdb002585c7bb6d4431808efc8ceccd933",
+			"MachineKey": "mkey:e6dec608577f738e3db56fbaa9d810f0cde40bd2cf6657ab91aed9b379cfff3c",
+			"Peers": [{
+				"ID":         4648533956705237,
+				"StableID":   "n4Ueb47LJd11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8cb3d8c3b9293c8f0bd73c67b8726184c19458df3b2fdc33edb5077577c87622",
+				"DiscoKey":   "discokey:1bf163abc8780df0d419db8dda0555b59cf4136e2c68aaa43f67f6f809254e5d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:59:21.846381466Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5359923902283198,
+				"StableID":   "nFHm3W7Xri11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0eb399846842feba08a6dda5ef7823c4487aed4dec3981146440356a988e430e",
+				"DiscoKey":   "discokey:71f827bbb63799a7efa635a8bb1defe36d8900d8e7a056a23fd0047adafab015",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55472",
+					"10.65.0.27:55472",
+					"172.17.0.1:55472",
+					"172.18.0.1:55472",
+					"172.19.0.1:55472"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:59:22.314946214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8587449604754225,
+				"StableID":   "nN3VEtjG4A21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25edb65560500f9a321085b121d46217f6e9ddeb9429ba3d675e46045a231c1d",
+				"DiscoKey":   "discokey:f0aafb9e69cf1f960f842d5fc104c86a1741de8b47efa58446cec9d649958952",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:51524",
+					"10.65.0.27:51524",
+					"172.17.0.1:51524",
+					"172.18.0.1:51524",
+					"172.19.0.1:51524"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:59:22.859445975Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7054301687383426,
+				"StableID":   "nD2znWYu5x11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95162b4593257a4c6e52fbe325c21b885d66a349e5c882220a097746eac1ac3c",
+				"DiscoKey":   "discokey:0722dedae894cdd0b6a712bfa976f0374a5fa96f20f345043b01b65047390b2c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:38761",
+					"10.65.0.27:38761",
+					"172.17.0.1:38761",
+					"172.18.0.1:38761",
+					"172.19.0.1:38761"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:59:23.401290302Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7056318023574034,
+				"StableID":   "nfP1XXWp6x11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21d65cc737295e080917b370c87747a9d018793dd416b536303735dc6f306051",
+				"DiscoKey":   "discokey:baf488a348decab0c1cf35e99d67e78df9345e9e238344b3e7ad7a813a83e011",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55402",
+					"10.65.0.27:55402",
+					"172.17.0.1:55402",
+					"172.18.0.1:55402",
+					"172.19.0.1:55402"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:59:23.936360042Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         886059625337608,
+				"StableID":   "nj6WvTHJv711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:047e0d1e2e947680396856cdb4d1d42d2984a8ec4a3ae53698096fad0dbefe04",
+				"DiscoKey":   "discokey:6c613824f7a16c27a6a088ad485f264c9af37392a4c62cf9090f4e9f75b4e07d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:51015",
+					"10.65.0.27:51015",
+					"172.17.0.1:51015",
+					"172.18.0.1:51015",
+					"172.19.0.1:51015"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:59:24.47557207Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1237801995050189,
+				"StableID":   "ntWdeexbfA11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2cc2be5e44a40f493cf2f1f4a6b3983a2c16f7b0c6da094b79c39259cb90a872",
+				"DiscoKey":   "discokey:a5323deaa3cd2cec986a93fa19e4216f984232d69d0bf43505b0eaefbf136d76",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:43968",
+					"10.65.0.27:43968",
+					"172.17.0.1:43968",
+					"172.18.0.1:43968",
+					"172.19.0.1:43968"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:59:25.56222905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8292164462702578,
+				"StableID":   "nswNPm6Yk721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5be9189cc1fc669fdd923c3809f3d7ed06c48f649f2a0dffd5a9f072dbf49774",
+				"DiscoKey":   "discokey:d0e5ff756f482a43a49d6bbcbd803d7b732c5259f3f6ad50522774067a713505",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39022",
+					"10.65.0.27:39022",
+					"172.17.0.1:39022",
+					"172.18.0.1:39022",
+					"172.19.0.1:39022"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:59:26.109968189Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3121204059158801,
+				"StableID":   "nrTWeojbNR11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a57fcdb6fc0010c0797c51f6d8dbb58617e7e552e5b9e44e517d1b2da313481f",
+				"DiscoKey":   "discokey:84844b9fabbc49b802200b3bd6396f24767e5de9b04b14de8fa1811f14fbcc48",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42110",
+					"10.65.0.27:42110",
+					"172.17.0.1:42110",
+					"172.18.0.1:42110",
+					"172.19.0.1:42110"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:59:26.63695447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7041872035295936,
+				"StableID":   "nBz41B3Hzw11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f3aa6f154dd174a9e95375e014cb5ae34a1eda4a4d93818577c20404f6fe8200",
+				"DiscoKey":   "discokey:bb45c9a0b35f544e9627e41667720fe061a1a8326cb6eef430ea35bff1bb8427",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:45876",
+					"10.65.0.27:45876",
+					"172.17.0.1:45876",
+					"172.18.0.1:45876",
+					"172.19.0.1:45876"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:59:27.187881267Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2606182753054042,
+				"StableID":   "nVNAS61MMM11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ff596cd59fb6b1fa98779794e6c6e834c8272cd13cffb02a80bed7d64373ab74",
+				"DiscoKey":   "discokey:72680374963bf354d06a02ad61c0e42965811afdb2c4ad4f3a674dbf373ce656",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59717",
+					"10.65.0.27:59717",
+					"172.17.0.1:59717",
+					"172.18.0.1:59717",
+					"172.19.0.1:59717"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:59:27.727424123Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7118128324010790,
+				"StableID":   "n9iE7LApax11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d8f96255f0e57ad1c818138e1d6c6acdc96e81c4e5be3921d1ca870047b34618",
+				"KeyExpiry":  "2026-11-08T21:59:28Z",
+				"DiscoKey":   "discokey:36c73842d286fad939852b4e379a87d49b6691638ca9b040278973af32110505",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52202",
+					"10.65.0.27:52202",
+					"172.17.0.1:52202",
+					"172.18.0.1:52202",
+					"172.19.0.1:52202"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:59:28.273370464Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5763425023509787,
+				"StableID":   "nJzXQLQG1n11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e2b91e8e6d60df05220502fbca6bdd832322b8b02f47117c88f8bf888e3b3052",
+				"KeyExpiry":  "2026-11-08T21:59:29Z",
+				"DiscoKey":   "discokey:ae8912110c60f9b1b87fa8a8d5cc6bbb4f4771dd6e45b39b66628d06e332f728",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59660",
+					"10.65.0.27:59660",
+					"172.17.0.1:59660",
+					"172.18.0.1:59660",
+					"172.19.0.1:59660"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:59:29.426749979Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3537737218491365,
+				"StableID":   "ntgzakMFdU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9e761383a57041c54c943a8b783a54fb40009c60b12ad57823dc04d5f537aa14",
+				"KeyExpiry":  "2026-11-08T21:59:30Z",
+				"DiscoKey":   "discokey:47b127cbf2b1c8a3217450b7303f0202801b6c35c65a78beabbbe636acd73028",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45403",
+					"10.65.0.27:45403",
+					"172.17.0.1:45403",
+					"172.18.0.1:45403",
+					"172.19.0.1:45403"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:59:30.113651377Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6776690889447541": {
+				"ID":          6776690889447541,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8292164462702578,
+				"StableID":   "nswNPm6Yk721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       8292164462702578,
+				"Key":        "nodekey:5be9189cc1fc669fdd923c3809f3d7ed06c48f649f2a0dffd5a9f072dbf49774",
+				"DiscoKey":   "discokey:d0e5ff756f482a43a49d6bbcbd803d7b732c5259f3f6ad50522774067a713505",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39022",
+					"10.65.0.27:39022",
+					"172.17.0.1:39022",
+					"172.18.0.1:39022",
+					"172.19.0.1:39022"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T21:59:26.109968189Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5be9189cc1fc669fdd923c3809f3d7ed06c48f649f2a0dffd5a9f072dbf49774",
+			"MachineKey": "mkey:5d46212ef418ba29962f832a640c2845e3468fc4c061be6b5193ffcb4bd80607",
+			"Peers": [{
+				"ID":         4648533956705237,
+				"StableID":   "n4Ueb47LJd11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8cb3d8c3b9293c8f0bd73c67b8726184c19458df3b2fdc33edb5077577c87622",
+				"DiscoKey":   "discokey:1bf163abc8780df0d419db8dda0555b59cf4136e2c68aaa43f67f6f809254e5d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:59:21.846381466Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5359923902283198,
+				"StableID":   "nFHm3W7Xri11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0eb399846842feba08a6dda5ef7823c4487aed4dec3981146440356a988e430e",
+				"DiscoKey":   "discokey:71f827bbb63799a7efa635a8bb1defe36d8900d8e7a056a23fd0047adafab015",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55472",
+					"10.65.0.27:55472",
+					"172.17.0.1:55472",
+					"172.18.0.1:55472",
+					"172.19.0.1:55472"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:59:22.314946214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8587449604754225,
+				"StableID":   "nN3VEtjG4A21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25edb65560500f9a321085b121d46217f6e9ddeb9429ba3d675e46045a231c1d",
+				"DiscoKey":   "discokey:f0aafb9e69cf1f960f842d5fc104c86a1741de8b47efa58446cec9d649958952",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:51524",
+					"10.65.0.27:51524",
+					"172.17.0.1:51524",
+					"172.18.0.1:51524",
+					"172.19.0.1:51524"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:59:22.859445975Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7054301687383426,
+				"StableID":   "nD2znWYu5x11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95162b4593257a4c6e52fbe325c21b885d66a349e5c882220a097746eac1ac3c",
+				"DiscoKey":   "discokey:0722dedae894cdd0b6a712bfa976f0374a5fa96f20f345043b01b65047390b2c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:38761",
+					"10.65.0.27:38761",
+					"172.17.0.1:38761",
+					"172.18.0.1:38761",
+					"172.19.0.1:38761"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:59:23.401290302Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7056318023574034,
+				"StableID":   "nfP1XXWp6x11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21d65cc737295e080917b370c87747a9d018793dd416b536303735dc6f306051",
+				"DiscoKey":   "discokey:baf488a348decab0c1cf35e99d67e78df9345e9e238344b3e7ad7a813a83e011",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55402",
+					"10.65.0.27:55402",
+					"172.17.0.1:55402",
+					"172.18.0.1:55402",
+					"172.19.0.1:55402"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:59:23.936360042Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         886059625337608,
+				"StableID":   "nj6WvTHJv711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:047e0d1e2e947680396856cdb4d1d42d2984a8ec4a3ae53698096fad0dbefe04",
+				"DiscoKey":   "discokey:6c613824f7a16c27a6a088ad485f264c9af37392a4c62cf9090f4e9f75b4e07d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:51015",
+					"10.65.0.27:51015",
+					"172.17.0.1:51015",
+					"172.18.0.1:51015",
+					"172.19.0.1:51015"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:59:24.47557207Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6776690889447541,
+				"StableID":   "n8eLDMBBvu11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cde65f65683b62c06fd7c41133e3d2fdb002585c7bb6d4431808efc8ceccd933",
+				"DiscoKey":   "discokey:212a083b5851e815ded1034f3adf6c15c42e3bfe070e3ee000e454b5f094be10",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44730",
+					"10.65.0.27:44730",
+					"172.17.0.1:44730",
+					"172.18.0.1:44730",
+					"172.19.0.1:44730"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:59:25.02163734Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1237801995050189,
+				"StableID":   "ntWdeexbfA11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2cc2be5e44a40f493cf2f1f4a6b3983a2c16f7b0c6da094b79c39259cb90a872",
+				"DiscoKey":   "discokey:a5323deaa3cd2cec986a93fa19e4216f984232d69d0bf43505b0eaefbf136d76",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:43968",
+					"10.65.0.27:43968",
+					"172.17.0.1:43968",
+					"172.18.0.1:43968",
+					"172.19.0.1:43968"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:59:25.56222905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3121204059158801,
+				"StableID":   "nrTWeojbNR11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a57fcdb6fc0010c0797c51f6d8dbb58617e7e552e5b9e44e517d1b2da313481f",
+				"DiscoKey":   "discokey:84844b9fabbc49b802200b3bd6396f24767e5de9b04b14de8fa1811f14fbcc48",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42110",
+					"10.65.0.27:42110",
+					"172.17.0.1:42110",
+					"172.18.0.1:42110",
+					"172.19.0.1:42110"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:59:26.63695447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7041872035295936,
+				"StableID":   "nBz41B3Hzw11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f3aa6f154dd174a9e95375e014cb5ae34a1eda4a4d93818577c20404f6fe8200",
+				"DiscoKey":   "discokey:bb45c9a0b35f544e9627e41667720fe061a1a8326cb6eef430ea35bff1bb8427",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:45876",
+					"10.65.0.27:45876",
+					"172.17.0.1:45876",
+					"172.18.0.1:45876",
+					"172.19.0.1:45876"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:59:27.187881267Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2606182753054042,
+				"StableID":   "nVNAS61MMM11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ff596cd59fb6b1fa98779794e6c6e834c8272cd13cffb02a80bed7d64373ab74",
+				"DiscoKey":   "discokey:72680374963bf354d06a02ad61c0e42965811afdb2c4ad4f3a674dbf373ce656",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59717",
+					"10.65.0.27:59717",
+					"172.17.0.1:59717",
+					"172.18.0.1:59717",
+					"172.19.0.1:59717"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:59:27.727424123Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7118128324010790,
+				"StableID":   "n9iE7LApax11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d8f96255f0e57ad1c818138e1d6c6acdc96e81c4e5be3921d1ca870047b34618",
+				"KeyExpiry":  "2026-11-08T21:59:28Z",
+				"DiscoKey":   "discokey:36c73842d286fad939852b4e379a87d49b6691638ca9b040278973af32110505",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52202",
+					"10.65.0.27:52202",
+					"172.17.0.1:52202",
+					"172.18.0.1:52202",
+					"172.19.0.1:52202"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:59:28.273370464Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5763425023509787,
+				"StableID":   "nJzXQLQG1n11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e2b91e8e6d60df05220502fbca6bdd832322b8b02f47117c88f8bf888e3b3052",
+				"KeyExpiry":  "2026-11-08T21:59:29Z",
+				"DiscoKey":   "discokey:ae8912110c60f9b1b87fa8a8d5cc6bbb4f4771dd6e45b39b66628d06e332f728",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59660",
+					"10.65.0.27:59660",
+					"172.17.0.1:59660",
+					"172.18.0.1:59660",
+					"172.19.0.1:59660"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:59:29.426749979Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3537737218491365,
+				"StableID":   "ntgzakMFdU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9e761383a57041c54c943a8b783a54fb40009c60b12ad57823dc04d5f537aa14",
+				"KeyExpiry":  "2026-11-08T21:59:30Z",
+				"DiscoKey":   "discokey:47b127cbf2b1c8a3217450b7303f0202801b6c35c65a78beabbbe636acd73028",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45403",
+					"10.65.0.27:45403",
+					"172.17.0.1:45403",
+					"172.18.0.1:45403",
+					"172.19.0.1:45403"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:59:30.113651377Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8292164462702578": {
+				"ID":          8292164462702578,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5763425023509787,
+				"StableID":   "nJzXQLQG1n11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e2b91e8e6d60df05220502fbca6bdd832322b8b02f47117c88f8bf888e3b3052",
+				"KeyExpiry":  "2026-11-08T21:59:29Z",
+				"DiscoKey":   "discokey:ae8912110c60f9b1b87fa8a8d5cc6bbb4f4771dd6e45b39b66628d06e332f728",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59660",
+					"10.65.0.27:59660",
+					"172.17.0.1:59660",
+					"172.18.0.1:59660",
+					"172.19.0.1:59660"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:59:29.426749979Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e2b91e8e6d60df05220502fbca6bdd832322b8b02f47117c88f8bf888e3b3052",
+			"MachineKey": "mkey:6d070da4058ff25ec529839e6e7f90288ef65b8a9f8faa7a43b02b7867ffa37c",
+			"Peers": [{
+				"ID":         4648533956705237,
+				"StableID":   "n4Ueb47LJd11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8cb3d8c3b9293c8f0bd73c67b8726184c19458df3b2fdc33edb5077577c87622",
+				"DiscoKey":   "discokey:1bf163abc8780df0d419db8dda0555b59cf4136e2c68aaa43f67f6f809254e5d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:59:21.846381466Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5359923902283198,
+				"StableID":   "nFHm3W7Xri11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0eb399846842feba08a6dda5ef7823c4487aed4dec3981146440356a988e430e",
+				"DiscoKey":   "discokey:71f827bbb63799a7efa635a8bb1defe36d8900d8e7a056a23fd0047adafab015",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55472",
+					"10.65.0.27:55472",
+					"172.17.0.1:55472",
+					"172.18.0.1:55472",
+					"172.19.0.1:55472"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:59:22.314946214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8587449604754225,
+				"StableID":   "nN3VEtjG4A21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25edb65560500f9a321085b121d46217f6e9ddeb9429ba3d675e46045a231c1d",
+				"DiscoKey":   "discokey:f0aafb9e69cf1f960f842d5fc104c86a1741de8b47efa58446cec9d649958952",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:51524",
+					"10.65.0.27:51524",
+					"172.17.0.1:51524",
+					"172.18.0.1:51524",
+					"172.19.0.1:51524"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:59:22.859445975Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7054301687383426,
+				"StableID":   "nD2znWYu5x11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95162b4593257a4c6e52fbe325c21b885d66a349e5c882220a097746eac1ac3c",
+				"DiscoKey":   "discokey:0722dedae894cdd0b6a712bfa976f0374a5fa96f20f345043b01b65047390b2c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:38761",
+					"10.65.0.27:38761",
+					"172.17.0.1:38761",
+					"172.18.0.1:38761",
+					"172.19.0.1:38761"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:59:23.401290302Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7056318023574034,
+				"StableID":   "nfP1XXWp6x11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21d65cc737295e080917b370c87747a9d018793dd416b536303735dc6f306051",
+				"DiscoKey":   "discokey:baf488a348decab0c1cf35e99d67e78df9345e9e238344b3e7ad7a813a83e011",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55402",
+					"10.65.0.27:55402",
+					"172.17.0.1:55402",
+					"172.18.0.1:55402",
+					"172.19.0.1:55402"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:59:23.936360042Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         886059625337608,
+				"StableID":   "nj6WvTHJv711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:047e0d1e2e947680396856cdb4d1d42d2984a8ec4a3ae53698096fad0dbefe04",
+				"DiscoKey":   "discokey:6c613824f7a16c27a6a088ad485f264c9af37392a4c62cf9090f4e9f75b4e07d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:51015",
+					"10.65.0.27:51015",
+					"172.17.0.1:51015",
+					"172.18.0.1:51015",
+					"172.19.0.1:51015"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:59:24.47557207Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6776690889447541,
+				"StableID":   "n8eLDMBBvu11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cde65f65683b62c06fd7c41133e3d2fdb002585c7bb6d4431808efc8ceccd933",
+				"DiscoKey":   "discokey:212a083b5851e815ded1034f3adf6c15c42e3bfe070e3ee000e454b5f094be10",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44730",
+					"10.65.0.27:44730",
+					"172.17.0.1:44730",
+					"172.18.0.1:44730",
+					"172.19.0.1:44730"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:59:25.02163734Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1237801995050189,
+				"StableID":   "ntWdeexbfA11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2cc2be5e44a40f493cf2f1f4a6b3983a2c16f7b0c6da094b79c39259cb90a872",
+				"DiscoKey":   "discokey:a5323deaa3cd2cec986a93fa19e4216f984232d69d0bf43505b0eaefbf136d76",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:43968",
+					"10.65.0.27:43968",
+					"172.17.0.1:43968",
+					"172.18.0.1:43968",
+					"172.19.0.1:43968"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:59:25.56222905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8292164462702578,
+				"StableID":   "nswNPm6Yk721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5be9189cc1fc669fdd923c3809f3d7ed06c48f649f2a0dffd5a9f072dbf49774",
+				"DiscoKey":   "discokey:d0e5ff756f482a43a49d6bbcbd803d7b732c5259f3f6ad50522774067a713505",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39022",
+					"10.65.0.27:39022",
+					"172.17.0.1:39022",
+					"172.18.0.1:39022",
+					"172.19.0.1:39022"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:59:26.109968189Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3121204059158801,
+				"StableID":   "nrTWeojbNR11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a57fcdb6fc0010c0797c51f6d8dbb58617e7e552e5b9e44e517d1b2da313481f",
+				"DiscoKey":   "discokey:84844b9fabbc49b802200b3bd6396f24767e5de9b04b14de8fa1811f14fbcc48",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42110",
+					"10.65.0.27:42110",
+					"172.17.0.1:42110",
+					"172.18.0.1:42110",
+					"172.19.0.1:42110"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T21:59:26.63695447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7041872035295936,
+				"StableID":   "nBz41B3Hzw11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f3aa6f154dd174a9e95375e014cb5ae34a1eda4a4d93818577c20404f6fe8200",
+				"DiscoKey":   "discokey:bb45c9a0b35f544e9627e41667720fe061a1a8326cb6eef430ea35bff1bb8427",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:45876",
+					"10.65.0.27:45876",
+					"172.17.0.1:45876",
+					"172.18.0.1:45876",
+					"172.19.0.1:45876"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:59:27.187881267Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2606182753054042,
+				"StableID":   "nVNAS61MMM11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ff596cd59fb6b1fa98779794e6c6e834c8272cd13cffb02a80bed7d64373ab74",
+				"DiscoKey":   "discokey:72680374963bf354d06a02ad61c0e42965811afdb2c4ad4f3a674dbf373ce656",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59717",
+					"10.65.0.27:59717",
+					"172.17.0.1:59717",
+					"172.18.0.1:59717",
+					"172.19.0.1:59717"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:59:27.727424123Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7118128324010790,
+				"StableID":   "n9iE7LApax11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d8f96255f0e57ad1c818138e1d6c6acdc96e81c4e5be3921d1ca870047b34618",
+				"KeyExpiry":  "2026-11-08T21:59:28Z",
+				"DiscoKey":   "discokey:36c73842d286fad939852b4e379a87d49b6691638ca9b040278973af32110505",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52202",
+					"10.65.0.27:52202",
+					"172.17.0.1:52202",
+					"172.18.0.1:52202",
+					"172.19.0.1:52202"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:59:28.273370464Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3537737218491365,
+				"StableID":   "ntgzakMFdU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9e761383a57041c54c943a8b783a54fb40009c60b12ad57823dc04d5f537aa14",
+				"KeyExpiry":  "2026-11-08T21:59:30Z",
+				"DiscoKey":   "discokey:47b127cbf2b1c8a3217450b7303f0202801b6c35c65a78beabbbe636acd73028",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45403",
+					"10.65.0.27:45403",
+					"172.17.0.1:45403",
+					"172.18.0.1:45403",
+					"172.19.0.1:45403"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:59:30.113651377Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3121204059158801,
+				"StableID":   "nrTWeojbNR11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       3121204059158801,
+				"Key":        "nodekey:a57fcdb6fc0010c0797c51f6d8dbb58617e7e552e5b9e44e517d1b2da313481f",
+				"DiscoKey":   "discokey:84844b9fabbc49b802200b3bd6396f24767e5de9b04b14de8fa1811f14fbcc48",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42110",
+					"10.65.0.27:42110",
+					"172.17.0.1:42110",
+					"172.18.0.1:42110",
+					"172.19.0.1:42110"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T21:59:26.63695447Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a57fcdb6fc0010c0797c51f6d8dbb58617e7e552e5b9e44e517d1b2da313481f",
+			"MachineKey": "mkey:132be1450fc3251ef32d08ebbaaef07add8c6e1978c6be742315006482a9e43b",
+			"Peers": [{
+				"ID":         4648533956705237,
+				"StableID":   "n4Ueb47LJd11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8cb3d8c3b9293c8f0bd73c67b8726184c19458df3b2fdc33edb5077577c87622",
+				"DiscoKey":   "discokey:1bf163abc8780df0d419db8dda0555b59cf4136e2c68aaa43f67f6f809254e5d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T21:59:21.846381466Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5359923902283198,
+				"StableID":   "nFHm3W7Xri11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0eb399846842feba08a6dda5ef7823c4487aed4dec3981146440356a988e430e",
+				"DiscoKey":   "discokey:71f827bbb63799a7efa635a8bb1defe36d8900d8e7a056a23fd0047adafab015",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55472",
+					"10.65.0.27:55472",
+					"172.17.0.1:55472",
+					"172.18.0.1:55472",
+					"172.19.0.1:55472"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T21:59:22.314946214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8587449604754225,
+				"StableID":   "nN3VEtjG4A21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25edb65560500f9a321085b121d46217f6e9ddeb9429ba3d675e46045a231c1d",
+				"DiscoKey":   "discokey:f0aafb9e69cf1f960f842d5fc104c86a1741de8b47efa58446cec9d649958952",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:51524",
+					"10.65.0.27:51524",
+					"172.17.0.1:51524",
+					"172.18.0.1:51524",
+					"172.19.0.1:51524"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T21:59:22.859445975Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7054301687383426,
+				"StableID":   "nD2znWYu5x11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95162b4593257a4c6e52fbe325c21b885d66a349e5c882220a097746eac1ac3c",
+				"DiscoKey":   "discokey:0722dedae894cdd0b6a712bfa976f0374a5fa96f20f345043b01b65047390b2c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:38761",
+					"10.65.0.27:38761",
+					"172.17.0.1:38761",
+					"172.18.0.1:38761",
+					"172.19.0.1:38761"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T21:59:23.401290302Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7056318023574034,
+				"StableID":   "nfP1XXWp6x11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21d65cc737295e080917b370c87747a9d018793dd416b536303735dc6f306051",
+				"DiscoKey":   "discokey:baf488a348decab0c1cf35e99d67e78df9345e9e238344b3e7ad7a813a83e011",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55402",
+					"10.65.0.27:55402",
+					"172.17.0.1:55402",
+					"172.18.0.1:55402",
+					"172.19.0.1:55402"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T21:59:23.936360042Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         886059625337608,
+				"StableID":   "nj6WvTHJv711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:047e0d1e2e947680396856cdb4d1d42d2984a8ec4a3ae53698096fad0dbefe04",
+				"DiscoKey":   "discokey:6c613824f7a16c27a6a088ad485f264c9af37392a4c62cf9090f4e9f75b4e07d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:51015",
+					"10.65.0.27:51015",
+					"172.17.0.1:51015",
+					"172.18.0.1:51015",
+					"172.19.0.1:51015"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T21:59:24.47557207Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6776690889447541,
+				"StableID":   "n8eLDMBBvu11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cde65f65683b62c06fd7c41133e3d2fdb002585c7bb6d4431808efc8ceccd933",
+				"DiscoKey":   "discokey:212a083b5851e815ded1034f3adf6c15c42e3bfe070e3ee000e454b5f094be10",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44730",
+					"10.65.0.27:44730",
+					"172.17.0.1:44730",
+					"172.18.0.1:44730",
+					"172.19.0.1:44730"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T21:59:25.02163734Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1237801995050189,
+				"StableID":   "ntWdeexbfA11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2cc2be5e44a40f493cf2f1f4a6b3983a2c16f7b0c6da094b79c39259cb90a872",
+				"DiscoKey":   "discokey:a5323deaa3cd2cec986a93fa19e4216f984232d69d0bf43505b0eaefbf136d76",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:43968",
+					"10.65.0.27:43968",
+					"172.17.0.1:43968",
+					"172.18.0.1:43968",
+					"172.19.0.1:43968"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T21:59:25.56222905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8292164462702578,
+				"StableID":   "nswNPm6Yk721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5be9189cc1fc669fdd923c3809f3d7ed06c48f649f2a0dffd5a9f072dbf49774",
+				"DiscoKey":   "discokey:d0e5ff756f482a43a49d6bbcbd803d7b732c5259f3f6ad50522774067a713505",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39022",
+					"10.65.0.27:39022",
+					"172.17.0.1:39022",
+					"172.18.0.1:39022",
+					"172.19.0.1:39022"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T21:59:26.109968189Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7041872035295936,
+				"StableID":   "nBz41B3Hzw11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f3aa6f154dd174a9e95375e014cb5ae34a1eda4a4d93818577c20404f6fe8200",
+				"DiscoKey":   "discokey:bb45c9a0b35f544e9627e41667720fe061a1a8326cb6eef430ea35bff1bb8427",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:45876",
+					"10.65.0.27:45876",
+					"172.17.0.1:45876",
+					"172.18.0.1:45876",
+					"172.19.0.1:45876"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T21:59:27.187881267Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2606182753054042,
+				"StableID":   "nVNAS61MMM11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ff596cd59fb6b1fa98779794e6c6e834c8272cd13cffb02a80bed7d64373ab74",
+				"DiscoKey":   "discokey:72680374963bf354d06a02ad61c0e42965811afdb2c4ad4f3a674dbf373ce656",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59717",
+					"10.65.0.27:59717",
+					"172.17.0.1:59717",
+					"172.18.0.1:59717",
+					"172.19.0.1:59717"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T21:59:27.727424123Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7118128324010790,
+				"StableID":   "n9iE7LApax11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d8f96255f0e57ad1c818138e1d6c6acdc96e81c4e5be3921d1ca870047b34618",
+				"KeyExpiry":  "2026-11-08T21:59:28Z",
+				"DiscoKey":   "discokey:36c73842d286fad939852b4e379a87d49b6691638ca9b040278973af32110505",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52202",
+					"10.65.0.27:52202",
+					"172.17.0.1:52202",
+					"172.18.0.1:52202",
+					"172.19.0.1:52202"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T21:59:28.273370464Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5763425023509787,
+				"StableID":   "nJzXQLQG1n11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e2b91e8e6d60df05220502fbca6bdd832322b8b02f47117c88f8bf888e3b3052",
+				"KeyExpiry":  "2026-11-08T21:59:29Z",
+				"DiscoKey":   "discokey:ae8912110c60f9b1b87fa8a8d5cc6bbb4f4771dd6e45b39b66628d06e332f728",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59660",
+					"10.65.0.27:59660",
+					"172.17.0.1:59660",
+					"172.18.0.1:59660",
+					"172.19.0.1:59660"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T21:59:29.426749979Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3537737218491365,
+				"StableID":   "ntgzakMFdU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9e761383a57041c54c943a8b783a54fb40009c60b12ad57823dc04d5f537aa14",
+				"KeyExpiry":  "2026-11-08T21:59:30Z",
+				"DiscoKey":   "discokey:47b127cbf2b1c8a3217450b7303f0202801b6c35c65a78beabbbe636acd73028",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:45403",
+					"10.65.0.27:45403",
+					"172.17.0.1:45403",
+					"172.18.0.1:45403",
+					"172.19.0.1:45403"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T21:59:30.113651377Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3121204059158801": {
+				"ID":          3121204059158801,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-user-autogroup-internet.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-user-autogroup-internet.hujson
@@ -1,0 +1,20112 @@
+// ssh-malformed-user-autogroup-internet
+//
+// ssh users autogroup:internet is rejected
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T22:00:15Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-malformed-user-autogroup-internet",
+	"description":    "ssh users autogroup:internet is rejected",
+	"category":       "ssh",
+	"captured_at":    "2026-05-12T22:00:15.385436597Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                        \n  \n                                                                                 \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh users autogroup:internet is rejected\",\n\t\"id\":          \"ssh-malformed-user-autogroup-internet\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"autogroup:member\"],\n\t\t\"users\":  [\"autogroup:internet\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-malformed/ssh-malformed-user-autogroup-internet.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["autogroup:member"],
+				"users":  ["autogroup:internet"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1052168206909879,
+				"StableID":   "ncTuT8gXD911CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1052168206909879,
+				"Key":        "nodekey:1e8a11f71ca86e206da21d01a7fcdccb6333db5850dd720a0af074795e0ef231",
+				"DiscoKey":   "discokey:42032608e02f123bd743aaf3d2dd576712df36a25c22b6ccee7c12c64b75cb40",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45235",
+					"10.65.0.27:45235",
+					"172.17.0.1:45235",
+					"172.18.0.1:45235",
+					"172.19.0.1:45235"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:00:28.625726675Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1e8a11f71ca86e206da21d01a7fcdccb6333db5850dd720a0af074795e0ef231",
+			"MachineKey": "mkey:053f30f5a089b453fa644c85fd3bc79c076f8d9630cef2bb0a8a434cbeb2ac4a",
+			"Peers": [{
+				"ID":         4495141380753413,
+				"StableID":   "nn5sv1kr6c11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:937530f808644d74694fae90ff94bca3eb2bfe885fe9352c67b711a6e07a2962",
+				"DiscoKey":   "discokey:f7b22608b81928325693a338c78ab912282d28b7ef42ad99c03ddc8c51adba53",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58185",
+					"10.65.0.27:58185",
+					"172.17.0.1:58185",
+					"172.18.0.1:58185",
+					"172.19.0.1:58185"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:00:17.947432139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1450381082602762,
+				"StableID":   "noh2gz3tKC11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eca4daa58421f834b68c9a1f924fdd344ec6b38086a555863fa36a9c5ab05266",
+				"DiscoKey":   "discokey:4e27b8354a1979df0dcb9971567a050eea2bdfa997ed02eaf45393d215eab85b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37127",
+					"10.65.0.27:37127",
+					"172.17.0.1:37127",
+					"172.18.0.1:37127",
+					"172.19.0.1:37127"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:00:18.447693816Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7932525158031531,
+				"StableID":   "ngTRZ7zew421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f91cade6a55dca0d2ebbfd3eb44bca69de98ace29c6a61f3d5b386b1e203d52e",
+				"DiscoKey":   "discokey:c6dd270f49e3cf172e986e92199ebe59698817971f3ac8e99b5fb72c91d9db48",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60525",
+					"10.65.0.27:60525",
+					"172.17.0.1:60525",
+					"172.18.0.1:60525",
+					"172.19.0.1:60525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:00:18.992377546Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1744935358783853,
+				"StableID":   "n4UWQbVHdE11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39c33009ab3818b705a57d56bbc3bfed8cc04c5ad8003ef051867b6a180ae458",
+				"DiscoKey":   "discokey:9750b4d6a4a394507fe0cc056489b48338ebcff60490fa271adab87e7cc8ac0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60603",
+					"10.65.0.27:60603",
+					"172.17.0.1:60603",
+					"172.18.0.1:60603",
+					"172.19.0.1:60603"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:00:19.527026241Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3398469095503197,
+				"StableID":   "n8rcTB2BYT11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5eea7f3d801991e6ae7926271e67490fc3ba774fe237cdf16327d575d458704e",
+				"DiscoKey":   "discokey:3dd5cdacf99bf4d963cb9e8c014b3ecf8161163e65ec50e37dcef1d529487450",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41878",
+					"10.65.0.27:41878",
+					"172.17.0.1:41878",
+					"172.18.0.1:41878",
+					"172.19.0.1:41878"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:00:20.080861296Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         234006431339882,
+				"StableID":   "n5iA2Exyp211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9ff433350b9968c07bf2605ae1e20bfefd83898f3c443e28aee1aa03a5e911c",
+				"DiscoKey":   "discokey:61843908a1d80f24781056b259ceae421ead777674dfd73ff098f5e40140980c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33221",
+					"10.65.0.27:33221",
+					"172.17.0.1:33221",
+					"172.18.0.1:33221",
+					"172.19.0.1:33221"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:00:20.613506288Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8423653745613238,
+				"StableID":   "noT44o66n821CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fad0d445f382d0ea31bba8afc8dcebcfaf40e5649d5d56abf4fc417c8b4b491b",
+				"DiscoKey":   "discokey:1e752cd529a9d64c0c84739e1503019d94e61a0152c7db05089642c7bfe86c17",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:39159",
+					"10.65.0.27:39159",
+					"172.17.0.1:39159",
+					"172.18.0.1:39159",
+					"172.19.0.1:39159"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:00:21.153149942Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1871679810150988,
+				"StableID":   "nPYHZargcF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:42c4c743b3ea12f8b86e55e3e7812733134fcabcaa1088940abddf5ab11fb434",
+				"DiscoKey":   "discokey:93a224207e16c646980487a32d015f027ec8bc84ab432aae2b9a08011acc5508",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45176",
+					"10.65.0.27:45176",
+					"172.17.0.1:45176",
+					"172.18.0.1:45176",
+					"172.19.0.1:45176"
+				],
+				"HomeDERP": 26,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:00:21.698143017Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4688437038264628,
+				"StableID":   "n9bqGsHQcd11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5740aa576367dce684ccee8be668840239ac24242a0b17e1b81b1fe9e703ac0d",
+				"DiscoKey":   "discokey:e2d2805ebe9114b0cbe5448f14191545652a129f13a5d2501388933b43996a15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41382",
+					"10.65.0.27:41382",
+					"172.17.0.1:41382",
+					"172.18.0.1:41382",
+					"172.19.0.1:41382"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:00:27.038567415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1063858269025390,
+				"StableID":   "ndktDfkpJ911CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86c332f64a9788d7b8275681c5379860d74dbdf5179822edc1bcdb891147432b",
+				"DiscoKey":   "discokey:05db89891926fbb9003e89bba8e1826b090c19b884c8fbb712d83eae09833b13",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44026",
+					"10.65.0.27:44026",
+					"172.17.0.1:44026",
+					"172.18.0.1:44026",
+					"172.19.0.1:44026"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:00:27.542246825Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1684851920459780,
+				"StableID":   "n1HzhmC5AE11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:272e170e0da4ec5bffc2432e83a4b0758830316bf5860d8a6ad6e76e47781310",
+				"DiscoKey":   "discokey:75035dcf3c2ec40bbe87e24023f5da381a212fc73c337d1a71f53dc7e698b114",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56041",
+					"10.65.0.27:56041",
+					"172.17.0.1:56041",
+					"172.18.0.1:56041",
+					"172.19.0.1:56041"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:00:28.087136807Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4183537695037414,
+				"StableID":   "nm61GbSjfZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d665aa77c2e820cff31f080fa005082635b770a80633013a058e249ee38f074f",
+				"KeyExpiry":  "2026-11-08T22:00:29Z",
+				"DiscoKey":   "discokey:9cc96cef8fb25f68168ef23823b632532dc430c723f79f4f5f7e7c37d95d8146",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:37119",
+					"10.65.0.27:37119",
+					"172.17.0.1:37119",
+					"172.18.0.1:37119",
+					"172.19.0.1:37119"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:00:29.177641043Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6566737788524804,
+				"StableID":   "n7Wpdr46Ht11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:4753793038a82d7abd75c3267f95ab0ee1f8da6f46534764864aa30533e7184a",
+				"KeyExpiry":  "2026-11-08T22:00:29Z",
+				"DiscoKey":   "discokey:8581a18a51a3a7b18d3a1945e3238fa89f6828004b36050f293911f831806133",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60838",
+					"10.65.0.27:60838",
+					"172.17.0.1:60838",
+					"172.18.0.1:60838",
+					"172.19.0.1:60838"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:00:29.708221603Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3184032635943231,
+				"StableID":   "nLjBq194sR11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ba5c31084b83e39f24a466d2642f5cb4796cd2acde55ea2c20dad4a4824fc659",
+				"KeyExpiry":  "2026-11-08T22:00:30Z",
+				"DiscoKey":   "discokey:5c52cbb125ffb7b792638d0dc37bee23f8dd583bb595865cc72265f5cc75c602",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:32969",
+					"10.65.0.27:32969",
+					"172.17.0.1:32969",
+					"172.18.0.1:32969",
+					"172.19.0.1:32969"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:00:30.248951131Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{
+				"principals": [
+					{"nodeIP": "100.64.0.17"},
+					{"nodeIP": "100.64.0.18"},
+					{"nodeIP": "100.64.0.19"},
+					{"nodeIP": "fd7a:115c:a1e0::12"},
+					{"nodeIP": "fd7a:115c:a1e0::13"},
+					{"nodeIP": "fd7a:115c:a1e0::11"}
+				],
+				"sshUsers": {"autogroup:internet": "autogroup:internet", "root": ""},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				}
+			}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1052168206909879": {
+				"ID":          1052168206909879,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		},
+		"ssh_rules": [{
+			"principals": [
+				{"nodeIP": "100.64.0.17"},
+				{"nodeIP": "100.64.0.18"},
+				{"nodeIP": "100.64.0.19"},
+				{"nodeIP": "fd7a:115c:a1e0::12"},
+				{"nodeIP": "fd7a:115c:a1e0::13"},
+				{"nodeIP": "fd7a:115c:a1e0::11"}
+			],
+			"sshUsers": {"autogroup:internet": "autogroup:internet", "root": ""},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}
+		}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         234006431339882,
+				"StableID":   "n5iA2Exyp211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       234006431339882,
+				"Key":        "nodekey:b9ff433350b9968c07bf2605ae1e20bfefd83898f3c443e28aee1aa03a5e911c",
+				"DiscoKey":   "discokey:61843908a1d80f24781056b259ceae421ead777674dfd73ff098f5e40140980c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33221",
+					"10.65.0.27:33221",
+					"172.17.0.1:33221",
+					"172.18.0.1:33221",
+					"172.19.0.1:33221"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:00:20.613506288Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b9ff433350b9968c07bf2605ae1e20bfefd83898f3c443e28aee1aa03a5e911c",
+			"MachineKey": "mkey:fc4d50baca3e0a9fcead6b9da073f7c2173d53b2d7a122a84791da62eccad62f",
+			"Peers": [{
+				"ID":         4495141380753413,
+				"StableID":   "nn5sv1kr6c11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:937530f808644d74694fae90ff94bca3eb2bfe885fe9352c67b711a6e07a2962",
+				"DiscoKey":   "discokey:f7b22608b81928325693a338c78ab912282d28b7ef42ad99c03ddc8c51adba53",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58185",
+					"10.65.0.27:58185",
+					"172.17.0.1:58185",
+					"172.18.0.1:58185",
+					"172.19.0.1:58185"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:00:17.947432139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1450381082602762,
+				"StableID":   "noh2gz3tKC11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eca4daa58421f834b68c9a1f924fdd344ec6b38086a555863fa36a9c5ab05266",
+				"DiscoKey":   "discokey:4e27b8354a1979df0dcb9971567a050eea2bdfa997ed02eaf45393d215eab85b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37127",
+					"10.65.0.27:37127",
+					"172.17.0.1:37127",
+					"172.18.0.1:37127",
+					"172.19.0.1:37127"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:00:18.447693816Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7932525158031531,
+				"StableID":   "ngTRZ7zew421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f91cade6a55dca0d2ebbfd3eb44bca69de98ace29c6a61f3d5b386b1e203d52e",
+				"DiscoKey":   "discokey:c6dd270f49e3cf172e986e92199ebe59698817971f3ac8e99b5fb72c91d9db48",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60525",
+					"10.65.0.27:60525",
+					"172.17.0.1:60525",
+					"172.18.0.1:60525",
+					"172.19.0.1:60525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:00:18.992377546Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1744935358783853,
+				"StableID":   "n4UWQbVHdE11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39c33009ab3818b705a57d56bbc3bfed8cc04c5ad8003ef051867b6a180ae458",
+				"DiscoKey":   "discokey:9750b4d6a4a394507fe0cc056489b48338ebcff60490fa271adab87e7cc8ac0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60603",
+					"10.65.0.27:60603",
+					"172.17.0.1:60603",
+					"172.18.0.1:60603",
+					"172.19.0.1:60603"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:00:19.527026241Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3398469095503197,
+				"StableID":   "n8rcTB2BYT11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5eea7f3d801991e6ae7926271e67490fc3ba774fe237cdf16327d575d458704e",
+				"DiscoKey":   "discokey:3dd5cdacf99bf4d963cb9e8c014b3ecf8161163e65ec50e37dcef1d529487450",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41878",
+					"10.65.0.27:41878",
+					"172.17.0.1:41878",
+					"172.18.0.1:41878",
+					"172.19.0.1:41878"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:00:20.080861296Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8423653745613238,
+				"StableID":   "noT44o66n821CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fad0d445f382d0ea31bba8afc8dcebcfaf40e5649d5d56abf4fc417c8b4b491b",
+				"DiscoKey":   "discokey:1e752cd529a9d64c0c84739e1503019d94e61a0152c7db05089642c7bfe86c17",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:39159",
+					"10.65.0.27:39159",
+					"172.17.0.1:39159",
+					"172.18.0.1:39159",
+					"172.19.0.1:39159"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:00:21.153149942Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1871679810150988,
+				"StableID":   "nPYHZargcF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:42c4c743b3ea12f8b86e55e3e7812733134fcabcaa1088940abddf5ab11fb434",
+				"DiscoKey":   "discokey:93a224207e16c646980487a32d015f027ec8bc84ab432aae2b9a08011acc5508",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45176",
+					"10.65.0.27:45176",
+					"172.17.0.1:45176",
+					"172.18.0.1:45176",
+					"172.19.0.1:45176"
+				],
+				"HomeDERP": 26,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:00:21.698143017Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4688437038264628,
+				"StableID":   "n9bqGsHQcd11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5740aa576367dce684ccee8be668840239ac24242a0b17e1b81b1fe9e703ac0d",
+				"DiscoKey":   "discokey:e2d2805ebe9114b0cbe5448f14191545652a129f13a5d2501388933b43996a15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41382",
+					"10.65.0.27:41382",
+					"172.17.0.1:41382",
+					"172.18.0.1:41382",
+					"172.19.0.1:41382"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:00:27.038567415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1063858269025390,
+				"StableID":   "ndktDfkpJ911CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86c332f64a9788d7b8275681c5379860d74dbdf5179822edc1bcdb891147432b",
+				"DiscoKey":   "discokey:05db89891926fbb9003e89bba8e1826b090c19b884c8fbb712d83eae09833b13",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44026",
+					"10.65.0.27:44026",
+					"172.17.0.1:44026",
+					"172.18.0.1:44026",
+					"172.19.0.1:44026"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:00:27.542246825Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1684851920459780,
+				"StableID":   "n1HzhmC5AE11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:272e170e0da4ec5bffc2432e83a4b0758830316bf5860d8a6ad6e76e47781310",
+				"DiscoKey":   "discokey:75035dcf3c2ec40bbe87e24023f5da381a212fc73c337d1a71f53dc7e698b114",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56041",
+					"10.65.0.27:56041",
+					"172.17.0.1:56041",
+					"172.18.0.1:56041",
+					"172.19.0.1:56041"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:00:28.087136807Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1052168206909879,
+				"StableID":   "ncTuT8gXD911CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1e8a11f71ca86e206da21d01a7fcdccb6333db5850dd720a0af074795e0ef231",
+				"DiscoKey":   "discokey:42032608e02f123bd743aaf3d2dd576712df36a25c22b6ccee7c12c64b75cb40",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45235",
+					"10.65.0.27:45235",
+					"172.17.0.1:45235",
+					"172.18.0.1:45235",
+					"172.19.0.1:45235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:00:28.625726675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4183537695037414,
+				"StableID":   "nm61GbSjfZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d665aa77c2e820cff31f080fa005082635b770a80633013a058e249ee38f074f",
+				"KeyExpiry":  "2026-11-08T22:00:29Z",
+				"DiscoKey":   "discokey:9cc96cef8fb25f68168ef23823b632532dc430c723f79f4f5f7e7c37d95d8146",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:37119",
+					"10.65.0.27:37119",
+					"172.17.0.1:37119",
+					"172.18.0.1:37119",
+					"172.19.0.1:37119"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:00:29.177641043Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6566737788524804,
+				"StableID":   "n7Wpdr46Ht11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:4753793038a82d7abd75c3267f95ab0ee1f8da6f46534764864aa30533e7184a",
+				"KeyExpiry":  "2026-11-08T22:00:29Z",
+				"DiscoKey":   "discokey:8581a18a51a3a7b18d3a1945e3238fa89f6828004b36050f293911f831806133",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60838",
+					"10.65.0.27:60838",
+					"172.17.0.1:60838",
+					"172.18.0.1:60838",
+					"172.19.0.1:60838"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:00:29.708221603Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3184032635943231,
+				"StableID":   "nLjBq194sR11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ba5c31084b83e39f24a466d2642f5cb4796cd2acde55ea2c20dad4a4824fc659",
+				"KeyExpiry":  "2026-11-08T22:00:30Z",
+				"DiscoKey":   "discokey:5c52cbb125ffb7b792638d0dc37bee23f8dd583bb595865cc72265f5cc75c602",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:32969",
+					"10.65.0.27:32969",
+					"172.17.0.1:32969",
+					"172.18.0.1:32969",
+					"172.19.0.1:32969"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:00:30.248951131Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "234006431339882": {
+				"ID":          234006431339882,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3184032635943231,
+				"StableID":   "nLjBq194sR11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ba5c31084b83e39f24a466d2642f5cb4796cd2acde55ea2c20dad4a4824fc659",
+				"KeyExpiry":  "2026-11-08T22:00:30Z",
+				"DiscoKey":   "discokey:5c52cbb125ffb7b792638d0dc37bee23f8dd583bb595865cc72265f5cc75c602",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:32969",
+					"10.65.0.27:32969",
+					"172.17.0.1:32969",
+					"172.18.0.1:32969",
+					"172.19.0.1:32969"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:00:30.248951131Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ba5c31084b83e39f24a466d2642f5cb4796cd2acde55ea2c20dad4a4824fc659",
+			"MachineKey": "mkey:3b24dae0897de4ac6b76e0404d1ddb6a5e97f4b0d9650c5d643059f9fb74fa7c",
+			"Peers": [{
+				"ID":         4495141380753413,
+				"StableID":   "nn5sv1kr6c11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:937530f808644d74694fae90ff94bca3eb2bfe885fe9352c67b711a6e07a2962",
+				"DiscoKey":   "discokey:f7b22608b81928325693a338c78ab912282d28b7ef42ad99c03ddc8c51adba53",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58185",
+					"10.65.0.27:58185",
+					"172.17.0.1:58185",
+					"172.18.0.1:58185",
+					"172.19.0.1:58185"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:00:17.947432139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1450381082602762,
+				"StableID":   "noh2gz3tKC11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eca4daa58421f834b68c9a1f924fdd344ec6b38086a555863fa36a9c5ab05266",
+				"DiscoKey":   "discokey:4e27b8354a1979df0dcb9971567a050eea2bdfa997ed02eaf45393d215eab85b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37127",
+					"10.65.0.27:37127",
+					"172.17.0.1:37127",
+					"172.18.0.1:37127",
+					"172.19.0.1:37127"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:00:18.447693816Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7932525158031531,
+				"StableID":   "ngTRZ7zew421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f91cade6a55dca0d2ebbfd3eb44bca69de98ace29c6a61f3d5b386b1e203d52e",
+				"DiscoKey":   "discokey:c6dd270f49e3cf172e986e92199ebe59698817971f3ac8e99b5fb72c91d9db48",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60525",
+					"10.65.0.27:60525",
+					"172.17.0.1:60525",
+					"172.18.0.1:60525",
+					"172.19.0.1:60525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:00:18.992377546Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1744935358783853,
+				"StableID":   "n4UWQbVHdE11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39c33009ab3818b705a57d56bbc3bfed8cc04c5ad8003ef051867b6a180ae458",
+				"DiscoKey":   "discokey:9750b4d6a4a394507fe0cc056489b48338ebcff60490fa271adab87e7cc8ac0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60603",
+					"10.65.0.27:60603",
+					"172.17.0.1:60603",
+					"172.18.0.1:60603",
+					"172.19.0.1:60603"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:00:19.527026241Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3398469095503197,
+				"StableID":   "n8rcTB2BYT11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5eea7f3d801991e6ae7926271e67490fc3ba774fe237cdf16327d575d458704e",
+				"DiscoKey":   "discokey:3dd5cdacf99bf4d963cb9e8c014b3ecf8161163e65ec50e37dcef1d529487450",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41878",
+					"10.65.0.27:41878",
+					"172.17.0.1:41878",
+					"172.18.0.1:41878",
+					"172.19.0.1:41878"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:00:20.080861296Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         234006431339882,
+				"StableID":   "n5iA2Exyp211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9ff433350b9968c07bf2605ae1e20bfefd83898f3c443e28aee1aa03a5e911c",
+				"DiscoKey":   "discokey:61843908a1d80f24781056b259ceae421ead777674dfd73ff098f5e40140980c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33221",
+					"10.65.0.27:33221",
+					"172.17.0.1:33221",
+					"172.18.0.1:33221",
+					"172.19.0.1:33221"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:00:20.613506288Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8423653745613238,
+				"StableID":   "noT44o66n821CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fad0d445f382d0ea31bba8afc8dcebcfaf40e5649d5d56abf4fc417c8b4b491b",
+				"DiscoKey":   "discokey:1e752cd529a9d64c0c84739e1503019d94e61a0152c7db05089642c7bfe86c17",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:39159",
+					"10.65.0.27:39159",
+					"172.17.0.1:39159",
+					"172.18.0.1:39159",
+					"172.19.0.1:39159"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:00:21.153149942Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1871679810150988,
+				"StableID":   "nPYHZargcF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:42c4c743b3ea12f8b86e55e3e7812733134fcabcaa1088940abddf5ab11fb434",
+				"DiscoKey":   "discokey:93a224207e16c646980487a32d015f027ec8bc84ab432aae2b9a08011acc5508",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45176",
+					"10.65.0.27:45176",
+					"172.17.0.1:45176",
+					"172.18.0.1:45176",
+					"172.19.0.1:45176"
+				],
+				"HomeDERP": 26,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:00:21.698143017Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4688437038264628,
+				"StableID":   "n9bqGsHQcd11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5740aa576367dce684ccee8be668840239ac24242a0b17e1b81b1fe9e703ac0d",
+				"DiscoKey":   "discokey:e2d2805ebe9114b0cbe5448f14191545652a129f13a5d2501388933b43996a15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41382",
+					"10.65.0.27:41382",
+					"172.17.0.1:41382",
+					"172.18.0.1:41382",
+					"172.19.0.1:41382"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:00:27.038567415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1063858269025390,
+				"StableID":   "ndktDfkpJ911CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86c332f64a9788d7b8275681c5379860d74dbdf5179822edc1bcdb891147432b",
+				"DiscoKey":   "discokey:05db89891926fbb9003e89bba8e1826b090c19b884c8fbb712d83eae09833b13",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44026",
+					"10.65.0.27:44026",
+					"172.17.0.1:44026",
+					"172.18.0.1:44026",
+					"172.19.0.1:44026"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:00:27.542246825Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1684851920459780,
+				"StableID":   "n1HzhmC5AE11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:272e170e0da4ec5bffc2432e83a4b0758830316bf5860d8a6ad6e76e47781310",
+				"DiscoKey":   "discokey:75035dcf3c2ec40bbe87e24023f5da381a212fc73c337d1a71f53dc7e698b114",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56041",
+					"10.65.0.27:56041",
+					"172.17.0.1:56041",
+					"172.18.0.1:56041",
+					"172.19.0.1:56041"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:00:28.087136807Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1052168206909879,
+				"StableID":   "ncTuT8gXD911CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1e8a11f71ca86e206da21d01a7fcdccb6333db5850dd720a0af074795e0ef231",
+				"DiscoKey":   "discokey:42032608e02f123bd743aaf3d2dd576712df36a25c22b6ccee7c12c64b75cb40",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45235",
+					"10.65.0.27:45235",
+					"172.17.0.1:45235",
+					"172.18.0.1:45235",
+					"172.19.0.1:45235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:00:28.625726675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4183537695037414,
+				"StableID":   "nm61GbSjfZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d665aa77c2e820cff31f080fa005082635b770a80633013a058e249ee38f074f",
+				"KeyExpiry":  "2026-11-08T22:00:29Z",
+				"DiscoKey":   "discokey:9cc96cef8fb25f68168ef23823b632532dc430c723f79f4f5f7e7c37d95d8146",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:37119",
+					"10.65.0.27:37119",
+					"172.17.0.1:37119",
+					"172.18.0.1:37119",
+					"172.19.0.1:37119"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:00:29.177641043Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6566737788524804,
+				"StableID":   "n7Wpdr46Ht11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:4753793038a82d7abd75c3267f95ab0ee1f8da6f46534764864aa30533e7184a",
+				"KeyExpiry":  "2026-11-08T22:00:29Z",
+				"DiscoKey":   "discokey:8581a18a51a3a7b18d3a1945e3238fa89f6828004b36050f293911f831806133",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60838",
+					"10.65.0.27:60838",
+					"172.17.0.1:60838",
+					"172.18.0.1:60838",
+					"172.19.0.1:60838"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:00:29.708221603Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7932525158031531,
+				"StableID":   "ngTRZ7zew421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       7932525158031531,
+				"Key":        "nodekey:f91cade6a55dca0d2ebbfd3eb44bca69de98ace29c6a61f3d5b386b1e203d52e",
+				"DiscoKey":   "discokey:c6dd270f49e3cf172e986e92199ebe59698817971f3ac8e99b5fb72c91d9db48",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60525",
+					"10.65.0.27:60525",
+					"172.17.0.1:60525",
+					"172.18.0.1:60525",
+					"172.19.0.1:60525"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:00:18.992377546Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f91cade6a55dca0d2ebbfd3eb44bca69de98ace29c6a61f3d5b386b1e203d52e",
+			"MachineKey": "mkey:3f40ca1bfe2209c67b81f6786a496992ee59642abdd50441c28edab237c42042",
+			"Peers": [{
+				"ID":         4495141380753413,
+				"StableID":   "nn5sv1kr6c11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:937530f808644d74694fae90ff94bca3eb2bfe885fe9352c67b711a6e07a2962",
+				"DiscoKey":   "discokey:f7b22608b81928325693a338c78ab912282d28b7ef42ad99c03ddc8c51adba53",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58185",
+					"10.65.0.27:58185",
+					"172.17.0.1:58185",
+					"172.18.0.1:58185",
+					"172.19.0.1:58185"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:00:17.947432139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1450381082602762,
+				"StableID":   "noh2gz3tKC11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eca4daa58421f834b68c9a1f924fdd344ec6b38086a555863fa36a9c5ab05266",
+				"DiscoKey":   "discokey:4e27b8354a1979df0dcb9971567a050eea2bdfa997ed02eaf45393d215eab85b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37127",
+					"10.65.0.27:37127",
+					"172.17.0.1:37127",
+					"172.18.0.1:37127",
+					"172.19.0.1:37127"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:00:18.447693816Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1744935358783853,
+				"StableID":   "n4UWQbVHdE11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39c33009ab3818b705a57d56bbc3bfed8cc04c5ad8003ef051867b6a180ae458",
+				"DiscoKey":   "discokey:9750b4d6a4a394507fe0cc056489b48338ebcff60490fa271adab87e7cc8ac0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60603",
+					"10.65.0.27:60603",
+					"172.17.0.1:60603",
+					"172.18.0.1:60603",
+					"172.19.0.1:60603"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:00:19.527026241Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3398469095503197,
+				"StableID":   "n8rcTB2BYT11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5eea7f3d801991e6ae7926271e67490fc3ba774fe237cdf16327d575d458704e",
+				"DiscoKey":   "discokey:3dd5cdacf99bf4d963cb9e8c014b3ecf8161163e65ec50e37dcef1d529487450",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41878",
+					"10.65.0.27:41878",
+					"172.17.0.1:41878",
+					"172.18.0.1:41878",
+					"172.19.0.1:41878"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:00:20.080861296Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         234006431339882,
+				"StableID":   "n5iA2Exyp211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9ff433350b9968c07bf2605ae1e20bfefd83898f3c443e28aee1aa03a5e911c",
+				"DiscoKey":   "discokey:61843908a1d80f24781056b259ceae421ead777674dfd73ff098f5e40140980c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33221",
+					"10.65.0.27:33221",
+					"172.17.0.1:33221",
+					"172.18.0.1:33221",
+					"172.19.0.1:33221"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:00:20.613506288Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8423653745613238,
+				"StableID":   "noT44o66n821CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fad0d445f382d0ea31bba8afc8dcebcfaf40e5649d5d56abf4fc417c8b4b491b",
+				"DiscoKey":   "discokey:1e752cd529a9d64c0c84739e1503019d94e61a0152c7db05089642c7bfe86c17",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:39159",
+					"10.65.0.27:39159",
+					"172.17.0.1:39159",
+					"172.18.0.1:39159",
+					"172.19.0.1:39159"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:00:21.153149942Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1871679810150988,
+				"StableID":   "nPYHZargcF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:42c4c743b3ea12f8b86e55e3e7812733134fcabcaa1088940abddf5ab11fb434",
+				"DiscoKey":   "discokey:93a224207e16c646980487a32d015f027ec8bc84ab432aae2b9a08011acc5508",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45176",
+					"10.65.0.27:45176",
+					"172.17.0.1:45176",
+					"172.18.0.1:45176",
+					"172.19.0.1:45176"
+				],
+				"HomeDERP": 26,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:00:21.698143017Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4688437038264628,
+				"StableID":   "n9bqGsHQcd11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5740aa576367dce684ccee8be668840239ac24242a0b17e1b81b1fe9e703ac0d",
+				"DiscoKey":   "discokey:e2d2805ebe9114b0cbe5448f14191545652a129f13a5d2501388933b43996a15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41382",
+					"10.65.0.27:41382",
+					"172.17.0.1:41382",
+					"172.18.0.1:41382",
+					"172.19.0.1:41382"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:00:27.038567415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1063858269025390,
+				"StableID":   "ndktDfkpJ911CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86c332f64a9788d7b8275681c5379860d74dbdf5179822edc1bcdb891147432b",
+				"DiscoKey":   "discokey:05db89891926fbb9003e89bba8e1826b090c19b884c8fbb712d83eae09833b13",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44026",
+					"10.65.0.27:44026",
+					"172.17.0.1:44026",
+					"172.18.0.1:44026",
+					"172.19.0.1:44026"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:00:27.542246825Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1684851920459780,
+				"StableID":   "n1HzhmC5AE11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:272e170e0da4ec5bffc2432e83a4b0758830316bf5860d8a6ad6e76e47781310",
+				"DiscoKey":   "discokey:75035dcf3c2ec40bbe87e24023f5da381a212fc73c337d1a71f53dc7e698b114",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56041",
+					"10.65.0.27:56041",
+					"172.17.0.1:56041",
+					"172.18.0.1:56041",
+					"172.19.0.1:56041"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:00:28.087136807Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1052168206909879,
+				"StableID":   "ncTuT8gXD911CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1e8a11f71ca86e206da21d01a7fcdccb6333db5850dd720a0af074795e0ef231",
+				"DiscoKey":   "discokey:42032608e02f123bd743aaf3d2dd576712df36a25c22b6ccee7c12c64b75cb40",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45235",
+					"10.65.0.27:45235",
+					"172.17.0.1:45235",
+					"172.18.0.1:45235",
+					"172.19.0.1:45235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:00:28.625726675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4183537695037414,
+				"StableID":   "nm61GbSjfZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d665aa77c2e820cff31f080fa005082635b770a80633013a058e249ee38f074f",
+				"KeyExpiry":  "2026-11-08T22:00:29Z",
+				"DiscoKey":   "discokey:9cc96cef8fb25f68168ef23823b632532dc430c723f79f4f5f7e7c37d95d8146",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:37119",
+					"10.65.0.27:37119",
+					"172.17.0.1:37119",
+					"172.18.0.1:37119",
+					"172.19.0.1:37119"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:00:29.177641043Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6566737788524804,
+				"StableID":   "n7Wpdr46Ht11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:4753793038a82d7abd75c3267f95ab0ee1f8da6f46534764864aa30533e7184a",
+				"KeyExpiry":  "2026-11-08T22:00:29Z",
+				"DiscoKey":   "discokey:8581a18a51a3a7b18d3a1945e3238fa89f6828004b36050f293911f831806133",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60838",
+					"10.65.0.27:60838",
+					"172.17.0.1:60838",
+					"172.18.0.1:60838",
+					"172.19.0.1:60838"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:00:29.708221603Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3184032635943231,
+				"StableID":   "nLjBq194sR11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ba5c31084b83e39f24a466d2642f5cb4796cd2acde55ea2c20dad4a4824fc659",
+				"KeyExpiry":  "2026-11-08T22:00:30Z",
+				"DiscoKey":   "discokey:5c52cbb125ffb7b792638d0dc37bee23f8dd583bb595865cc72265f5cc75c602",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:32969",
+					"10.65.0.27:32969",
+					"172.17.0.1:32969",
+					"172.18.0.1:32969",
+					"172.19.0.1:32969"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:00:30.248951131Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7932525158031531": {
+				"ID":          7932525158031531,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1871679810150988,
+				"StableID":   "nPYHZargcF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1871679810150988,
+				"Key":        "nodekey:42c4c743b3ea12f8b86e55e3e7812733134fcabcaa1088940abddf5ab11fb434",
+				"DiscoKey":   "discokey:93a224207e16c646980487a32d015f027ec8bc84ab432aae2b9a08011acc5508",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45176",
+					"10.65.0.27:45176",
+					"172.17.0.1:45176",
+					"172.18.0.1:45176",
+					"172.19.0.1:45176"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:00:21.698143017Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:42c4c743b3ea12f8b86e55e3e7812733134fcabcaa1088940abddf5ab11fb434",
+			"MachineKey": "mkey:dd894d441c62b5549b2e6221be5ac3c820b5f04a647be637e6f3a65ed345fa49",
+			"Peers": [{
+				"ID":         4495141380753413,
+				"StableID":   "nn5sv1kr6c11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:937530f808644d74694fae90ff94bca3eb2bfe885fe9352c67b711a6e07a2962",
+				"DiscoKey":   "discokey:f7b22608b81928325693a338c78ab912282d28b7ef42ad99c03ddc8c51adba53",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58185",
+					"10.65.0.27:58185",
+					"172.17.0.1:58185",
+					"172.18.0.1:58185",
+					"172.19.0.1:58185"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:00:17.947432139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1450381082602762,
+				"StableID":   "noh2gz3tKC11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eca4daa58421f834b68c9a1f924fdd344ec6b38086a555863fa36a9c5ab05266",
+				"DiscoKey":   "discokey:4e27b8354a1979df0dcb9971567a050eea2bdfa997ed02eaf45393d215eab85b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37127",
+					"10.65.0.27:37127",
+					"172.17.0.1:37127",
+					"172.18.0.1:37127",
+					"172.19.0.1:37127"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:00:18.447693816Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7932525158031531,
+				"StableID":   "ngTRZ7zew421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f91cade6a55dca0d2ebbfd3eb44bca69de98ace29c6a61f3d5b386b1e203d52e",
+				"DiscoKey":   "discokey:c6dd270f49e3cf172e986e92199ebe59698817971f3ac8e99b5fb72c91d9db48",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60525",
+					"10.65.0.27:60525",
+					"172.17.0.1:60525",
+					"172.18.0.1:60525",
+					"172.19.0.1:60525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:00:18.992377546Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1744935358783853,
+				"StableID":   "n4UWQbVHdE11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39c33009ab3818b705a57d56bbc3bfed8cc04c5ad8003ef051867b6a180ae458",
+				"DiscoKey":   "discokey:9750b4d6a4a394507fe0cc056489b48338ebcff60490fa271adab87e7cc8ac0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60603",
+					"10.65.0.27:60603",
+					"172.17.0.1:60603",
+					"172.18.0.1:60603",
+					"172.19.0.1:60603"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:00:19.527026241Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3398469095503197,
+				"StableID":   "n8rcTB2BYT11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5eea7f3d801991e6ae7926271e67490fc3ba774fe237cdf16327d575d458704e",
+				"DiscoKey":   "discokey:3dd5cdacf99bf4d963cb9e8c014b3ecf8161163e65ec50e37dcef1d529487450",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41878",
+					"10.65.0.27:41878",
+					"172.17.0.1:41878",
+					"172.18.0.1:41878",
+					"172.19.0.1:41878"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:00:20.080861296Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         234006431339882,
+				"StableID":   "n5iA2Exyp211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9ff433350b9968c07bf2605ae1e20bfefd83898f3c443e28aee1aa03a5e911c",
+				"DiscoKey":   "discokey:61843908a1d80f24781056b259ceae421ead777674dfd73ff098f5e40140980c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33221",
+					"10.65.0.27:33221",
+					"172.17.0.1:33221",
+					"172.18.0.1:33221",
+					"172.19.0.1:33221"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:00:20.613506288Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8423653745613238,
+				"StableID":   "noT44o66n821CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fad0d445f382d0ea31bba8afc8dcebcfaf40e5649d5d56abf4fc417c8b4b491b",
+				"DiscoKey":   "discokey:1e752cd529a9d64c0c84739e1503019d94e61a0152c7db05089642c7bfe86c17",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:39159",
+					"10.65.0.27:39159",
+					"172.17.0.1:39159",
+					"172.18.0.1:39159",
+					"172.19.0.1:39159"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:00:21.153149942Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4688437038264628,
+				"StableID":   "n9bqGsHQcd11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5740aa576367dce684ccee8be668840239ac24242a0b17e1b81b1fe9e703ac0d",
+				"DiscoKey":   "discokey:e2d2805ebe9114b0cbe5448f14191545652a129f13a5d2501388933b43996a15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41382",
+					"10.65.0.27:41382",
+					"172.17.0.1:41382",
+					"172.18.0.1:41382",
+					"172.19.0.1:41382"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:00:27.038567415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1063858269025390,
+				"StableID":   "ndktDfkpJ911CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86c332f64a9788d7b8275681c5379860d74dbdf5179822edc1bcdb891147432b",
+				"DiscoKey":   "discokey:05db89891926fbb9003e89bba8e1826b090c19b884c8fbb712d83eae09833b13",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44026",
+					"10.65.0.27:44026",
+					"172.17.0.1:44026",
+					"172.18.0.1:44026",
+					"172.19.0.1:44026"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:00:27.542246825Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1684851920459780,
+				"StableID":   "n1HzhmC5AE11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:272e170e0da4ec5bffc2432e83a4b0758830316bf5860d8a6ad6e76e47781310",
+				"DiscoKey":   "discokey:75035dcf3c2ec40bbe87e24023f5da381a212fc73c337d1a71f53dc7e698b114",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56041",
+					"10.65.0.27:56041",
+					"172.17.0.1:56041",
+					"172.18.0.1:56041",
+					"172.19.0.1:56041"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:00:28.087136807Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1052168206909879,
+				"StableID":   "ncTuT8gXD911CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1e8a11f71ca86e206da21d01a7fcdccb6333db5850dd720a0af074795e0ef231",
+				"DiscoKey":   "discokey:42032608e02f123bd743aaf3d2dd576712df36a25c22b6ccee7c12c64b75cb40",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45235",
+					"10.65.0.27:45235",
+					"172.17.0.1:45235",
+					"172.18.0.1:45235",
+					"172.19.0.1:45235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:00:28.625726675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4183537695037414,
+				"StableID":   "nm61GbSjfZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d665aa77c2e820cff31f080fa005082635b770a80633013a058e249ee38f074f",
+				"KeyExpiry":  "2026-11-08T22:00:29Z",
+				"DiscoKey":   "discokey:9cc96cef8fb25f68168ef23823b632532dc430c723f79f4f5f7e7c37d95d8146",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:37119",
+					"10.65.0.27:37119",
+					"172.17.0.1:37119",
+					"172.18.0.1:37119",
+					"172.19.0.1:37119"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:00:29.177641043Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6566737788524804,
+				"StableID":   "n7Wpdr46Ht11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:4753793038a82d7abd75c3267f95ab0ee1f8da6f46534764864aa30533e7184a",
+				"KeyExpiry":  "2026-11-08T22:00:29Z",
+				"DiscoKey":   "discokey:8581a18a51a3a7b18d3a1945e3238fa89f6828004b36050f293911f831806133",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60838",
+					"10.65.0.27:60838",
+					"172.17.0.1:60838",
+					"172.18.0.1:60838",
+					"172.19.0.1:60838"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:00:29.708221603Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3184032635943231,
+				"StableID":   "nLjBq194sR11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ba5c31084b83e39f24a466d2642f5cb4796cd2acde55ea2c20dad4a4824fc659",
+				"KeyExpiry":  "2026-11-08T22:00:30Z",
+				"DiscoKey":   "discokey:5c52cbb125ffb7b792638d0dc37bee23f8dd583bb595865cc72265f5cc75c602",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:32969",
+					"10.65.0.27:32969",
+					"172.17.0.1:32969",
+					"172.18.0.1:32969",
+					"172.19.0.1:32969"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:00:30.248951131Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1871679810150988": {
+				"ID":          1871679810150988,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4183537695037414,
+				"StableID":   "nm61GbSjfZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d665aa77c2e820cff31f080fa005082635b770a80633013a058e249ee38f074f",
+				"KeyExpiry":  "2026-11-08T22:00:29Z",
+				"DiscoKey":   "discokey:9cc96cef8fb25f68168ef23823b632532dc430c723f79f4f5f7e7c37d95d8146",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:37119",
+					"10.65.0.27:37119",
+					"172.17.0.1:37119",
+					"172.18.0.1:37119",
+					"172.19.0.1:37119"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:00:29.177641043Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d665aa77c2e820cff31f080fa005082635b770a80633013a058e249ee38f074f",
+			"MachineKey": "mkey:c45cbee39068658988190598e0befaa2c347572d88fb440b25a3f3adf1438743",
+			"Peers": [{
+				"ID":         4495141380753413,
+				"StableID":   "nn5sv1kr6c11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:937530f808644d74694fae90ff94bca3eb2bfe885fe9352c67b711a6e07a2962",
+				"DiscoKey":   "discokey:f7b22608b81928325693a338c78ab912282d28b7ef42ad99c03ddc8c51adba53",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58185",
+					"10.65.0.27:58185",
+					"172.17.0.1:58185",
+					"172.18.0.1:58185",
+					"172.19.0.1:58185"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:00:17.947432139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1450381082602762,
+				"StableID":   "noh2gz3tKC11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eca4daa58421f834b68c9a1f924fdd344ec6b38086a555863fa36a9c5ab05266",
+				"DiscoKey":   "discokey:4e27b8354a1979df0dcb9971567a050eea2bdfa997ed02eaf45393d215eab85b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37127",
+					"10.65.0.27:37127",
+					"172.17.0.1:37127",
+					"172.18.0.1:37127",
+					"172.19.0.1:37127"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:00:18.447693816Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7932525158031531,
+				"StableID":   "ngTRZ7zew421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f91cade6a55dca0d2ebbfd3eb44bca69de98ace29c6a61f3d5b386b1e203d52e",
+				"DiscoKey":   "discokey:c6dd270f49e3cf172e986e92199ebe59698817971f3ac8e99b5fb72c91d9db48",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60525",
+					"10.65.0.27:60525",
+					"172.17.0.1:60525",
+					"172.18.0.1:60525",
+					"172.19.0.1:60525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:00:18.992377546Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1744935358783853,
+				"StableID":   "n4UWQbVHdE11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39c33009ab3818b705a57d56bbc3bfed8cc04c5ad8003ef051867b6a180ae458",
+				"DiscoKey":   "discokey:9750b4d6a4a394507fe0cc056489b48338ebcff60490fa271adab87e7cc8ac0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60603",
+					"10.65.0.27:60603",
+					"172.17.0.1:60603",
+					"172.18.0.1:60603",
+					"172.19.0.1:60603"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:00:19.527026241Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3398469095503197,
+				"StableID":   "n8rcTB2BYT11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5eea7f3d801991e6ae7926271e67490fc3ba774fe237cdf16327d575d458704e",
+				"DiscoKey":   "discokey:3dd5cdacf99bf4d963cb9e8c014b3ecf8161163e65ec50e37dcef1d529487450",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41878",
+					"10.65.0.27:41878",
+					"172.17.0.1:41878",
+					"172.18.0.1:41878",
+					"172.19.0.1:41878"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:00:20.080861296Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         234006431339882,
+				"StableID":   "n5iA2Exyp211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9ff433350b9968c07bf2605ae1e20bfefd83898f3c443e28aee1aa03a5e911c",
+				"DiscoKey":   "discokey:61843908a1d80f24781056b259ceae421ead777674dfd73ff098f5e40140980c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33221",
+					"10.65.0.27:33221",
+					"172.17.0.1:33221",
+					"172.18.0.1:33221",
+					"172.19.0.1:33221"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:00:20.613506288Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8423653745613238,
+				"StableID":   "noT44o66n821CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fad0d445f382d0ea31bba8afc8dcebcfaf40e5649d5d56abf4fc417c8b4b491b",
+				"DiscoKey":   "discokey:1e752cd529a9d64c0c84739e1503019d94e61a0152c7db05089642c7bfe86c17",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:39159",
+					"10.65.0.27:39159",
+					"172.17.0.1:39159",
+					"172.18.0.1:39159",
+					"172.19.0.1:39159"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:00:21.153149942Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1871679810150988,
+				"StableID":   "nPYHZargcF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:42c4c743b3ea12f8b86e55e3e7812733134fcabcaa1088940abddf5ab11fb434",
+				"DiscoKey":   "discokey:93a224207e16c646980487a32d015f027ec8bc84ab432aae2b9a08011acc5508",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45176",
+					"10.65.0.27:45176",
+					"172.17.0.1:45176",
+					"172.18.0.1:45176",
+					"172.19.0.1:45176"
+				],
+				"HomeDERP": 26,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:00:21.698143017Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4688437038264628,
+				"StableID":   "n9bqGsHQcd11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5740aa576367dce684ccee8be668840239ac24242a0b17e1b81b1fe9e703ac0d",
+				"DiscoKey":   "discokey:e2d2805ebe9114b0cbe5448f14191545652a129f13a5d2501388933b43996a15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41382",
+					"10.65.0.27:41382",
+					"172.17.0.1:41382",
+					"172.18.0.1:41382",
+					"172.19.0.1:41382"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:00:27.038567415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1063858269025390,
+				"StableID":   "ndktDfkpJ911CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86c332f64a9788d7b8275681c5379860d74dbdf5179822edc1bcdb891147432b",
+				"DiscoKey":   "discokey:05db89891926fbb9003e89bba8e1826b090c19b884c8fbb712d83eae09833b13",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44026",
+					"10.65.0.27:44026",
+					"172.17.0.1:44026",
+					"172.18.0.1:44026",
+					"172.19.0.1:44026"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:00:27.542246825Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1684851920459780,
+				"StableID":   "n1HzhmC5AE11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:272e170e0da4ec5bffc2432e83a4b0758830316bf5860d8a6ad6e76e47781310",
+				"DiscoKey":   "discokey:75035dcf3c2ec40bbe87e24023f5da381a212fc73c337d1a71f53dc7e698b114",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56041",
+					"10.65.0.27:56041",
+					"172.17.0.1:56041",
+					"172.18.0.1:56041",
+					"172.19.0.1:56041"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:00:28.087136807Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1052168206909879,
+				"StableID":   "ncTuT8gXD911CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1e8a11f71ca86e206da21d01a7fcdccb6333db5850dd720a0af074795e0ef231",
+				"DiscoKey":   "discokey:42032608e02f123bd743aaf3d2dd576712df36a25c22b6ccee7c12c64b75cb40",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45235",
+					"10.65.0.27:45235",
+					"172.17.0.1:45235",
+					"172.18.0.1:45235",
+					"172.19.0.1:45235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:00:28.625726675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6566737788524804,
+				"StableID":   "n7Wpdr46Ht11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:4753793038a82d7abd75c3267f95ab0ee1f8da6f46534764864aa30533e7184a",
+				"KeyExpiry":  "2026-11-08T22:00:29Z",
+				"DiscoKey":   "discokey:8581a18a51a3a7b18d3a1945e3238fa89f6828004b36050f293911f831806133",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60838",
+					"10.65.0.27:60838",
+					"172.17.0.1:60838",
+					"172.18.0.1:60838",
+					"172.19.0.1:60838"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:00:29.708221603Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3184032635943231,
+				"StableID":   "nLjBq194sR11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ba5c31084b83e39f24a466d2642f5cb4796cd2acde55ea2c20dad4a4824fc659",
+				"KeyExpiry":  "2026-11-08T22:00:30Z",
+				"DiscoKey":   "discokey:5c52cbb125ffb7b792638d0dc37bee23f8dd583bb595865cc72265f5cc75c602",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:32969",
+					"10.65.0.27:32969",
+					"172.17.0.1:32969",
+					"172.18.0.1:32969",
+					"172.19.0.1:32969"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:00:30.248951131Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1684851920459780,
+				"StableID":   "n1HzhmC5AE11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1684851920459780,
+				"Key":        "nodekey:272e170e0da4ec5bffc2432e83a4b0758830316bf5860d8a6ad6e76e47781310",
+				"DiscoKey":   "discokey:75035dcf3c2ec40bbe87e24023f5da381a212fc73c337d1a71f53dc7e698b114",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56041",
+					"10.65.0.27:56041",
+					"172.17.0.1:56041",
+					"172.18.0.1:56041",
+					"172.19.0.1:56041"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:00:28.087136807Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:272e170e0da4ec5bffc2432e83a4b0758830316bf5860d8a6ad6e76e47781310",
+			"MachineKey": "mkey:2b602f308db86bbcaaf9534908cf61cbd7054b7f96edf9ab060cb118f0987e35",
+			"Peers": [{
+				"ID":         4495141380753413,
+				"StableID":   "nn5sv1kr6c11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:937530f808644d74694fae90ff94bca3eb2bfe885fe9352c67b711a6e07a2962",
+				"DiscoKey":   "discokey:f7b22608b81928325693a338c78ab912282d28b7ef42ad99c03ddc8c51adba53",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58185",
+					"10.65.0.27:58185",
+					"172.17.0.1:58185",
+					"172.18.0.1:58185",
+					"172.19.0.1:58185"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:00:17.947432139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1450381082602762,
+				"StableID":   "noh2gz3tKC11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eca4daa58421f834b68c9a1f924fdd344ec6b38086a555863fa36a9c5ab05266",
+				"DiscoKey":   "discokey:4e27b8354a1979df0dcb9971567a050eea2bdfa997ed02eaf45393d215eab85b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37127",
+					"10.65.0.27:37127",
+					"172.17.0.1:37127",
+					"172.18.0.1:37127",
+					"172.19.0.1:37127"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:00:18.447693816Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7932525158031531,
+				"StableID":   "ngTRZ7zew421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f91cade6a55dca0d2ebbfd3eb44bca69de98ace29c6a61f3d5b386b1e203d52e",
+				"DiscoKey":   "discokey:c6dd270f49e3cf172e986e92199ebe59698817971f3ac8e99b5fb72c91d9db48",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60525",
+					"10.65.0.27:60525",
+					"172.17.0.1:60525",
+					"172.18.0.1:60525",
+					"172.19.0.1:60525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:00:18.992377546Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1744935358783853,
+				"StableID":   "n4UWQbVHdE11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39c33009ab3818b705a57d56bbc3bfed8cc04c5ad8003ef051867b6a180ae458",
+				"DiscoKey":   "discokey:9750b4d6a4a394507fe0cc056489b48338ebcff60490fa271adab87e7cc8ac0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60603",
+					"10.65.0.27:60603",
+					"172.17.0.1:60603",
+					"172.18.0.1:60603",
+					"172.19.0.1:60603"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:00:19.527026241Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3398469095503197,
+				"StableID":   "n8rcTB2BYT11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5eea7f3d801991e6ae7926271e67490fc3ba774fe237cdf16327d575d458704e",
+				"DiscoKey":   "discokey:3dd5cdacf99bf4d963cb9e8c014b3ecf8161163e65ec50e37dcef1d529487450",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41878",
+					"10.65.0.27:41878",
+					"172.17.0.1:41878",
+					"172.18.0.1:41878",
+					"172.19.0.1:41878"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:00:20.080861296Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         234006431339882,
+				"StableID":   "n5iA2Exyp211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9ff433350b9968c07bf2605ae1e20bfefd83898f3c443e28aee1aa03a5e911c",
+				"DiscoKey":   "discokey:61843908a1d80f24781056b259ceae421ead777674dfd73ff098f5e40140980c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33221",
+					"10.65.0.27:33221",
+					"172.17.0.1:33221",
+					"172.18.0.1:33221",
+					"172.19.0.1:33221"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:00:20.613506288Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8423653745613238,
+				"StableID":   "noT44o66n821CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fad0d445f382d0ea31bba8afc8dcebcfaf40e5649d5d56abf4fc417c8b4b491b",
+				"DiscoKey":   "discokey:1e752cd529a9d64c0c84739e1503019d94e61a0152c7db05089642c7bfe86c17",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:39159",
+					"10.65.0.27:39159",
+					"172.17.0.1:39159",
+					"172.18.0.1:39159",
+					"172.19.0.1:39159"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:00:21.153149942Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1871679810150988,
+				"StableID":   "nPYHZargcF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:42c4c743b3ea12f8b86e55e3e7812733134fcabcaa1088940abddf5ab11fb434",
+				"DiscoKey":   "discokey:93a224207e16c646980487a32d015f027ec8bc84ab432aae2b9a08011acc5508",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45176",
+					"10.65.0.27:45176",
+					"172.17.0.1:45176",
+					"172.18.0.1:45176",
+					"172.19.0.1:45176"
+				],
+				"HomeDERP": 26,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:00:21.698143017Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4688437038264628,
+				"StableID":   "n9bqGsHQcd11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5740aa576367dce684ccee8be668840239ac24242a0b17e1b81b1fe9e703ac0d",
+				"DiscoKey":   "discokey:e2d2805ebe9114b0cbe5448f14191545652a129f13a5d2501388933b43996a15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41382",
+					"10.65.0.27:41382",
+					"172.17.0.1:41382",
+					"172.18.0.1:41382",
+					"172.19.0.1:41382"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:00:27.038567415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1063858269025390,
+				"StableID":   "ndktDfkpJ911CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86c332f64a9788d7b8275681c5379860d74dbdf5179822edc1bcdb891147432b",
+				"DiscoKey":   "discokey:05db89891926fbb9003e89bba8e1826b090c19b884c8fbb712d83eae09833b13",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44026",
+					"10.65.0.27:44026",
+					"172.17.0.1:44026",
+					"172.18.0.1:44026",
+					"172.19.0.1:44026"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:00:27.542246825Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1052168206909879,
+				"StableID":   "ncTuT8gXD911CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1e8a11f71ca86e206da21d01a7fcdccb6333db5850dd720a0af074795e0ef231",
+				"DiscoKey":   "discokey:42032608e02f123bd743aaf3d2dd576712df36a25c22b6ccee7c12c64b75cb40",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45235",
+					"10.65.0.27:45235",
+					"172.17.0.1:45235",
+					"172.18.0.1:45235",
+					"172.19.0.1:45235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:00:28.625726675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4183537695037414,
+				"StableID":   "nm61GbSjfZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d665aa77c2e820cff31f080fa005082635b770a80633013a058e249ee38f074f",
+				"KeyExpiry":  "2026-11-08T22:00:29Z",
+				"DiscoKey":   "discokey:9cc96cef8fb25f68168ef23823b632532dc430c723f79f4f5f7e7c37d95d8146",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:37119",
+					"10.65.0.27:37119",
+					"172.17.0.1:37119",
+					"172.18.0.1:37119",
+					"172.19.0.1:37119"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:00:29.177641043Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6566737788524804,
+				"StableID":   "n7Wpdr46Ht11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:4753793038a82d7abd75c3267f95ab0ee1f8da6f46534764864aa30533e7184a",
+				"KeyExpiry":  "2026-11-08T22:00:29Z",
+				"DiscoKey":   "discokey:8581a18a51a3a7b18d3a1945e3238fa89f6828004b36050f293911f831806133",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60838",
+					"10.65.0.27:60838",
+					"172.17.0.1:60838",
+					"172.18.0.1:60838",
+					"172.19.0.1:60838"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:00:29.708221603Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3184032635943231,
+				"StableID":   "nLjBq194sR11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ba5c31084b83e39f24a466d2642f5cb4796cd2acde55ea2c20dad4a4824fc659",
+				"KeyExpiry":  "2026-11-08T22:00:30Z",
+				"DiscoKey":   "discokey:5c52cbb125ffb7b792638d0dc37bee23f8dd583bb595865cc72265f5cc75c602",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:32969",
+					"10.65.0.27:32969",
+					"172.17.0.1:32969",
+					"172.18.0.1:32969",
+					"172.19.0.1:32969"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:00:30.248951131Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1684851920459780": {
+				"ID":          1684851920459780,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1450381082602762,
+				"StableID":   "noh2gz3tKC11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1450381082602762,
+				"Key":        "nodekey:eca4daa58421f834b68c9a1f924fdd344ec6b38086a555863fa36a9c5ab05266",
+				"DiscoKey":   "discokey:4e27b8354a1979df0dcb9971567a050eea2bdfa997ed02eaf45393d215eab85b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37127",
+					"10.65.0.27:37127",
+					"172.17.0.1:37127",
+					"172.18.0.1:37127",
+					"172.19.0.1:37127"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:00:18.447693816Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:eca4daa58421f834b68c9a1f924fdd344ec6b38086a555863fa36a9c5ab05266",
+			"MachineKey": "mkey:54b6773ba906aeb9089c0793485aa94e2ebf07e1f6dd1aae0c4d3580e7e98c4d",
+			"Peers": [{
+				"ID":         4495141380753413,
+				"StableID":   "nn5sv1kr6c11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:937530f808644d74694fae90ff94bca3eb2bfe885fe9352c67b711a6e07a2962",
+				"DiscoKey":   "discokey:f7b22608b81928325693a338c78ab912282d28b7ef42ad99c03ddc8c51adba53",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58185",
+					"10.65.0.27:58185",
+					"172.17.0.1:58185",
+					"172.18.0.1:58185",
+					"172.19.0.1:58185"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:00:17.947432139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7932525158031531,
+				"StableID":   "ngTRZ7zew421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f91cade6a55dca0d2ebbfd3eb44bca69de98ace29c6a61f3d5b386b1e203d52e",
+				"DiscoKey":   "discokey:c6dd270f49e3cf172e986e92199ebe59698817971f3ac8e99b5fb72c91d9db48",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60525",
+					"10.65.0.27:60525",
+					"172.17.0.1:60525",
+					"172.18.0.1:60525",
+					"172.19.0.1:60525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:00:18.992377546Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1744935358783853,
+				"StableID":   "n4UWQbVHdE11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39c33009ab3818b705a57d56bbc3bfed8cc04c5ad8003ef051867b6a180ae458",
+				"DiscoKey":   "discokey:9750b4d6a4a394507fe0cc056489b48338ebcff60490fa271adab87e7cc8ac0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60603",
+					"10.65.0.27:60603",
+					"172.17.0.1:60603",
+					"172.18.0.1:60603",
+					"172.19.0.1:60603"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:00:19.527026241Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3398469095503197,
+				"StableID":   "n8rcTB2BYT11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5eea7f3d801991e6ae7926271e67490fc3ba774fe237cdf16327d575d458704e",
+				"DiscoKey":   "discokey:3dd5cdacf99bf4d963cb9e8c014b3ecf8161163e65ec50e37dcef1d529487450",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41878",
+					"10.65.0.27:41878",
+					"172.17.0.1:41878",
+					"172.18.0.1:41878",
+					"172.19.0.1:41878"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:00:20.080861296Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         234006431339882,
+				"StableID":   "n5iA2Exyp211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9ff433350b9968c07bf2605ae1e20bfefd83898f3c443e28aee1aa03a5e911c",
+				"DiscoKey":   "discokey:61843908a1d80f24781056b259ceae421ead777674dfd73ff098f5e40140980c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33221",
+					"10.65.0.27:33221",
+					"172.17.0.1:33221",
+					"172.18.0.1:33221",
+					"172.19.0.1:33221"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:00:20.613506288Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8423653745613238,
+				"StableID":   "noT44o66n821CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fad0d445f382d0ea31bba8afc8dcebcfaf40e5649d5d56abf4fc417c8b4b491b",
+				"DiscoKey":   "discokey:1e752cd529a9d64c0c84739e1503019d94e61a0152c7db05089642c7bfe86c17",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:39159",
+					"10.65.0.27:39159",
+					"172.17.0.1:39159",
+					"172.18.0.1:39159",
+					"172.19.0.1:39159"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:00:21.153149942Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1871679810150988,
+				"StableID":   "nPYHZargcF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:42c4c743b3ea12f8b86e55e3e7812733134fcabcaa1088940abddf5ab11fb434",
+				"DiscoKey":   "discokey:93a224207e16c646980487a32d015f027ec8bc84ab432aae2b9a08011acc5508",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45176",
+					"10.65.0.27:45176",
+					"172.17.0.1:45176",
+					"172.18.0.1:45176",
+					"172.19.0.1:45176"
+				],
+				"HomeDERP": 26,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:00:21.698143017Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4688437038264628,
+				"StableID":   "n9bqGsHQcd11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5740aa576367dce684ccee8be668840239ac24242a0b17e1b81b1fe9e703ac0d",
+				"DiscoKey":   "discokey:e2d2805ebe9114b0cbe5448f14191545652a129f13a5d2501388933b43996a15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41382",
+					"10.65.0.27:41382",
+					"172.17.0.1:41382",
+					"172.18.0.1:41382",
+					"172.19.0.1:41382"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:00:27.038567415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1063858269025390,
+				"StableID":   "ndktDfkpJ911CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86c332f64a9788d7b8275681c5379860d74dbdf5179822edc1bcdb891147432b",
+				"DiscoKey":   "discokey:05db89891926fbb9003e89bba8e1826b090c19b884c8fbb712d83eae09833b13",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44026",
+					"10.65.0.27:44026",
+					"172.17.0.1:44026",
+					"172.18.0.1:44026",
+					"172.19.0.1:44026"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:00:27.542246825Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1684851920459780,
+				"StableID":   "n1HzhmC5AE11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:272e170e0da4ec5bffc2432e83a4b0758830316bf5860d8a6ad6e76e47781310",
+				"DiscoKey":   "discokey:75035dcf3c2ec40bbe87e24023f5da381a212fc73c337d1a71f53dc7e698b114",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56041",
+					"10.65.0.27:56041",
+					"172.17.0.1:56041",
+					"172.18.0.1:56041",
+					"172.19.0.1:56041"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:00:28.087136807Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1052168206909879,
+				"StableID":   "ncTuT8gXD911CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1e8a11f71ca86e206da21d01a7fcdccb6333db5850dd720a0af074795e0ef231",
+				"DiscoKey":   "discokey:42032608e02f123bd743aaf3d2dd576712df36a25c22b6ccee7c12c64b75cb40",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45235",
+					"10.65.0.27:45235",
+					"172.17.0.1:45235",
+					"172.18.0.1:45235",
+					"172.19.0.1:45235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:00:28.625726675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4183537695037414,
+				"StableID":   "nm61GbSjfZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d665aa77c2e820cff31f080fa005082635b770a80633013a058e249ee38f074f",
+				"KeyExpiry":  "2026-11-08T22:00:29Z",
+				"DiscoKey":   "discokey:9cc96cef8fb25f68168ef23823b632532dc430c723f79f4f5f7e7c37d95d8146",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:37119",
+					"10.65.0.27:37119",
+					"172.17.0.1:37119",
+					"172.18.0.1:37119",
+					"172.19.0.1:37119"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:00:29.177641043Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6566737788524804,
+				"StableID":   "n7Wpdr46Ht11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:4753793038a82d7abd75c3267f95ab0ee1f8da6f46534764864aa30533e7184a",
+				"KeyExpiry":  "2026-11-08T22:00:29Z",
+				"DiscoKey":   "discokey:8581a18a51a3a7b18d3a1945e3238fa89f6828004b36050f293911f831806133",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60838",
+					"10.65.0.27:60838",
+					"172.17.0.1:60838",
+					"172.18.0.1:60838",
+					"172.19.0.1:60838"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:00:29.708221603Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3184032635943231,
+				"StableID":   "nLjBq194sR11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ba5c31084b83e39f24a466d2642f5cb4796cd2acde55ea2c20dad4a4824fc659",
+				"KeyExpiry":  "2026-11-08T22:00:30Z",
+				"DiscoKey":   "discokey:5c52cbb125ffb7b792638d0dc37bee23f8dd583bb595865cc72265f5cc75c602",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:32969",
+					"10.65.0.27:32969",
+					"172.17.0.1:32969",
+					"172.18.0.1:32969",
+					"172.19.0.1:32969"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:00:30.248951131Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1450381082602762": {
+				"ID":          1450381082602762,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4495141380753413,
+				"StableID":   "nn5sv1kr6c11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       4495141380753413,
+				"Key":        "nodekey:937530f808644d74694fae90ff94bca3eb2bfe885fe9352c67b711a6e07a2962",
+				"DiscoKey":   "discokey:f7b22608b81928325693a338c78ab912282d28b7ef42ad99c03ddc8c51adba53",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58185",
+					"10.65.0.27:58185",
+					"172.17.0.1:58185",
+					"172.18.0.1:58185",
+					"172.19.0.1:58185"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:00:17.947432139Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:937530f808644d74694fae90ff94bca3eb2bfe885fe9352c67b711a6e07a2962",
+			"MachineKey": "mkey:b98df7d36b0cf4138058b340c4ac51559313afad51676f3c4affbe8c1ed50b07",
+			"Peers": [{
+				"ID":         1450381082602762,
+				"StableID":   "noh2gz3tKC11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eca4daa58421f834b68c9a1f924fdd344ec6b38086a555863fa36a9c5ab05266",
+				"DiscoKey":   "discokey:4e27b8354a1979df0dcb9971567a050eea2bdfa997ed02eaf45393d215eab85b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37127",
+					"10.65.0.27:37127",
+					"172.17.0.1:37127",
+					"172.18.0.1:37127",
+					"172.19.0.1:37127"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:00:18.447693816Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7932525158031531,
+				"StableID":   "ngTRZ7zew421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f91cade6a55dca0d2ebbfd3eb44bca69de98ace29c6a61f3d5b386b1e203d52e",
+				"DiscoKey":   "discokey:c6dd270f49e3cf172e986e92199ebe59698817971f3ac8e99b5fb72c91d9db48",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60525",
+					"10.65.0.27:60525",
+					"172.17.0.1:60525",
+					"172.18.0.1:60525",
+					"172.19.0.1:60525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:00:18.992377546Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1744935358783853,
+				"StableID":   "n4UWQbVHdE11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39c33009ab3818b705a57d56bbc3bfed8cc04c5ad8003ef051867b6a180ae458",
+				"DiscoKey":   "discokey:9750b4d6a4a394507fe0cc056489b48338ebcff60490fa271adab87e7cc8ac0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60603",
+					"10.65.0.27:60603",
+					"172.17.0.1:60603",
+					"172.18.0.1:60603",
+					"172.19.0.1:60603"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:00:19.527026241Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3398469095503197,
+				"StableID":   "n8rcTB2BYT11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5eea7f3d801991e6ae7926271e67490fc3ba774fe237cdf16327d575d458704e",
+				"DiscoKey":   "discokey:3dd5cdacf99bf4d963cb9e8c014b3ecf8161163e65ec50e37dcef1d529487450",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41878",
+					"10.65.0.27:41878",
+					"172.17.0.1:41878",
+					"172.18.0.1:41878",
+					"172.19.0.1:41878"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:00:20.080861296Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         234006431339882,
+				"StableID":   "n5iA2Exyp211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9ff433350b9968c07bf2605ae1e20bfefd83898f3c443e28aee1aa03a5e911c",
+				"DiscoKey":   "discokey:61843908a1d80f24781056b259ceae421ead777674dfd73ff098f5e40140980c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33221",
+					"10.65.0.27:33221",
+					"172.17.0.1:33221",
+					"172.18.0.1:33221",
+					"172.19.0.1:33221"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:00:20.613506288Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8423653745613238,
+				"StableID":   "noT44o66n821CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fad0d445f382d0ea31bba8afc8dcebcfaf40e5649d5d56abf4fc417c8b4b491b",
+				"DiscoKey":   "discokey:1e752cd529a9d64c0c84739e1503019d94e61a0152c7db05089642c7bfe86c17",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:39159",
+					"10.65.0.27:39159",
+					"172.17.0.1:39159",
+					"172.18.0.1:39159",
+					"172.19.0.1:39159"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:00:21.153149942Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1871679810150988,
+				"StableID":   "nPYHZargcF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:42c4c743b3ea12f8b86e55e3e7812733134fcabcaa1088940abddf5ab11fb434",
+				"DiscoKey":   "discokey:93a224207e16c646980487a32d015f027ec8bc84ab432aae2b9a08011acc5508",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45176",
+					"10.65.0.27:45176",
+					"172.17.0.1:45176",
+					"172.18.0.1:45176",
+					"172.19.0.1:45176"
+				],
+				"HomeDERP": 26,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:00:21.698143017Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4688437038264628,
+				"StableID":   "n9bqGsHQcd11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5740aa576367dce684ccee8be668840239ac24242a0b17e1b81b1fe9e703ac0d",
+				"DiscoKey":   "discokey:e2d2805ebe9114b0cbe5448f14191545652a129f13a5d2501388933b43996a15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41382",
+					"10.65.0.27:41382",
+					"172.17.0.1:41382",
+					"172.18.0.1:41382",
+					"172.19.0.1:41382"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:00:27.038567415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1063858269025390,
+				"StableID":   "ndktDfkpJ911CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86c332f64a9788d7b8275681c5379860d74dbdf5179822edc1bcdb891147432b",
+				"DiscoKey":   "discokey:05db89891926fbb9003e89bba8e1826b090c19b884c8fbb712d83eae09833b13",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44026",
+					"10.65.0.27:44026",
+					"172.17.0.1:44026",
+					"172.18.0.1:44026",
+					"172.19.0.1:44026"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:00:27.542246825Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1684851920459780,
+				"StableID":   "n1HzhmC5AE11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:272e170e0da4ec5bffc2432e83a4b0758830316bf5860d8a6ad6e76e47781310",
+				"DiscoKey":   "discokey:75035dcf3c2ec40bbe87e24023f5da381a212fc73c337d1a71f53dc7e698b114",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56041",
+					"10.65.0.27:56041",
+					"172.17.0.1:56041",
+					"172.18.0.1:56041",
+					"172.19.0.1:56041"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:00:28.087136807Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1052168206909879,
+				"StableID":   "ncTuT8gXD911CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1e8a11f71ca86e206da21d01a7fcdccb6333db5850dd720a0af074795e0ef231",
+				"DiscoKey":   "discokey:42032608e02f123bd743aaf3d2dd576712df36a25c22b6ccee7c12c64b75cb40",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45235",
+					"10.65.0.27:45235",
+					"172.17.0.1:45235",
+					"172.18.0.1:45235",
+					"172.19.0.1:45235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:00:28.625726675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4183537695037414,
+				"StableID":   "nm61GbSjfZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d665aa77c2e820cff31f080fa005082635b770a80633013a058e249ee38f074f",
+				"KeyExpiry":  "2026-11-08T22:00:29Z",
+				"DiscoKey":   "discokey:9cc96cef8fb25f68168ef23823b632532dc430c723f79f4f5f7e7c37d95d8146",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:37119",
+					"10.65.0.27:37119",
+					"172.17.0.1:37119",
+					"172.18.0.1:37119",
+					"172.19.0.1:37119"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:00:29.177641043Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6566737788524804,
+				"StableID":   "n7Wpdr46Ht11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:4753793038a82d7abd75c3267f95ab0ee1f8da6f46534764864aa30533e7184a",
+				"KeyExpiry":  "2026-11-08T22:00:29Z",
+				"DiscoKey":   "discokey:8581a18a51a3a7b18d3a1945e3238fa89f6828004b36050f293911f831806133",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60838",
+					"10.65.0.27:60838",
+					"172.17.0.1:60838",
+					"172.18.0.1:60838",
+					"172.19.0.1:60838"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:00:29.708221603Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3184032635943231,
+				"StableID":   "nLjBq194sR11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ba5c31084b83e39f24a466d2642f5cb4796cd2acde55ea2c20dad4a4824fc659",
+				"KeyExpiry":  "2026-11-08T22:00:30Z",
+				"DiscoKey":   "discokey:5c52cbb125ffb7b792638d0dc37bee23f8dd583bb595865cc72265f5cc75c602",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:32969",
+					"10.65.0.27:32969",
+					"172.17.0.1:32969",
+					"172.18.0.1:32969",
+					"172.19.0.1:32969"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:00:30.248951131Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4495141380753413": {
+				"ID":          4495141380753413,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3398469095503197,
+				"StableID":   "n8rcTB2BYT11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       3398469095503197,
+				"Key":        "nodekey:5eea7f3d801991e6ae7926271e67490fc3ba774fe237cdf16327d575d458704e",
+				"DiscoKey":   "discokey:3dd5cdacf99bf4d963cb9e8c014b3ecf8161163e65ec50e37dcef1d529487450",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41878",
+					"10.65.0.27:41878",
+					"172.17.0.1:41878",
+					"172.18.0.1:41878",
+					"172.19.0.1:41878"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:00:20.080861296Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5eea7f3d801991e6ae7926271e67490fc3ba774fe237cdf16327d575d458704e",
+			"MachineKey": "mkey:880bb213d552b7d354662bf87e9f1ed302ce9ccf18aa92ca9658e89f77fa9a53",
+			"Peers": [{
+				"ID":         4495141380753413,
+				"StableID":   "nn5sv1kr6c11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:937530f808644d74694fae90ff94bca3eb2bfe885fe9352c67b711a6e07a2962",
+				"DiscoKey":   "discokey:f7b22608b81928325693a338c78ab912282d28b7ef42ad99c03ddc8c51adba53",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58185",
+					"10.65.0.27:58185",
+					"172.17.0.1:58185",
+					"172.18.0.1:58185",
+					"172.19.0.1:58185"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:00:17.947432139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1450381082602762,
+				"StableID":   "noh2gz3tKC11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eca4daa58421f834b68c9a1f924fdd344ec6b38086a555863fa36a9c5ab05266",
+				"DiscoKey":   "discokey:4e27b8354a1979df0dcb9971567a050eea2bdfa997ed02eaf45393d215eab85b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37127",
+					"10.65.0.27:37127",
+					"172.17.0.1:37127",
+					"172.18.0.1:37127",
+					"172.19.0.1:37127"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:00:18.447693816Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7932525158031531,
+				"StableID":   "ngTRZ7zew421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f91cade6a55dca0d2ebbfd3eb44bca69de98ace29c6a61f3d5b386b1e203d52e",
+				"DiscoKey":   "discokey:c6dd270f49e3cf172e986e92199ebe59698817971f3ac8e99b5fb72c91d9db48",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60525",
+					"10.65.0.27:60525",
+					"172.17.0.1:60525",
+					"172.18.0.1:60525",
+					"172.19.0.1:60525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:00:18.992377546Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1744935358783853,
+				"StableID":   "n4UWQbVHdE11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39c33009ab3818b705a57d56bbc3bfed8cc04c5ad8003ef051867b6a180ae458",
+				"DiscoKey":   "discokey:9750b4d6a4a394507fe0cc056489b48338ebcff60490fa271adab87e7cc8ac0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60603",
+					"10.65.0.27:60603",
+					"172.17.0.1:60603",
+					"172.18.0.1:60603",
+					"172.19.0.1:60603"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:00:19.527026241Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         234006431339882,
+				"StableID":   "n5iA2Exyp211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9ff433350b9968c07bf2605ae1e20bfefd83898f3c443e28aee1aa03a5e911c",
+				"DiscoKey":   "discokey:61843908a1d80f24781056b259ceae421ead777674dfd73ff098f5e40140980c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33221",
+					"10.65.0.27:33221",
+					"172.17.0.1:33221",
+					"172.18.0.1:33221",
+					"172.19.0.1:33221"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:00:20.613506288Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8423653745613238,
+				"StableID":   "noT44o66n821CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fad0d445f382d0ea31bba8afc8dcebcfaf40e5649d5d56abf4fc417c8b4b491b",
+				"DiscoKey":   "discokey:1e752cd529a9d64c0c84739e1503019d94e61a0152c7db05089642c7bfe86c17",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:39159",
+					"10.65.0.27:39159",
+					"172.17.0.1:39159",
+					"172.18.0.1:39159",
+					"172.19.0.1:39159"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:00:21.153149942Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1871679810150988,
+				"StableID":   "nPYHZargcF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:42c4c743b3ea12f8b86e55e3e7812733134fcabcaa1088940abddf5ab11fb434",
+				"DiscoKey":   "discokey:93a224207e16c646980487a32d015f027ec8bc84ab432aae2b9a08011acc5508",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45176",
+					"10.65.0.27:45176",
+					"172.17.0.1:45176",
+					"172.18.0.1:45176",
+					"172.19.0.1:45176"
+				],
+				"HomeDERP": 26,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:00:21.698143017Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4688437038264628,
+				"StableID":   "n9bqGsHQcd11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5740aa576367dce684ccee8be668840239ac24242a0b17e1b81b1fe9e703ac0d",
+				"DiscoKey":   "discokey:e2d2805ebe9114b0cbe5448f14191545652a129f13a5d2501388933b43996a15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41382",
+					"10.65.0.27:41382",
+					"172.17.0.1:41382",
+					"172.18.0.1:41382",
+					"172.19.0.1:41382"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:00:27.038567415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1063858269025390,
+				"StableID":   "ndktDfkpJ911CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86c332f64a9788d7b8275681c5379860d74dbdf5179822edc1bcdb891147432b",
+				"DiscoKey":   "discokey:05db89891926fbb9003e89bba8e1826b090c19b884c8fbb712d83eae09833b13",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44026",
+					"10.65.0.27:44026",
+					"172.17.0.1:44026",
+					"172.18.0.1:44026",
+					"172.19.0.1:44026"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:00:27.542246825Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1684851920459780,
+				"StableID":   "n1HzhmC5AE11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:272e170e0da4ec5bffc2432e83a4b0758830316bf5860d8a6ad6e76e47781310",
+				"DiscoKey":   "discokey:75035dcf3c2ec40bbe87e24023f5da381a212fc73c337d1a71f53dc7e698b114",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56041",
+					"10.65.0.27:56041",
+					"172.17.0.1:56041",
+					"172.18.0.1:56041",
+					"172.19.0.1:56041"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:00:28.087136807Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1052168206909879,
+				"StableID":   "ncTuT8gXD911CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1e8a11f71ca86e206da21d01a7fcdccb6333db5850dd720a0af074795e0ef231",
+				"DiscoKey":   "discokey:42032608e02f123bd743aaf3d2dd576712df36a25c22b6ccee7c12c64b75cb40",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45235",
+					"10.65.0.27:45235",
+					"172.17.0.1:45235",
+					"172.18.0.1:45235",
+					"172.19.0.1:45235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:00:28.625726675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4183537695037414,
+				"StableID":   "nm61GbSjfZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d665aa77c2e820cff31f080fa005082635b770a80633013a058e249ee38f074f",
+				"KeyExpiry":  "2026-11-08T22:00:29Z",
+				"DiscoKey":   "discokey:9cc96cef8fb25f68168ef23823b632532dc430c723f79f4f5f7e7c37d95d8146",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:37119",
+					"10.65.0.27:37119",
+					"172.17.0.1:37119",
+					"172.18.0.1:37119",
+					"172.19.0.1:37119"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:00:29.177641043Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6566737788524804,
+				"StableID":   "n7Wpdr46Ht11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:4753793038a82d7abd75c3267f95ab0ee1f8da6f46534764864aa30533e7184a",
+				"KeyExpiry":  "2026-11-08T22:00:29Z",
+				"DiscoKey":   "discokey:8581a18a51a3a7b18d3a1945e3238fa89f6828004b36050f293911f831806133",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60838",
+					"10.65.0.27:60838",
+					"172.17.0.1:60838",
+					"172.18.0.1:60838",
+					"172.19.0.1:60838"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:00:29.708221603Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3184032635943231,
+				"StableID":   "nLjBq194sR11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ba5c31084b83e39f24a466d2642f5cb4796cd2acde55ea2c20dad4a4824fc659",
+				"KeyExpiry":  "2026-11-08T22:00:30Z",
+				"DiscoKey":   "discokey:5c52cbb125ffb7b792638d0dc37bee23f8dd583bb595865cc72265f5cc75c602",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:32969",
+					"10.65.0.27:32969",
+					"172.17.0.1:32969",
+					"172.18.0.1:32969",
+					"172.19.0.1:32969"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:00:30.248951131Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3398469095503197": {
+				"ID":          3398469095503197,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1744935358783853,
+				"StableID":   "n4UWQbVHdE11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1744935358783853,
+				"Key":        "nodekey:39c33009ab3818b705a57d56bbc3bfed8cc04c5ad8003ef051867b6a180ae458",
+				"DiscoKey":   "discokey:9750b4d6a4a394507fe0cc056489b48338ebcff60490fa271adab87e7cc8ac0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60603",
+					"10.65.0.27:60603",
+					"172.17.0.1:60603",
+					"172.18.0.1:60603",
+					"172.19.0.1:60603"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:00:19.527026241Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:39c33009ab3818b705a57d56bbc3bfed8cc04c5ad8003ef051867b6a180ae458",
+			"MachineKey": "mkey:f57114e6b11795cffa6e43d1d25024e48b156b2f73a809ad1e92b5e71db58e10",
+			"Peers": [{
+				"ID":         4495141380753413,
+				"StableID":   "nn5sv1kr6c11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:937530f808644d74694fae90ff94bca3eb2bfe885fe9352c67b711a6e07a2962",
+				"DiscoKey":   "discokey:f7b22608b81928325693a338c78ab912282d28b7ef42ad99c03ddc8c51adba53",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58185",
+					"10.65.0.27:58185",
+					"172.17.0.1:58185",
+					"172.18.0.1:58185",
+					"172.19.0.1:58185"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:00:17.947432139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1450381082602762,
+				"StableID":   "noh2gz3tKC11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eca4daa58421f834b68c9a1f924fdd344ec6b38086a555863fa36a9c5ab05266",
+				"DiscoKey":   "discokey:4e27b8354a1979df0dcb9971567a050eea2bdfa997ed02eaf45393d215eab85b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37127",
+					"10.65.0.27:37127",
+					"172.17.0.1:37127",
+					"172.18.0.1:37127",
+					"172.19.0.1:37127"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:00:18.447693816Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7932525158031531,
+				"StableID":   "ngTRZ7zew421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f91cade6a55dca0d2ebbfd3eb44bca69de98ace29c6a61f3d5b386b1e203d52e",
+				"DiscoKey":   "discokey:c6dd270f49e3cf172e986e92199ebe59698817971f3ac8e99b5fb72c91d9db48",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60525",
+					"10.65.0.27:60525",
+					"172.17.0.1:60525",
+					"172.18.0.1:60525",
+					"172.19.0.1:60525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:00:18.992377546Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3398469095503197,
+				"StableID":   "n8rcTB2BYT11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5eea7f3d801991e6ae7926271e67490fc3ba774fe237cdf16327d575d458704e",
+				"DiscoKey":   "discokey:3dd5cdacf99bf4d963cb9e8c014b3ecf8161163e65ec50e37dcef1d529487450",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41878",
+					"10.65.0.27:41878",
+					"172.17.0.1:41878",
+					"172.18.0.1:41878",
+					"172.19.0.1:41878"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:00:20.080861296Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         234006431339882,
+				"StableID":   "n5iA2Exyp211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9ff433350b9968c07bf2605ae1e20bfefd83898f3c443e28aee1aa03a5e911c",
+				"DiscoKey":   "discokey:61843908a1d80f24781056b259ceae421ead777674dfd73ff098f5e40140980c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33221",
+					"10.65.0.27:33221",
+					"172.17.0.1:33221",
+					"172.18.0.1:33221",
+					"172.19.0.1:33221"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:00:20.613506288Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8423653745613238,
+				"StableID":   "noT44o66n821CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fad0d445f382d0ea31bba8afc8dcebcfaf40e5649d5d56abf4fc417c8b4b491b",
+				"DiscoKey":   "discokey:1e752cd529a9d64c0c84739e1503019d94e61a0152c7db05089642c7bfe86c17",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:39159",
+					"10.65.0.27:39159",
+					"172.17.0.1:39159",
+					"172.18.0.1:39159",
+					"172.19.0.1:39159"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:00:21.153149942Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1871679810150988,
+				"StableID":   "nPYHZargcF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:42c4c743b3ea12f8b86e55e3e7812733134fcabcaa1088940abddf5ab11fb434",
+				"DiscoKey":   "discokey:93a224207e16c646980487a32d015f027ec8bc84ab432aae2b9a08011acc5508",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45176",
+					"10.65.0.27:45176",
+					"172.17.0.1:45176",
+					"172.18.0.1:45176",
+					"172.19.0.1:45176"
+				],
+				"HomeDERP": 26,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:00:21.698143017Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4688437038264628,
+				"StableID":   "n9bqGsHQcd11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5740aa576367dce684ccee8be668840239ac24242a0b17e1b81b1fe9e703ac0d",
+				"DiscoKey":   "discokey:e2d2805ebe9114b0cbe5448f14191545652a129f13a5d2501388933b43996a15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41382",
+					"10.65.0.27:41382",
+					"172.17.0.1:41382",
+					"172.18.0.1:41382",
+					"172.19.0.1:41382"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:00:27.038567415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1063858269025390,
+				"StableID":   "ndktDfkpJ911CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86c332f64a9788d7b8275681c5379860d74dbdf5179822edc1bcdb891147432b",
+				"DiscoKey":   "discokey:05db89891926fbb9003e89bba8e1826b090c19b884c8fbb712d83eae09833b13",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44026",
+					"10.65.0.27:44026",
+					"172.17.0.1:44026",
+					"172.18.0.1:44026",
+					"172.19.0.1:44026"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:00:27.542246825Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1684851920459780,
+				"StableID":   "n1HzhmC5AE11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:272e170e0da4ec5bffc2432e83a4b0758830316bf5860d8a6ad6e76e47781310",
+				"DiscoKey":   "discokey:75035dcf3c2ec40bbe87e24023f5da381a212fc73c337d1a71f53dc7e698b114",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56041",
+					"10.65.0.27:56041",
+					"172.17.0.1:56041",
+					"172.18.0.1:56041",
+					"172.19.0.1:56041"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:00:28.087136807Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1052168206909879,
+				"StableID":   "ncTuT8gXD911CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1e8a11f71ca86e206da21d01a7fcdccb6333db5850dd720a0af074795e0ef231",
+				"DiscoKey":   "discokey:42032608e02f123bd743aaf3d2dd576712df36a25c22b6ccee7c12c64b75cb40",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45235",
+					"10.65.0.27:45235",
+					"172.17.0.1:45235",
+					"172.18.0.1:45235",
+					"172.19.0.1:45235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:00:28.625726675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4183537695037414,
+				"StableID":   "nm61GbSjfZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d665aa77c2e820cff31f080fa005082635b770a80633013a058e249ee38f074f",
+				"KeyExpiry":  "2026-11-08T22:00:29Z",
+				"DiscoKey":   "discokey:9cc96cef8fb25f68168ef23823b632532dc430c723f79f4f5f7e7c37d95d8146",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:37119",
+					"10.65.0.27:37119",
+					"172.17.0.1:37119",
+					"172.18.0.1:37119",
+					"172.19.0.1:37119"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:00:29.177641043Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6566737788524804,
+				"StableID":   "n7Wpdr46Ht11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:4753793038a82d7abd75c3267f95ab0ee1f8da6f46534764864aa30533e7184a",
+				"KeyExpiry":  "2026-11-08T22:00:29Z",
+				"DiscoKey":   "discokey:8581a18a51a3a7b18d3a1945e3238fa89f6828004b36050f293911f831806133",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60838",
+					"10.65.0.27:60838",
+					"172.17.0.1:60838",
+					"172.18.0.1:60838",
+					"172.19.0.1:60838"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:00:29.708221603Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3184032635943231,
+				"StableID":   "nLjBq194sR11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ba5c31084b83e39f24a466d2642f5cb4796cd2acde55ea2c20dad4a4824fc659",
+				"KeyExpiry":  "2026-11-08T22:00:30Z",
+				"DiscoKey":   "discokey:5c52cbb125ffb7b792638d0dc37bee23f8dd583bb595865cc72265f5cc75c602",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:32969",
+					"10.65.0.27:32969",
+					"172.17.0.1:32969",
+					"172.18.0.1:32969",
+					"172.19.0.1:32969"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:00:30.248951131Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1744935358783853": {
+				"ID":          1744935358783853,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8423653745613238,
+				"StableID":   "noT44o66n821CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       8423653745613238,
+				"Key":        "nodekey:fad0d445f382d0ea31bba8afc8dcebcfaf40e5649d5d56abf4fc417c8b4b491b",
+				"DiscoKey":   "discokey:1e752cd529a9d64c0c84739e1503019d94e61a0152c7db05089642c7bfe86c17",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:39159",
+					"10.65.0.27:39159",
+					"172.17.0.1:39159",
+					"172.18.0.1:39159",
+					"172.19.0.1:39159"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:00:21.153149942Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:fad0d445f382d0ea31bba8afc8dcebcfaf40e5649d5d56abf4fc417c8b4b491b",
+			"MachineKey": "mkey:60d7abcc3cd3849af51af1d9d9a52e40f7b86c9129720d3b13103a7e550e3f33",
+			"Peers": [{
+				"ID":         4495141380753413,
+				"StableID":   "nn5sv1kr6c11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:937530f808644d74694fae90ff94bca3eb2bfe885fe9352c67b711a6e07a2962",
+				"DiscoKey":   "discokey:f7b22608b81928325693a338c78ab912282d28b7ef42ad99c03ddc8c51adba53",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58185",
+					"10.65.0.27:58185",
+					"172.17.0.1:58185",
+					"172.18.0.1:58185",
+					"172.19.0.1:58185"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:00:17.947432139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1450381082602762,
+				"StableID":   "noh2gz3tKC11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eca4daa58421f834b68c9a1f924fdd344ec6b38086a555863fa36a9c5ab05266",
+				"DiscoKey":   "discokey:4e27b8354a1979df0dcb9971567a050eea2bdfa997ed02eaf45393d215eab85b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37127",
+					"10.65.0.27:37127",
+					"172.17.0.1:37127",
+					"172.18.0.1:37127",
+					"172.19.0.1:37127"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:00:18.447693816Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7932525158031531,
+				"StableID":   "ngTRZ7zew421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f91cade6a55dca0d2ebbfd3eb44bca69de98ace29c6a61f3d5b386b1e203d52e",
+				"DiscoKey":   "discokey:c6dd270f49e3cf172e986e92199ebe59698817971f3ac8e99b5fb72c91d9db48",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60525",
+					"10.65.0.27:60525",
+					"172.17.0.1:60525",
+					"172.18.0.1:60525",
+					"172.19.0.1:60525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:00:18.992377546Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1744935358783853,
+				"StableID":   "n4UWQbVHdE11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39c33009ab3818b705a57d56bbc3bfed8cc04c5ad8003ef051867b6a180ae458",
+				"DiscoKey":   "discokey:9750b4d6a4a394507fe0cc056489b48338ebcff60490fa271adab87e7cc8ac0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60603",
+					"10.65.0.27:60603",
+					"172.17.0.1:60603",
+					"172.18.0.1:60603",
+					"172.19.0.1:60603"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:00:19.527026241Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3398469095503197,
+				"StableID":   "n8rcTB2BYT11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5eea7f3d801991e6ae7926271e67490fc3ba774fe237cdf16327d575d458704e",
+				"DiscoKey":   "discokey:3dd5cdacf99bf4d963cb9e8c014b3ecf8161163e65ec50e37dcef1d529487450",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41878",
+					"10.65.0.27:41878",
+					"172.17.0.1:41878",
+					"172.18.0.1:41878",
+					"172.19.0.1:41878"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:00:20.080861296Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         234006431339882,
+				"StableID":   "n5iA2Exyp211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9ff433350b9968c07bf2605ae1e20bfefd83898f3c443e28aee1aa03a5e911c",
+				"DiscoKey":   "discokey:61843908a1d80f24781056b259ceae421ead777674dfd73ff098f5e40140980c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33221",
+					"10.65.0.27:33221",
+					"172.17.0.1:33221",
+					"172.18.0.1:33221",
+					"172.19.0.1:33221"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:00:20.613506288Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1871679810150988,
+				"StableID":   "nPYHZargcF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:42c4c743b3ea12f8b86e55e3e7812733134fcabcaa1088940abddf5ab11fb434",
+				"DiscoKey":   "discokey:93a224207e16c646980487a32d015f027ec8bc84ab432aae2b9a08011acc5508",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45176",
+					"10.65.0.27:45176",
+					"172.17.0.1:45176",
+					"172.18.0.1:45176",
+					"172.19.0.1:45176"
+				],
+				"HomeDERP": 26,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:00:21.698143017Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4688437038264628,
+				"StableID":   "n9bqGsHQcd11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5740aa576367dce684ccee8be668840239ac24242a0b17e1b81b1fe9e703ac0d",
+				"DiscoKey":   "discokey:e2d2805ebe9114b0cbe5448f14191545652a129f13a5d2501388933b43996a15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41382",
+					"10.65.0.27:41382",
+					"172.17.0.1:41382",
+					"172.18.0.1:41382",
+					"172.19.0.1:41382"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:00:27.038567415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1063858269025390,
+				"StableID":   "ndktDfkpJ911CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86c332f64a9788d7b8275681c5379860d74dbdf5179822edc1bcdb891147432b",
+				"DiscoKey":   "discokey:05db89891926fbb9003e89bba8e1826b090c19b884c8fbb712d83eae09833b13",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44026",
+					"10.65.0.27:44026",
+					"172.17.0.1:44026",
+					"172.18.0.1:44026",
+					"172.19.0.1:44026"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:00:27.542246825Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1684851920459780,
+				"StableID":   "n1HzhmC5AE11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:272e170e0da4ec5bffc2432e83a4b0758830316bf5860d8a6ad6e76e47781310",
+				"DiscoKey":   "discokey:75035dcf3c2ec40bbe87e24023f5da381a212fc73c337d1a71f53dc7e698b114",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56041",
+					"10.65.0.27:56041",
+					"172.17.0.1:56041",
+					"172.18.0.1:56041",
+					"172.19.0.1:56041"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:00:28.087136807Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1052168206909879,
+				"StableID":   "ncTuT8gXD911CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1e8a11f71ca86e206da21d01a7fcdccb6333db5850dd720a0af074795e0ef231",
+				"DiscoKey":   "discokey:42032608e02f123bd743aaf3d2dd576712df36a25c22b6ccee7c12c64b75cb40",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45235",
+					"10.65.0.27:45235",
+					"172.17.0.1:45235",
+					"172.18.0.1:45235",
+					"172.19.0.1:45235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:00:28.625726675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4183537695037414,
+				"StableID":   "nm61GbSjfZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d665aa77c2e820cff31f080fa005082635b770a80633013a058e249ee38f074f",
+				"KeyExpiry":  "2026-11-08T22:00:29Z",
+				"DiscoKey":   "discokey:9cc96cef8fb25f68168ef23823b632532dc430c723f79f4f5f7e7c37d95d8146",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:37119",
+					"10.65.0.27:37119",
+					"172.17.0.1:37119",
+					"172.18.0.1:37119",
+					"172.19.0.1:37119"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:00:29.177641043Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6566737788524804,
+				"StableID":   "n7Wpdr46Ht11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:4753793038a82d7abd75c3267f95ab0ee1f8da6f46534764864aa30533e7184a",
+				"KeyExpiry":  "2026-11-08T22:00:29Z",
+				"DiscoKey":   "discokey:8581a18a51a3a7b18d3a1945e3238fa89f6828004b36050f293911f831806133",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60838",
+					"10.65.0.27:60838",
+					"172.17.0.1:60838",
+					"172.18.0.1:60838",
+					"172.19.0.1:60838"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:00:29.708221603Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3184032635943231,
+				"StableID":   "nLjBq194sR11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ba5c31084b83e39f24a466d2642f5cb4796cd2acde55ea2c20dad4a4824fc659",
+				"KeyExpiry":  "2026-11-08T22:00:30Z",
+				"DiscoKey":   "discokey:5c52cbb125ffb7b792638d0dc37bee23f8dd583bb595865cc72265f5cc75c602",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:32969",
+					"10.65.0.27:32969",
+					"172.17.0.1:32969",
+					"172.18.0.1:32969",
+					"172.19.0.1:32969"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:00:30.248951131Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8423653745613238": {
+				"ID":          8423653745613238,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4688437038264628,
+				"StableID":   "n9bqGsHQcd11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       4688437038264628,
+				"Key":        "nodekey:5740aa576367dce684ccee8be668840239ac24242a0b17e1b81b1fe9e703ac0d",
+				"DiscoKey":   "discokey:e2d2805ebe9114b0cbe5448f14191545652a129f13a5d2501388933b43996a15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41382",
+					"10.65.0.27:41382",
+					"172.17.0.1:41382",
+					"172.18.0.1:41382",
+					"172.19.0.1:41382"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:00:27.038567415Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5740aa576367dce684ccee8be668840239ac24242a0b17e1b81b1fe9e703ac0d",
+			"MachineKey": "mkey:689c2388103fea69d4dc38a5a121702344252276465fed13c0820fb2db91804b",
+			"Peers": [{
+				"ID":         4495141380753413,
+				"StableID":   "nn5sv1kr6c11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:937530f808644d74694fae90ff94bca3eb2bfe885fe9352c67b711a6e07a2962",
+				"DiscoKey":   "discokey:f7b22608b81928325693a338c78ab912282d28b7ef42ad99c03ddc8c51adba53",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58185",
+					"10.65.0.27:58185",
+					"172.17.0.1:58185",
+					"172.18.0.1:58185",
+					"172.19.0.1:58185"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:00:17.947432139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1450381082602762,
+				"StableID":   "noh2gz3tKC11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eca4daa58421f834b68c9a1f924fdd344ec6b38086a555863fa36a9c5ab05266",
+				"DiscoKey":   "discokey:4e27b8354a1979df0dcb9971567a050eea2bdfa997ed02eaf45393d215eab85b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37127",
+					"10.65.0.27:37127",
+					"172.17.0.1:37127",
+					"172.18.0.1:37127",
+					"172.19.0.1:37127"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:00:18.447693816Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7932525158031531,
+				"StableID":   "ngTRZ7zew421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f91cade6a55dca0d2ebbfd3eb44bca69de98ace29c6a61f3d5b386b1e203d52e",
+				"DiscoKey":   "discokey:c6dd270f49e3cf172e986e92199ebe59698817971f3ac8e99b5fb72c91d9db48",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60525",
+					"10.65.0.27:60525",
+					"172.17.0.1:60525",
+					"172.18.0.1:60525",
+					"172.19.0.1:60525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:00:18.992377546Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1744935358783853,
+				"StableID":   "n4UWQbVHdE11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39c33009ab3818b705a57d56bbc3bfed8cc04c5ad8003ef051867b6a180ae458",
+				"DiscoKey":   "discokey:9750b4d6a4a394507fe0cc056489b48338ebcff60490fa271adab87e7cc8ac0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60603",
+					"10.65.0.27:60603",
+					"172.17.0.1:60603",
+					"172.18.0.1:60603",
+					"172.19.0.1:60603"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:00:19.527026241Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3398469095503197,
+				"StableID":   "n8rcTB2BYT11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5eea7f3d801991e6ae7926271e67490fc3ba774fe237cdf16327d575d458704e",
+				"DiscoKey":   "discokey:3dd5cdacf99bf4d963cb9e8c014b3ecf8161163e65ec50e37dcef1d529487450",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41878",
+					"10.65.0.27:41878",
+					"172.17.0.1:41878",
+					"172.18.0.1:41878",
+					"172.19.0.1:41878"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:00:20.080861296Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         234006431339882,
+				"StableID":   "n5iA2Exyp211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9ff433350b9968c07bf2605ae1e20bfefd83898f3c443e28aee1aa03a5e911c",
+				"DiscoKey":   "discokey:61843908a1d80f24781056b259ceae421ead777674dfd73ff098f5e40140980c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33221",
+					"10.65.0.27:33221",
+					"172.17.0.1:33221",
+					"172.18.0.1:33221",
+					"172.19.0.1:33221"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:00:20.613506288Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8423653745613238,
+				"StableID":   "noT44o66n821CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fad0d445f382d0ea31bba8afc8dcebcfaf40e5649d5d56abf4fc417c8b4b491b",
+				"DiscoKey":   "discokey:1e752cd529a9d64c0c84739e1503019d94e61a0152c7db05089642c7bfe86c17",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:39159",
+					"10.65.0.27:39159",
+					"172.17.0.1:39159",
+					"172.18.0.1:39159",
+					"172.19.0.1:39159"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:00:21.153149942Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1871679810150988,
+				"StableID":   "nPYHZargcF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:42c4c743b3ea12f8b86e55e3e7812733134fcabcaa1088940abddf5ab11fb434",
+				"DiscoKey":   "discokey:93a224207e16c646980487a32d015f027ec8bc84ab432aae2b9a08011acc5508",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45176",
+					"10.65.0.27:45176",
+					"172.17.0.1:45176",
+					"172.18.0.1:45176",
+					"172.19.0.1:45176"
+				],
+				"HomeDERP": 26,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:00:21.698143017Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1063858269025390,
+				"StableID":   "ndktDfkpJ911CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86c332f64a9788d7b8275681c5379860d74dbdf5179822edc1bcdb891147432b",
+				"DiscoKey":   "discokey:05db89891926fbb9003e89bba8e1826b090c19b884c8fbb712d83eae09833b13",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44026",
+					"10.65.0.27:44026",
+					"172.17.0.1:44026",
+					"172.18.0.1:44026",
+					"172.19.0.1:44026"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:00:27.542246825Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1684851920459780,
+				"StableID":   "n1HzhmC5AE11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:272e170e0da4ec5bffc2432e83a4b0758830316bf5860d8a6ad6e76e47781310",
+				"DiscoKey":   "discokey:75035dcf3c2ec40bbe87e24023f5da381a212fc73c337d1a71f53dc7e698b114",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56041",
+					"10.65.0.27:56041",
+					"172.17.0.1:56041",
+					"172.18.0.1:56041",
+					"172.19.0.1:56041"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:00:28.087136807Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1052168206909879,
+				"StableID":   "ncTuT8gXD911CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1e8a11f71ca86e206da21d01a7fcdccb6333db5850dd720a0af074795e0ef231",
+				"DiscoKey":   "discokey:42032608e02f123bd743aaf3d2dd576712df36a25c22b6ccee7c12c64b75cb40",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45235",
+					"10.65.0.27:45235",
+					"172.17.0.1:45235",
+					"172.18.0.1:45235",
+					"172.19.0.1:45235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:00:28.625726675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4183537695037414,
+				"StableID":   "nm61GbSjfZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d665aa77c2e820cff31f080fa005082635b770a80633013a058e249ee38f074f",
+				"KeyExpiry":  "2026-11-08T22:00:29Z",
+				"DiscoKey":   "discokey:9cc96cef8fb25f68168ef23823b632532dc430c723f79f4f5f7e7c37d95d8146",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:37119",
+					"10.65.0.27:37119",
+					"172.17.0.1:37119",
+					"172.18.0.1:37119",
+					"172.19.0.1:37119"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:00:29.177641043Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6566737788524804,
+				"StableID":   "n7Wpdr46Ht11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:4753793038a82d7abd75c3267f95ab0ee1f8da6f46534764864aa30533e7184a",
+				"KeyExpiry":  "2026-11-08T22:00:29Z",
+				"DiscoKey":   "discokey:8581a18a51a3a7b18d3a1945e3238fa89f6828004b36050f293911f831806133",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60838",
+					"10.65.0.27:60838",
+					"172.17.0.1:60838",
+					"172.18.0.1:60838",
+					"172.19.0.1:60838"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:00:29.708221603Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3184032635943231,
+				"StableID":   "nLjBq194sR11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ba5c31084b83e39f24a466d2642f5cb4796cd2acde55ea2c20dad4a4824fc659",
+				"KeyExpiry":  "2026-11-08T22:00:30Z",
+				"DiscoKey":   "discokey:5c52cbb125ffb7b792638d0dc37bee23f8dd583bb595865cc72265f5cc75c602",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:32969",
+					"10.65.0.27:32969",
+					"172.17.0.1:32969",
+					"172.18.0.1:32969",
+					"172.19.0.1:32969"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:00:30.248951131Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4688437038264628": {
+				"ID":          4688437038264628,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6566737788524804,
+				"StableID":   "n7Wpdr46Ht11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:4753793038a82d7abd75c3267f95ab0ee1f8da6f46534764864aa30533e7184a",
+				"KeyExpiry":  "2026-11-08T22:00:29Z",
+				"DiscoKey":   "discokey:8581a18a51a3a7b18d3a1945e3238fa89f6828004b36050f293911f831806133",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60838",
+					"10.65.0.27:60838",
+					"172.17.0.1:60838",
+					"172.18.0.1:60838",
+					"172.19.0.1:60838"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:00:29.708221603Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4753793038a82d7abd75c3267f95ab0ee1f8da6f46534764864aa30533e7184a",
+			"MachineKey": "mkey:349bb4039252b1ccb6b94c940e9b663af117d8f3088bac6efc53b9536a1b423b",
+			"Peers": [{
+				"ID":         4495141380753413,
+				"StableID":   "nn5sv1kr6c11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:937530f808644d74694fae90ff94bca3eb2bfe885fe9352c67b711a6e07a2962",
+				"DiscoKey":   "discokey:f7b22608b81928325693a338c78ab912282d28b7ef42ad99c03ddc8c51adba53",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58185",
+					"10.65.0.27:58185",
+					"172.17.0.1:58185",
+					"172.18.0.1:58185",
+					"172.19.0.1:58185"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:00:17.947432139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1450381082602762,
+				"StableID":   "noh2gz3tKC11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eca4daa58421f834b68c9a1f924fdd344ec6b38086a555863fa36a9c5ab05266",
+				"DiscoKey":   "discokey:4e27b8354a1979df0dcb9971567a050eea2bdfa997ed02eaf45393d215eab85b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37127",
+					"10.65.0.27:37127",
+					"172.17.0.1:37127",
+					"172.18.0.1:37127",
+					"172.19.0.1:37127"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:00:18.447693816Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7932525158031531,
+				"StableID":   "ngTRZ7zew421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f91cade6a55dca0d2ebbfd3eb44bca69de98ace29c6a61f3d5b386b1e203d52e",
+				"DiscoKey":   "discokey:c6dd270f49e3cf172e986e92199ebe59698817971f3ac8e99b5fb72c91d9db48",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60525",
+					"10.65.0.27:60525",
+					"172.17.0.1:60525",
+					"172.18.0.1:60525",
+					"172.19.0.1:60525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:00:18.992377546Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1744935358783853,
+				"StableID":   "n4UWQbVHdE11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39c33009ab3818b705a57d56bbc3bfed8cc04c5ad8003ef051867b6a180ae458",
+				"DiscoKey":   "discokey:9750b4d6a4a394507fe0cc056489b48338ebcff60490fa271adab87e7cc8ac0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60603",
+					"10.65.0.27:60603",
+					"172.17.0.1:60603",
+					"172.18.0.1:60603",
+					"172.19.0.1:60603"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:00:19.527026241Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3398469095503197,
+				"StableID":   "n8rcTB2BYT11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5eea7f3d801991e6ae7926271e67490fc3ba774fe237cdf16327d575d458704e",
+				"DiscoKey":   "discokey:3dd5cdacf99bf4d963cb9e8c014b3ecf8161163e65ec50e37dcef1d529487450",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41878",
+					"10.65.0.27:41878",
+					"172.17.0.1:41878",
+					"172.18.0.1:41878",
+					"172.19.0.1:41878"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:00:20.080861296Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         234006431339882,
+				"StableID":   "n5iA2Exyp211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9ff433350b9968c07bf2605ae1e20bfefd83898f3c443e28aee1aa03a5e911c",
+				"DiscoKey":   "discokey:61843908a1d80f24781056b259ceae421ead777674dfd73ff098f5e40140980c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33221",
+					"10.65.0.27:33221",
+					"172.17.0.1:33221",
+					"172.18.0.1:33221",
+					"172.19.0.1:33221"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:00:20.613506288Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8423653745613238,
+				"StableID":   "noT44o66n821CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fad0d445f382d0ea31bba8afc8dcebcfaf40e5649d5d56abf4fc417c8b4b491b",
+				"DiscoKey":   "discokey:1e752cd529a9d64c0c84739e1503019d94e61a0152c7db05089642c7bfe86c17",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:39159",
+					"10.65.0.27:39159",
+					"172.17.0.1:39159",
+					"172.18.0.1:39159",
+					"172.19.0.1:39159"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:00:21.153149942Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1871679810150988,
+				"StableID":   "nPYHZargcF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:42c4c743b3ea12f8b86e55e3e7812733134fcabcaa1088940abddf5ab11fb434",
+				"DiscoKey":   "discokey:93a224207e16c646980487a32d015f027ec8bc84ab432aae2b9a08011acc5508",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45176",
+					"10.65.0.27:45176",
+					"172.17.0.1:45176",
+					"172.18.0.1:45176",
+					"172.19.0.1:45176"
+				],
+				"HomeDERP": 26,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:00:21.698143017Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4688437038264628,
+				"StableID":   "n9bqGsHQcd11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5740aa576367dce684ccee8be668840239ac24242a0b17e1b81b1fe9e703ac0d",
+				"DiscoKey":   "discokey:e2d2805ebe9114b0cbe5448f14191545652a129f13a5d2501388933b43996a15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41382",
+					"10.65.0.27:41382",
+					"172.17.0.1:41382",
+					"172.18.0.1:41382",
+					"172.19.0.1:41382"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:00:27.038567415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1063858269025390,
+				"StableID":   "ndktDfkpJ911CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86c332f64a9788d7b8275681c5379860d74dbdf5179822edc1bcdb891147432b",
+				"DiscoKey":   "discokey:05db89891926fbb9003e89bba8e1826b090c19b884c8fbb712d83eae09833b13",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44026",
+					"10.65.0.27:44026",
+					"172.17.0.1:44026",
+					"172.18.0.1:44026",
+					"172.19.0.1:44026"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:00:27.542246825Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1684851920459780,
+				"StableID":   "n1HzhmC5AE11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:272e170e0da4ec5bffc2432e83a4b0758830316bf5860d8a6ad6e76e47781310",
+				"DiscoKey":   "discokey:75035dcf3c2ec40bbe87e24023f5da381a212fc73c337d1a71f53dc7e698b114",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56041",
+					"10.65.0.27:56041",
+					"172.17.0.1:56041",
+					"172.18.0.1:56041",
+					"172.19.0.1:56041"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:00:28.087136807Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1052168206909879,
+				"StableID":   "ncTuT8gXD911CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1e8a11f71ca86e206da21d01a7fcdccb6333db5850dd720a0af074795e0ef231",
+				"DiscoKey":   "discokey:42032608e02f123bd743aaf3d2dd576712df36a25c22b6ccee7c12c64b75cb40",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45235",
+					"10.65.0.27:45235",
+					"172.17.0.1:45235",
+					"172.18.0.1:45235",
+					"172.19.0.1:45235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:00:28.625726675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4183537695037414,
+				"StableID":   "nm61GbSjfZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d665aa77c2e820cff31f080fa005082635b770a80633013a058e249ee38f074f",
+				"KeyExpiry":  "2026-11-08T22:00:29Z",
+				"DiscoKey":   "discokey:9cc96cef8fb25f68168ef23823b632532dc430c723f79f4f5f7e7c37d95d8146",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:37119",
+					"10.65.0.27:37119",
+					"172.17.0.1:37119",
+					"172.18.0.1:37119",
+					"172.19.0.1:37119"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:00:29.177641043Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3184032635943231,
+				"StableID":   "nLjBq194sR11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ba5c31084b83e39f24a466d2642f5cb4796cd2acde55ea2c20dad4a4824fc659",
+				"KeyExpiry":  "2026-11-08T22:00:30Z",
+				"DiscoKey":   "discokey:5c52cbb125ffb7b792638d0dc37bee23f8dd583bb595865cc72265f5cc75c602",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:32969",
+					"10.65.0.27:32969",
+					"172.17.0.1:32969",
+					"172.18.0.1:32969",
+					"172.19.0.1:32969"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:00:30.248951131Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1063858269025390,
+				"StableID":   "ndktDfkpJ911CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1063858269025390,
+				"Key":        "nodekey:86c332f64a9788d7b8275681c5379860d74dbdf5179822edc1bcdb891147432b",
+				"DiscoKey":   "discokey:05db89891926fbb9003e89bba8e1826b090c19b884c8fbb712d83eae09833b13",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44026",
+					"10.65.0.27:44026",
+					"172.17.0.1:44026",
+					"172.18.0.1:44026",
+					"172.19.0.1:44026"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:00:27.542246825Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:86c332f64a9788d7b8275681c5379860d74dbdf5179822edc1bcdb891147432b",
+			"MachineKey": "mkey:f75bad3c7df827343e2366b42bc26752fff0e6431a99d5335ed22c6364f6812c",
+			"Peers": [{
+				"ID":         4495141380753413,
+				"StableID":   "nn5sv1kr6c11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:937530f808644d74694fae90ff94bca3eb2bfe885fe9352c67b711a6e07a2962",
+				"DiscoKey":   "discokey:f7b22608b81928325693a338c78ab912282d28b7ef42ad99c03ddc8c51adba53",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58185",
+					"10.65.0.27:58185",
+					"172.17.0.1:58185",
+					"172.18.0.1:58185",
+					"172.19.0.1:58185"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:00:17.947432139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1450381082602762,
+				"StableID":   "noh2gz3tKC11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eca4daa58421f834b68c9a1f924fdd344ec6b38086a555863fa36a9c5ab05266",
+				"DiscoKey":   "discokey:4e27b8354a1979df0dcb9971567a050eea2bdfa997ed02eaf45393d215eab85b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37127",
+					"10.65.0.27:37127",
+					"172.17.0.1:37127",
+					"172.18.0.1:37127",
+					"172.19.0.1:37127"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:00:18.447693816Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7932525158031531,
+				"StableID":   "ngTRZ7zew421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f91cade6a55dca0d2ebbfd3eb44bca69de98ace29c6a61f3d5b386b1e203d52e",
+				"DiscoKey":   "discokey:c6dd270f49e3cf172e986e92199ebe59698817971f3ac8e99b5fb72c91d9db48",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60525",
+					"10.65.0.27:60525",
+					"172.17.0.1:60525",
+					"172.18.0.1:60525",
+					"172.19.0.1:60525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:00:18.992377546Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1744935358783853,
+				"StableID":   "n4UWQbVHdE11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39c33009ab3818b705a57d56bbc3bfed8cc04c5ad8003ef051867b6a180ae458",
+				"DiscoKey":   "discokey:9750b4d6a4a394507fe0cc056489b48338ebcff60490fa271adab87e7cc8ac0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60603",
+					"10.65.0.27:60603",
+					"172.17.0.1:60603",
+					"172.18.0.1:60603",
+					"172.19.0.1:60603"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:00:19.527026241Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3398469095503197,
+				"StableID":   "n8rcTB2BYT11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5eea7f3d801991e6ae7926271e67490fc3ba774fe237cdf16327d575d458704e",
+				"DiscoKey":   "discokey:3dd5cdacf99bf4d963cb9e8c014b3ecf8161163e65ec50e37dcef1d529487450",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41878",
+					"10.65.0.27:41878",
+					"172.17.0.1:41878",
+					"172.18.0.1:41878",
+					"172.19.0.1:41878"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:00:20.080861296Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         234006431339882,
+				"StableID":   "n5iA2Exyp211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9ff433350b9968c07bf2605ae1e20bfefd83898f3c443e28aee1aa03a5e911c",
+				"DiscoKey":   "discokey:61843908a1d80f24781056b259ceae421ead777674dfd73ff098f5e40140980c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33221",
+					"10.65.0.27:33221",
+					"172.17.0.1:33221",
+					"172.18.0.1:33221",
+					"172.19.0.1:33221"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:00:20.613506288Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8423653745613238,
+				"StableID":   "noT44o66n821CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fad0d445f382d0ea31bba8afc8dcebcfaf40e5649d5d56abf4fc417c8b4b491b",
+				"DiscoKey":   "discokey:1e752cd529a9d64c0c84739e1503019d94e61a0152c7db05089642c7bfe86c17",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:39159",
+					"10.65.0.27:39159",
+					"172.17.0.1:39159",
+					"172.18.0.1:39159",
+					"172.19.0.1:39159"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:00:21.153149942Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1871679810150988,
+				"StableID":   "nPYHZargcF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:42c4c743b3ea12f8b86e55e3e7812733134fcabcaa1088940abddf5ab11fb434",
+				"DiscoKey":   "discokey:93a224207e16c646980487a32d015f027ec8bc84ab432aae2b9a08011acc5508",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45176",
+					"10.65.0.27:45176",
+					"172.17.0.1:45176",
+					"172.18.0.1:45176",
+					"172.19.0.1:45176"
+				],
+				"HomeDERP": 26,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:00:21.698143017Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4688437038264628,
+				"StableID":   "n9bqGsHQcd11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5740aa576367dce684ccee8be668840239ac24242a0b17e1b81b1fe9e703ac0d",
+				"DiscoKey":   "discokey:e2d2805ebe9114b0cbe5448f14191545652a129f13a5d2501388933b43996a15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41382",
+					"10.65.0.27:41382",
+					"172.17.0.1:41382",
+					"172.18.0.1:41382",
+					"172.19.0.1:41382"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:00:27.038567415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1684851920459780,
+				"StableID":   "n1HzhmC5AE11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:272e170e0da4ec5bffc2432e83a4b0758830316bf5860d8a6ad6e76e47781310",
+				"DiscoKey":   "discokey:75035dcf3c2ec40bbe87e24023f5da381a212fc73c337d1a71f53dc7e698b114",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56041",
+					"10.65.0.27:56041",
+					"172.17.0.1:56041",
+					"172.18.0.1:56041",
+					"172.19.0.1:56041"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:00:28.087136807Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1052168206909879,
+				"StableID":   "ncTuT8gXD911CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1e8a11f71ca86e206da21d01a7fcdccb6333db5850dd720a0af074795e0ef231",
+				"DiscoKey":   "discokey:42032608e02f123bd743aaf3d2dd576712df36a25c22b6ccee7c12c64b75cb40",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45235",
+					"10.65.0.27:45235",
+					"172.17.0.1:45235",
+					"172.18.0.1:45235",
+					"172.19.0.1:45235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:00:28.625726675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4183537695037414,
+				"StableID":   "nm61GbSjfZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d665aa77c2e820cff31f080fa005082635b770a80633013a058e249ee38f074f",
+				"KeyExpiry":  "2026-11-08T22:00:29Z",
+				"DiscoKey":   "discokey:9cc96cef8fb25f68168ef23823b632532dc430c723f79f4f5f7e7c37d95d8146",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:37119",
+					"10.65.0.27:37119",
+					"172.17.0.1:37119",
+					"172.18.0.1:37119",
+					"172.19.0.1:37119"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:00:29.177641043Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6566737788524804,
+				"StableID":   "n7Wpdr46Ht11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:4753793038a82d7abd75c3267f95ab0ee1f8da6f46534764864aa30533e7184a",
+				"KeyExpiry":  "2026-11-08T22:00:29Z",
+				"DiscoKey":   "discokey:8581a18a51a3a7b18d3a1945e3238fa89f6828004b36050f293911f831806133",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60838",
+					"10.65.0.27:60838",
+					"172.17.0.1:60838",
+					"172.18.0.1:60838",
+					"172.19.0.1:60838"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:00:29.708221603Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3184032635943231,
+				"StableID":   "nLjBq194sR11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ba5c31084b83e39f24a466d2642f5cb4796cd2acde55ea2c20dad4a4824fc659",
+				"KeyExpiry":  "2026-11-08T22:00:30Z",
+				"DiscoKey":   "discokey:5c52cbb125ffb7b792638d0dc37bee23f8dd583bb595865cc72265f5cc75c602",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:32969",
+					"10.65.0.27:32969",
+					"172.17.0.1:32969",
+					"172.18.0.1:32969",
+					"172.19.0.1:32969"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:00:30.248951131Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1063858269025390": {
+				"ID":          1063858269025390,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-user-autogroup-member.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-user-autogroup-member.hujson
@@ -1,0 +1,20112 @@
+// ssh-malformed-user-autogroup-member
+//
+// ssh users autogroup:member is rejected
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T22:01:15Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-malformed-user-autogroup-member",
+	"description":    "ssh users autogroup:member is rejected",
+	"category":       "ssh",
+	"captured_at":    "2026-05-12T22:01:15.54740479Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                      \n  \n                                                                               \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh users autogroup:member is rejected\",\n\t\"id\":          \"ssh-malformed-user-autogroup-member\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"autogroup:member\"],\n\t\t\"users\":  [\"autogroup:member\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-malformed/ssh-malformed-user-autogroup-member.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["autogroup:member"],
+				"users":  ["autogroup:member"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1552676499746967,
+				"StableID":   "nzriPNBD8D11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1552676499746967,
+				"Key":        "nodekey:d1bea0530180043bd6c09dacd73c42c8dc75e8cba56560c0ef63751500499617",
+				"DiscoKey":   "discokey:59e55dc8f57d3e66a892dab38716bad360c707a39ecc0f65ac58a0d9e994eb1e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:40075",
+					"10.65.0.27:40075",
+					"172.17.0.1:40075",
+					"172.18.0.1:40075",
+					"172.19.0.1:40075"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:02:12.804604651Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d1bea0530180043bd6c09dacd73c42c8dc75e8cba56560c0ef63751500499617",
+			"MachineKey": "mkey:fb4039c5cf71d1314f6bb7d112412af713ac53e617accabddd8bbbca9fb54f79",
+			"Peers": [{
+				"ID":         3281193000221942,
+				"StableID":   "nsXhWpN4dS11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0086a787cae8961899b8d21db09bd878dd35723efb70e2be336509552b898269",
+				"DiscoKey":   "discokey:2f14238640f02240bb328ca4590814ff3f27d373d64916f802962067e2cd0a71",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38415",
+					"10.65.0.27:38415",
+					"172.17.0.1:38415",
+					"172.18.0.1:38415",
+					"172.19.0.1:38415"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:01:18.17236278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4766185274456039,
+				"StableID":   "nYRof6ccDe11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:adb3b489de7eebc64343a7a253f48c9aad9692ef13aa8ce29b1ea6d2f8ac365c",
+				"DiscoKey":   "discokey:7690097f29f4fbc829619f97de76e7947b0cdfd02406c5245b1316c001925348",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50045",
+					"10.65.0.27:50045",
+					"172.17.0.1:50045",
+					"172.18.0.1:50045",
+					"172.19.0.1:50045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:01:18.654536895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         538080972367332,
+				"StableID":   "nMFUxXUhC511CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:27dd848d78e935c87a87d3fbf367db9fe9ccd991de72ed6a2a304757f1db6439",
+				"DiscoKey":   "discokey:36eacbded1fe9b6d04901491ef8d3c6166619e3cd2ab89d30f10646b22fb2f15",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40623",
+					"10.65.0.27:40623",
+					"172.17.0.1:40623",
+					"172.18.0.1:40623",
+					"172.19.0.1:40623"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:01:19.196759907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7679630823091561,
+				"StableID":   "nG8EB1t7y221CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:70330263de73118f3ca9ef79a47b8312ff5bbafa502c4a9bf023285f63fe9e7c",
+				"DiscoKey":   "discokey:c446facb6f8d304709f153250adec71000d4049e186daa711d9735a250111851",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42418",
+					"10.65.0.27:42418",
+					"172.17.0.1:42418",
+					"172.18.0.1:42418",
+					"172.19.0.1:42418"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:01:19.725289158Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7598480586927999,
+				"StableID":   "nEUAhcCNL221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:968d2c0575b07efdb5cfae441618ac17721fca480a036ba33241aada2d46411e",
+				"DiscoKey":   "discokey:53201c269825934e1fba1c820b86b425e4f1e7dfffd83a07166e455009759a7c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:44426",
+					"10.65.0.27:44426",
+					"172.17.0.1:44426",
+					"172.18.0.1:44426",
+					"172.19.0.1:44426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:02:08.884137165Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7837764808078094,
+				"StableID":   "nTKfvsnjC421CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7c3e40a9ed0ff7d5aaa6d3c3bcdf4476d307a6aa350e02eab50c34ff3eebf802",
+				"DiscoKey":   "discokey:7613c59d9de023a1e89e2ec363b1448c2a6e17610f334441719b2bfb713ab935",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53066",
+					"10.65.0.27:53066",
+					"172.17.0.1:53066",
+					"172.18.0.1:53066",
+					"172.19.0.1:53066"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:02:09.44901447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3897120922254004,
+				"StableID":   "n97Vqyk1SX11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5cc95f5e89363d7b068291b5a91328034cd83874b4a9110890c5bac741e3be2b",
+				"DiscoKey":   "discokey:6934c6e438e79e31d99d6bc7dd843ab555b8ffb8943daf9af4e64fa29346261a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48441",
+					"10.65.0.27:48441",
+					"172.17.0.1:48441",
+					"172.18.0.1:48441",
+					"172.19.0.1:48441"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:02:09.947128895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3019417511731452,
+				"StableID":   "nXN81jyVaQ11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4d21c3c535aae23fb456f1835c3f37b13331f576439d020d787d00bb365a872",
+				"DiscoKey":   "discokey:1efba7dd66114ecbc6d6e8787d4ef0a876a55e6fd739e94674812894ce38d740",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57385",
+					"10.65.0.27:57385",
+					"172.17.0.1:57385",
+					"172.18.0.1:57385",
+					"172.19.0.1:57385"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:02:10.484613551Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3108214568090199,
+				"StableID":   "nkqUoWXiGR11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d28f478f06bd50f644a17739edaf1a1941bdf7905e94cf10977bc5d4e94ef4a",
+				"DiscoKey":   "discokey:2473ab0c7e1ba1a9375110c9b05a30ddce5838dc5550318ba19a0cd232c74464",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:57313",
+					"10.65.0.27:57313",
+					"172.17.0.1:57313",
+					"172.18.0.1:57313",
+					"172.19.0.1:57313"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:02:11.023346401Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1561625567398938,
+				"StableID":   "nZxcrpFGCD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc4e628c93e34160c6ee491175bc707ecfd774df8d546536182e785aeb9b4a26",
+				"DiscoKey":   "discokey:0196cba50c53deba824493433b17d2aadfddb1b4ae380ad0230bcaaad6019a24",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59933",
+					"10.65.0.27:59933",
+					"172.17.0.1:59933",
+					"172.18.0.1:59933",
+					"172.19.0.1:59933"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:02:11.715884325Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         699212911543336,
+				"StableID":   "nFpkey8gT611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93d1d4a8ec6a2319e7c60ebdbc96ba132de43149ed6ec0d80882e312a5934d5f",
+				"DiscoKey":   "discokey:9a26dd8f8eb613b478b7f54477331cdc9252d17a436e83b79eedcd951204e570",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48036",
+					"10.65.0.27:48036",
+					"172.17.0.1:48036",
+					"172.18.0.1:48036",
+					"172.19.0.1:48036"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:02:12.257434979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4245148950529360,
+				"StableID":   "nywrv8sd9a11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f2199499fd8615908740254269df16a742082ded1dd15f15f32e7a653187660d",
+				"KeyExpiry":  "2026-11-08T22:02:13Z",
+				"DiscoKey":   "discokey:2f19acc3b823c9d54adc97caeef31822a3b8cd8cd694b5e14d404ebfea13876e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48259",
+					"10.65.0.27:48259",
+					"172.17.0.1:48259",
+					"172.18.0.1:48259",
+					"172.19.0.1:48259"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:02:13.344910068Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1015446840501143,
+				"StableID":   "nSLX4s4uv811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b2e1badd530efba26faeb09079974118ac4899f8db05071fbb8a0dc16a1d1c66",
+				"KeyExpiry":  "2026-11-08T22:02:13Z",
+				"DiscoKey":   "discokey:16ad1c72302127fc9ca8eacbda21ee743e3ac8a83a42dbf9ad19713e8b5a7e30",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54989",
+					"10.65.0.27:54989",
+					"172.17.0.1:54989",
+					"172.18.0.1:54989",
+					"172.19.0.1:54989"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:02:13.881469153Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4957581331602300,
+				"StableID":   "nfWNqnFJif11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:30ed4d4a10ff8d4868148cf523c0c32816637b0ac36c9ab8be625f423668a818",
+				"KeyExpiry":  "2026-11-08T22:02:14Z",
+				"DiscoKey":   "discokey:ae1dabc9c565a6613dcbb9917108a4cee945005c3c56a14701700a03a183170f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47239",
+					"10.65.0.27:47239",
+					"172.17.0.1:47239",
+					"172.18.0.1:47239",
+					"172.19.0.1:47239"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:02:14.424652089Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{
+				"principals": [
+					{"nodeIP": "100.64.0.17"},
+					{"nodeIP": "100.64.0.18"},
+					{"nodeIP": "100.64.0.19"},
+					{"nodeIP": "fd7a:115c:a1e0::11"},
+					{"nodeIP": "fd7a:115c:a1e0::13"},
+					{"nodeIP": "fd7a:115c:a1e0::12"}
+				],
+				"sshUsers": {"autogroup:member": "autogroup:member", "root": ""},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				}
+			}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1552676499746967": {
+				"ID":          1552676499746967,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		},
+		"ssh_rules": [{
+			"principals": [
+				{"nodeIP": "100.64.0.17"},
+				{"nodeIP": "100.64.0.18"},
+				{"nodeIP": "100.64.0.19"},
+				{"nodeIP": "fd7a:115c:a1e0::11"},
+				{"nodeIP": "fd7a:115c:a1e0::13"},
+				{"nodeIP": "fd7a:115c:a1e0::12"}
+			],
+			"sshUsers": {"autogroup:member": "autogroup:member", "root": ""},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}
+		}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7837764808078094,
+				"StableID":   "nTKfvsnjC421CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       7837764808078094,
+				"Key":        "nodekey:7c3e40a9ed0ff7d5aaa6d3c3bcdf4476d307a6aa350e02eab50c34ff3eebf802",
+				"DiscoKey":   "discokey:7613c59d9de023a1e89e2ec363b1448c2a6e17610f334441719b2bfb713ab935",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53066",
+					"10.65.0.27:53066",
+					"172.17.0.1:53066",
+					"172.18.0.1:53066",
+					"172.19.0.1:53066"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:02:09.44901447Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7c3e40a9ed0ff7d5aaa6d3c3bcdf4476d307a6aa350e02eab50c34ff3eebf802",
+			"MachineKey": "mkey:f7081ea50b84a4fbe89e658e3b929f16802b209b91c75ba3d168167ef6460b6f",
+			"Peers": [{
+				"ID":         3281193000221942,
+				"StableID":   "nsXhWpN4dS11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0086a787cae8961899b8d21db09bd878dd35723efb70e2be336509552b898269",
+				"DiscoKey":   "discokey:2f14238640f02240bb328ca4590814ff3f27d373d64916f802962067e2cd0a71",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38415",
+					"10.65.0.27:38415",
+					"172.17.0.1:38415",
+					"172.18.0.1:38415",
+					"172.19.0.1:38415"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:01:18.17236278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4766185274456039,
+				"StableID":   "nYRof6ccDe11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:adb3b489de7eebc64343a7a253f48c9aad9692ef13aa8ce29b1ea6d2f8ac365c",
+				"DiscoKey":   "discokey:7690097f29f4fbc829619f97de76e7947b0cdfd02406c5245b1316c001925348",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50045",
+					"10.65.0.27:50045",
+					"172.17.0.1:50045",
+					"172.18.0.1:50045",
+					"172.19.0.1:50045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:01:18.654536895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         538080972367332,
+				"StableID":   "nMFUxXUhC511CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:27dd848d78e935c87a87d3fbf367db9fe9ccd991de72ed6a2a304757f1db6439",
+				"DiscoKey":   "discokey:36eacbded1fe9b6d04901491ef8d3c6166619e3cd2ab89d30f10646b22fb2f15",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40623",
+					"10.65.0.27:40623",
+					"172.17.0.1:40623",
+					"172.18.0.1:40623",
+					"172.19.0.1:40623"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:01:19.196759907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7679630823091561,
+				"StableID":   "nG8EB1t7y221CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:70330263de73118f3ca9ef79a47b8312ff5bbafa502c4a9bf023285f63fe9e7c",
+				"DiscoKey":   "discokey:c446facb6f8d304709f153250adec71000d4049e186daa711d9735a250111851",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42418",
+					"10.65.0.27:42418",
+					"172.17.0.1:42418",
+					"172.18.0.1:42418",
+					"172.19.0.1:42418"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:01:19.725289158Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7598480586927999,
+				"StableID":   "nEUAhcCNL221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:968d2c0575b07efdb5cfae441618ac17721fca480a036ba33241aada2d46411e",
+				"DiscoKey":   "discokey:53201c269825934e1fba1c820b86b425e4f1e7dfffd83a07166e455009759a7c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:44426",
+					"10.65.0.27:44426",
+					"172.17.0.1:44426",
+					"172.18.0.1:44426",
+					"172.19.0.1:44426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:02:08.884137165Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3897120922254004,
+				"StableID":   "n97Vqyk1SX11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5cc95f5e89363d7b068291b5a91328034cd83874b4a9110890c5bac741e3be2b",
+				"DiscoKey":   "discokey:6934c6e438e79e31d99d6bc7dd843ab555b8ffb8943daf9af4e64fa29346261a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48441",
+					"10.65.0.27:48441",
+					"172.17.0.1:48441",
+					"172.18.0.1:48441",
+					"172.19.0.1:48441"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:02:09.947128895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3019417511731452,
+				"StableID":   "nXN81jyVaQ11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4d21c3c535aae23fb456f1835c3f37b13331f576439d020d787d00bb365a872",
+				"DiscoKey":   "discokey:1efba7dd66114ecbc6d6e8787d4ef0a876a55e6fd739e94674812894ce38d740",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57385",
+					"10.65.0.27:57385",
+					"172.17.0.1:57385",
+					"172.18.0.1:57385",
+					"172.19.0.1:57385"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:02:10.484613551Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3108214568090199,
+				"StableID":   "nkqUoWXiGR11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d28f478f06bd50f644a17739edaf1a1941bdf7905e94cf10977bc5d4e94ef4a",
+				"DiscoKey":   "discokey:2473ab0c7e1ba1a9375110c9b05a30ddce5838dc5550318ba19a0cd232c74464",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:57313",
+					"10.65.0.27:57313",
+					"172.17.0.1:57313",
+					"172.18.0.1:57313",
+					"172.19.0.1:57313"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:02:11.023346401Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1561625567398938,
+				"StableID":   "nZxcrpFGCD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc4e628c93e34160c6ee491175bc707ecfd774df8d546536182e785aeb9b4a26",
+				"DiscoKey":   "discokey:0196cba50c53deba824493433b17d2aadfddb1b4ae380ad0230bcaaad6019a24",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59933",
+					"10.65.0.27:59933",
+					"172.17.0.1:59933",
+					"172.18.0.1:59933",
+					"172.19.0.1:59933"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:02:11.715884325Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         699212911543336,
+				"StableID":   "nFpkey8gT611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93d1d4a8ec6a2319e7c60ebdbc96ba132de43149ed6ec0d80882e312a5934d5f",
+				"DiscoKey":   "discokey:9a26dd8f8eb613b478b7f54477331cdc9252d17a436e83b79eedcd951204e570",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48036",
+					"10.65.0.27:48036",
+					"172.17.0.1:48036",
+					"172.18.0.1:48036",
+					"172.19.0.1:48036"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:02:12.257434979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1552676499746967,
+				"StableID":   "nzriPNBD8D11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1bea0530180043bd6c09dacd73c42c8dc75e8cba56560c0ef63751500499617",
+				"DiscoKey":   "discokey:59e55dc8f57d3e66a892dab38716bad360c707a39ecc0f65ac58a0d9e994eb1e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:40075",
+					"10.65.0.27:40075",
+					"172.17.0.1:40075",
+					"172.18.0.1:40075",
+					"172.19.0.1:40075"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:02:12.804604651Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4245148950529360,
+				"StableID":   "nywrv8sd9a11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f2199499fd8615908740254269df16a742082ded1dd15f15f32e7a653187660d",
+				"KeyExpiry":  "2026-11-08T22:02:13Z",
+				"DiscoKey":   "discokey:2f19acc3b823c9d54adc97caeef31822a3b8cd8cd694b5e14d404ebfea13876e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48259",
+					"10.65.0.27:48259",
+					"172.17.0.1:48259",
+					"172.18.0.1:48259",
+					"172.19.0.1:48259"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:02:13.344910068Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1015446840501143,
+				"StableID":   "nSLX4s4uv811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b2e1badd530efba26faeb09079974118ac4899f8db05071fbb8a0dc16a1d1c66",
+				"KeyExpiry":  "2026-11-08T22:02:13Z",
+				"DiscoKey":   "discokey:16ad1c72302127fc9ca8eacbda21ee743e3ac8a83a42dbf9ad19713e8b5a7e30",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54989",
+					"10.65.0.27:54989",
+					"172.17.0.1:54989",
+					"172.18.0.1:54989",
+					"172.19.0.1:54989"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:02:13.881469153Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4957581331602300,
+				"StableID":   "nfWNqnFJif11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:30ed4d4a10ff8d4868148cf523c0c32816637b0ac36c9ab8be625f423668a818",
+				"KeyExpiry":  "2026-11-08T22:02:14Z",
+				"DiscoKey":   "discokey:ae1dabc9c565a6613dcbb9917108a4cee945005c3c56a14701700a03a183170f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47239",
+					"10.65.0.27:47239",
+					"172.17.0.1:47239",
+					"172.18.0.1:47239",
+					"172.19.0.1:47239"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:02:14.424652089Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7837764808078094": {
+				"ID":          7837764808078094,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4957581331602300,
+				"StableID":   "nfWNqnFJif11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:30ed4d4a10ff8d4868148cf523c0c32816637b0ac36c9ab8be625f423668a818",
+				"KeyExpiry":  "2026-11-08T22:02:14Z",
+				"DiscoKey":   "discokey:ae1dabc9c565a6613dcbb9917108a4cee945005c3c56a14701700a03a183170f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47239",
+					"10.65.0.27:47239",
+					"172.17.0.1:47239",
+					"172.18.0.1:47239",
+					"172.19.0.1:47239"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:02:14.424652089Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:30ed4d4a10ff8d4868148cf523c0c32816637b0ac36c9ab8be625f423668a818",
+			"MachineKey": "mkey:2bcf248d02db67a6e2bb8925403b1102f3f007750d0a6e63cac14079050df032",
+			"Peers": [{
+				"ID":         3281193000221942,
+				"StableID":   "nsXhWpN4dS11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0086a787cae8961899b8d21db09bd878dd35723efb70e2be336509552b898269",
+				"DiscoKey":   "discokey:2f14238640f02240bb328ca4590814ff3f27d373d64916f802962067e2cd0a71",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38415",
+					"10.65.0.27:38415",
+					"172.17.0.1:38415",
+					"172.18.0.1:38415",
+					"172.19.0.1:38415"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:01:18.17236278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4766185274456039,
+				"StableID":   "nYRof6ccDe11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:adb3b489de7eebc64343a7a253f48c9aad9692ef13aa8ce29b1ea6d2f8ac365c",
+				"DiscoKey":   "discokey:7690097f29f4fbc829619f97de76e7947b0cdfd02406c5245b1316c001925348",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50045",
+					"10.65.0.27:50045",
+					"172.17.0.1:50045",
+					"172.18.0.1:50045",
+					"172.19.0.1:50045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:01:18.654536895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         538080972367332,
+				"StableID":   "nMFUxXUhC511CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:27dd848d78e935c87a87d3fbf367db9fe9ccd991de72ed6a2a304757f1db6439",
+				"DiscoKey":   "discokey:36eacbded1fe9b6d04901491ef8d3c6166619e3cd2ab89d30f10646b22fb2f15",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40623",
+					"10.65.0.27:40623",
+					"172.17.0.1:40623",
+					"172.18.0.1:40623",
+					"172.19.0.1:40623"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:01:19.196759907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7679630823091561,
+				"StableID":   "nG8EB1t7y221CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:70330263de73118f3ca9ef79a47b8312ff5bbafa502c4a9bf023285f63fe9e7c",
+				"DiscoKey":   "discokey:c446facb6f8d304709f153250adec71000d4049e186daa711d9735a250111851",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42418",
+					"10.65.0.27:42418",
+					"172.17.0.1:42418",
+					"172.18.0.1:42418",
+					"172.19.0.1:42418"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:01:19.725289158Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7598480586927999,
+				"StableID":   "nEUAhcCNL221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:968d2c0575b07efdb5cfae441618ac17721fca480a036ba33241aada2d46411e",
+				"DiscoKey":   "discokey:53201c269825934e1fba1c820b86b425e4f1e7dfffd83a07166e455009759a7c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:44426",
+					"10.65.0.27:44426",
+					"172.17.0.1:44426",
+					"172.18.0.1:44426",
+					"172.19.0.1:44426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:02:08.884137165Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7837764808078094,
+				"StableID":   "nTKfvsnjC421CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7c3e40a9ed0ff7d5aaa6d3c3bcdf4476d307a6aa350e02eab50c34ff3eebf802",
+				"DiscoKey":   "discokey:7613c59d9de023a1e89e2ec363b1448c2a6e17610f334441719b2bfb713ab935",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53066",
+					"10.65.0.27:53066",
+					"172.17.0.1:53066",
+					"172.18.0.1:53066",
+					"172.19.0.1:53066"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:02:09.44901447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3897120922254004,
+				"StableID":   "n97Vqyk1SX11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5cc95f5e89363d7b068291b5a91328034cd83874b4a9110890c5bac741e3be2b",
+				"DiscoKey":   "discokey:6934c6e438e79e31d99d6bc7dd843ab555b8ffb8943daf9af4e64fa29346261a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48441",
+					"10.65.0.27:48441",
+					"172.17.0.1:48441",
+					"172.18.0.1:48441",
+					"172.19.0.1:48441"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:02:09.947128895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3019417511731452,
+				"StableID":   "nXN81jyVaQ11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4d21c3c535aae23fb456f1835c3f37b13331f576439d020d787d00bb365a872",
+				"DiscoKey":   "discokey:1efba7dd66114ecbc6d6e8787d4ef0a876a55e6fd739e94674812894ce38d740",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57385",
+					"10.65.0.27:57385",
+					"172.17.0.1:57385",
+					"172.18.0.1:57385",
+					"172.19.0.1:57385"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:02:10.484613551Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3108214568090199,
+				"StableID":   "nkqUoWXiGR11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d28f478f06bd50f644a17739edaf1a1941bdf7905e94cf10977bc5d4e94ef4a",
+				"DiscoKey":   "discokey:2473ab0c7e1ba1a9375110c9b05a30ddce5838dc5550318ba19a0cd232c74464",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:57313",
+					"10.65.0.27:57313",
+					"172.17.0.1:57313",
+					"172.18.0.1:57313",
+					"172.19.0.1:57313"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:02:11.023346401Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1561625567398938,
+				"StableID":   "nZxcrpFGCD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc4e628c93e34160c6ee491175bc707ecfd774df8d546536182e785aeb9b4a26",
+				"DiscoKey":   "discokey:0196cba50c53deba824493433b17d2aadfddb1b4ae380ad0230bcaaad6019a24",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59933",
+					"10.65.0.27:59933",
+					"172.17.0.1:59933",
+					"172.18.0.1:59933",
+					"172.19.0.1:59933"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:02:11.715884325Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         699212911543336,
+				"StableID":   "nFpkey8gT611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93d1d4a8ec6a2319e7c60ebdbc96ba132de43149ed6ec0d80882e312a5934d5f",
+				"DiscoKey":   "discokey:9a26dd8f8eb613b478b7f54477331cdc9252d17a436e83b79eedcd951204e570",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48036",
+					"10.65.0.27:48036",
+					"172.17.0.1:48036",
+					"172.18.0.1:48036",
+					"172.19.0.1:48036"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:02:12.257434979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1552676499746967,
+				"StableID":   "nzriPNBD8D11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1bea0530180043bd6c09dacd73c42c8dc75e8cba56560c0ef63751500499617",
+				"DiscoKey":   "discokey:59e55dc8f57d3e66a892dab38716bad360c707a39ecc0f65ac58a0d9e994eb1e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:40075",
+					"10.65.0.27:40075",
+					"172.17.0.1:40075",
+					"172.18.0.1:40075",
+					"172.19.0.1:40075"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:02:12.804604651Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4245148950529360,
+				"StableID":   "nywrv8sd9a11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f2199499fd8615908740254269df16a742082ded1dd15f15f32e7a653187660d",
+				"KeyExpiry":  "2026-11-08T22:02:13Z",
+				"DiscoKey":   "discokey:2f19acc3b823c9d54adc97caeef31822a3b8cd8cd694b5e14d404ebfea13876e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48259",
+					"10.65.0.27:48259",
+					"172.17.0.1:48259",
+					"172.18.0.1:48259",
+					"172.19.0.1:48259"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:02:13.344910068Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1015446840501143,
+				"StableID":   "nSLX4s4uv811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b2e1badd530efba26faeb09079974118ac4899f8db05071fbb8a0dc16a1d1c66",
+				"KeyExpiry":  "2026-11-08T22:02:13Z",
+				"DiscoKey":   "discokey:16ad1c72302127fc9ca8eacbda21ee743e3ac8a83a42dbf9ad19713e8b5a7e30",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54989",
+					"10.65.0.27:54989",
+					"172.17.0.1:54989",
+					"172.18.0.1:54989",
+					"172.19.0.1:54989"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:02:13.881469153Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         538080972367332,
+				"StableID":   "nMFUxXUhC511CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       538080972367332,
+				"Key":        "nodekey:27dd848d78e935c87a87d3fbf367db9fe9ccd991de72ed6a2a304757f1db6439",
+				"DiscoKey":   "discokey:36eacbded1fe9b6d04901491ef8d3c6166619e3cd2ab89d30f10646b22fb2f15",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40623",
+					"10.65.0.27:40623",
+					"172.17.0.1:40623",
+					"172.18.0.1:40623",
+					"172.19.0.1:40623"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:01:19.196759907Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:27dd848d78e935c87a87d3fbf367db9fe9ccd991de72ed6a2a304757f1db6439",
+			"MachineKey": "mkey:25456f095bc510bec87afcb879c2830f079862583e55536bdf9325c942c3cb49",
+			"Peers": [{
+				"ID":         3281193000221942,
+				"StableID":   "nsXhWpN4dS11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0086a787cae8961899b8d21db09bd878dd35723efb70e2be336509552b898269",
+				"DiscoKey":   "discokey:2f14238640f02240bb328ca4590814ff3f27d373d64916f802962067e2cd0a71",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38415",
+					"10.65.0.27:38415",
+					"172.17.0.1:38415",
+					"172.18.0.1:38415",
+					"172.19.0.1:38415"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:01:18.17236278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4766185274456039,
+				"StableID":   "nYRof6ccDe11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:adb3b489de7eebc64343a7a253f48c9aad9692ef13aa8ce29b1ea6d2f8ac365c",
+				"DiscoKey":   "discokey:7690097f29f4fbc829619f97de76e7947b0cdfd02406c5245b1316c001925348",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50045",
+					"10.65.0.27:50045",
+					"172.17.0.1:50045",
+					"172.18.0.1:50045",
+					"172.19.0.1:50045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:01:18.654536895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7679630823091561,
+				"StableID":   "nG8EB1t7y221CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:70330263de73118f3ca9ef79a47b8312ff5bbafa502c4a9bf023285f63fe9e7c",
+				"DiscoKey":   "discokey:c446facb6f8d304709f153250adec71000d4049e186daa711d9735a250111851",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42418",
+					"10.65.0.27:42418",
+					"172.17.0.1:42418",
+					"172.18.0.1:42418",
+					"172.19.0.1:42418"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:01:19.725289158Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7598480586927999,
+				"StableID":   "nEUAhcCNL221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:968d2c0575b07efdb5cfae441618ac17721fca480a036ba33241aada2d46411e",
+				"DiscoKey":   "discokey:53201c269825934e1fba1c820b86b425e4f1e7dfffd83a07166e455009759a7c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:44426",
+					"10.65.0.27:44426",
+					"172.17.0.1:44426",
+					"172.18.0.1:44426",
+					"172.19.0.1:44426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:02:08.884137165Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7837764808078094,
+				"StableID":   "nTKfvsnjC421CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7c3e40a9ed0ff7d5aaa6d3c3bcdf4476d307a6aa350e02eab50c34ff3eebf802",
+				"DiscoKey":   "discokey:7613c59d9de023a1e89e2ec363b1448c2a6e17610f334441719b2bfb713ab935",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53066",
+					"10.65.0.27:53066",
+					"172.17.0.1:53066",
+					"172.18.0.1:53066",
+					"172.19.0.1:53066"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:02:09.44901447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3897120922254004,
+				"StableID":   "n97Vqyk1SX11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5cc95f5e89363d7b068291b5a91328034cd83874b4a9110890c5bac741e3be2b",
+				"DiscoKey":   "discokey:6934c6e438e79e31d99d6bc7dd843ab555b8ffb8943daf9af4e64fa29346261a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48441",
+					"10.65.0.27:48441",
+					"172.17.0.1:48441",
+					"172.18.0.1:48441",
+					"172.19.0.1:48441"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:02:09.947128895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3019417511731452,
+				"StableID":   "nXN81jyVaQ11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4d21c3c535aae23fb456f1835c3f37b13331f576439d020d787d00bb365a872",
+				"DiscoKey":   "discokey:1efba7dd66114ecbc6d6e8787d4ef0a876a55e6fd739e94674812894ce38d740",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57385",
+					"10.65.0.27:57385",
+					"172.17.0.1:57385",
+					"172.18.0.1:57385",
+					"172.19.0.1:57385"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:02:10.484613551Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3108214568090199,
+				"StableID":   "nkqUoWXiGR11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d28f478f06bd50f644a17739edaf1a1941bdf7905e94cf10977bc5d4e94ef4a",
+				"DiscoKey":   "discokey:2473ab0c7e1ba1a9375110c9b05a30ddce5838dc5550318ba19a0cd232c74464",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:57313",
+					"10.65.0.27:57313",
+					"172.17.0.1:57313",
+					"172.18.0.1:57313",
+					"172.19.0.1:57313"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:02:11.023346401Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1561625567398938,
+				"StableID":   "nZxcrpFGCD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc4e628c93e34160c6ee491175bc707ecfd774df8d546536182e785aeb9b4a26",
+				"DiscoKey":   "discokey:0196cba50c53deba824493433b17d2aadfddb1b4ae380ad0230bcaaad6019a24",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59933",
+					"10.65.0.27:59933",
+					"172.17.0.1:59933",
+					"172.18.0.1:59933",
+					"172.19.0.1:59933"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:02:11.715884325Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         699212911543336,
+				"StableID":   "nFpkey8gT611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93d1d4a8ec6a2319e7c60ebdbc96ba132de43149ed6ec0d80882e312a5934d5f",
+				"DiscoKey":   "discokey:9a26dd8f8eb613b478b7f54477331cdc9252d17a436e83b79eedcd951204e570",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48036",
+					"10.65.0.27:48036",
+					"172.17.0.1:48036",
+					"172.18.0.1:48036",
+					"172.19.0.1:48036"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:02:12.257434979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1552676499746967,
+				"StableID":   "nzriPNBD8D11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1bea0530180043bd6c09dacd73c42c8dc75e8cba56560c0ef63751500499617",
+				"DiscoKey":   "discokey:59e55dc8f57d3e66a892dab38716bad360c707a39ecc0f65ac58a0d9e994eb1e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:40075",
+					"10.65.0.27:40075",
+					"172.17.0.1:40075",
+					"172.18.0.1:40075",
+					"172.19.0.1:40075"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:02:12.804604651Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4245148950529360,
+				"StableID":   "nywrv8sd9a11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f2199499fd8615908740254269df16a742082ded1dd15f15f32e7a653187660d",
+				"KeyExpiry":  "2026-11-08T22:02:13Z",
+				"DiscoKey":   "discokey:2f19acc3b823c9d54adc97caeef31822a3b8cd8cd694b5e14d404ebfea13876e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48259",
+					"10.65.0.27:48259",
+					"172.17.0.1:48259",
+					"172.18.0.1:48259",
+					"172.19.0.1:48259"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:02:13.344910068Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1015446840501143,
+				"StableID":   "nSLX4s4uv811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b2e1badd530efba26faeb09079974118ac4899f8db05071fbb8a0dc16a1d1c66",
+				"KeyExpiry":  "2026-11-08T22:02:13Z",
+				"DiscoKey":   "discokey:16ad1c72302127fc9ca8eacbda21ee743e3ac8a83a42dbf9ad19713e8b5a7e30",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54989",
+					"10.65.0.27:54989",
+					"172.17.0.1:54989",
+					"172.18.0.1:54989",
+					"172.19.0.1:54989"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:02:13.881469153Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4957581331602300,
+				"StableID":   "nfWNqnFJif11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:30ed4d4a10ff8d4868148cf523c0c32816637b0ac36c9ab8be625f423668a818",
+				"KeyExpiry":  "2026-11-08T22:02:14Z",
+				"DiscoKey":   "discokey:ae1dabc9c565a6613dcbb9917108a4cee945005c3c56a14701700a03a183170f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47239",
+					"10.65.0.27:47239",
+					"172.17.0.1:47239",
+					"172.18.0.1:47239",
+					"172.19.0.1:47239"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:02:14.424652089Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "538080972367332": {
+				"ID":          538080972367332,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3019417511731452,
+				"StableID":   "nXN81jyVaQ11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       3019417511731452,
+				"Key":        "nodekey:b4d21c3c535aae23fb456f1835c3f37b13331f576439d020d787d00bb365a872",
+				"DiscoKey":   "discokey:1efba7dd66114ecbc6d6e8787d4ef0a876a55e6fd739e94674812894ce38d740",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57385",
+					"10.65.0.27:57385",
+					"172.17.0.1:57385",
+					"172.18.0.1:57385",
+					"172.19.0.1:57385"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:02:10.484613551Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b4d21c3c535aae23fb456f1835c3f37b13331f576439d020d787d00bb365a872",
+			"MachineKey": "mkey:30c2d5389bafc1eb8add61c63ea2469610a7367ca8bf20081f4b520b3d130f50",
+			"Peers": [{
+				"ID":         3281193000221942,
+				"StableID":   "nsXhWpN4dS11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0086a787cae8961899b8d21db09bd878dd35723efb70e2be336509552b898269",
+				"DiscoKey":   "discokey:2f14238640f02240bb328ca4590814ff3f27d373d64916f802962067e2cd0a71",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38415",
+					"10.65.0.27:38415",
+					"172.17.0.1:38415",
+					"172.18.0.1:38415",
+					"172.19.0.1:38415"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:01:18.17236278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4766185274456039,
+				"StableID":   "nYRof6ccDe11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:adb3b489de7eebc64343a7a253f48c9aad9692ef13aa8ce29b1ea6d2f8ac365c",
+				"DiscoKey":   "discokey:7690097f29f4fbc829619f97de76e7947b0cdfd02406c5245b1316c001925348",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50045",
+					"10.65.0.27:50045",
+					"172.17.0.1:50045",
+					"172.18.0.1:50045",
+					"172.19.0.1:50045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:01:18.654536895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         538080972367332,
+				"StableID":   "nMFUxXUhC511CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:27dd848d78e935c87a87d3fbf367db9fe9ccd991de72ed6a2a304757f1db6439",
+				"DiscoKey":   "discokey:36eacbded1fe9b6d04901491ef8d3c6166619e3cd2ab89d30f10646b22fb2f15",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40623",
+					"10.65.0.27:40623",
+					"172.17.0.1:40623",
+					"172.18.0.1:40623",
+					"172.19.0.1:40623"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:01:19.196759907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7679630823091561,
+				"StableID":   "nG8EB1t7y221CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:70330263de73118f3ca9ef79a47b8312ff5bbafa502c4a9bf023285f63fe9e7c",
+				"DiscoKey":   "discokey:c446facb6f8d304709f153250adec71000d4049e186daa711d9735a250111851",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42418",
+					"10.65.0.27:42418",
+					"172.17.0.1:42418",
+					"172.18.0.1:42418",
+					"172.19.0.1:42418"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:01:19.725289158Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7598480586927999,
+				"StableID":   "nEUAhcCNL221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:968d2c0575b07efdb5cfae441618ac17721fca480a036ba33241aada2d46411e",
+				"DiscoKey":   "discokey:53201c269825934e1fba1c820b86b425e4f1e7dfffd83a07166e455009759a7c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:44426",
+					"10.65.0.27:44426",
+					"172.17.0.1:44426",
+					"172.18.0.1:44426",
+					"172.19.0.1:44426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:02:08.884137165Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7837764808078094,
+				"StableID":   "nTKfvsnjC421CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7c3e40a9ed0ff7d5aaa6d3c3bcdf4476d307a6aa350e02eab50c34ff3eebf802",
+				"DiscoKey":   "discokey:7613c59d9de023a1e89e2ec363b1448c2a6e17610f334441719b2bfb713ab935",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53066",
+					"10.65.0.27:53066",
+					"172.17.0.1:53066",
+					"172.18.0.1:53066",
+					"172.19.0.1:53066"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:02:09.44901447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3897120922254004,
+				"StableID":   "n97Vqyk1SX11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5cc95f5e89363d7b068291b5a91328034cd83874b4a9110890c5bac741e3be2b",
+				"DiscoKey":   "discokey:6934c6e438e79e31d99d6bc7dd843ab555b8ffb8943daf9af4e64fa29346261a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48441",
+					"10.65.0.27:48441",
+					"172.17.0.1:48441",
+					"172.18.0.1:48441",
+					"172.19.0.1:48441"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:02:09.947128895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3108214568090199,
+				"StableID":   "nkqUoWXiGR11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d28f478f06bd50f644a17739edaf1a1941bdf7905e94cf10977bc5d4e94ef4a",
+				"DiscoKey":   "discokey:2473ab0c7e1ba1a9375110c9b05a30ddce5838dc5550318ba19a0cd232c74464",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:57313",
+					"10.65.0.27:57313",
+					"172.17.0.1:57313",
+					"172.18.0.1:57313",
+					"172.19.0.1:57313"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:02:11.023346401Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1561625567398938,
+				"StableID":   "nZxcrpFGCD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc4e628c93e34160c6ee491175bc707ecfd774df8d546536182e785aeb9b4a26",
+				"DiscoKey":   "discokey:0196cba50c53deba824493433b17d2aadfddb1b4ae380ad0230bcaaad6019a24",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59933",
+					"10.65.0.27:59933",
+					"172.17.0.1:59933",
+					"172.18.0.1:59933",
+					"172.19.0.1:59933"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:02:11.715884325Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         699212911543336,
+				"StableID":   "nFpkey8gT611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93d1d4a8ec6a2319e7c60ebdbc96ba132de43149ed6ec0d80882e312a5934d5f",
+				"DiscoKey":   "discokey:9a26dd8f8eb613b478b7f54477331cdc9252d17a436e83b79eedcd951204e570",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48036",
+					"10.65.0.27:48036",
+					"172.17.0.1:48036",
+					"172.18.0.1:48036",
+					"172.19.0.1:48036"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:02:12.257434979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1552676499746967,
+				"StableID":   "nzriPNBD8D11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1bea0530180043bd6c09dacd73c42c8dc75e8cba56560c0ef63751500499617",
+				"DiscoKey":   "discokey:59e55dc8f57d3e66a892dab38716bad360c707a39ecc0f65ac58a0d9e994eb1e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:40075",
+					"10.65.0.27:40075",
+					"172.17.0.1:40075",
+					"172.18.0.1:40075",
+					"172.19.0.1:40075"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:02:12.804604651Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4245148950529360,
+				"StableID":   "nywrv8sd9a11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f2199499fd8615908740254269df16a742082ded1dd15f15f32e7a653187660d",
+				"KeyExpiry":  "2026-11-08T22:02:13Z",
+				"DiscoKey":   "discokey:2f19acc3b823c9d54adc97caeef31822a3b8cd8cd694b5e14d404ebfea13876e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48259",
+					"10.65.0.27:48259",
+					"172.17.0.1:48259",
+					"172.18.0.1:48259",
+					"172.19.0.1:48259"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:02:13.344910068Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1015446840501143,
+				"StableID":   "nSLX4s4uv811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b2e1badd530efba26faeb09079974118ac4899f8db05071fbb8a0dc16a1d1c66",
+				"KeyExpiry":  "2026-11-08T22:02:13Z",
+				"DiscoKey":   "discokey:16ad1c72302127fc9ca8eacbda21ee743e3ac8a83a42dbf9ad19713e8b5a7e30",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54989",
+					"10.65.0.27:54989",
+					"172.17.0.1:54989",
+					"172.18.0.1:54989",
+					"172.19.0.1:54989"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:02:13.881469153Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4957581331602300,
+				"StableID":   "nfWNqnFJif11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:30ed4d4a10ff8d4868148cf523c0c32816637b0ac36c9ab8be625f423668a818",
+				"KeyExpiry":  "2026-11-08T22:02:14Z",
+				"DiscoKey":   "discokey:ae1dabc9c565a6613dcbb9917108a4cee945005c3c56a14701700a03a183170f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47239",
+					"10.65.0.27:47239",
+					"172.17.0.1:47239",
+					"172.18.0.1:47239",
+					"172.19.0.1:47239"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:02:14.424652089Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3019417511731452": {
+				"ID":          3019417511731452,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4245148950529360,
+				"StableID":   "nywrv8sd9a11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f2199499fd8615908740254269df16a742082ded1dd15f15f32e7a653187660d",
+				"KeyExpiry":  "2026-11-08T22:02:13Z",
+				"DiscoKey":   "discokey:2f19acc3b823c9d54adc97caeef31822a3b8cd8cd694b5e14d404ebfea13876e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48259",
+					"10.65.0.27:48259",
+					"172.17.0.1:48259",
+					"172.18.0.1:48259",
+					"172.19.0.1:48259"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:02:13.344910068Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f2199499fd8615908740254269df16a742082ded1dd15f15f32e7a653187660d",
+			"MachineKey": "mkey:a7847eed527af35a6233a52bf8ff091127864b170c66cf1071655a88b367d268",
+			"Peers": [{
+				"ID":         3281193000221942,
+				"StableID":   "nsXhWpN4dS11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0086a787cae8961899b8d21db09bd878dd35723efb70e2be336509552b898269",
+				"DiscoKey":   "discokey:2f14238640f02240bb328ca4590814ff3f27d373d64916f802962067e2cd0a71",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38415",
+					"10.65.0.27:38415",
+					"172.17.0.1:38415",
+					"172.18.0.1:38415",
+					"172.19.0.1:38415"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:01:18.17236278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4766185274456039,
+				"StableID":   "nYRof6ccDe11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:adb3b489de7eebc64343a7a253f48c9aad9692ef13aa8ce29b1ea6d2f8ac365c",
+				"DiscoKey":   "discokey:7690097f29f4fbc829619f97de76e7947b0cdfd02406c5245b1316c001925348",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50045",
+					"10.65.0.27:50045",
+					"172.17.0.1:50045",
+					"172.18.0.1:50045",
+					"172.19.0.1:50045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:01:18.654536895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         538080972367332,
+				"StableID":   "nMFUxXUhC511CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:27dd848d78e935c87a87d3fbf367db9fe9ccd991de72ed6a2a304757f1db6439",
+				"DiscoKey":   "discokey:36eacbded1fe9b6d04901491ef8d3c6166619e3cd2ab89d30f10646b22fb2f15",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40623",
+					"10.65.0.27:40623",
+					"172.17.0.1:40623",
+					"172.18.0.1:40623",
+					"172.19.0.1:40623"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:01:19.196759907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7679630823091561,
+				"StableID":   "nG8EB1t7y221CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:70330263de73118f3ca9ef79a47b8312ff5bbafa502c4a9bf023285f63fe9e7c",
+				"DiscoKey":   "discokey:c446facb6f8d304709f153250adec71000d4049e186daa711d9735a250111851",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42418",
+					"10.65.0.27:42418",
+					"172.17.0.1:42418",
+					"172.18.0.1:42418",
+					"172.19.0.1:42418"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:01:19.725289158Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7598480586927999,
+				"StableID":   "nEUAhcCNL221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:968d2c0575b07efdb5cfae441618ac17721fca480a036ba33241aada2d46411e",
+				"DiscoKey":   "discokey:53201c269825934e1fba1c820b86b425e4f1e7dfffd83a07166e455009759a7c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:44426",
+					"10.65.0.27:44426",
+					"172.17.0.1:44426",
+					"172.18.0.1:44426",
+					"172.19.0.1:44426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:02:08.884137165Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7837764808078094,
+				"StableID":   "nTKfvsnjC421CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7c3e40a9ed0ff7d5aaa6d3c3bcdf4476d307a6aa350e02eab50c34ff3eebf802",
+				"DiscoKey":   "discokey:7613c59d9de023a1e89e2ec363b1448c2a6e17610f334441719b2bfb713ab935",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53066",
+					"10.65.0.27:53066",
+					"172.17.0.1:53066",
+					"172.18.0.1:53066",
+					"172.19.0.1:53066"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:02:09.44901447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3897120922254004,
+				"StableID":   "n97Vqyk1SX11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5cc95f5e89363d7b068291b5a91328034cd83874b4a9110890c5bac741e3be2b",
+				"DiscoKey":   "discokey:6934c6e438e79e31d99d6bc7dd843ab555b8ffb8943daf9af4e64fa29346261a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48441",
+					"10.65.0.27:48441",
+					"172.17.0.1:48441",
+					"172.18.0.1:48441",
+					"172.19.0.1:48441"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:02:09.947128895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3019417511731452,
+				"StableID":   "nXN81jyVaQ11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4d21c3c535aae23fb456f1835c3f37b13331f576439d020d787d00bb365a872",
+				"DiscoKey":   "discokey:1efba7dd66114ecbc6d6e8787d4ef0a876a55e6fd739e94674812894ce38d740",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57385",
+					"10.65.0.27:57385",
+					"172.17.0.1:57385",
+					"172.18.0.1:57385",
+					"172.19.0.1:57385"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:02:10.484613551Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3108214568090199,
+				"StableID":   "nkqUoWXiGR11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d28f478f06bd50f644a17739edaf1a1941bdf7905e94cf10977bc5d4e94ef4a",
+				"DiscoKey":   "discokey:2473ab0c7e1ba1a9375110c9b05a30ddce5838dc5550318ba19a0cd232c74464",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:57313",
+					"10.65.0.27:57313",
+					"172.17.0.1:57313",
+					"172.18.0.1:57313",
+					"172.19.0.1:57313"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:02:11.023346401Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1561625567398938,
+				"StableID":   "nZxcrpFGCD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc4e628c93e34160c6ee491175bc707ecfd774df8d546536182e785aeb9b4a26",
+				"DiscoKey":   "discokey:0196cba50c53deba824493433b17d2aadfddb1b4ae380ad0230bcaaad6019a24",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59933",
+					"10.65.0.27:59933",
+					"172.17.0.1:59933",
+					"172.18.0.1:59933",
+					"172.19.0.1:59933"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:02:11.715884325Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         699212911543336,
+				"StableID":   "nFpkey8gT611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93d1d4a8ec6a2319e7c60ebdbc96ba132de43149ed6ec0d80882e312a5934d5f",
+				"DiscoKey":   "discokey:9a26dd8f8eb613b478b7f54477331cdc9252d17a436e83b79eedcd951204e570",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48036",
+					"10.65.0.27:48036",
+					"172.17.0.1:48036",
+					"172.18.0.1:48036",
+					"172.19.0.1:48036"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:02:12.257434979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1552676499746967,
+				"StableID":   "nzriPNBD8D11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1bea0530180043bd6c09dacd73c42c8dc75e8cba56560c0ef63751500499617",
+				"DiscoKey":   "discokey:59e55dc8f57d3e66a892dab38716bad360c707a39ecc0f65ac58a0d9e994eb1e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:40075",
+					"10.65.0.27:40075",
+					"172.17.0.1:40075",
+					"172.18.0.1:40075",
+					"172.19.0.1:40075"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:02:12.804604651Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1015446840501143,
+				"StableID":   "nSLX4s4uv811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b2e1badd530efba26faeb09079974118ac4899f8db05071fbb8a0dc16a1d1c66",
+				"KeyExpiry":  "2026-11-08T22:02:13Z",
+				"DiscoKey":   "discokey:16ad1c72302127fc9ca8eacbda21ee743e3ac8a83a42dbf9ad19713e8b5a7e30",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54989",
+					"10.65.0.27:54989",
+					"172.17.0.1:54989",
+					"172.18.0.1:54989",
+					"172.19.0.1:54989"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:02:13.881469153Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4957581331602300,
+				"StableID":   "nfWNqnFJif11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:30ed4d4a10ff8d4868148cf523c0c32816637b0ac36c9ab8be625f423668a818",
+				"KeyExpiry":  "2026-11-08T22:02:14Z",
+				"DiscoKey":   "discokey:ae1dabc9c565a6613dcbb9917108a4cee945005c3c56a14701700a03a183170f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47239",
+					"10.65.0.27:47239",
+					"172.17.0.1:47239",
+					"172.18.0.1:47239",
+					"172.19.0.1:47239"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:02:14.424652089Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         699212911543336,
+				"StableID":   "nFpkey8gT611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       699212911543336,
+				"Key":        "nodekey:93d1d4a8ec6a2319e7c60ebdbc96ba132de43149ed6ec0d80882e312a5934d5f",
+				"DiscoKey":   "discokey:9a26dd8f8eb613b478b7f54477331cdc9252d17a436e83b79eedcd951204e570",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48036",
+					"10.65.0.27:48036",
+					"172.17.0.1:48036",
+					"172.18.0.1:48036",
+					"172.19.0.1:48036"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:02:12.257434979Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:93d1d4a8ec6a2319e7c60ebdbc96ba132de43149ed6ec0d80882e312a5934d5f",
+			"MachineKey": "mkey:221b7f9380308ae3c312634380f1ddcd6b971f6e240719c6c83a816282e7de1d",
+			"Peers": [{
+				"ID":         3281193000221942,
+				"StableID":   "nsXhWpN4dS11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0086a787cae8961899b8d21db09bd878dd35723efb70e2be336509552b898269",
+				"DiscoKey":   "discokey:2f14238640f02240bb328ca4590814ff3f27d373d64916f802962067e2cd0a71",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38415",
+					"10.65.0.27:38415",
+					"172.17.0.1:38415",
+					"172.18.0.1:38415",
+					"172.19.0.1:38415"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:01:18.17236278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4766185274456039,
+				"StableID":   "nYRof6ccDe11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:adb3b489de7eebc64343a7a253f48c9aad9692ef13aa8ce29b1ea6d2f8ac365c",
+				"DiscoKey":   "discokey:7690097f29f4fbc829619f97de76e7947b0cdfd02406c5245b1316c001925348",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50045",
+					"10.65.0.27:50045",
+					"172.17.0.1:50045",
+					"172.18.0.1:50045",
+					"172.19.0.1:50045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:01:18.654536895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         538080972367332,
+				"StableID":   "nMFUxXUhC511CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:27dd848d78e935c87a87d3fbf367db9fe9ccd991de72ed6a2a304757f1db6439",
+				"DiscoKey":   "discokey:36eacbded1fe9b6d04901491ef8d3c6166619e3cd2ab89d30f10646b22fb2f15",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40623",
+					"10.65.0.27:40623",
+					"172.17.0.1:40623",
+					"172.18.0.1:40623",
+					"172.19.0.1:40623"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:01:19.196759907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7679630823091561,
+				"StableID":   "nG8EB1t7y221CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:70330263de73118f3ca9ef79a47b8312ff5bbafa502c4a9bf023285f63fe9e7c",
+				"DiscoKey":   "discokey:c446facb6f8d304709f153250adec71000d4049e186daa711d9735a250111851",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42418",
+					"10.65.0.27:42418",
+					"172.17.0.1:42418",
+					"172.18.0.1:42418",
+					"172.19.0.1:42418"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:01:19.725289158Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7598480586927999,
+				"StableID":   "nEUAhcCNL221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:968d2c0575b07efdb5cfae441618ac17721fca480a036ba33241aada2d46411e",
+				"DiscoKey":   "discokey:53201c269825934e1fba1c820b86b425e4f1e7dfffd83a07166e455009759a7c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:44426",
+					"10.65.0.27:44426",
+					"172.17.0.1:44426",
+					"172.18.0.1:44426",
+					"172.19.0.1:44426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:02:08.884137165Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7837764808078094,
+				"StableID":   "nTKfvsnjC421CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7c3e40a9ed0ff7d5aaa6d3c3bcdf4476d307a6aa350e02eab50c34ff3eebf802",
+				"DiscoKey":   "discokey:7613c59d9de023a1e89e2ec363b1448c2a6e17610f334441719b2bfb713ab935",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53066",
+					"10.65.0.27:53066",
+					"172.17.0.1:53066",
+					"172.18.0.1:53066",
+					"172.19.0.1:53066"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:02:09.44901447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3897120922254004,
+				"StableID":   "n97Vqyk1SX11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5cc95f5e89363d7b068291b5a91328034cd83874b4a9110890c5bac741e3be2b",
+				"DiscoKey":   "discokey:6934c6e438e79e31d99d6bc7dd843ab555b8ffb8943daf9af4e64fa29346261a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48441",
+					"10.65.0.27:48441",
+					"172.17.0.1:48441",
+					"172.18.0.1:48441",
+					"172.19.0.1:48441"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:02:09.947128895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3019417511731452,
+				"StableID":   "nXN81jyVaQ11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4d21c3c535aae23fb456f1835c3f37b13331f576439d020d787d00bb365a872",
+				"DiscoKey":   "discokey:1efba7dd66114ecbc6d6e8787d4ef0a876a55e6fd739e94674812894ce38d740",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57385",
+					"10.65.0.27:57385",
+					"172.17.0.1:57385",
+					"172.18.0.1:57385",
+					"172.19.0.1:57385"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:02:10.484613551Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3108214568090199,
+				"StableID":   "nkqUoWXiGR11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d28f478f06bd50f644a17739edaf1a1941bdf7905e94cf10977bc5d4e94ef4a",
+				"DiscoKey":   "discokey:2473ab0c7e1ba1a9375110c9b05a30ddce5838dc5550318ba19a0cd232c74464",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:57313",
+					"10.65.0.27:57313",
+					"172.17.0.1:57313",
+					"172.18.0.1:57313",
+					"172.19.0.1:57313"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:02:11.023346401Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1561625567398938,
+				"StableID":   "nZxcrpFGCD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc4e628c93e34160c6ee491175bc707ecfd774df8d546536182e785aeb9b4a26",
+				"DiscoKey":   "discokey:0196cba50c53deba824493433b17d2aadfddb1b4ae380ad0230bcaaad6019a24",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59933",
+					"10.65.0.27:59933",
+					"172.17.0.1:59933",
+					"172.18.0.1:59933",
+					"172.19.0.1:59933"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:02:11.715884325Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1552676499746967,
+				"StableID":   "nzriPNBD8D11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1bea0530180043bd6c09dacd73c42c8dc75e8cba56560c0ef63751500499617",
+				"DiscoKey":   "discokey:59e55dc8f57d3e66a892dab38716bad360c707a39ecc0f65ac58a0d9e994eb1e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:40075",
+					"10.65.0.27:40075",
+					"172.17.0.1:40075",
+					"172.18.0.1:40075",
+					"172.19.0.1:40075"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:02:12.804604651Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4245148950529360,
+				"StableID":   "nywrv8sd9a11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f2199499fd8615908740254269df16a742082ded1dd15f15f32e7a653187660d",
+				"KeyExpiry":  "2026-11-08T22:02:13Z",
+				"DiscoKey":   "discokey:2f19acc3b823c9d54adc97caeef31822a3b8cd8cd694b5e14d404ebfea13876e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48259",
+					"10.65.0.27:48259",
+					"172.17.0.1:48259",
+					"172.18.0.1:48259",
+					"172.19.0.1:48259"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:02:13.344910068Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1015446840501143,
+				"StableID":   "nSLX4s4uv811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b2e1badd530efba26faeb09079974118ac4899f8db05071fbb8a0dc16a1d1c66",
+				"KeyExpiry":  "2026-11-08T22:02:13Z",
+				"DiscoKey":   "discokey:16ad1c72302127fc9ca8eacbda21ee743e3ac8a83a42dbf9ad19713e8b5a7e30",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54989",
+					"10.65.0.27:54989",
+					"172.17.0.1:54989",
+					"172.18.0.1:54989",
+					"172.19.0.1:54989"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:02:13.881469153Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4957581331602300,
+				"StableID":   "nfWNqnFJif11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:30ed4d4a10ff8d4868148cf523c0c32816637b0ac36c9ab8be625f423668a818",
+				"KeyExpiry":  "2026-11-08T22:02:14Z",
+				"DiscoKey":   "discokey:ae1dabc9c565a6613dcbb9917108a4cee945005c3c56a14701700a03a183170f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47239",
+					"10.65.0.27:47239",
+					"172.17.0.1:47239",
+					"172.18.0.1:47239",
+					"172.19.0.1:47239"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:02:14.424652089Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "699212911543336": {
+				"ID":          699212911543336,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4766185274456039,
+				"StableID":   "nYRof6ccDe11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       4766185274456039,
+				"Key":        "nodekey:adb3b489de7eebc64343a7a253f48c9aad9692ef13aa8ce29b1ea6d2f8ac365c",
+				"DiscoKey":   "discokey:7690097f29f4fbc829619f97de76e7947b0cdfd02406c5245b1316c001925348",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50045",
+					"10.65.0.27:50045",
+					"172.17.0.1:50045",
+					"172.18.0.1:50045",
+					"172.19.0.1:50045"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:01:18.654536895Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:adb3b489de7eebc64343a7a253f48c9aad9692ef13aa8ce29b1ea6d2f8ac365c",
+			"MachineKey": "mkey:3b70d27e5fbb8aa797c72a65d2144b5af74098cb51a09885f681eb0479ad7a44",
+			"Peers": [{
+				"ID":         3281193000221942,
+				"StableID":   "nsXhWpN4dS11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0086a787cae8961899b8d21db09bd878dd35723efb70e2be336509552b898269",
+				"DiscoKey":   "discokey:2f14238640f02240bb328ca4590814ff3f27d373d64916f802962067e2cd0a71",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38415",
+					"10.65.0.27:38415",
+					"172.17.0.1:38415",
+					"172.18.0.1:38415",
+					"172.19.0.1:38415"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:01:18.17236278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         538080972367332,
+				"StableID":   "nMFUxXUhC511CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:27dd848d78e935c87a87d3fbf367db9fe9ccd991de72ed6a2a304757f1db6439",
+				"DiscoKey":   "discokey:36eacbded1fe9b6d04901491ef8d3c6166619e3cd2ab89d30f10646b22fb2f15",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40623",
+					"10.65.0.27:40623",
+					"172.17.0.1:40623",
+					"172.18.0.1:40623",
+					"172.19.0.1:40623"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:01:19.196759907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7679630823091561,
+				"StableID":   "nG8EB1t7y221CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:70330263de73118f3ca9ef79a47b8312ff5bbafa502c4a9bf023285f63fe9e7c",
+				"DiscoKey":   "discokey:c446facb6f8d304709f153250adec71000d4049e186daa711d9735a250111851",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42418",
+					"10.65.0.27:42418",
+					"172.17.0.1:42418",
+					"172.18.0.1:42418",
+					"172.19.0.1:42418"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:01:19.725289158Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7598480586927999,
+				"StableID":   "nEUAhcCNL221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:968d2c0575b07efdb5cfae441618ac17721fca480a036ba33241aada2d46411e",
+				"DiscoKey":   "discokey:53201c269825934e1fba1c820b86b425e4f1e7dfffd83a07166e455009759a7c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:44426",
+					"10.65.0.27:44426",
+					"172.17.0.1:44426",
+					"172.18.0.1:44426",
+					"172.19.0.1:44426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:02:08.884137165Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7837764808078094,
+				"StableID":   "nTKfvsnjC421CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7c3e40a9ed0ff7d5aaa6d3c3bcdf4476d307a6aa350e02eab50c34ff3eebf802",
+				"DiscoKey":   "discokey:7613c59d9de023a1e89e2ec363b1448c2a6e17610f334441719b2bfb713ab935",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53066",
+					"10.65.0.27:53066",
+					"172.17.0.1:53066",
+					"172.18.0.1:53066",
+					"172.19.0.1:53066"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:02:09.44901447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3897120922254004,
+				"StableID":   "n97Vqyk1SX11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5cc95f5e89363d7b068291b5a91328034cd83874b4a9110890c5bac741e3be2b",
+				"DiscoKey":   "discokey:6934c6e438e79e31d99d6bc7dd843ab555b8ffb8943daf9af4e64fa29346261a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48441",
+					"10.65.0.27:48441",
+					"172.17.0.1:48441",
+					"172.18.0.1:48441",
+					"172.19.0.1:48441"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:02:09.947128895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3019417511731452,
+				"StableID":   "nXN81jyVaQ11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4d21c3c535aae23fb456f1835c3f37b13331f576439d020d787d00bb365a872",
+				"DiscoKey":   "discokey:1efba7dd66114ecbc6d6e8787d4ef0a876a55e6fd739e94674812894ce38d740",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57385",
+					"10.65.0.27:57385",
+					"172.17.0.1:57385",
+					"172.18.0.1:57385",
+					"172.19.0.1:57385"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:02:10.484613551Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3108214568090199,
+				"StableID":   "nkqUoWXiGR11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d28f478f06bd50f644a17739edaf1a1941bdf7905e94cf10977bc5d4e94ef4a",
+				"DiscoKey":   "discokey:2473ab0c7e1ba1a9375110c9b05a30ddce5838dc5550318ba19a0cd232c74464",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:57313",
+					"10.65.0.27:57313",
+					"172.17.0.1:57313",
+					"172.18.0.1:57313",
+					"172.19.0.1:57313"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:02:11.023346401Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1561625567398938,
+				"StableID":   "nZxcrpFGCD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc4e628c93e34160c6ee491175bc707ecfd774df8d546536182e785aeb9b4a26",
+				"DiscoKey":   "discokey:0196cba50c53deba824493433b17d2aadfddb1b4ae380ad0230bcaaad6019a24",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59933",
+					"10.65.0.27:59933",
+					"172.17.0.1:59933",
+					"172.18.0.1:59933",
+					"172.19.0.1:59933"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:02:11.715884325Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         699212911543336,
+				"StableID":   "nFpkey8gT611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93d1d4a8ec6a2319e7c60ebdbc96ba132de43149ed6ec0d80882e312a5934d5f",
+				"DiscoKey":   "discokey:9a26dd8f8eb613b478b7f54477331cdc9252d17a436e83b79eedcd951204e570",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48036",
+					"10.65.0.27:48036",
+					"172.17.0.1:48036",
+					"172.18.0.1:48036",
+					"172.19.0.1:48036"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:02:12.257434979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1552676499746967,
+				"StableID":   "nzriPNBD8D11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1bea0530180043bd6c09dacd73c42c8dc75e8cba56560c0ef63751500499617",
+				"DiscoKey":   "discokey:59e55dc8f57d3e66a892dab38716bad360c707a39ecc0f65ac58a0d9e994eb1e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:40075",
+					"10.65.0.27:40075",
+					"172.17.0.1:40075",
+					"172.18.0.1:40075",
+					"172.19.0.1:40075"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:02:12.804604651Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4245148950529360,
+				"StableID":   "nywrv8sd9a11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f2199499fd8615908740254269df16a742082ded1dd15f15f32e7a653187660d",
+				"KeyExpiry":  "2026-11-08T22:02:13Z",
+				"DiscoKey":   "discokey:2f19acc3b823c9d54adc97caeef31822a3b8cd8cd694b5e14d404ebfea13876e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48259",
+					"10.65.0.27:48259",
+					"172.17.0.1:48259",
+					"172.18.0.1:48259",
+					"172.19.0.1:48259"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:02:13.344910068Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1015446840501143,
+				"StableID":   "nSLX4s4uv811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b2e1badd530efba26faeb09079974118ac4899f8db05071fbb8a0dc16a1d1c66",
+				"KeyExpiry":  "2026-11-08T22:02:13Z",
+				"DiscoKey":   "discokey:16ad1c72302127fc9ca8eacbda21ee743e3ac8a83a42dbf9ad19713e8b5a7e30",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54989",
+					"10.65.0.27:54989",
+					"172.17.0.1:54989",
+					"172.18.0.1:54989",
+					"172.19.0.1:54989"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:02:13.881469153Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4957581331602300,
+				"StableID":   "nfWNqnFJif11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:30ed4d4a10ff8d4868148cf523c0c32816637b0ac36c9ab8be625f423668a818",
+				"KeyExpiry":  "2026-11-08T22:02:14Z",
+				"DiscoKey":   "discokey:ae1dabc9c565a6613dcbb9917108a4cee945005c3c56a14701700a03a183170f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47239",
+					"10.65.0.27:47239",
+					"172.17.0.1:47239",
+					"172.18.0.1:47239",
+					"172.19.0.1:47239"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:02:14.424652089Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4766185274456039": {
+				"ID":          4766185274456039,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3281193000221942,
+				"StableID":   "nsXhWpN4dS11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       3281193000221942,
+				"Key":        "nodekey:0086a787cae8961899b8d21db09bd878dd35723efb70e2be336509552b898269",
+				"DiscoKey":   "discokey:2f14238640f02240bb328ca4590814ff3f27d373d64916f802962067e2cd0a71",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38415",
+					"10.65.0.27:38415",
+					"172.17.0.1:38415",
+					"172.18.0.1:38415",
+					"172.19.0.1:38415"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:01:18.17236278Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0086a787cae8961899b8d21db09bd878dd35723efb70e2be336509552b898269",
+			"MachineKey": "mkey:fb828d72530cf635e0e544243dd15599eae3b9222c9073f08154f5a22c19c10f",
+			"Peers": [{
+				"ID":         4766185274456039,
+				"StableID":   "nYRof6ccDe11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:adb3b489de7eebc64343a7a253f48c9aad9692ef13aa8ce29b1ea6d2f8ac365c",
+				"DiscoKey":   "discokey:7690097f29f4fbc829619f97de76e7947b0cdfd02406c5245b1316c001925348",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50045",
+					"10.65.0.27:50045",
+					"172.17.0.1:50045",
+					"172.18.0.1:50045",
+					"172.19.0.1:50045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:01:18.654536895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         538080972367332,
+				"StableID":   "nMFUxXUhC511CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:27dd848d78e935c87a87d3fbf367db9fe9ccd991de72ed6a2a304757f1db6439",
+				"DiscoKey":   "discokey:36eacbded1fe9b6d04901491ef8d3c6166619e3cd2ab89d30f10646b22fb2f15",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40623",
+					"10.65.0.27:40623",
+					"172.17.0.1:40623",
+					"172.18.0.1:40623",
+					"172.19.0.1:40623"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:01:19.196759907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7679630823091561,
+				"StableID":   "nG8EB1t7y221CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:70330263de73118f3ca9ef79a47b8312ff5bbafa502c4a9bf023285f63fe9e7c",
+				"DiscoKey":   "discokey:c446facb6f8d304709f153250adec71000d4049e186daa711d9735a250111851",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42418",
+					"10.65.0.27:42418",
+					"172.17.0.1:42418",
+					"172.18.0.1:42418",
+					"172.19.0.1:42418"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:01:19.725289158Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7598480586927999,
+				"StableID":   "nEUAhcCNL221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:968d2c0575b07efdb5cfae441618ac17721fca480a036ba33241aada2d46411e",
+				"DiscoKey":   "discokey:53201c269825934e1fba1c820b86b425e4f1e7dfffd83a07166e455009759a7c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:44426",
+					"10.65.0.27:44426",
+					"172.17.0.1:44426",
+					"172.18.0.1:44426",
+					"172.19.0.1:44426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:02:08.884137165Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7837764808078094,
+				"StableID":   "nTKfvsnjC421CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7c3e40a9ed0ff7d5aaa6d3c3bcdf4476d307a6aa350e02eab50c34ff3eebf802",
+				"DiscoKey":   "discokey:7613c59d9de023a1e89e2ec363b1448c2a6e17610f334441719b2bfb713ab935",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53066",
+					"10.65.0.27:53066",
+					"172.17.0.1:53066",
+					"172.18.0.1:53066",
+					"172.19.0.1:53066"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:02:09.44901447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3897120922254004,
+				"StableID":   "n97Vqyk1SX11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5cc95f5e89363d7b068291b5a91328034cd83874b4a9110890c5bac741e3be2b",
+				"DiscoKey":   "discokey:6934c6e438e79e31d99d6bc7dd843ab555b8ffb8943daf9af4e64fa29346261a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48441",
+					"10.65.0.27:48441",
+					"172.17.0.1:48441",
+					"172.18.0.1:48441",
+					"172.19.0.1:48441"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:02:09.947128895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3019417511731452,
+				"StableID":   "nXN81jyVaQ11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4d21c3c535aae23fb456f1835c3f37b13331f576439d020d787d00bb365a872",
+				"DiscoKey":   "discokey:1efba7dd66114ecbc6d6e8787d4ef0a876a55e6fd739e94674812894ce38d740",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57385",
+					"10.65.0.27:57385",
+					"172.17.0.1:57385",
+					"172.18.0.1:57385",
+					"172.19.0.1:57385"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:02:10.484613551Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3108214568090199,
+				"StableID":   "nkqUoWXiGR11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d28f478f06bd50f644a17739edaf1a1941bdf7905e94cf10977bc5d4e94ef4a",
+				"DiscoKey":   "discokey:2473ab0c7e1ba1a9375110c9b05a30ddce5838dc5550318ba19a0cd232c74464",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:57313",
+					"10.65.0.27:57313",
+					"172.17.0.1:57313",
+					"172.18.0.1:57313",
+					"172.19.0.1:57313"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:02:11.023346401Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1561625567398938,
+				"StableID":   "nZxcrpFGCD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc4e628c93e34160c6ee491175bc707ecfd774df8d546536182e785aeb9b4a26",
+				"DiscoKey":   "discokey:0196cba50c53deba824493433b17d2aadfddb1b4ae380ad0230bcaaad6019a24",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59933",
+					"10.65.0.27:59933",
+					"172.17.0.1:59933",
+					"172.18.0.1:59933",
+					"172.19.0.1:59933"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:02:11.715884325Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         699212911543336,
+				"StableID":   "nFpkey8gT611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93d1d4a8ec6a2319e7c60ebdbc96ba132de43149ed6ec0d80882e312a5934d5f",
+				"DiscoKey":   "discokey:9a26dd8f8eb613b478b7f54477331cdc9252d17a436e83b79eedcd951204e570",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48036",
+					"10.65.0.27:48036",
+					"172.17.0.1:48036",
+					"172.18.0.1:48036",
+					"172.19.0.1:48036"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:02:12.257434979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1552676499746967,
+				"StableID":   "nzriPNBD8D11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1bea0530180043bd6c09dacd73c42c8dc75e8cba56560c0ef63751500499617",
+				"DiscoKey":   "discokey:59e55dc8f57d3e66a892dab38716bad360c707a39ecc0f65ac58a0d9e994eb1e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:40075",
+					"10.65.0.27:40075",
+					"172.17.0.1:40075",
+					"172.18.0.1:40075",
+					"172.19.0.1:40075"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:02:12.804604651Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4245148950529360,
+				"StableID":   "nywrv8sd9a11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f2199499fd8615908740254269df16a742082ded1dd15f15f32e7a653187660d",
+				"KeyExpiry":  "2026-11-08T22:02:13Z",
+				"DiscoKey":   "discokey:2f19acc3b823c9d54adc97caeef31822a3b8cd8cd694b5e14d404ebfea13876e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48259",
+					"10.65.0.27:48259",
+					"172.17.0.1:48259",
+					"172.18.0.1:48259",
+					"172.19.0.1:48259"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:02:13.344910068Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1015446840501143,
+				"StableID":   "nSLX4s4uv811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b2e1badd530efba26faeb09079974118ac4899f8db05071fbb8a0dc16a1d1c66",
+				"KeyExpiry":  "2026-11-08T22:02:13Z",
+				"DiscoKey":   "discokey:16ad1c72302127fc9ca8eacbda21ee743e3ac8a83a42dbf9ad19713e8b5a7e30",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54989",
+					"10.65.0.27:54989",
+					"172.17.0.1:54989",
+					"172.18.0.1:54989",
+					"172.19.0.1:54989"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:02:13.881469153Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4957581331602300,
+				"StableID":   "nfWNqnFJif11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:30ed4d4a10ff8d4868148cf523c0c32816637b0ac36c9ab8be625f423668a818",
+				"KeyExpiry":  "2026-11-08T22:02:14Z",
+				"DiscoKey":   "discokey:ae1dabc9c565a6613dcbb9917108a4cee945005c3c56a14701700a03a183170f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47239",
+					"10.65.0.27:47239",
+					"172.17.0.1:47239",
+					"172.18.0.1:47239",
+					"172.19.0.1:47239"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:02:14.424652089Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3281193000221942": {
+				"ID":          3281193000221942,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7598480586927999,
+				"StableID":   "nEUAhcCNL221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       7598480586927999,
+				"Key":        "nodekey:968d2c0575b07efdb5cfae441618ac17721fca480a036ba33241aada2d46411e",
+				"DiscoKey":   "discokey:53201c269825934e1fba1c820b86b425e4f1e7dfffd83a07166e455009759a7c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:44426",
+					"10.65.0.27:44426",
+					"172.17.0.1:44426",
+					"172.18.0.1:44426",
+					"172.19.0.1:44426"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:02:08.884137165Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:968d2c0575b07efdb5cfae441618ac17721fca480a036ba33241aada2d46411e",
+			"MachineKey": "mkey:f52abc3abed4a79d879f4864c1c6593d873766988738617751f8898585c04459",
+			"Peers": [{
+				"ID":         3281193000221942,
+				"StableID":   "nsXhWpN4dS11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0086a787cae8961899b8d21db09bd878dd35723efb70e2be336509552b898269",
+				"DiscoKey":   "discokey:2f14238640f02240bb328ca4590814ff3f27d373d64916f802962067e2cd0a71",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38415",
+					"10.65.0.27:38415",
+					"172.17.0.1:38415",
+					"172.18.0.1:38415",
+					"172.19.0.1:38415"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:01:18.17236278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4766185274456039,
+				"StableID":   "nYRof6ccDe11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:adb3b489de7eebc64343a7a253f48c9aad9692ef13aa8ce29b1ea6d2f8ac365c",
+				"DiscoKey":   "discokey:7690097f29f4fbc829619f97de76e7947b0cdfd02406c5245b1316c001925348",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50045",
+					"10.65.0.27:50045",
+					"172.17.0.1:50045",
+					"172.18.0.1:50045",
+					"172.19.0.1:50045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:01:18.654536895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         538080972367332,
+				"StableID":   "nMFUxXUhC511CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:27dd848d78e935c87a87d3fbf367db9fe9ccd991de72ed6a2a304757f1db6439",
+				"DiscoKey":   "discokey:36eacbded1fe9b6d04901491ef8d3c6166619e3cd2ab89d30f10646b22fb2f15",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40623",
+					"10.65.0.27:40623",
+					"172.17.0.1:40623",
+					"172.18.0.1:40623",
+					"172.19.0.1:40623"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:01:19.196759907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7679630823091561,
+				"StableID":   "nG8EB1t7y221CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:70330263de73118f3ca9ef79a47b8312ff5bbafa502c4a9bf023285f63fe9e7c",
+				"DiscoKey":   "discokey:c446facb6f8d304709f153250adec71000d4049e186daa711d9735a250111851",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42418",
+					"10.65.0.27:42418",
+					"172.17.0.1:42418",
+					"172.18.0.1:42418",
+					"172.19.0.1:42418"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:01:19.725289158Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7837764808078094,
+				"StableID":   "nTKfvsnjC421CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7c3e40a9ed0ff7d5aaa6d3c3bcdf4476d307a6aa350e02eab50c34ff3eebf802",
+				"DiscoKey":   "discokey:7613c59d9de023a1e89e2ec363b1448c2a6e17610f334441719b2bfb713ab935",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53066",
+					"10.65.0.27:53066",
+					"172.17.0.1:53066",
+					"172.18.0.1:53066",
+					"172.19.0.1:53066"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:02:09.44901447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3897120922254004,
+				"StableID":   "n97Vqyk1SX11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5cc95f5e89363d7b068291b5a91328034cd83874b4a9110890c5bac741e3be2b",
+				"DiscoKey":   "discokey:6934c6e438e79e31d99d6bc7dd843ab555b8ffb8943daf9af4e64fa29346261a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48441",
+					"10.65.0.27:48441",
+					"172.17.0.1:48441",
+					"172.18.0.1:48441",
+					"172.19.0.1:48441"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:02:09.947128895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3019417511731452,
+				"StableID":   "nXN81jyVaQ11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4d21c3c535aae23fb456f1835c3f37b13331f576439d020d787d00bb365a872",
+				"DiscoKey":   "discokey:1efba7dd66114ecbc6d6e8787d4ef0a876a55e6fd739e94674812894ce38d740",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57385",
+					"10.65.0.27:57385",
+					"172.17.0.1:57385",
+					"172.18.0.1:57385",
+					"172.19.0.1:57385"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:02:10.484613551Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3108214568090199,
+				"StableID":   "nkqUoWXiGR11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d28f478f06bd50f644a17739edaf1a1941bdf7905e94cf10977bc5d4e94ef4a",
+				"DiscoKey":   "discokey:2473ab0c7e1ba1a9375110c9b05a30ddce5838dc5550318ba19a0cd232c74464",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:57313",
+					"10.65.0.27:57313",
+					"172.17.0.1:57313",
+					"172.18.0.1:57313",
+					"172.19.0.1:57313"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:02:11.023346401Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1561625567398938,
+				"StableID":   "nZxcrpFGCD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc4e628c93e34160c6ee491175bc707ecfd774df8d546536182e785aeb9b4a26",
+				"DiscoKey":   "discokey:0196cba50c53deba824493433b17d2aadfddb1b4ae380ad0230bcaaad6019a24",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59933",
+					"10.65.0.27:59933",
+					"172.17.0.1:59933",
+					"172.18.0.1:59933",
+					"172.19.0.1:59933"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:02:11.715884325Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         699212911543336,
+				"StableID":   "nFpkey8gT611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93d1d4a8ec6a2319e7c60ebdbc96ba132de43149ed6ec0d80882e312a5934d5f",
+				"DiscoKey":   "discokey:9a26dd8f8eb613b478b7f54477331cdc9252d17a436e83b79eedcd951204e570",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48036",
+					"10.65.0.27:48036",
+					"172.17.0.1:48036",
+					"172.18.0.1:48036",
+					"172.19.0.1:48036"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:02:12.257434979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1552676499746967,
+				"StableID":   "nzriPNBD8D11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1bea0530180043bd6c09dacd73c42c8dc75e8cba56560c0ef63751500499617",
+				"DiscoKey":   "discokey:59e55dc8f57d3e66a892dab38716bad360c707a39ecc0f65ac58a0d9e994eb1e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:40075",
+					"10.65.0.27:40075",
+					"172.17.0.1:40075",
+					"172.18.0.1:40075",
+					"172.19.0.1:40075"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:02:12.804604651Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4245148950529360,
+				"StableID":   "nywrv8sd9a11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f2199499fd8615908740254269df16a742082ded1dd15f15f32e7a653187660d",
+				"KeyExpiry":  "2026-11-08T22:02:13Z",
+				"DiscoKey":   "discokey:2f19acc3b823c9d54adc97caeef31822a3b8cd8cd694b5e14d404ebfea13876e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48259",
+					"10.65.0.27:48259",
+					"172.17.0.1:48259",
+					"172.18.0.1:48259",
+					"172.19.0.1:48259"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:02:13.344910068Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1015446840501143,
+				"StableID":   "nSLX4s4uv811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b2e1badd530efba26faeb09079974118ac4899f8db05071fbb8a0dc16a1d1c66",
+				"KeyExpiry":  "2026-11-08T22:02:13Z",
+				"DiscoKey":   "discokey:16ad1c72302127fc9ca8eacbda21ee743e3ac8a83a42dbf9ad19713e8b5a7e30",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54989",
+					"10.65.0.27:54989",
+					"172.17.0.1:54989",
+					"172.18.0.1:54989",
+					"172.19.0.1:54989"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:02:13.881469153Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4957581331602300,
+				"StableID":   "nfWNqnFJif11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:30ed4d4a10ff8d4868148cf523c0c32816637b0ac36c9ab8be625f423668a818",
+				"KeyExpiry":  "2026-11-08T22:02:14Z",
+				"DiscoKey":   "discokey:ae1dabc9c565a6613dcbb9917108a4cee945005c3c56a14701700a03a183170f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47239",
+					"10.65.0.27:47239",
+					"172.17.0.1:47239",
+					"172.18.0.1:47239",
+					"172.19.0.1:47239"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:02:14.424652089Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7598480586927999": {
+				"ID":          7598480586927999,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7679630823091561,
+				"StableID":   "nG8EB1t7y221CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       7679630823091561,
+				"Key":        "nodekey:70330263de73118f3ca9ef79a47b8312ff5bbafa502c4a9bf023285f63fe9e7c",
+				"DiscoKey":   "discokey:c446facb6f8d304709f153250adec71000d4049e186daa711d9735a250111851",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42418",
+					"10.65.0.27:42418",
+					"172.17.0.1:42418",
+					"172.18.0.1:42418",
+					"172.19.0.1:42418"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:01:19.725289158Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:70330263de73118f3ca9ef79a47b8312ff5bbafa502c4a9bf023285f63fe9e7c",
+			"MachineKey": "mkey:67ca3e5d6fa830791108f0d5c09c6be465ebca650bbc1de4f81ecb4543238567",
+			"Peers": [{
+				"ID":         3281193000221942,
+				"StableID":   "nsXhWpN4dS11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0086a787cae8961899b8d21db09bd878dd35723efb70e2be336509552b898269",
+				"DiscoKey":   "discokey:2f14238640f02240bb328ca4590814ff3f27d373d64916f802962067e2cd0a71",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38415",
+					"10.65.0.27:38415",
+					"172.17.0.1:38415",
+					"172.18.0.1:38415",
+					"172.19.0.1:38415"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:01:18.17236278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4766185274456039,
+				"StableID":   "nYRof6ccDe11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:adb3b489de7eebc64343a7a253f48c9aad9692ef13aa8ce29b1ea6d2f8ac365c",
+				"DiscoKey":   "discokey:7690097f29f4fbc829619f97de76e7947b0cdfd02406c5245b1316c001925348",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50045",
+					"10.65.0.27:50045",
+					"172.17.0.1:50045",
+					"172.18.0.1:50045",
+					"172.19.0.1:50045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:01:18.654536895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         538080972367332,
+				"StableID":   "nMFUxXUhC511CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:27dd848d78e935c87a87d3fbf367db9fe9ccd991de72ed6a2a304757f1db6439",
+				"DiscoKey":   "discokey:36eacbded1fe9b6d04901491ef8d3c6166619e3cd2ab89d30f10646b22fb2f15",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40623",
+					"10.65.0.27:40623",
+					"172.17.0.1:40623",
+					"172.18.0.1:40623",
+					"172.19.0.1:40623"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:01:19.196759907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7598480586927999,
+				"StableID":   "nEUAhcCNL221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:968d2c0575b07efdb5cfae441618ac17721fca480a036ba33241aada2d46411e",
+				"DiscoKey":   "discokey:53201c269825934e1fba1c820b86b425e4f1e7dfffd83a07166e455009759a7c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:44426",
+					"10.65.0.27:44426",
+					"172.17.0.1:44426",
+					"172.18.0.1:44426",
+					"172.19.0.1:44426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:02:08.884137165Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7837764808078094,
+				"StableID":   "nTKfvsnjC421CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7c3e40a9ed0ff7d5aaa6d3c3bcdf4476d307a6aa350e02eab50c34ff3eebf802",
+				"DiscoKey":   "discokey:7613c59d9de023a1e89e2ec363b1448c2a6e17610f334441719b2bfb713ab935",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53066",
+					"10.65.0.27:53066",
+					"172.17.0.1:53066",
+					"172.18.0.1:53066",
+					"172.19.0.1:53066"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:02:09.44901447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3897120922254004,
+				"StableID":   "n97Vqyk1SX11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5cc95f5e89363d7b068291b5a91328034cd83874b4a9110890c5bac741e3be2b",
+				"DiscoKey":   "discokey:6934c6e438e79e31d99d6bc7dd843ab555b8ffb8943daf9af4e64fa29346261a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48441",
+					"10.65.0.27:48441",
+					"172.17.0.1:48441",
+					"172.18.0.1:48441",
+					"172.19.0.1:48441"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:02:09.947128895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3019417511731452,
+				"StableID":   "nXN81jyVaQ11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4d21c3c535aae23fb456f1835c3f37b13331f576439d020d787d00bb365a872",
+				"DiscoKey":   "discokey:1efba7dd66114ecbc6d6e8787d4ef0a876a55e6fd739e94674812894ce38d740",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57385",
+					"10.65.0.27:57385",
+					"172.17.0.1:57385",
+					"172.18.0.1:57385",
+					"172.19.0.1:57385"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:02:10.484613551Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3108214568090199,
+				"StableID":   "nkqUoWXiGR11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d28f478f06bd50f644a17739edaf1a1941bdf7905e94cf10977bc5d4e94ef4a",
+				"DiscoKey":   "discokey:2473ab0c7e1ba1a9375110c9b05a30ddce5838dc5550318ba19a0cd232c74464",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:57313",
+					"10.65.0.27:57313",
+					"172.17.0.1:57313",
+					"172.18.0.1:57313",
+					"172.19.0.1:57313"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:02:11.023346401Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1561625567398938,
+				"StableID":   "nZxcrpFGCD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc4e628c93e34160c6ee491175bc707ecfd774df8d546536182e785aeb9b4a26",
+				"DiscoKey":   "discokey:0196cba50c53deba824493433b17d2aadfddb1b4ae380ad0230bcaaad6019a24",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59933",
+					"10.65.0.27:59933",
+					"172.17.0.1:59933",
+					"172.18.0.1:59933",
+					"172.19.0.1:59933"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:02:11.715884325Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         699212911543336,
+				"StableID":   "nFpkey8gT611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93d1d4a8ec6a2319e7c60ebdbc96ba132de43149ed6ec0d80882e312a5934d5f",
+				"DiscoKey":   "discokey:9a26dd8f8eb613b478b7f54477331cdc9252d17a436e83b79eedcd951204e570",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48036",
+					"10.65.0.27:48036",
+					"172.17.0.1:48036",
+					"172.18.0.1:48036",
+					"172.19.0.1:48036"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:02:12.257434979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1552676499746967,
+				"StableID":   "nzriPNBD8D11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1bea0530180043bd6c09dacd73c42c8dc75e8cba56560c0ef63751500499617",
+				"DiscoKey":   "discokey:59e55dc8f57d3e66a892dab38716bad360c707a39ecc0f65ac58a0d9e994eb1e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:40075",
+					"10.65.0.27:40075",
+					"172.17.0.1:40075",
+					"172.18.0.1:40075",
+					"172.19.0.1:40075"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:02:12.804604651Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4245148950529360,
+				"StableID":   "nywrv8sd9a11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f2199499fd8615908740254269df16a742082ded1dd15f15f32e7a653187660d",
+				"KeyExpiry":  "2026-11-08T22:02:13Z",
+				"DiscoKey":   "discokey:2f19acc3b823c9d54adc97caeef31822a3b8cd8cd694b5e14d404ebfea13876e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48259",
+					"10.65.0.27:48259",
+					"172.17.0.1:48259",
+					"172.18.0.1:48259",
+					"172.19.0.1:48259"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:02:13.344910068Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1015446840501143,
+				"StableID":   "nSLX4s4uv811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b2e1badd530efba26faeb09079974118ac4899f8db05071fbb8a0dc16a1d1c66",
+				"KeyExpiry":  "2026-11-08T22:02:13Z",
+				"DiscoKey":   "discokey:16ad1c72302127fc9ca8eacbda21ee743e3ac8a83a42dbf9ad19713e8b5a7e30",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54989",
+					"10.65.0.27:54989",
+					"172.17.0.1:54989",
+					"172.18.0.1:54989",
+					"172.19.0.1:54989"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:02:13.881469153Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4957581331602300,
+				"StableID":   "nfWNqnFJif11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:30ed4d4a10ff8d4868148cf523c0c32816637b0ac36c9ab8be625f423668a818",
+				"KeyExpiry":  "2026-11-08T22:02:14Z",
+				"DiscoKey":   "discokey:ae1dabc9c565a6613dcbb9917108a4cee945005c3c56a14701700a03a183170f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47239",
+					"10.65.0.27:47239",
+					"172.17.0.1:47239",
+					"172.18.0.1:47239",
+					"172.19.0.1:47239"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:02:14.424652089Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7679630823091561": {
+				"ID":          7679630823091561,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3897120922254004,
+				"StableID":   "n97Vqyk1SX11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       3897120922254004,
+				"Key":        "nodekey:5cc95f5e89363d7b068291b5a91328034cd83874b4a9110890c5bac741e3be2b",
+				"DiscoKey":   "discokey:6934c6e438e79e31d99d6bc7dd843ab555b8ffb8943daf9af4e64fa29346261a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48441",
+					"10.65.0.27:48441",
+					"172.17.0.1:48441",
+					"172.18.0.1:48441",
+					"172.19.0.1:48441"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:02:09.947128895Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5cc95f5e89363d7b068291b5a91328034cd83874b4a9110890c5bac741e3be2b",
+			"MachineKey": "mkey:937eea6b2ba4086ebeae553d0373609522640f1e6640a4e7ebdb5111f19d5872",
+			"Peers": [{
+				"ID":         3281193000221942,
+				"StableID":   "nsXhWpN4dS11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0086a787cae8961899b8d21db09bd878dd35723efb70e2be336509552b898269",
+				"DiscoKey":   "discokey:2f14238640f02240bb328ca4590814ff3f27d373d64916f802962067e2cd0a71",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38415",
+					"10.65.0.27:38415",
+					"172.17.0.1:38415",
+					"172.18.0.1:38415",
+					"172.19.0.1:38415"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:01:18.17236278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4766185274456039,
+				"StableID":   "nYRof6ccDe11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:adb3b489de7eebc64343a7a253f48c9aad9692ef13aa8ce29b1ea6d2f8ac365c",
+				"DiscoKey":   "discokey:7690097f29f4fbc829619f97de76e7947b0cdfd02406c5245b1316c001925348",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50045",
+					"10.65.0.27:50045",
+					"172.17.0.1:50045",
+					"172.18.0.1:50045",
+					"172.19.0.1:50045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:01:18.654536895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         538080972367332,
+				"StableID":   "nMFUxXUhC511CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:27dd848d78e935c87a87d3fbf367db9fe9ccd991de72ed6a2a304757f1db6439",
+				"DiscoKey":   "discokey:36eacbded1fe9b6d04901491ef8d3c6166619e3cd2ab89d30f10646b22fb2f15",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40623",
+					"10.65.0.27:40623",
+					"172.17.0.1:40623",
+					"172.18.0.1:40623",
+					"172.19.0.1:40623"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:01:19.196759907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7679630823091561,
+				"StableID":   "nG8EB1t7y221CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:70330263de73118f3ca9ef79a47b8312ff5bbafa502c4a9bf023285f63fe9e7c",
+				"DiscoKey":   "discokey:c446facb6f8d304709f153250adec71000d4049e186daa711d9735a250111851",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42418",
+					"10.65.0.27:42418",
+					"172.17.0.1:42418",
+					"172.18.0.1:42418",
+					"172.19.0.1:42418"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:01:19.725289158Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7598480586927999,
+				"StableID":   "nEUAhcCNL221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:968d2c0575b07efdb5cfae441618ac17721fca480a036ba33241aada2d46411e",
+				"DiscoKey":   "discokey:53201c269825934e1fba1c820b86b425e4f1e7dfffd83a07166e455009759a7c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:44426",
+					"10.65.0.27:44426",
+					"172.17.0.1:44426",
+					"172.18.0.1:44426",
+					"172.19.0.1:44426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:02:08.884137165Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7837764808078094,
+				"StableID":   "nTKfvsnjC421CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7c3e40a9ed0ff7d5aaa6d3c3bcdf4476d307a6aa350e02eab50c34ff3eebf802",
+				"DiscoKey":   "discokey:7613c59d9de023a1e89e2ec363b1448c2a6e17610f334441719b2bfb713ab935",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53066",
+					"10.65.0.27:53066",
+					"172.17.0.1:53066",
+					"172.18.0.1:53066",
+					"172.19.0.1:53066"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:02:09.44901447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3019417511731452,
+				"StableID":   "nXN81jyVaQ11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4d21c3c535aae23fb456f1835c3f37b13331f576439d020d787d00bb365a872",
+				"DiscoKey":   "discokey:1efba7dd66114ecbc6d6e8787d4ef0a876a55e6fd739e94674812894ce38d740",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57385",
+					"10.65.0.27:57385",
+					"172.17.0.1:57385",
+					"172.18.0.1:57385",
+					"172.19.0.1:57385"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:02:10.484613551Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3108214568090199,
+				"StableID":   "nkqUoWXiGR11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d28f478f06bd50f644a17739edaf1a1941bdf7905e94cf10977bc5d4e94ef4a",
+				"DiscoKey":   "discokey:2473ab0c7e1ba1a9375110c9b05a30ddce5838dc5550318ba19a0cd232c74464",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:57313",
+					"10.65.0.27:57313",
+					"172.17.0.1:57313",
+					"172.18.0.1:57313",
+					"172.19.0.1:57313"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:02:11.023346401Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1561625567398938,
+				"StableID":   "nZxcrpFGCD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc4e628c93e34160c6ee491175bc707ecfd774df8d546536182e785aeb9b4a26",
+				"DiscoKey":   "discokey:0196cba50c53deba824493433b17d2aadfddb1b4ae380ad0230bcaaad6019a24",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59933",
+					"10.65.0.27:59933",
+					"172.17.0.1:59933",
+					"172.18.0.1:59933",
+					"172.19.0.1:59933"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:02:11.715884325Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         699212911543336,
+				"StableID":   "nFpkey8gT611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93d1d4a8ec6a2319e7c60ebdbc96ba132de43149ed6ec0d80882e312a5934d5f",
+				"DiscoKey":   "discokey:9a26dd8f8eb613b478b7f54477331cdc9252d17a436e83b79eedcd951204e570",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48036",
+					"10.65.0.27:48036",
+					"172.17.0.1:48036",
+					"172.18.0.1:48036",
+					"172.19.0.1:48036"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:02:12.257434979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1552676499746967,
+				"StableID":   "nzriPNBD8D11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1bea0530180043bd6c09dacd73c42c8dc75e8cba56560c0ef63751500499617",
+				"DiscoKey":   "discokey:59e55dc8f57d3e66a892dab38716bad360c707a39ecc0f65ac58a0d9e994eb1e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:40075",
+					"10.65.0.27:40075",
+					"172.17.0.1:40075",
+					"172.18.0.1:40075",
+					"172.19.0.1:40075"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:02:12.804604651Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4245148950529360,
+				"StableID":   "nywrv8sd9a11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f2199499fd8615908740254269df16a742082ded1dd15f15f32e7a653187660d",
+				"KeyExpiry":  "2026-11-08T22:02:13Z",
+				"DiscoKey":   "discokey:2f19acc3b823c9d54adc97caeef31822a3b8cd8cd694b5e14d404ebfea13876e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48259",
+					"10.65.0.27:48259",
+					"172.17.0.1:48259",
+					"172.18.0.1:48259",
+					"172.19.0.1:48259"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:02:13.344910068Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1015446840501143,
+				"StableID":   "nSLX4s4uv811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b2e1badd530efba26faeb09079974118ac4899f8db05071fbb8a0dc16a1d1c66",
+				"KeyExpiry":  "2026-11-08T22:02:13Z",
+				"DiscoKey":   "discokey:16ad1c72302127fc9ca8eacbda21ee743e3ac8a83a42dbf9ad19713e8b5a7e30",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54989",
+					"10.65.0.27:54989",
+					"172.17.0.1:54989",
+					"172.18.0.1:54989",
+					"172.19.0.1:54989"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:02:13.881469153Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4957581331602300,
+				"StableID":   "nfWNqnFJif11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:30ed4d4a10ff8d4868148cf523c0c32816637b0ac36c9ab8be625f423668a818",
+				"KeyExpiry":  "2026-11-08T22:02:14Z",
+				"DiscoKey":   "discokey:ae1dabc9c565a6613dcbb9917108a4cee945005c3c56a14701700a03a183170f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47239",
+					"10.65.0.27:47239",
+					"172.17.0.1:47239",
+					"172.18.0.1:47239",
+					"172.19.0.1:47239"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:02:14.424652089Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3897120922254004": {
+				"ID":          3897120922254004,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3108214568090199,
+				"StableID":   "nkqUoWXiGR11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       3108214568090199,
+				"Key":        "nodekey:3d28f478f06bd50f644a17739edaf1a1941bdf7905e94cf10977bc5d4e94ef4a",
+				"DiscoKey":   "discokey:2473ab0c7e1ba1a9375110c9b05a30ddce5838dc5550318ba19a0cd232c74464",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:57313",
+					"10.65.0.27:57313",
+					"172.17.0.1:57313",
+					"172.18.0.1:57313",
+					"172.19.0.1:57313"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:02:11.023346401Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3d28f478f06bd50f644a17739edaf1a1941bdf7905e94cf10977bc5d4e94ef4a",
+			"MachineKey": "mkey:f160115e15a8028c14b0d5d0c9ff5821282aa84e796cbb76eb0a700d670c1c69",
+			"Peers": [{
+				"ID":         3281193000221942,
+				"StableID":   "nsXhWpN4dS11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0086a787cae8961899b8d21db09bd878dd35723efb70e2be336509552b898269",
+				"DiscoKey":   "discokey:2f14238640f02240bb328ca4590814ff3f27d373d64916f802962067e2cd0a71",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38415",
+					"10.65.0.27:38415",
+					"172.17.0.1:38415",
+					"172.18.0.1:38415",
+					"172.19.0.1:38415"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:01:18.17236278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4766185274456039,
+				"StableID":   "nYRof6ccDe11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:adb3b489de7eebc64343a7a253f48c9aad9692ef13aa8ce29b1ea6d2f8ac365c",
+				"DiscoKey":   "discokey:7690097f29f4fbc829619f97de76e7947b0cdfd02406c5245b1316c001925348",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50045",
+					"10.65.0.27:50045",
+					"172.17.0.1:50045",
+					"172.18.0.1:50045",
+					"172.19.0.1:50045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:01:18.654536895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         538080972367332,
+				"StableID":   "nMFUxXUhC511CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:27dd848d78e935c87a87d3fbf367db9fe9ccd991de72ed6a2a304757f1db6439",
+				"DiscoKey":   "discokey:36eacbded1fe9b6d04901491ef8d3c6166619e3cd2ab89d30f10646b22fb2f15",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40623",
+					"10.65.0.27:40623",
+					"172.17.0.1:40623",
+					"172.18.0.1:40623",
+					"172.19.0.1:40623"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:01:19.196759907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7679630823091561,
+				"StableID":   "nG8EB1t7y221CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:70330263de73118f3ca9ef79a47b8312ff5bbafa502c4a9bf023285f63fe9e7c",
+				"DiscoKey":   "discokey:c446facb6f8d304709f153250adec71000d4049e186daa711d9735a250111851",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42418",
+					"10.65.0.27:42418",
+					"172.17.0.1:42418",
+					"172.18.0.1:42418",
+					"172.19.0.1:42418"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:01:19.725289158Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7598480586927999,
+				"StableID":   "nEUAhcCNL221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:968d2c0575b07efdb5cfae441618ac17721fca480a036ba33241aada2d46411e",
+				"DiscoKey":   "discokey:53201c269825934e1fba1c820b86b425e4f1e7dfffd83a07166e455009759a7c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:44426",
+					"10.65.0.27:44426",
+					"172.17.0.1:44426",
+					"172.18.0.1:44426",
+					"172.19.0.1:44426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:02:08.884137165Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7837764808078094,
+				"StableID":   "nTKfvsnjC421CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7c3e40a9ed0ff7d5aaa6d3c3bcdf4476d307a6aa350e02eab50c34ff3eebf802",
+				"DiscoKey":   "discokey:7613c59d9de023a1e89e2ec363b1448c2a6e17610f334441719b2bfb713ab935",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53066",
+					"10.65.0.27:53066",
+					"172.17.0.1:53066",
+					"172.18.0.1:53066",
+					"172.19.0.1:53066"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:02:09.44901447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3897120922254004,
+				"StableID":   "n97Vqyk1SX11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5cc95f5e89363d7b068291b5a91328034cd83874b4a9110890c5bac741e3be2b",
+				"DiscoKey":   "discokey:6934c6e438e79e31d99d6bc7dd843ab555b8ffb8943daf9af4e64fa29346261a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48441",
+					"10.65.0.27:48441",
+					"172.17.0.1:48441",
+					"172.18.0.1:48441",
+					"172.19.0.1:48441"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:02:09.947128895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3019417511731452,
+				"StableID":   "nXN81jyVaQ11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4d21c3c535aae23fb456f1835c3f37b13331f576439d020d787d00bb365a872",
+				"DiscoKey":   "discokey:1efba7dd66114ecbc6d6e8787d4ef0a876a55e6fd739e94674812894ce38d740",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57385",
+					"10.65.0.27:57385",
+					"172.17.0.1:57385",
+					"172.18.0.1:57385",
+					"172.19.0.1:57385"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:02:10.484613551Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1561625567398938,
+				"StableID":   "nZxcrpFGCD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc4e628c93e34160c6ee491175bc707ecfd774df8d546536182e785aeb9b4a26",
+				"DiscoKey":   "discokey:0196cba50c53deba824493433b17d2aadfddb1b4ae380ad0230bcaaad6019a24",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59933",
+					"10.65.0.27:59933",
+					"172.17.0.1:59933",
+					"172.18.0.1:59933",
+					"172.19.0.1:59933"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:02:11.715884325Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         699212911543336,
+				"StableID":   "nFpkey8gT611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93d1d4a8ec6a2319e7c60ebdbc96ba132de43149ed6ec0d80882e312a5934d5f",
+				"DiscoKey":   "discokey:9a26dd8f8eb613b478b7f54477331cdc9252d17a436e83b79eedcd951204e570",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48036",
+					"10.65.0.27:48036",
+					"172.17.0.1:48036",
+					"172.18.0.1:48036",
+					"172.19.0.1:48036"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:02:12.257434979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1552676499746967,
+				"StableID":   "nzriPNBD8D11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1bea0530180043bd6c09dacd73c42c8dc75e8cba56560c0ef63751500499617",
+				"DiscoKey":   "discokey:59e55dc8f57d3e66a892dab38716bad360c707a39ecc0f65ac58a0d9e994eb1e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:40075",
+					"10.65.0.27:40075",
+					"172.17.0.1:40075",
+					"172.18.0.1:40075",
+					"172.19.0.1:40075"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:02:12.804604651Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4245148950529360,
+				"StableID":   "nywrv8sd9a11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f2199499fd8615908740254269df16a742082ded1dd15f15f32e7a653187660d",
+				"KeyExpiry":  "2026-11-08T22:02:13Z",
+				"DiscoKey":   "discokey:2f19acc3b823c9d54adc97caeef31822a3b8cd8cd694b5e14d404ebfea13876e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48259",
+					"10.65.0.27:48259",
+					"172.17.0.1:48259",
+					"172.18.0.1:48259",
+					"172.19.0.1:48259"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:02:13.344910068Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1015446840501143,
+				"StableID":   "nSLX4s4uv811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b2e1badd530efba26faeb09079974118ac4899f8db05071fbb8a0dc16a1d1c66",
+				"KeyExpiry":  "2026-11-08T22:02:13Z",
+				"DiscoKey":   "discokey:16ad1c72302127fc9ca8eacbda21ee743e3ac8a83a42dbf9ad19713e8b5a7e30",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54989",
+					"10.65.0.27:54989",
+					"172.17.0.1:54989",
+					"172.18.0.1:54989",
+					"172.19.0.1:54989"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:02:13.881469153Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4957581331602300,
+				"StableID":   "nfWNqnFJif11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:30ed4d4a10ff8d4868148cf523c0c32816637b0ac36c9ab8be625f423668a818",
+				"KeyExpiry":  "2026-11-08T22:02:14Z",
+				"DiscoKey":   "discokey:ae1dabc9c565a6613dcbb9917108a4cee945005c3c56a14701700a03a183170f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47239",
+					"10.65.0.27:47239",
+					"172.17.0.1:47239",
+					"172.18.0.1:47239",
+					"172.19.0.1:47239"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:02:14.424652089Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3108214568090199": {
+				"ID":          3108214568090199,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1015446840501143,
+				"StableID":   "nSLX4s4uv811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b2e1badd530efba26faeb09079974118ac4899f8db05071fbb8a0dc16a1d1c66",
+				"KeyExpiry":  "2026-11-08T22:02:13Z",
+				"DiscoKey":   "discokey:16ad1c72302127fc9ca8eacbda21ee743e3ac8a83a42dbf9ad19713e8b5a7e30",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54989",
+					"10.65.0.27:54989",
+					"172.17.0.1:54989",
+					"172.18.0.1:54989",
+					"172.19.0.1:54989"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:02:13.881469153Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b2e1badd530efba26faeb09079974118ac4899f8db05071fbb8a0dc16a1d1c66",
+			"MachineKey": "mkey:95bfeac5eece3f8eab171b3b687d55a151ff38a6fc0bb0c7e41ae24162a5d666",
+			"Peers": [{
+				"ID":         3281193000221942,
+				"StableID":   "nsXhWpN4dS11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0086a787cae8961899b8d21db09bd878dd35723efb70e2be336509552b898269",
+				"DiscoKey":   "discokey:2f14238640f02240bb328ca4590814ff3f27d373d64916f802962067e2cd0a71",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38415",
+					"10.65.0.27:38415",
+					"172.17.0.1:38415",
+					"172.18.0.1:38415",
+					"172.19.0.1:38415"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:01:18.17236278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4766185274456039,
+				"StableID":   "nYRof6ccDe11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:adb3b489de7eebc64343a7a253f48c9aad9692ef13aa8ce29b1ea6d2f8ac365c",
+				"DiscoKey":   "discokey:7690097f29f4fbc829619f97de76e7947b0cdfd02406c5245b1316c001925348",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50045",
+					"10.65.0.27:50045",
+					"172.17.0.1:50045",
+					"172.18.0.1:50045",
+					"172.19.0.1:50045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:01:18.654536895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         538080972367332,
+				"StableID":   "nMFUxXUhC511CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:27dd848d78e935c87a87d3fbf367db9fe9ccd991de72ed6a2a304757f1db6439",
+				"DiscoKey":   "discokey:36eacbded1fe9b6d04901491ef8d3c6166619e3cd2ab89d30f10646b22fb2f15",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40623",
+					"10.65.0.27:40623",
+					"172.17.0.1:40623",
+					"172.18.0.1:40623",
+					"172.19.0.1:40623"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:01:19.196759907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7679630823091561,
+				"StableID":   "nG8EB1t7y221CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:70330263de73118f3ca9ef79a47b8312ff5bbafa502c4a9bf023285f63fe9e7c",
+				"DiscoKey":   "discokey:c446facb6f8d304709f153250adec71000d4049e186daa711d9735a250111851",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42418",
+					"10.65.0.27:42418",
+					"172.17.0.1:42418",
+					"172.18.0.1:42418",
+					"172.19.0.1:42418"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:01:19.725289158Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7598480586927999,
+				"StableID":   "nEUAhcCNL221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:968d2c0575b07efdb5cfae441618ac17721fca480a036ba33241aada2d46411e",
+				"DiscoKey":   "discokey:53201c269825934e1fba1c820b86b425e4f1e7dfffd83a07166e455009759a7c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:44426",
+					"10.65.0.27:44426",
+					"172.17.0.1:44426",
+					"172.18.0.1:44426",
+					"172.19.0.1:44426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:02:08.884137165Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7837764808078094,
+				"StableID":   "nTKfvsnjC421CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7c3e40a9ed0ff7d5aaa6d3c3bcdf4476d307a6aa350e02eab50c34ff3eebf802",
+				"DiscoKey":   "discokey:7613c59d9de023a1e89e2ec363b1448c2a6e17610f334441719b2bfb713ab935",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53066",
+					"10.65.0.27:53066",
+					"172.17.0.1:53066",
+					"172.18.0.1:53066",
+					"172.19.0.1:53066"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:02:09.44901447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3897120922254004,
+				"StableID":   "n97Vqyk1SX11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5cc95f5e89363d7b068291b5a91328034cd83874b4a9110890c5bac741e3be2b",
+				"DiscoKey":   "discokey:6934c6e438e79e31d99d6bc7dd843ab555b8ffb8943daf9af4e64fa29346261a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48441",
+					"10.65.0.27:48441",
+					"172.17.0.1:48441",
+					"172.18.0.1:48441",
+					"172.19.0.1:48441"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:02:09.947128895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3019417511731452,
+				"StableID":   "nXN81jyVaQ11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4d21c3c535aae23fb456f1835c3f37b13331f576439d020d787d00bb365a872",
+				"DiscoKey":   "discokey:1efba7dd66114ecbc6d6e8787d4ef0a876a55e6fd739e94674812894ce38d740",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57385",
+					"10.65.0.27:57385",
+					"172.17.0.1:57385",
+					"172.18.0.1:57385",
+					"172.19.0.1:57385"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:02:10.484613551Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3108214568090199,
+				"StableID":   "nkqUoWXiGR11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d28f478f06bd50f644a17739edaf1a1941bdf7905e94cf10977bc5d4e94ef4a",
+				"DiscoKey":   "discokey:2473ab0c7e1ba1a9375110c9b05a30ddce5838dc5550318ba19a0cd232c74464",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:57313",
+					"10.65.0.27:57313",
+					"172.17.0.1:57313",
+					"172.18.0.1:57313",
+					"172.19.0.1:57313"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:02:11.023346401Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1561625567398938,
+				"StableID":   "nZxcrpFGCD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc4e628c93e34160c6ee491175bc707ecfd774df8d546536182e785aeb9b4a26",
+				"DiscoKey":   "discokey:0196cba50c53deba824493433b17d2aadfddb1b4ae380ad0230bcaaad6019a24",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59933",
+					"10.65.0.27:59933",
+					"172.17.0.1:59933",
+					"172.18.0.1:59933",
+					"172.19.0.1:59933"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:02:11.715884325Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         699212911543336,
+				"StableID":   "nFpkey8gT611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93d1d4a8ec6a2319e7c60ebdbc96ba132de43149ed6ec0d80882e312a5934d5f",
+				"DiscoKey":   "discokey:9a26dd8f8eb613b478b7f54477331cdc9252d17a436e83b79eedcd951204e570",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48036",
+					"10.65.0.27:48036",
+					"172.17.0.1:48036",
+					"172.18.0.1:48036",
+					"172.19.0.1:48036"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:02:12.257434979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1552676499746967,
+				"StableID":   "nzriPNBD8D11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1bea0530180043bd6c09dacd73c42c8dc75e8cba56560c0ef63751500499617",
+				"DiscoKey":   "discokey:59e55dc8f57d3e66a892dab38716bad360c707a39ecc0f65ac58a0d9e994eb1e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:40075",
+					"10.65.0.27:40075",
+					"172.17.0.1:40075",
+					"172.18.0.1:40075",
+					"172.19.0.1:40075"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:02:12.804604651Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4245148950529360,
+				"StableID":   "nywrv8sd9a11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f2199499fd8615908740254269df16a742082ded1dd15f15f32e7a653187660d",
+				"KeyExpiry":  "2026-11-08T22:02:13Z",
+				"DiscoKey":   "discokey:2f19acc3b823c9d54adc97caeef31822a3b8cd8cd694b5e14d404ebfea13876e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48259",
+					"10.65.0.27:48259",
+					"172.17.0.1:48259",
+					"172.18.0.1:48259",
+					"172.19.0.1:48259"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:02:13.344910068Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4957581331602300,
+				"StableID":   "nfWNqnFJif11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:30ed4d4a10ff8d4868148cf523c0c32816637b0ac36c9ab8be625f423668a818",
+				"KeyExpiry":  "2026-11-08T22:02:14Z",
+				"DiscoKey":   "discokey:ae1dabc9c565a6613dcbb9917108a4cee945005c3c56a14701700a03a183170f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47239",
+					"10.65.0.27:47239",
+					"172.17.0.1:47239",
+					"172.18.0.1:47239",
+					"172.19.0.1:47239"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:02:14.424652089Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1561625567398938,
+				"StableID":   "nZxcrpFGCD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1561625567398938,
+				"Key":        "nodekey:dc4e628c93e34160c6ee491175bc707ecfd774df8d546536182e785aeb9b4a26",
+				"DiscoKey":   "discokey:0196cba50c53deba824493433b17d2aadfddb1b4ae380ad0230bcaaad6019a24",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59933",
+					"10.65.0.27:59933",
+					"172.17.0.1:59933",
+					"172.18.0.1:59933",
+					"172.19.0.1:59933"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:02:11.715884325Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:dc4e628c93e34160c6ee491175bc707ecfd774df8d546536182e785aeb9b4a26",
+			"MachineKey": "mkey:c646efec71260f2634a8bd99fb79c97358f9de85b3e0aa439641e0ea5ebf9b2d",
+			"Peers": [{
+				"ID":         3281193000221942,
+				"StableID":   "nsXhWpN4dS11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0086a787cae8961899b8d21db09bd878dd35723efb70e2be336509552b898269",
+				"DiscoKey":   "discokey:2f14238640f02240bb328ca4590814ff3f27d373d64916f802962067e2cd0a71",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38415",
+					"10.65.0.27:38415",
+					"172.17.0.1:38415",
+					"172.18.0.1:38415",
+					"172.19.0.1:38415"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:01:18.17236278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4766185274456039,
+				"StableID":   "nYRof6ccDe11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:adb3b489de7eebc64343a7a253f48c9aad9692ef13aa8ce29b1ea6d2f8ac365c",
+				"DiscoKey":   "discokey:7690097f29f4fbc829619f97de76e7947b0cdfd02406c5245b1316c001925348",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50045",
+					"10.65.0.27:50045",
+					"172.17.0.1:50045",
+					"172.18.0.1:50045",
+					"172.19.0.1:50045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:01:18.654536895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         538080972367332,
+				"StableID":   "nMFUxXUhC511CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:27dd848d78e935c87a87d3fbf367db9fe9ccd991de72ed6a2a304757f1db6439",
+				"DiscoKey":   "discokey:36eacbded1fe9b6d04901491ef8d3c6166619e3cd2ab89d30f10646b22fb2f15",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40623",
+					"10.65.0.27:40623",
+					"172.17.0.1:40623",
+					"172.18.0.1:40623",
+					"172.19.0.1:40623"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:01:19.196759907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7679630823091561,
+				"StableID":   "nG8EB1t7y221CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:70330263de73118f3ca9ef79a47b8312ff5bbafa502c4a9bf023285f63fe9e7c",
+				"DiscoKey":   "discokey:c446facb6f8d304709f153250adec71000d4049e186daa711d9735a250111851",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42418",
+					"10.65.0.27:42418",
+					"172.17.0.1:42418",
+					"172.18.0.1:42418",
+					"172.19.0.1:42418"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:01:19.725289158Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7598480586927999,
+				"StableID":   "nEUAhcCNL221CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:968d2c0575b07efdb5cfae441618ac17721fca480a036ba33241aada2d46411e",
+				"DiscoKey":   "discokey:53201c269825934e1fba1c820b86b425e4f1e7dfffd83a07166e455009759a7c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:44426",
+					"10.65.0.27:44426",
+					"172.17.0.1:44426",
+					"172.18.0.1:44426",
+					"172.19.0.1:44426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:02:08.884137165Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7837764808078094,
+				"StableID":   "nTKfvsnjC421CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7c3e40a9ed0ff7d5aaa6d3c3bcdf4476d307a6aa350e02eab50c34ff3eebf802",
+				"DiscoKey":   "discokey:7613c59d9de023a1e89e2ec363b1448c2a6e17610f334441719b2bfb713ab935",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53066",
+					"10.65.0.27:53066",
+					"172.17.0.1:53066",
+					"172.18.0.1:53066",
+					"172.19.0.1:53066"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:02:09.44901447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3897120922254004,
+				"StableID":   "n97Vqyk1SX11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5cc95f5e89363d7b068291b5a91328034cd83874b4a9110890c5bac741e3be2b",
+				"DiscoKey":   "discokey:6934c6e438e79e31d99d6bc7dd843ab555b8ffb8943daf9af4e64fa29346261a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48441",
+					"10.65.0.27:48441",
+					"172.17.0.1:48441",
+					"172.18.0.1:48441",
+					"172.19.0.1:48441"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:02:09.947128895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3019417511731452,
+				"StableID":   "nXN81jyVaQ11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4d21c3c535aae23fb456f1835c3f37b13331f576439d020d787d00bb365a872",
+				"DiscoKey":   "discokey:1efba7dd66114ecbc6d6e8787d4ef0a876a55e6fd739e94674812894ce38d740",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57385",
+					"10.65.0.27:57385",
+					"172.17.0.1:57385",
+					"172.18.0.1:57385",
+					"172.19.0.1:57385"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:02:10.484613551Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3108214568090199,
+				"StableID":   "nkqUoWXiGR11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d28f478f06bd50f644a17739edaf1a1941bdf7905e94cf10977bc5d4e94ef4a",
+				"DiscoKey":   "discokey:2473ab0c7e1ba1a9375110c9b05a30ddce5838dc5550318ba19a0cd232c74464",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:57313",
+					"10.65.0.27:57313",
+					"172.17.0.1:57313",
+					"172.18.0.1:57313",
+					"172.19.0.1:57313"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:02:11.023346401Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         699212911543336,
+				"StableID":   "nFpkey8gT611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93d1d4a8ec6a2319e7c60ebdbc96ba132de43149ed6ec0d80882e312a5934d5f",
+				"DiscoKey":   "discokey:9a26dd8f8eb613b478b7f54477331cdc9252d17a436e83b79eedcd951204e570",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48036",
+					"10.65.0.27:48036",
+					"172.17.0.1:48036",
+					"172.18.0.1:48036",
+					"172.19.0.1:48036"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:02:12.257434979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1552676499746967,
+				"StableID":   "nzriPNBD8D11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1bea0530180043bd6c09dacd73c42c8dc75e8cba56560c0ef63751500499617",
+				"DiscoKey":   "discokey:59e55dc8f57d3e66a892dab38716bad360c707a39ecc0f65ac58a0d9e994eb1e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:40075",
+					"10.65.0.27:40075",
+					"172.17.0.1:40075",
+					"172.18.0.1:40075",
+					"172.19.0.1:40075"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:02:12.804604651Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4245148950529360,
+				"StableID":   "nywrv8sd9a11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f2199499fd8615908740254269df16a742082ded1dd15f15f32e7a653187660d",
+				"KeyExpiry":  "2026-11-08T22:02:13Z",
+				"DiscoKey":   "discokey:2f19acc3b823c9d54adc97caeef31822a3b8cd8cd694b5e14d404ebfea13876e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48259",
+					"10.65.0.27:48259",
+					"172.17.0.1:48259",
+					"172.18.0.1:48259",
+					"172.19.0.1:48259"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:02:13.344910068Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1015446840501143,
+				"StableID":   "nSLX4s4uv811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b2e1badd530efba26faeb09079974118ac4899f8db05071fbb8a0dc16a1d1c66",
+				"KeyExpiry":  "2026-11-08T22:02:13Z",
+				"DiscoKey":   "discokey:16ad1c72302127fc9ca8eacbda21ee743e3ac8a83a42dbf9ad19713e8b5a7e30",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54989",
+					"10.65.0.27:54989",
+					"172.17.0.1:54989",
+					"172.18.0.1:54989",
+					"172.19.0.1:54989"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:02:13.881469153Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4957581331602300,
+				"StableID":   "nfWNqnFJif11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:30ed4d4a10ff8d4868148cf523c0c32816637b0ac36c9ab8be625f423668a818",
+				"KeyExpiry":  "2026-11-08T22:02:14Z",
+				"DiscoKey":   "discokey:ae1dabc9c565a6613dcbb9917108a4cee945005c3c56a14701700a03a183170f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47239",
+					"10.65.0.27:47239",
+					"172.17.0.1:47239",
+					"172.18.0.1:47239",
+					"172.19.0.1:47239"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:02:14.424652089Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1561625567398938": {
+				"ID":          1561625567398938,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-user-autogroup-self.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-user-autogroup-self.hujson
@@ -1,0 +1,20104 @@
+// ssh-malformed-user-autogroup-self
+//
+// ssh users autogroup:self is rejected
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T22:02:59Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-malformed-user-autogroup-self",
+	"description":    "ssh users autogroup:self is rejected",
+	"category":       "ssh",
+	"captured_at":    "2026-05-12T22:02:59.70904847Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                    \n  \n                                                                              \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh users autogroup:self is rejected\",\n\t\"id\":          \"ssh-malformed-user-autogroup-self\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"autogroup:member\"],\n\t\t\"users\":  [\"autogroup:self\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-malformed/ssh-malformed-user-autogroup-self.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["autogroup:member"],
+				"users":  ["autogroup:self"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6468258047135598,
+				"StableID":   "n9Ak7uAVWs11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       6468258047135598,
+				"Key":        "nodekey:2567ad955d8d9480c8eb2bdb75126c4c8c07cac2fa48cd297107ef8f5dfb5202",
+				"DiscoKey":   "discokey:8d87bdd3eb8f636dc5b0ed189a9fcb22e5dbd680e94d7014df58c492aef68851",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:53616",
+					"10.65.0.27:53616",
+					"172.17.0.1:53616",
+					"172.18.0.1:53616",
+					"172.19.0.1:53616"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:03:08.777000304Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2567ad955d8d9480c8eb2bdb75126c4c8c07cac2fa48cd297107ef8f5dfb5202",
+			"MachineKey": "mkey:71ae32f2bfa65f25361dd0dcc1818b01998eeb86cf97de672880aa0c9de0fe4d",
+			"Peers": [{
+				"ID":         4778158905084370,
+				"StableID":   "nZCYQf83Ke11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b12938f529d15fbf7d733b3263f58bcbbebdaa79ce6c0adfcf6e58af4d822f66",
+				"DiscoKey":   "discokey:4af2342ba570ea1376a026f9630159b9cd96e50cbf033e703570d1d84be3546a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45163",
+					"10.65.0.27:45163",
+					"172.17.0.1:45163",
+					"172.18.0.1:45163",
+					"172.19.0.1:45163"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:03:02.856579649Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2172641053472854,
+				"StableID":   "nfs43bbzxH11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4c84d05352d371ad043bc87e8f2d28f563252370377da246f302e100ea61ea6d",
+				"DiscoKey":   "discokey:211d89d048dd9d58210fbc1b622dfcb170bca56500fbc6d0d3ac4cdd5ea98242",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:36639",
+					"10.65.0.27:36639",
+					"172.17.0.1:36639",
+					"172.18.0.1:36639",
+					"172.19.0.1:36639"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:03:03.38550291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4061196893810790,
+				"StableID":   "n3wFbqkKiY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:beda62eec575c69f5fd8f1bed233e197c192a6bef31c9c116235a332a482951b",
+				"DiscoKey":   "discokey:19b29be938553471d08ef741decbb39ca65862c90b6a730e371f1a552dce0f4a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:47517",
+					"10.65.0.27:47517",
+					"172.17.0.1:47517",
+					"172.18.0.1:47517",
+					"172.19.0.1:47517"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:03:03.928154443Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6671352957763120,
+				"StableID":   "nqHMuW8U6u11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36e371fb3c9e4ac8a77a8cccf18c4fa3164c05506b54ef5c3147744658b8ca3f",
+				"DiscoKey":   "discokey:6bfa46a58e1ca58c16dd3ef791cf0e59c5c585146d97e7b4e027e98d5769eb56",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50002",
+					"10.65.0.27:50002",
+					"172.17.0.1:50002",
+					"172.18.0.1:50002",
+					"172.19.0.1:50002"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:03:04.445919611Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         42066960161177,
+				"StableID":   "n23eDc24L111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:42844900b63a91c6cace6dd1ae46369a66c7ba55c1b19d879077b08925695a3c",
+				"DiscoKey":   "discokey:e025acbe1b236d708147009580579b3d44c65b33b6f31b99f1b4f5b59b082b39",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60998",
+					"10.65.0.27:60998",
+					"172.17.0.1:60998",
+					"172.18.0.1:60998",
+					"172.19.0.1:60998"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:03:04.996615062Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6125617552030490,
+				"StableID":   "ndz6tyaJqp11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c37891f42fb341b8e44de97fe5d5e919c3394a947313611b10fa5da6302f1a13",
+				"DiscoKey":   "discokey:d8f354e76db850e10e85c9ea85644c393e07a72d7160b65338a9a9c47d0da117",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38316",
+					"10.65.0.27:38316",
+					"172.17.0.1:38316",
+					"172.18.0.1:38316",
+					"172.19.0.1:38316"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:03:05.54511894Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3315845349970036,
+				"StableID":   "nVuszodktS11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f2d09dad73c4523333e6a42d492d94c88f7cbdf269b0a64b224189743dcff16",
+				"DiscoKey":   "discokey:d71a00863bf303b5cba78cd33f4ec19445bf489a76f7bb1928afac55e4ccdb4b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:42927",
+					"10.65.0.27:42927",
+					"172.17.0.1:42927",
+					"172.18.0.1:42927",
+					"172.19.0.1:42927"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:03:06.08455374Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8687519876479277,
+				"StableID":   "nGzGU7RbqA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06feede0aff475c4a0dd8f7e12d039e770e7d9a6840d4fc6bc00a9985fc4234e",
+				"DiscoKey":   "discokey:9848fed6433809f9ef64e2958c89b4cc36c857da63c5845d431f455c494a835b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55181",
+					"10.65.0.27:55181",
+					"172.17.0.1:55181",
+					"172.18.0.1:55181",
+					"172.19.0.1:55181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:03:06.635927155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5970190537324052,
+				"StableID":   "nPevpLnuco11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:083a1f83474173976cea8e57bab4d67e91921c2b3320b4feb0da6f6e920de83b",
+				"DiscoKey":   "discokey:580248f1a360bca5a61367e909ac8004f35330db13e5e54d15634e51fe82dc3a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43425",
+					"10.65.0.27:43425",
+					"172.17.0.1:43425",
+					"172.18.0.1:43425",
+					"172.19.0.1:43425"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:03:07.169035609Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5830946875491225,
+				"StableID":   "nE5NF36rXn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eba9818c8c61a21c476ba9b48faec003549215dad738fe92e606329e9423d679",
+				"DiscoKey":   "discokey:8bad6cb957eca2d632b9263f95b38b385850ef260600d23163ec36ed41e66d4d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59925",
+					"10.65.0.27:59925",
+					"172.17.0.1:59925",
+					"172.18.0.1:59925",
+					"172.19.0.1:59925"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:03:07.698871338Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         352782644637908,
+				"StableID":   "nm53G71nk311CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f1faef0a6bd6230059c858ec5d7da3e0637a1f539cb9cf6fd47e3ff5cafbe744",
+				"DiscoKey":   "discokey:9058d2eacd888d924c49658912eaf750f1f0a4034652ccc573eba7f4f5519269",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38143",
+					"10.65.0.27:38143",
+					"172.17.0.1:38143",
+					"172.18.0.1:38143",
+					"172.19.0.1:38143"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:03:08.229088305Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1095631849851761,
+				"StableID":   "nzVskfPDZ911CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:778136e5cde9ab4473bac5ae3e8722d09e28cee4ace175b71a1b4968f71dd835",
+				"KeyExpiry":  "2026-11-08T22:03:09Z",
+				"DiscoKey":   "discokey:e2af5b491e9547acd5618c1a88913ffa728c58e7e54f379fafb4203d015e2748",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33885",
+					"10.65.0.27:33885",
+					"172.17.0.1:33885",
+					"172.18.0.1:33885",
+					"172.19.0.1:33885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:03:09.314902662Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1082080724716970,
+				"StableID":   "n73TEhR5T911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bfddb154be3386c7d4265aeca1bd5da166ac968d358d7ed988cd832e58b81171",
+				"KeyExpiry":  "2026-11-08T22:03:09Z",
+				"DiscoKey":   "discokey:0d22c786f7f56f8ff96761be9611813da9a9254d0ccd8f372ccf069d4863cd37",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54017",
+					"10.65.0.27:54017",
+					"172.17.0.1:54017",
+					"172.18.0.1:54017",
+					"172.19.0.1:54017"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:03:09.880456695Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4524054647650237,
+				"StableID":   "nARJKAFxKc11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:09de103cb3e0bbc1ce13c31099e8f461b3a3d9f706985854d8dd518b12215336",
+				"KeyExpiry":  "2026-11-08T22:03:10Z",
+				"DiscoKey":   "discokey:676db65ee4334151bdd191cb6327fbdd30b0eb2198e3b86dfdeda58147d1ac22",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56478",
+					"10.65.0.27:56478",
+					"172.17.0.1:56478",
+					"172.18.0.1:56478",
+					"172.19.0.1:56478"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:03:10.408295152Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{"principals": [
+				{"nodeIP": "100.64.0.17"},
+				{"nodeIP": "100.64.0.18"},
+				{"nodeIP": "100.64.0.19"},
+				{"nodeIP": "fd7a:115c:a1e0::13"},
+				{"nodeIP": "fd7a:115c:a1e0::12"},
+				{"nodeIP": "fd7a:115c:a1e0::11"}
+			], "sshUsers": {"autogroup:self": "autogroup:self", "root": ""}, "action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6468258047135598": {
+				"ID":          6468258047135598,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		},
+		"ssh_rules": [{"principals": [
+			{"nodeIP": "100.64.0.17"},
+			{"nodeIP": "100.64.0.18"},
+			{"nodeIP": "100.64.0.19"},
+			{"nodeIP": "fd7a:115c:a1e0::13"},
+			{"nodeIP": "fd7a:115c:a1e0::12"},
+			{"nodeIP": "fd7a:115c:a1e0::11"}
+		], "sshUsers": {"autogroup:self": "autogroup:self", "root": ""}, "action": {
+			"accept":                    true,
+			"allowAgentForwarding":      true,
+			"allowLocalPortForwarding":  true,
+			"allowRemotePortForwarding": true
+		}}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6125617552030490,
+				"StableID":   "ndz6tyaJqp11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       6125617552030490,
+				"Key":        "nodekey:c37891f42fb341b8e44de97fe5d5e919c3394a947313611b10fa5da6302f1a13",
+				"DiscoKey":   "discokey:d8f354e76db850e10e85c9ea85644c393e07a72d7160b65338a9a9c47d0da117",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38316",
+					"10.65.0.27:38316",
+					"172.17.0.1:38316",
+					"172.18.0.1:38316",
+					"172.19.0.1:38316"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:03:05.54511894Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c37891f42fb341b8e44de97fe5d5e919c3394a947313611b10fa5da6302f1a13",
+			"MachineKey": "mkey:440acf764b8f497ea5bc5563dd6332f1d458a0f2c740d0e35fa8bdddc532027e",
+			"Peers": [{
+				"ID":         4778158905084370,
+				"StableID":   "nZCYQf83Ke11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b12938f529d15fbf7d733b3263f58bcbbebdaa79ce6c0adfcf6e58af4d822f66",
+				"DiscoKey":   "discokey:4af2342ba570ea1376a026f9630159b9cd96e50cbf033e703570d1d84be3546a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45163",
+					"10.65.0.27:45163",
+					"172.17.0.1:45163",
+					"172.18.0.1:45163",
+					"172.19.0.1:45163"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:03:02.856579649Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2172641053472854,
+				"StableID":   "nfs43bbzxH11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4c84d05352d371ad043bc87e8f2d28f563252370377da246f302e100ea61ea6d",
+				"DiscoKey":   "discokey:211d89d048dd9d58210fbc1b622dfcb170bca56500fbc6d0d3ac4cdd5ea98242",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:36639",
+					"10.65.0.27:36639",
+					"172.17.0.1:36639",
+					"172.18.0.1:36639",
+					"172.19.0.1:36639"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:03:03.38550291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4061196893810790,
+				"StableID":   "n3wFbqkKiY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:beda62eec575c69f5fd8f1bed233e197c192a6bef31c9c116235a332a482951b",
+				"DiscoKey":   "discokey:19b29be938553471d08ef741decbb39ca65862c90b6a730e371f1a552dce0f4a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:47517",
+					"10.65.0.27:47517",
+					"172.17.0.1:47517",
+					"172.18.0.1:47517",
+					"172.19.0.1:47517"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:03:03.928154443Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6671352957763120,
+				"StableID":   "nqHMuW8U6u11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36e371fb3c9e4ac8a77a8cccf18c4fa3164c05506b54ef5c3147744658b8ca3f",
+				"DiscoKey":   "discokey:6bfa46a58e1ca58c16dd3ef791cf0e59c5c585146d97e7b4e027e98d5769eb56",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50002",
+					"10.65.0.27:50002",
+					"172.17.0.1:50002",
+					"172.18.0.1:50002",
+					"172.19.0.1:50002"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:03:04.445919611Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         42066960161177,
+				"StableID":   "n23eDc24L111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:42844900b63a91c6cace6dd1ae46369a66c7ba55c1b19d879077b08925695a3c",
+				"DiscoKey":   "discokey:e025acbe1b236d708147009580579b3d44c65b33b6f31b99f1b4f5b59b082b39",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60998",
+					"10.65.0.27:60998",
+					"172.17.0.1:60998",
+					"172.18.0.1:60998",
+					"172.19.0.1:60998"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:03:04.996615062Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3315845349970036,
+				"StableID":   "nVuszodktS11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f2d09dad73c4523333e6a42d492d94c88f7cbdf269b0a64b224189743dcff16",
+				"DiscoKey":   "discokey:d71a00863bf303b5cba78cd33f4ec19445bf489a76f7bb1928afac55e4ccdb4b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:42927",
+					"10.65.0.27:42927",
+					"172.17.0.1:42927",
+					"172.18.0.1:42927",
+					"172.19.0.1:42927"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:03:06.08455374Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8687519876479277,
+				"StableID":   "nGzGU7RbqA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06feede0aff475c4a0dd8f7e12d039e770e7d9a6840d4fc6bc00a9985fc4234e",
+				"DiscoKey":   "discokey:9848fed6433809f9ef64e2958c89b4cc36c857da63c5845d431f455c494a835b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55181",
+					"10.65.0.27:55181",
+					"172.17.0.1:55181",
+					"172.18.0.1:55181",
+					"172.19.0.1:55181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:03:06.635927155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5970190537324052,
+				"StableID":   "nPevpLnuco11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:083a1f83474173976cea8e57bab4d67e91921c2b3320b4feb0da6f6e920de83b",
+				"DiscoKey":   "discokey:580248f1a360bca5a61367e909ac8004f35330db13e5e54d15634e51fe82dc3a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43425",
+					"10.65.0.27:43425",
+					"172.17.0.1:43425",
+					"172.18.0.1:43425",
+					"172.19.0.1:43425"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:03:07.169035609Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5830946875491225,
+				"StableID":   "nE5NF36rXn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eba9818c8c61a21c476ba9b48faec003549215dad738fe92e606329e9423d679",
+				"DiscoKey":   "discokey:8bad6cb957eca2d632b9263f95b38b385850ef260600d23163ec36ed41e66d4d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59925",
+					"10.65.0.27:59925",
+					"172.17.0.1:59925",
+					"172.18.0.1:59925",
+					"172.19.0.1:59925"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:03:07.698871338Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         352782644637908,
+				"StableID":   "nm53G71nk311CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f1faef0a6bd6230059c858ec5d7da3e0637a1f539cb9cf6fd47e3ff5cafbe744",
+				"DiscoKey":   "discokey:9058d2eacd888d924c49658912eaf750f1f0a4034652ccc573eba7f4f5519269",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38143",
+					"10.65.0.27:38143",
+					"172.17.0.1:38143",
+					"172.18.0.1:38143",
+					"172.19.0.1:38143"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:03:08.229088305Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6468258047135598,
+				"StableID":   "n9Ak7uAVWs11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2567ad955d8d9480c8eb2bdb75126c4c8c07cac2fa48cd297107ef8f5dfb5202",
+				"DiscoKey":   "discokey:8d87bdd3eb8f636dc5b0ed189a9fcb22e5dbd680e94d7014df58c492aef68851",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:53616",
+					"10.65.0.27:53616",
+					"172.17.0.1:53616",
+					"172.18.0.1:53616",
+					"172.19.0.1:53616"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:03:08.777000304Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1095631849851761,
+				"StableID":   "nzVskfPDZ911CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:778136e5cde9ab4473bac5ae3e8722d09e28cee4ace175b71a1b4968f71dd835",
+				"KeyExpiry":  "2026-11-08T22:03:09Z",
+				"DiscoKey":   "discokey:e2af5b491e9547acd5618c1a88913ffa728c58e7e54f379fafb4203d015e2748",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33885",
+					"10.65.0.27:33885",
+					"172.17.0.1:33885",
+					"172.18.0.1:33885",
+					"172.19.0.1:33885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:03:09.314902662Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1082080724716970,
+				"StableID":   "n73TEhR5T911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bfddb154be3386c7d4265aeca1bd5da166ac968d358d7ed988cd832e58b81171",
+				"KeyExpiry":  "2026-11-08T22:03:09Z",
+				"DiscoKey":   "discokey:0d22c786f7f56f8ff96761be9611813da9a9254d0ccd8f372ccf069d4863cd37",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54017",
+					"10.65.0.27:54017",
+					"172.17.0.1:54017",
+					"172.18.0.1:54017",
+					"172.19.0.1:54017"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:03:09.880456695Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4524054647650237,
+				"StableID":   "nARJKAFxKc11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:09de103cb3e0bbc1ce13c31099e8f461b3a3d9f706985854d8dd518b12215336",
+				"KeyExpiry":  "2026-11-08T22:03:10Z",
+				"DiscoKey":   "discokey:676db65ee4334151bdd191cb6327fbdd30b0eb2198e3b86dfdeda58147d1ac22",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56478",
+					"10.65.0.27:56478",
+					"172.17.0.1:56478",
+					"172.18.0.1:56478",
+					"172.19.0.1:56478"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:03:10.408295152Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6125617552030490": {
+				"ID":          6125617552030490,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4524054647650237,
+				"StableID":   "nARJKAFxKc11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:09de103cb3e0bbc1ce13c31099e8f461b3a3d9f706985854d8dd518b12215336",
+				"KeyExpiry":  "2026-11-08T22:03:10Z",
+				"DiscoKey":   "discokey:676db65ee4334151bdd191cb6327fbdd30b0eb2198e3b86dfdeda58147d1ac22",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56478",
+					"10.65.0.27:56478",
+					"172.17.0.1:56478",
+					"172.18.0.1:56478",
+					"172.19.0.1:56478"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:03:10.408295152Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:09de103cb3e0bbc1ce13c31099e8f461b3a3d9f706985854d8dd518b12215336",
+			"MachineKey": "mkey:88f380a66e00e79e18cfa86328426a0d2938d04cbdea5582ff7478af78b2c058",
+			"Peers": [{
+				"ID":         4778158905084370,
+				"StableID":   "nZCYQf83Ke11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b12938f529d15fbf7d733b3263f58bcbbebdaa79ce6c0adfcf6e58af4d822f66",
+				"DiscoKey":   "discokey:4af2342ba570ea1376a026f9630159b9cd96e50cbf033e703570d1d84be3546a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45163",
+					"10.65.0.27:45163",
+					"172.17.0.1:45163",
+					"172.18.0.1:45163",
+					"172.19.0.1:45163"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:03:02.856579649Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2172641053472854,
+				"StableID":   "nfs43bbzxH11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4c84d05352d371ad043bc87e8f2d28f563252370377da246f302e100ea61ea6d",
+				"DiscoKey":   "discokey:211d89d048dd9d58210fbc1b622dfcb170bca56500fbc6d0d3ac4cdd5ea98242",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:36639",
+					"10.65.0.27:36639",
+					"172.17.0.1:36639",
+					"172.18.0.1:36639",
+					"172.19.0.1:36639"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:03:03.38550291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4061196893810790,
+				"StableID":   "n3wFbqkKiY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:beda62eec575c69f5fd8f1bed233e197c192a6bef31c9c116235a332a482951b",
+				"DiscoKey":   "discokey:19b29be938553471d08ef741decbb39ca65862c90b6a730e371f1a552dce0f4a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:47517",
+					"10.65.0.27:47517",
+					"172.17.0.1:47517",
+					"172.18.0.1:47517",
+					"172.19.0.1:47517"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:03:03.928154443Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6671352957763120,
+				"StableID":   "nqHMuW8U6u11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36e371fb3c9e4ac8a77a8cccf18c4fa3164c05506b54ef5c3147744658b8ca3f",
+				"DiscoKey":   "discokey:6bfa46a58e1ca58c16dd3ef791cf0e59c5c585146d97e7b4e027e98d5769eb56",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50002",
+					"10.65.0.27:50002",
+					"172.17.0.1:50002",
+					"172.18.0.1:50002",
+					"172.19.0.1:50002"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:03:04.445919611Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         42066960161177,
+				"StableID":   "n23eDc24L111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:42844900b63a91c6cace6dd1ae46369a66c7ba55c1b19d879077b08925695a3c",
+				"DiscoKey":   "discokey:e025acbe1b236d708147009580579b3d44c65b33b6f31b99f1b4f5b59b082b39",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60998",
+					"10.65.0.27:60998",
+					"172.17.0.1:60998",
+					"172.18.0.1:60998",
+					"172.19.0.1:60998"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:03:04.996615062Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6125617552030490,
+				"StableID":   "ndz6tyaJqp11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c37891f42fb341b8e44de97fe5d5e919c3394a947313611b10fa5da6302f1a13",
+				"DiscoKey":   "discokey:d8f354e76db850e10e85c9ea85644c393e07a72d7160b65338a9a9c47d0da117",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38316",
+					"10.65.0.27:38316",
+					"172.17.0.1:38316",
+					"172.18.0.1:38316",
+					"172.19.0.1:38316"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:03:05.54511894Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3315845349970036,
+				"StableID":   "nVuszodktS11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f2d09dad73c4523333e6a42d492d94c88f7cbdf269b0a64b224189743dcff16",
+				"DiscoKey":   "discokey:d71a00863bf303b5cba78cd33f4ec19445bf489a76f7bb1928afac55e4ccdb4b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:42927",
+					"10.65.0.27:42927",
+					"172.17.0.1:42927",
+					"172.18.0.1:42927",
+					"172.19.0.1:42927"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:03:06.08455374Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8687519876479277,
+				"StableID":   "nGzGU7RbqA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06feede0aff475c4a0dd8f7e12d039e770e7d9a6840d4fc6bc00a9985fc4234e",
+				"DiscoKey":   "discokey:9848fed6433809f9ef64e2958c89b4cc36c857da63c5845d431f455c494a835b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55181",
+					"10.65.0.27:55181",
+					"172.17.0.1:55181",
+					"172.18.0.1:55181",
+					"172.19.0.1:55181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:03:06.635927155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5970190537324052,
+				"StableID":   "nPevpLnuco11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:083a1f83474173976cea8e57bab4d67e91921c2b3320b4feb0da6f6e920de83b",
+				"DiscoKey":   "discokey:580248f1a360bca5a61367e909ac8004f35330db13e5e54d15634e51fe82dc3a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43425",
+					"10.65.0.27:43425",
+					"172.17.0.1:43425",
+					"172.18.0.1:43425",
+					"172.19.0.1:43425"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:03:07.169035609Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5830946875491225,
+				"StableID":   "nE5NF36rXn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eba9818c8c61a21c476ba9b48faec003549215dad738fe92e606329e9423d679",
+				"DiscoKey":   "discokey:8bad6cb957eca2d632b9263f95b38b385850ef260600d23163ec36ed41e66d4d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59925",
+					"10.65.0.27:59925",
+					"172.17.0.1:59925",
+					"172.18.0.1:59925",
+					"172.19.0.1:59925"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:03:07.698871338Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         352782644637908,
+				"StableID":   "nm53G71nk311CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f1faef0a6bd6230059c858ec5d7da3e0637a1f539cb9cf6fd47e3ff5cafbe744",
+				"DiscoKey":   "discokey:9058d2eacd888d924c49658912eaf750f1f0a4034652ccc573eba7f4f5519269",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38143",
+					"10.65.0.27:38143",
+					"172.17.0.1:38143",
+					"172.18.0.1:38143",
+					"172.19.0.1:38143"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:03:08.229088305Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6468258047135598,
+				"StableID":   "n9Ak7uAVWs11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2567ad955d8d9480c8eb2bdb75126c4c8c07cac2fa48cd297107ef8f5dfb5202",
+				"DiscoKey":   "discokey:8d87bdd3eb8f636dc5b0ed189a9fcb22e5dbd680e94d7014df58c492aef68851",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:53616",
+					"10.65.0.27:53616",
+					"172.17.0.1:53616",
+					"172.18.0.1:53616",
+					"172.19.0.1:53616"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:03:08.777000304Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1095631849851761,
+				"StableID":   "nzVskfPDZ911CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:778136e5cde9ab4473bac5ae3e8722d09e28cee4ace175b71a1b4968f71dd835",
+				"KeyExpiry":  "2026-11-08T22:03:09Z",
+				"DiscoKey":   "discokey:e2af5b491e9547acd5618c1a88913ffa728c58e7e54f379fafb4203d015e2748",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33885",
+					"10.65.0.27:33885",
+					"172.17.0.1:33885",
+					"172.18.0.1:33885",
+					"172.19.0.1:33885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:03:09.314902662Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1082080724716970,
+				"StableID":   "n73TEhR5T911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bfddb154be3386c7d4265aeca1bd5da166ac968d358d7ed988cd832e58b81171",
+				"KeyExpiry":  "2026-11-08T22:03:09Z",
+				"DiscoKey":   "discokey:0d22c786f7f56f8ff96761be9611813da9a9254d0ccd8f372ccf069d4863cd37",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54017",
+					"10.65.0.27:54017",
+					"172.17.0.1:54017",
+					"172.18.0.1:54017",
+					"172.19.0.1:54017"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:03:09.880456695Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4061196893810790,
+				"StableID":   "n3wFbqkKiY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       4061196893810790,
+				"Key":        "nodekey:beda62eec575c69f5fd8f1bed233e197c192a6bef31c9c116235a332a482951b",
+				"DiscoKey":   "discokey:19b29be938553471d08ef741decbb39ca65862c90b6a730e371f1a552dce0f4a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:47517",
+					"10.65.0.27:47517",
+					"172.17.0.1:47517",
+					"172.18.0.1:47517",
+					"172.19.0.1:47517"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:03:03.928154443Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:beda62eec575c69f5fd8f1bed233e197c192a6bef31c9c116235a332a482951b",
+			"MachineKey": "mkey:d1ef2223d7569206a0e7b8d38b6f1978aa4ca3f4268ef1b58deb2f0b924b035f",
+			"Peers": [{
+				"ID":         4778158905084370,
+				"StableID":   "nZCYQf83Ke11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b12938f529d15fbf7d733b3263f58bcbbebdaa79ce6c0adfcf6e58af4d822f66",
+				"DiscoKey":   "discokey:4af2342ba570ea1376a026f9630159b9cd96e50cbf033e703570d1d84be3546a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45163",
+					"10.65.0.27:45163",
+					"172.17.0.1:45163",
+					"172.18.0.1:45163",
+					"172.19.0.1:45163"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:03:02.856579649Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2172641053472854,
+				"StableID":   "nfs43bbzxH11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4c84d05352d371ad043bc87e8f2d28f563252370377da246f302e100ea61ea6d",
+				"DiscoKey":   "discokey:211d89d048dd9d58210fbc1b622dfcb170bca56500fbc6d0d3ac4cdd5ea98242",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:36639",
+					"10.65.0.27:36639",
+					"172.17.0.1:36639",
+					"172.18.0.1:36639",
+					"172.19.0.1:36639"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:03:03.38550291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6671352957763120,
+				"StableID":   "nqHMuW8U6u11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36e371fb3c9e4ac8a77a8cccf18c4fa3164c05506b54ef5c3147744658b8ca3f",
+				"DiscoKey":   "discokey:6bfa46a58e1ca58c16dd3ef791cf0e59c5c585146d97e7b4e027e98d5769eb56",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50002",
+					"10.65.0.27:50002",
+					"172.17.0.1:50002",
+					"172.18.0.1:50002",
+					"172.19.0.1:50002"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:03:04.445919611Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         42066960161177,
+				"StableID":   "n23eDc24L111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:42844900b63a91c6cace6dd1ae46369a66c7ba55c1b19d879077b08925695a3c",
+				"DiscoKey":   "discokey:e025acbe1b236d708147009580579b3d44c65b33b6f31b99f1b4f5b59b082b39",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60998",
+					"10.65.0.27:60998",
+					"172.17.0.1:60998",
+					"172.18.0.1:60998",
+					"172.19.0.1:60998"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:03:04.996615062Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6125617552030490,
+				"StableID":   "ndz6tyaJqp11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c37891f42fb341b8e44de97fe5d5e919c3394a947313611b10fa5da6302f1a13",
+				"DiscoKey":   "discokey:d8f354e76db850e10e85c9ea85644c393e07a72d7160b65338a9a9c47d0da117",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38316",
+					"10.65.0.27:38316",
+					"172.17.0.1:38316",
+					"172.18.0.1:38316",
+					"172.19.0.1:38316"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:03:05.54511894Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3315845349970036,
+				"StableID":   "nVuszodktS11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f2d09dad73c4523333e6a42d492d94c88f7cbdf269b0a64b224189743dcff16",
+				"DiscoKey":   "discokey:d71a00863bf303b5cba78cd33f4ec19445bf489a76f7bb1928afac55e4ccdb4b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:42927",
+					"10.65.0.27:42927",
+					"172.17.0.1:42927",
+					"172.18.0.1:42927",
+					"172.19.0.1:42927"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:03:06.08455374Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8687519876479277,
+				"StableID":   "nGzGU7RbqA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06feede0aff475c4a0dd8f7e12d039e770e7d9a6840d4fc6bc00a9985fc4234e",
+				"DiscoKey":   "discokey:9848fed6433809f9ef64e2958c89b4cc36c857da63c5845d431f455c494a835b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55181",
+					"10.65.0.27:55181",
+					"172.17.0.1:55181",
+					"172.18.0.1:55181",
+					"172.19.0.1:55181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:03:06.635927155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5970190537324052,
+				"StableID":   "nPevpLnuco11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:083a1f83474173976cea8e57bab4d67e91921c2b3320b4feb0da6f6e920de83b",
+				"DiscoKey":   "discokey:580248f1a360bca5a61367e909ac8004f35330db13e5e54d15634e51fe82dc3a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43425",
+					"10.65.0.27:43425",
+					"172.17.0.1:43425",
+					"172.18.0.1:43425",
+					"172.19.0.1:43425"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:03:07.169035609Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5830946875491225,
+				"StableID":   "nE5NF36rXn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eba9818c8c61a21c476ba9b48faec003549215dad738fe92e606329e9423d679",
+				"DiscoKey":   "discokey:8bad6cb957eca2d632b9263f95b38b385850ef260600d23163ec36ed41e66d4d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59925",
+					"10.65.0.27:59925",
+					"172.17.0.1:59925",
+					"172.18.0.1:59925",
+					"172.19.0.1:59925"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:03:07.698871338Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         352782644637908,
+				"StableID":   "nm53G71nk311CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f1faef0a6bd6230059c858ec5d7da3e0637a1f539cb9cf6fd47e3ff5cafbe744",
+				"DiscoKey":   "discokey:9058d2eacd888d924c49658912eaf750f1f0a4034652ccc573eba7f4f5519269",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38143",
+					"10.65.0.27:38143",
+					"172.17.0.1:38143",
+					"172.18.0.1:38143",
+					"172.19.0.1:38143"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:03:08.229088305Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6468258047135598,
+				"StableID":   "n9Ak7uAVWs11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2567ad955d8d9480c8eb2bdb75126c4c8c07cac2fa48cd297107ef8f5dfb5202",
+				"DiscoKey":   "discokey:8d87bdd3eb8f636dc5b0ed189a9fcb22e5dbd680e94d7014df58c492aef68851",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:53616",
+					"10.65.0.27:53616",
+					"172.17.0.1:53616",
+					"172.18.0.1:53616",
+					"172.19.0.1:53616"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:03:08.777000304Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1095631849851761,
+				"StableID":   "nzVskfPDZ911CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:778136e5cde9ab4473bac5ae3e8722d09e28cee4ace175b71a1b4968f71dd835",
+				"KeyExpiry":  "2026-11-08T22:03:09Z",
+				"DiscoKey":   "discokey:e2af5b491e9547acd5618c1a88913ffa728c58e7e54f379fafb4203d015e2748",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33885",
+					"10.65.0.27:33885",
+					"172.17.0.1:33885",
+					"172.18.0.1:33885",
+					"172.19.0.1:33885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:03:09.314902662Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1082080724716970,
+				"StableID":   "n73TEhR5T911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bfddb154be3386c7d4265aeca1bd5da166ac968d358d7ed988cd832e58b81171",
+				"KeyExpiry":  "2026-11-08T22:03:09Z",
+				"DiscoKey":   "discokey:0d22c786f7f56f8ff96761be9611813da9a9254d0ccd8f372ccf069d4863cd37",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54017",
+					"10.65.0.27:54017",
+					"172.17.0.1:54017",
+					"172.18.0.1:54017",
+					"172.19.0.1:54017"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:03:09.880456695Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4524054647650237,
+				"StableID":   "nARJKAFxKc11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:09de103cb3e0bbc1ce13c31099e8f461b3a3d9f706985854d8dd518b12215336",
+				"KeyExpiry":  "2026-11-08T22:03:10Z",
+				"DiscoKey":   "discokey:676db65ee4334151bdd191cb6327fbdd30b0eb2198e3b86dfdeda58147d1ac22",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56478",
+					"10.65.0.27:56478",
+					"172.17.0.1:56478",
+					"172.18.0.1:56478",
+					"172.19.0.1:56478"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:03:10.408295152Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4061196893810790": {
+				"ID":          4061196893810790,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8687519876479277,
+				"StableID":   "nGzGU7RbqA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       8687519876479277,
+				"Key":        "nodekey:06feede0aff475c4a0dd8f7e12d039e770e7d9a6840d4fc6bc00a9985fc4234e",
+				"DiscoKey":   "discokey:9848fed6433809f9ef64e2958c89b4cc36c857da63c5845d431f455c494a835b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55181",
+					"10.65.0.27:55181",
+					"172.17.0.1:55181",
+					"172.18.0.1:55181",
+					"172.19.0.1:55181"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:03:06.635927155Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:06feede0aff475c4a0dd8f7e12d039e770e7d9a6840d4fc6bc00a9985fc4234e",
+			"MachineKey": "mkey:613aba5ba007a0774931b670940609a1728f1ae09abbf7122c207ae01e002b2e",
+			"Peers": [{
+				"ID":         4778158905084370,
+				"StableID":   "nZCYQf83Ke11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b12938f529d15fbf7d733b3263f58bcbbebdaa79ce6c0adfcf6e58af4d822f66",
+				"DiscoKey":   "discokey:4af2342ba570ea1376a026f9630159b9cd96e50cbf033e703570d1d84be3546a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45163",
+					"10.65.0.27:45163",
+					"172.17.0.1:45163",
+					"172.18.0.1:45163",
+					"172.19.0.1:45163"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:03:02.856579649Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2172641053472854,
+				"StableID":   "nfs43bbzxH11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4c84d05352d371ad043bc87e8f2d28f563252370377da246f302e100ea61ea6d",
+				"DiscoKey":   "discokey:211d89d048dd9d58210fbc1b622dfcb170bca56500fbc6d0d3ac4cdd5ea98242",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:36639",
+					"10.65.0.27:36639",
+					"172.17.0.1:36639",
+					"172.18.0.1:36639",
+					"172.19.0.1:36639"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:03:03.38550291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4061196893810790,
+				"StableID":   "n3wFbqkKiY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:beda62eec575c69f5fd8f1bed233e197c192a6bef31c9c116235a332a482951b",
+				"DiscoKey":   "discokey:19b29be938553471d08ef741decbb39ca65862c90b6a730e371f1a552dce0f4a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:47517",
+					"10.65.0.27:47517",
+					"172.17.0.1:47517",
+					"172.18.0.1:47517",
+					"172.19.0.1:47517"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:03:03.928154443Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6671352957763120,
+				"StableID":   "nqHMuW8U6u11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36e371fb3c9e4ac8a77a8cccf18c4fa3164c05506b54ef5c3147744658b8ca3f",
+				"DiscoKey":   "discokey:6bfa46a58e1ca58c16dd3ef791cf0e59c5c585146d97e7b4e027e98d5769eb56",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50002",
+					"10.65.0.27:50002",
+					"172.17.0.1:50002",
+					"172.18.0.1:50002",
+					"172.19.0.1:50002"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:03:04.445919611Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         42066960161177,
+				"StableID":   "n23eDc24L111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:42844900b63a91c6cace6dd1ae46369a66c7ba55c1b19d879077b08925695a3c",
+				"DiscoKey":   "discokey:e025acbe1b236d708147009580579b3d44c65b33b6f31b99f1b4f5b59b082b39",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60998",
+					"10.65.0.27:60998",
+					"172.17.0.1:60998",
+					"172.18.0.1:60998",
+					"172.19.0.1:60998"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:03:04.996615062Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6125617552030490,
+				"StableID":   "ndz6tyaJqp11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c37891f42fb341b8e44de97fe5d5e919c3394a947313611b10fa5da6302f1a13",
+				"DiscoKey":   "discokey:d8f354e76db850e10e85c9ea85644c393e07a72d7160b65338a9a9c47d0da117",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38316",
+					"10.65.0.27:38316",
+					"172.17.0.1:38316",
+					"172.18.0.1:38316",
+					"172.19.0.1:38316"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:03:05.54511894Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3315845349970036,
+				"StableID":   "nVuszodktS11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f2d09dad73c4523333e6a42d492d94c88f7cbdf269b0a64b224189743dcff16",
+				"DiscoKey":   "discokey:d71a00863bf303b5cba78cd33f4ec19445bf489a76f7bb1928afac55e4ccdb4b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:42927",
+					"10.65.0.27:42927",
+					"172.17.0.1:42927",
+					"172.18.0.1:42927",
+					"172.19.0.1:42927"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:03:06.08455374Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5970190537324052,
+				"StableID":   "nPevpLnuco11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:083a1f83474173976cea8e57bab4d67e91921c2b3320b4feb0da6f6e920de83b",
+				"DiscoKey":   "discokey:580248f1a360bca5a61367e909ac8004f35330db13e5e54d15634e51fe82dc3a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43425",
+					"10.65.0.27:43425",
+					"172.17.0.1:43425",
+					"172.18.0.1:43425",
+					"172.19.0.1:43425"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:03:07.169035609Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5830946875491225,
+				"StableID":   "nE5NF36rXn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eba9818c8c61a21c476ba9b48faec003549215dad738fe92e606329e9423d679",
+				"DiscoKey":   "discokey:8bad6cb957eca2d632b9263f95b38b385850ef260600d23163ec36ed41e66d4d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59925",
+					"10.65.0.27:59925",
+					"172.17.0.1:59925",
+					"172.18.0.1:59925",
+					"172.19.0.1:59925"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:03:07.698871338Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         352782644637908,
+				"StableID":   "nm53G71nk311CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f1faef0a6bd6230059c858ec5d7da3e0637a1f539cb9cf6fd47e3ff5cafbe744",
+				"DiscoKey":   "discokey:9058d2eacd888d924c49658912eaf750f1f0a4034652ccc573eba7f4f5519269",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38143",
+					"10.65.0.27:38143",
+					"172.17.0.1:38143",
+					"172.18.0.1:38143",
+					"172.19.0.1:38143"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:03:08.229088305Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6468258047135598,
+				"StableID":   "n9Ak7uAVWs11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2567ad955d8d9480c8eb2bdb75126c4c8c07cac2fa48cd297107ef8f5dfb5202",
+				"DiscoKey":   "discokey:8d87bdd3eb8f636dc5b0ed189a9fcb22e5dbd680e94d7014df58c492aef68851",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:53616",
+					"10.65.0.27:53616",
+					"172.17.0.1:53616",
+					"172.18.0.1:53616",
+					"172.19.0.1:53616"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:03:08.777000304Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1095631849851761,
+				"StableID":   "nzVskfPDZ911CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:778136e5cde9ab4473bac5ae3e8722d09e28cee4ace175b71a1b4968f71dd835",
+				"KeyExpiry":  "2026-11-08T22:03:09Z",
+				"DiscoKey":   "discokey:e2af5b491e9547acd5618c1a88913ffa728c58e7e54f379fafb4203d015e2748",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33885",
+					"10.65.0.27:33885",
+					"172.17.0.1:33885",
+					"172.18.0.1:33885",
+					"172.19.0.1:33885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:03:09.314902662Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1082080724716970,
+				"StableID":   "n73TEhR5T911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bfddb154be3386c7d4265aeca1bd5da166ac968d358d7ed988cd832e58b81171",
+				"KeyExpiry":  "2026-11-08T22:03:09Z",
+				"DiscoKey":   "discokey:0d22c786f7f56f8ff96761be9611813da9a9254d0ccd8f372ccf069d4863cd37",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54017",
+					"10.65.0.27:54017",
+					"172.17.0.1:54017",
+					"172.18.0.1:54017",
+					"172.19.0.1:54017"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:03:09.880456695Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4524054647650237,
+				"StableID":   "nARJKAFxKc11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:09de103cb3e0bbc1ce13c31099e8f461b3a3d9f706985854d8dd518b12215336",
+				"KeyExpiry":  "2026-11-08T22:03:10Z",
+				"DiscoKey":   "discokey:676db65ee4334151bdd191cb6327fbdd30b0eb2198e3b86dfdeda58147d1ac22",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56478",
+					"10.65.0.27:56478",
+					"172.17.0.1:56478",
+					"172.18.0.1:56478",
+					"172.19.0.1:56478"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:03:10.408295152Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8687519876479277": {
+				"ID":          8687519876479277,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1095631849851761,
+				"StableID":   "nzVskfPDZ911CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:778136e5cde9ab4473bac5ae3e8722d09e28cee4ace175b71a1b4968f71dd835",
+				"KeyExpiry":  "2026-11-08T22:03:09Z",
+				"DiscoKey":   "discokey:e2af5b491e9547acd5618c1a88913ffa728c58e7e54f379fafb4203d015e2748",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33885",
+					"10.65.0.27:33885",
+					"172.17.0.1:33885",
+					"172.18.0.1:33885",
+					"172.19.0.1:33885"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:03:09.314902662Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:778136e5cde9ab4473bac5ae3e8722d09e28cee4ace175b71a1b4968f71dd835",
+			"MachineKey": "mkey:af48240dea7b863fa2e5717f72d00c40292c67e17d047807bd26426aeef61b16",
+			"Peers": [{
+				"ID":         4778158905084370,
+				"StableID":   "nZCYQf83Ke11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b12938f529d15fbf7d733b3263f58bcbbebdaa79ce6c0adfcf6e58af4d822f66",
+				"DiscoKey":   "discokey:4af2342ba570ea1376a026f9630159b9cd96e50cbf033e703570d1d84be3546a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45163",
+					"10.65.0.27:45163",
+					"172.17.0.1:45163",
+					"172.18.0.1:45163",
+					"172.19.0.1:45163"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:03:02.856579649Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2172641053472854,
+				"StableID":   "nfs43bbzxH11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4c84d05352d371ad043bc87e8f2d28f563252370377da246f302e100ea61ea6d",
+				"DiscoKey":   "discokey:211d89d048dd9d58210fbc1b622dfcb170bca56500fbc6d0d3ac4cdd5ea98242",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:36639",
+					"10.65.0.27:36639",
+					"172.17.0.1:36639",
+					"172.18.0.1:36639",
+					"172.19.0.1:36639"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:03:03.38550291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4061196893810790,
+				"StableID":   "n3wFbqkKiY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:beda62eec575c69f5fd8f1bed233e197c192a6bef31c9c116235a332a482951b",
+				"DiscoKey":   "discokey:19b29be938553471d08ef741decbb39ca65862c90b6a730e371f1a552dce0f4a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:47517",
+					"10.65.0.27:47517",
+					"172.17.0.1:47517",
+					"172.18.0.1:47517",
+					"172.19.0.1:47517"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:03:03.928154443Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6671352957763120,
+				"StableID":   "nqHMuW8U6u11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36e371fb3c9e4ac8a77a8cccf18c4fa3164c05506b54ef5c3147744658b8ca3f",
+				"DiscoKey":   "discokey:6bfa46a58e1ca58c16dd3ef791cf0e59c5c585146d97e7b4e027e98d5769eb56",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50002",
+					"10.65.0.27:50002",
+					"172.17.0.1:50002",
+					"172.18.0.1:50002",
+					"172.19.0.1:50002"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:03:04.445919611Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         42066960161177,
+				"StableID":   "n23eDc24L111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:42844900b63a91c6cace6dd1ae46369a66c7ba55c1b19d879077b08925695a3c",
+				"DiscoKey":   "discokey:e025acbe1b236d708147009580579b3d44c65b33b6f31b99f1b4f5b59b082b39",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60998",
+					"10.65.0.27:60998",
+					"172.17.0.1:60998",
+					"172.18.0.1:60998",
+					"172.19.0.1:60998"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:03:04.996615062Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6125617552030490,
+				"StableID":   "ndz6tyaJqp11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c37891f42fb341b8e44de97fe5d5e919c3394a947313611b10fa5da6302f1a13",
+				"DiscoKey":   "discokey:d8f354e76db850e10e85c9ea85644c393e07a72d7160b65338a9a9c47d0da117",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38316",
+					"10.65.0.27:38316",
+					"172.17.0.1:38316",
+					"172.18.0.1:38316",
+					"172.19.0.1:38316"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:03:05.54511894Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3315845349970036,
+				"StableID":   "nVuszodktS11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f2d09dad73c4523333e6a42d492d94c88f7cbdf269b0a64b224189743dcff16",
+				"DiscoKey":   "discokey:d71a00863bf303b5cba78cd33f4ec19445bf489a76f7bb1928afac55e4ccdb4b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:42927",
+					"10.65.0.27:42927",
+					"172.17.0.1:42927",
+					"172.18.0.1:42927",
+					"172.19.0.1:42927"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:03:06.08455374Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8687519876479277,
+				"StableID":   "nGzGU7RbqA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06feede0aff475c4a0dd8f7e12d039e770e7d9a6840d4fc6bc00a9985fc4234e",
+				"DiscoKey":   "discokey:9848fed6433809f9ef64e2958c89b4cc36c857da63c5845d431f455c494a835b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55181",
+					"10.65.0.27:55181",
+					"172.17.0.1:55181",
+					"172.18.0.1:55181",
+					"172.19.0.1:55181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:03:06.635927155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5970190537324052,
+				"StableID":   "nPevpLnuco11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:083a1f83474173976cea8e57bab4d67e91921c2b3320b4feb0da6f6e920de83b",
+				"DiscoKey":   "discokey:580248f1a360bca5a61367e909ac8004f35330db13e5e54d15634e51fe82dc3a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43425",
+					"10.65.0.27:43425",
+					"172.17.0.1:43425",
+					"172.18.0.1:43425",
+					"172.19.0.1:43425"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:03:07.169035609Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5830946875491225,
+				"StableID":   "nE5NF36rXn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eba9818c8c61a21c476ba9b48faec003549215dad738fe92e606329e9423d679",
+				"DiscoKey":   "discokey:8bad6cb957eca2d632b9263f95b38b385850ef260600d23163ec36ed41e66d4d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59925",
+					"10.65.0.27:59925",
+					"172.17.0.1:59925",
+					"172.18.0.1:59925",
+					"172.19.0.1:59925"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:03:07.698871338Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         352782644637908,
+				"StableID":   "nm53G71nk311CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f1faef0a6bd6230059c858ec5d7da3e0637a1f539cb9cf6fd47e3ff5cafbe744",
+				"DiscoKey":   "discokey:9058d2eacd888d924c49658912eaf750f1f0a4034652ccc573eba7f4f5519269",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38143",
+					"10.65.0.27:38143",
+					"172.17.0.1:38143",
+					"172.18.0.1:38143",
+					"172.19.0.1:38143"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:03:08.229088305Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6468258047135598,
+				"StableID":   "n9Ak7uAVWs11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2567ad955d8d9480c8eb2bdb75126c4c8c07cac2fa48cd297107ef8f5dfb5202",
+				"DiscoKey":   "discokey:8d87bdd3eb8f636dc5b0ed189a9fcb22e5dbd680e94d7014df58c492aef68851",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:53616",
+					"10.65.0.27:53616",
+					"172.17.0.1:53616",
+					"172.18.0.1:53616",
+					"172.19.0.1:53616"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:03:08.777000304Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1082080724716970,
+				"StableID":   "n73TEhR5T911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bfddb154be3386c7d4265aeca1bd5da166ac968d358d7ed988cd832e58b81171",
+				"KeyExpiry":  "2026-11-08T22:03:09Z",
+				"DiscoKey":   "discokey:0d22c786f7f56f8ff96761be9611813da9a9254d0ccd8f372ccf069d4863cd37",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54017",
+					"10.65.0.27:54017",
+					"172.17.0.1:54017",
+					"172.18.0.1:54017",
+					"172.19.0.1:54017"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:03:09.880456695Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4524054647650237,
+				"StableID":   "nARJKAFxKc11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:09de103cb3e0bbc1ce13c31099e8f461b3a3d9f706985854d8dd518b12215336",
+				"KeyExpiry":  "2026-11-08T22:03:10Z",
+				"DiscoKey":   "discokey:676db65ee4334151bdd191cb6327fbdd30b0eb2198e3b86dfdeda58147d1ac22",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56478",
+					"10.65.0.27:56478",
+					"172.17.0.1:56478",
+					"172.18.0.1:56478",
+					"172.19.0.1:56478"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:03:10.408295152Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         352782644637908,
+				"StableID":   "nm53G71nk311CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       352782644637908,
+				"Key":        "nodekey:f1faef0a6bd6230059c858ec5d7da3e0637a1f539cb9cf6fd47e3ff5cafbe744",
+				"DiscoKey":   "discokey:9058d2eacd888d924c49658912eaf750f1f0a4034652ccc573eba7f4f5519269",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38143",
+					"10.65.0.27:38143",
+					"172.17.0.1:38143",
+					"172.18.0.1:38143",
+					"172.19.0.1:38143"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:03:08.229088305Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f1faef0a6bd6230059c858ec5d7da3e0637a1f539cb9cf6fd47e3ff5cafbe744",
+			"MachineKey": "mkey:5022cca9c128d34a87593caa40bd2ea43467cb55291dbc451287b492f0053745",
+			"Peers": [{
+				"ID":         4778158905084370,
+				"StableID":   "nZCYQf83Ke11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b12938f529d15fbf7d733b3263f58bcbbebdaa79ce6c0adfcf6e58af4d822f66",
+				"DiscoKey":   "discokey:4af2342ba570ea1376a026f9630159b9cd96e50cbf033e703570d1d84be3546a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45163",
+					"10.65.0.27:45163",
+					"172.17.0.1:45163",
+					"172.18.0.1:45163",
+					"172.19.0.1:45163"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:03:02.856579649Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2172641053472854,
+				"StableID":   "nfs43bbzxH11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4c84d05352d371ad043bc87e8f2d28f563252370377da246f302e100ea61ea6d",
+				"DiscoKey":   "discokey:211d89d048dd9d58210fbc1b622dfcb170bca56500fbc6d0d3ac4cdd5ea98242",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:36639",
+					"10.65.0.27:36639",
+					"172.17.0.1:36639",
+					"172.18.0.1:36639",
+					"172.19.0.1:36639"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:03:03.38550291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4061196893810790,
+				"StableID":   "n3wFbqkKiY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:beda62eec575c69f5fd8f1bed233e197c192a6bef31c9c116235a332a482951b",
+				"DiscoKey":   "discokey:19b29be938553471d08ef741decbb39ca65862c90b6a730e371f1a552dce0f4a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:47517",
+					"10.65.0.27:47517",
+					"172.17.0.1:47517",
+					"172.18.0.1:47517",
+					"172.19.0.1:47517"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:03:03.928154443Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6671352957763120,
+				"StableID":   "nqHMuW8U6u11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36e371fb3c9e4ac8a77a8cccf18c4fa3164c05506b54ef5c3147744658b8ca3f",
+				"DiscoKey":   "discokey:6bfa46a58e1ca58c16dd3ef791cf0e59c5c585146d97e7b4e027e98d5769eb56",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50002",
+					"10.65.0.27:50002",
+					"172.17.0.1:50002",
+					"172.18.0.1:50002",
+					"172.19.0.1:50002"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:03:04.445919611Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         42066960161177,
+				"StableID":   "n23eDc24L111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:42844900b63a91c6cace6dd1ae46369a66c7ba55c1b19d879077b08925695a3c",
+				"DiscoKey":   "discokey:e025acbe1b236d708147009580579b3d44c65b33b6f31b99f1b4f5b59b082b39",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60998",
+					"10.65.0.27:60998",
+					"172.17.0.1:60998",
+					"172.18.0.1:60998",
+					"172.19.0.1:60998"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:03:04.996615062Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6125617552030490,
+				"StableID":   "ndz6tyaJqp11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c37891f42fb341b8e44de97fe5d5e919c3394a947313611b10fa5da6302f1a13",
+				"DiscoKey":   "discokey:d8f354e76db850e10e85c9ea85644c393e07a72d7160b65338a9a9c47d0da117",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38316",
+					"10.65.0.27:38316",
+					"172.17.0.1:38316",
+					"172.18.0.1:38316",
+					"172.19.0.1:38316"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:03:05.54511894Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3315845349970036,
+				"StableID":   "nVuszodktS11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f2d09dad73c4523333e6a42d492d94c88f7cbdf269b0a64b224189743dcff16",
+				"DiscoKey":   "discokey:d71a00863bf303b5cba78cd33f4ec19445bf489a76f7bb1928afac55e4ccdb4b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:42927",
+					"10.65.0.27:42927",
+					"172.17.0.1:42927",
+					"172.18.0.1:42927",
+					"172.19.0.1:42927"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:03:06.08455374Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8687519876479277,
+				"StableID":   "nGzGU7RbqA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06feede0aff475c4a0dd8f7e12d039e770e7d9a6840d4fc6bc00a9985fc4234e",
+				"DiscoKey":   "discokey:9848fed6433809f9ef64e2958c89b4cc36c857da63c5845d431f455c494a835b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55181",
+					"10.65.0.27:55181",
+					"172.17.0.1:55181",
+					"172.18.0.1:55181",
+					"172.19.0.1:55181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:03:06.635927155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5970190537324052,
+				"StableID":   "nPevpLnuco11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:083a1f83474173976cea8e57bab4d67e91921c2b3320b4feb0da6f6e920de83b",
+				"DiscoKey":   "discokey:580248f1a360bca5a61367e909ac8004f35330db13e5e54d15634e51fe82dc3a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43425",
+					"10.65.0.27:43425",
+					"172.17.0.1:43425",
+					"172.18.0.1:43425",
+					"172.19.0.1:43425"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:03:07.169035609Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5830946875491225,
+				"StableID":   "nE5NF36rXn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eba9818c8c61a21c476ba9b48faec003549215dad738fe92e606329e9423d679",
+				"DiscoKey":   "discokey:8bad6cb957eca2d632b9263f95b38b385850ef260600d23163ec36ed41e66d4d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59925",
+					"10.65.0.27:59925",
+					"172.17.0.1:59925",
+					"172.18.0.1:59925",
+					"172.19.0.1:59925"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:03:07.698871338Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6468258047135598,
+				"StableID":   "n9Ak7uAVWs11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2567ad955d8d9480c8eb2bdb75126c4c8c07cac2fa48cd297107ef8f5dfb5202",
+				"DiscoKey":   "discokey:8d87bdd3eb8f636dc5b0ed189a9fcb22e5dbd680e94d7014df58c492aef68851",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:53616",
+					"10.65.0.27:53616",
+					"172.17.0.1:53616",
+					"172.18.0.1:53616",
+					"172.19.0.1:53616"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:03:08.777000304Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1095631849851761,
+				"StableID":   "nzVskfPDZ911CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:778136e5cde9ab4473bac5ae3e8722d09e28cee4ace175b71a1b4968f71dd835",
+				"KeyExpiry":  "2026-11-08T22:03:09Z",
+				"DiscoKey":   "discokey:e2af5b491e9547acd5618c1a88913ffa728c58e7e54f379fafb4203d015e2748",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33885",
+					"10.65.0.27:33885",
+					"172.17.0.1:33885",
+					"172.18.0.1:33885",
+					"172.19.0.1:33885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:03:09.314902662Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1082080724716970,
+				"StableID":   "n73TEhR5T911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bfddb154be3386c7d4265aeca1bd5da166ac968d358d7ed988cd832e58b81171",
+				"KeyExpiry":  "2026-11-08T22:03:09Z",
+				"DiscoKey":   "discokey:0d22c786f7f56f8ff96761be9611813da9a9254d0ccd8f372ccf069d4863cd37",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54017",
+					"10.65.0.27:54017",
+					"172.17.0.1:54017",
+					"172.18.0.1:54017",
+					"172.19.0.1:54017"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:03:09.880456695Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4524054647650237,
+				"StableID":   "nARJKAFxKc11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:09de103cb3e0bbc1ce13c31099e8f461b3a3d9f706985854d8dd518b12215336",
+				"KeyExpiry":  "2026-11-08T22:03:10Z",
+				"DiscoKey":   "discokey:676db65ee4334151bdd191cb6327fbdd30b0eb2198e3b86dfdeda58147d1ac22",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56478",
+					"10.65.0.27:56478",
+					"172.17.0.1:56478",
+					"172.18.0.1:56478",
+					"172.19.0.1:56478"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:03:10.408295152Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "352782644637908": {
+				"ID":          352782644637908,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2172641053472854,
+				"StableID":   "nfs43bbzxH11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       2172641053472854,
+				"Key":        "nodekey:4c84d05352d371ad043bc87e8f2d28f563252370377da246f302e100ea61ea6d",
+				"DiscoKey":   "discokey:211d89d048dd9d58210fbc1b622dfcb170bca56500fbc6d0d3ac4cdd5ea98242",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:36639",
+					"10.65.0.27:36639",
+					"172.17.0.1:36639",
+					"172.18.0.1:36639",
+					"172.19.0.1:36639"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:03:03.38550291Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4c84d05352d371ad043bc87e8f2d28f563252370377da246f302e100ea61ea6d",
+			"MachineKey": "mkey:89e0238e9ef108f3f862b3992c5bb50cebb0358f78cc3f05bdfffc2c1e07644d",
+			"Peers": [{
+				"ID":         4778158905084370,
+				"StableID":   "nZCYQf83Ke11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b12938f529d15fbf7d733b3263f58bcbbebdaa79ce6c0adfcf6e58af4d822f66",
+				"DiscoKey":   "discokey:4af2342ba570ea1376a026f9630159b9cd96e50cbf033e703570d1d84be3546a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45163",
+					"10.65.0.27:45163",
+					"172.17.0.1:45163",
+					"172.18.0.1:45163",
+					"172.19.0.1:45163"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:03:02.856579649Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4061196893810790,
+				"StableID":   "n3wFbqkKiY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:beda62eec575c69f5fd8f1bed233e197c192a6bef31c9c116235a332a482951b",
+				"DiscoKey":   "discokey:19b29be938553471d08ef741decbb39ca65862c90b6a730e371f1a552dce0f4a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:47517",
+					"10.65.0.27:47517",
+					"172.17.0.1:47517",
+					"172.18.0.1:47517",
+					"172.19.0.1:47517"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:03:03.928154443Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6671352957763120,
+				"StableID":   "nqHMuW8U6u11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36e371fb3c9e4ac8a77a8cccf18c4fa3164c05506b54ef5c3147744658b8ca3f",
+				"DiscoKey":   "discokey:6bfa46a58e1ca58c16dd3ef791cf0e59c5c585146d97e7b4e027e98d5769eb56",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50002",
+					"10.65.0.27:50002",
+					"172.17.0.1:50002",
+					"172.18.0.1:50002",
+					"172.19.0.1:50002"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:03:04.445919611Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         42066960161177,
+				"StableID":   "n23eDc24L111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:42844900b63a91c6cace6dd1ae46369a66c7ba55c1b19d879077b08925695a3c",
+				"DiscoKey":   "discokey:e025acbe1b236d708147009580579b3d44c65b33b6f31b99f1b4f5b59b082b39",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60998",
+					"10.65.0.27:60998",
+					"172.17.0.1:60998",
+					"172.18.0.1:60998",
+					"172.19.0.1:60998"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:03:04.996615062Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6125617552030490,
+				"StableID":   "ndz6tyaJqp11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c37891f42fb341b8e44de97fe5d5e919c3394a947313611b10fa5da6302f1a13",
+				"DiscoKey":   "discokey:d8f354e76db850e10e85c9ea85644c393e07a72d7160b65338a9a9c47d0da117",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38316",
+					"10.65.0.27:38316",
+					"172.17.0.1:38316",
+					"172.18.0.1:38316",
+					"172.19.0.1:38316"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:03:05.54511894Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3315845349970036,
+				"StableID":   "nVuszodktS11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f2d09dad73c4523333e6a42d492d94c88f7cbdf269b0a64b224189743dcff16",
+				"DiscoKey":   "discokey:d71a00863bf303b5cba78cd33f4ec19445bf489a76f7bb1928afac55e4ccdb4b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:42927",
+					"10.65.0.27:42927",
+					"172.17.0.1:42927",
+					"172.18.0.1:42927",
+					"172.19.0.1:42927"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:03:06.08455374Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8687519876479277,
+				"StableID":   "nGzGU7RbqA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06feede0aff475c4a0dd8f7e12d039e770e7d9a6840d4fc6bc00a9985fc4234e",
+				"DiscoKey":   "discokey:9848fed6433809f9ef64e2958c89b4cc36c857da63c5845d431f455c494a835b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55181",
+					"10.65.0.27:55181",
+					"172.17.0.1:55181",
+					"172.18.0.1:55181",
+					"172.19.0.1:55181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:03:06.635927155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5970190537324052,
+				"StableID":   "nPevpLnuco11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:083a1f83474173976cea8e57bab4d67e91921c2b3320b4feb0da6f6e920de83b",
+				"DiscoKey":   "discokey:580248f1a360bca5a61367e909ac8004f35330db13e5e54d15634e51fe82dc3a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43425",
+					"10.65.0.27:43425",
+					"172.17.0.1:43425",
+					"172.18.0.1:43425",
+					"172.19.0.1:43425"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:03:07.169035609Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5830946875491225,
+				"StableID":   "nE5NF36rXn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eba9818c8c61a21c476ba9b48faec003549215dad738fe92e606329e9423d679",
+				"DiscoKey":   "discokey:8bad6cb957eca2d632b9263f95b38b385850ef260600d23163ec36ed41e66d4d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59925",
+					"10.65.0.27:59925",
+					"172.17.0.1:59925",
+					"172.18.0.1:59925",
+					"172.19.0.1:59925"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:03:07.698871338Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         352782644637908,
+				"StableID":   "nm53G71nk311CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f1faef0a6bd6230059c858ec5d7da3e0637a1f539cb9cf6fd47e3ff5cafbe744",
+				"DiscoKey":   "discokey:9058d2eacd888d924c49658912eaf750f1f0a4034652ccc573eba7f4f5519269",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38143",
+					"10.65.0.27:38143",
+					"172.17.0.1:38143",
+					"172.18.0.1:38143",
+					"172.19.0.1:38143"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:03:08.229088305Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6468258047135598,
+				"StableID":   "n9Ak7uAVWs11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2567ad955d8d9480c8eb2bdb75126c4c8c07cac2fa48cd297107ef8f5dfb5202",
+				"DiscoKey":   "discokey:8d87bdd3eb8f636dc5b0ed189a9fcb22e5dbd680e94d7014df58c492aef68851",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:53616",
+					"10.65.0.27:53616",
+					"172.17.0.1:53616",
+					"172.18.0.1:53616",
+					"172.19.0.1:53616"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:03:08.777000304Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1095631849851761,
+				"StableID":   "nzVskfPDZ911CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:778136e5cde9ab4473bac5ae3e8722d09e28cee4ace175b71a1b4968f71dd835",
+				"KeyExpiry":  "2026-11-08T22:03:09Z",
+				"DiscoKey":   "discokey:e2af5b491e9547acd5618c1a88913ffa728c58e7e54f379fafb4203d015e2748",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33885",
+					"10.65.0.27:33885",
+					"172.17.0.1:33885",
+					"172.18.0.1:33885",
+					"172.19.0.1:33885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:03:09.314902662Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1082080724716970,
+				"StableID":   "n73TEhR5T911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bfddb154be3386c7d4265aeca1bd5da166ac968d358d7ed988cd832e58b81171",
+				"KeyExpiry":  "2026-11-08T22:03:09Z",
+				"DiscoKey":   "discokey:0d22c786f7f56f8ff96761be9611813da9a9254d0ccd8f372ccf069d4863cd37",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54017",
+					"10.65.0.27:54017",
+					"172.17.0.1:54017",
+					"172.18.0.1:54017",
+					"172.19.0.1:54017"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:03:09.880456695Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4524054647650237,
+				"StableID":   "nARJKAFxKc11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:09de103cb3e0bbc1ce13c31099e8f461b3a3d9f706985854d8dd518b12215336",
+				"KeyExpiry":  "2026-11-08T22:03:10Z",
+				"DiscoKey":   "discokey:676db65ee4334151bdd191cb6327fbdd30b0eb2198e3b86dfdeda58147d1ac22",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56478",
+					"10.65.0.27:56478",
+					"172.17.0.1:56478",
+					"172.18.0.1:56478",
+					"172.19.0.1:56478"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:03:10.408295152Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2172641053472854": {
+				"ID":          2172641053472854,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4778158905084370,
+				"StableID":   "nZCYQf83Ke11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       4778158905084370,
+				"Key":        "nodekey:b12938f529d15fbf7d733b3263f58bcbbebdaa79ce6c0adfcf6e58af4d822f66",
+				"DiscoKey":   "discokey:4af2342ba570ea1376a026f9630159b9cd96e50cbf033e703570d1d84be3546a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45163",
+					"10.65.0.27:45163",
+					"172.17.0.1:45163",
+					"172.18.0.1:45163",
+					"172.19.0.1:45163"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:03:02.856579649Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b12938f529d15fbf7d733b3263f58bcbbebdaa79ce6c0adfcf6e58af4d822f66",
+			"MachineKey": "mkey:1a382457d538f06b8365a20a7bd3c9278a6ae60da08693f34465eb93ea641959",
+			"Peers": [{
+				"ID":         2172641053472854,
+				"StableID":   "nfs43bbzxH11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4c84d05352d371ad043bc87e8f2d28f563252370377da246f302e100ea61ea6d",
+				"DiscoKey":   "discokey:211d89d048dd9d58210fbc1b622dfcb170bca56500fbc6d0d3ac4cdd5ea98242",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:36639",
+					"10.65.0.27:36639",
+					"172.17.0.1:36639",
+					"172.18.0.1:36639",
+					"172.19.0.1:36639"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:03:03.38550291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4061196893810790,
+				"StableID":   "n3wFbqkKiY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:beda62eec575c69f5fd8f1bed233e197c192a6bef31c9c116235a332a482951b",
+				"DiscoKey":   "discokey:19b29be938553471d08ef741decbb39ca65862c90b6a730e371f1a552dce0f4a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:47517",
+					"10.65.0.27:47517",
+					"172.17.0.1:47517",
+					"172.18.0.1:47517",
+					"172.19.0.1:47517"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:03:03.928154443Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6671352957763120,
+				"StableID":   "nqHMuW8U6u11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36e371fb3c9e4ac8a77a8cccf18c4fa3164c05506b54ef5c3147744658b8ca3f",
+				"DiscoKey":   "discokey:6bfa46a58e1ca58c16dd3ef791cf0e59c5c585146d97e7b4e027e98d5769eb56",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50002",
+					"10.65.0.27:50002",
+					"172.17.0.1:50002",
+					"172.18.0.1:50002",
+					"172.19.0.1:50002"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:03:04.445919611Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         42066960161177,
+				"StableID":   "n23eDc24L111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:42844900b63a91c6cace6dd1ae46369a66c7ba55c1b19d879077b08925695a3c",
+				"DiscoKey":   "discokey:e025acbe1b236d708147009580579b3d44c65b33b6f31b99f1b4f5b59b082b39",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60998",
+					"10.65.0.27:60998",
+					"172.17.0.1:60998",
+					"172.18.0.1:60998",
+					"172.19.0.1:60998"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:03:04.996615062Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6125617552030490,
+				"StableID":   "ndz6tyaJqp11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c37891f42fb341b8e44de97fe5d5e919c3394a947313611b10fa5da6302f1a13",
+				"DiscoKey":   "discokey:d8f354e76db850e10e85c9ea85644c393e07a72d7160b65338a9a9c47d0da117",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38316",
+					"10.65.0.27:38316",
+					"172.17.0.1:38316",
+					"172.18.0.1:38316",
+					"172.19.0.1:38316"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:03:05.54511894Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3315845349970036,
+				"StableID":   "nVuszodktS11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f2d09dad73c4523333e6a42d492d94c88f7cbdf269b0a64b224189743dcff16",
+				"DiscoKey":   "discokey:d71a00863bf303b5cba78cd33f4ec19445bf489a76f7bb1928afac55e4ccdb4b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:42927",
+					"10.65.0.27:42927",
+					"172.17.0.1:42927",
+					"172.18.0.1:42927",
+					"172.19.0.1:42927"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:03:06.08455374Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8687519876479277,
+				"StableID":   "nGzGU7RbqA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06feede0aff475c4a0dd8f7e12d039e770e7d9a6840d4fc6bc00a9985fc4234e",
+				"DiscoKey":   "discokey:9848fed6433809f9ef64e2958c89b4cc36c857da63c5845d431f455c494a835b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55181",
+					"10.65.0.27:55181",
+					"172.17.0.1:55181",
+					"172.18.0.1:55181",
+					"172.19.0.1:55181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:03:06.635927155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5970190537324052,
+				"StableID":   "nPevpLnuco11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:083a1f83474173976cea8e57bab4d67e91921c2b3320b4feb0da6f6e920de83b",
+				"DiscoKey":   "discokey:580248f1a360bca5a61367e909ac8004f35330db13e5e54d15634e51fe82dc3a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43425",
+					"10.65.0.27:43425",
+					"172.17.0.1:43425",
+					"172.18.0.1:43425",
+					"172.19.0.1:43425"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:03:07.169035609Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5830946875491225,
+				"StableID":   "nE5NF36rXn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eba9818c8c61a21c476ba9b48faec003549215dad738fe92e606329e9423d679",
+				"DiscoKey":   "discokey:8bad6cb957eca2d632b9263f95b38b385850ef260600d23163ec36ed41e66d4d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59925",
+					"10.65.0.27:59925",
+					"172.17.0.1:59925",
+					"172.18.0.1:59925",
+					"172.19.0.1:59925"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:03:07.698871338Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         352782644637908,
+				"StableID":   "nm53G71nk311CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f1faef0a6bd6230059c858ec5d7da3e0637a1f539cb9cf6fd47e3ff5cafbe744",
+				"DiscoKey":   "discokey:9058d2eacd888d924c49658912eaf750f1f0a4034652ccc573eba7f4f5519269",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38143",
+					"10.65.0.27:38143",
+					"172.17.0.1:38143",
+					"172.18.0.1:38143",
+					"172.19.0.1:38143"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:03:08.229088305Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6468258047135598,
+				"StableID":   "n9Ak7uAVWs11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2567ad955d8d9480c8eb2bdb75126c4c8c07cac2fa48cd297107ef8f5dfb5202",
+				"DiscoKey":   "discokey:8d87bdd3eb8f636dc5b0ed189a9fcb22e5dbd680e94d7014df58c492aef68851",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:53616",
+					"10.65.0.27:53616",
+					"172.17.0.1:53616",
+					"172.18.0.1:53616",
+					"172.19.0.1:53616"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:03:08.777000304Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1095631849851761,
+				"StableID":   "nzVskfPDZ911CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:778136e5cde9ab4473bac5ae3e8722d09e28cee4ace175b71a1b4968f71dd835",
+				"KeyExpiry":  "2026-11-08T22:03:09Z",
+				"DiscoKey":   "discokey:e2af5b491e9547acd5618c1a88913ffa728c58e7e54f379fafb4203d015e2748",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33885",
+					"10.65.0.27:33885",
+					"172.17.0.1:33885",
+					"172.18.0.1:33885",
+					"172.19.0.1:33885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:03:09.314902662Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1082080724716970,
+				"StableID":   "n73TEhR5T911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bfddb154be3386c7d4265aeca1bd5da166ac968d358d7ed988cd832e58b81171",
+				"KeyExpiry":  "2026-11-08T22:03:09Z",
+				"DiscoKey":   "discokey:0d22c786f7f56f8ff96761be9611813da9a9254d0ccd8f372ccf069d4863cd37",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54017",
+					"10.65.0.27:54017",
+					"172.17.0.1:54017",
+					"172.18.0.1:54017",
+					"172.19.0.1:54017"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:03:09.880456695Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4524054647650237,
+				"StableID":   "nARJKAFxKc11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:09de103cb3e0bbc1ce13c31099e8f461b3a3d9f706985854d8dd518b12215336",
+				"KeyExpiry":  "2026-11-08T22:03:10Z",
+				"DiscoKey":   "discokey:676db65ee4334151bdd191cb6327fbdd30b0eb2198e3b86dfdeda58147d1ac22",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56478",
+					"10.65.0.27:56478",
+					"172.17.0.1:56478",
+					"172.18.0.1:56478",
+					"172.19.0.1:56478"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:03:10.408295152Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4778158905084370": {
+				"ID":          4778158905084370,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         42066960161177,
+				"StableID":   "n23eDc24L111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       42066960161177,
+				"Key":        "nodekey:42844900b63a91c6cace6dd1ae46369a66c7ba55c1b19d879077b08925695a3c",
+				"DiscoKey":   "discokey:e025acbe1b236d708147009580579b3d44c65b33b6f31b99f1b4f5b59b082b39",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60998",
+					"10.65.0.27:60998",
+					"172.17.0.1:60998",
+					"172.18.0.1:60998",
+					"172.19.0.1:60998"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:03:04.996615062Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:42844900b63a91c6cace6dd1ae46369a66c7ba55c1b19d879077b08925695a3c",
+			"MachineKey": "mkey:621eab81630606046c5afa2f2a26a22612f2c4f718b76161a2bb8eace744f77d",
+			"Peers": [{
+				"ID":         4778158905084370,
+				"StableID":   "nZCYQf83Ke11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b12938f529d15fbf7d733b3263f58bcbbebdaa79ce6c0adfcf6e58af4d822f66",
+				"DiscoKey":   "discokey:4af2342ba570ea1376a026f9630159b9cd96e50cbf033e703570d1d84be3546a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45163",
+					"10.65.0.27:45163",
+					"172.17.0.1:45163",
+					"172.18.0.1:45163",
+					"172.19.0.1:45163"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:03:02.856579649Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2172641053472854,
+				"StableID":   "nfs43bbzxH11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4c84d05352d371ad043bc87e8f2d28f563252370377da246f302e100ea61ea6d",
+				"DiscoKey":   "discokey:211d89d048dd9d58210fbc1b622dfcb170bca56500fbc6d0d3ac4cdd5ea98242",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:36639",
+					"10.65.0.27:36639",
+					"172.17.0.1:36639",
+					"172.18.0.1:36639",
+					"172.19.0.1:36639"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:03:03.38550291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4061196893810790,
+				"StableID":   "n3wFbqkKiY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:beda62eec575c69f5fd8f1bed233e197c192a6bef31c9c116235a332a482951b",
+				"DiscoKey":   "discokey:19b29be938553471d08ef741decbb39ca65862c90b6a730e371f1a552dce0f4a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:47517",
+					"10.65.0.27:47517",
+					"172.17.0.1:47517",
+					"172.18.0.1:47517",
+					"172.19.0.1:47517"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:03:03.928154443Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6671352957763120,
+				"StableID":   "nqHMuW8U6u11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36e371fb3c9e4ac8a77a8cccf18c4fa3164c05506b54ef5c3147744658b8ca3f",
+				"DiscoKey":   "discokey:6bfa46a58e1ca58c16dd3ef791cf0e59c5c585146d97e7b4e027e98d5769eb56",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50002",
+					"10.65.0.27:50002",
+					"172.17.0.1:50002",
+					"172.18.0.1:50002",
+					"172.19.0.1:50002"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:03:04.445919611Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6125617552030490,
+				"StableID":   "ndz6tyaJqp11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c37891f42fb341b8e44de97fe5d5e919c3394a947313611b10fa5da6302f1a13",
+				"DiscoKey":   "discokey:d8f354e76db850e10e85c9ea85644c393e07a72d7160b65338a9a9c47d0da117",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38316",
+					"10.65.0.27:38316",
+					"172.17.0.1:38316",
+					"172.18.0.1:38316",
+					"172.19.0.1:38316"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:03:05.54511894Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3315845349970036,
+				"StableID":   "nVuszodktS11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f2d09dad73c4523333e6a42d492d94c88f7cbdf269b0a64b224189743dcff16",
+				"DiscoKey":   "discokey:d71a00863bf303b5cba78cd33f4ec19445bf489a76f7bb1928afac55e4ccdb4b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:42927",
+					"10.65.0.27:42927",
+					"172.17.0.1:42927",
+					"172.18.0.1:42927",
+					"172.19.0.1:42927"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:03:06.08455374Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8687519876479277,
+				"StableID":   "nGzGU7RbqA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06feede0aff475c4a0dd8f7e12d039e770e7d9a6840d4fc6bc00a9985fc4234e",
+				"DiscoKey":   "discokey:9848fed6433809f9ef64e2958c89b4cc36c857da63c5845d431f455c494a835b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55181",
+					"10.65.0.27:55181",
+					"172.17.0.1:55181",
+					"172.18.0.1:55181",
+					"172.19.0.1:55181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:03:06.635927155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5970190537324052,
+				"StableID":   "nPevpLnuco11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:083a1f83474173976cea8e57bab4d67e91921c2b3320b4feb0da6f6e920de83b",
+				"DiscoKey":   "discokey:580248f1a360bca5a61367e909ac8004f35330db13e5e54d15634e51fe82dc3a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43425",
+					"10.65.0.27:43425",
+					"172.17.0.1:43425",
+					"172.18.0.1:43425",
+					"172.19.0.1:43425"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:03:07.169035609Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5830946875491225,
+				"StableID":   "nE5NF36rXn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eba9818c8c61a21c476ba9b48faec003549215dad738fe92e606329e9423d679",
+				"DiscoKey":   "discokey:8bad6cb957eca2d632b9263f95b38b385850ef260600d23163ec36ed41e66d4d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59925",
+					"10.65.0.27:59925",
+					"172.17.0.1:59925",
+					"172.18.0.1:59925",
+					"172.19.0.1:59925"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:03:07.698871338Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         352782644637908,
+				"StableID":   "nm53G71nk311CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f1faef0a6bd6230059c858ec5d7da3e0637a1f539cb9cf6fd47e3ff5cafbe744",
+				"DiscoKey":   "discokey:9058d2eacd888d924c49658912eaf750f1f0a4034652ccc573eba7f4f5519269",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38143",
+					"10.65.0.27:38143",
+					"172.17.0.1:38143",
+					"172.18.0.1:38143",
+					"172.19.0.1:38143"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:03:08.229088305Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6468258047135598,
+				"StableID":   "n9Ak7uAVWs11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2567ad955d8d9480c8eb2bdb75126c4c8c07cac2fa48cd297107ef8f5dfb5202",
+				"DiscoKey":   "discokey:8d87bdd3eb8f636dc5b0ed189a9fcb22e5dbd680e94d7014df58c492aef68851",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:53616",
+					"10.65.0.27:53616",
+					"172.17.0.1:53616",
+					"172.18.0.1:53616",
+					"172.19.0.1:53616"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:03:08.777000304Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1095631849851761,
+				"StableID":   "nzVskfPDZ911CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:778136e5cde9ab4473bac5ae3e8722d09e28cee4ace175b71a1b4968f71dd835",
+				"KeyExpiry":  "2026-11-08T22:03:09Z",
+				"DiscoKey":   "discokey:e2af5b491e9547acd5618c1a88913ffa728c58e7e54f379fafb4203d015e2748",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33885",
+					"10.65.0.27:33885",
+					"172.17.0.1:33885",
+					"172.18.0.1:33885",
+					"172.19.0.1:33885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:03:09.314902662Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1082080724716970,
+				"StableID":   "n73TEhR5T911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bfddb154be3386c7d4265aeca1bd5da166ac968d358d7ed988cd832e58b81171",
+				"KeyExpiry":  "2026-11-08T22:03:09Z",
+				"DiscoKey":   "discokey:0d22c786f7f56f8ff96761be9611813da9a9254d0ccd8f372ccf069d4863cd37",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54017",
+					"10.65.0.27:54017",
+					"172.17.0.1:54017",
+					"172.18.0.1:54017",
+					"172.19.0.1:54017"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:03:09.880456695Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4524054647650237,
+				"StableID":   "nARJKAFxKc11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:09de103cb3e0bbc1ce13c31099e8f461b3a3d9f706985854d8dd518b12215336",
+				"KeyExpiry":  "2026-11-08T22:03:10Z",
+				"DiscoKey":   "discokey:676db65ee4334151bdd191cb6327fbdd30b0eb2198e3b86dfdeda58147d1ac22",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56478",
+					"10.65.0.27:56478",
+					"172.17.0.1:56478",
+					"172.18.0.1:56478",
+					"172.19.0.1:56478"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:03:10.408295152Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "42066960161177": {
+				"ID":          42066960161177,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6671352957763120,
+				"StableID":   "nqHMuW8U6u11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       6671352957763120,
+				"Key":        "nodekey:36e371fb3c9e4ac8a77a8cccf18c4fa3164c05506b54ef5c3147744658b8ca3f",
+				"DiscoKey":   "discokey:6bfa46a58e1ca58c16dd3ef791cf0e59c5c585146d97e7b4e027e98d5769eb56",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50002",
+					"10.65.0.27:50002",
+					"172.17.0.1:50002",
+					"172.18.0.1:50002",
+					"172.19.0.1:50002"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:03:04.445919611Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:36e371fb3c9e4ac8a77a8cccf18c4fa3164c05506b54ef5c3147744658b8ca3f",
+			"MachineKey": "mkey:6e342c4f25b62abaa8c57512ba3917c6698dfea67dc8b9f7a8c780d55f2ede54",
+			"Peers": [{
+				"ID":         4778158905084370,
+				"StableID":   "nZCYQf83Ke11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b12938f529d15fbf7d733b3263f58bcbbebdaa79ce6c0adfcf6e58af4d822f66",
+				"DiscoKey":   "discokey:4af2342ba570ea1376a026f9630159b9cd96e50cbf033e703570d1d84be3546a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45163",
+					"10.65.0.27:45163",
+					"172.17.0.1:45163",
+					"172.18.0.1:45163",
+					"172.19.0.1:45163"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:03:02.856579649Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2172641053472854,
+				"StableID":   "nfs43bbzxH11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4c84d05352d371ad043bc87e8f2d28f563252370377da246f302e100ea61ea6d",
+				"DiscoKey":   "discokey:211d89d048dd9d58210fbc1b622dfcb170bca56500fbc6d0d3ac4cdd5ea98242",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:36639",
+					"10.65.0.27:36639",
+					"172.17.0.1:36639",
+					"172.18.0.1:36639",
+					"172.19.0.1:36639"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:03:03.38550291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4061196893810790,
+				"StableID":   "n3wFbqkKiY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:beda62eec575c69f5fd8f1bed233e197c192a6bef31c9c116235a332a482951b",
+				"DiscoKey":   "discokey:19b29be938553471d08ef741decbb39ca65862c90b6a730e371f1a552dce0f4a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:47517",
+					"10.65.0.27:47517",
+					"172.17.0.1:47517",
+					"172.18.0.1:47517",
+					"172.19.0.1:47517"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:03:03.928154443Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         42066960161177,
+				"StableID":   "n23eDc24L111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:42844900b63a91c6cace6dd1ae46369a66c7ba55c1b19d879077b08925695a3c",
+				"DiscoKey":   "discokey:e025acbe1b236d708147009580579b3d44c65b33b6f31b99f1b4f5b59b082b39",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60998",
+					"10.65.0.27:60998",
+					"172.17.0.1:60998",
+					"172.18.0.1:60998",
+					"172.19.0.1:60998"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:03:04.996615062Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6125617552030490,
+				"StableID":   "ndz6tyaJqp11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c37891f42fb341b8e44de97fe5d5e919c3394a947313611b10fa5da6302f1a13",
+				"DiscoKey":   "discokey:d8f354e76db850e10e85c9ea85644c393e07a72d7160b65338a9a9c47d0da117",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38316",
+					"10.65.0.27:38316",
+					"172.17.0.1:38316",
+					"172.18.0.1:38316",
+					"172.19.0.1:38316"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:03:05.54511894Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3315845349970036,
+				"StableID":   "nVuszodktS11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f2d09dad73c4523333e6a42d492d94c88f7cbdf269b0a64b224189743dcff16",
+				"DiscoKey":   "discokey:d71a00863bf303b5cba78cd33f4ec19445bf489a76f7bb1928afac55e4ccdb4b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:42927",
+					"10.65.0.27:42927",
+					"172.17.0.1:42927",
+					"172.18.0.1:42927",
+					"172.19.0.1:42927"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:03:06.08455374Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8687519876479277,
+				"StableID":   "nGzGU7RbqA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06feede0aff475c4a0dd8f7e12d039e770e7d9a6840d4fc6bc00a9985fc4234e",
+				"DiscoKey":   "discokey:9848fed6433809f9ef64e2958c89b4cc36c857da63c5845d431f455c494a835b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55181",
+					"10.65.0.27:55181",
+					"172.17.0.1:55181",
+					"172.18.0.1:55181",
+					"172.19.0.1:55181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:03:06.635927155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5970190537324052,
+				"StableID":   "nPevpLnuco11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:083a1f83474173976cea8e57bab4d67e91921c2b3320b4feb0da6f6e920de83b",
+				"DiscoKey":   "discokey:580248f1a360bca5a61367e909ac8004f35330db13e5e54d15634e51fe82dc3a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43425",
+					"10.65.0.27:43425",
+					"172.17.0.1:43425",
+					"172.18.0.1:43425",
+					"172.19.0.1:43425"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:03:07.169035609Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5830946875491225,
+				"StableID":   "nE5NF36rXn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eba9818c8c61a21c476ba9b48faec003549215dad738fe92e606329e9423d679",
+				"DiscoKey":   "discokey:8bad6cb957eca2d632b9263f95b38b385850ef260600d23163ec36ed41e66d4d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59925",
+					"10.65.0.27:59925",
+					"172.17.0.1:59925",
+					"172.18.0.1:59925",
+					"172.19.0.1:59925"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:03:07.698871338Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         352782644637908,
+				"StableID":   "nm53G71nk311CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f1faef0a6bd6230059c858ec5d7da3e0637a1f539cb9cf6fd47e3ff5cafbe744",
+				"DiscoKey":   "discokey:9058d2eacd888d924c49658912eaf750f1f0a4034652ccc573eba7f4f5519269",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38143",
+					"10.65.0.27:38143",
+					"172.17.0.1:38143",
+					"172.18.0.1:38143",
+					"172.19.0.1:38143"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:03:08.229088305Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6468258047135598,
+				"StableID":   "n9Ak7uAVWs11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2567ad955d8d9480c8eb2bdb75126c4c8c07cac2fa48cd297107ef8f5dfb5202",
+				"DiscoKey":   "discokey:8d87bdd3eb8f636dc5b0ed189a9fcb22e5dbd680e94d7014df58c492aef68851",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:53616",
+					"10.65.0.27:53616",
+					"172.17.0.1:53616",
+					"172.18.0.1:53616",
+					"172.19.0.1:53616"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:03:08.777000304Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1095631849851761,
+				"StableID":   "nzVskfPDZ911CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:778136e5cde9ab4473bac5ae3e8722d09e28cee4ace175b71a1b4968f71dd835",
+				"KeyExpiry":  "2026-11-08T22:03:09Z",
+				"DiscoKey":   "discokey:e2af5b491e9547acd5618c1a88913ffa728c58e7e54f379fafb4203d015e2748",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33885",
+					"10.65.0.27:33885",
+					"172.17.0.1:33885",
+					"172.18.0.1:33885",
+					"172.19.0.1:33885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:03:09.314902662Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1082080724716970,
+				"StableID":   "n73TEhR5T911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bfddb154be3386c7d4265aeca1bd5da166ac968d358d7ed988cd832e58b81171",
+				"KeyExpiry":  "2026-11-08T22:03:09Z",
+				"DiscoKey":   "discokey:0d22c786f7f56f8ff96761be9611813da9a9254d0ccd8f372ccf069d4863cd37",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54017",
+					"10.65.0.27:54017",
+					"172.17.0.1:54017",
+					"172.18.0.1:54017",
+					"172.19.0.1:54017"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:03:09.880456695Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4524054647650237,
+				"StableID":   "nARJKAFxKc11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:09de103cb3e0bbc1ce13c31099e8f461b3a3d9f706985854d8dd518b12215336",
+				"KeyExpiry":  "2026-11-08T22:03:10Z",
+				"DiscoKey":   "discokey:676db65ee4334151bdd191cb6327fbdd30b0eb2198e3b86dfdeda58147d1ac22",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56478",
+					"10.65.0.27:56478",
+					"172.17.0.1:56478",
+					"172.18.0.1:56478",
+					"172.19.0.1:56478"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:03:10.408295152Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6671352957763120": {
+				"ID":          6671352957763120,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3315845349970036,
+				"StableID":   "nVuszodktS11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       3315845349970036,
+				"Key":        "nodekey:5f2d09dad73c4523333e6a42d492d94c88f7cbdf269b0a64b224189743dcff16",
+				"DiscoKey":   "discokey:d71a00863bf303b5cba78cd33f4ec19445bf489a76f7bb1928afac55e4ccdb4b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:42927",
+					"10.65.0.27:42927",
+					"172.17.0.1:42927",
+					"172.18.0.1:42927",
+					"172.19.0.1:42927"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:03:06.08455374Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5f2d09dad73c4523333e6a42d492d94c88f7cbdf269b0a64b224189743dcff16",
+			"MachineKey": "mkey:b00305062e3e3cf60ade316bee316b7f0b059ecd93642463c9892afa180bdc4f",
+			"Peers": [{
+				"ID":         4778158905084370,
+				"StableID":   "nZCYQf83Ke11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b12938f529d15fbf7d733b3263f58bcbbebdaa79ce6c0adfcf6e58af4d822f66",
+				"DiscoKey":   "discokey:4af2342ba570ea1376a026f9630159b9cd96e50cbf033e703570d1d84be3546a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45163",
+					"10.65.0.27:45163",
+					"172.17.0.1:45163",
+					"172.18.0.1:45163",
+					"172.19.0.1:45163"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:03:02.856579649Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2172641053472854,
+				"StableID":   "nfs43bbzxH11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4c84d05352d371ad043bc87e8f2d28f563252370377da246f302e100ea61ea6d",
+				"DiscoKey":   "discokey:211d89d048dd9d58210fbc1b622dfcb170bca56500fbc6d0d3ac4cdd5ea98242",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:36639",
+					"10.65.0.27:36639",
+					"172.17.0.1:36639",
+					"172.18.0.1:36639",
+					"172.19.0.1:36639"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:03:03.38550291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4061196893810790,
+				"StableID":   "n3wFbqkKiY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:beda62eec575c69f5fd8f1bed233e197c192a6bef31c9c116235a332a482951b",
+				"DiscoKey":   "discokey:19b29be938553471d08ef741decbb39ca65862c90b6a730e371f1a552dce0f4a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:47517",
+					"10.65.0.27:47517",
+					"172.17.0.1:47517",
+					"172.18.0.1:47517",
+					"172.19.0.1:47517"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:03:03.928154443Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6671352957763120,
+				"StableID":   "nqHMuW8U6u11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36e371fb3c9e4ac8a77a8cccf18c4fa3164c05506b54ef5c3147744658b8ca3f",
+				"DiscoKey":   "discokey:6bfa46a58e1ca58c16dd3ef791cf0e59c5c585146d97e7b4e027e98d5769eb56",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50002",
+					"10.65.0.27:50002",
+					"172.17.0.1:50002",
+					"172.18.0.1:50002",
+					"172.19.0.1:50002"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:03:04.445919611Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         42066960161177,
+				"StableID":   "n23eDc24L111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:42844900b63a91c6cace6dd1ae46369a66c7ba55c1b19d879077b08925695a3c",
+				"DiscoKey":   "discokey:e025acbe1b236d708147009580579b3d44c65b33b6f31b99f1b4f5b59b082b39",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60998",
+					"10.65.0.27:60998",
+					"172.17.0.1:60998",
+					"172.18.0.1:60998",
+					"172.19.0.1:60998"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:03:04.996615062Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6125617552030490,
+				"StableID":   "ndz6tyaJqp11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c37891f42fb341b8e44de97fe5d5e919c3394a947313611b10fa5da6302f1a13",
+				"DiscoKey":   "discokey:d8f354e76db850e10e85c9ea85644c393e07a72d7160b65338a9a9c47d0da117",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38316",
+					"10.65.0.27:38316",
+					"172.17.0.1:38316",
+					"172.18.0.1:38316",
+					"172.19.0.1:38316"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:03:05.54511894Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8687519876479277,
+				"StableID":   "nGzGU7RbqA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06feede0aff475c4a0dd8f7e12d039e770e7d9a6840d4fc6bc00a9985fc4234e",
+				"DiscoKey":   "discokey:9848fed6433809f9ef64e2958c89b4cc36c857da63c5845d431f455c494a835b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55181",
+					"10.65.0.27:55181",
+					"172.17.0.1:55181",
+					"172.18.0.1:55181",
+					"172.19.0.1:55181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:03:06.635927155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5970190537324052,
+				"StableID":   "nPevpLnuco11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:083a1f83474173976cea8e57bab4d67e91921c2b3320b4feb0da6f6e920de83b",
+				"DiscoKey":   "discokey:580248f1a360bca5a61367e909ac8004f35330db13e5e54d15634e51fe82dc3a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43425",
+					"10.65.0.27:43425",
+					"172.17.0.1:43425",
+					"172.18.0.1:43425",
+					"172.19.0.1:43425"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:03:07.169035609Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5830946875491225,
+				"StableID":   "nE5NF36rXn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eba9818c8c61a21c476ba9b48faec003549215dad738fe92e606329e9423d679",
+				"DiscoKey":   "discokey:8bad6cb957eca2d632b9263f95b38b385850ef260600d23163ec36ed41e66d4d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59925",
+					"10.65.0.27:59925",
+					"172.17.0.1:59925",
+					"172.18.0.1:59925",
+					"172.19.0.1:59925"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:03:07.698871338Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         352782644637908,
+				"StableID":   "nm53G71nk311CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f1faef0a6bd6230059c858ec5d7da3e0637a1f539cb9cf6fd47e3ff5cafbe744",
+				"DiscoKey":   "discokey:9058d2eacd888d924c49658912eaf750f1f0a4034652ccc573eba7f4f5519269",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38143",
+					"10.65.0.27:38143",
+					"172.17.0.1:38143",
+					"172.18.0.1:38143",
+					"172.19.0.1:38143"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:03:08.229088305Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6468258047135598,
+				"StableID":   "n9Ak7uAVWs11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2567ad955d8d9480c8eb2bdb75126c4c8c07cac2fa48cd297107ef8f5dfb5202",
+				"DiscoKey":   "discokey:8d87bdd3eb8f636dc5b0ed189a9fcb22e5dbd680e94d7014df58c492aef68851",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:53616",
+					"10.65.0.27:53616",
+					"172.17.0.1:53616",
+					"172.18.0.1:53616",
+					"172.19.0.1:53616"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:03:08.777000304Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1095631849851761,
+				"StableID":   "nzVskfPDZ911CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:778136e5cde9ab4473bac5ae3e8722d09e28cee4ace175b71a1b4968f71dd835",
+				"KeyExpiry":  "2026-11-08T22:03:09Z",
+				"DiscoKey":   "discokey:e2af5b491e9547acd5618c1a88913ffa728c58e7e54f379fafb4203d015e2748",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33885",
+					"10.65.0.27:33885",
+					"172.17.0.1:33885",
+					"172.18.0.1:33885",
+					"172.19.0.1:33885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:03:09.314902662Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1082080724716970,
+				"StableID":   "n73TEhR5T911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bfddb154be3386c7d4265aeca1bd5da166ac968d358d7ed988cd832e58b81171",
+				"KeyExpiry":  "2026-11-08T22:03:09Z",
+				"DiscoKey":   "discokey:0d22c786f7f56f8ff96761be9611813da9a9254d0ccd8f372ccf069d4863cd37",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54017",
+					"10.65.0.27:54017",
+					"172.17.0.1:54017",
+					"172.18.0.1:54017",
+					"172.19.0.1:54017"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:03:09.880456695Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4524054647650237,
+				"StableID":   "nARJKAFxKc11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:09de103cb3e0bbc1ce13c31099e8f461b3a3d9f706985854d8dd518b12215336",
+				"KeyExpiry":  "2026-11-08T22:03:10Z",
+				"DiscoKey":   "discokey:676db65ee4334151bdd191cb6327fbdd30b0eb2198e3b86dfdeda58147d1ac22",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56478",
+					"10.65.0.27:56478",
+					"172.17.0.1:56478",
+					"172.18.0.1:56478",
+					"172.19.0.1:56478"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:03:10.408295152Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3315845349970036": {
+				"ID":          3315845349970036,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5970190537324052,
+				"StableID":   "nPevpLnuco11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       5970190537324052,
+				"Key":        "nodekey:083a1f83474173976cea8e57bab4d67e91921c2b3320b4feb0da6f6e920de83b",
+				"DiscoKey":   "discokey:580248f1a360bca5a61367e909ac8004f35330db13e5e54d15634e51fe82dc3a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43425",
+					"10.65.0.27:43425",
+					"172.17.0.1:43425",
+					"172.18.0.1:43425",
+					"172.19.0.1:43425"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:03:07.169035609Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:083a1f83474173976cea8e57bab4d67e91921c2b3320b4feb0da6f6e920de83b",
+			"MachineKey": "mkey:a5ddbfcac4734fd58a25ab594a5fd1035e8390771cd75259846ab703fb0cdc55",
+			"Peers": [{
+				"ID":         4778158905084370,
+				"StableID":   "nZCYQf83Ke11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b12938f529d15fbf7d733b3263f58bcbbebdaa79ce6c0adfcf6e58af4d822f66",
+				"DiscoKey":   "discokey:4af2342ba570ea1376a026f9630159b9cd96e50cbf033e703570d1d84be3546a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45163",
+					"10.65.0.27:45163",
+					"172.17.0.1:45163",
+					"172.18.0.1:45163",
+					"172.19.0.1:45163"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:03:02.856579649Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2172641053472854,
+				"StableID":   "nfs43bbzxH11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4c84d05352d371ad043bc87e8f2d28f563252370377da246f302e100ea61ea6d",
+				"DiscoKey":   "discokey:211d89d048dd9d58210fbc1b622dfcb170bca56500fbc6d0d3ac4cdd5ea98242",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:36639",
+					"10.65.0.27:36639",
+					"172.17.0.1:36639",
+					"172.18.0.1:36639",
+					"172.19.0.1:36639"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:03:03.38550291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4061196893810790,
+				"StableID":   "n3wFbqkKiY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:beda62eec575c69f5fd8f1bed233e197c192a6bef31c9c116235a332a482951b",
+				"DiscoKey":   "discokey:19b29be938553471d08ef741decbb39ca65862c90b6a730e371f1a552dce0f4a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:47517",
+					"10.65.0.27:47517",
+					"172.17.0.1:47517",
+					"172.18.0.1:47517",
+					"172.19.0.1:47517"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:03:03.928154443Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6671352957763120,
+				"StableID":   "nqHMuW8U6u11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36e371fb3c9e4ac8a77a8cccf18c4fa3164c05506b54ef5c3147744658b8ca3f",
+				"DiscoKey":   "discokey:6bfa46a58e1ca58c16dd3ef791cf0e59c5c585146d97e7b4e027e98d5769eb56",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50002",
+					"10.65.0.27:50002",
+					"172.17.0.1:50002",
+					"172.18.0.1:50002",
+					"172.19.0.1:50002"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:03:04.445919611Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         42066960161177,
+				"StableID":   "n23eDc24L111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:42844900b63a91c6cace6dd1ae46369a66c7ba55c1b19d879077b08925695a3c",
+				"DiscoKey":   "discokey:e025acbe1b236d708147009580579b3d44c65b33b6f31b99f1b4f5b59b082b39",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60998",
+					"10.65.0.27:60998",
+					"172.17.0.1:60998",
+					"172.18.0.1:60998",
+					"172.19.0.1:60998"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:03:04.996615062Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6125617552030490,
+				"StableID":   "ndz6tyaJqp11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c37891f42fb341b8e44de97fe5d5e919c3394a947313611b10fa5da6302f1a13",
+				"DiscoKey":   "discokey:d8f354e76db850e10e85c9ea85644c393e07a72d7160b65338a9a9c47d0da117",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38316",
+					"10.65.0.27:38316",
+					"172.17.0.1:38316",
+					"172.18.0.1:38316",
+					"172.19.0.1:38316"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:03:05.54511894Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3315845349970036,
+				"StableID":   "nVuszodktS11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f2d09dad73c4523333e6a42d492d94c88f7cbdf269b0a64b224189743dcff16",
+				"DiscoKey":   "discokey:d71a00863bf303b5cba78cd33f4ec19445bf489a76f7bb1928afac55e4ccdb4b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:42927",
+					"10.65.0.27:42927",
+					"172.17.0.1:42927",
+					"172.18.0.1:42927",
+					"172.19.0.1:42927"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:03:06.08455374Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8687519876479277,
+				"StableID":   "nGzGU7RbqA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06feede0aff475c4a0dd8f7e12d039e770e7d9a6840d4fc6bc00a9985fc4234e",
+				"DiscoKey":   "discokey:9848fed6433809f9ef64e2958c89b4cc36c857da63c5845d431f455c494a835b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55181",
+					"10.65.0.27:55181",
+					"172.17.0.1:55181",
+					"172.18.0.1:55181",
+					"172.19.0.1:55181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:03:06.635927155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5830946875491225,
+				"StableID":   "nE5NF36rXn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eba9818c8c61a21c476ba9b48faec003549215dad738fe92e606329e9423d679",
+				"DiscoKey":   "discokey:8bad6cb957eca2d632b9263f95b38b385850ef260600d23163ec36ed41e66d4d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59925",
+					"10.65.0.27:59925",
+					"172.17.0.1:59925",
+					"172.18.0.1:59925",
+					"172.19.0.1:59925"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:03:07.698871338Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         352782644637908,
+				"StableID":   "nm53G71nk311CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f1faef0a6bd6230059c858ec5d7da3e0637a1f539cb9cf6fd47e3ff5cafbe744",
+				"DiscoKey":   "discokey:9058d2eacd888d924c49658912eaf750f1f0a4034652ccc573eba7f4f5519269",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38143",
+					"10.65.0.27:38143",
+					"172.17.0.1:38143",
+					"172.18.0.1:38143",
+					"172.19.0.1:38143"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:03:08.229088305Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6468258047135598,
+				"StableID":   "n9Ak7uAVWs11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2567ad955d8d9480c8eb2bdb75126c4c8c07cac2fa48cd297107ef8f5dfb5202",
+				"DiscoKey":   "discokey:8d87bdd3eb8f636dc5b0ed189a9fcb22e5dbd680e94d7014df58c492aef68851",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:53616",
+					"10.65.0.27:53616",
+					"172.17.0.1:53616",
+					"172.18.0.1:53616",
+					"172.19.0.1:53616"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:03:08.777000304Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1095631849851761,
+				"StableID":   "nzVskfPDZ911CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:778136e5cde9ab4473bac5ae3e8722d09e28cee4ace175b71a1b4968f71dd835",
+				"KeyExpiry":  "2026-11-08T22:03:09Z",
+				"DiscoKey":   "discokey:e2af5b491e9547acd5618c1a88913ffa728c58e7e54f379fafb4203d015e2748",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33885",
+					"10.65.0.27:33885",
+					"172.17.0.1:33885",
+					"172.18.0.1:33885",
+					"172.19.0.1:33885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:03:09.314902662Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1082080724716970,
+				"StableID":   "n73TEhR5T911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bfddb154be3386c7d4265aeca1bd5da166ac968d358d7ed988cd832e58b81171",
+				"KeyExpiry":  "2026-11-08T22:03:09Z",
+				"DiscoKey":   "discokey:0d22c786f7f56f8ff96761be9611813da9a9254d0ccd8f372ccf069d4863cd37",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54017",
+					"10.65.0.27:54017",
+					"172.17.0.1:54017",
+					"172.18.0.1:54017",
+					"172.19.0.1:54017"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:03:09.880456695Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4524054647650237,
+				"StableID":   "nARJKAFxKc11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:09de103cb3e0bbc1ce13c31099e8f461b3a3d9f706985854d8dd518b12215336",
+				"KeyExpiry":  "2026-11-08T22:03:10Z",
+				"DiscoKey":   "discokey:676db65ee4334151bdd191cb6327fbdd30b0eb2198e3b86dfdeda58147d1ac22",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56478",
+					"10.65.0.27:56478",
+					"172.17.0.1:56478",
+					"172.18.0.1:56478",
+					"172.19.0.1:56478"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:03:10.408295152Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5970190537324052": {
+				"ID":          5970190537324052,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1082080724716970,
+				"StableID":   "n73TEhR5T911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bfddb154be3386c7d4265aeca1bd5da166ac968d358d7ed988cd832e58b81171",
+				"KeyExpiry":  "2026-11-08T22:03:09Z",
+				"DiscoKey":   "discokey:0d22c786f7f56f8ff96761be9611813da9a9254d0ccd8f372ccf069d4863cd37",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54017",
+					"10.65.0.27:54017",
+					"172.17.0.1:54017",
+					"172.18.0.1:54017",
+					"172.19.0.1:54017"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:03:09.880456695Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:bfddb154be3386c7d4265aeca1bd5da166ac968d358d7ed988cd832e58b81171",
+			"MachineKey": "mkey:855a78c7bcfe830d58b4d20634f8b5a3258ed8cfd48b4b01b694242ca0af4119",
+			"Peers": [{
+				"ID":         4778158905084370,
+				"StableID":   "nZCYQf83Ke11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b12938f529d15fbf7d733b3263f58bcbbebdaa79ce6c0adfcf6e58af4d822f66",
+				"DiscoKey":   "discokey:4af2342ba570ea1376a026f9630159b9cd96e50cbf033e703570d1d84be3546a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45163",
+					"10.65.0.27:45163",
+					"172.17.0.1:45163",
+					"172.18.0.1:45163",
+					"172.19.0.1:45163"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:03:02.856579649Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2172641053472854,
+				"StableID":   "nfs43bbzxH11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4c84d05352d371ad043bc87e8f2d28f563252370377da246f302e100ea61ea6d",
+				"DiscoKey":   "discokey:211d89d048dd9d58210fbc1b622dfcb170bca56500fbc6d0d3ac4cdd5ea98242",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:36639",
+					"10.65.0.27:36639",
+					"172.17.0.1:36639",
+					"172.18.0.1:36639",
+					"172.19.0.1:36639"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:03:03.38550291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4061196893810790,
+				"StableID":   "n3wFbqkKiY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:beda62eec575c69f5fd8f1bed233e197c192a6bef31c9c116235a332a482951b",
+				"DiscoKey":   "discokey:19b29be938553471d08ef741decbb39ca65862c90b6a730e371f1a552dce0f4a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:47517",
+					"10.65.0.27:47517",
+					"172.17.0.1:47517",
+					"172.18.0.1:47517",
+					"172.19.0.1:47517"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:03:03.928154443Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6671352957763120,
+				"StableID":   "nqHMuW8U6u11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36e371fb3c9e4ac8a77a8cccf18c4fa3164c05506b54ef5c3147744658b8ca3f",
+				"DiscoKey":   "discokey:6bfa46a58e1ca58c16dd3ef791cf0e59c5c585146d97e7b4e027e98d5769eb56",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50002",
+					"10.65.0.27:50002",
+					"172.17.0.1:50002",
+					"172.18.0.1:50002",
+					"172.19.0.1:50002"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:03:04.445919611Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         42066960161177,
+				"StableID":   "n23eDc24L111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:42844900b63a91c6cace6dd1ae46369a66c7ba55c1b19d879077b08925695a3c",
+				"DiscoKey":   "discokey:e025acbe1b236d708147009580579b3d44c65b33b6f31b99f1b4f5b59b082b39",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60998",
+					"10.65.0.27:60998",
+					"172.17.0.1:60998",
+					"172.18.0.1:60998",
+					"172.19.0.1:60998"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:03:04.996615062Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6125617552030490,
+				"StableID":   "ndz6tyaJqp11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c37891f42fb341b8e44de97fe5d5e919c3394a947313611b10fa5da6302f1a13",
+				"DiscoKey":   "discokey:d8f354e76db850e10e85c9ea85644c393e07a72d7160b65338a9a9c47d0da117",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38316",
+					"10.65.0.27:38316",
+					"172.17.0.1:38316",
+					"172.18.0.1:38316",
+					"172.19.0.1:38316"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:03:05.54511894Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3315845349970036,
+				"StableID":   "nVuszodktS11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f2d09dad73c4523333e6a42d492d94c88f7cbdf269b0a64b224189743dcff16",
+				"DiscoKey":   "discokey:d71a00863bf303b5cba78cd33f4ec19445bf489a76f7bb1928afac55e4ccdb4b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:42927",
+					"10.65.0.27:42927",
+					"172.17.0.1:42927",
+					"172.18.0.1:42927",
+					"172.19.0.1:42927"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:03:06.08455374Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8687519876479277,
+				"StableID":   "nGzGU7RbqA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06feede0aff475c4a0dd8f7e12d039e770e7d9a6840d4fc6bc00a9985fc4234e",
+				"DiscoKey":   "discokey:9848fed6433809f9ef64e2958c89b4cc36c857da63c5845d431f455c494a835b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55181",
+					"10.65.0.27:55181",
+					"172.17.0.1:55181",
+					"172.18.0.1:55181",
+					"172.19.0.1:55181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:03:06.635927155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5970190537324052,
+				"StableID":   "nPevpLnuco11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:083a1f83474173976cea8e57bab4d67e91921c2b3320b4feb0da6f6e920de83b",
+				"DiscoKey":   "discokey:580248f1a360bca5a61367e909ac8004f35330db13e5e54d15634e51fe82dc3a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43425",
+					"10.65.0.27:43425",
+					"172.17.0.1:43425",
+					"172.18.0.1:43425",
+					"172.19.0.1:43425"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:03:07.169035609Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5830946875491225,
+				"StableID":   "nE5NF36rXn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eba9818c8c61a21c476ba9b48faec003549215dad738fe92e606329e9423d679",
+				"DiscoKey":   "discokey:8bad6cb957eca2d632b9263f95b38b385850ef260600d23163ec36ed41e66d4d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59925",
+					"10.65.0.27:59925",
+					"172.17.0.1:59925",
+					"172.18.0.1:59925",
+					"172.19.0.1:59925"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:03:07.698871338Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         352782644637908,
+				"StableID":   "nm53G71nk311CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f1faef0a6bd6230059c858ec5d7da3e0637a1f539cb9cf6fd47e3ff5cafbe744",
+				"DiscoKey":   "discokey:9058d2eacd888d924c49658912eaf750f1f0a4034652ccc573eba7f4f5519269",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38143",
+					"10.65.0.27:38143",
+					"172.17.0.1:38143",
+					"172.18.0.1:38143",
+					"172.19.0.1:38143"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:03:08.229088305Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6468258047135598,
+				"StableID":   "n9Ak7uAVWs11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2567ad955d8d9480c8eb2bdb75126c4c8c07cac2fa48cd297107ef8f5dfb5202",
+				"DiscoKey":   "discokey:8d87bdd3eb8f636dc5b0ed189a9fcb22e5dbd680e94d7014df58c492aef68851",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:53616",
+					"10.65.0.27:53616",
+					"172.17.0.1:53616",
+					"172.18.0.1:53616",
+					"172.19.0.1:53616"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:03:08.777000304Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1095631849851761,
+				"StableID":   "nzVskfPDZ911CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:778136e5cde9ab4473bac5ae3e8722d09e28cee4ace175b71a1b4968f71dd835",
+				"KeyExpiry":  "2026-11-08T22:03:09Z",
+				"DiscoKey":   "discokey:e2af5b491e9547acd5618c1a88913ffa728c58e7e54f379fafb4203d015e2748",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33885",
+					"10.65.0.27:33885",
+					"172.17.0.1:33885",
+					"172.18.0.1:33885",
+					"172.19.0.1:33885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:03:09.314902662Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4524054647650237,
+				"StableID":   "nARJKAFxKc11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:09de103cb3e0bbc1ce13c31099e8f461b3a3d9f706985854d8dd518b12215336",
+				"KeyExpiry":  "2026-11-08T22:03:10Z",
+				"DiscoKey":   "discokey:676db65ee4334151bdd191cb6327fbdd30b0eb2198e3b86dfdeda58147d1ac22",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56478",
+					"10.65.0.27:56478",
+					"172.17.0.1:56478",
+					"172.18.0.1:56478",
+					"172.19.0.1:56478"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:03:10.408295152Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5830946875491225,
+				"StableID":   "nE5NF36rXn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       5830946875491225,
+				"Key":        "nodekey:eba9818c8c61a21c476ba9b48faec003549215dad738fe92e606329e9423d679",
+				"DiscoKey":   "discokey:8bad6cb957eca2d632b9263f95b38b385850ef260600d23163ec36ed41e66d4d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59925",
+					"10.65.0.27:59925",
+					"172.17.0.1:59925",
+					"172.18.0.1:59925",
+					"172.19.0.1:59925"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:03:07.698871338Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:eba9818c8c61a21c476ba9b48faec003549215dad738fe92e606329e9423d679",
+			"MachineKey": "mkey:606fb3c7418fe709da5bfee210962c914081d65c241e771537e1440a751f0e1f",
+			"Peers": [{
+				"ID":         4778158905084370,
+				"StableID":   "nZCYQf83Ke11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b12938f529d15fbf7d733b3263f58bcbbebdaa79ce6c0adfcf6e58af4d822f66",
+				"DiscoKey":   "discokey:4af2342ba570ea1376a026f9630159b9cd96e50cbf033e703570d1d84be3546a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45163",
+					"10.65.0.27:45163",
+					"172.17.0.1:45163",
+					"172.18.0.1:45163",
+					"172.19.0.1:45163"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:03:02.856579649Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2172641053472854,
+				"StableID":   "nfs43bbzxH11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4c84d05352d371ad043bc87e8f2d28f563252370377da246f302e100ea61ea6d",
+				"DiscoKey":   "discokey:211d89d048dd9d58210fbc1b622dfcb170bca56500fbc6d0d3ac4cdd5ea98242",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:36639",
+					"10.65.0.27:36639",
+					"172.17.0.1:36639",
+					"172.18.0.1:36639",
+					"172.19.0.1:36639"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:03:03.38550291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4061196893810790,
+				"StableID":   "n3wFbqkKiY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:beda62eec575c69f5fd8f1bed233e197c192a6bef31c9c116235a332a482951b",
+				"DiscoKey":   "discokey:19b29be938553471d08ef741decbb39ca65862c90b6a730e371f1a552dce0f4a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:47517",
+					"10.65.0.27:47517",
+					"172.17.0.1:47517",
+					"172.18.0.1:47517",
+					"172.19.0.1:47517"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:03:03.928154443Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6671352957763120,
+				"StableID":   "nqHMuW8U6u11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36e371fb3c9e4ac8a77a8cccf18c4fa3164c05506b54ef5c3147744658b8ca3f",
+				"DiscoKey":   "discokey:6bfa46a58e1ca58c16dd3ef791cf0e59c5c585146d97e7b4e027e98d5769eb56",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50002",
+					"10.65.0.27:50002",
+					"172.17.0.1:50002",
+					"172.18.0.1:50002",
+					"172.19.0.1:50002"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:03:04.445919611Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         42066960161177,
+				"StableID":   "n23eDc24L111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:42844900b63a91c6cace6dd1ae46369a66c7ba55c1b19d879077b08925695a3c",
+				"DiscoKey":   "discokey:e025acbe1b236d708147009580579b3d44c65b33b6f31b99f1b4f5b59b082b39",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60998",
+					"10.65.0.27:60998",
+					"172.17.0.1:60998",
+					"172.18.0.1:60998",
+					"172.19.0.1:60998"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:03:04.996615062Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6125617552030490,
+				"StableID":   "ndz6tyaJqp11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c37891f42fb341b8e44de97fe5d5e919c3394a947313611b10fa5da6302f1a13",
+				"DiscoKey":   "discokey:d8f354e76db850e10e85c9ea85644c393e07a72d7160b65338a9a9c47d0da117",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38316",
+					"10.65.0.27:38316",
+					"172.17.0.1:38316",
+					"172.18.0.1:38316",
+					"172.19.0.1:38316"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:03:05.54511894Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3315845349970036,
+				"StableID":   "nVuszodktS11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f2d09dad73c4523333e6a42d492d94c88f7cbdf269b0a64b224189743dcff16",
+				"DiscoKey":   "discokey:d71a00863bf303b5cba78cd33f4ec19445bf489a76f7bb1928afac55e4ccdb4b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:42927",
+					"10.65.0.27:42927",
+					"172.17.0.1:42927",
+					"172.18.0.1:42927",
+					"172.19.0.1:42927"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:03:06.08455374Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8687519876479277,
+				"StableID":   "nGzGU7RbqA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06feede0aff475c4a0dd8f7e12d039e770e7d9a6840d4fc6bc00a9985fc4234e",
+				"DiscoKey":   "discokey:9848fed6433809f9ef64e2958c89b4cc36c857da63c5845d431f455c494a835b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55181",
+					"10.65.0.27:55181",
+					"172.17.0.1:55181",
+					"172.18.0.1:55181",
+					"172.19.0.1:55181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:03:06.635927155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5970190537324052,
+				"StableID":   "nPevpLnuco11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:083a1f83474173976cea8e57bab4d67e91921c2b3320b4feb0da6f6e920de83b",
+				"DiscoKey":   "discokey:580248f1a360bca5a61367e909ac8004f35330db13e5e54d15634e51fe82dc3a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43425",
+					"10.65.0.27:43425",
+					"172.17.0.1:43425",
+					"172.18.0.1:43425",
+					"172.19.0.1:43425"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:03:07.169035609Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         352782644637908,
+				"StableID":   "nm53G71nk311CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f1faef0a6bd6230059c858ec5d7da3e0637a1f539cb9cf6fd47e3ff5cafbe744",
+				"DiscoKey":   "discokey:9058d2eacd888d924c49658912eaf750f1f0a4034652ccc573eba7f4f5519269",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38143",
+					"10.65.0.27:38143",
+					"172.17.0.1:38143",
+					"172.18.0.1:38143",
+					"172.19.0.1:38143"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:03:08.229088305Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6468258047135598,
+				"StableID":   "n9Ak7uAVWs11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2567ad955d8d9480c8eb2bdb75126c4c8c07cac2fa48cd297107ef8f5dfb5202",
+				"DiscoKey":   "discokey:8d87bdd3eb8f636dc5b0ed189a9fcb22e5dbd680e94d7014df58c492aef68851",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:53616",
+					"10.65.0.27:53616",
+					"172.17.0.1:53616",
+					"172.18.0.1:53616",
+					"172.19.0.1:53616"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:03:08.777000304Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1095631849851761,
+				"StableID":   "nzVskfPDZ911CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:778136e5cde9ab4473bac5ae3e8722d09e28cee4ace175b71a1b4968f71dd835",
+				"KeyExpiry":  "2026-11-08T22:03:09Z",
+				"DiscoKey":   "discokey:e2af5b491e9547acd5618c1a88913ffa728c58e7e54f379fafb4203d015e2748",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33885",
+					"10.65.0.27:33885",
+					"172.17.0.1:33885",
+					"172.18.0.1:33885",
+					"172.19.0.1:33885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:03:09.314902662Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1082080724716970,
+				"StableID":   "n73TEhR5T911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bfddb154be3386c7d4265aeca1bd5da166ac968d358d7ed988cd832e58b81171",
+				"KeyExpiry":  "2026-11-08T22:03:09Z",
+				"DiscoKey":   "discokey:0d22c786f7f56f8ff96761be9611813da9a9254d0ccd8f372ccf069d4863cd37",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54017",
+					"10.65.0.27:54017",
+					"172.17.0.1:54017",
+					"172.18.0.1:54017",
+					"172.19.0.1:54017"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:03:09.880456695Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4524054647650237,
+				"StableID":   "nARJKAFxKc11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:09de103cb3e0bbc1ce13c31099e8f461b3a3d9f706985854d8dd518b12215336",
+				"KeyExpiry":  "2026-11-08T22:03:10Z",
+				"DiscoKey":   "discokey:676db65ee4334151bdd191cb6327fbdd30b0eb2198e3b86dfdeda58147d1ac22",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56478",
+					"10.65.0.27:56478",
+					"172.17.0.1:56478",
+					"172.18.0.1:56478",
+					"172.19.0.1:56478"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:03:10.408295152Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5830946875491225": {
+				"ID":          5830946875491225,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-user-autogroup-tagged.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-user-autogroup-tagged.hujson
@@ -1,0 +1,20112 @@
+// ssh-malformed-user-autogroup-tagged
+//
+// ssh users autogroup:tagged is rejected
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T22:03:55Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-malformed-user-autogroup-tagged",
+	"description":    "ssh users autogroup:tagged is rejected",
+	"category":       "ssh",
+	"captured_at":    "2026-05-12T22:03:55.584723768Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                      \n  \n                                                                               \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh users autogroup:tagged is rejected\",\n\t\"id\":          \"ssh-malformed-user-autogroup-tagged\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"autogroup:member\"],\n\t\t\"users\":  [\"autogroup:tagged\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-malformed/ssh-malformed-user-autogroup-tagged.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["autogroup:member"],
+				"users":  ["autogroup:tagged"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8866242676376056,
+				"StableID":   "nVToHKAYEC21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       8866242676376056,
+				"Key":        "nodekey:95e3dbacf62755330755f826c88d014a853c8835b8920072b28f3ff0cd136710",
+				"DiscoKey":   "discokey:153357c13f1f53e0d3f3269a37ac764a867d8d8726eeae558b4412b744f2c71c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38980",
+					"10.65.0.27:38980",
+					"172.17.0.1:38980",
+					"172.18.0.1:38980",
+					"172.19.0.1:38980"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:04:03.878870759Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:95e3dbacf62755330755f826c88d014a853c8835b8920072b28f3ff0cd136710",
+			"MachineKey": "mkey:4ac0f65d88ad177e79d7e2a07ed55756a12a819fd6b2604972e0586ca9225f27",
+			"Peers": [{
+				"ID":         8491222439515493,
+				"StableID":   "nAfy9s1hJ921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a240ab1f30785a49487e8f631b2192606c0f23f27a10de9b2e6050e56ac2603f",
+				"DiscoKey":   "discokey:b55fc0ee30a8d53ae363b92e404b08a6e1d4c343a92db2601e641cc959db730c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51655",
+					"10.65.0.27:51655",
+					"172.17.0.1:51655",
+					"172.18.0.1:51655",
+					"172.19.0.1:51655"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:03:57.981490233Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1649779838257168,
+				"StableID":   "nBSGuHvBtD11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ed82f0bc56f1691dac775139df3d1b81054000256b33c36eb71a3f6d59aac314",
+				"DiscoKey":   "discokey:c5ddb995ebafe4e65d5398a2a5218ecc595e1fb087741145f1d669396c6ec54a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50852",
+					"10.65.0.27:50852",
+					"172.17.0.1:50852",
+					"172.18.0.1:50852",
+					"172.19.0.1:50852"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:03:58.513893559Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6460500195375200,
+				"StableID":   "nhHfKLPySs11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c9b7f3aa9137d86e9e581a333156b9f71f1595f3ab93d8b2f94bfc5faf2b442",
+				"DiscoKey":   "discokey:c0ab93eb7e80f4ca3fc343d583b7aa27d1b1d42a94e4efec0cab382c1f200973",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53292",
+					"10.65.0.27:53292",
+					"172.17.0.1:53292",
+					"172.18.0.1:53292",
+					"172.19.0.1:53292"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:03:59.054539587Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4699682252504473,
+				"StableID":   "nQiBMegVhd11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8eb1f3676dd52658c117adde1a1ce03b3742fc6db3dc6546b34c8bfa5645aa35",
+				"DiscoKey":   "discokey:949690936a61f5740f6c231c648e868c2c3117ced778b5bce53caeb5df92b948",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:57430",
+					"10.65.0.27:57430",
+					"172.17.0.1:57430",
+					"172.18.0.1:57430",
+					"172.19.0.1:57430"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:03:59.581193274Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5398422059704600,
+				"StableID":   "n11XPpPx9j11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f786f74d4866ef6b8c6269033234f75d36fcbb90fd9235562c2377a02bccec35",
+				"DiscoKey":   "discokey:a1222c706ae20a079e83f58afeb95fc602c3c648c0f60065329958116fab162b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53894",
+					"10.65.0.27:53894",
+					"172.17.0.1:53894",
+					"172.18.0.1:53894",
+					"172.19.0.1:53894"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:04:00.135369653Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         398959213778801,
+				"StableID":   "nGAuYxyg7411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d35f6094eba879b47aae60bce1aa68eefe790f832e92e5005f09c6d3f0ca943c",
+				"DiscoKey":   "discokey:f426dda1645acee84f93db80ce28bb9088848433ce8843cb7376cbce7db09e0c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42975",
+					"10.65.0.27:42975",
+					"172.17.0.1:42975",
+					"172.18.0.1:42975",
+					"172.19.0.1:42975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:04:00.658057485Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2905948770773974,
+				"StableID":   "nPHKv6M7hP11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6dee1baf569b9966220c396858582fa17635c7f0ce006a4da0fdf2293e0f283d",
+				"DiscoKey":   "discokey:dcb28492cc1944032a812cf5cae4e3c407e1812734207672adc578458c04df02",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38318",
+					"10.65.0.27:38318",
+					"172.17.0.1:38318",
+					"172.18.0.1:38318",
+					"172.19.0.1:38318"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:04:01.198696031Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4562310105883451,
+				"StableID":   "n41HAi9Hdc11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c69894c28fd36600c7af37652e843e935c6b677b005a88d64f4ef6f5549638",
+				"DiscoKey":   "discokey:1247c5557ee0f9d21d46dab8eeffd9e5066b61c7b86e4f3d476f261aeb125872",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54560",
+					"10.65.0.27:54560",
+					"172.17.0.1:54560",
+					"172.18.0.1:54560",
+					"172.19.0.1:54560"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:04:01.729212942Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7768936078060628,
+				"StableID":   "n15Jk4nZf321CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:166e4f8d0176bfe04154af2cfcf3ca4e7f2f4efb28adc810de001e953ed0e931",
+				"DiscoKey":   "discokey:0222a393efb07131e7252e209d3fec4b02a4a82593dae27c8235bba2bddb286d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34815",
+					"10.65.0.27:34815",
+					"172.17.0.1:34815",
+					"172.18.0.1:34815",
+					"172.19.0.1:34815"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:04:02.26957766Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2601977946505300,
+				"StableID":   "n1hW5pYSKM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:605ffdb39ccdd629bf5b7c5f1d0ad17ba876ffad98cdfa985a929d0e6448610e",
+				"DiscoKey":   "discokey:d077a9992c2bb70b9c94c3ce29f6d8eecd1433b9c9187d141a88f7ce8680bf23",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52277",
+					"10.65.0.27:52277",
+					"172.17.0.1:52277",
+					"172.18.0.1:52277",
+					"172.19.0.1:52277"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:04:02.864339895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7256259790599196,
+				"StableID":   "n5RTo8eNfy11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:314ac8266cda6ea00529453da3f9134c72ac1b5d32a98bdcb022ea6c1760d36a",
+				"DiscoKey":   "discokey:5fb7f0056678e4ef9a5e7a14613d5ca9bacc93fb6d19f0d6cba3ccf7347ba935",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37358",
+					"10.65.0.27:37358",
+					"172.17.0.1:37358",
+					"172.18.0.1:37358",
+					"172.19.0.1:37358"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:04:03.366226325Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4183096974344498,
+				"StableID":   "nHaFH8sXfZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:9d13d918f3d1667ba114de999f3488a12aeba0e1eb3f98d21aa4273370571825",
+				"KeyExpiry":  "2026-11-08T22:04:04Z",
+				"DiscoKey":   "discokey:c5a10e0e2aace4be32efb41204a48c6e5742c244f797a1f42b21b2e09fcb104c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52565",
+					"10.65.0.27:52565",
+					"172.17.0.1:52565",
+					"172.18.0.1:52565",
+					"172.19.0.1:52565"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:04:04.410786066Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1143258373116122,
+				"StableID":   "noqcXcTnv911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:56ce887d809a311cab53e0de6d15e6344974e43021fbb52918e9b4a6fb8a011f",
+				"KeyExpiry":  "2026-11-08T22:04:04Z",
+				"DiscoKey":   "discokey:8a27a7485193808a62e44fedf19f31f28113ea13b0bb827f7d61a9253499035c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:56489",
+					"10.65.0.27:56489",
+					"172.17.0.1:56489",
+					"172.18.0.1:56489",
+					"172.19.0.1:56489"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:04:04.955311027Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         596461305159325,
+				"StableID":   "nG4y3a29f511CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:891e465b69ae1cf5562e9ff2e0473b49747bce485eace73f48775fd70f861b35",
+				"KeyExpiry":  "2026-11-08T22:04:05Z",
+				"DiscoKey":   "discokey:93a1a49309e8858bd88f2037776bcd02def0a08372e1fb869da8ff778be30b22",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58364",
+					"10.65.0.27:58364",
+					"172.17.0.1:58364",
+					"172.18.0.1:58364",
+					"172.19.0.1:58364"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:04:05.485132805Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{
+				"principals": [
+					{"nodeIP": "100.64.0.17"},
+					{"nodeIP": "100.64.0.18"},
+					{"nodeIP": "100.64.0.19"},
+					{"nodeIP": "fd7a:115c:a1e0::11"},
+					{"nodeIP": "fd7a:115c:a1e0::13"},
+					{"nodeIP": "fd7a:115c:a1e0::12"}
+				],
+				"sshUsers": {"autogroup:tagged": "autogroup:tagged", "root": ""},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				}
+			}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8866242676376056": {
+				"ID":          8866242676376056,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		},
+		"ssh_rules": [{
+			"principals": [
+				{"nodeIP": "100.64.0.17"},
+				{"nodeIP": "100.64.0.18"},
+				{"nodeIP": "100.64.0.19"},
+				{"nodeIP": "fd7a:115c:a1e0::11"},
+				{"nodeIP": "fd7a:115c:a1e0::13"},
+				{"nodeIP": "fd7a:115c:a1e0::12"}
+			],
+			"sshUsers": {"autogroup:tagged": "autogroup:tagged", "root": ""},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}
+		}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         398959213778801,
+				"StableID":   "nGAuYxyg7411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       398959213778801,
+				"Key":        "nodekey:d35f6094eba879b47aae60bce1aa68eefe790f832e92e5005f09c6d3f0ca943c",
+				"DiscoKey":   "discokey:f426dda1645acee84f93db80ce28bb9088848433ce8843cb7376cbce7db09e0c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42975",
+					"10.65.0.27:42975",
+					"172.17.0.1:42975",
+					"172.18.0.1:42975",
+					"172.19.0.1:42975"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:04:00.658057485Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d35f6094eba879b47aae60bce1aa68eefe790f832e92e5005f09c6d3f0ca943c",
+			"MachineKey": "mkey:7b88699c1a2d0c0be68c00697e6f4c9053d96a8eef18c935fcb64692d3abef79",
+			"Peers": [{
+				"ID":         8491222439515493,
+				"StableID":   "nAfy9s1hJ921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a240ab1f30785a49487e8f631b2192606c0f23f27a10de9b2e6050e56ac2603f",
+				"DiscoKey":   "discokey:b55fc0ee30a8d53ae363b92e404b08a6e1d4c343a92db2601e641cc959db730c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51655",
+					"10.65.0.27:51655",
+					"172.17.0.1:51655",
+					"172.18.0.1:51655",
+					"172.19.0.1:51655"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:03:57.981490233Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1649779838257168,
+				"StableID":   "nBSGuHvBtD11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ed82f0bc56f1691dac775139df3d1b81054000256b33c36eb71a3f6d59aac314",
+				"DiscoKey":   "discokey:c5ddb995ebafe4e65d5398a2a5218ecc595e1fb087741145f1d669396c6ec54a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50852",
+					"10.65.0.27:50852",
+					"172.17.0.1:50852",
+					"172.18.0.1:50852",
+					"172.19.0.1:50852"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:03:58.513893559Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6460500195375200,
+				"StableID":   "nhHfKLPySs11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c9b7f3aa9137d86e9e581a333156b9f71f1595f3ab93d8b2f94bfc5faf2b442",
+				"DiscoKey":   "discokey:c0ab93eb7e80f4ca3fc343d583b7aa27d1b1d42a94e4efec0cab382c1f200973",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53292",
+					"10.65.0.27:53292",
+					"172.17.0.1:53292",
+					"172.18.0.1:53292",
+					"172.19.0.1:53292"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:03:59.054539587Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4699682252504473,
+				"StableID":   "nQiBMegVhd11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8eb1f3676dd52658c117adde1a1ce03b3742fc6db3dc6546b34c8bfa5645aa35",
+				"DiscoKey":   "discokey:949690936a61f5740f6c231c648e868c2c3117ced778b5bce53caeb5df92b948",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:57430",
+					"10.65.0.27:57430",
+					"172.17.0.1:57430",
+					"172.18.0.1:57430",
+					"172.19.0.1:57430"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:03:59.581193274Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5398422059704600,
+				"StableID":   "n11XPpPx9j11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f786f74d4866ef6b8c6269033234f75d36fcbb90fd9235562c2377a02bccec35",
+				"DiscoKey":   "discokey:a1222c706ae20a079e83f58afeb95fc602c3c648c0f60065329958116fab162b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53894",
+					"10.65.0.27:53894",
+					"172.17.0.1:53894",
+					"172.18.0.1:53894",
+					"172.19.0.1:53894"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:04:00.135369653Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2905948770773974,
+				"StableID":   "nPHKv6M7hP11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6dee1baf569b9966220c396858582fa17635c7f0ce006a4da0fdf2293e0f283d",
+				"DiscoKey":   "discokey:dcb28492cc1944032a812cf5cae4e3c407e1812734207672adc578458c04df02",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38318",
+					"10.65.0.27:38318",
+					"172.17.0.1:38318",
+					"172.18.0.1:38318",
+					"172.19.0.1:38318"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:04:01.198696031Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4562310105883451,
+				"StableID":   "n41HAi9Hdc11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c69894c28fd36600c7af37652e843e935c6b677b005a88d64f4ef6f5549638",
+				"DiscoKey":   "discokey:1247c5557ee0f9d21d46dab8eeffd9e5066b61c7b86e4f3d476f261aeb125872",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54560",
+					"10.65.0.27:54560",
+					"172.17.0.1:54560",
+					"172.18.0.1:54560",
+					"172.19.0.1:54560"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:04:01.729212942Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7768936078060628,
+				"StableID":   "n15Jk4nZf321CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:166e4f8d0176bfe04154af2cfcf3ca4e7f2f4efb28adc810de001e953ed0e931",
+				"DiscoKey":   "discokey:0222a393efb07131e7252e209d3fec4b02a4a82593dae27c8235bba2bddb286d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34815",
+					"10.65.0.27:34815",
+					"172.17.0.1:34815",
+					"172.18.0.1:34815",
+					"172.19.0.1:34815"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:04:02.26957766Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2601977946505300,
+				"StableID":   "n1hW5pYSKM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:605ffdb39ccdd629bf5b7c5f1d0ad17ba876ffad98cdfa985a929d0e6448610e",
+				"DiscoKey":   "discokey:d077a9992c2bb70b9c94c3ce29f6d8eecd1433b9c9187d141a88f7ce8680bf23",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52277",
+					"10.65.0.27:52277",
+					"172.17.0.1:52277",
+					"172.18.0.1:52277",
+					"172.19.0.1:52277"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:04:02.864339895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7256259790599196,
+				"StableID":   "n5RTo8eNfy11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:314ac8266cda6ea00529453da3f9134c72ac1b5d32a98bdcb022ea6c1760d36a",
+				"DiscoKey":   "discokey:5fb7f0056678e4ef9a5e7a14613d5ca9bacc93fb6d19f0d6cba3ccf7347ba935",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37358",
+					"10.65.0.27:37358",
+					"172.17.0.1:37358",
+					"172.18.0.1:37358",
+					"172.19.0.1:37358"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:04:03.366226325Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8866242676376056,
+				"StableID":   "nVToHKAYEC21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95e3dbacf62755330755f826c88d014a853c8835b8920072b28f3ff0cd136710",
+				"DiscoKey":   "discokey:153357c13f1f53e0d3f3269a37ac764a867d8d8726eeae558b4412b744f2c71c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38980",
+					"10.65.0.27:38980",
+					"172.17.0.1:38980",
+					"172.18.0.1:38980",
+					"172.19.0.1:38980"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:04:03.878870759Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4183096974344498,
+				"StableID":   "nHaFH8sXfZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:9d13d918f3d1667ba114de999f3488a12aeba0e1eb3f98d21aa4273370571825",
+				"KeyExpiry":  "2026-11-08T22:04:04Z",
+				"DiscoKey":   "discokey:c5a10e0e2aace4be32efb41204a48c6e5742c244f797a1f42b21b2e09fcb104c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52565",
+					"10.65.0.27:52565",
+					"172.17.0.1:52565",
+					"172.18.0.1:52565",
+					"172.19.0.1:52565"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:04:04.410786066Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1143258373116122,
+				"StableID":   "noqcXcTnv911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:56ce887d809a311cab53e0de6d15e6344974e43021fbb52918e9b4a6fb8a011f",
+				"KeyExpiry":  "2026-11-08T22:04:04Z",
+				"DiscoKey":   "discokey:8a27a7485193808a62e44fedf19f31f28113ea13b0bb827f7d61a9253499035c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:56489",
+					"10.65.0.27:56489",
+					"172.17.0.1:56489",
+					"172.18.0.1:56489",
+					"172.19.0.1:56489"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:04:04.955311027Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         596461305159325,
+				"StableID":   "nG4y3a29f511CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:891e465b69ae1cf5562e9ff2e0473b49747bce485eace73f48775fd70f861b35",
+				"KeyExpiry":  "2026-11-08T22:04:05Z",
+				"DiscoKey":   "discokey:93a1a49309e8858bd88f2037776bcd02def0a08372e1fb869da8ff778be30b22",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58364",
+					"10.65.0.27:58364",
+					"172.17.0.1:58364",
+					"172.18.0.1:58364",
+					"172.19.0.1:58364"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:04:05.485132805Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "398959213778801": {
+				"ID":          398959213778801,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         596461305159325,
+				"StableID":   "nG4y3a29f511CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:891e465b69ae1cf5562e9ff2e0473b49747bce485eace73f48775fd70f861b35",
+				"KeyExpiry":  "2026-11-08T22:04:05Z",
+				"DiscoKey":   "discokey:93a1a49309e8858bd88f2037776bcd02def0a08372e1fb869da8ff778be30b22",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58364",
+					"10.65.0.27:58364",
+					"172.17.0.1:58364",
+					"172.18.0.1:58364",
+					"172.19.0.1:58364"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:04:05.485132805Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:891e465b69ae1cf5562e9ff2e0473b49747bce485eace73f48775fd70f861b35",
+			"MachineKey": "mkey:ad3c0014341fe5b5c0054e99a7cdab8d5bf1a5e4faee74a4f821ea1e2dc1f47a",
+			"Peers": [{
+				"ID":         8491222439515493,
+				"StableID":   "nAfy9s1hJ921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a240ab1f30785a49487e8f631b2192606c0f23f27a10de9b2e6050e56ac2603f",
+				"DiscoKey":   "discokey:b55fc0ee30a8d53ae363b92e404b08a6e1d4c343a92db2601e641cc959db730c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51655",
+					"10.65.0.27:51655",
+					"172.17.0.1:51655",
+					"172.18.0.1:51655",
+					"172.19.0.1:51655"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:03:57.981490233Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1649779838257168,
+				"StableID":   "nBSGuHvBtD11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ed82f0bc56f1691dac775139df3d1b81054000256b33c36eb71a3f6d59aac314",
+				"DiscoKey":   "discokey:c5ddb995ebafe4e65d5398a2a5218ecc595e1fb087741145f1d669396c6ec54a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50852",
+					"10.65.0.27:50852",
+					"172.17.0.1:50852",
+					"172.18.0.1:50852",
+					"172.19.0.1:50852"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:03:58.513893559Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6460500195375200,
+				"StableID":   "nhHfKLPySs11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c9b7f3aa9137d86e9e581a333156b9f71f1595f3ab93d8b2f94bfc5faf2b442",
+				"DiscoKey":   "discokey:c0ab93eb7e80f4ca3fc343d583b7aa27d1b1d42a94e4efec0cab382c1f200973",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53292",
+					"10.65.0.27:53292",
+					"172.17.0.1:53292",
+					"172.18.0.1:53292",
+					"172.19.0.1:53292"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:03:59.054539587Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4699682252504473,
+				"StableID":   "nQiBMegVhd11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8eb1f3676dd52658c117adde1a1ce03b3742fc6db3dc6546b34c8bfa5645aa35",
+				"DiscoKey":   "discokey:949690936a61f5740f6c231c648e868c2c3117ced778b5bce53caeb5df92b948",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:57430",
+					"10.65.0.27:57430",
+					"172.17.0.1:57430",
+					"172.18.0.1:57430",
+					"172.19.0.1:57430"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:03:59.581193274Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5398422059704600,
+				"StableID":   "n11XPpPx9j11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f786f74d4866ef6b8c6269033234f75d36fcbb90fd9235562c2377a02bccec35",
+				"DiscoKey":   "discokey:a1222c706ae20a079e83f58afeb95fc602c3c648c0f60065329958116fab162b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53894",
+					"10.65.0.27:53894",
+					"172.17.0.1:53894",
+					"172.18.0.1:53894",
+					"172.19.0.1:53894"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:04:00.135369653Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         398959213778801,
+				"StableID":   "nGAuYxyg7411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d35f6094eba879b47aae60bce1aa68eefe790f832e92e5005f09c6d3f0ca943c",
+				"DiscoKey":   "discokey:f426dda1645acee84f93db80ce28bb9088848433ce8843cb7376cbce7db09e0c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42975",
+					"10.65.0.27:42975",
+					"172.17.0.1:42975",
+					"172.18.0.1:42975",
+					"172.19.0.1:42975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:04:00.658057485Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2905948770773974,
+				"StableID":   "nPHKv6M7hP11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6dee1baf569b9966220c396858582fa17635c7f0ce006a4da0fdf2293e0f283d",
+				"DiscoKey":   "discokey:dcb28492cc1944032a812cf5cae4e3c407e1812734207672adc578458c04df02",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38318",
+					"10.65.0.27:38318",
+					"172.17.0.1:38318",
+					"172.18.0.1:38318",
+					"172.19.0.1:38318"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:04:01.198696031Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4562310105883451,
+				"StableID":   "n41HAi9Hdc11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c69894c28fd36600c7af37652e843e935c6b677b005a88d64f4ef6f5549638",
+				"DiscoKey":   "discokey:1247c5557ee0f9d21d46dab8eeffd9e5066b61c7b86e4f3d476f261aeb125872",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54560",
+					"10.65.0.27:54560",
+					"172.17.0.1:54560",
+					"172.18.0.1:54560",
+					"172.19.0.1:54560"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:04:01.729212942Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7768936078060628,
+				"StableID":   "n15Jk4nZf321CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:166e4f8d0176bfe04154af2cfcf3ca4e7f2f4efb28adc810de001e953ed0e931",
+				"DiscoKey":   "discokey:0222a393efb07131e7252e209d3fec4b02a4a82593dae27c8235bba2bddb286d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34815",
+					"10.65.0.27:34815",
+					"172.17.0.1:34815",
+					"172.18.0.1:34815",
+					"172.19.0.1:34815"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:04:02.26957766Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2601977946505300,
+				"StableID":   "n1hW5pYSKM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:605ffdb39ccdd629bf5b7c5f1d0ad17ba876ffad98cdfa985a929d0e6448610e",
+				"DiscoKey":   "discokey:d077a9992c2bb70b9c94c3ce29f6d8eecd1433b9c9187d141a88f7ce8680bf23",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52277",
+					"10.65.0.27:52277",
+					"172.17.0.1:52277",
+					"172.18.0.1:52277",
+					"172.19.0.1:52277"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:04:02.864339895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7256259790599196,
+				"StableID":   "n5RTo8eNfy11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:314ac8266cda6ea00529453da3f9134c72ac1b5d32a98bdcb022ea6c1760d36a",
+				"DiscoKey":   "discokey:5fb7f0056678e4ef9a5e7a14613d5ca9bacc93fb6d19f0d6cba3ccf7347ba935",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37358",
+					"10.65.0.27:37358",
+					"172.17.0.1:37358",
+					"172.18.0.1:37358",
+					"172.19.0.1:37358"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:04:03.366226325Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8866242676376056,
+				"StableID":   "nVToHKAYEC21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95e3dbacf62755330755f826c88d014a853c8835b8920072b28f3ff0cd136710",
+				"DiscoKey":   "discokey:153357c13f1f53e0d3f3269a37ac764a867d8d8726eeae558b4412b744f2c71c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38980",
+					"10.65.0.27:38980",
+					"172.17.0.1:38980",
+					"172.18.0.1:38980",
+					"172.19.0.1:38980"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:04:03.878870759Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4183096974344498,
+				"StableID":   "nHaFH8sXfZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:9d13d918f3d1667ba114de999f3488a12aeba0e1eb3f98d21aa4273370571825",
+				"KeyExpiry":  "2026-11-08T22:04:04Z",
+				"DiscoKey":   "discokey:c5a10e0e2aace4be32efb41204a48c6e5742c244f797a1f42b21b2e09fcb104c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52565",
+					"10.65.0.27:52565",
+					"172.17.0.1:52565",
+					"172.18.0.1:52565",
+					"172.19.0.1:52565"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:04:04.410786066Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1143258373116122,
+				"StableID":   "noqcXcTnv911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:56ce887d809a311cab53e0de6d15e6344974e43021fbb52918e9b4a6fb8a011f",
+				"KeyExpiry":  "2026-11-08T22:04:04Z",
+				"DiscoKey":   "discokey:8a27a7485193808a62e44fedf19f31f28113ea13b0bb827f7d61a9253499035c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:56489",
+					"10.65.0.27:56489",
+					"172.17.0.1:56489",
+					"172.18.0.1:56489",
+					"172.19.0.1:56489"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:04:04.955311027Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6460500195375200,
+				"StableID":   "nhHfKLPySs11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       6460500195375200,
+				"Key":        "nodekey:5c9b7f3aa9137d86e9e581a333156b9f71f1595f3ab93d8b2f94bfc5faf2b442",
+				"DiscoKey":   "discokey:c0ab93eb7e80f4ca3fc343d583b7aa27d1b1d42a94e4efec0cab382c1f200973",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53292",
+					"10.65.0.27:53292",
+					"172.17.0.1:53292",
+					"172.18.0.1:53292",
+					"172.19.0.1:53292"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:03:59.054539587Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5c9b7f3aa9137d86e9e581a333156b9f71f1595f3ab93d8b2f94bfc5faf2b442",
+			"MachineKey": "mkey:ac496a5ccd80a8ffbb1ba8317433999e079c573635171e83206b84dd634f7f6f",
+			"Peers": [{
+				"ID":         8491222439515493,
+				"StableID":   "nAfy9s1hJ921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a240ab1f30785a49487e8f631b2192606c0f23f27a10de9b2e6050e56ac2603f",
+				"DiscoKey":   "discokey:b55fc0ee30a8d53ae363b92e404b08a6e1d4c343a92db2601e641cc959db730c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51655",
+					"10.65.0.27:51655",
+					"172.17.0.1:51655",
+					"172.18.0.1:51655",
+					"172.19.0.1:51655"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:03:57.981490233Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1649779838257168,
+				"StableID":   "nBSGuHvBtD11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ed82f0bc56f1691dac775139df3d1b81054000256b33c36eb71a3f6d59aac314",
+				"DiscoKey":   "discokey:c5ddb995ebafe4e65d5398a2a5218ecc595e1fb087741145f1d669396c6ec54a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50852",
+					"10.65.0.27:50852",
+					"172.17.0.1:50852",
+					"172.18.0.1:50852",
+					"172.19.0.1:50852"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:03:58.513893559Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4699682252504473,
+				"StableID":   "nQiBMegVhd11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8eb1f3676dd52658c117adde1a1ce03b3742fc6db3dc6546b34c8bfa5645aa35",
+				"DiscoKey":   "discokey:949690936a61f5740f6c231c648e868c2c3117ced778b5bce53caeb5df92b948",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:57430",
+					"10.65.0.27:57430",
+					"172.17.0.1:57430",
+					"172.18.0.1:57430",
+					"172.19.0.1:57430"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:03:59.581193274Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5398422059704600,
+				"StableID":   "n11XPpPx9j11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f786f74d4866ef6b8c6269033234f75d36fcbb90fd9235562c2377a02bccec35",
+				"DiscoKey":   "discokey:a1222c706ae20a079e83f58afeb95fc602c3c648c0f60065329958116fab162b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53894",
+					"10.65.0.27:53894",
+					"172.17.0.1:53894",
+					"172.18.0.1:53894",
+					"172.19.0.1:53894"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:04:00.135369653Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         398959213778801,
+				"StableID":   "nGAuYxyg7411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d35f6094eba879b47aae60bce1aa68eefe790f832e92e5005f09c6d3f0ca943c",
+				"DiscoKey":   "discokey:f426dda1645acee84f93db80ce28bb9088848433ce8843cb7376cbce7db09e0c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42975",
+					"10.65.0.27:42975",
+					"172.17.0.1:42975",
+					"172.18.0.1:42975",
+					"172.19.0.1:42975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:04:00.658057485Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2905948770773974,
+				"StableID":   "nPHKv6M7hP11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6dee1baf569b9966220c396858582fa17635c7f0ce006a4da0fdf2293e0f283d",
+				"DiscoKey":   "discokey:dcb28492cc1944032a812cf5cae4e3c407e1812734207672adc578458c04df02",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38318",
+					"10.65.0.27:38318",
+					"172.17.0.1:38318",
+					"172.18.0.1:38318",
+					"172.19.0.1:38318"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:04:01.198696031Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4562310105883451,
+				"StableID":   "n41HAi9Hdc11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c69894c28fd36600c7af37652e843e935c6b677b005a88d64f4ef6f5549638",
+				"DiscoKey":   "discokey:1247c5557ee0f9d21d46dab8eeffd9e5066b61c7b86e4f3d476f261aeb125872",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54560",
+					"10.65.0.27:54560",
+					"172.17.0.1:54560",
+					"172.18.0.1:54560",
+					"172.19.0.1:54560"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:04:01.729212942Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7768936078060628,
+				"StableID":   "n15Jk4nZf321CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:166e4f8d0176bfe04154af2cfcf3ca4e7f2f4efb28adc810de001e953ed0e931",
+				"DiscoKey":   "discokey:0222a393efb07131e7252e209d3fec4b02a4a82593dae27c8235bba2bddb286d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34815",
+					"10.65.0.27:34815",
+					"172.17.0.1:34815",
+					"172.18.0.1:34815",
+					"172.19.0.1:34815"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:04:02.26957766Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2601977946505300,
+				"StableID":   "n1hW5pYSKM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:605ffdb39ccdd629bf5b7c5f1d0ad17ba876ffad98cdfa985a929d0e6448610e",
+				"DiscoKey":   "discokey:d077a9992c2bb70b9c94c3ce29f6d8eecd1433b9c9187d141a88f7ce8680bf23",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52277",
+					"10.65.0.27:52277",
+					"172.17.0.1:52277",
+					"172.18.0.1:52277",
+					"172.19.0.1:52277"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:04:02.864339895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7256259790599196,
+				"StableID":   "n5RTo8eNfy11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:314ac8266cda6ea00529453da3f9134c72ac1b5d32a98bdcb022ea6c1760d36a",
+				"DiscoKey":   "discokey:5fb7f0056678e4ef9a5e7a14613d5ca9bacc93fb6d19f0d6cba3ccf7347ba935",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37358",
+					"10.65.0.27:37358",
+					"172.17.0.1:37358",
+					"172.18.0.1:37358",
+					"172.19.0.1:37358"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:04:03.366226325Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8866242676376056,
+				"StableID":   "nVToHKAYEC21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95e3dbacf62755330755f826c88d014a853c8835b8920072b28f3ff0cd136710",
+				"DiscoKey":   "discokey:153357c13f1f53e0d3f3269a37ac764a867d8d8726eeae558b4412b744f2c71c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38980",
+					"10.65.0.27:38980",
+					"172.17.0.1:38980",
+					"172.18.0.1:38980",
+					"172.19.0.1:38980"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:04:03.878870759Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4183096974344498,
+				"StableID":   "nHaFH8sXfZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:9d13d918f3d1667ba114de999f3488a12aeba0e1eb3f98d21aa4273370571825",
+				"KeyExpiry":  "2026-11-08T22:04:04Z",
+				"DiscoKey":   "discokey:c5a10e0e2aace4be32efb41204a48c6e5742c244f797a1f42b21b2e09fcb104c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52565",
+					"10.65.0.27:52565",
+					"172.17.0.1:52565",
+					"172.18.0.1:52565",
+					"172.19.0.1:52565"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:04:04.410786066Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1143258373116122,
+				"StableID":   "noqcXcTnv911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:56ce887d809a311cab53e0de6d15e6344974e43021fbb52918e9b4a6fb8a011f",
+				"KeyExpiry":  "2026-11-08T22:04:04Z",
+				"DiscoKey":   "discokey:8a27a7485193808a62e44fedf19f31f28113ea13b0bb827f7d61a9253499035c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:56489",
+					"10.65.0.27:56489",
+					"172.17.0.1:56489",
+					"172.18.0.1:56489",
+					"172.19.0.1:56489"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:04:04.955311027Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         596461305159325,
+				"StableID":   "nG4y3a29f511CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:891e465b69ae1cf5562e9ff2e0473b49747bce485eace73f48775fd70f861b35",
+				"KeyExpiry":  "2026-11-08T22:04:05Z",
+				"DiscoKey":   "discokey:93a1a49309e8858bd88f2037776bcd02def0a08372e1fb869da8ff778be30b22",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58364",
+					"10.65.0.27:58364",
+					"172.17.0.1:58364",
+					"172.18.0.1:58364",
+					"172.19.0.1:58364"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:04:05.485132805Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6460500195375200": {
+				"ID":          6460500195375200,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4562310105883451,
+				"StableID":   "n41HAi9Hdc11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       4562310105883451,
+				"Key":        "nodekey:07c69894c28fd36600c7af37652e843e935c6b677b005a88d64f4ef6f5549638",
+				"DiscoKey":   "discokey:1247c5557ee0f9d21d46dab8eeffd9e5066b61c7b86e4f3d476f261aeb125872",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54560",
+					"10.65.0.27:54560",
+					"172.17.0.1:54560",
+					"172.18.0.1:54560",
+					"172.19.0.1:54560"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:04:01.729212942Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:07c69894c28fd36600c7af37652e843e935c6b677b005a88d64f4ef6f5549638",
+			"MachineKey": "mkey:f7d46604d5899a64580e5f7fa83a1bfbf63922bc98a9fe0c0ec582522c3dff5d",
+			"Peers": [{
+				"ID":         8491222439515493,
+				"StableID":   "nAfy9s1hJ921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a240ab1f30785a49487e8f631b2192606c0f23f27a10de9b2e6050e56ac2603f",
+				"DiscoKey":   "discokey:b55fc0ee30a8d53ae363b92e404b08a6e1d4c343a92db2601e641cc959db730c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51655",
+					"10.65.0.27:51655",
+					"172.17.0.1:51655",
+					"172.18.0.1:51655",
+					"172.19.0.1:51655"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:03:57.981490233Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1649779838257168,
+				"StableID":   "nBSGuHvBtD11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ed82f0bc56f1691dac775139df3d1b81054000256b33c36eb71a3f6d59aac314",
+				"DiscoKey":   "discokey:c5ddb995ebafe4e65d5398a2a5218ecc595e1fb087741145f1d669396c6ec54a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50852",
+					"10.65.0.27:50852",
+					"172.17.0.1:50852",
+					"172.18.0.1:50852",
+					"172.19.0.1:50852"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:03:58.513893559Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6460500195375200,
+				"StableID":   "nhHfKLPySs11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c9b7f3aa9137d86e9e581a333156b9f71f1595f3ab93d8b2f94bfc5faf2b442",
+				"DiscoKey":   "discokey:c0ab93eb7e80f4ca3fc343d583b7aa27d1b1d42a94e4efec0cab382c1f200973",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53292",
+					"10.65.0.27:53292",
+					"172.17.0.1:53292",
+					"172.18.0.1:53292",
+					"172.19.0.1:53292"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:03:59.054539587Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4699682252504473,
+				"StableID":   "nQiBMegVhd11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8eb1f3676dd52658c117adde1a1ce03b3742fc6db3dc6546b34c8bfa5645aa35",
+				"DiscoKey":   "discokey:949690936a61f5740f6c231c648e868c2c3117ced778b5bce53caeb5df92b948",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:57430",
+					"10.65.0.27:57430",
+					"172.17.0.1:57430",
+					"172.18.0.1:57430",
+					"172.19.0.1:57430"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:03:59.581193274Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5398422059704600,
+				"StableID":   "n11XPpPx9j11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f786f74d4866ef6b8c6269033234f75d36fcbb90fd9235562c2377a02bccec35",
+				"DiscoKey":   "discokey:a1222c706ae20a079e83f58afeb95fc602c3c648c0f60065329958116fab162b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53894",
+					"10.65.0.27:53894",
+					"172.17.0.1:53894",
+					"172.18.0.1:53894",
+					"172.19.0.1:53894"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:04:00.135369653Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         398959213778801,
+				"StableID":   "nGAuYxyg7411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d35f6094eba879b47aae60bce1aa68eefe790f832e92e5005f09c6d3f0ca943c",
+				"DiscoKey":   "discokey:f426dda1645acee84f93db80ce28bb9088848433ce8843cb7376cbce7db09e0c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42975",
+					"10.65.0.27:42975",
+					"172.17.0.1:42975",
+					"172.18.0.1:42975",
+					"172.19.0.1:42975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:04:00.658057485Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2905948770773974,
+				"StableID":   "nPHKv6M7hP11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6dee1baf569b9966220c396858582fa17635c7f0ce006a4da0fdf2293e0f283d",
+				"DiscoKey":   "discokey:dcb28492cc1944032a812cf5cae4e3c407e1812734207672adc578458c04df02",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38318",
+					"10.65.0.27:38318",
+					"172.17.0.1:38318",
+					"172.18.0.1:38318",
+					"172.19.0.1:38318"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:04:01.198696031Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7768936078060628,
+				"StableID":   "n15Jk4nZf321CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:166e4f8d0176bfe04154af2cfcf3ca4e7f2f4efb28adc810de001e953ed0e931",
+				"DiscoKey":   "discokey:0222a393efb07131e7252e209d3fec4b02a4a82593dae27c8235bba2bddb286d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34815",
+					"10.65.0.27:34815",
+					"172.17.0.1:34815",
+					"172.18.0.1:34815",
+					"172.19.0.1:34815"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:04:02.26957766Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2601977946505300,
+				"StableID":   "n1hW5pYSKM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:605ffdb39ccdd629bf5b7c5f1d0ad17ba876ffad98cdfa985a929d0e6448610e",
+				"DiscoKey":   "discokey:d077a9992c2bb70b9c94c3ce29f6d8eecd1433b9c9187d141a88f7ce8680bf23",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52277",
+					"10.65.0.27:52277",
+					"172.17.0.1:52277",
+					"172.18.0.1:52277",
+					"172.19.0.1:52277"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:04:02.864339895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7256259790599196,
+				"StableID":   "n5RTo8eNfy11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:314ac8266cda6ea00529453da3f9134c72ac1b5d32a98bdcb022ea6c1760d36a",
+				"DiscoKey":   "discokey:5fb7f0056678e4ef9a5e7a14613d5ca9bacc93fb6d19f0d6cba3ccf7347ba935",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37358",
+					"10.65.0.27:37358",
+					"172.17.0.1:37358",
+					"172.18.0.1:37358",
+					"172.19.0.1:37358"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:04:03.366226325Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8866242676376056,
+				"StableID":   "nVToHKAYEC21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95e3dbacf62755330755f826c88d014a853c8835b8920072b28f3ff0cd136710",
+				"DiscoKey":   "discokey:153357c13f1f53e0d3f3269a37ac764a867d8d8726eeae558b4412b744f2c71c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38980",
+					"10.65.0.27:38980",
+					"172.17.0.1:38980",
+					"172.18.0.1:38980",
+					"172.19.0.1:38980"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:04:03.878870759Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4183096974344498,
+				"StableID":   "nHaFH8sXfZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:9d13d918f3d1667ba114de999f3488a12aeba0e1eb3f98d21aa4273370571825",
+				"KeyExpiry":  "2026-11-08T22:04:04Z",
+				"DiscoKey":   "discokey:c5a10e0e2aace4be32efb41204a48c6e5742c244f797a1f42b21b2e09fcb104c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52565",
+					"10.65.0.27:52565",
+					"172.17.0.1:52565",
+					"172.18.0.1:52565",
+					"172.19.0.1:52565"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:04:04.410786066Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1143258373116122,
+				"StableID":   "noqcXcTnv911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:56ce887d809a311cab53e0de6d15e6344974e43021fbb52918e9b4a6fb8a011f",
+				"KeyExpiry":  "2026-11-08T22:04:04Z",
+				"DiscoKey":   "discokey:8a27a7485193808a62e44fedf19f31f28113ea13b0bb827f7d61a9253499035c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:56489",
+					"10.65.0.27:56489",
+					"172.17.0.1:56489",
+					"172.18.0.1:56489",
+					"172.19.0.1:56489"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:04:04.955311027Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         596461305159325,
+				"StableID":   "nG4y3a29f511CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:891e465b69ae1cf5562e9ff2e0473b49747bce485eace73f48775fd70f861b35",
+				"KeyExpiry":  "2026-11-08T22:04:05Z",
+				"DiscoKey":   "discokey:93a1a49309e8858bd88f2037776bcd02def0a08372e1fb869da8ff778be30b22",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58364",
+					"10.65.0.27:58364",
+					"172.17.0.1:58364",
+					"172.18.0.1:58364",
+					"172.19.0.1:58364"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:04:05.485132805Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4562310105883451": {
+				"ID":          4562310105883451,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4183096974344498,
+				"StableID":   "nHaFH8sXfZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:9d13d918f3d1667ba114de999f3488a12aeba0e1eb3f98d21aa4273370571825",
+				"KeyExpiry":  "2026-11-08T22:04:04Z",
+				"DiscoKey":   "discokey:c5a10e0e2aace4be32efb41204a48c6e5742c244f797a1f42b21b2e09fcb104c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52565",
+					"10.65.0.27:52565",
+					"172.17.0.1:52565",
+					"172.18.0.1:52565",
+					"172.19.0.1:52565"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:04:04.410786066Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9d13d918f3d1667ba114de999f3488a12aeba0e1eb3f98d21aa4273370571825",
+			"MachineKey": "mkey:d2034491d029333dde9c9797ec983fb43522cc270faadfa714145663b6b3ab5a",
+			"Peers": [{
+				"ID":         8491222439515493,
+				"StableID":   "nAfy9s1hJ921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a240ab1f30785a49487e8f631b2192606c0f23f27a10de9b2e6050e56ac2603f",
+				"DiscoKey":   "discokey:b55fc0ee30a8d53ae363b92e404b08a6e1d4c343a92db2601e641cc959db730c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51655",
+					"10.65.0.27:51655",
+					"172.17.0.1:51655",
+					"172.18.0.1:51655",
+					"172.19.0.1:51655"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:03:57.981490233Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1649779838257168,
+				"StableID":   "nBSGuHvBtD11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ed82f0bc56f1691dac775139df3d1b81054000256b33c36eb71a3f6d59aac314",
+				"DiscoKey":   "discokey:c5ddb995ebafe4e65d5398a2a5218ecc595e1fb087741145f1d669396c6ec54a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50852",
+					"10.65.0.27:50852",
+					"172.17.0.1:50852",
+					"172.18.0.1:50852",
+					"172.19.0.1:50852"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:03:58.513893559Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6460500195375200,
+				"StableID":   "nhHfKLPySs11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c9b7f3aa9137d86e9e581a333156b9f71f1595f3ab93d8b2f94bfc5faf2b442",
+				"DiscoKey":   "discokey:c0ab93eb7e80f4ca3fc343d583b7aa27d1b1d42a94e4efec0cab382c1f200973",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53292",
+					"10.65.0.27:53292",
+					"172.17.0.1:53292",
+					"172.18.0.1:53292",
+					"172.19.0.1:53292"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:03:59.054539587Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4699682252504473,
+				"StableID":   "nQiBMegVhd11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8eb1f3676dd52658c117adde1a1ce03b3742fc6db3dc6546b34c8bfa5645aa35",
+				"DiscoKey":   "discokey:949690936a61f5740f6c231c648e868c2c3117ced778b5bce53caeb5df92b948",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:57430",
+					"10.65.0.27:57430",
+					"172.17.0.1:57430",
+					"172.18.0.1:57430",
+					"172.19.0.1:57430"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:03:59.581193274Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5398422059704600,
+				"StableID":   "n11XPpPx9j11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f786f74d4866ef6b8c6269033234f75d36fcbb90fd9235562c2377a02bccec35",
+				"DiscoKey":   "discokey:a1222c706ae20a079e83f58afeb95fc602c3c648c0f60065329958116fab162b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53894",
+					"10.65.0.27:53894",
+					"172.17.0.1:53894",
+					"172.18.0.1:53894",
+					"172.19.0.1:53894"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:04:00.135369653Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         398959213778801,
+				"StableID":   "nGAuYxyg7411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d35f6094eba879b47aae60bce1aa68eefe790f832e92e5005f09c6d3f0ca943c",
+				"DiscoKey":   "discokey:f426dda1645acee84f93db80ce28bb9088848433ce8843cb7376cbce7db09e0c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42975",
+					"10.65.0.27:42975",
+					"172.17.0.1:42975",
+					"172.18.0.1:42975",
+					"172.19.0.1:42975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:04:00.658057485Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2905948770773974,
+				"StableID":   "nPHKv6M7hP11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6dee1baf569b9966220c396858582fa17635c7f0ce006a4da0fdf2293e0f283d",
+				"DiscoKey":   "discokey:dcb28492cc1944032a812cf5cae4e3c407e1812734207672adc578458c04df02",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38318",
+					"10.65.0.27:38318",
+					"172.17.0.1:38318",
+					"172.18.0.1:38318",
+					"172.19.0.1:38318"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:04:01.198696031Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4562310105883451,
+				"StableID":   "n41HAi9Hdc11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c69894c28fd36600c7af37652e843e935c6b677b005a88d64f4ef6f5549638",
+				"DiscoKey":   "discokey:1247c5557ee0f9d21d46dab8eeffd9e5066b61c7b86e4f3d476f261aeb125872",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54560",
+					"10.65.0.27:54560",
+					"172.17.0.1:54560",
+					"172.18.0.1:54560",
+					"172.19.0.1:54560"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:04:01.729212942Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7768936078060628,
+				"StableID":   "n15Jk4nZf321CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:166e4f8d0176bfe04154af2cfcf3ca4e7f2f4efb28adc810de001e953ed0e931",
+				"DiscoKey":   "discokey:0222a393efb07131e7252e209d3fec4b02a4a82593dae27c8235bba2bddb286d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34815",
+					"10.65.0.27:34815",
+					"172.17.0.1:34815",
+					"172.18.0.1:34815",
+					"172.19.0.1:34815"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:04:02.26957766Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2601977946505300,
+				"StableID":   "n1hW5pYSKM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:605ffdb39ccdd629bf5b7c5f1d0ad17ba876ffad98cdfa985a929d0e6448610e",
+				"DiscoKey":   "discokey:d077a9992c2bb70b9c94c3ce29f6d8eecd1433b9c9187d141a88f7ce8680bf23",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52277",
+					"10.65.0.27:52277",
+					"172.17.0.1:52277",
+					"172.18.0.1:52277",
+					"172.19.0.1:52277"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:04:02.864339895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7256259790599196,
+				"StableID":   "n5RTo8eNfy11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:314ac8266cda6ea00529453da3f9134c72ac1b5d32a98bdcb022ea6c1760d36a",
+				"DiscoKey":   "discokey:5fb7f0056678e4ef9a5e7a14613d5ca9bacc93fb6d19f0d6cba3ccf7347ba935",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37358",
+					"10.65.0.27:37358",
+					"172.17.0.1:37358",
+					"172.18.0.1:37358",
+					"172.19.0.1:37358"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:04:03.366226325Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8866242676376056,
+				"StableID":   "nVToHKAYEC21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95e3dbacf62755330755f826c88d014a853c8835b8920072b28f3ff0cd136710",
+				"DiscoKey":   "discokey:153357c13f1f53e0d3f3269a37ac764a867d8d8726eeae558b4412b744f2c71c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38980",
+					"10.65.0.27:38980",
+					"172.17.0.1:38980",
+					"172.18.0.1:38980",
+					"172.19.0.1:38980"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:04:03.878870759Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1143258373116122,
+				"StableID":   "noqcXcTnv911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:56ce887d809a311cab53e0de6d15e6344974e43021fbb52918e9b4a6fb8a011f",
+				"KeyExpiry":  "2026-11-08T22:04:04Z",
+				"DiscoKey":   "discokey:8a27a7485193808a62e44fedf19f31f28113ea13b0bb827f7d61a9253499035c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:56489",
+					"10.65.0.27:56489",
+					"172.17.0.1:56489",
+					"172.18.0.1:56489",
+					"172.19.0.1:56489"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:04:04.955311027Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         596461305159325,
+				"StableID":   "nG4y3a29f511CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:891e465b69ae1cf5562e9ff2e0473b49747bce485eace73f48775fd70f861b35",
+				"KeyExpiry":  "2026-11-08T22:04:05Z",
+				"DiscoKey":   "discokey:93a1a49309e8858bd88f2037776bcd02def0a08372e1fb869da8ff778be30b22",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58364",
+					"10.65.0.27:58364",
+					"172.17.0.1:58364",
+					"172.18.0.1:58364",
+					"172.19.0.1:58364"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:04:05.485132805Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7256259790599196,
+				"StableID":   "n5RTo8eNfy11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       7256259790599196,
+				"Key":        "nodekey:314ac8266cda6ea00529453da3f9134c72ac1b5d32a98bdcb022ea6c1760d36a",
+				"DiscoKey":   "discokey:5fb7f0056678e4ef9a5e7a14613d5ca9bacc93fb6d19f0d6cba3ccf7347ba935",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37358",
+					"10.65.0.27:37358",
+					"172.17.0.1:37358",
+					"172.18.0.1:37358",
+					"172.19.0.1:37358"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:04:03.366226325Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:314ac8266cda6ea00529453da3f9134c72ac1b5d32a98bdcb022ea6c1760d36a",
+			"MachineKey": "mkey:7fd366a364b19998fc587e4b0c1ee3006a34dfcacfe8207c5257ac7487521b4a",
+			"Peers": [{
+				"ID":         8491222439515493,
+				"StableID":   "nAfy9s1hJ921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a240ab1f30785a49487e8f631b2192606c0f23f27a10de9b2e6050e56ac2603f",
+				"DiscoKey":   "discokey:b55fc0ee30a8d53ae363b92e404b08a6e1d4c343a92db2601e641cc959db730c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51655",
+					"10.65.0.27:51655",
+					"172.17.0.1:51655",
+					"172.18.0.1:51655",
+					"172.19.0.1:51655"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:03:57.981490233Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1649779838257168,
+				"StableID":   "nBSGuHvBtD11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ed82f0bc56f1691dac775139df3d1b81054000256b33c36eb71a3f6d59aac314",
+				"DiscoKey":   "discokey:c5ddb995ebafe4e65d5398a2a5218ecc595e1fb087741145f1d669396c6ec54a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50852",
+					"10.65.0.27:50852",
+					"172.17.0.1:50852",
+					"172.18.0.1:50852",
+					"172.19.0.1:50852"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:03:58.513893559Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6460500195375200,
+				"StableID":   "nhHfKLPySs11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c9b7f3aa9137d86e9e581a333156b9f71f1595f3ab93d8b2f94bfc5faf2b442",
+				"DiscoKey":   "discokey:c0ab93eb7e80f4ca3fc343d583b7aa27d1b1d42a94e4efec0cab382c1f200973",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53292",
+					"10.65.0.27:53292",
+					"172.17.0.1:53292",
+					"172.18.0.1:53292",
+					"172.19.0.1:53292"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:03:59.054539587Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4699682252504473,
+				"StableID":   "nQiBMegVhd11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8eb1f3676dd52658c117adde1a1ce03b3742fc6db3dc6546b34c8bfa5645aa35",
+				"DiscoKey":   "discokey:949690936a61f5740f6c231c648e868c2c3117ced778b5bce53caeb5df92b948",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:57430",
+					"10.65.0.27:57430",
+					"172.17.0.1:57430",
+					"172.18.0.1:57430",
+					"172.19.0.1:57430"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:03:59.581193274Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5398422059704600,
+				"StableID":   "n11XPpPx9j11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f786f74d4866ef6b8c6269033234f75d36fcbb90fd9235562c2377a02bccec35",
+				"DiscoKey":   "discokey:a1222c706ae20a079e83f58afeb95fc602c3c648c0f60065329958116fab162b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53894",
+					"10.65.0.27:53894",
+					"172.17.0.1:53894",
+					"172.18.0.1:53894",
+					"172.19.0.1:53894"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:04:00.135369653Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         398959213778801,
+				"StableID":   "nGAuYxyg7411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d35f6094eba879b47aae60bce1aa68eefe790f832e92e5005f09c6d3f0ca943c",
+				"DiscoKey":   "discokey:f426dda1645acee84f93db80ce28bb9088848433ce8843cb7376cbce7db09e0c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42975",
+					"10.65.0.27:42975",
+					"172.17.0.1:42975",
+					"172.18.0.1:42975",
+					"172.19.0.1:42975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:04:00.658057485Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2905948770773974,
+				"StableID":   "nPHKv6M7hP11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6dee1baf569b9966220c396858582fa17635c7f0ce006a4da0fdf2293e0f283d",
+				"DiscoKey":   "discokey:dcb28492cc1944032a812cf5cae4e3c407e1812734207672adc578458c04df02",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38318",
+					"10.65.0.27:38318",
+					"172.17.0.1:38318",
+					"172.18.0.1:38318",
+					"172.19.0.1:38318"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:04:01.198696031Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4562310105883451,
+				"StableID":   "n41HAi9Hdc11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c69894c28fd36600c7af37652e843e935c6b677b005a88d64f4ef6f5549638",
+				"DiscoKey":   "discokey:1247c5557ee0f9d21d46dab8eeffd9e5066b61c7b86e4f3d476f261aeb125872",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54560",
+					"10.65.0.27:54560",
+					"172.17.0.1:54560",
+					"172.18.0.1:54560",
+					"172.19.0.1:54560"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:04:01.729212942Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7768936078060628,
+				"StableID":   "n15Jk4nZf321CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:166e4f8d0176bfe04154af2cfcf3ca4e7f2f4efb28adc810de001e953ed0e931",
+				"DiscoKey":   "discokey:0222a393efb07131e7252e209d3fec4b02a4a82593dae27c8235bba2bddb286d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34815",
+					"10.65.0.27:34815",
+					"172.17.0.1:34815",
+					"172.18.0.1:34815",
+					"172.19.0.1:34815"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:04:02.26957766Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2601977946505300,
+				"StableID":   "n1hW5pYSKM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:605ffdb39ccdd629bf5b7c5f1d0ad17ba876ffad98cdfa985a929d0e6448610e",
+				"DiscoKey":   "discokey:d077a9992c2bb70b9c94c3ce29f6d8eecd1433b9c9187d141a88f7ce8680bf23",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52277",
+					"10.65.0.27:52277",
+					"172.17.0.1:52277",
+					"172.18.0.1:52277",
+					"172.19.0.1:52277"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:04:02.864339895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8866242676376056,
+				"StableID":   "nVToHKAYEC21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95e3dbacf62755330755f826c88d014a853c8835b8920072b28f3ff0cd136710",
+				"DiscoKey":   "discokey:153357c13f1f53e0d3f3269a37ac764a867d8d8726eeae558b4412b744f2c71c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38980",
+					"10.65.0.27:38980",
+					"172.17.0.1:38980",
+					"172.18.0.1:38980",
+					"172.19.0.1:38980"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:04:03.878870759Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4183096974344498,
+				"StableID":   "nHaFH8sXfZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:9d13d918f3d1667ba114de999f3488a12aeba0e1eb3f98d21aa4273370571825",
+				"KeyExpiry":  "2026-11-08T22:04:04Z",
+				"DiscoKey":   "discokey:c5a10e0e2aace4be32efb41204a48c6e5742c244f797a1f42b21b2e09fcb104c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52565",
+					"10.65.0.27:52565",
+					"172.17.0.1:52565",
+					"172.18.0.1:52565",
+					"172.19.0.1:52565"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:04:04.410786066Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1143258373116122,
+				"StableID":   "noqcXcTnv911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:56ce887d809a311cab53e0de6d15e6344974e43021fbb52918e9b4a6fb8a011f",
+				"KeyExpiry":  "2026-11-08T22:04:04Z",
+				"DiscoKey":   "discokey:8a27a7485193808a62e44fedf19f31f28113ea13b0bb827f7d61a9253499035c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:56489",
+					"10.65.0.27:56489",
+					"172.17.0.1:56489",
+					"172.18.0.1:56489",
+					"172.19.0.1:56489"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:04:04.955311027Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         596461305159325,
+				"StableID":   "nG4y3a29f511CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:891e465b69ae1cf5562e9ff2e0473b49747bce485eace73f48775fd70f861b35",
+				"KeyExpiry":  "2026-11-08T22:04:05Z",
+				"DiscoKey":   "discokey:93a1a49309e8858bd88f2037776bcd02def0a08372e1fb869da8ff778be30b22",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58364",
+					"10.65.0.27:58364",
+					"172.17.0.1:58364",
+					"172.18.0.1:58364",
+					"172.19.0.1:58364"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:04:05.485132805Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7256259790599196": {
+				"ID":          7256259790599196,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1649779838257168,
+				"StableID":   "nBSGuHvBtD11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1649779838257168,
+				"Key":        "nodekey:ed82f0bc56f1691dac775139df3d1b81054000256b33c36eb71a3f6d59aac314",
+				"DiscoKey":   "discokey:c5ddb995ebafe4e65d5398a2a5218ecc595e1fb087741145f1d669396c6ec54a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50852",
+					"10.65.0.27:50852",
+					"172.17.0.1:50852",
+					"172.18.0.1:50852",
+					"172.19.0.1:50852"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:03:58.513893559Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ed82f0bc56f1691dac775139df3d1b81054000256b33c36eb71a3f6d59aac314",
+			"MachineKey": "mkey:081cabc174593e40ab0e2800466b371de6c4ec8bea4c9b18f2f1b0e27a9ea42e",
+			"Peers": [{
+				"ID":         8491222439515493,
+				"StableID":   "nAfy9s1hJ921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a240ab1f30785a49487e8f631b2192606c0f23f27a10de9b2e6050e56ac2603f",
+				"DiscoKey":   "discokey:b55fc0ee30a8d53ae363b92e404b08a6e1d4c343a92db2601e641cc959db730c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51655",
+					"10.65.0.27:51655",
+					"172.17.0.1:51655",
+					"172.18.0.1:51655",
+					"172.19.0.1:51655"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:03:57.981490233Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6460500195375200,
+				"StableID":   "nhHfKLPySs11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c9b7f3aa9137d86e9e581a333156b9f71f1595f3ab93d8b2f94bfc5faf2b442",
+				"DiscoKey":   "discokey:c0ab93eb7e80f4ca3fc343d583b7aa27d1b1d42a94e4efec0cab382c1f200973",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53292",
+					"10.65.0.27:53292",
+					"172.17.0.1:53292",
+					"172.18.0.1:53292",
+					"172.19.0.1:53292"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:03:59.054539587Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4699682252504473,
+				"StableID":   "nQiBMegVhd11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8eb1f3676dd52658c117adde1a1ce03b3742fc6db3dc6546b34c8bfa5645aa35",
+				"DiscoKey":   "discokey:949690936a61f5740f6c231c648e868c2c3117ced778b5bce53caeb5df92b948",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:57430",
+					"10.65.0.27:57430",
+					"172.17.0.1:57430",
+					"172.18.0.1:57430",
+					"172.19.0.1:57430"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:03:59.581193274Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5398422059704600,
+				"StableID":   "n11XPpPx9j11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f786f74d4866ef6b8c6269033234f75d36fcbb90fd9235562c2377a02bccec35",
+				"DiscoKey":   "discokey:a1222c706ae20a079e83f58afeb95fc602c3c648c0f60065329958116fab162b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53894",
+					"10.65.0.27:53894",
+					"172.17.0.1:53894",
+					"172.18.0.1:53894",
+					"172.19.0.1:53894"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:04:00.135369653Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         398959213778801,
+				"StableID":   "nGAuYxyg7411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d35f6094eba879b47aae60bce1aa68eefe790f832e92e5005f09c6d3f0ca943c",
+				"DiscoKey":   "discokey:f426dda1645acee84f93db80ce28bb9088848433ce8843cb7376cbce7db09e0c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42975",
+					"10.65.0.27:42975",
+					"172.17.0.1:42975",
+					"172.18.0.1:42975",
+					"172.19.0.1:42975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:04:00.658057485Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2905948770773974,
+				"StableID":   "nPHKv6M7hP11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6dee1baf569b9966220c396858582fa17635c7f0ce006a4da0fdf2293e0f283d",
+				"DiscoKey":   "discokey:dcb28492cc1944032a812cf5cae4e3c407e1812734207672adc578458c04df02",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38318",
+					"10.65.0.27:38318",
+					"172.17.0.1:38318",
+					"172.18.0.1:38318",
+					"172.19.0.1:38318"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:04:01.198696031Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4562310105883451,
+				"StableID":   "n41HAi9Hdc11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c69894c28fd36600c7af37652e843e935c6b677b005a88d64f4ef6f5549638",
+				"DiscoKey":   "discokey:1247c5557ee0f9d21d46dab8eeffd9e5066b61c7b86e4f3d476f261aeb125872",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54560",
+					"10.65.0.27:54560",
+					"172.17.0.1:54560",
+					"172.18.0.1:54560",
+					"172.19.0.1:54560"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:04:01.729212942Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7768936078060628,
+				"StableID":   "n15Jk4nZf321CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:166e4f8d0176bfe04154af2cfcf3ca4e7f2f4efb28adc810de001e953ed0e931",
+				"DiscoKey":   "discokey:0222a393efb07131e7252e209d3fec4b02a4a82593dae27c8235bba2bddb286d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34815",
+					"10.65.0.27:34815",
+					"172.17.0.1:34815",
+					"172.18.0.1:34815",
+					"172.19.0.1:34815"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:04:02.26957766Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2601977946505300,
+				"StableID":   "n1hW5pYSKM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:605ffdb39ccdd629bf5b7c5f1d0ad17ba876ffad98cdfa985a929d0e6448610e",
+				"DiscoKey":   "discokey:d077a9992c2bb70b9c94c3ce29f6d8eecd1433b9c9187d141a88f7ce8680bf23",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52277",
+					"10.65.0.27:52277",
+					"172.17.0.1:52277",
+					"172.18.0.1:52277",
+					"172.19.0.1:52277"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:04:02.864339895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7256259790599196,
+				"StableID":   "n5RTo8eNfy11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:314ac8266cda6ea00529453da3f9134c72ac1b5d32a98bdcb022ea6c1760d36a",
+				"DiscoKey":   "discokey:5fb7f0056678e4ef9a5e7a14613d5ca9bacc93fb6d19f0d6cba3ccf7347ba935",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37358",
+					"10.65.0.27:37358",
+					"172.17.0.1:37358",
+					"172.18.0.1:37358",
+					"172.19.0.1:37358"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:04:03.366226325Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8866242676376056,
+				"StableID":   "nVToHKAYEC21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95e3dbacf62755330755f826c88d014a853c8835b8920072b28f3ff0cd136710",
+				"DiscoKey":   "discokey:153357c13f1f53e0d3f3269a37ac764a867d8d8726eeae558b4412b744f2c71c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38980",
+					"10.65.0.27:38980",
+					"172.17.0.1:38980",
+					"172.18.0.1:38980",
+					"172.19.0.1:38980"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:04:03.878870759Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4183096974344498,
+				"StableID":   "nHaFH8sXfZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:9d13d918f3d1667ba114de999f3488a12aeba0e1eb3f98d21aa4273370571825",
+				"KeyExpiry":  "2026-11-08T22:04:04Z",
+				"DiscoKey":   "discokey:c5a10e0e2aace4be32efb41204a48c6e5742c244f797a1f42b21b2e09fcb104c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52565",
+					"10.65.0.27:52565",
+					"172.17.0.1:52565",
+					"172.18.0.1:52565",
+					"172.19.0.1:52565"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:04:04.410786066Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1143258373116122,
+				"StableID":   "noqcXcTnv911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:56ce887d809a311cab53e0de6d15e6344974e43021fbb52918e9b4a6fb8a011f",
+				"KeyExpiry":  "2026-11-08T22:04:04Z",
+				"DiscoKey":   "discokey:8a27a7485193808a62e44fedf19f31f28113ea13b0bb827f7d61a9253499035c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:56489",
+					"10.65.0.27:56489",
+					"172.17.0.1:56489",
+					"172.18.0.1:56489",
+					"172.19.0.1:56489"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:04:04.955311027Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         596461305159325,
+				"StableID":   "nG4y3a29f511CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:891e465b69ae1cf5562e9ff2e0473b49747bce485eace73f48775fd70f861b35",
+				"KeyExpiry":  "2026-11-08T22:04:05Z",
+				"DiscoKey":   "discokey:93a1a49309e8858bd88f2037776bcd02def0a08372e1fb869da8ff778be30b22",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58364",
+					"10.65.0.27:58364",
+					"172.17.0.1:58364",
+					"172.18.0.1:58364",
+					"172.19.0.1:58364"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:04:05.485132805Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1649779838257168": {
+				"ID":          1649779838257168,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8491222439515493,
+				"StableID":   "nAfy9s1hJ921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       8491222439515493,
+				"Key":        "nodekey:a240ab1f30785a49487e8f631b2192606c0f23f27a10de9b2e6050e56ac2603f",
+				"DiscoKey":   "discokey:b55fc0ee30a8d53ae363b92e404b08a6e1d4c343a92db2601e641cc959db730c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51655",
+					"10.65.0.27:51655",
+					"172.17.0.1:51655",
+					"172.18.0.1:51655",
+					"172.19.0.1:51655"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:03:57.981490233Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a240ab1f30785a49487e8f631b2192606c0f23f27a10de9b2e6050e56ac2603f",
+			"MachineKey": "mkey:a875bebc849e4d50f0312cf28e76057d56fda4e4b03ae18bb35bb311c36fde25",
+			"Peers": [{
+				"ID":         1649779838257168,
+				"StableID":   "nBSGuHvBtD11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ed82f0bc56f1691dac775139df3d1b81054000256b33c36eb71a3f6d59aac314",
+				"DiscoKey":   "discokey:c5ddb995ebafe4e65d5398a2a5218ecc595e1fb087741145f1d669396c6ec54a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50852",
+					"10.65.0.27:50852",
+					"172.17.0.1:50852",
+					"172.18.0.1:50852",
+					"172.19.0.1:50852"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:03:58.513893559Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6460500195375200,
+				"StableID":   "nhHfKLPySs11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c9b7f3aa9137d86e9e581a333156b9f71f1595f3ab93d8b2f94bfc5faf2b442",
+				"DiscoKey":   "discokey:c0ab93eb7e80f4ca3fc343d583b7aa27d1b1d42a94e4efec0cab382c1f200973",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53292",
+					"10.65.0.27:53292",
+					"172.17.0.1:53292",
+					"172.18.0.1:53292",
+					"172.19.0.1:53292"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:03:59.054539587Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4699682252504473,
+				"StableID":   "nQiBMegVhd11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8eb1f3676dd52658c117adde1a1ce03b3742fc6db3dc6546b34c8bfa5645aa35",
+				"DiscoKey":   "discokey:949690936a61f5740f6c231c648e868c2c3117ced778b5bce53caeb5df92b948",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:57430",
+					"10.65.0.27:57430",
+					"172.17.0.1:57430",
+					"172.18.0.1:57430",
+					"172.19.0.1:57430"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:03:59.581193274Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5398422059704600,
+				"StableID":   "n11XPpPx9j11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f786f74d4866ef6b8c6269033234f75d36fcbb90fd9235562c2377a02bccec35",
+				"DiscoKey":   "discokey:a1222c706ae20a079e83f58afeb95fc602c3c648c0f60065329958116fab162b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53894",
+					"10.65.0.27:53894",
+					"172.17.0.1:53894",
+					"172.18.0.1:53894",
+					"172.19.0.1:53894"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:04:00.135369653Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         398959213778801,
+				"StableID":   "nGAuYxyg7411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d35f6094eba879b47aae60bce1aa68eefe790f832e92e5005f09c6d3f0ca943c",
+				"DiscoKey":   "discokey:f426dda1645acee84f93db80ce28bb9088848433ce8843cb7376cbce7db09e0c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42975",
+					"10.65.0.27:42975",
+					"172.17.0.1:42975",
+					"172.18.0.1:42975",
+					"172.19.0.1:42975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:04:00.658057485Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2905948770773974,
+				"StableID":   "nPHKv6M7hP11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6dee1baf569b9966220c396858582fa17635c7f0ce006a4da0fdf2293e0f283d",
+				"DiscoKey":   "discokey:dcb28492cc1944032a812cf5cae4e3c407e1812734207672adc578458c04df02",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38318",
+					"10.65.0.27:38318",
+					"172.17.0.1:38318",
+					"172.18.0.1:38318",
+					"172.19.0.1:38318"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:04:01.198696031Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4562310105883451,
+				"StableID":   "n41HAi9Hdc11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c69894c28fd36600c7af37652e843e935c6b677b005a88d64f4ef6f5549638",
+				"DiscoKey":   "discokey:1247c5557ee0f9d21d46dab8eeffd9e5066b61c7b86e4f3d476f261aeb125872",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54560",
+					"10.65.0.27:54560",
+					"172.17.0.1:54560",
+					"172.18.0.1:54560",
+					"172.19.0.1:54560"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:04:01.729212942Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7768936078060628,
+				"StableID":   "n15Jk4nZf321CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:166e4f8d0176bfe04154af2cfcf3ca4e7f2f4efb28adc810de001e953ed0e931",
+				"DiscoKey":   "discokey:0222a393efb07131e7252e209d3fec4b02a4a82593dae27c8235bba2bddb286d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34815",
+					"10.65.0.27:34815",
+					"172.17.0.1:34815",
+					"172.18.0.1:34815",
+					"172.19.0.1:34815"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:04:02.26957766Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2601977946505300,
+				"StableID":   "n1hW5pYSKM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:605ffdb39ccdd629bf5b7c5f1d0ad17ba876ffad98cdfa985a929d0e6448610e",
+				"DiscoKey":   "discokey:d077a9992c2bb70b9c94c3ce29f6d8eecd1433b9c9187d141a88f7ce8680bf23",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52277",
+					"10.65.0.27:52277",
+					"172.17.0.1:52277",
+					"172.18.0.1:52277",
+					"172.19.0.1:52277"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:04:02.864339895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7256259790599196,
+				"StableID":   "n5RTo8eNfy11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:314ac8266cda6ea00529453da3f9134c72ac1b5d32a98bdcb022ea6c1760d36a",
+				"DiscoKey":   "discokey:5fb7f0056678e4ef9a5e7a14613d5ca9bacc93fb6d19f0d6cba3ccf7347ba935",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37358",
+					"10.65.0.27:37358",
+					"172.17.0.1:37358",
+					"172.18.0.1:37358",
+					"172.19.0.1:37358"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:04:03.366226325Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8866242676376056,
+				"StableID":   "nVToHKAYEC21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95e3dbacf62755330755f826c88d014a853c8835b8920072b28f3ff0cd136710",
+				"DiscoKey":   "discokey:153357c13f1f53e0d3f3269a37ac764a867d8d8726eeae558b4412b744f2c71c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38980",
+					"10.65.0.27:38980",
+					"172.17.0.1:38980",
+					"172.18.0.1:38980",
+					"172.19.0.1:38980"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:04:03.878870759Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4183096974344498,
+				"StableID":   "nHaFH8sXfZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:9d13d918f3d1667ba114de999f3488a12aeba0e1eb3f98d21aa4273370571825",
+				"KeyExpiry":  "2026-11-08T22:04:04Z",
+				"DiscoKey":   "discokey:c5a10e0e2aace4be32efb41204a48c6e5742c244f797a1f42b21b2e09fcb104c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52565",
+					"10.65.0.27:52565",
+					"172.17.0.1:52565",
+					"172.18.0.1:52565",
+					"172.19.0.1:52565"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:04:04.410786066Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1143258373116122,
+				"StableID":   "noqcXcTnv911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:56ce887d809a311cab53e0de6d15e6344974e43021fbb52918e9b4a6fb8a011f",
+				"KeyExpiry":  "2026-11-08T22:04:04Z",
+				"DiscoKey":   "discokey:8a27a7485193808a62e44fedf19f31f28113ea13b0bb827f7d61a9253499035c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:56489",
+					"10.65.0.27:56489",
+					"172.17.0.1:56489",
+					"172.18.0.1:56489",
+					"172.19.0.1:56489"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:04:04.955311027Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         596461305159325,
+				"StableID":   "nG4y3a29f511CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:891e465b69ae1cf5562e9ff2e0473b49747bce485eace73f48775fd70f861b35",
+				"KeyExpiry":  "2026-11-08T22:04:05Z",
+				"DiscoKey":   "discokey:93a1a49309e8858bd88f2037776bcd02def0a08372e1fb869da8ff778be30b22",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58364",
+					"10.65.0.27:58364",
+					"172.17.0.1:58364",
+					"172.18.0.1:58364",
+					"172.19.0.1:58364"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:04:05.485132805Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8491222439515493": {
+				"ID":          8491222439515493,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5398422059704600,
+				"StableID":   "n11XPpPx9j11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       5398422059704600,
+				"Key":        "nodekey:f786f74d4866ef6b8c6269033234f75d36fcbb90fd9235562c2377a02bccec35",
+				"DiscoKey":   "discokey:a1222c706ae20a079e83f58afeb95fc602c3c648c0f60065329958116fab162b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53894",
+					"10.65.0.27:53894",
+					"172.17.0.1:53894",
+					"172.18.0.1:53894",
+					"172.19.0.1:53894"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:04:00.135369653Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f786f74d4866ef6b8c6269033234f75d36fcbb90fd9235562c2377a02bccec35",
+			"MachineKey": "mkey:d96a24b810d30252d617e9b9efbe9f93788de14e43c23a561bb7d8f0aaf2b610",
+			"Peers": [{
+				"ID":         8491222439515493,
+				"StableID":   "nAfy9s1hJ921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a240ab1f30785a49487e8f631b2192606c0f23f27a10de9b2e6050e56ac2603f",
+				"DiscoKey":   "discokey:b55fc0ee30a8d53ae363b92e404b08a6e1d4c343a92db2601e641cc959db730c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51655",
+					"10.65.0.27:51655",
+					"172.17.0.1:51655",
+					"172.18.0.1:51655",
+					"172.19.0.1:51655"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:03:57.981490233Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1649779838257168,
+				"StableID":   "nBSGuHvBtD11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ed82f0bc56f1691dac775139df3d1b81054000256b33c36eb71a3f6d59aac314",
+				"DiscoKey":   "discokey:c5ddb995ebafe4e65d5398a2a5218ecc595e1fb087741145f1d669396c6ec54a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50852",
+					"10.65.0.27:50852",
+					"172.17.0.1:50852",
+					"172.18.0.1:50852",
+					"172.19.0.1:50852"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:03:58.513893559Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6460500195375200,
+				"StableID":   "nhHfKLPySs11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c9b7f3aa9137d86e9e581a333156b9f71f1595f3ab93d8b2f94bfc5faf2b442",
+				"DiscoKey":   "discokey:c0ab93eb7e80f4ca3fc343d583b7aa27d1b1d42a94e4efec0cab382c1f200973",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53292",
+					"10.65.0.27:53292",
+					"172.17.0.1:53292",
+					"172.18.0.1:53292",
+					"172.19.0.1:53292"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:03:59.054539587Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4699682252504473,
+				"StableID":   "nQiBMegVhd11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8eb1f3676dd52658c117adde1a1ce03b3742fc6db3dc6546b34c8bfa5645aa35",
+				"DiscoKey":   "discokey:949690936a61f5740f6c231c648e868c2c3117ced778b5bce53caeb5df92b948",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:57430",
+					"10.65.0.27:57430",
+					"172.17.0.1:57430",
+					"172.18.0.1:57430",
+					"172.19.0.1:57430"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:03:59.581193274Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         398959213778801,
+				"StableID":   "nGAuYxyg7411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d35f6094eba879b47aae60bce1aa68eefe790f832e92e5005f09c6d3f0ca943c",
+				"DiscoKey":   "discokey:f426dda1645acee84f93db80ce28bb9088848433ce8843cb7376cbce7db09e0c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42975",
+					"10.65.0.27:42975",
+					"172.17.0.1:42975",
+					"172.18.0.1:42975",
+					"172.19.0.1:42975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:04:00.658057485Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2905948770773974,
+				"StableID":   "nPHKv6M7hP11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6dee1baf569b9966220c396858582fa17635c7f0ce006a4da0fdf2293e0f283d",
+				"DiscoKey":   "discokey:dcb28492cc1944032a812cf5cae4e3c407e1812734207672adc578458c04df02",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38318",
+					"10.65.0.27:38318",
+					"172.17.0.1:38318",
+					"172.18.0.1:38318",
+					"172.19.0.1:38318"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:04:01.198696031Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4562310105883451,
+				"StableID":   "n41HAi9Hdc11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c69894c28fd36600c7af37652e843e935c6b677b005a88d64f4ef6f5549638",
+				"DiscoKey":   "discokey:1247c5557ee0f9d21d46dab8eeffd9e5066b61c7b86e4f3d476f261aeb125872",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54560",
+					"10.65.0.27:54560",
+					"172.17.0.1:54560",
+					"172.18.0.1:54560",
+					"172.19.0.1:54560"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:04:01.729212942Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7768936078060628,
+				"StableID":   "n15Jk4nZf321CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:166e4f8d0176bfe04154af2cfcf3ca4e7f2f4efb28adc810de001e953ed0e931",
+				"DiscoKey":   "discokey:0222a393efb07131e7252e209d3fec4b02a4a82593dae27c8235bba2bddb286d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34815",
+					"10.65.0.27:34815",
+					"172.17.0.1:34815",
+					"172.18.0.1:34815",
+					"172.19.0.1:34815"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:04:02.26957766Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2601977946505300,
+				"StableID":   "n1hW5pYSKM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:605ffdb39ccdd629bf5b7c5f1d0ad17ba876ffad98cdfa985a929d0e6448610e",
+				"DiscoKey":   "discokey:d077a9992c2bb70b9c94c3ce29f6d8eecd1433b9c9187d141a88f7ce8680bf23",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52277",
+					"10.65.0.27:52277",
+					"172.17.0.1:52277",
+					"172.18.0.1:52277",
+					"172.19.0.1:52277"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:04:02.864339895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7256259790599196,
+				"StableID":   "n5RTo8eNfy11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:314ac8266cda6ea00529453da3f9134c72ac1b5d32a98bdcb022ea6c1760d36a",
+				"DiscoKey":   "discokey:5fb7f0056678e4ef9a5e7a14613d5ca9bacc93fb6d19f0d6cba3ccf7347ba935",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37358",
+					"10.65.0.27:37358",
+					"172.17.0.1:37358",
+					"172.18.0.1:37358",
+					"172.19.0.1:37358"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:04:03.366226325Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8866242676376056,
+				"StableID":   "nVToHKAYEC21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95e3dbacf62755330755f826c88d014a853c8835b8920072b28f3ff0cd136710",
+				"DiscoKey":   "discokey:153357c13f1f53e0d3f3269a37ac764a867d8d8726eeae558b4412b744f2c71c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38980",
+					"10.65.0.27:38980",
+					"172.17.0.1:38980",
+					"172.18.0.1:38980",
+					"172.19.0.1:38980"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:04:03.878870759Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4183096974344498,
+				"StableID":   "nHaFH8sXfZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:9d13d918f3d1667ba114de999f3488a12aeba0e1eb3f98d21aa4273370571825",
+				"KeyExpiry":  "2026-11-08T22:04:04Z",
+				"DiscoKey":   "discokey:c5a10e0e2aace4be32efb41204a48c6e5742c244f797a1f42b21b2e09fcb104c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52565",
+					"10.65.0.27:52565",
+					"172.17.0.1:52565",
+					"172.18.0.1:52565",
+					"172.19.0.1:52565"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:04:04.410786066Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1143258373116122,
+				"StableID":   "noqcXcTnv911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:56ce887d809a311cab53e0de6d15e6344974e43021fbb52918e9b4a6fb8a011f",
+				"KeyExpiry":  "2026-11-08T22:04:04Z",
+				"DiscoKey":   "discokey:8a27a7485193808a62e44fedf19f31f28113ea13b0bb827f7d61a9253499035c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:56489",
+					"10.65.0.27:56489",
+					"172.17.0.1:56489",
+					"172.18.0.1:56489",
+					"172.19.0.1:56489"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:04:04.955311027Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         596461305159325,
+				"StableID":   "nG4y3a29f511CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:891e465b69ae1cf5562e9ff2e0473b49747bce485eace73f48775fd70f861b35",
+				"KeyExpiry":  "2026-11-08T22:04:05Z",
+				"DiscoKey":   "discokey:93a1a49309e8858bd88f2037776bcd02def0a08372e1fb869da8ff778be30b22",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58364",
+					"10.65.0.27:58364",
+					"172.17.0.1:58364",
+					"172.18.0.1:58364",
+					"172.19.0.1:58364"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:04:05.485132805Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5398422059704600": {
+				"ID":          5398422059704600,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4699682252504473,
+				"StableID":   "nQiBMegVhd11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       4699682252504473,
+				"Key":        "nodekey:8eb1f3676dd52658c117adde1a1ce03b3742fc6db3dc6546b34c8bfa5645aa35",
+				"DiscoKey":   "discokey:949690936a61f5740f6c231c648e868c2c3117ced778b5bce53caeb5df92b948",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:57430",
+					"10.65.0.27:57430",
+					"172.17.0.1:57430",
+					"172.18.0.1:57430",
+					"172.19.0.1:57430"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:03:59.581193274Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8eb1f3676dd52658c117adde1a1ce03b3742fc6db3dc6546b34c8bfa5645aa35",
+			"MachineKey": "mkey:f5f6845c43f33be781698f9cedb456fb89d2cd90e84962449cb22e27d8d6fa09",
+			"Peers": [{
+				"ID":         8491222439515493,
+				"StableID":   "nAfy9s1hJ921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a240ab1f30785a49487e8f631b2192606c0f23f27a10de9b2e6050e56ac2603f",
+				"DiscoKey":   "discokey:b55fc0ee30a8d53ae363b92e404b08a6e1d4c343a92db2601e641cc959db730c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51655",
+					"10.65.0.27:51655",
+					"172.17.0.1:51655",
+					"172.18.0.1:51655",
+					"172.19.0.1:51655"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:03:57.981490233Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1649779838257168,
+				"StableID":   "nBSGuHvBtD11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ed82f0bc56f1691dac775139df3d1b81054000256b33c36eb71a3f6d59aac314",
+				"DiscoKey":   "discokey:c5ddb995ebafe4e65d5398a2a5218ecc595e1fb087741145f1d669396c6ec54a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50852",
+					"10.65.0.27:50852",
+					"172.17.0.1:50852",
+					"172.18.0.1:50852",
+					"172.19.0.1:50852"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:03:58.513893559Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6460500195375200,
+				"StableID":   "nhHfKLPySs11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c9b7f3aa9137d86e9e581a333156b9f71f1595f3ab93d8b2f94bfc5faf2b442",
+				"DiscoKey":   "discokey:c0ab93eb7e80f4ca3fc343d583b7aa27d1b1d42a94e4efec0cab382c1f200973",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53292",
+					"10.65.0.27:53292",
+					"172.17.0.1:53292",
+					"172.18.0.1:53292",
+					"172.19.0.1:53292"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:03:59.054539587Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5398422059704600,
+				"StableID":   "n11XPpPx9j11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f786f74d4866ef6b8c6269033234f75d36fcbb90fd9235562c2377a02bccec35",
+				"DiscoKey":   "discokey:a1222c706ae20a079e83f58afeb95fc602c3c648c0f60065329958116fab162b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53894",
+					"10.65.0.27:53894",
+					"172.17.0.1:53894",
+					"172.18.0.1:53894",
+					"172.19.0.1:53894"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:04:00.135369653Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         398959213778801,
+				"StableID":   "nGAuYxyg7411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d35f6094eba879b47aae60bce1aa68eefe790f832e92e5005f09c6d3f0ca943c",
+				"DiscoKey":   "discokey:f426dda1645acee84f93db80ce28bb9088848433ce8843cb7376cbce7db09e0c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42975",
+					"10.65.0.27:42975",
+					"172.17.0.1:42975",
+					"172.18.0.1:42975",
+					"172.19.0.1:42975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:04:00.658057485Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2905948770773974,
+				"StableID":   "nPHKv6M7hP11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6dee1baf569b9966220c396858582fa17635c7f0ce006a4da0fdf2293e0f283d",
+				"DiscoKey":   "discokey:dcb28492cc1944032a812cf5cae4e3c407e1812734207672adc578458c04df02",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38318",
+					"10.65.0.27:38318",
+					"172.17.0.1:38318",
+					"172.18.0.1:38318",
+					"172.19.0.1:38318"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:04:01.198696031Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4562310105883451,
+				"StableID":   "n41HAi9Hdc11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c69894c28fd36600c7af37652e843e935c6b677b005a88d64f4ef6f5549638",
+				"DiscoKey":   "discokey:1247c5557ee0f9d21d46dab8eeffd9e5066b61c7b86e4f3d476f261aeb125872",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54560",
+					"10.65.0.27:54560",
+					"172.17.0.1:54560",
+					"172.18.0.1:54560",
+					"172.19.0.1:54560"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:04:01.729212942Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7768936078060628,
+				"StableID":   "n15Jk4nZf321CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:166e4f8d0176bfe04154af2cfcf3ca4e7f2f4efb28adc810de001e953ed0e931",
+				"DiscoKey":   "discokey:0222a393efb07131e7252e209d3fec4b02a4a82593dae27c8235bba2bddb286d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34815",
+					"10.65.0.27:34815",
+					"172.17.0.1:34815",
+					"172.18.0.1:34815",
+					"172.19.0.1:34815"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:04:02.26957766Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2601977946505300,
+				"StableID":   "n1hW5pYSKM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:605ffdb39ccdd629bf5b7c5f1d0ad17ba876ffad98cdfa985a929d0e6448610e",
+				"DiscoKey":   "discokey:d077a9992c2bb70b9c94c3ce29f6d8eecd1433b9c9187d141a88f7ce8680bf23",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52277",
+					"10.65.0.27:52277",
+					"172.17.0.1:52277",
+					"172.18.0.1:52277",
+					"172.19.0.1:52277"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:04:02.864339895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7256259790599196,
+				"StableID":   "n5RTo8eNfy11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:314ac8266cda6ea00529453da3f9134c72ac1b5d32a98bdcb022ea6c1760d36a",
+				"DiscoKey":   "discokey:5fb7f0056678e4ef9a5e7a14613d5ca9bacc93fb6d19f0d6cba3ccf7347ba935",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37358",
+					"10.65.0.27:37358",
+					"172.17.0.1:37358",
+					"172.18.0.1:37358",
+					"172.19.0.1:37358"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:04:03.366226325Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8866242676376056,
+				"StableID":   "nVToHKAYEC21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95e3dbacf62755330755f826c88d014a853c8835b8920072b28f3ff0cd136710",
+				"DiscoKey":   "discokey:153357c13f1f53e0d3f3269a37ac764a867d8d8726eeae558b4412b744f2c71c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38980",
+					"10.65.0.27:38980",
+					"172.17.0.1:38980",
+					"172.18.0.1:38980",
+					"172.19.0.1:38980"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:04:03.878870759Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4183096974344498,
+				"StableID":   "nHaFH8sXfZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:9d13d918f3d1667ba114de999f3488a12aeba0e1eb3f98d21aa4273370571825",
+				"KeyExpiry":  "2026-11-08T22:04:04Z",
+				"DiscoKey":   "discokey:c5a10e0e2aace4be32efb41204a48c6e5742c244f797a1f42b21b2e09fcb104c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52565",
+					"10.65.0.27:52565",
+					"172.17.0.1:52565",
+					"172.18.0.1:52565",
+					"172.19.0.1:52565"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:04:04.410786066Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1143258373116122,
+				"StableID":   "noqcXcTnv911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:56ce887d809a311cab53e0de6d15e6344974e43021fbb52918e9b4a6fb8a011f",
+				"KeyExpiry":  "2026-11-08T22:04:04Z",
+				"DiscoKey":   "discokey:8a27a7485193808a62e44fedf19f31f28113ea13b0bb827f7d61a9253499035c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:56489",
+					"10.65.0.27:56489",
+					"172.17.0.1:56489",
+					"172.18.0.1:56489",
+					"172.19.0.1:56489"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:04:04.955311027Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         596461305159325,
+				"StableID":   "nG4y3a29f511CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:891e465b69ae1cf5562e9ff2e0473b49747bce485eace73f48775fd70f861b35",
+				"KeyExpiry":  "2026-11-08T22:04:05Z",
+				"DiscoKey":   "discokey:93a1a49309e8858bd88f2037776bcd02def0a08372e1fb869da8ff778be30b22",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58364",
+					"10.65.0.27:58364",
+					"172.17.0.1:58364",
+					"172.18.0.1:58364",
+					"172.19.0.1:58364"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:04:05.485132805Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4699682252504473": {
+				"ID":          4699682252504473,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2905948770773974,
+				"StableID":   "nPHKv6M7hP11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       2905948770773974,
+				"Key":        "nodekey:6dee1baf569b9966220c396858582fa17635c7f0ce006a4da0fdf2293e0f283d",
+				"DiscoKey":   "discokey:dcb28492cc1944032a812cf5cae4e3c407e1812734207672adc578458c04df02",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38318",
+					"10.65.0.27:38318",
+					"172.17.0.1:38318",
+					"172.18.0.1:38318",
+					"172.19.0.1:38318"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:04:01.198696031Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6dee1baf569b9966220c396858582fa17635c7f0ce006a4da0fdf2293e0f283d",
+			"MachineKey": "mkey:5823e816c6d828d631155a8566a61f69a84da8b88b2f23081512813e10d95248",
+			"Peers": [{
+				"ID":         8491222439515493,
+				"StableID":   "nAfy9s1hJ921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a240ab1f30785a49487e8f631b2192606c0f23f27a10de9b2e6050e56ac2603f",
+				"DiscoKey":   "discokey:b55fc0ee30a8d53ae363b92e404b08a6e1d4c343a92db2601e641cc959db730c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51655",
+					"10.65.0.27:51655",
+					"172.17.0.1:51655",
+					"172.18.0.1:51655",
+					"172.19.0.1:51655"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:03:57.981490233Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1649779838257168,
+				"StableID":   "nBSGuHvBtD11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ed82f0bc56f1691dac775139df3d1b81054000256b33c36eb71a3f6d59aac314",
+				"DiscoKey":   "discokey:c5ddb995ebafe4e65d5398a2a5218ecc595e1fb087741145f1d669396c6ec54a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50852",
+					"10.65.0.27:50852",
+					"172.17.0.1:50852",
+					"172.18.0.1:50852",
+					"172.19.0.1:50852"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:03:58.513893559Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6460500195375200,
+				"StableID":   "nhHfKLPySs11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c9b7f3aa9137d86e9e581a333156b9f71f1595f3ab93d8b2f94bfc5faf2b442",
+				"DiscoKey":   "discokey:c0ab93eb7e80f4ca3fc343d583b7aa27d1b1d42a94e4efec0cab382c1f200973",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53292",
+					"10.65.0.27:53292",
+					"172.17.0.1:53292",
+					"172.18.0.1:53292",
+					"172.19.0.1:53292"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:03:59.054539587Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4699682252504473,
+				"StableID":   "nQiBMegVhd11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8eb1f3676dd52658c117adde1a1ce03b3742fc6db3dc6546b34c8bfa5645aa35",
+				"DiscoKey":   "discokey:949690936a61f5740f6c231c648e868c2c3117ced778b5bce53caeb5df92b948",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:57430",
+					"10.65.0.27:57430",
+					"172.17.0.1:57430",
+					"172.18.0.1:57430",
+					"172.19.0.1:57430"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:03:59.581193274Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5398422059704600,
+				"StableID":   "n11XPpPx9j11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f786f74d4866ef6b8c6269033234f75d36fcbb90fd9235562c2377a02bccec35",
+				"DiscoKey":   "discokey:a1222c706ae20a079e83f58afeb95fc602c3c648c0f60065329958116fab162b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53894",
+					"10.65.0.27:53894",
+					"172.17.0.1:53894",
+					"172.18.0.1:53894",
+					"172.19.0.1:53894"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:04:00.135369653Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         398959213778801,
+				"StableID":   "nGAuYxyg7411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d35f6094eba879b47aae60bce1aa68eefe790f832e92e5005f09c6d3f0ca943c",
+				"DiscoKey":   "discokey:f426dda1645acee84f93db80ce28bb9088848433ce8843cb7376cbce7db09e0c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42975",
+					"10.65.0.27:42975",
+					"172.17.0.1:42975",
+					"172.18.0.1:42975",
+					"172.19.0.1:42975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:04:00.658057485Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4562310105883451,
+				"StableID":   "n41HAi9Hdc11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c69894c28fd36600c7af37652e843e935c6b677b005a88d64f4ef6f5549638",
+				"DiscoKey":   "discokey:1247c5557ee0f9d21d46dab8eeffd9e5066b61c7b86e4f3d476f261aeb125872",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54560",
+					"10.65.0.27:54560",
+					"172.17.0.1:54560",
+					"172.18.0.1:54560",
+					"172.19.0.1:54560"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:04:01.729212942Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7768936078060628,
+				"StableID":   "n15Jk4nZf321CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:166e4f8d0176bfe04154af2cfcf3ca4e7f2f4efb28adc810de001e953ed0e931",
+				"DiscoKey":   "discokey:0222a393efb07131e7252e209d3fec4b02a4a82593dae27c8235bba2bddb286d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34815",
+					"10.65.0.27:34815",
+					"172.17.0.1:34815",
+					"172.18.0.1:34815",
+					"172.19.0.1:34815"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:04:02.26957766Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2601977946505300,
+				"StableID":   "n1hW5pYSKM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:605ffdb39ccdd629bf5b7c5f1d0ad17ba876ffad98cdfa985a929d0e6448610e",
+				"DiscoKey":   "discokey:d077a9992c2bb70b9c94c3ce29f6d8eecd1433b9c9187d141a88f7ce8680bf23",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52277",
+					"10.65.0.27:52277",
+					"172.17.0.1:52277",
+					"172.18.0.1:52277",
+					"172.19.0.1:52277"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:04:02.864339895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7256259790599196,
+				"StableID":   "n5RTo8eNfy11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:314ac8266cda6ea00529453da3f9134c72ac1b5d32a98bdcb022ea6c1760d36a",
+				"DiscoKey":   "discokey:5fb7f0056678e4ef9a5e7a14613d5ca9bacc93fb6d19f0d6cba3ccf7347ba935",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37358",
+					"10.65.0.27:37358",
+					"172.17.0.1:37358",
+					"172.18.0.1:37358",
+					"172.19.0.1:37358"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:04:03.366226325Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8866242676376056,
+				"StableID":   "nVToHKAYEC21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95e3dbacf62755330755f826c88d014a853c8835b8920072b28f3ff0cd136710",
+				"DiscoKey":   "discokey:153357c13f1f53e0d3f3269a37ac764a867d8d8726eeae558b4412b744f2c71c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38980",
+					"10.65.0.27:38980",
+					"172.17.0.1:38980",
+					"172.18.0.1:38980",
+					"172.19.0.1:38980"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:04:03.878870759Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4183096974344498,
+				"StableID":   "nHaFH8sXfZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:9d13d918f3d1667ba114de999f3488a12aeba0e1eb3f98d21aa4273370571825",
+				"KeyExpiry":  "2026-11-08T22:04:04Z",
+				"DiscoKey":   "discokey:c5a10e0e2aace4be32efb41204a48c6e5742c244f797a1f42b21b2e09fcb104c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52565",
+					"10.65.0.27:52565",
+					"172.17.0.1:52565",
+					"172.18.0.1:52565",
+					"172.19.0.1:52565"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:04:04.410786066Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1143258373116122,
+				"StableID":   "noqcXcTnv911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:56ce887d809a311cab53e0de6d15e6344974e43021fbb52918e9b4a6fb8a011f",
+				"KeyExpiry":  "2026-11-08T22:04:04Z",
+				"DiscoKey":   "discokey:8a27a7485193808a62e44fedf19f31f28113ea13b0bb827f7d61a9253499035c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:56489",
+					"10.65.0.27:56489",
+					"172.17.0.1:56489",
+					"172.18.0.1:56489",
+					"172.19.0.1:56489"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:04:04.955311027Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         596461305159325,
+				"StableID":   "nG4y3a29f511CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:891e465b69ae1cf5562e9ff2e0473b49747bce485eace73f48775fd70f861b35",
+				"KeyExpiry":  "2026-11-08T22:04:05Z",
+				"DiscoKey":   "discokey:93a1a49309e8858bd88f2037776bcd02def0a08372e1fb869da8ff778be30b22",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58364",
+					"10.65.0.27:58364",
+					"172.17.0.1:58364",
+					"172.18.0.1:58364",
+					"172.19.0.1:58364"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:04:05.485132805Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2905948770773974": {
+				"ID":          2905948770773974,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7768936078060628,
+				"StableID":   "n15Jk4nZf321CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       7768936078060628,
+				"Key":        "nodekey:166e4f8d0176bfe04154af2cfcf3ca4e7f2f4efb28adc810de001e953ed0e931",
+				"DiscoKey":   "discokey:0222a393efb07131e7252e209d3fec4b02a4a82593dae27c8235bba2bddb286d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34815",
+					"10.65.0.27:34815",
+					"172.17.0.1:34815",
+					"172.18.0.1:34815",
+					"172.19.0.1:34815"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:04:02.26957766Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:166e4f8d0176bfe04154af2cfcf3ca4e7f2f4efb28adc810de001e953ed0e931",
+			"MachineKey": "mkey:9739d7af4e0854bff1419aa46a4239572d4d0367d63ab3059b32947e77891f46",
+			"Peers": [{
+				"ID":         8491222439515493,
+				"StableID":   "nAfy9s1hJ921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a240ab1f30785a49487e8f631b2192606c0f23f27a10de9b2e6050e56ac2603f",
+				"DiscoKey":   "discokey:b55fc0ee30a8d53ae363b92e404b08a6e1d4c343a92db2601e641cc959db730c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51655",
+					"10.65.0.27:51655",
+					"172.17.0.1:51655",
+					"172.18.0.1:51655",
+					"172.19.0.1:51655"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:03:57.981490233Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1649779838257168,
+				"StableID":   "nBSGuHvBtD11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ed82f0bc56f1691dac775139df3d1b81054000256b33c36eb71a3f6d59aac314",
+				"DiscoKey":   "discokey:c5ddb995ebafe4e65d5398a2a5218ecc595e1fb087741145f1d669396c6ec54a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50852",
+					"10.65.0.27:50852",
+					"172.17.0.1:50852",
+					"172.18.0.1:50852",
+					"172.19.0.1:50852"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:03:58.513893559Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6460500195375200,
+				"StableID":   "nhHfKLPySs11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c9b7f3aa9137d86e9e581a333156b9f71f1595f3ab93d8b2f94bfc5faf2b442",
+				"DiscoKey":   "discokey:c0ab93eb7e80f4ca3fc343d583b7aa27d1b1d42a94e4efec0cab382c1f200973",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53292",
+					"10.65.0.27:53292",
+					"172.17.0.1:53292",
+					"172.18.0.1:53292",
+					"172.19.0.1:53292"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:03:59.054539587Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4699682252504473,
+				"StableID":   "nQiBMegVhd11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8eb1f3676dd52658c117adde1a1ce03b3742fc6db3dc6546b34c8bfa5645aa35",
+				"DiscoKey":   "discokey:949690936a61f5740f6c231c648e868c2c3117ced778b5bce53caeb5df92b948",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:57430",
+					"10.65.0.27:57430",
+					"172.17.0.1:57430",
+					"172.18.0.1:57430",
+					"172.19.0.1:57430"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:03:59.581193274Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5398422059704600,
+				"StableID":   "n11XPpPx9j11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f786f74d4866ef6b8c6269033234f75d36fcbb90fd9235562c2377a02bccec35",
+				"DiscoKey":   "discokey:a1222c706ae20a079e83f58afeb95fc602c3c648c0f60065329958116fab162b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53894",
+					"10.65.0.27:53894",
+					"172.17.0.1:53894",
+					"172.18.0.1:53894",
+					"172.19.0.1:53894"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:04:00.135369653Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         398959213778801,
+				"StableID":   "nGAuYxyg7411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d35f6094eba879b47aae60bce1aa68eefe790f832e92e5005f09c6d3f0ca943c",
+				"DiscoKey":   "discokey:f426dda1645acee84f93db80ce28bb9088848433ce8843cb7376cbce7db09e0c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42975",
+					"10.65.0.27:42975",
+					"172.17.0.1:42975",
+					"172.18.0.1:42975",
+					"172.19.0.1:42975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:04:00.658057485Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2905948770773974,
+				"StableID":   "nPHKv6M7hP11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6dee1baf569b9966220c396858582fa17635c7f0ce006a4da0fdf2293e0f283d",
+				"DiscoKey":   "discokey:dcb28492cc1944032a812cf5cae4e3c407e1812734207672adc578458c04df02",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38318",
+					"10.65.0.27:38318",
+					"172.17.0.1:38318",
+					"172.18.0.1:38318",
+					"172.19.0.1:38318"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:04:01.198696031Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4562310105883451,
+				"StableID":   "n41HAi9Hdc11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c69894c28fd36600c7af37652e843e935c6b677b005a88d64f4ef6f5549638",
+				"DiscoKey":   "discokey:1247c5557ee0f9d21d46dab8eeffd9e5066b61c7b86e4f3d476f261aeb125872",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54560",
+					"10.65.0.27:54560",
+					"172.17.0.1:54560",
+					"172.18.0.1:54560",
+					"172.19.0.1:54560"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:04:01.729212942Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2601977946505300,
+				"StableID":   "n1hW5pYSKM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:605ffdb39ccdd629bf5b7c5f1d0ad17ba876ffad98cdfa985a929d0e6448610e",
+				"DiscoKey":   "discokey:d077a9992c2bb70b9c94c3ce29f6d8eecd1433b9c9187d141a88f7ce8680bf23",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52277",
+					"10.65.0.27:52277",
+					"172.17.0.1:52277",
+					"172.18.0.1:52277",
+					"172.19.0.1:52277"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:04:02.864339895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7256259790599196,
+				"StableID":   "n5RTo8eNfy11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:314ac8266cda6ea00529453da3f9134c72ac1b5d32a98bdcb022ea6c1760d36a",
+				"DiscoKey":   "discokey:5fb7f0056678e4ef9a5e7a14613d5ca9bacc93fb6d19f0d6cba3ccf7347ba935",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37358",
+					"10.65.0.27:37358",
+					"172.17.0.1:37358",
+					"172.18.0.1:37358",
+					"172.19.0.1:37358"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:04:03.366226325Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8866242676376056,
+				"StableID":   "nVToHKAYEC21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95e3dbacf62755330755f826c88d014a853c8835b8920072b28f3ff0cd136710",
+				"DiscoKey":   "discokey:153357c13f1f53e0d3f3269a37ac764a867d8d8726eeae558b4412b744f2c71c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38980",
+					"10.65.0.27:38980",
+					"172.17.0.1:38980",
+					"172.18.0.1:38980",
+					"172.19.0.1:38980"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:04:03.878870759Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4183096974344498,
+				"StableID":   "nHaFH8sXfZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:9d13d918f3d1667ba114de999f3488a12aeba0e1eb3f98d21aa4273370571825",
+				"KeyExpiry":  "2026-11-08T22:04:04Z",
+				"DiscoKey":   "discokey:c5a10e0e2aace4be32efb41204a48c6e5742c244f797a1f42b21b2e09fcb104c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52565",
+					"10.65.0.27:52565",
+					"172.17.0.1:52565",
+					"172.18.0.1:52565",
+					"172.19.0.1:52565"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:04:04.410786066Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1143258373116122,
+				"StableID":   "noqcXcTnv911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:56ce887d809a311cab53e0de6d15e6344974e43021fbb52918e9b4a6fb8a011f",
+				"KeyExpiry":  "2026-11-08T22:04:04Z",
+				"DiscoKey":   "discokey:8a27a7485193808a62e44fedf19f31f28113ea13b0bb827f7d61a9253499035c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:56489",
+					"10.65.0.27:56489",
+					"172.17.0.1:56489",
+					"172.18.0.1:56489",
+					"172.19.0.1:56489"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:04:04.955311027Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         596461305159325,
+				"StableID":   "nG4y3a29f511CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:891e465b69ae1cf5562e9ff2e0473b49747bce485eace73f48775fd70f861b35",
+				"KeyExpiry":  "2026-11-08T22:04:05Z",
+				"DiscoKey":   "discokey:93a1a49309e8858bd88f2037776bcd02def0a08372e1fb869da8ff778be30b22",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58364",
+					"10.65.0.27:58364",
+					"172.17.0.1:58364",
+					"172.18.0.1:58364",
+					"172.19.0.1:58364"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:04:05.485132805Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7768936078060628": {
+				"ID":          7768936078060628,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1143258373116122,
+				"StableID":   "noqcXcTnv911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:56ce887d809a311cab53e0de6d15e6344974e43021fbb52918e9b4a6fb8a011f",
+				"KeyExpiry":  "2026-11-08T22:04:04Z",
+				"DiscoKey":   "discokey:8a27a7485193808a62e44fedf19f31f28113ea13b0bb827f7d61a9253499035c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:56489",
+					"10.65.0.27:56489",
+					"172.17.0.1:56489",
+					"172.18.0.1:56489",
+					"172.19.0.1:56489"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:04:04.955311027Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:56ce887d809a311cab53e0de6d15e6344974e43021fbb52918e9b4a6fb8a011f",
+			"MachineKey": "mkey:8f8482378ec09e574e8c32c3e55f7b65d5582ef6fc2a50c8ededdbf9580e1155",
+			"Peers": [{
+				"ID":         8491222439515493,
+				"StableID":   "nAfy9s1hJ921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a240ab1f30785a49487e8f631b2192606c0f23f27a10de9b2e6050e56ac2603f",
+				"DiscoKey":   "discokey:b55fc0ee30a8d53ae363b92e404b08a6e1d4c343a92db2601e641cc959db730c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51655",
+					"10.65.0.27:51655",
+					"172.17.0.1:51655",
+					"172.18.0.1:51655",
+					"172.19.0.1:51655"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:03:57.981490233Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1649779838257168,
+				"StableID":   "nBSGuHvBtD11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ed82f0bc56f1691dac775139df3d1b81054000256b33c36eb71a3f6d59aac314",
+				"DiscoKey":   "discokey:c5ddb995ebafe4e65d5398a2a5218ecc595e1fb087741145f1d669396c6ec54a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50852",
+					"10.65.0.27:50852",
+					"172.17.0.1:50852",
+					"172.18.0.1:50852",
+					"172.19.0.1:50852"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:03:58.513893559Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6460500195375200,
+				"StableID":   "nhHfKLPySs11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c9b7f3aa9137d86e9e581a333156b9f71f1595f3ab93d8b2f94bfc5faf2b442",
+				"DiscoKey":   "discokey:c0ab93eb7e80f4ca3fc343d583b7aa27d1b1d42a94e4efec0cab382c1f200973",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53292",
+					"10.65.0.27:53292",
+					"172.17.0.1:53292",
+					"172.18.0.1:53292",
+					"172.19.0.1:53292"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:03:59.054539587Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4699682252504473,
+				"StableID":   "nQiBMegVhd11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8eb1f3676dd52658c117adde1a1ce03b3742fc6db3dc6546b34c8bfa5645aa35",
+				"DiscoKey":   "discokey:949690936a61f5740f6c231c648e868c2c3117ced778b5bce53caeb5df92b948",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:57430",
+					"10.65.0.27:57430",
+					"172.17.0.1:57430",
+					"172.18.0.1:57430",
+					"172.19.0.1:57430"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:03:59.581193274Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5398422059704600,
+				"StableID":   "n11XPpPx9j11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f786f74d4866ef6b8c6269033234f75d36fcbb90fd9235562c2377a02bccec35",
+				"DiscoKey":   "discokey:a1222c706ae20a079e83f58afeb95fc602c3c648c0f60065329958116fab162b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53894",
+					"10.65.0.27:53894",
+					"172.17.0.1:53894",
+					"172.18.0.1:53894",
+					"172.19.0.1:53894"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:04:00.135369653Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         398959213778801,
+				"StableID":   "nGAuYxyg7411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d35f6094eba879b47aae60bce1aa68eefe790f832e92e5005f09c6d3f0ca943c",
+				"DiscoKey":   "discokey:f426dda1645acee84f93db80ce28bb9088848433ce8843cb7376cbce7db09e0c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42975",
+					"10.65.0.27:42975",
+					"172.17.0.1:42975",
+					"172.18.0.1:42975",
+					"172.19.0.1:42975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:04:00.658057485Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2905948770773974,
+				"StableID":   "nPHKv6M7hP11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6dee1baf569b9966220c396858582fa17635c7f0ce006a4da0fdf2293e0f283d",
+				"DiscoKey":   "discokey:dcb28492cc1944032a812cf5cae4e3c407e1812734207672adc578458c04df02",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38318",
+					"10.65.0.27:38318",
+					"172.17.0.1:38318",
+					"172.18.0.1:38318",
+					"172.19.0.1:38318"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:04:01.198696031Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4562310105883451,
+				"StableID":   "n41HAi9Hdc11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c69894c28fd36600c7af37652e843e935c6b677b005a88d64f4ef6f5549638",
+				"DiscoKey":   "discokey:1247c5557ee0f9d21d46dab8eeffd9e5066b61c7b86e4f3d476f261aeb125872",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54560",
+					"10.65.0.27:54560",
+					"172.17.0.1:54560",
+					"172.18.0.1:54560",
+					"172.19.0.1:54560"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:04:01.729212942Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7768936078060628,
+				"StableID":   "n15Jk4nZf321CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:166e4f8d0176bfe04154af2cfcf3ca4e7f2f4efb28adc810de001e953ed0e931",
+				"DiscoKey":   "discokey:0222a393efb07131e7252e209d3fec4b02a4a82593dae27c8235bba2bddb286d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34815",
+					"10.65.0.27:34815",
+					"172.17.0.1:34815",
+					"172.18.0.1:34815",
+					"172.19.0.1:34815"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:04:02.26957766Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2601977946505300,
+				"StableID":   "n1hW5pYSKM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:605ffdb39ccdd629bf5b7c5f1d0ad17ba876ffad98cdfa985a929d0e6448610e",
+				"DiscoKey":   "discokey:d077a9992c2bb70b9c94c3ce29f6d8eecd1433b9c9187d141a88f7ce8680bf23",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52277",
+					"10.65.0.27:52277",
+					"172.17.0.1:52277",
+					"172.18.0.1:52277",
+					"172.19.0.1:52277"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:04:02.864339895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7256259790599196,
+				"StableID":   "n5RTo8eNfy11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:314ac8266cda6ea00529453da3f9134c72ac1b5d32a98bdcb022ea6c1760d36a",
+				"DiscoKey":   "discokey:5fb7f0056678e4ef9a5e7a14613d5ca9bacc93fb6d19f0d6cba3ccf7347ba935",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37358",
+					"10.65.0.27:37358",
+					"172.17.0.1:37358",
+					"172.18.0.1:37358",
+					"172.19.0.1:37358"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:04:03.366226325Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8866242676376056,
+				"StableID":   "nVToHKAYEC21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95e3dbacf62755330755f826c88d014a853c8835b8920072b28f3ff0cd136710",
+				"DiscoKey":   "discokey:153357c13f1f53e0d3f3269a37ac764a867d8d8726eeae558b4412b744f2c71c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38980",
+					"10.65.0.27:38980",
+					"172.17.0.1:38980",
+					"172.18.0.1:38980",
+					"172.19.0.1:38980"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:04:03.878870759Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4183096974344498,
+				"StableID":   "nHaFH8sXfZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:9d13d918f3d1667ba114de999f3488a12aeba0e1eb3f98d21aa4273370571825",
+				"KeyExpiry":  "2026-11-08T22:04:04Z",
+				"DiscoKey":   "discokey:c5a10e0e2aace4be32efb41204a48c6e5742c244f797a1f42b21b2e09fcb104c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52565",
+					"10.65.0.27:52565",
+					"172.17.0.1:52565",
+					"172.18.0.1:52565",
+					"172.19.0.1:52565"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:04:04.410786066Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         596461305159325,
+				"StableID":   "nG4y3a29f511CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:891e465b69ae1cf5562e9ff2e0473b49747bce485eace73f48775fd70f861b35",
+				"KeyExpiry":  "2026-11-08T22:04:05Z",
+				"DiscoKey":   "discokey:93a1a49309e8858bd88f2037776bcd02def0a08372e1fb869da8ff778be30b22",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58364",
+					"10.65.0.27:58364",
+					"172.17.0.1:58364",
+					"172.18.0.1:58364",
+					"172.19.0.1:58364"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:04:05.485132805Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2601977946505300,
+				"StableID":   "n1hW5pYSKM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       2601977946505300,
+				"Key":        "nodekey:605ffdb39ccdd629bf5b7c5f1d0ad17ba876ffad98cdfa985a929d0e6448610e",
+				"DiscoKey":   "discokey:d077a9992c2bb70b9c94c3ce29f6d8eecd1433b9c9187d141a88f7ce8680bf23",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52277",
+					"10.65.0.27:52277",
+					"172.17.0.1:52277",
+					"172.18.0.1:52277",
+					"172.19.0.1:52277"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:04:02.864339895Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:605ffdb39ccdd629bf5b7c5f1d0ad17ba876ffad98cdfa985a929d0e6448610e",
+			"MachineKey": "mkey:40fdaeef7ccff7cc9002eaa36b00cee400aa7a06e49d6f7520dc23f5de9c9632",
+			"Peers": [{
+				"ID":         8491222439515493,
+				"StableID":   "nAfy9s1hJ921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a240ab1f30785a49487e8f631b2192606c0f23f27a10de9b2e6050e56ac2603f",
+				"DiscoKey":   "discokey:b55fc0ee30a8d53ae363b92e404b08a6e1d4c343a92db2601e641cc959db730c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51655",
+					"10.65.0.27:51655",
+					"172.17.0.1:51655",
+					"172.18.0.1:51655",
+					"172.19.0.1:51655"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:03:57.981490233Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1649779838257168,
+				"StableID":   "nBSGuHvBtD11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ed82f0bc56f1691dac775139df3d1b81054000256b33c36eb71a3f6d59aac314",
+				"DiscoKey":   "discokey:c5ddb995ebafe4e65d5398a2a5218ecc595e1fb087741145f1d669396c6ec54a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:50852",
+					"10.65.0.27:50852",
+					"172.17.0.1:50852",
+					"172.18.0.1:50852",
+					"172.19.0.1:50852"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:03:58.513893559Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6460500195375200,
+				"StableID":   "nhHfKLPySs11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c9b7f3aa9137d86e9e581a333156b9f71f1595f3ab93d8b2f94bfc5faf2b442",
+				"DiscoKey":   "discokey:c0ab93eb7e80f4ca3fc343d583b7aa27d1b1d42a94e4efec0cab382c1f200973",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53292",
+					"10.65.0.27:53292",
+					"172.17.0.1:53292",
+					"172.18.0.1:53292",
+					"172.19.0.1:53292"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:03:59.054539587Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4699682252504473,
+				"StableID":   "nQiBMegVhd11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8eb1f3676dd52658c117adde1a1ce03b3742fc6db3dc6546b34c8bfa5645aa35",
+				"DiscoKey":   "discokey:949690936a61f5740f6c231c648e868c2c3117ced778b5bce53caeb5df92b948",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:57430",
+					"10.65.0.27:57430",
+					"172.17.0.1:57430",
+					"172.18.0.1:57430",
+					"172.19.0.1:57430"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:03:59.581193274Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5398422059704600,
+				"StableID":   "n11XPpPx9j11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f786f74d4866ef6b8c6269033234f75d36fcbb90fd9235562c2377a02bccec35",
+				"DiscoKey":   "discokey:a1222c706ae20a079e83f58afeb95fc602c3c648c0f60065329958116fab162b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53894",
+					"10.65.0.27:53894",
+					"172.17.0.1:53894",
+					"172.18.0.1:53894",
+					"172.19.0.1:53894"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:04:00.135369653Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         398959213778801,
+				"StableID":   "nGAuYxyg7411CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d35f6094eba879b47aae60bce1aa68eefe790f832e92e5005f09c6d3f0ca943c",
+				"DiscoKey":   "discokey:f426dda1645acee84f93db80ce28bb9088848433ce8843cb7376cbce7db09e0c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42975",
+					"10.65.0.27:42975",
+					"172.17.0.1:42975",
+					"172.18.0.1:42975",
+					"172.19.0.1:42975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:04:00.658057485Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2905948770773974,
+				"StableID":   "nPHKv6M7hP11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6dee1baf569b9966220c396858582fa17635c7f0ce006a4da0fdf2293e0f283d",
+				"DiscoKey":   "discokey:dcb28492cc1944032a812cf5cae4e3c407e1812734207672adc578458c04df02",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38318",
+					"10.65.0.27:38318",
+					"172.17.0.1:38318",
+					"172.18.0.1:38318",
+					"172.19.0.1:38318"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:04:01.198696031Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4562310105883451,
+				"StableID":   "n41HAi9Hdc11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c69894c28fd36600c7af37652e843e935c6b677b005a88d64f4ef6f5549638",
+				"DiscoKey":   "discokey:1247c5557ee0f9d21d46dab8eeffd9e5066b61c7b86e4f3d476f261aeb125872",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54560",
+					"10.65.0.27:54560",
+					"172.17.0.1:54560",
+					"172.18.0.1:54560",
+					"172.19.0.1:54560"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:04:01.729212942Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7768936078060628,
+				"StableID":   "n15Jk4nZf321CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:166e4f8d0176bfe04154af2cfcf3ca4e7f2f4efb28adc810de001e953ed0e931",
+				"DiscoKey":   "discokey:0222a393efb07131e7252e209d3fec4b02a4a82593dae27c8235bba2bddb286d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34815",
+					"10.65.0.27:34815",
+					"172.17.0.1:34815",
+					"172.18.0.1:34815",
+					"172.19.0.1:34815"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:04:02.26957766Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7256259790599196,
+				"StableID":   "n5RTo8eNfy11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:314ac8266cda6ea00529453da3f9134c72ac1b5d32a98bdcb022ea6c1760d36a",
+				"DiscoKey":   "discokey:5fb7f0056678e4ef9a5e7a14613d5ca9bacc93fb6d19f0d6cba3ccf7347ba935",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37358",
+					"10.65.0.27:37358",
+					"172.17.0.1:37358",
+					"172.18.0.1:37358",
+					"172.19.0.1:37358"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:04:03.366226325Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8866242676376056,
+				"StableID":   "nVToHKAYEC21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:95e3dbacf62755330755f826c88d014a853c8835b8920072b28f3ff0cd136710",
+				"DiscoKey":   "discokey:153357c13f1f53e0d3f3269a37ac764a867d8d8726eeae558b4412b744f2c71c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38980",
+					"10.65.0.27:38980",
+					"172.17.0.1:38980",
+					"172.18.0.1:38980",
+					"172.19.0.1:38980"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:04:03.878870759Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4183096974344498,
+				"StableID":   "nHaFH8sXfZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:9d13d918f3d1667ba114de999f3488a12aeba0e1eb3f98d21aa4273370571825",
+				"KeyExpiry":  "2026-11-08T22:04:04Z",
+				"DiscoKey":   "discokey:c5a10e0e2aace4be32efb41204a48c6e5742c244f797a1f42b21b2e09fcb104c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52565",
+					"10.65.0.27:52565",
+					"172.17.0.1:52565",
+					"172.18.0.1:52565",
+					"172.19.0.1:52565"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:04:04.410786066Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1143258373116122,
+				"StableID":   "noqcXcTnv911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:56ce887d809a311cab53e0de6d15e6344974e43021fbb52918e9b4a6fb8a011f",
+				"KeyExpiry":  "2026-11-08T22:04:04Z",
+				"DiscoKey":   "discokey:8a27a7485193808a62e44fedf19f31f28113ea13b0bb827f7d61a9253499035c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:56489",
+					"10.65.0.27:56489",
+					"172.17.0.1:56489",
+					"172.18.0.1:56489",
+					"172.19.0.1:56489"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:04:04.955311027Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         596461305159325,
+				"StableID":   "nG4y3a29f511CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:891e465b69ae1cf5562e9ff2e0473b49747bce485eace73f48775fd70f861b35",
+				"KeyExpiry":  "2026-11-08T22:04:05Z",
+				"DiscoKey":   "discokey:93a1a49309e8858bd88f2037776bcd02def0a08372e1fb869da8ff778be30b22",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58364",
+					"10.65.0.27:58364",
+					"172.17.0.1:58364",
+					"172.18.0.1:58364",
+					"172.19.0.1:58364"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:04:05.485132805Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2601977946505300": {
+				"ID":          2601977946505300,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-user-empty.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-user-empty.hujson
@@ -1,0 +1,20081 @@
+// ssh-malformed-user-empty
+//
+// ssh users empty string is rejected
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T22:04:50Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-malformed-user-empty",
+	"description":    "ssh users empty string is rejected",
+	"category":       "ssh",
+	"captured_at":    "2026-05-12T22:04:50.719974996Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "user \"\" is not valid"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                           \n  \n                                                      \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh users empty string is rejected\",\n\t\"id\":          \"ssh-malformed-user-empty\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"autogroup:member\"],\n\t\t\"users\":  [\"\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-malformed/ssh-malformed-user-empty.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["autogroup:member"],
+				"users":  [""]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2629265752823742,
+				"StableID":   "nVGc5UMoXM11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       2629265752823742,
+				"Key":        "nodekey:34eb9266115cae5fa7a95ec41f0b292e24b32e3cb5107e9ce22a1c96aa968a4e",
+				"DiscoKey":   "discokey:e98f9e3abaa925a8bd66816c8e233ded5edece0df12732b22bd4bee9eb902e71",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:43943",
+					"10.65.0.27:43943",
+					"172.17.0.1:43943",
+					"172.18.0.1:43943",
+					"172.19.0.1:43943"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:04:59.260550637Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:34eb9266115cae5fa7a95ec41f0b292e24b32e3cb5107e9ce22a1c96aa968a4e",
+			"MachineKey": "mkey:6b243735ba529fe926eb98577f56844214ebc78b27f13dcc2620dd94af11f90d",
+			"Peers": [{
+				"ID":         1770596395891989,
+				"StableID":   "nGcBPmZupE11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5cf7dfb4297359ba0cbe6a5549d262270262bb58f1cb1a4ada6fd5fd15486e44",
+				"DiscoKey":   "discokey:1dc406d8a4bafdc881e8974ccecb5a92e24245044d97f0e3d55c82ab99479d45",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45825",
+					"10.65.0.27:45825",
+					"172.17.0.1:45825",
+					"172.18.0.1:45825",
+					"172.19.0.1:45825"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:04:53.28601152Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3942388568942736,
+				"StableID":   "nFYCm2sWnX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c80b637ba63929596fb9c22e2a7468dbaab733069168b01d4ff816970739166",
+				"DiscoKey":   "discokey:38439748949c62696fbe55350c97c9661b3ff33c00f0d09f2e6a77e7b3d8dc36",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37836",
+					"10.65.0.27:37836",
+					"172.17.0.1:37836",
+					"172.18.0.1:37836",
+					"172.19.0.1:37836"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:04:53.845326821Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7212130025057101,
+				"StableID":   "nEh3YiRPKy11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b26a5c2a4f87c18fc1a00171f60450a37aedf2fa426bd4a0e9998f695621f928",
+				"DiscoKey":   "discokey:cafc2407dedf41d2d3761d34cc6b766f7bd33d573feb2f7ca3b7f8ad558d7349",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56446",
+					"10.65.0.27:56446",
+					"172.17.0.1:56446",
+					"172.18.0.1:56446",
+					"172.19.0.1:56446"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:04:54.384411336Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         360229614638466,
+				"StableID":   "n9iqV2d9p311CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d9b3a85b8cb084191b3f7c65f16709c64f87c6c3854c2244b39a095be533138",
+				"DiscoKey":   "discokey:653d836afa376ee374e3b7c4db02b231b95b7cf68cf40d0e53da053778f8ef02",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:33116",
+					"10.65.0.27:33116",
+					"172.17.0.1:33116",
+					"172.18.0.1:33116",
+					"172.19.0.1:33116"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:04:54.922892486Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6337623294980712,
+				"StableID":   "nsvYQocKVr11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2cfdb9918eeb82ad8c4295473a8fa2964dfe2f1fe762f078c65fa5dbc9b35f2c",
+				"DiscoKey":   "discokey:e8d91f92594501d59046c1bd5ccb13550b6933ce95e937eae25cf8f622d8af6c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:44550",
+					"10.65.0.27:44550",
+					"172.17.0.1:44550",
+					"172.18.0.1:44550",
+					"172.19.0.1:44550"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:04:55.470595979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8719344879493080,
+				"StableID":   "n7YQ1UQ16B21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0121f40f1a20bf008e0ece0d7a3c83be6ee6f2564004d2a987156b00a9a8d741",
+				"DiscoKey":   "discokey:e6d28307f3d72528a67867a46b109ab83fd8b39b95ba183c2414f4203a854551",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:49291",
+					"10.65.0.27:49291",
+					"172.17.0.1:49291",
+					"172.18.0.1:49291",
+					"172.19.0.1:49291"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:04:56.011981447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7957743326954469,
+				"StableID":   "nQStnYR59521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:795220efe59a5cba12a775616ca9f352a48b59683e817635a8b0ee49e5179403",
+				"DiscoKey":   "discokey:f24791597a8b920b696c5b7574adbfe36be625ee71495a00e7fc65f14ca58330",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:32813",
+					"10.65.0.27:32813",
+					"172.17.0.1:32813",
+					"172.18.0.1:32813",
+					"172.19.0.1:32813"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:04:56.557914474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4487305531704325,
+				"StableID":   "nrfHncuJ3c11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ade330f965f0d4c410ab9a6839ff110c2d893ec5297d824a3751937b02bbe276",
+				"DiscoKey":   "discokey:0b57ce9bca09724ae0661843b142c9a3207b7b676f67896697f211d41fcbe40a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47557",
+					"10.65.0.27:47557",
+					"172.17.0.1:47557",
+					"172.18.0.1:47557",
+					"172.19.0.1:47557"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:04:57.101221392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3139133500763793,
+				"StableID":   "nCGH1RiiWR11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:287256207188031c99d92d2f9d92d92cf79d024e832f0dc8c2918bd103a1f773",
+				"DiscoKey":   "discokey:b76d2f6d79be8fdcb7b9a5f7b0495289f02e5411987c4a44148bb29ceb845202",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52703",
+					"10.65.0.27:52703",
+					"172.17.0.1:52703",
+					"172.18.0.1:52703",
+					"172.19.0.1:52703"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:04:57.636274753Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3522558669834099,
+				"StableID":   "nSadDJeNWU11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec5aad01f42d5b38d2acd4a00160cf739a79773c84022bacbe7063199070ea56",
+				"DiscoKey":   "discokey:732b43a5f2f493992e756a34fd52fc4de3dc8056a53bc2d9d6143739e3a1237b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38896",
+					"10.65.0.27:38896",
+					"172.17.0.1:38896",
+					"172.18.0.1:38896",
+					"172.19.0.1:38896"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:04:58.187769363Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3960847348496095,
+				"StableID":   "nkXKu7ksvX11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:44b8f6b1946ae7479c03facc963012e7822f7188052cdeaef18273958364ef7b",
+				"DiscoKey":   "discokey:9e93a855c013835052af1e15af9602abf5eeee184fb857aac699fe996b04d123",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58140",
+					"10.65.0.27:58140",
+					"172.17.0.1:58140",
+					"172.18.0.1:58140",
+					"172.19.0.1:58140"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:04:58.730257208Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         284466274045946,
+				"StableID":   "nfheXuSqD311CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6bcd00261e125e0249cb365a75412811c61f011f87bf3e3d719cc79560354c78",
+				"KeyExpiry":  "2026-11-08T22:04:59Z",
+				"DiscoKey":   "discokey:7aeb63544520cdd6c176d5a2cbe91f6324d77e2482260997f8b3b3e7aa0a9919",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45306",
+					"10.65.0.27:45306",
+					"172.17.0.1:45306",
+					"172.18.0.1:45306",
+					"172.19.0.1:45306"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:04:59.818377845Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         385019259895652,
+				"StableID":   "nBQWZaoN1411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:500a68a11ef98a8383a58752c3adf7edc12d71bf04bc01ec1da9ab7f91545416",
+				"KeyExpiry":  "2026-11-08T22:05:00Z",
+				"DiscoKey":   "discokey:9c8796da79dc4b32df74275b2d2002f826adb285ae343f4cb3b0f955c2e9c01c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52849",
+					"10.65.0.27:52849",
+					"172.17.0.1:52849",
+					"172.18.0.1:52849",
+					"172.19.0.1:52849"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:05:00.342818144Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3826583399242238,
+				"StableID":   "n77NUir4tW11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7b66b60cfa40905c6f133bc8846777495e032df2e0a4e02fd32f8581f0f6e34c",
+				"KeyExpiry":  "2026-11-08T22:05:00Z",
+				"DiscoKey":   "discokey:692efc2015785f6383d1833a8d9fa1b0f59126bb2c135de3ecbd268a447f046e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58975",
+					"10.65.0.27:58975",
+					"172.17.0.1:58975",
+					"172.18.0.1:58975",
+					"172.19.0.1:58975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:05:00.879242259Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2629265752823742": {
+				"ID":          2629265752823742,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8719344879493080,
+				"StableID":   "n7YQ1UQ16B21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       8719344879493080,
+				"Key":        "nodekey:0121f40f1a20bf008e0ece0d7a3c83be6ee6f2564004d2a987156b00a9a8d741",
+				"DiscoKey":   "discokey:e6d28307f3d72528a67867a46b109ab83fd8b39b95ba183c2414f4203a854551",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:49291",
+					"10.65.0.27:49291",
+					"172.17.0.1:49291",
+					"172.18.0.1:49291",
+					"172.19.0.1:49291"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:04:56.011981447Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0121f40f1a20bf008e0ece0d7a3c83be6ee6f2564004d2a987156b00a9a8d741",
+			"MachineKey": "mkey:bf4575becf705a183836883c3823df656e9fe0e9069ef42cd4154bf2971a0205",
+			"Peers": [{
+				"ID":         1770596395891989,
+				"StableID":   "nGcBPmZupE11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5cf7dfb4297359ba0cbe6a5549d262270262bb58f1cb1a4ada6fd5fd15486e44",
+				"DiscoKey":   "discokey:1dc406d8a4bafdc881e8974ccecb5a92e24245044d97f0e3d55c82ab99479d45",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45825",
+					"10.65.0.27:45825",
+					"172.17.0.1:45825",
+					"172.18.0.1:45825",
+					"172.19.0.1:45825"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:04:53.28601152Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3942388568942736,
+				"StableID":   "nFYCm2sWnX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c80b637ba63929596fb9c22e2a7468dbaab733069168b01d4ff816970739166",
+				"DiscoKey":   "discokey:38439748949c62696fbe55350c97c9661b3ff33c00f0d09f2e6a77e7b3d8dc36",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37836",
+					"10.65.0.27:37836",
+					"172.17.0.1:37836",
+					"172.18.0.1:37836",
+					"172.19.0.1:37836"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:04:53.845326821Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7212130025057101,
+				"StableID":   "nEh3YiRPKy11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b26a5c2a4f87c18fc1a00171f60450a37aedf2fa426bd4a0e9998f695621f928",
+				"DiscoKey":   "discokey:cafc2407dedf41d2d3761d34cc6b766f7bd33d573feb2f7ca3b7f8ad558d7349",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56446",
+					"10.65.0.27:56446",
+					"172.17.0.1:56446",
+					"172.18.0.1:56446",
+					"172.19.0.1:56446"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:04:54.384411336Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         360229614638466,
+				"StableID":   "n9iqV2d9p311CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d9b3a85b8cb084191b3f7c65f16709c64f87c6c3854c2244b39a095be533138",
+				"DiscoKey":   "discokey:653d836afa376ee374e3b7c4db02b231b95b7cf68cf40d0e53da053778f8ef02",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:33116",
+					"10.65.0.27:33116",
+					"172.17.0.1:33116",
+					"172.18.0.1:33116",
+					"172.19.0.1:33116"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:04:54.922892486Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6337623294980712,
+				"StableID":   "nsvYQocKVr11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2cfdb9918eeb82ad8c4295473a8fa2964dfe2f1fe762f078c65fa5dbc9b35f2c",
+				"DiscoKey":   "discokey:e8d91f92594501d59046c1bd5ccb13550b6933ce95e937eae25cf8f622d8af6c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:44550",
+					"10.65.0.27:44550",
+					"172.17.0.1:44550",
+					"172.18.0.1:44550",
+					"172.19.0.1:44550"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:04:55.470595979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7957743326954469,
+				"StableID":   "nQStnYR59521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:795220efe59a5cba12a775616ca9f352a48b59683e817635a8b0ee49e5179403",
+				"DiscoKey":   "discokey:f24791597a8b920b696c5b7574adbfe36be625ee71495a00e7fc65f14ca58330",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:32813",
+					"10.65.0.27:32813",
+					"172.17.0.1:32813",
+					"172.18.0.1:32813",
+					"172.19.0.1:32813"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:04:56.557914474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4487305531704325,
+				"StableID":   "nrfHncuJ3c11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ade330f965f0d4c410ab9a6839ff110c2d893ec5297d824a3751937b02bbe276",
+				"DiscoKey":   "discokey:0b57ce9bca09724ae0661843b142c9a3207b7b676f67896697f211d41fcbe40a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47557",
+					"10.65.0.27:47557",
+					"172.17.0.1:47557",
+					"172.18.0.1:47557",
+					"172.19.0.1:47557"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:04:57.101221392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3139133500763793,
+				"StableID":   "nCGH1RiiWR11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:287256207188031c99d92d2f9d92d92cf79d024e832f0dc8c2918bd103a1f773",
+				"DiscoKey":   "discokey:b76d2f6d79be8fdcb7b9a5f7b0495289f02e5411987c4a44148bb29ceb845202",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52703",
+					"10.65.0.27:52703",
+					"172.17.0.1:52703",
+					"172.18.0.1:52703",
+					"172.19.0.1:52703"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:04:57.636274753Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3522558669834099,
+				"StableID":   "nSadDJeNWU11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec5aad01f42d5b38d2acd4a00160cf739a79773c84022bacbe7063199070ea56",
+				"DiscoKey":   "discokey:732b43a5f2f493992e756a34fd52fc4de3dc8056a53bc2d9d6143739e3a1237b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38896",
+					"10.65.0.27:38896",
+					"172.17.0.1:38896",
+					"172.18.0.1:38896",
+					"172.19.0.1:38896"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:04:58.187769363Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3960847348496095,
+				"StableID":   "nkXKu7ksvX11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:44b8f6b1946ae7479c03facc963012e7822f7188052cdeaef18273958364ef7b",
+				"DiscoKey":   "discokey:9e93a855c013835052af1e15af9602abf5eeee184fb857aac699fe996b04d123",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58140",
+					"10.65.0.27:58140",
+					"172.17.0.1:58140",
+					"172.18.0.1:58140",
+					"172.19.0.1:58140"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:04:58.730257208Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2629265752823742,
+				"StableID":   "nVGc5UMoXM11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:34eb9266115cae5fa7a95ec41f0b292e24b32e3cb5107e9ce22a1c96aa968a4e",
+				"DiscoKey":   "discokey:e98f9e3abaa925a8bd66816c8e233ded5edece0df12732b22bd4bee9eb902e71",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:43943",
+					"10.65.0.27:43943",
+					"172.17.0.1:43943",
+					"172.18.0.1:43943",
+					"172.19.0.1:43943"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:04:59.260550637Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         284466274045946,
+				"StableID":   "nfheXuSqD311CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6bcd00261e125e0249cb365a75412811c61f011f87bf3e3d719cc79560354c78",
+				"KeyExpiry":  "2026-11-08T22:04:59Z",
+				"DiscoKey":   "discokey:7aeb63544520cdd6c176d5a2cbe91f6324d77e2482260997f8b3b3e7aa0a9919",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45306",
+					"10.65.0.27:45306",
+					"172.17.0.1:45306",
+					"172.18.0.1:45306",
+					"172.19.0.1:45306"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:04:59.818377845Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         385019259895652,
+				"StableID":   "nBQWZaoN1411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:500a68a11ef98a8383a58752c3adf7edc12d71bf04bc01ec1da9ab7f91545416",
+				"KeyExpiry":  "2026-11-08T22:05:00Z",
+				"DiscoKey":   "discokey:9c8796da79dc4b32df74275b2d2002f826adb285ae343f4cb3b0f955c2e9c01c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52849",
+					"10.65.0.27:52849",
+					"172.17.0.1:52849",
+					"172.18.0.1:52849",
+					"172.19.0.1:52849"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:05:00.342818144Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3826583399242238,
+				"StableID":   "n77NUir4tW11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7b66b60cfa40905c6f133bc8846777495e032df2e0a4e02fd32f8581f0f6e34c",
+				"KeyExpiry":  "2026-11-08T22:05:00Z",
+				"DiscoKey":   "discokey:692efc2015785f6383d1833a8d9fa1b0f59126bb2c135de3ecbd268a447f046e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58975",
+					"10.65.0.27:58975",
+					"172.17.0.1:58975",
+					"172.18.0.1:58975",
+					"172.19.0.1:58975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:05:00.879242259Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8719344879493080": {
+				"ID":          8719344879493080,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3826583399242238,
+				"StableID":   "n77NUir4tW11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7b66b60cfa40905c6f133bc8846777495e032df2e0a4e02fd32f8581f0f6e34c",
+				"KeyExpiry":  "2026-11-08T22:05:00Z",
+				"DiscoKey":   "discokey:692efc2015785f6383d1833a8d9fa1b0f59126bb2c135de3ecbd268a447f046e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58975",
+					"10.65.0.27:58975",
+					"172.17.0.1:58975",
+					"172.18.0.1:58975",
+					"172.19.0.1:58975"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:05:00.879242259Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7b66b60cfa40905c6f133bc8846777495e032df2e0a4e02fd32f8581f0f6e34c",
+			"MachineKey": "mkey:227381f4ff54f058b83fea19dba30964091dd039b5ceb5bb2631706d3448e365",
+			"Peers": [{
+				"ID":         1770596395891989,
+				"StableID":   "nGcBPmZupE11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5cf7dfb4297359ba0cbe6a5549d262270262bb58f1cb1a4ada6fd5fd15486e44",
+				"DiscoKey":   "discokey:1dc406d8a4bafdc881e8974ccecb5a92e24245044d97f0e3d55c82ab99479d45",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45825",
+					"10.65.0.27:45825",
+					"172.17.0.1:45825",
+					"172.18.0.1:45825",
+					"172.19.0.1:45825"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:04:53.28601152Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3942388568942736,
+				"StableID":   "nFYCm2sWnX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c80b637ba63929596fb9c22e2a7468dbaab733069168b01d4ff816970739166",
+				"DiscoKey":   "discokey:38439748949c62696fbe55350c97c9661b3ff33c00f0d09f2e6a77e7b3d8dc36",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37836",
+					"10.65.0.27:37836",
+					"172.17.0.1:37836",
+					"172.18.0.1:37836",
+					"172.19.0.1:37836"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:04:53.845326821Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7212130025057101,
+				"StableID":   "nEh3YiRPKy11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b26a5c2a4f87c18fc1a00171f60450a37aedf2fa426bd4a0e9998f695621f928",
+				"DiscoKey":   "discokey:cafc2407dedf41d2d3761d34cc6b766f7bd33d573feb2f7ca3b7f8ad558d7349",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56446",
+					"10.65.0.27:56446",
+					"172.17.0.1:56446",
+					"172.18.0.1:56446",
+					"172.19.0.1:56446"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:04:54.384411336Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         360229614638466,
+				"StableID":   "n9iqV2d9p311CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d9b3a85b8cb084191b3f7c65f16709c64f87c6c3854c2244b39a095be533138",
+				"DiscoKey":   "discokey:653d836afa376ee374e3b7c4db02b231b95b7cf68cf40d0e53da053778f8ef02",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:33116",
+					"10.65.0.27:33116",
+					"172.17.0.1:33116",
+					"172.18.0.1:33116",
+					"172.19.0.1:33116"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:04:54.922892486Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6337623294980712,
+				"StableID":   "nsvYQocKVr11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2cfdb9918eeb82ad8c4295473a8fa2964dfe2f1fe762f078c65fa5dbc9b35f2c",
+				"DiscoKey":   "discokey:e8d91f92594501d59046c1bd5ccb13550b6933ce95e937eae25cf8f622d8af6c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:44550",
+					"10.65.0.27:44550",
+					"172.17.0.1:44550",
+					"172.18.0.1:44550",
+					"172.19.0.1:44550"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:04:55.470595979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8719344879493080,
+				"StableID":   "n7YQ1UQ16B21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0121f40f1a20bf008e0ece0d7a3c83be6ee6f2564004d2a987156b00a9a8d741",
+				"DiscoKey":   "discokey:e6d28307f3d72528a67867a46b109ab83fd8b39b95ba183c2414f4203a854551",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:49291",
+					"10.65.0.27:49291",
+					"172.17.0.1:49291",
+					"172.18.0.1:49291",
+					"172.19.0.1:49291"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:04:56.011981447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7957743326954469,
+				"StableID":   "nQStnYR59521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:795220efe59a5cba12a775616ca9f352a48b59683e817635a8b0ee49e5179403",
+				"DiscoKey":   "discokey:f24791597a8b920b696c5b7574adbfe36be625ee71495a00e7fc65f14ca58330",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:32813",
+					"10.65.0.27:32813",
+					"172.17.0.1:32813",
+					"172.18.0.1:32813",
+					"172.19.0.1:32813"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:04:56.557914474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4487305531704325,
+				"StableID":   "nrfHncuJ3c11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ade330f965f0d4c410ab9a6839ff110c2d893ec5297d824a3751937b02bbe276",
+				"DiscoKey":   "discokey:0b57ce9bca09724ae0661843b142c9a3207b7b676f67896697f211d41fcbe40a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47557",
+					"10.65.0.27:47557",
+					"172.17.0.1:47557",
+					"172.18.0.1:47557",
+					"172.19.0.1:47557"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:04:57.101221392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3139133500763793,
+				"StableID":   "nCGH1RiiWR11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:287256207188031c99d92d2f9d92d92cf79d024e832f0dc8c2918bd103a1f773",
+				"DiscoKey":   "discokey:b76d2f6d79be8fdcb7b9a5f7b0495289f02e5411987c4a44148bb29ceb845202",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52703",
+					"10.65.0.27:52703",
+					"172.17.0.1:52703",
+					"172.18.0.1:52703",
+					"172.19.0.1:52703"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:04:57.636274753Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3522558669834099,
+				"StableID":   "nSadDJeNWU11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec5aad01f42d5b38d2acd4a00160cf739a79773c84022bacbe7063199070ea56",
+				"DiscoKey":   "discokey:732b43a5f2f493992e756a34fd52fc4de3dc8056a53bc2d9d6143739e3a1237b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38896",
+					"10.65.0.27:38896",
+					"172.17.0.1:38896",
+					"172.18.0.1:38896",
+					"172.19.0.1:38896"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:04:58.187769363Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3960847348496095,
+				"StableID":   "nkXKu7ksvX11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:44b8f6b1946ae7479c03facc963012e7822f7188052cdeaef18273958364ef7b",
+				"DiscoKey":   "discokey:9e93a855c013835052af1e15af9602abf5eeee184fb857aac699fe996b04d123",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58140",
+					"10.65.0.27:58140",
+					"172.17.0.1:58140",
+					"172.18.0.1:58140",
+					"172.19.0.1:58140"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:04:58.730257208Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2629265752823742,
+				"StableID":   "nVGc5UMoXM11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:34eb9266115cae5fa7a95ec41f0b292e24b32e3cb5107e9ce22a1c96aa968a4e",
+				"DiscoKey":   "discokey:e98f9e3abaa925a8bd66816c8e233ded5edece0df12732b22bd4bee9eb902e71",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:43943",
+					"10.65.0.27:43943",
+					"172.17.0.1:43943",
+					"172.18.0.1:43943",
+					"172.19.0.1:43943"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:04:59.260550637Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         284466274045946,
+				"StableID":   "nfheXuSqD311CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6bcd00261e125e0249cb365a75412811c61f011f87bf3e3d719cc79560354c78",
+				"KeyExpiry":  "2026-11-08T22:04:59Z",
+				"DiscoKey":   "discokey:7aeb63544520cdd6c176d5a2cbe91f6324d77e2482260997f8b3b3e7aa0a9919",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45306",
+					"10.65.0.27:45306",
+					"172.17.0.1:45306",
+					"172.18.0.1:45306",
+					"172.19.0.1:45306"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:04:59.818377845Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         385019259895652,
+				"StableID":   "nBQWZaoN1411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:500a68a11ef98a8383a58752c3adf7edc12d71bf04bc01ec1da9ab7f91545416",
+				"KeyExpiry":  "2026-11-08T22:05:00Z",
+				"DiscoKey":   "discokey:9c8796da79dc4b32df74275b2d2002f826adb285ae343f4cb3b0f955c2e9c01c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52849",
+					"10.65.0.27:52849",
+					"172.17.0.1:52849",
+					"172.18.0.1:52849",
+					"172.19.0.1:52849"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:05:00.342818144Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7212130025057101,
+				"StableID":   "nEh3YiRPKy11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       7212130025057101,
+				"Key":        "nodekey:b26a5c2a4f87c18fc1a00171f60450a37aedf2fa426bd4a0e9998f695621f928",
+				"DiscoKey":   "discokey:cafc2407dedf41d2d3761d34cc6b766f7bd33d573feb2f7ca3b7f8ad558d7349",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56446",
+					"10.65.0.27:56446",
+					"172.17.0.1:56446",
+					"172.18.0.1:56446",
+					"172.19.0.1:56446"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:04:54.384411336Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b26a5c2a4f87c18fc1a00171f60450a37aedf2fa426bd4a0e9998f695621f928",
+			"MachineKey": "mkey:12641136690537c6ef4d83e79dc033d76c7c272fb18253544a8ba5027e853c6b",
+			"Peers": [{
+				"ID":         1770596395891989,
+				"StableID":   "nGcBPmZupE11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5cf7dfb4297359ba0cbe6a5549d262270262bb58f1cb1a4ada6fd5fd15486e44",
+				"DiscoKey":   "discokey:1dc406d8a4bafdc881e8974ccecb5a92e24245044d97f0e3d55c82ab99479d45",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45825",
+					"10.65.0.27:45825",
+					"172.17.0.1:45825",
+					"172.18.0.1:45825",
+					"172.19.0.1:45825"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:04:53.28601152Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3942388568942736,
+				"StableID":   "nFYCm2sWnX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c80b637ba63929596fb9c22e2a7468dbaab733069168b01d4ff816970739166",
+				"DiscoKey":   "discokey:38439748949c62696fbe55350c97c9661b3ff33c00f0d09f2e6a77e7b3d8dc36",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37836",
+					"10.65.0.27:37836",
+					"172.17.0.1:37836",
+					"172.18.0.1:37836",
+					"172.19.0.1:37836"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:04:53.845326821Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         360229614638466,
+				"StableID":   "n9iqV2d9p311CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d9b3a85b8cb084191b3f7c65f16709c64f87c6c3854c2244b39a095be533138",
+				"DiscoKey":   "discokey:653d836afa376ee374e3b7c4db02b231b95b7cf68cf40d0e53da053778f8ef02",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:33116",
+					"10.65.0.27:33116",
+					"172.17.0.1:33116",
+					"172.18.0.1:33116",
+					"172.19.0.1:33116"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:04:54.922892486Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6337623294980712,
+				"StableID":   "nsvYQocKVr11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2cfdb9918eeb82ad8c4295473a8fa2964dfe2f1fe762f078c65fa5dbc9b35f2c",
+				"DiscoKey":   "discokey:e8d91f92594501d59046c1bd5ccb13550b6933ce95e937eae25cf8f622d8af6c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:44550",
+					"10.65.0.27:44550",
+					"172.17.0.1:44550",
+					"172.18.0.1:44550",
+					"172.19.0.1:44550"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:04:55.470595979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8719344879493080,
+				"StableID":   "n7YQ1UQ16B21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0121f40f1a20bf008e0ece0d7a3c83be6ee6f2564004d2a987156b00a9a8d741",
+				"DiscoKey":   "discokey:e6d28307f3d72528a67867a46b109ab83fd8b39b95ba183c2414f4203a854551",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:49291",
+					"10.65.0.27:49291",
+					"172.17.0.1:49291",
+					"172.18.0.1:49291",
+					"172.19.0.1:49291"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:04:56.011981447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7957743326954469,
+				"StableID":   "nQStnYR59521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:795220efe59a5cba12a775616ca9f352a48b59683e817635a8b0ee49e5179403",
+				"DiscoKey":   "discokey:f24791597a8b920b696c5b7574adbfe36be625ee71495a00e7fc65f14ca58330",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:32813",
+					"10.65.0.27:32813",
+					"172.17.0.1:32813",
+					"172.18.0.1:32813",
+					"172.19.0.1:32813"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:04:56.557914474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4487305531704325,
+				"StableID":   "nrfHncuJ3c11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ade330f965f0d4c410ab9a6839ff110c2d893ec5297d824a3751937b02bbe276",
+				"DiscoKey":   "discokey:0b57ce9bca09724ae0661843b142c9a3207b7b676f67896697f211d41fcbe40a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47557",
+					"10.65.0.27:47557",
+					"172.17.0.1:47557",
+					"172.18.0.1:47557",
+					"172.19.0.1:47557"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:04:57.101221392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3139133500763793,
+				"StableID":   "nCGH1RiiWR11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:287256207188031c99d92d2f9d92d92cf79d024e832f0dc8c2918bd103a1f773",
+				"DiscoKey":   "discokey:b76d2f6d79be8fdcb7b9a5f7b0495289f02e5411987c4a44148bb29ceb845202",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52703",
+					"10.65.0.27:52703",
+					"172.17.0.1:52703",
+					"172.18.0.1:52703",
+					"172.19.0.1:52703"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:04:57.636274753Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3522558669834099,
+				"StableID":   "nSadDJeNWU11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec5aad01f42d5b38d2acd4a00160cf739a79773c84022bacbe7063199070ea56",
+				"DiscoKey":   "discokey:732b43a5f2f493992e756a34fd52fc4de3dc8056a53bc2d9d6143739e3a1237b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38896",
+					"10.65.0.27:38896",
+					"172.17.0.1:38896",
+					"172.18.0.1:38896",
+					"172.19.0.1:38896"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:04:58.187769363Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3960847348496095,
+				"StableID":   "nkXKu7ksvX11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:44b8f6b1946ae7479c03facc963012e7822f7188052cdeaef18273958364ef7b",
+				"DiscoKey":   "discokey:9e93a855c013835052af1e15af9602abf5eeee184fb857aac699fe996b04d123",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58140",
+					"10.65.0.27:58140",
+					"172.17.0.1:58140",
+					"172.18.0.1:58140",
+					"172.19.0.1:58140"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:04:58.730257208Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2629265752823742,
+				"StableID":   "nVGc5UMoXM11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:34eb9266115cae5fa7a95ec41f0b292e24b32e3cb5107e9ce22a1c96aa968a4e",
+				"DiscoKey":   "discokey:e98f9e3abaa925a8bd66816c8e233ded5edece0df12732b22bd4bee9eb902e71",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:43943",
+					"10.65.0.27:43943",
+					"172.17.0.1:43943",
+					"172.18.0.1:43943",
+					"172.19.0.1:43943"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:04:59.260550637Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         284466274045946,
+				"StableID":   "nfheXuSqD311CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6bcd00261e125e0249cb365a75412811c61f011f87bf3e3d719cc79560354c78",
+				"KeyExpiry":  "2026-11-08T22:04:59Z",
+				"DiscoKey":   "discokey:7aeb63544520cdd6c176d5a2cbe91f6324d77e2482260997f8b3b3e7aa0a9919",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45306",
+					"10.65.0.27:45306",
+					"172.17.0.1:45306",
+					"172.18.0.1:45306",
+					"172.19.0.1:45306"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:04:59.818377845Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         385019259895652,
+				"StableID":   "nBQWZaoN1411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:500a68a11ef98a8383a58752c3adf7edc12d71bf04bc01ec1da9ab7f91545416",
+				"KeyExpiry":  "2026-11-08T22:05:00Z",
+				"DiscoKey":   "discokey:9c8796da79dc4b32df74275b2d2002f826adb285ae343f4cb3b0f955c2e9c01c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52849",
+					"10.65.0.27:52849",
+					"172.17.0.1:52849",
+					"172.18.0.1:52849",
+					"172.19.0.1:52849"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:05:00.342818144Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3826583399242238,
+				"StableID":   "n77NUir4tW11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7b66b60cfa40905c6f133bc8846777495e032df2e0a4e02fd32f8581f0f6e34c",
+				"KeyExpiry":  "2026-11-08T22:05:00Z",
+				"DiscoKey":   "discokey:692efc2015785f6383d1833a8d9fa1b0f59126bb2c135de3ecbd268a447f046e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58975",
+					"10.65.0.27:58975",
+					"172.17.0.1:58975",
+					"172.18.0.1:58975",
+					"172.19.0.1:58975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:05:00.879242259Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7212130025057101": {
+				"ID":          7212130025057101,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4487305531704325,
+				"StableID":   "nrfHncuJ3c11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       4487305531704325,
+				"Key":        "nodekey:ade330f965f0d4c410ab9a6839ff110c2d893ec5297d824a3751937b02bbe276",
+				"DiscoKey":   "discokey:0b57ce9bca09724ae0661843b142c9a3207b7b676f67896697f211d41fcbe40a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47557",
+					"10.65.0.27:47557",
+					"172.17.0.1:47557",
+					"172.18.0.1:47557",
+					"172.19.0.1:47557"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:04:57.101221392Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ade330f965f0d4c410ab9a6839ff110c2d893ec5297d824a3751937b02bbe276",
+			"MachineKey": "mkey:f5ee1c196cad72e8629027612f19f9fc166cbe66609540fed99e743c52ca8d6e",
+			"Peers": [{
+				"ID":         1770596395891989,
+				"StableID":   "nGcBPmZupE11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5cf7dfb4297359ba0cbe6a5549d262270262bb58f1cb1a4ada6fd5fd15486e44",
+				"DiscoKey":   "discokey:1dc406d8a4bafdc881e8974ccecb5a92e24245044d97f0e3d55c82ab99479d45",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45825",
+					"10.65.0.27:45825",
+					"172.17.0.1:45825",
+					"172.18.0.1:45825",
+					"172.19.0.1:45825"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:04:53.28601152Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3942388568942736,
+				"StableID":   "nFYCm2sWnX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c80b637ba63929596fb9c22e2a7468dbaab733069168b01d4ff816970739166",
+				"DiscoKey":   "discokey:38439748949c62696fbe55350c97c9661b3ff33c00f0d09f2e6a77e7b3d8dc36",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37836",
+					"10.65.0.27:37836",
+					"172.17.0.1:37836",
+					"172.18.0.1:37836",
+					"172.19.0.1:37836"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:04:53.845326821Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7212130025057101,
+				"StableID":   "nEh3YiRPKy11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b26a5c2a4f87c18fc1a00171f60450a37aedf2fa426bd4a0e9998f695621f928",
+				"DiscoKey":   "discokey:cafc2407dedf41d2d3761d34cc6b766f7bd33d573feb2f7ca3b7f8ad558d7349",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56446",
+					"10.65.0.27:56446",
+					"172.17.0.1:56446",
+					"172.18.0.1:56446",
+					"172.19.0.1:56446"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:04:54.384411336Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         360229614638466,
+				"StableID":   "n9iqV2d9p311CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d9b3a85b8cb084191b3f7c65f16709c64f87c6c3854c2244b39a095be533138",
+				"DiscoKey":   "discokey:653d836afa376ee374e3b7c4db02b231b95b7cf68cf40d0e53da053778f8ef02",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:33116",
+					"10.65.0.27:33116",
+					"172.17.0.1:33116",
+					"172.18.0.1:33116",
+					"172.19.0.1:33116"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:04:54.922892486Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6337623294980712,
+				"StableID":   "nsvYQocKVr11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2cfdb9918eeb82ad8c4295473a8fa2964dfe2f1fe762f078c65fa5dbc9b35f2c",
+				"DiscoKey":   "discokey:e8d91f92594501d59046c1bd5ccb13550b6933ce95e937eae25cf8f622d8af6c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:44550",
+					"10.65.0.27:44550",
+					"172.17.0.1:44550",
+					"172.18.0.1:44550",
+					"172.19.0.1:44550"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:04:55.470595979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8719344879493080,
+				"StableID":   "n7YQ1UQ16B21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0121f40f1a20bf008e0ece0d7a3c83be6ee6f2564004d2a987156b00a9a8d741",
+				"DiscoKey":   "discokey:e6d28307f3d72528a67867a46b109ab83fd8b39b95ba183c2414f4203a854551",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:49291",
+					"10.65.0.27:49291",
+					"172.17.0.1:49291",
+					"172.18.0.1:49291",
+					"172.19.0.1:49291"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:04:56.011981447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7957743326954469,
+				"StableID":   "nQStnYR59521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:795220efe59a5cba12a775616ca9f352a48b59683e817635a8b0ee49e5179403",
+				"DiscoKey":   "discokey:f24791597a8b920b696c5b7574adbfe36be625ee71495a00e7fc65f14ca58330",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:32813",
+					"10.65.0.27:32813",
+					"172.17.0.1:32813",
+					"172.18.0.1:32813",
+					"172.19.0.1:32813"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:04:56.557914474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3139133500763793,
+				"StableID":   "nCGH1RiiWR11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:287256207188031c99d92d2f9d92d92cf79d024e832f0dc8c2918bd103a1f773",
+				"DiscoKey":   "discokey:b76d2f6d79be8fdcb7b9a5f7b0495289f02e5411987c4a44148bb29ceb845202",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52703",
+					"10.65.0.27:52703",
+					"172.17.0.1:52703",
+					"172.18.0.1:52703",
+					"172.19.0.1:52703"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:04:57.636274753Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3522558669834099,
+				"StableID":   "nSadDJeNWU11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec5aad01f42d5b38d2acd4a00160cf739a79773c84022bacbe7063199070ea56",
+				"DiscoKey":   "discokey:732b43a5f2f493992e756a34fd52fc4de3dc8056a53bc2d9d6143739e3a1237b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38896",
+					"10.65.0.27:38896",
+					"172.17.0.1:38896",
+					"172.18.0.1:38896",
+					"172.19.0.1:38896"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:04:58.187769363Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3960847348496095,
+				"StableID":   "nkXKu7ksvX11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:44b8f6b1946ae7479c03facc963012e7822f7188052cdeaef18273958364ef7b",
+				"DiscoKey":   "discokey:9e93a855c013835052af1e15af9602abf5eeee184fb857aac699fe996b04d123",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58140",
+					"10.65.0.27:58140",
+					"172.17.0.1:58140",
+					"172.18.0.1:58140",
+					"172.19.0.1:58140"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:04:58.730257208Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2629265752823742,
+				"StableID":   "nVGc5UMoXM11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:34eb9266115cae5fa7a95ec41f0b292e24b32e3cb5107e9ce22a1c96aa968a4e",
+				"DiscoKey":   "discokey:e98f9e3abaa925a8bd66816c8e233ded5edece0df12732b22bd4bee9eb902e71",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:43943",
+					"10.65.0.27:43943",
+					"172.17.0.1:43943",
+					"172.18.0.1:43943",
+					"172.19.0.1:43943"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:04:59.260550637Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         284466274045946,
+				"StableID":   "nfheXuSqD311CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6bcd00261e125e0249cb365a75412811c61f011f87bf3e3d719cc79560354c78",
+				"KeyExpiry":  "2026-11-08T22:04:59Z",
+				"DiscoKey":   "discokey:7aeb63544520cdd6c176d5a2cbe91f6324d77e2482260997f8b3b3e7aa0a9919",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45306",
+					"10.65.0.27:45306",
+					"172.17.0.1:45306",
+					"172.18.0.1:45306",
+					"172.19.0.1:45306"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:04:59.818377845Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         385019259895652,
+				"StableID":   "nBQWZaoN1411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:500a68a11ef98a8383a58752c3adf7edc12d71bf04bc01ec1da9ab7f91545416",
+				"KeyExpiry":  "2026-11-08T22:05:00Z",
+				"DiscoKey":   "discokey:9c8796da79dc4b32df74275b2d2002f826adb285ae343f4cb3b0f955c2e9c01c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52849",
+					"10.65.0.27:52849",
+					"172.17.0.1:52849",
+					"172.18.0.1:52849",
+					"172.19.0.1:52849"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:05:00.342818144Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3826583399242238,
+				"StableID":   "n77NUir4tW11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7b66b60cfa40905c6f133bc8846777495e032df2e0a4e02fd32f8581f0f6e34c",
+				"KeyExpiry":  "2026-11-08T22:05:00Z",
+				"DiscoKey":   "discokey:692efc2015785f6383d1833a8d9fa1b0f59126bb2c135de3ecbd268a447f046e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58975",
+					"10.65.0.27:58975",
+					"172.17.0.1:58975",
+					"172.18.0.1:58975",
+					"172.19.0.1:58975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:05:00.879242259Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4487305531704325": {
+				"ID":          4487305531704325,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         284466274045946,
+				"StableID":   "nfheXuSqD311CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6bcd00261e125e0249cb365a75412811c61f011f87bf3e3d719cc79560354c78",
+				"KeyExpiry":  "2026-11-08T22:04:59Z",
+				"DiscoKey":   "discokey:7aeb63544520cdd6c176d5a2cbe91f6324d77e2482260997f8b3b3e7aa0a9919",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45306",
+					"10.65.0.27:45306",
+					"172.17.0.1:45306",
+					"172.18.0.1:45306",
+					"172.19.0.1:45306"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:04:59.818377845Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6bcd00261e125e0249cb365a75412811c61f011f87bf3e3d719cc79560354c78",
+			"MachineKey": "mkey:a4bb3c7feb77a69792e3daaebe684f468c0f740eb49facb03f548ed1f92daf28",
+			"Peers": [{
+				"ID":         1770596395891989,
+				"StableID":   "nGcBPmZupE11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5cf7dfb4297359ba0cbe6a5549d262270262bb58f1cb1a4ada6fd5fd15486e44",
+				"DiscoKey":   "discokey:1dc406d8a4bafdc881e8974ccecb5a92e24245044d97f0e3d55c82ab99479d45",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45825",
+					"10.65.0.27:45825",
+					"172.17.0.1:45825",
+					"172.18.0.1:45825",
+					"172.19.0.1:45825"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:04:53.28601152Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3942388568942736,
+				"StableID":   "nFYCm2sWnX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c80b637ba63929596fb9c22e2a7468dbaab733069168b01d4ff816970739166",
+				"DiscoKey":   "discokey:38439748949c62696fbe55350c97c9661b3ff33c00f0d09f2e6a77e7b3d8dc36",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37836",
+					"10.65.0.27:37836",
+					"172.17.0.1:37836",
+					"172.18.0.1:37836",
+					"172.19.0.1:37836"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:04:53.845326821Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7212130025057101,
+				"StableID":   "nEh3YiRPKy11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b26a5c2a4f87c18fc1a00171f60450a37aedf2fa426bd4a0e9998f695621f928",
+				"DiscoKey":   "discokey:cafc2407dedf41d2d3761d34cc6b766f7bd33d573feb2f7ca3b7f8ad558d7349",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56446",
+					"10.65.0.27:56446",
+					"172.17.0.1:56446",
+					"172.18.0.1:56446",
+					"172.19.0.1:56446"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:04:54.384411336Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         360229614638466,
+				"StableID":   "n9iqV2d9p311CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d9b3a85b8cb084191b3f7c65f16709c64f87c6c3854c2244b39a095be533138",
+				"DiscoKey":   "discokey:653d836afa376ee374e3b7c4db02b231b95b7cf68cf40d0e53da053778f8ef02",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:33116",
+					"10.65.0.27:33116",
+					"172.17.0.1:33116",
+					"172.18.0.1:33116",
+					"172.19.0.1:33116"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:04:54.922892486Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6337623294980712,
+				"StableID":   "nsvYQocKVr11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2cfdb9918eeb82ad8c4295473a8fa2964dfe2f1fe762f078c65fa5dbc9b35f2c",
+				"DiscoKey":   "discokey:e8d91f92594501d59046c1bd5ccb13550b6933ce95e937eae25cf8f622d8af6c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:44550",
+					"10.65.0.27:44550",
+					"172.17.0.1:44550",
+					"172.18.0.1:44550",
+					"172.19.0.1:44550"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:04:55.470595979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8719344879493080,
+				"StableID":   "n7YQ1UQ16B21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0121f40f1a20bf008e0ece0d7a3c83be6ee6f2564004d2a987156b00a9a8d741",
+				"DiscoKey":   "discokey:e6d28307f3d72528a67867a46b109ab83fd8b39b95ba183c2414f4203a854551",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:49291",
+					"10.65.0.27:49291",
+					"172.17.0.1:49291",
+					"172.18.0.1:49291",
+					"172.19.0.1:49291"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:04:56.011981447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7957743326954469,
+				"StableID":   "nQStnYR59521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:795220efe59a5cba12a775616ca9f352a48b59683e817635a8b0ee49e5179403",
+				"DiscoKey":   "discokey:f24791597a8b920b696c5b7574adbfe36be625ee71495a00e7fc65f14ca58330",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:32813",
+					"10.65.0.27:32813",
+					"172.17.0.1:32813",
+					"172.18.0.1:32813",
+					"172.19.0.1:32813"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:04:56.557914474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4487305531704325,
+				"StableID":   "nrfHncuJ3c11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ade330f965f0d4c410ab9a6839ff110c2d893ec5297d824a3751937b02bbe276",
+				"DiscoKey":   "discokey:0b57ce9bca09724ae0661843b142c9a3207b7b676f67896697f211d41fcbe40a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47557",
+					"10.65.0.27:47557",
+					"172.17.0.1:47557",
+					"172.18.0.1:47557",
+					"172.19.0.1:47557"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:04:57.101221392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3139133500763793,
+				"StableID":   "nCGH1RiiWR11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:287256207188031c99d92d2f9d92d92cf79d024e832f0dc8c2918bd103a1f773",
+				"DiscoKey":   "discokey:b76d2f6d79be8fdcb7b9a5f7b0495289f02e5411987c4a44148bb29ceb845202",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52703",
+					"10.65.0.27:52703",
+					"172.17.0.1:52703",
+					"172.18.0.1:52703",
+					"172.19.0.1:52703"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:04:57.636274753Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3522558669834099,
+				"StableID":   "nSadDJeNWU11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec5aad01f42d5b38d2acd4a00160cf739a79773c84022bacbe7063199070ea56",
+				"DiscoKey":   "discokey:732b43a5f2f493992e756a34fd52fc4de3dc8056a53bc2d9d6143739e3a1237b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38896",
+					"10.65.0.27:38896",
+					"172.17.0.1:38896",
+					"172.18.0.1:38896",
+					"172.19.0.1:38896"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:04:58.187769363Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3960847348496095,
+				"StableID":   "nkXKu7ksvX11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:44b8f6b1946ae7479c03facc963012e7822f7188052cdeaef18273958364ef7b",
+				"DiscoKey":   "discokey:9e93a855c013835052af1e15af9602abf5eeee184fb857aac699fe996b04d123",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58140",
+					"10.65.0.27:58140",
+					"172.17.0.1:58140",
+					"172.18.0.1:58140",
+					"172.19.0.1:58140"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:04:58.730257208Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2629265752823742,
+				"StableID":   "nVGc5UMoXM11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:34eb9266115cae5fa7a95ec41f0b292e24b32e3cb5107e9ce22a1c96aa968a4e",
+				"DiscoKey":   "discokey:e98f9e3abaa925a8bd66816c8e233ded5edece0df12732b22bd4bee9eb902e71",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:43943",
+					"10.65.0.27:43943",
+					"172.17.0.1:43943",
+					"172.18.0.1:43943",
+					"172.19.0.1:43943"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:04:59.260550637Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         385019259895652,
+				"StableID":   "nBQWZaoN1411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:500a68a11ef98a8383a58752c3adf7edc12d71bf04bc01ec1da9ab7f91545416",
+				"KeyExpiry":  "2026-11-08T22:05:00Z",
+				"DiscoKey":   "discokey:9c8796da79dc4b32df74275b2d2002f826adb285ae343f4cb3b0f955c2e9c01c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52849",
+					"10.65.0.27:52849",
+					"172.17.0.1:52849",
+					"172.18.0.1:52849",
+					"172.19.0.1:52849"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:05:00.342818144Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3826583399242238,
+				"StableID":   "n77NUir4tW11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7b66b60cfa40905c6f133bc8846777495e032df2e0a4e02fd32f8581f0f6e34c",
+				"KeyExpiry":  "2026-11-08T22:05:00Z",
+				"DiscoKey":   "discokey:692efc2015785f6383d1833a8d9fa1b0f59126bb2c135de3ecbd268a447f046e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58975",
+					"10.65.0.27:58975",
+					"172.17.0.1:58975",
+					"172.18.0.1:58975",
+					"172.19.0.1:58975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:05:00.879242259Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3960847348496095,
+				"StableID":   "nkXKu7ksvX11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       3960847348496095,
+				"Key":        "nodekey:44b8f6b1946ae7479c03facc963012e7822f7188052cdeaef18273958364ef7b",
+				"DiscoKey":   "discokey:9e93a855c013835052af1e15af9602abf5eeee184fb857aac699fe996b04d123",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58140",
+					"10.65.0.27:58140",
+					"172.17.0.1:58140",
+					"172.18.0.1:58140",
+					"172.19.0.1:58140"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:04:58.730257208Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:44b8f6b1946ae7479c03facc963012e7822f7188052cdeaef18273958364ef7b",
+			"MachineKey": "mkey:dbe5c49e186df9bf582b005e8fd947931af7293a88fc6da9bbdcaea4dd064233",
+			"Peers": [{
+				"ID":         1770596395891989,
+				"StableID":   "nGcBPmZupE11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5cf7dfb4297359ba0cbe6a5549d262270262bb58f1cb1a4ada6fd5fd15486e44",
+				"DiscoKey":   "discokey:1dc406d8a4bafdc881e8974ccecb5a92e24245044d97f0e3d55c82ab99479d45",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45825",
+					"10.65.0.27:45825",
+					"172.17.0.1:45825",
+					"172.18.0.1:45825",
+					"172.19.0.1:45825"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:04:53.28601152Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3942388568942736,
+				"StableID":   "nFYCm2sWnX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c80b637ba63929596fb9c22e2a7468dbaab733069168b01d4ff816970739166",
+				"DiscoKey":   "discokey:38439748949c62696fbe55350c97c9661b3ff33c00f0d09f2e6a77e7b3d8dc36",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37836",
+					"10.65.0.27:37836",
+					"172.17.0.1:37836",
+					"172.18.0.1:37836",
+					"172.19.0.1:37836"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:04:53.845326821Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7212130025057101,
+				"StableID":   "nEh3YiRPKy11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b26a5c2a4f87c18fc1a00171f60450a37aedf2fa426bd4a0e9998f695621f928",
+				"DiscoKey":   "discokey:cafc2407dedf41d2d3761d34cc6b766f7bd33d573feb2f7ca3b7f8ad558d7349",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56446",
+					"10.65.0.27:56446",
+					"172.17.0.1:56446",
+					"172.18.0.1:56446",
+					"172.19.0.1:56446"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:04:54.384411336Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         360229614638466,
+				"StableID":   "n9iqV2d9p311CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d9b3a85b8cb084191b3f7c65f16709c64f87c6c3854c2244b39a095be533138",
+				"DiscoKey":   "discokey:653d836afa376ee374e3b7c4db02b231b95b7cf68cf40d0e53da053778f8ef02",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:33116",
+					"10.65.0.27:33116",
+					"172.17.0.1:33116",
+					"172.18.0.1:33116",
+					"172.19.0.1:33116"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:04:54.922892486Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6337623294980712,
+				"StableID":   "nsvYQocKVr11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2cfdb9918eeb82ad8c4295473a8fa2964dfe2f1fe762f078c65fa5dbc9b35f2c",
+				"DiscoKey":   "discokey:e8d91f92594501d59046c1bd5ccb13550b6933ce95e937eae25cf8f622d8af6c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:44550",
+					"10.65.0.27:44550",
+					"172.17.0.1:44550",
+					"172.18.0.1:44550",
+					"172.19.0.1:44550"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:04:55.470595979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8719344879493080,
+				"StableID":   "n7YQ1UQ16B21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0121f40f1a20bf008e0ece0d7a3c83be6ee6f2564004d2a987156b00a9a8d741",
+				"DiscoKey":   "discokey:e6d28307f3d72528a67867a46b109ab83fd8b39b95ba183c2414f4203a854551",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:49291",
+					"10.65.0.27:49291",
+					"172.17.0.1:49291",
+					"172.18.0.1:49291",
+					"172.19.0.1:49291"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:04:56.011981447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7957743326954469,
+				"StableID":   "nQStnYR59521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:795220efe59a5cba12a775616ca9f352a48b59683e817635a8b0ee49e5179403",
+				"DiscoKey":   "discokey:f24791597a8b920b696c5b7574adbfe36be625ee71495a00e7fc65f14ca58330",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:32813",
+					"10.65.0.27:32813",
+					"172.17.0.1:32813",
+					"172.18.0.1:32813",
+					"172.19.0.1:32813"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:04:56.557914474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4487305531704325,
+				"StableID":   "nrfHncuJ3c11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ade330f965f0d4c410ab9a6839ff110c2d893ec5297d824a3751937b02bbe276",
+				"DiscoKey":   "discokey:0b57ce9bca09724ae0661843b142c9a3207b7b676f67896697f211d41fcbe40a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47557",
+					"10.65.0.27:47557",
+					"172.17.0.1:47557",
+					"172.18.0.1:47557",
+					"172.19.0.1:47557"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:04:57.101221392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3139133500763793,
+				"StableID":   "nCGH1RiiWR11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:287256207188031c99d92d2f9d92d92cf79d024e832f0dc8c2918bd103a1f773",
+				"DiscoKey":   "discokey:b76d2f6d79be8fdcb7b9a5f7b0495289f02e5411987c4a44148bb29ceb845202",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52703",
+					"10.65.0.27:52703",
+					"172.17.0.1:52703",
+					"172.18.0.1:52703",
+					"172.19.0.1:52703"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:04:57.636274753Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3522558669834099,
+				"StableID":   "nSadDJeNWU11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec5aad01f42d5b38d2acd4a00160cf739a79773c84022bacbe7063199070ea56",
+				"DiscoKey":   "discokey:732b43a5f2f493992e756a34fd52fc4de3dc8056a53bc2d9d6143739e3a1237b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38896",
+					"10.65.0.27:38896",
+					"172.17.0.1:38896",
+					"172.18.0.1:38896",
+					"172.19.0.1:38896"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:04:58.187769363Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2629265752823742,
+				"StableID":   "nVGc5UMoXM11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:34eb9266115cae5fa7a95ec41f0b292e24b32e3cb5107e9ce22a1c96aa968a4e",
+				"DiscoKey":   "discokey:e98f9e3abaa925a8bd66816c8e233ded5edece0df12732b22bd4bee9eb902e71",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:43943",
+					"10.65.0.27:43943",
+					"172.17.0.1:43943",
+					"172.18.0.1:43943",
+					"172.19.0.1:43943"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:04:59.260550637Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         284466274045946,
+				"StableID":   "nfheXuSqD311CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6bcd00261e125e0249cb365a75412811c61f011f87bf3e3d719cc79560354c78",
+				"KeyExpiry":  "2026-11-08T22:04:59Z",
+				"DiscoKey":   "discokey:7aeb63544520cdd6c176d5a2cbe91f6324d77e2482260997f8b3b3e7aa0a9919",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45306",
+					"10.65.0.27:45306",
+					"172.17.0.1:45306",
+					"172.18.0.1:45306",
+					"172.19.0.1:45306"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:04:59.818377845Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         385019259895652,
+				"StableID":   "nBQWZaoN1411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:500a68a11ef98a8383a58752c3adf7edc12d71bf04bc01ec1da9ab7f91545416",
+				"KeyExpiry":  "2026-11-08T22:05:00Z",
+				"DiscoKey":   "discokey:9c8796da79dc4b32df74275b2d2002f826adb285ae343f4cb3b0f955c2e9c01c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52849",
+					"10.65.0.27:52849",
+					"172.17.0.1:52849",
+					"172.18.0.1:52849",
+					"172.19.0.1:52849"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:05:00.342818144Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3826583399242238,
+				"StableID":   "n77NUir4tW11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7b66b60cfa40905c6f133bc8846777495e032df2e0a4e02fd32f8581f0f6e34c",
+				"KeyExpiry":  "2026-11-08T22:05:00Z",
+				"DiscoKey":   "discokey:692efc2015785f6383d1833a8d9fa1b0f59126bb2c135de3ecbd268a447f046e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58975",
+					"10.65.0.27:58975",
+					"172.17.0.1:58975",
+					"172.18.0.1:58975",
+					"172.19.0.1:58975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:05:00.879242259Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3960847348496095": {
+				"ID":          3960847348496095,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3942388568942736,
+				"StableID":   "nFYCm2sWnX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       3942388568942736,
+				"Key":        "nodekey:0c80b637ba63929596fb9c22e2a7468dbaab733069168b01d4ff816970739166",
+				"DiscoKey":   "discokey:38439748949c62696fbe55350c97c9661b3ff33c00f0d09f2e6a77e7b3d8dc36",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37836",
+					"10.65.0.27:37836",
+					"172.17.0.1:37836",
+					"172.18.0.1:37836",
+					"172.19.0.1:37836"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:04:53.845326821Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0c80b637ba63929596fb9c22e2a7468dbaab733069168b01d4ff816970739166",
+			"MachineKey": "mkey:8beef82a3f1645c05fceb8df128f4a3a521898faefce5113a9f54cf655b5641f",
+			"Peers": [{
+				"ID":         1770596395891989,
+				"StableID":   "nGcBPmZupE11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5cf7dfb4297359ba0cbe6a5549d262270262bb58f1cb1a4ada6fd5fd15486e44",
+				"DiscoKey":   "discokey:1dc406d8a4bafdc881e8974ccecb5a92e24245044d97f0e3d55c82ab99479d45",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45825",
+					"10.65.0.27:45825",
+					"172.17.0.1:45825",
+					"172.18.0.1:45825",
+					"172.19.0.1:45825"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:04:53.28601152Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7212130025057101,
+				"StableID":   "nEh3YiRPKy11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b26a5c2a4f87c18fc1a00171f60450a37aedf2fa426bd4a0e9998f695621f928",
+				"DiscoKey":   "discokey:cafc2407dedf41d2d3761d34cc6b766f7bd33d573feb2f7ca3b7f8ad558d7349",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56446",
+					"10.65.0.27:56446",
+					"172.17.0.1:56446",
+					"172.18.0.1:56446",
+					"172.19.0.1:56446"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:04:54.384411336Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         360229614638466,
+				"StableID":   "n9iqV2d9p311CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d9b3a85b8cb084191b3f7c65f16709c64f87c6c3854c2244b39a095be533138",
+				"DiscoKey":   "discokey:653d836afa376ee374e3b7c4db02b231b95b7cf68cf40d0e53da053778f8ef02",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:33116",
+					"10.65.0.27:33116",
+					"172.17.0.1:33116",
+					"172.18.0.1:33116",
+					"172.19.0.1:33116"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:04:54.922892486Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6337623294980712,
+				"StableID":   "nsvYQocKVr11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2cfdb9918eeb82ad8c4295473a8fa2964dfe2f1fe762f078c65fa5dbc9b35f2c",
+				"DiscoKey":   "discokey:e8d91f92594501d59046c1bd5ccb13550b6933ce95e937eae25cf8f622d8af6c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:44550",
+					"10.65.0.27:44550",
+					"172.17.0.1:44550",
+					"172.18.0.1:44550",
+					"172.19.0.1:44550"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:04:55.470595979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8719344879493080,
+				"StableID":   "n7YQ1UQ16B21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0121f40f1a20bf008e0ece0d7a3c83be6ee6f2564004d2a987156b00a9a8d741",
+				"DiscoKey":   "discokey:e6d28307f3d72528a67867a46b109ab83fd8b39b95ba183c2414f4203a854551",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:49291",
+					"10.65.0.27:49291",
+					"172.17.0.1:49291",
+					"172.18.0.1:49291",
+					"172.19.0.1:49291"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:04:56.011981447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7957743326954469,
+				"StableID":   "nQStnYR59521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:795220efe59a5cba12a775616ca9f352a48b59683e817635a8b0ee49e5179403",
+				"DiscoKey":   "discokey:f24791597a8b920b696c5b7574adbfe36be625ee71495a00e7fc65f14ca58330",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:32813",
+					"10.65.0.27:32813",
+					"172.17.0.1:32813",
+					"172.18.0.1:32813",
+					"172.19.0.1:32813"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:04:56.557914474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4487305531704325,
+				"StableID":   "nrfHncuJ3c11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ade330f965f0d4c410ab9a6839ff110c2d893ec5297d824a3751937b02bbe276",
+				"DiscoKey":   "discokey:0b57ce9bca09724ae0661843b142c9a3207b7b676f67896697f211d41fcbe40a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47557",
+					"10.65.0.27:47557",
+					"172.17.0.1:47557",
+					"172.18.0.1:47557",
+					"172.19.0.1:47557"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:04:57.101221392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3139133500763793,
+				"StableID":   "nCGH1RiiWR11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:287256207188031c99d92d2f9d92d92cf79d024e832f0dc8c2918bd103a1f773",
+				"DiscoKey":   "discokey:b76d2f6d79be8fdcb7b9a5f7b0495289f02e5411987c4a44148bb29ceb845202",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52703",
+					"10.65.0.27:52703",
+					"172.17.0.1:52703",
+					"172.18.0.1:52703",
+					"172.19.0.1:52703"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:04:57.636274753Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3522558669834099,
+				"StableID":   "nSadDJeNWU11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec5aad01f42d5b38d2acd4a00160cf739a79773c84022bacbe7063199070ea56",
+				"DiscoKey":   "discokey:732b43a5f2f493992e756a34fd52fc4de3dc8056a53bc2d9d6143739e3a1237b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38896",
+					"10.65.0.27:38896",
+					"172.17.0.1:38896",
+					"172.18.0.1:38896",
+					"172.19.0.1:38896"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:04:58.187769363Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3960847348496095,
+				"StableID":   "nkXKu7ksvX11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:44b8f6b1946ae7479c03facc963012e7822f7188052cdeaef18273958364ef7b",
+				"DiscoKey":   "discokey:9e93a855c013835052af1e15af9602abf5eeee184fb857aac699fe996b04d123",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58140",
+					"10.65.0.27:58140",
+					"172.17.0.1:58140",
+					"172.18.0.1:58140",
+					"172.19.0.1:58140"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:04:58.730257208Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2629265752823742,
+				"StableID":   "nVGc5UMoXM11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:34eb9266115cae5fa7a95ec41f0b292e24b32e3cb5107e9ce22a1c96aa968a4e",
+				"DiscoKey":   "discokey:e98f9e3abaa925a8bd66816c8e233ded5edece0df12732b22bd4bee9eb902e71",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:43943",
+					"10.65.0.27:43943",
+					"172.17.0.1:43943",
+					"172.18.0.1:43943",
+					"172.19.0.1:43943"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:04:59.260550637Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         284466274045946,
+				"StableID":   "nfheXuSqD311CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6bcd00261e125e0249cb365a75412811c61f011f87bf3e3d719cc79560354c78",
+				"KeyExpiry":  "2026-11-08T22:04:59Z",
+				"DiscoKey":   "discokey:7aeb63544520cdd6c176d5a2cbe91f6324d77e2482260997f8b3b3e7aa0a9919",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45306",
+					"10.65.0.27:45306",
+					"172.17.0.1:45306",
+					"172.18.0.1:45306",
+					"172.19.0.1:45306"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:04:59.818377845Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         385019259895652,
+				"StableID":   "nBQWZaoN1411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:500a68a11ef98a8383a58752c3adf7edc12d71bf04bc01ec1da9ab7f91545416",
+				"KeyExpiry":  "2026-11-08T22:05:00Z",
+				"DiscoKey":   "discokey:9c8796da79dc4b32df74275b2d2002f826adb285ae343f4cb3b0f955c2e9c01c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52849",
+					"10.65.0.27:52849",
+					"172.17.0.1:52849",
+					"172.18.0.1:52849",
+					"172.19.0.1:52849"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:05:00.342818144Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3826583399242238,
+				"StableID":   "n77NUir4tW11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7b66b60cfa40905c6f133bc8846777495e032df2e0a4e02fd32f8581f0f6e34c",
+				"KeyExpiry":  "2026-11-08T22:05:00Z",
+				"DiscoKey":   "discokey:692efc2015785f6383d1833a8d9fa1b0f59126bb2c135de3ecbd268a447f046e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58975",
+					"10.65.0.27:58975",
+					"172.17.0.1:58975",
+					"172.18.0.1:58975",
+					"172.19.0.1:58975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:05:00.879242259Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3942388568942736": {
+				"ID":          3942388568942736,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1770596395891989,
+				"StableID":   "nGcBPmZupE11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1770596395891989,
+				"Key":        "nodekey:5cf7dfb4297359ba0cbe6a5549d262270262bb58f1cb1a4ada6fd5fd15486e44",
+				"DiscoKey":   "discokey:1dc406d8a4bafdc881e8974ccecb5a92e24245044d97f0e3d55c82ab99479d45",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45825",
+					"10.65.0.27:45825",
+					"172.17.0.1:45825",
+					"172.18.0.1:45825",
+					"172.19.0.1:45825"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:04:53.28601152Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5cf7dfb4297359ba0cbe6a5549d262270262bb58f1cb1a4ada6fd5fd15486e44",
+			"MachineKey": "mkey:bc4ea37069e6776bdbe784b8cf6ed0181516dc49bc0744dabff67d639ca1494e",
+			"Peers": [{
+				"ID":         3942388568942736,
+				"StableID":   "nFYCm2sWnX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c80b637ba63929596fb9c22e2a7468dbaab733069168b01d4ff816970739166",
+				"DiscoKey":   "discokey:38439748949c62696fbe55350c97c9661b3ff33c00f0d09f2e6a77e7b3d8dc36",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37836",
+					"10.65.0.27:37836",
+					"172.17.0.1:37836",
+					"172.18.0.1:37836",
+					"172.19.0.1:37836"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:04:53.845326821Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7212130025057101,
+				"StableID":   "nEh3YiRPKy11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b26a5c2a4f87c18fc1a00171f60450a37aedf2fa426bd4a0e9998f695621f928",
+				"DiscoKey":   "discokey:cafc2407dedf41d2d3761d34cc6b766f7bd33d573feb2f7ca3b7f8ad558d7349",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56446",
+					"10.65.0.27:56446",
+					"172.17.0.1:56446",
+					"172.18.0.1:56446",
+					"172.19.0.1:56446"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:04:54.384411336Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         360229614638466,
+				"StableID":   "n9iqV2d9p311CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d9b3a85b8cb084191b3f7c65f16709c64f87c6c3854c2244b39a095be533138",
+				"DiscoKey":   "discokey:653d836afa376ee374e3b7c4db02b231b95b7cf68cf40d0e53da053778f8ef02",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:33116",
+					"10.65.0.27:33116",
+					"172.17.0.1:33116",
+					"172.18.0.1:33116",
+					"172.19.0.1:33116"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:04:54.922892486Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6337623294980712,
+				"StableID":   "nsvYQocKVr11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2cfdb9918eeb82ad8c4295473a8fa2964dfe2f1fe762f078c65fa5dbc9b35f2c",
+				"DiscoKey":   "discokey:e8d91f92594501d59046c1bd5ccb13550b6933ce95e937eae25cf8f622d8af6c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:44550",
+					"10.65.0.27:44550",
+					"172.17.0.1:44550",
+					"172.18.0.1:44550",
+					"172.19.0.1:44550"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:04:55.470595979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8719344879493080,
+				"StableID":   "n7YQ1UQ16B21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0121f40f1a20bf008e0ece0d7a3c83be6ee6f2564004d2a987156b00a9a8d741",
+				"DiscoKey":   "discokey:e6d28307f3d72528a67867a46b109ab83fd8b39b95ba183c2414f4203a854551",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:49291",
+					"10.65.0.27:49291",
+					"172.17.0.1:49291",
+					"172.18.0.1:49291",
+					"172.19.0.1:49291"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:04:56.011981447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7957743326954469,
+				"StableID":   "nQStnYR59521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:795220efe59a5cba12a775616ca9f352a48b59683e817635a8b0ee49e5179403",
+				"DiscoKey":   "discokey:f24791597a8b920b696c5b7574adbfe36be625ee71495a00e7fc65f14ca58330",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:32813",
+					"10.65.0.27:32813",
+					"172.17.0.1:32813",
+					"172.18.0.1:32813",
+					"172.19.0.1:32813"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:04:56.557914474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4487305531704325,
+				"StableID":   "nrfHncuJ3c11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ade330f965f0d4c410ab9a6839ff110c2d893ec5297d824a3751937b02bbe276",
+				"DiscoKey":   "discokey:0b57ce9bca09724ae0661843b142c9a3207b7b676f67896697f211d41fcbe40a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47557",
+					"10.65.0.27:47557",
+					"172.17.0.1:47557",
+					"172.18.0.1:47557",
+					"172.19.0.1:47557"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:04:57.101221392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3139133500763793,
+				"StableID":   "nCGH1RiiWR11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:287256207188031c99d92d2f9d92d92cf79d024e832f0dc8c2918bd103a1f773",
+				"DiscoKey":   "discokey:b76d2f6d79be8fdcb7b9a5f7b0495289f02e5411987c4a44148bb29ceb845202",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52703",
+					"10.65.0.27:52703",
+					"172.17.0.1:52703",
+					"172.18.0.1:52703",
+					"172.19.0.1:52703"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:04:57.636274753Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3522558669834099,
+				"StableID":   "nSadDJeNWU11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec5aad01f42d5b38d2acd4a00160cf739a79773c84022bacbe7063199070ea56",
+				"DiscoKey":   "discokey:732b43a5f2f493992e756a34fd52fc4de3dc8056a53bc2d9d6143739e3a1237b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38896",
+					"10.65.0.27:38896",
+					"172.17.0.1:38896",
+					"172.18.0.1:38896",
+					"172.19.0.1:38896"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:04:58.187769363Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3960847348496095,
+				"StableID":   "nkXKu7ksvX11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:44b8f6b1946ae7479c03facc963012e7822f7188052cdeaef18273958364ef7b",
+				"DiscoKey":   "discokey:9e93a855c013835052af1e15af9602abf5eeee184fb857aac699fe996b04d123",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58140",
+					"10.65.0.27:58140",
+					"172.17.0.1:58140",
+					"172.18.0.1:58140",
+					"172.19.0.1:58140"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:04:58.730257208Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2629265752823742,
+				"StableID":   "nVGc5UMoXM11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:34eb9266115cae5fa7a95ec41f0b292e24b32e3cb5107e9ce22a1c96aa968a4e",
+				"DiscoKey":   "discokey:e98f9e3abaa925a8bd66816c8e233ded5edece0df12732b22bd4bee9eb902e71",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:43943",
+					"10.65.0.27:43943",
+					"172.17.0.1:43943",
+					"172.18.0.1:43943",
+					"172.19.0.1:43943"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:04:59.260550637Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         284466274045946,
+				"StableID":   "nfheXuSqD311CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6bcd00261e125e0249cb365a75412811c61f011f87bf3e3d719cc79560354c78",
+				"KeyExpiry":  "2026-11-08T22:04:59Z",
+				"DiscoKey":   "discokey:7aeb63544520cdd6c176d5a2cbe91f6324d77e2482260997f8b3b3e7aa0a9919",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45306",
+					"10.65.0.27:45306",
+					"172.17.0.1:45306",
+					"172.18.0.1:45306",
+					"172.19.0.1:45306"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:04:59.818377845Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         385019259895652,
+				"StableID":   "nBQWZaoN1411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:500a68a11ef98a8383a58752c3adf7edc12d71bf04bc01ec1da9ab7f91545416",
+				"KeyExpiry":  "2026-11-08T22:05:00Z",
+				"DiscoKey":   "discokey:9c8796da79dc4b32df74275b2d2002f826adb285ae343f4cb3b0f955c2e9c01c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52849",
+					"10.65.0.27:52849",
+					"172.17.0.1:52849",
+					"172.18.0.1:52849",
+					"172.19.0.1:52849"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:05:00.342818144Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3826583399242238,
+				"StableID":   "n77NUir4tW11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7b66b60cfa40905c6f133bc8846777495e032df2e0a4e02fd32f8581f0f6e34c",
+				"KeyExpiry":  "2026-11-08T22:05:00Z",
+				"DiscoKey":   "discokey:692efc2015785f6383d1833a8d9fa1b0f59126bb2c135de3ecbd268a447f046e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58975",
+					"10.65.0.27:58975",
+					"172.17.0.1:58975",
+					"172.18.0.1:58975",
+					"172.19.0.1:58975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:05:00.879242259Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1770596395891989": {
+				"ID":          1770596395891989,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6337623294980712,
+				"StableID":   "nsvYQocKVr11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       6337623294980712,
+				"Key":        "nodekey:2cfdb9918eeb82ad8c4295473a8fa2964dfe2f1fe762f078c65fa5dbc9b35f2c",
+				"DiscoKey":   "discokey:e8d91f92594501d59046c1bd5ccb13550b6933ce95e937eae25cf8f622d8af6c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:44550",
+					"10.65.0.27:44550",
+					"172.17.0.1:44550",
+					"172.18.0.1:44550",
+					"172.19.0.1:44550"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:04:55.470595979Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2cfdb9918eeb82ad8c4295473a8fa2964dfe2f1fe762f078c65fa5dbc9b35f2c",
+			"MachineKey": "mkey:0e6e4db55ad0caf16503a99aba69cf90a29a542da4317c79a4cdb5c1a028fe08",
+			"Peers": [{
+				"ID":         1770596395891989,
+				"StableID":   "nGcBPmZupE11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5cf7dfb4297359ba0cbe6a5549d262270262bb58f1cb1a4ada6fd5fd15486e44",
+				"DiscoKey":   "discokey:1dc406d8a4bafdc881e8974ccecb5a92e24245044d97f0e3d55c82ab99479d45",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45825",
+					"10.65.0.27:45825",
+					"172.17.0.1:45825",
+					"172.18.0.1:45825",
+					"172.19.0.1:45825"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:04:53.28601152Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3942388568942736,
+				"StableID":   "nFYCm2sWnX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c80b637ba63929596fb9c22e2a7468dbaab733069168b01d4ff816970739166",
+				"DiscoKey":   "discokey:38439748949c62696fbe55350c97c9661b3ff33c00f0d09f2e6a77e7b3d8dc36",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37836",
+					"10.65.0.27:37836",
+					"172.17.0.1:37836",
+					"172.18.0.1:37836",
+					"172.19.0.1:37836"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:04:53.845326821Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7212130025057101,
+				"StableID":   "nEh3YiRPKy11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b26a5c2a4f87c18fc1a00171f60450a37aedf2fa426bd4a0e9998f695621f928",
+				"DiscoKey":   "discokey:cafc2407dedf41d2d3761d34cc6b766f7bd33d573feb2f7ca3b7f8ad558d7349",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56446",
+					"10.65.0.27:56446",
+					"172.17.0.1:56446",
+					"172.18.0.1:56446",
+					"172.19.0.1:56446"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:04:54.384411336Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         360229614638466,
+				"StableID":   "n9iqV2d9p311CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d9b3a85b8cb084191b3f7c65f16709c64f87c6c3854c2244b39a095be533138",
+				"DiscoKey":   "discokey:653d836afa376ee374e3b7c4db02b231b95b7cf68cf40d0e53da053778f8ef02",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:33116",
+					"10.65.0.27:33116",
+					"172.17.0.1:33116",
+					"172.18.0.1:33116",
+					"172.19.0.1:33116"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:04:54.922892486Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8719344879493080,
+				"StableID":   "n7YQ1UQ16B21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0121f40f1a20bf008e0ece0d7a3c83be6ee6f2564004d2a987156b00a9a8d741",
+				"DiscoKey":   "discokey:e6d28307f3d72528a67867a46b109ab83fd8b39b95ba183c2414f4203a854551",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:49291",
+					"10.65.0.27:49291",
+					"172.17.0.1:49291",
+					"172.18.0.1:49291",
+					"172.19.0.1:49291"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:04:56.011981447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7957743326954469,
+				"StableID":   "nQStnYR59521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:795220efe59a5cba12a775616ca9f352a48b59683e817635a8b0ee49e5179403",
+				"DiscoKey":   "discokey:f24791597a8b920b696c5b7574adbfe36be625ee71495a00e7fc65f14ca58330",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:32813",
+					"10.65.0.27:32813",
+					"172.17.0.1:32813",
+					"172.18.0.1:32813",
+					"172.19.0.1:32813"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:04:56.557914474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4487305531704325,
+				"StableID":   "nrfHncuJ3c11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ade330f965f0d4c410ab9a6839ff110c2d893ec5297d824a3751937b02bbe276",
+				"DiscoKey":   "discokey:0b57ce9bca09724ae0661843b142c9a3207b7b676f67896697f211d41fcbe40a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47557",
+					"10.65.0.27:47557",
+					"172.17.0.1:47557",
+					"172.18.0.1:47557",
+					"172.19.0.1:47557"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:04:57.101221392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3139133500763793,
+				"StableID":   "nCGH1RiiWR11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:287256207188031c99d92d2f9d92d92cf79d024e832f0dc8c2918bd103a1f773",
+				"DiscoKey":   "discokey:b76d2f6d79be8fdcb7b9a5f7b0495289f02e5411987c4a44148bb29ceb845202",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52703",
+					"10.65.0.27:52703",
+					"172.17.0.1:52703",
+					"172.18.0.1:52703",
+					"172.19.0.1:52703"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:04:57.636274753Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3522558669834099,
+				"StableID":   "nSadDJeNWU11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec5aad01f42d5b38d2acd4a00160cf739a79773c84022bacbe7063199070ea56",
+				"DiscoKey":   "discokey:732b43a5f2f493992e756a34fd52fc4de3dc8056a53bc2d9d6143739e3a1237b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38896",
+					"10.65.0.27:38896",
+					"172.17.0.1:38896",
+					"172.18.0.1:38896",
+					"172.19.0.1:38896"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:04:58.187769363Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3960847348496095,
+				"StableID":   "nkXKu7ksvX11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:44b8f6b1946ae7479c03facc963012e7822f7188052cdeaef18273958364ef7b",
+				"DiscoKey":   "discokey:9e93a855c013835052af1e15af9602abf5eeee184fb857aac699fe996b04d123",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58140",
+					"10.65.0.27:58140",
+					"172.17.0.1:58140",
+					"172.18.0.1:58140",
+					"172.19.0.1:58140"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:04:58.730257208Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2629265752823742,
+				"StableID":   "nVGc5UMoXM11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:34eb9266115cae5fa7a95ec41f0b292e24b32e3cb5107e9ce22a1c96aa968a4e",
+				"DiscoKey":   "discokey:e98f9e3abaa925a8bd66816c8e233ded5edece0df12732b22bd4bee9eb902e71",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:43943",
+					"10.65.0.27:43943",
+					"172.17.0.1:43943",
+					"172.18.0.1:43943",
+					"172.19.0.1:43943"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:04:59.260550637Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         284466274045946,
+				"StableID":   "nfheXuSqD311CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6bcd00261e125e0249cb365a75412811c61f011f87bf3e3d719cc79560354c78",
+				"KeyExpiry":  "2026-11-08T22:04:59Z",
+				"DiscoKey":   "discokey:7aeb63544520cdd6c176d5a2cbe91f6324d77e2482260997f8b3b3e7aa0a9919",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45306",
+					"10.65.0.27:45306",
+					"172.17.0.1:45306",
+					"172.18.0.1:45306",
+					"172.19.0.1:45306"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:04:59.818377845Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         385019259895652,
+				"StableID":   "nBQWZaoN1411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:500a68a11ef98a8383a58752c3adf7edc12d71bf04bc01ec1da9ab7f91545416",
+				"KeyExpiry":  "2026-11-08T22:05:00Z",
+				"DiscoKey":   "discokey:9c8796da79dc4b32df74275b2d2002f826adb285ae343f4cb3b0f955c2e9c01c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52849",
+					"10.65.0.27:52849",
+					"172.17.0.1:52849",
+					"172.18.0.1:52849",
+					"172.19.0.1:52849"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:05:00.342818144Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3826583399242238,
+				"StableID":   "n77NUir4tW11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7b66b60cfa40905c6f133bc8846777495e032df2e0a4e02fd32f8581f0f6e34c",
+				"KeyExpiry":  "2026-11-08T22:05:00Z",
+				"DiscoKey":   "discokey:692efc2015785f6383d1833a8d9fa1b0f59126bb2c135de3ecbd268a447f046e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58975",
+					"10.65.0.27:58975",
+					"172.17.0.1:58975",
+					"172.18.0.1:58975",
+					"172.19.0.1:58975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:05:00.879242259Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6337623294980712": {
+				"ID":          6337623294980712,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         360229614638466,
+				"StableID":   "n9iqV2d9p311CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       360229614638466,
+				"Key":        "nodekey:3d9b3a85b8cb084191b3f7c65f16709c64f87c6c3854c2244b39a095be533138",
+				"DiscoKey":   "discokey:653d836afa376ee374e3b7c4db02b231b95b7cf68cf40d0e53da053778f8ef02",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:33116",
+					"10.65.0.27:33116",
+					"172.17.0.1:33116",
+					"172.18.0.1:33116",
+					"172.19.0.1:33116"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:04:54.922892486Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3d9b3a85b8cb084191b3f7c65f16709c64f87c6c3854c2244b39a095be533138",
+			"MachineKey": "mkey:99497642e5d4196e6984f84d4937bcba8aad3414699b10075cda27fd438a0911",
+			"Peers": [{
+				"ID":         1770596395891989,
+				"StableID":   "nGcBPmZupE11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5cf7dfb4297359ba0cbe6a5549d262270262bb58f1cb1a4ada6fd5fd15486e44",
+				"DiscoKey":   "discokey:1dc406d8a4bafdc881e8974ccecb5a92e24245044d97f0e3d55c82ab99479d45",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45825",
+					"10.65.0.27:45825",
+					"172.17.0.1:45825",
+					"172.18.0.1:45825",
+					"172.19.0.1:45825"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:04:53.28601152Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3942388568942736,
+				"StableID":   "nFYCm2sWnX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c80b637ba63929596fb9c22e2a7468dbaab733069168b01d4ff816970739166",
+				"DiscoKey":   "discokey:38439748949c62696fbe55350c97c9661b3ff33c00f0d09f2e6a77e7b3d8dc36",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37836",
+					"10.65.0.27:37836",
+					"172.17.0.1:37836",
+					"172.18.0.1:37836",
+					"172.19.0.1:37836"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:04:53.845326821Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7212130025057101,
+				"StableID":   "nEh3YiRPKy11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b26a5c2a4f87c18fc1a00171f60450a37aedf2fa426bd4a0e9998f695621f928",
+				"DiscoKey":   "discokey:cafc2407dedf41d2d3761d34cc6b766f7bd33d573feb2f7ca3b7f8ad558d7349",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56446",
+					"10.65.0.27:56446",
+					"172.17.0.1:56446",
+					"172.18.0.1:56446",
+					"172.19.0.1:56446"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:04:54.384411336Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6337623294980712,
+				"StableID":   "nsvYQocKVr11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2cfdb9918eeb82ad8c4295473a8fa2964dfe2f1fe762f078c65fa5dbc9b35f2c",
+				"DiscoKey":   "discokey:e8d91f92594501d59046c1bd5ccb13550b6933ce95e937eae25cf8f622d8af6c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:44550",
+					"10.65.0.27:44550",
+					"172.17.0.1:44550",
+					"172.18.0.1:44550",
+					"172.19.0.1:44550"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:04:55.470595979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8719344879493080,
+				"StableID":   "n7YQ1UQ16B21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0121f40f1a20bf008e0ece0d7a3c83be6ee6f2564004d2a987156b00a9a8d741",
+				"DiscoKey":   "discokey:e6d28307f3d72528a67867a46b109ab83fd8b39b95ba183c2414f4203a854551",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:49291",
+					"10.65.0.27:49291",
+					"172.17.0.1:49291",
+					"172.18.0.1:49291",
+					"172.19.0.1:49291"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:04:56.011981447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7957743326954469,
+				"StableID":   "nQStnYR59521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:795220efe59a5cba12a775616ca9f352a48b59683e817635a8b0ee49e5179403",
+				"DiscoKey":   "discokey:f24791597a8b920b696c5b7574adbfe36be625ee71495a00e7fc65f14ca58330",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:32813",
+					"10.65.0.27:32813",
+					"172.17.0.1:32813",
+					"172.18.0.1:32813",
+					"172.19.0.1:32813"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:04:56.557914474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4487305531704325,
+				"StableID":   "nrfHncuJ3c11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ade330f965f0d4c410ab9a6839ff110c2d893ec5297d824a3751937b02bbe276",
+				"DiscoKey":   "discokey:0b57ce9bca09724ae0661843b142c9a3207b7b676f67896697f211d41fcbe40a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47557",
+					"10.65.0.27:47557",
+					"172.17.0.1:47557",
+					"172.18.0.1:47557",
+					"172.19.0.1:47557"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:04:57.101221392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3139133500763793,
+				"StableID":   "nCGH1RiiWR11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:287256207188031c99d92d2f9d92d92cf79d024e832f0dc8c2918bd103a1f773",
+				"DiscoKey":   "discokey:b76d2f6d79be8fdcb7b9a5f7b0495289f02e5411987c4a44148bb29ceb845202",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52703",
+					"10.65.0.27:52703",
+					"172.17.0.1:52703",
+					"172.18.0.1:52703",
+					"172.19.0.1:52703"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:04:57.636274753Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3522558669834099,
+				"StableID":   "nSadDJeNWU11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec5aad01f42d5b38d2acd4a00160cf739a79773c84022bacbe7063199070ea56",
+				"DiscoKey":   "discokey:732b43a5f2f493992e756a34fd52fc4de3dc8056a53bc2d9d6143739e3a1237b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38896",
+					"10.65.0.27:38896",
+					"172.17.0.1:38896",
+					"172.18.0.1:38896",
+					"172.19.0.1:38896"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:04:58.187769363Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3960847348496095,
+				"StableID":   "nkXKu7ksvX11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:44b8f6b1946ae7479c03facc963012e7822f7188052cdeaef18273958364ef7b",
+				"DiscoKey":   "discokey:9e93a855c013835052af1e15af9602abf5eeee184fb857aac699fe996b04d123",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58140",
+					"10.65.0.27:58140",
+					"172.17.0.1:58140",
+					"172.18.0.1:58140",
+					"172.19.0.1:58140"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:04:58.730257208Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2629265752823742,
+				"StableID":   "nVGc5UMoXM11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:34eb9266115cae5fa7a95ec41f0b292e24b32e3cb5107e9ce22a1c96aa968a4e",
+				"DiscoKey":   "discokey:e98f9e3abaa925a8bd66816c8e233ded5edece0df12732b22bd4bee9eb902e71",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:43943",
+					"10.65.0.27:43943",
+					"172.17.0.1:43943",
+					"172.18.0.1:43943",
+					"172.19.0.1:43943"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:04:59.260550637Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         284466274045946,
+				"StableID":   "nfheXuSqD311CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6bcd00261e125e0249cb365a75412811c61f011f87bf3e3d719cc79560354c78",
+				"KeyExpiry":  "2026-11-08T22:04:59Z",
+				"DiscoKey":   "discokey:7aeb63544520cdd6c176d5a2cbe91f6324d77e2482260997f8b3b3e7aa0a9919",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45306",
+					"10.65.0.27:45306",
+					"172.17.0.1:45306",
+					"172.18.0.1:45306",
+					"172.19.0.1:45306"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:04:59.818377845Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         385019259895652,
+				"StableID":   "nBQWZaoN1411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:500a68a11ef98a8383a58752c3adf7edc12d71bf04bc01ec1da9ab7f91545416",
+				"KeyExpiry":  "2026-11-08T22:05:00Z",
+				"DiscoKey":   "discokey:9c8796da79dc4b32df74275b2d2002f826adb285ae343f4cb3b0f955c2e9c01c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52849",
+					"10.65.0.27:52849",
+					"172.17.0.1:52849",
+					"172.18.0.1:52849",
+					"172.19.0.1:52849"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:05:00.342818144Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3826583399242238,
+				"StableID":   "n77NUir4tW11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7b66b60cfa40905c6f133bc8846777495e032df2e0a4e02fd32f8581f0f6e34c",
+				"KeyExpiry":  "2026-11-08T22:05:00Z",
+				"DiscoKey":   "discokey:692efc2015785f6383d1833a8d9fa1b0f59126bb2c135de3ecbd268a447f046e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58975",
+					"10.65.0.27:58975",
+					"172.17.0.1:58975",
+					"172.18.0.1:58975",
+					"172.19.0.1:58975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:05:00.879242259Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "360229614638466": {
+				"ID":          360229614638466,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7957743326954469,
+				"StableID":   "nQStnYR59521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       7957743326954469,
+				"Key":        "nodekey:795220efe59a5cba12a775616ca9f352a48b59683e817635a8b0ee49e5179403",
+				"DiscoKey":   "discokey:f24791597a8b920b696c5b7574adbfe36be625ee71495a00e7fc65f14ca58330",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:32813",
+					"10.65.0.27:32813",
+					"172.17.0.1:32813",
+					"172.18.0.1:32813",
+					"172.19.0.1:32813"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:04:56.557914474Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:795220efe59a5cba12a775616ca9f352a48b59683e817635a8b0ee49e5179403",
+			"MachineKey": "mkey:2c823cceffc183670fa29e58087fd36d2649e25aa646249753ea5aa85cc1330d",
+			"Peers": [{
+				"ID":         1770596395891989,
+				"StableID":   "nGcBPmZupE11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5cf7dfb4297359ba0cbe6a5549d262270262bb58f1cb1a4ada6fd5fd15486e44",
+				"DiscoKey":   "discokey:1dc406d8a4bafdc881e8974ccecb5a92e24245044d97f0e3d55c82ab99479d45",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45825",
+					"10.65.0.27:45825",
+					"172.17.0.1:45825",
+					"172.18.0.1:45825",
+					"172.19.0.1:45825"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:04:53.28601152Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3942388568942736,
+				"StableID":   "nFYCm2sWnX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c80b637ba63929596fb9c22e2a7468dbaab733069168b01d4ff816970739166",
+				"DiscoKey":   "discokey:38439748949c62696fbe55350c97c9661b3ff33c00f0d09f2e6a77e7b3d8dc36",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37836",
+					"10.65.0.27:37836",
+					"172.17.0.1:37836",
+					"172.18.0.1:37836",
+					"172.19.0.1:37836"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:04:53.845326821Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7212130025057101,
+				"StableID":   "nEh3YiRPKy11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b26a5c2a4f87c18fc1a00171f60450a37aedf2fa426bd4a0e9998f695621f928",
+				"DiscoKey":   "discokey:cafc2407dedf41d2d3761d34cc6b766f7bd33d573feb2f7ca3b7f8ad558d7349",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56446",
+					"10.65.0.27:56446",
+					"172.17.0.1:56446",
+					"172.18.0.1:56446",
+					"172.19.0.1:56446"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:04:54.384411336Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         360229614638466,
+				"StableID":   "n9iqV2d9p311CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d9b3a85b8cb084191b3f7c65f16709c64f87c6c3854c2244b39a095be533138",
+				"DiscoKey":   "discokey:653d836afa376ee374e3b7c4db02b231b95b7cf68cf40d0e53da053778f8ef02",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:33116",
+					"10.65.0.27:33116",
+					"172.17.0.1:33116",
+					"172.18.0.1:33116",
+					"172.19.0.1:33116"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:04:54.922892486Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6337623294980712,
+				"StableID":   "nsvYQocKVr11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2cfdb9918eeb82ad8c4295473a8fa2964dfe2f1fe762f078c65fa5dbc9b35f2c",
+				"DiscoKey":   "discokey:e8d91f92594501d59046c1bd5ccb13550b6933ce95e937eae25cf8f622d8af6c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:44550",
+					"10.65.0.27:44550",
+					"172.17.0.1:44550",
+					"172.18.0.1:44550",
+					"172.19.0.1:44550"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:04:55.470595979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8719344879493080,
+				"StableID":   "n7YQ1UQ16B21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0121f40f1a20bf008e0ece0d7a3c83be6ee6f2564004d2a987156b00a9a8d741",
+				"DiscoKey":   "discokey:e6d28307f3d72528a67867a46b109ab83fd8b39b95ba183c2414f4203a854551",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:49291",
+					"10.65.0.27:49291",
+					"172.17.0.1:49291",
+					"172.18.0.1:49291",
+					"172.19.0.1:49291"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:04:56.011981447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4487305531704325,
+				"StableID":   "nrfHncuJ3c11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ade330f965f0d4c410ab9a6839ff110c2d893ec5297d824a3751937b02bbe276",
+				"DiscoKey":   "discokey:0b57ce9bca09724ae0661843b142c9a3207b7b676f67896697f211d41fcbe40a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47557",
+					"10.65.0.27:47557",
+					"172.17.0.1:47557",
+					"172.18.0.1:47557",
+					"172.19.0.1:47557"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:04:57.101221392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3139133500763793,
+				"StableID":   "nCGH1RiiWR11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:287256207188031c99d92d2f9d92d92cf79d024e832f0dc8c2918bd103a1f773",
+				"DiscoKey":   "discokey:b76d2f6d79be8fdcb7b9a5f7b0495289f02e5411987c4a44148bb29ceb845202",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52703",
+					"10.65.0.27:52703",
+					"172.17.0.1:52703",
+					"172.18.0.1:52703",
+					"172.19.0.1:52703"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:04:57.636274753Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3522558669834099,
+				"StableID":   "nSadDJeNWU11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec5aad01f42d5b38d2acd4a00160cf739a79773c84022bacbe7063199070ea56",
+				"DiscoKey":   "discokey:732b43a5f2f493992e756a34fd52fc4de3dc8056a53bc2d9d6143739e3a1237b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38896",
+					"10.65.0.27:38896",
+					"172.17.0.1:38896",
+					"172.18.0.1:38896",
+					"172.19.0.1:38896"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:04:58.187769363Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3960847348496095,
+				"StableID":   "nkXKu7ksvX11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:44b8f6b1946ae7479c03facc963012e7822f7188052cdeaef18273958364ef7b",
+				"DiscoKey":   "discokey:9e93a855c013835052af1e15af9602abf5eeee184fb857aac699fe996b04d123",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58140",
+					"10.65.0.27:58140",
+					"172.17.0.1:58140",
+					"172.18.0.1:58140",
+					"172.19.0.1:58140"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:04:58.730257208Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2629265752823742,
+				"StableID":   "nVGc5UMoXM11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:34eb9266115cae5fa7a95ec41f0b292e24b32e3cb5107e9ce22a1c96aa968a4e",
+				"DiscoKey":   "discokey:e98f9e3abaa925a8bd66816c8e233ded5edece0df12732b22bd4bee9eb902e71",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:43943",
+					"10.65.0.27:43943",
+					"172.17.0.1:43943",
+					"172.18.0.1:43943",
+					"172.19.0.1:43943"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:04:59.260550637Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         284466274045946,
+				"StableID":   "nfheXuSqD311CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6bcd00261e125e0249cb365a75412811c61f011f87bf3e3d719cc79560354c78",
+				"KeyExpiry":  "2026-11-08T22:04:59Z",
+				"DiscoKey":   "discokey:7aeb63544520cdd6c176d5a2cbe91f6324d77e2482260997f8b3b3e7aa0a9919",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45306",
+					"10.65.0.27:45306",
+					"172.17.0.1:45306",
+					"172.18.0.1:45306",
+					"172.19.0.1:45306"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:04:59.818377845Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         385019259895652,
+				"StableID":   "nBQWZaoN1411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:500a68a11ef98a8383a58752c3adf7edc12d71bf04bc01ec1da9ab7f91545416",
+				"KeyExpiry":  "2026-11-08T22:05:00Z",
+				"DiscoKey":   "discokey:9c8796da79dc4b32df74275b2d2002f826adb285ae343f4cb3b0f955c2e9c01c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52849",
+					"10.65.0.27:52849",
+					"172.17.0.1:52849",
+					"172.18.0.1:52849",
+					"172.19.0.1:52849"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:05:00.342818144Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3826583399242238,
+				"StableID":   "n77NUir4tW11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7b66b60cfa40905c6f133bc8846777495e032df2e0a4e02fd32f8581f0f6e34c",
+				"KeyExpiry":  "2026-11-08T22:05:00Z",
+				"DiscoKey":   "discokey:692efc2015785f6383d1833a8d9fa1b0f59126bb2c135de3ecbd268a447f046e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58975",
+					"10.65.0.27:58975",
+					"172.17.0.1:58975",
+					"172.18.0.1:58975",
+					"172.19.0.1:58975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:05:00.879242259Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7957743326954469": {
+				"ID":          7957743326954469,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3139133500763793,
+				"StableID":   "nCGH1RiiWR11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       3139133500763793,
+				"Key":        "nodekey:287256207188031c99d92d2f9d92d92cf79d024e832f0dc8c2918bd103a1f773",
+				"DiscoKey":   "discokey:b76d2f6d79be8fdcb7b9a5f7b0495289f02e5411987c4a44148bb29ceb845202",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52703",
+					"10.65.0.27:52703",
+					"172.17.0.1:52703",
+					"172.18.0.1:52703",
+					"172.19.0.1:52703"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:04:57.636274753Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:287256207188031c99d92d2f9d92d92cf79d024e832f0dc8c2918bd103a1f773",
+			"MachineKey": "mkey:0253fae57bad5147485c06e5525d8397437f3f253571d38a94352e7fb076c979",
+			"Peers": [{
+				"ID":         1770596395891989,
+				"StableID":   "nGcBPmZupE11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5cf7dfb4297359ba0cbe6a5549d262270262bb58f1cb1a4ada6fd5fd15486e44",
+				"DiscoKey":   "discokey:1dc406d8a4bafdc881e8974ccecb5a92e24245044d97f0e3d55c82ab99479d45",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45825",
+					"10.65.0.27:45825",
+					"172.17.0.1:45825",
+					"172.18.0.1:45825",
+					"172.19.0.1:45825"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:04:53.28601152Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3942388568942736,
+				"StableID":   "nFYCm2sWnX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c80b637ba63929596fb9c22e2a7468dbaab733069168b01d4ff816970739166",
+				"DiscoKey":   "discokey:38439748949c62696fbe55350c97c9661b3ff33c00f0d09f2e6a77e7b3d8dc36",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37836",
+					"10.65.0.27:37836",
+					"172.17.0.1:37836",
+					"172.18.0.1:37836",
+					"172.19.0.1:37836"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:04:53.845326821Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7212130025057101,
+				"StableID":   "nEh3YiRPKy11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b26a5c2a4f87c18fc1a00171f60450a37aedf2fa426bd4a0e9998f695621f928",
+				"DiscoKey":   "discokey:cafc2407dedf41d2d3761d34cc6b766f7bd33d573feb2f7ca3b7f8ad558d7349",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56446",
+					"10.65.0.27:56446",
+					"172.17.0.1:56446",
+					"172.18.0.1:56446",
+					"172.19.0.1:56446"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:04:54.384411336Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         360229614638466,
+				"StableID":   "n9iqV2d9p311CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d9b3a85b8cb084191b3f7c65f16709c64f87c6c3854c2244b39a095be533138",
+				"DiscoKey":   "discokey:653d836afa376ee374e3b7c4db02b231b95b7cf68cf40d0e53da053778f8ef02",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:33116",
+					"10.65.0.27:33116",
+					"172.17.0.1:33116",
+					"172.18.0.1:33116",
+					"172.19.0.1:33116"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:04:54.922892486Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6337623294980712,
+				"StableID":   "nsvYQocKVr11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2cfdb9918eeb82ad8c4295473a8fa2964dfe2f1fe762f078c65fa5dbc9b35f2c",
+				"DiscoKey":   "discokey:e8d91f92594501d59046c1bd5ccb13550b6933ce95e937eae25cf8f622d8af6c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:44550",
+					"10.65.0.27:44550",
+					"172.17.0.1:44550",
+					"172.18.0.1:44550",
+					"172.19.0.1:44550"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:04:55.470595979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8719344879493080,
+				"StableID":   "n7YQ1UQ16B21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0121f40f1a20bf008e0ece0d7a3c83be6ee6f2564004d2a987156b00a9a8d741",
+				"DiscoKey":   "discokey:e6d28307f3d72528a67867a46b109ab83fd8b39b95ba183c2414f4203a854551",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:49291",
+					"10.65.0.27:49291",
+					"172.17.0.1:49291",
+					"172.18.0.1:49291",
+					"172.19.0.1:49291"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:04:56.011981447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7957743326954469,
+				"StableID":   "nQStnYR59521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:795220efe59a5cba12a775616ca9f352a48b59683e817635a8b0ee49e5179403",
+				"DiscoKey":   "discokey:f24791597a8b920b696c5b7574adbfe36be625ee71495a00e7fc65f14ca58330",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:32813",
+					"10.65.0.27:32813",
+					"172.17.0.1:32813",
+					"172.18.0.1:32813",
+					"172.19.0.1:32813"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:04:56.557914474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4487305531704325,
+				"StableID":   "nrfHncuJ3c11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ade330f965f0d4c410ab9a6839ff110c2d893ec5297d824a3751937b02bbe276",
+				"DiscoKey":   "discokey:0b57ce9bca09724ae0661843b142c9a3207b7b676f67896697f211d41fcbe40a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47557",
+					"10.65.0.27:47557",
+					"172.17.0.1:47557",
+					"172.18.0.1:47557",
+					"172.19.0.1:47557"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:04:57.101221392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3522558669834099,
+				"StableID":   "nSadDJeNWU11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec5aad01f42d5b38d2acd4a00160cf739a79773c84022bacbe7063199070ea56",
+				"DiscoKey":   "discokey:732b43a5f2f493992e756a34fd52fc4de3dc8056a53bc2d9d6143739e3a1237b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38896",
+					"10.65.0.27:38896",
+					"172.17.0.1:38896",
+					"172.18.0.1:38896",
+					"172.19.0.1:38896"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:04:58.187769363Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3960847348496095,
+				"StableID":   "nkXKu7ksvX11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:44b8f6b1946ae7479c03facc963012e7822f7188052cdeaef18273958364ef7b",
+				"DiscoKey":   "discokey:9e93a855c013835052af1e15af9602abf5eeee184fb857aac699fe996b04d123",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58140",
+					"10.65.0.27:58140",
+					"172.17.0.1:58140",
+					"172.18.0.1:58140",
+					"172.19.0.1:58140"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:04:58.730257208Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2629265752823742,
+				"StableID":   "nVGc5UMoXM11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:34eb9266115cae5fa7a95ec41f0b292e24b32e3cb5107e9ce22a1c96aa968a4e",
+				"DiscoKey":   "discokey:e98f9e3abaa925a8bd66816c8e233ded5edece0df12732b22bd4bee9eb902e71",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:43943",
+					"10.65.0.27:43943",
+					"172.17.0.1:43943",
+					"172.18.0.1:43943",
+					"172.19.0.1:43943"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:04:59.260550637Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         284466274045946,
+				"StableID":   "nfheXuSqD311CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6bcd00261e125e0249cb365a75412811c61f011f87bf3e3d719cc79560354c78",
+				"KeyExpiry":  "2026-11-08T22:04:59Z",
+				"DiscoKey":   "discokey:7aeb63544520cdd6c176d5a2cbe91f6324d77e2482260997f8b3b3e7aa0a9919",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45306",
+					"10.65.0.27:45306",
+					"172.17.0.1:45306",
+					"172.18.0.1:45306",
+					"172.19.0.1:45306"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:04:59.818377845Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         385019259895652,
+				"StableID":   "nBQWZaoN1411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:500a68a11ef98a8383a58752c3adf7edc12d71bf04bc01ec1da9ab7f91545416",
+				"KeyExpiry":  "2026-11-08T22:05:00Z",
+				"DiscoKey":   "discokey:9c8796da79dc4b32df74275b2d2002f826adb285ae343f4cb3b0f955c2e9c01c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52849",
+					"10.65.0.27:52849",
+					"172.17.0.1:52849",
+					"172.18.0.1:52849",
+					"172.19.0.1:52849"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:05:00.342818144Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3826583399242238,
+				"StableID":   "n77NUir4tW11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7b66b60cfa40905c6f133bc8846777495e032df2e0a4e02fd32f8581f0f6e34c",
+				"KeyExpiry":  "2026-11-08T22:05:00Z",
+				"DiscoKey":   "discokey:692efc2015785f6383d1833a8d9fa1b0f59126bb2c135de3ecbd268a447f046e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58975",
+					"10.65.0.27:58975",
+					"172.17.0.1:58975",
+					"172.18.0.1:58975",
+					"172.19.0.1:58975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:05:00.879242259Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3139133500763793": {
+				"ID":          3139133500763793,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         385019259895652,
+				"StableID":   "nBQWZaoN1411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:500a68a11ef98a8383a58752c3adf7edc12d71bf04bc01ec1da9ab7f91545416",
+				"KeyExpiry":  "2026-11-08T22:05:00Z",
+				"DiscoKey":   "discokey:9c8796da79dc4b32df74275b2d2002f826adb285ae343f4cb3b0f955c2e9c01c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52849",
+					"10.65.0.27:52849",
+					"172.17.0.1:52849",
+					"172.18.0.1:52849",
+					"172.19.0.1:52849"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:05:00.342818144Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:500a68a11ef98a8383a58752c3adf7edc12d71bf04bc01ec1da9ab7f91545416",
+			"MachineKey": "mkey:207c8854e05fa34a03f677ff103aef8740500c11ee485113023e7dbc7df10718",
+			"Peers": [{
+				"ID":         1770596395891989,
+				"StableID":   "nGcBPmZupE11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5cf7dfb4297359ba0cbe6a5549d262270262bb58f1cb1a4ada6fd5fd15486e44",
+				"DiscoKey":   "discokey:1dc406d8a4bafdc881e8974ccecb5a92e24245044d97f0e3d55c82ab99479d45",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45825",
+					"10.65.0.27:45825",
+					"172.17.0.1:45825",
+					"172.18.0.1:45825",
+					"172.19.0.1:45825"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:04:53.28601152Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3942388568942736,
+				"StableID":   "nFYCm2sWnX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c80b637ba63929596fb9c22e2a7468dbaab733069168b01d4ff816970739166",
+				"DiscoKey":   "discokey:38439748949c62696fbe55350c97c9661b3ff33c00f0d09f2e6a77e7b3d8dc36",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37836",
+					"10.65.0.27:37836",
+					"172.17.0.1:37836",
+					"172.18.0.1:37836",
+					"172.19.0.1:37836"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:04:53.845326821Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7212130025057101,
+				"StableID":   "nEh3YiRPKy11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b26a5c2a4f87c18fc1a00171f60450a37aedf2fa426bd4a0e9998f695621f928",
+				"DiscoKey":   "discokey:cafc2407dedf41d2d3761d34cc6b766f7bd33d573feb2f7ca3b7f8ad558d7349",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56446",
+					"10.65.0.27:56446",
+					"172.17.0.1:56446",
+					"172.18.0.1:56446",
+					"172.19.0.1:56446"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:04:54.384411336Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         360229614638466,
+				"StableID":   "n9iqV2d9p311CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d9b3a85b8cb084191b3f7c65f16709c64f87c6c3854c2244b39a095be533138",
+				"DiscoKey":   "discokey:653d836afa376ee374e3b7c4db02b231b95b7cf68cf40d0e53da053778f8ef02",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:33116",
+					"10.65.0.27:33116",
+					"172.17.0.1:33116",
+					"172.18.0.1:33116",
+					"172.19.0.1:33116"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:04:54.922892486Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6337623294980712,
+				"StableID":   "nsvYQocKVr11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2cfdb9918eeb82ad8c4295473a8fa2964dfe2f1fe762f078c65fa5dbc9b35f2c",
+				"DiscoKey":   "discokey:e8d91f92594501d59046c1bd5ccb13550b6933ce95e937eae25cf8f622d8af6c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:44550",
+					"10.65.0.27:44550",
+					"172.17.0.1:44550",
+					"172.18.0.1:44550",
+					"172.19.0.1:44550"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:04:55.470595979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8719344879493080,
+				"StableID":   "n7YQ1UQ16B21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0121f40f1a20bf008e0ece0d7a3c83be6ee6f2564004d2a987156b00a9a8d741",
+				"DiscoKey":   "discokey:e6d28307f3d72528a67867a46b109ab83fd8b39b95ba183c2414f4203a854551",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:49291",
+					"10.65.0.27:49291",
+					"172.17.0.1:49291",
+					"172.18.0.1:49291",
+					"172.19.0.1:49291"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:04:56.011981447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7957743326954469,
+				"StableID":   "nQStnYR59521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:795220efe59a5cba12a775616ca9f352a48b59683e817635a8b0ee49e5179403",
+				"DiscoKey":   "discokey:f24791597a8b920b696c5b7574adbfe36be625ee71495a00e7fc65f14ca58330",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:32813",
+					"10.65.0.27:32813",
+					"172.17.0.1:32813",
+					"172.18.0.1:32813",
+					"172.19.0.1:32813"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:04:56.557914474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4487305531704325,
+				"StableID":   "nrfHncuJ3c11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ade330f965f0d4c410ab9a6839ff110c2d893ec5297d824a3751937b02bbe276",
+				"DiscoKey":   "discokey:0b57ce9bca09724ae0661843b142c9a3207b7b676f67896697f211d41fcbe40a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47557",
+					"10.65.0.27:47557",
+					"172.17.0.1:47557",
+					"172.18.0.1:47557",
+					"172.19.0.1:47557"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:04:57.101221392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3139133500763793,
+				"StableID":   "nCGH1RiiWR11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:287256207188031c99d92d2f9d92d92cf79d024e832f0dc8c2918bd103a1f773",
+				"DiscoKey":   "discokey:b76d2f6d79be8fdcb7b9a5f7b0495289f02e5411987c4a44148bb29ceb845202",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52703",
+					"10.65.0.27:52703",
+					"172.17.0.1:52703",
+					"172.18.0.1:52703",
+					"172.19.0.1:52703"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:04:57.636274753Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3522558669834099,
+				"StableID":   "nSadDJeNWU11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec5aad01f42d5b38d2acd4a00160cf739a79773c84022bacbe7063199070ea56",
+				"DiscoKey":   "discokey:732b43a5f2f493992e756a34fd52fc4de3dc8056a53bc2d9d6143739e3a1237b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38896",
+					"10.65.0.27:38896",
+					"172.17.0.1:38896",
+					"172.18.0.1:38896",
+					"172.19.0.1:38896"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:04:58.187769363Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3960847348496095,
+				"StableID":   "nkXKu7ksvX11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:44b8f6b1946ae7479c03facc963012e7822f7188052cdeaef18273958364ef7b",
+				"DiscoKey":   "discokey:9e93a855c013835052af1e15af9602abf5eeee184fb857aac699fe996b04d123",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58140",
+					"10.65.0.27:58140",
+					"172.17.0.1:58140",
+					"172.18.0.1:58140",
+					"172.19.0.1:58140"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:04:58.730257208Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2629265752823742,
+				"StableID":   "nVGc5UMoXM11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:34eb9266115cae5fa7a95ec41f0b292e24b32e3cb5107e9ce22a1c96aa968a4e",
+				"DiscoKey":   "discokey:e98f9e3abaa925a8bd66816c8e233ded5edece0df12732b22bd4bee9eb902e71",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:43943",
+					"10.65.0.27:43943",
+					"172.17.0.1:43943",
+					"172.18.0.1:43943",
+					"172.19.0.1:43943"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:04:59.260550637Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         284466274045946,
+				"StableID":   "nfheXuSqD311CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6bcd00261e125e0249cb365a75412811c61f011f87bf3e3d719cc79560354c78",
+				"KeyExpiry":  "2026-11-08T22:04:59Z",
+				"DiscoKey":   "discokey:7aeb63544520cdd6c176d5a2cbe91f6324d77e2482260997f8b3b3e7aa0a9919",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45306",
+					"10.65.0.27:45306",
+					"172.17.0.1:45306",
+					"172.18.0.1:45306",
+					"172.19.0.1:45306"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:04:59.818377845Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3826583399242238,
+				"StableID":   "n77NUir4tW11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7b66b60cfa40905c6f133bc8846777495e032df2e0a4e02fd32f8581f0f6e34c",
+				"KeyExpiry":  "2026-11-08T22:05:00Z",
+				"DiscoKey":   "discokey:692efc2015785f6383d1833a8d9fa1b0f59126bb2c135de3ecbd268a447f046e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58975",
+					"10.65.0.27:58975",
+					"172.17.0.1:58975",
+					"172.18.0.1:58975",
+					"172.19.0.1:58975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:05:00.879242259Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3522558669834099,
+				"StableID":   "nSadDJeNWU11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       3522558669834099,
+				"Key":        "nodekey:ec5aad01f42d5b38d2acd4a00160cf739a79773c84022bacbe7063199070ea56",
+				"DiscoKey":   "discokey:732b43a5f2f493992e756a34fd52fc4de3dc8056a53bc2d9d6143739e3a1237b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38896",
+					"10.65.0.27:38896",
+					"172.17.0.1:38896",
+					"172.18.0.1:38896",
+					"172.19.0.1:38896"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:04:58.187769363Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ec5aad01f42d5b38d2acd4a00160cf739a79773c84022bacbe7063199070ea56",
+			"MachineKey": "mkey:65e796ee035dbf4833c2347f580844330b482e605f3f067c668aada8154bc83a",
+			"Peers": [{
+				"ID":         1770596395891989,
+				"StableID":   "nGcBPmZupE11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5cf7dfb4297359ba0cbe6a5549d262270262bb58f1cb1a4ada6fd5fd15486e44",
+				"DiscoKey":   "discokey:1dc406d8a4bafdc881e8974ccecb5a92e24245044d97f0e3d55c82ab99479d45",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:45825",
+					"10.65.0.27:45825",
+					"172.17.0.1:45825",
+					"172.18.0.1:45825",
+					"172.19.0.1:45825"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:04:53.28601152Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3942388568942736,
+				"StableID":   "nFYCm2sWnX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c80b637ba63929596fb9c22e2a7468dbaab733069168b01d4ff816970739166",
+				"DiscoKey":   "discokey:38439748949c62696fbe55350c97c9661b3ff33c00f0d09f2e6a77e7b3d8dc36",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37836",
+					"10.65.0.27:37836",
+					"172.17.0.1:37836",
+					"172.18.0.1:37836",
+					"172.19.0.1:37836"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:04:53.845326821Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7212130025057101,
+				"StableID":   "nEh3YiRPKy11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b26a5c2a4f87c18fc1a00171f60450a37aedf2fa426bd4a0e9998f695621f928",
+				"DiscoKey":   "discokey:cafc2407dedf41d2d3761d34cc6b766f7bd33d573feb2f7ca3b7f8ad558d7349",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56446",
+					"10.65.0.27:56446",
+					"172.17.0.1:56446",
+					"172.18.0.1:56446",
+					"172.19.0.1:56446"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:04:54.384411336Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         360229614638466,
+				"StableID":   "n9iqV2d9p311CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d9b3a85b8cb084191b3f7c65f16709c64f87c6c3854c2244b39a095be533138",
+				"DiscoKey":   "discokey:653d836afa376ee374e3b7c4db02b231b95b7cf68cf40d0e53da053778f8ef02",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:33116",
+					"10.65.0.27:33116",
+					"172.17.0.1:33116",
+					"172.18.0.1:33116",
+					"172.19.0.1:33116"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:04:54.922892486Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6337623294980712,
+				"StableID":   "nsvYQocKVr11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2cfdb9918eeb82ad8c4295473a8fa2964dfe2f1fe762f078c65fa5dbc9b35f2c",
+				"DiscoKey":   "discokey:e8d91f92594501d59046c1bd5ccb13550b6933ce95e937eae25cf8f622d8af6c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:44550",
+					"10.65.0.27:44550",
+					"172.17.0.1:44550",
+					"172.18.0.1:44550",
+					"172.19.0.1:44550"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:04:55.470595979Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8719344879493080,
+				"StableID":   "n7YQ1UQ16B21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0121f40f1a20bf008e0ece0d7a3c83be6ee6f2564004d2a987156b00a9a8d741",
+				"DiscoKey":   "discokey:e6d28307f3d72528a67867a46b109ab83fd8b39b95ba183c2414f4203a854551",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:49291",
+					"10.65.0.27:49291",
+					"172.17.0.1:49291",
+					"172.18.0.1:49291",
+					"172.19.0.1:49291"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:04:56.011981447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7957743326954469,
+				"StableID":   "nQStnYR59521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:795220efe59a5cba12a775616ca9f352a48b59683e817635a8b0ee49e5179403",
+				"DiscoKey":   "discokey:f24791597a8b920b696c5b7574adbfe36be625ee71495a00e7fc65f14ca58330",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:32813",
+					"10.65.0.27:32813",
+					"172.17.0.1:32813",
+					"172.18.0.1:32813",
+					"172.19.0.1:32813"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:04:56.557914474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4487305531704325,
+				"StableID":   "nrfHncuJ3c11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ade330f965f0d4c410ab9a6839ff110c2d893ec5297d824a3751937b02bbe276",
+				"DiscoKey":   "discokey:0b57ce9bca09724ae0661843b142c9a3207b7b676f67896697f211d41fcbe40a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47557",
+					"10.65.0.27:47557",
+					"172.17.0.1:47557",
+					"172.18.0.1:47557",
+					"172.19.0.1:47557"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:04:57.101221392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3139133500763793,
+				"StableID":   "nCGH1RiiWR11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:287256207188031c99d92d2f9d92d92cf79d024e832f0dc8c2918bd103a1f773",
+				"DiscoKey":   "discokey:b76d2f6d79be8fdcb7b9a5f7b0495289f02e5411987c4a44148bb29ceb845202",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52703",
+					"10.65.0.27:52703",
+					"172.17.0.1:52703",
+					"172.18.0.1:52703",
+					"172.19.0.1:52703"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:04:57.636274753Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3960847348496095,
+				"StableID":   "nkXKu7ksvX11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:44b8f6b1946ae7479c03facc963012e7822f7188052cdeaef18273958364ef7b",
+				"DiscoKey":   "discokey:9e93a855c013835052af1e15af9602abf5eeee184fb857aac699fe996b04d123",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58140",
+					"10.65.0.27:58140",
+					"172.17.0.1:58140",
+					"172.18.0.1:58140",
+					"172.19.0.1:58140"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:04:58.730257208Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2629265752823742,
+				"StableID":   "nVGc5UMoXM11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:34eb9266115cae5fa7a95ec41f0b292e24b32e3cb5107e9ce22a1c96aa968a4e",
+				"DiscoKey":   "discokey:e98f9e3abaa925a8bd66816c8e233ded5edece0df12732b22bd4bee9eb902e71",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:43943",
+					"10.65.0.27:43943",
+					"172.17.0.1:43943",
+					"172.18.0.1:43943",
+					"172.19.0.1:43943"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:04:59.260550637Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         284466274045946,
+				"StableID":   "nfheXuSqD311CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6bcd00261e125e0249cb365a75412811c61f011f87bf3e3d719cc79560354c78",
+				"KeyExpiry":  "2026-11-08T22:04:59Z",
+				"DiscoKey":   "discokey:7aeb63544520cdd6c176d5a2cbe91f6324d77e2482260997f8b3b3e7aa0a9919",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45306",
+					"10.65.0.27:45306",
+					"172.17.0.1:45306",
+					"172.18.0.1:45306",
+					"172.19.0.1:45306"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:04:59.818377845Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         385019259895652,
+				"StableID":   "nBQWZaoN1411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:500a68a11ef98a8383a58752c3adf7edc12d71bf04bc01ec1da9ab7f91545416",
+				"KeyExpiry":  "2026-11-08T22:05:00Z",
+				"DiscoKey":   "discokey:9c8796da79dc4b32df74275b2d2002f826adb285ae343f4cb3b0f955c2e9c01c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52849",
+					"10.65.0.27:52849",
+					"172.17.0.1:52849",
+					"172.18.0.1:52849",
+					"172.19.0.1:52849"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:05:00.342818144Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3826583399242238,
+				"StableID":   "n77NUir4tW11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7b66b60cfa40905c6f133bc8846777495e032df2e0a4e02fd32f8581f0f6e34c",
+				"KeyExpiry":  "2026-11-08T22:05:00Z",
+				"DiscoKey":   "discokey:692efc2015785f6383d1833a8d9fa1b0f59126bb2c135de3ecbd268a447f046e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58975",
+					"10.65.0.27:58975",
+					"172.17.0.1:58975",
+					"172.18.0.1:58975",
+					"172.19.0.1:58975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:05:00.879242259Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3522558669834099": {
+				"ID":          3522558669834099,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-user-group-prefix.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-user-group-prefix.hujson
@@ -1,0 +1,20105 @@
+// ssh-malformed-user-group-prefix
+//
+// ssh users group prefix is rejected
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T22:05:36Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-malformed-user-group-prefix",
+	"description":    "ssh users group prefix is rejected",
+	"category":       "ssh",
+	"captured_at":    "2026-05-12T22:05:36.974173407Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                  \n  \n                                                                              \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh users group prefix is rejected\",\n\t\"id\":          \"ssh-malformed-user-group-prefix\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"groups\": {\"group:foo\": [\"odin@example.com\"]}, \"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"autogroup:member\"],\n\t\t\"users\":  [\"group:foo\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-malformed/ssh-malformed-user-group-prefix.hujson",
+		"full_policy": {
+			"groups": {"group:foo": ["odin@example.com"]},
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["autogroup:member"],
+				"users":  ["group:foo"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4158494613113948,
+				"StableID":   "nF8BsubPUZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       4158494613113948,
+				"Key":        "nodekey:e6949527d3d96159cf1d2c271990882b7e8eb7334c8badcb45262ecdd9269979",
+				"DiscoKey":   "discokey:e956da49e1ad48308a5de2630498329fd8c79098062be8f8f649db2d2e8ecc59",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49468",
+					"10.65.0.27:49468",
+					"172.17.0.1:49468",
+					"172.18.0.1:49468",
+					"172.19.0.1:49468"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:05:45.492405132Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e6949527d3d96159cf1d2c271990882b7e8eb7334c8badcb45262ecdd9269979",
+			"MachineKey": "mkey:7603824804453e73030b4a1e7ce1e308d404c3dffde63c6f7210d8129553e26d",
+			"Peers": [{
+				"ID":         1739955780428306,
+				"StableID":   "nVGq7ug2bE11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2a010553d1364bd7b01eee864538e7157e3b5d94a1fa6b8d055525eecc5a225c",
+				"DiscoKey":   "discokey:80f0f220e264fd4c8b5d2149130fafde8da79e09906d218fa667157c6168673c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40196",
+					"10.65.0.27:40196",
+					"172.17.0.1:40196",
+					"172.18.0.1:40196",
+					"172.19.0.1:40196"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:05:39.621735969Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5809560303894851,
+				"StableID":   "nJSj9HJANn11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9746aecf38cf74bbc8569813cd241e253df170693938585e0072e788d587d64f",
+				"DiscoKey":   "discokey:d373d524a1adc17a49715aecc36a147f8e6ca5864163a702d9698ff65049cf04",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34477",
+					"10.65.0.27:34477",
+					"172.17.0.1:34477",
+					"172.18.0.1:34477",
+					"172.19.0.1:34477"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:05:40.086480156Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6410717481083811,
+				"StableID":   "nLBJLJgR4s11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25618206e95f18346352b2fbb9100ad9f98d2357aec7e0da3dad796a7ad10b43",
+				"DiscoKey":   "discokey:d34864640b62ea396a3c7c0eaa42f81dab2ad337432036a818c25cf4d907962b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43606",
+					"10.65.0.27:43606",
+					"172.17.0.1:43606",
+					"172.18.0.1:43606",
+					"172.19.0.1:43606"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:05:40.623358026Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2741196811603753,
+				"StableID":   "nA3LTLbVQN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b8f6b4c867879c50255d7376f0653e4af396f4c18c9a6263d22035c3c8d176a",
+				"DiscoKey":   "discokey:ab35d2ff7b4c9ee7c45af1e3d67186be5b5c4fb7b1eff0c7efff0dece346eb63",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40463",
+					"10.65.0.27:40463",
+					"172.17.0.1:40463",
+					"172.18.0.1:40463",
+					"172.19.0.1:40463"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:05:41.172270716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5148399933808640,
+				"StableID":   "nyBSHhjiCh11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ce03b844d28b6f0f6f7292dc4c787ce7fe2fd8d24f79671c68065f6d0516e4e",
+				"DiscoKey":   "discokey:30cd7df7d40c83ace21c31313145a400f77c6f90204c7e89548c327c6324ba31",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:46264",
+					"10.65.0.27:46264",
+					"172.17.0.1:46264",
+					"172.18.0.1:46264",
+					"172.19.0.1:46264"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:05:41.710407885Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2866230741916704,
+				"StableID":   "nyMbiE28PP11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a0838907563e9489b0020051f2aed9f23e07e7ee22cad17ed1c1729b168ed22",
+				"DiscoKey":   "discokey:f7d92636bdf7b163ece85b768b051775c400d0052d00d6e740c51947bc77d006",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53701",
+					"10.65.0.27:53701",
+					"172.17.0.1:53701",
+					"172.18.0.1:53701",
+					"172.19.0.1:53701"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:05:42.252428426Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5855576432549971,
+				"StableID":   "nrkAsg41jn11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4cf62346578e901a81686feda0c201d34b5812d3de708cfa28fd3012f604404e",
+				"DiscoKey":   "discokey:381cedd538673ac5e758b337eababf3839422232e8ff20f5fb8080606a73a51d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54971",
+					"10.65.0.27:54971",
+					"172.17.0.1:54971",
+					"172.18.0.1:54971",
+					"172.19.0.1:54971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:05:42.805677795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1921999311452042,
+				"StableID":   "nFFPaSfU1G11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5bef3fba1f2266af5b701c89a51005ecc4be2c288dcaf02fd517fdc5029a674f",
+				"DiscoKey":   "discokey:8c10a1a2b31e402cf8485b9d2f212dcb9068be80d8a402e7b3443c612b69f120",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57385",
+					"10.65.0.27:57385",
+					"172.17.0.1:57385",
+					"172.18.0.1:57385",
+					"172.19.0.1:57385"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:05:43.338622861Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4877052708108015,
+				"StableID":   "nkmi8Uup5f11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7fd81a5cc2f4c216088fc038169f73f7cd44b1a03f3fd07d9fdba80475627510",
+				"DiscoKey":   "discokey:690ee8ce7a543b0bc34b3acdb451a27685adbf529733a12d0ccc52bbecee3e27",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:59129",
+					"10.65.0.27:59129",
+					"172.17.0.1:59129",
+					"172.18.0.1:59129",
+					"172.19.0.1:59129"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:05:43.867947153Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4688324295371875,
+				"StableID":   "neU3a6LMcd11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6ad8e1c7c3684f5e013a8761cfa1339b272c1349335f07c1acbcdd177f31a041",
+				"DiscoKey":   "discokey:97f959fa4dd9d5c6ac5c64cf78bd02c7ddb6fb57f8aeed5290031251921a7a31",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52860",
+					"10.65.0.27:52860",
+					"172.17.0.1:52860",
+					"172.18.0.1:52860",
+					"172.19.0.1:52860"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:05:44.4125404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         960792509251671,
+				"StableID":   "n4BsxcP9W811CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25924f82c2e4e2a96289c138fb692ce3d85bbe7e1978923ee82d57c53dad215b",
+				"DiscoKey":   "discokey:626127ab79776864c8b898998c78e29548a4c668f2bac03f40e98cf15170882a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56295",
+					"10.65.0.27:56295",
+					"172.17.0.1:56295",
+					"172.18.0.1:56295",
+					"172.19.0.1:56295"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:05:44.955522153Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7090431354986173,
+				"StableID":   "nrbKoHcGNx11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:fb9336c0762bdc4d4abd0f68b0c06326d7767408be67266c44645a8e83efad3b",
+				"KeyExpiry":  "2026-11-08T22:05:46Z",
+				"DiscoKey":   "discokey:e5af7abaa6b05b806bec5d9c6266d68ea7edde00917118d921b90ed7827fa629",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53478",
+					"10.65.0.27:53478",
+					"172.17.0.1:53478",
+					"172.18.0.1:53478",
+					"172.19.0.1:53478"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:05:46.226072737Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8111831117153597,
+				"StableID":   "nQeQAo3sL621CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:181534dd8c8edfc7b34edde75a7221433b3b0439a1f9bf3f9f7967adbc2cbd7d",
+				"KeyExpiry":  "2026-11-08T22:05:46Z",
+				"DiscoKey":   "discokey:4ebf62eb1531d5c3e8158dc673be9f8975534228c4aa865831a047e8def7bb72",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38459",
+					"10.65.0.27:38459",
+					"172.17.0.1:38459",
+					"172.18.0.1:38459",
+					"172.19.0.1:38459"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:05:46.775986537Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         131690244027660,
+				"StableID":   "nmDwuCHe2211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1cbfd67af89dfe11470bbeb24948da9ee9d478ad60b14d1954af7f38bd781d65",
+				"KeyExpiry":  "2026-11-08T22:05:47Z",
+				"DiscoKey":   "discokey:bdda7ea1deddf188da9387ec1c259fdc5e6c1966ea76e6e531029d949033dc44",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33060",
+					"10.65.0.27:33060",
+					"172.17.0.1:33060",
+					"172.18.0.1:33060",
+					"172.19.0.1:33060"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:05:47.311819952Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{"principals": [
+				{"nodeIP": "100.64.0.17"},
+				{"nodeIP": "100.64.0.18"},
+				{"nodeIP": "100.64.0.19"},
+				{"nodeIP": "fd7a:115c:a1e0::11"},
+				{"nodeIP": "fd7a:115c:a1e0::12"},
+				{"nodeIP": "fd7a:115c:a1e0::13"}
+			], "sshUsers": {"group:foo": "group:foo", "root": ""}, "action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4158494613113948": {
+				"ID":          4158494613113948,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		},
+		"ssh_rules": [{"principals": [
+			{"nodeIP": "100.64.0.17"},
+			{"nodeIP": "100.64.0.18"},
+			{"nodeIP": "100.64.0.19"},
+			{"nodeIP": "fd7a:115c:a1e0::11"},
+			{"nodeIP": "fd7a:115c:a1e0::12"},
+			{"nodeIP": "fd7a:115c:a1e0::13"}
+		], "sshUsers": {"group:foo": "group:foo", "root": ""}, "action": {
+			"accept":                    true,
+			"allowAgentForwarding":      true,
+			"allowLocalPortForwarding":  true,
+			"allowRemotePortForwarding": true
+		}}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2866230741916704,
+				"StableID":   "nyMbiE28PP11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       2866230741916704,
+				"Key":        "nodekey:1a0838907563e9489b0020051f2aed9f23e07e7ee22cad17ed1c1729b168ed22",
+				"DiscoKey":   "discokey:f7d92636bdf7b163ece85b768b051775c400d0052d00d6e740c51947bc77d006",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53701",
+					"10.65.0.27:53701",
+					"172.17.0.1:53701",
+					"172.18.0.1:53701",
+					"172.19.0.1:53701"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:05:42.252428426Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1a0838907563e9489b0020051f2aed9f23e07e7ee22cad17ed1c1729b168ed22",
+			"MachineKey": "mkey:149b3cd315f64de198c433b6495210401a472386987fb67c2ca99c6c94dbe860",
+			"Peers": [{
+				"ID":         1739955780428306,
+				"StableID":   "nVGq7ug2bE11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2a010553d1364bd7b01eee864538e7157e3b5d94a1fa6b8d055525eecc5a225c",
+				"DiscoKey":   "discokey:80f0f220e264fd4c8b5d2149130fafde8da79e09906d218fa667157c6168673c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40196",
+					"10.65.0.27:40196",
+					"172.17.0.1:40196",
+					"172.18.0.1:40196",
+					"172.19.0.1:40196"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:05:39.621735969Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5809560303894851,
+				"StableID":   "nJSj9HJANn11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9746aecf38cf74bbc8569813cd241e253df170693938585e0072e788d587d64f",
+				"DiscoKey":   "discokey:d373d524a1adc17a49715aecc36a147f8e6ca5864163a702d9698ff65049cf04",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34477",
+					"10.65.0.27:34477",
+					"172.17.0.1:34477",
+					"172.18.0.1:34477",
+					"172.19.0.1:34477"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:05:40.086480156Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6410717481083811,
+				"StableID":   "nLBJLJgR4s11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25618206e95f18346352b2fbb9100ad9f98d2357aec7e0da3dad796a7ad10b43",
+				"DiscoKey":   "discokey:d34864640b62ea396a3c7c0eaa42f81dab2ad337432036a818c25cf4d907962b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43606",
+					"10.65.0.27:43606",
+					"172.17.0.1:43606",
+					"172.18.0.1:43606",
+					"172.19.0.1:43606"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:05:40.623358026Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2741196811603753,
+				"StableID":   "nA3LTLbVQN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b8f6b4c867879c50255d7376f0653e4af396f4c18c9a6263d22035c3c8d176a",
+				"DiscoKey":   "discokey:ab35d2ff7b4c9ee7c45af1e3d67186be5b5c4fb7b1eff0c7efff0dece346eb63",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40463",
+					"10.65.0.27:40463",
+					"172.17.0.1:40463",
+					"172.18.0.1:40463",
+					"172.19.0.1:40463"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:05:41.172270716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5148399933808640,
+				"StableID":   "nyBSHhjiCh11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ce03b844d28b6f0f6f7292dc4c787ce7fe2fd8d24f79671c68065f6d0516e4e",
+				"DiscoKey":   "discokey:30cd7df7d40c83ace21c31313145a400f77c6f90204c7e89548c327c6324ba31",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:46264",
+					"10.65.0.27:46264",
+					"172.17.0.1:46264",
+					"172.18.0.1:46264",
+					"172.19.0.1:46264"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:05:41.710407885Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5855576432549971,
+				"StableID":   "nrkAsg41jn11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4cf62346578e901a81686feda0c201d34b5812d3de708cfa28fd3012f604404e",
+				"DiscoKey":   "discokey:381cedd538673ac5e758b337eababf3839422232e8ff20f5fb8080606a73a51d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54971",
+					"10.65.0.27:54971",
+					"172.17.0.1:54971",
+					"172.18.0.1:54971",
+					"172.19.0.1:54971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:05:42.805677795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1921999311452042,
+				"StableID":   "nFFPaSfU1G11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5bef3fba1f2266af5b701c89a51005ecc4be2c288dcaf02fd517fdc5029a674f",
+				"DiscoKey":   "discokey:8c10a1a2b31e402cf8485b9d2f212dcb9068be80d8a402e7b3443c612b69f120",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57385",
+					"10.65.0.27:57385",
+					"172.17.0.1:57385",
+					"172.18.0.1:57385",
+					"172.19.0.1:57385"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:05:43.338622861Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4877052708108015,
+				"StableID":   "nkmi8Uup5f11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7fd81a5cc2f4c216088fc038169f73f7cd44b1a03f3fd07d9fdba80475627510",
+				"DiscoKey":   "discokey:690ee8ce7a543b0bc34b3acdb451a27685adbf529733a12d0ccc52bbecee3e27",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:59129",
+					"10.65.0.27:59129",
+					"172.17.0.1:59129",
+					"172.18.0.1:59129",
+					"172.19.0.1:59129"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:05:43.867947153Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4688324295371875,
+				"StableID":   "neU3a6LMcd11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6ad8e1c7c3684f5e013a8761cfa1339b272c1349335f07c1acbcdd177f31a041",
+				"DiscoKey":   "discokey:97f959fa4dd9d5c6ac5c64cf78bd02c7ddb6fb57f8aeed5290031251921a7a31",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52860",
+					"10.65.0.27:52860",
+					"172.17.0.1:52860",
+					"172.18.0.1:52860",
+					"172.19.0.1:52860"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:05:44.4125404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         960792509251671,
+				"StableID":   "n4BsxcP9W811CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25924f82c2e4e2a96289c138fb692ce3d85bbe7e1978923ee82d57c53dad215b",
+				"DiscoKey":   "discokey:626127ab79776864c8b898998c78e29548a4c668f2bac03f40e98cf15170882a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56295",
+					"10.65.0.27:56295",
+					"172.17.0.1:56295",
+					"172.18.0.1:56295",
+					"172.19.0.1:56295"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:05:44.955522153Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4158494613113948,
+				"StableID":   "nF8BsubPUZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e6949527d3d96159cf1d2c271990882b7e8eb7334c8badcb45262ecdd9269979",
+				"DiscoKey":   "discokey:e956da49e1ad48308a5de2630498329fd8c79098062be8f8f649db2d2e8ecc59",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49468",
+					"10.65.0.27:49468",
+					"172.17.0.1:49468",
+					"172.18.0.1:49468",
+					"172.19.0.1:49468"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:05:45.492405132Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7090431354986173,
+				"StableID":   "nrbKoHcGNx11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:fb9336c0762bdc4d4abd0f68b0c06326d7767408be67266c44645a8e83efad3b",
+				"KeyExpiry":  "2026-11-08T22:05:46Z",
+				"DiscoKey":   "discokey:e5af7abaa6b05b806bec5d9c6266d68ea7edde00917118d921b90ed7827fa629",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53478",
+					"10.65.0.27:53478",
+					"172.17.0.1:53478",
+					"172.18.0.1:53478",
+					"172.19.0.1:53478"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:05:46.226072737Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8111831117153597,
+				"StableID":   "nQeQAo3sL621CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:181534dd8c8edfc7b34edde75a7221433b3b0439a1f9bf3f9f7967adbc2cbd7d",
+				"KeyExpiry":  "2026-11-08T22:05:46Z",
+				"DiscoKey":   "discokey:4ebf62eb1531d5c3e8158dc673be9f8975534228c4aa865831a047e8def7bb72",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38459",
+					"10.65.0.27:38459",
+					"172.17.0.1:38459",
+					"172.18.0.1:38459",
+					"172.19.0.1:38459"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:05:46.775986537Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         131690244027660,
+				"StableID":   "nmDwuCHe2211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1cbfd67af89dfe11470bbeb24948da9ee9d478ad60b14d1954af7f38bd781d65",
+				"KeyExpiry":  "2026-11-08T22:05:47Z",
+				"DiscoKey":   "discokey:bdda7ea1deddf188da9387ec1c259fdc5e6c1966ea76e6e531029d949033dc44",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33060",
+					"10.65.0.27:33060",
+					"172.17.0.1:33060",
+					"172.18.0.1:33060",
+					"172.19.0.1:33060"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:05:47.311819952Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2866230741916704": {
+				"ID":          2866230741916704,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         131690244027660,
+				"StableID":   "nmDwuCHe2211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1cbfd67af89dfe11470bbeb24948da9ee9d478ad60b14d1954af7f38bd781d65",
+				"KeyExpiry":  "2026-11-08T22:05:47Z",
+				"DiscoKey":   "discokey:bdda7ea1deddf188da9387ec1c259fdc5e6c1966ea76e6e531029d949033dc44",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33060",
+					"10.65.0.27:33060",
+					"172.17.0.1:33060",
+					"172.18.0.1:33060",
+					"172.19.0.1:33060"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:05:47.311819952Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1cbfd67af89dfe11470bbeb24948da9ee9d478ad60b14d1954af7f38bd781d65",
+			"MachineKey": "mkey:13e9f1a359982ee1e681332dd2ce01e51f69c36cd47d1b792619d0773870440d",
+			"Peers": [{
+				"ID":         1739955780428306,
+				"StableID":   "nVGq7ug2bE11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2a010553d1364bd7b01eee864538e7157e3b5d94a1fa6b8d055525eecc5a225c",
+				"DiscoKey":   "discokey:80f0f220e264fd4c8b5d2149130fafde8da79e09906d218fa667157c6168673c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40196",
+					"10.65.0.27:40196",
+					"172.17.0.1:40196",
+					"172.18.0.1:40196",
+					"172.19.0.1:40196"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:05:39.621735969Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5809560303894851,
+				"StableID":   "nJSj9HJANn11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9746aecf38cf74bbc8569813cd241e253df170693938585e0072e788d587d64f",
+				"DiscoKey":   "discokey:d373d524a1adc17a49715aecc36a147f8e6ca5864163a702d9698ff65049cf04",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34477",
+					"10.65.0.27:34477",
+					"172.17.0.1:34477",
+					"172.18.0.1:34477",
+					"172.19.0.1:34477"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:05:40.086480156Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6410717481083811,
+				"StableID":   "nLBJLJgR4s11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25618206e95f18346352b2fbb9100ad9f98d2357aec7e0da3dad796a7ad10b43",
+				"DiscoKey":   "discokey:d34864640b62ea396a3c7c0eaa42f81dab2ad337432036a818c25cf4d907962b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43606",
+					"10.65.0.27:43606",
+					"172.17.0.1:43606",
+					"172.18.0.1:43606",
+					"172.19.0.1:43606"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:05:40.623358026Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2741196811603753,
+				"StableID":   "nA3LTLbVQN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b8f6b4c867879c50255d7376f0653e4af396f4c18c9a6263d22035c3c8d176a",
+				"DiscoKey":   "discokey:ab35d2ff7b4c9ee7c45af1e3d67186be5b5c4fb7b1eff0c7efff0dece346eb63",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40463",
+					"10.65.0.27:40463",
+					"172.17.0.1:40463",
+					"172.18.0.1:40463",
+					"172.19.0.1:40463"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:05:41.172270716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5148399933808640,
+				"StableID":   "nyBSHhjiCh11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ce03b844d28b6f0f6f7292dc4c787ce7fe2fd8d24f79671c68065f6d0516e4e",
+				"DiscoKey":   "discokey:30cd7df7d40c83ace21c31313145a400f77c6f90204c7e89548c327c6324ba31",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:46264",
+					"10.65.0.27:46264",
+					"172.17.0.1:46264",
+					"172.18.0.1:46264",
+					"172.19.0.1:46264"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:05:41.710407885Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2866230741916704,
+				"StableID":   "nyMbiE28PP11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a0838907563e9489b0020051f2aed9f23e07e7ee22cad17ed1c1729b168ed22",
+				"DiscoKey":   "discokey:f7d92636bdf7b163ece85b768b051775c400d0052d00d6e740c51947bc77d006",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53701",
+					"10.65.0.27:53701",
+					"172.17.0.1:53701",
+					"172.18.0.1:53701",
+					"172.19.0.1:53701"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:05:42.252428426Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5855576432549971,
+				"StableID":   "nrkAsg41jn11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4cf62346578e901a81686feda0c201d34b5812d3de708cfa28fd3012f604404e",
+				"DiscoKey":   "discokey:381cedd538673ac5e758b337eababf3839422232e8ff20f5fb8080606a73a51d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54971",
+					"10.65.0.27:54971",
+					"172.17.0.1:54971",
+					"172.18.0.1:54971",
+					"172.19.0.1:54971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:05:42.805677795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1921999311452042,
+				"StableID":   "nFFPaSfU1G11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5bef3fba1f2266af5b701c89a51005ecc4be2c288dcaf02fd517fdc5029a674f",
+				"DiscoKey":   "discokey:8c10a1a2b31e402cf8485b9d2f212dcb9068be80d8a402e7b3443c612b69f120",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57385",
+					"10.65.0.27:57385",
+					"172.17.0.1:57385",
+					"172.18.0.1:57385",
+					"172.19.0.1:57385"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:05:43.338622861Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4877052708108015,
+				"StableID":   "nkmi8Uup5f11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7fd81a5cc2f4c216088fc038169f73f7cd44b1a03f3fd07d9fdba80475627510",
+				"DiscoKey":   "discokey:690ee8ce7a543b0bc34b3acdb451a27685adbf529733a12d0ccc52bbecee3e27",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:59129",
+					"10.65.0.27:59129",
+					"172.17.0.1:59129",
+					"172.18.0.1:59129",
+					"172.19.0.1:59129"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:05:43.867947153Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4688324295371875,
+				"StableID":   "neU3a6LMcd11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6ad8e1c7c3684f5e013a8761cfa1339b272c1349335f07c1acbcdd177f31a041",
+				"DiscoKey":   "discokey:97f959fa4dd9d5c6ac5c64cf78bd02c7ddb6fb57f8aeed5290031251921a7a31",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52860",
+					"10.65.0.27:52860",
+					"172.17.0.1:52860",
+					"172.18.0.1:52860",
+					"172.19.0.1:52860"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:05:44.4125404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         960792509251671,
+				"StableID":   "n4BsxcP9W811CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25924f82c2e4e2a96289c138fb692ce3d85bbe7e1978923ee82d57c53dad215b",
+				"DiscoKey":   "discokey:626127ab79776864c8b898998c78e29548a4c668f2bac03f40e98cf15170882a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56295",
+					"10.65.0.27:56295",
+					"172.17.0.1:56295",
+					"172.18.0.1:56295",
+					"172.19.0.1:56295"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:05:44.955522153Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4158494613113948,
+				"StableID":   "nF8BsubPUZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e6949527d3d96159cf1d2c271990882b7e8eb7334c8badcb45262ecdd9269979",
+				"DiscoKey":   "discokey:e956da49e1ad48308a5de2630498329fd8c79098062be8f8f649db2d2e8ecc59",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49468",
+					"10.65.0.27:49468",
+					"172.17.0.1:49468",
+					"172.18.0.1:49468",
+					"172.19.0.1:49468"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:05:45.492405132Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7090431354986173,
+				"StableID":   "nrbKoHcGNx11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:fb9336c0762bdc4d4abd0f68b0c06326d7767408be67266c44645a8e83efad3b",
+				"KeyExpiry":  "2026-11-08T22:05:46Z",
+				"DiscoKey":   "discokey:e5af7abaa6b05b806bec5d9c6266d68ea7edde00917118d921b90ed7827fa629",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53478",
+					"10.65.0.27:53478",
+					"172.17.0.1:53478",
+					"172.18.0.1:53478",
+					"172.19.0.1:53478"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:05:46.226072737Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8111831117153597,
+				"StableID":   "nQeQAo3sL621CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:181534dd8c8edfc7b34edde75a7221433b3b0439a1f9bf3f9f7967adbc2cbd7d",
+				"KeyExpiry":  "2026-11-08T22:05:46Z",
+				"DiscoKey":   "discokey:4ebf62eb1531d5c3e8158dc673be9f8975534228c4aa865831a047e8def7bb72",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38459",
+					"10.65.0.27:38459",
+					"172.17.0.1:38459",
+					"172.18.0.1:38459",
+					"172.19.0.1:38459"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:05:46.775986537Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6410717481083811,
+				"StableID":   "nLBJLJgR4s11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       6410717481083811,
+				"Key":        "nodekey:25618206e95f18346352b2fbb9100ad9f98d2357aec7e0da3dad796a7ad10b43",
+				"DiscoKey":   "discokey:d34864640b62ea396a3c7c0eaa42f81dab2ad337432036a818c25cf4d907962b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43606",
+					"10.65.0.27:43606",
+					"172.17.0.1:43606",
+					"172.18.0.1:43606",
+					"172.19.0.1:43606"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:05:40.623358026Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:25618206e95f18346352b2fbb9100ad9f98d2357aec7e0da3dad796a7ad10b43",
+			"MachineKey": "mkey:93c0259f13b0e84defc92b8b8dafcaa338568f0e55d1d894335aa4fef975d63e",
+			"Peers": [{
+				"ID":         1739955780428306,
+				"StableID":   "nVGq7ug2bE11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2a010553d1364bd7b01eee864538e7157e3b5d94a1fa6b8d055525eecc5a225c",
+				"DiscoKey":   "discokey:80f0f220e264fd4c8b5d2149130fafde8da79e09906d218fa667157c6168673c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40196",
+					"10.65.0.27:40196",
+					"172.17.0.1:40196",
+					"172.18.0.1:40196",
+					"172.19.0.1:40196"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:05:39.621735969Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5809560303894851,
+				"StableID":   "nJSj9HJANn11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9746aecf38cf74bbc8569813cd241e253df170693938585e0072e788d587d64f",
+				"DiscoKey":   "discokey:d373d524a1adc17a49715aecc36a147f8e6ca5864163a702d9698ff65049cf04",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34477",
+					"10.65.0.27:34477",
+					"172.17.0.1:34477",
+					"172.18.0.1:34477",
+					"172.19.0.1:34477"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:05:40.086480156Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2741196811603753,
+				"StableID":   "nA3LTLbVQN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b8f6b4c867879c50255d7376f0653e4af396f4c18c9a6263d22035c3c8d176a",
+				"DiscoKey":   "discokey:ab35d2ff7b4c9ee7c45af1e3d67186be5b5c4fb7b1eff0c7efff0dece346eb63",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40463",
+					"10.65.0.27:40463",
+					"172.17.0.1:40463",
+					"172.18.0.1:40463",
+					"172.19.0.1:40463"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:05:41.172270716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5148399933808640,
+				"StableID":   "nyBSHhjiCh11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ce03b844d28b6f0f6f7292dc4c787ce7fe2fd8d24f79671c68065f6d0516e4e",
+				"DiscoKey":   "discokey:30cd7df7d40c83ace21c31313145a400f77c6f90204c7e89548c327c6324ba31",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:46264",
+					"10.65.0.27:46264",
+					"172.17.0.1:46264",
+					"172.18.0.1:46264",
+					"172.19.0.1:46264"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:05:41.710407885Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2866230741916704,
+				"StableID":   "nyMbiE28PP11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a0838907563e9489b0020051f2aed9f23e07e7ee22cad17ed1c1729b168ed22",
+				"DiscoKey":   "discokey:f7d92636bdf7b163ece85b768b051775c400d0052d00d6e740c51947bc77d006",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53701",
+					"10.65.0.27:53701",
+					"172.17.0.1:53701",
+					"172.18.0.1:53701",
+					"172.19.0.1:53701"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:05:42.252428426Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5855576432549971,
+				"StableID":   "nrkAsg41jn11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4cf62346578e901a81686feda0c201d34b5812d3de708cfa28fd3012f604404e",
+				"DiscoKey":   "discokey:381cedd538673ac5e758b337eababf3839422232e8ff20f5fb8080606a73a51d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54971",
+					"10.65.0.27:54971",
+					"172.17.0.1:54971",
+					"172.18.0.1:54971",
+					"172.19.0.1:54971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:05:42.805677795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1921999311452042,
+				"StableID":   "nFFPaSfU1G11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5bef3fba1f2266af5b701c89a51005ecc4be2c288dcaf02fd517fdc5029a674f",
+				"DiscoKey":   "discokey:8c10a1a2b31e402cf8485b9d2f212dcb9068be80d8a402e7b3443c612b69f120",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57385",
+					"10.65.0.27:57385",
+					"172.17.0.1:57385",
+					"172.18.0.1:57385",
+					"172.19.0.1:57385"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:05:43.338622861Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4877052708108015,
+				"StableID":   "nkmi8Uup5f11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7fd81a5cc2f4c216088fc038169f73f7cd44b1a03f3fd07d9fdba80475627510",
+				"DiscoKey":   "discokey:690ee8ce7a543b0bc34b3acdb451a27685adbf529733a12d0ccc52bbecee3e27",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:59129",
+					"10.65.0.27:59129",
+					"172.17.0.1:59129",
+					"172.18.0.1:59129",
+					"172.19.0.1:59129"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:05:43.867947153Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4688324295371875,
+				"StableID":   "neU3a6LMcd11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6ad8e1c7c3684f5e013a8761cfa1339b272c1349335f07c1acbcdd177f31a041",
+				"DiscoKey":   "discokey:97f959fa4dd9d5c6ac5c64cf78bd02c7ddb6fb57f8aeed5290031251921a7a31",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52860",
+					"10.65.0.27:52860",
+					"172.17.0.1:52860",
+					"172.18.0.1:52860",
+					"172.19.0.1:52860"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:05:44.4125404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         960792509251671,
+				"StableID":   "n4BsxcP9W811CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25924f82c2e4e2a96289c138fb692ce3d85bbe7e1978923ee82d57c53dad215b",
+				"DiscoKey":   "discokey:626127ab79776864c8b898998c78e29548a4c668f2bac03f40e98cf15170882a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56295",
+					"10.65.0.27:56295",
+					"172.17.0.1:56295",
+					"172.18.0.1:56295",
+					"172.19.0.1:56295"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:05:44.955522153Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4158494613113948,
+				"StableID":   "nF8BsubPUZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e6949527d3d96159cf1d2c271990882b7e8eb7334c8badcb45262ecdd9269979",
+				"DiscoKey":   "discokey:e956da49e1ad48308a5de2630498329fd8c79098062be8f8f649db2d2e8ecc59",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49468",
+					"10.65.0.27:49468",
+					"172.17.0.1:49468",
+					"172.18.0.1:49468",
+					"172.19.0.1:49468"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:05:45.492405132Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7090431354986173,
+				"StableID":   "nrbKoHcGNx11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:fb9336c0762bdc4d4abd0f68b0c06326d7767408be67266c44645a8e83efad3b",
+				"KeyExpiry":  "2026-11-08T22:05:46Z",
+				"DiscoKey":   "discokey:e5af7abaa6b05b806bec5d9c6266d68ea7edde00917118d921b90ed7827fa629",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53478",
+					"10.65.0.27:53478",
+					"172.17.0.1:53478",
+					"172.18.0.1:53478",
+					"172.19.0.1:53478"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:05:46.226072737Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8111831117153597,
+				"StableID":   "nQeQAo3sL621CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:181534dd8c8edfc7b34edde75a7221433b3b0439a1f9bf3f9f7967adbc2cbd7d",
+				"KeyExpiry":  "2026-11-08T22:05:46Z",
+				"DiscoKey":   "discokey:4ebf62eb1531d5c3e8158dc673be9f8975534228c4aa865831a047e8def7bb72",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38459",
+					"10.65.0.27:38459",
+					"172.17.0.1:38459",
+					"172.18.0.1:38459",
+					"172.19.0.1:38459"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:05:46.775986537Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         131690244027660,
+				"StableID":   "nmDwuCHe2211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1cbfd67af89dfe11470bbeb24948da9ee9d478ad60b14d1954af7f38bd781d65",
+				"KeyExpiry":  "2026-11-08T22:05:47Z",
+				"DiscoKey":   "discokey:bdda7ea1deddf188da9387ec1c259fdc5e6c1966ea76e6e531029d949033dc44",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33060",
+					"10.65.0.27:33060",
+					"172.17.0.1:33060",
+					"172.18.0.1:33060",
+					"172.19.0.1:33060"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:05:47.311819952Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6410717481083811": {
+				"ID":          6410717481083811,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1921999311452042,
+				"StableID":   "nFFPaSfU1G11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1921999311452042,
+				"Key":        "nodekey:5bef3fba1f2266af5b701c89a51005ecc4be2c288dcaf02fd517fdc5029a674f",
+				"DiscoKey":   "discokey:8c10a1a2b31e402cf8485b9d2f212dcb9068be80d8a402e7b3443c612b69f120",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57385",
+					"10.65.0.27:57385",
+					"172.17.0.1:57385",
+					"172.18.0.1:57385",
+					"172.19.0.1:57385"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:05:43.338622861Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5bef3fba1f2266af5b701c89a51005ecc4be2c288dcaf02fd517fdc5029a674f",
+			"MachineKey": "mkey:8bd7e24f3b0798323aec2d00ef61ecc7f592617843cc7b5087a61aa8db8e4021",
+			"Peers": [{
+				"ID":         1739955780428306,
+				"StableID":   "nVGq7ug2bE11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2a010553d1364bd7b01eee864538e7157e3b5d94a1fa6b8d055525eecc5a225c",
+				"DiscoKey":   "discokey:80f0f220e264fd4c8b5d2149130fafde8da79e09906d218fa667157c6168673c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40196",
+					"10.65.0.27:40196",
+					"172.17.0.1:40196",
+					"172.18.0.1:40196",
+					"172.19.0.1:40196"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:05:39.621735969Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5809560303894851,
+				"StableID":   "nJSj9HJANn11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9746aecf38cf74bbc8569813cd241e253df170693938585e0072e788d587d64f",
+				"DiscoKey":   "discokey:d373d524a1adc17a49715aecc36a147f8e6ca5864163a702d9698ff65049cf04",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34477",
+					"10.65.0.27:34477",
+					"172.17.0.1:34477",
+					"172.18.0.1:34477",
+					"172.19.0.1:34477"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:05:40.086480156Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6410717481083811,
+				"StableID":   "nLBJLJgR4s11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25618206e95f18346352b2fbb9100ad9f98d2357aec7e0da3dad796a7ad10b43",
+				"DiscoKey":   "discokey:d34864640b62ea396a3c7c0eaa42f81dab2ad337432036a818c25cf4d907962b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43606",
+					"10.65.0.27:43606",
+					"172.17.0.1:43606",
+					"172.18.0.1:43606",
+					"172.19.0.1:43606"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:05:40.623358026Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2741196811603753,
+				"StableID":   "nA3LTLbVQN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b8f6b4c867879c50255d7376f0653e4af396f4c18c9a6263d22035c3c8d176a",
+				"DiscoKey":   "discokey:ab35d2ff7b4c9ee7c45af1e3d67186be5b5c4fb7b1eff0c7efff0dece346eb63",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40463",
+					"10.65.0.27:40463",
+					"172.17.0.1:40463",
+					"172.18.0.1:40463",
+					"172.19.0.1:40463"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:05:41.172270716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5148399933808640,
+				"StableID":   "nyBSHhjiCh11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ce03b844d28b6f0f6f7292dc4c787ce7fe2fd8d24f79671c68065f6d0516e4e",
+				"DiscoKey":   "discokey:30cd7df7d40c83ace21c31313145a400f77c6f90204c7e89548c327c6324ba31",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:46264",
+					"10.65.0.27:46264",
+					"172.17.0.1:46264",
+					"172.18.0.1:46264",
+					"172.19.0.1:46264"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:05:41.710407885Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2866230741916704,
+				"StableID":   "nyMbiE28PP11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a0838907563e9489b0020051f2aed9f23e07e7ee22cad17ed1c1729b168ed22",
+				"DiscoKey":   "discokey:f7d92636bdf7b163ece85b768b051775c400d0052d00d6e740c51947bc77d006",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53701",
+					"10.65.0.27:53701",
+					"172.17.0.1:53701",
+					"172.18.0.1:53701",
+					"172.19.0.1:53701"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:05:42.252428426Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5855576432549971,
+				"StableID":   "nrkAsg41jn11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4cf62346578e901a81686feda0c201d34b5812d3de708cfa28fd3012f604404e",
+				"DiscoKey":   "discokey:381cedd538673ac5e758b337eababf3839422232e8ff20f5fb8080606a73a51d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54971",
+					"10.65.0.27:54971",
+					"172.17.0.1:54971",
+					"172.18.0.1:54971",
+					"172.19.0.1:54971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:05:42.805677795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4877052708108015,
+				"StableID":   "nkmi8Uup5f11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7fd81a5cc2f4c216088fc038169f73f7cd44b1a03f3fd07d9fdba80475627510",
+				"DiscoKey":   "discokey:690ee8ce7a543b0bc34b3acdb451a27685adbf529733a12d0ccc52bbecee3e27",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:59129",
+					"10.65.0.27:59129",
+					"172.17.0.1:59129",
+					"172.18.0.1:59129",
+					"172.19.0.1:59129"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:05:43.867947153Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4688324295371875,
+				"StableID":   "neU3a6LMcd11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6ad8e1c7c3684f5e013a8761cfa1339b272c1349335f07c1acbcdd177f31a041",
+				"DiscoKey":   "discokey:97f959fa4dd9d5c6ac5c64cf78bd02c7ddb6fb57f8aeed5290031251921a7a31",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52860",
+					"10.65.0.27:52860",
+					"172.17.0.1:52860",
+					"172.18.0.1:52860",
+					"172.19.0.1:52860"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:05:44.4125404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         960792509251671,
+				"StableID":   "n4BsxcP9W811CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25924f82c2e4e2a96289c138fb692ce3d85bbe7e1978923ee82d57c53dad215b",
+				"DiscoKey":   "discokey:626127ab79776864c8b898998c78e29548a4c668f2bac03f40e98cf15170882a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56295",
+					"10.65.0.27:56295",
+					"172.17.0.1:56295",
+					"172.18.0.1:56295",
+					"172.19.0.1:56295"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:05:44.955522153Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4158494613113948,
+				"StableID":   "nF8BsubPUZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e6949527d3d96159cf1d2c271990882b7e8eb7334c8badcb45262ecdd9269979",
+				"DiscoKey":   "discokey:e956da49e1ad48308a5de2630498329fd8c79098062be8f8f649db2d2e8ecc59",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49468",
+					"10.65.0.27:49468",
+					"172.17.0.1:49468",
+					"172.18.0.1:49468",
+					"172.19.0.1:49468"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:05:45.492405132Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7090431354986173,
+				"StableID":   "nrbKoHcGNx11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:fb9336c0762bdc4d4abd0f68b0c06326d7767408be67266c44645a8e83efad3b",
+				"KeyExpiry":  "2026-11-08T22:05:46Z",
+				"DiscoKey":   "discokey:e5af7abaa6b05b806bec5d9c6266d68ea7edde00917118d921b90ed7827fa629",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53478",
+					"10.65.0.27:53478",
+					"172.17.0.1:53478",
+					"172.18.0.1:53478",
+					"172.19.0.1:53478"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:05:46.226072737Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8111831117153597,
+				"StableID":   "nQeQAo3sL621CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:181534dd8c8edfc7b34edde75a7221433b3b0439a1f9bf3f9f7967adbc2cbd7d",
+				"KeyExpiry":  "2026-11-08T22:05:46Z",
+				"DiscoKey":   "discokey:4ebf62eb1531d5c3e8158dc673be9f8975534228c4aa865831a047e8def7bb72",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38459",
+					"10.65.0.27:38459",
+					"172.17.0.1:38459",
+					"172.18.0.1:38459",
+					"172.19.0.1:38459"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:05:46.775986537Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         131690244027660,
+				"StableID":   "nmDwuCHe2211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1cbfd67af89dfe11470bbeb24948da9ee9d478ad60b14d1954af7f38bd781d65",
+				"KeyExpiry":  "2026-11-08T22:05:47Z",
+				"DiscoKey":   "discokey:bdda7ea1deddf188da9387ec1c259fdc5e6c1966ea76e6e531029d949033dc44",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33060",
+					"10.65.0.27:33060",
+					"172.17.0.1:33060",
+					"172.18.0.1:33060",
+					"172.19.0.1:33060"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:05:47.311819952Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1921999311452042": {
+				"ID":          1921999311452042,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7090431354986173,
+				"StableID":   "nrbKoHcGNx11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:fb9336c0762bdc4d4abd0f68b0c06326d7767408be67266c44645a8e83efad3b",
+				"KeyExpiry":  "2026-11-08T22:05:46Z",
+				"DiscoKey":   "discokey:e5af7abaa6b05b806bec5d9c6266d68ea7edde00917118d921b90ed7827fa629",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53478",
+					"10.65.0.27:53478",
+					"172.17.0.1:53478",
+					"172.18.0.1:53478",
+					"172.19.0.1:53478"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:05:46.226072737Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:fb9336c0762bdc4d4abd0f68b0c06326d7767408be67266c44645a8e83efad3b",
+			"MachineKey": "mkey:d4adf29f6e72dc3f6f68c5cb097cd3aa0a3629559f77cb3ece5513406da06c4f",
+			"Peers": [{
+				"ID":         1739955780428306,
+				"StableID":   "nVGq7ug2bE11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2a010553d1364bd7b01eee864538e7157e3b5d94a1fa6b8d055525eecc5a225c",
+				"DiscoKey":   "discokey:80f0f220e264fd4c8b5d2149130fafde8da79e09906d218fa667157c6168673c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40196",
+					"10.65.0.27:40196",
+					"172.17.0.1:40196",
+					"172.18.0.1:40196",
+					"172.19.0.1:40196"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:05:39.621735969Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5809560303894851,
+				"StableID":   "nJSj9HJANn11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9746aecf38cf74bbc8569813cd241e253df170693938585e0072e788d587d64f",
+				"DiscoKey":   "discokey:d373d524a1adc17a49715aecc36a147f8e6ca5864163a702d9698ff65049cf04",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34477",
+					"10.65.0.27:34477",
+					"172.17.0.1:34477",
+					"172.18.0.1:34477",
+					"172.19.0.1:34477"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:05:40.086480156Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6410717481083811,
+				"StableID":   "nLBJLJgR4s11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25618206e95f18346352b2fbb9100ad9f98d2357aec7e0da3dad796a7ad10b43",
+				"DiscoKey":   "discokey:d34864640b62ea396a3c7c0eaa42f81dab2ad337432036a818c25cf4d907962b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43606",
+					"10.65.0.27:43606",
+					"172.17.0.1:43606",
+					"172.18.0.1:43606",
+					"172.19.0.1:43606"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:05:40.623358026Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2741196811603753,
+				"StableID":   "nA3LTLbVQN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b8f6b4c867879c50255d7376f0653e4af396f4c18c9a6263d22035c3c8d176a",
+				"DiscoKey":   "discokey:ab35d2ff7b4c9ee7c45af1e3d67186be5b5c4fb7b1eff0c7efff0dece346eb63",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40463",
+					"10.65.0.27:40463",
+					"172.17.0.1:40463",
+					"172.18.0.1:40463",
+					"172.19.0.1:40463"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:05:41.172270716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5148399933808640,
+				"StableID":   "nyBSHhjiCh11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ce03b844d28b6f0f6f7292dc4c787ce7fe2fd8d24f79671c68065f6d0516e4e",
+				"DiscoKey":   "discokey:30cd7df7d40c83ace21c31313145a400f77c6f90204c7e89548c327c6324ba31",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:46264",
+					"10.65.0.27:46264",
+					"172.17.0.1:46264",
+					"172.18.0.1:46264",
+					"172.19.0.1:46264"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:05:41.710407885Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2866230741916704,
+				"StableID":   "nyMbiE28PP11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a0838907563e9489b0020051f2aed9f23e07e7ee22cad17ed1c1729b168ed22",
+				"DiscoKey":   "discokey:f7d92636bdf7b163ece85b768b051775c400d0052d00d6e740c51947bc77d006",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53701",
+					"10.65.0.27:53701",
+					"172.17.0.1:53701",
+					"172.18.0.1:53701",
+					"172.19.0.1:53701"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:05:42.252428426Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5855576432549971,
+				"StableID":   "nrkAsg41jn11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4cf62346578e901a81686feda0c201d34b5812d3de708cfa28fd3012f604404e",
+				"DiscoKey":   "discokey:381cedd538673ac5e758b337eababf3839422232e8ff20f5fb8080606a73a51d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54971",
+					"10.65.0.27:54971",
+					"172.17.0.1:54971",
+					"172.18.0.1:54971",
+					"172.19.0.1:54971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:05:42.805677795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1921999311452042,
+				"StableID":   "nFFPaSfU1G11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5bef3fba1f2266af5b701c89a51005ecc4be2c288dcaf02fd517fdc5029a674f",
+				"DiscoKey":   "discokey:8c10a1a2b31e402cf8485b9d2f212dcb9068be80d8a402e7b3443c612b69f120",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57385",
+					"10.65.0.27:57385",
+					"172.17.0.1:57385",
+					"172.18.0.1:57385",
+					"172.19.0.1:57385"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:05:43.338622861Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4877052708108015,
+				"StableID":   "nkmi8Uup5f11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7fd81a5cc2f4c216088fc038169f73f7cd44b1a03f3fd07d9fdba80475627510",
+				"DiscoKey":   "discokey:690ee8ce7a543b0bc34b3acdb451a27685adbf529733a12d0ccc52bbecee3e27",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:59129",
+					"10.65.0.27:59129",
+					"172.17.0.1:59129",
+					"172.18.0.1:59129",
+					"172.19.0.1:59129"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:05:43.867947153Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4688324295371875,
+				"StableID":   "neU3a6LMcd11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6ad8e1c7c3684f5e013a8761cfa1339b272c1349335f07c1acbcdd177f31a041",
+				"DiscoKey":   "discokey:97f959fa4dd9d5c6ac5c64cf78bd02c7ddb6fb57f8aeed5290031251921a7a31",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52860",
+					"10.65.0.27:52860",
+					"172.17.0.1:52860",
+					"172.18.0.1:52860",
+					"172.19.0.1:52860"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:05:44.4125404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         960792509251671,
+				"StableID":   "n4BsxcP9W811CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25924f82c2e4e2a96289c138fb692ce3d85bbe7e1978923ee82d57c53dad215b",
+				"DiscoKey":   "discokey:626127ab79776864c8b898998c78e29548a4c668f2bac03f40e98cf15170882a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56295",
+					"10.65.0.27:56295",
+					"172.17.0.1:56295",
+					"172.18.0.1:56295",
+					"172.19.0.1:56295"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:05:44.955522153Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4158494613113948,
+				"StableID":   "nF8BsubPUZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e6949527d3d96159cf1d2c271990882b7e8eb7334c8badcb45262ecdd9269979",
+				"DiscoKey":   "discokey:e956da49e1ad48308a5de2630498329fd8c79098062be8f8f649db2d2e8ecc59",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49468",
+					"10.65.0.27:49468",
+					"172.17.0.1:49468",
+					"172.18.0.1:49468",
+					"172.19.0.1:49468"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:05:45.492405132Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8111831117153597,
+				"StableID":   "nQeQAo3sL621CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:181534dd8c8edfc7b34edde75a7221433b3b0439a1f9bf3f9f7967adbc2cbd7d",
+				"KeyExpiry":  "2026-11-08T22:05:46Z",
+				"DiscoKey":   "discokey:4ebf62eb1531d5c3e8158dc673be9f8975534228c4aa865831a047e8def7bb72",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38459",
+					"10.65.0.27:38459",
+					"172.17.0.1:38459",
+					"172.18.0.1:38459",
+					"172.19.0.1:38459"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:05:46.775986537Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         131690244027660,
+				"StableID":   "nmDwuCHe2211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1cbfd67af89dfe11470bbeb24948da9ee9d478ad60b14d1954af7f38bd781d65",
+				"KeyExpiry":  "2026-11-08T22:05:47Z",
+				"DiscoKey":   "discokey:bdda7ea1deddf188da9387ec1c259fdc5e6c1966ea76e6e531029d949033dc44",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33060",
+					"10.65.0.27:33060",
+					"172.17.0.1:33060",
+					"172.18.0.1:33060",
+					"172.19.0.1:33060"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:05:47.311819952Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         960792509251671,
+				"StableID":   "n4BsxcP9W811CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       960792509251671,
+				"Key":        "nodekey:25924f82c2e4e2a96289c138fb692ce3d85bbe7e1978923ee82d57c53dad215b",
+				"DiscoKey":   "discokey:626127ab79776864c8b898998c78e29548a4c668f2bac03f40e98cf15170882a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56295",
+					"10.65.0.27:56295",
+					"172.17.0.1:56295",
+					"172.18.0.1:56295",
+					"172.19.0.1:56295"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:05:44.955522153Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:25924f82c2e4e2a96289c138fb692ce3d85bbe7e1978923ee82d57c53dad215b",
+			"MachineKey": "mkey:fe365ea8ddbe810a20989cc9270a693beec3565b0cd4db53d70ae6c21237fc29",
+			"Peers": [{
+				"ID":         1739955780428306,
+				"StableID":   "nVGq7ug2bE11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2a010553d1364bd7b01eee864538e7157e3b5d94a1fa6b8d055525eecc5a225c",
+				"DiscoKey":   "discokey:80f0f220e264fd4c8b5d2149130fafde8da79e09906d218fa667157c6168673c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40196",
+					"10.65.0.27:40196",
+					"172.17.0.1:40196",
+					"172.18.0.1:40196",
+					"172.19.0.1:40196"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:05:39.621735969Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5809560303894851,
+				"StableID":   "nJSj9HJANn11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9746aecf38cf74bbc8569813cd241e253df170693938585e0072e788d587d64f",
+				"DiscoKey":   "discokey:d373d524a1adc17a49715aecc36a147f8e6ca5864163a702d9698ff65049cf04",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34477",
+					"10.65.0.27:34477",
+					"172.17.0.1:34477",
+					"172.18.0.1:34477",
+					"172.19.0.1:34477"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:05:40.086480156Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6410717481083811,
+				"StableID":   "nLBJLJgR4s11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25618206e95f18346352b2fbb9100ad9f98d2357aec7e0da3dad796a7ad10b43",
+				"DiscoKey":   "discokey:d34864640b62ea396a3c7c0eaa42f81dab2ad337432036a818c25cf4d907962b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43606",
+					"10.65.0.27:43606",
+					"172.17.0.1:43606",
+					"172.18.0.1:43606",
+					"172.19.0.1:43606"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:05:40.623358026Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2741196811603753,
+				"StableID":   "nA3LTLbVQN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b8f6b4c867879c50255d7376f0653e4af396f4c18c9a6263d22035c3c8d176a",
+				"DiscoKey":   "discokey:ab35d2ff7b4c9ee7c45af1e3d67186be5b5c4fb7b1eff0c7efff0dece346eb63",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40463",
+					"10.65.0.27:40463",
+					"172.17.0.1:40463",
+					"172.18.0.1:40463",
+					"172.19.0.1:40463"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:05:41.172270716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5148399933808640,
+				"StableID":   "nyBSHhjiCh11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ce03b844d28b6f0f6f7292dc4c787ce7fe2fd8d24f79671c68065f6d0516e4e",
+				"DiscoKey":   "discokey:30cd7df7d40c83ace21c31313145a400f77c6f90204c7e89548c327c6324ba31",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:46264",
+					"10.65.0.27:46264",
+					"172.17.0.1:46264",
+					"172.18.0.1:46264",
+					"172.19.0.1:46264"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:05:41.710407885Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2866230741916704,
+				"StableID":   "nyMbiE28PP11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a0838907563e9489b0020051f2aed9f23e07e7ee22cad17ed1c1729b168ed22",
+				"DiscoKey":   "discokey:f7d92636bdf7b163ece85b768b051775c400d0052d00d6e740c51947bc77d006",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53701",
+					"10.65.0.27:53701",
+					"172.17.0.1:53701",
+					"172.18.0.1:53701",
+					"172.19.0.1:53701"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:05:42.252428426Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5855576432549971,
+				"StableID":   "nrkAsg41jn11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4cf62346578e901a81686feda0c201d34b5812d3de708cfa28fd3012f604404e",
+				"DiscoKey":   "discokey:381cedd538673ac5e758b337eababf3839422232e8ff20f5fb8080606a73a51d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54971",
+					"10.65.0.27:54971",
+					"172.17.0.1:54971",
+					"172.18.0.1:54971",
+					"172.19.0.1:54971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:05:42.805677795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1921999311452042,
+				"StableID":   "nFFPaSfU1G11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5bef3fba1f2266af5b701c89a51005ecc4be2c288dcaf02fd517fdc5029a674f",
+				"DiscoKey":   "discokey:8c10a1a2b31e402cf8485b9d2f212dcb9068be80d8a402e7b3443c612b69f120",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57385",
+					"10.65.0.27:57385",
+					"172.17.0.1:57385",
+					"172.18.0.1:57385",
+					"172.19.0.1:57385"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:05:43.338622861Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4877052708108015,
+				"StableID":   "nkmi8Uup5f11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7fd81a5cc2f4c216088fc038169f73f7cd44b1a03f3fd07d9fdba80475627510",
+				"DiscoKey":   "discokey:690ee8ce7a543b0bc34b3acdb451a27685adbf529733a12d0ccc52bbecee3e27",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:59129",
+					"10.65.0.27:59129",
+					"172.17.0.1:59129",
+					"172.18.0.1:59129",
+					"172.19.0.1:59129"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:05:43.867947153Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4688324295371875,
+				"StableID":   "neU3a6LMcd11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6ad8e1c7c3684f5e013a8761cfa1339b272c1349335f07c1acbcdd177f31a041",
+				"DiscoKey":   "discokey:97f959fa4dd9d5c6ac5c64cf78bd02c7ddb6fb57f8aeed5290031251921a7a31",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52860",
+					"10.65.0.27:52860",
+					"172.17.0.1:52860",
+					"172.18.0.1:52860",
+					"172.19.0.1:52860"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:05:44.4125404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4158494613113948,
+				"StableID":   "nF8BsubPUZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e6949527d3d96159cf1d2c271990882b7e8eb7334c8badcb45262ecdd9269979",
+				"DiscoKey":   "discokey:e956da49e1ad48308a5de2630498329fd8c79098062be8f8f649db2d2e8ecc59",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49468",
+					"10.65.0.27:49468",
+					"172.17.0.1:49468",
+					"172.18.0.1:49468",
+					"172.19.0.1:49468"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:05:45.492405132Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7090431354986173,
+				"StableID":   "nrbKoHcGNx11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:fb9336c0762bdc4d4abd0f68b0c06326d7767408be67266c44645a8e83efad3b",
+				"KeyExpiry":  "2026-11-08T22:05:46Z",
+				"DiscoKey":   "discokey:e5af7abaa6b05b806bec5d9c6266d68ea7edde00917118d921b90ed7827fa629",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53478",
+					"10.65.0.27:53478",
+					"172.17.0.1:53478",
+					"172.18.0.1:53478",
+					"172.19.0.1:53478"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:05:46.226072737Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8111831117153597,
+				"StableID":   "nQeQAo3sL621CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:181534dd8c8edfc7b34edde75a7221433b3b0439a1f9bf3f9f7967adbc2cbd7d",
+				"KeyExpiry":  "2026-11-08T22:05:46Z",
+				"DiscoKey":   "discokey:4ebf62eb1531d5c3e8158dc673be9f8975534228c4aa865831a047e8def7bb72",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38459",
+					"10.65.0.27:38459",
+					"172.17.0.1:38459",
+					"172.18.0.1:38459",
+					"172.19.0.1:38459"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:05:46.775986537Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         131690244027660,
+				"StableID":   "nmDwuCHe2211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1cbfd67af89dfe11470bbeb24948da9ee9d478ad60b14d1954af7f38bd781d65",
+				"KeyExpiry":  "2026-11-08T22:05:47Z",
+				"DiscoKey":   "discokey:bdda7ea1deddf188da9387ec1c259fdc5e6c1966ea76e6e531029d949033dc44",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33060",
+					"10.65.0.27:33060",
+					"172.17.0.1:33060",
+					"172.18.0.1:33060",
+					"172.19.0.1:33060"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:05:47.311819952Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "960792509251671": {
+				"ID":          960792509251671,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5809560303894851,
+				"StableID":   "nJSj9HJANn11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       5809560303894851,
+				"Key":        "nodekey:9746aecf38cf74bbc8569813cd241e253df170693938585e0072e788d587d64f",
+				"DiscoKey":   "discokey:d373d524a1adc17a49715aecc36a147f8e6ca5864163a702d9698ff65049cf04",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34477",
+					"10.65.0.27:34477",
+					"172.17.0.1:34477",
+					"172.18.0.1:34477",
+					"172.19.0.1:34477"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:05:40.086480156Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9746aecf38cf74bbc8569813cd241e253df170693938585e0072e788d587d64f",
+			"MachineKey": "mkey:b19ab51fb9e978fd818df6c33d617dd728f823bf2dd8b0667570ac6ef422fa06",
+			"Peers": [{
+				"ID":         1739955780428306,
+				"StableID":   "nVGq7ug2bE11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2a010553d1364bd7b01eee864538e7157e3b5d94a1fa6b8d055525eecc5a225c",
+				"DiscoKey":   "discokey:80f0f220e264fd4c8b5d2149130fafde8da79e09906d218fa667157c6168673c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40196",
+					"10.65.0.27:40196",
+					"172.17.0.1:40196",
+					"172.18.0.1:40196",
+					"172.19.0.1:40196"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:05:39.621735969Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6410717481083811,
+				"StableID":   "nLBJLJgR4s11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25618206e95f18346352b2fbb9100ad9f98d2357aec7e0da3dad796a7ad10b43",
+				"DiscoKey":   "discokey:d34864640b62ea396a3c7c0eaa42f81dab2ad337432036a818c25cf4d907962b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43606",
+					"10.65.0.27:43606",
+					"172.17.0.1:43606",
+					"172.18.0.1:43606",
+					"172.19.0.1:43606"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:05:40.623358026Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2741196811603753,
+				"StableID":   "nA3LTLbVQN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b8f6b4c867879c50255d7376f0653e4af396f4c18c9a6263d22035c3c8d176a",
+				"DiscoKey":   "discokey:ab35d2ff7b4c9ee7c45af1e3d67186be5b5c4fb7b1eff0c7efff0dece346eb63",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40463",
+					"10.65.0.27:40463",
+					"172.17.0.1:40463",
+					"172.18.0.1:40463",
+					"172.19.0.1:40463"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:05:41.172270716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5148399933808640,
+				"StableID":   "nyBSHhjiCh11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ce03b844d28b6f0f6f7292dc4c787ce7fe2fd8d24f79671c68065f6d0516e4e",
+				"DiscoKey":   "discokey:30cd7df7d40c83ace21c31313145a400f77c6f90204c7e89548c327c6324ba31",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:46264",
+					"10.65.0.27:46264",
+					"172.17.0.1:46264",
+					"172.18.0.1:46264",
+					"172.19.0.1:46264"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:05:41.710407885Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2866230741916704,
+				"StableID":   "nyMbiE28PP11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a0838907563e9489b0020051f2aed9f23e07e7ee22cad17ed1c1729b168ed22",
+				"DiscoKey":   "discokey:f7d92636bdf7b163ece85b768b051775c400d0052d00d6e740c51947bc77d006",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53701",
+					"10.65.0.27:53701",
+					"172.17.0.1:53701",
+					"172.18.0.1:53701",
+					"172.19.0.1:53701"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:05:42.252428426Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5855576432549971,
+				"StableID":   "nrkAsg41jn11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4cf62346578e901a81686feda0c201d34b5812d3de708cfa28fd3012f604404e",
+				"DiscoKey":   "discokey:381cedd538673ac5e758b337eababf3839422232e8ff20f5fb8080606a73a51d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54971",
+					"10.65.0.27:54971",
+					"172.17.0.1:54971",
+					"172.18.0.1:54971",
+					"172.19.0.1:54971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:05:42.805677795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1921999311452042,
+				"StableID":   "nFFPaSfU1G11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5bef3fba1f2266af5b701c89a51005ecc4be2c288dcaf02fd517fdc5029a674f",
+				"DiscoKey":   "discokey:8c10a1a2b31e402cf8485b9d2f212dcb9068be80d8a402e7b3443c612b69f120",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57385",
+					"10.65.0.27:57385",
+					"172.17.0.1:57385",
+					"172.18.0.1:57385",
+					"172.19.0.1:57385"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:05:43.338622861Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4877052708108015,
+				"StableID":   "nkmi8Uup5f11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7fd81a5cc2f4c216088fc038169f73f7cd44b1a03f3fd07d9fdba80475627510",
+				"DiscoKey":   "discokey:690ee8ce7a543b0bc34b3acdb451a27685adbf529733a12d0ccc52bbecee3e27",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:59129",
+					"10.65.0.27:59129",
+					"172.17.0.1:59129",
+					"172.18.0.1:59129",
+					"172.19.0.1:59129"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:05:43.867947153Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4688324295371875,
+				"StableID":   "neU3a6LMcd11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6ad8e1c7c3684f5e013a8761cfa1339b272c1349335f07c1acbcdd177f31a041",
+				"DiscoKey":   "discokey:97f959fa4dd9d5c6ac5c64cf78bd02c7ddb6fb57f8aeed5290031251921a7a31",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52860",
+					"10.65.0.27:52860",
+					"172.17.0.1:52860",
+					"172.18.0.1:52860",
+					"172.19.0.1:52860"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:05:44.4125404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         960792509251671,
+				"StableID":   "n4BsxcP9W811CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25924f82c2e4e2a96289c138fb692ce3d85bbe7e1978923ee82d57c53dad215b",
+				"DiscoKey":   "discokey:626127ab79776864c8b898998c78e29548a4c668f2bac03f40e98cf15170882a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56295",
+					"10.65.0.27:56295",
+					"172.17.0.1:56295",
+					"172.18.0.1:56295",
+					"172.19.0.1:56295"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:05:44.955522153Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4158494613113948,
+				"StableID":   "nF8BsubPUZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e6949527d3d96159cf1d2c271990882b7e8eb7334c8badcb45262ecdd9269979",
+				"DiscoKey":   "discokey:e956da49e1ad48308a5de2630498329fd8c79098062be8f8f649db2d2e8ecc59",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49468",
+					"10.65.0.27:49468",
+					"172.17.0.1:49468",
+					"172.18.0.1:49468",
+					"172.19.0.1:49468"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:05:45.492405132Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7090431354986173,
+				"StableID":   "nrbKoHcGNx11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:fb9336c0762bdc4d4abd0f68b0c06326d7767408be67266c44645a8e83efad3b",
+				"KeyExpiry":  "2026-11-08T22:05:46Z",
+				"DiscoKey":   "discokey:e5af7abaa6b05b806bec5d9c6266d68ea7edde00917118d921b90ed7827fa629",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53478",
+					"10.65.0.27:53478",
+					"172.17.0.1:53478",
+					"172.18.0.1:53478",
+					"172.19.0.1:53478"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:05:46.226072737Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8111831117153597,
+				"StableID":   "nQeQAo3sL621CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:181534dd8c8edfc7b34edde75a7221433b3b0439a1f9bf3f9f7967adbc2cbd7d",
+				"KeyExpiry":  "2026-11-08T22:05:46Z",
+				"DiscoKey":   "discokey:4ebf62eb1531d5c3e8158dc673be9f8975534228c4aa865831a047e8def7bb72",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38459",
+					"10.65.0.27:38459",
+					"172.17.0.1:38459",
+					"172.18.0.1:38459",
+					"172.19.0.1:38459"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:05:46.775986537Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         131690244027660,
+				"StableID":   "nmDwuCHe2211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1cbfd67af89dfe11470bbeb24948da9ee9d478ad60b14d1954af7f38bd781d65",
+				"KeyExpiry":  "2026-11-08T22:05:47Z",
+				"DiscoKey":   "discokey:bdda7ea1deddf188da9387ec1c259fdc5e6c1966ea76e6e531029d949033dc44",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33060",
+					"10.65.0.27:33060",
+					"172.17.0.1:33060",
+					"172.18.0.1:33060",
+					"172.19.0.1:33060"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:05:47.311819952Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5809560303894851": {
+				"ID":          5809560303894851,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1739955780428306,
+				"StableID":   "nVGq7ug2bE11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1739955780428306,
+				"Key":        "nodekey:2a010553d1364bd7b01eee864538e7157e3b5d94a1fa6b8d055525eecc5a225c",
+				"DiscoKey":   "discokey:80f0f220e264fd4c8b5d2149130fafde8da79e09906d218fa667157c6168673c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40196",
+					"10.65.0.27:40196",
+					"172.17.0.1:40196",
+					"172.18.0.1:40196",
+					"172.19.0.1:40196"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:05:39.621735969Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2a010553d1364bd7b01eee864538e7157e3b5d94a1fa6b8d055525eecc5a225c",
+			"MachineKey": "mkey:59457f0794d2b5b801dca544094e1a6693d3b0dfdc7b2279f5fbce976d5bc105",
+			"Peers": [{
+				"ID":         5809560303894851,
+				"StableID":   "nJSj9HJANn11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9746aecf38cf74bbc8569813cd241e253df170693938585e0072e788d587d64f",
+				"DiscoKey":   "discokey:d373d524a1adc17a49715aecc36a147f8e6ca5864163a702d9698ff65049cf04",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34477",
+					"10.65.0.27:34477",
+					"172.17.0.1:34477",
+					"172.18.0.1:34477",
+					"172.19.0.1:34477"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:05:40.086480156Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6410717481083811,
+				"StableID":   "nLBJLJgR4s11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25618206e95f18346352b2fbb9100ad9f98d2357aec7e0da3dad796a7ad10b43",
+				"DiscoKey":   "discokey:d34864640b62ea396a3c7c0eaa42f81dab2ad337432036a818c25cf4d907962b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43606",
+					"10.65.0.27:43606",
+					"172.17.0.1:43606",
+					"172.18.0.1:43606",
+					"172.19.0.1:43606"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:05:40.623358026Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2741196811603753,
+				"StableID":   "nA3LTLbVQN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b8f6b4c867879c50255d7376f0653e4af396f4c18c9a6263d22035c3c8d176a",
+				"DiscoKey":   "discokey:ab35d2ff7b4c9ee7c45af1e3d67186be5b5c4fb7b1eff0c7efff0dece346eb63",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40463",
+					"10.65.0.27:40463",
+					"172.17.0.1:40463",
+					"172.18.0.1:40463",
+					"172.19.0.1:40463"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:05:41.172270716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5148399933808640,
+				"StableID":   "nyBSHhjiCh11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ce03b844d28b6f0f6f7292dc4c787ce7fe2fd8d24f79671c68065f6d0516e4e",
+				"DiscoKey":   "discokey:30cd7df7d40c83ace21c31313145a400f77c6f90204c7e89548c327c6324ba31",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:46264",
+					"10.65.0.27:46264",
+					"172.17.0.1:46264",
+					"172.18.0.1:46264",
+					"172.19.0.1:46264"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:05:41.710407885Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2866230741916704,
+				"StableID":   "nyMbiE28PP11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a0838907563e9489b0020051f2aed9f23e07e7ee22cad17ed1c1729b168ed22",
+				"DiscoKey":   "discokey:f7d92636bdf7b163ece85b768b051775c400d0052d00d6e740c51947bc77d006",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53701",
+					"10.65.0.27:53701",
+					"172.17.0.1:53701",
+					"172.18.0.1:53701",
+					"172.19.0.1:53701"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:05:42.252428426Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5855576432549971,
+				"StableID":   "nrkAsg41jn11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4cf62346578e901a81686feda0c201d34b5812d3de708cfa28fd3012f604404e",
+				"DiscoKey":   "discokey:381cedd538673ac5e758b337eababf3839422232e8ff20f5fb8080606a73a51d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54971",
+					"10.65.0.27:54971",
+					"172.17.0.1:54971",
+					"172.18.0.1:54971",
+					"172.19.0.1:54971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:05:42.805677795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1921999311452042,
+				"StableID":   "nFFPaSfU1G11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5bef3fba1f2266af5b701c89a51005ecc4be2c288dcaf02fd517fdc5029a674f",
+				"DiscoKey":   "discokey:8c10a1a2b31e402cf8485b9d2f212dcb9068be80d8a402e7b3443c612b69f120",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57385",
+					"10.65.0.27:57385",
+					"172.17.0.1:57385",
+					"172.18.0.1:57385",
+					"172.19.0.1:57385"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:05:43.338622861Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4877052708108015,
+				"StableID":   "nkmi8Uup5f11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7fd81a5cc2f4c216088fc038169f73f7cd44b1a03f3fd07d9fdba80475627510",
+				"DiscoKey":   "discokey:690ee8ce7a543b0bc34b3acdb451a27685adbf529733a12d0ccc52bbecee3e27",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:59129",
+					"10.65.0.27:59129",
+					"172.17.0.1:59129",
+					"172.18.0.1:59129",
+					"172.19.0.1:59129"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:05:43.867947153Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4688324295371875,
+				"StableID":   "neU3a6LMcd11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6ad8e1c7c3684f5e013a8761cfa1339b272c1349335f07c1acbcdd177f31a041",
+				"DiscoKey":   "discokey:97f959fa4dd9d5c6ac5c64cf78bd02c7ddb6fb57f8aeed5290031251921a7a31",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52860",
+					"10.65.0.27:52860",
+					"172.17.0.1:52860",
+					"172.18.0.1:52860",
+					"172.19.0.1:52860"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:05:44.4125404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         960792509251671,
+				"StableID":   "n4BsxcP9W811CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25924f82c2e4e2a96289c138fb692ce3d85bbe7e1978923ee82d57c53dad215b",
+				"DiscoKey":   "discokey:626127ab79776864c8b898998c78e29548a4c668f2bac03f40e98cf15170882a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56295",
+					"10.65.0.27:56295",
+					"172.17.0.1:56295",
+					"172.18.0.1:56295",
+					"172.19.0.1:56295"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:05:44.955522153Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4158494613113948,
+				"StableID":   "nF8BsubPUZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e6949527d3d96159cf1d2c271990882b7e8eb7334c8badcb45262ecdd9269979",
+				"DiscoKey":   "discokey:e956da49e1ad48308a5de2630498329fd8c79098062be8f8f649db2d2e8ecc59",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49468",
+					"10.65.0.27:49468",
+					"172.17.0.1:49468",
+					"172.18.0.1:49468",
+					"172.19.0.1:49468"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:05:45.492405132Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7090431354986173,
+				"StableID":   "nrbKoHcGNx11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:fb9336c0762bdc4d4abd0f68b0c06326d7767408be67266c44645a8e83efad3b",
+				"KeyExpiry":  "2026-11-08T22:05:46Z",
+				"DiscoKey":   "discokey:e5af7abaa6b05b806bec5d9c6266d68ea7edde00917118d921b90ed7827fa629",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53478",
+					"10.65.0.27:53478",
+					"172.17.0.1:53478",
+					"172.18.0.1:53478",
+					"172.19.0.1:53478"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:05:46.226072737Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8111831117153597,
+				"StableID":   "nQeQAo3sL621CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:181534dd8c8edfc7b34edde75a7221433b3b0439a1f9bf3f9f7967adbc2cbd7d",
+				"KeyExpiry":  "2026-11-08T22:05:46Z",
+				"DiscoKey":   "discokey:4ebf62eb1531d5c3e8158dc673be9f8975534228c4aa865831a047e8def7bb72",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38459",
+					"10.65.0.27:38459",
+					"172.17.0.1:38459",
+					"172.18.0.1:38459",
+					"172.19.0.1:38459"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:05:46.775986537Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         131690244027660,
+				"StableID":   "nmDwuCHe2211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1cbfd67af89dfe11470bbeb24948da9ee9d478ad60b14d1954af7f38bd781d65",
+				"KeyExpiry":  "2026-11-08T22:05:47Z",
+				"DiscoKey":   "discokey:bdda7ea1deddf188da9387ec1c259fdc5e6c1966ea76e6e531029d949033dc44",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33060",
+					"10.65.0.27:33060",
+					"172.17.0.1:33060",
+					"172.18.0.1:33060",
+					"172.19.0.1:33060"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:05:47.311819952Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1739955780428306": {
+				"ID":          1739955780428306,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5148399933808640,
+				"StableID":   "nyBSHhjiCh11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       5148399933808640,
+				"Key":        "nodekey:4ce03b844d28b6f0f6f7292dc4c787ce7fe2fd8d24f79671c68065f6d0516e4e",
+				"DiscoKey":   "discokey:30cd7df7d40c83ace21c31313145a400f77c6f90204c7e89548c327c6324ba31",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:46264",
+					"10.65.0.27:46264",
+					"172.17.0.1:46264",
+					"172.18.0.1:46264",
+					"172.19.0.1:46264"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:05:41.710407885Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4ce03b844d28b6f0f6f7292dc4c787ce7fe2fd8d24f79671c68065f6d0516e4e",
+			"MachineKey": "mkey:64a31abb390e9d409932bddedc82b40207cae721c77bb2ab8e7c5326e870c847",
+			"Peers": [{
+				"ID":         1739955780428306,
+				"StableID":   "nVGq7ug2bE11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2a010553d1364bd7b01eee864538e7157e3b5d94a1fa6b8d055525eecc5a225c",
+				"DiscoKey":   "discokey:80f0f220e264fd4c8b5d2149130fafde8da79e09906d218fa667157c6168673c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40196",
+					"10.65.0.27:40196",
+					"172.17.0.1:40196",
+					"172.18.0.1:40196",
+					"172.19.0.1:40196"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:05:39.621735969Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5809560303894851,
+				"StableID":   "nJSj9HJANn11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9746aecf38cf74bbc8569813cd241e253df170693938585e0072e788d587d64f",
+				"DiscoKey":   "discokey:d373d524a1adc17a49715aecc36a147f8e6ca5864163a702d9698ff65049cf04",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34477",
+					"10.65.0.27:34477",
+					"172.17.0.1:34477",
+					"172.18.0.1:34477",
+					"172.19.0.1:34477"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:05:40.086480156Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6410717481083811,
+				"StableID":   "nLBJLJgR4s11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25618206e95f18346352b2fbb9100ad9f98d2357aec7e0da3dad796a7ad10b43",
+				"DiscoKey":   "discokey:d34864640b62ea396a3c7c0eaa42f81dab2ad337432036a818c25cf4d907962b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43606",
+					"10.65.0.27:43606",
+					"172.17.0.1:43606",
+					"172.18.0.1:43606",
+					"172.19.0.1:43606"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:05:40.623358026Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2741196811603753,
+				"StableID":   "nA3LTLbVQN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b8f6b4c867879c50255d7376f0653e4af396f4c18c9a6263d22035c3c8d176a",
+				"DiscoKey":   "discokey:ab35d2ff7b4c9ee7c45af1e3d67186be5b5c4fb7b1eff0c7efff0dece346eb63",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40463",
+					"10.65.0.27:40463",
+					"172.17.0.1:40463",
+					"172.18.0.1:40463",
+					"172.19.0.1:40463"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:05:41.172270716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2866230741916704,
+				"StableID":   "nyMbiE28PP11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a0838907563e9489b0020051f2aed9f23e07e7ee22cad17ed1c1729b168ed22",
+				"DiscoKey":   "discokey:f7d92636bdf7b163ece85b768b051775c400d0052d00d6e740c51947bc77d006",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53701",
+					"10.65.0.27:53701",
+					"172.17.0.1:53701",
+					"172.18.0.1:53701",
+					"172.19.0.1:53701"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:05:42.252428426Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5855576432549971,
+				"StableID":   "nrkAsg41jn11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4cf62346578e901a81686feda0c201d34b5812d3de708cfa28fd3012f604404e",
+				"DiscoKey":   "discokey:381cedd538673ac5e758b337eababf3839422232e8ff20f5fb8080606a73a51d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54971",
+					"10.65.0.27:54971",
+					"172.17.0.1:54971",
+					"172.18.0.1:54971",
+					"172.19.0.1:54971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:05:42.805677795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1921999311452042,
+				"StableID":   "nFFPaSfU1G11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5bef3fba1f2266af5b701c89a51005ecc4be2c288dcaf02fd517fdc5029a674f",
+				"DiscoKey":   "discokey:8c10a1a2b31e402cf8485b9d2f212dcb9068be80d8a402e7b3443c612b69f120",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57385",
+					"10.65.0.27:57385",
+					"172.17.0.1:57385",
+					"172.18.0.1:57385",
+					"172.19.0.1:57385"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:05:43.338622861Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4877052708108015,
+				"StableID":   "nkmi8Uup5f11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7fd81a5cc2f4c216088fc038169f73f7cd44b1a03f3fd07d9fdba80475627510",
+				"DiscoKey":   "discokey:690ee8ce7a543b0bc34b3acdb451a27685adbf529733a12d0ccc52bbecee3e27",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:59129",
+					"10.65.0.27:59129",
+					"172.17.0.1:59129",
+					"172.18.0.1:59129",
+					"172.19.0.1:59129"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:05:43.867947153Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4688324295371875,
+				"StableID":   "neU3a6LMcd11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6ad8e1c7c3684f5e013a8761cfa1339b272c1349335f07c1acbcdd177f31a041",
+				"DiscoKey":   "discokey:97f959fa4dd9d5c6ac5c64cf78bd02c7ddb6fb57f8aeed5290031251921a7a31",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52860",
+					"10.65.0.27:52860",
+					"172.17.0.1:52860",
+					"172.18.0.1:52860",
+					"172.19.0.1:52860"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:05:44.4125404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         960792509251671,
+				"StableID":   "n4BsxcP9W811CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25924f82c2e4e2a96289c138fb692ce3d85bbe7e1978923ee82d57c53dad215b",
+				"DiscoKey":   "discokey:626127ab79776864c8b898998c78e29548a4c668f2bac03f40e98cf15170882a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56295",
+					"10.65.0.27:56295",
+					"172.17.0.1:56295",
+					"172.18.0.1:56295",
+					"172.19.0.1:56295"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:05:44.955522153Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4158494613113948,
+				"StableID":   "nF8BsubPUZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e6949527d3d96159cf1d2c271990882b7e8eb7334c8badcb45262ecdd9269979",
+				"DiscoKey":   "discokey:e956da49e1ad48308a5de2630498329fd8c79098062be8f8f649db2d2e8ecc59",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49468",
+					"10.65.0.27:49468",
+					"172.17.0.1:49468",
+					"172.18.0.1:49468",
+					"172.19.0.1:49468"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:05:45.492405132Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7090431354986173,
+				"StableID":   "nrbKoHcGNx11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:fb9336c0762bdc4d4abd0f68b0c06326d7767408be67266c44645a8e83efad3b",
+				"KeyExpiry":  "2026-11-08T22:05:46Z",
+				"DiscoKey":   "discokey:e5af7abaa6b05b806bec5d9c6266d68ea7edde00917118d921b90ed7827fa629",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53478",
+					"10.65.0.27:53478",
+					"172.17.0.1:53478",
+					"172.18.0.1:53478",
+					"172.19.0.1:53478"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:05:46.226072737Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8111831117153597,
+				"StableID":   "nQeQAo3sL621CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:181534dd8c8edfc7b34edde75a7221433b3b0439a1f9bf3f9f7967adbc2cbd7d",
+				"KeyExpiry":  "2026-11-08T22:05:46Z",
+				"DiscoKey":   "discokey:4ebf62eb1531d5c3e8158dc673be9f8975534228c4aa865831a047e8def7bb72",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38459",
+					"10.65.0.27:38459",
+					"172.17.0.1:38459",
+					"172.18.0.1:38459",
+					"172.19.0.1:38459"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:05:46.775986537Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         131690244027660,
+				"StableID":   "nmDwuCHe2211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1cbfd67af89dfe11470bbeb24948da9ee9d478ad60b14d1954af7f38bd781d65",
+				"KeyExpiry":  "2026-11-08T22:05:47Z",
+				"DiscoKey":   "discokey:bdda7ea1deddf188da9387ec1c259fdc5e6c1966ea76e6e531029d949033dc44",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33060",
+					"10.65.0.27:33060",
+					"172.17.0.1:33060",
+					"172.18.0.1:33060",
+					"172.19.0.1:33060"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:05:47.311819952Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5148399933808640": {
+				"ID":          5148399933808640,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2741196811603753,
+				"StableID":   "nA3LTLbVQN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       2741196811603753,
+				"Key":        "nodekey:0b8f6b4c867879c50255d7376f0653e4af396f4c18c9a6263d22035c3c8d176a",
+				"DiscoKey":   "discokey:ab35d2ff7b4c9ee7c45af1e3d67186be5b5c4fb7b1eff0c7efff0dece346eb63",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40463",
+					"10.65.0.27:40463",
+					"172.17.0.1:40463",
+					"172.18.0.1:40463",
+					"172.19.0.1:40463"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:05:41.172270716Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0b8f6b4c867879c50255d7376f0653e4af396f4c18c9a6263d22035c3c8d176a",
+			"MachineKey": "mkey:9484bbfa2fabfc60ab6acfc192afbbe3a715d6286a0d3c5553fcce7ad035ec0d",
+			"Peers": [{
+				"ID":         1739955780428306,
+				"StableID":   "nVGq7ug2bE11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2a010553d1364bd7b01eee864538e7157e3b5d94a1fa6b8d055525eecc5a225c",
+				"DiscoKey":   "discokey:80f0f220e264fd4c8b5d2149130fafde8da79e09906d218fa667157c6168673c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40196",
+					"10.65.0.27:40196",
+					"172.17.0.1:40196",
+					"172.18.0.1:40196",
+					"172.19.0.1:40196"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:05:39.621735969Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5809560303894851,
+				"StableID":   "nJSj9HJANn11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9746aecf38cf74bbc8569813cd241e253df170693938585e0072e788d587d64f",
+				"DiscoKey":   "discokey:d373d524a1adc17a49715aecc36a147f8e6ca5864163a702d9698ff65049cf04",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34477",
+					"10.65.0.27:34477",
+					"172.17.0.1:34477",
+					"172.18.0.1:34477",
+					"172.19.0.1:34477"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:05:40.086480156Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6410717481083811,
+				"StableID":   "nLBJLJgR4s11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25618206e95f18346352b2fbb9100ad9f98d2357aec7e0da3dad796a7ad10b43",
+				"DiscoKey":   "discokey:d34864640b62ea396a3c7c0eaa42f81dab2ad337432036a818c25cf4d907962b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43606",
+					"10.65.0.27:43606",
+					"172.17.0.1:43606",
+					"172.18.0.1:43606",
+					"172.19.0.1:43606"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:05:40.623358026Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5148399933808640,
+				"StableID":   "nyBSHhjiCh11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ce03b844d28b6f0f6f7292dc4c787ce7fe2fd8d24f79671c68065f6d0516e4e",
+				"DiscoKey":   "discokey:30cd7df7d40c83ace21c31313145a400f77c6f90204c7e89548c327c6324ba31",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:46264",
+					"10.65.0.27:46264",
+					"172.17.0.1:46264",
+					"172.18.0.1:46264",
+					"172.19.0.1:46264"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:05:41.710407885Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2866230741916704,
+				"StableID":   "nyMbiE28PP11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a0838907563e9489b0020051f2aed9f23e07e7ee22cad17ed1c1729b168ed22",
+				"DiscoKey":   "discokey:f7d92636bdf7b163ece85b768b051775c400d0052d00d6e740c51947bc77d006",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53701",
+					"10.65.0.27:53701",
+					"172.17.0.1:53701",
+					"172.18.0.1:53701",
+					"172.19.0.1:53701"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:05:42.252428426Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5855576432549971,
+				"StableID":   "nrkAsg41jn11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4cf62346578e901a81686feda0c201d34b5812d3de708cfa28fd3012f604404e",
+				"DiscoKey":   "discokey:381cedd538673ac5e758b337eababf3839422232e8ff20f5fb8080606a73a51d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54971",
+					"10.65.0.27:54971",
+					"172.17.0.1:54971",
+					"172.18.0.1:54971",
+					"172.19.0.1:54971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:05:42.805677795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1921999311452042,
+				"StableID":   "nFFPaSfU1G11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5bef3fba1f2266af5b701c89a51005ecc4be2c288dcaf02fd517fdc5029a674f",
+				"DiscoKey":   "discokey:8c10a1a2b31e402cf8485b9d2f212dcb9068be80d8a402e7b3443c612b69f120",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57385",
+					"10.65.0.27:57385",
+					"172.17.0.1:57385",
+					"172.18.0.1:57385",
+					"172.19.0.1:57385"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:05:43.338622861Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4877052708108015,
+				"StableID":   "nkmi8Uup5f11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7fd81a5cc2f4c216088fc038169f73f7cd44b1a03f3fd07d9fdba80475627510",
+				"DiscoKey":   "discokey:690ee8ce7a543b0bc34b3acdb451a27685adbf529733a12d0ccc52bbecee3e27",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:59129",
+					"10.65.0.27:59129",
+					"172.17.0.1:59129",
+					"172.18.0.1:59129",
+					"172.19.0.1:59129"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:05:43.867947153Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4688324295371875,
+				"StableID":   "neU3a6LMcd11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6ad8e1c7c3684f5e013a8761cfa1339b272c1349335f07c1acbcdd177f31a041",
+				"DiscoKey":   "discokey:97f959fa4dd9d5c6ac5c64cf78bd02c7ddb6fb57f8aeed5290031251921a7a31",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52860",
+					"10.65.0.27:52860",
+					"172.17.0.1:52860",
+					"172.18.0.1:52860",
+					"172.19.0.1:52860"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:05:44.4125404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         960792509251671,
+				"StableID":   "n4BsxcP9W811CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25924f82c2e4e2a96289c138fb692ce3d85bbe7e1978923ee82d57c53dad215b",
+				"DiscoKey":   "discokey:626127ab79776864c8b898998c78e29548a4c668f2bac03f40e98cf15170882a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56295",
+					"10.65.0.27:56295",
+					"172.17.0.1:56295",
+					"172.18.0.1:56295",
+					"172.19.0.1:56295"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:05:44.955522153Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4158494613113948,
+				"StableID":   "nF8BsubPUZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e6949527d3d96159cf1d2c271990882b7e8eb7334c8badcb45262ecdd9269979",
+				"DiscoKey":   "discokey:e956da49e1ad48308a5de2630498329fd8c79098062be8f8f649db2d2e8ecc59",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49468",
+					"10.65.0.27:49468",
+					"172.17.0.1:49468",
+					"172.18.0.1:49468",
+					"172.19.0.1:49468"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:05:45.492405132Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7090431354986173,
+				"StableID":   "nrbKoHcGNx11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:fb9336c0762bdc4d4abd0f68b0c06326d7767408be67266c44645a8e83efad3b",
+				"KeyExpiry":  "2026-11-08T22:05:46Z",
+				"DiscoKey":   "discokey:e5af7abaa6b05b806bec5d9c6266d68ea7edde00917118d921b90ed7827fa629",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53478",
+					"10.65.0.27:53478",
+					"172.17.0.1:53478",
+					"172.18.0.1:53478",
+					"172.19.0.1:53478"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:05:46.226072737Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8111831117153597,
+				"StableID":   "nQeQAo3sL621CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:181534dd8c8edfc7b34edde75a7221433b3b0439a1f9bf3f9f7967adbc2cbd7d",
+				"KeyExpiry":  "2026-11-08T22:05:46Z",
+				"DiscoKey":   "discokey:4ebf62eb1531d5c3e8158dc673be9f8975534228c4aa865831a047e8def7bb72",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38459",
+					"10.65.0.27:38459",
+					"172.17.0.1:38459",
+					"172.18.0.1:38459",
+					"172.19.0.1:38459"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:05:46.775986537Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         131690244027660,
+				"StableID":   "nmDwuCHe2211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1cbfd67af89dfe11470bbeb24948da9ee9d478ad60b14d1954af7f38bd781d65",
+				"KeyExpiry":  "2026-11-08T22:05:47Z",
+				"DiscoKey":   "discokey:bdda7ea1deddf188da9387ec1c259fdc5e6c1966ea76e6e531029d949033dc44",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33060",
+					"10.65.0.27:33060",
+					"172.17.0.1:33060",
+					"172.18.0.1:33060",
+					"172.19.0.1:33060"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:05:47.311819952Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2741196811603753": {
+				"ID":          2741196811603753,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5855576432549971,
+				"StableID":   "nrkAsg41jn11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       5855576432549971,
+				"Key":        "nodekey:4cf62346578e901a81686feda0c201d34b5812d3de708cfa28fd3012f604404e",
+				"DiscoKey":   "discokey:381cedd538673ac5e758b337eababf3839422232e8ff20f5fb8080606a73a51d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54971",
+					"10.65.0.27:54971",
+					"172.17.0.1:54971",
+					"172.18.0.1:54971",
+					"172.19.0.1:54971"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:05:42.805677795Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4cf62346578e901a81686feda0c201d34b5812d3de708cfa28fd3012f604404e",
+			"MachineKey": "mkey:28c691cdd2eaae79f04652922ad7eb728f3f2b6c5e20b9013101f5483ad91060",
+			"Peers": [{
+				"ID":         1739955780428306,
+				"StableID":   "nVGq7ug2bE11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2a010553d1364bd7b01eee864538e7157e3b5d94a1fa6b8d055525eecc5a225c",
+				"DiscoKey":   "discokey:80f0f220e264fd4c8b5d2149130fafde8da79e09906d218fa667157c6168673c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40196",
+					"10.65.0.27:40196",
+					"172.17.0.1:40196",
+					"172.18.0.1:40196",
+					"172.19.0.1:40196"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:05:39.621735969Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5809560303894851,
+				"StableID":   "nJSj9HJANn11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9746aecf38cf74bbc8569813cd241e253df170693938585e0072e788d587d64f",
+				"DiscoKey":   "discokey:d373d524a1adc17a49715aecc36a147f8e6ca5864163a702d9698ff65049cf04",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34477",
+					"10.65.0.27:34477",
+					"172.17.0.1:34477",
+					"172.18.0.1:34477",
+					"172.19.0.1:34477"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:05:40.086480156Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6410717481083811,
+				"StableID":   "nLBJLJgR4s11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25618206e95f18346352b2fbb9100ad9f98d2357aec7e0da3dad796a7ad10b43",
+				"DiscoKey":   "discokey:d34864640b62ea396a3c7c0eaa42f81dab2ad337432036a818c25cf4d907962b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43606",
+					"10.65.0.27:43606",
+					"172.17.0.1:43606",
+					"172.18.0.1:43606",
+					"172.19.0.1:43606"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:05:40.623358026Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2741196811603753,
+				"StableID":   "nA3LTLbVQN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b8f6b4c867879c50255d7376f0653e4af396f4c18c9a6263d22035c3c8d176a",
+				"DiscoKey":   "discokey:ab35d2ff7b4c9ee7c45af1e3d67186be5b5c4fb7b1eff0c7efff0dece346eb63",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40463",
+					"10.65.0.27:40463",
+					"172.17.0.1:40463",
+					"172.18.0.1:40463",
+					"172.19.0.1:40463"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:05:41.172270716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5148399933808640,
+				"StableID":   "nyBSHhjiCh11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ce03b844d28b6f0f6f7292dc4c787ce7fe2fd8d24f79671c68065f6d0516e4e",
+				"DiscoKey":   "discokey:30cd7df7d40c83ace21c31313145a400f77c6f90204c7e89548c327c6324ba31",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:46264",
+					"10.65.0.27:46264",
+					"172.17.0.1:46264",
+					"172.18.0.1:46264",
+					"172.19.0.1:46264"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:05:41.710407885Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2866230741916704,
+				"StableID":   "nyMbiE28PP11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a0838907563e9489b0020051f2aed9f23e07e7ee22cad17ed1c1729b168ed22",
+				"DiscoKey":   "discokey:f7d92636bdf7b163ece85b768b051775c400d0052d00d6e740c51947bc77d006",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53701",
+					"10.65.0.27:53701",
+					"172.17.0.1:53701",
+					"172.18.0.1:53701",
+					"172.19.0.1:53701"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:05:42.252428426Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1921999311452042,
+				"StableID":   "nFFPaSfU1G11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5bef3fba1f2266af5b701c89a51005ecc4be2c288dcaf02fd517fdc5029a674f",
+				"DiscoKey":   "discokey:8c10a1a2b31e402cf8485b9d2f212dcb9068be80d8a402e7b3443c612b69f120",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57385",
+					"10.65.0.27:57385",
+					"172.17.0.1:57385",
+					"172.18.0.1:57385",
+					"172.19.0.1:57385"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:05:43.338622861Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4877052708108015,
+				"StableID":   "nkmi8Uup5f11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7fd81a5cc2f4c216088fc038169f73f7cd44b1a03f3fd07d9fdba80475627510",
+				"DiscoKey":   "discokey:690ee8ce7a543b0bc34b3acdb451a27685adbf529733a12d0ccc52bbecee3e27",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:59129",
+					"10.65.0.27:59129",
+					"172.17.0.1:59129",
+					"172.18.0.1:59129",
+					"172.19.0.1:59129"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:05:43.867947153Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4688324295371875,
+				"StableID":   "neU3a6LMcd11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6ad8e1c7c3684f5e013a8761cfa1339b272c1349335f07c1acbcdd177f31a041",
+				"DiscoKey":   "discokey:97f959fa4dd9d5c6ac5c64cf78bd02c7ddb6fb57f8aeed5290031251921a7a31",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52860",
+					"10.65.0.27:52860",
+					"172.17.0.1:52860",
+					"172.18.0.1:52860",
+					"172.19.0.1:52860"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:05:44.4125404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         960792509251671,
+				"StableID":   "n4BsxcP9W811CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25924f82c2e4e2a96289c138fb692ce3d85bbe7e1978923ee82d57c53dad215b",
+				"DiscoKey":   "discokey:626127ab79776864c8b898998c78e29548a4c668f2bac03f40e98cf15170882a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56295",
+					"10.65.0.27:56295",
+					"172.17.0.1:56295",
+					"172.18.0.1:56295",
+					"172.19.0.1:56295"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:05:44.955522153Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4158494613113948,
+				"StableID":   "nF8BsubPUZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e6949527d3d96159cf1d2c271990882b7e8eb7334c8badcb45262ecdd9269979",
+				"DiscoKey":   "discokey:e956da49e1ad48308a5de2630498329fd8c79098062be8f8f649db2d2e8ecc59",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49468",
+					"10.65.0.27:49468",
+					"172.17.0.1:49468",
+					"172.18.0.1:49468",
+					"172.19.0.1:49468"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:05:45.492405132Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7090431354986173,
+				"StableID":   "nrbKoHcGNx11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:fb9336c0762bdc4d4abd0f68b0c06326d7767408be67266c44645a8e83efad3b",
+				"KeyExpiry":  "2026-11-08T22:05:46Z",
+				"DiscoKey":   "discokey:e5af7abaa6b05b806bec5d9c6266d68ea7edde00917118d921b90ed7827fa629",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53478",
+					"10.65.0.27:53478",
+					"172.17.0.1:53478",
+					"172.18.0.1:53478",
+					"172.19.0.1:53478"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:05:46.226072737Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8111831117153597,
+				"StableID":   "nQeQAo3sL621CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:181534dd8c8edfc7b34edde75a7221433b3b0439a1f9bf3f9f7967adbc2cbd7d",
+				"KeyExpiry":  "2026-11-08T22:05:46Z",
+				"DiscoKey":   "discokey:4ebf62eb1531d5c3e8158dc673be9f8975534228c4aa865831a047e8def7bb72",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38459",
+					"10.65.0.27:38459",
+					"172.17.0.1:38459",
+					"172.18.0.1:38459",
+					"172.19.0.1:38459"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:05:46.775986537Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         131690244027660,
+				"StableID":   "nmDwuCHe2211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1cbfd67af89dfe11470bbeb24948da9ee9d478ad60b14d1954af7f38bd781d65",
+				"KeyExpiry":  "2026-11-08T22:05:47Z",
+				"DiscoKey":   "discokey:bdda7ea1deddf188da9387ec1c259fdc5e6c1966ea76e6e531029d949033dc44",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33060",
+					"10.65.0.27:33060",
+					"172.17.0.1:33060",
+					"172.18.0.1:33060",
+					"172.19.0.1:33060"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:05:47.311819952Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5855576432549971": {
+				"ID":          5855576432549971,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4877052708108015,
+				"StableID":   "nkmi8Uup5f11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       4877052708108015,
+				"Key":        "nodekey:7fd81a5cc2f4c216088fc038169f73f7cd44b1a03f3fd07d9fdba80475627510",
+				"DiscoKey":   "discokey:690ee8ce7a543b0bc34b3acdb451a27685adbf529733a12d0ccc52bbecee3e27",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:59129",
+					"10.65.0.27:59129",
+					"172.17.0.1:59129",
+					"172.18.0.1:59129",
+					"172.19.0.1:59129"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:05:43.867947153Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7fd81a5cc2f4c216088fc038169f73f7cd44b1a03f3fd07d9fdba80475627510",
+			"MachineKey": "mkey:d10622804ee3a54e47e4410f4b32a937d71f1c446271fa0a937f9be6438e772c",
+			"Peers": [{
+				"ID":         1739955780428306,
+				"StableID":   "nVGq7ug2bE11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2a010553d1364bd7b01eee864538e7157e3b5d94a1fa6b8d055525eecc5a225c",
+				"DiscoKey":   "discokey:80f0f220e264fd4c8b5d2149130fafde8da79e09906d218fa667157c6168673c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40196",
+					"10.65.0.27:40196",
+					"172.17.0.1:40196",
+					"172.18.0.1:40196",
+					"172.19.0.1:40196"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:05:39.621735969Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5809560303894851,
+				"StableID":   "nJSj9HJANn11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9746aecf38cf74bbc8569813cd241e253df170693938585e0072e788d587d64f",
+				"DiscoKey":   "discokey:d373d524a1adc17a49715aecc36a147f8e6ca5864163a702d9698ff65049cf04",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34477",
+					"10.65.0.27:34477",
+					"172.17.0.1:34477",
+					"172.18.0.1:34477",
+					"172.19.0.1:34477"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:05:40.086480156Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6410717481083811,
+				"StableID":   "nLBJLJgR4s11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25618206e95f18346352b2fbb9100ad9f98d2357aec7e0da3dad796a7ad10b43",
+				"DiscoKey":   "discokey:d34864640b62ea396a3c7c0eaa42f81dab2ad337432036a818c25cf4d907962b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43606",
+					"10.65.0.27:43606",
+					"172.17.0.1:43606",
+					"172.18.0.1:43606",
+					"172.19.0.1:43606"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:05:40.623358026Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2741196811603753,
+				"StableID":   "nA3LTLbVQN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b8f6b4c867879c50255d7376f0653e4af396f4c18c9a6263d22035c3c8d176a",
+				"DiscoKey":   "discokey:ab35d2ff7b4c9ee7c45af1e3d67186be5b5c4fb7b1eff0c7efff0dece346eb63",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40463",
+					"10.65.0.27:40463",
+					"172.17.0.1:40463",
+					"172.18.0.1:40463",
+					"172.19.0.1:40463"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:05:41.172270716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5148399933808640,
+				"StableID":   "nyBSHhjiCh11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ce03b844d28b6f0f6f7292dc4c787ce7fe2fd8d24f79671c68065f6d0516e4e",
+				"DiscoKey":   "discokey:30cd7df7d40c83ace21c31313145a400f77c6f90204c7e89548c327c6324ba31",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:46264",
+					"10.65.0.27:46264",
+					"172.17.0.1:46264",
+					"172.18.0.1:46264",
+					"172.19.0.1:46264"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:05:41.710407885Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2866230741916704,
+				"StableID":   "nyMbiE28PP11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a0838907563e9489b0020051f2aed9f23e07e7ee22cad17ed1c1729b168ed22",
+				"DiscoKey":   "discokey:f7d92636bdf7b163ece85b768b051775c400d0052d00d6e740c51947bc77d006",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53701",
+					"10.65.0.27:53701",
+					"172.17.0.1:53701",
+					"172.18.0.1:53701",
+					"172.19.0.1:53701"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:05:42.252428426Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5855576432549971,
+				"StableID":   "nrkAsg41jn11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4cf62346578e901a81686feda0c201d34b5812d3de708cfa28fd3012f604404e",
+				"DiscoKey":   "discokey:381cedd538673ac5e758b337eababf3839422232e8ff20f5fb8080606a73a51d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54971",
+					"10.65.0.27:54971",
+					"172.17.0.1:54971",
+					"172.18.0.1:54971",
+					"172.19.0.1:54971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:05:42.805677795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1921999311452042,
+				"StableID":   "nFFPaSfU1G11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5bef3fba1f2266af5b701c89a51005ecc4be2c288dcaf02fd517fdc5029a674f",
+				"DiscoKey":   "discokey:8c10a1a2b31e402cf8485b9d2f212dcb9068be80d8a402e7b3443c612b69f120",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57385",
+					"10.65.0.27:57385",
+					"172.17.0.1:57385",
+					"172.18.0.1:57385",
+					"172.19.0.1:57385"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:05:43.338622861Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4688324295371875,
+				"StableID":   "neU3a6LMcd11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6ad8e1c7c3684f5e013a8761cfa1339b272c1349335f07c1acbcdd177f31a041",
+				"DiscoKey":   "discokey:97f959fa4dd9d5c6ac5c64cf78bd02c7ddb6fb57f8aeed5290031251921a7a31",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52860",
+					"10.65.0.27:52860",
+					"172.17.0.1:52860",
+					"172.18.0.1:52860",
+					"172.19.0.1:52860"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:05:44.4125404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         960792509251671,
+				"StableID":   "n4BsxcP9W811CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25924f82c2e4e2a96289c138fb692ce3d85bbe7e1978923ee82d57c53dad215b",
+				"DiscoKey":   "discokey:626127ab79776864c8b898998c78e29548a4c668f2bac03f40e98cf15170882a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56295",
+					"10.65.0.27:56295",
+					"172.17.0.1:56295",
+					"172.18.0.1:56295",
+					"172.19.0.1:56295"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:05:44.955522153Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4158494613113948,
+				"StableID":   "nF8BsubPUZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e6949527d3d96159cf1d2c271990882b7e8eb7334c8badcb45262ecdd9269979",
+				"DiscoKey":   "discokey:e956da49e1ad48308a5de2630498329fd8c79098062be8f8f649db2d2e8ecc59",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49468",
+					"10.65.0.27:49468",
+					"172.17.0.1:49468",
+					"172.18.0.1:49468",
+					"172.19.0.1:49468"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:05:45.492405132Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7090431354986173,
+				"StableID":   "nrbKoHcGNx11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:fb9336c0762bdc4d4abd0f68b0c06326d7767408be67266c44645a8e83efad3b",
+				"KeyExpiry":  "2026-11-08T22:05:46Z",
+				"DiscoKey":   "discokey:e5af7abaa6b05b806bec5d9c6266d68ea7edde00917118d921b90ed7827fa629",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53478",
+					"10.65.0.27:53478",
+					"172.17.0.1:53478",
+					"172.18.0.1:53478",
+					"172.19.0.1:53478"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:05:46.226072737Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8111831117153597,
+				"StableID":   "nQeQAo3sL621CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:181534dd8c8edfc7b34edde75a7221433b3b0439a1f9bf3f9f7967adbc2cbd7d",
+				"KeyExpiry":  "2026-11-08T22:05:46Z",
+				"DiscoKey":   "discokey:4ebf62eb1531d5c3e8158dc673be9f8975534228c4aa865831a047e8def7bb72",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38459",
+					"10.65.0.27:38459",
+					"172.17.0.1:38459",
+					"172.18.0.1:38459",
+					"172.19.0.1:38459"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:05:46.775986537Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         131690244027660,
+				"StableID":   "nmDwuCHe2211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1cbfd67af89dfe11470bbeb24948da9ee9d478ad60b14d1954af7f38bd781d65",
+				"KeyExpiry":  "2026-11-08T22:05:47Z",
+				"DiscoKey":   "discokey:bdda7ea1deddf188da9387ec1c259fdc5e6c1966ea76e6e531029d949033dc44",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33060",
+					"10.65.0.27:33060",
+					"172.17.0.1:33060",
+					"172.18.0.1:33060",
+					"172.19.0.1:33060"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:05:47.311819952Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4877052708108015": {
+				"ID":          4877052708108015,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8111831117153597,
+				"StableID":   "nQeQAo3sL621CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:181534dd8c8edfc7b34edde75a7221433b3b0439a1f9bf3f9f7967adbc2cbd7d",
+				"KeyExpiry":  "2026-11-08T22:05:46Z",
+				"DiscoKey":   "discokey:4ebf62eb1531d5c3e8158dc673be9f8975534228c4aa865831a047e8def7bb72",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38459",
+					"10.65.0.27:38459",
+					"172.17.0.1:38459",
+					"172.18.0.1:38459",
+					"172.19.0.1:38459"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:05:46.775986537Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:181534dd8c8edfc7b34edde75a7221433b3b0439a1f9bf3f9f7967adbc2cbd7d",
+			"MachineKey": "mkey:d7dc6601ef0ea8ea828cc3f026d8670b158ca3b536410c071a939ddd5b0ba842",
+			"Peers": [{
+				"ID":         1739955780428306,
+				"StableID":   "nVGq7ug2bE11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2a010553d1364bd7b01eee864538e7157e3b5d94a1fa6b8d055525eecc5a225c",
+				"DiscoKey":   "discokey:80f0f220e264fd4c8b5d2149130fafde8da79e09906d218fa667157c6168673c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40196",
+					"10.65.0.27:40196",
+					"172.17.0.1:40196",
+					"172.18.0.1:40196",
+					"172.19.0.1:40196"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:05:39.621735969Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5809560303894851,
+				"StableID":   "nJSj9HJANn11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9746aecf38cf74bbc8569813cd241e253df170693938585e0072e788d587d64f",
+				"DiscoKey":   "discokey:d373d524a1adc17a49715aecc36a147f8e6ca5864163a702d9698ff65049cf04",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34477",
+					"10.65.0.27:34477",
+					"172.17.0.1:34477",
+					"172.18.0.1:34477",
+					"172.19.0.1:34477"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:05:40.086480156Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6410717481083811,
+				"StableID":   "nLBJLJgR4s11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25618206e95f18346352b2fbb9100ad9f98d2357aec7e0da3dad796a7ad10b43",
+				"DiscoKey":   "discokey:d34864640b62ea396a3c7c0eaa42f81dab2ad337432036a818c25cf4d907962b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43606",
+					"10.65.0.27:43606",
+					"172.17.0.1:43606",
+					"172.18.0.1:43606",
+					"172.19.0.1:43606"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:05:40.623358026Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2741196811603753,
+				"StableID":   "nA3LTLbVQN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b8f6b4c867879c50255d7376f0653e4af396f4c18c9a6263d22035c3c8d176a",
+				"DiscoKey":   "discokey:ab35d2ff7b4c9ee7c45af1e3d67186be5b5c4fb7b1eff0c7efff0dece346eb63",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40463",
+					"10.65.0.27:40463",
+					"172.17.0.1:40463",
+					"172.18.0.1:40463",
+					"172.19.0.1:40463"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:05:41.172270716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5148399933808640,
+				"StableID":   "nyBSHhjiCh11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ce03b844d28b6f0f6f7292dc4c787ce7fe2fd8d24f79671c68065f6d0516e4e",
+				"DiscoKey":   "discokey:30cd7df7d40c83ace21c31313145a400f77c6f90204c7e89548c327c6324ba31",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:46264",
+					"10.65.0.27:46264",
+					"172.17.0.1:46264",
+					"172.18.0.1:46264",
+					"172.19.0.1:46264"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:05:41.710407885Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2866230741916704,
+				"StableID":   "nyMbiE28PP11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a0838907563e9489b0020051f2aed9f23e07e7ee22cad17ed1c1729b168ed22",
+				"DiscoKey":   "discokey:f7d92636bdf7b163ece85b768b051775c400d0052d00d6e740c51947bc77d006",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53701",
+					"10.65.0.27:53701",
+					"172.17.0.1:53701",
+					"172.18.0.1:53701",
+					"172.19.0.1:53701"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:05:42.252428426Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5855576432549971,
+				"StableID":   "nrkAsg41jn11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4cf62346578e901a81686feda0c201d34b5812d3de708cfa28fd3012f604404e",
+				"DiscoKey":   "discokey:381cedd538673ac5e758b337eababf3839422232e8ff20f5fb8080606a73a51d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54971",
+					"10.65.0.27:54971",
+					"172.17.0.1:54971",
+					"172.18.0.1:54971",
+					"172.19.0.1:54971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:05:42.805677795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1921999311452042,
+				"StableID":   "nFFPaSfU1G11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5bef3fba1f2266af5b701c89a51005ecc4be2c288dcaf02fd517fdc5029a674f",
+				"DiscoKey":   "discokey:8c10a1a2b31e402cf8485b9d2f212dcb9068be80d8a402e7b3443c612b69f120",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57385",
+					"10.65.0.27:57385",
+					"172.17.0.1:57385",
+					"172.18.0.1:57385",
+					"172.19.0.1:57385"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:05:43.338622861Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4877052708108015,
+				"StableID":   "nkmi8Uup5f11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7fd81a5cc2f4c216088fc038169f73f7cd44b1a03f3fd07d9fdba80475627510",
+				"DiscoKey":   "discokey:690ee8ce7a543b0bc34b3acdb451a27685adbf529733a12d0ccc52bbecee3e27",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:59129",
+					"10.65.0.27:59129",
+					"172.17.0.1:59129",
+					"172.18.0.1:59129",
+					"172.19.0.1:59129"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:05:43.867947153Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4688324295371875,
+				"StableID":   "neU3a6LMcd11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6ad8e1c7c3684f5e013a8761cfa1339b272c1349335f07c1acbcdd177f31a041",
+				"DiscoKey":   "discokey:97f959fa4dd9d5c6ac5c64cf78bd02c7ddb6fb57f8aeed5290031251921a7a31",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52860",
+					"10.65.0.27:52860",
+					"172.17.0.1:52860",
+					"172.18.0.1:52860",
+					"172.19.0.1:52860"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:05:44.4125404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         960792509251671,
+				"StableID":   "n4BsxcP9W811CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25924f82c2e4e2a96289c138fb692ce3d85bbe7e1978923ee82d57c53dad215b",
+				"DiscoKey":   "discokey:626127ab79776864c8b898998c78e29548a4c668f2bac03f40e98cf15170882a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56295",
+					"10.65.0.27:56295",
+					"172.17.0.1:56295",
+					"172.18.0.1:56295",
+					"172.19.0.1:56295"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:05:44.955522153Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4158494613113948,
+				"StableID":   "nF8BsubPUZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e6949527d3d96159cf1d2c271990882b7e8eb7334c8badcb45262ecdd9269979",
+				"DiscoKey":   "discokey:e956da49e1ad48308a5de2630498329fd8c79098062be8f8f649db2d2e8ecc59",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49468",
+					"10.65.0.27:49468",
+					"172.17.0.1:49468",
+					"172.18.0.1:49468",
+					"172.19.0.1:49468"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:05:45.492405132Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7090431354986173,
+				"StableID":   "nrbKoHcGNx11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:fb9336c0762bdc4d4abd0f68b0c06326d7767408be67266c44645a8e83efad3b",
+				"KeyExpiry":  "2026-11-08T22:05:46Z",
+				"DiscoKey":   "discokey:e5af7abaa6b05b806bec5d9c6266d68ea7edde00917118d921b90ed7827fa629",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53478",
+					"10.65.0.27:53478",
+					"172.17.0.1:53478",
+					"172.18.0.1:53478",
+					"172.19.0.1:53478"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:05:46.226072737Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         131690244027660,
+				"StableID":   "nmDwuCHe2211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1cbfd67af89dfe11470bbeb24948da9ee9d478ad60b14d1954af7f38bd781d65",
+				"KeyExpiry":  "2026-11-08T22:05:47Z",
+				"DiscoKey":   "discokey:bdda7ea1deddf188da9387ec1c259fdc5e6c1966ea76e6e531029d949033dc44",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33060",
+					"10.65.0.27:33060",
+					"172.17.0.1:33060",
+					"172.18.0.1:33060",
+					"172.19.0.1:33060"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:05:47.311819952Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4688324295371875,
+				"StableID":   "neU3a6LMcd11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       4688324295371875,
+				"Key":        "nodekey:6ad8e1c7c3684f5e013a8761cfa1339b272c1349335f07c1acbcdd177f31a041",
+				"DiscoKey":   "discokey:97f959fa4dd9d5c6ac5c64cf78bd02c7ddb6fb57f8aeed5290031251921a7a31",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52860",
+					"10.65.0.27:52860",
+					"172.17.0.1:52860",
+					"172.18.0.1:52860",
+					"172.19.0.1:52860"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:05:44.4125404Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6ad8e1c7c3684f5e013a8761cfa1339b272c1349335f07c1acbcdd177f31a041",
+			"MachineKey": "mkey:c5c1a4c81ba7c48abf20665c5bc58c5ef73022a5392c591de0b835ff90f37407",
+			"Peers": [{
+				"ID":         1739955780428306,
+				"StableID":   "nVGq7ug2bE11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2a010553d1364bd7b01eee864538e7157e3b5d94a1fa6b8d055525eecc5a225c",
+				"DiscoKey":   "discokey:80f0f220e264fd4c8b5d2149130fafde8da79e09906d218fa667157c6168673c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40196",
+					"10.65.0.27:40196",
+					"172.17.0.1:40196",
+					"172.18.0.1:40196",
+					"172.19.0.1:40196"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:05:39.621735969Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5809560303894851,
+				"StableID":   "nJSj9HJANn11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9746aecf38cf74bbc8569813cd241e253df170693938585e0072e788d587d64f",
+				"DiscoKey":   "discokey:d373d524a1adc17a49715aecc36a147f8e6ca5864163a702d9698ff65049cf04",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34477",
+					"10.65.0.27:34477",
+					"172.17.0.1:34477",
+					"172.18.0.1:34477",
+					"172.19.0.1:34477"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:05:40.086480156Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6410717481083811,
+				"StableID":   "nLBJLJgR4s11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25618206e95f18346352b2fbb9100ad9f98d2357aec7e0da3dad796a7ad10b43",
+				"DiscoKey":   "discokey:d34864640b62ea396a3c7c0eaa42f81dab2ad337432036a818c25cf4d907962b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43606",
+					"10.65.0.27:43606",
+					"172.17.0.1:43606",
+					"172.18.0.1:43606",
+					"172.19.0.1:43606"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:05:40.623358026Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2741196811603753,
+				"StableID":   "nA3LTLbVQN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b8f6b4c867879c50255d7376f0653e4af396f4c18c9a6263d22035c3c8d176a",
+				"DiscoKey":   "discokey:ab35d2ff7b4c9ee7c45af1e3d67186be5b5c4fb7b1eff0c7efff0dece346eb63",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:40463",
+					"10.65.0.27:40463",
+					"172.17.0.1:40463",
+					"172.18.0.1:40463",
+					"172.19.0.1:40463"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:05:41.172270716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5148399933808640,
+				"StableID":   "nyBSHhjiCh11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ce03b844d28b6f0f6f7292dc4c787ce7fe2fd8d24f79671c68065f6d0516e4e",
+				"DiscoKey":   "discokey:30cd7df7d40c83ace21c31313145a400f77c6f90204c7e89548c327c6324ba31",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:46264",
+					"10.65.0.27:46264",
+					"172.17.0.1:46264",
+					"172.18.0.1:46264",
+					"172.19.0.1:46264"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:05:41.710407885Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2866230741916704,
+				"StableID":   "nyMbiE28PP11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a0838907563e9489b0020051f2aed9f23e07e7ee22cad17ed1c1729b168ed22",
+				"DiscoKey":   "discokey:f7d92636bdf7b163ece85b768b051775c400d0052d00d6e740c51947bc77d006",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53701",
+					"10.65.0.27:53701",
+					"172.17.0.1:53701",
+					"172.18.0.1:53701",
+					"172.19.0.1:53701"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:05:42.252428426Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5855576432549971,
+				"StableID":   "nrkAsg41jn11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4cf62346578e901a81686feda0c201d34b5812d3de708cfa28fd3012f604404e",
+				"DiscoKey":   "discokey:381cedd538673ac5e758b337eababf3839422232e8ff20f5fb8080606a73a51d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54971",
+					"10.65.0.27:54971",
+					"172.17.0.1:54971",
+					"172.18.0.1:54971",
+					"172.19.0.1:54971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:05:42.805677795Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1921999311452042,
+				"StableID":   "nFFPaSfU1G11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5bef3fba1f2266af5b701c89a51005ecc4be2c288dcaf02fd517fdc5029a674f",
+				"DiscoKey":   "discokey:8c10a1a2b31e402cf8485b9d2f212dcb9068be80d8a402e7b3443c612b69f120",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57385",
+					"10.65.0.27:57385",
+					"172.17.0.1:57385",
+					"172.18.0.1:57385",
+					"172.19.0.1:57385"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:05:43.338622861Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4877052708108015,
+				"StableID":   "nkmi8Uup5f11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7fd81a5cc2f4c216088fc038169f73f7cd44b1a03f3fd07d9fdba80475627510",
+				"DiscoKey":   "discokey:690ee8ce7a543b0bc34b3acdb451a27685adbf529733a12d0ccc52bbecee3e27",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:59129",
+					"10.65.0.27:59129",
+					"172.17.0.1:59129",
+					"172.18.0.1:59129",
+					"172.19.0.1:59129"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:05:43.867947153Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         960792509251671,
+				"StableID":   "n4BsxcP9W811CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25924f82c2e4e2a96289c138fb692ce3d85bbe7e1978923ee82d57c53dad215b",
+				"DiscoKey":   "discokey:626127ab79776864c8b898998c78e29548a4c668f2bac03f40e98cf15170882a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56295",
+					"10.65.0.27:56295",
+					"172.17.0.1:56295",
+					"172.18.0.1:56295",
+					"172.19.0.1:56295"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:05:44.955522153Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4158494613113948,
+				"StableID":   "nF8BsubPUZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e6949527d3d96159cf1d2c271990882b7e8eb7334c8badcb45262ecdd9269979",
+				"DiscoKey":   "discokey:e956da49e1ad48308a5de2630498329fd8c79098062be8f8f649db2d2e8ecc59",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49468",
+					"10.65.0.27:49468",
+					"172.17.0.1:49468",
+					"172.18.0.1:49468",
+					"172.19.0.1:49468"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:05:45.492405132Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7090431354986173,
+				"StableID":   "nrbKoHcGNx11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:fb9336c0762bdc4d4abd0f68b0c06326d7767408be67266c44645a8e83efad3b",
+				"KeyExpiry":  "2026-11-08T22:05:46Z",
+				"DiscoKey":   "discokey:e5af7abaa6b05b806bec5d9c6266d68ea7edde00917118d921b90ed7827fa629",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53478",
+					"10.65.0.27:53478",
+					"172.17.0.1:53478",
+					"172.18.0.1:53478",
+					"172.19.0.1:53478"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:05:46.226072737Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8111831117153597,
+				"StableID":   "nQeQAo3sL621CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:181534dd8c8edfc7b34edde75a7221433b3b0439a1f9bf3f9f7967adbc2cbd7d",
+				"KeyExpiry":  "2026-11-08T22:05:46Z",
+				"DiscoKey":   "discokey:4ebf62eb1531d5c3e8158dc673be9f8975534228c4aa865831a047e8def7bb72",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38459",
+					"10.65.0.27:38459",
+					"172.17.0.1:38459",
+					"172.18.0.1:38459",
+					"172.19.0.1:38459"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:05:46.775986537Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         131690244027660,
+				"StableID":   "nmDwuCHe2211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1cbfd67af89dfe11470bbeb24948da9ee9d478ad60b14d1954af7f38bd781d65",
+				"KeyExpiry":  "2026-11-08T22:05:47Z",
+				"DiscoKey":   "discokey:bdda7ea1deddf188da9387ec1c259fdc5e6c1966ea76e6e531029d949033dc44",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33060",
+					"10.65.0.27:33060",
+					"172.17.0.1:33060",
+					"172.18.0.1:33060",
+					"172.19.0.1:33060"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:05:47.311819952Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4688324295371875": {
+				"ID":          4688324295371875,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-user-localpart-empty.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-user-localpart-empty.hujson
@@ -1,0 +1,20104 @@
+// ssh-malformed-user-localpart-empty
+//
+// ssh users localpart with empty value is rejected
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T22:06:32Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-malformed-user-localpart-empty",
+	"description":    "ssh users localpart with empty value is rejected",
+	"category":       "ssh",
+	"captured_at":    "2026-05-12T22:06:32.589464039Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                     \n  \n                                                                 \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh users localpart with empty value is rejected\",\n\t\"id\":          \"ssh-malformed-user-localpart-empty\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"autogroup:member\"],\n\t\t\"users\":  [\"localpart:\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-malformed/ssh-malformed-user-localpart-empty.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["autogroup:member"],
+				"users":  ["localpart:"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5933888869717837,
+				"StableID":   "naRcmWCULo11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       5933888869717837,
+				"Key":        "nodekey:f459cd8dde23f16d569790ae160faeee9a4fa217fb37570369d2947db01d227e",
+				"DiscoKey":   "discokey:fcc5b81a3a8c48487013c39d23e4225e815a0d2b4861bc0748e6b39562be667b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48785",
+					"10.65.0.27:48785",
+					"172.17.0.1:48785",
+					"172.18.0.1:48785",
+					"172.19.0.1:48785"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:06:41.158510677Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f459cd8dde23f16d569790ae160faeee9a4fa217fb37570369d2947db01d227e",
+			"MachineKey": "mkey:dda35f170d16bce5619ed2a50348eae2ae903bcdc142b7fd238d5817ebe4895d",
+			"Peers": [{
+				"ID":         6920934748798951,
+				"StableID":   "npDB8mDW3w11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47b5c769dd653aaee4c253cc9cfc9143ecc58c16a3994a7e225f622ba5ba5613",
+				"DiscoKey":   "discokey:f3b7ddd2b297f111b52e9427c466f88576714932ff66550d58498820dc6ea853",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36670",
+					"10.65.0.27:36670",
+					"172.17.0.1:36670",
+					"172.18.0.1:36670",
+					"172.19.0.1:36670"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:06:35.256583687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3756436047208366,
+				"StableID":   "nqUVBuCJLW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35b9d3bbc656d9d7c59fa0d07895215c29aa5b248d52ef8fa366d823acee5e49",
+				"DiscoKey":   "discokey:d3022a1cc96b5e1fb798214fa7ca314666eb1cc9887204a8345adada9d768073",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42483",
+					"10.65.0.27:42483",
+					"172.17.0.1:42483",
+					"172.18.0.1:42483",
+					"172.19.0.1:42483"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:06:35.754995318Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4289665011511728,
+				"StableID":   "nRjNo6EoVa11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:710ebdf3d8b4cead87a1ed6724867e0e84f5cfb0b96dab89a17327f30a754b53",
+				"DiscoKey":   "discokey:0c189f19ed58a97593d96d99f8ab56b8762a8d5da49cad5c305f6157ea6a6620",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43290",
+					"10.65.0.27:43290",
+					"172.17.0.1:43290",
+					"172.18.0.1:43290",
+					"172.19.0.1:43290"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:06:36.287335379Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4004681398849003,
+				"StableID":   "nz46qzBjGY11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e14460ac6291b183f9aa98f31facc6334c11019c410a8558137eefd5838f855d",
+				"DiscoKey":   "discokey:2ec4af07745a3aa3acd3828b46d03668306af388c2f8f56067a106aff966fd4b",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45473",
+					"10.65.0.27:45473",
+					"172.17.0.1:45473",
+					"172.18.0.1:45473",
+					"172.19.0.1:45473"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:06:36.821069681Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         476329778022449,
+				"StableID":   "nQpQNnNji411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:52f85530f1faa72939b3a61a59e3de9d765a4aca4903e18d3e548657ad749379",
+				"DiscoKey":   "discokey:104e8eaa08339f2553f6c4708246f349fee2ffc928153b34970c4d1c44b6817c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37698",
+					"10.65.0.27:37698",
+					"172.17.0.1:37698",
+					"172.18.0.1:37698",
+					"172.19.0.1:37698"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:06:37.365396211Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2225880377551186,
+				"StableID":   "nZA7oy67PJ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:328e25da6d4b697b30d4c4375fc73c7c49a735f45ba30c1fb7b1a32ae28d075d",
+				"DiscoKey":   "discokey:a02335e58bd97307a2191f6f43645f675bfd349ff2b2d2a62f4f1695fb183061",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54634",
+					"10.65.0.27:54634",
+					"172.17.0.1:54634",
+					"172.18.0.1:54634",
+					"172.19.0.1:54634"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:06:37.898840526Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2220245363657152,
+				"StableID":   "nTQyug5ZLJ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:848d600d93e3239865f9872af7c7738a212df831fe0ac675e3fd508320539009",
+				"DiscoKey":   "discokey:8bd7f58c123b752f1c8ddadebba0572e6143f251e0eec3c3101c0ce0630aa452",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33155",
+					"10.65.0.27:33155",
+					"172.17.0.1:33155",
+					"172.18.0.1:33155",
+					"172.19.0.1:33155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:06:38.449831012Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4102409940318928,
+				"StableID":   "njpDPTMz2Z11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6010b1f69fc4da53dc443f5bd9ef3289731c462fc12bf6fea0b64df9063c1b30",
+				"DiscoKey":   "discokey:8409725db66a333aa2f93902bbe7c6382b3b72ac48d088c393da06af91550d62",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52423",
+					"10.65.0.27:52423",
+					"172.17.0.1:52423",
+					"172.18.0.1:52423",
+					"172.19.0.1:52423"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:06:38.988365023Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4111732804383497,
+				"StableID":   "nkWSxQFD7Z11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1f6f715801e9aa93bd52f145db297b081c2be81795118c0049b38e6108af1244",
+				"DiscoKey":   "discokey:653df946a29ac9f953bf0a032c638a04d774889e2dadf7ba4906682ee9315a15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:58525",
+					"10.65.0.27:58525",
+					"172.17.0.1:58525",
+					"172.18.0.1:58525",
+					"172.19.0.1:58525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:06:39.52882574Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1600586859876637,
+				"StableID":   "nrXbrkhuVD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ac434d4fb2f7f55c9aa69fc1371f33157dbef9c9bb0598cad19cfa91574c3017",
+				"DiscoKey":   "discokey:9e54597fd5eeac09ed07fd2f413af2a429c92012bb22959f8432762caf88d125",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42399",
+					"10.65.0.27:42399",
+					"172.17.0.1:42399",
+					"172.18.0.1:42399",
+					"172.19.0.1:42399"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:06:40.084901196Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3019688698704079,
+				"StableID":   "ncKFst6daQ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc3644ae4554545c5de9652d1a99649400b9e9ea90631fac2899ceacb4057a1e",
+				"DiscoKey":   "discokey:a418501fe1969a9097e17983e2108682fcf51341e719285196952a116623e730",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35727",
+					"10.65.0.27:35727",
+					"172.17.0.1:35727",
+					"172.18.0.1:35727",
+					"172.19.0.1:35727"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:06:40.61810035Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6546445728991847,
+				"StableID":   "nJ6cpe2u7t11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:eac53cd48b9acee0c69497885405a2c8fcad770e92c94f782b38f05fc7001534",
+				"KeyExpiry":  "2026-11-08T22:06:41Z",
+				"DiscoKey":   "discokey:feddaa658dcbb026b1c5167c93df0f5f0ebecc7c6223e6590609fd3faf983f56",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45216",
+					"10.65.0.27:45216",
+					"172.17.0.1:45216",
+					"172.18.0.1:45216",
+					"172.19.0.1:45216"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:06:41.723762697Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         570529030803432,
+				"StableID":   "nPvVm9qPT511CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:501505a8b4781b7e1fff7722ef605788844c865265aa9e95f97229aa7ed7183a",
+				"KeyExpiry":  "2026-11-08T22:06:42Z",
+				"DiscoKey":   "discokey:947371d1d082da93055afe4a5fd223fcf501e00557746e0036587f3a9b4a0f7c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58615",
+					"10.65.0.27:58615",
+					"172.17.0.1:58615",
+					"172.18.0.1:58615",
+					"172.19.0.1:58615"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:06:42.246474856Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5898241027042958,
+				"StableID":   "nVNyypnK4o11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8bb47b6c7782b9d8e24c6d36ac8e82bcfa9d14934150389fb6b561369835a155",
+				"KeyExpiry":  "2026-11-08T22:06:42Z",
+				"DiscoKey":   "discokey:820710e9c0504871a5728473bfd1f00a63dc052f65d8abfedf768c4ae8a88b51",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53487",
+					"10.65.0.27:53487",
+					"172.17.0.1:53487",
+					"172.18.0.1:53487",
+					"172.19.0.1:53487"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:06:42.77529914Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{"principals": [
+				{"nodeIP": "100.64.0.17"},
+				{"nodeIP": "100.64.0.18"},
+				{"nodeIP": "100.64.0.19"},
+				{"nodeIP": "fd7a:115c:a1e0::12"},
+				{"nodeIP": "fd7a:115c:a1e0::13"},
+				{"nodeIP": "fd7a:115c:a1e0::11"}
+			], "sshUsers": {"localpart:": "localpart:", "root": ""}, "action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5933888869717837": {
+				"ID":          5933888869717837,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		},
+		"ssh_rules": [{"principals": [
+			{"nodeIP": "100.64.0.17"},
+			{"nodeIP": "100.64.0.18"},
+			{"nodeIP": "100.64.0.19"},
+			{"nodeIP": "fd7a:115c:a1e0::12"},
+			{"nodeIP": "fd7a:115c:a1e0::13"},
+			{"nodeIP": "fd7a:115c:a1e0::11"}
+		], "sshUsers": {"localpart:": "localpart:", "root": ""}, "action": {
+			"accept":                    true,
+			"allowAgentForwarding":      true,
+			"allowLocalPortForwarding":  true,
+			"allowRemotePortForwarding": true
+		}}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2225880377551186,
+				"StableID":   "nZA7oy67PJ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       2225880377551186,
+				"Key":        "nodekey:328e25da6d4b697b30d4c4375fc73c7c49a735f45ba30c1fb7b1a32ae28d075d",
+				"DiscoKey":   "discokey:a02335e58bd97307a2191f6f43645f675bfd349ff2b2d2a62f4f1695fb183061",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54634",
+					"10.65.0.27:54634",
+					"172.17.0.1:54634",
+					"172.18.0.1:54634",
+					"172.19.0.1:54634"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:06:37.898840526Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:328e25da6d4b697b30d4c4375fc73c7c49a735f45ba30c1fb7b1a32ae28d075d",
+			"MachineKey": "mkey:c41d5eb02f957ddcf8a6b1ddf456fbf89bacf07b095cf798a610b06cccfa742b",
+			"Peers": [{
+				"ID":         6920934748798951,
+				"StableID":   "npDB8mDW3w11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47b5c769dd653aaee4c253cc9cfc9143ecc58c16a3994a7e225f622ba5ba5613",
+				"DiscoKey":   "discokey:f3b7ddd2b297f111b52e9427c466f88576714932ff66550d58498820dc6ea853",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36670",
+					"10.65.0.27:36670",
+					"172.17.0.1:36670",
+					"172.18.0.1:36670",
+					"172.19.0.1:36670"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:06:35.256583687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3756436047208366,
+				"StableID":   "nqUVBuCJLW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35b9d3bbc656d9d7c59fa0d07895215c29aa5b248d52ef8fa366d823acee5e49",
+				"DiscoKey":   "discokey:d3022a1cc96b5e1fb798214fa7ca314666eb1cc9887204a8345adada9d768073",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42483",
+					"10.65.0.27:42483",
+					"172.17.0.1:42483",
+					"172.18.0.1:42483",
+					"172.19.0.1:42483"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:06:35.754995318Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4289665011511728,
+				"StableID":   "nRjNo6EoVa11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:710ebdf3d8b4cead87a1ed6724867e0e84f5cfb0b96dab89a17327f30a754b53",
+				"DiscoKey":   "discokey:0c189f19ed58a97593d96d99f8ab56b8762a8d5da49cad5c305f6157ea6a6620",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43290",
+					"10.65.0.27:43290",
+					"172.17.0.1:43290",
+					"172.18.0.1:43290",
+					"172.19.0.1:43290"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:06:36.287335379Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4004681398849003,
+				"StableID":   "nz46qzBjGY11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e14460ac6291b183f9aa98f31facc6334c11019c410a8558137eefd5838f855d",
+				"DiscoKey":   "discokey:2ec4af07745a3aa3acd3828b46d03668306af388c2f8f56067a106aff966fd4b",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45473",
+					"10.65.0.27:45473",
+					"172.17.0.1:45473",
+					"172.18.0.1:45473",
+					"172.19.0.1:45473"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:06:36.821069681Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         476329778022449,
+				"StableID":   "nQpQNnNji411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:52f85530f1faa72939b3a61a59e3de9d765a4aca4903e18d3e548657ad749379",
+				"DiscoKey":   "discokey:104e8eaa08339f2553f6c4708246f349fee2ffc928153b34970c4d1c44b6817c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37698",
+					"10.65.0.27:37698",
+					"172.17.0.1:37698",
+					"172.18.0.1:37698",
+					"172.19.0.1:37698"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:06:37.365396211Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2220245363657152,
+				"StableID":   "nTQyug5ZLJ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:848d600d93e3239865f9872af7c7738a212df831fe0ac675e3fd508320539009",
+				"DiscoKey":   "discokey:8bd7f58c123b752f1c8ddadebba0572e6143f251e0eec3c3101c0ce0630aa452",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33155",
+					"10.65.0.27:33155",
+					"172.17.0.1:33155",
+					"172.18.0.1:33155",
+					"172.19.0.1:33155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:06:38.449831012Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4102409940318928,
+				"StableID":   "njpDPTMz2Z11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6010b1f69fc4da53dc443f5bd9ef3289731c462fc12bf6fea0b64df9063c1b30",
+				"DiscoKey":   "discokey:8409725db66a333aa2f93902bbe7c6382b3b72ac48d088c393da06af91550d62",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52423",
+					"10.65.0.27:52423",
+					"172.17.0.1:52423",
+					"172.18.0.1:52423",
+					"172.19.0.1:52423"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:06:38.988365023Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4111732804383497,
+				"StableID":   "nkWSxQFD7Z11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1f6f715801e9aa93bd52f145db297b081c2be81795118c0049b38e6108af1244",
+				"DiscoKey":   "discokey:653df946a29ac9f953bf0a032c638a04d774889e2dadf7ba4906682ee9315a15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:58525",
+					"10.65.0.27:58525",
+					"172.17.0.1:58525",
+					"172.18.0.1:58525",
+					"172.19.0.1:58525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:06:39.52882574Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1600586859876637,
+				"StableID":   "nrXbrkhuVD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ac434d4fb2f7f55c9aa69fc1371f33157dbef9c9bb0598cad19cfa91574c3017",
+				"DiscoKey":   "discokey:9e54597fd5eeac09ed07fd2f413af2a429c92012bb22959f8432762caf88d125",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42399",
+					"10.65.0.27:42399",
+					"172.17.0.1:42399",
+					"172.18.0.1:42399",
+					"172.19.0.1:42399"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:06:40.084901196Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3019688698704079,
+				"StableID":   "ncKFst6daQ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc3644ae4554545c5de9652d1a99649400b9e9ea90631fac2899ceacb4057a1e",
+				"DiscoKey":   "discokey:a418501fe1969a9097e17983e2108682fcf51341e719285196952a116623e730",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35727",
+					"10.65.0.27:35727",
+					"172.17.0.1:35727",
+					"172.18.0.1:35727",
+					"172.19.0.1:35727"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:06:40.61810035Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5933888869717837,
+				"StableID":   "naRcmWCULo11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f459cd8dde23f16d569790ae160faeee9a4fa217fb37570369d2947db01d227e",
+				"DiscoKey":   "discokey:fcc5b81a3a8c48487013c39d23e4225e815a0d2b4861bc0748e6b39562be667b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48785",
+					"10.65.0.27:48785",
+					"172.17.0.1:48785",
+					"172.18.0.1:48785",
+					"172.19.0.1:48785"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:06:41.158510677Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6546445728991847,
+				"StableID":   "nJ6cpe2u7t11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:eac53cd48b9acee0c69497885405a2c8fcad770e92c94f782b38f05fc7001534",
+				"KeyExpiry":  "2026-11-08T22:06:41Z",
+				"DiscoKey":   "discokey:feddaa658dcbb026b1c5167c93df0f5f0ebecc7c6223e6590609fd3faf983f56",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45216",
+					"10.65.0.27:45216",
+					"172.17.0.1:45216",
+					"172.18.0.1:45216",
+					"172.19.0.1:45216"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:06:41.723762697Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         570529030803432,
+				"StableID":   "nPvVm9qPT511CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:501505a8b4781b7e1fff7722ef605788844c865265aa9e95f97229aa7ed7183a",
+				"KeyExpiry":  "2026-11-08T22:06:42Z",
+				"DiscoKey":   "discokey:947371d1d082da93055afe4a5fd223fcf501e00557746e0036587f3a9b4a0f7c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58615",
+					"10.65.0.27:58615",
+					"172.17.0.1:58615",
+					"172.18.0.1:58615",
+					"172.19.0.1:58615"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:06:42.246474856Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5898241027042958,
+				"StableID":   "nVNyypnK4o11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8bb47b6c7782b9d8e24c6d36ac8e82bcfa9d14934150389fb6b561369835a155",
+				"KeyExpiry":  "2026-11-08T22:06:42Z",
+				"DiscoKey":   "discokey:820710e9c0504871a5728473bfd1f00a63dc052f65d8abfedf768c4ae8a88b51",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53487",
+					"10.65.0.27:53487",
+					"172.17.0.1:53487",
+					"172.18.0.1:53487",
+					"172.19.0.1:53487"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:06:42.77529914Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2225880377551186": {
+				"ID":          2225880377551186,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5898241027042958,
+				"StableID":   "nVNyypnK4o11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8bb47b6c7782b9d8e24c6d36ac8e82bcfa9d14934150389fb6b561369835a155",
+				"KeyExpiry":  "2026-11-08T22:06:42Z",
+				"DiscoKey":   "discokey:820710e9c0504871a5728473bfd1f00a63dc052f65d8abfedf768c4ae8a88b51",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53487",
+					"10.65.0.27:53487",
+					"172.17.0.1:53487",
+					"172.18.0.1:53487",
+					"172.19.0.1:53487"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:06:42.77529914Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8bb47b6c7782b9d8e24c6d36ac8e82bcfa9d14934150389fb6b561369835a155",
+			"MachineKey": "mkey:b71ebc5591203eed8aceebea399ebb02727e8e7df6f31f739b7ccb2948b17321",
+			"Peers": [{
+				"ID":         6920934748798951,
+				"StableID":   "npDB8mDW3w11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47b5c769dd653aaee4c253cc9cfc9143ecc58c16a3994a7e225f622ba5ba5613",
+				"DiscoKey":   "discokey:f3b7ddd2b297f111b52e9427c466f88576714932ff66550d58498820dc6ea853",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36670",
+					"10.65.0.27:36670",
+					"172.17.0.1:36670",
+					"172.18.0.1:36670",
+					"172.19.0.1:36670"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:06:35.256583687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3756436047208366,
+				"StableID":   "nqUVBuCJLW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35b9d3bbc656d9d7c59fa0d07895215c29aa5b248d52ef8fa366d823acee5e49",
+				"DiscoKey":   "discokey:d3022a1cc96b5e1fb798214fa7ca314666eb1cc9887204a8345adada9d768073",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42483",
+					"10.65.0.27:42483",
+					"172.17.0.1:42483",
+					"172.18.0.1:42483",
+					"172.19.0.1:42483"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:06:35.754995318Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4289665011511728,
+				"StableID":   "nRjNo6EoVa11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:710ebdf3d8b4cead87a1ed6724867e0e84f5cfb0b96dab89a17327f30a754b53",
+				"DiscoKey":   "discokey:0c189f19ed58a97593d96d99f8ab56b8762a8d5da49cad5c305f6157ea6a6620",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43290",
+					"10.65.0.27:43290",
+					"172.17.0.1:43290",
+					"172.18.0.1:43290",
+					"172.19.0.1:43290"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:06:36.287335379Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4004681398849003,
+				"StableID":   "nz46qzBjGY11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e14460ac6291b183f9aa98f31facc6334c11019c410a8558137eefd5838f855d",
+				"DiscoKey":   "discokey:2ec4af07745a3aa3acd3828b46d03668306af388c2f8f56067a106aff966fd4b",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45473",
+					"10.65.0.27:45473",
+					"172.17.0.1:45473",
+					"172.18.0.1:45473",
+					"172.19.0.1:45473"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:06:36.821069681Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         476329778022449,
+				"StableID":   "nQpQNnNji411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:52f85530f1faa72939b3a61a59e3de9d765a4aca4903e18d3e548657ad749379",
+				"DiscoKey":   "discokey:104e8eaa08339f2553f6c4708246f349fee2ffc928153b34970c4d1c44b6817c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37698",
+					"10.65.0.27:37698",
+					"172.17.0.1:37698",
+					"172.18.0.1:37698",
+					"172.19.0.1:37698"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:06:37.365396211Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2225880377551186,
+				"StableID":   "nZA7oy67PJ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:328e25da6d4b697b30d4c4375fc73c7c49a735f45ba30c1fb7b1a32ae28d075d",
+				"DiscoKey":   "discokey:a02335e58bd97307a2191f6f43645f675bfd349ff2b2d2a62f4f1695fb183061",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54634",
+					"10.65.0.27:54634",
+					"172.17.0.1:54634",
+					"172.18.0.1:54634",
+					"172.19.0.1:54634"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:06:37.898840526Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2220245363657152,
+				"StableID":   "nTQyug5ZLJ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:848d600d93e3239865f9872af7c7738a212df831fe0ac675e3fd508320539009",
+				"DiscoKey":   "discokey:8bd7f58c123b752f1c8ddadebba0572e6143f251e0eec3c3101c0ce0630aa452",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33155",
+					"10.65.0.27:33155",
+					"172.17.0.1:33155",
+					"172.18.0.1:33155",
+					"172.19.0.1:33155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:06:38.449831012Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4102409940318928,
+				"StableID":   "njpDPTMz2Z11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6010b1f69fc4da53dc443f5bd9ef3289731c462fc12bf6fea0b64df9063c1b30",
+				"DiscoKey":   "discokey:8409725db66a333aa2f93902bbe7c6382b3b72ac48d088c393da06af91550d62",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52423",
+					"10.65.0.27:52423",
+					"172.17.0.1:52423",
+					"172.18.0.1:52423",
+					"172.19.0.1:52423"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:06:38.988365023Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4111732804383497,
+				"StableID":   "nkWSxQFD7Z11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1f6f715801e9aa93bd52f145db297b081c2be81795118c0049b38e6108af1244",
+				"DiscoKey":   "discokey:653df946a29ac9f953bf0a032c638a04d774889e2dadf7ba4906682ee9315a15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:58525",
+					"10.65.0.27:58525",
+					"172.17.0.1:58525",
+					"172.18.0.1:58525",
+					"172.19.0.1:58525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:06:39.52882574Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1600586859876637,
+				"StableID":   "nrXbrkhuVD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ac434d4fb2f7f55c9aa69fc1371f33157dbef9c9bb0598cad19cfa91574c3017",
+				"DiscoKey":   "discokey:9e54597fd5eeac09ed07fd2f413af2a429c92012bb22959f8432762caf88d125",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42399",
+					"10.65.0.27:42399",
+					"172.17.0.1:42399",
+					"172.18.0.1:42399",
+					"172.19.0.1:42399"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:06:40.084901196Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3019688698704079,
+				"StableID":   "ncKFst6daQ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc3644ae4554545c5de9652d1a99649400b9e9ea90631fac2899ceacb4057a1e",
+				"DiscoKey":   "discokey:a418501fe1969a9097e17983e2108682fcf51341e719285196952a116623e730",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35727",
+					"10.65.0.27:35727",
+					"172.17.0.1:35727",
+					"172.18.0.1:35727",
+					"172.19.0.1:35727"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:06:40.61810035Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5933888869717837,
+				"StableID":   "naRcmWCULo11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f459cd8dde23f16d569790ae160faeee9a4fa217fb37570369d2947db01d227e",
+				"DiscoKey":   "discokey:fcc5b81a3a8c48487013c39d23e4225e815a0d2b4861bc0748e6b39562be667b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48785",
+					"10.65.0.27:48785",
+					"172.17.0.1:48785",
+					"172.18.0.1:48785",
+					"172.19.0.1:48785"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:06:41.158510677Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6546445728991847,
+				"StableID":   "nJ6cpe2u7t11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:eac53cd48b9acee0c69497885405a2c8fcad770e92c94f782b38f05fc7001534",
+				"KeyExpiry":  "2026-11-08T22:06:41Z",
+				"DiscoKey":   "discokey:feddaa658dcbb026b1c5167c93df0f5f0ebecc7c6223e6590609fd3faf983f56",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45216",
+					"10.65.0.27:45216",
+					"172.17.0.1:45216",
+					"172.18.0.1:45216",
+					"172.19.0.1:45216"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:06:41.723762697Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         570529030803432,
+				"StableID":   "nPvVm9qPT511CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:501505a8b4781b7e1fff7722ef605788844c865265aa9e95f97229aa7ed7183a",
+				"KeyExpiry":  "2026-11-08T22:06:42Z",
+				"DiscoKey":   "discokey:947371d1d082da93055afe4a5fd223fcf501e00557746e0036587f3a9b4a0f7c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58615",
+					"10.65.0.27:58615",
+					"172.17.0.1:58615",
+					"172.18.0.1:58615",
+					"172.19.0.1:58615"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:06:42.246474856Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4289665011511728,
+				"StableID":   "nRjNo6EoVa11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       4289665011511728,
+				"Key":        "nodekey:710ebdf3d8b4cead87a1ed6724867e0e84f5cfb0b96dab89a17327f30a754b53",
+				"DiscoKey":   "discokey:0c189f19ed58a97593d96d99f8ab56b8762a8d5da49cad5c305f6157ea6a6620",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43290",
+					"10.65.0.27:43290",
+					"172.17.0.1:43290",
+					"172.18.0.1:43290",
+					"172.19.0.1:43290"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:06:36.287335379Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:710ebdf3d8b4cead87a1ed6724867e0e84f5cfb0b96dab89a17327f30a754b53",
+			"MachineKey": "mkey:b9c995e8408c4fedba3a462037449071f86d813fdf15e53c50df8b843bbb343d",
+			"Peers": [{
+				"ID":         6920934748798951,
+				"StableID":   "npDB8mDW3w11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47b5c769dd653aaee4c253cc9cfc9143ecc58c16a3994a7e225f622ba5ba5613",
+				"DiscoKey":   "discokey:f3b7ddd2b297f111b52e9427c466f88576714932ff66550d58498820dc6ea853",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36670",
+					"10.65.0.27:36670",
+					"172.17.0.1:36670",
+					"172.18.0.1:36670",
+					"172.19.0.1:36670"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:06:35.256583687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3756436047208366,
+				"StableID":   "nqUVBuCJLW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35b9d3bbc656d9d7c59fa0d07895215c29aa5b248d52ef8fa366d823acee5e49",
+				"DiscoKey":   "discokey:d3022a1cc96b5e1fb798214fa7ca314666eb1cc9887204a8345adada9d768073",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42483",
+					"10.65.0.27:42483",
+					"172.17.0.1:42483",
+					"172.18.0.1:42483",
+					"172.19.0.1:42483"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:06:35.754995318Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4004681398849003,
+				"StableID":   "nz46qzBjGY11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e14460ac6291b183f9aa98f31facc6334c11019c410a8558137eefd5838f855d",
+				"DiscoKey":   "discokey:2ec4af07745a3aa3acd3828b46d03668306af388c2f8f56067a106aff966fd4b",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45473",
+					"10.65.0.27:45473",
+					"172.17.0.1:45473",
+					"172.18.0.1:45473",
+					"172.19.0.1:45473"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:06:36.821069681Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         476329778022449,
+				"StableID":   "nQpQNnNji411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:52f85530f1faa72939b3a61a59e3de9d765a4aca4903e18d3e548657ad749379",
+				"DiscoKey":   "discokey:104e8eaa08339f2553f6c4708246f349fee2ffc928153b34970c4d1c44b6817c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37698",
+					"10.65.0.27:37698",
+					"172.17.0.1:37698",
+					"172.18.0.1:37698",
+					"172.19.0.1:37698"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:06:37.365396211Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2225880377551186,
+				"StableID":   "nZA7oy67PJ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:328e25da6d4b697b30d4c4375fc73c7c49a735f45ba30c1fb7b1a32ae28d075d",
+				"DiscoKey":   "discokey:a02335e58bd97307a2191f6f43645f675bfd349ff2b2d2a62f4f1695fb183061",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54634",
+					"10.65.0.27:54634",
+					"172.17.0.1:54634",
+					"172.18.0.1:54634",
+					"172.19.0.1:54634"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:06:37.898840526Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2220245363657152,
+				"StableID":   "nTQyug5ZLJ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:848d600d93e3239865f9872af7c7738a212df831fe0ac675e3fd508320539009",
+				"DiscoKey":   "discokey:8bd7f58c123b752f1c8ddadebba0572e6143f251e0eec3c3101c0ce0630aa452",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33155",
+					"10.65.0.27:33155",
+					"172.17.0.1:33155",
+					"172.18.0.1:33155",
+					"172.19.0.1:33155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:06:38.449831012Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4102409940318928,
+				"StableID":   "njpDPTMz2Z11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6010b1f69fc4da53dc443f5bd9ef3289731c462fc12bf6fea0b64df9063c1b30",
+				"DiscoKey":   "discokey:8409725db66a333aa2f93902bbe7c6382b3b72ac48d088c393da06af91550d62",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52423",
+					"10.65.0.27:52423",
+					"172.17.0.1:52423",
+					"172.18.0.1:52423",
+					"172.19.0.1:52423"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:06:38.988365023Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4111732804383497,
+				"StableID":   "nkWSxQFD7Z11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1f6f715801e9aa93bd52f145db297b081c2be81795118c0049b38e6108af1244",
+				"DiscoKey":   "discokey:653df946a29ac9f953bf0a032c638a04d774889e2dadf7ba4906682ee9315a15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:58525",
+					"10.65.0.27:58525",
+					"172.17.0.1:58525",
+					"172.18.0.1:58525",
+					"172.19.0.1:58525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:06:39.52882574Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1600586859876637,
+				"StableID":   "nrXbrkhuVD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ac434d4fb2f7f55c9aa69fc1371f33157dbef9c9bb0598cad19cfa91574c3017",
+				"DiscoKey":   "discokey:9e54597fd5eeac09ed07fd2f413af2a429c92012bb22959f8432762caf88d125",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42399",
+					"10.65.0.27:42399",
+					"172.17.0.1:42399",
+					"172.18.0.1:42399",
+					"172.19.0.1:42399"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:06:40.084901196Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3019688698704079,
+				"StableID":   "ncKFst6daQ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc3644ae4554545c5de9652d1a99649400b9e9ea90631fac2899ceacb4057a1e",
+				"DiscoKey":   "discokey:a418501fe1969a9097e17983e2108682fcf51341e719285196952a116623e730",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35727",
+					"10.65.0.27:35727",
+					"172.17.0.1:35727",
+					"172.18.0.1:35727",
+					"172.19.0.1:35727"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:06:40.61810035Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5933888869717837,
+				"StableID":   "naRcmWCULo11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f459cd8dde23f16d569790ae160faeee9a4fa217fb37570369d2947db01d227e",
+				"DiscoKey":   "discokey:fcc5b81a3a8c48487013c39d23e4225e815a0d2b4861bc0748e6b39562be667b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48785",
+					"10.65.0.27:48785",
+					"172.17.0.1:48785",
+					"172.18.0.1:48785",
+					"172.19.0.1:48785"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:06:41.158510677Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6546445728991847,
+				"StableID":   "nJ6cpe2u7t11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:eac53cd48b9acee0c69497885405a2c8fcad770e92c94f782b38f05fc7001534",
+				"KeyExpiry":  "2026-11-08T22:06:41Z",
+				"DiscoKey":   "discokey:feddaa658dcbb026b1c5167c93df0f5f0ebecc7c6223e6590609fd3faf983f56",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45216",
+					"10.65.0.27:45216",
+					"172.17.0.1:45216",
+					"172.18.0.1:45216",
+					"172.19.0.1:45216"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:06:41.723762697Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         570529030803432,
+				"StableID":   "nPvVm9qPT511CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:501505a8b4781b7e1fff7722ef605788844c865265aa9e95f97229aa7ed7183a",
+				"KeyExpiry":  "2026-11-08T22:06:42Z",
+				"DiscoKey":   "discokey:947371d1d082da93055afe4a5fd223fcf501e00557746e0036587f3a9b4a0f7c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58615",
+					"10.65.0.27:58615",
+					"172.17.0.1:58615",
+					"172.18.0.1:58615",
+					"172.19.0.1:58615"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:06:42.246474856Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5898241027042958,
+				"StableID":   "nVNyypnK4o11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8bb47b6c7782b9d8e24c6d36ac8e82bcfa9d14934150389fb6b561369835a155",
+				"KeyExpiry":  "2026-11-08T22:06:42Z",
+				"DiscoKey":   "discokey:820710e9c0504871a5728473bfd1f00a63dc052f65d8abfedf768c4ae8a88b51",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53487",
+					"10.65.0.27:53487",
+					"172.17.0.1:53487",
+					"172.18.0.1:53487",
+					"172.19.0.1:53487"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:06:42.77529914Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4289665011511728": {
+				"ID":          4289665011511728,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4102409940318928,
+				"StableID":   "njpDPTMz2Z11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       4102409940318928,
+				"Key":        "nodekey:6010b1f69fc4da53dc443f5bd9ef3289731c462fc12bf6fea0b64df9063c1b30",
+				"DiscoKey":   "discokey:8409725db66a333aa2f93902bbe7c6382b3b72ac48d088c393da06af91550d62",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52423",
+					"10.65.0.27:52423",
+					"172.17.0.1:52423",
+					"172.18.0.1:52423",
+					"172.19.0.1:52423"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:06:38.988365023Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6010b1f69fc4da53dc443f5bd9ef3289731c462fc12bf6fea0b64df9063c1b30",
+			"MachineKey": "mkey:adf5bb56aa9523882cfa0e2d82158eeb8ad4317390bb365fdbbeb1a1a6966b73",
+			"Peers": [{
+				"ID":         6920934748798951,
+				"StableID":   "npDB8mDW3w11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47b5c769dd653aaee4c253cc9cfc9143ecc58c16a3994a7e225f622ba5ba5613",
+				"DiscoKey":   "discokey:f3b7ddd2b297f111b52e9427c466f88576714932ff66550d58498820dc6ea853",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36670",
+					"10.65.0.27:36670",
+					"172.17.0.1:36670",
+					"172.18.0.1:36670",
+					"172.19.0.1:36670"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:06:35.256583687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3756436047208366,
+				"StableID":   "nqUVBuCJLW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35b9d3bbc656d9d7c59fa0d07895215c29aa5b248d52ef8fa366d823acee5e49",
+				"DiscoKey":   "discokey:d3022a1cc96b5e1fb798214fa7ca314666eb1cc9887204a8345adada9d768073",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42483",
+					"10.65.0.27:42483",
+					"172.17.0.1:42483",
+					"172.18.0.1:42483",
+					"172.19.0.1:42483"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:06:35.754995318Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4289665011511728,
+				"StableID":   "nRjNo6EoVa11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:710ebdf3d8b4cead87a1ed6724867e0e84f5cfb0b96dab89a17327f30a754b53",
+				"DiscoKey":   "discokey:0c189f19ed58a97593d96d99f8ab56b8762a8d5da49cad5c305f6157ea6a6620",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43290",
+					"10.65.0.27:43290",
+					"172.17.0.1:43290",
+					"172.18.0.1:43290",
+					"172.19.0.1:43290"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:06:36.287335379Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4004681398849003,
+				"StableID":   "nz46qzBjGY11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e14460ac6291b183f9aa98f31facc6334c11019c410a8558137eefd5838f855d",
+				"DiscoKey":   "discokey:2ec4af07745a3aa3acd3828b46d03668306af388c2f8f56067a106aff966fd4b",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45473",
+					"10.65.0.27:45473",
+					"172.17.0.1:45473",
+					"172.18.0.1:45473",
+					"172.19.0.1:45473"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:06:36.821069681Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         476329778022449,
+				"StableID":   "nQpQNnNji411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:52f85530f1faa72939b3a61a59e3de9d765a4aca4903e18d3e548657ad749379",
+				"DiscoKey":   "discokey:104e8eaa08339f2553f6c4708246f349fee2ffc928153b34970c4d1c44b6817c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37698",
+					"10.65.0.27:37698",
+					"172.17.0.1:37698",
+					"172.18.0.1:37698",
+					"172.19.0.1:37698"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:06:37.365396211Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2225880377551186,
+				"StableID":   "nZA7oy67PJ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:328e25da6d4b697b30d4c4375fc73c7c49a735f45ba30c1fb7b1a32ae28d075d",
+				"DiscoKey":   "discokey:a02335e58bd97307a2191f6f43645f675bfd349ff2b2d2a62f4f1695fb183061",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54634",
+					"10.65.0.27:54634",
+					"172.17.0.1:54634",
+					"172.18.0.1:54634",
+					"172.19.0.1:54634"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:06:37.898840526Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2220245363657152,
+				"StableID":   "nTQyug5ZLJ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:848d600d93e3239865f9872af7c7738a212df831fe0ac675e3fd508320539009",
+				"DiscoKey":   "discokey:8bd7f58c123b752f1c8ddadebba0572e6143f251e0eec3c3101c0ce0630aa452",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33155",
+					"10.65.0.27:33155",
+					"172.17.0.1:33155",
+					"172.18.0.1:33155",
+					"172.19.0.1:33155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:06:38.449831012Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4111732804383497,
+				"StableID":   "nkWSxQFD7Z11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1f6f715801e9aa93bd52f145db297b081c2be81795118c0049b38e6108af1244",
+				"DiscoKey":   "discokey:653df946a29ac9f953bf0a032c638a04d774889e2dadf7ba4906682ee9315a15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:58525",
+					"10.65.0.27:58525",
+					"172.17.0.1:58525",
+					"172.18.0.1:58525",
+					"172.19.0.1:58525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:06:39.52882574Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1600586859876637,
+				"StableID":   "nrXbrkhuVD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ac434d4fb2f7f55c9aa69fc1371f33157dbef9c9bb0598cad19cfa91574c3017",
+				"DiscoKey":   "discokey:9e54597fd5eeac09ed07fd2f413af2a429c92012bb22959f8432762caf88d125",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42399",
+					"10.65.0.27:42399",
+					"172.17.0.1:42399",
+					"172.18.0.1:42399",
+					"172.19.0.1:42399"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:06:40.084901196Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3019688698704079,
+				"StableID":   "ncKFst6daQ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc3644ae4554545c5de9652d1a99649400b9e9ea90631fac2899ceacb4057a1e",
+				"DiscoKey":   "discokey:a418501fe1969a9097e17983e2108682fcf51341e719285196952a116623e730",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35727",
+					"10.65.0.27:35727",
+					"172.17.0.1:35727",
+					"172.18.0.1:35727",
+					"172.19.0.1:35727"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:06:40.61810035Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5933888869717837,
+				"StableID":   "naRcmWCULo11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f459cd8dde23f16d569790ae160faeee9a4fa217fb37570369d2947db01d227e",
+				"DiscoKey":   "discokey:fcc5b81a3a8c48487013c39d23e4225e815a0d2b4861bc0748e6b39562be667b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48785",
+					"10.65.0.27:48785",
+					"172.17.0.1:48785",
+					"172.18.0.1:48785",
+					"172.19.0.1:48785"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:06:41.158510677Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6546445728991847,
+				"StableID":   "nJ6cpe2u7t11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:eac53cd48b9acee0c69497885405a2c8fcad770e92c94f782b38f05fc7001534",
+				"KeyExpiry":  "2026-11-08T22:06:41Z",
+				"DiscoKey":   "discokey:feddaa658dcbb026b1c5167c93df0f5f0ebecc7c6223e6590609fd3faf983f56",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45216",
+					"10.65.0.27:45216",
+					"172.17.0.1:45216",
+					"172.18.0.1:45216",
+					"172.19.0.1:45216"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:06:41.723762697Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         570529030803432,
+				"StableID":   "nPvVm9qPT511CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:501505a8b4781b7e1fff7722ef605788844c865265aa9e95f97229aa7ed7183a",
+				"KeyExpiry":  "2026-11-08T22:06:42Z",
+				"DiscoKey":   "discokey:947371d1d082da93055afe4a5fd223fcf501e00557746e0036587f3a9b4a0f7c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58615",
+					"10.65.0.27:58615",
+					"172.17.0.1:58615",
+					"172.18.0.1:58615",
+					"172.19.0.1:58615"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:06:42.246474856Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5898241027042958,
+				"StableID":   "nVNyypnK4o11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8bb47b6c7782b9d8e24c6d36ac8e82bcfa9d14934150389fb6b561369835a155",
+				"KeyExpiry":  "2026-11-08T22:06:42Z",
+				"DiscoKey":   "discokey:820710e9c0504871a5728473bfd1f00a63dc052f65d8abfedf768c4ae8a88b51",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53487",
+					"10.65.0.27:53487",
+					"172.17.0.1:53487",
+					"172.18.0.1:53487",
+					"172.19.0.1:53487"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:06:42.77529914Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4102409940318928": {
+				"ID":          4102409940318928,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6546445728991847,
+				"StableID":   "nJ6cpe2u7t11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:eac53cd48b9acee0c69497885405a2c8fcad770e92c94f782b38f05fc7001534",
+				"KeyExpiry":  "2026-11-08T22:06:41Z",
+				"DiscoKey":   "discokey:feddaa658dcbb026b1c5167c93df0f5f0ebecc7c6223e6590609fd3faf983f56",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45216",
+					"10.65.0.27:45216",
+					"172.17.0.1:45216",
+					"172.18.0.1:45216",
+					"172.19.0.1:45216"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:06:41.723762697Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:eac53cd48b9acee0c69497885405a2c8fcad770e92c94f782b38f05fc7001534",
+			"MachineKey": "mkey:497d7b32817c760df47a543f653f58fde02ac9c001e93d4a1c865eeb2608f811",
+			"Peers": [{
+				"ID":         6920934748798951,
+				"StableID":   "npDB8mDW3w11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47b5c769dd653aaee4c253cc9cfc9143ecc58c16a3994a7e225f622ba5ba5613",
+				"DiscoKey":   "discokey:f3b7ddd2b297f111b52e9427c466f88576714932ff66550d58498820dc6ea853",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36670",
+					"10.65.0.27:36670",
+					"172.17.0.1:36670",
+					"172.18.0.1:36670",
+					"172.19.0.1:36670"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:06:35.256583687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3756436047208366,
+				"StableID":   "nqUVBuCJLW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35b9d3bbc656d9d7c59fa0d07895215c29aa5b248d52ef8fa366d823acee5e49",
+				"DiscoKey":   "discokey:d3022a1cc96b5e1fb798214fa7ca314666eb1cc9887204a8345adada9d768073",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42483",
+					"10.65.0.27:42483",
+					"172.17.0.1:42483",
+					"172.18.0.1:42483",
+					"172.19.0.1:42483"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:06:35.754995318Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4289665011511728,
+				"StableID":   "nRjNo6EoVa11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:710ebdf3d8b4cead87a1ed6724867e0e84f5cfb0b96dab89a17327f30a754b53",
+				"DiscoKey":   "discokey:0c189f19ed58a97593d96d99f8ab56b8762a8d5da49cad5c305f6157ea6a6620",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43290",
+					"10.65.0.27:43290",
+					"172.17.0.1:43290",
+					"172.18.0.1:43290",
+					"172.19.0.1:43290"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:06:36.287335379Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4004681398849003,
+				"StableID":   "nz46qzBjGY11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e14460ac6291b183f9aa98f31facc6334c11019c410a8558137eefd5838f855d",
+				"DiscoKey":   "discokey:2ec4af07745a3aa3acd3828b46d03668306af388c2f8f56067a106aff966fd4b",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45473",
+					"10.65.0.27:45473",
+					"172.17.0.1:45473",
+					"172.18.0.1:45473",
+					"172.19.0.1:45473"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:06:36.821069681Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         476329778022449,
+				"StableID":   "nQpQNnNji411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:52f85530f1faa72939b3a61a59e3de9d765a4aca4903e18d3e548657ad749379",
+				"DiscoKey":   "discokey:104e8eaa08339f2553f6c4708246f349fee2ffc928153b34970c4d1c44b6817c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37698",
+					"10.65.0.27:37698",
+					"172.17.0.1:37698",
+					"172.18.0.1:37698",
+					"172.19.0.1:37698"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:06:37.365396211Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2225880377551186,
+				"StableID":   "nZA7oy67PJ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:328e25da6d4b697b30d4c4375fc73c7c49a735f45ba30c1fb7b1a32ae28d075d",
+				"DiscoKey":   "discokey:a02335e58bd97307a2191f6f43645f675bfd349ff2b2d2a62f4f1695fb183061",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54634",
+					"10.65.0.27:54634",
+					"172.17.0.1:54634",
+					"172.18.0.1:54634",
+					"172.19.0.1:54634"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:06:37.898840526Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2220245363657152,
+				"StableID":   "nTQyug5ZLJ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:848d600d93e3239865f9872af7c7738a212df831fe0ac675e3fd508320539009",
+				"DiscoKey":   "discokey:8bd7f58c123b752f1c8ddadebba0572e6143f251e0eec3c3101c0ce0630aa452",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33155",
+					"10.65.0.27:33155",
+					"172.17.0.1:33155",
+					"172.18.0.1:33155",
+					"172.19.0.1:33155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:06:38.449831012Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4102409940318928,
+				"StableID":   "njpDPTMz2Z11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6010b1f69fc4da53dc443f5bd9ef3289731c462fc12bf6fea0b64df9063c1b30",
+				"DiscoKey":   "discokey:8409725db66a333aa2f93902bbe7c6382b3b72ac48d088c393da06af91550d62",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52423",
+					"10.65.0.27:52423",
+					"172.17.0.1:52423",
+					"172.18.0.1:52423",
+					"172.19.0.1:52423"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:06:38.988365023Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4111732804383497,
+				"StableID":   "nkWSxQFD7Z11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1f6f715801e9aa93bd52f145db297b081c2be81795118c0049b38e6108af1244",
+				"DiscoKey":   "discokey:653df946a29ac9f953bf0a032c638a04d774889e2dadf7ba4906682ee9315a15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:58525",
+					"10.65.0.27:58525",
+					"172.17.0.1:58525",
+					"172.18.0.1:58525",
+					"172.19.0.1:58525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:06:39.52882574Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1600586859876637,
+				"StableID":   "nrXbrkhuVD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ac434d4fb2f7f55c9aa69fc1371f33157dbef9c9bb0598cad19cfa91574c3017",
+				"DiscoKey":   "discokey:9e54597fd5eeac09ed07fd2f413af2a429c92012bb22959f8432762caf88d125",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42399",
+					"10.65.0.27:42399",
+					"172.17.0.1:42399",
+					"172.18.0.1:42399",
+					"172.19.0.1:42399"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:06:40.084901196Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3019688698704079,
+				"StableID":   "ncKFst6daQ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc3644ae4554545c5de9652d1a99649400b9e9ea90631fac2899ceacb4057a1e",
+				"DiscoKey":   "discokey:a418501fe1969a9097e17983e2108682fcf51341e719285196952a116623e730",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35727",
+					"10.65.0.27:35727",
+					"172.17.0.1:35727",
+					"172.18.0.1:35727",
+					"172.19.0.1:35727"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:06:40.61810035Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5933888869717837,
+				"StableID":   "naRcmWCULo11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f459cd8dde23f16d569790ae160faeee9a4fa217fb37570369d2947db01d227e",
+				"DiscoKey":   "discokey:fcc5b81a3a8c48487013c39d23e4225e815a0d2b4861bc0748e6b39562be667b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48785",
+					"10.65.0.27:48785",
+					"172.17.0.1:48785",
+					"172.18.0.1:48785",
+					"172.19.0.1:48785"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:06:41.158510677Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         570529030803432,
+				"StableID":   "nPvVm9qPT511CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:501505a8b4781b7e1fff7722ef605788844c865265aa9e95f97229aa7ed7183a",
+				"KeyExpiry":  "2026-11-08T22:06:42Z",
+				"DiscoKey":   "discokey:947371d1d082da93055afe4a5fd223fcf501e00557746e0036587f3a9b4a0f7c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58615",
+					"10.65.0.27:58615",
+					"172.17.0.1:58615",
+					"172.18.0.1:58615",
+					"172.19.0.1:58615"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:06:42.246474856Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5898241027042958,
+				"StableID":   "nVNyypnK4o11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8bb47b6c7782b9d8e24c6d36ac8e82bcfa9d14934150389fb6b561369835a155",
+				"KeyExpiry":  "2026-11-08T22:06:42Z",
+				"DiscoKey":   "discokey:820710e9c0504871a5728473bfd1f00a63dc052f65d8abfedf768c4ae8a88b51",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53487",
+					"10.65.0.27:53487",
+					"172.17.0.1:53487",
+					"172.18.0.1:53487",
+					"172.19.0.1:53487"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:06:42.77529914Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3019688698704079,
+				"StableID":   "ncKFst6daQ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       3019688698704079,
+				"Key":        "nodekey:dc3644ae4554545c5de9652d1a99649400b9e9ea90631fac2899ceacb4057a1e",
+				"DiscoKey":   "discokey:a418501fe1969a9097e17983e2108682fcf51341e719285196952a116623e730",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35727",
+					"10.65.0.27:35727",
+					"172.17.0.1:35727",
+					"172.18.0.1:35727",
+					"172.19.0.1:35727"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:06:40.61810035Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:dc3644ae4554545c5de9652d1a99649400b9e9ea90631fac2899ceacb4057a1e",
+			"MachineKey": "mkey:1fa6197f0c3eaef49224c448b238b2c9e3801c02c7e5a6ca52ea069637bb882f",
+			"Peers": [{
+				"ID":         6920934748798951,
+				"StableID":   "npDB8mDW3w11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47b5c769dd653aaee4c253cc9cfc9143ecc58c16a3994a7e225f622ba5ba5613",
+				"DiscoKey":   "discokey:f3b7ddd2b297f111b52e9427c466f88576714932ff66550d58498820dc6ea853",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36670",
+					"10.65.0.27:36670",
+					"172.17.0.1:36670",
+					"172.18.0.1:36670",
+					"172.19.0.1:36670"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:06:35.256583687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3756436047208366,
+				"StableID":   "nqUVBuCJLW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35b9d3bbc656d9d7c59fa0d07895215c29aa5b248d52ef8fa366d823acee5e49",
+				"DiscoKey":   "discokey:d3022a1cc96b5e1fb798214fa7ca314666eb1cc9887204a8345adada9d768073",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42483",
+					"10.65.0.27:42483",
+					"172.17.0.1:42483",
+					"172.18.0.1:42483",
+					"172.19.0.1:42483"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:06:35.754995318Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4289665011511728,
+				"StableID":   "nRjNo6EoVa11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:710ebdf3d8b4cead87a1ed6724867e0e84f5cfb0b96dab89a17327f30a754b53",
+				"DiscoKey":   "discokey:0c189f19ed58a97593d96d99f8ab56b8762a8d5da49cad5c305f6157ea6a6620",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43290",
+					"10.65.0.27:43290",
+					"172.17.0.1:43290",
+					"172.18.0.1:43290",
+					"172.19.0.1:43290"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:06:36.287335379Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4004681398849003,
+				"StableID":   "nz46qzBjGY11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e14460ac6291b183f9aa98f31facc6334c11019c410a8558137eefd5838f855d",
+				"DiscoKey":   "discokey:2ec4af07745a3aa3acd3828b46d03668306af388c2f8f56067a106aff966fd4b",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45473",
+					"10.65.0.27:45473",
+					"172.17.0.1:45473",
+					"172.18.0.1:45473",
+					"172.19.0.1:45473"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:06:36.821069681Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         476329778022449,
+				"StableID":   "nQpQNnNji411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:52f85530f1faa72939b3a61a59e3de9d765a4aca4903e18d3e548657ad749379",
+				"DiscoKey":   "discokey:104e8eaa08339f2553f6c4708246f349fee2ffc928153b34970c4d1c44b6817c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37698",
+					"10.65.0.27:37698",
+					"172.17.0.1:37698",
+					"172.18.0.1:37698",
+					"172.19.0.1:37698"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:06:37.365396211Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2225880377551186,
+				"StableID":   "nZA7oy67PJ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:328e25da6d4b697b30d4c4375fc73c7c49a735f45ba30c1fb7b1a32ae28d075d",
+				"DiscoKey":   "discokey:a02335e58bd97307a2191f6f43645f675bfd349ff2b2d2a62f4f1695fb183061",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54634",
+					"10.65.0.27:54634",
+					"172.17.0.1:54634",
+					"172.18.0.1:54634",
+					"172.19.0.1:54634"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:06:37.898840526Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2220245363657152,
+				"StableID":   "nTQyug5ZLJ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:848d600d93e3239865f9872af7c7738a212df831fe0ac675e3fd508320539009",
+				"DiscoKey":   "discokey:8bd7f58c123b752f1c8ddadebba0572e6143f251e0eec3c3101c0ce0630aa452",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33155",
+					"10.65.0.27:33155",
+					"172.17.0.1:33155",
+					"172.18.0.1:33155",
+					"172.19.0.1:33155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:06:38.449831012Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4102409940318928,
+				"StableID":   "njpDPTMz2Z11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6010b1f69fc4da53dc443f5bd9ef3289731c462fc12bf6fea0b64df9063c1b30",
+				"DiscoKey":   "discokey:8409725db66a333aa2f93902bbe7c6382b3b72ac48d088c393da06af91550d62",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52423",
+					"10.65.0.27:52423",
+					"172.17.0.1:52423",
+					"172.18.0.1:52423",
+					"172.19.0.1:52423"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:06:38.988365023Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4111732804383497,
+				"StableID":   "nkWSxQFD7Z11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1f6f715801e9aa93bd52f145db297b081c2be81795118c0049b38e6108af1244",
+				"DiscoKey":   "discokey:653df946a29ac9f953bf0a032c638a04d774889e2dadf7ba4906682ee9315a15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:58525",
+					"10.65.0.27:58525",
+					"172.17.0.1:58525",
+					"172.18.0.1:58525",
+					"172.19.0.1:58525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:06:39.52882574Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1600586859876637,
+				"StableID":   "nrXbrkhuVD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ac434d4fb2f7f55c9aa69fc1371f33157dbef9c9bb0598cad19cfa91574c3017",
+				"DiscoKey":   "discokey:9e54597fd5eeac09ed07fd2f413af2a429c92012bb22959f8432762caf88d125",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42399",
+					"10.65.0.27:42399",
+					"172.17.0.1:42399",
+					"172.18.0.1:42399",
+					"172.19.0.1:42399"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:06:40.084901196Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5933888869717837,
+				"StableID":   "naRcmWCULo11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f459cd8dde23f16d569790ae160faeee9a4fa217fb37570369d2947db01d227e",
+				"DiscoKey":   "discokey:fcc5b81a3a8c48487013c39d23e4225e815a0d2b4861bc0748e6b39562be667b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48785",
+					"10.65.0.27:48785",
+					"172.17.0.1:48785",
+					"172.18.0.1:48785",
+					"172.19.0.1:48785"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:06:41.158510677Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6546445728991847,
+				"StableID":   "nJ6cpe2u7t11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:eac53cd48b9acee0c69497885405a2c8fcad770e92c94f782b38f05fc7001534",
+				"KeyExpiry":  "2026-11-08T22:06:41Z",
+				"DiscoKey":   "discokey:feddaa658dcbb026b1c5167c93df0f5f0ebecc7c6223e6590609fd3faf983f56",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45216",
+					"10.65.0.27:45216",
+					"172.17.0.1:45216",
+					"172.18.0.1:45216",
+					"172.19.0.1:45216"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:06:41.723762697Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         570529030803432,
+				"StableID":   "nPvVm9qPT511CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:501505a8b4781b7e1fff7722ef605788844c865265aa9e95f97229aa7ed7183a",
+				"KeyExpiry":  "2026-11-08T22:06:42Z",
+				"DiscoKey":   "discokey:947371d1d082da93055afe4a5fd223fcf501e00557746e0036587f3a9b4a0f7c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58615",
+					"10.65.0.27:58615",
+					"172.17.0.1:58615",
+					"172.18.0.1:58615",
+					"172.19.0.1:58615"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:06:42.246474856Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5898241027042958,
+				"StableID":   "nVNyypnK4o11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8bb47b6c7782b9d8e24c6d36ac8e82bcfa9d14934150389fb6b561369835a155",
+				"KeyExpiry":  "2026-11-08T22:06:42Z",
+				"DiscoKey":   "discokey:820710e9c0504871a5728473bfd1f00a63dc052f65d8abfedf768c4ae8a88b51",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53487",
+					"10.65.0.27:53487",
+					"172.17.0.1:53487",
+					"172.18.0.1:53487",
+					"172.19.0.1:53487"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:06:42.77529914Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3019688698704079": {
+				"ID":          3019688698704079,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3756436047208366,
+				"StableID":   "nqUVBuCJLW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       3756436047208366,
+				"Key":        "nodekey:35b9d3bbc656d9d7c59fa0d07895215c29aa5b248d52ef8fa366d823acee5e49",
+				"DiscoKey":   "discokey:d3022a1cc96b5e1fb798214fa7ca314666eb1cc9887204a8345adada9d768073",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42483",
+					"10.65.0.27:42483",
+					"172.17.0.1:42483",
+					"172.18.0.1:42483",
+					"172.19.0.1:42483"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:06:35.754995318Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:35b9d3bbc656d9d7c59fa0d07895215c29aa5b248d52ef8fa366d823acee5e49",
+			"MachineKey": "mkey:c0811d5809b50610279e82527a05d84f3c4dc7676be3fb6332bb89dff5ef370a",
+			"Peers": [{
+				"ID":         6920934748798951,
+				"StableID":   "npDB8mDW3w11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47b5c769dd653aaee4c253cc9cfc9143ecc58c16a3994a7e225f622ba5ba5613",
+				"DiscoKey":   "discokey:f3b7ddd2b297f111b52e9427c466f88576714932ff66550d58498820dc6ea853",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36670",
+					"10.65.0.27:36670",
+					"172.17.0.1:36670",
+					"172.18.0.1:36670",
+					"172.19.0.1:36670"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:06:35.256583687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4289665011511728,
+				"StableID":   "nRjNo6EoVa11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:710ebdf3d8b4cead87a1ed6724867e0e84f5cfb0b96dab89a17327f30a754b53",
+				"DiscoKey":   "discokey:0c189f19ed58a97593d96d99f8ab56b8762a8d5da49cad5c305f6157ea6a6620",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43290",
+					"10.65.0.27:43290",
+					"172.17.0.1:43290",
+					"172.18.0.1:43290",
+					"172.19.0.1:43290"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:06:36.287335379Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4004681398849003,
+				"StableID":   "nz46qzBjGY11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e14460ac6291b183f9aa98f31facc6334c11019c410a8558137eefd5838f855d",
+				"DiscoKey":   "discokey:2ec4af07745a3aa3acd3828b46d03668306af388c2f8f56067a106aff966fd4b",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45473",
+					"10.65.0.27:45473",
+					"172.17.0.1:45473",
+					"172.18.0.1:45473",
+					"172.19.0.1:45473"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:06:36.821069681Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         476329778022449,
+				"StableID":   "nQpQNnNji411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:52f85530f1faa72939b3a61a59e3de9d765a4aca4903e18d3e548657ad749379",
+				"DiscoKey":   "discokey:104e8eaa08339f2553f6c4708246f349fee2ffc928153b34970c4d1c44b6817c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37698",
+					"10.65.0.27:37698",
+					"172.17.0.1:37698",
+					"172.18.0.1:37698",
+					"172.19.0.1:37698"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:06:37.365396211Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2225880377551186,
+				"StableID":   "nZA7oy67PJ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:328e25da6d4b697b30d4c4375fc73c7c49a735f45ba30c1fb7b1a32ae28d075d",
+				"DiscoKey":   "discokey:a02335e58bd97307a2191f6f43645f675bfd349ff2b2d2a62f4f1695fb183061",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54634",
+					"10.65.0.27:54634",
+					"172.17.0.1:54634",
+					"172.18.0.1:54634",
+					"172.19.0.1:54634"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:06:37.898840526Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2220245363657152,
+				"StableID":   "nTQyug5ZLJ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:848d600d93e3239865f9872af7c7738a212df831fe0ac675e3fd508320539009",
+				"DiscoKey":   "discokey:8bd7f58c123b752f1c8ddadebba0572e6143f251e0eec3c3101c0ce0630aa452",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33155",
+					"10.65.0.27:33155",
+					"172.17.0.1:33155",
+					"172.18.0.1:33155",
+					"172.19.0.1:33155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:06:38.449831012Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4102409940318928,
+				"StableID":   "njpDPTMz2Z11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6010b1f69fc4da53dc443f5bd9ef3289731c462fc12bf6fea0b64df9063c1b30",
+				"DiscoKey":   "discokey:8409725db66a333aa2f93902bbe7c6382b3b72ac48d088c393da06af91550d62",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52423",
+					"10.65.0.27:52423",
+					"172.17.0.1:52423",
+					"172.18.0.1:52423",
+					"172.19.0.1:52423"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:06:38.988365023Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4111732804383497,
+				"StableID":   "nkWSxQFD7Z11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1f6f715801e9aa93bd52f145db297b081c2be81795118c0049b38e6108af1244",
+				"DiscoKey":   "discokey:653df946a29ac9f953bf0a032c638a04d774889e2dadf7ba4906682ee9315a15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:58525",
+					"10.65.0.27:58525",
+					"172.17.0.1:58525",
+					"172.18.0.1:58525",
+					"172.19.0.1:58525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:06:39.52882574Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1600586859876637,
+				"StableID":   "nrXbrkhuVD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ac434d4fb2f7f55c9aa69fc1371f33157dbef9c9bb0598cad19cfa91574c3017",
+				"DiscoKey":   "discokey:9e54597fd5eeac09ed07fd2f413af2a429c92012bb22959f8432762caf88d125",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42399",
+					"10.65.0.27:42399",
+					"172.17.0.1:42399",
+					"172.18.0.1:42399",
+					"172.19.0.1:42399"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:06:40.084901196Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3019688698704079,
+				"StableID":   "ncKFst6daQ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc3644ae4554545c5de9652d1a99649400b9e9ea90631fac2899ceacb4057a1e",
+				"DiscoKey":   "discokey:a418501fe1969a9097e17983e2108682fcf51341e719285196952a116623e730",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35727",
+					"10.65.0.27:35727",
+					"172.17.0.1:35727",
+					"172.18.0.1:35727",
+					"172.19.0.1:35727"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:06:40.61810035Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5933888869717837,
+				"StableID":   "naRcmWCULo11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f459cd8dde23f16d569790ae160faeee9a4fa217fb37570369d2947db01d227e",
+				"DiscoKey":   "discokey:fcc5b81a3a8c48487013c39d23e4225e815a0d2b4861bc0748e6b39562be667b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48785",
+					"10.65.0.27:48785",
+					"172.17.0.1:48785",
+					"172.18.0.1:48785",
+					"172.19.0.1:48785"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:06:41.158510677Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6546445728991847,
+				"StableID":   "nJ6cpe2u7t11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:eac53cd48b9acee0c69497885405a2c8fcad770e92c94f782b38f05fc7001534",
+				"KeyExpiry":  "2026-11-08T22:06:41Z",
+				"DiscoKey":   "discokey:feddaa658dcbb026b1c5167c93df0f5f0ebecc7c6223e6590609fd3faf983f56",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45216",
+					"10.65.0.27:45216",
+					"172.17.0.1:45216",
+					"172.18.0.1:45216",
+					"172.19.0.1:45216"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:06:41.723762697Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         570529030803432,
+				"StableID":   "nPvVm9qPT511CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:501505a8b4781b7e1fff7722ef605788844c865265aa9e95f97229aa7ed7183a",
+				"KeyExpiry":  "2026-11-08T22:06:42Z",
+				"DiscoKey":   "discokey:947371d1d082da93055afe4a5fd223fcf501e00557746e0036587f3a9b4a0f7c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58615",
+					"10.65.0.27:58615",
+					"172.17.0.1:58615",
+					"172.18.0.1:58615",
+					"172.19.0.1:58615"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:06:42.246474856Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5898241027042958,
+				"StableID":   "nVNyypnK4o11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8bb47b6c7782b9d8e24c6d36ac8e82bcfa9d14934150389fb6b561369835a155",
+				"KeyExpiry":  "2026-11-08T22:06:42Z",
+				"DiscoKey":   "discokey:820710e9c0504871a5728473bfd1f00a63dc052f65d8abfedf768c4ae8a88b51",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53487",
+					"10.65.0.27:53487",
+					"172.17.0.1:53487",
+					"172.18.0.1:53487",
+					"172.19.0.1:53487"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:06:42.77529914Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3756436047208366": {
+				"ID":          3756436047208366,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6920934748798951,
+				"StableID":   "npDB8mDW3w11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       6920934748798951,
+				"Key":        "nodekey:47b5c769dd653aaee4c253cc9cfc9143ecc58c16a3994a7e225f622ba5ba5613",
+				"DiscoKey":   "discokey:f3b7ddd2b297f111b52e9427c466f88576714932ff66550d58498820dc6ea853",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36670",
+					"10.65.0.27:36670",
+					"172.17.0.1:36670",
+					"172.18.0.1:36670",
+					"172.19.0.1:36670"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:06:35.256583687Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:47b5c769dd653aaee4c253cc9cfc9143ecc58c16a3994a7e225f622ba5ba5613",
+			"MachineKey": "mkey:6d255a1fba99880eb6691ffcb882632f1f1372ad46def7f4386550d9fc10a701",
+			"Peers": [{
+				"ID":         3756436047208366,
+				"StableID":   "nqUVBuCJLW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35b9d3bbc656d9d7c59fa0d07895215c29aa5b248d52ef8fa366d823acee5e49",
+				"DiscoKey":   "discokey:d3022a1cc96b5e1fb798214fa7ca314666eb1cc9887204a8345adada9d768073",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42483",
+					"10.65.0.27:42483",
+					"172.17.0.1:42483",
+					"172.18.0.1:42483",
+					"172.19.0.1:42483"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:06:35.754995318Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4289665011511728,
+				"StableID":   "nRjNo6EoVa11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:710ebdf3d8b4cead87a1ed6724867e0e84f5cfb0b96dab89a17327f30a754b53",
+				"DiscoKey":   "discokey:0c189f19ed58a97593d96d99f8ab56b8762a8d5da49cad5c305f6157ea6a6620",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43290",
+					"10.65.0.27:43290",
+					"172.17.0.1:43290",
+					"172.18.0.1:43290",
+					"172.19.0.1:43290"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:06:36.287335379Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4004681398849003,
+				"StableID":   "nz46qzBjGY11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e14460ac6291b183f9aa98f31facc6334c11019c410a8558137eefd5838f855d",
+				"DiscoKey":   "discokey:2ec4af07745a3aa3acd3828b46d03668306af388c2f8f56067a106aff966fd4b",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45473",
+					"10.65.0.27:45473",
+					"172.17.0.1:45473",
+					"172.18.0.1:45473",
+					"172.19.0.1:45473"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:06:36.821069681Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         476329778022449,
+				"StableID":   "nQpQNnNji411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:52f85530f1faa72939b3a61a59e3de9d765a4aca4903e18d3e548657ad749379",
+				"DiscoKey":   "discokey:104e8eaa08339f2553f6c4708246f349fee2ffc928153b34970c4d1c44b6817c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37698",
+					"10.65.0.27:37698",
+					"172.17.0.1:37698",
+					"172.18.0.1:37698",
+					"172.19.0.1:37698"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:06:37.365396211Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2225880377551186,
+				"StableID":   "nZA7oy67PJ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:328e25da6d4b697b30d4c4375fc73c7c49a735f45ba30c1fb7b1a32ae28d075d",
+				"DiscoKey":   "discokey:a02335e58bd97307a2191f6f43645f675bfd349ff2b2d2a62f4f1695fb183061",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54634",
+					"10.65.0.27:54634",
+					"172.17.0.1:54634",
+					"172.18.0.1:54634",
+					"172.19.0.1:54634"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:06:37.898840526Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2220245363657152,
+				"StableID":   "nTQyug5ZLJ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:848d600d93e3239865f9872af7c7738a212df831fe0ac675e3fd508320539009",
+				"DiscoKey":   "discokey:8bd7f58c123b752f1c8ddadebba0572e6143f251e0eec3c3101c0ce0630aa452",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33155",
+					"10.65.0.27:33155",
+					"172.17.0.1:33155",
+					"172.18.0.1:33155",
+					"172.19.0.1:33155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:06:38.449831012Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4102409940318928,
+				"StableID":   "njpDPTMz2Z11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6010b1f69fc4da53dc443f5bd9ef3289731c462fc12bf6fea0b64df9063c1b30",
+				"DiscoKey":   "discokey:8409725db66a333aa2f93902bbe7c6382b3b72ac48d088c393da06af91550d62",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52423",
+					"10.65.0.27:52423",
+					"172.17.0.1:52423",
+					"172.18.0.1:52423",
+					"172.19.0.1:52423"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:06:38.988365023Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4111732804383497,
+				"StableID":   "nkWSxQFD7Z11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1f6f715801e9aa93bd52f145db297b081c2be81795118c0049b38e6108af1244",
+				"DiscoKey":   "discokey:653df946a29ac9f953bf0a032c638a04d774889e2dadf7ba4906682ee9315a15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:58525",
+					"10.65.0.27:58525",
+					"172.17.0.1:58525",
+					"172.18.0.1:58525",
+					"172.19.0.1:58525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:06:39.52882574Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1600586859876637,
+				"StableID":   "nrXbrkhuVD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ac434d4fb2f7f55c9aa69fc1371f33157dbef9c9bb0598cad19cfa91574c3017",
+				"DiscoKey":   "discokey:9e54597fd5eeac09ed07fd2f413af2a429c92012bb22959f8432762caf88d125",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42399",
+					"10.65.0.27:42399",
+					"172.17.0.1:42399",
+					"172.18.0.1:42399",
+					"172.19.0.1:42399"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:06:40.084901196Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3019688698704079,
+				"StableID":   "ncKFst6daQ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc3644ae4554545c5de9652d1a99649400b9e9ea90631fac2899ceacb4057a1e",
+				"DiscoKey":   "discokey:a418501fe1969a9097e17983e2108682fcf51341e719285196952a116623e730",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35727",
+					"10.65.0.27:35727",
+					"172.17.0.1:35727",
+					"172.18.0.1:35727",
+					"172.19.0.1:35727"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:06:40.61810035Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5933888869717837,
+				"StableID":   "naRcmWCULo11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f459cd8dde23f16d569790ae160faeee9a4fa217fb37570369d2947db01d227e",
+				"DiscoKey":   "discokey:fcc5b81a3a8c48487013c39d23e4225e815a0d2b4861bc0748e6b39562be667b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48785",
+					"10.65.0.27:48785",
+					"172.17.0.1:48785",
+					"172.18.0.1:48785",
+					"172.19.0.1:48785"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:06:41.158510677Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6546445728991847,
+				"StableID":   "nJ6cpe2u7t11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:eac53cd48b9acee0c69497885405a2c8fcad770e92c94f782b38f05fc7001534",
+				"KeyExpiry":  "2026-11-08T22:06:41Z",
+				"DiscoKey":   "discokey:feddaa658dcbb026b1c5167c93df0f5f0ebecc7c6223e6590609fd3faf983f56",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45216",
+					"10.65.0.27:45216",
+					"172.17.0.1:45216",
+					"172.18.0.1:45216",
+					"172.19.0.1:45216"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:06:41.723762697Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         570529030803432,
+				"StableID":   "nPvVm9qPT511CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:501505a8b4781b7e1fff7722ef605788844c865265aa9e95f97229aa7ed7183a",
+				"KeyExpiry":  "2026-11-08T22:06:42Z",
+				"DiscoKey":   "discokey:947371d1d082da93055afe4a5fd223fcf501e00557746e0036587f3a9b4a0f7c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58615",
+					"10.65.0.27:58615",
+					"172.17.0.1:58615",
+					"172.18.0.1:58615",
+					"172.19.0.1:58615"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:06:42.246474856Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5898241027042958,
+				"StableID":   "nVNyypnK4o11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8bb47b6c7782b9d8e24c6d36ac8e82bcfa9d14934150389fb6b561369835a155",
+				"KeyExpiry":  "2026-11-08T22:06:42Z",
+				"DiscoKey":   "discokey:820710e9c0504871a5728473bfd1f00a63dc052f65d8abfedf768c4ae8a88b51",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53487",
+					"10.65.0.27:53487",
+					"172.17.0.1:53487",
+					"172.18.0.1:53487",
+					"172.19.0.1:53487"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:06:42.77529914Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6920934748798951": {
+				"ID":          6920934748798951,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         476329778022449,
+				"StableID":   "nQpQNnNji411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       476329778022449,
+				"Key":        "nodekey:52f85530f1faa72939b3a61a59e3de9d765a4aca4903e18d3e548657ad749379",
+				"DiscoKey":   "discokey:104e8eaa08339f2553f6c4708246f349fee2ffc928153b34970c4d1c44b6817c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37698",
+					"10.65.0.27:37698",
+					"172.17.0.1:37698",
+					"172.18.0.1:37698",
+					"172.19.0.1:37698"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:06:37.365396211Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:52f85530f1faa72939b3a61a59e3de9d765a4aca4903e18d3e548657ad749379",
+			"MachineKey": "mkey:fff1e02eef40b88a3843c77b64c509f8dbec39d82b9a5cc14162945613a87743",
+			"Peers": [{
+				"ID":         6920934748798951,
+				"StableID":   "npDB8mDW3w11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47b5c769dd653aaee4c253cc9cfc9143ecc58c16a3994a7e225f622ba5ba5613",
+				"DiscoKey":   "discokey:f3b7ddd2b297f111b52e9427c466f88576714932ff66550d58498820dc6ea853",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36670",
+					"10.65.0.27:36670",
+					"172.17.0.1:36670",
+					"172.18.0.1:36670",
+					"172.19.0.1:36670"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:06:35.256583687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3756436047208366,
+				"StableID":   "nqUVBuCJLW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35b9d3bbc656d9d7c59fa0d07895215c29aa5b248d52ef8fa366d823acee5e49",
+				"DiscoKey":   "discokey:d3022a1cc96b5e1fb798214fa7ca314666eb1cc9887204a8345adada9d768073",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42483",
+					"10.65.0.27:42483",
+					"172.17.0.1:42483",
+					"172.18.0.1:42483",
+					"172.19.0.1:42483"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:06:35.754995318Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4289665011511728,
+				"StableID":   "nRjNo6EoVa11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:710ebdf3d8b4cead87a1ed6724867e0e84f5cfb0b96dab89a17327f30a754b53",
+				"DiscoKey":   "discokey:0c189f19ed58a97593d96d99f8ab56b8762a8d5da49cad5c305f6157ea6a6620",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43290",
+					"10.65.0.27:43290",
+					"172.17.0.1:43290",
+					"172.18.0.1:43290",
+					"172.19.0.1:43290"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:06:36.287335379Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4004681398849003,
+				"StableID":   "nz46qzBjGY11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e14460ac6291b183f9aa98f31facc6334c11019c410a8558137eefd5838f855d",
+				"DiscoKey":   "discokey:2ec4af07745a3aa3acd3828b46d03668306af388c2f8f56067a106aff966fd4b",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45473",
+					"10.65.0.27:45473",
+					"172.17.0.1:45473",
+					"172.18.0.1:45473",
+					"172.19.0.1:45473"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:06:36.821069681Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2225880377551186,
+				"StableID":   "nZA7oy67PJ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:328e25da6d4b697b30d4c4375fc73c7c49a735f45ba30c1fb7b1a32ae28d075d",
+				"DiscoKey":   "discokey:a02335e58bd97307a2191f6f43645f675bfd349ff2b2d2a62f4f1695fb183061",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54634",
+					"10.65.0.27:54634",
+					"172.17.0.1:54634",
+					"172.18.0.1:54634",
+					"172.19.0.1:54634"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:06:37.898840526Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2220245363657152,
+				"StableID":   "nTQyug5ZLJ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:848d600d93e3239865f9872af7c7738a212df831fe0ac675e3fd508320539009",
+				"DiscoKey":   "discokey:8bd7f58c123b752f1c8ddadebba0572e6143f251e0eec3c3101c0ce0630aa452",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33155",
+					"10.65.0.27:33155",
+					"172.17.0.1:33155",
+					"172.18.0.1:33155",
+					"172.19.0.1:33155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:06:38.449831012Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4102409940318928,
+				"StableID":   "njpDPTMz2Z11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6010b1f69fc4da53dc443f5bd9ef3289731c462fc12bf6fea0b64df9063c1b30",
+				"DiscoKey":   "discokey:8409725db66a333aa2f93902bbe7c6382b3b72ac48d088c393da06af91550d62",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52423",
+					"10.65.0.27:52423",
+					"172.17.0.1:52423",
+					"172.18.0.1:52423",
+					"172.19.0.1:52423"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:06:38.988365023Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4111732804383497,
+				"StableID":   "nkWSxQFD7Z11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1f6f715801e9aa93bd52f145db297b081c2be81795118c0049b38e6108af1244",
+				"DiscoKey":   "discokey:653df946a29ac9f953bf0a032c638a04d774889e2dadf7ba4906682ee9315a15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:58525",
+					"10.65.0.27:58525",
+					"172.17.0.1:58525",
+					"172.18.0.1:58525",
+					"172.19.0.1:58525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:06:39.52882574Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1600586859876637,
+				"StableID":   "nrXbrkhuVD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ac434d4fb2f7f55c9aa69fc1371f33157dbef9c9bb0598cad19cfa91574c3017",
+				"DiscoKey":   "discokey:9e54597fd5eeac09ed07fd2f413af2a429c92012bb22959f8432762caf88d125",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42399",
+					"10.65.0.27:42399",
+					"172.17.0.1:42399",
+					"172.18.0.1:42399",
+					"172.19.0.1:42399"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:06:40.084901196Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3019688698704079,
+				"StableID":   "ncKFst6daQ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc3644ae4554545c5de9652d1a99649400b9e9ea90631fac2899ceacb4057a1e",
+				"DiscoKey":   "discokey:a418501fe1969a9097e17983e2108682fcf51341e719285196952a116623e730",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35727",
+					"10.65.0.27:35727",
+					"172.17.0.1:35727",
+					"172.18.0.1:35727",
+					"172.19.0.1:35727"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:06:40.61810035Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5933888869717837,
+				"StableID":   "naRcmWCULo11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f459cd8dde23f16d569790ae160faeee9a4fa217fb37570369d2947db01d227e",
+				"DiscoKey":   "discokey:fcc5b81a3a8c48487013c39d23e4225e815a0d2b4861bc0748e6b39562be667b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48785",
+					"10.65.0.27:48785",
+					"172.17.0.1:48785",
+					"172.18.0.1:48785",
+					"172.19.0.1:48785"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:06:41.158510677Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6546445728991847,
+				"StableID":   "nJ6cpe2u7t11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:eac53cd48b9acee0c69497885405a2c8fcad770e92c94f782b38f05fc7001534",
+				"KeyExpiry":  "2026-11-08T22:06:41Z",
+				"DiscoKey":   "discokey:feddaa658dcbb026b1c5167c93df0f5f0ebecc7c6223e6590609fd3faf983f56",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45216",
+					"10.65.0.27:45216",
+					"172.17.0.1:45216",
+					"172.18.0.1:45216",
+					"172.19.0.1:45216"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:06:41.723762697Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         570529030803432,
+				"StableID":   "nPvVm9qPT511CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:501505a8b4781b7e1fff7722ef605788844c865265aa9e95f97229aa7ed7183a",
+				"KeyExpiry":  "2026-11-08T22:06:42Z",
+				"DiscoKey":   "discokey:947371d1d082da93055afe4a5fd223fcf501e00557746e0036587f3a9b4a0f7c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58615",
+					"10.65.0.27:58615",
+					"172.17.0.1:58615",
+					"172.18.0.1:58615",
+					"172.19.0.1:58615"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:06:42.246474856Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5898241027042958,
+				"StableID":   "nVNyypnK4o11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8bb47b6c7782b9d8e24c6d36ac8e82bcfa9d14934150389fb6b561369835a155",
+				"KeyExpiry":  "2026-11-08T22:06:42Z",
+				"DiscoKey":   "discokey:820710e9c0504871a5728473bfd1f00a63dc052f65d8abfedf768c4ae8a88b51",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53487",
+					"10.65.0.27:53487",
+					"172.17.0.1:53487",
+					"172.18.0.1:53487",
+					"172.19.0.1:53487"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:06:42.77529914Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "476329778022449": {
+				"ID":          476329778022449,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4004681398849003,
+				"StableID":   "nz46qzBjGY11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       4004681398849003,
+				"Key":        "nodekey:e14460ac6291b183f9aa98f31facc6334c11019c410a8558137eefd5838f855d",
+				"DiscoKey":   "discokey:2ec4af07745a3aa3acd3828b46d03668306af388c2f8f56067a106aff966fd4b",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45473",
+					"10.65.0.27:45473",
+					"172.17.0.1:45473",
+					"172.18.0.1:45473",
+					"172.19.0.1:45473"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:06:36.821069681Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e14460ac6291b183f9aa98f31facc6334c11019c410a8558137eefd5838f855d",
+			"MachineKey": "mkey:3ee10c28939522c345125dcbd9fd2800dc3af2e4312c8d514e42bc16c0f82256",
+			"Peers": [{
+				"ID":         6920934748798951,
+				"StableID":   "npDB8mDW3w11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47b5c769dd653aaee4c253cc9cfc9143ecc58c16a3994a7e225f622ba5ba5613",
+				"DiscoKey":   "discokey:f3b7ddd2b297f111b52e9427c466f88576714932ff66550d58498820dc6ea853",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36670",
+					"10.65.0.27:36670",
+					"172.17.0.1:36670",
+					"172.18.0.1:36670",
+					"172.19.0.1:36670"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:06:35.256583687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3756436047208366,
+				"StableID":   "nqUVBuCJLW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35b9d3bbc656d9d7c59fa0d07895215c29aa5b248d52ef8fa366d823acee5e49",
+				"DiscoKey":   "discokey:d3022a1cc96b5e1fb798214fa7ca314666eb1cc9887204a8345adada9d768073",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42483",
+					"10.65.0.27:42483",
+					"172.17.0.1:42483",
+					"172.18.0.1:42483",
+					"172.19.0.1:42483"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:06:35.754995318Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4289665011511728,
+				"StableID":   "nRjNo6EoVa11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:710ebdf3d8b4cead87a1ed6724867e0e84f5cfb0b96dab89a17327f30a754b53",
+				"DiscoKey":   "discokey:0c189f19ed58a97593d96d99f8ab56b8762a8d5da49cad5c305f6157ea6a6620",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43290",
+					"10.65.0.27:43290",
+					"172.17.0.1:43290",
+					"172.18.0.1:43290",
+					"172.19.0.1:43290"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:06:36.287335379Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         476329778022449,
+				"StableID":   "nQpQNnNji411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:52f85530f1faa72939b3a61a59e3de9d765a4aca4903e18d3e548657ad749379",
+				"DiscoKey":   "discokey:104e8eaa08339f2553f6c4708246f349fee2ffc928153b34970c4d1c44b6817c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37698",
+					"10.65.0.27:37698",
+					"172.17.0.1:37698",
+					"172.18.0.1:37698",
+					"172.19.0.1:37698"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:06:37.365396211Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2225880377551186,
+				"StableID":   "nZA7oy67PJ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:328e25da6d4b697b30d4c4375fc73c7c49a735f45ba30c1fb7b1a32ae28d075d",
+				"DiscoKey":   "discokey:a02335e58bd97307a2191f6f43645f675bfd349ff2b2d2a62f4f1695fb183061",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54634",
+					"10.65.0.27:54634",
+					"172.17.0.1:54634",
+					"172.18.0.1:54634",
+					"172.19.0.1:54634"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:06:37.898840526Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2220245363657152,
+				"StableID":   "nTQyug5ZLJ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:848d600d93e3239865f9872af7c7738a212df831fe0ac675e3fd508320539009",
+				"DiscoKey":   "discokey:8bd7f58c123b752f1c8ddadebba0572e6143f251e0eec3c3101c0ce0630aa452",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33155",
+					"10.65.0.27:33155",
+					"172.17.0.1:33155",
+					"172.18.0.1:33155",
+					"172.19.0.1:33155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:06:38.449831012Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4102409940318928,
+				"StableID":   "njpDPTMz2Z11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6010b1f69fc4da53dc443f5bd9ef3289731c462fc12bf6fea0b64df9063c1b30",
+				"DiscoKey":   "discokey:8409725db66a333aa2f93902bbe7c6382b3b72ac48d088c393da06af91550d62",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52423",
+					"10.65.0.27:52423",
+					"172.17.0.1:52423",
+					"172.18.0.1:52423",
+					"172.19.0.1:52423"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:06:38.988365023Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4111732804383497,
+				"StableID":   "nkWSxQFD7Z11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1f6f715801e9aa93bd52f145db297b081c2be81795118c0049b38e6108af1244",
+				"DiscoKey":   "discokey:653df946a29ac9f953bf0a032c638a04d774889e2dadf7ba4906682ee9315a15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:58525",
+					"10.65.0.27:58525",
+					"172.17.0.1:58525",
+					"172.18.0.1:58525",
+					"172.19.0.1:58525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:06:39.52882574Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1600586859876637,
+				"StableID":   "nrXbrkhuVD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ac434d4fb2f7f55c9aa69fc1371f33157dbef9c9bb0598cad19cfa91574c3017",
+				"DiscoKey":   "discokey:9e54597fd5eeac09ed07fd2f413af2a429c92012bb22959f8432762caf88d125",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42399",
+					"10.65.0.27:42399",
+					"172.17.0.1:42399",
+					"172.18.0.1:42399",
+					"172.19.0.1:42399"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:06:40.084901196Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3019688698704079,
+				"StableID":   "ncKFst6daQ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc3644ae4554545c5de9652d1a99649400b9e9ea90631fac2899ceacb4057a1e",
+				"DiscoKey":   "discokey:a418501fe1969a9097e17983e2108682fcf51341e719285196952a116623e730",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35727",
+					"10.65.0.27:35727",
+					"172.17.0.1:35727",
+					"172.18.0.1:35727",
+					"172.19.0.1:35727"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:06:40.61810035Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5933888869717837,
+				"StableID":   "naRcmWCULo11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f459cd8dde23f16d569790ae160faeee9a4fa217fb37570369d2947db01d227e",
+				"DiscoKey":   "discokey:fcc5b81a3a8c48487013c39d23e4225e815a0d2b4861bc0748e6b39562be667b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48785",
+					"10.65.0.27:48785",
+					"172.17.0.1:48785",
+					"172.18.0.1:48785",
+					"172.19.0.1:48785"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:06:41.158510677Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6546445728991847,
+				"StableID":   "nJ6cpe2u7t11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:eac53cd48b9acee0c69497885405a2c8fcad770e92c94f782b38f05fc7001534",
+				"KeyExpiry":  "2026-11-08T22:06:41Z",
+				"DiscoKey":   "discokey:feddaa658dcbb026b1c5167c93df0f5f0ebecc7c6223e6590609fd3faf983f56",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45216",
+					"10.65.0.27:45216",
+					"172.17.0.1:45216",
+					"172.18.0.1:45216",
+					"172.19.0.1:45216"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:06:41.723762697Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         570529030803432,
+				"StableID":   "nPvVm9qPT511CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:501505a8b4781b7e1fff7722ef605788844c865265aa9e95f97229aa7ed7183a",
+				"KeyExpiry":  "2026-11-08T22:06:42Z",
+				"DiscoKey":   "discokey:947371d1d082da93055afe4a5fd223fcf501e00557746e0036587f3a9b4a0f7c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58615",
+					"10.65.0.27:58615",
+					"172.17.0.1:58615",
+					"172.18.0.1:58615",
+					"172.19.0.1:58615"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:06:42.246474856Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5898241027042958,
+				"StableID":   "nVNyypnK4o11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8bb47b6c7782b9d8e24c6d36ac8e82bcfa9d14934150389fb6b561369835a155",
+				"KeyExpiry":  "2026-11-08T22:06:42Z",
+				"DiscoKey":   "discokey:820710e9c0504871a5728473bfd1f00a63dc052f65d8abfedf768c4ae8a88b51",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53487",
+					"10.65.0.27:53487",
+					"172.17.0.1:53487",
+					"172.18.0.1:53487",
+					"172.19.0.1:53487"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:06:42.77529914Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4004681398849003": {
+				"ID":          4004681398849003,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2220245363657152,
+				"StableID":   "nTQyug5ZLJ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       2220245363657152,
+				"Key":        "nodekey:848d600d93e3239865f9872af7c7738a212df831fe0ac675e3fd508320539009",
+				"DiscoKey":   "discokey:8bd7f58c123b752f1c8ddadebba0572e6143f251e0eec3c3101c0ce0630aa452",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33155",
+					"10.65.0.27:33155",
+					"172.17.0.1:33155",
+					"172.18.0.1:33155",
+					"172.19.0.1:33155"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:06:38.449831012Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:848d600d93e3239865f9872af7c7738a212df831fe0ac675e3fd508320539009",
+			"MachineKey": "mkey:0f9bef0fae0579b0042f226015055118915b88d7db37ac9bc357402963a4101c",
+			"Peers": [{
+				"ID":         6920934748798951,
+				"StableID":   "npDB8mDW3w11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47b5c769dd653aaee4c253cc9cfc9143ecc58c16a3994a7e225f622ba5ba5613",
+				"DiscoKey":   "discokey:f3b7ddd2b297f111b52e9427c466f88576714932ff66550d58498820dc6ea853",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36670",
+					"10.65.0.27:36670",
+					"172.17.0.1:36670",
+					"172.18.0.1:36670",
+					"172.19.0.1:36670"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:06:35.256583687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3756436047208366,
+				"StableID":   "nqUVBuCJLW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35b9d3bbc656d9d7c59fa0d07895215c29aa5b248d52ef8fa366d823acee5e49",
+				"DiscoKey":   "discokey:d3022a1cc96b5e1fb798214fa7ca314666eb1cc9887204a8345adada9d768073",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42483",
+					"10.65.0.27:42483",
+					"172.17.0.1:42483",
+					"172.18.0.1:42483",
+					"172.19.0.1:42483"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:06:35.754995318Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4289665011511728,
+				"StableID":   "nRjNo6EoVa11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:710ebdf3d8b4cead87a1ed6724867e0e84f5cfb0b96dab89a17327f30a754b53",
+				"DiscoKey":   "discokey:0c189f19ed58a97593d96d99f8ab56b8762a8d5da49cad5c305f6157ea6a6620",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43290",
+					"10.65.0.27:43290",
+					"172.17.0.1:43290",
+					"172.18.0.1:43290",
+					"172.19.0.1:43290"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:06:36.287335379Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4004681398849003,
+				"StableID":   "nz46qzBjGY11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e14460ac6291b183f9aa98f31facc6334c11019c410a8558137eefd5838f855d",
+				"DiscoKey":   "discokey:2ec4af07745a3aa3acd3828b46d03668306af388c2f8f56067a106aff966fd4b",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45473",
+					"10.65.0.27:45473",
+					"172.17.0.1:45473",
+					"172.18.0.1:45473",
+					"172.19.0.1:45473"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:06:36.821069681Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         476329778022449,
+				"StableID":   "nQpQNnNji411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:52f85530f1faa72939b3a61a59e3de9d765a4aca4903e18d3e548657ad749379",
+				"DiscoKey":   "discokey:104e8eaa08339f2553f6c4708246f349fee2ffc928153b34970c4d1c44b6817c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37698",
+					"10.65.0.27:37698",
+					"172.17.0.1:37698",
+					"172.18.0.1:37698",
+					"172.19.0.1:37698"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:06:37.365396211Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2225880377551186,
+				"StableID":   "nZA7oy67PJ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:328e25da6d4b697b30d4c4375fc73c7c49a735f45ba30c1fb7b1a32ae28d075d",
+				"DiscoKey":   "discokey:a02335e58bd97307a2191f6f43645f675bfd349ff2b2d2a62f4f1695fb183061",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54634",
+					"10.65.0.27:54634",
+					"172.17.0.1:54634",
+					"172.18.0.1:54634",
+					"172.19.0.1:54634"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:06:37.898840526Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4102409940318928,
+				"StableID":   "njpDPTMz2Z11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6010b1f69fc4da53dc443f5bd9ef3289731c462fc12bf6fea0b64df9063c1b30",
+				"DiscoKey":   "discokey:8409725db66a333aa2f93902bbe7c6382b3b72ac48d088c393da06af91550d62",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52423",
+					"10.65.0.27:52423",
+					"172.17.0.1:52423",
+					"172.18.0.1:52423",
+					"172.19.0.1:52423"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:06:38.988365023Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4111732804383497,
+				"StableID":   "nkWSxQFD7Z11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1f6f715801e9aa93bd52f145db297b081c2be81795118c0049b38e6108af1244",
+				"DiscoKey":   "discokey:653df946a29ac9f953bf0a032c638a04d774889e2dadf7ba4906682ee9315a15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:58525",
+					"10.65.0.27:58525",
+					"172.17.0.1:58525",
+					"172.18.0.1:58525",
+					"172.19.0.1:58525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:06:39.52882574Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1600586859876637,
+				"StableID":   "nrXbrkhuVD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ac434d4fb2f7f55c9aa69fc1371f33157dbef9c9bb0598cad19cfa91574c3017",
+				"DiscoKey":   "discokey:9e54597fd5eeac09ed07fd2f413af2a429c92012bb22959f8432762caf88d125",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42399",
+					"10.65.0.27:42399",
+					"172.17.0.1:42399",
+					"172.18.0.1:42399",
+					"172.19.0.1:42399"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:06:40.084901196Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3019688698704079,
+				"StableID":   "ncKFst6daQ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc3644ae4554545c5de9652d1a99649400b9e9ea90631fac2899ceacb4057a1e",
+				"DiscoKey":   "discokey:a418501fe1969a9097e17983e2108682fcf51341e719285196952a116623e730",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35727",
+					"10.65.0.27:35727",
+					"172.17.0.1:35727",
+					"172.18.0.1:35727",
+					"172.19.0.1:35727"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:06:40.61810035Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5933888869717837,
+				"StableID":   "naRcmWCULo11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f459cd8dde23f16d569790ae160faeee9a4fa217fb37570369d2947db01d227e",
+				"DiscoKey":   "discokey:fcc5b81a3a8c48487013c39d23e4225e815a0d2b4861bc0748e6b39562be667b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48785",
+					"10.65.0.27:48785",
+					"172.17.0.1:48785",
+					"172.18.0.1:48785",
+					"172.19.0.1:48785"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:06:41.158510677Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6546445728991847,
+				"StableID":   "nJ6cpe2u7t11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:eac53cd48b9acee0c69497885405a2c8fcad770e92c94f782b38f05fc7001534",
+				"KeyExpiry":  "2026-11-08T22:06:41Z",
+				"DiscoKey":   "discokey:feddaa658dcbb026b1c5167c93df0f5f0ebecc7c6223e6590609fd3faf983f56",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45216",
+					"10.65.0.27:45216",
+					"172.17.0.1:45216",
+					"172.18.0.1:45216",
+					"172.19.0.1:45216"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:06:41.723762697Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         570529030803432,
+				"StableID":   "nPvVm9qPT511CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:501505a8b4781b7e1fff7722ef605788844c865265aa9e95f97229aa7ed7183a",
+				"KeyExpiry":  "2026-11-08T22:06:42Z",
+				"DiscoKey":   "discokey:947371d1d082da93055afe4a5fd223fcf501e00557746e0036587f3a9b4a0f7c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58615",
+					"10.65.0.27:58615",
+					"172.17.0.1:58615",
+					"172.18.0.1:58615",
+					"172.19.0.1:58615"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:06:42.246474856Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5898241027042958,
+				"StableID":   "nVNyypnK4o11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8bb47b6c7782b9d8e24c6d36ac8e82bcfa9d14934150389fb6b561369835a155",
+				"KeyExpiry":  "2026-11-08T22:06:42Z",
+				"DiscoKey":   "discokey:820710e9c0504871a5728473bfd1f00a63dc052f65d8abfedf768c4ae8a88b51",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53487",
+					"10.65.0.27:53487",
+					"172.17.0.1:53487",
+					"172.18.0.1:53487",
+					"172.19.0.1:53487"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:06:42.77529914Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2220245363657152": {
+				"ID":          2220245363657152,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4111732804383497,
+				"StableID":   "nkWSxQFD7Z11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       4111732804383497,
+				"Key":        "nodekey:1f6f715801e9aa93bd52f145db297b081c2be81795118c0049b38e6108af1244",
+				"DiscoKey":   "discokey:653df946a29ac9f953bf0a032c638a04d774889e2dadf7ba4906682ee9315a15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:58525",
+					"10.65.0.27:58525",
+					"172.17.0.1:58525",
+					"172.18.0.1:58525",
+					"172.19.0.1:58525"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:06:39.52882574Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1f6f715801e9aa93bd52f145db297b081c2be81795118c0049b38e6108af1244",
+			"MachineKey": "mkey:5afd831d46e73fc6b81cae18c44f7e49091769c3abf138b30bd8c0dd1cc23f69",
+			"Peers": [{
+				"ID":         6920934748798951,
+				"StableID":   "npDB8mDW3w11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47b5c769dd653aaee4c253cc9cfc9143ecc58c16a3994a7e225f622ba5ba5613",
+				"DiscoKey":   "discokey:f3b7ddd2b297f111b52e9427c466f88576714932ff66550d58498820dc6ea853",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36670",
+					"10.65.0.27:36670",
+					"172.17.0.1:36670",
+					"172.18.0.1:36670",
+					"172.19.0.1:36670"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:06:35.256583687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3756436047208366,
+				"StableID":   "nqUVBuCJLW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35b9d3bbc656d9d7c59fa0d07895215c29aa5b248d52ef8fa366d823acee5e49",
+				"DiscoKey":   "discokey:d3022a1cc96b5e1fb798214fa7ca314666eb1cc9887204a8345adada9d768073",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42483",
+					"10.65.0.27:42483",
+					"172.17.0.1:42483",
+					"172.18.0.1:42483",
+					"172.19.0.1:42483"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:06:35.754995318Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4289665011511728,
+				"StableID":   "nRjNo6EoVa11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:710ebdf3d8b4cead87a1ed6724867e0e84f5cfb0b96dab89a17327f30a754b53",
+				"DiscoKey":   "discokey:0c189f19ed58a97593d96d99f8ab56b8762a8d5da49cad5c305f6157ea6a6620",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43290",
+					"10.65.0.27:43290",
+					"172.17.0.1:43290",
+					"172.18.0.1:43290",
+					"172.19.0.1:43290"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:06:36.287335379Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4004681398849003,
+				"StableID":   "nz46qzBjGY11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e14460ac6291b183f9aa98f31facc6334c11019c410a8558137eefd5838f855d",
+				"DiscoKey":   "discokey:2ec4af07745a3aa3acd3828b46d03668306af388c2f8f56067a106aff966fd4b",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45473",
+					"10.65.0.27:45473",
+					"172.17.0.1:45473",
+					"172.18.0.1:45473",
+					"172.19.0.1:45473"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:06:36.821069681Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         476329778022449,
+				"StableID":   "nQpQNnNji411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:52f85530f1faa72939b3a61a59e3de9d765a4aca4903e18d3e548657ad749379",
+				"DiscoKey":   "discokey:104e8eaa08339f2553f6c4708246f349fee2ffc928153b34970c4d1c44b6817c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37698",
+					"10.65.0.27:37698",
+					"172.17.0.1:37698",
+					"172.18.0.1:37698",
+					"172.19.0.1:37698"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:06:37.365396211Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2225880377551186,
+				"StableID":   "nZA7oy67PJ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:328e25da6d4b697b30d4c4375fc73c7c49a735f45ba30c1fb7b1a32ae28d075d",
+				"DiscoKey":   "discokey:a02335e58bd97307a2191f6f43645f675bfd349ff2b2d2a62f4f1695fb183061",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54634",
+					"10.65.0.27:54634",
+					"172.17.0.1:54634",
+					"172.18.0.1:54634",
+					"172.19.0.1:54634"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:06:37.898840526Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2220245363657152,
+				"StableID":   "nTQyug5ZLJ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:848d600d93e3239865f9872af7c7738a212df831fe0ac675e3fd508320539009",
+				"DiscoKey":   "discokey:8bd7f58c123b752f1c8ddadebba0572e6143f251e0eec3c3101c0ce0630aa452",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33155",
+					"10.65.0.27:33155",
+					"172.17.0.1:33155",
+					"172.18.0.1:33155",
+					"172.19.0.1:33155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:06:38.449831012Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4102409940318928,
+				"StableID":   "njpDPTMz2Z11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6010b1f69fc4da53dc443f5bd9ef3289731c462fc12bf6fea0b64df9063c1b30",
+				"DiscoKey":   "discokey:8409725db66a333aa2f93902bbe7c6382b3b72ac48d088c393da06af91550d62",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52423",
+					"10.65.0.27:52423",
+					"172.17.0.1:52423",
+					"172.18.0.1:52423",
+					"172.19.0.1:52423"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:06:38.988365023Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1600586859876637,
+				"StableID":   "nrXbrkhuVD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ac434d4fb2f7f55c9aa69fc1371f33157dbef9c9bb0598cad19cfa91574c3017",
+				"DiscoKey":   "discokey:9e54597fd5eeac09ed07fd2f413af2a429c92012bb22959f8432762caf88d125",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42399",
+					"10.65.0.27:42399",
+					"172.17.0.1:42399",
+					"172.18.0.1:42399",
+					"172.19.0.1:42399"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:06:40.084901196Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3019688698704079,
+				"StableID":   "ncKFst6daQ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc3644ae4554545c5de9652d1a99649400b9e9ea90631fac2899ceacb4057a1e",
+				"DiscoKey":   "discokey:a418501fe1969a9097e17983e2108682fcf51341e719285196952a116623e730",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35727",
+					"10.65.0.27:35727",
+					"172.17.0.1:35727",
+					"172.18.0.1:35727",
+					"172.19.0.1:35727"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:06:40.61810035Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5933888869717837,
+				"StableID":   "naRcmWCULo11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f459cd8dde23f16d569790ae160faeee9a4fa217fb37570369d2947db01d227e",
+				"DiscoKey":   "discokey:fcc5b81a3a8c48487013c39d23e4225e815a0d2b4861bc0748e6b39562be667b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48785",
+					"10.65.0.27:48785",
+					"172.17.0.1:48785",
+					"172.18.0.1:48785",
+					"172.19.0.1:48785"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:06:41.158510677Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6546445728991847,
+				"StableID":   "nJ6cpe2u7t11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:eac53cd48b9acee0c69497885405a2c8fcad770e92c94f782b38f05fc7001534",
+				"KeyExpiry":  "2026-11-08T22:06:41Z",
+				"DiscoKey":   "discokey:feddaa658dcbb026b1c5167c93df0f5f0ebecc7c6223e6590609fd3faf983f56",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45216",
+					"10.65.0.27:45216",
+					"172.17.0.1:45216",
+					"172.18.0.1:45216",
+					"172.19.0.1:45216"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:06:41.723762697Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         570529030803432,
+				"StableID":   "nPvVm9qPT511CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:501505a8b4781b7e1fff7722ef605788844c865265aa9e95f97229aa7ed7183a",
+				"KeyExpiry":  "2026-11-08T22:06:42Z",
+				"DiscoKey":   "discokey:947371d1d082da93055afe4a5fd223fcf501e00557746e0036587f3a9b4a0f7c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58615",
+					"10.65.0.27:58615",
+					"172.17.0.1:58615",
+					"172.18.0.1:58615",
+					"172.19.0.1:58615"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:06:42.246474856Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5898241027042958,
+				"StableID":   "nVNyypnK4o11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8bb47b6c7782b9d8e24c6d36ac8e82bcfa9d14934150389fb6b561369835a155",
+				"KeyExpiry":  "2026-11-08T22:06:42Z",
+				"DiscoKey":   "discokey:820710e9c0504871a5728473bfd1f00a63dc052f65d8abfedf768c4ae8a88b51",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53487",
+					"10.65.0.27:53487",
+					"172.17.0.1:53487",
+					"172.18.0.1:53487",
+					"172.19.0.1:53487"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:06:42.77529914Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4111732804383497": {
+				"ID":          4111732804383497,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         570529030803432,
+				"StableID":   "nPvVm9qPT511CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:501505a8b4781b7e1fff7722ef605788844c865265aa9e95f97229aa7ed7183a",
+				"KeyExpiry":  "2026-11-08T22:06:42Z",
+				"DiscoKey":   "discokey:947371d1d082da93055afe4a5fd223fcf501e00557746e0036587f3a9b4a0f7c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58615",
+					"10.65.0.27:58615",
+					"172.17.0.1:58615",
+					"172.18.0.1:58615",
+					"172.19.0.1:58615"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:06:42.246474856Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:501505a8b4781b7e1fff7722ef605788844c865265aa9e95f97229aa7ed7183a",
+			"MachineKey": "mkey:6b18944bae4420c513e4ad6c1a12c321d4a6abab41ccad8afbf4eedd75ba9d71",
+			"Peers": [{
+				"ID":         6920934748798951,
+				"StableID":   "npDB8mDW3w11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47b5c769dd653aaee4c253cc9cfc9143ecc58c16a3994a7e225f622ba5ba5613",
+				"DiscoKey":   "discokey:f3b7ddd2b297f111b52e9427c466f88576714932ff66550d58498820dc6ea853",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36670",
+					"10.65.0.27:36670",
+					"172.17.0.1:36670",
+					"172.18.0.1:36670",
+					"172.19.0.1:36670"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:06:35.256583687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3756436047208366,
+				"StableID":   "nqUVBuCJLW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35b9d3bbc656d9d7c59fa0d07895215c29aa5b248d52ef8fa366d823acee5e49",
+				"DiscoKey":   "discokey:d3022a1cc96b5e1fb798214fa7ca314666eb1cc9887204a8345adada9d768073",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42483",
+					"10.65.0.27:42483",
+					"172.17.0.1:42483",
+					"172.18.0.1:42483",
+					"172.19.0.1:42483"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:06:35.754995318Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4289665011511728,
+				"StableID":   "nRjNo6EoVa11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:710ebdf3d8b4cead87a1ed6724867e0e84f5cfb0b96dab89a17327f30a754b53",
+				"DiscoKey":   "discokey:0c189f19ed58a97593d96d99f8ab56b8762a8d5da49cad5c305f6157ea6a6620",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43290",
+					"10.65.0.27:43290",
+					"172.17.0.1:43290",
+					"172.18.0.1:43290",
+					"172.19.0.1:43290"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:06:36.287335379Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4004681398849003,
+				"StableID":   "nz46qzBjGY11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e14460ac6291b183f9aa98f31facc6334c11019c410a8558137eefd5838f855d",
+				"DiscoKey":   "discokey:2ec4af07745a3aa3acd3828b46d03668306af388c2f8f56067a106aff966fd4b",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45473",
+					"10.65.0.27:45473",
+					"172.17.0.1:45473",
+					"172.18.0.1:45473",
+					"172.19.0.1:45473"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:06:36.821069681Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         476329778022449,
+				"StableID":   "nQpQNnNji411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:52f85530f1faa72939b3a61a59e3de9d765a4aca4903e18d3e548657ad749379",
+				"DiscoKey":   "discokey:104e8eaa08339f2553f6c4708246f349fee2ffc928153b34970c4d1c44b6817c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37698",
+					"10.65.0.27:37698",
+					"172.17.0.1:37698",
+					"172.18.0.1:37698",
+					"172.19.0.1:37698"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:06:37.365396211Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2225880377551186,
+				"StableID":   "nZA7oy67PJ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:328e25da6d4b697b30d4c4375fc73c7c49a735f45ba30c1fb7b1a32ae28d075d",
+				"DiscoKey":   "discokey:a02335e58bd97307a2191f6f43645f675bfd349ff2b2d2a62f4f1695fb183061",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54634",
+					"10.65.0.27:54634",
+					"172.17.0.1:54634",
+					"172.18.0.1:54634",
+					"172.19.0.1:54634"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:06:37.898840526Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2220245363657152,
+				"StableID":   "nTQyug5ZLJ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:848d600d93e3239865f9872af7c7738a212df831fe0ac675e3fd508320539009",
+				"DiscoKey":   "discokey:8bd7f58c123b752f1c8ddadebba0572e6143f251e0eec3c3101c0ce0630aa452",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33155",
+					"10.65.0.27:33155",
+					"172.17.0.1:33155",
+					"172.18.0.1:33155",
+					"172.19.0.1:33155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:06:38.449831012Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4102409940318928,
+				"StableID":   "njpDPTMz2Z11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6010b1f69fc4da53dc443f5bd9ef3289731c462fc12bf6fea0b64df9063c1b30",
+				"DiscoKey":   "discokey:8409725db66a333aa2f93902bbe7c6382b3b72ac48d088c393da06af91550d62",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52423",
+					"10.65.0.27:52423",
+					"172.17.0.1:52423",
+					"172.18.0.1:52423",
+					"172.19.0.1:52423"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:06:38.988365023Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4111732804383497,
+				"StableID":   "nkWSxQFD7Z11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1f6f715801e9aa93bd52f145db297b081c2be81795118c0049b38e6108af1244",
+				"DiscoKey":   "discokey:653df946a29ac9f953bf0a032c638a04d774889e2dadf7ba4906682ee9315a15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:58525",
+					"10.65.0.27:58525",
+					"172.17.0.1:58525",
+					"172.18.0.1:58525",
+					"172.19.0.1:58525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:06:39.52882574Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1600586859876637,
+				"StableID":   "nrXbrkhuVD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ac434d4fb2f7f55c9aa69fc1371f33157dbef9c9bb0598cad19cfa91574c3017",
+				"DiscoKey":   "discokey:9e54597fd5eeac09ed07fd2f413af2a429c92012bb22959f8432762caf88d125",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42399",
+					"10.65.0.27:42399",
+					"172.17.0.1:42399",
+					"172.18.0.1:42399",
+					"172.19.0.1:42399"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:06:40.084901196Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3019688698704079,
+				"StableID":   "ncKFst6daQ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc3644ae4554545c5de9652d1a99649400b9e9ea90631fac2899ceacb4057a1e",
+				"DiscoKey":   "discokey:a418501fe1969a9097e17983e2108682fcf51341e719285196952a116623e730",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35727",
+					"10.65.0.27:35727",
+					"172.17.0.1:35727",
+					"172.18.0.1:35727",
+					"172.19.0.1:35727"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:06:40.61810035Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5933888869717837,
+				"StableID":   "naRcmWCULo11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f459cd8dde23f16d569790ae160faeee9a4fa217fb37570369d2947db01d227e",
+				"DiscoKey":   "discokey:fcc5b81a3a8c48487013c39d23e4225e815a0d2b4861bc0748e6b39562be667b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48785",
+					"10.65.0.27:48785",
+					"172.17.0.1:48785",
+					"172.18.0.1:48785",
+					"172.19.0.1:48785"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:06:41.158510677Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6546445728991847,
+				"StableID":   "nJ6cpe2u7t11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:eac53cd48b9acee0c69497885405a2c8fcad770e92c94f782b38f05fc7001534",
+				"KeyExpiry":  "2026-11-08T22:06:41Z",
+				"DiscoKey":   "discokey:feddaa658dcbb026b1c5167c93df0f5f0ebecc7c6223e6590609fd3faf983f56",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45216",
+					"10.65.0.27:45216",
+					"172.17.0.1:45216",
+					"172.18.0.1:45216",
+					"172.19.0.1:45216"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:06:41.723762697Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5898241027042958,
+				"StableID":   "nVNyypnK4o11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8bb47b6c7782b9d8e24c6d36ac8e82bcfa9d14934150389fb6b561369835a155",
+				"KeyExpiry":  "2026-11-08T22:06:42Z",
+				"DiscoKey":   "discokey:820710e9c0504871a5728473bfd1f00a63dc052f65d8abfedf768c4ae8a88b51",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53487",
+					"10.65.0.27:53487",
+					"172.17.0.1:53487",
+					"172.18.0.1:53487",
+					"172.19.0.1:53487"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:06:42.77529914Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1600586859876637,
+				"StableID":   "nrXbrkhuVD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1600586859876637,
+				"Key":        "nodekey:ac434d4fb2f7f55c9aa69fc1371f33157dbef9c9bb0598cad19cfa91574c3017",
+				"DiscoKey":   "discokey:9e54597fd5eeac09ed07fd2f413af2a429c92012bb22959f8432762caf88d125",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:42399",
+					"10.65.0.27:42399",
+					"172.17.0.1:42399",
+					"172.18.0.1:42399",
+					"172.19.0.1:42399"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:06:40.084901196Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ac434d4fb2f7f55c9aa69fc1371f33157dbef9c9bb0598cad19cfa91574c3017",
+			"MachineKey": "mkey:ce8530c5e090e405e2f1acfffe29727a290b82e8a0d9cf5edca9de06c98ea748",
+			"Peers": [{
+				"ID":         6920934748798951,
+				"StableID":   "npDB8mDW3w11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47b5c769dd653aaee4c253cc9cfc9143ecc58c16a3994a7e225f622ba5ba5613",
+				"DiscoKey":   "discokey:f3b7ddd2b297f111b52e9427c466f88576714932ff66550d58498820dc6ea853",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36670",
+					"10.65.0.27:36670",
+					"172.17.0.1:36670",
+					"172.18.0.1:36670",
+					"172.19.0.1:36670"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:06:35.256583687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3756436047208366,
+				"StableID":   "nqUVBuCJLW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35b9d3bbc656d9d7c59fa0d07895215c29aa5b248d52ef8fa366d823acee5e49",
+				"DiscoKey":   "discokey:d3022a1cc96b5e1fb798214fa7ca314666eb1cc9887204a8345adada9d768073",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42483",
+					"10.65.0.27:42483",
+					"172.17.0.1:42483",
+					"172.18.0.1:42483",
+					"172.19.0.1:42483"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:06:35.754995318Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4289665011511728,
+				"StableID":   "nRjNo6EoVa11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:710ebdf3d8b4cead87a1ed6724867e0e84f5cfb0b96dab89a17327f30a754b53",
+				"DiscoKey":   "discokey:0c189f19ed58a97593d96d99f8ab56b8762a8d5da49cad5c305f6157ea6a6620",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43290",
+					"10.65.0.27:43290",
+					"172.17.0.1:43290",
+					"172.18.0.1:43290",
+					"172.19.0.1:43290"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:06:36.287335379Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4004681398849003,
+				"StableID":   "nz46qzBjGY11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e14460ac6291b183f9aa98f31facc6334c11019c410a8558137eefd5838f855d",
+				"DiscoKey":   "discokey:2ec4af07745a3aa3acd3828b46d03668306af388c2f8f56067a106aff966fd4b",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45473",
+					"10.65.0.27:45473",
+					"172.17.0.1:45473",
+					"172.18.0.1:45473",
+					"172.19.0.1:45473"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:06:36.821069681Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         476329778022449,
+				"StableID":   "nQpQNnNji411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:52f85530f1faa72939b3a61a59e3de9d765a4aca4903e18d3e548657ad749379",
+				"DiscoKey":   "discokey:104e8eaa08339f2553f6c4708246f349fee2ffc928153b34970c4d1c44b6817c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37698",
+					"10.65.0.27:37698",
+					"172.17.0.1:37698",
+					"172.18.0.1:37698",
+					"172.19.0.1:37698"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:06:37.365396211Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2225880377551186,
+				"StableID":   "nZA7oy67PJ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:328e25da6d4b697b30d4c4375fc73c7c49a735f45ba30c1fb7b1a32ae28d075d",
+				"DiscoKey":   "discokey:a02335e58bd97307a2191f6f43645f675bfd349ff2b2d2a62f4f1695fb183061",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54634",
+					"10.65.0.27:54634",
+					"172.17.0.1:54634",
+					"172.18.0.1:54634",
+					"172.19.0.1:54634"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:06:37.898840526Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2220245363657152,
+				"StableID":   "nTQyug5ZLJ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:848d600d93e3239865f9872af7c7738a212df831fe0ac675e3fd508320539009",
+				"DiscoKey":   "discokey:8bd7f58c123b752f1c8ddadebba0572e6143f251e0eec3c3101c0ce0630aa452",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33155",
+					"10.65.0.27:33155",
+					"172.17.0.1:33155",
+					"172.18.0.1:33155",
+					"172.19.0.1:33155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:06:38.449831012Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4102409940318928,
+				"StableID":   "njpDPTMz2Z11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6010b1f69fc4da53dc443f5bd9ef3289731c462fc12bf6fea0b64df9063c1b30",
+				"DiscoKey":   "discokey:8409725db66a333aa2f93902bbe7c6382b3b72ac48d088c393da06af91550d62",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52423",
+					"10.65.0.27:52423",
+					"172.17.0.1:52423",
+					"172.18.0.1:52423",
+					"172.19.0.1:52423"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:06:38.988365023Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4111732804383497,
+				"StableID":   "nkWSxQFD7Z11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1f6f715801e9aa93bd52f145db297b081c2be81795118c0049b38e6108af1244",
+				"DiscoKey":   "discokey:653df946a29ac9f953bf0a032c638a04d774889e2dadf7ba4906682ee9315a15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:58525",
+					"10.65.0.27:58525",
+					"172.17.0.1:58525",
+					"172.18.0.1:58525",
+					"172.19.0.1:58525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:06:39.52882574Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3019688698704079,
+				"StableID":   "ncKFst6daQ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc3644ae4554545c5de9652d1a99649400b9e9ea90631fac2899ceacb4057a1e",
+				"DiscoKey":   "discokey:a418501fe1969a9097e17983e2108682fcf51341e719285196952a116623e730",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35727",
+					"10.65.0.27:35727",
+					"172.17.0.1:35727",
+					"172.18.0.1:35727",
+					"172.19.0.1:35727"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:06:40.61810035Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5933888869717837,
+				"StableID":   "naRcmWCULo11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f459cd8dde23f16d569790ae160faeee9a4fa217fb37570369d2947db01d227e",
+				"DiscoKey":   "discokey:fcc5b81a3a8c48487013c39d23e4225e815a0d2b4861bc0748e6b39562be667b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:48785",
+					"10.65.0.27:48785",
+					"172.17.0.1:48785",
+					"172.18.0.1:48785",
+					"172.19.0.1:48785"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:06:41.158510677Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6546445728991847,
+				"StableID":   "nJ6cpe2u7t11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:eac53cd48b9acee0c69497885405a2c8fcad770e92c94f782b38f05fc7001534",
+				"KeyExpiry":  "2026-11-08T22:06:41Z",
+				"DiscoKey":   "discokey:feddaa658dcbb026b1c5167c93df0f5f0ebecc7c6223e6590609fd3faf983f56",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45216",
+					"10.65.0.27:45216",
+					"172.17.0.1:45216",
+					"172.18.0.1:45216",
+					"172.19.0.1:45216"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:06:41.723762697Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         570529030803432,
+				"StableID":   "nPvVm9qPT511CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:501505a8b4781b7e1fff7722ef605788844c865265aa9e95f97229aa7ed7183a",
+				"KeyExpiry":  "2026-11-08T22:06:42Z",
+				"DiscoKey":   "discokey:947371d1d082da93055afe4a5fd223fcf501e00557746e0036587f3a9b4a0f7c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58615",
+					"10.65.0.27:58615",
+					"172.17.0.1:58615",
+					"172.18.0.1:58615",
+					"172.19.0.1:58615"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:06:42.246474856Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5898241027042958,
+				"StableID":   "nVNyypnK4o11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8bb47b6c7782b9d8e24c6d36ac8e82bcfa9d14934150389fb6b561369835a155",
+				"KeyExpiry":  "2026-11-08T22:06:42Z",
+				"DiscoKey":   "discokey:820710e9c0504871a5728473bfd1f00a63dc052f65d8abfedf768c4ae8a88b51",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53487",
+					"10.65.0.27:53487",
+					"172.17.0.1:53487",
+					"172.18.0.1:53487",
+					"172.19.0.1:53487"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:06:42.77529914Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1600586859876637": {
+				"ID":          1600586859876637,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-user-localpart-multi-glob.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-user-localpart-multi-glob.hujson
@@ -1,0 +1,20083 @@
+// ssh-malformed-user-localpart-multi-glob
+//
+// ssh users localpart with double wildcard is rejected
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T22:07:28Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-malformed-user-localpart-multi-glob",
+	"description":    "ssh users localpart with double wildcard is rejected",
+	"category":       "ssh",
+	"captured_at":    "2026-05-12T22:07:28.062019124Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {
+			"message": "* is not associated with this Tailnet and cannot be used in user:*@<domain> expressions"
+		},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                          \n  \n                                                                        \n                                         \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh users localpart with double wildcard is rejected\",\n\t\"id\":          \"ssh-malformed-user-localpart-multi-glob\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"autogroup:member\"],\n\t\t\"users\":  [\"localpart:*@*\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-malformed/ssh-malformed-user-localpart-multi-glob.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["autogroup:member"],
+				"users":  ["localpart:*@*"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         818163205231930,
+				"StableID":   "nDS8n5mYP711CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       818163205231930,
+				"Key":        "nodekey:e18ac31e74b1a42e3c87414b6d403e066f6ecd0002bc47c4d15c570a9e7cd246",
+				"DiscoKey":   "discokey:d375e1ba22651786da69ff86fb8875db92af0be9f4a875925ad2b96a506a160e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39948",
+					"10.65.0.27:39948",
+					"172.17.0.1:39948",
+					"172.18.0.1:39948",
+					"172.19.0.1:39948"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:07:36.609205696Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e18ac31e74b1a42e3c87414b6d403e066f6ecd0002bc47c4d15c570a9e7cd246",
+			"MachineKey": "mkey:2fefe5e276371a73d57ef2a87ec93d9c33743389a085ab40c1e88e079311514f",
+			"Peers": [{
+				"ID":         6479580554056551,
+				"StableID":   "nJYHHSbcbs11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:534036fee32befc8def76d19bced2611cec4c9ea5ff06fc9125ca5d3a5fa394c",
+				"DiscoKey":   "discokey:a457fd752c63433b63a00ad13c196b72bbbb879157c93a5c834b44cdb1ace34f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54446",
+					"10.65.0.27:54446",
+					"172.17.0.1:54446",
+					"172.18.0.1:54446",
+					"172.19.0.1:54446"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:07:30.684306958Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2816977717950711,
+				"StableID":   "nnrbeDEpzN11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:828c9831759071eecf78af1bdef101e9af04f11a3322b6530c02c7f5628a8072",
+				"DiscoKey":   "discokey:e428510d31c80edc8ab4911bed1cfa4ed9fb256f8a863ee87b6ea4e6325d0178",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:46201",
+					"10.65.0.27:46201",
+					"172.17.0.1:46201",
+					"172.18.0.1:46201",
+					"172.19.0.1:46201"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:07:31.206906899Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5903664245366305,
+				"StableID":   "n8pSDSFn6o11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b80dddd3a9b37a678e490fb3803dba0f8ca22d020e5a1a043d1ca93905516027",
+				"DiscoKey":   "discokey:b1184af60a53c426fc6121a2b7c4755d79e17195822f72602524a8115ba6d411",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40208",
+					"10.65.0.27:40208",
+					"172.17.0.1:40208",
+					"172.18.0.1:40208",
+					"172.19.0.1:40208"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:07:31.763176233Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6014729432040478,
+				"StableID":   "no3JS6k5yo11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6635fa423f96ea142ce0bde68b60aac1a30513c2918454449d5ace83f3c18571",
+				"DiscoKey":   "discokey:b5ee5552f812eb458150160819218256bbf444970c70664bc3dfdc4638bbac1f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60502",
+					"10.65.0.27:60502",
+					"172.17.0.1:60502",
+					"172.18.0.1:60502",
+					"172.19.0.1:60502"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:07:32.291386771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7489233362587283,
+				"StableID":   "nc7UajTtU121CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:63a921faa59da289100969ecd538b2191cc0a2be8da6ae4b4689f63da1685b60",
+				"DiscoKey":   "discokey:4ec87a46abbb8eedf790e93beddbe43a6f31049a847c7749aa714dd7c435a83a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37260",
+					"10.65.0.27:37260",
+					"172.17.0.1:37260",
+					"172.18.0.1:37260",
+					"172.19.0.1:37260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:07:32.828546148Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4881874094114602,
+				"StableID":   "nuxFW9Z18f11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d4e1c2470af4ee707df3f5e50f6f7dada568e03ff687618946fb82004ada4347",
+				"DiscoKey":   "discokey:e7f9a6a6ba9e54e2fd87153f173b9c06d7b11a7d0429bcc4f49e2d380761684e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50358",
+					"10.65.0.27:50358",
+					"172.17.0.1:50358",
+					"172.18.0.1:50358",
+					"172.19.0.1:50358"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:07:33.36759875Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8112666823820910,
+				"StableID":   "njFXh31FM621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:482e81b7f77b8b542172c99c811b67ffe2aca0ddba857f700743fa1d73ffed6a",
+				"DiscoKey":   "discokey:7e5c8435764e2abc66f1d68433595b45161e290f3178b549014e4dd918d69736",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48093",
+					"10.65.0.27:48093",
+					"172.17.0.1:48093",
+					"172.18.0.1:48093",
+					"172.19.0.1:48093"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:07:33.913359829Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5829259574078004,
+				"StableID":   "n1daCLm5Xn11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:766014e368d34ec617570ebfbcb0877a653874e00796ee742936cd4265e4d574",
+				"DiscoKey":   "discokey:7db08cd1aba3f54ad43a612200f22932b310d18852f4e3dfe8b0fb35b321361f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:59857",
+					"10.65.0.27:59857",
+					"172.17.0.1:59857",
+					"172.18.0.1:59857",
+					"172.19.0.1:59857"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:07:34.45097998Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4256209531504822,
+				"StableID":   "nh6UbcQeEa11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2d4fdfe535a0c6e64a6a3fc41bc85299971f84ba868056e4e25d7fa573edf360",
+				"DiscoKey":   "discokey:f332cd2d0a3e01ec1156b6552d22c803424a2a8fee63822664d364a0c32fc803",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37941",
+					"10.65.0.27:37941",
+					"172.17.0.1:37941",
+					"172.18.0.1:37941",
+					"172.19.0.1:37941"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:07:34.992520254Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4988838610444073,
+				"StableID":   "ntviXBLTxf11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80d34443476f4fa20a4be3bdb35576b9d365303295e9777678a4c4f1546fba70",
+				"DiscoKey":   "discokey:abc4a52e919001f954f9c245068883208bbd7e6d74a52d3b8fc13c067eda7d54",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51268",
+					"10.65.0.27:51268",
+					"172.17.0.1:51268",
+					"172.18.0.1:51268",
+					"172.19.0.1:51268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:07:35.53016161Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3709003317634520,
+				"StableID":   "n9f4JDEpxV11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87c4970e02ee5157815d463a7d792c882321cf8d82a0eeb7370ac3ff0b78fb18",
+				"DiscoKey":   "discokey:e0781f6e73aa3310e56169aa8f798bf25ad541e5c99150182dd7cc207e556e41",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43637",
+					"10.65.0.27:43637",
+					"172.17.0.1:43637",
+					"172.18.0.1:43637",
+					"172.19.0.1:43637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:07:36.073292326Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3568096698125327,
+				"StableID":   "niUjqHrzrU11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6578eac37734f0ca30d21ae8707d38e30d3518f5438b01f3ada6d55c8f536136",
+				"KeyExpiry":  "2026-11-08T22:07:37Z",
+				"DiscoKey":   "discokey:62cf1aea48bbabd24deeef783337746c937d7b328bd9c293ebc4c8aeaeddfd2b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47310",
+					"10.65.0.27:47310",
+					"172.17.0.1:47310",
+					"172.18.0.1:47310",
+					"172.19.0.1:47310"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:07:37.143194956Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2796977951033685,
+				"StableID":   "nrqSjLskqN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2244680b5f743db685055692ef513ba7a799337736c5a510fb2dc311020d3d63",
+				"KeyExpiry":  "2026-11-08T22:07:37Z",
+				"DiscoKey":   "discokey:e715d93f923ae4f70de8d0db1b9fc44e7ca82432b97a69a80ef3598357ac510f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36314",
+					"10.65.0.27:36314",
+					"172.17.0.1:36314",
+					"172.18.0.1:36314",
+					"172.19.0.1:36314"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:07:37.686253398Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         866341581446789,
+				"StableID":   "n6hVuoKNm711CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9152a1f0fa73a02973a78d7a23e7a3a25308a110b22f352c2e41fc79c81f6c53",
+				"KeyExpiry":  "2026-11-08T22:07:38Z",
+				"DiscoKey":   "discokey:469b171fb99446be03db1fe5612be3930e590063ca55a4ad1f58719bcf707757",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:34961",
+					"10.65.0.27:34961",
+					"172.17.0.1:34961",
+					"172.18.0.1:34961",
+					"172.19.0.1:34961"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:07:38.230136065Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "818163205231930": {
+				"ID":          818163205231930,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4881874094114602,
+				"StableID":   "nuxFW9Z18f11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       4881874094114602,
+				"Key":        "nodekey:d4e1c2470af4ee707df3f5e50f6f7dada568e03ff687618946fb82004ada4347",
+				"DiscoKey":   "discokey:e7f9a6a6ba9e54e2fd87153f173b9c06d7b11a7d0429bcc4f49e2d380761684e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50358",
+					"10.65.0.27:50358",
+					"172.17.0.1:50358",
+					"172.18.0.1:50358",
+					"172.19.0.1:50358"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:07:33.36759875Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d4e1c2470af4ee707df3f5e50f6f7dada568e03ff687618946fb82004ada4347",
+			"MachineKey": "mkey:6a6462f2d6b54c7a6ca39e34fc35437d83acf29716b4c5f2fb1de5d423ff2908",
+			"Peers": [{
+				"ID":         6479580554056551,
+				"StableID":   "nJYHHSbcbs11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:534036fee32befc8def76d19bced2611cec4c9ea5ff06fc9125ca5d3a5fa394c",
+				"DiscoKey":   "discokey:a457fd752c63433b63a00ad13c196b72bbbb879157c93a5c834b44cdb1ace34f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54446",
+					"10.65.0.27:54446",
+					"172.17.0.1:54446",
+					"172.18.0.1:54446",
+					"172.19.0.1:54446"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:07:30.684306958Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2816977717950711,
+				"StableID":   "nnrbeDEpzN11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:828c9831759071eecf78af1bdef101e9af04f11a3322b6530c02c7f5628a8072",
+				"DiscoKey":   "discokey:e428510d31c80edc8ab4911bed1cfa4ed9fb256f8a863ee87b6ea4e6325d0178",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:46201",
+					"10.65.0.27:46201",
+					"172.17.0.1:46201",
+					"172.18.0.1:46201",
+					"172.19.0.1:46201"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:07:31.206906899Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5903664245366305,
+				"StableID":   "n8pSDSFn6o11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b80dddd3a9b37a678e490fb3803dba0f8ca22d020e5a1a043d1ca93905516027",
+				"DiscoKey":   "discokey:b1184af60a53c426fc6121a2b7c4755d79e17195822f72602524a8115ba6d411",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40208",
+					"10.65.0.27:40208",
+					"172.17.0.1:40208",
+					"172.18.0.1:40208",
+					"172.19.0.1:40208"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:07:31.763176233Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6014729432040478,
+				"StableID":   "no3JS6k5yo11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6635fa423f96ea142ce0bde68b60aac1a30513c2918454449d5ace83f3c18571",
+				"DiscoKey":   "discokey:b5ee5552f812eb458150160819218256bbf444970c70664bc3dfdc4638bbac1f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60502",
+					"10.65.0.27:60502",
+					"172.17.0.1:60502",
+					"172.18.0.1:60502",
+					"172.19.0.1:60502"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:07:32.291386771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7489233362587283,
+				"StableID":   "nc7UajTtU121CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:63a921faa59da289100969ecd538b2191cc0a2be8da6ae4b4689f63da1685b60",
+				"DiscoKey":   "discokey:4ec87a46abbb8eedf790e93beddbe43a6f31049a847c7749aa714dd7c435a83a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37260",
+					"10.65.0.27:37260",
+					"172.17.0.1:37260",
+					"172.18.0.1:37260",
+					"172.19.0.1:37260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:07:32.828546148Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8112666823820910,
+				"StableID":   "njFXh31FM621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:482e81b7f77b8b542172c99c811b67ffe2aca0ddba857f700743fa1d73ffed6a",
+				"DiscoKey":   "discokey:7e5c8435764e2abc66f1d68433595b45161e290f3178b549014e4dd918d69736",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48093",
+					"10.65.0.27:48093",
+					"172.17.0.1:48093",
+					"172.18.0.1:48093",
+					"172.19.0.1:48093"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:07:33.913359829Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5829259574078004,
+				"StableID":   "n1daCLm5Xn11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:766014e368d34ec617570ebfbcb0877a653874e00796ee742936cd4265e4d574",
+				"DiscoKey":   "discokey:7db08cd1aba3f54ad43a612200f22932b310d18852f4e3dfe8b0fb35b321361f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:59857",
+					"10.65.0.27:59857",
+					"172.17.0.1:59857",
+					"172.18.0.1:59857",
+					"172.19.0.1:59857"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:07:34.45097998Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4256209531504822,
+				"StableID":   "nh6UbcQeEa11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2d4fdfe535a0c6e64a6a3fc41bc85299971f84ba868056e4e25d7fa573edf360",
+				"DiscoKey":   "discokey:f332cd2d0a3e01ec1156b6552d22c803424a2a8fee63822664d364a0c32fc803",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37941",
+					"10.65.0.27:37941",
+					"172.17.0.1:37941",
+					"172.18.0.1:37941",
+					"172.19.0.1:37941"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:07:34.992520254Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4988838610444073,
+				"StableID":   "ntviXBLTxf11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80d34443476f4fa20a4be3bdb35576b9d365303295e9777678a4c4f1546fba70",
+				"DiscoKey":   "discokey:abc4a52e919001f954f9c245068883208bbd7e6d74a52d3b8fc13c067eda7d54",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51268",
+					"10.65.0.27:51268",
+					"172.17.0.1:51268",
+					"172.18.0.1:51268",
+					"172.19.0.1:51268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:07:35.53016161Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3709003317634520,
+				"StableID":   "n9f4JDEpxV11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87c4970e02ee5157815d463a7d792c882321cf8d82a0eeb7370ac3ff0b78fb18",
+				"DiscoKey":   "discokey:e0781f6e73aa3310e56169aa8f798bf25ad541e5c99150182dd7cc207e556e41",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43637",
+					"10.65.0.27:43637",
+					"172.17.0.1:43637",
+					"172.18.0.1:43637",
+					"172.19.0.1:43637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:07:36.073292326Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         818163205231930,
+				"StableID":   "nDS8n5mYP711CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e18ac31e74b1a42e3c87414b6d403e066f6ecd0002bc47c4d15c570a9e7cd246",
+				"DiscoKey":   "discokey:d375e1ba22651786da69ff86fb8875db92af0be9f4a875925ad2b96a506a160e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39948",
+					"10.65.0.27:39948",
+					"172.17.0.1:39948",
+					"172.18.0.1:39948",
+					"172.19.0.1:39948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:07:36.609205696Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3568096698125327,
+				"StableID":   "niUjqHrzrU11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6578eac37734f0ca30d21ae8707d38e30d3518f5438b01f3ada6d55c8f536136",
+				"KeyExpiry":  "2026-11-08T22:07:37Z",
+				"DiscoKey":   "discokey:62cf1aea48bbabd24deeef783337746c937d7b328bd9c293ebc4c8aeaeddfd2b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47310",
+					"10.65.0.27:47310",
+					"172.17.0.1:47310",
+					"172.18.0.1:47310",
+					"172.19.0.1:47310"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:07:37.143194956Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2796977951033685,
+				"StableID":   "nrqSjLskqN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2244680b5f743db685055692ef513ba7a799337736c5a510fb2dc311020d3d63",
+				"KeyExpiry":  "2026-11-08T22:07:37Z",
+				"DiscoKey":   "discokey:e715d93f923ae4f70de8d0db1b9fc44e7ca82432b97a69a80ef3598357ac510f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36314",
+					"10.65.0.27:36314",
+					"172.17.0.1:36314",
+					"172.18.0.1:36314",
+					"172.19.0.1:36314"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:07:37.686253398Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         866341581446789,
+				"StableID":   "n6hVuoKNm711CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9152a1f0fa73a02973a78d7a23e7a3a25308a110b22f352c2e41fc79c81f6c53",
+				"KeyExpiry":  "2026-11-08T22:07:38Z",
+				"DiscoKey":   "discokey:469b171fb99446be03db1fe5612be3930e590063ca55a4ad1f58719bcf707757",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:34961",
+					"10.65.0.27:34961",
+					"172.17.0.1:34961",
+					"172.18.0.1:34961",
+					"172.19.0.1:34961"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:07:38.230136065Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4881874094114602": {
+				"ID":          4881874094114602,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         866341581446789,
+				"StableID":   "n6hVuoKNm711CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9152a1f0fa73a02973a78d7a23e7a3a25308a110b22f352c2e41fc79c81f6c53",
+				"KeyExpiry":  "2026-11-08T22:07:38Z",
+				"DiscoKey":   "discokey:469b171fb99446be03db1fe5612be3930e590063ca55a4ad1f58719bcf707757",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:34961",
+					"10.65.0.27:34961",
+					"172.17.0.1:34961",
+					"172.18.0.1:34961",
+					"172.19.0.1:34961"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:07:38.230136065Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9152a1f0fa73a02973a78d7a23e7a3a25308a110b22f352c2e41fc79c81f6c53",
+			"MachineKey": "mkey:8ca6f6b3dffed45ce19d6d201111016da1bca3f180215e67fc2084dcd783e27d",
+			"Peers": [{
+				"ID":         6479580554056551,
+				"StableID":   "nJYHHSbcbs11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:534036fee32befc8def76d19bced2611cec4c9ea5ff06fc9125ca5d3a5fa394c",
+				"DiscoKey":   "discokey:a457fd752c63433b63a00ad13c196b72bbbb879157c93a5c834b44cdb1ace34f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54446",
+					"10.65.0.27:54446",
+					"172.17.0.1:54446",
+					"172.18.0.1:54446",
+					"172.19.0.1:54446"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:07:30.684306958Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2816977717950711,
+				"StableID":   "nnrbeDEpzN11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:828c9831759071eecf78af1bdef101e9af04f11a3322b6530c02c7f5628a8072",
+				"DiscoKey":   "discokey:e428510d31c80edc8ab4911bed1cfa4ed9fb256f8a863ee87b6ea4e6325d0178",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:46201",
+					"10.65.0.27:46201",
+					"172.17.0.1:46201",
+					"172.18.0.1:46201",
+					"172.19.0.1:46201"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:07:31.206906899Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5903664245366305,
+				"StableID":   "n8pSDSFn6o11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b80dddd3a9b37a678e490fb3803dba0f8ca22d020e5a1a043d1ca93905516027",
+				"DiscoKey":   "discokey:b1184af60a53c426fc6121a2b7c4755d79e17195822f72602524a8115ba6d411",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40208",
+					"10.65.0.27:40208",
+					"172.17.0.1:40208",
+					"172.18.0.1:40208",
+					"172.19.0.1:40208"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:07:31.763176233Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6014729432040478,
+				"StableID":   "no3JS6k5yo11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6635fa423f96ea142ce0bde68b60aac1a30513c2918454449d5ace83f3c18571",
+				"DiscoKey":   "discokey:b5ee5552f812eb458150160819218256bbf444970c70664bc3dfdc4638bbac1f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60502",
+					"10.65.0.27:60502",
+					"172.17.0.1:60502",
+					"172.18.0.1:60502",
+					"172.19.0.1:60502"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:07:32.291386771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7489233362587283,
+				"StableID":   "nc7UajTtU121CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:63a921faa59da289100969ecd538b2191cc0a2be8da6ae4b4689f63da1685b60",
+				"DiscoKey":   "discokey:4ec87a46abbb8eedf790e93beddbe43a6f31049a847c7749aa714dd7c435a83a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37260",
+					"10.65.0.27:37260",
+					"172.17.0.1:37260",
+					"172.18.0.1:37260",
+					"172.19.0.1:37260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:07:32.828546148Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4881874094114602,
+				"StableID":   "nuxFW9Z18f11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d4e1c2470af4ee707df3f5e50f6f7dada568e03ff687618946fb82004ada4347",
+				"DiscoKey":   "discokey:e7f9a6a6ba9e54e2fd87153f173b9c06d7b11a7d0429bcc4f49e2d380761684e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50358",
+					"10.65.0.27:50358",
+					"172.17.0.1:50358",
+					"172.18.0.1:50358",
+					"172.19.0.1:50358"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:07:33.36759875Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8112666823820910,
+				"StableID":   "njFXh31FM621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:482e81b7f77b8b542172c99c811b67ffe2aca0ddba857f700743fa1d73ffed6a",
+				"DiscoKey":   "discokey:7e5c8435764e2abc66f1d68433595b45161e290f3178b549014e4dd918d69736",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48093",
+					"10.65.0.27:48093",
+					"172.17.0.1:48093",
+					"172.18.0.1:48093",
+					"172.19.0.1:48093"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:07:33.913359829Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5829259574078004,
+				"StableID":   "n1daCLm5Xn11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:766014e368d34ec617570ebfbcb0877a653874e00796ee742936cd4265e4d574",
+				"DiscoKey":   "discokey:7db08cd1aba3f54ad43a612200f22932b310d18852f4e3dfe8b0fb35b321361f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:59857",
+					"10.65.0.27:59857",
+					"172.17.0.1:59857",
+					"172.18.0.1:59857",
+					"172.19.0.1:59857"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:07:34.45097998Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4256209531504822,
+				"StableID":   "nh6UbcQeEa11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2d4fdfe535a0c6e64a6a3fc41bc85299971f84ba868056e4e25d7fa573edf360",
+				"DiscoKey":   "discokey:f332cd2d0a3e01ec1156b6552d22c803424a2a8fee63822664d364a0c32fc803",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37941",
+					"10.65.0.27:37941",
+					"172.17.0.1:37941",
+					"172.18.0.1:37941",
+					"172.19.0.1:37941"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:07:34.992520254Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4988838610444073,
+				"StableID":   "ntviXBLTxf11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80d34443476f4fa20a4be3bdb35576b9d365303295e9777678a4c4f1546fba70",
+				"DiscoKey":   "discokey:abc4a52e919001f954f9c245068883208bbd7e6d74a52d3b8fc13c067eda7d54",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51268",
+					"10.65.0.27:51268",
+					"172.17.0.1:51268",
+					"172.18.0.1:51268",
+					"172.19.0.1:51268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:07:35.53016161Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3709003317634520,
+				"StableID":   "n9f4JDEpxV11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87c4970e02ee5157815d463a7d792c882321cf8d82a0eeb7370ac3ff0b78fb18",
+				"DiscoKey":   "discokey:e0781f6e73aa3310e56169aa8f798bf25ad541e5c99150182dd7cc207e556e41",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43637",
+					"10.65.0.27:43637",
+					"172.17.0.1:43637",
+					"172.18.0.1:43637",
+					"172.19.0.1:43637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:07:36.073292326Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         818163205231930,
+				"StableID":   "nDS8n5mYP711CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e18ac31e74b1a42e3c87414b6d403e066f6ecd0002bc47c4d15c570a9e7cd246",
+				"DiscoKey":   "discokey:d375e1ba22651786da69ff86fb8875db92af0be9f4a875925ad2b96a506a160e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39948",
+					"10.65.0.27:39948",
+					"172.17.0.1:39948",
+					"172.18.0.1:39948",
+					"172.19.0.1:39948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:07:36.609205696Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3568096698125327,
+				"StableID":   "niUjqHrzrU11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6578eac37734f0ca30d21ae8707d38e30d3518f5438b01f3ada6d55c8f536136",
+				"KeyExpiry":  "2026-11-08T22:07:37Z",
+				"DiscoKey":   "discokey:62cf1aea48bbabd24deeef783337746c937d7b328bd9c293ebc4c8aeaeddfd2b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47310",
+					"10.65.0.27:47310",
+					"172.17.0.1:47310",
+					"172.18.0.1:47310",
+					"172.19.0.1:47310"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:07:37.143194956Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2796977951033685,
+				"StableID":   "nrqSjLskqN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2244680b5f743db685055692ef513ba7a799337736c5a510fb2dc311020d3d63",
+				"KeyExpiry":  "2026-11-08T22:07:37Z",
+				"DiscoKey":   "discokey:e715d93f923ae4f70de8d0db1b9fc44e7ca82432b97a69a80ef3598357ac510f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36314",
+					"10.65.0.27:36314",
+					"172.17.0.1:36314",
+					"172.18.0.1:36314",
+					"172.19.0.1:36314"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:07:37.686253398Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5903664245366305,
+				"StableID":   "n8pSDSFn6o11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       5903664245366305,
+				"Key":        "nodekey:b80dddd3a9b37a678e490fb3803dba0f8ca22d020e5a1a043d1ca93905516027",
+				"DiscoKey":   "discokey:b1184af60a53c426fc6121a2b7c4755d79e17195822f72602524a8115ba6d411",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40208",
+					"10.65.0.27:40208",
+					"172.17.0.1:40208",
+					"172.18.0.1:40208",
+					"172.19.0.1:40208"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:07:31.763176233Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b80dddd3a9b37a678e490fb3803dba0f8ca22d020e5a1a043d1ca93905516027",
+			"MachineKey": "mkey:5e4ff76176a0480e10e7f30ff2ad4f5a4e0635c83e3b186a46048f8b9f4ba300",
+			"Peers": [{
+				"ID":         6479580554056551,
+				"StableID":   "nJYHHSbcbs11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:534036fee32befc8def76d19bced2611cec4c9ea5ff06fc9125ca5d3a5fa394c",
+				"DiscoKey":   "discokey:a457fd752c63433b63a00ad13c196b72bbbb879157c93a5c834b44cdb1ace34f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54446",
+					"10.65.0.27:54446",
+					"172.17.0.1:54446",
+					"172.18.0.1:54446",
+					"172.19.0.1:54446"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:07:30.684306958Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2816977717950711,
+				"StableID":   "nnrbeDEpzN11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:828c9831759071eecf78af1bdef101e9af04f11a3322b6530c02c7f5628a8072",
+				"DiscoKey":   "discokey:e428510d31c80edc8ab4911bed1cfa4ed9fb256f8a863ee87b6ea4e6325d0178",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:46201",
+					"10.65.0.27:46201",
+					"172.17.0.1:46201",
+					"172.18.0.1:46201",
+					"172.19.0.1:46201"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:07:31.206906899Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6014729432040478,
+				"StableID":   "no3JS6k5yo11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6635fa423f96ea142ce0bde68b60aac1a30513c2918454449d5ace83f3c18571",
+				"DiscoKey":   "discokey:b5ee5552f812eb458150160819218256bbf444970c70664bc3dfdc4638bbac1f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60502",
+					"10.65.0.27:60502",
+					"172.17.0.1:60502",
+					"172.18.0.1:60502",
+					"172.19.0.1:60502"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:07:32.291386771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7489233362587283,
+				"StableID":   "nc7UajTtU121CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:63a921faa59da289100969ecd538b2191cc0a2be8da6ae4b4689f63da1685b60",
+				"DiscoKey":   "discokey:4ec87a46abbb8eedf790e93beddbe43a6f31049a847c7749aa714dd7c435a83a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37260",
+					"10.65.0.27:37260",
+					"172.17.0.1:37260",
+					"172.18.0.1:37260",
+					"172.19.0.1:37260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:07:32.828546148Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4881874094114602,
+				"StableID":   "nuxFW9Z18f11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d4e1c2470af4ee707df3f5e50f6f7dada568e03ff687618946fb82004ada4347",
+				"DiscoKey":   "discokey:e7f9a6a6ba9e54e2fd87153f173b9c06d7b11a7d0429bcc4f49e2d380761684e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50358",
+					"10.65.0.27:50358",
+					"172.17.0.1:50358",
+					"172.18.0.1:50358",
+					"172.19.0.1:50358"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:07:33.36759875Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8112666823820910,
+				"StableID":   "njFXh31FM621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:482e81b7f77b8b542172c99c811b67ffe2aca0ddba857f700743fa1d73ffed6a",
+				"DiscoKey":   "discokey:7e5c8435764e2abc66f1d68433595b45161e290f3178b549014e4dd918d69736",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48093",
+					"10.65.0.27:48093",
+					"172.17.0.1:48093",
+					"172.18.0.1:48093",
+					"172.19.0.1:48093"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:07:33.913359829Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5829259574078004,
+				"StableID":   "n1daCLm5Xn11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:766014e368d34ec617570ebfbcb0877a653874e00796ee742936cd4265e4d574",
+				"DiscoKey":   "discokey:7db08cd1aba3f54ad43a612200f22932b310d18852f4e3dfe8b0fb35b321361f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:59857",
+					"10.65.0.27:59857",
+					"172.17.0.1:59857",
+					"172.18.0.1:59857",
+					"172.19.0.1:59857"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:07:34.45097998Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4256209531504822,
+				"StableID":   "nh6UbcQeEa11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2d4fdfe535a0c6e64a6a3fc41bc85299971f84ba868056e4e25d7fa573edf360",
+				"DiscoKey":   "discokey:f332cd2d0a3e01ec1156b6552d22c803424a2a8fee63822664d364a0c32fc803",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37941",
+					"10.65.0.27:37941",
+					"172.17.0.1:37941",
+					"172.18.0.1:37941",
+					"172.19.0.1:37941"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:07:34.992520254Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4988838610444073,
+				"StableID":   "ntviXBLTxf11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80d34443476f4fa20a4be3bdb35576b9d365303295e9777678a4c4f1546fba70",
+				"DiscoKey":   "discokey:abc4a52e919001f954f9c245068883208bbd7e6d74a52d3b8fc13c067eda7d54",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51268",
+					"10.65.0.27:51268",
+					"172.17.0.1:51268",
+					"172.18.0.1:51268",
+					"172.19.0.1:51268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:07:35.53016161Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3709003317634520,
+				"StableID":   "n9f4JDEpxV11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87c4970e02ee5157815d463a7d792c882321cf8d82a0eeb7370ac3ff0b78fb18",
+				"DiscoKey":   "discokey:e0781f6e73aa3310e56169aa8f798bf25ad541e5c99150182dd7cc207e556e41",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43637",
+					"10.65.0.27:43637",
+					"172.17.0.1:43637",
+					"172.18.0.1:43637",
+					"172.19.0.1:43637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:07:36.073292326Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         818163205231930,
+				"StableID":   "nDS8n5mYP711CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e18ac31e74b1a42e3c87414b6d403e066f6ecd0002bc47c4d15c570a9e7cd246",
+				"DiscoKey":   "discokey:d375e1ba22651786da69ff86fb8875db92af0be9f4a875925ad2b96a506a160e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39948",
+					"10.65.0.27:39948",
+					"172.17.0.1:39948",
+					"172.18.0.1:39948",
+					"172.19.0.1:39948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:07:36.609205696Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3568096698125327,
+				"StableID":   "niUjqHrzrU11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6578eac37734f0ca30d21ae8707d38e30d3518f5438b01f3ada6d55c8f536136",
+				"KeyExpiry":  "2026-11-08T22:07:37Z",
+				"DiscoKey":   "discokey:62cf1aea48bbabd24deeef783337746c937d7b328bd9c293ebc4c8aeaeddfd2b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47310",
+					"10.65.0.27:47310",
+					"172.17.0.1:47310",
+					"172.18.0.1:47310",
+					"172.19.0.1:47310"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:07:37.143194956Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2796977951033685,
+				"StableID":   "nrqSjLskqN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2244680b5f743db685055692ef513ba7a799337736c5a510fb2dc311020d3d63",
+				"KeyExpiry":  "2026-11-08T22:07:37Z",
+				"DiscoKey":   "discokey:e715d93f923ae4f70de8d0db1b9fc44e7ca82432b97a69a80ef3598357ac510f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36314",
+					"10.65.0.27:36314",
+					"172.17.0.1:36314",
+					"172.18.0.1:36314",
+					"172.19.0.1:36314"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:07:37.686253398Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         866341581446789,
+				"StableID":   "n6hVuoKNm711CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9152a1f0fa73a02973a78d7a23e7a3a25308a110b22f352c2e41fc79c81f6c53",
+				"KeyExpiry":  "2026-11-08T22:07:38Z",
+				"DiscoKey":   "discokey:469b171fb99446be03db1fe5612be3930e590063ca55a4ad1f58719bcf707757",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:34961",
+					"10.65.0.27:34961",
+					"172.17.0.1:34961",
+					"172.18.0.1:34961",
+					"172.19.0.1:34961"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:07:38.230136065Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5903664245366305": {
+				"ID":          5903664245366305,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5829259574078004,
+				"StableID":   "n1daCLm5Xn11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       5829259574078004,
+				"Key":        "nodekey:766014e368d34ec617570ebfbcb0877a653874e00796ee742936cd4265e4d574",
+				"DiscoKey":   "discokey:7db08cd1aba3f54ad43a612200f22932b310d18852f4e3dfe8b0fb35b321361f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:59857",
+					"10.65.0.27:59857",
+					"172.17.0.1:59857",
+					"172.18.0.1:59857",
+					"172.19.0.1:59857"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:07:34.45097998Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:766014e368d34ec617570ebfbcb0877a653874e00796ee742936cd4265e4d574",
+			"MachineKey": "mkey:78b960148c0fcf02f98dca61f6c36938b63b0926ce1c79b723b4eb461d7b3b45",
+			"Peers": [{
+				"ID":         6479580554056551,
+				"StableID":   "nJYHHSbcbs11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:534036fee32befc8def76d19bced2611cec4c9ea5ff06fc9125ca5d3a5fa394c",
+				"DiscoKey":   "discokey:a457fd752c63433b63a00ad13c196b72bbbb879157c93a5c834b44cdb1ace34f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54446",
+					"10.65.0.27:54446",
+					"172.17.0.1:54446",
+					"172.18.0.1:54446",
+					"172.19.0.1:54446"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:07:30.684306958Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2816977717950711,
+				"StableID":   "nnrbeDEpzN11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:828c9831759071eecf78af1bdef101e9af04f11a3322b6530c02c7f5628a8072",
+				"DiscoKey":   "discokey:e428510d31c80edc8ab4911bed1cfa4ed9fb256f8a863ee87b6ea4e6325d0178",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:46201",
+					"10.65.0.27:46201",
+					"172.17.0.1:46201",
+					"172.18.0.1:46201",
+					"172.19.0.1:46201"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:07:31.206906899Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5903664245366305,
+				"StableID":   "n8pSDSFn6o11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b80dddd3a9b37a678e490fb3803dba0f8ca22d020e5a1a043d1ca93905516027",
+				"DiscoKey":   "discokey:b1184af60a53c426fc6121a2b7c4755d79e17195822f72602524a8115ba6d411",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40208",
+					"10.65.0.27:40208",
+					"172.17.0.1:40208",
+					"172.18.0.1:40208",
+					"172.19.0.1:40208"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:07:31.763176233Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6014729432040478,
+				"StableID":   "no3JS6k5yo11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6635fa423f96ea142ce0bde68b60aac1a30513c2918454449d5ace83f3c18571",
+				"DiscoKey":   "discokey:b5ee5552f812eb458150160819218256bbf444970c70664bc3dfdc4638bbac1f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60502",
+					"10.65.0.27:60502",
+					"172.17.0.1:60502",
+					"172.18.0.1:60502",
+					"172.19.0.1:60502"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:07:32.291386771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7489233362587283,
+				"StableID":   "nc7UajTtU121CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:63a921faa59da289100969ecd538b2191cc0a2be8da6ae4b4689f63da1685b60",
+				"DiscoKey":   "discokey:4ec87a46abbb8eedf790e93beddbe43a6f31049a847c7749aa714dd7c435a83a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37260",
+					"10.65.0.27:37260",
+					"172.17.0.1:37260",
+					"172.18.0.1:37260",
+					"172.19.0.1:37260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:07:32.828546148Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4881874094114602,
+				"StableID":   "nuxFW9Z18f11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d4e1c2470af4ee707df3f5e50f6f7dada568e03ff687618946fb82004ada4347",
+				"DiscoKey":   "discokey:e7f9a6a6ba9e54e2fd87153f173b9c06d7b11a7d0429bcc4f49e2d380761684e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50358",
+					"10.65.0.27:50358",
+					"172.17.0.1:50358",
+					"172.18.0.1:50358",
+					"172.19.0.1:50358"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:07:33.36759875Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8112666823820910,
+				"StableID":   "njFXh31FM621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:482e81b7f77b8b542172c99c811b67ffe2aca0ddba857f700743fa1d73ffed6a",
+				"DiscoKey":   "discokey:7e5c8435764e2abc66f1d68433595b45161e290f3178b549014e4dd918d69736",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48093",
+					"10.65.0.27:48093",
+					"172.17.0.1:48093",
+					"172.18.0.1:48093",
+					"172.19.0.1:48093"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:07:33.913359829Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4256209531504822,
+				"StableID":   "nh6UbcQeEa11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2d4fdfe535a0c6e64a6a3fc41bc85299971f84ba868056e4e25d7fa573edf360",
+				"DiscoKey":   "discokey:f332cd2d0a3e01ec1156b6552d22c803424a2a8fee63822664d364a0c32fc803",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37941",
+					"10.65.0.27:37941",
+					"172.17.0.1:37941",
+					"172.18.0.1:37941",
+					"172.19.0.1:37941"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:07:34.992520254Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4988838610444073,
+				"StableID":   "ntviXBLTxf11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80d34443476f4fa20a4be3bdb35576b9d365303295e9777678a4c4f1546fba70",
+				"DiscoKey":   "discokey:abc4a52e919001f954f9c245068883208bbd7e6d74a52d3b8fc13c067eda7d54",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51268",
+					"10.65.0.27:51268",
+					"172.17.0.1:51268",
+					"172.18.0.1:51268",
+					"172.19.0.1:51268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:07:35.53016161Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3709003317634520,
+				"StableID":   "n9f4JDEpxV11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87c4970e02ee5157815d463a7d792c882321cf8d82a0eeb7370ac3ff0b78fb18",
+				"DiscoKey":   "discokey:e0781f6e73aa3310e56169aa8f798bf25ad541e5c99150182dd7cc207e556e41",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43637",
+					"10.65.0.27:43637",
+					"172.17.0.1:43637",
+					"172.18.0.1:43637",
+					"172.19.0.1:43637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:07:36.073292326Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         818163205231930,
+				"StableID":   "nDS8n5mYP711CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e18ac31e74b1a42e3c87414b6d403e066f6ecd0002bc47c4d15c570a9e7cd246",
+				"DiscoKey":   "discokey:d375e1ba22651786da69ff86fb8875db92af0be9f4a875925ad2b96a506a160e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39948",
+					"10.65.0.27:39948",
+					"172.17.0.1:39948",
+					"172.18.0.1:39948",
+					"172.19.0.1:39948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:07:36.609205696Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3568096698125327,
+				"StableID":   "niUjqHrzrU11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6578eac37734f0ca30d21ae8707d38e30d3518f5438b01f3ada6d55c8f536136",
+				"KeyExpiry":  "2026-11-08T22:07:37Z",
+				"DiscoKey":   "discokey:62cf1aea48bbabd24deeef783337746c937d7b328bd9c293ebc4c8aeaeddfd2b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47310",
+					"10.65.0.27:47310",
+					"172.17.0.1:47310",
+					"172.18.0.1:47310",
+					"172.19.0.1:47310"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:07:37.143194956Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2796977951033685,
+				"StableID":   "nrqSjLskqN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2244680b5f743db685055692ef513ba7a799337736c5a510fb2dc311020d3d63",
+				"KeyExpiry":  "2026-11-08T22:07:37Z",
+				"DiscoKey":   "discokey:e715d93f923ae4f70de8d0db1b9fc44e7ca82432b97a69a80ef3598357ac510f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36314",
+					"10.65.0.27:36314",
+					"172.17.0.1:36314",
+					"172.18.0.1:36314",
+					"172.19.0.1:36314"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:07:37.686253398Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         866341581446789,
+				"StableID":   "n6hVuoKNm711CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9152a1f0fa73a02973a78d7a23e7a3a25308a110b22f352c2e41fc79c81f6c53",
+				"KeyExpiry":  "2026-11-08T22:07:38Z",
+				"DiscoKey":   "discokey:469b171fb99446be03db1fe5612be3930e590063ca55a4ad1f58719bcf707757",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:34961",
+					"10.65.0.27:34961",
+					"172.17.0.1:34961",
+					"172.18.0.1:34961",
+					"172.19.0.1:34961"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:07:38.230136065Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5829259574078004": {
+				"ID":          5829259574078004,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3568096698125327,
+				"StableID":   "niUjqHrzrU11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6578eac37734f0ca30d21ae8707d38e30d3518f5438b01f3ada6d55c8f536136",
+				"KeyExpiry":  "2026-11-08T22:07:37Z",
+				"DiscoKey":   "discokey:62cf1aea48bbabd24deeef783337746c937d7b328bd9c293ebc4c8aeaeddfd2b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47310",
+					"10.65.0.27:47310",
+					"172.17.0.1:47310",
+					"172.18.0.1:47310",
+					"172.19.0.1:47310"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:07:37.143194956Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6578eac37734f0ca30d21ae8707d38e30d3518f5438b01f3ada6d55c8f536136",
+			"MachineKey": "mkey:be923e38810cc74c5aa814f6e995fd2da92d0b964dd5e5a7dd5749b5285f813f",
+			"Peers": [{
+				"ID":         6479580554056551,
+				"StableID":   "nJYHHSbcbs11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:534036fee32befc8def76d19bced2611cec4c9ea5ff06fc9125ca5d3a5fa394c",
+				"DiscoKey":   "discokey:a457fd752c63433b63a00ad13c196b72bbbb879157c93a5c834b44cdb1ace34f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54446",
+					"10.65.0.27:54446",
+					"172.17.0.1:54446",
+					"172.18.0.1:54446",
+					"172.19.0.1:54446"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:07:30.684306958Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2816977717950711,
+				"StableID":   "nnrbeDEpzN11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:828c9831759071eecf78af1bdef101e9af04f11a3322b6530c02c7f5628a8072",
+				"DiscoKey":   "discokey:e428510d31c80edc8ab4911bed1cfa4ed9fb256f8a863ee87b6ea4e6325d0178",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:46201",
+					"10.65.0.27:46201",
+					"172.17.0.1:46201",
+					"172.18.0.1:46201",
+					"172.19.0.1:46201"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:07:31.206906899Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5903664245366305,
+				"StableID":   "n8pSDSFn6o11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b80dddd3a9b37a678e490fb3803dba0f8ca22d020e5a1a043d1ca93905516027",
+				"DiscoKey":   "discokey:b1184af60a53c426fc6121a2b7c4755d79e17195822f72602524a8115ba6d411",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40208",
+					"10.65.0.27:40208",
+					"172.17.0.1:40208",
+					"172.18.0.1:40208",
+					"172.19.0.1:40208"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:07:31.763176233Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6014729432040478,
+				"StableID":   "no3JS6k5yo11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6635fa423f96ea142ce0bde68b60aac1a30513c2918454449d5ace83f3c18571",
+				"DiscoKey":   "discokey:b5ee5552f812eb458150160819218256bbf444970c70664bc3dfdc4638bbac1f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60502",
+					"10.65.0.27:60502",
+					"172.17.0.1:60502",
+					"172.18.0.1:60502",
+					"172.19.0.1:60502"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:07:32.291386771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7489233362587283,
+				"StableID":   "nc7UajTtU121CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:63a921faa59da289100969ecd538b2191cc0a2be8da6ae4b4689f63da1685b60",
+				"DiscoKey":   "discokey:4ec87a46abbb8eedf790e93beddbe43a6f31049a847c7749aa714dd7c435a83a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37260",
+					"10.65.0.27:37260",
+					"172.17.0.1:37260",
+					"172.18.0.1:37260",
+					"172.19.0.1:37260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:07:32.828546148Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4881874094114602,
+				"StableID":   "nuxFW9Z18f11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d4e1c2470af4ee707df3f5e50f6f7dada568e03ff687618946fb82004ada4347",
+				"DiscoKey":   "discokey:e7f9a6a6ba9e54e2fd87153f173b9c06d7b11a7d0429bcc4f49e2d380761684e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50358",
+					"10.65.0.27:50358",
+					"172.17.0.1:50358",
+					"172.18.0.1:50358",
+					"172.19.0.1:50358"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:07:33.36759875Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8112666823820910,
+				"StableID":   "njFXh31FM621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:482e81b7f77b8b542172c99c811b67ffe2aca0ddba857f700743fa1d73ffed6a",
+				"DiscoKey":   "discokey:7e5c8435764e2abc66f1d68433595b45161e290f3178b549014e4dd918d69736",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48093",
+					"10.65.0.27:48093",
+					"172.17.0.1:48093",
+					"172.18.0.1:48093",
+					"172.19.0.1:48093"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:07:33.913359829Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5829259574078004,
+				"StableID":   "n1daCLm5Xn11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:766014e368d34ec617570ebfbcb0877a653874e00796ee742936cd4265e4d574",
+				"DiscoKey":   "discokey:7db08cd1aba3f54ad43a612200f22932b310d18852f4e3dfe8b0fb35b321361f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:59857",
+					"10.65.0.27:59857",
+					"172.17.0.1:59857",
+					"172.18.0.1:59857",
+					"172.19.0.1:59857"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:07:34.45097998Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4256209531504822,
+				"StableID":   "nh6UbcQeEa11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2d4fdfe535a0c6e64a6a3fc41bc85299971f84ba868056e4e25d7fa573edf360",
+				"DiscoKey":   "discokey:f332cd2d0a3e01ec1156b6552d22c803424a2a8fee63822664d364a0c32fc803",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37941",
+					"10.65.0.27:37941",
+					"172.17.0.1:37941",
+					"172.18.0.1:37941",
+					"172.19.0.1:37941"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:07:34.992520254Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4988838610444073,
+				"StableID":   "ntviXBLTxf11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80d34443476f4fa20a4be3bdb35576b9d365303295e9777678a4c4f1546fba70",
+				"DiscoKey":   "discokey:abc4a52e919001f954f9c245068883208bbd7e6d74a52d3b8fc13c067eda7d54",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51268",
+					"10.65.0.27:51268",
+					"172.17.0.1:51268",
+					"172.18.0.1:51268",
+					"172.19.0.1:51268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:07:35.53016161Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3709003317634520,
+				"StableID":   "n9f4JDEpxV11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87c4970e02ee5157815d463a7d792c882321cf8d82a0eeb7370ac3ff0b78fb18",
+				"DiscoKey":   "discokey:e0781f6e73aa3310e56169aa8f798bf25ad541e5c99150182dd7cc207e556e41",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43637",
+					"10.65.0.27:43637",
+					"172.17.0.1:43637",
+					"172.18.0.1:43637",
+					"172.19.0.1:43637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:07:36.073292326Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         818163205231930,
+				"StableID":   "nDS8n5mYP711CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e18ac31e74b1a42e3c87414b6d403e066f6ecd0002bc47c4d15c570a9e7cd246",
+				"DiscoKey":   "discokey:d375e1ba22651786da69ff86fb8875db92af0be9f4a875925ad2b96a506a160e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39948",
+					"10.65.0.27:39948",
+					"172.17.0.1:39948",
+					"172.18.0.1:39948",
+					"172.19.0.1:39948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:07:36.609205696Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2796977951033685,
+				"StableID":   "nrqSjLskqN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2244680b5f743db685055692ef513ba7a799337736c5a510fb2dc311020d3d63",
+				"KeyExpiry":  "2026-11-08T22:07:37Z",
+				"DiscoKey":   "discokey:e715d93f923ae4f70de8d0db1b9fc44e7ca82432b97a69a80ef3598357ac510f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36314",
+					"10.65.0.27:36314",
+					"172.17.0.1:36314",
+					"172.18.0.1:36314",
+					"172.19.0.1:36314"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:07:37.686253398Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         866341581446789,
+				"StableID":   "n6hVuoKNm711CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9152a1f0fa73a02973a78d7a23e7a3a25308a110b22f352c2e41fc79c81f6c53",
+				"KeyExpiry":  "2026-11-08T22:07:38Z",
+				"DiscoKey":   "discokey:469b171fb99446be03db1fe5612be3930e590063ca55a4ad1f58719bcf707757",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:34961",
+					"10.65.0.27:34961",
+					"172.17.0.1:34961",
+					"172.18.0.1:34961",
+					"172.19.0.1:34961"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:07:38.230136065Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3709003317634520,
+				"StableID":   "n9f4JDEpxV11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       3709003317634520,
+				"Key":        "nodekey:87c4970e02ee5157815d463a7d792c882321cf8d82a0eeb7370ac3ff0b78fb18",
+				"DiscoKey":   "discokey:e0781f6e73aa3310e56169aa8f798bf25ad541e5c99150182dd7cc207e556e41",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43637",
+					"10.65.0.27:43637",
+					"172.17.0.1:43637",
+					"172.18.0.1:43637",
+					"172.19.0.1:43637"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:07:36.073292326Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:87c4970e02ee5157815d463a7d792c882321cf8d82a0eeb7370ac3ff0b78fb18",
+			"MachineKey": "mkey:9b86aa0d9b0c910337f63bec64de8022fe41da7549aed89e0d4c080b5445041d",
+			"Peers": [{
+				"ID":         6479580554056551,
+				"StableID":   "nJYHHSbcbs11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:534036fee32befc8def76d19bced2611cec4c9ea5ff06fc9125ca5d3a5fa394c",
+				"DiscoKey":   "discokey:a457fd752c63433b63a00ad13c196b72bbbb879157c93a5c834b44cdb1ace34f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54446",
+					"10.65.0.27:54446",
+					"172.17.0.1:54446",
+					"172.18.0.1:54446",
+					"172.19.0.1:54446"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:07:30.684306958Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2816977717950711,
+				"StableID":   "nnrbeDEpzN11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:828c9831759071eecf78af1bdef101e9af04f11a3322b6530c02c7f5628a8072",
+				"DiscoKey":   "discokey:e428510d31c80edc8ab4911bed1cfa4ed9fb256f8a863ee87b6ea4e6325d0178",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:46201",
+					"10.65.0.27:46201",
+					"172.17.0.1:46201",
+					"172.18.0.1:46201",
+					"172.19.0.1:46201"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:07:31.206906899Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5903664245366305,
+				"StableID":   "n8pSDSFn6o11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b80dddd3a9b37a678e490fb3803dba0f8ca22d020e5a1a043d1ca93905516027",
+				"DiscoKey":   "discokey:b1184af60a53c426fc6121a2b7c4755d79e17195822f72602524a8115ba6d411",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40208",
+					"10.65.0.27:40208",
+					"172.17.0.1:40208",
+					"172.18.0.1:40208",
+					"172.19.0.1:40208"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:07:31.763176233Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6014729432040478,
+				"StableID":   "no3JS6k5yo11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6635fa423f96ea142ce0bde68b60aac1a30513c2918454449d5ace83f3c18571",
+				"DiscoKey":   "discokey:b5ee5552f812eb458150160819218256bbf444970c70664bc3dfdc4638bbac1f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60502",
+					"10.65.0.27:60502",
+					"172.17.0.1:60502",
+					"172.18.0.1:60502",
+					"172.19.0.1:60502"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:07:32.291386771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7489233362587283,
+				"StableID":   "nc7UajTtU121CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:63a921faa59da289100969ecd538b2191cc0a2be8da6ae4b4689f63da1685b60",
+				"DiscoKey":   "discokey:4ec87a46abbb8eedf790e93beddbe43a6f31049a847c7749aa714dd7c435a83a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37260",
+					"10.65.0.27:37260",
+					"172.17.0.1:37260",
+					"172.18.0.1:37260",
+					"172.19.0.1:37260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:07:32.828546148Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4881874094114602,
+				"StableID":   "nuxFW9Z18f11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d4e1c2470af4ee707df3f5e50f6f7dada568e03ff687618946fb82004ada4347",
+				"DiscoKey":   "discokey:e7f9a6a6ba9e54e2fd87153f173b9c06d7b11a7d0429bcc4f49e2d380761684e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50358",
+					"10.65.0.27:50358",
+					"172.17.0.1:50358",
+					"172.18.0.1:50358",
+					"172.19.0.1:50358"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:07:33.36759875Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8112666823820910,
+				"StableID":   "njFXh31FM621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:482e81b7f77b8b542172c99c811b67ffe2aca0ddba857f700743fa1d73ffed6a",
+				"DiscoKey":   "discokey:7e5c8435764e2abc66f1d68433595b45161e290f3178b549014e4dd918d69736",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48093",
+					"10.65.0.27:48093",
+					"172.17.0.1:48093",
+					"172.18.0.1:48093",
+					"172.19.0.1:48093"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:07:33.913359829Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5829259574078004,
+				"StableID":   "n1daCLm5Xn11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:766014e368d34ec617570ebfbcb0877a653874e00796ee742936cd4265e4d574",
+				"DiscoKey":   "discokey:7db08cd1aba3f54ad43a612200f22932b310d18852f4e3dfe8b0fb35b321361f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:59857",
+					"10.65.0.27:59857",
+					"172.17.0.1:59857",
+					"172.18.0.1:59857",
+					"172.19.0.1:59857"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:07:34.45097998Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4256209531504822,
+				"StableID":   "nh6UbcQeEa11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2d4fdfe535a0c6e64a6a3fc41bc85299971f84ba868056e4e25d7fa573edf360",
+				"DiscoKey":   "discokey:f332cd2d0a3e01ec1156b6552d22c803424a2a8fee63822664d364a0c32fc803",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37941",
+					"10.65.0.27:37941",
+					"172.17.0.1:37941",
+					"172.18.0.1:37941",
+					"172.19.0.1:37941"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:07:34.992520254Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4988838610444073,
+				"StableID":   "ntviXBLTxf11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80d34443476f4fa20a4be3bdb35576b9d365303295e9777678a4c4f1546fba70",
+				"DiscoKey":   "discokey:abc4a52e919001f954f9c245068883208bbd7e6d74a52d3b8fc13c067eda7d54",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51268",
+					"10.65.0.27:51268",
+					"172.17.0.1:51268",
+					"172.18.0.1:51268",
+					"172.19.0.1:51268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:07:35.53016161Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         818163205231930,
+				"StableID":   "nDS8n5mYP711CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e18ac31e74b1a42e3c87414b6d403e066f6ecd0002bc47c4d15c570a9e7cd246",
+				"DiscoKey":   "discokey:d375e1ba22651786da69ff86fb8875db92af0be9f4a875925ad2b96a506a160e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39948",
+					"10.65.0.27:39948",
+					"172.17.0.1:39948",
+					"172.18.0.1:39948",
+					"172.19.0.1:39948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:07:36.609205696Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3568096698125327,
+				"StableID":   "niUjqHrzrU11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6578eac37734f0ca30d21ae8707d38e30d3518f5438b01f3ada6d55c8f536136",
+				"KeyExpiry":  "2026-11-08T22:07:37Z",
+				"DiscoKey":   "discokey:62cf1aea48bbabd24deeef783337746c937d7b328bd9c293ebc4c8aeaeddfd2b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47310",
+					"10.65.0.27:47310",
+					"172.17.0.1:47310",
+					"172.18.0.1:47310",
+					"172.19.0.1:47310"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:07:37.143194956Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2796977951033685,
+				"StableID":   "nrqSjLskqN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2244680b5f743db685055692ef513ba7a799337736c5a510fb2dc311020d3d63",
+				"KeyExpiry":  "2026-11-08T22:07:37Z",
+				"DiscoKey":   "discokey:e715d93f923ae4f70de8d0db1b9fc44e7ca82432b97a69a80ef3598357ac510f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36314",
+					"10.65.0.27:36314",
+					"172.17.0.1:36314",
+					"172.18.0.1:36314",
+					"172.19.0.1:36314"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:07:37.686253398Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         866341581446789,
+				"StableID":   "n6hVuoKNm711CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9152a1f0fa73a02973a78d7a23e7a3a25308a110b22f352c2e41fc79c81f6c53",
+				"KeyExpiry":  "2026-11-08T22:07:38Z",
+				"DiscoKey":   "discokey:469b171fb99446be03db1fe5612be3930e590063ca55a4ad1f58719bcf707757",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:34961",
+					"10.65.0.27:34961",
+					"172.17.0.1:34961",
+					"172.18.0.1:34961",
+					"172.19.0.1:34961"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:07:38.230136065Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3709003317634520": {
+				"ID":          3709003317634520,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2816977717950711,
+				"StableID":   "nnrbeDEpzN11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       2816977717950711,
+				"Key":        "nodekey:828c9831759071eecf78af1bdef101e9af04f11a3322b6530c02c7f5628a8072",
+				"DiscoKey":   "discokey:e428510d31c80edc8ab4911bed1cfa4ed9fb256f8a863ee87b6ea4e6325d0178",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:46201",
+					"10.65.0.27:46201",
+					"172.17.0.1:46201",
+					"172.18.0.1:46201",
+					"172.19.0.1:46201"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:07:31.206906899Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:828c9831759071eecf78af1bdef101e9af04f11a3322b6530c02c7f5628a8072",
+			"MachineKey": "mkey:9d55c609b1002cbabf31070ab8b0249ff879f4ecaf4cbf98aecfd02d20711138",
+			"Peers": [{
+				"ID":         6479580554056551,
+				"StableID":   "nJYHHSbcbs11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:534036fee32befc8def76d19bced2611cec4c9ea5ff06fc9125ca5d3a5fa394c",
+				"DiscoKey":   "discokey:a457fd752c63433b63a00ad13c196b72bbbb879157c93a5c834b44cdb1ace34f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54446",
+					"10.65.0.27:54446",
+					"172.17.0.1:54446",
+					"172.18.0.1:54446",
+					"172.19.0.1:54446"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:07:30.684306958Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5903664245366305,
+				"StableID":   "n8pSDSFn6o11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b80dddd3a9b37a678e490fb3803dba0f8ca22d020e5a1a043d1ca93905516027",
+				"DiscoKey":   "discokey:b1184af60a53c426fc6121a2b7c4755d79e17195822f72602524a8115ba6d411",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40208",
+					"10.65.0.27:40208",
+					"172.17.0.1:40208",
+					"172.18.0.1:40208",
+					"172.19.0.1:40208"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:07:31.763176233Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6014729432040478,
+				"StableID":   "no3JS6k5yo11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6635fa423f96ea142ce0bde68b60aac1a30513c2918454449d5ace83f3c18571",
+				"DiscoKey":   "discokey:b5ee5552f812eb458150160819218256bbf444970c70664bc3dfdc4638bbac1f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60502",
+					"10.65.0.27:60502",
+					"172.17.0.1:60502",
+					"172.18.0.1:60502",
+					"172.19.0.1:60502"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:07:32.291386771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7489233362587283,
+				"StableID":   "nc7UajTtU121CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:63a921faa59da289100969ecd538b2191cc0a2be8da6ae4b4689f63da1685b60",
+				"DiscoKey":   "discokey:4ec87a46abbb8eedf790e93beddbe43a6f31049a847c7749aa714dd7c435a83a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37260",
+					"10.65.0.27:37260",
+					"172.17.0.1:37260",
+					"172.18.0.1:37260",
+					"172.19.0.1:37260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:07:32.828546148Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4881874094114602,
+				"StableID":   "nuxFW9Z18f11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d4e1c2470af4ee707df3f5e50f6f7dada568e03ff687618946fb82004ada4347",
+				"DiscoKey":   "discokey:e7f9a6a6ba9e54e2fd87153f173b9c06d7b11a7d0429bcc4f49e2d380761684e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50358",
+					"10.65.0.27:50358",
+					"172.17.0.1:50358",
+					"172.18.0.1:50358",
+					"172.19.0.1:50358"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:07:33.36759875Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8112666823820910,
+				"StableID":   "njFXh31FM621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:482e81b7f77b8b542172c99c811b67ffe2aca0ddba857f700743fa1d73ffed6a",
+				"DiscoKey":   "discokey:7e5c8435764e2abc66f1d68433595b45161e290f3178b549014e4dd918d69736",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48093",
+					"10.65.0.27:48093",
+					"172.17.0.1:48093",
+					"172.18.0.1:48093",
+					"172.19.0.1:48093"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:07:33.913359829Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5829259574078004,
+				"StableID":   "n1daCLm5Xn11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:766014e368d34ec617570ebfbcb0877a653874e00796ee742936cd4265e4d574",
+				"DiscoKey":   "discokey:7db08cd1aba3f54ad43a612200f22932b310d18852f4e3dfe8b0fb35b321361f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:59857",
+					"10.65.0.27:59857",
+					"172.17.0.1:59857",
+					"172.18.0.1:59857",
+					"172.19.0.1:59857"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:07:34.45097998Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4256209531504822,
+				"StableID":   "nh6UbcQeEa11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2d4fdfe535a0c6e64a6a3fc41bc85299971f84ba868056e4e25d7fa573edf360",
+				"DiscoKey":   "discokey:f332cd2d0a3e01ec1156b6552d22c803424a2a8fee63822664d364a0c32fc803",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37941",
+					"10.65.0.27:37941",
+					"172.17.0.1:37941",
+					"172.18.0.1:37941",
+					"172.19.0.1:37941"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:07:34.992520254Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4988838610444073,
+				"StableID":   "ntviXBLTxf11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80d34443476f4fa20a4be3bdb35576b9d365303295e9777678a4c4f1546fba70",
+				"DiscoKey":   "discokey:abc4a52e919001f954f9c245068883208bbd7e6d74a52d3b8fc13c067eda7d54",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51268",
+					"10.65.0.27:51268",
+					"172.17.0.1:51268",
+					"172.18.0.1:51268",
+					"172.19.0.1:51268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:07:35.53016161Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3709003317634520,
+				"StableID":   "n9f4JDEpxV11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87c4970e02ee5157815d463a7d792c882321cf8d82a0eeb7370ac3ff0b78fb18",
+				"DiscoKey":   "discokey:e0781f6e73aa3310e56169aa8f798bf25ad541e5c99150182dd7cc207e556e41",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43637",
+					"10.65.0.27:43637",
+					"172.17.0.1:43637",
+					"172.18.0.1:43637",
+					"172.19.0.1:43637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:07:36.073292326Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         818163205231930,
+				"StableID":   "nDS8n5mYP711CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e18ac31e74b1a42e3c87414b6d403e066f6ecd0002bc47c4d15c570a9e7cd246",
+				"DiscoKey":   "discokey:d375e1ba22651786da69ff86fb8875db92af0be9f4a875925ad2b96a506a160e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39948",
+					"10.65.0.27:39948",
+					"172.17.0.1:39948",
+					"172.18.0.1:39948",
+					"172.19.0.1:39948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:07:36.609205696Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3568096698125327,
+				"StableID":   "niUjqHrzrU11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6578eac37734f0ca30d21ae8707d38e30d3518f5438b01f3ada6d55c8f536136",
+				"KeyExpiry":  "2026-11-08T22:07:37Z",
+				"DiscoKey":   "discokey:62cf1aea48bbabd24deeef783337746c937d7b328bd9c293ebc4c8aeaeddfd2b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47310",
+					"10.65.0.27:47310",
+					"172.17.0.1:47310",
+					"172.18.0.1:47310",
+					"172.19.0.1:47310"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:07:37.143194956Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2796977951033685,
+				"StableID":   "nrqSjLskqN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2244680b5f743db685055692ef513ba7a799337736c5a510fb2dc311020d3d63",
+				"KeyExpiry":  "2026-11-08T22:07:37Z",
+				"DiscoKey":   "discokey:e715d93f923ae4f70de8d0db1b9fc44e7ca82432b97a69a80ef3598357ac510f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36314",
+					"10.65.0.27:36314",
+					"172.17.0.1:36314",
+					"172.18.0.1:36314",
+					"172.19.0.1:36314"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:07:37.686253398Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         866341581446789,
+				"StableID":   "n6hVuoKNm711CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9152a1f0fa73a02973a78d7a23e7a3a25308a110b22f352c2e41fc79c81f6c53",
+				"KeyExpiry":  "2026-11-08T22:07:38Z",
+				"DiscoKey":   "discokey:469b171fb99446be03db1fe5612be3930e590063ca55a4ad1f58719bcf707757",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:34961",
+					"10.65.0.27:34961",
+					"172.17.0.1:34961",
+					"172.18.0.1:34961",
+					"172.19.0.1:34961"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:07:38.230136065Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2816977717950711": {
+				"ID":          2816977717950711,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6479580554056551,
+				"StableID":   "nJYHHSbcbs11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       6479580554056551,
+				"Key":        "nodekey:534036fee32befc8def76d19bced2611cec4c9ea5ff06fc9125ca5d3a5fa394c",
+				"DiscoKey":   "discokey:a457fd752c63433b63a00ad13c196b72bbbb879157c93a5c834b44cdb1ace34f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54446",
+					"10.65.0.27:54446",
+					"172.17.0.1:54446",
+					"172.18.0.1:54446",
+					"172.19.0.1:54446"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:07:30.684306958Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:534036fee32befc8def76d19bced2611cec4c9ea5ff06fc9125ca5d3a5fa394c",
+			"MachineKey": "mkey:eaa9d47b2ee794fe4e496d072af38efd21aff8ad8c604f77311a83d583cf8c01",
+			"Peers": [{
+				"ID":         2816977717950711,
+				"StableID":   "nnrbeDEpzN11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:828c9831759071eecf78af1bdef101e9af04f11a3322b6530c02c7f5628a8072",
+				"DiscoKey":   "discokey:e428510d31c80edc8ab4911bed1cfa4ed9fb256f8a863ee87b6ea4e6325d0178",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:46201",
+					"10.65.0.27:46201",
+					"172.17.0.1:46201",
+					"172.18.0.1:46201",
+					"172.19.0.1:46201"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:07:31.206906899Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5903664245366305,
+				"StableID":   "n8pSDSFn6o11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b80dddd3a9b37a678e490fb3803dba0f8ca22d020e5a1a043d1ca93905516027",
+				"DiscoKey":   "discokey:b1184af60a53c426fc6121a2b7c4755d79e17195822f72602524a8115ba6d411",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40208",
+					"10.65.0.27:40208",
+					"172.17.0.1:40208",
+					"172.18.0.1:40208",
+					"172.19.0.1:40208"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:07:31.763176233Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6014729432040478,
+				"StableID":   "no3JS6k5yo11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6635fa423f96ea142ce0bde68b60aac1a30513c2918454449d5ace83f3c18571",
+				"DiscoKey":   "discokey:b5ee5552f812eb458150160819218256bbf444970c70664bc3dfdc4638bbac1f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60502",
+					"10.65.0.27:60502",
+					"172.17.0.1:60502",
+					"172.18.0.1:60502",
+					"172.19.0.1:60502"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:07:32.291386771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7489233362587283,
+				"StableID":   "nc7UajTtU121CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:63a921faa59da289100969ecd538b2191cc0a2be8da6ae4b4689f63da1685b60",
+				"DiscoKey":   "discokey:4ec87a46abbb8eedf790e93beddbe43a6f31049a847c7749aa714dd7c435a83a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37260",
+					"10.65.0.27:37260",
+					"172.17.0.1:37260",
+					"172.18.0.1:37260",
+					"172.19.0.1:37260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:07:32.828546148Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4881874094114602,
+				"StableID":   "nuxFW9Z18f11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d4e1c2470af4ee707df3f5e50f6f7dada568e03ff687618946fb82004ada4347",
+				"DiscoKey":   "discokey:e7f9a6a6ba9e54e2fd87153f173b9c06d7b11a7d0429bcc4f49e2d380761684e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50358",
+					"10.65.0.27:50358",
+					"172.17.0.1:50358",
+					"172.18.0.1:50358",
+					"172.19.0.1:50358"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:07:33.36759875Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8112666823820910,
+				"StableID":   "njFXh31FM621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:482e81b7f77b8b542172c99c811b67ffe2aca0ddba857f700743fa1d73ffed6a",
+				"DiscoKey":   "discokey:7e5c8435764e2abc66f1d68433595b45161e290f3178b549014e4dd918d69736",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48093",
+					"10.65.0.27:48093",
+					"172.17.0.1:48093",
+					"172.18.0.1:48093",
+					"172.19.0.1:48093"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:07:33.913359829Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5829259574078004,
+				"StableID":   "n1daCLm5Xn11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:766014e368d34ec617570ebfbcb0877a653874e00796ee742936cd4265e4d574",
+				"DiscoKey":   "discokey:7db08cd1aba3f54ad43a612200f22932b310d18852f4e3dfe8b0fb35b321361f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:59857",
+					"10.65.0.27:59857",
+					"172.17.0.1:59857",
+					"172.18.0.1:59857",
+					"172.19.0.1:59857"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:07:34.45097998Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4256209531504822,
+				"StableID":   "nh6UbcQeEa11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2d4fdfe535a0c6e64a6a3fc41bc85299971f84ba868056e4e25d7fa573edf360",
+				"DiscoKey":   "discokey:f332cd2d0a3e01ec1156b6552d22c803424a2a8fee63822664d364a0c32fc803",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37941",
+					"10.65.0.27:37941",
+					"172.17.0.1:37941",
+					"172.18.0.1:37941",
+					"172.19.0.1:37941"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:07:34.992520254Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4988838610444073,
+				"StableID":   "ntviXBLTxf11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80d34443476f4fa20a4be3bdb35576b9d365303295e9777678a4c4f1546fba70",
+				"DiscoKey":   "discokey:abc4a52e919001f954f9c245068883208bbd7e6d74a52d3b8fc13c067eda7d54",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51268",
+					"10.65.0.27:51268",
+					"172.17.0.1:51268",
+					"172.18.0.1:51268",
+					"172.19.0.1:51268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:07:35.53016161Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3709003317634520,
+				"StableID":   "n9f4JDEpxV11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87c4970e02ee5157815d463a7d792c882321cf8d82a0eeb7370ac3ff0b78fb18",
+				"DiscoKey":   "discokey:e0781f6e73aa3310e56169aa8f798bf25ad541e5c99150182dd7cc207e556e41",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43637",
+					"10.65.0.27:43637",
+					"172.17.0.1:43637",
+					"172.18.0.1:43637",
+					"172.19.0.1:43637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:07:36.073292326Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         818163205231930,
+				"StableID":   "nDS8n5mYP711CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e18ac31e74b1a42e3c87414b6d403e066f6ecd0002bc47c4d15c570a9e7cd246",
+				"DiscoKey":   "discokey:d375e1ba22651786da69ff86fb8875db92af0be9f4a875925ad2b96a506a160e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39948",
+					"10.65.0.27:39948",
+					"172.17.0.1:39948",
+					"172.18.0.1:39948",
+					"172.19.0.1:39948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:07:36.609205696Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3568096698125327,
+				"StableID":   "niUjqHrzrU11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6578eac37734f0ca30d21ae8707d38e30d3518f5438b01f3ada6d55c8f536136",
+				"KeyExpiry":  "2026-11-08T22:07:37Z",
+				"DiscoKey":   "discokey:62cf1aea48bbabd24deeef783337746c937d7b328bd9c293ebc4c8aeaeddfd2b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47310",
+					"10.65.0.27:47310",
+					"172.17.0.1:47310",
+					"172.18.0.1:47310",
+					"172.19.0.1:47310"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:07:37.143194956Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2796977951033685,
+				"StableID":   "nrqSjLskqN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2244680b5f743db685055692ef513ba7a799337736c5a510fb2dc311020d3d63",
+				"KeyExpiry":  "2026-11-08T22:07:37Z",
+				"DiscoKey":   "discokey:e715d93f923ae4f70de8d0db1b9fc44e7ca82432b97a69a80ef3598357ac510f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36314",
+					"10.65.0.27:36314",
+					"172.17.0.1:36314",
+					"172.18.0.1:36314",
+					"172.19.0.1:36314"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:07:37.686253398Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         866341581446789,
+				"StableID":   "n6hVuoKNm711CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9152a1f0fa73a02973a78d7a23e7a3a25308a110b22f352c2e41fc79c81f6c53",
+				"KeyExpiry":  "2026-11-08T22:07:38Z",
+				"DiscoKey":   "discokey:469b171fb99446be03db1fe5612be3930e590063ca55a4ad1f58719bcf707757",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:34961",
+					"10.65.0.27:34961",
+					"172.17.0.1:34961",
+					"172.18.0.1:34961",
+					"172.19.0.1:34961"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:07:38.230136065Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6479580554056551": {
+				"ID":          6479580554056551,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7489233362587283,
+				"StableID":   "nc7UajTtU121CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       7489233362587283,
+				"Key":        "nodekey:63a921faa59da289100969ecd538b2191cc0a2be8da6ae4b4689f63da1685b60",
+				"DiscoKey":   "discokey:4ec87a46abbb8eedf790e93beddbe43a6f31049a847c7749aa714dd7c435a83a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37260",
+					"10.65.0.27:37260",
+					"172.17.0.1:37260",
+					"172.18.0.1:37260",
+					"172.19.0.1:37260"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:07:32.828546148Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:63a921faa59da289100969ecd538b2191cc0a2be8da6ae4b4689f63da1685b60",
+			"MachineKey": "mkey:2ac7b53e618fd704592564d8e9aa74e1fadc40d50a25094602c40c0f8ed36914",
+			"Peers": [{
+				"ID":         6479580554056551,
+				"StableID":   "nJYHHSbcbs11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:534036fee32befc8def76d19bced2611cec4c9ea5ff06fc9125ca5d3a5fa394c",
+				"DiscoKey":   "discokey:a457fd752c63433b63a00ad13c196b72bbbb879157c93a5c834b44cdb1ace34f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54446",
+					"10.65.0.27:54446",
+					"172.17.0.1:54446",
+					"172.18.0.1:54446",
+					"172.19.0.1:54446"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:07:30.684306958Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2816977717950711,
+				"StableID":   "nnrbeDEpzN11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:828c9831759071eecf78af1bdef101e9af04f11a3322b6530c02c7f5628a8072",
+				"DiscoKey":   "discokey:e428510d31c80edc8ab4911bed1cfa4ed9fb256f8a863ee87b6ea4e6325d0178",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:46201",
+					"10.65.0.27:46201",
+					"172.17.0.1:46201",
+					"172.18.0.1:46201",
+					"172.19.0.1:46201"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:07:31.206906899Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5903664245366305,
+				"StableID":   "n8pSDSFn6o11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b80dddd3a9b37a678e490fb3803dba0f8ca22d020e5a1a043d1ca93905516027",
+				"DiscoKey":   "discokey:b1184af60a53c426fc6121a2b7c4755d79e17195822f72602524a8115ba6d411",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40208",
+					"10.65.0.27:40208",
+					"172.17.0.1:40208",
+					"172.18.0.1:40208",
+					"172.19.0.1:40208"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:07:31.763176233Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6014729432040478,
+				"StableID":   "no3JS6k5yo11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6635fa423f96ea142ce0bde68b60aac1a30513c2918454449d5ace83f3c18571",
+				"DiscoKey":   "discokey:b5ee5552f812eb458150160819218256bbf444970c70664bc3dfdc4638bbac1f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60502",
+					"10.65.0.27:60502",
+					"172.17.0.1:60502",
+					"172.18.0.1:60502",
+					"172.19.0.1:60502"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:07:32.291386771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4881874094114602,
+				"StableID":   "nuxFW9Z18f11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d4e1c2470af4ee707df3f5e50f6f7dada568e03ff687618946fb82004ada4347",
+				"DiscoKey":   "discokey:e7f9a6a6ba9e54e2fd87153f173b9c06d7b11a7d0429bcc4f49e2d380761684e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50358",
+					"10.65.0.27:50358",
+					"172.17.0.1:50358",
+					"172.18.0.1:50358",
+					"172.19.0.1:50358"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:07:33.36759875Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8112666823820910,
+				"StableID":   "njFXh31FM621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:482e81b7f77b8b542172c99c811b67ffe2aca0ddba857f700743fa1d73ffed6a",
+				"DiscoKey":   "discokey:7e5c8435764e2abc66f1d68433595b45161e290f3178b549014e4dd918d69736",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48093",
+					"10.65.0.27:48093",
+					"172.17.0.1:48093",
+					"172.18.0.1:48093",
+					"172.19.0.1:48093"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:07:33.913359829Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5829259574078004,
+				"StableID":   "n1daCLm5Xn11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:766014e368d34ec617570ebfbcb0877a653874e00796ee742936cd4265e4d574",
+				"DiscoKey":   "discokey:7db08cd1aba3f54ad43a612200f22932b310d18852f4e3dfe8b0fb35b321361f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:59857",
+					"10.65.0.27:59857",
+					"172.17.0.1:59857",
+					"172.18.0.1:59857",
+					"172.19.0.1:59857"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:07:34.45097998Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4256209531504822,
+				"StableID":   "nh6UbcQeEa11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2d4fdfe535a0c6e64a6a3fc41bc85299971f84ba868056e4e25d7fa573edf360",
+				"DiscoKey":   "discokey:f332cd2d0a3e01ec1156b6552d22c803424a2a8fee63822664d364a0c32fc803",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37941",
+					"10.65.0.27:37941",
+					"172.17.0.1:37941",
+					"172.18.0.1:37941",
+					"172.19.0.1:37941"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:07:34.992520254Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4988838610444073,
+				"StableID":   "ntviXBLTxf11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80d34443476f4fa20a4be3bdb35576b9d365303295e9777678a4c4f1546fba70",
+				"DiscoKey":   "discokey:abc4a52e919001f954f9c245068883208bbd7e6d74a52d3b8fc13c067eda7d54",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51268",
+					"10.65.0.27:51268",
+					"172.17.0.1:51268",
+					"172.18.0.1:51268",
+					"172.19.0.1:51268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:07:35.53016161Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3709003317634520,
+				"StableID":   "n9f4JDEpxV11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87c4970e02ee5157815d463a7d792c882321cf8d82a0eeb7370ac3ff0b78fb18",
+				"DiscoKey":   "discokey:e0781f6e73aa3310e56169aa8f798bf25ad541e5c99150182dd7cc207e556e41",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43637",
+					"10.65.0.27:43637",
+					"172.17.0.1:43637",
+					"172.18.0.1:43637",
+					"172.19.0.1:43637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:07:36.073292326Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         818163205231930,
+				"StableID":   "nDS8n5mYP711CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e18ac31e74b1a42e3c87414b6d403e066f6ecd0002bc47c4d15c570a9e7cd246",
+				"DiscoKey":   "discokey:d375e1ba22651786da69ff86fb8875db92af0be9f4a875925ad2b96a506a160e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39948",
+					"10.65.0.27:39948",
+					"172.17.0.1:39948",
+					"172.18.0.1:39948",
+					"172.19.0.1:39948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:07:36.609205696Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3568096698125327,
+				"StableID":   "niUjqHrzrU11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6578eac37734f0ca30d21ae8707d38e30d3518f5438b01f3ada6d55c8f536136",
+				"KeyExpiry":  "2026-11-08T22:07:37Z",
+				"DiscoKey":   "discokey:62cf1aea48bbabd24deeef783337746c937d7b328bd9c293ebc4c8aeaeddfd2b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47310",
+					"10.65.0.27:47310",
+					"172.17.0.1:47310",
+					"172.18.0.1:47310",
+					"172.19.0.1:47310"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:07:37.143194956Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2796977951033685,
+				"StableID":   "nrqSjLskqN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2244680b5f743db685055692ef513ba7a799337736c5a510fb2dc311020d3d63",
+				"KeyExpiry":  "2026-11-08T22:07:37Z",
+				"DiscoKey":   "discokey:e715d93f923ae4f70de8d0db1b9fc44e7ca82432b97a69a80ef3598357ac510f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36314",
+					"10.65.0.27:36314",
+					"172.17.0.1:36314",
+					"172.18.0.1:36314",
+					"172.19.0.1:36314"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:07:37.686253398Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         866341581446789,
+				"StableID":   "n6hVuoKNm711CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9152a1f0fa73a02973a78d7a23e7a3a25308a110b22f352c2e41fc79c81f6c53",
+				"KeyExpiry":  "2026-11-08T22:07:38Z",
+				"DiscoKey":   "discokey:469b171fb99446be03db1fe5612be3930e590063ca55a4ad1f58719bcf707757",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:34961",
+					"10.65.0.27:34961",
+					"172.17.0.1:34961",
+					"172.18.0.1:34961",
+					"172.19.0.1:34961"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:07:38.230136065Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7489233362587283": {
+				"ID":          7489233362587283,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6014729432040478,
+				"StableID":   "no3JS6k5yo11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       6014729432040478,
+				"Key":        "nodekey:6635fa423f96ea142ce0bde68b60aac1a30513c2918454449d5ace83f3c18571",
+				"DiscoKey":   "discokey:b5ee5552f812eb458150160819218256bbf444970c70664bc3dfdc4638bbac1f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60502",
+					"10.65.0.27:60502",
+					"172.17.0.1:60502",
+					"172.18.0.1:60502",
+					"172.19.0.1:60502"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:07:32.291386771Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6635fa423f96ea142ce0bde68b60aac1a30513c2918454449d5ace83f3c18571",
+			"MachineKey": "mkey:aa554d592fb3f0f09121c27bb2a4877d3ee34f0dda4d838c15471b7287bcd13a",
+			"Peers": [{
+				"ID":         6479580554056551,
+				"StableID":   "nJYHHSbcbs11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:534036fee32befc8def76d19bced2611cec4c9ea5ff06fc9125ca5d3a5fa394c",
+				"DiscoKey":   "discokey:a457fd752c63433b63a00ad13c196b72bbbb879157c93a5c834b44cdb1ace34f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54446",
+					"10.65.0.27:54446",
+					"172.17.0.1:54446",
+					"172.18.0.1:54446",
+					"172.19.0.1:54446"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:07:30.684306958Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2816977717950711,
+				"StableID":   "nnrbeDEpzN11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:828c9831759071eecf78af1bdef101e9af04f11a3322b6530c02c7f5628a8072",
+				"DiscoKey":   "discokey:e428510d31c80edc8ab4911bed1cfa4ed9fb256f8a863ee87b6ea4e6325d0178",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:46201",
+					"10.65.0.27:46201",
+					"172.17.0.1:46201",
+					"172.18.0.1:46201",
+					"172.19.0.1:46201"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:07:31.206906899Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5903664245366305,
+				"StableID":   "n8pSDSFn6o11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b80dddd3a9b37a678e490fb3803dba0f8ca22d020e5a1a043d1ca93905516027",
+				"DiscoKey":   "discokey:b1184af60a53c426fc6121a2b7c4755d79e17195822f72602524a8115ba6d411",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40208",
+					"10.65.0.27:40208",
+					"172.17.0.1:40208",
+					"172.18.0.1:40208",
+					"172.19.0.1:40208"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:07:31.763176233Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7489233362587283,
+				"StableID":   "nc7UajTtU121CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:63a921faa59da289100969ecd538b2191cc0a2be8da6ae4b4689f63da1685b60",
+				"DiscoKey":   "discokey:4ec87a46abbb8eedf790e93beddbe43a6f31049a847c7749aa714dd7c435a83a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37260",
+					"10.65.0.27:37260",
+					"172.17.0.1:37260",
+					"172.18.0.1:37260",
+					"172.19.0.1:37260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:07:32.828546148Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4881874094114602,
+				"StableID":   "nuxFW9Z18f11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d4e1c2470af4ee707df3f5e50f6f7dada568e03ff687618946fb82004ada4347",
+				"DiscoKey":   "discokey:e7f9a6a6ba9e54e2fd87153f173b9c06d7b11a7d0429bcc4f49e2d380761684e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50358",
+					"10.65.0.27:50358",
+					"172.17.0.1:50358",
+					"172.18.0.1:50358",
+					"172.19.0.1:50358"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:07:33.36759875Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8112666823820910,
+				"StableID":   "njFXh31FM621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:482e81b7f77b8b542172c99c811b67ffe2aca0ddba857f700743fa1d73ffed6a",
+				"DiscoKey":   "discokey:7e5c8435764e2abc66f1d68433595b45161e290f3178b549014e4dd918d69736",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48093",
+					"10.65.0.27:48093",
+					"172.17.0.1:48093",
+					"172.18.0.1:48093",
+					"172.19.0.1:48093"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:07:33.913359829Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5829259574078004,
+				"StableID":   "n1daCLm5Xn11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:766014e368d34ec617570ebfbcb0877a653874e00796ee742936cd4265e4d574",
+				"DiscoKey":   "discokey:7db08cd1aba3f54ad43a612200f22932b310d18852f4e3dfe8b0fb35b321361f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:59857",
+					"10.65.0.27:59857",
+					"172.17.0.1:59857",
+					"172.18.0.1:59857",
+					"172.19.0.1:59857"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:07:34.45097998Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4256209531504822,
+				"StableID":   "nh6UbcQeEa11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2d4fdfe535a0c6e64a6a3fc41bc85299971f84ba868056e4e25d7fa573edf360",
+				"DiscoKey":   "discokey:f332cd2d0a3e01ec1156b6552d22c803424a2a8fee63822664d364a0c32fc803",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37941",
+					"10.65.0.27:37941",
+					"172.17.0.1:37941",
+					"172.18.0.1:37941",
+					"172.19.0.1:37941"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:07:34.992520254Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4988838610444073,
+				"StableID":   "ntviXBLTxf11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80d34443476f4fa20a4be3bdb35576b9d365303295e9777678a4c4f1546fba70",
+				"DiscoKey":   "discokey:abc4a52e919001f954f9c245068883208bbd7e6d74a52d3b8fc13c067eda7d54",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51268",
+					"10.65.0.27:51268",
+					"172.17.0.1:51268",
+					"172.18.0.1:51268",
+					"172.19.0.1:51268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:07:35.53016161Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3709003317634520,
+				"StableID":   "n9f4JDEpxV11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87c4970e02ee5157815d463a7d792c882321cf8d82a0eeb7370ac3ff0b78fb18",
+				"DiscoKey":   "discokey:e0781f6e73aa3310e56169aa8f798bf25ad541e5c99150182dd7cc207e556e41",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43637",
+					"10.65.0.27:43637",
+					"172.17.0.1:43637",
+					"172.18.0.1:43637",
+					"172.19.0.1:43637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:07:36.073292326Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         818163205231930,
+				"StableID":   "nDS8n5mYP711CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e18ac31e74b1a42e3c87414b6d403e066f6ecd0002bc47c4d15c570a9e7cd246",
+				"DiscoKey":   "discokey:d375e1ba22651786da69ff86fb8875db92af0be9f4a875925ad2b96a506a160e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39948",
+					"10.65.0.27:39948",
+					"172.17.0.1:39948",
+					"172.18.0.1:39948",
+					"172.19.0.1:39948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:07:36.609205696Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3568096698125327,
+				"StableID":   "niUjqHrzrU11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6578eac37734f0ca30d21ae8707d38e30d3518f5438b01f3ada6d55c8f536136",
+				"KeyExpiry":  "2026-11-08T22:07:37Z",
+				"DiscoKey":   "discokey:62cf1aea48bbabd24deeef783337746c937d7b328bd9c293ebc4c8aeaeddfd2b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47310",
+					"10.65.0.27:47310",
+					"172.17.0.1:47310",
+					"172.18.0.1:47310",
+					"172.19.0.1:47310"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:07:37.143194956Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2796977951033685,
+				"StableID":   "nrqSjLskqN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2244680b5f743db685055692ef513ba7a799337736c5a510fb2dc311020d3d63",
+				"KeyExpiry":  "2026-11-08T22:07:37Z",
+				"DiscoKey":   "discokey:e715d93f923ae4f70de8d0db1b9fc44e7ca82432b97a69a80ef3598357ac510f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36314",
+					"10.65.0.27:36314",
+					"172.17.0.1:36314",
+					"172.18.0.1:36314",
+					"172.19.0.1:36314"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:07:37.686253398Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         866341581446789,
+				"StableID":   "n6hVuoKNm711CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9152a1f0fa73a02973a78d7a23e7a3a25308a110b22f352c2e41fc79c81f6c53",
+				"KeyExpiry":  "2026-11-08T22:07:38Z",
+				"DiscoKey":   "discokey:469b171fb99446be03db1fe5612be3930e590063ca55a4ad1f58719bcf707757",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:34961",
+					"10.65.0.27:34961",
+					"172.17.0.1:34961",
+					"172.18.0.1:34961",
+					"172.19.0.1:34961"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:07:38.230136065Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6014729432040478": {
+				"ID":          6014729432040478,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8112666823820910,
+				"StableID":   "njFXh31FM621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       8112666823820910,
+				"Key":        "nodekey:482e81b7f77b8b542172c99c811b67ffe2aca0ddba857f700743fa1d73ffed6a",
+				"DiscoKey":   "discokey:7e5c8435764e2abc66f1d68433595b45161e290f3178b549014e4dd918d69736",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48093",
+					"10.65.0.27:48093",
+					"172.17.0.1:48093",
+					"172.18.0.1:48093",
+					"172.19.0.1:48093"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:07:33.913359829Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:482e81b7f77b8b542172c99c811b67ffe2aca0ddba857f700743fa1d73ffed6a",
+			"MachineKey": "mkey:af10c878c40477f3a5617dbb1829411a30be4922239b552c78adff7a8cf0865f",
+			"Peers": [{
+				"ID":         6479580554056551,
+				"StableID":   "nJYHHSbcbs11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:534036fee32befc8def76d19bced2611cec4c9ea5ff06fc9125ca5d3a5fa394c",
+				"DiscoKey":   "discokey:a457fd752c63433b63a00ad13c196b72bbbb879157c93a5c834b44cdb1ace34f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54446",
+					"10.65.0.27:54446",
+					"172.17.0.1:54446",
+					"172.18.0.1:54446",
+					"172.19.0.1:54446"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:07:30.684306958Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2816977717950711,
+				"StableID":   "nnrbeDEpzN11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:828c9831759071eecf78af1bdef101e9af04f11a3322b6530c02c7f5628a8072",
+				"DiscoKey":   "discokey:e428510d31c80edc8ab4911bed1cfa4ed9fb256f8a863ee87b6ea4e6325d0178",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:46201",
+					"10.65.0.27:46201",
+					"172.17.0.1:46201",
+					"172.18.0.1:46201",
+					"172.19.0.1:46201"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:07:31.206906899Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5903664245366305,
+				"StableID":   "n8pSDSFn6o11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b80dddd3a9b37a678e490fb3803dba0f8ca22d020e5a1a043d1ca93905516027",
+				"DiscoKey":   "discokey:b1184af60a53c426fc6121a2b7c4755d79e17195822f72602524a8115ba6d411",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40208",
+					"10.65.0.27:40208",
+					"172.17.0.1:40208",
+					"172.18.0.1:40208",
+					"172.19.0.1:40208"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:07:31.763176233Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6014729432040478,
+				"StableID":   "no3JS6k5yo11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6635fa423f96ea142ce0bde68b60aac1a30513c2918454449d5ace83f3c18571",
+				"DiscoKey":   "discokey:b5ee5552f812eb458150160819218256bbf444970c70664bc3dfdc4638bbac1f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60502",
+					"10.65.0.27:60502",
+					"172.17.0.1:60502",
+					"172.18.0.1:60502",
+					"172.19.0.1:60502"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:07:32.291386771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7489233362587283,
+				"StableID":   "nc7UajTtU121CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:63a921faa59da289100969ecd538b2191cc0a2be8da6ae4b4689f63da1685b60",
+				"DiscoKey":   "discokey:4ec87a46abbb8eedf790e93beddbe43a6f31049a847c7749aa714dd7c435a83a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37260",
+					"10.65.0.27:37260",
+					"172.17.0.1:37260",
+					"172.18.0.1:37260",
+					"172.19.0.1:37260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:07:32.828546148Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4881874094114602,
+				"StableID":   "nuxFW9Z18f11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d4e1c2470af4ee707df3f5e50f6f7dada568e03ff687618946fb82004ada4347",
+				"DiscoKey":   "discokey:e7f9a6a6ba9e54e2fd87153f173b9c06d7b11a7d0429bcc4f49e2d380761684e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50358",
+					"10.65.0.27:50358",
+					"172.17.0.1:50358",
+					"172.18.0.1:50358",
+					"172.19.0.1:50358"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:07:33.36759875Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5829259574078004,
+				"StableID":   "n1daCLm5Xn11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:766014e368d34ec617570ebfbcb0877a653874e00796ee742936cd4265e4d574",
+				"DiscoKey":   "discokey:7db08cd1aba3f54ad43a612200f22932b310d18852f4e3dfe8b0fb35b321361f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:59857",
+					"10.65.0.27:59857",
+					"172.17.0.1:59857",
+					"172.18.0.1:59857",
+					"172.19.0.1:59857"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:07:34.45097998Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4256209531504822,
+				"StableID":   "nh6UbcQeEa11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2d4fdfe535a0c6e64a6a3fc41bc85299971f84ba868056e4e25d7fa573edf360",
+				"DiscoKey":   "discokey:f332cd2d0a3e01ec1156b6552d22c803424a2a8fee63822664d364a0c32fc803",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37941",
+					"10.65.0.27:37941",
+					"172.17.0.1:37941",
+					"172.18.0.1:37941",
+					"172.19.0.1:37941"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:07:34.992520254Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4988838610444073,
+				"StableID":   "ntviXBLTxf11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80d34443476f4fa20a4be3bdb35576b9d365303295e9777678a4c4f1546fba70",
+				"DiscoKey":   "discokey:abc4a52e919001f954f9c245068883208bbd7e6d74a52d3b8fc13c067eda7d54",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51268",
+					"10.65.0.27:51268",
+					"172.17.0.1:51268",
+					"172.18.0.1:51268",
+					"172.19.0.1:51268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:07:35.53016161Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3709003317634520,
+				"StableID":   "n9f4JDEpxV11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87c4970e02ee5157815d463a7d792c882321cf8d82a0eeb7370ac3ff0b78fb18",
+				"DiscoKey":   "discokey:e0781f6e73aa3310e56169aa8f798bf25ad541e5c99150182dd7cc207e556e41",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43637",
+					"10.65.0.27:43637",
+					"172.17.0.1:43637",
+					"172.18.0.1:43637",
+					"172.19.0.1:43637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:07:36.073292326Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         818163205231930,
+				"StableID":   "nDS8n5mYP711CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e18ac31e74b1a42e3c87414b6d403e066f6ecd0002bc47c4d15c570a9e7cd246",
+				"DiscoKey":   "discokey:d375e1ba22651786da69ff86fb8875db92af0be9f4a875925ad2b96a506a160e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39948",
+					"10.65.0.27:39948",
+					"172.17.0.1:39948",
+					"172.18.0.1:39948",
+					"172.19.0.1:39948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:07:36.609205696Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3568096698125327,
+				"StableID":   "niUjqHrzrU11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6578eac37734f0ca30d21ae8707d38e30d3518f5438b01f3ada6d55c8f536136",
+				"KeyExpiry":  "2026-11-08T22:07:37Z",
+				"DiscoKey":   "discokey:62cf1aea48bbabd24deeef783337746c937d7b328bd9c293ebc4c8aeaeddfd2b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47310",
+					"10.65.0.27:47310",
+					"172.17.0.1:47310",
+					"172.18.0.1:47310",
+					"172.19.0.1:47310"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:07:37.143194956Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2796977951033685,
+				"StableID":   "nrqSjLskqN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2244680b5f743db685055692ef513ba7a799337736c5a510fb2dc311020d3d63",
+				"KeyExpiry":  "2026-11-08T22:07:37Z",
+				"DiscoKey":   "discokey:e715d93f923ae4f70de8d0db1b9fc44e7ca82432b97a69a80ef3598357ac510f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36314",
+					"10.65.0.27:36314",
+					"172.17.0.1:36314",
+					"172.18.0.1:36314",
+					"172.19.0.1:36314"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:07:37.686253398Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         866341581446789,
+				"StableID":   "n6hVuoKNm711CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9152a1f0fa73a02973a78d7a23e7a3a25308a110b22f352c2e41fc79c81f6c53",
+				"KeyExpiry":  "2026-11-08T22:07:38Z",
+				"DiscoKey":   "discokey:469b171fb99446be03db1fe5612be3930e590063ca55a4ad1f58719bcf707757",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:34961",
+					"10.65.0.27:34961",
+					"172.17.0.1:34961",
+					"172.18.0.1:34961",
+					"172.19.0.1:34961"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:07:38.230136065Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8112666823820910": {
+				"ID":          8112666823820910,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4256209531504822,
+				"StableID":   "nh6UbcQeEa11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       4256209531504822,
+				"Key":        "nodekey:2d4fdfe535a0c6e64a6a3fc41bc85299971f84ba868056e4e25d7fa573edf360",
+				"DiscoKey":   "discokey:f332cd2d0a3e01ec1156b6552d22c803424a2a8fee63822664d364a0c32fc803",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37941",
+					"10.65.0.27:37941",
+					"172.17.0.1:37941",
+					"172.18.0.1:37941",
+					"172.19.0.1:37941"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:07:34.992520254Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2d4fdfe535a0c6e64a6a3fc41bc85299971f84ba868056e4e25d7fa573edf360",
+			"MachineKey": "mkey:2fa3ee9b0087093eb4a8c142b3d2d43fd0419fd11561eb83e9a23f694421ed16",
+			"Peers": [{
+				"ID":         6479580554056551,
+				"StableID":   "nJYHHSbcbs11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:534036fee32befc8def76d19bced2611cec4c9ea5ff06fc9125ca5d3a5fa394c",
+				"DiscoKey":   "discokey:a457fd752c63433b63a00ad13c196b72bbbb879157c93a5c834b44cdb1ace34f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54446",
+					"10.65.0.27:54446",
+					"172.17.0.1:54446",
+					"172.18.0.1:54446",
+					"172.19.0.1:54446"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:07:30.684306958Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2816977717950711,
+				"StableID":   "nnrbeDEpzN11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:828c9831759071eecf78af1bdef101e9af04f11a3322b6530c02c7f5628a8072",
+				"DiscoKey":   "discokey:e428510d31c80edc8ab4911bed1cfa4ed9fb256f8a863ee87b6ea4e6325d0178",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:46201",
+					"10.65.0.27:46201",
+					"172.17.0.1:46201",
+					"172.18.0.1:46201",
+					"172.19.0.1:46201"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:07:31.206906899Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5903664245366305,
+				"StableID":   "n8pSDSFn6o11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b80dddd3a9b37a678e490fb3803dba0f8ca22d020e5a1a043d1ca93905516027",
+				"DiscoKey":   "discokey:b1184af60a53c426fc6121a2b7c4755d79e17195822f72602524a8115ba6d411",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40208",
+					"10.65.0.27:40208",
+					"172.17.0.1:40208",
+					"172.18.0.1:40208",
+					"172.19.0.1:40208"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:07:31.763176233Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6014729432040478,
+				"StableID":   "no3JS6k5yo11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6635fa423f96ea142ce0bde68b60aac1a30513c2918454449d5ace83f3c18571",
+				"DiscoKey":   "discokey:b5ee5552f812eb458150160819218256bbf444970c70664bc3dfdc4638bbac1f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60502",
+					"10.65.0.27:60502",
+					"172.17.0.1:60502",
+					"172.18.0.1:60502",
+					"172.19.0.1:60502"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:07:32.291386771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7489233362587283,
+				"StableID":   "nc7UajTtU121CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:63a921faa59da289100969ecd538b2191cc0a2be8da6ae4b4689f63da1685b60",
+				"DiscoKey":   "discokey:4ec87a46abbb8eedf790e93beddbe43a6f31049a847c7749aa714dd7c435a83a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37260",
+					"10.65.0.27:37260",
+					"172.17.0.1:37260",
+					"172.18.0.1:37260",
+					"172.19.0.1:37260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:07:32.828546148Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4881874094114602,
+				"StableID":   "nuxFW9Z18f11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d4e1c2470af4ee707df3f5e50f6f7dada568e03ff687618946fb82004ada4347",
+				"DiscoKey":   "discokey:e7f9a6a6ba9e54e2fd87153f173b9c06d7b11a7d0429bcc4f49e2d380761684e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50358",
+					"10.65.0.27:50358",
+					"172.17.0.1:50358",
+					"172.18.0.1:50358",
+					"172.19.0.1:50358"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:07:33.36759875Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8112666823820910,
+				"StableID":   "njFXh31FM621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:482e81b7f77b8b542172c99c811b67ffe2aca0ddba857f700743fa1d73ffed6a",
+				"DiscoKey":   "discokey:7e5c8435764e2abc66f1d68433595b45161e290f3178b549014e4dd918d69736",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48093",
+					"10.65.0.27:48093",
+					"172.17.0.1:48093",
+					"172.18.0.1:48093",
+					"172.19.0.1:48093"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:07:33.913359829Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5829259574078004,
+				"StableID":   "n1daCLm5Xn11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:766014e368d34ec617570ebfbcb0877a653874e00796ee742936cd4265e4d574",
+				"DiscoKey":   "discokey:7db08cd1aba3f54ad43a612200f22932b310d18852f4e3dfe8b0fb35b321361f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:59857",
+					"10.65.0.27:59857",
+					"172.17.0.1:59857",
+					"172.18.0.1:59857",
+					"172.19.0.1:59857"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:07:34.45097998Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4988838610444073,
+				"StableID":   "ntviXBLTxf11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80d34443476f4fa20a4be3bdb35576b9d365303295e9777678a4c4f1546fba70",
+				"DiscoKey":   "discokey:abc4a52e919001f954f9c245068883208bbd7e6d74a52d3b8fc13c067eda7d54",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51268",
+					"10.65.0.27:51268",
+					"172.17.0.1:51268",
+					"172.18.0.1:51268",
+					"172.19.0.1:51268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:07:35.53016161Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3709003317634520,
+				"StableID":   "n9f4JDEpxV11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87c4970e02ee5157815d463a7d792c882321cf8d82a0eeb7370ac3ff0b78fb18",
+				"DiscoKey":   "discokey:e0781f6e73aa3310e56169aa8f798bf25ad541e5c99150182dd7cc207e556e41",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43637",
+					"10.65.0.27:43637",
+					"172.17.0.1:43637",
+					"172.18.0.1:43637",
+					"172.19.0.1:43637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:07:36.073292326Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         818163205231930,
+				"StableID":   "nDS8n5mYP711CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e18ac31e74b1a42e3c87414b6d403e066f6ecd0002bc47c4d15c570a9e7cd246",
+				"DiscoKey":   "discokey:d375e1ba22651786da69ff86fb8875db92af0be9f4a875925ad2b96a506a160e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39948",
+					"10.65.0.27:39948",
+					"172.17.0.1:39948",
+					"172.18.0.1:39948",
+					"172.19.0.1:39948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:07:36.609205696Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3568096698125327,
+				"StableID":   "niUjqHrzrU11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6578eac37734f0ca30d21ae8707d38e30d3518f5438b01f3ada6d55c8f536136",
+				"KeyExpiry":  "2026-11-08T22:07:37Z",
+				"DiscoKey":   "discokey:62cf1aea48bbabd24deeef783337746c937d7b328bd9c293ebc4c8aeaeddfd2b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47310",
+					"10.65.0.27:47310",
+					"172.17.0.1:47310",
+					"172.18.0.1:47310",
+					"172.19.0.1:47310"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:07:37.143194956Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2796977951033685,
+				"StableID":   "nrqSjLskqN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2244680b5f743db685055692ef513ba7a799337736c5a510fb2dc311020d3d63",
+				"KeyExpiry":  "2026-11-08T22:07:37Z",
+				"DiscoKey":   "discokey:e715d93f923ae4f70de8d0db1b9fc44e7ca82432b97a69a80ef3598357ac510f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36314",
+					"10.65.0.27:36314",
+					"172.17.0.1:36314",
+					"172.18.0.1:36314",
+					"172.19.0.1:36314"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:07:37.686253398Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         866341581446789,
+				"StableID":   "n6hVuoKNm711CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9152a1f0fa73a02973a78d7a23e7a3a25308a110b22f352c2e41fc79c81f6c53",
+				"KeyExpiry":  "2026-11-08T22:07:38Z",
+				"DiscoKey":   "discokey:469b171fb99446be03db1fe5612be3930e590063ca55a4ad1f58719bcf707757",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:34961",
+					"10.65.0.27:34961",
+					"172.17.0.1:34961",
+					"172.18.0.1:34961",
+					"172.19.0.1:34961"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:07:38.230136065Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4256209531504822": {
+				"ID":          4256209531504822,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2796977951033685,
+				"StableID":   "nrqSjLskqN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2244680b5f743db685055692ef513ba7a799337736c5a510fb2dc311020d3d63",
+				"KeyExpiry":  "2026-11-08T22:07:37Z",
+				"DiscoKey":   "discokey:e715d93f923ae4f70de8d0db1b9fc44e7ca82432b97a69a80ef3598357ac510f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36314",
+					"10.65.0.27:36314",
+					"172.17.0.1:36314",
+					"172.18.0.1:36314",
+					"172.19.0.1:36314"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:07:37.686253398Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2244680b5f743db685055692ef513ba7a799337736c5a510fb2dc311020d3d63",
+			"MachineKey": "mkey:39085024f7c1b2290de46371a837b46c1f26a7b14df72396067c7241f3e20318",
+			"Peers": [{
+				"ID":         6479580554056551,
+				"StableID":   "nJYHHSbcbs11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:534036fee32befc8def76d19bced2611cec4c9ea5ff06fc9125ca5d3a5fa394c",
+				"DiscoKey":   "discokey:a457fd752c63433b63a00ad13c196b72bbbb879157c93a5c834b44cdb1ace34f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54446",
+					"10.65.0.27:54446",
+					"172.17.0.1:54446",
+					"172.18.0.1:54446",
+					"172.19.0.1:54446"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:07:30.684306958Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2816977717950711,
+				"StableID":   "nnrbeDEpzN11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:828c9831759071eecf78af1bdef101e9af04f11a3322b6530c02c7f5628a8072",
+				"DiscoKey":   "discokey:e428510d31c80edc8ab4911bed1cfa4ed9fb256f8a863ee87b6ea4e6325d0178",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:46201",
+					"10.65.0.27:46201",
+					"172.17.0.1:46201",
+					"172.18.0.1:46201",
+					"172.19.0.1:46201"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:07:31.206906899Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5903664245366305,
+				"StableID":   "n8pSDSFn6o11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b80dddd3a9b37a678e490fb3803dba0f8ca22d020e5a1a043d1ca93905516027",
+				"DiscoKey":   "discokey:b1184af60a53c426fc6121a2b7c4755d79e17195822f72602524a8115ba6d411",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40208",
+					"10.65.0.27:40208",
+					"172.17.0.1:40208",
+					"172.18.0.1:40208",
+					"172.19.0.1:40208"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:07:31.763176233Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6014729432040478,
+				"StableID":   "no3JS6k5yo11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6635fa423f96ea142ce0bde68b60aac1a30513c2918454449d5ace83f3c18571",
+				"DiscoKey":   "discokey:b5ee5552f812eb458150160819218256bbf444970c70664bc3dfdc4638bbac1f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60502",
+					"10.65.0.27:60502",
+					"172.17.0.1:60502",
+					"172.18.0.1:60502",
+					"172.19.0.1:60502"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:07:32.291386771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7489233362587283,
+				"StableID":   "nc7UajTtU121CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:63a921faa59da289100969ecd538b2191cc0a2be8da6ae4b4689f63da1685b60",
+				"DiscoKey":   "discokey:4ec87a46abbb8eedf790e93beddbe43a6f31049a847c7749aa714dd7c435a83a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37260",
+					"10.65.0.27:37260",
+					"172.17.0.1:37260",
+					"172.18.0.1:37260",
+					"172.19.0.1:37260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:07:32.828546148Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4881874094114602,
+				"StableID":   "nuxFW9Z18f11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d4e1c2470af4ee707df3f5e50f6f7dada568e03ff687618946fb82004ada4347",
+				"DiscoKey":   "discokey:e7f9a6a6ba9e54e2fd87153f173b9c06d7b11a7d0429bcc4f49e2d380761684e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50358",
+					"10.65.0.27:50358",
+					"172.17.0.1:50358",
+					"172.18.0.1:50358",
+					"172.19.0.1:50358"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:07:33.36759875Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8112666823820910,
+				"StableID":   "njFXh31FM621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:482e81b7f77b8b542172c99c811b67ffe2aca0ddba857f700743fa1d73ffed6a",
+				"DiscoKey":   "discokey:7e5c8435764e2abc66f1d68433595b45161e290f3178b549014e4dd918d69736",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48093",
+					"10.65.0.27:48093",
+					"172.17.0.1:48093",
+					"172.18.0.1:48093",
+					"172.19.0.1:48093"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:07:33.913359829Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5829259574078004,
+				"StableID":   "n1daCLm5Xn11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:766014e368d34ec617570ebfbcb0877a653874e00796ee742936cd4265e4d574",
+				"DiscoKey":   "discokey:7db08cd1aba3f54ad43a612200f22932b310d18852f4e3dfe8b0fb35b321361f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:59857",
+					"10.65.0.27:59857",
+					"172.17.0.1:59857",
+					"172.18.0.1:59857",
+					"172.19.0.1:59857"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:07:34.45097998Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4256209531504822,
+				"StableID":   "nh6UbcQeEa11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2d4fdfe535a0c6e64a6a3fc41bc85299971f84ba868056e4e25d7fa573edf360",
+				"DiscoKey":   "discokey:f332cd2d0a3e01ec1156b6552d22c803424a2a8fee63822664d364a0c32fc803",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37941",
+					"10.65.0.27:37941",
+					"172.17.0.1:37941",
+					"172.18.0.1:37941",
+					"172.19.0.1:37941"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:07:34.992520254Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4988838610444073,
+				"StableID":   "ntviXBLTxf11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80d34443476f4fa20a4be3bdb35576b9d365303295e9777678a4c4f1546fba70",
+				"DiscoKey":   "discokey:abc4a52e919001f954f9c245068883208bbd7e6d74a52d3b8fc13c067eda7d54",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51268",
+					"10.65.0.27:51268",
+					"172.17.0.1:51268",
+					"172.18.0.1:51268",
+					"172.19.0.1:51268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:07:35.53016161Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3709003317634520,
+				"StableID":   "n9f4JDEpxV11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87c4970e02ee5157815d463a7d792c882321cf8d82a0eeb7370ac3ff0b78fb18",
+				"DiscoKey":   "discokey:e0781f6e73aa3310e56169aa8f798bf25ad541e5c99150182dd7cc207e556e41",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43637",
+					"10.65.0.27:43637",
+					"172.17.0.1:43637",
+					"172.18.0.1:43637",
+					"172.19.0.1:43637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:07:36.073292326Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         818163205231930,
+				"StableID":   "nDS8n5mYP711CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e18ac31e74b1a42e3c87414b6d403e066f6ecd0002bc47c4d15c570a9e7cd246",
+				"DiscoKey":   "discokey:d375e1ba22651786da69ff86fb8875db92af0be9f4a875925ad2b96a506a160e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39948",
+					"10.65.0.27:39948",
+					"172.17.0.1:39948",
+					"172.18.0.1:39948",
+					"172.19.0.1:39948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:07:36.609205696Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3568096698125327,
+				"StableID":   "niUjqHrzrU11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6578eac37734f0ca30d21ae8707d38e30d3518f5438b01f3ada6d55c8f536136",
+				"KeyExpiry":  "2026-11-08T22:07:37Z",
+				"DiscoKey":   "discokey:62cf1aea48bbabd24deeef783337746c937d7b328bd9c293ebc4c8aeaeddfd2b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47310",
+					"10.65.0.27:47310",
+					"172.17.0.1:47310",
+					"172.18.0.1:47310",
+					"172.19.0.1:47310"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:07:37.143194956Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         866341581446789,
+				"StableID":   "n6hVuoKNm711CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9152a1f0fa73a02973a78d7a23e7a3a25308a110b22f352c2e41fc79c81f6c53",
+				"KeyExpiry":  "2026-11-08T22:07:38Z",
+				"DiscoKey":   "discokey:469b171fb99446be03db1fe5612be3930e590063ca55a4ad1f58719bcf707757",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:34961",
+					"10.65.0.27:34961",
+					"172.17.0.1:34961",
+					"172.18.0.1:34961",
+					"172.19.0.1:34961"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:07:38.230136065Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4988838610444073,
+				"StableID":   "ntviXBLTxf11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       4988838610444073,
+				"Key":        "nodekey:80d34443476f4fa20a4be3bdb35576b9d365303295e9777678a4c4f1546fba70",
+				"DiscoKey":   "discokey:abc4a52e919001f954f9c245068883208bbd7e6d74a52d3b8fc13c067eda7d54",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51268",
+					"10.65.0.27:51268",
+					"172.17.0.1:51268",
+					"172.18.0.1:51268",
+					"172.19.0.1:51268"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:07:35.53016161Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:80d34443476f4fa20a4be3bdb35576b9d365303295e9777678a4c4f1546fba70",
+			"MachineKey": "mkey:6422adc7a55816735504c5d8d3fd131552c799c0a890516db41111e01839a730",
+			"Peers": [{
+				"ID":         6479580554056551,
+				"StableID":   "nJYHHSbcbs11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:534036fee32befc8def76d19bced2611cec4c9ea5ff06fc9125ca5d3a5fa394c",
+				"DiscoKey":   "discokey:a457fd752c63433b63a00ad13c196b72bbbb879157c93a5c834b44cdb1ace34f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54446",
+					"10.65.0.27:54446",
+					"172.17.0.1:54446",
+					"172.18.0.1:54446",
+					"172.19.0.1:54446"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:07:30.684306958Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2816977717950711,
+				"StableID":   "nnrbeDEpzN11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:828c9831759071eecf78af1bdef101e9af04f11a3322b6530c02c7f5628a8072",
+				"DiscoKey":   "discokey:e428510d31c80edc8ab4911bed1cfa4ed9fb256f8a863ee87b6ea4e6325d0178",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:46201",
+					"10.65.0.27:46201",
+					"172.17.0.1:46201",
+					"172.18.0.1:46201",
+					"172.19.0.1:46201"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:07:31.206906899Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5903664245366305,
+				"StableID":   "n8pSDSFn6o11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b80dddd3a9b37a678e490fb3803dba0f8ca22d020e5a1a043d1ca93905516027",
+				"DiscoKey":   "discokey:b1184af60a53c426fc6121a2b7c4755d79e17195822f72602524a8115ba6d411",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40208",
+					"10.65.0.27:40208",
+					"172.17.0.1:40208",
+					"172.18.0.1:40208",
+					"172.19.0.1:40208"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:07:31.763176233Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6014729432040478,
+				"StableID":   "no3JS6k5yo11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6635fa423f96ea142ce0bde68b60aac1a30513c2918454449d5ace83f3c18571",
+				"DiscoKey":   "discokey:b5ee5552f812eb458150160819218256bbf444970c70664bc3dfdc4638bbac1f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60502",
+					"10.65.0.27:60502",
+					"172.17.0.1:60502",
+					"172.18.0.1:60502",
+					"172.19.0.1:60502"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:07:32.291386771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7489233362587283,
+				"StableID":   "nc7UajTtU121CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:63a921faa59da289100969ecd538b2191cc0a2be8da6ae4b4689f63da1685b60",
+				"DiscoKey":   "discokey:4ec87a46abbb8eedf790e93beddbe43a6f31049a847c7749aa714dd7c435a83a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37260",
+					"10.65.0.27:37260",
+					"172.17.0.1:37260",
+					"172.18.0.1:37260",
+					"172.19.0.1:37260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:07:32.828546148Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4881874094114602,
+				"StableID":   "nuxFW9Z18f11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d4e1c2470af4ee707df3f5e50f6f7dada568e03ff687618946fb82004ada4347",
+				"DiscoKey":   "discokey:e7f9a6a6ba9e54e2fd87153f173b9c06d7b11a7d0429bcc4f49e2d380761684e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50358",
+					"10.65.0.27:50358",
+					"172.17.0.1:50358",
+					"172.18.0.1:50358",
+					"172.19.0.1:50358"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:07:33.36759875Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8112666823820910,
+				"StableID":   "njFXh31FM621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:482e81b7f77b8b542172c99c811b67ffe2aca0ddba857f700743fa1d73ffed6a",
+				"DiscoKey":   "discokey:7e5c8435764e2abc66f1d68433595b45161e290f3178b549014e4dd918d69736",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:48093",
+					"10.65.0.27:48093",
+					"172.17.0.1:48093",
+					"172.18.0.1:48093",
+					"172.19.0.1:48093"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:07:33.913359829Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5829259574078004,
+				"StableID":   "n1daCLm5Xn11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:766014e368d34ec617570ebfbcb0877a653874e00796ee742936cd4265e4d574",
+				"DiscoKey":   "discokey:7db08cd1aba3f54ad43a612200f22932b310d18852f4e3dfe8b0fb35b321361f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:59857",
+					"10.65.0.27:59857",
+					"172.17.0.1:59857",
+					"172.18.0.1:59857",
+					"172.19.0.1:59857"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:07:34.45097998Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4256209531504822,
+				"StableID":   "nh6UbcQeEa11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2d4fdfe535a0c6e64a6a3fc41bc85299971f84ba868056e4e25d7fa573edf360",
+				"DiscoKey":   "discokey:f332cd2d0a3e01ec1156b6552d22c803424a2a8fee63822664d364a0c32fc803",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37941",
+					"10.65.0.27:37941",
+					"172.17.0.1:37941",
+					"172.18.0.1:37941",
+					"172.19.0.1:37941"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:07:34.992520254Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3709003317634520,
+				"StableID":   "n9f4JDEpxV11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87c4970e02ee5157815d463a7d792c882321cf8d82a0eeb7370ac3ff0b78fb18",
+				"DiscoKey":   "discokey:e0781f6e73aa3310e56169aa8f798bf25ad541e5c99150182dd7cc207e556e41",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43637",
+					"10.65.0.27:43637",
+					"172.17.0.1:43637",
+					"172.18.0.1:43637",
+					"172.19.0.1:43637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:07:36.073292326Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         818163205231930,
+				"StableID":   "nDS8n5mYP711CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e18ac31e74b1a42e3c87414b6d403e066f6ecd0002bc47c4d15c570a9e7cd246",
+				"DiscoKey":   "discokey:d375e1ba22651786da69ff86fb8875db92af0be9f4a875925ad2b96a506a160e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39948",
+					"10.65.0.27:39948",
+					"172.17.0.1:39948",
+					"172.18.0.1:39948",
+					"172.19.0.1:39948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:07:36.609205696Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3568096698125327,
+				"StableID":   "niUjqHrzrU11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:6578eac37734f0ca30d21ae8707d38e30d3518f5438b01f3ada6d55c8f536136",
+				"KeyExpiry":  "2026-11-08T22:07:37Z",
+				"DiscoKey":   "discokey:62cf1aea48bbabd24deeef783337746c937d7b328bd9c293ebc4c8aeaeddfd2b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47310",
+					"10.65.0.27:47310",
+					"172.17.0.1:47310",
+					"172.18.0.1:47310",
+					"172.19.0.1:47310"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:07:37.143194956Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2796977951033685,
+				"StableID":   "nrqSjLskqN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2244680b5f743db685055692ef513ba7a799337736c5a510fb2dc311020d3d63",
+				"KeyExpiry":  "2026-11-08T22:07:37Z",
+				"DiscoKey":   "discokey:e715d93f923ae4f70de8d0db1b9fc44e7ca82432b97a69a80ef3598357ac510f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36314",
+					"10.65.0.27:36314",
+					"172.17.0.1:36314",
+					"172.18.0.1:36314",
+					"172.19.0.1:36314"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:07:37.686253398Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         866341581446789,
+				"StableID":   "n6hVuoKNm711CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9152a1f0fa73a02973a78d7a23e7a3a25308a110b22f352c2e41fc79c81f6c53",
+				"KeyExpiry":  "2026-11-08T22:07:38Z",
+				"DiscoKey":   "discokey:469b171fb99446be03db1fe5612be3930e590063ca55a4ad1f58719bcf707757",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:34961",
+					"10.65.0.27:34961",
+					"172.17.0.1:34961",
+					"172.18.0.1:34961",
+					"172.19.0.1:34961"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:07:38.230136065Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4988838610444073": {
+				"ID":          4988838610444073,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-user-localpart-no-at.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-user-localpart-no-at.hujson
@@ -1,0 +1,20104 @@
+// ssh-malformed-user-localpart-no-at
+//
+// ssh users localpart without @domain is rejected
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T22:08:14Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-malformed-user-localpart-no-at",
+	"description":    "ssh users localpart without @domain is rejected",
+	"category":       "ssh",
+	"captured_at":    "2026-05-12T22:08:14.243863084Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                     \n  \n                                                             \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh users localpart without @domain is rejected\",\n\t\"id\":          \"ssh-malformed-user-localpart-no-at\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"autogroup:member\"],\n\t\t\"users\":  [\"localpart:foo\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-malformed/ssh-malformed-user-localpart-no-at.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["autogroup:member"],
+				"users":  ["localpart:foo"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         931014678892991,
+				"StableID":   "nxZh4GBfG811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       931014678892991,
+				"Key":        "nodekey:149ecbad549da2f6d0c078eb879391e837fc753dace39aa925f8d152b1fdd216",
+				"DiscoKey":   "discokey:aa05f156203d8d0970c224d052bd1025cf26d0dab8fe4f00df5f6b94773bd86d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:43843",
+					"10.65.0.27:43843",
+					"172.17.0.1:43843",
+					"172.18.0.1:43843",
+					"172.19.0.1:43843"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:08:22.742228676Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:149ecbad549da2f6d0c078eb879391e837fc753dace39aa925f8d152b1fdd216",
+			"MachineKey": "mkey:eef8c7021abebc73b25615eed31b555c876e2f4d4430aaacff50c76bc70f256c",
+			"Peers": [{
+				"ID":         148957841278087,
+				"StableID":   "neiPMTsTA211CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:02af530c97681235d93c0bbd5a7a4c87fe027445d85aec3b29b0be8d31f1c464",
+				"DiscoKey":   "discokey:fd7892baa918d2cda0f4647b72b12057c88d719e6ddffe442b318098f9bcae4e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40245",
+					"10.65.0.27:40245",
+					"172.17.0.1:40245",
+					"172.18.0.1:40245",
+					"172.19.0.1:40245"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:08:16.786699384Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5533285458892829,
+				"StableID":   "niP5AX23Dk11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8bea09cb94393da412ecfc150c714953c67e8c30f350ebc86dc33ceaf40a5d07",
+				"DiscoKey":   "discokey:789be08c0ee59d64b61fd300aa4137b625f08339fe4c63b8d97071052c34ba16",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54812",
+					"10.65.0.27:54812",
+					"172.17.0.1:54812",
+					"172.18.0.1:54812",
+					"172.19.0.1:54812"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:08:17.326251824Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8541400743771754,
+				"StableID":   "nFBK5c7Rh921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a3df18b5fc083c2b4094050e064f82f0bd44fb02dbefab798db43c69b389ab5b",
+				"DiscoKey":   "discokey:4a198e0a62ad9e09d6d8ba908ddbff95d174d970e1b131606d083eb5a0d0e419",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:49249",
+					"10.65.0.27:49249",
+					"172.17.0.1:49249",
+					"172.18.0.1:49249",
+					"172.19.0.1:49249"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:08:17.889420597Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5584721634865832,
+				"StableID":   "nuhkthALck11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3701cc87d5f6ba2958dc586fc06e08bf746d7f1c11504527545e877e819c234c",
+				"DiscoKey":   "discokey:70920f9c828f9e69f7bf72c695671531fb9192d7ae3153b3fe4383ed557ddc4d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:54578",
+					"10.65.0.27:54578",
+					"172.17.0.1:54578",
+					"172.18.0.1:54578",
+					"172.19.0.1:54578"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:08:18.408602694Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8476053722357188,
+				"StableID":   "nVfcZPZpB921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e2917926668b1690ac947978636bbeaaa11e5fca3cc8bcd2dd029c4f4d88a4e",
+				"DiscoKey":   "discokey:24561b23e1580a6fa8650de849ed9371faa791df4274e22ade0eead8c5285621",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56286",
+					"10.65.0.27:56286",
+					"172.17.0.1:56286",
+					"172.18.0.1:56286",
+					"172.19.0.1:56286"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:08:18.958122059Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8051724509496322,
+				"StableID":   "nFuz4g9es521CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dce1adc30d580db78debc3fbe29cecc5c6a97a5af5f68c3afc008008b4d7755a",
+				"DiscoKey":   "discokey:62eed2a0ddf493bc0ef37410fd9e2e64de4fb9dfc9cacc24e194d222918f9759",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37326",
+					"10.65.0.27:37326",
+					"172.17.0.1:37326",
+					"172.18.0.1:37326",
+					"172.19.0.1:37326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:08:19.49889894Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8879873325482014,
+				"StableID":   "nXyM5TDiLC21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e45d70a47100bf9af4394257cf1e2e7c6b4c42b033f053d848d940b7e7dc8b10",
+				"DiscoKey":   "discokey:4c37d5a03468f32a033137358e470ae191932d00f9b2eb40b6304dd64c89d14e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51240",
+					"10.65.0.27:51240",
+					"172.17.0.1:51240",
+					"172.18.0.1:51240",
+					"172.19.0.1:51240"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:08:20.031865887Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8201117514559389,
+				"StableID":   "nr1YM8TJ3721CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97794c1b6916a4000be51091f3c8bb50a72dcbbc1861c6dd42f4f3ddee118a28",
+				"DiscoKey":   "discokey:11b930a1d778e75487995b193c857b1b8ca9a3b75d0e19ea259c05eafd3d5063",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46503",
+					"10.65.0.27:46503",
+					"172.17.0.1:46503",
+					"172.18.0.1:46503",
+					"172.19.0.1:46503"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:08:20.571756539Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8296056659322812,
+				"StableID":   "nm3SUmLJn721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2e4d43d42fd01ad9ea34dfae2ab0ef0f5115a3aa40786b8fce9fa5f9c690cc7e",
+				"DiscoKey":   "discokey:aeb2ef0bbab520ec919509c5aa8d01708d42696a89b5360b71bce9c529025613",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36424",
+					"10.65.0.27:36424",
+					"172.17.0.1:36424",
+					"172.18.0.1:36424",
+					"172.19.0.1:36424"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:08:21.117315392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8374548226897233,
+				"StableID":   "nvm2XWBrP821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80035bd6b8c38d494ad21973b4fbfc85573c5e190728057f8ec64c7c7b48e317",
+				"DiscoKey":   "discokey:becf2c4e1e55e57aedf4d537da7034abba0318525c446677286219053c428b0f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35400",
+					"10.65.0.27:35400",
+					"172.17.0.1:35400",
+					"172.18.0.1:35400",
+					"172.19.0.1:35400"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:08:21.655866087Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1795137637676623,
+				"StableID":   "n2A8trD22F11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b5f6efd1cf8af210d8e258ff49d059acd09b02964a33d30957ba6c55727ece67",
+				"DiscoKey":   "discokey:b77e628f6dd6cf4c37e23f45745983de49b94897ea1ca79d57d765afc718b622",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40204",
+					"10.65.0.27:40204",
+					"172.17.0.1:40204",
+					"172.18.0.1:40204",
+					"172.19.0.1:40204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:08:22.200198897Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3144493133447296,
+				"StableID":   "nbGjP9W9ZR11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bf7b6bc99e8eb621a8725144d0796f70b5ed6e1c8e24065fa9184a0762ab6b02",
+				"KeyExpiry":  "2026-11-08T22:08:23Z",
+				"DiscoKey":   "discokey:e398cc9bf9587a14b1d465bef847acfd2556cea069273d4da7da64433e21c332",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53148",
+					"10.65.0.27:53148",
+					"172.17.0.1:53148",
+					"172.18.0.1:53148",
+					"172.19.0.1:53148"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:08:23.282009617Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8846900123352821,
+				"StableID":   "nS5e7k4n5C21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2f0da4cd4d52196fc226ebdc5322de05bf31762c154b85bc8a5fec791211767f",
+				"KeyExpiry":  "2026-11-08T22:08:23Z",
+				"DiscoKey":   "discokey:98db68f5c7afa3368f883388ae112062c1f052f01cfc4c64bf7de5835a276066",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46158",
+					"10.65.0.27:46158",
+					"172.17.0.1:46158",
+					"172.18.0.1:46158",
+					"172.19.0.1:46158"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:08:23.930327368Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6221836278277223,
+				"StableID":   "nn4aE96taq11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9b52000e7647025dec03beeb14538cdfce92c687507835561301eb081b40a368",
+				"KeyExpiry":  "2026-11-08T22:08:24Z",
+				"DiscoKey":   "discokey:eb6226aacabf287447001bdbc5a2764a4164b71474e8f8e4e7a8222470f66a5f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55407",
+					"10.65.0.27:55407",
+					"172.17.0.1:55407",
+					"172.18.0.1:55407",
+					"172.19.0.1:55407"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:08:24.629047889Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{"principals": [
+				{"nodeIP": "100.64.0.17"},
+				{"nodeIP": "100.64.0.18"},
+				{"nodeIP": "100.64.0.19"},
+				{"nodeIP": "fd7a:115c:a1e0::12"},
+				{"nodeIP": "fd7a:115c:a1e0::13"},
+				{"nodeIP": "fd7a:115c:a1e0::11"}
+			], "sshUsers": {"localpart:foo": "localpart:foo", "root": ""}, "action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "931014678892991": {
+				"ID":          931014678892991,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		},
+		"ssh_rules": [{"principals": [
+			{"nodeIP": "100.64.0.17"},
+			{"nodeIP": "100.64.0.18"},
+			{"nodeIP": "100.64.0.19"},
+			{"nodeIP": "fd7a:115c:a1e0::12"},
+			{"nodeIP": "fd7a:115c:a1e0::13"},
+			{"nodeIP": "fd7a:115c:a1e0::11"}
+		], "sshUsers": {"localpart:foo": "localpart:foo", "root": ""}, "action": {
+			"accept":                    true,
+			"allowAgentForwarding":      true,
+			"allowLocalPortForwarding":  true,
+			"allowRemotePortForwarding": true
+		}}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8051724509496322,
+				"StableID":   "nFuz4g9es521CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       8051724509496322,
+				"Key":        "nodekey:dce1adc30d580db78debc3fbe29cecc5c6a97a5af5f68c3afc008008b4d7755a",
+				"DiscoKey":   "discokey:62eed2a0ddf493bc0ef37410fd9e2e64de4fb9dfc9cacc24e194d222918f9759",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37326",
+					"10.65.0.27:37326",
+					"172.17.0.1:37326",
+					"172.18.0.1:37326",
+					"172.19.0.1:37326"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:08:19.49889894Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:dce1adc30d580db78debc3fbe29cecc5c6a97a5af5f68c3afc008008b4d7755a",
+			"MachineKey": "mkey:86b784993161e66825e4e409ffd2bde06fff9ae9b8db7ba193149e99b189df68",
+			"Peers": [{
+				"ID":         148957841278087,
+				"StableID":   "neiPMTsTA211CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:02af530c97681235d93c0bbd5a7a4c87fe027445d85aec3b29b0be8d31f1c464",
+				"DiscoKey":   "discokey:fd7892baa918d2cda0f4647b72b12057c88d719e6ddffe442b318098f9bcae4e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40245",
+					"10.65.0.27:40245",
+					"172.17.0.1:40245",
+					"172.18.0.1:40245",
+					"172.19.0.1:40245"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:08:16.786699384Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5533285458892829,
+				"StableID":   "niP5AX23Dk11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8bea09cb94393da412ecfc150c714953c67e8c30f350ebc86dc33ceaf40a5d07",
+				"DiscoKey":   "discokey:789be08c0ee59d64b61fd300aa4137b625f08339fe4c63b8d97071052c34ba16",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54812",
+					"10.65.0.27:54812",
+					"172.17.0.1:54812",
+					"172.18.0.1:54812",
+					"172.19.0.1:54812"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:08:17.326251824Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8541400743771754,
+				"StableID":   "nFBK5c7Rh921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a3df18b5fc083c2b4094050e064f82f0bd44fb02dbefab798db43c69b389ab5b",
+				"DiscoKey":   "discokey:4a198e0a62ad9e09d6d8ba908ddbff95d174d970e1b131606d083eb5a0d0e419",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:49249",
+					"10.65.0.27:49249",
+					"172.17.0.1:49249",
+					"172.18.0.1:49249",
+					"172.19.0.1:49249"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:08:17.889420597Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5584721634865832,
+				"StableID":   "nuhkthALck11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3701cc87d5f6ba2958dc586fc06e08bf746d7f1c11504527545e877e819c234c",
+				"DiscoKey":   "discokey:70920f9c828f9e69f7bf72c695671531fb9192d7ae3153b3fe4383ed557ddc4d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:54578",
+					"10.65.0.27:54578",
+					"172.17.0.1:54578",
+					"172.18.0.1:54578",
+					"172.19.0.1:54578"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:08:18.408602694Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8476053722357188,
+				"StableID":   "nVfcZPZpB921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e2917926668b1690ac947978636bbeaaa11e5fca3cc8bcd2dd029c4f4d88a4e",
+				"DiscoKey":   "discokey:24561b23e1580a6fa8650de849ed9371faa791df4274e22ade0eead8c5285621",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56286",
+					"10.65.0.27:56286",
+					"172.17.0.1:56286",
+					"172.18.0.1:56286",
+					"172.19.0.1:56286"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:08:18.958122059Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8879873325482014,
+				"StableID":   "nXyM5TDiLC21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e45d70a47100bf9af4394257cf1e2e7c6b4c42b033f053d848d940b7e7dc8b10",
+				"DiscoKey":   "discokey:4c37d5a03468f32a033137358e470ae191932d00f9b2eb40b6304dd64c89d14e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51240",
+					"10.65.0.27:51240",
+					"172.17.0.1:51240",
+					"172.18.0.1:51240",
+					"172.19.0.1:51240"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:08:20.031865887Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8201117514559389,
+				"StableID":   "nr1YM8TJ3721CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97794c1b6916a4000be51091f3c8bb50a72dcbbc1861c6dd42f4f3ddee118a28",
+				"DiscoKey":   "discokey:11b930a1d778e75487995b193c857b1b8ca9a3b75d0e19ea259c05eafd3d5063",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46503",
+					"10.65.0.27:46503",
+					"172.17.0.1:46503",
+					"172.18.0.1:46503",
+					"172.19.0.1:46503"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:08:20.571756539Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8296056659322812,
+				"StableID":   "nm3SUmLJn721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2e4d43d42fd01ad9ea34dfae2ab0ef0f5115a3aa40786b8fce9fa5f9c690cc7e",
+				"DiscoKey":   "discokey:aeb2ef0bbab520ec919509c5aa8d01708d42696a89b5360b71bce9c529025613",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36424",
+					"10.65.0.27:36424",
+					"172.17.0.1:36424",
+					"172.18.0.1:36424",
+					"172.19.0.1:36424"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:08:21.117315392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8374548226897233,
+				"StableID":   "nvm2XWBrP821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80035bd6b8c38d494ad21973b4fbfc85573c5e190728057f8ec64c7c7b48e317",
+				"DiscoKey":   "discokey:becf2c4e1e55e57aedf4d537da7034abba0318525c446677286219053c428b0f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35400",
+					"10.65.0.27:35400",
+					"172.17.0.1:35400",
+					"172.18.0.1:35400",
+					"172.19.0.1:35400"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:08:21.655866087Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1795137637676623,
+				"StableID":   "n2A8trD22F11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b5f6efd1cf8af210d8e258ff49d059acd09b02964a33d30957ba6c55727ece67",
+				"DiscoKey":   "discokey:b77e628f6dd6cf4c37e23f45745983de49b94897ea1ca79d57d765afc718b622",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40204",
+					"10.65.0.27:40204",
+					"172.17.0.1:40204",
+					"172.18.0.1:40204",
+					"172.19.0.1:40204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:08:22.200198897Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         931014678892991,
+				"StableID":   "nxZh4GBfG811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:149ecbad549da2f6d0c078eb879391e837fc753dace39aa925f8d152b1fdd216",
+				"DiscoKey":   "discokey:aa05f156203d8d0970c224d052bd1025cf26d0dab8fe4f00df5f6b94773bd86d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:43843",
+					"10.65.0.27:43843",
+					"172.17.0.1:43843",
+					"172.18.0.1:43843",
+					"172.19.0.1:43843"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:08:22.742228676Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3144493133447296,
+				"StableID":   "nbGjP9W9ZR11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bf7b6bc99e8eb621a8725144d0796f70b5ed6e1c8e24065fa9184a0762ab6b02",
+				"KeyExpiry":  "2026-11-08T22:08:23Z",
+				"DiscoKey":   "discokey:e398cc9bf9587a14b1d465bef847acfd2556cea069273d4da7da64433e21c332",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53148",
+					"10.65.0.27:53148",
+					"172.17.0.1:53148",
+					"172.18.0.1:53148",
+					"172.19.0.1:53148"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:08:23.282009617Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8846900123352821,
+				"StableID":   "nS5e7k4n5C21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2f0da4cd4d52196fc226ebdc5322de05bf31762c154b85bc8a5fec791211767f",
+				"KeyExpiry":  "2026-11-08T22:08:23Z",
+				"DiscoKey":   "discokey:98db68f5c7afa3368f883388ae112062c1f052f01cfc4c64bf7de5835a276066",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46158",
+					"10.65.0.27:46158",
+					"172.17.0.1:46158",
+					"172.18.0.1:46158",
+					"172.19.0.1:46158"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:08:23.930327368Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6221836278277223,
+				"StableID":   "nn4aE96taq11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9b52000e7647025dec03beeb14538cdfce92c687507835561301eb081b40a368",
+				"KeyExpiry":  "2026-11-08T22:08:24Z",
+				"DiscoKey":   "discokey:eb6226aacabf287447001bdbc5a2764a4164b71474e8f8e4e7a8222470f66a5f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55407",
+					"10.65.0.27:55407",
+					"172.17.0.1:55407",
+					"172.18.0.1:55407",
+					"172.19.0.1:55407"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:08:24.629047889Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8051724509496322": {
+				"ID":          8051724509496322,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6221836278277223,
+				"StableID":   "nn4aE96taq11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9b52000e7647025dec03beeb14538cdfce92c687507835561301eb081b40a368",
+				"KeyExpiry":  "2026-11-08T22:08:24Z",
+				"DiscoKey":   "discokey:eb6226aacabf287447001bdbc5a2764a4164b71474e8f8e4e7a8222470f66a5f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55407",
+					"10.65.0.27:55407",
+					"172.17.0.1:55407",
+					"172.18.0.1:55407",
+					"172.19.0.1:55407"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:08:24.629047889Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9b52000e7647025dec03beeb14538cdfce92c687507835561301eb081b40a368",
+			"MachineKey": "mkey:17e1803a7f726a917be899f819cf2855a9bca92f32fe9df6e93bbf6c57ed9572",
+			"Peers": [{
+				"ID":         148957841278087,
+				"StableID":   "neiPMTsTA211CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:02af530c97681235d93c0bbd5a7a4c87fe027445d85aec3b29b0be8d31f1c464",
+				"DiscoKey":   "discokey:fd7892baa918d2cda0f4647b72b12057c88d719e6ddffe442b318098f9bcae4e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40245",
+					"10.65.0.27:40245",
+					"172.17.0.1:40245",
+					"172.18.0.1:40245",
+					"172.19.0.1:40245"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:08:16.786699384Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5533285458892829,
+				"StableID":   "niP5AX23Dk11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8bea09cb94393da412ecfc150c714953c67e8c30f350ebc86dc33ceaf40a5d07",
+				"DiscoKey":   "discokey:789be08c0ee59d64b61fd300aa4137b625f08339fe4c63b8d97071052c34ba16",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54812",
+					"10.65.0.27:54812",
+					"172.17.0.1:54812",
+					"172.18.0.1:54812",
+					"172.19.0.1:54812"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:08:17.326251824Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8541400743771754,
+				"StableID":   "nFBK5c7Rh921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a3df18b5fc083c2b4094050e064f82f0bd44fb02dbefab798db43c69b389ab5b",
+				"DiscoKey":   "discokey:4a198e0a62ad9e09d6d8ba908ddbff95d174d970e1b131606d083eb5a0d0e419",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:49249",
+					"10.65.0.27:49249",
+					"172.17.0.1:49249",
+					"172.18.0.1:49249",
+					"172.19.0.1:49249"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:08:17.889420597Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5584721634865832,
+				"StableID":   "nuhkthALck11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3701cc87d5f6ba2958dc586fc06e08bf746d7f1c11504527545e877e819c234c",
+				"DiscoKey":   "discokey:70920f9c828f9e69f7bf72c695671531fb9192d7ae3153b3fe4383ed557ddc4d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:54578",
+					"10.65.0.27:54578",
+					"172.17.0.1:54578",
+					"172.18.0.1:54578",
+					"172.19.0.1:54578"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:08:18.408602694Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8476053722357188,
+				"StableID":   "nVfcZPZpB921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e2917926668b1690ac947978636bbeaaa11e5fca3cc8bcd2dd029c4f4d88a4e",
+				"DiscoKey":   "discokey:24561b23e1580a6fa8650de849ed9371faa791df4274e22ade0eead8c5285621",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56286",
+					"10.65.0.27:56286",
+					"172.17.0.1:56286",
+					"172.18.0.1:56286",
+					"172.19.0.1:56286"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:08:18.958122059Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8051724509496322,
+				"StableID":   "nFuz4g9es521CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dce1adc30d580db78debc3fbe29cecc5c6a97a5af5f68c3afc008008b4d7755a",
+				"DiscoKey":   "discokey:62eed2a0ddf493bc0ef37410fd9e2e64de4fb9dfc9cacc24e194d222918f9759",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37326",
+					"10.65.0.27:37326",
+					"172.17.0.1:37326",
+					"172.18.0.1:37326",
+					"172.19.0.1:37326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:08:19.49889894Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8879873325482014,
+				"StableID":   "nXyM5TDiLC21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e45d70a47100bf9af4394257cf1e2e7c6b4c42b033f053d848d940b7e7dc8b10",
+				"DiscoKey":   "discokey:4c37d5a03468f32a033137358e470ae191932d00f9b2eb40b6304dd64c89d14e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51240",
+					"10.65.0.27:51240",
+					"172.17.0.1:51240",
+					"172.18.0.1:51240",
+					"172.19.0.1:51240"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:08:20.031865887Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8201117514559389,
+				"StableID":   "nr1YM8TJ3721CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97794c1b6916a4000be51091f3c8bb50a72dcbbc1861c6dd42f4f3ddee118a28",
+				"DiscoKey":   "discokey:11b930a1d778e75487995b193c857b1b8ca9a3b75d0e19ea259c05eafd3d5063",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46503",
+					"10.65.0.27:46503",
+					"172.17.0.1:46503",
+					"172.18.0.1:46503",
+					"172.19.0.1:46503"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:08:20.571756539Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8296056659322812,
+				"StableID":   "nm3SUmLJn721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2e4d43d42fd01ad9ea34dfae2ab0ef0f5115a3aa40786b8fce9fa5f9c690cc7e",
+				"DiscoKey":   "discokey:aeb2ef0bbab520ec919509c5aa8d01708d42696a89b5360b71bce9c529025613",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36424",
+					"10.65.0.27:36424",
+					"172.17.0.1:36424",
+					"172.18.0.1:36424",
+					"172.19.0.1:36424"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:08:21.117315392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8374548226897233,
+				"StableID":   "nvm2XWBrP821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80035bd6b8c38d494ad21973b4fbfc85573c5e190728057f8ec64c7c7b48e317",
+				"DiscoKey":   "discokey:becf2c4e1e55e57aedf4d537da7034abba0318525c446677286219053c428b0f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35400",
+					"10.65.0.27:35400",
+					"172.17.0.1:35400",
+					"172.18.0.1:35400",
+					"172.19.0.1:35400"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:08:21.655866087Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1795137637676623,
+				"StableID":   "n2A8trD22F11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b5f6efd1cf8af210d8e258ff49d059acd09b02964a33d30957ba6c55727ece67",
+				"DiscoKey":   "discokey:b77e628f6dd6cf4c37e23f45745983de49b94897ea1ca79d57d765afc718b622",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40204",
+					"10.65.0.27:40204",
+					"172.17.0.1:40204",
+					"172.18.0.1:40204",
+					"172.19.0.1:40204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:08:22.200198897Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         931014678892991,
+				"StableID":   "nxZh4GBfG811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:149ecbad549da2f6d0c078eb879391e837fc753dace39aa925f8d152b1fdd216",
+				"DiscoKey":   "discokey:aa05f156203d8d0970c224d052bd1025cf26d0dab8fe4f00df5f6b94773bd86d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:43843",
+					"10.65.0.27:43843",
+					"172.17.0.1:43843",
+					"172.18.0.1:43843",
+					"172.19.0.1:43843"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:08:22.742228676Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3144493133447296,
+				"StableID":   "nbGjP9W9ZR11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bf7b6bc99e8eb621a8725144d0796f70b5ed6e1c8e24065fa9184a0762ab6b02",
+				"KeyExpiry":  "2026-11-08T22:08:23Z",
+				"DiscoKey":   "discokey:e398cc9bf9587a14b1d465bef847acfd2556cea069273d4da7da64433e21c332",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53148",
+					"10.65.0.27:53148",
+					"172.17.0.1:53148",
+					"172.18.0.1:53148",
+					"172.19.0.1:53148"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:08:23.282009617Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8846900123352821,
+				"StableID":   "nS5e7k4n5C21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2f0da4cd4d52196fc226ebdc5322de05bf31762c154b85bc8a5fec791211767f",
+				"KeyExpiry":  "2026-11-08T22:08:23Z",
+				"DiscoKey":   "discokey:98db68f5c7afa3368f883388ae112062c1f052f01cfc4c64bf7de5835a276066",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46158",
+					"10.65.0.27:46158",
+					"172.17.0.1:46158",
+					"172.18.0.1:46158",
+					"172.19.0.1:46158"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:08:23.930327368Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8541400743771754,
+				"StableID":   "nFBK5c7Rh921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       8541400743771754,
+				"Key":        "nodekey:a3df18b5fc083c2b4094050e064f82f0bd44fb02dbefab798db43c69b389ab5b",
+				"DiscoKey":   "discokey:4a198e0a62ad9e09d6d8ba908ddbff95d174d970e1b131606d083eb5a0d0e419",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:49249",
+					"10.65.0.27:49249",
+					"172.17.0.1:49249",
+					"172.18.0.1:49249",
+					"172.19.0.1:49249"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:08:17.889420597Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a3df18b5fc083c2b4094050e064f82f0bd44fb02dbefab798db43c69b389ab5b",
+			"MachineKey": "mkey:5f71113a53f6ae566d9b11b51d56065f77890bed0853fa78393aeff37143cf7d",
+			"Peers": [{
+				"ID":         148957841278087,
+				"StableID":   "neiPMTsTA211CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:02af530c97681235d93c0bbd5a7a4c87fe027445d85aec3b29b0be8d31f1c464",
+				"DiscoKey":   "discokey:fd7892baa918d2cda0f4647b72b12057c88d719e6ddffe442b318098f9bcae4e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40245",
+					"10.65.0.27:40245",
+					"172.17.0.1:40245",
+					"172.18.0.1:40245",
+					"172.19.0.1:40245"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:08:16.786699384Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5533285458892829,
+				"StableID":   "niP5AX23Dk11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8bea09cb94393da412ecfc150c714953c67e8c30f350ebc86dc33ceaf40a5d07",
+				"DiscoKey":   "discokey:789be08c0ee59d64b61fd300aa4137b625f08339fe4c63b8d97071052c34ba16",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54812",
+					"10.65.0.27:54812",
+					"172.17.0.1:54812",
+					"172.18.0.1:54812",
+					"172.19.0.1:54812"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:08:17.326251824Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5584721634865832,
+				"StableID":   "nuhkthALck11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3701cc87d5f6ba2958dc586fc06e08bf746d7f1c11504527545e877e819c234c",
+				"DiscoKey":   "discokey:70920f9c828f9e69f7bf72c695671531fb9192d7ae3153b3fe4383ed557ddc4d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:54578",
+					"10.65.0.27:54578",
+					"172.17.0.1:54578",
+					"172.18.0.1:54578",
+					"172.19.0.1:54578"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:08:18.408602694Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8476053722357188,
+				"StableID":   "nVfcZPZpB921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e2917926668b1690ac947978636bbeaaa11e5fca3cc8bcd2dd029c4f4d88a4e",
+				"DiscoKey":   "discokey:24561b23e1580a6fa8650de849ed9371faa791df4274e22ade0eead8c5285621",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56286",
+					"10.65.0.27:56286",
+					"172.17.0.1:56286",
+					"172.18.0.1:56286",
+					"172.19.0.1:56286"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:08:18.958122059Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8051724509496322,
+				"StableID":   "nFuz4g9es521CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dce1adc30d580db78debc3fbe29cecc5c6a97a5af5f68c3afc008008b4d7755a",
+				"DiscoKey":   "discokey:62eed2a0ddf493bc0ef37410fd9e2e64de4fb9dfc9cacc24e194d222918f9759",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37326",
+					"10.65.0.27:37326",
+					"172.17.0.1:37326",
+					"172.18.0.1:37326",
+					"172.19.0.1:37326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:08:19.49889894Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8879873325482014,
+				"StableID":   "nXyM5TDiLC21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e45d70a47100bf9af4394257cf1e2e7c6b4c42b033f053d848d940b7e7dc8b10",
+				"DiscoKey":   "discokey:4c37d5a03468f32a033137358e470ae191932d00f9b2eb40b6304dd64c89d14e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51240",
+					"10.65.0.27:51240",
+					"172.17.0.1:51240",
+					"172.18.0.1:51240",
+					"172.19.0.1:51240"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:08:20.031865887Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8201117514559389,
+				"StableID":   "nr1YM8TJ3721CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97794c1b6916a4000be51091f3c8bb50a72dcbbc1861c6dd42f4f3ddee118a28",
+				"DiscoKey":   "discokey:11b930a1d778e75487995b193c857b1b8ca9a3b75d0e19ea259c05eafd3d5063",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46503",
+					"10.65.0.27:46503",
+					"172.17.0.1:46503",
+					"172.18.0.1:46503",
+					"172.19.0.1:46503"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:08:20.571756539Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8296056659322812,
+				"StableID":   "nm3SUmLJn721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2e4d43d42fd01ad9ea34dfae2ab0ef0f5115a3aa40786b8fce9fa5f9c690cc7e",
+				"DiscoKey":   "discokey:aeb2ef0bbab520ec919509c5aa8d01708d42696a89b5360b71bce9c529025613",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36424",
+					"10.65.0.27:36424",
+					"172.17.0.1:36424",
+					"172.18.0.1:36424",
+					"172.19.0.1:36424"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:08:21.117315392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8374548226897233,
+				"StableID":   "nvm2XWBrP821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80035bd6b8c38d494ad21973b4fbfc85573c5e190728057f8ec64c7c7b48e317",
+				"DiscoKey":   "discokey:becf2c4e1e55e57aedf4d537da7034abba0318525c446677286219053c428b0f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35400",
+					"10.65.0.27:35400",
+					"172.17.0.1:35400",
+					"172.18.0.1:35400",
+					"172.19.0.1:35400"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:08:21.655866087Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1795137637676623,
+				"StableID":   "n2A8trD22F11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b5f6efd1cf8af210d8e258ff49d059acd09b02964a33d30957ba6c55727ece67",
+				"DiscoKey":   "discokey:b77e628f6dd6cf4c37e23f45745983de49b94897ea1ca79d57d765afc718b622",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40204",
+					"10.65.0.27:40204",
+					"172.17.0.1:40204",
+					"172.18.0.1:40204",
+					"172.19.0.1:40204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:08:22.200198897Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         931014678892991,
+				"StableID":   "nxZh4GBfG811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:149ecbad549da2f6d0c078eb879391e837fc753dace39aa925f8d152b1fdd216",
+				"DiscoKey":   "discokey:aa05f156203d8d0970c224d052bd1025cf26d0dab8fe4f00df5f6b94773bd86d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:43843",
+					"10.65.0.27:43843",
+					"172.17.0.1:43843",
+					"172.18.0.1:43843",
+					"172.19.0.1:43843"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:08:22.742228676Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3144493133447296,
+				"StableID":   "nbGjP9W9ZR11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bf7b6bc99e8eb621a8725144d0796f70b5ed6e1c8e24065fa9184a0762ab6b02",
+				"KeyExpiry":  "2026-11-08T22:08:23Z",
+				"DiscoKey":   "discokey:e398cc9bf9587a14b1d465bef847acfd2556cea069273d4da7da64433e21c332",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53148",
+					"10.65.0.27:53148",
+					"172.17.0.1:53148",
+					"172.18.0.1:53148",
+					"172.19.0.1:53148"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:08:23.282009617Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8846900123352821,
+				"StableID":   "nS5e7k4n5C21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2f0da4cd4d52196fc226ebdc5322de05bf31762c154b85bc8a5fec791211767f",
+				"KeyExpiry":  "2026-11-08T22:08:23Z",
+				"DiscoKey":   "discokey:98db68f5c7afa3368f883388ae112062c1f052f01cfc4c64bf7de5835a276066",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46158",
+					"10.65.0.27:46158",
+					"172.17.0.1:46158",
+					"172.18.0.1:46158",
+					"172.19.0.1:46158"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:08:23.930327368Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6221836278277223,
+				"StableID":   "nn4aE96taq11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9b52000e7647025dec03beeb14538cdfce92c687507835561301eb081b40a368",
+				"KeyExpiry":  "2026-11-08T22:08:24Z",
+				"DiscoKey":   "discokey:eb6226aacabf287447001bdbc5a2764a4164b71474e8f8e4e7a8222470f66a5f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55407",
+					"10.65.0.27:55407",
+					"172.17.0.1:55407",
+					"172.18.0.1:55407",
+					"172.19.0.1:55407"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:08:24.629047889Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8541400743771754": {
+				"ID":          8541400743771754,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8201117514559389,
+				"StableID":   "nr1YM8TJ3721CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       8201117514559389,
+				"Key":        "nodekey:97794c1b6916a4000be51091f3c8bb50a72dcbbc1861c6dd42f4f3ddee118a28",
+				"DiscoKey":   "discokey:11b930a1d778e75487995b193c857b1b8ca9a3b75d0e19ea259c05eafd3d5063",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46503",
+					"10.65.0.27:46503",
+					"172.17.0.1:46503",
+					"172.18.0.1:46503",
+					"172.19.0.1:46503"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:08:20.571756539Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:97794c1b6916a4000be51091f3c8bb50a72dcbbc1861c6dd42f4f3ddee118a28",
+			"MachineKey": "mkey:d49f2d5a158ec2609b677f51a80c80da5c5c319ca6bb79b99f8d106ae96bda08",
+			"Peers": [{
+				"ID":         148957841278087,
+				"StableID":   "neiPMTsTA211CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:02af530c97681235d93c0bbd5a7a4c87fe027445d85aec3b29b0be8d31f1c464",
+				"DiscoKey":   "discokey:fd7892baa918d2cda0f4647b72b12057c88d719e6ddffe442b318098f9bcae4e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40245",
+					"10.65.0.27:40245",
+					"172.17.0.1:40245",
+					"172.18.0.1:40245",
+					"172.19.0.1:40245"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:08:16.786699384Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5533285458892829,
+				"StableID":   "niP5AX23Dk11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8bea09cb94393da412ecfc150c714953c67e8c30f350ebc86dc33ceaf40a5d07",
+				"DiscoKey":   "discokey:789be08c0ee59d64b61fd300aa4137b625f08339fe4c63b8d97071052c34ba16",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54812",
+					"10.65.0.27:54812",
+					"172.17.0.1:54812",
+					"172.18.0.1:54812",
+					"172.19.0.1:54812"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:08:17.326251824Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8541400743771754,
+				"StableID":   "nFBK5c7Rh921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a3df18b5fc083c2b4094050e064f82f0bd44fb02dbefab798db43c69b389ab5b",
+				"DiscoKey":   "discokey:4a198e0a62ad9e09d6d8ba908ddbff95d174d970e1b131606d083eb5a0d0e419",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:49249",
+					"10.65.0.27:49249",
+					"172.17.0.1:49249",
+					"172.18.0.1:49249",
+					"172.19.0.1:49249"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:08:17.889420597Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5584721634865832,
+				"StableID":   "nuhkthALck11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3701cc87d5f6ba2958dc586fc06e08bf746d7f1c11504527545e877e819c234c",
+				"DiscoKey":   "discokey:70920f9c828f9e69f7bf72c695671531fb9192d7ae3153b3fe4383ed557ddc4d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:54578",
+					"10.65.0.27:54578",
+					"172.17.0.1:54578",
+					"172.18.0.1:54578",
+					"172.19.0.1:54578"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:08:18.408602694Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8476053722357188,
+				"StableID":   "nVfcZPZpB921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e2917926668b1690ac947978636bbeaaa11e5fca3cc8bcd2dd029c4f4d88a4e",
+				"DiscoKey":   "discokey:24561b23e1580a6fa8650de849ed9371faa791df4274e22ade0eead8c5285621",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56286",
+					"10.65.0.27:56286",
+					"172.17.0.1:56286",
+					"172.18.0.1:56286",
+					"172.19.0.1:56286"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:08:18.958122059Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8051724509496322,
+				"StableID":   "nFuz4g9es521CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dce1adc30d580db78debc3fbe29cecc5c6a97a5af5f68c3afc008008b4d7755a",
+				"DiscoKey":   "discokey:62eed2a0ddf493bc0ef37410fd9e2e64de4fb9dfc9cacc24e194d222918f9759",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37326",
+					"10.65.0.27:37326",
+					"172.17.0.1:37326",
+					"172.18.0.1:37326",
+					"172.19.0.1:37326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:08:19.49889894Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8879873325482014,
+				"StableID":   "nXyM5TDiLC21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e45d70a47100bf9af4394257cf1e2e7c6b4c42b033f053d848d940b7e7dc8b10",
+				"DiscoKey":   "discokey:4c37d5a03468f32a033137358e470ae191932d00f9b2eb40b6304dd64c89d14e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51240",
+					"10.65.0.27:51240",
+					"172.17.0.1:51240",
+					"172.18.0.1:51240",
+					"172.19.0.1:51240"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:08:20.031865887Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8296056659322812,
+				"StableID":   "nm3SUmLJn721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2e4d43d42fd01ad9ea34dfae2ab0ef0f5115a3aa40786b8fce9fa5f9c690cc7e",
+				"DiscoKey":   "discokey:aeb2ef0bbab520ec919509c5aa8d01708d42696a89b5360b71bce9c529025613",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36424",
+					"10.65.0.27:36424",
+					"172.17.0.1:36424",
+					"172.18.0.1:36424",
+					"172.19.0.1:36424"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:08:21.117315392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8374548226897233,
+				"StableID":   "nvm2XWBrP821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80035bd6b8c38d494ad21973b4fbfc85573c5e190728057f8ec64c7c7b48e317",
+				"DiscoKey":   "discokey:becf2c4e1e55e57aedf4d537da7034abba0318525c446677286219053c428b0f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35400",
+					"10.65.0.27:35400",
+					"172.17.0.1:35400",
+					"172.18.0.1:35400",
+					"172.19.0.1:35400"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:08:21.655866087Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1795137637676623,
+				"StableID":   "n2A8trD22F11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b5f6efd1cf8af210d8e258ff49d059acd09b02964a33d30957ba6c55727ece67",
+				"DiscoKey":   "discokey:b77e628f6dd6cf4c37e23f45745983de49b94897ea1ca79d57d765afc718b622",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40204",
+					"10.65.0.27:40204",
+					"172.17.0.1:40204",
+					"172.18.0.1:40204",
+					"172.19.0.1:40204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:08:22.200198897Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         931014678892991,
+				"StableID":   "nxZh4GBfG811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:149ecbad549da2f6d0c078eb879391e837fc753dace39aa925f8d152b1fdd216",
+				"DiscoKey":   "discokey:aa05f156203d8d0970c224d052bd1025cf26d0dab8fe4f00df5f6b94773bd86d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:43843",
+					"10.65.0.27:43843",
+					"172.17.0.1:43843",
+					"172.18.0.1:43843",
+					"172.19.0.1:43843"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:08:22.742228676Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3144493133447296,
+				"StableID":   "nbGjP9W9ZR11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bf7b6bc99e8eb621a8725144d0796f70b5ed6e1c8e24065fa9184a0762ab6b02",
+				"KeyExpiry":  "2026-11-08T22:08:23Z",
+				"DiscoKey":   "discokey:e398cc9bf9587a14b1d465bef847acfd2556cea069273d4da7da64433e21c332",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53148",
+					"10.65.0.27:53148",
+					"172.17.0.1:53148",
+					"172.18.0.1:53148",
+					"172.19.0.1:53148"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:08:23.282009617Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8846900123352821,
+				"StableID":   "nS5e7k4n5C21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2f0da4cd4d52196fc226ebdc5322de05bf31762c154b85bc8a5fec791211767f",
+				"KeyExpiry":  "2026-11-08T22:08:23Z",
+				"DiscoKey":   "discokey:98db68f5c7afa3368f883388ae112062c1f052f01cfc4c64bf7de5835a276066",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46158",
+					"10.65.0.27:46158",
+					"172.17.0.1:46158",
+					"172.18.0.1:46158",
+					"172.19.0.1:46158"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:08:23.930327368Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6221836278277223,
+				"StableID":   "nn4aE96taq11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9b52000e7647025dec03beeb14538cdfce92c687507835561301eb081b40a368",
+				"KeyExpiry":  "2026-11-08T22:08:24Z",
+				"DiscoKey":   "discokey:eb6226aacabf287447001bdbc5a2764a4164b71474e8f8e4e7a8222470f66a5f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55407",
+					"10.65.0.27:55407",
+					"172.17.0.1:55407",
+					"172.18.0.1:55407",
+					"172.19.0.1:55407"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:08:24.629047889Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8201117514559389": {
+				"ID":          8201117514559389,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3144493133447296,
+				"StableID":   "nbGjP9W9ZR11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bf7b6bc99e8eb621a8725144d0796f70b5ed6e1c8e24065fa9184a0762ab6b02",
+				"KeyExpiry":  "2026-11-08T22:08:23Z",
+				"DiscoKey":   "discokey:e398cc9bf9587a14b1d465bef847acfd2556cea069273d4da7da64433e21c332",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53148",
+					"10.65.0.27:53148",
+					"172.17.0.1:53148",
+					"172.18.0.1:53148",
+					"172.19.0.1:53148"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:08:23.282009617Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:bf7b6bc99e8eb621a8725144d0796f70b5ed6e1c8e24065fa9184a0762ab6b02",
+			"MachineKey": "mkey:9a37c819ae8955a112aa3c3800a0923a03d8a80ab22c1e22cbe6cb42cb4a9913",
+			"Peers": [{
+				"ID":         148957841278087,
+				"StableID":   "neiPMTsTA211CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:02af530c97681235d93c0bbd5a7a4c87fe027445d85aec3b29b0be8d31f1c464",
+				"DiscoKey":   "discokey:fd7892baa918d2cda0f4647b72b12057c88d719e6ddffe442b318098f9bcae4e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40245",
+					"10.65.0.27:40245",
+					"172.17.0.1:40245",
+					"172.18.0.1:40245",
+					"172.19.0.1:40245"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:08:16.786699384Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5533285458892829,
+				"StableID":   "niP5AX23Dk11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8bea09cb94393da412ecfc150c714953c67e8c30f350ebc86dc33ceaf40a5d07",
+				"DiscoKey":   "discokey:789be08c0ee59d64b61fd300aa4137b625f08339fe4c63b8d97071052c34ba16",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54812",
+					"10.65.0.27:54812",
+					"172.17.0.1:54812",
+					"172.18.0.1:54812",
+					"172.19.0.1:54812"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:08:17.326251824Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8541400743771754,
+				"StableID":   "nFBK5c7Rh921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a3df18b5fc083c2b4094050e064f82f0bd44fb02dbefab798db43c69b389ab5b",
+				"DiscoKey":   "discokey:4a198e0a62ad9e09d6d8ba908ddbff95d174d970e1b131606d083eb5a0d0e419",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:49249",
+					"10.65.0.27:49249",
+					"172.17.0.1:49249",
+					"172.18.0.1:49249",
+					"172.19.0.1:49249"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:08:17.889420597Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5584721634865832,
+				"StableID":   "nuhkthALck11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3701cc87d5f6ba2958dc586fc06e08bf746d7f1c11504527545e877e819c234c",
+				"DiscoKey":   "discokey:70920f9c828f9e69f7bf72c695671531fb9192d7ae3153b3fe4383ed557ddc4d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:54578",
+					"10.65.0.27:54578",
+					"172.17.0.1:54578",
+					"172.18.0.1:54578",
+					"172.19.0.1:54578"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:08:18.408602694Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8476053722357188,
+				"StableID":   "nVfcZPZpB921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e2917926668b1690ac947978636bbeaaa11e5fca3cc8bcd2dd029c4f4d88a4e",
+				"DiscoKey":   "discokey:24561b23e1580a6fa8650de849ed9371faa791df4274e22ade0eead8c5285621",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56286",
+					"10.65.0.27:56286",
+					"172.17.0.1:56286",
+					"172.18.0.1:56286",
+					"172.19.0.1:56286"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:08:18.958122059Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8051724509496322,
+				"StableID":   "nFuz4g9es521CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dce1adc30d580db78debc3fbe29cecc5c6a97a5af5f68c3afc008008b4d7755a",
+				"DiscoKey":   "discokey:62eed2a0ddf493bc0ef37410fd9e2e64de4fb9dfc9cacc24e194d222918f9759",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37326",
+					"10.65.0.27:37326",
+					"172.17.0.1:37326",
+					"172.18.0.1:37326",
+					"172.19.0.1:37326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:08:19.49889894Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8879873325482014,
+				"StableID":   "nXyM5TDiLC21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e45d70a47100bf9af4394257cf1e2e7c6b4c42b033f053d848d940b7e7dc8b10",
+				"DiscoKey":   "discokey:4c37d5a03468f32a033137358e470ae191932d00f9b2eb40b6304dd64c89d14e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51240",
+					"10.65.0.27:51240",
+					"172.17.0.1:51240",
+					"172.18.0.1:51240",
+					"172.19.0.1:51240"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:08:20.031865887Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8201117514559389,
+				"StableID":   "nr1YM8TJ3721CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97794c1b6916a4000be51091f3c8bb50a72dcbbc1861c6dd42f4f3ddee118a28",
+				"DiscoKey":   "discokey:11b930a1d778e75487995b193c857b1b8ca9a3b75d0e19ea259c05eafd3d5063",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46503",
+					"10.65.0.27:46503",
+					"172.17.0.1:46503",
+					"172.18.0.1:46503",
+					"172.19.0.1:46503"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:08:20.571756539Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8296056659322812,
+				"StableID":   "nm3SUmLJn721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2e4d43d42fd01ad9ea34dfae2ab0ef0f5115a3aa40786b8fce9fa5f9c690cc7e",
+				"DiscoKey":   "discokey:aeb2ef0bbab520ec919509c5aa8d01708d42696a89b5360b71bce9c529025613",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36424",
+					"10.65.0.27:36424",
+					"172.17.0.1:36424",
+					"172.18.0.1:36424",
+					"172.19.0.1:36424"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:08:21.117315392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8374548226897233,
+				"StableID":   "nvm2XWBrP821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80035bd6b8c38d494ad21973b4fbfc85573c5e190728057f8ec64c7c7b48e317",
+				"DiscoKey":   "discokey:becf2c4e1e55e57aedf4d537da7034abba0318525c446677286219053c428b0f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35400",
+					"10.65.0.27:35400",
+					"172.17.0.1:35400",
+					"172.18.0.1:35400",
+					"172.19.0.1:35400"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:08:21.655866087Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1795137637676623,
+				"StableID":   "n2A8trD22F11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b5f6efd1cf8af210d8e258ff49d059acd09b02964a33d30957ba6c55727ece67",
+				"DiscoKey":   "discokey:b77e628f6dd6cf4c37e23f45745983de49b94897ea1ca79d57d765afc718b622",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40204",
+					"10.65.0.27:40204",
+					"172.17.0.1:40204",
+					"172.18.0.1:40204",
+					"172.19.0.1:40204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:08:22.200198897Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         931014678892991,
+				"StableID":   "nxZh4GBfG811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:149ecbad549da2f6d0c078eb879391e837fc753dace39aa925f8d152b1fdd216",
+				"DiscoKey":   "discokey:aa05f156203d8d0970c224d052bd1025cf26d0dab8fe4f00df5f6b94773bd86d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:43843",
+					"10.65.0.27:43843",
+					"172.17.0.1:43843",
+					"172.18.0.1:43843",
+					"172.19.0.1:43843"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:08:22.742228676Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8846900123352821,
+				"StableID":   "nS5e7k4n5C21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2f0da4cd4d52196fc226ebdc5322de05bf31762c154b85bc8a5fec791211767f",
+				"KeyExpiry":  "2026-11-08T22:08:23Z",
+				"DiscoKey":   "discokey:98db68f5c7afa3368f883388ae112062c1f052f01cfc4c64bf7de5835a276066",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46158",
+					"10.65.0.27:46158",
+					"172.17.0.1:46158",
+					"172.18.0.1:46158",
+					"172.19.0.1:46158"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:08:23.930327368Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6221836278277223,
+				"StableID":   "nn4aE96taq11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9b52000e7647025dec03beeb14538cdfce92c687507835561301eb081b40a368",
+				"KeyExpiry":  "2026-11-08T22:08:24Z",
+				"DiscoKey":   "discokey:eb6226aacabf287447001bdbc5a2764a4164b71474e8f8e4e7a8222470f66a5f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55407",
+					"10.65.0.27:55407",
+					"172.17.0.1:55407",
+					"172.18.0.1:55407",
+					"172.19.0.1:55407"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:08:24.629047889Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1795137637676623,
+				"StableID":   "n2A8trD22F11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1795137637676623,
+				"Key":        "nodekey:b5f6efd1cf8af210d8e258ff49d059acd09b02964a33d30957ba6c55727ece67",
+				"DiscoKey":   "discokey:b77e628f6dd6cf4c37e23f45745983de49b94897ea1ca79d57d765afc718b622",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40204",
+					"10.65.0.27:40204",
+					"172.17.0.1:40204",
+					"172.18.0.1:40204",
+					"172.19.0.1:40204"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:08:22.200198897Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b5f6efd1cf8af210d8e258ff49d059acd09b02964a33d30957ba6c55727ece67",
+			"MachineKey": "mkey:45d40731209c3b59b643a8d6a239ab9c4379d2f8ec857cf8582e60ccfc909f44",
+			"Peers": [{
+				"ID":         148957841278087,
+				"StableID":   "neiPMTsTA211CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:02af530c97681235d93c0bbd5a7a4c87fe027445d85aec3b29b0be8d31f1c464",
+				"DiscoKey":   "discokey:fd7892baa918d2cda0f4647b72b12057c88d719e6ddffe442b318098f9bcae4e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40245",
+					"10.65.0.27:40245",
+					"172.17.0.1:40245",
+					"172.18.0.1:40245",
+					"172.19.0.1:40245"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:08:16.786699384Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5533285458892829,
+				"StableID":   "niP5AX23Dk11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8bea09cb94393da412ecfc150c714953c67e8c30f350ebc86dc33ceaf40a5d07",
+				"DiscoKey":   "discokey:789be08c0ee59d64b61fd300aa4137b625f08339fe4c63b8d97071052c34ba16",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54812",
+					"10.65.0.27:54812",
+					"172.17.0.1:54812",
+					"172.18.0.1:54812",
+					"172.19.0.1:54812"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:08:17.326251824Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8541400743771754,
+				"StableID":   "nFBK5c7Rh921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a3df18b5fc083c2b4094050e064f82f0bd44fb02dbefab798db43c69b389ab5b",
+				"DiscoKey":   "discokey:4a198e0a62ad9e09d6d8ba908ddbff95d174d970e1b131606d083eb5a0d0e419",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:49249",
+					"10.65.0.27:49249",
+					"172.17.0.1:49249",
+					"172.18.0.1:49249",
+					"172.19.0.1:49249"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:08:17.889420597Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5584721634865832,
+				"StableID":   "nuhkthALck11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3701cc87d5f6ba2958dc586fc06e08bf746d7f1c11504527545e877e819c234c",
+				"DiscoKey":   "discokey:70920f9c828f9e69f7bf72c695671531fb9192d7ae3153b3fe4383ed557ddc4d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:54578",
+					"10.65.0.27:54578",
+					"172.17.0.1:54578",
+					"172.18.0.1:54578",
+					"172.19.0.1:54578"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:08:18.408602694Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8476053722357188,
+				"StableID":   "nVfcZPZpB921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e2917926668b1690ac947978636bbeaaa11e5fca3cc8bcd2dd029c4f4d88a4e",
+				"DiscoKey":   "discokey:24561b23e1580a6fa8650de849ed9371faa791df4274e22ade0eead8c5285621",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56286",
+					"10.65.0.27:56286",
+					"172.17.0.1:56286",
+					"172.18.0.1:56286",
+					"172.19.0.1:56286"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:08:18.958122059Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8051724509496322,
+				"StableID":   "nFuz4g9es521CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dce1adc30d580db78debc3fbe29cecc5c6a97a5af5f68c3afc008008b4d7755a",
+				"DiscoKey":   "discokey:62eed2a0ddf493bc0ef37410fd9e2e64de4fb9dfc9cacc24e194d222918f9759",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37326",
+					"10.65.0.27:37326",
+					"172.17.0.1:37326",
+					"172.18.0.1:37326",
+					"172.19.0.1:37326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:08:19.49889894Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8879873325482014,
+				"StableID":   "nXyM5TDiLC21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e45d70a47100bf9af4394257cf1e2e7c6b4c42b033f053d848d940b7e7dc8b10",
+				"DiscoKey":   "discokey:4c37d5a03468f32a033137358e470ae191932d00f9b2eb40b6304dd64c89d14e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51240",
+					"10.65.0.27:51240",
+					"172.17.0.1:51240",
+					"172.18.0.1:51240",
+					"172.19.0.1:51240"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:08:20.031865887Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8201117514559389,
+				"StableID":   "nr1YM8TJ3721CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97794c1b6916a4000be51091f3c8bb50a72dcbbc1861c6dd42f4f3ddee118a28",
+				"DiscoKey":   "discokey:11b930a1d778e75487995b193c857b1b8ca9a3b75d0e19ea259c05eafd3d5063",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46503",
+					"10.65.0.27:46503",
+					"172.17.0.1:46503",
+					"172.18.0.1:46503",
+					"172.19.0.1:46503"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:08:20.571756539Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8296056659322812,
+				"StableID":   "nm3SUmLJn721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2e4d43d42fd01ad9ea34dfae2ab0ef0f5115a3aa40786b8fce9fa5f9c690cc7e",
+				"DiscoKey":   "discokey:aeb2ef0bbab520ec919509c5aa8d01708d42696a89b5360b71bce9c529025613",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36424",
+					"10.65.0.27:36424",
+					"172.17.0.1:36424",
+					"172.18.0.1:36424",
+					"172.19.0.1:36424"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:08:21.117315392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8374548226897233,
+				"StableID":   "nvm2XWBrP821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80035bd6b8c38d494ad21973b4fbfc85573c5e190728057f8ec64c7c7b48e317",
+				"DiscoKey":   "discokey:becf2c4e1e55e57aedf4d537da7034abba0318525c446677286219053c428b0f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35400",
+					"10.65.0.27:35400",
+					"172.17.0.1:35400",
+					"172.18.0.1:35400",
+					"172.19.0.1:35400"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:08:21.655866087Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         931014678892991,
+				"StableID":   "nxZh4GBfG811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:149ecbad549da2f6d0c078eb879391e837fc753dace39aa925f8d152b1fdd216",
+				"DiscoKey":   "discokey:aa05f156203d8d0970c224d052bd1025cf26d0dab8fe4f00df5f6b94773bd86d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:43843",
+					"10.65.0.27:43843",
+					"172.17.0.1:43843",
+					"172.18.0.1:43843",
+					"172.19.0.1:43843"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:08:22.742228676Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3144493133447296,
+				"StableID":   "nbGjP9W9ZR11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bf7b6bc99e8eb621a8725144d0796f70b5ed6e1c8e24065fa9184a0762ab6b02",
+				"KeyExpiry":  "2026-11-08T22:08:23Z",
+				"DiscoKey":   "discokey:e398cc9bf9587a14b1d465bef847acfd2556cea069273d4da7da64433e21c332",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53148",
+					"10.65.0.27:53148",
+					"172.17.0.1:53148",
+					"172.18.0.1:53148",
+					"172.19.0.1:53148"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:08:23.282009617Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8846900123352821,
+				"StableID":   "nS5e7k4n5C21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2f0da4cd4d52196fc226ebdc5322de05bf31762c154b85bc8a5fec791211767f",
+				"KeyExpiry":  "2026-11-08T22:08:23Z",
+				"DiscoKey":   "discokey:98db68f5c7afa3368f883388ae112062c1f052f01cfc4c64bf7de5835a276066",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46158",
+					"10.65.0.27:46158",
+					"172.17.0.1:46158",
+					"172.18.0.1:46158",
+					"172.19.0.1:46158"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:08:23.930327368Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6221836278277223,
+				"StableID":   "nn4aE96taq11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9b52000e7647025dec03beeb14538cdfce92c687507835561301eb081b40a368",
+				"KeyExpiry":  "2026-11-08T22:08:24Z",
+				"DiscoKey":   "discokey:eb6226aacabf287447001bdbc5a2764a4164b71474e8f8e4e7a8222470f66a5f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55407",
+					"10.65.0.27:55407",
+					"172.17.0.1:55407",
+					"172.18.0.1:55407",
+					"172.19.0.1:55407"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:08:24.629047889Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1795137637676623": {
+				"ID":          1795137637676623,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5533285458892829,
+				"StableID":   "niP5AX23Dk11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       5533285458892829,
+				"Key":        "nodekey:8bea09cb94393da412ecfc150c714953c67e8c30f350ebc86dc33ceaf40a5d07",
+				"DiscoKey":   "discokey:789be08c0ee59d64b61fd300aa4137b625f08339fe4c63b8d97071052c34ba16",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54812",
+					"10.65.0.27:54812",
+					"172.17.0.1:54812",
+					"172.18.0.1:54812",
+					"172.19.0.1:54812"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:08:17.326251824Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8bea09cb94393da412ecfc150c714953c67e8c30f350ebc86dc33ceaf40a5d07",
+			"MachineKey": "mkey:fd4a493912fbee7ff752a292d3c3e96954ee8d3a56943d110ac426d0ea9be85e",
+			"Peers": [{
+				"ID":         148957841278087,
+				"StableID":   "neiPMTsTA211CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:02af530c97681235d93c0bbd5a7a4c87fe027445d85aec3b29b0be8d31f1c464",
+				"DiscoKey":   "discokey:fd7892baa918d2cda0f4647b72b12057c88d719e6ddffe442b318098f9bcae4e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40245",
+					"10.65.0.27:40245",
+					"172.17.0.1:40245",
+					"172.18.0.1:40245",
+					"172.19.0.1:40245"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:08:16.786699384Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8541400743771754,
+				"StableID":   "nFBK5c7Rh921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a3df18b5fc083c2b4094050e064f82f0bd44fb02dbefab798db43c69b389ab5b",
+				"DiscoKey":   "discokey:4a198e0a62ad9e09d6d8ba908ddbff95d174d970e1b131606d083eb5a0d0e419",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:49249",
+					"10.65.0.27:49249",
+					"172.17.0.1:49249",
+					"172.18.0.1:49249",
+					"172.19.0.1:49249"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:08:17.889420597Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5584721634865832,
+				"StableID":   "nuhkthALck11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3701cc87d5f6ba2958dc586fc06e08bf746d7f1c11504527545e877e819c234c",
+				"DiscoKey":   "discokey:70920f9c828f9e69f7bf72c695671531fb9192d7ae3153b3fe4383ed557ddc4d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:54578",
+					"10.65.0.27:54578",
+					"172.17.0.1:54578",
+					"172.18.0.1:54578",
+					"172.19.0.1:54578"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:08:18.408602694Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8476053722357188,
+				"StableID":   "nVfcZPZpB921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e2917926668b1690ac947978636bbeaaa11e5fca3cc8bcd2dd029c4f4d88a4e",
+				"DiscoKey":   "discokey:24561b23e1580a6fa8650de849ed9371faa791df4274e22ade0eead8c5285621",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56286",
+					"10.65.0.27:56286",
+					"172.17.0.1:56286",
+					"172.18.0.1:56286",
+					"172.19.0.1:56286"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:08:18.958122059Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8051724509496322,
+				"StableID":   "nFuz4g9es521CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dce1adc30d580db78debc3fbe29cecc5c6a97a5af5f68c3afc008008b4d7755a",
+				"DiscoKey":   "discokey:62eed2a0ddf493bc0ef37410fd9e2e64de4fb9dfc9cacc24e194d222918f9759",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37326",
+					"10.65.0.27:37326",
+					"172.17.0.1:37326",
+					"172.18.0.1:37326",
+					"172.19.0.1:37326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:08:19.49889894Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8879873325482014,
+				"StableID":   "nXyM5TDiLC21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e45d70a47100bf9af4394257cf1e2e7c6b4c42b033f053d848d940b7e7dc8b10",
+				"DiscoKey":   "discokey:4c37d5a03468f32a033137358e470ae191932d00f9b2eb40b6304dd64c89d14e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51240",
+					"10.65.0.27:51240",
+					"172.17.0.1:51240",
+					"172.18.0.1:51240",
+					"172.19.0.1:51240"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:08:20.031865887Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8201117514559389,
+				"StableID":   "nr1YM8TJ3721CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97794c1b6916a4000be51091f3c8bb50a72dcbbc1861c6dd42f4f3ddee118a28",
+				"DiscoKey":   "discokey:11b930a1d778e75487995b193c857b1b8ca9a3b75d0e19ea259c05eafd3d5063",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46503",
+					"10.65.0.27:46503",
+					"172.17.0.1:46503",
+					"172.18.0.1:46503",
+					"172.19.0.1:46503"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:08:20.571756539Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8296056659322812,
+				"StableID":   "nm3SUmLJn721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2e4d43d42fd01ad9ea34dfae2ab0ef0f5115a3aa40786b8fce9fa5f9c690cc7e",
+				"DiscoKey":   "discokey:aeb2ef0bbab520ec919509c5aa8d01708d42696a89b5360b71bce9c529025613",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36424",
+					"10.65.0.27:36424",
+					"172.17.0.1:36424",
+					"172.18.0.1:36424",
+					"172.19.0.1:36424"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:08:21.117315392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8374548226897233,
+				"StableID":   "nvm2XWBrP821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80035bd6b8c38d494ad21973b4fbfc85573c5e190728057f8ec64c7c7b48e317",
+				"DiscoKey":   "discokey:becf2c4e1e55e57aedf4d537da7034abba0318525c446677286219053c428b0f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35400",
+					"10.65.0.27:35400",
+					"172.17.0.1:35400",
+					"172.18.0.1:35400",
+					"172.19.0.1:35400"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:08:21.655866087Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1795137637676623,
+				"StableID":   "n2A8trD22F11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b5f6efd1cf8af210d8e258ff49d059acd09b02964a33d30957ba6c55727ece67",
+				"DiscoKey":   "discokey:b77e628f6dd6cf4c37e23f45745983de49b94897ea1ca79d57d765afc718b622",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40204",
+					"10.65.0.27:40204",
+					"172.17.0.1:40204",
+					"172.18.0.1:40204",
+					"172.19.0.1:40204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:08:22.200198897Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         931014678892991,
+				"StableID":   "nxZh4GBfG811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:149ecbad549da2f6d0c078eb879391e837fc753dace39aa925f8d152b1fdd216",
+				"DiscoKey":   "discokey:aa05f156203d8d0970c224d052bd1025cf26d0dab8fe4f00df5f6b94773bd86d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:43843",
+					"10.65.0.27:43843",
+					"172.17.0.1:43843",
+					"172.18.0.1:43843",
+					"172.19.0.1:43843"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:08:22.742228676Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3144493133447296,
+				"StableID":   "nbGjP9W9ZR11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bf7b6bc99e8eb621a8725144d0796f70b5ed6e1c8e24065fa9184a0762ab6b02",
+				"KeyExpiry":  "2026-11-08T22:08:23Z",
+				"DiscoKey":   "discokey:e398cc9bf9587a14b1d465bef847acfd2556cea069273d4da7da64433e21c332",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53148",
+					"10.65.0.27:53148",
+					"172.17.0.1:53148",
+					"172.18.0.1:53148",
+					"172.19.0.1:53148"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:08:23.282009617Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8846900123352821,
+				"StableID":   "nS5e7k4n5C21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2f0da4cd4d52196fc226ebdc5322de05bf31762c154b85bc8a5fec791211767f",
+				"KeyExpiry":  "2026-11-08T22:08:23Z",
+				"DiscoKey":   "discokey:98db68f5c7afa3368f883388ae112062c1f052f01cfc4c64bf7de5835a276066",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46158",
+					"10.65.0.27:46158",
+					"172.17.0.1:46158",
+					"172.18.0.1:46158",
+					"172.19.0.1:46158"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:08:23.930327368Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6221836278277223,
+				"StableID":   "nn4aE96taq11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9b52000e7647025dec03beeb14538cdfce92c687507835561301eb081b40a368",
+				"KeyExpiry":  "2026-11-08T22:08:24Z",
+				"DiscoKey":   "discokey:eb6226aacabf287447001bdbc5a2764a4164b71474e8f8e4e7a8222470f66a5f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55407",
+					"10.65.0.27:55407",
+					"172.17.0.1:55407",
+					"172.18.0.1:55407",
+					"172.19.0.1:55407"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:08:24.629047889Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5533285458892829": {
+				"ID":          5533285458892829,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         148957841278087,
+				"StableID":   "neiPMTsTA211CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       148957841278087,
+				"Key":        "nodekey:02af530c97681235d93c0bbd5a7a4c87fe027445d85aec3b29b0be8d31f1c464",
+				"DiscoKey":   "discokey:fd7892baa918d2cda0f4647b72b12057c88d719e6ddffe442b318098f9bcae4e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40245",
+					"10.65.0.27:40245",
+					"172.17.0.1:40245",
+					"172.18.0.1:40245",
+					"172.19.0.1:40245"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:08:16.786699384Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:02af530c97681235d93c0bbd5a7a4c87fe027445d85aec3b29b0be8d31f1c464",
+			"MachineKey": "mkey:643d47ba5ea9e1d263f44a9119469a91ff826473d58454b6a474b3c10e4c2e66",
+			"Peers": [{
+				"ID":         5533285458892829,
+				"StableID":   "niP5AX23Dk11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8bea09cb94393da412ecfc150c714953c67e8c30f350ebc86dc33ceaf40a5d07",
+				"DiscoKey":   "discokey:789be08c0ee59d64b61fd300aa4137b625f08339fe4c63b8d97071052c34ba16",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54812",
+					"10.65.0.27:54812",
+					"172.17.0.1:54812",
+					"172.18.0.1:54812",
+					"172.19.0.1:54812"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:08:17.326251824Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8541400743771754,
+				"StableID":   "nFBK5c7Rh921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a3df18b5fc083c2b4094050e064f82f0bd44fb02dbefab798db43c69b389ab5b",
+				"DiscoKey":   "discokey:4a198e0a62ad9e09d6d8ba908ddbff95d174d970e1b131606d083eb5a0d0e419",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:49249",
+					"10.65.0.27:49249",
+					"172.17.0.1:49249",
+					"172.18.0.1:49249",
+					"172.19.0.1:49249"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:08:17.889420597Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5584721634865832,
+				"StableID":   "nuhkthALck11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3701cc87d5f6ba2958dc586fc06e08bf746d7f1c11504527545e877e819c234c",
+				"DiscoKey":   "discokey:70920f9c828f9e69f7bf72c695671531fb9192d7ae3153b3fe4383ed557ddc4d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:54578",
+					"10.65.0.27:54578",
+					"172.17.0.1:54578",
+					"172.18.0.1:54578",
+					"172.19.0.1:54578"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:08:18.408602694Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8476053722357188,
+				"StableID":   "nVfcZPZpB921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e2917926668b1690ac947978636bbeaaa11e5fca3cc8bcd2dd029c4f4d88a4e",
+				"DiscoKey":   "discokey:24561b23e1580a6fa8650de849ed9371faa791df4274e22ade0eead8c5285621",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56286",
+					"10.65.0.27:56286",
+					"172.17.0.1:56286",
+					"172.18.0.1:56286",
+					"172.19.0.1:56286"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:08:18.958122059Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8051724509496322,
+				"StableID":   "nFuz4g9es521CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dce1adc30d580db78debc3fbe29cecc5c6a97a5af5f68c3afc008008b4d7755a",
+				"DiscoKey":   "discokey:62eed2a0ddf493bc0ef37410fd9e2e64de4fb9dfc9cacc24e194d222918f9759",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37326",
+					"10.65.0.27:37326",
+					"172.17.0.1:37326",
+					"172.18.0.1:37326",
+					"172.19.0.1:37326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:08:19.49889894Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8879873325482014,
+				"StableID":   "nXyM5TDiLC21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e45d70a47100bf9af4394257cf1e2e7c6b4c42b033f053d848d940b7e7dc8b10",
+				"DiscoKey":   "discokey:4c37d5a03468f32a033137358e470ae191932d00f9b2eb40b6304dd64c89d14e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51240",
+					"10.65.0.27:51240",
+					"172.17.0.1:51240",
+					"172.18.0.1:51240",
+					"172.19.0.1:51240"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:08:20.031865887Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8201117514559389,
+				"StableID":   "nr1YM8TJ3721CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97794c1b6916a4000be51091f3c8bb50a72dcbbc1861c6dd42f4f3ddee118a28",
+				"DiscoKey":   "discokey:11b930a1d778e75487995b193c857b1b8ca9a3b75d0e19ea259c05eafd3d5063",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46503",
+					"10.65.0.27:46503",
+					"172.17.0.1:46503",
+					"172.18.0.1:46503",
+					"172.19.0.1:46503"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:08:20.571756539Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8296056659322812,
+				"StableID":   "nm3SUmLJn721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2e4d43d42fd01ad9ea34dfae2ab0ef0f5115a3aa40786b8fce9fa5f9c690cc7e",
+				"DiscoKey":   "discokey:aeb2ef0bbab520ec919509c5aa8d01708d42696a89b5360b71bce9c529025613",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36424",
+					"10.65.0.27:36424",
+					"172.17.0.1:36424",
+					"172.18.0.1:36424",
+					"172.19.0.1:36424"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:08:21.117315392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8374548226897233,
+				"StableID":   "nvm2XWBrP821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80035bd6b8c38d494ad21973b4fbfc85573c5e190728057f8ec64c7c7b48e317",
+				"DiscoKey":   "discokey:becf2c4e1e55e57aedf4d537da7034abba0318525c446677286219053c428b0f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35400",
+					"10.65.0.27:35400",
+					"172.17.0.1:35400",
+					"172.18.0.1:35400",
+					"172.19.0.1:35400"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:08:21.655866087Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1795137637676623,
+				"StableID":   "n2A8trD22F11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b5f6efd1cf8af210d8e258ff49d059acd09b02964a33d30957ba6c55727ece67",
+				"DiscoKey":   "discokey:b77e628f6dd6cf4c37e23f45745983de49b94897ea1ca79d57d765afc718b622",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40204",
+					"10.65.0.27:40204",
+					"172.17.0.1:40204",
+					"172.18.0.1:40204",
+					"172.19.0.1:40204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:08:22.200198897Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         931014678892991,
+				"StableID":   "nxZh4GBfG811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:149ecbad549da2f6d0c078eb879391e837fc753dace39aa925f8d152b1fdd216",
+				"DiscoKey":   "discokey:aa05f156203d8d0970c224d052bd1025cf26d0dab8fe4f00df5f6b94773bd86d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:43843",
+					"10.65.0.27:43843",
+					"172.17.0.1:43843",
+					"172.18.0.1:43843",
+					"172.19.0.1:43843"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:08:22.742228676Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3144493133447296,
+				"StableID":   "nbGjP9W9ZR11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bf7b6bc99e8eb621a8725144d0796f70b5ed6e1c8e24065fa9184a0762ab6b02",
+				"KeyExpiry":  "2026-11-08T22:08:23Z",
+				"DiscoKey":   "discokey:e398cc9bf9587a14b1d465bef847acfd2556cea069273d4da7da64433e21c332",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53148",
+					"10.65.0.27:53148",
+					"172.17.0.1:53148",
+					"172.18.0.1:53148",
+					"172.19.0.1:53148"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:08:23.282009617Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8846900123352821,
+				"StableID":   "nS5e7k4n5C21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2f0da4cd4d52196fc226ebdc5322de05bf31762c154b85bc8a5fec791211767f",
+				"KeyExpiry":  "2026-11-08T22:08:23Z",
+				"DiscoKey":   "discokey:98db68f5c7afa3368f883388ae112062c1f052f01cfc4c64bf7de5835a276066",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46158",
+					"10.65.0.27:46158",
+					"172.17.0.1:46158",
+					"172.18.0.1:46158",
+					"172.19.0.1:46158"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:08:23.930327368Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6221836278277223,
+				"StableID":   "nn4aE96taq11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9b52000e7647025dec03beeb14538cdfce92c687507835561301eb081b40a368",
+				"KeyExpiry":  "2026-11-08T22:08:24Z",
+				"DiscoKey":   "discokey:eb6226aacabf287447001bdbc5a2764a4164b71474e8f8e4e7a8222470f66a5f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55407",
+					"10.65.0.27:55407",
+					"172.17.0.1:55407",
+					"172.18.0.1:55407",
+					"172.19.0.1:55407"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:08:24.629047889Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "148957841278087": {
+				"ID":          148957841278087,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8476053722357188,
+				"StableID":   "nVfcZPZpB921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       8476053722357188,
+				"Key":        "nodekey:8e2917926668b1690ac947978636bbeaaa11e5fca3cc8bcd2dd029c4f4d88a4e",
+				"DiscoKey":   "discokey:24561b23e1580a6fa8650de849ed9371faa791df4274e22ade0eead8c5285621",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56286",
+					"10.65.0.27:56286",
+					"172.17.0.1:56286",
+					"172.18.0.1:56286",
+					"172.19.0.1:56286"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:08:18.958122059Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8e2917926668b1690ac947978636bbeaaa11e5fca3cc8bcd2dd029c4f4d88a4e",
+			"MachineKey": "mkey:e083d68abd7f9fdfaa3c8ee263f2cf0e052413406dfb3cbd8f635b72df868846",
+			"Peers": [{
+				"ID":         148957841278087,
+				"StableID":   "neiPMTsTA211CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:02af530c97681235d93c0bbd5a7a4c87fe027445d85aec3b29b0be8d31f1c464",
+				"DiscoKey":   "discokey:fd7892baa918d2cda0f4647b72b12057c88d719e6ddffe442b318098f9bcae4e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40245",
+					"10.65.0.27:40245",
+					"172.17.0.1:40245",
+					"172.18.0.1:40245",
+					"172.19.0.1:40245"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:08:16.786699384Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5533285458892829,
+				"StableID":   "niP5AX23Dk11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8bea09cb94393da412ecfc150c714953c67e8c30f350ebc86dc33ceaf40a5d07",
+				"DiscoKey":   "discokey:789be08c0ee59d64b61fd300aa4137b625f08339fe4c63b8d97071052c34ba16",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54812",
+					"10.65.0.27:54812",
+					"172.17.0.1:54812",
+					"172.18.0.1:54812",
+					"172.19.0.1:54812"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:08:17.326251824Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8541400743771754,
+				"StableID":   "nFBK5c7Rh921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a3df18b5fc083c2b4094050e064f82f0bd44fb02dbefab798db43c69b389ab5b",
+				"DiscoKey":   "discokey:4a198e0a62ad9e09d6d8ba908ddbff95d174d970e1b131606d083eb5a0d0e419",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:49249",
+					"10.65.0.27:49249",
+					"172.17.0.1:49249",
+					"172.18.0.1:49249",
+					"172.19.0.1:49249"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:08:17.889420597Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5584721634865832,
+				"StableID":   "nuhkthALck11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3701cc87d5f6ba2958dc586fc06e08bf746d7f1c11504527545e877e819c234c",
+				"DiscoKey":   "discokey:70920f9c828f9e69f7bf72c695671531fb9192d7ae3153b3fe4383ed557ddc4d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:54578",
+					"10.65.0.27:54578",
+					"172.17.0.1:54578",
+					"172.18.0.1:54578",
+					"172.19.0.1:54578"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:08:18.408602694Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8051724509496322,
+				"StableID":   "nFuz4g9es521CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dce1adc30d580db78debc3fbe29cecc5c6a97a5af5f68c3afc008008b4d7755a",
+				"DiscoKey":   "discokey:62eed2a0ddf493bc0ef37410fd9e2e64de4fb9dfc9cacc24e194d222918f9759",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37326",
+					"10.65.0.27:37326",
+					"172.17.0.1:37326",
+					"172.18.0.1:37326",
+					"172.19.0.1:37326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:08:19.49889894Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8879873325482014,
+				"StableID":   "nXyM5TDiLC21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e45d70a47100bf9af4394257cf1e2e7c6b4c42b033f053d848d940b7e7dc8b10",
+				"DiscoKey":   "discokey:4c37d5a03468f32a033137358e470ae191932d00f9b2eb40b6304dd64c89d14e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51240",
+					"10.65.0.27:51240",
+					"172.17.0.1:51240",
+					"172.18.0.1:51240",
+					"172.19.0.1:51240"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:08:20.031865887Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8201117514559389,
+				"StableID":   "nr1YM8TJ3721CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97794c1b6916a4000be51091f3c8bb50a72dcbbc1861c6dd42f4f3ddee118a28",
+				"DiscoKey":   "discokey:11b930a1d778e75487995b193c857b1b8ca9a3b75d0e19ea259c05eafd3d5063",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46503",
+					"10.65.0.27:46503",
+					"172.17.0.1:46503",
+					"172.18.0.1:46503",
+					"172.19.0.1:46503"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:08:20.571756539Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8296056659322812,
+				"StableID":   "nm3SUmLJn721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2e4d43d42fd01ad9ea34dfae2ab0ef0f5115a3aa40786b8fce9fa5f9c690cc7e",
+				"DiscoKey":   "discokey:aeb2ef0bbab520ec919509c5aa8d01708d42696a89b5360b71bce9c529025613",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36424",
+					"10.65.0.27:36424",
+					"172.17.0.1:36424",
+					"172.18.0.1:36424",
+					"172.19.0.1:36424"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:08:21.117315392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8374548226897233,
+				"StableID":   "nvm2XWBrP821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80035bd6b8c38d494ad21973b4fbfc85573c5e190728057f8ec64c7c7b48e317",
+				"DiscoKey":   "discokey:becf2c4e1e55e57aedf4d537da7034abba0318525c446677286219053c428b0f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35400",
+					"10.65.0.27:35400",
+					"172.17.0.1:35400",
+					"172.18.0.1:35400",
+					"172.19.0.1:35400"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:08:21.655866087Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1795137637676623,
+				"StableID":   "n2A8trD22F11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b5f6efd1cf8af210d8e258ff49d059acd09b02964a33d30957ba6c55727ece67",
+				"DiscoKey":   "discokey:b77e628f6dd6cf4c37e23f45745983de49b94897ea1ca79d57d765afc718b622",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40204",
+					"10.65.0.27:40204",
+					"172.17.0.1:40204",
+					"172.18.0.1:40204",
+					"172.19.0.1:40204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:08:22.200198897Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         931014678892991,
+				"StableID":   "nxZh4GBfG811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:149ecbad549da2f6d0c078eb879391e837fc753dace39aa925f8d152b1fdd216",
+				"DiscoKey":   "discokey:aa05f156203d8d0970c224d052bd1025cf26d0dab8fe4f00df5f6b94773bd86d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:43843",
+					"10.65.0.27:43843",
+					"172.17.0.1:43843",
+					"172.18.0.1:43843",
+					"172.19.0.1:43843"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:08:22.742228676Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3144493133447296,
+				"StableID":   "nbGjP9W9ZR11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bf7b6bc99e8eb621a8725144d0796f70b5ed6e1c8e24065fa9184a0762ab6b02",
+				"KeyExpiry":  "2026-11-08T22:08:23Z",
+				"DiscoKey":   "discokey:e398cc9bf9587a14b1d465bef847acfd2556cea069273d4da7da64433e21c332",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53148",
+					"10.65.0.27:53148",
+					"172.17.0.1:53148",
+					"172.18.0.1:53148",
+					"172.19.0.1:53148"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:08:23.282009617Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8846900123352821,
+				"StableID":   "nS5e7k4n5C21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2f0da4cd4d52196fc226ebdc5322de05bf31762c154b85bc8a5fec791211767f",
+				"KeyExpiry":  "2026-11-08T22:08:23Z",
+				"DiscoKey":   "discokey:98db68f5c7afa3368f883388ae112062c1f052f01cfc4c64bf7de5835a276066",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46158",
+					"10.65.0.27:46158",
+					"172.17.0.1:46158",
+					"172.18.0.1:46158",
+					"172.19.0.1:46158"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:08:23.930327368Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6221836278277223,
+				"StableID":   "nn4aE96taq11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9b52000e7647025dec03beeb14538cdfce92c687507835561301eb081b40a368",
+				"KeyExpiry":  "2026-11-08T22:08:24Z",
+				"DiscoKey":   "discokey:eb6226aacabf287447001bdbc5a2764a4164b71474e8f8e4e7a8222470f66a5f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55407",
+					"10.65.0.27:55407",
+					"172.17.0.1:55407",
+					"172.18.0.1:55407",
+					"172.19.0.1:55407"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:08:24.629047889Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8476053722357188": {
+				"ID":          8476053722357188,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5584721634865832,
+				"StableID":   "nuhkthALck11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       5584721634865832,
+				"Key":        "nodekey:3701cc87d5f6ba2958dc586fc06e08bf746d7f1c11504527545e877e819c234c",
+				"DiscoKey":   "discokey:70920f9c828f9e69f7bf72c695671531fb9192d7ae3153b3fe4383ed557ddc4d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:54578",
+					"10.65.0.27:54578",
+					"172.17.0.1:54578",
+					"172.18.0.1:54578",
+					"172.19.0.1:54578"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:08:18.408602694Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3701cc87d5f6ba2958dc586fc06e08bf746d7f1c11504527545e877e819c234c",
+			"MachineKey": "mkey:dc09da09fec8ef92ab8c9b51cfd154846731cd9be89eb0fde28a6fd8c2dacc23",
+			"Peers": [{
+				"ID":         148957841278087,
+				"StableID":   "neiPMTsTA211CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:02af530c97681235d93c0bbd5a7a4c87fe027445d85aec3b29b0be8d31f1c464",
+				"DiscoKey":   "discokey:fd7892baa918d2cda0f4647b72b12057c88d719e6ddffe442b318098f9bcae4e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40245",
+					"10.65.0.27:40245",
+					"172.17.0.1:40245",
+					"172.18.0.1:40245",
+					"172.19.0.1:40245"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:08:16.786699384Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5533285458892829,
+				"StableID":   "niP5AX23Dk11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8bea09cb94393da412ecfc150c714953c67e8c30f350ebc86dc33ceaf40a5d07",
+				"DiscoKey":   "discokey:789be08c0ee59d64b61fd300aa4137b625f08339fe4c63b8d97071052c34ba16",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54812",
+					"10.65.0.27:54812",
+					"172.17.0.1:54812",
+					"172.18.0.1:54812",
+					"172.19.0.1:54812"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:08:17.326251824Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8541400743771754,
+				"StableID":   "nFBK5c7Rh921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a3df18b5fc083c2b4094050e064f82f0bd44fb02dbefab798db43c69b389ab5b",
+				"DiscoKey":   "discokey:4a198e0a62ad9e09d6d8ba908ddbff95d174d970e1b131606d083eb5a0d0e419",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:49249",
+					"10.65.0.27:49249",
+					"172.17.0.1:49249",
+					"172.18.0.1:49249",
+					"172.19.0.1:49249"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:08:17.889420597Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8476053722357188,
+				"StableID":   "nVfcZPZpB921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e2917926668b1690ac947978636bbeaaa11e5fca3cc8bcd2dd029c4f4d88a4e",
+				"DiscoKey":   "discokey:24561b23e1580a6fa8650de849ed9371faa791df4274e22ade0eead8c5285621",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56286",
+					"10.65.0.27:56286",
+					"172.17.0.1:56286",
+					"172.18.0.1:56286",
+					"172.19.0.1:56286"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:08:18.958122059Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8051724509496322,
+				"StableID":   "nFuz4g9es521CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dce1adc30d580db78debc3fbe29cecc5c6a97a5af5f68c3afc008008b4d7755a",
+				"DiscoKey":   "discokey:62eed2a0ddf493bc0ef37410fd9e2e64de4fb9dfc9cacc24e194d222918f9759",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37326",
+					"10.65.0.27:37326",
+					"172.17.0.1:37326",
+					"172.18.0.1:37326",
+					"172.19.0.1:37326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:08:19.49889894Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8879873325482014,
+				"StableID":   "nXyM5TDiLC21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e45d70a47100bf9af4394257cf1e2e7c6b4c42b033f053d848d940b7e7dc8b10",
+				"DiscoKey":   "discokey:4c37d5a03468f32a033137358e470ae191932d00f9b2eb40b6304dd64c89d14e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51240",
+					"10.65.0.27:51240",
+					"172.17.0.1:51240",
+					"172.18.0.1:51240",
+					"172.19.0.1:51240"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:08:20.031865887Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8201117514559389,
+				"StableID":   "nr1YM8TJ3721CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97794c1b6916a4000be51091f3c8bb50a72dcbbc1861c6dd42f4f3ddee118a28",
+				"DiscoKey":   "discokey:11b930a1d778e75487995b193c857b1b8ca9a3b75d0e19ea259c05eafd3d5063",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46503",
+					"10.65.0.27:46503",
+					"172.17.0.1:46503",
+					"172.18.0.1:46503",
+					"172.19.0.1:46503"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:08:20.571756539Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8296056659322812,
+				"StableID":   "nm3SUmLJn721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2e4d43d42fd01ad9ea34dfae2ab0ef0f5115a3aa40786b8fce9fa5f9c690cc7e",
+				"DiscoKey":   "discokey:aeb2ef0bbab520ec919509c5aa8d01708d42696a89b5360b71bce9c529025613",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36424",
+					"10.65.0.27:36424",
+					"172.17.0.1:36424",
+					"172.18.0.1:36424",
+					"172.19.0.1:36424"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:08:21.117315392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8374548226897233,
+				"StableID":   "nvm2XWBrP821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80035bd6b8c38d494ad21973b4fbfc85573c5e190728057f8ec64c7c7b48e317",
+				"DiscoKey":   "discokey:becf2c4e1e55e57aedf4d537da7034abba0318525c446677286219053c428b0f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35400",
+					"10.65.0.27:35400",
+					"172.17.0.1:35400",
+					"172.18.0.1:35400",
+					"172.19.0.1:35400"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:08:21.655866087Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1795137637676623,
+				"StableID":   "n2A8trD22F11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b5f6efd1cf8af210d8e258ff49d059acd09b02964a33d30957ba6c55727ece67",
+				"DiscoKey":   "discokey:b77e628f6dd6cf4c37e23f45745983de49b94897ea1ca79d57d765afc718b622",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40204",
+					"10.65.0.27:40204",
+					"172.17.0.1:40204",
+					"172.18.0.1:40204",
+					"172.19.0.1:40204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:08:22.200198897Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         931014678892991,
+				"StableID":   "nxZh4GBfG811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:149ecbad549da2f6d0c078eb879391e837fc753dace39aa925f8d152b1fdd216",
+				"DiscoKey":   "discokey:aa05f156203d8d0970c224d052bd1025cf26d0dab8fe4f00df5f6b94773bd86d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:43843",
+					"10.65.0.27:43843",
+					"172.17.0.1:43843",
+					"172.18.0.1:43843",
+					"172.19.0.1:43843"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:08:22.742228676Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3144493133447296,
+				"StableID":   "nbGjP9W9ZR11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bf7b6bc99e8eb621a8725144d0796f70b5ed6e1c8e24065fa9184a0762ab6b02",
+				"KeyExpiry":  "2026-11-08T22:08:23Z",
+				"DiscoKey":   "discokey:e398cc9bf9587a14b1d465bef847acfd2556cea069273d4da7da64433e21c332",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53148",
+					"10.65.0.27:53148",
+					"172.17.0.1:53148",
+					"172.18.0.1:53148",
+					"172.19.0.1:53148"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:08:23.282009617Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8846900123352821,
+				"StableID":   "nS5e7k4n5C21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2f0da4cd4d52196fc226ebdc5322de05bf31762c154b85bc8a5fec791211767f",
+				"KeyExpiry":  "2026-11-08T22:08:23Z",
+				"DiscoKey":   "discokey:98db68f5c7afa3368f883388ae112062c1f052f01cfc4c64bf7de5835a276066",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46158",
+					"10.65.0.27:46158",
+					"172.17.0.1:46158",
+					"172.18.0.1:46158",
+					"172.19.0.1:46158"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:08:23.930327368Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6221836278277223,
+				"StableID":   "nn4aE96taq11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9b52000e7647025dec03beeb14538cdfce92c687507835561301eb081b40a368",
+				"KeyExpiry":  "2026-11-08T22:08:24Z",
+				"DiscoKey":   "discokey:eb6226aacabf287447001bdbc5a2764a4164b71474e8f8e4e7a8222470f66a5f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55407",
+					"10.65.0.27:55407",
+					"172.17.0.1:55407",
+					"172.18.0.1:55407",
+					"172.19.0.1:55407"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:08:24.629047889Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5584721634865832": {
+				"ID":          5584721634865832,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8879873325482014,
+				"StableID":   "nXyM5TDiLC21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       8879873325482014,
+				"Key":        "nodekey:e45d70a47100bf9af4394257cf1e2e7c6b4c42b033f053d848d940b7e7dc8b10",
+				"DiscoKey":   "discokey:4c37d5a03468f32a033137358e470ae191932d00f9b2eb40b6304dd64c89d14e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51240",
+					"10.65.0.27:51240",
+					"172.17.0.1:51240",
+					"172.18.0.1:51240",
+					"172.19.0.1:51240"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:08:20.031865887Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e45d70a47100bf9af4394257cf1e2e7c6b4c42b033f053d848d940b7e7dc8b10",
+			"MachineKey": "mkey:243816571ecf2e97a905afea2b42ba15c1a15e3adf9890ae80900b22c36e252a",
+			"Peers": [{
+				"ID":         148957841278087,
+				"StableID":   "neiPMTsTA211CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:02af530c97681235d93c0bbd5a7a4c87fe027445d85aec3b29b0be8d31f1c464",
+				"DiscoKey":   "discokey:fd7892baa918d2cda0f4647b72b12057c88d719e6ddffe442b318098f9bcae4e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40245",
+					"10.65.0.27:40245",
+					"172.17.0.1:40245",
+					"172.18.0.1:40245",
+					"172.19.0.1:40245"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:08:16.786699384Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5533285458892829,
+				"StableID":   "niP5AX23Dk11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8bea09cb94393da412ecfc150c714953c67e8c30f350ebc86dc33ceaf40a5d07",
+				"DiscoKey":   "discokey:789be08c0ee59d64b61fd300aa4137b625f08339fe4c63b8d97071052c34ba16",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54812",
+					"10.65.0.27:54812",
+					"172.17.0.1:54812",
+					"172.18.0.1:54812",
+					"172.19.0.1:54812"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:08:17.326251824Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8541400743771754,
+				"StableID":   "nFBK5c7Rh921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a3df18b5fc083c2b4094050e064f82f0bd44fb02dbefab798db43c69b389ab5b",
+				"DiscoKey":   "discokey:4a198e0a62ad9e09d6d8ba908ddbff95d174d970e1b131606d083eb5a0d0e419",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:49249",
+					"10.65.0.27:49249",
+					"172.17.0.1:49249",
+					"172.18.0.1:49249",
+					"172.19.0.1:49249"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:08:17.889420597Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5584721634865832,
+				"StableID":   "nuhkthALck11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3701cc87d5f6ba2958dc586fc06e08bf746d7f1c11504527545e877e819c234c",
+				"DiscoKey":   "discokey:70920f9c828f9e69f7bf72c695671531fb9192d7ae3153b3fe4383ed557ddc4d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:54578",
+					"10.65.0.27:54578",
+					"172.17.0.1:54578",
+					"172.18.0.1:54578",
+					"172.19.0.1:54578"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:08:18.408602694Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8476053722357188,
+				"StableID":   "nVfcZPZpB921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e2917926668b1690ac947978636bbeaaa11e5fca3cc8bcd2dd029c4f4d88a4e",
+				"DiscoKey":   "discokey:24561b23e1580a6fa8650de849ed9371faa791df4274e22ade0eead8c5285621",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56286",
+					"10.65.0.27:56286",
+					"172.17.0.1:56286",
+					"172.18.0.1:56286",
+					"172.19.0.1:56286"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:08:18.958122059Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8051724509496322,
+				"StableID":   "nFuz4g9es521CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dce1adc30d580db78debc3fbe29cecc5c6a97a5af5f68c3afc008008b4d7755a",
+				"DiscoKey":   "discokey:62eed2a0ddf493bc0ef37410fd9e2e64de4fb9dfc9cacc24e194d222918f9759",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37326",
+					"10.65.0.27:37326",
+					"172.17.0.1:37326",
+					"172.18.0.1:37326",
+					"172.19.0.1:37326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:08:19.49889894Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8201117514559389,
+				"StableID":   "nr1YM8TJ3721CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97794c1b6916a4000be51091f3c8bb50a72dcbbc1861c6dd42f4f3ddee118a28",
+				"DiscoKey":   "discokey:11b930a1d778e75487995b193c857b1b8ca9a3b75d0e19ea259c05eafd3d5063",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46503",
+					"10.65.0.27:46503",
+					"172.17.0.1:46503",
+					"172.18.0.1:46503",
+					"172.19.0.1:46503"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:08:20.571756539Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8296056659322812,
+				"StableID":   "nm3SUmLJn721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2e4d43d42fd01ad9ea34dfae2ab0ef0f5115a3aa40786b8fce9fa5f9c690cc7e",
+				"DiscoKey":   "discokey:aeb2ef0bbab520ec919509c5aa8d01708d42696a89b5360b71bce9c529025613",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36424",
+					"10.65.0.27:36424",
+					"172.17.0.1:36424",
+					"172.18.0.1:36424",
+					"172.19.0.1:36424"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:08:21.117315392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8374548226897233,
+				"StableID":   "nvm2XWBrP821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80035bd6b8c38d494ad21973b4fbfc85573c5e190728057f8ec64c7c7b48e317",
+				"DiscoKey":   "discokey:becf2c4e1e55e57aedf4d537da7034abba0318525c446677286219053c428b0f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35400",
+					"10.65.0.27:35400",
+					"172.17.0.1:35400",
+					"172.18.0.1:35400",
+					"172.19.0.1:35400"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:08:21.655866087Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1795137637676623,
+				"StableID":   "n2A8trD22F11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b5f6efd1cf8af210d8e258ff49d059acd09b02964a33d30957ba6c55727ece67",
+				"DiscoKey":   "discokey:b77e628f6dd6cf4c37e23f45745983de49b94897ea1ca79d57d765afc718b622",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40204",
+					"10.65.0.27:40204",
+					"172.17.0.1:40204",
+					"172.18.0.1:40204",
+					"172.19.0.1:40204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:08:22.200198897Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         931014678892991,
+				"StableID":   "nxZh4GBfG811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:149ecbad549da2f6d0c078eb879391e837fc753dace39aa925f8d152b1fdd216",
+				"DiscoKey":   "discokey:aa05f156203d8d0970c224d052bd1025cf26d0dab8fe4f00df5f6b94773bd86d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:43843",
+					"10.65.0.27:43843",
+					"172.17.0.1:43843",
+					"172.18.0.1:43843",
+					"172.19.0.1:43843"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:08:22.742228676Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3144493133447296,
+				"StableID":   "nbGjP9W9ZR11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bf7b6bc99e8eb621a8725144d0796f70b5ed6e1c8e24065fa9184a0762ab6b02",
+				"KeyExpiry":  "2026-11-08T22:08:23Z",
+				"DiscoKey":   "discokey:e398cc9bf9587a14b1d465bef847acfd2556cea069273d4da7da64433e21c332",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53148",
+					"10.65.0.27:53148",
+					"172.17.0.1:53148",
+					"172.18.0.1:53148",
+					"172.19.0.1:53148"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:08:23.282009617Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8846900123352821,
+				"StableID":   "nS5e7k4n5C21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2f0da4cd4d52196fc226ebdc5322de05bf31762c154b85bc8a5fec791211767f",
+				"KeyExpiry":  "2026-11-08T22:08:23Z",
+				"DiscoKey":   "discokey:98db68f5c7afa3368f883388ae112062c1f052f01cfc4c64bf7de5835a276066",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46158",
+					"10.65.0.27:46158",
+					"172.17.0.1:46158",
+					"172.18.0.1:46158",
+					"172.19.0.1:46158"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:08:23.930327368Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6221836278277223,
+				"StableID":   "nn4aE96taq11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9b52000e7647025dec03beeb14538cdfce92c687507835561301eb081b40a368",
+				"KeyExpiry":  "2026-11-08T22:08:24Z",
+				"DiscoKey":   "discokey:eb6226aacabf287447001bdbc5a2764a4164b71474e8f8e4e7a8222470f66a5f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55407",
+					"10.65.0.27:55407",
+					"172.17.0.1:55407",
+					"172.18.0.1:55407",
+					"172.19.0.1:55407"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:08:24.629047889Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8879873325482014": {
+				"ID":          8879873325482014,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8296056659322812,
+				"StableID":   "nm3SUmLJn721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       8296056659322812,
+				"Key":        "nodekey:2e4d43d42fd01ad9ea34dfae2ab0ef0f5115a3aa40786b8fce9fa5f9c690cc7e",
+				"DiscoKey":   "discokey:aeb2ef0bbab520ec919509c5aa8d01708d42696a89b5360b71bce9c529025613",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36424",
+					"10.65.0.27:36424",
+					"172.17.0.1:36424",
+					"172.18.0.1:36424",
+					"172.19.0.1:36424"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:08:21.117315392Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2e4d43d42fd01ad9ea34dfae2ab0ef0f5115a3aa40786b8fce9fa5f9c690cc7e",
+			"MachineKey": "mkey:4a8b9a62c1d7140a4f28df44b55b9341cef2fad57c821015bce7b9018e8d071e",
+			"Peers": [{
+				"ID":         148957841278087,
+				"StableID":   "neiPMTsTA211CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:02af530c97681235d93c0bbd5a7a4c87fe027445d85aec3b29b0be8d31f1c464",
+				"DiscoKey":   "discokey:fd7892baa918d2cda0f4647b72b12057c88d719e6ddffe442b318098f9bcae4e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40245",
+					"10.65.0.27:40245",
+					"172.17.0.1:40245",
+					"172.18.0.1:40245",
+					"172.19.0.1:40245"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:08:16.786699384Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5533285458892829,
+				"StableID":   "niP5AX23Dk11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8bea09cb94393da412ecfc150c714953c67e8c30f350ebc86dc33ceaf40a5d07",
+				"DiscoKey":   "discokey:789be08c0ee59d64b61fd300aa4137b625f08339fe4c63b8d97071052c34ba16",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54812",
+					"10.65.0.27:54812",
+					"172.17.0.1:54812",
+					"172.18.0.1:54812",
+					"172.19.0.1:54812"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:08:17.326251824Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8541400743771754,
+				"StableID":   "nFBK5c7Rh921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a3df18b5fc083c2b4094050e064f82f0bd44fb02dbefab798db43c69b389ab5b",
+				"DiscoKey":   "discokey:4a198e0a62ad9e09d6d8ba908ddbff95d174d970e1b131606d083eb5a0d0e419",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:49249",
+					"10.65.0.27:49249",
+					"172.17.0.1:49249",
+					"172.18.0.1:49249",
+					"172.19.0.1:49249"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:08:17.889420597Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5584721634865832,
+				"StableID":   "nuhkthALck11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3701cc87d5f6ba2958dc586fc06e08bf746d7f1c11504527545e877e819c234c",
+				"DiscoKey":   "discokey:70920f9c828f9e69f7bf72c695671531fb9192d7ae3153b3fe4383ed557ddc4d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:54578",
+					"10.65.0.27:54578",
+					"172.17.0.1:54578",
+					"172.18.0.1:54578",
+					"172.19.0.1:54578"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:08:18.408602694Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8476053722357188,
+				"StableID":   "nVfcZPZpB921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e2917926668b1690ac947978636bbeaaa11e5fca3cc8bcd2dd029c4f4d88a4e",
+				"DiscoKey":   "discokey:24561b23e1580a6fa8650de849ed9371faa791df4274e22ade0eead8c5285621",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56286",
+					"10.65.0.27:56286",
+					"172.17.0.1:56286",
+					"172.18.0.1:56286",
+					"172.19.0.1:56286"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:08:18.958122059Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8051724509496322,
+				"StableID":   "nFuz4g9es521CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dce1adc30d580db78debc3fbe29cecc5c6a97a5af5f68c3afc008008b4d7755a",
+				"DiscoKey":   "discokey:62eed2a0ddf493bc0ef37410fd9e2e64de4fb9dfc9cacc24e194d222918f9759",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37326",
+					"10.65.0.27:37326",
+					"172.17.0.1:37326",
+					"172.18.0.1:37326",
+					"172.19.0.1:37326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:08:19.49889894Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8879873325482014,
+				"StableID":   "nXyM5TDiLC21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e45d70a47100bf9af4394257cf1e2e7c6b4c42b033f053d848d940b7e7dc8b10",
+				"DiscoKey":   "discokey:4c37d5a03468f32a033137358e470ae191932d00f9b2eb40b6304dd64c89d14e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51240",
+					"10.65.0.27:51240",
+					"172.17.0.1:51240",
+					"172.18.0.1:51240",
+					"172.19.0.1:51240"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:08:20.031865887Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8201117514559389,
+				"StableID":   "nr1YM8TJ3721CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97794c1b6916a4000be51091f3c8bb50a72dcbbc1861c6dd42f4f3ddee118a28",
+				"DiscoKey":   "discokey:11b930a1d778e75487995b193c857b1b8ca9a3b75d0e19ea259c05eafd3d5063",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46503",
+					"10.65.0.27:46503",
+					"172.17.0.1:46503",
+					"172.18.0.1:46503",
+					"172.19.0.1:46503"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:08:20.571756539Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8374548226897233,
+				"StableID":   "nvm2XWBrP821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80035bd6b8c38d494ad21973b4fbfc85573c5e190728057f8ec64c7c7b48e317",
+				"DiscoKey":   "discokey:becf2c4e1e55e57aedf4d537da7034abba0318525c446677286219053c428b0f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35400",
+					"10.65.0.27:35400",
+					"172.17.0.1:35400",
+					"172.18.0.1:35400",
+					"172.19.0.1:35400"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:08:21.655866087Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1795137637676623,
+				"StableID":   "n2A8trD22F11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b5f6efd1cf8af210d8e258ff49d059acd09b02964a33d30957ba6c55727ece67",
+				"DiscoKey":   "discokey:b77e628f6dd6cf4c37e23f45745983de49b94897ea1ca79d57d765afc718b622",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40204",
+					"10.65.0.27:40204",
+					"172.17.0.1:40204",
+					"172.18.0.1:40204",
+					"172.19.0.1:40204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:08:22.200198897Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         931014678892991,
+				"StableID":   "nxZh4GBfG811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:149ecbad549da2f6d0c078eb879391e837fc753dace39aa925f8d152b1fdd216",
+				"DiscoKey":   "discokey:aa05f156203d8d0970c224d052bd1025cf26d0dab8fe4f00df5f6b94773bd86d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:43843",
+					"10.65.0.27:43843",
+					"172.17.0.1:43843",
+					"172.18.0.1:43843",
+					"172.19.0.1:43843"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:08:22.742228676Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3144493133447296,
+				"StableID":   "nbGjP9W9ZR11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bf7b6bc99e8eb621a8725144d0796f70b5ed6e1c8e24065fa9184a0762ab6b02",
+				"KeyExpiry":  "2026-11-08T22:08:23Z",
+				"DiscoKey":   "discokey:e398cc9bf9587a14b1d465bef847acfd2556cea069273d4da7da64433e21c332",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53148",
+					"10.65.0.27:53148",
+					"172.17.0.1:53148",
+					"172.18.0.1:53148",
+					"172.19.0.1:53148"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:08:23.282009617Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8846900123352821,
+				"StableID":   "nS5e7k4n5C21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2f0da4cd4d52196fc226ebdc5322de05bf31762c154b85bc8a5fec791211767f",
+				"KeyExpiry":  "2026-11-08T22:08:23Z",
+				"DiscoKey":   "discokey:98db68f5c7afa3368f883388ae112062c1f052f01cfc4c64bf7de5835a276066",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46158",
+					"10.65.0.27:46158",
+					"172.17.0.1:46158",
+					"172.18.0.1:46158",
+					"172.19.0.1:46158"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:08:23.930327368Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6221836278277223,
+				"StableID":   "nn4aE96taq11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9b52000e7647025dec03beeb14538cdfce92c687507835561301eb081b40a368",
+				"KeyExpiry":  "2026-11-08T22:08:24Z",
+				"DiscoKey":   "discokey:eb6226aacabf287447001bdbc5a2764a4164b71474e8f8e4e7a8222470f66a5f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55407",
+					"10.65.0.27:55407",
+					"172.17.0.1:55407",
+					"172.18.0.1:55407",
+					"172.19.0.1:55407"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:08:24.629047889Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8296056659322812": {
+				"ID":          8296056659322812,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8846900123352821,
+				"StableID":   "nS5e7k4n5C21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2f0da4cd4d52196fc226ebdc5322de05bf31762c154b85bc8a5fec791211767f",
+				"KeyExpiry":  "2026-11-08T22:08:23Z",
+				"DiscoKey":   "discokey:98db68f5c7afa3368f883388ae112062c1f052f01cfc4c64bf7de5835a276066",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46158",
+					"10.65.0.27:46158",
+					"172.17.0.1:46158",
+					"172.18.0.1:46158",
+					"172.19.0.1:46158"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:08:23.930327368Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2f0da4cd4d52196fc226ebdc5322de05bf31762c154b85bc8a5fec791211767f",
+			"MachineKey": "mkey:e69a1973da7840173ff65a36af9ded6d9771f0dc437dad61185f1ace17931023",
+			"Peers": [{
+				"ID":         148957841278087,
+				"StableID":   "neiPMTsTA211CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:02af530c97681235d93c0bbd5a7a4c87fe027445d85aec3b29b0be8d31f1c464",
+				"DiscoKey":   "discokey:fd7892baa918d2cda0f4647b72b12057c88d719e6ddffe442b318098f9bcae4e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40245",
+					"10.65.0.27:40245",
+					"172.17.0.1:40245",
+					"172.18.0.1:40245",
+					"172.19.0.1:40245"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:08:16.786699384Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5533285458892829,
+				"StableID":   "niP5AX23Dk11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8bea09cb94393da412ecfc150c714953c67e8c30f350ebc86dc33ceaf40a5d07",
+				"DiscoKey":   "discokey:789be08c0ee59d64b61fd300aa4137b625f08339fe4c63b8d97071052c34ba16",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54812",
+					"10.65.0.27:54812",
+					"172.17.0.1:54812",
+					"172.18.0.1:54812",
+					"172.19.0.1:54812"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:08:17.326251824Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8541400743771754,
+				"StableID":   "nFBK5c7Rh921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a3df18b5fc083c2b4094050e064f82f0bd44fb02dbefab798db43c69b389ab5b",
+				"DiscoKey":   "discokey:4a198e0a62ad9e09d6d8ba908ddbff95d174d970e1b131606d083eb5a0d0e419",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:49249",
+					"10.65.0.27:49249",
+					"172.17.0.1:49249",
+					"172.18.0.1:49249",
+					"172.19.0.1:49249"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:08:17.889420597Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5584721634865832,
+				"StableID":   "nuhkthALck11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3701cc87d5f6ba2958dc586fc06e08bf746d7f1c11504527545e877e819c234c",
+				"DiscoKey":   "discokey:70920f9c828f9e69f7bf72c695671531fb9192d7ae3153b3fe4383ed557ddc4d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:54578",
+					"10.65.0.27:54578",
+					"172.17.0.1:54578",
+					"172.18.0.1:54578",
+					"172.19.0.1:54578"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:08:18.408602694Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8476053722357188,
+				"StableID":   "nVfcZPZpB921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e2917926668b1690ac947978636bbeaaa11e5fca3cc8bcd2dd029c4f4d88a4e",
+				"DiscoKey":   "discokey:24561b23e1580a6fa8650de849ed9371faa791df4274e22ade0eead8c5285621",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56286",
+					"10.65.0.27:56286",
+					"172.17.0.1:56286",
+					"172.18.0.1:56286",
+					"172.19.0.1:56286"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:08:18.958122059Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8051724509496322,
+				"StableID":   "nFuz4g9es521CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dce1adc30d580db78debc3fbe29cecc5c6a97a5af5f68c3afc008008b4d7755a",
+				"DiscoKey":   "discokey:62eed2a0ddf493bc0ef37410fd9e2e64de4fb9dfc9cacc24e194d222918f9759",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37326",
+					"10.65.0.27:37326",
+					"172.17.0.1:37326",
+					"172.18.0.1:37326",
+					"172.19.0.1:37326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:08:19.49889894Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8879873325482014,
+				"StableID":   "nXyM5TDiLC21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e45d70a47100bf9af4394257cf1e2e7c6b4c42b033f053d848d940b7e7dc8b10",
+				"DiscoKey":   "discokey:4c37d5a03468f32a033137358e470ae191932d00f9b2eb40b6304dd64c89d14e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51240",
+					"10.65.0.27:51240",
+					"172.17.0.1:51240",
+					"172.18.0.1:51240",
+					"172.19.0.1:51240"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:08:20.031865887Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8201117514559389,
+				"StableID":   "nr1YM8TJ3721CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97794c1b6916a4000be51091f3c8bb50a72dcbbc1861c6dd42f4f3ddee118a28",
+				"DiscoKey":   "discokey:11b930a1d778e75487995b193c857b1b8ca9a3b75d0e19ea259c05eafd3d5063",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46503",
+					"10.65.0.27:46503",
+					"172.17.0.1:46503",
+					"172.18.0.1:46503",
+					"172.19.0.1:46503"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:08:20.571756539Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8296056659322812,
+				"StableID":   "nm3SUmLJn721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2e4d43d42fd01ad9ea34dfae2ab0ef0f5115a3aa40786b8fce9fa5f9c690cc7e",
+				"DiscoKey":   "discokey:aeb2ef0bbab520ec919509c5aa8d01708d42696a89b5360b71bce9c529025613",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36424",
+					"10.65.0.27:36424",
+					"172.17.0.1:36424",
+					"172.18.0.1:36424",
+					"172.19.0.1:36424"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:08:21.117315392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8374548226897233,
+				"StableID":   "nvm2XWBrP821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:80035bd6b8c38d494ad21973b4fbfc85573c5e190728057f8ec64c7c7b48e317",
+				"DiscoKey":   "discokey:becf2c4e1e55e57aedf4d537da7034abba0318525c446677286219053c428b0f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35400",
+					"10.65.0.27:35400",
+					"172.17.0.1:35400",
+					"172.18.0.1:35400",
+					"172.19.0.1:35400"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:08:21.655866087Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1795137637676623,
+				"StableID":   "n2A8trD22F11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b5f6efd1cf8af210d8e258ff49d059acd09b02964a33d30957ba6c55727ece67",
+				"DiscoKey":   "discokey:b77e628f6dd6cf4c37e23f45745983de49b94897ea1ca79d57d765afc718b622",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40204",
+					"10.65.0.27:40204",
+					"172.17.0.1:40204",
+					"172.18.0.1:40204",
+					"172.19.0.1:40204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:08:22.200198897Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         931014678892991,
+				"StableID":   "nxZh4GBfG811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:149ecbad549da2f6d0c078eb879391e837fc753dace39aa925f8d152b1fdd216",
+				"DiscoKey":   "discokey:aa05f156203d8d0970c224d052bd1025cf26d0dab8fe4f00df5f6b94773bd86d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:43843",
+					"10.65.0.27:43843",
+					"172.17.0.1:43843",
+					"172.18.0.1:43843",
+					"172.19.0.1:43843"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:08:22.742228676Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3144493133447296,
+				"StableID":   "nbGjP9W9ZR11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bf7b6bc99e8eb621a8725144d0796f70b5ed6e1c8e24065fa9184a0762ab6b02",
+				"KeyExpiry":  "2026-11-08T22:08:23Z",
+				"DiscoKey":   "discokey:e398cc9bf9587a14b1d465bef847acfd2556cea069273d4da7da64433e21c332",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53148",
+					"10.65.0.27:53148",
+					"172.17.0.1:53148",
+					"172.18.0.1:53148",
+					"172.19.0.1:53148"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:08:23.282009617Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6221836278277223,
+				"StableID":   "nn4aE96taq11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9b52000e7647025dec03beeb14538cdfce92c687507835561301eb081b40a368",
+				"KeyExpiry":  "2026-11-08T22:08:24Z",
+				"DiscoKey":   "discokey:eb6226aacabf287447001bdbc5a2764a4164b71474e8f8e4e7a8222470f66a5f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55407",
+					"10.65.0.27:55407",
+					"172.17.0.1:55407",
+					"172.18.0.1:55407",
+					"172.19.0.1:55407"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:08:24.629047889Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8374548226897233,
+				"StableID":   "nvm2XWBrP821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       8374548226897233,
+				"Key":        "nodekey:80035bd6b8c38d494ad21973b4fbfc85573c5e190728057f8ec64c7c7b48e317",
+				"DiscoKey":   "discokey:becf2c4e1e55e57aedf4d537da7034abba0318525c446677286219053c428b0f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35400",
+					"10.65.0.27:35400",
+					"172.17.0.1:35400",
+					"172.18.0.1:35400",
+					"172.19.0.1:35400"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:08:21.655866087Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:80035bd6b8c38d494ad21973b4fbfc85573c5e190728057f8ec64c7c7b48e317",
+			"MachineKey": "mkey:17017418c130de97d5d8313598342f1cddb9e37dfde090b38db5bc6ab9e9233f",
+			"Peers": [{
+				"ID":         148957841278087,
+				"StableID":   "neiPMTsTA211CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:02af530c97681235d93c0bbd5a7a4c87fe027445d85aec3b29b0be8d31f1c464",
+				"DiscoKey":   "discokey:fd7892baa918d2cda0f4647b72b12057c88d719e6ddffe442b318098f9bcae4e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:40245",
+					"10.65.0.27:40245",
+					"172.17.0.1:40245",
+					"172.18.0.1:40245",
+					"172.19.0.1:40245"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:08:16.786699384Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5533285458892829,
+				"StableID":   "niP5AX23Dk11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8bea09cb94393da412ecfc150c714953c67e8c30f350ebc86dc33ceaf40a5d07",
+				"DiscoKey":   "discokey:789be08c0ee59d64b61fd300aa4137b625f08339fe4c63b8d97071052c34ba16",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54812",
+					"10.65.0.27:54812",
+					"172.17.0.1:54812",
+					"172.18.0.1:54812",
+					"172.19.0.1:54812"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:08:17.326251824Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8541400743771754,
+				"StableID":   "nFBK5c7Rh921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a3df18b5fc083c2b4094050e064f82f0bd44fb02dbefab798db43c69b389ab5b",
+				"DiscoKey":   "discokey:4a198e0a62ad9e09d6d8ba908ddbff95d174d970e1b131606d083eb5a0d0e419",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:49249",
+					"10.65.0.27:49249",
+					"172.17.0.1:49249",
+					"172.18.0.1:49249",
+					"172.19.0.1:49249"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:08:17.889420597Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5584721634865832,
+				"StableID":   "nuhkthALck11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3701cc87d5f6ba2958dc586fc06e08bf746d7f1c11504527545e877e819c234c",
+				"DiscoKey":   "discokey:70920f9c828f9e69f7bf72c695671531fb9192d7ae3153b3fe4383ed557ddc4d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:54578",
+					"10.65.0.27:54578",
+					"172.17.0.1:54578",
+					"172.18.0.1:54578",
+					"172.19.0.1:54578"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:08:18.408602694Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8476053722357188,
+				"StableID":   "nVfcZPZpB921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e2917926668b1690ac947978636bbeaaa11e5fca3cc8bcd2dd029c4f4d88a4e",
+				"DiscoKey":   "discokey:24561b23e1580a6fa8650de849ed9371faa791df4274e22ade0eead8c5285621",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56286",
+					"10.65.0.27:56286",
+					"172.17.0.1:56286",
+					"172.18.0.1:56286",
+					"172.19.0.1:56286"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:08:18.958122059Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8051724509496322,
+				"StableID":   "nFuz4g9es521CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dce1adc30d580db78debc3fbe29cecc5c6a97a5af5f68c3afc008008b4d7755a",
+				"DiscoKey":   "discokey:62eed2a0ddf493bc0ef37410fd9e2e64de4fb9dfc9cacc24e194d222918f9759",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37326",
+					"10.65.0.27:37326",
+					"172.17.0.1:37326",
+					"172.18.0.1:37326",
+					"172.19.0.1:37326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:08:19.49889894Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8879873325482014,
+				"StableID":   "nXyM5TDiLC21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e45d70a47100bf9af4394257cf1e2e7c6b4c42b033f053d848d940b7e7dc8b10",
+				"DiscoKey":   "discokey:4c37d5a03468f32a033137358e470ae191932d00f9b2eb40b6304dd64c89d14e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51240",
+					"10.65.0.27:51240",
+					"172.17.0.1:51240",
+					"172.18.0.1:51240",
+					"172.19.0.1:51240"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:08:20.031865887Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8201117514559389,
+				"StableID":   "nr1YM8TJ3721CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97794c1b6916a4000be51091f3c8bb50a72dcbbc1861c6dd42f4f3ddee118a28",
+				"DiscoKey":   "discokey:11b930a1d778e75487995b193c857b1b8ca9a3b75d0e19ea259c05eafd3d5063",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46503",
+					"10.65.0.27:46503",
+					"172.17.0.1:46503",
+					"172.18.0.1:46503",
+					"172.19.0.1:46503"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:08:20.571756539Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8296056659322812,
+				"StableID":   "nm3SUmLJn721CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2e4d43d42fd01ad9ea34dfae2ab0ef0f5115a3aa40786b8fce9fa5f9c690cc7e",
+				"DiscoKey":   "discokey:aeb2ef0bbab520ec919509c5aa8d01708d42696a89b5360b71bce9c529025613",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36424",
+					"10.65.0.27:36424",
+					"172.17.0.1:36424",
+					"172.18.0.1:36424",
+					"172.19.0.1:36424"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:08:21.117315392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1795137637676623,
+				"StableID":   "n2A8trD22F11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b5f6efd1cf8af210d8e258ff49d059acd09b02964a33d30957ba6c55727ece67",
+				"DiscoKey":   "discokey:b77e628f6dd6cf4c37e23f45745983de49b94897ea1ca79d57d765afc718b622",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40204",
+					"10.65.0.27:40204",
+					"172.17.0.1:40204",
+					"172.18.0.1:40204",
+					"172.19.0.1:40204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:08:22.200198897Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         931014678892991,
+				"StableID":   "nxZh4GBfG811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:149ecbad549da2f6d0c078eb879391e837fc753dace39aa925f8d152b1fdd216",
+				"DiscoKey":   "discokey:aa05f156203d8d0970c224d052bd1025cf26d0dab8fe4f00df5f6b94773bd86d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:43843",
+					"10.65.0.27:43843",
+					"172.17.0.1:43843",
+					"172.18.0.1:43843",
+					"172.19.0.1:43843"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:08:22.742228676Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3144493133447296,
+				"StableID":   "nbGjP9W9ZR11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bf7b6bc99e8eb621a8725144d0796f70b5ed6e1c8e24065fa9184a0762ab6b02",
+				"KeyExpiry":  "2026-11-08T22:08:23Z",
+				"DiscoKey":   "discokey:e398cc9bf9587a14b1d465bef847acfd2556cea069273d4da7da64433e21c332",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53148",
+					"10.65.0.27:53148",
+					"172.17.0.1:53148",
+					"172.18.0.1:53148",
+					"172.19.0.1:53148"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:08:23.282009617Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8846900123352821,
+				"StableID":   "nS5e7k4n5C21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2f0da4cd4d52196fc226ebdc5322de05bf31762c154b85bc8a5fec791211767f",
+				"KeyExpiry":  "2026-11-08T22:08:23Z",
+				"DiscoKey":   "discokey:98db68f5c7afa3368f883388ae112062c1f052f01cfc4c64bf7de5835a276066",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46158",
+					"10.65.0.27:46158",
+					"172.17.0.1:46158",
+					"172.18.0.1:46158",
+					"172.19.0.1:46158"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:08:23.930327368Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6221836278277223,
+				"StableID":   "nn4aE96taq11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:9b52000e7647025dec03beeb14538cdfce92c687507835561301eb081b40a368",
+				"KeyExpiry":  "2026-11-08T22:08:24Z",
+				"DiscoKey":   "discokey:eb6226aacabf287447001bdbc5a2764a4164b71474e8f8e4e7a8222470f66a5f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55407",
+					"10.65.0.27:55407",
+					"172.17.0.1:55407",
+					"172.18.0.1:55407",
+					"172.19.0.1:55407"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:08:24.629047889Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8374548226897233": {
+				"ID":          8374548226897233,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-user-localpart-no-domain.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-user-localpart-no-domain.hujson
@@ -1,0 +1,20104 @@
+// ssh-malformed-user-localpart-no-domain
+//
+// ssh users localpart with empty domain is rejected
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T22:09:09Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-malformed-user-localpart-no-domain",
+	"description":    "ssh users localpart with empty domain is rejected",
+	"category":       "ssh",
+	"captured_at":    "2026-05-12T22:09:09.892779612Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                         \n  \n                                                            \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh users localpart with empty domain is rejected\",\n\t\"id\":          \"ssh-malformed-user-localpart-no-domain\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"autogroup:member\"],\n\t\t\"users\":  [\"localpart:*@\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-malformed/ssh-malformed-user-localpart-no-domain.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["autogroup:member"],
+				"users":  ["localpart:*@"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1014096996010250,
+				"StableID":   "ny4gvHcHv811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1014096996010250,
+				"Key":        "nodekey:71e2d791870f7e9467d5e8f500ce49cb9182d618bb436e27043e69590b09721c",
+				"DiscoKey":   "discokey:06bdef47dea8c16d845fc563964895e5386827e98d10a4a1501276e3b65abb65",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:60739",
+					"10.65.0.27:60739",
+					"172.17.0.1:60739",
+					"172.18.0.1:60739",
+					"172.19.0.1:60739"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:09:18.39882372Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:71e2d791870f7e9467d5e8f500ce49cb9182d618bb436e27043e69590b09721c",
+			"MachineKey": "mkey:7aa7bc0e9ce20a87780c2eaa5673d983c065e67bdaef42db7aeea5adff06b617",
+			"Peers": [{
+				"ID":         8114526209130773,
+				"StableID":   "nAsFDwq5N621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36c3161fd2ed824e8d0fba111f0ccfe357821557414c144cf73993df56fcd04d",
+				"DiscoKey":   "discokey:226f22cb8a293d147dc2821044fad2cc35baa790dbc8d3e3a8f2bc535c640711",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53020",
+					"10.65.0.27:53020",
+					"172.17.0.1:53020",
+					"172.18.0.1:53020",
+					"172.19.0.1:53020"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:09:12.44836122Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3765173621324555,
+				"StableID":   "nJijg8jFQW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2fec3721b390e2a459cce4a956afa20311a8bd0e5a6f94d59437d8a7c13f7376",
+				"DiscoKey":   "discokey:e29a161a723179bca1c0237c4ad1a0107a89878288514e8a8925619aaacdc810",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37966",
+					"10.65.0.27:37966",
+					"172.17.0.1:37966",
+					"172.18.0.1:37966",
+					"172.19.0.1:37966"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:09:12.993659272Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5317069389681284,
+				"StableID":   "nhX1X1Q7Xi11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cfa615f6dda9cfba1cb32447207a5efdaa2735c11047274c871e968052f3bf4d",
+				"DiscoKey":   "discokey:815d00bb9dab4c4ca634b79b07258af096882f3b264b8759ce8d42eb462cf151",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46235",
+					"10.65.0.27:46235",
+					"172.17.0.1:46235",
+					"172.18.0.1:46235",
+					"172.19.0.1:46235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:09:13.536999204Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8744378582905837,
+				"StableID":   "n82verzLHB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6a6fc786c392186639010c788ffc4677601c790a7c4915ac22d03907d842c52b",
+				"DiscoKey":   "discokey:746fea6809b5055ea2e1644ef583b7a55c80da88e81c406aa40cea6af9281264",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43171",
+					"10.65.0.27:43171",
+					"172.17.0.1:43171",
+					"172.18.0.1:43171",
+					"172.19.0.1:43171"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:09:14.06939005Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         82504563779278,
+				"StableID":   "n5k6nnFNe111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4832fc8bdc2538f606b1b4575062f8f26c9ee1f4b310bdfd484fa2f3fc085f1a",
+				"DiscoKey":   "discokey:b1054f8731053d01e169bac1630150abaae24e31363af1dfbd828946e7b6ea0c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40406",
+					"10.65.0.27:40406",
+					"172.17.0.1:40406",
+					"172.18.0.1:40406",
+					"172.19.0.1:40406"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:09:14.616309494Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5036590610458473,
+				"StableID":   "nkWcFJh5Lg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7d1ea7849142081c4c4e5a5dd05f60b054f9b8175de35e4b9329ba20b2a40f0b",
+				"DiscoKey":   "discokey:6083afefe0536f29ba434bcdeb1bb7a0bca8a5099c4fa4a3af4a87136345be70",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44833",
+					"10.65.0.27:44833",
+					"172.17.0.1:44833",
+					"172.18.0.1:44833",
+					"172.19.0.1:44833"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:09:15.156392498Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         815682844870495,
+				"StableID":   "nNSwp6cRN711CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9eecde188381106cc7fd8164e5dedcd3d30fb65b7220cb8bd3328ec34af30d06",
+				"DiscoKey":   "discokey:238e176e67c3dbfbbaac3f772e197565fbda633d9e463bffdefe6909ee418578",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41506",
+					"10.65.0.27:41506",
+					"172.17.0.1:41506",
+					"172.18.0.1:41506",
+					"172.19.0.1:41506"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:09:15.691990771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         958424841452086,
+				"StableID":   "nXfWGLC5V811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d4e9f05e623e1f1bc07f34850443728e8cfe7f1cb9fde67d44afff6d276356f",
+				"DiscoKey":   "discokey:3c86649b4897a19187696e4230a8f7f8616343df3d6eca7ead9e29784f82fb11",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47236",
+					"10.65.0.27:47236",
+					"172.17.0.1:47236",
+					"172.18.0.1:47236",
+					"172.19.0.1:47236"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:09:16.23865548Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6441793196883902,
+				"StableID":   "nBsbv4zVJs11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4fad52354c0a559d66b44be7ffd056d626b8901d0d6d79982a57e318cb544765",
+				"DiscoKey":   "discokey:a5a869b40095fbebe796da064ce9ff984f64ace82ab3f783f5faaf71f128971d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:50338",
+					"10.65.0.27:50338",
+					"172.17.0.1:50338",
+					"172.18.0.1:50338",
+					"172.19.0.1:50338"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:09:16.780573933Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2958693032730856,
+				"StableID":   "nBaajErz6Q11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:014af8a5046c50dfad264fb4062da433b681f443de36da9617d0c86202dd1026",
+				"DiscoKey":   "discokey:b50015ae862bdf971ae0d941a0bd78da86c451a352a08fb4f9ac0e5f30c4ea77",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51718",
+					"10.65.0.27:51718",
+					"172.17.0.1:51718",
+					"172.18.0.1:51718",
+					"172.19.0.1:51718"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:09:17.321173151Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7160680393704177,
+				"StableID":   "n4i2o2w5vx11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab23903e63e2612cb368380db7dbf13d95742e38ada9ef8b848d6ef9aac8730a",
+				"DiscoKey":   "discokey:399ba9cde79b89e5cc69a159f7df17b610f0431f688c0191113f36ed46f3bb1d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41268",
+					"10.65.0.27:41268",
+					"172.17.0.1:41268",
+					"172.18.0.1:41268",
+					"172.19.0.1:41268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:09:17.870267785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3739658176931298,
+				"StableID":   "n9LnEnUhCW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:50785bf6a6e450d14eb4dc29bf2050e9630d655fc1096ef047c9fab484aa9450",
+				"KeyExpiry":  "2026-11-08T22:09:18Z",
+				"DiscoKey":   "discokey:9ff0b1b874bb4c6e0bc48d9064624a224b180ffd210b955b1bd6e9029183fa08",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48911",
+					"10.65.0.27:48911",
+					"172.17.0.1:48911",
+					"172.18.0.1:48911",
+					"172.19.0.1:48911"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:09:18.941939275Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5104558182710938,
+				"StableID":   "nmWLs56srg11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:282367469425c3f1279bad959cf37db7ccdc7ccd99812b519870e2b94a468358",
+				"KeyExpiry":  "2026-11-08T22:09:19Z",
+				"DiscoKey":   "discokey:c2dc81af2357769a8335357bd8510c0cff79f0612e3f719998ee7be0acc4b921",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:37646",
+					"10.65.0.27:37646",
+					"172.17.0.1:37646",
+					"172.18.0.1:37646",
+					"172.19.0.1:37646"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:09:19.47634035Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6334121386671680,
+				"StableID":   "noJ7mRdjTr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d1ed5cb85fd631baed6c7bdd9c1a882407173be46293e77c6826dd55c05b487f",
+				"KeyExpiry":  "2026-11-08T22:09:20Z",
+				"DiscoKey":   "discokey:9566fb01babc305c0756818fe37e2c286336313ba65e95a5ea668a972ef36641",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57469",
+					"10.65.0.27:57469",
+					"172.17.0.1:57469",
+					"172.18.0.1:57469",
+					"172.19.0.1:57469"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:09:20.013704416Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{"principals": [
+				{"nodeIP": "100.64.0.17"},
+				{"nodeIP": "100.64.0.18"},
+				{"nodeIP": "100.64.0.19"},
+				{"nodeIP": "fd7a:115c:a1e0::12"},
+				{"nodeIP": "fd7a:115c:a1e0::11"},
+				{"nodeIP": "fd7a:115c:a1e0::13"}
+			], "sshUsers": {"localpart:*@": "localpart:*@", "root": ""}, "action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1014096996010250": {
+				"ID":          1014096996010250,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		},
+		"ssh_rules": [{"principals": [
+			{"nodeIP": "100.64.0.17"},
+			{"nodeIP": "100.64.0.18"},
+			{"nodeIP": "100.64.0.19"},
+			{"nodeIP": "fd7a:115c:a1e0::12"},
+			{"nodeIP": "fd7a:115c:a1e0::11"},
+			{"nodeIP": "fd7a:115c:a1e0::13"}
+		], "sshUsers": {"localpart:*@": "localpart:*@", "root": ""}, "action": {
+			"accept":                    true,
+			"allowAgentForwarding":      true,
+			"allowLocalPortForwarding":  true,
+			"allowRemotePortForwarding": true
+		}}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5036590610458473,
+				"StableID":   "nkWcFJh5Lg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       5036590610458473,
+				"Key":        "nodekey:7d1ea7849142081c4c4e5a5dd05f60b054f9b8175de35e4b9329ba20b2a40f0b",
+				"DiscoKey":   "discokey:6083afefe0536f29ba434bcdeb1bb7a0bca8a5099c4fa4a3af4a87136345be70",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44833",
+					"10.65.0.27:44833",
+					"172.17.0.1:44833",
+					"172.18.0.1:44833",
+					"172.19.0.1:44833"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:09:15.156392498Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7d1ea7849142081c4c4e5a5dd05f60b054f9b8175de35e4b9329ba20b2a40f0b",
+			"MachineKey": "mkey:8b7c36e856c4430743c27d86cef698c38e2a786a33a2f230c4c5be085b760d47",
+			"Peers": [{
+				"ID":         8114526209130773,
+				"StableID":   "nAsFDwq5N621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36c3161fd2ed824e8d0fba111f0ccfe357821557414c144cf73993df56fcd04d",
+				"DiscoKey":   "discokey:226f22cb8a293d147dc2821044fad2cc35baa790dbc8d3e3a8f2bc535c640711",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53020",
+					"10.65.0.27:53020",
+					"172.17.0.1:53020",
+					"172.18.0.1:53020",
+					"172.19.0.1:53020"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:09:12.44836122Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3765173621324555,
+				"StableID":   "nJijg8jFQW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2fec3721b390e2a459cce4a956afa20311a8bd0e5a6f94d59437d8a7c13f7376",
+				"DiscoKey":   "discokey:e29a161a723179bca1c0237c4ad1a0107a89878288514e8a8925619aaacdc810",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37966",
+					"10.65.0.27:37966",
+					"172.17.0.1:37966",
+					"172.18.0.1:37966",
+					"172.19.0.1:37966"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:09:12.993659272Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5317069389681284,
+				"StableID":   "nhX1X1Q7Xi11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cfa615f6dda9cfba1cb32447207a5efdaa2735c11047274c871e968052f3bf4d",
+				"DiscoKey":   "discokey:815d00bb9dab4c4ca634b79b07258af096882f3b264b8759ce8d42eb462cf151",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46235",
+					"10.65.0.27:46235",
+					"172.17.0.1:46235",
+					"172.18.0.1:46235",
+					"172.19.0.1:46235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:09:13.536999204Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8744378582905837,
+				"StableID":   "n82verzLHB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6a6fc786c392186639010c788ffc4677601c790a7c4915ac22d03907d842c52b",
+				"DiscoKey":   "discokey:746fea6809b5055ea2e1644ef583b7a55c80da88e81c406aa40cea6af9281264",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43171",
+					"10.65.0.27:43171",
+					"172.17.0.1:43171",
+					"172.18.0.1:43171",
+					"172.19.0.1:43171"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:09:14.06939005Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         82504563779278,
+				"StableID":   "n5k6nnFNe111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4832fc8bdc2538f606b1b4575062f8f26c9ee1f4b310bdfd484fa2f3fc085f1a",
+				"DiscoKey":   "discokey:b1054f8731053d01e169bac1630150abaae24e31363af1dfbd828946e7b6ea0c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40406",
+					"10.65.0.27:40406",
+					"172.17.0.1:40406",
+					"172.18.0.1:40406",
+					"172.19.0.1:40406"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:09:14.616309494Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         815682844870495,
+				"StableID":   "nNSwp6cRN711CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9eecde188381106cc7fd8164e5dedcd3d30fb65b7220cb8bd3328ec34af30d06",
+				"DiscoKey":   "discokey:238e176e67c3dbfbbaac3f772e197565fbda633d9e463bffdefe6909ee418578",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41506",
+					"10.65.0.27:41506",
+					"172.17.0.1:41506",
+					"172.18.0.1:41506",
+					"172.19.0.1:41506"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:09:15.691990771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         958424841452086,
+				"StableID":   "nXfWGLC5V811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d4e9f05e623e1f1bc07f34850443728e8cfe7f1cb9fde67d44afff6d276356f",
+				"DiscoKey":   "discokey:3c86649b4897a19187696e4230a8f7f8616343df3d6eca7ead9e29784f82fb11",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47236",
+					"10.65.0.27:47236",
+					"172.17.0.1:47236",
+					"172.18.0.1:47236",
+					"172.19.0.1:47236"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:09:16.23865548Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6441793196883902,
+				"StableID":   "nBsbv4zVJs11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4fad52354c0a559d66b44be7ffd056d626b8901d0d6d79982a57e318cb544765",
+				"DiscoKey":   "discokey:a5a869b40095fbebe796da064ce9ff984f64ace82ab3f783f5faaf71f128971d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:50338",
+					"10.65.0.27:50338",
+					"172.17.0.1:50338",
+					"172.18.0.1:50338",
+					"172.19.0.1:50338"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:09:16.780573933Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2958693032730856,
+				"StableID":   "nBaajErz6Q11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:014af8a5046c50dfad264fb4062da433b681f443de36da9617d0c86202dd1026",
+				"DiscoKey":   "discokey:b50015ae862bdf971ae0d941a0bd78da86c451a352a08fb4f9ac0e5f30c4ea77",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51718",
+					"10.65.0.27:51718",
+					"172.17.0.1:51718",
+					"172.18.0.1:51718",
+					"172.19.0.1:51718"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:09:17.321173151Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7160680393704177,
+				"StableID":   "n4i2o2w5vx11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab23903e63e2612cb368380db7dbf13d95742e38ada9ef8b848d6ef9aac8730a",
+				"DiscoKey":   "discokey:399ba9cde79b89e5cc69a159f7df17b610f0431f688c0191113f36ed46f3bb1d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41268",
+					"10.65.0.27:41268",
+					"172.17.0.1:41268",
+					"172.18.0.1:41268",
+					"172.19.0.1:41268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:09:17.870267785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1014096996010250,
+				"StableID":   "ny4gvHcHv811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:71e2d791870f7e9467d5e8f500ce49cb9182d618bb436e27043e69590b09721c",
+				"DiscoKey":   "discokey:06bdef47dea8c16d845fc563964895e5386827e98d10a4a1501276e3b65abb65",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:60739",
+					"10.65.0.27:60739",
+					"172.17.0.1:60739",
+					"172.18.0.1:60739",
+					"172.19.0.1:60739"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:09:18.39882372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3739658176931298,
+				"StableID":   "n9LnEnUhCW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:50785bf6a6e450d14eb4dc29bf2050e9630d655fc1096ef047c9fab484aa9450",
+				"KeyExpiry":  "2026-11-08T22:09:18Z",
+				"DiscoKey":   "discokey:9ff0b1b874bb4c6e0bc48d9064624a224b180ffd210b955b1bd6e9029183fa08",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48911",
+					"10.65.0.27:48911",
+					"172.17.0.1:48911",
+					"172.18.0.1:48911",
+					"172.19.0.1:48911"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:09:18.941939275Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5104558182710938,
+				"StableID":   "nmWLs56srg11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:282367469425c3f1279bad959cf37db7ccdc7ccd99812b519870e2b94a468358",
+				"KeyExpiry":  "2026-11-08T22:09:19Z",
+				"DiscoKey":   "discokey:c2dc81af2357769a8335357bd8510c0cff79f0612e3f719998ee7be0acc4b921",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:37646",
+					"10.65.0.27:37646",
+					"172.17.0.1:37646",
+					"172.18.0.1:37646",
+					"172.19.0.1:37646"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:09:19.47634035Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6334121386671680,
+				"StableID":   "noJ7mRdjTr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d1ed5cb85fd631baed6c7bdd9c1a882407173be46293e77c6826dd55c05b487f",
+				"KeyExpiry":  "2026-11-08T22:09:20Z",
+				"DiscoKey":   "discokey:9566fb01babc305c0756818fe37e2c286336313ba65e95a5ea668a972ef36641",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57469",
+					"10.65.0.27:57469",
+					"172.17.0.1:57469",
+					"172.18.0.1:57469",
+					"172.19.0.1:57469"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:09:20.013704416Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5036590610458473": {
+				"ID":          5036590610458473,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6334121386671680,
+				"StableID":   "noJ7mRdjTr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d1ed5cb85fd631baed6c7bdd9c1a882407173be46293e77c6826dd55c05b487f",
+				"KeyExpiry":  "2026-11-08T22:09:20Z",
+				"DiscoKey":   "discokey:9566fb01babc305c0756818fe37e2c286336313ba65e95a5ea668a972ef36641",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57469",
+					"10.65.0.27:57469",
+					"172.17.0.1:57469",
+					"172.18.0.1:57469",
+					"172.19.0.1:57469"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:09:20.013704416Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d1ed5cb85fd631baed6c7bdd9c1a882407173be46293e77c6826dd55c05b487f",
+			"MachineKey": "mkey:226ad3cf0c79baea8647930d8efe742f91ddf0b6048347571fab257981f8f566",
+			"Peers": [{
+				"ID":         8114526209130773,
+				"StableID":   "nAsFDwq5N621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36c3161fd2ed824e8d0fba111f0ccfe357821557414c144cf73993df56fcd04d",
+				"DiscoKey":   "discokey:226f22cb8a293d147dc2821044fad2cc35baa790dbc8d3e3a8f2bc535c640711",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53020",
+					"10.65.0.27:53020",
+					"172.17.0.1:53020",
+					"172.18.0.1:53020",
+					"172.19.0.1:53020"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:09:12.44836122Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3765173621324555,
+				"StableID":   "nJijg8jFQW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2fec3721b390e2a459cce4a956afa20311a8bd0e5a6f94d59437d8a7c13f7376",
+				"DiscoKey":   "discokey:e29a161a723179bca1c0237c4ad1a0107a89878288514e8a8925619aaacdc810",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37966",
+					"10.65.0.27:37966",
+					"172.17.0.1:37966",
+					"172.18.0.1:37966",
+					"172.19.0.1:37966"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:09:12.993659272Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5317069389681284,
+				"StableID":   "nhX1X1Q7Xi11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cfa615f6dda9cfba1cb32447207a5efdaa2735c11047274c871e968052f3bf4d",
+				"DiscoKey":   "discokey:815d00bb9dab4c4ca634b79b07258af096882f3b264b8759ce8d42eb462cf151",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46235",
+					"10.65.0.27:46235",
+					"172.17.0.1:46235",
+					"172.18.0.1:46235",
+					"172.19.0.1:46235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:09:13.536999204Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8744378582905837,
+				"StableID":   "n82verzLHB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6a6fc786c392186639010c788ffc4677601c790a7c4915ac22d03907d842c52b",
+				"DiscoKey":   "discokey:746fea6809b5055ea2e1644ef583b7a55c80da88e81c406aa40cea6af9281264",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43171",
+					"10.65.0.27:43171",
+					"172.17.0.1:43171",
+					"172.18.0.1:43171",
+					"172.19.0.1:43171"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:09:14.06939005Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         82504563779278,
+				"StableID":   "n5k6nnFNe111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4832fc8bdc2538f606b1b4575062f8f26c9ee1f4b310bdfd484fa2f3fc085f1a",
+				"DiscoKey":   "discokey:b1054f8731053d01e169bac1630150abaae24e31363af1dfbd828946e7b6ea0c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40406",
+					"10.65.0.27:40406",
+					"172.17.0.1:40406",
+					"172.18.0.1:40406",
+					"172.19.0.1:40406"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:09:14.616309494Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5036590610458473,
+				"StableID":   "nkWcFJh5Lg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7d1ea7849142081c4c4e5a5dd05f60b054f9b8175de35e4b9329ba20b2a40f0b",
+				"DiscoKey":   "discokey:6083afefe0536f29ba434bcdeb1bb7a0bca8a5099c4fa4a3af4a87136345be70",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44833",
+					"10.65.0.27:44833",
+					"172.17.0.1:44833",
+					"172.18.0.1:44833",
+					"172.19.0.1:44833"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:09:15.156392498Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         815682844870495,
+				"StableID":   "nNSwp6cRN711CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9eecde188381106cc7fd8164e5dedcd3d30fb65b7220cb8bd3328ec34af30d06",
+				"DiscoKey":   "discokey:238e176e67c3dbfbbaac3f772e197565fbda633d9e463bffdefe6909ee418578",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41506",
+					"10.65.0.27:41506",
+					"172.17.0.1:41506",
+					"172.18.0.1:41506",
+					"172.19.0.1:41506"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:09:15.691990771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         958424841452086,
+				"StableID":   "nXfWGLC5V811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d4e9f05e623e1f1bc07f34850443728e8cfe7f1cb9fde67d44afff6d276356f",
+				"DiscoKey":   "discokey:3c86649b4897a19187696e4230a8f7f8616343df3d6eca7ead9e29784f82fb11",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47236",
+					"10.65.0.27:47236",
+					"172.17.0.1:47236",
+					"172.18.0.1:47236",
+					"172.19.0.1:47236"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:09:16.23865548Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6441793196883902,
+				"StableID":   "nBsbv4zVJs11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4fad52354c0a559d66b44be7ffd056d626b8901d0d6d79982a57e318cb544765",
+				"DiscoKey":   "discokey:a5a869b40095fbebe796da064ce9ff984f64ace82ab3f783f5faaf71f128971d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:50338",
+					"10.65.0.27:50338",
+					"172.17.0.1:50338",
+					"172.18.0.1:50338",
+					"172.19.0.1:50338"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:09:16.780573933Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2958693032730856,
+				"StableID":   "nBaajErz6Q11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:014af8a5046c50dfad264fb4062da433b681f443de36da9617d0c86202dd1026",
+				"DiscoKey":   "discokey:b50015ae862bdf971ae0d941a0bd78da86c451a352a08fb4f9ac0e5f30c4ea77",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51718",
+					"10.65.0.27:51718",
+					"172.17.0.1:51718",
+					"172.18.0.1:51718",
+					"172.19.0.1:51718"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:09:17.321173151Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7160680393704177,
+				"StableID":   "n4i2o2w5vx11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab23903e63e2612cb368380db7dbf13d95742e38ada9ef8b848d6ef9aac8730a",
+				"DiscoKey":   "discokey:399ba9cde79b89e5cc69a159f7df17b610f0431f688c0191113f36ed46f3bb1d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41268",
+					"10.65.0.27:41268",
+					"172.17.0.1:41268",
+					"172.18.0.1:41268",
+					"172.19.0.1:41268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:09:17.870267785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1014096996010250,
+				"StableID":   "ny4gvHcHv811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:71e2d791870f7e9467d5e8f500ce49cb9182d618bb436e27043e69590b09721c",
+				"DiscoKey":   "discokey:06bdef47dea8c16d845fc563964895e5386827e98d10a4a1501276e3b65abb65",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:60739",
+					"10.65.0.27:60739",
+					"172.17.0.1:60739",
+					"172.18.0.1:60739",
+					"172.19.0.1:60739"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:09:18.39882372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3739658176931298,
+				"StableID":   "n9LnEnUhCW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:50785bf6a6e450d14eb4dc29bf2050e9630d655fc1096ef047c9fab484aa9450",
+				"KeyExpiry":  "2026-11-08T22:09:18Z",
+				"DiscoKey":   "discokey:9ff0b1b874bb4c6e0bc48d9064624a224b180ffd210b955b1bd6e9029183fa08",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48911",
+					"10.65.0.27:48911",
+					"172.17.0.1:48911",
+					"172.18.0.1:48911",
+					"172.19.0.1:48911"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:09:18.941939275Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5104558182710938,
+				"StableID":   "nmWLs56srg11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:282367469425c3f1279bad959cf37db7ccdc7ccd99812b519870e2b94a468358",
+				"KeyExpiry":  "2026-11-08T22:09:19Z",
+				"DiscoKey":   "discokey:c2dc81af2357769a8335357bd8510c0cff79f0612e3f719998ee7be0acc4b921",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:37646",
+					"10.65.0.27:37646",
+					"172.17.0.1:37646",
+					"172.18.0.1:37646",
+					"172.19.0.1:37646"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:09:19.47634035Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5317069389681284,
+				"StableID":   "nhX1X1Q7Xi11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       5317069389681284,
+				"Key":        "nodekey:cfa615f6dda9cfba1cb32447207a5efdaa2735c11047274c871e968052f3bf4d",
+				"DiscoKey":   "discokey:815d00bb9dab4c4ca634b79b07258af096882f3b264b8759ce8d42eb462cf151",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46235",
+					"10.65.0.27:46235",
+					"172.17.0.1:46235",
+					"172.18.0.1:46235",
+					"172.19.0.1:46235"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:09:13.536999204Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:cfa615f6dda9cfba1cb32447207a5efdaa2735c11047274c871e968052f3bf4d",
+			"MachineKey": "mkey:5676b82ceb7906b25eed9eb290d37c13bab47544758aa59d92b3aad21c06e42d",
+			"Peers": [{
+				"ID":         8114526209130773,
+				"StableID":   "nAsFDwq5N621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36c3161fd2ed824e8d0fba111f0ccfe357821557414c144cf73993df56fcd04d",
+				"DiscoKey":   "discokey:226f22cb8a293d147dc2821044fad2cc35baa790dbc8d3e3a8f2bc535c640711",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53020",
+					"10.65.0.27:53020",
+					"172.17.0.1:53020",
+					"172.18.0.1:53020",
+					"172.19.0.1:53020"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:09:12.44836122Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3765173621324555,
+				"StableID":   "nJijg8jFQW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2fec3721b390e2a459cce4a956afa20311a8bd0e5a6f94d59437d8a7c13f7376",
+				"DiscoKey":   "discokey:e29a161a723179bca1c0237c4ad1a0107a89878288514e8a8925619aaacdc810",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37966",
+					"10.65.0.27:37966",
+					"172.17.0.1:37966",
+					"172.18.0.1:37966",
+					"172.19.0.1:37966"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:09:12.993659272Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8744378582905837,
+				"StableID":   "n82verzLHB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6a6fc786c392186639010c788ffc4677601c790a7c4915ac22d03907d842c52b",
+				"DiscoKey":   "discokey:746fea6809b5055ea2e1644ef583b7a55c80da88e81c406aa40cea6af9281264",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43171",
+					"10.65.0.27:43171",
+					"172.17.0.1:43171",
+					"172.18.0.1:43171",
+					"172.19.0.1:43171"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:09:14.06939005Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         82504563779278,
+				"StableID":   "n5k6nnFNe111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4832fc8bdc2538f606b1b4575062f8f26c9ee1f4b310bdfd484fa2f3fc085f1a",
+				"DiscoKey":   "discokey:b1054f8731053d01e169bac1630150abaae24e31363af1dfbd828946e7b6ea0c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40406",
+					"10.65.0.27:40406",
+					"172.17.0.1:40406",
+					"172.18.0.1:40406",
+					"172.19.0.1:40406"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:09:14.616309494Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5036590610458473,
+				"StableID":   "nkWcFJh5Lg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7d1ea7849142081c4c4e5a5dd05f60b054f9b8175de35e4b9329ba20b2a40f0b",
+				"DiscoKey":   "discokey:6083afefe0536f29ba434bcdeb1bb7a0bca8a5099c4fa4a3af4a87136345be70",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44833",
+					"10.65.0.27:44833",
+					"172.17.0.1:44833",
+					"172.18.0.1:44833",
+					"172.19.0.1:44833"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:09:15.156392498Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         815682844870495,
+				"StableID":   "nNSwp6cRN711CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9eecde188381106cc7fd8164e5dedcd3d30fb65b7220cb8bd3328ec34af30d06",
+				"DiscoKey":   "discokey:238e176e67c3dbfbbaac3f772e197565fbda633d9e463bffdefe6909ee418578",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41506",
+					"10.65.0.27:41506",
+					"172.17.0.1:41506",
+					"172.18.0.1:41506",
+					"172.19.0.1:41506"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:09:15.691990771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         958424841452086,
+				"StableID":   "nXfWGLC5V811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d4e9f05e623e1f1bc07f34850443728e8cfe7f1cb9fde67d44afff6d276356f",
+				"DiscoKey":   "discokey:3c86649b4897a19187696e4230a8f7f8616343df3d6eca7ead9e29784f82fb11",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47236",
+					"10.65.0.27:47236",
+					"172.17.0.1:47236",
+					"172.18.0.1:47236",
+					"172.19.0.1:47236"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:09:16.23865548Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6441793196883902,
+				"StableID":   "nBsbv4zVJs11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4fad52354c0a559d66b44be7ffd056d626b8901d0d6d79982a57e318cb544765",
+				"DiscoKey":   "discokey:a5a869b40095fbebe796da064ce9ff984f64ace82ab3f783f5faaf71f128971d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:50338",
+					"10.65.0.27:50338",
+					"172.17.0.1:50338",
+					"172.18.0.1:50338",
+					"172.19.0.1:50338"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:09:16.780573933Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2958693032730856,
+				"StableID":   "nBaajErz6Q11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:014af8a5046c50dfad264fb4062da433b681f443de36da9617d0c86202dd1026",
+				"DiscoKey":   "discokey:b50015ae862bdf971ae0d941a0bd78da86c451a352a08fb4f9ac0e5f30c4ea77",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51718",
+					"10.65.0.27:51718",
+					"172.17.0.1:51718",
+					"172.18.0.1:51718",
+					"172.19.0.1:51718"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:09:17.321173151Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7160680393704177,
+				"StableID":   "n4i2o2w5vx11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab23903e63e2612cb368380db7dbf13d95742e38ada9ef8b848d6ef9aac8730a",
+				"DiscoKey":   "discokey:399ba9cde79b89e5cc69a159f7df17b610f0431f688c0191113f36ed46f3bb1d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41268",
+					"10.65.0.27:41268",
+					"172.17.0.1:41268",
+					"172.18.0.1:41268",
+					"172.19.0.1:41268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:09:17.870267785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1014096996010250,
+				"StableID":   "ny4gvHcHv811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:71e2d791870f7e9467d5e8f500ce49cb9182d618bb436e27043e69590b09721c",
+				"DiscoKey":   "discokey:06bdef47dea8c16d845fc563964895e5386827e98d10a4a1501276e3b65abb65",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:60739",
+					"10.65.0.27:60739",
+					"172.17.0.1:60739",
+					"172.18.0.1:60739",
+					"172.19.0.1:60739"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:09:18.39882372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3739658176931298,
+				"StableID":   "n9LnEnUhCW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:50785bf6a6e450d14eb4dc29bf2050e9630d655fc1096ef047c9fab484aa9450",
+				"KeyExpiry":  "2026-11-08T22:09:18Z",
+				"DiscoKey":   "discokey:9ff0b1b874bb4c6e0bc48d9064624a224b180ffd210b955b1bd6e9029183fa08",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48911",
+					"10.65.0.27:48911",
+					"172.17.0.1:48911",
+					"172.18.0.1:48911",
+					"172.19.0.1:48911"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:09:18.941939275Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5104558182710938,
+				"StableID":   "nmWLs56srg11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:282367469425c3f1279bad959cf37db7ccdc7ccd99812b519870e2b94a468358",
+				"KeyExpiry":  "2026-11-08T22:09:19Z",
+				"DiscoKey":   "discokey:c2dc81af2357769a8335357bd8510c0cff79f0612e3f719998ee7be0acc4b921",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:37646",
+					"10.65.0.27:37646",
+					"172.17.0.1:37646",
+					"172.18.0.1:37646",
+					"172.19.0.1:37646"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:09:19.47634035Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6334121386671680,
+				"StableID":   "noJ7mRdjTr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d1ed5cb85fd631baed6c7bdd9c1a882407173be46293e77c6826dd55c05b487f",
+				"KeyExpiry":  "2026-11-08T22:09:20Z",
+				"DiscoKey":   "discokey:9566fb01babc305c0756818fe37e2c286336313ba65e95a5ea668a972ef36641",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57469",
+					"10.65.0.27:57469",
+					"172.17.0.1:57469",
+					"172.18.0.1:57469",
+					"172.19.0.1:57469"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:09:20.013704416Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5317069389681284": {
+				"ID":          5317069389681284,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         958424841452086,
+				"StableID":   "nXfWGLC5V811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       958424841452086,
+				"Key":        "nodekey:9d4e9f05e623e1f1bc07f34850443728e8cfe7f1cb9fde67d44afff6d276356f",
+				"DiscoKey":   "discokey:3c86649b4897a19187696e4230a8f7f8616343df3d6eca7ead9e29784f82fb11",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47236",
+					"10.65.0.27:47236",
+					"172.17.0.1:47236",
+					"172.18.0.1:47236",
+					"172.19.0.1:47236"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:09:16.23865548Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9d4e9f05e623e1f1bc07f34850443728e8cfe7f1cb9fde67d44afff6d276356f",
+			"MachineKey": "mkey:51f9bd9bec24f62117d12bb0d0c7e10676f6d99cd7e8cd35d757030fb16c7258",
+			"Peers": [{
+				"ID":         8114526209130773,
+				"StableID":   "nAsFDwq5N621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36c3161fd2ed824e8d0fba111f0ccfe357821557414c144cf73993df56fcd04d",
+				"DiscoKey":   "discokey:226f22cb8a293d147dc2821044fad2cc35baa790dbc8d3e3a8f2bc535c640711",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53020",
+					"10.65.0.27:53020",
+					"172.17.0.1:53020",
+					"172.18.0.1:53020",
+					"172.19.0.1:53020"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:09:12.44836122Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3765173621324555,
+				"StableID":   "nJijg8jFQW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2fec3721b390e2a459cce4a956afa20311a8bd0e5a6f94d59437d8a7c13f7376",
+				"DiscoKey":   "discokey:e29a161a723179bca1c0237c4ad1a0107a89878288514e8a8925619aaacdc810",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37966",
+					"10.65.0.27:37966",
+					"172.17.0.1:37966",
+					"172.18.0.1:37966",
+					"172.19.0.1:37966"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:09:12.993659272Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5317069389681284,
+				"StableID":   "nhX1X1Q7Xi11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cfa615f6dda9cfba1cb32447207a5efdaa2735c11047274c871e968052f3bf4d",
+				"DiscoKey":   "discokey:815d00bb9dab4c4ca634b79b07258af096882f3b264b8759ce8d42eb462cf151",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46235",
+					"10.65.0.27:46235",
+					"172.17.0.1:46235",
+					"172.18.0.1:46235",
+					"172.19.0.1:46235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:09:13.536999204Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8744378582905837,
+				"StableID":   "n82verzLHB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6a6fc786c392186639010c788ffc4677601c790a7c4915ac22d03907d842c52b",
+				"DiscoKey":   "discokey:746fea6809b5055ea2e1644ef583b7a55c80da88e81c406aa40cea6af9281264",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43171",
+					"10.65.0.27:43171",
+					"172.17.0.1:43171",
+					"172.18.0.1:43171",
+					"172.19.0.1:43171"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:09:14.06939005Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         82504563779278,
+				"StableID":   "n5k6nnFNe111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4832fc8bdc2538f606b1b4575062f8f26c9ee1f4b310bdfd484fa2f3fc085f1a",
+				"DiscoKey":   "discokey:b1054f8731053d01e169bac1630150abaae24e31363af1dfbd828946e7b6ea0c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40406",
+					"10.65.0.27:40406",
+					"172.17.0.1:40406",
+					"172.18.0.1:40406",
+					"172.19.0.1:40406"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:09:14.616309494Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5036590610458473,
+				"StableID":   "nkWcFJh5Lg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7d1ea7849142081c4c4e5a5dd05f60b054f9b8175de35e4b9329ba20b2a40f0b",
+				"DiscoKey":   "discokey:6083afefe0536f29ba434bcdeb1bb7a0bca8a5099c4fa4a3af4a87136345be70",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44833",
+					"10.65.0.27:44833",
+					"172.17.0.1:44833",
+					"172.18.0.1:44833",
+					"172.19.0.1:44833"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:09:15.156392498Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         815682844870495,
+				"StableID":   "nNSwp6cRN711CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9eecde188381106cc7fd8164e5dedcd3d30fb65b7220cb8bd3328ec34af30d06",
+				"DiscoKey":   "discokey:238e176e67c3dbfbbaac3f772e197565fbda633d9e463bffdefe6909ee418578",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41506",
+					"10.65.0.27:41506",
+					"172.17.0.1:41506",
+					"172.18.0.1:41506",
+					"172.19.0.1:41506"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:09:15.691990771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6441793196883902,
+				"StableID":   "nBsbv4zVJs11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4fad52354c0a559d66b44be7ffd056d626b8901d0d6d79982a57e318cb544765",
+				"DiscoKey":   "discokey:a5a869b40095fbebe796da064ce9ff984f64ace82ab3f783f5faaf71f128971d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:50338",
+					"10.65.0.27:50338",
+					"172.17.0.1:50338",
+					"172.18.0.1:50338",
+					"172.19.0.1:50338"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:09:16.780573933Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2958693032730856,
+				"StableID":   "nBaajErz6Q11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:014af8a5046c50dfad264fb4062da433b681f443de36da9617d0c86202dd1026",
+				"DiscoKey":   "discokey:b50015ae862bdf971ae0d941a0bd78da86c451a352a08fb4f9ac0e5f30c4ea77",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51718",
+					"10.65.0.27:51718",
+					"172.17.0.1:51718",
+					"172.18.0.1:51718",
+					"172.19.0.1:51718"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:09:17.321173151Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7160680393704177,
+				"StableID":   "n4i2o2w5vx11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab23903e63e2612cb368380db7dbf13d95742e38ada9ef8b848d6ef9aac8730a",
+				"DiscoKey":   "discokey:399ba9cde79b89e5cc69a159f7df17b610f0431f688c0191113f36ed46f3bb1d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41268",
+					"10.65.0.27:41268",
+					"172.17.0.1:41268",
+					"172.18.0.1:41268",
+					"172.19.0.1:41268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:09:17.870267785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1014096996010250,
+				"StableID":   "ny4gvHcHv811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:71e2d791870f7e9467d5e8f500ce49cb9182d618bb436e27043e69590b09721c",
+				"DiscoKey":   "discokey:06bdef47dea8c16d845fc563964895e5386827e98d10a4a1501276e3b65abb65",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:60739",
+					"10.65.0.27:60739",
+					"172.17.0.1:60739",
+					"172.18.0.1:60739",
+					"172.19.0.1:60739"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:09:18.39882372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3739658176931298,
+				"StableID":   "n9LnEnUhCW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:50785bf6a6e450d14eb4dc29bf2050e9630d655fc1096ef047c9fab484aa9450",
+				"KeyExpiry":  "2026-11-08T22:09:18Z",
+				"DiscoKey":   "discokey:9ff0b1b874bb4c6e0bc48d9064624a224b180ffd210b955b1bd6e9029183fa08",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48911",
+					"10.65.0.27:48911",
+					"172.17.0.1:48911",
+					"172.18.0.1:48911",
+					"172.19.0.1:48911"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:09:18.941939275Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5104558182710938,
+				"StableID":   "nmWLs56srg11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:282367469425c3f1279bad959cf37db7ccdc7ccd99812b519870e2b94a468358",
+				"KeyExpiry":  "2026-11-08T22:09:19Z",
+				"DiscoKey":   "discokey:c2dc81af2357769a8335357bd8510c0cff79f0612e3f719998ee7be0acc4b921",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:37646",
+					"10.65.0.27:37646",
+					"172.17.0.1:37646",
+					"172.18.0.1:37646",
+					"172.19.0.1:37646"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:09:19.47634035Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6334121386671680,
+				"StableID":   "noJ7mRdjTr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d1ed5cb85fd631baed6c7bdd9c1a882407173be46293e77c6826dd55c05b487f",
+				"KeyExpiry":  "2026-11-08T22:09:20Z",
+				"DiscoKey":   "discokey:9566fb01babc305c0756818fe37e2c286336313ba65e95a5ea668a972ef36641",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57469",
+					"10.65.0.27:57469",
+					"172.17.0.1:57469",
+					"172.18.0.1:57469",
+					"172.19.0.1:57469"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:09:20.013704416Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "958424841452086": {
+				"ID":          958424841452086,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3739658176931298,
+				"StableID":   "n9LnEnUhCW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:50785bf6a6e450d14eb4dc29bf2050e9630d655fc1096ef047c9fab484aa9450",
+				"KeyExpiry":  "2026-11-08T22:09:18Z",
+				"DiscoKey":   "discokey:9ff0b1b874bb4c6e0bc48d9064624a224b180ffd210b955b1bd6e9029183fa08",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48911",
+					"10.65.0.27:48911",
+					"172.17.0.1:48911",
+					"172.18.0.1:48911",
+					"172.19.0.1:48911"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:09:18.941939275Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:50785bf6a6e450d14eb4dc29bf2050e9630d655fc1096ef047c9fab484aa9450",
+			"MachineKey": "mkey:58443127a275a68520afce46dd8c439b7a3e29f29937628eeb55033aa8b04304",
+			"Peers": [{
+				"ID":         8114526209130773,
+				"StableID":   "nAsFDwq5N621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36c3161fd2ed824e8d0fba111f0ccfe357821557414c144cf73993df56fcd04d",
+				"DiscoKey":   "discokey:226f22cb8a293d147dc2821044fad2cc35baa790dbc8d3e3a8f2bc535c640711",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53020",
+					"10.65.0.27:53020",
+					"172.17.0.1:53020",
+					"172.18.0.1:53020",
+					"172.19.0.1:53020"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:09:12.44836122Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3765173621324555,
+				"StableID":   "nJijg8jFQW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2fec3721b390e2a459cce4a956afa20311a8bd0e5a6f94d59437d8a7c13f7376",
+				"DiscoKey":   "discokey:e29a161a723179bca1c0237c4ad1a0107a89878288514e8a8925619aaacdc810",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37966",
+					"10.65.0.27:37966",
+					"172.17.0.1:37966",
+					"172.18.0.1:37966",
+					"172.19.0.1:37966"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:09:12.993659272Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5317069389681284,
+				"StableID":   "nhX1X1Q7Xi11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cfa615f6dda9cfba1cb32447207a5efdaa2735c11047274c871e968052f3bf4d",
+				"DiscoKey":   "discokey:815d00bb9dab4c4ca634b79b07258af096882f3b264b8759ce8d42eb462cf151",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46235",
+					"10.65.0.27:46235",
+					"172.17.0.1:46235",
+					"172.18.0.1:46235",
+					"172.19.0.1:46235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:09:13.536999204Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8744378582905837,
+				"StableID":   "n82verzLHB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6a6fc786c392186639010c788ffc4677601c790a7c4915ac22d03907d842c52b",
+				"DiscoKey":   "discokey:746fea6809b5055ea2e1644ef583b7a55c80da88e81c406aa40cea6af9281264",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43171",
+					"10.65.0.27:43171",
+					"172.17.0.1:43171",
+					"172.18.0.1:43171",
+					"172.19.0.1:43171"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:09:14.06939005Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         82504563779278,
+				"StableID":   "n5k6nnFNe111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4832fc8bdc2538f606b1b4575062f8f26c9ee1f4b310bdfd484fa2f3fc085f1a",
+				"DiscoKey":   "discokey:b1054f8731053d01e169bac1630150abaae24e31363af1dfbd828946e7b6ea0c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40406",
+					"10.65.0.27:40406",
+					"172.17.0.1:40406",
+					"172.18.0.1:40406",
+					"172.19.0.1:40406"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:09:14.616309494Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5036590610458473,
+				"StableID":   "nkWcFJh5Lg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7d1ea7849142081c4c4e5a5dd05f60b054f9b8175de35e4b9329ba20b2a40f0b",
+				"DiscoKey":   "discokey:6083afefe0536f29ba434bcdeb1bb7a0bca8a5099c4fa4a3af4a87136345be70",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44833",
+					"10.65.0.27:44833",
+					"172.17.0.1:44833",
+					"172.18.0.1:44833",
+					"172.19.0.1:44833"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:09:15.156392498Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         815682844870495,
+				"StableID":   "nNSwp6cRN711CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9eecde188381106cc7fd8164e5dedcd3d30fb65b7220cb8bd3328ec34af30d06",
+				"DiscoKey":   "discokey:238e176e67c3dbfbbaac3f772e197565fbda633d9e463bffdefe6909ee418578",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41506",
+					"10.65.0.27:41506",
+					"172.17.0.1:41506",
+					"172.18.0.1:41506",
+					"172.19.0.1:41506"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:09:15.691990771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         958424841452086,
+				"StableID":   "nXfWGLC5V811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d4e9f05e623e1f1bc07f34850443728e8cfe7f1cb9fde67d44afff6d276356f",
+				"DiscoKey":   "discokey:3c86649b4897a19187696e4230a8f7f8616343df3d6eca7ead9e29784f82fb11",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47236",
+					"10.65.0.27:47236",
+					"172.17.0.1:47236",
+					"172.18.0.1:47236",
+					"172.19.0.1:47236"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:09:16.23865548Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6441793196883902,
+				"StableID":   "nBsbv4zVJs11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4fad52354c0a559d66b44be7ffd056d626b8901d0d6d79982a57e318cb544765",
+				"DiscoKey":   "discokey:a5a869b40095fbebe796da064ce9ff984f64ace82ab3f783f5faaf71f128971d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:50338",
+					"10.65.0.27:50338",
+					"172.17.0.1:50338",
+					"172.18.0.1:50338",
+					"172.19.0.1:50338"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:09:16.780573933Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2958693032730856,
+				"StableID":   "nBaajErz6Q11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:014af8a5046c50dfad264fb4062da433b681f443de36da9617d0c86202dd1026",
+				"DiscoKey":   "discokey:b50015ae862bdf971ae0d941a0bd78da86c451a352a08fb4f9ac0e5f30c4ea77",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51718",
+					"10.65.0.27:51718",
+					"172.17.0.1:51718",
+					"172.18.0.1:51718",
+					"172.19.0.1:51718"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:09:17.321173151Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7160680393704177,
+				"StableID":   "n4i2o2w5vx11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab23903e63e2612cb368380db7dbf13d95742e38ada9ef8b848d6ef9aac8730a",
+				"DiscoKey":   "discokey:399ba9cde79b89e5cc69a159f7df17b610f0431f688c0191113f36ed46f3bb1d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41268",
+					"10.65.0.27:41268",
+					"172.17.0.1:41268",
+					"172.18.0.1:41268",
+					"172.19.0.1:41268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:09:17.870267785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1014096996010250,
+				"StableID":   "ny4gvHcHv811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:71e2d791870f7e9467d5e8f500ce49cb9182d618bb436e27043e69590b09721c",
+				"DiscoKey":   "discokey:06bdef47dea8c16d845fc563964895e5386827e98d10a4a1501276e3b65abb65",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:60739",
+					"10.65.0.27:60739",
+					"172.17.0.1:60739",
+					"172.18.0.1:60739",
+					"172.19.0.1:60739"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:09:18.39882372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5104558182710938,
+				"StableID":   "nmWLs56srg11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:282367469425c3f1279bad959cf37db7ccdc7ccd99812b519870e2b94a468358",
+				"KeyExpiry":  "2026-11-08T22:09:19Z",
+				"DiscoKey":   "discokey:c2dc81af2357769a8335357bd8510c0cff79f0612e3f719998ee7be0acc4b921",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:37646",
+					"10.65.0.27:37646",
+					"172.17.0.1:37646",
+					"172.18.0.1:37646",
+					"172.19.0.1:37646"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:09:19.47634035Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6334121386671680,
+				"StableID":   "noJ7mRdjTr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d1ed5cb85fd631baed6c7bdd9c1a882407173be46293e77c6826dd55c05b487f",
+				"KeyExpiry":  "2026-11-08T22:09:20Z",
+				"DiscoKey":   "discokey:9566fb01babc305c0756818fe37e2c286336313ba65e95a5ea668a972ef36641",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57469",
+					"10.65.0.27:57469",
+					"172.17.0.1:57469",
+					"172.18.0.1:57469",
+					"172.19.0.1:57469"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:09:20.013704416Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7160680393704177,
+				"StableID":   "n4i2o2w5vx11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       7160680393704177,
+				"Key":        "nodekey:ab23903e63e2612cb368380db7dbf13d95742e38ada9ef8b848d6ef9aac8730a",
+				"DiscoKey":   "discokey:399ba9cde79b89e5cc69a159f7df17b610f0431f688c0191113f36ed46f3bb1d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41268",
+					"10.65.0.27:41268",
+					"172.17.0.1:41268",
+					"172.18.0.1:41268",
+					"172.19.0.1:41268"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:09:17.870267785Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ab23903e63e2612cb368380db7dbf13d95742e38ada9ef8b848d6ef9aac8730a",
+			"MachineKey": "mkey:3414f72b31961e2df280747c56b02aad9d05146a1b815a9ffa4cd45711790c54",
+			"Peers": [{
+				"ID":         8114526209130773,
+				"StableID":   "nAsFDwq5N621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36c3161fd2ed824e8d0fba111f0ccfe357821557414c144cf73993df56fcd04d",
+				"DiscoKey":   "discokey:226f22cb8a293d147dc2821044fad2cc35baa790dbc8d3e3a8f2bc535c640711",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53020",
+					"10.65.0.27:53020",
+					"172.17.0.1:53020",
+					"172.18.0.1:53020",
+					"172.19.0.1:53020"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:09:12.44836122Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3765173621324555,
+				"StableID":   "nJijg8jFQW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2fec3721b390e2a459cce4a956afa20311a8bd0e5a6f94d59437d8a7c13f7376",
+				"DiscoKey":   "discokey:e29a161a723179bca1c0237c4ad1a0107a89878288514e8a8925619aaacdc810",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37966",
+					"10.65.0.27:37966",
+					"172.17.0.1:37966",
+					"172.18.0.1:37966",
+					"172.19.0.1:37966"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:09:12.993659272Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5317069389681284,
+				"StableID":   "nhX1X1Q7Xi11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cfa615f6dda9cfba1cb32447207a5efdaa2735c11047274c871e968052f3bf4d",
+				"DiscoKey":   "discokey:815d00bb9dab4c4ca634b79b07258af096882f3b264b8759ce8d42eb462cf151",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46235",
+					"10.65.0.27:46235",
+					"172.17.0.1:46235",
+					"172.18.0.1:46235",
+					"172.19.0.1:46235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:09:13.536999204Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8744378582905837,
+				"StableID":   "n82verzLHB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6a6fc786c392186639010c788ffc4677601c790a7c4915ac22d03907d842c52b",
+				"DiscoKey":   "discokey:746fea6809b5055ea2e1644ef583b7a55c80da88e81c406aa40cea6af9281264",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43171",
+					"10.65.0.27:43171",
+					"172.17.0.1:43171",
+					"172.18.0.1:43171",
+					"172.19.0.1:43171"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:09:14.06939005Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         82504563779278,
+				"StableID":   "n5k6nnFNe111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4832fc8bdc2538f606b1b4575062f8f26c9ee1f4b310bdfd484fa2f3fc085f1a",
+				"DiscoKey":   "discokey:b1054f8731053d01e169bac1630150abaae24e31363af1dfbd828946e7b6ea0c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40406",
+					"10.65.0.27:40406",
+					"172.17.0.1:40406",
+					"172.18.0.1:40406",
+					"172.19.0.1:40406"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:09:14.616309494Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5036590610458473,
+				"StableID":   "nkWcFJh5Lg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7d1ea7849142081c4c4e5a5dd05f60b054f9b8175de35e4b9329ba20b2a40f0b",
+				"DiscoKey":   "discokey:6083afefe0536f29ba434bcdeb1bb7a0bca8a5099c4fa4a3af4a87136345be70",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44833",
+					"10.65.0.27:44833",
+					"172.17.0.1:44833",
+					"172.18.0.1:44833",
+					"172.19.0.1:44833"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:09:15.156392498Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         815682844870495,
+				"StableID":   "nNSwp6cRN711CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9eecde188381106cc7fd8164e5dedcd3d30fb65b7220cb8bd3328ec34af30d06",
+				"DiscoKey":   "discokey:238e176e67c3dbfbbaac3f772e197565fbda633d9e463bffdefe6909ee418578",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41506",
+					"10.65.0.27:41506",
+					"172.17.0.1:41506",
+					"172.18.0.1:41506",
+					"172.19.0.1:41506"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:09:15.691990771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         958424841452086,
+				"StableID":   "nXfWGLC5V811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d4e9f05e623e1f1bc07f34850443728e8cfe7f1cb9fde67d44afff6d276356f",
+				"DiscoKey":   "discokey:3c86649b4897a19187696e4230a8f7f8616343df3d6eca7ead9e29784f82fb11",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47236",
+					"10.65.0.27:47236",
+					"172.17.0.1:47236",
+					"172.18.0.1:47236",
+					"172.19.0.1:47236"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:09:16.23865548Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6441793196883902,
+				"StableID":   "nBsbv4zVJs11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4fad52354c0a559d66b44be7ffd056d626b8901d0d6d79982a57e318cb544765",
+				"DiscoKey":   "discokey:a5a869b40095fbebe796da064ce9ff984f64ace82ab3f783f5faaf71f128971d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:50338",
+					"10.65.0.27:50338",
+					"172.17.0.1:50338",
+					"172.18.0.1:50338",
+					"172.19.0.1:50338"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:09:16.780573933Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2958693032730856,
+				"StableID":   "nBaajErz6Q11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:014af8a5046c50dfad264fb4062da433b681f443de36da9617d0c86202dd1026",
+				"DiscoKey":   "discokey:b50015ae862bdf971ae0d941a0bd78da86c451a352a08fb4f9ac0e5f30c4ea77",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51718",
+					"10.65.0.27:51718",
+					"172.17.0.1:51718",
+					"172.18.0.1:51718",
+					"172.19.0.1:51718"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:09:17.321173151Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1014096996010250,
+				"StableID":   "ny4gvHcHv811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:71e2d791870f7e9467d5e8f500ce49cb9182d618bb436e27043e69590b09721c",
+				"DiscoKey":   "discokey:06bdef47dea8c16d845fc563964895e5386827e98d10a4a1501276e3b65abb65",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:60739",
+					"10.65.0.27:60739",
+					"172.17.0.1:60739",
+					"172.18.0.1:60739",
+					"172.19.0.1:60739"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:09:18.39882372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3739658176931298,
+				"StableID":   "n9LnEnUhCW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:50785bf6a6e450d14eb4dc29bf2050e9630d655fc1096ef047c9fab484aa9450",
+				"KeyExpiry":  "2026-11-08T22:09:18Z",
+				"DiscoKey":   "discokey:9ff0b1b874bb4c6e0bc48d9064624a224b180ffd210b955b1bd6e9029183fa08",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48911",
+					"10.65.0.27:48911",
+					"172.17.0.1:48911",
+					"172.18.0.1:48911",
+					"172.19.0.1:48911"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:09:18.941939275Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5104558182710938,
+				"StableID":   "nmWLs56srg11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:282367469425c3f1279bad959cf37db7ccdc7ccd99812b519870e2b94a468358",
+				"KeyExpiry":  "2026-11-08T22:09:19Z",
+				"DiscoKey":   "discokey:c2dc81af2357769a8335357bd8510c0cff79f0612e3f719998ee7be0acc4b921",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:37646",
+					"10.65.0.27:37646",
+					"172.17.0.1:37646",
+					"172.18.0.1:37646",
+					"172.19.0.1:37646"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:09:19.47634035Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6334121386671680,
+				"StableID":   "noJ7mRdjTr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d1ed5cb85fd631baed6c7bdd9c1a882407173be46293e77c6826dd55c05b487f",
+				"KeyExpiry":  "2026-11-08T22:09:20Z",
+				"DiscoKey":   "discokey:9566fb01babc305c0756818fe37e2c286336313ba65e95a5ea668a972ef36641",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57469",
+					"10.65.0.27:57469",
+					"172.17.0.1:57469",
+					"172.18.0.1:57469",
+					"172.19.0.1:57469"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:09:20.013704416Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7160680393704177": {
+				"ID":          7160680393704177,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3765173621324555,
+				"StableID":   "nJijg8jFQW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       3765173621324555,
+				"Key":        "nodekey:2fec3721b390e2a459cce4a956afa20311a8bd0e5a6f94d59437d8a7c13f7376",
+				"DiscoKey":   "discokey:e29a161a723179bca1c0237c4ad1a0107a89878288514e8a8925619aaacdc810",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37966",
+					"10.65.0.27:37966",
+					"172.17.0.1:37966",
+					"172.18.0.1:37966",
+					"172.19.0.1:37966"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:09:12.993659272Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2fec3721b390e2a459cce4a956afa20311a8bd0e5a6f94d59437d8a7c13f7376",
+			"MachineKey": "mkey:1c98e6aeb0d7ec1aa97281111bb766c06fcc0986df9b2d38ea5b891feca3b316",
+			"Peers": [{
+				"ID":         8114526209130773,
+				"StableID":   "nAsFDwq5N621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36c3161fd2ed824e8d0fba111f0ccfe357821557414c144cf73993df56fcd04d",
+				"DiscoKey":   "discokey:226f22cb8a293d147dc2821044fad2cc35baa790dbc8d3e3a8f2bc535c640711",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53020",
+					"10.65.0.27:53020",
+					"172.17.0.1:53020",
+					"172.18.0.1:53020",
+					"172.19.0.1:53020"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:09:12.44836122Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5317069389681284,
+				"StableID":   "nhX1X1Q7Xi11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cfa615f6dda9cfba1cb32447207a5efdaa2735c11047274c871e968052f3bf4d",
+				"DiscoKey":   "discokey:815d00bb9dab4c4ca634b79b07258af096882f3b264b8759ce8d42eb462cf151",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46235",
+					"10.65.0.27:46235",
+					"172.17.0.1:46235",
+					"172.18.0.1:46235",
+					"172.19.0.1:46235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:09:13.536999204Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8744378582905837,
+				"StableID":   "n82verzLHB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6a6fc786c392186639010c788ffc4677601c790a7c4915ac22d03907d842c52b",
+				"DiscoKey":   "discokey:746fea6809b5055ea2e1644ef583b7a55c80da88e81c406aa40cea6af9281264",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43171",
+					"10.65.0.27:43171",
+					"172.17.0.1:43171",
+					"172.18.0.1:43171",
+					"172.19.0.1:43171"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:09:14.06939005Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         82504563779278,
+				"StableID":   "n5k6nnFNe111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4832fc8bdc2538f606b1b4575062f8f26c9ee1f4b310bdfd484fa2f3fc085f1a",
+				"DiscoKey":   "discokey:b1054f8731053d01e169bac1630150abaae24e31363af1dfbd828946e7b6ea0c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40406",
+					"10.65.0.27:40406",
+					"172.17.0.1:40406",
+					"172.18.0.1:40406",
+					"172.19.0.1:40406"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:09:14.616309494Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5036590610458473,
+				"StableID":   "nkWcFJh5Lg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7d1ea7849142081c4c4e5a5dd05f60b054f9b8175de35e4b9329ba20b2a40f0b",
+				"DiscoKey":   "discokey:6083afefe0536f29ba434bcdeb1bb7a0bca8a5099c4fa4a3af4a87136345be70",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44833",
+					"10.65.0.27:44833",
+					"172.17.0.1:44833",
+					"172.18.0.1:44833",
+					"172.19.0.1:44833"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:09:15.156392498Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         815682844870495,
+				"StableID":   "nNSwp6cRN711CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9eecde188381106cc7fd8164e5dedcd3d30fb65b7220cb8bd3328ec34af30d06",
+				"DiscoKey":   "discokey:238e176e67c3dbfbbaac3f772e197565fbda633d9e463bffdefe6909ee418578",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41506",
+					"10.65.0.27:41506",
+					"172.17.0.1:41506",
+					"172.18.0.1:41506",
+					"172.19.0.1:41506"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:09:15.691990771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         958424841452086,
+				"StableID":   "nXfWGLC5V811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d4e9f05e623e1f1bc07f34850443728e8cfe7f1cb9fde67d44afff6d276356f",
+				"DiscoKey":   "discokey:3c86649b4897a19187696e4230a8f7f8616343df3d6eca7ead9e29784f82fb11",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47236",
+					"10.65.0.27:47236",
+					"172.17.0.1:47236",
+					"172.18.0.1:47236",
+					"172.19.0.1:47236"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:09:16.23865548Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6441793196883902,
+				"StableID":   "nBsbv4zVJs11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4fad52354c0a559d66b44be7ffd056d626b8901d0d6d79982a57e318cb544765",
+				"DiscoKey":   "discokey:a5a869b40095fbebe796da064ce9ff984f64ace82ab3f783f5faaf71f128971d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:50338",
+					"10.65.0.27:50338",
+					"172.17.0.1:50338",
+					"172.18.0.1:50338",
+					"172.19.0.1:50338"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:09:16.780573933Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2958693032730856,
+				"StableID":   "nBaajErz6Q11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:014af8a5046c50dfad264fb4062da433b681f443de36da9617d0c86202dd1026",
+				"DiscoKey":   "discokey:b50015ae862bdf971ae0d941a0bd78da86c451a352a08fb4f9ac0e5f30c4ea77",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51718",
+					"10.65.0.27:51718",
+					"172.17.0.1:51718",
+					"172.18.0.1:51718",
+					"172.19.0.1:51718"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:09:17.321173151Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7160680393704177,
+				"StableID":   "n4i2o2w5vx11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab23903e63e2612cb368380db7dbf13d95742e38ada9ef8b848d6ef9aac8730a",
+				"DiscoKey":   "discokey:399ba9cde79b89e5cc69a159f7df17b610f0431f688c0191113f36ed46f3bb1d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41268",
+					"10.65.0.27:41268",
+					"172.17.0.1:41268",
+					"172.18.0.1:41268",
+					"172.19.0.1:41268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:09:17.870267785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1014096996010250,
+				"StableID":   "ny4gvHcHv811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:71e2d791870f7e9467d5e8f500ce49cb9182d618bb436e27043e69590b09721c",
+				"DiscoKey":   "discokey:06bdef47dea8c16d845fc563964895e5386827e98d10a4a1501276e3b65abb65",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:60739",
+					"10.65.0.27:60739",
+					"172.17.0.1:60739",
+					"172.18.0.1:60739",
+					"172.19.0.1:60739"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:09:18.39882372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3739658176931298,
+				"StableID":   "n9LnEnUhCW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:50785bf6a6e450d14eb4dc29bf2050e9630d655fc1096ef047c9fab484aa9450",
+				"KeyExpiry":  "2026-11-08T22:09:18Z",
+				"DiscoKey":   "discokey:9ff0b1b874bb4c6e0bc48d9064624a224b180ffd210b955b1bd6e9029183fa08",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48911",
+					"10.65.0.27:48911",
+					"172.17.0.1:48911",
+					"172.18.0.1:48911",
+					"172.19.0.1:48911"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:09:18.941939275Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5104558182710938,
+				"StableID":   "nmWLs56srg11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:282367469425c3f1279bad959cf37db7ccdc7ccd99812b519870e2b94a468358",
+				"KeyExpiry":  "2026-11-08T22:09:19Z",
+				"DiscoKey":   "discokey:c2dc81af2357769a8335357bd8510c0cff79f0612e3f719998ee7be0acc4b921",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:37646",
+					"10.65.0.27:37646",
+					"172.17.0.1:37646",
+					"172.18.0.1:37646",
+					"172.19.0.1:37646"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:09:19.47634035Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6334121386671680,
+				"StableID":   "noJ7mRdjTr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d1ed5cb85fd631baed6c7bdd9c1a882407173be46293e77c6826dd55c05b487f",
+				"KeyExpiry":  "2026-11-08T22:09:20Z",
+				"DiscoKey":   "discokey:9566fb01babc305c0756818fe37e2c286336313ba65e95a5ea668a972ef36641",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57469",
+					"10.65.0.27:57469",
+					"172.17.0.1:57469",
+					"172.18.0.1:57469",
+					"172.19.0.1:57469"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:09:20.013704416Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3765173621324555": {
+				"ID":          3765173621324555,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8114526209130773,
+				"StableID":   "nAsFDwq5N621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       8114526209130773,
+				"Key":        "nodekey:36c3161fd2ed824e8d0fba111f0ccfe357821557414c144cf73993df56fcd04d",
+				"DiscoKey":   "discokey:226f22cb8a293d147dc2821044fad2cc35baa790dbc8d3e3a8f2bc535c640711",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53020",
+					"10.65.0.27:53020",
+					"172.17.0.1:53020",
+					"172.18.0.1:53020",
+					"172.19.0.1:53020"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:09:12.44836122Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:36c3161fd2ed824e8d0fba111f0ccfe357821557414c144cf73993df56fcd04d",
+			"MachineKey": "mkey:d7e7c6b86a518deb94a8af54f9fd0ae4190203b2e621ee64e0f6417a57956d6d",
+			"Peers": [{
+				"ID":         3765173621324555,
+				"StableID":   "nJijg8jFQW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2fec3721b390e2a459cce4a956afa20311a8bd0e5a6f94d59437d8a7c13f7376",
+				"DiscoKey":   "discokey:e29a161a723179bca1c0237c4ad1a0107a89878288514e8a8925619aaacdc810",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37966",
+					"10.65.0.27:37966",
+					"172.17.0.1:37966",
+					"172.18.0.1:37966",
+					"172.19.0.1:37966"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:09:12.993659272Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5317069389681284,
+				"StableID":   "nhX1X1Q7Xi11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cfa615f6dda9cfba1cb32447207a5efdaa2735c11047274c871e968052f3bf4d",
+				"DiscoKey":   "discokey:815d00bb9dab4c4ca634b79b07258af096882f3b264b8759ce8d42eb462cf151",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46235",
+					"10.65.0.27:46235",
+					"172.17.0.1:46235",
+					"172.18.0.1:46235",
+					"172.19.0.1:46235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:09:13.536999204Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8744378582905837,
+				"StableID":   "n82verzLHB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6a6fc786c392186639010c788ffc4677601c790a7c4915ac22d03907d842c52b",
+				"DiscoKey":   "discokey:746fea6809b5055ea2e1644ef583b7a55c80da88e81c406aa40cea6af9281264",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43171",
+					"10.65.0.27:43171",
+					"172.17.0.1:43171",
+					"172.18.0.1:43171",
+					"172.19.0.1:43171"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:09:14.06939005Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         82504563779278,
+				"StableID":   "n5k6nnFNe111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4832fc8bdc2538f606b1b4575062f8f26c9ee1f4b310bdfd484fa2f3fc085f1a",
+				"DiscoKey":   "discokey:b1054f8731053d01e169bac1630150abaae24e31363af1dfbd828946e7b6ea0c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40406",
+					"10.65.0.27:40406",
+					"172.17.0.1:40406",
+					"172.18.0.1:40406",
+					"172.19.0.1:40406"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:09:14.616309494Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5036590610458473,
+				"StableID":   "nkWcFJh5Lg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7d1ea7849142081c4c4e5a5dd05f60b054f9b8175de35e4b9329ba20b2a40f0b",
+				"DiscoKey":   "discokey:6083afefe0536f29ba434bcdeb1bb7a0bca8a5099c4fa4a3af4a87136345be70",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44833",
+					"10.65.0.27:44833",
+					"172.17.0.1:44833",
+					"172.18.0.1:44833",
+					"172.19.0.1:44833"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:09:15.156392498Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         815682844870495,
+				"StableID":   "nNSwp6cRN711CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9eecde188381106cc7fd8164e5dedcd3d30fb65b7220cb8bd3328ec34af30d06",
+				"DiscoKey":   "discokey:238e176e67c3dbfbbaac3f772e197565fbda633d9e463bffdefe6909ee418578",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41506",
+					"10.65.0.27:41506",
+					"172.17.0.1:41506",
+					"172.18.0.1:41506",
+					"172.19.0.1:41506"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:09:15.691990771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         958424841452086,
+				"StableID":   "nXfWGLC5V811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d4e9f05e623e1f1bc07f34850443728e8cfe7f1cb9fde67d44afff6d276356f",
+				"DiscoKey":   "discokey:3c86649b4897a19187696e4230a8f7f8616343df3d6eca7ead9e29784f82fb11",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47236",
+					"10.65.0.27:47236",
+					"172.17.0.1:47236",
+					"172.18.0.1:47236",
+					"172.19.0.1:47236"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:09:16.23865548Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6441793196883902,
+				"StableID":   "nBsbv4zVJs11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4fad52354c0a559d66b44be7ffd056d626b8901d0d6d79982a57e318cb544765",
+				"DiscoKey":   "discokey:a5a869b40095fbebe796da064ce9ff984f64ace82ab3f783f5faaf71f128971d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:50338",
+					"10.65.0.27:50338",
+					"172.17.0.1:50338",
+					"172.18.0.1:50338",
+					"172.19.0.1:50338"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:09:16.780573933Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2958693032730856,
+				"StableID":   "nBaajErz6Q11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:014af8a5046c50dfad264fb4062da433b681f443de36da9617d0c86202dd1026",
+				"DiscoKey":   "discokey:b50015ae862bdf971ae0d941a0bd78da86c451a352a08fb4f9ac0e5f30c4ea77",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51718",
+					"10.65.0.27:51718",
+					"172.17.0.1:51718",
+					"172.18.0.1:51718",
+					"172.19.0.1:51718"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:09:17.321173151Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7160680393704177,
+				"StableID":   "n4i2o2w5vx11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab23903e63e2612cb368380db7dbf13d95742e38ada9ef8b848d6ef9aac8730a",
+				"DiscoKey":   "discokey:399ba9cde79b89e5cc69a159f7df17b610f0431f688c0191113f36ed46f3bb1d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41268",
+					"10.65.0.27:41268",
+					"172.17.0.1:41268",
+					"172.18.0.1:41268",
+					"172.19.0.1:41268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:09:17.870267785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1014096996010250,
+				"StableID":   "ny4gvHcHv811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:71e2d791870f7e9467d5e8f500ce49cb9182d618bb436e27043e69590b09721c",
+				"DiscoKey":   "discokey:06bdef47dea8c16d845fc563964895e5386827e98d10a4a1501276e3b65abb65",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:60739",
+					"10.65.0.27:60739",
+					"172.17.0.1:60739",
+					"172.18.0.1:60739",
+					"172.19.0.1:60739"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:09:18.39882372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3739658176931298,
+				"StableID":   "n9LnEnUhCW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:50785bf6a6e450d14eb4dc29bf2050e9630d655fc1096ef047c9fab484aa9450",
+				"KeyExpiry":  "2026-11-08T22:09:18Z",
+				"DiscoKey":   "discokey:9ff0b1b874bb4c6e0bc48d9064624a224b180ffd210b955b1bd6e9029183fa08",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48911",
+					"10.65.0.27:48911",
+					"172.17.0.1:48911",
+					"172.18.0.1:48911",
+					"172.19.0.1:48911"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:09:18.941939275Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5104558182710938,
+				"StableID":   "nmWLs56srg11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:282367469425c3f1279bad959cf37db7ccdc7ccd99812b519870e2b94a468358",
+				"KeyExpiry":  "2026-11-08T22:09:19Z",
+				"DiscoKey":   "discokey:c2dc81af2357769a8335357bd8510c0cff79f0612e3f719998ee7be0acc4b921",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:37646",
+					"10.65.0.27:37646",
+					"172.17.0.1:37646",
+					"172.18.0.1:37646",
+					"172.19.0.1:37646"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:09:19.47634035Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6334121386671680,
+				"StableID":   "noJ7mRdjTr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d1ed5cb85fd631baed6c7bdd9c1a882407173be46293e77c6826dd55c05b487f",
+				"KeyExpiry":  "2026-11-08T22:09:20Z",
+				"DiscoKey":   "discokey:9566fb01babc305c0756818fe37e2c286336313ba65e95a5ea668a972ef36641",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57469",
+					"10.65.0.27:57469",
+					"172.17.0.1:57469",
+					"172.18.0.1:57469",
+					"172.19.0.1:57469"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:09:20.013704416Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8114526209130773": {
+				"ID":          8114526209130773,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         82504563779278,
+				"StableID":   "n5k6nnFNe111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       82504563779278,
+				"Key":        "nodekey:4832fc8bdc2538f606b1b4575062f8f26c9ee1f4b310bdfd484fa2f3fc085f1a",
+				"DiscoKey":   "discokey:b1054f8731053d01e169bac1630150abaae24e31363af1dfbd828946e7b6ea0c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40406",
+					"10.65.0.27:40406",
+					"172.17.0.1:40406",
+					"172.18.0.1:40406",
+					"172.19.0.1:40406"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:09:14.616309494Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4832fc8bdc2538f606b1b4575062f8f26c9ee1f4b310bdfd484fa2f3fc085f1a",
+			"MachineKey": "mkey:4fc6ff08602917e70ff7e22e16537132c315c482c08abc7a0ac15665641cc371",
+			"Peers": [{
+				"ID":         8114526209130773,
+				"StableID":   "nAsFDwq5N621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36c3161fd2ed824e8d0fba111f0ccfe357821557414c144cf73993df56fcd04d",
+				"DiscoKey":   "discokey:226f22cb8a293d147dc2821044fad2cc35baa790dbc8d3e3a8f2bc535c640711",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53020",
+					"10.65.0.27:53020",
+					"172.17.0.1:53020",
+					"172.18.0.1:53020",
+					"172.19.0.1:53020"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:09:12.44836122Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3765173621324555,
+				"StableID":   "nJijg8jFQW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2fec3721b390e2a459cce4a956afa20311a8bd0e5a6f94d59437d8a7c13f7376",
+				"DiscoKey":   "discokey:e29a161a723179bca1c0237c4ad1a0107a89878288514e8a8925619aaacdc810",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37966",
+					"10.65.0.27:37966",
+					"172.17.0.1:37966",
+					"172.18.0.1:37966",
+					"172.19.0.1:37966"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:09:12.993659272Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5317069389681284,
+				"StableID":   "nhX1X1Q7Xi11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cfa615f6dda9cfba1cb32447207a5efdaa2735c11047274c871e968052f3bf4d",
+				"DiscoKey":   "discokey:815d00bb9dab4c4ca634b79b07258af096882f3b264b8759ce8d42eb462cf151",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46235",
+					"10.65.0.27:46235",
+					"172.17.0.1:46235",
+					"172.18.0.1:46235",
+					"172.19.0.1:46235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:09:13.536999204Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8744378582905837,
+				"StableID":   "n82verzLHB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6a6fc786c392186639010c788ffc4677601c790a7c4915ac22d03907d842c52b",
+				"DiscoKey":   "discokey:746fea6809b5055ea2e1644ef583b7a55c80da88e81c406aa40cea6af9281264",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43171",
+					"10.65.0.27:43171",
+					"172.17.0.1:43171",
+					"172.18.0.1:43171",
+					"172.19.0.1:43171"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:09:14.06939005Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5036590610458473,
+				"StableID":   "nkWcFJh5Lg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7d1ea7849142081c4c4e5a5dd05f60b054f9b8175de35e4b9329ba20b2a40f0b",
+				"DiscoKey":   "discokey:6083afefe0536f29ba434bcdeb1bb7a0bca8a5099c4fa4a3af4a87136345be70",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44833",
+					"10.65.0.27:44833",
+					"172.17.0.1:44833",
+					"172.18.0.1:44833",
+					"172.19.0.1:44833"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:09:15.156392498Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         815682844870495,
+				"StableID":   "nNSwp6cRN711CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9eecde188381106cc7fd8164e5dedcd3d30fb65b7220cb8bd3328ec34af30d06",
+				"DiscoKey":   "discokey:238e176e67c3dbfbbaac3f772e197565fbda633d9e463bffdefe6909ee418578",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41506",
+					"10.65.0.27:41506",
+					"172.17.0.1:41506",
+					"172.18.0.1:41506",
+					"172.19.0.1:41506"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:09:15.691990771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         958424841452086,
+				"StableID":   "nXfWGLC5V811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d4e9f05e623e1f1bc07f34850443728e8cfe7f1cb9fde67d44afff6d276356f",
+				"DiscoKey":   "discokey:3c86649b4897a19187696e4230a8f7f8616343df3d6eca7ead9e29784f82fb11",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47236",
+					"10.65.0.27:47236",
+					"172.17.0.1:47236",
+					"172.18.0.1:47236",
+					"172.19.0.1:47236"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:09:16.23865548Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6441793196883902,
+				"StableID":   "nBsbv4zVJs11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4fad52354c0a559d66b44be7ffd056d626b8901d0d6d79982a57e318cb544765",
+				"DiscoKey":   "discokey:a5a869b40095fbebe796da064ce9ff984f64ace82ab3f783f5faaf71f128971d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:50338",
+					"10.65.0.27:50338",
+					"172.17.0.1:50338",
+					"172.18.0.1:50338",
+					"172.19.0.1:50338"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:09:16.780573933Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2958693032730856,
+				"StableID":   "nBaajErz6Q11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:014af8a5046c50dfad264fb4062da433b681f443de36da9617d0c86202dd1026",
+				"DiscoKey":   "discokey:b50015ae862bdf971ae0d941a0bd78da86c451a352a08fb4f9ac0e5f30c4ea77",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51718",
+					"10.65.0.27:51718",
+					"172.17.0.1:51718",
+					"172.18.0.1:51718",
+					"172.19.0.1:51718"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:09:17.321173151Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7160680393704177,
+				"StableID":   "n4i2o2w5vx11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab23903e63e2612cb368380db7dbf13d95742e38ada9ef8b848d6ef9aac8730a",
+				"DiscoKey":   "discokey:399ba9cde79b89e5cc69a159f7df17b610f0431f688c0191113f36ed46f3bb1d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41268",
+					"10.65.0.27:41268",
+					"172.17.0.1:41268",
+					"172.18.0.1:41268",
+					"172.19.0.1:41268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:09:17.870267785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1014096996010250,
+				"StableID":   "ny4gvHcHv811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:71e2d791870f7e9467d5e8f500ce49cb9182d618bb436e27043e69590b09721c",
+				"DiscoKey":   "discokey:06bdef47dea8c16d845fc563964895e5386827e98d10a4a1501276e3b65abb65",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:60739",
+					"10.65.0.27:60739",
+					"172.17.0.1:60739",
+					"172.18.0.1:60739",
+					"172.19.0.1:60739"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:09:18.39882372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3739658176931298,
+				"StableID":   "n9LnEnUhCW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:50785bf6a6e450d14eb4dc29bf2050e9630d655fc1096ef047c9fab484aa9450",
+				"KeyExpiry":  "2026-11-08T22:09:18Z",
+				"DiscoKey":   "discokey:9ff0b1b874bb4c6e0bc48d9064624a224b180ffd210b955b1bd6e9029183fa08",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48911",
+					"10.65.0.27:48911",
+					"172.17.0.1:48911",
+					"172.18.0.1:48911",
+					"172.19.0.1:48911"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:09:18.941939275Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5104558182710938,
+				"StableID":   "nmWLs56srg11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:282367469425c3f1279bad959cf37db7ccdc7ccd99812b519870e2b94a468358",
+				"KeyExpiry":  "2026-11-08T22:09:19Z",
+				"DiscoKey":   "discokey:c2dc81af2357769a8335357bd8510c0cff79f0612e3f719998ee7be0acc4b921",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:37646",
+					"10.65.0.27:37646",
+					"172.17.0.1:37646",
+					"172.18.0.1:37646",
+					"172.19.0.1:37646"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:09:19.47634035Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6334121386671680,
+				"StableID":   "noJ7mRdjTr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d1ed5cb85fd631baed6c7bdd9c1a882407173be46293e77c6826dd55c05b487f",
+				"KeyExpiry":  "2026-11-08T22:09:20Z",
+				"DiscoKey":   "discokey:9566fb01babc305c0756818fe37e2c286336313ba65e95a5ea668a972ef36641",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57469",
+					"10.65.0.27:57469",
+					"172.17.0.1:57469",
+					"172.18.0.1:57469",
+					"172.19.0.1:57469"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:09:20.013704416Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "82504563779278": {
+				"ID":          82504563779278,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8744378582905837,
+				"StableID":   "n82verzLHB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       8744378582905837,
+				"Key":        "nodekey:6a6fc786c392186639010c788ffc4677601c790a7c4915ac22d03907d842c52b",
+				"DiscoKey":   "discokey:746fea6809b5055ea2e1644ef583b7a55c80da88e81c406aa40cea6af9281264",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43171",
+					"10.65.0.27:43171",
+					"172.17.0.1:43171",
+					"172.18.0.1:43171",
+					"172.19.0.1:43171"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:09:14.06939005Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6a6fc786c392186639010c788ffc4677601c790a7c4915ac22d03907d842c52b",
+			"MachineKey": "mkey:a9cefa53ec342cff937344bc9de7a6a8d9f7ea875cf7892cbace4f9266621102",
+			"Peers": [{
+				"ID":         8114526209130773,
+				"StableID":   "nAsFDwq5N621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36c3161fd2ed824e8d0fba111f0ccfe357821557414c144cf73993df56fcd04d",
+				"DiscoKey":   "discokey:226f22cb8a293d147dc2821044fad2cc35baa790dbc8d3e3a8f2bc535c640711",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53020",
+					"10.65.0.27:53020",
+					"172.17.0.1:53020",
+					"172.18.0.1:53020",
+					"172.19.0.1:53020"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:09:12.44836122Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3765173621324555,
+				"StableID":   "nJijg8jFQW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2fec3721b390e2a459cce4a956afa20311a8bd0e5a6f94d59437d8a7c13f7376",
+				"DiscoKey":   "discokey:e29a161a723179bca1c0237c4ad1a0107a89878288514e8a8925619aaacdc810",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37966",
+					"10.65.0.27:37966",
+					"172.17.0.1:37966",
+					"172.18.0.1:37966",
+					"172.19.0.1:37966"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:09:12.993659272Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5317069389681284,
+				"StableID":   "nhX1X1Q7Xi11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cfa615f6dda9cfba1cb32447207a5efdaa2735c11047274c871e968052f3bf4d",
+				"DiscoKey":   "discokey:815d00bb9dab4c4ca634b79b07258af096882f3b264b8759ce8d42eb462cf151",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46235",
+					"10.65.0.27:46235",
+					"172.17.0.1:46235",
+					"172.18.0.1:46235",
+					"172.19.0.1:46235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:09:13.536999204Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         82504563779278,
+				"StableID":   "n5k6nnFNe111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4832fc8bdc2538f606b1b4575062f8f26c9ee1f4b310bdfd484fa2f3fc085f1a",
+				"DiscoKey":   "discokey:b1054f8731053d01e169bac1630150abaae24e31363af1dfbd828946e7b6ea0c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40406",
+					"10.65.0.27:40406",
+					"172.17.0.1:40406",
+					"172.18.0.1:40406",
+					"172.19.0.1:40406"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:09:14.616309494Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5036590610458473,
+				"StableID":   "nkWcFJh5Lg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7d1ea7849142081c4c4e5a5dd05f60b054f9b8175de35e4b9329ba20b2a40f0b",
+				"DiscoKey":   "discokey:6083afefe0536f29ba434bcdeb1bb7a0bca8a5099c4fa4a3af4a87136345be70",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44833",
+					"10.65.0.27:44833",
+					"172.17.0.1:44833",
+					"172.18.0.1:44833",
+					"172.19.0.1:44833"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:09:15.156392498Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         815682844870495,
+				"StableID":   "nNSwp6cRN711CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9eecde188381106cc7fd8164e5dedcd3d30fb65b7220cb8bd3328ec34af30d06",
+				"DiscoKey":   "discokey:238e176e67c3dbfbbaac3f772e197565fbda633d9e463bffdefe6909ee418578",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41506",
+					"10.65.0.27:41506",
+					"172.17.0.1:41506",
+					"172.18.0.1:41506",
+					"172.19.0.1:41506"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:09:15.691990771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         958424841452086,
+				"StableID":   "nXfWGLC5V811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d4e9f05e623e1f1bc07f34850443728e8cfe7f1cb9fde67d44afff6d276356f",
+				"DiscoKey":   "discokey:3c86649b4897a19187696e4230a8f7f8616343df3d6eca7ead9e29784f82fb11",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47236",
+					"10.65.0.27:47236",
+					"172.17.0.1:47236",
+					"172.18.0.1:47236",
+					"172.19.0.1:47236"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:09:16.23865548Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6441793196883902,
+				"StableID":   "nBsbv4zVJs11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4fad52354c0a559d66b44be7ffd056d626b8901d0d6d79982a57e318cb544765",
+				"DiscoKey":   "discokey:a5a869b40095fbebe796da064ce9ff984f64ace82ab3f783f5faaf71f128971d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:50338",
+					"10.65.0.27:50338",
+					"172.17.0.1:50338",
+					"172.18.0.1:50338",
+					"172.19.0.1:50338"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:09:16.780573933Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2958693032730856,
+				"StableID":   "nBaajErz6Q11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:014af8a5046c50dfad264fb4062da433b681f443de36da9617d0c86202dd1026",
+				"DiscoKey":   "discokey:b50015ae862bdf971ae0d941a0bd78da86c451a352a08fb4f9ac0e5f30c4ea77",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51718",
+					"10.65.0.27:51718",
+					"172.17.0.1:51718",
+					"172.18.0.1:51718",
+					"172.19.0.1:51718"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:09:17.321173151Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7160680393704177,
+				"StableID":   "n4i2o2w5vx11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab23903e63e2612cb368380db7dbf13d95742e38ada9ef8b848d6ef9aac8730a",
+				"DiscoKey":   "discokey:399ba9cde79b89e5cc69a159f7df17b610f0431f688c0191113f36ed46f3bb1d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41268",
+					"10.65.0.27:41268",
+					"172.17.0.1:41268",
+					"172.18.0.1:41268",
+					"172.19.0.1:41268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:09:17.870267785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1014096996010250,
+				"StableID":   "ny4gvHcHv811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:71e2d791870f7e9467d5e8f500ce49cb9182d618bb436e27043e69590b09721c",
+				"DiscoKey":   "discokey:06bdef47dea8c16d845fc563964895e5386827e98d10a4a1501276e3b65abb65",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:60739",
+					"10.65.0.27:60739",
+					"172.17.0.1:60739",
+					"172.18.0.1:60739",
+					"172.19.0.1:60739"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:09:18.39882372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3739658176931298,
+				"StableID":   "n9LnEnUhCW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:50785bf6a6e450d14eb4dc29bf2050e9630d655fc1096ef047c9fab484aa9450",
+				"KeyExpiry":  "2026-11-08T22:09:18Z",
+				"DiscoKey":   "discokey:9ff0b1b874bb4c6e0bc48d9064624a224b180ffd210b955b1bd6e9029183fa08",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48911",
+					"10.65.0.27:48911",
+					"172.17.0.1:48911",
+					"172.18.0.1:48911",
+					"172.19.0.1:48911"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:09:18.941939275Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5104558182710938,
+				"StableID":   "nmWLs56srg11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:282367469425c3f1279bad959cf37db7ccdc7ccd99812b519870e2b94a468358",
+				"KeyExpiry":  "2026-11-08T22:09:19Z",
+				"DiscoKey":   "discokey:c2dc81af2357769a8335357bd8510c0cff79f0612e3f719998ee7be0acc4b921",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:37646",
+					"10.65.0.27:37646",
+					"172.17.0.1:37646",
+					"172.18.0.1:37646",
+					"172.19.0.1:37646"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:09:19.47634035Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6334121386671680,
+				"StableID":   "noJ7mRdjTr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d1ed5cb85fd631baed6c7bdd9c1a882407173be46293e77c6826dd55c05b487f",
+				"KeyExpiry":  "2026-11-08T22:09:20Z",
+				"DiscoKey":   "discokey:9566fb01babc305c0756818fe37e2c286336313ba65e95a5ea668a972ef36641",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57469",
+					"10.65.0.27:57469",
+					"172.17.0.1:57469",
+					"172.18.0.1:57469",
+					"172.19.0.1:57469"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:09:20.013704416Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8744378582905837": {
+				"ID":          8744378582905837,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         815682844870495,
+				"StableID":   "nNSwp6cRN711CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       815682844870495,
+				"Key":        "nodekey:9eecde188381106cc7fd8164e5dedcd3d30fb65b7220cb8bd3328ec34af30d06",
+				"DiscoKey":   "discokey:238e176e67c3dbfbbaac3f772e197565fbda633d9e463bffdefe6909ee418578",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41506",
+					"10.65.0.27:41506",
+					"172.17.0.1:41506",
+					"172.18.0.1:41506",
+					"172.19.0.1:41506"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:09:15.691990771Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9eecde188381106cc7fd8164e5dedcd3d30fb65b7220cb8bd3328ec34af30d06",
+			"MachineKey": "mkey:a559da1268f73bd4ae1dbeb794a790b17678325faa37786153fa840cf761ef60",
+			"Peers": [{
+				"ID":         8114526209130773,
+				"StableID":   "nAsFDwq5N621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36c3161fd2ed824e8d0fba111f0ccfe357821557414c144cf73993df56fcd04d",
+				"DiscoKey":   "discokey:226f22cb8a293d147dc2821044fad2cc35baa790dbc8d3e3a8f2bc535c640711",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53020",
+					"10.65.0.27:53020",
+					"172.17.0.1:53020",
+					"172.18.0.1:53020",
+					"172.19.0.1:53020"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:09:12.44836122Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3765173621324555,
+				"StableID":   "nJijg8jFQW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2fec3721b390e2a459cce4a956afa20311a8bd0e5a6f94d59437d8a7c13f7376",
+				"DiscoKey":   "discokey:e29a161a723179bca1c0237c4ad1a0107a89878288514e8a8925619aaacdc810",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37966",
+					"10.65.0.27:37966",
+					"172.17.0.1:37966",
+					"172.18.0.1:37966",
+					"172.19.0.1:37966"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:09:12.993659272Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5317069389681284,
+				"StableID":   "nhX1X1Q7Xi11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cfa615f6dda9cfba1cb32447207a5efdaa2735c11047274c871e968052f3bf4d",
+				"DiscoKey":   "discokey:815d00bb9dab4c4ca634b79b07258af096882f3b264b8759ce8d42eb462cf151",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46235",
+					"10.65.0.27:46235",
+					"172.17.0.1:46235",
+					"172.18.0.1:46235",
+					"172.19.0.1:46235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:09:13.536999204Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8744378582905837,
+				"StableID":   "n82verzLHB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6a6fc786c392186639010c788ffc4677601c790a7c4915ac22d03907d842c52b",
+				"DiscoKey":   "discokey:746fea6809b5055ea2e1644ef583b7a55c80da88e81c406aa40cea6af9281264",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43171",
+					"10.65.0.27:43171",
+					"172.17.0.1:43171",
+					"172.18.0.1:43171",
+					"172.19.0.1:43171"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:09:14.06939005Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         82504563779278,
+				"StableID":   "n5k6nnFNe111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4832fc8bdc2538f606b1b4575062f8f26c9ee1f4b310bdfd484fa2f3fc085f1a",
+				"DiscoKey":   "discokey:b1054f8731053d01e169bac1630150abaae24e31363af1dfbd828946e7b6ea0c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40406",
+					"10.65.0.27:40406",
+					"172.17.0.1:40406",
+					"172.18.0.1:40406",
+					"172.19.0.1:40406"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:09:14.616309494Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5036590610458473,
+				"StableID":   "nkWcFJh5Lg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7d1ea7849142081c4c4e5a5dd05f60b054f9b8175de35e4b9329ba20b2a40f0b",
+				"DiscoKey":   "discokey:6083afefe0536f29ba434bcdeb1bb7a0bca8a5099c4fa4a3af4a87136345be70",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44833",
+					"10.65.0.27:44833",
+					"172.17.0.1:44833",
+					"172.18.0.1:44833",
+					"172.19.0.1:44833"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:09:15.156392498Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         958424841452086,
+				"StableID":   "nXfWGLC5V811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d4e9f05e623e1f1bc07f34850443728e8cfe7f1cb9fde67d44afff6d276356f",
+				"DiscoKey":   "discokey:3c86649b4897a19187696e4230a8f7f8616343df3d6eca7ead9e29784f82fb11",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47236",
+					"10.65.0.27:47236",
+					"172.17.0.1:47236",
+					"172.18.0.1:47236",
+					"172.19.0.1:47236"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:09:16.23865548Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6441793196883902,
+				"StableID":   "nBsbv4zVJs11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4fad52354c0a559d66b44be7ffd056d626b8901d0d6d79982a57e318cb544765",
+				"DiscoKey":   "discokey:a5a869b40095fbebe796da064ce9ff984f64ace82ab3f783f5faaf71f128971d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:50338",
+					"10.65.0.27:50338",
+					"172.17.0.1:50338",
+					"172.18.0.1:50338",
+					"172.19.0.1:50338"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:09:16.780573933Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2958693032730856,
+				"StableID":   "nBaajErz6Q11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:014af8a5046c50dfad264fb4062da433b681f443de36da9617d0c86202dd1026",
+				"DiscoKey":   "discokey:b50015ae862bdf971ae0d941a0bd78da86c451a352a08fb4f9ac0e5f30c4ea77",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51718",
+					"10.65.0.27:51718",
+					"172.17.0.1:51718",
+					"172.18.0.1:51718",
+					"172.19.0.1:51718"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:09:17.321173151Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7160680393704177,
+				"StableID":   "n4i2o2w5vx11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab23903e63e2612cb368380db7dbf13d95742e38ada9ef8b848d6ef9aac8730a",
+				"DiscoKey":   "discokey:399ba9cde79b89e5cc69a159f7df17b610f0431f688c0191113f36ed46f3bb1d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41268",
+					"10.65.0.27:41268",
+					"172.17.0.1:41268",
+					"172.18.0.1:41268",
+					"172.19.0.1:41268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:09:17.870267785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1014096996010250,
+				"StableID":   "ny4gvHcHv811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:71e2d791870f7e9467d5e8f500ce49cb9182d618bb436e27043e69590b09721c",
+				"DiscoKey":   "discokey:06bdef47dea8c16d845fc563964895e5386827e98d10a4a1501276e3b65abb65",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:60739",
+					"10.65.0.27:60739",
+					"172.17.0.1:60739",
+					"172.18.0.1:60739",
+					"172.19.0.1:60739"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:09:18.39882372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3739658176931298,
+				"StableID":   "n9LnEnUhCW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:50785bf6a6e450d14eb4dc29bf2050e9630d655fc1096ef047c9fab484aa9450",
+				"KeyExpiry":  "2026-11-08T22:09:18Z",
+				"DiscoKey":   "discokey:9ff0b1b874bb4c6e0bc48d9064624a224b180ffd210b955b1bd6e9029183fa08",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48911",
+					"10.65.0.27:48911",
+					"172.17.0.1:48911",
+					"172.18.0.1:48911",
+					"172.19.0.1:48911"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:09:18.941939275Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5104558182710938,
+				"StableID":   "nmWLs56srg11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:282367469425c3f1279bad959cf37db7ccdc7ccd99812b519870e2b94a468358",
+				"KeyExpiry":  "2026-11-08T22:09:19Z",
+				"DiscoKey":   "discokey:c2dc81af2357769a8335357bd8510c0cff79f0612e3f719998ee7be0acc4b921",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:37646",
+					"10.65.0.27:37646",
+					"172.17.0.1:37646",
+					"172.18.0.1:37646",
+					"172.19.0.1:37646"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:09:19.47634035Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6334121386671680,
+				"StableID":   "noJ7mRdjTr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d1ed5cb85fd631baed6c7bdd9c1a882407173be46293e77c6826dd55c05b487f",
+				"KeyExpiry":  "2026-11-08T22:09:20Z",
+				"DiscoKey":   "discokey:9566fb01babc305c0756818fe37e2c286336313ba65e95a5ea668a972ef36641",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57469",
+					"10.65.0.27:57469",
+					"172.17.0.1:57469",
+					"172.18.0.1:57469",
+					"172.19.0.1:57469"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:09:20.013704416Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "815682844870495": {
+				"ID":          815682844870495,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6441793196883902,
+				"StableID":   "nBsbv4zVJs11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       6441793196883902,
+				"Key":        "nodekey:4fad52354c0a559d66b44be7ffd056d626b8901d0d6d79982a57e318cb544765",
+				"DiscoKey":   "discokey:a5a869b40095fbebe796da064ce9ff984f64ace82ab3f783f5faaf71f128971d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:50338",
+					"10.65.0.27:50338",
+					"172.17.0.1:50338",
+					"172.18.0.1:50338",
+					"172.19.0.1:50338"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:09:16.780573933Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4fad52354c0a559d66b44be7ffd056d626b8901d0d6d79982a57e318cb544765",
+			"MachineKey": "mkey:1fdddafc731a7109d070a5bb6fdd72f1eec76ef245831ee0118ec7dacd5d8645",
+			"Peers": [{
+				"ID":         8114526209130773,
+				"StableID":   "nAsFDwq5N621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36c3161fd2ed824e8d0fba111f0ccfe357821557414c144cf73993df56fcd04d",
+				"DiscoKey":   "discokey:226f22cb8a293d147dc2821044fad2cc35baa790dbc8d3e3a8f2bc535c640711",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53020",
+					"10.65.0.27:53020",
+					"172.17.0.1:53020",
+					"172.18.0.1:53020",
+					"172.19.0.1:53020"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:09:12.44836122Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3765173621324555,
+				"StableID":   "nJijg8jFQW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2fec3721b390e2a459cce4a956afa20311a8bd0e5a6f94d59437d8a7c13f7376",
+				"DiscoKey":   "discokey:e29a161a723179bca1c0237c4ad1a0107a89878288514e8a8925619aaacdc810",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37966",
+					"10.65.0.27:37966",
+					"172.17.0.1:37966",
+					"172.18.0.1:37966",
+					"172.19.0.1:37966"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:09:12.993659272Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5317069389681284,
+				"StableID":   "nhX1X1Q7Xi11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cfa615f6dda9cfba1cb32447207a5efdaa2735c11047274c871e968052f3bf4d",
+				"DiscoKey":   "discokey:815d00bb9dab4c4ca634b79b07258af096882f3b264b8759ce8d42eb462cf151",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46235",
+					"10.65.0.27:46235",
+					"172.17.0.1:46235",
+					"172.18.0.1:46235",
+					"172.19.0.1:46235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:09:13.536999204Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8744378582905837,
+				"StableID":   "n82verzLHB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6a6fc786c392186639010c788ffc4677601c790a7c4915ac22d03907d842c52b",
+				"DiscoKey":   "discokey:746fea6809b5055ea2e1644ef583b7a55c80da88e81c406aa40cea6af9281264",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43171",
+					"10.65.0.27:43171",
+					"172.17.0.1:43171",
+					"172.18.0.1:43171",
+					"172.19.0.1:43171"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:09:14.06939005Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         82504563779278,
+				"StableID":   "n5k6nnFNe111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4832fc8bdc2538f606b1b4575062f8f26c9ee1f4b310bdfd484fa2f3fc085f1a",
+				"DiscoKey":   "discokey:b1054f8731053d01e169bac1630150abaae24e31363af1dfbd828946e7b6ea0c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40406",
+					"10.65.0.27:40406",
+					"172.17.0.1:40406",
+					"172.18.0.1:40406",
+					"172.19.0.1:40406"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:09:14.616309494Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5036590610458473,
+				"StableID":   "nkWcFJh5Lg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7d1ea7849142081c4c4e5a5dd05f60b054f9b8175de35e4b9329ba20b2a40f0b",
+				"DiscoKey":   "discokey:6083afefe0536f29ba434bcdeb1bb7a0bca8a5099c4fa4a3af4a87136345be70",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44833",
+					"10.65.0.27:44833",
+					"172.17.0.1:44833",
+					"172.18.0.1:44833",
+					"172.19.0.1:44833"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:09:15.156392498Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         815682844870495,
+				"StableID":   "nNSwp6cRN711CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9eecde188381106cc7fd8164e5dedcd3d30fb65b7220cb8bd3328ec34af30d06",
+				"DiscoKey":   "discokey:238e176e67c3dbfbbaac3f772e197565fbda633d9e463bffdefe6909ee418578",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41506",
+					"10.65.0.27:41506",
+					"172.17.0.1:41506",
+					"172.18.0.1:41506",
+					"172.19.0.1:41506"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:09:15.691990771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         958424841452086,
+				"StableID":   "nXfWGLC5V811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d4e9f05e623e1f1bc07f34850443728e8cfe7f1cb9fde67d44afff6d276356f",
+				"DiscoKey":   "discokey:3c86649b4897a19187696e4230a8f7f8616343df3d6eca7ead9e29784f82fb11",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47236",
+					"10.65.0.27:47236",
+					"172.17.0.1:47236",
+					"172.18.0.1:47236",
+					"172.19.0.1:47236"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:09:16.23865548Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2958693032730856,
+				"StableID":   "nBaajErz6Q11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:014af8a5046c50dfad264fb4062da433b681f443de36da9617d0c86202dd1026",
+				"DiscoKey":   "discokey:b50015ae862bdf971ae0d941a0bd78da86c451a352a08fb4f9ac0e5f30c4ea77",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51718",
+					"10.65.0.27:51718",
+					"172.17.0.1:51718",
+					"172.18.0.1:51718",
+					"172.19.0.1:51718"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:09:17.321173151Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7160680393704177,
+				"StableID":   "n4i2o2w5vx11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab23903e63e2612cb368380db7dbf13d95742e38ada9ef8b848d6ef9aac8730a",
+				"DiscoKey":   "discokey:399ba9cde79b89e5cc69a159f7df17b610f0431f688c0191113f36ed46f3bb1d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41268",
+					"10.65.0.27:41268",
+					"172.17.0.1:41268",
+					"172.18.0.1:41268",
+					"172.19.0.1:41268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:09:17.870267785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1014096996010250,
+				"StableID":   "ny4gvHcHv811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:71e2d791870f7e9467d5e8f500ce49cb9182d618bb436e27043e69590b09721c",
+				"DiscoKey":   "discokey:06bdef47dea8c16d845fc563964895e5386827e98d10a4a1501276e3b65abb65",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:60739",
+					"10.65.0.27:60739",
+					"172.17.0.1:60739",
+					"172.18.0.1:60739",
+					"172.19.0.1:60739"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:09:18.39882372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3739658176931298,
+				"StableID":   "n9LnEnUhCW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:50785bf6a6e450d14eb4dc29bf2050e9630d655fc1096ef047c9fab484aa9450",
+				"KeyExpiry":  "2026-11-08T22:09:18Z",
+				"DiscoKey":   "discokey:9ff0b1b874bb4c6e0bc48d9064624a224b180ffd210b955b1bd6e9029183fa08",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48911",
+					"10.65.0.27:48911",
+					"172.17.0.1:48911",
+					"172.18.0.1:48911",
+					"172.19.0.1:48911"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:09:18.941939275Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5104558182710938,
+				"StableID":   "nmWLs56srg11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:282367469425c3f1279bad959cf37db7ccdc7ccd99812b519870e2b94a468358",
+				"KeyExpiry":  "2026-11-08T22:09:19Z",
+				"DiscoKey":   "discokey:c2dc81af2357769a8335357bd8510c0cff79f0612e3f719998ee7be0acc4b921",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:37646",
+					"10.65.0.27:37646",
+					"172.17.0.1:37646",
+					"172.18.0.1:37646",
+					"172.19.0.1:37646"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:09:19.47634035Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6334121386671680,
+				"StableID":   "noJ7mRdjTr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d1ed5cb85fd631baed6c7bdd9c1a882407173be46293e77c6826dd55c05b487f",
+				"KeyExpiry":  "2026-11-08T22:09:20Z",
+				"DiscoKey":   "discokey:9566fb01babc305c0756818fe37e2c286336313ba65e95a5ea668a972ef36641",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57469",
+					"10.65.0.27:57469",
+					"172.17.0.1:57469",
+					"172.18.0.1:57469",
+					"172.19.0.1:57469"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:09:20.013704416Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6441793196883902": {
+				"ID":          6441793196883902,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5104558182710938,
+				"StableID":   "nmWLs56srg11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:282367469425c3f1279bad959cf37db7ccdc7ccd99812b519870e2b94a468358",
+				"KeyExpiry":  "2026-11-08T22:09:19Z",
+				"DiscoKey":   "discokey:c2dc81af2357769a8335357bd8510c0cff79f0612e3f719998ee7be0acc4b921",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:37646",
+					"10.65.0.27:37646",
+					"172.17.0.1:37646",
+					"172.18.0.1:37646",
+					"172.19.0.1:37646"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:09:19.47634035Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:282367469425c3f1279bad959cf37db7ccdc7ccd99812b519870e2b94a468358",
+			"MachineKey": "mkey:7a4f92c4a9fe346593d89c848e58abe3849b95587491af48b445d5aa00b87c71",
+			"Peers": [{
+				"ID":         8114526209130773,
+				"StableID":   "nAsFDwq5N621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36c3161fd2ed824e8d0fba111f0ccfe357821557414c144cf73993df56fcd04d",
+				"DiscoKey":   "discokey:226f22cb8a293d147dc2821044fad2cc35baa790dbc8d3e3a8f2bc535c640711",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53020",
+					"10.65.0.27:53020",
+					"172.17.0.1:53020",
+					"172.18.0.1:53020",
+					"172.19.0.1:53020"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:09:12.44836122Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3765173621324555,
+				"StableID":   "nJijg8jFQW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2fec3721b390e2a459cce4a956afa20311a8bd0e5a6f94d59437d8a7c13f7376",
+				"DiscoKey":   "discokey:e29a161a723179bca1c0237c4ad1a0107a89878288514e8a8925619aaacdc810",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37966",
+					"10.65.0.27:37966",
+					"172.17.0.1:37966",
+					"172.18.0.1:37966",
+					"172.19.0.1:37966"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:09:12.993659272Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5317069389681284,
+				"StableID":   "nhX1X1Q7Xi11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cfa615f6dda9cfba1cb32447207a5efdaa2735c11047274c871e968052f3bf4d",
+				"DiscoKey":   "discokey:815d00bb9dab4c4ca634b79b07258af096882f3b264b8759ce8d42eb462cf151",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46235",
+					"10.65.0.27:46235",
+					"172.17.0.1:46235",
+					"172.18.0.1:46235",
+					"172.19.0.1:46235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:09:13.536999204Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8744378582905837,
+				"StableID":   "n82verzLHB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6a6fc786c392186639010c788ffc4677601c790a7c4915ac22d03907d842c52b",
+				"DiscoKey":   "discokey:746fea6809b5055ea2e1644ef583b7a55c80da88e81c406aa40cea6af9281264",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43171",
+					"10.65.0.27:43171",
+					"172.17.0.1:43171",
+					"172.18.0.1:43171",
+					"172.19.0.1:43171"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:09:14.06939005Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         82504563779278,
+				"StableID":   "n5k6nnFNe111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4832fc8bdc2538f606b1b4575062f8f26c9ee1f4b310bdfd484fa2f3fc085f1a",
+				"DiscoKey":   "discokey:b1054f8731053d01e169bac1630150abaae24e31363af1dfbd828946e7b6ea0c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40406",
+					"10.65.0.27:40406",
+					"172.17.0.1:40406",
+					"172.18.0.1:40406",
+					"172.19.0.1:40406"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:09:14.616309494Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5036590610458473,
+				"StableID":   "nkWcFJh5Lg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7d1ea7849142081c4c4e5a5dd05f60b054f9b8175de35e4b9329ba20b2a40f0b",
+				"DiscoKey":   "discokey:6083afefe0536f29ba434bcdeb1bb7a0bca8a5099c4fa4a3af4a87136345be70",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44833",
+					"10.65.0.27:44833",
+					"172.17.0.1:44833",
+					"172.18.0.1:44833",
+					"172.19.0.1:44833"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:09:15.156392498Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         815682844870495,
+				"StableID":   "nNSwp6cRN711CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9eecde188381106cc7fd8164e5dedcd3d30fb65b7220cb8bd3328ec34af30d06",
+				"DiscoKey":   "discokey:238e176e67c3dbfbbaac3f772e197565fbda633d9e463bffdefe6909ee418578",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41506",
+					"10.65.0.27:41506",
+					"172.17.0.1:41506",
+					"172.18.0.1:41506",
+					"172.19.0.1:41506"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:09:15.691990771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         958424841452086,
+				"StableID":   "nXfWGLC5V811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d4e9f05e623e1f1bc07f34850443728e8cfe7f1cb9fde67d44afff6d276356f",
+				"DiscoKey":   "discokey:3c86649b4897a19187696e4230a8f7f8616343df3d6eca7ead9e29784f82fb11",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47236",
+					"10.65.0.27:47236",
+					"172.17.0.1:47236",
+					"172.18.0.1:47236",
+					"172.19.0.1:47236"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:09:16.23865548Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6441793196883902,
+				"StableID":   "nBsbv4zVJs11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4fad52354c0a559d66b44be7ffd056d626b8901d0d6d79982a57e318cb544765",
+				"DiscoKey":   "discokey:a5a869b40095fbebe796da064ce9ff984f64ace82ab3f783f5faaf71f128971d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:50338",
+					"10.65.0.27:50338",
+					"172.17.0.1:50338",
+					"172.18.0.1:50338",
+					"172.19.0.1:50338"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:09:16.780573933Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2958693032730856,
+				"StableID":   "nBaajErz6Q11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:014af8a5046c50dfad264fb4062da433b681f443de36da9617d0c86202dd1026",
+				"DiscoKey":   "discokey:b50015ae862bdf971ae0d941a0bd78da86c451a352a08fb4f9ac0e5f30c4ea77",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51718",
+					"10.65.0.27:51718",
+					"172.17.0.1:51718",
+					"172.18.0.1:51718",
+					"172.19.0.1:51718"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:09:17.321173151Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7160680393704177,
+				"StableID":   "n4i2o2w5vx11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab23903e63e2612cb368380db7dbf13d95742e38ada9ef8b848d6ef9aac8730a",
+				"DiscoKey":   "discokey:399ba9cde79b89e5cc69a159f7df17b610f0431f688c0191113f36ed46f3bb1d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41268",
+					"10.65.0.27:41268",
+					"172.17.0.1:41268",
+					"172.18.0.1:41268",
+					"172.19.0.1:41268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:09:17.870267785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1014096996010250,
+				"StableID":   "ny4gvHcHv811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:71e2d791870f7e9467d5e8f500ce49cb9182d618bb436e27043e69590b09721c",
+				"DiscoKey":   "discokey:06bdef47dea8c16d845fc563964895e5386827e98d10a4a1501276e3b65abb65",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:60739",
+					"10.65.0.27:60739",
+					"172.17.0.1:60739",
+					"172.18.0.1:60739",
+					"172.19.0.1:60739"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:09:18.39882372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3739658176931298,
+				"StableID":   "n9LnEnUhCW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:50785bf6a6e450d14eb4dc29bf2050e9630d655fc1096ef047c9fab484aa9450",
+				"KeyExpiry":  "2026-11-08T22:09:18Z",
+				"DiscoKey":   "discokey:9ff0b1b874bb4c6e0bc48d9064624a224b180ffd210b955b1bd6e9029183fa08",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48911",
+					"10.65.0.27:48911",
+					"172.17.0.1:48911",
+					"172.18.0.1:48911",
+					"172.19.0.1:48911"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:09:18.941939275Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6334121386671680,
+				"StableID":   "noJ7mRdjTr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d1ed5cb85fd631baed6c7bdd9c1a882407173be46293e77c6826dd55c05b487f",
+				"KeyExpiry":  "2026-11-08T22:09:20Z",
+				"DiscoKey":   "discokey:9566fb01babc305c0756818fe37e2c286336313ba65e95a5ea668a972ef36641",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57469",
+					"10.65.0.27:57469",
+					"172.17.0.1:57469",
+					"172.18.0.1:57469",
+					"172.19.0.1:57469"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:09:20.013704416Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2958693032730856,
+				"StableID":   "nBaajErz6Q11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       2958693032730856,
+				"Key":        "nodekey:014af8a5046c50dfad264fb4062da433b681f443de36da9617d0c86202dd1026",
+				"DiscoKey":   "discokey:b50015ae862bdf971ae0d941a0bd78da86c451a352a08fb4f9ac0e5f30c4ea77",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51718",
+					"10.65.0.27:51718",
+					"172.17.0.1:51718",
+					"172.18.0.1:51718",
+					"172.19.0.1:51718"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:09:17.321173151Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:014af8a5046c50dfad264fb4062da433b681f443de36da9617d0c86202dd1026",
+			"MachineKey": "mkey:f105264effce5ffef7b05a23bc6301cfb89990407424d9ec94e57f506742c109",
+			"Peers": [{
+				"ID":         8114526209130773,
+				"StableID":   "nAsFDwq5N621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36c3161fd2ed824e8d0fba111f0ccfe357821557414c144cf73993df56fcd04d",
+				"DiscoKey":   "discokey:226f22cb8a293d147dc2821044fad2cc35baa790dbc8d3e3a8f2bc535c640711",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53020",
+					"10.65.0.27:53020",
+					"172.17.0.1:53020",
+					"172.18.0.1:53020",
+					"172.19.0.1:53020"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:09:12.44836122Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3765173621324555,
+				"StableID":   "nJijg8jFQW11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2fec3721b390e2a459cce4a956afa20311a8bd0e5a6f94d59437d8a7c13f7376",
+				"DiscoKey":   "discokey:e29a161a723179bca1c0237c4ad1a0107a89878288514e8a8925619aaacdc810",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37966",
+					"10.65.0.27:37966",
+					"172.17.0.1:37966",
+					"172.18.0.1:37966",
+					"172.19.0.1:37966"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:09:12.993659272Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5317069389681284,
+				"StableID":   "nhX1X1Q7Xi11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cfa615f6dda9cfba1cb32447207a5efdaa2735c11047274c871e968052f3bf4d",
+				"DiscoKey":   "discokey:815d00bb9dab4c4ca634b79b07258af096882f3b264b8759ce8d42eb462cf151",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46235",
+					"10.65.0.27:46235",
+					"172.17.0.1:46235",
+					"172.18.0.1:46235",
+					"172.19.0.1:46235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:09:13.536999204Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8744378582905837,
+				"StableID":   "n82verzLHB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6a6fc786c392186639010c788ffc4677601c790a7c4915ac22d03907d842c52b",
+				"DiscoKey":   "discokey:746fea6809b5055ea2e1644ef583b7a55c80da88e81c406aa40cea6af9281264",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43171",
+					"10.65.0.27:43171",
+					"172.17.0.1:43171",
+					"172.18.0.1:43171",
+					"172.19.0.1:43171"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:09:14.06939005Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         82504563779278,
+				"StableID":   "n5k6nnFNe111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4832fc8bdc2538f606b1b4575062f8f26c9ee1f4b310bdfd484fa2f3fc085f1a",
+				"DiscoKey":   "discokey:b1054f8731053d01e169bac1630150abaae24e31363af1dfbd828946e7b6ea0c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40406",
+					"10.65.0.27:40406",
+					"172.17.0.1:40406",
+					"172.18.0.1:40406",
+					"172.19.0.1:40406"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:09:14.616309494Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5036590610458473,
+				"StableID":   "nkWcFJh5Lg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7d1ea7849142081c4c4e5a5dd05f60b054f9b8175de35e4b9329ba20b2a40f0b",
+				"DiscoKey":   "discokey:6083afefe0536f29ba434bcdeb1bb7a0bca8a5099c4fa4a3af4a87136345be70",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44833",
+					"10.65.0.27:44833",
+					"172.17.0.1:44833",
+					"172.18.0.1:44833",
+					"172.19.0.1:44833"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:09:15.156392498Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         815682844870495,
+				"StableID":   "nNSwp6cRN711CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9eecde188381106cc7fd8164e5dedcd3d30fb65b7220cb8bd3328ec34af30d06",
+				"DiscoKey":   "discokey:238e176e67c3dbfbbaac3f772e197565fbda633d9e463bffdefe6909ee418578",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41506",
+					"10.65.0.27:41506",
+					"172.17.0.1:41506",
+					"172.18.0.1:41506",
+					"172.19.0.1:41506"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:09:15.691990771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         958424841452086,
+				"StableID":   "nXfWGLC5V811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d4e9f05e623e1f1bc07f34850443728e8cfe7f1cb9fde67d44afff6d276356f",
+				"DiscoKey":   "discokey:3c86649b4897a19187696e4230a8f7f8616343df3d6eca7ead9e29784f82fb11",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47236",
+					"10.65.0.27:47236",
+					"172.17.0.1:47236",
+					"172.18.0.1:47236",
+					"172.19.0.1:47236"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:09:16.23865548Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6441793196883902,
+				"StableID":   "nBsbv4zVJs11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4fad52354c0a559d66b44be7ffd056d626b8901d0d6d79982a57e318cb544765",
+				"DiscoKey":   "discokey:a5a869b40095fbebe796da064ce9ff984f64ace82ab3f783f5faaf71f128971d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:50338",
+					"10.65.0.27:50338",
+					"172.17.0.1:50338",
+					"172.18.0.1:50338",
+					"172.19.0.1:50338"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:09:16.780573933Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7160680393704177,
+				"StableID":   "n4i2o2w5vx11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab23903e63e2612cb368380db7dbf13d95742e38ada9ef8b848d6ef9aac8730a",
+				"DiscoKey":   "discokey:399ba9cde79b89e5cc69a159f7df17b610f0431f688c0191113f36ed46f3bb1d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41268",
+					"10.65.0.27:41268",
+					"172.17.0.1:41268",
+					"172.18.0.1:41268",
+					"172.19.0.1:41268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:09:17.870267785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1014096996010250,
+				"StableID":   "ny4gvHcHv811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:71e2d791870f7e9467d5e8f500ce49cb9182d618bb436e27043e69590b09721c",
+				"DiscoKey":   "discokey:06bdef47dea8c16d845fc563964895e5386827e98d10a4a1501276e3b65abb65",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:60739",
+					"10.65.0.27:60739",
+					"172.17.0.1:60739",
+					"172.18.0.1:60739",
+					"172.19.0.1:60739"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:09:18.39882372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3739658176931298,
+				"StableID":   "n9LnEnUhCW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:50785bf6a6e450d14eb4dc29bf2050e9630d655fc1096ef047c9fab484aa9450",
+				"KeyExpiry":  "2026-11-08T22:09:18Z",
+				"DiscoKey":   "discokey:9ff0b1b874bb4c6e0bc48d9064624a224b180ffd210b955b1bd6e9029183fa08",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48911",
+					"10.65.0.27:48911",
+					"172.17.0.1:48911",
+					"172.18.0.1:48911",
+					"172.19.0.1:48911"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:09:18.941939275Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5104558182710938,
+				"StableID":   "nmWLs56srg11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:282367469425c3f1279bad959cf37db7ccdc7ccd99812b519870e2b94a468358",
+				"KeyExpiry":  "2026-11-08T22:09:19Z",
+				"DiscoKey":   "discokey:c2dc81af2357769a8335357bd8510c0cff79f0612e3f719998ee7be0acc4b921",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:37646",
+					"10.65.0.27:37646",
+					"172.17.0.1:37646",
+					"172.18.0.1:37646",
+					"172.19.0.1:37646"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:09:19.47634035Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6334121386671680,
+				"StableID":   "noJ7mRdjTr11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d1ed5cb85fd631baed6c7bdd9c1a882407173be46293e77c6826dd55c05b487f",
+				"KeyExpiry":  "2026-11-08T22:09:20Z",
+				"DiscoKey":   "discokey:9566fb01babc305c0756818fe37e2c286336313ba65e95a5ea668a972ef36641",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57469",
+					"10.65.0.27:57469",
+					"172.17.0.1:57469",
+					"172.18.0.1:57469",
+					"172.19.0.1:57469"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:09:20.013704416Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2958693032730856": {
+				"ID":          2958693032730856,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-user-localpart-no-glob.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-user-localpart-no-glob.hujson
@@ -1,0 +1,20112 @@
+// ssh-malformed-user-localpart-no-glob
+//
+// ssh users localpart without glob is rejected
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T22:10:05Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-malformed-user-localpart-no-glob",
+	"description":    "ssh users localpart without glob is rejected",
+	"category":       "ssh",
+	"captured_at":    "2026-05-12T22:10:05.317473545Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                       \n  \n                                                                         \n                                                       \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh users localpart without glob is rejected\",\n\t\"id\":          \"ssh-malformed-user-localpart-no-glob\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"autogroup:member\"],\n\t\t\"users\":  [\"localpart:foo@example.com\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-malformed/ssh-malformed-user-localpart-no-glob.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["autogroup:member"],
+				"users":  ["localpart:foo@example.com"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5206214371150158,
+				"StableID":   "nF5q8ZRueh11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       5206214371150158,
+				"Key":        "nodekey:a6bb0978f30fa6e555b62205c811d1777b4adb705c3032ae0657112f9bd64a11",
+				"DiscoKey":   "discokey:6b22ca8eaa72bd673178b7a1b17153a475284d19c715ffaae8c2345b0cb9d472",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:50596",
+					"10.65.0.27:50596",
+					"172.17.0.1:50596",
+					"172.18.0.1:50596",
+					"172.19.0.1:50596"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:10:13.857173041Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a6bb0978f30fa6e555b62205c811d1777b4adb705c3032ae0657112f9bd64a11",
+			"MachineKey": "mkey:de00e6220685ec2a2da726214ee8204edc0d2f5c12f68c7a37aeb4c023417443",
+			"Peers": [{
+				"ID":         1285669455896445,
+				"StableID":   "nGpTFgMH3B11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10a7c49f80abd134e5539c63738d03d39fa93be860666215284e71441c515576",
+				"DiscoKey":   "discokey:c6839589c5ece4d9f89e9153c1afde8e825fc91b7c08ccff380b03dc6690084b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51162",
+					"10.65.0.27:51162",
+					"172.17.0.1:51162",
+					"172.18.0.1:51162",
+					"172.19.0.1:51162"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:10:07.902843125Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1368026745604867,
+				"StableID":   "n8FTv5kagB11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:61f59d38c73b144a51c001fd7713e6a38ae340b48656d1665db9424996657d38",
+				"DiscoKey":   "discokey:8bcbd57526c2e786167b7515fae3962320a24288d359301e438abaede6f7d868",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:60071",
+					"10.65.0.27:60071",
+					"172.17.0.1:60071",
+					"172.18.0.1:60071",
+					"172.19.0.1:60071"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:10:08.428579986Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4439465031872978,
+				"StableID":   "n7ohdfDefb11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7d0a51dfebb9b70b759a499bdb896573ccffcb7759036f9675cebb81a834a546",
+				"DiscoKey":   "discokey:9fd20abd384b4d53e3f9bfe8798db9c765911125cbbf1302b0391286fcd50e2f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33535",
+					"10.65.0.27:33535",
+					"172.17.0.1:33535",
+					"172.18.0.1:33535",
+					"172.19.0.1:33535"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:10:08.980804027Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3173123217679596,
+				"StableID":   "noNztqZ7nR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26c4da7100063a53f65d723dad899d463193b16628f6a63fa1ac4a9f87e8097f",
+				"DiscoKey":   "discokey:f0c957795eb196daa64268f646814f38e3a63e9ef64abe35fa06c4e0155b9776",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43132",
+					"10.65.0.27:43132",
+					"172.17.0.1:43132",
+					"172.18.0.1:43132",
+					"172.19.0.1:43132"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:10:09.523013351Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7454394752163285,
+				"StableID":   "n82esxJ7D121CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e420a14a9333217f54880096fed459f3667b056e86fd21b4ca1720d6ce095d42",
+				"DiscoKey":   "discokey:247cd9ca1b1b7f6ceee403624ad0f9e518b338dc6acf2006f5923191c85a7f37",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56797",
+					"10.65.0.27:56797",
+					"172.17.0.1:56797",
+					"172.18.0.1:56797",
+					"172.19.0.1:56797"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:10:10.062488879Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2815166818795474,
+				"StableID":   "nZn5hCfzyN11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a01509e1daef84a506cda8d6ee4a0d01c1198376d3c9694a248e5ecd666f5635",
+				"DiscoKey":   "discokey:91f509159d94eae866cb515a76fab9ee1239330adbd2f4ad100aa18089835c62",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40108",
+					"10.65.0.27:40108",
+					"172.17.0.1:40108",
+					"172.18.0.1:40108",
+					"172.19.0.1:40108"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:10:10.606982354Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7725211482286916,
+				"StableID":   "nwarwwCmK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c2aebd25a98733db00b877fc575773e5449993751e4b8199c3d3d20599ca471f",
+				"DiscoKey":   "discokey:2b9732a96bb41c9cc548bd15a8ca2fa013c1e98959ddd8c8df801c0008dfe705",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37604",
+					"10.65.0.27:37604",
+					"172.17.0.1:37604",
+					"172.18.0.1:37604",
+					"172.19.0.1:37604"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:10:11.140656048Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1773556953774490,
+				"StableID":   "nhnBkMLFrE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:596ec62125e92c83b1534db2856624ce30f87c80b0b538cec0f4c7aa982b5e40",
+				"DiscoKey":   "discokey:d93ad9b922bed652bfcde9baa8110cead44edbc0d58d2c23629f9fd1fa542438",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42973",
+					"10.65.0.27:42973",
+					"172.17.0.1:42973",
+					"172.18.0.1:42973",
+					"172.19.0.1:42973"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:10:11.703069243Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5380620594659572,
+				"StableID":   "nqq4tBnt1j11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d68aba78ad1eb1ab182e269ea2905653d061a0fa42536a4d4e23443366d1a74",
+				"DiscoKey":   "discokey:59d53817b16394419c1710400c77b0f15581695ba7ab815fc7c6e4764f940236",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53362",
+					"10.65.0.27:53362",
+					"172.17.0.1:53362",
+					"172.18.0.1:53362",
+					"172.19.0.1:53362"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:10:12.27683435Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5100797787866282,
+				"StableID":   "nPPqetJAqg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b0f9bd19345ce959e99209d857f0ad7914aa942ae4a259207d8cc37f26d0c24",
+				"DiscoKey":   "discokey:7f51315fdb94f8ed42c36342a9be730c76bbcfe20e0c85bf5560b69fd8e11451",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:39534",
+					"10.65.0.27:39534",
+					"172.17.0.1:39534",
+					"172.18.0.1:39534",
+					"172.19.0.1:39534"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:10:12.773184225Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2411809109152787,
+				"StableID":   "n4bA8s8KqK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe59a6e2ed236121da85027bfab0494236ddf0ae5da1438556327453125b8e6d",
+				"DiscoKey":   "discokey:5d59101df49496f8b5bc458ff87a88d78eafa47f11f5d0538aed0456cc863261",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:52689",
+					"10.65.0.27:52689",
+					"172.17.0.1:52689",
+					"172.18.0.1:52689",
+					"172.19.0.1:52689"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:10:13.307985572Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2248751212648568,
+				"StableID":   "nsg9B7tTZJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8ce2a9929033e7885055484e70f27adc51fa108cc6951921b9494e07bee72920",
+				"KeyExpiry":  "2026-11-08T22:10:14Z",
+				"DiscoKey":   "discokey:0c1a650e38303f00b4ffad5473f7f6fbbc17e4ccec293dea3a6b5949be8f5a37",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35549",
+					"10.65.0.27:35549",
+					"172.17.0.1:35549",
+					"172.18.0.1:35549",
+					"172.19.0.1:35549"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:10:14.437533871Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7846791554217952,
+				"StableID":   "nwa7agupG421CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:17ce140a9b6fb018394505188400cb5692eac30ac1d9936a1778466297d3bc42",
+				"KeyExpiry":  "2026-11-08T22:10:14Z",
+				"DiscoKey":   "discokey:bf278ed76bff01487b02ad3732433de82e57a02ffdd890283fd795145007161e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50054",
+					"10.65.0.27:50054",
+					"172.17.0.1:50054",
+					"172.18.0.1:50054",
+					"172.19.0.1:50054"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:10:14.931331045Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3029086976321069,
+				"StableID":   "n4ndUkyseQ11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:15613e4e4741e0dbef497a1fafd29461e9362a74fd9dd84f4859c379350db217",
+				"KeyExpiry":  "2026-11-08T22:10:15Z",
+				"DiscoKey":   "discokey:a201876356a1bc03ec0ffeb2db319cab59d419c1c274b5b5e60243670f45f440",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33971",
+					"10.65.0.27:33971",
+					"172.17.0.1:33971",
+					"172.18.0.1:33971",
+					"172.19.0.1:33971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:10:15.471723426Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{
+				"principals": [
+					{"nodeIP": "100.64.0.17"},
+					{"nodeIP": "100.64.0.18"},
+					{"nodeIP": "100.64.0.19"},
+					{"nodeIP": "fd7a:115c:a1e0::13"},
+					{"nodeIP": "fd7a:115c:a1e0::12"},
+					{"nodeIP": "fd7a:115c:a1e0::11"}
+				],
+				"sshUsers": {"localpart:foo@example.com": "localpart:foo@example.com", "root": ""},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				}
+			}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5206214371150158": {
+				"ID":          5206214371150158,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		},
+		"ssh_rules": [{
+			"principals": [
+				{"nodeIP": "100.64.0.17"},
+				{"nodeIP": "100.64.0.18"},
+				{"nodeIP": "100.64.0.19"},
+				{"nodeIP": "fd7a:115c:a1e0::13"},
+				{"nodeIP": "fd7a:115c:a1e0::12"},
+				{"nodeIP": "fd7a:115c:a1e0::11"}
+			],
+			"sshUsers": {"localpart:foo@example.com": "localpart:foo@example.com", "root": ""},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}
+		}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2815166818795474,
+				"StableID":   "nZn5hCfzyN11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       2815166818795474,
+				"Key":        "nodekey:a01509e1daef84a506cda8d6ee4a0d01c1198376d3c9694a248e5ecd666f5635",
+				"DiscoKey":   "discokey:91f509159d94eae866cb515a76fab9ee1239330adbd2f4ad100aa18089835c62",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40108",
+					"10.65.0.27:40108",
+					"172.17.0.1:40108",
+					"172.18.0.1:40108",
+					"172.19.0.1:40108"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:10:10.606982354Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a01509e1daef84a506cda8d6ee4a0d01c1198376d3c9694a248e5ecd666f5635",
+			"MachineKey": "mkey:411aee118ff421bc30aa498b23c5db199d75685af7c586273cc3b2bf0ea78907",
+			"Peers": [{
+				"ID":         1285669455896445,
+				"StableID":   "nGpTFgMH3B11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10a7c49f80abd134e5539c63738d03d39fa93be860666215284e71441c515576",
+				"DiscoKey":   "discokey:c6839589c5ece4d9f89e9153c1afde8e825fc91b7c08ccff380b03dc6690084b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51162",
+					"10.65.0.27:51162",
+					"172.17.0.1:51162",
+					"172.18.0.1:51162",
+					"172.19.0.1:51162"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:10:07.902843125Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1368026745604867,
+				"StableID":   "n8FTv5kagB11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:61f59d38c73b144a51c001fd7713e6a38ae340b48656d1665db9424996657d38",
+				"DiscoKey":   "discokey:8bcbd57526c2e786167b7515fae3962320a24288d359301e438abaede6f7d868",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:60071",
+					"10.65.0.27:60071",
+					"172.17.0.1:60071",
+					"172.18.0.1:60071",
+					"172.19.0.1:60071"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:10:08.428579986Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4439465031872978,
+				"StableID":   "n7ohdfDefb11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7d0a51dfebb9b70b759a499bdb896573ccffcb7759036f9675cebb81a834a546",
+				"DiscoKey":   "discokey:9fd20abd384b4d53e3f9bfe8798db9c765911125cbbf1302b0391286fcd50e2f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33535",
+					"10.65.0.27:33535",
+					"172.17.0.1:33535",
+					"172.18.0.1:33535",
+					"172.19.0.1:33535"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:10:08.980804027Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3173123217679596,
+				"StableID":   "noNztqZ7nR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26c4da7100063a53f65d723dad899d463193b16628f6a63fa1ac4a9f87e8097f",
+				"DiscoKey":   "discokey:f0c957795eb196daa64268f646814f38e3a63e9ef64abe35fa06c4e0155b9776",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43132",
+					"10.65.0.27:43132",
+					"172.17.0.1:43132",
+					"172.18.0.1:43132",
+					"172.19.0.1:43132"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:10:09.523013351Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7454394752163285,
+				"StableID":   "n82esxJ7D121CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e420a14a9333217f54880096fed459f3667b056e86fd21b4ca1720d6ce095d42",
+				"DiscoKey":   "discokey:247cd9ca1b1b7f6ceee403624ad0f9e518b338dc6acf2006f5923191c85a7f37",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56797",
+					"10.65.0.27:56797",
+					"172.17.0.1:56797",
+					"172.18.0.1:56797",
+					"172.19.0.1:56797"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:10:10.062488879Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7725211482286916,
+				"StableID":   "nwarwwCmK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c2aebd25a98733db00b877fc575773e5449993751e4b8199c3d3d20599ca471f",
+				"DiscoKey":   "discokey:2b9732a96bb41c9cc548bd15a8ca2fa013c1e98959ddd8c8df801c0008dfe705",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37604",
+					"10.65.0.27:37604",
+					"172.17.0.1:37604",
+					"172.18.0.1:37604",
+					"172.19.0.1:37604"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:10:11.140656048Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1773556953774490,
+				"StableID":   "nhnBkMLFrE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:596ec62125e92c83b1534db2856624ce30f87c80b0b538cec0f4c7aa982b5e40",
+				"DiscoKey":   "discokey:d93ad9b922bed652bfcde9baa8110cead44edbc0d58d2c23629f9fd1fa542438",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42973",
+					"10.65.0.27:42973",
+					"172.17.0.1:42973",
+					"172.18.0.1:42973",
+					"172.19.0.1:42973"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:10:11.703069243Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5380620594659572,
+				"StableID":   "nqq4tBnt1j11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d68aba78ad1eb1ab182e269ea2905653d061a0fa42536a4d4e23443366d1a74",
+				"DiscoKey":   "discokey:59d53817b16394419c1710400c77b0f15581695ba7ab815fc7c6e4764f940236",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53362",
+					"10.65.0.27:53362",
+					"172.17.0.1:53362",
+					"172.18.0.1:53362",
+					"172.19.0.1:53362"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:10:12.27683435Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5100797787866282,
+				"StableID":   "nPPqetJAqg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b0f9bd19345ce959e99209d857f0ad7914aa942ae4a259207d8cc37f26d0c24",
+				"DiscoKey":   "discokey:7f51315fdb94f8ed42c36342a9be730c76bbcfe20e0c85bf5560b69fd8e11451",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:39534",
+					"10.65.0.27:39534",
+					"172.17.0.1:39534",
+					"172.18.0.1:39534",
+					"172.19.0.1:39534"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:10:12.773184225Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2411809109152787,
+				"StableID":   "n4bA8s8KqK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe59a6e2ed236121da85027bfab0494236ddf0ae5da1438556327453125b8e6d",
+				"DiscoKey":   "discokey:5d59101df49496f8b5bc458ff87a88d78eafa47f11f5d0538aed0456cc863261",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:52689",
+					"10.65.0.27:52689",
+					"172.17.0.1:52689",
+					"172.18.0.1:52689",
+					"172.19.0.1:52689"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:10:13.307985572Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5206214371150158,
+				"StableID":   "nF5q8ZRueh11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6bb0978f30fa6e555b62205c811d1777b4adb705c3032ae0657112f9bd64a11",
+				"DiscoKey":   "discokey:6b22ca8eaa72bd673178b7a1b17153a475284d19c715ffaae8c2345b0cb9d472",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:50596",
+					"10.65.0.27:50596",
+					"172.17.0.1:50596",
+					"172.18.0.1:50596",
+					"172.19.0.1:50596"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:10:13.857173041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2248751212648568,
+				"StableID":   "nsg9B7tTZJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8ce2a9929033e7885055484e70f27adc51fa108cc6951921b9494e07bee72920",
+				"KeyExpiry":  "2026-11-08T22:10:14Z",
+				"DiscoKey":   "discokey:0c1a650e38303f00b4ffad5473f7f6fbbc17e4ccec293dea3a6b5949be8f5a37",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35549",
+					"10.65.0.27:35549",
+					"172.17.0.1:35549",
+					"172.18.0.1:35549",
+					"172.19.0.1:35549"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:10:14.437533871Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7846791554217952,
+				"StableID":   "nwa7agupG421CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:17ce140a9b6fb018394505188400cb5692eac30ac1d9936a1778466297d3bc42",
+				"KeyExpiry":  "2026-11-08T22:10:14Z",
+				"DiscoKey":   "discokey:bf278ed76bff01487b02ad3732433de82e57a02ffdd890283fd795145007161e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50054",
+					"10.65.0.27:50054",
+					"172.17.0.1:50054",
+					"172.18.0.1:50054",
+					"172.19.0.1:50054"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:10:14.931331045Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3029086976321069,
+				"StableID":   "n4ndUkyseQ11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:15613e4e4741e0dbef497a1fafd29461e9362a74fd9dd84f4859c379350db217",
+				"KeyExpiry":  "2026-11-08T22:10:15Z",
+				"DiscoKey":   "discokey:a201876356a1bc03ec0ffeb2db319cab59d419c1c274b5b5e60243670f45f440",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33971",
+					"10.65.0.27:33971",
+					"172.17.0.1:33971",
+					"172.18.0.1:33971",
+					"172.19.0.1:33971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:10:15.471723426Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2815166818795474": {
+				"ID":          2815166818795474,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3029086976321069,
+				"StableID":   "n4ndUkyseQ11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:15613e4e4741e0dbef497a1fafd29461e9362a74fd9dd84f4859c379350db217",
+				"KeyExpiry":  "2026-11-08T22:10:15Z",
+				"DiscoKey":   "discokey:a201876356a1bc03ec0ffeb2db319cab59d419c1c274b5b5e60243670f45f440",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33971",
+					"10.65.0.27:33971",
+					"172.17.0.1:33971",
+					"172.18.0.1:33971",
+					"172.19.0.1:33971"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:10:15.471723426Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:15613e4e4741e0dbef497a1fafd29461e9362a74fd9dd84f4859c379350db217",
+			"MachineKey": "mkey:34642caaa2e8e752e3fb7e74ea34d78d67cb00a573300b9356bfa9da2764880b",
+			"Peers": [{
+				"ID":         1285669455896445,
+				"StableID":   "nGpTFgMH3B11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10a7c49f80abd134e5539c63738d03d39fa93be860666215284e71441c515576",
+				"DiscoKey":   "discokey:c6839589c5ece4d9f89e9153c1afde8e825fc91b7c08ccff380b03dc6690084b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51162",
+					"10.65.0.27:51162",
+					"172.17.0.1:51162",
+					"172.18.0.1:51162",
+					"172.19.0.1:51162"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:10:07.902843125Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1368026745604867,
+				"StableID":   "n8FTv5kagB11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:61f59d38c73b144a51c001fd7713e6a38ae340b48656d1665db9424996657d38",
+				"DiscoKey":   "discokey:8bcbd57526c2e786167b7515fae3962320a24288d359301e438abaede6f7d868",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:60071",
+					"10.65.0.27:60071",
+					"172.17.0.1:60071",
+					"172.18.0.1:60071",
+					"172.19.0.1:60071"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:10:08.428579986Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4439465031872978,
+				"StableID":   "n7ohdfDefb11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7d0a51dfebb9b70b759a499bdb896573ccffcb7759036f9675cebb81a834a546",
+				"DiscoKey":   "discokey:9fd20abd384b4d53e3f9bfe8798db9c765911125cbbf1302b0391286fcd50e2f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33535",
+					"10.65.0.27:33535",
+					"172.17.0.1:33535",
+					"172.18.0.1:33535",
+					"172.19.0.1:33535"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:10:08.980804027Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3173123217679596,
+				"StableID":   "noNztqZ7nR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26c4da7100063a53f65d723dad899d463193b16628f6a63fa1ac4a9f87e8097f",
+				"DiscoKey":   "discokey:f0c957795eb196daa64268f646814f38e3a63e9ef64abe35fa06c4e0155b9776",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43132",
+					"10.65.0.27:43132",
+					"172.17.0.1:43132",
+					"172.18.0.1:43132",
+					"172.19.0.1:43132"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:10:09.523013351Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7454394752163285,
+				"StableID":   "n82esxJ7D121CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e420a14a9333217f54880096fed459f3667b056e86fd21b4ca1720d6ce095d42",
+				"DiscoKey":   "discokey:247cd9ca1b1b7f6ceee403624ad0f9e518b338dc6acf2006f5923191c85a7f37",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56797",
+					"10.65.0.27:56797",
+					"172.17.0.1:56797",
+					"172.18.0.1:56797",
+					"172.19.0.1:56797"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:10:10.062488879Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2815166818795474,
+				"StableID":   "nZn5hCfzyN11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a01509e1daef84a506cda8d6ee4a0d01c1198376d3c9694a248e5ecd666f5635",
+				"DiscoKey":   "discokey:91f509159d94eae866cb515a76fab9ee1239330adbd2f4ad100aa18089835c62",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40108",
+					"10.65.0.27:40108",
+					"172.17.0.1:40108",
+					"172.18.0.1:40108",
+					"172.19.0.1:40108"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:10:10.606982354Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7725211482286916,
+				"StableID":   "nwarwwCmK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c2aebd25a98733db00b877fc575773e5449993751e4b8199c3d3d20599ca471f",
+				"DiscoKey":   "discokey:2b9732a96bb41c9cc548bd15a8ca2fa013c1e98959ddd8c8df801c0008dfe705",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37604",
+					"10.65.0.27:37604",
+					"172.17.0.1:37604",
+					"172.18.0.1:37604",
+					"172.19.0.1:37604"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:10:11.140656048Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1773556953774490,
+				"StableID":   "nhnBkMLFrE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:596ec62125e92c83b1534db2856624ce30f87c80b0b538cec0f4c7aa982b5e40",
+				"DiscoKey":   "discokey:d93ad9b922bed652bfcde9baa8110cead44edbc0d58d2c23629f9fd1fa542438",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42973",
+					"10.65.0.27:42973",
+					"172.17.0.1:42973",
+					"172.18.0.1:42973",
+					"172.19.0.1:42973"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:10:11.703069243Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5380620594659572,
+				"StableID":   "nqq4tBnt1j11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d68aba78ad1eb1ab182e269ea2905653d061a0fa42536a4d4e23443366d1a74",
+				"DiscoKey":   "discokey:59d53817b16394419c1710400c77b0f15581695ba7ab815fc7c6e4764f940236",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53362",
+					"10.65.0.27:53362",
+					"172.17.0.1:53362",
+					"172.18.0.1:53362",
+					"172.19.0.1:53362"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:10:12.27683435Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5100797787866282,
+				"StableID":   "nPPqetJAqg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b0f9bd19345ce959e99209d857f0ad7914aa942ae4a259207d8cc37f26d0c24",
+				"DiscoKey":   "discokey:7f51315fdb94f8ed42c36342a9be730c76bbcfe20e0c85bf5560b69fd8e11451",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:39534",
+					"10.65.0.27:39534",
+					"172.17.0.1:39534",
+					"172.18.0.1:39534",
+					"172.19.0.1:39534"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:10:12.773184225Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2411809109152787,
+				"StableID":   "n4bA8s8KqK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe59a6e2ed236121da85027bfab0494236ddf0ae5da1438556327453125b8e6d",
+				"DiscoKey":   "discokey:5d59101df49496f8b5bc458ff87a88d78eafa47f11f5d0538aed0456cc863261",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:52689",
+					"10.65.0.27:52689",
+					"172.17.0.1:52689",
+					"172.18.0.1:52689",
+					"172.19.0.1:52689"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:10:13.307985572Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5206214371150158,
+				"StableID":   "nF5q8ZRueh11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6bb0978f30fa6e555b62205c811d1777b4adb705c3032ae0657112f9bd64a11",
+				"DiscoKey":   "discokey:6b22ca8eaa72bd673178b7a1b17153a475284d19c715ffaae8c2345b0cb9d472",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:50596",
+					"10.65.0.27:50596",
+					"172.17.0.1:50596",
+					"172.18.0.1:50596",
+					"172.19.0.1:50596"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:10:13.857173041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2248751212648568,
+				"StableID":   "nsg9B7tTZJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8ce2a9929033e7885055484e70f27adc51fa108cc6951921b9494e07bee72920",
+				"KeyExpiry":  "2026-11-08T22:10:14Z",
+				"DiscoKey":   "discokey:0c1a650e38303f00b4ffad5473f7f6fbbc17e4ccec293dea3a6b5949be8f5a37",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35549",
+					"10.65.0.27:35549",
+					"172.17.0.1:35549",
+					"172.18.0.1:35549",
+					"172.19.0.1:35549"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:10:14.437533871Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7846791554217952,
+				"StableID":   "nwa7agupG421CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:17ce140a9b6fb018394505188400cb5692eac30ac1d9936a1778466297d3bc42",
+				"KeyExpiry":  "2026-11-08T22:10:14Z",
+				"DiscoKey":   "discokey:bf278ed76bff01487b02ad3732433de82e57a02ffdd890283fd795145007161e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50054",
+					"10.65.0.27:50054",
+					"172.17.0.1:50054",
+					"172.18.0.1:50054",
+					"172.19.0.1:50054"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:10:14.931331045Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4439465031872978,
+				"StableID":   "n7ohdfDefb11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       4439465031872978,
+				"Key":        "nodekey:7d0a51dfebb9b70b759a499bdb896573ccffcb7759036f9675cebb81a834a546",
+				"DiscoKey":   "discokey:9fd20abd384b4d53e3f9bfe8798db9c765911125cbbf1302b0391286fcd50e2f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33535",
+					"10.65.0.27:33535",
+					"172.17.0.1:33535",
+					"172.18.0.1:33535",
+					"172.19.0.1:33535"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:10:08.980804027Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7d0a51dfebb9b70b759a499bdb896573ccffcb7759036f9675cebb81a834a546",
+			"MachineKey": "mkey:d5c07dc9b9581fed53b1de8dc02cf6cb919ccd3f507ccd047af07896022b8502",
+			"Peers": [{
+				"ID":         1285669455896445,
+				"StableID":   "nGpTFgMH3B11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10a7c49f80abd134e5539c63738d03d39fa93be860666215284e71441c515576",
+				"DiscoKey":   "discokey:c6839589c5ece4d9f89e9153c1afde8e825fc91b7c08ccff380b03dc6690084b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51162",
+					"10.65.0.27:51162",
+					"172.17.0.1:51162",
+					"172.18.0.1:51162",
+					"172.19.0.1:51162"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:10:07.902843125Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1368026745604867,
+				"StableID":   "n8FTv5kagB11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:61f59d38c73b144a51c001fd7713e6a38ae340b48656d1665db9424996657d38",
+				"DiscoKey":   "discokey:8bcbd57526c2e786167b7515fae3962320a24288d359301e438abaede6f7d868",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:60071",
+					"10.65.0.27:60071",
+					"172.17.0.1:60071",
+					"172.18.0.1:60071",
+					"172.19.0.1:60071"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:10:08.428579986Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3173123217679596,
+				"StableID":   "noNztqZ7nR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26c4da7100063a53f65d723dad899d463193b16628f6a63fa1ac4a9f87e8097f",
+				"DiscoKey":   "discokey:f0c957795eb196daa64268f646814f38e3a63e9ef64abe35fa06c4e0155b9776",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43132",
+					"10.65.0.27:43132",
+					"172.17.0.1:43132",
+					"172.18.0.1:43132",
+					"172.19.0.1:43132"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:10:09.523013351Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7454394752163285,
+				"StableID":   "n82esxJ7D121CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e420a14a9333217f54880096fed459f3667b056e86fd21b4ca1720d6ce095d42",
+				"DiscoKey":   "discokey:247cd9ca1b1b7f6ceee403624ad0f9e518b338dc6acf2006f5923191c85a7f37",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56797",
+					"10.65.0.27:56797",
+					"172.17.0.1:56797",
+					"172.18.0.1:56797",
+					"172.19.0.1:56797"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:10:10.062488879Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2815166818795474,
+				"StableID":   "nZn5hCfzyN11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a01509e1daef84a506cda8d6ee4a0d01c1198376d3c9694a248e5ecd666f5635",
+				"DiscoKey":   "discokey:91f509159d94eae866cb515a76fab9ee1239330adbd2f4ad100aa18089835c62",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40108",
+					"10.65.0.27:40108",
+					"172.17.0.1:40108",
+					"172.18.0.1:40108",
+					"172.19.0.1:40108"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:10:10.606982354Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7725211482286916,
+				"StableID":   "nwarwwCmK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c2aebd25a98733db00b877fc575773e5449993751e4b8199c3d3d20599ca471f",
+				"DiscoKey":   "discokey:2b9732a96bb41c9cc548bd15a8ca2fa013c1e98959ddd8c8df801c0008dfe705",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37604",
+					"10.65.0.27:37604",
+					"172.17.0.1:37604",
+					"172.18.0.1:37604",
+					"172.19.0.1:37604"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:10:11.140656048Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1773556953774490,
+				"StableID":   "nhnBkMLFrE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:596ec62125e92c83b1534db2856624ce30f87c80b0b538cec0f4c7aa982b5e40",
+				"DiscoKey":   "discokey:d93ad9b922bed652bfcde9baa8110cead44edbc0d58d2c23629f9fd1fa542438",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42973",
+					"10.65.0.27:42973",
+					"172.17.0.1:42973",
+					"172.18.0.1:42973",
+					"172.19.0.1:42973"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:10:11.703069243Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5380620594659572,
+				"StableID":   "nqq4tBnt1j11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d68aba78ad1eb1ab182e269ea2905653d061a0fa42536a4d4e23443366d1a74",
+				"DiscoKey":   "discokey:59d53817b16394419c1710400c77b0f15581695ba7ab815fc7c6e4764f940236",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53362",
+					"10.65.0.27:53362",
+					"172.17.0.1:53362",
+					"172.18.0.1:53362",
+					"172.19.0.1:53362"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:10:12.27683435Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5100797787866282,
+				"StableID":   "nPPqetJAqg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b0f9bd19345ce959e99209d857f0ad7914aa942ae4a259207d8cc37f26d0c24",
+				"DiscoKey":   "discokey:7f51315fdb94f8ed42c36342a9be730c76bbcfe20e0c85bf5560b69fd8e11451",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:39534",
+					"10.65.0.27:39534",
+					"172.17.0.1:39534",
+					"172.18.0.1:39534",
+					"172.19.0.1:39534"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:10:12.773184225Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2411809109152787,
+				"StableID":   "n4bA8s8KqK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe59a6e2ed236121da85027bfab0494236ddf0ae5da1438556327453125b8e6d",
+				"DiscoKey":   "discokey:5d59101df49496f8b5bc458ff87a88d78eafa47f11f5d0538aed0456cc863261",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:52689",
+					"10.65.0.27:52689",
+					"172.17.0.1:52689",
+					"172.18.0.1:52689",
+					"172.19.0.1:52689"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:10:13.307985572Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5206214371150158,
+				"StableID":   "nF5q8ZRueh11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6bb0978f30fa6e555b62205c811d1777b4adb705c3032ae0657112f9bd64a11",
+				"DiscoKey":   "discokey:6b22ca8eaa72bd673178b7a1b17153a475284d19c715ffaae8c2345b0cb9d472",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:50596",
+					"10.65.0.27:50596",
+					"172.17.0.1:50596",
+					"172.18.0.1:50596",
+					"172.19.0.1:50596"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:10:13.857173041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2248751212648568,
+				"StableID":   "nsg9B7tTZJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8ce2a9929033e7885055484e70f27adc51fa108cc6951921b9494e07bee72920",
+				"KeyExpiry":  "2026-11-08T22:10:14Z",
+				"DiscoKey":   "discokey:0c1a650e38303f00b4ffad5473f7f6fbbc17e4ccec293dea3a6b5949be8f5a37",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35549",
+					"10.65.0.27:35549",
+					"172.17.0.1:35549",
+					"172.18.0.1:35549",
+					"172.19.0.1:35549"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:10:14.437533871Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7846791554217952,
+				"StableID":   "nwa7agupG421CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:17ce140a9b6fb018394505188400cb5692eac30ac1d9936a1778466297d3bc42",
+				"KeyExpiry":  "2026-11-08T22:10:14Z",
+				"DiscoKey":   "discokey:bf278ed76bff01487b02ad3732433de82e57a02ffdd890283fd795145007161e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50054",
+					"10.65.0.27:50054",
+					"172.17.0.1:50054",
+					"172.18.0.1:50054",
+					"172.19.0.1:50054"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:10:14.931331045Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3029086976321069,
+				"StableID":   "n4ndUkyseQ11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:15613e4e4741e0dbef497a1fafd29461e9362a74fd9dd84f4859c379350db217",
+				"KeyExpiry":  "2026-11-08T22:10:15Z",
+				"DiscoKey":   "discokey:a201876356a1bc03ec0ffeb2db319cab59d419c1c274b5b5e60243670f45f440",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33971",
+					"10.65.0.27:33971",
+					"172.17.0.1:33971",
+					"172.18.0.1:33971",
+					"172.19.0.1:33971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:10:15.471723426Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4439465031872978": {
+				"ID":          4439465031872978,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1773556953774490,
+				"StableID":   "nhnBkMLFrE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1773556953774490,
+				"Key":        "nodekey:596ec62125e92c83b1534db2856624ce30f87c80b0b538cec0f4c7aa982b5e40",
+				"DiscoKey":   "discokey:d93ad9b922bed652bfcde9baa8110cead44edbc0d58d2c23629f9fd1fa542438",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42973",
+					"10.65.0.27:42973",
+					"172.17.0.1:42973",
+					"172.18.0.1:42973",
+					"172.19.0.1:42973"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:10:11.703069243Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:596ec62125e92c83b1534db2856624ce30f87c80b0b538cec0f4c7aa982b5e40",
+			"MachineKey": "mkey:47266c97ffda6337c7f0c0da37fd14015de7acc5f8b442a3a615678aa3996223",
+			"Peers": [{
+				"ID":         1285669455896445,
+				"StableID":   "nGpTFgMH3B11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10a7c49f80abd134e5539c63738d03d39fa93be860666215284e71441c515576",
+				"DiscoKey":   "discokey:c6839589c5ece4d9f89e9153c1afde8e825fc91b7c08ccff380b03dc6690084b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51162",
+					"10.65.0.27:51162",
+					"172.17.0.1:51162",
+					"172.18.0.1:51162",
+					"172.19.0.1:51162"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:10:07.902843125Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1368026745604867,
+				"StableID":   "n8FTv5kagB11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:61f59d38c73b144a51c001fd7713e6a38ae340b48656d1665db9424996657d38",
+				"DiscoKey":   "discokey:8bcbd57526c2e786167b7515fae3962320a24288d359301e438abaede6f7d868",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:60071",
+					"10.65.0.27:60071",
+					"172.17.0.1:60071",
+					"172.18.0.1:60071",
+					"172.19.0.1:60071"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:10:08.428579986Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4439465031872978,
+				"StableID":   "n7ohdfDefb11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7d0a51dfebb9b70b759a499bdb896573ccffcb7759036f9675cebb81a834a546",
+				"DiscoKey":   "discokey:9fd20abd384b4d53e3f9bfe8798db9c765911125cbbf1302b0391286fcd50e2f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33535",
+					"10.65.0.27:33535",
+					"172.17.0.1:33535",
+					"172.18.0.1:33535",
+					"172.19.0.1:33535"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:10:08.980804027Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3173123217679596,
+				"StableID":   "noNztqZ7nR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26c4da7100063a53f65d723dad899d463193b16628f6a63fa1ac4a9f87e8097f",
+				"DiscoKey":   "discokey:f0c957795eb196daa64268f646814f38e3a63e9ef64abe35fa06c4e0155b9776",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43132",
+					"10.65.0.27:43132",
+					"172.17.0.1:43132",
+					"172.18.0.1:43132",
+					"172.19.0.1:43132"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:10:09.523013351Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7454394752163285,
+				"StableID":   "n82esxJ7D121CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e420a14a9333217f54880096fed459f3667b056e86fd21b4ca1720d6ce095d42",
+				"DiscoKey":   "discokey:247cd9ca1b1b7f6ceee403624ad0f9e518b338dc6acf2006f5923191c85a7f37",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56797",
+					"10.65.0.27:56797",
+					"172.17.0.1:56797",
+					"172.18.0.1:56797",
+					"172.19.0.1:56797"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:10:10.062488879Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2815166818795474,
+				"StableID":   "nZn5hCfzyN11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a01509e1daef84a506cda8d6ee4a0d01c1198376d3c9694a248e5ecd666f5635",
+				"DiscoKey":   "discokey:91f509159d94eae866cb515a76fab9ee1239330adbd2f4ad100aa18089835c62",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40108",
+					"10.65.0.27:40108",
+					"172.17.0.1:40108",
+					"172.18.0.1:40108",
+					"172.19.0.1:40108"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:10:10.606982354Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7725211482286916,
+				"StableID":   "nwarwwCmK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c2aebd25a98733db00b877fc575773e5449993751e4b8199c3d3d20599ca471f",
+				"DiscoKey":   "discokey:2b9732a96bb41c9cc548bd15a8ca2fa013c1e98959ddd8c8df801c0008dfe705",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37604",
+					"10.65.0.27:37604",
+					"172.17.0.1:37604",
+					"172.18.0.1:37604",
+					"172.19.0.1:37604"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:10:11.140656048Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5380620594659572,
+				"StableID":   "nqq4tBnt1j11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d68aba78ad1eb1ab182e269ea2905653d061a0fa42536a4d4e23443366d1a74",
+				"DiscoKey":   "discokey:59d53817b16394419c1710400c77b0f15581695ba7ab815fc7c6e4764f940236",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53362",
+					"10.65.0.27:53362",
+					"172.17.0.1:53362",
+					"172.18.0.1:53362",
+					"172.19.0.1:53362"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:10:12.27683435Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5100797787866282,
+				"StableID":   "nPPqetJAqg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b0f9bd19345ce959e99209d857f0ad7914aa942ae4a259207d8cc37f26d0c24",
+				"DiscoKey":   "discokey:7f51315fdb94f8ed42c36342a9be730c76bbcfe20e0c85bf5560b69fd8e11451",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:39534",
+					"10.65.0.27:39534",
+					"172.17.0.1:39534",
+					"172.18.0.1:39534",
+					"172.19.0.1:39534"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:10:12.773184225Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2411809109152787,
+				"StableID":   "n4bA8s8KqK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe59a6e2ed236121da85027bfab0494236ddf0ae5da1438556327453125b8e6d",
+				"DiscoKey":   "discokey:5d59101df49496f8b5bc458ff87a88d78eafa47f11f5d0538aed0456cc863261",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:52689",
+					"10.65.0.27:52689",
+					"172.17.0.1:52689",
+					"172.18.0.1:52689",
+					"172.19.0.1:52689"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:10:13.307985572Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5206214371150158,
+				"StableID":   "nF5q8ZRueh11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6bb0978f30fa6e555b62205c811d1777b4adb705c3032ae0657112f9bd64a11",
+				"DiscoKey":   "discokey:6b22ca8eaa72bd673178b7a1b17153a475284d19c715ffaae8c2345b0cb9d472",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:50596",
+					"10.65.0.27:50596",
+					"172.17.0.1:50596",
+					"172.18.0.1:50596",
+					"172.19.0.1:50596"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:10:13.857173041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2248751212648568,
+				"StableID":   "nsg9B7tTZJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8ce2a9929033e7885055484e70f27adc51fa108cc6951921b9494e07bee72920",
+				"KeyExpiry":  "2026-11-08T22:10:14Z",
+				"DiscoKey":   "discokey:0c1a650e38303f00b4ffad5473f7f6fbbc17e4ccec293dea3a6b5949be8f5a37",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35549",
+					"10.65.0.27:35549",
+					"172.17.0.1:35549",
+					"172.18.0.1:35549",
+					"172.19.0.1:35549"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:10:14.437533871Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7846791554217952,
+				"StableID":   "nwa7agupG421CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:17ce140a9b6fb018394505188400cb5692eac30ac1d9936a1778466297d3bc42",
+				"KeyExpiry":  "2026-11-08T22:10:14Z",
+				"DiscoKey":   "discokey:bf278ed76bff01487b02ad3732433de82e57a02ffdd890283fd795145007161e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50054",
+					"10.65.0.27:50054",
+					"172.17.0.1:50054",
+					"172.18.0.1:50054",
+					"172.19.0.1:50054"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:10:14.931331045Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3029086976321069,
+				"StableID":   "n4ndUkyseQ11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:15613e4e4741e0dbef497a1fafd29461e9362a74fd9dd84f4859c379350db217",
+				"KeyExpiry":  "2026-11-08T22:10:15Z",
+				"DiscoKey":   "discokey:a201876356a1bc03ec0ffeb2db319cab59d419c1c274b5b5e60243670f45f440",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33971",
+					"10.65.0.27:33971",
+					"172.17.0.1:33971",
+					"172.18.0.1:33971",
+					"172.19.0.1:33971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:10:15.471723426Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1773556953774490": {
+				"ID":          1773556953774490,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2248751212648568,
+				"StableID":   "nsg9B7tTZJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8ce2a9929033e7885055484e70f27adc51fa108cc6951921b9494e07bee72920",
+				"KeyExpiry":  "2026-11-08T22:10:14Z",
+				"DiscoKey":   "discokey:0c1a650e38303f00b4ffad5473f7f6fbbc17e4ccec293dea3a6b5949be8f5a37",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35549",
+					"10.65.0.27:35549",
+					"172.17.0.1:35549",
+					"172.18.0.1:35549",
+					"172.19.0.1:35549"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:10:14.437533871Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8ce2a9929033e7885055484e70f27adc51fa108cc6951921b9494e07bee72920",
+			"MachineKey": "mkey:478dd7eb7d035444b79040626a353ee27ab11302172ee68494f9b5cef0f1487d",
+			"Peers": [{
+				"ID":         1285669455896445,
+				"StableID":   "nGpTFgMH3B11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10a7c49f80abd134e5539c63738d03d39fa93be860666215284e71441c515576",
+				"DiscoKey":   "discokey:c6839589c5ece4d9f89e9153c1afde8e825fc91b7c08ccff380b03dc6690084b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51162",
+					"10.65.0.27:51162",
+					"172.17.0.1:51162",
+					"172.18.0.1:51162",
+					"172.19.0.1:51162"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:10:07.902843125Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1368026745604867,
+				"StableID":   "n8FTv5kagB11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:61f59d38c73b144a51c001fd7713e6a38ae340b48656d1665db9424996657d38",
+				"DiscoKey":   "discokey:8bcbd57526c2e786167b7515fae3962320a24288d359301e438abaede6f7d868",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:60071",
+					"10.65.0.27:60071",
+					"172.17.0.1:60071",
+					"172.18.0.1:60071",
+					"172.19.0.1:60071"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:10:08.428579986Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4439465031872978,
+				"StableID":   "n7ohdfDefb11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7d0a51dfebb9b70b759a499bdb896573ccffcb7759036f9675cebb81a834a546",
+				"DiscoKey":   "discokey:9fd20abd384b4d53e3f9bfe8798db9c765911125cbbf1302b0391286fcd50e2f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33535",
+					"10.65.0.27:33535",
+					"172.17.0.1:33535",
+					"172.18.0.1:33535",
+					"172.19.0.1:33535"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:10:08.980804027Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3173123217679596,
+				"StableID":   "noNztqZ7nR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26c4da7100063a53f65d723dad899d463193b16628f6a63fa1ac4a9f87e8097f",
+				"DiscoKey":   "discokey:f0c957795eb196daa64268f646814f38e3a63e9ef64abe35fa06c4e0155b9776",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43132",
+					"10.65.0.27:43132",
+					"172.17.0.1:43132",
+					"172.18.0.1:43132",
+					"172.19.0.1:43132"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:10:09.523013351Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7454394752163285,
+				"StableID":   "n82esxJ7D121CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e420a14a9333217f54880096fed459f3667b056e86fd21b4ca1720d6ce095d42",
+				"DiscoKey":   "discokey:247cd9ca1b1b7f6ceee403624ad0f9e518b338dc6acf2006f5923191c85a7f37",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56797",
+					"10.65.0.27:56797",
+					"172.17.0.1:56797",
+					"172.18.0.1:56797",
+					"172.19.0.1:56797"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:10:10.062488879Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2815166818795474,
+				"StableID":   "nZn5hCfzyN11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a01509e1daef84a506cda8d6ee4a0d01c1198376d3c9694a248e5ecd666f5635",
+				"DiscoKey":   "discokey:91f509159d94eae866cb515a76fab9ee1239330adbd2f4ad100aa18089835c62",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40108",
+					"10.65.0.27:40108",
+					"172.17.0.1:40108",
+					"172.18.0.1:40108",
+					"172.19.0.1:40108"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:10:10.606982354Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7725211482286916,
+				"StableID":   "nwarwwCmK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c2aebd25a98733db00b877fc575773e5449993751e4b8199c3d3d20599ca471f",
+				"DiscoKey":   "discokey:2b9732a96bb41c9cc548bd15a8ca2fa013c1e98959ddd8c8df801c0008dfe705",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37604",
+					"10.65.0.27:37604",
+					"172.17.0.1:37604",
+					"172.18.0.1:37604",
+					"172.19.0.1:37604"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:10:11.140656048Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1773556953774490,
+				"StableID":   "nhnBkMLFrE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:596ec62125e92c83b1534db2856624ce30f87c80b0b538cec0f4c7aa982b5e40",
+				"DiscoKey":   "discokey:d93ad9b922bed652bfcde9baa8110cead44edbc0d58d2c23629f9fd1fa542438",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42973",
+					"10.65.0.27:42973",
+					"172.17.0.1:42973",
+					"172.18.0.1:42973",
+					"172.19.0.1:42973"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:10:11.703069243Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5380620594659572,
+				"StableID":   "nqq4tBnt1j11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d68aba78ad1eb1ab182e269ea2905653d061a0fa42536a4d4e23443366d1a74",
+				"DiscoKey":   "discokey:59d53817b16394419c1710400c77b0f15581695ba7ab815fc7c6e4764f940236",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53362",
+					"10.65.0.27:53362",
+					"172.17.0.1:53362",
+					"172.18.0.1:53362",
+					"172.19.0.1:53362"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:10:12.27683435Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5100797787866282,
+				"StableID":   "nPPqetJAqg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b0f9bd19345ce959e99209d857f0ad7914aa942ae4a259207d8cc37f26d0c24",
+				"DiscoKey":   "discokey:7f51315fdb94f8ed42c36342a9be730c76bbcfe20e0c85bf5560b69fd8e11451",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:39534",
+					"10.65.0.27:39534",
+					"172.17.0.1:39534",
+					"172.18.0.1:39534",
+					"172.19.0.1:39534"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:10:12.773184225Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2411809109152787,
+				"StableID":   "n4bA8s8KqK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe59a6e2ed236121da85027bfab0494236ddf0ae5da1438556327453125b8e6d",
+				"DiscoKey":   "discokey:5d59101df49496f8b5bc458ff87a88d78eafa47f11f5d0538aed0456cc863261",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:52689",
+					"10.65.0.27:52689",
+					"172.17.0.1:52689",
+					"172.18.0.1:52689",
+					"172.19.0.1:52689"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:10:13.307985572Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5206214371150158,
+				"StableID":   "nF5q8ZRueh11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6bb0978f30fa6e555b62205c811d1777b4adb705c3032ae0657112f9bd64a11",
+				"DiscoKey":   "discokey:6b22ca8eaa72bd673178b7a1b17153a475284d19c715ffaae8c2345b0cb9d472",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:50596",
+					"10.65.0.27:50596",
+					"172.17.0.1:50596",
+					"172.18.0.1:50596",
+					"172.19.0.1:50596"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:10:13.857173041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7846791554217952,
+				"StableID":   "nwa7agupG421CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:17ce140a9b6fb018394505188400cb5692eac30ac1d9936a1778466297d3bc42",
+				"KeyExpiry":  "2026-11-08T22:10:14Z",
+				"DiscoKey":   "discokey:bf278ed76bff01487b02ad3732433de82e57a02ffdd890283fd795145007161e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50054",
+					"10.65.0.27:50054",
+					"172.17.0.1:50054",
+					"172.18.0.1:50054",
+					"172.19.0.1:50054"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:10:14.931331045Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3029086976321069,
+				"StableID":   "n4ndUkyseQ11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:15613e4e4741e0dbef497a1fafd29461e9362a74fd9dd84f4859c379350db217",
+				"KeyExpiry":  "2026-11-08T22:10:15Z",
+				"DiscoKey":   "discokey:a201876356a1bc03ec0ffeb2db319cab59d419c1c274b5b5e60243670f45f440",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33971",
+					"10.65.0.27:33971",
+					"172.17.0.1:33971",
+					"172.18.0.1:33971",
+					"172.19.0.1:33971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:10:15.471723426Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2411809109152787,
+				"StableID":   "n4bA8s8KqK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       2411809109152787,
+				"Key":        "nodekey:fe59a6e2ed236121da85027bfab0494236ddf0ae5da1438556327453125b8e6d",
+				"DiscoKey":   "discokey:5d59101df49496f8b5bc458ff87a88d78eafa47f11f5d0538aed0456cc863261",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:52689",
+					"10.65.0.27:52689",
+					"172.17.0.1:52689",
+					"172.18.0.1:52689",
+					"172.19.0.1:52689"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:10:13.307985572Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:fe59a6e2ed236121da85027bfab0494236ddf0ae5da1438556327453125b8e6d",
+			"MachineKey": "mkey:a75e318fa9b09a736f2dccc01a42b8e91d020be4538ff4ccc2bc70551e3f6a4d",
+			"Peers": [{
+				"ID":         1285669455896445,
+				"StableID":   "nGpTFgMH3B11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10a7c49f80abd134e5539c63738d03d39fa93be860666215284e71441c515576",
+				"DiscoKey":   "discokey:c6839589c5ece4d9f89e9153c1afde8e825fc91b7c08ccff380b03dc6690084b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51162",
+					"10.65.0.27:51162",
+					"172.17.0.1:51162",
+					"172.18.0.1:51162",
+					"172.19.0.1:51162"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:10:07.902843125Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1368026745604867,
+				"StableID":   "n8FTv5kagB11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:61f59d38c73b144a51c001fd7713e6a38ae340b48656d1665db9424996657d38",
+				"DiscoKey":   "discokey:8bcbd57526c2e786167b7515fae3962320a24288d359301e438abaede6f7d868",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:60071",
+					"10.65.0.27:60071",
+					"172.17.0.1:60071",
+					"172.18.0.1:60071",
+					"172.19.0.1:60071"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:10:08.428579986Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4439465031872978,
+				"StableID":   "n7ohdfDefb11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7d0a51dfebb9b70b759a499bdb896573ccffcb7759036f9675cebb81a834a546",
+				"DiscoKey":   "discokey:9fd20abd384b4d53e3f9bfe8798db9c765911125cbbf1302b0391286fcd50e2f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33535",
+					"10.65.0.27:33535",
+					"172.17.0.1:33535",
+					"172.18.0.1:33535",
+					"172.19.0.1:33535"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:10:08.980804027Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3173123217679596,
+				"StableID":   "noNztqZ7nR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26c4da7100063a53f65d723dad899d463193b16628f6a63fa1ac4a9f87e8097f",
+				"DiscoKey":   "discokey:f0c957795eb196daa64268f646814f38e3a63e9ef64abe35fa06c4e0155b9776",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43132",
+					"10.65.0.27:43132",
+					"172.17.0.1:43132",
+					"172.18.0.1:43132",
+					"172.19.0.1:43132"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:10:09.523013351Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7454394752163285,
+				"StableID":   "n82esxJ7D121CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e420a14a9333217f54880096fed459f3667b056e86fd21b4ca1720d6ce095d42",
+				"DiscoKey":   "discokey:247cd9ca1b1b7f6ceee403624ad0f9e518b338dc6acf2006f5923191c85a7f37",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56797",
+					"10.65.0.27:56797",
+					"172.17.0.1:56797",
+					"172.18.0.1:56797",
+					"172.19.0.1:56797"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:10:10.062488879Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2815166818795474,
+				"StableID":   "nZn5hCfzyN11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a01509e1daef84a506cda8d6ee4a0d01c1198376d3c9694a248e5ecd666f5635",
+				"DiscoKey":   "discokey:91f509159d94eae866cb515a76fab9ee1239330adbd2f4ad100aa18089835c62",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40108",
+					"10.65.0.27:40108",
+					"172.17.0.1:40108",
+					"172.18.0.1:40108",
+					"172.19.0.1:40108"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:10:10.606982354Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7725211482286916,
+				"StableID":   "nwarwwCmK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c2aebd25a98733db00b877fc575773e5449993751e4b8199c3d3d20599ca471f",
+				"DiscoKey":   "discokey:2b9732a96bb41c9cc548bd15a8ca2fa013c1e98959ddd8c8df801c0008dfe705",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37604",
+					"10.65.0.27:37604",
+					"172.17.0.1:37604",
+					"172.18.0.1:37604",
+					"172.19.0.1:37604"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:10:11.140656048Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1773556953774490,
+				"StableID":   "nhnBkMLFrE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:596ec62125e92c83b1534db2856624ce30f87c80b0b538cec0f4c7aa982b5e40",
+				"DiscoKey":   "discokey:d93ad9b922bed652bfcde9baa8110cead44edbc0d58d2c23629f9fd1fa542438",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42973",
+					"10.65.0.27:42973",
+					"172.17.0.1:42973",
+					"172.18.0.1:42973",
+					"172.19.0.1:42973"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:10:11.703069243Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5380620594659572,
+				"StableID":   "nqq4tBnt1j11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d68aba78ad1eb1ab182e269ea2905653d061a0fa42536a4d4e23443366d1a74",
+				"DiscoKey":   "discokey:59d53817b16394419c1710400c77b0f15581695ba7ab815fc7c6e4764f940236",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53362",
+					"10.65.0.27:53362",
+					"172.17.0.1:53362",
+					"172.18.0.1:53362",
+					"172.19.0.1:53362"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:10:12.27683435Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5100797787866282,
+				"StableID":   "nPPqetJAqg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b0f9bd19345ce959e99209d857f0ad7914aa942ae4a259207d8cc37f26d0c24",
+				"DiscoKey":   "discokey:7f51315fdb94f8ed42c36342a9be730c76bbcfe20e0c85bf5560b69fd8e11451",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:39534",
+					"10.65.0.27:39534",
+					"172.17.0.1:39534",
+					"172.18.0.1:39534",
+					"172.19.0.1:39534"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:10:12.773184225Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5206214371150158,
+				"StableID":   "nF5q8ZRueh11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6bb0978f30fa6e555b62205c811d1777b4adb705c3032ae0657112f9bd64a11",
+				"DiscoKey":   "discokey:6b22ca8eaa72bd673178b7a1b17153a475284d19c715ffaae8c2345b0cb9d472",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:50596",
+					"10.65.0.27:50596",
+					"172.17.0.1:50596",
+					"172.18.0.1:50596",
+					"172.19.0.1:50596"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:10:13.857173041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2248751212648568,
+				"StableID":   "nsg9B7tTZJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8ce2a9929033e7885055484e70f27adc51fa108cc6951921b9494e07bee72920",
+				"KeyExpiry":  "2026-11-08T22:10:14Z",
+				"DiscoKey":   "discokey:0c1a650e38303f00b4ffad5473f7f6fbbc17e4ccec293dea3a6b5949be8f5a37",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35549",
+					"10.65.0.27:35549",
+					"172.17.0.1:35549",
+					"172.18.0.1:35549",
+					"172.19.0.1:35549"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:10:14.437533871Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7846791554217952,
+				"StableID":   "nwa7agupG421CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:17ce140a9b6fb018394505188400cb5692eac30ac1d9936a1778466297d3bc42",
+				"KeyExpiry":  "2026-11-08T22:10:14Z",
+				"DiscoKey":   "discokey:bf278ed76bff01487b02ad3732433de82e57a02ffdd890283fd795145007161e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50054",
+					"10.65.0.27:50054",
+					"172.17.0.1:50054",
+					"172.18.0.1:50054",
+					"172.19.0.1:50054"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:10:14.931331045Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3029086976321069,
+				"StableID":   "n4ndUkyseQ11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:15613e4e4741e0dbef497a1fafd29461e9362a74fd9dd84f4859c379350db217",
+				"KeyExpiry":  "2026-11-08T22:10:15Z",
+				"DiscoKey":   "discokey:a201876356a1bc03ec0ffeb2db319cab59d419c1c274b5b5e60243670f45f440",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33971",
+					"10.65.0.27:33971",
+					"172.17.0.1:33971",
+					"172.18.0.1:33971",
+					"172.19.0.1:33971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:10:15.471723426Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2411809109152787": {
+				"ID":          2411809109152787,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1368026745604867,
+				"StableID":   "n8FTv5kagB11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1368026745604867,
+				"Key":        "nodekey:61f59d38c73b144a51c001fd7713e6a38ae340b48656d1665db9424996657d38",
+				"DiscoKey":   "discokey:8bcbd57526c2e786167b7515fae3962320a24288d359301e438abaede6f7d868",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:60071",
+					"10.65.0.27:60071",
+					"172.17.0.1:60071",
+					"172.18.0.1:60071",
+					"172.19.0.1:60071"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:10:08.428579986Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:61f59d38c73b144a51c001fd7713e6a38ae340b48656d1665db9424996657d38",
+			"MachineKey": "mkey:bf535de882fd15c7c03bff4cfe9bb17567a967e2204f12a237c03c456d6ab057",
+			"Peers": [{
+				"ID":         1285669455896445,
+				"StableID":   "nGpTFgMH3B11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10a7c49f80abd134e5539c63738d03d39fa93be860666215284e71441c515576",
+				"DiscoKey":   "discokey:c6839589c5ece4d9f89e9153c1afde8e825fc91b7c08ccff380b03dc6690084b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51162",
+					"10.65.0.27:51162",
+					"172.17.0.1:51162",
+					"172.18.0.1:51162",
+					"172.19.0.1:51162"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:10:07.902843125Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4439465031872978,
+				"StableID":   "n7ohdfDefb11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7d0a51dfebb9b70b759a499bdb896573ccffcb7759036f9675cebb81a834a546",
+				"DiscoKey":   "discokey:9fd20abd384b4d53e3f9bfe8798db9c765911125cbbf1302b0391286fcd50e2f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33535",
+					"10.65.0.27:33535",
+					"172.17.0.1:33535",
+					"172.18.0.1:33535",
+					"172.19.0.1:33535"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:10:08.980804027Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3173123217679596,
+				"StableID":   "noNztqZ7nR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26c4da7100063a53f65d723dad899d463193b16628f6a63fa1ac4a9f87e8097f",
+				"DiscoKey":   "discokey:f0c957795eb196daa64268f646814f38e3a63e9ef64abe35fa06c4e0155b9776",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43132",
+					"10.65.0.27:43132",
+					"172.17.0.1:43132",
+					"172.18.0.1:43132",
+					"172.19.0.1:43132"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:10:09.523013351Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7454394752163285,
+				"StableID":   "n82esxJ7D121CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e420a14a9333217f54880096fed459f3667b056e86fd21b4ca1720d6ce095d42",
+				"DiscoKey":   "discokey:247cd9ca1b1b7f6ceee403624ad0f9e518b338dc6acf2006f5923191c85a7f37",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56797",
+					"10.65.0.27:56797",
+					"172.17.0.1:56797",
+					"172.18.0.1:56797",
+					"172.19.0.1:56797"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:10:10.062488879Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2815166818795474,
+				"StableID":   "nZn5hCfzyN11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a01509e1daef84a506cda8d6ee4a0d01c1198376d3c9694a248e5ecd666f5635",
+				"DiscoKey":   "discokey:91f509159d94eae866cb515a76fab9ee1239330adbd2f4ad100aa18089835c62",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40108",
+					"10.65.0.27:40108",
+					"172.17.0.1:40108",
+					"172.18.0.1:40108",
+					"172.19.0.1:40108"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:10:10.606982354Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7725211482286916,
+				"StableID":   "nwarwwCmK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c2aebd25a98733db00b877fc575773e5449993751e4b8199c3d3d20599ca471f",
+				"DiscoKey":   "discokey:2b9732a96bb41c9cc548bd15a8ca2fa013c1e98959ddd8c8df801c0008dfe705",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37604",
+					"10.65.0.27:37604",
+					"172.17.0.1:37604",
+					"172.18.0.1:37604",
+					"172.19.0.1:37604"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:10:11.140656048Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1773556953774490,
+				"StableID":   "nhnBkMLFrE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:596ec62125e92c83b1534db2856624ce30f87c80b0b538cec0f4c7aa982b5e40",
+				"DiscoKey":   "discokey:d93ad9b922bed652bfcde9baa8110cead44edbc0d58d2c23629f9fd1fa542438",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42973",
+					"10.65.0.27:42973",
+					"172.17.0.1:42973",
+					"172.18.0.1:42973",
+					"172.19.0.1:42973"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:10:11.703069243Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5380620594659572,
+				"StableID":   "nqq4tBnt1j11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d68aba78ad1eb1ab182e269ea2905653d061a0fa42536a4d4e23443366d1a74",
+				"DiscoKey":   "discokey:59d53817b16394419c1710400c77b0f15581695ba7ab815fc7c6e4764f940236",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53362",
+					"10.65.0.27:53362",
+					"172.17.0.1:53362",
+					"172.18.0.1:53362",
+					"172.19.0.1:53362"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:10:12.27683435Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5100797787866282,
+				"StableID":   "nPPqetJAqg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b0f9bd19345ce959e99209d857f0ad7914aa942ae4a259207d8cc37f26d0c24",
+				"DiscoKey":   "discokey:7f51315fdb94f8ed42c36342a9be730c76bbcfe20e0c85bf5560b69fd8e11451",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:39534",
+					"10.65.0.27:39534",
+					"172.17.0.1:39534",
+					"172.18.0.1:39534",
+					"172.19.0.1:39534"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:10:12.773184225Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2411809109152787,
+				"StableID":   "n4bA8s8KqK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe59a6e2ed236121da85027bfab0494236ddf0ae5da1438556327453125b8e6d",
+				"DiscoKey":   "discokey:5d59101df49496f8b5bc458ff87a88d78eafa47f11f5d0538aed0456cc863261",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:52689",
+					"10.65.0.27:52689",
+					"172.17.0.1:52689",
+					"172.18.0.1:52689",
+					"172.19.0.1:52689"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:10:13.307985572Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5206214371150158,
+				"StableID":   "nF5q8ZRueh11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6bb0978f30fa6e555b62205c811d1777b4adb705c3032ae0657112f9bd64a11",
+				"DiscoKey":   "discokey:6b22ca8eaa72bd673178b7a1b17153a475284d19c715ffaae8c2345b0cb9d472",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:50596",
+					"10.65.0.27:50596",
+					"172.17.0.1:50596",
+					"172.18.0.1:50596",
+					"172.19.0.1:50596"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:10:13.857173041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2248751212648568,
+				"StableID":   "nsg9B7tTZJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8ce2a9929033e7885055484e70f27adc51fa108cc6951921b9494e07bee72920",
+				"KeyExpiry":  "2026-11-08T22:10:14Z",
+				"DiscoKey":   "discokey:0c1a650e38303f00b4ffad5473f7f6fbbc17e4ccec293dea3a6b5949be8f5a37",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35549",
+					"10.65.0.27:35549",
+					"172.17.0.1:35549",
+					"172.18.0.1:35549",
+					"172.19.0.1:35549"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:10:14.437533871Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7846791554217952,
+				"StableID":   "nwa7agupG421CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:17ce140a9b6fb018394505188400cb5692eac30ac1d9936a1778466297d3bc42",
+				"KeyExpiry":  "2026-11-08T22:10:14Z",
+				"DiscoKey":   "discokey:bf278ed76bff01487b02ad3732433de82e57a02ffdd890283fd795145007161e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50054",
+					"10.65.0.27:50054",
+					"172.17.0.1:50054",
+					"172.18.0.1:50054",
+					"172.19.0.1:50054"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:10:14.931331045Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3029086976321069,
+				"StableID":   "n4ndUkyseQ11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:15613e4e4741e0dbef497a1fafd29461e9362a74fd9dd84f4859c379350db217",
+				"KeyExpiry":  "2026-11-08T22:10:15Z",
+				"DiscoKey":   "discokey:a201876356a1bc03ec0ffeb2db319cab59d419c1c274b5b5e60243670f45f440",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33971",
+					"10.65.0.27:33971",
+					"172.17.0.1:33971",
+					"172.18.0.1:33971",
+					"172.19.0.1:33971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:10:15.471723426Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1368026745604867": {
+				"ID":          1368026745604867,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1285669455896445,
+				"StableID":   "nGpTFgMH3B11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1285669455896445,
+				"Key":        "nodekey:10a7c49f80abd134e5539c63738d03d39fa93be860666215284e71441c515576",
+				"DiscoKey":   "discokey:c6839589c5ece4d9f89e9153c1afde8e825fc91b7c08ccff380b03dc6690084b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51162",
+					"10.65.0.27:51162",
+					"172.17.0.1:51162",
+					"172.18.0.1:51162",
+					"172.19.0.1:51162"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:10:07.902843125Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:10a7c49f80abd134e5539c63738d03d39fa93be860666215284e71441c515576",
+			"MachineKey": "mkey:7fe07450b8bff18780dd6e82a471541320c1d7c966cb70a947b5f6306d9f5820",
+			"Peers": [{
+				"ID":         1368026745604867,
+				"StableID":   "n8FTv5kagB11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:61f59d38c73b144a51c001fd7713e6a38ae340b48656d1665db9424996657d38",
+				"DiscoKey":   "discokey:8bcbd57526c2e786167b7515fae3962320a24288d359301e438abaede6f7d868",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:60071",
+					"10.65.0.27:60071",
+					"172.17.0.1:60071",
+					"172.18.0.1:60071",
+					"172.19.0.1:60071"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:10:08.428579986Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4439465031872978,
+				"StableID":   "n7ohdfDefb11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7d0a51dfebb9b70b759a499bdb896573ccffcb7759036f9675cebb81a834a546",
+				"DiscoKey":   "discokey:9fd20abd384b4d53e3f9bfe8798db9c765911125cbbf1302b0391286fcd50e2f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33535",
+					"10.65.0.27:33535",
+					"172.17.0.1:33535",
+					"172.18.0.1:33535",
+					"172.19.0.1:33535"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:10:08.980804027Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3173123217679596,
+				"StableID":   "noNztqZ7nR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26c4da7100063a53f65d723dad899d463193b16628f6a63fa1ac4a9f87e8097f",
+				"DiscoKey":   "discokey:f0c957795eb196daa64268f646814f38e3a63e9ef64abe35fa06c4e0155b9776",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43132",
+					"10.65.0.27:43132",
+					"172.17.0.1:43132",
+					"172.18.0.1:43132",
+					"172.19.0.1:43132"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:10:09.523013351Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7454394752163285,
+				"StableID":   "n82esxJ7D121CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e420a14a9333217f54880096fed459f3667b056e86fd21b4ca1720d6ce095d42",
+				"DiscoKey":   "discokey:247cd9ca1b1b7f6ceee403624ad0f9e518b338dc6acf2006f5923191c85a7f37",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56797",
+					"10.65.0.27:56797",
+					"172.17.0.1:56797",
+					"172.18.0.1:56797",
+					"172.19.0.1:56797"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:10:10.062488879Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2815166818795474,
+				"StableID":   "nZn5hCfzyN11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a01509e1daef84a506cda8d6ee4a0d01c1198376d3c9694a248e5ecd666f5635",
+				"DiscoKey":   "discokey:91f509159d94eae866cb515a76fab9ee1239330adbd2f4ad100aa18089835c62",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40108",
+					"10.65.0.27:40108",
+					"172.17.0.1:40108",
+					"172.18.0.1:40108",
+					"172.19.0.1:40108"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:10:10.606982354Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7725211482286916,
+				"StableID":   "nwarwwCmK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c2aebd25a98733db00b877fc575773e5449993751e4b8199c3d3d20599ca471f",
+				"DiscoKey":   "discokey:2b9732a96bb41c9cc548bd15a8ca2fa013c1e98959ddd8c8df801c0008dfe705",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37604",
+					"10.65.0.27:37604",
+					"172.17.0.1:37604",
+					"172.18.0.1:37604",
+					"172.19.0.1:37604"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:10:11.140656048Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1773556953774490,
+				"StableID":   "nhnBkMLFrE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:596ec62125e92c83b1534db2856624ce30f87c80b0b538cec0f4c7aa982b5e40",
+				"DiscoKey":   "discokey:d93ad9b922bed652bfcde9baa8110cead44edbc0d58d2c23629f9fd1fa542438",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42973",
+					"10.65.0.27:42973",
+					"172.17.0.1:42973",
+					"172.18.0.1:42973",
+					"172.19.0.1:42973"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:10:11.703069243Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5380620594659572,
+				"StableID":   "nqq4tBnt1j11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d68aba78ad1eb1ab182e269ea2905653d061a0fa42536a4d4e23443366d1a74",
+				"DiscoKey":   "discokey:59d53817b16394419c1710400c77b0f15581695ba7ab815fc7c6e4764f940236",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53362",
+					"10.65.0.27:53362",
+					"172.17.0.1:53362",
+					"172.18.0.1:53362",
+					"172.19.0.1:53362"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:10:12.27683435Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5100797787866282,
+				"StableID":   "nPPqetJAqg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b0f9bd19345ce959e99209d857f0ad7914aa942ae4a259207d8cc37f26d0c24",
+				"DiscoKey":   "discokey:7f51315fdb94f8ed42c36342a9be730c76bbcfe20e0c85bf5560b69fd8e11451",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:39534",
+					"10.65.0.27:39534",
+					"172.17.0.1:39534",
+					"172.18.0.1:39534",
+					"172.19.0.1:39534"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:10:12.773184225Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2411809109152787,
+				"StableID":   "n4bA8s8KqK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe59a6e2ed236121da85027bfab0494236ddf0ae5da1438556327453125b8e6d",
+				"DiscoKey":   "discokey:5d59101df49496f8b5bc458ff87a88d78eafa47f11f5d0538aed0456cc863261",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:52689",
+					"10.65.0.27:52689",
+					"172.17.0.1:52689",
+					"172.18.0.1:52689",
+					"172.19.0.1:52689"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:10:13.307985572Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5206214371150158,
+				"StableID":   "nF5q8ZRueh11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6bb0978f30fa6e555b62205c811d1777b4adb705c3032ae0657112f9bd64a11",
+				"DiscoKey":   "discokey:6b22ca8eaa72bd673178b7a1b17153a475284d19c715ffaae8c2345b0cb9d472",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:50596",
+					"10.65.0.27:50596",
+					"172.17.0.1:50596",
+					"172.18.0.1:50596",
+					"172.19.0.1:50596"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:10:13.857173041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2248751212648568,
+				"StableID":   "nsg9B7tTZJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8ce2a9929033e7885055484e70f27adc51fa108cc6951921b9494e07bee72920",
+				"KeyExpiry":  "2026-11-08T22:10:14Z",
+				"DiscoKey":   "discokey:0c1a650e38303f00b4ffad5473f7f6fbbc17e4ccec293dea3a6b5949be8f5a37",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35549",
+					"10.65.0.27:35549",
+					"172.17.0.1:35549",
+					"172.18.0.1:35549",
+					"172.19.0.1:35549"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:10:14.437533871Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7846791554217952,
+				"StableID":   "nwa7agupG421CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:17ce140a9b6fb018394505188400cb5692eac30ac1d9936a1778466297d3bc42",
+				"KeyExpiry":  "2026-11-08T22:10:14Z",
+				"DiscoKey":   "discokey:bf278ed76bff01487b02ad3732433de82e57a02ffdd890283fd795145007161e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50054",
+					"10.65.0.27:50054",
+					"172.17.0.1:50054",
+					"172.18.0.1:50054",
+					"172.19.0.1:50054"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:10:14.931331045Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3029086976321069,
+				"StableID":   "n4ndUkyseQ11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:15613e4e4741e0dbef497a1fafd29461e9362a74fd9dd84f4859c379350db217",
+				"KeyExpiry":  "2026-11-08T22:10:15Z",
+				"DiscoKey":   "discokey:a201876356a1bc03ec0ffeb2db319cab59d419c1c274b5b5e60243670f45f440",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33971",
+					"10.65.0.27:33971",
+					"172.17.0.1:33971",
+					"172.18.0.1:33971",
+					"172.19.0.1:33971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:10:15.471723426Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1285669455896445": {
+				"ID":          1285669455896445,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7454394752163285,
+				"StableID":   "n82esxJ7D121CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       7454394752163285,
+				"Key":        "nodekey:e420a14a9333217f54880096fed459f3667b056e86fd21b4ca1720d6ce095d42",
+				"DiscoKey":   "discokey:247cd9ca1b1b7f6ceee403624ad0f9e518b338dc6acf2006f5923191c85a7f37",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56797",
+					"10.65.0.27:56797",
+					"172.17.0.1:56797",
+					"172.18.0.1:56797",
+					"172.19.0.1:56797"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:10:10.062488879Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e420a14a9333217f54880096fed459f3667b056e86fd21b4ca1720d6ce095d42",
+			"MachineKey": "mkey:8dcff6e7c397bc2941f89a9c98a90842eeb94ce8969bba1f61dfc0add2d51569",
+			"Peers": [{
+				"ID":         1285669455896445,
+				"StableID":   "nGpTFgMH3B11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10a7c49f80abd134e5539c63738d03d39fa93be860666215284e71441c515576",
+				"DiscoKey":   "discokey:c6839589c5ece4d9f89e9153c1afde8e825fc91b7c08ccff380b03dc6690084b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51162",
+					"10.65.0.27:51162",
+					"172.17.0.1:51162",
+					"172.18.0.1:51162",
+					"172.19.0.1:51162"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:10:07.902843125Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1368026745604867,
+				"StableID":   "n8FTv5kagB11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:61f59d38c73b144a51c001fd7713e6a38ae340b48656d1665db9424996657d38",
+				"DiscoKey":   "discokey:8bcbd57526c2e786167b7515fae3962320a24288d359301e438abaede6f7d868",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:60071",
+					"10.65.0.27:60071",
+					"172.17.0.1:60071",
+					"172.18.0.1:60071",
+					"172.19.0.1:60071"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:10:08.428579986Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4439465031872978,
+				"StableID":   "n7ohdfDefb11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7d0a51dfebb9b70b759a499bdb896573ccffcb7759036f9675cebb81a834a546",
+				"DiscoKey":   "discokey:9fd20abd384b4d53e3f9bfe8798db9c765911125cbbf1302b0391286fcd50e2f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33535",
+					"10.65.0.27:33535",
+					"172.17.0.1:33535",
+					"172.18.0.1:33535",
+					"172.19.0.1:33535"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:10:08.980804027Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3173123217679596,
+				"StableID":   "noNztqZ7nR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26c4da7100063a53f65d723dad899d463193b16628f6a63fa1ac4a9f87e8097f",
+				"DiscoKey":   "discokey:f0c957795eb196daa64268f646814f38e3a63e9ef64abe35fa06c4e0155b9776",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43132",
+					"10.65.0.27:43132",
+					"172.17.0.1:43132",
+					"172.18.0.1:43132",
+					"172.19.0.1:43132"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:10:09.523013351Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2815166818795474,
+				"StableID":   "nZn5hCfzyN11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a01509e1daef84a506cda8d6ee4a0d01c1198376d3c9694a248e5ecd666f5635",
+				"DiscoKey":   "discokey:91f509159d94eae866cb515a76fab9ee1239330adbd2f4ad100aa18089835c62",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40108",
+					"10.65.0.27:40108",
+					"172.17.0.1:40108",
+					"172.18.0.1:40108",
+					"172.19.0.1:40108"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:10:10.606982354Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7725211482286916,
+				"StableID":   "nwarwwCmK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c2aebd25a98733db00b877fc575773e5449993751e4b8199c3d3d20599ca471f",
+				"DiscoKey":   "discokey:2b9732a96bb41c9cc548bd15a8ca2fa013c1e98959ddd8c8df801c0008dfe705",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37604",
+					"10.65.0.27:37604",
+					"172.17.0.1:37604",
+					"172.18.0.1:37604",
+					"172.19.0.1:37604"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:10:11.140656048Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1773556953774490,
+				"StableID":   "nhnBkMLFrE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:596ec62125e92c83b1534db2856624ce30f87c80b0b538cec0f4c7aa982b5e40",
+				"DiscoKey":   "discokey:d93ad9b922bed652bfcde9baa8110cead44edbc0d58d2c23629f9fd1fa542438",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42973",
+					"10.65.0.27:42973",
+					"172.17.0.1:42973",
+					"172.18.0.1:42973",
+					"172.19.0.1:42973"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:10:11.703069243Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5380620594659572,
+				"StableID":   "nqq4tBnt1j11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d68aba78ad1eb1ab182e269ea2905653d061a0fa42536a4d4e23443366d1a74",
+				"DiscoKey":   "discokey:59d53817b16394419c1710400c77b0f15581695ba7ab815fc7c6e4764f940236",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53362",
+					"10.65.0.27:53362",
+					"172.17.0.1:53362",
+					"172.18.0.1:53362",
+					"172.19.0.1:53362"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:10:12.27683435Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5100797787866282,
+				"StableID":   "nPPqetJAqg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b0f9bd19345ce959e99209d857f0ad7914aa942ae4a259207d8cc37f26d0c24",
+				"DiscoKey":   "discokey:7f51315fdb94f8ed42c36342a9be730c76bbcfe20e0c85bf5560b69fd8e11451",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:39534",
+					"10.65.0.27:39534",
+					"172.17.0.1:39534",
+					"172.18.0.1:39534",
+					"172.19.0.1:39534"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:10:12.773184225Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2411809109152787,
+				"StableID":   "n4bA8s8KqK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe59a6e2ed236121da85027bfab0494236ddf0ae5da1438556327453125b8e6d",
+				"DiscoKey":   "discokey:5d59101df49496f8b5bc458ff87a88d78eafa47f11f5d0538aed0456cc863261",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:52689",
+					"10.65.0.27:52689",
+					"172.17.0.1:52689",
+					"172.18.0.1:52689",
+					"172.19.0.1:52689"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:10:13.307985572Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5206214371150158,
+				"StableID":   "nF5q8ZRueh11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6bb0978f30fa6e555b62205c811d1777b4adb705c3032ae0657112f9bd64a11",
+				"DiscoKey":   "discokey:6b22ca8eaa72bd673178b7a1b17153a475284d19c715ffaae8c2345b0cb9d472",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:50596",
+					"10.65.0.27:50596",
+					"172.17.0.1:50596",
+					"172.18.0.1:50596",
+					"172.19.0.1:50596"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:10:13.857173041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2248751212648568,
+				"StableID":   "nsg9B7tTZJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8ce2a9929033e7885055484e70f27adc51fa108cc6951921b9494e07bee72920",
+				"KeyExpiry":  "2026-11-08T22:10:14Z",
+				"DiscoKey":   "discokey:0c1a650e38303f00b4ffad5473f7f6fbbc17e4ccec293dea3a6b5949be8f5a37",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35549",
+					"10.65.0.27:35549",
+					"172.17.0.1:35549",
+					"172.18.0.1:35549",
+					"172.19.0.1:35549"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:10:14.437533871Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7846791554217952,
+				"StableID":   "nwa7agupG421CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:17ce140a9b6fb018394505188400cb5692eac30ac1d9936a1778466297d3bc42",
+				"KeyExpiry":  "2026-11-08T22:10:14Z",
+				"DiscoKey":   "discokey:bf278ed76bff01487b02ad3732433de82e57a02ffdd890283fd795145007161e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50054",
+					"10.65.0.27:50054",
+					"172.17.0.1:50054",
+					"172.18.0.1:50054",
+					"172.19.0.1:50054"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:10:14.931331045Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3029086976321069,
+				"StableID":   "n4ndUkyseQ11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:15613e4e4741e0dbef497a1fafd29461e9362a74fd9dd84f4859c379350db217",
+				"KeyExpiry":  "2026-11-08T22:10:15Z",
+				"DiscoKey":   "discokey:a201876356a1bc03ec0ffeb2db319cab59d419c1c274b5b5e60243670f45f440",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33971",
+					"10.65.0.27:33971",
+					"172.17.0.1:33971",
+					"172.18.0.1:33971",
+					"172.19.0.1:33971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:10:15.471723426Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7454394752163285": {
+				"ID":          7454394752163285,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3173123217679596,
+				"StableID":   "noNztqZ7nR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       3173123217679596,
+				"Key":        "nodekey:26c4da7100063a53f65d723dad899d463193b16628f6a63fa1ac4a9f87e8097f",
+				"DiscoKey":   "discokey:f0c957795eb196daa64268f646814f38e3a63e9ef64abe35fa06c4e0155b9776",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43132",
+					"10.65.0.27:43132",
+					"172.17.0.1:43132",
+					"172.18.0.1:43132",
+					"172.19.0.1:43132"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:10:09.523013351Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:26c4da7100063a53f65d723dad899d463193b16628f6a63fa1ac4a9f87e8097f",
+			"MachineKey": "mkey:efae249f02494f041215fab423661797938df8c9598b20cdd7010978dca43c1c",
+			"Peers": [{
+				"ID":         1285669455896445,
+				"StableID":   "nGpTFgMH3B11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10a7c49f80abd134e5539c63738d03d39fa93be860666215284e71441c515576",
+				"DiscoKey":   "discokey:c6839589c5ece4d9f89e9153c1afde8e825fc91b7c08ccff380b03dc6690084b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51162",
+					"10.65.0.27:51162",
+					"172.17.0.1:51162",
+					"172.18.0.1:51162",
+					"172.19.0.1:51162"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:10:07.902843125Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1368026745604867,
+				"StableID":   "n8FTv5kagB11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:61f59d38c73b144a51c001fd7713e6a38ae340b48656d1665db9424996657d38",
+				"DiscoKey":   "discokey:8bcbd57526c2e786167b7515fae3962320a24288d359301e438abaede6f7d868",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:60071",
+					"10.65.0.27:60071",
+					"172.17.0.1:60071",
+					"172.18.0.1:60071",
+					"172.19.0.1:60071"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:10:08.428579986Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4439465031872978,
+				"StableID":   "n7ohdfDefb11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7d0a51dfebb9b70b759a499bdb896573ccffcb7759036f9675cebb81a834a546",
+				"DiscoKey":   "discokey:9fd20abd384b4d53e3f9bfe8798db9c765911125cbbf1302b0391286fcd50e2f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33535",
+					"10.65.0.27:33535",
+					"172.17.0.1:33535",
+					"172.18.0.1:33535",
+					"172.19.0.1:33535"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:10:08.980804027Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7454394752163285,
+				"StableID":   "n82esxJ7D121CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e420a14a9333217f54880096fed459f3667b056e86fd21b4ca1720d6ce095d42",
+				"DiscoKey":   "discokey:247cd9ca1b1b7f6ceee403624ad0f9e518b338dc6acf2006f5923191c85a7f37",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56797",
+					"10.65.0.27:56797",
+					"172.17.0.1:56797",
+					"172.18.0.1:56797",
+					"172.19.0.1:56797"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:10:10.062488879Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2815166818795474,
+				"StableID":   "nZn5hCfzyN11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a01509e1daef84a506cda8d6ee4a0d01c1198376d3c9694a248e5ecd666f5635",
+				"DiscoKey":   "discokey:91f509159d94eae866cb515a76fab9ee1239330adbd2f4ad100aa18089835c62",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40108",
+					"10.65.0.27:40108",
+					"172.17.0.1:40108",
+					"172.18.0.1:40108",
+					"172.19.0.1:40108"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:10:10.606982354Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7725211482286916,
+				"StableID":   "nwarwwCmK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c2aebd25a98733db00b877fc575773e5449993751e4b8199c3d3d20599ca471f",
+				"DiscoKey":   "discokey:2b9732a96bb41c9cc548bd15a8ca2fa013c1e98959ddd8c8df801c0008dfe705",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37604",
+					"10.65.0.27:37604",
+					"172.17.0.1:37604",
+					"172.18.0.1:37604",
+					"172.19.0.1:37604"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:10:11.140656048Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1773556953774490,
+				"StableID":   "nhnBkMLFrE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:596ec62125e92c83b1534db2856624ce30f87c80b0b538cec0f4c7aa982b5e40",
+				"DiscoKey":   "discokey:d93ad9b922bed652bfcde9baa8110cead44edbc0d58d2c23629f9fd1fa542438",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42973",
+					"10.65.0.27:42973",
+					"172.17.0.1:42973",
+					"172.18.0.1:42973",
+					"172.19.0.1:42973"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:10:11.703069243Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5380620594659572,
+				"StableID":   "nqq4tBnt1j11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d68aba78ad1eb1ab182e269ea2905653d061a0fa42536a4d4e23443366d1a74",
+				"DiscoKey":   "discokey:59d53817b16394419c1710400c77b0f15581695ba7ab815fc7c6e4764f940236",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53362",
+					"10.65.0.27:53362",
+					"172.17.0.1:53362",
+					"172.18.0.1:53362",
+					"172.19.0.1:53362"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:10:12.27683435Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5100797787866282,
+				"StableID":   "nPPqetJAqg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b0f9bd19345ce959e99209d857f0ad7914aa942ae4a259207d8cc37f26d0c24",
+				"DiscoKey":   "discokey:7f51315fdb94f8ed42c36342a9be730c76bbcfe20e0c85bf5560b69fd8e11451",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:39534",
+					"10.65.0.27:39534",
+					"172.17.0.1:39534",
+					"172.18.0.1:39534",
+					"172.19.0.1:39534"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:10:12.773184225Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2411809109152787,
+				"StableID":   "n4bA8s8KqK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe59a6e2ed236121da85027bfab0494236ddf0ae5da1438556327453125b8e6d",
+				"DiscoKey":   "discokey:5d59101df49496f8b5bc458ff87a88d78eafa47f11f5d0538aed0456cc863261",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:52689",
+					"10.65.0.27:52689",
+					"172.17.0.1:52689",
+					"172.18.0.1:52689",
+					"172.19.0.1:52689"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:10:13.307985572Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5206214371150158,
+				"StableID":   "nF5q8ZRueh11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6bb0978f30fa6e555b62205c811d1777b4adb705c3032ae0657112f9bd64a11",
+				"DiscoKey":   "discokey:6b22ca8eaa72bd673178b7a1b17153a475284d19c715ffaae8c2345b0cb9d472",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:50596",
+					"10.65.0.27:50596",
+					"172.17.0.1:50596",
+					"172.18.0.1:50596",
+					"172.19.0.1:50596"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:10:13.857173041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2248751212648568,
+				"StableID":   "nsg9B7tTZJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8ce2a9929033e7885055484e70f27adc51fa108cc6951921b9494e07bee72920",
+				"KeyExpiry":  "2026-11-08T22:10:14Z",
+				"DiscoKey":   "discokey:0c1a650e38303f00b4ffad5473f7f6fbbc17e4ccec293dea3a6b5949be8f5a37",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35549",
+					"10.65.0.27:35549",
+					"172.17.0.1:35549",
+					"172.18.0.1:35549",
+					"172.19.0.1:35549"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:10:14.437533871Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7846791554217952,
+				"StableID":   "nwa7agupG421CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:17ce140a9b6fb018394505188400cb5692eac30ac1d9936a1778466297d3bc42",
+				"KeyExpiry":  "2026-11-08T22:10:14Z",
+				"DiscoKey":   "discokey:bf278ed76bff01487b02ad3732433de82e57a02ffdd890283fd795145007161e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50054",
+					"10.65.0.27:50054",
+					"172.17.0.1:50054",
+					"172.18.0.1:50054",
+					"172.19.0.1:50054"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:10:14.931331045Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3029086976321069,
+				"StableID":   "n4ndUkyseQ11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:15613e4e4741e0dbef497a1fafd29461e9362a74fd9dd84f4859c379350db217",
+				"KeyExpiry":  "2026-11-08T22:10:15Z",
+				"DiscoKey":   "discokey:a201876356a1bc03ec0ffeb2db319cab59d419c1c274b5b5e60243670f45f440",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33971",
+					"10.65.0.27:33971",
+					"172.17.0.1:33971",
+					"172.18.0.1:33971",
+					"172.19.0.1:33971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:10:15.471723426Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3173123217679596": {
+				"ID":          3173123217679596,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7725211482286916,
+				"StableID":   "nwarwwCmK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       7725211482286916,
+				"Key":        "nodekey:c2aebd25a98733db00b877fc575773e5449993751e4b8199c3d3d20599ca471f",
+				"DiscoKey":   "discokey:2b9732a96bb41c9cc548bd15a8ca2fa013c1e98959ddd8c8df801c0008dfe705",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37604",
+					"10.65.0.27:37604",
+					"172.17.0.1:37604",
+					"172.18.0.1:37604",
+					"172.19.0.1:37604"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:10:11.140656048Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c2aebd25a98733db00b877fc575773e5449993751e4b8199c3d3d20599ca471f",
+			"MachineKey": "mkey:58e6fc26db39d8736429ab111b28b0dc1f7cc021ff86f7eb946d03b7b4a87620",
+			"Peers": [{
+				"ID":         1285669455896445,
+				"StableID":   "nGpTFgMH3B11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10a7c49f80abd134e5539c63738d03d39fa93be860666215284e71441c515576",
+				"DiscoKey":   "discokey:c6839589c5ece4d9f89e9153c1afde8e825fc91b7c08ccff380b03dc6690084b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51162",
+					"10.65.0.27:51162",
+					"172.17.0.1:51162",
+					"172.18.0.1:51162",
+					"172.19.0.1:51162"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:10:07.902843125Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1368026745604867,
+				"StableID":   "n8FTv5kagB11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:61f59d38c73b144a51c001fd7713e6a38ae340b48656d1665db9424996657d38",
+				"DiscoKey":   "discokey:8bcbd57526c2e786167b7515fae3962320a24288d359301e438abaede6f7d868",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:60071",
+					"10.65.0.27:60071",
+					"172.17.0.1:60071",
+					"172.18.0.1:60071",
+					"172.19.0.1:60071"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:10:08.428579986Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4439465031872978,
+				"StableID":   "n7ohdfDefb11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7d0a51dfebb9b70b759a499bdb896573ccffcb7759036f9675cebb81a834a546",
+				"DiscoKey":   "discokey:9fd20abd384b4d53e3f9bfe8798db9c765911125cbbf1302b0391286fcd50e2f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33535",
+					"10.65.0.27:33535",
+					"172.17.0.1:33535",
+					"172.18.0.1:33535",
+					"172.19.0.1:33535"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:10:08.980804027Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3173123217679596,
+				"StableID":   "noNztqZ7nR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26c4da7100063a53f65d723dad899d463193b16628f6a63fa1ac4a9f87e8097f",
+				"DiscoKey":   "discokey:f0c957795eb196daa64268f646814f38e3a63e9ef64abe35fa06c4e0155b9776",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43132",
+					"10.65.0.27:43132",
+					"172.17.0.1:43132",
+					"172.18.0.1:43132",
+					"172.19.0.1:43132"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:10:09.523013351Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7454394752163285,
+				"StableID":   "n82esxJ7D121CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e420a14a9333217f54880096fed459f3667b056e86fd21b4ca1720d6ce095d42",
+				"DiscoKey":   "discokey:247cd9ca1b1b7f6ceee403624ad0f9e518b338dc6acf2006f5923191c85a7f37",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56797",
+					"10.65.0.27:56797",
+					"172.17.0.1:56797",
+					"172.18.0.1:56797",
+					"172.19.0.1:56797"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:10:10.062488879Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2815166818795474,
+				"StableID":   "nZn5hCfzyN11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a01509e1daef84a506cda8d6ee4a0d01c1198376d3c9694a248e5ecd666f5635",
+				"DiscoKey":   "discokey:91f509159d94eae866cb515a76fab9ee1239330adbd2f4ad100aa18089835c62",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40108",
+					"10.65.0.27:40108",
+					"172.17.0.1:40108",
+					"172.18.0.1:40108",
+					"172.19.0.1:40108"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:10:10.606982354Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1773556953774490,
+				"StableID":   "nhnBkMLFrE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:596ec62125e92c83b1534db2856624ce30f87c80b0b538cec0f4c7aa982b5e40",
+				"DiscoKey":   "discokey:d93ad9b922bed652bfcde9baa8110cead44edbc0d58d2c23629f9fd1fa542438",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42973",
+					"10.65.0.27:42973",
+					"172.17.0.1:42973",
+					"172.18.0.1:42973",
+					"172.19.0.1:42973"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:10:11.703069243Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5380620594659572,
+				"StableID":   "nqq4tBnt1j11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d68aba78ad1eb1ab182e269ea2905653d061a0fa42536a4d4e23443366d1a74",
+				"DiscoKey":   "discokey:59d53817b16394419c1710400c77b0f15581695ba7ab815fc7c6e4764f940236",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53362",
+					"10.65.0.27:53362",
+					"172.17.0.1:53362",
+					"172.18.0.1:53362",
+					"172.19.0.1:53362"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:10:12.27683435Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5100797787866282,
+				"StableID":   "nPPqetJAqg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b0f9bd19345ce959e99209d857f0ad7914aa942ae4a259207d8cc37f26d0c24",
+				"DiscoKey":   "discokey:7f51315fdb94f8ed42c36342a9be730c76bbcfe20e0c85bf5560b69fd8e11451",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:39534",
+					"10.65.0.27:39534",
+					"172.17.0.1:39534",
+					"172.18.0.1:39534",
+					"172.19.0.1:39534"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:10:12.773184225Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2411809109152787,
+				"StableID":   "n4bA8s8KqK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe59a6e2ed236121da85027bfab0494236ddf0ae5da1438556327453125b8e6d",
+				"DiscoKey":   "discokey:5d59101df49496f8b5bc458ff87a88d78eafa47f11f5d0538aed0456cc863261",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:52689",
+					"10.65.0.27:52689",
+					"172.17.0.1:52689",
+					"172.18.0.1:52689",
+					"172.19.0.1:52689"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:10:13.307985572Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5206214371150158,
+				"StableID":   "nF5q8ZRueh11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6bb0978f30fa6e555b62205c811d1777b4adb705c3032ae0657112f9bd64a11",
+				"DiscoKey":   "discokey:6b22ca8eaa72bd673178b7a1b17153a475284d19c715ffaae8c2345b0cb9d472",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:50596",
+					"10.65.0.27:50596",
+					"172.17.0.1:50596",
+					"172.18.0.1:50596",
+					"172.19.0.1:50596"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:10:13.857173041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2248751212648568,
+				"StableID":   "nsg9B7tTZJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8ce2a9929033e7885055484e70f27adc51fa108cc6951921b9494e07bee72920",
+				"KeyExpiry":  "2026-11-08T22:10:14Z",
+				"DiscoKey":   "discokey:0c1a650e38303f00b4ffad5473f7f6fbbc17e4ccec293dea3a6b5949be8f5a37",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35549",
+					"10.65.0.27:35549",
+					"172.17.0.1:35549",
+					"172.18.0.1:35549",
+					"172.19.0.1:35549"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:10:14.437533871Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7846791554217952,
+				"StableID":   "nwa7agupG421CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:17ce140a9b6fb018394505188400cb5692eac30ac1d9936a1778466297d3bc42",
+				"KeyExpiry":  "2026-11-08T22:10:14Z",
+				"DiscoKey":   "discokey:bf278ed76bff01487b02ad3732433de82e57a02ffdd890283fd795145007161e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50054",
+					"10.65.0.27:50054",
+					"172.17.0.1:50054",
+					"172.18.0.1:50054",
+					"172.19.0.1:50054"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:10:14.931331045Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3029086976321069,
+				"StableID":   "n4ndUkyseQ11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:15613e4e4741e0dbef497a1fafd29461e9362a74fd9dd84f4859c379350db217",
+				"KeyExpiry":  "2026-11-08T22:10:15Z",
+				"DiscoKey":   "discokey:a201876356a1bc03ec0ffeb2db319cab59d419c1c274b5b5e60243670f45f440",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33971",
+					"10.65.0.27:33971",
+					"172.17.0.1:33971",
+					"172.18.0.1:33971",
+					"172.19.0.1:33971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:10:15.471723426Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7725211482286916": {
+				"ID":          7725211482286916,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5380620594659572,
+				"StableID":   "nqq4tBnt1j11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       5380620594659572,
+				"Key":        "nodekey:9d68aba78ad1eb1ab182e269ea2905653d061a0fa42536a4d4e23443366d1a74",
+				"DiscoKey":   "discokey:59d53817b16394419c1710400c77b0f15581695ba7ab815fc7c6e4764f940236",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53362",
+					"10.65.0.27:53362",
+					"172.17.0.1:53362",
+					"172.18.0.1:53362",
+					"172.19.0.1:53362"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:10:12.27683435Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9d68aba78ad1eb1ab182e269ea2905653d061a0fa42536a4d4e23443366d1a74",
+			"MachineKey": "mkey:db0780827e892c32dbadc4a3903ed036f2b245eac661a21c8d71769e4502c470",
+			"Peers": [{
+				"ID":         1285669455896445,
+				"StableID":   "nGpTFgMH3B11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10a7c49f80abd134e5539c63738d03d39fa93be860666215284e71441c515576",
+				"DiscoKey":   "discokey:c6839589c5ece4d9f89e9153c1afde8e825fc91b7c08ccff380b03dc6690084b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51162",
+					"10.65.0.27:51162",
+					"172.17.0.1:51162",
+					"172.18.0.1:51162",
+					"172.19.0.1:51162"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:10:07.902843125Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1368026745604867,
+				"StableID":   "n8FTv5kagB11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:61f59d38c73b144a51c001fd7713e6a38ae340b48656d1665db9424996657d38",
+				"DiscoKey":   "discokey:8bcbd57526c2e786167b7515fae3962320a24288d359301e438abaede6f7d868",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:60071",
+					"10.65.0.27:60071",
+					"172.17.0.1:60071",
+					"172.18.0.1:60071",
+					"172.19.0.1:60071"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:10:08.428579986Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4439465031872978,
+				"StableID":   "n7ohdfDefb11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7d0a51dfebb9b70b759a499bdb896573ccffcb7759036f9675cebb81a834a546",
+				"DiscoKey":   "discokey:9fd20abd384b4d53e3f9bfe8798db9c765911125cbbf1302b0391286fcd50e2f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33535",
+					"10.65.0.27:33535",
+					"172.17.0.1:33535",
+					"172.18.0.1:33535",
+					"172.19.0.1:33535"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:10:08.980804027Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3173123217679596,
+				"StableID":   "noNztqZ7nR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26c4da7100063a53f65d723dad899d463193b16628f6a63fa1ac4a9f87e8097f",
+				"DiscoKey":   "discokey:f0c957795eb196daa64268f646814f38e3a63e9ef64abe35fa06c4e0155b9776",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43132",
+					"10.65.0.27:43132",
+					"172.17.0.1:43132",
+					"172.18.0.1:43132",
+					"172.19.0.1:43132"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:10:09.523013351Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7454394752163285,
+				"StableID":   "n82esxJ7D121CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e420a14a9333217f54880096fed459f3667b056e86fd21b4ca1720d6ce095d42",
+				"DiscoKey":   "discokey:247cd9ca1b1b7f6ceee403624ad0f9e518b338dc6acf2006f5923191c85a7f37",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56797",
+					"10.65.0.27:56797",
+					"172.17.0.1:56797",
+					"172.18.0.1:56797",
+					"172.19.0.1:56797"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:10:10.062488879Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2815166818795474,
+				"StableID":   "nZn5hCfzyN11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a01509e1daef84a506cda8d6ee4a0d01c1198376d3c9694a248e5ecd666f5635",
+				"DiscoKey":   "discokey:91f509159d94eae866cb515a76fab9ee1239330adbd2f4ad100aa18089835c62",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40108",
+					"10.65.0.27:40108",
+					"172.17.0.1:40108",
+					"172.18.0.1:40108",
+					"172.19.0.1:40108"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:10:10.606982354Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7725211482286916,
+				"StableID":   "nwarwwCmK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c2aebd25a98733db00b877fc575773e5449993751e4b8199c3d3d20599ca471f",
+				"DiscoKey":   "discokey:2b9732a96bb41c9cc548bd15a8ca2fa013c1e98959ddd8c8df801c0008dfe705",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37604",
+					"10.65.0.27:37604",
+					"172.17.0.1:37604",
+					"172.18.0.1:37604",
+					"172.19.0.1:37604"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:10:11.140656048Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1773556953774490,
+				"StableID":   "nhnBkMLFrE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:596ec62125e92c83b1534db2856624ce30f87c80b0b538cec0f4c7aa982b5e40",
+				"DiscoKey":   "discokey:d93ad9b922bed652bfcde9baa8110cead44edbc0d58d2c23629f9fd1fa542438",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42973",
+					"10.65.0.27:42973",
+					"172.17.0.1:42973",
+					"172.18.0.1:42973",
+					"172.19.0.1:42973"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:10:11.703069243Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5100797787866282,
+				"StableID":   "nPPqetJAqg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b0f9bd19345ce959e99209d857f0ad7914aa942ae4a259207d8cc37f26d0c24",
+				"DiscoKey":   "discokey:7f51315fdb94f8ed42c36342a9be730c76bbcfe20e0c85bf5560b69fd8e11451",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:39534",
+					"10.65.0.27:39534",
+					"172.17.0.1:39534",
+					"172.18.0.1:39534",
+					"172.19.0.1:39534"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:10:12.773184225Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2411809109152787,
+				"StableID":   "n4bA8s8KqK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe59a6e2ed236121da85027bfab0494236ddf0ae5da1438556327453125b8e6d",
+				"DiscoKey":   "discokey:5d59101df49496f8b5bc458ff87a88d78eafa47f11f5d0538aed0456cc863261",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:52689",
+					"10.65.0.27:52689",
+					"172.17.0.1:52689",
+					"172.18.0.1:52689",
+					"172.19.0.1:52689"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:10:13.307985572Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5206214371150158,
+				"StableID":   "nF5q8ZRueh11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6bb0978f30fa6e555b62205c811d1777b4adb705c3032ae0657112f9bd64a11",
+				"DiscoKey":   "discokey:6b22ca8eaa72bd673178b7a1b17153a475284d19c715ffaae8c2345b0cb9d472",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:50596",
+					"10.65.0.27:50596",
+					"172.17.0.1:50596",
+					"172.18.0.1:50596",
+					"172.19.0.1:50596"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:10:13.857173041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2248751212648568,
+				"StableID":   "nsg9B7tTZJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8ce2a9929033e7885055484e70f27adc51fa108cc6951921b9494e07bee72920",
+				"KeyExpiry":  "2026-11-08T22:10:14Z",
+				"DiscoKey":   "discokey:0c1a650e38303f00b4ffad5473f7f6fbbc17e4ccec293dea3a6b5949be8f5a37",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35549",
+					"10.65.0.27:35549",
+					"172.17.0.1:35549",
+					"172.18.0.1:35549",
+					"172.19.0.1:35549"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:10:14.437533871Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7846791554217952,
+				"StableID":   "nwa7agupG421CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:17ce140a9b6fb018394505188400cb5692eac30ac1d9936a1778466297d3bc42",
+				"KeyExpiry":  "2026-11-08T22:10:14Z",
+				"DiscoKey":   "discokey:bf278ed76bff01487b02ad3732433de82e57a02ffdd890283fd795145007161e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50054",
+					"10.65.0.27:50054",
+					"172.17.0.1:50054",
+					"172.18.0.1:50054",
+					"172.19.0.1:50054"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:10:14.931331045Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3029086976321069,
+				"StableID":   "n4ndUkyseQ11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:15613e4e4741e0dbef497a1fafd29461e9362a74fd9dd84f4859c379350db217",
+				"KeyExpiry":  "2026-11-08T22:10:15Z",
+				"DiscoKey":   "discokey:a201876356a1bc03ec0ffeb2db319cab59d419c1c274b5b5e60243670f45f440",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33971",
+					"10.65.0.27:33971",
+					"172.17.0.1:33971",
+					"172.18.0.1:33971",
+					"172.19.0.1:33971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:10:15.471723426Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5380620594659572": {
+				"ID":          5380620594659572,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7846791554217952,
+				"StableID":   "nwa7agupG421CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:17ce140a9b6fb018394505188400cb5692eac30ac1d9936a1778466297d3bc42",
+				"KeyExpiry":  "2026-11-08T22:10:14Z",
+				"DiscoKey":   "discokey:bf278ed76bff01487b02ad3732433de82e57a02ffdd890283fd795145007161e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50054",
+					"10.65.0.27:50054",
+					"172.17.0.1:50054",
+					"172.18.0.1:50054",
+					"172.19.0.1:50054"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:10:14.931331045Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:17ce140a9b6fb018394505188400cb5692eac30ac1d9936a1778466297d3bc42",
+			"MachineKey": "mkey:ebdbf86120b4e2a9d0bd02ea14e745d4048d2ec23879d4423b006fc3925cd06d",
+			"Peers": [{
+				"ID":         1285669455896445,
+				"StableID":   "nGpTFgMH3B11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10a7c49f80abd134e5539c63738d03d39fa93be860666215284e71441c515576",
+				"DiscoKey":   "discokey:c6839589c5ece4d9f89e9153c1afde8e825fc91b7c08ccff380b03dc6690084b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51162",
+					"10.65.0.27:51162",
+					"172.17.0.1:51162",
+					"172.18.0.1:51162",
+					"172.19.0.1:51162"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:10:07.902843125Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1368026745604867,
+				"StableID":   "n8FTv5kagB11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:61f59d38c73b144a51c001fd7713e6a38ae340b48656d1665db9424996657d38",
+				"DiscoKey":   "discokey:8bcbd57526c2e786167b7515fae3962320a24288d359301e438abaede6f7d868",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:60071",
+					"10.65.0.27:60071",
+					"172.17.0.1:60071",
+					"172.18.0.1:60071",
+					"172.19.0.1:60071"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:10:08.428579986Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4439465031872978,
+				"StableID":   "n7ohdfDefb11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7d0a51dfebb9b70b759a499bdb896573ccffcb7759036f9675cebb81a834a546",
+				"DiscoKey":   "discokey:9fd20abd384b4d53e3f9bfe8798db9c765911125cbbf1302b0391286fcd50e2f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33535",
+					"10.65.0.27:33535",
+					"172.17.0.1:33535",
+					"172.18.0.1:33535",
+					"172.19.0.1:33535"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:10:08.980804027Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3173123217679596,
+				"StableID":   "noNztqZ7nR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26c4da7100063a53f65d723dad899d463193b16628f6a63fa1ac4a9f87e8097f",
+				"DiscoKey":   "discokey:f0c957795eb196daa64268f646814f38e3a63e9ef64abe35fa06c4e0155b9776",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43132",
+					"10.65.0.27:43132",
+					"172.17.0.1:43132",
+					"172.18.0.1:43132",
+					"172.19.0.1:43132"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:10:09.523013351Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7454394752163285,
+				"StableID":   "n82esxJ7D121CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e420a14a9333217f54880096fed459f3667b056e86fd21b4ca1720d6ce095d42",
+				"DiscoKey":   "discokey:247cd9ca1b1b7f6ceee403624ad0f9e518b338dc6acf2006f5923191c85a7f37",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56797",
+					"10.65.0.27:56797",
+					"172.17.0.1:56797",
+					"172.18.0.1:56797",
+					"172.19.0.1:56797"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:10:10.062488879Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2815166818795474,
+				"StableID":   "nZn5hCfzyN11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a01509e1daef84a506cda8d6ee4a0d01c1198376d3c9694a248e5ecd666f5635",
+				"DiscoKey":   "discokey:91f509159d94eae866cb515a76fab9ee1239330adbd2f4ad100aa18089835c62",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40108",
+					"10.65.0.27:40108",
+					"172.17.0.1:40108",
+					"172.18.0.1:40108",
+					"172.19.0.1:40108"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:10:10.606982354Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7725211482286916,
+				"StableID":   "nwarwwCmK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c2aebd25a98733db00b877fc575773e5449993751e4b8199c3d3d20599ca471f",
+				"DiscoKey":   "discokey:2b9732a96bb41c9cc548bd15a8ca2fa013c1e98959ddd8c8df801c0008dfe705",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37604",
+					"10.65.0.27:37604",
+					"172.17.0.1:37604",
+					"172.18.0.1:37604",
+					"172.19.0.1:37604"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:10:11.140656048Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1773556953774490,
+				"StableID":   "nhnBkMLFrE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:596ec62125e92c83b1534db2856624ce30f87c80b0b538cec0f4c7aa982b5e40",
+				"DiscoKey":   "discokey:d93ad9b922bed652bfcde9baa8110cead44edbc0d58d2c23629f9fd1fa542438",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42973",
+					"10.65.0.27:42973",
+					"172.17.0.1:42973",
+					"172.18.0.1:42973",
+					"172.19.0.1:42973"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:10:11.703069243Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5380620594659572,
+				"StableID":   "nqq4tBnt1j11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d68aba78ad1eb1ab182e269ea2905653d061a0fa42536a4d4e23443366d1a74",
+				"DiscoKey":   "discokey:59d53817b16394419c1710400c77b0f15581695ba7ab815fc7c6e4764f940236",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53362",
+					"10.65.0.27:53362",
+					"172.17.0.1:53362",
+					"172.18.0.1:53362",
+					"172.19.0.1:53362"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:10:12.27683435Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5100797787866282,
+				"StableID":   "nPPqetJAqg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b0f9bd19345ce959e99209d857f0ad7914aa942ae4a259207d8cc37f26d0c24",
+				"DiscoKey":   "discokey:7f51315fdb94f8ed42c36342a9be730c76bbcfe20e0c85bf5560b69fd8e11451",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:39534",
+					"10.65.0.27:39534",
+					"172.17.0.1:39534",
+					"172.18.0.1:39534",
+					"172.19.0.1:39534"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:10:12.773184225Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2411809109152787,
+				"StableID":   "n4bA8s8KqK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe59a6e2ed236121da85027bfab0494236ddf0ae5da1438556327453125b8e6d",
+				"DiscoKey":   "discokey:5d59101df49496f8b5bc458ff87a88d78eafa47f11f5d0538aed0456cc863261",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:52689",
+					"10.65.0.27:52689",
+					"172.17.0.1:52689",
+					"172.18.0.1:52689",
+					"172.19.0.1:52689"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:10:13.307985572Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5206214371150158,
+				"StableID":   "nF5q8ZRueh11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6bb0978f30fa6e555b62205c811d1777b4adb705c3032ae0657112f9bd64a11",
+				"DiscoKey":   "discokey:6b22ca8eaa72bd673178b7a1b17153a475284d19c715ffaae8c2345b0cb9d472",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:50596",
+					"10.65.0.27:50596",
+					"172.17.0.1:50596",
+					"172.18.0.1:50596",
+					"172.19.0.1:50596"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:10:13.857173041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2248751212648568,
+				"StableID":   "nsg9B7tTZJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8ce2a9929033e7885055484e70f27adc51fa108cc6951921b9494e07bee72920",
+				"KeyExpiry":  "2026-11-08T22:10:14Z",
+				"DiscoKey":   "discokey:0c1a650e38303f00b4ffad5473f7f6fbbc17e4ccec293dea3a6b5949be8f5a37",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35549",
+					"10.65.0.27:35549",
+					"172.17.0.1:35549",
+					"172.18.0.1:35549",
+					"172.19.0.1:35549"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:10:14.437533871Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3029086976321069,
+				"StableID":   "n4ndUkyseQ11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:15613e4e4741e0dbef497a1fafd29461e9362a74fd9dd84f4859c379350db217",
+				"KeyExpiry":  "2026-11-08T22:10:15Z",
+				"DiscoKey":   "discokey:a201876356a1bc03ec0ffeb2db319cab59d419c1c274b5b5e60243670f45f440",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33971",
+					"10.65.0.27:33971",
+					"172.17.0.1:33971",
+					"172.18.0.1:33971",
+					"172.19.0.1:33971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:10:15.471723426Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5100797787866282,
+				"StableID":   "nPPqetJAqg11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       5100797787866282,
+				"Key":        "nodekey:4b0f9bd19345ce959e99209d857f0ad7914aa942ae4a259207d8cc37f26d0c24",
+				"DiscoKey":   "discokey:7f51315fdb94f8ed42c36342a9be730c76bbcfe20e0c85bf5560b69fd8e11451",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:39534",
+					"10.65.0.27:39534",
+					"172.17.0.1:39534",
+					"172.18.0.1:39534",
+					"172.19.0.1:39534"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:10:12.773184225Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4b0f9bd19345ce959e99209d857f0ad7914aa942ae4a259207d8cc37f26d0c24",
+			"MachineKey": "mkey:8321c3027e2242c378e19e48583dba0cb8510b1058c0149f2c658310ccb3c552",
+			"Peers": [{
+				"ID":         1285669455896445,
+				"StableID":   "nGpTFgMH3B11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:10a7c49f80abd134e5539c63738d03d39fa93be860666215284e71441c515576",
+				"DiscoKey":   "discokey:c6839589c5ece4d9f89e9153c1afde8e825fc91b7c08ccff380b03dc6690084b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51162",
+					"10.65.0.27:51162",
+					"172.17.0.1:51162",
+					"172.18.0.1:51162",
+					"172.19.0.1:51162"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:10:07.902843125Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1368026745604867,
+				"StableID":   "n8FTv5kagB11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:61f59d38c73b144a51c001fd7713e6a38ae340b48656d1665db9424996657d38",
+				"DiscoKey":   "discokey:8bcbd57526c2e786167b7515fae3962320a24288d359301e438abaede6f7d868",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:60071",
+					"10.65.0.27:60071",
+					"172.17.0.1:60071",
+					"172.18.0.1:60071",
+					"172.19.0.1:60071"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:10:08.428579986Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4439465031872978,
+				"StableID":   "n7ohdfDefb11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7d0a51dfebb9b70b759a499bdb896573ccffcb7759036f9675cebb81a834a546",
+				"DiscoKey":   "discokey:9fd20abd384b4d53e3f9bfe8798db9c765911125cbbf1302b0391286fcd50e2f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33535",
+					"10.65.0.27:33535",
+					"172.17.0.1:33535",
+					"172.18.0.1:33535",
+					"172.19.0.1:33535"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:10:08.980804027Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3173123217679596,
+				"StableID":   "noNztqZ7nR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:26c4da7100063a53f65d723dad899d463193b16628f6a63fa1ac4a9f87e8097f",
+				"DiscoKey":   "discokey:f0c957795eb196daa64268f646814f38e3a63e9ef64abe35fa06c4e0155b9776",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43132",
+					"10.65.0.27:43132",
+					"172.17.0.1:43132",
+					"172.18.0.1:43132",
+					"172.19.0.1:43132"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:10:09.523013351Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7454394752163285,
+				"StableID":   "n82esxJ7D121CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e420a14a9333217f54880096fed459f3667b056e86fd21b4ca1720d6ce095d42",
+				"DiscoKey":   "discokey:247cd9ca1b1b7f6ceee403624ad0f9e518b338dc6acf2006f5923191c85a7f37",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56797",
+					"10.65.0.27:56797",
+					"172.17.0.1:56797",
+					"172.18.0.1:56797",
+					"172.19.0.1:56797"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:10:10.062488879Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2815166818795474,
+				"StableID":   "nZn5hCfzyN11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a01509e1daef84a506cda8d6ee4a0d01c1198376d3c9694a248e5ecd666f5635",
+				"DiscoKey":   "discokey:91f509159d94eae866cb515a76fab9ee1239330adbd2f4ad100aa18089835c62",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40108",
+					"10.65.0.27:40108",
+					"172.17.0.1:40108",
+					"172.18.0.1:40108",
+					"172.19.0.1:40108"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:10:10.606982354Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7725211482286916,
+				"StableID":   "nwarwwCmK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c2aebd25a98733db00b877fc575773e5449993751e4b8199c3d3d20599ca471f",
+				"DiscoKey":   "discokey:2b9732a96bb41c9cc548bd15a8ca2fa013c1e98959ddd8c8df801c0008dfe705",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37604",
+					"10.65.0.27:37604",
+					"172.17.0.1:37604",
+					"172.18.0.1:37604",
+					"172.19.0.1:37604"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:10:11.140656048Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1773556953774490,
+				"StableID":   "nhnBkMLFrE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:596ec62125e92c83b1534db2856624ce30f87c80b0b538cec0f4c7aa982b5e40",
+				"DiscoKey":   "discokey:d93ad9b922bed652bfcde9baa8110cead44edbc0d58d2c23629f9fd1fa542438",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42973",
+					"10.65.0.27:42973",
+					"172.17.0.1:42973",
+					"172.18.0.1:42973",
+					"172.19.0.1:42973"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:10:11.703069243Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5380620594659572,
+				"StableID":   "nqq4tBnt1j11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d68aba78ad1eb1ab182e269ea2905653d061a0fa42536a4d4e23443366d1a74",
+				"DiscoKey":   "discokey:59d53817b16394419c1710400c77b0f15581695ba7ab815fc7c6e4764f940236",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53362",
+					"10.65.0.27:53362",
+					"172.17.0.1:53362",
+					"172.18.0.1:53362",
+					"172.19.0.1:53362"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:10:12.27683435Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2411809109152787,
+				"StableID":   "n4bA8s8KqK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe59a6e2ed236121da85027bfab0494236ddf0ae5da1438556327453125b8e6d",
+				"DiscoKey":   "discokey:5d59101df49496f8b5bc458ff87a88d78eafa47f11f5d0538aed0456cc863261",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:52689",
+					"10.65.0.27:52689",
+					"172.17.0.1:52689",
+					"172.18.0.1:52689",
+					"172.19.0.1:52689"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:10:13.307985572Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5206214371150158,
+				"StableID":   "nF5q8ZRueh11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6bb0978f30fa6e555b62205c811d1777b4adb705c3032ae0657112f9bd64a11",
+				"DiscoKey":   "discokey:6b22ca8eaa72bd673178b7a1b17153a475284d19c715ffaae8c2345b0cb9d472",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:50596",
+					"10.65.0.27:50596",
+					"172.17.0.1:50596",
+					"172.18.0.1:50596",
+					"172.19.0.1:50596"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:10:13.857173041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2248751212648568,
+				"StableID":   "nsg9B7tTZJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8ce2a9929033e7885055484e70f27adc51fa108cc6951921b9494e07bee72920",
+				"KeyExpiry":  "2026-11-08T22:10:14Z",
+				"DiscoKey":   "discokey:0c1a650e38303f00b4ffad5473f7f6fbbc17e4ccec293dea3a6b5949be8f5a37",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35549",
+					"10.65.0.27:35549",
+					"172.17.0.1:35549",
+					"172.18.0.1:35549",
+					"172.19.0.1:35549"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:10:14.437533871Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7846791554217952,
+				"StableID":   "nwa7agupG421CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:17ce140a9b6fb018394505188400cb5692eac30ac1d9936a1778466297d3bc42",
+				"KeyExpiry":  "2026-11-08T22:10:14Z",
+				"DiscoKey":   "discokey:bf278ed76bff01487b02ad3732433de82e57a02ffdd890283fd795145007161e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50054",
+					"10.65.0.27:50054",
+					"172.17.0.1:50054",
+					"172.18.0.1:50054",
+					"172.19.0.1:50054"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:10:14.931331045Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3029086976321069,
+				"StableID":   "n4ndUkyseQ11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:15613e4e4741e0dbef497a1fafd29461e9362a74fd9dd84f4859c379350db217",
+				"KeyExpiry":  "2026-11-08T22:10:15Z",
+				"DiscoKey":   "discokey:a201876356a1bc03ec0ffeb2db319cab59d419c1c274b5b5e60243670f45f440",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:33971",
+					"10.65.0.27:33971",
+					"172.17.0.1:33971",
+					"172.18.0.1:33971",
+					"172.19.0.1:33971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:10:15.471723426Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5100797787866282": {
+				"ID":          5100797787866282,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-user-tag-prefix.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-user-tag-prefix.hujson
@@ -1,0 +1,20105 @@
+// ssh-malformed-user-tag-prefix
+//
+// ssh users tag prefix is rejected
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T22:11:00Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-malformed-user-tag-prefix",
+	"description":    "ssh users tag prefix is rejected",
+	"category":       "ssh",
+	"captured_at":    "2026-05-12T22:11:00.745331956Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                \n  \n                                                                          \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh users tag prefix is rejected\",\n\t\"id\":          \"ssh-malformed-user-tag-prefix\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"autogroup:member\"],\n\t\t\"users\":  [\"tag:foo\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:foo\":    [\"odin@example.com\"],\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-malformed/ssh-malformed-user-tag-prefix.hujson",
+		"full_policy": {"ssh": [{
+			"action": "accept",
+			"dst":    ["tag:server"],
+			"src":    ["autogroup:member"],
+			"users":  ["tag:foo"]
+		}], "tagOwners": {
+			"tag:foo":    ["odin@example.com"],
+			"tag:prod":   ["odin@example.com"],
+			"tag:server": ["odin@example.com"]
+		}}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8285171886816240,
+				"StableID":   "n9dBQ9RNh721CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       8285171886816240,
+				"Key":        "nodekey:9c497fb63aec1ed4a3f34d7b9ad252da6756f0db7019f72956d3bdaf3023f447",
+				"DiscoKey":   "discokey:52b00a1c33073905d806b423c4453c9eb30071ff0f1f2207e02899ac4454c81a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:50282",
+					"10.65.0.27:50282",
+					"172.17.0.1:50282",
+					"172.18.0.1:50282",
+					"172.19.0.1:50282"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:11:09.324809646Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9c497fb63aec1ed4a3f34d7b9ad252da6756f0db7019f72956d3bdaf3023f447",
+			"MachineKey": "mkey:2cf3f07859b74950078c95628482d7ef8197c354b7d8bd741679dcf1d01e1c20",
+			"Peers": [{
+				"ID":         7795012317679548,
+				"StableID":   "nFENkpkNs321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e30b88d2338acbdfa4c982672da4b2ee6a0ed1125765118bcb0266bb2275c78",
+				"DiscoKey":   "discokey:c8879dc6dbbc2c6df2bb187efdb3edc6ec511d9a7f4698d170929b4feefbf913",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:41045",
+					"10.65.0.27:41045",
+					"172.17.0.1:41045",
+					"172.18.0.1:41045",
+					"172.19.0.1:41045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:11:03.366454178Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2658989023662154,
+				"StableID":   "nfKyjh8GmM11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b97b00031302717abcb4795ff2baca0d05927497069988c5c40081ce250f6109",
+				"DiscoKey":   "discokey:720be127a534b03740ec4dffc6d023530a58e7c0453a7a96b7266ec0754ec948",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44124",
+					"10.65.0.27:44124",
+					"172.17.0.1:44124",
+					"172.18.0.1:44124",
+					"172.19.0.1:44124"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:11:03.89828392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2563925811358875,
+				"StableID":   "nz8WC3zC2M11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ca96115b4c2c976f5b0837be89d9df7e1257f26b92f2484aca73b4857ce9c55",
+				"DiscoKey":   "discokey:dd7b269a69cc2fe4cf7c2265ea8a563be0eaa26b19f9b2330e76f8373d72c409",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35417",
+					"10.65.0.27:35417",
+					"172.17.0.1:35417",
+					"172.18.0.1:35417",
+					"172.19.0.1:35417"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:11:04.432399005Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2215394298792381,
+				"StableID":   "nrfXvneMJJ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b21b16498ae1397a6a2b0ea0aec7a8d42867d5ac37a74c2a7563b11e8f78224a",
+				"DiscoKey":   "discokey:db6021ad39b6f5f0ba85a6a656127747b45d442cc44bf6618686453e28aabe22",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:11:04.964631532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3125719009315563,
+				"StableID":   "ntZDLcLeQR11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:59d8a02904deff653c945d32f7a7f98a69cdcaa8b05f22e82504a3b021e57d06",
+				"DiscoKey":   "discokey:fccc1bd5603bb130e2e8bd836fd09c4ffde2e655a4178ab3866c7b8763704008",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41206",
+					"10.65.0.27:41206",
+					"172.17.0.1:41206",
+					"172.18.0.1:41206",
+					"172.19.0.1:41206"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:11:05.512020264Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2112578502766591,
+				"StableID":   "nAk37brnVH11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08c775eaeaeb4e7c0a1cc2f5e871569f702b2becc7e46613085bd1ac2600255a",
+				"DiscoKey":   "discokey:4179c9d71b2d29f290b2554afcc7681c267e46c424e8e2352deb2c9f155add6e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39265",
+					"10.65.0.27:39265",
+					"172.17.0.1:39265",
+					"172.18.0.1:39265",
+					"172.19.0.1:39265"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:11:06.057397718Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8906729286268412,
+				"StableID":   "nZ9ENAgsYC21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2506aafee00233150ae724d824f90c6e6dc8742f5c10c2ec80b2ae9fd4e3fc06",
+				"DiscoKey":   "discokey:9ffa423721bc18f36f0ce3d1bc45285acfc53c96b01e2ab89395d8571fa03f32",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:45751",
+					"10.65.0.27:45751",
+					"172.17.0.1:45751",
+					"172.18.0.1:45751",
+					"172.19.0.1:45751"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:11:06.604197943Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5141445526124986,
+				"StableID":   "nKmF6E4a9h11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3434073467d2b3339b267f4ef0d0bd96064b6813dad25354ae002b362b94691f",
+				"DiscoKey":   "discokey:f8983fc793d38d2d8a2364daf0f3a9f8e60e4bc7b25da84ae7886de1df72d829",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33958",
+					"10.65.0.27:33958",
+					"172.17.0.1:33958",
+					"172.18.0.1:33958",
+					"172.19.0.1:33958"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:11:07.149196851Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5654962687639987,
+				"StableID":   "n4wQCHH9Am11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8893801cf53923ef1727d5b04bc7e7ef9db2ec0faa63049f33f4f5e3a1d2e661",
+				"DiscoKey":   "discokey:d0bb7268c33983892508acac8222a0b8e6d4db2c987fd61cb7cd9373e28d8b61",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46797",
+					"10.65.0.27:46797",
+					"172.17.0.1:46797",
+					"172.18.0.1:46797",
+					"172.19.0.1:46797"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:11:07.700993037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8526652530688909,
+				"StableID":   "n8gFznhja921CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:947927db7ec0409b45417f6ac72295f5aedd6d256aa296632c55a6896d572330",
+				"DiscoKey":   "discokey:09fe3298c1c5fed5c121a257661803fc26e4e6f9837d6966b2ff7f465b4e511d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54597",
+					"10.65.0.27:54597",
+					"172.17.0.1:54597",
+					"172.18.0.1:54597",
+					"172.19.0.1:54597"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:11:08.252437138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4518198577187111,
+				"StableID":   "nJAUR5RJHc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ada38e0b924e15db5edb9d0200794f809cd2f904a6924775f5b2bacc0273d79",
+				"DiscoKey":   "discokey:069013759ee1b623257c918a427124bc6114ec9275b3564ec96ce48134f21270",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36150",
+					"10.65.0.27:36150",
+					"172.17.0.1:36150",
+					"172.18.0.1:36150",
+					"172.19.0.1:36150"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:11:08.782386347Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4269871067550841,
+				"StableID":   "n4pfkoGqLa11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:534c7f0b05eb184bf6aeb99c28422a63d13d09e9b4b3e010c72d2b5195f8ea25",
+				"KeyExpiry":  "2026-11-08T22:11:09Z",
+				"DiscoKey":   "discokey:a6134eaa656961798296bf09b9b9f0de535b592cba62f73fde5e86631239fa7d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35459",
+					"10.65.0.27:35459",
+					"172.17.0.1:35459",
+					"172.18.0.1:35459",
+					"172.19.0.1:35459"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:11:09.878295429Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3867988008102548,
+				"StableID":   "nBNTyBVpCX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a5882a99c0965a4242cfd47b2233c8ebd70f8b10b2abb0b47d8ec8fb6a722f64",
+				"KeyExpiry":  "2026-11-08T22:11:10Z",
+				"DiscoKey":   "discokey:14fe9bc8594a1cad3141943970ee07f7e2ec7aee50a003d622bbe12af9a69c35",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:33834",
+					"10.65.0.27:33834",
+					"172.17.0.1:33834",
+					"172.18.0.1:33834",
+					"172.19.0.1:33834"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:11:10.417098091Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1536151596243616,
+				"StableID":   "nsJrFf6jzC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:0c86508999647ab76d3e3b36d7e3e5665fdf6021d98c0b4f1b34fe17a32fde1d",
+				"KeyExpiry":  "2026-11-08T22:11:10Z",
+				"DiscoKey":   "discokey:9c1558274db049b32e4d37a4e2a99ba0b3c78709bb54bad36e42d6f57d0d9362",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47599",
+					"10.65.0.27:47599",
+					"172.17.0.1:47599",
+					"172.18.0.1:47599",
+					"172.19.0.1:47599"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:11:10.957037949Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{"principals": [
+				{"nodeIP": "100.64.0.17"},
+				{"nodeIP": "100.64.0.18"},
+				{"nodeIP": "100.64.0.19"},
+				{"nodeIP": "fd7a:115c:a1e0::12"},
+				{"nodeIP": "fd7a:115c:a1e0::11"},
+				{"nodeIP": "fd7a:115c:a1e0::13"}
+			], "sshUsers": {"root": "", "tag:foo": "tag:foo"}, "action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8285171886816240": {
+				"ID":          8285171886816240,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		},
+		"ssh_rules": [{"principals": [
+			{"nodeIP": "100.64.0.17"},
+			{"nodeIP": "100.64.0.18"},
+			{"nodeIP": "100.64.0.19"},
+			{"nodeIP": "fd7a:115c:a1e0::12"},
+			{"nodeIP": "fd7a:115c:a1e0::11"},
+			{"nodeIP": "fd7a:115c:a1e0::13"}
+		], "sshUsers": {"root": "", "tag:foo": "tag:foo"}, "action": {
+			"accept":                    true,
+			"allowAgentForwarding":      true,
+			"allowLocalPortForwarding":  true,
+			"allowRemotePortForwarding": true
+		}}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2112578502766591,
+				"StableID":   "nAk37brnVH11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       2112578502766591,
+				"Key":        "nodekey:08c775eaeaeb4e7c0a1cc2f5e871569f702b2becc7e46613085bd1ac2600255a",
+				"DiscoKey":   "discokey:4179c9d71b2d29f290b2554afcc7681c267e46c424e8e2352deb2c9f155add6e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39265",
+					"10.65.0.27:39265",
+					"172.17.0.1:39265",
+					"172.18.0.1:39265",
+					"172.19.0.1:39265"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:11:06.057397718Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:08c775eaeaeb4e7c0a1cc2f5e871569f702b2becc7e46613085bd1ac2600255a",
+			"MachineKey": "mkey:0281797a909a2e6583f2a3fb176c17964e1a26dad611cf5f0da9a9abe729254c",
+			"Peers": [{
+				"ID":         7795012317679548,
+				"StableID":   "nFENkpkNs321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e30b88d2338acbdfa4c982672da4b2ee6a0ed1125765118bcb0266bb2275c78",
+				"DiscoKey":   "discokey:c8879dc6dbbc2c6df2bb187efdb3edc6ec511d9a7f4698d170929b4feefbf913",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:41045",
+					"10.65.0.27:41045",
+					"172.17.0.1:41045",
+					"172.18.0.1:41045",
+					"172.19.0.1:41045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:11:03.366454178Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2658989023662154,
+				"StableID":   "nfKyjh8GmM11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b97b00031302717abcb4795ff2baca0d05927497069988c5c40081ce250f6109",
+				"DiscoKey":   "discokey:720be127a534b03740ec4dffc6d023530a58e7c0453a7a96b7266ec0754ec948",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44124",
+					"10.65.0.27:44124",
+					"172.17.0.1:44124",
+					"172.18.0.1:44124",
+					"172.19.0.1:44124"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:11:03.89828392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2563925811358875,
+				"StableID":   "nz8WC3zC2M11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ca96115b4c2c976f5b0837be89d9df7e1257f26b92f2484aca73b4857ce9c55",
+				"DiscoKey":   "discokey:dd7b269a69cc2fe4cf7c2265ea8a563be0eaa26b19f9b2330e76f8373d72c409",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35417",
+					"10.65.0.27:35417",
+					"172.17.0.1:35417",
+					"172.18.0.1:35417",
+					"172.19.0.1:35417"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:11:04.432399005Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2215394298792381,
+				"StableID":   "nrfXvneMJJ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b21b16498ae1397a6a2b0ea0aec7a8d42867d5ac37a74c2a7563b11e8f78224a",
+				"DiscoKey":   "discokey:db6021ad39b6f5f0ba85a6a656127747b45d442cc44bf6618686453e28aabe22",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:11:04.964631532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3125719009315563,
+				"StableID":   "ntZDLcLeQR11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:59d8a02904deff653c945d32f7a7f98a69cdcaa8b05f22e82504a3b021e57d06",
+				"DiscoKey":   "discokey:fccc1bd5603bb130e2e8bd836fd09c4ffde2e655a4178ab3866c7b8763704008",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41206",
+					"10.65.0.27:41206",
+					"172.17.0.1:41206",
+					"172.18.0.1:41206",
+					"172.19.0.1:41206"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:11:05.512020264Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8906729286268412,
+				"StableID":   "nZ9ENAgsYC21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2506aafee00233150ae724d824f90c6e6dc8742f5c10c2ec80b2ae9fd4e3fc06",
+				"DiscoKey":   "discokey:9ffa423721bc18f36f0ce3d1bc45285acfc53c96b01e2ab89395d8571fa03f32",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:45751",
+					"10.65.0.27:45751",
+					"172.17.0.1:45751",
+					"172.18.0.1:45751",
+					"172.19.0.1:45751"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:11:06.604197943Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5141445526124986,
+				"StableID":   "nKmF6E4a9h11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3434073467d2b3339b267f4ef0d0bd96064b6813dad25354ae002b362b94691f",
+				"DiscoKey":   "discokey:f8983fc793d38d2d8a2364daf0f3a9f8e60e4bc7b25da84ae7886de1df72d829",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33958",
+					"10.65.0.27:33958",
+					"172.17.0.1:33958",
+					"172.18.0.1:33958",
+					"172.19.0.1:33958"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:11:07.149196851Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5654962687639987,
+				"StableID":   "n4wQCHH9Am11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8893801cf53923ef1727d5b04bc7e7ef9db2ec0faa63049f33f4f5e3a1d2e661",
+				"DiscoKey":   "discokey:d0bb7268c33983892508acac8222a0b8e6d4db2c987fd61cb7cd9373e28d8b61",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46797",
+					"10.65.0.27:46797",
+					"172.17.0.1:46797",
+					"172.18.0.1:46797",
+					"172.19.0.1:46797"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:11:07.700993037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8526652530688909,
+				"StableID":   "n8gFznhja921CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:947927db7ec0409b45417f6ac72295f5aedd6d256aa296632c55a6896d572330",
+				"DiscoKey":   "discokey:09fe3298c1c5fed5c121a257661803fc26e4e6f9837d6966b2ff7f465b4e511d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54597",
+					"10.65.0.27:54597",
+					"172.17.0.1:54597",
+					"172.18.0.1:54597",
+					"172.19.0.1:54597"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:11:08.252437138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4518198577187111,
+				"StableID":   "nJAUR5RJHc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ada38e0b924e15db5edb9d0200794f809cd2f904a6924775f5b2bacc0273d79",
+				"DiscoKey":   "discokey:069013759ee1b623257c918a427124bc6114ec9275b3564ec96ce48134f21270",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36150",
+					"10.65.0.27:36150",
+					"172.17.0.1:36150",
+					"172.18.0.1:36150",
+					"172.19.0.1:36150"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:11:08.782386347Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8285171886816240,
+				"StableID":   "n9dBQ9RNh721CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9c497fb63aec1ed4a3f34d7b9ad252da6756f0db7019f72956d3bdaf3023f447",
+				"DiscoKey":   "discokey:52b00a1c33073905d806b423c4453c9eb30071ff0f1f2207e02899ac4454c81a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:50282",
+					"10.65.0.27:50282",
+					"172.17.0.1:50282",
+					"172.18.0.1:50282",
+					"172.19.0.1:50282"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:11:09.324809646Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4269871067550841,
+				"StableID":   "n4pfkoGqLa11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:534c7f0b05eb184bf6aeb99c28422a63d13d09e9b4b3e010c72d2b5195f8ea25",
+				"KeyExpiry":  "2026-11-08T22:11:09Z",
+				"DiscoKey":   "discokey:a6134eaa656961798296bf09b9b9f0de535b592cba62f73fde5e86631239fa7d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35459",
+					"10.65.0.27:35459",
+					"172.17.0.1:35459",
+					"172.18.0.1:35459",
+					"172.19.0.1:35459"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:11:09.878295429Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3867988008102548,
+				"StableID":   "nBNTyBVpCX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a5882a99c0965a4242cfd47b2233c8ebd70f8b10b2abb0b47d8ec8fb6a722f64",
+				"KeyExpiry":  "2026-11-08T22:11:10Z",
+				"DiscoKey":   "discokey:14fe9bc8594a1cad3141943970ee07f7e2ec7aee50a003d622bbe12af9a69c35",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:33834",
+					"10.65.0.27:33834",
+					"172.17.0.1:33834",
+					"172.18.0.1:33834",
+					"172.19.0.1:33834"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:11:10.417098091Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1536151596243616,
+				"StableID":   "nsJrFf6jzC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:0c86508999647ab76d3e3b36d7e3e5665fdf6021d98c0b4f1b34fe17a32fde1d",
+				"KeyExpiry":  "2026-11-08T22:11:10Z",
+				"DiscoKey":   "discokey:9c1558274db049b32e4d37a4e2a99ba0b3c78709bb54bad36e42d6f57d0d9362",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47599",
+					"10.65.0.27:47599",
+					"172.17.0.1:47599",
+					"172.18.0.1:47599",
+					"172.19.0.1:47599"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:11:10.957037949Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2112578502766591": {
+				"ID":          2112578502766591,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1536151596243616,
+				"StableID":   "nsJrFf6jzC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:0c86508999647ab76d3e3b36d7e3e5665fdf6021d98c0b4f1b34fe17a32fde1d",
+				"KeyExpiry":  "2026-11-08T22:11:10Z",
+				"DiscoKey":   "discokey:9c1558274db049b32e4d37a4e2a99ba0b3c78709bb54bad36e42d6f57d0d9362",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47599",
+					"10.65.0.27:47599",
+					"172.17.0.1:47599",
+					"172.18.0.1:47599",
+					"172.19.0.1:47599"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:11:10.957037949Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0c86508999647ab76d3e3b36d7e3e5665fdf6021d98c0b4f1b34fe17a32fde1d",
+			"MachineKey": "mkey:2567958cde9c6423100400fe7ce75a7cec5db94da8f929965099fedf76658a22",
+			"Peers": [{
+				"ID":         7795012317679548,
+				"StableID":   "nFENkpkNs321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e30b88d2338acbdfa4c982672da4b2ee6a0ed1125765118bcb0266bb2275c78",
+				"DiscoKey":   "discokey:c8879dc6dbbc2c6df2bb187efdb3edc6ec511d9a7f4698d170929b4feefbf913",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:41045",
+					"10.65.0.27:41045",
+					"172.17.0.1:41045",
+					"172.18.0.1:41045",
+					"172.19.0.1:41045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:11:03.366454178Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2658989023662154,
+				"StableID":   "nfKyjh8GmM11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b97b00031302717abcb4795ff2baca0d05927497069988c5c40081ce250f6109",
+				"DiscoKey":   "discokey:720be127a534b03740ec4dffc6d023530a58e7c0453a7a96b7266ec0754ec948",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44124",
+					"10.65.0.27:44124",
+					"172.17.0.1:44124",
+					"172.18.0.1:44124",
+					"172.19.0.1:44124"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:11:03.89828392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2563925811358875,
+				"StableID":   "nz8WC3zC2M11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ca96115b4c2c976f5b0837be89d9df7e1257f26b92f2484aca73b4857ce9c55",
+				"DiscoKey":   "discokey:dd7b269a69cc2fe4cf7c2265ea8a563be0eaa26b19f9b2330e76f8373d72c409",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35417",
+					"10.65.0.27:35417",
+					"172.17.0.1:35417",
+					"172.18.0.1:35417",
+					"172.19.0.1:35417"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:11:04.432399005Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2215394298792381,
+				"StableID":   "nrfXvneMJJ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b21b16498ae1397a6a2b0ea0aec7a8d42867d5ac37a74c2a7563b11e8f78224a",
+				"DiscoKey":   "discokey:db6021ad39b6f5f0ba85a6a656127747b45d442cc44bf6618686453e28aabe22",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:11:04.964631532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3125719009315563,
+				"StableID":   "ntZDLcLeQR11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:59d8a02904deff653c945d32f7a7f98a69cdcaa8b05f22e82504a3b021e57d06",
+				"DiscoKey":   "discokey:fccc1bd5603bb130e2e8bd836fd09c4ffde2e655a4178ab3866c7b8763704008",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41206",
+					"10.65.0.27:41206",
+					"172.17.0.1:41206",
+					"172.18.0.1:41206",
+					"172.19.0.1:41206"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:11:05.512020264Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2112578502766591,
+				"StableID":   "nAk37brnVH11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08c775eaeaeb4e7c0a1cc2f5e871569f702b2becc7e46613085bd1ac2600255a",
+				"DiscoKey":   "discokey:4179c9d71b2d29f290b2554afcc7681c267e46c424e8e2352deb2c9f155add6e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39265",
+					"10.65.0.27:39265",
+					"172.17.0.1:39265",
+					"172.18.0.1:39265",
+					"172.19.0.1:39265"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:11:06.057397718Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8906729286268412,
+				"StableID":   "nZ9ENAgsYC21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2506aafee00233150ae724d824f90c6e6dc8742f5c10c2ec80b2ae9fd4e3fc06",
+				"DiscoKey":   "discokey:9ffa423721bc18f36f0ce3d1bc45285acfc53c96b01e2ab89395d8571fa03f32",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:45751",
+					"10.65.0.27:45751",
+					"172.17.0.1:45751",
+					"172.18.0.1:45751",
+					"172.19.0.1:45751"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:11:06.604197943Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5141445526124986,
+				"StableID":   "nKmF6E4a9h11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3434073467d2b3339b267f4ef0d0bd96064b6813dad25354ae002b362b94691f",
+				"DiscoKey":   "discokey:f8983fc793d38d2d8a2364daf0f3a9f8e60e4bc7b25da84ae7886de1df72d829",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33958",
+					"10.65.0.27:33958",
+					"172.17.0.1:33958",
+					"172.18.0.1:33958",
+					"172.19.0.1:33958"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:11:07.149196851Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5654962687639987,
+				"StableID":   "n4wQCHH9Am11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8893801cf53923ef1727d5b04bc7e7ef9db2ec0faa63049f33f4f5e3a1d2e661",
+				"DiscoKey":   "discokey:d0bb7268c33983892508acac8222a0b8e6d4db2c987fd61cb7cd9373e28d8b61",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46797",
+					"10.65.0.27:46797",
+					"172.17.0.1:46797",
+					"172.18.0.1:46797",
+					"172.19.0.1:46797"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:11:07.700993037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8526652530688909,
+				"StableID":   "n8gFznhja921CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:947927db7ec0409b45417f6ac72295f5aedd6d256aa296632c55a6896d572330",
+				"DiscoKey":   "discokey:09fe3298c1c5fed5c121a257661803fc26e4e6f9837d6966b2ff7f465b4e511d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54597",
+					"10.65.0.27:54597",
+					"172.17.0.1:54597",
+					"172.18.0.1:54597",
+					"172.19.0.1:54597"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:11:08.252437138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4518198577187111,
+				"StableID":   "nJAUR5RJHc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ada38e0b924e15db5edb9d0200794f809cd2f904a6924775f5b2bacc0273d79",
+				"DiscoKey":   "discokey:069013759ee1b623257c918a427124bc6114ec9275b3564ec96ce48134f21270",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36150",
+					"10.65.0.27:36150",
+					"172.17.0.1:36150",
+					"172.18.0.1:36150",
+					"172.19.0.1:36150"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:11:08.782386347Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8285171886816240,
+				"StableID":   "n9dBQ9RNh721CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9c497fb63aec1ed4a3f34d7b9ad252da6756f0db7019f72956d3bdaf3023f447",
+				"DiscoKey":   "discokey:52b00a1c33073905d806b423c4453c9eb30071ff0f1f2207e02899ac4454c81a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:50282",
+					"10.65.0.27:50282",
+					"172.17.0.1:50282",
+					"172.18.0.1:50282",
+					"172.19.0.1:50282"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:11:09.324809646Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4269871067550841,
+				"StableID":   "n4pfkoGqLa11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:534c7f0b05eb184bf6aeb99c28422a63d13d09e9b4b3e010c72d2b5195f8ea25",
+				"KeyExpiry":  "2026-11-08T22:11:09Z",
+				"DiscoKey":   "discokey:a6134eaa656961798296bf09b9b9f0de535b592cba62f73fde5e86631239fa7d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35459",
+					"10.65.0.27:35459",
+					"172.17.0.1:35459",
+					"172.18.0.1:35459",
+					"172.19.0.1:35459"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:11:09.878295429Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3867988008102548,
+				"StableID":   "nBNTyBVpCX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a5882a99c0965a4242cfd47b2233c8ebd70f8b10b2abb0b47d8ec8fb6a722f64",
+				"KeyExpiry":  "2026-11-08T22:11:10Z",
+				"DiscoKey":   "discokey:14fe9bc8594a1cad3141943970ee07f7e2ec7aee50a003d622bbe12af9a69c35",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:33834",
+					"10.65.0.27:33834",
+					"172.17.0.1:33834",
+					"172.18.0.1:33834",
+					"172.19.0.1:33834"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:11:10.417098091Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2563925811358875,
+				"StableID":   "nz8WC3zC2M11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       2563925811358875,
+				"Key":        "nodekey:4ca96115b4c2c976f5b0837be89d9df7e1257f26b92f2484aca73b4857ce9c55",
+				"DiscoKey":   "discokey:dd7b269a69cc2fe4cf7c2265ea8a563be0eaa26b19f9b2330e76f8373d72c409",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35417",
+					"10.65.0.27:35417",
+					"172.17.0.1:35417",
+					"172.18.0.1:35417",
+					"172.19.0.1:35417"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:11:04.432399005Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4ca96115b4c2c976f5b0837be89d9df7e1257f26b92f2484aca73b4857ce9c55",
+			"MachineKey": "mkey:5de085c764765e21610e6fdaf76f5cf475b0c36aa7d7f6b0563bd21cb240bc5e",
+			"Peers": [{
+				"ID":         7795012317679548,
+				"StableID":   "nFENkpkNs321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e30b88d2338acbdfa4c982672da4b2ee6a0ed1125765118bcb0266bb2275c78",
+				"DiscoKey":   "discokey:c8879dc6dbbc2c6df2bb187efdb3edc6ec511d9a7f4698d170929b4feefbf913",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:41045",
+					"10.65.0.27:41045",
+					"172.17.0.1:41045",
+					"172.18.0.1:41045",
+					"172.19.0.1:41045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:11:03.366454178Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2658989023662154,
+				"StableID":   "nfKyjh8GmM11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b97b00031302717abcb4795ff2baca0d05927497069988c5c40081ce250f6109",
+				"DiscoKey":   "discokey:720be127a534b03740ec4dffc6d023530a58e7c0453a7a96b7266ec0754ec948",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44124",
+					"10.65.0.27:44124",
+					"172.17.0.1:44124",
+					"172.18.0.1:44124",
+					"172.19.0.1:44124"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:11:03.89828392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2215394298792381,
+				"StableID":   "nrfXvneMJJ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b21b16498ae1397a6a2b0ea0aec7a8d42867d5ac37a74c2a7563b11e8f78224a",
+				"DiscoKey":   "discokey:db6021ad39b6f5f0ba85a6a656127747b45d442cc44bf6618686453e28aabe22",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:11:04.964631532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3125719009315563,
+				"StableID":   "ntZDLcLeQR11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:59d8a02904deff653c945d32f7a7f98a69cdcaa8b05f22e82504a3b021e57d06",
+				"DiscoKey":   "discokey:fccc1bd5603bb130e2e8bd836fd09c4ffde2e655a4178ab3866c7b8763704008",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41206",
+					"10.65.0.27:41206",
+					"172.17.0.1:41206",
+					"172.18.0.1:41206",
+					"172.19.0.1:41206"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:11:05.512020264Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2112578502766591,
+				"StableID":   "nAk37brnVH11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08c775eaeaeb4e7c0a1cc2f5e871569f702b2becc7e46613085bd1ac2600255a",
+				"DiscoKey":   "discokey:4179c9d71b2d29f290b2554afcc7681c267e46c424e8e2352deb2c9f155add6e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39265",
+					"10.65.0.27:39265",
+					"172.17.0.1:39265",
+					"172.18.0.1:39265",
+					"172.19.0.1:39265"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:11:06.057397718Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8906729286268412,
+				"StableID":   "nZ9ENAgsYC21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2506aafee00233150ae724d824f90c6e6dc8742f5c10c2ec80b2ae9fd4e3fc06",
+				"DiscoKey":   "discokey:9ffa423721bc18f36f0ce3d1bc45285acfc53c96b01e2ab89395d8571fa03f32",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:45751",
+					"10.65.0.27:45751",
+					"172.17.0.1:45751",
+					"172.18.0.1:45751",
+					"172.19.0.1:45751"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:11:06.604197943Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5141445526124986,
+				"StableID":   "nKmF6E4a9h11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3434073467d2b3339b267f4ef0d0bd96064b6813dad25354ae002b362b94691f",
+				"DiscoKey":   "discokey:f8983fc793d38d2d8a2364daf0f3a9f8e60e4bc7b25da84ae7886de1df72d829",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33958",
+					"10.65.0.27:33958",
+					"172.17.0.1:33958",
+					"172.18.0.1:33958",
+					"172.19.0.1:33958"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:11:07.149196851Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5654962687639987,
+				"StableID":   "n4wQCHH9Am11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8893801cf53923ef1727d5b04bc7e7ef9db2ec0faa63049f33f4f5e3a1d2e661",
+				"DiscoKey":   "discokey:d0bb7268c33983892508acac8222a0b8e6d4db2c987fd61cb7cd9373e28d8b61",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46797",
+					"10.65.0.27:46797",
+					"172.17.0.1:46797",
+					"172.18.0.1:46797",
+					"172.19.0.1:46797"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:11:07.700993037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8526652530688909,
+				"StableID":   "n8gFznhja921CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:947927db7ec0409b45417f6ac72295f5aedd6d256aa296632c55a6896d572330",
+				"DiscoKey":   "discokey:09fe3298c1c5fed5c121a257661803fc26e4e6f9837d6966b2ff7f465b4e511d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54597",
+					"10.65.0.27:54597",
+					"172.17.0.1:54597",
+					"172.18.0.1:54597",
+					"172.19.0.1:54597"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:11:08.252437138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4518198577187111,
+				"StableID":   "nJAUR5RJHc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ada38e0b924e15db5edb9d0200794f809cd2f904a6924775f5b2bacc0273d79",
+				"DiscoKey":   "discokey:069013759ee1b623257c918a427124bc6114ec9275b3564ec96ce48134f21270",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36150",
+					"10.65.0.27:36150",
+					"172.17.0.1:36150",
+					"172.18.0.1:36150",
+					"172.19.0.1:36150"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:11:08.782386347Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8285171886816240,
+				"StableID":   "n9dBQ9RNh721CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9c497fb63aec1ed4a3f34d7b9ad252da6756f0db7019f72956d3bdaf3023f447",
+				"DiscoKey":   "discokey:52b00a1c33073905d806b423c4453c9eb30071ff0f1f2207e02899ac4454c81a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:50282",
+					"10.65.0.27:50282",
+					"172.17.0.1:50282",
+					"172.18.0.1:50282",
+					"172.19.0.1:50282"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:11:09.324809646Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4269871067550841,
+				"StableID":   "n4pfkoGqLa11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:534c7f0b05eb184bf6aeb99c28422a63d13d09e9b4b3e010c72d2b5195f8ea25",
+				"KeyExpiry":  "2026-11-08T22:11:09Z",
+				"DiscoKey":   "discokey:a6134eaa656961798296bf09b9b9f0de535b592cba62f73fde5e86631239fa7d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35459",
+					"10.65.0.27:35459",
+					"172.17.0.1:35459",
+					"172.18.0.1:35459",
+					"172.19.0.1:35459"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:11:09.878295429Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3867988008102548,
+				"StableID":   "nBNTyBVpCX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a5882a99c0965a4242cfd47b2233c8ebd70f8b10b2abb0b47d8ec8fb6a722f64",
+				"KeyExpiry":  "2026-11-08T22:11:10Z",
+				"DiscoKey":   "discokey:14fe9bc8594a1cad3141943970ee07f7e2ec7aee50a003d622bbe12af9a69c35",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:33834",
+					"10.65.0.27:33834",
+					"172.17.0.1:33834",
+					"172.18.0.1:33834",
+					"172.19.0.1:33834"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:11:10.417098091Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1536151596243616,
+				"StableID":   "nsJrFf6jzC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:0c86508999647ab76d3e3b36d7e3e5665fdf6021d98c0b4f1b34fe17a32fde1d",
+				"KeyExpiry":  "2026-11-08T22:11:10Z",
+				"DiscoKey":   "discokey:9c1558274db049b32e4d37a4e2a99ba0b3c78709bb54bad36e42d6f57d0d9362",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47599",
+					"10.65.0.27:47599",
+					"172.17.0.1:47599",
+					"172.18.0.1:47599",
+					"172.19.0.1:47599"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:11:10.957037949Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2563925811358875": {
+				"ID":          2563925811358875,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5141445526124986,
+				"StableID":   "nKmF6E4a9h11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       5141445526124986,
+				"Key":        "nodekey:3434073467d2b3339b267f4ef0d0bd96064b6813dad25354ae002b362b94691f",
+				"DiscoKey":   "discokey:f8983fc793d38d2d8a2364daf0f3a9f8e60e4bc7b25da84ae7886de1df72d829",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33958",
+					"10.65.0.27:33958",
+					"172.17.0.1:33958",
+					"172.18.0.1:33958",
+					"172.19.0.1:33958"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:11:07.149196851Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3434073467d2b3339b267f4ef0d0bd96064b6813dad25354ae002b362b94691f",
+			"MachineKey": "mkey:2f5fa317665d5f04b568abf78c0a68e598bc840525cb6d4e51fac9f5109af959",
+			"Peers": [{
+				"ID":         7795012317679548,
+				"StableID":   "nFENkpkNs321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e30b88d2338acbdfa4c982672da4b2ee6a0ed1125765118bcb0266bb2275c78",
+				"DiscoKey":   "discokey:c8879dc6dbbc2c6df2bb187efdb3edc6ec511d9a7f4698d170929b4feefbf913",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:41045",
+					"10.65.0.27:41045",
+					"172.17.0.1:41045",
+					"172.18.0.1:41045",
+					"172.19.0.1:41045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:11:03.366454178Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2658989023662154,
+				"StableID":   "nfKyjh8GmM11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b97b00031302717abcb4795ff2baca0d05927497069988c5c40081ce250f6109",
+				"DiscoKey":   "discokey:720be127a534b03740ec4dffc6d023530a58e7c0453a7a96b7266ec0754ec948",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44124",
+					"10.65.0.27:44124",
+					"172.17.0.1:44124",
+					"172.18.0.1:44124",
+					"172.19.0.1:44124"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:11:03.89828392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2563925811358875,
+				"StableID":   "nz8WC3zC2M11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ca96115b4c2c976f5b0837be89d9df7e1257f26b92f2484aca73b4857ce9c55",
+				"DiscoKey":   "discokey:dd7b269a69cc2fe4cf7c2265ea8a563be0eaa26b19f9b2330e76f8373d72c409",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35417",
+					"10.65.0.27:35417",
+					"172.17.0.1:35417",
+					"172.18.0.1:35417",
+					"172.19.0.1:35417"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:11:04.432399005Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2215394298792381,
+				"StableID":   "nrfXvneMJJ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b21b16498ae1397a6a2b0ea0aec7a8d42867d5ac37a74c2a7563b11e8f78224a",
+				"DiscoKey":   "discokey:db6021ad39b6f5f0ba85a6a656127747b45d442cc44bf6618686453e28aabe22",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:11:04.964631532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3125719009315563,
+				"StableID":   "ntZDLcLeQR11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:59d8a02904deff653c945d32f7a7f98a69cdcaa8b05f22e82504a3b021e57d06",
+				"DiscoKey":   "discokey:fccc1bd5603bb130e2e8bd836fd09c4ffde2e655a4178ab3866c7b8763704008",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41206",
+					"10.65.0.27:41206",
+					"172.17.0.1:41206",
+					"172.18.0.1:41206",
+					"172.19.0.1:41206"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:11:05.512020264Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2112578502766591,
+				"StableID":   "nAk37brnVH11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08c775eaeaeb4e7c0a1cc2f5e871569f702b2becc7e46613085bd1ac2600255a",
+				"DiscoKey":   "discokey:4179c9d71b2d29f290b2554afcc7681c267e46c424e8e2352deb2c9f155add6e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39265",
+					"10.65.0.27:39265",
+					"172.17.0.1:39265",
+					"172.18.0.1:39265",
+					"172.19.0.1:39265"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:11:06.057397718Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8906729286268412,
+				"StableID":   "nZ9ENAgsYC21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2506aafee00233150ae724d824f90c6e6dc8742f5c10c2ec80b2ae9fd4e3fc06",
+				"DiscoKey":   "discokey:9ffa423721bc18f36f0ce3d1bc45285acfc53c96b01e2ab89395d8571fa03f32",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:45751",
+					"10.65.0.27:45751",
+					"172.17.0.1:45751",
+					"172.18.0.1:45751",
+					"172.19.0.1:45751"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:11:06.604197943Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5654962687639987,
+				"StableID":   "n4wQCHH9Am11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8893801cf53923ef1727d5b04bc7e7ef9db2ec0faa63049f33f4f5e3a1d2e661",
+				"DiscoKey":   "discokey:d0bb7268c33983892508acac8222a0b8e6d4db2c987fd61cb7cd9373e28d8b61",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46797",
+					"10.65.0.27:46797",
+					"172.17.0.1:46797",
+					"172.18.0.1:46797",
+					"172.19.0.1:46797"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:11:07.700993037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8526652530688909,
+				"StableID":   "n8gFznhja921CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:947927db7ec0409b45417f6ac72295f5aedd6d256aa296632c55a6896d572330",
+				"DiscoKey":   "discokey:09fe3298c1c5fed5c121a257661803fc26e4e6f9837d6966b2ff7f465b4e511d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54597",
+					"10.65.0.27:54597",
+					"172.17.0.1:54597",
+					"172.18.0.1:54597",
+					"172.19.0.1:54597"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:11:08.252437138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4518198577187111,
+				"StableID":   "nJAUR5RJHc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ada38e0b924e15db5edb9d0200794f809cd2f904a6924775f5b2bacc0273d79",
+				"DiscoKey":   "discokey:069013759ee1b623257c918a427124bc6114ec9275b3564ec96ce48134f21270",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36150",
+					"10.65.0.27:36150",
+					"172.17.0.1:36150",
+					"172.18.0.1:36150",
+					"172.19.0.1:36150"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:11:08.782386347Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8285171886816240,
+				"StableID":   "n9dBQ9RNh721CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9c497fb63aec1ed4a3f34d7b9ad252da6756f0db7019f72956d3bdaf3023f447",
+				"DiscoKey":   "discokey:52b00a1c33073905d806b423c4453c9eb30071ff0f1f2207e02899ac4454c81a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:50282",
+					"10.65.0.27:50282",
+					"172.17.0.1:50282",
+					"172.18.0.1:50282",
+					"172.19.0.1:50282"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:11:09.324809646Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4269871067550841,
+				"StableID":   "n4pfkoGqLa11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:534c7f0b05eb184bf6aeb99c28422a63d13d09e9b4b3e010c72d2b5195f8ea25",
+				"KeyExpiry":  "2026-11-08T22:11:09Z",
+				"DiscoKey":   "discokey:a6134eaa656961798296bf09b9b9f0de535b592cba62f73fde5e86631239fa7d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35459",
+					"10.65.0.27:35459",
+					"172.17.0.1:35459",
+					"172.18.0.1:35459",
+					"172.19.0.1:35459"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:11:09.878295429Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3867988008102548,
+				"StableID":   "nBNTyBVpCX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a5882a99c0965a4242cfd47b2233c8ebd70f8b10b2abb0b47d8ec8fb6a722f64",
+				"KeyExpiry":  "2026-11-08T22:11:10Z",
+				"DiscoKey":   "discokey:14fe9bc8594a1cad3141943970ee07f7e2ec7aee50a003d622bbe12af9a69c35",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:33834",
+					"10.65.0.27:33834",
+					"172.17.0.1:33834",
+					"172.18.0.1:33834",
+					"172.19.0.1:33834"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:11:10.417098091Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1536151596243616,
+				"StableID":   "nsJrFf6jzC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:0c86508999647ab76d3e3b36d7e3e5665fdf6021d98c0b4f1b34fe17a32fde1d",
+				"KeyExpiry":  "2026-11-08T22:11:10Z",
+				"DiscoKey":   "discokey:9c1558274db049b32e4d37a4e2a99ba0b3c78709bb54bad36e42d6f57d0d9362",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47599",
+					"10.65.0.27:47599",
+					"172.17.0.1:47599",
+					"172.18.0.1:47599",
+					"172.19.0.1:47599"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:11:10.957037949Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5141445526124986": {
+				"ID":          5141445526124986,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4269871067550841,
+				"StableID":   "n4pfkoGqLa11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:534c7f0b05eb184bf6aeb99c28422a63d13d09e9b4b3e010c72d2b5195f8ea25",
+				"KeyExpiry":  "2026-11-08T22:11:09Z",
+				"DiscoKey":   "discokey:a6134eaa656961798296bf09b9b9f0de535b592cba62f73fde5e86631239fa7d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35459",
+					"10.65.0.27:35459",
+					"172.17.0.1:35459",
+					"172.18.0.1:35459",
+					"172.19.0.1:35459"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:11:09.878295429Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:534c7f0b05eb184bf6aeb99c28422a63d13d09e9b4b3e010c72d2b5195f8ea25",
+			"MachineKey": "mkey:38a6f4a3ceebf722ca7931b87f81c1fe8ecc3c8486b8c278b98de84713e7d57c",
+			"Peers": [{
+				"ID":         7795012317679548,
+				"StableID":   "nFENkpkNs321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e30b88d2338acbdfa4c982672da4b2ee6a0ed1125765118bcb0266bb2275c78",
+				"DiscoKey":   "discokey:c8879dc6dbbc2c6df2bb187efdb3edc6ec511d9a7f4698d170929b4feefbf913",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:41045",
+					"10.65.0.27:41045",
+					"172.17.0.1:41045",
+					"172.18.0.1:41045",
+					"172.19.0.1:41045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:11:03.366454178Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2658989023662154,
+				"StableID":   "nfKyjh8GmM11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b97b00031302717abcb4795ff2baca0d05927497069988c5c40081ce250f6109",
+				"DiscoKey":   "discokey:720be127a534b03740ec4dffc6d023530a58e7c0453a7a96b7266ec0754ec948",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44124",
+					"10.65.0.27:44124",
+					"172.17.0.1:44124",
+					"172.18.0.1:44124",
+					"172.19.0.1:44124"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:11:03.89828392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2563925811358875,
+				"StableID":   "nz8WC3zC2M11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ca96115b4c2c976f5b0837be89d9df7e1257f26b92f2484aca73b4857ce9c55",
+				"DiscoKey":   "discokey:dd7b269a69cc2fe4cf7c2265ea8a563be0eaa26b19f9b2330e76f8373d72c409",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35417",
+					"10.65.0.27:35417",
+					"172.17.0.1:35417",
+					"172.18.0.1:35417",
+					"172.19.0.1:35417"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:11:04.432399005Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2215394298792381,
+				"StableID":   "nrfXvneMJJ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b21b16498ae1397a6a2b0ea0aec7a8d42867d5ac37a74c2a7563b11e8f78224a",
+				"DiscoKey":   "discokey:db6021ad39b6f5f0ba85a6a656127747b45d442cc44bf6618686453e28aabe22",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:11:04.964631532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3125719009315563,
+				"StableID":   "ntZDLcLeQR11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:59d8a02904deff653c945d32f7a7f98a69cdcaa8b05f22e82504a3b021e57d06",
+				"DiscoKey":   "discokey:fccc1bd5603bb130e2e8bd836fd09c4ffde2e655a4178ab3866c7b8763704008",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41206",
+					"10.65.0.27:41206",
+					"172.17.0.1:41206",
+					"172.18.0.1:41206",
+					"172.19.0.1:41206"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:11:05.512020264Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2112578502766591,
+				"StableID":   "nAk37brnVH11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08c775eaeaeb4e7c0a1cc2f5e871569f702b2becc7e46613085bd1ac2600255a",
+				"DiscoKey":   "discokey:4179c9d71b2d29f290b2554afcc7681c267e46c424e8e2352deb2c9f155add6e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39265",
+					"10.65.0.27:39265",
+					"172.17.0.1:39265",
+					"172.18.0.1:39265",
+					"172.19.0.1:39265"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:11:06.057397718Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8906729286268412,
+				"StableID":   "nZ9ENAgsYC21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2506aafee00233150ae724d824f90c6e6dc8742f5c10c2ec80b2ae9fd4e3fc06",
+				"DiscoKey":   "discokey:9ffa423721bc18f36f0ce3d1bc45285acfc53c96b01e2ab89395d8571fa03f32",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:45751",
+					"10.65.0.27:45751",
+					"172.17.0.1:45751",
+					"172.18.0.1:45751",
+					"172.19.0.1:45751"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:11:06.604197943Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5141445526124986,
+				"StableID":   "nKmF6E4a9h11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3434073467d2b3339b267f4ef0d0bd96064b6813dad25354ae002b362b94691f",
+				"DiscoKey":   "discokey:f8983fc793d38d2d8a2364daf0f3a9f8e60e4bc7b25da84ae7886de1df72d829",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33958",
+					"10.65.0.27:33958",
+					"172.17.0.1:33958",
+					"172.18.0.1:33958",
+					"172.19.0.1:33958"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:11:07.149196851Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5654962687639987,
+				"StableID":   "n4wQCHH9Am11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8893801cf53923ef1727d5b04bc7e7ef9db2ec0faa63049f33f4f5e3a1d2e661",
+				"DiscoKey":   "discokey:d0bb7268c33983892508acac8222a0b8e6d4db2c987fd61cb7cd9373e28d8b61",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46797",
+					"10.65.0.27:46797",
+					"172.17.0.1:46797",
+					"172.18.0.1:46797",
+					"172.19.0.1:46797"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:11:07.700993037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8526652530688909,
+				"StableID":   "n8gFznhja921CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:947927db7ec0409b45417f6ac72295f5aedd6d256aa296632c55a6896d572330",
+				"DiscoKey":   "discokey:09fe3298c1c5fed5c121a257661803fc26e4e6f9837d6966b2ff7f465b4e511d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54597",
+					"10.65.0.27:54597",
+					"172.17.0.1:54597",
+					"172.18.0.1:54597",
+					"172.19.0.1:54597"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:11:08.252437138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4518198577187111,
+				"StableID":   "nJAUR5RJHc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ada38e0b924e15db5edb9d0200794f809cd2f904a6924775f5b2bacc0273d79",
+				"DiscoKey":   "discokey:069013759ee1b623257c918a427124bc6114ec9275b3564ec96ce48134f21270",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36150",
+					"10.65.0.27:36150",
+					"172.17.0.1:36150",
+					"172.18.0.1:36150",
+					"172.19.0.1:36150"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:11:08.782386347Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8285171886816240,
+				"StableID":   "n9dBQ9RNh721CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9c497fb63aec1ed4a3f34d7b9ad252da6756f0db7019f72956d3bdaf3023f447",
+				"DiscoKey":   "discokey:52b00a1c33073905d806b423c4453c9eb30071ff0f1f2207e02899ac4454c81a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:50282",
+					"10.65.0.27:50282",
+					"172.17.0.1:50282",
+					"172.18.0.1:50282",
+					"172.19.0.1:50282"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:11:09.324809646Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3867988008102548,
+				"StableID":   "nBNTyBVpCX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a5882a99c0965a4242cfd47b2233c8ebd70f8b10b2abb0b47d8ec8fb6a722f64",
+				"KeyExpiry":  "2026-11-08T22:11:10Z",
+				"DiscoKey":   "discokey:14fe9bc8594a1cad3141943970ee07f7e2ec7aee50a003d622bbe12af9a69c35",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:33834",
+					"10.65.0.27:33834",
+					"172.17.0.1:33834",
+					"172.18.0.1:33834",
+					"172.19.0.1:33834"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:11:10.417098091Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1536151596243616,
+				"StableID":   "nsJrFf6jzC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:0c86508999647ab76d3e3b36d7e3e5665fdf6021d98c0b4f1b34fe17a32fde1d",
+				"KeyExpiry":  "2026-11-08T22:11:10Z",
+				"DiscoKey":   "discokey:9c1558274db049b32e4d37a4e2a99ba0b3c78709bb54bad36e42d6f57d0d9362",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47599",
+					"10.65.0.27:47599",
+					"172.17.0.1:47599",
+					"172.18.0.1:47599",
+					"172.19.0.1:47599"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:11:10.957037949Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4518198577187111,
+				"StableID":   "nJAUR5RJHc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       4518198577187111,
+				"Key":        "nodekey:7ada38e0b924e15db5edb9d0200794f809cd2f904a6924775f5b2bacc0273d79",
+				"DiscoKey":   "discokey:069013759ee1b623257c918a427124bc6114ec9275b3564ec96ce48134f21270",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36150",
+					"10.65.0.27:36150",
+					"172.17.0.1:36150",
+					"172.18.0.1:36150",
+					"172.19.0.1:36150"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:11:08.782386347Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7ada38e0b924e15db5edb9d0200794f809cd2f904a6924775f5b2bacc0273d79",
+			"MachineKey": "mkey:36312dec331138f99851a9f2b2368aac2d8e451f9a767ef1730dd2483c8d5565",
+			"Peers": [{
+				"ID":         7795012317679548,
+				"StableID":   "nFENkpkNs321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e30b88d2338acbdfa4c982672da4b2ee6a0ed1125765118bcb0266bb2275c78",
+				"DiscoKey":   "discokey:c8879dc6dbbc2c6df2bb187efdb3edc6ec511d9a7f4698d170929b4feefbf913",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:41045",
+					"10.65.0.27:41045",
+					"172.17.0.1:41045",
+					"172.18.0.1:41045",
+					"172.19.0.1:41045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:11:03.366454178Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2658989023662154,
+				"StableID":   "nfKyjh8GmM11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b97b00031302717abcb4795ff2baca0d05927497069988c5c40081ce250f6109",
+				"DiscoKey":   "discokey:720be127a534b03740ec4dffc6d023530a58e7c0453a7a96b7266ec0754ec948",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44124",
+					"10.65.0.27:44124",
+					"172.17.0.1:44124",
+					"172.18.0.1:44124",
+					"172.19.0.1:44124"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:11:03.89828392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2563925811358875,
+				"StableID":   "nz8WC3zC2M11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ca96115b4c2c976f5b0837be89d9df7e1257f26b92f2484aca73b4857ce9c55",
+				"DiscoKey":   "discokey:dd7b269a69cc2fe4cf7c2265ea8a563be0eaa26b19f9b2330e76f8373d72c409",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35417",
+					"10.65.0.27:35417",
+					"172.17.0.1:35417",
+					"172.18.0.1:35417",
+					"172.19.0.1:35417"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:11:04.432399005Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2215394298792381,
+				"StableID":   "nrfXvneMJJ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b21b16498ae1397a6a2b0ea0aec7a8d42867d5ac37a74c2a7563b11e8f78224a",
+				"DiscoKey":   "discokey:db6021ad39b6f5f0ba85a6a656127747b45d442cc44bf6618686453e28aabe22",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:11:04.964631532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3125719009315563,
+				"StableID":   "ntZDLcLeQR11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:59d8a02904deff653c945d32f7a7f98a69cdcaa8b05f22e82504a3b021e57d06",
+				"DiscoKey":   "discokey:fccc1bd5603bb130e2e8bd836fd09c4ffde2e655a4178ab3866c7b8763704008",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41206",
+					"10.65.0.27:41206",
+					"172.17.0.1:41206",
+					"172.18.0.1:41206",
+					"172.19.0.1:41206"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:11:05.512020264Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2112578502766591,
+				"StableID":   "nAk37brnVH11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08c775eaeaeb4e7c0a1cc2f5e871569f702b2becc7e46613085bd1ac2600255a",
+				"DiscoKey":   "discokey:4179c9d71b2d29f290b2554afcc7681c267e46c424e8e2352deb2c9f155add6e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39265",
+					"10.65.0.27:39265",
+					"172.17.0.1:39265",
+					"172.18.0.1:39265",
+					"172.19.0.1:39265"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:11:06.057397718Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8906729286268412,
+				"StableID":   "nZ9ENAgsYC21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2506aafee00233150ae724d824f90c6e6dc8742f5c10c2ec80b2ae9fd4e3fc06",
+				"DiscoKey":   "discokey:9ffa423721bc18f36f0ce3d1bc45285acfc53c96b01e2ab89395d8571fa03f32",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:45751",
+					"10.65.0.27:45751",
+					"172.17.0.1:45751",
+					"172.18.0.1:45751",
+					"172.19.0.1:45751"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:11:06.604197943Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5141445526124986,
+				"StableID":   "nKmF6E4a9h11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3434073467d2b3339b267f4ef0d0bd96064b6813dad25354ae002b362b94691f",
+				"DiscoKey":   "discokey:f8983fc793d38d2d8a2364daf0f3a9f8e60e4bc7b25da84ae7886de1df72d829",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33958",
+					"10.65.0.27:33958",
+					"172.17.0.1:33958",
+					"172.18.0.1:33958",
+					"172.19.0.1:33958"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:11:07.149196851Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5654962687639987,
+				"StableID":   "n4wQCHH9Am11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8893801cf53923ef1727d5b04bc7e7ef9db2ec0faa63049f33f4f5e3a1d2e661",
+				"DiscoKey":   "discokey:d0bb7268c33983892508acac8222a0b8e6d4db2c987fd61cb7cd9373e28d8b61",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46797",
+					"10.65.0.27:46797",
+					"172.17.0.1:46797",
+					"172.18.0.1:46797",
+					"172.19.0.1:46797"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:11:07.700993037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8526652530688909,
+				"StableID":   "n8gFznhja921CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:947927db7ec0409b45417f6ac72295f5aedd6d256aa296632c55a6896d572330",
+				"DiscoKey":   "discokey:09fe3298c1c5fed5c121a257661803fc26e4e6f9837d6966b2ff7f465b4e511d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54597",
+					"10.65.0.27:54597",
+					"172.17.0.1:54597",
+					"172.18.0.1:54597",
+					"172.19.0.1:54597"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:11:08.252437138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8285171886816240,
+				"StableID":   "n9dBQ9RNh721CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9c497fb63aec1ed4a3f34d7b9ad252da6756f0db7019f72956d3bdaf3023f447",
+				"DiscoKey":   "discokey:52b00a1c33073905d806b423c4453c9eb30071ff0f1f2207e02899ac4454c81a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:50282",
+					"10.65.0.27:50282",
+					"172.17.0.1:50282",
+					"172.18.0.1:50282",
+					"172.19.0.1:50282"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:11:09.324809646Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4269871067550841,
+				"StableID":   "n4pfkoGqLa11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:534c7f0b05eb184bf6aeb99c28422a63d13d09e9b4b3e010c72d2b5195f8ea25",
+				"KeyExpiry":  "2026-11-08T22:11:09Z",
+				"DiscoKey":   "discokey:a6134eaa656961798296bf09b9b9f0de535b592cba62f73fde5e86631239fa7d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35459",
+					"10.65.0.27:35459",
+					"172.17.0.1:35459",
+					"172.18.0.1:35459",
+					"172.19.0.1:35459"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:11:09.878295429Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3867988008102548,
+				"StableID":   "nBNTyBVpCX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a5882a99c0965a4242cfd47b2233c8ebd70f8b10b2abb0b47d8ec8fb6a722f64",
+				"KeyExpiry":  "2026-11-08T22:11:10Z",
+				"DiscoKey":   "discokey:14fe9bc8594a1cad3141943970ee07f7e2ec7aee50a003d622bbe12af9a69c35",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:33834",
+					"10.65.0.27:33834",
+					"172.17.0.1:33834",
+					"172.18.0.1:33834",
+					"172.19.0.1:33834"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:11:10.417098091Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1536151596243616,
+				"StableID":   "nsJrFf6jzC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:0c86508999647ab76d3e3b36d7e3e5665fdf6021d98c0b4f1b34fe17a32fde1d",
+				"KeyExpiry":  "2026-11-08T22:11:10Z",
+				"DiscoKey":   "discokey:9c1558274db049b32e4d37a4e2a99ba0b3c78709bb54bad36e42d6f57d0d9362",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47599",
+					"10.65.0.27:47599",
+					"172.17.0.1:47599",
+					"172.18.0.1:47599",
+					"172.19.0.1:47599"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:11:10.957037949Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4518198577187111": {
+				"ID":          4518198577187111,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2658989023662154,
+				"StableID":   "nfKyjh8GmM11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       2658989023662154,
+				"Key":        "nodekey:b97b00031302717abcb4795ff2baca0d05927497069988c5c40081ce250f6109",
+				"DiscoKey":   "discokey:720be127a534b03740ec4dffc6d023530a58e7c0453a7a96b7266ec0754ec948",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44124",
+					"10.65.0.27:44124",
+					"172.17.0.1:44124",
+					"172.18.0.1:44124",
+					"172.19.0.1:44124"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:11:03.89828392Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b97b00031302717abcb4795ff2baca0d05927497069988c5c40081ce250f6109",
+			"MachineKey": "mkey:8eeabea003bcc261d952c78e609d09b5d9409f34d5c789bd8f1d3c3e15a30c27",
+			"Peers": [{
+				"ID":         7795012317679548,
+				"StableID":   "nFENkpkNs321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e30b88d2338acbdfa4c982672da4b2ee6a0ed1125765118bcb0266bb2275c78",
+				"DiscoKey":   "discokey:c8879dc6dbbc2c6df2bb187efdb3edc6ec511d9a7f4698d170929b4feefbf913",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:41045",
+					"10.65.0.27:41045",
+					"172.17.0.1:41045",
+					"172.18.0.1:41045",
+					"172.19.0.1:41045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:11:03.366454178Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2563925811358875,
+				"StableID":   "nz8WC3zC2M11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ca96115b4c2c976f5b0837be89d9df7e1257f26b92f2484aca73b4857ce9c55",
+				"DiscoKey":   "discokey:dd7b269a69cc2fe4cf7c2265ea8a563be0eaa26b19f9b2330e76f8373d72c409",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35417",
+					"10.65.0.27:35417",
+					"172.17.0.1:35417",
+					"172.18.0.1:35417",
+					"172.19.0.1:35417"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:11:04.432399005Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2215394298792381,
+				"StableID":   "nrfXvneMJJ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b21b16498ae1397a6a2b0ea0aec7a8d42867d5ac37a74c2a7563b11e8f78224a",
+				"DiscoKey":   "discokey:db6021ad39b6f5f0ba85a6a656127747b45d442cc44bf6618686453e28aabe22",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:11:04.964631532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3125719009315563,
+				"StableID":   "ntZDLcLeQR11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:59d8a02904deff653c945d32f7a7f98a69cdcaa8b05f22e82504a3b021e57d06",
+				"DiscoKey":   "discokey:fccc1bd5603bb130e2e8bd836fd09c4ffde2e655a4178ab3866c7b8763704008",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41206",
+					"10.65.0.27:41206",
+					"172.17.0.1:41206",
+					"172.18.0.1:41206",
+					"172.19.0.1:41206"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:11:05.512020264Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2112578502766591,
+				"StableID":   "nAk37brnVH11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08c775eaeaeb4e7c0a1cc2f5e871569f702b2becc7e46613085bd1ac2600255a",
+				"DiscoKey":   "discokey:4179c9d71b2d29f290b2554afcc7681c267e46c424e8e2352deb2c9f155add6e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39265",
+					"10.65.0.27:39265",
+					"172.17.0.1:39265",
+					"172.18.0.1:39265",
+					"172.19.0.1:39265"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:11:06.057397718Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8906729286268412,
+				"StableID":   "nZ9ENAgsYC21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2506aafee00233150ae724d824f90c6e6dc8742f5c10c2ec80b2ae9fd4e3fc06",
+				"DiscoKey":   "discokey:9ffa423721bc18f36f0ce3d1bc45285acfc53c96b01e2ab89395d8571fa03f32",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:45751",
+					"10.65.0.27:45751",
+					"172.17.0.1:45751",
+					"172.18.0.1:45751",
+					"172.19.0.1:45751"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:11:06.604197943Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5141445526124986,
+				"StableID":   "nKmF6E4a9h11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3434073467d2b3339b267f4ef0d0bd96064b6813dad25354ae002b362b94691f",
+				"DiscoKey":   "discokey:f8983fc793d38d2d8a2364daf0f3a9f8e60e4bc7b25da84ae7886de1df72d829",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33958",
+					"10.65.0.27:33958",
+					"172.17.0.1:33958",
+					"172.18.0.1:33958",
+					"172.19.0.1:33958"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:11:07.149196851Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5654962687639987,
+				"StableID":   "n4wQCHH9Am11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8893801cf53923ef1727d5b04bc7e7ef9db2ec0faa63049f33f4f5e3a1d2e661",
+				"DiscoKey":   "discokey:d0bb7268c33983892508acac8222a0b8e6d4db2c987fd61cb7cd9373e28d8b61",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46797",
+					"10.65.0.27:46797",
+					"172.17.0.1:46797",
+					"172.18.0.1:46797",
+					"172.19.0.1:46797"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:11:07.700993037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8526652530688909,
+				"StableID":   "n8gFznhja921CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:947927db7ec0409b45417f6ac72295f5aedd6d256aa296632c55a6896d572330",
+				"DiscoKey":   "discokey:09fe3298c1c5fed5c121a257661803fc26e4e6f9837d6966b2ff7f465b4e511d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54597",
+					"10.65.0.27:54597",
+					"172.17.0.1:54597",
+					"172.18.0.1:54597",
+					"172.19.0.1:54597"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:11:08.252437138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4518198577187111,
+				"StableID":   "nJAUR5RJHc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ada38e0b924e15db5edb9d0200794f809cd2f904a6924775f5b2bacc0273d79",
+				"DiscoKey":   "discokey:069013759ee1b623257c918a427124bc6114ec9275b3564ec96ce48134f21270",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36150",
+					"10.65.0.27:36150",
+					"172.17.0.1:36150",
+					"172.18.0.1:36150",
+					"172.19.0.1:36150"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:11:08.782386347Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8285171886816240,
+				"StableID":   "n9dBQ9RNh721CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9c497fb63aec1ed4a3f34d7b9ad252da6756f0db7019f72956d3bdaf3023f447",
+				"DiscoKey":   "discokey:52b00a1c33073905d806b423c4453c9eb30071ff0f1f2207e02899ac4454c81a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:50282",
+					"10.65.0.27:50282",
+					"172.17.0.1:50282",
+					"172.18.0.1:50282",
+					"172.19.0.1:50282"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:11:09.324809646Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4269871067550841,
+				"StableID":   "n4pfkoGqLa11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:534c7f0b05eb184bf6aeb99c28422a63d13d09e9b4b3e010c72d2b5195f8ea25",
+				"KeyExpiry":  "2026-11-08T22:11:09Z",
+				"DiscoKey":   "discokey:a6134eaa656961798296bf09b9b9f0de535b592cba62f73fde5e86631239fa7d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35459",
+					"10.65.0.27:35459",
+					"172.17.0.1:35459",
+					"172.18.0.1:35459",
+					"172.19.0.1:35459"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:11:09.878295429Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3867988008102548,
+				"StableID":   "nBNTyBVpCX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a5882a99c0965a4242cfd47b2233c8ebd70f8b10b2abb0b47d8ec8fb6a722f64",
+				"KeyExpiry":  "2026-11-08T22:11:10Z",
+				"DiscoKey":   "discokey:14fe9bc8594a1cad3141943970ee07f7e2ec7aee50a003d622bbe12af9a69c35",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:33834",
+					"10.65.0.27:33834",
+					"172.17.0.1:33834",
+					"172.18.0.1:33834",
+					"172.19.0.1:33834"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:11:10.417098091Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1536151596243616,
+				"StableID":   "nsJrFf6jzC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:0c86508999647ab76d3e3b36d7e3e5665fdf6021d98c0b4f1b34fe17a32fde1d",
+				"KeyExpiry":  "2026-11-08T22:11:10Z",
+				"DiscoKey":   "discokey:9c1558274db049b32e4d37a4e2a99ba0b3c78709bb54bad36e42d6f57d0d9362",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47599",
+					"10.65.0.27:47599",
+					"172.17.0.1:47599",
+					"172.18.0.1:47599",
+					"172.19.0.1:47599"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:11:10.957037949Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2658989023662154": {
+				"ID":          2658989023662154,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7795012317679548,
+				"StableID":   "nFENkpkNs321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       7795012317679548,
+				"Key":        "nodekey:0e30b88d2338acbdfa4c982672da4b2ee6a0ed1125765118bcb0266bb2275c78",
+				"DiscoKey":   "discokey:c8879dc6dbbc2c6df2bb187efdb3edc6ec511d9a7f4698d170929b4feefbf913",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:41045",
+					"10.65.0.27:41045",
+					"172.17.0.1:41045",
+					"172.18.0.1:41045",
+					"172.19.0.1:41045"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:11:03.366454178Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0e30b88d2338acbdfa4c982672da4b2ee6a0ed1125765118bcb0266bb2275c78",
+			"MachineKey": "mkey:b2ad0f2f9fd95bebec48b3e02c6b70b988ed41600f9bd780ca57db4952091842",
+			"Peers": [{
+				"ID":         2658989023662154,
+				"StableID":   "nfKyjh8GmM11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b97b00031302717abcb4795ff2baca0d05927497069988c5c40081ce250f6109",
+				"DiscoKey":   "discokey:720be127a534b03740ec4dffc6d023530a58e7c0453a7a96b7266ec0754ec948",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44124",
+					"10.65.0.27:44124",
+					"172.17.0.1:44124",
+					"172.18.0.1:44124",
+					"172.19.0.1:44124"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:11:03.89828392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2563925811358875,
+				"StableID":   "nz8WC3zC2M11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ca96115b4c2c976f5b0837be89d9df7e1257f26b92f2484aca73b4857ce9c55",
+				"DiscoKey":   "discokey:dd7b269a69cc2fe4cf7c2265ea8a563be0eaa26b19f9b2330e76f8373d72c409",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35417",
+					"10.65.0.27:35417",
+					"172.17.0.1:35417",
+					"172.18.0.1:35417",
+					"172.19.0.1:35417"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:11:04.432399005Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2215394298792381,
+				"StableID":   "nrfXvneMJJ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b21b16498ae1397a6a2b0ea0aec7a8d42867d5ac37a74c2a7563b11e8f78224a",
+				"DiscoKey":   "discokey:db6021ad39b6f5f0ba85a6a656127747b45d442cc44bf6618686453e28aabe22",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:11:04.964631532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3125719009315563,
+				"StableID":   "ntZDLcLeQR11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:59d8a02904deff653c945d32f7a7f98a69cdcaa8b05f22e82504a3b021e57d06",
+				"DiscoKey":   "discokey:fccc1bd5603bb130e2e8bd836fd09c4ffde2e655a4178ab3866c7b8763704008",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41206",
+					"10.65.0.27:41206",
+					"172.17.0.1:41206",
+					"172.18.0.1:41206",
+					"172.19.0.1:41206"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:11:05.512020264Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2112578502766591,
+				"StableID":   "nAk37brnVH11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08c775eaeaeb4e7c0a1cc2f5e871569f702b2becc7e46613085bd1ac2600255a",
+				"DiscoKey":   "discokey:4179c9d71b2d29f290b2554afcc7681c267e46c424e8e2352deb2c9f155add6e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39265",
+					"10.65.0.27:39265",
+					"172.17.0.1:39265",
+					"172.18.0.1:39265",
+					"172.19.0.1:39265"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:11:06.057397718Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8906729286268412,
+				"StableID":   "nZ9ENAgsYC21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2506aafee00233150ae724d824f90c6e6dc8742f5c10c2ec80b2ae9fd4e3fc06",
+				"DiscoKey":   "discokey:9ffa423721bc18f36f0ce3d1bc45285acfc53c96b01e2ab89395d8571fa03f32",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:45751",
+					"10.65.0.27:45751",
+					"172.17.0.1:45751",
+					"172.18.0.1:45751",
+					"172.19.0.1:45751"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:11:06.604197943Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5141445526124986,
+				"StableID":   "nKmF6E4a9h11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3434073467d2b3339b267f4ef0d0bd96064b6813dad25354ae002b362b94691f",
+				"DiscoKey":   "discokey:f8983fc793d38d2d8a2364daf0f3a9f8e60e4bc7b25da84ae7886de1df72d829",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33958",
+					"10.65.0.27:33958",
+					"172.17.0.1:33958",
+					"172.18.0.1:33958",
+					"172.19.0.1:33958"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:11:07.149196851Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5654962687639987,
+				"StableID":   "n4wQCHH9Am11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8893801cf53923ef1727d5b04bc7e7ef9db2ec0faa63049f33f4f5e3a1d2e661",
+				"DiscoKey":   "discokey:d0bb7268c33983892508acac8222a0b8e6d4db2c987fd61cb7cd9373e28d8b61",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46797",
+					"10.65.0.27:46797",
+					"172.17.0.1:46797",
+					"172.18.0.1:46797",
+					"172.19.0.1:46797"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:11:07.700993037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8526652530688909,
+				"StableID":   "n8gFznhja921CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:947927db7ec0409b45417f6ac72295f5aedd6d256aa296632c55a6896d572330",
+				"DiscoKey":   "discokey:09fe3298c1c5fed5c121a257661803fc26e4e6f9837d6966b2ff7f465b4e511d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54597",
+					"10.65.0.27:54597",
+					"172.17.0.1:54597",
+					"172.18.0.1:54597",
+					"172.19.0.1:54597"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:11:08.252437138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4518198577187111,
+				"StableID":   "nJAUR5RJHc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ada38e0b924e15db5edb9d0200794f809cd2f904a6924775f5b2bacc0273d79",
+				"DiscoKey":   "discokey:069013759ee1b623257c918a427124bc6114ec9275b3564ec96ce48134f21270",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36150",
+					"10.65.0.27:36150",
+					"172.17.0.1:36150",
+					"172.18.0.1:36150",
+					"172.19.0.1:36150"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:11:08.782386347Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8285171886816240,
+				"StableID":   "n9dBQ9RNh721CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9c497fb63aec1ed4a3f34d7b9ad252da6756f0db7019f72956d3bdaf3023f447",
+				"DiscoKey":   "discokey:52b00a1c33073905d806b423c4453c9eb30071ff0f1f2207e02899ac4454c81a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:50282",
+					"10.65.0.27:50282",
+					"172.17.0.1:50282",
+					"172.18.0.1:50282",
+					"172.19.0.1:50282"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:11:09.324809646Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4269871067550841,
+				"StableID":   "n4pfkoGqLa11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:534c7f0b05eb184bf6aeb99c28422a63d13d09e9b4b3e010c72d2b5195f8ea25",
+				"KeyExpiry":  "2026-11-08T22:11:09Z",
+				"DiscoKey":   "discokey:a6134eaa656961798296bf09b9b9f0de535b592cba62f73fde5e86631239fa7d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35459",
+					"10.65.0.27:35459",
+					"172.17.0.1:35459",
+					"172.18.0.1:35459",
+					"172.19.0.1:35459"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:11:09.878295429Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3867988008102548,
+				"StableID":   "nBNTyBVpCX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a5882a99c0965a4242cfd47b2233c8ebd70f8b10b2abb0b47d8ec8fb6a722f64",
+				"KeyExpiry":  "2026-11-08T22:11:10Z",
+				"DiscoKey":   "discokey:14fe9bc8594a1cad3141943970ee07f7e2ec7aee50a003d622bbe12af9a69c35",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:33834",
+					"10.65.0.27:33834",
+					"172.17.0.1:33834",
+					"172.18.0.1:33834",
+					"172.19.0.1:33834"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:11:10.417098091Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1536151596243616,
+				"StableID":   "nsJrFf6jzC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:0c86508999647ab76d3e3b36d7e3e5665fdf6021d98c0b4f1b34fe17a32fde1d",
+				"KeyExpiry":  "2026-11-08T22:11:10Z",
+				"DiscoKey":   "discokey:9c1558274db049b32e4d37a4e2a99ba0b3c78709bb54bad36e42d6f57d0d9362",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47599",
+					"10.65.0.27:47599",
+					"172.17.0.1:47599",
+					"172.18.0.1:47599",
+					"172.19.0.1:47599"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:11:10.957037949Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7795012317679548": {
+				"ID":          7795012317679548,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3125719009315563,
+				"StableID":   "ntZDLcLeQR11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       3125719009315563,
+				"Key":        "nodekey:59d8a02904deff653c945d32f7a7f98a69cdcaa8b05f22e82504a3b021e57d06",
+				"DiscoKey":   "discokey:fccc1bd5603bb130e2e8bd836fd09c4ffde2e655a4178ab3866c7b8763704008",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41206",
+					"10.65.0.27:41206",
+					"172.17.0.1:41206",
+					"172.18.0.1:41206",
+					"172.19.0.1:41206"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:11:05.512020264Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:59d8a02904deff653c945d32f7a7f98a69cdcaa8b05f22e82504a3b021e57d06",
+			"MachineKey": "mkey:0d114c84f9fc3981f6e38c1fcfa9b9fdd382c7ca1688dbb8ef161643c08aba63",
+			"Peers": [{
+				"ID":         7795012317679548,
+				"StableID":   "nFENkpkNs321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e30b88d2338acbdfa4c982672da4b2ee6a0ed1125765118bcb0266bb2275c78",
+				"DiscoKey":   "discokey:c8879dc6dbbc2c6df2bb187efdb3edc6ec511d9a7f4698d170929b4feefbf913",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:41045",
+					"10.65.0.27:41045",
+					"172.17.0.1:41045",
+					"172.18.0.1:41045",
+					"172.19.0.1:41045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:11:03.366454178Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2658989023662154,
+				"StableID":   "nfKyjh8GmM11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b97b00031302717abcb4795ff2baca0d05927497069988c5c40081ce250f6109",
+				"DiscoKey":   "discokey:720be127a534b03740ec4dffc6d023530a58e7c0453a7a96b7266ec0754ec948",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44124",
+					"10.65.0.27:44124",
+					"172.17.0.1:44124",
+					"172.18.0.1:44124",
+					"172.19.0.1:44124"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:11:03.89828392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2563925811358875,
+				"StableID":   "nz8WC3zC2M11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ca96115b4c2c976f5b0837be89d9df7e1257f26b92f2484aca73b4857ce9c55",
+				"DiscoKey":   "discokey:dd7b269a69cc2fe4cf7c2265ea8a563be0eaa26b19f9b2330e76f8373d72c409",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35417",
+					"10.65.0.27:35417",
+					"172.17.0.1:35417",
+					"172.18.0.1:35417",
+					"172.19.0.1:35417"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:11:04.432399005Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2215394298792381,
+				"StableID":   "nrfXvneMJJ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b21b16498ae1397a6a2b0ea0aec7a8d42867d5ac37a74c2a7563b11e8f78224a",
+				"DiscoKey":   "discokey:db6021ad39b6f5f0ba85a6a656127747b45d442cc44bf6618686453e28aabe22",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:11:04.964631532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2112578502766591,
+				"StableID":   "nAk37brnVH11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08c775eaeaeb4e7c0a1cc2f5e871569f702b2becc7e46613085bd1ac2600255a",
+				"DiscoKey":   "discokey:4179c9d71b2d29f290b2554afcc7681c267e46c424e8e2352deb2c9f155add6e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39265",
+					"10.65.0.27:39265",
+					"172.17.0.1:39265",
+					"172.18.0.1:39265",
+					"172.19.0.1:39265"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:11:06.057397718Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8906729286268412,
+				"StableID":   "nZ9ENAgsYC21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2506aafee00233150ae724d824f90c6e6dc8742f5c10c2ec80b2ae9fd4e3fc06",
+				"DiscoKey":   "discokey:9ffa423721bc18f36f0ce3d1bc45285acfc53c96b01e2ab89395d8571fa03f32",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:45751",
+					"10.65.0.27:45751",
+					"172.17.0.1:45751",
+					"172.18.0.1:45751",
+					"172.19.0.1:45751"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:11:06.604197943Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5141445526124986,
+				"StableID":   "nKmF6E4a9h11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3434073467d2b3339b267f4ef0d0bd96064b6813dad25354ae002b362b94691f",
+				"DiscoKey":   "discokey:f8983fc793d38d2d8a2364daf0f3a9f8e60e4bc7b25da84ae7886de1df72d829",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33958",
+					"10.65.0.27:33958",
+					"172.17.0.1:33958",
+					"172.18.0.1:33958",
+					"172.19.0.1:33958"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:11:07.149196851Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5654962687639987,
+				"StableID":   "n4wQCHH9Am11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8893801cf53923ef1727d5b04bc7e7ef9db2ec0faa63049f33f4f5e3a1d2e661",
+				"DiscoKey":   "discokey:d0bb7268c33983892508acac8222a0b8e6d4db2c987fd61cb7cd9373e28d8b61",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46797",
+					"10.65.0.27:46797",
+					"172.17.0.1:46797",
+					"172.18.0.1:46797",
+					"172.19.0.1:46797"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:11:07.700993037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8526652530688909,
+				"StableID":   "n8gFznhja921CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:947927db7ec0409b45417f6ac72295f5aedd6d256aa296632c55a6896d572330",
+				"DiscoKey":   "discokey:09fe3298c1c5fed5c121a257661803fc26e4e6f9837d6966b2ff7f465b4e511d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54597",
+					"10.65.0.27:54597",
+					"172.17.0.1:54597",
+					"172.18.0.1:54597",
+					"172.19.0.1:54597"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:11:08.252437138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4518198577187111,
+				"StableID":   "nJAUR5RJHc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ada38e0b924e15db5edb9d0200794f809cd2f904a6924775f5b2bacc0273d79",
+				"DiscoKey":   "discokey:069013759ee1b623257c918a427124bc6114ec9275b3564ec96ce48134f21270",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36150",
+					"10.65.0.27:36150",
+					"172.17.0.1:36150",
+					"172.18.0.1:36150",
+					"172.19.0.1:36150"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:11:08.782386347Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8285171886816240,
+				"StableID":   "n9dBQ9RNh721CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9c497fb63aec1ed4a3f34d7b9ad252da6756f0db7019f72956d3bdaf3023f447",
+				"DiscoKey":   "discokey:52b00a1c33073905d806b423c4453c9eb30071ff0f1f2207e02899ac4454c81a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:50282",
+					"10.65.0.27:50282",
+					"172.17.0.1:50282",
+					"172.18.0.1:50282",
+					"172.19.0.1:50282"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:11:09.324809646Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4269871067550841,
+				"StableID":   "n4pfkoGqLa11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:534c7f0b05eb184bf6aeb99c28422a63d13d09e9b4b3e010c72d2b5195f8ea25",
+				"KeyExpiry":  "2026-11-08T22:11:09Z",
+				"DiscoKey":   "discokey:a6134eaa656961798296bf09b9b9f0de535b592cba62f73fde5e86631239fa7d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35459",
+					"10.65.0.27:35459",
+					"172.17.0.1:35459",
+					"172.18.0.1:35459",
+					"172.19.0.1:35459"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:11:09.878295429Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3867988008102548,
+				"StableID":   "nBNTyBVpCX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a5882a99c0965a4242cfd47b2233c8ebd70f8b10b2abb0b47d8ec8fb6a722f64",
+				"KeyExpiry":  "2026-11-08T22:11:10Z",
+				"DiscoKey":   "discokey:14fe9bc8594a1cad3141943970ee07f7e2ec7aee50a003d622bbe12af9a69c35",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:33834",
+					"10.65.0.27:33834",
+					"172.17.0.1:33834",
+					"172.18.0.1:33834",
+					"172.19.0.1:33834"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:11:10.417098091Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1536151596243616,
+				"StableID":   "nsJrFf6jzC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:0c86508999647ab76d3e3b36d7e3e5665fdf6021d98c0b4f1b34fe17a32fde1d",
+				"KeyExpiry":  "2026-11-08T22:11:10Z",
+				"DiscoKey":   "discokey:9c1558274db049b32e4d37a4e2a99ba0b3c78709bb54bad36e42d6f57d0d9362",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47599",
+					"10.65.0.27:47599",
+					"172.17.0.1:47599",
+					"172.18.0.1:47599",
+					"172.19.0.1:47599"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:11:10.957037949Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3125719009315563": {
+				"ID":          3125719009315563,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2215394298792381,
+				"StableID":   "nrfXvneMJJ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       2215394298792381,
+				"Key":        "nodekey:b21b16498ae1397a6a2b0ea0aec7a8d42867d5ac37a74c2a7563b11e8f78224a",
+				"DiscoKey":   "discokey:db6021ad39b6f5f0ba85a6a656127747b45d442cc44bf6618686453e28aabe22",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:11:04.964631532Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b21b16498ae1397a6a2b0ea0aec7a8d42867d5ac37a74c2a7563b11e8f78224a",
+			"MachineKey": "mkey:9604b17d6d34fe2809f6084959cd4c6de80575e55a368271a80582a3d1797120",
+			"Peers": [{
+				"ID":         7795012317679548,
+				"StableID":   "nFENkpkNs321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e30b88d2338acbdfa4c982672da4b2ee6a0ed1125765118bcb0266bb2275c78",
+				"DiscoKey":   "discokey:c8879dc6dbbc2c6df2bb187efdb3edc6ec511d9a7f4698d170929b4feefbf913",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:41045",
+					"10.65.0.27:41045",
+					"172.17.0.1:41045",
+					"172.18.0.1:41045",
+					"172.19.0.1:41045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:11:03.366454178Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2658989023662154,
+				"StableID":   "nfKyjh8GmM11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b97b00031302717abcb4795ff2baca0d05927497069988c5c40081ce250f6109",
+				"DiscoKey":   "discokey:720be127a534b03740ec4dffc6d023530a58e7c0453a7a96b7266ec0754ec948",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44124",
+					"10.65.0.27:44124",
+					"172.17.0.1:44124",
+					"172.18.0.1:44124",
+					"172.19.0.1:44124"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:11:03.89828392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2563925811358875,
+				"StableID":   "nz8WC3zC2M11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ca96115b4c2c976f5b0837be89d9df7e1257f26b92f2484aca73b4857ce9c55",
+				"DiscoKey":   "discokey:dd7b269a69cc2fe4cf7c2265ea8a563be0eaa26b19f9b2330e76f8373d72c409",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35417",
+					"10.65.0.27:35417",
+					"172.17.0.1:35417",
+					"172.18.0.1:35417",
+					"172.19.0.1:35417"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:11:04.432399005Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3125719009315563,
+				"StableID":   "ntZDLcLeQR11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:59d8a02904deff653c945d32f7a7f98a69cdcaa8b05f22e82504a3b021e57d06",
+				"DiscoKey":   "discokey:fccc1bd5603bb130e2e8bd836fd09c4ffde2e655a4178ab3866c7b8763704008",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41206",
+					"10.65.0.27:41206",
+					"172.17.0.1:41206",
+					"172.18.0.1:41206",
+					"172.19.0.1:41206"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:11:05.512020264Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2112578502766591,
+				"StableID":   "nAk37brnVH11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08c775eaeaeb4e7c0a1cc2f5e871569f702b2becc7e46613085bd1ac2600255a",
+				"DiscoKey":   "discokey:4179c9d71b2d29f290b2554afcc7681c267e46c424e8e2352deb2c9f155add6e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39265",
+					"10.65.0.27:39265",
+					"172.17.0.1:39265",
+					"172.18.0.1:39265",
+					"172.19.0.1:39265"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:11:06.057397718Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8906729286268412,
+				"StableID":   "nZ9ENAgsYC21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2506aafee00233150ae724d824f90c6e6dc8742f5c10c2ec80b2ae9fd4e3fc06",
+				"DiscoKey":   "discokey:9ffa423721bc18f36f0ce3d1bc45285acfc53c96b01e2ab89395d8571fa03f32",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:45751",
+					"10.65.0.27:45751",
+					"172.17.0.1:45751",
+					"172.18.0.1:45751",
+					"172.19.0.1:45751"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:11:06.604197943Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5141445526124986,
+				"StableID":   "nKmF6E4a9h11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3434073467d2b3339b267f4ef0d0bd96064b6813dad25354ae002b362b94691f",
+				"DiscoKey":   "discokey:f8983fc793d38d2d8a2364daf0f3a9f8e60e4bc7b25da84ae7886de1df72d829",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33958",
+					"10.65.0.27:33958",
+					"172.17.0.1:33958",
+					"172.18.0.1:33958",
+					"172.19.0.1:33958"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:11:07.149196851Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5654962687639987,
+				"StableID":   "n4wQCHH9Am11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8893801cf53923ef1727d5b04bc7e7ef9db2ec0faa63049f33f4f5e3a1d2e661",
+				"DiscoKey":   "discokey:d0bb7268c33983892508acac8222a0b8e6d4db2c987fd61cb7cd9373e28d8b61",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46797",
+					"10.65.0.27:46797",
+					"172.17.0.1:46797",
+					"172.18.0.1:46797",
+					"172.19.0.1:46797"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:11:07.700993037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8526652530688909,
+				"StableID":   "n8gFznhja921CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:947927db7ec0409b45417f6ac72295f5aedd6d256aa296632c55a6896d572330",
+				"DiscoKey":   "discokey:09fe3298c1c5fed5c121a257661803fc26e4e6f9837d6966b2ff7f465b4e511d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54597",
+					"10.65.0.27:54597",
+					"172.17.0.1:54597",
+					"172.18.0.1:54597",
+					"172.19.0.1:54597"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:11:08.252437138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4518198577187111,
+				"StableID":   "nJAUR5RJHc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ada38e0b924e15db5edb9d0200794f809cd2f904a6924775f5b2bacc0273d79",
+				"DiscoKey":   "discokey:069013759ee1b623257c918a427124bc6114ec9275b3564ec96ce48134f21270",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36150",
+					"10.65.0.27:36150",
+					"172.17.0.1:36150",
+					"172.18.0.1:36150",
+					"172.19.0.1:36150"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:11:08.782386347Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8285171886816240,
+				"StableID":   "n9dBQ9RNh721CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9c497fb63aec1ed4a3f34d7b9ad252da6756f0db7019f72956d3bdaf3023f447",
+				"DiscoKey":   "discokey:52b00a1c33073905d806b423c4453c9eb30071ff0f1f2207e02899ac4454c81a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:50282",
+					"10.65.0.27:50282",
+					"172.17.0.1:50282",
+					"172.18.0.1:50282",
+					"172.19.0.1:50282"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:11:09.324809646Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4269871067550841,
+				"StableID":   "n4pfkoGqLa11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:534c7f0b05eb184bf6aeb99c28422a63d13d09e9b4b3e010c72d2b5195f8ea25",
+				"KeyExpiry":  "2026-11-08T22:11:09Z",
+				"DiscoKey":   "discokey:a6134eaa656961798296bf09b9b9f0de535b592cba62f73fde5e86631239fa7d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35459",
+					"10.65.0.27:35459",
+					"172.17.0.1:35459",
+					"172.18.0.1:35459",
+					"172.19.0.1:35459"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:11:09.878295429Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3867988008102548,
+				"StableID":   "nBNTyBVpCX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a5882a99c0965a4242cfd47b2233c8ebd70f8b10b2abb0b47d8ec8fb6a722f64",
+				"KeyExpiry":  "2026-11-08T22:11:10Z",
+				"DiscoKey":   "discokey:14fe9bc8594a1cad3141943970ee07f7e2ec7aee50a003d622bbe12af9a69c35",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:33834",
+					"10.65.0.27:33834",
+					"172.17.0.1:33834",
+					"172.18.0.1:33834",
+					"172.19.0.1:33834"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:11:10.417098091Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1536151596243616,
+				"StableID":   "nsJrFf6jzC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:0c86508999647ab76d3e3b36d7e3e5665fdf6021d98c0b4f1b34fe17a32fde1d",
+				"KeyExpiry":  "2026-11-08T22:11:10Z",
+				"DiscoKey":   "discokey:9c1558274db049b32e4d37a4e2a99ba0b3c78709bb54bad36e42d6f57d0d9362",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47599",
+					"10.65.0.27:47599",
+					"172.17.0.1:47599",
+					"172.18.0.1:47599",
+					"172.19.0.1:47599"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:11:10.957037949Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2215394298792381": {
+				"ID":          2215394298792381,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8906729286268412,
+				"StableID":   "nZ9ENAgsYC21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       8906729286268412,
+				"Key":        "nodekey:2506aafee00233150ae724d824f90c6e6dc8742f5c10c2ec80b2ae9fd4e3fc06",
+				"DiscoKey":   "discokey:9ffa423721bc18f36f0ce3d1bc45285acfc53c96b01e2ab89395d8571fa03f32",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:45751",
+					"10.65.0.27:45751",
+					"172.17.0.1:45751",
+					"172.18.0.1:45751",
+					"172.19.0.1:45751"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:11:06.604197943Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2506aafee00233150ae724d824f90c6e6dc8742f5c10c2ec80b2ae9fd4e3fc06",
+			"MachineKey": "mkey:bc3913ab9c6c11fadf318704f3f0846e1059ba328c1914e13cd2888785adf721",
+			"Peers": [{
+				"ID":         7795012317679548,
+				"StableID":   "nFENkpkNs321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e30b88d2338acbdfa4c982672da4b2ee6a0ed1125765118bcb0266bb2275c78",
+				"DiscoKey":   "discokey:c8879dc6dbbc2c6df2bb187efdb3edc6ec511d9a7f4698d170929b4feefbf913",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:41045",
+					"10.65.0.27:41045",
+					"172.17.0.1:41045",
+					"172.18.0.1:41045",
+					"172.19.0.1:41045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:11:03.366454178Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2658989023662154,
+				"StableID":   "nfKyjh8GmM11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b97b00031302717abcb4795ff2baca0d05927497069988c5c40081ce250f6109",
+				"DiscoKey":   "discokey:720be127a534b03740ec4dffc6d023530a58e7c0453a7a96b7266ec0754ec948",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44124",
+					"10.65.0.27:44124",
+					"172.17.0.1:44124",
+					"172.18.0.1:44124",
+					"172.19.0.1:44124"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:11:03.89828392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2563925811358875,
+				"StableID":   "nz8WC3zC2M11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ca96115b4c2c976f5b0837be89d9df7e1257f26b92f2484aca73b4857ce9c55",
+				"DiscoKey":   "discokey:dd7b269a69cc2fe4cf7c2265ea8a563be0eaa26b19f9b2330e76f8373d72c409",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35417",
+					"10.65.0.27:35417",
+					"172.17.0.1:35417",
+					"172.18.0.1:35417",
+					"172.19.0.1:35417"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:11:04.432399005Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2215394298792381,
+				"StableID":   "nrfXvneMJJ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b21b16498ae1397a6a2b0ea0aec7a8d42867d5ac37a74c2a7563b11e8f78224a",
+				"DiscoKey":   "discokey:db6021ad39b6f5f0ba85a6a656127747b45d442cc44bf6618686453e28aabe22",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:11:04.964631532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3125719009315563,
+				"StableID":   "ntZDLcLeQR11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:59d8a02904deff653c945d32f7a7f98a69cdcaa8b05f22e82504a3b021e57d06",
+				"DiscoKey":   "discokey:fccc1bd5603bb130e2e8bd836fd09c4ffde2e655a4178ab3866c7b8763704008",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41206",
+					"10.65.0.27:41206",
+					"172.17.0.1:41206",
+					"172.18.0.1:41206",
+					"172.19.0.1:41206"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:11:05.512020264Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2112578502766591,
+				"StableID":   "nAk37brnVH11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08c775eaeaeb4e7c0a1cc2f5e871569f702b2becc7e46613085bd1ac2600255a",
+				"DiscoKey":   "discokey:4179c9d71b2d29f290b2554afcc7681c267e46c424e8e2352deb2c9f155add6e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39265",
+					"10.65.0.27:39265",
+					"172.17.0.1:39265",
+					"172.18.0.1:39265",
+					"172.19.0.1:39265"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:11:06.057397718Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5141445526124986,
+				"StableID":   "nKmF6E4a9h11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3434073467d2b3339b267f4ef0d0bd96064b6813dad25354ae002b362b94691f",
+				"DiscoKey":   "discokey:f8983fc793d38d2d8a2364daf0f3a9f8e60e4bc7b25da84ae7886de1df72d829",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33958",
+					"10.65.0.27:33958",
+					"172.17.0.1:33958",
+					"172.18.0.1:33958",
+					"172.19.0.1:33958"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:11:07.149196851Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5654962687639987,
+				"StableID":   "n4wQCHH9Am11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8893801cf53923ef1727d5b04bc7e7ef9db2ec0faa63049f33f4f5e3a1d2e661",
+				"DiscoKey":   "discokey:d0bb7268c33983892508acac8222a0b8e6d4db2c987fd61cb7cd9373e28d8b61",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46797",
+					"10.65.0.27:46797",
+					"172.17.0.1:46797",
+					"172.18.0.1:46797",
+					"172.19.0.1:46797"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:11:07.700993037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8526652530688909,
+				"StableID":   "n8gFznhja921CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:947927db7ec0409b45417f6ac72295f5aedd6d256aa296632c55a6896d572330",
+				"DiscoKey":   "discokey:09fe3298c1c5fed5c121a257661803fc26e4e6f9837d6966b2ff7f465b4e511d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54597",
+					"10.65.0.27:54597",
+					"172.17.0.1:54597",
+					"172.18.0.1:54597",
+					"172.19.0.1:54597"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:11:08.252437138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4518198577187111,
+				"StableID":   "nJAUR5RJHc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ada38e0b924e15db5edb9d0200794f809cd2f904a6924775f5b2bacc0273d79",
+				"DiscoKey":   "discokey:069013759ee1b623257c918a427124bc6114ec9275b3564ec96ce48134f21270",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36150",
+					"10.65.0.27:36150",
+					"172.17.0.1:36150",
+					"172.18.0.1:36150",
+					"172.19.0.1:36150"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:11:08.782386347Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8285171886816240,
+				"StableID":   "n9dBQ9RNh721CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9c497fb63aec1ed4a3f34d7b9ad252da6756f0db7019f72956d3bdaf3023f447",
+				"DiscoKey":   "discokey:52b00a1c33073905d806b423c4453c9eb30071ff0f1f2207e02899ac4454c81a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:50282",
+					"10.65.0.27:50282",
+					"172.17.0.1:50282",
+					"172.18.0.1:50282",
+					"172.19.0.1:50282"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:11:09.324809646Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4269871067550841,
+				"StableID":   "n4pfkoGqLa11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:534c7f0b05eb184bf6aeb99c28422a63d13d09e9b4b3e010c72d2b5195f8ea25",
+				"KeyExpiry":  "2026-11-08T22:11:09Z",
+				"DiscoKey":   "discokey:a6134eaa656961798296bf09b9b9f0de535b592cba62f73fde5e86631239fa7d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35459",
+					"10.65.0.27:35459",
+					"172.17.0.1:35459",
+					"172.18.0.1:35459",
+					"172.19.0.1:35459"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:11:09.878295429Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3867988008102548,
+				"StableID":   "nBNTyBVpCX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a5882a99c0965a4242cfd47b2233c8ebd70f8b10b2abb0b47d8ec8fb6a722f64",
+				"KeyExpiry":  "2026-11-08T22:11:10Z",
+				"DiscoKey":   "discokey:14fe9bc8594a1cad3141943970ee07f7e2ec7aee50a003d622bbe12af9a69c35",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:33834",
+					"10.65.0.27:33834",
+					"172.17.0.1:33834",
+					"172.18.0.1:33834",
+					"172.19.0.1:33834"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:11:10.417098091Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1536151596243616,
+				"StableID":   "nsJrFf6jzC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:0c86508999647ab76d3e3b36d7e3e5665fdf6021d98c0b4f1b34fe17a32fde1d",
+				"KeyExpiry":  "2026-11-08T22:11:10Z",
+				"DiscoKey":   "discokey:9c1558274db049b32e4d37a4e2a99ba0b3c78709bb54bad36e42d6f57d0d9362",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47599",
+					"10.65.0.27:47599",
+					"172.17.0.1:47599",
+					"172.18.0.1:47599",
+					"172.19.0.1:47599"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:11:10.957037949Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8906729286268412": {
+				"ID":          8906729286268412,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5654962687639987,
+				"StableID":   "n4wQCHH9Am11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       5654962687639987,
+				"Key":        "nodekey:8893801cf53923ef1727d5b04bc7e7ef9db2ec0faa63049f33f4f5e3a1d2e661",
+				"DiscoKey":   "discokey:d0bb7268c33983892508acac8222a0b8e6d4db2c987fd61cb7cd9373e28d8b61",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46797",
+					"10.65.0.27:46797",
+					"172.17.0.1:46797",
+					"172.18.0.1:46797",
+					"172.19.0.1:46797"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:11:07.700993037Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8893801cf53923ef1727d5b04bc7e7ef9db2ec0faa63049f33f4f5e3a1d2e661",
+			"MachineKey": "mkey:b1bfb9861732cb70478f940608715c49c39cc0fb32ac60d8280db2c5a0cac744",
+			"Peers": [{
+				"ID":         7795012317679548,
+				"StableID":   "nFENkpkNs321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e30b88d2338acbdfa4c982672da4b2ee6a0ed1125765118bcb0266bb2275c78",
+				"DiscoKey":   "discokey:c8879dc6dbbc2c6df2bb187efdb3edc6ec511d9a7f4698d170929b4feefbf913",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:41045",
+					"10.65.0.27:41045",
+					"172.17.0.1:41045",
+					"172.18.0.1:41045",
+					"172.19.0.1:41045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:11:03.366454178Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2658989023662154,
+				"StableID":   "nfKyjh8GmM11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b97b00031302717abcb4795ff2baca0d05927497069988c5c40081ce250f6109",
+				"DiscoKey":   "discokey:720be127a534b03740ec4dffc6d023530a58e7c0453a7a96b7266ec0754ec948",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44124",
+					"10.65.0.27:44124",
+					"172.17.0.1:44124",
+					"172.18.0.1:44124",
+					"172.19.0.1:44124"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:11:03.89828392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2563925811358875,
+				"StableID":   "nz8WC3zC2M11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ca96115b4c2c976f5b0837be89d9df7e1257f26b92f2484aca73b4857ce9c55",
+				"DiscoKey":   "discokey:dd7b269a69cc2fe4cf7c2265ea8a563be0eaa26b19f9b2330e76f8373d72c409",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35417",
+					"10.65.0.27:35417",
+					"172.17.0.1:35417",
+					"172.18.0.1:35417",
+					"172.19.0.1:35417"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:11:04.432399005Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2215394298792381,
+				"StableID":   "nrfXvneMJJ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b21b16498ae1397a6a2b0ea0aec7a8d42867d5ac37a74c2a7563b11e8f78224a",
+				"DiscoKey":   "discokey:db6021ad39b6f5f0ba85a6a656127747b45d442cc44bf6618686453e28aabe22",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:11:04.964631532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3125719009315563,
+				"StableID":   "ntZDLcLeQR11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:59d8a02904deff653c945d32f7a7f98a69cdcaa8b05f22e82504a3b021e57d06",
+				"DiscoKey":   "discokey:fccc1bd5603bb130e2e8bd836fd09c4ffde2e655a4178ab3866c7b8763704008",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41206",
+					"10.65.0.27:41206",
+					"172.17.0.1:41206",
+					"172.18.0.1:41206",
+					"172.19.0.1:41206"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:11:05.512020264Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2112578502766591,
+				"StableID":   "nAk37brnVH11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08c775eaeaeb4e7c0a1cc2f5e871569f702b2becc7e46613085bd1ac2600255a",
+				"DiscoKey":   "discokey:4179c9d71b2d29f290b2554afcc7681c267e46c424e8e2352deb2c9f155add6e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39265",
+					"10.65.0.27:39265",
+					"172.17.0.1:39265",
+					"172.18.0.1:39265",
+					"172.19.0.1:39265"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:11:06.057397718Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8906729286268412,
+				"StableID":   "nZ9ENAgsYC21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2506aafee00233150ae724d824f90c6e6dc8742f5c10c2ec80b2ae9fd4e3fc06",
+				"DiscoKey":   "discokey:9ffa423721bc18f36f0ce3d1bc45285acfc53c96b01e2ab89395d8571fa03f32",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:45751",
+					"10.65.0.27:45751",
+					"172.17.0.1:45751",
+					"172.18.0.1:45751",
+					"172.19.0.1:45751"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:11:06.604197943Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5141445526124986,
+				"StableID":   "nKmF6E4a9h11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3434073467d2b3339b267f4ef0d0bd96064b6813dad25354ae002b362b94691f",
+				"DiscoKey":   "discokey:f8983fc793d38d2d8a2364daf0f3a9f8e60e4bc7b25da84ae7886de1df72d829",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33958",
+					"10.65.0.27:33958",
+					"172.17.0.1:33958",
+					"172.18.0.1:33958",
+					"172.19.0.1:33958"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:11:07.149196851Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8526652530688909,
+				"StableID":   "n8gFznhja921CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:947927db7ec0409b45417f6ac72295f5aedd6d256aa296632c55a6896d572330",
+				"DiscoKey":   "discokey:09fe3298c1c5fed5c121a257661803fc26e4e6f9837d6966b2ff7f465b4e511d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54597",
+					"10.65.0.27:54597",
+					"172.17.0.1:54597",
+					"172.18.0.1:54597",
+					"172.19.0.1:54597"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:11:08.252437138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4518198577187111,
+				"StableID":   "nJAUR5RJHc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ada38e0b924e15db5edb9d0200794f809cd2f904a6924775f5b2bacc0273d79",
+				"DiscoKey":   "discokey:069013759ee1b623257c918a427124bc6114ec9275b3564ec96ce48134f21270",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36150",
+					"10.65.0.27:36150",
+					"172.17.0.1:36150",
+					"172.18.0.1:36150",
+					"172.19.0.1:36150"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:11:08.782386347Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8285171886816240,
+				"StableID":   "n9dBQ9RNh721CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9c497fb63aec1ed4a3f34d7b9ad252da6756f0db7019f72956d3bdaf3023f447",
+				"DiscoKey":   "discokey:52b00a1c33073905d806b423c4453c9eb30071ff0f1f2207e02899ac4454c81a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:50282",
+					"10.65.0.27:50282",
+					"172.17.0.1:50282",
+					"172.18.0.1:50282",
+					"172.19.0.1:50282"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:11:09.324809646Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4269871067550841,
+				"StableID":   "n4pfkoGqLa11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:534c7f0b05eb184bf6aeb99c28422a63d13d09e9b4b3e010c72d2b5195f8ea25",
+				"KeyExpiry":  "2026-11-08T22:11:09Z",
+				"DiscoKey":   "discokey:a6134eaa656961798296bf09b9b9f0de535b592cba62f73fde5e86631239fa7d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35459",
+					"10.65.0.27:35459",
+					"172.17.0.1:35459",
+					"172.18.0.1:35459",
+					"172.19.0.1:35459"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:11:09.878295429Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3867988008102548,
+				"StableID":   "nBNTyBVpCX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a5882a99c0965a4242cfd47b2233c8ebd70f8b10b2abb0b47d8ec8fb6a722f64",
+				"KeyExpiry":  "2026-11-08T22:11:10Z",
+				"DiscoKey":   "discokey:14fe9bc8594a1cad3141943970ee07f7e2ec7aee50a003d622bbe12af9a69c35",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:33834",
+					"10.65.0.27:33834",
+					"172.17.0.1:33834",
+					"172.18.0.1:33834",
+					"172.19.0.1:33834"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:11:10.417098091Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1536151596243616,
+				"StableID":   "nsJrFf6jzC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:0c86508999647ab76d3e3b36d7e3e5665fdf6021d98c0b4f1b34fe17a32fde1d",
+				"KeyExpiry":  "2026-11-08T22:11:10Z",
+				"DiscoKey":   "discokey:9c1558274db049b32e4d37a4e2a99ba0b3c78709bb54bad36e42d6f57d0d9362",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47599",
+					"10.65.0.27:47599",
+					"172.17.0.1:47599",
+					"172.18.0.1:47599",
+					"172.19.0.1:47599"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:11:10.957037949Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5654962687639987": {
+				"ID":          5654962687639987,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3867988008102548,
+				"StableID":   "nBNTyBVpCX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a5882a99c0965a4242cfd47b2233c8ebd70f8b10b2abb0b47d8ec8fb6a722f64",
+				"KeyExpiry":  "2026-11-08T22:11:10Z",
+				"DiscoKey":   "discokey:14fe9bc8594a1cad3141943970ee07f7e2ec7aee50a003d622bbe12af9a69c35",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:33834",
+					"10.65.0.27:33834",
+					"172.17.0.1:33834",
+					"172.18.0.1:33834",
+					"172.19.0.1:33834"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:11:10.417098091Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a5882a99c0965a4242cfd47b2233c8ebd70f8b10b2abb0b47d8ec8fb6a722f64",
+			"MachineKey": "mkey:d4d482fe7d5d9de4738badb7c161db22076af9548043991a23a08f54dcccd269",
+			"Peers": [{
+				"ID":         7795012317679548,
+				"StableID":   "nFENkpkNs321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e30b88d2338acbdfa4c982672da4b2ee6a0ed1125765118bcb0266bb2275c78",
+				"DiscoKey":   "discokey:c8879dc6dbbc2c6df2bb187efdb3edc6ec511d9a7f4698d170929b4feefbf913",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:41045",
+					"10.65.0.27:41045",
+					"172.17.0.1:41045",
+					"172.18.0.1:41045",
+					"172.19.0.1:41045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:11:03.366454178Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2658989023662154,
+				"StableID":   "nfKyjh8GmM11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b97b00031302717abcb4795ff2baca0d05927497069988c5c40081ce250f6109",
+				"DiscoKey":   "discokey:720be127a534b03740ec4dffc6d023530a58e7c0453a7a96b7266ec0754ec948",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44124",
+					"10.65.0.27:44124",
+					"172.17.0.1:44124",
+					"172.18.0.1:44124",
+					"172.19.0.1:44124"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:11:03.89828392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2563925811358875,
+				"StableID":   "nz8WC3zC2M11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ca96115b4c2c976f5b0837be89d9df7e1257f26b92f2484aca73b4857ce9c55",
+				"DiscoKey":   "discokey:dd7b269a69cc2fe4cf7c2265ea8a563be0eaa26b19f9b2330e76f8373d72c409",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35417",
+					"10.65.0.27:35417",
+					"172.17.0.1:35417",
+					"172.18.0.1:35417",
+					"172.19.0.1:35417"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:11:04.432399005Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2215394298792381,
+				"StableID":   "nrfXvneMJJ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b21b16498ae1397a6a2b0ea0aec7a8d42867d5ac37a74c2a7563b11e8f78224a",
+				"DiscoKey":   "discokey:db6021ad39b6f5f0ba85a6a656127747b45d442cc44bf6618686453e28aabe22",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:11:04.964631532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3125719009315563,
+				"StableID":   "ntZDLcLeQR11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:59d8a02904deff653c945d32f7a7f98a69cdcaa8b05f22e82504a3b021e57d06",
+				"DiscoKey":   "discokey:fccc1bd5603bb130e2e8bd836fd09c4ffde2e655a4178ab3866c7b8763704008",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41206",
+					"10.65.0.27:41206",
+					"172.17.0.1:41206",
+					"172.18.0.1:41206",
+					"172.19.0.1:41206"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:11:05.512020264Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2112578502766591,
+				"StableID":   "nAk37brnVH11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08c775eaeaeb4e7c0a1cc2f5e871569f702b2becc7e46613085bd1ac2600255a",
+				"DiscoKey":   "discokey:4179c9d71b2d29f290b2554afcc7681c267e46c424e8e2352deb2c9f155add6e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39265",
+					"10.65.0.27:39265",
+					"172.17.0.1:39265",
+					"172.18.0.1:39265",
+					"172.19.0.1:39265"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:11:06.057397718Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8906729286268412,
+				"StableID":   "nZ9ENAgsYC21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2506aafee00233150ae724d824f90c6e6dc8742f5c10c2ec80b2ae9fd4e3fc06",
+				"DiscoKey":   "discokey:9ffa423721bc18f36f0ce3d1bc45285acfc53c96b01e2ab89395d8571fa03f32",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:45751",
+					"10.65.0.27:45751",
+					"172.17.0.1:45751",
+					"172.18.0.1:45751",
+					"172.19.0.1:45751"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:11:06.604197943Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5141445526124986,
+				"StableID":   "nKmF6E4a9h11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3434073467d2b3339b267f4ef0d0bd96064b6813dad25354ae002b362b94691f",
+				"DiscoKey":   "discokey:f8983fc793d38d2d8a2364daf0f3a9f8e60e4bc7b25da84ae7886de1df72d829",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33958",
+					"10.65.0.27:33958",
+					"172.17.0.1:33958",
+					"172.18.0.1:33958",
+					"172.19.0.1:33958"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:11:07.149196851Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5654962687639987,
+				"StableID":   "n4wQCHH9Am11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8893801cf53923ef1727d5b04bc7e7ef9db2ec0faa63049f33f4f5e3a1d2e661",
+				"DiscoKey":   "discokey:d0bb7268c33983892508acac8222a0b8e6d4db2c987fd61cb7cd9373e28d8b61",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46797",
+					"10.65.0.27:46797",
+					"172.17.0.1:46797",
+					"172.18.0.1:46797",
+					"172.19.0.1:46797"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:11:07.700993037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8526652530688909,
+				"StableID":   "n8gFznhja921CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:947927db7ec0409b45417f6ac72295f5aedd6d256aa296632c55a6896d572330",
+				"DiscoKey":   "discokey:09fe3298c1c5fed5c121a257661803fc26e4e6f9837d6966b2ff7f465b4e511d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54597",
+					"10.65.0.27:54597",
+					"172.17.0.1:54597",
+					"172.18.0.1:54597",
+					"172.19.0.1:54597"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:11:08.252437138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4518198577187111,
+				"StableID":   "nJAUR5RJHc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ada38e0b924e15db5edb9d0200794f809cd2f904a6924775f5b2bacc0273d79",
+				"DiscoKey":   "discokey:069013759ee1b623257c918a427124bc6114ec9275b3564ec96ce48134f21270",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36150",
+					"10.65.0.27:36150",
+					"172.17.0.1:36150",
+					"172.18.0.1:36150",
+					"172.19.0.1:36150"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:11:08.782386347Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8285171886816240,
+				"StableID":   "n9dBQ9RNh721CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9c497fb63aec1ed4a3f34d7b9ad252da6756f0db7019f72956d3bdaf3023f447",
+				"DiscoKey":   "discokey:52b00a1c33073905d806b423c4453c9eb30071ff0f1f2207e02899ac4454c81a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:50282",
+					"10.65.0.27:50282",
+					"172.17.0.1:50282",
+					"172.18.0.1:50282",
+					"172.19.0.1:50282"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:11:09.324809646Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4269871067550841,
+				"StableID":   "n4pfkoGqLa11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:534c7f0b05eb184bf6aeb99c28422a63d13d09e9b4b3e010c72d2b5195f8ea25",
+				"KeyExpiry":  "2026-11-08T22:11:09Z",
+				"DiscoKey":   "discokey:a6134eaa656961798296bf09b9b9f0de535b592cba62f73fde5e86631239fa7d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35459",
+					"10.65.0.27:35459",
+					"172.17.0.1:35459",
+					"172.18.0.1:35459",
+					"172.19.0.1:35459"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:11:09.878295429Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1536151596243616,
+				"StableID":   "nsJrFf6jzC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:0c86508999647ab76d3e3b36d7e3e5665fdf6021d98c0b4f1b34fe17a32fde1d",
+				"KeyExpiry":  "2026-11-08T22:11:10Z",
+				"DiscoKey":   "discokey:9c1558274db049b32e4d37a4e2a99ba0b3c78709bb54bad36e42d6f57d0d9362",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47599",
+					"10.65.0.27:47599",
+					"172.17.0.1:47599",
+					"172.18.0.1:47599",
+					"172.19.0.1:47599"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:11:10.957037949Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8526652530688909,
+				"StableID":   "n8gFznhja921CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       8526652530688909,
+				"Key":        "nodekey:947927db7ec0409b45417f6ac72295f5aedd6d256aa296632c55a6896d572330",
+				"DiscoKey":   "discokey:09fe3298c1c5fed5c121a257661803fc26e4e6f9837d6966b2ff7f465b4e511d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54597",
+					"10.65.0.27:54597",
+					"172.17.0.1:54597",
+					"172.18.0.1:54597",
+					"172.19.0.1:54597"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:11:08.252437138Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:947927db7ec0409b45417f6ac72295f5aedd6d256aa296632c55a6896d572330",
+			"MachineKey": "mkey:865969103b415344a4bce455d9e38c590f45bf9137facb9528ff9375b87eb958",
+			"Peers": [{
+				"ID":         7795012317679548,
+				"StableID":   "nFENkpkNs321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e30b88d2338acbdfa4c982672da4b2ee6a0ed1125765118bcb0266bb2275c78",
+				"DiscoKey":   "discokey:c8879dc6dbbc2c6df2bb187efdb3edc6ec511d9a7f4698d170929b4feefbf913",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:41045",
+					"10.65.0.27:41045",
+					"172.17.0.1:41045",
+					"172.18.0.1:41045",
+					"172.19.0.1:41045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:11:03.366454178Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2658989023662154,
+				"StableID":   "nfKyjh8GmM11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b97b00031302717abcb4795ff2baca0d05927497069988c5c40081ce250f6109",
+				"DiscoKey":   "discokey:720be127a534b03740ec4dffc6d023530a58e7c0453a7a96b7266ec0754ec948",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44124",
+					"10.65.0.27:44124",
+					"172.17.0.1:44124",
+					"172.18.0.1:44124",
+					"172.19.0.1:44124"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:11:03.89828392Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2563925811358875,
+				"StableID":   "nz8WC3zC2M11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ca96115b4c2c976f5b0837be89d9df7e1257f26b92f2484aca73b4857ce9c55",
+				"DiscoKey":   "discokey:dd7b269a69cc2fe4cf7c2265ea8a563be0eaa26b19f9b2330e76f8373d72c409",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35417",
+					"10.65.0.27:35417",
+					"172.17.0.1:35417",
+					"172.18.0.1:35417",
+					"172.19.0.1:35417"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:11:04.432399005Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2215394298792381,
+				"StableID":   "nrfXvneMJJ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b21b16498ae1397a6a2b0ea0aec7a8d42867d5ac37a74c2a7563b11e8f78224a",
+				"DiscoKey":   "discokey:db6021ad39b6f5f0ba85a6a656127747b45d442cc44bf6618686453e28aabe22",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45786",
+					"10.65.0.27:45786",
+					"172.17.0.1:45786",
+					"172.18.0.1:45786",
+					"172.19.0.1:45786"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:11:04.964631532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3125719009315563,
+				"StableID":   "ntZDLcLeQR11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:59d8a02904deff653c945d32f7a7f98a69cdcaa8b05f22e82504a3b021e57d06",
+				"DiscoKey":   "discokey:fccc1bd5603bb130e2e8bd836fd09c4ffde2e655a4178ab3866c7b8763704008",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41206",
+					"10.65.0.27:41206",
+					"172.17.0.1:41206",
+					"172.18.0.1:41206",
+					"172.19.0.1:41206"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:11:05.512020264Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2112578502766591,
+				"StableID":   "nAk37brnVH11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08c775eaeaeb4e7c0a1cc2f5e871569f702b2becc7e46613085bd1ac2600255a",
+				"DiscoKey":   "discokey:4179c9d71b2d29f290b2554afcc7681c267e46c424e8e2352deb2c9f155add6e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39265",
+					"10.65.0.27:39265",
+					"172.17.0.1:39265",
+					"172.18.0.1:39265",
+					"172.19.0.1:39265"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:11:06.057397718Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8906729286268412,
+				"StableID":   "nZ9ENAgsYC21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2506aafee00233150ae724d824f90c6e6dc8742f5c10c2ec80b2ae9fd4e3fc06",
+				"DiscoKey":   "discokey:9ffa423721bc18f36f0ce3d1bc45285acfc53c96b01e2ab89395d8571fa03f32",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:45751",
+					"10.65.0.27:45751",
+					"172.17.0.1:45751",
+					"172.18.0.1:45751",
+					"172.19.0.1:45751"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:11:06.604197943Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5141445526124986,
+				"StableID":   "nKmF6E4a9h11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3434073467d2b3339b267f4ef0d0bd96064b6813dad25354ae002b362b94691f",
+				"DiscoKey":   "discokey:f8983fc793d38d2d8a2364daf0f3a9f8e60e4bc7b25da84ae7886de1df72d829",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33958",
+					"10.65.0.27:33958",
+					"172.17.0.1:33958",
+					"172.18.0.1:33958",
+					"172.19.0.1:33958"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:11:07.149196851Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5654962687639987,
+				"StableID":   "n4wQCHH9Am11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8893801cf53923ef1727d5b04bc7e7ef9db2ec0faa63049f33f4f5e3a1d2e661",
+				"DiscoKey":   "discokey:d0bb7268c33983892508acac8222a0b8e6d4db2c987fd61cb7cd9373e28d8b61",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:46797",
+					"10.65.0.27:46797",
+					"172.17.0.1:46797",
+					"172.18.0.1:46797",
+					"172.19.0.1:46797"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:11:07.700993037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4518198577187111,
+				"StableID":   "nJAUR5RJHc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ada38e0b924e15db5edb9d0200794f809cd2f904a6924775f5b2bacc0273d79",
+				"DiscoKey":   "discokey:069013759ee1b623257c918a427124bc6114ec9275b3564ec96ce48134f21270",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36150",
+					"10.65.0.27:36150",
+					"172.17.0.1:36150",
+					"172.18.0.1:36150",
+					"172.19.0.1:36150"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:11:08.782386347Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8285171886816240,
+				"StableID":   "n9dBQ9RNh721CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9c497fb63aec1ed4a3f34d7b9ad252da6756f0db7019f72956d3bdaf3023f447",
+				"DiscoKey":   "discokey:52b00a1c33073905d806b423c4453c9eb30071ff0f1f2207e02899ac4454c81a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:50282",
+					"10.65.0.27:50282",
+					"172.17.0.1:50282",
+					"172.18.0.1:50282",
+					"172.19.0.1:50282"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:11:09.324809646Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4269871067550841,
+				"StableID":   "n4pfkoGqLa11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:534c7f0b05eb184bf6aeb99c28422a63d13d09e9b4b3e010c72d2b5195f8ea25",
+				"KeyExpiry":  "2026-11-08T22:11:09Z",
+				"DiscoKey":   "discokey:a6134eaa656961798296bf09b9b9f0de535b592cba62f73fde5e86631239fa7d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:35459",
+					"10.65.0.27:35459",
+					"172.17.0.1:35459",
+					"172.18.0.1:35459",
+					"172.19.0.1:35459"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:11:09.878295429Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3867988008102548,
+				"StableID":   "nBNTyBVpCX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a5882a99c0965a4242cfd47b2233c8ebd70f8b10b2abb0b47d8ec8fb6a722f64",
+				"KeyExpiry":  "2026-11-08T22:11:10Z",
+				"DiscoKey":   "discokey:14fe9bc8594a1cad3141943970ee07f7e2ec7aee50a003d622bbe12af9a69c35",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:33834",
+					"10.65.0.27:33834",
+					"172.17.0.1:33834",
+					"172.18.0.1:33834",
+					"172.19.0.1:33834"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:11:10.417098091Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1536151596243616,
+				"StableID":   "nsJrFf6jzC11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:0c86508999647ab76d3e3b36d7e3e5665fdf6021d98c0b4f1b34fe17a32fde1d",
+				"KeyExpiry":  "2026-11-08T22:11:10Z",
+				"DiscoKey":   "discokey:9c1558274db049b32e4d37a4e2a99ba0b3c78709bb54bad36e42d6f57d0d9362",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47599",
+					"10.65.0.27:47599",
+					"172.17.0.1:47599",
+					"172.18.0.1:47599",
+					"172.19.0.1:47599"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:11:10.957037949Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8526652530688909": {
+				"ID":          8526652530688909,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-user-whitespace-leading.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-user-whitespace-leading.hujson
@@ -1,0 +1,20104 @@
+// ssh-malformed-user-whitespace-leading
+//
+// ssh user with leading whitespace
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-13T07:31:03Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-malformed-user-whitespace-leading",
+	"description":    "ssh user with leading whitespace",
+	"category":       "ssh",
+	"captured_at":    "2026-05-13T07:31:03.860390312Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                        \n  \n                                                                      \n                                      \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh user with leading whitespace\",\n\t\"id\":          \"ssh-malformed-user-whitespace-leading\",\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"autogroup:member\"],\n\t\t\"users\":  [\" root\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-edge/ssh-malformed-user-whitespace-leading.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["autogroup:member"],
+				"users":  [" root"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         673038927903314,
+				"StableID":   "nsX2MJbpF611CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       673038927903314,
+				"Key":        "nodekey:a3c2556197e74a78e99f1d4c5b2a2ae6b6708ef15cd9ff0459d46a815c8add07",
+				"DiscoKey":   "discokey:96e5105a3179d353dcd05b06a685bb130a6838bbafda62b379d93d483daa937f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54954",
+					"10.65.0.27:54954",
+					"172.17.0.1:54954",
+					"172.18.0.1:54954",
+					"172.19.0.1:54954"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:31:12.670634654Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a3c2556197e74a78e99f1d4c5b2a2ae6b6708ef15cd9ff0459d46a815c8add07",
+			"MachineKey": "mkey:a75b79be4e8180329220895ac9ece9dbc1d3eacd8d64251968c0a1ccafee5953",
+			"Peers": [{
+				"ID":         3044711647891538,
+				"StableID":   "n5JYCuQxmQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a4be0290f33d7e8e0f3e2baece89023c517d9defc6bd6f39311dd9d6462c037",
+				"DiscoKey":   "discokey:dee554b5039ede1c7443f1fd9b2859ab8778421f8b3a6ea24028e0f557d60f50",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33867",
+					"10.65.0.27:33867",
+					"172.17.0.1:33867",
+					"172.18.0.1:33867",
+					"172.19.0.1:33867"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:31:06.43607452Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3529506869988132,
+				"StableID":   "nKibsJAXZU11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c7a002e132b998aa3d017a2948a74a895734f381bdb9ea1ce3948fb8c6b9d2d",
+				"DiscoKey":   "discokey:4d2f4caf90f93206f3b6be6109c85f3c1deb9c75d6e181e39e481eb01ad9d562",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37144",
+					"10.65.0.27:37144",
+					"172.17.0.1:37144",
+					"172.18.0.1:37144",
+					"172.19.0.1:37144"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:31:06.966175837Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6998571567534440,
+				"StableID":   "ns8ZwEcfew11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7774291507134579406d8d227fb730462bbc50cc352fae506edc546e051d7a16",
+				"DiscoKey":   "discokey:e40752848e48022f29593503aa4ea85f14a6641cd49162cd3ee367a118da9621",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:48331",
+					"10.65.0.27:48331",
+					"172.17.0.1:48331",
+					"172.18.0.1:48331",
+					"172.19.0.1:48331"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:31:07.510957208Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2076690947231121,
+				"StableID":   "n4iLig9YDH11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0242ee2dc2cb07c0b095c21f422419d4522207c775940397d4d7b92d2b5f3f6e",
+				"DiscoKey":   "discokey:630390aa40c642b5f3b9d10816b0e5adbeb445e740a9ad3ec1d7b55e2d6ce72e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35307",
+					"10.65.0.27:35307",
+					"172.17.0.1:35307",
+					"172.18.0.1:35307",
+					"172.19.0.1:35307"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:31:08.048551369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1406494704076150,
+				"StableID":   "n7DhgPE1zB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:598e9d7129c8291e7ce5ddb814287071a343f521d2a6e484a879542108458117",
+				"DiscoKey":   "discokey:539f93805980a2557de45eb87b6ea095b49b93933f01d40d227d54bd089c0d2b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34362",
+					"10.65.0.27:34362",
+					"172.17.0.1:34362",
+					"172.18.0.1:34362",
+					"172.19.0.1:34362"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:31:08.596624551Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5054443933899250,
+				"StableID":   "nT1uJwfAUg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf4dbb7ff8494358ae5d033bccf2e7b8038e8273d0f1d81809f42b06bfe86371",
+				"DiscoKey":   "discokey:fa6604d7668eb04e7e8c222b21209647b47661c0ee14b853258780b3b3e68e10",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39105",
+					"10.65.0.27:39105",
+					"172.17.0.1:39105",
+					"172.18.0.1:39105",
+					"172.19.0.1:39105"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:31:09.136532579Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         266103745376067,
+				"StableID":   "nC3UkT6X5311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06e6d591dff74af9a6db6cd8b2941ea81116246e0970ab8289c4c58a21d0c927",
+				"DiscoKey":   "discokey:b526abb089f198874454d2c32ecb222110d24325d7abd49473dd531af0681759",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53681",
+					"10.65.0.27:53681",
+					"172.17.0.1:53681",
+					"172.18.0.1:53681",
+					"172.19.0.1:53681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:31:09.675579328Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3266753253037176,
+				"StableID":   "nqjzVy4XWS11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb07ec8887f16f675123eb974676337279a7b35496f317a92f7384421960052d",
+				"DiscoKey":   "discokey:8e344c27a4e8cbd02bbd9c59d9d59b3c17ce917a0206c62ac2bdf70446f4812d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52015",
+					"10.65.0.27:52015",
+					"172.17.0.1:52015",
+					"172.18.0.1:52015",
+					"172.19.0.1:52015"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:31:10.21575352Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1618753548139836,
+				"StableID":   "nTGWtpu8eD11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:67bcdb151f767a1862e2ccf44cba68a49951908c9fec0212179280fa99cabd17",
+				"DiscoKey":   "discokey:4a7ad1484a565ad3adebf6dcf5d5362554954c147537ec92557882cd50728812",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48778",
+					"10.65.0.27:48778",
+					"172.17.0.1:48778",
+					"172.18.0.1:48778",
+					"172.19.0.1:48778"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:31:10.752039827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4821237427074581,
+				"StableID":   "npixsSjYee11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:12c11a5c815152484a9e2f89394b4ff3368353709eae3a5b7b057fea3304140f",
+				"DiscoKey":   "discokey:69df57647f23ab5fcbd9d60d0e150c521b3ac9b033ea45c808e3a5ebcf7da018",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35640",
+					"10.65.0.27:35640",
+					"172.17.0.1:35640",
+					"172.18.0.1:35640",
+					"172.19.0.1:35640"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:31:11.299118205Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5448112130204058,
+				"StableID":   "nwREmhfTYj11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4536ffa89c32490c120df5330e63d86aa0e5300453bbb613ccae7fd7a879e20",
+				"DiscoKey":   "discokey:c6f4572c0152bedb9d47497d3c5d522daa453fda04f24f55ba17cf782c6d6f67",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58664",
+					"10.65.0.27:58664",
+					"172.17.0.1:58664",
+					"172.18.0.1:58664",
+					"172.19.0.1:58664"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:31:12.127192218Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7813074903309875,
+				"StableID":   "nJ65bHEZ1421CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:dd832802f5c4222e3a946eab4990e99742b6c443c0656d3bac06bb07f3712e4c",
+				"KeyExpiry":  "2026-11-09T07:31:13Z",
+				"DiscoKey":   "discokey:1c48c757538e4730fe9caef6ba950ac110c36d74bf212a8baf4d5af56d562303",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49516",
+					"10.65.0.27:49516",
+					"172.17.0.1:49516",
+					"172.18.0.1:49516",
+					"172.19.0.1:49516"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:31:13.205031795Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2792466842877790,
+				"StableID":   "n5kzYPNioN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8030adaaae7f90780f99c642cdb01ffd96f7c3d97d89f78357927194b0f1eb2b",
+				"KeyExpiry":  "2026-11-09T07:31:13Z",
+				"DiscoKey":   "discokey:cc6386e27a4af148d99ea578d28d33d9cb6266a103a35980e9681f02dba6cb51",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57287",
+					"10.65.0.27:57287",
+					"172.17.0.1:57287",
+					"172.18.0.1:57287",
+					"172.19.0.1:57287"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:31:13.74351519Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5746981103666968,
+				"StableID":   "nMH6X1Tpsm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7dcbf5008ae4e442aa04037836f470f9df41f05521f05bbe883ebad4a7974f55",
+				"KeyExpiry":  "2026-11-09T07:31:14Z",
+				"DiscoKey":   "discokey:149776f54d846498240437583f5affccc73cb1100f823cd7af21be4f49d79d69",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53436",
+					"10.65.0.27:53436",
+					"172.17.0.1:53436",
+					"172.18.0.1:53436",
+					"172.19.0.1:53436"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:31:14.270543041Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{"principals": [
+				{"nodeIP": "100.64.0.17"},
+				{"nodeIP": "100.64.0.18"},
+				{"nodeIP": "100.64.0.19"},
+				{"nodeIP": "fd7a:115c:a1e0::13"},
+				{"nodeIP": "fd7a:115c:a1e0::12"},
+				{"nodeIP": "fd7a:115c:a1e0::11"}
+			], "sshUsers": {"root": "root"}, "action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "673038927903314": {
+				"ID":          673038927903314,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		},
+		"ssh_rules": [{"principals": [
+			{"nodeIP": "100.64.0.17"},
+			{"nodeIP": "100.64.0.18"},
+			{"nodeIP": "100.64.0.19"},
+			{"nodeIP": "fd7a:115c:a1e0::13"},
+			{"nodeIP": "fd7a:115c:a1e0::12"},
+			{"nodeIP": "fd7a:115c:a1e0::11"}
+		], "sshUsers": {"root": "root"}, "action": {
+			"accept":                    true,
+			"allowAgentForwarding":      true,
+			"allowLocalPortForwarding":  true,
+			"allowRemotePortForwarding": true
+		}}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5054443933899250,
+				"StableID":   "nT1uJwfAUg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       5054443933899250,
+				"Key":        "nodekey:bf4dbb7ff8494358ae5d033bccf2e7b8038e8273d0f1d81809f42b06bfe86371",
+				"DiscoKey":   "discokey:fa6604d7668eb04e7e8c222b21209647b47661c0ee14b853258780b3b3e68e10",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39105",
+					"10.65.0.27:39105",
+					"172.17.0.1:39105",
+					"172.18.0.1:39105",
+					"172.19.0.1:39105"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:31:09.136532579Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:bf4dbb7ff8494358ae5d033bccf2e7b8038e8273d0f1d81809f42b06bfe86371",
+			"MachineKey": "mkey:771a926860a924a04d42073d642f371790c0365ccaeb1a8efe10d9475e53ef49",
+			"Peers": [{
+				"ID":         3044711647891538,
+				"StableID":   "n5JYCuQxmQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a4be0290f33d7e8e0f3e2baece89023c517d9defc6bd6f39311dd9d6462c037",
+				"DiscoKey":   "discokey:dee554b5039ede1c7443f1fd9b2859ab8778421f8b3a6ea24028e0f557d60f50",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33867",
+					"10.65.0.27:33867",
+					"172.17.0.1:33867",
+					"172.18.0.1:33867",
+					"172.19.0.1:33867"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:31:06.43607452Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3529506869988132,
+				"StableID":   "nKibsJAXZU11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c7a002e132b998aa3d017a2948a74a895734f381bdb9ea1ce3948fb8c6b9d2d",
+				"DiscoKey":   "discokey:4d2f4caf90f93206f3b6be6109c85f3c1deb9c75d6e181e39e481eb01ad9d562",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37144",
+					"10.65.0.27:37144",
+					"172.17.0.1:37144",
+					"172.18.0.1:37144",
+					"172.19.0.1:37144"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:31:06.966175837Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6998571567534440,
+				"StableID":   "ns8ZwEcfew11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7774291507134579406d8d227fb730462bbc50cc352fae506edc546e051d7a16",
+				"DiscoKey":   "discokey:e40752848e48022f29593503aa4ea85f14a6641cd49162cd3ee367a118da9621",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:48331",
+					"10.65.0.27:48331",
+					"172.17.0.1:48331",
+					"172.18.0.1:48331",
+					"172.19.0.1:48331"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:31:07.510957208Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2076690947231121,
+				"StableID":   "n4iLig9YDH11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0242ee2dc2cb07c0b095c21f422419d4522207c775940397d4d7b92d2b5f3f6e",
+				"DiscoKey":   "discokey:630390aa40c642b5f3b9d10816b0e5adbeb445e740a9ad3ec1d7b55e2d6ce72e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35307",
+					"10.65.0.27:35307",
+					"172.17.0.1:35307",
+					"172.18.0.1:35307",
+					"172.19.0.1:35307"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:31:08.048551369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1406494704076150,
+				"StableID":   "n7DhgPE1zB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:598e9d7129c8291e7ce5ddb814287071a343f521d2a6e484a879542108458117",
+				"DiscoKey":   "discokey:539f93805980a2557de45eb87b6ea095b49b93933f01d40d227d54bd089c0d2b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34362",
+					"10.65.0.27:34362",
+					"172.17.0.1:34362",
+					"172.18.0.1:34362",
+					"172.19.0.1:34362"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:31:08.596624551Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         266103745376067,
+				"StableID":   "nC3UkT6X5311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06e6d591dff74af9a6db6cd8b2941ea81116246e0970ab8289c4c58a21d0c927",
+				"DiscoKey":   "discokey:b526abb089f198874454d2c32ecb222110d24325d7abd49473dd531af0681759",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53681",
+					"10.65.0.27:53681",
+					"172.17.0.1:53681",
+					"172.18.0.1:53681",
+					"172.19.0.1:53681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:31:09.675579328Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3266753253037176,
+				"StableID":   "nqjzVy4XWS11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb07ec8887f16f675123eb974676337279a7b35496f317a92f7384421960052d",
+				"DiscoKey":   "discokey:8e344c27a4e8cbd02bbd9c59d9d59b3c17ce917a0206c62ac2bdf70446f4812d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52015",
+					"10.65.0.27:52015",
+					"172.17.0.1:52015",
+					"172.18.0.1:52015",
+					"172.19.0.1:52015"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:31:10.21575352Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1618753548139836,
+				"StableID":   "nTGWtpu8eD11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:67bcdb151f767a1862e2ccf44cba68a49951908c9fec0212179280fa99cabd17",
+				"DiscoKey":   "discokey:4a7ad1484a565ad3adebf6dcf5d5362554954c147537ec92557882cd50728812",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48778",
+					"10.65.0.27:48778",
+					"172.17.0.1:48778",
+					"172.18.0.1:48778",
+					"172.19.0.1:48778"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:31:10.752039827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4821237427074581,
+				"StableID":   "npixsSjYee11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:12c11a5c815152484a9e2f89394b4ff3368353709eae3a5b7b057fea3304140f",
+				"DiscoKey":   "discokey:69df57647f23ab5fcbd9d60d0e150c521b3ac9b033ea45c808e3a5ebcf7da018",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35640",
+					"10.65.0.27:35640",
+					"172.17.0.1:35640",
+					"172.18.0.1:35640",
+					"172.19.0.1:35640"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:31:11.299118205Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5448112130204058,
+				"StableID":   "nwREmhfTYj11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4536ffa89c32490c120df5330e63d86aa0e5300453bbb613ccae7fd7a879e20",
+				"DiscoKey":   "discokey:c6f4572c0152bedb9d47497d3c5d522daa453fda04f24f55ba17cf782c6d6f67",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58664",
+					"10.65.0.27:58664",
+					"172.17.0.1:58664",
+					"172.18.0.1:58664",
+					"172.19.0.1:58664"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:31:12.127192218Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         673038927903314,
+				"StableID":   "nsX2MJbpF611CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a3c2556197e74a78e99f1d4c5b2a2ae6b6708ef15cd9ff0459d46a815c8add07",
+				"DiscoKey":   "discokey:96e5105a3179d353dcd05b06a685bb130a6838bbafda62b379d93d483daa937f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54954",
+					"10.65.0.27:54954",
+					"172.17.0.1:54954",
+					"172.18.0.1:54954",
+					"172.19.0.1:54954"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:31:12.670634654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7813074903309875,
+				"StableID":   "nJ65bHEZ1421CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:dd832802f5c4222e3a946eab4990e99742b6c443c0656d3bac06bb07f3712e4c",
+				"KeyExpiry":  "2026-11-09T07:31:13Z",
+				"DiscoKey":   "discokey:1c48c757538e4730fe9caef6ba950ac110c36d74bf212a8baf4d5af56d562303",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49516",
+					"10.65.0.27:49516",
+					"172.17.0.1:49516",
+					"172.18.0.1:49516",
+					"172.19.0.1:49516"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:31:13.205031795Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2792466842877790,
+				"StableID":   "n5kzYPNioN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8030adaaae7f90780f99c642cdb01ffd96f7c3d97d89f78357927194b0f1eb2b",
+				"KeyExpiry":  "2026-11-09T07:31:13Z",
+				"DiscoKey":   "discokey:cc6386e27a4af148d99ea578d28d33d9cb6266a103a35980e9681f02dba6cb51",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57287",
+					"10.65.0.27:57287",
+					"172.17.0.1:57287",
+					"172.18.0.1:57287",
+					"172.19.0.1:57287"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:31:13.74351519Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5746981103666968,
+				"StableID":   "nMH6X1Tpsm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7dcbf5008ae4e442aa04037836f470f9df41f05521f05bbe883ebad4a7974f55",
+				"KeyExpiry":  "2026-11-09T07:31:14Z",
+				"DiscoKey":   "discokey:149776f54d846498240437583f5affccc73cb1100f823cd7af21be4f49d79d69",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53436",
+					"10.65.0.27:53436",
+					"172.17.0.1:53436",
+					"172.18.0.1:53436",
+					"172.19.0.1:53436"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:31:14.270543041Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5054443933899250": {
+				"ID":          5054443933899250,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5746981103666968,
+				"StableID":   "nMH6X1Tpsm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7dcbf5008ae4e442aa04037836f470f9df41f05521f05bbe883ebad4a7974f55",
+				"KeyExpiry":  "2026-11-09T07:31:14Z",
+				"DiscoKey":   "discokey:149776f54d846498240437583f5affccc73cb1100f823cd7af21be4f49d79d69",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53436",
+					"10.65.0.27:53436",
+					"172.17.0.1:53436",
+					"172.18.0.1:53436",
+					"172.19.0.1:53436"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:31:14.270543041Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7dcbf5008ae4e442aa04037836f470f9df41f05521f05bbe883ebad4a7974f55",
+			"MachineKey": "mkey:0e0fe1733b93d5a38f925c98bfd9ddf3758d8179e9d7d90b513d073ce2feac3b",
+			"Peers": [{
+				"ID":         3044711647891538,
+				"StableID":   "n5JYCuQxmQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a4be0290f33d7e8e0f3e2baece89023c517d9defc6bd6f39311dd9d6462c037",
+				"DiscoKey":   "discokey:dee554b5039ede1c7443f1fd9b2859ab8778421f8b3a6ea24028e0f557d60f50",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33867",
+					"10.65.0.27:33867",
+					"172.17.0.1:33867",
+					"172.18.0.1:33867",
+					"172.19.0.1:33867"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:31:06.43607452Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3529506869988132,
+				"StableID":   "nKibsJAXZU11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c7a002e132b998aa3d017a2948a74a895734f381bdb9ea1ce3948fb8c6b9d2d",
+				"DiscoKey":   "discokey:4d2f4caf90f93206f3b6be6109c85f3c1deb9c75d6e181e39e481eb01ad9d562",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37144",
+					"10.65.0.27:37144",
+					"172.17.0.1:37144",
+					"172.18.0.1:37144",
+					"172.19.0.1:37144"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:31:06.966175837Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6998571567534440,
+				"StableID":   "ns8ZwEcfew11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7774291507134579406d8d227fb730462bbc50cc352fae506edc546e051d7a16",
+				"DiscoKey":   "discokey:e40752848e48022f29593503aa4ea85f14a6641cd49162cd3ee367a118da9621",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:48331",
+					"10.65.0.27:48331",
+					"172.17.0.1:48331",
+					"172.18.0.1:48331",
+					"172.19.0.1:48331"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:31:07.510957208Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2076690947231121,
+				"StableID":   "n4iLig9YDH11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0242ee2dc2cb07c0b095c21f422419d4522207c775940397d4d7b92d2b5f3f6e",
+				"DiscoKey":   "discokey:630390aa40c642b5f3b9d10816b0e5adbeb445e740a9ad3ec1d7b55e2d6ce72e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35307",
+					"10.65.0.27:35307",
+					"172.17.0.1:35307",
+					"172.18.0.1:35307",
+					"172.19.0.1:35307"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:31:08.048551369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1406494704076150,
+				"StableID":   "n7DhgPE1zB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:598e9d7129c8291e7ce5ddb814287071a343f521d2a6e484a879542108458117",
+				"DiscoKey":   "discokey:539f93805980a2557de45eb87b6ea095b49b93933f01d40d227d54bd089c0d2b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34362",
+					"10.65.0.27:34362",
+					"172.17.0.1:34362",
+					"172.18.0.1:34362",
+					"172.19.0.1:34362"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:31:08.596624551Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5054443933899250,
+				"StableID":   "nT1uJwfAUg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf4dbb7ff8494358ae5d033bccf2e7b8038e8273d0f1d81809f42b06bfe86371",
+				"DiscoKey":   "discokey:fa6604d7668eb04e7e8c222b21209647b47661c0ee14b853258780b3b3e68e10",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39105",
+					"10.65.0.27:39105",
+					"172.17.0.1:39105",
+					"172.18.0.1:39105",
+					"172.19.0.1:39105"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:31:09.136532579Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         266103745376067,
+				"StableID":   "nC3UkT6X5311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06e6d591dff74af9a6db6cd8b2941ea81116246e0970ab8289c4c58a21d0c927",
+				"DiscoKey":   "discokey:b526abb089f198874454d2c32ecb222110d24325d7abd49473dd531af0681759",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53681",
+					"10.65.0.27:53681",
+					"172.17.0.1:53681",
+					"172.18.0.1:53681",
+					"172.19.0.1:53681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:31:09.675579328Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3266753253037176,
+				"StableID":   "nqjzVy4XWS11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb07ec8887f16f675123eb974676337279a7b35496f317a92f7384421960052d",
+				"DiscoKey":   "discokey:8e344c27a4e8cbd02bbd9c59d9d59b3c17ce917a0206c62ac2bdf70446f4812d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52015",
+					"10.65.0.27:52015",
+					"172.17.0.1:52015",
+					"172.18.0.1:52015",
+					"172.19.0.1:52015"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:31:10.21575352Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1618753548139836,
+				"StableID":   "nTGWtpu8eD11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:67bcdb151f767a1862e2ccf44cba68a49951908c9fec0212179280fa99cabd17",
+				"DiscoKey":   "discokey:4a7ad1484a565ad3adebf6dcf5d5362554954c147537ec92557882cd50728812",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48778",
+					"10.65.0.27:48778",
+					"172.17.0.1:48778",
+					"172.18.0.1:48778",
+					"172.19.0.1:48778"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:31:10.752039827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4821237427074581,
+				"StableID":   "npixsSjYee11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:12c11a5c815152484a9e2f89394b4ff3368353709eae3a5b7b057fea3304140f",
+				"DiscoKey":   "discokey:69df57647f23ab5fcbd9d60d0e150c521b3ac9b033ea45c808e3a5ebcf7da018",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35640",
+					"10.65.0.27:35640",
+					"172.17.0.1:35640",
+					"172.18.0.1:35640",
+					"172.19.0.1:35640"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:31:11.299118205Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5448112130204058,
+				"StableID":   "nwREmhfTYj11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4536ffa89c32490c120df5330e63d86aa0e5300453bbb613ccae7fd7a879e20",
+				"DiscoKey":   "discokey:c6f4572c0152bedb9d47497d3c5d522daa453fda04f24f55ba17cf782c6d6f67",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58664",
+					"10.65.0.27:58664",
+					"172.17.0.1:58664",
+					"172.18.0.1:58664",
+					"172.19.0.1:58664"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:31:12.127192218Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         673038927903314,
+				"StableID":   "nsX2MJbpF611CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a3c2556197e74a78e99f1d4c5b2a2ae6b6708ef15cd9ff0459d46a815c8add07",
+				"DiscoKey":   "discokey:96e5105a3179d353dcd05b06a685bb130a6838bbafda62b379d93d483daa937f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54954",
+					"10.65.0.27:54954",
+					"172.17.0.1:54954",
+					"172.18.0.1:54954",
+					"172.19.0.1:54954"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:31:12.670634654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7813074903309875,
+				"StableID":   "nJ65bHEZ1421CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:dd832802f5c4222e3a946eab4990e99742b6c443c0656d3bac06bb07f3712e4c",
+				"KeyExpiry":  "2026-11-09T07:31:13Z",
+				"DiscoKey":   "discokey:1c48c757538e4730fe9caef6ba950ac110c36d74bf212a8baf4d5af56d562303",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49516",
+					"10.65.0.27:49516",
+					"172.17.0.1:49516",
+					"172.18.0.1:49516",
+					"172.19.0.1:49516"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:31:13.205031795Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2792466842877790,
+				"StableID":   "n5kzYPNioN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8030adaaae7f90780f99c642cdb01ffd96f7c3d97d89f78357927194b0f1eb2b",
+				"KeyExpiry":  "2026-11-09T07:31:13Z",
+				"DiscoKey":   "discokey:cc6386e27a4af148d99ea578d28d33d9cb6266a103a35980e9681f02dba6cb51",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57287",
+					"10.65.0.27:57287",
+					"172.17.0.1:57287",
+					"172.18.0.1:57287",
+					"172.19.0.1:57287"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:31:13.74351519Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6998571567534440,
+				"StableID":   "ns8ZwEcfew11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       6998571567534440,
+				"Key":        "nodekey:7774291507134579406d8d227fb730462bbc50cc352fae506edc546e051d7a16",
+				"DiscoKey":   "discokey:e40752848e48022f29593503aa4ea85f14a6641cd49162cd3ee367a118da9621",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:48331",
+					"10.65.0.27:48331",
+					"172.17.0.1:48331",
+					"172.18.0.1:48331",
+					"172.19.0.1:48331"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:31:07.510957208Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7774291507134579406d8d227fb730462bbc50cc352fae506edc546e051d7a16",
+			"MachineKey": "mkey:66c02c739fb11b90837c38fb6e8b56aa4cf775200c6e2835e6ec753654683a2f",
+			"Peers": [{
+				"ID":         3044711647891538,
+				"StableID":   "n5JYCuQxmQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a4be0290f33d7e8e0f3e2baece89023c517d9defc6bd6f39311dd9d6462c037",
+				"DiscoKey":   "discokey:dee554b5039ede1c7443f1fd9b2859ab8778421f8b3a6ea24028e0f557d60f50",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33867",
+					"10.65.0.27:33867",
+					"172.17.0.1:33867",
+					"172.18.0.1:33867",
+					"172.19.0.1:33867"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:31:06.43607452Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3529506869988132,
+				"StableID":   "nKibsJAXZU11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c7a002e132b998aa3d017a2948a74a895734f381bdb9ea1ce3948fb8c6b9d2d",
+				"DiscoKey":   "discokey:4d2f4caf90f93206f3b6be6109c85f3c1deb9c75d6e181e39e481eb01ad9d562",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37144",
+					"10.65.0.27:37144",
+					"172.17.0.1:37144",
+					"172.18.0.1:37144",
+					"172.19.0.1:37144"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:31:06.966175837Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2076690947231121,
+				"StableID":   "n4iLig9YDH11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0242ee2dc2cb07c0b095c21f422419d4522207c775940397d4d7b92d2b5f3f6e",
+				"DiscoKey":   "discokey:630390aa40c642b5f3b9d10816b0e5adbeb445e740a9ad3ec1d7b55e2d6ce72e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35307",
+					"10.65.0.27:35307",
+					"172.17.0.1:35307",
+					"172.18.0.1:35307",
+					"172.19.0.1:35307"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:31:08.048551369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1406494704076150,
+				"StableID":   "n7DhgPE1zB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:598e9d7129c8291e7ce5ddb814287071a343f521d2a6e484a879542108458117",
+				"DiscoKey":   "discokey:539f93805980a2557de45eb87b6ea095b49b93933f01d40d227d54bd089c0d2b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34362",
+					"10.65.0.27:34362",
+					"172.17.0.1:34362",
+					"172.18.0.1:34362",
+					"172.19.0.1:34362"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:31:08.596624551Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5054443933899250,
+				"StableID":   "nT1uJwfAUg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf4dbb7ff8494358ae5d033bccf2e7b8038e8273d0f1d81809f42b06bfe86371",
+				"DiscoKey":   "discokey:fa6604d7668eb04e7e8c222b21209647b47661c0ee14b853258780b3b3e68e10",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39105",
+					"10.65.0.27:39105",
+					"172.17.0.1:39105",
+					"172.18.0.1:39105",
+					"172.19.0.1:39105"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:31:09.136532579Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         266103745376067,
+				"StableID":   "nC3UkT6X5311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06e6d591dff74af9a6db6cd8b2941ea81116246e0970ab8289c4c58a21d0c927",
+				"DiscoKey":   "discokey:b526abb089f198874454d2c32ecb222110d24325d7abd49473dd531af0681759",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53681",
+					"10.65.0.27:53681",
+					"172.17.0.1:53681",
+					"172.18.0.1:53681",
+					"172.19.0.1:53681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:31:09.675579328Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3266753253037176,
+				"StableID":   "nqjzVy4XWS11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb07ec8887f16f675123eb974676337279a7b35496f317a92f7384421960052d",
+				"DiscoKey":   "discokey:8e344c27a4e8cbd02bbd9c59d9d59b3c17ce917a0206c62ac2bdf70446f4812d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52015",
+					"10.65.0.27:52015",
+					"172.17.0.1:52015",
+					"172.18.0.1:52015",
+					"172.19.0.1:52015"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:31:10.21575352Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1618753548139836,
+				"StableID":   "nTGWtpu8eD11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:67bcdb151f767a1862e2ccf44cba68a49951908c9fec0212179280fa99cabd17",
+				"DiscoKey":   "discokey:4a7ad1484a565ad3adebf6dcf5d5362554954c147537ec92557882cd50728812",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48778",
+					"10.65.0.27:48778",
+					"172.17.0.1:48778",
+					"172.18.0.1:48778",
+					"172.19.0.1:48778"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:31:10.752039827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4821237427074581,
+				"StableID":   "npixsSjYee11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:12c11a5c815152484a9e2f89394b4ff3368353709eae3a5b7b057fea3304140f",
+				"DiscoKey":   "discokey:69df57647f23ab5fcbd9d60d0e150c521b3ac9b033ea45c808e3a5ebcf7da018",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35640",
+					"10.65.0.27:35640",
+					"172.17.0.1:35640",
+					"172.18.0.1:35640",
+					"172.19.0.1:35640"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:31:11.299118205Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5448112130204058,
+				"StableID":   "nwREmhfTYj11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4536ffa89c32490c120df5330e63d86aa0e5300453bbb613ccae7fd7a879e20",
+				"DiscoKey":   "discokey:c6f4572c0152bedb9d47497d3c5d522daa453fda04f24f55ba17cf782c6d6f67",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58664",
+					"10.65.0.27:58664",
+					"172.17.0.1:58664",
+					"172.18.0.1:58664",
+					"172.19.0.1:58664"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:31:12.127192218Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         673038927903314,
+				"StableID":   "nsX2MJbpF611CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a3c2556197e74a78e99f1d4c5b2a2ae6b6708ef15cd9ff0459d46a815c8add07",
+				"DiscoKey":   "discokey:96e5105a3179d353dcd05b06a685bb130a6838bbafda62b379d93d483daa937f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54954",
+					"10.65.0.27:54954",
+					"172.17.0.1:54954",
+					"172.18.0.1:54954",
+					"172.19.0.1:54954"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:31:12.670634654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7813074903309875,
+				"StableID":   "nJ65bHEZ1421CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:dd832802f5c4222e3a946eab4990e99742b6c443c0656d3bac06bb07f3712e4c",
+				"KeyExpiry":  "2026-11-09T07:31:13Z",
+				"DiscoKey":   "discokey:1c48c757538e4730fe9caef6ba950ac110c36d74bf212a8baf4d5af56d562303",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49516",
+					"10.65.0.27:49516",
+					"172.17.0.1:49516",
+					"172.18.0.1:49516",
+					"172.19.0.1:49516"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:31:13.205031795Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2792466842877790,
+				"StableID":   "n5kzYPNioN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8030adaaae7f90780f99c642cdb01ffd96f7c3d97d89f78357927194b0f1eb2b",
+				"KeyExpiry":  "2026-11-09T07:31:13Z",
+				"DiscoKey":   "discokey:cc6386e27a4af148d99ea578d28d33d9cb6266a103a35980e9681f02dba6cb51",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57287",
+					"10.65.0.27:57287",
+					"172.17.0.1:57287",
+					"172.18.0.1:57287",
+					"172.19.0.1:57287"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:31:13.74351519Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5746981103666968,
+				"StableID":   "nMH6X1Tpsm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7dcbf5008ae4e442aa04037836f470f9df41f05521f05bbe883ebad4a7974f55",
+				"KeyExpiry":  "2026-11-09T07:31:14Z",
+				"DiscoKey":   "discokey:149776f54d846498240437583f5affccc73cb1100f823cd7af21be4f49d79d69",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53436",
+					"10.65.0.27:53436",
+					"172.17.0.1:53436",
+					"172.18.0.1:53436",
+					"172.19.0.1:53436"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:31:14.270543041Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6998571567534440": {
+				"ID":          6998571567534440,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3266753253037176,
+				"StableID":   "nqjzVy4XWS11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       3266753253037176,
+				"Key":        "nodekey:fb07ec8887f16f675123eb974676337279a7b35496f317a92f7384421960052d",
+				"DiscoKey":   "discokey:8e344c27a4e8cbd02bbd9c59d9d59b3c17ce917a0206c62ac2bdf70446f4812d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52015",
+					"10.65.0.27:52015",
+					"172.17.0.1:52015",
+					"172.18.0.1:52015",
+					"172.19.0.1:52015"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:31:10.21575352Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:fb07ec8887f16f675123eb974676337279a7b35496f317a92f7384421960052d",
+			"MachineKey": "mkey:b3824bc698b53830e0a762d4b3e6380f112e3a9a232e299cf3576b04e0cc0941",
+			"Peers": [{
+				"ID":         3044711647891538,
+				"StableID":   "n5JYCuQxmQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a4be0290f33d7e8e0f3e2baece89023c517d9defc6bd6f39311dd9d6462c037",
+				"DiscoKey":   "discokey:dee554b5039ede1c7443f1fd9b2859ab8778421f8b3a6ea24028e0f557d60f50",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33867",
+					"10.65.0.27:33867",
+					"172.17.0.1:33867",
+					"172.18.0.1:33867",
+					"172.19.0.1:33867"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:31:06.43607452Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3529506869988132,
+				"StableID":   "nKibsJAXZU11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c7a002e132b998aa3d017a2948a74a895734f381bdb9ea1ce3948fb8c6b9d2d",
+				"DiscoKey":   "discokey:4d2f4caf90f93206f3b6be6109c85f3c1deb9c75d6e181e39e481eb01ad9d562",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37144",
+					"10.65.0.27:37144",
+					"172.17.0.1:37144",
+					"172.18.0.1:37144",
+					"172.19.0.1:37144"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:31:06.966175837Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6998571567534440,
+				"StableID":   "ns8ZwEcfew11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7774291507134579406d8d227fb730462bbc50cc352fae506edc546e051d7a16",
+				"DiscoKey":   "discokey:e40752848e48022f29593503aa4ea85f14a6641cd49162cd3ee367a118da9621",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:48331",
+					"10.65.0.27:48331",
+					"172.17.0.1:48331",
+					"172.18.0.1:48331",
+					"172.19.0.1:48331"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:31:07.510957208Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2076690947231121,
+				"StableID":   "n4iLig9YDH11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0242ee2dc2cb07c0b095c21f422419d4522207c775940397d4d7b92d2b5f3f6e",
+				"DiscoKey":   "discokey:630390aa40c642b5f3b9d10816b0e5adbeb445e740a9ad3ec1d7b55e2d6ce72e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35307",
+					"10.65.0.27:35307",
+					"172.17.0.1:35307",
+					"172.18.0.1:35307",
+					"172.19.0.1:35307"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:31:08.048551369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1406494704076150,
+				"StableID":   "n7DhgPE1zB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:598e9d7129c8291e7ce5ddb814287071a343f521d2a6e484a879542108458117",
+				"DiscoKey":   "discokey:539f93805980a2557de45eb87b6ea095b49b93933f01d40d227d54bd089c0d2b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34362",
+					"10.65.0.27:34362",
+					"172.17.0.1:34362",
+					"172.18.0.1:34362",
+					"172.19.0.1:34362"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:31:08.596624551Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5054443933899250,
+				"StableID":   "nT1uJwfAUg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf4dbb7ff8494358ae5d033bccf2e7b8038e8273d0f1d81809f42b06bfe86371",
+				"DiscoKey":   "discokey:fa6604d7668eb04e7e8c222b21209647b47661c0ee14b853258780b3b3e68e10",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39105",
+					"10.65.0.27:39105",
+					"172.17.0.1:39105",
+					"172.18.0.1:39105",
+					"172.19.0.1:39105"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:31:09.136532579Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         266103745376067,
+				"StableID":   "nC3UkT6X5311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06e6d591dff74af9a6db6cd8b2941ea81116246e0970ab8289c4c58a21d0c927",
+				"DiscoKey":   "discokey:b526abb089f198874454d2c32ecb222110d24325d7abd49473dd531af0681759",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53681",
+					"10.65.0.27:53681",
+					"172.17.0.1:53681",
+					"172.18.0.1:53681",
+					"172.19.0.1:53681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:31:09.675579328Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1618753548139836,
+				"StableID":   "nTGWtpu8eD11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:67bcdb151f767a1862e2ccf44cba68a49951908c9fec0212179280fa99cabd17",
+				"DiscoKey":   "discokey:4a7ad1484a565ad3adebf6dcf5d5362554954c147537ec92557882cd50728812",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48778",
+					"10.65.0.27:48778",
+					"172.17.0.1:48778",
+					"172.18.0.1:48778",
+					"172.19.0.1:48778"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:31:10.752039827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4821237427074581,
+				"StableID":   "npixsSjYee11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:12c11a5c815152484a9e2f89394b4ff3368353709eae3a5b7b057fea3304140f",
+				"DiscoKey":   "discokey:69df57647f23ab5fcbd9d60d0e150c521b3ac9b033ea45c808e3a5ebcf7da018",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35640",
+					"10.65.0.27:35640",
+					"172.17.0.1:35640",
+					"172.18.0.1:35640",
+					"172.19.0.1:35640"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:31:11.299118205Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5448112130204058,
+				"StableID":   "nwREmhfTYj11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4536ffa89c32490c120df5330e63d86aa0e5300453bbb613ccae7fd7a879e20",
+				"DiscoKey":   "discokey:c6f4572c0152bedb9d47497d3c5d522daa453fda04f24f55ba17cf782c6d6f67",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58664",
+					"10.65.0.27:58664",
+					"172.17.0.1:58664",
+					"172.18.0.1:58664",
+					"172.19.0.1:58664"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:31:12.127192218Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         673038927903314,
+				"StableID":   "nsX2MJbpF611CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a3c2556197e74a78e99f1d4c5b2a2ae6b6708ef15cd9ff0459d46a815c8add07",
+				"DiscoKey":   "discokey:96e5105a3179d353dcd05b06a685bb130a6838bbafda62b379d93d483daa937f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54954",
+					"10.65.0.27:54954",
+					"172.17.0.1:54954",
+					"172.18.0.1:54954",
+					"172.19.0.1:54954"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:31:12.670634654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7813074903309875,
+				"StableID":   "nJ65bHEZ1421CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:dd832802f5c4222e3a946eab4990e99742b6c443c0656d3bac06bb07f3712e4c",
+				"KeyExpiry":  "2026-11-09T07:31:13Z",
+				"DiscoKey":   "discokey:1c48c757538e4730fe9caef6ba950ac110c36d74bf212a8baf4d5af56d562303",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49516",
+					"10.65.0.27:49516",
+					"172.17.0.1:49516",
+					"172.18.0.1:49516",
+					"172.19.0.1:49516"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:31:13.205031795Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2792466842877790,
+				"StableID":   "n5kzYPNioN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8030adaaae7f90780f99c642cdb01ffd96f7c3d97d89f78357927194b0f1eb2b",
+				"KeyExpiry":  "2026-11-09T07:31:13Z",
+				"DiscoKey":   "discokey:cc6386e27a4af148d99ea578d28d33d9cb6266a103a35980e9681f02dba6cb51",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57287",
+					"10.65.0.27:57287",
+					"172.17.0.1:57287",
+					"172.18.0.1:57287",
+					"172.19.0.1:57287"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:31:13.74351519Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5746981103666968,
+				"StableID":   "nMH6X1Tpsm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7dcbf5008ae4e442aa04037836f470f9df41f05521f05bbe883ebad4a7974f55",
+				"KeyExpiry":  "2026-11-09T07:31:14Z",
+				"DiscoKey":   "discokey:149776f54d846498240437583f5affccc73cb1100f823cd7af21be4f49d79d69",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53436",
+					"10.65.0.27:53436",
+					"172.17.0.1:53436",
+					"172.18.0.1:53436",
+					"172.19.0.1:53436"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:31:14.270543041Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3266753253037176": {
+				"ID":          3266753253037176,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7813074903309875,
+				"StableID":   "nJ65bHEZ1421CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:dd832802f5c4222e3a946eab4990e99742b6c443c0656d3bac06bb07f3712e4c",
+				"KeyExpiry":  "2026-11-09T07:31:13Z",
+				"DiscoKey":   "discokey:1c48c757538e4730fe9caef6ba950ac110c36d74bf212a8baf4d5af56d562303",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49516",
+					"10.65.0.27:49516",
+					"172.17.0.1:49516",
+					"172.18.0.1:49516",
+					"172.19.0.1:49516"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:31:13.205031795Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:dd832802f5c4222e3a946eab4990e99742b6c443c0656d3bac06bb07f3712e4c",
+			"MachineKey": "mkey:724c6ac7525e6a9cd1889f518d1505117bf164a768888e61b80590ebcce9e672",
+			"Peers": [{
+				"ID":         3044711647891538,
+				"StableID":   "n5JYCuQxmQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a4be0290f33d7e8e0f3e2baece89023c517d9defc6bd6f39311dd9d6462c037",
+				"DiscoKey":   "discokey:dee554b5039ede1c7443f1fd9b2859ab8778421f8b3a6ea24028e0f557d60f50",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33867",
+					"10.65.0.27:33867",
+					"172.17.0.1:33867",
+					"172.18.0.1:33867",
+					"172.19.0.1:33867"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:31:06.43607452Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3529506869988132,
+				"StableID":   "nKibsJAXZU11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c7a002e132b998aa3d017a2948a74a895734f381bdb9ea1ce3948fb8c6b9d2d",
+				"DiscoKey":   "discokey:4d2f4caf90f93206f3b6be6109c85f3c1deb9c75d6e181e39e481eb01ad9d562",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37144",
+					"10.65.0.27:37144",
+					"172.17.0.1:37144",
+					"172.18.0.1:37144",
+					"172.19.0.1:37144"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:31:06.966175837Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6998571567534440,
+				"StableID":   "ns8ZwEcfew11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7774291507134579406d8d227fb730462bbc50cc352fae506edc546e051d7a16",
+				"DiscoKey":   "discokey:e40752848e48022f29593503aa4ea85f14a6641cd49162cd3ee367a118da9621",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:48331",
+					"10.65.0.27:48331",
+					"172.17.0.1:48331",
+					"172.18.0.1:48331",
+					"172.19.0.1:48331"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:31:07.510957208Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2076690947231121,
+				"StableID":   "n4iLig9YDH11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0242ee2dc2cb07c0b095c21f422419d4522207c775940397d4d7b92d2b5f3f6e",
+				"DiscoKey":   "discokey:630390aa40c642b5f3b9d10816b0e5adbeb445e740a9ad3ec1d7b55e2d6ce72e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35307",
+					"10.65.0.27:35307",
+					"172.17.0.1:35307",
+					"172.18.0.1:35307",
+					"172.19.0.1:35307"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:31:08.048551369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1406494704076150,
+				"StableID":   "n7DhgPE1zB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:598e9d7129c8291e7ce5ddb814287071a343f521d2a6e484a879542108458117",
+				"DiscoKey":   "discokey:539f93805980a2557de45eb87b6ea095b49b93933f01d40d227d54bd089c0d2b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34362",
+					"10.65.0.27:34362",
+					"172.17.0.1:34362",
+					"172.18.0.1:34362",
+					"172.19.0.1:34362"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:31:08.596624551Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5054443933899250,
+				"StableID":   "nT1uJwfAUg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf4dbb7ff8494358ae5d033bccf2e7b8038e8273d0f1d81809f42b06bfe86371",
+				"DiscoKey":   "discokey:fa6604d7668eb04e7e8c222b21209647b47661c0ee14b853258780b3b3e68e10",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39105",
+					"10.65.0.27:39105",
+					"172.17.0.1:39105",
+					"172.18.0.1:39105",
+					"172.19.0.1:39105"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:31:09.136532579Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         266103745376067,
+				"StableID":   "nC3UkT6X5311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06e6d591dff74af9a6db6cd8b2941ea81116246e0970ab8289c4c58a21d0c927",
+				"DiscoKey":   "discokey:b526abb089f198874454d2c32ecb222110d24325d7abd49473dd531af0681759",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53681",
+					"10.65.0.27:53681",
+					"172.17.0.1:53681",
+					"172.18.0.1:53681",
+					"172.19.0.1:53681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:31:09.675579328Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3266753253037176,
+				"StableID":   "nqjzVy4XWS11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb07ec8887f16f675123eb974676337279a7b35496f317a92f7384421960052d",
+				"DiscoKey":   "discokey:8e344c27a4e8cbd02bbd9c59d9d59b3c17ce917a0206c62ac2bdf70446f4812d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52015",
+					"10.65.0.27:52015",
+					"172.17.0.1:52015",
+					"172.18.0.1:52015",
+					"172.19.0.1:52015"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:31:10.21575352Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1618753548139836,
+				"StableID":   "nTGWtpu8eD11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:67bcdb151f767a1862e2ccf44cba68a49951908c9fec0212179280fa99cabd17",
+				"DiscoKey":   "discokey:4a7ad1484a565ad3adebf6dcf5d5362554954c147537ec92557882cd50728812",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48778",
+					"10.65.0.27:48778",
+					"172.17.0.1:48778",
+					"172.18.0.1:48778",
+					"172.19.0.1:48778"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:31:10.752039827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4821237427074581,
+				"StableID":   "npixsSjYee11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:12c11a5c815152484a9e2f89394b4ff3368353709eae3a5b7b057fea3304140f",
+				"DiscoKey":   "discokey:69df57647f23ab5fcbd9d60d0e150c521b3ac9b033ea45c808e3a5ebcf7da018",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35640",
+					"10.65.0.27:35640",
+					"172.17.0.1:35640",
+					"172.18.0.1:35640",
+					"172.19.0.1:35640"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:31:11.299118205Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5448112130204058,
+				"StableID":   "nwREmhfTYj11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4536ffa89c32490c120df5330e63d86aa0e5300453bbb613ccae7fd7a879e20",
+				"DiscoKey":   "discokey:c6f4572c0152bedb9d47497d3c5d522daa453fda04f24f55ba17cf782c6d6f67",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58664",
+					"10.65.0.27:58664",
+					"172.17.0.1:58664",
+					"172.18.0.1:58664",
+					"172.19.0.1:58664"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:31:12.127192218Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         673038927903314,
+				"StableID":   "nsX2MJbpF611CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a3c2556197e74a78e99f1d4c5b2a2ae6b6708ef15cd9ff0459d46a815c8add07",
+				"DiscoKey":   "discokey:96e5105a3179d353dcd05b06a685bb130a6838bbafda62b379d93d483daa937f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54954",
+					"10.65.0.27:54954",
+					"172.17.0.1:54954",
+					"172.18.0.1:54954",
+					"172.19.0.1:54954"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:31:12.670634654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2792466842877790,
+				"StableID":   "n5kzYPNioN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8030adaaae7f90780f99c642cdb01ffd96f7c3d97d89f78357927194b0f1eb2b",
+				"KeyExpiry":  "2026-11-09T07:31:13Z",
+				"DiscoKey":   "discokey:cc6386e27a4af148d99ea578d28d33d9cb6266a103a35980e9681f02dba6cb51",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57287",
+					"10.65.0.27:57287",
+					"172.17.0.1:57287",
+					"172.18.0.1:57287",
+					"172.19.0.1:57287"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:31:13.74351519Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5746981103666968,
+				"StableID":   "nMH6X1Tpsm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7dcbf5008ae4e442aa04037836f470f9df41f05521f05bbe883ebad4a7974f55",
+				"KeyExpiry":  "2026-11-09T07:31:14Z",
+				"DiscoKey":   "discokey:149776f54d846498240437583f5affccc73cb1100f823cd7af21be4f49d79d69",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53436",
+					"10.65.0.27:53436",
+					"172.17.0.1:53436",
+					"172.18.0.1:53436",
+					"172.19.0.1:53436"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:31:14.270543041Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5448112130204058,
+				"StableID":   "nwREmhfTYj11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       5448112130204058,
+				"Key":        "nodekey:a4536ffa89c32490c120df5330e63d86aa0e5300453bbb613ccae7fd7a879e20",
+				"DiscoKey":   "discokey:c6f4572c0152bedb9d47497d3c5d522daa453fda04f24f55ba17cf782c6d6f67",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58664",
+					"10.65.0.27:58664",
+					"172.17.0.1:58664",
+					"172.18.0.1:58664",
+					"172.19.0.1:58664"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:31:12.127192218Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a4536ffa89c32490c120df5330e63d86aa0e5300453bbb613ccae7fd7a879e20",
+			"MachineKey": "mkey:309ae70648bde1ddd6d4704164a3f4f25ae26542c2f9d9afd99c4d6bf5ea3659",
+			"Peers": [{
+				"ID":         3044711647891538,
+				"StableID":   "n5JYCuQxmQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a4be0290f33d7e8e0f3e2baece89023c517d9defc6bd6f39311dd9d6462c037",
+				"DiscoKey":   "discokey:dee554b5039ede1c7443f1fd9b2859ab8778421f8b3a6ea24028e0f557d60f50",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33867",
+					"10.65.0.27:33867",
+					"172.17.0.1:33867",
+					"172.18.0.1:33867",
+					"172.19.0.1:33867"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:31:06.43607452Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3529506869988132,
+				"StableID":   "nKibsJAXZU11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c7a002e132b998aa3d017a2948a74a895734f381bdb9ea1ce3948fb8c6b9d2d",
+				"DiscoKey":   "discokey:4d2f4caf90f93206f3b6be6109c85f3c1deb9c75d6e181e39e481eb01ad9d562",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37144",
+					"10.65.0.27:37144",
+					"172.17.0.1:37144",
+					"172.18.0.1:37144",
+					"172.19.0.1:37144"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:31:06.966175837Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6998571567534440,
+				"StableID":   "ns8ZwEcfew11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7774291507134579406d8d227fb730462bbc50cc352fae506edc546e051d7a16",
+				"DiscoKey":   "discokey:e40752848e48022f29593503aa4ea85f14a6641cd49162cd3ee367a118da9621",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:48331",
+					"10.65.0.27:48331",
+					"172.17.0.1:48331",
+					"172.18.0.1:48331",
+					"172.19.0.1:48331"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:31:07.510957208Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2076690947231121,
+				"StableID":   "n4iLig9YDH11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0242ee2dc2cb07c0b095c21f422419d4522207c775940397d4d7b92d2b5f3f6e",
+				"DiscoKey":   "discokey:630390aa40c642b5f3b9d10816b0e5adbeb445e740a9ad3ec1d7b55e2d6ce72e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35307",
+					"10.65.0.27:35307",
+					"172.17.0.1:35307",
+					"172.18.0.1:35307",
+					"172.19.0.1:35307"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:31:08.048551369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1406494704076150,
+				"StableID":   "n7DhgPE1zB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:598e9d7129c8291e7ce5ddb814287071a343f521d2a6e484a879542108458117",
+				"DiscoKey":   "discokey:539f93805980a2557de45eb87b6ea095b49b93933f01d40d227d54bd089c0d2b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34362",
+					"10.65.0.27:34362",
+					"172.17.0.1:34362",
+					"172.18.0.1:34362",
+					"172.19.0.1:34362"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:31:08.596624551Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5054443933899250,
+				"StableID":   "nT1uJwfAUg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf4dbb7ff8494358ae5d033bccf2e7b8038e8273d0f1d81809f42b06bfe86371",
+				"DiscoKey":   "discokey:fa6604d7668eb04e7e8c222b21209647b47661c0ee14b853258780b3b3e68e10",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39105",
+					"10.65.0.27:39105",
+					"172.17.0.1:39105",
+					"172.18.0.1:39105",
+					"172.19.0.1:39105"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:31:09.136532579Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         266103745376067,
+				"StableID":   "nC3UkT6X5311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06e6d591dff74af9a6db6cd8b2941ea81116246e0970ab8289c4c58a21d0c927",
+				"DiscoKey":   "discokey:b526abb089f198874454d2c32ecb222110d24325d7abd49473dd531af0681759",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53681",
+					"10.65.0.27:53681",
+					"172.17.0.1:53681",
+					"172.18.0.1:53681",
+					"172.19.0.1:53681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:31:09.675579328Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3266753253037176,
+				"StableID":   "nqjzVy4XWS11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb07ec8887f16f675123eb974676337279a7b35496f317a92f7384421960052d",
+				"DiscoKey":   "discokey:8e344c27a4e8cbd02bbd9c59d9d59b3c17ce917a0206c62ac2bdf70446f4812d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52015",
+					"10.65.0.27:52015",
+					"172.17.0.1:52015",
+					"172.18.0.1:52015",
+					"172.19.0.1:52015"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:31:10.21575352Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1618753548139836,
+				"StableID":   "nTGWtpu8eD11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:67bcdb151f767a1862e2ccf44cba68a49951908c9fec0212179280fa99cabd17",
+				"DiscoKey":   "discokey:4a7ad1484a565ad3adebf6dcf5d5362554954c147537ec92557882cd50728812",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48778",
+					"10.65.0.27:48778",
+					"172.17.0.1:48778",
+					"172.18.0.1:48778",
+					"172.19.0.1:48778"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:31:10.752039827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4821237427074581,
+				"StableID":   "npixsSjYee11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:12c11a5c815152484a9e2f89394b4ff3368353709eae3a5b7b057fea3304140f",
+				"DiscoKey":   "discokey:69df57647f23ab5fcbd9d60d0e150c521b3ac9b033ea45c808e3a5ebcf7da018",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35640",
+					"10.65.0.27:35640",
+					"172.17.0.1:35640",
+					"172.18.0.1:35640",
+					"172.19.0.1:35640"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:31:11.299118205Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         673038927903314,
+				"StableID":   "nsX2MJbpF611CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a3c2556197e74a78e99f1d4c5b2a2ae6b6708ef15cd9ff0459d46a815c8add07",
+				"DiscoKey":   "discokey:96e5105a3179d353dcd05b06a685bb130a6838bbafda62b379d93d483daa937f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54954",
+					"10.65.0.27:54954",
+					"172.17.0.1:54954",
+					"172.18.0.1:54954",
+					"172.19.0.1:54954"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:31:12.670634654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7813074903309875,
+				"StableID":   "nJ65bHEZ1421CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:dd832802f5c4222e3a946eab4990e99742b6c443c0656d3bac06bb07f3712e4c",
+				"KeyExpiry":  "2026-11-09T07:31:13Z",
+				"DiscoKey":   "discokey:1c48c757538e4730fe9caef6ba950ac110c36d74bf212a8baf4d5af56d562303",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49516",
+					"10.65.0.27:49516",
+					"172.17.0.1:49516",
+					"172.18.0.1:49516",
+					"172.19.0.1:49516"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:31:13.205031795Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2792466842877790,
+				"StableID":   "n5kzYPNioN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8030adaaae7f90780f99c642cdb01ffd96f7c3d97d89f78357927194b0f1eb2b",
+				"KeyExpiry":  "2026-11-09T07:31:13Z",
+				"DiscoKey":   "discokey:cc6386e27a4af148d99ea578d28d33d9cb6266a103a35980e9681f02dba6cb51",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57287",
+					"10.65.0.27:57287",
+					"172.17.0.1:57287",
+					"172.18.0.1:57287",
+					"172.19.0.1:57287"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:31:13.74351519Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5746981103666968,
+				"StableID":   "nMH6X1Tpsm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7dcbf5008ae4e442aa04037836f470f9df41f05521f05bbe883ebad4a7974f55",
+				"KeyExpiry":  "2026-11-09T07:31:14Z",
+				"DiscoKey":   "discokey:149776f54d846498240437583f5affccc73cb1100f823cd7af21be4f49d79d69",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53436",
+					"10.65.0.27:53436",
+					"172.17.0.1:53436",
+					"172.18.0.1:53436",
+					"172.19.0.1:53436"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:31:14.270543041Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5448112130204058": {
+				"ID":          5448112130204058,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3529506869988132,
+				"StableID":   "nKibsJAXZU11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       3529506869988132,
+				"Key":        "nodekey:1c7a002e132b998aa3d017a2948a74a895734f381bdb9ea1ce3948fb8c6b9d2d",
+				"DiscoKey":   "discokey:4d2f4caf90f93206f3b6be6109c85f3c1deb9c75d6e181e39e481eb01ad9d562",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37144",
+					"10.65.0.27:37144",
+					"172.17.0.1:37144",
+					"172.18.0.1:37144",
+					"172.19.0.1:37144"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:31:06.966175837Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1c7a002e132b998aa3d017a2948a74a895734f381bdb9ea1ce3948fb8c6b9d2d",
+			"MachineKey": "mkey:8983692c0bb3b0c869fc00f49a99a111efbdfeafc73a1d0eda330183f6d0022b",
+			"Peers": [{
+				"ID":         3044711647891538,
+				"StableID":   "n5JYCuQxmQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a4be0290f33d7e8e0f3e2baece89023c517d9defc6bd6f39311dd9d6462c037",
+				"DiscoKey":   "discokey:dee554b5039ede1c7443f1fd9b2859ab8778421f8b3a6ea24028e0f557d60f50",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33867",
+					"10.65.0.27:33867",
+					"172.17.0.1:33867",
+					"172.18.0.1:33867",
+					"172.19.0.1:33867"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:31:06.43607452Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6998571567534440,
+				"StableID":   "ns8ZwEcfew11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7774291507134579406d8d227fb730462bbc50cc352fae506edc546e051d7a16",
+				"DiscoKey":   "discokey:e40752848e48022f29593503aa4ea85f14a6641cd49162cd3ee367a118da9621",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:48331",
+					"10.65.0.27:48331",
+					"172.17.0.1:48331",
+					"172.18.0.1:48331",
+					"172.19.0.1:48331"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:31:07.510957208Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2076690947231121,
+				"StableID":   "n4iLig9YDH11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0242ee2dc2cb07c0b095c21f422419d4522207c775940397d4d7b92d2b5f3f6e",
+				"DiscoKey":   "discokey:630390aa40c642b5f3b9d10816b0e5adbeb445e740a9ad3ec1d7b55e2d6ce72e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35307",
+					"10.65.0.27:35307",
+					"172.17.0.1:35307",
+					"172.18.0.1:35307",
+					"172.19.0.1:35307"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:31:08.048551369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1406494704076150,
+				"StableID":   "n7DhgPE1zB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:598e9d7129c8291e7ce5ddb814287071a343f521d2a6e484a879542108458117",
+				"DiscoKey":   "discokey:539f93805980a2557de45eb87b6ea095b49b93933f01d40d227d54bd089c0d2b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34362",
+					"10.65.0.27:34362",
+					"172.17.0.1:34362",
+					"172.18.0.1:34362",
+					"172.19.0.1:34362"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:31:08.596624551Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5054443933899250,
+				"StableID":   "nT1uJwfAUg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf4dbb7ff8494358ae5d033bccf2e7b8038e8273d0f1d81809f42b06bfe86371",
+				"DiscoKey":   "discokey:fa6604d7668eb04e7e8c222b21209647b47661c0ee14b853258780b3b3e68e10",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39105",
+					"10.65.0.27:39105",
+					"172.17.0.1:39105",
+					"172.18.0.1:39105",
+					"172.19.0.1:39105"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:31:09.136532579Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         266103745376067,
+				"StableID":   "nC3UkT6X5311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06e6d591dff74af9a6db6cd8b2941ea81116246e0970ab8289c4c58a21d0c927",
+				"DiscoKey":   "discokey:b526abb089f198874454d2c32ecb222110d24325d7abd49473dd531af0681759",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53681",
+					"10.65.0.27:53681",
+					"172.17.0.1:53681",
+					"172.18.0.1:53681",
+					"172.19.0.1:53681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:31:09.675579328Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3266753253037176,
+				"StableID":   "nqjzVy4XWS11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb07ec8887f16f675123eb974676337279a7b35496f317a92f7384421960052d",
+				"DiscoKey":   "discokey:8e344c27a4e8cbd02bbd9c59d9d59b3c17ce917a0206c62ac2bdf70446f4812d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52015",
+					"10.65.0.27:52015",
+					"172.17.0.1:52015",
+					"172.18.0.1:52015",
+					"172.19.0.1:52015"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:31:10.21575352Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1618753548139836,
+				"StableID":   "nTGWtpu8eD11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:67bcdb151f767a1862e2ccf44cba68a49951908c9fec0212179280fa99cabd17",
+				"DiscoKey":   "discokey:4a7ad1484a565ad3adebf6dcf5d5362554954c147537ec92557882cd50728812",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48778",
+					"10.65.0.27:48778",
+					"172.17.0.1:48778",
+					"172.18.0.1:48778",
+					"172.19.0.1:48778"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:31:10.752039827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4821237427074581,
+				"StableID":   "npixsSjYee11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:12c11a5c815152484a9e2f89394b4ff3368353709eae3a5b7b057fea3304140f",
+				"DiscoKey":   "discokey:69df57647f23ab5fcbd9d60d0e150c521b3ac9b033ea45c808e3a5ebcf7da018",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35640",
+					"10.65.0.27:35640",
+					"172.17.0.1:35640",
+					"172.18.0.1:35640",
+					"172.19.0.1:35640"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:31:11.299118205Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5448112130204058,
+				"StableID":   "nwREmhfTYj11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4536ffa89c32490c120df5330e63d86aa0e5300453bbb613ccae7fd7a879e20",
+				"DiscoKey":   "discokey:c6f4572c0152bedb9d47497d3c5d522daa453fda04f24f55ba17cf782c6d6f67",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58664",
+					"10.65.0.27:58664",
+					"172.17.0.1:58664",
+					"172.18.0.1:58664",
+					"172.19.0.1:58664"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:31:12.127192218Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         673038927903314,
+				"StableID":   "nsX2MJbpF611CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a3c2556197e74a78e99f1d4c5b2a2ae6b6708ef15cd9ff0459d46a815c8add07",
+				"DiscoKey":   "discokey:96e5105a3179d353dcd05b06a685bb130a6838bbafda62b379d93d483daa937f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54954",
+					"10.65.0.27:54954",
+					"172.17.0.1:54954",
+					"172.18.0.1:54954",
+					"172.19.0.1:54954"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:31:12.670634654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7813074903309875,
+				"StableID":   "nJ65bHEZ1421CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:dd832802f5c4222e3a946eab4990e99742b6c443c0656d3bac06bb07f3712e4c",
+				"KeyExpiry":  "2026-11-09T07:31:13Z",
+				"DiscoKey":   "discokey:1c48c757538e4730fe9caef6ba950ac110c36d74bf212a8baf4d5af56d562303",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49516",
+					"10.65.0.27:49516",
+					"172.17.0.1:49516",
+					"172.18.0.1:49516",
+					"172.19.0.1:49516"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:31:13.205031795Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2792466842877790,
+				"StableID":   "n5kzYPNioN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8030adaaae7f90780f99c642cdb01ffd96f7c3d97d89f78357927194b0f1eb2b",
+				"KeyExpiry":  "2026-11-09T07:31:13Z",
+				"DiscoKey":   "discokey:cc6386e27a4af148d99ea578d28d33d9cb6266a103a35980e9681f02dba6cb51",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57287",
+					"10.65.0.27:57287",
+					"172.17.0.1:57287",
+					"172.18.0.1:57287",
+					"172.19.0.1:57287"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:31:13.74351519Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5746981103666968,
+				"StableID":   "nMH6X1Tpsm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7dcbf5008ae4e442aa04037836f470f9df41f05521f05bbe883ebad4a7974f55",
+				"KeyExpiry":  "2026-11-09T07:31:14Z",
+				"DiscoKey":   "discokey:149776f54d846498240437583f5affccc73cb1100f823cd7af21be4f49d79d69",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53436",
+					"10.65.0.27:53436",
+					"172.17.0.1:53436",
+					"172.18.0.1:53436",
+					"172.19.0.1:53436"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:31:14.270543041Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3529506869988132": {
+				"ID":          3529506869988132,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3044711647891538,
+				"StableID":   "n5JYCuQxmQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       3044711647891538,
+				"Key":        "nodekey:1a4be0290f33d7e8e0f3e2baece89023c517d9defc6bd6f39311dd9d6462c037",
+				"DiscoKey":   "discokey:dee554b5039ede1c7443f1fd9b2859ab8778421f8b3a6ea24028e0f557d60f50",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33867",
+					"10.65.0.27:33867",
+					"172.17.0.1:33867",
+					"172.18.0.1:33867",
+					"172.19.0.1:33867"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:31:06.43607452Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1a4be0290f33d7e8e0f3e2baece89023c517d9defc6bd6f39311dd9d6462c037",
+			"MachineKey": "mkey:f9a0216988c15cd338b68840dabe2f4bf98aadcc052c358b4d6dbbf34cce2a55",
+			"Peers": [{
+				"ID":         3529506869988132,
+				"StableID":   "nKibsJAXZU11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c7a002e132b998aa3d017a2948a74a895734f381bdb9ea1ce3948fb8c6b9d2d",
+				"DiscoKey":   "discokey:4d2f4caf90f93206f3b6be6109c85f3c1deb9c75d6e181e39e481eb01ad9d562",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37144",
+					"10.65.0.27:37144",
+					"172.17.0.1:37144",
+					"172.18.0.1:37144",
+					"172.19.0.1:37144"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:31:06.966175837Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6998571567534440,
+				"StableID":   "ns8ZwEcfew11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7774291507134579406d8d227fb730462bbc50cc352fae506edc546e051d7a16",
+				"DiscoKey":   "discokey:e40752848e48022f29593503aa4ea85f14a6641cd49162cd3ee367a118da9621",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:48331",
+					"10.65.0.27:48331",
+					"172.17.0.1:48331",
+					"172.18.0.1:48331",
+					"172.19.0.1:48331"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:31:07.510957208Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2076690947231121,
+				"StableID":   "n4iLig9YDH11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0242ee2dc2cb07c0b095c21f422419d4522207c775940397d4d7b92d2b5f3f6e",
+				"DiscoKey":   "discokey:630390aa40c642b5f3b9d10816b0e5adbeb445e740a9ad3ec1d7b55e2d6ce72e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35307",
+					"10.65.0.27:35307",
+					"172.17.0.1:35307",
+					"172.18.0.1:35307",
+					"172.19.0.1:35307"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:31:08.048551369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1406494704076150,
+				"StableID":   "n7DhgPE1zB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:598e9d7129c8291e7ce5ddb814287071a343f521d2a6e484a879542108458117",
+				"DiscoKey":   "discokey:539f93805980a2557de45eb87b6ea095b49b93933f01d40d227d54bd089c0d2b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34362",
+					"10.65.0.27:34362",
+					"172.17.0.1:34362",
+					"172.18.0.1:34362",
+					"172.19.0.1:34362"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:31:08.596624551Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5054443933899250,
+				"StableID":   "nT1uJwfAUg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf4dbb7ff8494358ae5d033bccf2e7b8038e8273d0f1d81809f42b06bfe86371",
+				"DiscoKey":   "discokey:fa6604d7668eb04e7e8c222b21209647b47661c0ee14b853258780b3b3e68e10",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39105",
+					"10.65.0.27:39105",
+					"172.17.0.1:39105",
+					"172.18.0.1:39105",
+					"172.19.0.1:39105"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:31:09.136532579Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         266103745376067,
+				"StableID":   "nC3UkT6X5311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06e6d591dff74af9a6db6cd8b2941ea81116246e0970ab8289c4c58a21d0c927",
+				"DiscoKey":   "discokey:b526abb089f198874454d2c32ecb222110d24325d7abd49473dd531af0681759",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53681",
+					"10.65.0.27:53681",
+					"172.17.0.1:53681",
+					"172.18.0.1:53681",
+					"172.19.0.1:53681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:31:09.675579328Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3266753253037176,
+				"StableID":   "nqjzVy4XWS11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb07ec8887f16f675123eb974676337279a7b35496f317a92f7384421960052d",
+				"DiscoKey":   "discokey:8e344c27a4e8cbd02bbd9c59d9d59b3c17ce917a0206c62ac2bdf70446f4812d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52015",
+					"10.65.0.27:52015",
+					"172.17.0.1:52015",
+					"172.18.0.1:52015",
+					"172.19.0.1:52015"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:31:10.21575352Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1618753548139836,
+				"StableID":   "nTGWtpu8eD11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:67bcdb151f767a1862e2ccf44cba68a49951908c9fec0212179280fa99cabd17",
+				"DiscoKey":   "discokey:4a7ad1484a565ad3adebf6dcf5d5362554954c147537ec92557882cd50728812",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48778",
+					"10.65.0.27:48778",
+					"172.17.0.1:48778",
+					"172.18.0.1:48778",
+					"172.19.0.1:48778"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:31:10.752039827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4821237427074581,
+				"StableID":   "npixsSjYee11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:12c11a5c815152484a9e2f89394b4ff3368353709eae3a5b7b057fea3304140f",
+				"DiscoKey":   "discokey:69df57647f23ab5fcbd9d60d0e150c521b3ac9b033ea45c808e3a5ebcf7da018",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35640",
+					"10.65.0.27:35640",
+					"172.17.0.1:35640",
+					"172.18.0.1:35640",
+					"172.19.0.1:35640"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:31:11.299118205Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5448112130204058,
+				"StableID":   "nwREmhfTYj11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4536ffa89c32490c120df5330e63d86aa0e5300453bbb613ccae7fd7a879e20",
+				"DiscoKey":   "discokey:c6f4572c0152bedb9d47497d3c5d522daa453fda04f24f55ba17cf782c6d6f67",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58664",
+					"10.65.0.27:58664",
+					"172.17.0.1:58664",
+					"172.18.0.1:58664",
+					"172.19.0.1:58664"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:31:12.127192218Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         673038927903314,
+				"StableID":   "nsX2MJbpF611CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a3c2556197e74a78e99f1d4c5b2a2ae6b6708ef15cd9ff0459d46a815c8add07",
+				"DiscoKey":   "discokey:96e5105a3179d353dcd05b06a685bb130a6838bbafda62b379d93d483daa937f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54954",
+					"10.65.0.27:54954",
+					"172.17.0.1:54954",
+					"172.18.0.1:54954",
+					"172.19.0.1:54954"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:31:12.670634654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7813074903309875,
+				"StableID":   "nJ65bHEZ1421CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:dd832802f5c4222e3a946eab4990e99742b6c443c0656d3bac06bb07f3712e4c",
+				"KeyExpiry":  "2026-11-09T07:31:13Z",
+				"DiscoKey":   "discokey:1c48c757538e4730fe9caef6ba950ac110c36d74bf212a8baf4d5af56d562303",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49516",
+					"10.65.0.27:49516",
+					"172.17.0.1:49516",
+					"172.18.0.1:49516",
+					"172.19.0.1:49516"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:31:13.205031795Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2792466842877790,
+				"StableID":   "n5kzYPNioN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8030adaaae7f90780f99c642cdb01ffd96f7c3d97d89f78357927194b0f1eb2b",
+				"KeyExpiry":  "2026-11-09T07:31:13Z",
+				"DiscoKey":   "discokey:cc6386e27a4af148d99ea578d28d33d9cb6266a103a35980e9681f02dba6cb51",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57287",
+					"10.65.0.27:57287",
+					"172.17.0.1:57287",
+					"172.18.0.1:57287",
+					"172.19.0.1:57287"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:31:13.74351519Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5746981103666968,
+				"StableID":   "nMH6X1Tpsm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7dcbf5008ae4e442aa04037836f470f9df41f05521f05bbe883ebad4a7974f55",
+				"KeyExpiry":  "2026-11-09T07:31:14Z",
+				"DiscoKey":   "discokey:149776f54d846498240437583f5affccc73cb1100f823cd7af21be4f49d79d69",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53436",
+					"10.65.0.27:53436",
+					"172.17.0.1:53436",
+					"172.18.0.1:53436",
+					"172.19.0.1:53436"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:31:14.270543041Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3044711647891538": {
+				"ID":          3044711647891538,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1406494704076150,
+				"StableID":   "n7DhgPE1zB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1406494704076150,
+				"Key":        "nodekey:598e9d7129c8291e7ce5ddb814287071a343f521d2a6e484a879542108458117",
+				"DiscoKey":   "discokey:539f93805980a2557de45eb87b6ea095b49b93933f01d40d227d54bd089c0d2b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34362",
+					"10.65.0.27:34362",
+					"172.17.0.1:34362",
+					"172.18.0.1:34362",
+					"172.19.0.1:34362"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:31:08.596624551Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:598e9d7129c8291e7ce5ddb814287071a343f521d2a6e484a879542108458117",
+			"MachineKey": "mkey:9e741f89571d98b594fd77b44d6c4f6f2c87b9df26ec709edffbd8555d8fed2e",
+			"Peers": [{
+				"ID":         3044711647891538,
+				"StableID":   "n5JYCuQxmQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a4be0290f33d7e8e0f3e2baece89023c517d9defc6bd6f39311dd9d6462c037",
+				"DiscoKey":   "discokey:dee554b5039ede1c7443f1fd9b2859ab8778421f8b3a6ea24028e0f557d60f50",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33867",
+					"10.65.0.27:33867",
+					"172.17.0.1:33867",
+					"172.18.0.1:33867",
+					"172.19.0.1:33867"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:31:06.43607452Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3529506869988132,
+				"StableID":   "nKibsJAXZU11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c7a002e132b998aa3d017a2948a74a895734f381bdb9ea1ce3948fb8c6b9d2d",
+				"DiscoKey":   "discokey:4d2f4caf90f93206f3b6be6109c85f3c1deb9c75d6e181e39e481eb01ad9d562",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37144",
+					"10.65.0.27:37144",
+					"172.17.0.1:37144",
+					"172.18.0.1:37144",
+					"172.19.0.1:37144"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:31:06.966175837Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6998571567534440,
+				"StableID":   "ns8ZwEcfew11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7774291507134579406d8d227fb730462bbc50cc352fae506edc546e051d7a16",
+				"DiscoKey":   "discokey:e40752848e48022f29593503aa4ea85f14a6641cd49162cd3ee367a118da9621",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:48331",
+					"10.65.0.27:48331",
+					"172.17.0.1:48331",
+					"172.18.0.1:48331",
+					"172.19.0.1:48331"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:31:07.510957208Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2076690947231121,
+				"StableID":   "n4iLig9YDH11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0242ee2dc2cb07c0b095c21f422419d4522207c775940397d4d7b92d2b5f3f6e",
+				"DiscoKey":   "discokey:630390aa40c642b5f3b9d10816b0e5adbeb445e740a9ad3ec1d7b55e2d6ce72e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35307",
+					"10.65.0.27:35307",
+					"172.17.0.1:35307",
+					"172.18.0.1:35307",
+					"172.19.0.1:35307"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:31:08.048551369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5054443933899250,
+				"StableID":   "nT1uJwfAUg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf4dbb7ff8494358ae5d033bccf2e7b8038e8273d0f1d81809f42b06bfe86371",
+				"DiscoKey":   "discokey:fa6604d7668eb04e7e8c222b21209647b47661c0ee14b853258780b3b3e68e10",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39105",
+					"10.65.0.27:39105",
+					"172.17.0.1:39105",
+					"172.18.0.1:39105",
+					"172.19.0.1:39105"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:31:09.136532579Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         266103745376067,
+				"StableID":   "nC3UkT6X5311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06e6d591dff74af9a6db6cd8b2941ea81116246e0970ab8289c4c58a21d0c927",
+				"DiscoKey":   "discokey:b526abb089f198874454d2c32ecb222110d24325d7abd49473dd531af0681759",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53681",
+					"10.65.0.27:53681",
+					"172.17.0.1:53681",
+					"172.18.0.1:53681",
+					"172.19.0.1:53681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:31:09.675579328Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3266753253037176,
+				"StableID":   "nqjzVy4XWS11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb07ec8887f16f675123eb974676337279a7b35496f317a92f7384421960052d",
+				"DiscoKey":   "discokey:8e344c27a4e8cbd02bbd9c59d9d59b3c17ce917a0206c62ac2bdf70446f4812d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52015",
+					"10.65.0.27:52015",
+					"172.17.0.1:52015",
+					"172.18.0.1:52015",
+					"172.19.0.1:52015"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:31:10.21575352Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1618753548139836,
+				"StableID":   "nTGWtpu8eD11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:67bcdb151f767a1862e2ccf44cba68a49951908c9fec0212179280fa99cabd17",
+				"DiscoKey":   "discokey:4a7ad1484a565ad3adebf6dcf5d5362554954c147537ec92557882cd50728812",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48778",
+					"10.65.0.27:48778",
+					"172.17.0.1:48778",
+					"172.18.0.1:48778",
+					"172.19.0.1:48778"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:31:10.752039827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4821237427074581,
+				"StableID":   "npixsSjYee11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:12c11a5c815152484a9e2f89394b4ff3368353709eae3a5b7b057fea3304140f",
+				"DiscoKey":   "discokey:69df57647f23ab5fcbd9d60d0e150c521b3ac9b033ea45c808e3a5ebcf7da018",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35640",
+					"10.65.0.27:35640",
+					"172.17.0.1:35640",
+					"172.18.0.1:35640",
+					"172.19.0.1:35640"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:31:11.299118205Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5448112130204058,
+				"StableID":   "nwREmhfTYj11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4536ffa89c32490c120df5330e63d86aa0e5300453bbb613ccae7fd7a879e20",
+				"DiscoKey":   "discokey:c6f4572c0152bedb9d47497d3c5d522daa453fda04f24f55ba17cf782c6d6f67",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58664",
+					"10.65.0.27:58664",
+					"172.17.0.1:58664",
+					"172.18.0.1:58664",
+					"172.19.0.1:58664"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:31:12.127192218Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         673038927903314,
+				"StableID":   "nsX2MJbpF611CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a3c2556197e74a78e99f1d4c5b2a2ae6b6708ef15cd9ff0459d46a815c8add07",
+				"DiscoKey":   "discokey:96e5105a3179d353dcd05b06a685bb130a6838bbafda62b379d93d483daa937f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54954",
+					"10.65.0.27:54954",
+					"172.17.0.1:54954",
+					"172.18.0.1:54954",
+					"172.19.0.1:54954"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:31:12.670634654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7813074903309875,
+				"StableID":   "nJ65bHEZ1421CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:dd832802f5c4222e3a946eab4990e99742b6c443c0656d3bac06bb07f3712e4c",
+				"KeyExpiry":  "2026-11-09T07:31:13Z",
+				"DiscoKey":   "discokey:1c48c757538e4730fe9caef6ba950ac110c36d74bf212a8baf4d5af56d562303",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49516",
+					"10.65.0.27:49516",
+					"172.17.0.1:49516",
+					"172.18.0.1:49516",
+					"172.19.0.1:49516"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:31:13.205031795Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2792466842877790,
+				"StableID":   "n5kzYPNioN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8030adaaae7f90780f99c642cdb01ffd96f7c3d97d89f78357927194b0f1eb2b",
+				"KeyExpiry":  "2026-11-09T07:31:13Z",
+				"DiscoKey":   "discokey:cc6386e27a4af148d99ea578d28d33d9cb6266a103a35980e9681f02dba6cb51",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57287",
+					"10.65.0.27:57287",
+					"172.17.0.1:57287",
+					"172.18.0.1:57287",
+					"172.19.0.1:57287"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:31:13.74351519Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5746981103666968,
+				"StableID":   "nMH6X1Tpsm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7dcbf5008ae4e442aa04037836f470f9df41f05521f05bbe883ebad4a7974f55",
+				"KeyExpiry":  "2026-11-09T07:31:14Z",
+				"DiscoKey":   "discokey:149776f54d846498240437583f5affccc73cb1100f823cd7af21be4f49d79d69",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53436",
+					"10.65.0.27:53436",
+					"172.17.0.1:53436",
+					"172.18.0.1:53436",
+					"172.19.0.1:53436"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:31:14.270543041Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1406494704076150": {
+				"ID":          1406494704076150,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2076690947231121,
+				"StableID":   "n4iLig9YDH11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       2076690947231121,
+				"Key":        "nodekey:0242ee2dc2cb07c0b095c21f422419d4522207c775940397d4d7b92d2b5f3f6e",
+				"DiscoKey":   "discokey:630390aa40c642b5f3b9d10816b0e5adbeb445e740a9ad3ec1d7b55e2d6ce72e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35307",
+					"10.65.0.27:35307",
+					"172.17.0.1:35307",
+					"172.18.0.1:35307",
+					"172.19.0.1:35307"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:31:08.048551369Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0242ee2dc2cb07c0b095c21f422419d4522207c775940397d4d7b92d2b5f3f6e",
+			"MachineKey": "mkey:ee3086c49c34accf2babda84a69f2d1b6773760b634cffa2247813e28bbf7f7d",
+			"Peers": [{
+				"ID":         3044711647891538,
+				"StableID":   "n5JYCuQxmQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a4be0290f33d7e8e0f3e2baece89023c517d9defc6bd6f39311dd9d6462c037",
+				"DiscoKey":   "discokey:dee554b5039ede1c7443f1fd9b2859ab8778421f8b3a6ea24028e0f557d60f50",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33867",
+					"10.65.0.27:33867",
+					"172.17.0.1:33867",
+					"172.18.0.1:33867",
+					"172.19.0.1:33867"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:31:06.43607452Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3529506869988132,
+				"StableID":   "nKibsJAXZU11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c7a002e132b998aa3d017a2948a74a895734f381bdb9ea1ce3948fb8c6b9d2d",
+				"DiscoKey":   "discokey:4d2f4caf90f93206f3b6be6109c85f3c1deb9c75d6e181e39e481eb01ad9d562",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37144",
+					"10.65.0.27:37144",
+					"172.17.0.1:37144",
+					"172.18.0.1:37144",
+					"172.19.0.1:37144"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:31:06.966175837Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6998571567534440,
+				"StableID":   "ns8ZwEcfew11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7774291507134579406d8d227fb730462bbc50cc352fae506edc546e051d7a16",
+				"DiscoKey":   "discokey:e40752848e48022f29593503aa4ea85f14a6641cd49162cd3ee367a118da9621",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:48331",
+					"10.65.0.27:48331",
+					"172.17.0.1:48331",
+					"172.18.0.1:48331",
+					"172.19.0.1:48331"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:31:07.510957208Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1406494704076150,
+				"StableID":   "n7DhgPE1zB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:598e9d7129c8291e7ce5ddb814287071a343f521d2a6e484a879542108458117",
+				"DiscoKey":   "discokey:539f93805980a2557de45eb87b6ea095b49b93933f01d40d227d54bd089c0d2b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34362",
+					"10.65.0.27:34362",
+					"172.17.0.1:34362",
+					"172.18.0.1:34362",
+					"172.19.0.1:34362"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:31:08.596624551Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5054443933899250,
+				"StableID":   "nT1uJwfAUg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf4dbb7ff8494358ae5d033bccf2e7b8038e8273d0f1d81809f42b06bfe86371",
+				"DiscoKey":   "discokey:fa6604d7668eb04e7e8c222b21209647b47661c0ee14b853258780b3b3e68e10",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39105",
+					"10.65.0.27:39105",
+					"172.17.0.1:39105",
+					"172.18.0.1:39105",
+					"172.19.0.1:39105"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:31:09.136532579Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         266103745376067,
+				"StableID":   "nC3UkT6X5311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06e6d591dff74af9a6db6cd8b2941ea81116246e0970ab8289c4c58a21d0c927",
+				"DiscoKey":   "discokey:b526abb089f198874454d2c32ecb222110d24325d7abd49473dd531af0681759",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53681",
+					"10.65.0.27:53681",
+					"172.17.0.1:53681",
+					"172.18.0.1:53681",
+					"172.19.0.1:53681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:31:09.675579328Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3266753253037176,
+				"StableID":   "nqjzVy4XWS11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb07ec8887f16f675123eb974676337279a7b35496f317a92f7384421960052d",
+				"DiscoKey":   "discokey:8e344c27a4e8cbd02bbd9c59d9d59b3c17ce917a0206c62ac2bdf70446f4812d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52015",
+					"10.65.0.27:52015",
+					"172.17.0.1:52015",
+					"172.18.0.1:52015",
+					"172.19.0.1:52015"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:31:10.21575352Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1618753548139836,
+				"StableID":   "nTGWtpu8eD11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:67bcdb151f767a1862e2ccf44cba68a49951908c9fec0212179280fa99cabd17",
+				"DiscoKey":   "discokey:4a7ad1484a565ad3adebf6dcf5d5362554954c147537ec92557882cd50728812",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48778",
+					"10.65.0.27:48778",
+					"172.17.0.1:48778",
+					"172.18.0.1:48778",
+					"172.19.0.1:48778"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:31:10.752039827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4821237427074581,
+				"StableID":   "npixsSjYee11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:12c11a5c815152484a9e2f89394b4ff3368353709eae3a5b7b057fea3304140f",
+				"DiscoKey":   "discokey:69df57647f23ab5fcbd9d60d0e150c521b3ac9b033ea45c808e3a5ebcf7da018",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35640",
+					"10.65.0.27:35640",
+					"172.17.0.1:35640",
+					"172.18.0.1:35640",
+					"172.19.0.1:35640"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:31:11.299118205Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5448112130204058,
+				"StableID":   "nwREmhfTYj11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4536ffa89c32490c120df5330e63d86aa0e5300453bbb613ccae7fd7a879e20",
+				"DiscoKey":   "discokey:c6f4572c0152bedb9d47497d3c5d522daa453fda04f24f55ba17cf782c6d6f67",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58664",
+					"10.65.0.27:58664",
+					"172.17.0.1:58664",
+					"172.18.0.1:58664",
+					"172.19.0.1:58664"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:31:12.127192218Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         673038927903314,
+				"StableID":   "nsX2MJbpF611CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a3c2556197e74a78e99f1d4c5b2a2ae6b6708ef15cd9ff0459d46a815c8add07",
+				"DiscoKey":   "discokey:96e5105a3179d353dcd05b06a685bb130a6838bbafda62b379d93d483daa937f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54954",
+					"10.65.0.27:54954",
+					"172.17.0.1:54954",
+					"172.18.0.1:54954",
+					"172.19.0.1:54954"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:31:12.670634654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7813074903309875,
+				"StableID":   "nJ65bHEZ1421CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:dd832802f5c4222e3a946eab4990e99742b6c443c0656d3bac06bb07f3712e4c",
+				"KeyExpiry":  "2026-11-09T07:31:13Z",
+				"DiscoKey":   "discokey:1c48c757538e4730fe9caef6ba950ac110c36d74bf212a8baf4d5af56d562303",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49516",
+					"10.65.0.27:49516",
+					"172.17.0.1:49516",
+					"172.18.0.1:49516",
+					"172.19.0.1:49516"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:31:13.205031795Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2792466842877790,
+				"StableID":   "n5kzYPNioN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8030adaaae7f90780f99c642cdb01ffd96f7c3d97d89f78357927194b0f1eb2b",
+				"KeyExpiry":  "2026-11-09T07:31:13Z",
+				"DiscoKey":   "discokey:cc6386e27a4af148d99ea578d28d33d9cb6266a103a35980e9681f02dba6cb51",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57287",
+					"10.65.0.27:57287",
+					"172.17.0.1:57287",
+					"172.18.0.1:57287",
+					"172.19.0.1:57287"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:31:13.74351519Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5746981103666968,
+				"StableID":   "nMH6X1Tpsm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7dcbf5008ae4e442aa04037836f470f9df41f05521f05bbe883ebad4a7974f55",
+				"KeyExpiry":  "2026-11-09T07:31:14Z",
+				"DiscoKey":   "discokey:149776f54d846498240437583f5affccc73cb1100f823cd7af21be4f49d79d69",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53436",
+					"10.65.0.27:53436",
+					"172.17.0.1:53436",
+					"172.18.0.1:53436",
+					"172.19.0.1:53436"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:31:14.270543041Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2076690947231121": {
+				"ID":          2076690947231121,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         266103745376067,
+				"StableID":   "nC3UkT6X5311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       266103745376067,
+				"Key":        "nodekey:06e6d591dff74af9a6db6cd8b2941ea81116246e0970ab8289c4c58a21d0c927",
+				"DiscoKey":   "discokey:b526abb089f198874454d2c32ecb222110d24325d7abd49473dd531af0681759",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53681",
+					"10.65.0.27:53681",
+					"172.17.0.1:53681",
+					"172.18.0.1:53681",
+					"172.19.0.1:53681"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:31:09.675579328Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:06e6d591dff74af9a6db6cd8b2941ea81116246e0970ab8289c4c58a21d0c927",
+			"MachineKey": "mkey:8b15b4bb64cf53b485f2e4225a010a97121d62cdac7a9b8424620c8025d65860",
+			"Peers": [{
+				"ID":         3044711647891538,
+				"StableID":   "n5JYCuQxmQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a4be0290f33d7e8e0f3e2baece89023c517d9defc6bd6f39311dd9d6462c037",
+				"DiscoKey":   "discokey:dee554b5039ede1c7443f1fd9b2859ab8778421f8b3a6ea24028e0f557d60f50",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33867",
+					"10.65.0.27:33867",
+					"172.17.0.1:33867",
+					"172.18.0.1:33867",
+					"172.19.0.1:33867"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:31:06.43607452Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3529506869988132,
+				"StableID":   "nKibsJAXZU11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c7a002e132b998aa3d017a2948a74a895734f381bdb9ea1ce3948fb8c6b9d2d",
+				"DiscoKey":   "discokey:4d2f4caf90f93206f3b6be6109c85f3c1deb9c75d6e181e39e481eb01ad9d562",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37144",
+					"10.65.0.27:37144",
+					"172.17.0.1:37144",
+					"172.18.0.1:37144",
+					"172.19.0.1:37144"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:31:06.966175837Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6998571567534440,
+				"StableID":   "ns8ZwEcfew11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7774291507134579406d8d227fb730462bbc50cc352fae506edc546e051d7a16",
+				"DiscoKey":   "discokey:e40752848e48022f29593503aa4ea85f14a6641cd49162cd3ee367a118da9621",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:48331",
+					"10.65.0.27:48331",
+					"172.17.0.1:48331",
+					"172.18.0.1:48331",
+					"172.19.0.1:48331"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:31:07.510957208Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2076690947231121,
+				"StableID":   "n4iLig9YDH11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0242ee2dc2cb07c0b095c21f422419d4522207c775940397d4d7b92d2b5f3f6e",
+				"DiscoKey":   "discokey:630390aa40c642b5f3b9d10816b0e5adbeb445e740a9ad3ec1d7b55e2d6ce72e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35307",
+					"10.65.0.27:35307",
+					"172.17.0.1:35307",
+					"172.18.0.1:35307",
+					"172.19.0.1:35307"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:31:08.048551369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1406494704076150,
+				"StableID":   "n7DhgPE1zB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:598e9d7129c8291e7ce5ddb814287071a343f521d2a6e484a879542108458117",
+				"DiscoKey":   "discokey:539f93805980a2557de45eb87b6ea095b49b93933f01d40d227d54bd089c0d2b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34362",
+					"10.65.0.27:34362",
+					"172.17.0.1:34362",
+					"172.18.0.1:34362",
+					"172.19.0.1:34362"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:31:08.596624551Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5054443933899250,
+				"StableID":   "nT1uJwfAUg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf4dbb7ff8494358ae5d033bccf2e7b8038e8273d0f1d81809f42b06bfe86371",
+				"DiscoKey":   "discokey:fa6604d7668eb04e7e8c222b21209647b47661c0ee14b853258780b3b3e68e10",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39105",
+					"10.65.0.27:39105",
+					"172.17.0.1:39105",
+					"172.18.0.1:39105",
+					"172.19.0.1:39105"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:31:09.136532579Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3266753253037176,
+				"StableID":   "nqjzVy4XWS11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb07ec8887f16f675123eb974676337279a7b35496f317a92f7384421960052d",
+				"DiscoKey":   "discokey:8e344c27a4e8cbd02bbd9c59d9d59b3c17ce917a0206c62ac2bdf70446f4812d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52015",
+					"10.65.0.27:52015",
+					"172.17.0.1:52015",
+					"172.18.0.1:52015",
+					"172.19.0.1:52015"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:31:10.21575352Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1618753548139836,
+				"StableID":   "nTGWtpu8eD11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:67bcdb151f767a1862e2ccf44cba68a49951908c9fec0212179280fa99cabd17",
+				"DiscoKey":   "discokey:4a7ad1484a565ad3adebf6dcf5d5362554954c147537ec92557882cd50728812",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48778",
+					"10.65.0.27:48778",
+					"172.17.0.1:48778",
+					"172.18.0.1:48778",
+					"172.19.0.1:48778"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:31:10.752039827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4821237427074581,
+				"StableID":   "npixsSjYee11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:12c11a5c815152484a9e2f89394b4ff3368353709eae3a5b7b057fea3304140f",
+				"DiscoKey":   "discokey:69df57647f23ab5fcbd9d60d0e150c521b3ac9b033ea45c808e3a5ebcf7da018",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35640",
+					"10.65.0.27:35640",
+					"172.17.0.1:35640",
+					"172.18.0.1:35640",
+					"172.19.0.1:35640"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:31:11.299118205Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5448112130204058,
+				"StableID":   "nwREmhfTYj11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4536ffa89c32490c120df5330e63d86aa0e5300453bbb613ccae7fd7a879e20",
+				"DiscoKey":   "discokey:c6f4572c0152bedb9d47497d3c5d522daa453fda04f24f55ba17cf782c6d6f67",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58664",
+					"10.65.0.27:58664",
+					"172.17.0.1:58664",
+					"172.18.0.1:58664",
+					"172.19.0.1:58664"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:31:12.127192218Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         673038927903314,
+				"StableID":   "nsX2MJbpF611CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a3c2556197e74a78e99f1d4c5b2a2ae6b6708ef15cd9ff0459d46a815c8add07",
+				"DiscoKey":   "discokey:96e5105a3179d353dcd05b06a685bb130a6838bbafda62b379d93d483daa937f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54954",
+					"10.65.0.27:54954",
+					"172.17.0.1:54954",
+					"172.18.0.1:54954",
+					"172.19.0.1:54954"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:31:12.670634654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7813074903309875,
+				"StableID":   "nJ65bHEZ1421CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:dd832802f5c4222e3a946eab4990e99742b6c443c0656d3bac06bb07f3712e4c",
+				"KeyExpiry":  "2026-11-09T07:31:13Z",
+				"DiscoKey":   "discokey:1c48c757538e4730fe9caef6ba950ac110c36d74bf212a8baf4d5af56d562303",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49516",
+					"10.65.0.27:49516",
+					"172.17.0.1:49516",
+					"172.18.0.1:49516",
+					"172.19.0.1:49516"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:31:13.205031795Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2792466842877790,
+				"StableID":   "n5kzYPNioN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8030adaaae7f90780f99c642cdb01ffd96f7c3d97d89f78357927194b0f1eb2b",
+				"KeyExpiry":  "2026-11-09T07:31:13Z",
+				"DiscoKey":   "discokey:cc6386e27a4af148d99ea578d28d33d9cb6266a103a35980e9681f02dba6cb51",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57287",
+					"10.65.0.27:57287",
+					"172.17.0.1:57287",
+					"172.18.0.1:57287",
+					"172.19.0.1:57287"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:31:13.74351519Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5746981103666968,
+				"StableID":   "nMH6X1Tpsm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7dcbf5008ae4e442aa04037836f470f9df41f05521f05bbe883ebad4a7974f55",
+				"KeyExpiry":  "2026-11-09T07:31:14Z",
+				"DiscoKey":   "discokey:149776f54d846498240437583f5affccc73cb1100f823cd7af21be4f49d79d69",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53436",
+					"10.65.0.27:53436",
+					"172.17.0.1:53436",
+					"172.18.0.1:53436",
+					"172.19.0.1:53436"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:31:14.270543041Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "266103745376067": {
+				"ID":          266103745376067,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1618753548139836,
+				"StableID":   "nTGWtpu8eD11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1618753548139836,
+				"Key":        "nodekey:67bcdb151f767a1862e2ccf44cba68a49951908c9fec0212179280fa99cabd17",
+				"DiscoKey":   "discokey:4a7ad1484a565ad3adebf6dcf5d5362554954c147537ec92557882cd50728812",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48778",
+					"10.65.0.27:48778",
+					"172.17.0.1:48778",
+					"172.18.0.1:48778",
+					"172.19.0.1:48778"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:31:10.752039827Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:67bcdb151f767a1862e2ccf44cba68a49951908c9fec0212179280fa99cabd17",
+			"MachineKey": "mkey:76428777e6a4b7c6a2d3822a5c75cabeed57b43f25b2cdee1acfe79ba22d8c42",
+			"Peers": [{
+				"ID":         3044711647891538,
+				"StableID":   "n5JYCuQxmQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a4be0290f33d7e8e0f3e2baece89023c517d9defc6bd6f39311dd9d6462c037",
+				"DiscoKey":   "discokey:dee554b5039ede1c7443f1fd9b2859ab8778421f8b3a6ea24028e0f557d60f50",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33867",
+					"10.65.0.27:33867",
+					"172.17.0.1:33867",
+					"172.18.0.1:33867",
+					"172.19.0.1:33867"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:31:06.43607452Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3529506869988132,
+				"StableID":   "nKibsJAXZU11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c7a002e132b998aa3d017a2948a74a895734f381bdb9ea1ce3948fb8c6b9d2d",
+				"DiscoKey":   "discokey:4d2f4caf90f93206f3b6be6109c85f3c1deb9c75d6e181e39e481eb01ad9d562",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37144",
+					"10.65.0.27:37144",
+					"172.17.0.1:37144",
+					"172.18.0.1:37144",
+					"172.19.0.1:37144"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:31:06.966175837Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6998571567534440,
+				"StableID":   "ns8ZwEcfew11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7774291507134579406d8d227fb730462bbc50cc352fae506edc546e051d7a16",
+				"DiscoKey":   "discokey:e40752848e48022f29593503aa4ea85f14a6641cd49162cd3ee367a118da9621",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:48331",
+					"10.65.0.27:48331",
+					"172.17.0.1:48331",
+					"172.18.0.1:48331",
+					"172.19.0.1:48331"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:31:07.510957208Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2076690947231121,
+				"StableID":   "n4iLig9YDH11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0242ee2dc2cb07c0b095c21f422419d4522207c775940397d4d7b92d2b5f3f6e",
+				"DiscoKey":   "discokey:630390aa40c642b5f3b9d10816b0e5adbeb445e740a9ad3ec1d7b55e2d6ce72e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35307",
+					"10.65.0.27:35307",
+					"172.17.0.1:35307",
+					"172.18.0.1:35307",
+					"172.19.0.1:35307"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:31:08.048551369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1406494704076150,
+				"StableID":   "n7DhgPE1zB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:598e9d7129c8291e7ce5ddb814287071a343f521d2a6e484a879542108458117",
+				"DiscoKey":   "discokey:539f93805980a2557de45eb87b6ea095b49b93933f01d40d227d54bd089c0d2b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34362",
+					"10.65.0.27:34362",
+					"172.17.0.1:34362",
+					"172.18.0.1:34362",
+					"172.19.0.1:34362"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:31:08.596624551Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5054443933899250,
+				"StableID":   "nT1uJwfAUg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf4dbb7ff8494358ae5d033bccf2e7b8038e8273d0f1d81809f42b06bfe86371",
+				"DiscoKey":   "discokey:fa6604d7668eb04e7e8c222b21209647b47661c0ee14b853258780b3b3e68e10",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39105",
+					"10.65.0.27:39105",
+					"172.17.0.1:39105",
+					"172.18.0.1:39105",
+					"172.19.0.1:39105"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:31:09.136532579Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         266103745376067,
+				"StableID":   "nC3UkT6X5311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06e6d591dff74af9a6db6cd8b2941ea81116246e0970ab8289c4c58a21d0c927",
+				"DiscoKey":   "discokey:b526abb089f198874454d2c32ecb222110d24325d7abd49473dd531af0681759",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53681",
+					"10.65.0.27:53681",
+					"172.17.0.1:53681",
+					"172.18.0.1:53681",
+					"172.19.0.1:53681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:31:09.675579328Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3266753253037176,
+				"StableID":   "nqjzVy4XWS11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb07ec8887f16f675123eb974676337279a7b35496f317a92f7384421960052d",
+				"DiscoKey":   "discokey:8e344c27a4e8cbd02bbd9c59d9d59b3c17ce917a0206c62ac2bdf70446f4812d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52015",
+					"10.65.0.27:52015",
+					"172.17.0.1:52015",
+					"172.18.0.1:52015",
+					"172.19.0.1:52015"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:31:10.21575352Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4821237427074581,
+				"StableID":   "npixsSjYee11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:12c11a5c815152484a9e2f89394b4ff3368353709eae3a5b7b057fea3304140f",
+				"DiscoKey":   "discokey:69df57647f23ab5fcbd9d60d0e150c521b3ac9b033ea45c808e3a5ebcf7da018",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35640",
+					"10.65.0.27:35640",
+					"172.17.0.1:35640",
+					"172.18.0.1:35640",
+					"172.19.0.1:35640"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:31:11.299118205Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5448112130204058,
+				"StableID":   "nwREmhfTYj11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4536ffa89c32490c120df5330e63d86aa0e5300453bbb613ccae7fd7a879e20",
+				"DiscoKey":   "discokey:c6f4572c0152bedb9d47497d3c5d522daa453fda04f24f55ba17cf782c6d6f67",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58664",
+					"10.65.0.27:58664",
+					"172.17.0.1:58664",
+					"172.18.0.1:58664",
+					"172.19.0.1:58664"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:31:12.127192218Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         673038927903314,
+				"StableID":   "nsX2MJbpF611CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a3c2556197e74a78e99f1d4c5b2a2ae6b6708ef15cd9ff0459d46a815c8add07",
+				"DiscoKey":   "discokey:96e5105a3179d353dcd05b06a685bb130a6838bbafda62b379d93d483daa937f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54954",
+					"10.65.0.27:54954",
+					"172.17.0.1:54954",
+					"172.18.0.1:54954",
+					"172.19.0.1:54954"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:31:12.670634654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7813074903309875,
+				"StableID":   "nJ65bHEZ1421CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:dd832802f5c4222e3a946eab4990e99742b6c443c0656d3bac06bb07f3712e4c",
+				"KeyExpiry":  "2026-11-09T07:31:13Z",
+				"DiscoKey":   "discokey:1c48c757538e4730fe9caef6ba950ac110c36d74bf212a8baf4d5af56d562303",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49516",
+					"10.65.0.27:49516",
+					"172.17.0.1:49516",
+					"172.18.0.1:49516",
+					"172.19.0.1:49516"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:31:13.205031795Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2792466842877790,
+				"StableID":   "n5kzYPNioN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8030adaaae7f90780f99c642cdb01ffd96f7c3d97d89f78357927194b0f1eb2b",
+				"KeyExpiry":  "2026-11-09T07:31:13Z",
+				"DiscoKey":   "discokey:cc6386e27a4af148d99ea578d28d33d9cb6266a103a35980e9681f02dba6cb51",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57287",
+					"10.65.0.27:57287",
+					"172.17.0.1:57287",
+					"172.18.0.1:57287",
+					"172.19.0.1:57287"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:31:13.74351519Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5746981103666968,
+				"StableID":   "nMH6X1Tpsm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7dcbf5008ae4e442aa04037836f470f9df41f05521f05bbe883ebad4a7974f55",
+				"KeyExpiry":  "2026-11-09T07:31:14Z",
+				"DiscoKey":   "discokey:149776f54d846498240437583f5affccc73cb1100f823cd7af21be4f49d79d69",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53436",
+					"10.65.0.27:53436",
+					"172.17.0.1:53436",
+					"172.18.0.1:53436",
+					"172.19.0.1:53436"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:31:14.270543041Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1618753548139836": {
+				"ID":          1618753548139836,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2792466842877790,
+				"StableID":   "n5kzYPNioN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8030adaaae7f90780f99c642cdb01ffd96f7c3d97d89f78357927194b0f1eb2b",
+				"KeyExpiry":  "2026-11-09T07:31:13Z",
+				"DiscoKey":   "discokey:cc6386e27a4af148d99ea578d28d33d9cb6266a103a35980e9681f02dba6cb51",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57287",
+					"10.65.0.27:57287",
+					"172.17.0.1:57287",
+					"172.18.0.1:57287",
+					"172.19.0.1:57287"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:31:13.74351519Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8030adaaae7f90780f99c642cdb01ffd96f7c3d97d89f78357927194b0f1eb2b",
+			"MachineKey": "mkey:fd4285cdace97c2f17fcd78b3d353ed4d6509bc67f3c02855686600e0633626f",
+			"Peers": [{
+				"ID":         3044711647891538,
+				"StableID":   "n5JYCuQxmQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a4be0290f33d7e8e0f3e2baece89023c517d9defc6bd6f39311dd9d6462c037",
+				"DiscoKey":   "discokey:dee554b5039ede1c7443f1fd9b2859ab8778421f8b3a6ea24028e0f557d60f50",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33867",
+					"10.65.0.27:33867",
+					"172.17.0.1:33867",
+					"172.18.0.1:33867",
+					"172.19.0.1:33867"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:31:06.43607452Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3529506869988132,
+				"StableID":   "nKibsJAXZU11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c7a002e132b998aa3d017a2948a74a895734f381bdb9ea1ce3948fb8c6b9d2d",
+				"DiscoKey":   "discokey:4d2f4caf90f93206f3b6be6109c85f3c1deb9c75d6e181e39e481eb01ad9d562",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37144",
+					"10.65.0.27:37144",
+					"172.17.0.1:37144",
+					"172.18.0.1:37144",
+					"172.19.0.1:37144"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:31:06.966175837Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6998571567534440,
+				"StableID":   "ns8ZwEcfew11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7774291507134579406d8d227fb730462bbc50cc352fae506edc546e051d7a16",
+				"DiscoKey":   "discokey:e40752848e48022f29593503aa4ea85f14a6641cd49162cd3ee367a118da9621",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:48331",
+					"10.65.0.27:48331",
+					"172.17.0.1:48331",
+					"172.18.0.1:48331",
+					"172.19.0.1:48331"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:31:07.510957208Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2076690947231121,
+				"StableID":   "n4iLig9YDH11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0242ee2dc2cb07c0b095c21f422419d4522207c775940397d4d7b92d2b5f3f6e",
+				"DiscoKey":   "discokey:630390aa40c642b5f3b9d10816b0e5adbeb445e740a9ad3ec1d7b55e2d6ce72e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35307",
+					"10.65.0.27:35307",
+					"172.17.0.1:35307",
+					"172.18.0.1:35307",
+					"172.19.0.1:35307"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:31:08.048551369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1406494704076150,
+				"StableID":   "n7DhgPE1zB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:598e9d7129c8291e7ce5ddb814287071a343f521d2a6e484a879542108458117",
+				"DiscoKey":   "discokey:539f93805980a2557de45eb87b6ea095b49b93933f01d40d227d54bd089c0d2b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34362",
+					"10.65.0.27:34362",
+					"172.17.0.1:34362",
+					"172.18.0.1:34362",
+					"172.19.0.1:34362"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:31:08.596624551Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5054443933899250,
+				"StableID":   "nT1uJwfAUg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf4dbb7ff8494358ae5d033bccf2e7b8038e8273d0f1d81809f42b06bfe86371",
+				"DiscoKey":   "discokey:fa6604d7668eb04e7e8c222b21209647b47661c0ee14b853258780b3b3e68e10",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39105",
+					"10.65.0.27:39105",
+					"172.17.0.1:39105",
+					"172.18.0.1:39105",
+					"172.19.0.1:39105"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:31:09.136532579Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         266103745376067,
+				"StableID":   "nC3UkT6X5311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06e6d591dff74af9a6db6cd8b2941ea81116246e0970ab8289c4c58a21d0c927",
+				"DiscoKey":   "discokey:b526abb089f198874454d2c32ecb222110d24325d7abd49473dd531af0681759",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53681",
+					"10.65.0.27:53681",
+					"172.17.0.1:53681",
+					"172.18.0.1:53681",
+					"172.19.0.1:53681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:31:09.675579328Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3266753253037176,
+				"StableID":   "nqjzVy4XWS11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb07ec8887f16f675123eb974676337279a7b35496f317a92f7384421960052d",
+				"DiscoKey":   "discokey:8e344c27a4e8cbd02bbd9c59d9d59b3c17ce917a0206c62ac2bdf70446f4812d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52015",
+					"10.65.0.27:52015",
+					"172.17.0.1:52015",
+					"172.18.0.1:52015",
+					"172.19.0.1:52015"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:31:10.21575352Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1618753548139836,
+				"StableID":   "nTGWtpu8eD11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:67bcdb151f767a1862e2ccf44cba68a49951908c9fec0212179280fa99cabd17",
+				"DiscoKey":   "discokey:4a7ad1484a565ad3adebf6dcf5d5362554954c147537ec92557882cd50728812",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48778",
+					"10.65.0.27:48778",
+					"172.17.0.1:48778",
+					"172.18.0.1:48778",
+					"172.19.0.1:48778"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:31:10.752039827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4821237427074581,
+				"StableID":   "npixsSjYee11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:12c11a5c815152484a9e2f89394b4ff3368353709eae3a5b7b057fea3304140f",
+				"DiscoKey":   "discokey:69df57647f23ab5fcbd9d60d0e150c521b3ac9b033ea45c808e3a5ebcf7da018",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35640",
+					"10.65.0.27:35640",
+					"172.17.0.1:35640",
+					"172.18.0.1:35640",
+					"172.19.0.1:35640"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:31:11.299118205Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5448112130204058,
+				"StableID":   "nwREmhfTYj11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4536ffa89c32490c120df5330e63d86aa0e5300453bbb613ccae7fd7a879e20",
+				"DiscoKey":   "discokey:c6f4572c0152bedb9d47497d3c5d522daa453fda04f24f55ba17cf782c6d6f67",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58664",
+					"10.65.0.27:58664",
+					"172.17.0.1:58664",
+					"172.18.0.1:58664",
+					"172.19.0.1:58664"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:31:12.127192218Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         673038927903314,
+				"StableID":   "nsX2MJbpF611CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a3c2556197e74a78e99f1d4c5b2a2ae6b6708ef15cd9ff0459d46a815c8add07",
+				"DiscoKey":   "discokey:96e5105a3179d353dcd05b06a685bb130a6838bbafda62b379d93d483daa937f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54954",
+					"10.65.0.27:54954",
+					"172.17.0.1:54954",
+					"172.18.0.1:54954",
+					"172.19.0.1:54954"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:31:12.670634654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7813074903309875,
+				"StableID":   "nJ65bHEZ1421CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:dd832802f5c4222e3a946eab4990e99742b6c443c0656d3bac06bb07f3712e4c",
+				"KeyExpiry":  "2026-11-09T07:31:13Z",
+				"DiscoKey":   "discokey:1c48c757538e4730fe9caef6ba950ac110c36d74bf212a8baf4d5af56d562303",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49516",
+					"10.65.0.27:49516",
+					"172.17.0.1:49516",
+					"172.18.0.1:49516",
+					"172.19.0.1:49516"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:31:13.205031795Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5746981103666968,
+				"StableID":   "nMH6X1Tpsm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7dcbf5008ae4e442aa04037836f470f9df41f05521f05bbe883ebad4a7974f55",
+				"KeyExpiry":  "2026-11-09T07:31:14Z",
+				"DiscoKey":   "discokey:149776f54d846498240437583f5affccc73cb1100f823cd7af21be4f49d79d69",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53436",
+					"10.65.0.27:53436",
+					"172.17.0.1:53436",
+					"172.18.0.1:53436",
+					"172.19.0.1:53436"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:31:14.270543041Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4821237427074581,
+				"StableID":   "npixsSjYee11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       4821237427074581,
+				"Key":        "nodekey:12c11a5c815152484a9e2f89394b4ff3368353709eae3a5b7b057fea3304140f",
+				"DiscoKey":   "discokey:69df57647f23ab5fcbd9d60d0e150c521b3ac9b033ea45c808e3a5ebcf7da018",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35640",
+					"10.65.0.27:35640",
+					"172.17.0.1:35640",
+					"172.18.0.1:35640",
+					"172.19.0.1:35640"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:31:11.299118205Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:12c11a5c815152484a9e2f89394b4ff3368353709eae3a5b7b057fea3304140f",
+			"MachineKey": "mkey:703f2225365ce1801d9afe44e2080595d1cfa664c13f7f63fb8726ebb3a6f974",
+			"Peers": [{
+				"ID":         3044711647891538,
+				"StableID":   "n5JYCuQxmQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a4be0290f33d7e8e0f3e2baece89023c517d9defc6bd6f39311dd9d6462c037",
+				"DiscoKey":   "discokey:dee554b5039ede1c7443f1fd9b2859ab8778421f8b3a6ea24028e0f557d60f50",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33867",
+					"10.65.0.27:33867",
+					"172.17.0.1:33867",
+					"172.18.0.1:33867",
+					"172.19.0.1:33867"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:31:06.43607452Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3529506869988132,
+				"StableID":   "nKibsJAXZU11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c7a002e132b998aa3d017a2948a74a895734f381bdb9ea1ce3948fb8c6b9d2d",
+				"DiscoKey":   "discokey:4d2f4caf90f93206f3b6be6109c85f3c1deb9c75d6e181e39e481eb01ad9d562",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37144",
+					"10.65.0.27:37144",
+					"172.17.0.1:37144",
+					"172.18.0.1:37144",
+					"172.19.0.1:37144"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:31:06.966175837Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6998571567534440,
+				"StableID":   "ns8ZwEcfew11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7774291507134579406d8d227fb730462bbc50cc352fae506edc546e051d7a16",
+				"DiscoKey":   "discokey:e40752848e48022f29593503aa4ea85f14a6641cd49162cd3ee367a118da9621",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:48331",
+					"10.65.0.27:48331",
+					"172.17.0.1:48331",
+					"172.18.0.1:48331",
+					"172.19.0.1:48331"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:31:07.510957208Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2076690947231121,
+				"StableID":   "n4iLig9YDH11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0242ee2dc2cb07c0b095c21f422419d4522207c775940397d4d7b92d2b5f3f6e",
+				"DiscoKey":   "discokey:630390aa40c642b5f3b9d10816b0e5adbeb445e740a9ad3ec1d7b55e2d6ce72e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35307",
+					"10.65.0.27:35307",
+					"172.17.0.1:35307",
+					"172.18.0.1:35307",
+					"172.19.0.1:35307"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:31:08.048551369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1406494704076150,
+				"StableID":   "n7DhgPE1zB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:598e9d7129c8291e7ce5ddb814287071a343f521d2a6e484a879542108458117",
+				"DiscoKey":   "discokey:539f93805980a2557de45eb87b6ea095b49b93933f01d40d227d54bd089c0d2b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34362",
+					"10.65.0.27:34362",
+					"172.17.0.1:34362",
+					"172.18.0.1:34362",
+					"172.19.0.1:34362"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:31:08.596624551Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5054443933899250,
+				"StableID":   "nT1uJwfAUg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf4dbb7ff8494358ae5d033bccf2e7b8038e8273d0f1d81809f42b06bfe86371",
+				"DiscoKey":   "discokey:fa6604d7668eb04e7e8c222b21209647b47661c0ee14b853258780b3b3e68e10",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39105",
+					"10.65.0.27:39105",
+					"172.17.0.1:39105",
+					"172.18.0.1:39105",
+					"172.19.0.1:39105"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:31:09.136532579Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         266103745376067,
+				"StableID":   "nC3UkT6X5311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06e6d591dff74af9a6db6cd8b2941ea81116246e0970ab8289c4c58a21d0c927",
+				"DiscoKey":   "discokey:b526abb089f198874454d2c32ecb222110d24325d7abd49473dd531af0681759",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:53681",
+					"10.65.0.27:53681",
+					"172.17.0.1:53681",
+					"172.18.0.1:53681",
+					"172.19.0.1:53681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:31:09.675579328Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3266753253037176,
+				"StableID":   "nqjzVy4XWS11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb07ec8887f16f675123eb974676337279a7b35496f317a92f7384421960052d",
+				"DiscoKey":   "discokey:8e344c27a4e8cbd02bbd9c59d9d59b3c17ce917a0206c62ac2bdf70446f4812d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52015",
+					"10.65.0.27:52015",
+					"172.17.0.1:52015",
+					"172.18.0.1:52015",
+					"172.19.0.1:52015"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:31:10.21575352Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1618753548139836,
+				"StableID":   "nTGWtpu8eD11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:67bcdb151f767a1862e2ccf44cba68a49951908c9fec0212179280fa99cabd17",
+				"DiscoKey":   "discokey:4a7ad1484a565ad3adebf6dcf5d5362554954c147537ec92557882cd50728812",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48778",
+					"10.65.0.27:48778",
+					"172.17.0.1:48778",
+					"172.18.0.1:48778",
+					"172.19.0.1:48778"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:31:10.752039827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5448112130204058,
+				"StableID":   "nwREmhfTYj11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4536ffa89c32490c120df5330e63d86aa0e5300453bbb613ccae7fd7a879e20",
+				"DiscoKey":   "discokey:c6f4572c0152bedb9d47497d3c5d522daa453fda04f24f55ba17cf782c6d6f67",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58664",
+					"10.65.0.27:58664",
+					"172.17.0.1:58664",
+					"172.18.0.1:58664",
+					"172.19.0.1:58664"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:31:12.127192218Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         673038927903314,
+				"StableID":   "nsX2MJbpF611CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a3c2556197e74a78e99f1d4c5b2a2ae6b6708ef15cd9ff0459d46a815c8add07",
+				"DiscoKey":   "discokey:96e5105a3179d353dcd05b06a685bb130a6838bbafda62b379d93d483daa937f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54954",
+					"10.65.0.27:54954",
+					"172.17.0.1:54954",
+					"172.18.0.1:54954",
+					"172.19.0.1:54954"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:31:12.670634654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7813074903309875,
+				"StableID":   "nJ65bHEZ1421CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:dd832802f5c4222e3a946eab4990e99742b6c443c0656d3bac06bb07f3712e4c",
+				"KeyExpiry":  "2026-11-09T07:31:13Z",
+				"DiscoKey":   "discokey:1c48c757538e4730fe9caef6ba950ac110c36d74bf212a8baf4d5af56d562303",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49516",
+					"10.65.0.27:49516",
+					"172.17.0.1:49516",
+					"172.18.0.1:49516",
+					"172.19.0.1:49516"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:31:13.205031795Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2792466842877790,
+				"StableID":   "n5kzYPNioN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8030adaaae7f90780f99c642cdb01ffd96f7c3d97d89f78357927194b0f1eb2b",
+				"KeyExpiry":  "2026-11-09T07:31:13Z",
+				"DiscoKey":   "discokey:cc6386e27a4af148d99ea578d28d33d9cb6266a103a35980e9681f02dba6cb51",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57287",
+					"10.65.0.27:57287",
+					"172.17.0.1:57287",
+					"172.18.0.1:57287",
+					"172.19.0.1:57287"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:31:13.74351519Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5746981103666968,
+				"StableID":   "nMH6X1Tpsm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7dcbf5008ae4e442aa04037836f470f9df41f05521f05bbe883ebad4a7974f55",
+				"KeyExpiry":  "2026-11-09T07:31:14Z",
+				"DiscoKey":   "discokey:149776f54d846498240437583f5affccc73cb1100f823cd7af21be4f49d79d69",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53436",
+					"10.65.0.27:53436",
+					"172.17.0.1:53436",
+					"172.18.0.1:53436",
+					"172.19.0.1:53436"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:31:14.270543041Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4821237427074581": {
+				"ID":          4821237427074581,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-user-wildcard.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-user-wildcard.hujson
@@ -1,0 +1,20081 @@
+// ssh-malformed-user-wildcard
+//
+// ssh users wildcard is rejected
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T22:11:57Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-malformed-user-wildcard",
+	"description":    "ssh users wildcard is rejected",
+	"category":       "ssh",
+	"captured_at":    "2026-05-12T22:11:57.069118275Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "user \"*\" is not valid"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                              \n  \n                                                                      \n                                         \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh users wildcard is rejected\",\n\t\"id\":          \"ssh-malformed-user-wildcard\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"autogroup:member\"],\n\t\t\"users\":  [\"*\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-malformed/ssh-malformed-user-wildcard.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["autogroup:member"],
+				"users":  ["*"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6580629105238557,
+				"StableID":   "n4J1j8yNPt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       6580629105238557,
+				"Key":        "nodekey:1e87f267764b8539a4b544082dd6a18cdc952d6b613da9ba89b6cf4afb730a32",
+				"DiscoKey":   "discokey:a491567ef7002d5ed47f0c086fdbe659f8b067de1b5e96d8be4c9e003453d854",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39438",
+					"10.65.0.27:39438",
+					"172.17.0.1:39438",
+					"172.18.0.1:39438",
+					"172.19.0.1:39438"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:12:05.589386892Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1e87f267764b8539a4b544082dd6a18cdc952d6b613da9ba89b6cf4afb730a32",
+			"MachineKey": "mkey:1639344de2d8122695de2bbedccf2ac4faca747ed944d79d8a03ff8ebbbc9a4c",
+			"Peers": [{
+				"ID":         4482450356427873,
+				"StableID":   "nLkuZTN71c11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89ccaa47993ae02031e6b7e51d611d37e7bc1ac28351159d29e1e3334131cb77",
+				"DiscoKey":   "discokey:93dbf266c2a3d7d0993d8f6f5237208d1ba798c5b9bb669d0d7e485ccb85b30d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38682",
+					"10.65.0.27:38682",
+					"172.17.0.1:38682",
+					"172.18.0.1:38682",
+					"172.19.0.1:38682"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:11:59.640186881Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7068620101739055,
+				"StableID":   "nJtD3WfPCx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8a9be2fbaa5a1367c3290722c854f464346a7b7ea428f3bda0816499ebcd457",
+				"DiscoKey":   "discokey:d0339ea43781d13d0035d1435f9e8f2f17e0cf94481123d26ad0b30ea8c51b52",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39522",
+					"10.65.0.27:39522",
+					"172.17.0.1:39522",
+					"172.18.0.1:39522",
+					"172.19.0.1:39522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:12:00.15565341Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7031458668959897,
+				"StableID":   "nxWfUmVZuw11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b93cc735925eb2d5688ca13f0a4ae2b8ae04c35ab8e47aff4b55e8aebbe9ab22",
+				"DiscoKey":   "discokey:35093e8225f1040f91e4b438e178524f88553dadee8e7dacec4391c23ffc330f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:42311",
+					"10.65.0.27:42311",
+					"172.17.0.1:42311",
+					"172.18.0.1:42311",
+					"172.19.0.1:42311"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:12:00.70480488Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5198733611861902,
+				"StableID":   "n3R64AvWbh11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7202047580a18f66aa5f1fc49a868ea201bc7cd5dfc7b1b2b708dc1f4e802628",
+				"DiscoKey":   "discokey:9487c2395655e06d815632014f333bc68493a0fb9d69fc3f6be8788d7aafad5b",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34269",
+					"10.65.0.27:34269",
+					"172.17.0.1:34269",
+					"172.18.0.1:34269",
+					"172.19.0.1:34269"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:12:01.245172899Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2301363068827519,
+				"StableID":   "nU9CkWuHyJ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:78ed73b6b212e652b59f77c76c59166e508dc5a521fb99a0fc289f55b704b934",
+				"DiscoKey":   "discokey:1081c2e2239a9fa429e917dafa325dcd40073889a03f15fbf7a32722f682e06e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52820",
+					"10.65.0.27:52820",
+					"172.17.0.1:52820",
+					"172.18.0.1:52820",
+					"172.19.0.1:52820"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:12:01.789263606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3797042110872127,
+				"StableID":   "nkhiyjrgeW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:69849e8eab09ca566404106dde8a9cf154c370312a2cf8550c9557b338ee4e24",
+				"DiscoKey":   "discokey:ae68fde56e33eda5ea505196426d5e3d463ed294f8f39b6438ee0110e9444a5d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:59018",
+					"10.65.0.27:59018",
+					"172.17.0.1:59018",
+					"172.18.0.1:59018",
+					"172.19.0.1:59018"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:12:02.3243937Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5778490359501510,
+				"StableID":   "nPuPZJ968n11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b349d0ec6a01cb78dbc6e8334ab586fbde7bca3b9d6f3b698afb6c64ba741924",
+				"DiscoKey":   "discokey:d9f9026b8fcdce67bf746af048e7baea0f5de189bdb8af5fb35b1edaf98c6c41",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44441",
+					"10.65.0.27:44441",
+					"172.17.0.1:44441",
+					"172.18.0.1:44441",
+					"172.19.0.1:44441"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:12:02.856468022Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5728238856256014,
+				"StableID":   "nm67J38Ljm11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e0578f990ee630e03a83c235e647dd78731e28398e3599304c58f2f1a182142",
+				"DiscoKey":   "discokey:7833a5b00b623f8a3cf6ddaa9c03f1918556a71ccb602f35cef88ca7dd449b00",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38784",
+					"10.65.0.27:38784",
+					"172.17.0.1:38784",
+					"172.18.0.1:38784",
+					"172.19.0.1:38784"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:12:03.424194865Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4298882061670553,
+				"StableID":   "nCkfxqLyZa11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4cf45e85b38be0ef0134d9981158f71ec19fb8ca68a0712a32b338be3f96610c",
+				"DiscoKey":   "discokey:fdf89004ed5c514952553f76308347b756ccbe304c7e0dc041e4f5b784919b14",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33613",
+					"10.65.0.27:33613",
+					"172.17.0.1:33613",
+					"172.18.0.1:33613",
+					"172.19.0.1:33613"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:12:03.949250372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2288063618721240,
+				"StableID":   "n7S5tyYGsJ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:70a48e25d5debf34e49c694b24272b5aaf304e72b7e63f812fe40822254af662",
+				"DiscoKey":   "discokey:384afa65601a7d679514d36738598d330338e001c8b3a08a801934109c94491c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56035",
+					"10.65.0.27:56035",
+					"172.17.0.1:56035",
+					"172.18.0.1:56035",
+					"172.19.0.1:56035"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:12:04.516158854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8243980449292963,
+				"StableID":   "nx5v7TPiN721CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea2b7d8d1264b411404ff67f0ad440c74c5c6f45eadac2480a08511facf27b4c",
+				"DiscoKey":   "discokey:6e027ff21f6116184202cae7050c4ca03c7ad25fb9dd44c67a0c14a3fff17b30",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58884",
+					"10.65.0.27:58884",
+					"172.17.0.1:58884",
+					"172.18.0.1:58884",
+					"172.19.0.1:58884"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:12:05.060134199Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5815465531620617,
+				"StableID":   "nCGPuFRqQn11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:dacbccbe653dbe85ef34461de4e5ed6fc031516c8870b39e7a44f616be064e7d",
+				"KeyExpiry":  "2026-11-08T22:12:06Z",
+				"DiscoKey":   "discokey:a74800a72b8733af19ca1780330d14a7a1a898318cdb05e85c52ec5ca6d5ec22",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41994",
+					"10.65.0.27:41994",
+					"172.17.0.1:41994",
+					"172.18.0.1:41994",
+					"172.19.0.1:41994"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:12:06.159279306Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6653063879670959,
+				"StableID":   "nNQahyhBxt11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:20de44f0f9114cecba8ada3e3e6ea58120055ddb663d771137eb9778165b7c6d",
+				"KeyExpiry":  "2026-11-08T22:12:06Z",
+				"DiscoKey":   "discokey:61334ba9f1b936c9ba19a4c78fbc9612b5bb3c9578f631911a87eada5f07236f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40651",
+					"10.65.0.27:40651",
+					"172.17.0.1:40651",
+					"172.18.0.1:40651",
+					"172.19.0.1:40651"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:12:06.663606898Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5703680719812368,
+				"StableID":   "nf2dsC2DYm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:feaea4075d470d08e2844ad8ef68934f75ef2668211a97881857c6aac7b2f048",
+				"KeyExpiry":  "2026-11-08T22:12:07Z",
+				"DiscoKey":   "discokey:13842efc4412bf0e75e0194bfa21d15ffb91fb50d778bba72fe32c4795792801",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39244",
+					"10.65.0.27:39244",
+					"172.17.0.1:39244",
+					"172.18.0.1:39244",
+					"172.19.0.1:39244"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:12:07.214874702Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6580629105238557": {
+				"ID":          6580629105238557,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3797042110872127,
+				"StableID":   "nkhiyjrgeW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       3797042110872127,
+				"Key":        "nodekey:69849e8eab09ca566404106dde8a9cf154c370312a2cf8550c9557b338ee4e24",
+				"DiscoKey":   "discokey:ae68fde56e33eda5ea505196426d5e3d463ed294f8f39b6438ee0110e9444a5d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:59018",
+					"10.65.0.27:59018",
+					"172.17.0.1:59018",
+					"172.18.0.1:59018",
+					"172.19.0.1:59018"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:12:02.3243937Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:69849e8eab09ca566404106dde8a9cf154c370312a2cf8550c9557b338ee4e24",
+			"MachineKey": "mkey:0ec62af4829ce6037fa87db5406c45714c397c552c2035950947ae19e777260d",
+			"Peers": [{
+				"ID":         4482450356427873,
+				"StableID":   "nLkuZTN71c11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89ccaa47993ae02031e6b7e51d611d37e7bc1ac28351159d29e1e3334131cb77",
+				"DiscoKey":   "discokey:93dbf266c2a3d7d0993d8f6f5237208d1ba798c5b9bb669d0d7e485ccb85b30d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38682",
+					"10.65.0.27:38682",
+					"172.17.0.1:38682",
+					"172.18.0.1:38682",
+					"172.19.0.1:38682"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:11:59.640186881Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7068620101739055,
+				"StableID":   "nJtD3WfPCx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8a9be2fbaa5a1367c3290722c854f464346a7b7ea428f3bda0816499ebcd457",
+				"DiscoKey":   "discokey:d0339ea43781d13d0035d1435f9e8f2f17e0cf94481123d26ad0b30ea8c51b52",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39522",
+					"10.65.0.27:39522",
+					"172.17.0.1:39522",
+					"172.18.0.1:39522",
+					"172.19.0.1:39522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:12:00.15565341Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7031458668959897,
+				"StableID":   "nxWfUmVZuw11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b93cc735925eb2d5688ca13f0a4ae2b8ae04c35ab8e47aff4b55e8aebbe9ab22",
+				"DiscoKey":   "discokey:35093e8225f1040f91e4b438e178524f88553dadee8e7dacec4391c23ffc330f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:42311",
+					"10.65.0.27:42311",
+					"172.17.0.1:42311",
+					"172.18.0.1:42311",
+					"172.19.0.1:42311"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:12:00.70480488Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5198733611861902,
+				"StableID":   "n3R64AvWbh11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7202047580a18f66aa5f1fc49a868ea201bc7cd5dfc7b1b2b708dc1f4e802628",
+				"DiscoKey":   "discokey:9487c2395655e06d815632014f333bc68493a0fb9d69fc3f6be8788d7aafad5b",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34269",
+					"10.65.0.27:34269",
+					"172.17.0.1:34269",
+					"172.18.0.1:34269",
+					"172.19.0.1:34269"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:12:01.245172899Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2301363068827519,
+				"StableID":   "nU9CkWuHyJ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:78ed73b6b212e652b59f77c76c59166e508dc5a521fb99a0fc289f55b704b934",
+				"DiscoKey":   "discokey:1081c2e2239a9fa429e917dafa325dcd40073889a03f15fbf7a32722f682e06e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52820",
+					"10.65.0.27:52820",
+					"172.17.0.1:52820",
+					"172.18.0.1:52820",
+					"172.19.0.1:52820"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:12:01.789263606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5778490359501510,
+				"StableID":   "nPuPZJ968n11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b349d0ec6a01cb78dbc6e8334ab586fbde7bca3b9d6f3b698afb6c64ba741924",
+				"DiscoKey":   "discokey:d9f9026b8fcdce67bf746af048e7baea0f5de189bdb8af5fb35b1edaf98c6c41",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44441",
+					"10.65.0.27:44441",
+					"172.17.0.1:44441",
+					"172.18.0.1:44441",
+					"172.19.0.1:44441"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:12:02.856468022Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5728238856256014,
+				"StableID":   "nm67J38Ljm11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e0578f990ee630e03a83c235e647dd78731e28398e3599304c58f2f1a182142",
+				"DiscoKey":   "discokey:7833a5b00b623f8a3cf6ddaa9c03f1918556a71ccb602f35cef88ca7dd449b00",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38784",
+					"10.65.0.27:38784",
+					"172.17.0.1:38784",
+					"172.18.0.1:38784",
+					"172.19.0.1:38784"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:12:03.424194865Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4298882061670553,
+				"StableID":   "nCkfxqLyZa11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4cf45e85b38be0ef0134d9981158f71ec19fb8ca68a0712a32b338be3f96610c",
+				"DiscoKey":   "discokey:fdf89004ed5c514952553f76308347b756ccbe304c7e0dc041e4f5b784919b14",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33613",
+					"10.65.0.27:33613",
+					"172.17.0.1:33613",
+					"172.18.0.1:33613",
+					"172.19.0.1:33613"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:12:03.949250372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2288063618721240,
+				"StableID":   "n7S5tyYGsJ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:70a48e25d5debf34e49c694b24272b5aaf304e72b7e63f812fe40822254af662",
+				"DiscoKey":   "discokey:384afa65601a7d679514d36738598d330338e001c8b3a08a801934109c94491c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56035",
+					"10.65.0.27:56035",
+					"172.17.0.1:56035",
+					"172.18.0.1:56035",
+					"172.19.0.1:56035"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:12:04.516158854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8243980449292963,
+				"StableID":   "nx5v7TPiN721CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea2b7d8d1264b411404ff67f0ad440c74c5c6f45eadac2480a08511facf27b4c",
+				"DiscoKey":   "discokey:6e027ff21f6116184202cae7050c4ca03c7ad25fb9dd44c67a0c14a3fff17b30",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58884",
+					"10.65.0.27:58884",
+					"172.17.0.1:58884",
+					"172.18.0.1:58884",
+					"172.19.0.1:58884"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:12:05.060134199Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6580629105238557,
+				"StableID":   "n4J1j8yNPt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1e87f267764b8539a4b544082dd6a18cdc952d6b613da9ba89b6cf4afb730a32",
+				"DiscoKey":   "discokey:a491567ef7002d5ed47f0c086fdbe659f8b067de1b5e96d8be4c9e003453d854",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39438",
+					"10.65.0.27:39438",
+					"172.17.0.1:39438",
+					"172.18.0.1:39438",
+					"172.19.0.1:39438"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:12:05.589386892Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5815465531620617,
+				"StableID":   "nCGPuFRqQn11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:dacbccbe653dbe85ef34461de4e5ed6fc031516c8870b39e7a44f616be064e7d",
+				"KeyExpiry":  "2026-11-08T22:12:06Z",
+				"DiscoKey":   "discokey:a74800a72b8733af19ca1780330d14a7a1a898318cdb05e85c52ec5ca6d5ec22",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41994",
+					"10.65.0.27:41994",
+					"172.17.0.1:41994",
+					"172.18.0.1:41994",
+					"172.19.0.1:41994"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:12:06.159279306Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6653063879670959,
+				"StableID":   "nNQahyhBxt11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:20de44f0f9114cecba8ada3e3e6ea58120055ddb663d771137eb9778165b7c6d",
+				"KeyExpiry":  "2026-11-08T22:12:06Z",
+				"DiscoKey":   "discokey:61334ba9f1b936c9ba19a4c78fbc9612b5bb3c9578f631911a87eada5f07236f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40651",
+					"10.65.0.27:40651",
+					"172.17.0.1:40651",
+					"172.18.0.1:40651",
+					"172.19.0.1:40651"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:12:06.663606898Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5703680719812368,
+				"StableID":   "nf2dsC2DYm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:feaea4075d470d08e2844ad8ef68934f75ef2668211a97881857c6aac7b2f048",
+				"KeyExpiry":  "2026-11-08T22:12:07Z",
+				"DiscoKey":   "discokey:13842efc4412bf0e75e0194bfa21d15ffb91fb50d778bba72fe32c4795792801",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39244",
+					"10.65.0.27:39244",
+					"172.17.0.1:39244",
+					"172.18.0.1:39244",
+					"172.19.0.1:39244"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:12:07.214874702Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3797042110872127": {
+				"ID":          3797042110872127,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5703680719812368,
+				"StableID":   "nf2dsC2DYm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:feaea4075d470d08e2844ad8ef68934f75ef2668211a97881857c6aac7b2f048",
+				"KeyExpiry":  "2026-11-08T22:12:07Z",
+				"DiscoKey":   "discokey:13842efc4412bf0e75e0194bfa21d15ffb91fb50d778bba72fe32c4795792801",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39244",
+					"10.65.0.27:39244",
+					"172.17.0.1:39244",
+					"172.18.0.1:39244",
+					"172.19.0.1:39244"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:12:07.214874702Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:feaea4075d470d08e2844ad8ef68934f75ef2668211a97881857c6aac7b2f048",
+			"MachineKey": "mkey:3b2ff0d06482922050490cc20473000518c616c40e1213a5cd46b73c65d8c60e",
+			"Peers": [{
+				"ID":         4482450356427873,
+				"StableID":   "nLkuZTN71c11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89ccaa47993ae02031e6b7e51d611d37e7bc1ac28351159d29e1e3334131cb77",
+				"DiscoKey":   "discokey:93dbf266c2a3d7d0993d8f6f5237208d1ba798c5b9bb669d0d7e485ccb85b30d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38682",
+					"10.65.0.27:38682",
+					"172.17.0.1:38682",
+					"172.18.0.1:38682",
+					"172.19.0.1:38682"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:11:59.640186881Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7068620101739055,
+				"StableID":   "nJtD3WfPCx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8a9be2fbaa5a1367c3290722c854f464346a7b7ea428f3bda0816499ebcd457",
+				"DiscoKey":   "discokey:d0339ea43781d13d0035d1435f9e8f2f17e0cf94481123d26ad0b30ea8c51b52",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39522",
+					"10.65.0.27:39522",
+					"172.17.0.1:39522",
+					"172.18.0.1:39522",
+					"172.19.0.1:39522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:12:00.15565341Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7031458668959897,
+				"StableID":   "nxWfUmVZuw11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b93cc735925eb2d5688ca13f0a4ae2b8ae04c35ab8e47aff4b55e8aebbe9ab22",
+				"DiscoKey":   "discokey:35093e8225f1040f91e4b438e178524f88553dadee8e7dacec4391c23ffc330f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:42311",
+					"10.65.0.27:42311",
+					"172.17.0.1:42311",
+					"172.18.0.1:42311",
+					"172.19.0.1:42311"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:12:00.70480488Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5198733611861902,
+				"StableID":   "n3R64AvWbh11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7202047580a18f66aa5f1fc49a868ea201bc7cd5dfc7b1b2b708dc1f4e802628",
+				"DiscoKey":   "discokey:9487c2395655e06d815632014f333bc68493a0fb9d69fc3f6be8788d7aafad5b",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34269",
+					"10.65.0.27:34269",
+					"172.17.0.1:34269",
+					"172.18.0.1:34269",
+					"172.19.0.1:34269"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:12:01.245172899Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2301363068827519,
+				"StableID":   "nU9CkWuHyJ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:78ed73b6b212e652b59f77c76c59166e508dc5a521fb99a0fc289f55b704b934",
+				"DiscoKey":   "discokey:1081c2e2239a9fa429e917dafa325dcd40073889a03f15fbf7a32722f682e06e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52820",
+					"10.65.0.27:52820",
+					"172.17.0.1:52820",
+					"172.18.0.1:52820",
+					"172.19.0.1:52820"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:12:01.789263606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3797042110872127,
+				"StableID":   "nkhiyjrgeW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:69849e8eab09ca566404106dde8a9cf154c370312a2cf8550c9557b338ee4e24",
+				"DiscoKey":   "discokey:ae68fde56e33eda5ea505196426d5e3d463ed294f8f39b6438ee0110e9444a5d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:59018",
+					"10.65.0.27:59018",
+					"172.17.0.1:59018",
+					"172.18.0.1:59018",
+					"172.19.0.1:59018"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:12:02.3243937Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5778490359501510,
+				"StableID":   "nPuPZJ968n11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b349d0ec6a01cb78dbc6e8334ab586fbde7bca3b9d6f3b698afb6c64ba741924",
+				"DiscoKey":   "discokey:d9f9026b8fcdce67bf746af048e7baea0f5de189bdb8af5fb35b1edaf98c6c41",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44441",
+					"10.65.0.27:44441",
+					"172.17.0.1:44441",
+					"172.18.0.1:44441",
+					"172.19.0.1:44441"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:12:02.856468022Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5728238856256014,
+				"StableID":   "nm67J38Ljm11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e0578f990ee630e03a83c235e647dd78731e28398e3599304c58f2f1a182142",
+				"DiscoKey":   "discokey:7833a5b00b623f8a3cf6ddaa9c03f1918556a71ccb602f35cef88ca7dd449b00",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38784",
+					"10.65.0.27:38784",
+					"172.17.0.1:38784",
+					"172.18.0.1:38784",
+					"172.19.0.1:38784"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:12:03.424194865Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4298882061670553,
+				"StableID":   "nCkfxqLyZa11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4cf45e85b38be0ef0134d9981158f71ec19fb8ca68a0712a32b338be3f96610c",
+				"DiscoKey":   "discokey:fdf89004ed5c514952553f76308347b756ccbe304c7e0dc041e4f5b784919b14",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33613",
+					"10.65.0.27:33613",
+					"172.17.0.1:33613",
+					"172.18.0.1:33613",
+					"172.19.0.1:33613"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:12:03.949250372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2288063618721240,
+				"StableID":   "n7S5tyYGsJ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:70a48e25d5debf34e49c694b24272b5aaf304e72b7e63f812fe40822254af662",
+				"DiscoKey":   "discokey:384afa65601a7d679514d36738598d330338e001c8b3a08a801934109c94491c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56035",
+					"10.65.0.27:56035",
+					"172.17.0.1:56035",
+					"172.18.0.1:56035",
+					"172.19.0.1:56035"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:12:04.516158854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8243980449292963,
+				"StableID":   "nx5v7TPiN721CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea2b7d8d1264b411404ff67f0ad440c74c5c6f45eadac2480a08511facf27b4c",
+				"DiscoKey":   "discokey:6e027ff21f6116184202cae7050c4ca03c7ad25fb9dd44c67a0c14a3fff17b30",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58884",
+					"10.65.0.27:58884",
+					"172.17.0.1:58884",
+					"172.18.0.1:58884",
+					"172.19.0.1:58884"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:12:05.060134199Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6580629105238557,
+				"StableID":   "n4J1j8yNPt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1e87f267764b8539a4b544082dd6a18cdc952d6b613da9ba89b6cf4afb730a32",
+				"DiscoKey":   "discokey:a491567ef7002d5ed47f0c086fdbe659f8b067de1b5e96d8be4c9e003453d854",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39438",
+					"10.65.0.27:39438",
+					"172.17.0.1:39438",
+					"172.18.0.1:39438",
+					"172.19.0.1:39438"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:12:05.589386892Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5815465531620617,
+				"StableID":   "nCGPuFRqQn11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:dacbccbe653dbe85ef34461de4e5ed6fc031516c8870b39e7a44f616be064e7d",
+				"KeyExpiry":  "2026-11-08T22:12:06Z",
+				"DiscoKey":   "discokey:a74800a72b8733af19ca1780330d14a7a1a898318cdb05e85c52ec5ca6d5ec22",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41994",
+					"10.65.0.27:41994",
+					"172.17.0.1:41994",
+					"172.18.0.1:41994",
+					"172.19.0.1:41994"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:12:06.159279306Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6653063879670959,
+				"StableID":   "nNQahyhBxt11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:20de44f0f9114cecba8ada3e3e6ea58120055ddb663d771137eb9778165b7c6d",
+				"KeyExpiry":  "2026-11-08T22:12:06Z",
+				"DiscoKey":   "discokey:61334ba9f1b936c9ba19a4c78fbc9612b5bb3c9578f631911a87eada5f07236f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40651",
+					"10.65.0.27:40651",
+					"172.17.0.1:40651",
+					"172.18.0.1:40651",
+					"172.19.0.1:40651"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:12:06.663606898Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7031458668959897,
+				"StableID":   "nxWfUmVZuw11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       7031458668959897,
+				"Key":        "nodekey:b93cc735925eb2d5688ca13f0a4ae2b8ae04c35ab8e47aff4b55e8aebbe9ab22",
+				"DiscoKey":   "discokey:35093e8225f1040f91e4b438e178524f88553dadee8e7dacec4391c23ffc330f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:42311",
+					"10.65.0.27:42311",
+					"172.17.0.1:42311",
+					"172.18.0.1:42311",
+					"172.19.0.1:42311"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:12:00.70480488Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b93cc735925eb2d5688ca13f0a4ae2b8ae04c35ab8e47aff4b55e8aebbe9ab22",
+			"MachineKey": "mkey:8abdc891a83fb548c9ceaa143de1be0c2b4f07b6e0ebcb1711b2d6470cd1313b",
+			"Peers": [{
+				"ID":         4482450356427873,
+				"StableID":   "nLkuZTN71c11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89ccaa47993ae02031e6b7e51d611d37e7bc1ac28351159d29e1e3334131cb77",
+				"DiscoKey":   "discokey:93dbf266c2a3d7d0993d8f6f5237208d1ba798c5b9bb669d0d7e485ccb85b30d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38682",
+					"10.65.0.27:38682",
+					"172.17.0.1:38682",
+					"172.18.0.1:38682",
+					"172.19.0.1:38682"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:11:59.640186881Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7068620101739055,
+				"StableID":   "nJtD3WfPCx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8a9be2fbaa5a1367c3290722c854f464346a7b7ea428f3bda0816499ebcd457",
+				"DiscoKey":   "discokey:d0339ea43781d13d0035d1435f9e8f2f17e0cf94481123d26ad0b30ea8c51b52",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39522",
+					"10.65.0.27:39522",
+					"172.17.0.1:39522",
+					"172.18.0.1:39522",
+					"172.19.0.1:39522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:12:00.15565341Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5198733611861902,
+				"StableID":   "n3R64AvWbh11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7202047580a18f66aa5f1fc49a868ea201bc7cd5dfc7b1b2b708dc1f4e802628",
+				"DiscoKey":   "discokey:9487c2395655e06d815632014f333bc68493a0fb9d69fc3f6be8788d7aafad5b",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34269",
+					"10.65.0.27:34269",
+					"172.17.0.1:34269",
+					"172.18.0.1:34269",
+					"172.19.0.1:34269"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:12:01.245172899Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2301363068827519,
+				"StableID":   "nU9CkWuHyJ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:78ed73b6b212e652b59f77c76c59166e508dc5a521fb99a0fc289f55b704b934",
+				"DiscoKey":   "discokey:1081c2e2239a9fa429e917dafa325dcd40073889a03f15fbf7a32722f682e06e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52820",
+					"10.65.0.27:52820",
+					"172.17.0.1:52820",
+					"172.18.0.1:52820",
+					"172.19.0.1:52820"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:12:01.789263606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3797042110872127,
+				"StableID":   "nkhiyjrgeW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:69849e8eab09ca566404106dde8a9cf154c370312a2cf8550c9557b338ee4e24",
+				"DiscoKey":   "discokey:ae68fde56e33eda5ea505196426d5e3d463ed294f8f39b6438ee0110e9444a5d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:59018",
+					"10.65.0.27:59018",
+					"172.17.0.1:59018",
+					"172.18.0.1:59018",
+					"172.19.0.1:59018"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:12:02.3243937Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5778490359501510,
+				"StableID":   "nPuPZJ968n11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b349d0ec6a01cb78dbc6e8334ab586fbde7bca3b9d6f3b698afb6c64ba741924",
+				"DiscoKey":   "discokey:d9f9026b8fcdce67bf746af048e7baea0f5de189bdb8af5fb35b1edaf98c6c41",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44441",
+					"10.65.0.27:44441",
+					"172.17.0.1:44441",
+					"172.18.0.1:44441",
+					"172.19.0.1:44441"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:12:02.856468022Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5728238856256014,
+				"StableID":   "nm67J38Ljm11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e0578f990ee630e03a83c235e647dd78731e28398e3599304c58f2f1a182142",
+				"DiscoKey":   "discokey:7833a5b00b623f8a3cf6ddaa9c03f1918556a71ccb602f35cef88ca7dd449b00",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38784",
+					"10.65.0.27:38784",
+					"172.17.0.1:38784",
+					"172.18.0.1:38784",
+					"172.19.0.1:38784"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:12:03.424194865Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4298882061670553,
+				"StableID":   "nCkfxqLyZa11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4cf45e85b38be0ef0134d9981158f71ec19fb8ca68a0712a32b338be3f96610c",
+				"DiscoKey":   "discokey:fdf89004ed5c514952553f76308347b756ccbe304c7e0dc041e4f5b784919b14",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33613",
+					"10.65.0.27:33613",
+					"172.17.0.1:33613",
+					"172.18.0.1:33613",
+					"172.19.0.1:33613"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:12:03.949250372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2288063618721240,
+				"StableID":   "n7S5tyYGsJ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:70a48e25d5debf34e49c694b24272b5aaf304e72b7e63f812fe40822254af662",
+				"DiscoKey":   "discokey:384afa65601a7d679514d36738598d330338e001c8b3a08a801934109c94491c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56035",
+					"10.65.0.27:56035",
+					"172.17.0.1:56035",
+					"172.18.0.1:56035",
+					"172.19.0.1:56035"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:12:04.516158854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8243980449292963,
+				"StableID":   "nx5v7TPiN721CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea2b7d8d1264b411404ff67f0ad440c74c5c6f45eadac2480a08511facf27b4c",
+				"DiscoKey":   "discokey:6e027ff21f6116184202cae7050c4ca03c7ad25fb9dd44c67a0c14a3fff17b30",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58884",
+					"10.65.0.27:58884",
+					"172.17.0.1:58884",
+					"172.18.0.1:58884",
+					"172.19.0.1:58884"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:12:05.060134199Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6580629105238557,
+				"StableID":   "n4J1j8yNPt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1e87f267764b8539a4b544082dd6a18cdc952d6b613da9ba89b6cf4afb730a32",
+				"DiscoKey":   "discokey:a491567ef7002d5ed47f0c086fdbe659f8b067de1b5e96d8be4c9e003453d854",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39438",
+					"10.65.0.27:39438",
+					"172.17.0.1:39438",
+					"172.18.0.1:39438",
+					"172.19.0.1:39438"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:12:05.589386892Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5815465531620617,
+				"StableID":   "nCGPuFRqQn11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:dacbccbe653dbe85ef34461de4e5ed6fc031516c8870b39e7a44f616be064e7d",
+				"KeyExpiry":  "2026-11-08T22:12:06Z",
+				"DiscoKey":   "discokey:a74800a72b8733af19ca1780330d14a7a1a898318cdb05e85c52ec5ca6d5ec22",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41994",
+					"10.65.0.27:41994",
+					"172.17.0.1:41994",
+					"172.18.0.1:41994",
+					"172.19.0.1:41994"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:12:06.159279306Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6653063879670959,
+				"StableID":   "nNQahyhBxt11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:20de44f0f9114cecba8ada3e3e6ea58120055ddb663d771137eb9778165b7c6d",
+				"KeyExpiry":  "2026-11-08T22:12:06Z",
+				"DiscoKey":   "discokey:61334ba9f1b936c9ba19a4c78fbc9612b5bb3c9578f631911a87eada5f07236f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40651",
+					"10.65.0.27:40651",
+					"172.17.0.1:40651",
+					"172.18.0.1:40651",
+					"172.19.0.1:40651"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:12:06.663606898Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5703680719812368,
+				"StableID":   "nf2dsC2DYm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:feaea4075d470d08e2844ad8ef68934f75ef2668211a97881857c6aac7b2f048",
+				"KeyExpiry":  "2026-11-08T22:12:07Z",
+				"DiscoKey":   "discokey:13842efc4412bf0e75e0194bfa21d15ffb91fb50d778bba72fe32c4795792801",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39244",
+					"10.65.0.27:39244",
+					"172.17.0.1:39244",
+					"172.18.0.1:39244",
+					"172.19.0.1:39244"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:12:07.214874702Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7031458668959897": {
+				"ID":          7031458668959897,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5728238856256014,
+				"StableID":   "nm67J38Ljm11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       5728238856256014,
+				"Key":        "nodekey:4e0578f990ee630e03a83c235e647dd78731e28398e3599304c58f2f1a182142",
+				"DiscoKey":   "discokey:7833a5b00b623f8a3cf6ddaa9c03f1918556a71ccb602f35cef88ca7dd449b00",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38784",
+					"10.65.0.27:38784",
+					"172.17.0.1:38784",
+					"172.18.0.1:38784",
+					"172.19.0.1:38784"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:12:03.424194865Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4e0578f990ee630e03a83c235e647dd78731e28398e3599304c58f2f1a182142",
+			"MachineKey": "mkey:407edf1278e7b1662179af87e78599f6e415f2ddc91158ed8a97814e3e0c505d",
+			"Peers": [{
+				"ID":         4482450356427873,
+				"StableID":   "nLkuZTN71c11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89ccaa47993ae02031e6b7e51d611d37e7bc1ac28351159d29e1e3334131cb77",
+				"DiscoKey":   "discokey:93dbf266c2a3d7d0993d8f6f5237208d1ba798c5b9bb669d0d7e485ccb85b30d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38682",
+					"10.65.0.27:38682",
+					"172.17.0.1:38682",
+					"172.18.0.1:38682",
+					"172.19.0.1:38682"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:11:59.640186881Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7068620101739055,
+				"StableID":   "nJtD3WfPCx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8a9be2fbaa5a1367c3290722c854f464346a7b7ea428f3bda0816499ebcd457",
+				"DiscoKey":   "discokey:d0339ea43781d13d0035d1435f9e8f2f17e0cf94481123d26ad0b30ea8c51b52",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39522",
+					"10.65.0.27:39522",
+					"172.17.0.1:39522",
+					"172.18.0.1:39522",
+					"172.19.0.1:39522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:12:00.15565341Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7031458668959897,
+				"StableID":   "nxWfUmVZuw11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b93cc735925eb2d5688ca13f0a4ae2b8ae04c35ab8e47aff4b55e8aebbe9ab22",
+				"DiscoKey":   "discokey:35093e8225f1040f91e4b438e178524f88553dadee8e7dacec4391c23ffc330f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:42311",
+					"10.65.0.27:42311",
+					"172.17.0.1:42311",
+					"172.18.0.1:42311",
+					"172.19.0.1:42311"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:12:00.70480488Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5198733611861902,
+				"StableID":   "n3R64AvWbh11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7202047580a18f66aa5f1fc49a868ea201bc7cd5dfc7b1b2b708dc1f4e802628",
+				"DiscoKey":   "discokey:9487c2395655e06d815632014f333bc68493a0fb9d69fc3f6be8788d7aafad5b",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34269",
+					"10.65.0.27:34269",
+					"172.17.0.1:34269",
+					"172.18.0.1:34269",
+					"172.19.0.1:34269"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:12:01.245172899Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2301363068827519,
+				"StableID":   "nU9CkWuHyJ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:78ed73b6b212e652b59f77c76c59166e508dc5a521fb99a0fc289f55b704b934",
+				"DiscoKey":   "discokey:1081c2e2239a9fa429e917dafa325dcd40073889a03f15fbf7a32722f682e06e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52820",
+					"10.65.0.27:52820",
+					"172.17.0.1:52820",
+					"172.18.0.1:52820",
+					"172.19.0.1:52820"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:12:01.789263606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3797042110872127,
+				"StableID":   "nkhiyjrgeW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:69849e8eab09ca566404106dde8a9cf154c370312a2cf8550c9557b338ee4e24",
+				"DiscoKey":   "discokey:ae68fde56e33eda5ea505196426d5e3d463ed294f8f39b6438ee0110e9444a5d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:59018",
+					"10.65.0.27:59018",
+					"172.17.0.1:59018",
+					"172.18.0.1:59018",
+					"172.19.0.1:59018"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:12:02.3243937Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5778490359501510,
+				"StableID":   "nPuPZJ968n11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b349d0ec6a01cb78dbc6e8334ab586fbde7bca3b9d6f3b698afb6c64ba741924",
+				"DiscoKey":   "discokey:d9f9026b8fcdce67bf746af048e7baea0f5de189bdb8af5fb35b1edaf98c6c41",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44441",
+					"10.65.0.27:44441",
+					"172.17.0.1:44441",
+					"172.18.0.1:44441",
+					"172.19.0.1:44441"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:12:02.856468022Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4298882061670553,
+				"StableID":   "nCkfxqLyZa11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4cf45e85b38be0ef0134d9981158f71ec19fb8ca68a0712a32b338be3f96610c",
+				"DiscoKey":   "discokey:fdf89004ed5c514952553f76308347b756ccbe304c7e0dc041e4f5b784919b14",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33613",
+					"10.65.0.27:33613",
+					"172.17.0.1:33613",
+					"172.18.0.1:33613",
+					"172.19.0.1:33613"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:12:03.949250372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2288063618721240,
+				"StableID":   "n7S5tyYGsJ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:70a48e25d5debf34e49c694b24272b5aaf304e72b7e63f812fe40822254af662",
+				"DiscoKey":   "discokey:384afa65601a7d679514d36738598d330338e001c8b3a08a801934109c94491c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56035",
+					"10.65.0.27:56035",
+					"172.17.0.1:56035",
+					"172.18.0.1:56035",
+					"172.19.0.1:56035"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:12:04.516158854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8243980449292963,
+				"StableID":   "nx5v7TPiN721CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea2b7d8d1264b411404ff67f0ad440c74c5c6f45eadac2480a08511facf27b4c",
+				"DiscoKey":   "discokey:6e027ff21f6116184202cae7050c4ca03c7ad25fb9dd44c67a0c14a3fff17b30",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58884",
+					"10.65.0.27:58884",
+					"172.17.0.1:58884",
+					"172.18.0.1:58884",
+					"172.19.0.1:58884"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:12:05.060134199Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6580629105238557,
+				"StableID":   "n4J1j8yNPt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1e87f267764b8539a4b544082dd6a18cdc952d6b613da9ba89b6cf4afb730a32",
+				"DiscoKey":   "discokey:a491567ef7002d5ed47f0c086fdbe659f8b067de1b5e96d8be4c9e003453d854",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39438",
+					"10.65.0.27:39438",
+					"172.17.0.1:39438",
+					"172.18.0.1:39438",
+					"172.19.0.1:39438"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:12:05.589386892Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5815465531620617,
+				"StableID":   "nCGPuFRqQn11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:dacbccbe653dbe85ef34461de4e5ed6fc031516c8870b39e7a44f616be064e7d",
+				"KeyExpiry":  "2026-11-08T22:12:06Z",
+				"DiscoKey":   "discokey:a74800a72b8733af19ca1780330d14a7a1a898318cdb05e85c52ec5ca6d5ec22",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41994",
+					"10.65.0.27:41994",
+					"172.17.0.1:41994",
+					"172.18.0.1:41994",
+					"172.19.0.1:41994"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:12:06.159279306Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6653063879670959,
+				"StableID":   "nNQahyhBxt11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:20de44f0f9114cecba8ada3e3e6ea58120055ddb663d771137eb9778165b7c6d",
+				"KeyExpiry":  "2026-11-08T22:12:06Z",
+				"DiscoKey":   "discokey:61334ba9f1b936c9ba19a4c78fbc9612b5bb3c9578f631911a87eada5f07236f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40651",
+					"10.65.0.27:40651",
+					"172.17.0.1:40651",
+					"172.18.0.1:40651",
+					"172.19.0.1:40651"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:12:06.663606898Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5703680719812368,
+				"StableID":   "nf2dsC2DYm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:feaea4075d470d08e2844ad8ef68934f75ef2668211a97881857c6aac7b2f048",
+				"KeyExpiry":  "2026-11-08T22:12:07Z",
+				"DiscoKey":   "discokey:13842efc4412bf0e75e0194bfa21d15ffb91fb50d778bba72fe32c4795792801",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39244",
+					"10.65.0.27:39244",
+					"172.17.0.1:39244",
+					"172.18.0.1:39244",
+					"172.19.0.1:39244"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:12:07.214874702Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5728238856256014": {
+				"ID":          5728238856256014,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5815465531620617,
+				"StableID":   "nCGPuFRqQn11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:dacbccbe653dbe85ef34461de4e5ed6fc031516c8870b39e7a44f616be064e7d",
+				"KeyExpiry":  "2026-11-08T22:12:06Z",
+				"DiscoKey":   "discokey:a74800a72b8733af19ca1780330d14a7a1a898318cdb05e85c52ec5ca6d5ec22",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41994",
+					"10.65.0.27:41994",
+					"172.17.0.1:41994",
+					"172.18.0.1:41994",
+					"172.19.0.1:41994"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:12:06.159279306Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:dacbccbe653dbe85ef34461de4e5ed6fc031516c8870b39e7a44f616be064e7d",
+			"MachineKey": "mkey:22b3eac4b8320673ef51dd92b211c6dedcb40aaa91b54da6f877ffb104909813",
+			"Peers": [{
+				"ID":         4482450356427873,
+				"StableID":   "nLkuZTN71c11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89ccaa47993ae02031e6b7e51d611d37e7bc1ac28351159d29e1e3334131cb77",
+				"DiscoKey":   "discokey:93dbf266c2a3d7d0993d8f6f5237208d1ba798c5b9bb669d0d7e485ccb85b30d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38682",
+					"10.65.0.27:38682",
+					"172.17.0.1:38682",
+					"172.18.0.1:38682",
+					"172.19.0.1:38682"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:11:59.640186881Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7068620101739055,
+				"StableID":   "nJtD3WfPCx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8a9be2fbaa5a1367c3290722c854f464346a7b7ea428f3bda0816499ebcd457",
+				"DiscoKey":   "discokey:d0339ea43781d13d0035d1435f9e8f2f17e0cf94481123d26ad0b30ea8c51b52",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39522",
+					"10.65.0.27:39522",
+					"172.17.0.1:39522",
+					"172.18.0.1:39522",
+					"172.19.0.1:39522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:12:00.15565341Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7031458668959897,
+				"StableID":   "nxWfUmVZuw11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b93cc735925eb2d5688ca13f0a4ae2b8ae04c35ab8e47aff4b55e8aebbe9ab22",
+				"DiscoKey":   "discokey:35093e8225f1040f91e4b438e178524f88553dadee8e7dacec4391c23ffc330f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:42311",
+					"10.65.0.27:42311",
+					"172.17.0.1:42311",
+					"172.18.0.1:42311",
+					"172.19.0.1:42311"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:12:00.70480488Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5198733611861902,
+				"StableID":   "n3R64AvWbh11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7202047580a18f66aa5f1fc49a868ea201bc7cd5dfc7b1b2b708dc1f4e802628",
+				"DiscoKey":   "discokey:9487c2395655e06d815632014f333bc68493a0fb9d69fc3f6be8788d7aafad5b",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34269",
+					"10.65.0.27:34269",
+					"172.17.0.1:34269",
+					"172.18.0.1:34269",
+					"172.19.0.1:34269"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:12:01.245172899Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2301363068827519,
+				"StableID":   "nU9CkWuHyJ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:78ed73b6b212e652b59f77c76c59166e508dc5a521fb99a0fc289f55b704b934",
+				"DiscoKey":   "discokey:1081c2e2239a9fa429e917dafa325dcd40073889a03f15fbf7a32722f682e06e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52820",
+					"10.65.0.27:52820",
+					"172.17.0.1:52820",
+					"172.18.0.1:52820",
+					"172.19.0.1:52820"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:12:01.789263606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3797042110872127,
+				"StableID":   "nkhiyjrgeW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:69849e8eab09ca566404106dde8a9cf154c370312a2cf8550c9557b338ee4e24",
+				"DiscoKey":   "discokey:ae68fde56e33eda5ea505196426d5e3d463ed294f8f39b6438ee0110e9444a5d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:59018",
+					"10.65.0.27:59018",
+					"172.17.0.1:59018",
+					"172.18.0.1:59018",
+					"172.19.0.1:59018"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:12:02.3243937Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5778490359501510,
+				"StableID":   "nPuPZJ968n11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b349d0ec6a01cb78dbc6e8334ab586fbde7bca3b9d6f3b698afb6c64ba741924",
+				"DiscoKey":   "discokey:d9f9026b8fcdce67bf746af048e7baea0f5de189bdb8af5fb35b1edaf98c6c41",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44441",
+					"10.65.0.27:44441",
+					"172.17.0.1:44441",
+					"172.18.0.1:44441",
+					"172.19.0.1:44441"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:12:02.856468022Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5728238856256014,
+				"StableID":   "nm67J38Ljm11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e0578f990ee630e03a83c235e647dd78731e28398e3599304c58f2f1a182142",
+				"DiscoKey":   "discokey:7833a5b00b623f8a3cf6ddaa9c03f1918556a71ccb602f35cef88ca7dd449b00",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38784",
+					"10.65.0.27:38784",
+					"172.17.0.1:38784",
+					"172.18.0.1:38784",
+					"172.19.0.1:38784"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:12:03.424194865Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4298882061670553,
+				"StableID":   "nCkfxqLyZa11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4cf45e85b38be0ef0134d9981158f71ec19fb8ca68a0712a32b338be3f96610c",
+				"DiscoKey":   "discokey:fdf89004ed5c514952553f76308347b756ccbe304c7e0dc041e4f5b784919b14",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33613",
+					"10.65.0.27:33613",
+					"172.17.0.1:33613",
+					"172.18.0.1:33613",
+					"172.19.0.1:33613"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:12:03.949250372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2288063618721240,
+				"StableID":   "n7S5tyYGsJ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:70a48e25d5debf34e49c694b24272b5aaf304e72b7e63f812fe40822254af662",
+				"DiscoKey":   "discokey:384afa65601a7d679514d36738598d330338e001c8b3a08a801934109c94491c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56035",
+					"10.65.0.27:56035",
+					"172.17.0.1:56035",
+					"172.18.0.1:56035",
+					"172.19.0.1:56035"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:12:04.516158854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8243980449292963,
+				"StableID":   "nx5v7TPiN721CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea2b7d8d1264b411404ff67f0ad440c74c5c6f45eadac2480a08511facf27b4c",
+				"DiscoKey":   "discokey:6e027ff21f6116184202cae7050c4ca03c7ad25fb9dd44c67a0c14a3fff17b30",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58884",
+					"10.65.0.27:58884",
+					"172.17.0.1:58884",
+					"172.18.0.1:58884",
+					"172.19.0.1:58884"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:12:05.060134199Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6580629105238557,
+				"StableID":   "n4J1j8yNPt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1e87f267764b8539a4b544082dd6a18cdc952d6b613da9ba89b6cf4afb730a32",
+				"DiscoKey":   "discokey:a491567ef7002d5ed47f0c086fdbe659f8b067de1b5e96d8be4c9e003453d854",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39438",
+					"10.65.0.27:39438",
+					"172.17.0.1:39438",
+					"172.18.0.1:39438",
+					"172.19.0.1:39438"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:12:05.589386892Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6653063879670959,
+				"StableID":   "nNQahyhBxt11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:20de44f0f9114cecba8ada3e3e6ea58120055ddb663d771137eb9778165b7c6d",
+				"KeyExpiry":  "2026-11-08T22:12:06Z",
+				"DiscoKey":   "discokey:61334ba9f1b936c9ba19a4c78fbc9612b5bb3c9578f631911a87eada5f07236f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40651",
+					"10.65.0.27:40651",
+					"172.17.0.1:40651",
+					"172.18.0.1:40651",
+					"172.19.0.1:40651"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:12:06.663606898Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5703680719812368,
+				"StableID":   "nf2dsC2DYm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:feaea4075d470d08e2844ad8ef68934f75ef2668211a97881857c6aac7b2f048",
+				"KeyExpiry":  "2026-11-08T22:12:07Z",
+				"DiscoKey":   "discokey:13842efc4412bf0e75e0194bfa21d15ffb91fb50d778bba72fe32c4795792801",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39244",
+					"10.65.0.27:39244",
+					"172.17.0.1:39244",
+					"172.18.0.1:39244",
+					"172.19.0.1:39244"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:12:07.214874702Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8243980449292963,
+				"StableID":   "nx5v7TPiN721CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       8243980449292963,
+				"Key":        "nodekey:ea2b7d8d1264b411404ff67f0ad440c74c5c6f45eadac2480a08511facf27b4c",
+				"DiscoKey":   "discokey:6e027ff21f6116184202cae7050c4ca03c7ad25fb9dd44c67a0c14a3fff17b30",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58884",
+					"10.65.0.27:58884",
+					"172.17.0.1:58884",
+					"172.18.0.1:58884",
+					"172.19.0.1:58884"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:12:05.060134199Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ea2b7d8d1264b411404ff67f0ad440c74c5c6f45eadac2480a08511facf27b4c",
+			"MachineKey": "mkey:ea79ec61bdda805653368a90802e9f59e5b4fc265b396b73cedbcb45d8438d14",
+			"Peers": [{
+				"ID":         4482450356427873,
+				"StableID":   "nLkuZTN71c11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89ccaa47993ae02031e6b7e51d611d37e7bc1ac28351159d29e1e3334131cb77",
+				"DiscoKey":   "discokey:93dbf266c2a3d7d0993d8f6f5237208d1ba798c5b9bb669d0d7e485ccb85b30d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38682",
+					"10.65.0.27:38682",
+					"172.17.0.1:38682",
+					"172.18.0.1:38682",
+					"172.19.0.1:38682"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:11:59.640186881Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7068620101739055,
+				"StableID":   "nJtD3WfPCx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8a9be2fbaa5a1367c3290722c854f464346a7b7ea428f3bda0816499ebcd457",
+				"DiscoKey":   "discokey:d0339ea43781d13d0035d1435f9e8f2f17e0cf94481123d26ad0b30ea8c51b52",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39522",
+					"10.65.0.27:39522",
+					"172.17.0.1:39522",
+					"172.18.0.1:39522",
+					"172.19.0.1:39522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:12:00.15565341Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7031458668959897,
+				"StableID":   "nxWfUmVZuw11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b93cc735925eb2d5688ca13f0a4ae2b8ae04c35ab8e47aff4b55e8aebbe9ab22",
+				"DiscoKey":   "discokey:35093e8225f1040f91e4b438e178524f88553dadee8e7dacec4391c23ffc330f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:42311",
+					"10.65.0.27:42311",
+					"172.17.0.1:42311",
+					"172.18.0.1:42311",
+					"172.19.0.1:42311"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:12:00.70480488Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5198733611861902,
+				"StableID":   "n3R64AvWbh11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7202047580a18f66aa5f1fc49a868ea201bc7cd5dfc7b1b2b708dc1f4e802628",
+				"DiscoKey":   "discokey:9487c2395655e06d815632014f333bc68493a0fb9d69fc3f6be8788d7aafad5b",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34269",
+					"10.65.0.27:34269",
+					"172.17.0.1:34269",
+					"172.18.0.1:34269",
+					"172.19.0.1:34269"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:12:01.245172899Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2301363068827519,
+				"StableID":   "nU9CkWuHyJ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:78ed73b6b212e652b59f77c76c59166e508dc5a521fb99a0fc289f55b704b934",
+				"DiscoKey":   "discokey:1081c2e2239a9fa429e917dafa325dcd40073889a03f15fbf7a32722f682e06e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52820",
+					"10.65.0.27:52820",
+					"172.17.0.1:52820",
+					"172.18.0.1:52820",
+					"172.19.0.1:52820"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:12:01.789263606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3797042110872127,
+				"StableID":   "nkhiyjrgeW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:69849e8eab09ca566404106dde8a9cf154c370312a2cf8550c9557b338ee4e24",
+				"DiscoKey":   "discokey:ae68fde56e33eda5ea505196426d5e3d463ed294f8f39b6438ee0110e9444a5d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:59018",
+					"10.65.0.27:59018",
+					"172.17.0.1:59018",
+					"172.18.0.1:59018",
+					"172.19.0.1:59018"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:12:02.3243937Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5778490359501510,
+				"StableID":   "nPuPZJ968n11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b349d0ec6a01cb78dbc6e8334ab586fbde7bca3b9d6f3b698afb6c64ba741924",
+				"DiscoKey":   "discokey:d9f9026b8fcdce67bf746af048e7baea0f5de189bdb8af5fb35b1edaf98c6c41",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44441",
+					"10.65.0.27:44441",
+					"172.17.0.1:44441",
+					"172.18.0.1:44441",
+					"172.19.0.1:44441"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:12:02.856468022Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5728238856256014,
+				"StableID":   "nm67J38Ljm11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e0578f990ee630e03a83c235e647dd78731e28398e3599304c58f2f1a182142",
+				"DiscoKey":   "discokey:7833a5b00b623f8a3cf6ddaa9c03f1918556a71ccb602f35cef88ca7dd449b00",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38784",
+					"10.65.0.27:38784",
+					"172.17.0.1:38784",
+					"172.18.0.1:38784",
+					"172.19.0.1:38784"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:12:03.424194865Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4298882061670553,
+				"StableID":   "nCkfxqLyZa11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4cf45e85b38be0ef0134d9981158f71ec19fb8ca68a0712a32b338be3f96610c",
+				"DiscoKey":   "discokey:fdf89004ed5c514952553f76308347b756ccbe304c7e0dc041e4f5b784919b14",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33613",
+					"10.65.0.27:33613",
+					"172.17.0.1:33613",
+					"172.18.0.1:33613",
+					"172.19.0.1:33613"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:12:03.949250372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2288063618721240,
+				"StableID":   "n7S5tyYGsJ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:70a48e25d5debf34e49c694b24272b5aaf304e72b7e63f812fe40822254af662",
+				"DiscoKey":   "discokey:384afa65601a7d679514d36738598d330338e001c8b3a08a801934109c94491c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56035",
+					"10.65.0.27:56035",
+					"172.17.0.1:56035",
+					"172.18.0.1:56035",
+					"172.19.0.1:56035"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:12:04.516158854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6580629105238557,
+				"StableID":   "n4J1j8yNPt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1e87f267764b8539a4b544082dd6a18cdc952d6b613da9ba89b6cf4afb730a32",
+				"DiscoKey":   "discokey:a491567ef7002d5ed47f0c086fdbe659f8b067de1b5e96d8be4c9e003453d854",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39438",
+					"10.65.0.27:39438",
+					"172.17.0.1:39438",
+					"172.18.0.1:39438",
+					"172.19.0.1:39438"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:12:05.589386892Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5815465531620617,
+				"StableID":   "nCGPuFRqQn11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:dacbccbe653dbe85ef34461de4e5ed6fc031516c8870b39e7a44f616be064e7d",
+				"KeyExpiry":  "2026-11-08T22:12:06Z",
+				"DiscoKey":   "discokey:a74800a72b8733af19ca1780330d14a7a1a898318cdb05e85c52ec5ca6d5ec22",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41994",
+					"10.65.0.27:41994",
+					"172.17.0.1:41994",
+					"172.18.0.1:41994",
+					"172.19.0.1:41994"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:12:06.159279306Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6653063879670959,
+				"StableID":   "nNQahyhBxt11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:20de44f0f9114cecba8ada3e3e6ea58120055ddb663d771137eb9778165b7c6d",
+				"KeyExpiry":  "2026-11-08T22:12:06Z",
+				"DiscoKey":   "discokey:61334ba9f1b936c9ba19a4c78fbc9612b5bb3c9578f631911a87eada5f07236f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40651",
+					"10.65.0.27:40651",
+					"172.17.0.1:40651",
+					"172.18.0.1:40651",
+					"172.19.0.1:40651"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:12:06.663606898Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5703680719812368,
+				"StableID":   "nf2dsC2DYm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:feaea4075d470d08e2844ad8ef68934f75ef2668211a97881857c6aac7b2f048",
+				"KeyExpiry":  "2026-11-08T22:12:07Z",
+				"DiscoKey":   "discokey:13842efc4412bf0e75e0194bfa21d15ffb91fb50d778bba72fe32c4795792801",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39244",
+					"10.65.0.27:39244",
+					"172.17.0.1:39244",
+					"172.18.0.1:39244",
+					"172.19.0.1:39244"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:12:07.214874702Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8243980449292963": {
+				"ID":          8243980449292963,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7068620101739055,
+				"StableID":   "nJtD3WfPCx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       7068620101739055,
+				"Key":        "nodekey:a8a9be2fbaa5a1367c3290722c854f464346a7b7ea428f3bda0816499ebcd457",
+				"DiscoKey":   "discokey:d0339ea43781d13d0035d1435f9e8f2f17e0cf94481123d26ad0b30ea8c51b52",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39522",
+					"10.65.0.27:39522",
+					"172.17.0.1:39522",
+					"172.18.0.1:39522",
+					"172.19.0.1:39522"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:12:00.15565341Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a8a9be2fbaa5a1367c3290722c854f464346a7b7ea428f3bda0816499ebcd457",
+			"MachineKey": "mkey:f15fef1f6aa704a875a908cb3825f62600853c76d7070af33effddb65d16e641",
+			"Peers": [{
+				"ID":         4482450356427873,
+				"StableID":   "nLkuZTN71c11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89ccaa47993ae02031e6b7e51d611d37e7bc1ac28351159d29e1e3334131cb77",
+				"DiscoKey":   "discokey:93dbf266c2a3d7d0993d8f6f5237208d1ba798c5b9bb669d0d7e485ccb85b30d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38682",
+					"10.65.0.27:38682",
+					"172.17.0.1:38682",
+					"172.18.0.1:38682",
+					"172.19.0.1:38682"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:11:59.640186881Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7031458668959897,
+				"StableID":   "nxWfUmVZuw11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b93cc735925eb2d5688ca13f0a4ae2b8ae04c35ab8e47aff4b55e8aebbe9ab22",
+				"DiscoKey":   "discokey:35093e8225f1040f91e4b438e178524f88553dadee8e7dacec4391c23ffc330f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:42311",
+					"10.65.0.27:42311",
+					"172.17.0.1:42311",
+					"172.18.0.1:42311",
+					"172.19.0.1:42311"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:12:00.70480488Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5198733611861902,
+				"StableID":   "n3R64AvWbh11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7202047580a18f66aa5f1fc49a868ea201bc7cd5dfc7b1b2b708dc1f4e802628",
+				"DiscoKey":   "discokey:9487c2395655e06d815632014f333bc68493a0fb9d69fc3f6be8788d7aafad5b",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34269",
+					"10.65.0.27:34269",
+					"172.17.0.1:34269",
+					"172.18.0.1:34269",
+					"172.19.0.1:34269"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:12:01.245172899Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2301363068827519,
+				"StableID":   "nU9CkWuHyJ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:78ed73b6b212e652b59f77c76c59166e508dc5a521fb99a0fc289f55b704b934",
+				"DiscoKey":   "discokey:1081c2e2239a9fa429e917dafa325dcd40073889a03f15fbf7a32722f682e06e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52820",
+					"10.65.0.27:52820",
+					"172.17.0.1:52820",
+					"172.18.0.1:52820",
+					"172.19.0.1:52820"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:12:01.789263606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3797042110872127,
+				"StableID":   "nkhiyjrgeW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:69849e8eab09ca566404106dde8a9cf154c370312a2cf8550c9557b338ee4e24",
+				"DiscoKey":   "discokey:ae68fde56e33eda5ea505196426d5e3d463ed294f8f39b6438ee0110e9444a5d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:59018",
+					"10.65.0.27:59018",
+					"172.17.0.1:59018",
+					"172.18.0.1:59018",
+					"172.19.0.1:59018"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:12:02.3243937Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5778490359501510,
+				"StableID":   "nPuPZJ968n11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b349d0ec6a01cb78dbc6e8334ab586fbde7bca3b9d6f3b698afb6c64ba741924",
+				"DiscoKey":   "discokey:d9f9026b8fcdce67bf746af048e7baea0f5de189bdb8af5fb35b1edaf98c6c41",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44441",
+					"10.65.0.27:44441",
+					"172.17.0.1:44441",
+					"172.18.0.1:44441",
+					"172.19.0.1:44441"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:12:02.856468022Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5728238856256014,
+				"StableID":   "nm67J38Ljm11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e0578f990ee630e03a83c235e647dd78731e28398e3599304c58f2f1a182142",
+				"DiscoKey":   "discokey:7833a5b00b623f8a3cf6ddaa9c03f1918556a71ccb602f35cef88ca7dd449b00",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38784",
+					"10.65.0.27:38784",
+					"172.17.0.1:38784",
+					"172.18.0.1:38784",
+					"172.19.0.1:38784"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:12:03.424194865Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4298882061670553,
+				"StableID":   "nCkfxqLyZa11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4cf45e85b38be0ef0134d9981158f71ec19fb8ca68a0712a32b338be3f96610c",
+				"DiscoKey":   "discokey:fdf89004ed5c514952553f76308347b756ccbe304c7e0dc041e4f5b784919b14",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33613",
+					"10.65.0.27:33613",
+					"172.17.0.1:33613",
+					"172.18.0.1:33613",
+					"172.19.0.1:33613"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:12:03.949250372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2288063618721240,
+				"StableID":   "n7S5tyYGsJ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:70a48e25d5debf34e49c694b24272b5aaf304e72b7e63f812fe40822254af662",
+				"DiscoKey":   "discokey:384afa65601a7d679514d36738598d330338e001c8b3a08a801934109c94491c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56035",
+					"10.65.0.27:56035",
+					"172.17.0.1:56035",
+					"172.18.0.1:56035",
+					"172.19.0.1:56035"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:12:04.516158854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8243980449292963,
+				"StableID":   "nx5v7TPiN721CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea2b7d8d1264b411404ff67f0ad440c74c5c6f45eadac2480a08511facf27b4c",
+				"DiscoKey":   "discokey:6e027ff21f6116184202cae7050c4ca03c7ad25fb9dd44c67a0c14a3fff17b30",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58884",
+					"10.65.0.27:58884",
+					"172.17.0.1:58884",
+					"172.18.0.1:58884",
+					"172.19.0.1:58884"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:12:05.060134199Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6580629105238557,
+				"StableID":   "n4J1j8yNPt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1e87f267764b8539a4b544082dd6a18cdc952d6b613da9ba89b6cf4afb730a32",
+				"DiscoKey":   "discokey:a491567ef7002d5ed47f0c086fdbe659f8b067de1b5e96d8be4c9e003453d854",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39438",
+					"10.65.0.27:39438",
+					"172.17.0.1:39438",
+					"172.18.0.1:39438",
+					"172.19.0.1:39438"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:12:05.589386892Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5815465531620617,
+				"StableID":   "nCGPuFRqQn11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:dacbccbe653dbe85ef34461de4e5ed6fc031516c8870b39e7a44f616be064e7d",
+				"KeyExpiry":  "2026-11-08T22:12:06Z",
+				"DiscoKey":   "discokey:a74800a72b8733af19ca1780330d14a7a1a898318cdb05e85c52ec5ca6d5ec22",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41994",
+					"10.65.0.27:41994",
+					"172.17.0.1:41994",
+					"172.18.0.1:41994",
+					"172.19.0.1:41994"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:12:06.159279306Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6653063879670959,
+				"StableID":   "nNQahyhBxt11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:20de44f0f9114cecba8ada3e3e6ea58120055ddb663d771137eb9778165b7c6d",
+				"KeyExpiry":  "2026-11-08T22:12:06Z",
+				"DiscoKey":   "discokey:61334ba9f1b936c9ba19a4c78fbc9612b5bb3c9578f631911a87eada5f07236f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40651",
+					"10.65.0.27:40651",
+					"172.17.0.1:40651",
+					"172.18.0.1:40651",
+					"172.19.0.1:40651"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:12:06.663606898Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5703680719812368,
+				"StableID":   "nf2dsC2DYm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:feaea4075d470d08e2844ad8ef68934f75ef2668211a97881857c6aac7b2f048",
+				"KeyExpiry":  "2026-11-08T22:12:07Z",
+				"DiscoKey":   "discokey:13842efc4412bf0e75e0194bfa21d15ffb91fb50d778bba72fe32c4795792801",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39244",
+					"10.65.0.27:39244",
+					"172.17.0.1:39244",
+					"172.18.0.1:39244",
+					"172.19.0.1:39244"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:12:07.214874702Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7068620101739055": {
+				"ID":          7068620101739055,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4482450356427873,
+				"StableID":   "nLkuZTN71c11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       4482450356427873,
+				"Key":        "nodekey:89ccaa47993ae02031e6b7e51d611d37e7bc1ac28351159d29e1e3334131cb77",
+				"DiscoKey":   "discokey:93dbf266c2a3d7d0993d8f6f5237208d1ba798c5b9bb669d0d7e485ccb85b30d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38682",
+					"10.65.0.27:38682",
+					"172.17.0.1:38682",
+					"172.18.0.1:38682",
+					"172.19.0.1:38682"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:11:59.640186881Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:89ccaa47993ae02031e6b7e51d611d37e7bc1ac28351159d29e1e3334131cb77",
+			"MachineKey": "mkey:d40927b26bbb26ec473c451594194d81b7de8d470e6cb1575279c76c39a93b61",
+			"Peers": [{
+				"ID":         7068620101739055,
+				"StableID":   "nJtD3WfPCx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8a9be2fbaa5a1367c3290722c854f464346a7b7ea428f3bda0816499ebcd457",
+				"DiscoKey":   "discokey:d0339ea43781d13d0035d1435f9e8f2f17e0cf94481123d26ad0b30ea8c51b52",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39522",
+					"10.65.0.27:39522",
+					"172.17.0.1:39522",
+					"172.18.0.1:39522",
+					"172.19.0.1:39522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:12:00.15565341Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7031458668959897,
+				"StableID":   "nxWfUmVZuw11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b93cc735925eb2d5688ca13f0a4ae2b8ae04c35ab8e47aff4b55e8aebbe9ab22",
+				"DiscoKey":   "discokey:35093e8225f1040f91e4b438e178524f88553dadee8e7dacec4391c23ffc330f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:42311",
+					"10.65.0.27:42311",
+					"172.17.0.1:42311",
+					"172.18.0.1:42311",
+					"172.19.0.1:42311"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:12:00.70480488Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5198733611861902,
+				"StableID":   "n3R64AvWbh11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7202047580a18f66aa5f1fc49a868ea201bc7cd5dfc7b1b2b708dc1f4e802628",
+				"DiscoKey":   "discokey:9487c2395655e06d815632014f333bc68493a0fb9d69fc3f6be8788d7aafad5b",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34269",
+					"10.65.0.27:34269",
+					"172.17.0.1:34269",
+					"172.18.0.1:34269",
+					"172.19.0.1:34269"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:12:01.245172899Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2301363068827519,
+				"StableID":   "nU9CkWuHyJ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:78ed73b6b212e652b59f77c76c59166e508dc5a521fb99a0fc289f55b704b934",
+				"DiscoKey":   "discokey:1081c2e2239a9fa429e917dafa325dcd40073889a03f15fbf7a32722f682e06e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52820",
+					"10.65.0.27:52820",
+					"172.17.0.1:52820",
+					"172.18.0.1:52820",
+					"172.19.0.1:52820"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:12:01.789263606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3797042110872127,
+				"StableID":   "nkhiyjrgeW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:69849e8eab09ca566404106dde8a9cf154c370312a2cf8550c9557b338ee4e24",
+				"DiscoKey":   "discokey:ae68fde56e33eda5ea505196426d5e3d463ed294f8f39b6438ee0110e9444a5d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:59018",
+					"10.65.0.27:59018",
+					"172.17.0.1:59018",
+					"172.18.0.1:59018",
+					"172.19.0.1:59018"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:12:02.3243937Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5778490359501510,
+				"StableID":   "nPuPZJ968n11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b349d0ec6a01cb78dbc6e8334ab586fbde7bca3b9d6f3b698afb6c64ba741924",
+				"DiscoKey":   "discokey:d9f9026b8fcdce67bf746af048e7baea0f5de189bdb8af5fb35b1edaf98c6c41",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44441",
+					"10.65.0.27:44441",
+					"172.17.0.1:44441",
+					"172.18.0.1:44441",
+					"172.19.0.1:44441"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:12:02.856468022Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5728238856256014,
+				"StableID":   "nm67J38Ljm11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e0578f990ee630e03a83c235e647dd78731e28398e3599304c58f2f1a182142",
+				"DiscoKey":   "discokey:7833a5b00b623f8a3cf6ddaa9c03f1918556a71ccb602f35cef88ca7dd449b00",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38784",
+					"10.65.0.27:38784",
+					"172.17.0.1:38784",
+					"172.18.0.1:38784",
+					"172.19.0.1:38784"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:12:03.424194865Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4298882061670553,
+				"StableID":   "nCkfxqLyZa11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4cf45e85b38be0ef0134d9981158f71ec19fb8ca68a0712a32b338be3f96610c",
+				"DiscoKey":   "discokey:fdf89004ed5c514952553f76308347b756ccbe304c7e0dc041e4f5b784919b14",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33613",
+					"10.65.0.27:33613",
+					"172.17.0.1:33613",
+					"172.18.0.1:33613",
+					"172.19.0.1:33613"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:12:03.949250372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2288063618721240,
+				"StableID":   "n7S5tyYGsJ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:70a48e25d5debf34e49c694b24272b5aaf304e72b7e63f812fe40822254af662",
+				"DiscoKey":   "discokey:384afa65601a7d679514d36738598d330338e001c8b3a08a801934109c94491c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56035",
+					"10.65.0.27:56035",
+					"172.17.0.1:56035",
+					"172.18.0.1:56035",
+					"172.19.0.1:56035"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:12:04.516158854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8243980449292963,
+				"StableID":   "nx5v7TPiN721CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea2b7d8d1264b411404ff67f0ad440c74c5c6f45eadac2480a08511facf27b4c",
+				"DiscoKey":   "discokey:6e027ff21f6116184202cae7050c4ca03c7ad25fb9dd44c67a0c14a3fff17b30",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58884",
+					"10.65.0.27:58884",
+					"172.17.0.1:58884",
+					"172.18.0.1:58884",
+					"172.19.0.1:58884"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:12:05.060134199Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6580629105238557,
+				"StableID":   "n4J1j8yNPt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1e87f267764b8539a4b544082dd6a18cdc952d6b613da9ba89b6cf4afb730a32",
+				"DiscoKey":   "discokey:a491567ef7002d5ed47f0c086fdbe659f8b067de1b5e96d8be4c9e003453d854",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39438",
+					"10.65.0.27:39438",
+					"172.17.0.1:39438",
+					"172.18.0.1:39438",
+					"172.19.0.1:39438"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:12:05.589386892Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5815465531620617,
+				"StableID":   "nCGPuFRqQn11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:dacbccbe653dbe85ef34461de4e5ed6fc031516c8870b39e7a44f616be064e7d",
+				"KeyExpiry":  "2026-11-08T22:12:06Z",
+				"DiscoKey":   "discokey:a74800a72b8733af19ca1780330d14a7a1a898318cdb05e85c52ec5ca6d5ec22",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41994",
+					"10.65.0.27:41994",
+					"172.17.0.1:41994",
+					"172.18.0.1:41994",
+					"172.19.0.1:41994"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:12:06.159279306Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6653063879670959,
+				"StableID":   "nNQahyhBxt11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:20de44f0f9114cecba8ada3e3e6ea58120055ddb663d771137eb9778165b7c6d",
+				"KeyExpiry":  "2026-11-08T22:12:06Z",
+				"DiscoKey":   "discokey:61334ba9f1b936c9ba19a4c78fbc9612b5bb3c9578f631911a87eada5f07236f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40651",
+					"10.65.0.27:40651",
+					"172.17.0.1:40651",
+					"172.18.0.1:40651",
+					"172.19.0.1:40651"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:12:06.663606898Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5703680719812368,
+				"StableID":   "nf2dsC2DYm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:feaea4075d470d08e2844ad8ef68934f75ef2668211a97881857c6aac7b2f048",
+				"KeyExpiry":  "2026-11-08T22:12:07Z",
+				"DiscoKey":   "discokey:13842efc4412bf0e75e0194bfa21d15ffb91fb50d778bba72fe32c4795792801",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39244",
+					"10.65.0.27:39244",
+					"172.17.0.1:39244",
+					"172.18.0.1:39244",
+					"172.19.0.1:39244"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:12:07.214874702Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4482450356427873": {
+				"ID":          4482450356427873,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2301363068827519,
+				"StableID":   "nU9CkWuHyJ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       2301363068827519,
+				"Key":        "nodekey:78ed73b6b212e652b59f77c76c59166e508dc5a521fb99a0fc289f55b704b934",
+				"DiscoKey":   "discokey:1081c2e2239a9fa429e917dafa325dcd40073889a03f15fbf7a32722f682e06e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52820",
+					"10.65.0.27:52820",
+					"172.17.0.1:52820",
+					"172.18.0.1:52820",
+					"172.19.0.1:52820"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:12:01.789263606Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:78ed73b6b212e652b59f77c76c59166e508dc5a521fb99a0fc289f55b704b934",
+			"MachineKey": "mkey:eac7348881b565ae884e6ef66da488f5ae643c3ef5d2714ecad493867578c45d",
+			"Peers": [{
+				"ID":         4482450356427873,
+				"StableID":   "nLkuZTN71c11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89ccaa47993ae02031e6b7e51d611d37e7bc1ac28351159d29e1e3334131cb77",
+				"DiscoKey":   "discokey:93dbf266c2a3d7d0993d8f6f5237208d1ba798c5b9bb669d0d7e485ccb85b30d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38682",
+					"10.65.0.27:38682",
+					"172.17.0.1:38682",
+					"172.18.0.1:38682",
+					"172.19.0.1:38682"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:11:59.640186881Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7068620101739055,
+				"StableID":   "nJtD3WfPCx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8a9be2fbaa5a1367c3290722c854f464346a7b7ea428f3bda0816499ebcd457",
+				"DiscoKey":   "discokey:d0339ea43781d13d0035d1435f9e8f2f17e0cf94481123d26ad0b30ea8c51b52",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39522",
+					"10.65.0.27:39522",
+					"172.17.0.1:39522",
+					"172.18.0.1:39522",
+					"172.19.0.1:39522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:12:00.15565341Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7031458668959897,
+				"StableID":   "nxWfUmVZuw11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b93cc735925eb2d5688ca13f0a4ae2b8ae04c35ab8e47aff4b55e8aebbe9ab22",
+				"DiscoKey":   "discokey:35093e8225f1040f91e4b438e178524f88553dadee8e7dacec4391c23ffc330f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:42311",
+					"10.65.0.27:42311",
+					"172.17.0.1:42311",
+					"172.18.0.1:42311",
+					"172.19.0.1:42311"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:12:00.70480488Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5198733611861902,
+				"StableID":   "n3R64AvWbh11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7202047580a18f66aa5f1fc49a868ea201bc7cd5dfc7b1b2b708dc1f4e802628",
+				"DiscoKey":   "discokey:9487c2395655e06d815632014f333bc68493a0fb9d69fc3f6be8788d7aafad5b",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34269",
+					"10.65.0.27:34269",
+					"172.17.0.1:34269",
+					"172.18.0.1:34269",
+					"172.19.0.1:34269"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:12:01.245172899Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3797042110872127,
+				"StableID":   "nkhiyjrgeW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:69849e8eab09ca566404106dde8a9cf154c370312a2cf8550c9557b338ee4e24",
+				"DiscoKey":   "discokey:ae68fde56e33eda5ea505196426d5e3d463ed294f8f39b6438ee0110e9444a5d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:59018",
+					"10.65.0.27:59018",
+					"172.17.0.1:59018",
+					"172.18.0.1:59018",
+					"172.19.0.1:59018"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:12:02.3243937Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5778490359501510,
+				"StableID":   "nPuPZJ968n11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b349d0ec6a01cb78dbc6e8334ab586fbde7bca3b9d6f3b698afb6c64ba741924",
+				"DiscoKey":   "discokey:d9f9026b8fcdce67bf746af048e7baea0f5de189bdb8af5fb35b1edaf98c6c41",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44441",
+					"10.65.0.27:44441",
+					"172.17.0.1:44441",
+					"172.18.0.1:44441",
+					"172.19.0.1:44441"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:12:02.856468022Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5728238856256014,
+				"StableID":   "nm67J38Ljm11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e0578f990ee630e03a83c235e647dd78731e28398e3599304c58f2f1a182142",
+				"DiscoKey":   "discokey:7833a5b00b623f8a3cf6ddaa9c03f1918556a71ccb602f35cef88ca7dd449b00",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38784",
+					"10.65.0.27:38784",
+					"172.17.0.1:38784",
+					"172.18.0.1:38784",
+					"172.19.0.1:38784"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:12:03.424194865Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4298882061670553,
+				"StableID":   "nCkfxqLyZa11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4cf45e85b38be0ef0134d9981158f71ec19fb8ca68a0712a32b338be3f96610c",
+				"DiscoKey":   "discokey:fdf89004ed5c514952553f76308347b756ccbe304c7e0dc041e4f5b784919b14",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33613",
+					"10.65.0.27:33613",
+					"172.17.0.1:33613",
+					"172.18.0.1:33613",
+					"172.19.0.1:33613"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:12:03.949250372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2288063618721240,
+				"StableID":   "n7S5tyYGsJ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:70a48e25d5debf34e49c694b24272b5aaf304e72b7e63f812fe40822254af662",
+				"DiscoKey":   "discokey:384afa65601a7d679514d36738598d330338e001c8b3a08a801934109c94491c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56035",
+					"10.65.0.27:56035",
+					"172.17.0.1:56035",
+					"172.18.0.1:56035",
+					"172.19.0.1:56035"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:12:04.516158854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8243980449292963,
+				"StableID":   "nx5v7TPiN721CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea2b7d8d1264b411404ff67f0ad440c74c5c6f45eadac2480a08511facf27b4c",
+				"DiscoKey":   "discokey:6e027ff21f6116184202cae7050c4ca03c7ad25fb9dd44c67a0c14a3fff17b30",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58884",
+					"10.65.0.27:58884",
+					"172.17.0.1:58884",
+					"172.18.0.1:58884",
+					"172.19.0.1:58884"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:12:05.060134199Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6580629105238557,
+				"StableID":   "n4J1j8yNPt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1e87f267764b8539a4b544082dd6a18cdc952d6b613da9ba89b6cf4afb730a32",
+				"DiscoKey":   "discokey:a491567ef7002d5ed47f0c086fdbe659f8b067de1b5e96d8be4c9e003453d854",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39438",
+					"10.65.0.27:39438",
+					"172.17.0.1:39438",
+					"172.18.0.1:39438",
+					"172.19.0.1:39438"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:12:05.589386892Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5815465531620617,
+				"StableID":   "nCGPuFRqQn11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:dacbccbe653dbe85ef34461de4e5ed6fc031516c8870b39e7a44f616be064e7d",
+				"KeyExpiry":  "2026-11-08T22:12:06Z",
+				"DiscoKey":   "discokey:a74800a72b8733af19ca1780330d14a7a1a898318cdb05e85c52ec5ca6d5ec22",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41994",
+					"10.65.0.27:41994",
+					"172.17.0.1:41994",
+					"172.18.0.1:41994",
+					"172.19.0.1:41994"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:12:06.159279306Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6653063879670959,
+				"StableID":   "nNQahyhBxt11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:20de44f0f9114cecba8ada3e3e6ea58120055ddb663d771137eb9778165b7c6d",
+				"KeyExpiry":  "2026-11-08T22:12:06Z",
+				"DiscoKey":   "discokey:61334ba9f1b936c9ba19a4c78fbc9612b5bb3c9578f631911a87eada5f07236f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40651",
+					"10.65.0.27:40651",
+					"172.17.0.1:40651",
+					"172.18.0.1:40651",
+					"172.19.0.1:40651"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:12:06.663606898Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5703680719812368,
+				"StableID":   "nf2dsC2DYm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:feaea4075d470d08e2844ad8ef68934f75ef2668211a97881857c6aac7b2f048",
+				"KeyExpiry":  "2026-11-08T22:12:07Z",
+				"DiscoKey":   "discokey:13842efc4412bf0e75e0194bfa21d15ffb91fb50d778bba72fe32c4795792801",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39244",
+					"10.65.0.27:39244",
+					"172.17.0.1:39244",
+					"172.18.0.1:39244",
+					"172.19.0.1:39244"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:12:07.214874702Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2301363068827519": {
+				"ID":          2301363068827519,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5198733611861902,
+				"StableID":   "n3R64AvWbh11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       5198733611861902,
+				"Key":        "nodekey:7202047580a18f66aa5f1fc49a868ea201bc7cd5dfc7b1b2b708dc1f4e802628",
+				"DiscoKey":   "discokey:9487c2395655e06d815632014f333bc68493a0fb9d69fc3f6be8788d7aafad5b",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34269",
+					"10.65.0.27:34269",
+					"172.17.0.1:34269",
+					"172.18.0.1:34269",
+					"172.19.0.1:34269"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:12:01.245172899Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7202047580a18f66aa5f1fc49a868ea201bc7cd5dfc7b1b2b708dc1f4e802628",
+			"MachineKey": "mkey:35c07a7ea4716da0afd9f983bf332a078661bcb44995997262bad353168ea215",
+			"Peers": [{
+				"ID":         4482450356427873,
+				"StableID":   "nLkuZTN71c11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89ccaa47993ae02031e6b7e51d611d37e7bc1ac28351159d29e1e3334131cb77",
+				"DiscoKey":   "discokey:93dbf266c2a3d7d0993d8f6f5237208d1ba798c5b9bb669d0d7e485ccb85b30d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38682",
+					"10.65.0.27:38682",
+					"172.17.0.1:38682",
+					"172.18.0.1:38682",
+					"172.19.0.1:38682"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:11:59.640186881Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7068620101739055,
+				"StableID":   "nJtD3WfPCx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8a9be2fbaa5a1367c3290722c854f464346a7b7ea428f3bda0816499ebcd457",
+				"DiscoKey":   "discokey:d0339ea43781d13d0035d1435f9e8f2f17e0cf94481123d26ad0b30ea8c51b52",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39522",
+					"10.65.0.27:39522",
+					"172.17.0.1:39522",
+					"172.18.0.1:39522",
+					"172.19.0.1:39522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:12:00.15565341Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7031458668959897,
+				"StableID":   "nxWfUmVZuw11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b93cc735925eb2d5688ca13f0a4ae2b8ae04c35ab8e47aff4b55e8aebbe9ab22",
+				"DiscoKey":   "discokey:35093e8225f1040f91e4b438e178524f88553dadee8e7dacec4391c23ffc330f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:42311",
+					"10.65.0.27:42311",
+					"172.17.0.1:42311",
+					"172.18.0.1:42311",
+					"172.19.0.1:42311"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:12:00.70480488Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2301363068827519,
+				"StableID":   "nU9CkWuHyJ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:78ed73b6b212e652b59f77c76c59166e508dc5a521fb99a0fc289f55b704b934",
+				"DiscoKey":   "discokey:1081c2e2239a9fa429e917dafa325dcd40073889a03f15fbf7a32722f682e06e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52820",
+					"10.65.0.27:52820",
+					"172.17.0.1:52820",
+					"172.18.0.1:52820",
+					"172.19.0.1:52820"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:12:01.789263606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3797042110872127,
+				"StableID":   "nkhiyjrgeW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:69849e8eab09ca566404106dde8a9cf154c370312a2cf8550c9557b338ee4e24",
+				"DiscoKey":   "discokey:ae68fde56e33eda5ea505196426d5e3d463ed294f8f39b6438ee0110e9444a5d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:59018",
+					"10.65.0.27:59018",
+					"172.17.0.1:59018",
+					"172.18.0.1:59018",
+					"172.19.0.1:59018"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:12:02.3243937Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5778490359501510,
+				"StableID":   "nPuPZJ968n11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b349d0ec6a01cb78dbc6e8334ab586fbde7bca3b9d6f3b698afb6c64ba741924",
+				"DiscoKey":   "discokey:d9f9026b8fcdce67bf746af048e7baea0f5de189bdb8af5fb35b1edaf98c6c41",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44441",
+					"10.65.0.27:44441",
+					"172.17.0.1:44441",
+					"172.18.0.1:44441",
+					"172.19.0.1:44441"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:12:02.856468022Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5728238856256014,
+				"StableID":   "nm67J38Ljm11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e0578f990ee630e03a83c235e647dd78731e28398e3599304c58f2f1a182142",
+				"DiscoKey":   "discokey:7833a5b00b623f8a3cf6ddaa9c03f1918556a71ccb602f35cef88ca7dd449b00",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38784",
+					"10.65.0.27:38784",
+					"172.17.0.1:38784",
+					"172.18.0.1:38784",
+					"172.19.0.1:38784"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:12:03.424194865Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4298882061670553,
+				"StableID":   "nCkfxqLyZa11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4cf45e85b38be0ef0134d9981158f71ec19fb8ca68a0712a32b338be3f96610c",
+				"DiscoKey":   "discokey:fdf89004ed5c514952553f76308347b756ccbe304c7e0dc041e4f5b784919b14",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33613",
+					"10.65.0.27:33613",
+					"172.17.0.1:33613",
+					"172.18.0.1:33613",
+					"172.19.0.1:33613"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:12:03.949250372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2288063618721240,
+				"StableID":   "n7S5tyYGsJ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:70a48e25d5debf34e49c694b24272b5aaf304e72b7e63f812fe40822254af662",
+				"DiscoKey":   "discokey:384afa65601a7d679514d36738598d330338e001c8b3a08a801934109c94491c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56035",
+					"10.65.0.27:56035",
+					"172.17.0.1:56035",
+					"172.18.0.1:56035",
+					"172.19.0.1:56035"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:12:04.516158854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8243980449292963,
+				"StableID":   "nx5v7TPiN721CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea2b7d8d1264b411404ff67f0ad440c74c5c6f45eadac2480a08511facf27b4c",
+				"DiscoKey":   "discokey:6e027ff21f6116184202cae7050c4ca03c7ad25fb9dd44c67a0c14a3fff17b30",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58884",
+					"10.65.0.27:58884",
+					"172.17.0.1:58884",
+					"172.18.0.1:58884",
+					"172.19.0.1:58884"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:12:05.060134199Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6580629105238557,
+				"StableID":   "n4J1j8yNPt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1e87f267764b8539a4b544082dd6a18cdc952d6b613da9ba89b6cf4afb730a32",
+				"DiscoKey":   "discokey:a491567ef7002d5ed47f0c086fdbe659f8b067de1b5e96d8be4c9e003453d854",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39438",
+					"10.65.0.27:39438",
+					"172.17.0.1:39438",
+					"172.18.0.1:39438",
+					"172.19.0.1:39438"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:12:05.589386892Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5815465531620617,
+				"StableID":   "nCGPuFRqQn11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:dacbccbe653dbe85ef34461de4e5ed6fc031516c8870b39e7a44f616be064e7d",
+				"KeyExpiry":  "2026-11-08T22:12:06Z",
+				"DiscoKey":   "discokey:a74800a72b8733af19ca1780330d14a7a1a898318cdb05e85c52ec5ca6d5ec22",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41994",
+					"10.65.0.27:41994",
+					"172.17.0.1:41994",
+					"172.18.0.1:41994",
+					"172.19.0.1:41994"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:12:06.159279306Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6653063879670959,
+				"StableID":   "nNQahyhBxt11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:20de44f0f9114cecba8ada3e3e6ea58120055ddb663d771137eb9778165b7c6d",
+				"KeyExpiry":  "2026-11-08T22:12:06Z",
+				"DiscoKey":   "discokey:61334ba9f1b936c9ba19a4c78fbc9612b5bb3c9578f631911a87eada5f07236f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40651",
+					"10.65.0.27:40651",
+					"172.17.0.1:40651",
+					"172.18.0.1:40651",
+					"172.19.0.1:40651"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:12:06.663606898Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5703680719812368,
+				"StableID":   "nf2dsC2DYm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:feaea4075d470d08e2844ad8ef68934f75ef2668211a97881857c6aac7b2f048",
+				"KeyExpiry":  "2026-11-08T22:12:07Z",
+				"DiscoKey":   "discokey:13842efc4412bf0e75e0194bfa21d15ffb91fb50d778bba72fe32c4795792801",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39244",
+					"10.65.0.27:39244",
+					"172.17.0.1:39244",
+					"172.18.0.1:39244",
+					"172.19.0.1:39244"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:12:07.214874702Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5198733611861902": {
+				"ID":          5198733611861902,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5778490359501510,
+				"StableID":   "nPuPZJ968n11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       5778490359501510,
+				"Key":        "nodekey:b349d0ec6a01cb78dbc6e8334ab586fbde7bca3b9d6f3b698afb6c64ba741924",
+				"DiscoKey":   "discokey:d9f9026b8fcdce67bf746af048e7baea0f5de189bdb8af5fb35b1edaf98c6c41",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44441",
+					"10.65.0.27:44441",
+					"172.17.0.1:44441",
+					"172.18.0.1:44441",
+					"172.19.0.1:44441"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:12:02.856468022Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b349d0ec6a01cb78dbc6e8334ab586fbde7bca3b9d6f3b698afb6c64ba741924",
+			"MachineKey": "mkey:5c16b16201c180686852959e430760ae5f09d6827c52ad6fd775af6c25e17932",
+			"Peers": [{
+				"ID":         4482450356427873,
+				"StableID":   "nLkuZTN71c11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89ccaa47993ae02031e6b7e51d611d37e7bc1ac28351159d29e1e3334131cb77",
+				"DiscoKey":   "discokey:93dbf266c2a3d7d0993d8f6f5237208d1ba798c5b9bb669d0d7e485ccb85b30d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38682",
+					"10.65.0.27:38682",
+					"172.17.0.1:38682",
+					"172.18.0.1:38682",
+					"172.19.0.1:38682"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:11:59.640186881Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7068620101739055,
+				"StableID":   "nJtD3WfPCx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8a9be2fbaa5a1367c3290722c854f464346a7b7ea428f3bda0816499ebcd457",
+				"DiscoKey":   "discokey:d0339ea43781d13d0035d1435f9e8f2f17e0cf94481123d26ad0b30ea8c51b52",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39522",
+					"10.65.0.27:39522",
+					"172.17.0.1:39522",
+					"172.18.0.1:39522",
+					"172.19.0.1:39522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:12:00.15565341Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7031458668959897,
+				"StableID":   "nxWfUmVZuw11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b93cc735925eb2d5688ca13f0a4ae2b8ae04c35ab8e47aff4b55e8aebbe9ab22",
+				"DiscoKey":   "discokey:35093e8225f1040f91e4b438e178524f88553dadee8e7dacec4391c23ffc330f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:42311",
+					"10.65.0.27:42311",
+					"172.17.0.1:42311",
+					"172.18.0.1:42311",
+					"172.19.0.1:42311"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:12:00.70480488Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5198733611861902,
+				"StableID":   "n3R64AvWbh11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7202047580a18f66aa5f1fc49a868ea201bc7cd5dfc7b1b2b708dc1f4e802628",
+				"DiscoKey":   "discokey:9487c2395655e06d815632014f333bc68493a0fb9d69fc3f6be8788d7aafad5b",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34269",
+					"10.65.0.27:34269",
+					"172.17.0.1:34269",
+					"172.18.0.1:34269",
+					"172.19.0.1:34269"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:12:01.245172899Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2301363068827519,
+				"StableID":   "nU9CkWuHyJ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:78ed73b6b212e652b59f77c76c59166e508dc5a521fb99a0fc289f55b704b934",
+				"DiscoKey":   "discokey:1081c2e2239a9fa429e917dafa325dcd40073889a03f15fbf7a32722f682e06e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52820",
+					"10.65.0.27:52820",
+					"172.17.0.1:52820",
+					"172.18.0.1:52820",
+					"172.19.0.1:52820"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:12:01.789263606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3797042110872127,
+				"StableID":   "nkhiyjrgeW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:69849e8eab09ca566404106dde8a9cf154c370312a2cf8550c9557b338ee4e24",
+				"DiscoKey":   "discokey:ae68fde56e33eda5ea505196426d5e3d463ed294f8f39b6438ee0110e9444a5d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:59018",
+					"10.65.0.27:59018",
+					"172.17.0.1:59018",
+					"172.18.0.1:59018",
+					"172.19.0.1:59018"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:12:02.3243937Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5728238856256014,
+				"StableID":   "nm67J38Ljm11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e0578f990ee630e03a83c235e647dd78731e28398e3599304c58f2f1a182142",
+				"DiscoKey":   "discokey:7833a5b00b623f8a3cf6ddaa9c03f1918556a71ccb602f35cef88ca7dd449b00",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38784",
+					"10.65.0.27:38784",
+					"172.17.0.1:38784",
+					"172.18.0.1:38784",
+					"172.19.0.1:38784"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:12:03.424194865Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4298882061670553,
+				"StableID":   "nCkfxqLyZa11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4cf45e85b38be0ef0134d9981158f71ec19fb8ca68a0712a32b338be3f96610c",
+				"DiscoKey":   "discokey:fdf89004ed5c514952553f76308347b756ccbe304c7e0dc041e4f5b784919b14",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33613",
+					"10.65.0.27:33613",
+					"172.17.0.1:33613",
+					"172.18.0.1:33613",
+					"172.19.0.1:33613"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:12:03.949250372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2288063618721240,
+				"StableID":   "n7S5tyYGsJ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:70a48e25d5debf34e49c694b24272b5aaf304e72b7e63f812fe40822254af662",
+				"DiscoKey":   "discokey:384afa65601a7d679514d36738598d330338e001c8b3a08a801934109c94491c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56035",
+					"10.65.0.27:56035",
+					"172.17.0.1:56035",
+					"172.18.0.1:56035",
+					"172.19.0.1:56035"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:12:04.516158854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8243980449292963,
+				"StableID":   "nx5v7TPiN721CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea2b7d8d1264b411404ff67f0ad440c74c5c6f45eadac2480a08511facf27b4c",
+				"DiscoKey":   "discokey:6e027ff21f6116184202cae7050c4ca03c7ad25fb9dd44c67a0c14a3fff17b30",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58884",
+					"10.65.0.27:58884",
+					"172.17.0.1:58884",
+					"172.18.0.1:58884",
+					"172.19.0.1:58884"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:12:05.060134199Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6580629105238557,
+				"StableID":   "n4J1j8yNPt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1e87f267764b8539a4b544082dd6a18cdc952d6b613da9ba89b6cf4afb730a32",
+				"DiscoKey":   "discokey:a491567ef7002d5ed47f0c086fdbe659f8b067de1b5e96d8be4c9e003453d854",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39438",
+					"10.65.0.27:39438",
+					"172.17.0.1:39438",
+					"172.18.0.1:39438",
+					"172.19.0.1:39438"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:12:05.589386892Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5815465531620617,
+				"StableID":   "nCGPuFRqQn11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:dacbccbe653dbe85ef34461de4e5ed6fc031516c8870b39e7a44f616be064e7d",
+				"KeyExpiry":  "2026-11-08T22:12:06Z",
+				"DiscoKey":   "discokey:a74800a72b8733af19ca1780330d14a7a1a898318cdb05e85c52ec5ca6d5ec22",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41994",
+					"10.65.0.27:41994",
+					"172.17.0.1:41994",
+					"172.18.0.1:41994",
+					"172.19.0.1:41994"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:12:06.159279306Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6653063879670959,
+				"StableID":   "nNQahyhBxt11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:20de44f0f9114cecba8ada3e3e6ea58120055ddb663d771137eb9778165b7c6d",
+				"KeyExpiry":  "2026-11-08T22:12:06Z",
+				"DiscoKey":   "discokey:61334ba9f1b936c9ba19a4c78fbc9612b5bb3c9578f631911a87eada5f07236f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40651",
+					"10.65.0.27:40651",
+					"172.17.0.1:40651",
+					"172.18.0.1:40651",
+					"172.19.0.1:40651"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:12:06.663606898Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5703680719812368,
+				"StableID":   "nf2dsC2DYm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:feaea4075d470d08e2844ad8ef68934f75ef2668211a97881857c6aac7b2f048",
+				"KeyExpiry":  "2026-11-08T22:12:07Z",
+				"DiscoKey":   "discokey:13842efc4412bf0e75e0194bfa21d15ffb91fb50d778bba72fe32c4795792801",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39244",
+					"10.65.0.27:39244",
+					"172.17.0.1:39244",
+					"172.18.0.1:39244",
+					"172.19.0.1:39244"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:12:07.214874702Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5778490359501510": {
+				"ID":          5778490359501510,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4298882061670553,
+				"StableID":   "nCkfxqLyZa11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       4298882061670553,
+				"Key":        "nodekey:4cf45e85b38be0ef0134d9981158f71ec19fb8ca68a0712a32b338be3f96610c",
+				"DiscoKey":   "discokey:fdf89004ed5c514952553f76308347b756ccbe304c7e0dc041e4f5b784919b14",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33613",
+					"10.65.0.27:33613",
+					"172.17.0.1:33613",
+					"172.18.0.1:33613",
+					"172.19.0.1:33613"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:12:03.949250372Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4cf45e85b38be0ef0134d9981158f71ec19fb8ca68a0712a32b338be3f96610c",
+			"MachineKey": "mkey:55db967baf17f4e4ea0883af10ae7cf98ced3813b07f1d9476972428c3720e07",
+			"Peers": [{
+				"ID":         4482450356427873,
+				"StableID":   "nLkuZTN71c11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89ccaa47993ae02031e6b7e51d611d37e7bc1ac28351159d29e1e3334131cb77",
+				"DiscoKey":   "discokey:93dbf266c2a3d7d0993d8f6f5237208d1ba798c5b9bb669d0d7e485ccb85b30d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38682",
+					"10.65.0.27:38682",
+					"172.17.0.1:38682",
+					"172.18.0.1:38682",
+					"172.19.0.1:38682"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:11:59.640186881Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7068620101739055,
+				"StableID":   "nJtD3WfPCx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8a9be2fbaa5a1367c3290722c854f464346a7b7ea428f3bda0816499ebcd457",
+				"DiscoKey":   "discokey:d0339ea43781d13d0035d1435f9e8f2f17e0cf94481123d26ad0b30ea8c51b52",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39522",
+					"10.65.0.27:39522",
+					"172.17.0.1:39522",
+					"172.18.0.1:39522",
+					"172.19.0.1:39522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:12:00.15565341Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7031458668959897,
+				"StableID":   "nxWfUmVZuw11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b93cc735925eb2d5688ca13f0a4ae2b8ae04c35ab8e47aff4b55e8aebbe9ab22",
+				"DiscoKey":   "discokey:35093e8225f1040f91e4b438e178524f88553dadee8e7dacec4391c23ffc330f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:42311",
+					"10.65.0.27:42311",
+					"172.17.0.1:42311",
+					"172.18.0.1:42311",
+					"172.19.0.1:42311"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:12:00.70480488Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5198733611861902,
+				"StableID":   "n3R64AvWbh11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7202047580a18f66aa5f1fc49a868ea201bc7cd5dfc7b1b2b708dc1f4e802628",
+				"DiscoKey":   "discokey:9487c2395655e06d815632014f333bc68493a0fb9d69fc3f6be8788d7aafad5b",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34269",
+					"10.65.0.27:34269",
+					"172.17.0.1:34269",
+					"172.18.0.1:34269",
+					"172.19.0.1:34269"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:12:01.245172899Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2301363068827519,
+				"StableID":   "nU9CkWuHyJ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:78ed73b6b212e652b59f77c76c59166e508dc5a521fb99a0fc289f55b704b934",
+				"DiscoKey":   "discokey:1081c2e2239a9fa429e917dafa325dcd40073889a03f15fbf7a32722f682e06e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52820",
+					"10.65.0.27:52820",
+					"172.17.0.1:52820",
+					"172.18.0.1:52820",
+					"172.19.0.1:52820"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:12:01.789263606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3797042110872127,
+				"StableID":   "nkhiyjrgeW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:69849e8eab09ca566404106dde8a9cf154c370312a2cf8550c9557b338ee4e24",
+				"DiscoKey":   "discokey:ae68fde56e33eda5ea505196426d5e3d463ed294f8f39b6438ee0110e9444a5d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:59018",
+					"10.65.0.27:59018",
+					"172.17.0.1:59018",
+					"172.18.0.1:59018",
+					"172.19.0.1:59018"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:12:02.3243937Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5778490359501510,
+				"StableID":   "nPuPZJ968n11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b349d0ec6a01cb78dbc6e8334ab586fbde7bca3b9d6f3b698afb6c64ba741924",
+				"DiscoKey":   "discokey:d9f9026b8fcdce67bf746af048e7baea0f5de189bdb8af5fb35b1edaf98c6c41",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44441",
+					"10.65.0.27:44441",
+					"172.17.0.1:44441",
+					"172.18.0.1:44441",
+					"172.19.0.1:44441"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:12:02.856468022Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5728238856256014,
+				"StableID":   "nm67J38Ljm11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e0578f990ee630e03a83c235e647dd78731e28398e3599304c58f2f1a182142",
+				"DiscoKey":   "discokey:7833a5b00b623f8a3cf6ddaa9c03f1918556a71ccb602f35cef88ca7dd449b00",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38784",
+					"10.65.0.27:38784",
+					"172.17.0.1:38784",
+					"172.18.0.1:38784",
+					"172.19.0.1:38784"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:12:03.424194865Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2288063618721240,
+				"StableID":   "n7S5tyYGsJ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:70a48e25d5debf34e49c694b24272b5aaf304e72b7e63f812fe40822254af662",
+				"DiscoKey":   "discokey:384afa65601a7d679514d36738598d330338e001c8b3a08a801934109c94491c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56035",
+					"10.65.0.27:56035",
+					"172.17.0.1:56035",
+					"172.18.0.1:56035",
+					"172.19.0.1:56035"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:12:04.516158854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8243980449292963,
+				"StableID":   "nx5v7TPiN721CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea2b7d8d1264b411404ff67f0ad440c74c5c6f45eadac2480a08511facf27b4c",
+				"DiscoKey":   "discokey:6e027ff21f6116184202cae7050c4ca03c7ad25fb9dd44c67a0c14a3fff17b30",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58884",
+					"10.65.0.27:58884",
+					"172.17.0.1:58884",
+					"172.18.0.1:58884",
+					"172.19.0.1:58884"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:12:05.060134199Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6580629105238557,
+				"StableID":   "n4J1j8yNPt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1e87f267764b8539a4b544082dd6a18cdc952d6b613da9ba89b6cf4afb730a32",
+				"DiscoKey":   "discokey:a491567ef7002d5ed47f0c086fdbe659f8b067de1b5e96d8be4c9e003453d854",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39438",
+					"10.65.0.27:39438",
+					"172.17.0.1:39438",
+					"172.18.0.1:39438",
+					"172.19.0.1:39438"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:12:05.589386892Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5815465531620617,
+				"StableID":   "nCGPuFRqQn11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:dacbccbe653dbe85ef34461de4e5ed6fc031516c8870b39e7a44f616be064e7d",
+				"KeyExpiry":  "2026-11-08T22:12:06Z",
+				"DiscoKey":   "discokey:a74800a72b8733af19ca1780330d14a7a1a898318cdb05e85c52ec5ca6d5ec22",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41994",
+					"10.65.0.27:41994",
+					"172.17.0.1:41994",
+					"172.18.0.1:41994",
+					"172.19.0.1:41994"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:12:06.159279306Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6653063879670959,
+				"StableID":   "nNQahyhBxt11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:20de44f0f9114cecba8ada3e3e6ea58120055ddb663d771137eb9778165b7c6d",
+				"KeyExpiry":  "2026-11-08T22:12:06Z",
+				"DiscoKey":   "discokey:61334ba9f1b936c9ba19a4c78fbc9612b5bb3c9578f631911a87eada5f07236f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40651",
+					"10.65.0.27:40651",
+					"172.17.0.1:40651",
+					"172.18.0.1:40651",
+					"172.19.0.1:40651"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:12:06.663606898Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5703680719812368,
+				"StableID":   "nf2dsC2DYm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:feaea4075d470d08e2844ad8ef68934f75ef2668211a97881857c6aac7b2f048",
+				"KeyExpiry":  "2026-11-08T22:12:07Z",
+				"DiscoKey":   "discokey:13842efc4412bf0e75e0194bfa21d15ffb91fb50d778bba72fe32c4795792801",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39244",
+					"10.65.0.27:39244",
+					"172.17.0.1:39244",
+					"172.18.0.1:39244",
+					"172.19.0.1:39244"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:12:07.214874702Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4298882061670553": {
+				"ID":          4298882061670553,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6653063879670959,
+				"StableID":   "nNQahyhBxt11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:20de44f0f9114cecba8ada3e3e6ea58120055ddb663d771137eb9778165b7c6d",
+				"KeyExpiry":  "2026-11-08T22:12:06Z",
+				"DiscoKey":   "discokey:61334ba9f1b936c9ba19a4c78fbc9612b5bb3c9578f631911a87eada5f07236f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40651",
+					"10.65.0.27:40651",
+					"172.17.0.1:40651",
+					"172.18.0.1:40651",
+					"172.19.0.1:40651"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:12:06.663606898Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:20de44f0f9114cecba8ada3e3e6ea58120055ddb663d771137eb9778165b7c6d",
+			"MachineKey": "mkey:005a2ee6c0b355cb61cc8621d917e52791cf75230950fa5901fbe2c88fcea947",
+			"Peers": [{
+				"ID":         4482450356427873,
+				"StableID":   "nLkuZTN71c11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89ccaa47993ae02031e6b7e51d611d37e7bc1ac28351159d29e1e3334131cb77",
+				"DiscoKey":   "discokey:93dbf266c2a3d7d0993d8f6f5237208d1ba798c5b9bb669d0d7e485ccb85b30d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38682",
+					"10.65.0.27:38682",
+					"172.17.0.1:38682",
+					"172.18.0.1:38682",
+					"172.19.0.1:38682"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:11:59.640186881Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7068620101739055,
+				"StableID":   "nJtD3WfPCx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8a9be2fbaa5a1367c3290722c854f464346a7b7ea428f3bda0816499ebcd457",
+				"DiscoKey":   "discokey:d0339ea43781d13d0035d1435f9e8f2f17e0cf94481123d26ad0b30ea8c51b52",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39522",
+					"10.65.0.27:39522",
+					"172.17.0.1:39522",
+					"172.18.0.1:39522",
+					"172.19.0.1:39522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:12:00.15565341Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7031458668959897,
+				"StableID":   "nxWfUmVZuw11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b93cc735925eb2d5688ca13f0a4ae2b8ae04c35ab8e47aff4b55e8aebbe9ab22",
+				"DiscoKey":   "discokey:35093e8225f1040f91e4b438e178524f88553dadee8e7dacec4391c23ffc330f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:42311",
+					"10.65.0.27:42311",
+					"172.17.0.1:42311",
+					"172.18.0.1:42311",
+					"172.19.0.1:42311"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:12:00.70480488Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5198733611861902,
+				"StableID":   "n3R64AvWbh11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7202047580a18f66aa5f1fc49a868ea201bc7cd5dfc7b1b2b708dc1f4e802628",
+				"DiscoKey":   "discokey:9487c2395655e06d815632014f333bc68493a0fb9d69fc3f6be8788d7aafad5b",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34269",
+					"10.65.0.27:34269",
+					"172.17.0.1:34269",
+					"172.18.0.1:34269",
+					"172.19.0.1:34269"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:12:01.245172899Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2301363068827519,
+				"StableID":   "nU9CkWuHyJ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:78ed73b6b212e652b59f77c76c59166e508dc5a521fb99a0fc289f55b704b934",
+				"DiscoKey":   "discokey:1081c2e2239a9fa429e917dafa325dcd40073889a03f15fbf7a32722f682e06e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52820",
+					"10.65.0.27:52820",
+					"172.17.0.1:52820",
+					"172.18.0.1:52820",
+					"172.19.0.1:52820"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:12:01.789263606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3797042110872127,
+				"StableID":   "nkhiyjrgeW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:69849e8eab09ca566404106dde8a9cf154c370312a2cf8550c9557b338ee4e24",
+				"DiscoKey":   "discokey:ae68fde56e33eda5ea505196426d5e3d463ed294f8f39b6438ee0110e9444a5d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:59018",
+					"10.65.0.27:59018",
+					"172.17.0.1:59018",
+					"172.18.0.1:59018",
+					"172.19.0.1:59018"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:12:02.3243937Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5778490359501510,
+				"StableID":   "nPuPZJ968n11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b349d0ec6a01cb78dbc6e8334ab586fbde7bca3b9d6f3b698afb6c64ba741924",
+				"DiscoKey":   "discokey:d9f9026b8fcdce67bf746af048e7baea0f5de189bdb8af5fb35b1edaf98c6c41",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44441",
+					"10.65.0.27:44441",
+					"172.17.0.1:44441",
+					"172.18.0.1:44441",
+					"172.19.0.1:44441"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:12:02.856468022Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5728238856256014,
+				"StableID":   "nm67J38Ljm11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e0578f990ee630e03a83c235e647dd78731e28398e3599304c58f2f1a182142",
+				"DiscoKey":   "discokey:7833a5b00b623f8a3cf6ddaa9c03f1918556a71ccb602f35cef88ca7dd449b00",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38784",
+					"10.65.0.27:38784",
+					"172.17.0.1:38784",
+					"172.18.0.1:38784",
+					"172.19.0.1:38784"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:12:03.424194865Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4298882061670553,
+				"StableID":   "nCkfxqLyZa11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4cf45e85b38be0ef0134d9981158f71ec19fb8ca68a0712a32b338be3f96610c",
+				"DiscoKey":   "discokey:fdf89004ed5c514952553f76308347b756ccbe304c7e0dc041e4f5b784919b14",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33613",
+					"10.65.0.27:33613",
+					"172.17.0.1:33613",
+					"172.18.0.1:33613",
+					"172.19.0.1:33613"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:12:03.949250372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2288063618721240,
+				"StableID":   "n7S5tyYGsJ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:70a48e25d5debf34e49c694b24272b5aaf304e72b7e63f812fe40822254af662",
+				"DiscoKey":   "discokey:384afa65601a7d679514d36738598d330338e001c8b3a08a801934109c94491c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56035",
+					"10.65.0.27:56035",
+					"172.17.0.1:56035",
+					"172.18.0.1:56035",
+					"172.19.0.1:56035"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:12:04.516158854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8243980449292963,
+				"StableID":   "nx5v7TPiN721CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea2b7d8d1264b411404ff67f0ad440c74c5c6f45eadac2480a08511facf27b4c",
+				"DiscoKey":   "discokey:6e027ff21f6116184202cae7050c4ca03c7ad25fb9dd44c67a0c14a3fff17b30",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58884",
+					"10.65.0.27:58884",
+					"172.17.0.1:58884",
+					"172.18.0.1:58884",
+					"172.19.0.1:58884"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:12:05.060134199Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6580629105238557,
+				"StableID":   "n4J1j8yNPt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1e87f267764b8539a4b544082dd6a18cdc952d6b613da9ba89b6cf4afb730a32",
+				"DiscoKey":   "discokey:a491567ef7002d5ed47f0c086fdbe659f8b067de1b5e96d8be4c9e003453d854",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39438",
+					"10.65.0.27:39438",
+					"172.17.0.1:39438",
+					"172.18.0.1:39438",
+					"172.19.0.1:39438"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:12:05.589386892Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5815465531620617,
+				"StableID":   "nCGPuFRqQn11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:dacbccbe653dbe85ef34461de4e5ed6fc031516c8870b39e7a44f616be064e7d",
+				"KeyExpiry":  "2026-11-08T22:12:06Z",
+				"DiscoKey":   "discokey:a74800a72b8733af19ca1780330d14a7a1a898318cdb05e85c52ec5ca6d5ec22",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41994",
+					"10.65.0.27:41994",
+					"172.17.0.1:41994",
+					"172.18.0.1:41994",
+					"172.19.0.1:41994"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:12:06.159279306Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5703680719812368,
+				"StableID":   "nf2dsC2DYm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:feaea4075d470d08e2844ad8ef68934f75ef2668211a97881857c6aac7b2f048",
+				"KeyExpiry":  "2026-11-08T22:12:07Z",
+				"DiscoKey":   "discokey:13842efc4412bf0e75e0194bfa21d15ffb91fb50d778bba72fe32c4795792801",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39244",
+					"10.65.0.27:39244",
+					"172.17.0.1:39244",
+					"172.18.0.1:39244",
+					"172.19.0.1:39244"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:12:07.214874702Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2288063618721240,
+				"StableID":   "n7S5tyYGsJ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       2288063618721240,
+				"Key":        "nodekey:70a48e25d5debf34e49c694b24272b5aaf304e72b7e63f812fe40822254af662",
+				"DiscoKey":   "discokey:384afa65601a7d679514d36738598d330338e001c8b3a08a801934109c94491c",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:56035",
+					"10.65.0.27:56035",
+					"172.17.0.1:56035",
+					"172.18.0.1:56035",
+					"172.19.0.1:56035"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:12:04.516158854Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:70a48e25d5debf34e49c694b24272b5aaf304e72b7e63f812fe40822254af662",
+			"MachineKey": "mkey:8265e1aaf2371c877fe8a88cb0d9ab1164a4708e7d0afad70efee42bf5b9785f",
+			"Peers": [{
+				"ID":         4482450356427873,
+				"StableID":   "nLkuZTN71c11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89ccaa47993ae02031e6b7e51d611d37e7bc1ac28351159d29e1e3334131cb77",
+				"DiscoKey":   "discokey:93dbf266c2a3d7d0993d8f6f5237208d1ba798c5b9bb669d0d7e485ccb85b30d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38682",
+					"10.65.0.27:38682",
+					"172.17.0.1:38682",
+					"172.18.0.1:38682",
+					"172.19.0.1:38682"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:11:59.640186881Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7068620101739055,
+				"StableID":   "nJtD3WfPCx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8a9be2fbaa5a1367c3290722c854f464346a7b7ea428f3bda0816499ebcd457",
+				"DiscoKey":   "discokey:d0339ea43781d13d0035d1435f9e8f2f17e0cf94481123d26ad0b30ea8c51b52",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39522",
+					"10.65.0.27:39522",
+					"172.17.0.1:39522",
+					"172.18.0.1:39522",
+					"172.19.0.1:39522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:12:00.15565341Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7031458668959897,
+				"StableID":   "nxWfUmVZuw11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b93cc735925eb2d5688ca13f0a4ae2b8ae04c35ab8e47aff4b55e8aebbe9ab22",
+				"DiscoKey":   "discokey:35093e8225f1040f91e4b438e178524f88553dadee8e7dacec4391c23ffc330f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:42311",
+					"10.65.0.27:42311",
+					"172.17.0.1:42311",
+					"172.18.0.1:42311",
+					"172.19.0.1:42311"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:12:00.70480488Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5198733611861902,
+				"StableID":   "n3R64AvWbh11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7202047580a18f66aa5f1fc49a868ea201bc7cd5dfc7b1b2b708dc1f4e802628",
+				"DiscoKey":   "discokey:9487c2395655e06d815632014f333bc68493a0fb9d69fc3f6be8788d7aafad5b",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34269",
+					"10.65.0.27:34269",
+					"172.17.0.1:34269",
+					"172.18.0.1:34269",
+					"172.19.0.1:34269"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:12:01.245172899Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2301363068827519,
+				"StableID":   "nU9CkWuHyJ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:78ed73b6b212e652b59f77c76c59166e508dc5a521fb99a0fc289f55b704b934",
+				"DiscoKey":   "discokey:1081c2e2239a9fa429e917dafa325dcd40073889a03f15fbf7a32722f682e06e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52820",
+					"10.65.0.27:52820",
+					"172.17.0.1:52820",
+					"172.18.0.1:52820",
+					"172.19.0.1:52820"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:12:01.789263606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3797042110872127,
+				"StableID":   "nkhiyjrgeW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:69849e8eab09ca566404106dde8a9cf154c370312a2cf8550c9557b338ee4e24",
+				"DiscoKey":   "discokey:ae68fde56e33eda5ea505196426d5e3d463ed294f8f39b6438ee0110e9444a5d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:59018",
+					"10.65.0.27:59018",
+					"172.17.0.1:59018",
+					"172.18.0.1:59018",
+					"172.19.0.1:59018"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:12:02.3243937Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5778490359501510,
+				"StableID":   "nPuPZJ968n11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b349d0ec6a01cb78dbc6e8334ab586fbde7bca3b9d6f3b698afb6c64ba741924",
+				"DiscoKey":   "discokey:d9f9026b8fcdce67bf746af048e7baea0f5de189bdb8af5fb35b1edaf98c6c41",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44441",
+					"10.65.0.27:44441",
+					"172.17.0.1:44441",
+					"172.18.0.1:44441",
+					"172.19.0.1:44441"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:12:02.856468022Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5728238856256014,
+				"StableID":   "nm67J38Ljm11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e0578f990ee630e03a83c235e647dd78731e28398e3599304c58f2f1a182142",
+				"DiscoKey":   "discokey:7833a5b00b623f8a3cf6ddaa9c03f1918556a71ccb602f35cef88ca7dd449b00",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38784",
+					"10.65.0.27:38784",
+					"172.17.0.1:38784",
+					"172.18.0.1:38784",
+					"172.19.0.1:38784"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:12:03.424194865Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4298882061670553,
+				"StableID":   "nCkfxqLyZa11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4cf45e85b38be0ef0134d9981158f71ec19fb8ca68a0712a32b338be3f96610c",
+				"DiscoKey":   "discokey:fdf89004ed5c514952553f76308347b756ccbe304c7e0dc041e4f5b784919b14",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:33613",
+					"10.65.0.27:33613",
+					"172.17.0.1:33613",
+					"172.18.0.1:33613",
+					"172.19.0.1:33613"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:12:03.949250372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8243980449292963,
+				"StableID":   "nx5v7TPiN721CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea2b7d8d1264b411404ff67f0ad440c74c5c6f45eadac2480a08511facf27b4c",
+				"DiscoKey":   "discokey:6e027ff21f6116184202cae7050c4ca03c7ad25fb9dd44c67a0c14a3fff17b30",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58884",
+					"10.65.0.27:58884",
+					"172.17.0.1:58884",
+					"172.18.0.1:58884",
+					"172.19.0.1:58884"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:12:05.060134199Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6580629105238557,
+				"StableID":   "n4J1j8yNPt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1e87f267764b8539a4b544082dd6a18cdc952d6b613da9ba89b6cf4afb730a32",
+				"DiscoKey":   "discokey:a491567ef7002d5ed47f0c086fdbe659f8b067de1b5e96d8be4c9e003453d854",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39438",
+					"10.65.0.27:39438",
+					"172.17.0.1:39438",
+					"172.18.0.1:39438",
+					"172.19.0.1:39438"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:12:05.589386892Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5815465531620617,
+				"StableID":   "nCGPuFRqQn11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:dacbccbe653dbe85ef34461de4e5ed6fc031516c8870b39e7a44f616be064e7d",
+				"KeyExpiry":  "2026-11-08T22:12:06Z",
+				"DiscoKey":   "discokey:a74800a72b8733af19ca1780330d14a7a1a898318cdb05e85c52ec5ca6d5ec22",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41994",
+					"10.65.0.27:41994",
+					"172.17.0.1:41994",
+					"172.18.0.1:41994",
+					"172.19.0.1:41994"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:12:06.159279306Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6653063879670959,
+				"StableID":   "nNQahyhBxt11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:20de44f0f9114cecba8ada3e3e6ea58120055ddb663d771137eb9778165b7c6d",
+				"KeyExpiry":  "2026-11-08T22:12:06Z",
+				"DiscoKey":   "discokey:61334ba9f1b936c9ba19a4c78fbc9612b5bb3c9578f631911a87eada5f07236f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40651",
+					"10.65.0.27:40651",
+					"172.17.0.1:40651",
+					"172.18.0.1:40651",
+					"172.19.0.1:40651"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T22:12:06.663606898Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5703680719812368,
+				"StableID":   "nf2dsC2DYm11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:feaea4075d470d08e2844ad8ef68934f75ef2668211a97881857c6aac7b2f048",
+				"KeyExpiry":  "2026-11-08T22:12:07Z",
+				"DiscoKey":   "discokey:13842efc4412bf0e75e0194bfa21d15ffb91fb50d778bba72fe32c4795792801",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39244",
+					"10.65.0.27:39244",
+					"172.17.0.1:39244",
+					"172.18.0.1:39244",
+					"172.19.0.1:39244"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:12:07.214874702Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2288063618721240": {
+				"ID":          2288063618721240,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-users-empty-array.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-users-empty-array.hujson
@@ -1,0 +1,20081 @@
+// ssh-malformed-users-empty-array
+//
+// ssh users empty array is rejected
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T22:12:43Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-malformed-users-empty-array",
+	"description":    "ssh users empty array is rejected",
+	"category":       "ssh",
+	"captured_at":    "2026-05-12T22:12:43.252756002Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "users must be specified"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                  \n  \n                                                                   \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh users empty array is rejected\",\n\t\"id\":          \"ssh-malformed-users-empty-array\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"autogroup:member\"],\n\t\t\"users\":  []\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-malformed/ssh-malformed-users-empty-array.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["autogroup:member"],
+				"users":  []
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         971317712465959,
+				"StableID":   "n4DW8Rsua811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       971317712465959,
+				"Key":        "nodekey:2423c5b4f5c9edae93f90c45305d3b7870ea1702d1444b920ea3645fdc055144",
+				"DiscoKey":   "discokey:42233904dacf1e0a90385252014c0fcebbc7fe6bd02c6e59864de89b05a51840",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:51807",
+					"10.65.0.27:51807",
+					"172.17.0.1:51807",
+					"172.18.0.1:51807",
+					"172.19.0.1:51807"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:12:51.879745394Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2423c5b4f5c9edae93f90c45305d3b7870ea1702d1444b920ea3645fdc055144",
+			"MachineKey": "mkey:3db932aa7e451fa806e019dec52a1f17e3e67d22cf67b49e680c24f2f7a57802",
+			"Peers": [{
+				"ID":         5558691465482482,
+				"StableID":   "n3Xgx8QYQk11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:98da7e6ebf8ab5100951b5ebd79e39565b462ba85ba10594372fefac12e13e4f",
+				"DiscoKey":   "discokey:d77cd03005778ec806410b6f34bf2d47594599a95e7e996ae8fdaab2c06d5833",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52099",
+					"10.65.0.27:52099",
+					"172.17.0.1:52099",
+					"172.18.0.1:52099",
+					"172.19.0.1:52099"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:12:45.895894102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2206922408666095,
+				"StableID":   "nzLB1M7XEJ11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6edecf637d1b72e078156a22394d4dea7a16953906de2b417697931a7b75d95a",
+				"DiscoKey":   "discokey:77b4a430760c4e5e669aed761df404a289f2b301e4f7f4a92d9c44a5e4655d69",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45931",
+					"10.65.0.27:45931",
+					"172.17.0.1:45931",
+					"172.18.0.1:45931",
+					"172.19.0.1:45931"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:12:46.432801487Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5087440775102692,
+				"StableID":   "nD74BfS7jg11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ac08d7f0ad82e0cf1efaed80e4d336b833be51646e01dfddcbbfb90616562015",
+				"DiscoKey":   "discokey:27ae7f82f4530a342d62ad2ca67b5d5243677aabdc10f75de8a39b08f99ca33c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45214",
+					"10.65.0.27:45214",
+					"172.17.0.1:45214",
+					"172.18.0.1:45214",
+					"172.19.0.1:45214"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:12:46.973792182Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1463992035291258,
+				"StableID":   "nKXJx7b3SC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c1648acb6e82abc453d71465082c59b7108146bb5c9be5c0edd1e7e872d2b34",
+				"DiscoKey":   "discokey:5a0846834e752129434d425e6ed3d66c79e20a731528398ec7695b6cd3e24151",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39677",
+					"10.65.0.27:39677",
+					"172.17.0.1:39677",
+					"172.18.0.1:39677",
+					"172.19.0.1:39677"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:12:47.535215898Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2480455672107944,
+				"StableID":   "nPpip8NQNL11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85bcf32b5f8933f2af2a029dfed5757e4d5bc9d6bdbf46b6292974e6d11d527b",
+				"DiscoKey":   "discokey:6b4d856936c08e772ed5713cac5bd2579ef6ddfc640c5ea0ec977b0411a6433a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40590",
+					"10.65.0.27:40590",
+					"172.17.0.1:40590",
+					"172.18.0.1:40590",
+					"172.19.0.1:40590"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:12:48.057525716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7114218108595119,
+				"StableID":   "nQV9msS3Zx11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:92264e4a656982c2b4c9ecd1ea8706eff37454995799a365538a1bc2a578a977",
+				"DiscoKey":   "discokey:87c7b9d30e4fc5485801aab92dcca177fdc08174d854877f6149c48ebc820328",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44686",
+					"10.65.0.27:44686",
+					"172.17.0.1:44686",
+					"172.18.0.1:44686",
+					"172.19.0.1:44686"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:12:48.593717138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         260808352712436,
+				"StableID":   "nKru2cz73311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:98ba75410c7c8aecb67b493832dd55d7b672eae4998f6d037a70c79993a5e47e",
+				"DiscoKey":   "discokey:fc65e0de86703d23c2c72177a4436550fec98676e3afc4afbbd1d0d5e8012e7f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58429",
+					"10.65.0.27:58429",
+					"172.17.0.1:58429",
+					"172.18.0.1:58429",
+					"172.19.0.1:58429"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:12:49.151757463Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1971300116950462,
+				"StableID":   "n3fDwFioPG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3ee77c1577449a8fb4517c9c85572898604082042524b52df393f82fe9426a48",
+				"DiscoKey":   "discokey:b5162837376348737a9da5579379b3528d5fb49e913972a776e38c75e180df07",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33235",
+					"10.65.0.27:33235",
+					"172.17.0.1:33235",
+					"172.18.0.1:33235",
+					"172.19.0.1:33235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:12:49.686954161Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1646544989659953,
+				"StableID":   "n4veQowirD11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6db7a8dd2b93e1b09c9af4d174c56c946d1eec7586bea5c75e9b624375f3442b",
+				"DiscoKey":   "discokey:08b1d5bc63e8dacfb078a9b276ea59f8ef1e2f00ce868e429324f4f19a7dac56",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35595",
+					"10.65.0.27:35595",
+					"172.17.0.1:35595",
+					"172.18.0.1:35595",
+					"172.19.0.1:35595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:12:50.224096993Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4729479275972653,
+				"StableID":   "nY64HFQzvd11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fa4ddc2510af5be8da1d02db19dfd6dca0757a89b80876a4559f3f92817a66d",
+				"DiscoKey":   "discokey:05b6f7f61be43bdebf3e2e95d20c44cdfc8c8d733b7f516c885a2cb26e5fa87f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49048",
+					"10.65.0.27:49048",
+					"172.17.0.1:49048",
+					"172.18.0.1:49048",
+					"172.19.0.1:49048"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:12:50.773768448Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1199415976500311,
+				"StableID":   "nWSudBdDNA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dec8653cbd3d5d0ee3a5b10a993c99b60c84dd72074e8acb2918a92543fef427",
+				"DiscoKey":   "discokey:d30ce9a476f5336971eeebc984ae0e2a29da3108f95fbe3b942b95cda9ded30f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:47936",
+					"10.65.0.27:47936",
+					"172.17.0.1:47936",
+					"172.18.0.1:47936",
+					"172.19.0.1:47936"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:12:51.31963675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3825410319579337,
+				"StableID":   "nnoTST3YsW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:575d39df85f32cbc5540e280d2942b58f50ba4fe65028d1edcdd2df04784983f",
+				"KeyExpiry":  "2026-11-08T22:12:52Z",
+				"DiscoKey":   "discokey:4c5ad71c45fdc9d2bfb8e9dff930492d92f6aaf5812938a94391470c03294144",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45129",
+					"10.65.0.27:45129",
+					"172.17.0.1:45129",
+					"172.18.0.1:45129",
+					"172.19.0.1:45129"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:12:52.411276822Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3821327416286260,
+				"StableID":   "nPzrFungqW11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b62feb33325b189d0b914fece2a1a61646a8835f0d3ae218442efdba998b3050",
+				"KeyExpiry":  "2026-11-08T22:12:52Z",
+				"DiscoKey":   "discokey:4b44846593f049e412a81cd20a3b735218d8cf62703f766e363da0133a63e65e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:42957",
+					"10.65.0.27:42957",
+					"172.17.0.1:42957",
+					"172.18.0.1:42957",
+					"172.19.0.1:42957"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 53165},
+					{"Proto": "peerapi6", "Port": 53165}
+				]},
+				"Created":              "2026-05-12T22:12:52.93257841Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5252472108465548,
+				"StableID":   "nBaoy4Yr1i11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:4d379b7250c65dba4fb229035fc5058a4550c621af42f5b7b25972bfd3f35422",
+				"KeyExpiry":  "2026-11-08T22:12:53Z",
+				"DiscoKey":   "discokey:e724c69890c6b6c097034c88982f335258d0bfee0ee143fcfd1f9bb7fc2c4c6f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59814",
+					"10.65.0.27:59814",
+					"172.17.0.1:59814",
+					"172.18.0.1:59814",
+					"172.19.0.1:59814"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:12:53.46976722Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "971317712465959": {
+				"ID":          971317712465959,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7114218108595119,
+				"StableID":   "nQV9msS3Zx11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       7114218108595119,
+				"Key":        "nodekey:92264e4a656982c2b4c9ecd1ea8706eff37454995799a365538a1bc2a578a977",
+				"DiscoKey":   "discokey:87c7b9d30e4fc5485801aab92dcca177fdc08174d854877f6149c48ebc820328",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44686",
+					"10.65.0.27:44686",
+					"172.17.0.1:44686",
+					"172.18.0.1:44686",
+					"172.19.0.1:44686"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:12:48.593717138Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:92264e4a656982c2b4c9ecd1ea8706eff37454995799a365538a1bc2a578a977",
+			"MachineKey": "mkey:85b3802c89a41b62592ce2dfa67576fe67e763d9821f43362bf965723477de10",
+			"Peers": [{
+				"ID":         5558691465482482,
+				"StableID":   "n3Xgx8QYQk11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:98da7e6ebf8ab5100951b5ebd79e39565b462ba85ba10594372fefac12e13e4f",
+				"DiscoKey":   "discokey:d77cd03005778ec806410b6f34bf2d47594599a95e7e996ae8fdaab2c06d5833",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52099",
+					"10.65.0.27:52099",
+					"172.17.0.1:52099",
+					"172.18.0.1:52099",
+					"172.19.0.1:52099"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:12:45.895894102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2206922408666095,
+				"StableID":   "nzLB1M7XEJ11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6edecf637d1b72e078156a22394d4dea7a16953906de2b417697931a7b75d95a",
+				"DiscoKey":   "discokey:77b4a430760c4e5e669aed761df404a289f2b301e4f7f4a92d9c44a5e4655d69",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45931",
+					"10.65.0.27:45931",
+					"172.17.0.1:45931",
+					"172.18.0.1:45931",
+					"172.19.0.1:45931"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:12:46.432801487Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5087440775102692,
+				"StableID":   "nD74BfS7jg11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ac08d7f0ad82e0cf1efaed80e4d336b833be51646e01dfddcbbfb90616562015",
+				"DiscoKey":   "discokey:27ae7f82f4530a342d62ad2ca67b5d5243677aabdc10f75de8a39b08f99ca33c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45214",
+					"10.65.0.27:45214",
+					"172.17.0.1:45214",
+					"172.18.0.1:45214",
+					"172.19.0.1:45214"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:12:46.973792182Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1463992035291258,
+				"StableID":   "nKXJx7b3SC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c1648acb6e82abc453d71465082c59b7108146bb5c9be5c0edd1e7e872d2b34",
+				"DiscoKey":   "discokey:5a0846834e752129434d425e6ed3d66c79e20a731528398ec7695b6cd3e24151",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39677",
+					"10.65.0.27:39677",
+					"172.17.0.1:39677",
+					"172.18.0.1:39677",
+					"172.19.0.1:39677"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:12:47.535215898Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2480455672107944,
+				"StableID":   "nPpip8NQNL11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85bcf32b5f8933f2af2a029dfed5757e4d5bc9d6bdbf46b6292974e6d11d527b",
+				"DiscoKey":   "discokey:6b4d856936c08e772ed5713cac5bd2579ef6ddfc640c5ea0ec977b0411a6433a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40590",
+					"10.65.0.27:40590",
+					"172.17.0.1:40590",
+					"172.18.0.1:40590",
+					"172.19.0.1:40590"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:12:48.057525716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         260808352712436,
+				"StableID":   "nKru2cz73311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:98ba75410c7c8aecb67b493832dd55d7b672eae4998f6d037a70c79993a5e47e",
+				"DiscoKey":   "discokey:fc65e0de86703d23c2c72177a4436550fec98676e3afc4afbbd1d0d5e8012e7f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58429",
+					"10.65.0.27:58429",
+					"172.17.0.1:58429",
+					"172.18.0.1:58429",
+					"172.19.0.1:58429"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:12:49.151757463Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1971300116950462,
+				"StableID":   "n3fDwFioPG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3ee77c1577449a8fb4517c9c85572898604082042524b52df393f82fe9426a48",
+				"DiscoKey":   "discokey:b5162837376348737a9da5579379b3528d5fb49e913972a776e38c75e180df07",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33235",
+					"10.65.0.27:33235",
+					"172.17.0.1:33235",
+					"172.18.0.1:33235",
+					"172.19.0.1:33235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:12:49.686954161Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1646544989659953,
+				"StableID":   "n4veQowirD11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6db7a8dd2b93e1b09c9af4d174c56c946d1eec7586bea5c75e9b624375f3442b",
+				"DiscoKey":   "discokey:08b1d5bc63e8dacfb078a9b276ea59f8ef1e2f00ce868e429324f4f19a7dac56",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35595",
+					"10.65.0.27:35595",
+					"172.17.0.1:35595",
+					"172.18.0.1:35595",
+					"172.19.0.1:35595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:12:50.224096993Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4729479275972653,
+				"StableID":   "nY64HFQzvd11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fa4ddc2510af5be8da1d02db19dfd6dca0757a89b80876a4559f3f92817a66d",
+				"DiscoKey":   "discokey:05b6f7f61be43bdebf3e2e95d20c44cdfc8c8d733b7f516c885a2cb26e5fa87f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49048",
+					"10.65.0.27:49048",
+					"172.17.0.1:49048",
+					"172.18.0.1:49048",
+					"172.19.0.1:49048"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:12:50.773768448Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1199415976500311,
+				"StableID":   "nWSudBdDNA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dec8653cbd3d5d0ee3a5b10a993c99b60c84dd72074e8acb2918a92543fef427",
+				"DiscoKey":   "discokey:d30ce9a476f5336971eeebc984ae0e2a29da3108f95fbe3b942b95cda9ded30f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:47936",
+					"10.65.0.27:47936",
+					"172.17.0.1:47936",
+					"172.18.0.1:47936",
+					"172.19.0.1:47936"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:12:51.31963675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         971317712465959,
+				"StableID":   "n4DW8Rsua811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2423c5b4f5c9edae93f90c45305d3b7870ea1702d1444b920ea3645fdc055144",
+				"DiscoKey":   "discokey:42233904dacf1e0a90385252014c0fcebbc7fe6bd02c6e59864de89b05a51840",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:51807",
+					"10.65.0.27:51807",
+					"172.17.0.1:51807",
+					"172.18.0.1:51807",
+					"172.19.0.1:51807"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:12:51.879745394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3825410319579337,
+				"StableID":   "nnoTST3YsW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:575d39df85f32cbc5540e280d2942b58f50ba4fe65028d1edcdd2df04784983f",
+				"KeyExpiry":  "2026-11-08T22:12:52Z",
+				"DiscoKey":   "discokey:4c5ad71c45fdc9d2bfb8e9dff930492d92f6aaf5812938a94391470c03294144",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45129",
+					"10.65.0.27:45129",
+					"172.17.0.1:45129",
+					"172.18.0.1:45129",
+					"172.19.0.1:45129"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:12:52.411276822Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3821327416286260,
+				"StableID":   "nPzrFungqW11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b62feb33325b189d0b914fece2a1a61646a8835f0d3ae218442efdba998b3050",
+				"KeyExpiry":  "2026-11-08T22:12:52Z",
+				"DiscoKey":   "discokey:4b44846593f049e412a81cd20a3b735218d8cf62703f766e363da0133a63e65e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:42957",
+					"10.65.0.27:42957",
+					"172.17.0.1:42957",
+					"172.18.0.1:42957",
+					"172.19.0.1:42957"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 53165},
+					{"Proto": "peerapi6", "Port": 53165}
+				]},
+				"Created":              "2026-05-12T22:12:52.93257841Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5252472108465548,
+				"StableID":   "nBaoy4Yr1i11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:4d379b7250c65dba4fb229035fc5058a4550c621af42f5b7b25972bfd3f35422",
+				"KeyExpiry":  "2026-11-08T22:12:53Z",
+				"DiscoKey":   "discokey:e724c69890c6b6c097034c88982f335258d0bfee0ee143fcfd1f9bb7fc2c4c6f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59814",
+					"10.65.0.27:59814",
+					"172.17.0.1:59814",
+					"172.18.0.1:59814",
+					"172.19.0.1:59814"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:12:53.46976722Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7114218108595119": {
+				"ID":          7114218108595119,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5252472108465548,
+				"StableID":   "nBaoy4Yr1i11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:4d379b7250c65dba4fb229035fc5058a4550c621af42f5b7b25972bfd3f35422",
+				"KeyExpiry":  "2026-11-08T22:12:53Z",
+				"DiscoKey":   "discokey:e724c69890c6b6c097034c88982f335258d0bfee0ee143fcfd1f9bb7fc2c4c6f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59814",
+					"10.65.0.27:59814",
+					"172.17.0.1:59814",
+					"172.18.0.1:59814",
+					"172.19.0.1:59814"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:12:53.46976722Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4d379b7250c65dba4fb229035fc5058a4550c621af42f5b7b25972bfd3f35422",
+			"MachineKey": "mkey:0ad5d2682875458fb0509811cea71018261e0eaedd30876c54a862331f58eb7d",
+			"Peers": [{
+				"ID":         5558691465482482,
+				"StableID":   "n3Xgx8QYQk11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:98da7e6ebf8ab5100951b5ebd79e39565b462ba85ba10594372fefac12e13e4f",
+				"DiscoKey":   "discokey:d77cd03005778ec806410b6f34bf2d47594599a95e7e996ae8fdaab2c06d5833",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52099",
+					"10.65.0.27:52099",
+					"172.17.0.1:52099",
+					"172.18.0.1:52099",
+					"172.19.0.1:52099"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:12:45.895894102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2206922408666095,
+				"StableID":   "nzLB1M7XEJ11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6edecf637d1b72e078156a22394d4dea7a16953906de2b417697931a7b75d95a",
+				"DiscoKey":   "discokey:77b4a430760c4e5e669aed761df404a289f2b301e4f7f4a92d9c44a5e4655d69",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45931",
+					"10.65.0.27:45931",
+					"172.17.0.1:45931",
+					"172.18.0.1:45931",
+					"172.19.0.1:45931"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:12:46.432801487Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5087440775102692,
+				"StableID":   "nD74BfS7jg11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ac08d7f0ad82e0cf1efaed80e4d336b833be51646e01dfddcbbfb90616562015",
+				"DiscoKey":   "discokey:27ae7f82f4530a342d62ad2ca67b5d5243677aabdc10f75de8a39b08f99ca33c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45214",
+					"10.65.0.27:45214",
+					"172.17.0.1:45214",
+					"172.18.0.1:45214",
+					"172.19.0.1:45214"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:12:46.973792182Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1463992035291258,
+				"StableID":   "nKXJx7b3SC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c1648acb6e82abc453d71465082c59b7108146bb5c9be5c0edd1e7e872d2b34",
+				"DiscoKey":   "discokey:5a0846834e752129434d425e6ed3d66c79e20a731528398ec7695b6cd3e24151",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39677",
+					"10.65.0.27:39677",
+					"172.17.0.1:39677",
+					"172.18.0.1:39677",
+					"172.19.0.1:39677"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:12:47.535215898Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2480455672107944,
+				"StableID":   "nPpip8NQNL11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85bcf32b5f8933f2af2a029dfed5757e4d5bc9d6bdbf46b6292974e6d11d527b",
+				"DiscoKey":   "discokey:6b4d856936c08e772ed5713cac5bd2579ef6ddfc640c5ea0ec977b0411a6433a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40590",
+					"10.65.0.27:40590",
+					"172.17.0.1:40590",
+					"172.18.0.1:40590",
+					"172.19.0.1:40590"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:12:48.057525716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7114218108595119,
+				"StableID":   "nQV9msS3Zx11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:92264e4a656982c2b4c9ecd1ea8706eff37454995799a365538a1bc2a578a977",
+				"DiscoKey":   "discokey:87c7b9d30e4fc5485801aab92dcca177fdc08174d854877f6149c48ebc820328",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44686",
+					"10.65.0.27:44686",
+					"172.17.0.1:44686",
+					"172.18.0.1:44686",
+					"172.19.0.1:44686"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:12:48.593717138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         260808352712436,
+				"StableID":   "nKru2cz73311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:98ba75410c7c8aecb67b493832dd55d7b672eae4998f6d037a70c79993a5e47e",
+				"DiscoKey":   "discokey:fc65e0de86703d23c2c72177a4436550fec98676e3afc4afbbd1d0d5e8012e7f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58429",
+					"10.65.0.27:58429",
+					"172.17.0.1:58429",
+					"172.18.0.1:58429",
+					"172.19.0.1:58429"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:12:49.151757463Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1971300116950462,
+				"StableID":   "n3fDwFioPG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3ee77c1577449a8fb4517c9c85572898604082042524b52df393f82fe9426a48",
+				"DiscoKey":   "discokey:b5162837376348737a9da5579379b3528d5fb49e913972a776e38c75e180df07",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33235",
+					"10.65.0.27:33235",
+					"172.17.0.1:33235",
+					"172.18.0.1:33235",
+					"172.19.0.1:33235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:12:49.686954161Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1646544989659953,
+				"StableID":   "n4veQowirD11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6db7a8dd2b93e1b09c9af4d174c56c946d1eec7586bea5c75e9b624375f3442b",
+				"DiscoKey":   "discokey:08b1d5bc63e8dacfb078a9b276ea59f8ef1e2f00ce868e429324f4f19a7dac56",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35595",
+					"10.65.0.27:35595",
+					"172.17.0.1:35595",
+					"172.18.0.1:35595",
+					"172.19.0.1:35595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:12:50.224096993Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4729479275972653,
+				"StableID":   "nY64HFQzvd11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fa4ddc2510af5be8da1d02db19dfd6dca0757a89b80876a4559f3f92817a66d",
+				"DiscoKey":   "discokey:05b6f7f61be43bdebf3e2e95d20c44cdfc8c8d733b7f516c885a2cb26e5fa87f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49048",
+					"10.65.0.27:49048",
+					"172.17.0.1:49048",
+					"172.18.0.1:49048",
+					"172.19.0.1:49048"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:12:50.773768448Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1199415976500311,
+				"StableID":   "nWSudBdDNA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dec8653cbd3d5d0ee3a5b10a993c99b60c84dd72074e8acb2918a92543fef427",
+				"DiscoKey":   "discokey:d30ce9a476f5336971eeebc984ae0e2a29da3108f95fbe3b942b95cda9ded30f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:47936",
+					"10.65.0.27:47936",
+					"172.17.0.1:47936",
+					"172.18.0.1:47936",
+					"172.19.0.1:47936"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:12:51.31963675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         971317712465959,
+				"StableID":   "n4DW8Rsua811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2423c5b4f5c9edae93f90c45305d3b7870ea1702d1444b920ea3645fdc055144",
+				"DiscoKey":   "discokey:42233904dacf1e0a90385252014c0fcebbc7fe6bd02c6e59864de89b05a51840",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:51807",
+					"10.65.0.27:51807",
+					"172.17.0.1:51807",
+					"172.18.0.1:51807",
+					"172.19.0.1:51807"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:12:51.879745394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3825410319579337,
+				"StableID":   "nnoTST3YsW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:575d39df85f32cbc5540e280d2942b58f50ba4fe65028d1edcdd2df04784983f",
+				"KeyExpiry":  "2026-11-08T22:12:52Z",
+				"DiscoKey":   "discokey:4c5ad71c45fdc9d2bfb8e9dff930492d92f6aaf5812938a94391470c03294144",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45129",
+					"10.65.0.27:45129",
+					"172.17.0.1:45129",
+					"172.18.0.1:45129",
+					"172.19.0.1:45129"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:12:52.411276822Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3821327416286260,
+				"StableID":   "nPzrFungqW11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b62feb33325b189d0b914fece2a1a61646a8835f0d3ae218442efdba998b3050",
+				"KeyExpiry":  "2026-11-08T22:12:52Z",
+				"DiscoKey":   "discokey:4b44846593f049e412a81cd20a3b735218d8cf62703f766e363da0133a63e65e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:42957",
+					"10.65.0.27:42957",
+					"172.17.0.1:42957",
+					"172.18.0.1:42957",
+					"172.19.0.1:42957"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 53165},
+					{"Proto": "peerapi6", "Port": 53165}
+				]},
+				"Created":              "2026-05-12T22:12:52.93257841Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5087440775102692,
+				"StableID":   "nD74BfS7jg11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       5087440775102692,
+				"Key":        "nodekey:ac08d7f0ad82e0cf1efaed80e4d336b833be51646e01dfddcbbfb90616562015",
+				"DiscoKey":   "discokey:27ae7f82f4530a342d62ad2ca67b5d5243677aabdc10f75de8a39b08f99ca33c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45214",
+					"10.65.0.27:45214",
+					"172.17.0.1:45214",
+					"172.18.0.1:45214",
+					"172.19.0.1:45214"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:12:46.973792182Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ac08d7f0ad82e0cf1efaed80e4d336b833be51646e01dfddcbbfb90616562015",
+			"MachineKey": "mkey:4cd1ac518c5b1a9e1974275ba7b82e32a2bda21d6f328ef46a64c9f8973b8d7c",
+			"Peers": [{
+				"ID":         5558691465482482,
+				"StableID":   "n3Xgx8QYQk11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:98da7e6ebf8ab5100951b5ebd79e39565b462ba85ba10594372fefac12e13e4f",
+				"DiscoKey":   "discokey:d77cd03005778ec806410b6f34bf2d47594599a95e7e996ae8fdaab2c06d5833",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52099",
+					"10.65.0.27:52099",
+					"172.17.0.1:52099",
+					"172.18.0.1:52099",
+					"172.19.0.1:52099"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:12:45.895894102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2206922408666095,
+				"StableID":   "nzLB1M7XEJ11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6edecf637d1b72e078156a22394d4dea7a16953906de2b417697931a7b75d95a",
+				"DiscoKey":   "discokey:77b4a430760c4e5e669aed761df404a289f2b301e4f7f4a92d9c44a5e4655d69",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45931",
+					"10.65.0.27:45931",
+					"172.17.0.1:45931",
+					"172.18.0.1:45931",
+					"172.19.0.1:45931"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:12:46.432801487Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1463992035291258,
+				"StableID":   "nKXJx7b3SC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c1648acb6e82abc453d71465082c59b7108146bb5c9be5c0edd1e7e872d2b34",
+				"DiscoKey":   "discokey:5a0846834e752129434d425e6ed3d66c79e20a731528398ec7695b6cd3e24151",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39677",
+					"10.65.0.27:39677",
+					"172.17.0.1:39677",
+					"172.18.0.1:39677",
+					"172.19.0.1:39677"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:12:47.535215898Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2480455672107944,
+				"StableID":   "nPpip8NQNL11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85bcf32b5f8933f2af2a029dfed5757e4d5bc9d6bdbf46b6292974e6d11d527b",
+				"DiscoKey":   "discokey:6b4d856936c08e772ed5713cac5bd2579ef6ddfc640c5ea0ec977b0411a6433a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40590",
+					"10.65.0.27:40590",
+					"172.17.0.1:40590",
+					"172.18.0.1:40590",
+					"172.19.0.1:40590"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:12:48.057525716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7114218108595119,
+				"StableID":   "nQV9msS3Zx11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:92264e4a656982c2b4c9ecd1ea8706eff37454995799a365538a1bc2a578a977",
+				"DiscoKey":   "discokey:87c7b9d30e4fc5485801aab92dcca177fdc08174d854877f6149c48ebc820328",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44686",
+					"10.65.0.27:44686",
+					"172.17.0.1:44686",
+					"172.18.0.1:44686",
+					"172.19.0.1:44686"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:12:48.593717138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         260808352712436,
+				"StableID":   "nKru2cz73311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:98ba75410c7c8aecb67b493832dd55d7b672eae4998f6d037a70c79993a5e47e",
+				"DiscoKey":   "discokey:fc65e0de86703d23c2c72177a4436550fec98676e3afc4afbbd1d0d5e8012e7f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58429",
+					"10.65.0.27:58429",
+					"172.17.0.1:58429",
+					"172.18.0.1:58429",
+					"172.19.0.1:58429"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:12:49.151757463Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1971300116950462,
+				"StableID":   "n3fDwFioPG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3ee77c1577449a8fb4517c9c85572898604082042524b52df393f82fe9426a48",
+				"DiscoKey":   "discokey:b5162837376348737a9da5579379b3528d5fb49e913972a776e38c75e180df07",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33235",
+					"10.65.0.27:33235",
+					"172.17.0.1:33235",
+					"172.18.0.1:33235",
+					"172.19.0.1:33235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:12:49.686954161Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1646544989659953,
+				"StableID":   "n4veQowirD11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6db7a8dd2b93e1b09c9af4d174c56c946d1eec7586bea5c75e9b624375f3442b",
+				"DiscoKey":   "discokey:08b1d5bc63e8dacfb078a9b276ea59f8ef1e2f00ce868e429324f4f19a7dac56",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35595",
+					"10.65.0.27:35595",
+					"172.17.0.1:35595",
+					"172.18.0.1:35595",
+					"172.19.0.1:35595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:12:50.224096993Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4729479275972653,
+				"StableID":   "nY64HFQzvd11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fa4ddc2510af5be8da1d02db19dfd6dca0757a89b80876a4559f3f92817a66d",
+				"DiscoKey":   "discokey:05b6f7f61be43bdebf3e2e95d20c44cdfc8c8d733b7f516c885a2cb26e5fa87f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49048",
+					"10.65.0.27:49048",
+					"172.17.0.1:49048",
+					"172.18.0.1:49048",
+					"172.19.0.1:49048"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:12:50.773768448Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1199415976500311,
+				"StableID":   "nWSudBdDNA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dec8653cbd3d5d0ee3a5b10a993c99b60c84dd72074e8acb2918a92543fef427",
+				"DiscoKey":   "discokey:d30ce9a476f5336971eeebc984ae0e2a29da3108f95fbe3b942b95cda9ded30f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:47936",
+					"10.65.0.27:47936",
+					"172.17.0.1:47936",
+					"172.18.0.1:47936",
+					"172.19.0.1:47936"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:12:51.31963675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         971317712465959,
+				"StableID":   "n4DW8Rsua811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2423c5b4f5c9edae93f90c45305d3b7870ea1702d1444b920ea3645fdc055144",
+				"DiscoKey":   "discokey:42233904dacf1e0a90385252014c0fcebbc7fe6bd02c6e59864de89b05a51840",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:51807",
+					"10.65.0.27:51807",
+					"172.17.0.1:51807",
+					"172.18.0.1:51807",
+					"172.19.0.1:51807"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:12:51.879745394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3825410319579337,
+				"StableID":   "nnoTST3YsW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:575d39df85f32cbc5540e280d2942b58f50ba4fe65028d1edcdd2df04784983f",
+				"KeyExpiry":  "2026-11-08T22:12:52Z",
+				"DiscoKey":   "discokey:4c5ad71c45fdc9d2bfb8e9dff930492d92f6aaf5812938a94391470c03294144",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45129",
+					"10.65.0.27:45129",
+					"172.17.0.1:45129",
+					"172.18.0.1:45129",
+					"172.19.0.1:45129"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:12:52.411276822Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3821327416286260,
+				"StableID":   "nPzrFungqW11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b62feb33325b189d0b914fece2a1a61646a8835f0d3ae218442efdba998b3050",
+				"KeyExpiry":  "2026-11-08T22:12:52Z",
+				"DiscoKey":   "discokey:4b44846593f049e412a81cd20a3b735218d8cf62703f766e363da0133a63e65e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:42957",
+					"10.65.0.27:42957",
+					"172.17.0.1:42957",
+					"172.18.0.1:42957",
+					"172.19.0.1:42957"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 53165},
+					{"Proto": "peerapi6", "Port": 53165}
+				]},
+				"Created":              "2026-05-12T22:12:52.93257841Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5252472108465548,
+				"StableID":   "nBaoy4Yr1i11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:4d379b7250c65dba4fb229035fc5058a4550c621af42f5b7b25972bfd3f35422",
+				"KeyExpiry":  "2026-11-08T22:12:53Z",
+				"DiscoKey":   "discokey:e724c69890c6b6c097034c88982f335258d0bfee0ee143fcfd1f9bb7fc2c4c6f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59814",
+					"10.65.0.27:59814",
+					"172.17.0.1:59814",
+					"172.18.0.1:59814",
+					"172.19.0.1:59814"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:12:53.46976722Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5087440775102692": {
+				"ID":          5087440775102692,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1971300116950462,
+				"StableID":   "n3fDwFioPG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1971300116950462,
+				"Key":        "nodekey:3ee77c1577449a8fb4517c9c85572898604082042524b52df393f82fe9426a48",
+				"DiscoKey":   "discokey:b5162837376348737a9da5579379b3528d5fb49e913972a776e38c75e180df07",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33235",
+					"10.65.0.27:33235",
+					"172.17.0.1:33235",
+					"172.18.0.1:33235",
+					"172.19.0.1:33235"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:12:49.686954161Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3ee77c1577449a8fb4517c9c85572898604082042524b52df393f82fe9426a48",
+			"MachineKey": "mkey:22357a82c154cd6b4bca9b980354ecd70b55fbfc154c55ee3f08b5f684afbd24",
+			"Peers": [{
+				"ID":         5558691465482482,
+				"StableID":   "n3Xgx8QYQk11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:98da7e6ebf8ab5100951b5ebd79e39565b462ba85ba10594372fefac12e13e4f",
+				"DiscoKey":   "discokey:d77cd03005778ec806410b6f34bf2d47594599a95e7e996ae8fdaab2c06d5833",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52099",
+					"10.65.0.27:52099",
+					"172.17.0.1:52099",
+					"172.18.0.1:52099",
+					"172.19.0.1:52099"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:12:45.895894102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2206922408666095,
+				"StableID":   "nzLB1M7XEJ11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6edecf637d1b72e078156a22394d4dea7a16953906de2b417697931a7b75d95a",
+				"DiscoKey":   "discokey:77b4a430760c4e5e669aed761df404a289f2b301e4f7f4a92d9c44a5e4655d69",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45931",
+					"10.65.0.27:45931",
+					"172.17.0.1:45931",
+					"172.18.0.1:45931",
+					"172.19.0.1:45931"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:12:46.432801487Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5087440775102692,
+				"StableID":   "nD74BfS7jg11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ac08d7f0ad82e0cf1efaed80e4d336b833be51646e01dfddcbbfb90616562015",
+				"DiscoKey":   "discokey:27ae7f82f4530a342d62ad2ca67b5d5243677aabdc10f75de8a39b08f99ca33c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45214",
+					"10.65.0.27:45214",
+					"172.17.0.1:45214",
+					"172.18.0.1:45214",
+					"172.19.0.1:45214"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:12:46.973792182Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1463992035291258,
+				"StableID":   "nKXJx7b3SC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c1648acb6e82abc453d71465082c59b7108146bb5c9be5c0edd1e7e872d2b34",
+				"DiscoKey":   "discokey:5a0846834e752129434d425e6ed3d66c79e20a731528398ec7695b6cd3e24151",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39677",
+					"10.65.0.27:39677",
+					"172.17.0.1:39677",
+					"172.18.0.1:39677",
+					"172.19.0.1:39677"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:12:47.535215898Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2480455672107944,
+				"StableID":   "nPpip8NQNL11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85bcf32b5f8933f2af2a029dfed5757e4d5bc9d6bdbf46b6292974e6d11d527b",
+				"DiscoKey":   "discokey:6b4d856936c08e772ed5713cac5bd2579ef6ddfc640c5ea0ec977b0411a6433a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40590",
+					"10.65.0.27:40590",
+					"172.17.0.1:40590",
+					"172.18.0.1:40590",
+					"172.19.0.1:40590"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:12:48.057525716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7114218108595119,
+				"StableID":   "nQV9msS3Zx11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:92264e4a656982c2b4c9ecd1ea8706eff37454995799a365538a1bc2a578a977",
+				"DiscoKey":   "discokey:87c7b9d30e4fc5485801aab92dcca177fdc08174d854877f6149c48ebc820328",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44686",
+					"10.65.0.27:44686",
+					"172.17.0.1:44686",
+					"172.18.0.1:44686",
+					"172.19.0.1:44686"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:12:48.593717138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         260808352712436,
+				"StableID":   "nKru2cz73311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:98ba75410c7c8aecb67b493832dd55d7b672eae4998f6d037a70c79993a5e47e",
+				"DiscoKey":   "discokey:fc65e0de86703d23c2c72177a4436550fec98676e3afc4afbbd1d0d5e8012e7f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58429",
+					"10.65.0.27:58429",
+					"172.17.0.1:58429",
+					"172.18.0.1:58429",
+					"172.19.0.1:58429"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:12:49.151757463Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1646544989659953,
+				"StableID":   "n4veQowirD11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6db7a8dd2b93e1b09c9af4d174c56c946d1eec7586bea5c75e9b624375f3442b",
+				"DiscoKey":   "discokey:08b1d5bc63e8dacfb078a9b276ea59f8ef1e2f00ce868e429324f4f19a7dac56",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35595",
+					"10.65.0.27:35595",
+					"172.17.0.1:35595",
+					"172.18.0.1:35595",
+					"172.19.0.1:35595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:12:50.224096993Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4729479275972653,
+				"StableID":   "nY64HFQzvd11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fa4ddc2510af5be8da1d02db19dfd6dca0757a89b80876a4559f3f92817a66d",
+				"DiscoKey":   "discokey:05b6f7f61be43bdebf3e2e95d20c44cdfc8c8d733b7f516c885a2cb26e5fa87f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49048",
+					"10.65.0.27:49048",
+					"172.17.0.1:49048",
+					"172.18.0.1:49048",
+					"172.19.0.1:49048"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:12:50.773768448Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1199415976500311,
+				"StableID":   "nWSudBdDNA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dec8653cbd3d5d0ee3a5b10a993c99b60c84dd72074e8acb2918a92543fef427",
+				"DiscoKey":   "discokey:d30ce9a476f5336971eeebc984ae0e2a29da3108f95fbe3b942b95cda9ded30f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:47936",
+					"10.65.0.27:47936",
+					"172.17.0.1:47936",
+					"172.18.0.1:47936",
+					"172.19.0.1:47936"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:12:51.31963675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         971317712465959,
+				"StableID":   "n4DW8Rsua811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2423c5b4f5c9edae93f90c45305d3b7870ea1702d1444b920ea3645fdc055144",
+				"DiscoKey":   "discokey:42233904dacf1e0a90385252014c0fcebbc7fe6bd02c6e59864de89b05a51840",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:51807",
+					"10.65.0.27:51807",
+					"172.17.0.1:51807",
+					"172.18.0.1:51807",
+					"172.19.0.1:51807"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:12:51.879745394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3825410319579337,
+				"StableID":   "nnoTST3YsW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:575d39df85f32cbc5540e280d2942b58f50ba4fe65028d1edcdd2df04784983f",
+				"KeyExpiry":  "2026-11-08T22:12:52Z",
+				"DiscoKey":   "discokey:4c5ad71c45fdc9d2bfb8e9dff930492d92f6aaf5812938a94391470c03294144",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45129",
+					"10.65.0.27:45129",
+					"172.17.0.1:45129",
+					"172.18.0.1:45129",
+					"172.19.0.1:45129"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:12:52.411276822Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3821327416286260,
+				"StableID":   "nPzrFungqW11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b62feb33325b189d0b914fece2a1a61646a8835f0d3ae218442efdba998b3050",
+				"KeyExpiry":  "2026-11-08T22:12:52Z",
+				"DiscoKey":   "discokey:4b44846593f049e412a81cd20a3b735218d8cf62703f766e363da0133a63e65e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:42957",
+					"10.65.0.27:42957",
+					"172.17.0.1:42957",
+					"172.18.0.1:42957",
+					"172.19.0.1:42957"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 53165},
+					{"Proto": "peerapi6", "Port": 53165}
+				]},
+				"Created":              "2026-05-12T22:12:52.93257841Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5252472108465548,
+				"StableID":   "nBaoy4Yr1i11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:4d379b7250c65dba4fb229035fc5058a4550c621af42f5b7b25972bfd3f35422",
+				"KeyExpiry":  "2026-11-08T22:12:53Z",
+				"DiscoKey":   "discokey:e724c69890c6b6c097034c88982f335258d0bfee0ee143fcfd1f9bb7fc2c4c6f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59814",
+					"10.65.0.27:59814",
+					"172.17.0.1:59814",
+					"172.18.0.1:59814",
+					"172.19.0.1:59814"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:12:53.46976722Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1971300116950462": {
+				"ID":          1971300116950462,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3825410319579337,
+				"StableID":   "nnoTST3YsW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:575d39df85f32cbc5540e280d2942b58f50ba4fe65028d1edcdd2df04784983f",
+				"KeyExpiry":  "2026-11-08T22:12:52Z",
+				"DiscoKey":   "discokey:4c5ad71c45fdc9d2bfb8e9dff930492d92f6aaf5812938a94391470c03294144",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45129",
+					"10.65.0.27:45129",
+					"172.17.0.1:45129",
+					"172.18.0.1:45129",
+					"172.19.0.1:45129"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:12:52.411276822Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:575d39df85f32cbc5540e280d2942b58f50ba4fe65028d1edcdd2df04784983f",
+			"MachineKey": "mkey:59bc8b199b923197352968864919860cff7da7213ec0837b7892a554f5d0881b",
+			"Peers": [{
+				"ID":         5558691465482482,
+				"StableID":   "n3Xgx8QYQk11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:98da7e6ebf8ab5100951b5ebd79e39565b462ba85ba10594372fefac12e13e4f",
+				"DiscoKey":   "discokey:d77cd03005778ec806410b6f34bf2d47594599a95e7e996ae8fdaab2c06d5833",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52099",
+					"10.65.0.27:52099",
+					"172.17.0.1:52099",
+					"172.18.0.1:52099",
+					"172.19.0.1:52099"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:12:45.895894102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2206922408666095,
+				"StableID":   "nzLB1M7XEJ11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6edecf637d1b72e078156a22394d4dea7a16953906de2b417697931a7b75d95a",
+				"DiscoKey":   "discokey:77b4a430760c4e5e669aed761df404a289f2b301e4f7f4a92d9c44a5e4655d69",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45931",
+					"10.65.0.27:45931",
+					"172.17.0.1:45931",
+					"172.18.0.1:45931",
+					"172.19.0.1:45931"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:12:46.432801487Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5087440775102692,
+				"StableID":   "nD74BfS7jg11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ac08d7f0ad82e0cf1efaed80e4d336b833be51646e01dfddcbbfb90616562015",
+				"DiscoKey":   "discokey:27ae7f82f4530a342d62ad2ca67b5d5243677aabdc10f75de8a39b08f99ca33c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45214",
+					"10.65.0.27:45214",
+					"172.17.0.1:45214",
+					"172.18.0.1:45214",
+					"172.19.0.1:45214"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:12:46.973792182Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1463992035291258,
+				"StableID":   "nKXJx7b3SC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c1648acb6e82abc453d71465082c59b7108146bb5c9be5c0edd1e7e872d2b34",
+				"DiscoKey":   "discokey:5a0846834e752129434d425e6ed3d66c79e20a731528398ec7695b6cd3e24151",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39677",
+					"10.65.0.27:39677",
+					"172.17.0.1:39677",
+					"172.18.0.1:39677",
+					"172.19.0.1:39677"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:12:47.535215898Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2480455672107944,
+				"StableID":   "nPpip8NQNL11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85bcf32b5f8933f2af2a029dfed5757e4d5bc9d6bdbf46b6292974e6d11d527b",
+				"DiscoKey":   "discokey:6b4d856936c08e772ed5713cac5bd2579ef6ddfc640c5ea0ec977b0411a6433a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40590",
+					"10.65.0.27:40590",
+					"172.17.0.1:40590",
+					"172.18.0.1:40590",
+					"172.19.0.1:40590"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:12:48.057525716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7114218108595119,
+				"StableID":   "nQV9msS3Zx11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:92264e4a656982c2b4c9ecd1ea8706eff37454995799a365538a1bc2a578a977",
+				"DiscoKey":   "discokey:87c7b9d30e4fc5485801aab92dcca177fdc08174d854877f6149c48ebc820328",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44686",
+					"10.65.0.27:44686",
+					"172.17.0.1:44686",
+					"172.18.0.1:44686",
+					"172.19.0.1:44686"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:12:48.593717138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         260808352712436,
+				"StableID":   "nKru2cz73311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:98ba75410c7c8aecb67b493832dd55d7b672eae4998f6d037a70c79993a5e47e",
+				"DiscoKey":   "discokey:fc65e0de86703d23c2c72177a4436550fec98676e3afc4afbbd1d0d5e8012e7f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58429",
+					"10.65.0.27:58429",
+					"172.17.0.1:58429",
+					"172.18.0.1:58429",
+					"172.19.0.1:58429"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:12:49.151757463Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1971300116950462,
+				"StableID":   "n3fDwFioPG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3ee77c1577449a8fb4517c9c85572898604082042524b52df393f82fe9426a48",
+				"DiscoKey":   "discokey:b5162837376348737a9da5579379b3528d5fb49e913972a776e38c75e180df07",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33235",
+					"10.65.0.27:33235",
+					"172.17.0.1:33235",
+					"172.18.0.1:33235",
+					"172.19.0.1:33235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:12:49.686954161Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1646544989659953,
+				"StableID":   "n4veQowirD11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6db7a8dd2b93e1b09c9af4d174c56c946d1eec7586bea5c75e9b624375f3442b",
+				"DiscoKey":   "discokey:08b1d5bc63e8dacfb078a9b276ea59f8ef1e2f00ce868e429324f4f19a7dac56",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35595",
+					"10.65.0.27:35595",
+					"172.17.0.1:35595",
+					"172.18.0.1:35595",
+					"172.19.0.1:35595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:12:50.224096993Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4729479275972653,
+				"StableID":   "nY64HFQzvd11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fa4ddc2510af5be8da1d02db19dfd6dca0757a89b80876a4559f3f92817a66d",
+				"DiscoKey":   "discokey:05b6f7f61be43bdebf3e2e95d20c44cdfc8c8d733b7f516c885a2cb26e5fa87f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49048",
+					"10.65.0.27:49048",
+					"172.17.0.1:49048",
+					"172.18.0.1:49048",
+					"172.19.0.1:49048"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:12:50.773768448Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1199415976500311,
+				"StableID":   "nWSudBdDNA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dec8653cbd3d5d0ee3a5b10a993c99b60c84dd72074e8acb2918a92543fef427",
+				"DiscoKey":   "discokey:d30ce9a476f5336971eeebc984ae0e2a29da3108f95fbe3b942b95cda9ded30f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:47936",
+					"10.65.0.27:47936",
+					"172.17.0.1:47936",
+					"172.18.0.1:47936",
+					"172.19.0.1:47936"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:12:51.31963675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         971317712465959,
+				"StableID":   "n4DW8Rsua811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2423c5b4f5c9edae93f90c45305d3b7870ea1702d1444b920ea3645fdc055144",
+				"DiscoKey":   "discokey:42233904dacf1e0a90385252014c0fcebbc7fe6bd02c6e59864de89b05a51840",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:51807",
+					"10.65.0.27:51807",
+					"172.17.0.1:51807",
+					"172.18.0.1:51807",
+					"172.19.0.1:51807"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:12:51.879745394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3821327416286260,
+				"StableID":   "nPzrFungqW11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b62feb33325b189d0b914fece2a1a61646a8835f0d3ae218442efdba998b3050",
+				"KeyExpiry":  "2026-11-08T22:12:52Z",
+				"DiscoKey":   "discokey:4b44846593f049e412a81cd20a3b735218d8cf62703f766e363da0133a63e65e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:42957",
+					"10.65.0.27:42957",
+					"172.17.0.1:42957",
+					"172.18.0.1:42957",
+					"172.19.0.1:42957"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 53165},
+					{"Proto": "peerapi6", "Port": 53165}
+				]},
+				"Created":              "2026-05-12T22:12:52.93257841Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5252472108465548,
+				"StableID":   "nBaoy4Yr1i11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:4d379b7250c65dba4fb229035fc5058a4550c621af42f5b7b25972bfd3f35422",
+				"KeyExpiry":  "2026-11-08T22:12:53Z",
+				"DiscoKey":   "discokey:e724c69890c6b6c097034c88982f335258d0bfee0ee143fcfd1f9bb7fc2c4c6f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59814",
+					"10.65.0.27:59814",
+					"172.17.0.1:59814",
+					"172.18.0.1:59814",
+					"172.19.0.1:59814"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:12:53.46976722Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1199415976500311,
+				"StableID":   "nWSudBdDNA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1199415976500311,
+				"Key":        "nodekey:dec8653cbd3d5d0ee3a5b10a993c99b60c84dd72074e8acb2918a92543fef427",
+				"DiscoKey":   "discokey:d30ce9a476f5336971eeebc984ae0e2a29da3108f95fbe3b942b95cda9ded30f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:47936",
+					"10.65.0.27:47936",
+					"172.17.0.1:47936",
+					"172.18.0.1:47936",
+					"172.19.0.1:47936"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:12:51.31963675Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:dec8653cbd3d5d0ee3a5b10a993c99b60c84dd72074e8acb2918a92543fef427",
+			"MachineKey": "mkey:4e56bd6592a5c5dddec5a85f07ab103df775b849976bfb3def2ac740b972c30c",
+			"Peers": [{
+				"ID":         5558691465482482,
+				"StableID":   "n3Xgx8QYQk11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:98da7e6ebf8ab5100951b5ebd79e39565b462ba85ba10594372fefac12e13e4f",
+				"DiscoKey":   "discokey:d77cd03005778ec806410b6f34bf2d47594599a95e7e996ae8fdaab2c06d5833",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52099",
+					"10.65.0.27:52099",
+					"172.17.0.1:52099",
+					"172.18.0.1:52099",
+					"172.19.0.1:52099"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:12:45.895894102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2206922408666095,
+				"StableID":   "nzLB1M7XEJ11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6edecf637d1b72e078156a22394d4dea7a16953906de2b417697931a7b75d95a",
+				"DiscoKey":   "discokey:77b4a430760c4e5e669aed761df404a289f2b301e4f7f4a92d9c44a5e4655d69",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45931",
+					"10.65.0.27:45931",
+					"172.17.0.1:45931",
+					"172.18.0.1:45931",
+					"172.19.0.1:45931"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:12:46.432801487Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5087440775102692,
+				"StableID":   "nD74BfS7jg11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ac08d7f0ad82e0cf1efaed80e4d336b833be51646e01dfddcbbfb90616562015",
+				"DiscoKey":   "discokey:27ae7f82f4530a342d62ad2ca67b5d5243677aabdc10f75de8a39b08f99ca33c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45214",
+					"10.65.0.27:45214",
+					"172.17.0.1:45214",
+					"172.18.0.1:45214",
+					"172.19.0.1:45214"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:12:46.973792182Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1463992035291258,
+				"StableID":   "nKXJx7b3SC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c1648acb6e82abc453d71465082c59b7108146bb5c9be5c0edd1e7e872d2b34",
+				"DiscoKey":   "discokey:5a0846834e752129434d425e6ed3d66c79e20a731528398ec7695b6cd3e24151",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39677",
+					"10.65.0.27:39677",
+					"172.17.0.1:39677",
+					"172.18.0.1:39677",
+					"172.19.0.1:39677"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:12:47.535215898Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2480455672107944,
+				"StableID":   "nPpip8NQNL11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85bcf32b5f8933f2af2a029dfed5757e4d5bc9d6bdbf46b6292974e6d11d527b",
+				"DiscoKey":   "discokey:6b4d856936c08e772ed5713cac5bd2579ef6ddfc640c5ea0ec977b0411a6433a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40590",
+					"10.65.0.27:40590",
+					"172.17.0.1:40590",
+					"172.18.0.1:40590",
+					"172.19.0.1:40590"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:12:48.057525716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7114218108595119,
+				"StableID":   "nQV9msS3Zx11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:92264e4a656982c2b4c9ecd1ea8706eff37454995799a365538a1bc2a578a977",
+				"DiscoKey":   "discokey:87c7b9d30e4fc5485801aab92dcca177fdc08174d854877f6149c48ebc820328",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44686",
+					"10.65.0.27:44686",
+					"172.17.0.1:44686",
+					"172.18.0.1:44686",
+					"172.19.0.1:44686"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:12:48.593717138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         260808352712436,
+				"StableID":   "nKru2cz73311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:98ba75410c7c8aecb67b493832dd55d7b672eae4998f6d037a70c79993a5e47e",
+				"DiscoKey":   "discokey:fc65e0de86703d23c2c72177a4436550fec98676e3afc4afbbd1d0d5e8012e7f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58429",
+					"10.65.0.27:58429",
+					"172.17.0.1:58429",
+					"172.18.0.1:58429",
+					"172.19.0.1:58429"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:12:49.151757463Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1971300116950462,
+				"StableID":   "n3fDwFioPG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3ee77c1577449a8fb4517c9c85572898604082042524b52df393f82fe9426a48",
+				"DiscoKey":   "discokey:b5162837376348737a9da5579379b3528d5fb49e913972a776e38c75e180df07",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33235",
+					"10.65.0.27:33235",
+					"172.17.0.1:33235",
+					"172.18.0.1:33235",
+					"172.19.0.1:33235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:12:49.686954161Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1646544989659953,
+				"StableID":   "n4veQowirD11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6db7a8dd2b93e1b09c9af4d174c56c946d1eec7586bea5c75e9b624375f3442b",
+				"DiscoKey":   "discokey:08b1d5bc63e8dacfb078a9b276ea59f8ef1e2f00ce868e429324f4f19a7dac56",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35595",
+					"10.65.0.27:35595",
+					"172.17.0.1:35595",
+					"172.18.0.1:35595",
+					"172.19.0.1:35595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:12:50.224096993Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4729479275972653,
+				"StableID":   "nY64HFQzvd11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fa4ddc2510af5be8da1d02db19dfd6dca0757a89b80876a4559f3f92817a66d",
+				"DiscoKey":   "discokey:05b6f7f61be43bdebf3e2e95d20c44cdfc8c8d733b7f516c885a2cb26e5fa87f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49048",
+					"10.65.0.27:49048",
+					"172.17.0.1:49048",
+					"172.18.0.1:49048",
+					"172.19.0.1:49048"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:12:50.773768448Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         971317712465959,
+				"StableID":   "n4DW8Rsua811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2423c5b4f5c9edae93f90c45305d3b7870ea1702d1444b920ea3645fdc055144",
+				"DiscoKey":   "discokey:42233904dacf1e0a90385252014c0fcebbc7fe6bd02c6e59864de89b05a51840",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:51807",
+					"10.65.0.27:51807",
+					"172.17.0.1:51807",
+					"172.18.0.1:51807",
+					"172.19.0.1:51807"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:12:51.879745394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3825410319579337,
+				"StableID":   "nnoTST3YsW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:575d39df85f32cbc5540e280d2942b58f50ba4fe65028d1edcdd2df04784983f",
+				"KeyExpiry":  "2026-11-08T22:12:52Z",
+				"DiscoKey":   "discokey:4c5ad71c45fdc9d2bfb8e9dff930492d92f6aaf5812938a94391470c03294144",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45129",
+					"10.65.0.27:45129",
+					"172.17.0.1:45129",
+					"172.18.0.1:45129",
+					"172.19.0.1:45129"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:12:52.411276822Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3821327416286260,
+				"StableID":   "nPzrFungqW11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b62feb33325b189d0b914fece2a1a61646a8835f0d3ae218442efdba998b3050",
+				"KeyExpiry":  "2026-11-08T22:12:52Z",
+				"DiscoKey":   "discokey:4b44846593f049e412a81cd20a3b735218d8cf62703f766e363da0133a63e65e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:42957",
+					"10.65.0.27:42957",
+					"172.17.0.1:42957",
+					"172.18.0.1:42957",
+					"172.19.0.1:42957"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 53165},
+					{"Proto": "peerapi6", "Port": 53165}
+				]},
+				"Created":              "2026-05-12T22:12:52.93257841Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5252472108465548,
+				"StableID":   "nBaoy4Yr1i11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:4d379b7250c65dba4fb229035fc5058a4550c621af42f5b7b25972bfd3f35422",
+				"KeyExpiry":  "2026-11-08T22:12:53Z",
+				"DiscoKey":   "discokey:e724c69890c6b6c097034c88982f335258d0bfee0ee143fcfd1f9bb7fc2c4c6f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59814",
+					"10.65.0.27:59814",
+					"172.17.0.1:59814",
+					"172.18.0.1:59814",
+					"172.19.0.1:59814"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:12:53.46976722Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1199415976500311": {
+				"ID":          1199415976500311,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2206922408666095,
+				"StableID":   "nzLB1M7XEJ11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       2206922408666095,
+				"Key":        "nodekey:6edecf637d1b72e078156a22394d4dea7a16953906de2b417697931a7b75d95a",
+				"DiscoKey":   "discokey:77b4a430760c4e5e669aed761df404a289f2b301e4f7f4a92d9c44a5e4655d69",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45931",
+					"10.65.0.27:45931",
+					"172.17.0.1:45931",
+					"172.18.0.1:45931",
+					"172.19.0.1:45931"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:12:46.432801487Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6edecf637d1b72e078156a22394d4dea7a16953906de2b417697931a7b75d95a",
+			"MachineKey": "mkey:322245d133de2c6bd23f96e17bdd5f0425bffb1782e42cfda10fb38620b68739",
+			"Peers": [{
+				"ID":         5558691465482482,
+				"StableID":   "n3Xgx8QYQk11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:98da7e6ebf8ab5100951b5ebd79e39565b462ba85ba10594372fefac12e13e4f",
+				"DiscoKey":   "discokey:d77cd03005778ec806410b6f34bf2d47594599a95e7e996ae8fdaab2c06d5833",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52099",
+					"10.65.0.27:52099",
+					"172.17.0.1:52099",
+					"172.18.0.1:52099",
+					"172.19.0.1:52099"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:12:45.895894102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5087440775102692,
+				"StableID":   "nD74BfS7jg11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ac08d7f0ad82e0cf1efaed80e4d336b833be51646e01dfddcbbfb90616562015",
+				"DiscoKey":   "discokey:27ae7f82f4530a342d62ad2ca67b5d5243677aabdc10f75de8a39b08f99ca33c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45214",
+					"10.65.0.27:45214",
+					"172.17.0.1:45214",
+					"172.18.0.1:45214",
+					"172.19.0.1:45214"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:12:46.973792182Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1463992035291258,
+				"StableID":   "nKXJx7b3SC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c1648acb6e82abc453d71465082c59b7108146bb5c9be5c0edd1e7e872d2b34",
+				"DiscoKey":   "discokey:5a0846834e752129434d425e6ed3d66c79e20a731528398ec7695b6cd3e24151",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39677",
+					"10.65.0.27:39677",
+					"172.17.0.1:39677",
+					"172.18.0.1:39677",
+					"172.19.0.1:39677"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:12:47.535215898Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2480455672107944,
+				"StableID":   "nPpip8NQNL11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85bcf32b5f8933f2af2a029dfed5757e4d5bc9d6bdbf46b6292974e6d11d527b",
+				"DiscoKey":   "discokey:6b4d856936c08e772ed5713cac5bd2579ef6ddfc640c5ea0ec977b0411a6433a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40590",
+					"10.65.0.27:40590",
+					"172.17.0.1:40590",
+					"172.18.0.1:40590",
+					"172.19.0.1:40590"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:12:48.057525716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7114218108595119,
+				"StableID":   "nQV9msS3Zx11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:92264e4a656982c2b4c9ecd1ea8706eff37454995799a365538a1bc2a578a977",
+				"DiscoKey":   "discokey:87c7b9d30e4fc5485801aab92dcca177fdc08174d854877f6149c48ebc820328",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44686",
+					"10.65.0.27:44686",
+					"172.17.0.1:44686",
+					"172.18.0.1:44686",
+					"172.19.0.1:44686"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:12:48.593717138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         260808352712436,
+				"StableID":   "nKru2cz73311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:98ba75410c7c8aecb67b493832dd55d7b672eae4998f6d037a70c79993a5e47e",
+				"DiscoKey":   "discokey:fc65e0de86703d23c2c72177a4436550fec98676e3afc4afbbd1d0d5e8012e7f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58429",
+					"10.65.0.27:58429",
+					"172.17.0.1:58429",
+					"172.18.0.1:58429",
+					"172.19.0.1:58429"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:12:49.151757463Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1971300116950462,
+				"StableID":   "n3fDwFioPG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3ee77c1577449a8fb4517c9c85572898604082042524b52df393f82fe9426a48",
+				"DiscoKey":   "discokey:b5162837376348737a9da5579379b3528d5fb49e913972a776e38c75e180df07",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33235",
+					"10.65.0.27:33235",
+					"172.17.0.1:33235",
+					"172.18.0.1:33235",
+					"172.19.0.1:33235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:12:49.686954161Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1646544989659953,
+				"StableID":   "n4veQowirD11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6db7a8dd2b93e1b09c9af4d174c56c946d1eec7586bea5c75e9b624375f3442b",
+				"DiscoKey":   "discokey:08b1d5bc63e8dacfb078a9b276ea59f8ef1e2f00ce868e429324f4f19a7dac56",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35595",
+					"10.65.0.27:35595",
+					"172.17.0.1:35595",
+					"172.18.0.1:35595",
+					"172.19.0.1:35595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:12:50.224096993Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4729479275972653,
+				"StableID":   "nY64HFQzvd11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fa4ddc2510af5be8da1d02db19dfd6dca0757a89b80876a4559f3f92817a66d",
+				"DiscoKey":   "discokey:05b6f7f61be43bdebf3e2e95d20c44cdfc8c8d733b7f516c885a2cb26e5fa87f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49048",
+					"10.65.0.27:49048",
+					"172.17.0.1:49048",
+					"172.18.0.1:49048",
+					"172.19.0.1:49048"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:12:50.773768448Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1199415976500311,
+				"StableID":   "nWSudBdDNA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dec8653cbd3d5d0ee3a5b10a993c99b60c84dd72074e8acb2918a92543fef427",
+				"DiscoKey":   "discokey:d30ce9a476f5336971eeebc984ae0e2a29da3108f95fbe3b942b95cda9ded30f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:47936",
+					"10.65.0.27:47936",
+					"172.17.0.1:47936",
+					"172.18.0.1:47936",
+					"172.19.0.1:47936"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:12:51.31963675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         971317712465959,
+				"StableID":   "n4DW8Rsua811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2423c5b4f5c9edae93f90c45305d3b7870ea1702d1444b920ea3645fdc055144",
+				"DiscoKey":   "discokey:42233904dacf1e0a90385252014c0fcebbc7fe6bd02c6e59864de89b05a51840",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:51807",
+					"10.65.0.27:51807",
+					"172.17.0.1:51807",
+					"172.18.0.1:51807",
+					"172.19.0.1:51807"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:12:51.879745394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3825410319579337,
+				"StableID":   "nnoTST3YsW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:575d39df85f32cbc5540e280d2942b58f50ba4fe65028d1edcdd2df04784983f",
+				"KeyExpiry":  "2026-11-08T22:12:52Z",
+				"DiscoKey":   "discokey:4c5ad71c45fdc9d2bfb8e9dff930492d92f6aaf5812938a94391470c03294144",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45129",
+					"10.65.0.27:45129",
+					"172.17.0.1:45129",
+					"172.18.0.1:45129",
+					"172.19.0.1:45129"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:12:52.411276822Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3821327416286260,
+				"StableID":   "nPzrFungqW11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b62feb33325b189d0b914fece2a1a61646a8835f0d3ae218442efdba998b3050",
+				"KeyExpiry":  "2026-11-08T22:12:52Z",
+				"DiscoKey":   "discokey:4b44846593f049e412a81cd20a3b735218d8cf62703f766e363da0133a63e65e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:42957",
+					"10.65.0.27:42957",
+					"172.17.0.1:42957",
+					"172.18.0.1:42957",
+					"172.19.0.1:42957"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 53165},
+					{"Proto": "peerapi6", "Port": 53165}
+				]},
+				"Created":              "2026-05-12T22:12:52.93257841Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5252472108465548,
+				"StableID":   "nBaoy4Yr1i11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:4d379b7250c65dba4fb229035fc5058a4550c621af42f5b7b25972bfd3f35422",
+				"KeyExpiry":  "2026-11-08T22:12:53Z",
+				"DiscoKey":   "discokey:e724c69890c6b6c097034c88982f335258d0bfee0ee143fcfd1f9bb7fc2c4c6f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59814",
+					"10.65.0.27:59814",
+					"172.17.0.1:59814",
+					"172.18.0.1:59814",
+					"172.19.0.1:59814"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:12:53.46976722Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2206922408666095": {
+				"ID":          2206922408666095,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5558691465482482,
+				"StableID":   "n3Xgx8QYQk11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       5558691465482482,
+				"Key":        "nodekey:98da7e6ebf8ab5100951b5ebd79e39565b462ba85ba10594372fefac12e13e4f",
+				"DiscoKey":   "discokey:d77cd03005778ec806410b6f34bf2d47594599a95e7e996ae8fdaab2c06d5833",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52099",
+					"10.65.0.27:52099",
+					"172.17.0.1:52099",
+					"172.18.0.1:52099",
+					"172.19.0.1:52099"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:12:45.895894102Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:98da7e6ebf8ab5100951b5ebd79e39565b462ba85ba10594372fefac12e13e4f",
+			"MachineKey": "mkey:cacd9f86cde5a802f395ba81b882ea530426bb490dd1cfdf20dbb530af5cf607",
+			"Peers": [{
+				"ID":         2206922408666095,
+				"StableID":   "nzLB1M7XEJ11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6edecf637d1b72e078156a22394d4dea7a16953906de2b417697931a7b75d95a",
+				"DiscoKey":   "discokey:77b4a430760c4e5e669aed761df404a289f2b301e4f7f4a92d9c44a5e4655d69",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45931",
+					"10.65.0.27:45931",
+					"172.17.0.1:45931",
+					"172.18.0.1:45931",
+					"172.19.0.1:45931"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:12:46.432801487Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5087440775102692,
+				"StableID":   "nD74BfS7jg11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ac08d7f0ad82e0cf1efaed80e4d336b833be51646e01dfddcbbfb90616562015",
+				"DiscoKey":   "discokey:27ae7f82f4530a342d62ad2ca67b5d5243677aabdc10f75de8a39b08f99ca33c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45214",
+					"10.65.0.27:45214",
+					"172.17.0.1:45214",
+					"172.18.0.1:45214",
+					"172.19.0.1:45214"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:12:46.973792182Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1463992035291258,
+				"StableID":   "nKXJx7b3SC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c1648acb6e82abc453d71465082c59b7108146bb5c9be5c0edd1e7e872d2b34",
+				"DiscoKey":   "discokey:5a0846834e752129434d425e6ed3d66c79e20a731528398ec7695b6cd3e24151",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39677",
+					"10.65.0.27:39677",
+					"172.17.0.1:39677",
+					"172.18.0.1:39677",
+					"172.19.0.1:39677"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:12:47.535215898Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2480455672107944,
+				"StableID":   "nPpip8NQNL11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85bcf32b5f8933f2af2a029dfed5757e4d5bc9d6bdbf46b6292974e6d11d527b",
+				"DiscoKey":   "discokey:6b4d856936c08e772ed5713cac5bd2579ef6ddfc640c5ea0ec977b0411a6433a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40590",
+					"10.65.0.27:40590",
+					"172.17.0.1:40590",
+					"172.18.0.1:40590",
+					"172.19.0.1:40590"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:12:48.057525716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7114218108595119,
+				"StableID":   "nQV9msS3Zx11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:92264e4a656982c2b4c9ecd1ea8706eff37454995799a365538a1bc2a578a977",
+				"DiscoKey":   "discokey:87c7b9d30e4fc5485801aab92dcca177fdc08174d854877f6149c48ebc820328",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44686",
+					"10.65.0.27:44686",
+					"172.17.0.1:44686",
+					"172.18.0.1:44686",
+					"172.19.0.1:44686"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:12:48.593717138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         260808352712436,
+				"StableID":   "nKru2cz73311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:98ba75410c7c8aecb67b493832dd55d7b672eae4998f6d037a70c79993a5e47e",
+				"DiscoKey":   "discokey:fc65e0de86703d23c2c72177a4436550fec98676e3afc4afbbd1d0d5e8012e7f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58429",
+					"10.65.0.27:58429",
+					"172.17.0.1:58429",
+					"172.18.0.1:58429",
+					"172.19.0.1:58429"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:12:49.151757463Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1971300116950462,
+				"StableID":   "n3fDwFioPG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3ee77c1577449a8fb4517c9c85572898604082042524b52df393f82fe9426a48",
+				"DiscoKey":   "discokey:b5162837376348737a9da5579379b3528d5fb49e913972a776e38c75e180df07",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33235",
+					"10.65.0.27:33235",
+					"172.17.0.1:33235",
+					"172.18.0.1:33235",
+					"172.19.0.1:33235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:12:49.686954161Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1646544989659953,
+				"StableID":   "n4veQowirD11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6db7a8dd2b93e1b09c9af4d174c56c946d1eec7586bea5c75e9b624375f3442b",
+				"DiscoKey":   "discokey:08b1d5bc63e8dacfb078a9b276ea59f8ef1e2f00ce868e429324f4f19a7dac56",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35595",
+					"10.65.0.27:35595",
+					"172.17.0.1:35595",
+					"172.18.0.1:35595",
+					"172.19.0.1:35595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:12:50.224096993Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4729479275972653,
+				"StableID":   "nY64HFQzvd11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fa4ddc2510af5be8da1d02db19dfd6dca0757a89b80876a4559f3f92817a66d",
+				"DiscoKey":   "discokey:05b6f7f61be43bdebf3e2e95d20c44cdfc8c8d733b7f516c885a2cb26e5fa87f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49048",
+					"10.65.0.27:49048",
+					"172.17.0.1:49048",
+					"172.18.0.1:49048",
+					"172.19.0.1:49048"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:12:50.773768448Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1199415976500311,
+				"StableID":   "nWSudBdDNA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dec8653cbd3d5d0ee3a5b10a993c99b60c84dd72074e8acb2918a92543fef427",
+				"DiscoKey":   "discokey:d30ce9a476f5336971eeebc984ae0e2a29da3108f95fbe3b942b95cda9ded30f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:47936",
+					"10.65.0.27:47936",
+					"172.17.0.1:47936",
+					"172.18.0.1:47936",
+					"172.19.0.1:47936"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:12:51.31963675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         971317712465959,
+				"StableID":   "n4DW8Rsua811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2423c5b4f5c9edae93f90c45305d3b7870ea1702d1444b920ea3645fdc055144",
+				"DiscoKey":   "discokey:42233904dacf1e0a90385252014c0fcebbc7fe6bd02c6e59864de89b05a51840",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:51807",
+					"10.65.0.27:51807",
+					"172.17.0.1:51807",
+					"172.18.0.1:51807",
+					"172.19.0.1:51807"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:12:51.879745394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3825410319579337,
+				"StableID":   "nnoTST3YsW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:575d39df85f32cbc5540e280d2942b58f50ba4fe65028d1edcdd2df04784983f",
+				"KeyExpiry":  "2026-11-08T22:12:52Z",
+				"DiscoKey":   "discokey:4c5ad71c45fdc9d2bfb8e9dff930492d92f6aaf5812938a94391470c03294144",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45129",
+					"10.65.0.27:45129",
+					"172.17.0.1:45129",
+					"172.18.0.1:45129",
+					"172.19.0.1:45129"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:12:52.411276822Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3821327416286260,
+				"StableID":   "nPzrFungqW11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b62feb33325b189d0b914fece2a1a61646a8835f0d3ae218442efdba998b3050",
+				"KeyExpiry":  "2026-11-08T22:12:52Z",
+				"DiscoKey":   "discokey:4b44846593f049e412a81cd20a3b735218d8cf62703f766e363da0133a63e65e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:42957",
+					"10.65.0.27:42957",
+					"172.17.0.1:42957",
+					"172.18.0.1:42957",
+					"172.19.0.1:42957"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 53165},
+					{"Proto": "peerapi6", "Port": 53165}
+				]},
+				"Created":              "2026-05-12T22:12:52.93257841Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5252472108465548,
+				"StableID":   "nBaoy4Yr1i11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:4d379b7250c65dba4fb229035fc5058a4550c621af42f5b7b25972bfd3f35422",
+				"KeyExpiry":  "2026-11-08T22:12:53Z",
+				"DiscoKey":   "discokey:e724c69890c6b6c097034c88982f335258d0bfee0ee143fcfd1f9bb7fc2c4c6f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59814",
+					"10.65.0.27:59814",
+					"172.17.0.1:59814",
+					"172.18.0.1:59814",
+					"172.19.0.1:59814"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:12:53.46976722Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5558691465482482": {
+				"ID":          5558691465482482,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2480455672107944,
+				"StableID":   "nPpip8NQNL11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       2480455672107944,
+				"Key":        "nodekey:85bcf32b5f8933f2af2a029dfed5757e4d5bc9d6bdbf46b6292974e6d11d527b",
+				"DiscoKey":   "discokey:6b4d856936c08e772ed5713cac5bd2579ef6ddfc640c5ea0ec977b0411a6433a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40590",
+					"10.65.0.27:40590",
+					"172.17.0.1:40590",
+					"172.18.0.1:40590",
+					"172.19.0.1:40590"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:12:48.057525716Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:85bcf32b5f8933f2af2a029dfed5757e4d5bc9d6bdbf46b6292974e6d11d527b",
+			"MachineKey": "mkey:1c5fe5b06d11af6e9d9985bbd811b82e635572407e782ee32a47bb6f47e8925f",
+			"Peers": [{
+				"ID":         5558691465482482,
+				"StableID":   "n3Xgx8QYQk11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:98da7e6ebf8ab5100951b5ebd79e39565b462ba85ba10594372fefac12e13e4f",
+				"DiscoKey":   "discokey:d77cd03005778ec806410b6f34bf2d47594599a95e7e996ae8fdaab2c06d5833",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52099",
+					"10.65.0.27:52099",
+					"172.17.0.1:52099",
+					"172.18.0.1:52099",
+					"172.19.0.1:52099"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:12:45.895894102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2206922408666095,
+				"StableID":   "nzLB1M7XEJ11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6edecf637d1b72e078156a22394d4dea7a16953906de2b417697931a7b75d95a",
+				"DiscoKey":   "discokey:77b4a430760c4e5e669aed761df404a289f2b301e4f7f4a92d9c44a5e4655d69",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45931",
+					"10.65.0.27:45931",
+					"172.17.0.1:45931",
+					"172.18.0.1:45931",
+					"172.19.0.1:45931"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:12:46.432801487Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5087440775102692,
+				"StableID":   "nD74BfS7jg11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ac08d7f0ad82e0cf1efaed80e4d336b833be51646e01dfddcbbfb90616562015",
+				"DiscoKey":   "discokey:27ae7f82f4530a342d62ad2ca67b5d5243677aabdc10f75de8a39b08f99ca33c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45214",
+					"10.65.0.27:45214",
+					"172.17.0.1:45214",
+					"172.18.0.1:45214",
+					"172.19.0.1:45214"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:12:46.973792182Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1463992035291258,
+				"StableID":   "nKXJx7b3SC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c1648acb6e82abc453d71465082c59b7108146bb5c9be5c0edd1e7e872d2b34",
+				"DiscoKey":   "discokey:5a0846834e752129434d425e6ed3d66c79e20a731528398ec7695b6cd3e24151",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39677",
+					"10.65.0.27:39677",
+					"172.17.0.1:39677",
+					"172.18.0.1:39677",
+					"172.19.0.1:39677"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:12:47.535215898Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7114218108595119,
+				"StableID":   "nQV9msS3Zx11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:92264e4a656982c2b4c9ecd1ea8706eff37454995799a365538a1bc2a578a977",
+				"DiscoKey":   "discokey:87c7b9d30e4fc5485801aab92dcca177fdc08174d854877f6149c48ebc820328",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44686",
+					"10.65.0.27:44686",
+					"172.17.0.1:44686",
+					"172.18.0.1:44686",
+					"172.19.0.1:44686"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:12:48.593717138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         260808352712436,
+				"StableID":   "nKru2cz73311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:98ba75410c7c8aecb67b493832dd55d7b672eae4998f6d037a70c79993a5e47e",
+				"DiscoKey":   "discokey:fc65e0de86703d23c2c72177a4436550fec98676e3afc4afbbd1d0d5e8012e7f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58429",
+					"10.65.0.27:58429",
+					"172.17.0.1:58429",
+					"172.18.0.1:58429",
+					"172.19.0.1:58429"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:12:49.151757463Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1971300116950462,
+				"StableID":   "n3fDwFioPG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3ee77c1577449a8fb4517c9c85572898604082042524b52df393f82fe9426a48",
+				"DiscoKey":   "discokey:b5162837376348737a9da5579379b3528d5fb49e913972a776e38c75e180df07",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33235",
+					"10.65.0.27:33235",
+					"172.17.0.1:33235",
+					"172.18.0.1:33235",
+					"172.19.0.1:33235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:12:49.686954161Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1646544989659953,
+				"StableID":   "n4veQowirD11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6db7a8dd2b93e1b09c9af4d174c56c946d1eec7586bea5c75e9b624375f3442b",
+				"DiscoKey":   "discokey:08b1d5bc63e8dacfb078a9b276ea59f8ef1e2f00ce868e429324f4f19a7dac56",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35595",
+					"10.65.0.27:35595",
+					"172.17.0.1:35595",
+					"172.18.0.1:35595",
+					"172.19.0.1:35595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:12:50.224096993Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4729479275972653,
+				"StableID":   "nY64HFQzvd11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fa4ddc2510af5be8da1d02db19dfd6dca0757a89b80876a4559f3f92817a66d",
+				"DiscoKey":   "discokey:05b6f7f61be43bdebf3e2e95d20c44cdfc8c8d733b7f516c885a2cb26e5fa87f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49048",
+					"10.65.0.27:49048",
+					"172.17.0.1:49048",
+					"172.18.0.1:49048",
+					"172.19.0.1:49048"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:12:50.773768448Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1199415976500311,
+				"StableID":   "nWSudBdDNA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dec8653cbd3d5d0ee3a5b10a993c99b60c84dd72074e8acb2918a92543fef427",
+				"DiscoKey":   "discokey:d30ce9a476f5336971eeebc984ae0e2a29da3108f95fbe3b942b95cda9ded30f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:47936",
+					"10.65.0.27:47936",
+					"172.17.0.1:47936",
+					"172.18.0.1:47936",
+					"172.19.0.1:47936"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:12:51.31963675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         971317712465959,
+				"StableID":   "n4DW8Rsua811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2423c5b4f5c9edae93f90c45305d3b7870ea1702d1444b920ea3645fdc055144",
+				"DiscoKey":   "discokey:42233904dacf1e0a90385252014c0fcebbc7fe6bd02c6e59864de89b05a51840",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:51807",
+					"10.65.0.27:51807",
+					"172.17.0.1:51807",
+					"172.18.0.1:51807",
+					"172.19.0.1:51807"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:12:51.879745394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3825410319579337,
+				"StableID":   "nnoTST3YsW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:575d39df85f32cbc5540e280d2942b58f50ba4fe65028d1edcdd2df04784983f",
+				"KeyExpiry":  "2026-11-08T22:12:52Z",
+				"DiscoKey":   "discokey:4c5ad71c45fdc9d2bfb8e9dff930492d92f6aaf5812938a94391470c03294144",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45129",
+					"10.65.0.27:45129",
+					"172.17.0.1:45129",
+					"172.18.0.1:45129",
+					"172.19.0.1:45129"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:12:52.411276822Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3821327416286260,
+				"StableID":   "nPzrFungqW11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b62feb33325b189d0b914fece2a1a61646a8835f0d3ae218442efdba998b3050",
+				"KeyExpiry":  "2026-11-08T22:12:52Z",
+				"DiscoKey":   "discokey:4b44846593f049e412a81cd20a3b735218d8cf62703f766e363da0133a63e65e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:42957",
+					"10.65.0.27:42957",
+					"172.17.0.1:42957",
+					"172.18.0.1:42957",
+					"172.19.0.1:42957"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 53165},
+					{"Proto": "peerapi6", "Port": 53165}
+				]},
+				"Created":              "2026-05-12T22:12:52.93257841Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5252472108465548,
+				"StableID":   "nBaoy4Yr1i11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:4d379b7250c65dba4fb229035fc5058a4550c621af42f5b7b25972bfd3f35422",
+				"KeyExpiry":  "2026-11-08T22:12:53Z",
+				"DiscoKey":   "discokey:e724c69890c6b6c097034c88982f335258d0bfee0ee143fcfd1f9bb7fc2c4c6f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59814",
+					"10.65.0.27:59814",
+					"172.17.0.1:59814",
+					"172.18.0.1:59814",
+					"172.19.0.1:59814"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:12:53.46976722Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2480455672107944": {
+				"ID":          2480455672107944,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1463992035291258,
+				"StableID":   "nKXJx7b3SC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1463992035291258,
+				"Key":        "nodekey:1c1648acb6e82abc453d71465082c59b7108146bb5c9be5c0edd1e7e872d2b34",
+				"DiscoKey":   "discokey:5a0846834e752129434d425e6ed3d66c79e20a731528398ec7695b6cd3e24151",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39677",
+					"10.65.0.27:39677",
+					"172.17.0.1:39677",
+					"172.18.0.1:39677",
+					"172.19.0.1:39677"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:12:47.535215898Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1c1648acb6e82abc453d71465082c59b7108146bb5c9be5c0edd1e7e872d2b34",
+			"MachineKey": "mkey:4dcb9a67076fddfa81b24990b0f019a450a0574b3bdeb74ae2d337526bf9616a",
+			"Peers": [{
+				"ID":         5558691465482482,
+				"StableID":   "n3Xgx8QYQk11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:98da7e6ebf8ab5100951b5ebd79e39565b462ba85ba10594372fefac12e13e4f",
+				"DiscoKey":   "discokey:d77cd03005778ec806410b6f34bf2d47594599a95e7e996ae8fdaab2c06d5833",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52099",
+					"10.65.0.27:52099",
+					"172.17.0.1:52099",
+					"172.18.0.1:52099",
+					"172.19.0.1:52099"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:12:45.895894102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2206922408666095,
+				"StableID":   "nzLB1M7XEJ11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6edecf637d1b72e078156a22394d4dea7a16953906de2b417697931a7b75d95a",
+				"DiscoKey":   "discokey:77b4a430760c4e5e669aed761df404a289f2b301e4f7f4a92d9c44a5e4655d69",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45931",
+					"10.65.0.27:45931",
+					"172.17.0.1:45931",
+					"172.18.0.1:45931",
+					"172.19.0.1:45931"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:12:46.432801487Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5087440775102692,
+				"StableID":   "nD74BfS7jg11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ac08d7f0ad82e0cf1efaed80e4d336b833be51646e01dfddcbbfb90616562015",
+				"DiscoKey":   "discokey:27ae7f82f4530a342d62ad2ca67b5d5243677aabdc10f75de8a39b08f99ca33c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45214",
+					"10.65.0.27:45214",
+					"172.17.0.1:45214",
+					"172.18.0.1:45214",
+					"172.19.0.1:45214"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:12:46.973792182Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2480455672107944,
+				"StableID":   "nPpip8NQNL11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85bcf32b5f8933f2af2a029dfed5757e4d5bc9d6bdbf46b6292974e6d11d527b",
+				"DiscoKey":   "discokey:6b4d856936c08e772ed5713cac5bd2579ef6ddfc640c5ea0ec977b0411a6433a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40590",
+					"10.65.0.27:40590",
+					"172.17.0.1:40590",
+					"172.18.0.1:40590",
+					"172.19.0.1:40590"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:12:48.057525716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7114218108595119,
+				"StableID":   "nQV9msS3Zx11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:92264e4a656982c2b4c9ecd1ea8706eff37454995799a365538a1bc2a578a977",
+				"DiscoKey":   "discokey:87c7b9d30e4fc5485801aab92dcca177fdc08174d854877f6149c48ebc820328",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44686",
+					"10.65.0.27:44686",
+					"172.17.0.1:44686",
+					"172.18.0.1:44686",
+					"172.19.0.1:44686"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:12:48.593717138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         260808352712436,
+				"StableID":   "nKru2cz73311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:98ba75410c7c8aecb67b493832dd55d7b672eae4998f6d037a70c79993a5e47e",
+				"DiscoKey":   "discokey:fc65e0de86703d23c2c72177a4436550fec98676e3afc4afbbd1d0d5e8012e7f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58429",
+					"10.65.0.27:58429",
+					"172.17.0.1:58429",
+					"172.18.0.1:58429",
+					"172.19.0.1:58429"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:12:49.151757463Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1971300116950462,
+				"StableID":   "n3fDwFioPG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3ee77c1577449a8fb4517c9c85572898604082042524b52df393f82fe9426a48",
+				"DiscoKey":   "discokey:b5162837376348737a9da5579379b3528d5fb49e913972a776e38c75e180df07",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33235",
+					"10.65.0.27:33235",
+					"172.17.0.1:33235",
+					"172.18.0.1:33235",
+					"172.19.0.1:33235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:12:49.686954161Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1646544989659953,
+				"StableID":   "n4veQowirD11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6db7a8dd2b93e1b09c9af4d174c56c946d1eec7586bea5c75e9b624375f3442b",
+				"DiscoKey":   "discokey:08b1d5bc63e8dacfb078a9b276ea59f8ef1e2f00ce868e429324f4f19a7dac56",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35595",
+					"10.65.0.27:35595",
+					"172.17.0.1:35595",
+					"172.18.0.1:35595",
+					"172.19.0.1:35595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:12:50.224096993Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4729479275972653,
+				"StableID":   "nY64HFQzvd11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fa4ddc2510af5be8da1d02db19dfd6dca0757a89b80876a4559f3f92817a66d",
+				"DiscoKey":   "discokey:05b6f7f61be43bdebf3e2e95d20c44cdfc8c8d733b7f516c885a2cb26e5fa87f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49048",
+					"10.65.0.27:49048",
+					"172.17.0.1:49048",
+					"172.18.0.1:49048",
+					"172.19.0.1:49048"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:12:50.773768448Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1199415976500311,
+				"StableID":   "nWSudBdDNA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dec8653cbd3d5d0ee3a5b10a993c99b60c84dd72074e8acb2918a92543fef427",
+				"DiscoKey":   "discokey:d30ce9a476f5336971eeebc984ae0e2a29da3108f95fbe3b942b95cda9ded30f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:47936",
+					"10.65.0.27:47936",
+					"172.17.0.1:47936",
+					"172.18.0.1:47936",
+					"172.19.0.1:47936"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:12:51.31963675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         971317712465959,
+				"StableID":   "n4DW8Rsua811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2423c5b4f5c9edae93f90c45305d3b7870ea1702d1444b920ea3645fdc055144",
+				"DiscoKey":   "discokey:42233904dacf1e0a90385252014c0fcebbc7fe6bd02c6e59864de89b05a51840",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:51807",
+					"10.65.0.27:51807",
+					"172.17.0.1:51807",
+					"172.18.0.1:51807",
+					"172.19.0.1:51807"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:12:51.879745394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3825410319579337,
+				"StableID":   "nnoTST3YsW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:575d39df85f32cbc5540e280d2942b58f50ba4fe65028d1edcdd2df04784983f",
+				"KeyExpiry":  "2026-11-08T22:12:52Z",
+				"DiscoKey":   "discokey:4c5ad71c45fdc9d2bfb8e9dff930492d92f6aaf5812938a94391470c03294144",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45129",
+					"10.65.0.27:45129",
+					"172.17.0.1:45129",
+					"172.18.0.1:45129",
+					"172.19.0.1:45129"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:12:52.411276822Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3821327416286260,
+				"StableID":   "nPzrFungqW11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b62feb33325b189d0b914fece2a1a61646a8835f0d3ae218442efdba998b3050",
+				"KeyExpiry":  "2026-11-08T22:12:52Z",
+				"DiscoKey":   "discokey:4b44846593f049e412a81cd20a3b735218d8cf62703f766e363da0133a63e65e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:42957",
+					"10.65.0.27:42957",
+					"172.17.0.1:42957",
+					"172.18.0.1:42957",
+					"172.19.0.1:42957"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 53165},
+					{"Proto": "peerapi6", "Port": 53165}
+				]},
+				"Created":              "2026-05-12T22:12:52.93257841Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5252472108465548,
+				"StableID":   "nBaoy4Yr1i11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:4d379b7250c65dba4fb229035fc5058a4550c621af42f5b7b25972bfd3f35422",
+				"KeyExpiry":  "2026-11-08T22:12:53Z",
+				"DiscoKey":   "discokey:e724c69890c6b6c097034c88982f335258d0bfee0ee143fcfd1f9bb7fc2c4c6f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59814",
+					"10.65.0.27:59814",
+					"172.17.0.1:59814",
+					"172.18.0.1:59814",
+					"172.19.0.1:59814"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:12:53.46976722Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1463992035291258": {
+				"ID":          1463992035291258,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         260808352712436,
+				"StableID":   "nKru2cz73311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       260808352712436,
+				"Key":        "nodekey:98ba75410c7c8aecb67b493832dd55d7b672eae4998f6d037a70c79993a5e47e",
+				"DiscoKey":   "discokey:fc65e0de86703d23c2c72177a4436550fec98676e3afc4afbbd1d0d5e8012e7f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58429",
+					"10.65.0.27:58429",
+					"172.17.0.1:58429",
+					"172.18.0.1:58429",
+					"172.19.0.1:58429"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:12:49.151757463Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:98ba75410c7c8aecb67b493832dd55d7b672eae4998f6d037a70c79993a5e47e",
+			"MachineKey": "mkey:1788f4e2c2674ae09f3ed992b11312c38b1b98cc281c645697a9d943528d3c60",
+			"Peers": [{
+				"ID":         5558691465482482,
+				"StableID":   "n3Xgx8QYQk11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:98da7e6ebf8ab5100951b5ebd79e39565b462ba85ba10594372fefac12e13e4f",
+				"DiscoKey":   "discokey:d77cd03005778ec806410b6f34bf2d47594599a95e7e996ae8fdaab2c06d5833",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52099",
+					"10.65.0.27:52099",
+					"172.17.0.1:52099",
+					"172.18.0.1:52099",
+					"172.19.0.1:52099"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:12:45.895894102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2206922408666095,
+				"StableID":   "nzLB1M7XEJ11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6edecf637d1b72e078156a22394d4dea7a16953906de2b417697931a7b75d95a",
+				"DiscoKey":   "discokey:77b4a430760c4e5e669aed761df404a289f2b301e4f7f4a92d9c44a5e4655d69",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45931",
+					"10.65.0.27:45931",
+					"172.17.0.1:45931",
+					"172.18.0.1:45931",
+					"172.19.0.1:45931"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:12:46.432801487Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5087440775102692,
+				"StableID":   "nD74BfS7jg11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ac08d7f0ad82e0cf1efaed80e4d336b833be51646e01dfddcbbfb90616562015",
+				"DiscoKey":   "discokey:27ae7f82f4530a342d62ad2ca67b5d5243677aabdc10f75de8a39b08f99ca33c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45214",
+					"10.65.0.27:45214",
+					"172.17.0.1:45214",
+					"172.18.0.1:45214",
+					"172.19.0.1:45214"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:12:46.973792182Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1463992035291258,
+				"StableID":   "nKXJx7b3SC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c1648acb6e82abc453d71465082c59b7108146bb5c9be5c0edd1e7e872d2b34",
+				"DiscoKey":   "discokey:5a0846834e752129434d425e6ed3d66c79e20a731528398ec7695b6cd3e24151",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39677",
+					"10.65.0.27:39677",
+					"172.17.0.1:39677",
+					"172.18.0.1:39677",
+					"172.19.0.1:39677"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:12:47.535215898Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2480455672107944,
+				"StableID":   "nPpip8NQNL11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85bcf32b5f8933f2af2a029dfed5757e4d5bc9d6bdbf46b6292974e6d11d527b",
+				"DiscoKey":   "discokey:6b4d856936c08e772ed5713cac5bd2579ef6ddfc640c5ea0ec977b0411a6433a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40590",
+					"10.65.0.27:40590",
+					"172.17.0.1:40590",
+					"172.18.0.1:40590",
+					"172.19.0.1:40590"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:12:48.057525716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7114218108595119,
+				"StableID":   "nQV9msS3Zx11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:92264e4a656982c2b4c9ecd1ea8706eff37454995799a365538a1bc2a578a977",
+				"DiscoKey":   "discokey:87c7b9d30e4fc5485801aab92dcca177fdc08174d854877f6149c48ebc820328",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44686",
+					"10.65.0.27:44686",
+					"172.17.0.1:44686",
+					"172.18.0.1:44686",
+					"172.19.0.1:44686"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:12:48.593717138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1971300116950462,
+				"StableID":   "n3fDwFioPG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3ee77c1577449a8fb4517c9c85572898604082042524b52df393f82fe9426a48",
+				"DiscoKey":   "discokey:b5162837376348737a9da5579379b3528d5fb49e913972a776e38c75e180df07",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33235",
+					"10.65.0.27:33235",
+					"172.17.0.1:33235",
+					"172.18.0.1:33235",
+					"172.19.0.1:33235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:12:49.686954161Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1646544989659953,
+				"StableID":   "n4veQowirD11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6db7a8dd2b93e1b09c9af4d174c56c946d1eec7586bea5c75e9b624375f3442b",
+				"DiscoKey":   "discokey:08b1d5bc63e8dacfb078a9b276ea59f8ef1e2f00ce868e429324f4f19a7dac56",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35595",
+					"10.65.0.27:35595",
+					"172.17.0.1:35595",
+					"172.18.0.1:35595",
+					"172.19.0.1:35595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:12:50.224096993Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4729479275972653,
+				"StableID":   "nY64HFQzvd11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fa4ddc2510af5be8da1d02db19dfd6dca0757a89b80876a4559f3f92817a66d",
+				"DiscoKey":   "discokey:05b6f7f61be43bdebf3e2e95d20c44cdfc8c8d733b7f516c885a2cb26e5fa87f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49048",
+					"10.65.0.27:49048",
+					"172.17.0.1:49048",
+					"172.18.0.1:49048",
+					"172.19.0.1:49048"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:12:50.773768448Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1199415976500311,
+				"StableID":   "nWSudBdDNA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dec8653cbd3d5d0ee3a5b10a993c99b60c84dd72074e8acb2918a92543fef427",
+				"DiscoKey":   "discokey:d30ce9a476f5336971eeebc984ae0e2a29da3108f95fbe3b942b95cda9ded30f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:47936",
+					"10.65.0.27:47936",
+					"172.17.0.1:47936",
+					"172.18.0.1:47936",
+					"172.19.0.1:47936"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:12:51.31963675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         971317712465959,
+				"StableID":   "n4DW8Rsua811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2423c5b4f5c9edae93f90c45305d3b7870ea1702d1444b920ea3645fdc055144",
+				"DiscoKey":   "discokey:42233904dacf1e0a90385252014c0fcebbc7fe6bd02c6e59864de89b05a51840",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:51807",
+					"10.65.0.27:51807",
+					"172.17.0.1:51807",
+					"172.18.0.1:51807",
+					"172.19.0.1:51807"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:12:51.879745394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3825410319579337,
+				"StableID":   "nnoTST3YsW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:575d39df85f32cbc5540e280d2942b58f50ba4fe65028d1edcdd2df04784983f",
+				"KeyExpiry":  "2026-11-08T22:12:52Z",
+				"DiscoKey":   "discokey:4c5ad71c45fdc9d2bfb8e9dff930492d92f6aaf5812938a94391470c03294144",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45129",
+					"10.65.0.27:45129",
+					"172.17.0.1:45129",
+					"172.18.0.1:45129",
+					"172.19.0.1:45129"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:12:52.411276822Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3821327416286260,
+				"StableID":   "nPzrFungqW11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b62feb33325b189d0b914fece2a1a61646a8835f0d3ae218442efdba998b3050",
+				"KeyExpiry":  "2026-11-08T22:12:52Z",
+				"DiscoKey":   "discokey:4b44846593f049e412a81cd20a3b735218d8cf62703f766e363da0133a63e65e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:42957",
+					"10.65.0.27:42957",
+					"172.17.0.1:42957",
+					"172.18.0.1:42957",
+					"172.19.0.1:42957"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 53165},
+					{"Proto": "peerapi6", "Port": 53165}
+				]},
+				"Created":              "2026-05-12T22:12:52.93257841Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5252472108465548,
+				"StableID":   "nBaoy4Yr1i11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:4d379b7250c65dba4fb229035fc5058a4550c621af42f5b7b25972bfd3f35422",
+				"KeyExpiry":  "2026-11-08T22:12:53Z",
+				"DiscoKey":   "discokey:e724c69890c6b6c097034c88982f335258d0bfee0ee143fcfd1f9bb7fc2c4c6f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59814",
+					"10.65.0.27:59814",
+					"172.17.0.1:59814",
+					"172.18.0.1:59814",
+					"172.19.0.1:59814"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:12:53.46976722Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "260808352712436": {
+				"ID":          260808352712436,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1646544989659953,
+				"StableID":   "n4veQowirD11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1646544989659953,
+				"Key":        "nodekey:6db7a8dd2b93e1b09c9af4d174c56c946d1eec7586bea5c75e9b624375f3442b",
+				"DiscoKey":   "discokey:08b1d5bc63e8dacfb078a9b276ea59f8ef1e2f00ce868e429324f4f19a7dac56",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35595",
+					"10.65.0.27:35595",
+					"172.17.0.1:35595",
+					"172.18.0.1:35595",
+					"172.19.0.1:35595"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:12:50.224096993Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6db7a8dd2b93e1b09c9af4d174c56c946d1eec7586bea5c75e9b624375f3442b",
+			"MachineKey": "mkey:95d31ec37db1a636d58ebb1fd06acd152bd654a23679b710f1dd275aff269e12",
+			"Peers": [{
+				"ID":         5558691465482482,
+				"StableID":   "n3Xgx8QYQk11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:98da7e6ebf8ab5100951b5ebd79e39565b462ba85ba10594372fefac12e13e4f",
+				"DiscoKey":   "discokey:d77cd03005778ec806410b6f34bf2d47594599a95e7e996ae8fdaab2c06d5833",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52099",
+					"10.65.0.27:52099",
+					"172.17.0.1:52099",
+					"172.18.0.1:52099",
+					"172.19.0.1:52099"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:12:45.895894102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2206922408666095,
+				"StableID":   "nzLB1M7XEJ11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6edecf637d1b72e078156a22394d4dea7a16953906de2b417697931a7b75d95a",
+				"DiscoKey":   "discokey:77b4a430760c4e5e669aed761df404a289f2b301e4f7f4a92d9c44a5e4655d69",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45931",
+					"10.65.0.27:45931",
+					"172.17.0.1:45931",
+					"172.18.0.1:45931",
+					"172.19.0.1:45931"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:12:46.432801487Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5087440775102692,
+				"StableID":   "nD74BfS7jg11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ac08d7f0ad82e0cf1efaed80e4d336b833be51646e01dfddcbbfb90616562015",
+				"DiscoKey":   "discokey:27ae7f82f4530a342d62ad2ca67b5d5243677aabdc10f75de8a39b08f99ca33c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45214",
+					"10.65.0.27:45214",
+					"172.17.0.1:45214",
+					"172.18.0.1:45214",
+					"172.19.0.1:45214"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:12:46.973792182Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1463992035291258,
+				"StableID":   "nKXJx7b3SC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c1648acb6e82abc453d71465082c59b7108146bb5c9be5c0edd1e7e872d2b34",
+				"DiscoKey":   "discokey:5a0846834e752129434d425e6ed3d66c79e20a731528398ec7695b6cd3e24151",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39677",
+					"10.65.0.27:39677",
+					"172.17.0.1:39677",
+					"172.18.0.1:39677",
+					"172.19.0.1:39677"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:12:47.535215898Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2480455672107944,
+				"StableID":   "nPpip8NQNL11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85bcf32b5f8933f2af2a029dfed5757e4d5bc9d6bdbf46b6292974e6d11d527b",
+				"DiscoKey":   "discokey:6b4d856936c08e772ed5713cac5bd2579ef6ddfc640c5ea0ec977b0411a6433a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40590",
+					"10.65.0.27:40590",
+					"172.17.0.1:40590",
+					"172.18.0.1:40590",
+					"172.19.0.1:40590"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:12:48.057525716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7114218108595119,
+				"StableID":   "nQV9msS3Zx11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:92264e4a656982c2b4c9ecd1ea8706eff37454995799a365538a1bc2a578a977",
+				"DiscoKey":   "discokey:87c7b9d30e4fc5485801aab92dcca177fdc08174d854877f6149c48ebc820328",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44686",
+					"10.65.0.27:44686",
+					"172.17.0.1:44686",
+					"172.18.0.1:44686",
+					"172.19.0.1:44686"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:12:48.593717138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         260808352712436,
+				"StableID":   "nKru2cz73311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:98ba75410c7c8aecb67b493832dd55d7b672eae4998f6d037a70c79993a5e47e",
+				"DiscoKey":   "discokey:fc65e0de86703d23c2c72177a4436550fec98676e3afc4afbbd1d0d5e8012e7f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58429",
+					"10.65.0.27:58429",
+					"172.17.0.1:58429",
+					"172.18.0.1:58429",
+					"172.19.0.1:58429"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:12:49.151757463Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1971300116950462,
+				"StableID":   "n3fDwFioPG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3ee77c1577449a8fb4517c9c85572898604082042524b52df393f82fe9426a48",
+				"DiscoKey":   "discokey:b5162837376348737a9da5579379b3528d5fb49e913972a776e38c75e180df07",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33235",
+					"10.65.0.27:33235",
+					"172.17.0.1:33235",
+					"172.18.0.1:33235",
+					"172.19.0.1:33235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:12:49.686954161Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4729479275972653,
+				"StableID":   "nY64HFQzvd11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fa4ddc2510af5be8da1d02db19dfd6dca0757a89b80876a4559f3f92817a66d",
+				"DiscoKey":   "discokey:05b6f7f61be43bdebf3e2e95d20c44cdfc8c8d733b7f516c885a2cb26e5fa87f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49048",
+					"10.65.0.27:49048",
+					"172.17.0.1:49048",
+					"172.18.0.1:49048",
+					"172.19.0.1:49048"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:12:50.773768448Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1199415976500311,
+				"StableID":   "nWSudBdDNA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dec8653cbd3d5d0ee3a5b10a993c99b60c84dd72074e8acb2918a92543fef427",
+				"DiscoKey":   "discokey:d30ce9a476f5336971eeebc984ae0e2a29da3108f95fbe3b942b95cda9ded30f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:47936",
+					"10.65.0.27:47936",
+					"172.17.0.1:47936",
+					"172.18.0.1:47936",
+					"172.19.0.1:47936"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:12:51.31963675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         971317712465959,
+				"StableID":   "n4DW8Rsua811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2423c5b4f5c9edae93f90c45305d3b7870ea1702d1444b920ea3645fdc055144",
+				"DiscoKey":   "discokey:42233904dacf1e0a90385252014c0fcebbc7fe6bd02c6e59864de89b05a51840",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:51807",
+					"10.65.0.27:51807",
+					"172.17.0.1:51807",
+					"172.18.0.1:51807",
+					"172.19.0.1:51807"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:12:51.879745394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3825410319579337,
+				"StableID":   "nnoTST3YsW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:575d39df85f32cbc5540e280d2942b58f50ba4fe65028d1edcdd2df04784983f",
+				"KeyExpiry":  "2026-11-08T22:12:52Z",
+				"DiscoKey":   "discokey:4c5ad71c45fdc9d2bfb8e9dff930492d92f6aaf5812938a94391470c03294144",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45129",
+					"10.65.0.27:45129",
+					"172.17.0.1:45129",
+					"172.18.0.1:45129",
+					"172.19.0.1:45129"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:12:52.411276822Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3821327416286260,
+				"StableID":   "nPzrFungqW11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b62feb33325b189d0b914fece2a1a61646a8835f0d3ae218442efdba998b3050",
+				"KeyExpiry":  "2026-11-08T22:12:52Z",
+				"DiscoKey":   "discokey:4b44846593f049e412a81cd20a3b735218d8cf62703f766e363da0133a63e65e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:42957",
+					"10.65.0.27:42957",
+					"172.17.0.1:42957",
+					"172.18.0.1:42957",
+					"172.19.0.1:42957"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 53165},
+					{"Proto": "peerapi6", "Port": 53165}
+				]},
+				"Created":              "2026-05-12T22:12:52.93257841Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5252472108465548,
+				"StableID":   "nBaoy4Yr1i11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:4d379b7250c65dba4fb229035fc5058a4550c621af42f5b7b25972bfd3f35422",
+				"KeyExpiry":  "2026-11-08T22:12:53Z",
+				"DiscoKey":   "discokey:e724c69890c6b6c097034c88982f335258d0bfee0ee143fcfd1f9bb7fc2c4c6f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59814",
+					"10.65.0.27:59814",
+					"172.17.0.1:59814",
+					"172.18.0.1:59814",
+					"172.19.0.1:59814"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:12:53.46976722Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1646544989659953": {
+				"ID":          1646544989659953,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3821327416286260,
+				"StableID":   "nPzrFungqW11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b62feb33325b189d0b914fece2a1a61646a8835f0d3ae218442efdba998b3050",
+				"KeyExpiry":  "2026-11-08T22:12:52Z",
+				"DiscoKey":   "discokey:4b44846593f049e412a81cd20a3b735218d8cf62703f766e363da0133a63e65e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:42957",
+					"10.65.0.27:42957",
+					"172.17.0.1:42957",
+					"172.18.0.1:42957",
+					"172.19.0.1:42957"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 53165},
+					{"Proto": "peerapi6", "Port": 53165},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:12:52.93257841Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b62feb33325b189d0b914fece2a1a61646a8835f0d3ae218442efdba998b3050",
+			"MachineKey": "mkey:3d83281dd820d7b0e6619ea058a50f40b2d90982aa6ba3d1969ce3df1c1a3338",
+			"Peers": [{
+				"ID":         5558691465482482,
+				"StableID":   "n3Xgx8QYQk11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:98da7e6ebf8ab5100951b5ebd79e39565b462ba85ba10594372fefac12e13e4f",
+				"DiscoKey":   "discokey:d77cd03005778ec806410b6f34bf2d47594599a95e7e996ae8fdaab2c06d5833",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52099",
+					"10.65.0.27:52099",
+					"172.17.0.1:52099",
+					"172.18.0.1:52099",
+					"172.19.0.1:52099"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:12:45.895894102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2206922408666095,
+				"StableID":   "nzLB1M7XEJ11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6edecf637d1b72e078156a22394d4dea7a16953906de2b417697931a7b75d95a",
+				"DiscoKey":   "discokey:77b4a430760c4e5e669aed761df404a289f2b301e4f7f4a92d9c44a5e4655d69",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45931",
+					"10.65.0.27:45931",
+					"172.17.0.1:45931",
+					"172.18.0.1:45931",
+					"172.19.0.1:45931"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:12:46.432801487Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5087440775102692,
+				"StableID":   "nD74BfS7jg11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ac08d7f0ad82e0cf1efaed80e4d336b833be51646e01dfddcbbfb90616562015",
+				"DiscoKey":   "discokey:27ae7f82f4530a342d62ad2ca67b5d5243677aabdc10f75de8a39b08f99ca33c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45214",
+					"10.65.0.27:45214",
+					"172.17.0.1:45214",
+					"172.18.0.1:45214",
+					"172.19.0.1:45214"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:12:46.973792182Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1463992035291258,
+				"StableID":   "nKXJx7b3SC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c1648acb6e82abc453d71465082c59b7108146bb5c9be5c0edd1e7e872d2b34",
+				"DiscoKey":   "discokey:5a0846834e752129434d425e6ed3d66c79e20a731528398ec7695b6cd3e24151",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39677",
+					"10.65.0.27:39677",
+					"172.17.0.1:39677",
+					"172.18.0.1:39677",
+					"172.19.0.1:39677"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:12:47.535215898Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2480455672107944,
+				"StableID":   "nPpip8NQNL11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85bcf32b5f8933f2af2a029dfed5757e4d5bc9d6bdbf46b6292974e6d11d527b",
+				"DiscoKey":   "discokey:6b4d856936c08e772ed5713cac5bd2579ef6ddfc640c5ea0ec977b0411a6433a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40590",
+					"10.65.0.27:40590",
+					"172.17.0.1:40590",
+					"172.18.0.1:40590",
+					"172.19.0.1:40590"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:12:48.057525716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7114218108595119,
+				"StableID":   "nQV9msS3Zx11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:92264e4a656982c2b4c9ecd1ea8706eff37454995799a365538a1bc2a578a977",
+				"DiscoKey":   "discokey:87c7b9d30e4fc5485801aab92dcca177fdc08174d854877f6149c48ebc820328",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44686",
+					"10.65.0.27:44686",
+					"172.17.0.1:44686",
+					"172.18.0.1:44686",
+					"172.19.0.1:44686"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:12:48.593717138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         260808352712436,
+				"StableID":   "nKru2cz73311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:98ba75410c7c8aecb67b493832dd55d7b672eae4998f6d037a70c79993a5e47e",
+				"DiscoKey":   "discokey:fc65e0de86703d23c2c72177a4436550fec98676e3afc4afbbd1d0d5e8012e7f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58429",
+					"10.65.0.27:58429",
+					"172.17.0.1:58429",
+					"172.18.0.1:58429",
+					"172.19.0.1:58429"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:12:49.151757463Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1971300116950462,
+				"StableID":   "n3fDwFioPG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3ee77c1577449a8fb4517c9c85572898604082042524b52df393f82fe9426a48",
+				"DiscoKey":   "discokey:b5162837376348737a9da5579379b3528d5fb49e913972a776e38c75e180df07",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33235",
+					"10.65.0.27:33235",
+					"172.17.0.1:33235",
+					"172.18.0.1:33235",
+					"172.19.0.1:33235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:12:49.686954161Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1646544989659953,
+				"StableID":   "n4veQowirD11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6db7a8dd2b93e1b09c9af4d174c56c946d1eec7586bea5c75e9b624375f3442b",
+				"DiscoKey":   "discokey:08b1d5bc63e8dacfb078a9b276ea59f8ef1e2f00ce868e429324f4f19a7dac56",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35595",
+					"10.65.0.27:35595",
+					"172.17.0.1:35595",
+					"172.18.0.1:35595",
+					"172.19.0.1:35595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:12:50.224096993Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4729479275972653,
+				"StableID":   "nY64HFQzvd11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5fa4ddc2510af5be8da1d02db19dfd6dca0757a89b80876a4559f3f92817a66d",
+				"DiscoKey":   "discokey:05b6f7f61be43bdebf3e2e95d20c44cdfc8c8d733b7f516c885a2cb26e5fa87f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49048",
+					"10.65.0.27:49048",
+					"172.17.0.1:49048",
+					"172.18.0.1:49048",
+					"172.19.0.1:49048"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:12:50.773768448Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1199415976500311,
+				"StableID":   "nWSudBdDNA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dec8653cbd3d5d0ee3a5b10a993c99b60c84dd72074e8acb2918a92543fef427",
+				"DiscoKey":   "discokey:d30ce9a476f5336971eeebc984ae0e2a29da3108f95fbe3b942b95cda9ded30f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:47936",
+					"10.65.0.27:47936",
+					"172.17.0.1:47936",
+					"172.18.0.1:47936",
+					"172.19.0.1:47936"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:12:51.31963675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         971317712465959,
+				"StableID":   "n4DW8Rsua811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2423c5b4f5c9edae93f90c45305d3b7870ea1702d1444b920ea3645fdc055144",
+				"DiscoKey":   "discokey:42233904dacf1e0a90385252014c0fcebbc7fe6bd02c6e59864de89b05a51840",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:51807",
+					"10.65.0.27:51807",
+					"172.17.0.1:51807",
+					"172.18.0.1:51807",
+					"172.19.0.1:51807"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:12:51.879745394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3825410319579337,
+				"StableID":   "nnoTST3YsW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:575d39df85f32cbc5540e280d2942b58f50ba4fe65028d1edcdd2df04784983f",
+				"KeyExpiry":  "2026-11-08T22:12:52Z",
+				"DiscoKey":   "discokey:4c5ad71c45fdc9d2bfb8e9dff930492d92f6aaf5812938a94391470c03294144",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45129",
+					"10.65.0.27:45129",
+					"172.17.0.1:45129",
+					"172.18.0.1:45129",
+					"172.19.0.1:45129"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:12:52.411276822Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5252472108465548,
+				"StableID":   "nBaoy4Yr1i11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:4d379b7250c65dba4fb229035fc5058a4550c621af42f5b7b25972bfd3f35422",
+				"KeyExpiry":  "2026-11-08T22:12:53Z",
+				"DiscoKey":   "discokey:e724c69890c6b6c097034c88982f335258d0bfee0ee143fcfd1f9bb7fc2c4c6f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59814",
+					"10.65.0.27:59814",
+					"172.17.0.1:59814",
+					"172.18.0.1:59814",
+					"172.19.0.1:59814"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:12:53.46976722Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4729479275972653,
+				"StableID":   "nY64HFQzvd11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       4729479275972653,
+				"Key":        "nodekey:5fa4ddc2510af5be8da1d02db19dfd6dca0757a89b80876a4559f3f92817a66d",
+				"DiscoKey":   "discokey:05b6f7f61be43bdebf3e2e95d20c44cdfc8c8d733b7f516c885a2cb26e5fa87f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49048",
+					"10.65.0.27:49048",
+					"172.17.0.1:49048",
+					"172.18.0.1:49048",
+					"172.19.0.1:49048"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:12:50.773768448Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5fa4ddc2510af5be8da1d02db19dfd6dca0757a89b80876a4559f3f92817a66d",
+			"MachineKey": "mkey:a8b6ca05de89ab981b83c9b60e2dcda7e5fda3c22d2fd5c96f5ca4b6b7bff30a",
+			"Peers": [{
+				"ID":         5558691465482482,
+				"StableID":   "n3Xgx8QYQk11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:98da7e6ebf8ab5100951b5ebd79e39565b462ba85ba10594372fefac12e13e4f",
+				"DiscoKey":   "discokey:d77cd03005778ec806410b6f34bf2d47594599a95e7e996ae8fdaab2c06d5833",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52099",
+					"10.65.0.27:52099",
+					"172.17.0.1:52099",
+					"172.18.0.1:52099",
+					"172.19.0.1:52099"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:12:45.895894102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2206922408666095,
+				"StableID":   "nzLB1M7XEJ11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6edecf637d1b72e078156a22394d4dea7a16953906de2b417697931a7b75d95a",
+				"DiscoKey":   "discokey:77b4a430760c4e5e669aed761df404a289f2b301e4f7f4a92d9c44a5e4655d69",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45931",
+					"10.65.0.27:45931",
+					"172.17.0.1:45931",
+					"172.18.0.1:45931",
+					"172.19.0.1:45931"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:12:46.432801487Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5087440775102692,
+				"StableID":   "nD74BfS7jg11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ac08d7f0ad82e0cf1efaed80e4d336b833be51646e01dfddcbbfb90616562015",
+				"DiscoKey":   "discokey:27ae7f82f4530a342d62ad2ca67b5d5243677aabdc10f75de8a39b08f99ca33c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:45214",
+					"10.65.0.27:45214",
+					"172.17.0.1:45214",
+					"172.18.0.1:45214",
+					"172.19.0.1:45214"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:12:46.973792182Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1463992035291258,
+				"StableID":   "nKXJx7b3SC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c1648acb6e82abc453d71465082c59b7108146bb5c9be5c0edd1e7e872d2b34",
+				"DiscoKey":   "discokey:5a0846834e752129434d425e6ed3d66c79e20a731528398ec7695b6cd3e24151",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39677",
+					"10.65.0.27:39677",
+					"172.17.0.1:39677",
+					"172.18.0.1:39677",
+					"172.19.0.1:39677"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:12:47.535215898Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2480455672107944,
+				"StableID":   "nPpip8NQNL11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85bcf32b5f8933f2af2a029dfed5757e4d5bc9d6bdbf46b6292974e6d11d527b",
+				"DiscoKey":   "discokey:6b4d856936c08e772ed5713cac5bd2579ef6ddfc640c5ea0ec977b0411a6433a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40590",
+					"10.65.0.27:40590",
+					"172.17.0.1:40590",
+					"172.18.0.1:40590",
+					"172.19.0.1:40590"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:12:48.057525716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7114218108595119,
+				"StableID":   "nQV9msS3Zx11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:92264e4a656982c2b4c9ecd1ea8706eff37454995799a365538a1bc2a578a977",
+				"DiscoKey":   "discokey:87c7b9d30e4fc5485801aab92dcca177fdc08174d854877f6149c48ebc820328",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44686",
+					"10.65.0.27:44686",
+					"172.17.0.1:44686",
+					"172.18.0.1:44686",
+					"172.19.0.1:44686"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:12:48.593717138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         260808352712436,
+				"StableID":   "nKru2cz73311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:98ba75410c7c8aecb67b493832dd55d7b672eae4998f6d037a70c79993a5e47e",
+				"DiscoKey":   "discokey:fc65e0de86703d23c2c72177a4436550fec98676e3afc4afbbd1d0d5e8012e7f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58429",
+					"10.65.0.27:58429",
+					"172.17.0.1:58429",
+					"172.18.0.1:58429",
+					"172.19.0.1:58429"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:12:49.151757463Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1971300116950462,
+				"StableID":   "n3fDwFioPG11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3ee77c1577449a8fb4517c9c85572898604082042524b52df393f82fe9426a48",
+				"DiscoKey":   "discokey:b5162837376348737a9da5579379b3528d5fb49e913972a776e38c75e180df07",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33235",
+					"10.65.0.27:33235",
+					"172.17.0.1:33235",
+					"172.18.0.1:33235",
+					"172.19.0.1:33235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:12:49.686954161Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1646544989659953,
+				"StableID":   "n4veQowirD11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6db7a8dd2b93e1b09c9af4d174c56c946d1eec7586bea5c75e9b624375f3442b",
+				"DiscoKey":   "discokey:08b1d5bc63e8dacfb078a9b276ea59f8ef1e2f00ce868e429324f4f19a7dac56",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35595",
+					"10.65.0.27:35595",
+					"172.17.0.1:35595",
+					"172.18.0.1:35595",
+					"172.19.0.1:35595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:12:50.224096993Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1199415976500311,
+				"StableID":   "nWSudBdDNA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dec8653cbd3d5d0ee3a5b10a993c99b60c84dd72074e8acb2918a92543fef427",
+				"DiscoKey":   "discokey:d30ce9a476f5336971eeebc984ae0e2a29da3108f95fbe3b942b95cda9ded30f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:47936",
+					"10.65.0.27:47936",
+					"172.17.0.1:47936",
+					"172.18.0.1:47936",
+					"172.19.0.1:47936"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:12:51.31963675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         971317712465959,
+				"StableID":   "n4DW8Rsua811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2423c5b4f5c9edae93f90c45305d3b7870ea1702d1444b920ea3645fdc055144",
+				"DiscoKey":   "discokey:42233904dacf1e0a90385252014c0fcebbc7fe6bd02c6e59864de89b05a51840",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:51807",
+					"10.65.0.27:51807",
+					"172.17.0.1:51807",
+					"172.18.0.1:51807",
+					"172.19.0.1:51807"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:12:51.879745394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3825410319579337,
+				"StableID":   "nnoTST3YsW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:575d39df85f32cbc5540e280d2942b58f50ba4fe65028d1edcdd2df04784983f",
+				"KeyExpiry":  "2026-11-08T22:12:52Z",
+				"DiscoKey":   "discokey:4c5ad71c45fdc9d2bfb8e9dff930492d92f6aaf5812938a94391470c03294144",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45129",
+					"10.65.0.27:45129",
+					"172.17.0.1:45129",
+					"172.18.0.1:45129",
+					"172.19.0.1:45129"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:12:52.411276822Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3821327416286260,
+				"StableID":   "nPzrFungqW11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b62feb33325b189d0b914fece2a1a61646a8835f0d3ae218442efdba998b3050",
+				"KeyExpiry":  "2026-11-08T22:12:52Z",
+				"DiscoKey":   "discokey:4b44846593f049e412a81cd20a3b735218d8cf62703f766e363da0133a63e65e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:42957",
+					"10.65.0.27:42957",
+					"172.17.0.1:42957",
+					"172.18.0.1:42957",
+					"172.19.0.1:42957"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 53165},
+					{"Proto": "peerapi6", "Port": 53165}
+				]},
+				"Created":              "2026-05-12T22:12:52.93257841Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5252472108465548,
+				"StableID":   "nBaoy4Yr1i11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:4d379b7250c65dba4fb229035fc5058a4550c621af42f5b7b25972bfd3f35422",
+				"KeyExpiry":  "2026-11-08T22:12:53Z",
+				"DiscoKey":   "discokey:e724c69890c6b6c097034c88982f335258d0bfee0ee143fcfd1f9bb7fc2c4c6f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59814",
+					"10.65.0.27:59814",
+					"172.17.0.1:59814",
+					"172.18.0.1:59814",
+					"172.19.0.1:59814"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:12:53.46976722Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4729479275972653": {
+				"ID":          4729479275972653,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-users-missing.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-users-missing.hujson
@@ -1,0 +1,20078 @@
+// ssh-malformed-users-missing
+//
+// ssh users field missing is rejected
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T22:13:29Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-malformed-users-missing",
+	"description":    "ssh users field missing is rejected",
+	"category":       "ssh",
+	"captured_at":    "2026-05-12T22:13:29.488051702Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "users must be specified"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                              \n  \n                                                         \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh users field missing is rejected\",\n\t\"id\":          \"ssh-malformed-users-missing\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"autogroup:member\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-malformed/ssh-malformed-users-missing.hujson",
+		"full_policy": {
+			"ssh": [
+				{"action": "accept", "dst": ["tag:server"], "src": ["autogroup:member"]}
+			],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6753705650493008,
+				"StableID":   "n7AdMvPmju11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       6753705650493008,
+				"Key":        "nodekey:19bb2883aa1f4fabdf7aef206ed1bdffe1606305deb6bfa732daa619f3708372",
+				"DiscoKey":   "discokey:9cb0fc99d2fe1a7b14bd9eafecb426cd24b2137a9d53a17e23973cc294f51d33",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44043",
+					"10.65.0.27:44043",
+					"172.17.0.1:44043",
+					"172.18.0.1:44043",
+					"172.19.0.1:44043"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:13:38.033328092Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:19bb2883aa1f4fabdf7aef206ed1bdffe1606305deb6bfa732daa619f3708372",
+			"MachineKey": "mkey:b7dae06d3e4d32f6dfedbfc510f641d89d4d33fbff02fe2ff4ede9ca4e8cf46e",
+			"Peers": [{
+				"ID":         7719163547601196,
+				"StableID":   "nFQjfYL2H321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f5ffa2b18c48294539836834475da4a03c873b1c1d5bddc7bf1971edefc9c158",
+				"DiscoKey":   "discokey:2dc89d3ad19c3380ace297c9f17670919f8d5cb5555296923333b88ee62eb30f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53049",
+					"10.65.0.27:53049",
+					"172.17.0.1:53049",
+					"172.18.0.1:53049",
+					"172.19.0.1:53049"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:13:32.134599243Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4646875696721316,
+				"StableID":   "n7AnqbYaHd11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86b0877ff0aafd24fa5b582d6e701c1de0d7f4fd0b626778f6780544f21da65e",
+				"DiscoKey":   "discokey:2a6110ce7830c1c2b789df7eb634706f12b52f4f6b0d13ef147a029da158b12d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45390",
+					"10.65.0.27:45390",
+					"172.17.0.1:45390",
+					"172.18.0.1:45390",
+					"172.19.0.1:45390"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:13:32.630513321Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6398465701021322,
+				"StableID":   "n3D1Vxqsxr11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:868b93b2ba5c5f7183276dc5f388a803d58d66477a5705ec56f687d73b62330a",
+				"DiscoKey":   "discokey:6dd5d182ac34cb3b9757c4842b4f096ed8eaa13f6b1e31eaf31bcd65b86b442a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35363",
+					"10.65.0.27:35363",
+					"172.17.0.1:35363",
+					"172.18.0.1:35363",
+					"172.19.0.1:35363"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:13:33.161639478Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5561987148277355,
+				"StableID":   "n2aTAKy2Sk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd7cd9487031017b6feaff009927c7ef85e13b93da2fc9c83a8467b0c59fd903",
+				"DiscoKey":   "discokey:3d6e788e89c04c82ae84234e752591774a22d25a34b2614b9463840083e08325",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51065",
+					"10.65.0.27:51065",
+					"172.17.0.1:51065",
+					"172.18.0.1:51065",
+					"172.19.0.1:51065"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:13:33.70769115Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3489551594547578,
+				"StableID":   "nR881zbRFU11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d2be220bd8a766dca167dc8df5cb73d494fc84f8d7ca8e85b846495173463153",
+				"DiscoKey":   "discokey:eba9b59d70752303cbe5d089e02167c5bd30faf105bc11ed270ada16979dcb35",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38335",
+					"10.65.0.27:38335",
+					"172.17.0.1:38335",
+					"172.18.0.1:38335",
+					"172.19.0.1:38335"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:13:34.253105915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8449658380066409,
+				"StableID":   "nnXwYTCsy821CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c36e6e2429500358bc51a8b42991510ce45a8da109207042b0142c4608d0b956",
+				"DiscoKey":   "discokey:dcdfbe417b769f984fb9b0a400cf3b125341b1d18301bb37a4a4ce0a4a68ef29",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39301",
+					"10.65.0.27:39301",
+					"172.17.0.1:39301",
+					"172.18.0.1:39301",
+					"172.19.0.1:39301"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:13:34.789711074Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7724333060802280,
+				"StableID":   "nyw8rc8NK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d04b23e7f941f7c689105a64f5c86c54b9b0d01c6aa4f634759ad083765e144",
+				"DiscoKey":   "discokey:2db32744ad75a83ac7bcde79e4c61bf9437a1656064d2a3ea3ef81161ebd217a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41984",
+					"10.65.0.27:41984",
+					"172.17.0.1:41984",
+					"172.18.0.1:41984",
+					"172.19.0.1:41984"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:13:35.324943716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3944579690127648,
+				"StableID":   "nFJ1eLRWoX11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b1b7b37df4b029adb5d24a39575956113c2b71a8c8a896646568062d0b5f7d3c",
+				"DiscoKey":   "discokey:be91faf33fbce07cd8787675cbfbe994e55118cb695991ae0975d393b1dbb03a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50093",
+					"10.65.0.27:50093",
+					"172.17.0.1:50093",
+					"172.18.0.1:50093",
+					"172.19.0.1:50093"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:13:35.859431146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         741676766661572,
+				"StableID":   "nHyn7Hbun611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a9c112e23c4a6311d26b3b1db8e2b16cec3c9288148edff73a2f15e3ebd36c01",
+				"DiscoKey":   "discokey:1550299eb28ac5bf790ef2ce4ff535bfbbb2ebcfd2540143bc64cd5f99dd9129",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34739",
+					"10.65.0.27:34739",
+					"172.17.0.1:34739",
+					"172.18.0.1:34739",
+					"172.19.0.1:34739"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:13:36.413972509Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1298541221208280,
+				"StableID":   "nMTD5cU79B11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7bda4ed3796d68606da6a365a62d2d75ac7c595467ac200640149cb413004277",
+				"DiscoKey":   "discokey:44be1862176824dab69a0f87461b30f6ab064688ca6dafa48897946e93a39b03",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55724",
+					"10.65.0.27:55724",
+					"172.17.0.1:55724",
+					"172.18.0.1:55724",
+					"172.19.0.1:55724"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:13:36.94891703Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1545753784186232,
+				"StableID":   "njSxiBL55D11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21922ff69734b12acdc916c2e38df8557ba8887806cc9b6fb595fb95b2fb9d0e",
+				"DiscoKey":   "discokey:3823dd4fda6ff4bb7931549533e22926778642bd4cdb8d9eb8a3e1def8e49571",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48404",
+					"10.65.0.27:48404",
+					"172.17.0.1:48404",
+					"172.18.0.1:48404",
+					"172.19.0.1:48404"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:13:37.487919248Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2505133883124715,
+				"StableID":   "nG9npucaZL11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:4d64d19bad71f8f4bbde115225dbd8d8e5627a055263da7aca493a47488a3370",
+				"KeyExpiry":  "2026-11-08T22:13:38Z",
+				"DiscoKey":   "discokey:7df5455bda8a26723b68f0e8550d83fb8c4726a81281332b07ec38b4488a460c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44065",
+					"10.65.0.27:44065",
+					"172.17.0.1:44065",
+					"172.18.0.1:44065",
+					"172.19.0.1:44065"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:13:38.578940395Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1300111451217282,
+				"StableID":   "n39Tvwip9B11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:d5b9e890da91e9025eef6dde567da82cba826ecdeec9bd9c4b60de435d7f5438",
+				"KeyExpiry":  "2026-11-08T22:13:39Z",
+				"DiscoKey":   "discokey:de9879950292f3742f71c7458087fa72ccc20b30cce7e3f8610e8c52899ea01e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39568",
+					"10.65.0.27:39568",
+					"172.17.0.1:39568",
+					"172.18.0.1:39568",
+					"172.19.0.1:39568"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 53165},
+					{"Proto": "peerapi6", "Port": 53165}
+				]},
+				"Created":              "2026-05-12T22:13:39.102386131Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4100897524667226,
+				"StableID":   "nqLgPCdJ2Z11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fc0e86e8745c8d6c3b38356f2c7775f7abdb820e5459fa1d57a4e274ac8c926b",
+				"KeyExpiry":  "2026-11-08T22:13:39Z",
+				"DiscoKey":   "discokey:2c1d1ce45c6235ae1acaaaadbe665af846cfb1b3bb2f1245edc5a661d1fd832c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60848",
+					"10.65.0.27:60848",
+					"172.17.0.1:60848",
+					"172.18.0.1:60848",
+					"172.19.0.1:60848"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:13:39.648098932Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6753705650493008": {
+				"ID":          6753705650493008,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8449658380066409,
+				"StableID":   "nnXwYTCsy821CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       8449658380066409,
+				"Key":        "nodekey:c36e6e2429500358bc51a8b42991510ce45a8da109207042b0142c4608d0b956",
+				"DiscoKey":   "discokey:dcdfbe417b769f984fb9b0a400cf3b125341b1d18301bb37a4a4ce0a4a68ef29",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39301",
+					"10.65.0.27:39301",
+					"172.17.0.1:39301",
+					"172.18.0.1:39301",
+					"172.19.0.1:39301"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:13:34.789711074Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c36e6e2429500358bc51a8b42991510ce45a8da109207042b0142c4608d0b956",
+			"MachineKey": "mkey:209b7c6305057cfe4233e27acc3c8377bc1cf51a74a6a8e364564cb62c715c5a",
+			"Peers": [{
+				"ID":         7719163547601196,
+				"StableID":   "nFQjfYL2H321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f5ffa2b18c48294539836834475da4a03c873b1c1d5bddc7bf1971edefc9c158",
+				"DiscoKey":   "discokey:2dc89d3ad19c3380ace297c9f17670919f8d5cb5555296923333b88ee62eb30f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53049",
+					"10.65.0.27:53049",
+					"172.17.0.1:53049",
+					"172.18.0.1:53049",
+					"172.19.0.1:53049"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:13:32.134599243Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4646875696721316,
+				"StableID":   "n7AnqbYaHd11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86b0877ff0aafd24fa5b582d6e701c1de0d7f4fd0b626778f6780544f21da65e",
+				"DiscoKey":   "discokey:2a6110ce7830c1c2b789df7eb634706f12b52f4f6b0d13ef147a029da158b12d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45390",
+					"10.65.0.27:45390",
+					"172.17.0.1:45390",
+					"172.18.0.1:45390",
+					"172.19.0.1:45390"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:13:32.630513321Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6398465701021322,
+				"StableID":   "n3D1Vxqsxr11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:868b93b2ba5c5f7183276dc5f388a803d58d66477a5705ec56f687d73b62330a",
+				"DiscoKey":   "discokey:6dd5d182ac34cb3b9757c4842b4f096ed8eaa13f6b1e31eaf31bcd65b86b442a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35363",
+					"10.65.0.27:35363",
+					"172.17.0.1:35363",
+					"172.18.0.1:35363",
+					"172.19.0.1:35363"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:13:33.161639478Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5561987148277355,
+				"StableID":   "n2aTAKy2Sk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd7cd9487031017b6feaff009927c7ef85e13b93da2fc9c83a8467b0c59fd903",
+				"DiscoKey":   "discokey:3d6e788e89c04c82ae84234e752591774a22d25a34b2614b9463840083e08325",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51065",
+					"10.65.0.27:51065",
+					"172.17.0.1:51065",
+					"172.18.0.1:51065",
+					"172.19.0.1:51065"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:13:33.70769115Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3489551594547578,
+				"StableID":   "nR881zbRFU11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d2be220bd8a766dca167dc8df5cb73d494fc84f8d7ca8e85b846495173463153",
+				"DiscoKey":   "discokey:eba9b59d70752303cbe5d089e02167c5bd30faf105bc11ed270ada16979dcb35",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38335",
+					"10.65.0.27:38335",
+					"172.17.0.1:38335",
+					"172.18.0.1:38335",
+					"172.19.0.1:38335"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:13:34.253105915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7724333060802280,
+				"StableID":   "nyw8rc8NK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d04b23e7f941f7c689105a64f5c86c54b9b0d01c6aa4f634759ad083765e144",
+				"DiscoKey":   "discokey:2db32744ad75a83ac7bcde79e4c61bf9437a1656064d2a3ea3ef81161ebd217a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41984",
+					"10.65.0.27:41984",
+					"172.17.0.1:41984",
+					"172.18.0.1:41984",
+					"172.19.0.1:41984"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:13:35.324943716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3944579690127648,
+				"StableID":   "nFJ1eLRWoX11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b1b7b37df4b029adb5d24a39575956113c2b71a8c8a896646568062d0b5f7d3c",
+				"DiscoKey":   "discokey:be91faf33fbce07cd8787675cbfbe994e55118cb695991ae0975d393b1dbb03a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50093",
+					"10.65.0.27:50093",
+					"172.17.0.1:50093",
+					"172.18.0.1:50093",
+					"172.19.0.1:50093"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:13:35.859431146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         741676766661572,
+				"StableID":   "nHyn7Hbun611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a9c112e23c4a6311d26b3b1db8e2b16cec3c9288148edff73a2f15e3ebd36c01",
+				"DiscoKey":   "discokey:1550299eb28ac5bf790ef2ce4ff535bfbbb2ebcfd2540143bc64cd5f99dd9129",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34739",
+					"10.65.0.27:34739",
+					"172.17.0.1:34739",
+					"172.18.0.1:34739",
+					"172.19.0.1:34739"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:13:36.413972509Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1298541221208280,
+				"StableID":   "nMTD5cU79B11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7bda4ed3796d68606da6a365a62d2d75ac7c595467ac200640149cb413004277",
+				"DiscoKey":   "discokey:44be1862176824dab69a0f87461b30f6ab064688ca6dafa48897946e93a39b03",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55724",
+					"10.65.0.27:55724",
+					"172.17.0.1:55724",
+					"172.18.0.1:55724",
+					"172.19.0.1:55724"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:13:36.94891703Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1545753784186232,
+				"StableID":   "njSxiBL55D11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21922ff69734b12acdc916c2e38df8557ba8887806cc9b6fb595fb95b2fb9d0e",
+				"DiscoKey":   "discokey:3823dd4fda6ff4bb7931549533e22926778642bd4cdb8d9eb8a3e1def8e49571",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48404",
+					"10.65.0.27:48404",
+					"172.17.0.1:48404",
+					"172.18.0.1:48404",
+					"172.19.0.1:48404"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:13:37.487919248Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6753705650493008,
+				"StableID":   "n7AdMvPmju11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:19bb2883aa1f4fabdf7aef206ed1bdffe1606305deb6bfa732daa619f3708372",
+				"DiscoKey":   "discokey:9cb0fc99d2fe1a7b14bd9eafecb426cd24b2137a9d53a17e23973cc294f51d33",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44043",
+					"10.65.0.27:44043",
+					"172.17.0.1:44043",
+					"172.18.0.1:44043",
+					"172.19.0.1:44043"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:13:38.033328092Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2505133883124715,
+				"StableID":   "nG9npucaZL11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:4d64d19bad71f8f4bbde115225dbd8d8e5627a055263da7aca493a47488a3370",
+				"KeyExpiry":  "2026-11-08T22:13:38Z",
+				"DiscoKey":   "discokey:7df5455bda8a26723b68f0e8550d83fb8c4726a81281332b07ec38b4488a460c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44065",
+					"10.65.0.27:44065",
+					"172.17.0.1:44065",
+					"172.18.0.1:44065",
+					"172.19.0.1:44065"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:13:38.578940395Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1300111451217282,
+				"StableID":   "n39Tvwip9B11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:d5b9e890da91e9025eef6dde567da82cba826ecdeec9bd9c4b60de435d7f5438",
+				"KeyExpiry":  "2026-11-08T22:13:39Z",
+				"DiscoKey":   "discokey:de9879950292f3742f71c7458087fa72ccc20b30cce7e3f8610e8c52899ea01e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39568",
+					"10.65.0.27:39568",
+					"172.17.0.1:39568",
+					"172.18.0.1:39568",
+					"172.19.0.1:39568"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 53165},
+					{"Proto": "peerapi6", "Port": 53165}
+				]},
+				"Created":              "2026-05-12T22:13:39.102386131Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4100897524667226,
+				"StableID":   "nqLgPCdJ2Z11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fc0e86e8745c8d6c3b38356f2c7775f7abdb820e5459fa1d57a4e274ac8c926b",
+				"KeyExpiry":  "2026-11-08T22:13:39Z",
+				"DiscoKey":   "discokey:2c1d1ce45c6235ae1acaaaadbe665af846cfb1b3bb2f1245edc5a661d1fd832c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60848",
+					"10.65.0.27:60848",
+					"172.17.0.1:60848",
+					"172.18.0.1:60848",
+					"172.19.0.1:60848"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:13:39.648098932Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8449658380066409": {
+				"ID":          8449658380066409,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4100897524667226,
+				"StableID":   "nqLgPCdJ2Z11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fc0e86e8745c8d6c3b38356f2c7775f7abdb820e5459fa1d57a4e274ac8c926b",
+				"KeyExpiry":  "2026-11-08T22:13:39Z",
+				"DiscoKey":   "discokey:2c1d1ce45c6235ae1acaaaadbe665af846cfb1b3bb2f1245edc5a661d1fd832c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60848",
+					"10.65.0.27:60848",
+					"172.17.0.1:60848",
+					"172.18.0.1:60848",
+					"172.19.0.1:60848"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:13:39.648098932Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:fc0e86e8745c8d6c3b38356f2c7775f7abdb820e5459fa1d57a4e274ac8c926b",
+			"MachineKey": "mkey:426d14dc284b77ef684a625af148755a46342be599c8506802063d1afc467148",
+			"Peers": [{
+				"ID":         7719163547601196,
+				"StableID":   "nFQjfYL2H321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f5ffa2b18c48294539836834475da4a03c873b1c1d5bddc7bf1971edefc9c158",
+				"DiscoKey":   "discokey:2dc89d3ad19c3380ace297c9f17670919f8d5cb5555296923333b88ee62eb30f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53049",
+					"10.65.0.27:53049",
+					"172.17.0.1:53049",
+					"172.18.0.1:53049",
+					"172.19.0.1:53049"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:13:32.134599243Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4646875696721316,
+				"StableID":   "n7AnqbYaHd11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86b0877ff0aafd24fa5b582d6e701c1de0d7f4fd0b626778f6780544f21da65e",
+				"DiscoKey":   "discokey:2a6110ce7830c1c2b789df7eb634706f12b52f4f6b0d13ef147a029da158b12d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45390",
+					"10.65.0.27:45390",
+					"172.17.0.1:45390",
+					"172.18.0.1:45390",
+					"172.19.0.1:45390"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:13:32.630513321Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6398465701021322,
+				"StableID":   "n3D1Vxqsxr11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:868b93b2ba5c5f7183276dc5f388a803d58d66477a5705ec56f687d73b62330a",
+				"DiscoKey":   "discokey:6dd5d182ac34cb3b9757c4842b4f096ed8eaa13f6b1e31eaf31bcd65b86b442a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35363",
+					"10.65.0.27:35363",
+					"172.17.0.1:35363",
+					"172.18.0.1:35363",
+					"172.19.0.1:35363"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:13:33.161639478Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5561987148277355,
+				"StableID":   "n2aTAKy2Sk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd7cd9487031017b6feaff009927c7ef85e13b93da2fc9c83a8467b0c59fd903",
+				"DiscoKey":   "discokey:3d6e788e89c04c82ae84234e752591774a22d25a34b2614b9463840083e08325",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51065",
+					"10.65.0.27:51065",
+					"172.17.0.1:51065",
+					"172.18.0.1:51065",
+					"172.19.0.1:51065"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:13:33.70769115Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3489551594547578,
+				"StableID":   "nR881zbRFU11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d2be220bd8a766dca167dc8df5cb73d494fc84f8d7ca8e85b846495173463153",
+				"DiscoKey":   "discokey:eba9b59d70752303cbe5d089e02167c5bd30faf105bc11ed270ada16979dcb35",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38335",
+					"10.65.0.27:38335",
+					"172.17.0.1:38335",
+					"172.18.0.1:38335",
+					"172.19.0.1:38335"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:13:34.253105915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8449658380066409,
+				"StableID":   "nnXwYTCsy821CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c36e6e2429500358bc51a8b42991510ce45a8da109207042b0142c4608d0b956",
+				"DiscoKey":   "discokey:dcdfbe417b769f984fb9b0a400cf3b125341b1d18301bb37a4a4ce0a4a68ef29",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39301",
+					"10.65.0.27:39301",
+					"172.17.0.1:39301",
+					"172.18.0.1:39301",
+					"172.19.0.1:39301"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:13:34.789711074Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7724333060802280,
+				"StableID":   "nyw8rc8NK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d04b23e7f941f7c689105a64f5c86c54b9b0d01c6aa4f634759ad083765e144",
+				"DiscoKey":   "discokey:2db32744ad75a83ac7bcde79e4c61bf9437a1656064d2a3ea3ef81161ebd217a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41984",
+					"10.65.0.27:41984",
+					"172.17.0.1:41984",
+					"172.18.0.1:41984",
+					"172.19.0.1:41984"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:13:35.324943716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3944579690127648,
+				"StableID":   "nFJ1eLRWoX11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b1b7b37df4b029adb5d24a39575956113c2b71a8c8a896646568062d0b5f7d3c",
+				"DiscoKey":   "discokey:be91faf33fbce07cd8787675cbfbe994e55118cb695991ae0975d393b1dbb03a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50093",
+					"10.65.0.27:50093",
+					"172.17.0.1:50093",
+					"172.18.0.1:50093",
+					"172.19.0.1:50093"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:13:35.859431146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         741676766661572,
+				"StableID":   "nHyn7Hbun611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a9c112e23c4a6311d26b3b1db8e2b16cec3c9288148edff73a2f15e3ebd36c01",
+				"DiscoKey":   "discokey:1550299eb28ac5bf790ef2ce4ff535bfbbb2ebcfd2540143bc64cd5f99dd9129",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34739",
+					"10.65.0.27:34739",
+					"172.17.0.1:34739",
+					"172.18.0.1:34739",
+					"172.19.0.1:34739"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:13:36.413972509Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1298541221208280,
+				"StableID":   "nMTD5cU79B11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7bda4ed3796d68606da6a365a62d2d75ac7c595467ac200640149cb413004277",
+				"DiscoKey":   "discokey:44be1862176824dab69a0f87461b30f6ab064688ca6dafa48897946e93a39b03",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55724",
+					"10.65.0.27:55724",
+					"172.17.0.1:55724",
+					"172.18.0.1:55724",
+					"172.19.0.1:55724"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:13:36.94891703Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1545753784186232,
+				"StableID":   "njSxiBL55D11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21922ff69734b12acdc916c2e38df8557ba8887806cc9b6fb595fb95b2fb9d0e",
+				"DiscoKey":   "discokey:3823dd4fda6ff4bb7931549533e22926778642bd4cdb8d9eb8a3e1def8e49571",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48404",
+					"10.65.0.27:48404",
+					"172.17.0.1:48404",
+					"172.18.0.1:48404",
+					"172.19.0.1:48404"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:13:37.487919248Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6753705650493008,
+				"StableID":   "n7AdMvPmju11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:19bb2883aa1f4fabdf7aef206ed1bdffe1606305deb6bfa732daa619f3708372",
+				"DiscoKey":   "discokey:9cb0fc99d2fe1a7b14bd9eafecb426cd24b2137a9d53a17e23973cc294f51d33",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44043",
+					"10.65.0.27:44043",
+					"172.17.0.1:44043",
+					"172.18.0.1:44043",
+					"172.19.0.1:44043"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:13:38.033328092Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2505133883124715,
+				"StableID":   "nG9npucaZL11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:4d64d19bad71f8f4bbde115225dbd8d8e5627a055263da7aca493a47488a3370",
+				"KeyExpiry":  "2026-11-08T22:13:38Z",
+				"DiscoKey":   "discokey:7df5455bda8a26723b68f0e8550d83fb8c4726a81281332b07ec38b4488a460c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44065",
+					"10.65.0.27:44065",
+					"172.17.0.1:44065",
+					"172.18.0.1:44065",
+					"172.19.0.1:44065"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:13:38.578940395Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1300111451217282,
+				"StableID":   "n39Tvwip9B11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:d5b9e890da91e9025eef6dde567da82cba826ecdeec9bd9c4b60de435d7f5438",
+				"KeyExpiry":  "2026-11-08T22:13:39Z",
+				"DiscoKey":   "discokey:de9879950292f3742f71c7458087fa72ccc20b30cce7e3f8610e8c52899ea01e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39568",
+					"10.65.0.27:39568",
+					"172.17.0.1:39568",
+					"172.18.0.1:39568",
+					"172.19.0.1:39568"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 53165},
+					{"Proto": "peerapi6", "Port": 53165}
+				]},
+				"Created":              "2026-05-12T22:13:39.102386131Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6398465701021322,
+				"StableID":   "n3D1Vxqsxr11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       6398465701021322,
+				"Key":        "nodekey:868b93b2ba5c5f7183276dc5f388a803d58d66477a5705ec56f687d73b62330a",
+				"DiscoKey":   "discokey:6dd5d182ac34cb3b9757c4842b4f096ed8eaa13f6b1e31eaf31bcd65b86b442a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35363",
+					"10.65.0.27:35363",
+					"172.17.0.1:35363",
+					"172.18.0.1:35363",
+					"172.19.0.1:35363"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:13:33.161639478Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:868b93b2ba5c5f7183276dc5f388a803d58d66477a5705ec56f687d73b62330a",
+			"MachineKey": "mkey:f3844bcb6ba8e4069007ec0c1e95495a2de503f07d3b21d2c1cb9f67383c9659",
+			"Peers": [{
+				"ID":         7719163547601196,
+				"StableID":   "nFQjfYL2H321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f5ffa2b18c48294539836834475da4a03c873b1c1d5bddc7bf1971edefc9c158",
+				"DiscoKey":   "discokey:2dc89d3ad19c3380ace297c9f17670919f8d5cb5555296923333b88ee62eb30f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53049",
+					"10.65.0.27:53049",
+					"172.17.0.1:53049",
+					"172.18.0.1:53049",
+					"172.19.0.1:53049"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:13:32.134599243Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4646875696721316,
+				"StableID":   "n7AnqbYaHd11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86b0877ff0aafd24fa5b582d6e701c1de0d7f4fd0b626778f6780544f21da65e",
+				"DiscoKey":   "discokey:2a6110ce7830c1c2b789df7eb634706f12b52f4f6b0d13ef147a029da158b12d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45390",
+					"10.65.0.27:45390",
+					"172.17.0.1:45390",
+					"172.18.0.1:45390",
+					"172.19.0.1:45390"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:13:32.630513321Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5561987148277355,
+				"StableID":   "n2aTAKy2Sk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd7cd9487031017b6feaff009927c7ef85e13b93da2fc9c83a8467b0c59fd903",
+				"DiscoKey":   "discokey:3d6e788e89c04c82ae84234e752591774a22d25a34b2614b9463840083e08325",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51065",
+					"10.65.0.27:51065",
+					"172.17.0.1:51065",
+					"172.18.0.1:51065",
+					"172.19.0.1:51065"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:13:33.70769115Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3489551594547578,
+				"StableID":   "nR881zbRFU11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d2be220bd8a766dca167dc8df5cb73d494fc84f8d7ca8e85b846495173463153",
+				"DiscoKey":   "discokey:eba9b59d70752303cbe5d089e02167c5bd30faf105bc11ed270ada16979dcb35",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38335",
+					"10.65.0.27:38335",
+					"172.17.0.1:38335",
+					"172.18.0.1:38335",
+					"172.19.0.1:38335"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:13:34.253105915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8449658380066409,
+				"StableID":   "nnXwYTCsy821CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c36e6e2429500358bc51a8b42991510ce45a8da109207042b0142c4608d0b956",
+				"DiscoKey":   "discokey:dcdfbe417b769f984fb9b0a400cf3b125341b1d18301bb37a4a4ce0a4a68ef29",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39301",
+					"10.65.0.27:39301",
+					"172.17.0.1:39301",
+					"172.18.0.1:39301",
+					"172.19.0.1:39301"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:13:34.789711074Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7724333060802280,
+				"StableID":   "nyw8rc8NK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d04b23e7f941f7c689105a64f5c86c54b9b0d01c6aa4f634759ad083765e144",
+				"DiscoKey":   "discokey:2db32744ad75a83ac7bcde79e4c61bf9437a1656064d2a3ea3ef81161ebd217a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41984",
+					"10.65.0.27:41984",
+					"172.17.0.1:41984",
+					"172.18.0.1:41984",
+					"172.19.0.1:41984"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:13:35.324943716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3944579690127648,
+				"StableID":   "nFJ1eLRWoX11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b1b7b37df4b029adb5d24a39575956113c2b71a8c8a896646568062d0b5f7d3c",
+				"DiscoKey":   "discokey:be91faf33fbce07cd8787675cbfbe994e55118cb695991ae0975d393b1dbb03a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50093",
+					"10.65.0.27:50093",
+					"172.17.0.1:50093",
+					"172.18.0.1:50093",
+					"172.19.0.1:50093"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:13:35.859431146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         741676766661572,
+				"StableID":   "nHyn7Hbun611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a9c112e23c4a6311d26b3b1db8e2b16cec3c9288148edff73a2f15e3ebd36c01",
+				"DiscoKey":   "discokey:1550299eb28ac5bf790ef2ce4ff535bfbbb2ebcfd2540143bc64cd5f99dd9129",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34739",
+					"10.65.0.27:34739",
+					"172.17.0.1:34739",
+					"172.18.0.1:34739",
+					"172.19.0.1:34739"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:13:36.413972509Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1298541221208280,
+				"StableID":   "nMTD5cU79B11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7bda4ed3796d68606da6a365a62d2d75ac7c595467ac200640149cb413004277",
+				"DiscoKey":   "discokey:44be1862176824dab69a0f87461b30f6ab064688ca6dafa48897946e93a39b03",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55724",
+					"10.65.0.27:55724",
+					"172.17.0.1:55724",
+					"172.18.0.1:55724",
+					"172.19.0.1:55724"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:13:36.94891703Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1545753784186232,
+				"StableID":   "njSxiBL55D11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21922ff69734b12acdc916c2e38df8557ba8887806cc9b6fb595fb95b2fb9d0e",
+				"DiscoKey":   "discokey:3823dd4fda6ff4bb7931549533e22926778642bd4cdb8d9eb8a3e1def8e49571",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48404",
+					"10.65.0.27:48404",
+					"172.17.0.1:48404",
+					"172.18.0.1:48404",
+					"172.19.0.1:48404"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:13:37.487919248Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6753705650493008,
+				"StableID":   "n7AdMvPmju11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:19bb2883aa1f4fabdf7aef206ed1bdffe1606305deb6bfa732daa619f3708372",
+				"DiscoKey":   "discokey:9cb0fc99d2fe1a7b14bd9eafecb426cd24b2137a9d53a17e23973cc294f51d33",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44043",
+					"10.65.0.27:44043",
+					"172.17.0.1:44043",
+					"172.18.0.1:44043",
+					"172.19.0.1:44043"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:13:38.033328092Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2505133883124715,
+				"StableID":   "nG9npucaZL11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:4d64d19bad71f8f4bbde115225dbd8d8e5627a055263da7aca493a47488a3370",
+				"KeyExpiry":  "2026-11-08T22:13:38Z",
+				"DiscoKey":   "discokey:7df5455bda8a26723b68f0e8550d83fb8c4726a81281332b07ec38b4488a460c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44065",
+					"10.65.0.27:44065",
+					"172.17.0.1:44065",
+					"172.18.0.1:44065",
+					"172.19.0.1:44065"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:13:38.578940395Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1300111451217282,
+				"StableID":   "n39Tvwip9B11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:d5b9e890da91e9025eef6dde567da82cba826ecdeec9bd9c4b60de435d7f5438",
+				"KeyExpiry":  "2026-11-08T22:13:39Z",
+				"DiscoKey":   "discokey:de9879950292f3742f71c7458087fa72ccc20b30cce7e3f8610e8c52899ea01e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39568",
+					"10.65.0.27:39568",
+					"172.17.0.1:39568",
+					"172.18.0.1:39568",
+					"172.19.0.1:39568"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 53165},
+					{"Proto": "peerapi6", "Port": 53165}
+				]},
+				"Created":              "2026-05-12T22:13:39.102386131Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4100897524667226,
+				"StableID":   "nqLgPCdJ2Z11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fc0e86e8745c8d6c3b38356f2c7775f7abdb820e5459fa1d57a4e274ac8c926b",
+				"KeyExpiry":  "2026-11-08T22:13:39Z",
+				"DiscoKey":   "discokey:2c1d1ce45c6235ae1acaaaadbe665af846cfb1b3bb2f1245edc5a661d1fd832c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60848",
+					"10.65.0.27:60848",
+					"172.17.0.1:60848",
+					"172.18.0.1:60848",
+					"172.19.0.1:60848"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:13:39.648098932Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6398465701021322": {
+				"ID":          6398465701021322,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3944579690127648,
+				"StableID":   "nFJ1eLRWoX11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       3944579690127648,
+				"Key":        "nodekey:b1b7b37df4b029adb5d24a39575956113c2b71a8c8a896646568062d0b5f7d3c",
+				"DiscoKey":   "discokey:be91faf33fbce07cd8787675cbfbe994e55118cb695991ae0975d393b1dbb03a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50093",
+					"10.65.0.27:50093",
+					"172.17.0.1:50093",
+					"172.18.0.1:50093",
+					"172.19.0.1:50093"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:13:35.859431146Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b1b7b37df4b029adb5d24a39575956113c2b71a8c8a896646568062d0b5f7d3c",
+			"MachineKey": "mkey:53bcc93a532de9dedc2f11e59c504581817ab2a4c6a94ad31fb4db559e77595b",
+			"Peers": [{
+				"ID":         7719163547601196,
+				"StableID":   "nFQjfYL2H321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f5ffa2b18c48294539836834475da4a03c873b1c1d5bddc7bf1971edefc9c158",
+				"DiscoKey":   "discokey:2dc89d3ad19c3380ace297c9f17670919f8d5cb5555296923333b88ee62eb30f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53049",
+					"10.65.0.27:53049",
+					"172.17.0.1:53049",
+					"172.18.0.1:53049",
+					"172.19.0.1:53049"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:13:32.134599243Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4646875696721316,
+				"StableID":   "n7AnqbYaHd11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86b0877ff0aafd24fa5b582d6e701c1de0d7f4fd0b626778f6780544f21da65e",
+				"DiscoKey":   "discokey:2a6110ce7830c1c2b789df7eb634706f12b52f4f6b0d13ef147a029da158b12d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45390",
+					"10.65.0.27:45390",
+					"172.17.0.1:45390",
+					"172.18.0.1:45390",
+					"172.19.0.1:45390"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:13:32.630513321Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6398465701021322,
+				"StableID":   "n3D1Vxqsxr11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:868b93b2ba5c5f7183276dc5f388a803d58d66477a5705ec56f687d73b62330a",
+				"DiscoKey":   "discokey:6dd5d182ac34cb3b9757c4842b4f096ed8eaa13f6b1e31eaf31bcd65b86b442a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35363",
+					"10.65.0.27:35363",
+					"172.17.0.1:35363",
+					"172.18.0.1:35363",
+					"172.19.0.1:35363"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:13:33.161639478Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5561987148277355,
+				"StableID":   "n2aTAKy2Sk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd7cd9487031017b6feaff009927c7ef85e13b93da2fc9c83a8467b0c59fd903",
+				"DiscoKey":   "discokey:3d6e788e89c04c82ae84234e752591774a22d25a34b2614b9463840083e08325",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51065",
+					"10.65.0.27:51065",
+					"172.17.0.1:51065",
+					"172.18.0.1:51065",
+					"172.19.0.1:51065"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:13:33.70769115Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3489551594547578,
+				"StableID":   "nR881zbRFU11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d2be220bd8a766dca167dc8df5cb73d494fc84f8d7ca8e85b846495173463153",
+				"DiscoKey":   "discokey:eba9b59d70752303cbe5d089e02167c5bd30faf105bc11ed270ada16979dcb35",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38335",
+					"10.65.0.27:38335",
+					"172.17.0.1:38335",
+					"172.18.0.1:38335",
+					"172.19.0.1:38335"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:13:34.253105915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8449658380066409,
+				"StableID":   "nnXwYTCsy821CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c36e6e2429500358bc51a8b42991510ce45a8da109207042b0142c4608d0b956",
+				"DiscoKey":   "discokey:dcdfbe417b769f984fb9b0a400cf3b125341b1d18301bb37a4a4ce0a4a68ef29",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39301",
+					"10.65.0.27:39301",
+					"172.17.0.1:39301",
+					"172.18.0.1:39301",
+					"172.19.0.1:39301"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:13:34.789711074Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7724333060802280,
+				"StableID":   "nyw8rc8NK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d04b23e7f941f7c689105a64f5c86c54b9b0d01c6aa4f634759ad083765e144",
+				"DiscoKey":   "discokey:2db32744ad75a83ac7bcde79e4c61bf9437a1656064d2a3ea3ef81161ebd217a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41984",
+					"10.65.0.27:41984",
+					"172.17.0.1:41984",
+					"172.18.0.1:41984",
+					"172.19.0.1:41984"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:13:35.324943716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         741676766661572,
+				"StableID":   "nHyn7Hbun611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a9c112e23c4a6311d26b3b1db8e2b16cec3c9288148edff73a2f15e3ebd36c01",
+				"DiscoKey":   "discokey:1550299eb28ac5bf790ef2ce4ff535bfbbb2ebcfd2540143bc64cd5f99dd9129",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34739",
+					"10.65.0.27:34739",
+					"172.17.0.1:34739",
+					"172.18.0.1:34739",
+					"172.19.0.1:34739"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:13:36.413972509Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1298541221208280,
+				"StableID":   "nMTD5cU79B11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7bda4ed3796d68606da6a365a62d2d75ac7c595467ac200640149cb413004277",
+				"DiscoKey":   "discokey:44be1862176824dab69a0f87461b30f6ab064688ca6dafa48897946e93a39b03",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55724",
+					"10.65.0.27:55724",
+					"172.17.0.1:55724",
+					"172.18.0.1:55724",
+					"172.19.0.1:55724"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:13:36.94891703Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1545753784186232,
+				"StableID":   "njSxiBL55D11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21922ff69734b12acdc916c2e38df8557ba8887806cc9b6fb595fb95b2fb9d0e",
+				"DiscoKey":   "discokey:3823dd4fda6ff4bb7931549533e22926778642bd4cdb8d9eb8a3e1def8e49571",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48404",
+					"10.65.0.27:48404",
+					"172.17.0.1:48404",
+					"172.18.0.1:48404",
+					"172.19.0.1:48404"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:13:37.487919248Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6753705650493008,
+				"StableID":   "n7AdMvPmju11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:19bb2883aa1f4fabdf7aef206ed1bdffe1606305deb6bfa732daa619f3708372",
+				"DiscoKey":   "discokey:9cb0fc99d2fe1a7b14bd9eafecb426cd24b2137a9d53a17e23973cc294f51d33",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44043",
+					"10.65.0.27:44043",
+					"172.17.0.1:44043",
+					"172.18.0.1:44043",
+					"172.19.0.1:44043"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:13:38.033328092Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2505133883124715,
+				"StableID":   "nG9npucaZL11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:4d64d19bad71f8f4bbde115225dbd8d8e5627a055263da7aca493a47488a3370",
+				"KeyExpiry":  "2026-11-08T22:13:38Z",
+				"DiscoKey":   "discokey:7df5455bda8a26723b68f0e8550d83fb8c4726a81281332b07ec38b4488a460c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44065",
+					"10.65.0.27:44065",
+					"172.17.0.1:44065",
+					"172.18.0.1:44065",
+					"172.19.0.1:44065"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:13:38.578940395Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1300111451217282,
+				"StableID":   "n39Tvwip9B11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:d5b9e890da91e9025eef6dde567da82cba826ecdeec9bd9c4b60de435d7f5438",
+				"KeyExpiry":  "2026-11-08T22:13:39Z",
+				"DiscoKey":   "discokey:de9879950292f3742f71c7458087fa72ccc20b30cce7e3f8610e8c52899ea01e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39568",
+					"10.65.0.27:39568",
+					"172.17.0.1:39568",
+					"172.18.0.1:39568",
+					"172.19.0.1:39568"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 53165},
+					{"Proto": "peerapi6", "Port": 53165}
+				]},
+				"Created":              "2026-05-12T22:13:39.102386131Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4100897524667226,
+				"StableID":   "nqLgPCdJ2Z11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fc0e86e8745c8d6c3b38356f2c7775f7abdb820e5459fa1d57a4e274ac8c926b",
+				"KeyExpiry":  "2026-11-08T22:13:39Z",
+				"DiscoKey":   "discokey:2c1d1ce45c6235ae1acaaaadbe665af846cfb1b3bb2f1245edc5a661d1fd832c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60848",
+					"10.65.0.27:60848",
+					"172.17.0.1:60848",
+					"172.18.0.1:60848",
+					"172.19.0.1:60848"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:13:39.648098932Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3944579690127648": {
+				"ID":          3944579690127648,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2505133883124715,
+				"StableID":   "nG9npucaZL11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:4d64d19bad71f8f4bbde115225dbd8d8e5627a055263da7aca493a47488a3370",
+				"KeyExpiry":  "2026-11-08T22:13:38Z",
+				"DiscoKey":   "discokey:7df5455bda8a26723b68f0e8550d83fb8c4726a81281332b07ec38b4488a460c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44065",
+					"10.65.0.27:44065",
+					"172.17.0.1:44065",
+					"172.18.0.1:44065",
+					"172.19.0.1:44065"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:13:38.578940395Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4d64d19bad71f8f4bbde115225dbd8d8e5627a055263da7aca493a47488a3370",
+			"MachineKey": "mkey:497ced38b6427d827ba72f0f79d60f4165f028efa14fcf04504d6d61470fd522",
+			"Peers": [{
+				"ID":         7719163547601196,
+				"StableID":   "nFQjfYL2H321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f5ffa2b18c48294539836834475da4a03c873b1c1d5bddc7bf1971edefc9c158",
+				"DiscoKey":   "discokey:2dc89d3ad19c3380ace297c9f17670919f8d5cb5555296923333b88ee62eb30f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53049",
+					"10.65.0.27:53049",
+					"172.17.0.1:53049",
+					"172.18.0.1:53049",
+					"172.19.0.1:53049"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:13:32.134599243Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4646875696721316,
+				"StableID":   "n7AnqbYaHd11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86b0877ff0aafd24fa5b582d6e701c1de0d7f4fd0b626778f6780544f21da65e",
+				"DiscoKey":   "discokey:2a6110ce7830c1c2b789df7eb634706f12b52f4f6b0d13ef147a029da158b12d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45390",
+					"10.65.0.27:45390",
+					"172.17.0.1:45390",
+					"172.18.0.1:45390",
+					"172.19.0.1:45390"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:13:32.630513321Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6398465701021322,
+				"StableID":   "n3D1Vxqsxr11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:868b93b2ba5c5f7183276dc5f388a803d58d66477a5705ec56f687d73b62330a",
+				"DiscoKey":   "discokey:6dd5d182ac34cb3b9757c4842b4f096ed8eaa13f6b1e31eaf31bcd65b86b442a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35363",
+					"10.65.0.27:35363",
+					"172.17.0.1:35363",
+					"172.18.0.1:35363",
+					"172.19.0.1:35363"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:13:33.161639478Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5561987148277355,
+				"StableID":   "n2aTAKy2Sk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd7cd9487031017b6feaff009927c7ef85e13b93da2fc9c83a8467b0c59fd903",
+				"DiscoKey":   "discokey:3d6e788e89c04c82ae84234e752591774a22d25a34b2614b9463840083e08325",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51065",
+					"10.65.0.27:51065",
+					"172.17.0.1:51065",
+					"172.18.0.1:51065",
+					"172.19.0.1:51065"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:13:33.70769115Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3489551594547578,
+				"StableID":   "nR881zbRFU11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d2be220bd8a766dca167dc8df5cb73d494fc84f8d7ca8e85b846495173463153",
+				"DiscoKey":   "discokey:eba9b59d70752303cbe5d089e02167c5bd30faf105bc11ed270ada16979dcb35",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38335",
+					"10.65.0.27:38335",
+					"172.17.0.1:38335",
+					"172.18.0.1:38335",
+					"172.19.0.1:38335"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:13:34.253105915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8449658380066409,
+				"StableID":   "nnXwYTCsy821CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c36e6e2429500358bc51a8b42991510ce45a8da109207042b0142c4608d0b956",
+				"DiscoKey":   "discokey:dcdfbe417b769f984fb9b0a400cf3b125341b1d18301bb37a4a4ce0a4a68ef29",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39301",
+					"10.65.0.27:39301",
+					"172.17.0.1:39301",
+					"172.18.0.1:39301",
+					"172.19.0.1:39301"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:13:34.789711074Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7724333060802280,
+				"StableID":   "nyw8rc8NK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d04b23e7f941f7c689105a64f5c86c54b9b0d01c6aa4f634759ad083765e144",
+				"DiscoKey":   "discokey:2db32744ad75a83ac7bcde79e4c61bf9437a1656064d2a3ea3ef81161ebd217a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41984",
+					"10.65.0.27:41984",
+					"172.17.0.1:41984",
+					"172.18.0.1:41984",
+					"172.19.0.1:41984"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:13:35.324943716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3944579690127648,
+				"StableID":   "nFJ1eLRWoX11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b1b7b37df4b029adb5d24a39575956113c2b71a8c8a896646568062d0b5f7d3c",
+				"DiscoKey":   "discokey:be91faf33fbce07cd8787675cbfbe994e55118cb695991ae0975d393b1dbb03a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50093",
+					"10.65.0.27:50093",
+					"172.17.0.1:50093",
+					"172.18.0.1:50093",
+					"172.19.0.1:50093"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:13:35.859431146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         741676766661572,
+				"StableID":   "nHyn7Hbun611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a9c112e23c4a6311d26b3b1db8e2b16cec3c9288148edff73a2f15e3ebd36c01",
+				"DiscoKey":   "discokey:1550299eb28ac5bf790ef2ce4ff535bfbbb2ebcfd2540143bc64cd5f99dd9129",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34739",
+					"10.65.0.27:34739",
+					"172.17.0.1:34739",
+					"172.18.0.1:34739",
+					"172.19.0.1:34739"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:13:36.413972509Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1298541221208280,
+				"StableID":   "nMTD5cU79B11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7bda4ed3796d68606da6a365a62d2d75ac7c595467ac200640149cb413004277",
+				"DiscoKey":   "discokey:44be1862176824dab69a0f87461b30f6ab064688ca6dafa48897946e93a39b03",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55724",
+					"10.65.0.27:55724",
+					"172.17.0.1:55724",
+					"172.18.0.1:55724",
+					"172.19.0.1:55724"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:13:36.94891703Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1545753784186232,
+				"StableID":   "njSxiBL55D11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21922ff69734b12acdc916c2e38df8557ba8887806cc9b6fb595fb95b2fb9d0e",
+				"DiscoKey":   "discokey:3823dd4fda6ff4bb7931549533e22926778642bd4cdb8d9eb8a3e1def8e49571",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48404",
+					"10.65.0.27:48404",
+					"172.17.0.1:48404",
+					"172.18.0.1:48404",
+					"172.19.0.1:48404"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:13:37.487919248Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6753705650493008,
+				"StableID":   "n7AdMvPmju11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:19bb2883aa1f4fabdf7aef206ed1bdffe1606305deb6bfa732daa619f3708372",
+				"DiscoKey":   "discokey:9cb0fc99d2fe1a7b14bd9eafecb426cd24b2137a9d53a17e23973cc294f51d33",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44043",
+					"10.65.0.27:44043",
+					"172.17.0.1:44043",
+					"172.18.0.1:44043",
+					"172.19.0.1:44043"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:13:38.033328092Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1300111451217282,
+				"StableID":   "n39Tvwip9B11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:d5b9e890da91e9025eef6dde567da82cba826ecdeec9bd9c4b60de435d7f5438",
+				"KeyExpiry":  "2026-11-08T22:13:39Z",
+				"DiscoKey":   "discokey:de9879950292f3742f71c7458087fa72ccc20b30cce7e3f8610e8c52899ea01e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39568",
+					"10.65.0.27:39568",
+					"172.17.0.1:39568",
+					"172.18.0.1:39568",
+					"172.19.0.1:39568"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 53165},
+					{"Proto": "peerapi6", "Port": 53165}
+				]},
+				"Created":              "2026-05-12T22:13:39.102386131Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4100897524667226,
+				"StableID":   "nqLgPCdJ2Z11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fc0e86e8745c8d6c3b38356f2c7775f7abdb820e5459fa1d57a4e274ac8c926b",
+				"KeyExpiry":  "2026-11-08T22:13:39Z",
+				"DiscoKey":   "discokey:2c1d1ce45c6235ae1acaaaadbe665af846cfb1b3bb2f1245edc5a661d1fd832c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60848",
+					"10.65.0.27:60848",
+					"172.17.0.1:60848",
+					"172.18.0.1:60848",
+					"172.19.0.1:60848"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:13:39.648098932Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1545753784186232,
+				"StableID":   "njSxiBL55D11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1545753784186232,
+				"Key":        "nodekey:21922ff69734b12acdc916c2e38df8557ba8887806cc9b6fb595fb95b2fb9d0e",
+				"DiscoKey":   "discokey:3823dd4fda6ff4bb7931549533e22926778642bd4cdb8d9eb8a3e1def8e49571",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48404",
+					"10.65.0.27:48404",
+					"172.17.0.1:48404",
+					"172.18.0.1:48404",
+					"172.19.0.1:48404"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:13:37.487919248Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:21922ff69734b12acdc916c2e38df8557ba8887806cc9b6fb595fb95b2fb9d0e",
+			"MachineKey": "mkey:1f8b51f359c742452faf94c8e10e0b24b9348a0eacca040cafc005b945e6bf43",
+			"Peers": [{
+				"ID":         7719163547601196,
+				"StableID":   "nFQjfYL2H321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f5ffa2b18c48294539836834475da4a03c873b1c1d5bddc7bf1971edefc9c158",
+				"DiscoKey":   "discokey:2dc89d3ad19c3380ace297c9f17670919f8d5cb5555296923333b88ee62eb30f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53049",
+					"10.65.0.27:53049",
+					"172.17.0.1:53049",
+					"172.18.0.1:53049",
+					"172.19.0.1:53049"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:13:32.134599243Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4646875696721316,
+				"StableID":   "n7AnqbYaHd11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86b0877ff0aafd24fa5b582d6e701c1de0d7f4fd0b626778f6780544f21da65e",
+				"DiscoKey":   "discokey:2a6110ce7830c1c2b789df7eb634706f12b52f4f6b0d13ef147a029da158b12d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45390",
+					"10.65.0.27:45390",
+					"172.17.0.1:45390",
+					"172.18.0.1:45390",
+					"172.19.0.1:45390"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:13:32.630513321Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6398465701021322,
+				"StableID":   "n3D1Vxqsxr11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:868b93b2ba5c5f7183276dc5f388a803d58d66477a5705ec56f687d73b62330a",
+				"DiscoKey":   "discokey:6dd5d182ac34cb3b9757c4842b4f096ed8eaa13f6b1e31eaf31bcd65b86b442a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35363",
+					"10.65.0.27:35363",
+					"172.17.0.1:35363",
+					"172.18.0.1:35363",
+					"172.19.0.1:35363"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:13:33.161639478Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5561987148277355,
+				"StableID":   "n2aTAKy2Sk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd7cd9487031017b6feaff009927c7ef85e13b93da2fc9c83a8467b0c59fd903",
+				"DiscoKey":   "discokey:3d6e788e89c04c82ae84234e752591774a22d25a34b2614b9463840083e08325",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51065",
+					"10.65.0.27:51065",
+					"172.17.0.1:51065",
+					"172.18.0.1:51065",
+					"172.19.0.1:51065"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:13:33.70769115Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3489551594547578,
+				"StableID":   "nR881zbRFU11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d2be220bd8a766dca167dc8df5cb73d494fc84f8d7ca8e85b846495173463153",
+				"DiscoKey":   "discokey:eba9b59d70752303cbe5d089e02167c5bd30faf105bc11ed270ada16979dcb35",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38335",
+					"10.65.0.27:38335",
+					"172.17.0.1:38335",
+					"172.18.0.1:38335",
+					"172.19.0.1:38335"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:13:34.253105915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8449658380066409,
+				"StableID":   "nnXwYTCsy821CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c36e6e2429500358bc51a8b42991510ce45a8da109207042b0142c4608d0b956",
+				"DiscoKey":   "discokey:dcdfbe417b769f984fb9b0a400cf3b125341b1d18301bb37a4a4ce0a4a68ef29",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39301",
+					"10.65.0.27:39301",
+					"172.17.0.1:39301",
+					"172.18.0.1:39301",
+					"172.19.0.1:39301"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:13:34.789711074Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7724333060802280,
+				"StableID":   "nyw8rc8NK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d04b23e7f941f7c689105a64f5c86c54b9b0d01c6aa4f634759ad083765e144",
+				"DiscoKey":   "discokey:2db32744ad75a83ac7bcde79e4c61bf9437a1656064d2a3ea3ef81161ebd217a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41984",
+					"10.65.0.27:41984",
+					"172.17.0.1:41984",
+					"172.18.0.1:41984",
+					"172.19.0.1:41984"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:13:35.324943716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3944579690127648,
+				"StableID":   "nFJ1eLRWoX11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b1b7b37df4b029adb5d24a39575956113c2b71a8c8a896646568062d0b5f7d3c",
+				"DiscoKey":   "discokey:be91faf33fbce07cd8787675cbfbe994e55118cb695991ae0975d393b1dbb03a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50093",
+					"10.65.0.27:50093",
+					"172.17.0.1:50093",
+					"172.18.0.1:50093",
+					"172.19.0.1:50093"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:13:35.859431146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         741676766661572,
+				"StableID":   "nHyn7Hbun611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a9c112e23c4a6311d26b3b1db8e2b16cec3c9288148edff73a2f15e3ebd36c01",
+				"DiscoKey":   "discokey:1550299eb28ac5bf790ef2ce4ff535bfbbb2ebcfd2540143bc64cd5f99dd9129",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34739",
+					"10.65.0.27:34739",
+					"172.17.0.1:34739",
+					"172.18.0.1:34739",
+					"172.19.0.1:34739"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:13:36.413972509Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1298541221208280,
+				"StableID":   "nMTD5cU79B11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7bda4ed3796d68606da6a365a62d2d75ac7c595467ac200640149cb413004277",
+				"DiscoKey":   "discokey:44be1862176824dab69a0f87461b30f6ab064688ca6dafa48897946e93a39b03",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55724",
+					"10.65.0.27:55724",
+					"172.17.0.1:55724",
+					"172.18.0.1:55724",
+					"172.19.0.1:55724"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:13:36.94891703Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6753705650493008,
+				"StableID":   "n7AdMvPmju11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:19bb2883aa1f4fabdf7aef206ed1bdffe1606305deb6bfa732daa619f3708372",
+				"DiscoKey":   "discokey:9cb0fc99d2fe1a7b14bd9eafecb426cd24b2137a9d53a17e23973cc294f51d33",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44043",
+					"10.65.0.27:44043",
+					"172.17.0.1:44043",
+					"172.18.0.1:44043",
+					"172.19.0.1:44043"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:13:38.033328092Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2505133883124715,
+				"StableID":   "nG9npucaZL11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:4d64d19bad71f8f4bbde115225dbd8d8e5627a055263da7aca493a47488a3370",
+				"KeyExpiry":  "2026-11-08T22:13:38Z",
+				"DiscoKey":   "discokey:7df5455bda8a26723b68f0e8550d83fb8c4726a81281332b07ec38b4488a460c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44065",
+					"10.65.0.27:44065",
+					"172.17.0.1:44065",
+					"172.18.0.1:44065",
+					"172.19.0.1:44065"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:13:38.578940395Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1300111451217282,
+				"StableID":   "n39Tvwip9B11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:d5b9e890da91e9025eef6dde567da82cba826ecdeec9bd9c4b60de435d7f5438",
+				"KeyExpiry":  "2026-11-08T22:13:39Z",
+				"DiscoKey":   "discokey:de9879950292f3742f71c7458087fa72ccc20b30cce7e3f8610e8c52899ea01e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39568",
+					"10.65.0.27:39568",
+					"172.17.0.1:39568",
+					"172.18.0.1:39568",
+					"172.19.0.1:39568"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 53165},
+					{"Proto": "peerapi6", "Port": 53165}
+				]},
+				"Created":              "2026-05-12T22:13:39.102386131Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4100897524667226,
+				"StableID":   "nqLgPCdJ2Z11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fc0e86e8745c8d6c3b38356f2c7775f7abdb820e5459fa1d57a4e274ac8c926b",
+				"KeyExpiry":  "2026-11-08T22:13:39Z",
+				"DiscoKey":   "discokey:2c1d1ce45c6235ae1acaaaadbe665af846cfb1b3bb2f1245edc5a661d1fd832c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60848",
+					"10.65.0.27:60848",
+					"172.17.0.1:60848",
+					"172.18.0.1:60848",
+					"172.19.0.1:60848"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:13:39.648098932Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1545753784186232": {
+				"ID":          1545753784186232,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4646875696721316,
+				"StableID":   "n7AnqbYaHd11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       4646875696721316,
+				"Key":        "nodekey:86b0877ff0aafd24fa5b582d6e701c1de0d7f4fd0b626778f6780544f21da65e",
+				"DiscoKey":   "discokey:2a6110ce7830c1c2b789df7eb634706f12b52f4f6b0d13ef147a029da158b12d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45390",
+					"10.65.0.27:45390",
+					"172.17.0.1:45390",
+					"172.18.0.1:45390",
+					"172.19.0.1:45390"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:13:32.630513321Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:86b0877ff0aafd24fa5b582d6e701c1de0d7f4fd0b626778f6780544f21da65e",
+			"MachineKey": "mkey:ff945294f158fe0b56e3edb818b92c29a9b7831e3565653c8070b77349179b5a",
+			"Peers": [{
+				"ID":         7719163547601196,
+				"StableID":   "nFQjfYL2H321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f5ffa2b18c48294539836834475da4a03c873b1c1d5bddc7bf1971edefc9c158",
+				"DiscoKey":   "discokey:2dc89d3ad19c3380ace297c9f17670919f8d5cb5555296923333b88ee62eb30f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53049",
+					"10.65.0.27:53049",
+					"172.17.0.1:53049",
+					"172.18.0.1:53049",
+					"172.19.0.1:53049"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:13:32.134599243Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6398465701021322,
+				"StableID":   "n3D1Vxqsxr11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:868b93b2ba5c5f7183276dc5f388a803d58d66477a5705ec56f687d73b62330a",
+				"DiscoKey":   "discokey:6dd5d182ac34cb3b9757c4842b4f096ed8eaa13f6b1e31eaf31bcd65b86b442a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35363",
+					"10.65.0.27:35363",
+					"172.17.0.1:35363",
+					"172.18.0.1:35363",
+					"172.19.0.1:35363"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:13:33.161639478Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5561987148277355,
+				"StableID":   "n2aTAKy2Sk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd7cd9487031017b6feaff009927c7ef85e13b93da2fc9c83a8467b0c59fd903",
+				"DiscoKey":   "discokey:3d6e788e89c04c82ae84234e752591774a22d25a34b2614b9463840083e08325",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51065",
+					"10.65.0.27:51065",
+					"172.17.0.1:51065",
+					"172.18.0.1:51065",
+					"172.19.0.1:51065"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:13:33.70769115Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3489551594547578,
+				"StableID":   "nR881zbRFU11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d2be220bd8a766dca167dc8df5cb73d494fc84f8d7ca8e85b846495173463153",
+				"DiscoKey":   "discokey:eba9b59d70752303cbe5d089e02167c5bd30faf105bc11ed270ada16979dcb35",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38335",
+					"10.65.0.27:38335",
+					"172.17.0.1:38335",
+					"172.18.0.1:38335",
+					"172.19.0.1:38335"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:13:34.253105915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8449658380066409,
+				"StableID":   "nnXwYTCsy821CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c36e6e2429500358bc51a8b42991510ce45a8da109207042b0142c4608d0b956",
+				"DiscoKey":   "discokey:dcdfbe417b769f984fb9b0a400cf3b125341b1d18301bb37a4a4ce0a4a68ef29",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39301",
+					"10.65.0.27:39301",
+					"172.17.0.1:39301",
+					"172.18.0.1:39301",
+					"172.19.0.1:39301"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:13:34.789711074Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7724333060802280,
+				"StableID":   "nyw8rc8NK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d04b23e7f941f7c689105a64f5c86c54b9b0d01c6aa4f634759ad083765e144",
+				"DiscoKey":   "discokey:2db32744ad75a83ac7bcde79e4c61bf9437a1656064d2a3ea3ef81161ebd217a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41984",
+					"10.65.0.27:41984",
+					"172.17.0.1:41984",
+					"172.18.0.1:41984",
+					"172.19.0.1:41984"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:13:35.324943716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3944579690127648,
+				"StableID":   "nFJ1eLRWoX11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b1b7b37df4b029adb5d24a39575956113c2b71a8c8a896646568062d0b5f7d3c",
+				"DiscoKey":   "discokey:be91faf33fbce07cd8787675cbfbe994e55118cb695991ae0975d393b1dbb03a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50093",
+					"10.65.0.27:50093",
+					"172.17.0.1:50093",
+					"172.18.0.1:50093",
+					"172.19.0.1:50093"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:13:35.859431146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         741676766661572,
+				"StableID":   "nHyn7Hbun611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a9c112e23c4a6311d26b3b1db8e2b16cec3c9288148edff73a2f15e3ebd36c01",
+				"DiscoKey":   "discokey:1550299eb28ac5bf790ef2ce4ff535bfbbb2ebcfd2540143bc64cd5f99dd9129",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34739",
+					"10.65.0.27:34739",
+					"172.17.0.1:34739",
+					"172.18.0.1:34739",
+					"172.19.0.1:34739"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:13:36.413972509Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1298541221208280,
+				"StableID":   "nMTD5cU79B11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7bda4ed3796d68606da6a365a62d2d75ac7c595467ac200640149cb413004277",
+				"DiscoKey":   "discokey:44be1862176824dab69a0f87461b30f6ab064688ca6dafa48897946e93a39b03",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55724",
+					"10.65.0.27:55724",
+					"172.17.0.1:55724",
+					"172.18.0.1:55724",
+					"172.19.0.1:55724"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:13:36.94891703Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1545753784186232,
+				"StableID":   "njSxiBL55D11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21922ff69734b12acdc916c2e38df8557ba8887806cc9b6fb595fb95b2fb9d0e",
+				"DiscoKey":   "discokey:3823dd4fda6ff4bb7931549533e22926778642bd4cdb8d9eb8a3e1def8e49571",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48404",
+					"10.65.0.27:48404",
+					"172.17.0.1:48404",
+					"172.18.0.1:48404",
+					"172.19.0.1:48404"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:13:37.487919248Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6753705650493008,
+				"StableID":   "n7AdMvPmju11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:19bb2883aa1f4fabdf7aef206ed1bdffe1606305deb6bfa732daa619f3708372",
+				"DiscoKey":   "discokey:9cb0fc99d2fe1a7b14bd9eafecb426cd24b2137a9d53a17e23973cc294f51d33",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44043",
+					"10.65.0.27:44043",
+					"172.17.0.1:44043",
+					"172.18.0.1:44043",
+					"172.19.0.1:44043"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:13:38.033328092Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2505133883124715,
+				"StableID":   "nG9npucaZL11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:4d64d19bad71f8f4bbde115225dbd8d8e5627a055263da7aca493a47488a3370",
+				"KeyExpiry":  "2026-11-08T22:13:38Z",
+				"DiscoKey":   "discokey:7df5455bda8a26723b68f0e8550d83fb8c4726a81281332b07ec38b4488a460c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44065",
+					"10.65.0.27:44065",
+					"172.17.0.1:44065",
+					"172.18.0.1:44065",
+					"172.19.0.1:44065"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:13:38.578940395Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1300111451217282,
+				"StableID":   "n39Tvwip9B11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:d5b9e890da91e9025eef6dde567da82cba826ecdeec9bd9c4b60de435d7f5438",
+				"KeyExpiry":  "2026-11-08T22:13:39Z",
+				"DiscoKey":   "discokey:de9879950292f3742f71c7458087fa72ccc20b30cce7e3f8610e8c52899ea01e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39568",
+					"10.65.0.27:39568",
+					"172.17.0.1:39568",
+					"172.18.0.1:39568",
+					"172.19.0.1:39568"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 53165},
+					{"Proto": "peerapi6", "Port": 53165}
+				]},
+				"Created":              "2026-05-12T22:13:39.102386131Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4100897524667226,
+				"StableID":   "nqLgPCdJ2Z11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fc0e86e8745c8d6c3b38356f2c7775f7abdb820e5459fa1d57a4e274ac8c926b",
+				"KeyExpiry":  "2026-11-08T22:13:39Z",
+				"DiscoKey":   "discokey:2c1d1ce45c6235ae1acaaaadbe665af846cfb1b3bb2f1245edc5a661d1fd832c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60848",
+					"10.65.0.27:60848",
+					"172.17.0.1:60848",
+					"172.18.0.1:60848",
+					"172.19.0.1:60848"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:13:39.648098932Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4646875696721316": {
+				"ID":          4646875696721316,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7719163547601196,
+				"StableID":   "nFQjfYL2H321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       7719163547601196,
+				"Key":        "nodekey:f5ffa2b18c48294539836834475da4a03c873b1c1d5bddc7bf1971edefc9c158",
+				"DiscoKey":   "discokey:2dc89d3ad19c3380ace297c9f17670919f8d5cb5555296923333b88ee62eb30f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53049",
+					"10.65.0.27:53049",
+					"172.17.0.1:53049",
+					"172.18.0.1:53049",
+					"172.19.0.1:53049"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:13:32.134599243Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f5ffa2b18c48294539836834475da4a03c873b1c1d5bddc7bf1971edefc9c158",
+			"MachineKey": "mkey:cbc081d5e87b95e220972e483f5005a61463287a58dadbfa07bef659c54d8c68",
+			"Peers": [{
+				"ID":         4646875696721316,
+				"StableID":   "n7AnqbYaHd11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86b0877ff0aafd24fa5b582d6e701c1de0d7f4fd0b626778f6780544f21da65e",
+				"DiscoKey":   "discokey:2a6110ce7830c1c2b789df7eb634706f12b52f4f6b0d13ef147a029da158b12d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45390",
+					"10.65.0.27:45390",
+					"172.17.0.1:45390",
+					"172.18.0.1:45390",
+					"172.19.0.1:45390"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:13:32.630513321Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6398465701021322,
+				"StableID":   "n3D1Vxqsxr11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:868b93b2ba5c5f7183276dc5f388a803d58d66477a5705ec56f687d73b62330a",
+				"DiscoKey":   "discokey:6dd5d182ac34cb3b9757c4842b4f096ed8eaa13f6b1e31eaf31bcd65b86b442a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35363",
+					"10.65.0.27:35363",
+					"172.17.0.1:35363",
+					"172.18.0.1:35363",
+					"172.19.0.1:35363"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:13:33.161639478Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5561987148277355,
+				"StableID":   "n2aTAKy2Sk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd7cd9487031017b6feaff009927c7ef85e13b93da2fc9c83a8467b0c59fd903",
+				"DiscoKey":   "discokey:3d6e788e89c04c82ae84234e752591774a22d25a34b2614b9463840083e08325",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51065",
+					"10.65.0.27:51065",
+					"172.17.0.1:51065",
+					"172.18.0.1:51065",
+					"172.19.0.1:51065"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:13:33.70769115Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3489551594547578,
+				"StableID":   "nR881zbRFU11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d2be220bd8a766dca167dc8df5cb73d494fc84f8d7ca8e85b846495173463153",
+				"DiscoKey":   "discokey:eba9b59d70752303cbe5d089e02167c5bd30faf105bc11ed270ada16979dcb35",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38335",
+					"10.65.0.27:38335",
+					"172.17.0.1:38335",
+					"172.18.0.1:38335",
+					"172.19.0.1:38335"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:13:34.253105915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8449658380066409,
+				"StableID":   "nnXwYTCsy821CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c36e6e2429500358bc51a8b42991510ce45a8da109207042b0142c4608d0b956",
+				"DiscoKey":   "discokey:dcdfbe417b769f984fb9b0a400cf3b125341b1d18301bb37a4a4ce0a4a68ef29",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39301",
+					"10.65.0.27:39301",
+					"172.17.0.1:39301",
+					"172.18.0.1:39301",
+					"172.19.0.1:39301"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:13:34.789711074Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7724333060802280,
+				"StableID":   "nyw8rc8NK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d04b23e7f941f7c689105a64f5c86c54b9b0d01c6aa4f634759ad083765e144",
+				"DiscoKey":   "discokey:2db32744ad75a83ac7bcde79e4c61bf9437a1656064d2a3ea3ef81161ebd217a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41984",
+					"10.65.0.27:41984",
+					"172.17.0.1:41984",
+					"172.18.0.1:41984",
+					"172.19.0.1:41984"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:13:35.324943716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3944579690127648,
+				"StableID":   "nFJ1eLRWoX11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b1b7b37df4b029adb5d24a39575956113c2b71a8c8a896646568062d0b5f7d3c",
+				"DiscoKey":   "discokey:be91faf33fbce07cd8787675cbfbe994e55118cb695991ae0975d393b1dbb03a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50093",
+					"10.65.0.27:50093",
+					"172.17.0.1:50093",
+					"172.18.0.1:50093",
+					"172.19.0.1:50093"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:13:35.859431146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         741676766661572,
+				"StableID":   "nHyn7Hbun611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a9c112e23c4a6311d26b3b1db8e2b16cec3c9288148edff73a2f15e3ebd36c01",
+				"DiscoKey":   "discokey:1550299eb28ac5bf790ef2ce4ff535bfbbb2ebcfd2540143bc64cd5f99dd9129",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34739",
+					"10.65.0.27:34739",
+					"172.17.0.1:34739",
+					"172.18.0.1:34739",
+					"172.19.0.1:34739"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:13:36.413972509Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1298541221208280,
+				"StableID":   "nMTD5cU79B11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7bda4ed3796d68606da6a365a62d2d75ac7c595467ac200640149cb413004277",
+				"DiscoKey":   "discokey:44be1862176824dab69a0f87461b30f6ab064688ca6dafa48897946e93a39b03",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55724",
+					"10.65.0.27:55724",
+					"172.17.0.1:55724",
+					"172.18.0.1:55724",
+					"172.19.0.1:55724"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:13:36.94891703Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1545753784186232,
+				"StableID":   "njSxiBL55D11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21922ff69734b12acdc916c2e38df8557ba8887806cc9b6fb595fb95b2fb9d0e",
+				"DiscoKey":   "discokey:3823dd4fda6ff4bb7931549533e22926778642bd4cdb8d9eb8a3e1def8e49571",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48404",
+					"10.65.0.27:48404",
+					"172.17.0.1:48404",
+					"172.18.0.1:48404",
+					"172.19.0.1:48404"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:13:37.487919248Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6753705650493008,
+				"StableID":   "n7AdMvPmju11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:19bb2883aa1f4fabdf7aef206ed1bdffe1606305deb6bfa732daa619f3708372",
+				"DiscoKey":   "discokey:9cb0fc99d2fe1a7b14bd9eafecb426cd24b2137a9d53a17e23973cc294f51d33",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44043",
+					"10.65.0.27:44043",
+					"172.17.0.1:44043",
+					"172.18.0.1:44043",
+					"172.19.0.1:44043"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:13:38.033328092Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2505133883124715,
+				"StableID":   "nG9npucaZL11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:4d64d19bad71f8f4bbde115225dbd8d8e5627a055263da7aca493a47488a3370",
+				"KeyExpiry":  "2026-11-08T22:13:38Z",
+				"DiscoKey":   "discokey:7df5455bda8a26723b68f0e8550d83fb8c4726a81281332b07ec38b4488a460c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44065",
+					"10.65.0.27:44065",
+					"172.17.0.1:44065",
+					"172.18.0.1:44065",
+					"172.19.0.1:44065"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:13:38.578940395Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1300111451217282,
+				"StableID":   "n39Tvwip9B11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:d5b9e890da91e9025eef6dde567da82cba826ecdeec9bd9c4b60de435d7f5438",
+				"KeyExpiry":  "2026-11-08T22:13:39Z",
+				"DiscoKey":   "discokey:de9879950292f3742f71c7458087fa72ccc20b30cce7e3f8610e8c52899ea01e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39568",
+					"10.65.0.27:39568",
+					"172.17.0.1:39568",
+					"172.18.0.1:39568",
+					"172.19.0.1:39568"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 53165},
+					{"Proto": "peerapi6", "Port": 53165}
+				]},
+				"Created":              "2026-05-12T22:13:39.102386131Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4100897524667226,
+				"StableID":   "nqLgPCdJ2Z11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fc0e86e8745c8d6c3b38356f2c7775f7abdb820e5459fa1d57a4e274ac8c926b",
+				"KeyExpiry":  "2026-11-08T22:13:39Z",
+				"DiscoKey":   "discokey:2c1d1ce45c6235ae1acaaaadbe665af846cfb1b3bb2f1245edc5a661d1fd832c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60848",
+					"10.65.0.27:60848",
+					"172.17.0.1:60848",
+					"172.18.0.1:60848",
+					"172.19.0.1:60848"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:13:39.648098932Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7719163547601196": {
+				"ID":          7719163547601196,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3489551594547578,
+				"StableID":   "nR881zbRFU11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       3489551594547578,
+				"Key":        "nodekey:d2be220bd8a766dca167dc8df5cb73d494fc84f8d7ca8e85b846495173463153",
+				"DiscoKey":   "discokey:eba9b59d70752303cbe5d089e02167c5bd30faf105bc11ed270ada16979dcb35",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38335",
+					"10.65.0.27:38335",
+					"172.17.0.1:38335",
+					"172.18.0.1:38335",
+					"172.19.0.1:38335"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:13:34.253105915Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d2be220bd8a766dca167dc8df5cb73d494fc84f8d7ca8e85b846495173463153",
+			"MachineKey": "mkey:fe2b0181e33cda0eab81babefd152d8b038f87237f07930d555a14f70a395a21",
+			"Peers": [{
+				"ID":         7719163547601196,
+				"StableID":   "nFQjfYL2H321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f5ffa2b18c48294539836834475da4a03c873b1c1d5bddc7bf1971edefc9c158",
+				"DiscoKey":   "discokey:2dc89d3ad19c3380ace297c9f17670919f8d5cb5555296923333b88ee62eb30f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53049",
+					"10.65.0.27:53049",
+					"172.17.0.1:53049",
+					"172.18.0.1:53049",
+					"172.19.0.1:53049"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:13:32.134599243Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4646875696721316,
+				"StableID":   "n7AnqbYaHd11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86b0877ff0aafd24fa5b582d6e701c1de0d7f4fd0b626778f6780544f21da65e",
+				"DiscoKey":   "discokey:2a6110ce7830c1c2b789df7eb634706f12b52f4f6b0d13ef147a029da158b12d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45390",
+					"10.65.0.27:45390",
+					"172.17.0.1:45390",
+					"172.18.0.1:45390",
+					"172.19.0.1:45390"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:13:32.630513321Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6398465701021322,
+				"StableID":   "n3D1Vxqsxr11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:868b93b2ba5c5f7183276dc5f388a803d58d66477a5705ec56f687d73b62330a",
+				"DiscoKey":   "discokey:6dd5d182ac34cb3b9757c4842b4f096ed8eaa13f6b1e31eaf31bcd65b86b442a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35363",
+					"10.65.0.27:35363",
+					"172.17.0.1:35363",
+					"172.18.0.1:35363",
+					"172.19.0.1:35363"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:13:33.161639478Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5561987148277355,
+				"StableID":   "n2aTAKy2Sk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd7cd9487031017b6feaff009927c7ef85e13b93da2fc9c83a8467b0c59fd903",
+				"DiscoKey":   "discokey:3d6e788e89c04c82ae84234e752591774a22d25a34b2614b9463840083e08325",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51065",
+					"10.65.0.27:51065",
+					"172.17.0.1:51065",
+					"172.18.0.1:51065",
+					"172.19.0.1:51065"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:13:33.70769115Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8449658380066409,
+				"StableID":   "nnXwYTCsy821CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c36e6e2429500358bc51a8b42991510ce45a8da109207042b0142c4608d0b956",
+				"DiscoKey":   "discokey:dcdfbe417b769f984fb9b0a400cf3b125341b1d18301bb37a4a4ce0a4a68ef29",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39301",
+					"10.65.0.27:39301",
+					"172.17.0.1:39301",
+					"172.18.0.1:39301",
+					"172.19.0.1:39301"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:13:34.789711074Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7724333060802280,
+				"StableID":   "nyw8rc8NK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d04b23e7f941f7c689105a64f5c86c54b9b0d01c6aa4f634759ad083765e144",
+				"DiscoKey":   "discokey:2db32744ad75a83ac7bcde79e4c61bf9437a1656064d2a3ea3ef81161ebd217a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41984",
+					"10.65.0.27:41984",
+					"172.17.0.1:41984",
+					"172.18.0.1:41984",
+					"172.19.0.1:41984"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:13:35.324943716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3944579690127648,
+				"StableID":   "nFJ1eLRWoX11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b1b7b37df4b029adb5d24a39575956113c2b71a8c8a896646568062d0b5f7d3c",
+				"DiscoKey":   "discokey:be91faf33fbce07cd8787675cbfbe994e55118cb695991ae0975d393b1dbb03a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50093",
+					"10.65.0.27:50093",
+					"172.17.0.1:50093",
+					"172.18.0.1:50093",
+					"172.19.0.1:50093"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:13:35.859431146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         741676766661572,
+				"StableID":   "nHyn7Hbun611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a9c112e23c4a6311d26b3b1db8e2b16cec3c9288148edff73a2f15e3ebd36c01",
+				"DiscoKey":   "discokey:1550299eb28ac5bf790ef2ce4ff535bfbbb2ebcfd2540143bc64cd5f99dd9129",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34739",
+					"10.65.0.27:34739",
+					"172.17.0.1:34739",
+					"172.18.0.1:34739",
+					"172.19.0.1:34739"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:13:36.413972509Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1298541221208280,
+				"StableID":   "nMTD5cU79B11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7bda4ed3796d68606da6a365a62d2d75ac7c595467ac200640149cb413004277",
+				"DiscoKey":   "discokey:44be1862176824dab69a0f87461b30f6ab064688ca6dafa48897946e93a39b03",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55724",
+					"10.65.0.27:55724",
+					"172.17.0.1:55724",
+					"172.18.0.1:55724",
+					"172.19.0.1:55724"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:13:36.94891703Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1545753784186232,
+				"StableID":   "njSxiBL55D11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21922ff69734b12acdc916c2e38df8557ba8887806cc9b6fb595fb95b2fb9d0e",
+				"DiscoKey":   "discokey:3823dd4fda6ff4bb7931549533e22926778642bd4cdb8d9eb8a3e1def8e49571",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48404",
+					"10.65.0.27:48404",
+					"172.17.0.1:48404",
+					"172.18.0.1:48404",
+					"172.19.0.1:48404"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:13:37.487919248Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6753705650493008,
+				"StableID":   "n7AdMvPmju11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:19bb2883aa1f4fabdf7aef206ed1bdffe1606305deb6bfa732daa619f3708372",
+				"DiscoKey":   "discokey:9cb0fc99d2fe1a7b14bd9eafecb426cd24b2137a9d53a17e23973cc294f51d33",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44043",
+					"10.65.0.27:44043",
+					"172.17.0.1:44043",
+					"172.18.0.1:44043",
+					"172.19.0.1:44043"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:13:38.033328092Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2505133883124715,
+				"StableID":   "nG9npucaZL11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:4d64d19bad71f8f4bbde115225dbd8d8e5627a055263da7aca493a47488a3370",
+				"KeyExpiry":  "2026-11-08T22:13:38Z",
+				"DiscoKey":   "discokey:7df5455bda8a26723b68f0e8550d83fb8c4726a81281332b07ec38b4488a460c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44065",
+					"10.65.0.27:44065",
+					"172.17.0.1:44065",
+					"172.18.0.1:44065",
+					"172.19.0.1:44065"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:13:38.578940395Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1300111451217282,
+				"StableID":   "n39Tvwip9B11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:d5b9e890da91e9025eef6dde567da82cba826ecdeec9bd9c4b60de435d7f5438",
+				"KeyExpiry":  "2026-11-08T22:13:39Z",
+				"DiscoKey":   "discokey:de9879950292f3742f71c7458087fa72ccc20b30cce7e3f8610e8c52899ea01e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39568",
+					"10.65.0.27:39568",
+					"172.17.0.1:39568",
+					"172.18.0.1:39568",
+					"172.19.0.1:39568"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 53165},
+					{"Proto": "peerapi6", "Port": 53165}
+				]},
+				"Created":              "2026-05-12T22:13:39.102386131Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4100897524667226,
+				"StableID":   "nqLgPCdJ2Z11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fc0e86e8745c8d6c3b38356f2c7775f7abdb820e5459fa1d57a4e274ac8c926b",
+				"KeyExpiry":  "2026-11-08T22:13:39Z",
+				"DiscoKey":   "discokey:2c1d1ce45c6235ae1acaaaadbe665af846cfb1b3bb2f1245edc5a661d1fd832c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60848",
+					"10.65.0.27:60848",
+					"172.17.0.1:60848",
+					"172.18.0.1:60848",
+					"172.19.0.1:60848"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:13:39.648098932Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3489551594547578": {
+				"ID":          3489551594547578,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5561987148277355,
+				"StableID":   "n2aTAKy2Sk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       5561987148277355,
+				"Key":        "nodekey:cd7cd9487031017b6feaff009927c7ef85e13b93da2fc9c83a8467b0c59fd903",
+				"DiscoKey":   "discokey:3d6e788e89c04c82ae84234e752591774a22d25a34b2614b9463840083e08325",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51065",
+					"10.65.0.27:51065",
+					"172.17.0.1:51065",
+					"172.18.0.1:51065",
+					"172.19.0.1:51065"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:13:33.70769115Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:cd7cd9487031017b6feaff009927c7ef85e13b93da2fc9c83a8467b0c59fd903",
+			"MachineKey": "mkey:6214a7ad977d95536ded69a506695dc6d30eff53fcb8a4537c96a265128da225",
+			"Peers": [{
+				"ID":         7719163547601196,
+				"StableID":   "nFQjfYL2H321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f5ffa2b18c48294539836834475da4a03c873b1c1d5bddc7bf1971edefc9c158",
+				"DiscoKey":   "discokey:2dc89d3ad19c3380ace297c9f17670919f8d5cb5555296923333b88ee62eb30f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53049",
+					"10.65.0.27:53049",
+					"172.17.0.1:53049",
+					"172.18.0.1:53049",
+					"172.19.0.1:53049"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:13:32.134599243Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4646875696721316,
+				"StableID":   "n7AnqbYaHd11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86b0877ff0aafd24fa5b582d6e701c1de0d7f4fd0b626778f6780544f21da65e",
+				"DiscoKey":   "discokey:2a6110ce7830c1c2b789df7eb634706f12b52f4f6b0d13ef147a029da158b12d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45390",
+					"10.65.0.27:45390",
+					"172.17.0.1:45390",
+					"172.18.0.1:45390",
+					"172.19.0.1:45390"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:13:32.630513321Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6398465701021322,
+				"StableID":   "n3D1Vxqsxr11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:868b93b2ba5c5f7183276dc5f388a803d58d66477a5705ec56f687d73b62330a",
+				"DiscoKey":   "discokey:6dd5d182ac34cb3b9757c4842b4f096ed8eaa13f6b1e31eaf31bcd65b86b442a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35363",
+					"10.65.0.27:35363",
+					"172.17.0.1:35363",
+					"172.18.0.1:35363",
+					"172.19.0.1:35363"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:13:33.161639478Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3489551594547578,
+				"StableID":   "nR881zbRFU11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d2be220bd8a766dca167dc8df5cb73d494fc84f8d7ca8e85b846495173463153",
+				"DiscoKey":   "discokey:eba9b59d70752303cbe5d089e02167c5bd30faf105bc11ed270ada16979dcb35",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38335",
+					"10.65.0.27:38335",
+					"172.17.0.1:38335",
+					"172.18.0.1:38335",
+					"172.19.0.1:38335"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:13:34.253105915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8449658380066409,
+				"StableID":   "nnXwYTCsy821CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c36e6e2429500358bc51a8b42991510ce45a8da109207042b0142c4608d0b956",
+				"DiscoKey":   "discokey:dcdfbe417b769f984fb9b0a400cf3b125341b1d18301bb37a4a4ce0a4a68ef29",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39301",
+					"10.65.0.27:39301",
+					"172.17.0.1:39301",
+					"172.18.0.1:39301",
+					"172.19.0.1:39301"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:13:34.789711074Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7724333060802280,
+				"StableID":   "nyw8rc8NK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d04b23e7f941f7c689105a64f5c86c54b9b0d01c6aa4f634759ad083765e144",
+				"DiscoKey":   "discokey:2db32744ad75a83ac7bcde79e4c61bf9437a1656064d2a3ea3ef81161ebd217a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41984",
+					"10.65.0.27:41984",
+					"172.17.0.1:41984",
+					"172.18.0.1:41984",
+					"172.19.0.1:41984"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:13:35.324943716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3944579690127648,
+				"StableID":   "nFJ1eLRWoX11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b1b7b37df4b029adb5d24a39575956113c2b71a8c8a896646568062d0b5f7d3c",
+				"DiscoKey":   "discokey:be91faf33fbce07cd8787675cbfbe994e55118cb695991ae0975d393b1dbb03a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50093",
+					"10.65.0.27:50093",
+					"172.17.0.1:50093",
+					"172.18.0.1:50093",
+					"172.19.0.1:50093"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:13:35.859431146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         741676766661572,
+				"StableID":   "nHyn7Hbun611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a9c112e23c4a6311d26b3b1db8e2b16cec3c9288148edff73a2f15e3ebd36c01",
+				"DiscoKey":   "discokey:1550299eb28ac5bf790ef2ce4ff535bfbbb2ebcfd2540143bc64cd5f99dd9129",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34739",
+					"10.65.0.27:34739",
+					"172.17.0.1:34739",
+					"172.18.0.1:34739",
+					"172.19.0.1:34739"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:13:36.413972509Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1298541221208280,
+				"StableID":   "nMTD5cU79B11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7bda4ed3796d68606da6a365a62d2d75ac7c595467ac200640149cb413004277",
+				"DiscoKey":   "discokey:44be1862176824dab69a0f87461b30f6ab064688ca6dafa48897946e93a39b03",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55724",
+					"10.65.0.27:55724",
+					"172.17.0.1:55724",
+					"172.18.0.1:55724",
+					"172.19.0.1:55724"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:13:36.94891703Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1545753784186232,
+				"StableID":   "njSxiBL55D11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21922ff69734b12acdc916c2e38df8557ba8887806cc9b6fb595fb95b2fb9d0e",
+				"DiscoKey":   "discokey:3823dd4fda6ff4bb7931549533e22926778642bd4cdb8d9eb8a3e1def8e49571",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48404",
+					"10.65.0.27:48404",
+					"172.17.0.1:48404",
+					"172.18.0.1:48404",
+					"172.19.0.1:48404"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:13:37.487919248Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6753705650493008,
+				"StableID":   "n7AdMvPmju11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:19bb2883aa1f4fabdf7aef206ed1bdffe1606305deb6bfa732daa619f3708372",
+				"DiscoKey":   "discokey:9cb0fc99d2fe1a7b14bd9eafecb426cd24b2137a9d53a17e23973cc294f51d33",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44043",
+					"10.65.0.27:44043",
+					"172.17.0.1:44043",
+					"172.18.0.1:44043",
+					"172.19.0.1:44043"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:13:38.033328092Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2505133883124715,
+				"StableID":   "nG9npucaZL11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:4d64d19bad71f8f4bbde115225dbd8d8e5627a055263da7aca493a47488a3370",
+				"KeyExpiry":  "2026-11-08T22:13:38Z",
+				"DiscoKey":   "discokey:7df5455bda8a26723b68f0e8550d83fb8c4726a81281332b07ec38b4488a460c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44065",
+					"10.65.0.27:44065",
+					"172.17.0.1:44065",
+					"172.18.0.1:44065",
+					"172.19.0.1:44065"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:13:38.578940395Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1300111451217282,
+				"StableID":   "n39Tvwip9B11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:d5b9e890da91e9025eef6dde567da82cba826ecdeec9bd9c4b60de435d7f5438",
+				"KeyExpiry":  "2026-11-08T22:13:39Z",
+				"DiscoKey":   "discokey:de9879950292f3742f71c7458087fa72ccc20b30cce7e3f8610e8c52899ea01e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39568",
+					"10.65.0.27:39568",
+					"172.17.0.1:39568",
+					"172.18.0.1:39568",
+					"172.19.0.1:39568"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 53165},
+					{"Proto": "peerapi6", "Port": 53165}
+				]},
+				"Created":              "2026-05-12T22:13:39.102386131Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4100897524667226,
+				"StableID":   "nqLgPCdJ2Z11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fc0e86e8745c8d6c3b38356f2c7775f7abdb820e5459fa1d57a4e274ac8c926b",
+				"KeyExpiry":  "2026-11-08T22:13:39Z",
+				"DiscoKey":   "discokey:2c1d1ce45c6235ae1acaaaadbe665af846cfb1b3bb2f1245edc5a661d1fd832c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60848",
+					"10.65.0.27:60848",
+					"172.17.0.1:60848",
+					"172.18.0.1:60848",
+					"172.19.0.1:60848"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:13:39.648098932Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5561987148277355": {
+				"ID":          5561987148277355,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7724333060802280,
+				"StableID":   "nyw8rc8NK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       7724333060802280,
+				"Key":        "nodekey:3d04b23e7f941f7c689105a64f5c86c54b9b0d01c6aa4f634759ad083765e144",
+				"DiscoKey":   "discokey:2db32744ad75a83ac7bcde79e4c61bf9437a1656064d2a3ea3ef81161ebd217a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41984",
+					"10.65.0.27:41984",
+					"172.17.0.1:41984",
+					"172.18.0.1:41984",
+					"172.19.0.1:41984"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:13:35.324943716Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3d04b23e7f941f7c689105a64f5c86c54b9b0d01c6aa4f634759ad083765e144",
+			"MachineKey": "mkey:a1b4cbc3444ec79405329e2e43d3cdbfe1afd70b454ba8d5e744ca5bbea6ff44",
+			"Peers": [{
+				"ID":         7719163547601196,
+				"StableID":   "nFQjfYL2H321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f5ffa2b18c48294539836834475da4a03c873b1c1d5bddc7bf1971edefc9c158",
+				"DiscoKey":   "discokey:2dc89d3ad19c3380ace297c9f17670919f8d5cb5555296923333b88ee62eb30f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53049",
+					"10.65.0.27:53049",
+					"172.17.0.1:53049",
+					"172.18.0.1:53049",
+					"172.19.0.1:53049"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:13:32.134599243Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4646875696721316,
+				"StableID":   "n7AnqbYaHd11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86b0877ff0aafd24fa5b582d6e701c1de0d7f4fd0b626778f6780544f21da65e",
+				"DiscoKey":   "discokey:2a6110ce7830c1c2b789df7eb634706f12b52f4f6b0d13ef147a029da158b12d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45390",
+					"10.65.0.27:45390",
+					"172.17.0.1:45390",
+					"172.18.0.1:45390",
+					"172.19.0.1:45390"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:13:32.630513321Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6398465701021322,
+				"StableID":   "n3D1Vxqsxr11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:868b93b2ba5c5f7183276dc5f388a803d58d66477a5705ec56f687d73b62330a",
+				"DiscoKey":   "discokey:6dd5d182ac34cb3b9757c4842b4f096ed8eaa13f6b1e31eaf31bcd65b86b442a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35363",
+					"10.65.0.27:35363",
+					"172.17.0.1:35363",
+					"172.18.0.1:35363",
+					"172.19.0.1:35363"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:13:33.161639478Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5561987148277355,
+				"StableID":   "n2aTAKy2Sk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd7cd9487031017b6feaff009927c7ef85e13b93da2fc9c83a8467b0c59fd903",
+				"DiscoKey":   "discokey:3d6e788e89c04c82ae84234e752591774a22d25a34b2614b9463840083e08325",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51065",
+					"10.65.0.27:51065",
+					"172.17.0.1:51065",
+					"172.18.0.1:51065",
+					"172.19.0.1:51065"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:13:33.70769115Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3489551594547578,
+				"StableID":   "nR881zbRFU11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d2be220bd8a766dca167dc8df5cb73d494fc84f8d7ca8e85b846495173463153",
+				"DiscoKey":   "discokey:eba9b59d70752303cbe5d089e02167c5bd30faf105bc11ed270ada16979dcb35",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38335",
+					"10.65.0.27:38335",
+					"172.17.0.1:38335",
+					"172.18.0.1:38335",
+					"172.19.0.1:38335"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:13:34.253105915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8449658380066409,
+				"StableID":   "nnXwYTCsy821CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c36e6e2429500358bc51a8b42991510ce45a8da109207042b0142c4608d0b956",
+				"DiscoKey":   "discokey:dcdfbe417b769f984fb9b0a400cf3b125341b1d18301bb37a4a4ce0a4a68ef29",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39301",
+					"10.65.0.27:39301",
+					"172.17.0.1:39301",
+					"172.18.0.1:39301",
+					"172.19.0.1:39301"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:13:34.789711074Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3944579690127648,
+				"StableID":   "nFJ1eLRWoX11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b1b7b37df4b029adb5d24a39575956113c2b71a8c8a896646568062d0b5f7d3c",
+				"DiscoKey":   "discokey:be91faf33fbce07cd8787675cbfbe994e55118cb695991ae0975d393b1dbb03a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50093",
+					"10.65.0.27:50093",
+					"172.17.0.1:50093",
+					"172.18.0.1:50093",
+					"172.19.0.1:50093"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:13:35.859431146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         741676766661572,
+				"StableID":   "nHyn7Hbun611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a9c112e23c4a6311d26b3b1db8e2b16cec3c9288148edff73a2f15e3ebd36c01",
+				"DiscoKey":   "discokey:1550299eb28ac5bf790ef2ce4ff535bfbbb2ebcfd2540143bc64cd5f99dd9129",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34739",
+					"10.65.0.27:34739",
+					"172.17.0.1:34739",
+					"172.18.0.1:34739",
+					"172.19.0.1:34739"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:13:36.413972509Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1298541221208280,
+				"StableID":   "nMTD5cU79B11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7bda4ed3796d68606da6a365a62d2d75ac7c595467ac200640149cb413004277",
+				"DiscoKey":   "discokey:44be1862176824dab69a0f87461b30f6ab064688ca6dafa48897946e93a39b03",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55724",
+					"10.65.0.27:55724",
+					"172.17.0.1:55724",
+					"172.18.0.1:55724",
+					"172.19.0.1:55724"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:13:36.94891703Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1545753784186232,
+				"StableID":   "njSxiBL55D11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21922ff69734b12acdc916c2e38df8557ba8887806cc9b6fb595fb95b2fb9d0e",
+				"DiscoKey":   "discokey:3823dd4fda6ff4bb7931549533e22926778642bd4cdb8d9eb8a3e1def8e49571",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48404",
+					"10.65.0.27:48404",
+					"172.17.0.1:48404",
+					"172.18.0.1:48404",
+					"172.19.0.1:48404"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:13:37.487919248Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6753705650493008,
+				"StableID":   "n7AdMvPmju11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:19bb2883aa1f4fabdf7aef206ed1bdffe1606305deb6bfa732daa619f3708372",
+				"DiscoKey":   "discokey:9cb0fc99d2fe1a7b14bd9eafecb426cd24b2137a9d53a17e23973cc294f51d33",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44043",
+					"10.65.0.27:44043",
+					"172.17.0.1:44043",
+					"172.18.0.1:44043",
+					"172.19.0.1:44043"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:13:38.033328092Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2505133883124715,
+				"StableID":   "nG9npucaZL11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:4d64d19bad71f8f4bbde115225dbd8d8e5627a055263da7aca493a47488a3370",
+				"KeyExpiry":  "2026-11-08T22:13:38Z",
+				"DiscoKey":   "discokey:7df5455bda8a26723b68f0e8550d83fb8c4726a81281332b07ec38b4488a460c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44065",
+					"10.65.0.27:44065",
+					"172.17.0.1:44065",
+					"172.18.0.1:44065",
+					"172.19.0.1:44065"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:13:38.578940395Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1300111451217282,
+				"StableID":   "n39Tvwip9B11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:d5b9e890da91e9025eef6dde567da82cba826ecdeec9bd9c4b60de435d7f5438",
+				"KeyExpiry":  "2026-11-08T22:13:39Z",
+				"DiscoKey":   "discokey:de9879950292f3742f71c7458087fa72ccc20b30cce7e3f8610e8c52899ea01e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39568",
+					"10.65.0.27:39568",
+					"172.17.0.1:39568",
+					"172.18.0.1:39568",
+					"172.19.0.1:39568"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 53165},
+					{"Proto": "peerapi6", "Port": 53165}
+				]},
+				"Created":              "2026-05-12T22:13:39.102386131Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4100897524667226,
+				"StableID":   "nqLgPCdJ2Z11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fc0e86e8745c8d6c3b38356f2c7775f7abdb820e5459fa1d57a4e274ac8c926b",
+				"KeyExpiry":  "2026-11-08T22:13:39Z",
+				"DiscoKey":   "discokey:2c1d1ce45c6235ae1acaaaadbe665af846cfb1b3bb2f1245edc5a661d1fd832c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60848",
+					"10.65.0.27:60848",
+					"172.17.0.1:60848",
+					"172.18.0.1:60848",
+					"172.19.0.1:60848"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:13:39.648098932Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7724333060802280": {
+				"ID":          7724333060802280,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         741676766661572,
+				"StableID":   "nHyn7Hbun611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       741676766661572,
+				"Key":        "nodekey:a9c112e23c4a6311d26b3b1db8e2b16cec3c9288148edff73a2f15e3ebd36c01",
+				"DiscoKey":   "discokey:1550299eb28ac5bf790ef2ce4ff535bfbbb2ebcfd2540143bc64cd5f99dd9129",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34739",
+					"10.65.0.27:34739",
+					"172.17.0.1:34739",
+					"172.18.0.1:34739",
+					"172.19.0.1:34739"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T22:13:36.413972509Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a9c112e23c4a6311d26b3b1db8e2b16cec3c9288148edff73a2f15e3ebd36c01",
+			"MachineKey": "mkey:ea20efda18a26d9da0d371fd7a8c46b04fe342251e343db1fe5ce7ae6a73f626",
+			"Peers": [{
+				"ID":         7719163547601196,
+				"StableID":   "nFQjfYL2H321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f5ffa2b18c48294539836834475da4a03c873b1c1d5bddc7bf1971edefc9c158",
+				"DiscoKey":   "discokey:2dc89d3ad19c3380ace297c9f17670919f8d5cb5555296923333b88ee62eb30f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53049",
+					"10.65.0.27:53049",
+					"172.17.0.1:53049",
+					"172.18.0.1:53049",
+					"172.19.0.1:53049"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:13:32.134599243Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4646875696721316,
+				"StableID":   "n7AnqbYaHd11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86b0877ff0aafd24fa5b582d6e701c1de0d7f4fd0b626778f6780544f21da65e",
+				"DiscoKey":   "discokey:2a6110ce7830c1c2b789df7eb634706f12b52f4f6b0d13ef147a029da158b12d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45390",
+					"10.65.0.27:45390",
+					"172.17.0.1:45390",
+					"172.18.0.1:45390",
+					"172.19.0.1:45390"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:13:32.630513321Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6398465701021322,
+				"StableID":   "n3D1Vxqsxr11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:868b93b2ba5c5f7183276dc5f388a803d58d66477a5705ec56f687d73b62330a",
+				"DiscoKey":   "discokey:6dd5d182ac34cb3b9757c4842b4f096ed8eaa13f6b1e31eaf31bcd65b86b442a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35363",
+					"10.65.0.27:35363",
+					"172.17.0.1:35363",
+					"172.18.0.1:35363",
+					"172.19.0.1:35363"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:13:33.161639478Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5561987148277355,
+				"StableID":   "n2aTAKy2Sk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd7cd9487031017b6feaff009927c7ef85e13b93da2fc9c83a8467b0c59fd903",
+				"DiscoKey":   "discokey:3d6e788e89c04c82ae84234e752591774a22d25a34b2614b9463840083e08325",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51065",
+					"10.65.0.27:51065",
+					"172.17.0.1:51065",
+					"172.18.0.1:51065",
+					"172.19.0.1:51065"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:13:33.70769115Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3489551594547578,
+				"StableID":   "nR881zbRFU11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d2be220bd8a766dca167dc8df5cb73d494fc84f8d7ca8e85b846495173463153",
+				"DiscoKey":   "discokey:eba9b59d70752303cbe5d089e02167c5bd30faf105bc11ed270ada16979dcb35",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38335",
+					"10.65.0.27:38335",
+					"172.17.0.1:38335",
+					"172.18.0.1:38335",
+					"172.19.0.1:38335"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:13:34.253105915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8449658380066409,
+				"StableID":   "nnXwYTCsy821CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c36e6e2429500358bc51a8b42991510ce45a8da109207042b0142c4608d0b956",
+				"DiscoKey":   "discokey:dcdfbe417b769f984fb9b0a400cf3b125341b1d18301bb37a4a4ce0a4a68ef29",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39301",
+					"10.65.0.27:39301",
+					"172.17.0.1:39301",
+					"172.18.0.1:39301",
+					"172.19.0.1:39301"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:13:34.789711074Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7724333060802280,
+				"StableID":   "nyw8rc8NK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d04b23e7f941f7c689105a64f5c86c54b9b0d01c6aa4f634759ad083765e144",
+				"DiscoKey":   "discokey:2db32744ad75a83ac7bcde79e4c61bf9437a1656064d2a3ea3ef81161ebd217a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41984",
+					"10.65.0.27:41984",
+					"172.17.0.1:41984",
+					"172.18.0.1:41984",
+					"172.19.0.1:41984"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:13:35.324943716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3944579690127648,
+				"StableID":   "nFJ1eLRWoX11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b1b7b37df4b029adb5d24a39575956113c2b71a8c8a896646568062d0b5f7d3c",
+				"DiscoKey":   "discokey:be91faf33fbce07cd8787675cbfbe994e55118cb695991ae0975d393b1dbb03a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50093",
+					"10.65.0.27:50093",
+					"172.17.0.1:50093",
+					"172.18.0.1:50093",
+					"172.19.0.1:50093"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:13:35.859431146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1298541221208280,
+				"StableID":   "nMTD5cU79B11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7bda4ed3796d68606da6a365a62d2d75ac7c595467ac200640149cb413004277",
+				"DiscoKey":   "discokey:44be1862176824dab69a0f87461b30f6ab064688ca6dafa48897946e93a39b03",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55724",
+					"10.65.0.27:55724",
+					"172.17.0.1:55724",
+					"172.18.0.1:55724",
+					"172.19.0.1:55724"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:13:36.94891703Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1545753784186232,
+				"StableID":   "njSxiBL55D11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21922ff69734b12acdc916c2e38df8557ba8887806cc9b6fb595fb95b2fb9d0e",
+				"DiscoKey":   "discokey:3823dd4fda6ff4bb7931549533e22926778642bd4cdb8d9eb8a3e1def8e49571",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48404",
+					"10.65.0.27:48404",
+					"172.17.0.1:48404",
+					"172.18.0.1:48404",
+					"172.19.0.1:48404"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:13:37.487919248Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6753705650493008,
+				"StableID":   "n7AdMvPmju11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:19bb2883aa1f4fabdf7aef206ed1bdffe1606305deb6bfa732daa619f3708372",
+				"DiscoKey":   "discokey:9cb0fc99d2fe1a7b14bd9eafecb426cd24b2137a9d53a17e23973cc294f51d33",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44043",
+					"10.65.0.27:44043",
+					"172.17.0.1:44043",
+					"172.18.0.1:44043",
+					"172.19.0.1:44043"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:13:38.033328092Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2505133883124715,
+				"StableID":   "nG9npucaZL11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:4d64d19bad71f8f4bbde115225dbd8d8e5627a055263da7aca493a47488a3370",
+				"KeyExpiry":  "2026-11-08T22:13:38Z",
+				"DiscoKey":   "discokey:7df5455bda8a26723b68f0e8550d83fb8c4726a81281332b07ec38b4488a460c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44065",
+					"10.65.0.27:44065",
+					"172.17.0.1:44065",
+					"172.18.0.1:44065",
+					"172.19.0.1:44065"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:13:38.578940395Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1300111451217282,
+				"StableID":   "n39Tvwip9B11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:d5b9e890da91e9025eef6dde567da82cba826ecdeec9bd9c4b60de435d7f5438",
+				"KeyExpiry":  "2026-11-08T22:13:39Z",
+				"DiscoKey":   "discokey:de9879950292f3742f71c7458087fa72ccc20b30cce7e3f8610e8c52899ea01e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39568",
+					"10.65.0.27:39568",
+					"172.17.0.1:39568",
+					"172.18.0.1:39568",
+					"172.19.0.1:39568"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 53165},
+					{"Proto": "peerapi6", "Port": 53165}
+				]},
+				"Created":              "2026-05-12T22:13:39.102386131Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4100897524667226,
+				"StableID":   "nqLgPCdJ2Z11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fc0e86e8745c8d6c3b38356f2c7775f7abdb820e5459fa1d57a4e274ac8c926b",
+				"KeyExpiry":  "2026-11-08T22:13:39Z",
+				"DiscoKey":   "discokey:2c1d1ce45c6235ae1acaaaadbe665af846cfb1b3bb2f1245edc5a661d1fd832c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60848",
+					"10.65.0.27:60848",
+					"172.17.0.1:60848",
+					"172.18.0.1:60848",
+					"172.19.0.1:60848"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:13:39.648098932Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "741676766661572": {
+				"ID":          741676766661572,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1300111451217282,
+				"StableID":   "n39Tvwip9B11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:d5b9e890da91e9025eef6dde567da82cba826ecdeec9bd9c4b60de435d7f5438",
+				"KeyExpiry":  "2026-11-08T22:13:39Z",
+				"DiscoKey":   "discokey:de9879950292f3742f71c7458087fa72ccc20b30cce7e3f8610e8c52899ea01e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39568",
+					"10.65.0.27:39568",
+					"172.17.0.1:39568",
+					"172.18.0.1:39568",
+					"172.19.0.1:39568"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 53165},
+					{"Proto": "peerapi6", "Port": 53165},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:13:39.102386131Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d5b9e890da91e9025eef6dde567da82cba826ecdeec9bd9c4b60de435d7f5438",
+			"MachineKey": "mkey:184164e15020928b77eb9e1cf949d3c7d73e661996861b8c5e937e3e7f696011",
+			"Peers": [{
+				"ID":         7719163547601196,
+				"StableID":   "nFQjfYL2H321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f5ffa2b18c48294539836834475da4a03c873b1c1d5bddc7bf1971edefc9c158",
+				"DiscoKey":   "discokey:2dc89d3ad19c3380ace297c9f17670919f8d5cb5555296923333b88ee62eb30f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53049",
+					"10.65.0.27:53049",
+					"172.17.0.1:53049",
+					"172.18.0.1:53049",
+					"172.19.0.1:53049"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:13:32.134599243Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4646875696721316,
+				"StableID":   "n7AnqbYaHd11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86b0877ff0aafd24fa5b582d6e701c1de0d7f4fd0b626778f6780544f21da65e",
+				"DiscoKey":   "discokey:2a6110ce7830c1c2b789df7eb634706f12b52f4f6b0d13ef147a029da158b12d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45390",
+					"10.65.0.27:45390",
+					"172.17.0.1:45390",
+					"172.18.0.1:45390",
+					"172.19.0.1:45390"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:13:32.630513321Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6398465701021322,
+				"StableID":   "n3D1Vxqsxr11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:868b93b2ba5c5f7183276dc5f388a803d58d66477a5705ec56f687d73b62330a",
+				"DiscoKey":   "discokey:6dd5d182ac34cb3b9757c4842b4f096ed8eaa13f6b1e31eaf31bcd65b86b442a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35363",
+					"10.65.0.27:35363",
+					"172.17.0.1:35363",
+					"172.18.0.1:35363",
+					"172.19.0.1:35363"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:13:33.161639478Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5561987148277355,
+				"StableID":   "n2aTAKy2Sk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd7cd9487031017b6feaff009927c7ef85e13b93da2fc9c83a8467b0c59fd903",
+				"DiscoKey":   "discokey:3d6e788e89c04c82ae84234e752591774a22d25a34b2614b9463840083e08325",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51065",
+					"10.65.0.27:51065",
+					"172.17.0.1:51065",
+					"172.18.0.1:51065",
+					"172.19.0.1:51065"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:13:33.70769115Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3489551594547578,
+				"StableID":   "nR881zbRFU11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d2be220bd8a766dca167dc8df5cb73d494fc84f8d7ca8e85b846495173463153",
+				"DiscoKey":   "discokey:eba9b59d70752303cbe5d089e02167c5bd30faf105bc11ed270ada16979dcb35",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38335",
+					"10.65.0.27:38335",
+					"172.17.0.1:38335",
+					"172.18.0.1:38335",
+					"172.19.0.1:38335"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:13:34.253105915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8449658380066409,
+				"StableID":   "nnXwYTCsy821CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c36e6e2429500358bc51a8b42991510ce45a8da109207042b0142c4608d0b956",
+				"DiscoKey":   "discokey:dcdfbe417b769f984fb9b0a400cf3b125341b1d18301bb37a4a4ce0a4a68ef29",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39301",
+					"10.65.0.27:39301",
+					"172.17.0.1:39301",
+					"172.18.0.1:39301",
+					"172.19.0.1:39301"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:13:34.789711074Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7724333060802280,
+				"StableID":   "nyw8rc8NK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d04b23e7f941f7c689105a64f5c86c54b9b0d01c6aa4f634759ad083765e144",
+				"DiscoKey":   "discokey:2db32744ad75a83ac7bcde79e4c61bf9437a1656064d2a3ea3ef81161ebd217a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41984",
+					"10.65.0.27:41984",
+					"172.17.0.1:41984",
+					"172.18.0.1:41984",
+					"172.19.0.1:41984"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:13:35.324943716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3944579690127648,
+				"StableID":   "nFJ1eLRWoX11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b1b7b37df4b029adb5d24a39575956113c2b71a8c8a896646568062d0b5f7d3c",
+				"DiscoKey":   "discokey:be91faf33fbce07cd8787675cbfbe994e55118cb695991ae0975d393b1dbb03a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50093",
+					"10.65.0.27:50093",
+					"172.17.0.1:50093",
+					"172.18.0.1:50093",
+					"172.19.0.1:50093"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:13:35.859431146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         741676766661572,
+				"StableID":   "nHyn7Hbun611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a9c112e23c4a6311d26b3b1db8e2b16cec3c9288148edff73a2f15e3ebd36c01",
+				"DiscoKey":   "discokey:1550299eb28ac5bf790ef2ce4ff535bfbbb2ebcfd2540143bc64cd5f99dd9129",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34739",
+					"10.65.0.27:34739",
+					"172.17.0.1:34739",
+					"172.18.0.1:34739",
+					"172.19.0.1:34739"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:13:36.413972509Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1298541221208280,
+				"StableID":   "nMTD5cU79B11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7bda4ed3796d68606da6a365a62d2d75ac7c595467ac200640149cb413004277",
+				"DiscoKey":   "discokey:44be1862176824dab69a0f87461b30f6ab064688ca6dafa48897946e93a39b03",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55724",
+					"10.65.0.27:55724",
+					"172.17.0.1:55724",
+					"172.18.0.1:55724",
+					"172.19.0.1:55724"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T22:13:36.94891703Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1545753784186232,
+				"StableID":   "njSxiBL55D11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21922ff69734b12acdc916c2e38df8557ba8887806cc9b6fb595fb95b2fb9d0e",
+				"DiscoKey":   "discokey:3823dd4fda6ff4bb7931549533e22926778642bd4cdb8d9eb8a3e1def8e49571",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48404",
+					"10.65.0.27:48404",
+					"172.17.0.1:48404",
+					"172.18.0.1:48404",
+					"172.19.0.1:48404"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:13:37.487919248Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6753705650493008,
+				"StableID":   "n7AdMvPmju11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:19bb2883aa1f4fabdf7aef206ed1bdffe1606305deb6bfa732daa619f3708372",
+				"DiscoKey":   "discokey:9cb0fc99d2fe1a7b14bd9eafecb426cd24b2137a9d53a17e23973cc294f51d33",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44043",
+					"10.65.0.27:44043",
+					"172.17.0.1:44043",
+					"172.18.0.1:44043",
+					"172.19.0.1:44043"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:13:38.033328092Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2505133883124715,
+				"StableID":   "nG9npucaZL11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:4d64d19bad71f8f4bbde115225dbd8d8e5627a055263da7aca493a47488a3370",
+				"KeyExpiry":  "2026-11-08T22:13:38Z",
+				"DiscoKey":   "discokey:7df5455bda8a26723b68f0e8550d83fb8c4726a81281332b07ec38b4488a460c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44065",
+					"10.65.0.27:44065",
+					"172.17.0.1:44065",
+					"172.18.0.1:44065",
+					"172.19.0.1:44065"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:13:38.578940395Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4100897524667226,
+				"StableID":   "nqLgPCdJ2Z11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fc0e86e8745c8d6c3b38356f2c7775f7abdb820e5459fa1d57a4e274ac8c926b",
+				"KeyExpiry":  "2026-11-08T22:13:39Z",
+				"DiscoKey":   "discokey:2c1d1ce45c6235ae1acaaaadbe665af846cfb1b3bb2f1245edc5a661d1fd832c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60848",
+					"10.65.0.27:60848",
+					"172.17.0.1:60848",
+					"172.18.0.1:60848",
+					"172.19.0.1:60848"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:13:39.648098932Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1298541221208280,
+				"StableID":   "nMTD5cU79B11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1298541221208280,
+				"Key":        "nodekey:7bda4ed3796d68606da6a365a62d2d75ac7c595467ac200640149cb413004277",
+				"DiscoKey":   "discokey:44be1862176824dab69a0f87461b30f6ab064688ca6dafa48897946e93a39b03",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55724",
+					"10.65.0.27:55724",
+					"172.17.0.1:55724",
+					"172.18.0.1:55724",
+					"172.19.0.1:55724"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T22:13:36.94891703Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7bda4ed3796d68606da6a365a62d2d75ac7c595467ac200640149cb413004277",
+			"MachineKey": "mkey:c855d06147e2877596e02bc43d780235c3bd3e135a807bd617b062667d4d027c",
+			"Peers": [{
+				"ID":         7719163547601196,
+				"StableID":   "nFQjfYL2H321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f5ffa2b18c48294539836834475da4a03c873b1c1d5bddc7bf1971edefc9c158",
+				"DiscoKey":   "discokey:2dc89d3ad19c3380ace297c9f17670919f8d5cb5555296923333b88ee62eb30f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53049",
+					"10.65.0.27:53049",
+					"172.17.0.1:53049",
+					"172.18.0.1:53049",
+					"172.19.0.1:53049"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T22:13:32.134599243Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4646875696721316,
+				"StableID":   "n7AnqbYaHd11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86b0877ff0aafd24fa5b582d6e701c1de0d7f4fd0b626778f6780544f21da65e",
+				"DiscoKey":   "discokey:2a6110ce7830c1c2b789df7eb634706f12b52f4f6b0d13ef147a029da158b12d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45390",
+					"10.65.0.27:45390",
+					"172.17.0.1:45390",
+					"172.18.0.1:45390",
+					"172.19.0.1:45390"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T22:13:32.630513321Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6398465701021322,
+				"StableID":   "n3D1Vxqsxr11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:868b93b2ba5c5f7183276dc5f388a803d58d66477a5705ec56f687d73b62330a",
+				"DiscoKey":   "discokey:6dd5d182ac34cb3b9757c4842b4f096ed8eaa13f6b1e31eaf31bcd65b86b442a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35363",
+					"10.65.0.27:35363",
+					"172.17.0.1:35363",
+					"172.18.0.1:35363",
+					"172.19.0.1:35363"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T22:13:33.161639478Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5561987148277355,
+				"StableID":   "n2aTAKy2Sk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd7cd9487031017b6feaff009927c7ef85e13b93da2fc9c83a8467b0c59fd903",
+				"DiscoKey":   "discokey:3d6e788e89c04c82ae84234e752591774a22d25a34b2614b9463840083e08325",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51065",
+					"10.65.0.27:51065",
+					"172.17.0.1:51065",
+					"172.18.0.1:51065",
+					"172.19.0.1:51065"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T22:13:33.70769115Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3489551594547578,
+				"StableID":   "nR881zbRFU11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d2be220bd8a766dca167dc8df5cb73d494fc84f8d7ca8e85b846495173463153",
+				"DiscoKey":   "discokey:eba9b59d70752303cbe5d089e02167c5bd30faf105bc11ed270ada16979dcb35",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38335",
+					"10.65.0.27:38335",
+					"172.17.0.1:38335",
+					"172.18.0.1:38335",
+					"172.19.0.1:38335"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T22:13:34.253105915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8449658380066409,
+				"StableID":   "nnXwYTCsy821CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c36e6e2429500358bc51a8b42991510ce45a8da109207042b0142c4608d0b956",
+				"DiscoKey":   "discokey:dcdfbe417b769f984fb9b0a400cf3b125341b1d18301bb37a4a4ce0a4a68ef29",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39301",
+					"10.65.0.27:39301",
+					"172.17.0.1:39301",
+					"172.18.0.1:39301",
+					"172.19.0.1:39301"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T22:13:34.789711074Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7724333060802280,
+				"StableID":   "nyw8rc8NK321CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d04b23e7f941f7c689105a64f5c86c54b9b0d01c6aa4f634759ad083765e144",
+				"DiscoKey":   "discokey:2db32744ad75a83ac7bcde79e4c61bf9437a1656064d2a3ea3ef81161ebd217a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41984",
+					"10.65.0.27:41984",
+					"172.17.0.1:41984",
+					"172.18.0.1:41984",
+					"172.19.0.1:41984"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T22:13:35.324943716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3944579690127648,
+				"StableID":   "nFJ1eLRWoX11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b1b7b37df4b029adb5d24a39575956113c2b71a8c8a896646568062d0b5f7d3c",
+				"DiscoKey":   "discokey:be91faf33fbce07cd8787675cbfbe994e55118cb695991ae0975d393b1dbb03a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50093",
+					"10.65.0.27:50093",
+					"172.17.0.1:50093",
+					"172.18.0.1:50093",
+					"172.19.0.1:50093"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T22:13:35.859431146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         741676766661572,
+				"StableID":   "nHyn7Hbun611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a9c112e23c4a6311d26b3b1db8e2b16cec3c9288148edff73a2f15e3ebd36c01",
+				"DiscoKey":   "discokey:1550299eb28ac5bf790ef2ce4ff535bfbbb2ebcfd2540143bc64cd5f99dd9129",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34739",
+					"10.65.0.27:34739",
+					"172.17.0.1:34739",
+					"172.18.0.1:34739",
+					"172.19.0.1:34739"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T22:13:36.413972509Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1545753784186232,
+				"StableID":   "njSxiBL55D11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:21922ff69734b12acdc916c2e38df8557ba8887806cc9b6fb595fb95b2fb9d0e",
+				"DiscoKey":   "discokey:3823dd4fda6ff4bb7931549533e22926778642bd4cdb8d9eb8a3e1def8e49571",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48404",
+					"10.65.0.27:48404",
+					"172.17.0.1:48404",
+					"172.18.0.1:48404",
+					"172.19.0.1:48404"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T22:13:37.487919248Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6753705650493008,
+				"StableID":   "n7AdMvPmju11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:19bb2883aa1f4fabdf7aef206ed1bdffe1606305deb6bfa732daa619f3708372",
+				"DiscoKey":   "discokey:9cb0fc99d2fe1a7b14bd9eafecb426cd24b2137a9d53a17e23973cc294f51d33",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44043",
+					"10.65.0.27:44043",
+					"172.17.0.1:44043",
+					"172.18.0.1:44043",
+					"172.19.0.1:44043"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T22:13:38.033328092Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2505133883124715,
+				"StableID":   "nG9npucaZL11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:4d64d19bad71f8f4bbde115225dbd8d8e5627a055263da7aca493a47488a3370",
+				"KeyExpiry":  "2026-11-08T22:13:38Z",
+				"DiscoKey":   "discokey:7df5455bda8a26723b68f0e8550d83fb8c4726a81281332b07ec38b4488a460c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44065",
+					"10.65.0.27:44065",
+					"172.17.0.1:44065",
+					"172.18.0.1:44065",
+					"172.19.0.1:44065"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T22:13:38.578940395Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1300111451217282,
+				"StableID":   "n39Tvwip9B11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:d5b9e890da91e9025eef6dde567da82cba826ecdeec9bd9c4b60de435d7f5438",
+				"KeyExpiry":  "2026-11-08T22:13:39Z",
+				"DiscoKey":   "discokey:de9879950292f3742f71c7458087fa72ccc20b30cce7e3f8610e8c52899ea01e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39568",
+					"10.65.0.27:39568",
+					"172.17.0.1:39568",
+					"172.18.0.1:39568",
+					"172.19.0.1:39568"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 53165},
+					{"Proto": "peerapi6", "Port": 53165}
+				]},
+				"Created":              "2026-05-12T22:13:39.102386131Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4100897524667226,
+				"StableID":   "nqLgPCdJ2Z11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fc0e86e8745c8d6c3b38356f2c7775f7abdb820e5459fa1d57a4e274ac8c926b",
+				"KeyExpiry":  "2026-11-08T22:13:39Z",
+				"DiscoKey":   "discokey:2c1d1ce45c6235ae1acaaaadbe665af846cfb1b3bb2f1245edc5a661d1fd832c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60848",
+					"10.65.0.27:60848",
+					"172.17.0.1:60848",
+					"172.18.0.1:60848",
+					"172.19.0.1:60848"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T22:13:39.648098932Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1298541221208280": {
+				"ID":          1298541221208280,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-users-mixed-valid-empty.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-users-mixed-valid-empty.hujson
@@ -1,0 +1,20081 @@
+// ssh-malformed-users-mixed-valid-empty
+//
+// ssh users with mixed valid and empty
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-13T07:31:59Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-malformed-users-mixed-valid-empty",
+	"description":    "ssh users with mixed valid and empty",
+	"category":       "ssh",
+	"captured_at":    "2026-05-13T07:31:59.601217393Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "user \"\" is not valid"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                        \n  \n                                                                      \n                                                                      \n            \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh users with mixed valid and empty\",\n\t\"id\":          \"ssh-malformed-users-mixed-valid-empty\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"autogroup:member\"],\n\t\t\"users\":  [\"root\", \"\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-edge/ssh-malformed-users-mixed-valid-empty.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["autogroup:member"],
+				"users":  ["root", ""]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4277392511586413,
+				"StableID":   "ntQN1CrEQa11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       4277392511586413,
+				"Key":        "nodekey:8f43cafcc0263d4fe5fd1f00b161b34f330d2c960f19c0424a1110f6d8b3ad79",
+				"DiscoKey":   "discokey:7d91e866dc1fe26dca650c6a6eb701af91b0bb7d5de7eb58b276835ef4892301",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:32799",
+					"10.65.0.27:32799",
+					"172.17.0.1:32799",
+					"172.18.0.1:32799",
+					"172.19.0.1:32799"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:32:08.153685446Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8f43cafcc0263d4fe5fd1f00b161b34f330d2c960f19c0424a1110f6d8b3ad79",
+			"MachineKey": "mkey:70db195bdf3cccc36ce60793c6478701fbc2eecbcf44877eb670195886471b16",
+			"Peers": [{
+				"ID":         4744643513638242,
+				"StableID":   "nByq2ujr3e11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ffc63b0b4e6df3afa51bd7f23e730c1c1602c86ad9bd2ecd623163d95621936",
+				"DiscoKey":   "discokey:44cdf0dd5debdcb0493de5054a6eaa110d1dcb750c8ad80b2368659e7b056469",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50660",
+					"10.65.0.27:50660",
+					"172.17.0.1:50660",
+					"172.18.0.1:50660",
+					"172.19.0.1:50660"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:32:02.242387317Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3384024868833209,
+				"StableID":   "nGAPcWbdRT11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8bc67a918aef9757ec1c2e8cbabf91973eb4d22f720c3bd881328cea69db54e",
+				"DiscoKey":   "discokey:5ac2b886460f769df10af7db3ca534ad28bf8c87060cb7aa594e51c03b871b44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51247",
+					"10.65.0.27:51247",
+					"172.17.0.1:51247",
+					"172.18.0.1:51247",
+					"172.19.0.1:51247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:32:02.762225978Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4104100983045156,
+				"StableID":   "ndHD3smk3Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c1f230674780923dec20f5b5defac12f78b113d4c89e2b77f504b428651bf25",
+				"DiscoKey":   "discokey:0386401c3bc77d5202103f928dde326d7c9cf11a3698fc33557df03f1577a94b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60676",
+					"10.65.0.27:60676",
+					"172.17.0.1:60676",
+					"172.18.0.1:60676",
+					"172.19.0.1:60676"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:32:03.29320231Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2053553102717197,
+				"StableID":   "ni7FdkM43H11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:462d530888e4e8e815ae993eab1f79d1d4c25aebf9d5750e6190121c5c38091d",
+				"DiscoKey":   "discokey:ca86b8d2271ebd4e08bc13fbeb823ade08e37df6bbd91f45b56d9982c30fb16a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49676",
+					"10.65.0.27:49676",
+					"172.17.0.1:49676",
+					"172.18.0.1:49676",
+					"172.19.0.1:49676"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:32:03.831192155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4485305050041784,
+				"StableID":   "nb8s4mMQ2c11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93c4a5bba11e6b6f85ece1cd6a8d9bafeba6497ddc12dc92ee64e1f0ca86e672",
+				"DiscoKey":   "discokey:684efa3f278e4aa7b5154dc47ccbc72353254cd5ae16601f73e50a18baf35d2d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33435",
+					"10.65.0.27:33435",
+					"172.17.0.1:33435",
+					"172.18.0.1:33435",
+					"172.19.0.1:33435"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:32:04.366260931Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6405819003809912,
+				"StableID":   "nw2sfA1D2s11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1ca3dbccc144b3c054256ff111274ba6fbd99ccccb1c38acb280dbd510f6595b",
+				"DiscoKey":   "discokey:26064138d413eb16852c9e78aeadaf1468c770c741a35049ce2d39676cfeed34",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40094",
+					"10.65.0.27:40094",
+					"172.17.0.1:40094",
+					"172.18.0.1:40094",
+					"172.19.0.1:40094"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:32:04.910825058Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7945506545729529,
+				"StableID":   "nWKZL4zX3521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b49d04dff8e09c0628519156c0f58abe66760419609302611c82bc6822b2dc79",
+				"DiscoKey":   "discokey:96d052db8c7e233697a52745fc029c314b692a76d229d4fdcdbd16c41f1bda19",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47320",
+					"10.65.0.27:47320",
+					"172.17.0.1:47320",
+					"172.18.0.1:47320",
+					"172.19.0.1:47320"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:32:05.446654167Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6773448591800793,
+				"StableID":   "nWDQUW1itu11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6e2453e3fbd0292765e5e97dc33dd066f25969f442fd1d9b3c4080e82d9c455",
+				"DiscoKey":   "discokey:19e8f74c660a72cba783b6ce69655c90e90bd2769161af2a08816e02a2a1751d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47027",
+					"10.65.0.27:47027",
+					"172.17.0.1:47027",
+					"172.18.0.1:47027",
+					"172.19.0.1:47027"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:32:05.987829594Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3076678267400490,
+				"StableID":   "nP1Eu18S2R11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec9995bd7505448783656e89f5de7f189a381aaf5b4b130626174ecb91863f0d",
+				"DiscoKey":   "discokey:79cb3eb1794766782d2828864dfb1ecade0bec0ba4fb5dd542f03f538a39d44f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52587",
+					"10.65.0.27:52587",
+					"172.17.0.1:52587",
+					"172.18.0.1:52587",
+					"172.19.0.1:52587"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:32:06.535404499Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4852696183438427,
+				"StableID":   "nc5HTo6ote11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c41cd99ab18b45734a4bd15e6d39bf220698a9f726f47f5c93d48011c603fe50",
+				"DiscoKey":   "discokey:4b3b0a842bcc9b1bc8b2d1225da72f91cea42207e3eb2954d594721472e0153a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54325",
+					"10.65.0.27:54325",
+					"172.17.0.1:54325",
+					"172.18.0.1:54325",
+					"172.19.0.1:54325"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:32:07.066875559Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5405486878286675,
+				"StableID":   "nLsQDWy9Dj11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdb4ec6888811dd3a458eee71e7e82b6ba57456247cea0286a0f52a3c6177443",
+				"DiscoKey":   "discokey:d4231b2fd36ac8a22ad0af9e8e95f034a36231b6307ec8dc7678e6d786ab4f36",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60962",
+					"10.65.0.27:60962",
+					"172.17.0.1:60962",
+					"172.18.0.1:60962",
+					"172.19.0.1:60962"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:32:07.614061815Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6683173110387055,
+				"StableID":   "nGTCKFdpBu11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d60fd719e033c223cff1df535ebc55d2ffe15e59fc3a0382ebb031534d2e085d",
+				"KeyExpiry":  "2026-11-09T07:32:08Z",
+				"DiscoKey":   "discokey:28b724f2b015833c37572d87ea899b0bcd73343f6de96a79f40a15f374423d39",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52317",
+					"10.65.0.27:52317",
+					"172.17.0.1:52317",
+					"172.18.0.1:52317",
+					"172.19.0.1:52317"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:32:08.704629899Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2795559571658972,
+				"StableID":   "nTLQQMc7qN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:94fc225713a77b24286773baa68596b86cb37df40a7c8c052b340a5f5a41e543",
+				"KeyExpiry":  "2026-11-09T07:32:09Z",
+				"DiscoKey":   "discokey:bb93b45b3b208bc98fc8d619b60bd255990659cbc97f4149b792121589977b3b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35279",
+					"10.65.0.27:35279",
+					"172.17.0.1:35279",
+					"172.18.0.1:35279",
+					"172.19.0.1:35279"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:32:09.23308551Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8827946835332669,
+				"StableID":   "nnKNxECCwB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ff47092463a9d39dc348b889d4782dde5685606d166e0abbe3c63f60f3889473",
+				"KeyExpiry":  "2026-11-09T07:32:09Z",
+				"DiscoKey":   "discokey:38782afda7639fb498262e15fe0074722246a2c6dd317657b4a54a541a746123",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60290",
+					"10.65.0.27:60290",
+					"172.17.0.1:60290",
+					"172.18.0.1:60290",
+					"172.19.0.1:60290"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:32:09.781574364Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4277392511586413": {
+				"ID":          4277392511586413,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6405819003809912,
+				"StableID":   "nw2sfA1D2s11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       6405819003809912,
+				"Key":        "nodekey:1ca3dbccc144b3c054256ff111274ba6fbd99ccccb1c38acb280dbd510f6595b",
+				"DiscoKey":   "discokey:26064138d413eb16852c9e78aeadaf1468c770c741a35049ce2d39676cfeed34",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40094",
+					"10.65.0.27:40094",
+					"172.17.0.1:40094",
+					"172.18.0.1:40094",
+					"172.19.0.1:40094"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:32:04.910825058Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1ca3dbccc144b3c054256ff111274ba6fbd99ccccb1c38acb280dbd510f6595b",
+			"MachineKey": "mkey:afda2cf7f00446a689abe976fe3f35dfe090e0bf324b122809a7eb3fc7271b7e",
+			"Peers": [{
+				"ID":         4744643513638242,
+				"StableID":   "nByq2ujr3e11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ffc63b0b4e6df3afa51bd7f23e730c1c1602c86ad9bd2ecd623163d95621936",
+				"DiscoKey":   "discokey:44cdf0dd5debdcb0493de5054a6eaa110d1dcb750c8ad80b2368659e7b056469",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50660",
+					"10.65.0.27:50660",
+					"172.17.0.1:50660",
+					"172.18.0.1:50660",
+					"172.19.0.1:50660"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:32:02.242387317Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3384024868833209,
+				"StableID":   "nGAPcWbdRT11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8bc67a918aef9757ec1c2e8cbabf91973eb4d22f720c3bd881328cea69db54e",
+				"DiscoKey":   "discokey:5ac2b886460f769df10af7db3ca534ad28bf8c87060cb7aa594e51c03b871b44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51247",
+					"10.65.0.27:51247",
+					"172.17.0.1:51247",
+					"172.18.0.1:51247",
+					"172.19.0.1:51247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:32:02.762225978Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4104100983045156,
+				"StableID":   "ndHD3smk3Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c1f230674780923dec20f5b5defac12f78b113d4c89e2b77f504b428651bf25",
+				"DiscoKey":   "discokey:0386401c3bc77d5202103f928dde326d7c9cf11a3698fc33557df03f1577a94b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60676",
+					"10.65.0.27:60676",
+					"172.17.0.1:60676",
+					"172.18.0.1:60676",
+					"172.19.0.1:60676"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:32:03.29320231Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2053553102717197,
+				"StableID":   "ni7FdkM43H11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:462d530888e4e8e815ae993eab1f79d1d4c25aebf9d5750e6190121c5c38091d",
+				"DiscoKey":   "discokey:ca86b8d2271ebd4e08bc13fbeb823ade08e37df6bbd91f45b56d9982c30fb16a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49676",
+					"10.65.0.27:49676",
+					"172.17.0.1:49676",
+					"172.18.0.1:49676",
+					"172.19.0.1:49676"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:32:03.831192155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4485305050041784,
+				"StableID":   "nb8s4mMQ2c11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93c4a5bba11e6b6f85ece1cd6a8d9bafeba6497ddc12dc92ee64e1f0ca86e672",
+				"DiscoKey":   "discokey:684efa3f278e4aa7b5154dc47ccbc72353254cd5ae16601f73e50a18baf35d2d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33435",
+					"10.65.0.27:33435",
+					"172.17.0.1:33435",
+					"172.18.0.1:33435",
+					"172.19.0.1:33435"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:32:04.366260931Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7945506545729529,
+				"StableID":   "nWKZL4zX3521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b49d04dff8e09c0628519156c0f58abe66760419609302611c82bc6822b2dc79",
+				"DiscoKey":   "discokey:96d052db8c7e233697a52745fc029c314b692a76d229d4fdcdbd16c41f1bda19",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47320",
+					"10.65.0.27:47320",
+					"172.17.0.1:47320",
+					"172.18.0.1:47320",
+					"172.19.0.1:47320"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:32:05.446654167Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6773448591800793,
+				"StableID":   "nWDQUW1itu11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6e2453e3fbd0292765e5e97dc33dd066f25969f442fd1d9b3c4080e82d9c455",
+				"DiscoKey":   "discokey:19e8f74c660a72cba783b6ce69655c90e90bd2769161af2a08816e02a2a1751d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47027",
+					"10.65.0.27:47027",
+					"172.17.0.1:47027",
+					"172.18.0.1:47027",
+					"172.19.0.1:47027"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:32:05.987829594Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3076678267400490,
+				"StableID":   "nP1Eu18S2R11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec9995bd7505448783656e89f5de7f189a381aaf5b4b130626174ecb91863f0d",
+				"DiscoKey":   "discokey:79cb3eb1794766782d2828864dfb1ecade0bec0ba4fb5dd542f03f538a39d44f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52587",
+					"10.65.0.27:52587",
+					"172.17.0.1:52587",
+					"172.18.0.1:52587",
+					"172.19.0.1:52587"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:32:06.535404499Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4852696183438427,
+				"StableID":   "nc5HTo6ote11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c41cd99ab18b45734a4bd15e6d39bf220698a9f726f47f5c93d48011c603fe50",
+				"DiscoKey":   "discokey:4b3b0a842bcc9b1bc8b2d1225da72f91cea42207e3eb2954d594721472e0153a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54325",
+					"10.65.0.27:54325",
+					"172.17.0.1:54325",
+					"172.18.0.1:54325",
+					"172.19.0.1:54325"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:32:07.066875559Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5405486878286675,
+				"StableID":   "nLsQDWy9Dj11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdb4ec6888811dd3a458eee71e7e82b6ba57456247cea0286a0f52a3c6177443",
+				"DiscoKey":   "discokey:d4231b2fd36ac8a22ad0af9e8e95f034a36231b6307ec8dc7678e6d786ab4f36",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60962",
+					"10.65.0.27:60962",
+					"172.17.0.1:60962",
+					"172.18.0.1:60962",
+					"172.19.0.1:60962"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:32:07.614061815Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4277392511586413,
+				"StableID":   "ntQN1CrEQa11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f43cafcc0263d4fe5fd1f00b161b34f330d2c960f19c0424a1110f6d8b3ad79",
+				"DiscoKey":   "discokey:7d91e866dc1fe26dca650c6a6eb701af91b0bb7d5de7eb58b276835ef4892301",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:32799",
+					"10.65.0.27:32799",
+					"172.17.0.1:32799",
+					"172.18.0.1:32799",
+					"172.19.0.1:32799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:32:08.153685446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6683173110387055,
+				"StableID":   "nGTCKFdpBu11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d60fd719e033c223cff1df535ebc55d2ffe15e59fc3a0382ebb031534d2e085d",
+				"KeyExpiry":  "2026-11-09T07:32:08Z",
+				"DiscoKey":   "discokey:28b724f2b015833c37572d87ea899b0bcd73343f6de96a79f40a15f374423d39",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52317",
+					"10.65.0.27:52317",
+					"172.17.0.1:52317",
+					"172.18.0.1:52317",
+					"172.19.0.1:52317"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:32:08.704629899Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2795559571658972,
+				"StableID":   "nTLQQMc7qN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:94fc225713a77b24286773baa68596b86cb37df40a7c8c052b340a5f5a41e543",
+				"KeyExpiry":  "2026-11-09T07:32:09Z",
+				"DiscoKey":   "discokey:bb93b45b3b208bc98fc8d619b60bd255990659cbc97f4149b792121589977b3b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35279",
+					"10.65.0.27:35279",
+					"172.17.0.1:35279",
+					"172.18.0.1:35279",
+					"172.19.0.1:35279"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:32:09.23308551Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8827946835332669,
+				"StableID":   "nnKNxECCwB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ff47092463a9d39dc348b889d4782dde5685606d166e0abbe3c63f60f3889473",
+				"KeyExpiry":  "2026-11-09T07:32:09Z",
+				"DiscoKey":   "discokey:38782afda7639fb498262e15fe0074722246a2c6dd317657b4a54a541a746123",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60290",
+					"10.65.0.27:60290",
+					"172.17.0.1:60290",
+					"172.18.0.1:60290",
+					"172.19.0.1:60290"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:32:09.781574364Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6405819003809912": {
+				"ID":          6405819003809912,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8827946835332669,
+				"StableID":   "nnKNxECCwB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ff47092463a9d39dc348b889d4782dde5685606d166e0abbe3c63f60f3889473",
+				"KeyExpiry":  "2026-11-09T07:32:09Z",
+				"DiscoKey":   "discokey:38782afda7639fb498262e15fe0074722246a2c6dd317657b4a54a541a746123",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60290",
+					"10.65.0.27:60290",
+					"172.17.0.1:60290",
+					"172.18.0.1:60290",
+					"172.19.0.1:60290"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:32:09.781574364Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ff47092463a9d39dc348b889d4782dde5685606d166e0abbe3c63f60f3889473",
+			"MachineKey": "mkey:b97f74f657536e26346bdee7bb733f3199ae684c22c4fd4b158ab0ea35269133",
+			"Peers": [{
+				"ID":         4744643513638242,
+				"StableID":   "nByq2ujr3e11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ffc63b0b4e6df3afa51bd7f23e730c1c1602c86ad9bd2ecd623163d95621936",
+				"DiscoKey":   "discokey:44cdf0dd5debdcb0493de5054a6eaa110d1dcb750c8ad80b2368659e7b056469",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50660",
+					"10.65.0.27:50660",
+					"172.17.0.1:50660",
+					"172.18.0.1:50660",
+					"172.19.0.1:50660"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:32:02.242387317Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3384024868833209,
+				"StableID":   "nGAPcWbdRT11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8bc67a918aef9757ec1c2e8cbabf91973eb4d22f720c3bd881328cea69db54e",
+				"DiscoKey":   "discokey:5ac2b886460f769df10af7db3ca534ad28bf8c87060cb7aa594e51c03b871b44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51247",
+					"10.65.0.27:51247",
+					"172.17.0.1:51247",
+					"172.18.0.1:51247",
+					"172.19.0.1:51247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:32:02.762225978Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4104100983045156,
+				"StableID":   "ndHD3smk3Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c1f230674780923dec20f5b5defac12f78b113d4c89e2b77f504b428651bf25",
+				"DiscoKey":   "discokey:0386401c3bc77d5202103f928dde326d7c9cf11a3698fc33557df03f1577a94b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60676",
+					"10.65.0.27:60676",
+					"172.17.0.1:60676",
+					"172.18.0.1:60676",
+					"172.19.0.1:60676"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:32:03.29320231Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2053553102717197,
+				"StableID":   "ni7FdkM43H11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:462d530888e4e8e815ae993eab1f79d1d4c25aebf9d5750e6190121c5c38091d",
+				"DiscoKey":   "discokey:ca86b8d2271ebd4e08bc13fbeb823ade08e37df6bbd91f45b56d9982c30fb16a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49676",
+					"10.65.0.27:49676",
+					"172.17.0.1:49676",
+					"172.18.0.1:49676",
+					"172.19.0.1:49676"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:32:03.831192155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4485305050041784,
+				"StableID":   "nb8s4mMQ2c11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93c4a5bba11e6b6f85ece1cd6a8d9bafeba6497ddc12dc92ee64e1f0ca86e672",
+				"DiscoKey":   "discokey:684efa3f278e4aa7b5154dc47ccbc72353254cd5ae16601f73e50a18baf35d2d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33435",
+					"10.65.0.27:33435",
+					"172.17.0.1:33435",
+					"172.18.0.1:33435",
+					"172.19.0.1:33435"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:32:04.366260931Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6405819003809912,
+				"StableID":   "nw2sfA1D2s11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1ca3dbccc144b3c054256ff111274ba6fbd99ccccb1c38acb280dbd510f6595b",
+				"DiscoKey":   "discokey:26064138d413eb16852c9e78aeadaf1468c770c741a35049ce2d39676cfeed34",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40094",
+					"10.65.0.27:40094",
+					"172.17.0.1:40094",
+					"172.18.0.1:40094",
+					"172.19.0.1:40094"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:32:04.910825058Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7945506545729529,
+				"StableID":   "nWKZL4zX3521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b49d04dff8e09c0628519156c0f58abe66760419609302611c82bc6822b2dc79",
+				"DiscoKey":   "discokey:96d052db8c7e233697a52745fc029c314b692a76d229d4fdcdbd16c41f1bda19",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47320",
+					"10.65.0.27:47320",
+					"172.17.0.1:47320",
+					"172.18.0.1:47320",
+					"172.19.0.1:47320"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:32:05.446654167Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6773448591800793,
+				"StableID":   "nWDQUW1itu11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6e2453e3fbd0292765e5e97dc33dd066f25969f442fd1d9b3c4080e82d9c455",
+				"DiscoKey":   "discokey:19e8f74c660a72cba783b6ce69655c90e90bd2769161af2a08816e02a2a1751d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47027",
+					"10.65.0.27:47027",
+					"172.17.0.1:47027",
+					"172.18.0.1:47027",
+					"172.19.0.1:47027"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:32:05.987829594Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3076678267400490,
+				"StableID":   "nP1Eu18S2R11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec9995bd7505448783656e89f5de7f189a381aaf5b4b130626174ecb91863f0d",
+				"DiscoKey":   "discokey:79cb3eb1794766782d2828864dfb1ecade0bec0ba4fb5dd542f03f538a39d44f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52587",
+					"10.65.0.27:52587",
+					"172.17.0.1:52587",
+					"172.18.0.1:52587",
+					"172.19.0.1:52587"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:32:06.535404499Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4852696183438427,
+				"StableID":   "nc5HTo6ote11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c41cd99ab18b45734a4bd15e6d39bf220698a9f726f47f5c93d48011c603fe50",
+				"DiscoKey":   "discokey:4b3b0a842bcc9b1bc8b2d1225da72f91cea42207e3eb2954d594721472e0153a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54325",
+					"10.65.0.27:54325",
+					"172.17.0.1:54325",
+					"172.18.0.1:54325",
+					"172.19.0.1:54325"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:32:07.066875559Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5405486878286675,
+				"StableID":   "nLsQDWy9Dj11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdb4ec6888811dd3a458eee71e7e82b6ba57456247cea0286a0f52a3c6177443",
+				"DiscoKey":   "discokey:d4231b2fd36ac8a22ad0af9e8e95f034a36231b6307ec8dc7678e6d786ab4f36",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60962",
+					"10.65.0.27:60962",
+					"172.17.0.1:60962",
+					"172.18.0.1:60962",
+					"172.19.0.1:60962"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:32:07.614061815Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4277392511586413,
+				"StableID":   "ntQN1CrEQa11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f43cafcc0263d4fe5fd1f00b161b34f330d2c960f19c0424a1110f6d8b3ad79",
+				"DiscoKey":   "discokey:7d91e866dc1fe26dca650c6a6eb701af91b0bb7d5de7eb58b276835ef4892301",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:32799",
+					"10.65.0.27:32799",
+					"172.17.0.1:32799",
+					"172.18.0.1:32799",
+					"172.19.0.1:32799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:32:08.153685446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6683173110387055,
+				"StableID":   "nGTCKFdpBu11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d60fd719e033c223cff1df535ebc55d2ffe15e59fc3a0382ebb031534d2e085d",
+				"KeyExpiry":  "2026-11-09T07:32:08Z",
+				"DiscoKey":   "discokey:28b724f2b015833c37572d87ea899b0bcd73343f6de96a79f40a15f374423d39",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52317",
+					"10.65.0.27:52317",
+					"172.17.0.1:52317",
+					"172.18.0.1:52317",
+					"172.19.0.1:52317"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:32:08.704629899Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2795559571658972,
+				"StableID":   "nTLQQMc7qN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:94fc225713a77b24286773baa68596b86cb37df40a7c8c052b340a5f5a41e543",
+				"KeyExpiry":  "2026-11-09T07:32:09Z",
+				"DiscoKey":   "discokey:bb93b45b3b208bc98fc8d619b60bd255990659cbc97f4149b792121589977b3b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35279",
+					"10.65.0.27:35279",
+					"172.17.0.1:35279",
+					"172.18.0.1:35279",
+					"172.19.0.1:35279"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:32:09.23308551Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4104100983045156,
+				"StableID":   "ndHD3smk3Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       4104100983045156,
+				"Key":        "nodekey:8c1f230674780923dec20f5b5defac12f78b113d4c89e2b77f504b428651bf25",
+				"DiscoKey":   "discokey:0386401c3bc77d5202103f928dde326d7c9cf11a3698fc33557df03f1577a94b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60676",
+					"10.65.0.27:60676",
+					"172.17.0.1:60676",
+					"172.18.0.1:60676",
+					"172.19.0.1:60676"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:32:03.29320231Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8c1f230674780923dec20f5b5defac12f78b113d4c89e2b77f504b428651bf25",
+			"MachineKey": "mkey:24034f92ed634e56dd78d55beb457848c5e06dc5e5a788c9992c07537fabdc73",
+			"Peers": [{
+				"ID":         4744643513638242,
+				"StableID":   "nByq2ujr3e11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ffc63b0b4e6df3afa51bd7f23e730c1c1602c86ad9bd2ecd623163d95621936",
+				"DiscoKey":   "discokey:44cdf0dd5debdcb0493de5054a6eaa110d1dcb750c8ad80b2368659e7b056469",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50660",
+					"10.65.0.27:50660",
+					"172.17.0.1:50660",
+					"172.18.0.1:50660",
+					"172.19.0.1:50660"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:32:02.242387317Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3384024868833209,
+				"StableID":   "nGAPcWbdRT11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8bc67a918aef9757ec1c2e8cbabf91973eb4d22f720c3bd881328cea69db54e",
+				"DiscoKey":   "discokey:5ac2b886460f769df10af7db3ca534ad28bf8c87060cb7aa594e51c03b871b44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51247",
+					"10.65.0.27:51247",
+					"172.17.0.1:51247",
+					"172.18.0.1:51247",
+					"172.19.0.1:51247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:32:02.762225978Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2053553102717197,
+				"StableID":   "ni7FdkM43H11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:462d530888e4e8e815ae993eab1f79d1d4c25aebf9d5750e6190121c5c38091d",
+				"DiscoKey":   "discokey:ca86b8d2271ebd4e08bc13fbeb823ade08e37df6bbd91f45b56d9982c30fb16a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49676",
+					"10.65.0.27:49676",
+					"172.17.0.1:49676",
+					"172.18.0.1:49676",
+					"172.19.0.1:49676"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:32:03.831192155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4485305050041784,
+				"StableID":   "nb8s4mMQ2c11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93c4a5bba11e6b6f85ece1cd6a8d9bafeba6497ddc12dc92ee64e1f0ca86e672",
+				"DiscoKey":   "discokey:684efa3f278e4aa7b5154dc47ccbc72353254cd5ae16601f73e50a18baf35d2d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33435",
+					"10.65.0.27:33435",
+					"172.17.0.1:33435",
+					"172.18.0.1:33435",
+					"172.19.0.1:33435"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:32:04.366260931Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6405819003809912,
+				"StableID":   "nw2sfA1D2s11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1ca3dbccc144b3c054256ff111274ba6fbd99ccccb1c38acb280dbd510f6595b",
+				"DiscoKey":   "discokey:26064138d413eb16852c9e78aeadaf1468c770c741a35049ce2d39676cfeed34",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40094",
+					"10.65.0.27:40094",
+					"172.17.0.1:40094",
+					"172.18.0.1:40094",
+					"172.19.0.1:40094"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:32:04.910825058Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7945506545729529,
+				"StableID":   "nWKZL4zX3521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b49d04dff8e09c0628519156c0f58abe66760419609302611c82bc6822b2dc79",
+				"DiscoKey":   "discokey:96d052db8c7e233697a52745fc029c314b692a76d229d4fdcdbd16c41f1bda19",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47320",
+					"10.65.0.27:47320",
+					"172.17.0.1:47320",
+					"172.18.0.1:47320",
+					"172.19.0.1:47320"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:32:05.446654167Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6773448591800793,
+				"StableID":   "nWDQUW1itu11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6e2453e3fbd0292765e5e97dc33dd066f25969f442fd1d9b3c4080e82d9c455",
+				"DiscoKey":   "discokey:19e8f74c660a72cba783b6ce69655c90e90bd2769161af2a08816e02a2a1751d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47027",
+					"10.65.0.27:47027",
+					"172.17.0.1:47027",
+					"172.18.0.1:47027",
+					"172.19.0.1:47027"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:32:05.987829594Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3076678267400490,
+				"StableID":   "nP1Eu18S2R11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec9995bd7505448783656e89f5de7f189a381aaf5b4b130626174ecb91863f0d",
+				"DiscoKey":   "discokey:79cb3eb1794766782d2828864dfb1ecade0bec0ba4fb5dd542f03f538a39d44f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52587",
+					"10.65.0.27:52587",
+					"172.17.0.1:52587",
+					"172.18.0.1:52587",
+					"172.19.0.1:52587"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:32:06.535404499Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4852696183438427,
+				"StableID":   "nc5HTo6ote11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c41cd99ab18b45734a4bd15e6d39bf220698a9f726f47f5c93d48011c603fe50",
+				"DiscoKey":   "discokey:4b3b0a842bcc9b1bc8b2d1225da72f91cea42207e3eb2954d594721472e0153a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54325",
+					"10.65.0.27:54325",
+					"172.17.0.1:54325",
+					"172.18.0.1:54325",
+					"172.19.0.1:54325"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:32:07.066875559Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5405486878286675,
+				"StableID":   "nLsQDWy9Dj11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdb4ec6888811dd3a458eee71e7e82b6ba57456247cea0286a0f52a3c6177443",
+				"DiscoKey":   "discokey:d4231b2fd36ac8a22ad0af9e8e95f034a36231b6307ec8dc7678e6d786ab4f36",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60962",
+					"10.65.0.27:60962",
+					"172.17.0.1:60962",
+					"172.18.0.1:60962",
+					"172.19.0.1:60962"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:32:07.614061815Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4277392511586413,
+				"StableID":   "ntQN1CrEQa11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f43cafcc0263d4fe5fd1f00b161b34f330d2c960f19c0424a1110f6d8b3ad79",
+				"DiscoKey":   "discokey:7d91e866dc1fe26dca650c6a6eb701af91b0bb7d5de7eb58b276835ef4892301",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:32799",
+					"10.65.0.27:32799",
+					"172.17.0.1:32799",
+					"172.18.0.1:32799",
+					"172.19.0.1:32799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:32:08.153685446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6683173110387055,
+				"StableID":   "nGTCKFdpBu11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d60fd719e033c223cff1df535ebc55d2ffe15e59fc3a0382ebb031534d2e085d",
+				"KeyExpiry":  "2026-11-09T07:32:08Z",
+				"DiscoKey":   "discokey:28b724f2b015833c37572d87ea899b0bcd73343f6de96a79f40a15f374423d39",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52317",
+					"10.65.0.27:52317",
+					"172.17.0.1:52317",
+					"172.18.0.1:52317",
+					"172.19.0.1:52317"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:32:08.704629899Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2795559571658972,
+				"StableID":   "nTLQQMc7qN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:94fc225713a77b24286773baa68596b86cb37df40a7c8c052b340a5f5a41e543",
+				"KeyExpiry":  "2026-11-09T07:32:09Z",
+				"DiscoKey":   "discokey:bb93b45b3b208bc98fc8d619b60bd255990659cbc97f4149b792121589977b3b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35279",
+					"10.65.0.27:35279",
+					"172.17.0.1:35279",
+					"172.18.0.1:35279",
+					"172.19.0.1:35279"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:32:09.23308551Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8827946835332669,
+				"StableID":   "nnKNxECCwB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ff47092463a9d39dc348b889d4782dde5685606d166e0abbe3c63f60f3889473",
+				"KeyExpiry":  "2026-11-09T07:32:09Z",
+				"DiscoKey":   "discokey:38782afda7639fb498262e15fe0074722246a2c6dd317657b4a54a541a746123",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60290",
+					"10.65.0.27:60290",
+					"172.17.0.1:60290",
+					"172.18.0.1:60290",
+					"172.19.0.1:60290"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:32:09.781574364Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4104100983045156": {
+				"ID":          4104100983045156,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6773448591800793,
+				"StableID":   "nWDQUW1itu11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       6773448591800793,
+				"Key":        "nodekey:f6e2453e3fbd0292765e5e97dc33dd066f25969f442fd1d9b3c4080e82d9c455",
+				"DiscoKey":   "discokey:19e8f74c660a72cba783b6ce69655c90e90bd2769161af2a08816e02a2a1751d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47027",
+					"10.65.0.27:47027",
+					"172.17.0.1:47027",
+					"172.18.0.1:47027",
+					"172.19.0.1:47027"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:32:05.987829594Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f6e2453e3fbd0292765e5e97dc33dd066f25969f442fd1d9b3c4080e82d9c455",
+			"MachineKey": "mkey:8a2505b3a882ad95423fe4d051c59444f1afa9682ef78de53cd7e6f71d681627",
+			"Peers": [{
+				"ID":         4744643513638242,
+				"StableID":   "nByq2ujr3e11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ffc63b0b4e6df3afa51bd7f23e730c1c1602c86ad9bd2ecd623163d95621936",
+				"DiscoKey":   "discokey:44cdf0dd5debdcb0493de5054a6eaa110d1dcb750c8ad80b2368659e7b056469",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50660",
+					"10.65.0.27:50660",
+					"172.17.0.1:50660",
+					"172.18.0.1:50660",
+					"172.19.0.1:50660"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:32:02.242387317Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3384024868833209,
+				"StableID":   "nGAPcWbdRT11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8bc67a918aef9757ec1c2e8cbabf91973eb4d22f720c3bd881328cea69db54e",
+				"DiscoKey":   "discokey:5ac2b886460f769df10af7db3ca534ad28bf8c87060cb7aa594e51c03b871b44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51247",
+					"10.65.0.27:51247",
+					"172.17.0.1:51247",
+					"172.18.0.1:51247",
+					"172.19.0.1:51247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:32:02.762225978Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4104100983045156,
+				"StableID":   "ndHD3smk3Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c1f230674780923dec20f5b5defac12f78b113d4c89e2b77f504b428651bf25",
+				"DiscoKey":   "discokey:0386401c3bc77d5202103f928dde326d7c9cf11a3698fc33557df03f1577a94b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60676",
+					"10.65.0.27:60676",
+					"172.17.0.1:60676",
+					"172.18.0.1:60676",
+					"172.19.0.1:60676"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:32:03.29320231Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2053553102717197,
+				"StableID":   "ni7FdkM43H11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:462d530888e4e8e815ae993eab1f79d1d4c25aebf9d5750e6190121c5c38091d",
+				"DiscoKey":   "discokey:ca86b8d2271ebd4e08bc13fbeb823ade08e37df6bbd91f45b56d9982c30fb16a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49676",
+					"10.65.0.27:49676",
+					"172.17.0.1:49676",
+					"172.18.0.1:49676",
+					"172.19.0.1:49676"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:32:03.831192155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4485305050041784,
+				"StableID":   "nb8s4mMQ2c11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93c4a5bba11e6b6f85ece1cd6a8d9bafeba6497ddc12dc92ee64e1f0ca86e672",
+				"DiscoKey":   "discokey:684efa3f278e4aa7b5154dc47ccbc72353254cd5ae16601f73e50a18baf35d2d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33435",
+					"10.65.0.27:33435",
+					"172.17.0.1:33435",
+					"172.18.0.1:33435",
+					"172.19.0.1:33435"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:32:04.366260931Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6405819003809912,
+				"StableID":   "nw2sfA1D2s11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1ca3dbccc144b3c054256ff111274ba6fbd99ccccb1c38acb280dbd510f6595b",
+				"DiscoKey":   "discokey:26064138d413eb16852c9e78aeadaf1468c770c741a35049ce2d39676cfeed34",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40094",
+					"10.65.0.27:40094",
+					"172.17.0.1:40094",
+					"172.18.0.1:40094",
+					"172.19.0.1:40094"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:32:04.910825058Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7945506545729529,
+				"StableID":   "nWKZL4zX3521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b49d04dff8e09c0628519156c0f58abe66760419609302611c82bc6822b2dc79",
+				"DiscoKey":   "discokey:96d052db8c7e233697a52745fc029c314b692a76d229d4fdcdbd16c41f1bda19",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47320",
+					"10.65.0.27:47320",
+					"172.17.0.1:47320",
+					"172.18.0.1:47320",
+					"172.19.0.1:47320"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:32:05.446654167Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3076678267400490,
+				"StableID":   "nP1Eu18S2R11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec9995bd7505448783656e89f5de7f189a381aaf5b4b130626174ecb91863f0d",
+				"DiscoKey":   "discokey:79cb3eb1794766782d2828864dfb1ecade0bec0ba4fb5dd542f03f538a39d44f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52587",
+					"10.65.0.27:52587",
+					"172.17.0.1:52587",
+					"172.18.0.1:52587",
+					"172.19.0.1:52587"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:32:06.535404499Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4852696183438427,
+				"StableID":   "nc5HTo6ote11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c41cd99ab18b45734a4bd15e6d39bf220698a9f726f47f5c93d48011c603fe50",
+				"DiscoKey":   "discokey:4b3b0a842bcc9b1bc8b2d1225da72f91cea42207e3eb2954d594721472e0153a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54325",
+					"10.65.0.27:54325",
+					"172.17.0.1:54325",
+					"172.18.0.1:54325",
+					"172.19.0.1:54325"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:32:07.066875559Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5405486878286675,
+				"StableID":   "nLsQDWy9Dj11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdb4ec6888811dd3a458eee71e7e82b6ba57456247cea0286a0f52a3c6177443",
+				"DiscoKey":   "discokey:d4231b2fd36ac8a22ad0af9e8e95f034a36231b6307ec8dc7678e6d786ab4f36",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60962",
+					"10.65.0.27:60962",
+					"172.17.0.1:60962",
+					"172.18.0.1:60962",
+					"172.19.0.1:60962"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:32:07.614061815Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4277392511586413,
+				"StableID":   "ntQN1CrEQa11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f43cafcc0263d4fe5fd1f00b161b34f330d2c960f19c0424a1110f6d8b3ad79",
+				"DiscoKey":   "discokey:7d91e866dc1fe26dca650c6a6eb701af91b0bb7d5de7eb58b276835ef4892301",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:32799",
+					"10.65.0.27:32799",
+					"172.17.0.1:32799",
+					"172.18.0.1:32799",
+					"172.19.0.1:32799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:32:08.153685446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6683173110387055,
+				"StableID":   "nGTCKFdpBu11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d60fd719e033c223cff1df535ebc55d2ffe15e59fc3a0382ebb031534d2e085d",
+				"KeyExpiry":  "2026-11-09T07:32:08Z",
+				"DiscoKey":   "discokey:28b724f2b015833c37572d87ea899b0bcd73343f6de96a79f40a15f374423d39",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52317",
+					"10.65.0.27:52317",
+					"172.17.0.1:52317",
+					"172.18.0.1:52317",
+					"172.19.0.1:52317"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:32:08.704629899Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2795559571658972,
+				"StableID":   "nTLQQMc7qN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:94fc225713a77b24286773baa68596b86cb37df40a7c8c052b340a5f5a41e543",
+				"KeyExpiry":  "2026-11-09T07:32:09Z",
+				"DiscoKey":   "discokey:bb93b45b3b208bc98fc8d619b60bd255990659cbc97f4149b792121589977b3b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35279",
+					"10.65.0.27:35279",
+					"172.17.0.1:35279",
+					"172.18.0.1:35279",
+					"172.19.0.1:35279"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:32:09.23308551Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8827946835332669,
+				"StableID":   "nnKNxECCwB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ff47092463a9d39dc348b889d4782dde5685606d166e0abbe3c63f60f3889473",
+				"KeyExpiry":  "2026-11-09T07:32:09Z",
+				"DiscoKey":   "discokey:38782afda7639fb498262e15fe0074722246a2c6dd317657b4a54a541a746123",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60290",
+					"10.65.0.27:60290",
+					"172.17.0.1:60290",
+					"172.18.0.1:60290",
+					"172.19.0.1:60290"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:32:09.781574364Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6773448591800793": {
+				"ID":          6773448591800793,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6683173110387055,
+				"StableID":   "nGTCKFdpBu11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d60fd719e033c223cff1df535ebc55d2ffe15e59fc3a0382ebb031534d2e085d",
+				"KeyExpiry":  "2026-11-09T07:32:08Z",
+				"DiscoKey":   "discokey:28b724f2b015833c37572d87ea899b0bcd73343f6de96a79f40a15f374423d39",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52317",
+					"10.65.0.27:52317",
+					"172.17.0.1:52317",
+					"172.18.0.1:52317",
+					"172.19.0.1:52317"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:32:08.704629899Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d60fd719e033c223cff1df535ebc55d2ffe15e59fc3a0382ebb031534d2e085d",
+			"MachineKey": "mkey:0045add603abb261efb12ac4b512a079e7b28dea00cb80177fdd529ea839b60b",
+			"Peers": [{
+				"ID":         4744643513638242,
+				"StableID":   "nByq2ujr3e11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ffc63b0b4e6df3afa51bd7f23e730c1c1602c86ad9bd2ecd623163d95621936",
+				"DiscoKey":   "discokey:44cdf0dd5debdcb0493de5054a6eaa110d1dcb750c8ad80b2368659e7b056469",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50660",
+					"10.65.0.27:50660",
+					"172.17.0.1:50660",
+					"172.18.0.1:50660",
+					"172.19.0.1:50660"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:32:02.242387317Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3384024868833209,
+				"StableID":   "nGAPcWbdRT11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8bc67a918aef9757ec1c2e8cbabf91973eb4d22f720c3bd881328cea69db54e",
+				"DiscoKey":   "discokey:5ac2b886460f769df10af7db3ca534ad28bf8c87060cb7aa594e51c03b871b44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51247",
+					"10.65.0.27:51247",
+					"172.17.0.1:51247",
+					"172.18.0.1:51247",
+					"172.19.0.1:51247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:32:02.762225978Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4104100983045156,
+				"StableID":   "ndHD3smk3Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c1f230674780923dec20f5b5defac12f78b113d4c89e2b77f504b428651bf25",
+				"DiscoKey":   "discokey:0386401c3bc77d5202103f928dde326d7c9cf11a3698fc33557df03f1577a94b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60676",
+					"10.65.0.27:60676",
+					"172.17.0.1:60676",
+					"172.18.0.1:60676",
+					"172.19.0.1:60676"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:32:03.29320231Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2053553102717197,
+				"StableID":   "ni7FdkM43H11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:462d530888e4e8e815ae993eab1f79d1d4c25aebf9d5750e6190121c5c38091d",
+				"DiscoKey":   "discokey:ca86b8d2271ebd4e08bc13fbeb823ade08e37df6bbd91f45b56d9982c30fb16a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49676",
+					"10.65.0.27:49676",
+					"172.17.0.1:49676",
+					"172.18.0.1:49676",
+					"172.19.0.1:49676"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:32:03.831192155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4485305050041784,
+				"StableID":   "nb8s4mMQ2c11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93c4a5bba11e6b6f85ece1cd6a8d9bafeba6497ddc12dc92ee64e1f0ca86e672",
+				"DiscoKey":   "discokey:684efa3f278e4aa7b5154dc47ccbc72353254cd5ae16601f73e50a18baf35d2d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33435",
+					"10.65.0.27:33435",
+					"172.17.0.1:33435",
+					"172.18.0.1:33435",
+					"172.19.0.1:33435"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:32:04.366260931Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6405819003809912,
+				"StableID":   "nw2sfA1D2s11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1ca3dbccc144b3c054256ff111274ba6fbd99ccccb1c38acb280dbd510f6595b",
+				"DiscoKey":   "discokey:26064138d413eb16852c9e78aeadaf1468c770c741a35049ce2d39676cfeed34",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40094",
+					"10.65.0.27:40094",
+					"172.17.0.1:40094",
+					"172.18.0.1:40094",
+					"172.19.0.1:40094"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:32:04.910825058Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7945506545729529,
+				"StableID":   "nWKZL4zX3521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b49d04dff8e09c0628519156c0f58abe66760419609302611c82bc6822b2dc79",
+				"DiscoKey":   "discokey:96d052db8c7e233697a52745fc029c314b692a76d229d4fdcdbd16c41f1bda19",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47320",
+					"10.65.0.27:47320",
+					"172.17.0.1:47320",
+					"172.18.0.1:47320",
+					"172.19.0.1:47320"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:32:05.446654167Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6773448591800793,
+				"StableID":   "nWDQUW1itu11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6e2453e3fbd0292765e5e97dc33dd066f25969f442fd1d9b3c4080e82d9c455",
+				"DiscoKey":   "discokey:19e8f74c660a72cba783b6ce69655c90e90bd2769161af2a08816e02a2a1751d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47027",
+					"10.65.0.27:47027",
+					"172.17.0.1:47027",
+					"172.18.0.1:47027",
+					"172.19.0.1:47027"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:32:05.987829594Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3076678267400490,
+				"StableID":   "nP1Eu18S2R11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec9995bd7505448783656e89f5de7f189a381aaf5b4b130626174ecb91863f0d",
+				"DiscoKey":   "discokey:79cb3eb1794766782d2828864dfb1ecade0bec0ba4fb5dd542f03f538a39d44f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52587",
+					"10.65.0.27:52587",
+					"172.17.0.1:52587",
+					"172.18.0.1:52587",
+					"172.19.0.1:52587"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:32:06.535404499Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4852696183438427,
+				"StableID":   "nc5HTo6ote11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c41cd99ab18b45734a4bd15e6d39bf220698a9f726f47f5c93d48011c603fe50",
+				"DiscoKey":   "discokey:4b3b0a842bcc9b1bc8b2d1225da72f91cea42207e3eb2954d594721472e0153a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54325",
+					"10.65.0.27:54325",
+					"172.17.0.1:54325",
+					"172.18.0.1:54325",
+					"172.19.0.1:54325"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:32:07.066875559Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5405486878286675,
+				"StableID":   "nLsQDWy9Dj11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdb4ec6888811dd3a458eee71e7e82b6ba57456247cea0286a0f52a3c6177443",
+				"DiscoKey":   "discokey:d4231b2fd36ac8a22ad0af9e8e95f034a36231b6307ec8dc7678e6d786ab4f36",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60962",
+					"10.65.0.27:60962",
+					"172.17.0.1:60962",
+					"172.18.0.1:60962",
+					"172.19.0.1:60962"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:32:07.614061815Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4277392511586413,
+				"StableID":   "ntQN1CrEQa11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f43cafcc0263d4fe5fd1f00b161b34f330d2c960f19c0424a1110f6d8b3ad79",
+				"DiscoKey":   "discokey:7d91e866dc1fe26dca650c6a6eb701af91b0bb7d5de7eb58b276835ef4892301",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:32799",
+					"10.65.0.27:32799",
+					"172.17.0.1:32799",
+					"172.18.0.1:32799",
+					"172.19.0.1:32799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:32:08.153685446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2795559571658972,
+				"StableID":   "nTLQQMc7qN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:94fc225713a77b24286773baa68596b86cb37df40a7c8c052b340a5f5a41e543",
+				"KeyExpiry":  "2026-11-09T07:32:09Z",
+				"DiscoKey":   "discokey:bb93b45b3b208bc98fc8d619b60bd255990659cbc97f4149b792121589977b3b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35279",
+					"10.65.0.27:35279",
+					"172.17.0.1:35279",
+					"172.18.0.1:35279",
+					"172.19.0.1:35279"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:32:09.23308551Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8827946835332669,
+				"StableID":   "nnKNxECCwB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ff47092463a9d39dc348b889d4782dde5685606d166e0abbe3c63f60f3889473",
+				"KeyExpiry":  "2026-11-09T07:32:09Z",
+				"DiscoKey":   "discokey:38782afda7639fb498262e15fe0074722246a2c6dd317657b4a54a541a746123",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60290",
+					"10.65.0.27:60290",
+					"172.17.0.1:60290",
+					"172.18.0.1:60290",
+					"172.19.0.1:60290"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:32:09.781574364Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5405486878286675,
+				"StableID":   "nLsQDWy9Dj11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       5405486878286675,
+				"Key":        "nodekey:cdb4ec6888811dd3a458eee71e7e82b6ba57456247cea0286a0f52a3c6177443",
+				"DiscoKey":   "discokey:d4231b2fd36ac8a22ad0af9e8e95f034a36231b6307ec8dc7678e6d786ab4f36",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60962",
+					"10.65.0.27:60962",
+					"172.17.0.1:60962",
+					"172.18.0.1:60962",
+					"172.19.0.1:60962"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:32:07.614061815Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:cdb4ec6888811dd3a458eee71e7e82b6ba57456247cea0286a0f52a3c6177443",
+			"MachineKey": "mkey:54696ad409073a1c20708e72f9fe6bdaeb9c90483f6b66d466eb1e38a49bf87a",
+			"Peers": [{
+				"ID":         4744643513638242,
+				"StableID":   "nByq2ujr3e11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ffc63b0b4e6df3afa51bd7f23e730c1c1602c86ad9bd2ecd623163d95621936",
+				"DiscoKey":   "discokey:44cdf0dd5debdcb0493de5054a6eaa110d1dcb750c8ad80b2368659e7b056469",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50660",
+					"10.65.0.27:50660",
+					"172.17.0.1:50660",
+					"172.18.0.1:50660",
+					"172.19.0.1:50660"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:32:02.242387317Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3384024868833209,
+				"StableID":   "nGAPcWbdRT11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8bc67a918aef9757ec1c2e8cbabf91973eb4d22f720c3bd881328cea69db54e",
+				"DiscoKey":   "discokey:5ac2b886460f769df10af7db3ca534ad28bf8c87060cb7aa594e51c03b871b44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51247",
+					"10.65.0.27:51247",
+					"172.17.0.1:51247",
+					"172.18.0.1:51247",
+					"172.19.0.1:51247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:32:02.762225978Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4104100983045156,
+				"StableID":   "ndHD3smk3Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c1f230674780923dec20f5b5defac12f78b113d4c89e2b77f504b428651bf25",
+				"DiscoKey":   "discokey:0386401c3bc77d5202103f928dde326d7c9cf11a3698fc33557df03f1577a94b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60676",
+					"10.65.0.27:60676",
+					"172.17.0.1:60676",
+					"172.18.0.1:60676",
+					"172.19.0.1:60676"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:32:03.29320231Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2053553102717197,
+				"StableID":   "ni7FdkM43H11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:462d530888e4e8e815ae993eab1f79d1d4c25aebf9d5750e6190121c5c38091d",
+				"DiscoKey":   "discokey:ca86b8d2271ebd4e08bc13fbeb823ade08e37df6bbd91f45b56d9982c30fb16a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49676",
+					"10.65.0.27:49676",
+					"172.17.0.1:49676",
+					"172.18.0.1:49676",
+					"172.19.0.1:49676"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:32:03.831192155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4485305050041784,
+				"StableID":   "nb8s4mMQ2c11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93c4a5bba11e6b6f85ece1cd6a8d9bafeba6497ddc12dc92ee64e1f0ca86e672",
+				"DiscoKey":   "discokey:684efa3f278e4aa7b5154dc47ccbc72353254cd5ae16601f73e50a18baf35d2d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33435",
+					"10.65.0.27:33435",
+					"172.17.0.1:33435",
+					"172.18.0.1:33435",
+					"172.19.0.1:33435"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:32:04.366260931Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6405819003809912,
+				"StableID":   "nw2sfA1D2s11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1ca3dbccc144b3c054256ff111274ba6fbd99ccccb1c38acb280dbd510f6595b",
+				"DiscoKey":   "discokey:26064138d413eb16852c9e78aeadaf1468c770c741a35049ce2d39676cfeed34",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40094",
+					"10.65.0.27:40094",
+					"172.17.0.1:40094",
+					"172.18.0.1:40094",
+					"172.19.0.1:40094"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:32:04.910825058Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7945506545729529,
+				"StableID":   "nWKZL4zX3521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b49d04dff8e09c0628519156c0f58abe66760419609302611c82bc6822b2dc79",
+				"DiscoKey":   "discokey:96d052db8c7e233697a52745fc029c314b692a76d229d4fdcdbd16c41f1bda19",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47320",
+					"10.65.0.27:47320",
+					"172.17.0.1:47320",
+					"172.18.0.1:47320",
+					"172.19.0.1:47320"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:32:05.446654167Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6773448591800793,
+				"StableID":   "nWDQUW1itu11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6e2453e3fbd0292765e5e97dc33dd066f25969f442fd1d9b3c4080e82d9c455",
+				"DiscoKey":   "discokey:19e8f74c660a72cba783b6ce69655c90e90bd2769161af2a08816e02a2a1751d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47027",
+					"10.65.0.27:47027",
+					"172.17.0.1:47027",
+					"172.18.0.1:47027",
+					"172.19.0.1:47027"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:32:05.987829594Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3076678267400490,
+				"StableID":   "nP1Eu18S2R11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec9995bd7505448783656e89f5de7f189a381aaf5b4b130626174ecb91863f0d",
+				"DiscoKey":   "discokey:79cb3eb1794766782d2828864dfb1ecade0bec0ba4fb5dd542f03f538a39d44f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52587",
+					"10.65.0.27:52587",
+					"172.17.0.1:52587",
+					"172.18.0.1:52587",
+					"172.19.0.1:52587"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:32:06.535404499Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4852696183438427,
+				"StableID":   "nc5HTo6ote11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c41cd99ab18b45734a4bd15e6d39bf220698a9f726f47f5c93d48011c603fe50",
+				"DiscoKey":   "discokey:4b3b0a842bcc9b1bc8b2d1225da72f91cea42207e3eb2954d594721472e0153a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54325",
+					"10.65.0.27:54325",
+					"172.17.0.1:54325",
+					"172.18.0.1:54325",
+					"172.19.0.1:54325"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:32:07.066875559Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4277392511586413,
+				"StableID":   "ntQN1CrEQa11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f43cafcc0263d4fe5fd1f00b161b34f330d2c960f19c0424a1110f6d8b3ad79",
+				"DiscoKey":   "discokey:7d91e866dc1fe26dca650c6a6eb701af91b0bb7d5de7eb58b276835ef4892301",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:32799",
+					"10.65.0.27:32799",
+					"172.17.0.1:32799",
+					"172.18.0.1:32799",
+					"172.19.0.1:32799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:32:08.153685446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6683173110387055,
+				"StableID":   "nGTCKFdpBu11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d60fd719e033c223cff1df535ebc55d2ffe15e59fc3a0382ebb031534d2e085d",
+				"KeyExpiry":  "2026-11-09T07:32:08Z",
+				"DiscoKey":   "discokey:28b724f2b015833c37572d87ea899b0bcd73343f6de96a79f40a15f374423d39",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52317",
+					"10.65.0.27:52317",
+					"172.17.0.1:52317",
+					"172.18.0.1:52317",
+					"172.19.0.1:52317"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:32:08.704629899Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2795559571658972,
+				"StableID":   "nTLQQMc7qN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:94fc225713a77b24286773baa68596b86cb37df40a7c8c052b340a5f5a41e543",
+				"KeyExpiry":  "2026-11-09T07:32:09Z",
+				"DiscoKey":   "discokey:bb93b45b3b208bc98fc8d619b60bd255990659cbc97f4149b792121589977b3b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35279",
+					"10.65.0.27:35279",
+					"172.17.0.1:35279",
+					"172.18.0.1:35279",
+					"172.19.0.1:35279"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:32:09.23308551Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8827946835332669,
+				"StableID":   "nnKNxECCwB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ff47092463a9d39dc348b889d4782dde5685606d166e0abbe3c63f60f3889473",
+				"KeyExpiry":  "2026-11-09T07:32:09Z",
+				"DiscoKey":   "discokey:38782afda7639fb498262e15fe0074722246a2c6dd317657b4a54a541a746123",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60290",
+					"10.65.0.27:60290",
+					"172.17.0.1:60290",
+					"172.18.0.1:60290",
+					"172.19.0.1:60290"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:32:09.781574364Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5405486878286675": {
+				"ID":          5405486878286675,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3384024868833209,
+				"StableID":   "nGAPcWbdRT11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       3384024868833209,
+				"Key":        "nodekey:b8bc67a918aef9757ec1c2e8cbabf91973eb4d22f720c3bd881328cea69db54e",
+				"DiscoKey":   "discokey:5ac2b886460f769df10af7db3ca534ad28bf8c87060cb7aa594e51c03b871b44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51247",
+					"10.65.0.27:51247",
+					"172.17.0.1:51247",
+					"172.18.0.1:51247",
+					"172.19.0.1:51247"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:32:02.762225978Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b8bc67a918aef9757ec1c2e8cbabf91973eb4d22f720c3bd881328cea69db54e",
+			"MachineKey": "mkey:75649143df94b963175be30681cacf03c3b07852b5a8643f8e2c22e879824069",
+			"Peers": [{
+				"ID":         4744643513638242,
+				"StableID":   "nByq2ujr3e11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ffc63b0b4e6df3afa51bd7f23e730c1c1602c86ad9bd2ecd623163d95621936",
+				"DiscoKey":   "discokey:44cdf0dd5debdcb0493de5054a6eaa110d1dcb750c8ad80b2368659e7b056469",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50660",
+					"10.65.0.27:50660",
+					"172.17.0.1:50660",
+					"172.18.0.1:50660",
+					"172.19.0.1:50660"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:32:02.242387317Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4104100983045156,
+				"StableID":   "ndHD3smk3Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c1f230674780923dec20f5b5defac12f78b113d4c89e2b77f504b428651bf25",
+				"DiscoKey":   "discokey:0386401c3bc77d5202103f928dde326d7c9cf11a3698fc33557df03f1577a94b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60676",
+					"10.65.0.27:60676",
+					"172.17.0.1:60676",
+					"172.18.0.1:60676",
+					"172.19.0.1:60676"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:32:03.29320231Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2053553102717197,
+				"StableID":   "ni7FdkM43H11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:462d530888e4e8e815ae993eab1f79d1d4c25aebf9d5750e6190121c5c38091d",
+				"DiscoKey":   "discokey:ca86b8d2271ebd4e08bc13fbeb823ade08e37df6bbd91f45b56d9982c30fb16a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49676",
+					"10.65.0.27:49676",
+					"172.17.0.1:49676",
+					"172.18.0.1:49676",
+					"172.19.0.1:49676"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:32:03.831192155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4485305050041784,
+				"StableID":   "nb8s4mMQ2c11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93c4a5bba11e6b6f85ece1cd6a8d9bafeba6497ddc12dc92ee64e1f0ca86e672",
+				"DiscoKey":   "discokey:684efa3f278e4aa7b5154dc47ccbc72353254cd5ae16601f73e50a18baf35d2d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33435",
+					"10.65.0.27:33435",
+					"172.17.0.1:33435",
+					"172.18.0.1:33435",
+					"172.19.0.1:33435"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:32:04.366260931Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6405819003809912,
+				"StableID":   "nw2sfA1D2s11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1ca3dbccc144b3c054256ff111274ba6fbd99ccccb1c38acb280dbd510f6595b",
+				"DiscoKey":   "discokey:26064138d413eb16852c9e78aeadaf1468c770c741a35049ce2d39676cfeed34",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40094",
+					"10.65.0.27:40094",
+					"172.17.0.1:40094",
+					"172.18.0.1:40094",
+					"172.19.0.1:40094"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:32:04.910825058Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7945506545729529,
+				"StableID":   "nWKZL4zX3521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b49d04dff8e09c0628519156c0f58abe66760419609302611c82bc6822b2dc79",
+				"DiscoKey":   "discokey:96d052db8c7e233697a52745fc029c314b692a76d229d4fdcdbd16c41f1bda19",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47320",
+					"10.65.0.27:47320",
+					"172.17.0.1:47320",
+					"172.18.0.1:47320",
+					"172.19.0.1:47320"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:32:05.446654167Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6773448591800793,
+				"StableID":   "nWDQUW1itu11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6e2453e3fbd0292765e5e97dc33dd066f25969f442fd1d9b3c4080e82d9c455",
+				"DiscoKey":   "discokey:19e8f74c660a72cba783b6ce69655c90e90bd2769161af2a08816e02a2a1751d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47027",
+					"10.65.0.27:47027",
+					"172.17.0.1:47027",
+					"172.18.0.1:47027",
+					"172.19.0.1:47027"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:32:05.987829594Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3076678267400490,
+				"StableID":   "nP1Eu18S2R11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec9995bd7505448783656e89f5de7f189a381aaf5b4b130626174ecb91863f0d",
+				"DiscoKey":   "discokey:79cb3eb1794766782d2828864dfb1ecade0bec0ba4fb5dd542f03f538a39d44f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52587",
+					"10.65.0.27:52587",
+					"172.17.0.1:52587",
+					"172.18.0.1:52587",
+					"172.19.0.1:52587"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:32:06.535404499Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4852696183438427,
+				"StableID":   "nc5HTo6ote11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c41cd99ab18b45734a4bd15e6d39bf220698a9f726f47f5c93d48011c603fe50",
+				"DiscoKey":   "discokey:4b3b0a842bcc9b1bc8b2d1225da72f91cea42207e3eb2954d594721472e0153a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54325",
+					"10.65.0.27:54325",
+					"172.17.0.1:54325",
+					"172.18.0.1:54325",
+					"172.19.0.1:54325"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:32:07.066875559Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5405486878286675,
+				"StableID":   "nLsQDWy9Dj11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdb4ec6888811dd3a458eee71e7e82b6ba57456247cea0286a0f52a3c6177443",
+				"DiscoKey":   "discokey:d4231b2fd36ac8a22ad0af9e8e95f034a36231b6307ec8dc7678e6d786ab4f36",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60962",
+					"10.65.0.27:60962",
+					"172.17.0.1:60962",
+					"172.18.0.1:60962",
+					"172.19.0.1:60962"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:32:07.614061815Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4277392511586413,
+				"StableID":   "ntQN1CrEQa11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f43cafcc0263d4fe5fd1f00b161b34f330d2c960f19c0424a1110f6d8b3ad79",
+				"DiscoKey":   "discokey:7d91e866dc1fe26dca650c6a6eb701af91b0bb7d5de7eb58b276835ef4892301",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:32799",
+					"10.65.0.27:32799",
+					"172.17.0.1:32799",
+					"172.18.0.1:32799",
+					"172.19.0.1:32799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:32:08.153685446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6683173110387055,
+				"StableID":   "nGTCKFdpBu11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d60fd719e033c223cff1df535ebc55d2ffe15e59fc3a0382ebb031534d2e085d",
+				"KeyExpiry":  "2026-11-09T07:32:08Z",
+				"DiscoKey":   "discokey:28b724f2b015833c37572d87ea899b0bcd73343f6de96a79f40a15f374423d39",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52317",
+					"10.65.0.27:52317",
+					"172.17.0.1:52317",
+					"172.18.0.1:52317",
+					"172.19.0.1:52317"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:32:08.704629899Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2795559571658972,
+				"StableID":   "nTLQQMc7qN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:94fc225713a77b24286773baa68596b86cb37df40a7c8c052b340a5f5a41e543",
+				"KeyExpiry":  "2026-11-09T07:32:09Z",
+				"DiscoKey":   "discokey:bb93b45b3b208bc98fc8d619b60bd255990659cbc97f4149b792121589977b3b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35279",
+					"10.65.0.27:35279",
+					"172.17.0.1:35279",
+					"172.18.0.1:35279",
+					"172.19.0.1:35279"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:32:09.23308551Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8827946835332669,
+				"StableID":   "nnKNxECCwB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ff47092463a9d39dc348b889d4782dde5685606d166e0abbe3c63f60f3889473",
+				"KeyExpiry":  "2026-11-09T07:32:09Z",
+				"DiscoKey":   "discokey:38782afda7639fb498262e15fe0074722246a2c6dd317657b4a54a541a746123",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60290",
+					"10.65.0.27:60290",
+					"172.17.0.1:60290",
+					"172.18.0.1:60290",
+					"172.19.0.1:60290"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:32:09.781574364Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3384024868833209": {
+				"ID":          3384024868833209,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4744643513638242,
+				"StableID":   "nByq2ujr3e11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       4744643513638242,
+				"Key":        "nodekey:4ffc63b0b4e6df3afa51bd7f23e730c1c1602c86ad9bd2ecd623163d95621936",
+				"DiscoKey":   "discokey:44cdf0dd5debdcb0493de5054a6eaa110d1dcb750c8ad80b2368659e7b056469",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50660",
+					"10.65.0.27:50660",
+					"172.17.0.1:50660",
+					"172.18.0.1:50660",
+					"172.19.0.1:50660"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:32:02.242387317Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4ffc63b0b4e6df3afa51bd7f23e730c1c1602c86ad9bd2ecd623163d95621936",
+			"MachineKey": "mkey:0c23f46fc6baec1e996ae428b4c16bc870e03850c1e71b142711146723fc1366",
+			"Peers": [{
+				"ID":         3384024868833209,
+				"StableID":   "nGAPcWbdRT11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8bc67a918aef9757ec1c2e8cbabf91973eb4d22f720c3bd881328cea69db54e",
+				"DiscoKey":   "discokey:5ac2b886460f769df10af7db3ca534ad28bf8c87060cb7aa594e51c03b871b44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51247",
+					"10.65.0.27:51247",
+					"172.17.0.1:51247",
+					"172.18.0.1:51247",
+					"172.19.0.1:51247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:32:02.762225978Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4104100983045156,
+				"StableID":   "ndHD3smk3Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c1f230674780923dec20f5b5defac12f78b113d4c89e2b77f504b428651bf25",
+				"DiscoKey":   "discokey:0386401c3bc77d5202103f928dde326d7c9cf11a3698fc33557df03f1577a94b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60676",
+					"10.65.0.27:60676",
+					"172.17.0.1:60676",
+					"172.18.0.1:60676",
+					"172.19.0.1:60676"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:32:03.29320231Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2053553102717197,
+				"StableID":   "ni7FdkM43H11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:462d530888e4e8e815ae993eab1f79d1d4c25aebf9d5750e6190121c5c38091d",
+				"DiscoKey":   "discokey:ca86b8d2271ebd4e08bc13fbeb823ade08e37df6bbd91f45b56d9982c30fb16a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49676",
+					"10.65.0.27:49676",
+					"172.17.0.1:49676",
+					"172.18.0.1:49676",
+					"172.19.0.1:49676"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:32:03.831192155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4485305050041784,
+				"StableID":   "nb8s4mMQ2c11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93c4a5bba11e6b6f85ece1cd6a8d9bafeba6497ddc12dc92ee64e1f0ca86e672",
+				"DiscoKey":   "discokey:684efa3f278e4aa7b5154dc47ccbc72353254cd5ae16601f73e50a18baf35d2d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33435",
+					"10.65.0.27:33435",
+					"172.17.0.1:33435",
+					"172.18.0.1:33435",
+					"172.19.0.1:33435"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:32:04.366260931Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6405819003809912,
+				"StableID":   "nw2sfA1D2s11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1ca3dbccc144b3c054256ff111274ba6fbd99ccccb1c38acb280dbd510f6595b",
+				"DiscoKey":   "discokey:26064138d413eb16852c9e78aeadaf1468c770c741a35049ce2d39676cfeed34",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40094",
+					"10.65.0.27:40094",
+					"172.17.0.1:40094",
+					"172.18.0.1:40094",
+					"172.19.0.1:40094"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:32:04.910825058Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7945506545729529,
+				"StableID":   "nWKZL4zX3521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b49d04dff8e09c0628519156c0f58abe66760419609302611c82bc6822b2dc79",
+				"DiscoKey":   "discokey:96d052db8c7e233697a52745fc029c314b692a76d229d4fdcdbd16c41f1bda19",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47320",
+					"10.65.0.27:47320",
+					"172.17.0.1:47320",
+					"172.18.0.1:47320",
+					"172.19.0.1:47320"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:32:05.446654167Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6773448591800793,
+				"StableID":   "nWDQUW1itu11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6e2453e3fbd0292765e5e97dc33dd066f25969f442fd1d9b3c4080e82d9c455",
+				"DiscoKey":   "discokey:19e8f74c660a72cba783b6ce69655c90e90bd2769161af2a08816e02a2a1751d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47027",
+					"10.65.0.27:47027",
+					"172.17.0.1:47027",
+					"172.18.0.1:47027",
+					"172.19.0.1:47027"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:32:05.987829594Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3076678267400490,
+				"StableID":   "nP1Eu18S2R11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec9995bd7505448783656e89f5de7f189a381aaf5b4b130626174ecb91863f0d",
+				"DiscoKey":   "discokey:79cb3eb1794766782d2828864dfb1ecade0bec0ba4fb5dd542f03f538a39d44f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52587",
+					"10.65.0.27:52587",
+					"172.17.0.1:52587",
+					"172.18.0.1:52587",
+					"172.19.0.1:52587"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:32:06.535404499Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4852696183438427,
+				"StableID":   "nc5HTo6ote11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c41cd99ab18b45734a4bd15e6d39bf220698a9f726f47f5c93d48011c603fe50",
+				"DiscoKey":   "discokey:4b3b0a842bcc9b1bc8b2d1225da72f91cea42207e3eb2954d594721472e0153a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54325",
+					"10.65.0.27:54325",
+					"172.17.0.1:54325",
+					"172.18.0.1:54325",
+					"172.19.0.1:54325"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:32:07.066875559Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5405486878286675,
+				"StableID":   "nLsQDWy9Dj11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdb4ec6888811dd3a458eee71e7e82b6ba57456247cea0286a0f52a3c6177443",
+				"DiscoKey":   "discokey:d4231b2fd36ac8a22ad0af9e8e95f034a36231b6307ec8dc7678e6d786ab4f36",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60962",
+					"10.65.0.27:60962",
+					"172.17.0.1:60962",
+					"172.18.0.1:60962",
+					"172.19.0.1:60962"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:32:07.614061815Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4277392511586413,
+				"StableID":   "ntQN1CrEQa11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f43cafcc0263d4fe5fd1f00b161b34f330d2c960f19c0424a1110f6d8b3ad79",
+				"DiscoKey":   "discokey:7d91e866dc1fe26dca650c6a6eb701af91b0bb7d5de7eb58b276835ef4892301",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:32799",
+					"10.65.0.27:32799",
+					"172.17.0.1:32799",
+					"172.18.0.1:32799",
+					"172.19.0.1:32799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:32:08.153685446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6683173110387055,
+				"StableID":   "nGTCKFdpBu11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d60fd719e033c223cff1df535ebc55d2ffe15e59fc3a0382ebb031534d2e085d",
+				"KeyExpiry":  "2026-11-09T07:32:08Z",
+				"DiscoKey":   "discokey:28b724f2b015833c37572d87ea899b0bcd73343f6de96a79f40a15f374423d39",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52317",
+					"10.65.0.27:52317",
+					"172.17.0.1:52317",
+					"172.18.0.1:52317",
+					"172.19.0.1:52317"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:32:08.704629899Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2795559571658972,
+				"StableID":   "nTLQQMc7qN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:94fc225713a77b24286773baa68596b86cb37df40a7c8c052b340a5f5a41e543",
+				"KeyExpiry":  "2026-11-09T07:32:09Z",
+				"DiscoKey":   "discokey:bb93b45b3b208bc98fc8d619b60bd255990659cbc97f4149b792121589977b3b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35279",
+					"10.65.0.27:35279",
+					"172.17.0.1:35279",
+					"172.18.0.1:35279",
+					"172.19.0.1:35279"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:32:09.23308551Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8827946835332669,
+				"StableID":   "nnKNxECCwB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ff47092463a9d39dc348b889d4782dde5685606d166e0abbe3c63f60f3889473",
+				"KeyExpiry":  "2026-11-09T07:32:09Z",
+				"DiscoKey":   "discokey:38782afda7639fb498262e15fe0074722246a2c6dd317657b4a54a541a746123",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60290",
+					"10.65.0.27:60290",
+					"172.17.0.1:60290",
+					"172.18.0.1:60290",
+					"172.19.0.1:60290"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:32:09.781574364Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4744643513638242": {
+				"ID":          4744643513638242,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4485305050041784,
+				"StableID":   "nb8s4mMQ2c11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       4485305050041784,
+				"Key":        "nodekey:93c4a5bba11e6b6f85ece1cd6a8d9bafeba6497ddc12dc92ee64e1f0ca86e672",
+				"DiscoKey":   "discokey:684efa3f278e4aa7b5154dc47ccbc72353254cd5ae16601f73e50a18baf35d2d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33435",
+					"10.65.0.27:33435",
+					"172.17.0.1:33435",
+					"172.18.0.1:33435",
+					"172.19.0.1:33435"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:32:04.366260931Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:93c4a5bba11e6b6f85ece1cd6a8d9bafeba6497ddc12dc92ee64e1f0ca86e672",
+			"MachineKey": "mkey:768338dd931f2567a5fef1a0cc198faba7b4c3f43abdd692140a1e769388ca21",
+			"Peers": [{
+				"ID":         4744643513638242,
+				"StableID":   "nByq2ujr3e11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ffc63b0b4e6df3afa51bd7f23e730c1c1602c86ad9bd2ecd623163d95621936",
+				"DiscoKey":   "discokey:44cdf0dd5debdcb0493de5054a6eaa110d1dcb750c8ad80b2368659e7b056469",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50660",
+					"10.65.0.27:50660",
+					"172.17.0.1:50660",
+					"172.18.0.1:50660",
+					"172.19.0.1:50660"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:32:02.242387317Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3384024868833209,
+				"StableID":   "nGAPcWbdRT11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8bc67a918aef9757ec1c2e8cbabf91973eb4d22f720c3bd881328cea69db54e",
+				"DiscoKey":   "discokey:5ac2b886460f769df10af7db3ca534ad28bf8c87060cb7aa594e51c03b871b44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51247",
+					"10.65.0.27:51247",
+					"172.17.0.1:51247",
+					"172.18.0.1:51247",
+					"172.19.0.1:51247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:32:02.762225978Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4104100983045156,
+				"StableID":   "ndHD3smk3Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c1f230674780923dec20f5b5defac12f78b113d4c89e2b77f504b428651bf25",
+				"DiscoKey":   "discokey:0386401c3bc77d5202103f928dde326d7c9cf11a3698fc33557df03f1577a94b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60676",
+					"10.65.0.27:60676",
+					"172.17.0.1:60676",
+					"172.18.0.1:60676",
+					"172.19.0.1:60676"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:32:03.29320231Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2053553102717197,
+				"StableID":   "ni7FdkM43H11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:462d530888e4e8e815ae993eab1f79d1d4c25aebf9d5750e6190121c5c38091d",
+				"DiscoKey":   "discokey:ca86b8d2271ebd4e08bc13fbeb823ade08e37df6bbd91f45b56d9982c30fb16a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49676",
+					"10.65.0.27:49676",
+					"172.17.0.1:49676",
+					"172.18.0.1:49676",
+					"172.19.0.1:49676"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:32:03.831192155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6405819003809912,
+				"StableID":   "nw2sfA1D2s11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1ca3dbccc144b3c054256ff111274ba6fbd99ccccb1c38acb280dbd510f6595b",
+				"DiscoKey":   "discokey:26064138d413eb16852c9e78aeadaf1468c770c741a35049ce2d39676cfeed34",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40094",
+					"10.65.0.27:40094",
+					"172.17.0.1:40094",
+					"172.18.0.1:40094",
+					"172.19.0.1:40094"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:32:04.910825058Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7945506545729529,
+				"StableID":   "nWKZL4zX3521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b49d04dff8e09c0628519156c0f58abe66760419609302611c82bc6822b2dc79",
+				"DiscoKey":   "discokey:96d052db8c7e233697a52745fc029c314b692a76d229d4fdcdbd16c41f1bda19",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47320",
+					"10.65.0.27:47320",
+					"172.17.0.1:47320",
+					"172.18.0.1:47320",
+					"172.19.0.1:47320"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:32:05.446654167Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6773448591800793,
+				"StableID":   "nWDQUW1itu11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6e2453e3fbd0292765e5e97dc33dd066f25969f442fd1d9b3c4080e82d9c455",
+				"DiscoKey":   "discokey:19e8f74c660a72cba783b6ce69655c90e90bd2769161af2a08816e02a2a1751d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47027",
+					"10.65.0.27:47027",
+					"172.17.0.1:47027",
+					"172.18.0.1:47027",
+					"172.19.0.1:47027"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:32:05.987829594Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3076678267400490,
+				"StableID":   "nP1Eu18S2R11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec9995bd7505448783656e89f5de7f189a381aaf5b4b130626174ecb91863f0d",
+				"DiscoKey":   "discokey:79cb3eb1794766782d2828864dfb1ecade0bec0ba4fb5dd542f03f538a39d44f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52587",
+					"10.65.0.27:52587",
+					"172.17.0.1:52587",
+					"172.18.0.1:52587",
+					"172.19.0.1:52587"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:32:06.535404499Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4852696183438427,
+				"StableID":   "nc5HTo6ote11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c41cd99ab18b45734a4bd15e6d39bf220698a9f726f47f5c93d48011c603fe50",
+				"DiscoKey":   "discokey:4b3b0a842bcc9b1bc8b2d1225da72f91cea42207e3eb2954d594721472e0153a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54325",
+					"10.65.0.27:54325",
+					"172.17.0.1:54325",
+					"172.18.0.1:54325",
+					"172.19.0.1:54325"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:32:07.066875559Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5405486878286675,
+				"StableID":   "nLsQDWy9Dj11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdb4ec6888811dd3a458eee71e7e82b6ba57456247cea0286a0f52a3c6177443",
+				"DiscoKey":   "discokey:d4231b2fd36ac8a22ad0af9e8e95f034a36231b6307ec8dc7678e6d786ab4f36",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60962",
+					"10.65.0.27:60962",
+					"172.17.0.1:60962",
+					"172.18.0.1:60962",
+					"172.19.0.1:60962"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:32:07.614061815Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4277392511586413,
+				"StableID":   "ntQN1CrEQa11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f43cafcc0263d4fe5fd1f00b161b34f330d2c960f19c0424a1110f6d8b3ad79",
+				"DiscoKey":   "discokey:7d91e866dc1fe26dca650c6a6eb701af91b0bb7d5de7eb58b276835ef4892301",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:32799",
+					"10.65.0.27:32799",
+					"172.17.0.1:32799",
+					"172.18.0.1:32799",
+					"172.19.0.1:32799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:32:08.153685446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6683173110387055,
+				"StableID":   "nGTCKFdpBu11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d60fd719e033c223cff1df535ebc55d2ffe15e59fc3a0382ebb031534d2e085d",
+				"KeyExpiry":  "2026-11-09T07:32:08Z",
+				"DiscoKey":   "discokey:28b724f2b015833c37572d87ea899b0bcd73343f6de96a79f40a15f374423d39",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52317",
+					"10.65.0.27:52317",
+					"172.17.0.1:52317",
+					"172.18.0.1:52317",
+					"172.19.0.1:52317"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:32:08.704629899Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2795559571658972,
+				"StableID":   "nTLQQMc7qN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:94fc225713a77b24286773baa68596b86cb37df40a7c8c052b340a5f5a41e543",
+				"KeyExpiry":  "2026-11-09T07:32:09Z",
+				"DiscoKey":   "discokey:bb93b45b3b208bc98fc8d619b60bd255990659cbc97f4149b792121589977b3b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35279",
+					"10.65.0.27:35279",
+					"172.17.0.1:35279",
+					"172.18.0.1:35279",
+					"172.19.0.1:35279"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:32:09.23308551Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8827946835332669,
+				"StableID":   "nnKNxECCwB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ff47092463a9d39dc348b889d4782dde5685606d166e0abbe3c63f60f3889473",
+				"KeyExpiry":  "2026-11-09T07:32:09Z",
+				"DiscoKey":   "discokey:38782afda7639fb498262e15fe0074722246a2c6dd317657b4a54a541a746123",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60290",
+					"10.65.0.27:60290",
+					"172.17.0.1:60290",
+					"172.18.0.1:60290",
+					"172.19.0.1:60290"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:32:09.781574364Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4485305050041784": {
+				"ID":          4485305050041784,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2053553102717197,
+				"StableID":   "ni7FdkM43H11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       2053553102717197,
+				"Key":        "nodekey:462d530888e4e8e815ae993eab1f79d1d4c25aebf9d5750e6190121c5c38091d",
+				"DiscoKey":   "discokey:ca86b8d2271ebd4e08bc13fbeb823ade08e37df6bbd91f45b56d9982c30fb16a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49676",
+					"10.65.0.27:49676",
+					"172.17.0.1:49676",
+					"172.18.0.1:49676",
+					"172.19.0.1:49676"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:32:03.831192155Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:462d530888e4e8e815ae993eab1f79d1d4c25aebf9d5750e6190121c5c38091d",
+			"MachineKey": "mkey:5e76eafcc540e0b7828e0669a8de55337b24cdf4e630225e017fa02e48ad0d4d",
+			"Peers": [{
+				"ID":         4744643513638242,
+				"StableID":   "nByq2ujr3e11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ffc63b0b4e6df3afa51bd7f23e730c1c1602c86ad9bd2ecd623163d95621936",
+				"DiscoKey":   "discokey:44cdf0dd5debdcb0493de5054a6eaa110d1dcb750c8ad80b2368659e7b056469",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50660",
+					"10.65.0.27:50660",
+					"172.17.0.1:50660",
+					"172.18.0.1:50660",
+					"172.19.0.1:50660"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:32:02.242387317Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3384024868833209,
+				"StableID":   "nGAPcWbdRT11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8bc67a918aef9757ec1c2e8cbabf91973eb4d22f720c3bd881328cea69db54e",
+				"DiscoKey":   "discokey:5ac2b886460f769df10af7db3ca534ad28bf8c87060cb7aa594e51c03b871b44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51247",
+					"10.65.0.27:51247",
+					"172.17.0.1:51247",
+					"172.18.0.1:51247",
+					"172.19.0.1:51247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:32:02.762225978Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4104100983045156,
+				"StableID":   "ndHD3smk3Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c1f230674780923dec20f5b5defac12f78b113d4c89e2b77f504b428651bf25",
+				"DiscoKey":   "discokey:0386401c3bc77d5202103f928dde326d7c9cf11a3698fc33557df03f1577a94b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60676",
+					"10.65.0.27:60676",
+					"172.17.0.1:60676",
+					"172.18.0.1:60676",
+					"172.19.0.1:60676"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:32:03.29320231Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4485305050041784,
+				"StableID":   "nb8s4mMQ2c11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93c4a5bba11e6b6f85ece1cd6a8d9bafeba6497ddc12dc92ee64e1f0ca86e672",
+				"DiscoKey":   "discokey:684efa3f278e4aa7b5154dc47ccbc72353254cd5ae16601f73e50a18baf35d2d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33435",
+					"10.65.0.27:33435",
+					"172.17.0.1:33435",
+					"172.18.0.1:33435",
+					"172.19.0.1:33435"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:32:04.366260931Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6405819003809912,
+				"StableID":   "nw2sfA1D2s11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1ca3dbccc144b3c054256ff111274ba6fbd99ccccb1c38acb280dbd510f6595b",
+				"DiscoKey":   "discokey:26064138d413eb16852c9e78aeadaf1468c770c741a35049ce2d39676cfeed34",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40094",
+					"10.65.0.27:40094",
+					"172.17.0.1:40094",
+					"172.18.0.1:40094",
+					"172.19.0.1:40094"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:32:04.910825058Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7945506545729529,
+				"StableID":   "nWKZL4zX3521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b49d04dff8e09c0628519156c0f58abe66760419609302611c82bc6822b2dc79",
+				"DiscoKey":   "discokey:96d052db8c7e233697a52745fc029c314b692a76d229d4fdcdbd16c41f1bda19",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47320",
+					"10.65.0.27:47320",
+					"172.17.0.1:47320",
+					"172.18.0.1:47320",
+					"172.19.0.1:47320"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:32:05.446654167Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6773448591800793,
+				"StableID":   "nWDQUW1itu11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6e2453e3fbd0292765e5e97dc33dd066f25969f442fd1d9b3c4080e82d9c455",
+				"DiscoKey":   "discokey:19e8f74c660a72cba783b6ce69655c90e90bd2769161af2a08816e02a2a1751d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47027",
+					"10.65.0.27:47027",
+					"172.17.0.1:47027",
+					"172.18.0.1:47027",
+					"172.19.0.1:47027"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:32:05.987829594Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3076678267400490,
+				"StableID":   "nP1Eu18S2R11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec9995bd7505448783656e89f5de7f189a381aaf5b4b130626174ecb91863f0d",
+				"DiscoKey":   "discokey:79cb3eb1794766782d2828864dfb1ecade0bec0ba4fb5dd542f03f538a39d44f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52587",
+					"10.65.0.27:52587",
+					"172.17.0.1:52587",
+					"172.18.0.1:52587",
+					"172.19.0.1:52587"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:32:06.535404499Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4852696183438427,
+				"StableID":   "nc5HTo6ote11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c41cd99ab18b45734a4bd15e6d39bf220698a9f726f47f5c93d48011c603fe50",
+				"DiscoKey":   "discokey:4b3b0a842bcc9b1bc8b2d1225da72f91cea42207e3eb2954d594721472e0153a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54325",
+					"10.65.0.27:54325",
+					"172.17.0.1:54325",
+					"172.18.0.1:54325",
+					"172.19.0.1:54325"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:32:07.066875559Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5405486878286675,
+				"StableID":   "nLsQDWy9Dj11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdb4ec6888811dd3a458eee71e7e82b6ba57456247cea0286a0f52a3c6177443",
+				"DiscoKey":   "discokey:d4231b2fd36ac8a22ad0af9e8e95f034a36231b6307ec8dc7678e6d786ab4f36",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60962",
+					"10.65.0.27:60962",
+					"172.17.0.1:60962",
+					"172.18.0.1:60962",
+					"172.19.0.1:60962"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:32:07.614061815Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4277392511586413,
+				"StableID":   "ntQN1CrEQa11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f43cafcc0263d4fe5fd1f00b161b34f330d2c960f19c0424a1110f6d8b3ad79",
+				"DiscoKey":   "discokey:7d91e866dc1fe26dca650c6a6eb701af91b0bb7d5de7eb58b276835ef4892301",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:32799",
+					"10.65.0.27:32799",
+					"172.17.0.1:32799",
+					"172.18.0.1:32799",
+					"172.19.0.1:32799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:32:08.153685446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6683173110387055,
+				"StableID":   "nGTCKFdpBu11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d60fd719e033c223cff1df535ebc55d2ffe15e59fc3a0382ebb031534d2e085d",
+				"KeyExpiry":  "2026-11-09T07:32:08Z",
+				"DiscoKey":   "discokey:28b724f2b015833c37572d87ea899b0bcd73343f6de96a79f40a15f374423d39",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52317",
+					"10.65.0.27:52317",
+					"172.17.0.1:52317",
+					"172.18.0.1:52317",
+					"172.19.0.1:52317"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:32:08.704629899Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2795559571658972,
+				"StableID":   "nTLQQMc7qN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:94fc225713a77b24286773baa68596b86cb37df40a7c8c052b340a5f5a41e543",
+				"KeyExpiry":  "2026-11-09T07:32:09Z",
+				"DiscoKey":   "discokey:bb93b45b3b208bc98fc8d619b60bd255990659cbc97f4149b792121589977b3b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35279",
+					"10.65.0.27:35279",
+					"172.17.0.1:35279",
+					"172.18.0.1:35279",
+					"172.19.0.1:35279"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:32:09.23308551Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8827946835332669,
+				"StableID":   "nnKNxECCwB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ff47092463a9d39dc348b889d4782dde5685606d166e0abbe3c63f60f3889473",
+				"KeyExpiry":  "2026-11-09T07:32:09Z",
+				"DiscoKey":   "discokey:38782afda7639fb498262e15fe0074722246a2c6dd317657b4a54a541a746123",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60290",
+					"10.65.0.27:60290",
+					"172.17.0.1:60290",
+					"172.18.0.1:60290",
+					"172.19.0.1:60290"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:32:09.781574364Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2053553102717197": {
+				"ID":          2053553102717197,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7945506545729529,
+				"StableID":   "nWKZL4zX3521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       7945506545729529,
+				"Key":        "nodekey:b49d04dff8e09c0628519156c0f58abe66760419609302611c82bc6822b2dc79",
+				"DiscoKey":   "discokey:96d052db8c7e233697a52745fc029c314b692a76d229d4fdcdbd16c41f1bda19",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47320",
+					"10.65.0.27:47320",
+					"172.17.0.1:47320",
+					"172.18.0.1:47320",
+					"172.19.0.1:47320"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:32:05.446654167Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b49d04dff8e09c0628519156c0f58abe66760419609302611c82bc6822b2dc79",
+			"MachineKey": "mkey:2230fc74e7c78e96c0255f61a28e2be242f24a206031e0defd301db37b161417",
+			"Peers": [{
+				"ID":         4744643513638242,
+				"StableID":   "nByq2ujr3e11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ffc63b0b4e6df3afa51bd7f23e730c1c1602c86ad9bd2ecd623163d95621936",
+				"DiscoKey":   "discokey:44cdf0dd5debdcb0493de5054a6eaa110d1dcb750c8ad80b2368659e7b056469",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50660",
+					"10.65.0.27:50660",
+					"172.17.0.1:50660",
+					"172.18.0.1:50660",
+					"172.19.0.1:50660"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:32:02.242387317Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3384024868833209,
+				"StableID":   "nGAPcWbdRT11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8bc67a918aef9757ec1c2e8cbabf91973eb4d22f720c3bd881328cea69db54e",
+				"DiscoKey":   "discokey:5ac2b886460f769df10af7db3ca534ad28bf8c87060cb7aa594e51c03b871b44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51247",
+					"10.65.0.27:51247",
+					"172.17.0.1:51247",
+					"172.18.0.1:51247",
+					"172.19.0.1:51247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:32:02.762225978Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4104100983045156,
+				"StableID":   "ndHD3smk3Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c1f230674780923dec20f5b5defac12f78b113d4c89e2b77f504b428651bf25",
+				"DiscoKey":   "discokey:0386401c3bc77d5202103f928dde326d7c9cf11a3698fc33557df03f1577a94b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60676",
+					"10.65.0.27:60676",
+					"172.17.0.1:60676",
+					"172.18.0.1:60676",
+					"172.19.0.1:60676"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:32:03.29320231Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2053553102717197,
+				"StableID":   "ni7FdkM43H11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:462d530888e4e8e815ae993eab1f79d1d4c25aebf9d5750e6190121c5c38091d",
+				"DiscoKey":   "discokey:ca86b8d2271ebd4e08bc13fbeb823ade08e37df6bbd91f45b56d9982c30fb16a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49676",
+					"10.65.0.27:49676",
+					"172.17.0.1:49676",
+					"172.18.0.1:49676",
+					"172.19.0.1:49676"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:32:03.831192155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4485305050041784,
+				"StableID":   "nb8s4mMQ2c11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93c4a5bba11e6b6f85ece1cd6a8d9bafeba6497ddc12dc92ee64e1f0ca86e672",
+				"DiscoKey":   "discokey:684efa3f278e4aa7b5154dc47ccbc72353254cd5ae16601f73e50a18baf35d2d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33435",
+					"10.65.0.27:33435",
+					"172.17.0.1:33435",
+					"172.18.0.1:33435",
+					"172.19.0.1:33435"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:32:04.366260931Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6405819003809912,
+				"StableID":   "nw2sfA1D2s11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1ca3dbccc144b3c054256ff111274ba6fbd99ccccb1c38acb280dbd510f6595b",
+				"DiscoKey":   "discokey:26064138d413eb16852c9e78aeadaf1468c770c741a35049ce2d39676cfeed34",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40094",
+					"10.65.0.27:40094",
+					"172.17.0.1:40094",
+					"172.18.0.1:40094",
+					"172.19.0.1:40094"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:32:04.910825058Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6773448591800793,
+				"StableID":   "nWDQUW1itu11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6e2453e3fbd0292765e5e97dc33dd066f25969f442fd1d9b3c4080e82d9c455",
+				"DiscoKey":   "discokey:19e8f74c660a72cba783b6ce69655c90e90bd2769161af2a08816e02a2a1751d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47027",
+					"10.65.0.27:47027",
+					"172.17.0.1:47027",
+					"172.18.0.1:47027",
+					"172.19.0.1:47027"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:32:05.987829594Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3076678267400490,
+				"StableID":   "nP1Eu18S2R11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec9995bd7505448783656e89f5de7f189a381aaf5b4b130626174ecb91863f0d",
+				"DiscoKey":   "discokey:79cb3eb1794766782d2828864dfb1ecade0bec0ba4fb5dd542f03f538a39d44f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52587",
+					"10.65.0.27:52587",
+					"172.17.0.1:52587",
+					"172.18.0.1:52587",
+					"172.19.0.1:52587"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:32:06.535404499Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4852696183438427,
+				"StableID":   "nc5HTo6ote11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c41cd99ab18b45734a4bd15e6d39bf220698a9f726f47f5c93d48011c603fe50",
+				"DiscoKey":   "discokey:4b3b0a842bcc9b1bc8b2d1225da72f91cea42207e3eb2954d594721472e0153a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54325",
+					"10.65.0.27:54325",
+					"172.17.0.1:54325",
+					"172.18.0.1:54325",
+					"172.19.0.1:54325"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:32:07.066875559Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5405486878286675,
+				"StableID":   "nLsQDWy9Dj11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdb4ec6888811dd3a458eee71e7e82b6ba57456247cea0286a0f52a3c6177443",
+				"DiscoKey":   "discokey:d4231b2fd36ac8a22ad0af9e8e95f034a36231b6307ec8dc7678e6d786ab4f36",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60962",
+					"10.65.0.27:60962",
+					"172.17.0.1:60962",
+					"172.18.0.1:60962",
+					"172.19.0.1:60962"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:32:07.614061815Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4277392511586413,
+				"StableID":   "ntQN1CrEQa11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f43cafcc0263d4fe5fd1f00b161b34f330d2c960f19c0424a1110f6d8b3ad79",
+				"DiscoKey":   "discokey:7d91e866dc1fe26dca650c6a6eb701af91b0bb7d5de7eb58b276835ef4892301",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:32799",
+					"10.65.0.27:32799",
+					"172.17.0.1:32799",
+					"172.18.0.1:32799",
+					"172.19.0.1:32799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:32:08.153685446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6683173110387055,
+				"StableID":   "nGTCKFdpBu11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d60fd719e033c223cff1df535ebc55d2ffe15e59fc3a0382ebb031534d2e085d",
+				"KeyExpiry":  "2026-11-09T07:32:08Z",
+				"DiscoKey":   "discokey:28b724f2b015833c37572d87ea899b0bcd73343f6de96a79f40a15f374423d39",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52317",
+					"10.65.0.27:52317",
+					"172.17.0.1:52317",
+					"172.18.0.1:52317",
+					"172.19.0.1:52317"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:32:08.704629899Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2795559571658972,
+				"StableID":   "nTLQQMc7qN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:94fc225713a77b24286773baa68596b86cb37df40a7c8c052b340a5f5a41e543",
+				"KeyExpiry":  "2026-11-09T07:32:09Z",
+				"DiscoKey":   "discokey:bb93b45b3b208bc98fc8d619b60bd255990659cbc97f4149b792121589977b3b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35279",
+					"10.65.0.27:35279",
+					"172.17.0.1:35279",
+					"172.18.0.1:35279",
+					"172.19.0.1:35279"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:32:09.23308551Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8827946835332669,
+				"StableID":   "nnKNxECCwB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ff47092463a9d39dc348b889d4782dde5685606d166e0abbe3c63f60f3889473",
+				"KeyExpiry":  "2026-11-09T07:32:09Z",
+				"DiscoKey":   "discokey:38782afda7639fb498262e15fe0074722246a2c6dd317657b4a54a541a746123",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60290",
+					"10.65.0.27:60290",
+					"172.17.0.1:60290",
+					"172.18.0.1:60290",
+					"172.19.0.1:60290"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:32:09.781574364Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7945506545729529": {
+				"ID":          7945506545729529,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3076678267400490,
+				"StableID":   "nP1Eu18S2R11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       3076678267400490,
+				"Key":        "nodekey:ec9995bd7505448783656e89f5de7f189a381aaf5b4b130626174ecb91863f0d",
+				"DiscoKey":   "discokey:79cb3eb1794766782d2828864dfb1ecade0bec0ba4fb5dd542f03f538a39d44f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52587",
+					"10.65.0.27:52587",
+					"172.17.0.1:52587",
+					"172.18.0.1:52587",
+					"172.19.0.1:52587"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:32:06.535404499Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ec9995bd7505448783656e89f5de7f189a381aaf5b4b130626174ecb91863f0d",
+			"MachineKey": "mkey:abd86017d70b95c4de3a69b26d2e379f48de12b32cde84bfa1cc374bc935ef72",
+			"Peers": [{
+				"ID":         4744643513638242,
+				"StableID":   "nByq2ujr3e11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ffc63b0b4e6df3afa51bd7f23e730c1c1602c86ad9bd2ecd623163d95621936",
+				"DiscoKey":   "discokey:44cdf0dd5debdcb0493de5054a6eaa110d1dcb750c8ad80b2368659e7b056469",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50660",
+					"10.65.0.27:50660",
+					"172.17.0.1:50660",
+					"172.18.0.1:50660",
+					"172.19.0.1:50660"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:32:02.242387317Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3384024868833209,
+				"StableID":   "nGAPcWbdRT11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8bc67a918aef9757ec1c2e8cbabf91973eb4d22f720c3bd881328cea69db54e",
+				"DiscoKey":   "discokey:5ac2b886460f769df10af7db3ca534ad28bf8c87060cb7aa594e51c03b871b44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51247",
+					"10.65.0.27:51247",
+					"172.17.0.1:51247",
+					"172.18.0.1:51247",
+					"172.19.0.1:51247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:32:02.762225978Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4104100983045156,
+				"StableID":   "ndHD3smk3Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c1f230674780923dec20f5b5defac12f78b113d4c89e2b77f504b428651bf25",
+				"DiscoKey":   "discokey:0386401c3bc77d5202103f928dde326d7c9cf11a3698fc33557df03f1577a94b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60676",
+					"10.65.0.27:60676",
+					"172.17.0.1:60676",
+					"172.18.0.1:60676",
+					"172.19.0.1:60676"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:32:03.29320231Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2053553102717197,
+				"StableID":   "ni7FdkM43H11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:462d530888e4e8e815ae993eab1f79d1d4c25aebf9d5750e6190121c5c38091d",
+				"DiscoKey":   "discokey:ca86b8d2271ebd4e08bc13fbeb823ade08e37df6bbd91f45b56d9982c30fb16a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49676",
+					"10.65.0.27:49676",
+					"172.17.0.1:49676",
+					"172.18.0.1:49676",
+					"172.19.0.1:49676"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:32:03.831192155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4485305050041784,
+				"StableID":   "nb8s4mMQ2c11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93c4a5bba11e6b6f85ece1cd6a8d9bafeba6497ddc12dc92ee64e1f0ca86e672",
+				"DiscoKey":   "discokey:684efa3f278e4aa7b5154dc47ccbc72353254cd5ae16601f73e50a18baf35d2d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33435",
+					"10.65.0.27:33435",
+					"172.17.0.1:33435",
+					"172.18.0.1:33435",
+					"172.19.0.1:33435"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:32:04.366260931Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6405819003809912,
+				"StableID":   "nw2sfA1D2s11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1ca3dbccc144b3c054256ff111274ba6fbd99ccccb1c38acb280dbd510f6595b",
+				"DiscoKey":   "discokey:26064138d413eb16852c9e78aeadaf1468c770c741a35049ce2d39676cfeed34",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40094",
+					"10.65.0.27:40094",
+					"172.17.0.1:40094",
+					"172.18.0.1:40094",
+					"172.19.0.1:40094"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:32:04.910825058Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7945506545729529,
+				"StableID":   "nWKZL4zX3521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b49d04dff8e09c0628519156c0f58abe66760419609302611c82bc6822b2dc79",
+				"DiscoKey":   "discokey:96d052db8c7e233697a52745fc029c314b692a76d229d4fdcdbd16c41f1bda19",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47320",
+					"10.65.0.27:47320",
+					"172.17.0.1:47320",
+					"172.18.0.1:47320",
+					"172.19.0.1:47320"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:32:05.446654167Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6773448591800793,
+				"StableID":   "nWDQUW1itu11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6e2453e3fbd0292765e5e97dc33dd066f25969f442fd1d9b3c4080e82d9c455",
+				"DiscoKey":   "discokey:19e8f74c660a72cba783b6ce69655c90e90bd2769161af2a08816e02a2a1751d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47027",
+					"10.65.0.27:47027",
+					"172.17.0.1:47027",
+					"172.18.0.1:47027",
+					"172.19.0.1:47027"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:32:05.987829594Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4852696183438427,
+				"StableID":   "nc5HTo6ote11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c41cd99ab18b45734a4bd15e6d39bf220698a9f726f47f5c93d48011c603fe50",
+				"DiscoKey":   "discokey:4b3b0a842bcc9b1bc8b2d1225da72f91cea42207e3eb2954d594721472e0153a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54325",
+					"10.65.0.27:54325",
+					"172.17.0.1:54325",
+					"172.18.0.1:54325",
+					"172.19.0.1:54325"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:32:07.066875559Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5405486878286675,
+				"StableID":   "nLsQDWy9Dj11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdb4ec6888811dd3a458eee71e7e82b6ba57456247cea0286a0f52a3c6177443",
+				"DiscoKey":   "discokey:d4231b2fd36ac8a22ad0af9e8e95f034a36231b6307ec8dc7678e6d786ab4f36",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60962",
+					"10.65.0.27:60962",
+					"172.17.0.1:60962",
+					"172.18.0.1:60962",
+					"172.19.0.1:60962"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:32:07.614061815Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4277392511586413,
+				"StableID":   "ntQN1CrEQa11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f43cafcc0263d4fe5fd1f00b161b34f330d2c960f19c0424a1110f6d8b3ad79",
+				"DiscoKey":   "discokey:7d91e866dc1fe26dca650c6a6eb701af91b0bb7d5de7eb58b276835ef4892301",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:32799",
+					"10.65.0.27:32799",
+					"172.17.0.1:32799",
+					"172.18.0.1:32799",
+					"172.19.0.1:32799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:32:08.153685446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6683173110387055,
+				"StableID":   "nGTCKFdpBu11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d60fd719e033c223cff1df535ebc55d2ffe15e59fc3a0382ebb031534d2e085d",
+				"KeyExpiry":  "2026-11-09T07:32:08Z",
+				"DiscoKey":   "discokey:28b724f2b015833c37572d87ea899b0bcd73343f6de96a79f40a15f374423d39",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52317",
+					"10.65.0.27:52317",
+					"172.17.0.1:52317",
+					"172.18.0.1:52317",
+					"172.19.0.1:52317"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:32:08.704629899Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2795559571658972,
+				"StableID":   "nTLQQMc7qN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:94fc225713a77b24286773baa68596b86cb37df40a7c8c052b340a5f5a41e543",
+				"KeyExpiry":  "2026-11-09T07:32:09Z",
+				"DiscoKey":   "discokey:bb93b45b3b208bc98fc8d619b60bd255990659cbc97f4149b792121589977b3b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35279",
+					"10.65.0.27:35279",
+					"172.17.0.1:35279",
+					"172.18.0.1:35279",
+					"172.19.0.1:35279"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:32:09.23308551Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8827946835332669,
+				"StableID":   "nnKNxECCwB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ff47092463a9d39dc348b889d4782dde5685606d166e0abbe3c63f60f3889473",
+				"KeyExpiry":  "2026-11-09T07:32:09Z",
+				"DiscoKey":   "discokey:38782afda7639fb498262e15fe0074722246a2c6dd317657b4a54a541a746123",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60290",
+					"10.65.0.27:60290",
+					"172.17.0.1:60290",
+					"172.18.0.1:60290",
+					"172.19.0.1:60290"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:32:09.781574364Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3076678267400490": {
+				"ID":          3076678267400490,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2795559571658972,
+				"StableID":   "nTLQQMc7qN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:94fc225713a77b24286773baa68596b86cb37df40a7c8c052b340a5f5a41e543",
+				"KeyExpiry":  "2026-11-09T07:32:09Z",
+				"DiscoKey":   "discokey:bb93b45b3b208bc98fc8d619b60bd255990659cbc97f4149b792121589977b3b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35279",
+					"10.65.0.27:35279",
+					"172.17.0.1:35279",
+					"172.18.0.1:35279",
+					"172.19.0.1:35279"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:32:09.23308551Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:94fc225713a77b24286773baa68596b86cb37df40a7c8c052b340a5f5a41e543",
+			"MachineKey": "mkey:77a9ec7a267b56e0ecf1994b4df3f192d64614cb0ae3912bfb194cbf47033830",
+			"Peers": [{
+				"ID":         4744643513638242,
+				"StableID":   "nByq2ujr3e11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ffc63b0b4e6df3afa51bd7f23e730c1c1602c86ad9bd2ecd623163d95621936",
+				"DiscoKey":   "discokey:44cdf0dd5debdcb0493de5054a6eaa110d1dcb750c8ad80b2368659e7b056469",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50660",
+					"10.65.0.27:50660",
+					"172.17.0.1:50660",
+					"172.18.0.1:50660",
+					"172.19.0.1:50660"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:32:02.242387317Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3384024868833209,
+				"StableID":   "nGAPcWbdRT11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8bc67a918aef9757ec1c2e8cbabf91973eb4d22f720c3bd881328cea69db54e",
+				"DiscoKey":   "discokey:5ac2b886460f769df10af7db3ca534ad28bf8c87060cb7aa594e51c03b871b44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51247",
+					"10.65.0.27:51247",
+					"172.17.0.1:51247",
+					"172.18.0.1:51247",
+					"172.19.0.1:51247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:32:02.762225978Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4104100983045156,
+				"StableID":   "ndHD3smk3Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c1f230674780923dec20f5b5defac12f78b113d4c89e2b77f504b428651bf25",
+				"DiscoKey":   "discokey:0386401c3bc77d5202103f928dde326d7c9cf11a3698fc33557df03f1577a94b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60676",
+					"10.65.0.27:60676",
+					"172.17.0.1:60676",
+					"172.18.0.1:60676",
+					"172.19.0.1:60676"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:32:03.29320231Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2053553102717197,
+				"StableID":   "ni7FdkM43H11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:462d530888e4e8e815ae993eab1f79d1d4c25aebf9d5750e6190121c5c38091d",
+				"DiscoKey":   "discokey:ca86b8d2271ebd4e08bc13fbeb823ade08e37df6bbd91f45b56d9982c30fb16a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49676",
+					"10.65.0.27:49676",
+					"172.17.0.1:49676",
+					"172.18.0.1:49676",
+					"172.19.0.1:49676"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:32:03.831192155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4485305050041784,
+				"StableID":   "nb8s4mMQ2c11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93c4a5bba11e6b6f85ece1cd6a8d9bafeba6497ddc12dc92ee64e1f0ca86e672",
+				"DiscoKey":   "discokey:684efa3f278e4aa7b5154dc47ccbc72353254cd5ae16601f73e50a18baf35d2d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33435",
+					"10.65.0.27:33435",
+					"172.17.0.1:33435",
+					"172.18.0.1:33435",
+					"172.19.0.1:33435"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:32:04.366260931Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6405819003809912,
+				"StableID":   "nw2sfA1D2s11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1ca3dbccc144b3c054256ff111274ba6fbd99ccccb1c38acb280dbd510f6595b",
+				"DiscoKey":   "discokey:26064138d413eb16852c9e78aeadaf1468c770c741a35049ce2d39676cfeed34",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40094",
+					"10.65.0.27:40094",
+					"172.17.0.1:40094",
+					"172.18.0.1:40094",
+					"172.19.0.1:40094"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:32:04.910825058Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7945506545729529,
+				"StableID":   "nWKZL4zX3521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b49d04dff8e09c0628519156c0f58abe66760419609302611c82bc6822b2dc79",
+				"DiscoKey":   "discokey:96d052db8c7e233697a52745fc029c314b692a76d229d4fdcdbd16c41f1bda19",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47320",
+					"10.65.0.27:47320",
+					"172.17.0.1:47320",
+					"172.18.0.1:47320",
+					"172.19.0.1:47320"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:32:05.446654167Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6773448591800793,
+				"StableID":   "nWDQUW1itu11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6e2453e3fbd0292765e5e97dc33dd066f25969f442fd1d9b3c4080e82d9c455",
+				"DiscoKey":   "discokey:19e8f74c660a72cba783b6ce69655c90e90bd2769161af2a08816e02a2a1751d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47027",
+					"10.65.0.27:47027",
+					"172.17.0.1:47027",
+					"172.18.0.1:47027",
+					"172.19.0.1:47027"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:32:05.987829594Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3076678267400490,
+				"StableID":   "nP1Eu18S2R11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec9995bd7505448783656e89f5de7f189a381aaf5b4b130626174ecb91863f0d",
+				"DiscoKey":   "discokey:79cb3eb1794766782d2828864dfb1ecade0bec0ba4fb5dd542f03f538a39d44f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52587",
+					"10.65.0.27:52587",
+					"172.17.0.1:52587",
+					"172.18.0.1:52587",
+					"172.19.0.1:52587"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:32:06.535404499Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4852696183438427,
+				"StableID":   "nc5HTo6ote11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c41cd99ab18b45734a4bd15e6d39bf220698a9f726f47f5c93d48011c603fe50",
+				"DiscoKey":   "discokey:4b3b0a842bcc9b1bc8b2d1225da72f91cea42207e3eb2954d594721472e0153a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54325",
+					"10.65.0.27:54325",
+					"172.17.0.1:54325",
+					"172.18.0.1:54325",
+					"172.19.0.1:54325"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:32:07.066875559Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5405486878286675,
+				"StableID":   "nLsQDWy9Dj11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdb4ec6888811dd3a458eee71e7e82b6ba57456247cea0286a0f52a3c6177443",
+				"DiscoKey":   "discokey:d4231b2fd36ac8a22ad0af9e8e95f034a36231b6307ec8dc7678e6d786ab4f36",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60962",
+					"10.65.0.27:60962",
+					"172.17.0.1:60962",
+					"172.18.0.1:60962",
+					"172.19.0.1:60962"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:32:07.614061815Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4277392511586413,
+				"StableID":   "ntQN1CrEQa11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f43cafcc0263d4fe5fd1f00b161b34f330d2c960f19c0424a1110f6d8b3ad79",
+				"DiscoKey":   "discokey:7d91e866dc1fe26dca650c6a6eb701af91b0bb7d5de7eb58b276835ef4892301",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:32799",
+					"10.65.0.27:32799",
+					"172.17.0.1:32799",
+					"172.18.0.1:32799",
+					"172.19.0.1:32799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:32:08.153685446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6683173110387055,
+				"StableID":   "nGTCKFdpBu11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d60fd719e033c223cff1df535ebc55d2ffe15e59fc3a0382ebb031534d2e085d",
+				"KeyExpiry":  "2026-11-09T07:32:08Z",
+				"DiscoKey":   "discokey:28b724f2b015833c37572d87ea899b0bcd73343f6de96a79f40a15f374423d39",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52317",
+					"10.65.0.27:52317",
+					"172.17.0.1:52317",
+					"172.18.0.1:52317",
+					"172.19.0.1:52317"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:32:08.704629899Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8827946835332669,
+				"StableID":   "nnKNxECCwB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ff47092463a9d39dc348b889d4782dde5685606d166e0abbe3c63f60f3889473",
+				"KeyExpiry":  "2026-11-09T07:32:09Z",
+				"DiscoKey":   "discokey:38782afda7639fb498262e15fe0074722246a2c6dd317657b4a54a541a746123",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60290",
+					"10.65.0.27:60290",
+					"172.17.0.1:60290",
+					"172.18.0.1:60290",
+					"172.19.0.1:60290"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:32:09.781574364Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4852696183438427,
+				"StableID":   "nc5HTo6ote11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       4852696183438427,
+				"Key":        "nodekey:c41cd99ab18b45734a4bd15e6d39bf220698a9f726f47f5c93d48011c603fe50",
+				"DiscoKey":   "discokey:4b3b0a842bcc9b1bc8b2d1225da72f91cea42207e3eb2954d594721472e0153a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54325",
+					"10.65.0.27:54325",
+					"172.17.0.1:54325",
+					"172.18.0.1:54325",
+					"172.19.0.1:54325"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:32:07.066875559Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c41cd99ab18b45734a4bd15e6d39bf220698a9f726f47f5c93d48011c603fe50",
+			"MachineKey": "mkey:6ddae0ac94c721f64e9a8faac16d2153c2f6149245941b1cf2cbd05b7999686d",
+			"Peers": [{
+				"ID":         4744643513638242,
+				"StableID":   "nByq2ujr3e11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ffc63b0b4e6df3afa51bd7f23e730c1c1602c86ad9bd2ecd623163d95621936",
+				"DiscoKey":   "discokey:44cdf0dd5debdcb0493de5054a6eaa110d1dcb750c8ad80b2368659e7b056469",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50660",
+					"10.65.0.27:50660",
+					"172.17.0.1:50660",
+					"172.18.0.1:50660",
+					"172.19.0.1:50660"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:32:02.242387317Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3384024868833209,
+				"StableID":   "nGAPcWbdRT11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8bc67a918aef9757ec1c2e8cbabf91973eb4d22f720c3bd881328cea69db54e",
+				"DiscoKey":   "discokey:5ac2b886460f769df10af7db3ca534ad28bf8c87060cb7aa594e51c03b871b44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51247",
+					"10.65.0.27:51247",
+					"172.17.0.1:51247",
+					"172.18.0.1:51247",
+					"172.19.0.1:51247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:32:02.762225978Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4104100983045156,
+				"StableID":   "ndHD3smk3Z11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c1f230674780923dec20f5b5defac12f78b113d4c89e2b77f504b428651bf25",
+				"DiscoKey":   "discokey:0386401c3bc77d5202103f928dde326d7c9cf11a3698fc33557df03f1577a94b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60676",
+					"10.65.0.27:60676",
+					"172.17.0.1:60676",
+					"172.18.0.1:60676",
+					"172.19.0.1:60676"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:32:03.29320231Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2053553102717197,
+				"StableID":   "ni7FdkM43H11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:462d530888e4e8e815ae993eab1f79d1d4c25aebf9d5750e6190121c5c38091d",
+				"DiscoKey":   "discokey:ca86b8d2271ebd4e08bc13fbeb823ade08e37df6bbd91f45b56d9982c30fb16a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49676",
+					"10.65.0.27:49676",
+					"172.17.0.1:49676",
+					"172.18.0.1:49676",
+					"172.19.0.1:49676"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:32:03.831192155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4485305050041784,
+				"StableID":   "nb8s4mMQ2c11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93c4a5bba11e6b6f85ece1cd6a8d9bafeba6497ddc12dc92ee64e1f0ca86e672",
+				"DiscoKey":   "discokey:684efa3f278e4aa7b5154dc47ccbc72353254cd5ae16601f73e50a18baf35d2d",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33435",
+					"10.65.0.27:33435",
+					"172.17.0.1:33435",
+					"172.18.0.1:33435",
+					"172.19.0.1:33435"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:32:04.366260931Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6405819003809912,
+				"StableID":   "nw2sfA1D2s11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1ca3dbccc144b3c054256ff111274ba6fbd99ccccb1c38acb280dbd510f6595b",
+				"DiscoKey":   "discokey:26064138d413eb16852c9e78aeadaf1468c770c741a35049ce2d39676cfeed34",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40094",
+					"10.65.0.27:40094",
+					"172.17.0.1:40094",
+					"172.18.0.1:40094",
+					"172.19.0.1:40094"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:32:04.910825058Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7945506545729529,
+				"StableID":   "nWKZL4zX3521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b49d04dff8e09c0628519156c0f58abe66760419609302611c82bc6822b2dc79",
+				"DiscoKey":   "discokey:96d052db8c7e233697a52745fc029c314b692a76d229d4fdcdbd16c41f1bda19",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47320",
+					"10.65.0.27:47320",
+					"172.17.0.1:47320",
+					"172.18.0.1:47320",
+					"172.19.0.1:47320"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:32:05.446654167Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6773448591800793,
+				"StableID":   "nWDQUW1itu11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f6e2453e3fbd0292765e5e97dc33dd066f25969f442fd1d9b3c4080e82d9c455",
+				"DiscoKey":   "discokey:19e8f74c660a72cba783b6ce69655c90e90bd2769161af2a08816e02a2a1751d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47027",
+					"10.65.0.27:47027",
+					"172.17.0.1:47027",
+					"172.18.0.1:47027",
+					"172.19.0.1:47027"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:32:05.987829594Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3076678267400490,
+				"StableID":   "nP1Eu18S2R11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec9995bd7505448783656e89f5de7f189a381aaf5b4b130626174ecb91863f0d",
+				"DiscoKey":   "discokey:79cb3eb1794766782d2828864dfb1ecade0bec0ba4fb5dd542f03f538a39d44f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52587",
+					"10.65.0.27:52587",
+					"172.17.0.1:52587",
+					"172.18.0.1:52587",
+					"172.19.0.1:52587"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:32:06.535404499Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5405486878286675,
+				"StableID":   "nLsQDWy9Dj11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdb4ec6888811dd3a458eee71e7e82b6ba57456247cea0286a0f52a3c6177443",
+				"DiscoKey":   "discokey:d4231b2fd36ac8a22ad0af9e8e95f034a36231b6307ec8dc7678e6d786ab4f36",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60962",
+					"10.65.0.27:60962",
+					"172.17.0.1:60962",
+					"172.18.0.1:60962",
+					"172.19.0.1:60962"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:32:07.614061815Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4277392511586413,
+				"StableID":   "ntQN1CrEQa11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f43cafcc0263d4fe5fd1f00b161b34f330d2c960f19c0424a1110f6d8b3ad79",
+				"DiscoKey":   "discokey:7d91e866dc1fe26dca650c6a6eb701af91b0bb7d5de7eb58b276835ef4892301",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:32799",
+					"10.65.0.27:32799",
+					"172.17.0.1:32799",
+					"172.18.0.1:32799",
+					"172.19.0.1:32799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:32:08.153685446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6683173110387055,
+				"StableID":   "nGTCKFdpBu11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d60fd719e033c223cff1df535ebc55d2ffe15e59fc3a0382ebb031534d2e085d",
+				"KeyExpiry":  "2026-11-09T07:32:08Z",
+				"DiscoKey":   "discokey:28b724f2b015833c37572d87ea899b0bcd73343f6de96a79f40a15f374423d39",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52317",
+					"10.65.0.27:52317",
+					"172.17.0.1:52317",
+					"172.18.0.1:52317",
+					"172.19.0.1:52317"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:32:08.704629899Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2795559571658972,
+				"StableID":   "nTLQQMc7qN11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:94fc225713a77b24286773baa68596b86cb37df40a7c8c052b340a5f5a41e543",
+				"KeyExpiry":  "2026-11-09T07:32:09Z",
+				"DiscoKey":   "discokey:bb93b45b3b208bc98fc8d619b60bd255990659cbc97f4149b792121589977b3b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35279",
+					"10.65.0.27:35279",
+					"172.17.0.1:35279",
+					"172.18.0.1:35279",
+					"172.19.0.1:35279"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:32:09.23308551Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8827946835332669,
+				"StableID":   "nnKNxECCwB21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ff47092463a9d39dc348b889d4782dde5685606d166e0abbe3c63f60f3889473",
+				"KeyExpiry":  "2026-11-09T07:32:09Z",
+				"DiscoKey":   "discokey:38782afda7639fb498262e15fe0074722246a2c6dd317657b4a54a541a746123",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:60290",
+					"10.65.0.27:60290",
+					"172.17.0.1:60290",
+					"172.18.0.1:60290",
+					"172.19.0.1:60290"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:32:09.781574364Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4852696183438427": {
+				"ID":          4852696183438427,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-users-mixed-valid-wildcard.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-malformed-users-mixed-valid-wildcard.hujson
@@ -1,0 +1,20081 @@
+// ssh-malformed-users-mixed-valid-wildcard
+//
+// ssh users with valid and wildcard
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-13T07:32:45Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-malformed-users-mixed-valid-wildcard",
+	"description":    "ssh users with valid and wildcard",
+	"category":       "ssh",
+	"captured_at":    "2026-05-13T07:32:45.796657953Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "user \"*\" is not valid"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                           \n  \n                                                                    \n                                                        \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh users with valid and wildcard\",\n\t\"id\":          \"ssh-malformed-users-mixed-valid-wildcard\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"autogroup:member\"],\n\t\t\"users\":  [\"root\", \"*\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-edge/ssh-malformed-users-mixed-valid-wildcard.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["autogroup:member"],
+				"users":  ["root", "*"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6564724472241463,
+				"StableID":   "nLMcmSBBGt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       6564724472241463,
+				"Key":        "nodekey:dc14de9d9a162689136fd28faf374183af616d0481ed3b3b003309031eb21b59",
+				"DiscoKey":   "discokey:03c884c386c36199ff796cc107e227843c310c4813f4b1c7bd33a4f29cb5eb0d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54984",
+					"10.65.0.27:54984",
+					"172.17.0.1:54984",
+					"172.18.0.1:54984",
+					"172.19.0.1:54984"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:32:54.299382606Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:dc14de9d9a162689136fd28faf374183af616d0481ed3b3b003309031eb21b59",
+			"MachineKey": "mkey:6a7cc4b8202225b9ae6984b54c4b337687bee74ba50c0166d8c324027e28ca7a",
+			"Peers": [{
+				"ID":         5359816779709991,
+				"StableID":   "ntMazHJUri11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eea0922ab286de3f730174cc71b6bc83d2867280d7b08a8f4edcfa61e34e3d3f",
+				"DiscoKey":   "discokey:4d0af95b4695ff00c47133467ec638f55468c24cbc2cef0efadb637a7256ae29",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52490",
+					"10.65.0.27:52490",
+					"172.17.0.1:52490",
+					"172.18.0.1:52490",
+					"172.19.0.1:52490"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:32:48.344790394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4137245329573985,
+				"StableID":   "ngciSKRmJZ11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a0b89ca4434405d36415735c8d612e4631a07e94543036b59a2311055083b00",
+				"DiscoKey":   "discokey:18e326a1803ea7fe98767ae3c00feecb5818a6a25b989214544062560e759d25",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42085",
+					"10.65.0.27:42085",
+					"172.17.0.1:42085",
+					"172.18.0.1:42085",
+					"172.19.0.1:42085"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:32:48.882592345Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8063101005441181,
+				"StableID":   "nA9Q4Uznx521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b50379d3461d041fea143c416d7be57342c67769059f3317a43f5a5421906f7b",
+				"DiscoKey":   "discokey:852103a463b3f7b46da87ae39fe35475d8af6b1a645d7e1658597724745b8c7d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35008",
+					"10.65.0.27:35008",
+					"172.17.0.1:35008",
+					"172.18.0.1:35008",
+					"172.19.0.1:35008"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:32:49.431864299Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1481967211625628,
+				"StableID":   "nXzWjQmBaC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:74c8aabc46d926dd1ac0fec904116305916c4fb4baab969c6d9806b5390e5d53",
+				"DiscoKey":   "discokey:9b280551710a3d62f04fe3c438f42b997b9ddb6efa7e404489159b9c4e3c145c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51035",
+					"10.65.0.27:51035",
+					"172.17.0.1:51035",
+					"172.18.0.1:51035",
+					"172.19.0.1:51035"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:32:49.973753515Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6975276302435565,
+				"StableID":   "n86p8Ug7Uw11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc9c8eba05af20517d5c6eeb184d56912a24178dda43bf1245ab48e49cf71b4c",
+				"DiscoKey":   "discokey:d216db9bcccd11a2838ccc6d59122831caf0670d7f2c8f33a76fb45a89c85d39",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57073",
+					"10.65.0.27:57073",
+					"172.17.0.1:57073",
+					"172.18.0.1:57073",
+					"172.19.0.1:57073"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:32:50.515690657Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5344740924395709,
+				"StableID":   "nULSHJHeji11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f42070dd2bcfb21164fc887e3063d737e6f907316243017a0ffc971cbc65574",
+				"DiscoKey":   "discokey:cf3ab951412e97b9eb904a1cd872f5d40c2ec374890a2e0cc52e2bca298e8404",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58527",
+					"10.65.0.27:58527",
+					"172.17.0.1:58527",
+					"172.18.0.1:58527",
+					"172.19.0.1:58527"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:32:51.050087982Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1257759953096300,
+				"StableID":   "nqoP4qDepA11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36bb870f8dc9e3803dc5a37baf2a64de33990f745ac8076b7ebfa3a5729ea639",
+				"DiscoKey":   "discokey:6945d861c12cc14d5d6e41a7aa40a9ba904d42265dc1ca5932bb440e89ac1470",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43972",
+					"10.65.0.27:43972",
+					"172.17.0.1:43972",
+					"172.18.0.1:43972",
+					"172.19.0.1:43972"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:32:51.590602748Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8013214272394711,
+				"StableID":   "n47jHxYCa521CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e08800c88148323eae3efc28d31e38eb34fc12eae2fcac549b34b44f0e0d0f66",
+				"DiscoKey":   "discokey:e0e25df51244d5685e127a8bbe126ed57fc782b70f19a8a795729e1a72606764",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36646",
+					"10.65.0.27:36646",
+					"172.17.0.1:36646",
+					"172.18.0.1:36646",
+					"172.19.0.1:36646"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:32:52.14345186Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3989811399952650,
+				"StableID":   "nZAuwdaz9Y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:572ee63a2622e7ac1f246f513bd82acd45d9fd1decd423ef835da858e5e9230f",
+				"DiscoKey":   "discokey:2b44621e0ff36d09e6b3686f29bf998a09163728cb0930951965e637a4e5ac6d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45347",
+					"10.65.0.27:45347",
+					"172.17.0.1:45347",
+					"172.18.0.1:45347",
+					"172.19.0.1:45347"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:32:52.679012032Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6041340428675552,
+				"StableID":   "nRTr5bm8Bp11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4d896e34487b494e68ccf954fb75267a6851c0ecc22d5b5ebec21eb2ca3366e",
+				"DiscoKey":   "discokey:678b539cbdbc1dd2b3b4420ec6b4c535d71a1b91fbdc34e55c6bf307cd16c137",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40268",
+					"10.65.0.27:40268",
+					"172.17.0.1:40268",
+					"172.18.0.1:40268",
+					"172.19.0.1:40268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:32:53.223586723Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5306201310471235,
+				"StableID":   "nNaGapuBSi11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee75185e044fb8c7785b8daf8a961311584ad07e080267742eedbde37bfd9137",
+				"DiscoKey":   "discokey:3bb418b636311b3b591f9f12e07995def4d12875626d23854bf5ea9d3e334d50",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55405",
+					"10.65.0.27:55405",
+					"172.17.0.1:55405",
+					"172.18.0.1:55405",
+					"172.19.0.1:55405"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:32:53.741071785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6059396706062051,
+				"StableID":   "nrCAVS5KKp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:94109679f6d34bbd8c79bdca9580cc4953b5a4539aa7a4cdbc46ad4b80c99733",
+				"KeyExpiry":  "2026-11-09T07:32:54Z",
+				"DiscoKey":   "discokey:fdc014d1d66e2d2f1608eb70e2d4ecbdef7451ed1c1b117e3fd94bda6e0cb679",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41881",
+					"10.65.0.27:41881",
+					"172.17.0.1:41881",
+					"172.18.0.1:41881",
+					"172.19.0.1:41881"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:32:54.862730909Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1677361396784083,
+				"StableID":   "nCRDnVSg6E11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:143d4f75f8ea8d8312de1d5855f0f9cb4ab5d3f93ebbb82201f2f77306639f37",
+				"KeyExpiry":  "2026-11-09T07:32:55Z",
+				"DiscoKey":   "discokey:892b260f0287567cb61ed29eb410b3bd51c0e5191a7f306baee683a77f179a3e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41785",
+					"10.65.0.27:41785",
+					"172.17.0.1:41785",
+					"172.18.0.1:41785",
+					"172.19.0.1:41785"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:32:55.363770604Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6926875846217797,
+				"StableID":   "nr7PZPHC6w11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:50539aad140a60a1b705ba3e01a36baa1c38c1eaacef8391912d0576bf609915",
+				"KeyExpiry":  "2026-11-09T07:32:55Z",
+				"DiscoKey":   "discokey:b49a52d37618740ef20f2205dadb426f1a98a98f5fc85352f4763668ea5ee85f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50973",
+					"10.65.0.27:50973",
+					"172.17.0.1:50973",
+					"172.18.0.1:50973",
+					"172.19.0.1:50973"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:32:55.977789285Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6564724472241463": {
+				"ID":          6564724472241463,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5344740924395709,
+				"StableID":   "nULSHJHeji11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       5344740924395709,
+				"Key":        "nodekey:4f42070dd2bcfb21164fc887e3063d737e6f907316243017a0ffc971cbc65574",
+				"DiscoKey":   "discokey:cf3ab951412e97b9eb904a1cd872f5d40c2ec374890a2e0cc52e2bca298e8404",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58527",
+					"10.65.0.27:58527",
+					"172.17.0.1:58527",
+					"172.18.0.1:58527",
+					"172.19.0.1:58527"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:32:51.050087982Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4f42070dd2bcfb21164fc887e3063d737e6f907316243017a0ffc971cbc65574",
+			"MachineKey": "mkey:421aae7f41ac42f704abc72f0b0140ef36c00f831f8e663607ded991451b0101",
+			"Peers": [{
+				"ID":         5359816779709991,
+				"StableID":   "ntMazHJUri11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eea0922ab286de3f730174cc71b6bc83d2867280d7b08a8f4edcfa61e34e3d3f",
+				"DiscoKey":   "discokey:4d0af95b4695ff00c47133467ec638f55468c24cbc2cef0efadb637a7256ae29",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52490",
+					"10.65.0.27:52490",
+					"172.17.0.1:52490",
+					"172.18.0.1:52490",
+					"172.19.0.1:52490"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:32:48.344790394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4137245329573985,
+				"StableID":   "ngciSKRmJZ11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a0b89ca4434405d36415735c8d612e4631a07e94543036b59a2311055083b00",
+				"DiscoKey":   "discokey:18e326a1803ea7fe98767ae3c00feecb5818a6a25b989214544062560e759d25",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42085",
+					"10.65.0.27:42085",
+					"172.17.0.1:42085",
+					"172.18.0.1:42085",
+					"172.19.0.1:42085"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:32:48.882592345Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8063101005441181,
+				"StableID":   "nA9Q4Uznx521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b50379d3461d041fea143c416d7be57342c67769059f3317a43f5a5421906f7b",
+				"DiscoKey":   "discokey:852103a463b3f7b46da87ae39fe35475d8af6b1a645d7e1658597724745b8c7d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35008",
+					"10.65.0.27:35008",
+					"172.17.0.1:35008",
+					"172.18.0.1:35008",
+					"172.19.0.1:35008"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:32:49.431864299Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1481967211625628,
+				"StableID":   "nXzWjQmBaC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:74c8aabc46d926dd1ac0fec904116305916c4fb4baab969c6d9806b5390e5d53",
+				"DiscoKey":   "discokey:9b280551710a3d62f04fe3c438f42b997b9ddb6efa7e404489159b9c4e3c145c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51035",
+					"10.65.0.27:51035",
+					"172.17.0.1:51035",
+					"172.18.0.1:51035",
+					"172.19.0.1:51035"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:32:49.973753515Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6975276302435565,
+				"StableID":   "n86p8Ug7Uw11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc9c8eba05af20517d5c6eeb184d56912a24178dda43bf1245ab48e49cf71b4c",
+				"DiscoKey":   "discokey:d216db9bcccd11a2838ccc6d59122831caf0670d7f2c8f33a76fb45a89c85d39",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57073",
+					"10.65.0.27:57073",
+					"172.17.0.1:57073",
+					"172.18.0.1:57073",
+					"172.19.0.1:57073"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:32:50.515690657Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1257759953096300,
+				"StableID":   "nqoP4qDepA11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36bb870f8dc9e3803dc5a37baf2a64de33990f745ac8076b7ebfa3a5729ea639",
+				"DiscoKey":   "discokey:6945d861c12cc14d5d6e41a7aa40a9ba904d42265dc1ca5932bb440e89ac1470",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43972",
+					"10.65.0.27:43972",
+					"172.17.0.1:43972",
+					"172.18.0.1:43972",
+					"172.19.0.1:43972"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:32:51.590602748Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8013214272394711,
+				"StableID":   "n47jHxYCa521CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e08800c88148323eae3efc28d31e38eb34fc12eae2fcac549b34b44f0e0d0f66",
+				"DiscoKey":   "discokey:e0e25df51244d5685e127a8bbe126ed57fc782b70f19a8a795729e1a72606764",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36646",
+					"10.65.0.27:36646",
+					"172.17.0.1:36646",
+					"172.18.0.1:36646",
+					"172.19.0.1:36646"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:32:52.14345186Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3989811399952650,
+				"StableID":   "nZAuwdaz9Y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:572ee63a2622e7ac1f246f513bd82acd45d9fd1decd423ef835da858e5e9230f",
+				"DiscoKey":   "discokey:2b44621e0ff36d09e6b3686f29bf998a09163728cb0930951965e637a4e5ac6d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45347",
+					"10.65.0.27:45347",
+					"172.17.0.1:45347",
+					"172.18.0.1:45347",
+					"172.19.0.1:45347"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:32:52.679012032Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6041340428675552,
+				"StableID":   "nRTr5bm8Bp11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4d896e34487b494e68ccf954fb75267a6851c0ecc22d5b5ebec21eb2ca3366e",
+				"DiscoKey":   "discokey:678b539cbdbc1dd2b3b4420ec6b4c535d71a1b91fbdc34e55c6bf307cd16c137",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40268",
+					"10.65.0.27:40268",
+					"172.17.0.1:40268",
+					"172.18.0.1:40268",
+					"172.19.0.1:40268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:32:53.223586723Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5306201310471235,
+				"StableID":   "nNaGapuBSi11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee75185e044fb8c7785b8daf8a961311584ad07e080267742eedbde37bfd9137",
+				"DiscoKey":   "discokey:3bb418b636311b3b591f9f12e07995def4d12875626d23854bf5ea9d3e334d50",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55405",
+					"10.65.0.27:55405",
+					"172.17.0.1:55405",
+					"172.18.0.1:55405",
+					"172.19.0.1:55405"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:32:53.741071785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6564724472241463,
+				"StableID":   "nLMcmSBBGt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc14de9d9a162689136fd28faf374183af616d0481ed3b3b003309031eb21b59",
+				"DiscoKey":   "discokey:03c884c386c36199ff796cc107e227843c310c4813f4b1c7bd33a4f29cb5eb0d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54984",
+					"10.65.0.27:54984",
+					"172.17.0.1:54984",
+					"172.18.0.1:54984",
+					"172.19.0.1:54984"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:32:54.299382606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6059396706062051,
+				"StableID":   "nrCAVS5KKp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:94109679f6d34bbd8c79bdca9580cc4953b5a4539aa7a4cdbc46ad4b80c99733",
+				"KeyExpiry":  "2026-11-09T07:32:54Z",
+				"DiscoKey":   "discokey:fdc014d1d66e2d2f1608eb70e2d4ecbdef7451ed1c1b117e3fd94bda6e0cb679",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41881",
+					"10.65.0.27:41881",
+					"172.17.0.1:41881",
+					"172.18.0.1:41881",
+					"172.19.0.1:41881"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:32:54.862730909Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1677361396784083,
+				"StableID":   "nCRDnVSg6E11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:143d4f75f8ea8d8312de1d5855f0f9cb4ab5d3f93ebbb82201f2f77306639f37",
+				"KeyExpiry":  "2026-11-09T07:32:55Z",
+				"DiscoKey":   "discokey:892b260f0287567cb61ed29eb410b3bd51c0e5191a7f306baee683a77f179a3e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41785",
+					"10.65.0.27:41785",
+					"172.17.0.1:41785",
+					"172.18.0.1:41785",
+					"172.19.0.1:41785"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:32:55.363770604Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6926875846217797,
+				"StableID":   "nr7PZPHC6w11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:50539aad140a60a1b705ba3e01a36baa1c38c1eaacef8391912d0576bf609915",
+				"KeyExpiry":  "2026-11-09T07:32:55Z",
+				"DiscoKey":   "discokey:b49a52d37618740ef20f2205dadb426f1a98a98f5fc85352f4763668ea5ee85f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50973",
+					"10.65.0.27:50973",
+					"172.17.0.1:50973",
+					"172.18.0.1:50973",
+					"172.19.0.1:50973"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:32:55.977789285Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5344740924395709": {
+				"ID":          5344740924395709,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6926875846217797,
+				"StableID":   "nr7PZPHC6w11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:50539aad140a60a1b705ba3e01a36baa1c38c1eaacef8391912d0576bf609915",
+				"KeyExpiry":  "2026-11-09T07:32:55Z",
+				"DiscoKey":   "discokey:b49a52d37618740ef20f2205dadb426f1a98a98f5fc85352f4763668ea5ee85f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50973",
+					"10.65.0.27:50973",
+					"172.17.0.1:50973",
+					"172.18.0.1:50973",
+					"172.19.0.1:50973"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:32:55.977789285Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:50539aad140a60a1b705ba3e01a36baa1c38c1eaacef8391912d0576bf609915",
+			"MachineKey": "mkey:3a10bc7c44f2cbc8af3e2f7884fa643946266fe8ac1af1852013fb379946370b",
+			"Peers": [{
+				"ID":         5359816779709991,
+				"StableID":   "ntMazHJUri11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eea0922ab286de3f730174cc71b6bc83d2867280d7b08a8f4edcfa61e34e3d3f",
+				"DiscoKey":   "discokey:4d0af95b4695ff00c47133467ec638f55468c24cbc2cef0efadb637a7256ae29",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52490",
+					"10.65.0.27:52490",
+					"172.17.0.1:52490",
+					"172.18.0.1:52490",
+					"172.19.0.1:52490"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:32:48.344790394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4137245329573985,
+				"StableID":   "ngciSKRmJZ11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a0b89ca4434405d36415735c8d612e4631a07e94543036b59a2311055083b00",
+				"DiscoKey":   "discokey:18e326a1803ea7fe98767ae3c00feecb5818a6a25b989214544062560e759d25",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42085",
+					"10.65.0.27:42085",
+					"172.17.0.1:42085",
+					"172.18.0.1:42085",
+					"172.19.0.1:42085"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:32:48.882592345Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8063101005441181,
+				"StableID":   "nA9Q4Uznx521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b50379d3461d041fea143c416d7be57342c67769059f3317a43f5a5421906f7b",
+				"DiscoKey":   "discokey:852103a463b3f7b46da87ae39fe35475d8af6b1a645d7e1658597724745b8c7d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35008",
+					"10.65.0.27:35008",
+					"172.17.0.1:35008",
+					"172.18.0.1:35008",
+					"172.19.0.1:35008"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:32:49.431864299Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1481967211625628,
+				"StableID":   "nXzWjQmBaC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:74c8aabc46d926dd1ac0fec904116305916c4fb4baab969c6d9806b5390e5d53",
+				"DiscoKey":   "discokey:9b280551710a3d62f04fe3c438f42b997b9ddb6efa7e404489159b9c4e3c145c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51035",
+					"10.65.0.27:51035",
+					"172.17.0.1:51035",
+					"172.18.0.1:51035",
+					"172.19.0.1:51035"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:32:49.973753515Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6975276302435565,
+				"StableID":   "n86p8Ug7Uw11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc9c8eba05af20517d5c6eeb184d56912a24178dda43bf1245ab48e49cf71b4c",
+				"DiscoKey":   "discokey:d216db9bcccd11a2838ccc6d59122831caf0670d7f2c8f33a76fb45a89c85d39",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57073",
+					"10.65.0.27:57073",
+					"172.17.0.1:57073",
+					"172.18.0.1:57073",
+					"172.19.0.1:57073"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:32:50.515690657Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5344740924395709,
+				"StableID":   "nULSHJHeji11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f42070dd2bcfb21164fc887e3063d737e6f907316243017a0ffc971cbc65574",
+				"DiscoKey":   "discokey:cf3ab951412e97b9eb904a1cd872f5d40c2ec374890a2e0cc52e2bca298e8404",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58527",
+					"10.65.0.27:58527",
+					"172.17.0.1:58527",
+					"172.18.0.1:58527",
+					"172.19.0.1:58527"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:32:51.050087982Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1257759953096300,
+				"StableID":   "nqoP4qDepA11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36bb870f8dc9e3803dc5a37baf2a64de33990f745ac8076b7ebfa3a5729ea639",
+				"DiscoKey":   "discokey:6945d861c12cc14d5d6e41a7aa40a9ba904d42265dc1ca5932bb440e89ac1470",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43972",
+					"10.65.0.27:43972",
+					"172.17.0.1:43972",
+					"172.18.0.1:43972",
+					"172.19.0.1:43972"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:32:51.590602748Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8013214272394711,
+				"StableID":   "n47jHxYCa521CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e08800c88148323eae3efc28d31e38eb34fc12eae2fcac549b34b44f0e0d0f66",
+				"DiscoKey":   "discokey:e0e25df51244d5685e127a8bbe126ed57fc782b70f19a8a795729e1a72606764",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36646",
+					"10.65.0.27:36646",
+					"172.17.0.1:36646",
+					"172.18.0.1:36646",
+					"172.19.0.1:36646"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:32:52.14345186Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3989811399952650,
+				"StableID":   "nZAuwdaz9Y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:572ee63a2622e7ac1f246f513bd82acd45d9fd1decd423ef835da858e5e9230f",
+				"DiscoKey":   "discokey:2b44621e0ff36d09e6b3686f29bf998a09163728cb0930951965e637a4e5ac6d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45347",
+					"10.65.0.27:45347",
+					"172.17.0.1:45347",
+					"172.18.0.1:45347",
+					"172.19.0.1:45347"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:32:52.679012032Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6041340428675552,
+				"StableID":   "nRTr5bm8Bp11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4d896e34487b494e68ccf954fb75267a6851c0ecc22d5b5ebec21eb2ca3366e",
+				"DiscoKey":   "discokey:678b539cbdbc1dd2b3b4420ec6b4c535d71a1b91fbdc34e55c6bf307cd16c137",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40268",
+					"10.65.0.27:40268",
+					"172.17.0.1:40268",
+					"172.18.0.1:40268",
+					"172.19.0.1:40268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:32:53.223586723Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5306201310471235,
+				"StableID":   "nNaGapuBSi11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee75185e044fb8c7785b8daf8a961311584ad07e080267742eedbde37bfd9137",
+				"DiscoKey":   "discokey:3bb418b636311b3b591f9f12e07995def4d12875626d23854bf5ea9d3e334d50",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55405",
+					"10.65.0.27:55405",
+					"172.17.0.1:55405",
+					"172.18.0.1:55405",
+					"172.19.0.1:55405"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:32:53.741071785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6564724472241463,
+				"StableID":   "nLMcmSBBGt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc14de9d9a162689136fd28faf374183af616d0481ed3b3b003309031eb21b59",
+				"DiscoKey":   "discokey:03c884c386c36199ff796cc107e227843c310c4813f4b1c7bd33a4f29cb5eb0d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54984",
+					"10.65.0.27:54984",
+					"172.17.0.1:54984",
+					"172.18.0.1:54984",
+					"172.19.0.1:54984"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:32:54.299382606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6059396706062051,
+				"StableID":   "nrCAVS5KKp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:94109679f6d34bbd8c79bdca9580cc4953b5a4539aa7a4cdbc46ad4b80c99733",
+				"KeyExpiry":  "2026-11-09T07:32:54Z",
+				"DiscoKey":   "discokey:fdc014d1d66e2d2f1608eb70e2d4ecbdef7451ed1c1b117e3fd94bda6e0cb679",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41881",
+					"10.65.0.27:41881",
+					"172.17.0.1:41881",
+					"172.18.0.1:41881",
+					"172.19.0.1:41881"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:32:54.862730909Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1677361396784083,
+				"StableID":   "nCRDnVSg6E11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:143d4f75f8ea8d8312de1d5855f0f9cb4ab5d3f93ebbb82201f2f77306639f37",
+				"KeyExpiry":  "2026-11-09T07:32:55Z",
+				"DiscoKey":   "discokey:892b260f0287567cb61ed29eb410b3bd51c0e5191a7f306baee683a77f179a3e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41785",
+					"10.65.0.27:41785",
+					"172.17.0.1:41785",
+					"172.18.0.1:41785",
+					"172.19.0.1:41785"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:32:55.363770604Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8063101005441181,
+				"StableID":   "nA9Q4Uznx521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       8063101005441181,
+				"Key":        "nodekey:b50379d3461d041fea143c416d7be57342c67769059f3317a43f5a5421906f7b",
+				"DiscoKey":   "discokey:852103a463b3f7b46da87ae39fe35475d8af6b1a645d7e1658597724745b8c7d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35008",
+					"10.65.0.27:35008",
+					"172.17.0.1:35008",
+					"172.18.0.1:35008",
+					"172.19.0.1:35008"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:32:49.431864299Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b50379d3461d041fea143c416d7be57342c67769059f3317a43f5a5421906f7b",
+			"MachineKey": "mkey:0ac01cb3d0b082f844758da2d94fc6ba0db787d4f67d4cb890cf370f31f74173",
+			"Peers": [{
+				"ID":         5359816779709991,
+				"StableID":   "ntMazHJUri11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eea0922ab286de3f730174cc71b6bc83d2867280d7b08a8f4edcfa61e34e3d3f",
+				"DiscoKey":   "discokey:4d0af95b4695ff00c47133467ec638f55468c24cbc2cef0efadb637a7256ae29",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52490",
+					"10.65.0.27:52490",
+					"172.17.0.1:52490",
+					"172.18.0.1:52490",
+					"172.19.0.1:52490"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:32:48.344790394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4137245329573985,
+				"StableID":   "ngciSKRmJZ11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a0b89ca4434405d36415735c8d612e4631a07e94543036b59a2311055083b00",
+				"DiscoKey":   "discokey:18e326a1803ea7fe98767ae3c00feecb5818a6a25b989214544062560e759d25",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42085",
+					"10.65.0.27:42085",
+					"172.17.0.1:42085",
+					"172.18.0.1:42085",
+					"172.19.0.1:42085"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:32:48.882592345Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1481967211625628,
+				"StableID":   "nXzWjQmBaC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:74c8aabc46d926dd1ac0fec904116305916c4fb4baab969c6d9806b5390e5d53",
+				"DiscoKey":   "discokey:9b280551710a3d62f04fe3c438f42b997b9ddb6efa7e404489159b9c4e3c145c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51035",
+					"10.65.0.27:51035",
+					"172.17.0.1:51035",
+					"172.18.0.1:51035",
+					"172.19.0.1:51035"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:32:49.973753515Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6975276302435565,
+				"StableID":   "n86p8Ug7Uw11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc9c8eba05af20517d5c6eeb184d56912a24178dda43bf1245ab48e49cf71b4c",
+				"DiscoKey":   "discokey:d216db9bcccd11a2838ccc6d59122831caf0670d7f2c8f33a76fb45a89c85d39",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57073",
+					"10.65.0.27:57073",
+					"172.17.0.1:57073",
+					"172.18.0.1:57073",
+					"172.19.0.1:57073"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:32:50.515690657Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5344740924395709,
+				"StableID":   "nULSHJHeji11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f42070dd2bcfb21164fc887e3063d737e6f907316243017a0ffc971cbc65574",
+				"DiscoKey":   "discokey:cf3ab951412e97b9eb904a1cd872f5d40c2ec374890a2e0cc52e2bca298e8404",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58527",
+					"10.65.0.27:58527",
+					"172.17.0.1:58527",
+					"172.18.0.1:58527",
+					"172.19.0.1:58527"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:32:51.050087982Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1257759953096300,
+				"StableID":   "nqoP4qDepA11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36bb870f8dc9e3803dc5a37baf2a64de33990f745ac8076b7ebfa3a5729ea639",
+				"DiscoKey":   "discokey:6945d861c12cc14d5d6e41a7aa40a9ba904d42265dc1ca5932bb440e89ac1470",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43972",
+					"10.65.0.27:43972",
+					"172.17.0.1:43972",
+					"172.18.0.1:43972",
+					"172.19.0.1:43972"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:32:51.590602748Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8013214272394711,
+				"StableID":   "n47jHxYCa521CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e08800c88148323eae3efc28d31e38eb34fc12eae2fcac549b34b44f0e0d0f66",
+				"DiscoKey":   "discokey:e0e25df51244d5685e127a8bbe126ed57fc782b70f19a8a795729e1a72606764",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36646",
+					"10.65.0.27:36646",
+					"172.17.0.1:36646",
+					"172.18.0.1:36646",
+					"172.19.0.1:36646"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:32:52.14345186Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3989811399952650,
+				"StableID":   "nZAuwdaz9Y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:572ee63a2622e7ac1f246f513bd82acd45d9fd1decd423ef835da858e5e9230f",
+				"DiscoKey":   "discokey:2b44621e0ff36d09e6b3686f29bf998a09163728cb0930951965e637a4e5ac6d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45347",
+					"10.65.0.27:45347",
+					"172.17.0.1:45347",
+					"172.18.0.1:45347",
+					"172.19.0.1:45347"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:32:52.679012032Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6041340428675552,
+				"StableID":   "nRTr5bm8Bp11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4d896e34487b494e68ccf954fb75267a6851c0ecc22d5b5ebec21eb2ca3366e",
+				"DiscoKey":   "discokey:678b539cbdbc1dd2b3b4420ec6b4c535d71a1b91fbdc34e55c6bf307cd16c137",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40268",
+					"10.65.0.27:40268",
+					"172.17.0.1:40268",
+					"172.18.0.1:40268",
+					"172.19.0.1:40268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:32:53.223586723Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5306201310471235,
+				"StableID":   "nNaGapuBSi11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee75185e044fb8c7785b8daf8a961311584ad07e080267742eedbde37bfd9137",
+				"DiscoKey":   "discokey:3bb418b636311b3b591f9f12e07995def4d12875626d23854bf5ea9d3e334d50",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55405",
+					"10.65.0.27:55405",
+					"172.17.0.1:55405",
+					"172.18.0.1:55405",
+					"172.19.0.1:55405"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:32:53.741071785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6564724472241463,
+				"StableID":   "nLMcmSBBGt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc14de9d9a162689136fd28faf374183af616d0481ed3b3b003309031eb21b59",
+				"DiscoKey":   "discokey:03c884c386c36199ff796cc107e227843c310c4813f4b1c7bd33a4f29cb5eb0d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54984",
+					"10.65.0.27:54984",
+					"172.17.0.1:54984",
+					"172.18.0.1:54984",
+					"172.19.0.1:54984"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:32:54.299382606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6059396706062051,
+				"StableID":   "nrCAVS5KKp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:94109679f6d34bbd8c79bdca9580cc4953b5a4539aa7a4cdbc46ad4b80c99733",
+				"KeyExpiry":  "2026-11-09T07:32:54Z",
+				"DiscoKey":   "discokey:fdc014d1d66e2d2f1608eb70e2d4ecbdef7451ed1c1b117e3fd94bda6e0cb679",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41881",
+					"10.65.0.27:41881",
+					"172.17.0.1:41881",
+					"172.18.0.1:41881",
+					"172.19.0.1:41881"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:32:54.862730909Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1677361396784083,
+				"StableID":   "nCRDnVSg6E11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:143d4f75f8ea8d8312de1d5855f0f9cb4ab5d3f93ebbb82201f2f77306639f37",
+				"KeyExpiry":  "2026-11-09T07:32:55Z",
+				"DiscoKey":   "discokey:892b260f0287567cb61ed29eb410b3bd51c0e5191a7f306baee683a77f179a3e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41785",
+					"10.65.0.27:41785",
+					"172.17.0.1:41785",
+					"172.18.0.1:41785",
+					"172.19.0.1:41785"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:32:55.363770604Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6926875846217797,
+				"StableID":   "nr7PZPHC6w11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:50539aad140a60a1b705ba3e01a36baa1c38c1eaacef8391912d0576bf609915",
+				"KeyExpiry":  "2026-11-09T07:32:55Z",
+				"DiscoKey":   "discokey:b49a52d37618740ef20f2205dadb426f1a98a98f5fc85352f4763668ea5ee85f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50973",
+					"10.65.0.27:50973",
+					"172.17.0.1:50973",
+					"172.18.0.1:50973",
+					"172.19.0.1:50973"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:32:55.977789285Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8063101005441181": {
+				"ID":          8063101005441181,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8013214272394711,
+				"StableID":   "n47jHxYCa521CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       8013214272394711,
+				"Key":        "nodekey:e08800c88148323eae3efc28d31e38eb34fc12eae2fcac549b34b44f0e0d0f66",
+				"DiscoKey":   "discokey:e0e25df51244d5685e127a8bbe126ed57fc782b70f19a8a795729e1a72606764",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36646",
+					"10.65.0.27:36646",
+					"172.17.0.1:36646",
+					"172.18.0.1:36646",
+					"172.19.0.1:36646"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:32:52.14345186Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e08800c88148323eae3efc28d31e38eb34fc12eae2fcac549b34b44f0e0d0f66",
+			"MachineKey": "mkey:ea7458f0b3f7ea75a8feb00331290a151f18a1239eaedcd3406cf35cf98b7a5e",
+			"Peers": [{
+				"ID":         5359816779709991,
+				"StableID":   "ntMazHJUri11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eea0922ab286de3f730174cc71b6bc83d2867280d7b08a8f4edcfa61e34e3d3f",
+				"DiscoKey":   "discokey:4d0af95b4695ff00c47133467ec638f55468c24cbc2cef0efadb637a7256ae29",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52490",
+					"10.65.0.27:52490",
+					"172.17.0.1:52490",
+					"172.18.0.1:52490",
+					"172.19.0.1:52490"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:32:48.344790394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4137245329573985,
+				"StableID":   "ngciSKRmJZ11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a0b89ca4434405d36415735c8d612e4631a07e94543036b59a2311055083b00",
+				"DiscoKey":   "discokey:18e326a1803ea7fe98767ae3c00feecb5818a6a25b989214544062560e759d25",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42085",
+					"10.65.0.27:42085",
+					"172.17.0.1:42085",
+					"172.18.0.1:42085",
+					"172.19.0.1:42085"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:32:48.882592345Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8063101005441181,
+				"StableID":   "nA9Q4Uznx521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b50379d3461d041fea143c416d7be57342c67769059f3317a43f5a5421906f7b",
+				"DiscoKey":   "discokey:852103a463b3f7b46da87ae39fe35475d8af6b1a645d7e1658597724745b8c7d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35008",
+					"10.65.0.27:35008",
+					"172.17.0.1:35008",
+					"172.18.0.1:35008",
+					"172.19.0.1:35008"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:32:49.431864299Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1481967211625628,
+				"StableID":   "nXzWjQmBaC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:74c8aabc46d926dd1ac0fec904116305916c4fb4baab969c6d9806b5390e5d53",
+				"DiscoKey":   "discokey:9b280551710a3d62f04fe3c438f42b997b9ddb6efa7e404489159b9c4e3c145c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51035",
+					"10.65.0.27:51035",
+					"172.17.0.1:51035",
+					"172.18.0.1:51035",
+					"172.19.0.1:51035"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:32:49.973753515Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6975276302435565,
+				"StableID":   "n86p8Ug7Uw11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc9c8eba05af20517d5c6eeb184d56912a24178dda43bf1245ab48e49cf71b4c",
+				"DiscoKey":   "discokey:d216db9bcccd11a2838ccc6d59122831caf0670d7f2c8f33a76fb45a89c85d39",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57073",
+					"10.65.0.27:57073",
+					"172.17.0.1:57073",
+					"172.18.0.1:57073",
+					"172.19.0.1:57073"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:32:50.515690657Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5344740924395709,
+				"StableID":   "nULSHJHeji11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f42070dd2bcfb21164fc887e3063d737e6f907316243017a0ffc971cbc65574",
+				"DiscoKey":   "discokey:cf3ab951412e97b9eb904a1cd872f5d40c2ec374890a2e0cc52e2bca298e8404",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58527",
+					"10.65.0.27:58527",
+					"172.17.0.1:58527",
+					"172.18.0.1:58527",
+					"172.19.0.1:58527"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:32:51.050087982Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1257759953096300,
+				"StableID":   "nqoP4qDepA11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36bb870f8dc9e3803dc5a37baf2a64de33990f745ac8076b7ebfa3a5729ea639",
+				"DiscoKey":   "discokey:6945d861c12cc14d5d6e41a7aa40a9ba904d42265dc1ca5932bb440e89ac1470",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43972",
+					"10.65.0.27:43972",
+					"172.17.0.1:43972",
+					"172.18.0.1:43972",
+					"172.19.0.1:43972"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:32:51.590602748Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3989811399952650,
+				"StableID":   "nZAuwdaz9Y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:572ee63a2622e7ac1f246f513bd82acd45d9fd1decd423ef835da858e5e9230f",
+				"DiscoKey":   "discokey:2b44621e0ff36d09e6b3686f29bf998a09163728cb0930951965e637a4e5ac6d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45347",
+					"10.65.0.27:45347",
+					"172.17.0.1:45347",
+					"172.18.0.1:45347",
+					"172.19.0.1:45347"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:32:52.679012032Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6041340428675552,
+				"StableID":   "nRTr5bm8Bp11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4d896e34487b494e68ccf954fb75267a6851c0ecc22d5b5ebec21eb2ca3366e",
+				"DiscoKey":   "discokey:678b539cbdbc1dd2b3b4420ec6b4c535d71a1b91fbdc34e55c6bf307cd16c137",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40268",
+					"10.65.0.27:40268",
+					"172.17.0.1:40268",
+					"172.18.0.1:40268",
+					"172.19.0.1:40268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:32:53.223586723Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5306201310471235,
+				"StableID":   "nNaGapuBSi11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee75185e044fb8c7785b8daf8a961311584ad07e080267742eedbde37bfd9137",
+				"DiscoKey":   "discokey:3bb418b636311b3b591f9f12e07995def4d12875626d23854bf5ea9d3e334d50",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55405",
+					"10.65.0.27:55405",
+					"172.17.0.1:55405",
+					"172.18.0.1:55405",
+					"172.19.0.1:55405"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:32:53.741071785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6564724472241463,
+				"StableID":   "nLMcmSBBGt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc14de9d9a162689136fd28faf374183af616d0481ed3b3b003309031eb21b59",
+				"DiscoKey":   "discokey:03c884c386c36199ff796cc107e227843c310c4813f4b1c7bd33a4f29cb5eb0d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54984",
+					"10.65.0.27:54984",
+					"172.17.0.1:54984",
+					"172.18.0.1:54984",
+					"172.19.0.1:54984"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:32:54.299382606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6059396706062051,
+				"StableID":   "nrCAVS5KKp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:94109679f6d34bbd8c79bdca9580cc4953b5a4539aa7a4cdbc46ad4b80c99733",
+				"KeyExpiry":  "2026-11-09T07:32:54Z",
+				"DiscoKey":   "discokey:fdc014d1d66e2d2f1608eb70e2d4ecbdef7451ed1c1b117e3fd94bda6e0cb679",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41881",
+					"10.65.0.27:41881",
+					"172.17.0.1:41881",
+					"172.18.0.1:41881",
+					"172.19.0.1:41881"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:32:54.862730909Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1677361396784083,
+				"StableID":   "nCRDnVSg6E11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:143d4f75f8ea8d8312de1d5855f0f9cb4ab5d3f93ebbb82201f2f77306639f37",
+				"KeyExpiry":  "2026-11-09T07:32:55Z",
+				"DiscoKey":   "discokey:892b260f0287567cb61ed29eb410b3bd51c0e5191a7f306baee683a77f179a3e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41785",
+					"10.65.0.27:41785",
+					"172.17.0.1:41785",
+					"172.18.0.1:41785",
+					"172.19.0.1:41785"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:32:55.363770604Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6926875846217797,
+				"StableID":   "nr7PZPHC6w11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:50539aad140a60a1b705ba3e01a36baa1c38c1eaacef8391912d0576bf609915",
+				"KeyExpiry":  "2026-11-09T07:32:55Z",
+				"DiscoKey":   "discokey:b49a52d37618740ef20f2205dadb426f1a98a98f5fc85352f4763668ea5ee85f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50973",
+					"10.65.0.27:50973",
+					"172.17.0.1:50973",
+					"172.18.0.1:50973",
+					"172.19.0.1:50973"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:32:55.977789285Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8013214272394711": {
+				"ID":          8013214272394711,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6059396706062051,
+				"StableID":   "nrCAVS5KKp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:94109679f6d34bbd8c79bdca9580cc4953b5a4539aa7a4cdbc46ad4b80c99733",
+				"KeyExpiry":  "2026-11-09T07:32:54Z",
+				"DiscoKey":   "discokey:fdc014d1d66e2d2f1608eb70e2d4ecbdef7451ed1c1b117e3fd94bda6e0cb679",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41881",
+					"10.65.0.27:41881",
+					"172.17.0.1:41881",
+					"172.18.0.1:41881",
+					"172.19.0.1:41881"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:32:54.862730909Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:94109679f6d34bbd8c79bdca9580cc4953b5a4539aa7a4cdbc46ad4b80c99733",
+			"MachineKey": "mkey:36bd7f4f93239bcdce89c03c309575e524401fd18f8ed43840f6248817b9ba77",
+			"Peers": [{
+				"ID":         5359816779709991,
+				"StableID":   "ntMazHJUri11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eea0922ab286de3f730174cc71b6bc83d2867280d7b08a8f4edcfa61e34e3d3f",
+				"DiscoKey":   "discokey:4d0af95b4695ff00c47133467ec638f55468c24cbc2cef0efadb637a7256ae29",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52490",
+					"10.65.0.27:52490",
+					"172.17.0.1:52490",
+					"172.18.0.1:52490",
+					"172.19.0.1:52490"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:32:48.344790394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4137245329573985,
+				"StableID":   "ngciSKRmJZ11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a0b89ca4434405d36415735c8d612e4631a07e94543036b59a2311055083b00",
+				"DiscoKey":   "discokey:18e326a1803ea7fe98767ae3c00feecb5818a6a25b989214544062560e759d25",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42085",
+					"10.65.0.27:42085",
+					"172.17.0.1:42085",
+					"172.18.0.1:42085",
+					"172.19.0.1:42085"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:32:48.882592345Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8063101005441181,
+				"StableID":   "nA9Q4Uznx521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b50379d3461d041fea143c416d7be57342c67769059f3317a43f5a5421906f7b",
+				"DiscoKey":   "discokey:852103a463b3f7b46da87ae39fe35475d8af6b1a645d7e1658597724745b8c7d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35008",
+					"10.65.0.27:35008",
+					"172.17.0.1:35008",
+					"172.18.0.1:35008",
+					"172.19.0.1:35008"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:32:49.431864299Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1481967211625628,
+				"StableID":   "nXzWjQmBaC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:74c8aabc46d926dd1ac0fec904116305916c4fb4baab969c6d9806b5390e5d53",
+				"DiscoKey":   "discokey:9b280551710a3d62f04fe3c438f42b997b9ddb6efa7e404489159b9c4e3c145c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51035",
+					"10.65.0.27:51035",
+					"172.17.0.1:51035",
+					"172.18.0.1:51035",
+					"172.19.0.1:51035"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:32:49.973753515Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6975276302435565,
+				"StableID":   "n86p8Ug7Uw11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc9c8eba05af20517d5c6eeb184d56912a24178dda43bf1245ab48e49cf71b4c",
+				"DiscoKey":   "discokey:d216db9bcccd11a2838ccc6d59122831caf0670d7f2c8f33a76fb45a89c85d39",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57073",
+					"10.65.0.27:57073",
+					"172.17.0.1:57073",
+					"172.18.0.1:57073",
+					"172.19.0.1:57073"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:32:50.515690657Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5344740924395709,
+				"StableID":   "nULSHJHeji11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f42070dd2bcfb21164fc887e3063d737e6f907316243017a0ffc971cbc65574",
+				"DiscoKey":   "discokey:cf3ab951412e97b9eb904a1cd872f5d40c2ec374890a2e0cc52e2bca298e8404",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58527",
+					"10.65.0.27:58527",
+					"172.17.0.1:58527",
+					"172.18.0.1:58527",
+					"172.19.0.1:58527"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:32:51.050087982Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1257759953096300,
+				"StableID":   "nqoP4qDepA11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36bb870f8dc9e3803dc5a37baf2a64de33990f745ac8076b7ebfa3a5729ea639",
+				"DiscoKey":   "discokey:6945d861c12cc14d5d6e41a7aa40a9ba904d42265dc1ca5932bb440e89ac1470",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43972",
+					"10.65.0.27:43972",
+					"172.17.0.1:43972",
+					"172.18.0.1:43972",
+					"172.19.0.1:43972"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:32:51.590602748Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8013214272394711,
+				"StableID":   "n47jHxYCa521CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e08800c88148323eae3efc28d31e38eb34fc12eae2fcac549b34b44f0e0d0f66",
+				"DiscoKey":   "discokey:e0e25df51244d5685e127a8bbe126ed57fc782b70f19a8a795729e1a72606764",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36646",
+					"10.65.0.27:36646",
+					"172.17.0.1:36646",
+					"172.18.0.1:36646",
+					"172.19.0.1:36646"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:32:52.14345186Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3989811399952650,
+				"StableID":   "nZAuwdaz9Y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:572ee63a2622e7ac1f246f513bd82acd45d9fd1decd423ef835da858e5e9230f",
+				"DiscoKey":   "discokey:2b44621e0ff36d09e6b3686f29bf998a09163728cb0930951965e637a4e5ac6d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45347",
+					"10.65.0.27:45347",
+					"172.17.0.1:45347",
+					"172.18.0.1:45347",
+					"172.19.0.1:45347"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:32:52.679012032Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6041340428675552,
+				"StableID":   "nRTr5bm8Bp11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4d896e34487b494e68ccf954fb75267a6851c0ecc22d5b5ebec21eb2ca3366e",
+				"DiscoKey":   "discokey:678b539cbdbc1dd2b3b4420ec6b4c535d71a1b91fbdc34e55c6bf307cd16c137",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40268",
+					"10.65.0.27:40268",
+					"172.17.0.1:40268",
+					"172.18.0.1:40268",
+					"172.19.0.1:40268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:32:53.223586723Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5306201310471235,
+				"StableID":   "nNaGapuBSi11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee75185e044fb8c7785b8daf8a961311584ad07e080267742eedbde37bfd9137",
+				"DiscoKey":   "discokey:3bb418b636311b3b591f9f12e07995def4d12875626d23854bf5ea9d3e334d50",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55405",
+					"10.65.0.27:55405",
+					"172.17.0.1:55405",
+					"172.18.0.1:55405",
+					"172.19.0.1:55405"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:32:53.741071785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6564724472241463,
+				"StableID":   "nLMcmSBBGt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc14de9d9a162689136fd28faf374183af616d0481ed3b3b003309031eb21b59",
+				"DiscoKey":   "discokey:03c884c386c36199ff796cc107e227843c310c4813f4b1c7bd33a4f29cb5eb0d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54984",
+					"10.65.0.27:54984",
+					"172.17.0.1:54984",
+					"172.18.0.1:54984",
+					"172.19.0.1:54984"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:32:54.299382606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1677361396784083,
+				"StableID":   "nCRDnVSg6E11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:143d4f75f8ea8d8312de1d5855f0f9cb4ab5d3f93ebbb82201f2f77306639f37",
+				"KeyExpiry":  "2026-11-09T07:32:55Z",
+				"DiscoKey":   "discokey:892b260f0287567cb61ed29eb410b3bd51c0e5191a7f306baee683a77f179a3e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41785",
+					"10.65.0.27:41785",
+					"172.17.0.1:41785",
+					"172.18.0.1:41785",
+					"172.19.0.1:41785"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:32:55.363770604Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6926875846217797,
+				"StableID":   "nr7PZPHC6w11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:50539aad140a60a1b705ba3e01a36baa1c38c1eaacef8391912d0576bf609915",
+				"KeyExpiry":  "2026-11-09T07:32:55Z",
+				"DiscoKey":   "discokey:b49a52d37618740ef20f2205dadb426f1a98a98f5fc85352f4763668ea5ee85f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50973",
+					"10.65.0.27:50973",
+					"172.17.0.1:50973",
+					"172.18.0.1:50973",
+					"172.19.0.1:50973"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:32:55.977789285Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5306201310471235,
+				"StableID":   "nNaGapuBSi11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       5306201310471235,
+				"Key":        "nodekey:ee75185e044fb8c7785b8daf8a961311584ad07e080267742eedbde37bfd9137",
+				"DiscoKey":   "discokey:3bb418b636311b3b591f9f12e07995def4d12875626d23854bf5ea9d3e334d50",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55405",
+					"10.65.0.27:55405",
+					"172.17.0.1:55405",
+					"172.18.0.1:55405",
+					"172.19.0.1:55405"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:32:53.741071785Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ee75185e044fb8c7785b8daf8a961311584ad07e080267742eedbde37bfd9137",
+			"MachineKey": "mkey:543e49e05da7018ed56bca99172318fc39a60666b60c8698b0266f72d66d5a1f",
+			"Peers": [{
+				"ID":         5359816779709991,
+				"StableID":   "ntMazHJUri11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eea0922ab286de3f730174cc71b6bc83d2867280d7b08a8f4edcfa61e34e3d3f",
+				"DiscoKey":   "discokey:4d0af95b4695ff00c47133467ec638f55468c24cbc2cef0efadb637a7256ae29",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52490",
+					"10.65.0.27:52490",
+					"172.17.0.1:52490",
+					"172.18.0.1:52490",
+					"172.19.0.1:52490"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:32:48.344790394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4137245329573985,
+				"StableID":   "ngciSKRmJZ11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a0b89ca4434405d36415735c8d612e4631a07e94543036b59a2311055083b00",
+				"DiscoKey":   "discokey:18e326a1803ea7fe98767ae3c00feecb5818a6a25b989214544062560e759d25",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42085",
+					"10.65.0.27:42085",
+					"172.17.0.1:42085",
+					"172.18.0.1:42085",
+					"172.19.0.1:42085"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:32:48.882592345Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8063101005441181,
+				"StableID":   "nA9Q4Uznx521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b50379d3461d041fea143c416d7be57342c67769059f3317a43f5a5421906f7b",
+				"DiscoKey":   "discokey:852103a463b3f7b46da87ae39fe35475d8af6b1a645d7e1658597724745b8c7d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35008",
+					"10.65.0.27:35008",
+					"172.17.0.1:35008",
+					"172.18.0.1:35008",
+					"172.19.0.1:35008"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:32:49.431864299Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1481967211625628,
+				"StableID":   "nXzWjQmBaC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:74c8aabc46d926dd1ac0fec904116305916c4fb4baab969c6d9806b5390e5d53",
+				"DiscoKey":   "discokey:9b280551710a3d62f04fe3c438f42b997b9ddb6efa7e404489159b9c4e3c145c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51035",
+					"10.65.0.27:51035",
+					"172.17.0.1:51035",
+					"172.18.0.1:51035",
+					"172.19.0.1:51035"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:32:49.973753515Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6975276302435565,
+				"StableID":   "n86p8Ug7Uw11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc9c8eba05af20517d5c6eeb184d56912a24178dda43bf1245ab48e49cf71b4c",
+				"DiscoKey":   "discokey:d216db9bcccd11a2838ccc6d59122831caf0670d7f2c8f33a76fb45a89c85d39",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57073",
+					"10.65.0.27:57073",
+					"172.17.0.1:57073",
+					"172.18.0.1:57073",
+					"172.19.0.1:57073"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:32:50.515690657Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5344740924395709,
+				"StableID":   "nULSHJHeji11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f42070dd2bcfb21164fc887e3063d737e6f907316243017a0ffc971cbc65574",
+				"DiscoKey":   "discokey:cf3ab951412e97b9eb904a1cd872f5d40c2ec374890a2e0cc52e2bca298e8404",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58527",
+					"10.65.0.27:58527",
+					"172.17.0.1:58527",
+					"172.18.0.1:58527",
+					"172.19.0.1:58527"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:32:51.050087982Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1257759953096300,
+				"StableID":   "nqoP4qDepA11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36bb870f8dc9e3803dc5a37baf2a64de33990f745ac8076b7ebfa3a5729ea639",
+				"DiscoKey":   "discokey:6945d861c12cc14d5d6e41a7aa40a9ba904d42265dc1ca5932bb440e89ac1470",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43972",
+					"10.65.0.27:43972",
+					"172.17.0.1:43972",
+					"172.18.0.1:43972",
+					"172.19.0.1:43972"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:32:51.590602748Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8013214272394711,
+				"StableID":   "n47jHxYCa521CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e08800c88148323eae3efc28d31e38eb34fc12eae2fcac549b34b44f0e0d0f66",
+				"DiscoKey":   "discokey:e0e25df51244d5685e127a8bbe126ed57fc782b70f19a8a795729e1a72606764",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36646",
+					"10.65.0.27:36646",
+					"172.17.0.1:36646",
+					"172.18.0.1:36646",
+					"172.19.0.1:36646"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:32:52.14345186Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3989811399952650,
+				"StableID":   "nZAuwdaz9Y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:572ee63a2622e7ac1f246f513bd82acd45d9fd1decd423ef835da858e5e9230f",
+				"DiscoKey":   "discokey:2b44621e0ff36d09e6b3686f29bf998a09163728cb0930951965e637a4e5ac6d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45347",
+					"10.65.0.27:45347",
+					"172.17.0.1:45347",
+					"172.18.0.1:45347",
+					"172.19.0.1:45347"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:32:52.679012032Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6041340428675552,
+				"StableID":   "nRTr5bm8Bp11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4d896e34487b494e68ccf954fb75267a6851c0ecc22d5b5ebec21eb2ca3366e",
+				"DiscoKey":   "discokey:678b539cbdbc1dd2b3b4420ec6b4c535d71a1b91fbdc34e55c6bf307cd16c137",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40268",
+					"10.65.0.27:40268",
+					"172.17.0.1:40268",
+					"172.18.0.1:40268",
+					"172.19.0.1:40268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:32:53.223586723Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6564724472241463,
+				"StableID":   "nLMcmSBBGt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc14de9d9a162689136fd28faf374183af616d0481ed3b3b003309031eb21b59",
+				"DiscoKey":   "discokey:03c884c386c36199ff796cc107e227843c310c4813f4b1c7bd33a4f29cb5eb0d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54984",
+					"10.65.0.27:54984",
+					"172.17.0.1:54984",
+					"172.18.0.1:54984",
+					"172.19.0.1:54984"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:32:54.299382606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6059396706062051,
+				"StableID":   "nrCAVS5KKp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:94109679f6d34bbd8c79bdca9580cc4953b5a4539aa7a4cdbc46ad4b80c99733",
+				"KeyExpiry":  "2026-11-09T07:32:54Z",
+				"DiscoKey":   "discokey:fdc014d1d66e2d2f1608eb70e2d4ecbdef7451ed1c1b117e3fd94bda6e0cb679",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41881",
+					"10.65.0.27:41881",
+					"172.17.0.1:41881",
+					"172.18.0.1:41881",
+					"172.19.0.1:41881"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:32:54.862730909Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1677361396784083,
+				"StableID":   "nCRDnVSg6E11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:143d4f75f8ea8d8312de1d5855f0f9cb4ab5d3f93ebbb82201f2f77306639f37",
+				"KeyExpiry":  "2026-11-09T07:32:55Z",
+				"DiscoKey":   "discokey:892b260f0287567cb61ed29eb410b3bd51c0e5191a7f306baee683a77f179a3e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41785",
+					"10.65.0.27:41785",
+					"172.17.0.1:41785",
+					"172.18.0.1:41785",
+					"172.19.0.1:41785"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:32:55.363770604Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6926875846217797,
+				"StableID":   "nr7PZPHC6w11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:50539aad140a60a1b705ba3e01a36baa1c38c1eaacef8391912d0576bf609915",
+				"KeyExpiry":  "2026-11-09T07:32:55Z",
+				"DiscoKey":   "discokey:b49a52d37618740ef20f2205dadb426f1a98a98f5fc85352f4763668ea5ee85f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50973",
+					"10.65.0.27:50973",
+					"172.17.0.1:50973",
+					"172.18.0.1:50973",
+					"172.19.0.1:50973"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:32:55.977789285Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5306201310471235": {
+				"ID":          5306201310471235,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4137245329573985,
+				"StableID":   "ngciSKRmJZ11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       4137245329573985,
+				"Key":        "nodekey:8a0b89ca4434405d36415735c8d612e4631a07e94543036b59a2311055083b00",
+				"DiscoKey":   "discokey:18e326a1803ea7fe98767ae3c00feecb5818a6a25b989214544062560e759d25",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42085",
+					"10.65.0.27:42085",
+					"172.17.0.1:42085",
+					"172.18.0.1:42085",
+					"172.19.0.1:42085"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:32:48.882592345Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8a0b89ca4434405d36415735c8d612e4631a07e94543036b59a2311055083b00",
+			"MachineKey": "mkey:a567a28976cecba23308ebfbb8f7938157e668ca257cbf5c2d9ef3ed47b04158",
+			"Peers": [{
+				"ID":         5359816779709991,
+				"StableID":   "ntMazHJUri11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eea0922ab286de3f730174cc71b6bc83d2867280d7b08a8f4edcfa61e34e3d3f",
+				"DiscoKey":   "discokey:4d0af95b4695ff00c47133467ec638f55468c24cbc2cef0efadb637a7256ae29",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52490",
+					"10.65.0.27:52490",
+					"172.17.0.1:52490",
+					"172.18.0.1:52490",
+					"172.19.0.1:52490"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:32:48.344790394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8063101005441181,
+				"StableID":   "nA9Q4Uznx521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b50379d3461d041fea143c416d7be57342c67769059f3317a43f5a5421906f7b",
+				"DiscoKey":   "discokey:852103a463b3f7b46da87ae39fe35475d8af6b1a645d7e1658597724745b8c7d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35008",
+					"10.65.0.27:35008",
+					"172.17.0.1:35008",
+					"172.18.0.1:35008",
+					"172.19.0.1:35008"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:32:49.431864299Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1481967211625628,
+				"StableID":   "nXzWjQmBaC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:74c8aabc46d926dd1ac0fec904116305916c4fb4baab969c6d9806b5390e5d53",
+				"DiscoKey":   "discokey:9b280551710a3d62f04fe3c438f42b997b9ddb6efa7e404489159b9c4e3c145c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51035",
+					"10.65.0.27:51035",
+					"172.17.0.1:51035",
+					"172.18.0.1:51035",
+					"172.19.0.1:51035"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:32:49.973753515Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6975276302435565,
+				"StableID":   "n86p8Ug7Uw11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc9c8eba05af20517d5c6eeb184d56912a24178dda43bf1245ab48e49cf71b4c",
+				"DiscoKey":   "discokey:d216db9bcccd11a2838ccc6d59122831caf0670d7f2c8f33a76fb45a89c85d39",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57073",
+					"10.65.0.27:57073",
+					"172.17.0.1:57073",
+					"172.18.0.1:57073",
+					"172.19.0.1:57073"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:32:50.515690657Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5344740924395709,
+				"StableID":   "nULSHJHeji11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f42070dd2bcfb21164fc887e3063d737e6f907316243017a0ffc971cbc65574",
+				"DiscoKey":   "discokey:cf3ab951412e97b9eb904a1cd872f5d40c2ec374890a2e0cc52e2bca298e8404",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58527",
+					"10.65.0.27:58527",
+					"172.17.0.1:58527",
+					"172.18.0.1:58527",
+					"172.19.0.1:58527"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:32:51.050087982Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1257759953096300,
+				"StableID":   "nqoP4qDepA11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36bb870f8dc9e3803dc5a37baf2a64de33990f745ac8076b7ebfa3a5729ea639",
+				"DiscoKey":   "discokey:6945d861c12cc14d5d6e41a7aa40a9ba904d42265dc1ca5932bb440e89ac1470",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43972",
+					"10.65.0.27:43972",
+					"172.17.0.1:43972",
+					"172.18.0.1:43972",
+					"172.19.0.1:43972"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:32:51.590602748Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8013214272394711,
+				"StableID":   "n47jHxYCa521CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e08800c88148323eae3efc28d31e38eb34fc12eae2fcac549b34b44f0e0d0f66",
+				"DiscoKey":   "discokey:e0e25df51244d5685e127a8bbe126ed57fc782b70f19a8a795729e1a72606764",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36646",
+					"10.65.0.27:36646",
+					"172.17.0.1:36646",
+					"172.18.0.1:36646",
+					"172.19.0.1:36646"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:32:52.14345186Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3989811399952650,
+				"StableID":   "nZAuwdaz9Y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:572ee63a2622e7ac1f246f513bd82acd45d9fd1decd423ef835da858e5e9230f",
+				"DiscoKey":   "discokey:2b44621e0ff36d09e6b3686f29bf998a09163728cb0930951965e637a4e5ac6d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45347",
+					"10.65.0.27:45347",
+					"172.17.0.1:45347",
+					"172.18.0.1:45347",
+					"172.19.0.1:45347"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:32:52.679012032Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6041340428675552,
+				"StableID":   "nRTr5bm8Bp11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4d896e34487b494e68ccf954fb75267a6851c0ecc22d5b5ebec21eb2ca3366e",
+				"DiscoKey":   "discokey:678b539cbdbc1dd2b3b4420ec6b4c535d71a1b91fbdc34e55c6bf307cd16c137",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40268",
+					"10.65.0.27:40268",
+					"172.17.0.1:40268",
+					"172.18.0.1:40268",
+					"172.19.0.1:40268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:32:53.223586723Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5306201310471235,
+				"StableID":   "nNaGapuBSi11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee75185e044fb8c7785b8daf8a961311584ad07e080267742eedbde37bfd9137",
+				"DiscoKey":   "discokey:3bb418b636311b3b591f9f12e07995def4d12875626d23854bf5ea9d3e334d50",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55405",
+					"10.65.0.27:55405",
+					"172.17.0.1:55405",
+					"172.18.0.1:55405",
+					"172.19.0.1:55405"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:32:53.741071785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6564724472241463,
+				"StableID":   "nLMcmSBBGt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc14de9d9a162689136fd28faf374183af616d0481ed3b3b003309031eb21b59",
+				"DiscoKey":   "discokey:03c884c386c36199ff796cc107e227843c310c4813f4b1c7bd33a4f29cb5eb0d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54984",
+					"10.65.0.27:54984",
+					"172.17.0.1:54984",
+					"172.18.0.1:54984",
+					"172.19.0.1:54984"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:32:54.299382606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6059396706062051,
+				"StableID":   "nrCAVS5KKp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:94109679f6d34bbd8c79bdca9580cc4953b5a4539aa7a4cdbc46ad4b80c99733",
+				"KeyExpiry":  "2026-11-09T07:32:54Z",
+				"DiscoKey":   "discokey:fdc014d1d66e2d2f1608eb70e2d4ecbdef7451ed1c1b117e3fd94bda6e0cb679",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41881",
+					"10.65.0.27:41881",
+					"172.17.0.1:41881",
+					"172.18.0.1:41881",
+					"172.19.0.1:41881"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:32:54.862730909Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1677361396784083,
+				"StableID":   "nCRDnVSg6E11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:143d4f75f8ea8d8312de1d5855f0f9cb4ab5d3f93ebbb82201f2f77306639f37",
+				"KeyExpiry":  "2026-11-09T07:32:55Z",
+				"DiscoKey":   "discokey:892b260f0287567cb61ed29eb410b3bd51c0e5191a7f306baee683a77f179a3e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41785",
+					"10.65.0.27:41785",
+					"172.17.0.1:41785",
+					"172.18.0.1:41785",
+					"172.19.0.1:41785"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:32:55.363770604Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6926875846217797,
+				"StableID":   "nr7PZPHC6w11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:50539aad140a60a1b705ba3e01a36baa1c38c1eaacef8391912d0576bf609915",
+				"KeyExpiry":  "2026-11-09T07:32:55Z",
+				"DiscoKey":   "discokey:b49a52d37618740ef20f2205dadb426f1a98a98f5fc85352f4763668ea5ee85f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50973",
+					"10.65.0.27:50973",
+					"172.17.0.1:50973",
+					"172.18.0.1:50973",
+					"172.19.0.1:50973"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:32:55.977789285Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4137245329573985": {
+				"ID":          4137245329573985,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5359816779709991,
+				"StableID":   "ntMazHJUri11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       5359816779709991,
+				"Key":        "nodekey:eea0922ab286de3f730174cc71b6bc83d2867280d7b08a8f4edcfa61e34e3d3f",
+				"DiscoKey":   "discokey:4d0af95b4695ff00c47133467ec638f55468c24cbc2cef0efadb637a7256ae29",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52490",
+					"10.65.0.27:52490",
+					"172.17.0.1:52490",
+					"172.18.0.1:52490",
+					"172.19.0.1:52490"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:32:48.344790394Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:eea0922ab286de3f730174cc71b6bc83d2867280d7b08a8f4edcfa61e34e3d3f",
+			"MachineKey": "mkey:deea615f78bd03f26d3ef0532aa26e4cb128b4bdedb9334a20d3a7634dc9580a",
+			"Peers": [{
+				"ID":         4137245329573985,
+				"StableID":   "ngciSKRmJZ11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a0b89ca4434405d36415735c8d612e4631a07e94543036b59a2311055083b00",
+				"DiscoKey":   "discokey:18e326a1803ea7fe98767ae3c00feecb5818a6a25b989214544062560e759d25",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42085",
+					"10.65.0.27:42085",
+					"172.17.0.1:42085",
+					"172.18.0.1:42085",
+					"172.19.0.1:42085"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:32:48.882592345Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8063101005441181,
+				"StableID":   "nA9Q4Uznx521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b50379d3461d041fea143c416d7be57342c67769059f3317a43f5a5421906f7b",
+				"DiscoKey":   "discokey:852103a463b3f7b46da87ae39fe35475d8af6b1a645d7e1658597724745b8c7d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35008",
+					"10.65.0.27:35008",
+					"172.17.0.1:35008",
+					"172.18.0.1:35008",
+					"172.19.0.1:35008"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:32:49.431864299Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1481967211625628,
+				"StableID":   "nXzWjQmBaC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:74c8aabc46d926dd1ac0fec904116305916c4fb4baab969c6d9806b5390e5d53",
+				"DiscoKey":   "discokey:9b280551710a3d62f04fe3c438f42b997b9ddb6efa7e404489159b9c4e3c145c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51035",
+					"10.65.0.27:51035",
+					"172.17.0.1:51035",
+					"172.18.0.1:51035",
+					"172.19.0.1:51035"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:32:49.973753515Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6975276302435565,
+				"StableID":   "n86p8Ug7Uw11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc9c8eba05af20517d5c6eeb184d56912a24178dda43bf1245ab48e49cf71b4c",
+				"DiscoKey":   "discokey:d216db9bcccd11a2838ccc6d59122831caf0670d7f2c8f33a76fb45a89c85d39",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57073",
+					"10.65.0.27:57073",
+					"172.17.0.1:57073",
+					"172.18.0.1:57073",
+					"172.19.0.1:57073"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:32:50.515690657Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5344740924395709,
+				"StableID":   "nULSHJHeji11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f42070dd2bcfb21164fc887e3063d737e6f907316243017a0ffc971cbc65574",
+				"DiscoKey":   "discokey:cf3ab951412e97b9eb904a1cd872f5d40c2ec374890a2e0cc52e2bca298e8404",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58527",
+					"10.65.0.27:58527",
+					"172.17.0.1:58527",
+					"172.18.0.1:58527",
+					"172.19.0.1:58527"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:32:51.050087982Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1257759953096300,
+				"StableID":   "nqoP4qDepA11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36bb870f8dc9e3803dc5a37baf2a64de33990f745ac8076b7ebfa3a5729ea639",
+				"DiscoKey":   "discokey:6945d861c12cc14d5d6e41a7aa40a9ba904d42265dc1ca5932bb440e89ac1470",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43972",
+					"10.65.0.27:43972",
+					"172.17.0.1:43972",
+					"172.18.0.1:43972",
+					"172.19.0.1:43972"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:32:51.590602748Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8013214272394711,
+				"StableID":   "n47jHxYCa521CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e08800c88148323eae3efc28d31e38eb34fc12eae2fcac549b34b44f0e0d0f66",
+				"DiscoKey":   "discokey:e0e25df51244d5685e127a8bbe126ed57fc782b70f19a8a795729e1a72606764",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36646",
+					"10.65.0.27:36646",
+					"172.17.0.1:36646",
+					"172.18.0.1:36646",
+					"172.19.0.1:36646"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:32:52.14345186Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3989811399952650,
+				"StableID":   "nZAuwdaz9Y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:572ee63a2622e7ac1f246f513bd82acd45d9fd1decd423ef835da858e5e9230f",
+				"DiscoKey":   "discokey:2b44621e0ff36d09e6b3686f29bf998a09163728cb0930951965e637a4e5ac6d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45347",
+					"10.65.0.27:45347",
+					"172.17.0.1:45347",
+					"172.18.0.1:45347",
+					"172.19.0.1:45347"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:32:52.679012032Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6041340428675552,
+				"StableID":   "nRTr5bm8Bp11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4d896e34487b494e68ccf954fb75267a6851c0ecc22d5b5ebec21eb2ca3366e",
+				"DiscoKey":   "discokey:678b539cbdbc1dd2b3b4420ec6b4c535d71a1b91fbdc34e55c6bf307cd16c137",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40268",
+					"10.65.0.27:40268",
+					"172.17.0.1:40268",
+					"172.18.0.1:40268",
+					"172.19.0.1:40268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:32:53.223586723Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5306201310471235,
+				"StableID":   "nNaGapuBSi11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee75185e044fb8c7785b8daf8a961311584ad07e080267742eedbde37bfd9137",
+				"DiscoKey":   "discokey:3bb418b636311b3b591f9f12e07995def4d12875626d23854bf5ea9d3e334d50",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55405",
+					"10.65.0.27:55405",
+					"172.17.0.1:55405",
+					"172.18.0.1:55405",
+					"172.19.0.1:55405"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:32:53.741071785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6564724472241463,
+				"StableID":   "nLMcmSBBGt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc14de9d9a162689136fd28faf374183af616d0481ed3b3b003309031eb21b59",
+				"DiscoKey":   "discokey:03c884c386c36199ff796cc107e227843c310c4813f4b1c7bd33a4f29cb5eb0d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54984",
+					"10.65.0.27:54984",
+					"172.17.0.1:54984",
+					"172.18.0.1:54984",
+					"172.19.0.1:54984"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:32:54.299382606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6059396706062051,
+				"StableID":   "nrCAVS5KKp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:94109679f6d34bbd8c79bdca9580cc4953b5a4539aa7a4cdbc46ad4b80c99733",
+				"KeyExpiry":  "2026-11-09T07:32:54Z",
+				"DiscoKey":   "discokey:fdc014d1d66e2d2f1608eb70e2d4ecbdef7451ed1c1b117e3fd94bda6e0cb679",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41881",
+					"10.65.0.27:41881",
+					"172.17.0.1:41881",
+					"172.18.0.1:41881",
+					"172.19.0.1:41881"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:32:54.862730909Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1677361396784083,
+				"StableID":   "nCRDnVSg6E11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:143d4f75f8ea8d8312de1d5855f0f9cb4ab5d3f93ebbb82201f2f77306639f37",
+				"KeyExpiry":  "2026-11-09T07:32:55Z",
+				"DiscoKey":   "discokey:892b260f0287567cb61ed29eb410b3bd51c0e5191a7f306baee683a77f179a3e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41785",
+					"10.65.0.27:41785",
+					"172.17.0.1:41785",
+					"172.18.0.1:41785",
+					"172.19.0.1:41785"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:32:55.363770604Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6926875846217797,
+				"StableID":   "nr7PZPHC6w11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:50539aad140a60a1b705ba3e01a36baa1c38c1eaacef8391912d0576bf609915",
+				"KeyExpiry":  "2026-11-09T07:32:55Z",
+				"DiscoKey":   "discokey:b49a52d37618740ef20f2205dadb426f1a98a98f5fc85352f4763668ea5ee85f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50973",
+					"10.65.0.27:50973",
+					"172.17.0.1:50973",
+					"172.18.0.1:50973",
+					"172.19.0.1:50973"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:32:55.977789285Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5359816779709991": {
+				"ID":          5359816779709991,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6975276302435565,
+				"StableID":   "n86p8Ug7Uw11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       6975276302435565,
+				"Key":        "nodekey:dc9c8eba05af20517d5c6eeb184d56912a24178dda43bf1245ab48e49cf71b4c",
+				"DiscoKey":   "discokey:d216db9bcccd11a2838ccc6d59122831caf0670d7f2c8f33a76fb45a89c85d39",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57073",
+					"10.65.0.27:57073",
+					"172.17.0.1:57073",
+					"172.18.0.1:57073",
+					"172.19.0.1:57073"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:32:50.515690657Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:dc9c8eba05af20517d5c6eeb184d56912a24178dda43bf1245ab48e49cf71b4c",
+			"MachineKey": "mkey:e5bbe40dbd7b009b076f9fc791f4da90c3e905bea5e509561a654ef7f4bbd656",
+			"Peers": [{
+				"ID":         5359816779709991,
+				"StableID":   "ntMazHJUri11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eea0922ab286de3f730174cc71b6bc83d2867280d7b08a8f4edcfa61e34e3d3f",
+				"DiscoKey":   "discokey:4d0af95b4695ff00c47133467ec638f55468c24cbc2cef0efadb637a7256ae29",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52490",
+					"10.65.0.27:52490",
+					"172.17.0.1:52490",
+					"172.18.0.1:52490",
+					"172.19.0.1:52490"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:32:48.344790394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4137245329573985,
+				"StableID":   "ngciSKRmJZ11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a0b89ca4434405d36415735c8d612e4631a07e94543036b59a2311055083b00",
+				"DiscoKey":   "discokey:18e326a1803ea7fe98767ae3c00feecb5818a6a25b989214544062560e759d25",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42085",
+					"10.65.0.27:42085",
+					"172.17.0.1:42085",
+					"172.18.0.1:42085",
+					"172.19.0.1:42085"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:32:48.882592345Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8063101005441181,
+				"StableID":   "nA9Q4Uznx521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b50379d3461d041fea143c416d7be57342c67769059f3317a43f5a5421906f7b",
+				"DiscoKey":   "discokey:852103a463b3f7b46da87ae39fe35475d8af6b1a645d7e1658597724745b8c7d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35008",
+					"10.65.0.27:35008",
+					"172.17.0.1:35008",
+					"172.18.0.1:35008",
+					"172.19.0.1:35008"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:32:49.431864299Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1481967211625628,
+				"StableID":   "nXzWjQmBaC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:74c8aabc46d926dd1ac0fec904116305916c4fb4baab969c6d9806b5390e5d53",
+				"DiscoKey":   "discokey:9b280551710a3d62f04fe3c438f42b997b9ddb6efa7e404489159b9c4e3c145c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51035",
+					"10.65.0.27:51035",
+					"172.17.0.1:51035",
+					"172.18.0.1:51035",
+					"172.19.0.1:51035"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:32:49.973753515Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5344740924395709,
+				"StableID":   "nULSHJHeji11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f42070dd2bcfb21164fc887e3063d737e6f907316243017a0ffc971cbc65574",
+				"DiscoKey":   "discokey:cf3ab951412e97b9eb904a1cd872f5d40c2ec374890a2e0cc52e2bca298e8404",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58527",
+					"10.65.0.27:58527",
+					"172.17.0.1:58527",
+					"172.18.0.1:58527",
+					"172.19.0.1:58527"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:32:51.050087982Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1257759953096300,
+				"StableID":   "nqoP4qDepA11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36bb870f8dc9e3803dc5a37baf2a64de33990f745ac8076b7ebfa3a5729ea639",
+				"DiscoKey":   "discokey:6945d861c12cc14d5d6e41a7aa40a9ba904d42265dc1ca5932bb440e89ac1470",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43972",
+					"10.65.0.27:43972",
+					"172.17.0.1:43972",
+					"172.18.0.1:43972",
+					"172.19.0.1:43972"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:32:51.590602748Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8013214272394711,
+				"StableID":   "n47jHxYCa521CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e08800c88148323eae3efc28d31e38eb34fc12eae2fcac549b34b44f0e0d0f66",
+				"DiscoKey":   "discokey:e0e25df51244d5685e127a8bbe126ed57fc782b70f19a8a795729e1a72606764",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36646",
+					"10.65.0.27:36646",
+					"172.17.0.1:36646",
+					"172.18.0.1:36646",
+					"172.19.0.1:36646"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:32:52.14345186Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3989811399952650,
+				"StableID":   "nZAuwdaz9Y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:572ee63a2622e7ac1f246f513bd82acd45d9fd1decd423ef835da858e5e9230f",
+				"DiscoKey":   "discokey:2b44621e0ff36d09e6b3686f29bf998a09163728cb0930951965e637a4e5ac6d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45347",
+					"10.65.0.27:45347",
+					"172.17.0.1:45347",
+					"172.18.0.1:45347",
+					"172.19.0.1:45347"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:32:52.679012032Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6041340428675552,
+				"StableID":   "nRTr5bm8Bp11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4d896e34487b494e68ccf954fb75267a6851c0ecc22d5b5ebec21eb2ca3366e",
+				"DiscoKey":   "discokey:678b539cbdbc1dd2b3b4420ec6b4c535d71a1b91fbdc34e55c6bf307cd16c137",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40268",
+					"10.65.0.27:40268",
+					"172.17.0.1:40268",
+					"172.18.0.1:40268",
+					"172.19.0.1:40268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:32:53.223586723Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5306201310471235,
+				"StableID":   "nNaGapuBSi11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee75185e044fb8c7785b8daf8a961311584ad07e080267742eedbde37bfd9137",
+				"DiscoKey":   "discokey:3bb418b636311b3b591f9f12e07995def4d12875626d23854bf5ea9d3e334d50",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55405",
+					"10.65.0.27:55405",
+					"172.17.0.1:55405",
+					"172.18.0.1:55405",
+					"172.19.0.1:55405"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:32:53.741071785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6564724472241463,
+				"StableID":   "nLMcmSBBGt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc14de9d9a162689136fd28faf374183af616d0481ed3b3b003309031eb21b59",
+				"DiscoKey":   "discokey:03c884c386c36199ff796cc107e227843c310c4813f4b1c7bd33a4f29cb5eb0d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54984",
+					"10.65.0.27:54984",
+					"172.17.0.1:54984",
+					"172.18.0.1:54984",
+					"172.19.0.1:54984"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:32:54.299382606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6059396706062051,
+				"StableID":   "nrCAVS5KKp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:94109679f6d34bbd8c79bdca9580cc4953b5a4539aa7a4cdbc46ad4b80c99733",
+				"KeyExpiry":  "2026-11-09T07:32:54Z",
+				"DiscoKey":   "discokey:fdc014d1d66e2d2f1608eb70e2d4ecbdef7451ed1c1b117e3fd94bda6e0cb679",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41881",
+					"10.65.0.27:41881",
+					"172.17.0.1:41881",
+					"172.18.0.1:41881",
+					"172.19.0.1:41881"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:32:54.862730909Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1677361396784083,
+				"StableID":   "nCRDnVSg6E11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:143d4f75f8ea8d8312de1d5855f0f9cb4ab5d3f93ebbb82201f2f77306639f37",
+				"KeyExpiry":  "2026-11-09T07:32:55Z",
+				"DiscoKey":   "discokey:892b260f0287567cb61ed29eb410b3bd51c0e5191a7f306baee683a77f179a3e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41785",
+					"10.65.0.27:41785",
+					"172.17.0.1:41785",
+					"172.18.0.1:41785",
+					"172.19.0.1:41785"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:32:55.363770604Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6926875846217797,
+				"StableID":   "nr7PZPHC6w11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:50539aad140a60a1b705ba3e01a36baa1c38c1eaacef8391912d0576bf609915",
+				"KeyExpiry":  "2026-11-09T07:32:55Z",
+				"DiscoKey":   "discokey:b49a52d37618740ef20f2205dadb426f1a98a98f5fc85352f4763668ea5ee85f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50973",
+					"10.65.0.27:50973",
+					"172.17.0.1:50973",
+					"172.18.0.1:50973",
+					"172.19.0.1:50973"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:32:55.977789285Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6975276302435565": {
+				"ID":          6975276302435565,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1481967211625628,
+				"StableID":   "nXzWjQmBaC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1481967211625628,
+				"Key":        "nodekey:74c8aabc46d926dd1ac0fec904116305916c4fb4baab969c6d9806b5390e5d53",
+				"DiscoKey":   "discokey:9b280551710a3d62f04fe3c438f42b997b9ddb6efa7e404489159b9c4e3c145c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51035",
+					"10.65.0.27:51035",
+					"172.17.0.1:51035",
+					"172.18.0.1:51035",
+					"172.19.0.1:51035"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:32:49.973753515Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:74c8aabc46d926dd1ac0fec904116305916c4fb4baab969c6d9806b5390e5d53",
+			"MachineKey": "mkey:2e014677c5e251d2df8b276e390b992677d28e03340acac68103205c274bd723",
+			"Peers": [{
+				"ID":         5359816779709991,
+				"StableID":   "ntMazHJUri11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eea0922ab286de3f730174cc71b6bc83d2867280d7b08a8f4edcfa61e34e3d3f",
+				"DiscoKey":   "discokey:4d0af95b4695ff00c47133467ec638f55468c24cbc2cef0efadb637a7256ae29",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52490",
+					"10.65.0.27:52490",
+					"172.17.0.1:52490",
+					"172.18.0.1:52490",
+					"172.19.0.1:52490"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:32:48.344790394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4137245329573985,
+				"StableID":   "ngciSKRmJZ11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a0b89ca4434405d36415735c8d612e4631a07e94543036b59a2311055083b00",
+				"DiscoKey":   "discokey:18e326a1803ea7fe98767ae3c00feecb5818a6a25b989214544062560e759d25",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42085",
+					"10.65.0.27:42085",
+					"172.17.0.1:42085",
+					"172.18.0.1:42085",
+					"172.19.0.1:42085"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:32:48.882592345Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8063101005441181,
+				"StableID":   "nA9Q4Uznx521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b50379d3461d041fea143c416d7be57342c67769059f3317a43f5a5421906f7b",
+				"DiscoKey":   "discokey:852103a463b3f7b46da87ae39fe35475d8af6b1a645d7e1658597724745b8c7d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35008",
+					"10.65.0.27:35008",
+					"172.17.0.1:35008",
+					"172.18.0.1:35008",
+					"172.19.0.1:35008"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:32:49.431864299Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6975276302435565,
+				"StableID":   "n86p8Ug7Uw11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc9c8eba05af20517d5c6eeb184d56912a24178dda43bf1245ab48e49cf71b4c",
+				"DiscoKey":   "discokey:d216db9bcccd11a2838ccc6d59122831caf0670d7f2c8f33a76fb45a89c85d39",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57073",
+					"10.65.0.27:57073",
+					"172.17.0.1:57073",
+					"172.18.0.1:57073",
+					"172.19.0.1:57073"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:32:50.515690657Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5344740924395709,
+				"StableID":   "nULSHJHeji11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f42070dd2bcfb21164fc887e3063d737e6f907316243017a0ffc971cbc65574",
+				"DiscoKey":   "discokey:cf3ab951412e97b9eb904a1cd872f5d40c2ec374890a2e0cc52e2bca298e8404",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58527",
+					"10.65.0.27:58527",
+					"172.17.0.1:58527",
+					"172.18.0.1:58527",
+					"172.19.0.1:58527"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:32:51.050087982Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1257759953096300,
+				"StableID":   "nqoP4qDepA11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36bb870f8dc9e3803dc5a37baf2a64de33990f745ac8076b7ebfa3a5729ea639",
+				"DiscoKey":   "discokey:6945d861c12cc14d5d6e41a7aa40a9ba904d42265dc1ca5932bb440e89ac1470",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43972",
+					"10.65.0.27:43972",
+					"172.17.0.1:43972",
+					"172.18.0.1:43972",
+					"172.19.0.1:43972"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:32:51.590602748Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8013214272394711,
+				"StableID":   "n47jHxYCa521CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e08800c88148323eae3efc28d31e38eb34fc12eae2fcac549b34b44f0e0d0f66",
+				"DiscoKey":   "discokey:e0e25df51244d5685e127a8bbe126ed57fc782b70f19a8a795729e1a72606764",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36646",
+					"10.65.0.27:36646",
+					"172.17.0.1:36646",
+					"172.18.0.1:36646",
+					"172.19.0.1:36646"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:32:52.14345186Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3989811399952650,
+				"StableID":   "nZAuwdaz9Y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:572ee63a2622e7ac1f246f513bd82acd45d9fd1decd423ef835da858e5e9230f",
+				"DiscoKey":   "discokey:2b44621e0ff36d09e6b3686f29bf998a09163728cb0930951965e637a4e5ac6d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45347",
+					"10.65.0.27:45347",
+					"172.17.0.1:45347",
+					"172.18.0.1:45347",
+					"172.19.0.1:45347"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:32:52.679012032Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6041340428675552,
+				"StableID":   "nRTr5bm8Bp11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4d896e34487b494e68ccf954fb75267a6851c0ecc22d5b5ebec21eb2ca3366e",
+				"DiscoKey":   "discokey:678b539cbdbc1dd2b3b4420ec6b4c535d71a1b91fbdc34e55c6bf307cd16c137",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40268",
+					"10.65.0.27:40268",
+					"172.17.0.1:40268",
+					"172.18.0.1:40268",
+					"172.19.0.1:40268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:32:53.223586723Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5306201310471235,
+				"StableID":   "nNaGapuBSi11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee75185e044fb8c7785b8daf8a961311584ad07e080267742eedbde37bfd9137",
+				"DiscoKey":   "discokey:3bb418b636311b3b591f9f12e07995def4d12875626d23854bf5ea9d3e334d50",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55405",
+					"10.65.0.27:55405",
+					"172.17.0.1:55405",
+					"172.18.0.1:55405",
+					"172.19.0.1:55405"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:32:53.741071785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6564724472241463,
+				"StableID":   "nLMcmSBBGt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc14de9d9a162689136fd28faf374183af616d0481ed3b3b003309031eb21b59",
+				"DiscoKey":   "discokey:03c884c386c36199ff796cc107e227843c310c4813f4b1c7bd33a4f29cb5eb0d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54984",
+					"10.65.0.27:54984",
+					"172.17.0.1:54984",
+					"172.18.0.1:54984",
+					"172.19.0.1:54984"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:32:54.299382606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6059396706062051,
+				"StableID":   "nrCAVS5KKp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:94109679f6d34bbd8c79bdca9580cc4953b5a4539aa7a4cdbc46ad4b80c99733",
+				"KeyExpiry":  "2026-11-09T07:32:54Z",
+				"DiscoKey":   "discokey:fdc014d1d66e2d2f1608eb70e2d4ecbdef7451ed1c1b117e3fd94bda6e0cb679",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41881",
+					"10.65.0.27:41881",
+					"172.17.0.1:41881",
+					"172.18.0.1:41881",
+					"172.19.0.1:41881"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:32:54.862730909Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1677361396784083,
+				"StableID":   "nCRDnVSg6E11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:143d4f75f8ea8d8312de1d5855f0f9cb4ab5d3f93ebbb82201f2f77306639f37",
+				"KeyExpiry":  "2026-11-09T07:32:55Z",
+				"DiscoKey":   "discokey:892b260f0287567cb61ed29eb410b3bd51c0e5191a7f306baee683a77f179a3e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41785",
+					"10.65.0.27:41785",
+					"172.17.0.1:41785",
+					"172.18.0.1:41785",
+					"172.19.0.1:41785"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:32:55.363770604Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6926875846217797,
+				"StableID":   "nr7PZPHC6w11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:50539aad140a60a1b705ba3e01a36baa1c38c1eaacef8391912d0576bf609915",
+				"KeyExpiry":  "2026-11-09T07:32:55Z",
+				"DiscoKey":   "discokey:b49a52d37618740ef20f2205dadb426f1a98a98f5fc85352f4763668ea5ee85f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50973",
+					"10.65.0.27:50973",
+					"172.17.0.1:50973",
+					"172.18.0.1:50973",
+					"172.19.0.1:50973"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:32:55.977789285Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1481967211625628": {
+				"ID":          1481967211625628,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1257759953096300,
+				"StableID":   "nqoP4qDepA11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1257759953096300,
+				"Key":        "nodekey:36bb870f8dc9e3803dc5a37baf2a64de33990f745ac8076b7ebfa3a5729ea639",
+				"DiscoKey":   "discokey:6945d861c12cc14d5d6e41a7aa40a9ba904d42265dc1ca5932bb440e89ac1470",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43972",
+					"10.65.0.27:43972",
+					"172.17.0.1:43972",
+					"172.18.0.1:43972",
+					"172.19.0.1:43972"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:32:51.590602748Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:36bb870f8dc9e3803dc5a37baf2a64de33990f745ac8076b7ebfa3a5729ea639",
+			"MachineKey": "mkey:ece23abcfefcd08e060f3eb5e829282ae511069d9212deb7de7e68fb54a6f531",
+			"Peers": [{
+				"ID":         5359816779709991,
+				"StableID":   "ntMazHJUri11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eea0922ab286de3f730174cc71b6bc83d2867280d7b08a8f4edcfa61e34e3d3f",
+				"DiscoKey":   "discokey:4d0af95b4695ff00c47133467ec638f55468c24cbc2cef0efadb637a7256ae29",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52490",
+					"10.65.0.27:52490",
+					"172.17.0.1:52490",
+					"172.18.0.1:52490",
+					"172.19.0.1:52490"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:32:48.344790394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4137245329573985,
+				"StableID":   "ngciSKRmJZ11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a0b89ca4434405d36415735c8d612e4631a07e94543036b59a2311055083b00",
+				"DiscoKey":   "discokey:18e326a1803ea7fe98767ae3c00feecb5818a6a25b989214544062560e759d25",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42085",
+					"10.65.0.27:42085",
+					"172.17.0.1:42085",
+					"172.18.0.1:42085",
+					"172.19.0.1:42085"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:32:48.882592345Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8063101005441181,
+				"StableID":   "nA9Q4Uznx521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b50379d3461d041fea143c416d7be57342c67769059f3317a43f5a5421906f7b",
+				"DiscoKey":   "discokey:852103a463b3f7b46da87ae39fe35475d8af6b1a645d7e1658597724745b8c7d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35008",
+					"10.65.0.27:35008",
+					"172.17.0.1:35008",
+					"172.18.0.1:35008",
+					"172.19.0.1:35008"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:32:49.431864299Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1481967211625628,
+				"StableID":   "nXzWjQmBaC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:74c8aabc46d926dd1ac0fec904116305916c4fb4baab969c6d9806b5390e5d53",
+				"DiscoKey":   "discokey:9b280551710a3d62f04fe3c438f42b997b9ddb6efa7e404489159b9c4e3c145c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51035",
+					"10.65.0.27:51035",
+					"172.17.0.1:51035",
+					"172.18.0.1:51035",
+					"172.19.0.1:51035"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:32:49.973753515Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6975276302435565,
+				"StableID":   "n86p8Ug7Uw11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc9c8eba05af20517d5c6eeb184d56912a24178dda43bf1245ab48e49cf71b4c",
+				"DiscoKey":   "discokey:d216db9bcccd11a2838ccc6d59122831caf0670d7f2c8f33a76fb45a89c85d39",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57073",
+					"10.65.0.27:57073",
+					"172.17.0.1:57073",
+					"172.18.0.1:57073",
+					"172.19.0.1:57073"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:32:50.515690657Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5344740924395709,
+				"StableID":   "nULSHJHeji11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f42070dd2bcfb21164fc887e3063d737e6f907316243017a0ffc971cbc65574",
+				"DiscoKey":   "discokey:cf3ab951412e97b9eb904a1cd872f5d40c2ec374890a2e0cc52e2bca298e8404",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58527",
+					"10.65.0.27:58527",
+					"172.17.0.1:58527",
+					"172.18.0.1:58527",
+					"172.19.0.1:58527"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:32:51.050087982Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8013214272394711,
+				"StableID":   "n47jHxYCa521CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e08800c88148323eae3efc28d31e38eb34fc12eae2fcac549b34b44f0e0d0f66",
+				"DiscoKey":   "discokey:e0e25df51244d5685e127a8bbe126ed57fc782b70f19a8a795729e1a72606764",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36646",
+					"10.65.0.27:36646",
+					"172.17.0.1:36646",
+					"172.18.0.1:36646",
+					"172.19.0.1:36646"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:32:52.14345186Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3989811399952650,
+				"StableID":   "nZAuwdaz9Y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:572ee63a2622e7ac1f246f513bd82acd45d9fd1decd423ef835da858e5e9230f",
+				"DiscoKey":   "discokey:2b44621e0ff36d09e6b3686f29bf998a09163728cb0930951965e637a4e5ac6d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45347",
+					"10.65.0.27:45347",
+					"172.17.0.1:45347",
+					"172.18.0.1:45347",
+					"172.19.0.1:45347"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:32:52.679012032Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6041340428675552,
+				"StableID":   "nRTr5bm8Bp11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4d896e34487b494e68ccf954fb75267a6851c0ecc22d5b5ebec21eb2ca3366e",
+				"DiscoKey":   "discokey:678b539cbdbc1dd2b3b4420ec6b4c535d71a1b91fbdc34e55c6bf307cd16c137",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40268",
+					"10.65.0.27:40268",
+					"172.17.0.1:40268",
+					"172.18.0.1:40268",
+					"172.19.0.1:40268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:32:53.223586723Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5306201310471235,
+				"StableID":   "nNaGapuBSi11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee75185e044fb8c7785b8daf8a961311584ad07e080267742eedbde37bfd9137",
+				"DiscoKey":   "discokey:3bb418b636311b3b591f9f12e07995def4d12875626d23854bf5ea9d3e334d50",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55405",
+					"10.65.0.27:55405",
+					"172.17.0.1:55405",
+					"172.18.0.1:55405",
+					"172.19.0.1:55405"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:32:53.741071785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6564724472241463,
+				"StableID":   "nLMcmSBBGt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc14de9d9a162689136fd28faf374183af616d0481ed3b3b003309031eb21b59",
+				"DiscoKey":   "discokey:03c884c386c36199ff796cc107e227843c310c4813f4b1c7bd33a4f29cb5eb0d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54984",
+					"10.65.0.27:54984",
+					"172.17.0.1:54984",
+					"172.18.0.1:54984",
+					"172.19.0.1:54984"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:32:54.299382606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6059396706062051,
+				"StableID":   "nrCAVS5KKp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:94109679f6d34bbd8c79bdca9580cc4953b5a4539aa7a4cdbc46ad4b80c99733",
+				"KeyExpiry":  "2026-11-09T07:32:54Z",
+				"DiscoKey":   "discokey:fdc014d1d66e2d2f1608eb70e2d4ecbdef7451ed1c1b117e3fd94bda6e0cb679",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41881",
+					"10.65.0.27:41881",
+					"172.17.0.1:41881",
+					"172.18.0.1:41881",
+					"172.19.0.1:41881"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:32:54.862730909Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1677361396784083,
+				"StableID":   "nCRDnVSg6E11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:143d4f75f8ea8d8312de1d5855f0f9cb4ab5d3f93ebbb82201f2f77306639f37",
+				"KeyExpiry":  "2026-11-09T07:32:55Z",
+				"DiscoKey":   "discokey:892b260f0287567cb61ed29eb410b3bd51c0e5191a7f306baee683a77f179a3e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41785",
+					"10.65.0.27:41785",
+					"172.17.0.1:41785",
+					"172.18.0.1:41785",
+					"172.19.0.1:41785"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:32:55.363770604Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6926875846217797,
+				"StableID":   "nr7PZPHC6w11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:50539aad140a60a1b705ba3e01a36baa1c38c1eaacef8391912d0576bf609915",
+				"KeyExpiry":  "2026-11-09T07:32:55Z",
+				"DiscoKey":   "discokey:b49a52d37618740ef20f2205dadb426f1a98a98f5fc85352f4763668ea5ee85f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50973",
+					"10.65.0.27:50973",
+					"172.17.0.1:50973",
+					"172.18.0.1:50973",
+					"172.19.0.1:50973"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:32:55.977789285Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1257759953096300": {
+				"ID":          1257759953096300,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}, "1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3989811399952650,
+				"StableID":   "nZAuwdaz9Y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       3989811399952650,
+				"Key":        "nodekey:572ee63a2622e7ac1f246f513bd82acd45d9fd1decd423ef835da858e5e9230f",
+				"DiscoKey":   "discokey:2b44621e0ff36d09e6b3686f29bf998a09163728cb0930951965e637a4e5ac6d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45347",
+					"10.65.0.27:45347",
+					"172.17.0.1:45347",
+					"172.18.0.1:45347",
+					"172.19.0.1:45347"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T07:32:52.679012032Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:572ee63a2622e7ac1f246f513bd82acd45d9fd1decd423ef835da858e5e9230f",
+			"MachineKey": "mkey:c76aec8f4aeb8dcd56814a07806ab6df5485dd42f56096a220d11147271ed92c",
+			"Peers": [{
+				"ID":         5359816779709991,
+				"StableID":   "ntMazHJUri11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eea0922ab286de3f730174cc71b6bc83d2867280d7b08a8f4edcfa61e34e3d3f",
+				"DiscoKey":   "discokey:4d0af95b4695ff00c47133467ec638f55468c24cbc2cef0efadb637a7256ae29",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52490",
+					"10.65.0.27:52490",
+					"172.17.0.1:52490",
+					"172.18.0.1:52490",
+					"172.19.0.1:52490"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:32:48.344790394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4137245329573985,
+				"StableID":   "ngciSKRmJZ11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a0b89ca4434405d36415735c8d612e4631a07e94543036b59a2311055083b00",
+				"DiscoKey":   "discokey:18e326a1803ea7fe98767ae3c00feecb5818a6a25b989214544062560e759d25",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42085",
+					"10.65.0.27:42085",
+					"172.17.0.1:42085",
+					"172.18.0.1:42085",
+					"172.19.0.1:42085"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:32:48.882592345Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8063101005441181,
+				"StableID":   "nA9Q4Uznx521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b50379d3461d041fea143c416d7be57342c67769059f3317a43f5a5421906f7b",
+				"DiscoKey":   "discokey:852103a463b3f7b46da87ae39fe35475d8af6b1a645d7e1658597724745b8c7d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35008",
+					"10.65.0.27:35008",
+					"172.17.0.1:35008",
+					"172.18.0.1:35008",
+					"172.19.0.1:35008"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:32:49.431864299Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1481967211625628,
+				"StableID":   "nXzWjQmBaC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:74c8aabc46d926dd1ac0fec904116305916c4fb4baab969c6d9806b5390e5d53",
+				"DiscoKey":   "discokey:9b280551710a3d62f04fe3c438f42b997b9ddb6efa7e404489159b9c4e3c145c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51035",
+					"10.65.0.27:51035",
+					"172.17.0.1:51035",
+					"172.18.0.1:51035",
+					"172.19.0.1:51035"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:32:49.973753515Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6975276302435565,
+				"StableID":   "n86p8Ug7Uw11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc9c8eba05af20517d5c6eeb184d56912a24178dda43bf1245ab48e49cf71b4c",
+				"DiscoKey":   "discokey:d216db9bcccd11a2838ccc6d59122831caf0670d7f2c8f33a76fb45a89c85d39",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57073",
+					"10.65.0.27:57073",
+					"172.17.0.1:57073",
+					"172.18.0.1:57073",
+					"172.19.0.1:57073"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:32:50.515690657Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5344740924395709,
+				"StableID":   "nULSHJHeji11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f42070dd2bcfb21164fc887e3063d737e6f907316243017a0ffc971cbc65574",
+				"DiscoKey":   "discokey:cf3ab951412e97b9eb904a1cd872f5d40c2ec374890a2e0cc52e2bca298e8404",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58527",
+					"10.65.0.27:58527",
+					"172.17.0.1:58527",
+					"172.18.0.1:58527",
+					"172.19.0.1:58527"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:32:51.050087982Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1257759953096300,
+				"StableID":   "nqoP4qDepA11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36bb870f8dc9e3803dc5a37baf2a64de33990f745ac8076b7ebfa3a5729ea639",
+				"DiscoKey":   "discokey:6945d861c12cc14d5d6e41a7aa40a9ba904d42265dc1ca5932bb440e89ac1470",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43972",
+					"10.65.0.27:43972",
+					"172.17.0.1:43972",
+					"172.18.0.1:43972",
+					"172.19.0.1:43972"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:32:51.590602748Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8013214272394711,
+				"StableID":   "n47jHxYCa521CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e08800c88148323eae3efc28d31e38eb34fc12eae2fcac549b34b44f0e0d0f66",
+				"DiscoKey":   "discokey:e0e25df51244d5685e127a8bbe126ed57fc782b70f19a8a795729e1a72606764",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36646",
+					"10.65.0.27:36646",
+					"172.17.0.1:36646",
+					"172.18.0.1:36646",
+					"172.19.0.1:36646"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:32:52.14345186Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6041340428675552,
+				"StableID":   "nRTr5bm8Bp11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4d896e34487b494e68ccf954fb75267a6851c0ecc22d5b5ebec21eb2ca3366e",
+				"DiscoKey":   "discokey:678b539cbdbc1dd2b3b4420ec6b4c535d71a1b91fbdc34e55c6bf307cd16c137",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40268",
+					"10.65.0.27:40268",
+					"172.17.0.1:40268",
+					"172.18.0.1:40268",
+					"172.19.0.1:40268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:32:53.223586723Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5306201310471235,
+				"StableID":   "nNaGapuBSi11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee75185e044fb8c7785b8daf8a961311584ad07e080267742eedbde37bfd9137",
+				"DiscoKey":   "discokey:3bb418b636311b3b591f9f12e07995def4d12875626d23854bf5ea9d3e334d50",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55405",
+					"10.65.0.27:55405",
+					"172.17.0.1:55405",
+					"172.18.0.1:55405",
+					"172.19.0.1:55405"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:32:53.741071785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6564724472241463,
+				"StableID":   "nLMcmSBBGt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc14de9d9a162689136fd28faf374183af616d0481ed3b3b003309031eb21b59",
+				"DiscoKey":   "discokey:03c884c386c36199ff796cc107e227843c310c4813f4b1c7bd33a4f29cb5eb0d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54984",
+					"10.65.0.27:54984",
+					"172.17.0.1:54984",
+					"172.18.0.1:54984",
+					"172.19.0.1:54984"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:32:54.299382606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6059396706062051,
+				"StableID":   "nrCAVS5KKp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:94109679f6d34bbd8c79bdca9580cc4953b5a4539aa7a4cdbc46ad4b80c99733",
+				"KeyExpiry":  "2026-11-09T07:32:54Z",
+				"DiscoKey":   "discokey:fdc014d1d66e2d2f1608eb70e2d4ecbdef7451ed1c1b117e3fd94bda6e0cb679",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41881",
+					"10.65.0.27:41881",
+					"172.17.0.1:41881",
+					"172.18.0.1:41881",
+					"172.19.0.1:41881"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:32:54.862730909Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1677361396784083,
+				"StableID":   "nCRDnVSg6E11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:143d4f75f8ea8d8312de1d5855f0f9cb4ab5d3f93ebbb82201f2f77306639f37",
+				"KeyExpiry":  "2026-11-09T07:32:55Z",
+				"DiscoKey":   "discokey:892b260f0287567cb61ed29eb410b3bd51c0e5191a7f306baee683a77f179a3e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41785",
+					"10.65.0.27:41785",
+					"172.17.0.1:41785",
+					"172.18.0.1:41785",
+					"172.19.0.1:41785"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:32:55.363770604Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6926875846217797,
+				"StableID":   "nr7PZPHC6w11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:50539aad140a60a1b705ba3e01a36baa1c38c1eaacef8391912d0576bf609915",
+				"KeyExpiry":  "2026-11-09T07:32:55Z",
+				"DiscoKey":   "discokey:b49a52d37618740ef20f2205dadb426f1a98a98f5fc85352f4763668ea5ee85f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50973",
+					"10.65.0.27:50973",
+					"172.17.0.1:50973",
+					"172.18.0.1:50973",
+					"172.19.0.1:50973"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:32:55.977789285Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "3989811399952650": {
+				"ID":          3989811399952650,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1677361396784083,
+				"StableID":   "nCRDnVSg6E11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:143d4f75f8ea8d8312de1d5855f0f9cb4ab5d3f93ebbb82201f2f77306639f37",
+				"KeyExpiry":  "2026-11-09T07:32:55Z",
+				"DiscoKey":   "discokey:892b260f0287567cb61ed29eb410b3bd51c0e5191a7f306baee683a77f179a3e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41785",
+					"10.65.0.27:41785",
+					"172.17.0.1:41785",
+					"172.18.0.1:41785",
+					"172.19.0.1:41785"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:32:55.363770604Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:143d4f75f8ea8d8312de1d5855f0f9cb4ab5d3f93ebbb82201f2f77306639f37",
+			"MachineKey": "mkey:6ab1d43da4aa670ce49c9d11b6d08a2f4d083df73e3632e40782d8f300937b76",
+			"Peers": [{
+				"ID":         5359816779709991,
+				"StableID":   "ntMazHJUri11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eea0922ab286de3f730174cc71b6bc83d2867280d7b08a8f4edcfa61e34e3d3f",
+				"DiscoKey":   "discokey:4d0af95b4695ff00c47133467ec638f55468c24cbc2cef0efadb637a7256ae29",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52490",
+					"10.65.0.27:52490",
+					"172.17.0.1:52490",
+					"172.18.0.1:52490",
+					"172.19.0.1:52490"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:32:48.344790394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4137245329573985,
+				"StableID":   "ngciSKRmJZ11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a0b89ca4434405d36415735c8d612e4631a07e94543036b59a2311055083b00",
+				"DiscoKey":   "discokey:18e326a1803ea7fe98767ae3c00feecb5818a6a25b989214544062560e759d25",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42085",
+					"10.65.0.27:42085",
+					"172.17.0.1:42085",
+					"172.18.0.1:42085",
+					"172.19.0.1:42085"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:32:48.882592345Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8063101005441181,
+				"StableID":   "nA9Q4Uznx521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b50379d3461d041fea143c416d7be57342c67769059f3317a43f5a5421906f7b",
+				"DiscoKey":   "discokey:852103a463b3f7b46da87ae39fe35475d8af6b1a645d7e1658597724745b8c7d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35008",
+					"10.65.0.27:35008",
+					"172.17.0.1:35008",
+					"172.18.0.1:35008",
+					"172.19.0.1:35008"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:32:49.431864299Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1481967211625628,
+				"StableID":   "nXzWjQmBaC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:74c8aabc46d926dd1ac0fec904116305916c4fb4baab969c6d9806b5390e5d53",
+				"DiscoKey":   "discokey:9b280551710a3d62f04fe3c438f42b997b9ddb6efa7e404489159b9c4e3c145c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51035",
+					"10.65.0.27:51035",
+					"172.17.0.1:51035",
+					"172.18.0.1:51035",
+					"172.19.0.1:51035"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:32:49.973753515Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6975276302435565,
+				"StableID":   "n86p8Ug7Uw11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc9c8eba05af20517d5c6eeb184d56912a24178dda43bf1245ab48e49cf71b4c",
+				"DiscoKey":   "discokey:d216db9bcccd11a2838ccc6d59122831caf0670d7f2c8f33a76fb45a89c85d39",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57073",
+					"10.65.0.27:57073",
+					"172.17.0.1:57073",
+					"172.18.0.1:57073",
+					"172.19.0.1:57073"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:32:50.515690657Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5344740924395709,
+				"StableID":   "nULSHJHeji11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f42070dd2bcfb21164fc887e3063d737e6f907316243017a0ffc971cbc65574",
+				"DiscoKey":   "discokey:cf3ab951412e97b9eb904a1cd872f5d40c2ec374890a2e0cc52e2bca298e8404",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58527",
+					"10.65.0.27:58527",
+					"172.17.0.1:58527",
+					"172.18.0.1:58527",
+					"172.19.0.1:58527"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:32:51.050087982Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1257759953096300,
+				"StableID":   "nqoP4qDepA11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36bb870f8dc9e3803dc5a37baf2a64de33990f745ac8076b7ebfa3a5729ea639",
+				"DiscoKey":   "discokey:6945d861c12cc14d5d6e41a7aa40a9ba904d42265dc1ca5932bb440e89ac1470",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43972",
+					"10.65.0.27:43972",
+					"172.17.0.1:43972",
+					"172.18.0.1:43972",
+					"172.19.0.1:43972"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:32:51.590602748Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8013214272394711,
+				"StableID":   "n47jHxYCa521CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e08800c88148323eae3efc28d31e38eb34fc12eae2fcac549b34b44f0e0d0f66",
+				"DiscoKey":   "discokey:e0e25df51244d5685e127a8bbe126ed57fc782b70f19a8a795729e1a72606764",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36646",
+					"10.65.0.27:36646",
+					"172.17.0.1:36646",
+					"172.18.0.1:36646",
+					"172.19.0.1:36646"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:32:52.14345186Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3989811399952650,
+				"StableID":   "nZAuwdaz9Y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:572ee63a2622e7ac1f246f513bd82acd45d9fd1decd423ef835da858e5e9230f",
+				"DiscoKey":   "discokey:2b44621e0ff36d09e6b3686f29bf998a09163728cb0930951965e637a4e5ac6d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45347",
+					"10.65.0.27:45347",
+					"172.17.0.1:45347",
+					"172.18.0.1:45347",
+					"172.19.0.1:45347"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:32:52.679012032Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6041340428675552,
+				"StableID":   "nRTr5bm8Bp11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4d896e34487b494e68ccf954fb75267a6851c0ecc22d5b5ebec21eb2ca3366e",
+				"DiscoKey":   "discokey:678b539cbdbc1dd2b3b4420ec6b4c535d71a1b91fbdc34e55c6bf307cd16c137",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40268",
+					"10.65.0.27:40268",
+					"172.17.0.1:40268",
+					"172.18.0.1:40268",
+					"172.19.0.1:40268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T07:32:53.223586723Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5306201310471235,
+				"StableID":   "nNaGapuBSi11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee75185e044fb8c7785b8daf8a961311584ad07e080267742eedbde37bfd9137",
+				"DiscoKey":   "discokey:3bb418b636311b3b591f9f12e07995def4d12875626d23854bf5ea9d3e334d50",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55405",
+					"10.65.0.27:55405",
+					"172.17.0.1:55405",
+					"172.18.0.1:55405",
+					"172.19.0.1:55405"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:32:53.741071785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6564724472241463,
+				"StableID":   "nLMcmSBBGt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc14de9d9a162689136fd28faf374183af616d0481ed3b3b003309031eb21b59",
+				"DiscoKey":   "discokey:03c884c386c36199ff796cc107e227843c310c4813f4b1c7bd33a4f29cb5eb0d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54984",
+					"10.65.0.27:54984",
+					"172.17.0.1:54984",
+					"172.18.0.1:54984",
+					"172.19.0.1:54984"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:32:54.299382606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6059396706062051,
+				"StableID":   "nrCAVS5KKp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:94109679f6d34bbd8c79bdca9580cc4953b5a4539aa7a4cdbc46ad4b80c99733",
+				"KeyExpiry":  "2026-11-09T07:32:54Z",
+				"DiscoKey":   "discokey:fdc014d1d66e2d2f1608eb70e2d4ecbdef7451ed1c1b117e3fd94bda6e0cb679",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41881",
+					"10.65.0.27:41881",
+					"172.17.0.1:41881",
+					"172.18.0.1:41881",
+					"172.19.0.1:41881"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:32:54.862730909Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6926875846217797,
+				"StableID":   "nr7PZPHC6w11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:50539aad140a60a1b705ba3e01a36baa1c38c1eaacef8391912d0576bf609915",
+				"KeyExpiry":  "2026-11-09T07:32:55Z",
+				"DiscoKey":   "discokey:b49a52d37618740ef20f2205dadb426f1a98a98f5fc85352f4763668ea5ee85f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50973",
+					"10.65.0.27:50973",
+					"172.17.0.1:50973",
+					"172.18.0.1:50973",
+					"172.19.0.1:50973"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:32:55.977789285Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6041340428675552,
+				"StableID":   "nRTr5bm8Bp11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       6041340428675552,
+				"Key":        "nodekey:a4d896e34487b494e68ccf954fb75267a6851c0ecc22d5b5ebec21eb2ca3366e",
+				"DiscoKey":   "discokey:678b539cbdbc1dd2b3b4420ec6b4c535d71a1b91fbdc34e55c6bf307cd16c137",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40268",
+					"10.65.0.27:40268",
+					"172.17.0.1:40268",
+					"172.18.0.1:40268",
+					"172.19.0.1:40268"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T07:32:53.223586723Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a4d896e34487b494e68ccf954fb75267a6851c0ecc22d5b5ebec21eb2ca3366e",
+			"MachineKey": "mkey:0e82ba74a62b07f612c36735dbfd13d4c52e9b80acf882faba908db4977ecc77",
+			"Peers": [{
+				"ID":         5359816779709991,
+				"StableID":   "ntMazHJUri11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:eea0922ab286de3f730174cc71b6bc83d2867280d7b08a8f4edcfa61e34e3d3f",
+				"DiscoKey":   "discokey:4d0af95b4695ff00c47133467ec638f55468c24cbc2cef0efadb637a7256ae29",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52490",
+					"10.65.0.27:52490",
+					"172.17.0.1:52490",
+					"172.18.0.1:52490",
+					"172.19.0.1:52490"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T07:32:48.344790394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4137245329573985,
+				"StableID":   "ngciSKRmJZ11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a0b89ca4434405d36415735c8d612e4631a07e94543036b59a2311055083b00",
+				"DiscoKey":   "discokey:18e326a1803ea7fe98767ae3c00feecb5818a6a25b989214544062560e759d25",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:42085",
+					"10.65.0.27:42085",
+					"172.17.0.1:42085",
+					"172.18.0.1:42085",
+					"172.19.0.1:42085"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T07:32:48.882592345Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8063101005441181,
+				"StableID":   "nA9Q4Uznx521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b50379d3461d041fea143c416d7be57342c67769059f3317a43f5a5421906f7b",
+				"DiscoKey":   "discokey:852103a463b3f7b46da87ae39fe35475d8af6b1a645d7e1658597724745b8c7d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35008",
+					"10.65.0.27:35008",
+					"172.17.0.1:35008",
+					"172.18.0.1:35008",
+					"172.19.0.1:35008"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T07:32:49.431864299Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1481967211625628,
+				"StableID":   "nXzWjQmBaC11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:74c8aabc46d926dd1ac0fec904116305916c4fb4baab969c6d9806b5390e5d53",
+				"DiscoKey":   "discokey:9b280551710a3d62f04fe3c438f42b997b9ddb6efa7e404489159b9c4e3c145c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:51035",
+					"10.65.0.27:51035",
+					"172.17.0.1:51035",
+					"172.18.0.1:51035",
+					"172.19.0.1:51035"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T07:32:49.973753515Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6975276302435565,
+				"StableID":   "n86p8Ug7Uw11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc9c8eba05af20517d5c6eeb184d56912a24178dda43bf1245ab48e49cf71b4c",
+				"DiscoKey":   "discokey:d216db9bcccd11a2838ccc6d59122831caf0670d7f2c8f33a76fb45a89c85d39",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57073",
+					"10.65.0.27:57073",
+					"172.17.0.1:57073",
+					"172.18.0.1:57073",
+					"172.19.0.1:57073"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T07:32:50.515690657Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5344740924395709,
+				"StableID":   "nULSHJHeji11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f42070dd2bcfb21164fc887e3063d737e6f907316243017a0ffc971cbc65574",
+				"DiscoKey":   "discokey:cf3ab951412e97b9eb904a1cd872f5d40c2ec374890a2e0cc52e2bca298e8404",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58527",
+					"10.65.0.27:58527",
+					"172.17.0.1:58527",
+					"172.18.0.1:58527",
+					"172.19.0.1:58527"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T07:32:51.050087982Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1257759953096300,
+				"StableID":   "nqoP4qDepA11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36bb870f8dc9e3803dc5a37baf2a64de33990f745ac8076b7ebfa3a5729ea639",
+				"DiscoKey":   "discokey:6945d861c12cc14d5d6e41a7aa40a9ba904d42265dc1ca5932bb440e89ac1470",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43972",
+					"10.65.0.27:43972",
+					"172.17.0.1:43972",
+					"172.18.0.1:43972",
+					"172.19.0.1:43972"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T07:32:51.590602748Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8013214272394711,
+				"StableID":   "n47jHxYCa521CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e08800c88148323eae3efc28d31e38eb34fc12eae2fcac549b34b44f0e0d0f66",
+				"DiscoKey":   "discokey:e0e25df51244d5685e127a8bbe126ed57fc782b70f19a8a795729e1a72606764",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36646",
+					"10.65.0.27:36646",
+					"172.17.0.1:36646",
+					"172.18.0.1:36646",
+					"172.19.0.1:36646"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T07:32:52.14345186Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3989811399952650,
+				"StableID":   "nZAuwdaz9Y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:572ee63a2622e7ac1f246f513bd82acd45d9fd1decd423ef835da858e5e9230f",
+				"DiscoKey":   "discokey:2b44621e0ff36d09e6b3686f29bf998a09163728cb0930951965e637a4e5ac6d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45347",
+					"10.65.0.27:45347",
+					"172.17.0.1:45347",
+					"172.18.0.1:45347",
+					"172.19.0.1:45347"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T07:32:52.679012032Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5306201310471235,
+				"StableID":   "nNaGapuBSi11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee75185e044fb8c7785b8daf8a961311584ad07e080267742eedbde37bfd9137",
+				"DiscoKey":   "discokey:3bb418b636311b3b591f9f12e07995def4d12875626d23854bf5ea9d3e334d50",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55405",
+					"10.65.0.27:55405",
+					"172.17.0.1:55405",
+					"172.18.0.1:55405",
+					"172.19.0.1:55405"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T07:32:53.741071785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6564724472241463,
+				"StableID":   "nLMcmSBBGt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc14de9d9a162689136fd28faf374183af616d0481ed3b3b003309031eb21b59",
+				"DiscoKey":   "discokey:03c884c386c36199ff796cc107e227843c310c4813f4b1c7bd33a4f29cb5eb0d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:54984",
+					"10.65.0.27:54984",
+					"172.17.0.1:54984",
+					"172.18.0.1:54984",
+					"172.19.0.1:54984"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T07:32:54.299382606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6059396706062051,
+				"StableID":   "nrCAVS5KKp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:94109679f6d34bbd8c79bdca9580cc4953b5a4539aa7a4cdbc46ad4b80c99733",
+				"KeyExpiry":  "2026-11-09T07:32:54Z",
+				"DiscoKey":   "discokey:fdc014d1d66e2d2f1608eb70e2d4ecbdef7451ed1c1b117e3fd94bda6e0cb679",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:41881",
+					"10.65.0.27:41881",
+					"172.17.0.1:41881",
+					"172.18.0.1:41881",
+					"172.19.0.1:41881"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T07:32:54.862730909Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1677361396784083,
+				"StableID":   "nCRDnVSg6E11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:143d4f75f8ea8d8312de1d5855f0f9cb4ab5d3f93ebbb82201f2f77306639f37",
+				"KeyExpiry":  "2026-11-09T07:32:55Z",
+				"DiscoKey":   "discokey:892b260f0287567cb61ed29eb410b3bd51c0e5191a7f306baee683a77f179a3e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41785",
+					"10.65.0.27:41785",
+					"172.17.0.1:41785",
+					"172.18.0.1:41785",
+					"172.19.0.1:41785"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T07:32:55.363770604Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6926875846217797,
+				"StableID":   "nr7PZPHC6w11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:50539aad140a60a1b705ba3e01a36baa1c38c1eaacef8391912d0576bf609915",
+				"KeyExpiry":  "2026-11-09T07:32:55Z",
+				"DiscoKey":   "discokey:b49a52d37618740ef20f2205dadb426f1a98a98f5fc85352f4763668ea5ee85f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50973",
+					"10.65.0.27:50973",
+					"172.17.0.1:50973",
+					"172.18.0.1:50973",
+					"172.19.0.1:50973"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T07:32:55.977789285Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6041340428675552": {
+				"ID":          6041340428675552,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-many-tags-as-dst.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-many-tags-as-dst.hujson
@@ -1,0 +1,22143 @@
+// ssh-many-tags-as-dst
+//
+// ssh rule with multiple tag dsts
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-13T09:14:30Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-many-tags-as-dst",
+	"description":    "ssh rule with multiple tag dsts",
+	"category":       "ssh",
+	"captured_at":    "2026-05-13T09:14:30.37198918Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                       \n  \n                                                                      \n                                     \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh rule with multiple tag dsts\",\n\t\"id\":          \"ssh-many-tags-as-dst\",\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\", \"tag:prod\", \"tag:extra\"],\n\t\t\"src\":    [\"thor@example.org\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:extra\":  [\"odin@example.com\"],\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-edges/ssh-many-tags-as-dst.hujson",
+		"full_policy": {"ssh": [{
+			"action": "accept",
+			"dst":    ["tag:server", "tag:prod", "tag:extra"],
+			"src":    ["thor@example.org"],
+			"users":  ["root"]
+		}], "tagOwners": {
+			"tag:extra":  ["odin@example.com"],
+			"tag:prod":   ["odin@example.com"],
+			"tag:server": ["odin@example.com"]
+		}}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7492479871341914,
+				"StableID":   "nZCSSzjMW121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       7492479871341914,
+				"Key":        "nodekey:94197bf76ee983cf5ce7b3e7e45ec911814a04b83ce8e72cc0e9ca36ada86224",
+				"DiscoKey":   "discokey:f581bc05b5d08fb8541feae196c4866e94b3813c08df8d843f2c3dec3e3a0b5e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38464",
+					"10.65.0.27:38464",
+					"172.17.0.1:38464",
+					"172.18.0.1:38464",
+					"172.19.0.1:38464",
+					"172.20.0.1:38464",
+					"172.21.0.1:38464",
+					"172.22.0.1:38464",
+					"172.23.0.1:38464",
+					"172.24.0.1:38464",
+					"172.25.0.1:38464",
+					"172.26.0.1:38464",
+					"172.27.0.1:38464",
+					"172.28.0.1:38464"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:14:38.807670086Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:94197bf76ee983cf5ce7b3e7e45ec911814a04b83ce8e72cc0e9ca36ada86224",
+			"MachineKey": "mkey:263fac9c7b3446741344d5948d554420a4c07c83f8c01e3e695d75b35e9f3a01",
+			"Peers": [{
+				"ID":         2840293870652164,
+				"StableID":   "nTSmDphNBP11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65bfe3aab37558c3d4257f7c4a3ce5a1fe9c0d545783dffd6fb27ffffa470a2e",
+				"DiscoKey":   "discokey:a4d7e3fb3fc79731a2c6d0f9981b49fd9888a3dccb9ea5ec8f79708e2549d90f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47906",
+					"10.65.0.27:47906",
+					"172.17.0.1:47906",
+					"172.18.0.1:47906",
+					"172.19.0.1:47906",
+					"172.20.0.1:47906",
+					"172.21.0.1:47906",
+					"172.22.0.1:47906",
+					"172.23.0.1:47906",
+					"172.24.0.1:47906",
+					"172.25.0.1:47906",
+					"172.26.0.1:47906",
+					"172.27.0.1:47906",
+					"172.28.0.1:47906"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:14:32.914936157Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3944447720512740,
+				"StableID":   "nBYEwGxSoX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd52f08d01f7e477b25d99a8459790671a4edcf479268db13bcb68972da5ef26",
+				"DiscoKey":   "discokey:29c2f5ece02e2602991a80fcd1e26044ae95e886a22a1c71132f7f3f301de552",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35813",
+					"10.65.0.27:35813",
+					"172.17.0.1:35813",
+					"172.18.0.1:35813",
+					"172.19.0.1:35813",
+					"172.20.0.1:35813",
+					"172.21.0.1:35813",
+					"172.22.0.1:35813",
+					"172.23.0.1:35813",
+					"172.24.0.1:35813",
+					"172.25.0.1:35813",
+					"172.26.0.1:35813",
+					"172.27.0.1:35813",
+					"172.28.0.1:35813"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:14:33.444311138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8196632796973305,
+				"StableID":   "nQteDPeG1721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c08f2124f0292c7e3bc13e2d8d2ad4f092a71686f3b24f88b7bb47201513d54",
+				"DiscoKey":   "discokey:dacc24dde10d1a36e280fcc9402f9b7187f0ea43128cf478d76b73dfc175f602",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39819",
+					"10.65.0.27:39819",
+					"172.17.0.1:39819",
+					"172.18.0.1:39819",
+					"172.19.0.1:39819",
+					"172.20.0.1:39819",
+					"172.21.0.1:39819",
+					"172.22.0.1:39819",
+					"172.23.0.1:39819",
+					"172.24.0.1:39819",
+					"172.25.0.1:39819",
+					"172.26.0.1:39819",
+					"172.27.0.1:39819",
+					"172.28.0.1:39819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:14:33.978522762Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3530720735132739,
+				"StableID":   "n6nkyh35aU11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3fb7232e7768dec4cba16c8e80abc1bd76a65ce5350208774913c4617f346323",
+				"DiscoKey":   "discokey:561530bf3f9f0768e9c504a9c5e5c13b4c7dac43ea67fdced9290132ec9d1509",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35092",
+					"10.65.0.27:35092",
+					"172.17.0.1:35092",
+					"172.18.0.1:35092",
+					"172.19.0.1:35092",
+					"172.20.0.1:35092",
+					"172.21.0.1:35092",
+					"172.22.0.1:35092",
+					"172.23.0.1:35092",
+					"172.24.0.1:35092",
+					"172.25.0.1:35092",
+					"172.26.0.1:35092",
+					"172.27.0.1:35092",
+					"172.28.0.1:35092"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:14:34.519796394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8493166885310382,
+				"StableID":   "nF1wAM6aK921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b67714dc940f6a6c3f20bc0474c08f0a0d508dbb660b67d4e5382af025a9b264",
+				"DiscoKey":   "discokey:eb7f68d16983c883fefeeee570629d844f6b1821f78a8769b6c8ffa26e64c97f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49260",
+					"10.65.0.27:49260",
+					"172.17.0.1:49260",
+					"172.18.0.1:49260",
+					"172.19.0.1:49260",
+					"172.20.0.1:49260",
+					"172.21.0.1:49260",
+					"172.22.0.1:49260",
+					"172.23.0.1:49260",
+					"172.24.0.1:49260",
+					"172.25.0.1:49260",
+					"172.26.0.1:49260",
+					"172.27.0.1:49260",
+					"172.28.0.1:49260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:14:35.055432543Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6905021408415337,
+				"StableID":   "nJd9joCJvv11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22a6989ab145d63e5dc0190d424872b2e13d69c840276015ada95a260ee3a813",
+				"DiscoKey":   "discokey:3d2b4f0c5ca407ea4226bfcf74e39faaf98d448741f49a4ea4a55c51a6c97e74",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33099",
+					"10.65.0.27:33099",
+					"172.17.0.1:33099",
+					"172.18.0.1:33099",
+					"172.19.0.1:33099",
+					"172.20.0.1:33099",
+					"172.21.0.1:33099",
+					"172.22.0.1:33099",
+					"172.23.0.1:33099",
+					"172.24.0.1:33099",
+					"172.25.0.1:33099",
+					"172.26.0.1:33099",
+					"172.27.0.1:33099",
+					"172.28.0.1:33099"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:14:35.589805582Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1378366829076477,
+				"StableID":   "nnF2hqMGmB11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8c1cae6b2713e6afd28791292ce29afa5e8d37fbbc5fd5b91047d0e74980d2c",
+				"DiscoKey":   "discokey:f8e2a2f49c94748f64d088c0c05530956245a73e92321502c7ef5a8c374bcb3a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51558",
+					"10.65.0.27:51558",
+					"172.17.0.1:51558",
+					"172.18.0.1:51558",
+					"172.19.0.1:51558",
+					"172.20.0.1:51558",
+					"172.21.0.1:51558",
+					"172.22.0.1:51558",
+					"172.23.0.1:51558",
+					"172.24.0.1:51558",
+					"172.25.0.1:51558",
+					"172.26.0.1:51558",
+					"172.27.0.1:51558",
+					"172.28.0.1:51558"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:14:36.123605174Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8096131484985793,
+				"StableID":   "nQ8rRSekD621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5ed161b91ef60de21d1932add68bb1a403c7075494bc635c14ed065846b6023",
+				"DiscoKey":   "discokey:342cf3aa2e3fe8811029ee42ffb6911b44105deb8348846ff4b891d9d2842559",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36582",
+					"10.65.0.27:36582",
+					"172.17.0.1:36582",
+					"172.18.0.1:36582",
+					"172.19.0.1:36582",
+					"172.20.0.1:36582",
+					"172.21.0.1:36582",
+					"172.22.0.1:36582",
+					"172.23.0.1:36582",
+					"172.24.0.1:36582",
+					"172.25.0.1:36582",
+					"172.26.0.1:36582",
+					"172.27.0.1:36582",
+					"172.28.0.1:36582"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:14:36.697309618Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5263862495942249,
+				"StableID":   "nnFwW2k17i11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:759cab22549715a036dc3776fd5599511ec3132e6c4d69858d27095db3d99b17",
+				"DiscoKey":   "discokey:a24b6e3eb1290c84367432907f3c785aacb66b15edc579bd872a8aa4e6550e2b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53998",
+					"10.65.0.27:53998",
+					"172.17.0.1:53998",
+					"172.18.0.1:53998",
+					"172.19.0.1:53998",
+					"172.20.0.1:53998",
+					"172.21.0.1:53998",
+					"172.22.0.1:53998",
+					"172.23.0.1:53998",
+					"172.24.0.1:53998",
+					"172.25.0.1:53998",
+					"172.26.0.1:53998",
+					"172.27.0.1:53998",
+					"172.28.0.1:53998"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:14:37.223103871Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         652158256515153,
+				"StableID":   "nvVCvJ6N6611CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f71f8cedfac1f8c676ad5c576041a4eecf18f24d30471f99ea12cdc3224b208",
+				"DiscoKey":   "discokey:78940d0a8f7aa5a7a819ac538f90c50575351ec5646ea57b96f1a65127ffb662",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59893",
+					"10.65.0.27:59893",
+					"172.17.0.1:59893",
+					"172.18.0.1:59893",
+					"172.19.0.1:59893",
+					"172.20.0.1:59893",
+					"172.21.0.1:59893",
+					"172.22.0.1:59893",
+					"172.23.0.1:59893",
+					"172.24.0.1:59893",
+					"172.25.0.1:59893",
+					"172.26.0.1:59893",
+					"172.27.0.1:59893",
+					"172.28.0.1:59893"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:14:37.736228983Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2630166202798887,
+				"StableID":   "nxf6mM1DYM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b1232181959ec13a3e9624e8ce271ccf28570308e230e27c39182ace737853c",
+				"DiscoKey":   "discokey:ef2ec17c497da07d53c33ec478e9fc67db2d46ab0633a3a8510c322266249408",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:46591",
+					"10.65.0.27:46591",
+					"172.17.0.1:46591",
+					"172.18.0.1:46591",
+					"172.19.0.1:46591",
+					"172.20.0.1:46591",
+					"172.21.0.1:46591",
+					"172.22.0.1:46591",
+					"172.23.0.1:46591",
+					"172.24.0.1:46591",
+					"172.25.0.1:46591",
+					"172.26.0.1:46591",
+					"172.27.0.1:46591",
+					"172.28.0.1:46591"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:14:38.273699887Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4496192053903417,
+				"StableID":   "nCgPKnLL7c11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8ba3519054665252fe52daf2ca358693b2874665dac7febee26662dc7df2772d",
+				"KeyExpiry":  "2026-11-09T09:14:39Z",
+				"DiscoKey":   "discokey:6333bf224f6f9dcfcd47951e70e92b96218bdbea11fcbef77e28ba214c06303e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54449",
+					"10.65.0.27:54449",
+					"172.17.0.1:54449",
+					"172.18.0.1:54449",
+					"172.19.0.1:54449",
+					"172.20.0.1:54449",
+					"172.21.0.1:54449",
+					"172.22.0.1:54449",
+					"172.23.0.1:54449",
+					"172.24.0.1:54449",
+					"172.25.0.1:54449",
+					"172.26.0.1:54449",
+					"172.27.0.1:54449",
+					"172.28.0.1:54449"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:14:39.365637808Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5894916202258050,
+				"StableID":   "nTysbFTp2o11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b1530603c3fdbe6e274470f89fedb14c05237a75072d94676073d58c5f941a37",
+				"KeyExpiry":  "2026-11-09T09:14:39Z",
+				"DiscoKey":   "discokey:8ff5c8d67ced5c0fa173009f9be01d85d23651b478da2fad407a09382f706e35",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35852",
+					"10.65.0.27:35852",
+					"172.17.0.1:35852",
+					"172.18.0.1:35852",
+					"172.19.0.1:35852",
+					"172.20.0.1:35852",
+					"172.21.0.1:35852",
+					"172.22.0.1:35852",
+					"172.23.0.1:35852",
+					"172.24.0.1:35852",
+					"172.25.0.1:35852",
+					"172.26.0.1:35852",
+					"172.27.0.1:35852",
+					"172.28.0.1:35852"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:14:39.898001202Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2161925042966337,
+				"StableID":   "nAVBt579tH11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1092e1b55eb5c0d2f5610c08013089fab5f95281b4b2e07b644c00693a70ce04",
+				"KeyExpiry":  "2026-11-09T09:14:40Z",
+				"DiscoKey":   "discokey:cb33dfc58e777b4694782a8f94c7b4ae3e9852580af53edbbe02fd45fb6cfe28",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:40634",
+					"10.65.0.27:40634",
+					"172.17.0.1:40634",
+					"172.18.0.1:40634",
+					"172.19.0.1:40634",
+					"172.20.0.1:40634",
+					"172.21.0.1:40634",
+					"172.22.0.1:40634",
+					"172.23.0.1:40634",
+					"172.24.0.1:40634",
+					"172.25.0.1:40634",
+					"172.26.0.1:40634",
+					"172.27.0.1:40634",
+					"172.28.0.1:40634"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:14:40.443043267Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{
+				"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+				"sshUsers":   {"root": "root"},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				}
+			}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7492479871341914": {
+				"ID":          7492479871341914,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		},
+		"ssh_rules": [{
+			"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+			"sshUsers":   {"root": "root"},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}
+		}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6905021408415337,
+				"StableID":   "nJd9joCJvv11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       6905021408415337,
+				"Key":        "nodekey:22a6989ab145d63e5dc0190d424872b2e13d69c840276015ada95a260ee3a813",
+				"DiscoKey":   "discokey:3d2b4f0c5ca407ea4226bfcf74e39faaf98d448741f49a4ea4a55c51a6c97e74",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33099",
+					"10.65.0.27:33099",
+					"172.17.0.1:33099",
+					"172.18.0.1:33099",
+					"172.19.0.1:33099",
+					"172.20.0.1:33099",
+					"172.21.0.1:33099",
+					"172.22.0.1:33099",
+					"172.23.0.1:33099",
+					"172.24.0.1:33099",
+					"172.25.0.1:33099",
+					"172.26.0.1:33099",
+					"172.27.0.1:33099",
+					"172.28.0.1:33099"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:14:35.589805582Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:22a6989ab145d63e5dc0190d424872b2e13d69c840276015ada95a260ee3a813",
+			"MachineKey": "mkey:ca27fac1701efe3692430f1dc6f7084d55eb96de6f97d1099a308f045fd03549",
+			"Peers": [{
+				"ID":         2840293870652164,
+				"StableID":   "nTSmDphNBP11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65bfe3aab37558c3d4257f7c4a3ce5a1fe9c0d545783dffd6fb27ffffa470a2e",
+				"DiscoKey":   "discokey:a4d7e3fb3fc79731a2c6d0f9981b49fd9888a3dccb9ea5ec8f79708e2549d90f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47906",
+					"10.65.0.27:47906",
+					"172.17.0.1:47906",
+					"172.18.0.1:47906",
+					"172.19.0.1:47906",
+					"172.20.0.1:47906",
+					"172.21.0.1:47906",
+					"172.22.0.1:47906",
+					"172.23.0.1:47906",
+					"172.24.0.1:47906",
+					"172.25.0.1:47906",
+					"172.26.0.1:47906",
+					"172.27.0.1:47906",
+					"172.28.0.1:47906"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:14:32.914936157Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3944447720512740,
+				"StableID":   "nBYEwGxSoX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd52f08d01f7e477b25d99a8459790671a4edcf479268db13bcb68972da5ef26",
+				"DiscoKey":   "discokey:29c2f5ece02e2602991a80fcd1e26044ae95e886a22a1c71132f7f3f301de552",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35813",
+					"10.65.0.27:35813",
+					"172.17.0.1:35813",
+					"172.18.0.1:35813",
+					"172.19.0.1:35813",
+					"172.20.0.1:35813",
+					"172.21.0.1:35813",
+					"172.22.0.1:35813",
+					"172.23.0.1:35813",
+					"172.24.0.1:35813",
+					"172.25.0.1:35813",
+					"172.26.0.1:35813",
+					"172.27.0.1:35813",
+					"172.28.0.1:35813"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:14:33.444311138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8196632796973305,
+				"StableID":   "nQteDPeG1721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c08f2124f0292c7e3bc13e2d8d2ad4f092a71686f3b24f88b7bb47201513d54",
+				"DiscoKey":   "discokey:dacc24dde10d1a36e280fcc9402f9b7187f0ea43128cf478d76b73dfc175f602",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39819",
+					"10.65.0.27:39819",
+					"172.17.0.1:39819",
+					"172.18.0.1:39819",
+					"172.19.0.1:39819",
+					"172.20.0.1:39819",
+					"172.21.0.1:39819",
+					"172.22.0.1:39819",
+					"172.23.0.1:39819",
+					"172.24.0.1:39819",
+					"172.25.0.1:39819",
+					"172.26.0.1:39819",
+					"172.27.0.1:39819",
+					"172.28.0.1:39819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:14:33.978522762Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3530720735132739,
+				"StableID":   "n6nkyh35aU11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3fb7232e7768dec4cba16c8e80abc1bd76a65ce5350208774913c4617f346323",
+				"DiscoKey":   "discokey:561530bf3f9f0768e9c504a9c5e5c13b4c7dac43ea67fdced9290132ec9d1509",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35092",
+					"10.65.0.27:35092",
+					"172.17.0.1:35092",
+					"172.18.0.1:35092",
+					"172.19.0.1:35092",
+					"172.20.0.1:35092",
+					"172.21.0.1:35092",
+					"172.22.0.1:35092",
+					"172.23.0.1:35092",
+					"172.24.0.1:35092",
+					"172.25.0.1:35092",
+					"172.26.0.1:35092",
+					"172.27.0.1:35092",
+					"172.28.0.1:35092"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:14:34.519796394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8493166885310382,
+				"StableID":   "nF1wAM6aK921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b67714dc940f6a6c3f20bc0474c08f0a0d508dbb660b67d4e5382af025a9b264",
+				"DiscoKey":   "discokey:eb7f68d16983c883fefeeee570629d844f6b1821f78a8769b6c8ffa26e64c97f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49260",
+					"10.65.0.27:49260",
+					"172.17.0.1:49260",
+					"172.18.0.1:49260",
+					"172.19.0.1:49260",
+					"172.20.0.1:49260",
+					"172.21.0.1:49260",
+					"172.22.0.1:49260",
+					"172.23.0.1:49260",
+					"172.24.0.1:49260",
+					"172.25.0.1:49260",
+					"172.26.0.1:49260",
+					"172.27.0.1:49260",
+					"172.28.0.1:49260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:14:35.055432543Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1378366829076477,
+				"StableID":   "nnF2hqMGmB11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8c1cae6b2713e6afd28791292ce29afa5e8d37fbbc5fd5b91047d0e74980d2c",
+				"DiscoKey":   "discokey:f8e2a2f49c94748f64d088c0c05530956245a73e92321502c7ef5a8c374bcb3a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51558",
+					"10.65.0.27:51558",
+					"172.17.0.1:51558",
+					"172.18.0.1:51558",
+					"172.19.0.1:51558",
+					"172.20.0.1:51558",
+					"172.21.0.1:51558",
+					"172.22.0.1:51558",
+					"172.23.0.1:51558",
+					"172.24.0.1:51558",
+					"172.25.0.1:51558",
+					"172.26.0.1:51558",
+					"172.27.0.1:51558",
+					"172.28.0.1:51558"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:14:36.123605174Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8096131484985793,
+				"StableID":   "nQ8rRSekD621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5ed161b91ef60de21d1932add68bb1a403c7075494bc635c14ed065846b6023",
+				"DiscoKey":   "discokey:342cf3aa2e3fe8811029ee42ffb6911b44105deb8348846ff4b891d9d2842559",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36582",
+					"10.65.0.27:36582",
+					"172.17.0.1:36582",
+					"172.18.0.1:36582",
+					"172.19.0.1:36582",
+					"172.20.0.1:36582",
+					"172.21.0.1:36582",
+					"172.22.0.1:36582",
+					"172.23.0.1:36582",
+					"172.24.0.1:36582",
+					"172.25.0.1:36582",
+					"172.26.0.1:36582",
+					"172.27.0.1:36582",
+					"172.28.0.1:36582"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:14:36.697309618Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5263862495942249,
+				"StableID":   "nnFwW2k17i11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:759cab22549715a036dc3776fd5599511ec3132e6c4d69858d27095db3d99b17",
+				"DiscoKey":   "discokey:a24b6e3eb1290c84367432907f3c785aacb66b15edc579bd872a8aa4e6550e2b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53998",
+					"10.65.0.27:53998",
+					"172.17.0.1:53998",
+					"172.18.0.1:53998",
+					"172.19.0.1:53998",
+					"172.20.0.1:53998",
+					"172.21.0.1:53998",
+					"172.22.0.1:53998",
+					"172.23.0.1:53998",
+					"172.24.0.1:53998",
+					"172.25.0.1:53998",
+					"172.26.0.1:53998",
+					"172.27.0.1:53998",
+					"172.28.0.1:53998"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:14:37.223103871Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         652158256515153,
+				"StableID":   "nvVCvJ6N6611CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f71f8cedfac1f8c676ad5c576041a4eecf18f24d30471f99ea12cdc3224b208",
+				"DiscoKey":   "discokey:78940d0a8f7aa5a7a819ac538f90c50575351ec5646ea57b96f1a65127ffb662",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59893",
+					"10.65.0.27:59893",
+					"172.17.0.1:59893",
+					"172.18.0.1:59893",
+					"172.19.0.1:59893",
+					"172.20.0.1:59893",
+					"172.21.0.1:59893",
+					"172.22.0.1:59893",
+					"172.23.0.1:59893",
+					"172.24.0.1:59893",
+					"172.25.0.1:59893",
+					"172.26.0.1:59893",
+					"172.27.0.1:59893",
+					"172.28.0.1:59893"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:14:37.736228983Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2630166202798887,
+				"StableID":   "nxf6mM1DYM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b1232181959ec13a3e9624e8ce271ccf28570308e230e27c39182ace737853c",
+				"DiscoKey":   "discokey:ef2ec17c497da07d53c33ec478e9fc67db2d46ab0633a3a8510c322266249408",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:46591",
+					"10.65.0.27:46591",
+					"172.17.0.1:46591",
+					"172.18.0.1:46591",
+					"172.19.0.1:46591",
+					"172.20.0.1:46591",
+					"172.21.0.1:46591",
+					"172.22.0.1:46591",
+					"172.23.0.1:46591",
+					"172.24.0.1:46591",
+					"172.25.0.1:46591",
+					"172.26.0.1:46591",
+					"172.27.0.1:46591",
+					"172.28.0.1:46591"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:14:38.273699887Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7492479871341914,
+				"StableID":   "nZCSSzjMW121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:94197bf76ee983cf5ce7b3e7e45ec911814a04b83ce8e72cc0e9ca36ada86224",
+				"DiscoKey":   "discokey:f581bc05b5d08fb8541feae196c4866e94b3813c08df8d843f2c3dec3e3a0b5e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38464",
+					"10.65.0.27:38464",
+					"172.17.0.1:38464",
+					"172.18.0.1:38464",
+					"172.19.0.1:38464",
+					"172.20.0.1:38464",
+					"172.21.0.1:38464",
+					"172.22.0.1:38464",
+					"172.23.0.1:38464",
+					"172.24.0.1:38464",
+					"172.25.0.1:38464",
+					"172.26.0.1:38464",
+					"172.27.0.1:38464",
+					"172.28.0.1:38464"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:14:38.807670086Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4496192053903417,
+				"StableID":   "nCgPKnLL7c11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8ba3519054665252fe52daf2ca358693b2874665dac7febee26662dc7df2772d",
+				"KeyExpiry":  "2026-11-09T09:14:39Z",
+				"DiscoKey":   "discokey:6333bf224f6f9dcfcd47951e70e92b96218bdbea11fcbef77e28ba214c06303e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54449",
+					"10.65.0.27:54449",
+					"172.17.0.1:54449",
+					"172.18.0.1:54449",
+					"172.19.0.1:54449",
+					"172.20.0.1:54449",
+					"172.21.0.1:54449",
+					"172.22.0.1:54449",
+					"172.23.0.1:54449",
+					"172.24.0.1:54449",
+					"172.25.0.1:54449",
+					"172.26.0.1:54449",
+					"172.27.0.1:54449",
+					"172.28.0.1:54449"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:14:39.365637808Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5894916202258050,
+				"StableID":   "nTysbFTp2o11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b1530603c3fdbe6e274470f89fedb14c05237a75072d94676073d58c5f941a37",
+				"KeyExpiry":  "2026-11-09T09:14:39Z",
+				"DiscoKey":   "discokey:8ff5c8d67ced5c0fa173009f9be01d85d23651b478da2fad407a09382f706e35",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35852",
+					"10.65.0.27:35852",
+					"172.17.0.1:35852",
+					"172.18.0.1:35852",
+					"172.19.0.1:35852",
+					"172.20.0.1:35852",
+					"172.21.0.1:35852",
+					"172.22.0.1:35852",
+					"172.23.0.1:35852",
+					"172.24.0.1:35852",
+					"172.25.0.1:35852",
+					"172.26.0.1:35852",
+					"172.27.0.1:35852",
+					"172.28.0.1:35852"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:14:39.898001202Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2161925042966337,
+				"StableID":   "nAVBt579tH11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1092e1b55eb5c0d2f5610c08013089fab5f95281b4b2e07b644c00693a70ce04",
+				"KeyExpiry":  "2026-11-09T09:14:40Z",
+				"DiscoKey":   "discokey:cb33dfc58e777b4694782a8f94c7b4ae3e9852580af53edbbe02fd45fb6cfe28",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:40634",
+					"10.65.0.27:40634",
+					"172.17.0.1:40634",
+					"172.18.0.1:40634",
+					"172.19.0.1:40634",
+					"172.20.0.1:40634",
+					"172.21.0.1:40634",
+					"172.22.0.1:40634",
+					"172.23.0.1:40634",
+					"172.24.0.1:40634",
+					"172.25.0.1:40634",
+					"172.26.0.1:40634",
+					"172.27.0.1:40634",
+					"172.28.0.1:40634"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:14:40.443043267Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6905021408415337": {
+				"ID":          6905021408415337,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2161925042966337,
+				"StableID":   "nAVBt579tH11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1092e1b55eb5c0d2f5610c08013089fab5f95281b4b2e07b644c00693a70ce04",
+				"KeyExpiry":  "2026-11-09T09:14:40Z",
+				"DiscoKey":   "discokey:cb33dfc58e777b4694782a8f94c7b4ae3e9852580af53edbbe02fd45fb6cfe28",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:40634",
+					"10.65.0.27:40634",
+					"172.17.0.1:40634",
+					"172.18.0.1:40634",
+					"172.19.0.1:40634",
+					"172.20.0.1:40634",
+					"172.21.0.1:40634",
+					"172.22.0.1:40634",
+					"172.23.0.1:40634",
+					"172.24.0.1:40634",
+					"172.25.0.1:40634",
+					"172.26.0.1:40634",
+					"172.27.0.1:40634",
+					"172.28.0.1:40634"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:14:40.443043267Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1092e1b55eb5c0d2f5610c08013089fab5f95281b4b2e07b644c00693a70ce04",
+			"MachineKey": "mkey:9261fa7935b1c572fa3bb3c27e7aab855c682a75bb7baec2a22d236fdeec064a",
+			"Peers": [{
+				"ID":         2840293870652164,
+				"StableID":   "nTSmDphNBP11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65bfe3aab37558c3d4257f7c4a3ce5a1fe9c0d545783dffd6fb27ffffa470a2e",
+				"DiscoKey":   "discokey:a4d7e3fb3fc79731a2c6d0f9981b49fd9888a3dccb9ea5ec8f79708e2549d90f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47906",
+					"10.65.0.27:47906",
+					"172.17.0.1:47906",
+					"172.18.0.1:47906",
+					"172.19.0.1:47906",
+					"172.20.0.1:47906",
+					"172.21.0.1:47906",
+					"172.22.0.1:47906",
+					"172.23.0.1:47906",
+					"172.24.0.1:47906",
+					"172.25.0.1:47906",
+					"172.26.0.1:47906",
+					"172.27.0.1:47906",
+					"172.28.0.1:47906"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:14:32.914936157Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3944447720512740,
+				"StableID":   "nBYEwGxSoX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd52f08d01f7e477b25d99a8459790671a4edcf479268db13bcb68972da5ef26",
+				"DiscoKey":   "discokey:29c2f5ece02e2602991a80fcd1e26044ae95e886a22a1c71132f7f3f301de552",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35813",
+					"10.65.0.27:35813",
+					"172.17.0.1:35813",
+					"172.18.0.1:35813",
+					"172.19.0.1:35813",
+					"172.20.0.1:35813",
+					"172.21.0.1:35813",
+					"172.22.0.1:35813",
+					"172.23.0.1:35813",
+					"172.24.0.1:35813",
+					"172.25.0.1:35813",
+					"172.26.0.1:35813",
+					"172.27.0.1:35813",
+					"172.28.0.1:35813"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:14:33.444311138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8196632796973305,
+				"StableID":   "nQteDPeG1721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c08f2124f0292c7e3bc13e2d8d2ad4f092a71686f3b24f88b7bb47201513d54",
+				"DiscoKey":   "discokey:dacc24dde10d1a36e280fcc9402f9b7187f0ea43128cf478d76b73dfc175f602",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39819",
+					"10.65.0.27:39819",
+					"172.17.0.1:39819",
+					"172.18.0.1:39819",
+					"172.19.0.1:39819",
+					"172.20.0.1:39819",
+					"172.21.0.1:39819",
+					"172.22.0.1:39819",
+					"172.23.0.1:39819",
+					"172.24.0.1:39819",
+					"172.25.0.1:39819",
+					"172.26.0.1:39819",
+					"172.27.0.1:39819",
+					"172.28.0.1:39819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:14:33.978522762Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3530720735132739,
+				"StableID":   "n6nkyh35aU11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3fb7232e7768dec4cba16c8e80abc1bd76a65ce5350208774913c4617f346323",
+				"DiscoKey":   "discokey:561530bf3f9f0768e9c504a9c5e5c13b4c7dac43ea67fdced9290132ec9d1509",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35092",
+					"10.65.0.27:35092",
+					"172.17.0.1:35092",
+					"172.18.0.1:35092",
+					"172.19.0.1:35092",
+					"172.20.0.1:35092",
+					"172.21.0.1:35092",
+					"172.22.0.1:35092",
+					"172.23.0.1:35092",
+					"172.24.0.1:35092",
+					"172.25.0.1:35092",
+					"172.26.0.1:35092",
+					"172.27.0.1:35092",
+					"172.28.0.1:35092"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:14:34.519796394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8493166885310382,
+				"StableID":   "nF1wAM6aK921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b67714dc940f6a6c3f20bc0474c08f0a0d508dbb660b67d4e5382af025a9b264",
+				"DiscoKey":   "discokey:eb7f68d16983c883fefeeee570629d844f6b1821f78a8769b6c8ffa26e64c97f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49260",
+					"10.65.0.27:49260",
+					"172.17.0.1:49260",
+					"172.18.0.1:49260",
+					"172.19.0.1:49260",
+					"172.20.0.1:49260",
+					"172.21.0.1:49260",
+					"172.22.0.1:49260",
+					"172.23.0.1:49260",
+					"172.24.0.1:49260",
+					"172.25.0.1:49260",
+					"172.26.0.1:49260",
+					"172.27.0.1:49260",
+					"172.28.0.1:49260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:14:35.055432543Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6905021408415337,
+				"StableID":   "nJd9joCJvv11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22a6989ab145d63e5dc0190d424872b2e13d69c840276015ada95a260ee3a813",
+				"DiscoKey":   "discokey:3d2b4f0c5ca407ea4226bfcf74e39faaf98d448741f49a4ea4a55c51a6c97e74",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33099",
+					"10.65.0.27:33099",
+					"172.17.0.1:33099",
+					"172.18.0.1:33099",
+					"172.19.0.1:33099",
+					"172.20.0.1:33099",
+					"172.21.0.1:33099",
+					"172.22.0.1:33099",
+					"172.23.0.1:33099",
+					"172.24.0.1:33099",
+					"172.25.0.1:33099",
+					"172.26.0.1:33099",
+					"172.27.0.1:33099",
+					"172.28.0.1:33099"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:14:35.589805582Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1378366829076477,
+				"StableID":   "nnF2hqMGmB11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8c1cae6b2713e6afd28791292ce29afa5e8d37fbbc5fd5b91047d0e74980d2c",
+				"DiscoKey":   "discokey:f8e2a2f49c94748f64d088c0c05530956245a73e92321502c7ef5a8c374bcb3a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51558",
+					"10.65.0.27:51558",
+					"172.17.0.1:51558",
+					"172.18.0.1:51558",
+					"172.19.0.1:51558",
+					"172.20.0.1:51558",
+					"172.21.0.1:51558",
+					"172.22.0.1:51558",
+					"172.23.0.1:51558",
+					"172.24.0.1:51558",
+					"172.25.0.1:51558",
+					"172.26.0.1:51558",
+					"172.27.0.1:51558",
+					"172.28.0.1:51558"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:14:36.123605174Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8096131484985793,
+				"StableID":   "nQ8rRSekD621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5ed161b91ef60de21d1932add68bb1a403c7075494bc635c14ed065846b6023",
+				"DiscoKey":   "discokey:342cf3aa2e3fe8811029ee42ffb6911b44105deb8348846ff4b891d9d2842559",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36582",
+					"10.65.0.27:36582",
+					"172.17.0.1:36582",
+					"172.18.0.1:36582",
+					"172.19.0.1:36582",
+					"172.20.0.1:36582",
+					"172.21.0.1:36582",
+					"172.22.0.1:36582",
+					"172.23.0.1:36582",
+					"172.24.0.1:36582",
+					"172.25.0.1:36582",
+					"172.26.0.1:36582",
+					"172.27.0.1:36582",
+					"172.28.0.1:36582"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:14:36.697309618Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5263862495942249,
+				"StableID":   "nnFwW2k17i11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:759cab22549715a036dc3776fd5599511ec3132e6c4d69858d27095db3d99b17",
+				"DiscoKey":   "discokey:a24b6e3eb1290c84367432907f3c785aacb66b15edc579bd872a8aa4e6550e2b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53998",
+					"10.65.0.27:53998",
+					"172.17.0.1:53998",
+					"172.18.0.1:53998",
+					"172.19.0.1:53998",
+					"172.20.0.1:53998",
+					"172.21.0.1:53998",
+					"172.22.0.1:53998",
+					"172.23.0.1:53998",
+					"172.24.0.1:53998",
+					"172.25.0.1:53998",
+					"172.26.0.1:53998",
+					"172.27.0.1:53998",
+					"172.28.0.1:53998"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:14:37.223103871Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         652158256515153,
+				"StableID":   "nvVCvJ6N6611CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f71f8cedfac1f8c676ad5c576041a4eecf18f24d30471f99ea12cdc3224b208",
+				"DiscoKey":   "discokey:78940d0a8f7aa5a7a819ac538f90c50575351ec5646ea57b96f1a65127ffb662",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59893",
+					"10.65.0.27:59893",
+					"172.17.0.1:59893",
+					"172.18.0.1:59893",
+					"172.19.0.1:59893",
+					"172.20.0.1:59893",
+					"172.21.0.1:59893",
+					"172.22.0.1:59893",
+					"172.23.0.1:59893",
+					"172.24.0.1:59893",
+					"172.25.0.1:59893",
+					"172.26.0.1:59893",
+					"172.27.0.1:59893",
+					"172.28.0.1:59893"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:14:37.736228983Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2630166202798887,
+				"StableID":   "nxf6mM1DYM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b1232181959ec13a3e9624e8ce271ccf28570308e230e27c39182ace737853c",
+				"DiscoKey":   "discokey:ef2ec17c497da07d53c33ec478e9fc67db2d46ab0633a3a8510c322266249408",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:46591",
+					"10.65.0.27:46591",
+					"172.17.0.1:46591",
+					"172.18.0.1:46591",
+					"172.19.0.1:46591",
+					"172.20.0.1:46591",
+					"172.21.0.1:46591",
+					"172.22.0.1:46591",
+					"172.23.0.1:46591",
+					"172.24.0.1:46591",
+					"172.25.0.1:46591",
+					"172.26.0.1:46591",
+					"172.27.0.1:46591",
+					"172.28.0.1:46591"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:14:38.273699887Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7492479871341914,
+				"StableID":   "nZCSSzjMW121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:94197bf76ee983cf5ce7b3e7e45ec911814a04b83ce8e72cc0e9ca36ada86224",
+				"DiscoKey":   "discokey:f581bc05b5d08fb8541feae196c4866e94b3813c08df8d843f2c3dec3e3a0b5e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38464",
+					"10.65.0.27:38464",
+					"172.17.0.1:38464",
+					"172.18.0.1:38464",
+					"172.19.0.1:38464",
+					"172.20.0.1:38464",
+					"172.21.0.1:38464",
+					"172.22.0.1:38464",
+					"172.23.0.1:38464",
+					"172.24.0.1:38464",
+					"172.25.0.1:38464",
+					"172.26.0.1:38464",
+					"172.27.0.1:38464",
+					"172.28.0.1:38464"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:14:38.807670086Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4496192053903417,
+				"StableID":   "nCgPKnLL7c11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8ba3519054665252fe52daf2ca358693b2874665dac7febee26662dc7df2772d",
+				"KeyExpiry":  "2026-11-09T09:14:39Z",
+				"DiscoKey":   "discokey:6333bf224f6f9dcfcd47951e70e92b96218bdbea11fcbef77e28ba214c06303e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54449",
+					"10.65.0.27:54449",
+					"172.17.0.1:54449",
+					"172.18.0.1:54449",
+					"172.19.0.1:54449",
+					"172.20.0.1:54449",
+					"172.21.0.1:54449",
+					"172.22.0.1:54449",
+					"172.23.0.1:54449",
+					"172.24.0.1:54449",
+					"172.25.0.1:54449",
+					"172.26.0.1:54449",
+					"172.27.0.1:54449",
+					"172.28.0.1:54449"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:14:39.365637808Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5894916202258050,
+				"StableID":   "nTysbFTp2o11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b1530603c3fdbe6e274470f89fedb14c05237a75072d94676073d58c5f941a37",
+				"KeyExpiry":  "2026-11-09T09:14:39Z",
+				"DiscoKey":   "discokey:8ff5c8d67ced5c0fa173009f9be01d85d23651b478da2fad407a09382f706e35",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35852",
+					"10.65.0.27:35852",
+					"172.17.0.1:35852",
+					"172.18.0.1:35852",
+					"172.19.0.1:35852",
+					"172.20.0.1:35852",
+					"172.21.0.1:35852",
+					"172.22.0.1:35852",
+					"172.23.0.1:35852",
+					"172.24.0.1:35852",
+					"172.25.0.1:35852",
+					"172.26.0.1:35852",
+					"172.27.0.1:35852",
+					"172.28.0.1:35852"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:14:39.898001202Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8196632796973305,
+				"StableID":   "nQteDPeG1721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       8196632796973305,
+				"Key":        "nodekey:0c08f2124f0292c7e3bc13e2d8d2ad4f092a71686f3b24f88b7bb47201513d54",
+				"DiscoKey":   "discokey:dacc24dde10d1a36e280fcc9402f9b7187f0ea43128cf478d76b73dfc175f602",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39819",
+					"10.65.0.27:39819",
+					"172.17.0.1:39819",
+					"172.18.0.1:39819",
+					"172.19.0.1:39819",
+					"172.20.0.1:39819",
+					"172.21.0.1:39819",
+					"172.22.0.1:39819",
+					"172.23.0.1:39819",
+					"172.24.0.1:39819",
+					"172.25.0.1:39819",
+					"172.26.0.1:39819",
+					"172.27.0.1:39819",
+					"172.28.0.1:39819"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:14:33.978522762Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0c08f2124f0292c7e3bc13e2d8d2ad4f092a71686f3b24f88b7bb47201513d54",
+			"MachineKey": "mkey:d3f5c25d2702b7068326cc0f8b8aa602bb43a85c7ae8c8cb5956ca8612892950",
+			"Peers": [{
+				"ID":         2840293870652164,
+				"StableID":   "nTSmDphNBP11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65bfe3aab37558c3d4257f7c4a3ce5a1fe9c0d545783dffd6fb27ffffa470a2e",
+				"DiscoKey":   "discokey:a4d7e3fb3fc79731a2c6d0f9981b49fd9888a3dccb9ea5ec8f79708e2549d90f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47906",
+					"10.65.0.27:47906",
+					"172.17.0.1:47906",
+					"172.18.0.1:47906",
+					"172.19.0.1:47906",
+					"172.20.0.1:47906",
+					"172.21.0.1:47906",
+					"172.22.0.1:47906",
+					"172.23.0.1:47906",
+					"172.24.0.1:47906",
+					"172.25.0.1:47906",
+					"172.26.0.1:47906",
+					"172.27.0.1:47906",
+					"172.28.0.1:47906"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:14:32.914936157Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3944447720512740,
+				"StableID":   "nBYEwGxSoX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd52f08d01f7e477b25d99a8459790671a4edcf479268db13bcb68972da5ef26",
+				"DiscoKey":   "discokey:29c2f5ece02e2602991a80fcd1e26044ae95e886a22a1c71132f7f3f301de552",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35813",
+					"10.65.0.27:35813",
+					"172.17.0.1:35813",
+					"172.18.0.1:35813",
+					"172.19.0.1:35813",
+					"172.20.0.1:35813",
+					"172.21.0.1:35813",
+					"172.22.0.1:35813",
+					"172.23.0.1:35813",
+					"172.24.0.1:35813",
+					"172.25.0.1:35813",
+					"172.26.0.1:35813",
+					"172.27.0.1:35813",
+					"172.28.0.1:35813"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:14:33.444311138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3530720735132739,
+				"StableID":   "n6nkyh35aU11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3fb7232e7768dec4cba16c8e80abc1bd76a65ce5350208774913c4617f346323",
+				"DiscoKey":   "discokey:561530bf3f9f0768e9c504a9c5e5c13b4c7dac43ea67fdced9290132ec9d1509",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35092",
+					"10.65.0.27:35092",
+					"172.17.0.1:35092",
+					"172.18.0.1:35092",
+					"172.19.0.1:35092",
+					"172.20.0.1:35092",
+					"172.21.0.1:35092",
+					"172.22.0.1:35092",
+					"172.23.0.1:35092",
+					"172.24.0.1:35092",
+					"172.25.0.1:35092",
+					"172.26.0.1:35092",
+					"172.27.0.1:35092",
+					"172.28.0.1:35092"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:14:34.519796394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8493166885310382,
+				"StableID":   "nF1wAM6aK921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b67714dc940f6a6c3f20bc0474c08f0a0d508dbb660b67d4e5382af025a9b264",
+				"DiscoKey":   "discokey:eb7f68d16983c883fefeeee570629d844f6b1821f78a8769b6c8ffa26e64c97f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49260",
+					"10.65.0.27:49260",
+					"172.17.0.1:49260",
+					"172.18.0.1:49260",
+					"172.19.0.1:49260",
+					"172.20.0.1:49260",
+					"172.21.0.1:49260",
+					"172.22.0.1:49260",
+					"172.23.0.1:49260",
+					"172.24.0.1:49260",
+					"172.25.0.1:49260",
+					"172.26.0.1:49260",
+					"172.27.0.1:49260",
+					"172.28.0.1:49260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:14:35.055432543Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6905021408415337,
+				"StableID":   "nJd9joCJvv11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22a6989ab145d63e5dc0190d424872b2e13d69c840276015ada95a260ee3a813",
+				"DiscoKey":   "discokey:3d2b4f0c5ca407ea4226bfcf74e39faaf98d448741f49a4ea4a55c51a6c97e74",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33099",
+					"10.65.0.27:33099",
+					"172.17.0.1:33099",
+					"172.18.0.1:33099",
+					"172.19.0.1:33099",
+					"172.20.0.1:33099",
+					"172.21.0.1:33099",
+					"172.22.0.1:33099",
+					"172.23.0.1:33099",
+					"172.24.0.1:33099",
+					"172.25.0.1:33099",
+					"172.26.0.1:33099",
+					"172.27.0.1:33099",
+					"172.28.0.1:33099"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:14:35.589805582Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1378366829076477,
+				"StableID":   "nnF2hqMGmB11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8c1cae6b2713e6afd28791292ce29afa5e8d37fbbc5fd5b91047d0e74980d2c",
+				"DiscoKey":   "discokey:f8e2a2f49c94748f64d088c0c05530956245a73e92321502c7ef5a8c374bcb3a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51558",
+					"10.65.0.27:51558",
+					"172.17.0.1:51558",
+					"172.18.0.1:51558",
+					"172.19.0.1:51558",
+					"172.20.0.1:51558",
+					"172.21.0.1:51558",
+					"172.22.0.1:51558",
+					"172.23.0.1:51558",
+					"172.24.0.1:51558",
+					"172.25.0.1:51558",
+					"172.26.0.1:51558",
+					"172.27.0.1:51558",
+					"172.28.0.1:51558"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:14:36.123605174Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8096131484985793,
+				"StableID":   "nQ8rRSekD621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5ed161b91ef60de21d1932add68bb1a403c7075494bc635c14ed065846b6023",
+				"DiscoKey":   "discokey:342cf3aa2e3fe8811029ee42ffb6911b44105deb8348846ff4b891d9d2842559",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36582",
+					"10.65.0.27:36582",
+					"172.17.0.1:36582",
+					"172.18.0.1:36582",
+					"172.19.0.1:36582",
+					"172.20.0.1:36582",
+					"172.21.0.1:36582",
+					"172.22.0.1:36582",
+					"172.23.0.1:36582",
+					"172.24.0.1:36582",
+					"172.25.0.1:36582",
+					"172.26.0.1:36582",
+					"172.27.0.1:36582",
+					"172.28.0.1:36582"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:14:36.697309618Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5263862495942249,
+				"StableID":   "nnFwW2k17i11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:759cab22549715a036dc3776fd5599511ec3132e6c4d69858d27095db3d99b17",
+				"DiscoKey":   "discokey:a24b6e3eb1290c84367432907f3c785aacb66b15edc579bd872a8aa4e6550e2b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53998",
+					"10.65.0.27:53998",
+					"172.17.0.1:53998",
+					"172.18.0.1:53998",
+					"172.19.0.1:53998",
+					"172.20.0.1:53998",
+					"172.21.0.1:53998",
+					"172.22.0.1:53998",
+					"172.23.0.1:53998",
+					"172.24.0.1:53998",
+					"172.25.0.1:53998",
+					"172.26.0.1:53998",
+					"172.27.0.1:53998",
+					"172.28.0.1:53998"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:14:37.223103871Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         652158256515153,
+				"StableID":   "nvVCvJ6N6611CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f71f8cedfac1f8c676ad5c576041a4eecf18f24d30471f99ea12cdc3224b208",
+				"DiscoKey":   "discokey:78940d0a8f7aa5a7a819ac538f90c50575351ec5646ea57b96f1a65127ffb662",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59893",
+					"10.65.0.27:59893",
+					"172.17.0.1:59893",
+					"172.18.0.1:59893",
+					"172.19.0.1:59893",
+					"172.20.0.1:59893",
+					"172.21.0.1:59893",
+					"172.22.0.1:59893",
+					"172.23.0.1:59893",
+					"172.24.0.1:59893",
+					"172.25.0.1:59893",
+					"172.26.0.1:59893",
+					"172.27.0.1:59893",
+					"172.28.0.1:59893"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:14:37.736228983Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2630166202798887,
+				"StableID":   "nxf6mM1DYM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b1232181959ec13a3e9624e8ce271ccf28570308e230e27c39182ace737853c",
+				"DiscoKey":   "discokey:ef2ec17c497da07d53c33ec478e9fc67db2d46ab0633a3a8510c322266249408",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:46591",
+					"10.65.0.27:46591",
+					"172.17.0.1:46591",
+					"172.18.0.1:46591",
+					"172.19.0.1:46591",
+					"172.20.0.1:46591",
+					"172.21.0.1:46591",
+					"172.22.0.1:46591",
+					"172.23.0.1:46591",
+					"172.24.0.1:46591",
+					"172.25.0.1:46591",
+					"172.26.0.1:46591",
+					"172.27.0.1:46591",
+					"172.28.0.1:46591"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:14:38.273699887Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7492479871341914,
+				"StableID":   "nZCSSzjMW121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:94197bf76ee983cf5ce7b3e7e45ec911814a04b83ce8e72cc0e9ca36ada86224",
+				"DiscoKey":   "discokey:f581bc05b5d08fb8541feae196c4866e94b3813c08df8d843f2c3dec3e3a0b5e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38464",
+					"10.65.0.27:38464",
+					"172.17.0.1:38464",
+					"172.18.0.1:38464",
+					"172.19.0.1:38464",
+					"172.20.0.1:38464",
+					"172.21.0.1:38464",
+					"172.22.0.1:38464",
+					"172.23.0.1:38464",
+					"172.24.0.1:38464",
+					"172.25.0.1:38464",
+					"172.26.0.1:38464",
+					"172.27.0.1:38464",
+					"172.28.0.1:38464"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:14:38.807670086Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4496192053903417,
+				"StableID":   "nCgPKnLL7c11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8ba3519054665252fe52daf2ca358693b2874665dac7febee26662dc7df2772d",
+				"KeyExpiry":  "2026-11-09T09:14:39Z",
+				"DiscoKey":   "discokey:6333bf224f6f9dcfcd47951e70e92b96218bdbea11fcbef77e28ba214c06303e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54449",
+					"10.65.0.27:54449",
+					"172.17.0.1:54449",
+					"172.18.0.1:54449",
+					"172.19.0.1:54449",
+					"172.20.0.1:54449",
+					"172.21.0.1:54449",
+					"172.22.0.1:54449",
+					"172.23.0.1:54449",
+					"172.24.0.1:54449",
+					"172.25.0.1:54449",
+					"172.26.0.1:54449",
+					"172.27.0.1:54449",
+					"172.28.0.1:54449"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:14:39.365637808Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5894916202258050,
+				"StableID":   "nTysbFTp2o11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b1530603c3fdbe6e274470f89fedb14c05237a75072d94676073d58c5f941a37",
+				"KeyExpiry":  "2026-11-09T09:14:39Z",
+				"DiscoKey":   "discokey:8ff5c8d67ced5c0fa173009f9be01d85d23651b478da2fad407a09382f706e35",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35852",
+					"10.65.0.27:35852",
+					"172.17.0.1:35852",
+					"172.18.0.1:35852",
+					"172.19.0.1:35852",
+					"172.20.0.1:35852",
+					"172.21.0.1:35852",
+					"172.22.0.1:35852",
+					"172.23.0.1:35852",
+					"172.24.0.1:35852",
+					"172.25.0.1:35852",
+					"172.26.0.1:35852",
+					"172.27.0.1:35852",
+					"172.28.0.1:35852"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:14:39.898001202Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2161925042966337,
+				"StableID":   "nAVBt579tH11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1092e1b55eb5c0d2f5610c08013089fab5f95281b4b2e07b644c00693a70ce04",
+				"KeyExpiry":  "2026-11-09T09:14:40Z",
+				"DiscoKey":   "discokey:cb33dfc58e777b4694782a8f94c7b4ae3e9852580af53edbbe02fd45fb6cfe28",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:40634",
+					"10.65.0.27:40634",
+					"172.17.0.1:40634",
+					"172.18.0.1:40634",
+					"172.19.0.1:40634",
+					"172.20.0.1:40634",
+					"172.21.0.1:40634",
+					"172.22.0.1:40634",
+					"172.23.0.1:40634",
+					"172.24.0.1:40634",
+					"172.25.0.1:40634",
+					"172.26.0.1:40634",
+					"172.27.0.1:40634",
+					"172.28.0.1:40634"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:14:40.443043267Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8196632796973305": {
+				"ID":          8196632796973305,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8096131484985793,
+				"StableID":   "nQ8rRSekD621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       8096131484985793,
+				"Key":        "nodekey:e5ed161b91ef60de21d1932add68bb1a403c7075494bc635c14ed065846b6023",
+				"DiscoKey":   "discokey:342cf3aa2e3fe8811029ee42ffb6911b44105deb8348846ff4b891d9d2842559",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36582",
+					"10.65.0.27:36582",
+					"172.17.0.1:36582",
+					"172.18.0.1:36582",
+					"172.19.0.1:36582",
+					"172.20.0.1:36582",
+					"172.21.0.1:36582",
+					"172.22.0.1:36582",
+					"172.23.0.1:36582",
+					"172.24.0.1:36582",
+					"172.25.0.1:36582",
+					"172.26.0.1:36582",
+					"172.27.0.1:36582",
+					"172.28.0.1:36582"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:14:36.697309618Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e5ed161b91ef60de21d1932add68bb1a403c7075494bc635c14ed065846b6023",
+			"MachineKey": "mkey:7183d09eac217ee28cfc610ac8f7e7e2c607b5ef2974a25126faa8007325753b",
+			"Peers": [{
+				"ID":         2840293870652164,
+				"StableID":   "nTSmDphNBP11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65bfe3aab37558c3d4257f7c4a3ce5a1fe9c0d545783dffd6fb27ffffa470a2e",
+				"DiscoKey":   "discokey:a4d7e3fb3fc79731a2c6d0f9981b49fd9888a3dccb9ea5ec8f79708e2549d90f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47906",
+					"10.65.0.27:47906",
+					"172.17.0.1:47906",
+					"172.18.0.1:47906",
+					"172.19.0.1:47906",
+					"172.20.0.1:47906",
+					"172.21.0.1:47906",
+					"172.22.0.1:47906",
+					"172.23.0.1:47906",
+					"172.24.0.1:47906",
+					"172.25.0.1:47906",
+					"172.26.0.1:47906",
+					"172.27.0.1:47906",
+					"172.28.0.1:47906"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:14:32.914936157Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3944447720512740,
+				"StableID":   "nBYEwGxSoX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd52f08d01f7e477b25d99a8459790671a4edcf479268db13bcb68972da5ef26",
+				"DiscoKey":   "discokey:29c2f5ece02e2602991a80fcd1e26044ae95e886a22a1c71132f7f3f301de552",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35813",
+					"10.65.0.27:35813",
+					"172.17.0.1:35813",
+					"172.18.0.1:35813",
+					"172.19.0.1:35813",
+					"172.20.0.1:35813",
+					"172.21.0.1:35813",
+					"172.22.0.1:35813",
+					"172.23.0.1:35813",
+					"172.24.0.1:35813",
+					"172.25.0.1:35813",
+					"172.26.0.1:35813",
+					"172.27.0.1:35813",
+					"172.28.0.1:35813"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:14:33.444311138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8196632796973305,
+				"StableID":   "nQteDPeG1721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c08f2124f0292c7e3bc13e2d8d2ad4f092a71686f3b24f88b7bb47201513d54",
+				"DiscoKey":   "discokey:dacc24dde10d1a36e280fcc9402f9b7187f0ea43128cf478d76b73dfc175f602",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39819",
+					"10.65.0.27:39819",
+					"172.17.0.1:39819",
+					"172.18.0.1:39819",
+					"172.19.0.1:39819",
+					"172.20.0.1:39819",
+					"172.21.0.1:39819",
+					"172.22.0.1:39819",
+					"172.23.0.1:39819",
+					"172.24.0.1:39819",
+					"172.25.0.1:39819",
+					"172.26.0.1:39819",
+					"172.27.0.1:39819",
+					"172.28.0.1:39819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:14:33.978522762Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3530720735132739,
+				"StableID":   "n6nkyh35aU11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3fb7232e7768dec4cba16c8e80abc1bd76a65ce5350208774913c4617f346323",
+				"DiscoKey":   "discokey:561530bf3f9f0768e9c504a9c5e5c13b4c7dac43ea67fdced9290132ec9d1509",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35092",
+					"10.65.0.27:35092",
+					"172.17.0.1:35092",
+					"172.18.0.1:35092",
+					"172.19.0.1:35092",
+					"172.20.0.1:35092",
+					"172.21.0.1:35092",
+					"172.22.0.1:35092",
+					"172.23.0.1:35092",
+					"172.24.0.1:35092",
+					"172.25.0.1:35092",
+					"172.26.0.1:35092",
+					"172.27.0.1:35092",
+					"172.28.0.1:35092"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:14:34.519796394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8493166885310382,
+				"StableID":   "nF1wAM6aK921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b67714dc940f6a6c3f20bc0474c08f0a0d508dbb660b67d4e5382af025a9b264",
+				"DiscoKey":   "discokey:eb7f68d16983c883fefeeee570629d844f6b1821f78a8769b6c8ffa26e64c97f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49260",
+					"10.65.0.27:49260",
+					"172.17.0.1:49260",
+					"172.18.0.1:49260",
+					"172.19.0.1:49260",
+					"172.20.0.1:49260",
+					"172.21.0.1:49260",
+					"172.22.0.1:49260",
+					"172.23.0.1:49260",
+					"172.24.0.1:49260",
+					"172.25.0.1:49260",
+					"172.26.0.1:49260",
+					"172.27.0.1:49260",
+					"172.28.0.1:49260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:14:35.055432543Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6905021408415337,
+				"StableID":   "nJd9joCJvv11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22a6989ab145d63e5dc0190d424872b2e13d69c840276015ada95a260ee3a813",
+				"DiscoKey":   "discokey:3d2b4f0c5ca407ea4226bfcf74e39faaf98d448741f49a4ea4a55c51a6c97e74",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33099",
+					"10.65.0.27:33099",
+					"172.17.0.1:33099",
+					"172.18.0.1:33099",
+					"172.19.0.1:33099",
+					"172.20.0.1:33099",
+					"172.21.0.1:33099",
+					"172.22.0.1:33099",
+					"172.23.0.1:33099",
+					"172.24.0.1:33099",
+					"172.25.0.1:33099",
+					"172.26.0.1:33099",
+					"172.27.0.1:33099",
+					"172.28.0.1:33099"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:14:35.589805582Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1378366829076477,
+				"StableID":   "nnF2hqMGmB11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8c1cae6b2713e6afd28791292ce29afa5e8d37fbbc5fd5b91047d0e74980d2c",
+				"DiscoKey":   "discokey:f8e2a2f49c94748f64d088c0c05530956245a73e92321502c7ef5a8c374bcb3a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51558",
+					"10.65.0.27:51558",
+					"172.17.0.1:51558",
+					"172.18.0.1:51558",
+					"172.19.0.1:51558",
+					"172.20.0.1:51558",
+					"172.21.0.1:51558",
+					"172.22.0.1:51558",
+					"172.23.0.1:51558",
+					"172.24.0.1:51558",
+					"172.25.0.1:51558",
+					"172.26.0.1:51558",
+					"172.27.0.1:51558",
+					"172.28.0.1:51558"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:14:36.123605174Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5263862495942249,
+				"StableID":   "nnFwW2k17i11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:759cab22549715a036dc3776fd5599511ec3132e6c4d69858d27095db3d99b17",
+				"DiscoKey":   "discokey:a24b6e3eb1290c84367432907f3c785aacb66b15edc579bd872a8aa4e6550e2b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53998",
+					"10.65.0.27:53998",
+					"172.17.0.1:53998",
+					"172.18.0.1:53998",
+					"172.19.0.1:53998",
+					"172.20.0.1:53998",
+					"172.21.0.1:53998",
+					"172.22.0.1:53998",
+					"172.23.0.1:53998",
+					"172.24.0.1:53998",
+					"172.25.0.1:53998",
+					"172.26.0.1:53998",
+					"172.27.0.1:53998",
+					"172.28.0.1:53998"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:14:37.223103871Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         652158256515153,
+				"StableID":   "nvVCvJ6N6611CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f71f8cedfac1f8c676ad5c576041a4eecf18f24d30471f99ea12cdc3224b208",
+				"DiscoKey":   "discokey:78940d0a8f7aa5a7a819ac538f90c50575351ec5646ea57b96f1a65127ffb662",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59893",
+					"10.65.0.27:59893",
+					"172.17.0.1:59893",
+					"172.18.0.1:59893",
+					"172.19.0.1:59893",
+					"172.20.0.1:59893",
+					"172.21.0.1:59893",
+					"172.22.0.1:59893",
+					"172.23.0.1:59893",
+					"172.24.0.1:59893",
+					"172.25.0.1:59893",
+					"172.26.0.1:59893",
+					"172.27.0.1:59893",
+					"172.28.0.1:59893"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:14:37.736228983Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2630166202798887,
+				"StableID":   "nxf6mM1DYM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b1232181959ec13a3e9624e8ce271ccf28570308e230e27c39182ace737853c",
+				"DiscoKey":   "discokey:ef2ec17c497da07d53c33ec478e9fc67db2d46ab0633a3a8510c322266249408",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:46591",
+					"10.65.0.27:46591",
+					"172.17.0.1:46591",
+					"172.18.0.1:46591",
+					"172.19.0.1:46591",
+					"172.20.0.1:46591",
+					"172.21.0.1:46591",
+					"172.22.0.1:46591",
+					"172.23.0.1:46591",
+					"172.24.0.1:46591",
+					"172.25.0.1:46591",
+					"172.26.0.1:46591",
+					"172.27.0.1:46591",
+					"172.28.0.1:46591"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:14:38.273699887Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7492479871341914,
+				"StableID":   "nZCSSzjMW121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:94197bf76ee983cf5ce7b3e7e45ec911814a04b83ce8e72cc0e9ca36ada86224",
+				"DiscoKey":   "discokey:f581bc05b5d08fb8541feae196c4866e94b3813c08df8d843f2c3dec3e3a0b5e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38464",
+					"10.65.0.27:38464",
+					"172.17.0.1:38464",
+					"172.18.0.1:38464",
+					"172.19.0.1:38464",
+					"172.20.0.1:38464",
+					"172.21.0.1:38464",
+					"172.22.0.1:38464",
+					"172.23.0.1:38464",
+					"172.24.0.1:38464",
+					"172.25.0.1:38464",
+					"172.26.0.1:38464",
+					"172.27.0.1:38464",
+					"172.28.0.1:38464"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:14:38.807670086Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4496192053903417,
+				"StableID":   "nCgPKnLL7c11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8ba3519054665252fe52daf2ca358693b2874665dac7febee26662dc7df2772d",
+				"KeyExpiry":  "2026-11-09T09:14:39Z",
+				"DiscoKey":   "discokey:6333bf224f6f9dcfcd47951e70e92b96218bdbea11fcbef77e28ba214c06303e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54449",
+					"10.65.0.27:54449",
+					"172.17.0.1:54449",
+					"172.18.0.1:54449",
+					"172.19.0.1:54449",
+					"172.20.0.1:54449",
+					"172.21.0.1:54449",
+					"172.22.0.1:54449",
+					"172.23.0.1:54449",
+					"172.24.0.1:54449",
+					"172.25.0.1:54449",
+					"172.26.0.1:54449",
+					"172.27.0.1:54449",
+					"172.28.0.1:54449"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:14:39.365637808Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5894916202258050,
+				"StableID":   "nTysbFTp2o11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b1530603c3fdbe6e274470f89fedb14c05237a75072d94676073d58c5f941a37",
+				"KeyExpiry":  "2026-11-09T09:14:39Z",
+				"DiscoKey":   "discokey:8ff5c8d67ced5c0fa173009f9be01d85d23651b478da2fad407a09382f706e35",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35852",
+					"10.65.0.27:35852",
+					"172.17.0.1:35852",
+					"172.18.0.1:35852",
+					"172.19.0.1:35852",
+					"172.20.0.1:35852",
+					"172.21.0.1:35852",
+					"172.22.0.1:35852",
+					"172.23.0.1:35852",
+					"172.24.0.1:35852",
+					"172.25.0.1:35852",
+					"172.26.0.1:35852",
+					"172.27.0.1:35852",
+					"172.28.0.1:35852"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:14:39.898001202Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2161925042966337,
+				"StableID":   "nAVBt579tH11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1092e1b55eb5c0d2f5610c08013089fab5f95281b4b2e07b644c00693a70ce04",
+				"KeyExpiry":  "2026-11-09T09:14:40Z",
+				"DiscoKey":   "discokey:cb33dfc58e777b4694782a8f94c7b4ae3e9852580af53edbbe02fd45fb6cfe28",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:40634",
+					"10.65.0.27:40634",
+					"172.17.0.1:40634",
+					"172.18.0.1:40634",
+					"172.19.0.1:40634",
+					"172.20.0.1:40634",
+					"172.21.0.1:40634",
+					"172.22.0.1:40634",
+					"172.23.0.1:40634",
+					"172.24.0.1:40634",
+					"172.25.0.1:40634",
+					"172.26.0.1:40634",
+					"172.27.0.1:40634",
+					"172.28.0.1:40634"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:14:40.443043267Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8096131484985793": {
+				"ID":          8096131484985793,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4496192053903417,
+				"StableID":   "nCgPKnLL7c11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8ba3519054665252fe52daf2ca358693b2874665dac7febee26662dc7df2772d",
+				"KeyExpiry":  "2026-11-09T09:14:39Z",
+				"DiscoKey":   "discokey:6333bf224f6f9dcfcd47951e70e92b96218bdbea11fcbef77e28ba214c06303e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54449",
+					"10.65.0.27:54449",
+					"172.17.0.1:54449",
+					"172.18.0.1:54449",
+					"172.19.0.1:54449",
+					"172.20.0.1:54449",
+					"172.21.0.1:54449",
+					"172.22.0.1:54449",
+					"172.23.0.1:54449",
+					"172.24.0.1:54449",
+					"172.25.0.1:54449",
+					"172.26.0.1:54449",
+					"172.27.0.1:54449",
+					"172.28.0.1:54449"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:14:39.365637808Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8ba3519054665252fe52daf2ca358693b2874665dac7febee26662dc7df2772d",
+			"MachineKey": "mkey:8f0d63e2ae10b27a400151d0c9269908560a2d57c2fee385d273f9c0057b6a1d",
+			"Peers": [{
+				"ID":         2840293870652164,
+				"StableID":   "nTSmDphNBP11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65bfe3aab37558c3d4257f7c4a3ce5a1fe9c0d545783dffd6fb27ffffa470a2e",
+				"DiscoKey":   "discokey:a4d7e3fb3fc79731a2c6d0f9981b49fd9888a3dccb9ea5ec8f79708e2549d90f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47906",
+					"10.65.0.27:47906",
+					"172.17.0.1:47906",
+					"172.18.0.1:47906",
+					"172.19.0.1:47906",
+					"172.20.0.1:47906",
+					"172.21.0.1:47906",
+					"172.22.0.1:47906",
+					"172.23.0.1:47906",
+					"172.24.0.1:47906",
+					"172.25.0.1:47906",
+					"172.26.0.1:47906",
+					"172.27.0.1:47906",
+					"172.28.0.1:47906"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:14:32.914936157Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3944447720512740,
+				"StableID":   "nBYEwGxSoX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd52f08d01f7e477b25d99a8459790671a4edcf479268db13bcb68972da5ef26",
+				"DiscoKey":   "discokey:29c2f5ece02e2602991a80fcd1e26044ae95e886a22a1c71132f7f3f301de552",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35813",
+					"10.65.0.27:35813",
+					"172.17.0.1:35813",
+					"172.18.0.1:35813",
+					"172.19.0.1:35813",
+					"172.20.0.1:35813",
+					"172.21.0.1:35813",
+					"172.22.0.1:35813",
+					"172.23.0.1:35813",
+					"172.24.0.1:35813",
+					"172.25.0.1:35813",
+					"172.26.0.1:35813",
+					"172.27.0.1:35813",
+					"172.28.0.1:35813"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:14:33.444311138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8196632796973305,
+				"StableID":   "nQteDPeG1721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c08f2124f0292c7e3bc13e2d8d2ad4f092a71686f3b24f88b7bb47201513d54",
+				"DiscoKey":   "discokey:dacc24dde10d1a36e280fcc9402f9b7187f0ea43128cf478d76b73dfc175f602",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39819",
+					"10.65.0.27:39819",
+					"172.17.0.1:39819",
+					"172.18.0.1:39819",
+					"172.19.0.1:39819",
+					"172.20.0.1:39819",
+					"172.21.0.1:39819",
+					"172.22.0.1:39819",
+					"172.23.0.1:39819",
+					"172.24.0.1:39819",
+					"172.25.0.1:39819",
+					"172.26.0.1:39819",
+					"172.27.0.1:39819",
+					"172.28.0.1:39819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:14:33.978522762Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3530720735132739,
+				"StableID":   "n6nkyh35aU11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3fb7232e7768dec4cba16c8e80abc1bd76a65ce5350208774913c4617f346323",
+				"DiscoKey":   "discokey:561530bf3f9f0768e9c504a9c5e5c13b4c7dac43ea67fdced9290132ec9d1509",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35092",
+					"10.65.0.27:35092",
+					"172.17.0.1:35092",
+					"172.18.0.1:35092",
+					"172.19.0.1:35092",
+					"172.20.0.1:35092",
+					"172.21.0.1:35092",
+					"172.22.0.1:35092",
+					"172.23.0.1:35092",
+					"172.24.0.1:35092",
+					"172.25.0.1:35092",
+					"172.26.0.1:35092",
+					"172.27.0.1:35092",
+					"172.28.0.1:35092"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:14:34.519796394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8493166885310382,
+				"StableID":   "nF1wAM6aK921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b67714dc940f6a6c3f20bc0474c08f0a0d508dbb660b67d4e5382af025a9b264",
+				"DiscoKey":   "discokey:eb7f68d16983c883fefeeee570629d844f6b1821f78a8769b6c8ffa26e64c97f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49260",
+					"10.65.0.27:49260",
+					"172.17.0.1:49260",
+					"172.18.0.1:49260",
+					"172.19.0.1:49260",
+					"172.20.0.1:49260",
+					"172.21.0.1:49260",
+					"172.22.0.1:49260",
+					"172.23.0.1:49260",
+					"172.24.0.1:49260",
+					"172.25.0.1:49260",
+					"172.26.0.1:49260",
+					"172.27.0.1:49260",
+					"172.28.0.1:49260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:14:35.055432543Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6905021408415337,
+				"StableID":   "nJd9joCJvv11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22a6989ab145d63e5dc0190d424872b2e13d69c840276015ada95a260ee3a813",
+				"DiscoKey":   "discokey:3d2b4f0c5ca407ea4226bfcf74e39faaf98d448741f49a4ea4a55c51a6c97e74",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33099",
+					"10.65.0.27:33099",
+					"172.17.0.1:33099",
+					"172.18.0.1:33099",
+					"172.19.0.1:33099",
+					"172.20.0.1:33099",
+					"172.21.0.1:33099",
+					"172.22.0.1:33099",
+					"172.23.0.1:33099",
+					"172.24.0.1:33099",
+					"172.25.0.1:33099",
+					"172.26.0.1:33099",
+					"172.27.0.1:33099",
+					"172.28.0.1:33099"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:14:35.589805582Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1378366829076477,
+				"StableID":   "nnF2hqMGmB11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8c1cae6b2713e6afd28791292ce29afa5e8d37fbbc5fd5b91047d0e74980d2c",
+				"DiscoKey":   "discokey:f8e2a2f49c94748f64d088c0c05530956245a73e92321502c7ef5a8c374bcb3a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51558",
+					"10.65.0.27:51558",
+					"172.17.0.1:51558",
+					"172.18.0.1:51558",
+					"172.19.0.1:51558",
+					"172.20.0.1:51558",
+					"172.21.0.1:51558",
+					"172.22.0.1:51558",
+					"172.23.0.1:51558",
+					"172.24.0.1:51558",
+					"172.25.0.1:51558",
+					"172.26.0.1:51558",
+					"172.27.0.1:51558",
+					"172.28.0.1:51558"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:14:36.123605174Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8096131484985793,
+				"StableID":   "nQ8rRSekD621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5ed161b91ef60de21d1932add68bb1a403c7075494bc635c14ed065846b6023",
+				"DiscoKey":   "discokey:342cf3aa2e3fe8811029ee42ffb6911b44105deb8348846ff4b891d9d2842559",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36582",
+					"10.65.0.27:36582",
+					"172.17.0.1:36582",
+					"172.18.0.1:36582",
+					"172.19.0.1:36582",
+					"172.20.0.1:36582",
+					"172.21.0.1:36582",
+					"172.22.0.1:36582",
+					"172.23.0.1:36582",
+					"172.24.0.1:36582",
+					"172.25.0.1:36582",
+					"172.26.0.1:36582",
+					"172.27.0.1:36582",
+					"172.28.0.1:36582"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:14:36.697309618Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5263862495942249,
+				"StableID":   "nnFwW2k17i11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:759cab22549715a036dc3776fd5599511ec3132e6c4d69858d27095db3d99b17",
+				"DiscoKey":   "discokey:a24b6e3eb1290c84367432907f3c785aacb66b15edc579bd872a8aa4e6550e2b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53998",
+					"10.65.0.27:53998",
+					"172.17.0.1:53998",
+					"172.18.0.1:53998",
+					"172.19.0.1:53998",
+					"172.20.0.1:53998",
+					"172.21.0.1:53998",
+					"172.22.0.1:53998",
+					"172.23.0.1:53998",
+					"172.24.0.1:53998",
+					"172.25.0.1:53998",
+					"172.26.0.1:53998",
+					"172.27.0.1:53998",
+					"172.28.0.1:53998"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:14:37.223103871Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         652158256515153,
+				"StableID":   "nvVCvJ6N6611CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f71f8cedfac1f8c676ad5c576041a4eecf18f24d30471f99ea12cdc3224b208",
+				"DiscoKey":   "discokey:78940d0a8f7aa5a7a819ac538f90c50575351ec5646ea57b96f1a65127ffb662",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59893",
+					"10.65.0.27:59893",
+					"172.17.0.1:59893",
+					"172.18.0.1:59893",
+					"172.19.0.1:59893",
+					"172.20.0.1:59893",
+					"172.21.0.1:59893",
+					"172.22.0.1:59893",
+					"172.23.0.1:59893",
+					"172.24.0.1:59893",
+					"172.25.0.1:59893",
+					"172.26.0.1:59893",
+					"172.27.0.1:59893",
+					"172.28.0.1:59893"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:14:37.736228983Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2630166202798887,
+				"StableID":   "nxf6mM1DYM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b1232181959ec13a3e9624e8ce271ccf28570308e230e27c39182ace737853c",
+				"DiscoKey":   "discokey:ef2ec17c497da07d53c33ec478e9fc67db2d46ab0633a3a8510c322266249408",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:46591",
+					"10.65.0.27:46591",
+					"172.17.0.1:46591",
+					"172.18.0.1:46591",
+					"172.19.0.1:46591",
+					"172.20.0.1:46591",
+					"172.21.0.1:46591",
+					"172.22.0.1:46591",
+					"172.23.0.1:46591",
+					"172.24.0.1:46591",
+					"172.25.0.1:46591",
+					"172.26.0.1:46591",
+					"172.27.0.1:46591",
+					"172.28.0.1:46591"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:14:38.273699887Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7492479871341914,
+				"StableID":   "nZCSSzjMW121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:94197bf76ee983cf5ce7b3e7e45ec911814a04b83ce8e72cc0e9ca36ada86224",
+				"DiscoKey":   "discokey:f581bc05b5d08fb8541feae196c4866e94b3813c08df8d843f2c3dec3e3a0b5e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38464",
+					"10.65.0.27:38464",
+					"172.17.0.1:38464",
+					"172.18.0.1:38464",
+					"172.19.0.1:38464",
+					"172.20.0.1:38464",
+					"172.21.0.1:38464",
+					"172.22.0.1:38464",
+					"172.23.0.1:38464",
+					"172.24.0.1:38464",
+					"172.25.0.1:38464",
+					"172.26.0.1:38464",
+					"172.27.0.1:38464",
+					"172.28.0.1:38464"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:14:38.807670086Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5894916202258050,
+				"StableID":   "nTysbFTp2o11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b1530603c3fdbe6e274470f89fedb14c05237a75072d94676073d58c5f941a37",
+				"KeyExpiry":  "2026-11-09T09:14:39Z",
+				"DiscoKey":   "discokey:8ff5c8d67ced5c0fa173009f9be01d85d23651b478da2fad407a09382f706e35",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35852",
+					"10.65.0.27:35852",
+					"172.17.0.1:35852",
+					"172.18.0.1:35852",
+					"172.19.0.1:35852",
+					"172.20.0.1:35852",
+					"172.21.0.1:35852",
+					"172.22.0.1:35852",
+					"172.23.0.1:35852",
+					"172.24.0.1:35852",
+					"172.25.0.1:35852",
+					"172.26.0.1:35852",
+					"172.27.0.1:35852",
+					"172.28.0.1:35852"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:14:39.898001202Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2161925042966337,
+				"StableID":   "nAVBt579tH11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1092e1b55eb5c0d2f5610c08013089fab5f95281b4b2e07b644c00693a70ce04",
+				"KeyExpiry":  "2026-11-09T09:14:40Z",
+				"DiscoKey":   "discokey:cb33dfc58e777b4694782a8f94c7b4ae3e9852580af53edbbe02fd45fb6cfe28",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:40634",
+					"10.65.0.27:40634",
+					"172.17.0.1:40634",
+					"172.18.0.1:40634",
+					"172.19.0.1:40634",
+					"172.20.0.1:40634",
+					"172.21.0.1:40634",
+					"172.22.0.1:40634",
+					"172.23.0.1:40634",
+					"172.24.0.1:40634",
+					"172.25.0.1:40634",
+					"172.26.0.1:40634",
+					"172.27.0.1:40634",
+					"172.28.0.1:40634"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:14:40.443043267Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2630166202798887,
+				"StableID":   "nxf6mM1DYM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       2630166202798887,
+				"Key":        "nodekey:9b1232181959ec13a3e9624e8ce271ccf28570308e230e27c39182ace737853c",
+				"DiscoKey":   "discokey:ef2ec17c497da07d53c33ec478e9fc67db2d46ab0633a3a8510c322266249408",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:46591",
+					"10.65.0.27:46591",
+					"172.17.0.1:46591",
+					"172.18.0.1:46591",
+					"172.19.0.1:46591",
+					"172.20.0.1:46591",
+					"172.21.0.1:46591",
+					"172.22.0.1:46591",
+					"172.23.0.1:46591",
+					"172.24.0.1:46591",
+					"172.25.0.1:46591",
+					"172.26.0.1:46591",
+					"172.27.0.1:46591",
+					"172.28.0.1:46591"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:14:38.273699887Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9b1232181959ec13a3e9624e8ce271ccf28570308e230e27c39182ace737853c",
+			"MachineKey": "mkey:7f03449a6fe091b87bebc6e899cb73390eb0a203a1bc67d90025343101f44e12",
+			"Peers": [{
+				"ID":         2840293870652164,
+				"StableID":   "nTSmDphNBP11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65bfe3aab37558c3d4257f7c4a3ce5a1fe9c0d545783dffd6fb27ffffa470a2e",
+				"DiscoKey":   "discokey:a4d7e3fb3fc79731a2c6d0f9981b49fd9888a3dccb9ea5ec8f79708e2549d90f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47906",
+					"10.65.0.27:47906",
+					"172.17.0.1:47906",
+					"172.18.0.1:47906",
+					"172.19.0.1:47906",
+					"172.20.0.1:47906",
+					"172.21.0.1:47906",
+					"172.22.0.1:47906",
+					"172.23.0.1:47906",
+					"172.24.0.1:47906",
+					"172.25.0.1:47906",
+					"172.26.0.1:47906",
+					"172.27.0.1:47906",
+					"172.28.0.1:47906"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:14:32.914936157Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3944447720512740,
+				"StableID":   "nBYEwGxSoX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd52f08d01f7e477b25d99a8459790671a4edcf479268db13bcb68972da5ef26",
+				"DiscoKey":   "discokey:29c2f5ece02e2602991a80fcd1e26044ae95e886a22a1c71132f7f3f301de552",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35813",
+					"10.65.0.27:35813",
+					"172.17.0.1:35813",
+					"172.18.0.1:35813",
+					"172.19.0.1:35813",
+					"172.20.0.1:35813",
+					"172.21.0.1:35813",
+					"172.22.0.1:35813",
+					"172.23.0.1:35813",
+					"172.24.0.1:35813",
+					"172.25.0.1:35813",
+					"172.26.0.1:35813",
+					"172.27.0.1:35813",
+					"172.28.0.1:35813"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:14:33.444311138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8196632796973305,
+				"StableID":   "nQteDPeG1721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c08f2124f0292c7e3bc13e2d8d2ad4f092a71686f3b24f88b7bb47201513d54",
+				"DiscoKey":   "discokey:dacc24dde10d1a36e280fcc9402f9b7187f0ea43128cf478d76b73dfc175f602",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39819",
+					"10.65.0.27:39819",
+					"172.17.0.1:39819",
+					"172.18.0.1:39819",
+					"172.19.0.1:39819",
+					"172.20.0.1:39819",
+					"172.21.0.1:39819",
+					"172.22.0.1:39819",
+					"172.23.0.1:39819",
+					"172.24.0.1:39819",
+					"172.25.0.1:39819",
+					"172.26.0.1:39819",
+					"172.27.0.1:39819",
+					"172.28.0.1:39819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:14:33.978522762Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3530720735132739,
+				"StableID":   "n6nkyh35aU11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3fb7232e7768dec4cba16c8e80abc1bd76a65ce5350208774913c4617f346323",
+				"DiscoKey":   "discokey:561530bf3f9f0768e9c504a9c5e5c13b4c7dac43ea67fdced9290132ec9d1509",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35092",
+					"10.65.0.27:35092",
+					"172.17.0.1:35092",
+					"172.18.0.1:35092",
+					"172.19.0.1:35092",
+					"172.20.0.1:35092",
+					"172.21.0.1:35092",
+					"172.22.0.1:35092",
+					"172.23.0.1:35092",
+					"172.24.0.1:35092",
+					"172.25.0.1:35092",
+					"172.26.0.1:35092",
+					"172.27.0.1:35092",
+					"172.28.0.1:35092"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:14:34.519796394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8493166885310382,
+				"StableID":   "nF1wAM6aK921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b67714dc940f6a6c3f20bc0474c08f0a0d508dbb660b67d4e5382af025a9b264",
+				"DiscoKey":   "discokey:eb7f68d16983c883fefeeee570629d844f6b1821f78a8769b6c8ffa26e64c97f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49260",
+					"10.65.0.27:49260",
+					"172.17.0.1:49260",
+					"172.18.0.1:49260",
+					"172.19.0.1:49260",
+					"172.20.0.1:49260",
+					"172.21.0.1:49260",
+					"172.22.0.1:49260",
+					"172.23.0.1:49260",
+					"172.24.0.1:49260",
+					"172.25.0.1:49260",
+					"172.26.0.1:49260",
+					"172.27.0.1:49260",
+					"172.28.0.1:49260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:14:35.055432543Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6905021408415337,
+				"StableID":   "nJd9joCJvv11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22a6989ab145d63e5dc0190d424872b2e13d69c840276015ada95a260ee3a813",
+				"DiscoKey":   "discokey:3d2b4f0c5ca407ea4226bfcf74e39faaf98d448741f49a4ea4a55c51a6c97e74",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33099",
+					"10.65.0.27:33099",
+					"172.17.0.1:33099",
+					"172.18.0.1:33099",
+					"172.19.0.1:33099",
+					"172.20.0.1:33099",
+					"172.21.0.1:33099",
+					"172.22.0.1:33099",
+					"172.23.0.1:33099",
+					"172.24.0.1:33099",
+					"172.25.0.1:33099",
+					"172.26.0.1:33099",
+					"172.27.0.1:33099",
+					"172.28.0.1:33099"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:14:35.589805582Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1378366829076477,
+				"StableID":   "nnF2hqMGmB11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8c1cae6b2713e6afd28791292ce29afa5e8d37fbbc5fd5b91047d0e74980d2c",
+				"DiscoKey":   "discokey:f8e2a2f49c94748f64d088c0c05530956245a73e92321502c7ef5a8c374bcb3a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51558",
+					"10.65.0.27:51558",
+					"172.17.0.1:51558",
+					"172.18.0.1:51558",
+					"172.19.0.1:51558",
+					"172.20.0.1:51558",
+					"172.21.0.1:51558",
+					"172.22.0.1:51558",
+					"172.23.0.1:51558",
+					"172.24.0.1:51558",
+					"172.25.0.1:51558",
+					"172.26.0.1:51558",
+					"172.27.0.1:51558",
+					"172.28.0.1:51558"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:14:36.123605174Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8096131484985793,
+				"StableID":   "nQ8rRSekD621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5ed161b91ef60de21d1932add68bb1a403c7075494bc635c14ed065846b6023",
+				"DiscoKey":   "discokey:342cf3aa2e3fe8811029ee42ffb6911b44105deb8348846ff4b891d9d2842559",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36582",
+					"10.65.0.27:36582",
+					"172.17.0.1:36582",
+					"172.18.0.1:36582",
+					"172.19.0.1:36582",
+					"172.20.0.1:36582",
+					"172.21.0.1:36582",
+					"172.22.0.1:36582",
+					"172.23.0.1:36582",
+					"172.24.0.1:36582",
+					"172.25.0.1:36582",
+					"172.26.0.1:36582",
+					"172.27.0.1:36582",
+					"172.28.0.1:36582"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:14:36.697309618Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5263862495942249,
+				"StableID":   "nnFwW2k17i11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:759cab22549715a036dc3776fd5599511ec3132e6c4d69858d27095db3d99b17",
+				"DiscoKey":   "discokey:a24b6e3eb1290c84367432907f3c785aacb66b15edc579bd872a8aa4e6550e2b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53998",
+					"10.65.0.27:53998",
+					"172.17.0.1:53998",
+					"172.18.0.1:53998",
+					"172.19.0.1:53998",
+					"172.20.0.1:53998",
+					"172.21.0.1:53998",
+					"172.22.0.1:53998",
+					"172.23.0.1:53998",
+					"172.24.0.1:53998",
+					"172.25.0.1:53998",
+					"172.26.0.1:53998",
+					"172.27.0.1:53998",
+					"172.28.0.1:53998"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:14:37.223103871Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         652158256515153,
+				"StableID":   "nvVCvJ6N6611CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f71f8cedfac1f8c676ad5c576041a4eecf18f24d30471f99ea12cdc3224b208",
+				"DiscoKey":   "discokey:78940d0a8f7aa5a7a819ac538f90c50575351ec5646ea57b96f1a65127ffb662",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59893",
+					"10.65.0.27:59893",
+					"172.17.0.1:59893",
+					"172.18.0.1:59893",
+					"172.19.0.1:59893",
+					"172.20.0.1:59893",
+					"172.21.0.1:59893",
+					"172.22.0.1:59893",
+					"172.23.0.1:59893",
+					"172.24.0.1:59893",
+					"172.25.0.1:59893",
+					"172.26.0.1:59893",
+					"172.27.0.1:59893",
+					"172.28.0.1:59893"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:14:37.736228983Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7492479871341914,
+				"StableID":   "nZCSSzjMW121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:94197bf76ee983cf5ce7b3e7e45ec911814a04b83ce8e72cc0e9ca36ada86224",
+				"DiscoKey":   "discokey:f581bc05b5d08fb8541feae196c4866e94b3813c08df8d843f2c3dec3e3a0b5e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38464",
+					"10.65.0.27:38464",
+					"172.17.0.1:38464",
+					"172.18.0.1:38464",
+					"172.19.0.1:38464",
+					"172.20.0.1:38464",
+					"172.21.0.1:38464",
+					"172.22.0.1:38464",
+					"172.23.0.1:38464",
+					"172.24.0.1:38464",
+					"172.25.0.1:38464",
+					"172.26.0.1:38464",
+					"172.27.0.1:38464",
+					"172.28.0.1:38464"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:14:38.807670086Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4496192053903417,
+				"StableID":   "nCgPKnLL7c11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8ba3519054665252fe52daf2ca358693b2874665dac7febee26662dc7df2772d",
+				"KeyExpiry":  "2026-11-09T09:14:39Z",
+				"DiscoKey":   "discokey:6333bf224f6f9dcfcd47951e70e92b96218bdbea11fcbef77e28ba214c06303e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54449",
+					"10.65.0.27:54449",
+					"172.17.0.1:54449",
+					"172.18.0.1:54449",
+					"172.19.0.1:54449",
+					"172.20.0.1:54449",
+					"172.21.0.1:54449",
+					"172.22.0.1:54449",
+					"172.23.0.1:54449",
+					"172.24.0.1:54449",
+					"172.25.0.1:54449",
+					"172.26.0.1:54449",
+					"172.27.0.1:54449",
+					"172.28.0.1:54449"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:14:39.365637808Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5894916202258050,
+				"StableID":   "nTysbFTp2o11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b1530603c3fdbe6e274470f89fedb14c05237a75072d94676073d58c5f941a37",
+				"KeyExpiry":  "2026-11-09T09:14:39Z",
+				"DiscoKey":   "discokey:8ff5c8d67ced5c0fa173009f9be01d85d23651b478da2fad407a09382f706e35",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35852",
+					"10.65.0.27:35852",
+					"172.17.0.1:35852",
+					"172.18.0.1:35852",
+					"172.19.0.1:35852",
+					"172.20.0.1:35852",
+					"172.21.0.1:35852",
+					"172.22.0.1:35852",
+					"172.23.0.1:35852",
+					"172.24.0.1:35852",
+					"172.25.0.1:35852",
+					"172.26.0.1:35852",
+					"172.27.0.1:35852",
+					"172.28.0.1:35852"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:14:39.898001202Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2161925042966337,
+				"StableID":   "nAVBt579tH11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1092e1b55eb5c0d2f5610c08013089fab5f95281b4b2e07b644c00693a70ce04",
+				"KeyExpiry":  "2026-11-09T09:14:40Z",
+				"DiscoKey":   "discokey:cb33dfc58e777b4694782a8f94c7b4ae3e9852580af53edbbe02fd45fb6cfe28",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:40634",
+					"10.65.0.27:40634",
+					"172.17.0.1:40634",
+					"172.18.0.1:40634",
+					"172.19.0.1:40634",
+					"172.20.0.1:40634",
+					"172.21.0.1:40634",
+					"172.22.0.1:40634",
+					"172.23.0.1:40634",
+					"172.24.0.1:40634",
+					"172.25.0.1:40634",
+					"172.26.0.1:40634",
+					"172.27.0.1:40634",
+					"172.28.0.1:40634"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:14:40.443043267Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{
+				"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+				"sshUsers":   {"root": "root"},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				}
+			}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2630166202798887": {
+				"ID":          2630166202798887,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		},
+		"ssh_rules": [{
+			"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+			"sshUsers":   {"root": "root"},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}
+		}]
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3944447720512740,
+				"StableID":   "nBYEwGxSoX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       3944447720512740,
+				"Key":        "nodekey:cd52f08d01f7e477b25d99a8459790671a4edcf479268db13bcb68972da5ef26",
+				"DiscoKey":   "discokey:29c2f5ece02e2602991a80fcd1e26044ae95e886a22a1c71132f7f3f301de552",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35813",
+					"10.65.0.27:35813",
+					"172.17.0.1:35813",
+					"172.18.0.1:35813",
+					"172.19.0.1:35813",
+					"172.20.0.1:35813",
+					"172.21.0.1:35813",
+					"172.22.0.1:35813",
+					"172.23.0.1:35813",
+					"172.24.0.1:35813",
+					"172.25.0.1:35813",
+					"172.26.0.1:35813",
+					"172.27.0.1:35813",
+					"172.28.0.1:35813"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:14:33.444311138Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:cd52f08d01f7e477b25d99a8459790671a4edcf479268db13bcb68972da5ef26",
+			"MachineKey": "mkey:986062d2fa49470d6391f13e2f3ba014e255f86f23c13658e402a0c6c371bf03",
+			"Peers": [{
+				"ID":         2840293870652164,
+				"StableID":   "nTSmDphNBP11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65bfe3aab37558c3d4257f7c4a3ce5a1fe9c0d545783dffd6fb27ffffa470a2e",
+				"DiscoKey":   "discokey:a4d7e3fb3fc79731a2c6d0f9981b49fd9888a3dccb9ea5ec8f79708e2549d90f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47906",
+					"10.65.0.27:47906",
+					"172.17.0.1:47906",
+					"172.18.0.1:47906",
+					"172.19.0.1:47906",
+					"172.20.0.1:47906",
+					"172.21.0.1:47906",
+					"172.22.0.1:47906",
+					"172.23.0.1:47906",
+					"172.24.0.1:47906",
+					"172.25.0.1:47906",
+					"172.26.0.1:47906",
+					"172.27.0.1:47906",
+					"172.28.0.1:47906"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:14:32.914936157Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8196632796973305,
+				"StableID":   "nQteDPeG1721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c08f2124f0292c7e3bc13e2d8d2ad4f092a71686f3b24f88b7bb47201513d54",
+				"DiscoKey":   "discokey:dacc24dde10d1a36e280fcc9402f9b7187f0ea43128cf478d76b73dfc175f602",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39819",
+					"10.65.0.27:39819",
+					"172.17.0.1:39819",
+					"172.18.0.1:39819",
+					"172.19.0.1:39819",
+					"172.20.0.1:39819",
+					"172.21.0.1:39819",
+					"172.22.0.1:39819",
+					"172.23.0.1:39819",
+					"172.24.0.1:39819",
+					"172.25.0.1:39819",
+					"172.26.0.1:39819",
+					"172.27.0.1:39819",
+					"172.28.0.1:39819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:14:33.978522762Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3530720735132739,
+				"StableID":   "n6nkyh35aU11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3fb7232e7768dec4cba16c8e80abc1bd76a65ce5350208774913c4617f346323",
+				"DiscoKey":   "discokey:561530bf3f9f0768e9c504a9c5e5c13b4c7dac43ea67fdced9290132ec9d1509",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35092",
+					"10.65.0.27:35092",
+					"172.17.0.1:35092",
+					"172.18.0.1:35092",
+					"172.19.0.1:35092",
+					"172.20.0.1:35092",
+					"172.21.0.1:35092",
+					"172.22.0.1:35092",
+					"172.23.0.1:35092",
+					"172.24.0.1:35092",
+					"172.25.0.1:35092",
+					"172.26.0.1:35092",
+					"172.27.0.1:35092",
+					"172.28.0.1:35092"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:14:34.519796394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8493166885310382,
+				"StableID":   "nF1wAM6aK921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b67714dc940f6a6c3f20bc0474c08f0a0d508dbb660b67d4e5382af025a9b264",
+				"DiscoKey":   "discokey:eb7f68d16983c883fefeeee570629d844f6b1821f78a8769b6c8ffa26e64c97f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49260",
+					"10.65.0.27:49260",
+					"172.17.0.1:49260",
+					"172.18.0.1:49260",
+					"172.19.0.1:49260",
+					"172.20.0.1:49260",
+					"172.21.0.1:49260",
+					"172.22.0.1:49260",
+					"172.23.0.1:49260",
+					"172.24.0.1:49260",
+					"172.25.0.1:49260",
+					"172.26.0.1:49260",
+					"172.27.0.1:49260",
+					"172.28.0.1:49260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:14:35.055432543Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6905021408415337,
+				"StableID":   "nJd9joCJvv11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22a6989ab145d63e5dc0190d424872b2e13d69c840276015ada95a260ee3a813",
+				"DiscoKey":   "discokey:3d2b4f0c5ca407ea4226bfcf74e39faaf98d448741f49a4ea4a55c51a6c97e74",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33099",
+					"10.65.0.27:33099",
+					"172.17.0.1:33099",
+					"172.18.0.1:33099",
+					"172.19.0.1:33099",
+					"172.20.0.1:33099",
+					"172.21.0.1:33099",
+					"172.22.0.1:33099",
+					"172.23.0.1:33099",
+					"172.24.0.1:33099",
+					"172.25.0.1:33099",
+					"172.26.0.1:33099",
+					"172.27.0.1:33099",
+					"172.28.0.1:33099"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:14:35.589805582Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1378366829076477,
+				"StableID":   "nnF2hqMGmB11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8c1cae6b2713e6afd28791292ce29afa5e8d37fbbc5fd5b91047d0e74980d2c",
+				"DiscoKey":   "discokey:f8e2a2f49c94748f64d088c0c05530956245a73e92321502c7ef5a8c374bcb3a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51558",
+					"10.65.0.27:51558",
+					"172.17.0.1:51558",
+					"172.18.0.1:51558",
+					"172.19.0.1:51558",
+					"172.20.0.1:51558",
+					"172.21.0.1:51558",
+					"172.22.0.1:51558",
+					"172.23.0.1:51558",
+					"172.24.0.1:51558",
+					"172.25.0.1:51558",
+					"172.26.0.1:51558",
+					"172.27.0.1:51558",
+					"172.28.0.1:51558"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:14:36.123605174Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8096131484985793,
+				"StableID":   "nQ8rRSekD621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5ed161b91ef60de21d1932add68bb1a403c7075494bc635c14ed065846b6023",
+				"DiscoKey":   "discokey:342cf3aa2e3fe8811029ee42ffb6911b44105deb8348846ff4b891d9d2842559",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36582",
+					"10.65.0.27:36582",
+					"172.17.0.1:36582",
+					"172.18.0.1:36582",
+					"172.19.0.1:36582",
+					"172.20.0.1:36582",
+					"172.21.0.1:36582",
+					"172.22.0.1:36582",
+					"172.23.0.1:36582",
+					"172.24.0.1:36582",
+					"172.25.0.1:36582",
+					"172.26.0.1:36582",
+					"172.27.0.1:36582",
+					"172.28.0.1:36582"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:14:36.697309618Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5263862495942249,
+				"StableID":   "nnFwW2k17i11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:759cab22549715a036dc3776fd5599511ec3132e6c4d69858d27095db3d99b17",
+				"DiscoKey":   "discokey:a24b6e3eb1290c84367432907f3c785aacb66b15edc579bd872a8aa4e6550e2b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53998",
+					"10.65.0.27:53998",
+					"172.17.0.1:53998",
+					"172.18.0.1:53998",
+					"172.19.0.1:53998",
+					"172.20.0.1:53998",
+					"172.21.0.1:53998",
+					"172.22.0.1:53998",
+					"172.23.0.1:53998",
+					"172.24.0.1:53998",
+					"172.25.0.1:53998",
+					"172.26.0.1:53998",
+					"172.27.0.1:53998",
+					"172.28.0.1:53998"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:14:37.223103871Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         652158256515153,
+				"StableID":   "nvVCvJ6N6611CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f71f8cedfac1f8c676ad5c576041a4eecf18f24d30471f99ea12cdc3224b208",
+				"DiscoKey":   "discokey:78940d0a8f7aa5a7a819ac538f90c50575351ec5646ea57b96f1a65127ffb662",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59893",
+					"10.65.0.27:59893",
+					"172.17.0.1:59893",
+					"172.18.0.1:59893",
+					"172.19.0.1:59893",
+					"172.20.0.1:59893",
+					"172.21.0.1:59893",
+					"172.22.0.1:59893",
+					"172.23.0.1:59893",
+					"172.24.0.1:59893",
+					"172.25.0.1:59893",
+					"172.26.0.1:59893",
+					"172.27.0.1:59893",
+					"172.28.0.1:59893"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:14:37.736228983Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2630166202798887,
+				"StableID":   "nxf6mM1DYM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b1232181959ec13a3e9624e8ce271ccf28570308e230e27c39182ace737853c",
+				"DiscoKey":   "discokey:ef2ec17c497da07d53c33ec478e9fc67db2d46ab0633a3a8510c322266249408",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:46591",
+					"10.65.0.27:46591",
+					"172.17.0.1:46591",
+					"172.18.0.1:46591",
+					"172.19.0.1:46591",
+					"172.20.0.1:46591",
+					"172.21.0.1:46591",
+					"172.22.0.1:46591",
+					"172.23.0.1:46591",
+					"172.24.0.1:46591",
+					"172.25.0.1:46591",
+					"172.26.0.1:46591",
+					"172.27.0.1:46591",
+					"172.28.0.1:46591"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:14:38.273699887Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7492479871341914,
+				"StableID":   "nZCSSzjMW121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:94197bf76ee983cf5ce7b3e7e45ec911814a04b83ce8e72cc0e9ca36ada86224",
+				"DiscoKey":   "discokey:f581bc05b5d08fb8541feae196c4866e94b3813c08df8d843f2c3dec3e3a0b5e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38464",
+					"10.65.0.27:38464",
+					"172.17.0.1:38464",
+					"172.18.0.1:38464",
+					"172.19.0.1:38464",
+					"172.20.0.1:38464",
+					"172.21.0.1:38464",
+					"172.22.0.1:38464",
+					"172.23.0.1:38464",
+					"172.24.0.1:38464",
+					"172.25.0.1:38464",
+					"172.26.0.1:38464",
+					"172.27.0.1:38464",
+					"172.28.0.1:38464"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:14:38.807670086Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4496192053903417,
+				"StableID":   "nCgPKnLL7c11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8ba3519054665252fe52daf2ca358693b2874665dac7febee26662dc7df2772d",
+				"KeyExpiry":  "2026-11-09T09:14:39Z",
+				"DiscoKey":   "discokey:6333bf224f6f9dcfcd47951e70e92b96218bdbea11fcbef77e28ba214c06303e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54449",
+					"10.65.0.27:54449",
+					"172.17.0.1:54449",
+					"172.18.0.1:54449",
+					"172.19.0.1:54449",
+					"172.20.0.1:54449",
+					"172.21.0.1:54449",
+					"172.22.0.1:54449",
+					"172.23.0.1:54449",
+					"172.24.0.1:54449",
+					"172.25.0.1:54449",
+					"172.26.0.1:54449",
+					"172.27.0.1:54449",
+					"172.28.0.1:54449"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:14:39.365637808Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5894916202258050,
+				"StableID":   "nTysbFTp2o11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b1530603c3fdbe6e274470f89fedb14c05237a75072d94676073d58c5f941a37",
+				"KeyExpiry":  "2026-11-09T09:14:39Z",
+				"DiscoKey":   "discokey:8ff5c8d67ced5c0fa173009f9be01d85d23651b478da2fad407a09382f706e35",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35852",
+					"10.65.0.27:35852",
+					"172.17.0.1:35852",
+					"172.18.0.1:35852",
+					"172.19.0.1:35852",
+					"172.20.0.1:35852",
+					"172.21.0.1:35852",
+					"172.22.0.1:35852",
+					"172.23.0.1:35852",
+					"172.24.0.1:35852",
+					"172.25.0.1:35852",
+					"172.26.0.1:35852",
+					"172.27.0.1:35852",
+					"172.28.0.1:35852"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:14:39.898001202Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2161925042966337,
+				"StableID":   "nAVBt579tH11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1092e1b55eb5c0d2f5610c08013089fab5f95281b4b2e07b644c00693a70ce04",
+				"KeyExpiry":  "2026-11-09T09:14:40Z",
+				"DiscoKey":   "discokey:cb33dfc58e777b4694782a8f94c7b4ae3e9852580af53edbbe02fd45fb6cfe28",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:40634",
+					"10.65.0.27:40634",
+					"172.17.0.1:40634",
+					"172.18.0.1:40634",
+					"172.19.0.1:40634",
+					"172.20.0.1:40634",
+					"172.21.0.1:40634",
+					"172.22.0.1:40634",
+					"172.23.0.1:40634",
+					"172.24.0.1:40634",
+					"172.25.0.1:40634",
+					"172.26.0.1:40634",
+					"172.27.0.1:40634",
+					"172.28.0.1:40634"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:14:40.443043267Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3944447720512740": {
+				"ID":          3944447720512740,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2840293870652164,
+				"StableID":   "nTSmDphNBP11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       2840293870652164,
+				"Key":        "nodekey:65bfe3aab37558c3d4257f7c4a3ce5a1fe9c0d545783dffd6fb27ffffa470a2e",
+				"DiscoKey":   "discokey:a4d7e3fb3fc79731a2c6d0f9981b49fd9888a3dccb9ea5ec8f79708e2549d90f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47906",
+					"10.65.0.27:47906",
+					"172.17.0.1:47906",
+					"172.18.0.1:47906",
+					"172.19.0.1:47906",
+					"172.20.0.1:47906",
+					"172.21.0.1:47906",
+					"172.22.0.1:47906",
+					"172.23.0.1:47906",
+					"172.24.0.1:47906",
+					"172.25.0.1:47906",
+					"172.26.0.1:47906",
+					"172.27.0.1:47906",
+					"172.28.0.1:47906"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:14:32.914936157Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:65bfe3aab37558c3d4257f7c4a3ce5a1fe9c0d545783dffd6fb27ffffa470a2e",
+			"MachineKey": "mkey:5be72d6481916f687466a800c25443328ba3f099c0be7245015ab16079a6042a",
+			"Peers": [{
+				"ID":         3944447720512740,
+				"StableID":   "nBYEwGxSoX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd52f08d01f7e477b25d99a8459790671a4edcf479268db13bcb68972da5ef26",
+				"DiscoKey":   "discokey:29c2f5ece02e2602991a80fcd1e26044ae95e886a22a1c71132f7f3f301de552",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35813",
+					"10.65.0.27:35813",
+					"172.17.0.1:35813",
+					"172.18.0.1:35813",
+					"172.19.0.1:35813",
+					"172.20.0.1:35813",
+					"172.21.0.1:35813",
+					"172.22.0.1:35813",
+					"172.23.0.1:35813",
+					"172.24.0.1:35813",
+					"172.25.0.1:35813",
+					"172.26.0.1:35813",
+					"172.27.0.1:35813",
+					"172.28.0.1:35813"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:14:33.444311138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8196632796973305,
+				"StableID":   "nQteDPeG1721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c08f2124f0292c7e3bc13e2d8d2ad4f092a71686f3b24f88b7bb47201513d54",
+				"DiscoKey":   "discokey:dacc24dde10d1a36e280fcc9402f9b7187f0ea43128cf478d76b73dfc175f602",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39819",
+					"10.65.0.27:39819",
+					"172.17.0.1:39819",
+					"172.18.0.1:39819",
+					"172.19.0.1:39819",
+					"172.20.0.1:39819",
+					"172.21.0.1:39819",
+					"172.22.0.1:39819",
+					"172.23.0.1:39819",
+					"172.24.0.1:39819",
+					"172.25.0.1:39819",
+					"172.26.0.1:39819",
+					"172.27.0.1:39819",
+					"172.28.0.1:39819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:14:33.978522762Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3530720735132739,
+				"StableID":   "n6nkyh35aU11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3fb7232e7768dec4cba16c8e80abc1bd76a65ce5350208774913c4617f346323",
+				"DiscoKey":   "discokey:561530bf3f9f0768e9c504a9c5e5c13b4c7dac43ea67fdced9290132ec9d1509",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35092",
+					"10.65.0.27:35092",
+					"172.17.0.1:35092",
+					"172.18.0.1:35092",
+					"172.19.0.1:35092",
+					"172.20.0.1:35092",
+					"172.21.0.1:35092",
+					"172.22.0.1:35092",
+					"172.23.0.1:35092",
+					"172.24.0.1:35092",
+					"172.25.0.1:35092",
+					"172.26.0.1:35092",
+					"172.27.0.1:35092",
+					"172.28.0.1:35092"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:14:34.519796394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8493166885310382,
+				"StableID":   "nF1wAM6aK921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b67714dc940f6a6c3f20bc0474c08f0a0d508dbb660b67d4e5382af025a9b264",
+				"DiscoKey":   "discokey:eb7f68d16983c883fefeeee570629d844f6b1821f78a8769b6c8ffa26e64c97f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49260",
+					"10.65.0.27:49260",
+					"172.17.0.1:49260",
+					"172.18.0.1:49260",
+					"172.19.0.1:49260",
+					"172.20.0.1:49260",
+					"172.21.0.1:49260",
+					"172.22.0.1:49260",
+					"172.23.0.1:49260",
+					"172.24.0.1:49260",
+					"172.25.0.1:49260",
+					"172.26.0.1:49260",
+					"172.27.0.1:49260",
+					"172.28.0.1:49260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:14:35.055432543Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6905021408415337,
+				"StableID":   "nJd9joCJvv11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22a6989ab145d63e5dc0190d424872b2e13d69c840276015ada95a260ee3a813",
+				"DiscoKey":   "discokey:3d2b4f0c5ca407ea4226bfcf74e39faaf98d448741f49a4ea4a55c51a6c97e74",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33099",
+					"10.65.0.27:33099",
+					"172.17.0.1:33099",
+					"172.18.0.1:33099",
+					"172.19.0.1:33099",
+					"172.20.0.1:33099",
+					"172.21.0.1:33099",
+					"172.22.0.1:33099",
+					"172.23.0.1:33099",
+					"172.24.0.1:33099",
+					"172.25.0.1:33099",
+					"172.26.0.1:33099",
+					"172.27.0.1:33099",
+					"172.28.0.1:33099"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:14:35.589805582Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1378366829076477,
+				"StableID":   "nnF2hqMGmB11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8c1cae6b2713e6afd28791292ce29afa5e8d37fbbc5fd5b91047d0e74980d2c",
+				"DiscoKey":   "discokey:f8e2a2f49c94748f64d088c0c05530956245a73e92321502c7ef5a8c374bcb3a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51558",
+					"10.65.0.27:51558",
+					"172.17.0.1:51558",
+					"172.18.0.1:51558",
+					"172.19.0.1:51558",
+					"172.20.0.1:51558",
+					"172.21.0.1:51558",
+					"172.22.0.1:51558",
+					"172.23.0.1:51558",
+					"172.24.0.1:51558",
+					"172.25.0.1:51558",
+					"172.26.0.1:51558",
+					"172.27.0.1:51558",
+					"172.28.0.1:51558"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:14:36.123605174Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8096131484985793,
+				"StableID":   "nQ8rRSekD621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5ed161b91ef60de21d1932add68bb1a403c7075494bc635c14ed065846b6023",
+				"DiscoKey":   "discokey:342cf3aa2e3fe8811029ee42ffb6911b44105deb8348846ff4b891d9d2842559",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36582",
+					"10.65.0.27:36582",
+					"172.17.0.1:36582",
+					"172.18.0.1:36582",
+					"172.19.0.1:36582",
+					"172.20.0.1:36582",
+					"172.21.0.1:36582",
+					"172.22.0.1:36582",
+					"172.23.0.1:36582",
+					"172.24.0.1:36582",
+					"172.25.0.1:36582",
+					"172.26.0.1:36582",
+					"172.27.0.1:36582",
+					"172.28.0.1:36582"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:14:36.697309618Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5263862495942249,
+				"StableID":   "nnFwW2k17i11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:759cab22549715a036dc3776fd5599511ec3132e6c4d69858d27095db3d99b17",
+				"DiscoKey":   "discokey:a24b6e3eb1290c84367432907f3c785aacb66b15edc579bd872a8aa4e6550e2b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53998",
+					"10.65.0.27:53998",
+					"172.17.0.1:53998",
+					"172.18.0.1:53998",
+					"172.19.0.1:53998",
+					"172.20.0.1:53998",
+					"172.21.0.1:53998",
+					"172.22.0.1:53998",
+					"172.23.0.1:53998",
+					"172.24.0.1:53998",
+					"172.25.0.1:53998",
+					"172.26.0.1:53998",
+					"172.27.0.1:53998",
+					"172.28.0.1:53998"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:14:37.223103871Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         652158256515153,
+				"StableID":   "nvVCvJ6N6611CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f71f8cedfac1f8c676ad5c576041a4eecf18f24d30471f99ea12cdc3224b208",
+				"DiscoKey":   "discokey:78940d0a8f7aa5a7a819ac538f90c50575351ec5646ea57b96f1a65127ffb662",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59893",
+					"10.65.0.27:59893",
+					"172.17.0.1:59893",
+					"172.18.0.1:59893",
+					"172.19.0.1:59893",
+					"172.20.0.1:59893",
+					"172.21.0.1:59893",
+					"172.22.0.1:59893",
+					"172.23.0.1:59893",
+					"172.24.0.1:59893",
+					"172.25.0.1:59893",
+					"172.26.0.1:59893",
+					"172.27.0.1:59893",
+					"172.28.0.1:59893"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:14:37.736228983Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2630166202798887,
+				"StableID":   "nxf6mM1DYM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b1232181959ec13a3e9624e8ce271ccf28570308e230e27c39182ace737853c",
+				"DiscoKey":   "discokey:ef2ec17c497da07d53c33ec478e9fc67db2d46ab0633a3a8510c322266249408",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:46591",
+					"10.65.0.27:46591",
+					"172.17.0.1:46591",
+					"172.18.0.1:46591",
+					"172.19.0.1:46591",
+					"172.20.0.1:46591",
+					"172.21.0.1:46591",
+					"172.22.0.1:46591",
+					"172.23.0.1:46591",
+					"172.24.0.1:46591",
+					"172.25.0.1:46591",
+					"172.26.0.1:46591",
+					"172.27.0.1:46591",
+					"172.28.0.1:46591"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:14:38.273699887Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7492479871341914,
+				"StableID":   "nZCSSzjMW121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:94197bf76ee983cf5ce7b3e7e45ec911814a04b83ce8e72cc0e9ca36ada86224",
+				"DiscoKey":   "discokey:f581bc05b5d08fb8541feae196c4866e94b3813c08df8d843f2c3dec3e3a0b5e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38464",
+					"10.65.0.27:38464",
+					"172.17.0.1:38464",
+					"172.18.0.1:38464",
+					"172.19.0.1:38464",
+					"172.20.0.1:38464",
+					"172.21.0.1:38464",
+					"172.22.0.1:38464",
+					"172.23.0.1:38464",
+					"172.24.0.1:38464",
+					"172.25.0.1:38464",
+					"172.26.0.1:38464",
+					"172.27.0.1:38464",
+					"172.28.0.1:38464"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:14:38.807670086Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4496192053903417,
+				"StableID":   "nCgPKnLL7c11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8ba3519054665252fe52daf2ca358693b2874665dac7febee26662dc7df2772d",
+				"KeyExpiry":  "2026-11-09T09:14:39Z",
+				"DiscoKey":   "discokey:6333bf224f6f9dcfcd47951e70e92b96218bdbea11fcbef77e28ba214c06303e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54449",
+					"10.65.0.27:54449",
+					"172.17.0.1:54449",
+					"172.18.0.1:54449",
+					"172.19.0.1:54449",
+					"172.20.0.1:54449",
+					"172.21.0.1:54449",
+					"172.22.0.1:54449",
+					"172.23.0.1:54449",
+					"172.24.0.1:54449",
+					"172.25.0.1:54449",
+					"172.26.0.1:54449",
+					"172.27.0.1:54449",
+					"172.28.0.1:54449"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:14:39.365637808Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5894916202258050,
+				"StableID":   "nTysbFTp2o11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b1530603c3fdbe6e274470f89fedb14c05237a75072d94676073d58c5f941a37",
+				"KeyExpiry":  "2026-11-09T09:14:39Z",
+				"DiscoKey":   "discokey:8ff5c8d67ced5c0fa173009f9be01d85d23651b478da2fad407a09382f706e35",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35852",
+					"10.65.0.27:35852",
+					"172.17.0.1:35852",
+					"172.18.0.1:35852",
+					"172.19.0.1:35852",
+					"172.20.0.1:35852",
+					"172.21.0.1:35852",
+					"172.22.0.1:35852",
+					"172.23.0.1:35852",
+					"172.24.0.1:35852",
+					"172.25.0.1:35852",
+					"172.26.0.1:35852",
+					"172.27.0.1:35852",
+					"172.28.0.1:35852"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:14:39.898001202Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2161925042966337,
+				"StableID":   "nAVBt579tH11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1092e1b55eb5c0d2f5610c08013089fab5f95281b4b2e07b644c00693a70ce04",
+				"KeyExpiry":  "2026-11-09T09:14:40Z",
+				"DiscoKey":   "discokey:cb33dfc58e777b4694782a8f94c7b4ae3e9852580af53edbbe02fd45fb6cfe28",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:40634",
+					"10.65.0.27:40634",
+					"172.17.0.1:40634",
+					"172.18.0.1:40634",
+					"172.19.0.1:40634",
+					"172.20.0.1:40634",
+					"172.21.0.1:40634",
+					"172.22.0.1:40634",
+					"172.23.0.1:40634",
+					"172.24.0.1:40634",
+					"172.25.0.1:40634",
+					"172.26.0.1:40634",
+					"172.27.0.1:40634",
+					"172.28.0.1:40634"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:14:40.443043267Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2840293870652164": {
+				"ID":          2840293870652164,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8493166885310382,
+				"StableID":   "nF1wAM6aK921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       8493166885310382,
+				"Key":        "nodekey:b67714dc940f6a6c3f20bc0474c08f0a0d508dbb660b67d4e5382af025a9b264",
+				"DiscoKey":   "discokey:eb7f68d16983c883fefeeee570629d844f6b1821f78a8769b6c8ffa26e64c97f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49260",
+					"10.65.0.27:49260",
+					"172.17.0.1:49260",
+					"172.18.0.1:49260",
+					"172.19.0.1:49260",
+					"172.20.0.1:49260",
+					"172.21.0.1:49260",
+					"172.22.0.1:49260",
+					"172.23.0.1:49260",
+					"172.24.0.1:49260",
+					"172.25.0.1:49260",
+					"172.26.0.1:49260",
+					"172.27.0.1:49260",
+					"172.28.0.1:49260"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:14:35.055432543Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b67714dc940f6a6c3f20bc0474c08f0a0d508dbb660b67d4e5382af025a9b264",
+			"MachineKey": "mkey:d36d39c7a8ff4216cb82ecee4f9a38e66661200dbe598b680ec811c5f928326e",
+			"Peers": [{
+				"ID":         2840293870652164,
+				"StableID":   "nTSmDphNBP11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65bfe3aab37558c3d4257f7c4a3ce5a1fe9c0d545783dffd6fb27ffffa470a2e",
+				"DiscoKey":   "discokey:a4d7e3fb3fc79731a2c6d0f9981b49fd9888a3dccb9ea5ec8f79708e2549d90f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47906",
+					"10.65.0.27:47906",
+					"172.17.0.1:47906",
+					"172.18.0.1:47906",
+					"172.19.0.1:47906",
+					"172.20.0.1:47906",
+					"172.21.0.1:47906",
+					"172.22.0.1:47906",
+					"172.23.0.1:47906",
+					"172.24.0.1:47906",
+					"172.25.0.1:47906",
+					"172.26.0.1:47906",
+					"172.27.0.1:47906",
+					"172.28.0.1:47906"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:14:32.914936157Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3944447720512740,
+				"StableID":   "nBYEwGxSoX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd52f08d01f7e477b25d99a8459790671a4edcf479268db13bcb68972da5ef26",
+				"DiscoKey":   "discokey:29c2f5ece02e2602991a80fcd1e26044ae95e886a22a1c71132f7f3f301de552",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35813",
+					"10.65.0.27:35813",
+					"172.17.0.1:35813",
+					"172.18.0.1:35813",
+					"172.19.0.1:35813",
+					"172.20.0.1:35813",
+					"172.21.0.1:35813",
+					"172.22.0.1:35813",
+					"172.23.0.1:35813",
+					"172.24.0.1:35813",
+					"172.25.0.1:35813",
+					"172.26.0.1:35813",
+					"172.27.0.1:35813",
+					"172.28.0.1:35813"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:14:33.444311138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8196632796973305,
+				"StableID":   "nQteDPeG1721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c08f2124f0292c7e3bc13e2d8d2ad4f092a71686f3b24f88b7bb47201513d54",
+				"DiscoKey":   "discokey:dacc24dde10d1a36e280fcc9402f9b7187f0ea43128cf478d76b73dfc175f602",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39819",
+					"10.65.0.27:39819",
+					"172.17.0.1:39819",
+					"172.18.0.1:39819",
+					"172.19.0.1:39819",
+					"172.20.0.1:39819",
+					"172.21.0.1:39819",
+					"172.22.0.1:39819",
+					"172.23.0.1:39819",
+					"172.24.0.1:39819",
+					"172.25.0.1:39819",
+					"172.26.0.1:39819",
+					"172.27.0.1:39819",
+					"172.28.0.1:39819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:14:33.978522762Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3530720735132739,
+				"StableID":   "n6nkyh35aU11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3fb7232e7768dec4cba16c8e80abc1bd76a65ce5350208774913c4617f346323",
+				"DiscoKey":   "discokey:561530bf3f9f0768e9c504a9c5e5c13b4c7dac43ea67fdced9290132ec9d1509",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35092",
+					"10.65.0.27:35092",
+					"172.17.0.1:35092",
+					"172.18.0.1:35092",
+					"172.19.0.1:35092",
+					"172.20.0.1:35092",
+					"172.21.0.1:35092",
+					"172.22.0.1:35092",
+					"172.23.0.1:35092",
+					"172.24.0.1:35092",
+					"172.25.0.1:35092",
+					"172.26.0.1:35092",
+					"172.27.0.1:35092",
+					"172.28.0.1:35092"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:14:34.519796394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6905021408415337,
+				"StableID":   "nJd9joCJvv11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22a6989ab145d63e5dc0190d424872b2e13d69c840276015ada95a260ee3a813",
+				"DiscoKey":   "discokey:3d2b4f0c5ca407ea4226bfcf74e39faaf98d448741f49a4ea4a55c51a6c97e74",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33099",
+					"10.65.0.27:33099",
+					"172.17.0.1:33099",
+					"172.18.0.1:33099",
+					"172.19.0.1:33099",
+					"172.20.0.1:33099",
+					"172.21.0.1:33099",
+					"172.22.0.1:33099",
+					"172.23.0.1:33099",
+					"172.24.0.1:33099",
+					"172.25.0.1:33099",
+					"172.26.0.1:33099",
+					"172.27.0.1:33099",
+					"172.28.0.1:33099"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:14:35.589805582Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1378366829076477,
+				"StableID":   "nnF2hqMGmB11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8c1cae6b2713e6afd28791292ce29afa5e8d37fbbc5fd5b91047d0e74980d2c",
+				"DiscoKey":   "discokey:f8e2a2f49c94748f64d088c0c05530956245a73e92321502c7ef5a8c374bcb3a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51558",
+					"10.65.0.27:51558",
+					"172.17.0.1:51558",
+					"172.18.0.1:51558",
+					"172.19.0.1:51558",
+					"172.20.0.1:51558",
+					"172.21.0.1:51558",
+					"172.22.0.1:51558",
+					"172.23.0.1:51558",
+					"172.24.0.1:51558",
+					"172.25.0.1:51558",
+					"172.26.0.1:51558",
+					"172.27.0.1:51558",
+					"172.28.0.1:51558"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:14:36.123605174Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8096131484985793,
+				"StableID":   "nQ8rRSekD621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5ed161b91ef60de21d1932add68bb1a403c7075494bc635c14ed065846b6023",
+				"DiscoKey":   "discokey:342cf3aa2e3fe8811029ee42ffb6911b44105deb8348846ff4b891d9d2842559",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36582",
+					"10.65.0.27:36582",
+					"172.17.0.1:36582",
+					"172.18.0.1:36582",
+					"172.19.0.1:36582",
+					"172.20.0.1:36582",
+					"172.21.0.1:36582",
+					"172.22.0.1:36582",
+					"172.23.0.1:36582",
+					"172.24.0.1:36582",
+					"172.25.0.1:36582",
+					"172.26.0.1:36582",
+					"172.27.0.1:36582",
+					"172.28.0.1:36582"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:14:36.697309618Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5263862495942249,
+				"StableID":   "nnFwW2k17i11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:759cab22549715a036dc3776fd5599511ec3132e6c4d69858d27095db3d99b17",
+				"DiscoKey":   "discokey:a24b6e3eb1290c84367432907f3c785aacb66b15edc579bd872a8aa4e6550e2b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53998",
+					"10.65.0.27:53998",
+					"172.17.0.1:53998",
+					"172.18.0.1:53998",
+					"172.19.0.1:53998",
+					"172.20.0.1:53998",
+					"172.21.0.1:53998",
+					"172.22.0.1:53998",
+					"172.23.0.1:53998",
+					"172.24.0.1:53998",
+					"172.25.0.1:53998",
+					"172.26.0.1:53998",
+					"172.27.0.1:53998",
+					"172.28.0.1:53998"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:14:37.223103871Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         652158256515153,
+				"StableID":   "nvVCvJ6N6611CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f71f8cedfac1f8c676ad5c576041a4eecf18f24d30471f99ea12cdc3224b208",
+				"DiscoKey":   "discokey:78940d0a8f7aa5a7a819ac538f90c50575351ec5646ea57b96f1a65127ffb662",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59893",
+					"10.65.0.27:59893",
+					"172.17.0.1:59893",
+					"172.18.0.1:59893",
+					"172.19.0.1:59893",
+					"172.20.0.1:59893",
+					"172.21.0.1:59893",
+					"172.22.0.1:59893",
+					"172.23.0.1:59893",
+					"172.24.0.1:59893",
+					"172.25.0.1:59893",
+					"172.26.0.1:59893",
+					"172.27.0.1:59893",
+					"172.28.0.1:59893"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:14:37.736228983Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2630166202798887,
+				"StableID":   "nxf6mM1DYM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b1232181959ec13a3e9624e8ce271ccf28570308e230e27c39182ace737853c",
+				"DiscoKey":   "discokey:ef2ec17c497da07d53c33ec478e9fc67db2d46ab0633a3a8510c322266249408",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:46591",
+					"10.65.0.27:46591",
+					"172.17.0.1:46591",
+					"172.18.0.1:46591",
+					"172.19.0.1:46591",
+					"172.20.0.1:46591",
+					"172.21.0.1:46591",
+					"172.22.0.1:46591",
+					"172.23.0.1:46591",
+					"172.24.0.1:46591",
+					"172.25.0.1:46591",
+					"172.26.0.1:46591",
+					"172.27.0.1:46591",
+					"172.28.0.1:46591"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:14:38.273699887Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7492479871341914,
+				"StableID":   "nZCSSzjMW121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:94197bf76ee983cf5ce7b3e7e45ec911814a04b83ce8e72cc0e9ca36ada86224",
+				"DiscoKey":   "discokey:f581bc05b5d08fb8541feae196c4866e94b3813c08df8d843f2c3dec3e3a0b5e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38464",
+					"10.65.0.27:38464",
+					"172.17.0.1:38464",
+					"172.18.0.1:38464",
+					"172.19.0.1:38464",
+					"172.20.0.1:38464",
+					"172.21.0.1:38464",
+					"172.22.0.1:38464",
+					"172.23.0.1:38464",
+					"172.24.0.1:38464",
+					"172.25.0.1:38464",
+					"172.26.0.1:38464",
+					"172.27.0.1:38464",
+					"172.28.0.1:38464"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:14:38.807670086Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4496192053903417,
+				"StableID":   "nCgPKnLL7c11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8ba3519054665252fe52daf2ca358693b2874665dac7febee26662dc7df2772d",
+				"KeyExpiry":  "2026-11-09T09:14:39Z",
+				"DiscoKey":   "discokey:6333bf224f6f9dcfcd47951e70e92b96218bdbea11fcbef77e28ba214c06303e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54449",
+					"10.65.0.27:54449",
+					"172.17.0.1:54449",
+					"172.18.0.1:54449",
+					"172.19.0.1:54449",
+					"172.20.0.1:54449",
+					"172.21.0.1:54449",
+					"172.22.0.1:54449",
+					"172.23.0.1:54449",
+					"172.24.0.1:54449",
+					"172.25.0.1:54449",
+					"172.26.0.1:54449",
+					"172.27.0.1:54449",
+					"172.28.0.1:54449"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:14:39.365637808Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5894916202258050,
+				"StableID":   "nTysbFTp2o11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b1530603c3fdbe6e274470f89fedb14c05237a75072d94676073d58c5f941a37",
+				"KeyExpiry":  "2026-11-09T09:14:39Z",
+				"DiscoKey":   "discokey:8ff5c8d67ced5c0fa173009f9be01d85d23651b478da2fad407a09382f706e35",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35852",
+					"10.65.0.27:35852",
+					"172.17.0.1:35852",
+					"172.18.0.1:35852",
+					"172.19.0.1:35852",
+					"172.20.0.1:35852",
+					"172.21.0.1:35852",
+					"172.22.0.1:35852",
+					"172.23.0.1:35852",
+					"172.24.0.1:35852",
+					"172.25.0.1:35852",
+					"172.26.0.1:35852",
+					"172.27.0.1:35852",
+					"172.28.0.1:35852"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:14:39.898001202Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2161925042966337,
+				"StableID":   "nAVBt579tH11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1092e1b55eb5c0d2f5610c08013089fab5f95281b4b2e07b644c00693a70ce04",
+				"KeyExpiry":  "2026-11-09T09:14:40Z",
+				"DiscoKey":   "discokey:cb33dfc58e777b4694782a8f94c7b4ae3e9852580af53edbbe02fd45fb6cfe28",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:40634",
+					"10.65.0.27:40634",
+					"172.17.0.1:40634",
+					"172.18.0.1:40634",
+					"172.19.0.1:40634",
+					"172.20.0.1:40634",
+					"172.21.0.1:40634",
+					"172.22.0.1:40634",
+					"172.23.0.1:40634",
+					"172.24.0.1:40634",
+					"172.25.0.1:40634",
+					"172.26.0.1:40634",
+					"172.27.0.1:40634",
+					"172.28.0.1:40634"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:14:40.443043267Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8493166885310382": {
+				"ID":          8493166885310382,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3530720735132739,
+				"StableID":   "n6nkyh35aU11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       3530720735132739,
+				"Key":        "nodekey:3fb7232e7768dec4cba16c8e80abc1bd76a65ce5350208774913c4617f346323",
+				"DiscoKey":   "discokey:561530bf3f9f0768e9c504a9c5e5c13b4c7dac43ea67fdced9290132ec9d1509",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35092",
+					"10.65.0.27:35092",
+					"172.17.0.1:35092",
+					"172.18.0.1:35092",
+					"172.19.0.1:35092",
+					"172.20.0.1:35092",
+					"172.21.0.1:35092",
+					"172.22.0.1:35092",
+					"172.23.0.1:35092",
+					"172.24.0.1:35092",
+					"172.25.0.1:35092",
+					"172.26.0.1:35092",
+					"172.27.0.1:35092",
+					"172.28.0.1:35092"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:14:34.519796394Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3fb7232e7768dec4cba16c8e80abc1bd76a65ce5350208774913c4617f346323",
+			"MachineKey": "mkey:559a447649e69db28de16fc89c3102c05e4849bcb17e683558226151c7c5e309",
+			"Peers": [{
+				"ID":         2840293870652164,
+				"StableID":   "nTSmDphNBP11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65bfe3aab37558c3d4257f7c4a3ce5a1fe9c0d545783dffd6fb27ffffa470a2e",
+				"DiscoKey":   "discokey:a4d7e3fb3fc79731a2c6d0f9981b49fd9888a3dccb9ea5ec8f79708e2549d90f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47906",
+					"10.65.0.27:47906",
+					"172.17.0.1:47906",
+					"172.18.0.1:47906",
+					"172.19.0.1:47906",
+					"172.20.0.1:47906",
+					"172.21.0.1:47906",
+					"172.22.0.1:47906",
+					"172.23.0.1:47906",
+					"172.24.0.1:47906",
+					"172.25.0.1:47906",
+					"172.26.0.1:47906",
+					"172.27.0.1:47906",
+					"172.28.0.1:47906"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:14:32.914936157Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3944447720512740,
+				"StableID":   "nBYEwGxSoX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd52f08d01f7e477b25d99a8459790671a4edcf479268db13bcb68972da5ef26",
+				"DiscoKey":   "discokey:29c2f5ece02e2602991a80fcd1e26044ae95e886a22a1c71132f7f3f301de552",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35813",
+					"10.65.0.27:35813",
+					"172.17.0.1:35813",
+					"172.18.0.1:35813",
+					"172.19.0.1:35813",
+					"172.20.0.1:35813",
+					"172.21.0.1:35813",
+					"172.22.0.1:35813",
+					"172.23.0.1:35813",
+					"172.24.0.1:35813",
+					"172.25.0.1:35813",
+					"172.26.0.1:35813",
+					"172.27.0.1:35813",
+					"172.28.0.1:35813"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:14:33.444311138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8196632796973305,
+				"StableID":   "nQteDPeG1721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c08f2124f0292c7e3bc13e2d8d2ad4f092a71686f3b24f88b7bb47201513d54",
+				"DiscoKey":   "discokey:dacc24dde10d1a36e280fcc9402f9b7187f0ea43128cf478d76b73dfc175f602",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39819",
+					"10.65.0.27:39819",
+					"172.17.0.1:39819",
+					"172.18.0.1:39819",
+					"172.19.0.1:39819",
+					"172.20.0.1:39819",
+					"172.21.0.1:39819",
+					"172.22.0.1:39819",
+					"172.23.0.1:39819",
+					"172.24.0.1:39819",
+					"172.25.0.1:39819",
+					"172.26.0.1:39819",
+					"172.27.0.1:39819",
+					"172.28.0.1:39819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:14:33.978522762Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8493166885310382,
+				"StableID":   "nF1wAM6aK921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b67714dc940f6a6c3f20bc0474c08f0a0d508dbb660b67d4e5382af025a9b264",
+				"DiscoKey":   "discokey:eb7f68d16983c883fefeeee570629d844f6b1821f78a8769b6c8ffa26e64c97f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49260",
+					"10.65.0.27:49260",
+					"172.17.0.1:49260",
+					"172.18.0.1:49260",
+					"172.19.0.1:49260",
+					"172.20.0.1:49260",
+					"172.21.0.1:49260",
+					"172.22.0.1:49260",
+					"172.23.0.1:49260",
+					"172.24.0.1:49260",
+					"172.25.0.1:49260",
+					"172.26.0.1:49260",
+					"172.27.0.1:49260",
+					"172.28.0.1:49260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:14:35.055432543Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6905021408415337,
+				"StableID":   "nJd9joCJvv11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22a6989ab145d63e5dc0190d424872b2e13d69c840276015ada95a260ee3a813",
+				"DiscoKey":   "discokey:3d2b4f0c5ca407ea4226bfcf74e39faaf98d448741f49a4ea4a55c51a6c97e74",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33099",
+					"10.65.0.27:33099",
+					"172.17.0.1:33099",
+					"172.18.0.1:33099",
+					"172.19.0.1:33099",
+					"172.20.0.1:33099",
+					"172.21.0.1:33099",
+					"172.22.0.1:33099",
+					"172.23.0.1:33099",
+					"172.24.0.1:33099",
+					"172.25.0.1:33099",
+					"172.26.0.1:33099",
+					"172.27.0.1:33099",
+					"172.28.0.1:33099"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:14:35.589805582Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1378366829076477,
+				"StableID":   "nnF2hqMGmB11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8c1cae6b2713e6afd28791292ce29afa5e8d37fbbc5fd5b91047d0e74980d2c",
+				"DiscoKey":   "discokey:f8e2a2f49c94748f64d088c0c05530956245a73e92321502c7ef5a8c374bcb3a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51558",
+					"10.65.0.27:51558",
+					"172.17.0.1:51558",
+					"172.18.0.1:51558",
+					"172.19.0.1:51558",
+					"172.20.0.1:51558",
+					"172.21.0.1:51558",
+					"172.22.0.1:51558",
+					"172.23.0.1:51558",
+					"172.24.0.1:51558",
+					"172.25.0.1:51558",
+					"172.26.0.1:51558",
+					"172.27.0.1:51558",
+					"172.28.0.1:51558"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:14:36.123605174Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8096131484985793,
+				"StableID":   "nQ8rRSekD621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5ed161b91ef60de21d1932add68bb1a403c7075494bc635c14ed065846b6023",
+				"DiscoKey":   "discokey:342cf3aa2e3fe8811029ee42ffb6911b44105deb8348846ff4b891d9d2842559",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36582",
+					"10.65.0.27:36582",
+					"172.17.0.1:36582",
+					"172.18.0.1:36582",
+					"172.19.0.1:36582",
+					"172.20.0.1:36582",
+					"172.21.0.1:36582",
+					"172.22.0.1:36582",
+					"172.23.0.1:36582",
+					"172.24.0.1:36582",
+					"172.25.0.1:36582",
+					"172.26.0.1:36582",
+					"172.27.0.1:36582",
+					"172.28.0.1:36582"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:14:36.697309618Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5263862495942249,
+				"StableID":   "nnFwW2k17i11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:759cab22549715a036dc3776fd5599511ec3132e6c4d69858d27095db3d99b17",
+				"DiscoKey":   "discokey:a24b6e3eb1290c84367432907f3c785aacb66b15edc579bd872a8aa4e6550e2b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53998",
+					"10.65.0.27:53998",
+					"172.17.0.1:53998",
+					"172.18.0.1:53998",
+					"172.19.0.1:53998",
+					"172.20.0.1:53998",
+					"172.21.0.1:53998",
+					"172.22.0.1:53998",
+					"172.23.0.1:53998",
+					"172.24.0.1:53998",
+					"172.25.0.1:53998",
+					"172.26.0.1:53998",
+					"172.27.0.1:53998",
+					"172.28.0.1:53998"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:14:37.223103871Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         652158256515153,
+				"StableID":   "nvVCvJ6N6611CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f71f8cedfac1f8c676ad5c576041a4eecf18f24d30471f99ea12cdc3224b208",
+				"DiscoKey":   "discokey:78940d0a8f7aa5a7a819ac538f90c50575351ec5646ea57b96f1a65127ffb662",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59893",
+					"10.65.0.27:59893",
+					"172.17.0.1:59893",
+					"172.18.0.1:59893",
+					"172.19.0.1:59893",
+					"172.20.0.1:59893",
+					"172.21.0.1:59893",
+					"172.22.0.1:59893",
+					"172.23.0.1:59893",
+					"172.24.0.1:59893",
+					"172.25.0.1:59893",
+					"172.26.0.1:59893",
+					"172.27.0.1:59893",
+					"172.28.0.1:59893"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:14:37.736228983Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2630166202798887,
+				"StableID":   "nxf6mM1DYM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b1232181959ec13a3e9624e8ce271ccf28570308e230e27c39182ace737853c",
+				"DiscoKey":   "discokey:ef2ec17c497da07d53c33ec478e9fc67db2d46ab0633a3a8510c322266249408",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:46591",
+					"10.65.0.27:46591",
+					"172.17.0.1:46591",
+					"172.18.0.1:46591",
+					"172.19.0.1:46591",
+					"172.20.0.1:46591",
+					"172.21.0.1:46591",
+					"172.22.0.1:46591",
+					"172.23.0.1:46591",
+					"172.24.0.1:46591",
+					"172.25.0.1:46591",
+					"172.26.0.1:46591",
+					"172.27.0.1:46591",
+					"172.28.0.1:46591"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:14:38.273699887Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7492479871341914,
+				"StableID":   "nZCSSzjMW121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:94197bf76ee983cf5ce7b3e7e45ec911814a04b83ce8e72cc0e9ca36ada86224",
+				"DiscoKey":   "discokey:f581bc05b5d08fb8541feae196c4866e94b3813c08df8d843f2c3dec3e3a0b5e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38464",
+					"10.65.0.27:38464",
+					"172.17.0.1:38464",
+					"172.18.0.1:38464",
+					"172.19.0.1:38464",
+					"172.20.0.1:38464",
+					"172.21.0.1:38464",
+					"172.22.0.1:38464",
+					"172.23.0.1:38464",
+					"172.24.0.1:38464",
+					"172.25.0.1:38464",
+					"172.26.0.1:38464",
+					"172.27.0.1:38464",
+					"172.28.0.1:38464"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:14:38.807670086Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4496192053903417,
+				"StableID":   "nCgPKnLL7c11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8ba3519054665252fe52daf2ca358693b2874665dac7febee26662dc7df2772d",
+				"KeyExpiry":  "2026-11-09T09:14:39Z",
+				"DiscoKey":   "discokey:6333bf224f6f9dcfcd47951e70e92b96218bdbea11fcbef77e28ba214c06303e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54449",
+					"10.65.0.27:54449",
+					"172.17.0.1:54449",
+					"172.18.0.1:54449",
+					"172.19.0.1:54449",
+					"172.20.0.1:54449",
+					"172.21.0.1:54449",
+					"172.22.0.1:54449",
+					"172.23.0.1:54449",
+					"172.24.0.1:54449",
+					"172.25.0.1:54449",
+					"172.26.0.1:54449",
+					"172.27.0.1:54449",
+					"172.28.0.1:54449"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:14:39.365637808Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5894916202258050,
+				"StableID":   "nTysbFTp2o11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b1530603c3fdbe6e274470f89fedb14c05237a75072d94676073d58c5f941a37",
+				"KeyExpiry":  "2026-11-09T09:14:39Z",
+				"DiscoKey":   "discokey:8ff5c8d67ced5c0fa173009f9be01d85d23651b478da2fad407a09382f706e35",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35852",
+					"10.65.0.27:35852",
+					"172.17.0.1:35852",
+					"172.18.0.1:35852",
+					"172.19.0.1:35852",
+					"172.20.0.1:35852",
+					"172.21.0.1:35852",
+					"172.22.0.1:35852",
+					"172.23.0.1:35852",
+					"172.24.0.1:35852",
+					"172.25.0.1:35852",
+					"172.26.0.1:35852",
+					"172.27.0.1:35852",
+					"172.28.0.1:35852"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:14:39.898001202Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2161925042966337,
+				"StableID":   "nAVBt579tH11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1092e1b55eb5c0d2f5610c08013089fab5f95281b4b2e07b644c00693a70ce04",
+				"KeyExpiry":  "2026-11-09T09:14:40Z",
+				"DiscoKey":   "discokey:cb33dfc58e777b4694782a8f94c7b4ae3e9852580af53edbbe02fd45fb6cfe28",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:40634",
+					"10.65.0.27:40634",
+					"172.17.0.1:40634",
+					"172.18.0.1:40634",
+					"172.19.0.1:40634",
+					"172.20.0.1:40634",
+					"172.21.0.1:40634",
+					"172.22.0.1:40634",
+					"172.23.0.1:40634",
+					"172.24.0.1:40634",
+					"172.25.0.1:40634",
+					"172.26.0.1:40634",
+					"172.27.0.1:40634",
+					"172.28.0.1:40634"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:14:40.443043267Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3530720735132739": {
+				"ID":          3530720735132739,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1378366829076477,
+				"StableID":   "nnF2hqMGmB11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1378366829076477,
+				"Key":        "nodekey:a8c1cae6b2713e6afd28791292ce29afa5e8d37fbbc5fd5b91047d0e74980d2c",
+				"DiscoKey":   "discokey:f8e2a2f49c94748f64d088c0c05530956245a73e92321502c7ef5a8c374bcb3a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51558",
+					"10.65.0.27:51558",
+					"172.17.0.1:51558",
+					"172.18.0.1:51558",
+					"172.19.0.1:51558",
+					"172.20.0.1:51558",
+					"172.21.0.1:51558",
+					"172.22.0.1:51558",
+					"172.23.0.1:51558",
+					"172.24.0.1:51558",
+					"172.25.0.1:51558",
+					"172.26.0.1:51558",
+					"172.27.0.1:51558",
+					"172.28.0.1:51558"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:14:36.123605174Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a8c1cae6b2713e6afd28791292ce29afa5e8d37fbbc5fd5b91047d0e74980d2c",
+			"MachineKey": "mkey:7749a3460a079bd3064fbcd095766f1d16f0fb5cf421b99e54760339fc6a1e1a",
+			"Peers": [{
+				"ID":         2840293870652164,
+				"StableID":   "nTSmDphNBP11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65bfe3aab37558c3d4257f7c4a3ce5a1fe9c0d545783dffd6fb27ffffa470a2e",
+				"DiscoKey":   "discokey:a4d7e3fb3fc79731a2c6d0f9981b49fd9888a3dccb9ea5ec8f79708e2549d90f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47906",
+					"10.65.0.27:47906",
+					"172.17.0.1:47906",
+					"172.18.0.1:47906",
+					"172.19.0.1:47906",
+					"172.20.0.1:47906",
+					"172.21.0.1:47906",
+					"172.22.0.1:47906",
+					"172.23.0.1:47906",
+					"172.24.0.1:47906",
+					"172.25.0.1:47906",
+					"172.26.0.1:47906",
+					"172.27.0.1:47906",
+					"172.28.0.1:47906"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:14:32.914936157Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3944447720512740,
+				"StableID":   "nBYEwGxSoX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd52f08d01f7e477b25d99a8459790671a4edcf479268db13bcb68972da5ef26",
+				"DiscoKey":   "discokey:29c2f5ece02e2602991a80fcd1e26044ae95e886a22a1c71132f7f3f301de552",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35813",
+					"10.65.0.27:35813",
+					"172.17.0.1:35813",
+					"172.18.0.1:35813",
+					"172.19.0.1:35813",
+					"172.20.0.1:35813",
+					"172.21.0.1:35813",
+					"172.22.0.1:35813",
+					"172.23.0.1:35813",
+					"172.24.0.1:35813",
+					"172.25.0.1:35813",
+					"172.26.0.1:35813",
+					"172.27.0.1:35813",
+					"172.28.0.1:35813"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:14:33.444311138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8196632796973305,
+				"StableID":   "nQteDPeG1721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c08f2124f0292c7e3bc13e2d8d2ad4f092a71686f3b24f88b7bb47201513d54",
+				"DiscoKey":   "discokey:dacc24dde10d1a36e280fcc9402f9b7187f0ea43128cf478d76b73dfc175f602",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39819",
+					"10.65.0.27:39819",
+					"172.17.0.1:39819",
+					"172.18.0.1:39819",
+					"172.19.0.1:39819",
+					"172.20.0.1:39819",
+					"172.21.0.1:39819",
+					"172.22.0.1:39819",
+					"172.23.0.1:39819",
+					"172.24.0.1:39819",
+					"172.25.0.1:39819",
+					"172.26.0.1:39819",
+					"172.27.0.1:39819",
+					"172.28.0.1:39819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:14:33.978522762Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3530720735132739,
+				"StableID":   "n6nkyh35aU11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3fb7232e7768dec4cba16c8e80abc1bd76a65ce5350208774913c4617f346323",
+				"DiscoKey":   "discokey:561530bf3f9f0768e9c504a9c5e5c13b4c7dac43ea67fdced9290132ec9d1509",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35092",
+					"10.65.0.27:35092",
+					"172.17.0.1:35092",
+					"172.18.0.1:35092",
+					"172.19.0.1:35092",
+					"172.20.0.1:35092",
+					"172.21.0.1:35092",
+					"172.22.0.1:35092",
+					"172.23.0.1:35092",
+					"172.24.0.1:35092",
+					"172.25.0.1:35092",
+					"172.26.0.1:35092",
+					"172.27.0.1:35092",
+					"172.28.0.1:35092"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:14:34.519796394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8493166885310382,
+				"StableID":   "nF1wAM6aK921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b67714dc940f6a6c3f20bc0474c08f0a0d508dbb660b67d4e5382af025a9b264",
+				"DiscoKey":   "discokey:eb7f68d16983c883fefeeee570629d844f6b1821f78a8769b6c8ffa26e64c97f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49260",
+					"10.65.0.27:49260",
+					"172.17.0.1:49260",
+					"172.18.0.1:49260",
+					"172.19.0.1:49260",
+					"172.20.0.1:49260",
+					"172.21.0.1:49260",
+					"172.22.0.1:49260",
+					"172.23.0.1:49260",
+					"172.24.0.1:49260",
+					"172.25.0.1:49260",
+					"172.26.0.1:49260",
+					"172.27.0.1:49260",
+					"172.28.0.1:49260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:14:35.055432543Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6905021408415337,
+				"StableID":   "nJd9joCJvv11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22a6989ab145d63e5dc0190d424872b2e13d69c840276015ada95a260ee3a813",
+				"DiscoKey":   "discokey:3d2b4f0c5ca407ea4226bfcf74e39faaf98d448741f49a4ea4a55c51a6c97e74",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33099",
+					"10.65.0.27:33099",
+					"172.17.0.1:33099",
+					"172.18.0.1:33099",
+					"172.19.0.1:33099",
+					"172.20.0.1:33099",
+					"172.21.0.1:33099",
+					"172.22.0.1:33099",
+					"172.23.0.1:33099",
+					"172.24.0.1:33099",
+					"172.25.0.1:33099",
+					"172.26.0.1:33099",
+					"172.27.0.1:33099",
+					"172.28.0.1:33099"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:14:35.589805582Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8096131484985793,
+				"StableID":   "nQ8rRSekD621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5ed161b91ef60de21d1932add68bb1a403c7075494bc635c14ed065846b6023",
+				"DiscoKey":   "discokey:342cf3aa2e3fe8811029ee42ffb6911b44105deb8348846ff4b891d9d2842559",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36582",
+					"10.65.0.27:36582",
+					"172.17.0.1:36582",
+					"172.18.0.1:36582",
+					"172.19.0.1:36582",
+					"172.20.0.1:36582",
+					"172.21.0.1:36582",
+					"172.22.0.1:36582",
+					"172.23.0.1:36582",
+					"172.24.0.1:36582",
+					"172.25.0.1:36582",
+					"172.26.0.1:36582",
+					"172.27.0.1:36582",
+					"172.28.0.1:36582"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:14:36.697309618Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5263862495942249,
+				"StableID":   "nnFwW2k17i11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:759cab22549715a036dc3776fd5599511ec3132e6c4d69858d27095db3d99b17",
+				"DiscoKey":   "discokey:a24b6e3eb1290c84367432907f3c785aacb66b15edc579bd872a8aa4e6550e2b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53998",
+					"10.65.0.27:53998",
+					"172.17.0.1:53998",
+					"172.18.0.1:53998",
+					"172.19.0.1:53998",
+					"172.20.0.1:53998",
+					"172.21.0.1:53998",
+					"172.22.0.1:53998",
+					"172.23.0.1:53998",
+					"172.24.0.1:53998",
+					"172.25.0.1:53998",
+					"172.26.0.1:53998",
+					"172.27.0.1:53998",
+					"172.28.0.1:53998"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:14:37.223103871Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         652158256515153,
+				"StableID":   "nvVCvJ6N6611CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f71f8cedfac1f8c676ad5c576041a4eecf18f24d30471f99ea12cdc3224b208",
+				"DiscoKey":   "discokey:78940d0a8f7aa5a7a819ac538f90c50575351ec5646ea57b96f1a65127ffb662",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59893",
+					"10.65.0.27:59893",
+					"172.17.0.1:59893",
+					"172.18.0.1:59893",
+					"172.19.0.1:59893",
+					"172.20.0.1:59893",
+					"172.21.0.1:59893",
+					"172.22.0.1:59893",
+					"172.23.0.1:59893",
+					"172.24.0.1:59893",
+					"172.25.0.1:59893",
+					"172.26.0.1:59893",
+					"172.27.0.1:59893",
+					"172.28.0.1:59893"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:14:37.736228983Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2630166202798887,
+				"StableID":   "nxf6mM1DYM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b1232181959ec13a3e9624e8ce271ccf28570308e230e27c39182ace737853c",
+				"DiscoKey":   "discokey:ef2ec17c497da07d53c33ec478e9fc67db2d46ab0633a3a8510c322266249408",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:46591",
+					"10.65.0.27:46591",
+					"172.17.0.1:46591",
+					"172.18.0.1:46591",
+					"172.19.0.1:46591",
+					"172.20.0.1:46591",
+					"172.21.0.1:46591",
+					"172.22.0.1:46591",
+					"172.23.0.1:46591",
+					"172.24.0.1:46591",
+					"172.25.0.1:46591",
+					"172.26.0.1:46591",
+					"172.27.0.1:46591",
+					"172.28.0.1:46591"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:14:38.273699887Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7492479871341914,
+				"StableID":   "nZCSSzjMW121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:94197bf76ee983cf5ce7b3e7e45ec911814a04b83ce8e72cc0e9ca36ada86224",
+				"DiscoKey":   "discokey:f581bc05b5d08fb8541feae196c4866e94b3813c08df8d843f2c3dec3e3a0b5e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38464",
+					"10.65.0.27:38464",
+					"172.17.0.1:38464",
+					"172.18.0.1:38464",
+					"172.19.0.1:38464",
+					"172.20.0.1:38464",
+					"172.21.0.1:38464",
+					"172.22.0.1:38464",
+					"172.23.0.1:38464",
+					"172.24.0.1:38464",
+					"172.25.0.1:38464",
+					"172.26.0.1:38464",
+					"172.27.0.1:38464",
+					"172.28.0.1:38464"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:14:38.807670086Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4496192053903417,
+				"StableID":   "nCgPKnLL7c11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8ba3519054665252fe52daf2ca358693b2874665dac7febee26662dc7df2772d",
+				"KeyExpiry":  "2026-11-09T09:14:39Z",
+				"DiscoKey":   "discokey:6333bf224f6f9dcfcd47951e70e92b96218bdbea11fcbef77e28ba214c06303e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54449",
+					"10.65.0.27:54449",
+					"172.17.0.1:54449",
+					"172.18.0.1:54449",
+					"172.19.0.1:54449",
+					"172.20.0.1:54449",
+					"172.21.0.1:54449",
+					"172.22.0.1:54449",
+					"172.23.0.1:54449",
+					"172.24.0.1:54449",
+					"172.25.0.1:54449",
+					"172.26.0.1:54449",
+					"172.27.0.1:54449",
+					"172.28.0.1:54449"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:14:39.365637808Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5894916202258050,
+				"StableID":   "nTysbFTp2o11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b1530603c3fdbe6e274470f89fedb14c05237a75072d94676073d58c5f941a37",
+				"KeyExpiry":  "2026-11-09T09:14:39Z",
+				"DiscoKey":   "discokey:8ff5c8d67ced5c0fa173009f9be01d85d23651b478da2fad407a09382f706e35",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35852",
+					"10.65.0.27:35852",
+					"172.17.0.1:35852",
+					"172.18.0.1:35852",
+					"172.19.0.1:35852",
+					"172.20.0.1:35852",
+					"172.21.0.1:35852",
+					"172.22.0.1:35852",
+					"172.23.0.1:35852",
+					"172.24.0.1:35852",
+					"172.25.0.1:35852",
+					"172.26.0.1:35852",
+					"172.27.0.1:35852",
+					"172.28.0.1:35852"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:14:39.898001202Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2161925042966337,
+				"StableID":   "nAVBt579tH11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1092e1b55eb5c0d2f5610c08013089fab5f95281b4b2e07b644c00693a70ce04",
+				"KeyExpiry":  "2026-11-09T09:14:40Z",
+				"DiscoKey":   "discokey:cb33dfc58e777b4694782a8f94c7b4ae3e9852580af53edbbe02fd45fb6cfe28",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:40634",
+					"10.65.0.27:40634",
+					"172.17.0.1:40634",
+					"172.18.0.1:40634",
+					"172.19.0.1:40634",
+					"172.20.0.1:40634",
+					"172.21.0.1:40634",
+					"172.22.0.1:40634",
+					"172.23.0.1:40634",
+					"172.24.0.1:40634",
+					"172.25.0.1:40634",
+					"172.26.0.1:40634",
+					"172.27.0.1:40634",
+					"172.28.0.1:40634"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:14:40.443043267Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1378366829076477": {
+				"ID":          1378366829076477,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5263862495942249,
+				"StableID":   "nnFwW2k17i11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       5263862495942249,
+				"Key":        "nodekey:759cab22549715a036dc3776fd5599511ec3132e6c4d69858d27095db3d99b17",
+				"DiscoKey":   "discokey:a24b6e3eb1290c84367432907f3c785aacb66b15edc579bd872a8aa4e6550e2b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53998",
+					"10.65.0.27:53998",
+					"172.17.0.1:53998",
+					"172.18.0.1:53998",
+					"172.19.0.1:53998",
+					"172.20.0.1:53998",
+					"172.21.0.1:53998",
+					"172.22.0.1:53998",
+					"172.23.0.1:53998",
+					"172.24.0.1:53998",
+					"172.25.0.1:53998",
+					"172.26.0.1:53998",
+					"172.27.0.1:53998",
+					"172.28.0.1:53998"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:14:37.223103871Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:759cab22549715a036dc3776fd5599511ec3132e6c4d69858d27095db3d99b17",
+			"MachineKey": "mkey:ae53bf6939367a17cc4f014fa59c5bebcd0c5417aa633c9a90b8f4374ea74b63",
+			"Peers": [{
+				"ID":         2840293870652164,
+				"StableID":   "nTSmDphNBP11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65bfe3aab37558c3d4257f7c4a3ce5a1fe9c0d545783dffd6fb27ffffa470a2e",
+				"DiscoKey":   "discokey:a4d7e3fb3fc79731a2c6d0f9981b49fd9888a3dccb9ea5ec8f79708e2549d90f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47906",
+					"10.65.0.27:47906",
+					"172.17.0.1:47906",
+					"172.18.0.1:47906",
+					"172.19.0.1:47906",
+					"172.20.0.1:47906",
+					"172.21.0.1:47906",
+					"172.22.0.1:47906",
+					"172.23.0.1:47906",
+					"172.24.0.1:47906",
+					"172.25.0.1:47906",
+					"172.26.0.1:47906",
+					"172.27.0.1:47906",
+					"172.28.0.1:47906"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:14:32.914936157Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3944447720512740,
+				"StableID":   "nBYEwGxSoX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd52f08d01f7e477b25d99a8459790671a4edcf479268db13bcb68972da5ef26",
+				"DiscoKey":   "discokey:29c2f5ece02e2602991a80fcd1e26044ae95e886a22a1c71132f7f3f301de552",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35813",
+					"10.65.0.27:35813",
+					"172.17.0.1:35813",
+					"172.18.0.1:35813",
+					"172.19.0.1:35813",
+					"172.20.0.1:35813",
+					"172.21.0.1:35813",
+					"172.22.0.1:35813",
+					"172.23.0.1:35813",
+					"172.24.0.1:35813",
+					"172.25.0.1:35813",
+					"172.26.0.1:35813",
+					"172.27.0.1:35813",
+					"172.28.0.1:35813"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:14:33.444311138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8196632796973305,
+				"StableID":   "nQteDPeG1721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c08f2124f0292c7e3bc13e2d8d2ad4f092a71686f3b24f88b7bb47201513d54",
+				"DiscoKey":   "discokey:dacc24dde10d1a36e280fcc9402f9b7187f0ea43128cf478d76b73dfc175f602",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39819",
+					"10.65.0.27:39819",
+					"172.17.0.1:39819",
+					"172.18.0.1:39819",
+					"172.19.0.1:39819",
+					"172.20.0.1:39819",
+					"172.21.0.1:39819",
+					"172.22.0.1:39819",
+					"172.23.0.1:39819",
+					"172.24.0.1:39819",
+					"172.25.0.1:39819",
+					"172.26.0.1:39819",
+					"172.27.0.1:39819",
+					"172.28.0.1:39819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:14:33.978522762Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3530720735132739,
+				"StableID":   "n6nkyh35aU11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3fb7232e7768dec4cba16c8e80abc1bd76a65ce5350208774913c4617f346323",
+				"DiscoKey":   "discokey:561530bf3f9f0768e9c504a9c5e5c13b4c7dac43ea67fdced9290132ec9d1509",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35092",
+					"10.65.0.27:35092",
+					"172.17.0.1:35092",
+					"172.18.0.1:35092",
+					"172.19.0.1:35092",
+					"172.20.0.1:35092",
+					"172.21.0.1:35092",
+					"172.22.0.1:35092",
+					"172.23.0.1:35092",
+					"172.24.0.1:35092",
+					"172.25.0.1:35092",
+					"172.26.0.1:35092",
+					"172.27.0.1:35092",
+					"172.28.0.1:35092"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:14:34.519796394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8493166885310382,
+				"StableID":   "nF1wAM6aK921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b67714dc940f6a6c3f20bc0474c08f0a0d508dbb660b67d4e5382af025a9b264",
+				"DiscoKey":   "discokey:eb7f68d16983c883fefeeee570629d844f6b1821f78a8769b6c8ffa26e64c97f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49260",
+					"10.65.0.27:49260",
+					"172.17.0.1:49260",
+					"172.18.0.1:49260",
+					"172.19.0.1:49260",
+					"172.20.0.1:49260",
+					"172.21.0.1:49260",
+					"172.22.0.1:49260",
+					"172.23.0.1:49260",
+					"172.24.0.1:49260",
+					"172.25.0.1:49260",
+					"172.26.0.1:49260",
+					"172.27.0.1:49260",
+					"172.28.0.1:49260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:14:35.055432543Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6905021408415337,
+				"StableID":   "nJd9joCJvv11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22a6989ab145d63e5dc0190d424872b2e13d69c840276015ada95a260ee3a813",
+				"DiscoKey":   "discokey:3d2b4f0c5ca407ea4226bfcf74e39faaf98d448741f49a4ea4a55c51a6c97e74",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33099",
+					"10.65.0.27:33099",
+					"172.17.0.1:33099",
+					"172.18.0.1:33099",
+					"172.19.0.1:33099",
+					"172.20.0.1:33099",
+					"172.21.0.1:33099",
+					"172.22.0.1:33099",
+					"172.23.0.1:33099",
+					"172.24.0.1:33099",
+					"172.25.0.1:33099",
+					"172.26.0.1:33099",
+					"172.27.0.1:33099",
+					"172.28.0.1:33099"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:14:35.589805582Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1378366829076477,
+				"StableID":   "nnF2hqMGmB11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8c1cae6b2713e6afd28791292ce29afa5e8d37fbbc5fd5b91047d0e74980d2c",
+				"DiscoKey":   "discokey:f8e2a2f49c94748f64d088c0c05530956245a73e92321502c7ef5a8c374bcb3a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51558",
+					"10.65.0.27:51558",
+					"172.17.0.1:51558",
+					"172.18.0.1:51558",
+					"172.19.0.1:51558",
+					"172.20.0.1:51558",
+					"172.21.0.1:51558",
+					"172.22.0.1:51558",
+					"172.23.0.1:51558",
+					"172.24.0.1:51558",
+					"172.25.0.1:51558",
+					"172.26.0.1:51558",
+					"172.27.0.1:51558",
+					"172.28.0.1:51558"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:14:36.123605174Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8096131484985793,
+				"StableID":   "nQ8rRSekD621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5ed161b91ef60de21d1932add68bb1a403c7075494bc635c14ed065846b6023",
+				"DiscoKey":   "discokey:342cf3aa2e3fe8811029ee42ffb6911b44105deb8348846ff4b891d9d2842559",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36582",
+					"10.65.0.27:36582",
+					"172.17.0.1:36582",
+					"172.18.0.1:36582",
+					"172.19.0.1:36582",
+					"172.20.0.1:36582",
+					"172.21.0.1:36582",
+					"172.22.0.1:36582",
+					"172.23.0.1:36582",
+					"172.24.0.1:36582",
+					"172.25.0.1:36582",
+					"172.26.0.1:36582",
+					"172.27.0.1:36582",
+					"172.28.0.1:36582"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:14:36.697309618Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         652158256515153,
+				"StableID":   "nvVCvJ6N6611CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f71f8cedfac1f8c676ad5c576041a4eecf18f24d30471f99ea12cdc3224b208",
+				"DiscoKey":   "discokey:78940d0a8f7aa5a7a819ac538f90c50575351ec5646ea57b96f1a65127ffb662",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59893",
+					"10.65.0.27:59893",
+					"172.17.0.1:59893",
+					"172.18.0.1:59893",
+					"172.19.0.1:59893",
+					"172.20.0.1:59893",
+					"172.21.0.1:59893",
+					"172.22.0.1:59893",
+					"172.23.0.1:59893",
+					"172.24.0.1:59893",
+					"172.25.0.1:59893",
+					"172.26.0.1:59893",
+					"172.27.0.1:59893",
+					"172.28.0.1:59893"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:14:37.736228983Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2630166202798887,
+				"StableID":   "nxf6mM1DYM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b1232181959ec13a3e9624e8ce271ccf28570308e230e27c39182ace737853c",
+				"DiscoKey":   "discokey:ef2ec17c497da07d53c33ec478e9fc67db2d46ab0633a3a8510c322266249408",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:46591",
+					"10.65.0.27:46591",
+					"172.17.0.1:46591",
+					"172.18.0.1:46591",
+					"172.19.0.1:46591",
+					"172.20.0.1:46591",
+					"172.21.0.1:46591",
+					"172.22.0.1:46591",
+					"172.23.0.1:46591",
+					"172.24.0.1:46591",
+					"172.25.0.1:46591",
+					"172.26.0.1:46591",
+					"172.27.0.1:46591",
+					"172.28.0.1:46591"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:14:38.273699887Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7492479871341914,
+				"StableID":   "nZCSSzjMW121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:94197bf76ee983cf5ce7b3e7e45ec911814a04b83ce8e72cc0e9ca36ada86224",
+				"DiscoKey":   "discokey:f581bc05b5d08fb8541feae196c4866e94b3813c08df8d843f2c3dec3e3a0b5e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38464",
+					"10.65.0.27:38464",
+					"172.17.0.1:38464",
+					"172.18.0.1:38464",
+					"172.19.0.1:38464",
+					"172.20.0.1:38464",
+					"172.21.0.1:38464",
+					"172.22.0.1:38464",
+					"172.23.0.1:38464",
+					"172.24.0.1:38464",
+					"172.25.0.1:38464",
+					"172.26.0.1:38464",
+					"172.27.0.1:38464",
+					"172.28.0.1:38464"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:14:38.807670086Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4496192053903417,
+				"StableID":   "nCgPKnLL7c11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8ba3519054665252fe52daf2ca358693b2874665dac7febee26662dc7df2772d",
+				"KeyExpiry":  "2026-11-09T09:14:39Z",
+				"DiscoKey":   "discokey:6333bf224f6f9dcfcd47951e70e92b96218bdbea11fcbef77e28ba214c06303e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54449",
+					"10.65.0.27:54449",
+					"172.17.0.1:54449",
+					"172.18.0.1:54449",
+					"172.19.0.1:54449",
+					"172.20.0.1:54449",
+					"172.21.0.1:54449",
+					"172.22.0.1:54449",
+					"172.23.0.1:54449",
+					"172.24.0.1:54449",
+					"172.25.0.1:54449",
+					"172.26.0.1:54449",
+					"172.27.0.1:54449",
+					"172.28.0.1:54449"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:14:39.365637808Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5894916202258050,
+				"StableID":   "nTysbFTp2o11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b1530603c3fdbe6e274470f89fedb14c05237a75072d94676073d58c5f941a37",
+				"KeyExpiry":  "2026-11-09T09:14:39Z",
+				"DiscoKey":   "discokey:8ff5c8d67ced5c0fa173009f9be01d85d23651b478da2fad407a09382f706e35",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35852",
+					"10.65.0.27:35852",
+					"172.17.0.1:35852",
+					"172.18.0.1:35852",
+					"172.19.0.1:35852",
+					"172.20.0.1:35852",
+					"172.21.0.1:35852",
+					"172.22.0.1:35852",
+					"172.23.0.1:35852",
+					"172.24.0.1:35852",
+					"172.25.0.1:35852",
+					"172.26.0.1:35852",
+					"172.27.0.1:35852",
+					"172.28.0.1:35852"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:14:39.898001202Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2161925042966337,
+				"StableID":   "nAVBt579tH11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1092e1b55eb5c0d2f5610c08013089fab5f95281b4b2e07b644c00693a70ce04",
+				"KeyExpiry":  "2026-11-09T09:14:40Z",
+				"DiscoKey":   "discokey:cb33dfc58e777b4694782a8f94c7b4ae3e9852580af53edbbe02fd45fb6cfe28",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:40634",
+					"10.65.0.27:40634",
+					"172.17.0.1:40634",
+					"172.18.0.1:40634",
+					"172.19.0.1:40634",
+					"172.20.0.1:40634",
+					"172.21.0.1:40634",
+					"172.22.0.1:40634",
+					"172.23.0.1:40634",
+					"172.24.0.1:40634",
+					"172.25.0.1:40634",
+					"172.26.0.1:40634",
+					"172.27.0.1:40634",
+					"172.28.0.1:40634"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:14:40.443043267Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5263862495942249": {
+				"ID":          5263862495942249,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5894916202258050,
+				"StableID":   "nTysbFTp2o11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b1530603c3fdbe6e274470f89fedb14c05237a75072d94676073d58c5f941a37",
+				"KeyExpiry":  "2026-11-09T09:14:39Z",
+				"DiscoKey":   "discokey:8ff5c8d67ced5c0fa173009f9be01d85d23651b478da2fad407a09382f706e35",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35852",
+					"10.65.0.27:35852",
+					"172.17.0.1:35852",
+					"172.18.0.1:35852",
+					"172.19.0.1:35852",
+					"172.20.0.1:35852",
+					"172.21.0.1:35852",
+					"172.22.0.1:35852",
+					"172.23.0.1:35852",
+					"172.24.0.1:35852",
+					"172.25.0.1:35852",
+					"172.26.0.1:35852",
+					"172.27.0.1:35852",
+					"172.28.0.1:35852"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:14:39.898001202Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b1530603c3fdbe6e274470f89fedb14c05237a75072d94676073d58c5f941a37",
+			"MachineKey": "mkey:98cf48977647354c916fa2da38f5889eb4bfbd475b9183e7c6b10973ae600b0e",
+			"Peers": [{
+				"ID":         2840293870652164,
+				"StableID":   "nTSmDphNBP11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65bfe3aab37558c3d4257f7c4a3ce5a1fe9c0d545783dffd6fb27ffffa470a2e",
+				"DiscoKey":   "discokey:a4d7e3fb3fc79731a2c6d0f9981b49fd9888a3dccb9ea5ec8f79708e2549d90f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47906",
+					"10.65.0.27:47906",
+					"172.17.0.1:47906",
+					"172.18.0.1:47906",
+					"172.19.0.1:47906",
+					"172.20.0.1:47906",
+					"172.21.0.1:47906",
+					"172.22.0.1:47906",
+					"172.23.0.1:47906",
+					"172.24.0.1:47906",
+					"172.25.0.1:47906",
+					"172.26.0.1:47906",
+					"172.27.0.1:47906",
+					"172.28.0.1:47906"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:14:32.914936157Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3944447720512740,
+				"StableID":   "nBYEwGxSoX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd52f08d01f7e477b25d99a8459790671a4edcf479268db13bcb68972da5ef26",
+				"DiscoKey":   "discokey:29c2f5ece02e2602991a80fcd1e26044ae95e886a22a1c71132f7f3f301de552",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35813",
+					"10.65.0.27:35813",
+					"172.17.0.1:35813",
+					"172.18.0.1:35813",
+					"172.19.0.1:35813",
+					"172.20.0.1:35813",
+					"172.21.0.1:35813",
+					"172.22.0.1:35813",
+					"172.23.0.1:35813",
+					"172.24.0.1:35813",
+					"172.25.0.1:35813",
+					"172.26.0.1:35813",
+					"172.27.0.1:35813",
+					"172.28.0.1:35813"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:14:33.444311138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8196632796973305,
+				"StableID":   "nQteDPeG1721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c08f2124f0292c7e3bc13e2d8d2ad4f092a71686f3b24f88b7bb47201513d54",
+				"DiscoKey":   "discokey:dacc24dde10d1a36e280fcc9402f9b7187f0ea43128cf478d76b73dfc175f602",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39819",
+					"10.65.0.27:39819",
+					"172.17.0.1:39819",
+					"172.18.0.1:39819",
+					"172.19.0.1:39819",
+					"172.20.0.1:39819",
+					"172.21.0.1:39819",
+					"172.22.0.1:39819",
+					"172.23.0.1:39819",
+					"172.24.0.1:39819",
+					"172.25.0.1:39819",
+					"172.26.0.1:39819",
+					"172.27.0.1:39819",
+					"172.28.0.1:39819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:14:33.978522762Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3530720735132739,
+				"StableID":   "n6nkyh35aU11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3fb7232e7768dec4cba16c8e80abc1bd76a65ce5350208774913c4617f346323",
+				"DiscoKey":   "discokey:561530bf3f9f0768e9c504a9c5e5c13b4c7dac43ea67fdced9290132ec9d1509",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35092",
+					"10.65.0.27:35092",
+					"172.17.0.1:35092",
+					"172.18.0.1:35092",
+					"172.19.0.1:35092",
+					"172.20.0.1:35092",
+					"172.21.0.1:35092",
+					"172.22.0.1:35092",
+					"172.23.0.1:35092",
+					"172.24.0.1:35092",
+					"172.25.0.1:35092",
+					"172.26.0.1:35092",
+					"172.27.0.1:35092",
+					"172.28.0.1:35092"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:14:34.519796394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8493166885310382,
+				"StableID":   "nF1wAM6aK921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b67714dc940f6a6c3f20bc0474c08f0a0d508dbb660b67d4e5382af025a9b264",
+				"DiscoKey":   "discokey:eb7f68d16983c883fefeeee570629d844f6b1821f78a8769b6c8ffa26e64c97f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49260",
+					"10.65.0.27:49260",
+					"172.17.0.1:49260",
+					"172.18.0.1:49260",
+					"172.19.0.1:49260",
+					"172.20.0.1:49260",
+					"172.21.0.1:49260",
+					"172.22.0.1:49260",
+					"172.23.0.1:49260",
+					"172.24.0.1:49260",
+					"172.25.0.1:49260",
+					"172.26.0.1:49260",
+					"172.27.0.1:49260",
+					"172.28.0.1:49260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:14:35.055432543Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6905021408415337,
+				"StableID":   "nJd9joCJvv11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22a6989ab145d63e5dc0190d424872b2e13d69c840276015ada95a260ee3a813",
+				"DiscoKey":   "discokey:3d2b4f0c5ca407ea4226bfcf74e39faaf98d448741f49a4ea4a55c51a6c97e74",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33099",
+					"10.65.0.27:33099",
+					"172.17.0.1:33099",
+					"172.18.0.1:33099",
+					"172.19.0.1:33099",
+					"172.20.0.1:33099",
+					"172.21.0.1:33099",
+					"172.22.0.1:33099",
+					"172.23.0.1:33099",
+					"172.24.0.1:33099",
+					"172.25.0.1:33099",
+					"172.26.0.1:33099",
+					"172.27.0.1:33099",
+					"172.28.0.1:33099"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:14:35.589805582Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1378366829076477,
+				"StableID":   "nnF2hqMGmB11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8c1cae6b2713e6afd28791292ce29afa5e8d37fbbc5fd5b91047d0e74980d2c",
+				"DiscoKey":   "discokey:f8e2a2f49c94748f64d088c0c05530956245a73e92321502c7ef5a8c374bcb3a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51558",
+					"10.65.0.27:51558",
+					"172.17.0.1:51558",
+					"172.18.0.1:51558",
+					"172.19.0.1:51558",
+					"172.20.0.1:51558",
+					"172.21.0.1:51558",
+					"172.22.0.1:51558",
+					"172.23.0.1:51558",
+					"172.24.0.1:51558",
+					"172.25.0.1:51558",
+					"172.26.0.1:51558",
+					"172.27.0.1:51558",
+					"172.28.0.1:51558"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:14:36.123605174Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8096131484985793,
+				"StableID":   "nQ8rRSekD621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5ed161b91ef60de21d1932add68bb1a403c7075494bc635c14ed065846b6023",
+				"DiscoKey":   "discokey:342cf3aa2e3fe8811029ee42ffb6911b44105deb8348846ff4b891d9d2842559",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36582",
+					"10.65.0.27:36582",
+					"172.17.0.1:36582",
+					"172.18.0.1:36582",
+					"172.19.0.1:36582",
+					"172.20.0.1:36582",
+					"172.21.0.1:36582",
+					"172.22.0.1:36582",
+					"172.23.0.1:36582",
+					"172.24.0.1:36582",
+					"172.25.0.1:36582",
+					"172.26.0.1:36582",
+					"172.27.0.1:36582",
+					"172.28.0.1:36582"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:14:36.697309618Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5263862495942249,
+				"StableID":   "nnFwW2k17i11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:759cab22549715a036dc3776fd5599511ec3132e6c4d69858d27095db3d99b17",
+				"DiscoKey":   "discokey:a24b6e3eb1290c84367432907f3c785aacb66b15edc579bd872a8aa4e6550e2b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53998",
+					"10.65.0.27:53998",
+					"172.17.0.1:53998",
+					"172.18.0.1:53998",
+					"172.19.0.1:53998",
+					"172.20.0.1:53998",
+					"172.21.0.1:53998",
+					"172.22.0.1:53998",
+					"172.23.0.1:53998",
+					"172.24.0.1:53998",
+					"172.25.0.1:53998",
+					"172.26.0.1:53998",
+					"172.27.0.1:53998",
+					"172.28.0.1:53998"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:14:37.223103871Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         652158256515153,
+				"StableID":   "nvVCvJ6N6611CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f71f8cedfac1f8c676ad5c576041a4eecf18f24d30471f99ea12cdc3224b208",
+				"DiscoKey":   "discokey:78940d0a8f7aa5a7a819ac538f90c50575351ec5646ea57b96f1a65127ffb662",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59893",
+					"10.65.0.27:59893",
+					"172.17.0.1:59893",
+					"172.18.0.1:59893",
+					"172.19.0.1:59893",
+					"172.20.0.1:59893",
+					"172.21.0.1:59893",
+					"172.22.0.1:59893",
+					"172.23.0.1:59893",
+					"172.24.0.1:59893",
+					"172.25.0.1:59893",
+					"172.26.0.1:59893",
+					"172.27.0.1:59893",
+					"172.28.0.1:59893"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:14:37.736228983Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2630166202798887,
+				"StableID":   "nxf6mM1DYM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b1232181959ec13a3e9624e8ce271ccf28570308e230e27c39182ace737853c",
+				"DiscoKey":   "discokey:ef2ec17c497da07d53c33ec478e9fc67db2d46ab0633a3a8510c322266249408",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:46591",
+					"10.65.0.27:46591",
+					"172.17.0.1:46591",
+					"172.18.0.1:46591",
+					"172.19.0.1:46591",
+					"172.20.0.1:46591",
+					"172.21.0.1:46591",
+					"172.22.0.1:46591",
+					"172.23.0.1:46591",
+					"172.24.0.1:46591",
+					"172.25.0.1:46591",
+					"172.26.0.1:46591",
+					"172.27.0.1:46591",
+					"172.28.0.1:46591"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:14:38.273699887Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7492479871341914,
+				"StableID":   "nZCSSzjMW121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:94197bf76ee983cf5ce7b3e7e45ec911814a04b83ce8e72cc0e9ca36ada86224",
+				"DiscoKey":   "discokey:f581bc05b5d08fb8541feae196c4866e94b3813c08df8d843f2c3dec3e3a0b5e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38464",
+					"10.65.0.27:38464",
+					"172.17.0.1:38464",
+					"172.18.0.1:38464",
+					"172.19.0.1:38464",
+					"172.20.0.1:38464",
+					"172.21.0.1:38464",
+					"172.22.0.1:38464",
+					"172.23.0.1:38464",
+					"172.24.0.1:38464",
+					"172.25.0.1:38464",
+					"172.26.0.1:38464",
+					"172.27.0.1:38464",
+					"172.28.0.1:38464"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:14:38.807670086Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4496192053903417,
+				"StableID":   "nCgPKnLL7c11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8ba3519054665252fe52daf2ca358693b2874665dac7febee26662dc7df2772d",
+				"KeyExpiry":  "2026-11-09T09:14:39Z",
+				"DiscoKey":   "discokey:6333bf224f6f9dcfcd47951e70e92b96218bdbea11fcbef77e28ba214c06303e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54449",
+					"10.65.0.27:54449",
+					"172.17.0.1:54449",
+					"172.18.0.1:54449",
+					"172.19.0.1:54449",
+					"172.20.0.1:54449",
+					"172.21.0.1:54449",
+					"172.22.0.1:54449",
+					"172.23.0.1:54449",
+					"172.24.0.1:54449",
+					"172.25.0.1:54449",
+					"172.26.0.1:54449",
+					"172.27.0.1:54449",
+					"172.28.0.1:54449"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:14:39.365637808Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2161925042966337,
+				"StableID":   "nAVBt579tH11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1092e1b55eb5c0d2f5610c08013089fab5f95281b4b2e07b644c00693a70ce04",
+				"KeyExpiry":  "2026-11-09T09:14:40Z",
+				"DiscoKey":   "discokey:cb33dfc58e777b4694782a8f94c7b4ae3e9852580af53edbbe02fd45fb6cfe28",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:40634",
+					"10.65.0.27:40634",
+					"172.17.0.1:40634",
+					"172.18.0.1:40634",
+					"172.19.0.1:40634",
+					"172.20.0.1:40634",
+					"172.21.0.1:40634",
+					"172.22.0.1:40634",
+					"172.23.0.1:40634",
+					"172.24.0.1:40634",
+					"172.25.0.1:40634",
+					"172.26.0.1:40634",
+					"172.27.0.1:40634",
+					"172.28.0.1:40634"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:14:40.443043267Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         652158256515153,
+				"StableID":   "nvVCvJ6N6611CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       652158256515153,
+				"Key":        "nodekey:9f71f8cedfac1f8c676ad5c576041a4eecf18f24d30471f99ea12cdc3224b208",
+				"DiscoKey":   "discokey:78940d0a8f7aa5a7a819ac538f90c50575351ec5646ea57b96f1a65127ffb662",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59893",
+					"10.65.0.27:59893",
+					"172.17.0.1:59893",
+					"172.18.0.1:59893",
+					"172.19.0.1:59893",
+					"172.20.0.1:59893",
+					"172.21.0.1:59893",
+					"172.22.0.1:59893",
+					"172.23.0.1:59893",
+					"172.24.0.1:59893",
+					"172.25.0.1:59893",
+					"172.26.0.1:59893",
+					"172.27.0.1:59893",
+					"172.28.0.1:59893"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:14:37.736228983Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9f71f8cedfac1f8c676ad5c576041a4eecf18f24d30471f99ea12cdc3224b208",
+			"MachineKey": "mkey:3c00a1fed8971841bae98e692aa4a80107ef42cdfe20c2f28069c5389edbac53",
+			"Peers": [{
+				"ID":         2840293870652164,
+				"StableID":   "nTSmDphNBP11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65bfe3aab37558c3d4257f7c4a3ce5a1fe9c0d545783dffd6fb27ffffa470a2e",
+				"DiscoKey":   "discokey:a4d7e3fb3fc79731a2c6d0f9981b49fd9888a3dccb9ea5ec8f79708e2549d90f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47906",
+					"10.65.0.27:47906",
+					"172.17.0.1:47906",
+					"172.18.0.1:47906",
+					"172.19.0.1:47906",
+					"172.20.0.1:47906",
+					"172.21.0.1:47906",
+					"172.22.0.1:47906",
+					"172.23.0.1:47906",
+					"172.24.0.1:47906",
+					"172.25.0.1:47906",
+					"172.26.0.1:47906",
+					"172.27.0.1:47906",
+					"172.28.0.1:47906"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:14:32.914936157Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3944447720512740,
+				"StableID":   "nBYEwGxSoX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd52f08d01f7e477b25d99a8459790671a4edcf479268db13bcb68972da5ef26",
+				"DiscoKey":   "discokey:29c2f5ece02e2602991a80fcd1e26044ae95e886a22a1c71132f7f3f301de552",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35813",
+					"10.65.0.27:35813",
+					"172.17.0.1:35813",
+					"172.18.0.1:35813",
+					"172.19.0.1:35813",
+					"172.20.0.1:35813",
+					"172.21.0.1:35813",
+					"172.22.0.1:35813",
+					"172.23.0.1:35813",
+					"172.24.0.1:35813",
+					"172.25.0.1:35813",
+					"172.26.0.1:35813",
+					"172.27.0.1:35813",
+					"172.28.0.1:35813"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:14:33.444311138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8196632796973305,
+				"StableID":   "nQteDPeG1721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c08f2124f0292c7e3bc13e2d8d2ad4f092a71686f3b24f88b7bb47201513d54",
+				"DiscoKey":   "discokey:dacc24dde10d1a36e280fcc9402f9b7187f0ea43128cf478d76b73dfc175f602",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39819",
+					"10.65.0.27:39819",
+					"172.17.0.1:39819",
+					"172.18.0.1:39819",
+					"172.19.0.1:39819",
+					"172.20.0.1:39819",
+					"172.21.0.1:39819",
+					"172.22.0.1:39819",
+					"172.23.0.1:39819",
+					"172.24.0.1:39819",
+					"172.25.0.1:39819",
+					"172.26.0.1:39819",
+					"172.27.0.1:39819",
+					"172.28.0.1:39819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:14:33.978522762Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3530720735132739,
+				"StableID":   "n6nkyh35aU11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3fb7232e7768dec4cba16c8e80abc1bd76a65ce5350208774913c4617f346323",
+				"DiscoKey":   "discokey:561530bf3f9f0768e9c504a9c5e5c13b4c7dac43ea67fdced9290132ec9d1509",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:35092",
+					"10.65.0.27:35092",
+					"172.17.0.1:35092",
+					"172.18.0.1:35092",
+					"172.19.0.1:35092",
+					"172.20.0.1:35092",
+					"172.21.0.1:35092",
+					"172.22.0.1:35092",
+					"172.23.0.1:35092",
+					"172.24.0.1:35092",
+					"172.25.0.1:35092",
+					"172.26.0.1:35092",
+					"172.27.0.1:35092",
+					"172.28.0.1:35092"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:14:34.519796394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8493166885310382,
+				"StableID":   "nF1wAM6aK921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b67714dc940f6a6c3f20bc0474c08f0a0d508dbb660b67d4e5382af025a9b264",
+				"DiscoKey":   "discokey:eb7f68d16983c883fefeeee570629d844f6b1821f78a8769b6c8ffa26e64c97f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49260",
+					"10.65.0.27:49260",
+					"172.17.0.1:49260",
+					"172.18.0.1:49260",
+					"172.19.0.1:49260",
+					"172.20.0.1:49260",
+					"172.21.0.1:49260",
+					"172.22.0.1:49260",
+					"172.23.0.1:49260",
+					"172.24.0.1:49260",
+					"172.25.0.1:49260",
+					"172.26.0.1:49260",
+					"172.27.0.1:49260",
+					"172.28.0.1:49260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:14:35.055432543Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6905021408415337,
+				"StableID":   "nJd9joCJvv11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22a6989ab145d63e5dc0190d424872b2e13d69c840276015ada95a260ee3a813",
+				"DiscoKey":   "discokey:3d2b4f0c5ca407ea4226bfcf74e39faaf98d448741f49a4ea4a55c51a6c97e74",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33099",
+					"10.65.0.27:33099",
+					"172.17.0.1:33099",
+					"172.18.0.1:33099",
+					"172.19.0.1:33099",
+					"172.20.0.1:33099",
+					"172.21.0.1:33099",
+					"172.22.0.1:33099",
+					"172.23.0.1:33099",
+					"172.24.0.1:33099",
+					"172.25.0.1:33099",
+					"172.26.0.1:33099",
+					"172.27.0.1:33099",
+					"172.28.0.1:33099"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:14:35.589805582Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1378366829076477,
+				"StableID":   "nnF2hqMGmB11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a8c1cae6b2713e6afd28791292ce29afa5e8d37fbbc5fd5b91047d0e74980d2c",
+				"DiscoKey":   "discokey:f8e2a2f49c94748f64d088c0c05530956245a73e92321502c7ef5a8c374bcb3a",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51558",
+					"10.65.0.27:51558",
+					"172.17.0.1:51558",
+					"172.18.0.1:51558",
+					"172.19.0.1:51558",
+					"172.20.0.1:51558",
+					"172.21.0.1:51558",
+					"172.22.0.1:51558",
+					"172.23.0.1:51558",
+					"172.24.0.1:51558",
+					"172.25.0.1:51558",
+					"172.26.0.1:51558",
+					"172.27.0.1:51558",
+					"172.28.0.1:51558"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:14:36.123605174Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8096131484985793,
+				"StableID":   "nQ8rRSekD621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5ed161b91ef60de21d1932add68bb1a403c7075494bc635c14ed065846b6023",
+				"DiscoKey":   "discokey:342cf3aa2e3fe8811029ee42ffb6911b44105deb8348846ff4b891d9d2842559",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36582",
+					"10.65.0.27:36582",
+					"172.17.0.1:36582",
+					"172.18.0.1:36582",
+					"172.19.0.1:36582",
+					"172.20.0.1:36582",
+					"172.21.0.1:36582",
+					"172.22.0.1:36582",
+					"172.23.0.1:36582",
+					"172.24.0.1:36582",
+					"172.25.0.1:36582",
+					"172.26.0.1:36582",
+					"172.27.0.1:36582",
+					"172.28.0.1:36582"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:14:36.697309618Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5263862495942249,
+				"StableID":   "nnFwW2k17i11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:759cab22549715a036dc3776fd5599511ec3132e6c4d69858d27095db3d99b17",
+				"DiscoKey":   "discokey:a24b6e3eb1290c84367432907f3c785aacb66b15edc579bd872a8aa4e6550e2b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53998",
+					"10.65.0.27:53998",
+					"172.17.0.1:53998",
+					"172.18.0.1:53998",
+					"172.19.0.1:53998",
+					"172.20.0.1:53998",
+					"172.21.0.1:53998",
+					"172.22.0.1:53998",
+					"172.23.0.1:53998",
+					"172.24.0.1:53998",
+					"172.25.0.1:53998",
+					"172.26.0.1:53998",
+					"172.27.0.1:53998",
+					"172.28.0.1:53998"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:14:37.223103871Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2630166202798887,
+				"StableID":   "nxf6mM1DYM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9b1232181959ec13a3e9624e8ce271ccf28570308e230e27c39182ace737853c",
+				"DiscoKey":   "discokey:ef2ec17c497da07d53c33ec478e9fc67db2d46ab0633a3a8510c322266249408",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:46591",
+					"10.65.0.27:46591",
+					"172.17.0.1:46591",
+					"172.18.0.1:46591",
+					"172.19.0.1:46591",
+					"172.20.0.1:46591",
+					"172.21.0.1:46591",
+					"172.22.0.1:46591",
+					"172.23.0.1:46591",
+					"172.24.0.1:46591",
+					"172.25.0.1:46591",
+					"172.26.0.1:46591",
+					"172.27.0.1:46591",
+					"172.28.0.1:46591"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:14:38.273699887Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7492479871341914,
+				"StableID":   "nZCSSzjMW121CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:94197bf76ee983cf5ce7b3e7e45ec911814a04b83ce8e72cc0e9ca36ada86224",
+				"DiscoKey":   "discokey:f581bc05b5d08fb8541feae196c4866e94b3813c08df8d843f2c3dec3e3a0b5e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38464",
+					"10.65.0.27:38464",
+					"172.17.0.1:38464",
+					"172.18.0.1:38464",
+					"172.19.0.1:38464",
+					"172.20.0.1:38464",
+					"172.21.0.1:38464",
+					"172.22.0.1:38464",
+					"172.23.0.1:38464",
+					"172.24.0.1:38464",
+					"172.25.0.1:38464",
+					"172.26.0.1:38464",
+					"172.27.0.1:38464",
+					"172.28.0.1:38464"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:14:38.807670086Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4496192053903417,
+				"StableID":   "nCgPKnLL7c11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8ba3519054665252fe52daf2ca358693b2874665dac7febee26662dc7df2772d",
+				"KeyExpiry":  "2026-11-09T09:14:39Z",
+				"DiscoKey":   "discokey:6333bf224f6f9dcfcd47951e70e92b96218bdbea11fcbef77e28ba214c06303e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54449",
+					"10.65.0.27:54449",
+					"172.17.0.1:54449",
+					"172.18.0.1:54449",
+					"172.19.0.1:54449",
+					"172.20.0.1:54449",
+					"172.21.0.1:54449",
+					"172.22.0.1:54449",
+					"172.23.0.1:54449",
+					"172.24.0.1:54449",
+					"172.25.0.1:54449",
+					"172.26.0.1:54449",
+					"172.27.0.1:54449",
+					"172.28.0.1:54449"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:14:39.365637808Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5894916202258050,
+				"StableID":   "nTysbFTp2o11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b1530603c3fdbe6e274470f89fedb14c05237a75072d94676073d58c5f941a37",
+				"KeyExpiry":  "2026-11-09T09:14:39Z",
+				"DiscoKey":   "discokey:8ff5c8d67ced5c0fa173009f9be01d85d23651b478da2fad407a09382f706e35",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:35852",
+					"10.65.0.27:35852",
+					"172.17.0.1:35852",
+					"172.18.0.1:35852",
+					"172.19.0.1:35852",
+					"172.20.0.1:35852",
+					"172.21.0.1:35852",
+					"172.22.0.1:35852",
+					"172.23.0.1:35852",
+					"172.24.0.1:35852",
+					"172.25.0.1:35852",
+					"172.26.0.1:35852",
+					"172.27.0.1:35852",
+					"172.28.0.1:35852"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:14:39.898001202Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2161925042966337,
+				"StableID":   "nAVBt579tH11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1092e1b55eb5c0d2f5610c08013089fab5f95281b4b2e07b644c00693a70ce04",
+				"KeyExpiry":  "2026-11-09T09:14:40Z",
+				"DiscoKey":   "discokey:cb33dfc58e777b4694782a8f94c7b4ae3e9852580af53edbbe02fd45fb6cfe28",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:40634",
+					"10.65.0.27:40634",
+					"172.17.0.1:40634",
+					"172.18.0.1:40634",
+					"172.19.0.1:40634",
+					"172.20.0.1:40634",
+					"172.21.0.1:40634",
+					"172.22.0.1:40634",
+					"172.23.0.1:40634",
+					"172.24.0.1:40634",
+					"172.25.0.1:40634",
+					"172.26.0.1:40634",
+					"172.27.0.1:40634",
+					"172.28.0.1:40634"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:14:40.443043267Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "652158256515153": {
+				"ID":          652158256515153,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-multi-rule-accept-then-check.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-multi-rule-accept-then-check.hujson
@@ -1,0 +1,21916 @@
+// ssh-multi-rule-accept-then-check
+//
+// ssh accept then check rule, same src/dst/users
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-13T09:15:25Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-multi-rule-accept-then-check",
+	"description":    "ssh accept then check rule, same src/dst/users",
+	"category":       "ssh",
+	"captured_at":    "2026-05-13T09:15:25.72131662Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                   \n  \n                                                                           \n                                                                          \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh accept then check rule, same src/dst/users\",\n\t\"id\":          \"ssh-multi-rule-accept-then-check\",\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"thor@example.org\"],\n\t\t\"users\":  [\"root\"]\n\t}, {\n\t\t\"action\":      \"check\",\n\t\t\"checkPeriod\": \"1h\",\n\t\t\"dst\":         [\"tag:server\"],\n\t\t\"src\":         [\"thor@example.org\"],\n\t\t\"users\":       [\"root\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-edges/ssh-multi-rule-accept-then-check.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["thor@example.org"],
+				"users":  ["root"]
+			}, {
+				"action":      "check",
+				"checkPeriod": "1h",
+				"dst":         ["tag:server"],
+				"src":         ["thor@example.org"],
+				"users":       ["root"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6822175784289894,
+				"StableID":   "nHLdcPzmGv11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       6822175784289894,
+				"Key":        "nodekey:2a5a4d61c7a162a017f223e153a523dd627941f09524057fdc20fc72ad5a6752",
+				"DiscoKey":   "discokey:12a001687ba08dfa23c0821301fd782c7e7e42466757a6eddd545d468acaab23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49318",
+					"10.65.0.27:49318",
+					"172.17.0.1:49318",
+					"172.18.0.1:49318",
+					"172.19.0.1:49318",
+					"172.20.0.1:49318",
+					"172.21.0.1:49318",
+					"172.22.0.1:49318",
+					"172.23.0.1:49318",
+					"172.24.0.1:49318",
+					"172.25.0.1:49318",
+					"172.26.0.1:49318",
+					"172.27.0.1:49318"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:15:34.184201249Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2a5a4d61c7a162a017f223e153a523dd627941f09524057fdc20fc72ad5a6752",
+			"MachineKey": "mkey:002a8914a7247f116f0b31b2c1325388d80aa3b1a97d73ecb10ca1930892da32",
+			"Peers": [{
+				"ID":         7162973470033938,
+				"StableID":   "n3yb6gA8wx11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f7a5f0bbcc8f893221307ac5995f0e10e6b477f2f3aa713d4e0735873002411a",
+				"DiscoKey":   "discokey:dfbbc8dde5ca6d475decf3c9ccab9f58ce5c964721bb5ba8ffa13d1caa329c55",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49088",
+					"10.65.0.27:49088",
+					"172.17.0.1:49088",
+					"172.18.0.1:49088",
+					"172.19.0.1:49088",
+					"172.20.0.1:49088",
+					"172.21.0.1:49088",
+					"172.22.0.1:49088",
+					"172.23.0.1:49088",
+					"172.24.0.1:49088",
+					"172.25.0.1:49088",
+					"172.26.0.1:49088",
+					"172.27.0.1:49088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:15:28.250506567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7414170185595947,
+				"StableID":   "nSQkfMgttz11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f9c3aff1e051a0dec2a83dd8d1b39ed1789c202962c875aa153aa11ab72ccd0f",
+				"DiscoKey":   "discokey:e7ee02e15b803c613066967d925358eeb23046916ad2bc472cad0ceb5c2e9b5b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34681",
+					"10.65.0.27:34681",
+					"172.17.0.1:34681",
+					"172.18.0.1:34681",
+					"172.19.0.1:34681",
+					"172.20.0.1:34681",
+					"172.21.0.1:34681",
+					"172.22.0.1:34681",
+					"172.23.0.1:34681",
+					"172.24.0.1:34681",
+					"172.25.0.1:34681",
+					"172.26.0.1:34681",
+					"172.27.0.1:34681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:15:28.75901772Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8662839316658527,
+				"StableID":   "n45zuk6ReA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:88c62ac6c9912b5b232d3e81a4b600df7acaf9d24f8d97cf4094e0dc4ab2f762",
+				"DiscoKey":   "discokey:782e6b13e8ed4968c00253cb16830c93ae318ddbd9da8462446eb83e6533e275",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36767",
+					"10.65.0.27:36767",
+					"172.17.0.1:36767",
+					"172.18.0.1:36767",
+					"172.19.0.1:36767",
+					"172.20.0.1:36767",
+					"172.21.0.1:36767",
+					"172.22.0.1:36767",
+					"172.23.0.1:36767",
+					"172.24.0.1:36767",
+					"172.25.0.1:36767",
+					"172.26.0.1:36767",
+					"172.27.0.1:36767"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:15:29.341591591Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3909366360514707,
+				"StableID":   "nLMPHfRZXX11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6472555e2b3141e1dc9e6c9cb88b41a235ad445a194fae30e2eb8e19be4e5c75",
+				"DiscoKey":   "discokey:710235f1fcd9e41e4a6a3e0dc616c9a89409482e906d27fa14f2bd725ef4f441",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34420",
+					"10.65.0.27:34420",
+					"172.17.0.1:34420",
+					"172.18.0.1:34420",
+					"172.19.0.1:34420",
+					"172.20.0.1:34420",
+					"172.21.0.1:34420",
+					"172.22.0.1:34420",
+					"172.23.0.1:34420",
+					"172.24.0.1:34420",
+					"172.25.0.1:34420",
+					"172.26.0.1:34420",
+					"172.27.0.1:34420"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:15:29.854217179Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7999044957232230,
+				"StableID":   "nuppR8MnT521CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bba3e3334366a763e4495df4c8f031992b8476967fdd62f1a9167807cc5d5d42",
+				"DiscoKey":   "discokey:5b1ea0d50c8cce5b99aa06600ee89f58050cb5d1b02b65f8878a0beda041f97c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38433",
+					"10.65.0.27:38433",
+					"172.17.0.1:38433",
+					"172.18.0.1:38433",
+					"172.19.0.1:38433",
+					"172.20.0.1:38433",
+					"172.21.0.1:38433",
+					"172.22.0.1:38433",
+					"172.23.0.1:38433",
+					"172.24.0.1:38433",
+					"172.25.0.1:38433",
+					"172.26.0.1:38433",
+					"172.27.0.1:38433"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:15:30.388337037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         925197816773822,
+				"StableID":   "nPyssuN2E811CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9ab6c9017ac7f2d534fa570cd6f5bde1f80ffd27a28fe78795d806ddb8c00b00",
+				"DiscoKey":   "discokey:98bdbbdc0b5dcb0deb1e48877bac8571d5bfcc6255cc1c217004830202c2857a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54250",
+					"10.65.0.27:54250",
+					"172.17.0.1:54250",
+					"172.18.0.1:54250",
+					"172.19.0.1:54250",
+					"172.20.0.1:54250",
+					"172.21.0.1:54250",
+					"172.22.0.1:54250",
+					"172.23.0.1:54250",
+					"172.24.0.1:54250",
+					"172.25.0.1:54250",
+					"172.26.0.1:54250",
+					"172.27.0.1:54250"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:15:30.938054577Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5200609388484747,
+				"StableID":   "nzJb12CNch11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5817a7f58d795ae00e48506a9fdb12d85e8b691a7051579bee5d2fb40ecfa83f",
+				"DiscoKey":   "discokey:82871a2ba027f3f57ed9a4b033b9d1cfd4e35b5322a56d6d2575a2a0aeb88037",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58248",
+					"10.65.0.27:58248",
+					"172.17.0.1:58248",
+					"172.18.0.1:58248",
+					"172.19.0.1:58248",
+					"172.20.0.1:58248",
+					"172.21.0.1:58248",
+					"172.22.0.1:58248",
+					"172.23.0.1:58248",
+					"172.24.0.1:58248",
+					"172.25.0.1:58248",
+					"172.26.0.1:58248",
+					"172.27.0.1:58248"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:15:31.474110403Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3561426999795519,
+				"StableID":   "nvpQSbeyoU11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a795fafef9f4a89c46426029efe816a9395b5340862528a19d7b76e956788015",
+				"DiscoKey":   "discokey:63f4da40c2314bab916b10d166373c1fdb4325de44a2d554b8b59e4f0bebd609",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38290",
+					"10.65.0.27:38290",
+					"172.17.0.1:38290",
+					"172.18.0.1:38290",
+					"172.19.0.1:38290",
+					"172.20.0.1:38290",
+					"172.21.0.1:38290",
+					"172.22.0.1:38290",
+					"172.23.0.1:38290",
+					"172.24.0.1:38290",
+					"172.25.0.1:38290",
+					"172.26.0.1:38290",
+					"172.27.0.1:38290"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:15:32.046626874Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5801515494625177,
+				"StableID":   "nUWQuWyWJn11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d3ce6431fef8e3b4963aaa319c0c53dc97054e3042d73eecade99c5201a78d40",
+				"DiscoKey":   "discokey:55be253434b1b88c06b4325eb66fde5bf9f85a6633e376a58450b842824bcc75",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:60761",
+					"10.65.0.27:60761",
+					"172.17.0.1:60761",
+					"172.18.0.1:60761",
+					"172.19.0.1:60761",
+					"172.20.0.1:60761",
+					"172.21.0.1:60761",
+					"172.22.0.1:60761",
+					"172.23.0.1:60761",
+					"172.24.0.1:60761",
+					"172.25.0.1:60761",
+					"172.26.0.1:60761",
+					"172.27.0.1:60761"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:15:32.553760632Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4571778998843261,
+				"StableID":   "nCgko9tZhc11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6683546b33900d2c5093322416f2bc94fbc87b5f2d9e30fbb720cec2953a8927",
+				"DiscoKey":   "discokey:1e25ffa1290170bbe24651b7fd2bf6f293c7f3cc3f5f32fbd49ab6324cea5571",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:57830",
+					"10.65.0.27:57830",
+					"172.17.0.1:57830",
+					"172.18.0.1:57830",
+					"172.19.0.1:57830",
+					"172.20.0.1:57830",
+					"172.21.0.1:57830",
+					"172.22.0.1:57830",
+					"172.23.0.1:57830",
+					"172.24.0.1:57830",
+					"172.25.0.1:57830",
+					"172.26.0.1:57830",
+					"172.27.0.1:57830"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:15:33.114398928Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1131422399557847,
+				"StableID":   "nN6M5nYRq911CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2bbec591da434185a620f820e76467f9ee661eb42e66c91d5480a784ea8db47a",
+				"DiscoKey":   "discokey:eb1f29c9f9e4748cfdd944fa6db66e15612b4193659fa190b6bb1ad537508a0a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:45678",
+					"10.65.0.27:45678",
+					"172.17.0.1:45678",
+					"172.18.0.1:45678",
+					"172.19.0.1:45678",
+					"172.20.0.1:45678",
+					"172.21.0.1:45678",
+					"172.22.0.1:45678",
+					"172.23.0.1:45678",
+					"172.24.0.1:45678",
+					"172.25.0.1:45678",
+					"172.26.0.1:45678",
+					"172.27.0.1:45678"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:15:33.63530708Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2650053646205287,
+				"StableID":   "niGu27RDhM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8a11e5466f5dbb2f59ed9b3c17c12e9bdce9b29e5562b00826be58a7e4f1172f",
+				"KeyExpiry":  "2026-11-09T09:15:34Z",
+				"DiscoKey":   "discokey:344b88352870f93262b5717013e8e7b273bee1192ae370700600d635c0bc2813",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:36041",
+					"10.65.0.27:36041",
+					"172.17.0.1:36041",
+					"172.18.0.1:36041",
+					"172.19.0.1:36041",
+					"172.20.0.1:36041",
+					"172.21.0.1:36041",
+					"172.22.0.1:36041",
+					"172.23.0.1:36041",
+					"172.24.0.1:36041",
+					"172.25.0.1:36041",
+					"172.26.0.1:36041",
+					"172.27.0.1:36041"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:15:34.716718907Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1590577337976957,
+				"StableID":   "nGGVgdmNRD11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8fce3266003e6f1a594b71724e63e0ba888524dba3671b9e9716348491811308",
+				"KeyExpiry":  "2026-11-09T09:15:35Z",
+				"DiscoKey":   "discokey:6af7d5d07601570131533159eb2e764026847e1c5a45398fb6d0201b319a1c28",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39304",
+					"10.65.0.27:39304",
+					"172.17.0.1:39304",
+					"172.18.0.1:39304",
+					"172.19.0.1:39304",
+					"172.20.0.1:39304",
+					"172.21.0.1:39304",
+					"172.22.0.1:39304",
+					"172.23.0.1:39304",
+					"172.24.0.1:39304",
+					"172.25.0.1:39304",
+					"172.26.0.1:39304",
+					"172.27.0.1:39304"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:15:35.265754047Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6654845318017443,
+				"StableID":   "n6SkJ7Wzxt11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3bae111f6933443c9cf88a9f43e65f7c0a2e50da05842e1441d74d311170be57",
+				"KeyExpiry":  "2026-11-09T09:15:35Z",
+				"DiscoKey":   "discokey:34a3642936c383953f7b115a65371c8d1800e8a7e497cb38d6f069c805d13452",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49652",
+					"10.65.0.27:49652",
+					"172.17.0.1:49652",
+					"172.18.0.1:49652",
+					"172.19.0.1:49652",
+					"172.20.0.1:49652",
+					"172.21.0.1:49652",
+					"172.22.0.1:49652",
+					"172.23.0.1:49652",
+					"172.24.0.1:49652",
+					"172.25.0.1:49652",
+					"172.26.0.1:49652",
+					"172.27.0.1:49652"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:15:35.794196155Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{
+				"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+				"sshUsers":   {"root": "root"},
+				"action": {
+					"holdAndDelegate": "https://unused/machine/ssh/action/$SRC_NODE_ID/to/$DST_NODE_ID?local_user=$LOCAL_USER"
+				}
+			}, {
+				"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+				"sshUsers":   {"root": "root"},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				}
+			}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6822175784289894": {
+				"ID":          6822175784289894,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		},
+		"ssh_rules": [{
+			"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+			"sshUsers":   {"root": "root"},
+			"action": {
+				"holdAndDelegate": "https://unused/machine/ssh/action/$SRC_NODE_ID/to/$DST_NODE_ID?local_user=$LOCAL_USER"
+			}
+		}, {
+			"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+			"sshUsers":   {"root": "root"},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}
+		}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         925197816773822,
+				"StableID":   "nPyssuN2E811CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       925197816773822,
+				"Key":        "nodekey:9ab6c9017ac7f2d534fa570cd6f5bde1f80ffd27a28fe78795d806ddb8c00b00",
+				"DiscoKey":   "discokey:98bdbbdc0b5dcb0deb1e48877bac8571d5bfcc6255cc1c217004830202c2857a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54250",
+					"10.65.0.27:54250",
+					"172.17.0.1:54250",
+					"172.18.0.1:54250",
+					"172.19.0.1:54250",
+					"172.20.0.1:54250",
+					"172.21.0.1:54250",
+					"172.22.0.1:54250",
+					"172.23.0.1:54250",
+					"172.24.0.1:54250",
+					"172.25.0.1:54250",
+					"172.26.0.1:54250",
+					"172.27.0.1:54250"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:15:30.938054577Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9ab6c9017ac7f2d534fa570cd6f5bde1f80ffd27a28fe78795d806ddb8c00b00",
+			"MachineKey": "mkey:cca240aa4e646a3eeaf8c785025dcd29eb4425e77c90848fda96b075a1f73746",
+			"Peers": [{
+				"ID":         7162973470033938,
+				"StableID":   "n3yb6gA8wx11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f7a5f0bbcc8f893221307ac5995f0e10e6b477f2f3aa713d4e0735873002411a",
+				"DiscoKey":   "discokey:dfbbc8dde5ca6d475decf3c9ccab9f58ce5c964721bb5ba8ffa13d1caa329c55",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49088",
+					"10.65.0.27:49088",
+					"172.17.0.1:49088",
+					"172.18.0.1:49088",
+					"172.19.0.1:49088",
+					"172.20.0.1:49088",
+					"172.21.0.1:49088",
+					"172.22.0.1:49088",
+					"172.23.0.1:49088",
+					"172.24.0.1:49088",
+					"172.25.0.1:49088",
+					"172.26.0.1:49088",
+					"172.27.0.1:49088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:15:28.250506567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7414170185595947,
+				"StableID":   "nSQkfMgttz11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f9c3aff1e051a0dec2a83dd8d1b39ed1789c202962c875aa153aa11ab72ccd0f",
+				"DiscoKey":   "discokey:e7ee02e15b803c613066967d925358eeb23046916ad2bc472cad0ceb5c2e9b5b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34681",
+					"10.65.0.27:34681",
+					"172.17.0.1:34681",
+					"172.18.0.1:34681",
+					"172.19.0.1:34681",
+					"172.20.0.1:34681",
+					"172.21.0.1:34681",
+					"172.22.0.1:34681",
+					"172.23.0.1:34681",
+					"172.24.0.1:34681",
+					"172.25.0.1:34681",
+					"172.26.0.1:34681",
+					"172.27.0.1:34681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:15:28.75901772Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8662839316658527,
+				"StableID":   "n45zuk6ReA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:88c62ac6c9912b5b232d3e81a4b600df7acaf9d24f8d97cf4094e0dc4ab2f762",
+				"DiscoKey":   "discokey:782e6b13e8ed4968c00253cb16830c93ae318ddbd9da8462446eb83e6533e275",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36767",
+					"10.65.0.27:36767",
+					"172.17.0.1:36767",
+					"172.18.0.1:36767",
+					"172.19.0.1:36767",
+					"172.20.0.1:36767",
+					"172.21.0.1:36767",
+					"172.22.0.1:36767",
+					"172.23.0.1:36767",
+					"172.24.0.1:36767",
+					"172.25.0.1:36767",
+					"172.26.0.1:36767",
+					"172.27.0.1:36767"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:15:29.341591591Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3909366360514707,
+				"StableID":   "nLMPHfRZXX11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6472555e2b3141e1dc9e6c9cb88b41a235ad445a194fae30e2eb8e19be4e5c75",
+				"DiscoKey":   "discokey:710235f1fcd9e41e4a6a3e0dc616c9a89409482e906d27fa14f2bd725ef4f441",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34420",
+					"10.65.0.27:34420",
+					"172.17.0.1:34420",
+					"172.18.0.1:34420",
+					"172.19.0.1:34420",
+					"172.20.0.1:34420",
+					"172.21.0.1:34420",
+					"172.22.0.1:34420",
+					"172.23.0.1:34420",
+					"172.24.0.1:34420",
+					"172.25.0.1:34420",
+					"172.26.0.1:34420",
+					"172.27.0.1:34420"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:15:29.854217179Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7999044957232230,
+				"StableID":   "nuppR8MnT521CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bba3e3334366a763e4495df4c8f031992b8476967fdd62f1a9167807cc5d5d42",
+				"DiscoKey":   "discokey:5b1ea0d50c8cce5b99aa06600ee89f58050cb5d1b02b65f8878a0beda041f97c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38433",
+					"10.65.0.27:38433",
+					"172.17.0.1:38433",
+					"172.18.0.1:38433",
+					"172.19.0.1:38433",
+					"172.20.0.1:38433",
+					"172.21.0.1:38433",
+					"172.22.0.1:38433",
+					"172.23.0.1:38433",
+					"172.24.0.1:38433",
+					"172.25.0.1:38433",
+					"172.26.0.1:38433",
+					"172.27.0.1:38433"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:15:30.388337037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5200609388484747,
+				"StableID":   "nzJb12CNch11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5817a7f58d795ae00e48506a9fdb12d85e8b691a7051579bee5d2fb40ecfa83f",
+				"DiscoKey":   "discokey:82871a2ba027f3f57ed9a4b033b9d1cfd4e35b5322a56d6d2575a2a0aeb88037",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58248",
+					"10.65.0.27:58248",
+					"172.17.0.1:58248",
+					"172.18.0.1:58248",
+					"172.19.0.1:58248",
+					"172.20.0.1:58248",
+					"172.21.0.1:58248",
+					"172.22.0.1:58248",
+					"172.23.0.1:58248",
+					"172.24.0.1:58248",
+					"172.25.0.1:58248",
+					"172.26.0.1:58248",
+					"172.27.0.1:58248"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:15:31.474110403Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3561426999795519,
+				"StableID":   "nvpQSbeyoU11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a795fafef9f4a89c46426029efe816a9395b5340862528a19d7b76e956788015",
+				"DiscoKey":   "discokey:63f4da40c2314bab916b10d166373c1fdb4325de44a2d554b8b59e4f0bebd609",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38290",
+					"10.65.0.27:38290",
+					"172.17.0.1:38290",
+					"172.18.0.1:38290",
+					"172.19.0.1:38290",
+					"172.20.0.1:38290",
+					"172.21.0.1:38290",
+					"172.22.0.1:38290",
+					"172.23.0.1:38290",
+					"172.24.0.1:38290",
+					"172.25.0.1:38290",
+					"172.26.0.1:38290",
+					"172.27.0.1:38290"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:15:32.046626874Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5801515494625177,
+				"StableID":   "nUWQuWyWJn11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d3ce6431fef8e3b4963aaa319c0c53dc97054e3042d73eecade99c5201a78d40",
+				"DiscoKey":   "discokey:55be253434b1b88c06b4325eb66fde5bf9f85a6633e376a58450b842824bcc75",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:60761",
+					"10.65.0.27:60761",
+					"172.17.0.1:60761",
+					"172.18.0.1:60761",
+					"172.19.0.1:60761",
+					"172.20.0.1:60761",
+					"172.21.0.1:60761",
+					"172.22.0.1:60761",
+					"172.23.0.1:60761",
+					"172.24.0.1:60761",
+					"172.25.0.1:60761",
+					"172.26.0.1:60761",
+					"172.27.0.1:60761"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:15:32.553760632Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4571778998843261,
+				"StableID":   "nCgko9tZhc11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6683546b33900d2c5093322416f2bc94fbc87b5f2d9e30fbb720cec2953a8927",
+				"DiscoKey":   "discokey:1e25ffa1290170bbe24651b7fd2bf6f293c7f3cc3f5f32fbd49ab6324cea5571",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:57830",
+					"10.65.0.27:57830",
+					"172.17.0.1:57830",
+					"172.18.0.1:57830",
+					"172.19.0.1:57830",
+					"172.20.0.1:57830",
+					"172.21.0.1:57830",
+					"172.22.0.1:57830",
+					"172.23.0.1:57830",
+					"172.24.0.1:57830",
+					"172.25.0.1:57830",
+					"172.26.0.1:57830",
+					"172.27.0.1:57830"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:15:33.114398928Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1131422399557847,
+				"StableID":   "nN6M5nYRq911CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2bbec591da434185a620f820e76467f9ee661eb42e66c91d5480a784ea8db47a",
+				"DiscoKey":   "discokey:eb1f29c9f9e4748cfdd944fa6db66e15612b4193659fa190b6bb1ad537508a0a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:45678",
+					"10.65.0.27:45678",
+					"172.17.0.1:45678",
+					"172.18.0.1:45678",
+					"172.19.0.1:45678",
+					"172.20.0.1:45678",
+					"172.21.0.1:45678",
+					"172.22.0.1:45678",
+					"172.23.0.1:45678",
+					"172.24.0.1:45678",
+					"172.25.0.1:45678",
+					"172.26.0.1:45678",
+					"172.27.0.1:45678"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:15:33.63530708Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6822175784289894,
+				"StableID":   "nHLdcPzmGv11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2a5a4d61c7a162a017f223e153a523dd627941f09524057fdc20fc72ad5a6752",
+				"DiscoKey":   "discokey:12a001687ba08dfa23c0821301fd782c7e7e42466757a6eddd545d468acaab23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49318",
+					"10.65.0.27:49318",
+					"172.17.0.1:49318",
+					"172.18.0.1:49318",
+					"172.19.0.1:49318",
+					"172.20.0.1:49318",
+					"172.21.0.1:49318",
+					"172.22.0.1:49318",
+					"172.23.0.1:49318",
+					"172.24.0.1:49318",
+					"172.25.0.1:49318",
+					"172.26.0.1:49318",
+					"172.27.0.1:49318"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:15:34.184201249Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2650053646205287,
+				"StableID":   "niGu27RDhM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8a11e5466f5dbb2f59ed9b3c17c12e9bdce9b29e5562b00826be58a7e4f1172f",
+				"KeyExpiry":  "2026-11-09T09:15:34Z",
+				"DiscoKey":   "discokey:344b88352870f93262b5717013e8e7b273bee1192ae370700600d635c0bc2813",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:36041",
+					"10.65.0.27:36041",
+					"172.17.0.1:36041",
+					"172.18.0.1:36041",
+					"172.19.0.1:36041",
+					"172.20.0.1:36041",
+					"172.21.0.1:36041",
+					"172.22.0.1:36041",
+					"172.23.0.1:36041",
+					"172.24.0.1:36041",
+					"172.25.0.1:36041",
+					"172.26.0.1:36041",
+					"172.27.0.1:36041"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:15:34.716718907Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1590577337976957,
+				"StableID":   "nGGVgdmNRD11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8fce3266003e6f1a594b71724e63e0ba888524dba3671b9e9716348491811308",
+				"KeyExpiry":  "2026-11-09T09:15:35Z",
+				"DiscoKey":   "discokey:6af7d5d07601570131533159eb2e764026847e1c5a45398fb6d0201b319a1c28",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39304",
+					"10.65.0.27:39304",
+					"172.17.0.1:39304",
+					"172.18.0.1:39304",
+					"172.19.0.1:39304",
+					"172.20.0.1:39304",
+					"172.21.0.1:39304",
+					"172.22.0.1:39304",
+					"172.23.0.1:39304",
+					"172.24.0.1:39304",
+					"172.25.0.1:39304",
+					"172.26.0.1:39304",
+					"172.27.0.1:39304"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:15:35.265754047Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6654845318017443,
+				"StableID":   "n6SkJ7Wzxt11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3bae111f6933443c9cf88a9f43e65f7c0a2e50da05842e1441d74d311170be57",
+				"KeyExpiry":  "2026-11-09T09:15:35Z",
+				"DiscoKey":   "discokey:34a3642936c383953f7b115a65371c8d1800e8a7e497cb38d6f069c805d13452",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49652",
+					"10.65.0.27:49652",
+					"172.17.0.1:49652",
+					"172.18.0.1:49652",
+					"172.19.0.1:49652",
+					"172.20.0.1:49652",
+					"172.21.0.1:49652",
+					"172.22.0.1:49652",
+					"172.23.0.1:49652",
+					"172.24.0.1:49652",
+					"172.25.0.1:49652",
+					"172.26.0.1:49652",
+					"172.27.0.1:49652"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:15:35.794196155Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "925197816773822": {
+				"ID":          925197816773822,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6654845318017443,
+				"StableID":   "n6SkJ7Wzxt11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3bae111f6933443c9cf88a9f43e65f7c0a2e50da05842e1441d74d311170be57",
+				"KeyExpiry":  "2026-11-09T09:15:35Z",
+				"DiscoKey":   "discokey:34a3642936c383953f7b115a65371c8d1800e8a7e497cb38d6f069c805d13452",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49652",
+					"10.65.0.27:49652",
+					"172.17.0.1:49652",
+					"172.18.0.1:49652",
+					"172.19.0.1:49652",
+					"172.20.0.1:49652",
+					"172.21.0.1:49652",
+					"172.22.0.1:49652",
+					"172.23.0.1:49652",
+					"172.24.0.1:49652",
+					"172.25.0.1:49652",
+					"172.26.0.1:49652",
+					"172.27.0.1:49652"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:15:35.794196155Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3bae111f6933443c9cf88a9f43e65f7c0a2e50da05842e1441d74d311170be57",
+			"MachineKey": "mkey:4a7ed6aebb76bccc25afa96d6172b12ac56784ed0f957873fc7fbb14eaedd143",
+			"Peers": [{
+				"ID":         7162973470033938,
+				"StableID":   "n3yb6gA8wx11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f7a5f0bbcc8f893221307ac5995f0e10e6b477f2f3aa713d4e0735873002411a",
+				"DiscoKey":   "discokey:dfbbc8dde5ca6d475decf3c9ccab9f58ce5c964721bb5ba8ffa13d1caa329c55",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49088",
+					"10.65.0.27:49088",
+					"172.17.0.1:49088",
+					"172.18.0.1:49088",
+					"172.19.0.1:49088",
+					"172.20.0.1:49088",
+					"172.21.0.1:49088",
+					"172.22.0.1:49088",
+					"172.23.0.1:49088",
+					"172.24.0.1:49088",
+					"172.25.0.1:49088",
+					"172.26.0.1:49088",
+					"172.27.0.1:49088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:15:28.250506567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7414170185595947,
+				"StableID":   "nSQkfMgttz11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f9c3aff1e051a0dec2a83dd8d1b39ed1789c202962c875aa153aa11ab72ccd0f",
+				"DiscoKey":   "discokey:e7ee02e15b803c613066967d925358eeb23046916ad2bc472cad0ceb5c2e9b5b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34681",
+					"10.65.0.27:34681",
+					"172.17.0.1:34681",
+					"172.18.0.1:34681",
+					"172.19.0.1:34681",
+					"172.20.0.1:34681",
+					"172.21.0.1:34681",
+					"172.22.0.1:34681",
+					"172.23.0.1:34681",
+					"172.24.0.1:34681",
+					"172.25.0.1:34681",
+					"172.26.0.1:34681",
+					"172.27.0.1:34681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:15:28.75901772Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8662839316658527,
+				"StableID":   "n45zuk6ReA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:88c62ac6c9912b5b232d3e81a4b600df7acaf9d24f8d97cf4094e0dc4ab2f762",
+				"DiscoKey":   "discokey:782e6b13e8ed4968c00253cb16830c93ae318ddbd9da8462446eb83e6533e275",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36767",
+					"10.65.0.27:36767",
+					"172.17.0.1:36767",
+					"172.18.0.1:36767",
+					"172.19.0.1:36767",
+					"172.20.0.1:36767",
+					"172.21.0.1:36767",
+					"172.22.0.1:36767",
+					"172.23.0.1:36767",
+					"172.24.0.1:36767",
+					"172.25.0.1:36767",
+					"172.26.0.1:36767",
+					"172.27.0.1:36767"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:15:29.341591591Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3909366360514707,
+				"StableID":   "nLMPHfRZXX11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6472555e2b3141e1dc9e6c9cb88b41a235ad445a194fae30e2eb8e19be4e5c75",
+				"DiscoKey":   "discokey:710235f1fcd9e41e4a6a3e0dc616c9a89409482e906d27fa14f2bd725ef4f441",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34420",
+					"10.65.0.27:34420",
+					"172.17.0.1:34420",
+					"172.18.0.1:34420",
+					"172.19.0.1:34420",
+					"172.20.0.1:34420",
+					"172.21.0.1:34420",
+					"172.22.0.1:34420",
+					"172.23.0.1:34420",
+					"172.24.0.1:34420",
+					"172.25.0.1:34420",
+					"172.26.0.1:34420",
+					"172.27.0.1:34420"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:15:29.854217179Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7999044957232230,
+				"StableID":   "nuppR8MnT521CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bba3e3334366a763e4495df4c8f031992b8476967fdd62f1a9167807cc5d5d42",
+				"DiscoKey":   "discokey:5b1ea0d50c8cce5b99aa06600ee89f58050cb5d1b02b65f8878a0beda041f97c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38433",
+					"10.65.0.27:38433",
+					"172.17.0.1:38433",
+					"172.18.0.1:38433",
+					"172.19.0.1:38433",
+					"172.20.0.1:38433",
+					"172.21.0.1:38433",
+					"172.22.0.1:38433",
+					"172.23.0.1:38433",
+					"172.24.0.1:38433",
+					"172.25.0.1:38433",
+					"172.26.0.1:38433",
+					"172.27.0.1:38433"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:15:30.388337037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         925197816773822,
+				"StableID":   "nPyssuN2E811CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9ab6c9017ac7f2d534fa570cd6f5bde1f80ffd27a28fe78795d806ddb8c00b00",
+				"DiscoKey":   "discokey:98bdbbdc0b5dcb0deb1e48877bac8571d5bfcc6255cc1c217004830202c2857a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54250",
+					"10.65.0.27:54250",
+					"172.17.0.1:54250",
+					"172.18.0.1:54250",
+					"172.19.0.1:54250",
+					"172.20.0.1:54250",
+					"172.21.0.1:54250",
+					"172.22.0.1:54250",
+					"172.23.0.1:54250",
+					"172.24.0.1:54250",
+					"172.25.0.1:54250",
+					"172.26.0.1:54250",
+					"172.27.0.1:54250"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:15:30.938054577Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5200609388484747,
+				"StableID":   "nzJb12CNch11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5817a7f58d795ae00e48506a9fdb12d85e8b691a7051579bee5d2fb40ecfa83f",
+				"DiscoKey":   "discokey:82871a2ba027f3f57ed9a4b033b9d1cfd4e35b5322a56d6d2575a2a0aeb88037",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58248",
+					"10.65.0.27:58248",
+					"172.17.0.1:58248",
+					"172.18.0.1:58248",
+					"172.19.0.1:58248",
+					"172.20.0.1:58248",
+					"172.21.0.1:58248",
+					"172.22.0.1:58248",
+					"172.23.0.1:58248",
+					"172.24.0.1:58248",
+					"172.25.0.1:58248",
+					"172.26.0.1:58248",
+					"172.27.0.1:58248"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:15:31.474110403Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3561426999795519,
+				"StableID":   "nvpQSbeyoU11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a795fafef9f4a89c46426029efe816a9395b5340862528a19d7b76e956788015",
+				"DiscoKey":   "discokey:63f4da40c2314bab916b10d166373c1fdb4325de44a2d554b8b59e4f0bebd609",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38290",
+					"10.65.0.27:38290",
+					"172.17.0.1:38290",
+					"172.18.0.1:38290",
+					"172.19.0.1:38290",
+					"172.20.0.1:38290",
+					"172.21.0.1:38290",
+					"172.22.0.1:38290",
+					"172.23.0.1:38290",
+					"172.24.0.1:38290",
+					"172.25.0.1:38290",
+					"172.26.0.1:38290",
+					"172.27.0.1:38290"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:15:32.046626874Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5801515494625177,
+				"StableID":   "nUWQuWyWJn11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d3ce6431fef8e3b4963aaa319c0c53dc97054e3042d73eecade99c5201a78d40",
+				"DiscoKey":   "discokey:55be253434b1b88c06b4325eb66fde5bf9f85a6633e376a58450b842824bcc75",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:60761",
+					"10.65.0.27:60761",
+					"172.17.0.1:60761",
+					"172.18.0.1:60761",
+					"172.19.0.1:60761",
+					"172.20.0.1:60761",
+					"172.21.0.1:60761",
+					"172.22.0.1:60761",
+					"172.23.0.1:60761",
+					"172.24.0.1:60761",
+					"172.25.0.1:60761",
+					"172.26.0.1:60761",
+					"172.27.0.1:60761"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:15:32.553760632Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4571778998843261,
+				"StableID":   "nCgko9tZhc11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6683546b33900d2c5093322416f2bc94fbc87b5f2d9e30fbb720cec2953a8927",
+				"DiscoKey":   "discokey:1e25ffa1290170bbe24651b7fd2bf6f293c7f3cc3f5f32fbd49ab6324cea5571",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:57830",
+					"10.65.0.27:57830",
+					"172.17.0.1:57830",
+					"172.18.0.1:57830",
+					"172.19.0.1:57830",
+					"172.20.0.1:57830",
+					"172.21.0.1:57830",
+					"172.22.0.1:57830",
+					"172.23.0.1:57830",
+					"172.24.0.1:57830",
+					"172.25.0.1:57830",
+					"172.26.0.1:57830",
+					"172.27.0.1:57830"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:15:33.114398928Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1131422399557847,
+				"StableID":   "nN6M5nYRq911CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2bbec591da434185a620f820e76467f9ee661eb42e66c91d5480a784ea8db47a",
+				"DiscoKey":   "discokey:eb1f29c9f9e4748cfdd944fa6db66e15612b4193659fa190b6bb1ad537508a0a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:45678",
+					"10.65.0.27:45678",
+					"172.17.0.1:45678",
+					"172.18.0.1:45678",
+					"172.19.0.1:45678",
+					"172.20.0.1:45678",
+					"172.21.0.1:45678",
+					"172.22.0.1:45678",
+					"172.23.0.1:45678",
+					"172.24.0.1:45678",
+					"172.25.0.1:45678",
+					"172.26.0.1:45678",
+					"172.27.0.1:45678"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:15:33.63530708Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6822175784289894,
+				"StableID":   "nHLdcPzmGv11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2a5a4d61c7a162a017f223e153a523dd627941f09524057fdc20fc72ad5a6752",
+				"DiscoKey":   "discokey:12a001687ba08dfa23c0821301fd782c7e7e42466757a6eddd545d468acaab23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49318",
+					"10.65.0.27:49318",
+					"172.17.0.1:49318",
+					"172.18.0.1:49318",
+					"172.19.0.1:49318",
+					"172.20.0.1:49318",
+					"172.21.0.1:49318",
+					"172.22.0.1:49318",
+					"172.23.0.1:49318",
+					"172.24.0.1:49318",
+					"172.25.0.1:49318",
+					"172.26.0.1:49318",
+					"172.27.0.1:49318"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:15:34.184201249Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2650053646205287,
+				"StableID":   "niGu27RDhM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8a11e5466f5dbb2f59ed9b3c17c12e9bdce9b29e5562b00826be58a7e4f1172f",
+				"KeyExpiry":  "2026-11-09T09:15:34Z",
+				"DiscoKey":   "discokey:344b88352870f93262b5717013e8e7b273bee1192ae370700600d635c0bc2813",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:36041",
+					"10.65.0.27:36041",
+					"172.17.0.1:36041",
+					"172.18.0.1:36041",
+					"172.19.0.1:36041",
+					"172.20.0.1:36041",
+					"172.21.0.1:36041",
+					"172.22.0.1:36041",
+					"172.23.0.1:36041",
+					"172.24.0.1:36041",
+					"172.25.0.1:36041",
+					"172.26.0.1:36041",
+					"172.27.0.1:36041"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:15:34.716718907Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1590577337976957,
+				"StableID":   "nGGVgdmNRD11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8fce3266003e6f1a594b71724e63e0ba888524dba3671b9e9716348491811308",
+				"KeyExpiry":  "2026-11-09T09:15:35Z",
+				"DiscoKey":   "discokey:6af7d5d07601570131533159eb2e764026847e1c5a45398fb6d0201b319a1c28",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39304",
+					"10.65.0.27:39304",
+					"172.17.0.1:39304",
+					"172.18.0.1:39304",
+					"172.19.0.1:39304",
+					"172.20.0.1:39304",
+					"172.21.0.1:39304",
+					"172.22.0.1:39304",
+					"172.23.0.1:39304",
+					"172.24.0.1:39304",
+					"172.25.0.1:39304",
+					"172.26.0.1:39304",
+					"172.27.0.1:39304"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:15:35.265754047Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8662839316658527,
+				"StableID":   "n45zuk6ReA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       8662839316658527,
+				"Key":        "nodekey:88c62ac6c9912b5b232d3e81a4b600df7acaf9d24f8d97cf4094e0dc4ab2f762",
+				"DiscoKey":   "discokey:782e6b13e8ed4968c00253cb16830c93ae318ddbd9da8462446eb83e6533e275",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36767",
+					"10.65.0.27:36767",
+					"172.17.0.1:36767",
+					"172.18.0.1:36767",
+					"172.19.0.1:36767",
+					"172.20.0.1:36767",
+					"172.21.0.1:36767",
+					"172.22.0.1:36767",
+					"172.23.0.1:36767",
+					"172.24.0.1:36767",
+					"172.25.0.1:36767",
+					"172.26.0.1:36767",
+					"172.27.0.1:36767"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:15:29.341591591Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:88c62ac6c9912b5b232d3e81a4b600df7acaf9d24f8d97cf4094e0dc4ab2f762",
+			"MachineKey": "mkey:16fda7ea3b3e3e20193e476a8571576d7020117214b116ba8b0d80210580ce2b",
+			"Peers": [{
+				"ID":         7162973470033938,
+				"StableID":   "n3yb6gA8wx11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f7a5f0bbcc8f893221307ac5995f0e10e6b477f2f3aa713d4e0735873002411a",
+				"DiscoKey":   "discokey:dfbbc8dde5ca6d475decf3c9ccab9f58ce5c964721bb5ba8ffa13d1caa329c55",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49088",
+					"10.65.0.27:49088",
+					"172.17.0.1:49088",
+					"172.18.0.1:49088",
+					"172.19.0.1:49088",
+					"172.20.0.1:49088",
+					"172.21.0.1:49088",
+					"172.22.0.1:49088",
+					"172.23.0.1:49088",
+					"172.24.0.1:49088",
+					"172.25.0.1:49088",
+					"172.26.0.1:49088",
+					"172.27.0.1:49088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:15:28.250506567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7414170185595947,
+				"StableID":   "nSQkfMgttz11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f9c3aff1e051a0dec2a83dd8d1b39ed1789c202962c875aa153aa11ab72ccd0f",
+				"DiscoKey":   "discokey:e7ee02e15b803c613066967d925358eeb23046916ad2bc472cad0ceb5c2e9b5b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34681",
+					"10.65.0.27:34681",
+					"172.17.0.1:34681",
+					"172.18.0.1:34681",
+					"172.19.0.1:34681",
+					"172.20.0.1:34681",
+					"172.21.0.1:34681",
+					"172.22.0.1:34681",
+					"172.23.0.1:34681",
+					"172.24.0.1:34681",
+					"172.25.0.1:34681",
+					"172.26.0.1:34681",
+					"172.27.0.1:34681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:15:28.75901772Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3909366360514707,
+				"StableID":   "nLMPHfRZXX11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6472555e2b3141e1dc9e6c9cb88b41a235ad445a194fae30e2eb8e19be4e5c75",
+				"DiscoKey":   "discokey:710235f1fcd9e41e4a6a3e0dc616c9a89409482e906d27fa14f2bd725ef4f441",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34420",
+					"10.65.0.27:34420",
+					"172.17.0.1:34420",
+					"172.18.0.1:34420",
+					"172.19.0.1:34420",
+					"172.20.0.1:34420",
+					"172.21.0.1:34420",
+					"172.22.0.1:34420",
+					"172.23.0.1:34420",
+					"172.24.0.1:34420",
+					"172.25.0.1:34420",
+					"172.26.0.1:34420",
+					"172.27.0.1:34420"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:15:29.854217179Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7999044957232230,
+				"StableID":   "nuppR8MnT521CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bba3e3334366a763e4495df4c8f031992b8476967fdd62f1a9167807cc5d5d42",
+				"DiscoKey":   "discokey:5b1ea0d50c8cce5b99aa06600ee89f58050cb5d1b02b65f8878a0beda041f97c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38433",
+					"10.65.0.27:38433",
+					"172.17.0.1:38433",
+					"172.18.0.1:38433",
+					"172.19.0.1:38433",
+					"172.20.0.1:38433",
+					"172.21.0.1:38433",
+					"172.22.0.1:38433",
+					"172.23.0.1:38433",
+					"172.24.0.1:38433",
+					"172.25.0.1:38433",
+					"172.26.0.1:38433",
+					"172.27.0.1:38433"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:15:30.388337037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         925197816773822,
+				"StableID":   "nPyssuN2E811CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9ab6c9017ac7f2d534fa570cd6f5bde1f80ffd27a28fe78795d806ddb8c00b00",
+				"DiscoKey":   "discokey:98bdbbdc0b5dcb0deb1e48877bac8571d5bfcc6255cc1c217004830202c2857a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54250",
+					"10.65.0.27:54250",
+					"172.17.0.1:54250",
+					"172.18.0.1:54250",
+					"172.19.0.1:54250",
+					"172.20.0.1:54250",
+					"172.21.0.1:54250",
+					"172.22.0.1:54250",
+					"172.23.0.1:54250",
+					"172.24.0.1:54250",
+					"172.25.0.1:54250",
+					"172.26.0.1:54250",
+					"172.27.0.1:54250"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:15:30.938054577Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5200609388484747,
+				"StableID":   "nzJb12CNch11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5817a7f58d795ae00e48506a9fdb12d85e8b691a7051579bee5d2fb40ecfa83f",
+				"DiscoKey":   "discokey:82871a2ba027f3f57ed9a4b033b9d1cfd4e35b5322a56d6d2575a2a0aeb88037",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58248",
+					"10.65.0.27:58248",
+					"172.17.0.1:58248",
+					"172.18.0.1:58248",
+					"172.19.0.1:58248",
+					"172.20.0.1:58248",
+					"172.21.0.1:58248",
+					"172.22.0.1:58248",
+					"172.23.0.1:58248",
+					"172.24.0.1:58248",
+					"172.25.0.1:58248",
+					"172.26.0.1:58248",
+					"172.27.0.1:58248"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:15:31.474110403Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3561426999795519,
+				"StableID":   "nvpQSbeyoU11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a795fafef9f4a89c46426029efe816a9395b5340862528a19d7b76e956788015",
+				"DiscoKey":   "discokey:63f4da40c2314bab916b10d166373c1fdb4325de44a2d554b8b59e4f0bebd609",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38290",
+					"10.65.0.27:38290",
+					"172.17.0.1:38290",
+					"172.18.0.1:38290",
+					"172.19.0.1:38290",
+					"172.20.0.1:38290",
+					"172.21.0.1:38290",
+					"172.22.0.1:38290",
+					"172.23.0.1:38290",
+					"172.24.0.1:38290",
+					"172.25.0.1:38290",
+					"172.26.0.1:38290",
+					"172.27.0.1:38290"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:15:32.046626874Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5801515494625177,
+				"StableID":   "nUWQuWyWJn11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d3ce6431fef8e3b4963aaa319c0c53dc97054e3042d73eecade99c5201a78d40",
+				"DiscoKey":   "discokey:55be253434b1b88c06b4325eb66fde5bf9f85a6633e376a58450b842824bcc75",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:60761",
+					"10.65.0.27:60761",
+					"172.17.0.1:60761",
+					"172.18.0.1:60761",
+					"172.19.0.1:60761",
+					"172.20.0.1:60761",
+					"172.21.0.1:60761",
+					"172.22.0.1:60761",
+					"172.23.0.1:60761",
+					"172.24.0.1:60761",
+					"172.25.0.1:60761",
+					"172.26.0.1:60761",
+					"172.27.0.1:60761"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:15:32.553760632Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4571778998843261,
+				"StableID":   "nCgko9tZhc11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6683546b33900d2c5093322416f2bc94fbc87b5f2d9e30fbb720cec2953a8927",
+				"DiscoKey":   "discokey:1e25ffa1290170bbe24651b7fd2bf6f293c7f3cc3f5f32fbd49ab6324cea5571",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:57830",
+					"10.65.0.27:57830",
+					"172.17.0.1:57830",
+					"172.18.0.1:57830",
+					"172.19.0.1:57830",
+					"172.20.0.1:57830",
+					"172.21.0.1:57830",
+					"172.22.0.1:57830",
+					"172.23.0.1:57830",
+					"172.24.0.1:57830",
+					"172.25.0.1:57830",
+					"172.26.0.1:57830",
+					"172.27.0.1:57830"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:15:33.114398928Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1131422399557847,
+				"StableID":   "nN6M5nYRq911CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2bbec591da434185a620f820e76467f9ee661eb42e66c91d5480a784ea8db47a",
+				"DiscoKey":   "discokey:eb1f29c9f9e4748cfdd944fa6db66e15612b4193659fa190b6bb1ad537508a0a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:45678",
+					"10.65.0.27:45678",
+					"172.17.0.1:45678",
+					"172.18.0.1:45678",
+					"172.19.0.1:45678",
+					"172.20.0.1:45678",
+					"172.21.0.1:45678",
+					"172.22.0.1:45678",
+					"172.23.0.1:45678",
+					"172.24.0.1:45678",
+					"172.25.0.1:45678",
+					"172.26.0.1:45678",
+					"172.27.0.1:45678"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:15:33.63530708Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6822175784289894,
+				"StableID":   "nHLdcPzmGv11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2a5a4d61c7a162a017f223e153a523dd627941f09524057fdc20fc72ad5a6752",
+				"DiscoKey":   "discokey:12a001687ba08dfa23c0821301fd782c7e7e42466757a6eddd545d468acaab23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49318",
+					"10.65.0.27:49318",
+					"172.17.0.1:49318",
+					"172.18.0.1:49318",
+					"172.19.0.1:49318",
+					"172.20.0.1:49318",
+					"172.21.0.1:49318",
+					"172.22.0.1:49318",
+					"172.23.0.1:49318",
+					"172.24.0.1:49318",
+					"172.25.0.1:49318",
+					"172.26.0.1:49318",
+					"172.27.0.1:49318"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:15:34.184201249Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2650053646205287,
+				"StableID":   "niGu27RDhM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8a11e5466f5dbb2f59ed9b3c17c12e9bdce9b29e5562b00826be58a7e4f1172f",
+				"KeyExpiry":  "2026-11-09T09:15:34Z",
+				"DiscoKey":   "discokey:344b88352870f93262b5717013e8e7b273bee1192ae370700600d635c0bc2813",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:36041",
+					"10.65.0.27:36041",
+					"172.17.0.1:36041",
+					"172.18.0.1:36041",
+					"172.19.0.1:36041",
+					"172.20.0.1:36041",
+					"172.21.0.1:36041",
+					"172.22.0.1:36041",
+					"172.23.0.1:36041",
+					"172.24.0.1:36041",
+					"172.25.0.1:36041",
+					"172.26.0.1:36041",
+					"172.27.0.1:36041"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:15:34.716718907Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1590577337976957,
+				"StableID":   "nGGVgdmNRD11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8fce3266003e6f1a594b71724e63e0ba888524dba3671b9e9716348491811308",
+				"KeyExpiry":  "2026-11-09T09:15:35Z",
+				"DiscoKey":   "discokey:6af7d5d07601570131533159eb2e764026847e1c5a45398fb6d0201b319a1c28",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39304",
+					"10.65.0.27:39304",
+					"172.17.0.1:39304",
+					"172.18.0.1:39304",
+					"172.19.0.1:39304",
+					"172.20.0.1:39304",
+					"172.21.0.1:39304",
+					"172.22.0.1:39304",
+					"172.23.0.1:39304",
+					"172.24.0.1:39304",
+					"172.25.0.1:39304",
+					"172.26.0.1:39304",
+					"172.27.0.1:39304"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:15:35.265754047Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6654845318017443,
+				"StableID":   "n6SkJ7Wzxt11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3bae111f6933443c9cf88a9f43e65f7c0a2e50da05842e1441d74d311170be57",
+				"KeyExpiry":  "2026-11-09T09:15:35Z",
+				"DiscoKey":   "discokey:34a3642936c383953f7b115a65371c8d1800e8a7e497cb38d6f069c805d13452",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49652",
+					"10.65.0.27:49652",
+					"172.17.0.1:49652",
+					"172.18.0.1:49652",
+					"172.19.0.1:49652",
+					"172.20.0.1:49652",
+					"172.21.0.1:49652",
+					"172.22.0.1:49652",
+					"172.23.0.1:49652",
+					"172.24.0.1:49652",
+					"172.25.0.1:49652",
+					"172.26.0.1:49652",
+					"172.27.0.1:49652"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:15:35.794196155Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8662839316658527": {
+				"ID":          8662839316658527,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3561426999795519,
+				"StableID":   "nvpQSbeyoU11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       3561426999795519,
+				"Key":        "nodekey:a795fafef9f4a89c46426029efe816a9395b5340862528a19d7b76e956788015",
+				"DiscoKey":   "discokey:63f4da40c2314bab916b10d166373c1fdb4325de44a2d554b8b59e4f0bebd609",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38290",
+					"10.65.0.27:38290",
+					"172.17.0.1:38290",
+					"172.18.0.1:38290",
+					"172.19.0.1:38290",
+					"172.20.0.1:38290",
+					"172.21.0.1:38290",
+					"172.22.0.1:38290",
+					"172.23.0.1:38290",
+					"172.24.0.1:38290",
+					"172.25.0.1:38290",
+					"172.26.0.1:38290",
+					"172.27.0.1:38290"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:15:32.046626874Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a795fafef9f4a89c46426029efe816a9395b5340862528a19d7b76e956788015",
+			"MachineKey": "mkey:b38e39e8749e7ff4055a89cb4b64ae1539a0135d92d3786eea1ddd8dfc487568",
+			"Peers": [{
+				"ID":         7162973470033938,
+				"StableID":   "n3yb6gA8wx11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f7a5f0bbcc8f893221307ac5995f0e10e6b477f2f3aa713d4e0735873002411a",
+				"DiscoKey":   "discokey:dfbbc8dde5ca6d475decf3c9ccab9f58ce5c964721bb5ba8ffa13d1caa329c55",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49088",
+					"10.65.0.27:49088",
+					"172.17.0.1:49088",
+					"172.18.0.1:49088",
+					"172.19.0.1:49088",
+					"172.20.0.1:49088",
+					"172.21.0.1:49088",
+					"172.22.0.1:49088",
+					"172.23.0.1:49088",
+					"172.24.0.1:49088",
+					"172.25.0.1:49088",
+					"172.26.0.1:49088",
+					"172.27.0.1:49088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:15:28.250506567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7414170185595947,
+				"StableID":   "nSQkfMgttz11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f9c3aff1e051a0dec2a83dd8d1b39ed1789c202962c875aa153aa11ab72ccd0f",
+				"DiscoKey":   "discokey:e7ee02e15b803c613066967d925358eeb23046916ad2bc472cad0ceb5c2e9b5b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34681",
+					"10.65.0.27:34681",
+					"172.17.0.1:34681",
+					"172.18.0.1:34681",
+					"172.19.0.1:34681",
+					"172.20.0.1:34681",
+					"172.21.0.1:34681",
+					"172.22.0.1:34681",
+					"172.23.0.1:34681",
+					"172.24.0.1:34681",
+					"172.25.0.1:34681",
+					"172.26.0.1:34681",
+					"172.27.0.1:34681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:15:28.75901772Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8662839316658527,
+				"StableID":   "n45zuk6ReA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:88c62ac6c9912b5b232d3e81a4b600df7acaf9d24f8d97cf4094e0dc4ab2f762",
+				"DiscoKey":   "discokey:782e6b13e8ed4968c00253cb16830c93ae318ddbd9da8462446eb83e6533e275",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36767",
+					"10.65.0.27:36767",
+					"172.17.0.1:36767",
+					"172.18.0.1:36767",
+					"172.19.0.1:36767",
+					"172.20.0.1:36767",
+					"172.21.0.1:36767",
+					"172.22.0.1:36767",
+					"172.23.0.1:36767",
+					"172.24.0.1:36767",
+					"172.25.0.1:36767",
+					"172.26.0.1:36767",
+					"172.27.0.1:36767"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:15:29.341591591Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3909366360514707,
+				"StableID":   "nLMPHfRZXX11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6472555e2b3141e1dc9e6c9cb88b41a235ad445a194fae30e2eb8e19be4e5c75",
+				"DiscoKey":   "discokey:710235f1fcd9e41e4a6a3e0dc616c9a89409482e906d27fa14f2bd725ef4f441",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34420",
+					"10.65.0.27:34420",
+					"172.17.0.1:34420",
+					"172.18.0.1:34420",
+					"172.19.0.1:34420",
+					"172.20.0.1:34420",
+					"172.21.0.1:34420",
+					"172.22.0.1:34420",
+					"172.23.0.1:34420",
+					"172.24.0.1:34420",
+					"172.25.0.1:34420",
+					"172.26.0.1:34420",
+					"172.27.0.1:34420"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:15:29.854217179Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7999044957232230,
+				"StableID":   "nuppR8MnT521CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bba3e3334366a763e4495df4c8f031992b8476967fdd62f1a9167807cc5d5d42",
+				"DiscoKey":   "discokey:5b1ea0d50c8cce5b99aa06600ee89f58050cb5d1b02b65f8878a0beda041f97c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38433",
+					"10.65.0.27:38433",
+					"172.17.0.1:38433",
+					"172.18.0.1:38433",
+					"172.19.0.1:38433",
+					"172.20.0.1:38433",
+					"172.21.0.1:38433",
+					"172.22.0.1:38433",
+					"172.23.0.1:38433",
+					"172.24.0.1:38433",
+					"172.25.0.1:38433",
+					"172.26.0.1:38433",
+					"172.27.0.1:38433"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:15:30.388337037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         925197816773822,
+				"StableID":   "nPyssuN2E811CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9ab6c9017ac7f2d534fa570cd6f5bde1f80ffd27a28fe78795d806ddb8c00b00",
+				"DiscoKey":   "discokey:98bdbbdc0b5dcb0deb1e48877bac8571d5bfcc6255cc1c217004830202c2857a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54250",
+					"10.65.0.27:54250",
+					"172.17.0.1:54250",
+					"172.18.0.1:54250",
+					"172.19.0.1:54250",
+					"172.20.0.1:54250",
+					"172.21.0.1:54250",
+					"172.22.0.1:54250",
+					"172.23.0.1:54250",
+					"172.24.0.1:54250",
+					"172.25.0.1:54250",
+					"172.26.0.1:54250",
+					"172.27.0.1:54250"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:15:30.938054577Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5200609388484747,
+				"StableID":   "nzJb12CNch11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5817a7f58d795ae00e48506a9fdb12d85e8b691a7051579bee5d2fb40ecfa83f",
+				"DiscoKey":   "discokey:82871a2ba027f3f57ed9a4b033b9d1cfd4e35b5322a56d6d2575a2a0aeb88037",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58248",
+					"10.65.0.27:58248",
+					"172.17.0.1:58248",
+					"172.18.0.1:58248",
+					"172.19.0.1:58248",
+					"172.20.0.1:58248",
+					"172.21.0.1:58248",
+					"172.22.0.1:58248",
+					"172.23.0.1:58248",
+					"172.24.0.1:58248",
+					"172.25.0.1:58248",
+					"172.26.0.1:58248",
+					"172.27.0.1:58248"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:15:31.474110403Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5801515494625177,
+				"StableID":   "nUWQuWyWJn11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d3ce6431fef8e3b4963aaa319c0c53dc97054e3042d73eecade99c5201a78d40",
+				"DiscoKey":   "discokey:55be253434b1b88c06b4325eb66fde5bf9f85a6633e376a58450b842824bcc75",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:60761",
+					"10.65.0.27:60761",
+					"172.17.0.1:60761",
+					"172.18.0.1:60761",
+					"172.19.0.1:60761",
+					"172.20.0.1:60761",
+					"172.21.0.1:60761",
+					"172.22.0.1:60761",
+					"172.23.0.1:60761",
+					"172.24.0.1:60761",
+					"172.25.0.1:60761",
+					"172.26.0.1:60761",
+					"172.27.0.1:60761"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:15:32.553760632Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4571778998843261,
+				"StableID":   "nCgko9tZhc11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6683546b33900d2c5093322416f2bc94fbc87b5f2d9e30fbb720cec2953a8927",
+				"DiscoKey":   "discokey:1e25ffa1290170bbe24651b7fd2bf6f293c7f3cc3f5f32fbd49ab6324cea5571",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:57830",
+					"10.65.0.27:57830",
+					"172.17.0.1:57830",
+					"172.18.0.1:57830",
+					"172.19.0.1:57830",
+					"172.20.0.1:57830",
+					"172.21.0.1:57830",
+					"172.22.0.1:57830",
+					"172.23.0.1:57830",
+					"172.24.0.1:57830",
+					"172.25.0.1:57830",
+					"172.26.0.1:57830",
+					"172.27.0.1:57830"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:15:33.114398928Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1131422399557847,
+				"StableID":   "nN6M5nYRq911CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2bbec591da434185a620f820e76467f9ee661eb42e66c91d5480a784ea8db47a",
+				"DiscoKey":   "discokey:eb1f29c9f9e4748cfdd944fa6db66e15612b4193659fa190b6bb1ad537508a0a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:45678",
+					"10.65.0.27:45678",
+					"172.17.0.1:45678",
+					"172.18.0.1:45678",
+					"172.19.0.1:45678",
+					"172.20.0.1:45678",
+					"172.21.0.1:45678",
+					"172.22.0.1:45678",
+					"172.23.0.1:45678",
+					"172.24.0.1:45678",
+					"172.25.0.1:45678",
+					"172.26.0.1:45678",
+					"172.27.0.1:45678"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:15:33.63530708Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6822175784289894,
+				"StableID":   "nHLdcPzmGv11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2a5a4d61c7a162a017f223e153a523dd627941f09524057fdc20fc72ad5a6752",
+				"DiscoKey":   "discokey:12a001687ba08dfa23c0821301fd782c7e7e42466757a6eddd545d468acaab23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49318",
+					"10.65.0.27:49318",
+					"172.17.0.1:49318",
+					"172.18.0.1:49318",
+					"172.19.0.1:49318",
+					"172.20.0.1:49318",
+					"172.21.0.1:49318",
+					"172.22.0.1:49318",
+					"172.23.0.1:49318",
+					"172.24.0.1:49318",
+					"172.25.0.1:49318",
+					"172.26.0.1:49318",
+					"172.27.0.1:49318"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:15:34.184201249Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2650053646205287,
+				"StableID":   "niGu27RDhM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8a11e5466f5dbb2f59ed9b3c17c12e9bdce9b29e5562b00826be58a7e4f1172f",
+				"KeyExpiry":  "2026-11-09T09:15:34Z",
+				"DiscoKey":   "discokey:344b88352870f93262b5717013e8e7b273bee1192ae370700600d635c0bc2813",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:36041",
+					"10.65.0.27:36041",
+					"172.17.0.1:36041",
+					"172.18.0.1:36041",
+					"172.19.0.1:36041",
+					"172.20.0.1:36041",
+					"172.21.0.1:36041",
+					"172.22.0.1:36041",
+					"172.23.0.1:36041",
+					"172.24.0.1:36041",
+					"172.25.0.1:36041",
+					"172.26.0.1:36041",
+					"172.27.0.1:36041"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:15:34.716718907Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1590577337976957,
+				"StableID":   "nGGVgdmNRD11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8fce3266003e6f1a594b71724e63e0ba888524dba3671b9e9716348491811308",
+				"KeyExpiry":  "2026-11-09T09:15:35Z",
+				"DiscoKey":   "discokey:6af7d5d07601570131533159eb2e764026847e1c5a45398fb6d0201b319a1c28",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39304",
+					"10.65.0.27:39304",
+					"172.17.0.1:39304",
+					"172.18.0.1:39304",
+					"172.19.0.1:39304",
+					"172.20.0.1:39304",
+					"172.21.0.1:39304",
+					"172.22.0.1:39304",
+					"172.23.0.1:39304",
+					"172.24.0.1:39304",
+					"172.25.0.1:39304",
+					"172.26.0.1:39304",
+					"172.27.0.1:39304"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:15:35.265754047Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6654845318017443,
+				"StableID":   "n6SkJ7Wzxt11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3bae111f6933443c9cf88a9f43e65f7c0a2e50da05842e1441d74d311170be57",
+				"KeyExpiry":  "2026-11-09T09:15:35Z",
+				"DiscoKey":   "discokey:34a3642936c383953f7b115a65371c8d1800e8a7e497cb38d6f069c805d13452",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49652",
+					"10.65.0.27:49652",
+					"172.17.0.1:49652",
+					"172.18.0.1:49652",
+					"172.19.0.1:49652",
+					"172.20.0.1:49652",
+					"172.21.0.1:49652",
+					"172.22.0.1:49652",
+					"172.23.0.1:49652",
+					"172.24.0.1:49652",
+					"172.25.0.1:49652",
+					"172.26.0.1:49652",
+					"172.27.0.1:49652"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:15:35.794196155Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3561426999795519": {
+				"ID":          3561426999795519,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2650053646205287,
+				"StableID":   "niGu27RDhM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8a11e5466f5dbb2f59ed9b3c17c12e9bdce9b29e5562b00826be58a7e4f1172f",
+				"KeyExpiry":  "2026-11-09T09:15:34Z",
+				"DiscoKey":   "discokey:344b88352870f93262b5717013e8e7b273bee1192ae370700600d635c0bc2813",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:36041",
+					"10.65.0.27:36041",
+					"172.17.0.1:36041",
+					"172.18.0.1:36041",
+					"172.19.0.1:36041",
+					"172.20.0.1:36041",
+					"172.21.0.1:36041",
+					"172.22.0.1:36041",
+					"172.23.0.1:36041",
+					"172.24.0.1:36041",
+					"172.25.0.1:36041",
+					"172.26.0.1:36041",
+					"172.27.0.1:36041"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:15:34.716718907Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8a11e5466f5dbb2f59ed9b3c17c12e9bdce9b29e5562b00826be58a7e4f1172f",
+			"MachineKey": "mkey:510616036d98adf4cc71bde62fc0affd20b48d7b9f6d8b8ba7a477284d522f6c",
+			"Peers": [{
+				"ID":         7162973470033938,
+				"StableID":   "n3yb6gA8wx11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f7a5f0bbcc8f893221307ac5995f0e10e6b477f2f3aa713d4e0735873002411a",
+				"DiscoKey":   "discokey:dfbbc8dde5ca6d475decf3c9ccab9f58ce5c964721bb5ba8ffa13d1caa329c55",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49088",
+					"10.65.0.27:49088",
+					"172.17.0.1:49088",
+					"172.18.0.1:49088",
+					"172.19.0.1:49088",
+					"172.20.0.1:49088",
+					"172.21.0.1:49088",
+					"172.22.0.1:49088",
+					"172.23.0.1:49088",
+					"172.24.0.1:49088",
+					"172.25.0.1:49088",
+					"172.26.0.1:49088",
+					"172.27.0.1:49088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:15:28.250506567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7414170185595947,
+				"StableID":   "nSQkfMgttz11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f9c3aff1e051a0dec2a83dd8d1b39ed1789c202962c875aa153aa11ab72ccd0f",
+				"DiscoKey":   "discokey:e7ee02e15b803c613066967d925358eeb23046916ad2bc472cad0ceb5c2e9b5b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34681",
+					"10.65.0.27:34681",
+					"172.17.0.1:34681",
+					"172.18.0.1:34681",
+					"172.19.0.1:34681",
+					"172.20.0.1:34681",
+					"172.21.0.1:34681",
+					"172.22.0.1:34681",
+					"172.23.0.1:34681",
+					"172.24.0.1:34681",
+					"172.25.0.1:34681",
+					"172.26.0.1:34681",
+					"172.27.0.1:34681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:15:28.75901772Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8662839316658527,
+				"StableID":   "n45zuk6ReA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:88c62ac6c9912b5b232d3e81a4b600df7acaf9d24f8d97cf4094e0dc4ab2f762",
+				"DiscoKey":   "discokey:782e6b13e8ed4968c00253cb16830c93ae318ddbd9da8462446eb83e6533e275",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36767",
+					"10.65.0.27:36767",
+					"172.17.0.1:36767",
+					"172.18.0.1:36767",
+					"172.19.0.1:36767",
+					"172.20.0.1:36767",
+					"172.21.0.1:36767",
+					"172.22.0.1:36767",
+					"172.23.0.1:36767",
+					"172.24.0.1:36767",
+					"172.25.0.1:36767",
+					"172.26.0.1:36767",
+					"172.27.0.1:36767"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:15:29.341591591Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3909366360514707,
+				"StableID":   "nLMPHfRZXX11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6472555e2b3141e1dc9e6c9cb88b41a235ad445a194fae30e2eb8e19be4e5c75",
+				"DiscoKey":   "discokey:710235f1fcd9e41e4a6a3e0dc616c9a89409482e906d27fa14f2bd725ef4f441",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34420",
+					"10.65.0.27:34420",
+					"172.17.0.1:34420",
+					"172.18.0.1:34420",
+					"172.19.0.1:34420",
+					"172.20.0.1:34420",
+					"172.21.0.1:34420",
+					"172.22.0.1:34420",
+					"172.23.0.1:34420",
+					"172.24.0.1:34420",
+					"172.25.0.1:34420",
+					"172.26.0.1:34420",
+					"172.27.0.1:34420"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:15:29.854217179Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7999044957232230,
+				"StableID":   "nuppR8MnT521CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bba3e3334366a763e4495df4c8f031992b8476967fdd62f1a9167807cc5d5d42",
+				"DiscoKey":   "discokey:5b1ea0d50c8cce5b99aa06600ee89f58050cb5d1b02b65f8878a0beda041f97c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38433",
+					"10.65.0.27:38433",
+					"172.17.0.1:38433",
+					"172.18.0.1:38433",
+					"172.19.0.1:38433",
+					"172.20.0.1:38433",
+					"172.21.0.1:38433",
+					"172.22.0.1:38433",
+					"172.23.0.1:38433",
+					"172.24.0.1:38433",
+					"172.25.0.1:38433",
+					"172.26.0.1:38433",
+					"172.27.0.1:38433"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:15:30.388337037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         925197816773822,
+				"StableID":   "nPyssuN2E811CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9ab6c9017ac7f2d534fa570cd6f5bde1f80ffd27a28fe78795d806ddb8c00b00",
+				"DiscoKey":   "discokey:98bdbbdc0b5dcb0deb1e48877bac8571d5bfcc6255cc1c217004830202c2857a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54250",
+					"10.65.0.27:54250",
+					"172.17.0.1:54250",
+					"172.18.0.1:54250",
+					"172.19.0.1:54250",
+					"172.20.0.1:54250",
+					"172.21.0.1:54250",
+					"172.22.0.1:54250",
+					"172.23.0.1:54250",
+					"172.24.0.1:54250",
+					"172.25.0.1:54250",
+					"172.26.0.1:54250",
+					"172.27.0.1:54250"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:15:30.938054577Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5200609388484747,
+				"StableID":   "nzJb12CNch11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5817a7f58d795ae00e48506a9fdb12d85e8b691a7051579bee5d2fb40ecfa83f",
+				"DiscoKey":   "discokey:82871a2ba027f3f57ed9a4b033b9d1cfd4e35b5322a56d6d2575a2a0aeb88037",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58248",
+					"10.65.0.27:58248",
+					"172.17.0.1:58248",
+					"172.18.0.1:58248",
+					"172.19.0.1:58248",
+					"172.20.0.1:58248",
+					"172.21.0.1:58248",
+					"172.22.0.1:58248",
+					"172.23.0.1:58248",
+					"172.24.0.1:58248",
+					"172.25.0.1:58248",
+					"172.26.0.1:58248",
+					"172.27.0.1:58248"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:15:31.474110403Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3561426999795519,
+				"StableID":   "nvpQSbeyoU11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a795fafef9f4a89c46426029efe816a9395b5340862528a19d7b76e956788015",
+				"DiscoKey":   "discokey:63f4da40c2314bab916b10d166373c1fdb4325de44a2d554b8b59e4f0bebd609",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38290",
+					"10.65.0.27:38290",
+					"172.17.0.1:38290",
+					"172.18.0.1:38290",
+					"172.19.0.1:38290",
+					"172.20.0.1:38290",
+					"172.21.0.1:38290",
+					"172.22.0.1:38290",
+					"172.23.0.1:38290",
+					"172.24.0.1:38290",
+					"172.25.0.1:38290",
+					"172.26.0.1:38290",
+					"172.27.0.1:38290"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:15:32.046626874Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5801515494625177,
+				"StableID":   "nUWQuWyWJn11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d3ce6431fef8e3b4963aaa319c0c53dc97054e3042d73eecade99c5201a78d40",
+				"DiscoKey":   "discokey:55be253434b1b88c06b4325eb66fde5bf9f85a6633e376a58450b842824bcc75",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:60761",
+					"10.65.0.27:60761",
+					"172.17.0.1:60761",
+					"172.18.0.1:60761",
+					"172.19.0.1:60761",
+					"172.20.0.1:60761",
+					"172.21.0.1:60761",
+					"172.22.0.1:60761",
+					"172.23.0.1:60761",
+					"172.24.0.1:60761",
+					"172.25.0.1:60761",
+					"172.26.0.1:60761",
+					"172.27.0.1:60761"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:15:32.553760632Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4571778998843261,
+				"StableID":   "nCgko9tZhc11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6683546b33900d2c5093322416f2bc94fbc87b5f2d9e30fbb720cec2953a8927",
+				"DiscoKey":   "discokey:1e25ffa1290170bbe24651b7fd2bf6f293c7f3cc3f5f32fbd49ab6324cea5571",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:57830",
+					"10.65.0.27:57830",
+					"172.17.0.1:57830",
+					"172.18.0.1:57830",
+					"172.19.0.1:57830",
+					"172.20.0.1:57830",
+					"172.21.0.1:57830",
+					"172.22.0.1:57830",
+					"172.23.0.1:57830",
+					"172.24.0.1:57830",
+					"172.25.0.1:57830",
+					"172.26.0.1:57830",
+					"172.27.0.1:57830"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:15:33.114398928Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1131422399557847,
+				"StableID":   "nN6M5nYRq911CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2bbec591da434185a620f820e76467f9ee661eb42e66c91d5480a784ea8db47a",
+				"DiscoKey":   "discokey:eb1f29c9f9e4748cfdd944fa6db66e15612b4193659fa190b6bb1ad537508a0a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:45678",
+					"10.65.0.27:45678",
+					"172.17.0.1:45678",
+					"172.18.0.1:45678",
+					"172.19.0.1:45678",
+					"172.20.0.1:45678",
+					"172.21.0.1:45678",
+					"172.22.0.1:45678",
+					"172.23.0.1:45678",
+					"172.24.0.1:45678",
+					"172.25.0.1:45678",
+					"172.26.0.1:45678",
+					"172.27.0.1:45678"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:15:33.63530708Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6822175784289894,
+				"StableID":   "nHLdcPzmGv11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2a5a4d61c7a162a017f223e153a523dd627941f09524057fdc20fc72ad5a6752",
+				"DiscoKey":   "discokey:12a001687ba08dfa23c0821301fd782c7e7e42466757a6eddd545d468acaab23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49318",
+					"10.65.0.27:49318",
+					"172.17.0.1:49318",
+					"172.18.0.1:49318",
+					"172.19.0.1:49318",
+					"172.20.0.1:49318",
+					"172.21.0.1:49318",
+					"172.22.0.1:49318",
+					"172.23.0.1:49318",
+					"172.24.0.1:49318",
+					"172.25.0.1:49318",
+					"172.26.0.1:49318",
+					"172.27.0.1:49318"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:15:34.184201249Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1590577337976957,
+				"StableID":   "nGGVgdmNRD11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8fce3266003e6f1a594b71724e63e0ba888524dba3671b9e9716348491811308",
+				"KeyExpiry":  "2026-11-09T09:15:35Z",
+				"DiscoKey":   "discokey:6af7d5d07601570131533159eb2e764026847e1c5a45398fb6d0201b319a1c28",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39304",
+					"10.65.0.27:39304",
+					"172.17.0.1:39304",
+					"172.18.0.1:39304",
+					"172.19.0.1:39304",
+					"172.20.0.1:39304",
+					"172.21.0.1:39304",
+					"172.22.0.1:39304",
+					"172.23.0.1:39304",
+					"172.24.0.1:39304",
+					"172.25.0.1:39304",
+					"172.26.0.1:39304",
+					"172.27.0.1:39304"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:15:35.265754047Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6654845318017443,
+				"StableID":   "n6SkJ7Wzxt11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3bae111f6933443c9cf88a9f43e65f7c0a2e50da05842e1441d74d311170be57",
+				"KeyExpiry":  "2026-11-09T09:15:35Z",
+				"DiscoKey":   "discokey:34a3642936c383953f7b115a65371c8d1800e8a7e497cb38d6f069c805d13452",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49652",
+					"10.65.0.27:49652",
+					"172.17.0.1:49652",
+					"172.18.0.1:49652",
+					"172.19.0.1:49652",
+					"172.20.0.1:49652",
+					"172.21.0.1:49652",
+					"172.22.0.1:49652",
+					"172.23.0.1:49652",
+					"172.24.0.1:49652",
+					"172.25.0.1:49652",
+					"172.26.0.1:49652",
+					"172.27.0.1:49652"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:15:35.794196155Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1131422399557847,
+				"StableID":   "nN6M5nYRq911CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1131422399557847,
+				"Key":        "nodekey:2bbec591da434185a620f820e76467f9ee661eb42e66c91d5480a784ea8db47a",
+				"DiscoKey":   "discokey:eb1f29c9f9e4748cfdd944fa6db66e15612b4193659fa190b6bb1ad537508a0a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:45678",
+					"10.65.0.27:45678",
+					"172.17.0.1:45678",
+					"172.18.0.1:45678",
+					"172.19.0.1:45678",
+					"172.20.0.1:45678",
+					"172.21.0.1:45678",
+					"172.22.0.1:45678",
+					"172.23.0.1:45678",
+					"172.24.0.1:45678",
+					"172.25.0.1:45678",
+					"172.26.0.1:45678",
+					"172.27.0.1:45678"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:15:33.63530708Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2bbec591da434185a620f820e76467f9ee661eb42e66c91d5480a784ea8db47a",
+			"MachineKey": "mkey:316687d626c4f12576618b1614f13f315acaeaca1642cfc826abbd84853bc62f",
+			"Peers": [{
+				"ID":         7162973470033938,
+				"StableID":   "n3yb6gA8wx11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f7a5f0bbcc8f893221307ac5995f0e10e6b477f2f3aa713d4e0735873002411a",
+				"DiscoKey":   "discokey:dfbbc8dde5ca6d475decf3c9ccab9f58ce5c964721bb5ba8ffa13d1caa329c55",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49088",
+					"10.65.0.27:49088",
+					"172.17.0.1:49088",
+					"172.18.0.1:49088",
+					"172.19.0.1:49088",
+					"172.20.0.1:49088",
+					"172.21.0.1:49088",
+					"172.22.0.1:49088",
+					"172.23.0.1:49088",
+					"172.24.0.1:49088",
+					"172.25.0.1:49088",
+					"172.26.0.1:49088",
+					"172.27.0.1:49088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:15:28.250506567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7414170185595947,
+				"StableID":   "nSQkfMgttz11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f9c3aff1e051a0dec2a83dd8d1b39ed1789c202962c875aa153aa11ab72ccd0f",
+				"DiscoKey":   "discokey:e7ee02e15b803c613066967d925358eeb23046916ad2bc472cad0ceb5c2e9b5b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34681",
+					"10.65.0.27:34681",
+					"172.17.0.1:34681",
+					"172.18.0.1:34681",
+					"172.19.0.1:34681",
+					"172.20.0.1:34681",
+					"172.21.0.1:34681",
+					"172.22.0.1:34681",
+					"172.23.0.1:34681",
+					"172.24.0.1:34681",
+					"172.25.0.1:34681",
+					"172.26.0.1:34681",
+					"172.27.0.1:34681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:15:28.75901772Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8662839316658527,
+				"StableID":   "n45zuk6ReA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:88c62ac6c9912b5b232d3e81a4b600df7acaf9d24f8d97cf4094e0dc4ab2f762",
+				"DiscoKey":   "discokey:782e6b13e8ed4968c00253cb16830c93ae318ddbd9da8462446eb83e6533e275",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36767",
+					"10.65.0.27:36767",
+					"172.17.0.1:36767",
+					"172.18.0.1:36767",
+					"172.19.0.1:36767",
+					"172.20.0.1:36767",
+					"172.21.0.1:36767",
+					"172.22.0.1:36767",
+					"172.23.0.1:36767",
+					"172.24.0.1:36767",
+					"172.25.0.1:36767",
+					"172.26.0.1:36767",
+					"172.27.0.1:36767"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:15:29.341591591Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3909366360514707,
+				"StableID":   "nLMPHfRZXX11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6472555e2b3141e1dc9e6c9cb88b41a235ad445a194fae30e2eb8e19be4e5c75",
+				"DiscoKey":   "discokey:710235f1fcd9e41e4a6a3e0dc616c9a89409482e906d27fa14f2bd725ef4f441",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34420",
+					"10.65.0.27:34420",
+					"172.17.0.1:34420",
+					"172.18.0.1:34420",
+					"172.19.0.1:34420",
+					"172.20.0.1:34420",
+					"172.21.0.1:34420",
+					"172.22.0.1:34420",
+					"172.23.0.1:34420",
+					"172.24.0.1:34420",
+					"172.25.0.1:34420",
+					"172.26.0.1:34420",
+					"172.27.0.1:34420"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:15:29.854217179Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7999044957232230,
+				"StableID":   "nuppR8MnT521CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bba3e3334366a763e4495df4c8f031992b8476967fdd62f1a9167807cc5d5d42",
+				"DiscoKey":   "discokey:5b1ea0d50c8cce5b99aa06600ee89f58050cb5d1b02b65f8878a0beda041f97c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38433",
+					"10.65.0.27:38433",
+					"172.17.0.1:38433",
+					"172.18.0.1:38433",
+					"172.19.0.1:38433",
+					"172.20.0.1:38433",
+					"172.21.0.1:38433",
+					"172.22.0.1:38433",
+					"172.23.0.1:38433",
+					"172.24.0.1:38433",
+					"172.25.0.1:38433",
+					"172.26.0.1:38433",
+					"172.27.0.1:38433"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:15:30.388337037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         925197816773822,
+				"StableID":   "nPyssuN2E811CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9ab6c9017ac7f2d534fa570cd6f5bde1f80ffd27a28fe78795d806ddb8c00b00",
+				"DiscoKey":   "discokey:98bdbbdc0b5dcb0deb1e48877bac8571d5bfcc6255cc1c217004830202c2857a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54250",
+					"10.65.0.27:54250",
+					"172.17.0.1:54250",
+					"172.18.0.1:54250",
+					"172.19.0.1:54250",
+					"172.20.0.1:54250",
+					"172.21.0.1:54250",
+					"172.22.0.1:54250",
+					"172.23.0.1:54250",
+					"172.24.0.1:54250",
+					"172.25.0.1:54250",
+					"172.26.0.1:54250",
+					"172.27.0.1:54250"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:15:30.938054577Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5200609388484747,
+				"StableID":   "nzJb12CNch11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5817a7f58d795ae00e48506a9fdb12d85e8b691a7051579bee5d2fb40ecfa83f",
+				"DiscoKey":   "discokey:82871a2ba027f3f57ed9a4b033b9d1cfd4e35b5322a56d6d2575a2a0aeb88037",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58248",
+					"10.65.0.27:58248",
+					"172.17.0.1:58248",
+					"172.18.0.1:58248",
+					"172.19.0.1:58248",
+					"172.20.0.1:58248",
+					"172.21.0.1:58248",
+					"172.22.0.1:58248",
+					"172.23.0.1:58248",
+					"172.24.0.1:58248",
+					"172.25.0.1:58248",
+					"172.26.0.1:58248",
+					"172.27.0.1:58248"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:15:31.474110403Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3561426999795519,
+				"StableID":   "nvpQSbeyoU11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a795fafef9f4a89c46426029efe816a9395b5340862528a19d7b76e956788015",
+				"DiscoKey":   "discokey:63f4da40c2314bab916b10d166373c1fdb4325de44a2d554b8b59e4f0bebd609",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38290",
+					"10.65.0.27:38290",
+					"172.17.0.1:38290",
+					"172.18.0.1:38290",
+					"172.19.0.1:38290",
+					"172.20.0.1:38290",
+					"172.21.0.1:38290",
+					"172.22.0.1:38290",
+					"172.23.0.1:38290",
+					"172.24.0.1:38290",
+					"172.25.0.1:38290",
+					"172.26.0.1:38290",
+					"172.27.0.1:38290"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:15:32.046626874Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5801515494625177,
+				"StableID":   "nUWQuWyWJn11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d3ce6431fef8e3b4963aaa319c0c53dc97054e3042d73eecade99c5201a78d40",
+				"DiscoKey":   "discokey:55be253434b1b88c06b4325eb66fde5bf9f85a6633e376a58450b842824bcc75",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:60761",
+					"10.65.0.27:60761",
+					"172.17.0.1:60761",
+					"172.18.0.1:60761",
+					"172.19.0.1:60761",
+					"172.20.0.1:60761",
+					"172.21.0.1:60761",
+					"172.22.0.1:60761",
+					"172.23.0.1:60761",
+					"172.24.0.1:60761",
+					"172.25.0.1:60761",
+					"172.26.0.1:60761",
+					"172.27.0.1:60761"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:15:32.553760632Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4571778998843261,
+				"StableID":   "nCgko9tZhc11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6683546b33900d2c5093322416f2bc94fbc87b5f2d9e30fbb720cec2953a8927",
+				"DiscoKey":   "discokey:1e25ffa1290170bbe24651b7fd2bf6f293c7f3cc3f5f32fbd49ab6324cea5571",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:57830",
+					"10.65.0.27:57830",
+					"172.17.0.1:57830",
+					"172.18.0.1:57830",
+					"172.19.0.1:57830",
+					"172.20.0.1:57830",
+					"172.21.0.1:57830",
+					"172.22.0.1:57830",
+					"172.23.0.1:57830",
+					"172.24.0.1:57830",
+					"172.25.0.1:57830",
+					"172.26.0.1:57830",
+					"172.27.0.1:57830"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:15:33.114398928Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6822175784289894,
+				"StableID":   "nHLdcPzmGv11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2a5a4d61c7a162a017f223e153a523dd627941f09524057fdc20fc72ad5a6752",
+				"DiscoKey":   "discokey:12a001687ba08dfa23c0821301fd782c7e7e42466757a6eddd545d468acaab23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49318",
+					"10.65.0.27:49318",
+					"172.17.0.1:49318",
+					"172.18.0.1:49318",
+					"172.19.0.1:49318",
+					"172.20.0.1:49318",
+					"172.21.0.1:49318",
+					"172.22.0.1:49318",
+					"172.23.0.1:49318",
+					"172.24.0.1:49318",
+					"172.25.0.1:49318",
+					"172.26.0.1:49318",
+					"172.27.0.1:49318"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:15:34.184201249Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2650053646205287,
+				"StableID":   "niGu27RDhM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8a11e5466f5dbb2f59ed9b3c17c12e9bdce9b29e5562b00826be58a7e4f1172f",
+				"KeyExpiry":  "2026-11-09T09:15:34Z",
+				"DiscoKey":   "discokey:344b88352870f93262b5717013e8e7b273bee1192ae370700600d635c0bc2813",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:36041",
+					"10.65.0.27:36041",
+					"172.17.0.1:36041",
+					"172.18.0.1:36041",
+					"172.19.0.1:36041",
+					"172.20.0.1:36041",
+					"172.21.0.1:36041",
+					"172.22.0.1:36041",
+					"172.23.0.1:36041",
+					"172.24.0.1:36041",
+					"172.25.0.1:36041",
+					"172.26.0.1:36041",
+					"172.27.0.1:36041"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:15:34.716718907Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1590577337976957,
+				"StableID":   "nGGVgdmNRD11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8fce3266003e6f1a594b71724e63e0ba888524dba3671b9e9716348491811308",
+				"KeyExpiry":  "2026-11-09T09:15:35Z",
+				"DiscoKey":   "discokey:6af7d5d07601570131533159eb2e764026847e1c5a45398fb6d0201b319a1c28",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39304",
+					"10.65.0.27:39304",
+					"172.17.0.1:39304",
+					"172.18.0.1:39304",
+					"172.19.0.1:39304",
+					"172.20.0.1:39304",
+					"172.21.0.1:39304",
+					"172.22.0.1:39304",
+					"172.23.0.1:39304",
+					"172.24.0.1:39304",
+					"172.25.0.1:39304",
+					"172.26.0.1:39304",
+					"172.27.0.1:39304"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:15:35.265754047Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6654845318017443,
+				"StableID":   "n6SkJ7Wzxt11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3bae111f6933443c9cf88a9f43e65f7c0a2e50da05842e1441d74d311170be57",
+				"KeyExpiry":  "2026-11-09T09:15:35Z",
+				"DiscoKey":   "discokey:34a3642936c383953f7b115a65371c8d1800e8a7e497cb38d6f069c805d13452",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49652",
+					"10.65.0.27:49652",
+					"172.17.0.1:49652",
+					"172.18.0.1:49652",
+					"172.19.0.1:49652",
+					"172.20.0.1:49652",
+					"172.21.0.1:49652",
+					"172.22.0.1:49652",
+					"172.23.0.1:49652",
+					"172.24.0.1:49652",
+					"172.25.0.1:49652",
+					"172.26.0.1:49652",
+					"172.27.0.1:49652"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:15:35.794196155Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1131422399557847": {
+				"ID":          1131422399557847,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7414170185595947,
+				"StableID":   "nSQkfMgttz11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       7414170185595947,
+				"Key":        "nodekey:f9c3aff1e051a0dec2a83dd8d1b39ed1789c202962c875aa153aa11ab72ccd0f",
+				"DiscoKey":   "discokey:e7ee02e15b803c613066967d925358eeb23046916ad2bc472cad0ceb5c2e9b5b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34681",
+					"10.65.0.27:34681",
+					"172.17.0.1:34681",
+					"172.18.0.1:34681",
+					"172.19.0.1:34681",
+					"172.20.0.1:34681",
+					"172.21.0.1:34681",
+					"172.22.0.1:34681",
+					"172.23.0.1:34681",
+					"172.24.0.1:34681",
+					"172.25.0.1:34681",
+					"172.26.0.1:34681",
+					"172.27.0.1:34681"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:15:28.75901772Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f9c3aff1e051a0dec2a83dd8d1b39ed1789c202962c875aa153aa11ab72ccd0f",
+			"MachineKey": "mkey:9b333d3973008fbf589998b810637161f66271805b5e964d9d72baf8de202051",
+			"Peers": [{
+				"ID":         7162973470033938,
+				"StableID":   "n3yb6gA8wx11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f7a5f0bbcc8f893221307ac5995f0e10e6b477f2f3aa713d4e0735873002411a",
+				"DiscoKey":   "discokey:dfbbc8dde5ca6d475decf3c9ccab9f58ce5c964721bb5ba8ffa13d1caa329c55",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49088",
+					"10.65.0.27:49088",
+					"172.17.0.1:49088",
+					"172.18.0.1:49088",
+					"172.19.0.1:49088",
+					"172.20.0.1:49088",
+					"172.21.0.1:49088",
+					"172.22.0.1:49088",
+					"172.23.0.1:49088",
+					"172.24.0.1:49088",
+					"172.25.0.1:49088",
+					"172.26.0.1:49088",
+					"172.27.0.1:49088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:15:28.250506567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8662839316658527,
+				"StableID":   "n45zuk6ReA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:88c62ac6c9912b5b232d3e81a4b600df7acaf9d24f8d97cf4094e0dc4ab2f762",
+				"DiscoKey":   "discokey:782e6b13e8ed4968c00253cb16830c93ae318ddbd9da8462446eb83e6533e275",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36767",
+					"10.65.0.27:36767",
+					"172.17.0.1:36767",
+					"172.18.0.1:36767",
+					"172.19.0.1:36767",
+					"172.20.0.1:36767",
+					"172.21.0.1:36767",
+					"172.22.0.1:36767",
+					"172.23.0.1:36767",
+					"172.24.0.1:36767",
+					"172.25.0.1:36767",
+					"172.26.0.1:36767",
+					"172.27.0.1:36767"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:15:29.341591591Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3909366360514707,
+				"StableID":   "nLMPHfRZXX11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6472555e2b3141e1dc9e6c9cb88b41a235ad445a194fae30e2eb8e19be4e5c75",
+				"DiscoKey":   "discokey:710235f1fcd9e41e4a6a3e0dc616c9a89409482e906d27fa14f2bd725ef4f441",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34420",
+					"10.65.0.27:34420",
+					"172.17.0.1:34420",
+					"172.18.0.1:34420",
+					"172.19.0.1:34420",
+					"172.20.0.1:34420",
+					"172.21.0.1:34420",
+					"172.22.0.1:34420",
+					"172.23.0.1:34420",
+					"172.24.0.1:34420",
+					"172.25.0.1:34420",
+					"172.26.0.1:34420",
+					"172.27.0.1:34420"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:15:29.854217179Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7999044957232230,
+				"StableID":   "nuppR8MnT521CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bba3e3334366a763e4495df4c8f031992b8476967fdd62f1a9167807cc5d5d42",
+				"DiscoKey":   "discokey:5b1ea0d50c8cce5b99aa06600ee89f58050cb5d1b02b65f8878a0beda041f97c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38433",
+					"10.65.0.27:38433",
+					"172.17.0.1:38433",
+					"172.18.0.1:38433",
+					"172.19.0.1:38433",
+					"172.20.0.1:38433",
+					"172.21.0.1:38433",
+					"172.22.0.1:38433",
+					"172.23.0.1:38433",
+					"172.24.0.1:38433",
+					"172.25.0.1:38433",
+					"172.26.0.1:38433",
+					"172.27.0.1:38433"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:15:30.388337037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         925197816773822,
+				"StableID":   "nPyssuN2E811CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9ab6c9017ac7f2d534fa570cd6f5bde1f80ffd27a28fe78795d806ddb8c00b00",
+				"DiscoKey":   "discokey:98bdbbdc0b5dcb0deb1e48877bac8571d5bfcc6255cc1c217004830202c2857a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54250",
+					"10.65.0.27:54250",
+					"172.17.0.1:54250",
+					"172.18.0.1:54250",
+					"172.19.0.1:54250",
+					"172.20.0.1:54250",
+					"172.21.0.1:54250",
+					"172.22.0.1:54250",
+					"172.23.0.1:54250",
+					"172.24.0.1:54250",
+					"172.25.0.1:54250",
+					"172.26.0.1:54250",
+					"172.27.0.1:54250"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:15:30.938054577Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5200609388484747,
+				"StableID":   "nzJb12CNch11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5817a7f58d795ae00e48506a9fdb12d85e8b691a7051579bee5d2fb40ecfa83f",
+				"DiscoKey":   "discokey:82871a2ba027f3f57ed9a4b033b9d1cfd4e35b5322a56d6d2575a2a0aeb88037",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58248",
+					"10.65.0.27:58248",
+					"172.17.0.1:58248",
+					"172.18.0.1:58248",
+					"172.19.0.1:58248",
+					"172.20.0.1:58248",
+					"172.21.0.1:58248",
+					"172.22.0.1:58248",
+					"172.23.0.1:58248",
+					"172.24.0.1:58248",
+					"172.25.0.1:58248",
+					"172.26.0.1:58248",
+					"172.27.0.1:58248"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:15:31.474110403Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3561426999795519,
+				"StableID":   "nvpQSbeyoU11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a795fafef9f4a89c46426029efe816a9395b5340862528a19d7b76e956788015",
+				"DiscoKey":   "discokey:63f4da40c2314bab916b10d166373c1fdb4325de44a2d554b8b59e4f0bebd609",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38290",
+					"10.65.0.27:38290",
+					"172.17.0.1:38290",
+					"172.18.0.1:38290",
+					"172.19.0.1:38290",
+					"172.20.0.1:38290",
+					"172.21.0.1:38290",
+					"172.22.0.1:38290",
+					"172.23.0.1:38290",
+					"172.24.0.1:38290",
+					"172.25.0.1:38290",
+					"172.26.0.1:38290",
+					"172.27.0.1:38290"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:15:32.046626874Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5801515494625177,
+				"StableID":   "nUWQuWyWJn11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d3ce6431fef8e3b4963aaa319c0c53dc97054e3042d73eecade99c5201a78d40",
+				"DiscoKey":   "discokey:55be253434b1b88c06b4325eb66fde5bf9f85a6633e376a58450b842824bcc75",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:60761",
+					"10.65.0.27:60761",
+					"172.17.0.1:60761",
+					"172.18.0.1:60761",
+					"172.19.0.1:60761",
+					"172.20.0.1:60761",
+					"172.21.0.1:60761",
+					"172.22.0.1:60761",
+					"172.23.0.1:60761",
+					"172.24.0.1:60761",
+					"172.25.0.1:60761",
+					"172.26.0.1:60761",
+					"172.27.0.1:60761"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:15:32.553760632Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4571778998843261,
+				"StableID":   "nCgko9tZhc11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6683546b33900d2c5093322416f2bc94fbc87b5f2d9e30fbb720cec2953a8927",
+				"DiscoKey":   "discokey:1e25ffa1290170bbe24651b7fd2bf6f293c7f3cc3f5f32fbd49ab6324cea5571",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:57830",
+					"10.65.0.27:57830",
+					"172.17.0.1:57830",
+					"172.18.0.1:57830",
+					"172.19.0.1:57830",
+					"172.20.0.1:57830",
+					"172.21.0.1:57830",
+					"172.22.0.1:57830",
+					"172.23.0.1:57830",
+					"172.24.0.1:57830",
+					"172.25.0.1:57830",
+					"172.26.0.1:57830",
+					"172.27.0.1:57830"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:15:33.114398928Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1131422399557847,
+				"StableID":   "nN6M5nYRq911CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2bbec591da434185a620f820e76467f9ee661eb42e66c91d5480a784ea8db47a",
+				"DiscoKey":   "discokey:eb1f29c9f9e4748cfdd944fa6db66e15612b4193659fa190b6bb1ad537508a0a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:45678",
+					"10.65.0.27:45678",
+					"172.17.0.1:45678",
+					"172.18.0.1:45678",
+					"172.19.0.1:45678",
+					"172.20.0.1:45678",
+					"172.21.0.1:45678",
+					"172.22.0.1:45678",
+					"172.23.0.1:45678",
+					"172.24.0.1:45678",
+					"172.25.0.1:45678",
+					"172.26.0.1:45678",
+					"172.27.0.1:45678"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:15:33.63530708Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6822175784289894,
+				"StableID":   "nHLdcPzmGv11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2a5a4d61c7a162a017f223e153a523dd627941f09524057fdc20fc72ad5a6752",
+				"DiscoKey":   "discokey:12a001687ba08dfa23c0821301fd782c7e7e42466757a6eddd545d468acaab23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49318",
+					"10.65.0.27:49318",
+					"172.17.0.1:49318",
+					"172.18.0.1:49318",
+					"172.19.0.1:49318",
+					"172.20.0.1:49318",
+					"172.21.0.1:49318",
+					"172.22.0.1:49318",
+					"172.23.0.1:49318",
+					"172.24.0.1:49318",
+					"172.25.0.1:49318",
+					"172.26.0.1:49318",
+					"172.27.0.1:49318"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:15:34.184201249Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2650053646205287,
+				"StableID":   "niGu27RDhM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8a11e5466f5dbb2f59ed9b3c17c12e9bdce9b29e5562b00826be58a7e4f1172f",
+				"KeyExpiry":  "2026-11-09T09:15:34Z",
+				"DiscoKey":   "discokey:344b88352870f93262b5717013e8e7b273bee1192ae370700600d635c0bc2813",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:36041",
+					"10.65.0.27:36041",
+					"172.17.0.1:36041",
+					"172.18.0.1:36041",
+					"172.19.0.1:36041",
+					"172.20.0.1:36041",
+					"172.21.0.1:36041",
+					"172.22.0.1:36041",
+					"172.23.0.1:36041",
+					"172.24.0.1:36041",
+					"172.25.0.1:36041",
+					"172.26.0.1:36041",
+					"172.27.0.1:36041"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:15:34.716718907Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1590577337976957,
+				"StableID":   "nGGVgdmNRD11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8fce3266003e6f1a594b71724e63e0ba888524dba3671b9e9716348491811308",
+				"KeyExpiry":  "2026-11-09T09:15:35Z",
+				"DiscoKey":   "discokey:6af7d5d07601570131533159eb2e764026847e1c5a45398fb6d0201b319a1c28",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39304",
+					"10.65.0.27:39304",
+					"172.17.0.1:39304",
+					"172.18.0.1:39304",
+					"172.19.0.1:39304",
+					"172.20.0.1:39304",
+					"172.21.0.1:39304",
+					"172.22.0.1:39304",
+					"172.23.0.1:39304",
+					"172.24.0.1:39304",
+					"172.25.0.1:39304",
+					"172.26.0.1:39304",
+					"172.27.0.1:39304"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:15:35.265754047Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6654845318017443,
+				"StableID":   "n6SkJ7Wzxt11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3bae111f6933443c9cf88a9f43e65f7c0a2e50da05842e1441d74d311170be57",
+				"KeyExpiry":  "2026-11-09T09:15:35Z",
+				"DiscoKey":   "discokey:34a3642936c383953f7b115a65371c8d1800e8a7e497cb38d6f069c805d13452",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49652",
+					"10.65.0.27:49652",
+					"172.17.0.1:49652",
+					"172.18.0.1:49652",
+					"172.19.0.1:49652",
+					"172.20.0.1:49652",
+					"172.21.0.1:49652",
+					"172.22.0.1:49652",
+					"172.23.0.1:49652",
+					"172.24.0.1:49652",
+					"172.25.0.1:49652",
+					"172.26.0.1:49652",
+					"172.27.0.1:49652"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:15:35.794196155Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7414170185595947": {
+				"ID":          7414170185595947,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7162973470033938,
+				"StableID":   "n3yb6gA8wx11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       7162973470033938,
+				"Key":        "nodekey:f7a5f0bbcc8f893221307ac5995f0e10e6b477f2f3aa713d4e0735873002411a",
+				"DiscoKey":   "discokey:dfbbc8dde5ca6d475decf3c9ccab9f58ce5c964721bb5ba8ffa13d1caa329c55",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49088",
+					"10.65.0.27:49088",
+					"172.17.0.1:49088",
+					"172.18.0.1:49088",
+					"172.19.0.1:49088",
+					"172.20.0.1:49088",
+					"172.21.0.1:49088",
+					"172.22.0.1:49088",
+					"172.23.0.1:49088",
+					"172.24.0.1:49088",
+					"172.25.0.1:49088",
+					"172.26.0.1:49088",
+					"172.27.0.1:49088"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:15:28.250506567Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f7a5f0bbcc8f893221307ac5995f0e10e6b477f2f3aa713d4e0735873002411a",
+			"MachineKey": "mkey:3d40acccd5ba2389696edc9bc74c159570bdedbc87a3958ad9a67ccb45cc9d65",
+			"Peers": [{
+				"ID":         7414170185595947,
+				"StableID":   "nSQkfMgttz11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f9c3aff1e051a0dec2a83dd8d1b39ed1789c202962c875aa153aa11ab72ccd0f",
+				"DiscoKey":   "discokey:e7ee02e15b803c613066967d925358eeb23046916ad2bc472cad0ceb5c2e9b5b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34681",
+					"10.65.0.27:34681",
+					"172.17.0.1:34681",
+					"172.18.0.1:34681",
+					"172.19.0.1:34681",
+					"172.20.0.1:34681",
+					"172.21.0.1:34681",
+					"172.22.0.1:34681",
+					"172.23.0.1:34681",
+					"172.24.0.1:34681",
+					"172.25.0.1:34681",
+					"172.26.0.1:34681",
+					"172.27.0.1:34681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:15:28.75901772Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8662839316658527,
+				"StableID":   "n45zuk6ReA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:88c62ac6c9912b5b232d3e81a4b600df7acaf9d24f8d97cf4094e0dc4ab2f762",
+				"DiscoKey":   "discokey:782e6b13e8ed4968c00253cb16830c93ae318ddbd9da8462446eb83e6533e275",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36767",
+					"10.65.0.27:36767",
+					"172.17.0.1:36767",
+					"172.18.0.1:36767",
+					"172.19.0.1:36767",
+					"172.20.0.1:36767",
+					"172.21.0.1:36767",
+					"172.22.0.1:36767",
+					"172.23.0.1:36767",
+					"172.24.0.1:36767",
+					"172.25.0.1:36767",
+					"172.26.0.1:36767",
+					"172.27.0.1:36767"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:15:29.341591591Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3909366360514707,
+				"StableID":   "nLMPHfRZXX11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6472555e2b3141e1dc9e6c9cb88b41a235ad445a194fae30e2eb8e19be4e5c75",
+				"DiscoKey":   "discokey:710235f1fcd9e41e4a6a3e0dc616c9a89409482e906d27fa14f2bd725ef4f441",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34420",
+					"10.65.0.27:34420",
+					"172.17.0.1:34420",
+					"172.18.0.1:34420",
+					"172.19.0.1:34420",
+					"172.20.0.1:34420",
+					"172.21.0.1:34420",
+					"172.22.0.1:34420",
+					"172.23.0.1:34420",
+					"172.24.0.1:34420",
+					"172.25.0.1:34420",
+					"172.26.0.1:34420",
+					"172.27.0.1:34420"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:15:29.854217179Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7999044957232230,
+				"StableID":   "nuppR8MnT521CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bba3e3334366a763e4495df4c8f031992b8476967fdd62f1a9167807cc5d5d42",
+				"DiscoKey":   "discokey:5b1ea0d50c8cce5b99aa06600ee89f58050cb5d1b02b65f8878a0beda041f97c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38433",
+					"10.65.0.27:38433",
+					"172.17.0.1:38433",
+					"172.18.0.1:38433",
+					"172.19.0.1:38433",
+					"172.20.0.1:38433",
+					"172.21.0.1:38433",
+					"172.22.0.1:38433",
+					"172.23.0.1:38433",
+					"172.24.0.1:38433",
+					"172.25.0.1:38433",
+					"172.26.0.1:38433",
+					"172.27.0.1:38433"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:15:30.388337037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         925197816773822,
+				"StableID":   "nPyssuN2E811CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9ab6c9017ac7f2d534fa570cd6f5bde1f80ffd27a28fe78795d806ddb8c00b00",
+				"DiscoKey":   "discokey:98bdbbdc0b5dcb0deb1e48877bac8571d5bfcc6255cc1c217004830202c2857a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54250",
+					"10.65.0.27:54250",
+					"172.17.0.1:54250",
+					"172.18.0.1:54250",
+					"172.19.0.1:54250",
+					"172.20.0.1:54250",
+					"172.21.0.1:54250",
+					"172.22.0.1:54250",
+					"172.23.0.1:54250",
+					"172.24.0.1:54250",
+					"172.25.0.1:54250",
+					"172.26.0.1:54250",
+					"172.27.0.1:54250"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:15:30.938054577Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5200609388484747,
+				"StableID":   "nzJb12CNch11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5817a7f58d795ae00e48506a9fdb12d85e8b691a7051579bee5d2fb40ecfa83f",
+				"DiscoKey":   "discokey:82871a2ba027f3f57ed9a4b033b9d1cfd4e35b5322a56d6d2575a2a0aeb88037",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58248",
+					"10.65.0.27:58248",
+					"172.17.0.1:58248",
+					"172.18.0.1:58248",
+					"172.19.0.1:58248",
+					"172.20.0.1:58248",
+					"172.21.0.1:58248",
+					"172.22.0.1:58248",
+					"172.23.0.1:58248",
+					"172.24.0.1:58248",
+					"172.25.0.1:58248",
+					"172.26.0.1:58248",
+					"172.27.0.1:58248"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:15:31.474110403Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3561426999795519,
+				"StableID":   "nvpQSbeyoU11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a795fafef9f4a89c46426029efe816a9395b5340862528a19d7b76e956788015",
+				"DiscoKey":   "discokey:63f4da40c2314bab916b10d166373c1fdb4325de44a2d554b8b59e4f0bebd609",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38290",
+					"10.65.0.27:38290",
+					"172.17.0.1:38290",
+					"172.18.0.1:38290",
+					"172.19.0.1:38290",
+					"172.20.0.1:38290",
+					"172.21.0.1:38290",
+					"172.22.0.1:38290",
+					"172.23.0.1:38290",
+					"172.24.0.1:38290",
+					"172.25.0.1:38290",
+					"172.26.0.1:38290",
+					"172.27.0.1:38290"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:15:32.046626874Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5801515494625177,
+				"StableID":   "nUWQuWyWJn11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d3ce6431fef8e3b4963aaa319c0c53dc97054e3042d73eecade99c5201a78d40",
+				"DiscoKey":   "discokey:55be253434b1b88c06b4325eb66fde5bf9f85a6633e376a58450b842824bcc75",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:60761",
+					"10.65.0.27:60761",
+					"172.17.0.1:60761",
+					"172.18.0.1:60761",
+					"172.19.0.1:60761",
+					"172.20.0.1:60761",
+					"172.21.0.1:60761",
+					"172.22.0.1:60761",
+					"172.23.0.1:60761",
+					"172.24.0.1:60761",
+					"172.25.0.1:60761",
+					"172.26.0.1:60761",
+					"172.27.0.1:60761"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:15:32.553760632Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4571778998843261,
+				"StableID":   "nCgko9tZhc11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6683546b33900d2c5093322416f2bc94fbc87b5f2d9e30fbb720cec2953a8927",
+				"DiscoKey":   "discokey:1e25ffa1290170bbe24651b7fd2bf6f293c7f3cc3f5f32fbd49ab6324cea5571",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:57830",
+					"10.65.0.27:57830",
+					"172.17.0.1:57830",
+					"172.18.0.1:57830",
+					"172.19.0.1:57830",
+					"172.20.0.1:57830",
+					"172.21.0.1:57830",
+					"172.22.0.1:57830",
+					"172.23.0.1:57830",
+					"172.24.0.1:57830",
+					"172.25.0.1:57830",
+					"172.26.0.1:57830",
+					"172.27.0.1:57830"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:15:33.114398928Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1131422399557847,
+				"StableID":   "nN6M5nYRq911CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2bbec591da434185a620f820e76467f9ee661eb42e66c91d5480a784ea8db47a",
+				"DiscoKey":   "discokey:eb1f29c9f9e4748cfdd944fa6db66e15612b4193659fa190b6bb1ad537508a0a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:45678",
+					"10.65.0.27:45678",
+					"172.17.0.1:45678",
+					"172.18.0.1:45678",
+					"172.19.0.1:45678",
+					"172.20.0.1:45678",
+					"172.21.0.1:45678",
+					"172.22.0.1:45678",
+					"172.23.0.1:45678",
+					"172.24.0.1:45678",
+					"172.25.0.1:45678",
+					"172.26.0.1:45678",
+					"172.27.0.1:45678"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:15:33.63530708Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6822175784289894,
+				"StableID":   "nHLdcPzmGv11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2a5a4d61c7a162a017f223e153a523dd627941f09524057fdc20fc72ad5a6752",
+				"DiscoKey":   "discokey:12a001687ba08dfa23c0821301fd782c7e7e42466757a6eddd545d468acaab23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49318",
+					"10.65.0.27:49318",
+					"172.17.0.1:49318",
+					"172.18.0.1:49318",
+					"172.19.0.1:49318",
+					"172.20.0.1:49318",
+					"172.21.0.1:49318",
+					"172.22.0.1:49318",
+					"172.23.0.1:49318",
+					"172.24.0.1:49318",
+					"172.25.0.1:49318",
+					"172.26.0.1:49318",
+					"172.27.0.1:49318"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:15:34.184201249Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2650053646205287,
+				"StableID":   "niGu27RDhM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8a11e5466f5dbb2f59ed9b3c17c12e9bdce9b29e5562b00826be58a7e4f1172f",
+				"KeyExpiry":  "2026-11-09T09:15:34Z",
+				"DiscoKey":   "discokey:344b88352870f93262b5717013e8e7b273bee1192ae370700600d635c0bc2813",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:36041",
+					"10.65.0.27:36041",
+					"172.17.0.1:36041",
+					"172.18.0.1:36041",
+					"172.19.0.1:36041",
+					"172.20.0.1:36041",
+					"172.21.0.1:36041",
+					"172.22.0.1:36041",
+					"172.23.0.1:36041",
+					"172.24.0.1:36041",
+					"172.25.0.1:36041",
+					"172.26.0.1:36041",
+					"172.27.0.1:36041"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:15:34.716718907Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1590577337976957,
+				"StableID":   "nGGVgdmNRD11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8fce3266003e6f1a594b71724e63e0ba888524dba3671b9e9716348491811308",
+				"KeyExpiry":  "2026-11-09T09:15:35Z",
+				"DiscoKey":   "discokey:6af7d5d07601570131533159eb2e764026847e1c5a45398fb6d0201b319a1c28",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39304",
+					"10.65.0.27:39304",
+					"172.17.0.1:39304",
+					"172.18.0.1:39304",
+					"172.19.0.1:39304",
+					"172.20.0.1:39304",
+					"172.21.0.1:39304",
+					"172.22.0.1:39304",
+					"172.23.0.1:39304",
+					"172.24.0.1:39304",
+					"172.25.0.1:39304",
+					"172.26.0.1:39304",
+					"172.27.0.1:39304"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:15:35.265754047Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6654845318017443,
+				"StableID":   "n6SkJ7Wzxt11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3bae111f6933443c9cf88a9f43e65f7c0a2e50da05842e1441d74d311170be57",
+				"KeyExpiry":  "2026-11-09T09:15:35Z",
+				"DiscoKey":   "discokey:34a3642936c383953f7b115a65371c8d1800e8a7e497cb38d6f069c805d13452",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49652",
+					"10.65.0.27:49652",
+					"172.17.0.1:49652",
+					"172.18.0.1:49652",
+					"172.19.0.1:49652",
+					"172.20.0.1:49652",
+					"172.21.0.1:49652",
+					"172.22.0.1:49652",
+					"172.23.0.1:49652",
+					"172.24.0.1:49652",
+					"172.25.0.1:49652",
+					"172.26.0.1:49652",
+					"172.27.0.1:49652"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:15:35.794196155Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7162973470033938": {
+				"ID":          7162973470033938,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7999044957232230,
+				"StableID":   "nuppR8MnT521CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       7999044957232230,
+				"Key":        "nodekey:bba3e3334366a763e4495df4c8f031992b8476967fdd62f1a9167807cc5d5d42",
+				"DiscoKey":   "discokey:5b1ea0d50c8cce5b99aa06600ee89f58050cb5d1b02b65f8878a0beda041f97c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38433",
+					"10.65.0.27:38433",
+					"172.17.0.1:38433",
+					"172.18.0.1:38433",
+					"172.19.0.1:38433",
+					"172.20.0.1:38433",
+					"172.21.0.1:38433",
+					"172.22.0.1:38433",
+					"172.23.0.1:38433",
+					"172.24.0.1:38433",
+					"172.25.0.1:38433",
+					"172.26.0.1:38433",
+					"172.27.0.1:38433"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:15:30.388337037Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:bba3e3334366a763e4495df4c8f031992b8476967fdd62f1a9167807cc5d5d42",
+			"MachineKey": "mkey:2d000c931deac78ceac5655e6ca7192fb1279fc8500cd92734e19049c80e0c13",
+			"Peers": [{
+				"ID":         7162973470033938,
+				"StableID":   "n3yb6gA8wx11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f7a5f0bbcc8f893221307ac5995f0e10e6b477f2f3aa713d4e0735873002411a",
+				"DiscoKey":   "discokey:dfbbc8dde5ca6d475decf3c9ccab9f58ce5c964721bb5ba8ffa13d1caa329c55",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49088",
+					"10.65.0.27:49088",
+					"172.17.0.1:49088",
+					"172.18.0.1:49088",
+					"172.19.0.1:49088",
+					"172.20.0.1:49088",
+					"172.21.0.1:49088",
+					"172.22.0.1:49088",
+					"172.23.0.1:49088",
+					"172.24.0.1:49088",
+					"172.25.0.1:49088",
+					"172.26.0.1:49088",
+					"172.27.0.1:49088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:15:28.250506567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7414170185595947,
+				"StableID":   "nSQkfMgttz11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f9c3aff1e051a0dec2a83dd8d1b39ed1789c202962c875aa153aa11ab72ccd0f",
+				"DiscoKey":   "discokey:e7ee02e15b803c613066967d925358eeb23046916ad2bc472cad0ceb5c2e9b5b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34681",
+					"10.65.0.27:34681",
+					"172.17.0.1:34681",
+					"172.18.0.1:34681",
+					"172.19.0.1:34681",
+					"172.20.0.1:34681",
+					"172.21.0.1:34681",
+					"172.22.0.1:34681",
+					"172.23.0.1:34681",
+					"172.24.0.1:34681",
+					"172.25.0.1:34681",
+					"172.26.0.1:34681",
+					"172.27.0.1:34681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:15:28.75901772Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8662839316658527,
+				"StableID":   "n45zuk6ReA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:88c62ac6c9912b5b232d3e81a4b600df7acaf9d24f8d97cf4094e0dc4ab2f762",
+				"DiscoKey":   "discokey:782e6b13e8ed4968c00253cb16830c93ae318ddbd9da8462446eb83e6533e275",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36767",
+					"10.65.0.27:36767",
+					"172.17.0.1:36767",
+					"172.18.0.1:36767",
+					"172.19.0.1:36767",
+					"172.20.0.1:36767",
+					"172.21.0.1:36767",
+					"172.22.0.1:36767",
+					"172.23.0.1:36767",
+					"172.24.0.1:36767",
+					"172.25.0.1:36767",
+					"172.26.0.1:36767",
+					"172.27.0.1:36767"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:15:29.341591591Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3909366360514707,
+				"StableID":   "nLMPHfRZXX11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6472555e2b3141e1dc9e6c9cb88b41a235ad445a194fae30e2eb8e19be4e5c75",
+				"DiscoKey":   "discokey:710235f1fcd9e41e4a6a3e0dc616c9a89409482e906d27fa14f2bd725ef4f441",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34420",
+					"10.65.0.27:34420",
+					"172.17.0.1:34420",
+					"172.18.0.1:34420",
+					"172.19.0.1:34420",
+					"172.20.0.1:34420",
+					"172.21.0.1:34420",
+					"172.22.0.1:34420",
+					"172.23.0.1:34420",
+					"172.24.0.1:34420",
+					"172.25.0.1:34420",
+					"172.26.0.1:34420",
+					"172.27.0.1:34420"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:15:29.854217179Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         925197816773822,
+				"StableID":   "nPyssuN2E811CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9ab6c9017ac7f2d534fa570cd6f5bde1f80ffd27a28fe78795d806ddb8c00b00",
+				"DiscoKey":   "discokey:98bdbbdc0b5dcb0deb1e48877bac8571d5bfcc6255cc1c217004830202c2857a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54250",
+					"10.65.0.27:54250",
+					"172.17.0.1:54250",
+					"172.18.0.1:54250",
+					"172.19.0.1:54250",
+					"172.20.0.1:54250",
+					"172.21.0.1:54250",
+					"172.22.0.1:54250",
+					"172.23.0.1:54250",
+					"172.24.0.1:54250",
+					"172.25.0.1:54250",
+					"172.26.0.1:54250",
+					"172.27.0.1:54250"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:15:30.938054577Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5200609388484747,
+				"StableID":   "nzJb12CNch11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5817a7f58d795ae00e48506a9fdb12d85e8b691a7051579bee5d2fb40ecfa83f",
+				"DiscoKey":   "discokey:82871a2ba027f3f57ed9a4b033b9d1cfd4e35b5322a56d6d2575a2a0aeb88037",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58248",
+					"10.65.0.27:58248",
+					"172.17.0.1:58248",
+					"172.18.0.1:58248",
+					"172.19.0.1:58248",
+					"172.20.0.1:58248",
+					"172.21.0.1:58248",
+					"172.22.0.1:58248",
+					"172.23.0.1:58248",
+					"172.24.0.1:58248",
+					"172.25.0.1:58248",
+					"172.26.0.1:58248",
+					"172.27.0.1:58248"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:15:31.474110403Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3561426999795519,
+				"StableID":   "nvpQSbeyoU11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a795fafef9f4a89c46426029efe816a9395b5340862528a19d7b76e956788015",
+				"DiscoKey":   "discokey:63f4da40c2314bab916b10d166373c1fdb4325de44a2d554b8b59e4f0bebd609",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38290",
+					"10.65.0.27:38290",
+					"172.17.0.1:38290",
+					"172.18.0.1:38290",
+					"172.19.0.1:38290",
+					"172.20.0.1:38290",
+					"172.21.0.1:38290",
+					"172.22.0.1:38290",
+					"172.23.0.1:38290",
+					"172.24.0.1:38290",
+					"172.25.0.1:38290",
+					"172.26.0.1:38290",
+					"172.27.0.1:38290"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:15:32.046626874Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5801515494625177,
+				"StableID":   "nUWQuWyWJn11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d3ce6431fef8e3b4963aaa319c0c53dc97054e3042d73eecade99c5201a78d40",
+				"DiscoKey":   "discokey:55be253434b1b88c06b4325eb66fde5bf9f85a6633e376a58450b842824bcc75",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:60761",
+					"10.65.0.27:60761",
+					"172.17.0.1:60761",
+					"172.18.0.1:60761",
+					"172.19.0.1:60761",
+					"172.20.0.1:60761",
+					"172.21.0.1:60761",
+					"172.22.0.1:60761",
+					"172.23.0.1:60761",
+					"172.24.0.1:60761",
+					"172.25.0.1:60761",
+					"172.26.0.1:60761",
+					"172.27.0.1:60761"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:15:32.553760632Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4571778998843261,
+				"StableID":   "nCgko9tZhc11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6683546b33900d2c5093322416f2bc94fbc87b5f2d9e30fbb720cec2953a8927",
+				"DiscoKey":   "discokey:1e25ffa1290170bbe24651b7fd2bf6f293c7f3cc3f5f32fbd49ab6324cea5571",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:57830",
+					"10.65.0.27:57830",
+					"172.17.0.1:57830",
+					"172.18.0.1:57830",
+					"172.19.0.1:57830",
+					"172.20.0.1:57830",
+					"172.21.0.1:57830",
+					"172.22.0.1:57830",
+					"172.23.0.1:57830",
+					"172.24.0.1:57830",
+					"172.25.0.1:57830",
+					"172.26.0.1:57830",
+					"172.27.0.1:57830"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:15:33.114398928Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1131422399557847,
+				"StableID":   "nN6M5nYRq911CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2bbec591da434185a620f820e76467f9ee661eb42e66c91d5480a784ea8db47a",
+				"DiscoKey":   "discokey:eb1f29c9f9e4748cfdd944fa6db66e15612b4193659fa190b6bb1ad537508a0a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:45678",
+					"10.65.0.27:45678",
+					"172.17.0.1:45678",
+					"172.18.0.1:45678",
+					"172.19.0.1:45678",
+					"172.20.0.1:45678",
+					"172.21.0.1:45678",
+					"172.22.0.1:45678",
+					"172.23.0.1:45678",
+					"172.24.0.1:45678",
+					"172.25.0.1:45678",
+					"172.26.0.1:45678",
+					"172.27.0.1:45678"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:15:33.63530708Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6822175784289894,
+				"StableID":   "nHLdcPzmGv11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2a5a4d61c7a162a017f223e153a523dd627941f09524057fdc20fc72ad5a6752",
+				"DiscoKey":   "discokey:12a001687ba08dfa23c0821301fd782c7e7e42466757a6eddd545d468acaab23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49318",
+					"10.65.0.27:49318",
+					"172.17.0.1:49318",
+					"172.18.0.1:49318",
+					"172.19.0.1:49318",
+					"172.20.0.1:49318",
+					"172.21.0.1:49318",
+					"172.22.0.1:49318",
+					"172.23.0.1:49318",
+					"172.24.0.1:49318",
+					"172.25.0.1:49318",
+					"172.26.0.1:49318",
+					"172.27.0.1:49318"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:15:34.184201249Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2650053646205287,
+				"StableID":   "niGu27RDhM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8a11e5466f5dbb2f59ed9b3c17c12e9bdce9b29e5562b00826be58a7e4f1172f",
+				"KeyExpiry":  "2026-11-09T09:15:34Z",
+				"DiscoKey":   "discokey:344b88352870f93262b5717013e8e7b273bee1192ae370700600d635c0bc2813",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:36041",
+					"10.65.0.27:36041",
+					"172.17.0.1:36041",
+					"172.18.0.1:36041",
+					"172.19.0.1:36041",
+					"172.20.0.1:36041",
+					"172.21.0.1:36041",
+					"172.22.0.1:36041",
+					"172.23.0.1:36041",
+					"172.24.0.1:36041",
+					"172.25.0.1:36041",
+					"172.26.0.1:36041",
+					"172.27.0.1:36041"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:15:34.716718907Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1590577337976957,
+				"StableID":   "nGGVgdmNRD11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8fce3266003e6f1a594b71724e63e0ba888524dba3671b9e9716348491811308",
+				"KeyExpiry":  "2026-11-09T09:15:35Z",
+				"DiscoKey":   "discokey:6af7d5d07601570131533159eb2e764026847e1c5a45398fb6d0201b319a1c28",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39304",
+					"10.65.0.27:39304",
+					"172.17.0.1:39304",
+					"172.18.0.1:39304",
+					"172.19.0.1:39304",
+					"172.20.0.1:39304",
+					"172.21.0.1:39304",
+					"172.22.0.1:39304",
+					"172.23.0.1:39304",
+					"172.24.0.1:39304",
+					"172.25.0.1:39304",
+					"172.26.0.1:39304",
+					"172.27.0.1:39304"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:15:35.265754047Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6654845318017443,
+				"StableID":   "n6SkJ7Wzxt11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3bae111f6933443c9cf88a9f43e65f7c0a2e50da05842e1441d74d311170be57",
+				"KeyExpiry":  "2026-11-09T09:15:35Z",
+				"DiscoKey":   "discokey:34a3642936c383953f7b115a65371c8d1800e8a7e497cb38d6f069c805d13452",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49652",
+					"10.65.0.27:49652",
+					"172.17.0.1:49652",
+					"172.18.0.1:49652",
+					"172.19.0.1:49652",
+					"172.20.0.1:49652",
+					"172.21.0.1:49652",
+					"172.22.0.1:49652",
+					"172.23.0.1:49652",
+					"172.24.0.1:49652",
+					"172.25.0.1:49652",
+					"172.26.0.1:49652",
+					"172.27.0.1:49652"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:15:35.794196155Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7999044957232230": {
+				"ID":          7999044957232230,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3909366360514707,
+				"StableID":   "nLMPHfRZXX11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       3909366360514707,
+				"Key":        "nodekey:6472555e2b3141e1dc9e6c9cb88b41a235ad445a194fae30e2eb8e19be4e5c75",
+				"DiscoKey":   "discokey:710235f1fcd9e41e4a6a3e0dc616c9a89409482e906d27fa14f2bd725ef4f441",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34420",
+					"10.65.0.27:34420",
+					"172.17.0.1:34420",
+					"172.18.0.1:34420",
+					"172.19.0.1:34420",
+					"172.20.0.1:34420",
+					"172.21.0.1:34420",
+					"172.22.0.1:34420",
+					"172.23.0.1:34420",
+					"172.24.0.1:34420",
+					"172.25.0.1:34420",
+					"172.26.0.1:34420",
+					"172.27.0.1:34420"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:15:29.854217179Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6472555e2b3141e1dc9e6c9cb88b41a235ad445a194fae30e2eb8e19be4e5c75",
+			"MachineKey": "mkey:621847b201767b8959a3895c2cfd4b4ae7d57faa57ce14993208420aae80d31f",
+			"Peers": [{
+				"ID":         7162973470033938,
+				"StableID":   "n3yb6gA8wx11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f7a5f0bbcc8f893221307ac5995f0e10e6b477f2f3aa713d4e0735873002411a",
+				"DiscoKey":   "discokey:dfbbc8dde5ca6d475decf3c9ccab9f58ce5c964721bb5ba8ffa13d1caa329c55",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49088",
+					"10.65.0.27:49088",
+					"172.17.0.1:49088",
+					"172.18.0.1:49088",
+					"172.19.0.1:49088",
+					"172.20.0.1:49088",
+					"172.21.0.1:49088",
+					"172.22.0.1:49088",
+					"172.23.0.1:49088",
+					"172.24.0.1:49088",
+					"172.25.0.1:49088",
+					"172.26.0.1:49088",
+					"172.27.0.1:49088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:15:28.250506567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7414170185595947,
+				"StableID":   "nSQkfMgttz11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f9c3aff1e051a0dec2a83dd8d1b39ed1789c202962c875aa153aa11ab72ccd0f",
+				"DiscoKey":   "discokey:e7ee02e15b803c613066967d925358eeb23046916ad2bc472cad0ceb5c2e9b5b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34681",
+					"10.65.0.27:34681",
+					"172.17.0.1:34681",
+					"172.18.0.1:34681",
+					"172.19.0.1:34681",
+					"172.20.0.1:34681",
+					"172.21.0.1:34681",
+					"172.22.0.1:34681",
+					"172.23.0.1:34681",
+					"172.24.0.1:34681",
+					"172.25.0.1:34681",
+					"172.26.0.1:34681",
+					"172.27.0.1:34681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:15:28.75901772Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8662839316658527,
+				"StableID":   "n45zuk6ReA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:88c62ac6c9912b5b232d3e81a4b600df7acaf9d24f8d97cf4094e0dc4ab2f762",
+				"DiscoKey":   "discokey:782e6b13e8ed4968c00253cb16830c93ae318ddbd9da8462446eb83e6533e275",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36767",
+					"10.65.0.27:36767",
+					"172.17.0.1:36767",
+					"172.18.0.1:36767",
+					"172.19.0.1:36767",
+					"172.20.0.1:36767",
+					"172.21.0.1:36767",
+					"172.22.0.1:36767",
+					"172.23.0.1:36767",
+					"172.24.0.1:36767",
+					"172.25.0.1:36767",
+					"172.26.0.1:36767",
+					"172.27.0.1:36767"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:15:29.341591591Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7999044957232230,
+				"StableID":   "nuppR8MnT521CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bba3e3334366a763e4495df4c8f031992b8476967fdd62f1a9167807cc5d5d42",
+				"DiscoKey":   "discokey:5b1ea0d50c8cce5b99aa06600ee89f58050cb5d1b02b65f8878a0beda041f97c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38433",
+					"10.65.0.27:38433",
+					"172.17.0.1:38433",
+					"172.18.0.1:38433",
+					"172.19.0.1:38433",
+					"172.20.0.1:38433",
+					"172.21.0.1:38433",
+					"172.22.0.1:38433",
+					"172.23.0.1:38433",
+					"172.24.0.1:38433",
+					"172.25.0.1:38433",
+					"172.26.0.1:38433",
+					"172.27.0.1:38433"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:15:30.388337037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         925197816773822,
+				"StableID":   "nPyssuN2E811CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9ab6c9017ac7f2d534fa570cd6f5bde1f80ffd27a28fe78795d806ddb8c00b00",
+				"DiscoKey":   "discokey:98bdbbdc0b5dcb0deb1e48877bac8571d5bfcc6255cc1c217004830202c2857a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54250",
+					"10.65.0.27:54250",
+					"172.17.0.1:54250",
+					"172.18.0.1:54250",
+					"172.19.0.1:54250",
+					"172.20.0.1:54250",
+					"172.21.0.1:54250",
+					"172.22.0.1:54250",
+					"172.23.0.1:54250",
+					"172.24.0.1:54250",
+					"172.25.0.1:54250",
+					"172.26.0.1:54250",
+					"172.27.0.1:54250"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:15:30.938054577Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5200609388484747,
+				"StableID":   "nzJb12CNch11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5817a7f58d795ae00e48506a9fdb12d85e8b691a7051579bee5d2fb40ecfa83f",
+				"DiscoKey":   "discokey:82871a2ba027f3f57ed9a4b033b9d1cfd4e35b5322a56d6d2575a2a0aeb88037",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58248",
+					"10.65.0.27:58248",
+					"172.17.0.1:58248",
+					"172.18.0.1:58248",
+					"172.19.0.1:58248",
+					"172.20.0.1:58248",
+					"172.21.0.1:58248",
+					"172.22.0.1:58248",
+					"172.23.0.1:58248",
+					"172.24.0.1:58248",
+					"172.25.0.1:58248",
+					"172.26.0.1:58248",
+					"172.27.0.1:58248"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:15:31.474110403Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3561426999795519,
+				"StableID":   "nvpQSbeyoU11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a795fafef9f4a89c46426029efe816a9395b5340862528a19d7b76e956788015",
+				"DiscoKey":   "discokey:63f4da40c2314bab916b10d166373c1fdb4325de44a2d554b8b59e4f0bebd609",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38290",
+					"10.65.0.27:38290",
+					"172.17.0.1:38290",
+					"172.18.0.1:38290",
+					"172.19.0.1:38290",
+					"172.20.0.1:38290",
+					"172.21.0.1:38290",
+					"172.22.0.1:38290",
+					"172.23.0.1:38290",
+					"172.24.0.1:38290",
+					"172.25.0.1:38290",
+					"172.26.0.1:38290",
+					"172.27.0.1:38290"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:15:32.046626874Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5801515494625177,
+				"StableID":   "nUWQuWyWJn11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d3ce6431fef8e3b4963aaa319c0c53dc97054e3042d73eecade99c5201a78d40",
+				"DiscoKey":   "discokey:55be253434b1b88c06b4325eb66fde5bf9f85a6633e376a58450b842824bcc75",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:60761",
+					"10.65.0.27:60761",
+					"172.17.0.1:60761",
+					"172.18.0.1:60761",
+					"172.19.0.1:60761",
+					"172.20.0.1:60761",
+					"172.21.0.1:60761",
+					"172.22.0.1:60761",
+					"172.23.0.1:60761",
+					"172.24.0.1:60761",
+					"172.25.0.1:60761",
+					"172.26.0.1:60761",
+					"172.27.0.1:60761"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:15:32.553760632Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4571778998843261,
+				"StableID":   "nCgko9tZhc11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6683546b33900d2c5093322416f2bc94fbc87b5f2d9e30fbb720cec2953a8927",
+				"DiscoKey":   "discokey:1e25ffa1290170bbe24651b7fd2bf6f293c7f3cc3f5f32fbd49ab6324cea5571",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:57830",
+					"10.65.0.27:57830",
+					"172.17.0.1:57830",
+					"172.18.0.1:57830",
+					"172.19.0.1:57830",
+					"172.20.0.1:57830",
+					"172.21.0.1:57830",
+					"172.22.0.1:57830",
+					"172.23.0.1:57830",
+					"172.24.0.1:57830",
+					"172.25.0.1:57830",
+					"172.26.0.1:57830",
+					"172.27.0.1:57830"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:15:33.114398928Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1131422399557847,
+				"StableID":   "nN6M5nYRq911CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2bbec591da434185a620f820e76467f9ee661eb42e66c91d5480a784ea8db47a",
+				"DiscoKey":   "discokey:eb1f29c9f9e4748cfdd944fa6db66e15612b4193659fa190b6bb1ad537508a0a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:45678",
+					"10.65.0.27:45678",
+					"172.17.0.1:45678",
+					"172.18.0.1:45678",
+					"172.19.0.1:45678",
+					"172.20.0.1:45678",
+					"172.21.0.1:45678",
+					"172.22.0.1:45678",
+					"172.23.0.1:45678",
+					"172.24.0.1:45678",
+					"172.25.0.1:45678",
+					"172.26.0.1:45678",
+					"172.27.0.1:45678"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:15:33.63530708Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6822175784289894,
+				"StableID":   "nHLdcPzmGv11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2a5a4d61c7a162a017f223e153a523dd627941f09524057fdc20fc72ad5a6752",
+				"DiscoKey":   "discokey:12a001687ba08dfa23c0821301fd782c7e7e42466757a6eddd545d468acaab23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49318",
+					"10.65.0.27:49318",
+					"172.17.0.1:49318",
+					"172.18.0.1:49318",
+					"172.19.0.1:49318",
+					"172.20.0.1:49318",
+					"172.21.0.1:49318",
+					"172.22.0.1:49318",
+					"172.23.0.1:49318",
+					"172.24.0.1:49318",
+					"172.25.0.1:49318",
+					"172.26.0.1:49318",
+					"172.27.0.1:49318"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:15:34.184201249Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2650053646205287,
+				"StableID":   "niGu27RDhM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8a11e5466f5dbb2f59ed9b3c17c12e9bdce9b29e5562b00826be58a7e4f1172f",
+				"KeyExpiry":  "2026-11-09T09:15:34Z",
+				"DiscoKey":   "discokey:344b88352870f93262b5717013e8e7b273bee1192ae370700600d635c0bc2813",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:36041",
+					"10.65.0.27:36041",
+					"172.17.0.1:36041",
+					"172.18.0.1:36041",
+					"172.19.0.1:36041",
+					"172.20.0.1:36041",
+					"172.21.0.1:36041",
+					"172.22.0.1:36041",
+					"172.23.0.1:36041",
+					"172.24.0.1:36041",
+					"172.25.0.1:36041",
+					"172.26.0.1:36041",
+					"172.27.0.1:36041"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:15:34.716718907Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1590577337976957,
+				"StableID":   "nGGVgdmNRD11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8fce3266003e6f1a594b71724e63e0ba888524dba3671b9e9716348491811308",
+				"KeyExpiry":  "2026-11-09T09:15:35Z",
+				"DiscoKey":   "discokey:6af7d5d07601570131533159eb2e764026847e1c5a45398fb6d0201b319a1c28",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39304",
+					"10.65.0.27:39304",
+					"172.17.0.1:39304",
+					"172.18.0.1:39304",
+					"172.19.0.1:39304",
+					"172.20.0.1:39304",
+					"172.21.0.1:39304",
+					"172.22.0.1:39304",
+					"172.23.0.1:39304",
+					"172.24.0.1:39304",
+					"172.25.0.1:39304",
+					"172.26.0.1:39304",
+					"172.27.0.1:39304"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:15:35.265754047Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6654845318017443,
+				"StableID":   "n6SkJ7Wzxt11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3bae111f6933443c9cf88a9f43e65f7c0a2e50da05842e1441d74d311170be57",
+				"KeyExpiry":  "2026-11-09T09:15:35Z",
+				"DiscoKey":   "discokey:34a3642936c383953f7b115a65371c8d1800e8a7e497cb38d6f069c805d13452",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49652",
+					"10.65.0.27:49652",
+					"172.17.0.1:49652",
+					"172.18.0.1:49652",
+					"172.19.0.1:49652",
+					"172.20.0.1:49652",
+					"172.21.0.1:49652",
+					"172.22.0.1:49652",
+					"172.23.0.1:49652",
+					"172.24.0.1:49652",
+					"172.25.0.1:49652",
+					"172.26.0.1:49652",
+					"172.27.0.1:49652"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:15:35.794196155Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3909366360514707": {
+				"ID":          3909366360514707,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5200609388484747,
+				"StableID":   "nzJb12CNch11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       5200609388484747,
+				"Key":        "nodekey:5817a7f58d795ae00e48506a9fdb12d85e8b691a7051579bee5d2fb40ecfa83f",
+				"DiscoKey":   "discokey:82871a2ba027f3f57ed9a4b033b9d1cfd4e35b5322a56d6d2575a2a0aeb88037",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58248",
+					"10.65.0.27:58248",
+					"172.17.0.1:58248",
+					"172.18.0.1:58248",
+					"172.19.0.1:58248",
+					"172.20.0.1:58248",
+					"172.21.0.1:58248",
+					"172.22.0.1:58248",
+					"172.23.0.1:58248",
+					"172.24.0.1:58248",
+					"172.25.0.1:58248",
+					"172.26.0.1:58248",
+					"172.27.0.1:58248"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:15:31.474110403Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5817a7f58d795ae00e48506a9fdb12d85e8b691a7051579bee5d2fb40ecfa83f",
+			"MachineKey": "mkey:be4c51b49003f59e08407978ddccee9c8d65fdaf486fa3a22905fa92a95c330c",
+			"Peers": [{
+				"ID":         7162973470033938,
+				"StableID":   "n3yb6gA8wx11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f7a5f0bbcc8f893221307ac5995f0e10e6b477f2f3aa713d4e0735873002411a",
+				"DiscoKey":   "discokey:dfbbc8dde5ca6d475decf3c9ccab9f58ce5c964721bb5ba8ffa13d1caa329c55",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49088",
+					"10.65.0.27:49088",
+					"172.17.0.1:49088",
+					"172.18.0.1:49088",
+					"172.19.0.1:49088",
+					"172.20.0.1:49088",
+					"172.21.0.1:49088",
+					"172.22.0.1:49088",
+					"172.23.0.1:49088",
+					"172.24.0.1:49088",
+					"172.25.0.1:49088",
+					"172.26.0.1:49088",
+					"172.27.0.1:49088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:15:28.250506567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7414170185595947,
+				"StableID":   "nSQkfMgttz11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f9c3aff1e051a0dec2a83dd8d1b39ed1789c202962c875aa153aa11ab72ccd0f",
+				"DiscoKey":   "discokey:e7ee02e15b803c613066967d925358eeb23046916ad2bc472cad0ceb5c2e9b5b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34681",
+					"10.65.0.27:34681",
+					"172.17.0.1:34681",
+					"172.18.0.1:34681",
+					"172.19.0.1:34681",
+					"172.20.0.1:34681",
+					"172.21.0.1:34681",
+					"172.22.0.1:34681",
+					"172.23.0.1:34681",
+					"172.24.0.1:34681",
+					"172.25.0.1:34681",
+					"172.26.0.1:34681",
+					"172.27.0.1:34681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:15:28.75901772Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8662839316658527,
+				"StableID":   "n45zuk6ReA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:88c62ac6c9912b5b232d3e81a4b600df7acaf9d24f8d97cf4094e0dc4ab2f762",
+				"DiscoKey":   "discokey:782e6b13e8ed4968c00253cb16830c93ae318ddbd9da8462446eb83e6533e275",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36767",
+					"10.65.0.27:36767",
+					"172.17.0.1:36767",
+					"172.18.0.1:36767",
+					"172.19.0.1:36767",
+					"172.20.0.1:36767",
+					"172.21.0.1:36767",
+					"172.22.0.1:36767",
+					"172.23.0.1:36767",
+					"172.24.0.1:36767",
+					"172.25.0.1:36767",
+					"172.26.0.1:36767",
+					"172.27.0.1:36767"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:15:29.341591591Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3909366360514707,
+				"StableID":   "nLMPHfRZXX11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6472555e2b3141e1dc9e6c9cb88b41a235ad445a194fae30e2eb8e19be4e5c75",
+				"DiscoKey":   "discokey:710235f1fcd9e41e4a6a3e0dc616c9a89409482e906d27fa14f2bd725ef4f441",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34420",
+					"10.65.0.27:34420",
+					"172.17.0.1:34420",
+					"172.18.0.1:34420",
+					"172.19.0.1:34420",
+					"172.20.0.1:34420",
+					"172.21.0.1:34420",
+					"172.22.0.1:34420",
+					"172.23.0.1:34420",
+					"172.24.0.1:34420",
+					"172.25.0.1:34420",
+					"172.26.0.1:34420",
+					"172.27.0.1:34420"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:15:29.854217179Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7999044957232230,
+				"StableID":   "nuppR8MnT521CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bba3e3334366a763e4495df4c8f031992b8476967fdd62f1a9167807cc5d5d42",
+				"DiscoKey":   "discokey:5b1ea0d50c8cce5b99aa06600ee89f58050cb5d1b02b65f8878a0beda041f97c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38433",
+					"10.65.0.27:38433",
+					"172.17.0.1:38433",
+					"172.18.0.1:38433",
+					"172.19.0.1:38433",
+					"172.20.0.1:38433",
+					"172.21.0.1:38433",
+					"172.22.0.1:38433",
+					"172.23.0.1:38433",
+					"172.24.0.1:38433",
+					"172.25.0.1:38433",
+					"172.26.0.1:38433",
+					"172.27.0.1:38433"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:15:30.388337037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         925197816773822,
+				"StableID":   "nPyssuN2E811CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9ab6c9017ac7f2d534fa570cd6f5bde1f80ffd27a28fe78795d806ddb8c00b00",
+				"DiscoKey":   "discokey:98bdbbdc0b5dcb0deb1e48877bac8571d5bfcc6255cc1c217004830202c2857a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54250",
+					"10.65.0.27:54250",
+					"172.17.0.1:54250",
+					"172.18.0.1:54250",
+					"172.19.0.1:54250",
+					"172.20.0.1:54250",
+					"172.21.0.1:54250",
+					"172.22.0.1:54250",
+					"172.23.0.1:54250",
+					"172.24.0.1:54250",
+					"172.25.0.1:54250",
+					"172.26.0.1:54250",
+					"172.27.0.1:54250"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:15:30.938054577Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3561426999795519,
+				"StableID":   "nvpQSbeyoU11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a795fafef9f4a89c46426029efe816a9395b5340862528a19d7b76e956788015",
+				"DiscoKey":   "discokey:63f4da40c2314bab916b10d166373c1fdb4325de44a2d554b8b59e4f0bebd609",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38290",
+					"10.65.0.27:38290",
+					"172.17.0.1:38290",
+					"172.18.0.1:38290",
+					"172.19.0.1:38290",
+					"172.20.0.1:38290",
+					"172.21.0.1:38290",
+					"172.22.0.1:38290",
+					"172.23.0.1:38290",
+					"172.24.0.1:38290",
+					"172.25.0.1:38290",
+					"172.26.0.1:38290",
+					"172.27.0.1:38290"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:15:32.046626874Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5801515494625177,
+				"StableID":   "nUWQuWyWJn11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d3ce6431fef8e3b4963aaa319c0c53dc97054e3042d73eecade99c5201a78d40",
+				"DiscoKey":   "discokey:55be253434b1b88c06b4325eb66fde5bf9f85a6633e376a58450b842824bcc75",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:60761",
+					"10.65.0.27:60761",
+					"172.17.0.1:60761",
+					"172.18.0.1:60761",
+					"172.19.0.1:60761",
+					"172.20.0.1:60761",
+					"172.21.0.1:60761",
+					"172.22.0.1:60761",
+					"172.23.0.1:60761",
+					"172.24.0.1:60761",
+					"172.25.0.1:60761",
+					"172.26.0.1:60761",
+					"172.27.0.1:60761"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:15:32.553760632Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4571778998843261,
+				"StableID":   "nCgko9tZhc11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6683546b33900d2c5093322416f2bc94fbc87b5f2d9e30fbb720cec2953a8927",
+				"DiscoKey":   "discokey:1e25ffa1290170bbe24651b7fd2bf6f293c7f3cc3f5f32fbd49ab6324cea5571",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:57830",
+					"10.65.0.27:57830",
+					"172.17.0.1:57830",
+					"172.18.0.1:57830",
+					"172.19.0.1:57830",
+					"172.20.0.1:57830",
+					"172.21.0.1:57830",
+					"172.22.0.1:57830",
+					"172.23.0.1:57830",
+					"172.24.0.1:57830",
+					"172.25.0.1:57830",
+					"172.26.0.1:57830",
+					"172.27.0.1:57830"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:15:33.114398928Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1131422399557847,
+				"StableID":   "nN6M5nYRq911CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2bbec591da434185a620f820e76467f9ee661eb42e66c91d5480a784ea8db47a",
+				"DiscoKey":   "discokey:eb1f29c9f9e4748cfdd944fa6db66e15612b4193659fa190b6bb1ad537508a0a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:45678",
+					"10.65.0.27:45678",
+					"172.17.0.1:45678",
+					"172.18.0.1:45678",
+					"172.19.0.1:45678",
+					"172.20.0.1:45678",
+					"172.21.0.1:45678",
+					"172.22.0.1:45678",
+					"172.23.0.1:45678",
+					"172.24.0.1:45678",
+					"172.25.0.1:45678",
+					"172.26.0.1:45678",
+					"172.27.0.1:45678"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:15:33.63530708Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6822175784289894,
+				"StableID":   "nHLdcPzmGv11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2a5a4d61c7a162a017f223e153a523dd627941f09524057fdc20fc72ad5a6752",
+				"DiscoKey":   "discokey:12a001687ba08dfa23c0821301fd782c7e7e42466757a6eddd545d468acaab23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49318",
+					"10.65.0.27:49318",
+					"172.17.0.1:49318",
+					"172.18.0.1:49318",
+					"172.19.0.1:49318",
+					"172.20.0.1:49318",
+					"172.21.0.1:49318",
+					"172.22.0.1:49318",
+					"172.23.0.1:49318",
+					"172.24.0.1:49318",
+					"172.25.0.1:49318",
+					"172.26.0.1:49318",
+					"172.27.0.1:49318"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:15:34.184201249Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2650053646205287,
+				"StableID":   "niGu27RDhM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8a11e5466f5dbb2f59ed9b3c17c12e9bdce9b29e5562b00826be58a7e4f1172f",
+				"KeyExpiry":  "2026-11-09T09:15:34Z",
+				"DiscoKey":   "discokey:344b88352870f93262b5717013e8e7b273bee1192ae370700600d635c0bc2813",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:36041",
+					"10.65.0.27:36041",
+					"172.17.0.1:36041",
+					"172.18.0.1:36041",
+					"172.19.0.1:36041",
+					"172.20.0.1:36041",
+					"172.21.0.1:36041",
+					"172.22.0.1:36041",
+					"172.23.0.1:36041",
+					"172.24.0.1:36041",
+					"172.25.0.1:36041",
+					"172.26.0.1:36041",
+					"172.27.0.1:36041"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:15:34.716718907Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1590577337976957,
+				"StableID":   "nGGVgdmNRD11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8fce3266003e6f1a594b71724e63e0ba888524dba3671b9e9716348491811308",
+				"KeyExpiry":  "2026-11-09T09:15:35Z",
+				"DiscoKey":   "discokey:6af7d5d07601570131533159eb2e764026847e1c5a45398fb6d0201b319a1c28",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39304",
+					"10.65.0.27:39304",
+					"172.17.0.1:39304",
+					"172.18.0.1:39304",
+					"172.19.0.1:39304",
+					"172.20.0.1:39304",
+					"172.21.0.1:39304",
+					"172.22.0.1:39304",
+					"172.23.0.1:39304",
+					"172.24.0.1:39304",
+					"172.25.0.1:39304",
+					"172.26.0.1:39304",
+					"172.27.0.1:39304"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:15:35.265754047Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6654845318017443,
+				"StableID":   "n6SkJ7Wzxt11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3bae111f6933443c9cf88a9f43e65f7c0a2e50da05842e1441d74d311170be57",
+				"KeyExpiry":  "2026-11-09T09:15:35Z",
+				"DiscoKey":   "discokey:34a3642936c383953f7b115a65371c8d1800e8a7e497cb38d6f069c805d13452",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49652",
+					"10.65.0.27:49652",
+					"172.17.0.1:49652",
+					"172.18.0.1:49652",
+					"172.19.0.1:49652",
+					"172.20.0.1:49652",
+					"172.21.0.1:49652",
+					"172.22.0.1:49652",
+					"172.23.0.1:49652",
+					"172.24.0.1:49652",
+					"172.25.0.1:49652",
+					"172.26.0.1:49652",
+					"172.27.0.1:49652"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:15:35.794196155Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5200609388484747": {
+				"ID":          5200609388484747,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5801515494625177,
+				"StableID":   "nUWQuWyWJn11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       5801515494625177,
+				"Key":        "nodekey:d3ce6431fef8e3b4963aaa319c0c53dc97054e3042d73eecade99c5201a78d40",
+				"DiscoKey":   "discokey:55be253434b1b88c06b4325eb66fde5bf9f85a6633e376a58450b842824bcc75",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:60761",
+					"10.65.0.27:60761",
+					"172.17.0.1:60761",
+					"172.18.0.1:60761",
+					"172.19.0.1:60761",
+					"172.20.0.1:60761",
+					"172.21.0.1:60761",
+					"172.22.0.1:60761",
+					"172.23.0.1:60761",
+					"172.24.0.1:60761",
+					"172.25.0.1:60761",
+					"172.26.0.1:60761",
+					"172.27.0.1:60761"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:15:32.553760632Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d3ce6431fef8e3b4963aaa319c0c53dc97054e3042d73eecade99c5201a78d40",
+			"MachineKey": "mkey:bc787cb83a08915785276c20c2c949288e2db7a89eafb68e3f1c18455ea20000",
+			"Peers": [{
+				"ID":         7162973470033938,
+				"StableID":   "n3yb6gA8wx11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f7a5f0bbcc8f893221307ac5995f0e10e6b477f2f3aa713d4e0735873002411a",
+				"DiscoKey":   "discokey:dfbbc8dde5ca6d475decf3c9ccab9f58ce5c964721bb5ba8ffa13d1caa329c55",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49088",
+					"10.65.0.27:49088",
+					"172.17.0.1:49088",
+					"172.18.0.1:49088",
+					"172.19.0.1:49088",
+					"172.20.0.1:49088",
+					"172.21.0.1:49088",
+					"172.22.0.1:49088",
+					"172.23.0.1:49088",
+					"172.24.0.1:49088",
+					"172.25.0.1:49088",
+					"172.26.0.1:49088",
+					"172.27.0.1:49088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:15:28.250506567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7414170185595947,
+				"StableID":   "nSQkfMgttz11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f9c3aff1e051a0dec2a83dd8d1b39ed1789c202962c875aa153aa11ab72ccd0f",
+				"DiscoKey":   "discokey:e7ee02e15b803c613066967d925358eeb23046916ad2bc472cad0ceb5c2e9b5b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34681",
+					"10.65.0.27:34681",
+					"172.17.0.1:34681",
+					"172.18.0.1:34681",
+					"172.19.0.1:34681",
+					"172.20.0.1:34681",
+					"172.21.0.1:34681",
+					"172.22.0.1:34681",
+					"172.23.0.1:34681",
+					"172.24.0.1:34681",
+					"172.25.0.1:34681",
+					"172.26.0.1:34681",
+					"172.27.0.1:34681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:15:28.75901772Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8662839316658527,
+				"StableID":   "n45zuk6ReA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:88c62ac6c9912b5b232d3e81a4b600df7acaf9d24f8d97cf4094e0dc4ab2f762",
+				"DiscoKey":   "discokey:782e6b13e8ed4968c00253cb16830c93ae318ddbd9da8462446eb83e6533e275",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36767",
+					"10.65.0.27:36767",
+					"172.17.0.1:36767",
+					"172.18.0.1:36767",
+					"172.19.0.1:36767",
+					"172.20.0.1:36767",
+					"172.21.0.1:36767",
+					"172.22.0.1:36767",
+					"172.23.0.1:36767",
+					"172.24.0.1:36767",
+					"172.25.0.1:36767",
+					"172.26.0.1:36767",
+					"172.27.0.1:36767"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:15:29.341591591Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3909366360514707,
+				"StableID":   "nLMPHfRZXX11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6472555e2b3141e1dc9e6c9cb88b41a235ad445a194fae30e2eb8e19be4e5c75",
+				"DiscoKey":   "discokey:710235f1fcd9e41e4a6a3e0dc616c9a89409482e906d27fa14f2bd725ef4f441",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34420",
+					"10.65.0.27:34420",
+					"172.17.0.1:34420",
+					"172.18.0.1:34420",
+					"172.19.0.1:34420",
+					"172.20.0.1:34420",
+					"172.21.0.1:34420",
+					"172.22.0.1:34420",
+					"172.23.0.1:34420",
+					"172.24.0.1:34420",
+					"172.25.0.1:34420",
+					"172.26.0.1:34420",
+					"172.27.0.1:34420"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:15:29.854217179Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7999044957232230,
+				"StableID":   "nuppR8MnT521CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bba3e3334366a763e4495df4c8f031992b8476967fdd62f1a9167807cc5d5d42",
+				"DiscoKey":   "discokey:5b1ea0d50c8cce5b99aa06600ee89f58050cb5d1b02b65f8878a0beda041f97c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38433",
+					"10.65.0.27:38433",
+					"172.17.0.1:38433",
+					"172.18.0.1:38433",
+					"172.19.0.1:38433",
+					"172.20.0.1:38433",
+					"172.21.0.1:38433",
+					"172.22.0.1:38433",
+					"172.23.0.1:38433",
+					"172.24.0.1:38433",
+					"172.25.0.1:38433",
+					"172.26.0.1:38433",
+					"172.27.0.1:38433"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:15:30.388337037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         925197816773822,
+				"StableID":   "nPyssuN2E811CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9ab6c9017ac7f2d534fa570cd6f5bde1f80ffd27a28fe78795d806ddb8c00b00",
+				"DiscoKey":   "discokey:98bdbbdc0b5dcb0deb1e48877bac8571d5bfcc6255cc1c217004830202c2857a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54250",
+					"10.65.0.27:54250",
+					"172.17.0.1:54250",
+					"172.18.0.1:54250",
+					"172.19.0.1:54250",
+					"172.20.0.1:54250",
+					"172.21.0.1:54250",
+					"172.22.0.1:54250",
+					"172.23.0.1:54250",
+					"172.24.0.1:54250",
+					"172.25.0.1:54250",
+					"172.26.0.1:54250",
+					"172.27.0.1:54250"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:15:30.938054577Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5200609388484747,
+				"StableID":   "nzJb12CNch11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5817a7f58d795ae00e48506a9fdb12d85e8b691a7051579bee5d2fb40ecfa83f",
+				"DiscoKey":   "discokey:82871a2ba027f3f57ed9a4b033b9d1cfd4e35b5322a56d6d2575a2a0aeb88037",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58248",
+					"10.65.0.27:58248",
+					"172.17.0.1:58248",
+					"172.18.0.1:58248",
+					"172.19.0.1:58248",
+					"172.20.0.1:58248",
+					"172.21.0.1:58248",
+					"172.22.0.1:58248",
+					"172.23.0.1:58248",
+					"172.24.0.1:58248",
+					"172.25.0.1:58248",
+					"172.26.0.1:58248",
+					"172.27.0.1:58248"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:15:31.474110403Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3561426999795519,
+				"StableID":   "nvpQSbeyoU11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a795fafef9f4a89c46426029efe816a9395b5340862528a19d7b76e956788015",
+				"DiscoKey":   "discokey:63f4da40c2314bab916b10d166373c1fdb4325de44a2d554b8b59e4f0bebd609",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38290",
+					"10.65.0.27:38290",
+					"172.17.0.1:38290",
+					"172.18.0.1:38290",
+					"172.19.0.1:38290",
+					"172.20.0.1:38290",
+					"172.21.0.1:38290",
+					"172.22.0.1:38290",
+					"172.23.0.1:38290",
+					"172.24.0.1:38290",
+					"172.25.0.1:38290",
+					"172.26.0.1:38290",
+					"172.27.0.1:38290"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:15:32.046626874Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4571778998843261,
+				"StableID":   "nCgko9tZhc11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6683546b33900d2c5093322416f2bc94fbc87b5f2d9e30fbb720cec2953a8927",
+				"DiscoKey":   "discokey:1e25ffa1290170bbe24651b7fd2bf6f293c7f3cc3f5f32fbd49ab6324cea5571",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:57830",
+					"10.65.0.27:57830",
+					"172.17.0.1:57830",
+					"172.18.0.1:57830",
+					"172.19.0.1:57830",
+					"172.20.0.1:57830",
+					"172.21.0.1:57830",
+					"172.22.0.1:57830",
+					"172.23.0.1:57830",
+					"172.24.0.1:57830",
+					"172.25.0.1:57830",
+					"172.26.0.1:57830",
+					"172.27.0.1:57830"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:15:33.114398928Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1131422399557847,
+				"StableID":   "nN6M5nYRq911CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2bbec591da434185a620f820e76467f9ee661eb42e66c91d5480a784ea8db47a",
+				"DiscoKey":   "discokey:eb1f29c9f9e4748cfdd944fa6db66e15612b4193659fa190b6bb1ad537508a0a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:45678",
+					"10.65.0.27:45678",
+					"172.17.0.1:45678",
+					"172.18.0.1:45678",
+					"172.19.0.1:45678",
+					"172.20.0.1:45678",
+					"172.21.0.1:45678",
+					"172.22.0.1:45678",
+					"172.23.0.1:45678",
+					"172.24.0.1:45678",
+					"172.25.0.1:45678",
+					"172.26.0.1:45678",
+					"172.27.0.1:45678"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:15:33.63530708Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6822175784289894,
+				"StableID":   "nHLdcPzmGv11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2a5a4d61c7a162a017f223e153a523dd627941f09524057fdc20fc72ad5a6752",
+				"DiscoKey":   "discokey:12a001687ba08dfa23c0821301fd782c7e7e42466757a6eddd545d468acaab23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49318",
+					"10.65.0.27:49318",
+					"172.17.0.1:49318",
+					"172.18.0.1:49318",
+					"172.19.0.1:49318",
+					"172.20.0.1:49318",
+					"172.21.0.1:49318",
+					"172.22.0.1:49318",
+					"172.23.0.1:49318",
+					"172.24.0.1:49318",
+					"172.25.0.1:49318",
+					"172.26.0.1:49318",
+					"172.27.0.1:49318"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:15:34.184201249Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2650053646205287,
+				"StableID":   "niGu27RDhM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8a11e5466f5dbb2f59ed9b3c17c12e9bdce9b29e5562b00826be58a7e4f1172f",
+				"KeyExpiry":  "2026-11-09T09:15:34Z",
+				"DiscoKey":   "discokey:344b88352870f93262b5717013e8e7b273bee1192ae370700600d635c0bc2813",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:36041",
+					"10.65.0.27:36041",
+					"172.17.0.1:36041",
+					"172.18.0.1:36041",
+					"172.19.0.1:36041",
+					"172.20.0.1:36041",
+					"172.21.0.1:36041",
+					"172.22.0.1:36041",
+					"172.23.0.1:36041",
+					"172.24.0.1:36041",
+					"172.25.0.1:36041",
+					"172.26.0.1:36041",
+					"172.27.0.1:36041"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:15:34.716718907Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1590577337976957,
+				"StableID":   "nGGVgdmNRD11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8fce3266003e6f1a594b71724e63e0ba888524dba3671b9e9716348491811308",
+				"KeyExpiry":  "2026-11-09T09:15:35Z",
+				"DiscoKey":   "discokey:6af7d5d07601570131533159eb2e764026847e1c5a45398fb6d0201b319a1c28",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39304",
+					"10.65.0.27:39304",
+					"172.17.0.1:39304",
+					"172.18.0.1:39304",
+					"172.19.0.1:39304",
+					"172.20.0.1:39304",
+					"172.21.0.1:39304",
+					"172.22.0.1:39304",
+					"172.23.0.1:39304",
+					"172.24.0.1:39304",
+					"172.25.0.1:39304",
+					"172.26.0.1:39304",
+					"172.27.0.1:39304"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:15:35.265754047Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6654845318017443,
+				"StableID":   "n6SkJ7Wzxt11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3bae111f6933443c9cf88a9f43e65f7c0a2e50da05842e1441d74d311170be57",
+				"KeyExpiry":  "2026-11-09T09:15:35Z",
+				"DiscoKey":   "discokey:34a3642936c383953f7b115a65371c8d1800e8a7e497cb38d6f069c805d13452",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49652",
+					"10.65.0.27:49652",
+					"172.17.0.1:49652",
+					"172.18.0.1:49652",
+					"172.19.0.1:49652",
+					"172.20.0.1:49652",
+					"172.21.0.1:49652",
+					"172.22.0.1:49652",
+					"172.23.0.1:49652",
+					"172.24.0.1:49652",
+					"172.25.0.1:49652",
+					"172.26.0.1:49652",
+					"172.27.0.1:49652"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:15:35.794196155Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5801515494625177": {
+				"ID":          5801515494625177,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1590577337976957,
+				"StableID":   "nGGVgdmNRD11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8fce3266003e6f1a594b71724e63e0ba888524dba3671b9e9716348491811308",
+				"KeyExpiry":  "2026-11-09T09:15:35Z",
+				"DiscoKey":   "discokey:6af7d5d07601570131533159eb2e764026847e1c5a45398fb6d0201b319a1c28",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39304",
+					"10.65.0.27:39304",
+					"172.17.0.1:39304",
+					"172.18.0.1:39304",
+					"172.19.0.1:39304",
+					"172.20.0.1:39304",
+					"172.21.0.1:39304",
+					"172.22.0.1:39304",
+					"172.23.0.1:39304",
+					"172.24.0.1:39304",
+					"172.25.0.1:39304",
+					"172.26.0.1:39304",
+					"172.27.0.1:39304"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:15:35.265754047Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8fce3266003e6f1a594b71724e63e0ba888524dba3671b9e9716348491811308",
+			"MachineKey": "mkey:ff62bfe25fe35b4f79471d02b5d1b62b9ce666dc3231b5f890961164e6733374",
+			"Peers": [{
+				"ID":         7162973470033938,
+				"StableID":   "n3yb6gA8wx11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f7a5f0bbcc8f893221307ac5995f0e10e6b477f2f3aa713d4e0735873002411a",
+				"DiscoKey":   "discokey:dfbbc8dde5ca6d475decf3c9ccab9f58ce5c964721bb5ba8ffa13d1caa329c55",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49088",
+					"10.65.0.27:49088",
+					"172.17.0.1:49088",
+					"172.18.0.1:49088",
+					"172.19.0.1:49088",
+					"172.20.0.1:49088",
+					"172.21.0.1:49088",
+					"172.22.0.1:49088",
+					"172.23.0.1:49088",
+					"172.24.0.1:49088",
+					"172.25.0.1:49088",
+					"172.26.0.1:49088",
+					"172.27.0.1:49088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:15:28.250506567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7414170185595947,
+				"StableID":   "nSQkfMgttz11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f9c3aff1e051a0dec2a83dd8d1b39ed1789c202962c875aa153aa11ab72ccd0f",
+				"DiscoKey":   "discokey:e7ee02e15b803c613066967d925358eeb23046916ad2bc472cad0ceb5c2e9b5b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34681",
+					"10.65.0.27:34681",
+					"172.17.0.1:34681",
+					"172.18.0.1:34681",
+					"172.19.0.1:34681",
+					"172.20.0.1:34681",
+					"172.21.0.1:34681",
+					"172.22.0.1:34681",
+					"172.23.0.1:34681",
+					"172.24.0.1:34681",
+					"172.25.0.1:34681",
+					"172.26.0.1:34681",
+					"172.27.0.1:34681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:15:28.75901772Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8662839316658527,
+				"StableID":   "n45zuk6ReA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:88c62ac6c9912b5b232d3e81a4b600df7acaf9d24f8d97cf4094e0dc4ab2f762",
+				"DiscoKey":   "discokey:782e6b13e8ed4968c00253cb16830c93ae318ddbd9da8462446eb83e6533e275",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36767",
+					"10.65.0.27:36767",
+					"172.17.0.1:36767",
+					"172.18.0.1:36767",
+					"172.19.0.1:36767",
+					"172.20.0.1:36767",
+					"172.21.0.1:36767",
+					"172.22.0.1:36767",
+					"172.23.0.1:36767",
+					"172.24.0.1:36767",
+					"172.25.0.1:36767",
+					"172.26.0.1:36767",
+					"172.27.0.1:36767"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:15:29.341591591Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3909366360514707,
+				"StableID":   "nLMPHfRZXX11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6472555e2b3141e1dc9e6c9cb88b41a235ad445a194fae30e2eb8e19be4e5c75",
+				"DiscoKey":   "discokey:710235f1fcd9e41e4a6a3e0dc616c9a89409482e906d27fa14f2bd725ef4f441",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34420",
+					"10.65.0.27:34420",
+					"172.17.0.1:34420",
+					"172.18.0.1:34420",
+					"172.19.0.1:34420",
+					"172.20.0.1:34420",
+					"172.21.0.1:34420",
+					"172.22.0.1:34420",
+					"172.23.0.1:34420",
+					"172.24.0.1:34420",
+					"172.25.0.1:34420",
+					"172.26.0.1:34420",
+					"172.27.0.1:34420"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:15:29.854217179Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7999044957232230,
+				"StableID":   "nuppR8MnT521CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bba3e3334366a763e4495df4c8f031992b8476967fdd62f1a9167807cc5d5d42",
+				"DiscoKey":   "discokey:5b1ea0d50c8cce5b99aa06600ee89f58050cb5d1b02b65f8878a0beda041f97c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38433",
+					"10.65.0.27:38433",
+					"172.17.0.1:38433",
+					"172.18.0.1:38433",
+					"172.19.0.1:38433",
+					"172.20.0.1:38433",
+					"172.21.0.1:38433",
+					"172.22.0.1:38433",
+					"172.23.0.1:38433",
+					"172.24.0.1:38433",
+					"172.25.0.1:38433",
+					"172.26.0.1:38433",
+					"172.27.0.1:38433"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:15:30.388337037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         925197816773822,
+				"StableID":   "nPyssuN2E811CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9ab6c9017ac7f2d534fa570cd6f5bde1f80ffd27a28fe78795d806ddb8c00b00",
+				"DiscoKey":   "discokey:98bdbbdc0b5dcb0deb1e48877bac8571d5bfcc6255cc1c217004830202c2857a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54250",
+					"10.65.0.27:54250",
+					"172.17.0.1:54250",
+					"172.18.0.1:54250",
+					"172.19.0.1:54250",
+					"172.20.0.1:54250",
+					"172.21.0.1:54250",
+					"172.22.0.1:54250",
+					"172.23.0.1:54250",
+					"172.24.0.1:54250",
+					"172.25.0.1:54250",
+					"172.26.0.1:54250",
+					"172.27.0.1:54250"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:15:30.938054577Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5200609388484747,
+				"StableID":   "nzJb12CNch11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5817a7f58d795ae00e48506a9fdb12d85e8b691a7051579bee5d2fb40ecfa83f",
+				"DiscoKey":   "discokey:82871a2ba027f3f57ed9a4b033b9d1cfd4e35b5322a56d6d2575a2a0aeb88037",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58248",
+					"10.65.0.27:58248",
+					"172.17.0.1:58248",
+					"172.18.0.1:58248",
+					"172.19.0.1:58248",
+					"172.20.0.1:58248",
+					"172.21.0.1:58248",
+					"172.22.0.1:58248",
+					"172.23.0.1:58248",
+					"172.24.0.1:58248",
+					"172.25.0.1:58248",
+					"172.26.0.1:58248",
+					"172.27.0.1:58248"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:15:31.474110403Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3561426999795519,
+				"StableID":   "nvpQSbeyoU11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a795fafef9f4a89c46426029efe816a9395b5340862528a19d7b76e956788015",
+				"DiscoKey":   "discokey:63f4da40c2314bab916b10d166373c1fdb4325de44a2d554b8b59e4f0bebd609",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38290",
+					"10.65.0.27:38290",
+					"172.17.0.1:38290",
+					"172.18.0.1:38290",
+					"172.19.0.1:38290",
+					"172.20.0.1:38290",
+					"172.21.0.1:38290",
+					"172.22.0.1:38290",
+					"172.23.0.1:38290",
+					"172.24.0.1:38290",
+					"172.25.0.1:38290",
+					"172.26.0.1:38290",
+					"172.27.0.1:38290"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:15:32.046626874Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5801515494625177,
+				"StableID":   "nUWQuWyWJn11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d3ce6431fef8e3b4963aaa319c0c53dc97054e3042d73eecade99c5201a78d40",
+				"DiscoKey":   "discokey:55be253434b1b88c06b4325eb66fde5bf9f85a6633e376a58450b842824bcc75",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:60761",
+					"10.65.0.27:60761",
+					"172.17.0.1:60761",
+					"172.18.0.1:60761",
+					"172.19.0.1:60761",
+					"172.20.0.1:60761",
+					"172.21.0.1:60761",
+					"172.22.0.1:60761",
+					"172.23.0.1:60761",
+					"172.24.0.1:60761",
+					"172.25.0.1:60761",
+					"172.26.0.1:60761",
+					"172.27.0.1:60761"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:15:32.553760632Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4571778998843261,
+				"StableID":   "nCgko9tZhc11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6683546b33900d2c5093322416f2bc94fbc87b5f2d9e30fbb720cec2953a8927",
+				"DiscoKey":   "discokey:1e25ffa1290170bbe24651b7fd2bf6f293c7f3cc3f5f32fbd49ab6324cea5571",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:57830",
+					"10.65.0.27:57830",
+					"172.17.0.1:57830",
+					"172.18.0.1:57830",
+					"172.19.0.1:57830",
+					"172.20.0.1:57830",
+					"172.21.0.1:57830",
+					"172.22.0.1:57830",
+					"172.23.0.1:57830",
+					"172.24.0.1:57830",
+					"172.25.0.1:57830",
+					"172.26.0.1:57830",
+					"172.27.0.1:57830"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:15:33.114398928Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1131422399557847,
+				"StableID":   "nN6M5nYRq911CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2bbec591da434185a620f820e76467f9ee661eb42e66c91d5480a784ea8db47a",
+				"DiscoKey":   "discokey:eb1f29c9f9e4748cfdd944fa6db66e15612b4193659fa190b6bb1ad537508a0a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:45678",
+					"10.65.0.27:45678",
+					"172.17.0.1:45678",
+					"172.18.0.1:45678",
+					"172.19.0.1:45678",
+					"172.20.0.1:45678",
+					"172.21.0.1:45678",
+					"172.22.0.1:45678",
+					"172.23.0.1:45678",
+					"172.24.0.1:45678",
+					"172.25.0.1:45678",
+					"172.26.0.1:45678",
+					"172.27.0.1:45678"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:15:33.63530708Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6822175784289894,
+				"StableID":   "nHLdcPzmGv11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2a5a4d61c7a162a017f223e153a523dd627941f09524057fdc20fc72ad5a6752",
+				"DiscoKey":   "discokey:12a001687ba08dfa23c0821301fd782c7e7e42466757a6eddd545d468acaab23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49318",
+					"10.65.0.27:49318",
+					"172.17.0.1:49318",
+					"172.18.0.1:49318",
+					"172.19.0.1:49318",
+					"172.20.0.1:49318",
+					"172.21.0.1:49318",
+					"172.22.0.1:49318",
+					"172.23.0.1:49318",
+					"172.24.0.1:49318",
+					"172.25.0.1:49318",
+					"172.26.0.1:49318",
+					"172.27.0.1:49318"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:15:34.184201249Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2650053646205287,
+				"StableID":   "niGu27RDhM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8a11e5466f5dbb2f59ed9b3c17c12e9bdce9b29e5562b00826be58a7e4f1172f",
+				"KeyExpiry":  "2026-11-09T09:15:34Z",
+				"DiscoKey":   "discokey:344b88352870f93262b5717013e8e7b273bee1192ae370700600d635c0bc2813",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:36041",
+					"10.65.0.27:36041",
+					"172.17.0.1:36041",
+					"172.18.0.1:36041",
+					"172.19.0.1:36041",
+					"172.20.0.1:36041",
+					"172.21.0.1:36041",
+					"172.22.0.1:36041",
+					"172.23.0.1:36041",
+					"172.24.0.1:36041",
+					"172.25.0.1:36041",
+					"172.26.0.1:36041",
+					"172.27.0.1:36041"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:15:34.716718907Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6654845318017443,
+				"StableID":   "n6SkJ7Wzxt11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3bae111f6933443c9cf88a9f43e65f7c0a2e50da05842e1441d74d311170be57",
+				"KeyExpiry":  "2026-11-09T09:15:35Z",
+				"DiscoKey":   "discokey:34a3642936c383953f7b115a65371c8d1800e8a7e497cb38d6f069c805d13452",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49652",
+					"10.65.0.27:49652",
+					"172.17.0.1:49652",
+					"172.18.0.1:49652",
+					"172.19.0.1:49652",
+					"172.20.0.1:49652",
+					"172.21.0.1:49652",
+					"172.22.0.1:49652",
+					"172.23.0.1:49652",
+					"172.24.0.1:49652",
+					"172.25.0.1:49652",
+					"172.26.0.1:49652",
+					"172.27.0.1:49652"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:15:35.794196155Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4571778998843261,
+				"StableID":   "nCgko9tZhc11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       4571778998843261,
+				"Key":        "nodekey:6683546b33900d2c5093322416f2bc94fbc87b5f2d9e30fbb720cec2953a8927",
+				"DiscoKey":   "discokey:1e25ffa1290170bbe24651b7fd2bf6f293c7f3cc3f5f32fbd49ab6324cea5571",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:57830",
+					"10.65.0.27:57830",
+					"172.17.0.1:57830",
+					"172.18.0.1:57830",
+					"172.19.0.1:57830",
+					"172.20.0.1:57830",
+					"172.21.0.1:57830",
+					"172.22.0.1:57830",
+					"172.23.0.1:57830",
+					"172.24.0.1:57830",
+					"172.25.0.1:57830",
+					"172.26.0.1:57830",
+					"172.27.0.1:57830"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:15:33.114398928Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6683546b33900d2c5093322416f2bc94fbc87b5f2d9e30fbb720cec2953a8927",
+			"MachineKey": "mkey:e72b7d2668970336646d309fcff834752d065c1b0a88b625cb4c29549a2f5e11",
+			"Peers": [{
+				"ID":         7162973470033938,
+				"StableID":   "n3yb6gA8wx11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f7a5f0bbcc8f893221307ac5995f0e10e6b477f2f3aa713d4e0735873002411a",
+				"DiscoKey":   "discokey:dfbbc8dde5ca6d475decf3c9ccab9f58ce5c964721bb5ba8ffa13d1caa329c55",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49088",
+					"10.65.0.27:49088",
+					"172.17.0.1:49088",
+					"172.18.0.1:49088",
+					"172.19.0.1:49088",
+					"172.20.0.1:49088",
+					"172.21.0.1:49088",
+					"172.22.0.1:49088",
+					"172.23.0.1:49088",
+					"172.24.0.1:49088",
+					"172.25.0.1:49088",
+					"172.26.0.1:49088",
+					"172.27.0.1:49088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:15:28.250506567Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7414170185595947,
+				"StableID":   "nSQkfMgttz11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f9c3aff1e051a0dec2a83dd8d1b39ed1789c202962c875aa153aa11ab72ccd0f",
+				"DiscoKey":   "discokey:e7ee02e15b803c613066967d925358eeb23046916ad2bc472cad0ceb5c2e9b5b",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:34681",
+					"10.65.0.27:34681",
+					"172.17.0.1:34681",
+					"172.18.0.1:34681",
+					"172.19.0.1:34681",
+					"172.20.0.1:34681",
+					"172.21.0.1:34681",
+					"172.22.0.1:34681",
+					"172.23.0.1:34681",
+					"172.24.0.1:34681",
+					"172.25.0.1:34681",
+					"172.26.0.1:34681",
+					"172.27.0.1:34681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:15:28.75901772Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8662839316658527,
+				"StableID":   "n45zuk6ReA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:88c62ac6c9912b5b232d3e81a4b600df7acaf9d24f8d97cf4094e0dc4ab2f762",
+				"DiscoKey":   "discokey:782e6b13e8ed4968c00253cb16830c93ae318ddbd9da8462446eb83e6533e275",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36767",
+					"10.65.0.27:36767",
+					"172.17.0.1:36767",
+					"172.18.0.1:36767",
+					"172.19.0.1:36767",
+					"172.20.0.1:36767",
+					"172.21.0.1:36767",
+					"172.22.0.1:36767",
+					"172.23.0.1:36767",
+					"172.24.0.1:36767",
+					"172.25.0.1:36767",
+					"172.26.0.1:36767",
+					"172.27.0.1:36767"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:15:29.341591591Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3909366360514707,
+				"StableID":   "nLMPHfRZXX11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6472555e2b3141e1dc9e6c9cb88b41a235ad445a194fae30e2eb8e19be4e5c75",
+				"DiscoKey":   "discokey:710235f1fcd9e41e4a6a3e0dc616c9a89409482e906d27fa14f2bd725ef4f441",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34420",
+					"10.65.0.27:34420",
+					"172.17.0.1:34420",
+					"172.18.0.1:34420",
+					"172.19.0.1:34420",
+					"172.20.0.1:34420",
+					"172.21.0.1:34420",
+					"172.22.0.1:34420",
+					"172.23.0.1:34420",
+					"172.24.0.1:34420",
+					"172.25.0.1:34420",
+					"172.26.0.1:34420",
+					"172.27.0.1:34420"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:15:29.854217179Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7999044957232230,
+				"StableID":   "nuppR8MnT521CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bba3e3334366a763e4495df4c8f031992b8476967fdd62f1a9167807cc5d5d42",
+				"DiscoKey":   "discokey:5b1ea0d50c8cce5b99aa06600ee89f58050cb5d1b02b65f8878a0beda041f97c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38433",
+					"10.65.0.27:38433",
+					"172.17.0.1:38433",
+					"172.18.0.1:38433",
+					"172.19.0.1:38433",
+					"172.20.0.1:38433",
+					"172.21.0.1:38433",
+					"172.22.0.1:38433",
+					"172.23.0.1:38433",
+					"172.24.0.1:38433",
+					"172.25.0.1:38433",
+					"172.26.0.1:38433",
+					"172.27.0.1:38433"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:15:30.388337037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         925197816773822,
+				"StableID":   "nPyssuN2E811CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9ab6c9017ac7f2d534fa570cd6f5bde1f80ffd27a28fe78795d806ddb8c00b00",
+				"DiscoKey":   "discokey:98bdbbdc0b5dcb0deb1e48877bac8571d5bfcc6255cc1c217004830202c2857a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54250",
+					"10.65.0.27:54250",
+					"172.17.0.1:54250",
+					"172.18.0.1:54250",
+					"172.19.0.1:54250",
+					"172.20.0.1:54250",
+					"172.21.0.1:54250",
+					"172.22.0.1:54250",
+					"172.23.0.1:54250",
+					"172.24.0.1:54250",
+					"172.25.0.1:54250",
+					"172.26.0.1:54250",
+					"172.27.0.1:54250"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:15:30.938054577Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5200609388484747,
+				"StableID":   "nzJb12CNch11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5817a7f58d795ae00e48506a9fdb12d85e8b691a7051579bee5d2fb40ecfa83f",
+				"DiscoKey":   "discokey:82871a2ba027f3f57ed9a4b033b9d1cfd4e35b5322a56d6d2575a2a0aeb88037",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58248",
+					"10.65.0.27:58248",
+					"172.17.0.1:58248",
+					"172.18.0.1:58248",
+					"172.19.0.1:58248",
+					"172.20.0.1:58248",
+					"172.21.0.1:58248",
+					"172.22.0.1:58248",
+					"172.23.0.1:58248",
+					"172.24.0.1:58248",
+					"172.25.0.1:58248",
+					"172.26.0.1:58248",
+					"172.27.0.1:58248"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:15:31.474110403Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3561426999795519,
+				"StableID":   "nvpQSbeyoU11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a795fafef9f4a89c46426029efe816a9395b5340862528a19d7b76e956788015",
+				"DiscoKey":   "discokey:63f4da40c2314bab916b10d166373c1fdb4325de44a2d554b8b59e4f0bebd609",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38290",
+					"10.65.0.27:38290",
+					"172.17.0.1:38290",
+					"172.18.0.1:38290",
+					"172.19.0.1:38290",
+					"172.20.0.1:38290",
+					"172.21.0.1:38290",
+					"172.22.0.1:38290",
+					"172.23.0.1:38290",
+					"172.24.0.1:38290",
+					"172.25.0.1:38290",
+					"172.26.0.1:38290",
+					"172.27.0.1:38290"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:15:32.046626874Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5801515494625177,
+				"StableID":   "nUWQuWyWJn11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d3ce6431fef8e3b4963aaa319c0c53dc97054e3042d73eecade99c5201a78d40",
+				"DiscoKey":   "discokey:55be253434b1b88c06b4325eb66fde5bf9f85a6633e376a58450b842824bcc75",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:60761",
+					"10.65.0.27:60761",
+					"172.17.0.1:60761",
+					"172.18.0.1:60761",
+					"172.19.0.1:60761",
+					"172.20.0.1:60761",
+					"172.21.0.1:60761",
+					"172.22.0.1:60761",
+					"172.23.0.1:60761",
+					"172.24.0.1:60761",
+					"172.25.0.1:60761",
+					"172.26.0.1:60761",
+					"172.27.0.1:60761"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:15:32.553760632Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1131422399557847,
+				"StableID":   "nN6M5nYRq911CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2bbec591da434185a620f820e76467f9ee661eb42e66c91d5480a784ea8db47a",
+				"DiscoKey":   "discokey:eb1f29c9f9e4748cfdd944fa6db66e15612b4193659fa190b6bb1ad537508a0a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:45678",
+					"10.65.0.27:45678",
+					"172.17.0.1:45678",
+					"172.18.0.1:45678",
+					"172.19.0.1:45678",
+					"172.20.0.1:45678",
+					"172.21.0.1:45678",
+					"172.22.0.1:45678",
+					"172.23.0.1:45678",
+					"172.24.0.1:45678",
+					"172.25.0.1:45678",
+					"172.26.0.1:45678",
+					"172.27.0.1:45678"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:15:33.63530708Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6822175784289894,
+				"StableID":   "nHLdcPzmGv11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2a5a4d61c7a162a017f223e153a523dd627941f09524057fdc20fc72ad5a6752",
+				"DiscoKey":   "discokey:12a001687ba08dfa23c0821301fd782c7e7e42466757a6eddd545d468acaab23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49318",
+					"10.65.0.27:49318",
+					"172.17.0.1:49318",
+					"172.18.0.1:49318",
+					"172.19.0.1:49318",
+					"172.20.0.1:49318",
+					"172.21.0.1:49318",
+					"172.22.0.1:49318",
+					"172.23.0.1:49318",
+					"172.24.0.1:49318",
+					"172.25.0.1:49318",
+					"172.26.0.1:49318",
+					"172.27.0.1:49318"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:15:34.184201249Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2650053646205287,
+				"StableID":   "niGu27RDhM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8a11e5466f5dbb2f59ed9b3c17c12e9bdce9b29e5562b00826be58a7e4f1172f",
+				"KeyExpiry":  "2026-11-09T09:15:34Z",
+				"DiscoKey":   "discokey:344b88352870f93262b5717013e8e7b273bee1192ae370700600d635c0bc2813",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:36041",
+					"10.65.0.27:36041",
+					"172.17.0.1:36041",
+					"172.18.0.1:36041",
+					"172.19.0.1:36041",
+					"172.20.0.1:36041",
+					"172.21.0.1:36041",
+					"172.22.0.1:36041",
+					"172.23.0.1:36041",
+					"172.24.0.1:36041",
+					"172.25.0.1:36041",
+					"172.26.0.1:36041",
+					"172.27.0.1:36041"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:15:34.716718907Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1590577337976957,
+				"StableID":   "nGGVgdmNRD11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8fce3266003e6f1a594b71724e63e0ba888524dba3671b9e9716348491811308",
+				"KeyExpiry":  "2026-11-09T09:15:35Z",
+				"DiscoKey":   "discokey:6af7d5d07601570131533159eb2e764026847e1c5a45398fb6d0201b319a1c28",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39304",
+					"10.65.0.27:39304",
+					"172.17.0.1:39304",
+					"172.18.0.1:39304",
+					"172.19.0.1:39304",
+					"172.20.0.1:39304",
+					"172.21.0.1:39304",
+					"172.22.0.1:39304",
+					"172.23.0.1:39304",
+					"172.24.0.1:39304",
+					"172.25.0.1:39304",
+					"172.26.0.1:39304",
+					"172.27.0.1:39304"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:15:35.265754047Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6654845318017443,
+				"StableID":   "n6SkJ7Wzxt11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3bae111f6933443c9cf88a9f43e65f7c0a2e50da05842e1441d74d311170be57",
+				"KeyExpiry":  "2026-11-09T09:15:35Z",
+				"DiscoKey":   "discokey:34a3642936c383953f7b115a65371c8d1800e8a7e497cb38d6f069c805d13452",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49652",
+					"10.65.0.27:49652",
+					"172.17.0.1:49652",
+					"172.18.0.1:49652",
+					"172.19.0.1:49652",
+					"172.20.0.1:49652",
+					"172.21.0.1:49652",
+					"172.22.0.1:49652",
+					"172.23.0.1:49652",
+					"172.24.0.1:49652",
+					"172.25.0.1:49652",
+					"172.26.0.1:49652",
+					"172.27.0.1:49652"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:15:35.794196155Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4571778998843261": {
+				"ID":          4571778998843261,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-multi-rule-check-then-accept.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-multi-rule-check-then-accept.hujson
@@ -1,0 +1,21916 @@
+// ssh-multi-rule-check-then-accept
+//
+// ssh check then accept rule, same src/dst/users
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-13T09:32:22Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-multi-rule-check-then-accept",
+	"description":    "ssh check then accept rule, same src/dst/users",
+	"category":       "ssh",
+	"captured_at":    "2026-05-13T09:32:22.54446225Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                   \n  \n                                                                        \n                                          \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh check then accept rule, same src/dst/users\",\n\t\"id\":          \"ssh-multi-rule-check-then-accept\",\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\":      \"check\",\n\t\t\"checkPeriod\": \"1h\",\n\t\t\"dst\":         [\"tag:server\"],\n\t\t\"src\":         [\"thor@example.org\"],\n\t\t\"users\":       [\"root\"]\n\t}, {\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"thor@example.org\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-edges/ssh-multi-rule-check-then-accept.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action":      "check",
+				"checkPeriod": "1h",
+				"dst":         ["tag:server"],
+				"src":         ["thor@example.org"],
+				"users":       ["root"]
+			}, {
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["thor@example.org"],
+				"users":  ["root"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5525739855615142,
+				"StableID":   "njow2Lpc9k11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       5525739855615142,
+				"Key":        "nodekey:878d3dc41fc5c018d1286fcfc61475aa0ddaba8dfb08529a3196cdb64768eb4a",
+				"DiscoKey":   "discokey:06b81e82c8ce2d5f3909a5bce2bdee5ed297dd821afe08e38a15f13bd89ea257",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:33872",
+					"10.65.0.27:33872",
+					"172.17.0.1:33872",
+					"172.18.0.1:33872",
+					"172.19.0.1:33872",
+					"172.20.0.1:33872",
+					"172.21.0.1:33872",
+					"172.22.0.1:33872",
+					"172.23.0.1:33872",
+					"172.24.0.1:33872",
+					"172.25.0.1:33872",
+					"172.26.0.1:33872",
+					"172.27.0.1:33872"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:32:35.0718264Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:878d3dc41fc5c018d1286fcfc61475aa0ddaba8dfb08529a3196cdb64768eb4a",
+			"MachineKey": "mkey:a62c0f92d9b9eaccb1a490a28a744c48a5f862b8132fbf1e0a02b134f99ae057",
+			"Peers": [{
+				"ID":         8148649908875331,
+				"StableID":   "nQ5zhVDYd621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:34ae890a67e5d412c929bce7c14f74e0b14b57f15f5b72c30272ece0ade3f956",
+				"DiscoKey":   "discokey:597ce076bc8e09c80d609d13a71bb2e397108538d803b86f51f6d8f85cc3a14e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46427",
+					"10.65.0.27:46427",
+					"172.17.0.1:46427",
+					"172.18.0.1:46427",
+					"172.19.0.1:46427",
+					"172.20.0.1:46427",
+					"172.21.0.1:46427",
+					"172.22.0.1:46427",
+					"172.23.0.1:46427",
+					"172.24.0.1:46427",
+					"172.25.0.1:46427",
+					"172.26.0.1:46427",
+					"172.27.0.1:46427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:32:29.103855414Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         391639347960856,
+				"StableID":   "nFnF5hhN4411CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6fee700014fceb14b971c5f3fa0b085583de317a60b028590eee406133cd7271",
+				"DiscoKey":   "discokey:7df6539d847203c3b179a5ca7280281d27a8934b308a2a0e7e8233df4fb72e35",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47469",
+					"10.65.0.27:47469",
+					"172.17.0.1:47469",
+					"172.18.0.1:47469",
+					"172.19.0.1:47469",
+					"172.20.0.1:47469",
+					"172.21.0.1:47469",
+					"172.22.0.1:47469",
+					"172.23.0.1:47469",
+					"172.24.0.1:47469",
+					"172.25.0.1:47469",
+					"172.26.0.1:47469",
+					"172.27.0.1:47469"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:32:29.634846588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4028006846160904,
+				"StableID":   "nwWZjkuHTY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c12617359030b76fe8ebe4669b17843b33bb26937d24a5fc038ec4aca1ba9c26",
+				"DiscoKey":   "discokey:5a1070a7160c63c8bb5774f7813c3cc522f54ba17aa835ac9ca522afe275157a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34387",
+					"10.65.0.27:34387",
+					"172.17.0.1:34387",
+					"172.18.0.1:34387",
+					"172.19.0.1:34387",
+					"172.20.0.1:34387",
+					"172.21.0.1:34387",
+					"172.22.0.1:34387",
+					"172.23.0.1:34387",
+					"172.24.0.1:34387",
+					"172.25.0.1:34387",
+					"172.26.0.1:34387",
+					"172.27.0.1:34387"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:32:30.182224358Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5667609051101869,
+				"StableID":   "nrTm2oUsFm11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0466cdf3ee08d9e7a33aa4ff693cdfb2557741196f15ec2466495d03ea90bb24",
+				"DiscoKey":   "discokey:c2e78a42f31849b917095daf147e8ee4bc9aadddb3b9e03f82437a765996b979",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49885",
+					"10.65.0.27:49885",
+					"172.17.0.1:49885",
+					"172.18.0.1:49885",
+					"172.19.0.1:49885",
+					"172.20.0.1:49885",
+					"172.21.0.1:49885",
+					"172.22.0.1:49885",
+					"172.23.0.1:49885",
+					"172.24.0.1:49885",
+					"172.25.0.1:49885",
+					"172.26.0.1:49885",
+					"172.27.0.1:49885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:32:30.726623781Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7941934760275445,
+				"StableID":   "nUxUtDAv1521CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9a9aa185696cd03de991e3c7fbebe238d84949b7c05325f4ed3027b8379013d",
+				"DiscoKey":   "discokey:73f984575d16237be0d09b95e6cc3368d1e92328ad88ceea61bdb9ca7adc1c1b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50093",
+					"10.65.0.27:50093",
+					"172.17.0.1:50093",
+					"172.18.0.1:50093",
+					"172.19.0.1:50093",
+					"172.20.0.1:50093",
+					"172.21.0.1:50093",
+					"172.22.0.1:50093",
+					"172.23.0.1:50093",
+					"172.24.0.1:50093",
+					"172.25.0.1:50093",
+					"172.26.0.1:50093",
+					"172.27.0.1:50093"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:32:31.264509883Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5117522356983846,
+				"StableID":   "nPoAZodjxg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5ba657c0d8cabbbf649e6fbe62f201662e4972bf7a9885cb71c023b05e4ddb3d",
+				"DiscoKey":   "discokey:855ff5cd29f1f4198c46f3cce4b92a8a6282ead0d35e2ce8f39d0aef2d564628",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:36776",
+					"10.65.0.27:36776",
+					"172.17.0.1:36776",
+					"172.18.0.1:36776",
+					"172.19.0.1:36776",
+					"172.20.0.1:36776",
+					"172.21.0.1:36776",
+					"172.22.0.1:36776",
+					"172.23.0.1:36776",
+					"172.24.0.1:36776",
+					"172.25.0.1:36776",
+					"172.26.0.1:36776",
+					"172.27.0.1:36776"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:32:31.826882566Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         287924645502741,
+				"StableID":   "nLxLywHQF311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a41b428cfcb7a3e5f7de22e9076a13cb6ad3a654ecdd5eb892be78710e4b244",
+				"DiscoKey":   "discokey:0e890516ee8be4d0a1ad4de5942b053e72ae5b30fae17762961d9e9e37a95339",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33298",
+					"10.65.0.27:33298",
+					"172.17.0.1:33298",
+					"172.18.0.1:33298",
+					"172.19.0.1:33298",
+					"172.20.0.1:33298",
+					"172.21.0.1:33298",
+					"172.22.0.1:33298",
+					"172.23.0.1:33298",
+					"172.24.0.1:33298",
+					"172.25.0.1:33298",
+					"172.26.0.1:33298",
+					"172.27.0.1:33298"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:32:32.352383431Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2901116932549833,
+				"StableID":   "nkxRvVRveP11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d50d3291ddcc2426ed52cb1ec7eb372d9b96ed42481bfdaa92edf19933b7a832",
+				"DiscoKey":   "discokey:a35aa66bbfc1ed0a7c4389d94f4a312c3e876b851181c7b5223ebadd96c3943f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48578",
+					"10.65.0.27:48578",
+					"172.17.0.1:48578",
+					"172.18.0.1:48578",
+					"172.19.0.1:48578",
+					"172.20.0.1:48578",
+					"172.21.0.1:48578",
+					"172.22.0.1:48578",
+					"172.23.0.1:48578",
+					"172.24.0.1:48578",
+					"172.25.0.1:48578",
+					"172.26.0.1:48578",
+					"172.27.0.1:48578"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:32:32.893684817Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7120072954315803,
+				"StableID":   "nGVrR6Fhbx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2eda08d9b7d67afa59433c3ad43fa88bb3b634cbc4e148bdd696e81f6ec98867",
+				"DiscoKey":   "discokey:501227c04801df77eadb36c9e1afb905ef69d7d4179c21b1813e8c2172a1790d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45566",
+					"10.65.0.27:45566",
+					"172.17.0.1:45566",
+					"172.18.0.1:45566",
+					"172.19.0.1:45566",
+					"172.20.0.1:45566",
+					"172.21.0.1:45566",
+					"172.22.0.1:45566",
+					"172.23.0.1:45566",
+					"172.24.0.1:45566",
+					"172.25.0.1:45566",
+					"172.26.0.1:45566",
+					"172.27.0.1:45566"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:32:33.465196384Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5888021051733811,
+				"StableID":   "n8Z8m4Lhyn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:09e6d8653854ae1da75e3875192abc593a30f26e60260d4aa881cd103262f110",
+				"DiscoKey":   "discokey:bd3186a88a5dd8901e1a823279a4a0a207aa590c88e242677a94fb0a6400977e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58684",
+					"10.65.0.27:58684",
+					"172.17.0.1:58684",
+					"172.18.0.1:58684",
+					"172.19.0.1:58684",
+					"172.20.0.1:58684",
+					"172.21.0.1:58684",
+					"172.22.0.1:58684",
+					"172.23.0.1:58684",
+					"172.24.0.1:58684",
+					"172.25.0.1:58684",
+					"172.26.0.1:58684",
+					"172.27.0.1:58684"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:32:33.993070049Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6150803441526927,
+				"StableID":   "n855hEBi2q11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c09e025ef3afa0b114831bdb3df9a21fd957e66529a02b7abda72c8d12edb557",
+				"DiscoKey":   "discokey:e40d89391874357ced5eaf747aa4111240a92a6253e12572aca7c9a9aa8b1b32",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38819",
+					"10.65.0.27:38819",
+					"172.17.0.1:38819",
+					"172.18.0.1:38819",
+					"172.19.0.1:38819",
+					"172.20.0.1:38819",
+					"172.21.0.1:38819",
+					"172.22.0.1:38819",
+					"172.23.0.1:38819",
+					"172.24.0.1:38819",
+					"172.25.0.1:38819",
+					"172.26.0.1:38819",
+					"172.27.0.1:38819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:32:34.552360717Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8745332619298087,
+				"StableID":   "nnJoaP4nHB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:807d14fb0b782361ea13d98b82fcfb807a4cdd48f93ea57e1dd76d65498a6b38",
+				"KeyExpiry":  "2026-11-09T09:32:35Z",
+				"DiscoKey":   "discokey:aee8eb99f195b741bf394cd36106086b0ddb07976ca74153927216b327281742",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45759",
+					"10.65.0.27:45759",
+					"172.17.0.1:45759",
+					"172.18.0.1:45759",
+					"172.19.0.1:45759",
+					"172.20.0.1:45759",
+					"172.21.0.1:45759",
+					"172.22.0.1:45759",
+					"172.23.0.1:45759",
+					"172.24.0.1:45759",
+					"172.25.0.1:45759",
+					"172.26.0.1:45759",
+					"172.27.0.1:45759"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:32:35.616160418Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3874427254547311,
+				"StableID":   "n8Rd8ndjFX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bee7fba92b33ef72d90bc38b48c5c500ac2731e2c5f56b5545fa43b059053973",
+				"KeyExpiry":  "2026-11-09T09:32:36Z",
+				"DiscoKey":   "discokey:b2955b623cedbab0242b00574aeb08f48e38df1e99c0128aeb1e85f77794ef6e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:45049",
+					"10.65.0.27:45049",
+					"172.17.0.1:45049",
+					"172.18.0.1:45049",
+					"172.19.0.1:45049",
+					"172.20.0.1:45049",
+					"172.21.0.1:45049",
+					"172.22.0.1:45049",
+					"172.23.0.1:45049",
+					"172.24.0.1:45049",
+					"172.25.0.1:45049",
+					"172.26.0.1:45049",
+					"172.27.0.1:45049"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:32:36.160990465Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7587609051638003,
+				"StableID":   "ncM7MAdSF221CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e2fb44c0f8b5ee8ebebce7b53fe85e66b63fc8bb71e3db350e45e4d9ffdb705a",
+				"KeyExpiry":  "2026-11-09T09:32:36Z",
+				"DiscoKey":   "discokey:3336cb49d6bacf01ef1f81b38ec9d8dbb08b6be1411c2fe4f17f6ed99a4db25c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50296",
+					"10.65.0.27:50296",
+					"172.17.0.1:50296",
+					"172.18.0.1:50296",
+					"172.19.0.1:50296",
+					"172.20.0.1:50296",
+					"172.21.0.1:50296",
+					"172.22.0.1:50296",
+					"172.23.0.1:50296",
+					"172.24.0.1:50296",
+					"172.25.0.1:50296",
+					"172.26.0.1:50296",
+					"172.27.0.1:50296"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:32:36.700599251Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{
+				"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+				"sshUsers":   {"root": "root"},
+				"action": {
+					"holdAndDelegate": "https://unused/machine/ssh/action/$SRC_NODE_ID/to/$DST_NODE_ID?local_user=$LOCAL_USER"
+				}
+			}, {
+				"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+				"sshUsers":   {"root": "root"},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				}
+			}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5525739855615142": {
+				"ID":          5525739855615142,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		},
+		"ssh_rules": [{
+			"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+			"sshUsers":   {"root": "root"},
+			"action": {
+				"holdAndDelegate": "https://unused/machine/ssh/action/$SRC_NODE_ID/to/$DST_NODE_ID?local_user=$LOCAL_USER"
+			}
+		}, {
+			"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+			"sshUsers":   {"root": "root"},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}
+		}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5117522356983846,
+				"StableID":   "nPoAZodjxg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       5117522356983846,
+				"Key":        "nodekey:5ba657c0d8cabbbf649e6fbe62f201662e4972bf7a9885cb71c023b05e4ddb3d",
+				"DiscoKey":   "discokey:855ff5cd29f1f4198c46f3cce4b92a8a6282ead0d35e2ce8f39d0aef2d564628",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:36776",
+					"10.65.0.27:36776",
+					"172.17.0.1:36776",
+					"172.18.0.1:36776",
+					"172.19.0.1:36776",
+					"172.20.0.1:36776",
+					"172.21.0.1:36776",
+					"172.22.0.1:36776",
+					"172.23.0.1:36776",
+					"172.24.0.1:36776",
+					"172.25.0.1:36776",
+					"172.26.0.1:36776",
+					"172.27.0.1:36776"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:32:31.826882566Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5ba657c0d8cabbbf649e6fbe62f201662e4972bf7a9885cb71c023b05e4ddb3d",
+			"MachineKey": "mkey:ba62aee5fcd70a1cb684d09b115376eef11640d5a1f2e5b0b10c0725f1584048",
+			"Peers": [{
+				"ID":         8148649908875331,
+				"StableID":   "nQ5zhVDYd621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:34ae890a67e5d412c929bce7c14f74e0b14b57f15f5b72c30272ece0ade3f956",
+				"DiscoKey":   "discokey:597ce076bc8e09c80d609d13a71bb2e397108538d803b86f51f6d8f85cc3a14e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46427",
+					"10.65.0.27:46427",
+					"172.17.0.1:46427",
+					"172.18.0.1:46427",
+					"172.19.0.1:46427",
+					"172.20.0.1:46427",
+					"172.21.0.1:46427",
+					"172.22.0.1:46427",
+					"172.23.0.1:46427",
+					"172.24.0.1:46427",
+					"172.25.0.1:46427",
+					"172.26.0.1:46427",
+					"172.27.0.1:46427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:32:29.103855414Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         391639347960856,
+				"StableID":   "nFnF5hhN4411CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6fee700014fceb14b971c5f3fa0b085583de317a60b028590eee406133cd7271",
+				"DiscoKey":   "discokey:7df6539d847203c3b179a5ca7280281d27a8934b308a2a0e7e8233df4fb72e35",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47469",
+					"10.65.0.27:47469",
+					"172.17.0.1:47469",
+					"172.18.0.1:47469",
+					"172.19.0.1:47469",
+					"172.20.0.1:47469",
+					"172.21.0.1:47469",
+					"172.22.0.1:47469",
+					"172.23.0.1:47469",
+					"172.24.0.1:47469",
+					"172.25.0.1:47469",
+					"172.26.0.1:47469",
+					"172.27.0.1:47469"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:32:29.634846588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4028006846160904,
+				"StableID":   "nwWZjkuHTY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c12617359030b76fe8ebe4669b17843b33bb26937d24a5fc038ec4aca1ba9c26",
+				"DiscoKey":   "discokey:5a1070a7160c63c8bb5774f7813c3cc522f54ba17aa835ac9ca522afe275157a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34387",
+					"10.65.0.27:34387",
+					"172.17.0.1:34387",
+					"172.18.0.1:34387",
+					"172.19.0.1:34387",
+					"172.20.0.1:34387",
+					"172.21.0.1:34387",
+					"172.22.0.1:34387",
+					"172.23.0.1:34387",
+					"172.24.0.1:34387",
+					"172.25.0.1:34387",
+					"172.26.0.1:34387",
+					"172.27.0.1:34387"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:32:30.182224358Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5667609051101869,
+				"StableID":   "nrTm2oUsFm11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0466cdf3ee08d9e7a33aa4ff693cdfb2557741196f15ec2466495d03ea90bb24",
+				"DiscoKey":   "discokey:c2e78a42f31849b917095daf147e8ee4bc9aadddb3b9e03f82437a765996b979",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49885",
+					"10.65.0.27:49885",
+					"172.17.0.1:49885",
+					"172.18.0.1:49885",
+					"172.19.0.1:49885",
+					"172.20.0.1:49885",
+					"172.21.0.1:49885",
+					"172.22.0.1:49885",
+					"172.23.0.1:49885",
+					"172.24.0.1:49885",
+					"172.25.0.1:49885",
+					"172.26.0.1:49885",
+					"172.27.0.1:49885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:32:30.726623781Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7941934760275445,
+				"StableID":   "nUxUtDAv1521CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9a9aa185696cd03de991e3c7fbebe238d84949b7c05325f4ed3027b8379013d",
+				"DiscoKey":   "discokey:73f984575d16237be0d09b95e6cc3368d1e92328ad88ceea61bdb9ca7adc1c1b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50093",
+					"10.65.0.27:50093",
+					"172.17.0.1:50093",
+					"172.18.0.1:50093",
+					"172.19.0.1:50093",
+					"172.20.0.1:50093",
+					"172.21.0.1:50093",
+					"172.22.0.1:50093",
+					"172.23.0.1:50093",
+					"172.24.0.1:50093",
+					"172.25.0.1:50093",
+					"172.26.0.1:50093",
+					"172.27.0.1:50093"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:32:31.264509883Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         287924645502741,
+				"StableID":   "nLxLywHQF311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a41b428cfcb7a3e5f7de22e9076a13cb6ad3a654ecdd5eb892be78710e4b244",
+				"DiscoKey":   "discokey:0e890516ee8be4d0a1ad4de5942b053e72ae5b30fae17762961d9e9e37a95339",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33298",
+					"10.65.0.27:33298",
+					"172.17.0.1:33298",
+					"172.18.0.1:33298",
+					"172.19.0.1:33298",
+					"172.20.0.1:33298",
+					"172.21.0.1:33298",
+					"172.22.0.1:33298",
+					"172.23.0.1:33298",
+					"172.24.0.1:33298",
+					"172.25.0.1:33298",
+					"172.26.0.1:33298",
+					"172.27.0.1:33298"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:32:32.352383431Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2901116932549833,
+				"StableID":   "nkxRvVRveP11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d50d3291ddcc2426ed52cb1ec7eb372d9b96ed42481bfdaa92edf19933b7a832",
+				"DiscoKey":   "discokey:a35aa66bbfc1ed0a7c4389d94f4a312c3e876b851181c7b5223ebadd96c3943f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48578",
+					"10.65.0.27:48578",
+					"172.17.0.1:48578",
+					"172.18.0.1:48578",
+					"172.19.0.1:48578",
+					"172.20.0.1:48578",
+					"172.21.0.1:48578",
+					"172.22.0.1:48578",
+					"172.23.0.1:48578",
+					"172.24.0.1:48578",
+					"172.25.0.1:48578",
+					"172.26.0.1:48578",
+					"172.27.0.1:48578"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:32:32.893684817Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7120072954315803,
+				"StableID":   "nGVrR6Fhbx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2eda08d9b7d67afa59433c3ad43fa88bb3b634cbc4e148bdd696e81f6ec98867",
+				"DiscoKey":   "discokey:501227c04801df77eadb36c9e1afb905ef69d7d4179c21b1813e8c2172a1790d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45566",
+					"10.65.0.27:45566",
+					"172.17.0.1:45566",
+					"172.18.0.1:45566",
+					"172.19.0.1:45566",
+					"172.20.0.1:45566",
+					"172.21.0.1:45566",
+					"172.22.0.1:45566",
+					"172.23.0.1:45566",
+					"172.24.0.1:45566",
+					"172.25.0.1:45566",
+					"172.26.0.1:45566",
+					"172.27.0.1:45566"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:32:33.465196384Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5888021051733811,
+				"StableID":   "n8Z8m4Lhyn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:09e6d8653854ae1da75e3875192abc593a30f26e60260d4aa881cd103262f110",
+				"DiscoKey":   "discokey:bd3186a88a5dd8901e1a823279a4a0a207aa590c88e242677a94fb0a6400977e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58684",
+					"10.65.0.27:58684",
+					"172.17.0.1:58684",
+					"172.18.0.1:58684",
+					"172.19.0.1:58684",
+					"172.20.0.1:58684",
+					"172.21.0.1:58684",
+					"172.22.0.1:58684",
+					"172.23.0.1:58684",
+					"172.24.0.1:58684",
+					"172.25.0.1:58684",
+					"172.26.0.1:58684",
+					"172.27.0.1:58684"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:32:33.993070049Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6150803441526927,
+				"StableID":   "n855hEBi2q11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c09e025ef3afa0b114831bdb3df9a21fd957e66529a02b7abda72c8d12edb557",
+				"DiscoKey":   "discokey:e40d89391874357ced5eaf747aa4111240a92a6253e12572aca7c9a9aa8b1b32",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38819",
+					"10.65.0.27:38819",
+					"172.17.0.1:38819",
+					"172.18.0.1:38819",
+					"172.19.0.1:38819",
+					"172.20.0.1:38819",
+					"172.21.0.1:38819",
+					"172.22.0.1:38819",
+					"172.23.0.1:38819",
+					"172.24.0.1:38819",
+					"172.25.0.1:38819",
+					"172.26.0.1:38819",
+					"172.27.0.1:38819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:32:34.552360717Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5525739855615142,
+				"StableID":   "njow2Lpc9k11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:878d3dc41fc5c018d1286fcfc61475aa0ddaba8dfb08529a3196cdb64768eb4a",
+				"DiscoKey":   "discokey:06b81e82c8ce2d5f3909a5bce2bdee5ed297dd821afe08e38a15f13bd89ea257",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:33872",
+					"10.65.0.27:33872",
+					"172.17.0.1:33872",
+					"172.18.0.1:33872",
+					"172.19.0.1:33872",
+					"172.20.0.1:33872",
+					"172.21.0.1:33872",
+					"172.22.0.1:33872",
+					"172.23.0.1:33872",
+					"172.24.0.1:33872",
+					"172.25.0.1:33872",
+					"172.26.0.1:33872",
+					"172.27.0.1:33872"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:32:35.0718264Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8745332619298087,
+				"StableID":   "nnJoaP4nHB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:807d14fb0b782361ea13d98b82fcfb807a4cdd48f93ea57e1dd76d65498a6b38",
+				"KeyExpiry":  "2026-11-09T09:32:35Z",
+				"DiscoKey":   "discokey:aee8eb99f195b741bf394cd36106086b0ddb07976ca74153927216b327281742",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45759",
+					"10.65.0.27:45759",
+					"172.17.0.1:45759",
+					"172.18.0.1:45759",
+					"172.19.0.1:45759",
+					"172.20.0.1:45759",
+					"172.21.0.1:45759",
+					"172.22.0.1:45759",
+					"172.23.0.1:45759",
+					"172.24.0.1:45759",
+					"172.25.0.1:45759",
+					"172.26.0.1:45759",
+					"172.27.0.1:45759"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:32:35.616160418Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3874427254547311,
+				"StableID":   "n8Rd8ndjFX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bee7fba92b33ef72d90bc38b48c5c500ac2731e2c5f56b5545fa43b059053973",
+				"KeyExpiry":  "2026-11-09T09:32:36Z",
+				"DiscoKey":   "discokey:b2955b623cedbab0242b00574aeb08f48e38df1e99c0128aeb1e85f77794ef6e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:45049",
+					"10.65.0.27:45049",
+					"172.17.0.1:45049",
+					"172.18.0.1:45049",
+					"172.19.0.1:45049",
+					"172.20.0.1:45049",
+					"172.21.0.1:45049",
+					"172.22.0.1:45049",
+					"172.23.0.1:45049",
+					"172.24.0.1:45049",
+					"172.25.0.1:45049",
+					"172.26.0.1:45049",
+					"172.27.0.1:45049"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:32:36.160990465Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7587609051638003,
+				"StableID":   "ncM7MAdSF221CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e2fb44c0f8b5ee8ebebce7b53fe85e66b63fc8bb71e3db350e45e4d9ffdb705a",
+				"KeyExpiry":  "2026-11-09T09:32:36Z",
+				"DiscoKey":   "discokey:3336cb49d6bacf01ef1f81b38ec9d8dbb08b6be1411c2fe4f17f6ed99a4db25c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50296",
+					"10.65.0.27:50296",
+					"172.17.0.1:50296",
+					"172.18.0.1:50296",
+					"172.19.0.1:50296",
+					"172.20.0.1:50296",
+					"172.21.0.1:50296",
+					"172.22.0.1:50296",
+					"172.23.0.1:50296",
+					"172.24.0.1:50296",
+					"172.25.0.1:50296",
+					"172.26.0.1:50296",
+					"172.27.0.1:50296"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:32:36.700599251Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5117522356983846": {
+				"ID":          5117522356983846,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7587609051638003,
+				"StableID":   "ncM7MAdSF221CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e2fb44c0f8b5ee8ebebce7b53fe85e66b63fc8bb71e3db350e45e4d9ffdb705a",
+				"KeyExpiry":  "2026-11-09T09:32:36Z",
+				"DiscoKey":   "discokey:3336cb49d6bacf01ef1f81b38ec9d8dbb08b6be1411c2fe4f17f6ed99a4db25c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50296",
+					"10.65.0.27:50296",
+					"172.17.0.1:50296",
+					"172.18.0.1:50296",
+					"172.19.0.1:50296",
+					"172.20.0.1:50296",
+					"172.21.0.1:50296",
+					"172.22.0.1:50296",
+					"172.23.0.1:50296",
+					"172.24.0.1:50296",
+					"172.25.0.1:50296",
+					"172.26.0.1:50296",
+					"172.27.0.1:50296"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:32:36.700599251Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e2fb44c0f8b5ee8ebebce7b53fe85e66b63fc8bb71e3db350e45e4d9ffdb705a",
+			"MachineKey": "mkey:34d421f13ce3dc1ad7299f4758fe08a0910285c291b603a062ad2f7590f5f94f",
+			"Peers": [{
+				"ID":         8148649908875331,
+				"StableID":   "nQ5zhVDYd621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:34ae890a67e5d412c929bce7c14f74e0b14b57f15f5b72c30272ece0ade3f956",
+				"DiscoKey":   "discokey:597ce076bc8e09c80d609d13a71bb2e397108538d803b86f51f6d8f85cc3a14e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46427",
+					"10.65.0.27:46427",
+					"172.17.0.1:46427",
+					"172.18.0.1:46427",
+					"172.19.0.1:46427",
+					"172.20.0.1:46427",
+					"172.21.0.1:46427",
+					"172.22.0.1:46427",
+					"172.23.0.1:46427",
+					"172.24.0.1:46427",
+					"172.25.0.1:46427",
+					"172.26.0.1:46427",
+					"172.27.0.1:46427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:32:29.103855414Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         391639347960856,
+				"StableID":   "nFnF5hhN4411CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6fee700014fceb14b971c5f3fa0b085583de317a60b028590eee406133cd7271",
+				"DiscoKey":   "discokey:7df6539d847203c3b179a5ca7280281d27a8934b308a2a0e7e8233df4fb72e35",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47469",
+					"10.65.0.27:47469",
+					"172.17.0.1:47469",
+					"172.18.0.1:47469",
+					"172.19.0.1:47469",
+					"172.20.0.1:47469",
+					"172.21.0.1:47469",
+					"172.22.0.1:47469",
+					"172.23.0.1:47469",
+					"172.24.0.1:47469",
+					"172.25.0.1:47469",
+					"172.26.0.1:47469",
+					"172.27.0.1:47469"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:32:29.634846588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4028006846160904,
+				"StableID":   "nwWZjkuHTY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c12617359030b76fe8ebe4669b17843b33bb26937d24a5fc038ec4aca1ba9c26",
+				"DiscoKey":   "discokey:5a1070a7160c63c8bb5774f7813c3cc522f54ba17aa835ac9ca522afe275157a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34387",
+					"10.65.0.27:34387",
+					"172.17.0.1:34387",
+					"172.18.0.1:34387",
+					"172.19.0.1:34387",
+					"172.20.0.1:34387",
+					"172.21.0.1:34387",
+					"172.22.0.1:34387",
+					"172.23.0.1:34387",
+					"172.24.0.1:34387",
+					"172.25.0.1:34387",
+					"172.26.0.1:34387",
+					"172.27.0.1:34387"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:32:30.182224358Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5667609051101869,
+				"StableID":   "nrTm2oUsFm11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0466cdf3ee08d9e7a33aa4ff693cdfb2557741196f15ec2466495d03ea90bb24",
+				"DiscoKey":   "discokey:c2e78a42f31849b917095daf147e8ee4bc9aadddb3b9e03f82437a765996b979",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49885",
+					"10.65.0.27:49885",
+					"172.17.0.1:49885",
+					"172.18.0.1:49885",
+					"172.19.0.1:49885",
+					"172.20.0.1:49885",
+					"172.21.0.1:49885",
+					"172.22.0.1:49885",
+					"172.23.0.1:49885",
+					"172.24.0.1:49885",
+					"172.25.0.1:49885",
+					"172.26.0.1:49885",
+					"172.27.0.1:49885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:32:30.726623781Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7941934760275445,
+				"StableID":   "nUxUtDAv1521CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9a9aa185696cd03de991e3c7fbebe238d84949b7c05325f4ed3027b8379013d",
+				"DiscoKey":   "discokey:73f984575d16237be0d09b95e6cc3368d1e92328ad88ceea61bdb9ca7adc1c1b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50093",
+					"10.65.0.27:50093",
+					"172.17.0.1:50093",
+					"172.18.0.1:50093",
+					"172.19.0.1:50093",
+					"172.20.0.1:50093",
+					"172.21.0.1:50093",
+					"172.22.0.1:50093",
+					"172.23.0.1:50093",
+					"172.24.0.1:50093",
+					"172.25.0.1:50093",
+					"172.26.0.1:50093",
+					"172.27.0.1:50093"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:32:31.264509883Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5117522356983846,
+				"StableID":   "nPoAZodjxg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5ba657c0d8cabbbf649e6fbe62f201662e4972bf7a9885cb71c023b05e4ddb3d",
+				"DiscoKey":   "discokey:855ff5cd29f1f4198c46f3cce4b92a8a6282ead0d35e2ce8f39d0aef2d564628",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:36776",
+					"10.65.0.27:36776",
+					"172.17.0.1:36776",
+					"172.18.0.1:36776",
+					"172.19.0.1:36776",
+					"172.20.0.1:36776",
+					"172.21.0.1:36776",
+					"172.22.0.1:36776",
+					"172.23.0.1:36776",
+					"172.24.0.1:36776",
+					"172.25.0.1:36776",
+					"172.26.0.1:36776",
+					"172.27.0.1:36776"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:32:31.826882566Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         287924645502741,
+				"StableID":   "nLxLywHQF311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a41b428cfcb7a3e5f7de22e9076a13cb6ad3a654ecdd5eb892be78710e4b244",
+				"DiscoKey":   "discokey:0e890516ee8be4d0a1ad4de5942b053e72ae5b30fae17762961d9e9e37a95339",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33298",
+					"10.65.0.27:33298",
+					"172.17.0.1:33298",
+					"172.18.0.1:33298",
+					"172.19.0.1:33298",
+					"172.20.0.1:33298",
+					"172.21.0.1:33298",
+					"172.22.0.1:33298",
+					"172.23.0.1:33298",
+					"172.24.0.1:33298",
+					"172.25.0.1:33298",
+					"172.26.0.1:33298",
+					"172.27.0.1:33298"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:32:32.352383431Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2901116932549833,
+				"StableID":   "nkxRvVRveP11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d50d3291ddcc2426ed52cb1ec7eb372d9b96ed42481bfdaa92edf19933b7a832",
+				"DiscoKey":   "discokey:a35aa66bbfc1ed0a7c4389d94f4a312c3e876b851181c7b5223ebadd96c3943f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48578",
+					"10.65.0.27:48578",
+					"172.17.0.1:48578",
+					"172.18.0.1:48578",
+					"172.19.0.1:48578",
+					"172.20.0.1:48578",
+					"172.21.0.1:48578",
+					"172.22.0.1:48578",
+					"172.23.0.1:48578",
+					"172.24.0.1:48578",
+					"172.25.0.1:48578",
+					"172.26.0.1:48578",
+					"172.27.0.1:48578"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:32:32.893684817Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7120072954315803,
+				"StableID":   "nGVrR6Fhbx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2eda08d9b7d67afa59433c3ad43fa88bb3b634cbc4e148bdd696e81f6ec98867",
+				"DiscoKey":   "discokey:501227c04801df77eadb36c9e1afb905ef69d7d4179c21b1813e8c2172a1790d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45566",
+					"10.65.0.27:45566",
+					"172.17.0.1:45566",
+					"172.18.0.1:45566",
+					"172.19.0.1:45566",
+					"172.20.0.1:45566",
+					"172.21.0.1:45566",
+					"172.22.0.1:45566",
+					"172.23.0.1:45566",
+					"172.24.0.1:45566",
+					"172.25.0.1:45566",
+					"172.26.0.1:45566",
+					"172.27.0.1:45566"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:32:33.465196384Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5888021051733811,
+				"StableID":   "n8Z8m4Lhyn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:09e6d8653854ae1da75e3875192abc593a30f26e60260d4aa881cd103262f110",
+				"DiscoKey":   "discokey:bd3186a88a5dd8901e1a823279a4a0a207aa590c88e242677a94fb0a6400977e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58684",
+					"10.65.0.27:58684",
+					"172.17.0.1:58684",
+					"172.18.0.1:58684",
+					"172.19.0.1:58684",
+					"172.20.0.1:58684",
+					"172.21.0.1:58684",
+					"172.22.0.1:58684",
+					"172.23.0.1:58684",
+					"172.24.0.1:58684",
+					"172.25.0.1:58684",
+					"172.26.0.1:58684",
+					"172.27.0.1:58684"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:32:33.993070049Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6150803441526927,
+				"StableID":   "n855hEBi2q11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c09e025ef3afa0b114831bdb3df9a21fd957e66529a02b7abda72c8d12edb557",
+				"DiscoKey":   "discokey:e40d89391874357ced5eaf747aa4111240a92a6253e12572aca7c9a9aa8b1b32",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38819",
+					"10.65.0.27:38819",
+					"172.17.0.1:38819",
+					"172.18.0.1:38819",
+					"172.19.0.1:38819",
+					"172.20.0.1:38819",
+					"172.21.0.1:38819",
+					"172.22.0.1:38819",
+					"172.23.0.1:38819",
+					"172.24.0.1:38819",
+					"172.25.0.1:38819",
+					"172.26.0.1:38819",
+					"172.27.0.1:38819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:32:34.552360717Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5525739855615142,
+				"StableID":   "njow2Lpc9k11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:878d3dc41fc5c018d1286fcfc61475aa0ddaba8dfb08529a3196cdb64768eb4a",
+				"DiscoKey":   "discokey:06b81e82c8ce2d5f3909a5bce2bdee5ed297dd821afe08e38a15f13bd89ea257",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:33872",
+					"10.65.0.27:33872",
+					"172.17.0.1:33872",
+					"172.18.0.1:33872",
+					"172.19.0.1:33872",
+					"172.20.0.1:33872",
+					"172.21.0.1:33872",
+					"172.22.0.1:33872",
+					"172.23.0.1:33872",
+					"172.24.0.1:33872",
+					"172.25.0.1:33872",
+					"172.26.0.1:33872",
+					"172.27.0.1:33872"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:32:35.0718264Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8745332619298087,
+				"StableID":   "nnJoaP4nHB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:807d14fb0b782361ea13d98b82fcfb807a4cdd48f93ea57e1dd76d65498a6b38",
+				"KeyExpiry":  "2026-11-09T09:32:35Z",
+				"DiscoKey":   "discokey:aee8eb99f195b741bf394cd36106086b0ddb07976ca74153927216b327281742",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45759",
+					"10.65.0.27:45759",
+					"172.17.0.1:45759",
+					"172.18.0.1:45759",
+					"172.19.0.1:45759",
+					"172.20.0.1:45759",
+					"172.21.0.1:45759",
+					"172.22.0.1:45759",
+					"172.23.0.1:45759",
+					"172.24.0.1:45759",
+					"172.25.0.1:45759",
+					"172.26.0.1:45759",
+					"172.27.0.1:45759"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:32:35.616160418Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3874427254547311,
+				"StableID":   "n8Rd8ndjFX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bee7fba92b33ef72d90bc38b48c5c500ac2731e2c5f56b5545fa43b059053973",
+				"KeyExpiry":  "2026-11-09T09:32:36Z",
+				"DiscoKey":   "discokey:b2955b623cedbab0242b00574aeb08f48e38df1e99c0128aeb1e85f77794ef6e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:45049",
+					"10.65.0.27:45049",
+					"172.17.0.1:45049",
+					"172.18.0.1:45049",
+					"172.19.0.1:45049",
+					"172.20.0.1:45049",
+					"172.21.0.1:45049",
+					"172.22.0.1:45049",
+					"172.23.0.1:45049",
+					"172.24.0.1:45049",
+					"172.25.0.1:45049",
+					"172.26.0.1:45049",
+					"172.27.0.1:45049"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:32:36.160990465Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4028006846160904,
+				"StableID":   "nwWZjkuHTY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       4028006846160904,
+				"Key":        "nodekey:c12617359030b76fe8ebe4669b17843b33bb26937d24a5fc038ec4aca1ba9c26",
+				"DiscoKey":   "discokey:5a1070a7160c63c8bb5774f7813c3cc522f54ba17aa835ac9ca522afe275157a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34387",
+					"10.65.0.27:34387",
+					"172.17.0.1:34387",
+					"172.18.0.1:34387",
+					"172.19.0.1:34387",
+					"172.20.0.1:34387",
+					"172.21.0.1:34387",
+					"172.22.0.1:34387",
+					"172.23.0.1:34387",
+					"172.24.0.1:34387",
+					"172.25.0.1:34387",
+					"172.26.0.1:34387",
+					"172.27.0.1:34387"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:32:30.182224358Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c12617359030b76fe8ebe4669b17843b33bb26937d24a5fc038ec4aca1ba9c26",
+			"MachineKey": "mkey:9bb6887446d6e8a8842143f0c5ac7c0df4cafc8e29693616dab82b327990c049",
+			"Peers": [{
+				"ID":         8148649908875331,
+				"StableID":   "nQ5zhVDYd621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:34ae890a67e5d412c929bce7c14f74e0b14b57f15f5b72c30272ece0ade3f956",
+				"DiscoKey":   "discokey:597ce076bc8e09c80d609d13a71bb2e397108538d803b86f51f6d8f85cc3a14e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46427",
+					"10.65.0.27:46427",
+					"172.17.0.1:46427",
+					"172.18.0.1:46427",
+					"172.19.0.1:46427",
+					"172.20.0.1:46427",
+					"172.21.0.1:46427",
+					"172.22.0.1:46427",
+					"172.23.0.1:46427",
+					"172.24.0.1:46427",
+					"172.25.0.1:46427",
+					"172.26.0.1:46427",
+					"172.27.0.1:46427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:32:29.103855414Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         391639347960856,
+				"StableID":   "nFnF5hhN4411CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6fee700014fceb14b971c5f3fa0b085583de317a60b028590eee406133cd7271",
+				"DiscoKey":   "discokey:7df6539d847203c3b179a5ca7280281d27a8934b308a2a0e7e8233df4fb72e35",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47469",
+					"10.65.0.27:47469",
+					"172.17.0.1:47469",
+					"172.18.0.1:47469",
+					"172.19.0.1:47469",
+					"172.20.0.1:47469",
+					"172.21.0.1:47469",
+					"172.22.0.1:47469",
+					"172.23.0.1:47469",
+					"172.24.0.1:47469",
+					"172.25.0.1:47469",
+					"172.26.0.1:47469",
+					"172.27.0.1:47469"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:32:29.634846588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5667609051101869,
+				"StableID":   "nrTm2oUsFm11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0466cdf3ee08d9e7a33aa4ff693cdfb2557741196f15ec2466495d03ea90bb24",
+				"DiscoKey":   "discokey:c2e78a42f31849b917095daf147e8ee4bc9aadddb3b9e03f82437a765996b979",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49885",
+					"10.65.0.27:49885",
+					"172.17.0.1:49885",
+					"172.18.0.1:49885",
+					"172.19.0.1:49885",
+					"172.20.0.1:49885",
+					"172.21.0.1:49885",
+					"172.22.0.1:49885",
+					"172.23.0.1:49885",
+					"172.24.0.1:49885",
+					"172.25.0.1:49885",
+					"172.26.0.1:49885",
+					"172.27.0.1:49885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:32:30.726623781Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7941934760275445,
+				"StableID":   "nUxUtDAv1521CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9a9aa185696cd03de991e3c7fbebe238d84949b7c05325f4ed3027b8379013d",
+				"DiscoKey":   "discokey:73f984575d16237be0d09b95e6cc3368d1e92328ad88ceea61bdb9ca7adc1c1b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50093",
+					"10.65.0.27:50093",
+					"172.17.0.1:50093",
+					"172.18.0.1:50093",
+					"172.19.0.1:50093",
+					"172.20.0.1:50093",
+					"172.21.0.1:50093",
+					"172.22.0.1:50093",
+					"172.23.0.1:50093",
+					"172.24.0.1:50093",
+					"172.25.0.1:50093",
+					"172.26.0.1:50093",
+					"172.27.0.1:50093"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:32:31.264509883Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5117522356983846,
+				"StableID":   "nPoAZodjxg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5ba657c0d8cabbbf649e6fbe62f201662e4972bf7a9885cb71c023b05e4ddb3d",
+				"DiscoKey":   "discokey:855ff5cd29f1f4198c46f3cce4b92a8a6282ead0d35e2ce8f39d0aef2d564628",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:36776",
+					"10.65.0.27:36776",
+					"172.17.0.1:36776",
+					"172.18.0.1:36776",
+					"172.19.0.1:36776",
+					"172.20.0.1:36776",
+					"172.21.0.1:36776",
+					"172.22.0.1:36776",
+					"172.23.0.1:36776",
+					"172.24.0.1:36776",
+					"172.25.0.1:36776",
+					"172.26.0.1:36776",
+					"172.27.0.1:36776"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:32:31.826882566Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         287924645502741,
+				"StableID":   "nLxLywHQF311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a41b428cfcb7a3e5f7de22e9076a13cb6ad3a654ecdd5eb892be78710e4b244",
+				"DiscoKey":   "discokey:0e890516ee8be4d0a1ad4de5942b053e72ae5b30fae17762961d9e9e37a95339",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33298",
+					"10.65.0.27:33298",
+					"172.17.0.1:33298",
+					"172.18.0.1:33298",
+					"172.19.0.1:33298",
+					"172.20.0.1:33298",
+					"172.21.0.1:33298",
+					"172.22.0.1:33298",
+					"172.23.0.1:33298",
+					"172.24.0.1:33298",
+					"172.25.0.1:33298",
+					"172.26.0.1:33298",
+					"172.27.0.1:33298"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:32:32.352383431Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2901116932549833,
+				"StableID":   "nkxRvVRveP11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d50d3291ddcc2426ed52cb1ec7eb372d9b96ed42481bfdaa92edf19933b7a832",
+				"DiscoKey":   "discokey:a35aa66bbfc1ed0a7c4389d94f4a312c3e876b851181c7b5223ebadd96c3943f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48578",
+					"10.65.0.27:48578",
+					"172.17.0.1:48578",
+					"172.18.0.1:48578",
+					"172.19.0.1:48578",
+					"172.20.0.1:48578",
+					"172.21.0.1:48578",
+					"172.22.0.1:48578",
+					"172.23.0.1:48578",
+					"172.24.0.1:48578",
+					"172.25.0.1:48578",
+					"172.26.0.1:48578",
+					"172.27.0.1:48578"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:32:32.893684817Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7120072954315803,
+				"StableID":   "nGVrR6Fhbx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2eda08d9b7d67afa59433c3ad43fa88bb3b634cbc4e148bdd696e81f6ec98867",
+				"DiscoKey":   "discokey:501227c04801df77eadb36c9e1afb905ef69d7d4179c21b1813e8c2172a1790d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45566",
+					"10.65.0.27:45566",
+					"172.17.0.1:45566",
+					"172.18.0.1:45566",
+					"172.19.0.1:45566",
+					"172.20.0.1:45566",
+					"172.21.0.1:45566",
+					"172.22.0.1:45566",
+					"172.23.0.1:45566",
+					"172.24.0.1:45566",
+					"172.25.0.1:45566",
+					"172.26.0.1:45566",
+					"172.27.0.1:45566"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:32:33.465196384Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5888021051733811,
+				"StableID":   "n8Z8m4Lhyn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:09e6d8653854ae1da75e3875192abc593a30f26e60260d4aa881cd103262f110",
+				"DiscoKey":   "discokey:bd3186a88a5dd8901e1a823279a4a0a207aa590c88e242677a94fb0a6400977e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58684",
+					"10.65.0.27:58684",
+					"172.17.0.1:58684",
+					"172.18.0.1:58684",
+					"172.19.0.1:58684",
+					"172.20.0.1:58684",
+					"172.21.0.1:58684",
+					"172.22.0.1:58684",
+					"172.23.0.1:58684",
+					"172.24.0.1:58684",
+					"172.25.0.1:58684",
+					"172.26.0.1:58684",
+					"172.27.0.1:58684"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:32:33.993070049Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6150803441526927,
+				"StableID":   "n855hEBi2q11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c09e025ef3afa0b114831bdb3df9a21fd957e66529a02b7abda72c8d12edb557",
+				"DiscoKey":   "discokey:e40d89391874357ced5eaf747aa4111240a92a6253e12572aca7c9a9aa8b1b32",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38819",
+					"10.65.0.27:38819",
+					"172.17.0.1:38819",
+					"172.18.0.1:38819",
+					"172.19.0.1:38819",
+					"172.20.0.1:38819",
+					"172.21.0.1:38819",
+					"172.22.0.1:38819",
+					"172.23.0.1:38819",
+					"172.24.0.1:38819",
+					"172.25.0.1:38819",
+					"172.26.0.1:38819",
+					"172.27.0.1:38819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:32:34.552360717Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5525739855615142,
+				"StableID":   "njow2Lpc9k11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:878d3dc41fc5c018d1286fcfc61475aa0ddaba8dfb08529a3196cdb64768eb4a",
+				"DiscoKey":   "discokey:06b81e82c8ce2d5f3909a5bce2bdee5ed297dd821afe08e38a15f13bd89ea257",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:33872",
+					"10.65.0.27:33872",
+					"172.17.0.1:33872",
+					"172.18.0.1:33872",
+					"172.19.0.1:33872",
+					"172.20.0.1:33872",
+					"172.21.0.1:33872",
+					"172.22.0.1:33872",
+					"172.23.0.1:33872",
+					"172.24.0.1:33872",
+					"172.25.0.1:33872",
+					"172.26.0.1:33872",
+					"172.27.0.1:33872"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:32:35.0718264Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8745332619298087,
+				"StableID":   "nnJoaP4nHB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:807d14fb0b782361ea13d98b82fcfb807a4cdd48f93ea57e1dd76d65498a6b38",
+				"KeyExpiry":  "2026-11-09T09:32:35Z",
+				"DiscoKey":   "discokey:aee8eb99f195b741bf394cd36106086b0ddb07976ca74153927216b327281742",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45759",
+					"10.65.0.27:45759",
+					"172.17.0.1:45759",
+					"172.18.0.1:45759",
+					"172.19.0.1:45759",
+					"172.20.0.1:45759",
+					"172.21.0.1:45759",
+					"172.22.0.1:45759",
+					"172.23.0.1:45759",
+					"172.24.0.1:45759",
+					"172.25.0.1:45759",
+					"172.26.0.1:45759",
+					"172.27.0.1:45759"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:32:35.616160418Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3874427254547311,
+				"StableID":   "n8Rd8ndjFX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bee7fba92b33ef72d90bc38b48c5c500ac2731e2c5f56b5545fa43b059053973",
+				"KeyExpiry":  "2026-11-09T09:32:36Z",
+				"DiscoKey":   "discokey:b2955b623cedbab0242b00574aeb08f48e38df1e99c0128aeb1e85f77794ef6e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:45049",
+					"10.65.0.27:45049",
+					"172.17.0.1:45049",
+					"172.18.0.1:45049",
+					"172.19.0.1:45049",
+					"172.20.0.1:45049",
+					"172.21.0.1:45049",
+					"172.22.0.1:45049",
+					"172.23.0.1:45049",
+					"172.24.0.1:45049",
+					"172.25.0.1:45049",
+					"172.26.0.1:45049",
+					"172.27.0.1:45049"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:32:36.160990465Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7587609051638003,
+				"StableID":   "ncM7MAdSF221CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e2fb44c0f8b5ee8ebebce7b53fe85e66b63fc8bb71e3db350e45e4d9ffdb705a",
+				"KeyExpiry":  "2026-11-09T09:32:36Z",
+				"DiscoKey":   "discokey:3336cb49d6bacf01ef1f81b38ec9d8dbb08b6be1411c2fe4f17f6ed99a4db25c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50296",
+					"10.65.0.27:50296",
+					"172.17.0.1:50296",
+					"172.18.0.1:50296",
+					"172.19.0.1:50296",
+					"172.20.0.1:50296",
+					"172.21.0.1:50296",
+					"172.22.0.1:50296",
+					"172.23.0.1:50296",
+					"172.24.0.1:50296",
+					"172.25.0.1:50296",
+					"172.26.0.1:50296",
+					"172.27.0.1:50296"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:32:36.700599251Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4028006846160904": {
+				"ID":          4028006846160904,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2901116932549833,
+				"StableID":   "nkxRvVRveP11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       2901116932549833,
+				"Key":        "nodekey:d50d3291ddcc2426ed52cb1ec7eb372d9b96ed42481bfdaa92edf19933b7a832",
+				"DiscoKey":   "discokey:a35aa66bbfc1ed0a7c4389d94f4a312c3e876b851181c7b5223ebadd96c3943f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48578",
+					"10.65.0.27:48578",
+					"172.17.0.1:48578",
+					"172.18.0.1:48578",
+					"172.19.0.1:48578",
+					"172.20.0.1:48578",
+					"172.21.0.1:48578",
+					"172.22.0.1:48578",
+					"172.23.0.1:48578",
+					"172.24.0.1:48578",
+					"172.25.0.1:48578",
+					"172.26.0.1:48578",
+					"172.27.0.1:48578"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:32:32.893684817Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d50d3291ddcc2426ed52cb1ec7eb372d9b96ed42481bfdaa92edf19933b7a832",
+			"MachineKey": "mkey:c0bd5ca722c6dbcf1d5002457470ef58a374256f106e2a2f3d24bde07baf2057",
+			"Peers": [{
+				"ID":         8148649908875331,
+				"StableID":   "nQ5zhVDYd621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:34ae890a67e5d412c929bce7c14f74e0b14b57f15f5b72c30272ece0ade3f956",
+				"DiscoKey":   "discokey:597ce076bc8e09c80d609d13a71bb2e397108538d803b86f51f6d8f85cc3a14e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46427",
+					"10.65.0.27:46427",
+					"172.17.0.1:46427",
+					"172.18.0.1:46427",
+					"172.19.0.1:46427",
+					"172.20.0.1:46427",
+					"172.21.0.1:46427",
+					"172.22.0.1:46427",
+					"172.23.0.1:46427",
+					"172.24.0.1:46427",
+					"172.25.0.1:46427",
+					"172.26.0.1:46427",
+					"172.27.0.1:46427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:32:29.103855414Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         391639347960856,
+				"StableID":   "nFnF5hhN4411CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6fee700014fceb14b971c5f3fa0b085583de317a60b028590eee406133cd7271",
+				"DiscoKey":   "discokey:7df6539d847203c3b179a5ca7280281d27a8934b308a2a0e7e8233df4fb72e35",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47469",
+					"10.65.0.27:47469",
+					"172.17.0.1:47469",
+					"172.18.0.1:47469",
+					"172.19.0.1:47469",
+					"172.20.0.1:47469",
+					"172.21.0.1:47469",
+					"172.22.0.1:47469",
+					"172.23.0.1:47469",
+					"172.24.0.1:47469",
+					"172.25.0.1:47469",
+					"172.26.0.1:47469",
+					"172.27.0.1:47469"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:32:29.634846588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4028006846160904,
+				"StableID":   "nwWZjkuHTY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c12617359030b76fe8ebe4669b17843b33bb26937d24a5fc038ec4aca1ba9c26",
+				"DiscoKey":   "discokey:5a1070a7160c63c8bb5774f7813c3cc522f54ba17aa835ac9ca522afe275157a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34387",
+					"10.65.0.27:34387",
+					"172.17.0.1:34387",
+					"172.18.0.1:34387",
+					"172.19.0.1:34387",
+					"172.20.0.1:34387",
+					"172.21.0.1:34387",
+					"172.22.0.1:34387",
+					"172.23.0.1:34387",
+					"172.24.0.1:34387",
+					"172.25.0.1:34387",
+					"172.26.0.1:34387",
+					"172.27.0.1:34387"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:32:30.182224358Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5667609051101869,
+				"StableID":   "nrTm2oUsFm11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0466cdf3ee08d9e7a33aa4ff693cdfb2557741196f15ec2466495d03ea90bb24",
+				"DiscoKey":   "discokey:c2e78a42f31849b917095daf147e8ee4bc9aadddb3b9e03f82437a765996b979",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49885",
+					"10.65.0.27:49885",
+					"172.17.0.1:49885",
+					"172.18.0.1:49885",
+					"172.19.0.1:49885",
+					"172.20.0.1:49885",
+					"172.21.0.1:49885",
+					"172.22.0.1:49885",
+					"172.23.0.1:49885",
+					"172.24.0.1:49885",
+					"172.25.0.1:49885",
+					"172.26.0.1:49885",
+					"172.27.0.1:49885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:32:30.726623781Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7941934760275445,
+				"StableID":   "nUxUtDAv1521CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9a9aa185696cd03de991e3c7fbebe238d84949b7c05325f4ed3027b8379013d",
+				"DiscoKey":   "discokey:73f984575d16237be0d09b95e6cc3368d1e92328ad88ceea61bdb9ca7adc1c1b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50093",
+					"10.65.0.27:50093",
+					"172.17.0.1:50093",
+					"172.18.0.1:50093",
+					"172.19.0.1:50093",
+					"172.20.0.1:50093",
+					"172.21.0.1:50093",
+					"172.22.0.1:50093",
+					"172.23.0.1:50093",
+					"172.24.0.1:50093",
+					"172.25.0.1:50093",
+					"172.26.0.1:50093",
+					"172.27.0.1:50093"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:32:31.264509883Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5117522356983846,
+				"StableID":   "nPoAZodjxg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5ba657c0d8cabbbf649e6fbe62f201662e4972bf7a9885cb71c023b05e4ddb3d",
+				"DiscoKey":   "discokey:855ff5cd29f1f4198c46f3cce4b92a8a6282ead0d35e2ce8f39d0aef2d564628",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:36776",
+					"10.65.0.27:36776",
+					"172.17.0.1:36776",
+					"172.18.0.1:36776",
+					"172.19.0.1:36776",
+					"172.20.0.1:36776",
+					"172.21.0.1:36776",
+					"172.22.0.1:36776",
+					"172.23.0.1:36776",
+					"172.24.0.1:36776",
+					"172.25.0.1:36776",
+					"172.26.0.1:36776",
+					"172.27.0.1:36776"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:32:31.826882566Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         287924645502741,
+				"StableID":   "nLxLywHQF311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a41b428cfcb7a3e5f7de22e9076a13cb6ad3a654ecdd5eb892be78710e4b244",
+				"DiscoKey":   "discokey:0e890516ee8be4d0a1ad4de5942b053e72ae5b30fae17762961d9e9e37a95339",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33298",
+					"10.65.0.27:33298",
+					"172.17.0.1:33298",
+					"172.18.0.1:33298",
+					"172.19.0.1:33298",
+					"172.20.0.1:33298",
+					"172.21.0.1:33298",
+					"172.22.0.1:33298",
+					"172.23.0.1:33298",
+					"172.24.0.1:33298",
+					"172.25.0.1:33298",
+					"172.26.0.1:33298",
+					"172.27.0.1:33298"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:32:32.352383431Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7120072954315803,
+				"StableID":   "nGVrR6Fhbx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2eda08d9b7d67afa59433c3ad43fa88bb3b634cbc4e148bdd696e81f6ec98867",
+				"DiscoKey":   "discokey:501227c04801df77eadb36c9e1afb905ef69d7d4179c21b1813e8c2172a1790d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45566",
+					"10.65.0.27:45566",
+					"172.17.0.1:45566",
+					"172.18.0.1:45566",
+					"172.19.0.1:45566",
+					"172.20.0.1:45566",
+					"172.21.0.1:45566",
+					"172.22.0.1:45566",
+					"172.23.0.1:45566",
+					"172.24.0.1:45566",
+					"172.25.0.1:45566",
+					"172.26.0.1:45566",
+					"172.27.0.1:45566"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:32:33.465196384Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5888021051733811,
+				"StableID":   "n8Z8m4Lhyn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:09e6d8653854ae1da75e3875192abc593a30f26e60260d4aa881cd103262f110",
+				"DiscoKey":   "discokey:bd3186a88a5dd8901e1a823279a4a0a207aa590c88e242677a94fb0a6400977e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58684",
+					"10.65.0.27:58684",
+					"172.17.0.1:58684",
+					"172.18.0.1:58684",
+					"172.19.0.1:58684",
+					"172.20.0.1:58684",
+					"172.21.0.1:58684",
+					"172.22.0.1:58684",
+					"172.23.0.1:58684",
+					"172.24.0.1:58684",
+					"172.25.0.1:58684",
+					"172.26.0.1:58684",
+					"172.27.0.1:58684"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:32:33.993070049Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6150803441526927,
+				"StableID":   "n855hEBi2q11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c09e025ef3afa0b114831bdb3df9a21fd957e66529a02b7abda72c8d12edb557",
+				"DiscoKey":   "discokey:e40d89391874357ced5eaf747aa4111240a92a6253e12572aca7c9a9aa8b1b32",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38819",
+					"10.65.0.27:38819",
+					"172.17.0.1:38819",
+					"172.18.0.1:38819",
+					"172.19.0.1:38819",
+					"172.20.0.1:38819",
+					"172.21.0.1:38819",
+					"172.22.0.1:38819",
+					"172.23.0.1:38819",
+					"172.24.0.1:38819",
+					"172.25.0.1:38819",
+					"172.26.0.1:38819",
+					"172.27.0.1:38819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:32:34.552360717Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5525739855615142,
+				"StableID":   "njow2Lpc9k11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:878d3dc41fc5c018d1286fcfc61475aa0ddaba8dfb08529a3196cdb64768eb4a",
+				"DiscoKey":   "discokey:06b81e82c8ce2d5f3909a5bce2bdee5ed297dd821afe08e38a15f13bd89ea257",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:33872",
+					"10.65.0.27:33872",
+					"172.17.0.1:33872",
+					"172.18.0.1:33872",
+					"172.19.0.1:33872",
+					"172.20.0.1:33872",
+					"172.21.0.1:33872",
+					"172.22.0.1:33872",
+					"172.23.0.1:33872",
+					"172.24.0.1:33872",
+					"172.25.0.1:33872",
+					"172.26.0.1:33872",
+					"172.27.0.1:33872"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:32:35.0718264Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8745332619298087,
+				"StableID":   "nnJoaP4nHB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:807d14fb0b782361ea13d98b82fcfb807a4cdd48f93ea57e1dd76d65498a6b38",
+				"KeyExpiry":  "2026-11-09T09:32:35Z",
+				"DiscoKey":   "discokey:aee8eb99f195b741bf394cd36106086b0ddb07976ca74153927216b327281742",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45759",
+					"10.65.0.27:45759",
+					"172.17.0.1:45759",
+					"172.18.0.1:45759",
+					"172.19.0.1:45759",
+					"172.20.0.1:45759",
+					"172.21.0.1:45759",
+					"172.22.0.1:45759",
+					"172.23.0.1:45759",
+					"172.24.0.1:45759",
+					"172.25.0.1:45759",
+					"172.26.0.1:45759",
+					"172.27.0.1:45759"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:32:35.616160418Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3874427254547311,
+				"StableID":   "n8Rd8ndjFX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bee7fba92b33ef72d90bc38b48c5c500ac2731e2c5f56b5545fa43b059053973",
+				"KeyExpiry":  "2026-11-09T09:32:36Z",
+				"DiscoKey":   "discokey:b2955b623cedbab0242b00574aeb08f48e38df1e99c0128aeb1e85f77794ef6e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:45049",
+					"10.65.0.27:45049",
+					"172.17.0.1:45049",
+					"172.18.0.1:45049",
+					"172.19.0.1:45049",
+					"172.20.0.1:45049",
+					"172.21.0.1:45049",
+					"172.22.0.1:45049",
+					"172.23.0.1:45049",
+					"172.24.0.1:45049",
+					"172.25.0.1:45049",
+					"172.26.0.1:45049",
+					"172.27.0.1:45049"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:32:36.160990465Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7587609051638003,
+				"StableID":   "ncM7MAdSF221CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e2fb44c0f8b5ee8ebebce7b53fe85e66b63fc8bb71e3db350e45e4d9ffdb705a",
+				"KeyExpiry":  "2026-11-09T09:32:36Z",
+				"DiscoKey":   "discokey:3336cb49d6bacf01ef1f81b38ec9d8dbb08b6be1411c2fe4f17f6ed99a4db25c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50296",
+					"10.65.0.27:50296",
+					"172.17.0.1:50296",
+					"172.18.0.1:50296",
+					"172.19.0.1:50296",
+					"172.20.0.1:50296",
+					"172.21.0.1:50296",
+					"172.22.0.1:50296",
+					"172.23.0.1:50296",
+					"172.24.0.1:50296",
+					"172.25.0.1:50296",
+					"172.26.0.1:50296",
+					"172.27.0.1:50296"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:32:36.700599251Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2901116932549833": {
+				"ID":          2901116932549833,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8745332619298087,
+				"StableID":   "nnJoaP4nHB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:807d14fb0b782361ea13d98b82fcfb807a4cdd48f93ea57e1dd76d65498a6b38",
+				"KeyExpiry":  "2026-11-09T09:32:35Z",
+				"DiscoKey":   "discokey:aee8eb99f195b741bf394cd36106086b0ddb07976ca74153927216b327281742",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45759",
+					"10.65.0.27:45759",
+					"172.17.0.1:45759",
+					"172.18.0.1:45759",
+					"172.19.0.1:45759",
+					"172.20.0.1:45759",
+					"172.21.0.1:45759",
+					"172.22.0.1:45759",
+					"172.23.0.1:45759",
+					"172.24.0.1:45759",
+					"172.25.0.1:45759",
+					"172.26.0.1:45759",
+					"172.27.0.1:45759"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:32:35.616160418Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:807d14fb0b782361ea13d98b82fcfb807a4cdd48f93ea57e1dd76d65498a6b38",
+			"MachineKey": "mkey:71261cf383e01dc2e202488ae29b9d67cc25cff90cc1c5eb08aa6cb391747556",
+			"Peers": [{
+				"ID":         8148649908875331,
+				"StableID":   "nQ5zhVDYd621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:34ae890a67e5d412c929bce7c14f74e0b14b57f15f5b72c30272ece0ade3f956",
+				"DiscoKey":   "discokey:597ce076bc8e09c80d609d13a71bb2e397108538d803b86f51f6d8f85cc3a14e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46427",
+					"10.65.0.27:46427",
+					"172.17.0.1:46427",
+					"172.18.0.1:46427",
+					"172.19.0.1:46427",
+					"172.20.0.1:46427",
+					"172.21.0.1:46427",
+					"172.22.0.1:46427",
+					"172.23.0.1:46427",
+					"172.24.0.1:46427",
+					"172.25.0.1:46427",
+					"172.26.0.1:46427",
+					"172.27.0.1:46427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:32:29.103855414Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         391639347960856,
+				"StableID":   "nFnF5hhN4411CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6fee700014fceb14b971c5f3fa0b085583de317a60b028590eee406133cd7271",
+				"DiscoKey":   "discokey:7df6539d847203c3b179a5ca7280281d27a8934b308a2a0e7e8233df4fb72e35",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47469",
+					"10.65.0.27:47469",
+					"172.17.0.1:47469",
+					"172.18.0.1:47469",
+					"172.19.0.1:47469",
+					"172.20.0.1:47469",
+					"172.21.0.1:47469",
+					"172.22.0.1:47469",
+					"172.23.0.1:47469",
+					"172.24.0.1:47469",
+					"172.25.0.1:47469",
+					"172.26.0.1:47469",
+					"172.27.0.1:47469"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:32:29.634846588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4028006846160904,
+				"StableID":   "nwWZjkuHTY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c12617359030b76fe8ebe4669b17843b33bb26937d24a5fc038ec4aca1ba9c26",
+				"DiscoKey":   "discokey:5a1070a7160c63c8bb5774f7813c3cc522f54ba17aa835ac9ca522afe275157a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34387",
+					"10.65.0.27:34387",
+					"172.17.0.1:34387",
+					"172.18.0.1:34387",
+					"172.19.0.1:34387",
+					"172.20.0.1:34387",
+					"172.21.0.1:34387",
+					"172.22.0.1:34387",
+					"172.23.0.1:34387",
+					"172.24.0.1:34387",
+					"172.25.0.1:34387",
+					"172.26.0.1:34387",
+					"172.27.0.1:34387"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:32:30.182224358Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5667609051101869,
+				"StableID":   "nrTm2oUsFm11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0466cdf3ee08d9e7a33aa4ff693cdfb2557741196f15ec2466495d03ea90bb24",
+				"DiscoKey":   "discokey:c2e78a42f31849b917095daf147e8ee4bc9aadddb3b9e03f82437a765996b979",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49885",
+					"10.65.0.27:49885",
+					"172.17.0.1:49885",
+					"172.18.0.1:49885",
+					"172.19.0.1:49885",
+					"172.20.0.1:49885",
+					"172.21.0.1:49885",
+					"172.22.0.1:49885",
+					"172.23.0.1:49885",
+					"172.24.0.1:49885",
+					"172.25.0.1:49885",
+					"172.26.0.1:49885",
+					"172.27.0.1:49885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:32:30.726623781Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7941934760275445,
+				"StableID":   "nUxUtDAv1521CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9a9aa185696cd03de991e3c7fbebe238d84949b7c05325f4ed3027b8379013d",
+				"DiscoKey":   "discokey:73f984575d16237be0d09b95e6cc3368d1e92328ad88ceea61bdb9ca7adc1c1b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50093",
+					"10.65.0.27:50093",
+					"172.17.0.1:50093",
+					"172.18.0.1:50093",
+					"172.19.0.1:50093",
+					"172.20.0.1:50093",
+					"172.21.0.1:50093",
+					"172.22.0.1:50093",
+					"172.23.0.1:50093",
+					"172.24.0.1:50093",
+					"172.25.0.1:50093",
+					"172.26.0.1:50093",
+					"172.27.0.1:50093"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:32:31.264509883Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5117522356983846,
+				"StableID":   "nPoAZodjxg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5ba657c0d8cabbbf649e6fbe62f201662e4972bf7a9885cb71c023b05e4ddb3d",
+				"DiscoKey":   "discokey:855ff5cd29f1f4198c46f3cce4b92a8a6282ead0d35e2ce8f39d0aef2d564628",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:36776",
+					"10.65.0.27:36776",
+					"172.17.0.1:36776",
+					"172.18.0.1:36776",
+					"172.19.0.1:36776",
+					"172.20.0.1:36776",
+					"172.21.0.1:36776",
+					"172.22.0.1:36776",
+					"172.23.0.1:36776",
+					"172.24.0.1:36776",
+					"172.25.0.1:36776",
+					"172.26.0.1:36776",
+					"172.27.0.1:36776"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:32:31.826882566Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         287924645502741,
+				"StableID":   "nLxLywHQF311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a41b428cfcb7a3e5f7de22e9076a13cb6ad3a654ecdd5eb892be78710e4b244",
+				"DiscoKey":   "discokey:0e890516ee8be4d0a1ad4de5942b053e72ae5b30fae17762961d9e9e37a95339",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33298",
+					"10.65.0.27:33298",
+					"172.17.0.1:33298",
+					"172.18.0.1:33298",
+					"172.19.0.1:33298",
+					"172.20.0.1:33298",
+					"172.21.0.1:33298",
+					"172.22.0.1:33298",
+					"172.23.0.1:33298",
+					"172.24.0.1:33298",
+					"172.25.0.1:33298",
+					"172.26.0.1:33298",
+					"172.27.0.1:33298"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:32:32.352383431Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2901116932549833,
+				"StableID":   "nkxRvVRveP11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d50d3291ddcc2426ed52cb1ec7eb372d9b96ed42481bfdaa92edf19933b7a832",
+				"DiscoKey":   "discokey:a35aa66bbfc1ed0a7c4389d94f4a312c3e876b851181c7b5223ebadd96c3943f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48578",
+					"10.65.0.27:48578",
+					"172.17.0.1:48578",
+					"172.18.0.1:48578",
+					"172.19.0.1:48578",
+					"172.20.0.1:48578",
+					"172.21.0.1:48578",
+					"172.22.0.1:48578",
+					"172.23.0.1:48578",
+					"172.24.0.1:48578",
+					"172.25.0.1:48578",
+					"172.26.0.1:48578",
+					"172.27.0.1:48578"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:32:32.893684817Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7120072954315803,
+				"StableID":   "nGVrR6Fhbx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2eda08d9b7d67afa59433c3ad43fa88bb3b634cbc4e148bdd696e81f6ec98867",
+				"DiscoKey":   "discokey:501227c04801df77eadb36c9e1afb905ef69d7d4179c21b1813e8c2172a1790d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45566",
+					"10.65.0.27:45566",
+					"172.17.0.1:45566",
+					"172.18.0.1:45566",
+					"172.19.0.1:45566",
+					"172.20.0.1:45566",
+					"172.21.0.1:45566",
+					"172.22.0.1:45566",
+					"172.23.0.1:45566",
+					"172.24.0.1:45566",
+					"172.25.0.1:45566",
+					"172.26.0.1:45566",
+					"172.27.0.1:45566"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:32:33.465196384Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5888021051733811,
+				"StableID":   "n8Z8m4Lhyn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:09e6d8653854ae1da75e3875192abc593a30f26e60260d4aa881cd103262f110",
+				"DiscoKey":   "discokey:bd3186a88a5dd8901e1a823279a4a0a207aa590c88e242677a94fb0a6400977e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58684",
+					"10.65.0.27:58684",
+					"172.17.0.1:58684",
+					"172.18.0.1:58684",
+					"172.19.0.1:58684",
+					"172.20.0.1:58684",
+					"172.21.0.1:58684",
+					"172.22.0.1:58684",
+					"172.23.0.1:58684",
+					"172.24.0.1:58684",
+					"172.25.0.1:58684",
+					"172.26.0.1:58684",
+					"172.27.0.1:58684"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:32:33.993070049Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6150803441526927,
+				"StableID":   "n855hEBi2q11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c09e025ef3afa0b114831bdb3df9a21fd957e66529a02b7abda72c8d12edb557",
+				"DiscoKey":   "discokey:e40d89391874357ced5eaf747aa4111240a92a6253e12572aca7c9a9aa8b1b32",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38819",
+					"10.65.0.27:38819",
+					"172.17.0.1:38819",
+					"172.18.0.1:38819",
+					"172.19.0.1:38819",
+					"172.20.0.1:38819",
+					"172.21.0.1:38819",
+					"172.22.0.1:38819",
+					"172.23.0.1:38819",
+					"172.24.0.1:38819",
+					"172.25.0.1:38819",
+					"172.26.0.1:38819",
+					"172.27.0.1:38819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:32:34.552360717Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5525739855615142,
+				"StableID":   "njow2Lpc9k11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:878d3dc41fc5c018d1286fcfc61475aa0ddaba8dfb08529a3196cdb64768eb4a",
+				"DiscoKey":   "discokey:06b81e82c8ce2d5f3909a5bce2bdee5ed297dd821afe08e38a15f13bd89ea257",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:33872",
+					"10.65.0.27:33872",
+					"172.17.0.1:33872",
+					"172.18.0.1:33872",
+					"172.19.0.1:33872",
+					"172.20.0.1:33872",
+					"172.21.0.1:33872",
+					"172.22.0.1:33872",
+					"172.23.0.1:33872",
+					"172.24.0.1:33872",
+					"172.25.0.1:33872",
+					"172.26.0.1:33872",
+					"172.27.0.1:33872"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:32:35.0718264Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3874427254547311,
+				"StableID":   "n8Rd8ndjFX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bee7fba92b33ef72d90bc38b48c5c500ac2731e2c5f56b5545fa43b059053973",
+				"KeyExpiry":  "2026-11-09T09:32:36Z",
+				"DiscoKey":   "discokey:b2955b623cedbab0242b00574aeb08f48e38df1e99c0128aeb1e85f77794ef6e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:45049",
+					"10.65.0.27:45049",
+					"172.17.0.1:45049",
+					"172.18.0.1:45049",
+					"172.19.0.1:45049",
+					"172.20.0.1:45049",
+					"172.21.0.1:45049",
+					"172.22.0.1:45049",
+					"172.23.0.1:45049",
+					"172.24.0.1:45049",
+					"172.25.0.1:45049",
+					"172.26.0.1:45049",
+					"172.27.0.1:45049"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:32:36.160990465Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7587609051638003,
+				"StableID":   "ncM7MAdSF221CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e2fb44c0f8b5ee8ebebce7b53fe85e66b63fc8bb71e3db350e45e4d9ffdb705a",
+				"KeyExpiry":  "2026-11-09T09:32:36Z",
+				"DiscoKey":   "discokey:3336cb49d6bacf01ef1f81b38ec9d8dbb08b6be1411c2fe4f17f6ed99a4db25c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50296",
+					"10.65.0.27:50296",
+					"172.17.0.1:50296",
+					"172.18.0.1:50296",
+					"172.19.0.1:50296",
+					"172.20.0.1:50296",
+					"172.21.0.1:50296",
+					"172.22.0.1:50296",
+					"172.23.0.1:50296",
+					"172.24.0.1:50296",
+					"172.25.0.1:50296",
+					"172.26.0.1:50296",
+					"172.27.0.1:50296"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:32:36.700599251Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6150803441526927,
+				"StableID":   "n855hEBi2q11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       6150803441526927,
+				"Key":        "nodekey:c09e025ef3afa0b114831bdb3df9a21fd957e66529a02b7abda72c8d12edb557",
+				"DiscoKey":   "discokey:e40d89391874357ced5eaf747aa4111240a92a6253e12572aca7c9a9aa8b1b32",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38819",
+					"10.65.0.27:38819",
+					"172.17.0.1:38819",
+					"172.18.0.1:38819",
+					"172.19.0.1:38819",
+					"172.20.0.1:38819",
+					"172.21.0.1:38819",
+					"172.22.0.1:38819",
+					"172.23.0.1:38819",
+					"172.24.0.1:38819",
+					"172.25.0.1:38819",
+					"172.26.0.1:38819",
+					"172.27.0.1:38819"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:32:34.552360717Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c09e025ef3afa0b114831bdb3df9a21fd957e66529a02b7abda72c8d12edb557",
+			"MachineKey": "mkey:891d701e18e197707b486d8b379da8ab324a70362a244c69e7ffde1151c55f55",
+			"Peers": [{
+				"ID":         8148649908875331,
+				"StableID":   "nQ5zhVDYd621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:34ae890a67e5d412c929bce7c14f74e0b14b57f15f5b72c30272ece0ade3f956",
+				"DiscoKey":   "discokey:597ce076bc8e09c80d609d13a71bb2e397108538d803b86f51f6d8f85cc3a14e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46427",
+					"10.65.0.27:46427",
+					"172.17.0.1:46427",
+					"172.18.0.1:46427",
+					"172.19.0.1:46427",
+					"172.20.0.1:46427",
+					"172.21.0.1:46427",
+					"172.22.0.1:46427",
+					"172.23.0.1:46427",
+					"172.24.0.1:46427",
+					"172.25.0.1:46427",
+					"172.26.0.1:46427",
+					"172.27.0.1:46427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:32:29.103855414Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         391639347960856,
+				"StableID":   "nFnF5hhN4411CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6fee700014fceb14b971c5f3fa0b085583de317a60b028590eee406133cd7271",
+				"DiscoKey":   "discokey:7df6539d847203c3b179a5ca7280281d27a8934b308a2a0e7e8233df4fb72e35",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47469",
+					"10.65.0.27:47469",
+					"172.17.0.1:47469",
+					"172.18.0.1:47469",
+					"172.19.0.1:47469",
+					"172.20.0.1:47469",
+					"172.21.0.1:47469",
+					"172.22.0.1:47469",
+					"172.23.0.1:47469",
+					"172.24.0.1:47469",
+					"172.25.0.1:47469",
+					"172.26.0.1:47469",
+					"172.27.0.1:47469"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:32:29.634846588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4028006846160904,
+				"StableID":   "nwWZjkuHTY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c12617359030b76fe8ebe4669b17843b33bb26937d24a5fc038ec4aca1ba9c26",
+				"DiscoKey":   "discokey:5a1070a7160c63c8bb5774f7813c3cc522f54ba17aa835ac9ca522afe275157a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34387",
+					"10.65.0.27:34387",
+					"172.17.0.1:34387",
+					"172.18.0.1:34387",
+					"172.19.0.1:34387",
+					"172.20.0.1:34387",
+					"172.21.0.1:34387",
+					"172.22.0.1:34387",
+					"172.23.0.1:34387",
+					"172.24.0.1:34387",
+					"172.25.0.1:34387",
+					"172.26.0.1:34387",
+					"172.27.0.1:34387"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:32:30.182224358Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5667609051101869,
+				"StableID":   "nrTm2oUsFm11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0466cdf3ee08d9e7a33aa4ff693cdfb2557741196f15ec2466495d03ea90bb24",
+				"DiscoKey":   "discokey:c2e78a42f31849b917095daf147e8ee4bc9aadddb3b9e03f82437a765996b979",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49885",
+					"10.65.0.27:49885",
+					"172.17.0.1:49885",
+					"172.18.0.1:49885",
+					"172.19.0.1:49885",
+					"172.20.0.1:49885",
+					"172.21.0.1:49885",
+					"172.22.0.1:49885",
+					"172.23.0.1:49885",
+					"172.24.0.1:49885",
+					"172.25.0.1:49885",
+					"172.26.0.1:49885",
+					"172.27.0.1:49885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:32:30.726623781Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7941934760275445,
+				"StableID":   "nUxUtDAv1521CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9a9aa185696cd03de991e3c7fbebe238d84949b7c05325f4ed3027b8379013d",
+				"DiscoKey":   "discokey:73f984575d16237be0d09b95e6cc3368d1e92328ad88ceea61bdb9ca7adc1c1b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50093",
+					"10.65.0.27:50093",
+					"172.17.0.1:50093",
+					"172.18.0.1:50093",
+					"172.19.0.1:50093",
+					"172.20.0.1:50093",
+					"172.21.0.1:50093",
+					"172.22.0.1:50093",
+					"172.23.0.1:50093",
+					"172.24.0.1:50093",
+					"172.25.0.1:50093",
+					"172.26.0.1:50093",
+					"172.27.0.1:50093"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:32:31.264509883Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5117522356983846,
+				"StableID":   "nPoAZodjxg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5ba657c0d8cabbbf649e6fbe62f201662e4972bf7a9885cb71c023b05e4ddb3d",
+				"DiscoKey":   "discokey:855ff5cd29f1f4198c46f3cce4b92a8a6282ead0d35e2ce8f39d0aef2d564628",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:36776",
+					"10.65.0.27:36776",
+					"172.17.0.1:36776",
+					"172.18.0.1:36776",
+					"172.19.0.1:36776",
+					"172.20.0.1:36776",
+					"172.21.0.1:36776",
+					"172.22.0.1:36776",
+					"172.23.0.1:36776",
+					"172.24.0.1:36776",
+					"172.25.0.1:36776",
+					"172.26.0.1:36776",
+					"172.27.0.1:36776"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:32:31.826882566Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         287924645502741,
+				"StableID":   "nLxLywHQF311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a41b428cfcb7a3e5f7de22e9076a13cb6ad3a654ecdd5eb892be78710e4b244",
+				"DiscoKey":   "discokey:0e890516ee8be4d0a1ad4de5942b053e72ae5b30fae17762961d9e9e37a95339",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33298",
+					"10.65.0.27:33298",
+					"172.17.0.1:33298",
+					"172.18.0.1:33298",
+					"172.19.0.1:33298",
+					"172.20.0.1:33298",
+					"172.21.0.1:33298",
+					"172.22.0.1:33298",
+					"172.23.0.1:33298",
+					"172.24.0.1:33298",
+					"172.25.0.1:33298",
+					"172.26.0.1:33298",
+					"172.27.0.1:33298"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:32:32.352383431Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2901116932549833,
+				"StableID":   "nkxRvVRveP11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d50d3291ddcc2426ed52cb1ec7eb372d9b96ed42481bfdaa92edf19933b7a832",
+				"DiscoKey":   "discokey:a35aa66bbfc1ed0a7c4389d94f4a312c3e876b851181c7b5223ebadd96c3943f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48578",
+					"10.65.0.27:48578",
+					"172.17.0.1:48578",
+					"172.18.0.1:48578",
+					"172.19.0.1:48578",
+					"172.20.0.1:48578",
+					"172.21.0.1:48578",
+					"172.22.0.1:48578",
+					"172.23.0.1:48578",
+					"172.24.0.1:48578",
+					"172.25.0.1:48578",
+					"172.26.0.1:48578",
+					"172.27.0.1:48578"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:32:32.893684817Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7120072954315803,
+				"StableID":   "nGVrR6Fhbx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2eda08d9b7d67afa59433c3ad43fa88bb3b634cbc4e148bdd696e81f6ec98867",
+				"DiscoKey":   "discokey:501227c04801df77eadb36c9e1afb905ef69d7d4179c21b1813e8c2172a1790d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45566",
+					"10.65.0.27:45566",
+					"172.17.0.1:45566",
+					"172.18.0.1:45566",
+					"172.19.0.1:45566",
+					"172.20.0.1:45566",
+					"172.21.0.1:45566",
+					"172.22.0.1:45566",
+					"172.23.0.1:45566",
+					"172.24.0.1:45566",
+					"172.25.0.1:45566",
+					"172.26.0.1:45566",
+					"172.27.0.1:45566"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:32:33.465196384Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5888021051733811,
+				"StableID":   "n8Z8m4Lhyn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:09e6d8653854ae1da75e3875192abc593a30f26e60260d4aa881cd103262f110",
+				"DiscoKey":   "discokey:bd3186a88a5dd8901e1a823279a4a0a207aa590c88e242677a94fb0a6400977e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58684",
+					"10.65.0.27:58684",
+					"172.17.0.1:58684",
+					"172.18.0.1:58684",
+					"172.19.0.1:58684",
+					"172.20.0.1:58684",
+					"172.21.0.1:58684",
+					"172.22.0.1:58684",
+					"172.23.0.1:58684",
+					"172.24.0.1:58684",
+					"172.25.0.1:58684",
+					"172.26.0.1:58684",
+					"172.27.0.1:58684"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:32:33.993070049Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5525739855615142,
+				"StableID":   "njow2Lpc9k11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:878d3dc41fc5c018d1286fcfc61475aa0ddaba8dfb08529a3196cdb64768eb4a",
+				"DiscoKey":   "discokey:06b81e82c8ce2d5f3909a5bce2bdee5ed297dd821afe08e38a15f13bd89ea257",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:33872",
+					"10.65.0.27:33872",
+					"172.17.0.1:33872",
+					"172.18.0.1:33872",
+					"172.19.0.1:33872",
+					"172.20.0.1:33872",
+					"172.21.0.1:33872",
+					"172.22.0.1:33872",
+					"172.23.0.1:33872",
+					"172.24.0.1:33872",
+					"172.25.0.1:33872",
+					"172.26.0.1:33872",
+					"172.27.0.1:33872"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:32:35.0718264Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8745332619298087,
+				"StableID":   "nnJoaP4nHB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:807d14fb0b782361ea13d98b82fcfb807a4cdd48f93ea57e1dd76d65498a6b38",
+				"KeyExpiry":  "2026-11-09T09:32:35Z",
+				"DiscoKey":   "discokey:aee8eb99f195b741bf394cd36106086b0ddb07976ca74153927216b327281742",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45759",
+					"10.65.0.27:45759",
+					"172.17.0.1:45759",
+					"172.18.0.1:45759",
+					"172.19.0.1:45759",
+					"172.20.0.1:45759",
+					"172.21.0.1:45759",
+					"172.22.0.1:45759",
+					"172.23.0.1:45759",
+					"172.24.0.1:45759",
+					"172.25.0.1:45759",
+					"172.26.0.1:45759",
+					"172.27.0.1:45759"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:32:35.616160418Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3874427254547311,
+				"StableID":   "n8Rd8ndjFX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bee7fba92b33ef72d90bc38b48c5c500ac2731e2c5f56b5545fa43b059053973",
+				"KeyExpiry":  "2026-11-09T09:32:36Z",
+				"DiscoKey":   "discokey:b2955b623cedbab0242b00574aeb08f48e38df1e99c0128aeb1e85f77794ef6e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:45049",
+					"10.65.0.27:45049",
+					"172.17.0.1:45049",
+					"172.18.0.1:45049",
+					"172.19.0.1:45049",
+					"172.20.0.1:45049",
+					"172.21.0.1:45049",
+					"172.22.0.1:45049",
+					"172.23.0.1:45049",
+					"172.24.0.1:45049",
+					"172.25.0.1:45049",
+					"172.26.0.1:45049",
+					"172.27.0.1:45049"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:32:36.160990465Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7587609051638003,
+				"StableID":   "ncM7MAdSF221CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e2fb44c0f8b5ee8ebebce7b53fe85e66b63fc8bb71e3db350e45e4d9ffdb705a",
+				"KeyExpiry":  "2026-11-09T09:32:36Z",
+				"DiscoKey":   "discokey:3336cb49d6bacf01ef1f81b38ec9d8dbb08b6be1411c2fe4f17f6ed99a4db25c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50296",
+					"10.65.0.27:50296",
+					"172.17.0.1:50296",
+					"172.18.0.1:50296",
+					"172.19.0.1:50296",
+					"172.20.0.1:50296",
+					"172.21.0.1:50296",
+					"172.22.0.1:50296",
+					"172.23.0.1:50296",
+					"172.24.0.1:50296",
+					"172.25.0.1:50296",
+					"172.26.0.1:50296",
+					"172.27.0.1:50296"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:32:36.700599251Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6150803441526927": {
+				"ID":          6150803441526927,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         391639347960856,
+				"StableID":   "nFnF5hhN4411CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       391639347960856,
+				"Key":        "nodekey:6fee700014fceb14b971c5f3fa0b085583de317a60b028590eee406133cd7271",
+				"DiscoKey":   "discokey:7df6539d847203c3b179a5ca7280281d27a8934b308a2a0e7e8233df4fb72e35",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47469",
+					"10.65.0.27:47469",
+					"172.17.0.1:47469",
+					"172.18.0.1:47469",
+					"172.19.0.1:47469",
+					"172.20.0.1:47469",
+					"172.21.0.1:47469",
+					"172.22.0.1:47469",
+					"172.23.0.1:47469",
+					"172.24.0.1:47469",
+					"172.25.0.1:47469",
+					"172.26.0.1:47469",
+					"172.27.0.1:47469"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:32:29.634846588Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6fee700014fceb14b971c5f3fa0b085583de317a60b028590eee406133cd7271",
+			"MachineKey": "mkey:ed40a63487b3a2f4d51afd822ff88d1bd36a7112211b97c476ff9fe74139f161",
+			"Peers": [{
+				"ID":         8148649908875331,
+				"StableID":   "nQ5zhVDYd621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:34ae890a67e5d412c929bce7c14f74e0b14b57f15f5b72c30272ece0ade3f956",
+				"DiscoKey":   "discokey:597ce076bc8e09c80d609d13a71bb2e397108538d803b86f51f6d8f85cc3a14e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46427",
+					"10.65.0.27:46427",
+					"172.17.0.1:46427",
+					"172.18.0.1:46427",
+					"172.19.0.1:46427",
+					"172.20.0.1:46427",
+					"172.21.0.1:46427",
+					"172.22.0.1:46427",
+					"172.23.0.1:46427",
+					"172.24.0.1:46427",
+					"172.25.0.1:46427",
+					"172.26.0.1:46427",
+					"172.27.0.1:46427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:32:29.103855414Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4028006846160904,
+				"StableID":   "nwWZjkuHTY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c12617359030b76fe8ebe4669b17843b33bb26937d24a5fc038ec4aca1ba9c26",
+				"DiscoKey":   "discokey:5a1070a7160c63c8bb5774f7813c3cc522f54ba17aa835ac9ca522afe275157a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34387",
+					"10.65.0.27:34387",
+					"172.17.0.1:34387",
+					"172.18.0.1:34387",
+					"172.19.0.1:34387",
+					"172.20.0.1:34387",
+					"172.21.0.1:34387",
+					"172.22.0.1:34387",
+					"172.23.0.1:34387",
+					"172.24.0.1:34387",
+					"172.25.0.1:34387",
+					"172.26.0.1:34387",
+					"172.27.0.1:34387"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:32:30.182224358Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5667609051101869,
+				"StableID":   "nrTm2oUsFm11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0466cdf3ee08d9e7a33aa4ff693cdfb2557741196f15ec2466495d03ea90bb24",
+				"DiscoKey":   "discokey:c2e78a42f31849b917095daf147e8ee4bc9aadddb3b9e03f82437a765996b979",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49885",
+					"10.65.0.27:49885",
+					"172.17.0.1:49885",
+					"172.18.0.1:49885",
+					"172.19.0.1:49885",
+					"172.20.0.1:49885",
+					"172.21.0.1:49885",
+					"172.22.0.1:49885",
+					"172.23.0.1:49885",
+					"172.24.0.1:49885",
+					"172.25.0.1:49885",
+					"172.26.0.1:49885",
+					"172.27.0.1:49885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:32:30.726623781Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7941934760275445,
+				"StableID":   "nUxUtDAv1521CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9a9aa185696cd03de991e3c7fbebe238d84949b7c05325f4ed3027b8379013d",
+				"DiscoKey":   "discokey:73f984575d16237be0d09b95e6cc3368d1e92328ad88ceea61bdb9ca7adc1c1b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50093",
+					"10.65.0.27:50093",
+					"172.17.0.1:50093",
+					"172.18.0.1:50093",
+					"172.19.0.1:50093",
+					"172.20.0.1:50093",
+					"172.21.0.1:50093",
+					"172.22.0.1:50093",
+					"172.23.0.1:50093",
+					"172.24.0.1:50093",
+					"172.25.0.1:50093",
+					"172.26.0.1:50093",
+					"172.27.0.1:50093"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:32:31.264509883Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5117522356983846,
+				"StableID":   "nPoAZodjxg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5ba657c0d8cabbbf649e6fbe62f201662e4972bf7a9885cb71c023b05e4ddb3d",
+				"DiscoKey":   "discokey:855ff5cd29f1f4198c46f3cce4b92a8a6282ead0d35e2ce8f39d0aef2d564628",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:36776",
+					"10.65.0.27:36776",
+					"172.17.0.1:36776",
+					"172.18.0.1:36776",
+					"172.19.0.1:36776",
+					"172.20.0.1:36776",
+					"172.21.0.1:36776",
+					"172.22.0.1:36776",
+					"172.23.0.1:36776",
+					"172.24.0.1:36776",
+					"172.25.0.1:36776",
+					"172.26.0.1:36776",
+					"172.27.0.1:36776"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:32:31.826882566Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         287924645502741,
+				"StableID":   "nLxLywHQF311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a41b428cfcb7a3e5f7de22e9076a13cb6ad3a654ecdd5eb892be78710e4b244",
+				"DiscoKey":   "discokey:0e890516ee8be4d0a1ad4de5942b053e72ae5b30fae17762961d9e9e37a95339",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33298",
+					"10.65.0.27:33298",
+					"172.17.0.1:33298",
+					"172.18.0.1:33298",
+					"172.19.0.1:33298",
+					"172.20.0.1:33298",
+					"172.21.0.1:33298",
+					"172.22.0.1:33298",
+					"172.23.0.1:33298",
+					"172.24.0.1:33298",
+					"172.25.0.1:33298",
+					"172.26.0.1:33298",
+					"172.27.0.1:33298"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:32:32.352383431Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2901116932549833,
+				"StableID":   "nkxRvVRveP11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d50d3291ddcc2426ed52cb1ec7eb372d9b96ed42481bfdaa92edf19933b7a832",
+				"DiscoKey":   "discokey:a35aa66bbfc1ed0a7c4389d94f4a312c3e876b851181c7b5223ebadd96c3943f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48578",
+					"10.65.0.27:48578",
+					"172.17.0.1:48578",
+					"172.18.0.1:48578",
+					"172.19.0.1:48578",
+					"172.20.0.1:48578",
+					"172.21.0.1:48578",
+					"172.22.0.1:48578",
+					"172.23.0.1:48578",
+					"172.24.0.1:48578",
+					"172.25.0.1:48578",
+					"172.26.0.1:48578",
+					"172.27.0.1:48578"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:32:32.893684817Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7120072954315803,
+				"StableID":   "nGVrR6Fhbx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2eda08d9b7d67afa59433c3ad43fa88bb3b634cbc4e148bdd696e81f6ec98867",
+				"DiscoKey":   "discokey:501227c04801df77eadb36c9e1afb905ef69d7d4179c21b1813e8c2172a1790d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45566",
+					"10.65.0.27:45566",
+					"172.17.0.1:45566",
+					"172.18.0.1:45566",
+					"172.19.0.1:45566",
+					"172.20.0.1:45566",
+					"172.21.0.1:45566",
+					"172.22.0.1:45566",
+					"172.23.0.1:45566",
+					"172.24.0.1:45566",
+					"172.25.0.1:45566",
+					"172.26.0.1:45566",
+					"172.27.0.1:45566"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:32:33.465196384Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5888021051733811,
+				"StableID":   "n8Z8m4Lhyn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:09e6d8653854ae1da75e3875192abc593a30f26e60260d4aa881cd103262f110",
+				"DiscoKey":   "discokey:bd3186a88a5dd8901e1a823279a4a0a207aa590c88e242677a94fb0a6400977e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58684",
+					"10.65.0.27:58684",
+					"172.17.0.1:58684",
+					"172.18.0.1:58684",
+					"172.19.0.1:58684",
+					"172.20.0.1:58684",
+					"172.21.0.1:58684",
+					"172.22.0.1:58684",
+					"172.23.0.1:58684",
+					"172.24.0.1:58684",
+					"172.25.0.1:58684",
+					"172.26.0.1:58684",
+					"172.27.0.1:58684"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:32:33.993070049Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6150803441526927,
+				"StableID":   "n855hEBi2q11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c09e025ef3afa0b114831bdb3df9a21fd957e66529a02b7abda72c8d12edb557",
+				"DiscoKey":   "discokey:e40d89391874357ced5eaf747aa4111240a92a6253e12572aca7c9a9aa8b1b32",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38819",
+					"10.65.0.27:38819",
+					"172.17.0.1:38819",
+					"172.18.0.1:38819",
+					"172.19.0.1:38819",
+					"172.20.0.1:38819",
+					"172.21.0.1:38819",
+					"172.22.0.1:38819",
+					"172.23.0.1:38819",
+					"172.24.0.1:38819",
+					"172.25.0.1:38819",
+					"172.26.0.1:38819",
+					"172.27.0.1:38819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:32:34.552360717Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5525739855615142,
+				"StableID":   "njow2Lpc9k11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:878d3dc41fc5c018d1286fcfc61475aa0ddaba8dfb08529a3196cdb64768eb4a",
+				"DiscoKey":   "discokey:06b81e82c8ce2d5f3909a5bce2bdee5ed297dd821afe08e38a15f13bd89ea257",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:33872",
+					"10.65.0.27:33872",
+					"172.17.0.1:33872",
+					"172.18.0.1:33872",
+					"172.19.0.1:33872",
+					"172.20.0.1:33872",
+					"172.21.0.1:33872",
+					"172.22.0.1:33872",
+					"172.23.0.1:33872",
+					"172.24.0.1:33872",
+					"172.25.0.1:33872",
+					"172.26.0.1:33872",
+					"172.27.0.1:33872"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:32:35.0718264Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8745332619298087,
+				"StableID":   "nnJoaP4nHB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:807d14fb0b782361ea13d98b82fcfb807a4cdd48f93ea57e1dd76d65498a6b38",
+				"KeyExpiry":  "2026-11-09T09:32:35Z",
+				"DiscoKey":   "discokey:aee8eb99f195b741bf394cd36106086b0ddb07976ca74153927216b327281742",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45759",
+					"10.65.0.27:45759",
+					"172.17.0.1:45759",
+					"172.18.0.1:45759",
+					"172.19.0.1:45759",
+					"172.20.0.1:45759",
+					"172.21.0.1:45759",
+					"172.22.0.1:45759",
+					"172.23.0.1:45759",
+					"172.24.0.1:45759",
+					"172.25.0.1:45759",
+					"172.26.0.1:45759",
+					"172.27.0.1:45759"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:32:35.616160418Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3874427254547311,
+				"StableID":   "n8Rd8ndjFX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bee7fba92b33ef72d90bc38b48c5c500ac2731e2c5f56b5545fa43b059053973",
+				"KeyExpiry":  "2026-11-09T09:32:36Z",
+				"DiscoKey":   "discokey:b2955b623cedbab0242b00574aeb08f48e38df1e99c0128aeb1e85f77794ef6e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:45049",
+					"10.65.0.27:45049",
+					"172.17.0.1:45049",
+					"172.18.0.1:45049",
+					"172.19.0.1:45049",
+					"172.20.0.1:45049",
+					"172.21.0.1:45049",
+					"172.22.0.1:45049",
+					"172.23.0.1:45049",
+					"172.24.0.1:45049",
+					"172.25.0.1:45049",
+					"172.26.0.1:45049",
+					"172.27.0.1:45049"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:32:36.160990465Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7587609051638003,
+				"StableID":   "ncM7MAdSF221CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e2fb44c0f8b5ee8ebebce7b53fe85e66b63fc8bb71e3db350e45e4d9ffdb705a",
+				"KeyExpiry":  "2026-11-09T09:32:36Z",
+				"DiscoKey":   "discokey:3336cb49d6bacf01ef1f81b38ec9d8dbb08b6be1411c2fe4f17f6ed99a4db25c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50296",
+					"10.65.0.27:50296",
+					"172.17.0.1:50296",
+					"172.18.0.1:50296",
+					"172.19.0.1:50296",
+					"172.20.0.1:50296",
+					"172.21.0.1:50296",
+					"172.22.0.1:50296",
+					"172.23.0.1:50296",
+					"172.24.0.1:50296",
+					"172.25.0.1:50296",
+					"172.26.0.1:50296",
+					"172.27.0.1:50296"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:32:36.700599251Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "391639347960856": {
+				"ID":          391639347960856,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8148649908875331,
+				"StableID":   "nQ5zhVDYd621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       8148649908875331,
+				"Key":        "nodekey:34ae890a67e5d412c929bce7c14f74e0b14b57f15f5b72c30272ece0ade3f956",
+				"DiscoKey":   "discokey:597ce076bc8e09c80d609d13a71bb2e397108538d803b86f51f6d8f85cc3a14e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46427",
+					"10.65.0.27:46427",
+					"172.17.0.1:46427",
+					"172.18.0.1:46427",
+					"172.19.0.1:46427",
+					"172.20.0.1:46427",
+					"172.21.0.1:46427",
+					"172.22.0.1:46427",
+					"172.23.0.1:46427",
+					"172.24.0.1:46427",
+					"172.25.0.1:46427",
+					"172.26.0.1:46427",
+					"172.27.0.1:46427"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:32:29.103855414Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:34ae890a67e5d412c929bce7c14f74e0b14b57f15f5b72c30272ece0ade3f956",
+			"MachineKey": "mkey:e32fb56911c30eaa19c5561655feb5af55d9fef11ac2cae1587918e849ad0626",
+			"Peers": [{
+				"ID":         391639347960856,
+				"StableID":   "nFnF5hhN4411CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6fee700014fceb14b971c5f3fa0b085583de317a60b028590eee406133cd7271",
+				"DiscoKey":   "discokey:7df6539d847203c3b179a5ca7280281d27a8934b308a2a0e7e8233df4fb72e35",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47469",
+					"10.65.0.27:47469",
+					"172.17.0.1:47469",
+					"172.18.0.1:47469",
+					"172.19.0.1:47469",
+					"172.20.0.1:47469",
+					"172.21.0.1:47469",
+					"172.22.0.1:47469",
+					"172.23.0.1:47469",
+					"172.24.0.1:47469",
+					"172.25.0.1:47469",
+					"172.26.0.1:47469",
+					"172.27.0.1:47469"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:32:29.634846588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4028006846160904,
+				"StableID":   "nwWZjkuHTY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c12617359030b76fe8ebe4669b17843b33bb26937d24a5fc038ec4aca1ba9c26",
+				"DiscoKey":   "discokey:5a1070a7160c63c8bb5774f7813c3cc522f54ba17aa835ac9ca522afe275157a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34387",
+					"10.65.0.27:34387",
+					"172.17.0.1:34387",
+					"172.18.0.1:34387",
+					"172.19.0.1:34387",
+					"172.20.0.1:34387",
+					"172.21.0.1:34387",
+					"172.22.0.1:34387",
+					"172.23.0.1:34387",
+					"172.24.0.1:34387",
+					"172.25.0.1:34387",
+					"172.26.0.1:34387",
+					"172.27.0.1:34387"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:32:30.182224358Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5667609051101869,
+				"StableID":   "nrTm2oUsFm11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0466cdf3ee08d9e7a33aa4ff693cdfb2557741196f15ec2466495d03ea90bb24",
+				"DiscoKey":   "discokey:c2e78a42f31849b917095daf147e8ee4bc9aadddb3b9e03f82437a765996b979",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49885",
+					"10.65.0.27:49885",
+					"172.17.0.1:49885",
+					"172.18.0.1:49885",
+					"172.19.0.1:49885",
+					"172.20.0.1:49885",
+					"172.21.0.1:49885",
+					"172.22.0.1:49885",
+					"172.23.0.1:49885",
+					"172.24.0.1:49885",
+					"172.25.0.1:49885",
+					"172.26.0.1:49885",
+					"172.27.0.1:49885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:32:30.726623781Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7941934760275445,
+				"StableID":   "nUxUtDAv1521CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9a9aa185696cd03de991e3c7fbebe238d84949b7c05325f4ed3027b8379013d",
+				"DiscoKey":   "discokey:73f984575d16237be0d09b95e6cc3368d1e92328ad88ceea61bdb9ca7adc1c1b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50093",
+					"10.65.0.27:50093",
+					"172.17.0.1:50093",
+					"172.18.0.1:50093",
+					"172.19.0.1:50093",
+					"172.20.0.1:50093",
+					"172.21.0.1:50093",
+					"172.22.0.1:50093",
+					"172.23.0.1:50093",
+					"172.24.0.1:50093",
+					"172.25.0.1:50093",
+					"172.26.0.1:50093",
+					"172.27.0.1:50093"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:32:31.264509883Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5117522356983846,
+				"StableID":   "nPoAZodjxg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5ba657c0d8cabbbf649e6fbe62f201662e4972bf7a9885cb71c023b05e4ddb3d",
+				"DiscoKey":   "discokey:855ff5cd29f1f4198c46f3cce4b92a8a6282ead0d35e2ce8f39d0aef2d564628",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:36776",
+					"10.65.0.27:36776",
+					"172.17.0.1:36776",
+					"172.18.0.1:36776",
+					"172.19.0.1:36776",
+					"172.20.0.1:36776",
+					"172.21.0.1:36776",
+					"172.22.0.1:36776",
+					"172.23.0.1:36776",
+					"172.24.0.1:36776",
+					"172.25.0.1:36776",
+					"172.26.0.1:36776",
+					"172.27.0.1:36776"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:32:31.826882566Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         287924645502741,
+				"StableID":   "nLxLywHQF311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a41b428cfcb7a3e5f7de22e9076a13cb6ad3a654ecdd5eb892be78710e4b244",
+				"DiscoKey":   "discokey:0e890516ee8be4d0a1ad4de5942b053e72ae5b30fae17762961d9e9e37a95339",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33298",
+					"10.65.0.27:33298",
+					"172.17.0.1:33298",
+					"172.18.0.1:33298",
+					"172.19.0.1:33298",
+					"172.20.0.1:33298",
+					"172.21.0.1:33298",
+					"172.22.0.1:33298",
+					"172.23.0.1:33298",
+					"172.24.0.1:33298",
+					"172.25.0.1:33298",
+					"172.26.0.1:33298",
+					"172.27.0.1:33298"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:32:32.352383431Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2901116932549833,
+				"StableID":   "nkxRvVRveP11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d50d3291ddcc2426ed52cb1ec7eb372d9b96ed42481bfdaa92edf19933b7a832",
+				"DiscoKey":   "discokey:a35aa66bbfc1ed0a7c4389d94f4a312c3e876b851181c7b5223ebadd96c3943f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48578",
+					"10.65.0.27:48578",
+					"172.17.0.1:48578",
+					"172.18.0.1:48578",
+					"172.19.0.1:48578",
+					"172.20.0.1:48578",
+					"172.21.0.1:48578",
+					"172.22.0.1:48578",
+					"172.23.0.1:48578",
+					"172.24.0.1:48578",
+					"172.25.0.1:48578",
+					"172.26.0.1:48578",
+					"172.27.0.1:48578"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:32:32.893684817Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7120072954315803,
+				"StableID":   "nGVrR6Fhbx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2eda08d9b7d67afa59433c3ad43fa88bb3b634cbc4e148bdd696e81f6ec98867",
+				"DiscoKey":   "discokey:501227c04801df77eadb36c9e1afb905ef69d7d4179c21b1813e8c2172a1790d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45566",
+					"10.65.0.27:45566",
+					"172.17.0.1:45566",
+					"172.18.0.1:45566",
+					"172.19.0.1:45566",
+					"172.20.0.1:45566",
+					"172.21.0.1:45566",
+					"172.22.0.1:45566",
+					"172.23.0.1:45566",
+					"172.24.0.1:45566",
+					"172.25.0.1:45566",
+					"172.26.0.1:45566",
+					"172.27.0.1:45566"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:32:33.465196384Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5888021051733811,
+				"StableID":   "n8Z8m4Lhyn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:09e6d8653854ae1da75e3875192abc593a30f26e60260d4aa881cd103262f110",
+				"DiscoKey":   "discokey:bd3186a88a5dd8901e1a823279a4a0a207aa590c88e242677a94fb0a6400977e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58684",
+					"10.65.0.27:58684",
+					"172.17.0.1:58684",
+					"172.18.0.1:58684",
+					"172.19.0.1:58684",
+					"172.20.0.1:58684",
+					"172.21.0.1:58684",
+					"172.22.0.1:58684",
+					"172.23.0.1:58684",
+					"172.24.0.1:58684",
+					"172.25.0.1:58684",
+					"172.26.0.1:58684",
+					"172.27.0.1:58684"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:32:33.993070049Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6150803441526927,
+				"StableID":   "n855hEBi2q11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c09e025ef3afa0b114831bdb3df9a21fd957e66529a02b7abda72c8d12edb557",
+				"DiscoKey":   "discokey:e40d89391874357ced5eaf747aa4111240a92a6253e12572aca7c9a9aa8b1b32",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38819",
+					"10.65.0.27:38819",
+					"172.17.0.1:38819",
+					"172.18.0.1:38819",
+					"172.19.0.1:38819",
+					"172.20.0.1:38819",
+					"172.21.0.1:38819",
+					"172.22.0.1:38819",
+					"172.23.0.1:38819",
+					"172.24.0.1:38819",
+					"172.25.0.1:38819",
+					"172.26.0.1:38819",
+					"172.27.0.1:38819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:32:34.552360717Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5525739855615142,
+				"StableID":   "njow2Lpc9k11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:878d3dc41fc5c018d1286fcfc61475aa0ddaba8dfb08529a3196cdb64768eb4a",
+				"DiscoKey":   "discokey:06b81e82c8ce2d5f3909a5bce2bdee5ed297dd821afe08e38a15f13bd89ea257",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:33872",
+					"10.65.0.27:33872",
+					"172.17.0.1:33872",
+					"172.18.0.1:33872",
+					"172.19.0.1:33872",
+					"172.20.0.1:33872",
+					"172.21.0.1:33872",
+					"172.22.0.1:33872",
+					"172.23.0.1:33872",
+					"172.24.0.1:33872",
+					"172.25.0.1:33872",
+					"172.26.0.1:33872",
+					"172.27.0.1:33872"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:32:35.0718264Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8745332619298087,
+				"StableID":   "nnJoaP4nHB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:807d14fb0b782361ea13d98b82fcfb807a4cdd48f93ea57e1dd76d65498a6b38",
+				"KeyExpiry":  "2026-11-09T09:32:35Z",
+				"DiscoKey":   "discokey:aee8eb99f195b741bf394cd36106086b0ddb07976ca74153927216b327281742",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45759",
+					"10.65.0.27:45759",
+					"172.17.0.1:45759",
+					"172.18.0.1:45759",
+					"172.19.0.1:45759",
+					"172.20.0.1:45759",
+					"172.21.0.1:45759",
+					"172.22.0.1:45759",
+					"172.23.0.1:45759",
+					"172.24.0.1:45759",
+					"172.25.0.1:45759",
+					"172.26.0.1:45759",
+					"172.27.0.1:45759"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:32:35.616160418Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3874427254547311,
+				"StableID":   "n8Rd8ndjFX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bee7fba92b33ef72d90bc38b48c5c500ac2731e2c5f56b5545fa43b059053973",
+				"KeyExpiry":  "2026-11-09T09:32:36Z",
+				"DiscoKey":   "discokey:b2955b623cedbab0242b00574aeb08f48e38df1e99c0128aeb1e85f77794ef6e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:45049",
+					"10.65.0.27:45049",
+					"172.17.0.1:45049",
+					"172.18.0.1:45049",
+					"172.19.0.1:45049",
+					"172.20.0.1:45049",
+					"172.21.0.1:45049",
+					"172.22.0.1:45049",
+					"172.23.0.1:45049",
+					"172.24.0.1:45049",
+					"172.25.0.1:45049",
+					"172.26.0.1:45049",
+					"172.27.0.1:45049"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:32:36.160990465Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7587609051638003,
+				"StableID":   "ncM7MAdSF221CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e2fb44c0f8b5ee8ebebce7b53fe85e66b63fc8bb71e3db350e45e4d9ffdb705a",
+				"KeyExpiry":  "2026-11-09T09:32:36Z",
+				"DiscoKey":   "discokey:3336cb49d6bacf01ef1f81b38ec9d8dbb08b6be1411c2fe4f17f6ed99a4db25c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50296",
+					"10.65.0.27:50296",
+					"172.17.0.1:50296",
+					"172.18.0.1:50296",
+					"172.19.0.1:50296",
+					"172.20.0.1:50296",
+					"172.21.0.1:50296",
+					"172.22.0.1:50296",
+					"172.23.0.1:50296",
+					"172.24.0.1:50296",
+					"172.25.0.1:50296",
+					"172.26.0.1:50296",
+					"172.27.0.1:50296"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:32:36.700599251Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8148649908875331": {
+				"ID":          8148649908875331,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7941934760275445,
+				"StableID":   "nUxUtDAv1521CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       7941934760275445,
+				"Key":        "nodekey:b9a9aa185696cd03de991e3c7fbebe238d84949b7c05325f4ed3027b8379013d",
+				"DiscoKey":   "discokey:73f984575d16237be0d09b95e6cc3368d1e92328ad88ceea61bdb9ca7adc1c1b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50093",
+					"10.65.0.27:50093",
+					"172.17.0.1:50093",
+					"172.18.0.1:50093",
+					"172.19.0.1:50093",
+					"172.20.0.1:50093",
+					"172.21.0.1:50093",
+					"172.22.0.1:50093",
+					"172.23.0.1:50093",
+					"172.24.0.1:50093",
+					"172.25.0.1:50093",
+					"172.26.0.1:50093",
+					"172.27.0.1:50093"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:32:31.264509883Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b9a9aa185696cd03de991e3c7fbebe238d84949b7c05325f4ed3027b8379013d",
+			"MachineKey": "mkey:074f66084d064bc724065171e9d92f4911bbbe20e593f9a3267bebfb70fe3655",
+			"Peers": [{
+				"ID":         8148649908875331,
+				"StableID":   "nQ5zhVDYd621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:34ae890a67e5d412c929bce7c14f74e0b14b57f15f5b72c30272ece0ade3f956",
+				"DiscoKey":   "discokey:597ce076bc8e09c80d609d13a71bb2e397108538d803b86f51f6d8f85cc3a14e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46427",
+					"10.65.0.27:46427",
+					"172.17.0.1:46427",
+					"172.18.0.1:46427",
+					"172.19.0.1:46427",
+					"172.20.0.1:46427",
+					"172.21.0.1:46427",
+					"172.22.0.1:46427",
+					"172.23.0.1:46427",
+					"172.24.0.1:46427",
+					"172.25.0.1:46427",
+					"172.26.0.1:46427",
+					"172.27.0.1:46427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:32:29.103855414Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         391639347960856,
+				"StableID":   "nFnF5hhN4411CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6fee700014fceb14b971c5f3fa0b085583de317a60b028590eee406133cd7271",
+				"DiscoKey":   "discokey:7df6539d847203c3b179a5ca7280281d27a8934b308a2a0e7e8233df4fb72e35",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47469",
+					"10.65.0.27:47469",
+					"172.17.0.1:47469",
+					"172.18.0.1:47469",
+					"172.19.0.1:47469",
+					"172.20.0.1:47469",
+					"172.21.0.1:47469",
+					"172.22.0.1:47469",
+					"172.23.0.1:47469",
+					"172.24.0.1:47469",
+					"172.25.0.1:47469",
+					"172.26.0.1:47469",
+					"172.27.0.1:47469"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:32:29.634846588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4028006846160904,
+				"StableID":   "nwWZjkuHTY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c12617359030b76fe8ebe4669b17843b33bb26937d24a5fc038ec4aca1ba9c26",
+				"DiscoKey":   "discokey:5a1070a7160c63c8bb5774f7813c3cc522f54ba17aa835ac9ca522afe275157a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34387",
+					"10.65.0.27:34387",
+					"172.17.0.1:34387",
+					"172.18.0.1:34387",
+					"172.19.0.1:34387",
+					"172.20.0.1:34387",
+					"172.21.0.1:34387",
+					"172.22.0.1:34387",
+					"172.23.0.1:34387",
+					"172.24.0.1:34387",
+					"172.25.0.1:34387",
+					"172.26.0.1:34387",
+					"172.27.0.1:34387"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:32:30.182224358Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5667609051101869,
+				"StableID":   "nrTm2oUsFm11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0466cdf3ee08d9e7a33aa4ff693cdfb2557741196f15ec2466495d03ea90bb24",
+				"DiscoKey":   "discokey:c2e78a42f31849b917095daf147e8ee4bc9aadddb3b9e03f82437a765996b979",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49885",
+					"10.65.0.27:49885",
+					"172.17.0.1:49885",
+					"172.18.0.1:49885",
+					"172.19.0.1:49885",
+					"172.20.0.1:49885",
+					"172.21.0.1:49885",
+					"172.22.0.1:49885",
+					"172.23.0.1:49885",
+					"172.24.0.1:49885",
+					"172.25.0.1:49885",
+					"172.26.0.1:49885",
+					"172.27.0.1:49885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:32:30.726623781Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5117522356983846,
+				"StableID":   "nPoAZodjxg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5ba657c0d8cabbbf649e6fbe62f201662e4972bf7a9885cb71c023b05e4ddb3d",
+				"DiscoKey":   "discokey:855ff5cd29f1f4198c46f3cce4b92a8a6282ead0d35e2ce8f39d0aef2d564628",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:36776",
+					"10.65.0.27:36776",
+					"172.17.0.1:36776",
+					"172.18.0.1:36776",
+					"172.19.0.1:36776",
+					"172.20.0.1:36776",
+					"172.21.0.1:36776",
+					"172.22.0.1:36776",
+					"172.23.0.1:36776",
+					"172.24.0.1:36776",
+					"172.25.0.1:36776",
+					"172.26.0.1:36776",
+					"172.27.0.1:36776"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:32:31.826882566Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         287924645502741,
+				"StableID":   "nLxLywHQF311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a41b428cfcb7a3e5f7de22e9076a13cb6ad3a654ecdd5eb892be78710e4b244",
+				"DiscoKey":   "discokey:0e890516ee8be4d0a1ad4de5942b053e72ae5b30fae17762961d9e9e37a95339",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33298",
+					"10.65.0.27:33298",
+					"172.17.0.1:33298",
+					"172.18.0.1:33298",
+					"172.19.0.1:33298",
+					"172.20.0.1:33298",
+					"172.21.0.1:33298",
+					"172.22.0.1:33298",
+					"172.23.0.1:33298",
+					"172.24.0.1:33298",
+					"172.25.0.1:33298",
+					"172.26.0.1:33298",
+					"172.27.0.1:33298"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:32:32.352383431Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2901116932549833,
+				"StableID":   "nkxRvVRveP11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d50d3291ddcc2426ed52cb1ec7eb372d9b96ed42481bfdaa92edf19933b7a832",
+				"DiscoKey":   "discokey:a35aa66bbfc1ed0a7c4389d94f4a312c3e876b851181c7b5223ebadd96c3943f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48578",
+					"10.65.0.27:48578",
+					"172.17.0.1:48578",
+					"172.18.0.1:48578",
+					"172.19.0.1:48578",
+					"172.20.0.1:48578",
+					"172.21.0.1:48578",
+					"172.22.0.1:48578",
+					"172.23.0.1:48578",
+					"172.24.0.1:48578",
+					"172.25.0.1:48578",
+					"172.26.0.1:48578",
+					"172.27.0.1:48578"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:32:32.893684817Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7120072954315803,
+				"StableID":   "nGVrR6Fhbx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2eda08d9b7d67afa59433c3ad43fa88bb3b634cbc4e148bdd696e81f6ec98867",
+				"DiscoKey":   "discokey:501227c04801df77eadb36c9e1afb905ef69d7d4179c21b1813e8c2172a1790d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45566",
+					"10.65.0.27:45566",
+					"172.17.0.1:45566",
+					"172.18.0.1:45566",
+					"172.19.0.1:45566",
+					"172.20.0.1:45566",
+					"172.21.0.1:45566",
+					"172.22.0.1:45566",
+					"172.23.0.1:45566",
+					"172.24.0.1:45566",
+					"172.25.0.1:45566",
+					"172.26.0.1:45566",
+					"172.27.0.1:45566"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:32:33.465196384Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5888021051733811,
+				"StableID":   "n8Z8m4Lhyn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:09e6d8653854ae1da75e3875192abc593a30f26e60260d4aa881cd103262f110",
+				"DiscoKey":   "discokey:bd3186a88a5dd8901e1a823279a4a0a207aa590c88e242677a94fb0a6400977e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58684",
+					"10.65.0.27:58684",
+					"172.17.0.1:58684",
+					"172.18.0.1:58684",
+					"172.19.0.1:58684",
+					"172.20.0.1:58684",
+					"172.21.0.1:58684",
+					"172.22.0.1:58684",
+					"172.23.0.1:58684",
+					"172.24.0.1:58684",
+					"172.25.0.1:58684",
+					"172.26.0.1:58684",
+					"172.27.0.1:58684"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:32:33.993070049Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6150803441526927,
+				"StableID":   "n855hEBi2q11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c09e025ef3afa0b114831bdb3df9a21fd957e66529a02b7abda72c8d12edb557",
+				"DiscoKey":   "discokey:e40d89391874357ced5eaf747aa4111240a92a6253e12572aca7c9a9aa8b1b32",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38819",
+					"10.65.0.27:38819",
+					"172.17.0.1:38819",
+					"172.18.0.1:38819",
+					"172.19.0.1:38819",
+					"172.20.0.1:38819",
+					"172.21.0.1:38819",
+					"172.22.0.1:38819",
+					"172.23.0.1:38819",
+					"172.24.0.1:38819",
+					"172.25.0.1:38819",
+					"172.26.0.1:38819",
+					"172.27.0.1:38819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:32:34.552360717Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5525739855615142,
+				"StableID":   "njow2Lpc9k11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:878d3dc41fc5c018d1286fcfc61475aa0ddaba8dfb08529a3196cdb64768eb4a",
+				"DiscoKey":   "discokey:06b81e82c8ce2d5f3909a5bce2bdee5ed297dd821afe08e38a15f13bd89ea257",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:33872",
+					"10.65.0.27:33872",
+					"172.17.0.1:33872",
+					"172.18.0.1:33872",
+					"172.19.0.1:33872",
+					"172.20.0.1:33872",
+					"172.21.0.1:33872",
+					"172.22.0.1:33872",
+					"172.23.0.1:33872",
+					"172.24.0.1:33872",
+					"172.25.0.1:33872",
+					"172.26.0.1:33872",
+					"172.27.0.1:33872"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:32:35.0718264Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8745332619298087,
+				"StableID":   "nnJoaP4nHB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:807d14fb0b782361ea13d98b82fcfb807a4cdd48f93ea57e1dd76d65498a6b38",
+				"KeyExpiry":  "2026-11-09T09:32:35Z",
+				"DiscoKey":   "discokey:aee8eb99f195b741bf394cd36106086b0ddb07976ca74153927216b327281742",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45759",
+					"10.65.0.27:45759",
+					"172.17.0.1:45759",
+					"172.18.0.1:45759",
+					"172.19.0.1:45759",
+					"172.20.0.1:45759",
+					"172.21.0.1:45759",
+					"172.22.0.1:45759",
+					"172.23.0.1:45759",
+					"172.24.0.1:45759",
+					"172.25.0.1:45759",
+					"172.26.0.1:45759",
+					"172.27.0.1:45759"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:32:35.616160418Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3874427254547311,
+				"StableID":   "n8Rd8ndjFX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bee7fba92b33ef72d90bc38b48c5c500ac2731e2c5f56b5545fa43b059053973",
+				"KeyExpiry":  "2026-11-09T09:32:36Z",
+				"DiscoKey":   "discokey:b2955b623cedbab0242b00574aeb08f48e38df1e99c0128aeb1e85f77794ef6e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:45049",
+					"10.65.0.27:45049",
+					"172.17.0.1:45049",
+					"172.18.0.1:45049",
+					"172.19.0.1:45049",
+					"172.20.0.1:45049",
+					"172.21.0.1:45049",
+					"172.22.0.1:45049",
+					"172.23.0.1:45049",
+					"172.24.0.1:45049",
+					"172.25.0.1:45049",
+					"172.26.0.1:45049",
+					"172.27.0.1:45049"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:32:36.160990465Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7587609051638003,
+				"StableID":   "ncM7MAdSF221CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e2fb44c0f8b5ee8ebebce7b53fe85e66b63fc8bb71e3db350e45e4d9ffdb705a",
+				"KeyExpiry":  "2026-11-09T09:32:36Z",
+				"DiscoKey":   "discokey:3336cb49d6bacf01ef1f81b38ec9d8dbb08b6be1411c2fe4f17f6ed99a4db25c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50296",
+					"10.65.0.27:50296",
+					"172.17.0.1:50296",
+					"172.18.0.1:50296",
+					"172.19.0.1:50296",
+					"172.20.0.1:50296",
+					"172.21.0.1:50296",
+					"172.22.0.1:50296",
+					"172.23.0.1:50296",
+					"172.24.0.1:50296",
+					"172.25.0.1:50296",
+					"172.26.0.1:50296",
+					"172.27.0.1:50296"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:32:36.700599251Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7941934760275445": {
+				"ID":          7941934760275445,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5667609051101869,
+				"StableID":   "nrTm2oUsFm11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       5667609051101869,
+				"Key":        "nodekey:0466cdf3ee08d9e7a33aa4ff693cdfb2557741196f15ec2466495d03ea90bb24",
+				"DiscoKey":   "discokey:c2e78a42f31849b917095daf147e8ee4bc9aadddb3b9e03f82437a765996b979",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49885",
+					"10.65.0.27:49885",
+					"172.17.0.1:49885",
+					"172.18.0.1:49885",
+					"172.19.0.1:49885",
+					"172.20.0.1:49885",
+					"172.21.0.1:49885",
+					"172.22.0.1:49885",
+					"172.23.0.1:49885",
+					"172.24.0.1:49885",
+					"172.25.0.1:49885",
+					"172.26.0.1:49885",
+					"172.27.0.1:49885"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:32:30.726623781Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0466cdf3ee08d9e7a33aa4ff693cdfb2557741196f15ec2466495d03ea90bb24",
+			"MachineKey": "mkey:09af019dd953685fb57c37e60878d607d54901e0e86c996429f100995472a10c",
+			"Peers": [{
+				"ID":         8148649908875331,
+				"StableID":   "nQ5zhVDYd621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:34ae890a67e5d412c929bce7c14f74e0b14b57f15f5b72c30272ece0ade3f956",
+				"DiscoKey":   "discokey:597ce076bc8e09c80d609d13a71bb2e397108538d803b86f51f6d8f85cc3a14e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46427",
+					"10.65.0.27:46427",
+					"172.17.0.1:46427",
+					"172.18.0.1:46427",
+					"172.19.0.1:46427",
+					"172.20.0.1:46427",
+					"172.21.0.1:46427",
+					"172.22.0.1:46427",
+					"172.23.0.1:46427",
+					"172.24.0.1:46427",
+					"172.25.0.1:46427",
+					"172.26.0.1:46427",
+					"172.27.0.1:46427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:32:29.103855414Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         391639347960856,
+				"StableID":   "nFnF5hhN4411CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6fee700014fceb14b971c5f3fa0b085583de317a60b028590eee406133cd7271",
+				"DiscoKey":   "discokey:7df6539d847203c3b179a5ca7280281d27a8934b308a2a0e7e8233df4fb72e35",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47469",
+					"10.65.0.27:47469",
+					"172.17.0.1:47469",
+					"172.18.0.1:47469",
+					"172.19.0.1:47469",
+					"172.20.0.1:47469",
+					"172.21.0.1:47469",
+					"172.22.0.1:47469",
+					"172.23.0.1:47469",
+					"172.24.0.1:47469",
+					"172.25.0.1:47469",
+					"172.26.0.1:47469",
+					"172.27.0.1:47469"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:32:29.634846588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4028006846160904,
+				"StableID":   "nwWZjkuHTY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c12617359030b76fe8ebe4669b17843b33bb26937d24a5fc038ec4aca1ba9c26",
+				"DiscoKey":   "discokey:5a1070a7160c63c8bb5774f7813c3cc522f54ba17aa835ac9ca522afe275157a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34387",
+					"10.65.0.27:34387",
+					"172.17.0.1:34387",
+					"172.18.0.1:34387",
+					"172.19.0.1:34387",
+					"172.20.0.1:34387",
+					"172.21.0.1:34387",
+					"172.22.0.1:34387",
+					"172.23.0.1:34387",
+					"172.24.0.1:34387",
+					"172.25.0.1:34387",
+					"172.26.0.1:34387",
+					"172.27.0.1:34387"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:32:30.182224358Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7941934760275445,
+				"StableID":   "nUxUtDAv1521CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9a9aa185696cd03de991e3c7fbebe238d84949b7c05325f4ed3027b8379013d",
+				"DiscoKey":   "discokey:73f984575d16237be0d09b95e6cc3368d1e92328ad88ceea61bdb9ca7adc1c1b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50093",
+					"10.65.0.27:50093",
+					"172.17.0.1:50093",
+					"172.18.0.1:50093",
+					"172.19.0.1:50093",
+					"172.20.0.1:50093",
+					"172.21.0.1:50093",
+					"172.22.0.1:50093",
+					"172.23.0.1:50093",
+					"172.24.0.1:50093",
+					"172.25.0.1:50093",
+					"172.26.0.1:50093",
+					"172.27.0.1:50093"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:32:31.264509883Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5117522356983846,
+				"StableID":   "nPoAZodjxg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5ba657c0d8cabbbf649e6fbe62f201662e4972bf7a9885cb71c023b05e4ddb3d",
+				"DiscoKey":   "discokey:855ff5cd29f1f4198c46f3cce4b92a8a6282ead0d35e2ce8f39d0aef2d564628",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:36776",
+					"10.65.0.27:36776",
+					"172.17.0.1:36776",
+					"172.18.0.1:36776",
+					"172.19.0.1:36776",
+					"172.20.0.1:36776",
+					"172.21.0.1:36776",
+					"172.22.0.1:36776",
+					"172.23.0.1:36776",
+					"172.24.0.1:36776",
+					"172.25.0.1:36776",
+					"172.26.0.1:36776",
+					"172.27.0.1:36776"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:32:31.826882566Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         287924645502741,
+				"StableID":   "nLxLywHQF311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a41b428cfcb7a3e5f7de22e9076a13cb6ad3a654ecdd5eb892be78710e4b244",
+				"DiscoKey":   "discokey:0e890516ee8be4d0a1ad4de5942b053e72ae5b30fae17762961d9e9e37a95339",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33298",
+					"10.65.0.27:33298",
+					"172.17.0.1:33298",
+					"172.18.0.1:33298",
+					"172.19.0.1:33298",
+					"172.20.0.1:33298",
+					"172.21.0.1:33298",
+					"172.22.0.1:33298",
+					"172.23.0.1:33298",
+					"172.24.0.1:33298",
+					"172.25.0.1:33298",
+					"172.26.0.1:33298",
+					"172.27.0.1:33298"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:32:32.352383431Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2901116932549833,
+				"StableID":   "nkxRvVRveP11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d50d3291ddcc2426ed52cb1ec7eb372d9b96ed42481bfdaa92edf19933b7a832",
+				"DiscoKey":   "discokey:a35aa66bbfc1ed0a7c4389d94f4a312c3e876b851181c7b5223ebadd96c3943f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48578",
+					"10.65.0.27:48578",
+					"172.17.0.1:48578",
+					"172.18.0.1:48578",
+					"172.19.0.1:48578",
+					"172.20.0.1:48578",
+					"172.21.0.1:48578",
+					"172.22.0.1:48578",
+					"172.23.0.1:48578",
+					"172.24.0.1:48578",
+					"172.25.0.1:48578",
+					"172.26.0.1:48578",
+					"172.27.0.1:48578"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:32:32.893684817Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7120072954315803,
+				"StableID":   "nGVrR6Fhbx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2eda08d9b7d67afa59433c3ad43fa88bb3b634cbc4e148bdd696e81f6ec98867",
+				"DiscoKey":   "discokey:501227c04801df77eadb36c9e1afb905ef69d7d4179c21b1813e8c2172a1790d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45566",
+					"10.65.0.27:45566",
+					"172.17.0.1:45566",
+					"172.18.0.1:45566",
+					"172.19.0.1:45566",
+					"172.20.0.1:45566",
+					"172.21.0.1:45566",
+					"172.22.0.1:45566",
+					"172.23.0.1:45566",
+					"172.24.0.1:45566",
+					"172.25.0.1:45566",
+					"172.26.0.1:45566",
+					"172.27.0.1:45566"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:32:33.465196384Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5888021051733811,
+				"StableID":   "n8Z8m4Lhyn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:09e6d8653854ae1da75e3875192abc593a30f26e60260d4aa881cd103262f110",
+				"DiscoKey":   "discokey:bd3186a88a5dd8901e1a823279a4a0a207aa590c88e242677a94fb0a6400977e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58684",
+					"10.65.0.27:58684",
+					"172.17.0.1:58684",
+					"172.18.0.1:58684",
+					"172.19.0.1:58684",
+					"172.20.0.1:58684",
+					"172.21.0.1:58684",
+					"172.22.0.1:58684",
+					"172.23.0.1:58684",
+					"172.24.0.1:58684",
+					"172.25.0.1:58684",
+					"172.26.0.1:58684",
+					"172.27.0.1:58684"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:32:33.993070049Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6150803441526927,
+				"StableID":   "n855hEBi2q11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c09e025ef3afa0b114831bdb3df9a21fd957e66529a02b7abda72c8d12edb557",
+				"DiscoKey":   "discokey:e40d89391874357ced5eaf747aa4111240a92a6253e12572aca7c9a9aa8b1b32",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38819",
+					"10.65.0.27:38819",
+					"172.17.0.1:38819",
+					"172.18.0.1:38819",
+					"172.19.0.1:38819",
+					"172.20.0.1:38819",
+					"172.21.0.1:38819",
+					"172.22.0.1:38819",
+					"172.23.0.1:38819",
+					"172.24.0.1:38819",
+					"172.25.0.1:38819",
+					"172.26.0.1:38819",
+					"172.27.0.1:38819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:32:34.552360717Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5525739855615142,
+				"StableID":   "njow2Lpc9k11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:878d3dc41fc5c018d1286fcfc61475aa0ddaba8dfb08529a3196cdb64768eb4a",
+				"DiscoKey":   "discokey:06b81e82c8ce2d5f3909a5bce2bdee5ed297dd821afe08e38a15f13bd89ea257",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:33872",
+					"10.65.0.27:33872",
+					"172.17.0.1:33872",
+					"172.18.0.1:33872",
+					"172.19.0.1:33872",
+					"172.20.0.1:33872",
+					"172.21.0.1:33872",
+					"172.22.0.1:33872",
+					"172.23.0.1:33872",
+					"172.24.0.1:33872",
+					"172.25.0.1:33872",
+					"172.26.0.1:33872",
+					"172.27.0.1:33872"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:32:35.0718264Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8745332619298087,
+				"StableID":   "nnJoaP4nHB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:807d14fb0b782361ea13d98b82fcfb807a4cdd48f93ea57e1dd76d65498a6b38",
+				"KeyExpiry":  "2026-11-09T09:32:35Z",
+				"DiscoKey":   "discokey:aee8eb99f195b741bf394cd36106086b0ddb07976ca74153927216b327281742",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45759",
+					"10.65.0.27:45759",
+					"172.17.0.1:45759",
+					"172.18.0.1:45759",
+					"172.19.0.1:45759",
+					"172.20.0.1:45759",
+					"172.21.0.1:45759",
+					"172.22.0.1:45759",
+					"172.23.0.1:45759",
+					"172.24.0.1:45759",
+					"172.25.0.1:45759",
+					"172.26.0.1:45759",
+					"172.27.0.1:45759"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:32:35.616160418Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3874427254547311,
+				"StableID":   "n8Rd8ndjFX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bee7fba92b33ef72d90bc38b48c5c500ac2731e2c5f56b5545fa43b059053973",
+				"KeyExpiry":  "2026-11-09T09:32:36Z",
+				"DiscoKey":   "discokey:b2955b623cedbab0242b00574aeb08f48e38df1e99c0128aeb1e85f77794ef6e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:45049",
+					"10.65.0.27:45049",
+					"172.17.0.1:45049",
+					"172.18.0.1:45049",
+					"172.19.0.1:45049",
+					"172.20.0.1:45049",
+					"172.21.0.1:45049",
+					"172.22.0.1:45049",
+					"172.23.0.1:45049",
+					"172.24.0.1:45049",
+					"172.25.0.1:45049",
+					"172.26.0.1:45049",
+					"172.27.0.1:45049"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:32:36.160990465Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7587609051638003,
+				"StableID":   "ncM7MAdSF221CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e2fb44c0f8b5ee8ebebce7b53fe85e66b63fc8bb71e3db350e45e4d9ffdb705a",
+				"KeyExpiry":  "2026-11-09T09:32:36Z",
+				"DiscoKey":   "discokey:3336cb49d6bacf01ef1f81b38ec9d8dbb08b6be1411c2fe4f17f6ed99a4db25c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50296",
+					"10.65.0.27:50296",
+					"172.17.0.1:50296",
+					"172.18.0.1:50296",
+					"172.19.0.1:50296",
+					"172.20.0.1:50296",
+					"172.21.0.1:50296",
+					"172.22.0.1:50296",
+					"172.23.0.1:50296",
+					"172.24.0.1:50296",
+					"172.25.0.1:50296",
+					"172.26.0.1:50296",
+					"172.27.0.1:50296"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:32:36.700599251Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5667609051101869": {
+				"ID":          5667609051101869,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         287924645502741,
+				"StableID":   "nLxLywHQF311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       287924645502741,
+				"Key":        "nodekey:1a41b428cfcb7a3e5f7de22e9076a13cb6ad3a654ecdd5eb892be78710e4b244",
+				"DiscoKey":   "discokey:0e890516ee8be4d0a1ad4de5942b053e72ae5b30fae17762961d9e9e37a95339",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33298",
+					"10.65.0.27:33298",
+					"172.17.0.1:33298",
+					"172.18.0.1:33298",
+					"172.19.0.1:33298",
+					"172.20.0.1:33298",
+					"172.21.0.1:33298",
+					"172.22.0.1:33298",
+					"172.23.0.1:33298",
+					"172.24.0.1:33298",
+					"172.25.0.1:33298",
+					"172.26.0.1:33298",
+					"172.27.0.1:33298"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:32:32.352383431Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1a41b428cfcb7a3e5f7de22e9076a13cb6ad3a654ecdd5eb892be78710e4b244",
+			"MachineKey": "mkey:6fa9b18c553eb7d9d6c4b08b3582422b6ccf4cd6acc24f0bd1a4afbb184e797d",
+			"Peers": [{
+				"ID":         8148649908875331,
+				"StableID":   "nQ5zhVDYd621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:34ae890a67e5d412c929bce7c14f74e0b14b57f15f5b72c30272ece0ade3f956",
+				"DiscoKey":   "discokey:597ce076bc8e09c80d609d13a71bb2e397108538d803b86f51f6d8f85cc3a14e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46427",
+					"10.65.0.27:46427",
+					"172.17.0.1:46427",
+					"172.18.0.1:46427",
+					"172.19.0.1:46427",
+					"172.20.0.1:46427",
+					"172.21.0.1:46427",
+					"172.22.0.1:46427",
+					"172.23.0.1:46427",
+					"172.24.0.1:46427",
+					"172.25.0.1:46427",
+					"172.26.0.1:46427",
+					"172.27.0.1:46427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:32:29.103855414Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         391639347960856,
+				"StableID":   "nFnF5hhN4411CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6fee700014fceb14b971c5f3fa0b085583de317a60b028590eee406133cd7271",
+				"DiscoKey":   "discokey:7df6539d847203c3b179a5ca7280281d27a8934b308a2a0e7e8233df4fb72e35",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47469",
+					"10.65.0.27:47469",
+					"172.17.0.1:47469",
+					"172.18.0.1:47469",
+					"172.19.0.1:47469",
+					"172.20.0.1:47469",
+					"172.21.0.1:47469",
+					"172.22.0.1:47469",
+					"172.23.0.1:47469",
+					"172.24.0.1:47469",
+					"172.25.0.1:47469",
+					"172.26.0.1:47469",
+					"172.27.0.1:47469"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:32:29.634846588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4028006846160904,
+				"StableID":   "nwWZjkuHTY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c12617359030b76fe8ebe4669b17843b33bb26937d24a5fc038ec4aca1ba9c26",
+				"DiscoKey":   "discokey:5a1070a7160c63c8bb5774f7813c3cc522f54ba17aa835ac9ca522afe275157a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34387",
+					"10.65.0.27:34387",
+					"172.17.0.1:34387",
+					"172.18.0.1:34387",
+					"172.19.0.1:34387",
+					"172.20.0.1:34387",
+					"172.21.0.1:34387",
+					"172.22.0.1:34387",
+					"172.23.0.1:34387",
+					"172.24.0.1:34387",
+					"172.25.0.1:34387",
+					"172.26.0.1:34387",
+					"172.27.0.1:34387"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:32:30.182224358Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5667609051101869,
+				"StableID":   "nrTm2oUsFm11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0466cdf3ee08d9e7a33aa4ff693cdfb2557741196f15ec2466495d03ea90bb24",
+				"DiscoKey":   "discokey:c2e78a42f31849b917095daf147e8ee4bc9aadddb3b9e03f82437a765996b979",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49885",
+					"10.65.0.27:49885",
+					"172.17.0.1:49885",
+					"172.18.0.1:49885",
+					"172.19.0.1:49885",
+					"172.20.0.1:49885",
+					"172.21.0.1:49885",
+					"172.22.0.1:49885",
+					"172.23.0.1:49885",
+					"172.24.0.1:49885",
+					"172.25.0.1:49885",
+					"172.26.0.1:49885",
+					"172.27.0.1:49885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:32:30.726623781Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7941934760275445,
+				"StableID":   "nUxUtDAv1521CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9a9aa185696cd03de991e3c7fbebe238d84949b7c05325f4ed3027b8379013d",
+				"DiscoKey":   "discokey:73f984575d16237be0d09b95e6cc3368d1e92328ad88ceea61bdb9ca7adc1c1b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50093",
+					"10.65.0.27:50093",
+					"172.17.0.1:50093",
+					"172.18.0.1:50093",
+					"172.19.0.1:50093",
+					"172.20.0.1:50093",
+					"172.21.0.1:50093",
+					"172.22.0.1:50093",
+					"172.23.0.1:50093",
+					"172.24.0.1:50093",
+					"172.25.0.1:50093",
+					"172.26.0.1:50093",
+					"172.27.0.1:50093"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:32:31.264509883Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5117522356983846,
+				"StableID":   "nPoAZodjxg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5ba657c0d8cabbbf649e6fbe62f201662e4972bf7a9885cb71c023b05e4ddb3d",
+				"DiscoKey":   "discokey:855ff5cd29f1f4198c46f3cce4b92a8a6282ead0d35e2ce8f39d0aef2d564628",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:36776",
+					"10.65.0.27:36776",
+					"172.17.0.1:36776",
+					"172.18.0.1:36776",
+					"172.19.0.1:36776",
+					"172.20.0.1:36776",
+					"172.21.0.1:36776",
+					"172.22.0.1:36776",
+					"172.23.0.1:36776",
+					"172.24.0.1:36776",
+					"172.25.0.1:36776",
+					"172.26.0.1:36776",
+					"172.27.0.1:36776"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:32:31.826882566Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2901116932549833,
+				"StableID":   "nkxRvVRveP11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d50d3291ddcc2426ed52cb1ec7eb372d9b96ed42481bfdaa92edf19933b7a832",
+				"DiscoKey":   "discokey:a35aa66bbfc1ed0a7c4389d94f4a312c3e876b851181c7b5223ebadd96c3943f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48578",
+					"10.65.0.27:48578",
+					"172.17.0.1:48578",
+					"172.18.0.1:48578",
+					"172.19.0.1:48578",
+					"172.20.0.1:48578",
+					"172.21.0.1:48578",
+					"172.22.0.1:48578",
+					"172.23.0.1:48578",
+					"172.24.0.1:48578",
+					"172.25.0.1:48578",
+					"172.26.0.1:48578",
+					"172.27.0.1:48578"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:32:32.893684817Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7120072954315803,
+				"StableID":   "nGVrR6Fhbx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2eda08d9b7d67afa59433c3ad43fa88bb3b634cbc4e148bdd696e81f6ec98867",
+				"DiscoKey":   "discokey:501227c04801df77eadb36c9e1afb905ef69d7d4179c21b1813e8c2172a1790d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45566",
+					"10.65.0.27:45566",
+					"172.17.0.1:45566",
+					"172.18.0.1:45566",
+					"172.19.0.1:45566",
+					"172.20.0.1:45566",
+					"172.21.0.1:45566",
+					"172.22.0.1:45566",
+					"172.23.0.1:45566",
+					"172.24.0.1:45566",
+					"172.25.0.1:45566",
+					"172.26.0.1:45566",
+					"172.27.0.1:45566"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:32:33.465196384Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5888021051733811,
+				"StableID":   "n8Z8m4Lhyn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:09e6d8653854ae1da75e3875192abc593a30f26e60260d4aa881cd103262f110",
+				"DiscoKey":   "discokey:bd3186a88a5dd8901e1a823279a4a0a207aa590c88e242677a94fb0a6400977e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58684",
+					"10.65.0.27:58684",
+					"172.17.0.1:58684",
+					"172.18.0.1:58684",
+					"172.19.0.1:58684",
+					"172.20.0.1:58684",
+					"172.21.0.1:58684",
+					"172.22.0.1:58684",
+					"172.23.0.1:58684",
+					"172.24.0.1:58684",
+					"172.25.0.1:58684",
+					"172.26.0.1:58684",
+					"172.27.0.1:58684"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:32:33.993070049Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6150803441526927,
+				"StableID":   "n855hEBi2q11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c09e025ef3afa0b114831bdb3df9a21fd957e66529a02b7abda72c8d12edb557",
+				"DiscoKey":   "discokey:e40d89391874357ced5eaf747aa4111240a92a6253e12572aca7c9a9aa8b1b32",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38819",
+					"10.65.0.27:38819",
+					"172.17.0.1:38819",
+					"172.18.0.1:38819",
+					"172.19.0.1:38819",
+					"172.20.0.1:38819",
+					"172.21.0.1:38819",
+					"172.22.0.1:38819",
+					"172.23.0.1:38819",
+					"172.24.0.1:38819",
+					"172.25.0.1:38819",
+					"172.26.0.1:38819",
+					"172.27.0.1:38819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:32:34.552360717Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5525739855615142,
+				"StableID":   "njow2Lpc9k11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:878d3dc41fc5c018d1286fcfc61475aa0ddaba8dfb08529a3196cdb64768eb4a",
+				"DiscoKey":   "discokey:06b81e82c8ce2d5f3909a5bce2bdee5ed297dd821afe08e38a15f13bd89ea257",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:33872",
+					"10.65.0.27:33872",
+					"172.17.0.1:33872",
+					"172.18.0.1:33872",
+					"172.19.0.1:33872",
+					"172.20.0.1:33872",
+					"172.21.0.1:33872",
+					"172.22.0.1:33872",
+					"172.23.0.1:33872",
+					"172.24.0.1:33872",
+					"172.25.0.1:33872",
+					"172.26.0.1:33872",
+					"172.27.0.1:33872"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:32:35.0718264Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8745332619298087,
+				"StableID":   "nnJoaP4nHB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:807d14fb0b782361ea13d98b82fcfb807a4cdd48f93ea57e1dd76d65498a6b38",
+				"KeyExpiry":  "2026-11-09T09:32:35Z",
+				"DiscoKey":   "discokey:aee8eb99f195b741bf394cd36106086b0ddb07976ca74153927216b327281742",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45759",
+					"10.65.0.27:45759",
+					"172.17.0.1:45759",
+					"172.18.0.1:45759",
+					"172.19.0.1:45759",
+					"172.20.0.1:45759",
+					"172.21.0.1:45759",
+					"172.22.0.1:45759",
+					"172.23.0.1:45759",
+					"172.24.0.1:45759",
+					"172.25.0.1:45759",
+					"172.26.0.1:45759",
+					"172.27.0.1:45759"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:32:35.616160418Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3874427254547311,
+				"StableID":   "n8Rd8ndjFX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bee7fba92b33ef72d90bc38b48c5c500ac2731e2c5f56b5545fa43b059053973",
+				"KeyExpiry":  "2026-11-09T09:32:36Z",
+				"DiscoKey":   "discokey:b2955b623cedbab0242b00574aeb08f48e38df1e99c0128aeb1e85f77794ef6e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:45049",
+					"10.65.0.27:45049",
+					"172.17.0.1:45049",
+					"172.18.0.1:45049",
+					"172.19.0.1:45049",
+					"172.20.0.1:45049",
+					"172.21.0.1:45049",
+					"172.22.0.1:45049",
+					"172.23.0.1:45049",
+					"172.24.0.1:45049",
+					"172.25.0.1:45049",
+					"172.26.0.1:45049",
+					"172.27.0.1:45049"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:32:36.160990465Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7587609051638003,
+				"StableID":   "ncM7MAdSF221CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e2fb44c0f8b5ee8ebebce7b53fe85e66b63fc8bb71e3db350e45e4d9ffdb705a",
+				"KeyExpiry":  "2026-11-09T09:32:36Z",
+				"DiscoKey":   "discokey:3336cb49d6bacf01ef1f81b38ec9d8dbb08b6be1411c2fe4f17f6ed99a4db25c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50296",
+					"10.65.0.27:50296",
+					"172.17.0.1:50296",
+					"172.18.0.1:50296",
+					"172.19.0.1:50296",
+					"172.20.0.1:50296",
+					"172.21.0.1:50296",
+					"172.22.0.1:50296",
+					"172.23.0.1:50296",
+					"172.24.0.1:50296",
+					"172.25.0.1:50296",
+					"172.26.0.1:50296",
+					"172.27.0.1:50296"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:32:36.700599251Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "287924645502741": {
+				"ID":          287924645502741,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7120072954315803,
+				"StableID":   "nGVrR6Fhbx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       7120072954315803,
+				"Key":        "nodekey:2eda08d9b7d67afa59433c3ad43fa88bb3b634cbc4e148bdd696e81f6ec98867",
+				"DiscoKey":   "discokey:501227c04801df77eadb36c9e1afb905ef69d7d4179c21b1813e8c2172a1790d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45566",
+					"10.65.0.27:45566",
+					"172.17.0.1:45566",
+					"172.18.0.1:45566",
+					"172.19.0.1:45566",
+					"172.20.0.1:45566",
+					"172.21.0.1:45566",
+					"172.22.0.1:45566",
+					"172.23.0.1:45566",
+					"172.24.0.1:45566",
+					"172.25.0.1:45566",
+					"172.26.0.1:45566",
+					"172.27.0.1:45566"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:32:33.465196384Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2eda08d9b7d67afa59433c3ad43fa88bb3b634cbc4e148bdd696e81f6ec98867",
+			"MachineKey": "mkey:3a30f9d6ce328e563a1c1731aa3233a2ee838eff5c7837fbc56d30b2cf454340",
+			"Peers": [{
+				"ID":         8148649908875331,
+				"StableID":   "nQ5zhVDYd621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:34ae890a67e5d412c929bce7c14f74e0b14b57f15f5b72c30272ece0ade3f956",
+				"DiscoKey":   "discokey:597ce076bc8e09c80d609d13a71bb2e397108538d803b86f51f6d8f85cc3a14e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46427",
+					"10.65.0.27:46427",
+					"172.17.0.1:46427",
+					"172.18.0.1:46427",
+					"172.19.0.1:46427",
+					"172.20.0.1:46427",
+					"172.21.0.1:46427",
+					"172.22.0.1:46427",
+					"172.23.0.1:46427",
+					"172.24.0.1:46427",
+					"172.25.0.1:46427",
+					"172.26.0.1:46427",
+					"172.27.0.1:46427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:32:29.103855414Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         391639347960856,
+				"StableID":   "nFnF5hhN4411CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6fee700014fceb14b971c5f3fa0b085583de317a60b028590eee406133cd7271",
+				"DiscoKey":   "discokey:7df6539d847203c3b179a5ca7280281d27a8934b308a2a0e7e8233df4fb72e35",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47469",
+					"10.65.0.27:47469",
+					"172.17.0.1:47469",
+					"172.18.0.1:47469",
+					"172.19.0.1:47469",
+					"172.20.0.1:47469",
+					"172.21.0.1:47469",
+					"172.22.0.1:47469",
+					"172.23.0.1:47469",
+					"172.24.0.1:47469",
+					"172.25.0.1:47469",
+					"172.26.0.1:47469",
+					"172.27.0.1:47469"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:32:29.634846588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4028006846160904,
+				"StableID":   "nwWZjkuHTY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c12617359030b76fe8ebe4669b17843b33bb26937d24a5fc038ec4aca1ba9c26",
+				"DiscoKey":   "discokey:5a1070a7160c63c8bb5774f7813c3cc522f54ba17aa835ac9ca522afe275157a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34387",
+					"10.65.0.27:34387",
+					"172.17.0.1:34387",
+					"172.18.0.1:34387",
+					"172.19.0.1:34387",
+					"172.20.0.1:34387",
+					"172.21.0.1:34387",
+					"172.22.0.1:34387",
+					"172.23.0.1:34387",
+					"172.24.0.1:34387",
+					"172.25.0.1:34387",
+					"172.26.0.1:34387",
+					"172.27.0.1:34387"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:32:30.182224358Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5667609051101869,
+				"StableID":   "nrTm2oUsFm11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0466cdf3ee08d9e7a33aa4ff693cdfb2557741196f15ec2466495d03ea90bb24",
+				"DiscoKey":   "discokey:c2e78a42f31849b917095daf147e8ee4bc9aadddb3b9e03f82437a765996b979",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49885",
+					"10.65.0.27:49885",
+					"172.17.0.1:49885",
+					"172.18.0.1:49885",
+					"172.19.0.1:49885",
+					"172.20.0.1:49885",
+					"172.21.0.1:49885",
+					"172.22.0.1:49885",
+					"172.23.0.1:49885",
+					"172.24.0.1:49885",
+					"172.25.0.1:49885",
+					"172.26.0.1:49885",
+					"172.27.0.1:49885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:32:30.726623781Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7941934760275445,
+				"StableID":   "nUxUtDAv1521CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9a9aa185696cd03de991e3c7fbebe238d84949b7c05325f4ed3027b8379013d",
+				"DiscoKey":   "discokey:73f984575d16237be0d09b95e6cc3368d1e92328ad88ceea61bdb9ca7adc1c1b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50093",
+					"10.65.0.27:50093",
+					"172.17.0.1:50093",
+					"172.18.0.1:50093",
+					"172.19.0.1:50093",
+					"172.20.0.1:50093",
+					"172.21.0.1:50093",
+					"172.22.0.1:50093",
+					"172.23.0.1:50093",
+					"172.24.0.1:50093",
+					"172.25.0.1:50093",
+					"172.26.0.1:50093",
+					"172.27.0.1:50093"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:32:31.264509883Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5117522356983846,
+				"StableID":   "nPoAZodjxg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5ba657c0d8cabbbf649e6fbe62f201662e4972bf7a9885cb71c023b05e4ddb3d",
+				"DiscoKey":   "discokey:855ff5cd29f1f4198c46f3cce4b92a8a6282ead0d35e2ce8f39d0aef2d564628",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:36776",
+					"10.65.0.27:36776",
+					"172.17.0.1:36776",
+					"172.18.0.1:36776",
+					"172.19.0.1:36776",
+					"172.20.0.1:36776",
+					"172.21.0.1:36776",
+					"172.22.0.1:36776",
+					"172.23.0.1:36776",
+					"172.24.0.1:36776",
+					"172.25.0.1:36776",
+					"172.26.0.1:36776",
+					"172.27.0.1:36776"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:32:31.826882566Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         287924645502741,
+				"StableID":   "nLxLywHQF311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a41b428cfcb7a3e5f7de22e9076a13cb6ad3a654ecdd5eb892be78710e4b244",
+				"DiscoKey":   "discokey:0e890516ee8be4d0a1ad4de5942b053e72ae5b30fae17762961d9e9e37a95339",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33298",
+					"10.65.0.27:33298",
+					"172.17.0.1:33298",
+					"172.18.0.1:33298",
+					"172.19.0.1:33298",
+					"172.20.0.1:33298",
+					"172.21.0.1:33298",
+					"172.22.0.1:33298",
+					"172.23.0.1:33298",
+					"172.24.0.1:33298",
+					"172.25.0.1:33298",
+					"172.26.0.1:33298",
+					"172.27.0.1:33298"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:32:32.352383431Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2901116932549833,
+				"StableID":   "nkxRvVRveP11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d50d3291ddcc2426ed52cb1ec7eb372d9b96ed42481bfdaa92edf19933b7a832",
+				"DiscoKey":   "discokey:a35aa66bbfc1ed0a7c4389d94f4a312c3e876b851181c7b5223ebadd96c3943f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48578",
+					"10.65.0.27:48578",
+					"172.17.0.1:48578",
+					"172.18.0.1:48578",
+					"172.19.0.1:48578",
+					"172.20.0.1:48578",
+					"172.21.0.1:48578",
+					"172.22.0.1:48578",
+					"172.23.0.1:48578",
+					"172.24.0.1:48578",
+					"172.25.0.1:48578",
+					"172.26.0.1:48578",
+					"172.27.0.1:48578"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:32:32.893684817Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5888021051733811,
+				"StableID":   "n8Z8m4Lhyn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:09e6d8653854ae1da75e3875192abc593a30f26e60260d4aa881cd103262f110",
+				"DiscoKey":   "discokey:bd3186a88a5dd8901e1a823279a4a0a207aa590c88e242677a94fb0a6400977e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58684",
+					"10.65.0.27:58684",
+					"172.17.0.1:58684",
+					"172.18.0.1:58684",
+					"172.19.0.1:58684",
+					"172.20.0.1:58684",
+					"172.21.0.1:58684",
+					"172.22.0.1:58684",
+					"172.23.0.1:58684",
+					"172.24.0.1:58684",
+					"172.25.0.1:58684",
+					"172.26.0.1:58684",
+					"172.27.0.1:58684"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:32:33.993070049Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6150803441526927,
+				"StableID":   "n855hEBi2q11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c09e025ef3afa0b114831bdb3df9a21fd957e66529a02b7abda72c8d12edb557",
+				"DiscoKey":   "discokey:e40d89391874357ced5eaf747aa4111240a92a6253e12572aca7c9a9aa8b1b32",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38819",
+					"10.65.0.27:38819",
+					"172.17.0.1:38819",
+					"172.18.0.1:38819",
+					"172.19.0.1:38819",
+					"172.20.0.1:38819",
+					"172.21.0.1:38819",
+					"172.22.0.1:38819",
+					"172.23.0.1:38819",
+					"172.24.0.1:38819",
+					"172.25.0.1:38819",
+					"172.26.0.1:38819",
+					"172.27.0.1:38819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:32:34.552360717Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5525739855615142,
+				"StableID":   "njow2Lpc9k11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:878d3dc41fc5c018d1286fcfc61475aa0ddaba8dfb08529a3196cdb64768eb4a",
+				"DiscoKey":   "discokey:06b81e82c8ce2d5f3909a5bce2bdee5ed297dd821afe08e38a15f13bd89ea257",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:33872",
+					"10.65.0.27:33872",
+					"172.17.0.1:33872",
+					"172.18.0.1:33872",
+					"172.19.0.1:33872",
+					"172.20.0.1:33872",
+					"172.21.0.1:33872",
+					"172.22.0.1:33872",
+					"172.23.0.1:33872",
+					"172.24.0.1:33872",
+					"172.25.0.1:33872",
+					"172.26.0.1:33872",
+					"172.27.0.1:33872"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:32:35.0718264Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8745332619298087,
+				"StableID":   "nnJoaP4nHB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:807d14fb0b782361ea13d98b82fcfb807a4cdd48f93ea57e1dd76d65498a6b38",
+				"KeyExpiry":  "2026-11-09T09:32:35Z",
+				"DiscoKey":   "discokey:aee8eb99f195b741bf394cd36106086b0ddb07976ca74153927216b327281742",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45759",
+					"10.65.0.27:45759",
+					"172.17.0.1:45759",
+					"172.18.0.1:45759",
+					"172.19.0.1:45759",
+					"172.20.0.1:45759",
+					"172.21.0.1:45759",
+					"172.22.0.1:45759",
+					"172.23.0.1:45759",
+					"172.24.0.1:45759",
+					"172.25.0.1:45759",
+					"172.26.0.1:45759",
+					"172.27.0.1:45759"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:32:35.616160418Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3874427254547311,
+				"StableID":   "n8Rd8ndjFX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bee7fba92b33ef72d90bc38b48c5c500ac2731e2c5f56b5545fa43b059053973",
+				"KeyExpiry":  "2026-11-09T09:32:36Z",
+				"DiscoKey":   "discokey:b2955b623cedbab0242b00574aeb08f48e38df1e99c0128aeb1e85f77794ef6e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:45049",
+					"10.65.0.27:45049",
+					"172.17.0.1:45049",
+					"172.18.0.1:45049",
+					"172.19.0.1:45049",
+					"172.20.0.1:45049",
+					"172.21.0.1:45049",
+					"172.22.0.1:45049",
+					"172.23.0.1:45049",
+					"172.24.0.1:45049",
+					"172.25.0.1:45049",
+					"172.26.0.1:45049",
+					"172.27.0.1:45049"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:32:36.160990465Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7587609051638003,
+				"StableID":   "ncM7MAdSF221CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e2fb44c0f8b5ee8ebebce7b53fe85e66b63fc8bb71e3db350e45e4d9ffdb705a",
+				"KeyExpiry":  "2026-11-09T09:32:36Z",
+				"DiscoKey":   "discokey:3336cb49d6bacf01ef1f81b38ec9d8dbb08b6be1411c2fe4f17f6ed99a4db25c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50296",
+					"10.65.0.27:50296",
+					"172.17.0.1:50296",
+					"172.18.0.1:50296",
+					"172.19.0.1:50296",
+					"172.20.0.1:50296",
+					"172.21.0.1:50296",
+					"172.22.0.1:50296",
+					"172.23.0.1:50296",
+					"172.24.0.1:50296",
+					"172.25.0.1:50296",
+					"172.26.0.1:50296",
+					"172.27.0.1:50296"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:32:36.700599251Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7120072954315803": {
+				"ID":          7120072954315803,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3874427254547311,
+				"StableID":   "n8Rd8ndjFX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bee7fba92b33ef72d90bc38b48c5c500ac2731e2c5f56b5545fa43b059053973",
+				"KeyExpiry":  "2026-11-09T09:32:36Z",
+				"DiscoKey":   "discokey:b2955b623cedbab0242b00574aeb08f48e38df1e99c0128aeb1e85f77794ef6e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:45049",
+					"10.65.0.27:45049",
+					"172.17.0.1:45049",
+					"172.18.0.1:45049",
+					"172.19.0.1:45049",
+					"172.20.0.1:45049",
+					"172.21.0.1:45049",
+					"172.22.0.1:45049",
+					"172.23.0.1:45049",
+					"172.24.0.1:45049",
+					"172.25.0.1:45049",
+					"172.26.0.1:45049",
+					"172.27.0.1:45049"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:32:36.160990465Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:bee7fba92b33ef72d90bc38b48c5c500ac2731e2c5f56b5545fa43b059053973",
+			"MachineKey": "mkey:1674b9a3336b6fa1008291b434e25bd9d8b1065893f80e44df2452d59cdbea52",
+			"Peers": [{
+				"ID":         8148649908875331,
+				"StableID":   "nQ5zhVDYd621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:34ae890a67e5d412c929bce7c14f74e0b14b57f15f5b72c30272ece0ade3f956",
+				"DiscoKey":   "discokey:597ce076bc8e09c80d609d13a71bb2e397108538d803b86f51f6d8f85cc3a14e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46427",
+					"10.65.0.27:46427",
+					"172.17.0.1:46427",
+					"172.18.0.1:46427",
+					"172.19.0.1:46427",
+					"172.20.0.1:46427",
+					"172.21.0.1:46427",
+					"172.22.0.1:46427",
+					"172.23.0.1:46427",
+					"172.24.0.1:46427",
+					"172.25.0.1:46427",
+					"172.26.0.1:46427",
+					"172.27.0.1:46427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:32:29.103855414Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         391639347960856,
+				"StableID":   "nFnF5hhN4411CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6fee700014fceb14b971c5f3fa0b085583de317a60b028590eee406133cd7271",
+				"DiscoKey":   "discokey:7df6539d847203c3b179a5ca7280281d27a8934b308a2a0e7e8233df4fb72e35",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47469",
+					"10.65.0.27:47469",
+					"172.17.0.1:47469",
+					"172.18.0.1:47469",
+					"172.19.0.1:47469",
+					"172.20.0.1:47469",
+					"172.21.0.1:47469",
+					"172.22.0.1:47469",
+					"172.23.0.1:47469",
+					"172.24.0.1:47469",
+					"172.25.0.1:47469",
+					"172.26.0.1:47469",
+					"172.27.0.1:47469"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:32:29.634846588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4028006846160904,
+				"StableID":   "nwWZjkuHTY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c12617359030b76fe8ebe4669b17843b33bb26937d24a5fc038ec4aca1ba9c26",
+				"DiscoKey":   "discokey:5a1070a7160c63c8bb5774f7813c3cc522f54ba17aa835ac9ca522afe275157a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34387",
+					"10.65.0.27:34387",
+					"172.17.0.1:34387",
+					"172.18.0.1:34387",
+					"172.19.0.1:34387",
+					"172.20.0.1:34387",
+					"172.21.0.1:34387",
+					"172.22.0.1:34387",
+					"172.23.0.1:34387",
+					"172.24.0.1:34387",
+					"172.25.0.1:34387",
+					"172.26.0.1:34387",
+					"172.27.0.1:34387"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:32:30.182224358Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5667609051101869,
+				"StableID":   "nrTm2oUsFm11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0466cdf3ee08d9e7a33aa4ff693cdfb2557741196f15ec2466495d03ea90bb24",
+				"DiscoKey":   "discokey:c2e78a42f31849b917095daf147e8ee4bc9aadddb3b9e03f82437a765996b979",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49885",
+					"10.65.0.27:49885",
+					"172.17.0.1:49885",
+					"172.18.0.1:49885",
+					"172.19.0.1:49885",
+					"172.20.0.1:49885",
+					"172.21.0.1:49885",
+					"172.22.0.1:49885",
+					"172.23.0.1:49885",
+					"172.24.0.1:49885",
+					"172.25.0.1:49885",
+					"172.26.0.1:49885",
+					"172.27.0.1:49885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:32:30.726623781Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7941934760275445,
+				"StableID":   "nUxUtDAv1521CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9a9aa185696cd03de991e3c7fbebe238d84949b7c05325f4ed3027b8379013d",
+				"DiscoKey":   "discokey:73f984575d16237be0d09b95e6cc3368d1e92328ad88ceea61bdb9ca7adc1c1b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50093",
+					"10.65.0.27:50093",
+					"172.17.0.1:50093",
+					"172.18.0.1:50093",
+					"172.19.0.1:50093",
+					"172.20.0.1:50093",
+					"172.21.0.1:50093",
+					"172.22.0.1:50093",
+					"172.23.0.1:50093",
+					"172.24.0.1:50093",
+					"172.25.0.1:50093",
+					"172.26.0.1:50093",
+					"172.27.0.1:50093"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:32:31.264509883Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5117522356983846,
+				"StableID":   "nPoAZodjxg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5ba657c0d8cabbbf649e6fbe62f201662e4972bf7a9885cb71c023b05e4ddb3d",
+				"DiscoKey":   "discokey:855ff5cd29f1f4198c46f3cce4b92a8a6282ead0d35e2ce8f39d0aef2d564628",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:36776",
+					"10.65.0.27:36776",
+					"172.17.0.1:36776",
+					"172.18.0.1:36776",
+					"172.19.0.1:36776",
+					"172.20.0.1:36776",
+					"172.21.0.1:36776",
+					"172.22.0.1:36776",
+					"172.23.0.1:36776",
+					"172.24.0.1:36776",
+					"172.25.0.1:36776",
+					"172.26.0.1:36776",
+					"172.27.0.1:36776"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:32:31.826882566Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         287924645502741,
+				"StableID":   "nLxLywHQF311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a41b428cfcb7a3e5f7de22e9076a13cb6ad3a654ecdd5eb892be78710e4b244",
+				"DiscoKey":   "discokey:0e890516ee8be4d0a1ad4de5942b053e72ae5b30fae17762961d9e9e37a95339",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33298",
+					"10.65.0.27:33298",
+					"172.17.0.1:33298",
+					"172.18.0.1:33298",
+					"172.19.0.1:33298",
+					"172.20.0.1:33298",
+					"172.21.0.1:33298",
+					"172.22.0.1:33298",
+					"172.23.0.1:33298",
+					"172.24.0.1:33298",
+					"172.25.0.1:33298",
+					"172.26.0.1:33298",
+					"172.27.0.1:33298"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:32:32.352383431Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2901116932549833,
+				"StableID":   "nkxRvVRveP11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d50d3291ddcc2426ed52cb1ec7eb372d9b96ed42481bfdaa92edf19933b7a832",
+				"DiscoKey":   "discokey:a35aa66bbfc1ed0a7c4389d94f4a312c3e876b851181c7b5223ebadd96c3943f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48578",
+					"10.65.0.27:48578",
+					"172.17.0.1:48578",
+					"172.18.0.1:48578",
+					"172.19.0.1:48578",
+					"172.20.0.1:48578",
+					"172.21.0.1:48578",
+					"172.22.0.1:48578",
+					"172.23.0.1:48578",
+					"172.24.0.1:48578",
+					"172.25.0.1:48578",
+					"172.26.0.1:48578",
+					"172.27.0.1:48578"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:32:32.893684817Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7120072954315803,
+				"StableID":   "nGVrR6Fhbx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2eda08d9b7d67afa59433c3ad43fa88bb3b634cbc4e148bdd696e81f6ec98867",
+				"DiscoKey":   "discokey:501227c04801df77eadb36c9e1afb905ef69d7d4179c21b1813e8c2172a1790d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45566",
+					"10.65.0.27:45566",
+					"172.17.0.1:45566",
+					"172.18.0.1:45566",
+					"172.19.0.1:45566",
+					"172.20.0.1:45566",
+					"172.21.0.1:45566",
+					"172.22.0.1:45566",
+					"172.23.0.1:45566",
+					"172.24.0.1:45566",
+					"172.25.0.1:45566",
+					"172.26.0.1:45566",
+					"172.27.0.1:45566"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:32:33.465196384Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5888021051733811,
+				"StableID":   "n8Z8m4Lhyn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:09e6d8653854ae1da75e3875192abc593a30f26e60260d4aa881cd103262f110",
+				"DiscoKey":   "discokey:bd3186a88a5dd8901e1a823279a4a0a207aa590c88e242677a94fb0a6400977e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58684",
+					"10.65.0.27:58684",
+					"172.17.0.1:58684",
+					"172.18.0.1:58684",
+					"172.19.0.1:58684",
+					"172.20.0.1:58684",
+					"172.21.0.1:58684",
+					"172.22.0.1:58684",
+					"172.23.0.1:58684",
+					"172.24.0.1:58684",
+					"172.25.0.1:58684",
+					"172.26.0.1:58684",
+					"172.27.0.1:58684"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:32:33.993070049Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6150803441526927,
+				"StableID":   "n855hEBi2q11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c09e025ef3afa0b114831bdb3df9a21fd957e66529a02b7abda72c8d12edb557",
+				"DiscoKey":   "discokey:e40d89391874357ced5eaf747aa4111240a92a6253e12572aca7c9a9aa8b1b32",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38819",
+					"10.65.0.27:38819",
+					"172.17.0.1:38819",
+					"172.18.0.1:38819",
+					"172.19.0.1:38819",
+					"172.20.0.1:38819",
+					"172.21.0.1:38819",
+					"172.22.0.1:38819",
+					"172.23.0.1:38819",
+					"172.24.0.1:38819",
+					"172.25.0.1:38819",
+					"172.26.0.1:38819",
+					"172.27.0.1:38819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:32:34.552360717Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5525739855615142,
+				"StableID":   "njow2Lpc9k11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:878d3dc41fc5c018d1286fcfc61475aa0ddaba8dfb08529a3196cdb64768eb4a",
+				"DiscoKey":   "discokey:06b81e82c8ce2d5f3909a5bce2bdee5ed297dd821afe08e38a15f13bd89ea257",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:33872",
+					"10.65.0.27:33872",
+					"172.17.0.1:33872",
+					"172.18.0.1:33872",
+					"172.19.0.1:33872",
+					"172.20.0.1:33872",
+					"172.21.0.1:33872",
+					"172.22.0.1:33872",
+					"172.23.0.1:33872",
+					"172.24.0.1:33872",
+					"172.25.0.1:33872",
+					"172.26.0.1:33872",
+					"172.27.0.1:33872"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:32:35.0718264Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8745332619298087,
+				"StableID":   "nnJoaP4nHB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:807d14fb0b782361ea13d98b82fcfb807a4cdd48f93ea57e1dd76d65498a6b38",
+				"KeyExpiry":  "2026-11-09T09:32:35Z",
+				"DiscoKey":   "discokey:aee8eb99f195b741bf394cd36106086b0ddb07976ca74153927216b327281742",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45759",
+					"10.65.0.27:45759",
+					"172.17.0.1:45759",
+					"172.18.0.1:45759",
+					"172.19.0.1:45759",
+					"172.20.0.1:45759",
+					"172.21.0.1:45759",
+					"172.22.0.1:45759",
+					"172.23.0.1:45759",
+					"172.24.0.1:45759",
+					"172.25.0.1:45759",
+					"172.26.0.1:45759",
+					"172.27.0.1:45759"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:32:35.616160418Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7587609051638003,
+				"StableID":   "ncM7MAdSF221CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e2fb44c0f8b5ee8ebebce7b53fe85e66b63fc8bb71e3db350e45e4d9ffdb705a",
+				"KeyExpiry":  "2026-11-09T09:32:36Z",
+				"DiscoKey":   "discokey:3336cb49d6bacf01ef1f81b38ec9d8dbb08b6be1411c2fe4f17f6ed99a4db25c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50296",
+					"10.65.0.27:50296",
+					"172.17.0.1:50296",
+					"172.18.0.1:50296",
+					"172.19.0.1:50296",
+					"172.20.0.1:50296",
+					"172.21.0.1:50296",
+					"172.22.0.1:50296",
+					"172.23.0.1:50296",
+					"172.24.0.1:50296",
+					"172.25.0.1:50296",
+					"172.26.0.1:50296",
+					"172.27.0.1:50296"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:32:36.700599251Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5888021051733811,
+				"StableID":   "n8Z8m4Lhyn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       5888021051733811,
+				"Key":        "nodekey:09e6d8653854ae1da75e3875192abc593a30f26e60260d4aa881cd103262f110",
+				"DiscoKey":   "discokey:bd3186a88a5dd8901e1a823279a4a0a207aa590c88e242677a94fb0a6400977e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58684",
+					"10.65.0.27:58684",
+					"172.17.0.1:58684",
+					"172.18.0.1:58684",
+					"172.19.0.1:58684",
+					"172.20.0.1:58684",
+					"172.21.0.1:58684",
+					"172.22.0.1:58684",
+					"172.23.0.1:58684",
+					"172.24.0.1:58684",
+					"172.25.0.1:58684",
+					"172.26.0.1:58684",
+					"172.27.0.1:58684"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:32:33.993070049Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:09e6d8653854ae1da75e3875192abc593a30f26e60260d4aa881cd103262f110",
+			"MachineKey": "mkey:93233a92342deaea8cc13673d6f9d963bcc81f247923eb83cb0b26c504869133",
+			"Peers": [{
+				"ID":         8148649908875331,
+				"StableID":   "nQ5zhVDYd621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:34ae890a67e5d412c929bce7c14f74e0b14b57f15f5b72c30272ece0ade3f956",
+				"DiscoKey":   "discokey:597ce076bc8e09c80d609d13a71bb2e397108538d803b86f51f6d8f85cc3a14e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46427",
+					"10.65.0.27:46427",
+					"172.17.0.1:46427",
+					"172.18.0.1:46427",
+					"172.19.0.1:46427",
+					"172.20.0.1:46427",
+					"172.21.0.1:46427",
+					"172.22.0.1:46427",
+					"172.23.0.1:46427",
+					"172.24.0.1:46427",
+					"172.25.0.1:46427",
+					"172.26.0.1:46427",
+					"172.27.0.1:46427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:32:29.103855414Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         391639347960856,
+				"StableID":   "nFnF5hhN4411CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6fee700014fceb14b971c5f3fa0b085583de317a60b028590eee406133cd7271",
+				"DiscoKey":   "discokey:7df6539d847203c3b179a5ca7280281d27a8934b308a2a0e7e8233df4fb72e35",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:47469",
+					"10.65.0.27:47469",
+					"172.17.0.1:47469",
+					"172.18.0.1:47469",
+					"172.19.0.1:47469",
+					"172.20.0.1:47469",
+					"172.21.0.1:47469",
+					"172.22.0.1:47469",
+					"172.23.0.1:47469",
+					"172.24.0.1:47469",
+					"172.25.0.1:47469",
+					"172.26.0.1:47469",
+					"172.27.0.1:47469"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:32:29.634846588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4028006846160904,
+				"StableID":   "nwWZjkuHTY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c12617359030b76fe8ebe4669b17843b33bb26937d24a5fc038ec4aca1ba9c26",
+				"DiscoKey":   "discokey:5a1070a7160c63c8bb5774f7813c3cc522f54ba17aa835ac9ca522afe275157a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34387",
+					"10.65.0.27:34387",
+					"172.17.0.1:34387",
+					"172.18.0.1:34387",
+					"172.19.0.1:34387",
+					"172.20.0.1:34387",
+					"172.21.0.1:34387",
+					"172.22.0.1:34387",
+					"172.23.0.1:34387",
+					"172.24.0.1:34387",
+					"172.25.0.1:34387",
+					"172.26.0.1:34387",
+					"172.27.0.1:34387"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:32:30.182224358Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5667609051101869,
+				"StableID":   "nrTm2oUsFm11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0466cdf3ee08d9e7a33aa4ff693cdfb2557741196f15ec2466495d03ea90bb24",
+				"DiscoKey":   "discokey:c2e78a42f31849b917095daf147e8ee4bc9aadddb3b9e03f82437a765996b979",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:49885",
+					"10.65.0.27:49885",
+					"172.17.0.1:49885",
+					"172.18.0.1:49885",
+					"172.19.0.1:49885",
+					"172.20.0.1:49885",
+					"172.21.0.1:49885",
+					"172.22.0.1:49885",
+					"172.23.0.1:49885",
+					"172.24.0.1:49885",
+					"172.25.0.1:49885",
+					"172.26.0.1:49885",
+					"172.27.0.1:49885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:32:30.726623781Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7941934760275445,
+				"StableID":   "nUxUtDAv1521CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b9a9aa185696cd03de991e3c7fbebe238d84949b7c05325f4ed3027b8379013d",
+				"DiscoKey":   "discokey:73f984575d16237be0d09b95e6cc3368d1e92328ad88ceea61bdb9ca7adc1c1b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50093",
+					"10.65.0.27:50093",
+					"172.17.0.1:50093",
+					"172.18.0.1:50093",
+					"172.19.0.1:50093",
+					"172.20.0.1:50093",
+					"172.21.0.1:50093",
+					"172.22.0.1:50093",
+					"172.23.0.1:50093",
+					"172.24.0.1:50093",
+					"172.25.0.1:50093",
+					"172.26.0.1:50093",
+					"172.27.0.1:50093"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:32:31.264509883Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5117522356983846,
+				"StableID":   "nPoAZodjxg11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5ba657c0d8cabbbf649e6fbe62f201662e4972bf7a9885cb71c023b05e4ddb3d",
+				"DiscoKey":   "discokey:855ff5cd29f1f4198c46f3cce4b92a8a6282ead0d35e2ce8f39d0aef2d564628",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:36776",
+					"10.65.0.27:36776",
+					"172.17.0.1:36776",
+					"172.18.0.1:36776",
+					"172.19.0.1:36776",
+					"172.20.0.1:36776",
+					"172.21.0.1:36776",
+					"172.22.0.1:36776",
+					"172.23.0.1:36776",
+					"172.24.0.1:36776",
+					"172.25.0.1:36776",
+					"172.26.0.1:36776",
+					"172.27.0.1:36776"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:32:31.826882566Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         287924645502741,
+				"StableID":   "nLxLywHQF311CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a41b428cfcb7a3e5f7de22e9076a13cb6ad3a654ecdd5eb892be78710e4b244",
+				"DiscoKey":   "discokey:0e890516ee8be4d0a1ad4de5942b053e72ae5b30fae17762961d9e9e37a95339",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33298",
+					"10.65.0.27:33298",
+					"172.17.0.1:33298",
+					"172.18.0.1:33298",
+					"172.19.0.1:33298",
+					"172.20.0.1:33298",
+					"172.21.0.1:33298",
+					"172.22.0.1:33298",
+					"172.23.0.1:33298",
+					"172.24.0.1:33298",
+					"172.25.0.1:33298",
+					"172.26.0.1:33298",
+					"172.27.0.1:33298"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:32:32.352383431Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2901116932549833,
+				"StableID":   "nkxRvVRveP11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d50d3291ddcc2426ed52cb1ec7eb372d9b96ed42481bfdaa92edf19933b7a832",
+				"DiscoKey":   "discokey:a35aa66bbfc1ed0a7c4389d94f4a312c3e876b851181c7b5223ebadd96c3943f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48578",
+					"10.65.0.27:48578",
+					"172.17.0.1:48578",
+					"172.18.0.1:48578",
+					"172.19.0.1:48578",
+					"172.20.0.1:48578",
+					"172.21.0.1:48578",
+					"172.22.0.1:48578",
+					"172.23.0.1:48578",
+					"172.24.0.1:48578",
+					"172.25.0.1:48578",
+					"172.26.0.1:48578",
+					"172.27.0.1:48578"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:32:32.893684817Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7120072954315803,
+				"StableID":   "nGVrR6Fhbx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2eda08d9b7d67afa59433c3ad43fa88bb3b634cbc4e148bdd696e81f6ec98867",
+				"DiscoKey":   "discokey:501227c04801df77eadb36c9e1afb905ef69d7d4179c21b1813e8c2172a1790d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45566",
+					"10.65.0.27:45566",
+					"172.17.0.1:45566",
+					"172.18.0.1:45566",
+					"172.19.0.1:45566",
+					"172.20.0.1:45566",
+					"172.21.0.1:45566",
+					"172.22.0.1:45566",
+					"172.23.0.1:45566",
+					"172.24.0.1:45566",
+					"172.25.0.1:45566",
+					"172.26.0.1:45566",
+					"172.27.0.1:45566"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:32:33.465196384Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6150803441526927,
+				"StableID":   "n855hEBi2q11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c09e025ef3afa0b114831bdb3df9a21fd957e66529a02b7abda72c8d12edb557",
+				"DiscoKey":   "discokey:e40d89391874357ced5eaf747aa4111240a92a6253e12572aca7c9a9aa8b1b32",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38819",
+					"10.65.0.27:38819",
+					"172.17.0.1:38819",
+					"172.18.0.1:38819",
+					"172.19.0.1:38819",
+					"172.20.0.1:38819",
+					"172.21.0.1:38819",
+					"172.22.0.1:38819",
+					"172.23.0.1:38819",
+					"172.24.0.1:38819",
+					"172.25.0.1:38819",
+					"172.26.0.1:38819",
+					"172.27.0.1:38819"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:32:34.552360717Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5525739855615142,
+				"StableID":   "njow2Lpc9k11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:878d3dc41fc5c018d1286fcfc61475aa0ddaba8dfb08529a3196cdb64768eb4a",
+				"DiscoKey":   "discokey:06b81e82c8ce2d5f3909a5bce2bdee5ed297dd821afe08e38a15f13bd89ea257",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:33872",
+					"10.65.0.27:33872",
+					"172.17.0.1:33872",
+					"172.18.0.1:33872",
+					"172.19.0.1:33872",
+					"172.20.0.1:33872",
+					"172.21.0.1:33872",
+					"172.22.0.1:33872",
+					"172.23.0.1:33872",
+					"172.24.0.1:33872",
+					"172.25.0.1:33872",
+					"172.26.0.1:33872",
+					"172.27.0.1:33872"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:32:35.0718264Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8745332619298087,
+				"StableID":   "nnJoaP4nHB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:807d14fb0b782361ea13d98b82fcfb807a4cdd48f93ea57e1dd76d65498a6b38",
+				"KeyExpiry":  "2026-11-09T09:32:35Z",
+				"DiscoKey":   "discokey:aee8eb99f195b741bf394cd36106086b0ddb07976ca74153927216b327281742",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45759",
+					"10.65.0.27:45759",
+					"172.17.0.1:45759",
+					"172.18.0.1:45759",
+					"172.19.0.1:45759",
+					"172.20.0.1:45759",
+					"172.21.0.1:45759",
+					"172.22.0.1:45759",
+					"172.23.0.1:45759",
+					"172.24.0.1:45759",
+					"172.25.0.1:45759",
+					"172.26.0.1:45759",
+					"172.27.0.1:45759"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:32:35.616160418Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3874427254547311,
+				"StableID":   "n8Rd8ndjFX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bee7fba92b33ef72d90bc38b48c5c500ac2731e2c5f56b5545fa43b059053973",
+				"KeyExpiry":  "2026-11-09T09:32:36Z",
+				"DiscoKey":   "discokey:b2955b623cedbab0242b00574aeb08f48e38df1e99c0128aeb1e85f77794ef6e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:45049",
+					"10.65.0.27:45049",
+					"172.17.0.1:45049",
+					"172.18.0.1:45049",
+					"172.19.0.1:45049",
+					"172.20.0.1:45049",
+					"172.21.0.1:45049",
+					"172.22.0.1:45049",
+					"172.23.0.1:45049",
+					"172.24.0.1:45049",
+					"172.25.0.1:45049",
+					"172.26.0.1:45049",
+					"172.27.0.1:45049"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:32:36.160990465Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7587609051638003,
+				"StableID":   "ncM7MAdSF221CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e2fb44c0f8b5ee8ebebce7b53fe85e66b63fc8bb71e3db350e45e4d9ffdb705a",
+				"KeyExpiry":  "2026-11-09T09:32:36Z",
+				"DiscoKey":   "discokey:3336cb49d6bacf01ef1f81b38ec9d8dbb08b6be1411c2fe4f17f6ed99a4db25c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50296",
+					"10.65.0.27:50296",
+					"172.17.0.1:50296",
+					"172.18.0.1:50296",
+					"172.19.0.1:50296",
+					"172.20.0.1:50296",
+					"172.21.0.1:50296",
+					"172.22.0.1:50296",
+					"172.23.0.1:50296",
+					"172.24.0.1:50296",
+					"172.25.0.1:50296",
+					"172.26.0.1:50296",
+					"172.27.0.1:50296"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:32:36.700599251Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5888021051733811": {
+				"ID":          5888021051733811,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-multi-rule-disjoint-srcs.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-multi-rule-disjoint-srcs.hujson
@@ -1,0 +1,22146 @@
+// ssh-multi-rule-disjoint-srcs
+//
+// ssh two rules with disjoint srcs, same dst/users
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-13T09:16:28Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-multi-rule-disjoint-srcs",
+	"description":    "ssh two rules with disjoint srcs, same dst/users",
+	"category":       "ssh",
+	"captured_at":    "2026-05-13T09:16:28.738604222Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                               \n  \n                                                                       \n                                                             \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh two rules with disjoint srcs, same dst/users\",\n\t\"id\":          \"ssh-multi-rule-disjoint-srcs\",\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"thor@example.org\"],\n\t\t\"users\":  [\"root\"]\n\t}, {\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"freya@example.com\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-edges/ssh-multi-rule-disjoint-srcs.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["thor@example.org"],
+				"users":  ["root"]
+			}, {
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["freya@example.com"],
+				"users":  ["root"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8655535422778369,
+				"StableID":   "nkLhppE7bA21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       8655535422778369,
+				"Key":        "nodekey:51ea7fe1af6a214a081f391094984c7ffc0ada6e7b0f955269cf478437343d37",
+				"DiscoKey":   "discokey:c613e971fe0d620109ca52c5e53ae02ef23e0da58e5e3fcd53e2225c6c361f49",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:57088",
+					"10.65.0.27:57088",
+					"172.17.0.1:57088",
+					"172.18.0.1:57088",
+					"172.19.0.1:57088",
+					"172.20.0.1:57088",
+					"172.21.0.1:57088",
+					"172.22.0.1:57088",
+					"172.23.0.1:57088",
+					"172.24.0.1:57088",
+					"172.25.0.1:57088",
+					"172.26.0.1:57088",
+					"172.27.0.1:57088",
+					"172.28.0.1:57088"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:16:37.584099691Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:51ea7fe1af6a214a081f391094984c7ffc0ada6e7b0f955269cf478437343d37",
+			"MachineKey": "mkey:c6a0e52e481ac2126d8de7fd7f790b0cc553d410f0499745048ecf8f6b313a40",
+			"Peers": [{
+				"ID":         4544457554236945,
+				"StableID":   "n84eJFCCVc11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb69a9a3fd98283abb5b824a0e46b6d27ce37cc55932b72bf440c437db22d237",
+				"DiscoKey":   "discokey:a578f456e0138f1dc305b742ef3a500571ec5fd487a809b1117a6c8c9b000249",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36024",
+					"10.65.0.27:36024",
+					"172.17.0.1:36024",
+					"172.18.0.1:36024",
+					"172.19.0.1:36024",
+					"172.20.0.1:36024",
+					"172.21.0.1:36024",
+					"172.22.0.1:36024",
+					"172.23.0.1:36024",
+					"172.24.0.1:36024",
+					"172.25.0.1:36024",
+					"172.26.0.1:36024",
+					"172.27.0.1:36024",
+					"172.28.0.1:36024"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:16:31.110445532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2009417783924731,
+				"StableID":   "npXydsz4hG11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:753aa05e1103d96f6c54ad81c74c07654ed38a7353ab11489bb6a33dd824ed2d",
+				"DiscoKey":   "discokey:418bd024545893836054b8e180770ce90aea857fb8398f41a30ba280ca2c6901",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:56408",
+					"10.65.0.27:56408",
+					"172.17.0.1:56408",
+					"172.18.0.1:56408",
+					"172.19.0.1:56408",
+					"172.20.0.1:56408",
+					"172.21.0.1:56408",
+					"172.22.0.1:56408",
+					"172.23.0.1:56408",
+					"172.24.0.1:56408",
+					"172.25.0.1:56408",
+					"172.26.0.1:56408",
+					"172.27.0.1:56408",
+					"172.28.0.1:56408"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:16:31.735738377Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4637492199793181,
+				"StableID":   "ngYHMG4LDd11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:49c1763a9be9eb89c359f01714a9d818ad37ae4baa05b6f8eea689a62711b971",
+				"DiscoKey":   "discokey:9d3c95541d5aad0f118e534d243d71ea498d2660bb3554b8b3cc1ee21751c76e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36617",
+					"10.65.0.27:36617",
+					"172.17.0.1:36617",
+					"172.18.0.1:36617",
+					"172.19.0.1:36617",
+					"172.20.0.1:36617",
+					"172.21.0.1:36617",
+					"172.22.0.1:36617",
+					"172.23.0.1:36617",
+					"172.24.0.1:36617",
+					"172.25.0.1:36617",
+					"172.26.0.1:36617",
+					"172.27.0.1:36617",
+					"172.28.0.1:36617"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:16:32.261223987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4527847942638130,
+				"StableID":   "nTudoUtfMc11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:893b1cf6338cd631a24f7a3f0b8d1cfec096306fd567160a19137374b8cdb158",
+				"DiscoKey":   "discokey:df102ddc65336ee2f5ead02501b0db365aa9c7e90d446f0e4d98f3c223543b6e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59980",
+					"10.65.0.27:59980",
+					"172.17.0.1:59980",
+					"172.18.0.1:59980",
+					"172.19.0.1:59980",
+					"172.20.0.1:59980",
+					"172.21.0.1:59980",
+					"172.22.0.1:59980",
+					"172.23.0.1:59980",
+					"172.24.0.1:59980",
+					"172.25.0.1:59980",
+					"172.26.0.1:59980",
+					"172.27.0.1:59980",
+					"172.28.0.1:59980"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:16:33.317360859Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3801184942400324,
+				"StableID":   "nFxBpbgZgW11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:44da45e66d237c8652357ce0f54e681b03f91770691f28f892bfdc6578829b7f",
+				"DiscoKey":   "discokey:0a2146d82fda5c146aabe7ee1b17633e2d84035a208c13978301b706fe33cc1b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41449",
+					"10.65.0.27:41449",
+					"172.17.0.1:41449",
+					"172.18.0.1:41449",
+					"172.19.0.1:41449",
+					"172.20.0.1:41449",
+					"172.21.0.1:41449",
+					"172.22.0.1:41449",
+					"172.23.0.1:41449",
+					"172.24.0.1:41449",
+					"172.25.0.1:41449",
+					"172.26.0.1:41449",
+					"172.27.0.1:41449",
+					"172.28.0.1:41449"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:16:33.846892606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2884204743856928,
+				"StableID":   "nFNjijAGXP11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2288cbc791982d1febb37aa4632bca2afa58382205fa1debb16cb33c5097810f",
+				"DiscoKey":   "discokey:86ee1b0358dbe766533ecd96fb31297444a367bce9a7f65d63f1c21f6d189140",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50881",
+					"10.65.0.27:50881",
+					"172.17.0.1:50881",
+					"172.18.0.1:50881",
+					"172.19.0.1:50881",
+					"172.20.0.1:50881",
+					"172.21.0.1:50881",
+					"172.22.0.1:50881",
+					"172.23.0.1:50881",
+					"172.24.0.1:50881",
+					"172.25.0.1:50881",
+					"172.26.0.1:50881",
+					"172.27.0.1:50881",
+					"172.28.0.1:50881"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:16:34.38370158Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8068649566328922,
+				"StableID":   "nF7HP3kJ1621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dab39f217dc07a9a7265f9276d64ea1f59d461acb0ec058bd6e6cca4def2bb64",
+				"DiscoKey":   "discokey:63b9dca87a0d91279a35610d3029c6e7ce8bd5f800b5b9ac30f4386c49691c49",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44693",
+					"10.65.0.27:44693",
+					"172.17.0.1:44693",
+					"172.18.0.1:44693",
+					"172.19.0.1:44693",
+					"172.20.0.1:44693",
+					"172.21.0.1:44693",
+					"172.22.0.1:44693",
+					"172.23.0.1:44693",
+					"172.24.0.1:44693",
+					"172.25.0.1:44693",
+					"172.26.0.1:44693",
+					"172.27.0.1:44693",
+					"172.28.0.1:44693"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:16:34.900934564Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4294990921984530,
+				"StableID":   "nwMgGT8DYa11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:abbf2a0b102da082048e4a7e17a105a4731374fbd704134435b087699cb8607e",
+				"DiscoKey":   "discokey:b23fd71a513c8f30044586a0f38c845ae12cd58bbd3bb8a99ec9ddefa0b39e63",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50929",
+					"10.65.0.27:50929",
+					"172.17.0.1:50929",
+					"172.18.0.1:50929",
+					"172.19.0.1:50929",
+					"172.20.0.1:50929",
+					"172.21.0.1:50929",
+					"172.22.0.1:50929",
+					"172.23.0.1:50929",
+					"172.24.0.1:50929",
+					"172.25.0.1:50929",
+					"172.26.0.1:50929",
+					"172.27.0.1:50929",
+					"172.28.0.1:50929"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:16:35.432173376Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6683286104949244,
+				"StableID":   "ny7sFQbsBu11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4bb754b07a5725035b3bd889a8892ceaca64bdae3e2ad880ef302c3028b95e0d",
+				"DiscoKey":   "discokey:dd7a82d53b4b91c6f52539b4232687a61b1916e0c668b5007b4174fdee16137e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39866",
+					"10.65.0.27:39866",
+					"172.17.0.1:39866",
+					"172.18.0.1:39866",
+					"172.19.0.1:39866",
+					"172.20.0.1:39866",
+					"172.21.0.1:39866",
+					"172.22.0.1:39866",
+					"172.23.0.1:39866",
+					"172.24.0.1:39866",
+					"172.25.0.1:39866",
+					"172.26.0.1:39866",
+					"172.27.0.1:39866",
+					"172.28.0.1:39866"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:16:35.972074185Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2789200956428515,
+				"StableID":   "nc9HMcaEnN11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1d10f62d48a41ae8f2ff37f709fc71c9771d3ecae79f5888dbf5e9178e8fd43b",
+				"DiscoKey":   "discokey:4b0eeb701ea2de2e741363d16e822b997ceae786c7154214b8491f24e09e4d56",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49056",
+					"10.65.0.27:49056",
+					"172.17.0.1:49056",
+					"172.18.0.1:49056",
+					"172.19.0.1:49056",
+					"172.20.0.1:49056",
+					"172.21.0.1:49056",
+					"172.22.0.1:49056",
+					"172.23.0.1:49056",
+					"172.24.0.1:49056",
+					"172.25.0.1:49056",
+					"172.26.0.1:49056",
+					"172.27.0.1:49056",
+					"172.28.0.1:49056"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:16:36.504343844Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3136722346387547,
+				"StableID":   "nYZrYsNdVR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1c5c6665c13e9cffa7c924b2434ac58dd7c98cae7b7d0c82ae75f674d2c5064",
+				"DiscoKey":   "discokey:17e5772ce8a8e2c92ecda771799f562d4676d35fdc8174abb7aa966e89752703",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:59410",
+					"10.65.0.27:59410",
+					"172.17.0.1:59410",
+					"172.18.0.1:59410",
+					"172.19.0.1:59410",
+					"172.20.0.1:59410",
+					"172.21.0.1:59410",
+					"172.22.0.1:59410",
+					"172.23.0.1:59410",
+					"172.24.0.1:59410",
+					"172.25.0.1:59410",
+					"172.26.0.1:59410",
+					"172.27.0.1:59410",
+					"172.28.0.1:59410"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:16:37.031283368Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8817121571615835,
+				"StableID":   "nLqDUHqHrB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ff438b3d370ac7e8535275f6c9dd632885819ef9174502cd4f75a68367484022",
+				"KeyExpiry":  "2026-11-09T09:16:38Z",
+				"DiscoKey":   "discokey:ba73117d5dc25aa3894fcf29c41b93d5c3fe1a75ae7fe523a4e3e19f970ed538",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45196",
+					"10.65.0.27:45196",
+					"172.17.0.1:45196",
+					"172.18.0.1:45196",
+					"172.19.0.1:45196",
+					"172.20.0.1:45196",
+					"172.21.0.1:45196",
+					"172.22.0.1:45196",
+					"172.23.0.1:45196",
+					"172.24.0.1:45196",
+					"172.25.0.1:45196",
+					"172.26.0.1:45196",
+					"172.27.0.1:45196",
+					"172.28.0.1:45196"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:16:38.177732012Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3438518289772750,
+				"StableID":   "nBDecb3KrT11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5a701bba6af81b1d3119253be60d716401f2d9a50fd5dc50536113b0a9f08660",
+				"KeyExpiry":  "2026-11-09T09:16:38Z",
+				"DiscoKey":   "discokey:1927d7fbdb293edda5e8619c4dca14d6e7d7e05c5ede001b380a2f08c4989172",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55365",
+					"10.65.0.27:55365",
+					"172.17.0.1:55365",
+					"172.18.0.1:55365",
+					"172.19.0.1:55365",
+					"172.20.0.1:55365",
+					"172.21.0.1:55365",
+					"172.22.0.1:55365",
+					"172.23.0.1:55365",
+					"172.24.0.1:55365",
+					"172.25.0.1:55365",
+					"172.26.0.1:55365",
+					"172.27.0.1:55365",
+					"172.28.0.1:55365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:16:38.715741477Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4232648330810505,
+				"StableID":   "npaHyfVy3a11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7b5184612ccbb8983f218368c8035d305c0fa4a6092021190b0a05b953b10425",
+				"KeyExpiry":  "2026-11-09T09:16:39Z",
+				"DiscoKey":   "discokey:5208598b8cac01e196a19a8d49f96773a9835d24c68bd69598a5937f23c63e4a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56825",
+					"10.65.0.27:56825",
+					"172.17.0.1:56825",
+					"172.18.0.1:56825",
+					"172.19.0.1:56825",
+					"172.20.0.1:56825",
+					"172.21.0.1:56825",
+					"172.22.0.1:56825",
+					"172.23.0.1:56825",
+					"172.24.0.1:56825",
+					"172.25.0.1:56825",
+					"172.26.0.1:56825",
+					"172.27.0.1:56825",
+					"172.28.0.1:56825"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:16:39.250040788Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{
+				"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+				"sshUsers":   {"root": "root"},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				}
+			}, {
+				"principals": [{"nodeIP": "100.64.0.18"}, {"nodeIP": "fd7a:115c:a1e0::12"}],
+				"sshUsers":   {"root": "root"},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				}
+			}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8655535422778369": {
+				"ID":          8655535422778369,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		},
+		"ssh_rules": [{
+			"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+			"sshUsers":   {"root": "root"},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}
+		}, {
+			"principals": [{"nodeIP": "100.64.0.18"}, {"nodeIP": "fd7a:115c:a1e0::12"}],
+			"sshUsers":   {"root": "root"},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}
+		}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2884204743856928,
+				"StableID":   "nFNjijAGXP11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       2884204743856928,
+				"Key":        "nodekey:2288cbc791982d1febb37aa4632bca2afa58382205fa1debb16cb33c5097810f",
+				"DiscoKey":   "discokey:86ee1b0358dbe766533ecd96fb31297444a367bce9a7f65d63f1c21f6d189140",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50881",
+					"10.65.0.27:50881",
+					"172.17.0.1:50881",
+					"172.18.0.1:50881",
+					"172.19.0.1:50881",
+					"172.20.0.1:50881",
+					"172.21.0.1:50881",
+					"172.22.0.1:50881",
+					"172.23.0.1:50881",
+					"172.24.0.1:50881",
+					"172.25.0.1:50881",
+					"172.26.0.1:50881",
+					"172.27.0.1:50881",
+					"172.28.0.1:50881"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:16:34.38370158Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2288cbc791982d1febb37aa4632bca2afa58382205fa1debb16cb33c5097810f",
+			"MachineKey": "mkey:65ee6aa74cc44618a13d6f8aea5d6030b2d7be0670f9485477a1c170b70fc17b",
+			"Peers": [{
+				"ID":         4544457554236945,
+				"StableID":   "n84eJFCCVc11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb69a9a3fd98283abb5b824a0e46b6d27ce37cc55932b72bf440c437db22d237",
+				"DiscoKey":   "discokey:a578f456e0138f1dc305b742ef3a500571ec5fd487a809b1117a6c8c9b000249",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36024",
+					"10.65.0.27:36024",
+					"172.17.0.1:36024",
+					"172.18.0.1:36024",
+					"172.19.0.1:36024",
+					"172.20.0.1:36024",
+					"172.21.0.1:36024",
+					"172.22.0.1:36024",
+					"172.23.0.1:36024",
+					"172.24.0.1:36024",
+					"172.25.0.1:36024",
+					"172.26.0.1:36024",
+					"172.27.0.1:36024",
+					"172.28.0.1:36024"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:16:31.110445532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2009417783924731,
+				"StableID":   "npXydsz4hG11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:753aa05e1103d96f6c54ad81c74c07654ed38a7353ab11489bb6a33dd824ed2d",
+				"DiscoKey":   "discokey:418bd024545893836054b8e180770ce90aea857fb8398f41a30ba280ca2c6901",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:56408",
+					"10.65.0.27:56408",
+					"172.17.0.1:56408",
+					"172.18.0.1:56408",
+					"172.19.0.1:56408",
+					"172.20.0.1:56408",
+					"172.21.0.1:56408",
+					"172.22.0.1:56408",
+					"172.23.0.1:56408",
+					"172.24.0.1:56408",
+					"172.25.0.1:56408",
+					"172.26.0.1:56408",
+					"172.27.0.1:56408",
+					"172.28.0.1:56408"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:16:31.735738377Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4637492199793181,
+				"StableID":   "ngYHMG4LDd11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:49c1763a9be9eb89c359f01714a9d818ad37ae4baa05b6f8eea689a62711b971",
+				"DiscoKey":   "discokey:9d3c95541d5aad0f118e534d243d71ea498d2660bb3554b8b3cc1ee21751c76e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36617",
+					"10.65.0.27:36617",
+					"172.17.0.1:36617",
+					"172.18.0.1:36617",
+					"172.19.0.1:36617",
+					"172.20.0.1:36617",
+					"172.21.0.1:36617",
+					"172.22.0.1:36617",
+					"172.23.0.1:36617",
+					"172.24.0.1:36617",
+					"172.25.0.1:36617",
+					"172.26.0.1:36617",
+					"172.27.0.1:36617",
+					"172.28.0.1:36617"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:16:32.261223987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4527847942638130,
+				"StableID":   "nTudoUtfMc11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:893b1cf6338cd631a24f7a3f0b8d1cfec096306fd567160a19137374b8cdb158",
+				"DiscoKey":   "discokey:df102ddc65336ee2f5ead02501b0db365aa9c7e90d446f0e4d98f3c223543b6e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59980",
+					"10.65.0.27:59980",
+					"172.17.0.1:59980",
+					"172.18.0.1:59980",
+					"172.19.0.1:59980",
+					"172.20.0.1:59980",
+					"172.21.0.1:59980",
+					"172.22.0.1:59980",
+					"172.23.0.1:59980",
+					"172.24.0.1:59980",
+					"172.25.0.1:59980",
+					"172.26.0.1:59980",
+					"172.27.0.1:59980",
+					"172.28.0.1:59980"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:16:33.317360859Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3801184942400324,
+				"StableID":   "nFxBpbgZgW11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:44da45e66d237c8652357ce0f54e681b03f91770691f28f892bfdc6578829b7f",
+				"DiscoKey":   "discokey:0a2146d82fda5c146aabe7ee1b17633e2d84035a208c13978301b706fe33cc1b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41449",
+					"10.65.0.27:41449",
+					"172.17.0.1:41449",
+					"172.18.0.1:41449",
+					"172.19.0.1:41449",
+					"172.20.0.1:41449",
+					"172.21.0.1:41449",
+					"172.22.0.1:41449",
+					"172.23.0.1:41449",
+					"172.24.0.1:41449",
+					"172.25.0.1:41449",
+					"172.26.0.1:41449",
+					"172.27.0.1:41449",
+					"172.28.0.1:41449"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:16:33.846892606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8068649566328922,
+				"StableID":   "nF7HP3kJ1621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dab39f217dc07a9a7265f9276d64ea1f59d461acb0ec058bd6e6cca4def2bb64",
+				"DiscoKey":   "discokey:63b9dca87a0d91279a35610d3029c6e7ce8bd5f800b5b9ac30f4386c49691c49",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44693",
+					"10.65.0.27:44693",
+					"172.17.0.1:44693",
+					"172.18.0.1:44693",
+					"172.19.0.1:44693",
+					"172.20.0.1:44693",
+					"172.21.0.1:44693",
+					"172.22.0.1:44693",
+					"172.23.0.1:44693",
+					"172.24.0.1:44693",
+					"172.25.0.1:44693",
+					"172.26.0.1:44693",
+					"172.27.0.1:44693",
+					"172.28.0.1:44693"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:16:34.900934564Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4294990921984530,
+				"StableID":   "nwMgGT8DYa11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:abbf2a0b102da082048e4a7e17a105a4731374fbd704134435b087699cb8607e",
+				"DiscoKey":   "discokey:b23fd71a513c8f30044586a0f38c845ae12cd58bbd3bb8a99ec9ddefa0b39e63",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50929",
+					"10.65.0.27:50929",
+					"172.17.0.1:50929",
+					"172.18.0.1:50929",
+					"172.19.0.1:50929",
+					"172.20.0.1:50929",
+					"172.21.0.1:50929",
+					"172.22.0.1:50929",
+					"172.23.0.1:50929",
+					"172.24.0.1:50929",
+					"172.25.0.1:50929",
+					"172.26.0.1:50929",
+					"172.27.0.1:50929",
+					"172.28.0.1:50929"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:16:35.432173376Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6683286104949244,
+				"StableID":   "ny7sFQbsBu11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4bb754b07a5725035b3bd889a8892ceaca64bdae3e2ad880ef302c3028b95e0d",
+				"DiscoKey":   "discokey:dd7a82d53b4b91c6f52539b4232687a61b1916e0c668b5007b4174fdee16137e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39866",
+					"10.65.0.27:39866",
+					"172.17.0.1:39866",
+					"172.18.0.1:39866",
+					"172.19.0.1:39866",
+					"172.20.0.1:39866",
+					"172.21.0.1:39866",
+					"172.22.0.1:39866",
+					"172.23.0.1:39866",
+					"172.24.0.1:39866",
+					"172.25.0.1:39866",
+					"172.26.0.1:39866",
+					"172.27.0.1:39866",
+					"172.28.0.1:39866"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:16:35.972074185Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2789200956428515,
+				"StableID":   "nc9HMcaEnN11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1d10f62d48a41ae8f2ff37f709fc71c9771d3ecae79f5888dbf5e9178e8fd43b",
+				"DiscoKey":   "discokey:4b0eeb701ea2de2e741363d16e822b997ceae786c7154214b8491f24e09e4d56",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49056",
+					"10.65.0.27:49056",
+					"172.17.0.1:49056",
+					"172.18.0.1:49056",
+					"172.19.0.1:49056",
+					"172.20.0.1:49056",
+					"172.21.0.1:49056",
+					"172.22.0.1:49056",
+					"172.23.0.1:49056",
+					"172.24.0.1:49056",
+					"172.25.0.1:49056",
+					"172.26.0.1:49056",
+					"172.27.0.1:49056",
+					"172.28.0.1:49056"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:16:36.504343844Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3136722346387547,
+				"StableID":   "nYZrYsNdVR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1c5c6665c13e9cffa7c924b2434ac58dd7c98cae7b7d0c82ae75f674d2c5064",
+				"DiscoKey":   "discokey:17e5772ce8a8e2c92ecda771799f562d4676d35fdc8174abb7aa966e89752703",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:59410",
+					"10.65.0.27:59410",
+					"172.17.0.1:59410",
+					"172.18.0.1:59410",
+					"172.19.0.1:59410",
+					"172.20.0.1:59410",
+					"172.21.0.1:59410",
+					"172.22.0.1:59410",
+					"172.23.0.1:59410",
+					"172.24.0.1:59410",
+					"172.25.0.1:59410",
+					"172.26.0.1:59410",
+					"172.27.0.1:59410",
+					"172.28.0.1:59410"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:16:37.031283368Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8655535422778369,
+				"StableID":   "nkLhppE7bA21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51ea7fe1af6a214a081f391094984c7ffc0ada6e7b0f955269cf478437343d37",
+				"DiscoKey":   "discokey:c613e971fe0d620109ca52c5e53ae02ef23e0da58e5e3fcd53e2225c6c361f49",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:57088",
+					"10.65.0.27:57088",
+					"172.17.0.1:57088",
+					"172.18.0.1:57088",
+					"172.19.0.1:57088",
+					"172.20.0.1:57088",
+					"172.21.0.1:57088",
+					"172.22.0.1:57088",
+					"172.23.0.1:57088",
+					"172.24.0.1:57088",
+					"172.25.0.1:57088",
+					"172.26.0.1:57088",
+					"172.27.0.1:57088",
+					"172.28.0.1:57088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:16:37.584099691Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8817121571615835,
+				"StableID":   "nLqDUHqHrB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ff438b3d370ac7e8535275f6c9dd632885819ef9174502cd4f75a68367484022",
+				"KeyExpiry":  "2026-11-09T09:16:38Z",
+				"DiscoKey":   "discokey:ba73117d5dc25aa3894fcf29c41b93d5c3fe1a75ae7fe523a4e3e19f970ed538",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45196",
+					"10.65.0.27:45196",
+					"172.17.0.1:45196",
+					"172.18.0.1:45196",
+					"172.19.0.1:45196",
+					"172.20.0.1:45196",
+					"172.21.0.1:45196",
+					"172.22.0.1:45196",
+					"172.23.0.1:45196",
+					"172.24.0.1:45196",
+					"172.25.0.1:45196",
+					"172.26.0.1:45196",
+					"172.27.0.1:45196",
+					"172.28.0.1:45196"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:16:38.177732012Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3438518289772750,
+				"StableID":   "nBDecb3KrT11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5a701bba6af81b1d3119253be60d716401f2d9a50fd5dc50536113b0a9f08660",
+				"KeyExpiry":  "2026-11-09T09:16:38Z",
+				"DiscoKey":   "discokey:1927d7fbdb293edda5e8619c4dca14d6e7d7e05c5ede001b380a2f08c4989172",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55365",
+					"10.65.0.27:55365",
+					"172.17.0.1:55365",
+					"172.18.0.1:55365",
+					"172.19.0.1:55365",
+					"172.20.0.1:55365",
+					"172.21.0.1:55365",
+					"172.22.0.1:55365",
+					"172.23.0.1:55365",
+					"172.24.0.1:55365",
+					"172.25.0.1:55365",
+					"172.26.0.1:55365",
+					"172.27.0.1:55365",
+					"172.28.0.1:55365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:16:38.715741477Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4232648330810505,
+				"StableID":   "npaHyfVy3a11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7b5184612ccbb8983f218368c8035d305c0fa4a6092021190b0a05b953b10425",
+				"KeyExpiry":  "2026-11-09T09:16:39Z",
+				"DiscoKey":   "discokey:5208598b8cac01e196a19a8d49f96773a9835d24c68bd69598a5937f23c63e4a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56825",
+					"10.65.0.27:56825",
+					"172.17.0.1:56825",
+					"172.18.0.1:56825",
+					"172.19.0.1:56825",
+					"172.20.0.1:56825",
+					"172.21.0.1:56825",
+					"172.22.0.1:56825",
+					"172.23.0.1:56825",
+					"172.24.0.1:56825",
+					"172.25.0.1:56825",
+					"172.26.0.1:56825",
+					"172.27.0.1:56825",
+					"172.28.0.1:56825"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:16:39.250040788Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2884204743856928": {
+				"ID":          2884204743856928,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4232648330810505,
+				"StableID":   "npaHyfVy3a11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7b5184612ccbb8983f218368c8035d305c0fa4a6092021190b0a05b953b10425",
+				"KeyExpiry":  "2026-11-09T09:16:39Z",
+				"DiscoKey":   "discokey:5208598b8cac01e196a19a8d49f96773a9835d24c68bd69598a5937f23c63e4a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56825",
+					"10.65.0.27:56825",
+					"172.17.0.1:56825",
+					"172.18.0.1:56825",
+					"172.19.0.1:56825",
+					"172.20.0.1:56825",
+					"172.21.0.1:56825",
+					"172.22.0.1:56825",
+					"172.23.0.1:56825",
+					"172.24.0.1:56825",
+					"172.25.0.1:56825",
+					"172.26.0.1:56825",
+					"172.27.0.1:56825",
+					"172.28.0.1:56825"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:16:39.250040788Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7b5184612ccbb8983f218368c8035d305c0fa4a6092021190b0a05b953b10425",
+			"MachineKey": "mkey:3c7e5a1013a510f019553ec2c38f338d63cb782553d63f9370f89478949a5a03",
+			"Peers": [{
+				"ID":         4544457554236945,
+				"StableID":   "n84eJFCCVc11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb69a9a3fd98283abb5b824a0e46b6d27ce37cc55932b72bf440c437db22d237",
+				"DiscoKey":   "discokey:a578f456e0138f1dc305b742ef3a500571ec5fd487a809b1117a6c8c9b000249",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36024",
+					"10.65.0.27:36024",
+					"172.17.0.1:36024",
+					"172.18.0.1:36024",
+					"172.19.0.1:36024",
+					"172.20.0.1:36024",
+					"172.21.0.1:36024",
+					"172.22.0.1:36024",
+					"172.23.0.1:36024",
+					"172.24.0.1:36024",
+					"172.25.0.1:36024",
+					"172.26.0.1:36024",
+					"172.27.0.1:36024",
+					"172.28.0.1:36024"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:16:31.110445532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2009417783924731,
+				"StableID":   "npXydsz4hG11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:753aa05e1103d96f6c54ad81c74c07654ed38a7353ab11489bb6a33dd824ed2d",
+				"DiscoKey":   "discokey:418bd024545893836054b8e180770ce90aea857fb8398f41a30ba280ca2c6901",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:56408",
+					"10.65.0.27:56408",
+					"172.17.0.1:56408",
+					"172.18.0.1:56408",
+					"172.19.0.1:56408",
+					"172.20.0.1:56408",
+					"172.21.0.1:56408",
+					"172.22.0.1:56408",
+					"172.23.0.1:56408",
+					"172.24.0.1:56408",
+					"172.25.0.1:56408",
+					"172.26.0.1:56408",
+					"172.27.0.1:56408",
+					"172.28.0.1:56408"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:16:31.735738377Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4637492199793181,
+				"StableID":   "ngYHMG4LDd11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:49c1763a9be9eb89c359f01714a9d818ad37ae4baa05b6f8eea689a62711b971",
+				"DiscoKey":   "discokey:9d3c95541d5aad0f118e534d243d71ea498d2660bb3554b8b3cc1ee21751c76e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36617",
+					"10.65.0.27:36617",
+					"172.17.0.1:36617",
+					"172.18.0.1:36617",
+					"172.19.0.1:36617",
+					"172.20.0.1:36617",
+					"172.21.0.1:36617",
+					"172.22.0.1:36617",
+					"172.23.0.1:36617",
+					"172.24.0.1:36617",
+					"172.25.0.1:36617",
+					"172.26.0.1:36617",
+					"172.27.0.1:36617",
+					"172.28.0.1:36617"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:16:32.261223987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4527847942638130,
+				"StableID":   "nTudoUtfMc11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:893b1cf6338cd631a24f7a3f0b8d1cfec096306fd567160a19137374b8cdb158",
+				"DiscoKey":   "discokey:df102ddc65336ee2f5ead02501b0db365aa9c7e90d446f0e4d98f3c223543b6e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59980",
+					"10.65.0.27:59980",
+					"172.17.0.1:59980",
+					"172.18.0.1:59980",
+					"172.19.0.1:59980",
+					"172.20.0.1:59980",
+					"172.21.0.1:59980",
+					"172.22.0.1:59980",
+					"172.23.0.1:59980",
+					"172.24.0.1:59980",
+					"172.25.0.1:59980",
+					"172.26.0.1:59980",
+					"172.27.0.1:59980",
+					"172.28.0.1:59980"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:16:33.317360859Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3801184942400324,
+				"StableID":   "nFxBpbgZgW11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:44da45e66d237c8652357ce0f54e681b03f91770691f28f892bfdc6578829b7f",
+				"DiscoKey":   "discokey:0a2146d82fda5c146aabe7ee1b17633e2d84035a208c13978301b706fe33cc1b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41449",
+					"10.65.0.27:41449",
+					"172.17.0.1:41449",
+					"172.18.0.1:41449",
+					"172.19.0.1:41449",
+					"172.20.0.1:41449",
+					"172.21.0.1:41449",
+					"172.22.0.1:41449",
+					"172.23.0.1:41449",
+					"172.24.0.1:41449",
+					"172.25.0.1:41449",
+					"172.26.0.1:41449",
+					"172.27.0.1:41449",
+					"172.28.0.1:41449"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:16:33.846892606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2884204743856928,
+				"StableID":   "nFNjijAGXP11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2288cbc791982d1febb37aa4632bca2afa58382205fa1debb16cb33c5097810f",
+				"DiscoKey":   "discokey:86ee1b0358dbe766533ecd96fb31297444a367bce9a7f65d63f1c21f6d189140",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50881",
+					"10.65.0.27:50881",
+					"172.17.0.1:50881",
+					"172.18.0.1:50881",
+					"172.19.0.1:50881",
+					"172.20.0.1:50881",
+					"172.21.0.1:50881",
+					"172.22.0.1:50881",
+					"172.23.0.1:50881",
+					"172.24.0.1:50881",
+					"172.25.0.1:50881",
+					"172.26.0.1:50881",
+					"172.27.0.1:50881",
+					"172.28.0.1:50881"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:16:34.38370158Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8068649566328922,
+				"StableID":   "nF7HP3kJ1621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dab39f217dc07a9a7265f9276d64ea1f59d461acb0ec058bd6e6cca4def2bb64",
+				"DiscoKey":   "discokey:63b9dca87a0d91279a35610d3029c6e7ce8bd5f800b5b9ac30f4386c49691c49",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44693",
+					"10.65.0.27:44693",
+					"172.17.0.1:44693",
+					"172.18.0.1:44693",
+					"172.19.0.1:44693",
+					"172.20.0.1:44693",
+					"172.21.0.1:44693",
+					"172.22.0.1:44693",
+					"172.23.0.1:44693",
+					"172.24.0.1:44693",
+					"172.25.0.1:44693",
+					"172.26.0.1:44693",
+					"172.27.0.1:44693",
+					"172.28.0.1:44693"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:16:34.900934564Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4294990921984530,
+				"StableID":   "nwMgGT8DYa11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:abbf2a0b102da082048e4a7e17a105a4731374fbd704134435b087699cb8607e",
+				"DiscoKey":   "discokey:b23fd71a513c8f30044586a0f38c845ae12cd58bbd3bb8a99ec9ddefa0b39e63",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50929",
+					"10.65.0.27:50929",
+					"172.17.0.1:50929",
+					"172.18.0.1:50929",
+					"172.19.0.1:50929",
+					"172.20.0.1:50929",
+					"172.21.0.1:50929",
+					"172.22.0.1:50929",
+					"172.23.0.1:50929",
+					"172.24.0.1:50929",
+					"172.25.0.1:50929",
+					"172.26.0.1:50929",
+					"172.27.0.1:50929",
+					"172.28.0.1:50929"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:16:35.432173376Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6683286104949244,
+				"StableID":   "ny7sFQbsBu11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4bb754b07a5725035b3bd889a8892ceaca64bdae3e2ad880ef302c3028b95e0d",
+				"DiscoKey":   "discokey:dd7a82d53b4b91c6f52539b4232687a61b1916e0c668b5007b4174fdee16137e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39866",
+					"10.65.0.27:39866",
+					"172.17.0.1:39866",
+					"172.18.0.1:39866",
+					"172.19.0.1:39866",
+					"172.20.0.1:39866",
+					"172.21.0.1:39866",
+					"172.22.0.1:39866",
+					"172.23.0.1:39866",
+					"172.24.0.1:39866",
+					"172.25.0.1:39866",
+					"172.26.0.1:39866",
+					"172.27.0.1:39866",
+					"172.28.0.1:39866"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:16:35.972074185Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2789200956428515,
+				"StableID":   "nc9HMcaEnN11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1d10f62d48a41ae8f2ff37f709fc71c9771d3ecae79f5888dbf5e9178e8fd43b",
+				"DiscoKey":   "discokey:4b0eeb701ea2de2e741363d16e822b997ceae786c7154214b8491f24e09e4d56",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49056",
+					"10.65.0.27:49056",
+					"172.17.0.1:49056",
+					"172.18.0.1:49056",
+					"172.19.0.1:49056",
+					"172.20.0.1:49056",
+					"172.21.0.1:49056",
+					"172.22.0.1:49056",
+					"172.23.0.1:49056",
+					"172.24.0.1:49056",
+					"172.25.0.1:49056",
+					"172.26.0.1:49056",
+					"172.27.0.1:49056",
+					"172.28.0.1:49056"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:16:36.504343844Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3136722346387547,
+				"StableID":   "nYZrYsNdVR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1c5c6665c13e9cffa7c924b2434ac58dd7c98cae7b7d0c82ae75f674d2c5064",
+				"DiscoKey":   "discokey:17e5772ce8a8e2c92ecda771799f562d4676d35fdc8174abb7aa966e89752703",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:59410",
+					"10.65.0.27:59410",
+					"172.17.0.1:59410",
+					"172.18.0.1:59410",
+					"172.19.0.1:59410",
+					"172.20.0.1:59410",
+					"172.21.0.1:59410",
+					"172.22.0.1:59410",
+					"172.23.0.1:59410",
+					"172.24.0.1:59410",
+					"172.25.0.1:59410",
+					"172.26.0.1:59410",
+					"172.27.0.1:59410",
+					"172.28.0.1:59410"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:16:37.031283368Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8655535422778369,
+				"StableID":   "nkLhppE7bA21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51ea7fe1af6a214a081f391094984c7ffc0ada6e7b0f955269cf478437343d37",
+				"DiscoKey":   "discokey:c613e971fe0d620109ca52c5e53ae02ef23e0da58e5e3fcd53e2225c6c361f49",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:57088",
+					"10.65.0.27:57088",
+					"172.17.0.1:57088",
+					"172.18.0.1:57088",
+					"172.19.0.1:57088",
+					"172.20.0.1:57088",
+					"172.21.0.1:57088",
+					"172.22.0.1:57088",
+					"172.23.0.1:57088",
+					"172.24.0.1:57088",
+					"172.25.0.1:57088",
+					"172.26.0.1:57088",
+					"172.27.0.1:57088",
+					"172.28.0.1:57088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:16:37.584099691Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8817121571615835,
+				"StableID":   "nLqDUHqHrB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ff438b3d370ac7e8535275f6c9dd632885819ef9174502cd4f75a68367484022",
+				"KeyExpiry":  "2026-11-09T09:16:38Z",
+				"DiscoKey":   "discokey:ba73117d5dc25aa3894fcf29c41b93d5c3fe1a75ae7fe523a4e3e19f970ed538",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45196",
+					"10.65.0.27:45196",
+					"172.17.0.1:45196",
+					"172.18.0.1:45196",
+					"172.19.0.1:45196",
+					"172.20.0.1:45196",
+					"172.21.0.1:45196",
+					"172.22.0.1:45196",
+					"172.23.0.1:45196",
+					"172.24.0.1:45196",
+					"172.25.0.1:45196",
+					"172.26.0.1:45196",
+					"172.27.0.1:45196",
+					"172.28.0.1:45196"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:16:38.177732012Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3438518289772750,
+				"StableID":   "nBDecb3KrT11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5a701bba6af81b1d3119253be60d716401f2d9a50fd5dc50536113b0a9f08660",
+				"KeyExpiry":  "2026-11-09T09:16:38Z",
+				"DiscoKey":   "discokey:1927d7fbdb293edda5e8619c4dca14d6e7d7e05c5ede001b380a2f08c4989172",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55365",
+					"10.65.0.27:55365",
+					"172.17.0.1:55365",
+					"172.18.0.1:55365",
+					"172.19.0.1:55365",
+					"172.20.0.1:55365",
+					"172.21.0.1:55365",
+					"172.22.0.1:55365",
+					"172.23.0.1:55365",
+					"172.24.0.1:55365",
+					"172.25.0.1:55365",
+					"172.26.0.1:55365",
+					"172.27.0.1:55365",
+					"172.28.0.1:55365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:16:38.715741477Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4637492199793181,
+				"StableID":   "ngYHMG4LDd11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       4637492199793181,
+				"Key":        "nodekey:49c1763a9be9eb89c359f01714a9d818ad37ae4baa05b6f8eea689a62711b971",
+				"DiscoKey":   "discokey:9d3c95541d5aad0f118e534d243d71ea498d2660bb3554b8b3cc1ee21751c76e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36617",
+					"10.65.0.27:36617",
+					"172.17.0.1:36617",
+					"172.18.0.1:36617",
+					"172.19.0.1:36617",
+					"172.20.0.1:36617",
+					"172.21.0.1:36617",
+					"172.22.0.1:36617",
+					"172.23.0.1:36617",
+					"172.24.0.1:36617",
+					"172.25.0.1:36617",
+					"172.26.0.1:36617",
+					"172.27.0.1:36617",
+					"172.28.0.1:36617"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:16:32.261223987Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:49c1763a9be9eb89c359f01714a9d818ad37ae4baa05b6f8eea689a62711b971",
+			"MachineKey": "mkey:927fd6f331d421edb316d49cf1624077e4d8cabc577a73bb9c2d70d70f98b762",
+			"Peers": [{
+				"ID":         4544457554236945,
+				"StableID":   "n84eJFCCVc11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb69a9a3fd98283abb5b824a0e46b6d27ce37cc55932b72bf440c437db22d237",
+				"DiscoKey":   "discokey:a578f456e0138f1dc305b742ef3a500571ec5fd487a809b1117a6c8c9b000249",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36024",
+					"10.65.0.27:36024",
+					"172.17.0.1:36024",
+					"172.18.0.1:36024",
+					"172.19.0.1:36024",
+					"172.20.0.1:36024",
+					"172.21.0.1:36024",
+					"172.22.0.1:36024",
+					"172.23.0.1:36024",
+					"172.24.0.1:36024",
+					"172.25.0.1:36024",
+					"172.26.0.1:36024",
+					"172.27.0.1:36024",
+					"172.28.0.1:36024"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:16:31.110445532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2009417783924731,
+				"StableID":   "npXydsz4hG11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:753aa05e1103d96f6c54ad81c74c07654ed38a7353ab11489bb6a33dd824ed2d",
+				"DiscoKey":   "discokey:418bd024545893836054b8e180770ce90aea857fb8398f41a30ba280ca2c6901",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:56408",
+					"10.65.0.27:56408",
+					"172.17.0.1:56408",
+					"172.18.0.1:56408",
+					"172.19.0.1:56408",
+					"172.20.0.1:56408",
+					"172.21.0.1:56408",
+					"172.22.0.1:56408",
+					"172.23.0.1:56408",
+					"172.24.0.1:56408",
+					"172.25.0.1:56408",
+					"172.26.0.1:56408",
+					"172.27.0.1:56408",
+					"172.28.0.1:56408"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:16:31.735738377Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4527847942638130,
+				"StableID":   "nTudoUtfMc11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:893b1cf6338cd631a24f7a3f0b8d1cfec096306fd567160a19137374b8cdb158",
+				"DiscoKey":   "discokey:df102ddc65336ee2f5ead02501b0db365aa9c7e90d446f0e4d98f3c223543b6e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59980",
+					"10.65.0.27:59980",
+					"172.17.0.1:59980",
+					"172.18.0.1:59980",
+					"172.19.0.1:59980",
+					"172.20.0.1:59980",
+					"172.21.0.1:59980",
+					"172.22.0.1:59980",
+					"172.23.0.1:59980",
+					"172.24.0.1:59980",
+					"172.25.0.1:59980",
+					"172.26.0.1:59980",
+					"172.27.0.1:59980",
+					"172.28.0.1:59980"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:16:33.317360859Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3801184942400324,
+				"StableID":   "nFxBpbgZgW11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:44da45e66d237c8652357ce0f54e681b03f91770691f28f892bfdc6578829b7f",
+				"DiscoKey":   "discokey:0a2146d82fda5c146aabe7ee1b17633e2d84035a208c13978301b706fe33cc1b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41449",
+					"10.65.0.27:41449",
+					"172.17.0.1:41449",
+					"172.18.0.1:41449",
+					"172.19.0.1:41449",
+					"172.20.0.1:41449",
+					"172.21.0.1:41449",
+					"172.22.0.1:41449",
+					"172.23.0.1:41449",
+					"172.24.0.1:41449",
+					"172.25.0.1:41449",
+					"172.26.0.1:41449",
+					"172.27.0.1:41449",
+					"172.28.0.1:41449"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:16:33.846892606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2884204743856928,
+				"StableID":   "nFNjijAGXP11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2288cbc791982d1febb37aa4632bca2afa58382205fa1debb16cb33c5097810f",
+				"DiscoKey":   "discokey:86ee1b0358dbe766533ecd96fb31297444a367bce9a7f65d63f1c21f6d189140",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50881",
+					"10.65.0.27:50881",
+					"172.17.0.1:50881",
+					"172.18.0.1:50881",
+					"172.19.0.1:50881",
+					"172.20.0.1:50881",
+					"172.21.0.1:50881",
+					"172.22.0.1:50881",
+					"172.23.0.1:50881",
+					"172.24.0.1:50881",
+					"172.25.0.1:50881",
+					"172.26.0.1:50881",
+					"172.27.0.1:50881",
+					"172.28.0.1:50881"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:16:34.38370158Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8068649566328922,
+				"StableID":   "nF7HP3kJ1621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dab39f217dc07a9a7265f9276d64ea1f59d461acb0ec058bd6e6cca4def2bb64",
+				"DiscoKey":   "discokey:63b9dca87a0d91279a35610d3029c6e7ce8bd5f800b5b9ac30f4386c49691c49",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44693",
+					"10.65.0.27:44693",
+					"172.17.0.1:44693",
+					"172.18.0.1:44693",
+					"172.19.0.1:44693",
+					"172.20.0.1:44693",
+					"172.21.0.1:44693",
+					"172.22.0.1:44693",
+					"172.23.0.1:44693",
+					"172.24.0.1:44693",
+					"172.25.0.1:44693",
+					"172.26.0.1:44693",
+					"172.27.0.1:44693",
+					"172.28.0.1:44693"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:16:34.900934564Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4294990921984530,
+				"StableID":   "nwMgGT8DYa11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:abbf2a0b102da082048e4a7e17a105a4731374fbd704134435b087699cb8607e",
+				"DiscoKey":   "discokey:b23fd71a513c8f30044586a0f38c845ae12cd58bbd3bb8a99ec9ddefa0b39e63",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50929",
+					"10.65.0.27:50929",
+					"172.17.0.1:50929",
+					"172.18.0.1:50929",
+					"172.19.0.1:50929",
+					"172.20.0.1:50929",
+					"172.21.0.1:50929",
+					"172.22.0.1:50929",
+					"172.23.0.1:50929",
+					"172.24.0.1:50929",
+					"172.25.0.1:50929",
+					"172.26.0.1:50929",
+					"172.27.0.1:50929",
+					"172.28.0.1:50929"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:16:35.432173376Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6683286104949244,
+				"StableID":   "ny7sFQbsBu11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4bb754b07a5725035b3bd889a8892ceaca64bdae3e2ad880ef302c3028b95e0d",
+				"DiscoKey":   "discokey:dd7a82d53b4b91c6f52539b4232687a61b1916e0c668b5007b4174fdee16137e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39866",
+					"10.65.0.27:39866",
+					"172.17.0.1:39866",
+					"172.18.0.1:39866",
+					"172.19.0.1:39866",
+					"172.20.0.1:39866",
+					"172.21.0.1:39866",
+					"172.22.0.1:39866",
+					"172.23.0.1:39866",
+					"172.24.0.1:39866",
+					"172.25.0.1:39866",
+					"172.26.0.1:39866",
+					"172.27.0.1:39866",
+					"172.28.0.1:39866"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:16:35.972074185Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2789200956428515,
+				"StableID":   "nc9HMcaEnN11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1d10f62d48a41ae8f2ff37f709fc71c9771d3ecae79f5888dbf5e9178e8fd43b",
+				"DiscoKey":   "discokey:4b0eeb701ea2de2e741363d16e822b997ceae786c7154214b8491f24e09e4d56",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49056",
+					"10.65.0.27:49056",
+					"172.17.0.1:49056",
+					"172.18.0.1:49056",
+					"172.19.0.1:49056",
+					"172.20.0.1:49056",
+					"172.21.0.1:49056",
+					"172.22.0.1:49056",
+					"172.23.0.1:49056",
+					"172.24.0.1:49056",
+					"172.25.0.1:49056",
+					"172.26.0.1:49056",
+					"172.27.0.1:49056",
+					"172.28.0.1:49056"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:16:36.504343844Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3136722346387547,
+				"StableID":   "nYZrYsNdVR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1c5c6665c13e9cffa7c924b2434ac58dd7c98cae7b7d0c82ae75f674d2c5064",
+				"DiscoKey":   "discokey:17e5772ce8a8e2c92ecda771799f562d4676d35fdc8174abb7aa966e89752703",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:59410",
+					"10.65.0.27:59410",
+					"172.17.0.1:59410",
+					"172.18.0.1:59410",
+					"172.19.0.1:59410",
+					"172.20.0.1:59410",
+					"172.21.0.1:59410",
+					"172.22.0.1:59410",
+					"172.23.0.1:59410",
+					"172.24.0.1:59410",
+					"172.25.0.1:59410",
+					"172.26.0.1:59410",
+					"172.27.0.1:59410",
+					"172.28.0.1:59410"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:16:37.031283368Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8655535422778369,
+				"StableID":   "nkLhppE7bA21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51ea7fe1af6a214a081f391094984c7ffc0ada6e7b0f955269cf478437343d37",
+				"DiscoKey":   "discokey:c613e971fe0d620109ca52c5e53ae02ef23e0da58e5e3fcd53e2225c6c361f49",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:57088",
+					"10.65.0.27:57088",
+					"172.17.0.1:57088",
+					"172.18.0.1:57088",
+					"172.19.0.1:57088",
+					"172.20.0.1:57088",
+					"172.21.0.1:57088",
+					"172.22.0.1:57088",
+					"172.23.0.1:57088",
+					"172.24.0.1:57088",
+					"172.25.0.1:57088",
+					"172.26.0.1:57088",
+					"172.27.0.1:57088",
+					"172.28.0.1:57088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:16:37.584099691Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8817121571615835,
+				"StableID":   "nLqDUHqHrB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ff438b3d370ac7e8535275f6c9dd632885819ef9174502cd4f75a68367484022",
+				"KeyExpiry":  "2026-11-09T09:16:38Z",
+				"DiscoKey":   "discokey:ba73117d5dc25aa3894fcf29c41b93d5c3fe1a75ae7fe523a4e3e19f970ed538",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45196",
+					"10.65.0.27:45196",
+					"172.17.0.1:45196",
+					"172.18.0.1:45196",
+					"172.19.0.1:45196",
+					"172.20.0.1:45196",
+					"172.21.0.1:45196",
+					"172.22.0.1:45196",
+					"172.23.0.1:45196",
+					"172.24.0.1:45196",
+					"172.25.0.1:45196",
+					"172.26.0.1:45196",
+					"172.27.0.1:45196",
+					"172.28.0.1:45196"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:16:38.177732012Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3438518289772750,
+				"StableID":   "nBDecb3KrT11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5a701bba6af81b1d3119253be60d716401f2d9a50fd5dc50536113b0a9f08660",
+				"KeyExpiry":  "2026-11-09T09:16:38Z",
+				"DiscoKey":   "discokey:1927d7fbdb293edda5e8619c4dca14d6e7d7e05c5ede001b380a2f08c4989172",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55365",
+					"10.65.0.27:55365",
+					"172.17.0.1:55365",
+					"172.18.0.1:55365",
+					"172.19.0.1:55365",
+					"172.20.0.1:55365",
+					"172.21.0.1:55365",
+					"172.22.0.1:55365",
+					"172.23.0.1:55365",
+					"172.24.0.1:55365",
+					"172.25.0.1:55365",
+					"172.26.0.1:55365",
+					"172.27.0.1:55365",
+					"172.28.0.1:55365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:16:38.715741477Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4232648330810505,
+				"StableID":   "npaHyfVy3a11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7b5184612ccbb8983f218368c8035d305c0fa4a6092021190b0a05b953b10425",
+				"KeyExpiry":  "2026-11-09T09:16:39Z",
+				"DiscoKey":   "discokey:5208598b8cac01e196a19a8d49f96773a9835d24c68bd69598a5937f23c63e4a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56825",
+					"10.65.0.27:56825",
+					"172.17.0.1:56825",
+					"172.18.0.1:56825",
+					"172.19.0.1:56825",
+					"172.20.0.1:56825",
+					"172.21.0.1:56825",
+					"172.22.0.1:56825",
+					"172.23.0.1:56825",
+					"172.24.0.1:56825",
+					"172.25.0.1:56825",
+					"172.26.0.1:56825",
+					"172.27.0.1:56825",
+					"172.28.0.1:56825"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:16:39.250040788Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4637492199793181": {
+				"ID":          4637492199793181,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4294990921984530,
+				"StableID":   "nwMgGT8DYa11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       4294990921984530,
+				"Key":        "nodekey:abbf2a0b102da082048e4a7e17a105a4731374fbd704134435b087699cb8607e",
+				"DiscoKey":   "discokey:b23fd71a513c8f30044586a0f38c845ae12cd58bbd3bb8a99ec9ddefa0b39e63",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50929",
+					"10.65.0.27:50929",
+					"172.17.0.1:50929",
+					"172.18.0.1:50929",
+					"172.19.0.1:50929",
+					"172.20.0.1:50929",
+					"172.21.0.1:50929",
+					"172.22.0.1:50929",
+					"172.23.0.1:50929",
+					"172.24.0.1:50929",
+					"172.25.0.1:50929",
+					"172.26.0.1:50929",
+					"172.27.0.1:50929",
+					"172.28.0.1:50929"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:16:35.432173376Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:abbf2a0b102da082048e4a7e17a105a4731374fbd704134435b087699cb8607e",
+			"MachineKey": "mkey:48ab3aa4b93f630b98fa88ce346cd1ef25c935abe04f2e24b02a7b7b35980462",
+			"Peers": [{
+				"ID":         4544457554236945,
+				"StableID":   "n84eJFCCVc11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb69a9a3fd98283abb5b824a0e46b6d27ce37cc55932b72bf440c437db22d237",
+				"DiscoKey":   "discokey:a578f456e0138f1dc305b742ef3a500571ec5fd487a809b1117a6c8c9b000249",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36024",
+					"10.65.0.27:36024",
+					"172.17.0.1:36024",
+					"172.18.0.1:36024",
+					"172.19.0.1:36024",
+					"172.20.0.1:36024",
+					"172.21.0.1:36024",
+					"172.22.0.1:36024",
+					"172.23.0.1:36024",
+					"172.24.0.1:36024",
+					"172.25.0.1:36024",
+					"172.26.0.1:36024",
+					"172.27.0.1:36024",
+					"172.28.0.1:36024"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:16:31.110445532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2009417783924731,
+				"StableID":   "npXydsz4hG11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:753aa05e1103d96f6c54ad81c74c07654ed38a7353ab11489bb6a33dd824ed2d",
+				"DiscoKey":   "discokey:418bd024545893836054b8e180770ce90aea857fb8398f41a30ba280ca2c6901",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:56408",
+					"10.65.0.27:56408",
+					"172.17.0.1:56408",
+					"172.18.0.1:56408",
+					"172.19.0.1:56408",
+					"172.20.0.1:56408",
+					"172.21.0.1:56408",
+					"172.22.0.1:56408",
+					"172.23.0.1:56408",
+					"172.24.0.1:56408",
+					"172.25.0.1:56408",
+					"172.26.0.1:56408",
+					"172.27.0.1:56408",
+					"172.28.0.1:56408"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:16:31.735738377Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4637492199793181,
+				"StableID":   "ngYHMG4LDd11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:49c1763a9be9eb89c359f01714a9d818ad37ae4baa05b6f8eea689a62711b971",
+				"DiscoKey":   "discokey:9d3c95541d5aad0f118e534d243d71ea498d2660bb3554b8b3cc1ee21751c76e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36617",
+					"10.65.0.27:36617",
+					"172.17.0.1:36617",
+					"172.18.0.1:36617",
+					"172.19.0.1:36617",
+					"172.20.0.1:36617",
+					"172.21.0.1:36617",
+					"172.22.0.1:36617",
+					"172.23.0.1:36617",
+					"172.24.0.1:36617",
+					"172.25.0.1:36617",
+					"172.26.0.1:36617",
+					"172.27.0.1:36617",
+					"172.28.0.1:36617"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:16:32.261223987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4527847942638130,
+				"StableID":   "nTudoUtfMc11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:893b1cf6338cd631a24f7a3f0b8d1cfec096306fd567160a19137374b8cdb158",
+				"DiscoKey":   "discokey:df102ddc65336ee2f5ead02501b0db365aa9c7e90d446f0e4d98f3c223543b6e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59980",
+					"10.65.0.27:59980",
+					"172.17.0.1:59980",
+					"172.18.0.1:59980",
+					"172.19.0.1:59980",
+					"172.20.0.1:59980",
+					"172.21.0.1:59980",
+					"172.22.0.1:59980",
+					"172.23.0.1:59980",
+					"172.24.0.1:59980",
+					"172.25.0.1:59980",
+					"172.26.0.1:59980",
+					"172.27.0.1:59980",
+					"172.28.0.1:59980"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:16:33.317360859Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3801184942400324,
+				"StableID":   "nFxBpbgZgW11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:44da45e66d237c8652357ce0f54e681b03f91770691f28f892bfdc6578829b7f",
+				"DiscoKey":   "discokey:0a2146d82fda5c146aabe7ee1b17633e2d84035a208c13978301b706fe33cc1b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41449",
+					"10.65.0.27:41449",
+					"172.17.0.1:41449",
+					"172.18.0.1:41449",
+					"172.19.0.1:41449",
+					"172.20.0.1:41449",
+					"172.21.0.1:41449",
+					"172.22.0.1:41449",
+					"172.23.0.1:41449",
+					"172.24.0.1:41449",
+					"172.25.0.1:41449",
+					"172.26.0.1:41449",
+					"172.27.0.1:41449",
+					"172.28.0.1:41449"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:16:33.846892606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2884204743856928,
+				"StableID":   "nFNjijAGXP11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2288cbc791982d1febb37aa4632bca2afa58382205fa1debb16cb33c5097810f",
+				"DiscoKey":   "discokey:86ee1b0358dbe766533ecd96fb31297444a367bce9a7f65d63f1c21f6d189140",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50881",
+					"10.65.0.27:50881",
+					"172.17.0.1:50881",
+					"172.18.0.1:50881",
+					"172.19.0.1:50881",
+					"172.20.0.1:50881",
+					"172.21.0.1:50881",
+					"172.22.0.1:50881",
+					"172.23.0.1:50881",
+					"172.24.0.1:50881",
+					"172.25.0.1:50881",
+					"172.26.0.1:50881",
+					"172.27.0.1:50881",
+					"172.28.0.1:50881"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:16:34.38370158Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8068649566328922,
+				"StableID":   "nF7HP3kJ1621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dab39f217dc07a9a7265f9276d64ea1f59d461acb0ec058bd6e6cca4def2bb64",
+				"DiscoKey":   "discokey:63b9dca87a0d91279a35610d3029c6e7ce8bd5f800b5b9ac30f4386c49691c49",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44693",
+					"10.65.0.27:44693",
+					"172.17.0.1:44693",
+					"172.18.0.1:44693",
+					"172.19.0.1:44693",
+					"172.20.0.1:44693",
+					"172.21.0.1:44693",
+					"172.22.0.1:44693",
+					"172.23.0.1:44693",
+					"172.24.0.1:44693",
+					"172.25.0.1:44693",
+					"172.26.0.1:44693",
+					"172.27.0.1:44693",
+					"172.28.0.1:44693"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:16:34.900934564Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6683286104949244,
+				"StableID":   "ny7sFQbsBu11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4bb754b07a5725035b3bd889a8892ceaca64bdae3e2ad880ef302c3028b95e0d",
+				"DiscoKey":   "discokey:dd7a82d53b4b91c6f52539b4232687a61b1916e0c668b5007b4174fdee16137e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39866",
+					"10.65.0.27:39866",
+					"172.17.0.1:39866",
+					"172.18.0.1:39866",
+					"172.19.0.1:39866",
+					"172.20.0.1:39866",
+					"172.21.0.1:39866",
+					"172.22.0.1:39866",
+					"172.23.0.1:39866",
+					"172.24.0.1:39866",
+					"172.25.0.1:39866",
+					"172.26.0.1:39866",
+					"172.27.0.1:39866",
+					"172.28.0.1:39866"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:16:35.972074185Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2789200956428515,
+				"StableID":   "nc9HMcaEnN11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1d10f62d48a41ae8f2ff37f709fc71c9771d3ecae79f5888dbf5e9178e8fd43b",
+				"DiscoKey":   "discokey:4b0eeb701ea2de2e741363d16e822b997ceae786c7154214b8491f24e09e4d56",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49056",
+					"10.65.0.27:49056",
+					"172.17.0.1:49056",
+					"172.18.0.1:49056",
+					"172.19.0.1:49056",
+					"172.20.0.1:49056",
+					"172.21.0.1:49056",
+					"172.22.0.1:49056",
+					"172.23.0.1:49056",
+					"172.24.0.1:49056",
+					"172.25.0.1:49056",
+					"172.26.0.1:49056",
+					"172.27.0.1:49056",
+					"172.28.0.1:49056"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:16:36.504343844Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3136722346387547,
+				"StableID":   "nYZrYsNdVR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1c5c6665c13e9cffa7c924b2434ac58dd7c98cae7b7d0c82ae75f674d2c5064",
+				"DiscoKey":   "discokey:17e5772ce8a8e2c92ecda771799f562d4676d35fdc8174abb7aa966e89752703",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:59410",
+					"10.65.0.27:59410",
+					"172.17.0.1:59410",
+					"172.18.0.1:59410",
+					"172.19.0.1:59410",
+					"172.20.0.1:59410",
+					"172.21.0.1:59410",
+					"172.22.0.1:59410",
+					"172.23.0.1:59410",
+					"172.24.0.1:59410",
+					"172.25.0.1:59410",
+					"172.26.0.1:59410",
+					"172.27.0.1:59410",
+					"172.28.0.1:59410"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:16:37.031283368Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8655535422778369,
+				"StableID":   "nkLhppE7bA21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51ea7fe1af6a214a081f391094984c7ffc0ada6e7b0f955269cf478437343d37",
+				"DiscoKey":   "discokey:c613e971fe0d620109ca52c5e53ae02ef23e0da58e5e3fcd53e2225c6c361f49",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:57088",
+					"10.65.0.27:57088",
+					"172.17.0.1:57088",
+					"172.18.0.1:57088",
+					"172.19.0.1:57088",
+					"172.20.0.1:57088",
+					"172.21.0.1:57088",
+					"172.22.0.1:57088",
+					"172.23.0.1:57088",
+					"172.24.0.1:57088",
+					"172.25.0.1:57088",
+					"172.26.0.1:57088",
+					"172.27.0.1:57088",
+					"172.28.0.1:57088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:16:37.584099691Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8817121571615835,
+				"StableID":   "nLqDUHqHrB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ff438b3d370ac7e8535275f6c9dd632885819ef9174502cd4f75a68367484022",
+				"KeyExpiry":  "2026-11-09T09:16:38Z",
+				"DiscoKey":   "discokey:ba73117d5dc25aa3894fcf29c41b93d5c3fe1a75ae7fe523a4e3e19f970ed538",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45196",
+					"10.65.0.27:45196",
+					"172.17.0.1:45196",
+					"172.18.0.1:45196",
+					"172.19.0.1:45196",
+					"172.20.0.1:45196",
+					"172.21.0.1:45196",
+					"172.22.0.1:45196",
+					"172.23.0.1:45196",
+					"172.24.0.1:45196",
+					"172.25.0.1:45196",
+					"172.26.0.1:45196",
+					"172.27.0.1:45196",
+					"172.28.0.1:45196"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:16:38.177732012Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3438518289772750,
+				"StableID":   "nBDecb3KrT11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5a701bba6af81b1d3119253be60d716401f2d9a50fd5dc50536113b0a9f08660",
+				"KeyExpiry":  "2026-11-09T09:16:38Z",
+				"DiscoKey":   "discokey:1927d7fbdb293edda5e8619c4dca14d6e7d7e05c5ede001b380a2f08c4989172",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55365",
+					"10.65.0.27:55365",
+					"172.17.0.1:55365",
+					"172.18.0.1:55365",
+					"172.19.0.1:55365",
+					"172.20.0.1:55365",
+					"172.21.0.1:55365",
+					"172.22.0.1:55365",
+					"172.23.0.1:55365",
+					"172.24.0.1:55365",
+					"172.25.0.1:55365",
+					"172.26.0.1:55365",
+					"172.27.0.1:55365",
+					"172.28.0.1:55365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:16:38.715741477Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4232648330810505,
+				"StableID":   "npaHyfVy3a11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7b5184612ccbb8983f218368c8035d305c0fa4a6092021190b0a05b953b10425",
+				"KeyExpiry":  "2026-11-09T09:16:39Z",
+				"DiscoKey":   "discokey:5208598b8cac01e196a19a8d49f96773a9835d24c68bd69598a5937f23c63e4a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56825",
+					"10.65.0.27:56825",
+					"172.17.0.1:56825",
+					"172.18.0.1:56825",
+					"172.19.0.1:56825",
+					"172.20.0.1:56825",
+					"172.21.0.1:56825",
+					"172.22.0.1:56825",
+					"172.23.0.1:56825",
+					"172.24.0.1:56825",
+					"172.25.0.1:56825",
+					"172.26.0.1:56825",
+					"172.27.0.1:56825",
+					"172.28.0.1:56825"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:16:39.250040788Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4294990921984530": {
+				"ID":          4294990921984530,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8817121571615835,
+				"StableID":   "nLqDUHqHrB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ff438b3d370ac7e8535275f6c9dd632885819ef9174502cd4f75a68367484022",
+				"KeyExpiry":  "2026-11-09T09:16:38Z",
+				"DiscoKey":   "discokey:ba73117d5dc25aa3894fcf29c41b93d5c3fe1a75ae7fe523a4e3e19f970ed538",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45196",
+					"10.65.0.27:45196",
+					"172.17.0.1:45196",
+					"172.18.0.1:45196",
+					"172.19.0.1:45196",
+					"172.20.0.1:45196",
+					"172.21.0.1:45196",
+					"172.22.0.1:45196",
+					"172.23.0.1:45196",
+					"172.24.0.1:45196",
+					"172.25.0.1:45196",
+					"172.26.0.1:45196",
+					"172.27.0.1:45196",
+					"172.28.0.1:45196"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:16:38.177732012Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ff438b3d370ac7e8535275f6c9dd632885819ef9174502cd4f75a68367484022",
+			"MachineKey": "mkey:3a1293beaf383cce86487fde1f1be8ae4377f7b75d139f0aa180cc9f8c466b5c",
+			"Peers": [{
+				"ID":         4544457554236945,
+				"StableID":   "n84eJFCCVc11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb69a9a3fd98283abb5b824a0e46b6d27ce37cc55932b72bf440c437db22d237",
+				"DiscoKey":   "discokey:a578f456e0138f1dc305b742ef3a500571ec5fd487a809b1117a6c8c9b000249",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36024",
+					"10.65.0.27:36024",
+					"172.17.0.1:36024",
+					"172.18.0.1:36024",
+					"172.19.0.1:36024",
+					"172.20.0.1:36024",
+					"172.21.0.1:36024",
+					"172.22.0.1:36024",
+					"172.23.0.1:36024",
+					"172.24.0.1:36024",
+					"172.25.0.1:36024",
+					"172.26.0.1:36024",
+					"172.27.0.1:36024",
+					"172.28.0.1:36024"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:16:31.110445532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2009417783924731,
+				"StableID":   "npXydsz4hG11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:753aa05e1103d96f6c54ad81c74c07654ed38a7353ab11489bb6a33dd824ed2d",
+				"DiscoKey":   "discokey:418bd024545893836054b8e180770ce90aea857fb8398f41a30ba280ca2c6901",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:56408",
+					"10.65.0.27:56408",
+					"172.17.0.1:56408",
+					"172.18.0.1:56408",
+					"172.19.0.1:56408",
+					"172.20.0.1:56408",
+					"172.21.0.1:56408",
+					"172.22.0.1:56408",
+					"172.23.0.1:56408",
+					"172.24.0.1:56408",
+					"172.25.0.1:56408",
+					"172.26.0.1:56408",
+					"172.27.0.1:56408",
+					"172.28.0.1:56408"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:16:31.735738377Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4637492199793181,
+				"StableID":   "ngYHMG4LDd11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:49c1763a9be9eb89c359f01714a9d818ad37ae4baa05b6f8eea689a62711b971",
+				"DiscoKey":   "discokey:9d3c95541d5aad0f118e534d243d71ea498d2660bb3554b8b3cc1ee21751c76e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36617",
+					"10.65.0.27:36617",
+					"172.17.0.1:36617",
+					"172.18.0.1:36617",
+					"172.19.0.1:36617",
+					"172.20.0.1:36617",
+					"172.21.0.1:36617",
+					"172.22.0.1:36617",
+					"172.23.0.1:36617",
+					"172.24.0.1:36617",
+					"172.25.0.1:36617",
+					"172.26.0.1:36617",
+					"172.27.0.1:36617",
+					"172.28.0.1:36617"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:16:32.261223987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4527847942638130,
+				"StableID":   "nTudoUtfMc11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:893b1cf6338cd631a24f7a3f0b8d1cfec096306fd567160a19137374b8cdb158",
+				"DiscoKey":   "discokey:df102ddc65336ee2f5ead02501b0db365aa9c7e90d446f0e4d98f3c223543b6e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59980",
+					"10.65.0.27:59980",
+					"172.17.0.1:59980",
+					"172.18.0.1:59980",
+					"172.19.0.1:59980",
+					"172.20.0.1:59980",
+					"172.21.0.1:59980",
+					"172.22.0.1:59980",
+					"172.23.0.1:59980",
+					"172.24.0.1:59980",
+					"172.25.0.1:59980",
+					"172.26.0.1:59980",
+					"172.27.0.1:59980",
+					"172.28.0.1:59980"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:16:33.317360859Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3801184942400324,
+				"StableID":   "nFxBpbgZgW11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:44da45e66d237c8652357ce0f54e681b03f91770691f28f892bfdc6578829b7f",
+				"DiscoKey":   "discokey:0a2146d82fda5c146aabe7ee1b17633e2d84035a208c13978301b706fe33cc1b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41449",
+					"10.65.0.27:41449",
+					"172.17.0.1:41449",
+					"172.18.0.1:41449",
+					"172.19.0.1:41449",
+					"172.20.0.1:41449",
+					"172.21.0.1:41449",
+					"172.22.0.1:41449",
+					"172.23.0.1:41449",
+					"172.24.0.1:41449",
+					"172.25.0.1:41449",
+					"172.26.0.1:41449",
+					"172.27.0.1:41449",
+					"172.28.0.1:41449"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:16:33.846892606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2884204743856928,
+				"StableID":   "nFNjijAGXP11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2288cbc791982d1febb37aa4632bca2afa58382205fa1debb16cb33c5097810f",
+				"DiscoKey":   "discokey:86ee1b0358dbe766533ecd96fb31297444a367bce9a7f65d63f1c21f6d189140",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50881",
+					"10.65.0.27:50881",
+					"172.17.0.1:50881",
+					"172.18.0.1:50881",
+					"172.19.0.1:50881",
+					"172.20.0.1:50881",
+					"172.21.0.1:50881",
+					"172.22.0.1:50881",
+					"172.23.0.1:50881",
+					"172.24.0.1:50881",
+					"172.25.0.1:50881",
+					"172.26.0.1:50881",
+					"172.27.0.1:50881",
+					"172.28.0.1:50881"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:16:34.38370158Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8068649566328922,
+				"StableID":   "nF7HP3kJ1621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dab39f217dc07a9a7265f9276d64ea1f59d461acb0ec058bd6e6cca4def2bb64",
+				"DiscoKey":   "discokey:63b9dca87a0d91279a35610d3029c6e7ce8bd5f800b5b9ac30f4386c49691c49",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44693",
+					"10.65.0.27:44693",
+					"172.17.0.1:44693",
+					"172.18.0.1:44693",
+					"172.19.0.1:44693",
+					"172.20.0.1:44693",
+					"172.21.0.1:44693",
+					"172.22.0.1:44693",
+					"172.23.0.1:44693",
+					"172.24.0.1:44693",
+					"172.25.0.1:44693",
+					"172.26.0.1:44693",
+					"172.27.0.1:44693",
+					"172.28.0.1:44693"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:16:34.900934564Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4294990921984530,
+				"StableID":   "nwMgGT8DYa11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:abbf2a0b102da082048e4a7e17a105a4731374fbd704134435b087699cb8607e",
+				"DiscoKey":   "discokey:b23fd71a513c8f30044586a0f38c845ae12cd58bbd3bb8a99ec9ddefa0b39e63",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50929",
+					"10.65.0.27:50929",
+					"172.17.0.1:50929",
+					"172.18.0.1:50929",
+					"172.19.0.1:50929",
+					"172.20.0.1:50929",
+					"172.21.0.1:50929",
+					"172.22.0.1:50929",
+					"172.23.0.1:50929",
+					"172.24.0.1:50929",
+					"172.25.0.1:50929",
+					"172.26.0.1:50929",
+					"172.27.0.1:50929",
+					"172.28.0.1:50929"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:16:35.432173376Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6683286104949244,
+				"StableID":   "ny7sFQbsBu11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4bb754b07a5725035b3bd889a8892ceaca64bdae3e2ad880ef302c3028b95e0d",
+				"DiscoKey":   "discokey:dd7a82d53b4b91c6f52539b4232687a61b1916e0c668b5007b4174fdee16137e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39866",
+					"10.65.0.27:39866",
+					"172.17.0.1:39866",
+					"172.18.0.1:39866",
+					"172.19.0.1:39866",
+					"172.20.0.1:39866",
+					"172.21.0.1:39866",
+					"172.22.0.1:39866",
+					"172.23.0.1:39866",
+					"172.24.0.1:39866",
+					"172.25.0.1:39866",
+					"172.26.0.1:39866",
+					"172.27.0.1:39866",
+					"172.28.0.1:39866"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:16:35.972074185Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2789200956428515,
+				"StableID":   "nc9HMcaEnN11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1d10f62d48a41ae8f2ff37f709fc71c9771d3ecae79f5888dbf5e9178e8fd43b",
+				"DiscoKey":   "discokey:4b0eeb701ea2de2e741363d16e822b997ceae786c7154214b8491f24e09e4d56",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49056",
+					"10.65.0.27:49056",
+					"172.17.0.1:49056",
+					"172.18.0.1:49056",
+					"172.19.0.1:49056",
+					"172.20.0.1:49056",
+					"172.21.0.1:49056",
+					"172.22.0.1:49056",
+					"172.23.0.1:49056",
+					"172.24.0.1:49056",
+					"172.25.0.1:49056",
+					"172.26.0.1:49056",
+					"172.27.0.1:49056",
+					"172.28.0.1:49056"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:16:36.504343844Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3136722346387547,
+				"StableID":   "nYZrYsNdVR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1c5c6665c13e9cffa7c924b2434ac58dd7c98cae7b7d0c82ae75f674d2c5064",
+				"DiscoKey":   "discokey:17e5772ce8a8e2c92ecda771799f562d4676d35fdc8174abb7aa966e89752703",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:59410",
+					"10.65.0.27:59410",
+					"172.17.0.1:59410",
+					"172.18.0.1:59410",
+					"172.19.0.1:59410",
+					"172.20.0.1:59410",
+					"172.21.0.1:59410",
+					"172.22.0.1:59410",
+					"172.23.0.1:59410",
+					"172.24.0.1:59410",
+					"172.25.0.1:59410",
+					"172.26.0.1:59410",
+					"172.27.0.1:59410",
+					"172.28.0.1:59410"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:16:37.031283368Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8655535422778369,
+				"StableID":   "nkLhppE7bA21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51ea7fe1af6a214a081f391094984c7ffc0ada6e7b0f955269cf478437343d37",
+				"DiscoKey":   "discokey:c613e971fe0d620109ca52c5e53ae02ef23e0da58e5e3fcd53e2225c6c361f49",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:57088",
+					"10.65.0.27:57088",
+					"172.17.0.1:57088",
+					"172.18.0.1:57088",
+					"172.19.0.1:57088",
+					"172.20.0.1:57088",
+					"172.21.0.1:57088",
+					"172.22.0.1:57088",
+					"172.23.0.1:57088",
+					"172.24.0.1:57088",
+					"172.25.0.1:57088",
+					"172.26.0.1:57088",
+					"172.27.0.1:57088",
+					"172.28.0.1:57088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:16:37.584099691Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3438518289772750,
+				"StableID":   "nBDecb3KrT11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5a701bba6af81b1d3119253be60d716401f2d9a50fd5dc50536113b0a9f08660",
+				"KeyExpiry":  "2026-11-09T09:16:38Z",
+				"DiscoKey":   "discokey:1927d7fbdb293edda5e8619c4dca14d6e7d7e05c5ede001b380a2f08c4989172",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55365",
+					"10.65.0.27:55365",
+					"172.17.0.1:55365",
+					"172.18.0.1:55365",
+					"172.19.0.1:55365",
+					"172.20.0.1:55365",
+					"172.21.0.1:55365",
+					"172.22.0.1:55365",
+					"172.23.0.1:55365",
+					"172.24.0.1:55365",
+					"172.25.0.1:55365",
+					"172.26.0.1:55365",
+					"172.27.0.1:55365",
+					"172.28.0.1:55365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:16:38.715741477Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4232648330810505,
+				"StableID":   "npaHyfVy3a11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7b5184612ccbb8983f218368c8035d305c0fa4a6092021190b0a05b953b10425",
+				"KeyExpiry":  "2026-11-09T09:16:39Z",
+				"DiscoKey":   "discokey:5208598b8cac01e196a19a8d49f96773a9835d24c68bd69598a5937f23c63e4a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56825",
+					"10.65.0.27:56825",
+					"172.17.0.1:56825",
+					"172.18.0.1:56825",
+					"172.19.0.1:56825",
+					"172.20.0.1:56825",
+					"172.21.0.1:56825",
+					"172.22.0.1:56825",
+					"172.23.0.1:56825",
+					"172.24.0.1:56825",
+					"172.25.0.1:56825",
+					"172.26.0.1:56825",
+					"172.27.0.1:56825",
+					"172.28.0.1:56825"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:16:39.250040788Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3136722346387547,
+				"StableID":   "nYZrYsNdVR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       3136722346387547,
+				"Key":        "nodekey:c1c5c6665c13e9cffa7c924b2434ac58dd7c98cae7b7d0c82ae75f674d2c5064",
+				"DiscoKey":   "discokey:17e5772ce8a8e2c92ecda771799f562d4676d35fdc8174abb7aa966e89752703",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:59410",
+					"10.65.0.27:59410",
+					"172.17.0.1:59410",
+					"172.18.0.1:59410",
+					"172.19.0.1:59410",
+					"172.20.0.1:59410",
+					"172.21.0.1:59410",
+					"172.22.0.1:59410",
+					"172.23.0.1:59410",
+					"172.24.0.1:59410",
+					"172.25.0.1:59410",
+					"172.26.0.1:59410",
+					"172.27.0.1:59410",
+					"172.28.0.1:59410"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:16:37.031283368Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c1c5c6665c13e9cffa7c924b2434ac58dd7c98cae7b7d0c82ae75f674d2c5064",
+			"MachineKey": "mkey:21f9a3d881073512b334ed1d0fe2d5647ea5ed59c9a976179e0ba4f9600b954d",
+			"Peers": [{
+				"ID":         4544457554236945,
+				"StableID":   "n84eJFCCVc11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb69a9a3fd98283abb5b824a0e46b6d27ce37cc55932b72bf440c437db22d237",
+				"DiscoKey":   "discokey:a578f456e0138f1dc305b742ef3a500571ec5fd487a809b1117a6c8c9b000249",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36024",
+					"10.65.0.27:36024",
+					"172.17.0.1:36024",
+					"172.18.0.1:36024",
+					"172.19.0.1:36024",
+					"172.20.0.1:36024",
+					"172.21.0.1:36024",
+					"172.22.0.1:36024",
+					"172.23.0.1:36024",
+					"172.24.0.1:36024",
+					"172.25.0.1:36024",
+					"172.26.0.1:36024",
+					"172.27.0.1:36024",
+					"172.28.0.1:36024"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:16:31.110445532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2009417783924731,
+				"StableID":   "npXydsz4hG11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:753aa05e1103d96f6c54ad81c74c07654ed38a7353ab11489bb6a33dd824ed2d",
+				"DiscoKey":   "discokey:418bd024545893836054b8e180770ce90aea857fb8398f41a30ba280ca2c6901",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:56408",
+					"10.65.0.27:56408",
+					"172.17.0.1:56408",
+					"172.18.0.1:56408",
+					"172.19.0.1:56408",
+					"172.20.0.1:56408",
+					"172.21.0.1:56408",
+					"172.22.0.1:56408",
+					"172.23.0.1:56408",
+					"172.24.0.1:56408",
+					"172.25.0.1:56408",
+					"172.26.0.1:56408",
+					"172.27.0.1:56408",
+					"172.28.0.1:56408"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:16:31.735738377Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4637492199793181,
+				"StableID":   "ngYHMG4LDd11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:49c1763a9be9eb89c359f01714a9d818ad37ae4baa05b6f8eea689a62711b971",
+				"DiscoKey":   "discokey:9d3c95541d5aad0f118e534d243d71ea498d2660bb3554b8b3cc1ee21751c76e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36617",
+					"10.65.0.27:36617",
+					"172.17.0.1:36617",
+					"172.18.0.1:36617",
+					"172.19.0.1:36617",
+					"172.20.0.1:36617",
+					"172.21.0.1:36617",
+					"172.22.0.1:36617",
+					"172.23.0.1:36617",
+					"172.24.0.1:36617",
+					"172.25.0.1:36617",
+					"172.26.0.1:36617",
+					"172.27.0.1:36617",
+					"172.28.0.1:36617"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:16:32.261223987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4527847942638130,
+				"StableID":   "nTudoUtfMc11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:893b1cf6338cd631a24f7a3f0b8d1cfec096306fd567160a19137374b8cdb158",
+				"DiscoKey":   "discokey:df102ddc65336ee2f5ead02501b0db365aa9c7e90d446f0e4d98f3c223543b6e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59980",
+					"10.65.0.27:59980",
+					"172.17.0.1:59980",
+					"172.18.0.1:59980",
+					"172.19.0.1:59980",
+					"172.20.0.1:59980",
+					"172.21.0.1:59980",
+					"172.22.0.1:59980",
+					"172.23.0.1:59980",
+					"172.24.0.1:59980",
+					"172.25.0.1:59980",
+					"172.26.0.1:59980",
+					"172.27.0.1:59980",
+					"172.28.0.1:59980"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:16:33.317360859Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3801184942400324,
+				"StableID":   "nFxBpbgZgW11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:44da45e66d237c8652357ce0f54e681b03f91770691f28f892bfdc6578829b7f",
+				"DiscoKey":   "discokey:0a2146d82fda5c146aabe7ee1b17633e2d84035a208c13978301b706fe33cc1b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41449",
+					"10.65.0.27:41449",
+					"172.17.0.1:41449",
+					"172.18.0.1:41449",
+					"172.19.0.1:41449",
+					"172.20.0.1:41449",
+					"172.21.0.1:41449",
+					"172.22.0.1:41449",
+					"172.23.0.1:41449",
+					"172.24.0.1:41449",
+					"172.25.0.1:41449",
+					"172.26.0.1:41449",
+					"172.27.0.1:41449",
+					"172.28.0.1:41449"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:16:33.846892606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2884204743856928,
+				"StableID":   "nFNjijAGXP11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2288cbc791982d1febb37aa4632bca2afa58382205fa1debb16cb33c5097810f",
+				"DiscoKey":   "discokey:86ee1b0358dbe766533ecd96fb31297444a367bce9a7f65d63f1c21f6d189140",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50881",
+					"10.65.0.27:50881",
+					"172.17.0.1:50881",
+					"172.18.0.1:50881",
+					"172.19.0.1:50881",
+					"172.20.0.1:50881",
+					"172.21.0.1:50881",
+					"172.22.0.1:50881",
+					"172.23.0.1:50881",
+					"172.24.0.1:50881",
+					"172.25.0.1:50881",
+					"172.26.0.1:50881",
+					"172.27.0.1:50881",
+					"172.28.0.1:50881"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:16:34.38370158Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8068649566328922,
+				"StableID":   "nF7HP3kJ1621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dab39f217dc07a9a7265f9276d64ea1f59d461acb0ec058bd6e6cca4def2bb64",
+				"DiscoKey":   "discokey:63b9dca87a0d91279a35610d3029c6e7ce8bd5f800b5b9ac30f4386c49691c49",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44693",
+					"10.65.0.27:44693",
+					"172.17.0.1:44693",
+					"172.18.0.1:44693",
+					"172.19.0.1:44693",
+					"172.20.0.1:44693",
+					"172.21.0.1:44693",
+					"172.22.0.1:44693",
+					"172.23.0.1:44693",
+					"172.24.0.1:44693",
+					"172.25.0.1:44693",
+					"172.26.0.1:44693",
+					"172.27.0.1:44693",
+					"172.28.0.1:44693"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:16:34.900934564Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4294990921984530,
+				"StableID":   "nwMgGT8DYa11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:abbf2a0b102da082048e4a7e17a105a4731374fbd704134435b087699cb8607e",
+				"DiscoKey":   "discokey:b23fd71a513c8f30044586a0f38c845ae12cd58bbd3bb8a99ec9ddefa0b39e63",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50929",
+					"10.65.0.27:50929",
+					"172.17.0.1:50929",
+					"172.18.0.1:50929",
+					"172.19.0.1:50929",
+					"172.20.0.1:50929",
+					"172.21.0.1:50929",
+					"172.22.0.1:50929",
+					"172.23.0.1:50929",
+					"172.24.0.1:50929",
+					"172.25.0.1:50929",
+					"172.26.0.1:50929",
+					"172.27.0.1:50929",
+					"172.28.0.1:50929"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:16:35.432173376Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6683286104949244,
+				"StableID":   "ny7sFQbsBu11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4bb754b07a5725035b3bd889a8892ceaca64bdae3e2ad880ef302c3028b95e0d",
+				"DiscoKey":   "discokey:dd7a82d53b4b91c6f52539b4232687a61b1916e0c668b5007b4174fdee16137e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39866",
+					"10.65.0.27:39866",
+					"172.17.0.1:39866",
+					"172.18.0.1:39866",
+					"172.19.0.1:39866",
+					"172.20.0.1:39866",
+					"172.21.0.1:39866",
+					"172.22.0.1:39866",
+					"172.23.0.1:39866",
+					"172.24.0.1:39866",
+					"172.25.0.1:39866",
+					"172.26.0.1:39866",
+					"172.27.0.1:39866",
+					"172.28.0.1:39866"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:16:35.972074185Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2789200956428515,
+				"StableID":   "nc9HMcaEnN11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1d10f62d48a41ae8f2ff37f709fc71c9771d3ecae79f5888dbf5e9178e8fd43b",
+				"DiscoKey":   "discokey:4b0eeb701ea2de2e741363d16e822b997ceae786c7154214b8491f24e09e4d56",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49056",
+					"10.65.0.27:49056",
+					"172.17.0.1:49056",
+					"172.18.0.1:49056",
+					"172.19.0.1:49056",
+					"172.20.0.1:49056",
+					"172.21.0.1:49056",
+					"172.22.0.1:49056",
+					"172.23.0.1:49056",
+					"172.24.0.1:49056",
+					"172.25.0.1:49056",
+					"172.26.0.1:49056",
+					"172.27.0.1:49056",
+					"172.28.0.1:49056"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:16:36.504343844Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8655535422778369,
+				"StableID":   "nkLhppE7bA21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51ea7fe1af6a214a081f391094984c7ffc0ada6e7b0f955269cf478437343d37",
+				"DiscoKey":   "discokey:c613e971fe0d620109ca52c5e53ae02ef23e0da58e5e3fcd53e2225c6c361f49",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:57088",
+					"10.65.0.27:57088",
+					"172.17.0.1:57088",
+					"172.18.0.1:57088",
+					"172.19.0.1:57088",
+					"172.20.0.1:57088",
+					"172.21.0.1:57088",
+					"172.22.0.1:57088",
+					"172.23.0.1:57088",
+					"172.24.0.1:57088",
+					"172.25.0.1:57088",
+					"172.26.0.1:57088",
+					"172.27.0.1:57088",
+					"172.28.0.1:57088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:16:37.584099691Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8817121571615835,
+				"StableID":   "nLqDUHqHrB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ff438b3d370ac7e8535275f6c9dd632885819ef9174502cd4f75a68367484022",
+				"KeyExpiry":  "2026-11-09T09:16:38Z",
+				"DiscoKey":   "discokey:ba73117d5dc25aa3894fcf29c41b93d5c3fe1a75ae7fe523a4e3e19f970ed538",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45196",
+					"10.65.0.27:45196",
+					"172.17.0.1:45196",
+					"172.18.0.1:45196",
+					"172.19.0.1:45196",
+					"172.20.0.1:45196",
+					"172.21.0.1:45196",
+					"172.22.0.1:45196",
+					"172.23.0.1:45196",
+					"172.24.0.1:45196",
+					"172.25.0.1:45196",
+					"172.26.0.1:45196",
+					"172.27.0.1:45196",
+					"172.28.0.1:45196"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:16:38.177732012Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3438518289772750,
+				"StableID":   "nBDecb3KrT11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5a701bba6af81b1d3119253be60d716401f2d9a50fd5dc50536113b0a9f08660",
+				"KeyExpiry":  "2026-11-09T09:16:38Z",
+				"DiscoKey":   "discokey:1927d7fbdb293edda5e8619c4dca14d6e7d7e05c5ede001b380a2f08c4989172",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55365",
+					"10.65.0.27:55365",
+					"172.17.0.1:55365",
+					"172.18.0.1:55365",
+					"172.19.0.1:55365",
+					"172.20.0.1:55365",
+					"172.21.0.1:55365",
+					"172.22.0.1:55365",
+					"172.23.0.1:55365",
+					"172.24.0.1:55365",
+					"172.25.0.1:55365",
+					"172.26.0.1:55365",
+					"172.27.0.1:55365",
+					"172.28.0.1:55365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:16:38.715741477Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4232648330810505,
+				"StableID":   "npaHyfVy3a11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7b5184612ccbb8983f218368c8035d305c0fa4a6092021190b0a05b953b10425",
+				"KeyExpiry":  "2026-11-09T09:16:39Z",
+				"DiscoKey":   "discokey:5208598b8cac01e196a19a8d49f96773a9835d24c68bd69598a5937f23c63e4a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56825",
+					"10.65.0.27:56825",
+					"172.17.0.1:56825",
+					"172.18.0.1:56825",
+					"172.19.0.1:56825",
+					"172.20.0.1:56825",
+					"172.21.0.1:56825",
+					"172.22.0.1:56825",
+					"172.23.0.1:56825",
+					"172.24.0.1:56825",
+					"172.25.0.1:56825",
+					"172.26.0.1:56825",
+					"172.27.0.1:56825",
+					"172.28.0.1:56825"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:16:39.250040788Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3136722346387547": {
+				"ID":          3136722346387547,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2009417783924731,
+				"StableID":   "npXydsz4hG11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       2009417783924731,
+				"Key":        "nodekey:753aa05e1103d96f6c54ad81c74c07654ed38a7353ab11489bb6a33dd824ed2d",
+				"DiscoKey":   "discokey:418bd024545893836054b8e180770ce90aea857fb8398f41a30ba280ca2c6901",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:56408",
+					"10.65.0.27:56408",
+					"172.17.0.1:56408",
+					"172.18.0.1:56408",
+					"172.19.0.1:56408",
+					"172.20.0.1:56408",
+					"172.21.0.1:56408",
+					"172.22.0.1:56408",
+					"172.23.0.1:56408",
+					"172.24.0.1:56408",
+					"172.25.0.1:56408",
+					"172.26.0.1:56408",
+					"172.27.0.1:56408",
+					"172.28.0.1:56408"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:16:31.735738377Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:753aa05e1103d96f6c54ad81c74c07654ed38a7353ab11489bb6a33dd824ed2d",
+			"MachineKey": "mkey:229a1450b0af47eebd8b4716e93d3f90bf908d515b5c8492ec3a06d8fa3ddf06",
+			"Peers": [{
+				"ID":         4544457554236945,
+				"StableID":   "n84eJFCCVc11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb69a9a3fd98283abb5b824a0e46b6d27ce37cc55932b72bf440c437db22d237",
+				"DiscoKey":   "discokey:a578f456e0138f1dc305b742ef3a500571ec5fd487a809b1117a6c8c9b000249",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36024",
+					"10.65.0.27:36024",
+					"172.17.0.1:36024",
+					"172.18.0.1:36024",
+					"172.19.0.1:36024",
+					"172.20.0.1:36024",
+					"172.21.0.1:36024",
+					"172.22.0.1:36024",
+					"172.23.0.1:36024",
+					"172.24.0.1:36024",
+					"172.25.0.1:36024",
+					"172.26.0.1:36024",
+					"172.27.0.1:36024",
+					"172.28.0.1:36024"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:16:31.110445532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4637492199793181,
+				"StableID":   "ngYHMG4LDd11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:49c1763a9be9eb89c359f01714a9d818ad37ae4baa05b6f8eea689a62711b971",
+				"DiscoKey":   "discokey:9d3c95541d5aad0f118e534d243d71ea498d2660bb3554b8b3cc1ee21751c76e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36617",
+					"10.65.0.27:36617",
+					"172.17.0.1:36617",
+					"172.18.0.1:36617",
+					"172.19.0.1:36617",
+					"172.20.0.1:36617",
+					"172.21.0.1:36617",
+					"172.22.0.1:36617",
+					"172.23.0.1:36617",
+					"172.24.0.1:36617",
+					"172.25.0.1:36617",
+					"172.26.0.1:36617",
+					"172.27.0.1:36617",
+					"172.28.0.1:36617"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:16:32.261223987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4527847942638130,
+				"StableID":   "nTudoUtfMc11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:893b1cf6338cd631a24f7a3f0b8d1cfec096306fd567160a19137374b8cdb158",
+				"DiscoKey":   "discokey:df102ddc65336ee2f5ead02501b0db365aa9c7e90d446f0e4d98f3c223543b6e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59980",
+					"10.65.0.27:59980",
+					"172.17.0.1:59980",
+					"172.18.0.1:59980",
+					"172.19.0.1:59980",
+					"172.20.0.1:59980",
+					"172.21.0.1:59980",
+					"172.22.0.1:59980",
+					"172.23.0.1:59980",
+					"172.24.0.1:59980",
+					"172.25.0.1:59980",
+					"172.26.0.1:59980",
+					"172.27.0.1:59980",
+					"172.28.0.1:59980"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:16:33.317360859Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3801184942400324,
+				"StableID":   "nFxBpbgZgW11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:44da45e66d237c8652357ce0f54e681b03f91770691f28f892bfdc6578829b7f",
+				"DiscoKey":   "discokey:0a2146d82fda5c146aabe7ee1b17633e2d84035a208c13978301b706fe33cc1b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41449",
+					"10.65.0.27:41449",
+					"172.17.0.1:41449",
+					"172.18.0.1:41449",
+					"172.19.0.1:41449",
+					"172.20.0.1:41449",
+					"172.21.0.1:41449",
+					"172.22.0.1:41449",
+					"172.23.0.1:41449",
+					"172.24.0.1:41449",
+					"172.25.0.1:41449",
+					"172.26.0.1:41449",
+					"172.27.0.1:41449",
+					"172.28.0.1:41449"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:16:33.846892606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2884204743856928,
+				"StableID":   "nFNjijAGXP11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2288cbc791982d1febb37aa4632bca2afa58382205fa1debb16cb33c5097810f",
+				"DiscoKey":   "discokey:86ee1b0358dbe766533ecd96fb31297444a367bce9a7f65d63f1c21f6d189140",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50881",
+					"10.65.0.27:50881",
+					"172.17.0.1:50881",
+					"172.18.0.1:50881",
+					"172.19.0.1:50881",
+					"172.20.0.1:50881",
+					"172.21.0.1:50881",
+					"172.22.0.1:50881",
+					"172.23.0.1:50881",
+					"172.24.0.1:50881",
+					"172.25.0.1:50881",
+					"172.26.0.1:50881",
+					"172.27.0.1:50881",
+					"172.28.0.1:50881"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:16:34.38370158Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8068649566328922,
+				"StableID":   "nF7HP3kJ1621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dab39f217dc07a9a7265f9276d64ea1f59d461acb0ec058bd6e6cca4def2bb64",
+				"DiscoKey":   "discokey:63b9dca87a0d91279a35610d3029c6e7ce8bd5f800b5b9ac30f4386c49691c49",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44693",
+					"10.65.0.27:44693",
+					"172.17.0.1:44693",
+					"172.18.0.1:44693",
+					"172.19.0.1:44693",
+					"172.20.0.1:44693",
+					"172.21.0.1:44693",
+					"172.22.0.1:44693",
+					"172.23.0.1:44693",
+					"172.24.0.1:44693",
+					"172.25.0.1:44693",
+					"172.26.0.1:44693",
+					"172.27.0.1:44693",
+					"172.28.0.1:44693"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:16:34.900934564Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4294990921984530,
+				"StableID":   "nwMgGT8DYa11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:abbf2a0b102da082048e4a7e17a105a4731374fbd704134435b087699cb8607e",
+				"DiscoKey":   "discokey:b23fd71a513c8f30044586a0f38c845ae12cd58bbd3bb8a99ec9ddefa0b39e63",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50929",
+					"10.65.0.27:50929",
+					"172.17.0.1:50929",
+					"172.18.0.1:50929",
+					"172.19.0.1:50929",
+					"172.20.0.1:50929",
+					"172.21.0.1:50929",
+					"172.22.0.1:50929",
+					"172.23.0.1:50929",
+					"172.24.0.1:50929",
+					"172.25.0.1:50929",
+					"172.26.0.1:50929",
+					"172.27.0.1:50929",
+					"172.28.0.1:50929"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:16:35.432173376Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6683286104949244,
+				"StableID":   "ny7sFQbsBu11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4bb754b07a5725035b3bd889a8892ceaca64bdae3e2ad880ef302c3028b95e0d",
+				"DiscoKey":   "discokey:dd7a82d53b4b91c6f52539b4232687a61b1916e0c668b5007b4174fdee16137e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39866",
+					"10.65.0.27:39866",
+					"172.17.0.1:39866",
+					"172.18.0.1:39866",
+					"172.19.0.1:39866",
+					"172.20.0.1:39866",
+					"172.21.0.1:39866",
+					"172.22.0.1:39866",
+					"172.23.0.1:39866",
+					"172.24.0.1:39866",
+					"172.25.0.1:39866",
+					"172.26.0.1:39866",
+					"172.27.0.1:39866",
+					"172.28.0.1:39866"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:16:35.972074185Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2789200956428515,
+				"StableID":   "nc9HMcaEnN11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1d10f62d48a41ae8f2ff37f709fc71c9771d3ecae79f5888dbf5e9178e8fd43b",
+				"DiscoKey":   "discokey:4b0eeb701ea2de2e741363d16e822b997ceae786c7154214b8491f24e09e4d56",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49056",
+					"10.65.0.27:49056",
+					"172.17.0.1:49056",
+					"172.18.0.1:49056",
+					"172.19.0.1:49056",
+					"172.20.0.1:49056",
+					"172.21.0.1:49056",
+					"172.22.0.1:49056",
+					"172.23.0.1:49056",
+					"172.24.0.1:49056",
+					"172.25.0.1:49056",
+					"172.26.0.1:49056",
+					"172.27.0.1:49056",
+					"172.28.0.1:49056"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:16:36.504343844Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3136722346387547,
+				"StableID":   "nYZrYsNdVR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1c5c6665c13e9cffa7c924b2434ac58dd7c98cae7b7d0c82ae75f674d2c5064",
+				"DiscoKey":   "discokey:17e5772ce8a8e2c92ecda771799f562d4676d35fdc8174abb7aa966e89752703",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:59410",
+					"10.65.0.27:59410",
+					"172.17.0.1:59410",
+					"172.18.0.1:59410",
+					"172.19.0.1:59410",
+					"172.20.0.1:59410",
+					"172.21.0.1:59410",
+					"172.22.0.1:59410",
+					"172.23.0.1:59410",
+					"172.24.0.1:59410",
+					"172.25.0.1:59410",
+					"172.26.0.1:59410",
+					"172.27.0.1:59410",
+					"172.28.0.1:59410"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:16:37.031283368Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8655535422778369,
+				"StableID":   "nkLhppE7bA21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51ea7fe1af6a214a081f391094984c7ffc0ada6e7b0f955269cf478437343d37",
+				"DiscoKey":   "discokey:c613e971fe0d620109ca52c5e53ae02ef23e0da58e5e3fcd53e2225c6c361f49",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:57088",
+					"10.65.0.27:57088",
+					"172.17.0.1:57088",
+					"172.18.0.1:57088",
+					"172.19.0.1:57088",
+					"172.20.0.1:57088",
+					"172.21.0.1:57088",
+					"172.22.0.1:57088",
+					"172.23.0.1:57088",
+					"172.24.0.1:57088",
+					"172.25.0.1:57088",
+					"172.26.0.1:57088",
+					"172.27.0.1:57088",
+					"172.28.0.1:57088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:16:37.584099691Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8817121571615835,
+				"StableID":   "nLqDUHqHrB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ff438b3d370ac7e8535275f6c9dd632885819ef9174502cd4f75a68367484022",
+				"KeyExpiry":  "2026-11-09T09:16:38Z",
+				"DiscoKey":   "discokey:ba73117d5dc25aa3894fcf29c41b93d5c3fe1a75ae7fe523a4e3e19f970ed538",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45196",
+					"10.65.0.27:45196",
+					"172.17.0.1:45196",
+					"172.18.0.1:45196",
+					"172.19.0.1:45196",
+					"172.20.0.1:45196",
+					"172.21.0.1:45196",
+					"172.22.0.1:45196",
+					"172.23.0.1:45196",
+					"172.24.0.1:45196",
+					"172.25.0.1:45196",
+					"172.26.0.1:45196",
+					"172.27.0.1:45196",
+					"172.28.0.1:45196"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:16:38.177732012Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3438518289772750,
+				"StableID":   "nBDecb3KrT11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5a701bba6af81b1d3119253be60d716401f2d9a50fd5dc50536113b0a9f08660",
+				"KeyExpiry":  "2026-11-09T09:16:38Z",
+				"DiscoKey":   "discokey:1927d7fbdb293edda5e8619c4dca14d6e7d7e05c5ede001b380a2f08c4989172",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55365",
+					"10.65.0.27:55365",
+					"172.17.0.1:55365",
+					"172.18.0.1:55365",
+					"172.19.0.1:55365",
+					"172.20.0.1:55365",
+					"172.21.0.1:55365",
+					"172.22.0.1:55365",
+					"172.23.0.1:55365",
+					"172.24.0.1:55365",
+					"172.25.0.1:55365",
+					"172.26.0.1:55365",
+					"172.27.0.1:55365",
+					"172.28.0.1:55365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:16:38.715741477Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4232648330810505,
+				"StableID":   "npaHyfVy3a11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7b5184612ccbb8983f218368c8035d305c0fa4a6092021190b0a05b953b10425",
+				"KeyExpiry":  "2026-11-09T09:16:39Z",
+				"DiscoKey":   "discokey:5208598b8cac01e196a19a8d49f96773a9835d24c68bd69598a5937f23c63e4a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56825",
+					"10.65.0.27:56825",
+					"172.17.0.1:56825",
+					"172.18.0.1:56825",
+					"172.19.0.1:56825",
+					"172.20.0.1:56825",
+					"172.21.0.1:56825",
+					"172.22.0.1:56825",
+					"172.23.0.1:56825",
+					"172.24.0.1:56825",
+					"172.25.0.1:56825",
+					"172.26.0.1:56825",
+					"172.27.0.1:56825",
+					"172.28.0.1:56825"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:16:39.250040788Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2009417783924731": {
+				"ID":          2009417783924731,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4544457554236945,
+				"StableID":   "n84eJFCCVc11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       4544457554236945,
+				"Key":        "nodekey:cb69a9a3fd98283abb5b824a0e46b6d27ce37cc55932b72bf440c437db22d237",
+				"DiscoKey":   "discokey:a578f456e0138f1dc305b742ef3a500571ec5fd487a809b1117a6c8c9b000249",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36024",
+					"10.65.0.27:36024",
+					"172.17.0.1:36024",
+					"172.18.0.1:36024",
+					"172.19.0.1:36024",
+					"172.20.0.1:36024",
+					"172.21.0.1:36024",
+					"172.22.0.1:36024",
+					"172.23.0.1:36024",
+					"172.24.0.1:36024",
+					"172.25.0.1:36024",
+					"172.26.0.1:36024",
+					"172.27.0.1:36024",
+					"172.28.0.1:36024"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:16:31.110445532Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:cb69a9a3fd98283abb5b824a0e46b6d27ce37cc55932b72bf440c437db22d237",
+			"MachineKey": "mkey:8f598fc8abf3df5875b2b627b3da6fe306e2b59199ee5dd18ab1b5a77147615e",
+			"Peers": [{
+				"ID":         2009417783924731,
+				"StableID":   "npXydsz4hG11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:753aa05e1103d96f6c54ad81c74c07654ed38a7353ab11489bb6a33dd824ed2d",
+				"DiscoKey":   "discokey:418bd024545893836054b8e180770ce90aea857fb8398f41a30ba280ca2c6901",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:56408",
+					"10.65.0.27:56408",
+					"172.17.0.1:56408",
+					"172.18.0.1:56408",
+					"172.19.0.1:56408",
+					"172.20.0.1:56408",
+					"172.21.0.1:56408",
+					"172.22.0.1:56408",
+					"172.23.0.1:56408",
+					"172.24.0.1:56408",
+					"172.25.0.1:56408",
+					"172.26.0.1:56408",
+					"172.27.0.1:56408",
+					"172.28.0.1:56408"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:16:31.735738377Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4637492199793181,
+				"StableID":   "ngYHMG4LDd11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:49c1763a9be9eb89c359f01714a9d818ad37ae4baa05b6f8eea689a62711b971",
+				"DiscoKey":   "discokey:9d3c95541d5aad0f118e534d243d71ea498d2660bb3554b8b3cc1ee21751c76e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36617",
+					"10.65.0.27:36617",
+					"172.17.0.1:36617",
+					"172.18.0.1:36617",
+					"172.19.0.1:36617",
+					"172.20.0.1:36617",
+					"172.21.0.1:36617",
+					"172.22.0.1:36617",
+					"172.23.0.1:36617",
+					"172.24.0.1:36617",
+					"172.25.0.1:36617",
+					"172.26.0.1:36617",
+					"172.27.0.1:36617",
+					"172.28.0.1:36617"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:16:32.261223987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4527847942638130,
+				"StableID":   "nTudoUtfMc11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:893b1cf6338cd631a24f7a3f0b8d1cfec096306fd567160a19137374b8cdb158",
+				"DiscoKey":   "discokey:df102ddc65336ee2f5ead02501b0db365aa9c7e90d446f0e4d98f3c223543b6e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59980",
+					"10.65.0.27:59980",
+					"172.17.0.1:59980",
+					"172.18.0.1:59980",
+					"172.19.0.1:59980",
+					"172.20.0.1:59980",
+					"172.21.0.1:59980",
+					"172.22.0.1:59980",
+					"172.23.0.1:59980",
+					"172.24.0.1:59980",
+					"172.25.0.1:59980",
+					"172.26.0.1:59980",
+					"172.27.0.1:59980",
+					"172.28.0.1:59980"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:16:33.317360859Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3801184942400324,
+				"StableID":   "nFxBpbgZgW11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:44da45e66d237c8652357ce0f54e681b03f91770691f28f892bfdc6578829b7f",
+				"DiscoKey":   "discokey:0a2146d82fda5c146aabe7ee1b17633e2d84035a208c13978301b706fe33cc1b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41449",
+					"10.65.0.27:41449",
+					"172.17.0.1:41449",
+					"172.18.0.1:41449",
+					"172.19.0.1:41449",
+					"172.20.0.1:41449",
+					"172.21.0.1:41449",
+					"172.22.0.1:41449",
+					"172.23.0.1:41449",
+					"172.24.0.1:41449",
+					"172.25.0.1:41449",
+					"172.26.0.1:41449",
+					"172.27.0.1:41449",
+					"172.28.0.1:41449"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:16:33.846892606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2884204743856928,
+				"StableID":   "nFNjijAGXP11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2288cbc791982d1febb37aa4632bca2afa58382205fa1debb16cb33c5097810f",
+				"DiscoKey":   "discokey:86ee1b0358dbe766533ecd96fb31297444a367bce9a7f65d63f1c21f6d189140",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50881",
+					"10.65.0.27:50881",
+					"172.17.0.1:50881",
+					"172.18.0.1:50881",
+					"172.19.0.1:50881",
+					"172.20.0.1:50881",
+					"172.21.0.1:50881",
+					"172.22.0.1:50881",
+					"172.23.0.1:50881",
+					"172.24.0.1:50881",
+					"172.25.0.1:50881",
+					"172.26.0.1:50881",
+					"172.27.0.1:50881",
+					"172.28.0.1:50881"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:16:34.38370158Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8068649566328922,
+				"StableID":   "nF7HP3kJ1621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dab39f217dc07a9a7265f9276d64ea1f59d461acb0ec058bd6e6cca4def2bb64",
+				"DiscoKey":   "discokey:63b9dca87a0d91279a35610d3029c6e7ce8bd5f800b5b9ac30f4386c49691c49",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44693",
+					"10.65.0.27:44693",
+					"172.17.0.1:44693",
+					"172.18.0.1:44693",
+					"172.19.0.1:44693",
+					"172.20.0.1:44693",
+					"172.21.0.1:44693",
+					"172.22.0.1:44693",
+					"172.23.0.1:44693",
+					"172.24.0.1:44693",
+					"172.25.0.1:44693",
+					"172.26.0.1:44693",
+					"172.27.0.1:44693",
+					"172.28.0.1:44693"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:16:34.900934564Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4294990921984530,
+				"StableID":   "nwMgGT8DYa11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:abbf2a0b102da082048e4a7e17a105a4731374fbd704134435b087699cb8607e",
+				"DiscoKey":   "discokey:b23fd71a513c8f30044586a0f38c845ae12cd58bbd3bb8a99ec9ddefa0b39e63",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50929",
+					"10.65.0.27:50929",
+					"172.17.0.1:50929",
+					"172.18.0.1:50929",
+					"172.19.0.1:50929",
+					"172.20.0.1:50929",
+					"172.21.0.1:50929",
+					"172.22.0.1:50929",
+					"172.23.0.1:50929",
+					"172.24.0.1:50929",
+					"172.25.0.1:50929",
+					"172.26.0.1:50929",
+					"172.27.0.1:50929",
+					"172.28.0.1:50929"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:16:35.432173376Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6683286104949244,
+				"StableID":   "ny7sFQbsBu11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4bb754b07a5725035b3bd889a8892ceaca64bdae3e2ad880ef302c3028b95e0d",
+				"DiscoKey":   "discokey:dd7a82d53b4b91c6f52539b4232687a61b1916e0c668b5007b4174fdee16137e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39866",
+					"10.65.0.27:39866",
+					"172.17.0.1:39866",
+					"172.18.0.1:39866",
+					"172.19.0.1:39866",
+					"172.20.0.1:39866",
+					"172.21.0.1:39866",
+					"172.22.0.1:39866",
+					"172.23.0.1:39866",
+					"172.24.0.1:39866",
+					"172.25.0.1:39866",
+					"172.26.0.1:39866",
+					"172.27.0.1:39866",
+					"172.28.0.1:39866"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:16:35.972074185Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2789200956428515,
+				"StableID":   "nc9HMcaEnN11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1d10f62d48a41ae8f2ff37f709fc71c9771d3ecae79f5888dbf5e9178e8fd43b",
+				"DiscoKey":   "discokey:4b0eeb701ea2de2e741363d16e822b997ceae786c7154214b8491f24e09e4d56",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49056",
+					"10.65.0.27:49056",
+					"172.17.0.1:49056",
+					"172.18.0.1:49056",
+					"172.19.0.1:49056",
+					"172.20.0.1:49056",
+					"172.21.0.1:49056",
+					"172.22.0.1:49056",
+					"172.23.0.1:49056",
+					"172.24.0.1:49056",
+					"172.25.0.1:49056",
+					"172.26.0.1:49056",
+					"172.27.0.1:49056",
+					"172.28.0.1:49056"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:16:36.504343844Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3136722346387547,
+				"StableID":   "nYZrYsNdVR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1c5c6665c13e9cffa7c924b2434ac58dd7c98cae7b7d0c82ae75f674d2c5064",
+				"DiscoKey":   "discokey:17e5772ce8a8e2c92ecda771799f562d4676d35fdc8174abb7aa966e89752703",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:59410",
+					"10.65.0.27:59410",
+					"172.17.0.1:59410",
+					"172.18.0.1:59410",
+					"172.19.0.1:59410",
+					"172.20.0.1:59410",
+					"172.21.0.1:59410",
+					"172.22.0.1:59410",
+					"172.23.0.1:59410",
+					"172.24.0.1:59410",
+					"172.25.0.1:59410",
+					"172.26.0.1:59410",
+					"172.27.0.1:59410",
+					"172.28.0.1:59410"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:16:37.031283368Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8655535422778369,
+				"StableID":   "nkLhppE7bA21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51ea7fe1af6a214a081f391094984c7ffc0ada6e7b0f955269cf478437343d37",
+				"DiscoKey":   "discokey:c613e971fe0d620109ca52c5e53ae02ef23e0da58e5e3fcd53e2225c6c361f49",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:57088",
+					"10.65.0.27:57088",
+					"172.17.0.1:57088",
+					"172.18.0.1:57088",
+					"172.19.0.1:57088",
+					"172.20.0.1:57088",
+					"172.21.0.1:57088",
+					"172.22.0.1:57088",
+					"172.23.0.1:57088",
+					"172.24.0.1:57088",
+					"172.25.0.1:57088",
+					"172.26.0.1:57088",
+					"172.27.0.1:57088",
+					"172.28.0.1:57088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:16:37.584099691Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8817121571615835,
+				"StableID":   "nLqDUHqHrB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ff438b3d370ac7e8535275f6c9dd632885819ef9174502cd4f75a68367484022",
+				"KeyExpiry":  "2026-11-09T09:16:38Z",
+				"DiscoKey":   "discokey:ba73117d5dc25aa3894fcf29c41b93d5c3fe1a75ae7fe523a4e3e19f970ed538",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45196",
+					"10.65.0.27:45196",
+					"172.17.0.1:45196",
+					"172.18.0.1:45196",
+					"172.19.0.1:45196",
+					"172.20.0.1:45196",
+					"172.21.0.1:45196",
+					"172.22.0.1:45196",
+					"172.23.0.1:45196",
+					"172.24.0.1:45196",
+					"172.25.0.1:45196",
+					"172.26.0.1:45196",
+					"172.27.0.1:45196",
+					"172.28.0.1:45196"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:16:38.177732012Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3438518289772750,
+				"StableID":   "nBDecb3KrT11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5a701bba6af81b1d3119253be60d716401f2d9a50fd5dc50536113b0a9f08660",
+				"KeyExpiry":  "2026-11-09T09:16:38Z",
+				"DiscoKey":   "discokey:1927d7fbdb293edda5e8619c4dca14d6e7d7e05c5ede001b380a2f08c4989172",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55365",
+					"10.65.0.27:55365",
+					"172.17.0.1:55365",
+					"172.18.0.1:55365",
+					"172.19.0.1:55365",
+					"172.20.0.1:55365",
+					"172.21.0.1:55365",
+					"172.22.0.1:55365",
+					"172.23.0.1:55365",
+					"172.24.0.1:55365",
+					"172.25.0.1:55365",
+					"172.26.0.1:55365",
+					"172.27.0.1:55365",
+					"172.28.0.1:55365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:16:38.715741477Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4232648330810505,
+				"StableID":   "npaHyfVy3a11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7b5184612ccbb8983f218368c8035d305c0fa4a6092021190b0a05b953b10425",
+				"KeyExpiry":  "2026-11-09T09:16:39Z",
+				"DiscoKey":   "discokey:5208598b8cac01e196a19a8d49f96773a9835d24c68bd69598a5937f23c63e4a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56825",
+					"10.65.0.27:56825",
+					"172.17.0.1:56825",
+					"172.18.0.1:56825",
+					"172.19.0.1:56825",
+					"172.20.0.1:56825",
+					"172.21.0.1:56825",
+					"172.22.0.1:56825",
+					"172.23.0.1:56825",
+					"172.24.0.1:56825",
+					"172.25.0.1:56825",
+					"172.26.0.1:56825",
+					"172.27.0.1:56825",
+					"172.28.0.1:56825"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:16:39.250040788Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4544457554236945": {
+				"ID":          4544457554236945,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3801184942400324,
+				"StableID":   "nFxBpbgZgW11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       3801184942400324,
+				"Key":        "nodekey:44da45e66d237c8652357ce0f54e681b03f91770691f28f892bfdc6578829b7f",
+				"DiscoKey":   "discokey:0a2146d82fda5c146aabe7ee1b17633e2d84035a208c13978301b706fe33cc1b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41449",
+					"10.65.0.27:41449",
+					"172.17.0.1:41449",
+					"172.18.0.1:41449",
+					"172.19.0.1:41449",
+					"172.20.0.1:41449",
+					"172.21.0.1:41449",
+					"172.22.0.1:41449",
+					"172.23.0.1:41449",
+					"172.24.0.1:41449",
+					"172.25.0.1:41449",
+					"172.26.0.1:41449",
+					"172.27.0.1:41449",
+					"172.28.0.1:41449"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:16:33.846892606Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:44da45e66d237c8652357ce0f54e681b03f91770691f28f892bfdc6578829b7f",
+			"MachineKey": "mkey:eceea36a598dbc54569a2ec3627396c8cf3626779061a7076a13bedd9ad80648",
+			"Peers": [{
+				"ID":         4544457554236945,
+				"StableID":   "n84eJFCCVc11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb69a9a3fd98283abb5b824a0e46b6d27ce37cc55932b72bf440c437db22d237",
+				"DiscoKey":   "discokey:a578f456e0138f1dc305b742ef3a500571ec5fd487a809b1117a6c8c9b000249",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36024",
+					"10.65.0.27:36024",
+					"172.17.0.1:36024",
+					"172.18.0.1:36024",
+					"172.19.0.1:36024",
+					"172.20.0.1:36024",
+					"172.21.0.1:36024",
+					"172.22.0.1:36024",
+					"172.23.0.1:36024",
+					"172.24.0.1:36024",
+					"172.25.0.1:36024",
+					"172.26.0.1:36024",
+					"172.27.0.1:36024",
+					"172.28.0.1:36024"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:16:31.110445532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2009417783924731,
+				"StableID":   "npXydsz4hG11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:753aa05e1103d96f6c54ad81c74c07654ed38a7353ab11489bb6a33dd824ed2d",
+				"DiscoKey":   "discokey:418bd024545893836054b8e180770ce90aea857fb8398f41a30ba280ca2c6901",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:56408",
+					"10.65.0.27:56408",
+					"172.17.0.1:56408",
+					"172.18.0.1:56408",
+					"172.19.0.1:56408",
+					"172.20.0.1:56408",
+					"172.21.0.1:56408",
+					"172.22.0.1:56408",
+					"172.23.0.1:56408",
+					"172.24.0.1:56408",
+					"172.25.0.1:56408",
+					"172.26.0.1:56408",
+					"172.27.0.1:56408",
+					"172.28.0.1:56408"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:16:31.735738377Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4637492199793181,
+				"StableID":   "ngYHMG4LDd11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:49c1763a9be9eb89c359f01714a9d818ad37ae4baa05b6f8eea689a62711b971",
+				"DiscoKey":   "discokey:9d3c95541d5aad0f118e534d243d71ea498d2660bb3554b8b3cc1ee21751c76e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36617",
+					"10.65.0.27:36617",
+					"172.17.0.1:36617",
+					"172.18.0.1:36617",
+					"172.19.0.1:36617",
+					"172.20.0.1:36617",
+					"172.21.0.1:36617",
+					"172.22.0.1:36617",
+					"172.23.0.1:36617",
+					"172.24.0.1:36617",
+					"172.25.0.1:36617",
+					"172.26.0.1:36617",
+					"172.27.0.1:36617",
+					"172.28.0.1:36617"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:16:32.261223987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4527847942638130,
+				"StableID":   "nTudoUtfMc11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:893b1cf6338cd631a24f7a3f0b8d1cfec096306fd567160a19137374b8cdb158",
+				"DiscoKey":   "discokey:df102ddc65336ee2f5ead02501b0db365aa9c7e90d446f0e4d98f3c223543b6e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59980",
+					"10.65.0.27:59980",
+					"172.17.0.1:59980",
+					"172.18.0.1:59980",
+					"172.19.0.1:59980",
+					"172.20.0.1:59980",
+					"172.21.0.1:59980",
+					"172.22.0.1:59980",
+					"172.23.0.1:59980",
+					"172.24.0.1:59980",
+					"172.25.0.1:59980",
+					"172.26.0.1:59980",
+					"172.27.0.1:59980",
+					"172.28.0.1:59980"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:16:33.317360859Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2884204743856928,
+				"StableID":   "nFNjijAGXP11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2288cbc791982d1febb37aa4632bca2afa58382205fa1debb16cb33c5097810f",
+				"DiscoKey":   "discokey:86ee1b0358dbe766533ecd96fb31297444a367bce9a7f65d63f1c21f6d189140",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50881",
+					"10.65.0.27:50881",
+					"172.17.0.1:50881",
+					"172.18.0.1:50881",
+					"172.19.0.1:50881",
+					"172.20.0.1:50881",
+					"172.21.0.1:50881",
+					"172.22.0.1:50881",
+					"172.23.0.1:50881",
+					"172.24.0.1:50881",
+					"172.25.0.1:50881",
+					"172.26.0.1:50881",
+					"172.27.0.1:50881",
+					"172.28.0.1:50881"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:16:34.38370158Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8068649566328922,
+				"StableID":   "nF7HP3kJ1621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dab39f217dc07a9a7265f9276d64ea1f59d461acb0ec058bd6e6cca4def2bb64",
+				"DiscoKey":   "discokey:63b9dca87a0d91279a35610d3029c6e7ce8bd5f800b5b9ac30f4386c49691c49",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44693",
+					"10.65.0.27:44693",
+					"172.17.0.1:44693",
+					"172.18.0.1:44693",
+					"172.19.0.1:44693",
+					"172.20.0.1:44693",
+					"172.21.0.1:44693",
+					"172.22.0.1:44693",
+					"172.23.0.1:44693",
+					"172.24.0.1:44693",
+					"172.25.0.1:44693",
+					"172.26.0.1:44693",
+					"172.27.0.1:44693",
+					"172.28.0.1:44693"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:16:34.900934564Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4294990921984530,
+				"StableID":   "nwMgGT8DYa11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:abbf2a0b102da082048e4a7e17a105a4731374fbd704134435b087699cb8607e",
+				"DiscoKey":   "discokey:b23fd71a513c8f30044586a0f38c845ae12cd58bbd3bb8a99ec9ddefa0b39e63",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50929",
+					"10.65.0.27:50929",
+					"172.17.0.1:50929",
+					"172.18.0.1:50929",
+					"172.19.0.1:50929",
+					"172.20.0.1:50929",
+					"172.21.0.1:50929",
+					"172.22.0.1:50929",
+					"172.23.0.1:50929",
+					"172.24.0.1:50929",
+					"172.25.0.1:50929",
+					"172.26.0.1:50929",
+					"172.27.0.1:50929",
+					"172.28.0.1:50929"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:16:35.432173376Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6683286104949244,
+				"StableID":   "ny7sFQbsBu11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4bb754b07a5725035b3bd889a8892ceaca64bdae3e2ad880ef302c3028b95e0d",
+				"DiscoKey":   "discokey:dd7a82d53b4b91c6f52539b4232687a61b1916e0c668b5007b4174fdee16137e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39866",
+					"10.65.0.27:39866",
+					"172.17.0.1:39866",
+					"172.18.0.1:39866",
+					"172.19.0.1:39866",
+					"172.20.0.1:39866",
+					"172.21.0.1:39866",
+					"172.22.0.1:39866",
+					"172.23.0.1:39866",
+					"172.24.0.1:39866",
+					"172.25.0.1:39866",
+					"172.26.0.1:39866",
+					"172.27.0.1:39866",
+					"172.28.0.1:39866"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:16:35.972074185Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2789200956428515,
+				"StableID":   "nc9HMcaEnN11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1d10f62d48a41ae8f2ff37f709fc71c9771d3ecae79f5888dbf5e9178e8fd43b",
+				"DiscoKey":   "discokey:4b0eeb701ea2de2e741363d16e822b997ceae786c7154214b8491f24e09e4d56",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49056",
+					"10.65.0.27:49056",
+					"172.17.0.1:49056",
+					"172.18.0.1:49056",
+					"172.19.0.1:49056",
+					"172.20.0.1:49056",
+					"172.21.0.1:49056",
+					"172.22.0.1:49056",
+					"172.23.0.1:49056",
+					"172.24.0.1:49056",
+					"172.25.0.1:49056",
+					"172.26.0.1:49056",
+					"172.27.0.1:49056",
+					"172.28.0.1:49056"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:16:36.504343844Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3136722346387547,
+				"StableID":   "nYZrYsNdVR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1c5c6665c13e9cffa7c924b2434ac58dd7c98cae7b7d0c82ae75f674d2c5064",
+				"DiscoKey":   "discokey:17e5772ce8a8e2c92ecda771799f562d4676d35fdc8174abb7aa966e89752703",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:59410",
+					"10.65.0.27:59410",
+					"172.17.0.1:59410",
+					"172.18.0.1:59410",
+					"172.19.0.1:59410",
+					"172.20.0.1:59410",
+					"172.21.0.1:59410",
+					"172.22.0.1:59410",
+					"172.23.0.1:59410",
+					"172.24.0.1:59410",
+					"172.25.0.1:59410",
+					"172.26.0.1:59410",
+					"172.27.0.1:59410",
+					"172.28.0.1:59410"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:16:37.031283368Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8655535422778369,
+				"StableID":   "nkLhppE7bA21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51ea7fe1af6a214a081f391094984c7ffc0ada6e7b0f955269cf478437343d37",
+				"DiscoKey":   "discokey:c613e971fe0d620109ca52c5e53ae02ef23e0da58e5e3fcd53e2225c6c361f49",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:57088",
+					"10.65.0.27:57088",
+					"172.17.0.1:57088",
+					"172.18.0.1:57088",
+					"172.19.0.1:57088",
+					"172.20.0.1:57088",
+					"172.21.0.1:57088",
+					"172.22.0.1:57088",
+					"172.23.0.1:57088",
+					"172.24.0.1:57088",
+					"172.25.0.1:57088",
+					"172.26.0.1:57088",
+					"172.27.0.1:57088",
+					"172.28.0.1:57088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:16:37.584099691Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8817121571615835,
+				"StableID":   "nLqDUHqHrB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ff438b3d370ac7e8535275f6c9dd632885819ef9174502cd4f75a68367484022",
+				"KeyExpiry":  "2026-11-09T09:16:38Z",
+				"DiscoKey":   "discokey:ba73117d5dc25aa3894fcf29c41b93d5c3fe1a75ae7fe523a4e3e19f970ed538",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45196",
+					"10.65.0.27:45196",
+					"172.17.0.1:45196",
+					"172.18.0.1:45196",
+					"172.19.0.1:45196",
+					"172.20.0.1:45196",
+					"172.21.0.1:45196",
+					"172.22.0.1:45196",
+					"172.23.0.1:45196",
+					"172.24.0.1:45196",
+					"172.25.0.1:45196",
+					"172.26.0.1:45196",
+					"172.27.0.1:45196",
+					"172.28.0.1:45196"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:16:38.177732012Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3438518289772750,
+				"StableID":   "nBDecb3KrT11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5a701bba6af81b1d3119253be60d716401f2d9a50fd5dc50536113b0a9f08660",
+				"KeyExpiry":  "2026-11-09T09:16:38Z",
+				"DiscoKey":   "discokey:1927d7fbdb293edda5e8619c4dca14d6e7d7e05c5ede001b380a2f08c4989172",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55365",
+					"10.65.0.27:55365",
+					"172.17.0.1:55365",
+					"172.18.0.1:55365",
+					"172.19.0.1:55365",
+					"172.20.0.1:55365",
+					"172.21.0.1:55365",
+					"172.22.0.1:55365",
+					"172.23.0.1:55365",
+					"172.24.0.1:55365",
+					"172.25.0.1:55365",
+					"172.26.0.1:55365",
+					"172.27.0.1:55365",
+					"172.28.0.1:55365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:16:38.715741477Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4232648330810505,
+				"StableID":   "npaHyfVy3a11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7b5184612ccbb8983f218368c8035d305c0fa4a6092021190b0a05b953b10425",
+				"KeyExpiry":  "2026-11-09T09:16:39Z",
+				"DiscoKey":   "discokey:5208598b8cac01e196a19a8d49f96773a9835d24c68bd69598a5937f23c63e4a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56825",
+					"10.65.0.27:56825",
+					"172.17.0.1:56825",
+					"172.18.0.1:56825",
+					"172.19.0.1:56825",
+					"172.20.0.1:56825",
+					"172.21.0.1:56825",
+					"172.22.0.1:56825",
+					"172.23.0.1:56825",
+					"172.24.0.1:56825",
+					"172.25.0.1:56825",
+					"172.26.0.1:56825",
+					"172.27.0.1:56825",
+					"172.28.0.1:56825"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:16:39.250040788Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3801184942400324": {
+				"ID":          3801184942400324,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4527847942638130,
+				"StableID":   "nTudoUtfMc11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       4527847942638130,
+				"Key":        "nodekey:893b1cf6338cd631a24f7a3f0b8d1cfec096306fd567160a19137374b8cdb158",
+				"DiscoKey":   "discokey:df102ddc65336ee2f5ead02501b0db365aa9c7e90d446f0e4d98f3c223543b6e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59980",
+					"10.65.0.27:59980",
+					"172.17.0.1:59980",
+					"172.18.0.1:59980",
+					"172.19.0.1:59980",
+					"172.20.0.1:59980",
+					"172.21.0.1:59980",
+					"172.22.0.1:59980",
+					"172.23.0.1:59980",
+					"172.24.0.1:59980",
+					"172.25.0.1:59980",
+					"172.26.0.1:59980",
+					"172.27.0.1:59980",
+					"172.28.0.1:59980"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:16:33.317360859Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:893b1cf6338cd631a24f7a3f0b8d1cfec096306fd567160a19137374b8cdb158",
+			"MachineKey": "mkey:a141a9e427a9fef7cf4e6f7d8c8cb2ff306c32e3dabe7c0a9c969a586a34617a",
+			"Peers": [{
+				"ID":         4544457554236945,
+				"StableID":   "n84eJFCCVc11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb69a9a3fd98283abb5b824a0e46b6d27ce37cc55932b72bf440c437db22d237",
+				"DiscoKey":   "discokey:a578f456e0138f1dc305b742ef3a500571ec5fd487a809b1117a6c8c9b000249",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36024",
+					"10.65.0.27:36024",
+					"172.17.0.1:36024",
+					"172.18.0.1:36024",
+					"172.19.0.1:36024",
+					"172.20.0.1:36024",
+					"172.21.0.1:36024",
+					"172.22.0.1:36024",
+					"172.23.0.1:36024",
+					"172.24.0.1:36024",
+					"172.25.0.1:36024",
+					"172.26.0.1:36024",
+					"172.27.0.1:36024",
+					"172.28.0.1:36024"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:16:31.110445532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2009417783924731,
+				"StableID":   "npXydsz4hG11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:753aa05e1103d96f6c54ad81c74c07654ed38a7353ab11489bb6a33dd824ed2d",
+				"DiscoKey":   "discokey:418bd024545893836054b8e180770ce90aea857fb8398f41a30ba280ca2c6901",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:56408",
+					"10.65.0.27:56408",
+					"172.17.0.1:56408",
+					"172.18.0.1:56408",
+					"172.19.0.1:56408",
+					"172.20.0.1:56408",
+					"172.21.0.1:56408",
+					"172.22.0.1:56408",
+					"172.23.0.1:56408",
+					"172.24.0.1:56408",
+					"172.25.0.1:56408",
+					"172.26.0.1:56408",
+					"172.27.0.1:56408",
+					"172.28.0.1:56408"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:16:31.735738377Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4637492199793181,
+				"StableID":   "ngYHMG4LDd11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:49c1763a9be9eb89c359f01714a9d818ad37ae4baa05b6f8eea689a62711b971",
+				"DiscoKey":   "discokey:9d3c95541d5aad0f118e534d243d71ea498d2660bb3554b8b3cc1ee21751c76e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36617",
+					"10.65.0.27:36617",
+					"172.17.0.1:36617",
+					"172.18.0.1:36617",
+					"172.19.0.1:36617",
+					"172.20.0.1:36617",
+					"172.21.0.1:36617",
+					"172.22.0.1:36617",
+					"172.23.0.1:36617",
+					"172.24.0.1:36617",
+					"172.25.0.1:36617",
+					"172.26.0.1:36617",
+					"172.27.0.1:36617",
+					"172.28.0.1:36617"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:16:32.261223987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3801184942400324,
+				"StableID":   "nFxBpbgZgW11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:44da45e66d237c8652357ce0f54e681b03f91770691f28f892bfdc6578829b7f",
+				"DiscoKey":   "discokey:0a2146d82fda5c146aabe7ee1b17633e2d84035a208c13978301b706fe33cc1b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41449",
+					"10.65.0.27:41449",
+					"172.17.0.1:41449",
+					"172.18.0.1:41449",
+					"172.19.0.1:41449",
+					"172.20.0.1:41449",
+					"172.21.0.1:41449",
+					"172.22.0.1:41449",
+					"172.23.0.1:41449",
+					"172.24.0.1:41449",
+					"172.25.0.1:41449",
+					"172.26.0.1:41449",
+					"172.27.0.1:41449",
+					"172.28.0.1:41449"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:16:33.846892606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2884204743856928,
+				"StableID":   "nFNjijAGXP11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2288cbc791982d1febb37aa4632bca2afa58382205fa1debb16cb33c5097810f",
+				"DiscoKey":   "discokey:86ee1b0358dbe766533ecd96fb31297444a367bce9a7f65d63f1c21f6d189140",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50881",
+					"10.65.0.27:50881",
+					"172.17.0.1:50881",
+					"172.18.0.1:50881",
+					"172.19.0.1:50881",
+					"172.20.0.1:50881",
+					"172.21.0.1:50881",
+					"172.22.0.1:50881",
+					"172.23.0.1:50881",
+					"172.24.0.1:50881",
+					"172.25.0.1:50881",
+					"172.26.0.1:50881",
+					"172.27.0.1:50881",
+					"172.28.0.1:50881"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:16:34.38370158Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8068649566328922,
+				"StableID":   "nF7HP3kJ1621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dab39f217dc07a9a7265f9276d64ea1f59d461acb0ec058bd6e6cca4def2bb64",
+				"DiscoKey":   "discokey:63b9dca87a0d91279a35610d3029c6e7ce8bd5f800b5b9ac30f4386c49691c49",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44693",
+					"10.65.0.27:44693",
+					"172.17.0.1:44693",
+					"172.18.0.1:44693",
+					"172.19.0.1:44693",
+					"172.20.0.1:44693",
+					"172.21.0.1:44693",
+					"172.22.0.1:44693",
+					"172.23.0.1:44693",
+					"172.24.0.1:44693",
+					"172.25.0.1:44693",
+					"172.26.0.1:44693",
+					"172.27.0.1:44693",
+					"172.28.0.1:44693"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:16:34.900934564Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4294990921984530,
+				"StableID":   "nwMgGT8DYa11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:abbf2a0b102da082048e4a7e17a105a4731374fbd704134435b087699cb8607e",
+				"DiscoKey":   "discokey:b23fd71a513c8f30044586a0f38c845ae12cd58bbd3bb8a99ec9ddefa0b39e63",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50929",
+					"10.65.0.27:50929",
+					"172.17.0.1:50929",
+					"172.18.0.1:50929",
+					"172.19.0.1:50929",
+					"172.20.0.1:50929",
+					"172.21.0.1:50929",
+					"172.22.0.1:50929",
+					"172.23.0.1:50929",
+					"172.24.0.1:50929",
+					"172.25.0.1:50929",
+					"172.26.0.1:50929",
+					"172.27.0.1:50929",
+					"172.28.0.1:50929"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:16:35.432173376Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6683286104949244,
+				"StableID":   "ny7sFQbsBu11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4bb754b07a5725035b3bd889a8892ceaca64bdae3e2ad880ef302c3028b95e0d",
+				"DiscoKey":   "discokey:dd7a82d53b4b91c6f52539b4232687a61b1916e0c668b5007b4174fdee16137e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39866",
+					"10.65.0.27:39866",
+					"172.17.0.1:39866",
+					"172.18.0.1:39866",
+					"172.19.0.1:39866",
+					"172.20.0.1:39866",
+					"172.21.0.1:39866",
+					"172.22.0.1:39866",
+					"172.23.0.1:39866",
+					"172.24.0.1:39866",
+					"172.25.0.1:39866",
+					"172.26.0.1:39866",
+					"172.27.0.1:39866",
+					"172.28.0.1:39866"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:16:35.972074185Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2789200956428515,
+				"StableID":   "nc9HMcaEnN11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1d10f62d48a41ae8f2ff37f709fc71c9771d3ecae79f5888dbf5e9178e8fd43b",
+				"DiscoKey":   "discokey:4b0eeb701ea2de2e741363d16e822b997ceae786c7154214b8491f24e09e4d56",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49056",
+					"10.65.0.27:49056",
+					"172.17.0.1:49056",
+					"172.18.0.1:49056",
+					"172.19.0.1:49056",
+					"172.20.0.1:49056",
+					"172.21.0.1:49056",
+					"172.22.0.1:49056",
+					"172.23.0.1:49056",
+					"172.24.0.1:49056",
+					"172.25.0.1:49056",
+					"172.26.0.1:49056",
+					"172.27.0.1:49056",
+					"172.28.0.1:49056"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:16:36.504343844Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3136722346387547,
+				"StableID":   "nYZrYsNdVR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1c5c6665c13e9cffa7c924b2434ac58dd7c98cae7b7d0c82ae75f674d2c5064",
+				"DiscoKey":   "discokey:17e5772ce8a8e2c92ecda771799f562d4676d35fdc8174abb7aa966e89752703",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:59410",
+					"10.65.0.27:59410",
+					"172.17.0.1:59410",
+					"172.18.0.1:59410",
+					"172.19.0.1:59410",
+					"172.20.0.1:59410",
+					"172.21.0.1:59410",
+					"172.22.0.1:59410",
+					"172.23.0.1:59410",
+					"172.24.0.1:59410",
+					"172.25.0.1:59410",
+					"172.26.0.1:59410",
+					"172.27.0.1:59410",
+					"172.28.0.1:59410"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:16:37.031283368Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8655535422778369,
+				"StableID":   "nkLhppE7bA21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51ea7fe1af6a214a081f391094984c7ffc0ada6e7b0f955269cf478437343d37",
+				"DiscoKey":   "discokey:c613e971fe0d620109ca52c5e53ae02ef23e0da58e5e3fcd53e2225c6c361f49",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:57088",
+					"10.65.0.27:57088",
+					"172.17.0.1:57088",
+					"172.18.0.1:57088",
+					"172.19.0.1:57088",
+					"172.20.0.1:57088",
+					"172.21.0.1:57088",
+					"172.22.0.1:57088",
+					"172.23.0.1:57088",
+					"172.24.0.1:57088",
+					"172.25.0.1:57088",
+					"172.26.0.1:57088",
+					"172.27.0.1:57088",
+					"172.28.0.1:57088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:16:37.584099691Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8817121571615835,
+				"StableID":   "nLqDUHqHrB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ff438b3d370ac7e8535275f6c9dd632885819ef9174502cd4f75a68367484022",
+				"KeyExpiry":  "2026-11-09T09:16:38Z",
+				"DiscoKey":   "discokey:ba73117d5dc25aa3894fcf29c41b93d5c3fe1a75ae7fe523a4e3e19f970ed538",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45196",
+					"10.65.0.27:45196",
+					"172.17.0.1:45196",
+					"172.18.0.1:45196",
+					"172.19.0.1:45196",
+					"172.20.0.1:45196",
+					"172.21.0.1:45196",
+					"172.22.0.1:45196",
+					"172.23.0.1:45196",
+					"172.24.0.1:45196",
+					"172.25.0.1:45196",
+					"172.26.0.1:45196",
+					"172.27.0.1:45196",
+					"172.28.0.1:45196"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:16:38.177732012Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3438518289772750,
+				"StableID":   "nBDecb3KrT11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5a701bba6af81b1d3119253be60d716401f2d9a50fd5dc50536113b0a9f08660",
+				"KeyExpiry":  "2026-11-09T09:16:38Z",
+				"DiscoKey":   "discokey:1927d7fbdb293edda5e8619c4dca14d6e7d7e05c5ede001b380a2f08c4989172",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55365",
+					"10.65.0.27:55365",
+					"172.17.0.1:55365",
+					"172.18.0.1:55365",
+					"172.19.0.1:55365",
+					"172.20.0.1:55365",
+					"172.21.0.1:55365",
+					"172.22.0.1:55365",
+					"172.23.0.1:55365",
+					"172.24.0.1:55365",
+					"172.25.0.1:55365",
+					"172.26.0.1:55365",
+					"172.27.0.1:55365",
+					"172.28.0.1:55365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:16:38.715741477Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4232648330810505,
+				"StableID":   "npaHyfVy3a11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7b5184612ccbb8983f218368c8035d305c0fa4a6092021190b0a05b953b10425",
+				"KeyExpiry":  "2026-11-09T09:16:39Z",
+				"DiscoKey":   "discokey:5208598b8cac01e196a19a8d49f96773a9835d24c68bd69598a5937f23c63e4a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56825",
+					"10.65.0.27:56825",
+					"172.17.0.1:56825",
+					"172.18.0.1:56825",
+					"172.19.0.1:56825",
+					"172.20.0.1:56825",
+					"172.21.0.1:56825",
+					"172.22.0.1:56825",
+					"172.23.0.1:56825",
+					"172.24.0.1:56825",
+					"172.25.0.1:56825",
+					"172.26.0.1:56825",
+					"172.27.0.1:56825",
+					"172.28.0.1:56825"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:16:39.250040788Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4527847942638130": {
+				"ID":          4527847942638130,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8068649566328922,
+				"StableID":   "nF7HP3kJ1621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       8068649566328922,
+				"Key":        "nodekey:dab39f217dc07a9a7265f9276d64ea1f59d461acb0ec058bd6e6cca4def2bb64",
+				"DiscoKey":   "discokey:63b9dca87a0d91279a35610d3029c6e7ce8bd5f800b5b9ac30f4386c49691c49",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44693",
+					"10.65.0.27:44693",
+					"172.17.0.1:44693",
+					"172.18.0.1:44693",
+					"172.19.0.1:44693",
+					"172.20.0.1:44693",
+					"172.21.0.1:44693",
+					"172.22.0.1:44693",
+					"172.23.0.1:44693",
+					"172.24.0.1:44693",
+					"172.25.0.1:44693",
+					"172.26.0.1:44693",
+					"172.27.0.1:44693",
+					"172.28.0.1:44693"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:16:34.900934564Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:dab39f217dc07a9a7265f9276d64ea1f59d461acb0ec058bd6e6cca4def2bb64",
+			"MachineKey": "mkey:e1624d384856ccd8976b1e4f80c0ce87652448c9dde7914ec7ab3f887fdcae0e",
+			"Peers": [{
+				"ID":         4544457554236945,
+				"StableID":   "n84eJFCCVc11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb69a9a3fd98283abb5b824a0e46b6d27ce37cc55932b72bf440c437db22d237",
+				"DiscoKey":   "discokey:a578f456e0138f1dc305b742ef3a500571ec5fd487a809b1117a6c8c9b000249",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36024",
+					"10.65.0.27:36024",
+					"172.17.0.1:36024",
+					"172.18.0.1:36024",
+					"172.19.0.1:36024",
+					"172.20.0.1:36024",
+					"172.21.0.1:36024",
+					"172.22.0.1:36024",
+					"172.23.0.1:36024",
+					"172.24.0.1:36024",
+					"172.25.0.1:36024",
+					"172.26.0.1:36024",
+					"172.27.0.1:36024",
+					"172.28.0.1:36024"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:16:31.110445532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2009417783924731,
+				"StableID":   "npXydsz4hG11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:753aa05e1103d96f6c54ad81c74c07654ed38a7353ab11489bb6a33dd824ed2d",
+				"DiscoKey":   "discokey:418bd024545893836054b8e180770ce90aea857fb8398f41a30ba280ca2c6901",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:56408",
+					"10.65.0.27:56408",
+					"172.17.0.1:56408",
+					"172.18.0.1:56408",
+					"172.19.0.1:56408",
+					"172.20.0.1:56408",
+					"172.21.0.1:56408",
+					"172.22.0.1:56408",
+					"172.23.0.1:56408",
+					"172.24.0.1:56408",
+					"172.25.0.1:56408",
+					"172.26.0.1:56408",
+					"172.27.0.1:56408",
+					"172.28.0.1:56408"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:16:31.735738377Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4637492199793181,
+				"StableID":   "ngYHMG4LDd11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:49c1763a9be9eb89c359f01714a9d818ad37ae4baa05b6f8eea689a62711b971",
+				"DiscoKey":   "discokey:9d3c95541d5aad0f118e534d243d71ea498d2660bb3554b8b3cc1ee21751c76e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36617",
+					"10.65.0.27:36617",
+					"172.17.0.1:36617",
+					"172.18.0.1:36617",
+					"172.19.0.1:36617",
+					"172.20.0.1:36617",
+					"172.21.0.1:36617",
+					"172.22.0.1:36617",
+					"172.23.0.1:36617",
+					"172.24.0.1:36617",
+					"172.25.0.1:36617",
+					"172.26.0.1:36617",
+					"172.27.0.1:36617",
+					"172.28.0.1:36617"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:16:32.261223987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4527847942638130,
+				"StableID":   "nTudoUtfMc11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:893b1cf6338cd631a24f7a3f0b8d1cfec096306fd567160a19137374b8cdb158",
+				"DiscoKey":   "discokey:df102ddc65336ee2f5ead02501b0db365aa9c7e90d446f0e4d98f3c223543b6e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59980",
+					"10.65.0.27:59980",
+					"172.17.0.1:59980",
+					"172.18.0.1:59980",
+					"172.19.0.1:59980",
+					"172.20.0.1:59980",
+					"172.21.0.1:59980",
+					"172.22.0.1:59980",
+					"172.23.0.1:59980",
+					"172.24.0.1:59980",
+					"172.25.0.1:59980",
+					"172.26.0.1:59980",
+					"172.27.0.1:59980",
+					"172.28.0.1:59980"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:16:33.317360859Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3801184942400324,
+				"StableID":   "nFxBpbgZgW11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:44da45e66d237c8652357ce0f54e681b03f91770691f28f892bfdc6578829b7f",
+				"DiscoKey":   "discokey:0a2146d82fda5c146aabe7ee1b17633e2d84035a208c13978301b706fe33cc1b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41449",
+					"10.65.0.27:41449",
+					"172.17.0.1:41449",
+					"172.18.0.1:41449",
+					"172.19.0.1:41449",
+					"172.20.0.1:41449",
+					"172.21.0.1:41449",
+					"172.22.0.1:41449",
+					"172.23.0.1:41449",
+					"172.24.0.1:41449",
+					"172.25.0.1:41449",
+					"172.26.0.1:41449",
+					"172.27.0.1:41449",
+					"172.28.0.1:41449"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:16:33.846892606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2884204743856928,
+				"StableID":   "nFNjijAGXP11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2288cbc791982d1febb37aa4632bca2afa58382205fa1debb16cb33c5097810f",
+				"DiscoKey":   "discokey:86ee1b0358dbe766533ecd96fb31297444a367bce9a7f65d63f1c21f6d189140",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50881",
+					"10.65.0.27:50881",
+					"172.17.0.1:50881",
+					"172.18.0.1:50881",
+					"172.19.0.1:50881",
+					"172.20.0.1:50881",
+					"172.21.0.1:50881",
+					"172.22.0.1:50881",
+					"172.23.0.1:50881",
+					"172.24.0.1:50881",
+					"172.25.0.1:50881",
+					"172.26.0.1:50881",
+					"172.27.0.1:50881",
+					"172.28.0.1:50881"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:16:34.38370158Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4294990921984530,
+				"StableID":   "nwMgGT8DYa11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:abbf2a0b102da082048e4a7e17a105a4731374fbd704134435b087699cb8607e",
+				"DiscoKey":   "discokey:b23fd71a513c8f30044586a0f38c845ae12cd58bbd3bb8a99ec9ddefa0b39e63",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50929",
+					"10.65.0.27:50929",
+					"172.17.0.1:50929",
+					"172.18.0.1:50929",
+					"172.19.0.1:50929",
+					"172.20.0.1:50929",
+					"172.21.0.1:50929",
+					"172.22.0.1:50929",
+					"172.23.0.1:50929",
+					"172.24.0.1:50929",
+					"172.25.0.1:50929",
+					"172.26.0.1:50929",
+					"172.27.0.1:50929",
+					"172.28.0.1:50929"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:16:35.432173376Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6683286104949244,
+				"StableID":   "ny7sFQbsBu11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4bb754b07a5725035b3bd889a8892ceaca64bdae3e2ad880ef302c3028b95e0d",
+				"DiscoKey":   "discokey:dd7a82d53b4b91c6f52539b4232687a61b1916e0c668b5007b4174fdee16137e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39866",
+					"10.65.0.27:39866",
+					"172.17.0.1:39866",
+					"172.18.0.1:39866",
+					"172.19.0.1:39866",
+					"172.20.0.1:39866",
+					"172.21.0.1:39866",
+					"172.22.0.1:39866",
+					"172.23.0.1:39866",
+					"172.24.0.1:39866",
+					"172.25.0.1:39866",
+					"172.26.0.1:39866",
+					"172.27.0.1:39866",
+					"172.28.0.1:39866"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:16:35.972074185Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2789200956428515,
+				"StableID":   "nc9HMcaEnN11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1d10f62d48a41ae8f2ff37f709fc71c9771d3ecae79f5888dbf5e9178e8fd43b",
+				"DiscoKey":   "discokey:4b0eeb701ea2de2e741363d16e822b997ceae786c7154214b8491f24e09e4d56",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49056",
+					"10.65.0.27:49056",
+					"172.17.0.1:49056",
+					"172.18.0.1:49056",
+					"172.19.0.1:49056",
+					"172.20.0.1:49056",
+					"172.21.0.1:49056",
+					"172.22.0.1:49056",
+					"172.23.0.1:49056",
+					"172.24.0.1:49056",
+					"172.25.0.1:49056",
+					"172.26.0.1:49056",
+					"172.27.0.1:49056",
+					"172.28.0.1:49056"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:16:36.504343844Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3136722346387547,
+				"StableID":   "nYZrYsNdVR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1c5c6665c13e9cffa7c924b2434ac58dd7c98cae7b7d0c82ae75f674d2c5064",
+				"DiscoKey":   "discokey:17e5772ce8a8e2c92ecda771799f562d4676d35fdc8174abb7aa966e89752703",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:59410",
+					"10.65.0.27:59410",
+					"172.17.0.1:59410",
+					"172.18.0.1:59410",
+					"172.19.0.1:59410",
+					"172.20.0.1:59410",
+					"172.21.0.1:59410",
+					"172.22.0.1:59410",
+					"172.23.0.1:59410",
+					"172.24.0.1:59410",
+					"172.25.0.1:59410",
+					"172.26.0.1:59410",
+					"172.27.0.1:59410",
+					"172.28.0.1:59410"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:16:37.031283368Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8655535422778369,
+				"StableID":   "nkLhppE7bA21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51ea7fe1af6a214a081f391094984c7ffc0ada6e7b0f955269cf478437343d37",
+				"DiscoKey":   "discokey:c613e971fe0d620109ca52c5e53ae02ef23e0da58e5e3fcd53e2225c6c361f49",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:57088",
+					"10.65.0.27:57088",
+					"172.17.0.1:57088",
+					"172.18.0.1:57088",
+					"172.19.0.1:57088",
+					"172.20.0.1:57088",
+					"172.21.0.1:57088",
+					"172.22.0.1:57088",
+					"172.23.0.1:57088",
+					"172.24.0.1:57088",
+					"172.25.0.1:57088",
+					"172.26.0.1:57088",
+					"172.27.0.1:57088",
+					"172.28.0.1:57088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:16:37.584099691Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8817121571615835,
+				"StableID":   "nLqDUHqHrB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ff438b3d370ac7e8535275f6c9dd632885819ef9174502cd4f75a68367484022",
+				"KeyExpiry":  "2026-11-09T09:16:38Z",
+				"DiscoKey":   "discokey:ba73117d5dc25aa3894fcf29c41b93d5c3fe1a75ae7fe523a4e3e19f970ed538",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45196",
+					"10.65.0.27:45196",
+					"172.17.0.1:45196",
+					"172.18.0.1:45196",
+					"172.19.0.1:45196",
+					"172.20.0.1:45196",
+					"172.21.0.1:45196",
+					"172.22.0.1:45196",
+					"172.23.0.1:45196",
+					"172.24.0.1:45196",
+					"172.25.0.1:45196",
+					"172.26.0.1:45196",
+					"172.27.0.1:45196",
+					"172.28.0.1:45196"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:16:38.177732012Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3438518289772750,
+				"StableID":   "nBDecb3KrT11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5a701bba6af81b1d3119253be60d716401f2d9a50fd5dc50536113b0a9f08660",
+				"KeyExpiry":  "2026-11-09T09:16:38Z",
+				"DiscoKey":   "discokey:1927d7fbdb293edda5e8619c4dca14d6e7d7e05c5ede001b380a2f08c4989172",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55365",
+					"10.65.0.27:55365",
+					"172.17.0.1:55365",
+					"172.18.0.1:55365",
+					"172.19.0.1:55365",
+					"172.20.0.1:55365",
+					"172.21.0.1:55365",
+					"172.22.0.1:55365",
+					"172.23.0.1:55365",
+					"172.24.0.1:55365",
+					"172.25.0.1:55365",
+					"172.26.0.1:55365",
+					"172.27.0.1:55365",
+					"172.28.0.1:55365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:16:38.715741477Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4232648330810505,
+				"StableID":   "npaHyfVy3a11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7b5184612ccbb8983f218368c8035d305c0fa4a6092021190b0a05b953b10425",
+				"KeyExpiry":  "2026-11-09T09:16:39Z",
+				"DiscoKey":   "discokey:5208598b8cac01e196a19a8d49f96773a9835d24c68bd69598a5937f23c63e4a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56825",
+					"10.65.0.27:56825",
+					"172.17.0.1:56825",
+					"172.18.0.1:56825",
+					"172.19.0.1:56825",
+					"172.20.0.1:56825",
+					"172.21.0.1:56825",
+					"172.22.0.1:56825",
+					"172.23.0.1:56825",
+					"172.24.0.1:56825",
+					"172.25.0.1:56825",
+					"172.26.0.1:56825",
+					"172.27.0.1:56825",
+					"172.28.0.1:56825"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:16:39.250040788Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8068649566328922": {
+				"ID":          8068649566328922,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6683286104949244,
+				"StableID":   "ny7sFQbsBu11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       6683286104949244,
+				"Key":        "nodekey:4bb754b07a5725035b3bd889a8892ceaca64bdae3e2ad880ef302c3028b95e0d",
+				"DiscoKey":   "discokey:dd7a82d53b4b91c6f52539b4232687a61b1916e0c668b5007b4174fdee16137e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39866",
+					"10.65.0.27:39866",
+					"172.17.0.1:39866",
+					"172.18.0.1:39866",
+					"172.19.0.1:39866",
+					"172.20.0.1:39866",
+					"172.21.0.1:39866",
+					"172.22.0.1:39866",
+					"172.23.0.1:39866",
+					"172.24.0.1:39866",
+					"172.25.0.1:39866",
+					"172.26.0.1:39866",
+					"172.27.0.1:39866",
+					"172.28.0.1:39866"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:16:35.972074185Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4bb754b07a5725035b3bd889a8892ceaca64bdae3e2ad880ef302c3028b95e0d",
+			"MachineKey": "mkey:bab590d5b664d53cbe11e924ba5cdf14915667043aa822c8b34dc1ccd4cc4251",
+			"Peers": [{
+				"ID":         4544457554236945,
+				"StableID":   "n84eJFCCVc11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb69a9a3fd98283abb5b824a0e46b6d27ce37cc55932b72bf440c437db22d237",
+				"DiscoKey":   "discokey:a578f456e0138f1dc305b742ef3a500571ec5fd487a809b1117a6c8c9b000249",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36024",
+					"10.65.0.27:36024",
+					"172.17.0.1:36024",
+					"172.18.0.1:36024",
+					"172.19.0.1:36024",
+					"172.20.0.1:36024",
+					"172.21.0.1:36024",
+					"172.22.0.1:36024",
+					"172.23.0.1:36024",
+					"172.24.0.1:36024",
+					"172.25.0.1:36024",
+					"172.26.0.1:36024",
+					"172.27.0.1:36024",
+					"172.28.0.1:36024"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:16:31.110445532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2009417783924731,
+				"StableID":   "npXydsz4hG11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:753aa05e1103d96f6c54ad81c74c07654ed38a7353ab11489bb6a33dd824ed2d",
+				"DiscoKey":   "discokey:418bd024545893836054b8e180770ce90aea857fb8398f41a30ba280ca2c6901",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:56408",
+					"10.65.0.27:56408",
+					"172.17.0.1:56408",
+					"172.18.0.1:56408",
+					"172.19.0.1:56408",
+					"172.20.0.1:56408",
+					"172.21.0.1:56408",
+					"172.22.0.1:56408",
+					"172.23.0.1:56408",
+					"172.24.0.1:56408",
+					"172.25.0.1:56408",
+					"172.26.0.1:56408",
+					"172.27.0.1:56408",
+					"172.28.0.1:56408"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:16:31.735738377Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4637492199793181,
+				"StableID":   "ngYHMG4LDd11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:49c1763a9be9eb89c359f01714a9d818ad37ae4baa05b6f8eea689a62711b971",
+				"DiscoKey":   "discokey:9d3c95541d5aad0f118e534d243d71ea498d2660bb3554b8b3cc1ee21751c76e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36617",
+					"10.65.0.27:36617",
+					"172.17.0.1:36617",
+					"172.18.0.1:36617",
+					"172.19.0.1:36617",
+					"172.20.0.1:36617",
+					"172.21.0.1:36617",
+					"172.22.0.1:36617",
+					"172.23.0.1:36617",
+					"172.24.0.1:36617",
+					"172.25.0.1:36617",
+					"172.26.0.1:36617",
+					"172.27.0.1:36617",
+					"172.28.0.1:36617"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:16:32.261223987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4527847942638130,
+				"StableID":   "nTudoUtfMc11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:893b1cf6338cd631a24f7a3f0b8d1cfec096306fd567160a19137374b8cdb158",
+				"DiscoKey":   "discokey:df102ddc65336ee2f5ead02501b0db365aa9c7e90d446f0e4d98f3c223543b6e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59980",
+					"10.65.0.27:59980",
+					"172.17.0.1:59980",
+					"172.18.0.1:59980",
+					"172.19.0.1:59980",
+					"172.20.0.1:59980",
+					"172.21.0.1:59980",
+					"172.22.0.1:59980",
+					"172.23.0.1:59980",
+					"172.24.0.1:59980",
+					"172.25.0.1:59980",
+					"172.26.0.1:59980",
+					"172.27.0.1:59980",
+					"172.28.0.1:59980"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:16:33.317360859Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3801184942400324,
+				"StableID":   "nFxBpbgZgW11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:44da45e66d237c8652357ce0f54e681b03f91770691f28f892bfdc6578829b7f",
+				"DiscoKey":   "discokey:0a2146d82fda5c146aabe7ee1b17633e2d84035a208c13978301b706fe33cc1b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41449",
+					"10.65.0.27:41449",
+					"172.17.0.1:41449",
+					"172.18.0.1:41449",
+					"172.19.0.1:41449",
+					"172.20.0.1:41449",
+					"172.21.0.1:41449",
+					"172.22.0.1:41449",
+					"172.23.0.1:41449",
+					"172.24.0.1:41449",
+					"172.25.0.1:41449",
+					"172.26.0.1:41449",
+					"172.27.0.1:41449",
+					"172.28.0.1:41449"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:16:33.846892606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2884204743856928,
+				"StableID":   "nFNjijAGXP11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2288cbc791982d1febb37aa4632bca2afa58382205fa1debb16cb33c5097810f",
+				"DiscoKey":   "discokey:86ee1b0358dbe766533ecd96fb31297444a367bce9a7f65d63f1c21f6d189140",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50881",
+					"10.65.0.27:50881",
+					"172.17.0.1:50881",
+					"172.18.0.1:50881",
+					"172.19.0.1:50881",
+					"172.20.0.1:50881",
+					"172.21.0.1:50881",
+					"172.22.0.1:50881",
+					"172.23.0.1:50881",
+					"172.24.0.1:50881",
+					"172.25.0.1:50881",
+					"172.26.0.1:50881",
+					"172.27.0.1:50881",
+					"172.28.0.1:50881"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:16:34.38370158Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8068649566328922,
+				"StableID":   "nF7HP3kJ1621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dab39f217dc07a9a7265f9276d64ea1f59d461acb0ec058bd6e6cca4def2bb64",
+				"DiscoKey":   "discokey:63b9dca87a0d91279a35610d3029c6e7ce8bd5f800b5b9ac30f4386c49691c49",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44693",
+					"10.65.0.27:44693",
+					"172.17.0.1:44693",
+					"172.18.0.1:44693",
+					"172.19.0.1:44693",
+					"172.20.0.1:44693",
+					"172.21.0.1:44693",
+					"172.22.0.1:44693",
+					"172.23.0.1:44693",
+					"172.24.0.1:44693",
+					"172.25.0.1:44693",
+					"172.26.0.1:44693",
+					"172.27.0.1:44693",
+					"172.28.0.1:44693"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:16:34.900934564Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4294990921984530,
+				"StableID":   "nwMgGT8DYa11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:abbf2a0b102da082048e4a7e17a105a4731374fbd704134435b087699cb8607e",
+				"DiscoKey":   "discokey:b23fd71a513c8f30044586a0f38c845ae12cd58bbd3bb8a99ec9ddefa0b39e63",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50929",
+					"10.65.0.27:50929",
+					"172.17.0.1:50929",
+					"172.18.0.1:50929",
+					"172.19.0.1:50929",
+					"172.20.0.1:50929",
+					"172.21.0.1:50929",
+					"172.22.0.1:50929",
+					"172.23.0.1:50929",
+					"172.24.0.1:50929",
+					"172.25.0.1:50929",
+					"172.26.0.1:50929",
+					"172.27.0.1:50929",
+					"172.28.0.1:50929"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:16:35.432173376Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2789200956428515,
+				"StableID":   "nc9HMcaEnN11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1d10f62d48a41ae8f2ff37f709fc71c9771d3ecae79f5888dbf5e9178e8fd43b",
+				"DiscoKey":   "discokey:4b0eeb701ea2de2e741363d16e822b997ceae786c7154214b8491f24e09e4d56",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49056",
+					"10.65.0.27:49056",
+					"172.17.0.1:49056",
+					"172.18.0.1:49056",
+					"172.19.0.1:49056",
+					"172.20.0.1:49056",
+					"172.21.0.1:49056",
+					"172.22.0.1:49056",
+					"172.23.0.1:49056",
+					"172.24.0.1:49056",
+					"172.25.0.1:49056",
+					"172.26.0.1:49056",
+					"172.27.0.1:49056",
+					"172.28.0.1:49056"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:16:36.504343844Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3136722346387547,
+				"StableID":   "nYZrYsNdVR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1c5c6665c13e9cffa7c924b2434ac58dd7c98cae7b7d0c82ae75f674d2c5064",
+				"DiscoKey":   "discokey:17e5772ce8a8e2c92ecda771799f562d4676d35fdc8174abb7aa966e89752703",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:59410",
+					"10.65.0.27:59410",
+					"172.17.0.1:59410",
+					"172.18.0.1:59410",
+					"172.19.0.1:59410",
+					"172.20.0.1:59410",
+					"172.21.0.1:59410",
+					"172.22.0.1:59410",
+					"172.23.0.1:59410",
+					"172.24.0.1:59410",
+					"172.25.0.1:59410",
+					"172.26.0.1:59410",
+					"172.27.0.1:59410",
+					"172.28.0.1:59410"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:16:37.031283368Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8655535422778369,
+				"StableID":   "nkLhppE7bA21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51ea7fe1af6a214a081f391094984c7ffc0ada6e7b0f955269cf478437343d37",
+				"DiscoKey":   "discokey:c613e971fe0d620109ca52c5e53ae02ef23e0da58e5e3fcd53e2225c6c361f49",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:57088",
+					"10.65.0.27:57088",
+					"172.17.0.1:57088",
+					"172.18.0.1:57088",
+					"172.19.0.1:57088",
+					"172.20.0.1:57088",
+					"172.21.0.1:57088",
+					"172.22.0.1:57088",
+					"172.23.0.1:57088",
+					"172.24.0.1:57088",
+					"172.25.0.1:57088",
+					"172.26.0.1:57088",
+					"172.27.0.1:57088",
+					"172.28.0.1:57088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:16:37.584099691Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8817121571615835,
+				"StableID":   "nLqDUHqHrB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ff438b3d370ac7e8535275f6c9dd632885819ef9174502cd4f75a68367484022",
+				"KeyExpiry":  "2026-11-09T09:16:38Z",
+				"DiscoKey":   "discokey:ba73117d5dc25aa3894fcf29c41b93d5c3fe1a75ae7fe523a4e3e19f970ed538",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45196",
+					"10.65.0.27:45196",
+					"172.17.0.1:45196",
+					"172.18.0.1:45196",
+					"172.19.0.1:45196",
+					"172.20.0.1:45196",
+					"172.21.0.1:45196",
+					"172.22.0.1:45196",
+					"172.23.0.1:45196",
+					"172.24.0.1:45196",
+					"172.25.0.1:45196",
+					"172.26.0.1:45196",
+					"172.27.0.1:45196",
+					"172.28.0.1:45196"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:16:38.177732012Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3438518289772750,
+				"StableID":   "nBDecb3KrT11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5a701bba6af81b1d3119253be60d716401f2d9a50fd5dc50536113b0a9f08660",
+				"KeyExpiry":  "2026-11-09T09:16:38Z",
+				"DiscoKey":   "discokey:1927d7fbdb293edda5e8619c4dca14d6e7d7e05c5ede001b380a2f08c4989172",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55365",
+					"10.65.0.27:55365",
+					"172.17.0.1:55365",
+					"172.18.0.1:55365",
+					"172.19.0.1:55365",
+					"172.20.0.1:55365",
+					"172.21.0.1:55365",
+					"172.22.0.1:55365",
+					"172.23.0.1:55365",
+					"172.24.0.1:55365",
+					"172.25.0.1:55365",
+					"172.26.0.1:55365",
+					"172.27.0.1:55365",
+					"172.28.0.1:55365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:16:38.715741477Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4232648330810505,
+				"StableID":   "npaHyfVy3a11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7b5184612ccbb8983f218368c8035d305c0fa4a6092021190b0a05b953b10425",
+				"KeyExpiry":  "2026-11-09T09:16:39Z",
+				"DiscoKey":   "discokey:5208598b8cac01e196a19a8d49f96773a9835d24c68bd69598a5937f23c63e4a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56825",
+					"10.65.0.27:56825",
+					"172.17.0.1:56825",
+					"172.18.0.1:56825",
+					"172.19.0.1:56825",
+					"172.20.0.1:56825",
+					"172.21.0.1:56825",
+					"172.22.0.1:56825",
+					"172.23.0.1:56825",
+					"172.24.0.1:56825",
+					"172.25.0.1:56825",
+					"172.26.0.1:56825",
+					"172.27.0.1:56825",
+					"172.28.0.1:56825"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:16:39.250040788Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6683286104949244": {
+				"ID":          6683286104949244,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3438518289772750,
+				"StableID":   "nBDecb3KrT11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5a701bba6af81b1d3119253be60d716401f2d9a50fd5dc50536113b0a9f08660",
+				"KeyExpiry":  "2026-11-09T09:16:38Z",
+				"DiscoKey":   "discokey:1927d7fbdb293edda5e8619c4dca14d6e7d7e05c5ede001b380a2f08c4989172",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55365",
+					"10.65.0.27:55365",
+					"172.17.0.1:55365",
+					"172.18.0.1:55365",
+					"172.19.0.1:55365",
+					"172.20.0.1:55365",
+					"172.21.0.1:55365",
+					"172.22.0.1:55365",
+					"172.23.0.1:55365",
+					"172.24.0.1:55365",
+					"172.25.0.1:55365",
+					"172.26.0.1:55365",
+					"172.27.0.1:55365",
+					"172.28.0.1:55365"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:16:38.715741477Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5a701bba6af81b1d3119253be60d716401f2d9a50fd5dc50536113b0a9f08660",
+			"MachineKey": "mkey:c9bb8f70561c43918b8701ff3c137bde1c0eade1f593e254633600777b42da4d",
+			"Peers": [{
+				"ID":         4544457554236945,
+				"StableID":   "n84eJFCCVc11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb69a9a3fd98283abb5b824a0e46b6d27ce37cc55932b72bf440c437db22d237",
+				"DiscoKey":   "discokey:a578f456e0138f1dc305b742ef3a500571ec5fd487a809b1117a6c8c9b000249",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36024",
+					"10.65.0.27:36024",
+					"172.17.0.1:36024",
+					"172.18.0.1:36024",
+					"172.19.0.1:36024",
+					"172.20.0.1:36024",
+					"172.21.0.1:36024",
+					"172.22.0.1:36024",
+					"172.23.0.1:36024",
+					"172.24.0.1:36024",
+					"172.25.0.1:36024",
+					"172.26.0.1:36024",
+					"172.27.0.1:36024",
+					"172.28.0.1:36024"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:16:31.110445532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2009417783924731,
+				"StableID":   "npXydsz4hG11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:753aa05e1103d96f6c54ad81c74c07654ed38a7353ab11489bb6a33dd824ed2d",
+				"DiscoKey":   "discokey:418bd024545893836054b8e180770ce90aea857fb8398f41a30ba280ca2c6901",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:56408",
+					"10.65.0.27:56408",
+					"172.17.0.1:56408",
+					"172.18.0.1:56408",
+					"172.19.0.1:56408",
+					"172.20.0.1:56408",
+					"172.21.0.1:56408",
+					"172.22.0.1:56408",
+					"172.23.0.1:56408",
+					"172.24.0.1:56408",
+					"172.25.0.1:56408",
+					"172.26.0.1:56408",
+					"172.27.0.1:56408",
+					"172.28.0.1:56408"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:16:31.735738377Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4637492199793181,
+				"StableID":   "ngYHMG4LDd11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:49c1763a9be9eb89c359f01714a9d818ad37ae4baa05b6f8eea689a62711b971",
+				"DiscoKey":   "discokey:9d3c95541d5aad0f118e534d243d71ea498d2660bb3554b8b3cc1ee21751c76e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36617",
+					"10.65.0.27:36617",
+					"172.17.0.1:36617",
+					"172.18.0.1:36617",
+					"172.19.0.1:36617",
+					"172.20.0.1:36617",
+					"172.21.0.1:36617",
+					"172.22.0.1:36617",
+					"172.23.0.1:36617",
+					"172.24.0.1:36617",
+					"172.25.0.1:36617",
+					"172.26.0.1:36617",
+					"172.27.0.1:36617",
+					"172.28.0.1:36617"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:16:32.261223987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4527847942638130,
+				"StableID":   "nTudoUtfMc11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:893b1cf6338cd631a24f7a3f0b8d1cfec096306fd567160a19137374b8cdb158",
+				"DiscoKey":   "discokey:df102ddc65336ee2f5ead02501b0db365aa9c7e90d446f0e4d98f3c223543b6e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59980",
+					"10.65.0.27:59980",
+					"172.17.0.1:59980",
+					"172.18.0.1:59980",
+					"172.19.0.1:59980",
+					"172.20.0.1:59980",
+					"172.21.0.1:59980",
+					"172.22.0.1:59980",
+					"172.23.0.1:59980",
+					"172.24.0.1:59980",
+					"172.25.0.1:59980",
+					"172.26.0.1:59980",
+					"172.27.0.1:59980",
+					"172.28.0.1:59980"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:16:33.317360859Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3801184942400324,
+				"StableID":   "nFxBpbgZgW11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:44da45e66d237c8652357ce0f54e681b03f91770691f28f892bfdc6578829b7f",
+				"DiscoKey":   "discokey:0a2146d82fda5c146aabe7ee1b17633e2d84035a208c13978301b706fe33cc1b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41449",
+					"10.65.0.27:41449",
+					"172.17.0.1:41449",
+					"172.18.0.1:41449",
+					"172.19.0.1:41449",
+					"172.20.0.1:41449",
+					"172.21.0.1:41449",
+					"172.22.0.1:41449",
+					"172.23.0.1:41449",
+					"172.24.0.1:41449",
+					"172.25.0.1:41449",
+					"172.26.0.1:41449",
+					"172.27.0.1:41449",
+					"172.28.0.1:41449"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:16:33.846892606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2884204743856928,
+				"StableID":   "nFNjijAGXP11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2288cbc791982d1febb37aa4632bca2afa58382205fa1debb16cb33c5097810f",
+				"DiscoKey":   "discokey:86ee1b0358dbe766533ecd96fb31297444a367bce9a7f65d63f1c21f6d189140",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50881",
+					"10.65.0.27:50881",
+					"172.17.0.1:50881",
+					"172.18.0.1:50881",
+					"172.19.0.1:50881",
+					"172.20.0.1:50881",
+					"172.21.0.1:50881",
+					"172.22.0.1:50881",
+					"172.23.0.1:50881",
+					"172.24.0.1:50881",
+					"172.25.0.1:50881",
+					"172.26.0.1:50881",
+					"172.27.0.1:50881",
+					"172.28.0.1:50881"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:16:34.38370158Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8068649566328922,
+				"StableID":   "nF7HP3kJ1621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dab39f217dc07a9a7265f9276d64ea1f59d461acb0ec058bd6e6cca4def2bb64",
+				"DiscoKey":   "discokey:63b9dca87a0d91279a35610d3029c6e7ce8bd5f800b5b9ac30f4386c49691c49",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44693",
+					"10.65.0.27:44693",
+					"172.17.0.1:44693",
+					"172.18.0.1:44693",
+					"172.19.0.1:44693",
+					"172.20.0.1:44693",
+					"172.21.0.1:44693",
+					"172.22.0.1:44693",
+					"172.23.0.1:44693",
+					"172.24.0.1:44693",
+					"172.25.0.1:44693",
+					"172.26.0.1:44693",
+					"172.27.0.1:44693",
+					"172.28.0.1:44693"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:16:34.900934564Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4294990921984530,
+				"StableID":   "nwMgGT8DYa11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:abbf2a0b102da082048e4a7e17a105a4731374fbd704134435b087699cb8607e",
+				"DiscoKey":   "discokey:b23fd71a513c8f30044586a0f38c845ae12cd58bbd3bb8a99ec9ddefa0b39e63",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50929",
+					"10.65.0.27:50929",
+					"172.17.0.1:50929",
+					"172.18.0.1:50929",
+					"172.19.0.1:50929",
+					"172.20.0.1:50929",
+					"172.21.0.1:50929",
+					"172.22.0.1:50929",
+					"172.23.0.1:50929",
+					"172.24.0.1:50929",
+					"172.25.0.1:50929",
+					"172.26.0.1:50929",
+					"172.27.0.1:50929",
+					"172.28.0.1:50929"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:16:35.432173376Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6683286104949244,
+				"StableID":   "ny7sFQbsBu11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4bb754b07a5725035b3bd889a8892ceaca64bdae3e2ad880ef302c3028b95e0d",
+				"DiscoKey":   "discokey:dd7a82d53b4b91c6f52539b4232687a61b1916e0c668b5007b4174fdee16137e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39866",
+					"10.65.0.27:39866",
+					"172.17.0.1:39866",
+					"172.18.0.1:39866",
+					"172.19.0.1:39866",
+					"172.20.0.1:39866",
+					"172.21.0.1:39866",
+					"172.22.0.1:39866",
+					"172.23.0.1:39866",
+					"172.24.0.1:39866",
+					"172.25.0.1:39866",
+					"172.26.0.1:39866",
+					"172.27.0.1:39866",
+					"172.28.0.1:39866"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:16:35.972074185Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2789200956428515,
+				"StableID":   "nc9HMcaEnN11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1d10f62d48a41ae8f2ff37f709fc71c9771d3ecae79f5888dbf5e9178e8fd43b",
+				"DiscoKey":   "discokey:4b0eeb701ea2de2e741363d16e822b997ceae786c7154214b8491f24e09e4d56",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49056",
+					"10.65.0.27:49056",
+					"172.17.0.1:49056",
+					"172.18.0.1:49056",
+					"172.19.0.1:49056",
+					"172.20.0.1:49056",
+					"172.21.0.1:49056",
+					"172.22.0.1:49056",
+					"172.23.0.1:49056",
+					"172.24.0.1:49056",
+					"172.25.0.1:49056",
+					"172.26.0.1:49056",
+					"172.27.0.1:49056",
+					"172.28.0.1:49056"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:16:36.504343844Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3136722346387547,
+				"StableID":   "nYZrYsNdVR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1c5c6665c13e9cffa7c924b2434ac58dd7c98cae7b7d0c82ae75f674d2c5064",
+				"DiscoKey":   "discokey:17e5772ce8a8e2c92ecda771799f562d4676d35fdc8174abb7aa966e89752703",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:59410",
+					"10.65.0.27:59410",
+					"172.17.0.1:59410",
+					"172.18.0.1:59410",
+					"172.19.0.1:59410",
+					"172.20.0.1:59410",
+					"172.21.0.1:59410",
+					"172.22.0.1:59410",
+					"172.23.0.1:59410",
+					"172.24.0.1:59410",
+					"172.25.0.1:59410",
+					"172.26.0.1:59410",
+					"172.27.0.1:59410",
+					"172.28.0.1:59410"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:16:37.031283368Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8655535422778369,
+				"StableID":   "nkLhppE7bA21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51ea7fe1af6a214a081f391094984c7ffc0ada6e7b0f955269cf478437343d37",
+				"DiscoKey":   "discokey:c613e971fe0d620109ca52c5e53ae02ef23e0da58e5e3fcd53e2225c6c361f49",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:57088",
+					"10.65.0.27:57088",
+					"172.17.0.1:57088",
+					"172.18.0.1:57088",
+					"172.19.0.1:57088",
+					"172.20.0.1:57088",
+					"172.21.0.1:57088",
+					"172.22.0.1:57088",
+					"172.23.0.1:57088",
+					"172.24.0.1:57088",
+					"172.25.0.1:57088",
+					"172.26.0.1:57088",
+					"172.27.0.1:57088",
+					"172.28.0.1:57088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:16:37.584099691Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8817121571615835,
+				"StableID":   "nLqDUHqHrB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ff438b3d370ac7e8535275f6c9dd632885819ef9174502cd4f75a68367484022",
+				"KeyExpiry":  "2026-11-09T09:16:38Z",
+				"DiscoKey":   "discokey:ba73117d5dc25aa3894fcf29c41b93d5c3fe1a75ae7fe523a4e3e19f970ed538",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45196",
+					"10.65.0.27:45196",
+					"172.17.0.1:45196",
+					"172.18.0.1:45196",
+					"172.19.0.1:45196",
+					"172.20.0.1:45196",
+					"172.21.0.1:45196",
+					"172.22.0.1:45196",
+					"172.23.0.1:45196",
+					"172.24.0.1:45196",
+					"172.25.0.1:45196",
+					"172.26.0.1:45196",
+					"172.27.0.1:45196",
+					"172.28.0.1:45196"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:16:38.177732012Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4232648330810505,
+				"StableID":   "npaHyfVy3a11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7b5184612ccbb8983f218368c8035d305c0fa4a6092021190b0a05b953b10425",
+				"KeyExpiry":  "2026-11-09T09:16:39Z",
+				"DiscoKey":   "discokey:5208598b8cac01e196a19a8d49f96773a9835d24c68bd69598a5937f23c63e4a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56825",
+					"10.65.0.27:56825",
+					"172.17.0.1:56825",
+					"172.18.0.1:56825",
+					"172.19.0.1:56825",
+					"172.20.0.1:56825",
+					"172.21.0.1:56825",
+					"172.22.0.1:56825",
+					"172.23.0.1:56825",
+					"172.24.0.1:56825",
+					"172.25.0.1:56825",
+					"172.26.0.1:56825",
+					"172.27.0.1:56825",
+					"172.28.0.1:56825"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:16:39.250040788Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2789200956428515,
+				"StableID":   "nc9HMcaEnN11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       2789200956428515,
+				"Key":        "nodekey:1d10f62d48a41ae8f2ff37f709fc71c9771d3ecae79f5888dbf5e9178e8fd43b",
+				"DiscoKey":   "discokey:4b0eeb701ea2de2e741363d16e822b997ceae786c7154214b8491f24e09e4d56",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49056",
+					"10.65.0.27:49056",
+					"172.17.0.1:49056",
+					"172.18.0.1:49056",
+					"172.19.0.1:49056",
+					"172.20.0.1:49056",
+					"172.21.0.1:49056",
+					"172.22.0.1:49056",
+					"172.23.0.1:49056",
+					"172.24.0.1:49056",
+					"172.25.0.1:49056",
+					"172.26.0.1:49056",
+					"172.27.0.1:49056",
+					"172.28.0.1:49056"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:16:36.504343844Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1d10f62d48a41ae8f2ff37f709fc71c9771d3ecae79f5888dbf5e9178e8fd43b",
+			"MachineKey": "mkey:ff82d279176916a2250f2c827ab01fe7c0961eea52d499f80ee91d2e118feb34",
+			"Peers": [{
+				"ID":         4544457554236945,
+				"StableID":   "n84eJFCCVc11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb69a9a3fd98283abb5b824a0e46b6d27ce37cc55932b72bf440c437db22d237",
+				"DiscoKey":   "discokey:a578f456e0138f1dc305b742ef3a500571ec5fd487a809b1117a6c8c9b000249",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:36024",
+					"10.65.0.27:36024",
+					"172.17.0.1:36024",
+					"172.18.0.1:36024",
+					"172.19.0.1:36024",
+					"172.20.0.1:36024",
+					"172.21.0.1:36024",
+					"172.22.0.1:36024",
+					"172.23.0.1:36024",
+					"172.24.0.1:36024",
+					"172.25.0.1:36024",
+					"172.26.0.1:36024",
+					"172.27.0.1:36024",
+					"172.28.0.1:36024"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:16:31.110445532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2009417783924731,
+				"StableID":   "npXydsz4hG11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:753aa05e1103d96f6c54ad81c74c07654ed38a7353ab11489bb6a33dd824ed2d",
+				"DiscoKey":   "discokey:418bd024545893836054b8e180770ce90aea857fb8398f41a30ba280ca2c6901",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:56408",
+					"10.65.0.27:56408",
+					"172.17.0.1:56408",
+					"172.18.0.1:56408",
+					"172.19.0.1:56408",
+					"172.20.0.1:56408",
+					"172.21.0.1:56408",
+					"172.22.0.1:56408",
+					"172.23.0.1:56408",
+					"172.24.0.1:56408",
+					"172.25.0.1:56408",
+					"172.26.0.1:56408",
+					"172.27.0.1:56408",
+					"172.28.0.1:56408"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:16:31.735738377Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4637492199793181,
+				"StableID":   "ngYHMG4LDd11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:49c1763a9be9eb89c359f01714a9d818ad37ae4baa05b6f8eea689a62711b971",
+				"DiscoKey":   "discokey:9d3c95541d5aad0f118e534d243d71ea498d2660bb3554b8b3cc1ee21751c76e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36617",
+					"10.65.0.27:36617",
+					"172.17.0.1:36617",
+					"172.18.0.1:36617",
+					"172.19.0.1:36617",
+					"172.20.0.1:36617",
+					"172.21.0.1:36617",
+					"172.22.0.1:36617",
+					"172.23.0.1:36617",
+					"172.24.0.1:36617",
+					"172.25.0.1:36617",
+					"172.26.0.1:36617",
+					"172.27.0.1:36617",
+					"172.28.0.1:36617"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:16:32.261223987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4527847942638130,
+				"StableID":   "nTudoUtfMc11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:893b1cf6338cd631a24f7a3f0b8d1cfec096306fd567160a19137374b8cdb158",
+				"DiscoKey":   "discokey:df102ddc65336ee2f5ead02501b0db365aa9c7e90d446f0e4d98f3c223543b6e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59980",
+					"10.65.0.27:59980",
+					"172.17.0.1:59980",
+					"172.18.0.1:59980",
+					"172.19.0.1:59980",
+					"172.20.0.1:59980",
+					"172.21.0.1:59980",
+					"172.22.0.1:59980",
+					"172.23.0.1:59980",
+					"172.24.0.1:59980",
+					"172.25.0.1:59980",
+					"172.26.0.1:59980",
+					"172.27.0.1:59980",
+					"172.28.0.1:59980"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:16:33.317360859Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3801184942400324,
+				"StableID":   "nFxBpbgZgW11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:44da45e66d237c8652357ce0f54e681b03f91770691f28f892bfdc6578829b7f",
+				"DiscoKey":   "discokey:0a2146d82fda5c146aabe7ee1b17633e2d84035a208c13978301b706fe33cc1b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41449",
+					"10.65.0.27:41449",
+					"172.17.0.1:41449",
+					"172.18.0.1:41449",
+					"172.19.0.1:41449",
+					"172.20.0.1:41449",
+					"172.21.0.1:41449",
+					"172.22.0.1:41449",
+					"172.23.0.1:41449",
+					"172.24.0.1:41449",
+					"172.25.0.1:41449",
+					"172.26.0.1:41449",
+					"172.27.0.1:41449",
+					"172.28.0.1:41449"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:16:33.846892606Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2884204743856928,
+				"StableID":   "nFNjijAGXP11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2288cbc791982d1febb37aa4632bca2afa58382205fa1debb16cb33c5097810f",
+				"DiscoKey":   "discokey:86ee1b0358dbe766533ecd96fb31297444a367bce9a7f65d63f1c21f6d189140",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50881",
+					"10.65.0.27:50881",
+					"172.17.0.1:50881",
+					"172.18.0.1:50881",
+					"172.19.0.1:50881",
+					"172.20.0.1:50881",
+					"172.21.0.1:50881",
+					"172.22.0.1:50881",
+					"172.23.0.1:50881",
+					"172.24.0.1:50881",
+					"172.25.0.1:50881",
+					"172.26.0.1:50881",
+					"172.27.0.1:50881",
+					"172.28.0.1:50881"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:16:34.38370158Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8068649566328922,
+				"StableID":   "nF7HP3kJ1621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dab39f217dc07a9a7265f9276d64ea1f59d461acb0ec058bd6e6cca4def2bb64",
+				"DiscoKey":   "discokey:63b9dca87a0d91279a35610d3029c6e7ce8bd5f800b5b9ac30f4386c49691c49",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44693",
+					"10.65.0.27:44693",
+					"172.17.0.1:44693",
+					"172.18.0.1:44693",
+					"172.19.0.1:44693",
+					"172.20.0.1:44693",
+					"172.21.0.1:44693",
+					"172.22.0.1:44693",
+					"172.23.0.1:44693",
+					"172.24.0.1:44693",
+					"172.25.0.1:44693",
+					"172.26.0.1:44693",
+					"172.27.0.1:44693",
+					"172.28.0.1:44693"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:16:34.900934564Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4294990921984530,
+				"StableID":   "nwMgGT8DYa11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:abbf2a0b102da082048e4a7e17a105a4731374fbd704134435b087699cb8607e",
+				"DiscoKey":   "discokey:b23fd71a513c8f30044586a0f38c845ae12cd58bbd3bb8a99ec9ddefa0b39e63",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:50929",
+					"10.65.0.27:50929",
+					"172.17.0.1:50929",
+					"172.18.0.1:50929",
+					"172.19.0.1:50929",
+					"172.20.0.1:50929",
+					"172.21.0.1:50929",
+					"172.22.0.1:50929",
+					"172.23.0.1:50929",
+					"172.24.0.1:50929",
+					"172.25.0.1:50929",
+					"172.26.0.1:50929",
+					"172.27.0.1:50929",
+					"172.28.0.1:50929"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:16:35.432173376Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6683286104949244,
+				"StableID":   "ny7sFQbsBu11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4bb754b07a5725035b3bd889a8892ceaca64bdae3e2ad880ef302c3028b95e0d",
+				"DiscoKey":   "discokey:dd7a82d53b4b91c6f52539b4232687a61b1916e0c668b5007b4174fdee16137e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39866",
+					"10.65.0.27:39866",
+					"172.17.0.1:39866",
+					"172.18.0.1:39866",
+					"172.19.0.1:39866",
+					"172.20.0.1:39866",
+					"172.21.0.1:39866",
+					"172.22.0.1:39866",
+					"172.23.0.1:39866",
+					"172.24.0.1:39866",
+					"172.25.0.1:39866",
+					"172.26.0.1:39866",
+					"172.27.0.1:39866",
+					"172.28.0.1:39866"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:16:35.972074185Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3136722346387547,
+				"StableID":   "nYZrYsNdVR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1c5c6665c13e9cffa7c924b2434ac58dd7c98cae7b7d0c82ae75f674d2c5064",
+				"DiscoKey":   "discokey:17e5772ce8a8e2c92ecda771799f562d4676d35fdc8174abb7aa966e89752703",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:59410",
+					"10.65.0.27:59410",
+					"172.17.0.1:59410",
+					"172.18.0.1:59410",
+					"172.19.0.1:59410",
+					"172.20.0.1:59410",
+					"172.21.0.1:59410",
+					"172.22.0.1:59410",
+					"172.23.0.1:59410",
+					"172.24.0.1:59410",
+					"172.25.0.1:59410",
+					"172.26.0.1:59410",
+					"172.27.0.1:59410",
+					"172.28.0.1:59410"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:16:37.031283368Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8655535422778369,
+				"StableID":   "nkLhppE7bA21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51ea7fe1af6a214a081f391094984c7ffc0ada6e7b0f955269cf478437343d37",
+				"DiscoKey":   "discokey:c613e971fe0d620109ca52c5e53ae02ef23e0da58e5e3fcd53e2225c6c361f49",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:57088",
+					"10.65.0.27:57088",
+					"172.17.0.1:57088",
+					"172.18.0.1:57088",
+					"172.19.0.1:57088",
+					"172.20.0.1:57088",
+					"172.21.0.1:57088",
+					"172.22.0.1:57088",
+					"172.23.0.1:57088",
+					"172.24.0.1:57088",
+					"172.25.0.1:57088",
+					"172.26.0.1:57088",
+					"172.27.0.1:57088",
+					"172.28.0.1:57088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:16:37.584099691Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8817121571615835,
+				"StableID":   "nLqDUHqHrB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ff438b3d370ac7e8535275f6c9dd632885819ef9174502cd4f75a68367484022",
+				"KeyExpiry":  "2026-11-09T09:16:38Z",
+				"DiscoKey":   "discokey:ba73117d5dc25aa3894fcf29c41b93d5c3fe1a75ae7fe523a4e3e19f970ed538",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45196",
+					"10.65.0.27:45196",
+					"172.17.0.1:45196",
+					"172.18.0.1:45196",
+					"172.19.0.1:45196",
+					"172.20.0.1:45196",
+					"172.21.0.1:45196",
+					"172.22.0.1:45196",
+					"172.23.0.1:45196",
+					"172.24.0.1:45196",
+					"172.25.0.1:45196",
+					"172.26.0.1:45196",
+					"172.27.0.1:45196",
+					"172.28.0.1:45196"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:16:38.177732012Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3438518289772750,
+				"StableID":   "nBDecb3KrT11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5a701bba6af81b1d3119253be60d716401f2d9a50fd5dc50536113b0a9f08660",
+				"KeyExpiry":  "2026-11-09T09:16:38Z",
+				"DiscoKey":   "discokey:1927d7fbdb293edda5e8619c4dca14d6e7d7e05c5ede001b380a2f08c4989172",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55365",
+					"10.65.0.27:55365",
+					"172.17.0.1:55365",
+					"172.18.0.1:55365",
+					"172.19.0.1:55365",
+					"172.20.0.1:55365",
+					"172.21.0.1:55365",
+					"172.22.0.1:55365",
+					"172.23.0.1:55365",
+					"172.24.0.1:55365",
+					"172.25.0.1:55365",
+					"172.26.0.1:55365",
+					"172.27.0.1:55365",
+					"172.28.0.1:55365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:16:38.715741477Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4232648330810505,
+				"StableID":   "npaHyfVy3a11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7b5184612ccbb8983f218368c8035d305c0fa4a6092021190b0a05b953b10425",
+				"KeyExpiry":  "2026-11-09T09:16:39Z",
+				"DiscoKey":   "discokey:5208598b8cac01e196a19a8d49f96773a9835d24c68bd69598a5937f23c63e4a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56825",
+					"10.65.0.27:56825",
+					"172.17.0.1:56825",
+					"172.18.0.1:56825",
+					"172.19.0.1:56825",
+					"172.20.0.1:56825",
+					"172.21.0.1:56825",
+					"172.22.0.1:56825",
+					"172.23.0.1:56825",
+					"172.24.0.1:56825",
+					"172.25.0.1:56825",
+					"172.26.0.1:56825",
+					"172.27.0.1:56825",
+					"172.28.0.1:56825"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:16:39.250040788Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2789200956428515": {
+				"ID":          2789200956428515,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-multi-rule-overlap-conflicting-acceptenv.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-multi-rule-overlap-conflicting-acceptenv.hujson
@@ -1,0 +1,22152 @@
+// ssh-multi-rule-overlap-conflicting-acceptenv
+//
+// ssh two rules same src/dst/users, different acceptEnv
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-13T09:17:24Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-multi-rule-overlap-conflicting-acceptenv",
+	"description":    "ssh two rules same src/dst/users, different acceptEnv",
+	"category":       "ssh",
+	"captured_at":    "2026-05-13T09:17:24.768527073Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                               \n  \n                                                                       \n                                                                 \n                   \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh two rules same src/dst/users, different acceptEnv\",\n\t\"id\":          \"ssh-multi-rule-overlap-conflicting-acceptenv\",\n\t\"policy\": {\"ssh\": [{\n\t\t\"acceptEnv\": [\"TERM\"],\n\t\t\"action\":    \"accept\",\n\t\t\"dst\":       [\"tag:server\"],\n\t\t\"src\":       [\"thor@example.org\"],\n\t\t\"users\":     [\"root\"]\n\t}, {\n\t\t\"acceptEnv\": [\"LC_*\"],\n\t\t\"action\":    \"accept\",\n\t\t\"dst\":       [\"tag:server\"],\n\t\t\"src\":       [\"thor@example.org\"],\n\t\t\"users\":     [\"root\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-edges/ssh-multi-rule-overlap-conflicting-acceptenv.hujson",
+		"full_policy": {
+			"ssh": [{
+				"acceptEnv": ["TERM"],
+				"action":    "accept",
+				"dst":       ["tag:server"],
+				"src":       ["thor@example.org"],
+				"users":     ["root"]
+			}, {
+				"acceptEnv": ["LC_*"],
+				"action":    "accept",
+				"dst":       ["tag:server"],
+				"src":       ["thor@example.org"],
+				"users":     ["root"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2205486211879948,
+				"StableID":   "njAFDDPsDJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       2205486211879948,
+				"Key":        "nodekey:280db06fdb1275071ce0e8b86d3f3ec2781914c95854a9bf9731471ca3368118",
+				"DiscoKey":   "discokey:6c3aa80a7e71cd8999abc158814de52644e6bcc18e5fa5ce8d8d0992eac7c53a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41569",
+					"10.65.0.27:41569",
+					"172.17.0.1:41569",
+					"172.18.0.1:41569",
+					"172.19.0.1:41569",
+					"172.20.0.1:41569",
+					"172.21.0.1:41569",
+					"172.22.0.1:41569",
+					"172.23.0.1:41569",
+					"172.24.0.1:41569",
+					"172.25.0.1:41569",
+					"172.26.0.1:41569",
+					"172.27.0.1:41569",
+					"172.28.0.1:41569"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:17:33.553972143Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:280db06fdb1275071ce0e8b86d3f3ec2781914c95854a9bf9731471ca3368118",
+			"MachineKey": "mkey:920f7ca0780b26bbce39fea4b06a2794e06f0130117108a1320779a278378617",
+			"Peers": [{
+				"ID":         7267738963119122,
+				"StableID":   "n1E9yMBaky11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90085b2eac99b281e0343aa6634593a7ed4bd8e47e40c08c1c011bb05508f749",
+				"DiscoKey":   "discokey:a0ee95e28dd3d32bc9be6488d5030e36ca6d6fd123030794ef10140c5729ea3c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38781",
+					"10.65.0.27:38781",
+					"172.17.0.1:38781",
+					"172.18.0.1:38781",
+					"172.19.0.1:38781",
+					"172.20.0.1:38781",
+					"172.21.0.1:38781",
+					"172.22.0.1:38781",
+					"172.23.0.1:38781",
+					"172.24.0.1:38781",
+					"172.25.0.1:38781",
+					"172.26.0.1:38781",
+					"172.27.0.1:38781",
+					"172.28.0.1:38781"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:17:27.367207025Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3909302976209550,
+				"StableID":   "nohFE6mXXX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a1743f26bdca03b52d481b3ea0584a7d606430e2e0c506ca6be1a30e8b4a3006",
+				"DiscoKey":   "discokey:6b586235ad5cc37daf7c0463b5fdafe6c46269d42f31001c1df6f64828726b58",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44597",
+					"10.65.0.27:44597",
+					"172.17.0.1:44597",
+					"172.18.0.1:44597",
+					"172.19.0.1:44597",
+					"172.20.0.1:44597",
+					"172.21.0.1:44597",
+					"172.22.0.1:44597",
+					"172.23.0.1:44597",
+					"172.24.0.1:44597",
+					"172.25.0.1:44597",
+					"172.26.0.1:44597",
+					"172.27.0.1:44597",
+					"172.28.0.1:44597"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:17:28.086837834Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         387632227359478,
+				"StableID":   "nbykYbSZ2411CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a1f01689a1e22ccac1cffb0f5b21ce4fbeb85ddeefc7c80523dcda5a0a5d0948",
+				"DiscoKey":   "discokey:7366f41f4cee419ce831f057a4d5a6e2dfa7f3e7200e53e4b7685500c1e7a77a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:54326",
+					"10.65.0.27:54326",
+					"172.17.0.1:54326",
+					"172.18.0.1:54326",
+					"172.19.0.1:54326",
+					"172.20.0.1:54326",
+					"172.21.0.1:54326",
+					"172.22.0.1:54326",
+					"172.23.0.1:54326",
+					"172.24.0.1:54326",
+					"172.25.0.1:54326",
+					"172.26.0.1:54326",
+					"172.27.0.1:54326",
+					"172.28.0.1:54326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:17:28.629811446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1278908908902243,
+				"StableID":   "npMzrZmDzA11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85b6dab0e12f1319ae37b0135c9346681d5e7c73508525f26b4ffee8db753923",
+				"DiscoKey":   "discokey:c8f1d2be652eb4c31c8210d75f692358985d2162a07c93a072da3ae9f83cb501",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:38988",
+					"10.65.0.27:38988",
+					"172.17.0.1:38988",
+					"172.18.0.1:38988",
+					"172.19.0.1:38988",
+					"172.20.0.1:38988",
+					"172.21.0.1:38988",
+					"172.22.0.1:38988",
+					"172.23.0.1:38988",
+					"172.24.0.1:38988",
+					"172.25.0.1:38988",
+					"172.26.0.1:38988",
+					"172.27.0.1:38988",
+					"172.28.0.1:38988"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:17:29.183402864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4946368161903454,
+				"StableID":   "nb1gRqhDdf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec62fe51cac5cc9f43ad8aca85e4510bb568ced679df71a767ce190ab13b024b",
+				"DiscoKey":   "discokey:57e5df14c1618fe5956e9c0514572103cc8b6d87bc0a70a7b63460f6d127fe01",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48298",
+					"10.65.0.27:48298",
+					"172.17.0.1:48298",
+					"172.18.0.1:48298",
+					"172.19.0.1:48298",
+					"172.20.0.1:48298",
+					"172.21.0.1:48298",
+					"172.22.0.1:48298",
+					"172.23.0.1:48298",
+					"172.24.0.1:48298",
+					"172.25.0.1:48298",
+					"172.26.0.1:48298",
+					"172.27.0.1:48298",
+					"172.28.0.1:48298"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:17:29.73586827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3154700592985201,
+				"StableID":   "ncLydqdmdR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d499e95919abd1e7c7c3cb3b81bb9729ac709f4db6ae61040ed723a31b7bf67c",
+				"DiscoKey":   "discokey:569a0f33a5360c93a079a374be601613cf704794f8f00c8ac6727eb5adb0d502",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38714",
+					"10.65.0.27:38714",
+					"172.17.0.1:38714",
+					"172.18.0.1:38714",
+					"172.19.0.1:38714",
+					"172.20.0.1:38714",
+					"172.21.0.1:38714",
+					"172.22.0.1:38714",
+					"172.23.0.1:38714",
+					"172.24.0.1:38714",
+					"172.25.0.1:38714",
+					"172.26.0.1:38714",
+					"172.27.0.1:38714",
+					"172.28.0.1:38714"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:17:30.264898478Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6208974310850102,
+				"StableID":   "nVCYD9E4Vq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af7ffec8810d5b3fe5923128358511f60581552520a1e72aae1c05adb2eaaa64",
+				"DiscoKey":   "discokey:c0cc373615cff41800b24e3a13eab3c1133ba1395a28a8efd8267546fc25cb56",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47124",
+					"10.65.0.27:47124",
+					"172.17.0.1:47124",
+					"172.18.0.1:47124",
+					"172.19.0.1:47124",
+					"172.20.0.1:47124",
+					"172.21.0.1:47124",
+					"172.22.0.1:47124",
+					"172.23.0.1:47124",
+					"172.24.0.1:47124",
+					"172.25.0.1:47124",
+					"172.26.0.1:47124",
+					"172.27.0.1:47124",
+					"172.28.0.1:47124"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:17:30.804386633Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5352238830031791,
+				"StableID":   "nLqgXpE3oi11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:64e261e1bb2482497b377ccc7f0b6a9ef29225abef61bbd0e43f7b2bb4b59548",
+				"DiscoKey":   "discokey:fe0db25ff7c34a4af51f837364d556b38c33b03d2f354bf563cbb6d0a5dffa68",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54665",
+					"10.65.0.27:54665",
+					"172.17.0.1:54665",
+					"172.18.0.1:54665",
+					"172.19.0.1:54665",
+					"172.20.0.1:54665",
+					"172.21.0.1:54665",
+					"172.22.0.1:54665",
+					"172.23.0.1:54665",
+					"172.24.0.1:54665",
+					"172.25.0.1:54665",
+					"172.26.0.1:54665",
+					"172.27.0.1:54665",
+					"172.28.0.1:54665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:17:31.336846118Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3877487888534945,
+				"StableID":   "n44qsq28HX11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:88459b5ce2d35ea5962fb966cc017777fab80d0309ccbf1784920f224aa93d11",
+				"DiscoKey":   "discokey:dd9fca8e7a32bb7fb8d077f7ca91a572a6d3f4544bc59993a1e9bcd2d5233137",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:55045",
+					"10.65.0.27:55045",
+					"172.17.0.1:55045",
+					"172.18.0.1:55045",
+					"172.19.0.1:55045",
+					"172.20.0.1:55045",
+					"172.21.0.1:55045",
+					"172.22.0.1:55045",
+					"172.23.0.1:55045",
+					"172.24.0.1:55045",
+					"172.25.0.1:55045",
+					"172.26.0.1:55045",
+					"172.27.0.1:55045",
+					"172.28.0.1:55045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:17:31.923308474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6775939488263536,
+				"StableID":   "nT4sTYSquu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d9edf97ee150ce92d98d1a65dfc848b7f5f5532b50feb0ac766f912b7e6153e",
+				"DiscoKey":   "discokey:db9366b0621b82422e3ef035d440cd5913199af49ec8df2f61f8eda98be3931f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:32885",
+					"10.65.0.27:32885",
+					"172.17.0.1:32885",
+					"172.18.0.1:32885",
+					"172.19.0.1:32885",
+					"172.20.0.1:32885",
+					"172.21.0.1:32885",
+					"172.22.0.1:32885",
+					"172.23.0.1:32885",
+					"172.24.0.1:32885",
+					"172.25.0.1:32885",
+					"172.26.0.1:32885",
+					"172.27.0.1:32885",
+					"172.28.0.1:32885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:17:32.470384761Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1642175263121054,
+				"StableID":   "nRtwdFAkpD11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af45f6c34aaded41b49ccefb641dfe8594f0a2aeafb7b9d03c1f2bb2db082255",
+				"DiscoKey":   "discokey:6de66d3dbb146817449cd4bd469cdd3859bb6f1c7e98dd9281113643c0d6c05a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44111",
+					"10.65.0.27:44111",
+					"172.17.0.1:44111",
+					"172.18.0.1:44111",
+					"172.19.0.1:44111",
+					"172.20.0.1:44111",
+					"172.21.0.1:44111",
+					"172.22.0.1:44111",
+					"172.23.0.1:44111",
+					"172.24.0.1:44111",
+					"172.25.0.1:44111",
+					"172.26.0.1:44111",
+					"172.27.0.1:44111",
+					"172.28.0.1:44111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:17:33.012319725Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7609651075458153,
+				"StableID":   "nUWiWYdRR221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a35f5c2db011b7f7550698c55688b6dbede87f56db3a18ae4e5d9f7089a8306b",
+				"KeyExpiry":  "2026-11-09T09:17:34Z",
+				"DiscoKey":   "discokey:f591d8af27668c045e2f33927567688e9915163ffc5a769e83ca1ba65ff5e164",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49541",
+					"10.65.0.27:49541",
+					"172.17.0.1:49541",
+					"172.18.0.1:49541",
+					"172.19.0.1:49541",
+					"172.20.0.1:49541",
+					"172.21.0.1:49541",
+					"172.22.0.1:49541",
+					"172.23.0.1:49541",
+					"172.24.0.1:49541",
+					"172.25.0.1:49541",
+					"172.26.0.1:49541",
+					"172.27.0.1:49541",
+					"172.28.0.1:49541"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:17:34.094327635Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6959374370599248,
+				"StableID":   "nw8astxuLw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5fcc8d855420dbf95e34ac09a3439f2879a30d55cb4c8c93354b03e94610df01",
+				"KeyExpiry":  "2026-11-09T09:17:34Z",
+				"DiscoKey":   "discokey:38ceb917783142ef6a89f7a6fc8d3acae022852743b459a2fba28a2c9e85360c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51108",
+					"10.65.0.27:51108",
+					"172.17.0.1:51108",
+					"172.18.0.1:51108",
+					"172.19.0.1:51108",
+					"172.20.0.1:51108",
+					"172.21.0.1:51108",
+					"172.22.0.1:51108",
+					"172.23.0.1:51108",
+					"172.24.0.1:51108",
+					"172.25.0.1:51108",
+					"172.26.0.1:51108",
+					"172.27.0.1:51108",
+					"172.28.0.1:51108"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:17:34.646533445Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3229698221397392,
+				"StableID":   "nV96FMhjDS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:69853df8125c47b11605630704f9718bd263073378e2c9ab06d92ffad055f440",
+				"KeyExpiry":  "2026-11-09T09:17:35Z",
+				"DiscoKey":   "discokey:d6fe8ea030f27c7f096ee187a0ce83d33110ad7217cae9fd3b6298191d58dc48",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39247",
+					"10.65.0.27:39247",
+					"172.17.0.1:39247",
+					"172.18.0.1:39247",
+					"172.19.0.1:39247",
+					"172.20.0.1:39247",
+					"172.21.0.1:39247",
+					"172.22.0.1:39247",
+					"172.23.0.1:39247",
+					"172.24.0.1:39247",
+					"172.25.0.1:39247",
+					"172.26.0.1:39247",
+					"172.27.0.1:39247",
+					"172.28.0.1:39247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:17:35.203500028Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{
+				"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+				"sshUsers":   {"root": "root"},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				},
+				"acceptEnv": ["TERM"]
+			}, {
+				"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+				"sshUsers":   {"root": "root"},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				},
+				"acceptEnv": ["LC_*"]
+			}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2205486211879948": {
+				"ID":          2205486211879948,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		},
+		"ssh_rules": [{
+			"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+			"sshUsers":   {"root": "root"},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			},
+			"acceptEnv": ["TERM"]
+		}, {
+			"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+			"sshUsers":   {"root": "root"},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			},
+			"acceptEnv": ["LC_*"]
+		}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3154700592985201,
+				"StableID":   "ncLydqdmdR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       3154700592985201,
+				"Key":        "nodekey:d499e95919abd1e7c7c3cb3b81bb9729ac709f4db6ae61040ed723a31b7bf67c",
+				"DiscoKey":   "discokey:569a0f33a5360c93a079a374be601613cf704794f8f00c8ac6727eb5adb0d502",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38714",
+					"10.65.0.27:38714",
+					"172.17.0.1:38714",
+					"172.18.0.1:38714",
+					"172.19.0.1:38714",
+					"172.20.0.1:38714",
+					"172.21.0.1:38714",
+					"172.22.0.1:38714",
+					"172.23.0.1:38714",
+					"172.24.0.1:38714",
+					"172.25.0.1:38714",
+					"172.26.0.1:38714",
+					"172.27.0.1:38714",
+					"172.28.0.1:38714"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:17:30.264898478Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d499e95919abd1e7c7c3cb3b81bb9729ac709f4db6ae61040ed723a31b7bf67c",
+			"MachineKey": "mkey:070e516160f27d44b335003d316d92d898e1f9c37d0d397c50e79c852b713f38",
+			"Peers": [{
+				"ID":         7267738963119122,
+				"StableID":   "n1E9yMBaky11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90085b2eac99b281e0343aa6634593a7ed4bd8e47e40c08c1c011bb05508f749",
+				"DiscoKey":   "discokey:a0ee95e28dd3d32bc9be6488d5030e36ca6d6fd123030794ef10140c5729ea3c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38781",
+					"10.65.0.27:38781",
+					"172.17.0.1:38781",
+					"172.18.0.1:38781",
+					"172.19.0.1:38781",
+					"172.20.0.1:38781",
+					"172.21.0.1:38781",
+					"172.22.0.1:38781",
+					"172.23.0.1:38781",
+					"172.24.0.1:38781",
+					"172.25.0.1:38781",
+					"172.26.0.1:38781",
+					"172.27.0.1:38781",
+					"172.28.0.1:38781"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:17:27.367207025Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3909302976209550,
+				"StableID":   "nohFE6mXXX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a1743f26bdca03b52d481b3ea0584a7d606430e2e0c506ca6be1a30e8b4a3006",
+				"DiscoKey":   "discokey:6b586235ad5cc37daf7c0463b5fdafe6c46269d42f31001c1df6f64828726b58",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44597",
+					"10.65.0.27:44597",
+					"172.17.0.1:44597",
+					"172.18.0.1:44597",
+					"172.19.0.1:44597",
+					"172.20.0.1:44597",
+					"172.21.0.1:44597",
+					"172.22.0.1:44597",
+					"172.23.0.1:44597",
+					"172.24.0.1:44597",
+					"172.25.0.1:44597",
+					"172.26.0.1:44597",
+					"172.27.0.1:44597",
+					"172.28.0.1:44597"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:17:28.086837834Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         387632227359478,
+				"StableID":   "nbykYbSZ2411CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a1f01689a1e22ccac1cffb0f5b21ce4fbeb85ddeefc7c80523dcda5a0a5d0948",
+				"DiscoKey":   "discokey:7366f41f4cee419ce831f057a4d5a6e2dfa7f3e7200e53e4b7685500c1e7a77a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:54326",
+					"10.65.0.27:54326",
+					"172.17.0.1:54326",
+					"172.18.0.1:54326",
+					"172.19.0.1:54326",
+					"172.20.0.1:54326",
+					"172.21.0.1:54326",
+					"172.22.0.1:54326",
+					"172.23.0.1:54326",
+					"172.24.0.1:54326",
+					"172.25.0.1:54326",
+					"172.26.0.1:54326",
+					"172.27.0.1:54326",
+					"172.28.0.1:54326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:17:28.629811446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1278908908902243,
+				"StableID":   "npMzrZmDzA11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85b6dab0e12f1319ae37b0135c9346681d5e7c73508525f26b4ffee8db753923",
+				"DiscoKey":   "discokey:c8f1d2be652eb4c31c8210d75f692358985d2162a07c93a072da3ae9f83cb501",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:38988",
+					"10.65.0.27:38988",
+					"172.17.0.1:38988",
+					"172.18.0.1:38988",
+					"172.19.0.1:38988",
+					"172.20.0.1:38988",
+					"172.21.0.1:38988",
+					"172.22.0.1:38988",
+					"172.23.0.1:38988",
+					"172.24.0.1:38988",
+					"172.25.0.1:38988",
+					"172.26.0.1:38988",
+					"172.27.0.1:38988",
+					"172.28.0.1:38988"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:17:29.183402864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4946368161903454,
+				"StableID":   "nb1gRqhDdf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec62fe51cac5cc9f43ad8aca85e4510bb568ced679df71a767ce190ab13b024b",
+				"DiscoKey":   "discokey:57e5df14c1618fe5956e9c0514572103cc8b6d87bc0a70a7b63460f6d127fe01",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48298",
+					"10.65.0.27:48298",
+					"172.17.0.1:48298",
+					"172.18.0.1:48298",
+					"172.19.0.1:48298",
+					"172.20.0.1:48298",
+					"172.21.0.1:48298",
+					"172.22.0.1:48298",
+					"172.23.0.1:48298",
+					"172.24.0.1:48298",
+					"172.25.0.1:48298",
+					"172.26.0.1:48298",
+					"172.27.0.1:48298",
+					"172.28.0.1:48298"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:17:29.73586827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6208974310850102,
+				"StableID":   "nVCYD9E4Vq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af7ffec8810d5b3fe5923128358511f60581552520a1e72aae1c05adb2eaaa64",
+				"DiscoKey":   "discokey:c0cc373615cff41800b24e3a13eab3c1133ba1395a28a8efd8267546fc25cb56",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47124",
+					"10.65.0.27:47124",
+					"172.17.0.1:47124",
+					"172.18.0.1:47124",
+					"172.19.0.1:47124",
+					"172.20.0.1:47124",
+					"172.21.0.1:47124",
+					"172.22.0.1:47124",
+					"172.23.0.1:47124",
+					"172.24.0.1:47124",
+					"172.25.0.1:47124",
+					"172.26.0.1:47124",
+					"172.27.0.1:47124",
+					"172.28.0.1:47124"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:17:30.804386633Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5352238830031791,
+				"StableID":   "nLqgXpE3oi11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:64e261e1bb2482497b377ccc7f0b6a9ef29225abef61bbd0e43f7b2bb4b59548",
+				"DiscoKey":   "discokey:fe0db25ff7c34a4af51f837364d556b38c33b03d2f354bf563cbb6d0a5dffa68",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54665",
+					"10.65.0.27:54665",
+					"172.17.0.1:54665",
+					"172.18.0.1:54665",
+					"172.19.0.1:54665",
+					"172.20.0.1:54665",
+					"172.21.0.1:54665",
+					"172.22.0.1:54665",
+					"172.23.0.1:54665",
+					"172.24.0.1:54665",
+					"172.25.0.1:54665",
+					"172.26.0.1:54665",
+					"172.27.0.1:54665",
+					"172.28.0.1:54665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:17:31.336846118Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3877487888534945,
+				"StableID":   "n44qsq28HX11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:88459b5ce2d35ea5962fb966cc017777fab80d0309ccbf1784920f224aa93d11",
+				"DiscoKey":   "discokey:dd9fca8e7a32bb7fb8d077f7ca91a572a6d3f4544bc59993a1e9bcd2d5233137",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:55045",
+					"10.65.0.27:55045",
+					"172.17.0.1:55045",
+					"172.18.0.1:55045",
+					"172.19.0.1:55045",
+					"172.20.0.1:55045",
+					"172.21.0.1:55045",
+					"172.22.0.1:55045",
+					"172.23.0.1:55045",
+					"172.24.0.1:55045",
+					"172.25.0.1:55045",
+					"172.26.0.1:55045",
+					"172.27.0.1:55045",
+					"172.28.0.1:55045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:17:31.923308474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6775939488263536,
+				"StableID":   "nT4sTYSquu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d9edf97ee150ce92d98d1a65dfc848b7f5f5532b50feb0ac766f912b7e6153e",
+				"DiscoKey":   "discokey:db9366b0621b82422e3ef035d440cd5913199af49ec8df2f61f8eda98be3931f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:32885",
+					"10.65.0.27:32885",
+					"172.17.0.1:32885",
+					"172.18.0.1:32885",
+					"172.19.0.1:32885",
+					"172.20.0.1:32885",
+					"172.21.0.1:32885",
+					"172.22.0.1:32885",
+					"172.23.0.1:32885",
+					"172.24.0.1:32885",
+					"172.25.0.1:32885",
+					"172.26.0.1:32885",
+					"172.27.0.1:32885",
+					"172.28.0.1:32885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:17:32.470384761Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1642175263121054,
+				"StableID":   "nRtwdFAkpD11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af45f6c34aaded41b49ccefb641dfe8594f0a2aeafb7b9d03c1f2bb2db082255",
+				"DiscoKey":   "discokey:6de66d3dbb146817449cd4bd469cdd3859bb6f1c7e98dd9281113643c0d6c05a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44111",
+					"10.65.0.27:44111",
+					"172.17.0.1:44111",
+					"172.18.0.1:44111",
+					"172.19.0.1:44111",
+					"172.20.0.1:44111",
+					"172.21.0.1:44111",
+					"172.22.0.1:44111",
+					"172.23.0.1:44111",
+					"172.24.0.1:44111",
+					"172.25.0.1:44111",
+					"172.26.0.1:44111",
+					"172.27.0.1:44111",
+					"172.28.0.1:44111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:17:33.012319725Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2205486211879948,
+				"StableID":   "njAFDDPsDJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:280db06fdb1275071ce0e8b86d3f3ec2781914c95854a9bf9731471ca3368118",
+				"DiscoKey":   "discokey:6c3aa80a7e71cd8999abc158814de52644e6bcc18e5fa5ce8d8d0992eac7c53a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41569",
+					"10.65.0.27:41569",
+					"172.17.0.1:41569",
+					"172.18.0.1:41569",
+					"172.19.0.1:41569",
+					"172.20.0.1:41569",
+					"172.21.0.1:41569",
+					"172.22.0.1:41569",
+					"172.23.0.1:41569",
+					"172.24.0.1:41569",
+					"172.25.0.1:41569",
+					"172.26.0.1:41569",
+					"172.27.0.1:41569",
+					"172.28.0.1:41569"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:17:33.553972143Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7609651075458153,
+				"StableID":   "nUWiWYdRR221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a35f5c2db011b7f7550698c55688b6dbede87f56db3a18ae4e5d9f7089a8306b",
+				"KeyExpiry":  "2026-11-09T09:17:34Z",
+				"DiscoKey":   "discokey:f591d8af27668c045e2f33927567688e9915163ffc5a769e83ca1ba65ff5e164",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49541",
+					"10.65.0.27:49541",
+					"172.17.0.1:49541",
+					"172.18.0.1:49541",
+					"172.19.0.1:49541",
+					"172.20.0.1:49541",
+					"172.21.0.1:49541",
+					"172.22.0.1:49541",
+					"172.23.0.1:49541",
+					"172.24.0.1:49541",
+					"172.25.0.1:49541",
+					"172.26.0.1:49541",
+					"172.27.0.1:49541",
+					"172.28.0.1:49541"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:17:34.094327635Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6959374370599248,
+				"StableID":   "nw8astxuLw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5fcc8d855420dbf95e34ac09a3439f2879a30d55cb4c8c93354b03e94610df01",
+				"KeyExpiry":  "2026-11-09T09:17:34Z",
+				"DiscoKey":   "discokey:38ceb917783142ef6a89f7a6fc8d3acae022852743b459a2fba28a2c9e85360c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51108",
+					"10.65.0.27:51108",
+					"172.17.0.1:51108",
+					"172.18.0.1:51108",
+					"172.19.0.1:51108",
+					"172.20.0.1:51108",
+					"172.21.0.1:51108",
+					"172.22.0.1:51108",
+					"172.23.0.1:51108",
+					"172.24.0.1:51108",
+					"172.25.0.1:51108",
+					"172.26.0.1:51108",
+					"172.27.0.1:51108",
+					"172.28.0.1:51108"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:17:34.646533445Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3229698221397392,
+				"StableID":   "nV96FMhjDS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:69853df8125c47b11605630704f9718bd263073378e2c9ab06d92ffad055f440",
+				"KeyExpiry":  "2026-11-09T09:17:35Z",
+				"DiscoKey":   "discokey:d6fe8ea030f27c7f096ee187a0ce83d33110ad7217cae9fd3b6298191d58dc48",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39247",
+					"10.65.0.27:39247",
+					"172.17.0.1:39247",
+					"172.18.0.1:39247",
+					"172.19.0.1:39247",
+					"172.20.0.1:39247",
+					"172.21.0.1:39247",
+					"172.22.0.1:39247",
+					"172.23.0.1:39247",
+					"172.24.0.1:39247",
+					"172.25.0.1:39247",
+					"172.26.0.1:39247",
+					"172.27.0.1:39247",
+					"172.28.0.1:39247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:17:35.203500028Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3154700592985201": {
+				"ID":          3154700592985201,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3229698221397392,
+				"StableID":   "nV96FMhjDS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:69853df8125c47b11605630704f9718bd263073378e2c9ab06d92ffad055f440",
+				"KeyExpiry":  "2026-11-09T09:17:35Z",
+				"DiscoKey":   "discokey:d6fe8ea030f27c7f096ee187a0ce83d33110ad7217cae9fd3b6298191d58dc48",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39247",
+					"10.65.0.27:39247",
+					"172.17.0.1:39247",
+					"172.18.0.1:39247",
+					"172.19.0.1:39247",
+					"172.20.0.1:39247",
+					"172.21.0.1:39247",
+					"172.22.0.1:39247",
+					"172.23.0.1:39247",
+					"172.24.0.1:39247",
+					"172.25.0.1:39247",
+					"172.26.0.1:39247",
+					"172.27.0.1:39247",
+					"172.28.0.1:39247"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:17:35.203500028Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:69853df8125c47b11605630704f9718bd263073378e2c9ab06d92ffad055f440",
+			"MachineKey": "mkey:559a6a9b38807b688714af2a4c6df7a3bd6eb18342e45421e5e7c8b81f8dfa1d",
+			"Peers": [{
+				"ID":         7267738963119122,
+				"StableID":   "n1E9yMBaky11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90085b2eac99b281e0343aa6634593a7ed4bd8e47e40c08c1c011bb05508f749",
+				"DiscoKey":   "discokey:a0ee95e28dd3d32bc9be6488d5030e36ca6d6fd123030794ef10140c5729ea3c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38781",
+					"10.65.0.27:38781",
+					"172.17.0.1:38781",
+					"172.18.0.1:38781",
+					"172.19.0.1:38781",
+					"172.20.0.1:38781",
+					"172.21.0.1:38781",
+					"172.22.0.1:38781",
+					"172.23.0.1:38781",
+					"172.24.0.1:38781",
+					"172.25.0.1:38781",
+					"172.26.0.1:38781",
+					"172.27.0.1:38781",
+					"172.28.0.1:38781"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:17:27.367207025Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3909302976209550,
+				"StableID":   "nohFE6mXXX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a1743f26bdca03b52d481b3ea0584a7d606430e2e0c506ca6be1a30e8b4a3006",
+				"DiscoKey":   "discokey:6b586235ad5cc37daf7c0463b5fdafe6c46269d42f31001c1df6f64828726b58",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44597",
+					"10.65.0.27:44597",
+					"172.17.0.1:44597",
+					"172.18.0.1:44597",
+					"172.19.0.1:44597",
+					"172.20.0.1:44597",
+					"172.21.0.1:44597",
+					"172.22.0.1:44597",
+					"172.23.0.1:44597",
+					"172.24.0.1:44597",
+					"172.25.0.1:44597",
+					"172.26.0.1:44597",
+					"172.27.0.1:44597",
+					"172.28.0.1:44597"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:17:28.086837834Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         387632227359478,
+				"StableID":   "nbykYbSZ2411CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a1f01689a1e22ccac1cffb0f5b21ce4fbeb85ddeefc7c80523dcda5a0a5d0948",
+				"DiscoKey":   "discokey:7366f41f4cee419ce831f057a4d5a6e2dfa7f3e7200e53e4b7685500c1e7a77a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:54326",
+					"10.65.0.27:54326",
+					"172.17.0.1:54326",
+					"172.18.0.1:54326",
+					"172.19.0.1:54326",
+					"172.20.0.1:54326",
+					"172.21.0.1:54326",
+					"172.22.0.1:54326",
+					"172.23.0.1:54326",
+					"172.24.0.1:54326",
+					"172.25.0.1:54326",
+					"172.26.0.1:54326",
+					"172.27.0.1:54326",
+					"172.28.0.1:54326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:17:28.629811446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1278908908902243,
+				"StableID":   "npMzrZmDzA11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85b6dab0e12f1319ae37b0135c9346681d5e7c73508525f26b4ffee8db753923",
+				"DiscoKey":   "discokey:c8f1d2be652eb4c31c8210d75f692358985d2162a07c93a072da3ae9f83cb501",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:38988",
+					"10.65.0.27:38988",
+					"172.17.0.1:38988",
+					"172.18.0.1:38988",
+					"172.19.0.1:38988",
+					"172.20.0.1:38988",
+					"172.21.0.1:38988",
+					"172.22.0.1:38988",
+					"172.23.0.1:38988",
+					"172.24.0.1:38988",
+					"172.25.0.1:38988",
+					"172.26.0.1:38988",
+					"172.27.0.1:38988",
+					"172.28.0.1:38988"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:17:29.183402864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4946368161903454,
+				"StableID":   "nb1gRqhDdf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec62fe51cac5cc9f43ad8aca85e4510bb568ced679df71a767ce190ab13b024b",
+				"DiscoKey":   "discokey:57e5df14c1618fe5956e9c0514572103cc8b6d87bc0a70a7b63460f6d127fe01",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48298",
+					"10.65.0.27:48298",
+					"172.17.0.1:48298",
+					"172.18.0.1:48298",
+					"172.19.0.1:48298",
+					"172.20.0.1:48298",
+					"172.21.0.1:48298",
+					"172.22.0.1:48298",
+					"172.23.0.1:48298",
+					"172.24.0.1:48298",
+					"172.25.0.1:48298",
+					"172.26.0.1:48298",
+					"172.27.0.1:48298",
+					"172.28.0.1:48298"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:17:29.73586827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3154700592985201,
+				"StableID":   "ncLydqdmdR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d499e95919abd1e7c7c3cb3b81bb9729ac709f4db6ae61040ed723a31b7bf67c",
+				"DiscoKey":   "discokey:569a0f33a5360c93a079a374be601613cf704794f8f00c8ac6727eb5adb0d502",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38714",
+					"10.65.0.27:38714",
+					"172.17.0.1:38714",
+					"172.18.0.1:38714",
+					"172.19.0.1:38714",
+					"172.20.0.1:38714",
+					"172.21.0.1:38714",
+					"172.22.0.1:38714",
+					"172.23.0.1:38714",
+					"172.24.0.1:38714",
+					"172.25.0.1:38714",
+					"172.26.0.1:38714",
+					"172.27.0.1:38714",
+					"172.28.0.1:38714"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:17:30.264898478Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6208974310850102,
+				"StableID":   "nVCYD9E4Vq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af7ffec8810d5b3fe5923128358511f60581552520a1e72aae1c05adb2eaaa64",
+				"DiscoKey":   "discokey:c0cc373615cff41800b24e3a13eab3c1133ba1395a28a8efd8267546fc25cb56",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47124",
+					"10.65.0.27:47124",
+					"172.17.0.1:47124",
+					"172.18.0.1:47124",
+					"172.19.0.1:47124",
+					"172.20.0.1:47124",
+					"172.21.0.1:47124",
+					"172.22.0.1:47124",
+					"172.23.0.1:47124",
+					"172.24.0.1:47124",
+					"172.25.0.1:47124",
+					"172.26.0.1:47124",
+					"172.27.0.1:47124",
+					"172.28.0.1:47124"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:17:30.804386633Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5352238830031791,
+				"StableID":   "nLqgXpE3oi11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:64e261e1bb2482497b377ccc7f0b6a9ef29225abef61bbd0e43f7b2bb4b59548",
+				"DiscoKey":   "discokey:fe0db25ff7c34a4af51f837364d556b38c33b03d2f354bf563cbb6d0a5dffa68",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54665",
+					"10.65.0.27:54665",
+					"172.17.0.1:54665",
+					"172.18.0.1:54665",
+					"172.19.0.1:54665",
+					"172.20.0.1:54665",
+					"172.21.0.1:54665",
+					"172.22.0.1:54665",
+					"172.23.0.1:54665",
+					"172.24.0.1:54665",
+					"172.25.0.1:54665",
+					"172.26.0.1:54665",
+					"172.27.0.1:54665",
+					"172.28.0.1:54665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:17:31.336846118Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3877487888534945,
+				"StableID":   "n44qsq28HX11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:88459b5ce2d35ea5962fb966cc017777fab80d0309ccbf1784920f224aa93d11",
+				"DiscoKey":   "discokey:dd9fca8e7a32bb7fb8d077f7ca91a572a6d3f4544bc59993a1e9bcd2d5233137",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:55045",
+					"10.65.0.27:55045",
+					"172.17.0.1:55045",
+					"172.18.0.1:55045",
+					"172.19.0.1:55045",
+					"172.20.0.1:55045",
+					"172.21.0.1:55045",
+					"172.22.0.1:55045",
+					"172.23.0.1:55045",
+					"172.24.0.1:55045",
+					"172.25.0.1:55045",
+					"172.26.0.1:55045",
+					"172.27.0.1:55045",
+					"172.28.0.1:55045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:17:31.923308474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6775939488263536,
+				"StableID":   "nT4sTYSquu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d9edf97ee150ce92d98d1a65dfc848b7f5f5532b50feb0ac766f912b7e6153e",
+				"DiscoKey":   "discokey:db9366b0621b82422e3ef035d440cd5913199af49ec8df2f61f8eda98be3931f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:32885",
+					"10.65.0.27:32885",
+					"172.17.0.1:32885",
+					"172.18.0.1:32885",
+					"172.19.0.1:32885",
+					"172.20.0.1:32885",
+					"172.21.0.1:32885",
+					"172.22.0.1:32885",
+					"172.23.0.1:32885",
+					"172.24.0.1:32885",
+					"172.25.0.1:32885",
+					"172.26.0.1:32885",
+					"172.27.0.1:32885",
+					"172.28.0.1:32885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:17:32.470384761Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1642175263121054,
+				"StableID":   "nRtwdFAkpD11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af45f6c34aaded41b49ccefb641dfe8594f0a2aeafb7b9d03c1f2bb2db082255",
+				"DiscoKey":   "discokey:6de66d3dbb146817449cd4bd469cdd3859bb6f1c7e98dd9281113643c0d6c05a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44111",
+					"10.65.0.27:44111",
+					"172.17.0.1:44111",
+					"172.18.0.1:44111",
+					"172.19.0.1:44111",
+					"172.20.0.1:44111",
+					"172.21.0.1:44111",
+					"172.22.0.1:44111",
+					"172.23.0.1:44111",
+					"172.24.0.1:44111",
+					"172.25.0.1:44111",
+					"172.26.0.1:44111",
+					"172.27.0.1:44111",
+					"172.28.0.1:44111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:17:33.012319725Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2205486211879948,
+				"StableID":   "njAFDDPsDJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:280db06fdb1275071ce0e8b86d3f3ec2781914c95854a9bf9731471ca3368118",
+				"DiscoKey":   "discokey:6c3aa80a7e71cd8999abc158814de52644e6bcc18e5fa5ce8d8d0992eac7c53a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41569",
+					"10.65.0.27:41569",
+					"172.17.0.1:41569",
+					"172.18.0.1:41569",
+					"172.19.0.1:41569",
+					"172.20.0.1:41569",
+					"172.21.0.1:41569",
+					"172.22.0.1:41569",
+					"172.23.0.1:41569",
+					"172.24.0.1:41569",
+					"172.25.0.1:41569",
+					"172.26.0.1:41569",
+					"172.27.0.1:41569",
+					"172.28.0.1:41569"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:17:33.553972143Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7609651075458153,
+				"StableID":   "nUWiWYdRR221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a35f5c2db011b7f7550698c55688b6dbede87f56db3a18ae4e5d9f7089a8306b",
+				"KeyExpiry":  "2026-11-09T09:17:34Z",
+				"DiscoKey":   "discokey:f591d8af27668c045e2f33927567688e9915163ffc5a769e83ca1ba65ff5e164",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49541",
+					"10.65.0.27:49541",
+					"172.17.0.1:49541",
+					"172.18.0.1:49541",
+					"172.19.0.1:49541",
+					"172.20.0.1:49541",
+					"172.21.0.1:49541",
+					"172.22.0.1:49541",
+					"172.23.0.1:49541",
+					"172.24.0.1:49541",
+					"172.25.0.1:49541",
+					"172.26.0.1:49541",
+					"172.27.0.1:49541",
+					"172.28.0.1:49541"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:17:34.094327635Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6959374370599248,
+				"StableID":   "nw8astxuLw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5fcc8d855420dbf95e34ac09a3439f2879a30d55cb4c8c93354b03e94610df01",
+				"KeyExpiry":  "2026-11-09T09:17:34Z",
+				"DiscoKey":   "discokey:38ceb917783142ef6a89f7a6fc8d3acae022852743b459a2fba28a2c9e85360c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51108",
+					"10.65.0.27:51108",
+					"172.17.0.1:51108",
+					"172.18.0.1:51108",
+					"172.19.0.1:51108",
+					"172.20.0.1:51108",
+					"172.21.0.1:51108",
+					"172.22.0.1:51108",
+					"172.23.0.1:51108",
+					"172.24.0.1:51108",
+					"172.25.0.1:51108",
+					"172.26.0.1:51108",
+					"172.27.0.1:51108",
+					"172.28.0.1:51108"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:17:34.646533445Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         387632227359478,
+				"StableID":   "nbykYbSZ2411CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       387632227359478,
+				"Key":        "nodekey:a1f01689a1e22ccac1cffb0f5b21ce4fbeb85ddeefc7c80523dcda5a0a5d0948",
+				"DiscoKey":   "discokey:7366f41f4cee419ce831f057a4d5a6e2dfa7f3e7200e53e4b7685500c1e7a77a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:54326",
+					"10.65.0.27:54326",
+					"172.17.0.1:54326",
+					"172.18.0.1:54326",
+					"172.19.0.1:54326",
+					"172.20.0.1:54326",
+					"172.21.0.1:54326",
+					"172.22.0.1:54326",
+					"172.23.0.1:54326",
+					"172.24.0.1:54326",
+					"172.25.0.1:54326",
+					"172.26.0.1:54326",
+					"172.27.0.1:54326",
+					"172.28.0.1:54326"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:17:28.629811446Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a1f01689a1e22ccac1cffb0f5b21ce4fbeb85ddeefc7c80523dcda5a0a5d0948",
+			"MachineKey": "mkey:9b36e96451dd43e8bef54601994d3bd4d7ec75dac6b89289711ae2ca966c9c16",
+			"Peers": [{
+				"ID":         7267738963119122,
+				"StableID":   "n1E9yMBaky11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90085b2eac99b281e0343aa6634593a7ed4bd8e47e40c08c1c011bb05508f749",
+				"DiscoKey":   "discokey:a0ee95e28dd3d32bc9be6488d5030e36ca6d6fd123030794ef10140c5729ea3c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38781",
+					"10.65.0.27:38781",
+					"172.17.0.1:38781",
+					"172.18.0.1:38781",
+					"172.19.0.1:38781",
+					"172.20.0.1:38781",
+					"172.21.0.1:38781",
+					"172.22.0.1:38781",
+					"172.23.0.1:38781",
+					"172.24.0.1:38781",
+					"172.25.0.1:38781",
+					"172.26.0.1:38781",
+					"172.27.0.1:38781",
+					"172.28.0.1:38781"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:17:27.367207025Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3909302976209550,
+				"StableID":   "nohFE6mXXX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a1743f26bdca03b52d481b3ea0584a7d606430e2e0c506ca6be1a30e8b4a3006",
+				"DiscoKey":   "discokey:6b586235ad5cc37daf7c0463b5fdafe6c46269d42f31001c1df6f64828726b58",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44597",
+					"10.65.0.27:44597",
+					"172.17.0.1:44597",
+					"172.18.0.1:44597",
+					"172.19.0.1:44597",
+					"172.20.0.1:44597",
+					"172.21.0.1:44597",
+					"172.22.0.1:44597",
+					"172.23.0.1:44597",
+					"172.24.0.1:44597",
+					"172.25.0.1:44597",
+					"172.26.0.1:44597",
+					"172.27.0.1:44597",
+					"172.28.0.1:44597"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:17:28.086837834Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1278908908902243,
+				"StableID":   "npMzrZmDzA11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85b6dab0e12f1319ae37b0135c9346681d5e7c73508525f26b4ffee8db753923",
+				"DiscoKey":   "discokey:c8f1d2be652eb4c31c8210d75f692358985d2162a07c93a072da3ae9f83cb501",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:38988",
+					"10.65.0.27:38988",
+					"172.17.0.1:38988",
+					"172.18.0.1:38988",
+					"172.19.0.1:38988",
+					"172.20.0.1:38988",
+					"172.21.0.1:38988",
+					"172.22.0.1:38988",
+					"172.23.0.1:38988",
+					"172.24.0.1:38988",
+					"172.25.0.1:38988",
+					"172.26.0.1:38988",
+					"172.27.0.1:38988",
+					"172.28.0.1:38988"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:17:29.183402864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4946368161903454,
+				"StableID":   "nb1gRqhDdf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec62fe51cac5cc9f43ad8aca85e4510bb568ced679df71a767ce190ab13b024b",
+				"DiscoKey":   "discokey:57e5df14c1618fe5956e9c0514572103cc8b6d87bc0a70a7b63460f6d127fe01",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48298",
+					"10.65.0.27:48298",
+					"172.17.0.1:48298",
+					"172.18.0.1:48298",
+					"172.19.0.1:48298",
+					"172.20.0.1:48298",
+					"172.21.0.1:48298",
+					"172.22.0.1:48298",
+					"172.23.0.1:48298",
+					"172.24.0.1:48298",
+					"172.25.0.1:48298",
+					"172.26.0.1:48298",
+					"172.27.0.1:48298",
+					"172.28.0.1:48298"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:17:29.73586827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3154700592985201,
+				"StableID":   "ncLydqdmdR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d499e95919abd1e7c7c3cb3b81bb9729ac709f4db6ae61040ed723a31b7bf67c",
+				"DiscoKey":   "discokey:569a0f33a5360c93a079a374be601613cf704794f8f00c8ac6727eb5adb0d502",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38714",
+					"10.65.0.27:38714",
+					"172.17.0.1:38714",
+					"172.18.0.1:38714",
+					"172.19.0.1:38714",
+					"172.20.0.1:38714",
+					"172.21.0.1:38714",
+					"172.22.0.1:38714",
+					"172.23.0.1:38714",
+					"172.24.0.1:38714",
+					"172.25.0.1:38714",
+					"172.26.0.1:38714",
+					"172.27.0.1:38714",
+					"172.28.0.1:38714"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:17:30.264898478Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6208974310850102,
+				"StableID":   "nVCYD9E4Vq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af7ffec8810d5b3fe5923128358511f60581552520a1e72aae1c05adb2eaaa64",
+				"DiscoKey":   "discokey:c0cc373615cff41800b24e3a13eab3c1133ba1395a28a8efd8267546fc25cb56",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47124",
+					"10.65.0.27:47124",
+					"172.17.0.1:47124",
+					"172.18.0.1:47124",
+					"172.19.0.1:47124",
+					"172.20.0.1:47124",
+					"172.21.0.1:47124",
+					"172.22.0.1:47124",
+					"172.23.0.1:47124",
+					"172.24.0.1:47124",
+					"172.25.0.1:47124",
+					"172.26.0.1:47124",
+					"172.27.0.1:47124",
+					"172.28.0.1:47124"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:17:30.804386633Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5352238830031791,
+				"StableID":   "nLqgXpE3oi11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:64e261e1bb2482497b377ccc7f0b6a9ef29225abef61bbd0e43f7b2bb4b59548",
+				"DiscoKey":   "discokey:fe0db25ff7c34a4af51f837364d556b38c33b03d2f354bf563cbb6d0a5dffa68",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54665",
+					"10.65.0.27:54665",
+					"172.17.0.1:54665",
+					"172.18.0.1:54665",
+					"172.19.0.1:54665",
+					"172.20.0.1:54665",
+					"172.21.0.1:54665",
+					"172.22.0.1:54665",
+					"172.23.0.1:54665",
+					"172.24.0.1:54665",
+					"172.25.0.1:54665",
+					"172.26.0.1:54665",
+					"172.27.0.1:54665",
+					"172.28.0.1:54665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:17:31.336846118Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3877487888534945,
+				"StableID":   "n44qsq28HX11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:88459b5ce2d35ea5962fb966cc017777fab80d0309ccbf1784920f224aa93d11",
+				"DiscoKey":   "discokey:dd9fca8e7a32bb7fb8d077f7ca91a572a6d3f4544bc59993a1e9bcd2d5233137",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:55045",
+					"10.65.0.27:55045",
+					"172.17.0.1:55045",
+					"172.18.0.1:55045",
+					"172.19.0.1:55045",
+					"172.20.0.1:55045",
+					"172.21.0.1:55045",
+					"172.22.0.1:55045",
+					"172.23.0.1:55045",
+					"172.24.0.1:55045",
+					"172.25.0.1:55045",
+					"172.26.0.1:55045",
+					"172.27.0.1:55045",
+					"172.28.0.1:55045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:17:31.923308474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6775939488263536,
+				"StableID":   "nT4sTYSquu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d9edf97ee150ce92d98d1a65dfc848b7f5f5532b50feb0ac766f912b7e6153e",
+				"DiscoKey":   "discokey:db9366b0621b82422e3ef035d440cd5913199af49ec8df2f61f8eda98be3931f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:32885",
+					"10.65.0.27:32885",
+					"172.17.0.1:32885",
+					"172.18.0.1:32885",
+					"172.19.0.1:32885",
+					"172.20.0.1:32885",
+					"172.21.0.1:32885",
+					"172.22.0.1:32885",
+					"172.23.0.1:32885",
+					"172.24.0.1:32885",
+					"172.25.0.1:32885",
+					"172.26.0.1:32885",
+					"172.27.0.1:32885",
+					"172.28.0.1:32885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:17:32.470384761Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1642175263121054,
+				"StableID":   "nRtwdFAkpD11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af45f6c34aaded41b49ccefb641dfe8594f0a2aeafb7b9d03c1f2bb2db082255",
+				"DiscoKey":   "discokey:6de66d3dbb146817449cd4bd469cdd3859bb6f1c7e98dd9281113643c0d6c05a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44111",
+					"10.65.0.27:44111",
+					"172.17.0.1:44111",
+					"172.18.0.1:44111",
+					"172.19.0.1:44111",
+					"172.20.0.1:44111",
+					"172.21.0.1:44111",
+					"172.22.0.1:44111",
+					"172.23.0.1:44111",
+					"172.24.0.1:44111",
+					"172.25.0.1:44111",
+					"172.26.0.1:44111",
+					"172.27.0.1:44111",
+					"172.28.0.1:44111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:17:33.012319725Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2205486211879948,
+				"StableID":   "njAFDDPsDJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:280db06fdb1275071ce0e8b86d3f3ec2781914c95854a9bf9731471ca3368118",
+				"DiscoKey":   "discokey:6c3aa80a7e71cd8999abc158814de52644e6bcc18e5fa5ce8d8d0992eac7c53a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41569",
+					"10.65.0.27:41569",
+					"172.17.0.1:41569",
+					"172.18.0.1:41569",
+					"172.19.0.1:41569",
+					"172.20.0.1:41569",
+					"172.21.0.1:41569",
+					"172.22.0.1:41569",
+					"172.23.0.1:41569",
+					"172.24.0.1:41569",
+					"172.25.0.1:41569",
+					"172.26.0.1:41569",
+					"172.27.0.1:41569",
+					"172.28.0.1:41569"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:17:33.553972143Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7609651075458153,
+				"StableID":   "nUWiWYdRR221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a35f5c2db011b7f7550698c55688b6dbede87f56db3a18ae4e5d9f7089a8306b",
+				"KeyExpiry":  "2026-11-09T09:17:34Z",
+				"DiscoKey":   "discokey:f591d8af27668c045e2f33927567688e9915163ffc5a769e83ca1ba65ff5e164",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49541",
+					"10.65.0.27:49541",
+					"172.17.0.1:49541",
+					"172.18.0.1:49541",
+					"172.19.0.1:49541",
+					"172.20.0.1:49541",
+					"172.21.0.1:49541",
+					"172.22.0.1:49541",
+					"172.23.0.1:49541",
+					"172.24.0.1:49541",
+					"172.25.0.1:49541",
+					"172.26.0.1:49541",
+					"172.27.0.1:49541",
+					"172.28.0.1:49541"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:17:34.094327635Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6959374370599248,
+				"StableID":   "nw8astxuLw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5fcc8d855420dbf95e34ac09a3439f2879a30d55cb4c8c93354b03e94610df01",
+				"KeyExpiry":  "2026-11-09T09:17:34Z",
+				"DiscoKey":   "discokey:38ceb917783142ef6a89f7a6fc8d3acae022852743b459a2fba28a2c9e85360c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51108",
+					"10.65.0.27:51108",
+					"172.17.0.1:51108",
+					"172.18.0.1:51108",
+					"172.19.0.1:51108",
+					"172.20.0.1:51108",
+					"172.21.0.1:51108",
+					"172.22.0.1:51108",
+					"172.23.0.1:51108",
+					"172.24.0.1:51108",
+					"172.25.0.1:51108",
+					"172.26.0.1:51108",
+					"172.27.0.1:51108",
+					"172.28.0.1:51108"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:17:34.646533445Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3229698221397392,
+				"StableID":   "nV96FMhjDS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:69853df8125c47b11605630704f9718bd263073378e2c9ab06d92ffad055f440",
+				"KeyExpiry":  "2026-11-09T09:17:35Z",
+				"DiscoKey":   "discokey:d6fe8ea030f27c7f096ee187a0ce83d33110ad7217cae9fd3b6298191d58dc48",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39247",
+					"10.65.0.27:39247",
+					"172.17.0.1:39247",
+					"172.18.0.1:39247",
+					"172.19.0.1:39247",
+					"172.20.0.1:39247",
+					"172.21.0.1:39247",
+					"172.22.0.1:39247",
+					"172.23.0.1:39247",
+					"172.24.0.1:39247",
+					"172.25.0.1:39247",
+					"172.26.0.1:39247",
+					"172.27.0.1:39247",
+					"172.28.0.1:39247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:17:35.203500028Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "387632227359478": {
+				"ID":          387632227359478,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5352238830031791,
+				"StableID":   "nLqgXpE3oi11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       5352238830031791,
+				"Key":        "nodekey:64e261e1bb2482497b377ccc7f0b6a9ef29225abef61bbd0e43f7b2bb4b59548",
+				"DiscoKey":   "discokey:fe0db25ff7c34a4af51f837364d556b38c33b03d2f354bf563cbb6d0a5dffa68",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54665",
+					"10.65.0.27:54665",
+					"172.17.0.1:54665",
+					"172.18.0.1:54665",
+					"172.19.0.1:54665",
+					"172.20.0.1:54665",
+					"172.21.0.1:54665",
+					"172.22.0.1:54665",
+					"172.23.0.1:54665",
+					"172.24.0.1:54665",
+					"172.25.0.1:54665",
+					"172.26.0.1:54665",
+					"172.27.0.1:54665",
+					"172.28.0.1:54665"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:17:31.336846118Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:64e261e1bb2482497b377ccc7f0b6a9ef29225abef61bbd0e43f7b2bb4b59548",
+			"MachineKey": "mkey:25af5535db8a99b58eb412beb629802a0273d6463224b73a39f7d5f7de5faf43",
+			"Peers": [{
+				"ID":         7267738963119122,
+				"StableID":   "n1E9yMBaky11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90085b2eac99b281e0343aa6634593a7ed4bd8e47e40c08c1c011bb05508f749",
+				"DiscoKey":   "discokey:a0ee95e28dd3d32bc9be6488d5030e36ca6d6fd123030794ef10140c5729ea3c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38781",
+					"10.65.0.27:38781",
+					"172.17.0.1:38781",
+					"172.18.0.1:38781",
+					"172.19.0.1:38781",
+					"172.20.0.1:38781",
+					"172.21.0.1:38781",
+					"172.22.0.1:38781",
+					"172.23.0.1:38781",
+					"172.24.0.1:38781",
+					"172.25.0.1:38781",
+					"172.26.0.1:38781",
+					"172.27.0.1:38781",
+					"172.28.0.1:38781"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:17:27.367207025Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3909302976209550,
+				"StableID":   "nohFE6mXXX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a1743f26bdca03b52d481b3ea0584a7d606430e2e0c506ca6be1a30e8b4a3006",
+				"DiscoKey":   "discokey:6b586235ad5cc37daf7c0463b5fdafe6c46269d42f31001c1df6f64828726b58",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44597",
+					"10.65.0.27:44597",
+					"172.17.0.1:44597",
+					"172.18.0.1:44597",
+					"172.19.0.1:44597",
+					"172.20.0.1:44597",
+					"172.21.0.1:44597",
+					"172.22.0.1:44597",
+					"172.23.0.1:44597",
+					"172.24.0.1:44597",
+					"172.25.0.1:44597",
+					"172.26.0.1:44597",
+					"172.27.0.1:44597",
+					"172.28.0.1:44597"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:17:28.086837834Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         387632227359478,
+				"StableID":   "nbykYbSZ2411CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a1f01689a1e22ccac1cffb0f5b21ce4fbeb85ddeefc7c80523dcda5a0a5d0948",
+				"DiscoKey":   "discokey:7366f41f4cee419ce831f057a4d5a6e2dfa7f3e7200e53e4b7685500c1e7a77a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:54326",
+					"10.65.0.27:54326",
+					"172.17.0.1:54326",
+					"172.18.0.1:54326",
+					"172.19.0.1:54326",
+					"172.20.0.1:54326",
+					"172.21.0.1:54326",
+					"172.22.0.1:54326",
+					"172.23.0.1:54326",
+					"172.24.0.1:54326",
+					"172.25.0.1:54326",
+					"172.26.0.1:54326",
+					"172.27.0.1:54326",
+					"172.28.0.1:54326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:17:28.629811446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1278908908902243,
+				"StableID":   "npMzrZmDzA11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85b6dab0e12f1319ae37b0135c9346681d5e7c73508525f26b4ffee8db753923",
+				"DiscoKey":   "discokey:c8f1d2be652eb4c31c8210d75f692358985d2162a07c93a072da3ae9f83cb501",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:38988",
+					"10.65.0.27:38988",
+					"172.17.0.1:38988",
+					"172.18.0.1:38988",
+					"172.19.0.1:38988",
+					"172.20.0.1:38988",
+					"172.21.0.1:38988",
+					"172.22.0.1:38988",
+					"172.23.0.1:38988",
+					"172.24.0.1:38988",
+					"172.25.0.1:38988",
+					"172.26.0.1:38988",
+					"172.27.0.1:38988",
+					"172.28.0.1:38988"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:17:29.183402864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4946368161903454,
+				"StableID":   "nb1gRqhDdf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec62fe51cac5cc9f43ad8aca85e4510bb568ced679df71a767ce190ab13b024b",
+				"DiscoKey":   "discokey:57e5df14c1618fe5956e9c0514572103cc8b6d87bc0a70a7b63460f6d127fe01",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48298",
+					"10.65.0.27:48298",
+					"172.17.0.1:48298",
+					"172.18.0.1:48298",
+					"172.19.0.1:48298",
+					"172.20.0.1:48298",
+					"172.21.0.1:48298",
+					"172.22.0.1:48298",
+					"172.23.0.1:48298",
+					"172.24.0.1:48298",
+					"172.25.0.1:48298",
+					"172.26.0.1:48298",
+					"172.27.0.1:48298",
+					"172.28.0.1:48298"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:17:29.73586827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3154700592985201,
+				"StableID":   "ncLydqdmdR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d499e95919abd1e7c7c3cb3b81bb9729ac709f4db6ae61040ed723a31b7bf67c",
+				"DiscoKey":   "discokey:569a0f33a5360c93a079a374be601613cf704794f8f00c8ac6727eb5adb0d502",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38714",
+					"10.65.0.27:38714",
+					"172.17.0.1:38714",
+					"172.18.0.1:38714",
+					"172.19.0.1:38714",
+					"172.20.0.1:38714",
+					"172.21.0.1:38714",
+					"172.22.0.1:38714",
+					"172.23.0.1:38714",
+					"172.24.0.1:38714",
+					"172.25.0.1:38714",
+					"172.26.0.1:38714",
+					"172.27.0.1:38714",
+					"172.28.0.1:38714"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:17:30.264898478Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6208974310850102,
+				"StableID":   "nVCYD9E4Vq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af7ffec8810d5b3fe5923128358511f60581552520a1e72aae1c05adb2eaaa64",
+				"DiscoKey":   "discokey:c0cc373615cff41800b24e3a13eab3c1133ba1395a28a8efd8267546fc25cb56",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47124",
+					"10.65.0.27:47124",
+					"172.17.0.1:47124",
+					"172.18.0.1:47124",
+					"172.19.0.1:47124",
+					"172.20.0.1:47124",
+					"172.21.0.1:47124",
+					"172.22.0.1:47124",
+					"172.23.0.1:47124",
+					"172.24.0.1:47124",
+					"172.25.0.1:47124",
+					"172.26.0.1:47124",
+					"172.27.0.1:47124",
+					"172.28.0.1:47124"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:17:30.804386633Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3877487888534945,
+				"StableID":   "n44qsq28HX11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:88459b5ce2d35ea5962fb966cc017777fab80d0309ccbf1784920f224aa93d11",
+				"DiscoKey":   "discokey:dd9fca8e7a32bb7fb8d077f7ca91a572a6d3f4544bc59993a1e9bcd2d5233137",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:55045",
+					"10.65.0.27:55045",
+					"172.17.0.1:55045",
+					"172.18.0.1:55045",
+					"172.19.0.1:55045",
+					"172.20.0.1:55045",
+					"172.21.0.1:55045",
+					"172.22.0.1:55045",
+					"172.23.0.1:55045",
+					"172.24.0.1:55045",
+					"172.25.0.1:55045",
+					"172.26.0.1:55045",
+					"172.27.0.1:55045",
+					"172.28.0.1:55045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:17:31.923308474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6775939488263536,
+				"StableID":   "nT4sTYSquu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d9edf97ee150ce92d98d1a65dfc848b7f5f5532b50feb0ac766f912b7e6153e",
+				"DiscoKey":   "discokey:db9366b0621b82422e3ef035d440cd5913199af49ec8df2f61f8eda98be3931f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:32885",
+					"10.65.0.27:32885",
+					"172.17.0.1:32885",
+					"172.18.0.1:32885",
+					"172.19.0.1:32885",
+					"172.20.0.1:32885",
+					"172.21.0.1:32885",
+					"172.22.0.1:32885",
+					"172.23.0.1:32885",
+					"172.24.0.1:32885",
+					"172.25.0.1:32885",
+					"172.26.0.1:32885",
+					"172.27.0.1:32885",
+					"172.28.0.1:32885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:17:32.470384761Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1642175263121054,
+				"StableID":   "nRtwdFAkpD11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af45f6c34aaded41b49ccefb641dfe8594f0a2aeafb7b9d03c1f2bb2db082255",
+				"DiscoKey":   "discokey:6de66d3dbb146817449cd4bd469cdd3859bb6f1c7e98dd9281113643c0d6c05a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44111",
+					"10.65.0.27:44111",
+					"172.17.0.1:44111",
+					"172.18.0.1:44111",
+					"172.19.0.1:44111",
+					"172.20.0.1:44111",
+					"172.21.0.1:44111",
+					"172.22.0.1:44111",
+					"172.23.0.1:44111",
+					"172.24.0.1:44111",
+					"172.25.0.1:44111",
+					"172.26.0.1:44111",
+					"172.27.0.1:44111",
+					"172.28.0.1:44111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:17:33.012319725Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2205486211879948,
+				"StableID":   "njAFDDPsDJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:280db06fdb1275071ce0e8b86d3f3ec2781914c95854a9bf9731471ca3368118",
+				"DiscoKey":   "discokey:6c3aa80a7e71cd8999abc158814de52644e6bcc18e5fa5ce8d8d0992eac7c53a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41569",
+					"10.65.0.27:41569",
+					"172.17.0.1:41569",
+					"172.18.0.1:41569",
+					"172.19.0.1:41569",
+					"172.20.0.1:41569",
+					"172.21.0.1:41569",
+					"172.22.0.1:41569",
+					"172.23.0.1:41569",
+					"172.24.0.1:41569",
+					"172.25.0.1:41569",
+					"172.26.0.1:41569",
+					"172.27.0.1:41569",
+					"172.28.0.1:41569"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:17:33.553972143Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7609651075458153,
+				"StableID":   "nUWiWYdRR221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a35f5c2db011b7f7550698c55688b6dbede87f56db3a18ae4e5d9f7089a8306b",
+				"KeyExpiry":  "2026-11-09T09:17:34Z",
+				"DiscoKey":   "discokey:f591d8af27668c045e2f33927567688e9915163ffc5a769e83ca1ba65ff5e164",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49541",
+					"10.65.0.27:49541",
+					"172.17.0.1:49541",
+					"172.18.0.1:49541",
+					"172.19.0.1:49541",
+					"172.20.0.1:49541",
+					"172.21.0.1:49541",
+					"172.22.0.1:49541",
+					"172.23.0.1:49541",
+					"172.24.0.1:49541",
+					"172.25.0.1:49541",
+					"172.26.0.1:49541",
+					"172.27.0.1:49541",
+					"172.28.0.1:49541"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:17:34.094327635Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6959374370599248,
+				"StableID":   "nw8astxuLw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5fcc8d855420dbf95e34ac09a3439f2879a30d55cb4c8c93354b03e94610df01",
+				"KeyExpiry":  "2026-11-09T09:17:34Z",
+				"DiscoKey":   "discokey:38ceb917783142ef6a89f7a6fc8d3acae022852743b459a2fba28a2c9e85360c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51108",
+					"10.65.0.27:51108",
+					"172.17.0.1:51108",
+					"172.18.0.1:51108",
+					"172.19.0.1:51108",
+					"172.20.0.1:51108",
+					"172.21.0.1:51108",
+					"172.22.0.1:51108",
+					"172.23.0.1:51108",
+					"172.24.0.1:51108",
+					"172.25.0.1:51108",
+					"172.26.0.1:51108",
+					"172.27.0.1:51108",
+					"172.28.0.1:51108"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:17:34.646533445Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3229698221397392,
+				"StableID":   "nV96FMhjDS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:69853df8125c47b11605630704f9718bd263073378e2c9ab06d92ffad055f440",
+				"KeyExpiry":  "2026-11-09T09:17:35Z",
+				"DiscoKey":   "discokey:d6fe8ea030f27c7f096ee187a0ce83d33110ad7217cae9fd3b6298191d58dc48",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39247",
+					"10.65.0.27:39247",
+					"172.17.0.1:39247",
+					"172.18.0.1:39247",
+					"172.19.0.1:39247",
+					"172.20.0.1:39247",
+					"172.21.0.1:39247",
+					"172.22.0.1:39247",
+					"172.23.0.1:39247",
+					"172.24.0.1:39247",
+					"172.25.0.1:39247",
+					"172.26.0.1:39247",
+					"172.27.0.1:39247",
+					"172.28.0.1:39247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:17:35.203500028Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5352238830031791": {
+				"ID":          5352238830031791,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7609651075458153,
+				"StableID":   "nUWiWYdRR221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a35f5c2db011b7f7550698c55688b6dbede87f56db3a18ae4e5d9f7089a8306b",
+				"KeyExpiry":  "2026-11-09T09:17:34Z",
+				"DiscoKey":   "discokey:f591d8af27668c045e2f33927567688e9915163ffc5a769e83ca1ba65ff5e164",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49541",
+					"10.65.0.27:49541",
+					"172.17.0.1:49541",
+					"172.18.0.1:49541",
+					"172.19.0.1:49541",
+					"172.20.0.1:49541",
+					"172.21.0.1:49541",
+					"172.22.0.1:49541",
+					"172.23.0.1:49541",
+					"172.24.0.1:49541",
+					"172.25.0.1:49541",
+					"172.26.0.1:49541",
+					"172.27.0.1:49541",
+					"172.28.0.1:49541"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:17:34.094327635Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a35f5c2db011b7f7550698c55688b6dbede87f56db3a18ae4e5d9f7089a8306b",
+			"MachineKey": "mkey:71b49394e01688727fd5057b2ef3927f90e0229c374b0a9903dd4e64a8d84172",
+			"Peers": [{
+				"ID":         7267738963119122,
+				"StableID":   "n1E9yMBaky11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90085b2eac99b281e0343aa6634593a7ed4bd8e47e40c08c1c011bb05508f749",
+				"DiscoKey":   "discokey:a0ee95e28dd3d32bc9be6488d5030e36ca6d6fd123030794ef10140c5729ea3c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38781",
+					"10.65.0.27:38781",
+					"172.17.0.1:38781",
+					"172.18.0.1:38781",
+					"172.19.0.1:38781",
+					"172.20.0.1:38781",
+					"172.21.0.1:38781",
+					"172.22.0.1:38781",
+					"172.23.0.1:38781",
+					"172.24.0.1:38781",
+					"172.25.0.1:38781",
+					"172.26.0.1:38781",
+					"172.27.0.1:38781",
+					"172.28.0.1:38781"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:17:27.367207025Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3909302976209550,
+				"StableID":   "nohFE6mXXX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a1743f26bdca03b52d481b3ea0584a7d606430e2e0c506ca6be1a30e8b4a3006",
+				"DiscoKey":   "discokey:6b586235ad5cc37daf7c0463b5fdafe6c46269d42f31001c1df6f64828726b58",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44597",
+					"10.65.0.27:44597",
+					"172.17.0.1:44597",
+					"172.18.0.1:44597",
+					"172.19.0.1:44597",
+					"172.20.0.1:44597",
+					"172.21.0.1:44597",
+					"172.22.0.1:44597",
+					"172.23.0.1:44597",
+					"172.24.0.1:44597",
+					"172.25.0.1:44597",
+					"172.26.0.1:44597",
+					"172.27.0.1:44597",
+					"172.28.0.1:44597"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:17:28.086837834Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         387632227359478,
+				"StableID":   "nbykYbSZ2411CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a1f01689a1e22ccac1cffb0f5b21ce4fbeb85ddeefc7c80523dcda5a0a5d0948",
+				"DiscoKey":   "discokey:7366f41f4cee419ce831f057a4d5a6e2dfa7f3e7200e53e4b7685500c1e7a77a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:54326",
+					"10.65.0.27:54326",
+					"172.17.0.1:54326",
+					"172.18.0.1:54326",
+					"172.19.0.1:54326",
+					"172.20.0.1:54326",
+					"172.21.0.1:54326",
+					"172.22.0.1:54326",
+					"172.23.0.1:54326",
+					"172.24.0.1:54326",
+					"172.25.0.1:54326",
+					"172.26.0.1:54326",
+					"172.27.0.1:54326",
+					"172.28.0.1:54326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:17:28.629811446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1278908908902243,
+				"StableID":   "npMzrZmDzA11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85b6dab0e12f1319ae37b0135c9346681d5e7c73508525f26b4ffee8db753923",
+				"DiscoKey":   "discokey:c8f1d2be652eb4c31c8210d75f692358985d2162a07c93a072da3ae9f83cb501",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:38988",
+					"10.65.0.27:38988",
+					"172.17.0.1:38988",
+					"172.18.0.1:38988",
+					"172.19.0.1:38988",
+					"172.20.0.1:38988",
+					"172.21.0.1:38988",
+					"172.22.0.1:38988",
+					"172.23.0.1:38988",
+					"172.24.0.1:38988",
+					"172.25.0.1:38988",
+					"172.26.0.1:38988",
+					"172.27.0.1:38988",
+					"172.28.0.1:38988"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:17:29.183402864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4946368161903454,
+				"StableID":   "nb1gRqhDdf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec62fe51cac5cc9f43ad8aca85e4510bb568ced679df71a767ce190ab13b024b",
+				"DiscoKey":   "discokey:57e5df14c1618fe5956e9c0514572103cc8b6d87bc0a70a7b63460f6d127fe01",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48298",
+					"10.65.0.27:48298",
+					"172.17.0.1:48298",
+					"172.18.0.1:48298",
+					"172.19.0.1:48298",
+					"172.20.0.1:48298",
+					"172.21.0.1:48298",
+					"172.22.0.1:48298",
+					"172.23.0.1:48298",
+					"172.24.0.1:48298",
+					"172.25.0.1:48298",
+					"172.26.0.1:48298",
+					"172.27.0.1:48298",
+					"172.28.0.1:48298"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:17:29.73586827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3154700592985201,
+				"StableID":   "ncLydqdmdR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d499e95919abd1e7c7c3cb3b81bb9729ac709f4db6ae61040ed723a31b7bf67c",
+				"DiscoKey":   "discokey:569a0f33a5360c93a079a374be601613cf704794f8f00c8ac6727eb5adb0d502",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38714",
+					"10.65.0.27:38714",
+					"172.17.0.1:38714",
+					"172.18.0.1:38714",
+					"172.19.0.1:38714",
+					"172.20.0.1:38714",
+					"172.21.0.1:38714",
+					"172.22.0.1:38714",
+					"172.23.0.1:38714",
+					"172.24.0.1:38714",
+					"172.25.0.1:38714",
+					"172.26.0.1:38714",
+					"172.27.0.1:38714",
+					"172.28.0.1:38714"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:17:30.264898478Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6208974310850102,
+				"StableID":   "nVCYD9E4Vq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af7ffec8810d5b3fe5923128358511f60581552520a1e72aae1c05adb2eaaa64",
+				"DiscoKey":   "discokey:c0cc373615cff41800b24e3a13eab3c1133ba1395a28a8efd8267546fc25cb56",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47124",
+					"10.65.0.27:47124",
+					"172.17.0.1:47124",
+					"172.18.0.1:47124",
+					"172.19.0.1:47124",
+					"172.20.0.1:47124",
+					"172.21.0.1:47124",
+					"172.22.0.1:47124",
+					"172.23.0.1:47124",
+					"172.24.0.1:47124",
+					"172.25.0.1:47124",
+					"172.26.0.1:47124",
+					"172.27.0.1:47124",
+					"172.28.0.1:47124"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:17:30.804386633Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5352238830031791,
+				"StableID":   "nLqgXpE3oi11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:64e261e1bb2482497b377ccc7f0b6a9ef29225abef61bbd0e43f7b2bb4b59548",
+				"DiscoKey":   "discokey:fe0db25ff7c34a4af51f837364d556b38c33b03d2f354bf563cbb6d0a5dffa68",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54665",
+					"10.65.0.27:54665",
+					"172.17.0.1:54665",
+					"172.18.0.1:54665",
+					"172.19.0.1:54665",
+					"172.20.0.1:54665",
+					"172.21.0.1:54665",
+					"172.22.0.1:54665",
+					"172.23.0.1:54665",
+					"172.24.0.1:54665",
+					"172.25.0.1:54665",
+					"172.26.0.1:54665",
+					"172.27.0.1:54665",
+					"172.28.0.1:54665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:17:31.336846118Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3877487888534945,
+				"StableID":   "n44qsq28HX11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:88459b5ce2d35ea5962fb966cc017777fab80d0309ccbf1784920f224aa93d11",
+				"DiscoKey":   "discokey:dd9fca8e7a32bb7fb8d077f7ca91a572a6d3f4544bc59993a1e9bcd2d5233137",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:55045",
+					"10.65.0.27:55045",
+					"172.17.0.1:55045",
+					"172.18.0.1:55045",
+					"172.19.0.1:55045",
+					"172.20.0.1:55045",
+					"172.21.0.1:55045",
+					"172.22.0.1:55045",
+					"172.23.0.1:55045",
+					"172.24.0.1:55045",
+					"172.25.0.1:55045",
+					"172.26.0.1:55045",
+					"172.27.0.1:55045",
+					"172.28.0.1:55045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:17:31.923308474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6775939488263536,
+				"StableID":   "nT4sTYSquu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d9edf97ee150ce92d98d1a65dfc848b7f5f5532b50feb0ac766f912b7e6153e",
+				"DiscoKey":   "discokey:db9366b0621b82422e3ef035d440cd5913199af49ec8df2f61f8eda98be3931f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:32885",
+					"10.65.0.27:32885",
+					"172.17.0.1:32885",
+					"172.18.0.1:32885",
+					"172.19.0.1:32885",
+					"172.20.0.1:32885",
+					"172.21.0.1:32885",
+					"172.22.0.1:32885",
+					"172.23.0.1:32885",
+					"172.24.0.1:32885",
+					"172.25.0.1:32885",
+					"172.26.0.1:32885",
+					"172.27.0.1:32885",
+					"172.28.0.1:32885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:17:32.470384761Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1642175263121054,
+				"StableID":   "nRtwdFAkpD11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af45f6c34aaded41b49ccefb641dfe8594f0a2aeafb7b9d03c1f2bb2db082255",
+				"DiscoKey":   "discokey:6de66d3dbb146817449cd4bd469cdd3859bb6f1c7e98dd9281113643c0d6c05a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44111",
+					"10.65.0.27:44111",
+					"172.17.0.1:44111",
+					"172.18.0.1:44111",
+					"172.19.0.1:44111",
+					"172.20.0.1:44111",
+					"172.21.0.1:44111",
+					"172.22.0.1:44111",
+					"172.23.0.1:44111",
+					"172.24.0.1:44111",
+					"172.25.0.1:44111",
+					"172.26.0.1:44111",
+					"172.27.0.1:44111",
+					"172.28.0.1:44111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:17:33.012319725Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2205486211879948,
+				"StableID":   "njAFDDPsDJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:280db06fdb1275071ce0e8b86d3f3ec2781914c95854a9bf9731471ca3368118",
+				"DiscoKey":   "discokey:6c3aa80a7e71cd8999abc158814de52644e6bcc18e5fa5ce8d8d0992eac7c53a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41569",
+					"10.65.0.27:41569",
+					"172.17.0.1:41569",
+					"172.18.0.1:41569",
+					"172.19.0.1:41569",
+					"172.20.0.1:41569",
+					"172.21.0.1:41569",
+					"172.22.0.1:41569",
+					"172.23.0.1:41569",
+					"172.24.0.1:41569",
+					"172.25.0.1:41569",
+					"172.26.0.1:41569",
+					"172.27.0.1:41569",
+					"172.28.0.1:41569"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:17:33.553972143Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6959374370599248,
+				"StableID":   "nw8astxuLw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5fcc8d855420dbf95e34ac09a3439f2879a30d55cb4c8c93354b03e94610df01",
+				"KeyExpiry":  "2026-11-09T09:17:34Z",
+				"DiscoKey":   "discokey:38ceb917783142ef6a89f7a6fc8d3acae022852743b459a2fba28a2c9e85360c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51108",
+					"10.65.0.27:51108",
+					"172.17.0.1:51108",
+					"172.18.0.1:51108",
+					"172.19.0.1:51108",
+					"172.20.0.1:51108",
+					"172.21.0.1:51108",
+					"172.22.0.1:51108",
+					"172.23.0.1:51108",
+					"172.24.0.1:51108",
+					"172.25.0.1:51108",
+					"172.26.0.1:51108",
+					"172.27.0.1:51108",
+					"172.28.0.1:51108"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:17:34.646533445Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3229698221397392,
+				"StableID":   "nV96FMhjDS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:69853df8125c47b11605630704f9718bd263073378e2c9ab06d92ffad055f440",
+				"KeyExpiry":  "2026-11-09T09:17:35Z",
+				"DiscoKey":   "discokey:d6fe8ea030f27c7f096ee187a0ce83d33110ad7217cae9fd3b6298191d58dc48",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39247",
+					"10.65.0.27:39247",
+					"172.17.0.1:39247",
+					"172.18.0.1:39247",
+					"172.19.0.1:39247",
+					"172.20.0.1:39247",
+					"172.21.0.1:39247",
+					"172.22.0.1:39247",
+					"172.23.0.1:39247",
+					"172.24.0.1:39247",
+					"172.25.0.1:39247",
+					"172.26.0.1:39247",
+					"172.27.0.1:39247",
+					"172.28.0.1:39247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:17:35.203500028Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1642175263121054,
+				"StableID":   "nRtwdFAkpD11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1642175263121054,
+				"Key":        "nodekey:af45f6c34aaded41b49ccefb641dfe8594f0a2aeafb7b9d03c1f2bb2db082255",
+				"DiscoKey":   "discokey:6de66d3dbb146817449cd4bd469cdd3859bb6f1c7e98dd9281113643c0d6c05a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44111",
+					"10.65.0.27:44111",
+					"172.17.0.1:44111",
+					"172.18.0.1:44111",
+					"172.19.0.1:44111",
+					"172.20.0.1:44111",
+					"172.21.0.1:44111",
+					"172.22.0.1:44111",
+					"172.23.0.1:44111",
+					"172.24.0.1:44111",
+					"172.25.0.1:44111",
+					"172.26.0.1:44111",
+					"172.27.0.1:44111",
+					"172.28.0.1:44111"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:17:33.012319725Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:af45f6c34aaded41b49ccefb641dfe8594f0a2aeafb7b9d03c1f2bb2db082255",
+			"MachineKey": "mkey:9241d1a6c24d1523954b8d1d256823dfdf024782c0e42c188123ffd1319b5909",
+			"Peers": [{
+				"ID":         7267738963119122,
+				"StableID":   "n1E9yMBaky11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90085b2eac99b281e0343aa6634593a7ed4bd8e47e40c08c1c011bb05508f749",
+				"DiscoKey":   "discokey:a0ee95e28dd3d32bc9be6488d5030e36ca6d6fd123030794ef10140c5729ea3c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38781",
+					"10.65.0.27:38781",
+					"172.17.0.1:38781",
+					"172.18.0.1:38781",
+					"172.19.0.1:38781",
+					"172.20.0.1:38781",
+					"172.21.0.1:38781",
+					"172.22.0.1:38781",
+					"172.23.0.1:38781",
+					"172.24.0.1:38781",
+					"172.25.0.1:38781",
+					"172.26.0.1:38781",
+					"172.27.0.1:38781",
+					"172.28.0.1:38781"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:17:27.367207025Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3909302976209550,
+				"StableID":   "nohFE6mXXX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a1743f26bdca03b52d481b3ea0584a7d606430e2e0c506ca6be1a30e8b4a3006",
+				"DiscoKey":   "discokey:6b586235ad5cc37daf7c0463b5fdafe6c46269d42f31001c1df6f64828726b58",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44597",
+					"10.65.0.27:44597",
+					"172.17.0.1:44597",
+					"172.18.0.1:44597",
+					"172.19.0.1:44597",
+					"172.20.0.1:44597",
+					"172.21.0.1:44597",
+					"172.22.0.1:44597",
+					"172.23.0.1:44597",
+					"172.24.0.1:44597",
+					"172.25.0.1:44597",
+					"172.26.0.1:44597",
+					"172.27.0.1:44597",
+					"172.28.0.1:44597"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:17:28.086837834Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         387632227359478,
+				"StableID":   "nbykYbSZ2411CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a1f01689a1e22ccac1cffb0f5b21ce4fbeb85ddeefc7c80523dcda5a0a5d0948",
+				"DiscoKey":   "discokey:7366f41f4cee419ce831f057a4d5a6e2dfa7f3e7200e53e4b7685500c1e7a77a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:54326",
+					"10.65.0.27:54326",
+					"172.17.0.1:54326",
+					"172.18.0.1:54326",
+					"172.19.0.1:54326",
+					"172.20.0.1:54326",
+					"172.21.0.1:54326",
+					"172.22.0.1:54326",
+					"172.23.0.1:54326",
+					"172.24.0.1:54326",
+					"172.25.0.1:54326",
+					"172.26.0.1:54326",
+					"172.27.0.1:54326",
+					"172.28.0.1:54326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:17:28.629811446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1278908908902243,
+				"StableID":   "npMzrZmDzA11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85b6dab0e12f1319ae37b0135c9346681d5e7c73508525f26b4ffee8db753923",
+				"DiscoKey":   "discokey:c8f1d2be652eb4c31c8210d75f692358985d2162a07c93a072da3ae9f83cb501",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:38988",
+					"10.65.0.27:38988",
+					"172.17.0.1:38988",
+					"172.18.0.1:38988",
+					"172.19.0.1:38988",
+					"172.20.0.1:38988",
+					"172.21.0.1:38988",
+					"172.22.0.1:38988",
+					"172.23.0.1:38988",
+					"172.24.0.1:38988",
+					"172.25.0.1:38988",
+					"172.26.0.1:38988",
+					"172.27.0.1:38988",
+					"172.28.0.1:38988"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:17:29.183402864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4946368161903454,
+				"StableID":   "nb1gRqhDdf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec62fe51cac5cc9f43ad8aca85e4510bb568ced679df71a767ce190ab13b024b",
+				"DiscoKey":   "discokey:57e5df14c1618fe5956e9c0514572103cc8b6d87bc0a70a7b63460f6d127fe01",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48298",
+					"10.65.0.27:48298",
+					"172.17.0.1:48298",
+					"172.18.0.1:48298",
+					"172.19.0.1:48298",
+					"172.20.0.1:48298",
+					"172.21.0.1:48298",
+					"172.22.0.1:48298",
+					"172.23.0.1:48298",
+					"172.24.0.1:48298",
+					"172.25.0.1:48298",
+					"172.26.0.1:48298",
+					"172.27.0.1:48298",
+					"172.28.0.1:48298"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:17:29.73586827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3154700592985201,
+				"StableID":   "ncLydqdmdR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d499e95919abd1e7c7c3cb3b81bb9729ac709f4db6ae61040ed723a31b7bf67c",
+				"DiscoKey":   "discokey:569a0f33a5360c93a079a374be601613cf704794f8f00c8ac6727eb5adb0d502",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38714",
+					"10.65.0.27:38714",
+					"172.17.0.1:38714",
+					"172.18.0.1:38714",
+					"172.19.0.1:38714",
+					"172.20.0.1:38714",
+					"172.21.0.1:38714",
+					"172.22.0.1:38714",
+					"172.23.0.1:38714",
+					"172.24.0.1:38714",
+					"172.25.0.1:38714",
+					"172.26.0.1:38714",
+					"172.27.0.1:38714",
+					"172.28.0.1:38714"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:17:30.264898478Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6208974310850102,
+				"StableID":   "nVCYD9E4Vq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af7ffec8810d5b3fe5923128358511f60581552520a1e72aae1c05adb2eaaa64",
+				"DiscoKey":   "discokey:c0cc373615cff41800b24e3a13eab3c1133ba1395a28a8efd8267546fc25cb56",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47124",
+					"10.65.0.27:47124",
+					"172.17.0.1:47124",
+					"172.18.0.1:47124",
+					"172.19.0.1:47124",
+					"172.20.0.1:47124",
+					"172.21.0.1:47124",
+					"172.22.0.1:47124",
+					"172.23.0.1:47124",
+					"172.24.0.1:47124",
+					"172.25.0.1:47124",
+					"172.26.0.1:47124",
+					"172.27.0.1:47124",
+					"172.28.0.1:47124"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:17:30.804386633Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5352238830031791,
+				"StableID":   "nLqgXpE3oi11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:64e261e1bb2482497b377ccc7f0b6a9ef29225abef61bbd0e43f7b2bb4b59548",
+				"DiscoKey":   "discokey:fe0db25ff7c34a4af51f837364d556b38c33b03d2f354bf563cbb6d0a5dffa68",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54665",
+					"10.65.0.27:54665",
+					"172.17.0.1:54665",
+					"172.18.0.1:54665",
+					"172.19.0.1:54665",
+					"172.20.0.1:54665",
+					"172.21.0.1:54665",
+					"172.22.0.1:54665",
+					"172.23.0.1:54665",
+					"172.24.0.1:54665",
+					"172.25.0.1:54665",
+					"172.26.0.1:54665",
+					"172.27.0.1:54665",
+					"172.28.0.1:54665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:17:31.336846118Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3877487888534945,
+				"StableID":   "n44qsq28HX11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:88459b5ce2d35ea5962fb966cc017777fab80d0309ccbf1784920f224aa93d11",
+				"DiscoKey":   "discokey:dd9fca8e7a32bb7fb8d077f7ca91a572a6d3f4544bc59993a1e9bcd2d5233137",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:55045",
+					"10.65.0.27:55045",
+					"172.17.0.1:55045",
+					"172.18.0.1:55045",
+					"172.19.0.1:55045",
+					"172.20.0.1:55045",
+					"172.21.0.1:55045",
+					"172.22.0.1:55045",
+					"172.23.0.1:55045",
+					"172.24.0.1:55045",
+					"172.25.0.1:55045",
+					"172.26.0.1:55045",
+					"172.27.0.1:55045",
+					"172.28.0.1:55045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:17:31.923308474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6775939488263536,
+				"StableID":   "nT4sTYSquu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d9edf97ee150ce92d98d1a65dfc848b7f5f5532b50feb0ac766f912b7e6153e",
+				"DiscoKey":   "discokey:db9366b0621b82422e3ef035d440cd5913199af49ec8df2f61f8eda98be3931f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:32885",
+					"10.65.0.27:32885",
+					"172.17.0.1:32885",
+					"172.18.0.1:32885",
+					"172.19.0.1:32885",
+					"172.20.0.1:32885",
+					"172.21.0.1:32885",
+					"172.22.0.1:32885",
+					"172.23.0.1:32885",
+					"172.24.0.1:32885",
+					"172.25.0.1:32885",
+					"172.26.0.1:32885",
+					"172.27.0.1:32885",
+					"172.28.0.1:32885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:17:32.470384761Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2205486211879948,
+				"StableID":   "njAFDDPsDJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:280db06fdb1275071ce0e8b86d3f3ec2781914c95854a9bf9731471ca3368118",
+				"DiscoKey":   "discokey:6c3aa80a7e71cd8999abc158814de52644e6bcc18e5fa5ce8d8d0992eac7c53a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41569",
+					"10.65.0.27:41569",
+					"172.17.0.1:41569",
+					"172.18.0.1:41569",
+					"172.19.0.1:41569",
+					"172.20.0.1:41569",
+					"172.21.0.1:41569",
+					"172.22.0.1:41569",
+					"172.23.0.1:41569",
+					"172.24.0.1:41569",
+					"172.25.0.1:41569",
+					"172.26.0.1:41569",
+					"172.27.0.1:41569",
+					"172.28.0.1:41569"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:17:33.553972143Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7609651075458153,
+				"StableID":   "nUWiWYdRR221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a35f5c2db011b7f7550698c55688b6dbede87f56db3a18ae4e5d9f7089a8306b",
+				"KeyExpiry":  "2026-11-09T09:17:34Z",
+				"DiscoKey":   "discokey:f591d8af27668c045e2f33927567688e9915163ffc5a769e83ca1ba65ff5e164",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49541",
+					"10.65.0.27:49541",
+					"172.17.0.1:49541",
+					"172.18.0.1:49541",
+					"172.19.0.1:49541",
+					"172.20.0.1:49541",
+					"172.21.0.1:49541",
+					"172.22.0.1:49541",
+					"172.23.0.1:49541",
+					"172.24.0.1:49541",
+					"172.25.0.1:49541",
+					"172.26.0.1:49541",
+					"172.27.0.1:49541",
+					"172.28.0.1:49541"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:17:34.094327635Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6959374370599248,
+				"StableID":   "nw8astxuLw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5fcc8d855420dbf95e34ac09a3439f2879a30d55cb4c8c93354b03e94610df01",
+				"KeyExpiry":  "2026-11-09T09:17:34Z",
+				"DiscoKey":   "discokey:38ceb917783142ef6a89f7a6fc8d3acae022852743b459a2fba28a2c9e85360c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51108",
+					"10.65.0.27:51108",
+					"172.17.0.1:51108",
+					"172.18.0.1:51108",
+					"172.19.0.1:51108",
+					"172.20.0.1:51108",
+					"172.21.0.1:51108",
+					"172.22.0.1:51108",
+					"172.23.0.1:51108",
+					"172.24.0.1:51108",
+					"172.25.0.1:51108",
+					"172.26.0.1:51108",
+					"172.27.0.1:51108",
+					"172.28.0.1:51108"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:17:34.646533445Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3229698221397392,
+				"StableID":   "nV96FMhjDS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:69853df8125c47b11605630704f9718bd263073378e2c9ab06d92ffad055f440",
+				"KeyExpiry":  "2026-11-09T09:17:35Z",
+				"DiscoKey":   "discokey:d6fe8ea030f27c7f096ee187a0ce83d33110ad7217cae9fd3b6298191d58dc48",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39247",
+					"10.65.0.27:39247",
+					"172.17.0.1:39247",
+					"172.18.0.1:39247",
+					"172.19.0.1:39247",
+					"172.20.0.1:39247",
+					"172.21.0.1:39247",
+					"172.22.0.1:39247",
+					"172.23.0.1:39247",
+					"172.24.0.1:39247",
+					"172.25.0.1:39247",
+					"172.26.0.1:39247",
+					"172.27.0.1:39247",
+					"172.28.0.1:39247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:17:35.203500028Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1642175263121054": {
+				"ID":          1642175263121054,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3909302976209550,
+				"StableID":   "nohFE6mXXX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       3909302976209550,
+				"Key":        "nodekey:a1743f26bdca03b52d481b3ea0584a7d606430e2e0c506ca6be1a30e8b4a3006",
+				"DiscoKey":   "discokey:6b586235ad5cc37daf7c0463b5fdafe6c46269d42f31001c1df6f64828726b58",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44597",
+					"10.65.0.27:44597",
+					"172.17.0.1:44597",
+					"172.18.0.1:44597",
+					"172.19.0.1:44597",
+					"172.20.0.1:44597",
+					"172.21.0.1:44597",
+					"172.22.0.1:44597",
+					"172.23.0.1:44597",
+					"172.24.0.1:44597",
+					"172.25.0.1:44597",
+					"172.26.0.1:44597",
+					"172.27.0.1:44597",
+					"172.28.0.1:44597"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:17:28.086837834Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a1743f26bdca03b52d481b3ea0584a7d606430e2e0c506ca6be1a30e8b4a3006",
+			"MachineKey": "mkey:7cf705b3b1452c5a02ae85c4ca27eb85e771913cadc36770738b840631bb2b7b",
+			"Peers": [{
+				"ID":         7267738963119122,
+				"StableID":   "n1E9yMBaky11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90085b2eac99b281e0343aa6634593a7ed4bd8e47e40c08c1c011bb05508f749",
+				"DiscoKey":   "discokey:a0ee95e28dd3d32bc9be6488d5030e36ca6d6fd123030794ef10140c5729ea3c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38781",
+					"10.65.0.27:38781",
+					"172.17.0.1:38781",
+					"172.18.0.1:38781",
+					"172.19.0.1:38781",
+					"172.20.0.1:38781",
+					"172.21.0.1:38781",
+					"172.22.0.1:38781",
+					"172.23.0.1:38781",
+					"172.24.0.1:38781",
+					"172.25.0.1:38781",
+					"172.26.0.1:38781",
+					"172.27.0.1:38781",
+					"172.28.0.1:38781"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:17:27.367207025Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         387632227359478,
+				"StableID":   "nbykYbSZ2411CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a1f01689a1e22ccac1cffb0f5b21ce4fbeb85ddeefc7c80523dcda5a0a5d0948",
+				"DiscoKey":   "discokey:7366f41f4cee419ce831f057a4d5a6e2dfa7f3e7200e53e4b7685500c1e7a77a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:54326",
+					"10.65.0.27:54326",
+					"172.17.0.1:54326",
+					"172.18.0.1:54326",
+					"172.19.0.1:54326",
+					"172.20.0.1:54326",
+					"172.21.0.1:54326",
+					"172.22.0.1:54326",
+					"172.23.0.1:54326",
+					"172.24.0.1:54326",
+					"172.25.0.1:54326",
+					"172.26.0.1:54326",
+					"172.27.0.1:54326",
+					"172.28.0.1:54326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:17:28.629811446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1278908908902243,
+				"StableID":   "npMzrZmDzA11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85b6dab0e12f1319ae37b0135c9346681d5e7c73508525f26b4ffee8db753923",
+				"DiscoKey":   "discokey:c8f1d2be652eb4c31c8210d75f692358985d2162a07c93a072da3ae9f83cb501",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:38988",
+					"10.65.0.27:38988",
+					"172.17.0.1:38988",
+					"172.18.0.1:38988",
+					"172.19.0.1:38988",
+					"172.20.0.1:38988",
+					"172.21.0.1:38988",
+					"172.22.0.1:38988",
+					"172.23.0.1:38988",
+					"172.24.0.1:38988",
+					"172.25.0.1:38988",
+					"172.26.0.1:38988",
+					"172.27.0.1:38988",
+					"172.28.0.1:38988"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:17:29.183402864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4946368161903454,
+				"StableID":   "nb1gRqhDdf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec62fe51cac5cc9f43ad8aca85e4510bb568ced679df71a767ce190ab13b024b",
+				"DiscoKey":   "discokey:57e5df14c1618fe5956e9c0514572103cc8b6d87bc0a70a7b63460f6d127fe01",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48298",
+					"10.65.0.27:48298",
+					"172.17.0.1:48298",
+					"172.18.0.1:48298",
+					"172.19.0.1:48298",
+					"172.20.0.1:48298",
+					"172.21.0.1:48298",
+					"172.22.0.1:48298",
+					"172.23.0.1:48298",
+					"172.24.0.1:48298",
+					"172.25.0.1:48298",
+					"172.26.0.1:48298",
+					"172.27.0.1:48298",
+					"172.28.0.1:48298"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:17:29.73586827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3154700592985201,
+				"StableID":   "ncLydqdmdR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d499e95919abd1e7c7c3cb3b81bb9729ac709f4db6ae61040ed723a31b7bf67c",
+				"DiscoKey":   "discokey:569a0f33a5360c93a079a374be601613cf704794f8f00c8ac6727eb5adb0d502",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38714",
+					"10.65.0.27:38714",
+					"172.17.0.1:38714",
+					"172.18.0.1:38714",
+					"172.19.0.1:38714",
+					"172.20.0.1:38714",
+					"172.21.0.1:38714",
+					"172.22.0.1:38714",
+					"172.23.0.1:38714",
+					"172.24.0.1:38714",
+					"172.25.0.1:38714",
+					"172.26.0.1:38714",
+					"172.27.0.1:38714",
+					"172.28.0.1:38714"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:17:30.264898478Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6208974310850102,
+				"StableID":   "nVCYD9E4Vq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af7ffec8810d5b3fe5923128358511f60581552520a1e72aae1c05adb2eaaa64",
+				"DiscoKey":   "discokey:c0cc373615cff41800b24e3a13eab3c1133ba1395a28a8efd8267546fc25cb56",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47124",
+					"10.65.0.27:47124",
+					"172.17.0.1:47124",
+					"172.18.0.1:47124",
+					"172.19.0.1:47124",
+					"172.20.0.1:47124",
+					"172.21.0.1:47124",
+					"172.22.0.1:47124",
+					"172.23.0.1:47124",
+					"172.24.0.1:47124",
+					"172.25.0.1:47124",
+					"172.26.0.1:47124",
+					"172.27.0.1:47124",
+					"172.28.0.1:47124"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:17:30.804386633Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5352238830031791,
+				"StableID":   "nLqgXpE3oi11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:64e261e1bb2482497b377ccc7f0b6a9ef29225abef61bbd0e43f7b2bb4b59548",
+				"DiscoKey":   "discokey:fe0db25ff7c34a4af51f837364d556b38c33b03d2f354bf563cbb6d0a5dffa68",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54665",
+					"10.65.0.27:54665",
+					"172.17.0.1:54665",
+					"172.18.0.1:54665",
+					"172.19.0.1:54665",
+					"172.20.0.1:54665",
+					"172.21.0.1:54665",
+					"172.22.0.1:54665",
+					"172.23.0.1:54665",
+					"172.24.0.1:54665",
+					"172.25.0.1:54665",
+					"172.26.0.1:54665",
+					"172.27.0.1:54665",
+					"172.28.0.1:54665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:17:31.336846118Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3877487888534945,
+				"StableID":   "n44qsq28HX11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:88459b5ce2d35ea5962fb966cc017777fab80d0309ccbf1784920f224aa93d11",
+				"DiscoKey":   "discokey:dd9fca8e7a32bb7fb8d077f7ca91a572a6d3f4544bc59993a1e9bcd2d5233137",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:55045",
+					"10.65.0.27:55045",
+					"172.17.0.1:55045",
+					"172.18.0.1:55045",
+					"172.19.0.1:55045",
+					"172.20.0.1:55045",
+					"172.21.0.1:55045",
+					"172.22.0.1:55045",
+					"172.23.0.1:55045",
+					"172.24.0.1:55045",
+					"172.25.0.1:55045",
+					"172.26.0.1:55045",
+					"172.27.0.1:55045",
+					"172.28.0.1:55045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:17:31.923308474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6775939488263536,
+				"StableID":   "nT4sTYSquu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d9edf97ee150ce92d98d1a65dfc848b7f5f5532b50feb0ac766f912b7e6153e",
+				"DiscoKey":   "discokey:db9366b0621b82422e3ef035d440cd5913199af49ec8df2f61f8eda98be3931f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:32885",
+					"10.65.0.27:32885",
+					"172.17.0.1:32885",
+					"172.18.0.1:32885",
+					"172.19.0.1:32885",
+					"172.20.0.1:32885",
+					"172.21.0.1:32885",
+					"172.22.0.1:32885",
+					"172.23.0.1:32885",
+					"172.24.0.1:32885",
+					"172.25.0.1:32885",
+					"172.26.0.1:32885",
+					"172.27.0.1:32885",
+					"172.28.0.1:32885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:17:32.470384761Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1642175263121054,
+				"StableID":   "nRtwdFAkpD11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af45f6c34aaded41b49ccefb641dfe8594f0a2aeafb7b9d03c1f2bb2db082255",
+				"DiscoKey":   "discokey:6de66d3dbb146817449cd4bd469cdd3859bb6f1c7e98dd9281113643c0d6c05a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44111",
+					"10.65.0.27:44111",
+					"172.17.0.1:44111",
+					"172.18.0.1:44111",
+					"172.19.0.1:44111",
+					"172.20.0.1:44111",
+					"172.21.0.1:44111",
+					"172.22.0.1:44111",
+					"172.23.0.1:44111",
+					"172.24.0.1:44111",
+					"172.25.0.1:44111",
+					"172.26.0.1:44111",
+					"172.27.0.1:44111",
+					"172.28.0.1:44111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:17:33.012319725Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2205486211879948,
+				"StableID":   "njAFDDPsDJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:280db06fdb1275071ce0e8b86d3f3ec2781914c95854a9bf9731471ca3368118",
+				"DiscoKey":   "discokey:6c3aa80a7e71cd8999abc158814de52644e6bcc18e5fa5ce8d8d0992eac7c53a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41569",
+					"10.65.0.27:41569",
+					"172.17.0.1:41569",
+					"172.18.0.1:41569",
+					"172.19.0.1:41569",
+					"172.20.0.1:41569",
+					"172.21.0.1:41569",
+					"172.22.0.1:41569",
+					"172.23.0.1:41569",
+					"172.24.0.1:41569",
+					"172.25.0.1:41569",
+					"172.26.0.1:41569",
+					"172.27.0.1:41569",
+					"172.28.0.1:41569"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:17:33.553972143Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7609651075458153,
+				"StableID":   "nUWiWYdRR221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a35f5c2db011b7f7550698c55688b6dbede87f56db3a18ae4e5d9f7089a8306b",
+				"KeyExpiry":  "2026-11-09T09:17:34Z",
+				"DiscoKey":   "discokey:f591d8af27668c045e2f33927567688e9915163ffc5a769e83ca1ba65ff5e164",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49541",
+					"10.65.0.27:49541",
+					"172.17.0.1:49541",
+					"172.18.0.1:49541",
+					"172.19.0.1:49541",
+					"172.20.0.1:49541",
+					"172.21.0.1:49541",
+					"172.22.0.1:49541",
+					"172.23.0.1:49541",
+					"172.24.0.1:49541",
+					"172.25.0.1:49541",
+					"172.26.0.1:49541",
+					"172.27.0.1:49541",
+					"172.28.0.1:49541"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:17:34.094327635Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6959374370599248,
+				"StableID":   "nw8astxuLw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5fcc8d855420dbf95e34ac09a3439f2879a30d55cb4c8c93354b03e94610df01",
+				"KeyExpiry":  "2026-11-09T09:17:34Z",
+				"DiscoKey":   "discokey:38ceb917783142ef6a89f7a6fc8d3acae022852743b459a2fba28a2c9e85360c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51108",
+					"10.65.0.27:51108",
+					"172.17.0.1:51108",
+					"172.18.0.1:51108",
+					"172.19.0.1:51108",
+					"172.20.0.1:51108",
+					"172.21.0.1:51108",
+					"172.22.0.1:51108",
+					"172.23.0.1:51108",
+					"172.24.0.1:51108",
+					"172.25.0.1:51108",
+					"172.26.0.1:51108",
+					"172.27.0.1:51108",
+					"172.28.0.1:51108"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:17:34.646533445Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3229698221397392,
+				"StableID":   "nV96FMhjDS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:69853df8125c47b11605630704f9718bd263073378e2c9ab06d92ffad055f440",
+				"KeyExpiry":  "2026-11-09T09:17:35Z",
+				"DiscoKey":   "discokey:d6fe8ea030f27c7f096ee187a0ce83d33110ad7217cae9fd3b6298191d58dc48",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39247",
+					"10.65.0.27:39247",
+					"172.17.0.1:39247",
+					"172.18.0.1:39247",
+					"172.19.0.1:39247",
+					"172.20.0.1:39247",
+					"172.21.0.1:39247",
+					"172.22.0.1:39247",
+					"172.23.0.1:39247",
+					"172.24.0.1:39247",
+					"172.25.0.1:39247",
+					"172.26.0.1:39247",
+					"172.27.0.1:39247",
+					"172.28.0.1:39247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:17:35.203500028Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3909302976209550": {
+				"ID":          3909302976209550,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7267738963119122,
+				"StableID":   "n1E9yMBaky11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       7267738963119122,
+				"Key":        "nodekey:90085b2eac99b281e0343aa6634593a7ed4bd8e47e40c08c1c011bb05508f749",
+				"DiscoKey":   "discokey:a0ee95e28dd3d32bc9be6488d5030e36ca6d6fd123030794ef10140c5729ea3c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38781",
+					"10.65.0.27:38781",
+					"172.17.0.1:38781",
+					"172.18.0.1:38781",
+					"172.19.0.1:38781",
+					"172.20.0.1:38781",
+					"172.21.0.1:38781",
+					"172.22.0.1:38781",
+					"172.23.0.1:38781",
+					"172.24.0.1:38781",
+					"172.25.0.1:38781",
+					"172.26.0.1:38781",
+					"172.27.0.1:38781",
+					"172.28.0.1:38781"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:17:27.367207025Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:90085b2eac99b281e0343aa6634593a7ed4bd8e47e40c08c1c011bb05508f749",
+			"MachineKey": "mkey:05d3c4858eb7b11e2fa050aeb77317bbd9b4c9e2b6aaae59b53d68d2455fec43",
+			"Peers": [{
+				"ID":         3909302976209550,
+				"StableID":   "nohFE6mXXX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a1743f26bdca03b52d481b3ea0584a7d606430e2e0c506ca6be1a30e8b4a3006",
+				"DiscoKey":   "discokey:6b586235ad5cc37daf7c0463b5fdafe6c46269d42f31001c1df6f64828726b58",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44597",
+					"10.65.0.27:44597",
+					"172.17.0.1:44597",
+					"172.18.0.1:44597",
+					"172.19.0.1:44597",
+					"172.20.0.1:44597",
+					"172.21.0.1:44597",
+					"172.22.0.1:44597",
+					"172.23.0.1:44597",
+					"172.24.0.1:44597",
+					"172.25.0.1:44597",
+					"172.26.0.1:44597",
+					"172.27.0.1:44597",
+					"172.28.0.1:44597"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:17:28.086837834Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         387632227359478,
+				"StableID":   "nbykYbSZ2411CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a1f01689a1e22ccac1cffb0f5b21ce4fbeb85ddeefc7c80523dcda5a0a5d0948",
+				"DiscoKey":   "discokey:7366f41f4cee419ce831f057a4d5a6e2dfa7f3e7200e53e4b7685500c1e7a77a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:54326",
+					"10.65.0.27:54326",
+					"172.17.0.1:54326",
+					"172.18.0.1:54326",
+					"172.19.0.1:54326",
+					"172.20.0.1:54326",
+					"172.21.0.1:54326",
+					"172.22.0.1:54326",
+					"172.23.0.1:54326",
+					"172.24.0.1:54326",
+					"172.25.0.1:54326",
+					"172.26.0.1:54326",
+					"172.27.0.1:54326",
+					"172.28.0.1:54326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:17:28.629811446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1278908908902243,
+				"StableID":   "npMzrZmDzA11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85b6dab0e12f1319ae37b0135c9346681d5e7c73508525f26b4ffee8db753923",
+				"DiscoKey":   "discokey:c8f1d2be652eb4c31c8210d75f692358985d2162a07c93a072da3ae9f83cb501",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:38988",
+					"10.65.0.27:38988",
+					"172.17.0.1:38988",
+					"172.18.0.1:38988",
+					"172.19.0.1:38988",
+					"172.20.0.1:38988",
+					"172.21.0.1:38988",
+					"172.22.0.1:38988",
+					"172.23.0.1:38988",
+					"172.24.0.1:38988",
+					"172.25.0.1:38988",
+					"172.26.0.1:38988",
+					"172.27.0.1:38988",
+					"172.28.0.1:38988"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:17:29.183402864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4946368161903454,
+				"StableID":   "nb1gRqhDdf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec62fe51cac5cc9f43ad8aca85e4510bb568ced679df71a767ce190ab13b024b",
+				"DiscoKey":   "discokey:57e5df14c1618fe5956e9c0514572103cc8b6d87bc0a70a7b63460f6d127fe01",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48298",
+					"10.65.0.27:48298",
+					"172.17.0.1:48298",
+					"172.18.0.1:48298",
+					"172.19.0.1:48298",
+					"172.20.0.1:48298",
+					"172.21.0.1:48298",
+					"172.22.0.1:48298",
+					"172.23.0.1:48298",
+					"172.24.0.1:48298",
+					"172.25.0.1:48298",
+					"172.26.0.1:48298",
+					"172.27.0.1:48298",
+					"172.28.0.1:48298"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:17:29.73586827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3154700592985201,
+				"StableID":   "ncLydqdmdR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d499e95919abd1e7c7c3cb3b81bb9729ac709f4db6ae61040ed723a31b7bf67c",
+				"DiscoKey":   "discokey:569a0f33a5360c93a079a374be601613cf704794f8f00c8ac6727eb5adb0d502",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38714",
+					"10.65.0.27:38714",
+					"172.17.0.1:38714",
+					"172.18.0.1:38714",
+					"172.19.0.1:38714",
+					"172.20.0.1:38714",
+					"172.21.0.1:38714",
+					"172.22.0.1:38714",
+					"172.23.0.1:38714",
+					"172.24.0.1:38714",
+					"172.25.0.1:38714",
+					"172.26.0.1:38714",
+					"172.27.0.1:38714",
+					"172.28.0.1:38714"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:17:30.264898478Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6208974310850102,
+				"StableID":   "nVCYD9E4Vq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af7ffec8810d5b3fe5923128358511f60581552520a1e72aae1c05adb2eaaa64",
+				"DiscoKey":   "discokey:c0cc373615cff41800b24e3a13eab3c1133ba1395a28a8efd8267546fc25cb56",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47124",
+					"10.65.0.27:47124",
+					"172.17.0.1:47124",
+					"172.18.0.1:47124",
+					"172.19.0.1:47124",
+					"172.20.0.1:47124",
+					"172.21.0.1:47124",
+					"172.22.0.1:47124",
+					"172.23.0.1:47124",
+					"172.24.0.1:47124",
+					"172.25.0.1:47124",
+					"172.26.0.1:47124",
+					"172.27.0.1:47124",
+					"172.28.0.1:47124"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:17:30.804386633Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5352238830031791,
+				"StableID":   "nLqgXpE3oi11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:64e261e1bb2482497b377ccc7f0b6a9ef29225abef61bbd0e43f7b2bb4b59548",
+				"DiscoKey":   "discokey:fe0db25ff7c34a4af51f837364d556b38c33b03d2f354bf563cbb6d0a5dffa68",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54665",
+					"10.65.0.27:54665",
+					"172.17.0.1:54665",
+					"172.18.0.1:54665",
+					"172.19.0.1:54665",
+					"172.20.0.1:54665",
+					"172.21.0.1:54665",
+					"172.22.0.1:54665",
+					"172.23.0.1:54665",
+					"172.24.0.1:54665",
+					"172.25.0.1:54665",
+					"172.26.0.1:54665",
+					"172.27.0.1:54665",
+					"172.28.0.1:54665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:17:31.336846118Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3877487888534945,
+				"StableID":   "n44qsq28HX11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:88459b5ce2d35ea5962fb966cc017777fab80d0309ccbf1784920f224aa93d11",
+				"DiscoKey":   "discokey:dd9fca8e7a32bb7fb8d077f7ca91a572a6d3f4544bc59993a1e9bcd2d5233137",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:55045",
+					"10.65.0.27:55045",
+					"172.17.0.1:55045",
+					"172.18.0.1:55045",
+					"172.19.0.1:55045",
+					"172.20.0.1:55045",
+					"172.21.0.1:55045",
+					"172.22.0.1:55045",
+					"172.23.0.1:55045",
+					"172.24.0.1:55045",
+					"172.25.0.1:55045",
+					"172.26.0.1:55045",
+					"172.27.0.1:55045",
+					"172.28.0.1:55045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:17:31.923308474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6775939488263536,
+				"StableID":   "nT4sTYSquu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d9edf97ee150ce92d98d1a65dfc848b7f5f5532b50feb0ac766f912b7e6153e",
+				"DiscoKey":   "discokey:db9366b0621b82422e3ef035d440cd5913199af49ec8df2f61f8eda98be3931f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:32885",
+					"10.65.0.27:32885",
+					"172.17.0.1:32885",
+					"172.18.0.1:32885",
+					"172.19.0.1:32885",
+					"172.20.0.1:32885",
+					"172.21.0.1:32885",
+					"172.22.0.1:32885",
+					"172.23.0.1:32885",
+					"172.24.0.1:32885",
+					"172.25.0.1:32885",
+					"172.26.0.1:32885",
+					"172.27.0.1:32885",
+					"172.28.0.1:32885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:17:32.470384761Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1642175263121054,
+				"StableID":   "nRtwdFAkpD11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af45f6c34aaded41b49ccefb641dfe8594f0a2aeafb7b9d03c1f2bb2db082255",
+				"DiscoKey":   "discokey:6de66d3dbb146817449cd4bd469cdd3859bb6f1c7e98dd9281113643c0d6c05a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44111",
+					"10.65.0.27:44111",
+					"172.17.0.1:44111",
+					"172.18.0.1:44111",
+					"172.19.0.1:44111",
+					"172.20.0.1:44111",
+					"172.21.0.1:44111",
+					"172.22.0.1:44111",
+					"172.23.0.1:44111",
+					"172.24.0.1:44111",
+					"172.25.0.1:44111",
+					"172.26.0.1:44111",
+					"172.27.0.1:44111",
+					"172.28.0.1:44111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:17:33.012319725Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2205486211879948,
+				"StableID":   "njAFDDPsDJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:280db06fdb1275071ce0e8b86d3f3ec2781914c95854a9bf9731471ca3368118",
+				"DiscoKey":   "discokey:6c3aa80a7e71cd8999abc158814de52644e6bcc18e5fa5ce8d8d0992eac7c53a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41569",
+					"10.65.0.27:41569",
+					"172.17.0.1:41569",
+					"172.18.0.1:41569",
+					"172.19.0.1:41569",
+					"172.20.0.1:41569",
+					"172.21.0.1:41569",
+					"172.22.0.1:41569",
+					"172.23.0.1:41569",
+					"172.24.0.1:41569",
+					"172.25.0.1:41569",
+					"172.26.0.1:41569",
+					"172.27.0.1:41569",
+					"172.28.0.1:41569"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:17:33.553972143Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7609651075458153,
+				"StableID":   "nUWiWYdRR221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a35f5c2db011b7f7550698c55688b6dbede87f56db3a18ae4e5d9f7089a8306b",
+				"KeyExpiry":  "2026-11-09T09:17:34Z",
+				"DiscoKey":   "discokey:f591d8af27668c045e2f33927567688e9915163ffc5a769e83ca1ba65ff5e164",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49541",
+					"10.65.0.27:49541",
+					"172.17.0.1:49541",
+					"172.18.0.1:49541",
+					"172.19.0.1:49541",
+					"172.20.0.1:49541",
+					"172.21.0.1:49541",
+					"172.22.0.1:49541",
+					"172.23.0.1:49541",
+					"172.24.0.1:49541",
+					"172.25.0.1:49541",
+					"172.26.0.1:49541",
+					"172.27.0.1:49541",
+					"172.28.0.1:49541"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:17:34.094327635Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6959374370599248,
+				"StableID":   "nw8astxuLw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5fcc8d855420dbf95e34ac09a3439f2879a30d55cb4c8c93354b03e94610df01",
+				"KeyExpiry":  "2026-11-09T09:17:34Z",
+				"DiscoKey":   "discokey:38ceb917783142ef6a89f7a6fc8d3acae022852743b459a2fba28a2c9e85360c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51108",
+					"10.65.0.27:51108",
+					"172.17.0.1:51108",
+					"172.18.0.1:51108",
+					"172.19.0.1:51108",
+					"172.20.0.1:51108",
+					"172.21.0.1:51108",
+					"172.22.0.1:51108",
+					"172.23.0.1:51108",
+					"172.24.0.1:51108",
+					"172.25.0.1:51108",
+					"172.26.0.1:51108",
+					"172.27.0.1:51108",
+					"172.28.0.1:51108"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:17:34.646533445Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3229698221397392,
+				"StableID":   "nV96FMhjDS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:69853df8125c47b11605630704f9718bd263073378e2c9ab06d92ffad055f440",
+				"KeyExpiry":  "2026-11-09T09:17:35Z",
+				"DiscoKey":   "discokey:d6fe8ea030f27c7f096ee187a0ce83d33110ad7217cae9fd3b6298191d58dc48",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39247",
+					"10.65.0.27:39247",
+					"172.17.0.1:39247",
+					"172.18.0.1:39247",
+					"172.19.0.1:39247",
+					"172.20.0.1:39247",
+					"172.21.0.1:39247",
+					"172.22.0.1:39247",
+					"172.23.0.1:39247",
+					"172.24.0.1:39247",
+					"172.25.0.1:39247",
+					"172.26.0.1:39247",
+					"172.27.0.1:39247",
+					"172.28.0.1:39247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:17:35.203500028Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7267738963119122": {
+				"ID":          7267738963119122,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4946368161903454,
+				"StableID":   "nb1gRqhDdf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       4946368161903454,
+				"Key":        "nodekey:ec62fe51cac5cc9f43ad8aca85e4510bb568ced679df71a767ce190ab13b024b",
+				"DiscoKey":   "discokey:57e5df14c1618fe5956e9c0514572103cc8b6d87bc0a70a7b63460f6d127fe01",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48298",
+					"10.65.0.27:48298",
+					"172.17.0.1:48298",
+					"172.18.0.1:48298",
+					"172.19.0.1:48298",
+					"172.20.0.1:48298",
+					"172.21.0.1:48298",
+					"172.22.0.1:48298",
+					"172.23.0.1:48298",
+					"172.24.0.1:48298",
+					"172.25.0.1:48298",
+					"172.26.0.1:48298",
+					"172.27.0.1:48298",
+					"172.28.0.1:48298"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:17:29.73586827Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ec62fe51cac5cc9f43ad8aca85e4510bb568ced679df71a767ce190ab13b024b",
+			"MachineKey": "mkey:0d1d47443c53bd23ec614c6290faa60554f60b6f9ae55fd6860566d58de4bf47",
+			"Peers": [{
+				"ID":         7267738963119122,
+				"StableID":   "n1E9yMBaky11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90085b2eac99b281e0343aa6634593a7ed4bd8e47e40c08c1c011bb05508f749",
+				"DiscoKey":   "discokey:a0ee95e28dd3d32bc9be6488d5030e36ca6d6fd123030794ef10140c5729ea3c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38781",
+					"10.65.0.27:38781",
+					"172.17.0.1:38781",
+					"172.18.0.1:38781",
+					"172.19.0.1:38781",
+					"172.20.0.1:38781",
+					"172.21.0.1:38781",
+					"172.22.0.1:38781",
+					"172.23.0.1:38781",
+					"172.24.0.1:38781",
+					"172.25.0.1:38781",
+					"172.26.0.1:38781",
+					"172.27.0.1:38781",
+					"172.28.0.1:38781"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:17:27.367207025Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3909302976209550,
+				"StableID":   "nohFE6mXXX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a1743f26bdca03b52d481b3ea0584a7d606430e2e0c506ca6be1a30e8b4a3006",
+				"DiscoKey":   "discokey:6b586235ad5cc37daf7c0463b5fdafe6c46269d42f31001c1df6f64828726b58",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44597",
+					"10.65.0.27:44597",
+					"172.17.0.1:44597",
+					"172.18.0.1:44597",
+					"172.19.0.1:44597",
+					"172.20.0.1:44597",
+					"172.21.0.1:44597",
+					"172.22.0.1:44597",
+					"172.23.0.1:44597",
+					"172.24.0.1:44597",
+					"172.25.0.1:44597",
+					"172.26.0.1:44597",
+					"172.27.0.1:44597",
+					"172.28.0.1:44597"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:17:28.086837834Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         387632227359478,
+				"StableID":   "nbykYbSZ2411CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a1f01689a1e22ccac1cffb0f5b21ce4fbeb85ddeefc7c80523dcda5a0a5d0948",
+				"DiscoKey":   "discokey:7366f41f4cee419ce831f057a4d5a6e2dfa7f3e7200e53e4b7685500c1e7a77a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:54326",
+					"10.65.0.27:54326",
+					"172.17.0.1:54326",
+					"172.18.0.1:54326",
+					"172.19.0.1:54326",
+					"172.20.0.1:54326",
+					"172.21.0.1:54326",
+					"172.22.0.1:54326",
+					"172.23.0.1:54326",
+					"172.24.0.1:54326",
+					"172.25.0.1:54326",
+					"172.26.0.1:54326",
+					"172.27.0.1:54326",
+					"172.28.0.1:54326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:17:28.629811446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1278908908902243,
+				"StableID":   "npMzrZmDzA11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85b6dab0e12f1319ae37b0135c9346681d5e7c73508525f26b4ffee8db753923",
+				"DiscoKey":   "discokey:c8f1d2be652eb4c31c8210d75f692358985d2162a07c93a072da3ae9f83cb501",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:38988",
+					"10.65.0.27:38988",
+					"172.17.0.1:38988",
+					"172.18.0.1:38988",
+					"172.19.0.1:38988",
+					"172.20.0.1:38988",
+					"172.21.0.1:38988",
+					"172.22.0.1:38988",
+					"172.23.0.1:38988",
+					"172.24.0.1:38988",
+					"172.25.0.1:38988",
+					"172.26.0.1:38988",
+					"172.27.0.1:38988",
+					"172.28.0.1:38988"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:17:29.183402864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3154700592985201,
+				"StableID":   "ncLydqdmdR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d499e95919abd1e7c7c3cb3b81bb9729ac709f4db6ae61040ed723a31b7bf67c",
+				"DiscoKey":   "discokey:569a0f33a5360c93a079a374be601613cf704794f8f00c8ac6727eb5adb0d502",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38714",
+					"10.65.0.27:38714",
+					"172.17.0.1:38714",
+					"172.18.0.1:38714",
+					"172.19.0.1:38714",
+					"172.20.0.1:38714",
+					"172.21.0.1:38714",
+					"172.22.0.1:38714",
+					"172.23.0.1:38714",
+					"172.24.0.1:38714",
+					"172.25.0.1:38714",
+					"172.26.0.1:38714",
+					"172.27.0.1:38714",
+					"172.28.0.1:38714"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:17:30.264898478Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6208974310850102,
+				"StableID":   "nVCYD9E4Vq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af7ffec8810d5b3fe5923128358511f60581552520a1e72aae1c05adb2eaaa64",
+				"DiscoKey":   "discokey:c0cc373615cff41800b24e3a13eab3c1133ba1395a28a8efd8267546fc25cb56",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47124",
+					"10.65.0.27:47124",
+					"172.17.0.1:47124",
+					"172.18.0.1:47124",
+					"172.19.0.1:47124",
+					"172.20.0.1:47124",
+					"172.21.0.1:47124",
+					"172.22.0.1:47124",
+					"172.23.0.1:47124",
+					"172.24.0.1:47124",
+					"172.25.0.1:47124",
+					"172.26.0.1:47124",
+					"172.27.0.1:47124",
+					"172.28.0.1:47124"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:17:30.804386633Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5352238830031791,
+				"StableID":   "nLqgXpE3oi11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:64e261e1bb2482497b377ccc7f0b6a9ef29225abef61bbd0e43f7b2bb4b59548",
+				"DiscoKey":   "discokey:fe0db25ff7c34a4af51f837364d556b38c33b03d2f354bf563cbb6d0a5dffa68",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54665",
+					"10.65.0.27:54665",
+					"172.17.0.1:54665",
+					"172.18.0.1:54665",
+					"172.19.0.1:54665",
+					"172.20.0.1:54665",
+					"172.21.0.1:54665",
+					"172.22.0.1:54665",
+					"172.23.0.1:54665",
+					"172.24.0.1:54665",
+					"172.25.0.1:54665",
+					"172.26.0.1:54665",
+					"172.27.0.1:54665",
+					"172.28.0.1:54665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:17:31.336846118Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3877487888534945,
+				"StableID":   "n44qsq28HX11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:88459b5ce2d35ea5962fb966cc017777fab80d0309ccbf1784920f224aa93d11",
+				"DiscoKey":   "discokey:dd9fca8e7a32bb7fb8d077f7ca91a572a6d3f4544bc59993a1e9bcd2d5233137",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:55045",
+					"10.65.0.27:55045",
+					"172.17.0.1:55045",
+					"172.18.0.1:55045",
+					"172.19.0.1:55045",
+					"172.20.0.1:55045",
+					"172.21.0.1:55045",
+					"172.22.0.1:55045",
+					"172.23.0.1:55045",
+					"172.24.0.1:55045",
+					"172.25.0.1:55045",
+					"172.26.0.1:55045",
+					"172.27.0.1:55045",
+					"172.28.0.1:55045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:17:31.923308474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6775939488263536,
+				"StableID":   "nT4sTYSquu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d9edf97ee150ce92d98d1a65dfc848b7f5f5532b50feb0ac766f912b7e6153e",
+				"DiscoKey":   "discokey:db9366b0621b82422e3ef035d440cd5913199af49ec8df2f61f8eda98be3931f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:32885",
+					"10.65.0.27:32885",
+					"172.17.0.1:32885",
+					"172.18.0.1:32885",
+					"172.19.0.1:32885",
+					"172.20.0.1:32885",
+					"172.21.0.1:32885",
+					"172.22.0.1:32885",
+					"172.23.0.1:32885",
+					"172.24.0.1:32885",
+					"172.25.0.1:32885",
+					"172.26.0.1:32885",
+					"172.27.0.1:32885",
+					"172.28.0.1:32885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:17:32.470384761Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1642175263121054,
+				"StableID":   "nRtwdFAkpD11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af45f6c34aaded41b49ccefb641dfe8594f0a2aeafb7b9d03c1f2bb2db082255",
+				"DiscoKey":   "discokey:6de66d3dbb146817449cd4bd469cdd3859bb6f1c7e98dd9281113643c0d6c05a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44111",
+					"10.65.0.27:44111",
+					"172.17.0.1:44111",
+					"172.18.0.1:44111",
+					"172.19.0.1:44111",
+					"172.20.0.1:44111",
+					"172.21.0.1:44111",
+					"172.22.0.1:44111",
+					"172.23.0.1:44111",
+					"172.24.0.1:44111",
+					"172.25.0.1:44111",
+					"172.26.0.1:44111",
+					"172.27.0.1:44111",
+					"172.28.0.1:44111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:17:33.012319725Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2205486211879948,
+				"StableID":   "njAFDDPsDJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:280db06fdb1275071ce0e8b86d3f3ec2781914c95854a9bf9731471ca3368118",
+				"DiscoKey":   "discokey:6c3aa80a7e71cd8999abc158814de52644e6bcc18e5fa5ce8d8d0992eac7c53a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41569",
+					"10.65.0.27:41569",
+					"172.17.0.1:41569",
+					"172.18.0.1:41569",
+					"172.19.0.1:41569",
+					"172.20.0.1:41569",
+					"172.21.0.1:41569",
+					"172.22.0.1:41569",
+					"172.23.0.1:41569",
+					"172.24.0.1:41569",
+					"172.25.0.1:41569",
+					"172.26.0.1:41569",
+					"172.27.0.1:41569",
+					"172.28.0.1:41569"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:17:33.553972143Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7609651075458153,
+				"StableID":   "nUWiWYdRR221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a35f5c2db011b7f7550698c55688b6dbede87f56db3a18ae4e5d9f7089a8306b",
+				"KeyExpiry":  "2026-11-09T09:17:34Z",
+				"DiscoKey":   "discokey:f591d8af27668c045e2f33927567688e9915163ffc5a769e83ca1ba65ff5e164",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49541",
+					"10.65.0.27:49541",
+					"172.17.0.1:49541",
+					"172.18.0.1:49541",
+					"172.19.0.1:49541",
+					"172.20.0.1:49541",
+					"172.21.0.1:49541",
+					"172.22.0.1:49541",
+					"172.23.0.1:49541",
+					"172.24.0.1:49541",
+					"172.25.0.1:49541",
+					"172.26.0.1:49541",
+					"172.27.0.1:49541",
+					"172.28.0.1:49541"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:17:34.094327635Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6959374370599248,
+				"StableID":   "nw8astxuLw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5fcc8d855420dbf95e34ac09a3439f2879a30d55cb4c8c93354b03e94610df01",
+				"KeyExpiry":  "2026-11-09T09:17:34Z",
+				"DiscoKey":   "discokey:38ceb917783142ef6a89f7a6fc8d3acae022852743b459a2fba28a2c9e85360c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51108",
+					"10.65.0.27:51108",
+					"172.17.0.1:51108",
+					"172.18.0.1:51108",
+					"172.19.0.1:51108",
+					"172.20.0.1:51108",
+					"172.21.0.1:51108",
+					"172.22.0.1:51108",
+					"172.23.0.1:51108",
+					"172.24.0.1:51108",
+					"172.25.0.1:51108",
+					"172.26.0.1:51108",
+					"172.27.0.1:51108",
+					"172.28.0.1:51108"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:17:34.646533445Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3229698221397392,
+				"StableID":   "nV96FMhjDS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:69853df8125c47b11605630704f9718bd263073378e2c9ab06d92ffad055f440",
+				"KeyExpiry":  "2026-11-09T09:17:35Z",
+				"DiscoKey":   "discokey:d6fe8ea030f27c7f096ee187a0ce83d33110ad7217cae9fd3b6298191d58dc48",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39247",
+					"10.65.0.27:39247",
+					"172.17.0.1:39247",
+					"172.18.0.1:39247",
+					"172.19.0.1:39247",
+					"172.20.0.1:39247",
+					"172.21.0.1:39247",
+					"172.22.0.1:39247",
+					"172.23.0.1:39247",
+					"172.24.0.1:39247",
+					"172.25.0.1:39247",
+					"172.26.0.1:39247",
+					"172.27.0.1:39247",
+					"172.28.0.1:39247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:17:35.203500028Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4946368161903454": {
+				"ID":          4946368161903454,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1278908908902243,
+				"StableID":   "npMzrZmDzA11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1278908908902243,
+				"Key":        "nodekey:85b6dab0e12f1319ae37b0135c9346681d5e7c73508525f26b4ffee8db753923",
+				"DiscoKey":   "discokey:c8f1d2be652eb4c31c8210d75f692358985d2162a07c93a072da3ae9f83cb501",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:38988",
+					"10.65.0.27:38988",
+					"172.17.0.1:38988",
+					"172.18.0.1:38988",
+					"172.19.0.1:38988",
+					"172.20.0.1:38988",
+					"172.21.0.1:38988",
+					"172.22.0.1:38988",
+					"172.23.0.1:38988",
+					"172.24.0.1:38988",
+					"172.25.0.1:38988",
+					"172.26.0.1:38988",
+					"172.27.0.1:38988",
+					"172.28.0.1:38988"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:17:29.183402864Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:85b6dab0e12f1319ae37b0135c9346681d5e7c73508525f26b4ffee8db753923",
+			"MachineKey": "mkey:a2097ac83e6341f30aacf23cb024fb8279fd3f872a02b1b938a974804470616a",
+			"Peers": [{
+				"ID":         7267738963119122,
+				"StableID":   "n1E9yMBaky11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90085b2eac99b281e0343aa6634593a7ed4bd8e47e40c08c1c011bb05508f749",
+				"DiscoKey":   "discokey:a0ee95e28dd3d32bc9be6488d5030e36ca6d6fd123030794ef10140c5729ea3c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38781",
+					"10.65.0.27:38781",
+					"172.17.0.1:38781",
+					"172.18.0.1:38781",
+					"172.19.0.1:38781",
+					"172.20.0.1:38781",
+					"172.21.0.1:38781",
+					"172.22.0.1:38781",
+					"172.23.0.1:38781",
+					"172.24.0.1:38781",
+					"172.25.0.1:38781",
+					"172.26.0.1:38781",
+					"172.27.0.1:38781",
+					"172.28.0.1:38781"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:17:27.367207025Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3909302976209550,
+				"StableID":   "nohFE6mXXX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a1743f26bdca03b52d481b3ea0584a7d606430e2e0c506ca6be1a30e8b4a3006",
+				"DiscoKey":   "discokey:6b586235ad5cc37daf7c0463b5fdafe6c46269d42f31001c1df6f64828726b58",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44597",
+					"10.65.0.27:44597",
+					"172.17.0.1:44597",
+					"172.18.0.1:44597",
+					"172.19.0.1:44597",
+					"172.20.0.1:44597",
+					"172.21.0.1:44597",
+					"172.22.0.1:44597",
+					"172.23.0.1:44597",
+					"172.24.0.1:44597",
+					"172.25.0.1:44597",
+					"172.26.0.1:44597",
+					"172.27.0.1:44597",
+					"172.28.0.1:44597"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:17:28.086837834Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         387632227359478,
+				"StableID":   "nbykYbSZ2411CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a1f01689a1e22ccac1cffb0f5b21ce4fbeb85ddeefc7c80523dcda5a0a5d0948",
+				"DiscoKey":   "discokey:7366f41f4cee419ce831f057a4d5a6e2dfa7f3e7200e53e4b7685500c1e7a77a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:54326",
+					"10.65.0.27:54326",
+					"172.17.0.1:54326",
+					"172.18.0.1:54326",
+					"172.19.0.1:54326",
+					"172.20.0.1:54326",
+					"172.21.0.1:54326",
+					"172.22.0.1:54326",
+					"172.23.0.1:54326",
+					"172.24.0.1:54326",
+					"172.25.0.1:54326",
+					"172.26.0.1:54326",
+					"172.27.0.1:54326",
+					"172.28.0.1:54326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:17:28.629811446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4946368161903454,
+				"StableID":   "nb1gRqhDdf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec62fe51cac5cc9f43ad8aca85e4510bb568ced679df71a767ce190ab13b024b",
+				"DiscoKey":   "discokey:57e5df14c1618fe5956e9c0514572103cc8b6d87bc0a70a7b63460f6d127fe01",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48298",
+					"10.65.0.27:48298",
+					"172.17.0.1:48298",
+					"172.18.0.1:48298",
+					"172.19.0.1:48298",
+					"172.20.0.1:48298",
+					"172.21.0.1:48298",
+					"172.22.0.1:48298",
+					"172.23.0.1:48298",
+					"172.24.0.1:48298",
+					"172.25.0.1:48298",
+					"172.26.0.1:48298",
+					"172.27.0.1:48298",
+					"172.28.0.1:48298"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:17:29.73586827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3154700592985201,
+				"StableID":   "ncLydqdmdR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d499e95919abd1e7c7c3cb3b81bb9729ac709f4db6ae61040ed723a31b7bf67c",
+				"DiscoKey":   "discokey:569a0f33a5360c93a079a374be601613cf704794f8f00c8ac6727eb5adb0d502",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38714",
+					"10.65.0.27:38714",
+					"172.17.0.1:38714",
+					"172.18.0.1:38714",
+					"172.19.0.1:38714",
+					"172.20.0.1:38714",
+					"172.21.0.1:38714",
+					"172.22.0.1:38714",
+					"172.23.0.1:38714",
+					"172.24.0.1:38714",
+					"172.25.0.1:38714",
+					"172.26.0.1:38714",
+					"172.27.0.1:38714",
+					"172.28.0.1:38714"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:17:30.264898478Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6208974310850102,
+				"StableID":   "nVCYD9E4Vq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af7ffec8810d5b3fe5923128358511f60581552520a1e72aae1c05adb2eaaa64",
+				"DiscoKey":   "discokey:c0cc373615cff41800b24e3a13eab3c1133ba1395a28a8efd8267546fc25cb56",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47124",
+					"10.65.0.27:47124",
+					"172.17.0.1:47124",
+					"172.18.0.1:47124",
+					"172.19.0.1:47124",
+					"172.20.0.1:47124",
+					"172.21.0.1:47124",
+					"172.22.0.1:47124",
+					"172.23.0.1:47124",
+					"172.24.0.1:47124",
+					"172.25.0.1:47124",
+					"172.26.0.1:47124",
+					"172.27.0.1:47124",
+					"172.28.0.1:47124"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:17:30.804386633Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5352238830031791,
+				"StableID":   "nLqgXpE3oi11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:64e261e1bb2482497b377ccc7f0b6a9ef29225abef61bbd0e43f7b2bb4b59548",
+				"DiscoKey":   "discokey:fe0db25ff7c34a4af51f837364d556b38c33b03d2f354bf563cbb6d0a5dffa68",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54665",
+					"10.65.0.27:54665",
+					"172.17.0.1:54665",
+					"172.18.0.1:54665",
+					"172.19.0.1:54665",
+					"172.20.0.1:54665",
+					"172.21.0.1:54665",
+					"172.22.0.1:54665",
+					"172.23.0.1:54665",
+					"172.24.0.1:54665",
+					"172.25.0.1:54665",
+					"172.26.0.1:54665",
+					"172.27.0.1:54665",
+					"172.28.0.1:54665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:17:31.336846118Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3877487888534945,
+				"StableID":   "n44qsq28HX11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:88459b5ce2d35ea5962fb966cc017777fab80d0309ccbf1784920f224aa93d11",
+				"DiscoKey":   "discokey:dd9fca8e7a32bb7fb8d077f7ca91a572a6d3f4544bc59993a1e9bcd2d5233137",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:55045",
+					"10.65.0.27:55045",
+					"172.17.0.1:55045",
+					"172.18.0.1:55045",
+					"172.19.0.1:55045",
+					"172.20.0.1:55045",
+					"172.21.0.1:55045",
+					"172.22.0.1:55045",
+					"172.23.0.1:55045",
+					"172.24.0.1:55045",
+					"172.25.0.1:55045",
+					"172.26.0.1:55045",
+					"172.27.0.1:55045",
+					"172.28.0.1:55045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:17:31.923308474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6775939488263536,
+				"StableID":   "nT4sTYSquu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d9edf97ee150ce92d98d1a65dfc848b7f5f5532b50feb0ac766f912b7e6153e",
+				"DiscoKey":   "discokey:db9366b0621b82422e3ef035d440cd5913199af49ec8df2f61f8eda98be3931f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:32885",
+					"10.65.0.27:32885",
+					"172.17.0.1:32885",
+					"172.18.0.1:32885",
+					"172.19.0.1:32885",
+					"172.20.0.1:32885",
+					"172.21.0.1:32885",
+					"172.22.0.1:32885",
+					"172.23.0.1:32885",
+					"172.24.0.1:32885",
+					"172.25.0.1:32885",
+					"172.26.0.1:32885",
+					"172.27.0.1:32885",
+					"172.28.0.1:32885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:17:32.470384761Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1642175263121054,
+				"StableID":   "nRtwdFAkpD11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af45f6c34aaded41b49ccefb641dfe8594f0a2aeafb7b9d03c1f2bb2db082255",
+				"DiscoKey":   "discokey:6de66d3dbb146817449cd4bd469cdd3859bb6f1c7e98dd9281113643c0d6c05a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44111",
+					"10.65.0.27:44111",
+					"172.17.0.1:44111",
+					"172.18.0.1:44111",
+					"172.19.0.1:44111",
+					"172.20.0.1:44111",
+					"172.21.0.1:44111",
+					"172.22.0.1:44111",
+					"172.23.0.1:44111",
+					"172.24.0.1:44111",
+					"172.25.0.1:44111",
+					"172.26.0.1:44111",
+					"172.27.0.1:44111",
+					"172.28.0.1:44111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:17:33.012319725Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2205486211879948,
+				"StableID":   "njAFDDPsDJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:280db06fdb1275071ce0e8b86d3f3ec2781914c95854a9bf9731471ca3368118",
+				"DiscoKey":   "discokey:6c3aa80a7e71cd8999abc158814de52644e6bcc18e5fa5ce8d8d0992eac7c53a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41569",
+					"10.65.0.27:41569",
+					"172.17.0.1:41569",
+					"172.18.0.1:41569",
+					"172.19.0.1:41569",
+					"172.20.0.1:41569",
+					"172.21.0.1:41569",
+					"172.22.0.1:41569",
+					"172.23.0.1:41569",
+					"172.24.0.1:41569",
+					"172.25.0.1:41569",
+					"172.26.0.1:41569",
+					"172.27.0.1:41569",
+					"172.28.0.1:41569"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:17:33.553972143Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7609651075458153,
+				"StableID":   "nUWiWYdRR221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a35f5c2db011b7f7550698c55688b6dbede87f56db3a18ae4e5d9f7089a8306b",
+				"KeyExpiry":  "2026-11-09T09:17:34Z",
+				"DiscoKey":   "discokey:f591d8af27668c045e2f33927567688e9915163ffc5a769e83ca1ba65ff5e164",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49541",
+					"10.65.0.27:49541",
+					"172.17.0.1:49541",
+					"172.18.0.1:49541",
+					"172.19.0.1:49541",
+					"172.20.0.1:49541",
+					"172.21.0.1:49541",
+					"172.22.0.1:49541",
+					"172.23.0.1:49541",
+					"172.24.0.1:49541",
+					"172.25.0.1:49541",
+					"172.26.0.1:49541",
+					"172.27.0.1:49541",
+					"172.28.0.1:49541"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:17:34.094327635Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6959374370599248,
+				"StableID":   "nw8astxuLw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5fcc8d855420dbf95e34ac09a3439f2879a30d55cb4c8c93354b03e94610df01",
+				"KeyExpiry":  "2026-11-09T09:17:34Z",
+				"DiscoKey":   "discokey:38ceb917783142ef6a89f7a6fc8d3acae022852743b459a2fba28a2c9e85360c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51108",
+					"10.65.0.27:51108",
+					"172.17.0.1:51108",
+					"172.18.0.1:51108",
+					"172.19.0.1:51108",
+					"172.20.0.1:51108",
+					"172.21.0.1:51108",
+					"172.22.0.1:51108",
+					"172.23.0.1:51108",
+					"172.24.0.1:51108",
+					"172.25.0.1:51108",
+					"172.26.0.1:51108",
+					"172.27.0.1:51108",
+					"172.28.0.1:51108"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:17:34.646533445Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3229698221397392,
+				"StableID":   "nV96FMhjDS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:69853df8125c47b11605630704f9718bd263073378e2c9ab06d92ffad055f440",
+				"KeyExpiry":  "2026-11-09T09:17:35Z",
+				"DiscoKey":   "discokey:d6fe8ea030f27c7f096ee187a0ce83d33110ad7217cae9fd3b6298191d58dc48",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39247",
+					"10.65.0.27:39247",
+					"172.17.0.1:39247",
+					"172.18.0.1:39247",
+					"172.19.0.1:39247",
+					"172.20.0.1:39247",
+					"172.21.0.1:39247",
+					"172.22.0.1:39247",
+					"172.23.0.1:39247",
+					"172.24.0.1:39247",
+					"172.25.0.1:39247",
+					"172.26.0.1:39247",
+					"172.27.0.1:39247",
+					"172.28.0.1:39247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:17:35.203500028Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1278908908902243": {
+				"ID":          1278908908902243,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6208974310850102,
+				"StableID":   "nVCYD9E4Vq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       6208974310850102,
+				"Key":        "nodekey:af7ffec8810d5b3fe5923128358511f60581552520a1e72aae1c05adb2eaaa64",
+				"DiscoKey":   "discokey:c0cc373615cff41800b24e3a13eab3c1133ba1395a28a8efd8267546fc25cb56",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47124",
+					"10.65.0.27:47124",
+					"172.17.0.1:47124",
+					"172.18.0.1:47124",
+					"172.19.0.1:47124",
+					"172.20.0.1:47124",
+					"172.21.0.1:47124",
+					"172.22.0.1:47124",
+					"172.23.0.1:47124",
+					"172.24.0.1:47124",
+					"172.25.0.1:47124",
+					"172.26.0.1:47124",
+					"172.27.0.1:47124",
+					"172.28.0.1:47124"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:17:30.804386633Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:af7ffec8810d5b3fe5923128358511f60581552520a1e72aae1c05adb2eaaa64",
+			"MachineKey": "mkey:5ea882ec8b09e32eea2c9c72c7707183f0cd3a4efc25ae5438103ddbf03c1427",
+			"Peers": [{
+				"ID":         7267738963119122,
+				"StableID":   "n1E9yMBaky11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90085b2eac99b281e0343aa6634593a7ed4bd8e47e40c08c1c011bb05508f749",
+				"DiscoKey":   "discokey:a0ee95e28dd3d32bc9be6488d5030e36ca6d6fd123030794ef10140c5729ea3c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38781",
+					"10.65.0.27:38781",
+					"172.17.0.1:38781",
+					"172.18.0.1:38781",
+					"172.19.0.1:38781",
+					"172.20.0.1:38781",
+					"172.21.0.1:38781",
+					"172.22.0.1:38781",
+					"172.23.0.1:38781",
+					"172.24.0.1:38781",
+					"172.25.0.1:38781",
+					"172.26.0.1:38781",
+					"172.27.0.1:38781",
+					"172.28.0.1:38781"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:17:27.367207025Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3909302976209550,
+				"StableID":   "nohFE6mXXX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a1743f26bdca03b52d481b3ea0584a7d606430e2e0c506ca6be1a30e8b4a3006",
+				"DiscoKey":   "discokey:6b586235ad5cc37daf7c0463b5fdafe6c46269d42f31001c1df6f64828726b58",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44597",
+					"10.65.0.27:44597",
+					"172.17.0.1:44597",
+					"172.18.0.1:44597",
+					"172.19.0.1:44597",
+					"172.20.0.1:44597",
+					"172.21.0.1:44597",
+					"172.22.0.1:44597",
+					"172.23.0.1:44597",
+					"172.24.0.1:44597",
+					"172.25.0.1:44597",
+					"172.26.0.1:44597",
+					"172.27.0.1:44597",
+					"172.28.0.1:44597"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:17:28.086837834Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         387632227359478,
+				"StableID":   "nbykYbSZ2411CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a1f01689a1e22ccac1cffb0f5b21ce4fbeb85ddeefc7c80523dcda5a0a5d0948",
+				"DiscoKey":   "discokey:7366f41f4cee419ce831f057a4d5a6e2dfa7f3e7200e53e4b7685500c1e7a77a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:54326",
+					"10.65.0.27:54326",
+					"172.17.0.1:54326",
+					"172.18.0.1:54326",
+					"172.19.0.1:54326",
+					"172.20.0.1:54326",
+					"172.21.0.1:54326",
+					"172.22.0.1:54326",
+					"172.23.0.1:54326",
+					"172.24.0.1:54326",
+					"172.25.0.1:54326",
+					"172.26.0.1:54326",
+					"172.27.0.1:54326",
+					"172.28.0.1:54326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:17:28.629811446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1278908908902243,
+				"StableID":   "npMzrZmDzA11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85b6dab0e12f1319ae37b0135c9346681d5e7c73508525f26b4ffee8db753923",
+				"DiscoKey":   "discokey:c8f1d2be652eb4c31c8210d75f692358985d2162a07c93a072da3ae9f83cb501",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:38988",
+					"10.65.0.27:38988",
+					"172.17.0.1:38988",
+					"172.18.0.1:38988",
+					"172.19.0.1:38988",
+					"172.20.0.1:38988",
+					"172.21.0.1:38988",
+					"172.22.0.1:38988",
+					"172.23.0.1:38988",
+					"172.24.0.1:38988",
+					"172.25.0.1:38988",
+					"172.26.0.1:38988",
+					"172.27.0.1:38988",
+					"172.28.0.1:38988"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:17:29.183402864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4946368161903454,
+				"StableID":   "nb1gRqhDdf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec62fe51cac5cc9f43ad8aca85e4510bb568ced679df71a767ce190ab13b024b",
+				"DiscoKey":   "discokey:57e5df14c1618fe5956e9c0514572103cc8b6d87bc0a70a7b63460f6d127fe01",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48298",
+					"10.65.0.27:48298",
+					"172.17.0.1:48298",
+					"172.18.0.1:48298",
+					"172.19.0.1:48298",
+					"172.20.0.1:48298",
+					"172.21.0.1:48298",
+					"172.22.0.1:48298",
+					"172.23.0.1:48298",
+					"172.24.0.1:48298",
+					"172.25.0.1:48298",
+					"172.26.0.1:48298",
+					"172.27.0.1:48298",
+					"172.28.0.1:48298"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:17:29.73586827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3154700592985201,
+				"StableID":   "ncLydqdmdR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d499e95919abd1e7c7c3cb3b81bb9729ac709f4db6ae61040ed723a31b7bf67c",
+				"DiscoKey":   "discokey:569a0f33a5360c93a079a374be601613cf704794f8f00c8ac6727eb5adb0d502",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38714",
+					"10.65.0.27:38714",
+					"172.17.0.1:38714",
+					"172.18.0.1:38714",
+					"172.19.0.1:38714",
+					"172.20.0.1:38714",
+					"172.21.0.1:38714",
+					"172.22.0.1:38714",
+					"172.23.0.1:38714",
+					"172.24.0.1:38714",
+					"172.25.0.1:38714",
+					"172.26.0.1:38714",
+					"172.27.0.1:38714",
+					"172.28.0.1:38714"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:17:30.264898478Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5352238830031791,
+				"StableID":   "nLqgXpE3oi11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:64e261e1bb2482497b377ccc7f0b6a9ef29225abef61bbd0e43f7b2bb4b59548",
+				"DiscoKey":   "discokey:fe0db25ff7c34a4af51f837364d556b38c33b03d2f354bf563cbb6d0a5dffa68",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54665",
+					"10.65.0.27:54665",
+					"172.17.0.1:54665",
+					"172.18.0.1:54665",
+					"172.19.0.1:54665",
+					"172.20.0.1:54665",
+					"172.21.0.1:54665",
+					"172.22.0.1:54665",
+					"172.23.0.1:54665",
+					"172.24.0.1:54665",
+					"172.25.0.1:54665",
+					"172.26.0.1:54665",
+					"172.27.0.1:54665",
+					"172.28.0.1:54665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:17:31.336846118Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3877487888534945,
+				"StableID":   "n44qsq28HX11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:88459b5ce2d35ea5962fb966cc017777fab80d0309ccbf1784920f224aa93d11",
+				"DiscoKey":   "discokey:dd9fca8e7a32bb7fb8d077f7ca91a572a6d3f4544bc59993a1e9bcd2d5233137",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:55045",
+					"10.65.0.27:55045",
+					"172.17.0.1:55045",
+					"172.18.0.1:55045",
+					"172.19.0.1:55045",
+					"172.20.0.1:55045",
+					"172.21.0.1:55045",
+					"172.22.0.1:55045",
+					"172.23.0.1:55045",
+					"172.24.0.1:55045",
+					"172.25.0.1:55045",
+					"172.26.0.1:55045",
+					"172.27.0.1:55045",
+					"172.28.0.1:55045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:17:31.923308474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6775939488263536,
+				"StableID":   "nT4sTYSquu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d9edf97ee150ce92d98d1a65dfc848b7f5f5532b50feb0ac766f912b7e6153e",
+				"DiscoKey":   "discokey:db9366b0621b82422e3ef035d440cd5913199af49ec8df2f61f8eda98be3931f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:32885",
+					"10.65.0.27:32885",
+					"172.17.0.1:32885",
+					"172.18.0.1:32885",
+					"172.19.0.1:32885",
+					"172.20.0.1:32885",
+					"172.21.0.1:32885",
+					"172.22.0.1:32885",
+					"172.23.0.1:32885",
+					"172.24.0.1:32885",
+					"172.25.0.1:32885",
+					"172.26.0.1:32885",
+					"172.27.0.1:32885",
+					"172.28.0.1:32885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:17:32.470384761Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1642175263121054,
+				"StableID":   "nRtwdFAkpD11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af45f6c34aaded41b49ccefb641dfe8594f0a2aeafb7b9d03c1f2bb2db082255",
+				"DiscoKey":   "discokey:6de66d3dbb146817449cd4bd469cdd3859bb6f1c7e98dd9281113643c0d6c05a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44111",
+					"10.65.0.27:44111",
+					"172.17.0.1:44111",
+					"172.18.0.1:44111",
+					"172.19.0.1:44111",
+					"172.20.0.1:44111",
+					"172.21.0.1:44111",
+					"172.22.0.1:44111",
+					"172.23.0.1:44111",
+					"172.24.0.1:44111",
+					"172.25.0.1:44111",
+					"172.26.0.1:44111",
+					"172.27.0.1:44111",
+					"172.28.0.1:44111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:17:33.012319725Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2205486211879948,
+				"StableID":   "njAFDDPsDJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:280db06fdb1275071ce0e8b86d3f3ec2781914c95854a9bf9731471ca3368118",
+				"DiscoKey":   "discokey:6c3aa80a7e71cd8999abc158814de52644e6bcc18e5fa5ce8d8d0992eac7c53a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41569",
+					"10.65.0.27:41569",
+					"172.17.0.1:41569",
+					"172.18.0.1:41569",
+					"172.19.0.1:41569",
+					"172.20.0.1:41569",
+					"172.21.0.1:41569",
+					"172.22.0.1:41569",
+					"172.23.0.1:41569",
+					"172.24.0.1:41569",
+					"172.25.0.1:41569",
+					"172.26.0.1:41569",
+					"172.27.0.1:41569",
+					"172.28.0.1:41569"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:17:33.553972143Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7609651075458153,
+				"StableID":   "nUWiWYdRR221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a35f5c2db011b7f7550698c55688b6dbede87f56db3a18ae4e5d9f7089a8306b",
+				"KeyExpiry":  "2026-11-09T09:17:34Z",
+				"DiscoKey":   "discokey:f591d8af27668c045e2f33927567688e9915163ffc5a769e83ca1ba65ff5e164",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49541",
+					"10.65.0.27:49541",
+					"172.17.0.1:49541",
+					"172.18.0.1:49541",
+					"172.19.0.1:49541",
+					"172.20.0.1:49541",
+					"172.21.0.1:49541",
+					"172.22.0.1:49541",
+					"172.23.0.1:49541",
+					"172.24.0.1:49541",
+					"172.25.0.1:49541",
+					"172.26.0.1:49541",
+					"172.27.0.1:49541",
+					"172.28.0.1:49541"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:17:34.094327635Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6959374370599248,
+				"StableID":   "nw8astxuLw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5fcc8d855420dbf95e34ac09a3439f2879a30d55cb4c8c93354b03e94610df01",
+				"KeyExpiry":  "2026-11-09T09:17:34Z",
+				"DiscoKey":   "discokey:38ceb917783142ef6a89f7a6fc8d3acae022852743b459a2fba28a2c9e85360c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51108",
+					"10.65.0.27:51108",
+					"172.17.0.1:51108",
+					"172.18.0.1:51108",
+					"172.19.0.1:51108",
+					"172.20.0.1:51108",
+					"172.21.0.1:51108",
+					"172.22.0.1:51108",
+					"172.23.0.1:51108",
+					"172.24.0.1:51108",
+					"172.25.0.1:51108",
+					"172.26.0.1:51108",
+					"172.27.0.1:51108",
+					"172.28.0.1:51108"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:17:34.646533445Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3229698221397392,
+				"StableID":   "nV96FMhjDS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:69853df8125c47b11605630704f9718bd263073378e2c9ab06d92ffad055f440",
+				"KeyExpiry":  "2026-11-09T09:17:35Z",
+				"DiscoKey":   "discokey:d6fe8ea030f27c7f096ee187a0ce83d33110ad7217cae9fd3b6298191d58dc48",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39247",
+					"10.65.0.27:39247",
+					"172.17.0.1:39247",
+					"172.18.0.1:39247",
+					"172.19.0.1:39247",
+					"172.20.0.1:39247",
+					"172.21.0.1:39247",
+					"172.22.0.1:39247",
+					"172.23.0.1:39247",
+					"172.24.0.1:39247",
+					"172.25.0.1:39247",
+					"172.26.0.1:39247",
+					"172.27.0.1:39247",
+					"172.28.0.1:39247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:17:35.203500028Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6208974310850102": {
+				"ID":          6208974310850102,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3877487888534945,
+				"StableID":   "n44qsq28HX11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       3877487888534945,
+				"Key":        "nodekey:88459b5ce2d35ea5962fb966cc017777fab80d0309ccbf1784920f224aa93d11",
+				"DiscoKey":   "discokey:dd9fca8e7a32bb7fb8d077f7ca91a572a6d3f4544bc59993a1e9bcd2d5233137",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:55045",
+					"10.65.0.27:55045",
+					"172.17.0.1:55045",
+					"172.18.0.1:55045",
+					"172.19.0.1:55045",
+					"172.20.0.1:55045",
+					"172.21.0.1:55045",
+					"172.22.0.1:55045",
+					"172.23.0.1:55045",
+					"172.24.0.1:55045",
+					"172.25.0.1:55045",
+					"172.26.0.1:55045",
+					"172.27.0.1:55045",
+					"172.28.0.1:55045"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:17:31.923308474Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:88459b5ce2d35ea5962fb966cc017777fab80d0309ccbf1784920f224aa93d11",
+			"MachineKey": "mkey:9efe2d50ce6b6c4fc0ec7f92f78ffea580d63ad0364e78d29d2cc6196131e908",
+			"Peers": [{
+				"ID":         7267738963119122,
+				"StableID":   "n1E9yMBaky11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90085b2eac99b281e0343aa6634593a7ed4bd8e47e40c08c1c011bb05508f749",
+				"DiscoKey":   "discokey:a0ee95e28dd3d32bc9be6488d5030e36ca6d6fd123030794ef10140c5729ea3c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38781",
+					"10.65.0.27:38781",
+					"172.17.0.1:38781",
+					"172.18.0.1:38781",
+					"172.19.0.1:38781",
+					"172.20.0.1:38781",
+					"172.21.0.1:38781",
+					"172.22.0.1:38781",
+					"172.23.0.1:38781",
+					"172.24.0.1:38781",
+					"172.25.0.1:38781",
+					"172.26.0.1:38781",
+					"172.27.0.1:38781",
+					"172.28.0.1:38781"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:17:27.367207025Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3909302976209550,
+				"StableID":   "nohFE6mXXX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a1743f26bdca03b52d481b3ea0584a7d606430e2e0c506ca6be1a30e8b4a3006",
+				"DiscoKey":   "discokey:6b586235ad5cc37daf7c0463b5fdafe6c46269d42f31001c1df6f64828726b58",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44597",
+					"10.65.0.27:44597",
+					"172.17.0.1:44597",
+					"172.18.0.1:44597",
+					"172.19.0.1:44597",
+					"172.20.0.1:44597",
+					"172.21.0.1:44597",
+					"172.22.0.1:44597",
+					"172.23.0.1:44597",
+					"172.24.0.1:44597",
+					"172.25.0.1:44597",
+					"172.26.0.1:44597",
+					"172.27.0.1:44597",
+					"172.28.0.1:44597"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:17:28.086837834Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         387632227359478,
+				"StableID":   "nbykYbSZ2411CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a1f01689a1e22ccac1cffb0f5b21ce4fbeb85ddeefc7c80523dcda5a0a5d0948",
+				"DiscoKey":   "discokey:7366f41f4cee419ce831f057a4d5a6e2dfa7f3e7200e53e4b7685500c1e7a77a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:54326",
+					"10.65.0.27:54326",
+					"172.17.0.1:54326",
+					"172.18.0.1:54326",
+					"172.19.0.1:54326",
+					"172.20.0.1:54326",
+					"172.21.0.1:54326",
+					"172.22.0.1:54326",
+					"172.23.0.1:54326",
+					"172.24.0.1:54326",
+					"172.25.0.1:54326",
+					"172.26.0.1:54326",
+					"172.27.0.1:54326",
+					"172.28.0.1:54326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:17:28.629811446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1278908908902243,
+				"StableID":   "npMzrZmDzA11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85b6dab0e12f1319ae37b0135c9346681d5e7c73508525f26b4ffee8db753923",
+				"DiscoKey":   "discokey:c8f1d2be652eb4c31c8210d75f692358985d2162a07c93a072da3ae9f83cb501",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:38988",
+					"10.65.0.27:38988",
+					"172.17.0.1:38988",
+					"172.18.0.1:38988",
+					"172.19.0.1:38988",
+					"172.20.0.1:38988",
+					"172.21.0.1:38988",
+					"172.22.0.1:38988",
+					"172.23.0.1:38988",
+					"172.24.0.1:38988",
+					"172.25.0.1:38988",
+					"172.26.0.1:38988",
+					"172.27.0.1:38988",
+					"172.28.0.1:38988"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:17:29.183402864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4946368161903454,
+				"StableID":   "nb1gRqhDdf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec62fe51cac5cc9f43ad8aca85e4510bb568ced679df71a767ce190ab13b024b",
+				"DiscoKey":   "discokey:57e5df14c1618fe5956e9c0514572103cc8b6d87bc0a70a7b63460f6d127fe01",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48298",
+					"10.65.0.27:48298",
+					"172.17.0.1:48298",
+					"172.18.0.1:48298",
+					"172.19.0.1:48298",
+					"172.20.0.1:48298",
+					"172.21.0.1:48298",
+					"172.22.0.1:48298",
+					"172.23.0.1:48298",
+					"172.24.0.1:48298",
+					"172.25.0.1:48298",
+					"172.26.0.1:48298",
+					"172.27.0.1:48298",
+					"172.28.0.1:48298"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:17:29.73586827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3154700592985201,
+				"StableID":   "ncLydqdmdR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d499e95919abd1e7c7c3cb3b81bb9729ac709f4db6ae61040ed723a31b7bf67c",
+				"DiscoKey":   "discokey:569a0f33a5360c93a079a374be601613cf704794f8f00c8ac6727eb5adb0d502",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38714",
+					"10.65.0.27:38714",
+					"172.17.0.1:38714",
+					"172.18.0.1:38714",
+					"172.19.0.1:38714",
+					"172.20.0.1:38714",
+					"172.21.0.1:38714",
+					"172.22.0.1:38714",
+					"172.23.0.1:38714",
+					"172.24.0.1:38714",
+					"172.25.0.1:38714",
+					"172.26.0.1:38714",
+					"172.27.0.1:38714",
+					"172.28.0.1:38714"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:17:30.264898478Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6208974310850102,
+				"StableID":   "nVCYD9E4Vq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af7ffec8810d5b3fe5923128358511f60581552520a1e72aae1c05adb2eaaa64",
+				"DiscoKey":   "discokey:c0cc373615cff41800b24e3a13eab3c1133ba1395a28a8efd8267546fc25cb56",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47124",
+					"10.65.0.27:47124",
+					"172.17.0.1:47124",
+					"172.18.0.1:47124",
+					"172.19.0.1:47124",
+					"172.20.0.1:47124",
+					"172.21.0.1:47124",
+					"172.22.0.1:47124",
+					"172.23.0.1:47124",
+					"172.24.0.1:47124",
+					"172.25.0.1:47124",
+					"172.26.0.1:47124",
+					"172.27.0.1:47124",
+					"172.28.0.1:47124"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:17:30.804386633Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5352238830031791,
+				"StableID":   "nLqgXpE3oi11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:64e261e1bb2482497b377ccc7f0b6a9ef29225abef61bbd0e43f7b2bb4b59548",
+				"DiscoKey":   "discokey:fe0db25ff7c34a4af51f837364d556b38c33b03d2f354bf563cbb6d0a5dffa68",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54665",
+					"10.65.0.27:54665",
+					"172.17.0.1:54665",
+					"172.18.0.1:54665",
+					"172.19.0.1:54665",
+					"172.20.0.1:54665",
+					"172.21.0.1:54665",
+					"172.22.0.1:54665",
+					"172.23.0.1:54665",
+					"172.24.0.1:54665",
+					"172.25.0.1:54665",
+					"172.26.0.1:54665",
+					"172.27.0.1:54665",
+					"172.28.0.1:54665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:17:31.336846118Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6775939488263536,
+				"StableID":   "nT4sTYSquu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d9edf97ee150ce92d98d1a65dfc848b7f5f5532b50feb0ac766f912b7e6153e",
+				"DiscoKey":   "discokey:db9366b0621b82422e3ef035d440cd5913199af49ec8df2f61f8eda98be3931f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:32885",
+					"10.65.0.27:32885",
+					"172.17.0.1:32885",
+					"172.18.0.1:32885",
+					"172.19.0.1:32885",
+					"172.20.0.1:32885",
+					"172.21.0.1:32885",
+					"172.22.0.1:32885",
+					"172.23.0.1:32885",
+					"172.24.0.1:32885",
+					"172.25.0.1:32885",
+					"172.26.0.1:32885",
+					"172.27.0.1:32885",
+					"172.28.0.1:32885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:17:32.470384761Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1642175263121054,
+				"StableID":   "nRtwdFAkpD11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af45f6c34aaded41b49ccefb641dfe8594f0a2aeafb7b9d03c1f2bb2db082255",
+				"DiscoKey":   "discokey:6de66d3dbb146817449cd4bd469cdd3859bb6f1c7e98dd9281113643c0d6c05a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44111",
+					"10.65.0.27:44111",
+					"172.17.0.1:44111",
+					"172.18.0.1:44111",
+					"172.19.0.1:44111",
+					"172.20.0.1:44111",
+					"172.21.0.1:44111",
+					"172.22.0.1:44111",
+					"172.23.0.1:44111",
+					"172.24.0.1:44111",
+					"172.25.0.1:44111",
+					"172.26.0.1:44111",
+					"172.27.0.1:44111",
+					"172.28.0.1:44111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:17:33.012319725Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2205486211879948,
+				"StableID":   "njAFDDPsDJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:280db06fdb1275071ce0e8b86d3f3ec2781914c95854a9bf9731471ca3368118",
+				"DiscoKey":   "discokey:6c3aa80a7e71cd8999abc158814de52644e6bcc18e5fa5ce8d8d0992eac7c53a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41569",
+					"10.65.0.27:41569",
+					"172.17.0.1:41569",
+					"172.18.0.1:41569",
+					"172.19.0.1:41569",
+					"172.20.0.1:41569",
+					"172.21.0.1:41569",
+					"172.22.0.1:41569",
+					"172.23.0.1:41569",
+					"172.24.0.1:41569",
+					"172.25.0.1:41569",
+					"172.26.0.1:41569",
+					"172.27.0.1:41569",
+					"172.28.0.1:41569"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:17:33.553972143Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7609651075458153,
+				"StableID":   "nUWiWYdRR221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a35f5c2db011b7f7550698c55688b6dbede87f56db3a18ae4e5d9f7089a8306b",
+				"KeyExpiry":  "2026-11-09T09:17:34Z",
+				"DiscoKey":   "discokey:f591d8af27668c045e2f33927567688e9915163ffc5a769e83ca1ba65ff5e164",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49541",
+					"10.65.0.27:49541",
+					"172.17.0.1:49541",
+					"172.18.0.1:49541",
+					"172.19.0.1:49541",
+					"172.20.0.1:49541",
+					"172.21.0.1:49541",
+					"172.22.0.1:49541",
+					"172.23.0.1:49541",
+					"172.24.0.1:49541",
+					"172.25.0.1:49541",
+					"172.26.0.1:49541",
+					"172.27.0.1:49541",
+					"172.28.0.1:49541"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:17:34.094327635Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6959374370599248,
+				"StableID":   "nw8astxuLw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5fcc8d855420dbf95e34ac09a3439f2879a30d55cb4c8c93354b03e94610df01",
+				"KeyExpiry":  "2026-11-09T09:17:34Z",
+				"DiscoKey":   "discokey:38ceb917783142ef6a89f7a6fc8d3acae022852743b459a2fba28a2c9e85360c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51108",
+					"10.65.0.27:51108",
+					"172.17.0.1:51108",
+					"172.18.0.1:51108",
+					"172.19.0.1:51108",
+					"172.20.0.1:51108",
+					"172.21.0.1:51108",
+					"172.22.0.1:51108",
+					"172.23.0.1:51108",
+					"172.24.0.1:51108",
+					"172.25.0.1:51108",
+					"172.26.0.1:51108",
+					"172.27.0.1:51108",
+					"172.28.0.1:51108"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:17:34.646533445Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3229698221397392,
+				"StableID":   "nV96FMhjDS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:69853df8125c47b11605630704f9718bd263073378e2c9ab06d92ffad055f440",
+				"KeyExpiry":  "2026-11-09T09:17:35Z",
+				"DiscoKey":   "discokey:d6fe8ea030f27c7f096ee187a0ce83d33110ad7217cae9fd3b6298191d58dc48",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39247",
+					"10.65.0.27:39247",
+					"172.17.0.1:39247",
+					"172.18.0.1:39247",
+					"172.19.0.1:39247",
+					"172.20.0.1:39247",
+					"172.21.0.1:39247",
+					"172.22.0.1:39247",
+					"172.23.0.1:39247",
+					"172.24.0.1:39247",
+					"172.25.0.1:39247",
+					"172.26.0.1:39247",
+					"172.27.0.1:39247",
+					"172.28.0.1:39247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:17:35.203500028Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3877487888534945": {
+				"ID":          3877487888534945,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6959374370599248,
+				"StableID":   "nw8astxuLw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5fcc8d855420dbf95e34ac09a3439f2879a30d55cb4c8c93354b03e94610df01",
+				"KeyExpiry":  "2026-11-09T09:17:34Z",
+				"DiscoKey":   "discokey:38ceb917783142ef6a89f7a6fc8d3acae022852743b459a2fba28a2c9e85360c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51108",
+					"10.65.0.27:51108",
+					"172.17.0.1:51108",
+					"172.18.0.1:51108",
+					"172.19.0.1:51108",
+					"172.20.0.1:51108",
+					"172.21.0.1:51108",
+					"172.22.0.1:51108",
+					"172.23.0.1:51108",
+					"172.24.0.1:51108",
+					"172.25.0.1:51108",
+					"172.26.0.1:51108",
+					"172.27.0.1:51108",
+					"172.28.0.1:51108"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:17:34.646533445Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5fcc8d855420dbf95e34ac09a3439f2879a30d55cb4c8c93354b03e94610df01",
+			"MachineKey": "mkey:9505ef39e2cdc0a477bd70402e5fb7ad90c0cef9a4e5223ed796aaaaa2d09c27",
+			"Peers": [{
+				"ID":         7267738963119122,
+				"StableID":   "n1E9yMBaky11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90085b2eac99b281e0343aa6634593a7ed4bd8e47e40c08c1c011bb05508f749",
+				"DiscoKey":   "discokey:a0ee95e28dd3d32bc9be6488d5030e36ca6d6fd123030794ef10140c5729ea3c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38781",
+					"10.65.0.27:38781",
+					"172.17.0.1:38781",
+					"172.18.0.1:38781",
+					"172.19.0.1:38781",
+					"172.20.0.1:38781",
+					"172.21.0.1:38781",
+					"172.22.0.1:38781",
+					"172.23.0.1:38781",
+					"172.24.0.1:38781",
+					"172.25.0.1:38781",
+					"172.26.0.1:38781",
+					"172.27.0.1:38781",
+					"172.28.0.1:38781"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:17:27.367207025Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3909302976209550,
+				"StableID":   "nohFE6mXXX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a1743f26bdca03b52d481b3ea0584a7d606430e2e0c506ca6be1a30e8b4a3006",
+				"DiscoKey":   "discokey:6b586235ad5cc37daf7c0463b5fdafe6c46269d42f31001c1df6f64828726b58",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44597",
+					"10.65.0.27:44597",
+					"172.17.0.1:44597",
+					"172.18.0.1:44597",
+					"172.19.0.1:44597",
+					"172.20.0.1:44597",
+					"172.21.0.1:44597",
+					"172.22.0.1:44597",
+					"172.23.0.1:44597",
+					"172.24.0.1:44597",
+					"172.25.0.1:44597",
+					"172.26.0.1:44597",
+					"172.27.0.1:44597",
+					"172.28.0.1:44597"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:17:28.086837834Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         387632227359478,
+				"StableID":   "nbykYbSZ2411CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a1f01689a1e22ccac1cffb0f5b21ce4fbeb85ddeefc7c80523dcda5a0a5d0948",
+				"DiscoKey":   "discokey:7366f41f4cee419ce831f057a4d5a6e2dfa7f3e7200e53e4b7685500c1e7a77a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:54326",
+					"10.65.0.27:54326",
+					"172.17.0.1:54326",
+					"172.18.0.1:54326",
+					"172.19.0.1:54326",
+					"172.20.0.1:54326",
+					"172.21.0.1:54326",
+					"172.22.0.1:54326",
+					"172.23.0.1:54326",
+					"172.24.0.1:54326",
+					"172.25.0.1:54326",
+					"172.26.0.1:54326",
+					"172.27.0.1:54326",
+					"172.28.0.1:54326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:17:28.629811446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1278908908902243,
+				"StableID":   "npMzrZmDzA11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85b6dab0e12f1319ae37b0135c9346681d5e7c73508525f26b4ffee8db753923",
+				"DiscoKey":   "discokey:c8f1d2be652eb4c31c8210d75f692358985d2162a07c93a072da3ae9f83cb501",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:38988",
+					"10.65.0.27:38988",
+					"172.17.0.1:38988",
+					"172.18.0.1:38988",
+					"172.19.0.1:38988",
+					"172.20.0.1:38988",
+					"172.21.0.1:38988",
+					"172.22.0.1:38988",
+					"172.23.0.1:38988",
+					"172.24.0.1:38988",
+					"172.25.0.1:38988",
+					"172.26.0.1:38988",
+					"172.27.0.1:38988",
+					"172.28.0.1:38988"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:17:29.183402864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4946368161903454,
+				"StableID":   "nb1gRqhDdf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec62fe51cac5cc9f43ad8aca85e4510bb568ced679df71a767ce190ab13b024b",
+				"DiscoKey":   "discokey:57e5df14c1618fe5956e9c0514572103cc8b6d87bc0a70a7b63460f6d127fe01",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48298",
+					"10.65.0.27:48298",
+					"172.17.0.1:48298",
+					"172.18.0.1:48298",
+					"172.19.0.1:48298",
+					"172.20.0.1:48298",
+					"172.21.0.1:48298",
+					"172.22.0.1:48298",
+					"172.23.0.1:48298",
+					"172.24.0.1:48298",
+					"172.25.0.1:48298",
+					"172.26.0.1:48298",
+					"172.27.0.1:48298",
+					"172.28.0.1:48298"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:17:29.73586827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3154700592985201,
+				"StableID":   "ncLydqdmdR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d499e95919abd1e7c7c3cb3b81bb9729ac709f4db6ae61040ed723a31b7bf67c",
+				"DiscoKey":   "discokey:569a0f33a5360c93a079a374be601613cf704794f8f00c8ac6727eb5adb0d502",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38714",
+					"10.65.0.27:38714",
+					"172.17.0.1:38714",
+					"172.18.0.1:38714",
+					"172.19.0.1:38714",
+					"172.20.0.1:38714",
+					"172.21.0.1:38714",
+					"172.22.0.1:38714",
+					"172.23.0.1:38714",
+					"172.24.0.1:38714",
+					"172.25.0.1:38714",
+					"172.26.0.1:38714",
+					"172.27.0.1:38714",
+					"172.28.0.1:38714"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:17:30.264898478Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6208974310850102,
+				"StableID":   "nVCYD9E4Vq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af7ffec8810d5b3fe5923128358511f60581552520a1e72aae1c05adb2eaaa64",
+				"DiscoKey":   "discokey:c0cc373615cff41800b24e3a13eab3c1133ba1395a28a8efd8267546fc25cb56",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47124",
+					"10.65.0.27:47124",
+					"172.17.0.1:47124",
+					"172.18.0.1:47124",
+					"172.19.0.1:47124",
+					"172.20.0.1:47124",
+					"172.21.0.1:47124",
+					"172.22.0.1:47124",
+					"172.23.0.1:47124",
+					"172.24.0.1:47124",
+					"172.25.0.1:47124",
+					"172.26.0.1:47124",
+					"172.27.0.1:47124",
+					"172.28.0.1:47124"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:17:30.804386633Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5352238830031791,
+				"StableID":   "nLqgXpE3oi11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:64e261e1bb2482497b377ccc7f0b6a9ef29225abef61bbd0e43f7b2bb4b59548",
+				"DiscoKey":   "discokey:fe0db25ff7c34a4af51f837364d556b38c33b03d2f354bf563cbb6d0a5dffa68",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54665",
+					"10.65.0.27:54665",
+					"172.17.0.1:54665",
+					"172.18.0.1:54665",
+					"172.19.0.1:54665",
+					"172.20.0.1:54665",
+					"172.21.0.1:54665",
+					"172.22.0.1:54665",
+					"172.23.0.1:54665",
+					"172.24.0.1:54665",
+					"172.25.0.1:54665",
+					"172.26.0.1:54665",
+					"172.27.0.1:54665",
+					"172.28.0.1:54665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:17:31.336846118Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3877487888534945,
+				"StableID":   "n44qsq28HX11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:88459b5ce2d35ea5962fb966cc017777fab80d0309ccbf1784920f224aa93d11",
+				"DiscoKey":   "discokey:dd9fca8e7a32bb7fb8d077f7ca91a572a6d3f4544bc59993a1e9bcd2d5233137",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:55045",
+					"10.65.0.27:55045",
+					"172.17.0.1:55045",
+					"172.18.0.1:55045",
+					"172.19.0.1:55045",
+					"172.20.0.1:55045",
+					"172.21.0.1:55045",
+					"172.22.0.1:55045",
+					"172.23.0.1:55045",
+					"172.24.0.1:55045",
+					"172.25.0.1:55045",
+					"172.26.0.1:55045",
+					"172.27.0.1:55045",
+					"172.28.0.1:55045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:17:31.923308474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6775939488263536,
+				"StableID":   "nT4sTYSquu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d9edf97ee150ce92d98d1a65dfc848b7f5f5532b50feb0ac766f912b7e6153e",
+				"DiscoKey":   "discokey:db9366b0621b82422e3ef035d440cd5913199af49ec8df2f61f8eda98be3931f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:32885",
+					"10.65.0.27:32885",
+					"172.17.0.1:32885",
+					"172.18.0.1:32885",
+					"172.19.0.1:32885",
+					"172.20.0.1:32885",
+					"172.21.0.1:32885",
+					"172.22.0.1:32885",
+					"172.23.0.1:32885",
+					"172.24.0.1:32885",
+					"172.25.0.1:32885",
+					"172.26.0.1:32885",
+					"172.27.0.1:32885",
+					"172.28.0.1:32885"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:17:32.470384761Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1642175263121054,
+				"StableID":   "nRtwdFAkpD11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af45f6c34aaded41b49ccefb641dfe8594f0a2aeafb7b9d03c1f2bb2db082255",
+				"DiscoKey":   "discokey:6de66d3dbb146817449cd4bd469cdd3859bb6f1c7e98dd9281113643c0d6c05a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44111",
+					"10.65.0.27:44111",
+					"172.17.0.1:44111",
+					"172.18.0.1:44111",
+					"172.19.0.1:44111",
+					"172.20.0.1:44111",
+					"172.21.0.1:44111",
+					"172.22.0.1:44111",
+					"172.23.0.1:44111",
+					"172.24.0.1:44111",
+					"172.25.0.1:44111",
+					"172.26.0.1:44111",
+					"172.27.0.1:44111",
+					"172.28.0.1:44111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:17:33.012319725Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2205486211879948,
+				"StableID":   "njAFDDPsDJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:280db06fdb1275071ce0e8b86d3f3ec2781914c95854a9bf9731471ca3368118",
+				"DiscoKey":   "discokey:6c3aa80a7e71cd8999abc158814de52644e6bcc18e5fa5ce8d8d0992eac7c53a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41569",
+					"10.65.0.27:41569",
+					"172.17.0.1:41569",
+					"172.18.0.1:41569",
+					"172.19.0.1:41569",
+					"172.20.0.1:41569",
+					"172.21.0.1:41569",
+					"172.22.0.1:41569",
+					"172.23.0.1:41569",
+					"172.24.0.1:41569",
+					"172.25.0.1:41569",
+					"172.26.0.1:41569",
+					"172.27.0.1:41569",
+					"172.28.0.1:41569"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:17:33.553972143Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7609651075458153,
+				"StableID":   "nUWiWYdRR221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a35f5c2db011b7f7550698c55688b6dbede87f56db3a18ae4e5d9f7089a8306b",
+				"KeyExpiry":  "2026-11-09T09:17:34Z",
+				"DiscoKey":   "discokey:f591d8af27668c045e2f33927567688e9915163ffc5a769e83ca1ba65ff5e164",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49541",
+					"10.65.0.27:49541",
+					"172.17.0.1:49541",
+					"172.18.0.1:49541",
+					"172.19.0.1:49541",
+					"172.20.0.1:49541",
+					"172.21.0.1:49541",
+					"172.22.0.1:49541",
+					"172.23.0.1:49541",
+					"172.24.0.1:49541",
+					"172.25.0.1:49541",
+					"172.26.0.1:49541",
+					"172.27.0.1:49541",
+					"172.28.0.1:49541"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:17:34.094327635Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3229698221397392,
+				"StableID":   "nV96FMhjDS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:69853df8125c47b11605630704f9718bd263073378e2c9ab06d92ffad055f440",
+				"KeyExpiry":  "2026-11-09T09:17:35Z",
+				"DiscoKey":   "discokey:d6fe8ea030f27c7f096ee187a0ce83d33110ad7217cae9fd3b6298191d58dc48",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39247",
+					"10.65.0.27:39247",
+					"172.17.0.1:39247",
+					"172.18.0.1:39247",
+					"172.19.0.1:39247",
+					"172.20.0.1:39247",
+					"172.21.0.1:39247",
+					"172.22.0.1:39247",
+					"172.23.0.1:39247",
+					"172.24.0.1:39247",
+					"172.25.0.1:39247",
+					"172.26.0.1:39247",
+					"172.27.0.1:39247",
+					"172.28.0.1:39247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:17:35.203500028Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6775939488263536,
+				"StableID":   "nT4sTYSquu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       6775939488263536,
+				"Key":        "nodekey:4d9edf97ee150ce92d98d1a65dfc848b7f5f5532b50feb0ac766f912b7e6153e",
+				"DiscoKey":   "discokey:db9366b0621b82422e3ef035d440cd5913199af49ec8df2f61f8eda98be3931f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:32885",
+					"10.65.0.27:32885",
+					"172.17.0.1:32885",
+					"172.18.0.1:32885",
+					"172.19.0.1:32885",
+					"172.20.0.1:32885",
+					"172.21.0.1:32885",
+					"172.22.0.1:32885",
+					"172.23.0.1:32885",
+					"172.24.0.1:32885",
+					"172.25.0.1:32885",
+					"172.26.0.1:32885",
+					"172.27.0.1:32885",
+					"172.28.0.1:32885"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:17:32.470384761Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4d9edf97ee150ce92d98d1a65dfc848b7f5f5532b50feb0ac766f912b7e6153e",
+			"MachineKey": "mkey:a99105f718d1577885676519976b8c87d9d51d4519a64b5d6fdad4c537c9be6e",
+			"Peers": [{
+				"ID":         7267738963119122,
+				"StableID":   "n1E9yMBaky11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90085b2eac99b281e0343aa6634593a7ed4bd8e47e40c08c1c011bb05508f749",
+				"DiscoKey":   "discokey:a0ee95e28dd3d32bc9be6488d5030e36ca6d6fd123030794ef10140c5729ea3c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38781",
+					"10.65.0.27:38781",
+					"172.17.0.1:38781",
+					"172.18.0.1:38781",
+					"172.19.0.1:38781",
+					"172.20.0.1:38781",
+					"172.21.0.1:38781",
+					"172.22.0.1:38781",
+					"172.23.0.1:38781",
+					"172.24.0.1:38781",
+					"172.25.0.1:38781",
+					"172.26.0.1:38781",
+					"172.27.0.1:38781",
+					"172.28.0.1:38781"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:17:27.367207025Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3909302976209550,
+				"StableID":   "nohFE6mXXX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a1743f26bdca03b52d481b3ea0584a7d606430e2e0c506ca6be1a30e8b4a3006",
+				"DiscoKey":   "discokey:6b586235ad5cc37daf7c0463b5fdafe6c46269d42f31001c1df6f64828726b58",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44597",
+					"10.65.0.27:44597",
+					"172.17.0.1:44597",
+					"172.18.0.1:44597",
+					"172.19.0.1:44597",
+					"172.20.0.1:44597",
+					"172.21.0.1:44597",
+					"172.22.0.1:44597",
+					"172.23.0.1:44597",
+					"172.24.0.1:44597",
+					"172.25.0.1:44597",
+					"172.26.0.1:44597",
+					"172.27.0.1:44597",
+					"172.28.0.1:44597"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:17:28.086837834Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         387632227359478,
+				"StableID":   "nbykYbSZ2411CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a1f01689a1e22ccac1cffb0f5b21ce4fbeb85ddeefc7c80523dcda5a0a5d0948",
+				"DiscoKey":   "discokey:7366f41f4cee419ce831f057a4d5a6e2dfa7f3e7200e53e4b7685500c1e7a77a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:54326",
+					"10.65.0.27:54326",
+					"172.17.0.1:54326",
+					"172.18.0.1:54326",
+					"172.19.0.1:54326",
+					"172.20.0.1:54326",
+					"172.21.0.1:54326",
+					"172.22.0.1:54326",
+					"172.23.0.1:54326",
+					"172.24.0.1:54326",
+					"172.25.0.1:54326",
+					"172.26.0.1:54326",
+					"172.27.0.1:54326",
+					"172.28.0.1:54326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:17:28.629811446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1278908908902243,
+				"StableID":   "npMzrZmDzA11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:85b6dab0e12f1319ae37b0135c9346681d5e7c73508525f26b4ffee8db753923",
+				"DiscoKey":   "discokey:c8f1d2be652eb4c31c8210d75f692358985d2162a07c93a072da3ae9f83cb501",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:38988",
+					"10.65.0.27:38988",
+					"172.17.0.1:38988",
+					"172.18.0.1:38988",
+					"172.19.0.1:38988",
+					"172.20.0.1:38988",
+					"172.21.0.1:38988",
+					"172.22.0.1:38988",
+					"172.23.0.1:38988",
+					"172.24.0.1:38988",
+					"172.25.0.1:38988",
+					"172.26.0.1:38988",
+					"172.27.0.1:38988",
+					"172.28.0.1:38988"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:17:29.183402864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4946368161903454,
+				"StableID":   "nb1gRqhDdf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec62fe51cac5cc9f43ad8aca85e4510bb568ced679df71a767ce190ab13b024b",
+				"DiscoKey":   "discokey:57e5df14c1618fe5956e9c0514572103cc8b6d87bc0a70a7b63460f6d127fe01",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48298",
+					"10.65.0.27:48298",
+					"172.17.0.1:48298",
+					"172.18.0.1:48298",
+					"172.19.0.1:48298",
+					"172.20.0.1:48298",
+					"172.21.0.1:48298",
+					"172.22.0.1:48298",
+					"172.23.0.1:48298",
+					"172.24.0.1:48298",
+					"172.25.0.1:48298",
+					"172.26.0.1:48298",
+					"172.27.0.1:48298",
+					"172.28.0.1:48298"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:17:29.73586827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3154700592985201,
+				"StableID":   "ncLydqdmdR11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d499e95919abd1e7c7c3cb3b81bb9729ac709f4db6ae61040ed723a31b7bf67c",
+				"DiscoKey":   "discokey:569a0f33a5360c93a079a374be601613cf704794f8f00c8ac6727eb5adb0d502",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38714",
+					"10.65.0.27:38714",
+					"172.17.0.1:38714",
+					"172.18.0.1:38714",
+					"172.19.0.1:38714",
+					"172.20.0.1:38714",
+					"172.21.0.1:38714",
+					"172.22.0.1:38714",
+					"172.23.0.1:38714",
+					"172.24.0.1:38714",
+					"172.25.0.1:38714",
+					"172.26.0.1:38714",
+					"172.27.0.1:38714",
+					"172.28.0.1:38714"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:17:30.264898478Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6208974310850102,
+				"StableID":   "nVCYD9E4Vq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af7ffec8810d5b3fe5923128358511f60581552520a1e72aae1c05adb2eaaa64",
+				"DiscoKey":   "discokey:c0cc373615cff41800b24e3a13eab3c1133ba1395a28a8efd8267546fc25cb56",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47124",
+					"10.65.0.27:47124",
+					"172.17.0.1:47124",
+					"172.18.0.1:47124",
+					"172.19.0.1:47124",
+					"172.20.0.1:47124",
+					"172.21.0.1:47124",
+					"172.22.0.1:47124",
+					"172.23.0.1:47124",
+					"172.24.0.1:47124",
+					"172.25.0.1:47124",
+					"172.26.0.1:47124",
+					"172.27.0.1:47124",
+					"172.28.0.1:47124"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:17:30.804386633Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5352238830031791,
+				"StableID":   "nLqgXpE3oi11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:64e261e1bb2482497b377ccc7f0b6a9ef29225abef61bbd0e43f7b2bb4b59548",
+				"DiscoKey":   "discokey:fe0db25ff7c34a4af51f837364d556b38c33b03d2f354bf563cbb6d0a5dffa68",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54665",
+					"10.65.0.27:54665",
+					"172.17.0.1:54665",
+					"172.18.0.1:54665",
+					"172.19.0.1:54665",
+					"172.20.0.1:54665",
+					"172.21.0.1:54665",
+					"172.22.0.1:54665",
+					"172.23.0.1:54665",
+					"172.24.0.1:54665",
+					"172.25.0.1:54665",
+					"172.26.0.1:54665",
+					"172.27.0.1:54665",
+					"172.28.0.1:54665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:17:31.336846118Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3877487888534945,
+				"StableID":   "n44qsq28HX11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:88459b5ce2d35ea5962fb966cc017777fab80d0309ccbf1784920f224aa93d11",
+				"DiscoKey":   "discokey:dd9fca8e7a32bb7fb8d077f7ca91a572a6d3f4544bc59993a1e9bcd2d5233137",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:55045",
+					"10.65.0.27:55045",
+					"172.17.0.1:55045",
+					"172.18.0.1:55045",
+					"172.19.0.1:55045",
+					"172.20.0.1:55045",
+					"172.21.0.1:55045",
+					"172.22.0.1:55045",
+					"172.23.0.1:55045",
+					"172.24.0.1:55045",
+					"172.25.0.1:55045",
+					"172.26.0.1:55045",
+					"172.27.0.1:55045",
+					"172.28.0.1:55045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:17:31.923308474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1642175263121054,
+				"StableID":   "nRtwdFAkpD11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af45f6c34aaded41b49ccefb641dfe8594f0a2aeafb7b9d03c1f2bb2db082255",
+				"DiscoKey":   "discokey:6de66d3dbb146817449cd4bd469cdd3859bb6f1c7e98dd9281113643c0d6c05a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44111",
+					"10.65.0.27:44111",
+					"172.17.0.1:44111",
+					"172.18.0.1:44111",
+					"172.19.0.1:44111",
+					"172.20.0.1:44111",
+					"172.21.0.1:44111",
+					"172.22.0.1:44111",
+					"172.23.0.1:44111",
+					"172.24.0.1:44111",
+					"172.25.0.1:44111",
+					"172.26.0.1:44111",
+					"172.27.0.1:44111",
+					"172.28.0.1:44111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:17:33.012319725Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2205486211879948,
+				"StableID":   "njAFDDPsDJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:280db06fdb1275071ce0e8b86d3f3ec2781914c95854a9bf9731471ca3368118",
+				"DiscoKey":   "discokey:6c3aa80a7e71cd8999abc158814de52644e6bcc18e5fa5ce8d8d0992eac7c53a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41569",
+					"10.65.0.27:41569",
+					"172.17.0.1:41569",
+					"172.18.0.1:41569",
+					"172.19.0.1:41569",
+					"172.20.0.1:41569",
+					"172.21.0.1:41569",
+					"172.22.0.1:41569",
+					"172.23.0.1:41569",
+					"172.24.0.1:41569",
+					"172.25.0.1:41569",
+					"172.26.0.1:41569",
+					"172.27.0.1:41569",
+					"172.28.0.1:41569"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:17:33.553972143Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7609651075458153,
+				"StableID":   "nUWiWYdRR221CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a35f5c2db011b7f7550698c55688b6dbede87f56db3a18ae4e5d9f7089a8306b",
+				"KeyExpiry":  "2026-11-09T09:17:34Z",
+				"DiscoKey":   "discokey:f591d8af27668c045e2f33927567688e9915163ffc5a769e83ca1ba65ff5e164",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49541",
+					"10.65.0.27:49541",
+					"172.17.0.1:49541",
+					"172.18.0.1:49541",
+					"172.19.0.1:49541",
+					"172.20.0.1:49541",
+					"172.21.0.1:49541",
+					"172.22.0.1:49541",
+					"172.23.0.1:49541",
+					"172.24.0.1:49541",
+					"172.25.0.1:49541",
+					"172.26.0.1:49541",
+					"172.27.0.1:49541",
+					"172.28.0.1:49541"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:17:34.094327635Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6959374370599248,
+				"StableID":   "nw8astxuLw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5fcc8d855420dbf95e34ac09a3439f2879a30d55cb4c8c93354b03e94610df01",
+				"KeyExpiry":  "2026-11-09T09:17:34Z",
+				"DiscoKey":   "discokey:38ceb917783142ef6a89f7a6fc8d3acae022852743b459a2fba28a2c9e85360c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51108",
+					"10.65.0.27:51108",
+					"172.17.0.1:51108",
+					"172.18.0.1:51108",
+					"172.19.0.1:51108",
+					"172.20.0.1:51108",
+					"172.21.0.1:51108",
+					"172.22.0.1:51108",
+					"172.23.0.1:51108",
+					"172.24.0.1:51108",
+					"172.25.0.1:51108",
+					"172.26.0.1:51108",
+					"172.27.0.1:51108",
+					"172.28.0.1:51108"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:17:34.646533445Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3229698221397392,
+				"StableID":   "nV96FMhjDS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:69853df8125c47b11605630704f9718bd263073378e2c9ab06d92ffad055f440",
+				"KeyExpiry":  "2026-11-09T09:17:35Z",
+				"DiscoKey":   "discokey:d6fe8ea030f27c7f096ee187a0ce83d33110ad7217cae9fd3b6298191d58dc48",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39247",
+					"10.65.0.27:39247",
+					"172.17.0.1:39247",
+					"172.18.0.1:39247",
+					"172.19.0.1:39247",
+					"172.20.0.1:39247",
+					"172.21.0.1:39247",
+					"172.22.0.1:39247",
+					"172.23.0.1:39247",
+					"172.24.0.1:39247",
+					"172.25.0.1:39247",
+					"172.26.0.1:39247",
+					"172.27.0.1:39247",
+					"172.28.0.1:39247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:17:35.203500028Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6775939488263536": {
+				"ID":          6775939488263536,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-multi-rule-overlap-different-users.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-multi-rule-overlap-different-users.hujson
@@ -1,0 +1,22146 @@
+// ssh-multi-rule-overlap-different-users
+//
+// ssh two rules same src/dst, users differ
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-13T09:18:20Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-multi-rule-overlap-different-users",
+	"description":    "ssh two rules same src/dst, users differ",
+	"category":       "ssh",
+	"captured_at":    "2026-05-13T09:18:20.4515237Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                         \n  \n                                                                       \n                                                                       \n                               \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh two rules same src/dst, users differ\",\n\t\"id\":          \"ssh-multi-rule-overlap-different-users\",\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"thor@example.org\"],\n\t\t\"users\":  [\"root\"]\n\t}, {\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"thor@example.org\"],\n\t\t\"users\":  [\"ubuntu\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-edges/ssh-multi-rule-overlap-different-users.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["thor@example.org"],
+				"users":  ["root"]
+			}, {
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["thor@example.org"],
+				"users":  ["ubuntu"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7610624439162705,
+				"StableID":   "naP8LXCsR221CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       7610624439162705,
+				"Key":        "nodekey:64323e2acab6388073367f6bf33ca27be3b617808e77f282172e1cfb7288e408",
+				"DiscoKey":   "discokey:8265adf738a508dd79d5594c9051086e367f735e364a9b0f8b07444ab4837a23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47593",
+					"10.65.0.27:47593",
+					"172.17.0.1:47593",
+					"172.18.0.1:47593",
+					"172.19.0.1:47593",
+					"172.20.0.1:47593",
+					"172.21.0.1:47593",
+					"172.22.0.1:47593",
+					"172.23.0.1:47593",
+					"172.24.0.1:47593",
+					"172.25.0.1:47593",
+					"172.26.0.1:47593",
+					"172.27.0.1:47593",
+					"172.28.0.1:47593"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:18:28.975436501Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:64323e2acab6388073367f6bf33ca27be3b617808e77f282172e1cfb7288e408",
+			"MachineKey": "mkey:c75b7929f814be71e815a5e894118ffc14c2a2f0629966a0428abc7411f5a14c",
+			"Peers": [{
+				"ID":         3629659383597747,
+				"StableID":   "nAgYYqzsLV11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:826a2f590555f412bea08e52ef573e5eaeefc23475cda5dbc0dc33407fd51368",
+				"DiscoKey":   "discokey:cfe29272e4f8d6d52e1d6cc80a109cb33332104b72b6be4d16173959c58e2d3a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:42911",
+					"10.65.0.27:42911",
+					"172.17.0.1:42911",
+					"172.18.0.1:42911",
+					"172.19.0.1:42911",
+					"172.20.0.1:42911",
+					"172.21.0.1:42911",
+					"172.22.0.1:42911",
+					"172.23.0.1:42911",
+					"172.24.0.1:42911",
+					"172.25.0.1:42911",
+					"172.26.0.1:42911",
+					"172.27.0.1:42911",
+					"172.28.0.1:42911"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:18:23.064882594Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7634452867421641,
+				"StableID":   "nEoRwb8fc221CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd433ce90513732d1a814e056979c959e7c0572fc7f523b5356b9086dda90e6f",
+				"DiscoKey":   "discokey:9f5e41c049b90f62e8c2b7ff30aaba7da14aa336b3f6ca79037752c5e9600874",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43181",
+					"10.65.0.27:43181",
+					"172.17.0.1:43181",
+					"172.18.0.1:43181",
+					"172.19.0.1:43181",
+					"172.20.0.1:43181",
+					"172.21.0.1:43181",
+					"172.22.0.1:43181",
+					"172.23.0.1:43181",
+					"172.24.0.1:43181",
+					"172.25.0.1:43181",
+					"172.26.0.1:43181",
+					"172.27.0.1:43181",
+					"172.28.0.1:43181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:18:23.610236176Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6288708298322901,
+				"StableID":   "nJTsenhA7r11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9574ee86e49d545297709b7d3733d6f96ffe4563e75e41597f917221548c6d09",
+				"DiscoKey":   "discokey:683bd93e93958206447f011fbe123ec261a83ffaf6a3a058f9867fbe9af1ec40",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43316",
+					"10.65.0.27:43316",
+					"172.17.0.1:43316",
+					"172.18.0.1:43316",
+					"172.19.0.1:43316",
+					"172.20.0.1:43316",
+					"172.21.0.1:43316",
+					"172.22.0.1:43316",
+					"172.23.0.1:43316",
+					"172.24.0.1:43316",
+					"172.25.0.1:43316",
+					"172.26.0.1:43316",
+					"172.27.0.1:43316",
+					"172.28.0.1:43316"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:18:24.144090057Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3872101206780,
+				"StableID":   "n9ooKPik2111CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc1c67bf3c3b82002d30abb24af84188710e1bec537d3d8aec1167ccbc474040",
+				"DiscoKey":   "discokey:95e97236e791c770a6fcb06b316c5dcc721ebad3ecd8a393c534f8b5f4082b71",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:52545",
+					"10.65.0.27:52545",
+					"172.17.0.1:52545",
+					"172.18.0.1:52545",
+					"172.19.0.1:52545",
+					"172.20.0.1:52545",
+					"172.21.0.1:52545",
+					"172.22.0.1:52545",
+					"172.23.0.1:52545",
+					"172.24.0.1:52545",
+					"172.25.0.1:52545",
+					"172.26.0.1:52545",
+					"172.27.0.1:52545",
+					"172.28.0.1:52545"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:18:24.679562462Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1351878608113606,
+				"StableID":   "nhksJQZGZB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:632860ce4649a5e7ec6dfb212db5bde87642e475954c87968565670b7e9b6431",
+				"DiscoKey":   "discokey:2e99bf667d271a84d45861465ca6e7ca59f31c555bbd9ae399d13a068b116540",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33481",
+					"10.65.0.27:33481",
+					"172.17.0.1:33481",
+					"172.18.0.1:33481",
+					"172.19.0.1:33481",
+					"172.20.0.1:33481",
+					"172.21.0.1:33481",
+					"172.22.0.1:33481",
+					"172.23.0.1:33481",
+					"172.24.0.1:33481",
+					"172.25.0.1:33481",
+					"172.26.0.1:33481",
+					"172.27.0.1:33481",
+					"172.28.0.1:33481"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:18:25.212870114Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4710579020748619,
+				"StableID":   "neziSYvRnd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6b4e8a634a3026b7bafafb5b30550a77da67edf0fb28baf9dd323b117fc27165",
+				"DiscoKey":   "discokey:bb9dd4a17807d1c1156537152e599056f06445fa54da389634a48a572404685c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42046",
+					"10.65.0.27:42046",
+					"172.17.0.1:42046",
+					"172.18.0.1:42046",
+					"172.19.0.1:42046",
+					"172.20.0.1:42046",
+					"172.21.0.1:42046",
+					"172.22.0.1:42046",
+					"172.23.0.1:42046",
+					"172.24.0.1:42046",
+					"172.25.0.1:42046",
+					"172.26.0.1:42046",
+					"172.27.0.1:42046",
+					"172.28.0.1:42046"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:18:25.753413192Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3703453112569412,
+				"StableID":   "nR3Mg8SJvV11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:00b270a28bef133635425b307228ec0749d00c11255722cc06b9f05abfbe2372",
+				"DiscoKey":   "discokey:643a35b7d9b7d07b748d1b9eddcb6223dee33adfbb95815ea9441e5169d91919",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49879",
+					"10.65.0.27:49879",
+					"172.17.0.1:49879",
+					"172.18.0.1:49879",
+					"172.19.0.1:49879",
+					"172.20.0.1:49879",
+					"172.21.0.1:49879",
+					"172.22.0.1:49879",
+					"172.23.0.1:49879",
+					"172.24.0.1:49879",
+					"172.25.0.1:49879",
+					"172.26.0.1:49879",
+					"172.27.0.1:49879",
+					"172.28.0.1:49879"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:18:26.305678811Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7146136476813947,
+				"StableID":   "nUhMfUtVox11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31c027a88808fbf2e12d20d7339e211908e878abb9f0ed2803e224cca5f17210",
+				"DiscoKey":   "discokey:14492165aef132522938760516d62795a37b46e4b96c98d79d98a04f9d6ff63e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:41689",
+					"10.65.0.27:41689",
+					"172.17.0.1:41689",
+					"172.18.0.1:41689",
+					"172.19.0.1:41689",
+					"172.20.0.1:41689",
+					"172.21.0.1:41689",
+					"172.22.0.1:41689",
+					"172.23.0.1:41689",
+					"172.24.0.1:41689",
+					"172.25.0.1:41689",
+					"172.26.0.1:41689",
+					"172.27.0.1:41689",
+					"172.28.0.1:41689"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:18:26.835487556Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5234182443223358,
+				"StableID":   "nMSjtd6ash11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e9ff37a5bf38f75dbd43a6a05b912542422ecc99a63934300725175b0b556018",
+				"DiscoKey":   "discokey:25b2098902097e8778340a0aea5e195476acc246f89e022f4bb7ca2d6299da49",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38639",
+					"10.65.0.27:38639",
+					"172.17.0.1:38639",
+					"172.18.0.1:38639",
+					"172.19.0.1:38639",
+					"172.20.0.1:38639",
+					"172.21.0.1:38639",
+					"172.22.0.1:38639",
+					"172.23.0.1:38639",
+					"172.24.0.1:38639",
+					"172.25.0.1:38639",
+					"172.26.0.1:38639",
+					"172.27.0.1:38639",
+					"172.28.0.1:38639"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:18:27.413681071Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4277455258369164,
+				"StableID":   "nor2jnVGQa11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3c36636ee28c97a9c6353ec32ec246767d10813a18f68a3bf84df208e5c37263",
+				"DiscoKey":   "discokey:8c04276a99d1cff78d424cc57e20d789b9585852b73bd8e6f18bfc345597622f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40861",
+					"10.65.0.27:40861",
+					"172.17.0.1:40861",
+					"172.18.0.1:40861",
+					"172.19.0.1:40861",
+					"172.20.0.1:40861",
+					"172.21.0.1:40861",
+					"172.22.0.1:40861",
+					"172.23.0.1:40861",
+					"172.24.0.1:40861",
+					"172.25.0.1:40861",
+					"172.26.0.1:40861",
+					"172.27.0.1:40861",
+					"172.28.0.1:40861"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:18:27.90103441Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6210021292995392,
+				"StableID":   "nbghSHjXVq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87128166c893a60ba96b44e59f7fd0d1d139db8efc029d37ad753bc27d01d658",
+				"DiscoKey":   "discokey:e560631cb9b92a8cc999d49c9967f0ef9c0d0207804f37040c24a90cb5566759",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40401",
+					"10.65.0.27:40401",
+					"172.17.0.1:40401",
+					"172.18.0.1:40401",
+					"172.19.0.1:40401",
+					"172.20.0.1:40401",
+					"172.21.0.1:40401",
+					"172.22.0.1:40401",
+					"172.23.0.1:40401",
+					"172.24.0.1:40401",
+					"172.25.0.1:40401",
+					"172.26.0.1:40401",
+					"172.27.0.1:40401",
+					"172.28.0.1:40401"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:18:28.446165874Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         171923215953612,
+				"StableID":   "nZ7Vsc8sL211CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5613b48ea96ace9530f814555295e862a446e2369dd1ad56d065dbe8683d892e",
+				"KeyExpiry":  "2026-11-09T09:18:29Z",
+				"DiscoKey":   "discokey:0a359bd65f92d91db2039f94d50db21d0674d16f2743adfba2cf07a5b9534135",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46507",
+					"10.65.0.27:46507",
+					"172.17.0.1:46507",
+					"172.18.0.1:46507",
+					"172.19.0.1:46507",
+					"172.20.0.1:46507",
+					"172.21.0.1:46507",
+					"172.22.0.1:46507",
+					"172.23.0.1:46507",
+					"172.24.0.1:46507",
+					"172.25.0.1:46507",
+					"172.26.0.1:46507",
+					"172.27.0.1:46507",
+					"172.28.0.1:46507"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:18:29.572595367Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4589858193929405,
+				"StableID":   "n86GNvnkqc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:30a2d8497c37a412110d6334b2c9b1ade3a01014f3a04f2b29f1c0781be82d55",
+				"KeyExpiry":  "2026-11-09T09:18:30Z",
+				"DiscoKey":   "discokey:50ffe6a2296a06d0562488d3c1ae7754c33b641f77058c0d48b6f0e1538a0269",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58735",
+					"10.65.0.27:58735",
+					"172.17.0.1:58735",
+					"172.18.0.1:58735",
+					"172.19.0.1:58735",
+					"172.20.0.1:58735",
+					"172.21.0.1:58735",
+					"172.22.0.1:58735",
+					"172.23.0.1:58735",
+					"172.24.0.1:58735",
+					"172.25.0.1:58735",
+					"172.26.0.1:58735",
+					"172.27.0.1:58735",
+					"172.28.0.1:58735"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:18:30.059549244Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         910391420385261,
+				"StableID":   "ntkALTSK7811CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:31746f4776a57d2bbb43ca359e7d10d9f27a8e0496061bbc6de32e449e13867b",
+				"KeyExpiry":  "2026-11-09T09:18:30Z",
+				"DiscoKey":   "discokey:3ce571dfd38f447fbe40480090cfa44d4bbbffa28743b767d7d0c197de23a65a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49501",
+					"10.65.0.27:49501",
+					"172.17.0.1:49501",
+					"172.18.0.1:49501",
+					"172.19.0.1:49501",
+					"172.20.0.1:49501",
+					"172.21.0.1:49501",
+					"172.22.0.1:49501",
+					"172.23.0.1:49501",
+					"172.24.0.1:49501",
+					"172.25.0.1:49501",
+					"172.26.0.1:49501",
+					"172.27.0.1:49501",
+					"172.28.0.1:49501"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:18:30.586131649Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{
+				"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+				"sshUsers":   {"root": "root"},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				}
+			}, {
+				"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+				"sshUsers":   {"root": "", "ubuntu": "ubuntu"},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				}
+			}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7610624439162705": {
+				"ID":          7610624439162705,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		},
+		"ssh_rules": [{
+			"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+			"sshUsers":   {"root": "root"},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}
+		}, {
+			"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+			"sshUsers":   {"root": "", "ubuntu": "ubuntu"},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}
+		}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4710579020748619,
+				"StableID":   "neziSYvRnd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       4710579020748619,
+				"Key":        "nodekey:6b4e8a634a3026b7bafafb5b30550a77da67edf0fb28baf9dd323b117fc27165",
+				"DiscoKey":   "discokey:bb9dd4a17807d1c1156537152e599056f06445fa54da389634a48a572404685c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42046",
+					"10.65.0.27:42046",
+					"172.17.0.1:42046",
+					"172.18.0.1:42046",
+					"172.19.0.1:42046",
+					"172.20.0.1:42046",
+					"172.21.0.1:42046",
+					"172.22.0.1:42046",
+					"172.23.0.1:42046",
+					"172.24.0.1:42046",
+					"172.25.0.1:42046",
+					"172.26.0.1:42046",
+					"172.27.0.1:42046",
+					"172.28.0.1:42046"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:18:25.753413192Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6b4e8a634a3026b7bafafb5b30550a77da67edf0fb28baf9dd323b117fc27165",
+			"MachineKey": "mkey:0165c7dec4445fffaeda701a16eeec526e5108f114fa45b154eea6c190b71523",
+			"Peers": [{
+				"ID":         3629659383597747,
+				"StableID":   "nAgYYqzsLV11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:826a2f590555f412bea08e52ef573e5eaeefc23475cda5dbc0dc33407fd51368",
+				"DiscoKey":   "discokey:cfe29272e4f8d6d52e1d6cc80a109cb33332104b72b6be4d16173959c58e2d3a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:42911",
+					"10.65.0.27:42911",
+					"172.17.0.1:42911",
+					"172.18.0.1:42911",
+					"172.19.0.1:42911",
+					"172.20.0.1:42911",
+					"172.21.0.1:42911",
+					"172.22.0.1:42911",
+					"172.23.0.1:42911",
+					"172.24.0.1:42911",
+					"172.25.0.1:42911",
+					"172.26.0.1:42911",
+					"172.27.0.1:42911",
+					"172.28.0.1:42911"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:18:23.064882594Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7634452867421641,
+				"StableID":   "nEoRwb8fc221CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd433ce90513732d1a814e056979c959e7c0572fc7f523b5356b9086dda90e6f",
+				"DiscoKey":   "discokey:9f5e41c049b90f62e8c2b7ff30aaba7da14aa336b3f6ca79037752c5e9600874",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43181",
+					"10.65.0.27:43181",
+					"172.17.0.1:43181",
+					"172.18.0.1:43181",
+					"172.19.0.1:43181",
+					"172.20.0.1:43181",
+					"172.21.0.1:43181",
+					"172.22.0.1:43181",
+					"172.23.0.1:43181",
+					"172.24.0.1:43181",
+					"172.25.0.1:43181",
+					"172.26.0.1:43181",
+					"172.27.0.1:43181",
+					"172.28.0.1:43181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:18:23.610236176Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6288708298322901,
+				"StableID":   "nJTsenhA7r11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9574ee86e49d545297709b7d3733d6f96ffe4563e75e41597f917221548c6d09",
+				"DiscoKey":   "discokey:683bd93e93958206447f011fbe123ec261a83ffaf6a3a058f9867fbe9af1ec40",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43316",
+					"10.65.0.27:43316",
+					"172.17.0.1:43316",
+					"172.18.0.1:43316",
+					"172.19.0.1:43316",
+					"172.20.0.1:43316",
+					"172.21.0.1:43316",
+					"172.22.0.1:43316",
+					"172.23.0.1:43316",
+					"172.24.0.1:43316",
+					"172.25.0.1:43316",
+					"172.26.0.1:43316",
+					"172.27.0.1:43316",
+					"172.28.0.1:43316"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:18:24.144090057Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3872101206780,
+				"StableID":   "n9ooKPik2111CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc1c67bf3c3b82002d30abb24af84188710e1bec537d3d8aec1167ccbc474040",
+				"DiscoKey":   "discokey:95e97236e791c770a6fcb06b316c5dcc721ebad3ecd8a393c534f8b5f4082b71",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:52545",
+					"10.65.0.27:52545",
+					"172.17.0.1:52545",
+					"172.18.0.1:52545",
+					"172.19.0.1:52545",
+					"172.20.0.1:52545",
+					"172.21.0.1:52545",
+					"172.22.0.1:52545",
+					"172.23.0.1:52545",
+					"172.24.0.1:52545",
+					"172.25.0.1:52545",
+					"172.26.0.1:52545",
+					"172.27.0.1:52545",
+					"172.28.0.1:52545"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:18:24.679562462Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1351878608113606,
+				"StableID":   "nhksJQZGZB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:632860ce4649a5e7ec6dfb212db5bde87642e475954c87968565670b7e9b6431",
+				"DiscoKey":   "discokey:2e99bf667d271a84d45861465ca6e7ca59f31c555bbd9ae399d13a068b116540",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33481",
+					"10.65.0.27:33481",
+					"172.17.0.1:33481",
+					"172.18.0.1:33481",
+					"172.19.0.1:33481",
+					"172.20.0.1:33481",
+					"172.21.0.1:33481",
+					"172.22.0.1:33481",
+					"172.23.0.1:33481",
+					"172.24.0.1:33481",
+					"172.25.0.1:33481",
+					"172.26.0.1:33481",
+					"172.27.0.1:33481",
+					"172.28.0.1:33481"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:18:25.212870114Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3703453112569412,
+				"StableID":   "nR3Mg8SJvV11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:00b270a28bef133635425b307228ec0749d00c11255722cc06b9f05abfbe2372",
+				"DiscoKey":   "discokey:643a35b7d9b7d07b748d1b9eddcb6223dee33adfbb95815ea9441e5169d91919",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49879",
+					"10.65.0.27:49879",
+					"172.17.0.1:49879",
+					"172.18.0.1:49879",
+					"172.19.0.1:49879",
+					"172.20.0.1:49879",
+					"172.21.0.1:49879",
+					"172.22.0.1:49879",
+					"172.23.0.1:49879",
+					"172.24.0.1:49879",
+					"172.25.0.1:49879",
+					"172.26.0.1:49879",
+					"172.27.0.1:49879",
+					"172.28.0.1:49879"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:18:26.305678811Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7146136476813947,
+				"StableID":   "nUhMfUtVox11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31c027a88808fbf2e12d20d7339e211908e878abb9f0ed2803e224cca5f17210",
+				"DiscoKey":   "discokey:14492165aef132522938760516d62795a37b46e4b96c98d79d98a04f9d6ff63e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:41689",
+					"10.65.0.27:41689",
+					"172.17.0.1:41689",
+					"172.18.0.1:41689",
+					"172.19.0.1:41689",
+					"172.20.0.1:41689",
+					"172.21.0.1:41689",
+					"172.22.0.1:41689",
+					"172.23.0.1:41689",
+					"172.24.0.1:41689",
+					"172.25.0.1:41689",
+					"172.26.0.1:41689",
+					"172.27.0.1:41689",
+					"172.28.0.1:41689"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:18:26.835487556Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5234182443223358,
+				"StableID":   "nMSjtd6ash11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e9ff37a5bf38f75dbd43a6a05b912542422ecc99a63934300725175b0b556018",
+				"DiscoKey":   "discokey:25b2098902097e8778340a0aea5e195476acc246f89e022f4bb7ca2d6299da49",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38639",
+					"10.65.0.27:38639",
+					"172.17.0.1:38639",
+					"172.18.0.1:38639",
+					"172.19.0.1:38639",
+					"172.20.0.1:38639",
+					"172.21.0.1:38639",
+					"172.22.0.1:38639",
+					"172.23.0.1:38639",
+					"172.24.0.1:38639",
+					"172.25.0.1:38639",
+					"172.26.0.1:38639",
+					"172.27.0.1:38639",
+					"172.28.0.1:38639"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:18:27.413681071Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4277455258369164,
+				"StableID":   "nor2jnVGQa11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3c36636ee28c97a9c6353ec32ec246767d10813a18f68a3bf84df208e5c37263",
+				"DiscoKey":   "discokey:8c04276a99d1cff78d424cc57e20d789b9585852b73bd8e6f18bfc345597622f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40861",
+					"10.65.0.27:40861",
+					"172.17.0.1:40861",
+					"172.18.0.1:40861",
+					"172.19.0.1:40861",
+					"172.20.0.1:40861",
+					"172.21.0.1:40861",
+					"172.22.0.1:40861",
+					"172.23.0.1:40861",
+					"172.24.0.1:40861",
+					"172.25.0.1:40861",
+					"172.26.0.1:40861",
+					"172.27.0.1:40861",
+					"172.28.0.1:40861"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:18:27.90103441Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6210021292995392,
+				"StableID":   "nbghSHjXVq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87128166c893a60ba96b44e59f7fd0d1d139db8efc029d37ad753bc27d01d658",
+				"DiscoKey":   "discokey:e560631cb9b92a8cc999d49c9967f0ef9c0d0207804f37040c24a90cb5566759",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40401",
+					"10.65.0.27:40401",
+					"172.17.0.1:40401",
+					"172.18.0.1:40401",
+					"172.19.0.1:40401",
+					"172.20.0.1:40401",
+					"172.21.0.1:40401",
+					"172.22.0.1:40401",
+					"172.23.0.1:40401",
+					"172.24.0.1:40401",
+					"172.25.0.1:40401",
+					"172.26.0.1:40401",
+					"172.27.0.1:40401",
+					"172.28.0.1:40401"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:18:28.446165874Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7610624439162705,
+				"StableID":   "naP8LXCsR221CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:64323e2acab6388073367f6bf33ca27be3b617808e77f282172e1cfb7288e408",
+				"DiscoKey":   "discokey:8265adf738a508dd79d5594c9051086e367f735e364a9b0f8b07444ab4837a23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47593",
+					"10.65.0.27:47593",
+					"172.17.0.1:47593",
+					"172.18.0.1:47593",
+					"172.19.0.1:47593",
+					"172.20.0.1:47593",
+					"172.21.0.1:47593",
+					"172.22.0.1:47593",
+					"172.23.0.1:47593",
+					"172.24.0.1:47593",
+					"172.25.0.1:47593",
+					"172.26.0.1:47593",
+					"172.27.0.1:47593",
+					"172.28.0.1:47593"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:18:28.975436501Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         171923215953612,
+				"StableID":   "nZ7Vsc8sL211CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5613b48ea96ace9530f814555295e862a446e2369dd1ad56d065dbe8683d892e",
+				"KeyExpiry":  "2026-11-09T09:18:29Z",
+				"DiscoKey":   "discokey:0a359bd65f92d91db2039f94d50db21d0674d16f2743adfba2cf07a5b9534135",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46507",
+					"10.65.0.27:46507",
+					"172.17.0.1:46507",
+					"172.18.0.1:46507",
+					"172.19.0.1:46507",
+					"172.20.0.1:46507",
+					"172.21.0.1:46507",
+					"172.22.0.1:46507",
+					"172.23.0.1:46507",
+					"172.24.0.1:46507",
+					"172.25.0.1:46507",
+					"172.26.0.1:46507",
+					"172.27.0.1:46507",
+					"172.28.0.1:46507"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:18:29.572595367Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4589858193929405,
+				"StableID":   "n86GNvnkqc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:30a2d8497c37a412110d6334b2c9b1ade3a01014f3a04f2b29f1c0781be82d55",
+				"KeyExpiry":  "2026-11-09T09:18:30Z",
+				"DiscoKey":   "discokey:50ffe6a2296a06d0562488d3c1ae7754c33b641f77058c0d48b6f0e1538a0269",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58735",
+					"10.65.0.27:58735",
+					"172.17.0.1:58735",
+					"172.18.0.1:58735",
+					"172.19.0.1:58735",
+					"172.20.0.1:58735",
+					"172.21.0.1:58735",
+					"172.22.0.1:58735",
+					"172.23.0.1:58735",
+					"172.24.0.1:58735",
+					"172.25.0.1:58735",
+					"172.26.0.1:58735",
+					"172.27.0.1:58735",
+					"172.28.0.1:58735"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:18:30.059549244Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         910391420385261,
+				"StableID":   "ntkALTSK7811CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:31746f4776a57d2bbb43ca359e7d10d9f27a8e0496061bbc6de32e449e13867b",
+				"KeyExpiry":  "2026-11-09T09:18:30Z",
+				"DiscoKey":   "discokey:3ce571dfd38f447fbe40480090cfa44d4bbbffa28743b767d7d0c197de23a65a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49501",
+					"10.65.0.27:49501",
+					"172.17.0.1:49501",
+					"172.18.0.1:49501",
+					"172.19.0.1:49501",
+					"172.20.0.1:49501",
+					"172.21.0.1:49501",
+					"172.22.0.1:49501",
+					"172.23.0.1:49501",
+					"172.24.0.1:49501",
+					"172.25.0.1:49501",
+					"172.26.0.1:49501",
+					"172.27.0.1:49501",
+					"172.28.0.1:49501"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:18:30.586131649Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4710579020748619": {
+				"ID":          4710579020748619,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         910391420385261,
+				"StableID":   "ntkALTSK7811CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:31746f4776a57d2bbb43ca359e7d10d9f27a8e0496061bbc6de32e449e13867b",
+				"KeyExpiry":  "2026-11-09T09:18:30Z",
+				"DiscoKey":   "discokey:3ce571dfd38f447fbe40480090cfa44d4bbbffa28743b767d7d0c197de23a65a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49501",
+					"10.65.0.27:49501",
+					"172.17.0.1:49501",
+					"172.18.0.1:49501",
+					"172.19.0.1:49501",
+					"172.20.0.1:49501",
+					"172.21.0.1:49501",
+					"172.22.0.1:49501",
+					"172.23.0.1:49501",
+					"172.24.0.1:49501",
+					"172.25.0.1:49501",
+					"172.26.0.1:49501",
+					"172.27.0.1:49501",
+					"172.28.0.1:49501"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:18:30.586131649Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:31746f4776a57d2bbb43ca359e7d10d9f27a8e0496061bbc6de32e449e13867b",
+			"MachineKey": "mkey:3541d1d70824ed2ee77cd74f4037f62497cc7e119a3fd3f94d4b5f1f7df0e63d",
+			"Peers": [{
+				"ID":         3629659383597747,
+				"StableID":   "nAgYYqzsLV11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:826a2f590555f412bea08e52ef573e5eaeefc23475cda5dbc0dc33407fd51368",
+				"DiscoKey":   "discokey:cfe29272e4f8d6d52e1d6cc80a109cb33332104b72b6be4d16173959c58e2d3a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:42911",
+					"10.65.0.27:42911",
+					"172.17.0.1:42911",
+					"172.18.0.1:42911",
+					"172.19.0.1:42911",
+					"172.20.0.1:42911",
+					"172.21.0.1:42911",
+					"172.22.0.1:42911",
+					"172.23.0.1:42911",
+					"172.24.0.1:42911",
+					"172.25.0.1:42911",
+					"172.26.0.1:42911",
+					"172.27.0.1:42911",
+					"172.28.0.1:42911"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:18:23.064882594Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7634452867421641,
+				"StableID":   "nEoRwb8fc221CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd433ce90513732d1a814e056979c959e7c0572fc7f523b5356b9086dda90e6f",
+				"DiscoKey":   "discokey:9f5e41c049b90f62e8c2b7ff30aaba7da14aa336b3f6ca79037752c5e9600874",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43181",
+					"10.65.0.27:43181",
+					"172.17.0.1:43181",
+					"172.18.0.1:43181",
+					"172.19.0.1:43181",
+					"172.20.0.1:43181",
+					"172.21.0.1:43181",
+					"172.22.0.1:43181",
+					"172.23.0.1:43181",
+					"172.24.0.1:43181",
+					"172.25.0.1:43181",
+					"172.26.0.1:43181",
+					"172.27.0.1:43181",
+					"172.28.0.1:43181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:18:23.610236176Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6288708298322901,
+				"StableID":   "nJTsenhA7r11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9574ee86e49d545297709b7d3733d6f96ffe4563e75e41597f917221548c6d09",
+				"DiscoKey":   "discokey:683bd93e93958206447f011fbe123ec261a83ffaf6a3a058f9867fbe9af1ec40",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43316",
+					"10.65.0.27:43316",
+					"172.17.0.1:43316",
+					"172.18.0.1:43316",
+					"172.19.0.1:43316",
+					"172.20.0.1:43316",
+					"172.21.0.1:43316",
+					"172.22.0.1:43316",
+					"172.23.0.1:43316",
+					"172.24.0.1:43316",
+					"172.25.0.1:43316",
+					"172.26.0.1:43316",
+					"172.27.0.1:43316",
+					"172.28.0.1:43316"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:18:24.144090057Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3872101206780,
+				"StableID":   "n9ooKPik2111CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc1c67bf3c3b82002d30abb24af84188710e1bec537d3d8aec1167ccbc474040",
+				"DiscoKey":   "discokey:95e97236e791c770a6fcb06b316c5dcc721ebad3ecd8a393c534f8b5f4082b71",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:52545",
+					"10.65.0.27:52545",
+					"172.17.0.1:52545",
+					"172.18.0.1:52545",
+					"172.19.0.1:52545",
+					"172.20.0.1:52545",
+					"172.21.0.1:52545",
+					"172.22.0.1:52545",
+					"172.23.0.1:52545",
+					"172.24.0.1:52545",
+					"172.25.0.1:52545",
+					"172.26.0.1:52545",
+					"172.27.0.1:52545",
+					"172.28.0.1:52545"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:18:24.679562462Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1351878608113606,
+				"StableID":   "nhksJQZGZB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:632860ce4649a5e7ec6dfb212db5bde87642e475954c87968565670b7e9b6431",
+				"DiscoKey":   "discokey:2e99bf667d271a84d45861465ca6e7ca59f31c555bbd9ae399d13a068b116540",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33481",
+					"10.65.0.27:33481",
+					"172.17.0.1:33481",
+					"172.18.0.1:33481",
+					"172.19.0.1:33481",
+					"172.20.0.1:33481",
+					"172.21.0.1:33481",
+					"172.22.0.1:33481",
+					"172.23.0.1:33481",
+					"172.24.0.1:33481",
+					"172.25.0.1:33481",
+					"172.26.0.1:33481",
+					"172.27.0.1:33481",
+					"172.28.0.1:33481"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:18:25.212870114Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4710579020748619,
+				"StableID":   "neziSYvRnd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6b4e8a634a3026b7bafafb5b30550a77da67edf0fb28baf9dd323b117fc27165",
+				"DiscoKey":   "discokey:bb9dd4a17807d1c1156537152e599056f06445fa54da389634a48a572404685c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42046",
+					"10.65.0.27:42046",
+					"172.17.0.1:42046",
+					"172.18.0.1:42046",
+					"172.19.0.1:42046",
+					"172.20.0.1:42046",
+					"172.21.0.1:42046",
+					"172.22.0.1:42046",
+					"172.23.0.1:42046",
+					"172.24.0.1:42046",
+					"172.25.0.1:42046",
+					"172.26.0.1:42046",
+					"172.27.0.1:42046",
+					"172.28.0.1:42046"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:18:25.753413192Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3703453112569412,
+				"StableID":   "nR3Mg8SJvV11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:00b270a28bef133635425b307228ec0749d00c11255722cc06b9f05abfbe2372",
+				"DiscoKey":   "discokey:643a35b7d9b7d07b748d1b9eddcb6223dee33adfbb95815ea9441e5169d91919",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49879",
+					"10.65.0.27:49879",
+					"172.17.0.1:49879",
+					"172.18.0.1:49879",
+					"172.19.0.1:49879",
+					"172.20.0.1:49879",
+					"172.21.0.1:49879",
+					"172.22.0.1:49879",
+					"172.23.0.1:49879",
+					"172.24.0.1:49879",
+					"172.25.0.1:49879",
+					"172.26.0.1:49879",
+					"172.27.0.1:49879",
+					"172.28.0.1:49879"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:18:26.305678811Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7146136476813947,
+				"StableID":   "nUhMfUtVox11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31c027a88808fbf2e12d20d7339e211908e878abb9f0ed2803e224cca5f17210",
+				"DiscoKey":   "discokey:14492165aef132522938760516d62795a37b46e4b96c98d79d98a04f9d6ff63e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:41689",
+					"10.65.0.27:41689",
+					"172.17.0.1:41689",
+					"172.18.0.1:41689",
+					"172.19.0.1:41689",
+					"172.20.0.1:41689",
+					"172.21.0.1:41689",
+					"172.22.0.1:41689",
+					"172.23.0.1:41689",
+					"172.24.0.1:41689",
+					"172.25.0.1:41689",
+					"172.26.0.1:41689",
+					"172.27.0.1:41689",
+					"172.28.0.1:41689"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:18:26.835487556Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5234182443223358,
+				"StableID":   "nMSjtd6ash11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e9ff37a5bf38f75dbd43a6a05b912542422ecc99a63934300725175b0b556018",
+				"DiscoKey":   "discokey:25b2098902097e8778340a0aea5e195476acc246f89e022f4bb7ca2d6299da49",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38639",
+					"10.65.0.27:38639",
+					"172.17.0.1:38639",
+					"172.18.0.1:38639",
+					"172.19.0.1:38639",
+					"172.20.0.1:38639",
+					"172.21.0.1:38639",
+					"172.22.0.1:38639",
+					"172.23.0.1:38639",
+					"172.24.0.1:38639",
+					"172.25.0.1:38639",
+					"172.26.0.1:38639",
+					"172.27.0.1:38639",
+					"172.28.0.1:38639"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:18:27.413681071Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4277455258369164,
+				"StableID":   "nor2jnVGQa11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3c36636ee28c97a9c6353ec32ec246767d10813a18f68a3bf84df208e5c37263",
+				"DiscoKey":   "discokey:8c04276a99d1cff78d424cc57e20d789b9585852b73bd8e6f18bfc345597622f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40861",
+					"10.65.0.27:40861",
+					"172.17.0.1:40861",
+					"172.18.0.1:40861",
+					"172.19.0.1:40861",
+					"172.20.0.1:40861",
+					"172.21.0.1:40861",
+					"172.22.0.1:40861",
+					"172.23.0.1:40861",
+					"172.24.0.1:40861",
+					"172.25.0.1:40861",
+					"172.26.0.1:40861",
+					"172.27.0.1:40861",
+					"172.28.0.1:40861"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:18:27.90103441Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6210021292995392,
+				"StableID":   "nbghSHjXVq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87128166c893a60ba96b44e59f7fd0d1d139db8efc029d37ad753bc27d01d658",
+				"DiscoKey":   "discokey:e560631cb9b92a8cc999d49c9967f0ef9c0d0207804f37040c24a90cb5566759",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40401",
+					"10.65.0.27:40401",
+					"172.17.0.1:40401",
+					"172.18.0.1:40401",
+					"172.19.0.1:40401",
+					"172.20.0.1:40401",
+					"172.21.0.1:40401",
+					"172.22.0.1:40401",
+					"172.23.0.1:40401",
+					"172.24.0.1:40401",
+					"172.25.0.1:40401",
+					"172.26.0.1:40401",
+					"172.27.0.1:40401",
+					"172.28.0.1:40401"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:18:28.446165874Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7610624439162705,
+				"StableID":   "naP8LXCsR221CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:64323e2acab6388073367f6bf33ca27be3b617808e77f282172e1cfb7288e408",
+				"DiscoKey":   "discokey:8265adf738a508dd79d5594c9051086e367f735e364a9b0f8b07444ab4837a23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47593",
+					"10.65.0.27:47593",
+					"172.17.0.1:47593",
+					"172.18.0.1:47593",
+					"172.19.0.1:47593",
+					"172.20.0.1:47593",
+					"172.21.0.1:47593",
+					"172.22.0.1:47593",
+					"172.23.0.1:47593",
+					"172.24.0.1:47593",
+					"172.25.0.1:47593",
+					"172.26.0.1:47593",
+					"172.27.0.1:47593",
+					"172.28.0.1:47593"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:18:28.975436501Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         171923215953612,
+				"StableID":   "nZ7Vsc8sL211CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5613b48ea96ace9530f814555295e862a446e2369dd1ad56d065dbe8683d892e",
+				"KeyExpiry":  "2026-11-09T09:18:29Z",
+				"DiscoKey":   "discokey:0a359bd65f92d91db2039f94d50db21d0674d16f2743adfba2cf07a5b9534135",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46507",
+					"10.65.0.27:46507",
+					"172.17.0.1:46507",
+					"172.18.0.1:46507",
+					"172.19.0.1:46507",
+					"172.20.0.1:46507",
+					"172.21.0.1:46507",
+					"172.22.0.1:46507",
+					"172.23.0.1:46507",
+					"172.24.0.1:46507",
+					"172.25.0.1:46507",
+					"172.26.0.1:46507",
+					"172.27.0.1:46507",
+					"172.28.0.1:46507"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:18:29.572595367Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4589858193929405,
+				"StableID":   "n86GNvnkqc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:30a2d8497c37a412110d6334b2c9b1ade3a01014f3a04f2b29f1c0781be82d55",
+				"KeyExpiry":  "2026-11-09T09:18:30Z",
+				"DiscoKey":   "discokey:50ffe6a2296a06d0562488d3c1ae7754c33b641f77058c0d48b6f0e1538a0269",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58735",
+					"10.65.0.27:58735",
+					"172.17.0.1:58735",
+					"172.18.0.1:58735",
+					"172.19.0.1:58735",
+					"172.20.0.1:58735",
+					"172.21.0.1:58735",
+					"172.22.0.1:58735",
+					"172.23.0.1:58735",
+					"172.24.0.1:58735",
+					"172.25.0.1:58735",
+					"172.26.0.1:58735",
+					"172.27.0.1:58735",
+					"172.28.0.1:58735"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:18:30.059549244Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6288708298322901,
+				"StableID":   "nJTsenhA7r11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       6288708298322901,
+				"Key":        "nodekey:9574ee86e49d545297709b7d3733d6f96ffe4563e75e41597f917221548c6d09",
+				"DiscoKey":   "discokey:683bd93e93958206447f011fbe123ec261a83ffaf6a3a058f9867fbe9af1ec40",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43316",
+					"10.65.0.27:43316",
+					"172.17.0.1:43316",
+					"172.18.0.1:43316",
+					"172.19.0.1:43316",
+					"172.20.0.1:43316",
+					"172.21.0.1:43316",
+					"172.22.0.1:43316",
+					"172.23.0.1:43316",
+					"172.24.0.1:43316",
+					"172.25.0.1:43316",
+					"172.26.0.1:43316",
+					"172.27.0.1:43316",
+					"172.28.0.1:43316"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:18:24.144090057Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9574ee86e49d545297709b7d3733d6f96ffe4563e75e41597f917221548c6d09",
+			"MachineKey": "mkey:4cc25823b0e865b97d604edefe71353fad60040268d0e53e27e914de86139606",
+			"Peers": [{
+				"ID":         3629659383597747,
+				"StableID":   "nAgYYqzsLV11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:826a2f590555f412bea08e52ef573e5eaeefc23475cda5dbc0dc33407fd51368",
+				"DiscoKey":   "discokey:cfe29272e4f8d6d52e1d6cc80a109cb33332104b72b6be4d16173959c58e2d3a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:42911",
+					"10.65.0.27:42911",
+					"172.17.0.1:42911",
+					"172.18.0.1:42911",
+					"172.19.0.1:42911",
+					"172.20.0.1:42911",
+					"172.21.0.1:42911",
+					"172.22.0.1:42911",
+					"172.23.0.1:42911",
+					"172.24.0.1:42911",
+					"172.25.0.1:42911",
+					"172.26.0.1:42911",
+					"172.27.0.1:42911",
+					"172.28.0.1:42911"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:18:23.064882594Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7634452867421641,
+				"StableID":   "nEoRwb8fc221CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd433ce90513732d1a814e056979c959e7c0572fc7f523b5356b9086dda90e6f",
+				"DiscoKey":   "discokey:9f5e41c049b90f62e8c2b7ff30aaba7da14aa336b3f6ca79037752c5e9600874",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43181",
+					"10.65.0.27:43181",
+					"172.17.0.1:43181",
+					"172.18.0.1:43181",
+					"172.19.0.1:43181",
+					"172.20.0.1:43181",
+					"172.21.0.1:43181",
+					"172.22.0.1:43181",
+					"172.23.0.1:43181",
+					"172.24.0.1:43181",
+					"172.25.0.1:43181",
+					"172.26.0.1:43181",
+					"172.27.0.1:43181",
+					"172.28.0.1:43181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:18:23.610236176Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3872101206780,
+				"StableID":   "n9ooKPik2111CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc1c67bf3c3b82002d30abb24af84188710e1bec537d3d8aec1167ccbc474040",
+				"DiscoKey":   "discokey:95e97236e791c770a6fcb06b316c5dcc721ebad3ecd8a393c534f8b5f4082b71",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:52545",
+					"10.65.0.27:52545",
+					"172.17.0.1:52545",
+					"172.18.0.1:52545",
+					"172.19.0.1:52545",
+					"172.20.0.1:52545",
+					"172.21.0.1:52545",
+					"172.22.0.1:52545",
+					"172.23.0.1:52545",
+					"172.24.0.1:52545",
+					"172.25.0.1:52545",
+					"172.26.0.1:52545",
+					"172.27.0.1:52545",
+					"172.28.0.1:52545"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:18:24.679562462Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1351878608113606,
+				"StableID":   "nhksJQZGZB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:632860ce4649a5e7ec6dfb212db5bde87642e475954c87968565670b7e9b6431",
+				"DiscoKey":   "discokey:2e99bf667d271a84d45861465ca6e7ca59f31c555bbd9ae399d13a068b116540",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33481",
+					"10.65.0.27:33481",
+					"172.17.0.1:33481",
+					"172.18.0.1:33481",
+					"172.19.0.1:33481",
+					"172.20.0.1:33481",
+					"172.21.0.1:33481",
+					"172.22.0.1:33481",
+					"172.23.0.1:33481",
+					"172.24.0.1:33481",
+					"172.25.0.1:33481",
+					"172.26.0.1:33481",
+					"172.27.0.1:33481",
+					"172.28.0.1:33481"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:18:25.212870114Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4710579020748619,
+				"StableID":   "neziSYvRnd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6b4e8a634a3026b7bafafb5b30550a77da67edf0fb28baf9dd323b117fc27165",
+				"DiscoKey":   "discokey:bb9dd4a17807d1c1156537152e599056f06445fa54da389634a48a572404685c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42046",
+					"10.65.0.27:42046",
+					"172.17.0.1:42046",
+					"172.18.0.1:42046",
+					"172.19.0.1:42046",
+					"172.20.0.1:42046",
+					"172.21.0.1:42046",
+					"172.22.0.1:42046",
+					"172.23.0.1:42046",
+					"172.24.0.1:42046",
+					"172.25.0.1:42046",
+					"172.26.0.1:42046",
+					"172.27.0.1:42046",
+					"172.28.0.1:42046"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:18:25.753413192Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3703453112569412,
+				"StableID":   "nR3Mg8SJvV11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:00b270a28bef133635425b307228ec0749d00c11255722cc06b9f05abfbe2372",
+				"DiscoKey":   "discokey:643a35b7d9b7d07b748d1b9eddcb6223dee33adfbb95815ea9441e5169d91919",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49879",
+					"10.65.0.27:49879",
+					"172.17.0.1:49879",
+					"172.18.0.1:49879",
+					"172.19.0.1:49879",
+					"172.20.0.1:49879",
+					"172.21.0.1:49879",
+					"172.22.0.1:49879",
+					"172.23.0.1:49879",
+					"172.24.0.1:49879",
+					"172.25.0.1:49879",
+					"172.26.0.1:49879",
+					"172.27.0.1:49879",
+					"172.28.0.1:49879"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:18:26.305678811Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7146136476813947,
+				"StableID":   "nUhMfUtVox11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31c027a88808fbf2e12d20d7339e211908e878abb9f0ed2803e224cca5f17210",
+				"DiscoKey":   "discokey:14492165aef132522938760516d62795a37b46e4b96c98d79d98a04f9d6ff63e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:41689",
+					"10.65.0.27:41689",
+					"172.17.0.1:41689",
+					"172.18.0.1:41689",
+					"172.19.0.1:41689",
+					"172.20.0.1:41689",
+					"172.21.0.1:41689",
+					"172.22.0.1:41689",
+					"172.23.0.1:41689",
+					"172.24.0.1:41689",
+					"172.25.0.1:41689",
+					"172.26.0.1:41689",
+					"172.27.0.1:41689",
+					"172.28.0.1:41689"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:18:26.835487556Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5234182443223358,
+				"StableID":   "nMSjtd6ash11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e9ff37a5bf38f75dbd43a6a05b912542422ecc99a63934300725175b0b556018",
+				"DiscoKey":   "discokey:25b2098902097e8778340a0aea5e195476acc246f89e022f4bb7ca2d6299da49",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38639",
+					"10.65.0.27:38639",
+					"172.17.0.1:38639",
+					"172.18.0.1:38639",
+					"172.19.0.1:38639",
+					"172.20.0.1:38639",
+					"172.21.0.1:38639",
+					"172.22.0.1:38639",
+					"172.23.0.1:38639",
+					"172.24.0.1:38639",
+					"172.25.0.1:38639",
+					"172.26.0.1:38639",
+					"172.27.0.1:38639",
+					"172.28.0.1:38639"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:18:27.413681071Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4277455258369164,
+				"StableID":   "nor2jnVGQa11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3c36636ee28c97a9c6353ec32ec246767d10813a18f68a3bf84df208e5c37263",
+				"DiscoKey":   "discokey:8c04276a99d1cff78d424cc57e20d789b9585852b73bd8e6f18bfc345597622f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40861",
+					"10.65.0.27:40861",
+					"172.17.0.1:40861",
+					"172.18.0.1:40861",
+					"172.19.0.1:40861",
+					"172.20.0.1:40861",
+					"172.21.0.1:40861",
+					"172.22.0.1:40861",
+					"172.23.0.1:40861",
+					"172.24.0.1:40861",
+					"172.25.0.1:40861",
+					"172.26.0.1:40861",
+					"172.27.0.1:40861",
+					"172.28.0.1:40861"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:18:27.90103441Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6210021292995392,
+				"StableID":   "nbghSHjXVq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87128166c893a60ba96b44e59f7fd0d1d139db8efc029d37ad753bc27d01d658",
+				"DiscoKey":   "discokey:e560631cb9b92a8cc999d49c9967f0ef9c0d0207804f37040c24a90cb5566759",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40401",
+					"10.65.0.27:40401",
+					"172.17.0.1:40401",
+					"172.18.0.1:40401",
+					"172.19.0.1:40401",
+					"172.20.0.1:40401",
+					"172.21.0.1:40401",
+					"172.22.0.1:40401",
+					"172.23.0.1:40401",
+					"172.24.0.1:40401",
+					"172.25.0.1:40401",
+					"172.26.0.1:40401",
+					"172.27.0.1:40401",
+					"172.28.0.1:40401"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:18:28.446165874Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7610624439162705,
+				"StableID":   "naP8LXCsR221CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:64323e2acab6388073367f6bf33ca27be3b617808e77f282172e1cfb7288e408",
+				"DiscoKey":   "discokey:8265adf738a508dd79d5594c9051086e367f735e364a9b0f8b07444ab4837a23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47593",
+					"10.65.0.27:47593",
+					"172.17.0.1:47593",
+					"172.18.0.1:47593",
+					"172.19.0.1:47593",
+					"172.20.0.1:47593",
+					"172.21.0.1:47593",
+					"172.22.0.1:47593",
+					"172.23.0.1:47593",
+					"172.24.0.1:47593",
+					"172.25.0.1:47593",
+					"172.26.0.1:47593",
+					"172.27.0.1:47593",
+					"172.28.0.1:47593"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:18:28.975436501Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         171923215953612,
+				"StableID":   "nZ7Vsc8sL211CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5613b48ea96ace9530f814555295e862a446e2369dd1ad56d065dbe8683d892e",
+				"KeyExpiry":  "2026-11-09T09:18:29Z",
+				"DiscoKey":   "discokey:0a359bd65f92d91db2039f94d50db21d0674d16f2743adfba2cf07a5b9534135",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46507",
+					"10.65.0.27:46507",
+					"172.17.0.1:46507",
+					"172.18.0.1:46507",
+					"172.19.0.1:46507",
+					"172.20.0.1:46507",
+					"172.21.0.1:46507",
+					"172.22.0.1:46507",
+					"172.23.0.1:46507",
+					"172.24.0.1:46507",
+					"172.25.0.1:46507",
+					"172.26.0.1:46507",
+					"172.27.0.1:46507",
+					"172.28.0.1:46507"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:18:29.572595367Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4589858193929405,
+				"StableID":   "n86GNvnkqc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:30a2d8497c37a412110d6334b2c9b1ade3a01014f3a04f2b29f1c0781be82d55",
+				"KeyExpiry":  "2026-11-09T09:18:30Z",
+				"DiscoKey":   "discokey:50ffe6a2296a06d0562488d3c1ae7754c33b641f77058c0d48b6f0e1538a0269",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58735",
+					"10.65.0.27:58735",
+					"172.17.0.1:58735",
+					"172.18.0.1:58735",
+					"172.19.0.1:58735",
+					"172.20.0.1:58735",
+					"172.21.0.1:58735",
+					"172.22.0.1:58735",
+					"172.23.0.1:58735",
+					"172.24.0.1:58735",
+					"172.25.0.1:58735",
+					"172.26.0.1:58735",
+					"172.27.0.1:58735",
+					"172.28.0.1:58735"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:18:30.059549244Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         910391420385261,
+				"StableID":   "ntkALTSK7811CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:31746f4776a57d2bbb43ca359e7d10d9f27a8e0496061bbc6de32e449e13867b",
+				"KeyExpiry":  "2026-11-09T09:18:30Z",
+				"DiscoKey":   "discokey:3ce571dfd38f447fbe40480090cfa44d4bbbffa28743b767d7d0c197de23a65a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49501",
+					"10.65.0.27:49501",
+					"172.17.0.1:49501",
+					"172.18.0.1:49501",
+					"172.19.0.1:49501",
+					"172.20.0.1:49501",
+					"172.21.0.1:49501",
+					"172.22.0.1:49501",
+					"172.23.0.1:49501",
+					"172.24.0.1:49501",
+					"172.25.0.1:49501",
+					"172.26.0.1:49501",
+					"172.27.0.1:49501",
+					"172.28.0.1:49501"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:18:30.586131649Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6288708298322901": {
+				"ID":          6288708298322901,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7146136476813947,
+				"StableID":   "nUhMfUtVox11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       7146136476813947,
+				"Key":        "nodekey:31c027a88808fbf2e12d20d7339e211908e878abb9f0ed2803e224cca5f17210",
+				"DiscoKey":   "discokey:14492165aef132522938760516d62795a37b46e4b96c98d79d98a04f9d6ff63e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:41689",
+					"10.65.0.27:41689",
+					"172.17.0.1:41689",
+					"172.18.0.1:41689",
+					"172.19.0.1:41689",
+					"172.20.0.1:41689",
+					"172.21.0.1:41689",
+					"172.22.0.1:41689",
+					"172.23.0.1:41689",
+					"172.24.0.1:41689",
+					"172.25.0.1:41689",
+					"172.26.0.1:41689",
+					"172.27.0.1:41689",
+					"172.28.0.1:41689"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:18:26.835487556Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:31c027a88808fbf2e12d20d7339e211908e878abb9f0ed2803e224cca5f17210",
+			"MachineKey": "mkey:39a280cafead9553335d38bf21496902a8182038de011fef6ba35822a6ccbf37",
+			"Peers": [{
+				"ID":         3629659383597747,
+				"StableID":   "nAgYYqzsLV11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:826a2f590555f412bea08e52ef573e5eaeefc23475cda5dbc0dc33407fd51368",
+				"DiscoKey":   "discokey:cfe29272e4f8d6d52e1d6cc80a109cb33332104b72b6be4d16173959c58e2d3a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:42911",
+					"10.65.0.27:42911",
+					"172.17.0.1:42911",
+					"172.18.0.1:42911",
+					"172.19.0.1:42911",
+					"172.20.0.1:42911",
+					"172.21.0.1:42911",
+					"172.22.0.1:42911",
+					"172.23.0.1:42911",
+					"172.24.0.1:42911",
+					"172.25.0.1:42911",
+					"172.26.0.1:42911",
+					"172.27.0.1:42911",
+					"172.28.0.1:42911"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:18:23.064882594Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7634452867421641,
+				"StableID":   "nEoRwb8fc221CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd433ce90513732d1a814e056979c959e7c0572fc7f523b5356b9086dda90e6f",
+				"DiscoKey":   "discokey:9f5e41c049b90f62e8c2b7ff30aaba7da14aa336b3f6ca79037752c5e9600874",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43181",
+					"10.65.0.27:43181",
+					"172.17.0.1:43181",
+					"172.18.0.1:43181",
+					"172.19.0.1:43181",
+					"172.20.0.1:43181",
+					"172.21.0.1:43181",
+					"172.22.0.1:43181",
+					"172.23.0.1:43181",
+					"172.24.0.1:43181",
+					"172.25.0.1:43181",
+					"172.26.0.1:43181",
+					"172.27.0.1:43181",
+					"172.28.0.1:43181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:18:23.610236176Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6288708298322901,
+				"StableID":   "nJTsenhA7r11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9574ee86e49d545297709b7d3733d6f96ffe4563e75e41597f917221548c6d09",
+				"DiscoKey":   "discokey:683bd93e93958206447f011fbe123ec261a83ffaf6a3a058f9867fbe9af1ec40",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43316",
+					"10.65.0.27:43316",
+					"172.17.0.1:43316",
+					"172.18.0.1:43316",
+					"172.19.0.1:43316",
+					"172.20.0.1:43316",
+					"172.21.0.1:43316",
+					"172.22.0.1:43316",
+					"172.23.0.1:43316",
+					"172.24.0.1:43316",
+					"172.25.0.1:43316",
+					"172.26.0.1:43316",
+					"172.27.0.1:43316",
+					"172.28.0.1:43316"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:18:24.144090057Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3872101206780,
+				"StableID":   "n9ooKPik2111CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc1c67bf3c3b82002d30abb24af84188710e1bec537d3d8aec1167ccbc474040",
+				"DiscoKey":   "discokey:95e97236e791c770a6fcb06b316c5dcc721ebad3ecd8a393c534f8b5f4082b71",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:52545",
+					"10.65.0.27:52545",
+					"172.17.0.1:52545",
+					"172.18.0.1:52545",
+					"172.19.0.1:52545",
+					"172.20.0.1:52545",
+					"172.21.0.1:52545",
+					"172.22.0.1:52545",
+					"172.23.0.1:52545",
+					"172.24.0.1:52545",
+					"172.25.0.1:52545",
+					"172.26.0.1:52545",
+					"172.27.0.1:52545",
+					"172.28.0.1:52545"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:18:24.679562462Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1351878608113606,
+				"StableID":   "nhksJQZGZB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:632860ce4649a5e7ec6dfb212db5bde87642e475954c87968565670b7e9b6431",
+				"DiscoKey":   "discokey:2e99bf667d271a84d45861465ca6e7ca59f31c555bbd9ae399d13a068b116540",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33481",
+					"10.65.0.27:33481",
+					"172.17.0.1:33481",
+					"172.18.0.1:33481",
+					"172.19.0.1:33481",
+					"172.20.0.1:33481",
+					"172.21.0.1:33481",
+					"172.22.0.1:33481",
+					"172.23.0.1:33481",
+					"172.24.0.1:33481",
+					"172.25.0.1:33481",
+					"172.26.0.1:33481",
+					"172.27.0.1:33481",
+					"172.28.0.1:33481"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:18:25.212870114Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4710579020748619,
+				"StableID":   "neziSYvRnd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6b4e8a634a3026b7bafafb5b30550a77da67edf0fb28baf9dd323b117fc27165",
+				"DiscoKey":   "discokey:bb9dd4a17807d1c1156537152e599056f06445fa54da389634a48a572404685c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42046",
+					"10.65.0.27:42046",
+					"172.17.0.1:42046",
+					"172.18.0.1:42046",
+					"172.19.0.1:42046",
+					"172.20.0.1:42046",
+					"172.21.0.1:42046",
+					"172.22.0.1:42046",
+					"172.23.0.1:42046",
+					"172.24.0.1:42046",
+					"172.25.0.1:42046",
+					"172.26.0.1:42046",
+					"172.27.0.1:42046",
+					"172.28.0.1:42046"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:18:25.753413192Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3703453112569412,
+				"StableID":   "nR3Mg8SJvV11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:00b270a28bef133635425b307228ec0749d00c11255722cc06b9f05abfbe2372",
+				"DiscoKey":   "discokey:643a35b7d9b7d07b748d1b9eddcb6223dee33adfbb95815ea9441e5169d91919",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49879",
+					"10.65.0.27:49879",
+					"172.17.0.1:49879",
+					"172.18.0.1:49879",
+					"172.19.0.1:49879",
+					"172.20.0.1:49879",
+					"172.21.0.1:49879",
+					"172.22.0.1:49879",
+					"172.23.0.1:49879",
+					"172.24.0.1:49879",
+					"172.25.0.1:49879",
+					"172.26.0.1:49879",
+					"172.27.0.1:49879",
+					"172.28.0.1:49879"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:18:26.305678811Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5234182443223358,
+				"StableID":   "nMSjtd6ash11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e9ff37a5bf38f75dbd43a6a05b912542422ecc99a63934300725175b0b556018",
+				"DiscoKey":   "discokey:25b2098902097e8778340a0aea5e195476acc246f89e022f4bb7ca2d6299da49",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38639",
+					"10.65.0.27:38639",
+					"172.17.0.1:38639",
+					"172.18.0.1:38639",
+					"172.19.0.1:38639",
+					"172.20.0.1:38639",
+					"172.21.0.1:38639",
+					"172.22.0.1:38639",
+					"172.23.0.1:38639",
+					"172.24.0.1:38639",
+					"172.25.0.1:38639",
+					"172.26.0.1:38639",
+					"172.27.0.1:38639",
+					"172.28.0.1:38639"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:18:27.413681071Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4277455258369164,
+				"StableID":   "nor2jnVGQa11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3c36636ee28c97a9c6353ec32ec246767d10813a18f68a3bf84df208e5c37263",
+				"DiscoKey":   "discokey:8c04276a99d1cff78d424cc57e20d789b9585852b73bd8e6f18bfc345597622f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40861",
+					"10.65.0.27:40861",
+					"172.17.0.1:40861",
+					"172.18.0.1:40861",
+					"172.19.0.1:40861",
+					"172.20.0.1:40861",
+					"172.21.0.1:40861",
+					"172.22.0.1:40861",
+					"172.23.0.1:40861",
+					"172.24.0.1:40861",
+					"172.25.0.1:40861",
+					"172.26.0.1:40861",
+					"172.27.0.1:40861",
+					"172.28.0.1:40861"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:18:27.90103441Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6210021292995392,
+				"StableID":   "nbghSHjXVq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87128166c893a60ba96b44e59f7fd0d1d139db8efc029d37ad753bc27d01d658",
+				"DiscoKey":   "discokey:e560631cb9b92a8cc999d49c9967f0ef9c0d0207804f37040c24a90cb5566759",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40401",
+					"10.65.0.27:40401",
+					"172.17.0.1:40401",
+					"172.18.0.1:40401",
+					"172.19.0.1:40401",
+					"172.20.0.1:40401",
+					"172.21.0.1:40401",
+					"172.22.0.1:40401",
+					"172.23.0.1:40401",
+					"172.24.0.1:40401",
+					"172.25.0.1:40401",
+					"172.26.0.1:40401",
+					"172.27.0.1:40401",
+					"172.28.0.1:40401"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:18:28.446165874Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7610624439162705,
+				"StableID":   "naP8LXCsR221CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:64323e2acab6388073367f6bf33ca27be3b617808e77f282172e1cfb7288e408",
+				"DiscoKey":   "discokey:8265adf738a508dd79d5594c9051086e367f735e364a9b0f8b07444ab4837a23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47593",
+					"10.65.0.27:47593",
+					"172.17.0.1:47593",
+					"172.18.0.1:47593",
+					"172.19.0.1:47593",
+					"172.20.0.1:47593",
+					"172.21.0.1:47593",
+					"172.22.0.1:47593",
+					"172.23.0.1:47593",
+					"172.24.0.1:47593",
+					"172.25.0.1:47593",
+					"172.26.0.1:47593",
+					"172.27.0.1:47593",
+					"172.28.0.1:47593"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:18:28.975436501Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         171923215953612,
+				"StableID":   "nZ7Vsc8sL211CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5613b48ea96ace9530f814555295e862a446e2369dd1ad56d065dbe8683d892e",
+				"KeyExpiry":  "2026-11-09T09:18:29Z",
+				"DiscoKey":   "discokey:0a359bd65f92d91db2039f94d50db21d0674d16f2743adfba2cf07a5b9534135",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46507",
+					"10.65.0.27:46507",
+					"172.17.0.1:46507",
+					"172.18.0.1:46507",
+					"172.19.0.1:46507",
+					"172.20.0.1:46507",
+					"172.21.0.1:46507",
+					"172.22.0.1:46507",
+					"172.23.0.1:46507",
+					"172.24.0.1:46507",
+					"172.25.0.1:46507",
+					"172.26.0.1:46507",
+					"172.27.0.1:46507",
+					"172.28.0.1:46507"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:18:29.572595367Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4589858193929405,
+				"StableID":   "n86GNvnkqc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:30a2d8497c37a412110d6334b2c9b1ade3a01014f3a04f2b29f1c0781be82d55",
+				"KeyExpiry":  "2026-11-09T09:18:30Z",
+				"DiscoKey":   "discokey:50ffe6a2296a06d0562488d3c1ae7754c33b641f77058c0d48b6f0e1538a0269",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58735",
+					"10.65.0.27:58735",
+					"172.17.0.1:58735",
+					"172.18.0.1:58735",
+					"172.19.0.1:58735",
+					"172.20.0.1:58735",
+					"172.21.0.1:58735",
+					"172.22.0.1:58735",
+					"172.23.0.1:58735",
+					"172.24.0.1:58735",
+					"172.25.0.1:58735",
+					"172.26.0.1:58735",
+					"172.27.0.1:58735",
+					"172.28.0.1:58735"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:18:30.059549244Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         910391420385261,
+				"StableID":   "ntkALTSK7811CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:31746f4776a57d2bbb43ca359e7d10d9f27a8e0496061bbc6de32e449e13867b",
+				"KeyExpiry":  "2026-11-09T09:18:30Z",
+				"DiscoKey":   "discokey:3ce571dfd38f447fbe40480090cfa44d4bbbffa28743b767d7d0c197de23a65a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49501",
+					"10.65.0.27:49501",
+					"172.17.0.1:49501",
+					"172.18.0.1:49501",
+					"172.19.0.1:49501",
+					"172.20.0.1:49501",
+					"172.21.0.1:49501",
+					"172.22.0.1:49501",
+					"172.23.0.1:49501",
+					"172.24.0.1:49501",
+					"172.25.0.1:49501",
+					"172.26.0.1:49501",
+					"172.27.0.1:49501",
+					"172.28.0.1:49501"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:18:30.586131649Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7146136476813947": {
+				"ID":          7146136476813947,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         171923215953612,
+				"StableID":   "nZ7Vsc8sL211CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5613b48ea96ace9530f814555295e862a446e2369dd1ad56d065dbe8683d892e",
+				"KeyExpiry":  "2026-11-09T09:18:29Z",
+				"DiscoKey":   "discokey:0a359bd65f92d91db2039f94d50db21d0674d16f2743adfba2cf07a5b9534135",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46507",
+					"10.65.0.27:46507",
+					"172.17.0.1:46507",
+					"172.18.0.1:46507",
+					"172.19.0.1:46507",
+					"172.20.0.1:46507",
+					"172.21.0.1:46507",
+					"172.22.0.1:46507",
+					"172.23.0.1:46507",
+					"172.24.0.1:46507",
+					"172.25.0.1:46507",
+					"172.26.0.1:46507",
+					"172.27.0.1:46507",
+					"172.28.0.1:46507"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:18:29.572595367Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5613b48ea96ace9530f814555295e862a446e2369dd1ad56d065dbe8683d892e",
+			"MachineKey": "mkey:de567801f4730ab074ea9ef780545ff21ea375002f367e6452bdd6c61fb62154",
+			"Peers": [{
+				"ID":         3629659383597747,
+				"StableID":   "nAgYYqzsLV11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:826a2f590555f412bea08e52ef573e5eaeefc23475cda5dbc0dc33407fd51368",
+				"DiscoKey":   "discokey:cfe29272e4f8d6d52e1d6cc80a109cb33332104b72b6be4d16173959c58e2d3a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:42911",
+					"10.65.0.27:42911",
+					"172.17.0.1:42911",
+					"172.18.0.1:42911",
+					"172.19.0.1:42911",
+					"172.20.0.1:42911",
+					"172.21.0.1:42911",
+					"172.22.0.1:42911",
+					"172.23.0.1:42911",
+					"172.24.0.1:42911",
+					"172.25.0.1:42911",
+					"172.26.0.1:42911",
+					"172.27.0.1:42911",
+					"172.28.0.1:42911"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:18:23.064882594Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7634452867421641,
+				"StableID":   "nEoRwb8fc221CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd433ce90513732d1a814e056979c959e7c0572fc7f523b5356b9086dda90e6f",
+				"DiscoKey":   "discokey:9f5e41c049b90f62e8c2b7ff30aaba7da14aa336b3f6ca79037752c5e9600874",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43181",
+					"10.65.0.27:43181",
+					"172.17.0.1:43181",
+					"172.18.0.1:43181",
+					"172.19.0.1:43181",
+					"172.20.0.1:43181",
+					"172.21.0.1:43181",
+					"172.22.0.1:43181",
+					"172.23.0.1:43181",
+					"172.24.0.1:43181",
+					"172.25.0.1:43181",
+					"172.26.0.1:43181",
+					"172.27.0.1:43181",
+					"172.28.0.1:43181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:18:23.610236176Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6288708298322901,
+				"StableID":   "nJTsenhA7r11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9574ee86e49d545297709b7d3733d6f96ffe4563e75e41597f917221548c6d09",
+				"DiscoKey":   "discokey:683bd93e93958206447f011fbe123ec261a83ffaf6a3a058f9867fbe9af1ec40",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43316",
+					"10.65.0.27:43316",
+					"172.17.0.1:43316",
+					"172.18.0.1:43316",
+					"172.19.0.1:43316",
+					"172.20.0.1:43316",
+					"172.21.0.1:43316",
+					"172.22.0.1:43316",
+					"172.23.0.1:43316",
+					"172.24.0.1:43316",
+					"172.25.0.1:43316",
+					"172.26.0.1:43316",
+					"172.27.0.1:43316",
+					"172.28.0.1:43316"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:18:24.144090057Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3872101206780,
+				"StableID":   "n9ooKPik2111CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc1c67bf3c3b82002d30abb24af84188710e1bec537d3d8aec1167ccbc474040",
+				"DiscoKey":   "discokey:95e97236e791c770a6fcb06b316c5dcc721ebad3ecd8a393c534f8b5f4082b71",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:52545",
+					"10.65.0.27:52545",
+					"172.17.0.1:52545",
+					"172.18.0.1:52545",
+					"172.19.0.1:52545",
+					"172.20.0.1:52545",
+					"172.21.0.1:52545",
+					"172.22.0.1:52545",
+					"172.23.0.1:52545",
+					"172.24.0.1:52545",
+					"172.25.0.1:52545",
+					"172.26.0.1:52545",
+					"172.27.0.1:52545",
+					"172.28.0.1:52545"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:18:24.679562462Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1351878608113606,
+				"StableID":   "nhksJQZGZB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:632860ce4649a5e7ec6dfb212db5bde87642e475954c87968565670b7e9b6431",
+				"DiscoKey":   "discokey:2e99bf667d271a84d45861465ca6e7ca59f31c555bbd9ae399d13a068b116540",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33481",
+					"10.65.0.27:33481",
+					"172.17.0.1:33481",
+					"172.18.0.1:33481",
+					"172.19.0.1:33481",
+					"172.20.0.1:33481",
+					"172.21.0.1:33481",
+					"172.22.0.1:33481",
+					"172.23.0.1:33481",
+					"172.24.0.1:33481",
+					"172.25.0.1:33481",
+					"172.26.0.1:33481",
+					"172.27.0.1:33481",
+					"172.28.0.1:33481"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:18:25.212870114Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4710579020748619,
+				"StableID":   "neziSYvRnd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6b4e8a634a3026b7bafafb5b30550a77da67edf0fb28baf9dd323b117fc27165",
+				"DiscoKey":   "discokey:bb9dd4a17807d1c1156537152e599056f06445fa54da389634a48a572404685c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42046",
+					"10.65.0.27:42046",
+					"172.17.0.1:42046",
+					"172.18.0.1:42046",
+					"172.19.0.1:42046",
+					"172.20.0.1:42046",
+					"172.21.0.1:42046",
+					"172.22.0.1:42046",
+					"172.23.0.1:42046",
+					"172.24.0.1:42046",
+					"172.25.0.1:42046",
+					"172.26.0.1:42046",
+					"172.27.0.1:42046",
+					"172.28.0.1:42046"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:18:25.753413192Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3703453112569412,
+				"StableID":   "nR3Mg8SJvV11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:00b270a28bef133635425b307228ec0749d00c11255722cc06b9f05abfbe2372",
+				"DiscoKey":   "discokey:643a35b7d9b7d07b748d1b9eddcb6223dee33adfbb95815ea9441e5169d91919",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49879",
+					"10.65.0.27:49879",
+					"172.17.0.1:49879",
+					"172.18.0.1:49879",
+					"172.19.0.1:49879",
+					"172.20.0.1:49879",
+					"172.21.0.1:49879",
+					"172.22.0.1:49879",
+					"172.23.0.1:49879",
+					"172.24.0.1:49879",
+					"172.25.0.1:49879",
+					"172.26.0.1:49879",
+					"172.27.0.1:49879",
+					"172.28.0.1:49879"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:18:26.305678811Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7146136476813947,
+				"StableID":   "nUhMfUtVox11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31c027a88808fbf2e12d20d7339e211908e878abb9f0ed2803e224cca5f17210",
+				"DiscoKey":   "discokey:14492165aef132522938760516d62795a37b46e4b96c98d79d98a04f9d6ff63e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:41689",
+					"10.65.0.27:41689",
+					"172.17.0.1:41689",
+					"172.18.0.1:41689",
+					"172.19.0.1:41689",
+					"172.20.0.1:41689",
+					"172.21.0.1:41689",
+					"172.22.0.1:41689",
+					"172.23.0.1:41689",
+					"172.24.0.1:41689",
+					"172.25.0.1:41689",
+					"172.26.0.1:41689",
+					"172.27.0.1:41689",
+					"172.28.0.1:41689"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:18:26.835487556Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5234182443223358,
+				"StableID":   "nMSjtd6ash11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e9ff37a5bf38f75dbd43a6a05b912542422ecc99a63934300725175b0b556018",
+				"DiscoKey":   "discokey:25b2098902097e8778340a0aea5e195476acc246f89e022f4bb7ca2d6299da49",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38639",
+					"10.65.0.27:38639",
+					"172.17.0.1:38639",
+					"172.18.0.1:38639",
+					"172.19.0.1:38639",
+					"172.20.0.1:38639",
+					"172.21.0.1:38639",
+					"172.22.0.1:38639",
+					"172.23.0.1:38639",
+					"172.24.0.1:38639",
+					"172.25.0.1:38639",
+					"172.26.0.1:38639",
+					"172.27.0.1:38639",
+					"172.28.0.1:38639"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:18:27.413681071Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4277455258369164,
+				"StableID":   "nor2jnVGQa11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3c36636ee28c97a9c6353ec32ec246767d10813a18f68a3bf84df208e5c37263",
+				"DiscoKey":   "discokey:8c04276a99d1cff78d424cc57e20d789b9585852b73bd8e6f18bfc345597622f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40861",
+					"10.65.0.27:40861",
+					"172.17.0.1:40861",
+					"172.18.0.1:40861",
+					"172.19.0.1:40861",
+					"172.20.0.1:40861",
+					"172.21.0.1:40861",
+					"172.22.0.1:40861",
+					"172.23.0.1:40861",
+					"172.24.0.1:40861",
+					"172.25.0.1:40861",
+					"172.26.0.1:40861",
+					"172.27.0.1:40861",
+					"172.28.0.1:40861"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:18:27.90103441Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6210021292995392,
+				"StableID":   "nbghSHjXVq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87128166c893a60ba96b44e59f7fd0d1d139db8efc029d37ad753bc27d01d658",
+				"DiscoKey":   "discokey:e560631cb9b92a8cc999d49c9967f0ef9c0d0207804f37040c24a90cb5566759",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40401",
+					"10.65.0.27:40401",
+					"172.17.0.1:40401",
+					"172.18.0.1:40401",
+					"172.19.0.1:40401",
+					"172.20.0.1:40401",
+					"172.21.0.1:40401",
+					"172.22.0.1:40401",
+					"172.23.0.1:40401",
+					"172.24.0.1:40401",
+					"172.25.0.1:40401",
+					"172.26.0.1:40401",
+					"172.27.0.1:40401",
+					"172.28.0.1:40401"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:18:28.446165874Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7610624439162705,
+				"StableID":   "naP8LXCsR221CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:64323e2acab6388073367f6bf33ca27be3b617808e77f282172e1cfb7288e408",
+				"DiscoKey":   "discokey:8265adf738a508dd79d5594c9051086e367f735e364a9b0f8b07444ab4837a23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47593",
+					"10.65.0.27:47593",
+					"172.17.0.1:47593",
+					"172.18.0.1:47593",
+					"172.19.0.1:47593",
+					"172.20.0.1:47593",
+					"172.21.0.1:47593",
+					"172.22.0.1:47593",
+					"172.23.0.1:47593",
+					"172.24.0.1:47593",
+					"172.25.0.1:47593",
+					"172.26.0.1:47593",
+					"172.27.0.1:47593",
+					"172.28.0.1:47593"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:18:28.975436501Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4589858193929405,
+				"StableID":   "n86GNvnkqc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:30a2d8497c37a412110d6334b2c9b1ade3a01014f3a04f2b29f1c0781be82d55",
+				"KeyExpiry":  "2026-11-09T09:18:30Z",
+				"DiscoKey":   "discokey:50ffe6a2296a06d0562488d3c1ae7754c33b641f77058c0d48b6f0e1538a0269",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58735",
+					"10.65.0.27:58735",
+					"172.17.0.1:58735",
+					"172.18.0.1:58735",
+					"172.19.0.1:58735",
+					"172.20.0.1:58735",
+					"172.21.0.1:58735",
+					"172.22.0.1:58735",
+					"172.23.0.1:58735",
+					"172.24.0.1:58735",
+					"172.25.0.1:58735",
+					"172.26.0.1:58735",
+					"172.27.0.1:58735",
+					"172.28.0.1:58735"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:18:30.059549244Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         910391420385261,
+				"StableID":   "ntkALTSK7811CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:31746f4776a57d2bbb43ca359e7d10d9f27a8e0496061bbc6de32e449e13867b",
+				"KeyExpiry":  "2026-11-09T09:18:30Z",
+				"DiscoKey":   "discokey:3ce571dfd38f447fbe40480090cfa44d4bbbffa28743b767d7d0c197de23a65a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49501",
+					"10.65.0.27:49501",
+					"172.17.0.1:49501",
+					"172.18.0.1:49501",
+					"172.19.0.1:49501",
+					"172.20.0.1:49501",
+					"172.21.0.1:49501",
+					"172.22.0.1:49501",
+					"172.23.0.1:49501",
+					"172.24.0.1:49501",
+					"172.25.0.1:49501",
+					"172.26.0.1:49501",
+					"172.27.0.1:49501",
+					"172.28.0.1:49501"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:18:30.586131649Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6210021292995392,
+				"StableID":   "nbghSHjXVq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       6210021292995392,
+				"Key":        "nodekey:87128166c893a60ba96b44e59f7fd0d1d139db8efc029d37ad753bc27d01d658",
+				"DiscoKey":   "discokey:e560631cb9b92a8cc999d49c9967f0ef9c0d0207804f37040c24a90cb5566759",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40401",
+					"10.65.0.27:40401",
+					"172.17.0.1:40401",
+					"172.18.0.1:40401",
+					"172.19.0.1:40401",
+					"172.20.0.1:40401",
+					"172.21.0.1:40401",
+					"172.22.0.1:40401",
+					"172.23.0.1:40401",
+					"172.24.0.1:40401",
+					"172.25.0.1:40401",
+					"172.26.0.1:40401",
+					"172.27.0.1:40401",
+					"172.28.0.1:40401"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:18:28.446165874Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:87128166c893a60ba96b44e59f7fd0d1d139db8efc029d37ad753bc27d01d658",
+			"MachineKey": "mkey:9285ca52f06a24f593a63727f16fbda91b2567ef612123c5fc13477274691b67",
+			"Peers": [{
+				"ID":         3629659383597747,
+				"StableID":   "nAgYYqzsLV11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:826a2f590555f412bea08e52ef573e5eaeefc23475cda5dbc0dc33407fd51368",
+				"DiscoKey":   "discokey:cfe29272e4f8d6d52e1d6cc80a109cb33332104b72b6be4d16173959c58e2d3a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:42911",
+					"10.65.0.27:42911",
+					"172.17.0.1:42911",
+					"172.18.0.1:42911",
+					"172.19.0.1:42911",
+					"172.20.0.1:42911",
+					"172.21.0.1:42911",
+					"172.22.0.1:42911",
+					"172.23.0.1:42911",
+					"172.24.0.1:42911",
+					"172.25.0.1:42911",
+					"172.26.0.1:42911",
+					"172.27.0.1:42911",
+					"172.28.0.1:42911"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:18:23.064882594Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7634452867421641,
+				"StableID":   "nEoRwb8fc221CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd433ce90513732d1a814e056979c959e7c0572fc7f523b5356b9086dda90e6f",
+				"DiscoKey":   "discokey:9f5e41c049b90f62e8c2b7ff30aaba7da14aa336b3f6ca79037752c5e9600874",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43181",
+					"10.65.0.27:43181",
+					"172.17.0.1:43181",
+					"172.18.0.1:43181",
+					"172.19.0.1:43181",
+					"172.20.0.1:43181",
+					"172.21.0.1:43181",
+					"172.22.0.1:43181",
+					"172.23.0.1:43181",
+					"172.24.0.1:43181",
+					"172.25.0.1:43181",
+					"172.26.0.1:43181",
+					"172.27.0.1:43181",
+					"172.28.0.1:43181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:18:23.610236176Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6288708298322901,
+				"StableID":   "nJTsenhA7r11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9574ee86e49d545297709b7d3733d6f96ffe4563e75e41597f917221548c6d09",
+				"DiscoKey":   "discokey:683bd93e93958206447f011fbe123ec261a83ffaf6a3a058f9867fbe9af1ec40",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43316",
+					"10.65.0.27:43316",
+					"172.17.0.1:43316",
+					"172.18.0.1:43316",
+					"172.19.0.1:43316",
+					"172.20.0.1:43316",
+					"172.21.0.1:43316",
+					"172.22.0.1:43316",
+					"172.23.0.1:43316",
+					"172.24.0.1:43316",
+					"172.25.0.1:43316",
+					"172.26.0.1:43316",
+					"172.27.0.1:43316",
+					"172.28.0.1:43316"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:18:24.144090057Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3872101206780,
+				"StableID":   "n9ooKPik2111CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc1c67bf3c3b82002d30abb24af84188710e1bec537d3d8aec1167ccbc474040",
+				"DiscoKey":   "discokey:95e97236e791c770a6fcb06b316c5dcc721ebad3ecd8a393c534f8b5f4082b71",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:52545",
+					"10.65.0.27:52545",
+					"172.17.0.1:52545",
+					"172.18.0.1:52545",
+					"172.19.0.1:52545",
+					"172.20.0.1:52545",
+					"172.21.0.1:52545",
+					"172.22.0.1:52545",
+					"172.23.0.1:52545",
+					"172.24.0.1:52545",
+					"172.25.0.1:52545",
+					"172.26.0.1:52545",
+					"172.27.0.1:52545",
+					"172.28.0.1:52545"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:18:24.679562462Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1351878608113606,
+				"StableID":   "nhksJQZGZB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:632860ce4649a5e7ec6dfb212db5bde87642e475954c87968565670b7e9b6431",
+				"DiscoKey":   "discokey:2e99bf667d271a84d45861465ca6e7ca59f31c555bbd9ae399d13a068b116540",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33481",
+					"10.65.0.27:33481",
+					"172.17.0.1:33481",
+					"172.18.0.1:33481",
+					"172.19.0.1:33481",
+					"172.20.0.1:33481",
+					"172.21.0.1:33481",
+					"172.22.0.1:33481",
+					"172.23.0.1:33481",
+					"172.24.0.1:33481",
+					"172.25.0.1:33481",
+					"172.26.0.1:33481",
+					"172.27.0.1:33481",
+					"172.28.0.1:33481"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:18:25.212870114Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4710579020748619,
+				"StableID":   "neziSYvRnd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6b4e8a634a3026b7bafafb5b30550a77da67edf0fb28baf9dd323b117fc27165",
+				"DiscoKey":   "discokey:bb9dd4a17807d1c1156537152e599056f06445fa54da389634a48a572404685c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42046",
+					"10.65.0.27:42046",
+					"172.17.0.1:42046",
+					"172.18.0.1:42046",
+					"172.19.0.1:42046",
+					"172.20.0.1:42046",
+					"172.21.0.1:42046",
+					"172.22.0.1:42046",
+					"172.23.0.1:42046",
+					"172.24.0.1:42046",
+					"172.25.0.1:42046",
+					"172.26.0.1:42046",
+					"172.27.0.1:42046",
+					"172.28.0.1:42046"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:18:25.753413192Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3703453112569412,
+				"StableID":   "nR3Mg8SJvV11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:00b270a28bef133635425b307228ec0749d00c11255722cc06b9f05abfbe2372",
+				"DiscoKey":   "discokey:643a35b7d9b7d07b748d1b9eddcb6223dee33adfbb95815ea9441e5169d91919",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49879",
+					"10.65.0.27:49879",
+					"172.17.0.1:49879",
+					"172.18.0.1:49879",
+					"172.19.0.1:49879",
+					"172.20.0.1:49879",
+					"172.21.0.1:49879",
+					"172.22.0.1:49879",
+					"172.23.0.1:49879",
+					"172.24.0.1:49879",
+					"172.25.0.1:49879",
+					"172.26.0.1:49879",
+					"172.27.0.1:49879",
+					"172.28.0.1:49879"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:18:26.305678811Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7146136476813947,
+				"StableID":   "nUhMfUtVox11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31c027a88808fbf2e12d20d7339e211908e878abb9f0ed2803e224cca5f17210",
+				"DiscoKey":   "discokey:14492165aef132522938760516d62795a37b46e4b96c98d79d98a04f9d6ff63e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:41689",
+					"10.65.0.27:41689",
+					"172.17.0.1:41689",
+					"172.18.0.1:41689",
+					"172.19.0.1:41689",
+					"172.20.0.1:41689",
+					"172.21.0.1:41689",
+					"172.22.0.1:41689",
+					"172.23.0.1:41689",
+					"172.24.0.1:41689",
+					"172.25.0.1:41689",
+					"172.26.0.1:41689",
+					"172.27.0.1:41689",
+					"172.28.0.1:41689"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:18:26.835487556Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5234182443223358,
+				"StableID":   "nMSjtd6ash11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e9ff37a5bf38f75dbd43a6a05b912542422ecc99a63934300725175b0b556018",
+				"DiscoKey":   "discokey:25b2098902097e8778340a0aea5e195476acc246f89e022f4bb7ca2d6299da49",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38639",
+					"10.65.0.27:38639",
+					"172.17.0.1:38639",
+					"172.18.0.1:38639",
+					"172.19.0.1:38639",
+					"172.20.0.1:38639",
+					"172.21.0.1:38639",
+					"172.22.0.1:38639",
+					"172.23.0.1:38639",
+					"172.24.0.1:38639",
+					"172.25.0.1:38639",
+					"172.26.0.1:38639",
+					"172.27.0.1:38639",
+					"172.28.0.1:38639"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:18:27.413681071Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4277455258369164,
+				"StableID":   "nor2jnVGQa11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3c36636ee28c97a9c6353ec32ec246767d10813a18f68a3bf84df208e5c37263",
+				"DiscoKey":   "discokey:8c04276a99d1cff78d424cc57e20d789b9585852b73bd8e6f18bfc345597622f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40861",
+					"10.65.0.27:40861",
+					"172.17.0.1:40861",
+					"172.18.0.1:40861",
+					"172.19.0.1:40861",
+					"172.20.0.1:40861",
+					"172.21.0.1:40861",
+					"172.22.0.1:40861",
+					"172.23.0.1:40861",
+					"172.24.0.1:40861",
+					"172.25.0.1:40861",
+					"172.26.0.1:40861",
+					"172.27.0.1:40861",
+					"172.28.0.1:40861"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:18:27.90103441Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7610624439162705,
+				"StableID":   "naP8LXCsR221CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:64323e2acab6388073367f6bf33ca27be3b617808e77f282172e1cfb7288e408",
+				"DiscoKey":   "discokey:8265adf738a508dd79d5594c9051086e367f735e364a9b0f8b07444ab4837a23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47593",
+					"10.65.0.27:47593",
+					"172.17.0.1:47593",
+					"172.18.0.1:47593",
+					"172.19.0.1:47593",
+					"172.20.0.1:47593",
+					"172.21.0.1:47593",
+					"172.22.0.1:47593",
+					"172.23.0.1:47593",
+					"172.24.0.1:47593",
+					"172.25.0.1:47593",
+					"172.26.0.1:47593",
+					"172.27.0.1:47593",
+					"172.28.0.1:47593"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:18:28.975436501Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         171923215953612,
+				"StableID":   "nZ7Vsc8sL211CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5613b48ea96ace9530f814555295e862a446e2369dd1ad56d065dbe8683d892e",
+				"KeyExpiry":  "2026-11-09T09:18:29Z",
+				"DiscoKey":   "discokey:0a359bd65f92d91db2039f94d50db21d0674d16f2743adfba2cf07a5b9534135",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46507",
+					"10.65.0.27:46507",
+					"172.17.0.1:46507",
+					"172.18.0.1:46507",
+					"172.19.0.1:46507",
+					"172.20.0.1:46507",
+					"172.21.0.1:46507",
+					"172.22.0.1:46507",
+					"172.23.0.1:46507",
+					"172.24.0.1:46507",
+					"172.25.0.1:46507",
+					"172.26.0.1:46507",
+					"172.27.0.1:46507",
+					"172.28.0.1:46507"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:18:29.572595367Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4589858193929405,
+				"StableID":   "n86GNvnkqc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:30a2d8497c37a412110d6334b2c9b1ade3a01014f3a04f2b29f1c0781be82d55",
+				"KeyExpiry":  "2026-11-09T09:18:30Z",
+				"DiscoKey":   "discokey:50ffe6a2296a06d0562488d3c1ae7754c33b641f77058c0d48b6f0e1538a0269",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58735",
+					"10.65.0.27:58735",
+					"172.17.0.1:58735",
+					"172.18.0.1:58735",
+					"172.19.0.1:58735",
+					"172.20.0.1:58735",
+					"172.21.0.1:58735",
+					"172.22.0.1:58735",
+					"172.23.0.1:58735",
+					"172.24.0.1:58735",
+					"172.25.0.1:58735",
+					"172.26.0.1:58735",
+					"172.27.0.1:58735",
+					"172.28.0.1:58735"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:18:30.059549244Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         910391420385261,
+				"StableID":   "ntkALTSK7811CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:31746f4776a57d2bbb43ca359e7d10d9f27a8e0496061bbc6de32e449e13867b",
+				"KeyExpiry":  "2026-11-09T09:18:30Z",
+				"DiscoKey":   "discokey:3ce571dfd38f447fbe40480090cfa44d4bbbffa28743b767d7d0c197de23a65a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49501",
+					"10.65.0.27:49501",
+					"172.17.0.1:49501",
+					"172.18.0.1:49501",
+					"172.19.0.1:49501",
+					"172.20.0.1:49501",
+					"172.21.0.1:49501",
+					"172.22.0.1:49501",
+					"172.23.0.1:49501",
+					"172.24.0.1:49501",
+					"172.25.0.1:49501",
+					"172.26.0.1:49501",
+					"172.27.0.1:49501",
+					"172.28.0.1:49501"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:18:30.586131649Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6210021292995392": {
+				"ID":          6210021292995392,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7634452867421641,
+				"StableID":   "nEoRwb8fc221CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       7634452867421641,
+				"Key":        "nodekey:cd433ce90513732d1a814e056979c959e7c0572fc7f523b5356b9086dda90e6f",
+				"DiscoKey":   "discokey:9f5e41c049b90f62e8c2b7ff30aaba7da14aa336b3f6ca79037752c5e9600874",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43181",
+					"10.65.0.27:43181",
+					"172.17.0.1:43181",
+					"172.18.0.1:43181",
+					"172.19.0.1:43181",
+					"172.20.0.1:43181",
+					"172.21.0.1:43181",
+					"172.22.0.1:43181",
+					"172.23.0.1:43181",
+					"172.24.0.1:43181",
+					"172.25.0.1:43181",
+					"172.26.0.1:43181",
+					"172.27.0.1:43181",
+					"172.28.0.1:43181"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:18:23.610236176Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:cd433ce90513732d1a814e056979c959e7c0572fc7f523b5356b9086dda90e6f",
+			"MachineKey": "mkey:1716a292ef2b95c84b33654f6d242a2ec3fdb3b42b0f333d6279b9b5825fcd4a",
+			"Peers": [{
+				"ID":         3629659383597747,
+				"StableID":   "nAgYYqzsLV11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:826a2f590555f412bea08e52ef573e5eaeefc23475cda5dbc0dc33407fd51368",
+				"DiscoKey":   "discokey:cfe29272e4f8d6d52e1d6cc80a109cb33332104b72b6be4d16173959c58e2d3a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:42911",
+					"10.65.0.27:42911",
+					"172.17.0.1:42911",
+					"172.18.0.1:42911",
+					"172.19.0.1:42911",
+					"172.20.0.1:42911",
+					"172.21.0.1:42911",
+					"172.22.0.1:42911",
+					"172.23.0.1:42911",
+					"172.24.0.1:42911",
+					"172.25.0.1:42911",
+					"172.26.0.1:42911",
+					"172.27.0.1:42911",
+					"172.28.0.1:42911"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:18:23.064882594Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6288708298322901,
+				"StableID":   "nJTsenhA7r11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9574ee86e49d545297709b7d3733d6f96ffe4563e75e41597f917221548c6d09",
+				"DiscoKey":   "discokey:683bd93e93958206447f011fbe123ec261a83ffaf6a3a058f9867fbe9af1ec40",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43316",
+					"10.65.0.27:43316",
+					"172.17.0.1:43316",
+					"172.18.0.1:43316",
+					"172.19.0.1:43316",
+					"172.20.0.1:43316",
+					"172.21.0.1:43316",
+					"172.22.0.1:43316",
+					"172.23.0.1:43316",
+					"172.24.0.1:43316",
+					"172.25.0.1:43316",
+					"172.26.0.1:43316",
+					"172.27.0.1:43316",
+					"172.28.0.1:43316"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:18:24.144090057Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3872101206780,
+				"StableID":   "n9ooKPik2111CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc1c67bf3c3b82002d30abb24af84188710e1bec537d3d8aec1167ccbc474040",
+				"DiscoKey":   "discokey:95e97236e791c770a6fcb06b316c5dcc721ebad3ecd8a393c534f8b5f4082b71",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:52545",
+					"10.65.0.27:52545",
+					"172.17.0.1:52545",
+					"172.18.0.1:52545",
+					"172.19.0.1:52545",
+					"172.20.0.1:52545",
+					"172.21.0.1:52545",
+					"172.22.0.1:52545",
+					"172.23.0.1:52545",
+					"172.24.0.1:52545",
+					"172.25.0.1:52545",
+					"172.26.0.1:52545",
+					"172.27.0.1:52545",
+					"172.28.0.1:52545"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:18:24.679562462Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1351878608113606,
+				"StableID":   "nhksJQZGZB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:632860ce4649a5e7ec6dfb212db5bde87642e475954c87968565670b7e9b6431",
+				"DiscoKey":   "discokey:2e99bf667d271a84d45861465ca6e7ca59f31c555bbd9ae399d13a068b116540",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33481",
+					"10.65.0.27:33481",
+					"172.17.0.1:33481",
+					"172.18.0.1:33481",
+					"172.19.0.1:33481",
+					"172.20.0.1:33481",
+					"172.21.0.1:33481",
+					"172.22.0.1:33481",
+					"172.23.0.1:33481",
+					"172.24.0.1:33481",
+					"172.25.0.1:33481",
+					"172.26.0.1:33481",
+					"172.27.0.1:33481",
+					"172.28.0.1:33481"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:18:25.212870114Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4710579020748619,
+				"StableID":   "neziSYvRnd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6b4e8a634a3026b7bafafb5b30550a77da67edf0fb28baf9dd323b117fc27165",
+				"DiscoKey":   "discokey:bb9dd4a17807d1c1156537152e599056f06445fa54da389634a48a572404685c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42046",
+					"10.65.0.27:42046",
+					"172.17.0.1:42046",
+					"172.18.0.1:42046",
+					"172.19.0.1:42046",
+					"172.20.0.1:42046",
+					"172.21.0.1:42046",
+					"172.22.0.1:42046",
+					"172.23.0.1:42046",
+					"172.24.0.1:42046",
+					"172.25.0.1:42046",
+					"172.26.0.1:42046",
+					"172.27.0.1:42046",
+					"172.28.0.1:42046"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:18:25.753413192Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3703453112569412,
+				"StableID":   "nR3Mg8SJvV11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:00b270a28bef133635425b307228ec0749d00c11255722cc06b9f05abfbe2372",
+				"DiscoKey":   "discokey:643a35b7d9b7d07b748d1b9eddcb6223dee33adfbb95815ea9441e5169d91919",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49879",
+					"10.65.0.27:49879",
+					"172.17.0.1:49879",
+					"172.18.0.1:49879",
+					"172.19.0.1:49879",
+					"172.20.0.1:49879",
+					"172.21.0.1:49879",
+					"172.22.0.1:49879",
+					"172.23.0.1:49879",
+					"172.24.0.1:49879",
+					"172.25.0.1:49879",
+					"172.26.0.1:49879",
+					"172.27.0.1:49879",
+					"172.28.0.1:49879"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:18:26.305678811Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7146136476813947,
+				"StableID":   "nUhMfUtVox11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31c027a88808fbf2e12d20d7339e211908e878abb9f0ed2803e224cca5f17210",
+				"DiscoKey":   "discokey:14492165aef132522938760516d62795a37b46e4b96c98d79d98a04f9d6ff63e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:41689",
+					"10.65.0.27:41689",
+					"172.17.0.1:41689",
+					"172.18.0.1:41689",
+					"172.19.0.1:41689",
+					"172.20.0.1:41689",
+					"172.21.0.1:41689",
+					"172.22.0.1:41689",
+					"172.23.0.1:41689",
+					"172.24.0.1:41689",
+					"172.25.0.1:41689",
+					"172.26.0.1:41689",
+					"172.27.0.1:41689",
+					"172.28.0.1:41689"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:18:26.835487556Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5234182443223358,
+				"StableID":   "nMSjtd6ash11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e9ff37a5bf38f75dbd43a6a05b912542422ecc99a63934300725175b0b556018",
+				"DiscoKey":   "discokey:25b2098902097e8778340a0aea5e195476acc246f89e022f4bb7ca2d6299da49",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38639",
+					"10.65.0.27:38639",
+					"172.17.0.1:38639",
+					"172.18.0.1:38639",
+					"172.19.0.1:38639",
+					"172.20.0.1:38639",
+					"172.21.0.1:38639",
+					"172.22.0.1:38639",
+					"172.23.0.1:38639",
+					"172.24.0.1:38639",
+					"172.25.0.1:38639",
+					"172.26.0.1:38639",
+					"172.27.0.1:38639",
+					"172.28.0.1:38639"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:18:27.413681071Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4277455258369164,
+				"StableID":   "nor2jnVGQa11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3c36636ee28c97a9c6353ec32ec246767d10813a18f68a3bf84df208e5c37263",
+				"DiscoKey":   "discokey:8c04276a99d1cff78d424cc57e20d789b9585852b73bd8e6f18bfc345597622f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40861",
+					"10.65.0.27:40861",
+					"172.17.0.1:40861",
+					"172.18.0.1:40861",
+					"172.19.0.1:40861",
+					"172.20.0.1:40861",
+					"172.21.0.1:40861",
+					"172.22.0.1:40861",
+					"172.23.0.1:40861",
+					"172.24.0.1:40861",
+					"172.25.0.1:40861",
+					"172.26.0.1:40861",
+					"172.27.0.1:40861",
+					"172.28.0.1:40861"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:18:27.90103441Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6210021292995392,
+				"StableID":   "nbghSHjXVq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87128166c893a60ba96b44e59f7fd0d1d139db8efc029d37ad753bc27d01d658",
+				"DiscoKey":   "discokey:e560631cb9b92a8cc999d49c9967f0ef9c0d0207804f37040c24a90cb5566759",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40401",
+					"10.65.0.27:40401",
+					"172.17.0.1:40401",
+					"172.18.0.1:40401",
+					"172.19.0.1:40401",
+					"172.20.0.1:40401",
+					"172.21.0.1:40401",
+					"172.22.0.1:40401",
+					"172.23.0.1:40401",
+					"172.24.0.1:40401",
+					"172.25.0.1:40401",
+					"172.26.0.1:40401",
+					"172.27.0.1:40401",
+					"172.28.0.1:40401"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:18:28.446165874Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7610624439162705,
+				"StableID":   "naP8LXCsR221CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:64323e2acab6388073367f6bf33ca27be3b617808e77f282172e1cfb7288e408",
+				"DiscoKey":   "discokey:8265adf738a508dd79d5594c9051086e367f735e364a9b0f8b07444ab4837a23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47593",
+					"10.65.0.27:47593",
+					"172.17.0.1:47593",
+					"172.18.0.1:47593",
+					"172.19.0.1:47593",
+					"172.20.0.1:47593",
+					"172.21.0.1:47593",
+					"172.22.0.1:47593",
+					"172.23.0.1:47593",
+					"172.24.0.1:47593",
+					"172.25.0.1:47593",
+					"172.26.0.1:47593",
+					"172.27.0.1:47593",
+					"172.28.0.1:47593"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:18:28.975436501Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         171923215953612,
+				"StableID":   "nZ7Vsc8sL211CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5613b48ea96ace9530f814555295e862a446e2369dd1ad56d065dbe8683d892e",
+				"KeyExpiry":  "2026-11-09T09:18:29Z",
+				"DiscoKey":   "discokey:0a359bd65f92d91db2039f94d50db21d0674d16f2743adfba2cf07a5b9534135",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46507",
+					"10.65.0.27:46507",
+					"172.17.0.1:46507",
+					"172.18.0.1:46507",
+					"172.19.0.1:46507",
+					"172.20.0.1:46507",
+					"172.21.0.1:46507",
+					"172.22.0.1:46507",
+					"172.23.0.1:46507",
+					"172.24.0.1:46507",
+					"172.25.0.1:46507",
+					"172.26.0.1:46507",
+					"172.27.0.1:46507",
+					"172.28.0.1:46507"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:18:29.572595367Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4589858193929405,
+				"StableID":   "n86GNvnkqc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:30a2d8497c37a412110d6334b2c9b1ade3a01014f3a04f2b29f1c0781be82d55",
+				"KeyExpiry":  "2026-11-09T09:18:30Z",
+				"DiscoKey":   "discokey:50ffe6a2296a06d0562488d3c1ae7754c33b641f77058c0d48b6f0e1538a0269",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58735",
+					"10.65.0.27:58735",
+					"172.17.0.1:58735",
+					"172.18.0.1:58735",
+					"172.19.0.1:58735",
+					"172.20.0.1:58735",
+					"172.21.0.1:58735",
+					"172.22.0.1:58735",
+					"172.23.0.1:58735",
+					"172.24.0.1:58735",
+					"172.25.0.1:58735",
+					"172.26.0.1:58735",
+					"172.27.0.1:58735",
+					"172.28.0.1:58735"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:18:30.059549244Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         910391420385261,
+				"StableID":   "ntkALTSK7811CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:31746f4776a57d2bbb43ca359e7d10d9f27a8e0496061bbc6de32e449e13867b",
+				"KeyExpiry":  "2026-11-09T09:18:30Z",
+				"DiscoKey":   "discokey:3ce571dfd38f447fbe40480090cfa44d4bbbffa28743b767d7d0c197de23a65a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49501",
+					"10.65.0.27:49501",
+					"172.17.0.1:49501",
+					"172.18.0.1:49501",
+					"172.19.0.1:49501",
+					"172.20.0.1:49501",
+					"172.21.0.1:49501",
+					"172.22.0.1:49501",
+					"172.23.0.1:49501",
+					"172.24.0.1:49501",
+					"172.25.0.1:49501",
+					"172.26.0.1:49501",
+					"172.27.0.1:49501",
+					"172.28.0.1:49501"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:18:30.586131649Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7634452867421641": {
+				"ID":          7634452867421641,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3629659383597747,
+				"StableID":   "nAgYYqzsLV11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       3629659383597747,
+				"Key":        "nodekey:826a2f590555f412bea08e52ef573e5eaeefc23475cda5dbc0dc33407fd51368",
+				"DiscoKey":   "discokey:cfe29272e4f8d6d52e1d6cc80a109cb33332104b72b6be4d16173959c58e2d3a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:42911",
+					"10.65.0.27:42911",
+					"172.17.0.1:42911",
+					"172.18.0.1:42911",
+					"172.19.0.1:42911",
+					"172.20.0.1:42911",
+					"172.21.0.1:42911",
+					"172.22.0.1:42911",
+					"172.23.0.1:42911",
+					"172.24.0.1:42911",
+					"172.25.0.1:42911",
+					"172.26.0.1:42911",
+					"172.27.0.1:42911",
+					"172.28.0.1:42911"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:18:23.064882594Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:826a2f590555f412bea08e52ef573e5eaeefc23475cda5dbc0dc33407fd51368",
+			"MachineKey": "mkey:f3b912c72e9ebeb6324465a9f03b3ed1afd017cadccdafa11672b4a2cb1fb62a",
+			"Peers": [{
+				"ID":         7634452867421641,
+				"StableID":   "nEoRwb8fc221CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd433ce90513732d1a814e056979c959e7c0572fc7f523b5356b9086dda90e6f",
+				"DiscoKey":   "discokey:9f5e41c049b90f62e8c2b7ff30aaba7da14aa336b3f6ca79037752c5e9600874",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43181",
+					"10.65.0.27:43181",
+					"172.17.0.1:43181",
+					"172.18.0.1:43181",
+					"172.19.0.1:43181",
+					"172.20.0.1:43181",
+					"172.21.0.1:43181",
+					"172.22.0.1:43181",
+					"172.23.0.1:43181",
+					"172.24.0.1:43181",
+					"172.25.0.1:43181",
+					"172.26.0.1:43181",
+					"172.27.0.1:43181",
+					"172.28.0.1:43181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:18:23.610236176Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6288708298322901,
+				"StableID":   "nJTsenhA7r11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9574ee86e49d545297709b7d3733d6f96ffe4563e75e41597f917221548c6d09",
+				"DiscoKey":   "discokey:683bd93e93958206447f011fbe123ec261a83ffaf6a3a058f9867fbe9af1ec40",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43316",
+					"10.65.0.27:43316",
+					"172.17.0.1:43316",
+					"172.18.0.1:43316",
+					"172.19.0.1:43316",
+					"172.20.0.1:43316",
+					"172.21.0.1:43316",
+					"172.22.0.1:43316",
+					"172.23.0.1:43316",
+					"172.24.0.1:43316",
+					"172.25.0.1:43316",
+					"172.26.0.1:43316",
+					"172.27.0.1:43316",
+					"172.28.0.1:43316"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:18:24.144090057Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3872101206780,
+				"StableID":   "n9ooKPik2111CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc1c67bf3c3b82002d30abb24af84188710e1bec537d3d8aec1167ccbc474040",
+				"DiscoKey":   "discokey:95e97236e791c770a6fcb06b316c5dcc721ebad3ecd8a393c534f8b5f4082b71",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:52545",
+					"10.65.0.27:52545",
+					"172.17.0.1:52545",
+					"172.18.0.1:52545",
+					"172.19.0.1:52545",
+					"172.20.0.1:52545",
+					"172.21.0.1:52545",
+					"172.22.0.1:52545",
+					"172.23.0.1:52545",
+					"172.24.0.1:52545",
+					"172.25.0.1:52545",
+					"172.26.0.1:52545",
+					"172.27.0.1:52545",
+					"172.28.0.1:52545"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:18:24.679562462Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1351878608113606,
+				"StableID":   "nhksJQZGZB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:632860ce4649a5e7ec6dfb212db5bde87642e475954c87968565670b7e9b6431",
+				"DiscoKey":   "discokey:2e99bf667d271a84d45861465ca6e7ca59f31c555bbd9ae399d13a068b116540",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33481",
+					"10.65.0.27:33481",
+					"172.17.0.1:33481",
+					"172.18.0.1:33481",
+					"172.19.0.1:33481",
+					"172.20.0.1:33481",
+					"172.21.0.1:33481",
+					"172.22.0.1:33481",
+					"172.23.0.1:33481",
+					"172.24.0.1:33481",
+					"172.25.0.1:33481",
+					"172.26.0.1:33481",
+					"172.27.0.1:33481",
+					"172.28.0.1:33481"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:18:25.212870114Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4710579020748619,
+				"StableID":   "neziSYvRnd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6b4e8a634a3026b7bafafb5b30550a77da67edf0fb28baf9dd323b117fc27165",
+				"DiscoKey":   "discokey:bb9dd4a17807d1c1156537152e599056f06445fa54da389634a48a572404685c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42046",
+					"10.65.0.27:42046",
+					"172.17.0.1:42046",
+					"172.18.0.1:42046",
+					"172.19.0.1:42046",
+					"172.20.0.1:42046",
+					"172.21.0.1:42046",
+					"172.22.0.1:42046",
+					"172.23.0.1:42046",
+					"172.24.0.1:42046",
+					"172.25.0.1:42046",
+					"172.26.0.1:42046",
+					"172.27.0.1:42046",
+					"172.28.0.1:42046"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:18:25.753413192Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3703453112569412,
+				"StableID":   "nR3Mg8SJvV11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:00b270a28bef133635425b307228ec0749d00c11255722cc06b9f05abfbe2372",
+				"DiscoKey":   "discokey:643a35b7d9b7d07b748d1b9eddcb6223dee33adfbb95815ea9441e5169d91919",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49879",
+					"10.65.0.27:49879",
+					"172.17.0.1:49879",
+					"172.18.0.1:49879",
+					"172.19.0.1:49879",
+					"172.20.0.1:49879",
+					"172.21.0.1:49879",
+					"172.22.0.1:49879",
+					"172.23.0.1:49879",
+					"172.24.0.1:49879",
+					"172.25.0.1:49879",
+					"172.26.0.1:49879",
+					"172.27.0.1:49879",
+					"172.28.0.1:49879"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:18:26.305678811Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7146136476813947,
+				"StableID":   "nUhMfUtVox11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31c027a88808fbf2e12d20d7339e211908e878abb9f0ed2803e224cca5f17210",
+				"DiscoKey":   "discokey:14492165aef132522938760516d62795a37b46e4b96c98d79d98a04f9d6ff63e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:41689",
+					"10.65.0.27:41689",
+					"172.17.0.1:41689",
+					"172.18.0.1:41689",
+					"172.19.0.1:41689",
+					"172.20.0.1:41689",
+					"172.21.0.1:41689",
+					"172.22.0.1:41689",
+					"172.23.0.1:41689",
+					"172.24.0.1:41689",
+					"172.25.0.1:41689",
+					"172.26.0.1:41689",
+					"172.27.0.1:41689",
+					"172.28.0.1:41689"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:18:26.835487556Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5234182443223358,
+				"StableID":   "nMSjtd6ash11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e9ff37a5bf38f75dbd43a6a05b912542422ecc99a63934300725175b0b556018",
+				"DiscoKey":   "discokey:25b2098902097e8778340a0aea5e195476acc246f89e022f4bb7ca2d6299da49",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38639",
+					"10.65.0.27:38639",
+					"172.17.0.1:38639",
+					"172.18.0.1:38639",
+					"172.19.0.1:38639",
+					"172.20.0.1:38639",
+					"172.21.0.1:38639",
+					"172.22.0.1:38639",
+					"172.23.0.1:38639",
+					"172.24.0.1:38639",
+					"172.25.0.1:38639",
+					"172.26.0.1:38639",
+					"172.27.0.1:38639",
+					"172.28.0.1:38639"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:18:27.413681071Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4277455258369164,
+				"StableID":   "nor2jnVGQa11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3c36636ee28c97a9c6353ec32ec246767d10813a18f68a3bf84df208e5c37263",
+				"DiscoKey":   "discokey:8c04276a99d1cff78d424cc57e20d789b9585852b73bd8e6f18bfc345597622f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40861",
+					"10.65.0.27:40861",
+					"172.17.0.1:40861",
+					"172.18.0.1:40861",
+					"172.19.0.1:40861",
+					"172.20.0.1:40861",
+					"172.21.0.1:40861",
+					"172.22.0.1:40861",
+					"172.23.0.1:40861",
+					"172.24.0.1:40861",
+					"172.25.0.1:40861",
+					"172.26.0.1:40861",
+					"172.27.0.1:40861",
+					"172.28.0.1:40861"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:18:27.90103441Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6210021292995392,
+				"StableID":   "nbghSHjXVq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87128166c893a60ba96b44e59f7fd0d1d139db8efc029d37ad753bc27d01d658",
+				"DiscoKey":   "discokey:e560631cb9b92a8cc999d49c9967f0ef9c0d0207804f37040c24a90cb5566759",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40401",
+					"10.65.0.27:40401",
+					"172.17.0.1:40401",
+					"172.18.0.1:40401",
+					"172.19.0.1:40401",
+					"172.20.0.1:40401",
+					"172.21.0.1:40401",
+					"172.22.0.1:40401",
+					"172.23.0.1:40401",
+					"172.24.0.1:40401",
+					"172.25.0.1:40401",
+					"172.26.0.1:40401",
+					"172.27.0.1:40401",
+					"172.28.0.1:40401"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:18:28.446165874Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7610624439162705,
+				"StableID":   "naP8LXCsR221CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:64323e2acab6388073367f6bf33ca27be3b617808e77f282172e1cfb7288e408",
+				"DiscoKey":   "discokey:8265adf738a508dd79d5594c9051086e367f735e364a9b0f8b07444ab4837a23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47593",
+					"10.65.0.27:47593",
+					"172.17.0.1:47593",
+					"172.18.0.1:47593",
+					"172.19.0.1:47593",
+					"172.20.0.1:47593",
+					"172.21.0.1:47593",
+					"172.22.0.1:47593",
+					"172.23.0.1:47593",
+					"172.24.0.1:47593",
+					"172.25.0.1:47593",
+					"172.26.0.1:47593",
+					"172.27.0.1:47593",
+					"172.28.0.1:47593"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:18:28.975436501Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         171923215953612,
+				"StableID":   "nZ7Vsc8sL211CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5613b48ea96ace9530f814555295e862a446e2369dd1ad56d065dbe8683d892e",
+				"KeyExpiry":  "2026-11-09T09:18:29Z",
+				"DiscoKey":   "discokey:0a359bd65f92d91db2039f94d50db21d0674d16f2743adfba2cf07a5b9534135",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46507",
+					"10.65.0.27:46507",
+					"172.17.0.1:46507",
+					"172.18.0.1:46507",
+					"172.19.0.1:46507",
+					"172.20.0.1:46507",
+					"172.21.0.1:46507",
+					"172.22.0.1:46507",
+					"172.23.0.1:46507",
+					"172.24.0.1:46507",
+					"172.25.0.1:46507",
+					"172.26.0.1:46507",
+					"172.27.0.1:46507",
+					"172.28.0.1:46507"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:18:29.572595367Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4589858193929405,
+				"StableID":   "n86GNvnkqc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:30a2d8497c37a412110d6334b2c9b1ade3a01014f3a04f2b29f1c0781be82d55",
+				"KeyExpiry":  "2026-11-09T09:18:30Z",
+				"DiscoKey":   "discokey:50ffe6a2296a06d0562488d3c1ae7754c33b641f77058c0d48b6f0e1538a0269",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58735",
+					"10.65.0.27:58735",
+					"172.17.0.1:58735",
+					"172.18.0.1:58735",
+					"172.19.0.1:58735",
+					"172.20.0.1:58735",
+					"172.21.0.1:58735",
+					"172.22.0.1:58735",
+					"172.23.0.1:58735",
+					"172.24.0.1:58735",
+					"172.25.0.1:58735",
+					"172.26.0.1:58735",
+					"172.27.0.1:58735",
+					"172.28.0.1:58735"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:18:30.059549244Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         910391420385261,
+				"StableID":   "ntkALTSK7811CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:31746f4776a57d2bbb43ca359e7d10d9f27a8e0496061bbc6de32e449e13867b",
+				"KeyExpiry":  "2026-11-09T09:18:30Z",
+				"DiscoKey":   "discokey:3ce571dfd38f447fbe40480090cfa44d4bbbffa28743b767d7d0c197de23a65a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49501",
+					"10.65.0.27:49501",
+					"172.17.0.1:49501",
+					"172.18.0.1:49501",
+					"172.19.0.1:49501",
+					"172.20.0.1:49501",
+					"172.21.0.1:49501",
+					"172.22.0.1:49501",
+					"172.23.0.1:49501",
+					"172.24.0.1:49501",
+					"172.25.0.1:49501",
+					"172.26.0.1:49501",
+					"172.27.0.1:49501",
+					"172.28.0.1:49501"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:18:30.586131649Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3629659383597747": {
+				"ID":          3629659383597747,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1351878608113606,
+				"StableID":   "nhksJQZGZB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1351878608113606,
+				"Key":        "nodekey:632860ce4649a5e7ec6dfb212db5bde87642e475954c87968565670b7e9b6431",
+				"DiscoKey":   "discokey:2e99bf667d271a84d45861465ca6e7ca59f31c555bbd9ae399d13a068b116540",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33481",
+					"10.65.0.27:33481",
+					"172.17.0.1:33481",
+					"172.18.0.1:33481",
+					"172.19.0.1:33481",
+					"172.20.0.1:33481",
+					"172.21.0.1:33481",
+					"172.22.0.1:33481",
+					"172.23.0.1:33481",
+					"172.24.0.1:33481",
+					"172.25.0.1:33481",
+					"172.26.0.1:33481",
+					"172.27.0.1:33481",
+					"172.28.0.1:33481"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:18:25.212870114Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:632860ce4649a5e7ec6dfb212db5bde87642e475954c87968565670b7e9b6431",
+			"MachineKey": "mkey:0f3352e1e14a6e2ad68260cac83d6fd82e288a91c0134c0a0ab780b3ffbe3035",
+			"Peers": [{
+				"ID":         3629659383597747,
+				"StableID":   "nAgYYqzsLV11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:826a2f590555f412bea08e52ef573e5eaeefc23475cda5dbc0dc33407fd51368",
+				"DiscoKey":   "discokey:cfe29272e4f8d6d52e1d6cc80a109cb33332104b72b6be4d16173959c58e2d3a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:42911",
+					"10.65.0.27:42911",
+					"172.17.0.1:42911",
+					"172.18.0.1:42911",
+					"172.19.0.1:42911",
+					"172.20.0.1:42911",
+					"172.21.0.1:42911",
+					"172.22.0.1:42911",
+					"172.23.0.1:42911",
+					"172.24.0.1:42911",
+					"172.25.0.1:42911",
+					"172.26.0.1:42911",
+					"172.27.0.1:42911",
+					"172.28.0.1:42911"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:18:23.064882594Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7634452867421641,
+				"StableID":   "nEoRwb8fc221CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd433ce90513732d1a814e056979c959e7c0572fc7f523b5356b9086dda90e6f",
+				"DiscoKey":   "discokey:9f5e41c049b90f62e8c2b7ff30aaba7da14aa336b3f6ca79037752c5e9600874",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43181",
+					"10.65.0.27:43181",
+					"172.17.0.1:43181",
+					"172.18.0.1:43181",
+					"172.19.0.1:43181",
+					"172.20.0.1:43181",
+					"172.21.0.1:43181",
+					"172.22.0.1:43181",
+					"172.23.0.1:43181",
+					"172.24.0.1:43181",
+					"172.25.0.1:43181",
+					"172.26.0.1:43181",
+					"172.27.0.1:43181",
+					"172.28.0.1:43181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:18:23.610236176Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6288708298322901,
+				"StableID":   "nJTsenhA7r11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9574ee86e49d545297709b7d3733d6f96ffe4563e75e41597f917221548c6d09",
+				"DiscoKey":   "discokey:683bd93e93958206447f011fbe123ec261a83ffaf6a3a058f9867fbe9af1ec40",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43316",
+					"10.65.0.27:43316",
+					"172.17.0.1:43316",
+					"172.18.0.1:43316",
+					"172.19.0.1:43316",
+					"172.20.0.1:43316",
+					"172.21.0.1:43316",
+					"172.22.0.1:43316",
+					"172.23.0.1:43316",
+					"172.24.0.1:43316",
+					"172.25.0.1:43316",
+					"172.26.0.1:43316",
+					"172.27.0.1:43316",
+					"172.28.0.1:43316"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:18:24.144090057Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3872101206780,
+				"StableID":   "n9ooKPik2111CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc1c67bf3c3b82002d30abb24af84188710e1bec537d3d8aec1167ccbc474040",
+				"DiscoKey":   "discokey:95e97236e791c770a6fcb06b316c5dcc721ebad3ecd8a393c534f8b5f4082b71",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:52545",
+					"10.65.0.27:52545",
+					"172.17.0.1:52545",
+					"172.18.0.1:52545",
+					"172.19.0.1:52545",
+					"172.20.0.1:52545",
+					"172.21.0.1:52545",
+					"172.22.0.1:52545",
+					"172.23.0.1:52545",
+					"172.24.0.1:52545",
+					"172.25.0.1:52545",
+					"172.26.0.1:52545",
+					"172.27.0.1:52545",
+					"172.28.0.1:52545"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:18:24.679562462Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4710579020748619,
+				"StableID":   "neziSYvRnd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6b4e8a634a3026b7bafafb5b30550a77da67edf0fb28baf9dd323b117fc27165",
+				"DiscoKey":   "discokey:bb9dd4a17807d1c1156537152e599056f06445fa54da389634a48a572404685c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42046",
+					"10.65.0.27:42046",
+					"172.17.0.1:42046",
+					"172.18.0.1:42046",
+					"172.19.0.1:42046",
+					"172.20.0.1:42046",
+					"172.21.0.1:42046",
+					"172.22.0.1:42046",
+					"172.23.0.1:42046",
+					"172.24.0.1:42046",
+					"172.25.0.1:42046",
+					"172.26.0.1:42046",
+					"172.27.0.1:42046",
+					"172.28.0.1:42046"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:18:25.753413192Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3703453112569412,
+				"StableID":   "nR3Mg8SJvV11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:00b270a28bef133635425b307228ec0749d00c11255722cc06b9f05abfbe2372",
+				"DiscoKey":   "discokey:643a35b7d9b7d07b748d1b9eddcb6223dee33adfbb95815ea9441e5169d91919",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49879",
+					"10.65.0.27:49879",
+					"172.17.0.1:49879",
+					"172.18.0.1:49879",
+					"172.19.0.1:49879",
+					"172.20.0.1:49879",
+					"172.21.0.1:49879",
+					"172.22.0.1:49879",
+					"172.23.0.1:49879",
+					"172.24.0.1:49879",
+					"172.25.0.1:49879",
+					"172.26.0.1:49879",
+					"172.27.0.1:49879",
+					"172.28.0.1:49879"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:18:26.305678811Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7146136476813947,
+				"StableID":   "nUhMfUtVox11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31c027a88808fbf2e12d20d7339e211908e878abb9f0ed2803e224cca5f17210",
+				"DiscoKey":   "discokey:14492165aef132522938760516d62795a37b46e4b96c98d79d98a04f9d6ff63e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:41689",
+					"10.65.0.27:41689",
+					"172.17.0.1:41689",
+					"172.18.0.1:41689",
+					"172.19.0.1:41689",
+					"172.20.0.1:41689",
+					"172.21.0.1:41689",
+					"172.22.0.1:41689",
+					"172.23.0.1:41689",
+					"172.24.0.1:41689",
+					"172.25.0.1:41689",
+					"172.26.0.1:41689",
+					"172.27.0.1:41689",
+					"172.28.0.1:41689"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:18:26.835487556Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5234182443223358,
+				"StableID":   "nMSjtd6ash11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e9ff37a5bf38f75dbd43a6a05b912542422ecc99a63934300725175b0b556018",
+				"DiscoKey":   "discokey:25b2098902097e8778340a0aea5e195476acc246f89e022f4bb7ca2d6299da49",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38639",
+					"10.65.0.27:38639",
+					"172.17.0.1:38639",
+					"172.18.0.1:38639",
+					"172.19.0.1:38639",
+					"172.20.0.1:38639",
+					"172.21.0.1:38639",
+					"172.22.0.1:38639",
+					"172.23.0.1:38639",
+					"172.24.0.1:38639",
+					"172.25.0.1:38639",
+					"172.26.0.1:38639",
+					"172.27.0.1:38639",
+					"172.28.0.1:38639"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:18:27.413681071Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4277455258369164,
+				"StableID":   "nor2jnVGQa11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3c36636ee28c97a9c6353ec32ec246767d10813a18f68a3bf84df208e5c37263",
+				"DiscoKey":   "discokey:8c04276a99d1cff78d424cc57e20d789b9585852b73bd8e6f18bfc345597622f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40861",
+					"10.65.0.27:40861",
+					"172.17.0.1:40861",
+					"172.18.0.1:40861",
+					"172.19.0.1:40861",
+					"172.20.0.1:40861",
+					"172.21.0.1:40861",
+					"172.22.0.1:40861",
+					"172.23.0.1:40861",
+					"172.24.0.1:40861",
+					"172.25.0.1:40861",
+					"172.26.0.1:40861",
+					"172.27.0.1:40861",
+					"172.28.0.1:40861"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:18:27.90103441Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6210021292995392,
+				"StableID":   "nbghSHjXVq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87128166c893a60ba96b44e59f7fd0d1d139db8efc029d37ad753bc27d01d658",
+				"DiscoKey":   "discokey:e560631cb9b92a8cc999d49c9967f0ef9c0d0207804f37040c24a90cb5566759",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40401",
+					"10.65.0.27:40401",
+					"172.17.0.1:40401",
+					"172.18.0.1:40401",
+					"172.19.0.1:40401",
+					"172.20.0.1:40401",
+					"172.21.0.1:40401",
+					"172.22.0.1:40401",
+					"172.23.0.1:40401",
+					"172.24.0.1:40401",
+					"172.25.0.1:40401",
+					"172.26.0.1:40401",
+					"172.27.0.1:40401",
+					"172.28.0.1:40401"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:18:28.446165874Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7610624439162705,
+				"StableID":   "naP8LXCsR221CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:64323e2acab6388073367f6bf33ca27be3b617808e77f282172e1cfb7288e408",
+				"DiscoKey":   "discokey:8265adf738a508dd79d5594c9051086e367f735e364a9b0f8b07444ab4837a23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47593",
+					"10.65.0.27:47593",
+					"172.17.0.1:47593",
+					"172.18.0.1:47593",
+					"172.19.0.1:47593",
+					"172.20.0.1:47593",
+					"172.21.0.1:47593",
+					"172.22.0.1:47593",
+					"172.23.0.1:47593",
+					"172.24.0.1:47593",
+					"172.25.0.1:47593",
+					"172.26.0.1:47593",
+					"172.27.0.1:47593",
+					"172.28.0.1:47593"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:18:28.975436501Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         171923215953612,
+				"StableID":   "nZ7Vsc8sL211CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5613b48ea96ace9530f814555295e862a446e2369dd1ad56d065dbe8683d892e",
+				"KeyExpiry":  "2026-11-09T09:18:29Z",
+				"DiscoKey":   "discokey:0a359bd65f92d91db2039f94d50db21d0674d16f2743adfba2cf07a5b9534135",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46507",
+					"10.65.0.27:46507",
+					"172.17.0.1:46507",
+					"172.18.0.1:46507",
+					"172.19.0.1:46507",
+					"172.20.0.1:46507",
+					"172.21.0.1:46507",
+					"172.22.0.1:46507",
+					"172.23.0.1:46507",
+					"172.24.0.1:46507",
+					"172.25.0.1:46507",
+					"172.26.0.1:46507",
+					"172.27.0.1:46507",
+					"172.28.0.1:46507"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:18:29.572595367Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4589858193929405,
+				"StableID":   "n86GNvnkqc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:30a2d8497c37a412110d6334b2c9b1ade3a01014f3a04f2b29f1c0781be82d55",
+				"KeyExpiry":  "2026-11-09T09:18:30Z",
+				"DiscoKey":   "discokey:50ffe6a2296a06d0562488d3c1ae7754c33b641f77058c0d48b6f0e1538a0269",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58735",
+					"10.65.0.27:58735",
+					"172.17.0.1:58735",
+					"172.18.0.1:58735",
+					"172.19.0.1:58735",
+					"172.20.0.1:58735",
+					"172.21.0.1:58735",
+					"172.22.0.1:58735",
+					"172.23.0.1:58735",
+					"172.24.0.1:58735",
+					"172.25.0.1:58735",
+					"172.26.0.1:58735",
+					"172.27.0.1:58735",
+					"172.28.0.1:58735"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:18:30.059549244Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         910391420385261,
+				"StableID":   "ntkALTSK7811CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:31746f4776a57d2bbb43ca359e7d10d9f27a8e0496061bbc6de32e449e13867b",
+				"KeyExpiry":  "2026-11-09T09:18:30Z",
+				"DiscoKey":   "discokey:3ce571dfd38f447fbe40480090cfa44d4bbbffa28743b767d7d0c197de23a65a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49501",
+					"10.65.0.27:49501",
+					"172.17.0.1:49501",
+					"172.18.0.1:49501",
+					"172.19.0.1:49501",
+					"172.20.0.1:49501",
+					"172.21.0.1:49501",
+					"172.22.0.1:49501",
+					"172.23.0.1:49501",
+					"172.24.0.1:49501",
+					"172.25.0.1:49501",
+					"172.26.0.1:49501",
+					"172.27.0.1:49501",
+					"172.28.0.1:49501"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:18:30.586131649Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1351878608113606": {
+				"ID":          1351878608113606,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3872101206780,
+				"StableID":   "n9ooKPik2111CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       3872101206780,
+				"Key":        "nodekey:dc1c67bf3c3b82002d30abb24af84188710e1bec537d3d8aec1167ccbc474040",
+				"DiscoKey":   "discokey:95e97236e791c770a6fcb06b316c5dcc721ebad3ecd8a393c534f8b5f4082b71",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:52545",
+					"10.65.0.27:52545",
+					"172.17.0.1:52545",
+					"172.18.0.1:52545",
+					"172.19.0.1:52545",
+					"172.20.0.1:52545",
+					"172.21.0.1:52545",
+					"172.22.0.1:52545",
+					"172.23.0.1:52545",
+					"172.24.0.1:52545",
+					"172.25.0.1:52545",
+					"172.26.0.1:52545",
+					"172.27.0.1:52545",
+					"172.28.0.1:52545"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:18:24.679562462Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:dc1c67bf3c3b82002d30abb24af84188710e1bec537d3d8aec1167ccbc474040",
+			"MachineKey": "mkey:3b7062f50cfd05e8a36751e172fd13682125015bf9b0b96ccfe77c30913b6b6a",
+			"Peers": [{
+				"ID":         3629659383597747,
+				"StableID":   "nAgYYqzsLV11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:826a2f590555f412bea08e52ef573e5eaeefc23475cda5dbc0dc33407fd51368",
+				"DiscoKey":   "discokey:cfe29272e4f8d6d52e1d6cc80a109cb33332104b72b6be4d16173959c58e2d3a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:42911",
+					"10.65.0.27:42911",
+					"172.17.0.1:42911",
+					"172.18.0.1:42911",
+					"172.19.0.1:42911",
+					"172.20.0.1:42911",
+					"172.21.0.1:42911",
+					"172.22.0.1:42911",
+					"172.23.0.1:42911",
+					"172.24.0.1:42911",
+					"172.25.0.1:42911",
+					"172.26.0.1:42911",
+					"172.27.0.1:42911",
+					"172.28.0.1:42911"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:18:23.064882594Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7634452867421641,
+				"StableID":   "nEoRwb8fc221CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd433ce90513732d1a814e056979c959e7c0572fc7f523b5356b9086dda90e6f",
+				"DiscoKey":   "discokey:9f5e41c049b90f62e8c2b7ff30aaba7da14aa336b3f6ca79037752c5e9600874",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43181",
+					"10.65.0.27:43181",
+					"172.17.0.1:43181",
+					"172.18.0.1:43181",
+					"172.19.0.1:43181",
+					"172.20.0.1:43181",
+					"172.21.0.1:43181",
+					"172.22.0.1:43181",
+					"172.23.0.1:43181",
+					"172.24.0.1:43181",
+					"172.25.0.1:43181",
+					"172.26.0.1:43181",
+					"172.27.0.1:43181",
+					"172.28.0.1:43181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:18:23.610236176Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6288708298322901,
+				"StableID":   "nJTsenhA7r11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9574ee86e49d545297709b7d3733d6f96ffe4563e75e41597f917221548c6d09",
+				"DiscoKey":   "discokey:683bd93e93958206447f011fbe123ec261a83ffaf6a3a058f9867fbe9af1ec40",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43316",
+					"10.65.0.27:43316",
+					"172.17.0.1:43316",
+					"172.18.0.1:43316",
+					"172.19.0.1:43316",
+					"172.20.0.1:43316",
+					"172.21.0.1:43316",
+					"172.22.0.1:43316",
+					"172.23.0.1:43316",
+					"172.24.0.1:43316",
+					"172.25.0.1:43316",
+					"172.26.0.1:43316",
+					"172.27.0.1:43316",
+					"172.28.0.1:43316"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:18:24.144090057Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1351878608113606,
+				"StableID":   "nhksJQZGZB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:632860ce4649a5e7ec6dfb212db5bde87642e475954c87968565670b7e9b6431",
+				"DiscoKey":   "discokey:2e99bf667d271a84d45861465ca6e7ca59f31c555bbd9ae399d13a068b116540",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33481",
+					"10.65.0.27:33481",
+					"172.17.0.1:33481",
+					"172.18.0.1:33481",
+					"172.19.0.1:33481",
+					"172.20.0.1:33481",
+					"172.21.0.1:33481",
+					"172.22.0.1:33481",
+					"172.23.0.1:33481",
+					"172.24.0.1:33481",
+					"172.25.0.1:33481",
+					"172.26.0.1:33481",
+					"172.27.0.1:33481",
+					"172.28.0.1:33481"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:18:25.212870114Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4710579020748619,
+				"StableID":   "neziSYvRnd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6b4e8a634a3026b7bafafb5b30550a77da67edf0fb28baf9dd323b117fc27165",
+				"DiscoKey":   "discokey:bb9dd4a17807d1c1156537152e599056f06445fa54da389634a48a572404685c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42046",
+					"10.65.0.27:42046",
+					"172.17.0.1:42046",
+					"172.18.0.1:42046",
+					"172.19.0.1:42046",
+					"172.20.0.1:42046",
+					"172.21.0.1:42046",
+					"172.22.0.1:42046",
+					"172.23.0.1:42046",
+					"172.24.0.1:42046",
+					"172.25.0.1:42046",
+					"172.26.0.1:42046",
+					"172.27.0.1:42046",
+					"172.28.0.1:42046"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:18:25.753413192Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3703453112569412,
+				"StableID":   "nR3Mg8SJvV11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:00b270a28bef133635425b307228ec0749d00c11255722cc06b9f05abfbe2372",
+				"DiscoKey":   "discokey:643a35b7d9b7d07b748d1b9eddcb6223dee33adfbb95815ea9441e5169d91919",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49879",
+					"10.65.0.27:49879",
+					"172.17.0.1:49879",
+					"172.18.0.1:49879",
+					"172.19.0.1:49879",
+					"172.20.0.1:49879",
+					"172.21.0.1:49879",
+					"172.22.0.1:49879",
+					"172.23.0.1:49879",
+					"172.24.0.1:49879",
+					"172.25.0.1:49879",
+					"172.26.0.1:49879",
+					"172.27.0.1:49879",
+					"172.28.0.1:49879"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:18:26.305678811Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7146136476813947,
+				"StableID":   "nUhMfUtVox11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31c027a88808fbf2e12d20d7339e211908e878abb9f0ed2803e224cca5f17210",
+				"DiscoKey":   "discokey:14492165aef132522938760516d62795a37b46e4b96c98d79d98a04f9d6ff63e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:41689",
+					"10.65.0.27:41689",
+					"172.17.0.1:41689",
+					"172.18.0.1:41689",
+					"172.19.0.1:41689",
+					"172.20.0.1:41689",
+					"172.21.0.1:41689",
+					"172.22.0.1:41689",
+					"172.23.0.1:41689",
+					"172.24.0.1:41689",
+					"172.25.0.1:41689",
+					"172.26.0.1:41689",
+					"172.27.0.1:41689",
+					"172.28.0.1:41689"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:18:26.835487556Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5234182443223358,
+				"StableID":   "nMSjtd6ash11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e9ff37a5bf38f75dbd43a6a05b912542422ecc99a63934300725175b0b556018",
+				"DiscoKey":   "discokey:25b2098902097e8778340a0aea5e195476acc246f89e022f4bb7ca2d6299da49",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38639",
+					"10.65.0.27:38639",
+					"172.17.0.1:38639",
+					"172.18.0.1:38639",
+					"172.19.0.1:38639",
+					"172.20.0.1:38639",
+					"172.21.0.1:38639",
+					"172.22.0.1:38639",
+					"172.23.0.1:38639",
+					"172.24.0.1:38639",
+					"172.25.0.1:38639",
+					"172.26.0.1:38639",
+					"172.27.0.1:38639",
+					"172.28.0.1:38639"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:18:27.413681071Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4277455258369164,
+				"StableID":   "nor2jnVGQa11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3c36636ee28c97a9c6353ec32ec246767d10813a18f68a3bf84df208e5c37263",
+				"DiscoKey":   "discokey:8c04276a99d1cff78d424cc57e20d789b9585852b73bd8e6f18bfc345597622f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40861",
+					"10.65.0.27:40861",
+					"172.17.0.1:40861",
+					"172.18.0.1:40861",
+					"172.19.0.1:40861",
+					"172.20.0.1:40861",
+					"172.21.0.1:40861",
+					"172.22.0.1:40861",
+					"172.23.0.1:40861",
+					"172.24.0.1:40861",
+					"172.25.0.1:40861",
+					"172.26.0.1:40861",
+					"172.27.0.1:40861",
+					"172.28.0.1:40861"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:18:27.90103441Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6210021292995392,
+				"StableID":   "nbghSHjXVq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87128166c893a60ba96b44e59f7fd0d1d139db8efc029d37ad753bc27d01d658",
+				"DiscoKey":   "discokey:e560631cb9b92a8cc999d49c9967f0ef9c0d0207804f37040c24a90cb5566759",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40401",
+					"10.65.0.27:40401",
+					"172.17.0.1:40401",
+					"172.18.0.1:40401",
+					"172.19.0.1:40401",
+					"172.20.0.1:40401",
+					"172.21.0.1:40401",
+					"172.22.0.1:40401",
+					"172.23.0.1:40401",
+					"172.24.0.1:40401",
+					"172.25.0.1:40401",
+					"172.26.0.1:40401",
+					"172.27.0.1:40401",
+					"172.28.0.1:40401"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:18:28.446165874Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7610624439162705,
+				"StableID":   "naP8LXCsR221CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:64323e2acab6388073367f6bf33ca27be3b617808e77f282172e1cfb7288e408",
+				"DiscoKey":   "discokey:8265adf738a508dd79d5594c9051086e367f735e364a9b0f8b07444ab4837a23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47593",
+					"10.65.0.27:47593",
+					"172.17.0.1:47593",
+					"172.18.0.1:47593",
+					"172.19.0.1:47593",
+					"172.20.0.1:47593",
+					"172.21.0.1:47593",
+					"172.22.0.1:47593",
+					"172.23.0.1:47593",
+					"172.24.0.1:47593",
+					"172.25.0.1:47593",
+					"172.26.0.1:47593",
+					"172.27.0.1:47593",
+					"172.28.0.1:47593"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:18:28.975436501Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         171923215953612,
+				"StableID":   "nZ7Vsc8sL211CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5613b48ea96ace9530f814555295e862a446e2369dd1ad56d065dbe8683d892e",
+				"KeyExpiry":  "2026-11-09T09:18:29Z",
+				"DiscoKey":   "discokey:0a359bd65f92d91db2039f94d50db21d0674d16f2743adfba2cf07a5b9534135",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46507",
+					"10.65.0.27:46507",
+					"172.17.0.1:46507",
+					"172.18.0.1:46507",
+					"172.19.0.1:46507",
+					"172.20.0.1:46507",
+					"172.21.0.1:46507",
+					"172.22.0.1:46507",
+					"172.23.0.1:46507",
+					"172.24.0.1:46507",
+					"172.25.0.1:46507",
+					"172.26.0.1:46507",
+					"172.27.0.1:46507",
+					"172.28.0.1:46507"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:18:29.572595367Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4589858193929405,
+				"StableID":   "n86GNvnkqc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:30a2d8497c37a412110d6334b2c9b1ade3a01014f3a04f2b29f1c0781be82d55",
+				"KeyExpiry":  "2026-11-09T09:18:30Z",
+				"DiscoKey":   "discokey:50ffe6a2296a06d0562488d3c1ae7754c33b641f77058c0d48b6f0e1538a0269",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58735",
+					"10.65.0.27:58735",
+					"172.17.0.1:58735",
+					"172.18.0.1:58735",
+					"172.19.0.1:58735",
+					"172.20.0.1:58735",
+					"172.21.0.1:58735",
+					"172.22.0.1:58735",
+					"172.23.0.1:58735",
+					"172.24.0.1:58735",
+					"172.25.0.1:58735",
+					"172.26.0.1:58735",
+					"172.27.0.1:58735",
+					"172.28.0.1:58735"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:18:30.059549244Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         910391420385261,
+				"StableID":   "ntkALTSK7811CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:31746f4776a57d2bbb43ca359e7d10d9f27a8e0496061bbc6de32e449e13867b",
+				"KeyExpiry":  "2026-11-09T09:18:30Z",
+				"DiscoKey":   "discokey:3ce571dfd38f447fbe40480090cfa44d4bbbffa28743b767d7d0c197de23a65a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49501",
+					"10.65.0.27:49501",
+					"172.17.0.1:49501",
+					"172.18.0.1:49501",
+					"172.19.0.1:49501",
+					"172.20.0.1:49501",
+					"172.21.0.1:49501",
+					"172.22.0.1:49501",
+					"172.23.0.1:49501",
+					"172.24.0.1:49501",
+					"172.25.0.1:49501",
+					"172.26.0.1:49501",
+					"172.27.0.1:49501",
+					"172.28.0.1:49501"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:18:30.586131649Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3872101206780": {
+				"ID":          3872101206780,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3703453112569412,
+				"StableID":   "nR3Mg8SJvV11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       3703453112569412,
+				"Key":        "nodekey:00b270a28bef133635425b307228ec0749d00c11255722cc06b9f05abfbe2372",
+				"DiscoKey":   "discokey:643a35b7d9b7d07b748d1b9eddcb6223dee33adfbb95815ea9441e5169d91919",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49879",
+					"10.65.0.27:49879",
+					"172.17.0.1:49879",
+					"172.18.0.1:49879",
+					"172.19.0.1:49879",
+					"172.20.0.1:49879",
+					"172.21.0.1:49879",
+					"172.22.0.1:49879",
+					"172.23.0.1:49879",
+					"172.24.0.1:49879",
+					"172.25.0.1:49879",
+					"172.26.0.1:49879",
+					"172.27.0.1:49879",
+					"172.28.0.1:49879"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:18:26.305678811Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:00b270a28bef133635425b307228ec0749d00c11255722cc06b9f05abfbe2372",
+			"MachineKey": "mkey:64d439345dea3e9b10a8746b2707f3056a99885451194fddbe07772cfa49640b",
+			"Peers": [{
+				"ID":         3629659383597747,
+				"StableID":   "nAgYYqzsLV11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:826a2f590555f412bea08e52ef573e5eaeefc23475cda5dbc0dc33407fd51368",
+				"DiscoKey":   "discokey:cfe29272e4f8d6d52e1d6cc80a109cb33332104b72b6be4d16173959c58e2d3a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:42911",
+					"10.65.0.27:42911",
+					"172.17.0.1:42911",
+					"172.18.0.1:42911",
+					"172.19.0.1:42911",
+					"172.20.0.1:42911",
+					"172.21.0.1:42911",
+					"172.22.0.1:42911",
+					"172.23.0.1:42911",
+					"172.24.0.1:42911",
+					"172.25.0.1:42911",
+					"172.26.0.1:42911",
+					"172.27.0.1:42911",
+					"172.28.0.1:42911"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:18:23.064882594Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7634452867421641,
+				"StableID":   "nEoRwb8fc221CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd433ce90513732d1a814e056979c959e7c0572fc7f523b5356b9086dda90e6f",
+				"DiscoKey":   "discokey:9f5e41c049b90f62e8c2b7ff30aaba7da14aa336b3f6ca79037752c5e9600874",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43181",
+					"10.65.0.27:43181",
+					"172.17.0.1:43181",
+					"172.18.0.1:43181",
+					"172.19.0.1:43181",
+					"172.20.0.1:43181",
+					"172.21.0.1:43181",
+					"172.22.0.1:43181",
+					"172.23.0.1:43181",
+					"172.24.0.1:43181",
+					"172.25.0.1:43181",
+					"172.26.0.1:43181",
+					"172.27.0.1:43181",
+					"172.28.0.1:43181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:18:23.610236176Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6288708298322901,
+				"StableID":   "nJTsenhA7r11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9574ee86e49d545297709b7d3733d6f96ffe4563e75e41597f917221548c6d09",
+				"DiscoKey":   "discokey:683bd93e93958206447f011fbe123ec261a83ffaf6a3a058f9867fbe9af1ec40",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43316",
+					"10.65.0.27:43316",
+					"172.17.0.1:43316",
+					"172.18.0.1:43316",
+					"172.19.0.1:43316",
+					"172.20.0.1:43316",
+					"172.21.0.1:43316",
+					"172.22.0.1:43316",
+					"172.23.0.1:43316",
+					"172.24.0.1:43316",
+					"172.25.0.1:43316",
+					"172.26.0.1:43316",
+					"172.27.0.1:43316",
+					"172.28.0.1:43316"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:18:24.144090057Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3872101206780,
+				"StableID":   "n9ooKPik2111CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc1c67bf3c3b82002d30abb24af84188710e1bec537d3d8aec1167ccbc474040",
+				"DiscoKey":   "discokey:95e97236e791c770a6fcb06b316c5dcc721ebad3ecd8a393c534f8b5f4082b71",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:52545",
+					"10.65.0.27:52545",
+					"172.17.0.1:52545",
+					"172.18.0.1:52545",
+					"172.19.0.1:52545",
+					"172.20.0.1:52545",
+					"172.21.0.1:52545",
+					"172.22.0.1:52545",
+					"172.23.0.1:52545",
+					"172.24.0.1:52545",
+					"172.25.0.1:52545",
+					"172.26.0.1:52545",
+					"172.27.0.1:52545",
+					"172.28.0.1:52545"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:18:24.679562462Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1351878608113606,
+				"StableID":   "nhksJQZGZB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:632860ce4649a5e7ec6dfb212db5bde87642e475954c87968565670b7e9b6431",
+				"DiscoKey":   "discokey:2e99bf667d271a84d45861465ca6e7ca59f31c555bbd9ae399d13a068b116540",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33481",
+					"10.65.0.27:33481",
+					"172.17.0.1:33481",
+					"172.18.0.1:33481",
+					"172.19.0.1:33481",
+					"172.20.0.1:33481",
+					"172.21.0.1:33481",
+					"172.22.0.1:33481",
+					"172.23.0.1:33481",
+					"172.24.0.1:33481",
+					"172.25.0.1:33481",
+					"172.26.0.1:33481",
+					"172.27.0.1:33481",
+					"172.28.0.1:33481"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:18:25.212870114Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4710579020748619,
+				"StableID":   "neziSYvRnd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6b4e8a634a3026b7bafafb5b30550a77da67edf0fb28baf9dd323b117fc27165",
+				"DiscoKey":   "discokey:bb9dd4a17807d1c1156537152e599056f06445fa54da389634a48a572404685c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42046",
+					"10.65.0.27:42046",
+					"172.17.0.1:42046",
+					"172.18.0.1:42046",
+					"172.19.0.1:42046",
+					"172.20.0.1:42046",
+					"172.21.0.1:42046",
+					"172.22.0.1:42046",
+					"172.23.0.1:42046",
+					"172.24.0.1:42046",
+					"172.25.0.1:42046",
+					"172.26.0.1:42046",
+					"172.27.0.1:42046",
+					"172.28.0.1:42046"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:18:25.753413192Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7146136476813947,
+				"StableID":   "nUhMfUtVox11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31c027a88808fbf2e12d20d7339e211908e878abb9f0ed2803e224cca5f17210",
+				"DiscoKey":   "discokey:14492165aef132522938760516d62795a37b46e4b96c98d79d98a04f9d6ff63e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:41689",
+					"10.65.0.27:41689",
+					"172.17.0.1:41689",
+					"172.18.0.1:41689",
+					"172.19.0.1:41689",
+					"172.20.0.1:41689",
+					"172.21.0.1:41689",
+					"172.22.0.1:41689",
+					"172.23.0.1:41689",
+					"172.24.0.1:41689",
+					"172.25.0.1:41689",
+					"172.26.0.1:41689",
+					"172.27.0.1:41689",
+					"172.28.0.1:41689"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:18:26.835487556Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5234182443223358,
+				"StableID":   "nMSjtd6ash11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e9ff37a5bf38f75dbd43a6a05b912542422ecc99a63934300725175b0b556018",
+				"DiscoKey":   "discokey:25b2098902097e8778340a0aea5e195476acc246f89e022f4bb7ca2d6299da49",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38639",
+					"10.65.0.27:38639",
+					"172.17.0.1:38639",
+					"172.18.0.1:38639",
+					"172.19.0.1:38639",
+					"172.20.0.1:38639",
+					"172.21.0.1:38639",
+					"172.22.0.1:38639",
+					"172.23.0.1:38639",
+					"172.24.0.1:38639",
+					"172.25.0.1:38639",
+					"172.26.0.1:38639",
+					"172.27.0.1:38639",
+					"172.28.0.1:38639"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:18:27.413681071Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4277455258369164,
+				"StableID":   "nor2jnVGQa11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3c36636ee28c97a9c6353ec32ec246767d10813a18f68a3bf84df208e5c37263",
+				"DiscoKey":   "discokey:8c04276a99d1cff78d424cc57e20d789b9585852b73bd8e6f18bfc345597622f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40861",
+					"10.65.0.27:40861",
+					"172.17.0.1:40861",
+					"172.18.0.1:40861",
+					"172.19.0.1:40861",
+					"172.20.0.1:40861",
+					"172.21.0.1:40861",
+					"172.22.0.1:40861",
+					"172.23.0.1:40861",
+					"172.24.0.1:40861",
+					"172.25.0.1:40861",
+					"172.26.0.1:40861",
+					"172.27.0.1:40861",
+					"172.28.0.1:40861"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:18:27.90103441Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6210021292995392,
+				"StableID":   "nbghSHjXVq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87128166c893a60ba96b44e59f7fd0d1d139db8efc029d37ad753bc27d01d658",
+				"DiscoKey":   "discokey:e560631cb9b92a8cc999d49c9967f0ef9c0d0207804f37040c24a90cb5566759",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40401",
+					"10.65.0.27:40401",
+					"172.17.0.1:40401",
+					"172.18.0.1:40401",
+					"172.19.0.1:40401",
+					"172.20.0.1:40401",
+					"172.21.0.1:40401",
+					"172.22.0.1:40401",
+					"172.23.0.1:40401",
+					"172.24.0.1:40401",
+					"172.25.0.1:40401",
+					"172.26.0.1:40401",
+					"172.27.0.1:40401",
+					"172.28.0.1:40401"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:18:28.446165874Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7610624439162705,
+				"StableID":   "naP8LXCsR221CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:64323e2acab6388073367f6bf33ca27be3b617808e77f282172e1cfb7288e408",
+				"DiscoKey":   "discokey:8265adf738a508dd79d5594c9051086e367f735e364a9b0f8b07444ab4837a23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47593",
+					"10.65.0.27:47593",
+					"172.17.0.1:47593",
+					"172.18.0.1:47593",
+					"172.19.0.1:47593",
+					"172.20.0.1:47593",
+					"172.21.0.1:47593",
+					"172.22.0.1:47593",
+					"172.23.0.1:47593",
+					"172.24.0.1:47593",
+					"172.25.0.1:47593",
+					"172.26.0.1:47593",
+					"172.27.0.1:47593",
+					"172.28.0.1:47593"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:18:28.975436501Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         171923215953612,
+				"StableID":   "nZ7Vsc8sL211CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5613b48ea96ace9530f814555295e862a446e2369dd1ad56d065dbe8683d892e",
+				"KeyExpiry":  "2026-11-09T09:18:29Z",
+				"DiscoKey":   "discokey:0a359bd65f92d91db2039f94d50db21d0674d16f2743adfba2cf07a5b9534135",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46507",
+					"10.65.0.27:46507",
+					"172.17.0.1:46507",
+					"172.18.0.1:46507",
+					"172.19.0.1:46507",
+					"172.20.0.1:46507",
+					"172.21.0.1:46507",
+					"172.22.0.1:46507",
+					"172.23.0.1:46507",
+					"172.24.0.1:46507",
+					"172.25.0.1:46507",
+					"172.26.0.1:46507",
+					"172.27.0.1:46507",
+					"172.28.0.1:46507"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:18:29.572595367Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4589858193929405,
+				"StableID":   "n86GNvnkqc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:30a2d8497c37a412110d6334b2c9b1ade3a01014f3a04f2b29f1c0781be82d55",
+				"KeyExpiry":  "2026-11-09T09:18:30Z",
+				"DiscoKey":   "discokey:50ffe6a2296a06d0562488d3c1ae7754c33b641f77058c0d48b6f0e1538a0269",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58735",
+					"10.65.0.27:58735",
+					"172.17.0.1:58735",
+					"172.18.0.1:58735",
+					"172.19.0.1:58735",
+					"172.20.0.1:58735",
+					"172.21.0.1:58735",
+					"172.22.0.1:58735",
+					"172.23.0.1:58735",
+					"172.24.0.1:58735",
+					"172.25.0.1:58735",
+					"172.26.0.1:58735",
+					"172.27.0.1:58735",
+					"172.28.0.1:58735"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:18:30.059549244Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         910391420385261,
+				"StableID":   "ntkALTSK7811CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:31746f4776a57d2bbb43ca359e7d10d9f27a8e0496061bbc6de32e449e13867b",
+				"KeyExpiry":  "2026-11-09T09:18:30Z",
+				"DiscoKey":   "discokey:3ce571dfd38f447fbe40480090cfa44d4bbbffa28743b767d7d0c197de23a65a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49501",
+					"10.65.0.27:49501",
+					"172.17.0.1:49501",
+					"172.18.0.1:49501",
+					"172.19.0.1:49501",
+					"172.20.0.1:49501",
+					"172.21.0.1:49501",
+					"172.22.0.1:49501",
+					"172.23.0.1:49501",
+					"172.24.0.1:49501",
+					"172.25.0.1:49501",
+					"172.26.0.1:49501",
+					"172.27.0.1:49501",
+					"172.28.0.1:49501"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:18:30.586131649Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3703453112569412": {
+				"ID":          3703453112569412,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5234182443223358,
+				"StableID":   "nMSjtd6ash11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       5234182443223358,
+				"Key":        "nodekey:e9ff37a5bf38f75dbd43a6a05b912542422ecc99a63934300725175b0b556018",
+				"DiscoKey":   "discokey:25b2098902097e8778340a0aea5e195476acc246f89e022f4bb7ca2d6299da49",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38639",
+					"10.65.0.27:38639",
+					"172.17.0.1:38639",
+					"172.18.0.1:38639",
+					"172.19.0.1:38639",
+					"172.20.0.1:38639",
+					"172.21.0.1:38639",
+					"172.22.0.1:38639",
+					"172.23.0.1:38639",
+					"172.24.0.1:38639",
+					"172.25.0.1:38639",
+					"172.26.0.1:38639",
+					"172.27.0.1:38639",
+					"172.28.0.1:38639"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:18:27.413681071Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e9ff37a5bf38f75dbd43a6a05b912542422ecc99a63934300725175b0b556018",
+			"MachineKey": "mkey:ee331ee77570ae4f9e84b1b6dd0e23564585567ac5de83f78fa66aeb59878174",
+			"Peers": [{
+				"ID":         3629659383597747,
+				"StableID":   "nAgYYqzsLV11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:826a2f590555f412bea08e52ef573e5eaeefc23475cda5dbc0dc33407fd51368",
+				"DiscoKey":   "discokey:cfe29272e4f8d6d52e1d6cc80a109cb33332104b72b6be4d16173959c58e2d3a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:42911",
+					"10.65.0.27:42911",
+					"172.17.0.1:42911",
+					"172.18.0.1:42911",
+					"172.19.0.1:42911",
+					"172.20.0.1:42911",
+					"172.21.0.1:42911",
+					"172.22.0.1:42911",
+					"172.23.0.1:42911",
+					"172.24.0.1:42911",
+					"172.25.0.1:42911",
+					"172.26.0.1:42911",
+					"172.27.0.1:42911",
+					"172.28.0.1:42911"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:18:23.064882594Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7634452867421641,
+				"StableID":   "nEoRwb8fc221CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd433ce90513732d1a814e056979c959e7c0572fc7f523b5356b9086dda90e6f",
+				"DiscoKey":   "discokey:9f5e41c049b90f62e8c2b7ff30aaba7da14aa336b3f6ca79037752c5e9600874",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43181",
+					"10.65.0.27:43181",
+					"172.17.0.1:43181",
+					"172.18.0.1:43181",
+					"172.19.0.1:43181",
+					"172.20.0.1:43181",
+					"172.21.0.1:43181",
+					"172.22.0.1:43181",
+					"172.23.0.1:43181",
+					"172.24.0.1:43181",
+					"172.25.0.1:43181",
+					"172.26.0.1:43181",
+					"172.27.0.1:43181",
+					"172.28.0.1:43181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:18:23.610236176Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6288708298322901,
+				"StableID":   "nJTsenhA7r11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9574ee86e49d545297709b7d3733d6f96ffe4563e75e41597f917221548c6d09",
+				"DiscoKey":   "discokey:683bd93e93958206447f011fbe123ec261a83ffaf6a3a058f9867fbe9af1ec40",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43316",
+					"10.65.0.27:43316",
+					"172.17.0.1:43316",
+					"172.18.0.1:43316",
+					"172.19.0.1:43316",
+					"172.20.0.1:43316",
+					"172.21.0.1:43316",
+					"172.22.0.1:43316",
+					"172.23.0.1:43316",
+					"172.24.0.1:43316",
+					"172.25.0.1:43316",
+					"172.26.0.1:43316",
+					"172.27.0.1:43316",
+					"172.28.0.1:43316"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:18:24.144090057Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3872101206780,
+				"StableID":   "n9ooKPik2111CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc1c67bf3c3b82002d30abb24af84188710e1bec537d3d8aec1167ccbc474040",
+				"DiscoKey":   "discokey:95e97236e791c770a6fcb06b316c5dcc721ebad3ecd8a393c534f8b5f4082b71",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:52545",
+					"10.65.0.27:52545",
+					"172.17.0.1:52545",
+					"172.18.0.1:52545",
+					"172.19.0.1:52545",
+					"172.20.0.1:52545",
+					"172.21.0.1:52545",
+					"172.22.0.1:52545",
+					"172.23.0.1:52545",
+					"172.24.0.1:52545",
+					"172.25.0.1:52545",
+					"172.26.0.1:52545",
+					"172.27.0.1:52545",
+					"172.28.0.1:52545"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:18:24.679562462Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1351878608113606,
+				"StableID":   "nhksJQZGZB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:632860ce4649a5e7ec6dfb212db5bde87642e475954c87968565670b7e9b6431",
+				"DiscoKey":   "discokey:2e99bf667d271a84d45861465ca6e7ca59f31c555bbd9ae399d13a068b116540",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33481",
+					"10.65.0.27:33481",
+					"172.17.0.1:33481",
+					"172.18.0.1:33481",
+					"172.19.0.1:33481",
+					"172.20.0.1:33481",
+					"172.21.0.1:33481",
+					"172.22.0.1:33481",
+					"172.23.0.1:33481",
+					"172.24.0.1:33481",
+					"172.25.0.1:33481",
+					"172.26.0.1:33481",
+					"172.27.0.1:33481",
+					"172.28.0.1:33481"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:18:25.212870114Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4710579020748619,
+				"StableID":   "neziSYvRnd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6b4e8a634a3026b7bafafb5b30550a77da67edf0fb28baf9dd323b117fc27165",
+				"DiscoKey":   "discokey:bb9dd4a17807d1c1156537152e599056f06445fa54da389634a48a572404685c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42046",
+					"10.65.0.27:42046",
+					"172.17.0.1:42046",
+					"172.18.0.1:42046",
+					"172.19.0.1:42046",
+					"172.20.0.1:42046",
+					"172.21.0.1:42046",
+					"172.22.0.1:42046",
+					"172.23.0.1:42046",
+					"172.24.0.1:42046",
+					"172.25.0.1:42046",
+					"172.26.0.1:42046",
+					"172.27.0.1:42046",
+					"172.28.0.1:42046"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:18:25.753413192Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3703453112569412,
+				"StableID":   "nR3Mg8SJvV11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:00b270a28bef133635425b307228ec0749d00c11255722cc06b9f05abfbe2372",
+				"DiscoKey":   "discokey:643a35b7d9b7d07b748d1b9eddcb6223dee33adfbb95815ea9441e5169d91919",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49879",
+					"10.65.0.27:49879",
+					"172.17.0.1:49879",
+					"172.18.0.1:49879",
+					"172.19.0.1:49879",
+					"172.20.0.1:49879",
+					"172.21.0.1:49879",
+					"172.22.0.1:49879",
+					"172.23.0.1:49879",
+					"172.24.0.1:49879",
+					"172.25.0.1:49879",
+					"172.26.0.1:49879",
+					"172.27.0.1:49879",
+					"172.28.0.1:49879"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:18:26.305678811Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7146136476813947,
+				"StableID":   "nUhMfUtVox11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31c027a88808fbf2e12d20d7339e211908e878abb9f0ed2803e224cca5f17210",
+				"DiscoKey":   "discokey:14492165aef132522938760516d62795a37b46e4b96c98d79d98a04f9d6ff63e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:41689",
+					"10.65.0.27:41689",
+					"172.17.0.1:41689",
+					"172.18.0.1:41689",
+					"172.19.0.1:41689",
+					"172.20.0.1:41689",
+					"172.21.0.1:41689",
+					"172.22.0.1:41689",
+					"172.23.0.1:41689",
+					"172.24.0.1:41689",
+					"172.25.0.1:41689",
+					"172.26.0.1:41689",
+					"172.27.0.1:41689",
+					"172.28.0.1:41689"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:18:26.835487556Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4277455258369164,
+				"StableID":   "nor2jnVGQa11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3c36636ee28c97a9c6353ec32ec246767d10813a18f68a3bf84df208e5c37263",
+				"DiscoKey":   "discokey:8c04276a99d1cff78d424cc57e20d789b9585852b73bd8e6f18bfc345597622f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40861",
+					"10.65.0.27:40861",
+					"172.17.0.1:40861",
+					"172.18.0.1:40861",
+					"172.19.0.1:40861",
+					"172.20.0.1:40861",
+					"172.21.0.1:40861",
+					"172.22.0.1:40861",
+					"172.23.0.1:40861",
+					"172.24.0.1:40861",
+					"172.25.0.1:40861",
+					"172.26.0.1:40861",
+					"172.27.0.1:40861",
+					"172.28.0.1:40861"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:18:27.90103441Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6210021292995392,
+				"StableID":   "nbghSHjXVq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87128166c893a60ba96b44e59f7fd0d1d139db8efc029d37ad753bc27d01d658",
+				"DiscoKey":   "discokey:e560631cb9b92a8cc999d49c9967f0ef9c0d0207804f37040c24a90cb5566759",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40401",
+					"10.65.0.27:40401",
+					"172.17.0.1:40401",
+					"172.18.0.1:40401",
+					"172.19.0.1:40401",
+					"172.20.0.1:40401",
+					"172.21.0.1:40401",
+					"172.22.0.1:40401",
+					"172.23.0.1:40401",
+					"172.24.0.1:40401",
+					"172.25.0.1:40401",
+					"172.26.0.1:40401",
+					"172.27.0.1:40401",
+					"172.28.0.1:40401"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:18:28.446165874Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7610624439162705,
+				"StableID":   "naP8LXCsR221CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:64323e2acab6388073367f6bf33ca27be3b617808e77f282172e1cfb7288e408",
+				"DiscoKey":   "discokey:8265adf738a508dd79d5594c9051086e367f735e364a9b0f8b07444ab4837a23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47593",
+					"10.65.0.27:47593",
+					"172.17.0.1:47593",
+					"172.18.0.1:47593",
+					"172.19.0.1:47593",
+					"172.20.0.1:47593",
+					"172.21.0.1:47593",
+					"172.22.0.1:47593",
+					"172.23.0.1:47593",
+					"172.24.0.1:47593",
+					"172.25.0.1:47593",
+					"172.26.0.1:47593",
+					"172.27.0.1:47593",
+					"172.28.0.1:47593"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:18:28.975436501Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         171923215953612,
+				"StableID":   "nZ7Vsc8sL211CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5613b48ea96ace9530f814555295e862a446e2369dd1ad56d065dbe8683d892e",
+				"KeyExpiry":  "2026-11-09T09:18:29Z",
+				"DiscoKey":   "discokey:0a359bd65f92d91db2039f94d50db21d0674d16f2743adfba2cf07a5b9534135",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46507",
+					"10.65.0.27:46507",
+					"172.17.0.1:46507",
+					"172.18.0.1:46507",
+					"172.19.0.1:46507",
+					"172.20.0.1:46507",
+					"172.21.0.1:46507",
+					"172.22.0.1:46507",
+					"172.23.0.1:46507",
+					"172.24.0.1:46507",
+					"172.25.0.1:46507",
+					"172.26.0.1:46507",
+					"172.27.0.1:46507",
+					"172.28.0.1:46507"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:18:29.572595367Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4589858193929405,
+				"StableID":   "n86GNvnkqc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:30a2d8497c37a412110d6334b2c9b1ade3a01014f3a04f2b29f1c0781be82d55",
+				"KeyExpiry":  "2026-11-09T09:18:30Z",
+				"DiscoKey":   "discokey:50ffe6a2296a06d0562488d3c1ae7754c33b641f77058c0d48b6f0e1538a0269",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58735",
+					"10.65.0.27:58735",
+					"172.17.0.1:58735",
+					"172.18.0.1:58735",
+					"172.19.0.1:58735",
+					"172.20.0.1:58735",
+					"172.21.0.1:58735",
+					"172.22.0.1:58735",
+					"172.23.0.1:58735",
+					"172.24.0.1:58735",
+					"172.25.0.1:58735",
+					"172.26.0.1:58735",
+					"172.27.0.1:58735",
+					"172.28.0.1:58735"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:18:30.059549244Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         910391420385261,
+				"StableID":   "ntkALTSK7811CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:31746f4776a57d2bbb43ca359e7d10d9f27a8e0496061bbc6de32e449e13867b",
+				"KeyExpiry":  "2026-11-09T09:18:30Z",
+				"DiscoKey":   "discokey:3ce571dfd38f447fbe40480090cfa44d4bbbffa28743b767d7d0c197de23a65a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49501",
+					"10.65.0.27:49501",
+					"172.17.0.1:49501",
+					"172.18.0.1:49501",
+					"172.19.0.1:49501",
+					"172.20.0.1:49501",
+					"172.21.0.1:49501",
+					"172.22.0.1:49501",
+					"172.23.0.1:49501",
+					"172.24.0.1:49501",
+					"172.25.0.1:49501",
+					"172.26.0.1:49501",
+					"172.27.0.1:49501",
+					"172.28.0.1:49501"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:18:30.586131649Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5234182443223358": {
+				"ID":          5234182443223358,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4589858193929405,
+				"StableID":   "n86GNvnkqc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:30a2d8497c37a412110d6334b2c9b1ade3a01014f3a04f2b29f1c0781be82d55",
+				"KeyExpiry":  "2026-11-09T09:18:30Z",
+				"DiscoKey":   "discokey:50ffe6a2296a06d0562488d3c1ae7754c33b641f77058c0d48b6f0e1538a0269",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58735",
+					"10.65.0.27:58735",
+					"172.17.0.1:58735",
+					"172.18.0.1:58735",
+					"172.19.0.1:58735",
+					"172.20.0.1:58735",
+					"172.21.0.1:58735",
+					"172.22.0.1:58735",
+					"172.23.0.1:58735",
+					"172.24.0.1:58735",
+					"172.25.0.1:58735",
+					"172.26.0.1:58735",
+					"172.27.0.1:58735",
+					"172.28.0.1:58735"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:18:30.059549244Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:30a2d8497c37a412110d6334b2c9b1ade3a01014f3a04f2b29f1c0781be82d55",
+			"MachineKey": "mkey:894b4936be77df81e7f58c83a81257c300e3e62a36607e64a4ae828b46e9617d",
+			"Peers": [{
+				"ID":         3629659383597747,
+				"StableID":   "nAgYYqzsLV11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:826a2f590555f412bea08e52ef573e5eaeefc23475cda5dbc0dc33407fd51368",
+				"DiscoKey":   "discokey:cfe29272e4f8d6d52e1d6cc80a109cb33332104b72b6be4d16173959c58e2d3a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:42911",
+					"10.65.0.27:42911",
+					"172.17.0.1:42911",
+					"172.18.0.1:42911",
+					"172.19.0.1:42911",
+					"172.20.0.1:42911",
+					"172.21.0.1:42911",
+					"172.22.0.1:42911",
+					"172.23.0.1:42911",
+					"172.24.0.1:42911",
+					"172.25.0.1:42911",
+					"172.26.0.1:42911",
+					"172.27.0.1:42911",
+					"172.28.0.1:42911"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:18:23.064882594Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7634452867421641,
+				"StableID":   "nEoRwb8fc221CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd433ce90513732d1a814e056979c959e7c0572fc7f523b5356b9086dda90e6f",
+				"DiscoKey":   "discokey:9f5e41c049b90f62e8c2b7ff30aaba7da14aa336b3f6ca79037752c5e9600874",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43181",
+					"10.65.0.27:43181",
+					"172.17.0.1:43181",
+					"172.18.0.1:43181",
+					"172.19.0.1:43181",
+					"172.20.0.1:43181",
+					"172.21.0.1:43181",
+					"172.22.0.1:43181",
+					"172.23.0.1:43181",
+					"172.24.0.1:43181",
+					"172.25.0.1:43181",
+					"172.26.0.1:43181",
+					"172.27.0.1:43181",
+					"172.28.0.1:43181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:18:23.610236176Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6288708298322901,
+				"StableID":   "nJTsenhA7r11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9574ee86e49d545297709b7d3733d6f96ffe4563e75e41597f917221548c6d09",
+				"DiscoKey":   "discokey:683bd93e93958206447f011fbe123ec261a83ffaf6a3a058f9867fbe9af1ec40",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43316",
+					"10.65.0.27:43316",
+					"172.17.0.1:43316",
+					"172.18.0.1:43316",
+					"172.19.0.1:43316",
+					"172.20.0.1:43316",
+					"172.21.0.1:43316",
+					"172.22.0.1:43316",
+					"172.23.0.1:43316",
+					"172.24.0.1:43316",
+					"172.25.0.1:43316",
+					"172.26.0.1:43316",
+					"172.27.0.1:43316",
+					"172.28.0.1:43316"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:18:24.144090057Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3872101206780,
+				"StableID":   "n9ooKPik2111CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc1c67bf3c3b82002d30abb24af84188710e1bec537d3d8aec1167ccbc474040",
+				"DiscoKey":   "discokey:95e97236e791c770a6fcb06b316c5dcc721ebad3ecd8a393c534f8b5f4082b71",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:52545",
+					"10.65.0.27:52545",
+					"172.17.0.1:52545",
+					"172.18.0.1:52545",
+					"172.19.0.1:52545",
+					"172.20.0.1:52545",
+					"172.21.0.1:52545",
+					"172.22.0.1:52545",
+					"172.23.0.1:52545",
+					"172.24.0.1:52545",
+					"172.25.0.1:52545",
+					"172.26.0.1:52545",
+					"172.27.0.1:52545",
+					"172.28.0.1:52545"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:18:24.679562462Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1351878608113606,
+				"StableID":   "nhksJQZGZB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:632860ce4649a5e7ec6dfb212db5bde87642e475954c87968565670b7e9b6431",
+				"DiscoKey":   "discokey:2e99bf667d271a84d45861465ca6e7ca59f31c555bbd9ae399d13a068b116540",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33481",
+					"10.65.0.27:33481",
+					"172.17.0.1:33481",
+					"172.18.0.1:33481",
+					"172.19.0.1:33481",
+					"172.20.0.1:33481",
+					"172.21.0.1:33481",
+					"172.22.0.1:33481",
+					"172.23.0.1:33481",
+					"172.24.0.1:33481",
+					"172.25.0.1:33481",
+					"172.26.0.1:33481",
+					"172.27.0.1:33481",
+					"172.28.0.1:33481"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:18:25.212870114Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4710579020748619,
+				"StableID":   "neziSYvRnd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6b4e8a634a3026b7bafafb5b30550a77da67edf0fb28baf9dd323b117fc27165",
+				"DiscoKey":   "discokey:bb9dd4a17807d1c1156537152e599056f06445fa54da389634a48a572404685c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42046",
+					"10.65.0.27:42046",
+					"172.17.0.1:42046",
+					"172.18.0.1:42046",
+					"172.19.0.1:42046",
+					"172.20.0.1:42046",
+					"172.21.0.1:42046",
+					"172.22.0.1:42046",
+					"172.23.0.1:42046",
+					"172.24.0.1:42046",
+					"172.25.0.1:42046",
+					"172.26.0.1:42046",
+					"172.27.0.1:42046",
+					"172.28.0.1:42046"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:18:25.753413192Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3703453112569412,
+				"StableID":   "nR3Mg8SJvV11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:00b270a28bef133635425b307228ec0749d00c11255722cc06b9f05abfbe2372",
+				"DiscoKey":   "discokey:643a35b7d9b7d07b748d1b9eddcb6223dee33adfbb95815ea9441e5169d91919",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49879",
+					"10.65.0.27:49879",
+					"172.17.0.1:49879",
+					"172.18.0.1:49879",
+					"172.19.0.1:49879",
+					"172.20.0.1:49879",
+					"172.21.0.1:49879",
+					"172.22.0.1:49879",
+					"172.23.0.1:49879",
+					"172.24.0.1:49879",
+					"172.25.0.1:49879",
+					"172.26.0.1:49879",
+					"172.27.0.1:49879",
+					"172.28.0.1:49879"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:18:26.305678811Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7146136476813947,
+				"StableID":   "nUhMfUtVox11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31c027a88808fbf2e12d20d7339e211908e878abb9f0ed2803e224cca5f17210",
+				"DiscoKey":   "discokey:14492165aef132522938760516d62795a37b46e4b96c98d79d98a04f9d6ff63e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:41689",
+					"10.65.0.27:41689",
+					"172.17.0.1:41689",
+					"172.18.0.1:41689",
+					"172.19.0.1:41689",
+					"172.20.0.1:41689",
+					"172.21.0.1:41689",
+					"172.22.0.1:41689",
+					"172.23.0.1:41689",
+					"172.24.0.1:41689",
+					"172.25.0.1:41689",
+					"172.26.0.1:41689",
+					"172.27.0.1:41689",
+					"172.28.0.1:41689"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:18:26.835487556Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5234182443223358,
+				"StableID":   "nMSjtd6ash11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e9ff37a5bf38f75dbd43a6a05b912542422ecc99a63934300725175b0b556018",
+				"DiscoKey":   "discokey:25b2098902097e8778340a0aea5e195476acc246f89e022f4bb7ca2d6299da49",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38639",
+					"10.65.0.27:38639",
+					"172.17.0.1:38639",
+					"172.18.0.1:38639",
+					"172.19.0.1:38639",
+					"172.20.0.1:38639",
+					"172.21.0.1:38639",
+					"172.22.0.1:38639",
+					"172.23.0.1:38639",
+					"172.24.0.1:38639",
+					"172.25.0.1:38639",
+					"172.26.0.1:38639",
+					"172.27.0.1:38639",
+					"172.28.0.1:38639"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:18:27.413681071Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4277455258369164,
+				"StableID":   "nor2jnVGQa11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3c36636ee28c97a9c6353ec32ec246767d10813a18f68a3bf84df208e5c37263",
+				"DiscoKey":   "discokey:8c04276a99d1cff78d424cc57e20d789b9585852b73bd8e6f18bfc345597622f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40861",
+					"10.65.0.27:40861",
+					"172.17.0.1:40861",
+					"172.18.0.1:40861",
+					"172.19.0.1:40861",
+					"172.20.0.1:40861",
+					"172.21.0.1:40861",
+					"172.22.0.1:40861",
+					"172.23.0.1:40861",
+					"172.24.0.1:40861",
+					"172.25.0.1:40861",
+					"172.26.0.1:40861",
+					"172.27.0.1:40861",
+					"172.28.0.1:40861"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:18:27.90103441Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6210021292995392,
+				"StableID":   "nbghSHjXVq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87128166c893a60ba96b44e59f7fd0d1d139db8efc029d37ad753bc27d01d658",
+				"DiscoKey":   "discokey:e560631cb9b92a8cc999d49c9967f0ef9c0d0207804f37040c24a90cb5566759",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40401",
+					"10.65.0.27:40401",
+					"172.17.0.1:40401",
+					"172.18.0.1:40401",
+					"172.19.0.1:40401",
+					"172.20.0.1:40401",
+					"172.21.0.1:40401",
+					"172.22.0.1:40401",
+					"172.23.0.1:40401",
+					"172.24.0.1:40401",
+					"172.25.0.1:40401",
+					"172.26.0.1:40401",
+					"172.27.0.1:40401",
+					"172.28.0.1:40401"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:18:28.446165874Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7610624439162705,
+				"StableID":   "naP8LXCsR221CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:64323e2acab6388073367f6bf33ca27be3b617808e77f282172e1cfb7288e408",
+				"DiscoKey":   "discokey:8265adf738a508dd79d5594c9051086e367f735e364a9b0f8b07444ab4837a23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47593",
+					"10.65.0.27:47593",
+					"172.17.0.1:47593",
+					"172.18.0.1:47593",
+					"172.19.0.1:47593",
+					"172.20.0.1:47593",
+					"172.21.0.1:47593",
+					"172.22.0.1:47593",
+					"172.23.0.1:47593",
+					"172.24.0.1:47593",
+					"172.25.0.1:47593",
+					"172.26.0.1:47593",
+					"172.27.0.1:47593",
+					"172.28.0.1:47593"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:18:28.975436501Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         171923215953612,
+				"StableID":   "nZ7Vsc8sL211CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5613b48ea96ace9530f814555295e862a446e2369dd1ad56d065dbe8683d892e",
+				"KeyExpiry":  "2026-11-09T09:18:29Z",
+				"DiscoKey":   "discokey:0a359bd65f92d91db2039f94d50db21d0674d16f2743adfba2cf07a5b9534135",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46507",
+					"10.65.0.27:46507",
+					"172.17.0.1:46507",
+					"172.18.0.1:46507",
+					"172.19.0.1:46507",
+					"172.20.0.1:46507",
+					"172.21.0.1:46507",
+					"172.22.0.1:46507",
+					"172.23.0.1:46507",
+					"172.24.0.1:46507",
+					"172.25.0.1:46507",
+					"172.26.0.1:46507",
+					"172.27.0.1:46507",
+					"172.28.0.1:46507"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:18:29.572595367Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         910391420385261,
+				"StableID":   "ntkALTSK7811CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:31746f4776a57d2bbb43ca359e7d10d9f27a8e0496061bbc6de32e449e13867b",
+				"KeyExpiry":  "2026-11-09T09:18:30Z",
+				"DiscoKey":   "discokey:3ce571dfd38f447fbe40480090cfa44d4bbbffa28743b767d7d0c197de23a65a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49501",
+					"10.65.0.27:49501",
+					"172.17.0.1:49501",
+					"172.18.0.1:49501",
+					"172.19.0.1:49501",
+					"172.20.0.1:49501",
+					"172.21.0.1:49501",
+					"172.22.0.1:49501",
+					"172.23.0.1:49501",
+					"172.24.0.1:49501",
+					"172.25.0.1:49501",
+					"172.26.0.1:49501",
+					"172.27.0.1:49501",
+					"172.28.0.1:49501"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:18:30.586131649Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4277455258369164,
+				"StableID":   "nor2jnVGQa11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       4277455258369164,
+				"Key":        "nodekey:3c36636ee28c97a9c6353ec32ec246767d10813a18f68a3bf84df208e5c37263",
+				"DiscoKey":   "discokey:8c04276a99d1cff78d424cc57e20d789b9585852b73bd8e6f18bfc345597622f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40861",
+					"10.65.0.27:40861",
+					"172.17.0.1:40861",
+					"172.18.0.1:40861",
+					"172.19.0.1:40861",
+					"172.20.0.1:40861",
+					"172.21.0.1:40861",
+					"172.22.0.1:40861",
+					"172.23.0.1:40861",
+					"172.24.0.1:40861",
+					"172.25.0.1:40861",
+					"172.26.0.1:40861",
+					"172.27.0.1:40861",
+					"172.28.0.1:40861"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:18:27.90103441Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3c36636ee28c97a9c6353ec32ec246767d10813a18f68a3bf84df208e5c37263",
+			"MachineKey": "mkey:6ed9390f4b35890afec6bf28b981d37c8e35ec002171073370730ff3023b5875",
+			"Peers": [{
+				"ID":         3629659383597747,
+				"StableID":   "nAgYYqzsLV11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:826a2f590555f412bea08e52ef573e5eaeefc23475cda5dbc0dc33407fd51368",
+				"DiscoKey":   "discokey:cfe29272e4f8d6d52e1d6cc80a109cb33332104b72b6be4d16173959c58e2d3a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:42911",
+					"10.65.0.27:42911",
+					"172.17.0.1:42911",
+					"172.18.0.1:42911",
+					"172.19.0.1:42911",
+					"172.20.0.1:42911",
+					"172.21.0.1:42911",
+					"172.22.0.1:42911",
+					"172.23.0.1:42911",
+					"172.24.0.1:42911",
+					"172.25.0.1:42911",
+					"172.26.0.1:42911",
+					"172.27.0.1:42911",
+					"172.28.0.1:42911"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:18:23.064882594Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7634452867421641,
+				"StableID":   "nEoRwb8fc221CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd433ce90513732d1a814e056979c959e7c0572fc7f523b5356b9086dda90e6f",
+				"DiscoKey":   "discokey:9f5e41c049b90f62e8c2b7ff30aaba7da14aa336b3f6ca79037752c5e9600874",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43181",
+					"10.65.0.27:43181",
+					"172.17.0.1:43181",
+					"172.18.0.1:43181",
+					"172.19.0.1:43181",
+					"172.20.0.1:43181",
+					"172.21.0.1:43181",
+					"172.22.0.1:43181",
+					"172.23.0.1:43181",
+					"172.24.0.1:43181",
+					"172.25.0.1:43181",
+					"172.26.0.1:43181",
+					"172.27.0.1:43181",
+					"172.28.0.1:43181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:18:23.610236176Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6288708298322901,
+				"StableID":   "nJTsenhA7r11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9574ee86e49d545297709b7d3733d6f96ffe4563e75e41597f917221548c6d09",
+				"DiscoKey":   "discokey:683bd93e93958206447f011fbe123ec261a83ffaf6a3a058f9867fbe9af1ec40",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43316",
+					"10.65.0.27:43316",
+					"172.17.0.1:43316",
+					"172.18.0.1:43316",
+					"172.19.0.1:43316",
+					"172.20.0.1:43316",
+					"172.21.0.1:43316",
+					"172.22.0.1:43316",
+					"172.23.0.1:43316",
+					"172.24.0.1:43316",
+					"172.25.0.1:43316",
+					"172.26.0.1:43316",
+					"172.27.0.1:43316",
+					"172.28.0.1:43316"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:18:24.144090057Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3872101206780,
+				"StableID":   "n9ooKPik2111CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc1c67bf3c3b82002d30abb24af84188710e1bec537d3d8aec1167ccbc474040",
+				"DiscoKey":   "discokey:95e97236e791c770a6fcb06b316c5dcc721ebad3ecd8a393c534f8b5f4082b71",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:52545",
+					"10.65.0.27:52545",
+					"172.17.0.1:52545",
+					"172.18.0.1:52545",
+					"172.19.0.1:52545",
+					"172.20.0.1:52545",
+					"172.21.0.1:52545",
+					"172.22.0.1:52545",
+					"172.23.0.1:52545",
+					"172.24.0.1:52545",
+					"172.25.0.1:52545",
+					"172.26.0.1:52545",
+					"172.27.0.1:52545",
+					"172.28.0.1:52545"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:18:24.679562462Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1351878608113606,
+				"StableID":   "nhksJQZGZB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:632860ce4649a5e7ec6dfb212db5bde87642e475954c87968565670b7e9b6431",
+				"DiscoKey":   "discokey:2e99bf667d271a84d45861465ca6e7ca59f31c555bbd9ae399d13a068b116540",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:33481",
+					"10.65.0.27:33481",
+					"172.17.0.1:33481",
+					"172.18.0.1:33481",
+					"172.19.0.1:33481",
+					"172.20.0.1:33481",
+					"172.21.0.1:33481",
+					"172.22.0.1:33481",
+					"172.23.0.1:33481",
+					"172.24.0.1:33481",
+					"172.25.0.1:33481",
+					"172.26.0.1:33481",
+					"172.27.0.1:33481",
+					"172.28.0.1:33481"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:18:25.212870114Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4710579020748619,
+				"StableID":   "neziSYvRnd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6b4e8a634a3026b7bafafb5b30550a77da67edf0fb28baf9dd323b117fc27165",
+				"DiscoKey":   "discokey:bb9dd4a17807d1c1156537152e599056f06445fa54da389634a48a572404685c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42046",
+					"10.65.0.27:42046",
+					"172.17.0.1:42046",
+					"172.18.0.1:42046",
+					"172.19.0.1:42046",
+					"172.20.0.1:42046",
+					"172.21.0.1:42046",
+					"172.22.0.1:42046",
+					"172.23.0.1:42046",
+					"172.24.0.1:42046",
+					"172.25.0.1:42046",
+					"172.26.0.1:42046",
+					"172.27.0.1:42046",
+					"172.28.0.1:42046"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:18:25.753413192Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3703453112569412,
+				"StableID":   "nR3Mg8SJvV11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:00b270a28bef133635425b307228ec0749d00c11255722cc06b9f05abfbe2372",
+				"DiscoKey":   "discokey:643a35b7d9b7d07b748d1b9eddcb6223dee33adfbb95815ea9441e5169d91919",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:49879",
+					"10.65.0.27:49879",
+					"172.17.0.1:49879",
+					"172.18.0.1:49879",
+					"172.19.0.1:49879",
+					"172.20.0.1:49879",
+					"172.21.0.1:49879",
+					"172.22.0.1:49879",
+					"172.23.0.1:49879",
+					"172.24.0.1:49879",
+					"172.25.0.1:49879",
+					"172.26.0.1:49879",
+					"172.27.0.1:49879",
+					"172.28.0.1:49879"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:18:26.305678811Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7146136476813947,
+				"StableID":   "nUhMfUtVox11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31c027a88808fbf2e12d20d7339e211908e878abb9f0ed2803e224cca5f17210",
+				"DiscoKey":   "discokey:14492165aef132522938760516d62795a37b46e4b96c98d79d98a04f9d6ff63e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:41689",
+					"10.65.0.27:41689",
+					"172.17.0.1:41689",
+					"172.18.0.1:41689",
+					"172.19.0.1:41689",
+					"172.20.0.1:41689",
+					"172.21.0.1:41689",
+					"172.22.0.1:41689",
+					"172.23.0.1:41689",
+					"172.24.0.1:41689",
+					"172.25.0.1:41689",
+					"172.26.0.1:41689",
+					"172.27.0.1:41689",
+					"172.28.0.1:41689"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:18:26.835487556Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5234182443223358,
+				"StableID":   "nMSjtd6ash11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e9ff37a5bf38f75dbd43a6a05b912542422ecc99a63934300725175b0b556018",
+				"DiscoKey":   "discokey:25b2098902097e8778340a0aea5e195476acc246f89e022f4bb7ca2d6299da49",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38639",
+					"10.65.0.27:38639",
+					"172.17.0.1:38639",
+					"172.18.0.1:38639",
+					"172.19.0.1:38639",
+					"172.20.0.1:38639",
+					"172.21.0.1:38639",
+					"172.22.0.1:38639",
+					"172.23.0.1:38639",
+					"172.24.0.1:38639",
+					"172.25.0.1:38639",
+					"172.26.0.1:38639",
+					"172.27.0.1:38639",
+					"172.28.0.1:38639"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:18:27.413681071Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6210021292995392,
+				"StableID":   "nbghSHjXVq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87128166c893a60ba96b44e59f7fd0d1d139db8efc029d37ad753bc27d01d658",
+				"DiscoKey":   "discokey:e560631cb9b92a8cc999d49c9967f0ef9c0d0207804f37040c24a90cb5566759",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:40401",
+					"10.65.0.27:40401",
+					"172.17.0.1:40401",
+					"172.18.0.1:40401",
+					"172.19.0.1:40401",
+					"172.20.0.1:40401",
+					"172.21.0.1:40401",
+					"172.22.0.1:40401",
+					"172.23.0.1:40401",
+					"172.24.0.1:40401",
+					"172.25.0.1:40401",
+					"172.26.0.1:40401",
+					"172.27.0.1:40401",
+					"172.28.0.1:40401"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:18:28.446165874Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7610624439162705,
+				"StableID":   "naP8LXCsR221CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:64323e2acab6388073367f6bf33ca27be3b617808e77f282172e1cfb7288e408",
+				"DiscoKey":   "discokey:8265adf738a508dd79d5594c9051086e367f735e364a9b0f8b07444ab4837a23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47593",
+					"10.65.0.27:47593",
+					"172.17.0.1:47593",
+					"172.18.0.1:47593",
+					"172.19.0.1:47593",
+					"172.20.0.1:47593",
+					"172.21.0.1:47593",
+					"172.22.0.1:47593",
+					"172.23.0.1:47593",
+					"172.24.0.1:47593",
+					"172.25.0.1:47593",
+					"172.26.0.1:47593",
+					"172.27.0.1:47593",
+					"172.28.0.1:47593"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:18:28.975436501Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         171923215953612,
+				"StableID":   "nZ7Vsc8sL211CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5613b48ea96ace9530f814555295e862a446e2369dd1ad56d065dbe8683d892e",
+				"KeyExpiry":  "2026-11-09T09:18:29Z",
+				"DiscoKey":   "discokey:0a359bd65f92d91db2039f94d50db21d0674d16f2743adfba2cf07a5b9534135",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46507",
+					"10.65.0.27:46507",
+					"172.17.0.1:46507",
+					"172.18.0.1:46507",
+					"172.19.0.1:46507",
+					"172.20.0.1:46507",
+					"172.21.0.1:46507",
+					"172.22.0.1:46507",
+					"172.23.0.1:46507",
+					"172.24.0.1:46507",
+					"172.25.0.1:46507",
+					"172.26.0.1:46507",
+					"172.27.0.1:46507",
+					"172.28.0.1:46507"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:18:29.572595367Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4589858193929405,
+				"StableID":   "n86GNvnkqc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:30a2d8497c37a412110d6334b2c9b1ade3a01014f3a04f2b29f1c0781be82d55",
+				"KeyExpiry":  "2026-11-09T09:18:30Z",
+				"DiscoKey":   "discokey:50ffe6a2296a06d0562488d3c1ae7754c33b641f77058c0d48b6f0e1538a0269",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:58735",
+					"10.65.0.27:58735",
+					"172.17.0.1:58735",
+					"172.18.0.1:58735",
+					"172.19.0.1:58735",
+					"172.20.0.1:58735",
+					"172.21.0.1:58735",
+					"172.22.0.1:58735",
+					"172.23.0.1:58735",
+					"172.24.0.1:58735",
+					"172.25.0.1:58735",
+					"172.26.0.1:58735",
+					"172.27.0.1:58735",
+					"172.28.0.1:58735"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:18:30.059549244Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         910391420385261,
+				"StableID":   "ntkALTSK7811CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:31746f4776a57d2bbb43ca359e7d10d9f27a8e0496061bbc6de32e449e13867b",
+				"KeyExpiry":  "2026-11-09T09:18:30Z",
+				"DiscoKey":   "discokey:3ce571dfd38f447fbe40480090cfa44d4bbbffa28743b767d7d0c197de23a65a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49501",
+					"10.65.0.27:49501",
+					"172.17.0.1:49501",
+					"172.18.0.1:49501",
+					"172.19.0.1:49501",
+					"172.20.0.1:49501",
+					"172.21.0.1:49501",
+					"172.22.0.1:49501",
+					"172.23.0.1:49501",
+					"172.24.0.1:49501",
+					"172.25.0.1:49501",
+					"172.26.0.1:49501",
+					"172.27.0.1:49501",
+					"172.28.0.1:49501"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:18:30.586131649Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4277455258369164": {
+				"ID":          4277455258369164,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-multi-src-multi-dst-multi-user.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-multi-src-multi-dst-multi-user.hujson
@@ -1,0 +1,22146 @@
+// ssh-multi-src-multi-dst-multi-user
+//
+// ssh rule with 2 srcs x 2 dsts x 2 users
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-13T09:19:15Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-multi-src-multi-dst-multi-user",
+	"description":    "ssh rule with 2 srcs x 2 dsts x 2 users",
+	"category":       "ssh",
+	"captured_at":    "2026-05-13T09:19:15.894174223Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                     \n  \n                                                                   \n                                                                   \n              \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh rule with 2 srcs x 2 dsts x 2 users\",\n\t\"id\":          \"ssh-multi-src-multi-dst-multi-user\",\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\", \"tag:prod\"],\n\t\t\"src\":    [\"thor@example.org\", \"odin@example.com\"],\n\t\t\"users\":  [\"root\", \"ubuntu\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-edges/ssh-multi-src-multi-dst-multi-user.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server", "tag:prod"],
+				"src":    ["thor@example.org", "odin@example.com"],
+				"users":  ["root", "ubuntu"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3426536136371848,
+				"StableID":   "nV5Uk3JtkT11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       3426536136371848,
+				"Key":        "nodekey:9acfa98fbb055c7bbfbcfc470e2a3d7c4ec2e992b0718826593b6d1abc45cb1f",
+				"DiscoKey":   "discokey:5e5ace1c16176fb4349597cd6b68958f2a40160e8d74765bb4f53885a135ae75",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36618",
+					"10.65.0.27:36618",
+					"172.17.0.1:36618",
+					"172.18.0.1:36618",
+					"172.19.0.1:36618",
+					"172.20.0.1:36618",
+					"172.21.0.1:36618",
+					"172.22.0.1:36618",
+					"172.23.0.1:36618",
+					"172.24.0.1:36618",
+					"172.25.0.1:36618",
+					"172.26.0.1:36618",
+					"172.27.0.1:36618",
+					"172.28.0.1:36618"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:19:24.279863448Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9acfa98fbb055c7bbfbcfc470e2a3d7c4ec2e992b0718826593b6d1abc45cb1f",
+			"MachineKey": "mkey:7cff2a88f9cbefe770d6aa7ea1585e12ca189bfe38318334d349c977157a583b",
+			"Peers": [{
+				"ID":         8573270307094724,
+				"StableID":   "ndBgFrGrw921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5de5d550caee76af25800ff2bafdfa25b3ee0c1a527297092b6bee88428d291e",
+				"DiscoKey":   "discokey:78d3621ddf45b61eb6efef3619f62e5f49ca13b2b47e07a8aeb4e9991295d87f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58135",
+					"10.65.0.27:58135",
+					"172.17.0.1:58135",
+					"172.18.0.1:58135",
+					"172.19.0.1:58135",
+					"172.20.0.1:58135",
+					"172.21.0.1:58135",
+					"172.22.0.1:58135",
+					"172.23.0.1:58135",
+					"172.24.0.1:58135",
+					"172.25.0.1:58135",
+					"172.26.0.1:58135",
+					"172.27.0.1:58135",
+					"172.28.0.1:58135"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:19:18.34069644Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4757874630165731,
+				"StableID":   "nzQWVKJr9e11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:877d125b234c5f659d778821d79fee683681f31e495153a20af7c60dcfc24c64",
+				"DiscoKey":   "discokey:8fe88cddefa5b8cedc575e52ccbbfadb4639b7bb852024bdb55c063601cd2b1f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37973",
+					"10.65.0.27:37973",
+					"172.17.0.1:37973",
+					"172.18.0.1:37973",
+					"172.19.0.1:37973",
+					"172.20.0.1:37973",
+					"172.21.0.1:37973",
+					"172.22.0.1:37973",
+					"172.23.0.1:37973",
+					"172.24.0.1:37973",
+					"172.25.0.1:37973",
+					"172.26.0.1:37973",
+					"172.27.0.1:37973",
+					"172.28.0.1:37973"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:19:18.859688049Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5181576811348899,
+				"StableID":   "nSrsLiEkTh11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93e906a9692b49c5eda79cce6a97ed4799a48e1605e746494496a77c39aae528",
+				"DiscoKey":   "discokey:6ba5c2b98606fd8bf77d552d88b0c2ba92fe06c93fc2e6fcae76813ff14c2371",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:44257",
+					"10.65.0.27:44257",
+					"172.17.0.1:44257",
+					"172.18.0.1:44257",
+					"172.19.0.1:44257",
+					"172.20.0.1:44257",
+					"172.21.0.1:44257",
+					"172.22.0.1:44257",
+					"172.23.0.1:44257",
+					"172.24.0.1:44257",
+					"172.25.0.1:44257",
+					"172.26.0.1:44257",
+					"172.27.0.1:44257",
+					"172.28.0.1:44257"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:19:19.420242613Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3024142579763633,
+				"StableID":   "nYSs5f6ecQ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f5ef265e9d7fe135001251b2512cf85ea9ad43d7aa44b338e95335004b6aae01",
+				"DiscoKey":   "discokey:9e5f76deebc53ac3b3deaf8e01600088e43398bc51076a70cd468a5a2fbc4527",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34886",
+					"10.65.0.27:34886",
+					"172.17.0.1:34886",
+					"172.18.0.1:34886",
+					"172.19.0.1:34886",
+					"172.20.0.1:34886",
+					"172.21.0.1:34886",
+					"172.22.0.1:34886",
+					"172.23.0.1:34886",
+					"172.24.0.1:34886",
+					"172.25.0.1:34886",
+					"172.26.0.1:34886",
+					"172.27.0.1:34886",
+					"172.28.0.1:34886"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:19:19.9714794Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7907824750755997,
+				"StableID":   "nCij9X9Uk421CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e15db383b9c813c3c6c972ef3d514208ff3e02fa3d80e28cd7cf8c6ef25b656f",
+				"DiscoKey":   "discokey:1532948c521598c248fbdbe0b7fd01133db4f6fdcc657d8874a6b968f6903757",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41744",
+					"10.65.0.27:41744",
+					"172.17.0.1:41744",
+					"172.18.0.1:41744",
+					"172.19.0.1:41744",
+					"172.20.0.1:41744",
+					"172.21.0.1:41744",
+					"172.22.0.1:41744",
+					"172.23.0.1:41744",
+					"172.24.0.1:41744",
+					"172.25.0.1:41744",
+					"172.26.0.1:41744",
+					"172.27.0.1:41744",
+					"172.28.0.1:41744"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:19:20.501136787Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4784639507416429,
+				"StableID":   "n6jS3GNyMe11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:be0d544d162ab0cc7eab0034e6efc0bf3052698d6c2675a496d59c66a47bb271",
+				"DiscoKey":   "discokey:601f5de8b0e63c86913fb4f7a3c29b4367d39af5707d5c4115e5595312c65965",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:60965",
+					"10.65.0.27:60965",
+					"172.17.0.1:60965",
+					"172.18.0.1:60965",
+					"172.19.0.1:60965",
+					"172.20.0.1:60965",
+					"172.21.0.1:60965",
+					"172.22.0.1:60965",
+					"172.23.0.1:60965",
+					"172.24.0.1:60965",
+					"172.25.0.1:60965",
+					"172.26.0.1:60965",
+					"172.27.0.1:60965",
+					"172.28.0.1:60965"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:19:21.040816987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3426646194877689,
+				"StableID":   "n2V5FjBwkT11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9dc6d6f65864f92af390216540c9b809f076879fa6ab1ddf4477566c3d3ca72c",
+				"DiscoKey":   "discokey:023df61eb4a134f8b491c87215f64b6875f0232fc5483452c0cf987b99f7882e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:32842",
+					"10.65.0.27:32842",
+					"172.17.0.1:32842",
+					"172.18.0.1:32842",
+					"172.19.0.1:32842",
+					"172.20.0.1:32842",
+					"172.21.0.1:32842",
+					"172.22.0.1:32842",
+					"172.23.0.1:32842",
+					"172.24.0.1:32842",
+					"172.25.0.1:32842",
+					"172.26.0.1:32842",
+					"172.27.0.1:32842",
+					"172.28.0.1:32842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:19:21.585938624Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6486969541950041,
+				"StableID":   "nWodq1hxes11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:528c424e05b2a205ff1bff5e5190722becab3d5a10566d11272a30cdddedc91f",
+				"DiscoKey":   "discokey:34927bc670b26f71112fe7735f62e5e23727099fc8728b68dd5a04e86a5c7918",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47647",
+					"10.65.0.27:47647",
+					"172.17.0.1:47647",
+					"172.18.0.1:47647",
+					"172.19.0.1:47647",
+					"172.20.0.1:47647",
+					"172.21.0.1:47647",
+					"172.22.0.1:47647",
+					"172.23.0.1:47647",
+					"172.24.0.1:47647",
+					"172.25.0.1:47647",
+					"172.26.0.1:47647",
+					"172.27.0.1:47647",
+					"172.28.0.1:47647"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:19:22.122736953Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         503241623682931,
+				"StableID":   "nE4s1eJvv411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65f1409c11bd8b452d418f03aaf3a3369b1cae8c45c079cff5c2a46d92eb060f",
+				"DiscoKey":   "discokey:f1146b5ff2cb1e8f090ffefcdb7d5e885388aa34bdd197656f65914cc3da7578",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48284",
+					"10.65.0.27:48284",
+					"172.17.0.1:48284",
+					"172.18.0.1:48284",
+					"172.19.0.1:48284",
+					"172.20.0.1:48284",
+					"172.21.0.1:48284",
+					"172.22.0.1:48284",
+					"172.23.0.1:48284",
+					"172.24.0.1:48284",
+					"172.25.0.1:48284",
+					"172.26.0.1:48284",
+					"172.27.0.1:48284",
+					"172.28.0.1:48284"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:19:22.659613084Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1543860425024168,
+				"StableID":   "nsCM4YbD4D11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc542a090ddb07798283d5e07c2f2a5b5c346d3f348b9af0fe3ed8c97c34a73f",
+				"DiscoKey":   "discokey:9c81180c8dcfd8cdbcbb5a6cdff8788b7478e139043e1c9cb430bb12ff4d9c41",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49569",
+					"10.65.0.27:49569",
+					"172.17.0.1:49569",
+					"172.18.0.1:49569",
+					"172.19.0.1:49569",
+					"172.20.0.1:49569",
+					"172.21.0.1:49569",
+					"172.22.0.1:49569",
+					"172.23.0.1:49569",
+					"172.24.0.1:49569",
+					"172.25.0.1:49569",
+					"172.26.0.1:49569",
+					"172.27.0.1:49569",
+					"172.28.0.1:49569"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:19:23.203947754Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         405195271382504,
+				"StableID":   "nsk9cynWA411CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae23a3331702698e34b01628737d5b8c91a4860ef321ede711ec45a1f7f16a39",
+				"DiscoKey":   "discokey:e169bbf9a738b39c766c1d60db70b02932e5436e0c948a8100001ff9a670e669",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43159",
+					"10.65.0.27:43159",
+					"172.17.0.1:43159",
+					"172.18.0.1:43159",
+					"172.19.0.1:43159",
+					"172.20.0.1:43159",
+					"172.21.0.1:43159",
+					"172.22.0.1:43159",
+					"172.23.0.1:43159",
+					"172.24.0.1:43159",
+					"172.25.0.1:43159",
+					"172.26.0.1:43159",
+					"172.27.0.1:43159",
+					"172.28.0.1:43159"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:19:23.74529735Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3012369755640188,
+				"StableID":   "nFaxv2rJXQ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bf81993c448c401aabadfb70775d12ea095e3661892ad67b2ac1df81287d4419",
+				"KeyExpiry":  "2026-11-09T09:19:24Z",
+				"DiscoKey":   "discokey:5f695b82c9c07a756d9396d5c6ddaaf6f793ee3e942f0fc7dd7abee85acf7716",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44334",
+					"10.65.0.27:44334",
+					"172.17.0.1:44334",
+					"172.18.0.1:44334",
+					"172.19.0.1:44334",
+					"172.20.0.1:44334",
+					"172.21.0.1:44334",
+					"172.22.0.1:44334",
+					"172.23.0.1:44334",
+					"172.24.0.1:44334",
+					"172.25.0.1:44334",
+					"172.26.0.1:44334",
+					"172.27.0.1:44334",
+					"172.28.0.1:44334"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:19:24.811647723Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7468751552721751,
+				"StableID":   "ncdCBSScK121CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1dfc22f5f5c6f1c3ed49365c6aecd7052aab04c55c7fb36b648c1e0e3f90ce06",
+				"KeyExpiry":  "2026-11-09T09:19:25Z",
+				"DiscoKey":   "discokey:3ebea6bb99e095d26d9832c20ef05cf3656a46b26658f6199c22ac578444446d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49818",
+					"10.65.0.27:49818",
+					"172.17.0.1:49818",
+					"172.18.0.1:49818",
+					"172.19.0.1:49818",
+					"172.20.0.1:49818",
+					"172.21.0.1:49818",
+					"172.22.0.1:49818",
+					"172.23.0.1:49818",
+					"172.24.0.1:49818",
+					"172.25.0.1:49818",
+					"172.26.0.1:49818",
+					"172.27.0.1:49818",
+					"172.28.0.1:49818"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:19:25.353736893Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5452265111916024,
+				"StableID":   "nsg3Y2mLaj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a2dc8487de8773ec3bb4ef74f14b9e2bd8dbc3ef4bae39fb2b60e26447edce28",
+				"KeyExpiry":  "2026-11-09T09:19:25Z",
+				"DiscoKey":   "discokey:13a5d9f2ab3232d280bd0902671b54b3f12970168a613de5a841db3778eafc73",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49612",
+					"10.65.0.27:49612",
+					"172.17.0.1:49612",
+					"172.18.0.1:49612",
+					"172.19.0.1:49612",
+					"172.20.0.1:49612",
+					"172.21.0.1:49612",
+					"172.22.0.1:49612",
+					"172.23.0.1:49612",
+					"172.24.0.1:49612",
+					"172.25.0.1:49612",
+					"172.26.0.1:49612",
+					"172.27.0.1:49612",
+					"172.28.0.1:49612"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:19:25.921846203Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{"principals": [
+				{"nodeIP": "100.64.0.17"},
+				{"nodeIP": "100.64.0.19"},
+				{"nodeIP": "fd7a:115c:a1e0::11"},
+				{"nodeIP": "fd7a:115c:a1e0::13"}
+			], "sshUsers": {"root": "root", "ubuntu": "ubuntu"}, "action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3426536136371848": {
+				"ID":          3426536136371848,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		},
+		"ssh_rules": [{"principals": [
+			{"nodeIP": "100.64.0.17"},
+			{"nodeIP": "100.64.0.19"},
+			{"nodeIP": "fd7a:115c:a1e0::11"},
+			{"nodeIP": "fd7a:115c:a1e0::13"}
+		], "sshUsers": {"root": "root", "ubuntu": "ubuntu"}, "action": {
+			"accept":                    true,
+			"allowAgentForwarding":      true,
+			"allowLocalPortForwarding":  true,
+			"allowRemotePortForwarding": true
+		}}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4784639507416429,
+				"StableID":   "n6jS3GNyMe11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       4784639507416429,
+				"Key":        "nodekey:be0d544d162ab0cc7eab0034e6efc0bf3052698d6c2675a496d59c66a47bb271",
+				"DiscoKey":   "discokey:601f5de8b0e63c86913fb4f7a3c29b4367d39af5707d5c4115e5595312c65965",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:60965",
+					"10.65.0.27:60965",
+					"172.17.0.1:60965",
+					"172.18.0.1:60965",
+					"172.19.0.1:60965",
+					"172.20.0.1:60965",
+					"172.21.0.1:60965",
+					"172.22.0.1:60965",
+					"172.23.0.1:60965",
+					"172.24.0.1:60965",
+					"172.25.0.1:60965",
+					"172.26.0.1:60965",
+					"172.27.0.1:60965",
+					"172.28.0.1:60965"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:19:21.040816987Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:be0d544d162ab0cc7eab0034e6efc0bf3052698d6c2675a496d59c66a47bb271",
+			"MachineKey": "mkey:19cf10d648ddfaea067dd580cf489b0e70f9d85647b8a5cae890c86169b0692e",
+			"Peers": [{
+				"ID":         8573270307094724,
+				"StableID":   "ndBgFrGrw921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5de5d550caee76af25800ff2bafdfa25b3ee0c1a527297092b6bee88428d291e",
+				"DiscoKey":   "discokey:78d3621ddf45b61eb6efef3619f62e5f49ca13b2b47e07a8aeb4e9991295d87f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58135",
+					"10.65.0.27:58135",
+					"172.17.0.1:58135",
+					"172.18.0.1:58135",
+					"172.19.0.1:58135",
+					"172.20.0.1:58135",
+					"172.21.0.1:58135",
+					"172.22.0.1:58135",
+					"172.23.0.1:58135",
+					"172.24.0.1:58135",
+					"172.25.0.1:58135",
+					"172.26.0.1:58135",
+					"172.27.0.1:58135",
+					"172.28.0.1:58135"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:19:18.34069644Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4757874630165731,
+				"StableID":   "nzQWVKJr9e11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:877d125b234c5f659d778821d79fee683681f31e495153a20af7c60dcfc24c64",
+				"DiscoKey":   "discokey:8fe88cddefa5b8cedc575e52ccbbfadb4639b7bb852024bdb55c063601cd2b1f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37973",
+					"10.65.0.27:37973",
+					"172.17.0.1:37973",
+					"172.18.0.1:37973",
+					"172.19.0.1:37973",
+					"172.20.0.1:37973",
+					"172.21.0.1:37973",
+					"172.22.0.1:37973",
+					"172.23.0.1:37973",
+					"172.24.0.1:37973",
+					"172.25.0.1:37973",
+					"172.26.0.1:37973",
+					"172.27.0.1:37973",
+					"172.28.0.1:37973"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:19:18.859688049Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5181576811348899,
+				"StableID":   "nSrsLiEkTh11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93e906a9692b49c5eda79cce6a97ed4799a48e1605e746494496a77c39aae528",
+				"DiscoKey":   "discokey:6ba5c2b98606fd8bf77d552d88b0c2ba92fe06c93fc2e6fcae76813ff14c2371",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:44257",
+					"10.65.0.27:44257",
+					"172.17.0.1:44257",
+					"172.18.0.1:44257",
+					"172.19.0.1:44257",
+					"172.20.0.1:44257",
+					"172.21.0.1:44257",
+					"172.22.0.1:44257",
+					"172.23.0.1:44257",
+					"172.24.0.1:44257",
+					"172.25.0.1:44257",
+					"172.26.0.1:44257",
+					"172.27.0.1:44257",
+					"172.28.0.1:44257"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:19:19.420242613Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3024142579763633,
+				"StableID":   "nYSs5f6ecQ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f5ef265e9d7fe135001251b2512cf85ea9ad43d7aa44b338e95335004b6aae01",
+				"DiscoKey":   "discokey:9e5f76deebc53ac3b3deaf8e01600088e43398bc51076a70cd468a5a2fbc4527",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34886",
+					"10.65.0.27:34886",
+					"172.17.0.1:34886",
+					"172.18.0.1:34886",
+					"172.19.0.1:34886",
+					"172.20.0.1:34886",
+					"172.21.0.1:34886",
+					"172.22.0.1:34886",
+					"172.23.0.1:34886",
+					"172.24.0.1:34886",
+					"172.25.0.1:34886",
+					"172.26.0.1:34886",
+					"172.27.0.1:34886",
+					"172.28.0.1:34886"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:19:19.9714794Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7907824750755997,
+				"StableID":   "nCij9X9Uk421CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e15db383b9c813c3c6c972ef3d514208ff3e02fa3d80e28cd7cf8c6ef25b656f",
+				"DiscoKey":   "discokey:1532948c521598c248fbdbe0b7fd01133db4f6fdcc657d8874a6b968f6903757",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41744",
+					"10.65.0.27:41744",
+					"172.17.0.1:41744",
+					"172.18.0.1:41744",
+					"172.19.0.1:41744",
+					"172.20.0.1:41744",
+					"172.21.0.1:41744",
+					"172.22.0.1:41744",
+					"172.23.0.1:41744",
+					"172.24.0.1:41744",
+					"172.25.0.1:41744",
+					"172.26.0.1:41744",
+					"172.27.0.1:41744",
+					"172.28.0.1:41744"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:19:20.501136787Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3426646194877689,
+				"StableID":   "n2V5FjBwkT11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9dc6d6f65864f92af390216540c9b809f076879fa6ab1ddf4477566c3d3ca72c",
+				"DiscoKey":   "discokey:023df61eb4a134f8b491c87215f64b6875f0232fc5483452c0cf987b99f7882e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:32842",
+					"10.65.0.27:32842",
+					"172.17.0.1:32842",
+					"172.18.0.1:32842",
+					"172.19.0.1:32842",
+					"172.20.0.1:32842",
+					"172.21.0.1:32842",
+					"172.22.0.1:32842",
+					"172.23.0.1:32842",
+					"172.24.0.1:32842",
+					"172.25.0.1:32842",
+					"172.26.0.1:32842",
+					"172.27.0.1:32842",
+					"172.28.0.1:32842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:19:21.585938624Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6486969541950041,
+				"StableID":   "nWodq1hxes11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:528c424e05b2a205ff1bff5e5190722becab3d5a10566d11272a30cdddedc91f",
+				"DiscoKey":   "discokey:34927bc670b26f71112fe7735f62e5e23727099fc8728b68dd5a04e86a5c7918",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47647",
+					"10.65.0.27:47647",
+					"172.17.0.1:47647",
+					"172.18.0.1:47647",
+					"172.19.0.1:47647",
+					"172.20.0.1:47647",
+					"172.21.0.1:47647",
+					"172.22.0.1:47647",
+					"172.23.0.1:47647",
+					"172.24.0.1:47647",
+					"172.25.0.1:47647",
+					"172.26.0.1:47647",
+					"172.27.0.1:47647",
+					"172.28.0.1:47647"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:19:22.122736953Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         503241623682931,
+				"StableID":   "nE4s1eJvv411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65f1409c11bd8b452d418f03aaf3a3369b1cae8c45c079cff5c2a46d92eb060f",
+				"DiscoKey":   "discokey:f1146b5ff2cb1e8f090ffefcdb7d5e885388aa34bdd197656f65914cc3da7578",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48284",
+					"10.65.0.27:48284",
+					"172.17.0.1:48284",
+					"172.18.0.1:48284",
+					"172.19.0.1:48284",
+					"172.20.0.1:48284",
+					"172.21.0.1:48284",
+					"172.22.0.1:48284",
+					"172.23.0.1:48284",
+					"172.24.0.1:48284",
+					"172.25.0.1:48284",
+					"172.26.0.1:48284",
+					"172.27.0.1:48284",
+					"172.28.0.1:48284"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:19:22.659613084Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1543860425024168,
+				"StableID":   "nsCM4YbD4D11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc542a090ddb07798283d5e07c2f2a5b5c346d3f348b9af0fe3ed8c97c34a73f",
+				"DiscoKey":   "discokey:9c81180c8dcfd8cdbcbb5a6cdff8788b7478e139043e1c9cb430bb12ff4d9c41",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49569",
+					"10.65.0.27:49569",
+					"172.17.0.1:49569",
+					"172.18.0.1:49569",
+					"172.19.0.1:49569",
+					"172.20.0.1:49569",
+					"172.21.0.1:49569",
+					"172.22.0.1:49569",
+					"172.23.0.1:49569",
+					"172.24.0.1:49569",
+					"172.25.0.1:49569",
+					"172.26.0.1:49569",
+					"172.27.0.1:49569",
+					"172.28.0.1:49569"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:19:23.203947754Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         405195271382504,
+				"StableID":   "nsk9cynWA411CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae23a3331702698e34b01628737d5b8c91a4860ef321ede711ec45a1f7f16a39",
+				"DiscoKey":   "discokey:e169bbf9a738b39c766c1d60db70b02932e5436e0c948a8100001ff9a670e669",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43159",
+					"10.65.0.27:43159",
+					"172.17.0.1:43159",
+					"172.18.0.1:43159",
+					"172.19.0.1:43159",
+					"172.20.0.1:43159",
+					"172.21.0.1:43159",
+					"172.22.0.1:43159",
+					"172.23.0.1:43159",
+					"172.24.0.1:43159",
+					"172.25.0.1:43159",
+					"172.26.0.1:43159",
+					"172.27.0.1:43159",
+					"172.28.0.1:43159"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:19:23.74529735Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3426536136371848,
+				"StableID":   "nV5Uk3JtkT11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9acfa98fbb055c7bbfbcfc470e2a3d7c4ec2e992b0718826593b6d1abc45cb1f",
+				"DiscoKey":   "discokey:5e5ace1c16176fb4349597cd6b68958f2a40160e8d74765bb4f53885a135ae75",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36618",
+					"10.65.0.27:36618",
+					"172.17.0.1:36618",
+					"172.18.0.1:36618",
+					"172.19.0.1:36618",
+					"172.20.0.1:36618",
+					"172.21.0.1:36618",
+					"172.22.0.1:36618",
+					"172.23.0.1:36618",
+					"172.24.0.1:36618",
+					"172.25.0.1:36618",
+					"172.26.0.1:36618",
+					"172.27.0.1:36618",
+					"172.28.0.1:36618"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:19:24.279863448Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3012369755640188,
+				"StableID":   "nFaxv2rJXQ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bf81993c448c401aabadfb70775d12ea095e3661892ad67b2ac1df81287d4419",
+				"KeyExpiry":  "2026-11-09T09:19:24Z",
+				"DiscoKey":   "discokey:5f695b82c9c07a756d9396d5c6ddaaf6f793ee3e942f0fc7dd7abee85acf7716",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44334",
+					"10.65.0.27:44334",
+					"172.17.0.1:44334",
+					"172.18.0.1:44334",
+					"172.19.0.1:44334",
+					"172.20.0.1:44334",
+					"172.21.0.1:44334",
+					"172.22.0.1:44334",
+					"172.23.0.1:44334",
+					"172.24.0.1:44334",
+					"172.25.0.1:44334",
+					"172.26.0.1:44334",
+					"172.27.0.1:44334",
+					"172.28.0.1:44334"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:19:24.811647723Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7468751552721751,
+				"StableID":   "ncdCBSScK121CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1dfc22f5f5c6f1c3ed49365c6aecd7052aab04c55c7fb36b648c1e0e3f90ce06",
+				"KeyExpiry":  "2026-11-09T09:19:25Z",
+				"DiscoKey":   "discokey:3ebea6bb99e095d26d9832c20ef05cf3656a46b26658f6199c22ac578444446d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49818",
+					"10.65.0.27:49818",
+					"172.17.0.1:49818",
+					"172.18.0.1:49818",
+					"172.19.0.1:49818",
+					"172.20.0.1:49818",
+					"172.21.0.1:49818",
+					"172.22.0.1:49818",
+					"172.23.0.1:49818",
+					"172.24.0.1:49818",
+					"172.25.0.1:49818",
+					"172.26.0.1:49818",
+					"172.27.0.1:49818",
+					"172.28.0.1:49818"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:19:25.353736893Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5452265111916024,
+				"StableID":   "nsg3Y2mLaj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a2dc8487de8773ec3bb4ef74f14b9e2bd8dbc3ef4bae39fb2b60e26447edce28",
+				"KeyExpiry":  "2026-11-09T09:19:25Z",
+				"DiscoKey":   "discokey:13a5d9f2ab3232d280bd0902671b54b3f12970168a613de5a841db3778eafc73",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49612",
+					"10.65.0.27:49612",
+					"172.17.0.1:49612",
+					"172.18.0.1:49612",
+					"172.19.0.1:49612",
+					"172.20.0.1:49612",
+					"172.21.0.1:49612",
+					"172.22.0.1:49612",
+					"172.23.0.1:49612",
+					"172.24.0.1:49612",
+					"172.25.0.1:49612",
+					"172.26.0.1:49612",
+					"172.27.0.1:49612",
+					"172.28.0.1:49612"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:19:25.921846203Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4784639507416429": {
+				"ID":          4784639507416429,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5452265111916024,
+				"StableID":   "nsg3Y2mLaj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a2dc8487de8773ec3bb4ef74f14b9e2bd8dbc3ef4bae39fb2b60e26447edce28",
+				"KeyExpiry":  "2026-11-09T09:19:25Z",
+				"DiscoKey":   "discokey:13a5d9f2ab3232d280bd0902671b54b3f12970168a613de5a841db3778eafc73",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49612",
+					"10.65.0.27:49612",
+					"172.17.0.1:49612",
+					"172.18.0.1:49612",
+					"172.19.0.1:49612",
+					"172.20.0.1:49612",
+					"172.21.0.1:49612",
+					"172.22.0.1:49612",
+					"172.23.0.1:49612",
+					"172.24.0.1:49612",
+					"172.25.0.1:49612",
+					"172.26.0.1:49612",
+					"172.27.0.1:49612",
+					"172.28.0.1:49612"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:19:25.921846203Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a2dc8487de8773ec3bb4ef74f14b9e2bd8dbc3ef4bae39fb2b60e26447edce28",
+			"MachineKey": "mkey:32cee8ff6f08745232481c9eaf0eb24eecc5bef74906daed00cd4c7286b85045",
+			"Peers": [{
+				"ID":         8573270307094724,
+				"StableID":   "ndBgFrGrw921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5de5d550caee76af25800ff2bafdfa25b3ee0c1a527297092b6bee88428d291e",
+				"DiscoKey":   "discokey:78d3621ddf45b61eb6efef3619f62e5f49ca13b2b47e07a8aeb4e9991295d87f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58135",
+					"10.65.0.27:58135",
+					"172.17.0.1:58135",
+					"172.18.0.1:58135",
+					"172.19.0.1:58135",
+					"172.20.0.1:58135",
+					"172.21.0.1:58135",
+					"172.22.0.1:58135",
+					"172.23.0.1:58135",
+					"172.24.0.1:58135",
+					"172.25.0.1:58135",
+					"172.26.0.1:58135",
+					"172.27.0.1:58135",
+					"172.28.0.1:58135"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:19:18.34069644Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4757874630165731,
+				"StableID":   "nzQWVKJr9e11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:877d125b234c5f659d778821d79fee683681f31e495153a20af7c60dcfc24c64",
+				"DiscoKey":   "discokey:8fe88cddefa5b8cedc575e52ccbbfadb4639b7bb852024bdb55c063601cd2b1f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37973",
+					"10.65.0.27:37973",
+					"172.17.0.1:37973",
+					"172.18.0.1:37973",
+					"172.19.0.1:37973",
+					"172.20.0.1:37973",
+					"172.21.0.1:37973",
+					"172.22.0.1:37973",
+					"172.23.0.1:37973",
+					"172.24.0.1:37973",
+					"172.25.0.1:37973",
+					"172.26.0.1:37973",
+					"172.27.0.1:37973",
+					"172.28.0.1:37973"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:19:18.859688049Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5181576811348899,
+				"StableID":   "nSrsLiEkTh11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93e906a9692b49c5eda79cce6a97ed4799a48e1605e746494496a77c39aae528",
+				"DiscoKey":   "discokey:6ba5c2b98606fd8bf77d552d88b0c2ba92fe06c93fc2e6fcae76813ff14c2371",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:44257",
+					"10.65.0.27:44257",
+					"172.17.0.1:44257",
+					"172.18.0.1:44257",
+					"172.19.0.1:44257",
+					"172.20.0.1:44257",
+					"172.21.0.1:44257",
+					"172.22.0.1:44257",
+					"172.23.0.1:44257",
+					"172.24.0.1:44257",
+					"172.25.0.1:44257",
+					"172.26.0.1:44257",
+					"172.27.0.1:44257",
+					"172.28.0.1:44257"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:19:19.420242613Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3024142579763633,
+				"StableID":   "nYSs5f6ecQ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f5ef265e9d7fe135001251b2512cf85ea9ad43d7aa44b338e95335004b6aae01",
+				"DiscoKey":   "discokey:9e5f76deebc53ac3b3deaf8e01600088e43398bc51076a70cd468a5a2fbc4527",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34886",
+					"10.65.0.27:34886",
+					"172.17.0.1:34886",
+					"172.18.0.1:34886",
+					"172.19.0.1:34886",
+					"172.20.0.1:34886",
+					"172.21.0.1:34886",
+					"172.22.0.1:34886",
+					"172.23.0.1:34886",
+					"172.24.0.1:34886",
+					"172.25.0.1:34886",
+					"172.26.0.1:34886",
+					"172.27.0.1:34886",
+					"172.28.0.1:34886"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:19:19.9714794Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7907824750755997,
+				"StableID":   "nCij9X9Uk421CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e15db383b9c813c3c6c972ef3d514208ff3e02fa3d80e28cd7cf8c6ef25b656f",
+				"DiscoKey":   "discokey:1532948c521598c248fbdbe0b7fd01133db4f6fdcc657d8874a6b968f6903757",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41744",
+					"10.65.0.27:41744",
+					"172.17.0.1:41744",
+					"172.18.0.1:41744",
+					"172.19.0.1:41744",
+					"172.20.0.1:41744",
+					"172.21.0.1:41744",
+					"172.22.0.1:41744",
+					"172.23.0.1:41744",
+					"172.24.0.1:41744",
+					"172.25.0.1:41744",
+					"172.26.0.1:41744",
+					"172.27.0.1:41744",
+					"172.28.0.1:41744"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:19:20.501136787Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4784639507416429,
+				"StableID":   "n6jS3GNyMe11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:be0d544d162ab0cc7eab0034e6efc0bf3052698d6c2675a496d59c66a47bb271",
+				"DiscoKey":   "discokey:601f5de8b0e63c86913fb4f7a3c29b4367d39af5707d5c4115e5595312c65965",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:60965",
+					"10.65.0.27:60965",
+					"172.17.0.1:60965",
+					"172.18.0.1:60965",
+					"172.19.0.1:60965",
+					"172.20.0.1:60965",
+					"172.21.0.1:60965",
+					"172.22.0.1:60965",
+					"172.23.0.1:60965",
+					"172.24.0.1:60965",
+					"172.25.0.1:60965",
+					"172.26.0.1:60965",
+					"172.27.0.1:60965",
+					"172.28.0.1:60965"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:19:21.040816987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3426646194877689,
+				"StableID":   "n2V5FjBwkT11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9dc6d6f65864f92af390216540c9b809f076879fa6ab1ddf4477566c3d3ca72c",
+				"DiscoKey":   "discokey:023df61eb4a134f8b491c87215f64b6875f0232fc5483452c0cf987b99f7882e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:32842",
+					"10.65.0.27:32842",
+					"172.17.0.1:32842",
+					"172.18.0.1:32842",
+					"172.19.0.1:32842",
+					"172.20.0.1:32842",
+					"172.21.0.1:32842",
+					"172.22.0.1:32842",
+					"172.23.0.1:32842",
+					"172.24.0.1:32842",
+					"172.25.0.1:32842",
+					"172.26.0.1:32842",
+					"172.27.0.1:32842",
+					"172.28.0.1:32842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:19:21.585938624Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6486969541950041,
+				"StableID":   "nWodq1hxes11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:528c424e05b2a205ff1bff5e5190722becab3d5a10566d11272a30cdddedc91f",
+				"DiscoKey":   "discokey:34927bc670b26f71112fe7735f62e5e23727099fc8728b68dd5a04e86a5c7918",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47647",
+					"10.65.0.27:47647",
+					"172.17.0.1:47647",
+					"172.18.0.1:47647",
+					"172.19.0.1:47647",
+					"172.20.0.1:47647",
+					"172.21.0.1:47647",
+					"172.22.0.1:47647",
+					"172.23.0.1:47647",
+					"172.24.0.1:47647",
+					"172.25.0.1:47647",
+					"172.26.0.1:47647",
+					"172.27.0.1:47647",
+					"172.28.0.1:47647"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:19:22.122736953Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         503241623682931,
+				"StableID":   "nE4s1eJvv411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65f1409c11bd8b452d418f03aaf3a3369b1cae8c45c079cff5c2a46d92eb060f",
+				"DiscoKey":   "discokey:f1146b5ff2cb1e8f090ffefcdb7d5e885388aa34bdd197656f65914cc3da7578",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48284",
+					"10.65.0.27:48284",
+					"172.17.0.1:48284",
+					"172.18.0.1:48284",
+					"172.19.0.1:48284",
+					"172.20.0.1:48284",
+					"172.21.0.1:48284",
+					"172.22.0.1:48284",
+					"172.23.0.1:48284",
+					"172.24.0.1:48284",
+					"172.25.0.1:48284",
+					"172.26.0.1:48284",
+					"172.27.0.1:48284",
+					"172.28.0.1:48284"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:19:22.659613084Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1543860425024168,
+				"StableID":   "nsCM4YbD4D11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc542a090ddb07798283d5e07c2f2a5b5c346d3f348b9af0fe3ed8c97c34a73f",
+				"DiscoKey":   "discokey:9c81180c8dcfd8cdbcbb5a6cdff8788b7478e139043e1c9cb430bb12ff4d9c41",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49569",
+					"10.65.0.27:49569",
+					"172.17.0.1:49569",
+					"172.18.0.1:49569",
+					"172.19.0.1:49569",
+					"172.20.0.1:49569",
+					"172.21.0.1:49569",
+					"172.22.0.1:49569",
+					"172.23.0.1:49569",
+					"172.24.0.1:49569",
+					"172.25.0.1:49569",
+					"172.26.0.1:49569",
+					"172.27.0.1:49569",
+					"172.28.0.1:49569"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:19:23.203947754Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         405195271382504,
+				"StableID":   "nsk9cynWA411CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae23a3331702698e34b01628737d5b8c91a4860ef321ede711ec45a1f7f16a39",
+				"DiscoKey":   "discokey:e169bbf9a738b39c766c1d60db70b02932e5436e0c948a8100001ff9a670e669",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43159",
+					"10.65.0.27:43159",
+					"172.17.0.1:43159",
+					"172.18.0.1:43159",
+					"172.19.0.1:43159",
+					"172.20.0.1:43159",
+					"172.21.0.1:43159",
+					"172.22.0.1:43159",
+					"172.23.0.1:43159",
+					"172.24.0.1:43159",
+					"172.25.0.1:43159",
+					"172.26.0.1:43159",
+					"172.27.0.1:43159",
+					"172.28.0.1:43159"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:19:23.74529735Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3426536136371848,
+				"StableID":   "nV5Uk3JtkT11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9acfa98fbb055c7bbfbcfc470e2a3d7c4ec2e992b0718826593b6d1abc45cb1f",
+				"DiscoKey":   "discokey:5e5ace1c16176fb4349597cd6b68958f2a40160e8d74765bb4f53885a135ae75",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36618",
+					"10.65.0.27:36618",
+					"172.17.0.1:36618",
+					"172.18.0.1:36618",
+					"172.19.0.1:36618",
+					"172.20.0.1:36618",
+					"172.21.0.1:36618",
+					"172.22.0.1:36618",
+					"172.23.0.1:36618",
+					"172.24.0.1:36618",
+					"172.25.0.1:36618",
+					"172.26.0.1:36618",
+					"172.27.0.1:36618",
+					"172.28.0.1:36618"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:19:24.279863448Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3012369755640188,
+				"StableID":   "nFaxv2rJXQ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bf81993c448c401aabadfb70775d12ea095e3661892ad67b2ac1df81287d4419",
+				"KeyExpiry":  "2026-11-09T09:19:24Z",
+				"DiscoKey":   "discokey:5f695b82c9c07a756d9396d5c6ddaaf6f793ee3e942f0fc7dd7abee85acf7716",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44334",
+					"10.65.0.27:44334",
+					"172.17.0.1:44334",
+					"172.18.0.1:44334",
+					"172.19.0.1:44334",
+					"172.20.0.1:44334",
+					"172.21.0.1:44334",
+					"172.22.0.1:44334",
+					"172.23.0.1:44334",
+					"172.24.0.1:44334",
+					"172.25.0.1:44334",
+					"172.26.0.1:44334",
+					"172.27.0.1:44334",
+					"172.28.0.1:44334"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:19:24.811647723Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7468751552721751,
+				"StableID":   "ncdCBSScK121CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1dfc22f5f5c6f1c3ed49365c6aecd7052aab04c55c7fb36b648c1e0e3f90ce06",
+				"KeyExpiry":  "2026-11-09T09:19:25Z",
+				"DiscoKey":   "discokey:3ebea6bb99e095d26d9832c20ef05cf3656a46b26658f6199c22ac578444446d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49818",
+					"10.65.0.27:49818",
+					"172.17.0.1:49818",
+					"172.18.0.1:49818",
+					"172.19.0.1:49818",
+					"172.20.0.1:49818",
+					"172.21.0.1:49818",
+					"172.22.0.1:49818",
+					"172.23.0.1:49818",
+					"172.24.0.1:49818",
+					"172.25.0.1:49818",
+					"172.26.0.1:49818",
+					"172.27.0.1:49818",
+					"172.28.0.1:49818"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:19:25.353736893Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5181576811348899,
+				"StableID":   "nSrsLiEkTh11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       5181576811348899,
+				"Key":        "nodekey:93e906a9692b49c5eda79cce6a97ed4799a48e1605e746494496a77c39aae528",
+				"DiscoKey":   "discokey:6ba5c2b98606fd8bf77d552d88b0c2ba92fe06c93fc2e6fcae76813ff14c2371",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:44257",
+					"10.65.0.27:44257",
+					"172.17.0.1:44257",
+					"172.18.0.1:44257",
+					"172.19.0.1:44257",
+					"172.20.0.1:44257",
+					"172.21.0.1:44257",
+					"172.22.0.1:44257",
+					"172.23.0.1:44257",
+					"172.24.0.1:44257",
+					"172.25.0.1:44257",
+					"172.26.0.1:44257",
+					"172.27.0.1:44257",
+					"172.28.0.1:44257"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:19:19.420242613Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:93e906a9692b49c5eda79cce6a97ed4799a48e1605e746494496a77c39aae528",
+			"MachineKey": "mkey:bb9f2c1a023ff2146cc3f41f748979783848230b562cb7de9cd1dd82bef4e944",
+			"Peers": [{
+				"ID":         8573270307094724,
+				"StableID":   "ndBgFrGrw921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5de5d550caee76af25800ff2bafdfa25b3ee0c1a527297092b6bee88428d291e",
+				"DiscoKey":   "discokey:78d3621ddf45b61eb6efef3619f62e5f49ca13b2b47e07a8aeb4e9991295d87f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58135",
+					"10.65.0.27:58135",
+					"172.17.0.1:58135",
+					"172.18.0.1:58135",
+					"172.19.0.1:58135",
+					"172.20.0.1:58135",
+					"172.21.0.1:58135",
+					"172.22.0.1:58135",
+					"172.23.0.1:58135",
+					"172.24.0.1:58135",
+					"172.25.0.1:58135",
+					"172.26.0.1:58135",
+					"172.27.0.1:58135",
+					"172.28.0.1:58135"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:19:18.34069644Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4757874630165731,
+				"StableID":   "nzQWVKJr9e11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:877d125b234c5f659d778821d79fee683681f31e495153a20af7c60dcfc24c64",
+				"DiscoKey":   "discokey:8fe88cddefa5b8cedc575e52ccbbfadb4639b7bb852024bdb55c063601cd2b1f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37973",
+					"10.65.0.27:37973",
+					"172.17.0.1:37973",
+					"172.18.0.1:37973",
+					"172.19.0.1:37973",
+					"172.20.0.1:37973",
+					"172.21.0.1:37973",
+					"172.22.0.1:37973",
+					"172.23.0.1:37973",
+					"172.24.0.1:37973",
+					"172.25.0.1:37973",
+					"172.26.0.1:37973",
+					"172.27.0.1:37973",
+					"172.28.0.1:37973"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:19:18.859688049Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3024142579763633,
+				"StableID":   "nYSs5f6ecQ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f5ef265e9d7fe135001251b2512cf85ea9ad43d7aa44b338e95335004b6aae01",
+				"DiscoKey":   "discokey:9e5f76deebc53ac3b3deaf8e01600088e43398bc51076a70cd468a5a2fbc4527",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34886",
+					"10.65.0.27:34886",
+					"172.17.0.1:34886",
+					"172.18.0.1:34886",
+					"172.19.0.1:34886",
+					"172.20.0.1:34886",
+					"172.21.0.1:34886",
+					"172.22.0.1:34886",
+					"172.23.0.1:34886",
+					"172.24.0.1:34886",
+					"172.25.0.1:34886",
+					"172.26.0.1:34886",
+					"172.27.0.1:34886",
+					"172.28.0.1:34886"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:19:19.9714794Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7907824750755997,
+				"StableID":   "nCij9X9Uk421CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e15db383b9c813c3c6c972ef3d514208ff3e02fa3d80e28cd7cf8c6ef25b656f",
+				"DiscoKey":   "discokey:1532948c521598c248fbdbe0b7fd01133db4f6fdcc657d8874a6b968f6903757",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41744",
+					"10.65.0.27:41744",
+					"172.17.0.1:41744",
+					"172.18.0.1:41744",
+					"172.19.0.1:41744",
+					"172.20.0.1:41744",
+					"172.21.0.1:41744",
+					"172.22.0.1:41744",
+					"172.23.0.1:41744",
+					"172.24.0.1:41744",
+					"172.25.0.1:41744",
+					"172.26.0.1:41744",
+					"172.27.0.1:41744",
+					"172.28.0.1:41744"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:19:20.501136787Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4784639507416429,
+				"StableID":   "n6jS3GNyMe11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:be0d544d162ab0cc7eab0034e6efc0bf3052698d6c2675a496d59c66a47bb271",
+				"DiscoKey":   "discokey:601f5de8b0e63c86913fb4f7a3c29b4367d39af5707d5c4115e5595312c65965",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:60965",
+					"10.65.0.27:60965",
+					"172.17.0.1:60965",
+					"172.18.0.1:60965",
+					"172.19.0.1:60965",
+					"172.20.0.1:60965",
+					"172.21.0.1:60965",
+					"172.22.0.1:60965",
+					"172.23.0.1:60965",
+					"172.24.0.1:60965",
+					"172.25.0.1:60965",
+					"172.26.0.1:60965",
+					"172.27.0.1:60965",
+					"172.28.0.1:60965"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:19:21.040816987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3426646194877689,
+				"StableID":   "n2V5FjBwkT11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9dc6d6f65864f92af390216540c9b809f076879fa6ab1ddf4477566c3d3ca72c",
+				"DiscoKey":   "discokey:023df61eb4a134f8b491c87215f64b6875f0232fc5483452c0cf987b99f7882e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:32842",
+					"10.65.0.27:32842",
+					"172.17.0.1:32842",
+					"172.18.0.1:32842",
+					"172.19.0.1:32842",
+					"172.20.0.1:32842",
+					"172.21.0.1:32842",
+					"172.22.0.1:32842",
+					"172.23.0.1:32842",
+					"172.24.0.1:32842",
+					"172.25.0.1:32842",
+					"172.26.0.1:32842",
+					"172.27.0.1:32842",
+					"172.28.0.1:32842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:19:21.585938624Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6486969541950041,
+				"StableID":   "nWodq1hxes11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:528c424e05b2a205ff1bff5e5190722becab3d5a10566d11272a30cdddedc91f",
+				"DiscoKey":   "discokey:34927bc670b26f71112fe7735f62e5e23727099fc8728b68dd5a04e86a5c7918",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47647",
+					"10.65.0.27:47647",
+					"172.17.0.1:47647",
+					"172.18.0.1:47647",
+					"172.19.0.1:47647",
+					"172.20.0.1:47647",
+					"172.21.0.1:47647",
+					"172.22.0.1:47647",
+					"172.23.0.1:47647",
+					"172.24.0.1:47647",
+					"172.25.0.1:47647",
+					"172.26.0.1:47647",
+					"172.27.0.1:47647",
+					"172.28.0.1:47647"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:19:22.122736953Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         503241623682931,
+				"StableID":   "nE4s1eJvv411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65f1409c11bd8b452d418f03aaf3a3369b1cae8c45c079cff5c2a46d92eb060f",
+				"DiscoKey":   "discokey:f1146b5ff2cb1e8f090ffefcdb7d5e885388aa34bdd197656f65914cc3da7578",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48284",
+					"10.65.0.27:48284",
+					"172.17.0.1:48284",
+					"172.18.0.1:48284",
+					"172.19.0.1:48284",
+					"172.20.0.1:48284",
+					"172.21.0.1:48284",
+					"172.22.0.1:48284",
+					"172.23.0.1:48284",
+					"172.24.0.1:48284",
+					"172.25.0.1:48284",
+					"172.26.0.1:48284",
+					"172.27.0.1:48284",
+					"172.28.0.1:48284"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:19:22.659613084Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1543860425024168,
+				"StableID":   "nsCM4YbD4D11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc542a090ddb07798283d5e07c2f2a5b5c346d3f348b9af0fe3ed8c97c34a73f",
+				"DiscoKey":   "discokey:9c81180c8dcfd8cdbcbb5a6cdff8788b7478e139043e1c9cb430bb12ff4d9c41",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49569",
+					"10.65.0.27:49569",
+					"172.17.0.1:49569",
+					"172.18.0.1:49569",
+					"172.19.0.1:49569",
+					"172.20.0.1:49569",
+					"172.21.0.1:49569",
+					"172.22.0.1:49569",
+					"172.23.0.1:49569",
+					"172.24.0.1:49569",
+					"172.25.0.1:49569",
+					"172.26.0.1:49569",
+					"172.27.0.1:49569",
+					"172.28.0.1:49569"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:19:23.203947754Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         405195271382504,
+				"StableID":   "nsk9cynWA411CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae23a3331702698e34b01628737d5b8c91a4860ef321ede711ec45a1f7f16a39",
+				"DiscoKey":   "discokey:e169bbf9a738b39c766c1d60db70b02932e5436e0c948a8100001ff9a670e669",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43159",
+					"10.65.0.27:43159",
+					"172.17.0.1:43159",
+					"172.18.0.1:43159",
+					"172.19.0.1:43159",
+					"172.20.0.1:43159",
+					"172.21.0.1:43159",
+					"172.22.0.1:43159",
+					"172.23.0.1:43159",
+					"172.24.0.1:43159",
+					"172.25.0.1:43159",
+					"172.26.0.1:43159",
+					"172.27.0.1:43159",
+					"172.28.0.1:43159"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:19:23.74529735Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3426536136371848,
+				"StableID":   "nV5Uk3JtkT11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9acfa98fbb055c7bbfbcfc470e2a3d7c4ec2e992b0718826593b6d1abc45cb1f",
+				"DiscoKey":   "discokey:5e5ace1c16176fb4349597cd6b68958f2a40160e8d74765bb4f53885a135ae75",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36618",
+					"10.65.0.27:36618",
+					"172.17.0.1:36618",
+					"172.18.0.1:36618",
+					"172.19.0.1:36618",
+					"172.20.0.1:36618",
+					"172.21.0.1:36618",
+					"172.22.0.1:36618",
+					"172.23.0.1:36618",
+					"172.24.0.1:36618",
+					"172.25.0.1:36618",
+					"172.26.0.1:36618",
+					"172.27.0.1:36618",
+					"172.28.0.1:36618"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:19:24.279863448Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3012369755640188,
+				"StableID":   "nFaxv2rJXQ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bf81993c448c401aabadfb70775d12ea095e3661892ad67b2ac1df81287d4419",
+				"KeyExpiry":  "2026-11-09T09:19:24Z",
+				"DiscoKey":   "discokey:5f695b82c9c07a756d9396d5c6ddaaf6f793ee3e942f0fc7dd7abee85acf7716",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44334",
+					"10.65.0.27:44334",
+					"172.17.0.1:44334",
+					"172.18.0.1:44334",
+					"172.19.0.1:44334",
+					"172.20.0.1:44334",
+					"172.21.0.1:44334",
+					"172.22.0.1:44334",
+					"172.23.0.1:44334",
+					"172.24.0.1:44334",
+					"172.25.0.1:44334",
+					"172.26.0.1:44334",
+					"172.27.0.1:44334",
+					"172.28.0.1:44334"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:19:24.811647723Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7468751552721751,
+				"StableID":   "ncdCBSScK121CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1dfc22f5f5c6f1c3ed49365c6aecd7052aab04c55c7fb36b648c1e0e3f90ce06",
+				"KeyExpiry":  "2026-11-09T09:19:25Z",
+				"DiscoKey":   "discokey:3ebea6bb99e095d26d9832c20ef05cf3656a46b26658f6199c22ac578444446d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49818",
+					"10.65.0.27:49818",
+					"172.17.0.1:49818",
+					"172.18.0.1:49818",
+					"172.19.0.1:49818",
+					"172.20.0.1:49818",
+					"172.21.0.1:49818",
+					"172.22.0.1:49818",
+					"172.23.0.1:49818",
+					"172.24.0.1:49818",
+					"172.25.0.1:49818",
+					"172.26.0.1:49818",
+					"172.27.0.1:49818",
+					"172.28.0.1:49818"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:19:25.353736893Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5452265111916024,
+				"StableID":   "nsg3Y2mLaj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a2dc8487de8773ec3bb4ef74f14b9e2bd8dbc3ef4bae39fb2b60e26447edce28",
+				"KeyExpiry":  "2026-11-09T09:19:25Z",
+				"DiscoKey":   "discokey:13a5d9f2ab3232d280bd0902671b54b3f12970168a613de5a841db3778eafc73",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49612",
+					"10.65.0.27:49612",
+					"172.17.0.1:49612",
+					"172.18.0.1:49612",
+					"172.19.0.1:49612",
+					"172.20.0.1:49612",
+					"172.21.0.1:49612",
+					"172.22.0.1:49612",
+					"172.23.0.1:49612",
+					"172.24.0.1:49612",
+					"172.25.0.1:49612",
+					"172.26.0.1:49612",
+					"172.27.0.1:49612",
+					"172.28.0.1:49612"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:19:25.921846203Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5181576811348899": {
+				"ID":          5181576811348899,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6486969541950041,
+				"StableID":   "nWodq1hxes11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       6486969541950041,
+				"Key":        "nodekey:528c424e05b2a205ff1bff5e5190722becab3d5a10566d11272a30cdddedc91f",
+				"DiscoKey":   "discokey:34927bc670b26f71112fe7735f62e5e23727099fc8728b68dd5a04e86a5c7918",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47647",
+					"10.65.0.27:47647",
+					"172.17.0.1:47647",
+					"172.18.0.1:47647",
+					"172.19.0.1:47647",
+					"172.20.0.1:47647",
+					"172.21.0.1:47647",
+					"172.22.0.1:47647",
+					"172.23.0.1:47647",
+					"172.24.0.1:47647",
+					"172.25.0.1:47647",
+					"172.26.0.1:47647",
+					"172.27.0.1:47647",
+					"172.28.0.1:47647"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:19:22.122736953Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:528c424e05b2a205ff1bff5e5190722becab3d5a10566d11272a30cdddedc91f",
+			"MachineKey": "mkey:790fbe40bf47df5da1e68d7c12f6e7c445ceea0d91543fa5962742ccf289212b",
+			"Peers": [{
+				"ID":         8573270307094724,
+				"StableID":   "ndBgFrGrw921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5de5d550caee76af25800ff2bafdfa25b3ee0c1a527297092b6bee88428d291e",
+				"DiscoKey":   "discokey:78d3621ddf45b61eb6efef3619f62e5f49ca13b2b47e07a8aeb4e9991295d87f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58135",
+					"10.65.0.27:58135",
+					"172.17.0.1:58135",
+					"172.18.0.1:58135",
+					"172.19.0.1:58135",
+					"172.20.0.1:58135",
+					"172.21.0.1:58135",
+					"172.22.0.1:58135",
+					"172.23.0.1:58135",
+					"172.24.0.1:58135",
+					"172.25.0.1:58135",
+					"172.26.0.1:58135",
+					"172.27.0.1:58135",
+					"172.28.0.1:58135"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:19:18.34069644Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4757874630165731,
+				"StableID":   "nzQWVKJr9e11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:877d125b234c5f659d778821d79fee683681f31e495153a20af7c60dcfc24c64",
+				"DiscoKey":   "discokey:8fe88cddefa5b8cedc575e52ccbbfadb4639b7bb852024bdb55c063601cd2b1f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37973",
+					"10.65.0.27:37973",
+					"172.17.0.1:37973",
+					"172.18.0.1:37973",
+					"172.19.0.1:37973",
+					"172.20.0.1:37973",
+					"172.21.0.1:37973",
+					"172.22.0.1:37973",
+					"172.23.0.1:37973",
+					"172.24.0.1:37973",
+					"172.25.0.1:37973",
+					"172.26.0.1:37973",
+					"172.27.0.1:37973",
+					"172.28.0.1:37973"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:19:18.859688049Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5181576811348899,
+				"StableID":   "nSrsLiEkTh11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93e906a9692b49c5eda79cce6a97ed4799a48e1605e746494496a77c39aae528",
+				"DiscoKey":   "discokey:6ba5c2b98606fd8bf77d552d88b0c2ba92fe06c93fc2e6fcae76813ff14c2371",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:44257",
+					"10.65.0.27:44257",
+					"172.17.0.1:44257",
+					"172.18.0.1:44257",
+					"172.19.0.1:44257",
+					"172.20.0.1:44257",
+					"172.21.0.1:44257",
+					"172.22.0.1:44257",
+					"172.23.0.1:44257",
+					"172.24.0.1:44257",
+					"172.25.0.1:44257",
+					"172.26.0.1:44257",
+					"172.27.0.1:44257",
+					"172.28.0.1:44257"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:19:19.420242613Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3024142579763633,
+				"StableID":   "nYSs5f6ecQ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f5ef265e9d7fe135001251b2512cf85ea9ad43d7aa44b338e95335004b6aae01",
+				"DiscoKey":   "discokey:9e5f76deebc53ac3b3deaf8e01600088e43398bc51076a70cd468a5a2fbc4527",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34886",
+					"10.65.0.27:34886",
+					"172.17.0.1:34886",
+					"172.18.0.1:34886",
+					"172.19.0.1:34886",
+					"172.20.0.1:34886",
+					"172.21.0.1:34886",
+					"172.22.0.1:34886",
+					"172.23.0.1:34886",
+					"172.24.0.1:34886",
+					"172.25.0.1:34886",
+					"172.26.0.1:34886",
+					"172.27.0.1:34886",
+					"172.28.0.1:34886"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:19:19.9714794Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7907824750755997,
+				"StableID":   "nCij9X9Uk421CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e15db383b9c813c3c6c972ef3d514208ff3e02fa3d80e28cd7cf8c6ef25b656f",
+				"DiscoKey":   "discokey:1532948c521598c248fbdbe0b7fd01133db4f6fdcc657d8874a6b968f6903757",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41744",
+					"10.65.0.27:41744",
+					"172.17.0.1:41744",
+					"172.18.0.1:41744",
+					"172.19.0.1:41744",
+					"172.20.0.1:41744",
+					"172.21.0.1:41744",
+					"172.22.0.1:41744",
+					"172.23.0.1:41744",
+					"172.24.0.1:41744",
+					"172.25.0.1:41744",
+					"172.26.0.1:41744",
+					"172.27.0.1:41744",
+					"172.28.0.1:41744"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:19:20.501136787Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4784639507416429,
+				"StableID":   "n6jS3GNyMe11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:be0d544d162ab0cc7eab0034e6efc0bf3052698d6c2675a496d59c66a47bb271",
+				"DiscoKey":   "discokey:601f5de8b0e63c86913fb4f7a3c29b4367d39af5707d5c4115e5595312c65965",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:60965",
+					"10.65.0.27:60965",
+					"172.17.0.1:60965",
+					"172.18.0.1:60965",
+					"172.19.0.1:60965",
+					"172.20.0.1:60965",
+					"172.21.0.1:60965",
+					"172.22.0.1:60965",
+					"172.23.0.1:60965",
+					"172.24.0.1:60965",
+					"172.25.0.1:60965",
+					"172.26.0.1:60965",
+					"172.27.0.1:60965",
+					"172.28.0.1:60965"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:19:21.040816987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3426646194877689,
+				"StableID":   "n2V5FjBwkT11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9dc6d6f65864f92af390216540c9b809f076879fa6ab1ddf4477566c3d3ca72c",
+				"DiscoKey":   "discokey:023df61eb4a134f8b491c87215f64b6875f0232fc5483452c0cf987b99f7882e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:32842",
+					"10.65.0.27:32842",
+					"172.17.0.1:32842",
+					"172.18.0.1:32842",
+					"172.19.0.1:32842",
+					"172.20.0.1:32842",
+					"172.21.0.1:32842",
+					"172.22.0.1:32842",
+					"172.23.0.1:32842",
+					"172.24.0.1:32842",
+					"172.25.0.1:32842",
+					"172.26.0.1:32842",
+					"172.27.0.1:32842",
+					"172.28.0.1:32842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:19:21.585938624Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         503241623682931,
+				"StableID":   "nE4s1eJvv411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65f1409c11bd8b452d418f03aaf3a3369b1cae8c45c079cff5c2a46d92eb060f",
+				"DiscoKey":   "discokey:f1146b5ff2cb1e8f090ffefcdb7d5e885388aa34bdd197656f65914cc3da7578",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48284",
+					"10.65.0.27:48284",
+					"172.17.0.1:48284",
+					"172.18.0.1:48284",
+					"172.19.0.1:48284",
+					"172.20.0.1:48284",
+					"172.21.0.1:48284",
+					"172.22.0.1:48284",
+					"172.23.0.1:48284",
+					"172.24.0.1:48284",
+					"172.25.0.1:48284",
+					"172.26.0.1:48284",
+					"172.27.0.1:48284",
+					"172.28.0.1:48284"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:19:22.659613084Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1543860425024168,
+				"StableID":   "nsCM4YbD4D11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc542a090ddb07798283d5e07c2f2a5b5c346d3f348b9af0fe3ed8c97c34a73f",
+				"DiscoKey":   "discokey:9c81180c8dcfd8cdbcbb5a6cdff8788b7478e139043e1c9cb430bb12ff4d9c41",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49569",
+					"10.65.0.27:49569",
+					"172.17.0.1:49569",
+					"172.18.0.1:49569",
+					"172.19.0.1:49569",
+					"172.20.0.1:49569",
+					"172.21.0.1:49569",
+					"172.22.0.1:49569",
+					"172.23.0.1:49569",
+					"172.24.0.1:49569",
+					"172.25.0.1:49569",
+					"172.26.0.1:49569",
+					"172.27.0.1:49569",
+					"172.28.0.1:49569"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:19:23.203947754Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         405195271382504,
+				"StableID":   "nsk9cynWA411CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae23a3331702698e34b01628737d5b8c91a4860ef321ede711ec45a1f7f16a39",
+				"DiscoKey":   "discokey:e169bbf9a738b39c766c1d60db70b02932e5436e0c948a8100001ff9a670e669",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43159",
+					"10.65.0.27:43159",
+					"172.17.0.1:43159",
+					"172.18.0.1:43159",
+					"172.19.0.1:43159",
+					"172.20.0.1:43159",
+					"172.21.0.1:43159",
+					"172.22.0.1:43159",
+					"172.23.0.1:43159",
+					"172.24.0.1:43159",
+					"172.25.0.1:43159",
+					"172.26.0.1:43159",
+					"172.27.0.1:43159",
+					"172.28.0.1:43159"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:19:23.74529735Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3426536136371848,
+				"StableID":   "nV5Uk3JtkT11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9acfa98fbb055c7bbfbcfc470e2a3d7c4ec2e992b0718826593b6d1abc45cb1f",
+				"DiscoKey":   "discokey:5e5ace1c16176fb4349597cd6b68958f2a40160e8d74765bb4f53885a135ae75",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36618",
+					"10.65.0.27:36618",
+					"172.17.0.1:36618",
+					"172.18.0.1:36618",
+					"172.19.0.1:36618",
+					"172.20.0.1:36618",
+					"172.21.0.1:36618",
+					"172.22.0.1:36618",
+					"172.23.0.1:36618",
+					"172.24.0.1:36618",
+					"172.25.0.1:36618",
+					"172.26.0.1:36618",
+					"172.27.0.1:36618",
+					"172.28.0.1:36618"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:19:24.279863448Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3012369755640188,
+				"StableID":   "nFaxv2rJXQ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bf81993c448c401aabadfb70775d12ea095e3661892ad67b2ac1df81287d4419",
+				"KeyExpiry":  "2026-11-09T09:19:24Z",
+				"DiscoKey":   "discokey:5f695b82c9c07a756d9396d5c6ddaaf6f793ee3e942f0fc7dd7abee85acf7716",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44334",
+					"10.65.0.27:44334",
+					"172.17.0.1:44334",
+					"172.18.0.1:44334",
+					"172.19.0.1:44334",
+					"172.20.0.1:44334",
+					"172.21.0.1:44334",
+					"172.22.0.1:44334",
+					"172.23.0.1:44334",
+					"172.24.0.1:44334",
+					"172.25.0.1:44334",
+					"172.26.0.1:44334",
+					"172.27.0.1:44334",
+					"172.28.0.1:44334"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:19:24.811647723Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7468751552721751,
+				"StableID":   "ncdCBSScK121CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1dfc22f5f5c6f1c3ed49365c6aecd7052aab04c55c7fb36b648c1e0e3f90ce06",
+				"KeyExpiry":  "2026-11-09T09:19:25Z",
+				"DiscoKey":   "discokey:3ebea6bb99e095d26d9832c20ef05cf3656a46b26658f6199c22ac578444446d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49818",
+					"10.65.0.27:49818",
+					"172.17.0.1:49818",
+					"172.18.0.1:49818",
+					"172.19.0.1:49818",
+					"172.20.0.1:49818",
+					"172.21.0.1:49818",
+					"172.22.0.1:49818",
+					"172.23.0.1:49818",
+					"172.24.0.1:49818",
+					"172.25.0.1:49818",
+					"172.26.0.1:49818",
+					"172.27.0.1:49818",
+					"172.28.0.1:49818"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:19:25.353736893Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5452265111916024,
+				"StableID":   "nsg3Y2mLaj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a2dc8487de8773ec3bb4ef74f14b9e2bd8dbc3ef4bae39fb2b60e26447edce28",
+				"KeyExpiry":  "2026-11-09T09:19:25Z",
+				"DiscoKey":   "discokey:13a5d9f2ab3232d280bd0902671b54b3f12970168a613de5a841db3778eafc73",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49612",
+					"10.65.0.27:49612",
+					"172.17.0.1:49612",
+					"172.18.0.1:49612",
+					"172.19.0.1:49612",
+					"172.20.0.1:49612",
+					"172.21.0.1:49612",
+					"172.22.0.1:49612",
+					"172.23.0.1:49612",
+					"172.24.0.1:49612",
+					"172.25.0.1:49612",
+					"172.26.0.1:49612",
+					"172.27.0.1:49612",
+					"172.28.0.1:49612"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:19:25.921846203Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6486969541950041": {
+				"ID":          6486969541950041,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3012369755640188,
+				"StableID":   "nFaxv2rJXQ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bf81993c448c401aabadfb70775d12ea095e3661892ad67b2ac1df81287d4419",
+				"KeyExpiry":  "2026-11-09T09:19:24Z",
+				"DiscoKey":   "discokey:5f695b82c9c07a756d9396d5c6ddaaf6f793ee3e942f0fc7dd7abee85acf7716",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44334",
+					"10.65.0.27:44334",
+					"172.17.0.1:44334",
+					"172.18.0.1:44334",
+					"172.19.0.1:44334",
+					"172.20.0.1:44334",
+					"172.21.0.1:44334",
+					"172.22.0.1:44334",
+					"172.23.0.1:44334",
+					"172.24.0.1:44334",
+					"172.25.0.1:44334",
+					"172.26.0.1:44334",
+					"172.27.0.1:44334",
+					"172.28.0.1:44334"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:19:24.811647723Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:bf81993c448c401aabadfb70775d12ea095e3661892ad67b2ac1df81287d4419",
+			"MachineKey": "mkey:bee9610840020da52832e361f1efbfe0aaa3915fad9b552cad0180a9961e3346",
+			"Peers": [{
+				"ID":         8573270307094724,
+				"StableID":   "ndBgFrGrw921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5de5d550caee76af25800ff2bafdfa25b3ee0c1a527297092b6bee88428d291e",
+				"DiscoKey":   "discokey:78d3621ddf45b61eb6efef3619f62e5f49ca13b2b47e07a8aeb4e9991295d87f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58135",
+					"10.65.0.27:58135",
+					"172.17.0.1:58135",
+					"172.18.0.1:58135",
+					"172.19.0.1:58135",
+					"172.20.0.1:58135",
+					"172.21.0.1:58135",
+					"172.22.0.1:58135",
+					"172.23.0.1:58135",
+					"172.24.0.1:58135",
+					"172.25.0.1:58135",
+					"172.26.0.1:58135",
+					"172.27.0.1:58135",
+					"172.28.0.1:58135"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:19:18.34069644Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4757874630165731,
+				"StableID":   "nzQWVKJr9e11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:877d125b234c5f659d778821d79fee683681f31e495153a20af7c60dcfc24c64",
+				"DiscoKey":   "discokey:8fe88cddefa5b8cedc575e52ccbbfadb4639b7bb852024bdb55c063601cd2b1f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37973",
+					"10.65.0.27:37973",
+					"172.17.0.1:37973",
+					"172.18.0.1:37973",
+					"172.19.0.1:37973",
+					"172.20.0.1:37973",
+					"172.21.0.1:37973",
+					"172.22.0.1:37973",
+					"172.23.0.1:37973",
+					"172.24.0.1:37973",
+					"172.25.0.1:37973",
+					"172.26.0.1:37973",
+					"172.27.0.1:37973",
+					"172.28.0.1:37973"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:19:18.859688049Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5181576811348899,
+				"StableID":   "nSrsLiEkTh11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93e906a9692b49c5eda79cce6a97ed4799a48e1605e746494496a77c39aae528",
+				"DiscoKey":   "discokey:6ba5c2b98606fd8bf77d552d88b0c2ba92fe06c93fc2e6fcae76813ff14c2371",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:44257",
+					"10.65.0.27:44257",
+					"172.17.0.1:44257",
+					"172.18.0.1:44257",
+					"172.19.0.1:44257",
+					"172.20.0.1:44257",
+					"172.21.0.1:44257",
+					"172.22.0.1:44257",
+					"172.23.0.1:44257",
+					"172.24.0.1:44257",
+					"172.25.0.1:44257",
+					"172.26.0.1:44257",
+					"172.27.0.1:44257",
+					"172.28.0.1:44257"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:19:19.420242613Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3024142579763633,
+				"StableID":   "nYSs5f6ecQ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f5ef265e9d7fe135001251b2512cf85ea9ad43d7aa44b338e95335004b6aae01",
+				"DiscoKey":   "discokey:9e5f76deebc53ac3b3deaf8e01600088e43398bc51076a70cd468a5a2fbc4527",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34886",
+					"10.65.0.27:34886",
+					"172.17.0.1:34886",
+					"172.18.0.1:34886",
+					"172.19.0.1:34886",
+					"172.20.0.1:34886",
+					"172.21.0.1:34886",
+					"172.22.0.1:34886",
+					"172.23.0.1:34886",
+					"172.24.0.1:34886",
+					"172.25.0.1:34886",
+					"172.26.0.1:34886",
+					"172.27.0.1:34886",
+					"172.28.0.1:34886"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:19:19.9714794Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7907824750755997,
+				"StableID":   "nCij9X9Uk421CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e15db383b9c813c3c6c972ef3d514208ff3e02fa3d80e28cd7cf8c6ef25b656f",
+				"DiscoKey":   "discokey:1532948c521598c248fbdbe0b7fd01133db4f6fdcc657d8874a6b968f6903757",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41744",
+					"10.65.0.27:41744",
+					"172.17.0.1:41744",
+					"172.18.0.1:41744",
+					"172.19.0.1:41744",
+					"172.20.0.1:41744",
+					"172.21.0.1:41744",
+					"172.22.0.1:41744",
+					"172.23.0.1:41744",
+					"172.24.0.1:41744",
+					"172.25.0.1:41744",
+					"172.26.0.1:41744",
+					"172.27.0.1:41744",
+					"172.28.0.1:41744"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:19:20.501136787Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4784639507416429,
+				"StableID":   "n6jS3GNyMe11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:be0d544d162ab0cc7eab0034e6efc0bf3052698d6c2675a496d59c66a47bb271",
+				"DiscoKey":   "discokey:601f5de8b0e63c86913fb4f7a3c29b4367d39af5707d5c4115e5595312c65965",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:60965",
+					"10.65.0.27:60965",
+					"172.17.0.1:60965",
+					"172.18.0.1:60965",
+					"172.19.0.1:60965",
+					"172.20.0.1:60965",
+					"172.21.0.1:60965",
+					"172.22.0.1:60965",
+					"172.23.0.1:60965",
+					"172.24.0.1:60965",
+					"172.25.0.1:60965",
+					"172.26.0.1:60965",
+					"172.27.0.1:60965",
+					"172.28.0.1:60965"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:19:21.040816987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3426646194877689,
+				"StableID":   "n2V5FjBwkT11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9dc6d6f65864f92af390216540c9b809f076879fa6ab1ddf4477566c3d3ca72c",
+				"DiscoKey":   "discokey:023df61eb4a134f8b491c87215f64b6875f0232fc5483452c0cf987b99f7882e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:32842",
+					"10.65.0.27:32842",
+					"172.17.0.1:32842",
+					"172.18.0.1:32842",
+					"172.19.0.1:32842",
+					"172.20.0.1:32842",
+					"172.21.0.1:32842",
+					"172.22.0.1:32842",
+					"172.23.0.1:32842",
+					"172.24.0.1:32842",
+					"172.25.0.1:32842",
+					"172.26.0.1:32842",
+					"172.27.0.1:32842",
+					"172.28.0.1:32842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:19:21.585938624Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6486969541950041,
+				"StableID":   "nWodq1hxes11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:528c424e05b2a205ff1bff5e5190722becab3d5a10566d11272a30cdddedc91f",
+				"DiscoKey":   "discokey:34927bc670b26f71112fe7735f62e5e23727099fc8728b68dd5a04e86a5c7918",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47647",
+					"10.65.0.27:47647",
+					"172.17.0.1:47647",
+					"172.18.0.1:47647",
+					"172.19.0.1:47647",
+					"172.20.0.1:47647",
+					"172.21.0.1:47647",
+					"172.22.0.1:47647",
+					"172.23.0.1:47647",
+					"172.24.0.1:47647",
+					"172.25.0.1:47647",
+					"172.26.0.1:47647",
+					"172.27.0.1:47647",
+					"172.28.0.1:47647"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:19:22.122736953Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         503241623682931,
+				"StableID":   "nE4s1eJvv411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65f1409c11bd8b452d418f03aaf3a3369b1cae8c45c079cff5c2a46d92eb060f",
+				"DiscoKey":   "discokey:f1146b5ff2cb1e8f090ffefcdb7d5e885388aa34bdd197656f65914cc3da7578",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48284",
+					"10.65.0.27:48284",
+					"172.17.0.1:48284",
+					"172.18.0.1:48284",
+					"172.19.0.1:48284",
+					"172.20.0.1:48284",
+					"172.21.0.1:48284",
+					"172.22.0.1:48284",
+					"172.23.0.1:48284",
+					"172.24.0.1:48284",
+					"172.25.0.1:48284",
+					"172.26.0.1:48284",
+					"172.27.0.1:48284",
+					"172.28.0.1:48284"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:19:22.659613084Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1543860425024168,
+				"StableID":   "nsCM4YbD4D11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc542a090ddb07798283d5e07c2f2a5b5c346d3f348b9af0fe3ed8c97c34a73f",
+				"DiscoKey":   "discokey:9c81180c8dcfd8cdbcbb5a6cdff8788b7478e139043e1c9cb430bb12ff4d9c41",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49569",
+					"10.65.0.27:49569",
+					"172.17.0.1:49569",
+					"172.18.0.1:49569",
+					"172.19.0.1:49569",
+					"172.20.0.1:49569",
+					"172.21.0.1:49569",
+					"172.22.0.1:49569",
+					"172.23.0.1:49569",
+					"172.24.0.1:49569",
+					"172.25.0.1:49569",
+					"172.26.0.1:49569",
+					"172.27.0.1:49569",
+					"172.28.0.1:49569"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:19:23.203947754Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         405195271382504,
+				"StableID":   "nsk9cynWA411CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae23a3331702698e34b01628737d5b8c91a4860ef321ede711ec45a1f7f16a39",
+				"DiscoKey":   "discokey:e169bbf9a738b39c766c1d60db70b02932e5436e0c948a8100001ff9a670e669",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43159",
+					"10.65.0.27:43159",
+					"172.17.0.1:43159",
+					"172.18.0.1:43159",
+					"172.19.0.1:43159",
+					"172.20.0.1:43159",
+					"172.21.0.1:43159",
+					"172.22.0.1:43159",
+					"172.23.0.1:43159",
+					"172.24.0.1:43159",
+					"172.25.0.1:43159",
+					"172.26.0.1:43159",
+					"172.27.0.1:43159",
+					"172.28.0.1:43159"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:19:23.74529735Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3426536136371848,
+				"StableID":   "nV5Uk3JtkT11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9acfa98fbb055c7bbfbcfc470e2a3d7c4ec2e992b0718826593b6d1abc45cb1f",
+				"DiscoKey":   "discokey:5e5ace1c16176fb4349597cd6b68958f2a40160e8d74765bb4f53885a135ae75",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36618",
+					"10.65.0.27:36618",
+					"172.17.0.1:36618",
+					"172.18.0.1:36618",
+					"172.19.0.1:36618",
+					"172.20.0.1:36618",
+					"172.21.0.1:36618",
+					"172.22.0.1:36618",
+					"172.23.0.1:36618",
+					"172.24.0.1:36618",
+					"172.25.0.1:36618",
+					"172.26.0.1:36618",
+					"172.27.0.1:36618",
+					"172.28.0.1:36618"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:19:24.279863448Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7468751552721751,
+				"StableID":   "ncdCBSScK121CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1dfc22f5f5c6f1c3ed49365c6aecd7052aab04c55c7fb36b648c1e0e3f90ce06",
+				"KeyExpiry":  "2026-11-09T09:19:25Z",
+				"DiscoKey":   "discokey:3ebea6bb99e095d26d9832c20ef05cf3656a46b26658f6199c22ac578444446d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49818",
+					"10.65.0.27:49818",
+					"172.17.0.1:49818",
+					"172.18.0.1:49818",
+					"172.19.0.1:49818",
+					"172.20.0.1:49818",
+					"172.21.0.1:49818",
+					"172.22.0.1:49818",
+					"172.23.0.1:49818",
+					"172.24.0.1:49818",
+					"172.25.0.1:49818",
+					"172.26.0.1:49818",
+					"172.27.0.1:49818",
+					"172.28.0.1:49818"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:19:25.353736893Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5452265111916024,
+				"StableID":   "nsg3Y2mLaj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a2dc8487de8773ec3bb4ef74f14b9e2bd8dbc3ef4bae39fb2b60e26447edce28",
+				"KeyExpiry":  "2026-11-09T09:19:25Z",
+				"DiscoKey":   "discokey:13a5d9f2ab3232d280bd0902671b54b3f12970168a613de5a841db3778eafc73",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49612",
+					"10.65.0.27:49612",
+					"172.17.0.1:49612",
+					"172.18.0.1:49612",
+					"172.19.0.1:49612",
+					"172.20.0.1:49612",
+					"172.21.0.1:49612",
+					"172.22.0.1:49612",
+					"172.23.0.1:49612",
+					"172.24.0.1:49612",
+					"172.25.0.1:49612",
+					"172.26.0.1:49612",
+					"172.27.0.1:49612",
+					"172.28.0.1:49612"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:19:25.921846203Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         405195271382504,
+				"StableID":   "nsk9cynWA411CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       405195271382504,
+				"Key":        "nodekey:ae23a3331702698e34b01628737d5b8c91a4860ef321ede711ec45a1f7f16a39",
+				"DiscoKey":   "discokey:e169bbf9a738b39c766c1d60db70b02932e5436e0c948a8100001ff9a670e669",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43159",
+					"10.65.0.27:43159",
+					"172.17.0.1:43159",
+					"172.18.0.1:43159",
+					"172.19.0.1:43159",
+					"172.20.0.1:43159",
+					"172.21.0.1:43159",
+					"172.22.0.1:43159",
+					"172.23.0.1:43159",
+					"172.24.0.1:43159",
+					"172.25.0.1:43159",
+					"172.26.0.1:43159",
+					"172.27.0.1:43159",
+					"172.28.0.1:43159"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:19:23.74529735Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ae23a3331702698e34b01628737d5b8c91a4860ef321ede711ec45a1f7f16a39",
+			"MachineKey": "mkey:874ad0a6e361d44881bbf9d02b8b4a1d755ddfc355f59b71e34f0dbf7e96b03e",
+			"Peers": [{
+				"ID":         8573270307094724,
+				"StableID":   "ndBgFrGrw921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5de5d550caee76af25800ff2bafdfa25b3ee0c1a527297092b6bee88428d291e",
+				"DiscoKey":   "discokey:78d3621ddf45b61eb6efef3619f62e5f49ca13b2b47e07a8aeb4e9991295d87f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58135",
+					"10.65.0.27:58135",
+					"172.17.0.1:58135",
+					"172.18.0.1:58135",
+					"172.19.0.1:58135",
+					"172.20.0.1:58135",
+					"172.21.0.1:58135",
+					"172.22.0.1:58135",
+					"172.23.0.1:58135",
+					"172.24.0.1:58135",
+					"172.25.0.1:58135",
+					"172.26.0.1:58135",
+					"172.27.0.1:58135",
+					"172.28.0.1:58135"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:19:18.34069644Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4757874630165731,
+				"StableID":   "nzQWVKJr9e11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:877d125b234c5f659d778821d79fee683681f31e495153a20af7c60dcfc24c64",
+				"DiscoKey":   "discokey:8fe88cddefa5b8cedc575e52ccbbfadb4639b7bb852024bdb55c063601cd2b1f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37973",
+					"10.65.0.27:37973",
+					"172.17.0.1:37973",
+					"172.18.0.1:37973",
+					"172.19.0.1:37973",
+					"172.20.0.1:37973",
+					"172.21.0.1:37973",
+					"172.22.0.1:37973",
+					"172.23.0.1:37973",
+					"172.24.0.1:37973",
+					"172.25.0.1:37973",
+					"172.26.0.1:37973",
+					"172.27.0.1:37973",
+					"172.28.0.1:37973"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:19:18.859688049Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5181576811348899,
+				"StableID":   "nSrsLiEkTh11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93e906a9692b49c5eda79cce6a97ed4799a48e1605e746494496a77c39aae528",
+				"DiscoKey":   "discokey:6ba5c2b98606fd8bf77d552d88b0c2ba92fe06c93fc2e6fcae76813ff14c2371",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:44257",
+					"10.65.0.27:44257",
+					"172.17.0.1:44257",
+					"172.18.0.1:44257",
+					"172.19.0.1:44257",
+					"172.20.0.1:44257",
+					"172.21.0.1:44257",
+					"172.22.0.1:44257",
+					"172.23.0.1:44257",
+					"172.24.0.1:44257",
+					"172.25.0.1:44257",
+					"172.26.0.1:44257",
+					"172.27.0.1:44257",
+					"172.28.0.1:44257"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:19:19.420242613Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3024142579763633,
+				"StableID":   "nYSs5f6ecQ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f5ef265e9d7fe135001251b2512cf85ea9ad43d7aa44b338e95335004b6aae01",
+				"DiscoKey":   "discokey:9e5f76deebc53ac3b3deaf8e01600088e43398bc51076a70cd468a5a2fbc4527",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34886",
+					"10.65.0.27:34886",
+					"172.17.0.1:34886",
+					"172.18.0.1:34886",
+					"172.19.0.1:34886",
+					"172.20.0.1:34886",
+					"172.21.0.1:34886",
+					"172.22.0.1:34886",
+					"172.23.0.1:34886",
+					"172.24.0.1:34886",
+					"172.25.0.1:34886",
+					"172.26.0.1:34886",
+					"172.27.0.1:34886",
+					"172.28.0.1:34886"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:19:19.9714794Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7907824750755997,
+				"StableID":   "nCij9X9Uk421CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e15db383b9c813c3c6c972ef3d514208ff3e02fa3d80e28cd7cf8c6ef25b656f",
+				"DiscoKey":   "discokey:1532948c521598c248fbdbe0b7fd01133db4f6fdcc657d8874a6b968f6903757",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41744",
+					"10.65.0.27:41744",
+					"172.17.0.1:41744",
+					"172.18.0.1:41744",
+					"172.19.0.1:41744",
+					"172.20.0.1:41744",
+					"172.21.0.1:41744",
+					"172.22.0.1:41744",
+					"172.23.0.1:41744",
+					"172.24.0.1:41744",
+					"172.25.0.1:41744",
+					"172.26.0.1:41744",
+					"172.27.0.1:41744",
+					"172.28.0.1:41744"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:19:20.501136787Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4784639507416429,
+				"StableID":   "n6jS3GNyMe11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:be0d544d162ab0cc7eab0034e6efc0bf3052698d6c2675a496d59c66a47bb271",
+				"DiscoKey":   "discokey:601f5de8b0e63c86913fb4f7a3c29b4367d39af5707d5c4115e5595312c65965",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:60965",
+					"10.65.0.27:60965",
+					"172.17.0.1:60965",
+					"172.18.0.1:60965",
+					"172.19.0.1:60965",
+					"172.20.0.1:60965",
+					"172.21.0.1:60965",
+					"172.22.0.1:60965",
+					"172.23.0.1:60965",
+					"172.24.0.1:60965",
+					"172.25.0.1:60965",
+					"172.26.0.1:60965",
+					"172.27.0.1:60965",
+					"172.28.0.1:60965"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:19:21.040816987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3426646194877689,
+				"StableID":   "n2V5FjBwkT11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9dc6d6f65864f92af390216540c9b809f076879fa6ab1ddf4477566c3d3ca72c",
+				"DiscoKey":   "discokey:023df61eb4a134f8b491c87215f64b6875f0232fc5483452c0cf987b99f7882e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:32842",
+					"10.65.0.27:32842",
+					"172.17.0.1:32842",
+					"172.18.0.1:32842",
+					"172.19.0.1:32842",
+					"172.20.0.1:32842",
+					"172.21.0.1:32842",
+					"172.22.0.1:32842",
+					"172.23.0.1:32842",
+					"172.24.0.1:32842",
+					"172.25.0.1:32842",
+					"172.26.0.1:32842",
+					"172.27.0.1:32842",
+					"172.28.0.1:32842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:19:21.585938624Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6486969541950041,
+				"StableID":   "nWodq1hxes11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:528c424e05b2a205ff1bff5e5190722becab3d5a10566d11272a30cdddedc91f",
+				"DiscoKey":   "discokey:34927bc670b26f71112fe7735f62e5e23727099fc8728b68dd5a04e86a5c7918",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47647",
+					"10.65.0.27:47647",
+					"172.17.0.1:47647",
+					"172.18.0.1:47647",
+					"172.19.0.1:47647",
+					"172.20.0.1:47647",
+					"172.21.0.1:47647",
+					"172.22.0.1:47647",
+					"172.23.0.1:47647",
+					"172.24.0.1:47647",
+					"172.25.0.1:47647",
+					"172.26.0.1:47647",
+					"172.27.0.1:47647",
+					"172.28.0.1:47647"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:19:22.122736953Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         503241623682931,
+				"StableID":   "nE4s1eJvv411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65f1409c11bd8b452d418f03aaf3a3369b1cae8c45c079cff5c2a46d92eb060f",
+				"DiscoKey":   "discokey:f1146b5ff2cb1e8f090ffefcdb7d5e885388aa34bdd197656f65914cc3da7578",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48284",
+					"10.65.0.27:48284",
+					"172.17.0.1:48284",
+					"172.18.0.1:48284",
+					"172.19.0.1:48284",
+					"172.20.0.1:48284",
+					"172.21.0.1:48284",
+					"172.22.0.1:48284",
+					"172.23.0.1:48284",
+					"172.24.0.1:48284",
+					"172.25.0.1:48284",
+					"172.26.0.1:48284",
+					"172.27.0.1:48284",
+					"172.28.0.1:48284"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:19:22.659613084Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1543860425024168,
+				"StableID":   "nsCM4YbD4D11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc542a090ddb07798283d5e07c2f2a5b5c346d3f348b9af0fe3ed8c97c34a73f",
+				"DiscoKey":   "discokey:9c81180c8dcfd8cdbcbb5a6cdff8788b7478e139043e1c9cb430bb12ff4d9c41",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49569",
+					"10.65.0.27:49569",
+					"172.17.0.1:49569",
+					"172.18.0.1:49569",
+					"172.19.0.1:49569",
+					"172.20.0.1:49569",
+					"172.21.0.1:49569",
+					"172.22.0.1:49569",
+					"172.23.0.1:49569",
+					"172.24.0.1:49569",
+					"172.25.0.1:49569",
+					"172.26.0.1:49569",
+					"172.27.0.1:49569",
+					"172.28.0.1:49569"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:19:23.203947754Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3426536136371848,
+				"StableID":   "nV5Uk3JtkT11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9acfa98fbb055c7bbfbcfc470e2a3d7c4ec2e992b0718826593b6d1abc45cb1f",
+				"DiscoKey":   "discokey:5e5ace1c16176fb4349597cd6b68958f2a40160e8d74765bb4f53885a135ae75",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36618",
+					"10.65.0.27:36618",
+					"172.17.0.1:36618",
+					"172.18.0.1:36618",
+					"172.19.0.1:36618",
+					"172.20.0.1:36618",
+					"172.21.0.1:36618",
+					"172.22.0.1:36618",
+					"172.23.0.1:36618",
+					"172.24.0.1:36618",
+					"172.25.0.1:36618",
+					"172.26.0.1:36618",
+					"172.27.0.1:36618",
+					"172.28.0.1:36618"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:19:24.279863448Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3012369755640188,
+				"StableID":   "nFaxv2rJXQ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bf81993c448c401aabadfb70775d12ea095e3661892ad67b2ac1df81287d4419",
+				"KeyExpiry":  "2026-11-09T09:19:24Z",
+				"DiscoKey":   "discokey:5f695b82c9c07a756d9396d5c6ddaaf6f793ee3e942f0fc7dd7abee85acf7716",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44334",
+					"10.65.0.27:44334",
+					"172.17.0.1:44334",
+					"172.18.0.1:44334",
+					"172.19.0.1:44334",
+					"172.20.0.1:44334",
+					"172.21.0.1:44334",
+					"172.22.0.1:44334",
+					"172.23.0.1:44334",
+					"172.24.0.1:44334",
+					"172.25.0.1:44334",
+					"172.26.0.1:44334",
+					"172.27.0.1:44334",
+					"172.28.0.1:44334"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:19:24.811647723Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7468751552721751,
+				"StableID":   "ncdCBSScK121CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1dfc22f5f5c6f1c3ed49365c6aecd7052aab04c55c7fb36b648c1e0e3f90ce06",
+				"KeyExpiry":  "2026-11-09T09:19:25Z",
+				"DiscoKey":   "discokey:3ebea6bb99e095d26d9832c20ef05cf3656a46b26658f6199c22ac578444446d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49818",
+					"10.65.0.27:49818",
+					"172.17.0.1:49818",
+					"172.18.0.1:49818",
+					"172.19.0.1:49818",
+					"172.20.0.1:49818",
+					"172.21.0.1:49818",
+					"172.22.0.1:49818",
+					"172.23.0.1:49818",
+					"172.24.0.1:49818",
+					"172.25.0.1:49818",
+					"172.26.0.1:49818",
+					"172.27.0.1:49818",
+					"172.28.0.1:49818"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:19:25.353736893Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5452265111916024,
+				"StableID":   "nsg3Y2mLaj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a2dc8487de8773ec3bb4ef74f14b9e2bd8dbc3ef4bae39fb2b60e26447edce28",
+				"KeyExpiry":  "2026-11-09T09:19:25Z",
+				"DiscoKey":   "discokey:13a5d9f2ab3232d280bd0902671b54b3f12970168a613de5a841db3778eafc73",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49612",
+					"10.65.0.27:49612",
+					"172.17.0.1:49612",
+					"172.18.0.1:49612",
+					"172.19.0.1:49612",
+					"172.20.0.1:49612",
+					"172.21.0.1:49612",
+					"172.22.0.1:49612",
+					"172.23.0.1:49612",
+					"172.24.0.1:49612",
+					"172.25.0.1:49612",
+					"172.26.0.1:49612",
+					"172.27.0.1:49612",
+					"172.28.0.1:49612"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:19:25.921846203Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{"principals": [
+				{"nodeIP": "100.64.0.17"},
+				{"nodeIP": "100.64.0.19"},
+				{"nodeIP": "fd7a:115c:a1e0::11"},
+				{"nodeIP": "fd7a:115c:a1e0::13"}
+			], "sshUsers": {"root": "root", "ubuntu": "ubuntu"}, "action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "405195271382504": {
+				"ID":          405195271382504,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		},
+		"ssh_rules": [{"principals": [
+			{"nodeIP": "100.64.0.17"},
+			{"nodeIP": "100.64.0.19"},
+			{"nodeIP": "fd7a:115c:a1e0::11"},
+			{"nodeIP": "fd7a:115c:a1e0::13"}
+		], "sshUsers": {"root": "root", "ubuntu": "ubuntu"}, "action": {
+			"accept":                    true,
+			"allowAgentForwarding":      true,
+			"allowLocalPortForwarding":  true,
+			"allowRemotePortForwarding": true
+		}}]
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4757874630165731,
+				"StableID":   "nzQWVKJr9e11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       4757874630165731,
+				"Key":        "nodekey:877d125b234c5f659d778821d79fee683681f31e495153a20af7c60dcfc24c64",
+				"DiscoKey":   "discokey:8fe88cddefa5b8cedc575e52ccbbfadb4639b7bb852024bdb55c063601cd2b1f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37973",
+					"10.65.0.27:37973",
+					"172.17.0.1:37973",
+					"172.18.0.1:37973",
+					"172.19.0.1:37973",
+					"172.20.0.1:37973",
+					"172.21.0.1:37973",
+					"172.22.0.1:37973",
+					"172.23.0.1:37973",
+					"172.24.0.1:37973",
+					"172.25.0.1:37973",
+					"172.26.0.1:37973",
+					"172.27.0.1:37973",
+					"172.28.0.1:37973"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:19:18.859688049Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:877d125b234c5f659d778821d79fee683681f31e495153a20af7c60dcfc24c64",
+			"MachineKey": "mkey:0fd3d7b3e79813a4d4a72c1d0f84cc128df2f0756681f8325f392170a9957c30",
+			"Peers": [{
+				"ID":         8573270307094724,
+				"StableID":   "ndBgFrGrw921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5de5d550caee76af25800ff2bafdfa25b3ee0c1a527297092b6bee88428d291e",
+				"DiscoKey":   "discokey:78d3621ddf45b61eb6efef3619f62e5f49ca13b2b47e07a8aeb4e9991295d87f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58135",
+					"10.65.0.27:58135",
+					"172.17.0.1:58135",
+					"172.18.0.1:58135",
+					"172.19.0.1:58135",
+					"172.20.0.1:58135",
+					"172.21.0.1:58135",
+					"172.22.0.1:58135",
+					"172.23.0.1:58135",
+					"172.24.0.1:58135",
+					"172.25.0.1:58135",
+					"172.26.0.1:58135",
+					"172.27.0.1:58135",
+					"172.28.0.1:58135"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:19:18.34069644Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5181576811348899,
+				"StableID":   "nSrsLiEkTh11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93e906a9692b49c5eda79cce6a97ed4799a48e1605e746494496a77c39aae528",
+				"DiscoKey":   "discokey:6ba5c2b98606fd8bf77d552d88b0c2ba92fe06c93fc2e6fcae76813ff14c2371",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:44257",
+					"10.65.0.27:44257",
+					"172.17.0.1:44257",
+					"172.18.0.1:44257",
+					"172.19.0.1:44257",
+					"172.20.0.1:44257",
+					"172.21.0.1:44257",
+					"172.22.0.1:44257",
+					"172.23.0.1:44257",
+					"172.24.0.1:44257",
+					"172.25.0.1:44257",
+					"172.26.0.1:44257",
+					"172.27.0.1:44257",
+					"172.28.0.1:44257"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:19:19.420242613Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3024142579763633,
+				"StableID":   "nYSs5f6ecQ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f5ef265e9d7fe135001251b2512cf85ea9ad43d7aa44b338e95335004b6aae01",
+				"DiscoKey":   "discokey:9e5f76deebc53ac3b3deaf8e01600088e43398bc51076a70cd468a5a2fbc4527",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34886",
+					"10.65.0.27:34886",
+					"172.17.0.1:34886",
+					"172.18.0.1:34886",
+					"172.19.0.1:34886",
+					"172.20.0.1:34886",
+					"172.21.0.1:34886",
+					"172.22.0.1:34886",
+					"172.23.0.1:34886",
+					"172.24.0.1:34886",
+					"172.25.0.1:34886",
+					"172.26.0.1:34886",
+					"172.27.0.1:34886",
+					"172.28.0.1:34886"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:19:19.9714794Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7907824750755997,
+				"StableID":   "nCij9X9Uk421CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e15db383b9c813c3c6c972ef3d514208ff3e02fa3d80e28cd7cf8c6ef25b656f",
+				"DiscoKey":   "discokey:1532948c521598c248fbdbe0b7fd01133db4f6fdcc657d8874a6b968f6903757",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41744",
+					"10.65.0.27:41744",
+					"172.17.0.1:41744",
+					"172.18.0.1:41744",
+					"172.19.0.1:41744",
+					"172.20.0.1:41744",
+					"172.21.0.1:41744",
+					"172.22.0.1:41744",
+					"172.23.0.1:41744",
+					"172.24.0.1:41744",
+					"172.25.0.1:41744",
+					"172.26.0.1:41744",
+					"172.27.0.1:41744",
+					"172.28.0.1:41744"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:19:20.501136787Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4784639507416429,
+				"StableID":   "n6jS3GNyMe11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:be0d544d162ab0cc7eab0034e6efc0bf3052698d6c2675a496d59c66a47bb271",
+				"DiscoKey":   "discokey:601f5de8b0e63c86913fb4f7a3c29b4367d39af5707d5c4115e5595312c65965",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:60965",
+					"10.65.0.27:60965",
+					"172.17.0.1:60965",
+					"172.18.0.1:60965",
+					"172.19.0.1:60965",
+					"172.20.0.1:60965",
+					"172.21.0.1:60965",
+					"172.22.0.1:60965",
+					"172.23.0.1:60965",
+					"172.24.0.1:60965",
+					"172.25.0.1:60965",
+					"172.26.0.1:60965",
+					"172.27.0.1:60965",
+					"172.28.0.1:60965"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:19:21.040816987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3426646194877689,
+				"StableID":   "n2V5FjBwkT11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9dc6d6f65864f92af390216540c9b809f076879fa6ab1ddf4477566c3d3ca72c",
+				"DiscoKey":   "discokey:023df61eb4a134f8b491c87215f64b6875f0232fc5483452c0cf987b99f7882e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:32842",
+					"10.65.0.27:32842",
+					"172.17.0.1:32842",
+					"172.18.0.1:32842",
+					"172.19.0.1:32842",
+					"172.20.0.1:32842",
+					"172.21.0.1:32842",
+					"172.22.0.1:32842",
+					"172.23.0.1:32842",
+					"172.24.0.1:32842",
+					"172.25.0.1:32842",
+					"172.26.0.1:32842",
+					"172.27.0.1:32842",
+					"172.28.0.1:32842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:19:21.585938624Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6486969541950041,
+				"StableID":   "nWodq1hxes11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:528c424e05b2a205ff1bff5e5190722becab3d5a10566d11272a30cdddedc91f",
+				"DiscoKey":   "discokey:34927bc670b26f71112fe7735f62e5e23727099fc8728b68dd5a04e86a5c7918",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47647",
+					"10.65.0.27:47647",
+					"172.17.0.1:47647",
+					"172.18.0.1:47647",
+					"172.19.0.1:47647",
+					"172.20.0.1:47647",
+					"172.21.0.1:47647",
+					"172.22.0.1:47647",
+					"172.23.0.1:47647",
+					"172.24.0.1:47647",
+					"172.25.0.1:47647",
+					"172.26.0.1:47647",
+					"172.27.0.1:47647",
+					"172.28.0.1:47647"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:19:22.122736953Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         503241623682931,
+				"StableID":   "nE4s1eJvv411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65f1409c11bd8b452d418f03aaf3a3369b1cae8c45c079cff5c2a46d92eb060f",
+				"DiscoKey":   "discokey:f1146b5ff2cb1e8f090ffefcdb7d5e885388aa34bdd197656f65914cc3da7578",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48284",
+					"10.65.0.27:48284",
+					"172.17.0.1:48284",
+					"172.18.0.1:48284",
+					"172.19.0.1:48284",
+					"172.20.0.1:48284",
+					"172.21.0.1:48284",
+					"172.22.0.1:48284",
+					"172.23.0.1:48284",
+					"172.24.0.1:48284",
+					"172.25.0.1:48284",
+					"172.26.0.1:48284",
+					"172.27.0.1:48284",
+					"172.28.0.1:48284"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:19:22.659613084Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1543860425024168,
+				"StableID":   "nsCM4YbD4D11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc542a090ddb07798283d5e07c2f2a5b5c346d3f348b9af0fe3ed8c97c34a73f",
+				"DiscoKey":   "discokey:9c81180c8dcfd8cdbcbb5a6cdff8788b7478e139043e1c9cb430bb12ff4d9c41",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49569",
+					"10.65.0.27:49569",
+					"172.17.0.1:49569",
+					"172.18.0.1:49569",
+					"172.19.0.1:49569",
+					"172.20.0.1:49569",
+					"172.21.0.1:49569",
+					"172.22.0.1:49569",
+					"172.23.0.1:49569",
+					"172.24.0.1:49569",
+					"172.25.0.1:49569",
+					"172.26.0.1:49569",
+					"172.27.0.1:49569",
+					"172.28.0.1:49569"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:19:23.203947754Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         405195271382504,
+				"StableID":   "nsk9cynWA411CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae23a3331702698e34b01628737d5b8c91a4860ef321ede711ec45a1f7f16a39",
+				"DiscoKey":   "discokey:e169bbf9a738b39c766c1d60db70b02932e5436e0c948a8100001ff9a670e669",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43159",
+					"10.65.0.27:43159",
+					"172.17.0.1:43159",
+					"172.18.0.1:43159",
+					"172.19.0.1:43159",
+					"172.20.0.1:43159",
+					"172.21.0.1:43159",
+					"172.22.0.1:43159",
+					"172.23.0.1:43159",
+					"172.24.0.1:43159",
+					"172.25.0.1:43159",
+					"172.26.0.1:43159",
+					"172.27.0.1:43159",
+					"172.28.0.1:43159"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:19:23.74529735Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3426536136371848,
+				"StableID":   "nV5Uk3JtkT11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9acfa98fbb055c7bbfbcfc470e2a3d7c4ec2e992b0718826593b6d1abc45cb1f",
+				"DiscoKey":   "discokey:5e5ace1c16176fb4349597cd6b68958f2a40160e8d74765bb4f53885a135ae75",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36618",
+					"10.65.0.27:36618",
+					"172.17.0.1:36618",
+					"172.18.0.1:36618",
+					"172.19.0.1:36618",
+					"172.20.0.1:36618",
+					"172.21.0.1:36618",
+					"172.22.0.1:36618",
+					"172.23.0.1:36618",
+					"172.24.0.1:36618",
+					"172.25.0.1:36618",
+					"172.26.0.1:36618",
+					"172.27.0.1:36618",
+					"172.28.0.1:36618"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:19:24.279863448Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3012369755640188,
+				"StableID":   "nFaxv2rJXQ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bf81993c448c401aabadfb70775d12ea095e3661892ad67b2ac1df81287d4419",
+				"KeyExpiry":  "2026-11-09T09:19:24Z",
+				"DiscoKey":   "discokey:5f695b82c9c07a756d9396d5c6ddaaf6f793ee3e942f0fc7dd7abee85acf7716",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44334",
+					"10.65.0.27:44334",
+					"172.17.0.1:44334",
+					"172.18.0.1:44334",
+					"172.19.0.1:44334",
+					"172.20.0.1:44334",
+					"172.21.0.1:44334",
+					"172.22.0.1:44334",
+					"172.23.0.1:44334",
+					"172.24.0.1:44334",
+					"172.25.0.1:44334",
+					"172.26.0.1:44334",
+					"172.27.0.1:44334",
+					"172.28.0.1:44334"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:19:24.811647723Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7468751552721751,
+				"StableID":   "ncdCBSScK121CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1dfc22f5f5c6f1c3ed49365c6aecd7052aab04c55c7fb36b648c1e0e3f90ce06",
+				"KeyExpiry":  "2026-11-09T09:19:25Z",
+				"DiscoKey":   "discokey:3ebea6bb99e095d26d9832c20ef05cf3656a46b26658f6199c22ac578444446d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49818",
+					"10.65.0.27:49818",
+					"172.17.0.1:49818",
+					"172.18.0.1:49818",
+					"172.19.0.1:49818",
+					"172.20.0.1:49818",
+					"172.21.0.1:49818",
+					"172.22.0.1:49818",
+					"172.23.0.1:49818",
+					"172.24.0.1:49818",
+					"172.25.0.1:49818",
+					"172.26.0.1:49818",
+					"172.27.0.1:49818",
+					"172.28.0.1:49818"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:19:25.353736893Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5452265111916024,
+				"StableID":   "nsg3Y2mLaj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a2dc8487de8773ec3bb4ef74f14b9e2bd8dbc3ef4bae39fb2b60e26447edce28",
+				"KeyExpiry":  "2026-11-09T09:19:25Z",
+				"DiscoKey":   "discokey:13a5d9f2ab3232d280bd0902671b54b3f12970168a613de5a841db3778eafc73",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49612",
+					"10.65.0.27:49612",
+					"172.17.0.1:49612",
+					"172.18.0.1:49612",
+					"172.19.0.1:49612",
+					"172.20.0.1:49612",
+					"172.21.0.1:49612",
+					"172.22.0.1:49612",
+					"172.23.0.1:49612",
+					"172.24.0.1:49612",
+					"172.25.0.1:49612",
+					"172.26.0.1:49612",
+					"172.27.0.1:49612",
+					"172.28.0.1:49612"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:19:25.921846203Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4757874630165731": {
+				"ID":          4757874630165731,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8573270307094724,
+				"StableID":   "ndBgFrGrw921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       8573270307094724,
+				"Key":        "nodekey:5de5d550caee76af25800ff2bafdfa25b3ee0c1a527297092b6bee88428d291e",
+				"DiscoKey":   "discokey:78d3621ddf45b61eb6efef3619f62e5f49ca13b2b47e07a8aeb4e9991295d87f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58135",
+					"10.65.0.27:58135",
+					"172.17.0.1:58135",
+					"172.18.0.1:58135",
+					"172.19.0.1:58135",
+					"172.20.0.1:58135",
+					"172.21.0.1:58135",
+					"172.22.0.1:58135",
+					"172.23.0.1:58135",
+					"172.24.0.1:58135",
+					"172.25.0.1:58135",
+					"172.26.0.1:58135",
+					"172.27.0.1:58135",
+					"172.28.0.1:58135"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:19:18.34069644Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5de5d550caee76af25800ff2bafdfa25b3ee0c1a527297092b6bee88428d291e",
+			"MachineKey": "mkey:ccfeea6be6935ab23dbea5c10c77ad54982a02cb55a55b6aba6c618769685947",
+			"Peers": [{
+				"ID":         4757874630165731,
+				"StableID":   "nzQWVKJr9e11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:877d125b234c5f659d778821d79fee683681f31e495153a20af7c60dcfc24c64",
+				"DiscoKey":   "discokey:8fe88cddefa5b8cedc575e52ccbbfadb4639b7bb852024bdb55c063601cd2b1f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37973",
+					"10.65.0.27:37973",
+					"172.17.0.1:37973",
+					"172.18.0.1:37973",
+					"172.19.0.1:37973",
+					"172.20.0.1:37973",
+					"172.21.0.1:37973",
+					"172.22.0.1:37973",
+					"172.23.0.1:37973",
+					"172.24.0.1:37973",
+					"172.25.0.1:37973",
+					"172.26.0.1:37973",
+					"172.27.0.1:37973",
+					"172.28.0.1:37973"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:19:18.859688049Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5181576811348899,
+				"StableID":   "nSrsLiEkTh11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93e906a9692b49c5eda79cce6a97ed4799a48e1605e746494496a77c39aae528",
+				"DiscoKey":   "discokey:6ba5c2b98606fd8bf77d552d88b0c2ba92fe06c93fc2e6fcae76813ff14c2371",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:44257",
+					"10.65.0.27:44257",
+					"172.17.0.1:44257",
+					"172.18.0.1:44257",
+					"172.19.0.1:44257",
+					"172.20.0.1:44257",
+					"172.21.0.1:44257",
+					"172.22.0.1:44257",
+					"172.23.0.1:44257",
+					"172.24.0.1:44257",
+					"172.25.0.1:44257",
+					"172.26.0.1:44257",
+					"172.27.0.1:44257",
+					"172.28.0.1:44257"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:19:19.420242613Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3024142579763633,
+				"StableID":   "nYSs5f6ecQ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f5ef265e9d7fe135001251b2512cf85ea9ad43d7aa44b338e95335004b6aae01",
+				"DiscoKey":   "discokey:9e5f76deebc53ac3b3deaf8e01600088e43398bc51076a70cd468a5a2fbc4527",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34886",
+					"10.65.0.27:34886",
+					"172.17.0.1:34886",
+					"172.18.0.1:34886",
+					"172.19.0.1:34886",
+					"172.20.0.1:34886",
+					"172.21.0.1:34886",
+					"172.22.0.1:34886",
+					"172.23.0.1:34886",
+					"172.24.0.1:34886",
+					"172.25.0.1:34886",
+					"172.26.0.1:34886",
+					"172.27.0.1:34886",
+					"172.28.0.1:34886"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:19:19.9714794Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7907824750755997,
+				"StableID":   "nCij9X9Uk421CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e15db383b9c813c3c6c972ef3d514208ff3e02fa3d80e28cd7cf8c6ef25b656f",
+				"DiscoKey":   "discokey:1532948c521598c248fbdbe0b7fd01133db4f6fdcc657d8874a6b968f6903757",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41744",
+					"10.65.0.27:41744",
+					"172.17.0.1:41744",
+					"172.18.0.1:41744",
+					"172.19.0.1:41744",
+					"172.20.0.1:41744",
+					"172.21.0.1:41744",
+					"172.22.0.1:41744",
+					"172.23.0.1:41744",
+					"172.24.0.1:41744",
+					"172.25.0.1:41744",
+					"172.26.0.1:41744",
+					"172.27.0.1:41744",
+					"172.28.0.1:41744"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:19:20.501136787Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4784639507416429,
+				"StableID":   "n6jS3GNyMe11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:be0d544d162ab0cc7eab0034e6efc0bf3052698d6c2675a496d59c66a47bb271",
+				"DiscoKey":   "discokey:601f5de8b0e63c86913fb4f7a3c29b4367d39af5707d5c4115e5595312c65965",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:60965",
+					"10.65.0.27:60965",
+					"172.17.0.1:60965",
+					"172.18.0.1:60965",
+					"172.19.0.1:60965",
+					"172.20.0.1:60965",
+					"172.21.0.1:60965",
+					"172.22.0.1:60965",
+					"172.23.0.1:60965",
+					"172.24.0.1:60965",
+					"172.25.0.1:60965",
+					"172.26.0.1:60965",
+					"172.27.0.1:60965",
+					"172.28.0.1:60965"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:19:21.040816987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3426646194877689,
+				"StableID":   "n2V5FjBwkT11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9dc6d6f65864f92af390216540c9b809f076879fa6ab1ddf4477566c3d3ca72c",
+				"DiscoKey":   "discokey:023df61eb4a134f8b491c87215f64b6875f0232fc5483452c0cf987b99f7882e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:32842",
+					"10.65.0.27:32842",
+					"172.17.0.1:32842",
+					"172.18.0.1:32842",
+					"172.19.0.1:32842",
+					"172.20.0.1:32842",
+					"172.21.0.1:32842",
+					"172.22.0.1:32842",
+					"172.23.0.1:32842",
+					"172.24.0.1:32842",
+					"172.25.0.1:32842",
+					"172.26.0.1:32842",
+					"172.27.0.1:32842",
+					"172.28.0.1:32842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:19:21.585938624Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6486969541950041,
+				"StableID":   "nWodq1hxes11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:528c424e05b2a205ff1bff5e5190722becab3d5a10566d11272a30cdddedc91f",
+				"DiscoKey":   "discokey:34927bc670b26f71112fe7735f62e5e23727099fc8728b68dd5a04e86a5c7918",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47647",
+					"10.65.0.27:47647",
+					"172.17.0.1:47647",
+					"172.18.0.1:47647",
+					"172.19.0.1:47647",
+					"172.20.0.1:47647",
+					"172.21.0.1:47647",
+					"172.22.0.1:47647",
+					"172.23.0.1:47647",
+					"172.24.0.1:47647",
+					"172.25.0.1:47647",
+					"172.26.0.1:47647",
+					"172.27.0.1:47647",
+					"172.28.0.1:47647"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:19:22.122736953Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         503241623682931,
+				"StableID":   "nE4s1eJvv411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65f1409c11bd8b452d418f03aaf3a3369b1cae8c45c079cff5c2a46d92eb060f",
+				"DiscoKey":   "discokey:f1146b5ff2cb1e8f090ffefcdb7d5e885388aa34bdd197656f65914cc3da7578",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48284",
+					"10.65.0.27:48284",
+					"172.17.0.1:48284",
+					"172.18.0.1:48284",
+					"172.19.0.1:48284",
+					"172.20.0.1:48284",
+					"172.21.0.1:48284",
+					"172.22.0.1:48284",
+					"172.23.0.1:48284",
+					"172.24.0.1:48284",
+					"172.25.0.1:48284",
+					"172.26.0.1:48284",
+					"172.27.0.1:48284",
+					"172.28.0.1:48284"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:19:22.659613084Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1543860425024168,
+				"StableID":   "nsCM4YbD4D11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc542a090ddb07798283d5e07c2f2a5b5c346d3f348b9af0fe3ed8c97c34a73f",
+				"DiscoKey":   "discokey:9c81180c8dcfd8cdbcbb5a6cdff8788b7478e139043e1c9cb430bb12ff4d9c41",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49569",
+					"10.65.0.27:49569",
+					"172.17.0.1:49569",
+					"172.18.0.1:49569",
+					"172.19.0.1:49569",
+					"172.20.0.1:49569",
+					"172.21.0.1:49569",
+					"172.22.0.1:49569",
+					"172.23.0.1:49569",
+					"172.24.0.1:49569",
+					"172.25.0.1:49569",
+					"172.26.0.1:49569",
+					"172.27.0.1:49569",
+					"172.28.0.1:49569"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:19:23.203947754Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         405195271382504,
+				"StableID":   "nsk9cynWA411CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae23a3331702698e34b01628737d5b8c91a4860ef321ede711ec45a1f7f16a39",
+				"DiscoKey":   "discokey:e169bbf9a738b39c766c1d60db70b02932e5436e0c948a8100001ff9a670e669",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43159",
+					"10.65.0.27:43159",
+					"172.17.0.1:43159",
+					"172.18.0.1:43159",
+					"172.19.0.1:43159",
+					"172.20.0.1:43159",
+					"172.21.0.1:43159",
+					"172.22.0.1:43159",
+					"172.23.0.1:43159",
+					"172.24.0.1:43159",
+					"172.25.0.1:43159",
+					"172.26.0.1:43159",
+					"172.27.0.1:43159",
+					"172.28.0.1:43159"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:19:23.74529735Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3426536136371848,
+				"StableID":   "nV5Uk3JtkT11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9acfa98fbb055c7bbfbcfc470e2a3d7c4ec2e992b0718826593b6d1abc45cb1f",
+				"DiscoKey":   "discokey:5e5ace1c16176fb4349597cd6b68958f2a40160e8d74765bb4f53885a135ae75",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36618",
+					"10.65.0.27:36618",
+					"172.17.0.1:36618",
+					"172.18.0.1:36618",
+					"172.19.0.1:36618",
+					"172.20.0.1:36618",
+					"172.21.0.1:36618",
+					"172.22.0.1:36618",
+					"172.23.0.1:36618",
+					"172.24.0.1:36618",
+					"172.25.0.1:36618",
+					"172.26.0.1:36618",
+					"172.27.0.1:36618",
+					"172.28.0.1:36618"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:19:24.279863448Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3012369755640188,
+				"StableID":   "nFaxv2rJXQ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bf81993c448c401aabadfb70775d12ea095e3661892ad67b2ac1df81287d4419",
+				"KeyExpiry":  "2026-11-09T09:19:24Z",
+				"DiscoKey":   "discokey:5f695b82c9c07a756d9396d5c6ddaaf6f793ee3e942f0fc7dd7abee85acf7716",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44334",
+					"10.65.0.27:44334",
+					"172.17.0.1:44334",
+					"172.18.0.1:44334",
+					"172.19.0.1:44334",
+					"172.20.0.1:44334",
+					"172.21.0.1:44334",
+					"172.22.0.1:44334",
+					"172.23.0.1:44334",
+					"172.24.0.1:44334",
+					"172.25.0.1:44334",
+					"172.26.0.1:44334",
+					"172.27.0.1:44334",
+					"172.28.0.1:44334"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:19:24.811647723Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7468751552721751,
+				"StableID":   "ncdCBSScK121CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1dfc22f5f5c6f1c3ed49365c6aecd7052aab04c55c7fb36b648c1e0e3f90ce06",
+				"KeyExpiry":  "2026-11-09T09:19:25Z",
+				"DiscoKey":   "discokey:3ebea6bb99e095d26d9832c20ef05cf3656a46b26658f6199c22ac578444446d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49818",
+					"10.65.0.27:49818",
+					"172.17.0.1:49818",
+					"172.18.0.1:49818",
+					"172.19.0.1:49818",
+					"172.20.0.1:49818",
+					"172.21.0.1:49818",
+					"172.22.0.1:49818",
+					"172.23.0.1:49818",
+					"172.24.0.1:49818",
+					"172.25.0.1:49818",
+					"172.26.0.1:49818",
+					"172.27.0.1:49818",
+					"172.28.0.1:49818"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:19:25.353736893Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5452265111916024,
+				"StableID":   "nsg3Y2mLaj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a2dc8487de8773ec3bb4ef74f14b9e2bd8dbc3ef4bae39fb2b60e26447edce28",
+				"KeyExpiry":  "2026-11-09T09:19:25Z",
+				"DiscoKey":   "discokey:13a5d9f2ab3232d280bd0902671b54b3f12970168a613de5a841db3778eafc73",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49612",
+					"10.65.0.27:49612",
+					"172.17.0.1:49612",
+					"172.18.0.1:49612",
+					"172.19.0.1:49612",
+					"172.20.0.1:49612",
+					"172.21.0.1:49612",
+					"172.22.0.1:49612",
+					"172.23.0.1:49612",
+					"172.24.0.1:49612",
+					"172.25.0.1:49612",
+					"172.26.0.1:49612",
+					"172.27.0.1:49612",
+					"172.28.0.1:49612"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:19:25.921846203Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8573270307094724": {
+				"ID":          8573270307094724,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7907824750755997,
+				"StableID":   "nCij9X9Uk421CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       7907824750755997,
+				"Key":        "nodekey:e15db383b9c813c3c6c972ef3d514208ff3e02fa3d80e28cd7cf8c6ef25b656f",
+				"DiscoKey":   "discokey:1532948c521598c248fbdbe0b7fd01133db4f6fdcc657d8874a6b968f6903757",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41744",
+					"10.65.0.27:41744",
+					"172.17.0.1:41744",
+					"172.18.0.1:41744",
+					"172.19.0.1:41744",
+					"172.20.0.1:41744",
+					"172.21.0.1:41744",
+					"172.22.0.1:41744",
+					"172.23.0.1:41744",
+					"172.24.0.1:41744",
+					"172.25.0.1:41744",
+					"172.26.0.1:41744",
+					"172.27.0.1:41744",
+					"172.28.0.1:41744"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:19:20.501136787Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e15db383b9c813c3c6c972ef3d514208ff3e02fa3d80e28cd7cf8c6ef25b656f",
+			"MachineKey": "mkey:9ddac53a62451655bbb5986ce3a460a193882db41a5ab27f5f983d3f07953566",
+			"Peers": [{
+				"ID":         8573270307094724,
+				"StableID":   "ndBgFrGrw921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5de5d550caee76af25800ff2bafdfa25b3ee0c1a527297092b6bee88428d291e",
+				"DiscoKey":   "discokey:78d3621ddf45b61eb6efef3619f62e5f49ca13b2b47e07a8aeb4e9991295d87f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58135",
+					"10.65.0.27:58135",
+					"172.17.0.1:58135",
+					"172.18.0.1:58135",
+					"172.19.0.1:58135",
+					"172.20.0.1:58135",
+					"172.21.0.1:58135",
+					"172.22.0.1:58135",
+					"172.23.0.1:58135",
+					"172.24.0.1:58135",
+					"172.25.0.1:58135",
+					"172.26.0.1:58135",
+					"172.27.0.1:58135",
+					"172.28.0.1:58135"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:19:18.34069644Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4757874630165731,
+				"StableID":   "nzQWVKJr9e11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:877d125b234c5f659d778821d79fee683681f31e495153a20af7c60dcfc24c64",
+				"DiscoKey":   "discokey:8fe88cddefa5b8cedc575e52ccbbfadb4639b7bb852024bdb55c063601cd2b1f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37973",
+					"10.65.0.27:37973",
+					"172.17.0.1:37973",
+					"172.18.0.1:37973",
+					"172.19.0.1:37973",
+					"172.20.0.1:37973",
+					"172.21.0.1:37973",
+					"172.22.0.1:37973",
+					"172.23.0.1:37973",
+					"172.24.0.1:37973",
+					"172.25.0.1:37973",
+					"172.26.0.1:37973",
+					"172.27.0.1:37973",
+					"172.28.0.1:37973"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:19:18.859688049Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5181576811348899,
+				"StableID":   "nSrsLiEkTh11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93e906a9692b49c5eda79cce6a97ed4799a48e1605e746494496a77c39aae528",
+				"DiscoKey":   "discokey:6ba5c2b98606fd8bf77d552d88b0c2ba92fe06c93fc2e6fcae76813ff14c2371",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:44257",
+					"10.65.0.27:44257",
+					"172.17.0.1:44257",
+					"172.18.0.1:44257",
+					"172.19.0.1:44257",
+					"172.20.0.1:44257",
+					"172.21.0.1:44257",
+					"172.22.0.1:44257",
+					"172.23.0.1:44257",
+					"172.24.0.1:44257",
+					"172.25.0.1:44257",
+					"172.26.0.1:44257",
+					"172.27.0.1:44257",
+					"172.28.0.1:44257"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:19:19.420242613Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3024142579763633,
+				"StableID":   "nYSs5f6ecQ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f5ef265e9d7fe135001251b2512cf85ea9ad43d7aa44b338e95335004b6aae01",
+				"DiscoKey":   "discokey:9e5f76deebc53ac3b3deaf8e01600088e43398bc51076a70cd468a5a2fbc4527",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34886",
+					"10.65.0.27:34886",
+					"172.17.0.1:34886",
+					"172.18.0.1:34886",
+					"172.19.0.1:34886",
+					"172.20.0.1:34886",
+					"172.21.0.1:34886",
+					"172.22.0.1:34886",
+					"172.23.0.1:34886",
+					"172.24.0.1:34886",
+					"172.25.0.1:34886",
+					"172.26.0.1:34886",
+					"172.27.0.1:34886",
+					"172.28.0.1:34886"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:19:19.9714794Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4784639507416429,
+				"StableID":   "n6jS3GNyMe11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:be0d544d162ab0cc7eab0034e6efc0bf3052698d6c2675a496d59c66a47bb271",
+				"DiscoKey":   "discokey:601f5de8b0e63c86913fb4f7a3c29b4367d39af5707d5c4115e5595312c65965",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:60965",
+					"10.65.0.27:60965",
+					"172.17.0.1:60965",
+					"172.18.0.1:60965",
+					"172.19.0.1:60965",
+					"172.20.0.1:60965",
+					"172.21.0.1:60965",
+					"172.22.0.1:60965",
+					"172.23.0.1:60965",
+					"172.24.0.1:60965",
+					"172.25.0.1:60965",
+					"172.26.0.1:60965",
+					"172.27.0.1:60965",
+					"172.28.0.1:60965"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:19:21.040816987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3426646194877689,
+				"StableID":   "n2V5FjBwkT11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9dc6d6f65864f92af390216540c9b809f076879fa6ab1ddf4477566c3d3ca72c",
+				"DiscoKey":   "discokey:023df61eb4a134f8b491c87215f64b6875f0232fc5483452c0cf987b99f7882e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:32842",
+					"10.65.0.27:32842",
+					"172.17.0.1:32842",
+					"172.18.0.1:32842",
+					"172.19.0.1:32842",
+					"172.20.0.1:32842",
+					"172.21.0.1:32842",
+					"172.22.0.1:32842",
+					"172.23.0.1:32842",
+					"172.24.0.1:32842",
+					"172.25.0.1:32842",
+					"172.26.0.1:32842",
+					"172.27.0.1:32842",
+					"172.28.0.1:32842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:19:21.585938624Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6486969541950041,
+				"StableID":   "nWodq1hxes11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:528c424e05b2a205ff1bff5e5190722becab3d5a10566d11272a30cdddedc91f",
+				"DiscoKey":   "discokey:34927bc670b26f71112fe7735f62e5e23727099fc8728b68dd5a04e86a5c7918",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47647",
+					"10.65.0.27:47647",
+					"172.17.0.1:47647",
+					"172.18.0.1:47647",
+					"172.19.0.1:47647",
+					"172.20.0.1:47647",
+					"172.21.0.1:47647",
+					"172.22.0.1:47647",
+					"172.23.0.1:47647",
+					"172.24.0.1:47647",
+					"172.25.0.1:47647",
+					"172.26.0.1:47647",
+					"172.27.0.1:47647",
+					"172.28.0.1:47647"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:19:22.122736953Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         503241623682931,
+				"StableID":   "nE4s1eJvv411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65f1409c11bd8b452d418f03aaf3a3369b1cae8c45c079cff5c2a46d92eb060f",
+				"DiscoKey":   "discokey:f1146b5ff2cb1e8f090ffefcdb7d5e885388aa34bdd197656f65914cc3da7578",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48284",
+					"10.65.0.27:48284",
+					"172.17.0.1:48284",
+					"172.18.0.1:48284",
+					"172.19.0.1:48284",
+					"172.20.0.1:48284",
+					"172.21.0.1:48284",
+					"172.22.0.1:48284",
+					"172.23.0.1:48284",
+					"172.24.0.1:48284",
+					"172.25.0.1:48284",
+					"172.26.0.1:48284",
+					"172.27.0.1:48284",
+					"172.28.0.1:48284"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:19:22.659613084Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1543860425024168,
+				"StableID":   "nsCM4YbD4D11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc542a090ddb07798283d5e07c2f2a5b5c346d3f348b9af0fe3ed8c97c34a73f",
+				"DiscoKey":   "discokey:9c81180c8dcfd8cdbcbb5a6cdff8788b7478e139043e1c9cb430bb12ff4d9c41",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49569",
+					"10.65.0.27:49569",
+					"172.17.0.1:49569",
+					"172.18.0.1:49569",
+					"172.19.0.1:49569",
+					"172.20.0.1:49569",
+					"172.21.0.1:49569",
+					"172.22.0.1:49569",
+					"172.23.0.1:49569",
+					"172.24.0.1:49569",
+					"172.25.0.1:49569",
+					"172.26.0.1:49569",
+					"172.27.0.1:49569",
+					"172.28.0.1:49569"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:19:23.203947754Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         405195271382504,
+				"StableID":   "nsk9cynWA411CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae23a3331702698e34b01628737d5b8c91a4860ef321ede711ec45a1f7f16a39",
+				"DiscoKey":   "discokey:e169bbf9a738b39c766c1d60db70b02932e5436e0c948a8100001ff9a670e669",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43159",
+					"10.65.0.27:43159",
+					"172.17.0.1:43159",
+					"172.18.0.1:43159",
+					"172.19.0.1:43159",
+					"172.20.0.1:43159",
+					"172.21.0.1:43159",
+					"172.22.0.1:43159",
+					"172.23.0.1:43159",
+					"172.24.0.1:43159",
+					"172.25.0.1:43159",
+					"172.26.0.1:43159",
+					"172.27.0.1:43159",
+					"172.28.0.1:43159"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:19:23.74529735Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3426536136371848,
+				"StableID":   "nV5Uk3JtkT11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9acfa98fbb055c7bbfbcfc470e2a3d7c4ec2e992b0718826593b6d1abc45cb1f",
+				"DiscoKey":   "discokey:5e5ace1c16176fb4349597cd6b68958f2a40160e8d74765bb4f53885a135ae75",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36618",
+					"10.65.0.27:36618",
+					"172.17.0.1:36618",
+					"172.18.0.1:36618",
+					"172.19.0.1:36618",
+					"172.20.0.1:36618",
+					"172.21.0.1:36618",
+					"172.22.0.1:36618",
+					"172.23.0.1:36618",
+					"172.24.0.1:36618",
+					"172.25.0.1:36618",
+					"172.26.0.1:36618",
+					"172.27.0.1:36618",
+					"172.28.0.1:36618"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:19:24.279863448Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3012369755640188,
+				"StableID":   "nFaxv2rJXQ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bf81993c448c401aabadfb70775d12ea095e3661892ad67b2ac1df81287d4419",
+				"KeyExpiry":  "2026-11-09T09:19:24Z",
+				"DiscoKey":   "discokey:5f695b82c9c07a756d9396d5c6ddaaf6f793ee3e942f0fc7dd7abee85acf7716",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44334",
+					"10.65.0.27:44334",
+					"172.17.0.1:44334",
+					"172.18.0.1:44334",
+					"172.19.0.1:44334",
+					"172.20.0.1:44334",
+					"172.21.0.1:44334",
+					"172.22.0.1:44334",
+					"172.23.0.1:44334",
+					"172.24.0.1:44334",
+					"172.25.0.1:44334",
+					"172.26.0.1:44334",
+					"172.27.0.1:44334",
+					"172.28.0.1:44334"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:19:24.811647723Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7468751552721751,
+				"StableID":   "ncdCBSScK121CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1dfc22f5f5c6f1c3ed49365c6aecd7052aab04c55c7fb36b648c1e0e3f90ce06",
+				"KeyExpiry":  "2026-11-09T09:19:25Z",
+				"DiscoKey":   "discokey:3ebea6bb99e095d26d9832c20ef05cf3656a46b26658f6199c22ac578444446d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49818",
+					"10.65.0.27:49818",
+					"172.17.0.1:49818",
+					"172.18.0.1:49818",
+					"172.19.0.1:49818",
+					"172.20.0.1:49818",
+					"172.21.0.1:49818",
+					"172.22.0.1:49818",
+					"172.23.0.1:49818",
+					"172.24.0.1:49818",
+					"172.25.0.1:49818",
+					"172.26.0.1:49818",
+					"172.27.0.1:49818",
+					"172.28.0.1:49818"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:19:25.353736893Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5452265111916024,
+				"StableID":   "nsg3Y2mLaj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a2dc8487de8773ec3bb4ef74f14b9e2bd8dbc3ef4bae39fb2b60e26447edce28",
+				"KeyExpiry":  "2026-11-09T09:19:25Z",
+				"DiscoKey":   "discokey:13a5d9f2ab3232d280bd0902671b54b3f12970168a613de5a841db3778eafc73",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49612",
+					"10.65.0.27:49612",
+					"172.17.0.1:49612",
+					"172.18.0.1:49612",
+					"172.19.0.1:49612",
+					"172.20.0.1:49612",
+					"172.21.0.1:49612",
+					"172.22.0.1:49612",
+					"172.23.0.1:49612",
+					"172.24.0.1:49612",
+					"172.25.0.1:49612",
+					"172.26.0.1:49612",
+					"172.27.0.1:49612",
+					"172.28.0.1:49612"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:19:25.921846203Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7907824750755997": {
+				"ID":          7907824750755997,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3024142579763633,
+				"StableID":   "nYSs5f6ecQ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       3024142579763633,
+				"Key":        "nodekey:f5ef265e9d7fe135001251b2512cf85ea9ad43d7aa44b338e95335004b6aae01",
+				"DiscoKey":   "discokey:9e5f76deebc53ac3b3deaf8e01600088e43398bc51076a70cd468a5a2fbc4527",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34886",
+					"10.65.0.27:34886",
+					"172.17.0.1:34886",
+					"172.18.0.1:34886",
+					"172.19.0.1:34886",
+					"172.20.0.1:34886",
+					"172.21.0.1:34886",
+					"172.22.0.1:34886",
+					"172.23.0.1:34886",
+					"172.24.0.1:34886",
+					"172.25.0.1:34886",
+					"172.26.0.1:34886",
+					"172.27.0.1:34886",
+					"172.28.0.1:34886"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:19:19.9714794Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f5ef265e9d7fe135001251b2512cf85ea9ad43d7aa44b338e95335004b6aae01",
+			"MachineKey": "mkey:1010d594e952091c728f843158bc1df6e6897c8932f99fdc1362f5c0ecadfd39",
+			"Peers": [{
+				"ID":         8573270307094724,
+				"StableID":   "ndBgFrGrw921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5de5d550caee76af25800ff2bafdfa25b3ee0c1a527297092b6bee88428d291e",
+				"DiscoKey":   "discokey:78d3621ddf45b61eb6efef3619f62e5f49ca13b2b47e07a8aeb4e9991295d87f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58135",
+					"10.65.0.27:58135",
+					"172.17.0.1:58135",
+					"172.18.0.1:58135",
+					"172.19.0.1:58135",
+					"172.20.0.1:58135",
+					"172.21.0.1:58135",
+					"172.22.0.1:58135",
+					"172.23.0.1:58135",
+					"172.24.0.1:58135",
+					"172.25.0.1:58135",
+					"172.26.0.1:58135",
+					"172.27.0.1:58135",
+					"172.28.0.1:58135"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:19:18.34069644Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4757874630165731,
+				"StableID":   "nzQWVKJr9e11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:877d125b234c5f659d778821d79fee683681f31e495153a20af7c60dcfc24c64",
+				"DiscoKey":   "discokey:8fe88cddefa5b8cedc575e52ccbbfadb4639b7bb852024bdb55c063601cd2b1f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37973",
+					"10.65.0.27:37973",
+					"172.17.0.1:37973",
+					"172.18.0.1:37973",
+					"172.19.0.1:37973",
+					"172.20.0.1:37973",
+					"172.21.0.1:37973",
+					"172.22.0.1:37973",
+					"172.23.0.1:37973",
+					"172.24.0.1:37973",
+					"172.25.0.1:37973",
+					"172.26.0.1:37973",
+					"172.27.0.1:37973",
+					"172.28.0.1:37973"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:19:18.859688049Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5181576811348899,
+				"StableID":   "nSrsLiEkTh11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93e906a9692b49c5eda79cce6a97ed4799a48e1605e746494496a77c39aae528",
+				"DiscoKey":   "discokey:6ba5c2b98606fd8bf77d552d88b0c2ba92fe06c93fc2e6fcae76813ff14c2371",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:44257",
+					"10.65.0.27:44257",
+					"172.17.0.1:44257",
+					"172.18.0.1:44257",
+					"172.19.0.1:44257",
+					"172.20.0.1:44257",
+					"172.21.0.1:44257",
+					"172.22.0.1:44257",
+					"172.23.0.1:44257",
+					"172.24.0.1:44257",
+					"172.25.0.1:44257",
+					"172.26.0.1:44257",
+					"172.27.0.1:44257",
+					"172.28.0.1:44257"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:19:19.420242613Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7907824750755997,
+				"StableID":   "nCij9X9Uk421CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e15db383b9c813c3c6c972ef3d514208ff3e02fa3d80e28cd7cf8c6ef25b656f",
+				"DiscoKey":   "discokey:1532948c521598c248fbdbe0b7fd01133db4f6fdcc657d8874a6b968f6903757",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41744",
+					"10.65.0.27:41744",
+					"172.17.0.1:41744",
+					"172.18.0.1:41744",
+					"172.19.0.1:41744",
+					"172.20.0.1:41744",
+					"172.21.0.1:41744",
+					"172.22.0.1:41744",
+					"172.23.0.1:41744",
+					"172.24.0.1:41744",
+					"172.25.0.1:41744",
+					"172.26.0.1:41744",
+					"172.27.0.1:41744",
+					"172.28.0.1:41744"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:19:20.501136787Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4784639507416429,
+				"StableID":   "n6jS3GNyMe11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:be0d544d162ab0cc7eab0034e6efc0bf3052698d6c2675a496d59c66a47bb271",
+				"DiscoKey":   "discokey:601f5de8b0e63c86913fb4f7a3c29b4367d39af5707d5c4115e5595312c65965",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:60965",
+					"10.65.0.27:60965",
+					"172.17.0.1:60965",
+					"172.18.0.1:60965",
+					"172.19.0.1:60965",
+					"172.20.0.1:60965",
+					"172.21.0.1:60965",
+					"172.22.0.1:60965",
+					"172.23.0.1:60965",
+					"172.24.0.1:60965",
+					"172.25.0.1:60965",
+					"172.26.0.1:60965",
+					"172.27.0.1:60965",
+					"172.28.0.1:60965"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:19:21.040816987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3426646194877689,
+				"StableID":   "n2V5FjBwkT11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9dc6d6f65864f92af390216540c9b809f076879fa6ab1ddf4477566c3d3ca72c",
+				"DiscoKey":   "discokey:023df61eb4a134f8b491c87215f64b6875f0232fc5483452c0cf987b99f7882e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:32842",
+					"10.65.0.27:32842",
+					"172.17.0.1:32842",
+					"172.18.0.1:32842",
+					"172.19.0.1:32842",
+					"172.20.0.1:32842",
+					"172.21.0.1:32842",
+					"172.22.0.1:32842",
+					"172.23.0.1:32842",
+					"172.24.0.1:32842",
+					"172.25.0.1:32842",
+					"172.26.0.1:32842",
+					"172.27.0.1:32842",
+					"172.28.0.1:32842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:19:21.585938624Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6486969541950041,
+				"StableID":   "nWodq1hxes11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:528c424e05b2a205ff1bff5e5190722becab3d5a10566d11272a30cdddedc91f",
+				"DiscoKey":   "discokey:34927bc670b26f71112fe7735f62e5e23727099fc8728b68dd5a04e86a5c7918",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47647",
+					"10.65.0.27:47647",
+					"172.17.0.1:47647",
+					"172.18.0.1:47647",
+					"172.19.0.1:47647",
+					"172.20.0.1:47647",
+					"172.21.0.1:47647",
+					"172.22.0.1:47647",
+					"172.23.0.1:47647",
+					"172.24.0.1:47647",
+					"172.25.0.1:47647",
+					"172.26.0.1:47647",
+					"172.27.0.1:47647",
+					"172.28.0.1:47647"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:19:22.122736953Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         503241623682931,
+				"StableID":   "nE4s1eJvv411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65f1409c11bd8b452d418f03aaf3a3369b1cae8c45c079cff5c2a46d92eb060f",
+				"DiscoKey":   "discokey:f1146b5ff2cb1e8f090ffefcdb7d5e885388aa34bdd197656f65914cc3da7578",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48284",
+					"10.65.0.27:48284",
+					"172.17.0.1:48284",
+					"172.18.0.1:48284",
+					"172.19.0.1:48284",
+					"172.20.0.1:48284",
+					"172.21.0.1:48284",
+					"172.22.0.1:48284",
+					"172.23.0.1:48284",
+					"172.24.0.1:48284",
+					"172.25.0.1:48284",
+					"172.26.0.1:48284",
+					"172.27.0.1:48284",
+					"172.28.0.1:48284"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:19:22.659613084Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1543860425024168,
+				"StableID":   "nsCM4YbD4D11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc542a090ddb07798283d5e07c2f2a5b5c346d3f348b9af0fe3ed8c97c34a73f",
+				"DiscoKey":   "discokey:9c81180c8dcfd8cdbcbb5a6cdff8788b7478e139043e1c9cb430bb12ff4d9c41",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49569",
+					"10.65.0.27:49569",
+					"172.17.0.1:49569",
+					"172.18.0.1:49569",
+					"172.19.0.1:49569",
+					"172.20.0.1:49569",
+					"172.21.0.1:49569",
+					"172.22.0.1:49569",
+					"172.23.0.1:49569",
+					"172.24.0.1:49569",
+					"172.25.0.1:49569",
+					"172.26.0.1:49569",
+					"172.27.0.1:49569",
+					"172.28.0.1:49569"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:19:23.203947754Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         405195271382504,
+				"StableID":   "nsk9cynWA411CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae23a3331702698e34b01628737d5b8c91a4860ef321ede711ec45a1f7f16a39",
+				"DiscoKey":   "discokey:e169bbf9a738b39c766c1d60db70b02932e5436e0c948a8100001ff9a670e669",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43159",
+					"10.65.0.27:43159",
+					"172.17.0.1:43159",
+					"172.18.0.1:43159",
+					"172.19.0.1:43159",
+					"172.20.0.1:43159",
+					"172.21.0.1:43159",
+					"172.22.0.1:43159",
+					"172.23.0.1:43159",
+					"172.24.0.1:43159",
+					"172.25.0.1:43159",
+					"172.26.0.1:43159",
+					"172.27.0.1:43159",
+					"172.28.0.1:43159"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:19:23.74529735Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3426536136371848,
+				"StableID":   "nV5Uk3JtkT11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9acfa98fbb055c7bbfbcfc470e2a3d7c4ec2e992b0718826593b6d1abc45cb1f",
+				"DiscoKey":   "discokey:5e5ace1c16176fb4349597cd6b68958f2a40160e8d74765bb4f53885a135ae75",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36618",
+					"10.65.0.27:36618",
+					"172.17.0.1:36618",
+					"172.18.0.1:36618",
+					"172.19.0.1:36618",
+					"172.20.0.1:36618",
+					"172.21.0.1:36618",
+					"172.22.0.1:36618",
+					"172.23.0.1:36618",
+					"172.24.0.1:36618",
+					"172.25.0.1:36618",
+					"172.26.0.1:36618",
+					"172.27.0.1:36618",
+					"172.28.0.1:36618"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:19:24.279863448Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3012369755640188,
+				"StableID":   "nFaxv2rJXQ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bf81993c448c401aabadfb70775d12ea095e3661892ad67b2ac1df81287d4419",
+				"KeyExpiry":  "2026-11-09T09:19:24Z",
+				"DiscoKey":   "discokey:5f695b82c9c07a756d9396d5c6ddaaf6f793ee3e942f0fc7dd7abee85acf7716",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44334",
+					"10.65.0.27:44334",
+					"172.17.0.1:44334",
+					"172.18.0.1:44334",
+					"172.19.0.1:44334",
+					"172.20.0.1:44334",
+					"172.21.0.1:44334",
+					"172.22.0.1:44334",
+					"172.23.0.1:44334",
+					"172.24.0.1:44334",
+					"172.25.0.1:44334",
+					"172.26.0.1:44334",
+					"172.27.0.1:44334",
+					"172.28.0.1:44334"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:19:24.811647723Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7468751552721751,
+				"StableID":   "ncdCBSScK121CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1dfc22f5f5c6f1c3ed49365c6aecd7052aab04c55c7fb36b648c1e0e3f90ce06",
+				"KeyExpiry":  "2026-11-09T09:19:25Z",
+				"DiscoKey":   "discokey:3ebea6bb99e095d26d9832c20ef05cf3656a46b26658f6199c22ac578444446d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49818",
+					"10.65.0.27:49818",
+					"172.17.0.1:49818",
+					"172.18.0.1:49818",
+					"172.19.0.1:49818",
+					"172.20.0.1:49818",
+					"172.21.0.1:49818",
+					"172.22.0.1:49818",
+					"172.23.0.1:49818",
+					"172.24.0.1:49818",
+					"172.25.0.1:49818",
+					"172.26.0.1:49818",
+					"172.27.0.1:49818",
+					"172.28.0.1:49818"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:19:25.353736893Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5452265111916024,
+				"StableID":   "nsg3Y2mLaj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a2dc8487de8773ec3bb4ef74f14b9e2bd8dbc3ef4bae39fb2b60e26447edce28",
+				"KeyExpiry":  "2026-11-09T09:19:25Z",
+				"DiscoKey":   "discokey:13a5d9f2ab3232d280bd0902671b54b3f12970168a613de5a841db3778eafc73",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49612",
+					"10.65.0.27:49612",
+					"172.17.0.1:49612",
+					"172.18.0.1:49612",
+					"172.19.0.1:49612",
+					"172.20.0.1:49612",
+					"172.21.0.1:49612",
+					"172.22.0.1:49612",
+					"172.23.0.1:49612",
+					"172.24.0.1:49612",
+					"172.25.0.1:49612",
+					"172.26.0.1:49612",
+					"172.27.0.1:49612",
+					"172.28.0.1:49612"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:19:25.921846203Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3024142579763633": {
+				"ID":          3024142579763633,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3426646194877689,
+				"StableID":   "n2V5FjBwkT11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       3426646194877689,
+				"Key":        "nodekey:9dc6d6f65864f92af390216540c9b809f076879fa6ab1ddf4477566c3d3ca72c",
+				"DiscoKey":   "discokey:023df61eb4a134f8b491c87215f64b6875f0232fc5483452c0cf987b99f7882e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:32842",
+					"10.65.0.27:32842",
+					"172.17.0.1:32842",
+					"172.18.0.1:32842",
+					"172.19.0.1:32842",
+					"172.20.0.1:32842",
+					"172.21.0.1:32842",
+					"172.22.0.1:32842",
+					"172.23.0.1:32842",
+					"172.24.0.1:32842",
+					"172.25.0.1:32842",
+					"172.26.0.1:32842",
+					"172.27.0.1:32842",
+					"172.28.0.1:32842"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:19:21.585938624Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9dc6d6f65864f92af390216540c9b809f076879fa6ab1ddf4477566c3d3ca72c",
+			"MachineKey": "mkey:60579331c82e36ccbe7402c1e8e22a04f17aa2b10217661061902834bd53ff7d",
+			"Peers": [{
+				"ID":         8573270307094724,
+				"StableID":   "ndBgFrGrw921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5de5d550caee76af25800ff2bafdfa25b3ee0c1a527297092b6bee88428d291e",
+				"DiscoKey":   "discokey:78d3621ddf45b61eb6efef3619f62e5f49ca13b2b47e07a8aeb4e9991295d87f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58135",
+					"10.65.0.27:58135",
+					"172.17.0.1:58135",
+					"172.18.0.1:58135",
+					"172.19.0.1:58135",
+					"172.20.0.1:58135",
+					"172.21.0.1:58135",
+					"172.22.0.1:58135",
+					"172.23.0.1:58135",
+					"172.24.0.1:58135",
+					"172.25.0.1:58135",
+					"172.26.0.1:58135",
+					"172.27.0.1:58135",
+					"172.28.0.1:58135"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:19:18.34069644Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4757874630165731,
+				"StableID":   "nzQWVKJr9e11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:877d125b234c5f659d778821d79fee683681f31e495153a20af7c60dcfc24c64",
+				"DiscoKey":   "discokey:8fe88cddefa5b8cedc575e52ccbbfadb4639b7bb852024bdb55c063601cd2b1f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37973",
+					"10.65.0.27:37973",
+					"172.17.0.1:37973",
+					"172.18.0.1:37973",
+					"172.19.0.1:37973",
+					"172.20.0.1:37973",
+					"172.21.0.1:37973",
+					"172.22.0.1:37973",
+					"172.23.0.1:37973",
+					"172.24.0.1:37973",
+					"172.25.0.1:37973",
+					"172.26.0.1:37973",
+					"172.27.0.1:37973",
+					"172.28.0.1:37973"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:19:18.859688049Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5181576811348899,
+				"StableID":   "nSrsLiEkTh11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93e906a9692b49c5eda79cce6a97ed4799a48e1605e746494496a77c39aae528",
+				"DiscoKey":   "discokey:6ba5c2b98606fd8bf77d552d88b0c2ba92fe06c93fc2e6fcae76813ff14c2371",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:44257",
+					"10.65.0.27:44257",
+					"172.17.0.1:44257",
+					"172.18.0.1:44257",
+					"172.19.0.1:44257",
+					"172.20.0.1:44257",
+					"172.21.0.1:44257",
+					"172.22.0.1:44257",
+					"172.23.0.1:44257",
+					"172.24.0.1:44257",
+					"172.25.0.1:44257",
+					"172.26.0.1:44257",
+					"172.27.0.1:44257",
+					"172.28.0.1:44257"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:19:19.420242613Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3024142579763633,
+				"StableID":   "nYSs5f6ecQ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f5ef265e9d7fe135001251b2512cf85ea9ad43d7aa44b338e95335004b6aae01",
+				"DiscoKey":   "discokey:9e5f76deebc53ac3b3deaf8e01600088e43398bc51076a70cd468a5a2fbc4527",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34886",
+					"10.65.0.27:34886",
+					"172.17.0.1:34886",
+					"172.18.0.1:34886",
+					"172.19.0.1:34886",
+					"172.20.0.1:34886",
+					"172.21.0.1:34886",
+					"172.22.0.1:34886",
+					"172.23.0.1:34886",
+					"172.24.0.1:34886",
+					"172.25.0.1:34886",
+					"172.26.0.1:34886",
+					"172.27.0.1:34886",
+					"172.28.0.1:34886"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:19:19.9714794Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7907824750755997,
+				"StableID":   "nCij9X9Uk421CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e15db383b9c813c3c6c972ef3d514208ff3e02fa3d80e28cd7cf8c6ef25b656f",
+				"DiscoKey":   "discokey:1532948c521598c248fbdbe0b7fd01133db4f6fdcc657d8874a6b968f6903757",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41744",
+					"10.65.0.27:41744",
+					"172.17.0.1:41744",
+					"172.18.0.1:41744",
+					"172.19.0.1:41744",
+					"172.20.0.1:41744",
+					"172.21.0.1:41744",
+					"172.22.0.1:41744",
+					"172.23.0.1:41744",
+					"172.24.0.1:41744",
+					"172.25.0.1:41744",
+					"172.26.0.1:41744",
+					"172.27.0.1:41744",
+					"172.28.0.1:41744"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:19:20.501136787Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4784639507416429,
+				"StableID":   "n6jS3GNyMe11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:be0d544d162ab0cc7eab0034e6efc0bf3052698d6c2675a496d59c66a47bb271",
+				"DiscoKey":   "discokey:601f5de8b0e63c86913fb4f7a3c29b4367d39af5707d5c4115e5595312c65965",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:60965",
+					"10.65.0.27:60965",
+					"172.17.0.1:60965",
+					"172.18.0.1:60965",
+					"172.19.0.1:60965",
+					"172.20.0.1:60965",
+					"172.21.0.1:60965",
+					"172.22.0.1:60965",
+					"172.23.0.1:60965",
+					"172.24.0.1:60965",
+					"172.25.0.1:60965",
+					"172.26.0.1:60965",
+					"172.27.0.1:60965",
+					"172.28.0.1:60965"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:19:21.040816987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6486969541950041,
+				"StableID":   "nWodq1hxes11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:528c424e05b2a205ff1bff5e5190722becab3d5a10566d11272a30cdddedc91f",
+				"DiscoKey":   "discokey:34927bc670b26f71112fe7735f62e5e23727099fc8728b68dd5a04e86a5c7918",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47647",
+					"10.65.0.27:47647",
+					"172.17.0.1:47647",
+					"172.18.0.1:47647",
+					"172.19.0.1:47647",
+					"172.20.0.1:47647",
+					"172.21.0.1:47647",
+					"172.22.0.1:47647",
+					"172.23.0.1:47647",
+					"172.24.0.1:47647",
+					"172.25.0.1:47647",
+					"172.26.0.1:47647",
+					"172.27.0.1:47647",
+					"172.28.0.1:47647"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:19:22.122736953Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         503241623682931,
+				"StableID":   "nE4s1eJvv411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65f1409c11bd8b452d418f03aaf3a3369b1cae8c45c079cff5c2a46d92eb060f",
+				"DiscoKey":   "discokey:f1146b5ff2cb1e8f090ffefcdb7d5e885388aa34bdd197656f65914cc3da7578",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48284",
+					"10.65.0.27:48284",
+					"172.17.0.1:48284",
+					"172.18.0.1:48284",
+					"172.19.0.1:48284",
+					"172.20.0.1:48284",
+					"172.21.0.1:48284",
+					"172.22.0.1:48284",
+					"172.23.0.1:48284",
+					"172.24.0.1:48284",
+					"172.25.0.1:48284",
+					"172.26.0.1:48284",
+					"172.27.0.1:48284",
+					"172.28.0.1:48284"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:19:22.659613084Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1543860425024168,
+				"StableID":   "nsCM4YbD4D11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc542a090ddb07798283d5e07c2f2a5b5c346d3f348b9af0fe3ed8c97c34a73f",
+				"DiscoKey":   "discokey:9c81180c8dcfd8cdbcbb5a6cdff8788b7478e139043e1c9cb430bb12ff4d9c41",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49569",
+					"10.65.0.27:49569",
+					"172.17.0.1:49569",
+					"172.18.0.1:49569",
+					"172.19.0.1:49569",
+					"172.20.0.1:49569",
+					"172.21.0.1:49569",
+					"172.22.0.1:49569",
+					"172.23.0.1:49569",
+					"172.24.0.1:49569",
+					"172.25.0.1:49569",
+					"172.26.0.1:49569",
+					"172.27.0.1:49569",
+					"172.28.0.1:49569"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:19:23.203947754Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         405195271382504,
+				"StableID":   "nsk9cynWA411CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae23a3331702698e34b01628737d5b8c91a4860ef321ede711ec45a1f7f16a39",
+				"DiscoKey":   "discokey:e169bbf9a738b39c766c1d60db70b02932e5436e0c948a8100001ff9a670e669",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43159",
+					"10.65.0.27:43159",
+					"172.17.0.1:43159",
+					"172.18.0.1:43159",
+					"172.19.0.1:43159",
+					"172.20.0.1:43159",
+					"172.21.0.1:43159",
+					"172.22.0.1:43159",
+					"172.23.0.1:43159",
+					"172.24.0.1:43159",
+					"172.25.0.1:43159",
+					"172.26.0.1:43159",
+					"172.27.0.1:43159",
+					"172.28.0.1:43159"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:19:23.74529735Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3426536136371848,
+				"StableID":   "nV5Uk3JtkT11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9acfa98fbb055c7bbfbcfc470e2a3d7c4ec2e992b0718826593b6d1abc45cb1f",
+				"DiscoKey":   "discokey:5e5ace1c16176fb4349597cd6b68958f2a40160e8d74765bb4f53885a135ae75",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36618",
+					"10.65.0.27:36618",
+					"172.17.0.1:36618",
+					"172.18.0.1:36618",
+					"172.19.0.1:36618",
+					"172.20.0.1:36618",
+					"172.21.0.1:36618",
+					"172.22.0.1:36618",
+					"172.23.0.1:36618",
+					"172.24.0.1:36618",
+					"172.25.0.1:36618",
+					"172.26.0.1:36618",
+					"172.27.0.1:36618",
+					"172.28.0.1:36618"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:19:24.279863448Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3012369755640188,
+				"StableID":   "nFaxv2rJXQ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bf81993c448c401aabadfb70775d12ea095e3661892ad67b2ac1df81287d4419",
+				"KeyExpiry":  "2026-11-09T09:19:24Z",
+				"DiscoKey":   "discokey:5f695b82c9c07a756d9396d5c6ddaaf6f793ee3e942f0fc7dd7abee85acf7716",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44334",
+					"10.65.0.27:44334",
+					"172.17.0.1:44334",
+					"172.18.0.1:44334",
+					"172.19.0.1:44334",
+					"172.20.0.1:44334",
+					"172.21.0.1:44334",
+					"172.22.0.1:44334",
+					"172.23.0.1:44334",
+					"172.24.0.1:44334",
+					"172.25.0.1:44334",
+					"172.26.0.1:44334",
+					"172.27.0.1:44334",
+					"172.28.0.1:44334"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:19:24.811647723Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7468751552721751,
+				"StableID":   "ncdCBSScK121CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1dfc22f5f5c6f1c3ed49365c6aecd7052aab04c55c7fb36b648c1e0e3f90ce06",
+				"KeyExpiry":  "2026-11-09T09:19:25Z",
+				"DiscoKey":   "discokey:3ebea6bb99e095d26d9832c20ef05cf3656a46b26658f6199c22ac578444446d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49818",
+					"10.65.0.27:49818",
+					"172.17.0.1:49818",
+					"172.18.0.1:49818",
+					"172.19.0.1:49818",
+					"172.20.0.1:49818",
+					"172.21.0.1:49818",
+					"172.22.0.1:49818",
+					"172.23.0.1:49818",
+					"172.24.0.1:49818",
+					"172.25.0.1:49818",
+					"172.26.0.1:49818",
+					"172.27.0.1:49818",
+					"172.28.0.1:49818"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:19:25.353736893Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5452265111916024,
+				"StableID":   "nsg3Y2mLaj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a2dc8487de8773ec3bb4ef74f14b9e2bd8dbc3ef4bae39fb2b60e26447edce28",
+				"KeyExpiry":  "2026-11-09T09:19:25Z",
+				"DiscoKey":   "discokey:13a5d9f2ab3232d280bd0902671b54b3f12970168a613de5a841db3778eafc73",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49612",
+					"10.65.0.27:49612",
+					"172.17.0.1:49612",
+					"172.18.0.1:49612",
+					"172.19.0.1:49612",
+					"172.20.0.1:49612",
+					"172.21.0.1:49612",
+					"172.22.0.1:49612",
+					"172.23.0.1:49612",
+					"172.24.0.1:49612",
+					"172.25.0.1:49612",
+					"172.26.0.1:49612",
+					"172.27.0.1:49612",
+					"172.28.0.1:49612"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:19:25.921846203Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3426646194877689": {
+				"ID":          3426646194877689,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         503241623682931,
+				"StableID":   "nE4s1eJvv411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       503241623682931,
+				"Key":        "nodekey:65f1409c11bd8b452d418f03aaf3a3369b1cae8c45c079cff5c2a46d92eb060f",
+				"DiscoKey":   "discokey:f1146b5ff2cb1e8f090ffefcdb7d5e885388aa34bdd197656f65914cc3da7578",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48284",
+					"10.65.0.27:48284",
+					"172.17.0.1:48284",
+					"172.18.0.1:48284",
+					"172.19.0.1:48284",
+					"172.20.0.1:48284",
+					"172.21.0.1:48284",
+					"172.22.0.1:48284",
+					"172.23.0.1:48284",
+					"172.24.0.1:48284",
+					"172.25.0.1:48284",
+					"172.26.0.1:48284",
+					"172.27.0.1:48284",
+					"172.28.0.1:48284"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:19:22.659613084Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:65f1409c11bd8b452d418f03aaf3a3369b1cae8c45c079cff5c2a46d92eb060f",
+			"MachineKey": "mkey:9c4434eddfb7f974db80cfd84e81af0e0378358c133c2fea2024d3ed5d679172",
+			"Peers": [{
+				"ID":         8573270307094724,
+				"StableID":   "ndBgFrGrw921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5de5d550caee76af25800ff2bafdfa25b3ee0c1a527297092b6bee88428d291e",
+				"DiscoKey":   "discokey:78d3621ddf45b61eb6efef3619f62e5f49ca13b2b47e07a8aeb4e9991295d87f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58135",
+					"10.65.0.27:58135",
+					"172.17.0.1:58135",
+					"172.18.0.1:58135",
+					"172.19.0.1:58135",
+					"172.20.0.1:58135",
+					"172.21.0.1:58135",
+					"172.22.0.1:58135",
+					"172.23.0.1:58135",
+					"172.24.0.1:58135",
+					"172.25.0.1:58135",
+					"172.26.0.1:58135",
+					"172.27.0.1:58135",
+					"172.28.0.1:58135"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:19:18.34069644Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4757874630165731,
+				"StableID":   "nzQWVKJr9e11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:877d125b234c5f659d778821d79fee683681f31e495153a20af7c60dcfc24c64",
+				"DiscoKey":   "discokey:8fe88cddefa5b8cedc575e52ccbbfadb4639b7bb852024bdb55c063601cd2b1f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37973",
+					"10.65.0.27:37973",
+					"172.17.0.1:37973",
+					"172.18.0.1:37973",
+					"172.19.0.1:37973",
+					"172.20.0.1:37973",
+					"172.21.0.1:37973",
+					"172.22.0.1:37973",
+					"172.23.0.1:37973",
+					"172.24.0.1:37973",
+					"172.25.0.1:37973",
+					"172.26.0.1:37973",
+					"172.27.0.1:37973",
+					"172.28.0.1:37973"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:19:18.859688049Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5181576811348899,
+				"StableID":   "nSrsLiEkTh11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93e906a9692b49c5eda79cce6a97ed4799a48e1605e746494496a77c39aae528",
+				"DiscoKey":   "discokey:6ba5c2b98606fd8bf77d552d88b0c2ba92fe06c93fc2e6fcae76813ff14c2371",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:44257",
+					"10.65.0.27:44257",
+					"172.17.0.1:44257",
+					"172.18.0.1:44257",
+					"172.19.0.1:44257",
+					"172.20.0.1:44257",
+					"172.21.0.1:44257",
+					"172.22.0.1:44257",
+					"172.23.0.1:44257",
+					"172.24.0.1:44257",
+					"172.25.0.1:44257",
+					"172.26.0.1:44257",
+					"172.27.0.1:44257",
+					"172.28.0.1:44257"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:19:19.420242613Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3024142579763633,
+				"StableID":   "nYSs5f6ecQ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f5ef265e9d7fe135001251b2512cf85ea9ad43d7aa44b338e95335004b6aae01",
+				"DiscoKey":   "discokey:9e5f76deebc53ac3b3deaf8e01600088e43398bc51076a70cd468a5a2fbc4527",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34886",
+					"10.65.0.27:34886",
+					"172.17.0.1:34886",
+					"172.18.0.1:34886",
+					"172.19.0.1:34886",
+					"172.20.0.1:34886",
+					"172.21.0.1:34886",
+					"172.22.0.1:34886",
+					"172.23.0.1:34886",
+					"172.24.0.1:34886",
+					"172.25.0.1:34886",
+					"172.26.0.1:34886",
+					"172.27.0.1:34886",
+					"172.28.0.1:34886"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:19:19.9714794Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7907824750755997,
+				"StableID":   "nCij9X9Uk421CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e15db383b9c813c3c6c972ef3d514208ff3e02fa3d80e28cd7cf8c6ef25b656f",
+				"DiscoKey":   "discokey:1532948c521598c248fbdbe0b7fd01133db4f6fdcc657d8874a6b968f6903757",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41744",
+					"10.65.0.27:41744",
+					"172.17.0.1:41744",
+					"172.18.0.1:41744",
+					"172.19.0.1:41744",
+					"172.20.0.1:41744",
+					"172.21.0.1:41744",
+					"172.22.0.1:41744",
+					"172.23.0.1:41744",
+					"172.24.0.1:41744",
+					"172.25.0.1:41744",
+					"172.26.0.1:41744",
+					"172.27.0.1:41744",
+					"172.28.0.1:41744"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:19:20.501136787Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4784639507416429,
+				"StableID":   "n6jS3GNyMe11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:be0d544d162ab0cc7eab0034e6efc0bf3052698d6c2675a496d59c66a47bb271",
+				"DiscoKey":   "discokey:601f5de8b0e63c86913fb4f7a3c29b4367d39af5707d5c4115e5595312c65965",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:60965",
+					"10.65.0.27:60965",
+					"172.17.0.1:60965",
+					"172.18.0.1:60965",
+					"172.19.0.1:60965",
+					"172.20.0.1:60965",
+					"172.21.0.1:60965",
+					"172.22.0.1:60965",
+					"172.23.0.1:60965",
+					"172.24.0.1:60965",
+					"172.25.0.1:60965",
+					"172.26.0.1:60965",
+					"172.27.0.1:60965",
+					"172.28.0.1:60965"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:19:21.040816987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3426646194877689,
+				"StableID":   "n2V5FjBwkT11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9dc6d6f65864f92af390216540c9b809f076879fa6ab1ddf4477566c3d3ca72c",
+				"DiscoKey":   "discokey:023df61eb4a134f8b491c87215f64b6875f0232fc5483452c0cf987b99f7882e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:32842",
+					"10.65.0.27:32842",
+					"172.17.0.1:32842",
+					"172.18.0.1:32842",
+					"172.19.0.1:32842",
+					"172.20.0.1:32842",
+					"172.21.0.1:32842",
+					"172.22.0.1:32842",
+					"172.23.0.1:32842",
+					"172.24.0.1:32842",
+					"172.25.0.1:32842",
+					"172.26.0.1:32842",
+					"172.27.0.1:32842",
+					"172.28.0.1:32842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:19:21.585938624Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6486969541950041,
+				"StableID":   "nWodq1hxes11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:528c424e05b2a205ff1bff5e5190722becab3d5a10566d11272a30cdddedc91f",
+				"DiscoKey":   "discokey:34927bc670b26f71112fe7735f62e5e23727099fc8728b68dd5a04e86a5c7918",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47647",
+					"10.65.0.27:47647",
+					"172.17.0.1:47647",
+					"172.18.0.1:47647",
+					"172.19.0.1:47647",
+					"172.20.0.1:47647",
+					"172.21.0.1:47647",
+					"172.22.0.1:47647",
+					"172.23.0.1:47647",
+					"172.24.0.1:47647",
+					"172.25.0.1:47647",
+					"172.26.0.1:47647",
+					"172.27.0.1:47647",
+					"172.28.0.1:47647"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:19:22.122736953Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1543860425024168,
+				"StableID":   "nsCM4YbD4D11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc542a090ddb07798283d5e07c2f2a5b5c346d3f348b9af0fe3ed8c97c34a73f",
+				"DiscoKey":   "discokey:9c81180c8dcfd8cdbcbb5a6cdff8788b7478e139043e1c9cb430bb12ff4d9c41",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49569",
+					"10.65.0.27:49569",
+					"172.17.0.1:49569",
+					"172.18.0.1:49569",
+					"172.19.0.1:49569",
+					"172.20.0.1:49569",
+					"172.21.0.1:49569",
+					"172.22.0.1:49569",
+					"172.23.0.1:49569",
+					"172.24.0.1:49569",
+					"172.25.0.1:49569",
+					"172.26.0.1:49569",
+					"172.27.0.1:49569",
+					"172.28.0.1:49569"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:19:23.203947754Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         405195271382504,
+				"StableID":   "nsk9cynWA411CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae23a3331702698e34b01628737d5b8c91a4860ef321ede711ec45a1f7f16a39",
+				"DiscoKey":   "discokey:e169bbf9a738b39c766c1d60db70b02932e5436e0c948a8100001ff9a670e669",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43159",
+					"10.65.0.27:43159",
+					"172.17.0.1:43159",
+					"172.18.0.1:43159",
+					"172.19.0.1:43159",
+					"172.20.0.1:43159",
+					"172.21.0.1:43159",
+					"172.22.0.1:43159",
+					"172.23.0.1:43159",
+					"172.24.0.1:43159",
+					"172.25.0.1:43159",
+					"172.26.0.1:43159",
+					"172.27.0.1:43159",
+					"172.28.0.1:43159"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:19:23.74529735Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3426536136371848,
+				"StableID":   "nV5Uk3JtkT11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9acfa98fbb055c7bbfbcfc470e2a3d7c4ec2e992b0718826593b6d1abc45cb1f",
+				"DiscoKey":   "discokey:5e5ace1c16176fb4349597cd6b68958f2a40160e8d74765bb4f53885a135ae75",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36618",
+					"10.65.0.27:36618",
+					"172.17.0.1:36618",
+					"172.18.0.1:36618",
+					"172.19.0.1:36618",
+					"172.20.0.1:36618",
+					"172.21.0.1:36618",
+					"172.22.0.1:36618",
+					"172.23.0.1:36618",
+					"172.24.0.1:36618",
+					"172.25.0.1:36618",
+					"172.26.0.1:36618",
+					"172.27.0.1:36618",
+					"172.28.0.1:36618"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:19:24.279863448Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3012369755640188,
+				"StableID":   "nFaxv2rJXQ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bf81993c448c401aabadfb70775d12ea095e3661892ad67b2ac1df81287d4419",
+				"KeyExpiry":  "2026-11-09T09:19:24Z",
+				"DiscoKey":   "discokey:5f695b82c9c07a756d9396d5c6ddaaf6f793ee3e942f0fc7dd7abee85acf7716",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44334",
+					"10.65.0.27:44334",
+					"172.17.0.1:44334",
+					"172.18.0.1:44334",
+					"172.19.0.1:44334",
+					"172.20.0.1:44334",
+					"172.21.0.1:44334",
+					"172.22.0.1:44334",
+					"172.23.0.1:44334",
+					"172.24.0.1:44334",
+					"172.25.0.1:44334",
+					"172.26.0.1:44334",
+					"172.27.0.1:44334",
+					"172.28.0.1:44334"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:19:24.811647723Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7468751552721751,
+				"StableID":   "ncdCBSScK121CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1dfc22f5f5c6f1c3ed49365c6aecd7052aab04c55c7fb36b648c1e0e3f90ce06",
+				"KeyExpiry":  "2026-11-09T09:19:25Z",
+				"DiscoKey":   "discokey:3ebea6bb99e095d26d9832c20ef05cf3656a46b26658f6199c22ac578444446d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49818",
+					"10.65.0.27:49818",
+					"172.17.0.1:49818",
+					"172.18.0.1:49818",
+					"172.19.0.1:49818",
+					"172.20.0.1:49818",
+					"172.21.0.1:49818",
+					"172.22.0.1:49818",
+					"172.23.0.1:49818",
+					"172.24.0.1:49818",
+					"172.25.0.1:49818",
+					"172.26.0.1:49818",
+					"172.27.0.1:49818",
+					"172.28.0.1:49818"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:19:25.353736893Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5452265111916024,
+				"StableID":   "nsg3Y2mLaj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a2dc8487de8773ec3bb4ef74f14b9e2bd8dbc3ef4bae39fb2b60e26447edce28",
+				"KeyExpiry":  "2026-11-09T09:19:25Z",
+				"DiscoKey":   "discokey:13a5d9f2ab3232d280bd0902671b54b3f12970168a613de5a841db3778eafc73",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49612",
+					"10.65.0.27:49612",
+					"172.17.0.1:49612",
+					"172.18.0.1:49612",
+					"172.19.0.1:49612",
+					"172.20.0.1:49612",
+					"172.21.0.1:49612",
+					"172.22.0.1:49612",
+					"172.23.0.1:49612",
+					"172.24.0.1:49612",
+					"172.25.0.1:49612",
+					"172.26.0.1:49612",
+					"172.27.0.1:49612",
+					"172.28.0.1:49612"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:19:25.921846203Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "503241623682931": {
+				"ID":          503241623682931,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7468751552721751,
+				"StableID":   "ncdCBSScK121CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1dfc22f5f5c6f1c3ed49365c6aecd7052aab04c55c7fb36b648c1e0e3f90ce06",
+				"KeyExpiry":  "2026-11-09T09:19:25Z",
+				"DiscoKey":   "discokey:3ebea6bb99e095d26d9832c20ef05cf3656a46b26658f6199c22ac578444446d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49818",
+					"10.65.0.27:49818",
+					"172.17.0.1:49818",
+					"172.18.0.1:49818",
+					"172.19.0.1:49818",
+					"172.20.0.1:49818",
+					"172.21.0.1:49818",
+					"172.22.0.1:49818",
+					"172.23.0.1:49818",
+					"172.24.0.1:49818",
+					"172.25.0.1:49818",
+					"172.26.0.1:49818",
+					"172.27.0.1:49818",
+					"172.28.0.1:49818"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:19:25.353736893Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1dfc22f5f5c6f1c3ed49365c6aecd7052aab04c55c7fb36b648c1e0e3f90ce06",
+			"MachineKey": "mkey:653cb90f05e86b4f5eacd4866d0b330e13cb4f1123d543e27f121b798ea73c07",
+			"Peers": [{
+				"ID":         8573270307094724,
+				"StableID":   "ndBgFrGrw921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5de5d550caee76af25800ff2bafdfa25b3ee0c1a527297092b6bee88428d291e",
+				"DiscoKey":   "discokey:78d3621ddf45b61eb6efef3619f62e5f49ca13b2b47e07a8aeb4e9991295d87f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58135",
+					"10.65.0.27:58135",
+					"172.17.0.1:58135",
+					"172.18.0.1:58135",
+					"172.19.0.1:58135",
+					"172.20.0.1:58135",
+					"172.21.0.1:58135",
+					"172.22.0.1:58135",
+					"172.23.0.1:58135",
+					"172.24.0.1:58135",
+					"172.25.0.1:58135",
+					"172.26.0.1:58135",
+					"172.27.0.1:58135",
+					"172.28.0.1:58135"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:19:18.34069644Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4757874630165731,
+				"StableID":   "nzQWVKJr9e11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:877d125b234c5f659d778821d79fee683681f31e495153a20af7c60dcfc24c64",
+				"DiscoKey":   "discokey:8fe88cddefa5b8cedc575e52ccbbfadb4639b7bb852024bdb55c063601cd2b1f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37973",
+					"10.65.0.27:37973",
+					"172.17.0.1:37973",
+					"172.18.0.1:37973",
+					"172.19.0.1:37973",
+					"172.20.0.1:37973",
+					"172.21.0.1:37973",
+					"172.22.0.1:37973",
+					"172.23.0.1:37973",
+					"172.24.0.1:37973",
+					"172.25.0.1:37973",
+					"172.26.0.1:37973",
+					"172.27.0.1:37973",
+					"172.28.0.1:37973"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:19:18.859688049Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5181576811348899,
+				"StableID":   "nSrsLiEkTh11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93e906a9692b49c5eda79cce6a97ed4799a48e1605e746494496a77c39aae528",
+				"DiscoKey":   "discokey:6ba5c2b98606fd8bf77d552d88b0c2ba92fe06c93fc2e6fcae76813ff14c2371",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:44257",
+					"10.65.0.27:44257",
+					"172.17.0.1:44257",
+					"172.18.0.1:44257",
+					"172.19.0.1:44257",
+					"172.20.0.1:44257",
+					"172.21.0.1:44257",
+					"172.22.0.1:44257",
+					"172.23.0.1:44257",
+					"172.24.0.1:44257",
+					"172.25.0.1:44257",
+					"172.26.0.1:44257",
+					"172.27.0.1:44257",
+					"172.28.0.1:44257"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:19:19.420242613Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3024142579763633,
+				"StableID":   "nYSs5f6ecQ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f5ef265e9d7fe135001251b2512cf85ea9ad43d7aa44b338e95335004b6aae01",
+				"DiscoKey":   "discokey:9e5f76deebc53ac3b3deaf8e01600088e43398bc51076a70cd468a5a2fbc4527",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34886",
+					"10.65.0.27:34886",
+					"172.17.0.1:34886",
+					"172.18.0.1:34886",
+					"172.19.0.1:34886",
+					"172.20.0.1:34886",
+					"172.21.0.1:34886",
+					"172.22.0.1:34886",
+					"172.23.0.1:34886",
+					"172.24.0.1:34886",
+					"172.25.0.1:34886",
+					"172.26.0.1:34886",
+					"172.27.0.1:34886",
+					"172.28.0.1:34886"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:19:19.9714794Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7907824750755997,
+				"StableID":   "nCij9X9Uk421CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e15db383b9c813c3c6c972ef3d514208ff3e02fa3d80e28cd7cf8c6ef25b656f",
+				"DiscoKey":   "discokey:1532948c521598c248fbdbe0b7fd01133db4f6fdcc657d8874a6b968f6903757",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41744",
+					"10.65.0.27:41744",
+					"172.17.0.1:41744",
+					"172.18.0.1:41744",
+					"172.19.0.1:41744",
+					"172.20.0.1:41744",
+					"172.21.0.1:41744",
+					"172.22.0.1:41744",
+					"172.23.0.1:41744",
+					"172.24.0.1:41744",
+					"172.25.0.1:41744",
+					"172.26.0.1:41744",
+					"172.27.0.1:41744",
+					"172.28.0.1:41744"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:19:20.501136787Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4784639507416429,
+				"StableID":   "n6jS3GNyMe11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:be0d544d162ab0cc7eab0034e6efc0bf3052698d6c2675a496d59c66a47bb271",
+				"DiscoKey":   "discokey:601f5de8b0e63c86913fb4f7a3c29b4367d39af5707d5c4115e5595312c65965",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:60965",
+					"10.65.0.27:60965",
+					"172.17.0.1:60965",
+					"172.18.0.1:60965",
+					"172.19.0.1:60965",
+					"172.20.0.1:60965",
+					"172.21.0.1:60965",
+					"172.22.0.1:60965",
+					"172.23.0.1:60965",
+					"172.24.0.1:60965",
+					"172.25.0.1:60965",
+					"172.26.0.1:60965",
+					"172.27.0.1:60965",
+					"172.28.0.1:60965"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:19:21.040816987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3426646194877689,
+				"StableID":   "n2V5FjBwkT11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9dc6d6f65864f92af390216540c9b809f076879fa6ab1ddf4477566c3d3ca72c",
+				"DiscoKey":   "discokey:023df61eb4a134f8b491c87215f64b6875f0232fc5483452c0cf987b99f7882e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:32842",
+					"10.65.0.27:32842",
+					"172.17.0.1:32842",
+					"172.18.0.1:32842",
+					"172.19.0.1:32842",
+					"172.20.0.1:32842",
+					"172.21.0.1:32842",
+					"172.22.0.1:32842",
+					"172.23.0.1:32842",
+					"172.24.0.1:32842",
+					"172.25.0.1:32842",
+					"172.26.0.1:32842",
+					"172.27.0.1:32842",
+					"172.28.0.1:32842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:19:21.585938624Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6486969541950041,
+				"StableID":   "nWodq1hxes11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:528c424e05b2a205ff1bff5e5190722becab3d5a10566d11272a30cdddedc91f",
+				"DiscoKey":   "discokey:34927bc670b26f71112fe7735f62e5e23727099fc8728b68dd5a04e86a5c7918",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47647",
+					"10.65.0.27:47647",
+					"172.17.0.1:47647",
+					"172.18.0.1:47647",
+					"172.19.0.1:47647",
+					"172.20.0.1:47647",
+					"172.21.0.1:47647",
+					"172.22.0.1:47647",
+					"172.23.0.1:47647",
+					"172.24.0.1:47647",
+					"172.25.0.1:47647",
+					"172.26.0.1:47647",
+					"172.27.0.1:47647",
+					"172.28.0.1:47647"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:19:22.122736953Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         503241623682931,
+				"StableID":   "nE4s1eJvv411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65f1409c11bd8b452d418f03aaf3a3369b1cae8c45c079cff5c2a46d92eb060f",
+				"DiscoKey":   "discokey:f1146b5ff2cb1e8f090ffefcdb7d5e885388aa34bdd197656f65914cc3da7578",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48284",
+					"10.65.0.27:48284",
+					"172.17.0.1:48284",
+					"172.18.0.1:48284",
+					"172.19.0.1:48284",
+					"172.20.0.1:48284",
+					"172.21.0.1:48284",
+					"172.22.0.1:48284",
+					"172.23.0.1:48284",
+					"172.24.0.1:48284",
+					"172.25.0.1:48284",
+					"172.26.0.1:48284",
+					"172.27.0.1:48284",
+					"172.28.0.1:48284"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:19:22.659613084Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1543860425024168,
+				"StableID":   "nsCM4YbD4D11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc542a090ddb07798283d5e07c2f2a5b5c346d3f348b9af0fe3ed8c97c34a73f",
+				"DiscoKey":   "discokey:9c81180c8dcfd8cdbcbb5a6cdff8788b7478e139043e1c9cb430bb12ff4d9c41",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49569",
+					"10.65.0.27:49569",
+					"172.17.0.1:49569",
+					"172.18.0.1:49569",
+					"172.19.0.1:49569",
+					"172.20.0.1:49569",
+					"172.21.0.1:49569",
+					"172.22.0.1:49569",
+					"172.23.0.1:49569",
+					"172.24.0.1:49569",
+					"172.25.0.1:49569",
+					"172.26.0.1:49569",
+					"172.27.0.1:49569",
+					"172.28.0.1:49569"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:19:23.203947754Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         405195271382504,
+				"StableID":   "nsk9cynWA411CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae23a3331702698e34b01628737d5b8c91a4860ef321ede711ec45a1f7f16a39",
+				"DiscoKey":   "discokey:e169bbf9a738b39c766c1d60db70b02932e5436e0c948a8100001ff9a670e669",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43159",
+					"10.65.0.27:43159",
+					"172.17.0.1:43159",
+					"172.18.0.1:43159",
+					"172.19.0.1:43159",
+					"172.20.0.1:43159",
+					"172.21.0.1:43159",
+					"172.22.0.1:43159",
+					"172.23.0.1:43159",
+					"172.24.0.1:43159",
+					"172.25.0.1:43159",
+					"172.26.0.1:43159",
+					"172.27.0.1:43159",
+					"172.28.0.1:43159"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:19:23.74529735Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3426536136371848,
+				"StableID":   "nV5Uk3JtkT11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9acfa98fbb055c7bbfbcfc470e2a3d7c4ec2e992b0718826593b6d1abc45cb1f",
+				"DiscoKey":   "discokey:5e5ace1c16176fb4349597cd6b68958f2a40160e8d74765bb4f53885a135ae75",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36618",
+					"10.65.0.27:36618",
+					"172.17.0.1:36618",
+					"172.18.0.1:36618",
+					"172.19.0.1:36618",
+					"172.20.0.1:36618",
+					"172.21.0.1:36618",
+					"172.22.0.1:36618",
+					"172.23.0.1:36618",
+					"172.24.0.1:36618",
+					"172.25.0.1:36618",
+					"172.26.0.1:36618",
+					"172.27.0.1:36618",
+					"172.28.0.1:36618"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:19:24.279863448Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3012369755640188,
+				"StableID":   "nFaxv2rJXQ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bf81993c448c401aabadfb70775d12ea095e3661892ad67b2ac1df81287d4419",
+				"KeyExpiry":  "2026-11-09T09:19:24Z",
+				"DiscoKey":   "discokey:5f695b82c9c07a756d9396d5c6ddaaf6f793ee3e942f0fc7dd7abee85acf7716",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44334",
+					"10.65.0.27:44334",
+					"172.17.0.1:44334",
+					"172.18.0.1:44334",
+					"172.19.0.1:44334",
+					"172.20.0.1:44334",
+					"172.21.0.1:44334",
+					"172.22.0.1:44334",
+					"172.23.0.1:44334",
+					"172.24.0.1:44334",
+					"172.25.0.1:44334",
+					"172.26.0.1:44334",
+					"172.27.0.1:44334",
+					"172.28.0.1:44334"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:19:24.811647723Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5452265111916024,
+				"StableID":   "nsg3Y2mLaj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a2dc8487de8773ec3bb4ef74f14b9e2bd8dbc3ef4bae39fb2b60e26447edce28",
+				"KeyExpiry":  "2026-11-09T09:19:25Z",
+				"DiscoKey":   "discokey:13a5d9f2ab3232d280bd0902671b54b3f12970168a613de5a841db3778eafc73",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49612",
+					"10.65.0.27:49612",
+					"172.17.0.1:49612",
+					"172.18.0.1:49612",
+					"172.19.0.1:49612",
+					"172.20.0.1:49612",
+					"172.21.0.1:49612",
+					"172.22.0.1:49612",
+					"172.23.0.1:49612",
+					"172.24.0.1:49612",
+					"172.25.0.1:49612",
+					"172.26.0.1:49612",
+					"172.27.0.1:49612",
+					"172.28.0.1:49612"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:19:25.921846203Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1543860425024168,
+				"StableID":   "nsCM4YbD4D11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1543860425024168,
+				"Key":        "nodekey:fc542a090ddb07798283d5e07c2f2a5b5c346d3f348b9af0fe3ed8c97c34a73f",
+				"DiscoKey":   "discokey:9c81180c8dcfd8cdbcbb5a6cdff8788b7478e139043e1c9cb430bb12ff4d9c41",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49569",
+					"10.65.0.27:49569",
+					"172.17.0.1:49569",
+					"172.18.0.1:49569",
+					"172.19.0.1:49569",
+					"172.20.0.1:49569",
+					"172.21.0.1:49569",
+					"172.22.0.1:49569",
+					"172.23.0.1:49569",
+					"172.24.0.1:49569",
+					"172.25.0.1:49569",
+					"172.26.0.1:49569",
+					"172.27.0.1:49569",
+					"172.28.0.1:49569"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:19:23.203947754Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:fc542a090ddb07798283d5e07c2f2a5b5c346d3f348b9af0fe3ed8c97c34a73f",
+			"MachineKey": "mkey:df05d142a4e327f7a90b2884949a5258eb7629b37178ac267639b0c591cb1d06",
+			"Peers": [{
+				"ID":         8573270307094724,
+				"StableID":   "ndBgFrGrw921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5de5d550caee76af25800ff2bafdfa25b3ee0c1a527297092b6bee88428d291e",
+				"DiscoKey":   "discokey:78d3621ddf45b61eb6efef3619f62e5f49ca13b2b47e07a8aeb4e9991295d87f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58135",
+					"10.65.0.27:58135",
+					"172.17.0.1:58135",
+					"172.18.0.1:58135",
+					"172.19.0.1:58135",
+					"172.20.0.1:58135",
+					"172.21.0.1:58135",
+					"172.22.0.1:58135",
+					"172.23.0.1:58135",
+					"172.24.0.1:58135",
+					"172.25.0.1:58135",
+					"172.26.0.1:58135",
+					"172.27.0.1:58135",
+					"172.28.0.1:58135"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:19:18.34069644Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4757874630165731,
+				"StableID":   "nzQWVKJr9e11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:877d125b234c5f659d778821d79fee683681f31e495153a20af7c60dcfc24c64",
+				"DiscoKey":   "discokey:8fe88cddefa5b8cedc575e52ccbbfadb4639b7bb852024bdb55c063601cd2b1f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37973",
+					"10.65.0.27:37973",
+					"172.17.0.1:37973",
+					"172.18.0.1:37973",
+					"172.19.0.1:37973",
+					"172.20.0.1:37973",
+					"172.21.0.1:37973",
+					"172.22.0.1:37973",
+					"172.23.0.1:37973",
+					"172.24.0.1:37973",
+					"172.25.0.1:37973",
+					"172.26.0.1:37973",
+					"172.27.0.1:37973",
+					"172.28.0.1:37973"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:19:18.859688049Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5181576811348899,
+				"StableID":   "nSrsLiEkTh11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93e906a9692b49c5eda79cce6a97ed4799a48e1605e746494496a77c39aae528",
+				"DiscoKey":   "discokey:6ba5c2b98606fd8bf77d552d88b0c2ba92fe06c93fc2e6fcae76813ff14c2371",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:44257",
+					"10.65.0.27:44257",
+					"172.17.0.1:44257",
+					"172.18.0.1:44257",
+					"172.19.0.1:44257",
+					"172.20.0.1:44257",
+					"172.21.0.1:44257",
+					"172.22.0.1:44257",
+					"172.23.0.1:44257",
+					"172.24.0.1:44257",
+					"172.25.0.1:44257",
+					"172.26.0.1:44257",
+					"172.27.0.1:44257",
+					"172.28.0.1:44257"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:19:19.420242613Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3024142579763633,
+				"StableID":   "nYSs5f6ecQ11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f5ef265e9d7fe135001251b2512cf85ea9ad43d7aa44b338e95335004b6aae01",
+				"DiscoKey":   "discokey:9e5f76deebc53ac3b3deaf8e01600088e43398bc51076a70cd468a5a2fbc4527",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:34886",
+					"10.65.0.27:34886",
+					"172.17.0.1:34886",
+					"172.18.0.1:34886",
+					"172.19.0.1:34886",
+					"172.20.0.1:34886",
+					"172.21.0.1:34886",
+					"172.22.0.1:34886",
+					"172.23.0.1:34886",
+					"172.24.0.1:34886",
+					"172.25.0.1:34886",
+					"172.26.0.1:34886",
+					"172.27.0.1:34886",
+					"172.28.0.1:34886"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:19:19.9714794Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7907824750755997,
+				"StableID":   "nCij9X9Uk421CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e15db383b9c813c3c6c972ef3d514208ff3e02fa3d80e28cd7cf8c6ef25b656f",
+				"DiscoKey":   "discokey:1532948c521598c248fbdbe0b7fd01133db4f6fdcc657d8874a6b968f6903757",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41744",
+					"10.65.0.27:41744",
+					"172.17.0.1:41744",
+					"172.18.0.1:41744",
+					"172.19.0.1:41744",
+					"172.20.0.1:41744",
+					"172.21.0.1:41744",
+					"172.22.0.1:41744",
+					"172.23.0.1:41744",
+					"172.24.0.1:41744",
+					"172.25.0.1:41744",
+					"172.26.0.1:41744",
+					"172.27.0.1:41744",
+					"172.28.0.1:41744"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:19:20.501136787Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4784639507416429,
+				"StableID":   "n6jS3GNyMe11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:be0d544d162ab0cc7eab0034e6efc0bf3052698d6c2675a496d59c66a47bb271",
+				"DiscoKey":   "discokey:601f5de8b0e63c86913fb4f7a3c29b4367d39af5707d5c4115e5595312c65965",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:60965",
+					"10.65.0.27:60965",
+					"172.17.0.1:60965",
+					"172.18.0.1:60965",
+					"172.19.0.1:60965",
+					"172.20.0.1:60965",
+					"172.21.0.1:60965",
+					"172.22.0.1:60965",
+					"172.23.0.1:60965",
+					"172.24.0.1:60965",
+					"172.25.0.1:60965",
+					"172.26.0.1:60965",
+					"172.27.0.1:60965",
+					"172.28.0.1:60965"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:19:21.040816987Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3426646194877689,
+				"StableID":   "n2V5FjBwkT11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9dc6d6f65864f92af390216540c9b809f076879fa6ab1ddf4477566c3d3ca72c",
+				"DiscoKey":   "discokey:023df61eb4a134f8b491c87215f64b6875f0232fc5483452c0cf987b99f7882e",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:32842",
+					"10.65.0.27:32842",
+					"172.17.0.1:32842",
+					"172.18.0.1:32842",
+					"172.19.0.1:32842",
+					"172.20.0.1:32842",
+					"172.21.0.1:32842",
+					"172.22.0.1:32842",
+					"172.23.0.1:32842",
+					"172.24.0.1:32842",
+					"172.25.0.1:32842",
+					"172.26.0.1:32842",
+					"172.27.0.1:32842",
+					"172.28.0.1:32842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:19:21.585938624Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6486969541950041,
+				"StableID":   "nWodq1hxes11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:528c424e05b2a205ff1bff5e5190722becab3d5a10566d11272a30cdddedc91f",
+				"DiscoKey":   "discokey:34927bc670b26f71112fe7735f62e5e23727099fc8728b68dd5a04e86a5c7918",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47647",
+					"10.65.0.27:47647",
+					"172.17.0.1:47647",
+					"172.18.0.1:47647",
+					"172.19.0.1:47647",
+					"172.20.0.1:47647",
+					"172.21.0.1:47647",
+					"172.22.0.1:47647",
+					"172.23.0.1:47647",
+					"172.24.0.1:47647",
+					"172.25.0.1:47647",
+					"172.26.0.1:47647",
+					"172.27.0.1:47647",
+					"172.28.0.1:47647"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:19:22.122736953Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         503241623682931,
+				"StableID":   "nE4s1eJvv411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:65f1409c11bd8b452d418f03aaf3a3369b1cae8c45c079cff5c2a46d92eb060f",
+				"DiscoKey":   "discokey:f1146b5ff2cb1e8f090ffefcdb7d5e885388aa34bdd197656f65914cc3da7578",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:48284",
+					"10.65.0.27:48284",
+					"172.17.0.1:48284",
+					"172.18.0.1:48284",
+					"172.19.0.1:48284",
+					"172.20.0.1:48284",
+					"172.21.0.1:48284",
+					"172.22.0.1:48284",
+					"172.23.0.1:48284",
+					"172.24.0.1:48284",
+					"172.25.0.1:48284",
+					"172.26.0.1:48284",
+					"172.27.0.1:48284",
+					"172.28.0.1:48284"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:19:22.659613084Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         405195271382504,
+				"StableID":   "nsk9cynWA411CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae23a3331702698e34b01628737d5b8c91a4860ef321ede711ec45a1f7f16a39",
+				"DiscoKey":   "discokey:e169bbf9a738b39c766c1d60db70b02932e5436e0c948a8100001ff9a670e669",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43159",
+					"10.65.0.27:43159",
+					"172.17.0.1:43159",
+					"172.18.0.1:43159",
+					"172.19.0.1:43159",
+					"172.20.0.1:43159",
+					"172.21.0.1:43159",
+					"172.22.0.1:43159",
+					"172.23.0.1:43159",
+					"172.24.0.1:43159",
+					"172.25.0.1:43159",
+					"172.26.0.1:43159",
+					"172.27.0.1:43159",
+					"172.28.0.1:43159"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:19:23.74529735Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3426536136371848,
+				"StableID":   "nV5Uk3JtkT11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9acfa98fbb055c7bbfbcfc470e2a3d7c4ec2e992b0718826593b6d1abc45cb1f",
+				"DiscoKey":   "discokey:5e5ace1c16176fb4349597cd6b68958f2a40160e8d74765bb4f53885a135ae75",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36618",
+					"10.65.0.27:36618",
+					"172.17.0.1:36618",
+					"172.18.0.1:36618",
+					"172.19.0.1:36618",
+					"172.20.0.1:36618",
+					"172.21.0.1:36618",
+					"172.22.0.1:36618",
+					"172.23.0.1:36618",
+					"172.24.0.1:36618",
+					"172.25.0.1:36618",
+					"172.26.0.1:36618",
+					"172.27.0.1:36618",
+					"172.28.0.1:36618"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:19:24.279863448Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3012369755640188,
+				"StableID":   "nFaxv2rJXQ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:bf81993c448c401aabadfb70775d12ea095e3661892ad67b2ac1df81287d4419",
+				"KeyExpiry":  "2026-11-09T09:19:24Z",
+				"DiscoKey":   "discokey:5f695b82c9c07a756d9396d5c6ddaaf6f793ee3e942f0fc7dd7abee85acf7716",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:44334",
+					"10.65.0.27:44334",
+					"172.17.0.1:44334",
+					"172.18.0.1:44334",
+					"172.19.0.1:44334",
+					"172.20.0.1:44334",
+					"172.21.0.1:44334",
+					"172.22.0.1:44334",
+					"172.23.0.1:44334",
+					"172.24.0.1:44334",
+					"172.25.0.1:44334",
+					"172.26.0.1:44334",
+					"172.27.0.1:44334",
+					"172.28.0.1:44334"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:19:24.811647723Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7468751552721751,
+				"StableID":   "ncdCBSScK121CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1dfc22f5f5c6f1c3ed49365c6aecd7052aab04c55c7fb36b648c1e0e3f90ce06",
+				"KeyExpiry":  "2026-11-09T09:19:25Z",
+				"DiscoKey":   "discokey:3ebea6bb99e095d26d9832c20ef05cf3656a46b26658f6199c22ac578444446d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49818",
+					"10.65.0.27:49818",
+					"172.17.0.1:49818",
+					"172.18.0.1:49818",
+					"172.19.0.1:49818",
+					"172.20.0.1:49818",
+					"172.21.0.1:49818",
+					"172.22.0.1:49818",
+					"172.23.0.1:49818",
+					"172.24.0.1:49818",
+					"172.25.0.1:49818",
+					"172.26.0.1:49818",
+					"172.27.0.1:49818",
+					"172.28.0.1:49818"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:19:25.353736893Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5452265111916024,
+				"StableID":   "nsg3Y2mLaj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a2dc8487de8773ec3bb4ef74f14b9e2bd8dbc3ef4bae39fb2b60e26447edce28",
+				"KeyExpiry":  "2026-11-09T09:19:25Z",
+				"DiscoKey":   "discokey:13a5d9f2ab3232d280bd0902671b54b3f12970168a613de5a841db3778eafc73",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49612",
+					"10.65.0.27:49612",
+					"172.17.0.1:49612",
+					"172.18.0.1:49612",
+					"172.19.0.1:49612",
+					"172.20.0.1:49612",
+					"172.21.0.1:49612",
+					"172.22.0.1:49612",
+					"172.23.0.1:49612",
+					"172.24.0.1:49612",
+					"172.25.0.1:49612",
+					"172.26.0.1:49612",
+					"172.27.0.1:49612",
+					"172.28.0.1:49612"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:19:25.921846203Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1543860425024168": {
+				"ID":          1543860425024168,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-src-autogroup-tagged-no-tagged-nodes.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-src-autogroup-tagged-no-tagged-nodes.hujson
@@ -1,0 +1,21944 @@
+// ssh-src-autogroup-tagged-no-tagged-nodes
+//
+// ssh src = autogroup:tagged
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-13T09:20:11Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-src-autogroup-tagged-no-tagged-nodes",
+	"description":    "ssh src = autogroup:tagged",
+	"category":       "ssh",
+	"captured_at":    "2026-05-13T09:20:11.16222426Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                           \n  \n                                                                    \n                                                                      \n                                                               \n                        \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh src = autogroup:tagged\",\n\t\"id\":          \"ssh-src-autogroup-tagged-no-tagged-nodes\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"autogroup:tagged\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-edges/ssh-src-autogroup-tagged-no-tagged-nodes.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["autogroup:tagged"],
+				"users":  ["root"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8570237187749009,
+				"StableID":   "nczCthbUv921CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       8570237187749009,
+				"Key":        "nodekey:5a1a1fd1951cf4e6dce860f46d77baded0e023223abff26ecda38d139dd83c72",
+				"DiscoKey":   "discokey:16e8d2427e69b9d2cac1673da23765fa701b04a5ce3d28530f70b820741dc90c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:51710",
+					"10.65.0.27:51710",
+					"172.17.0.1:51710",
+					"172.18.0.1:51710",
+					"172.19.0.1:51710",
+					"172.20.0.1:51710",
+					"172.21.0.1:51710",
+					"172.22.0.1:51710",
+					"172.23.0.1:51710",
+					"172.24.0.1:51710",
+					"172.25.0.1:51710",
+					"172.26.0.1:51710",
+					"172.27.0.1:51710"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:20:19.72301037Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5a1a1fd1951cf4e6dce860f46d77baded0e023223abff26ecda38d139dd83c72",
+			"MachineKey": "mkey:c3a8daa2b047ac9ac384353cc06bace5334a5f597a80be78eabf368d5db41131",
+			"Peers": [{
+				"ID":         6830305435958871,
+				"StableID":   "n6iR6RYTLv11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1676c76341ac59f3e5436c2389eb994e0306eb4d24995af57c238ed23999494d",
+				"DiscoKey":   "discokey:0e653906e350a03c3cedd9442690eff3a20d007add6c275a9cf80dc8d388fc38",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33482",
+					"10.65.0.27:33482",
+					"172.17.0.1:33482",
+					"172.18.0.1:33482",
+					"172.19.0.1:33482",
+					"172.20.0.1:33482",
+					"172.21.0.1:33482",
+					"172.22.0.1:33482",
+					"172.23.0.1:33482",
+					"172.24.0.1:33482",
+					"172.25.0.1:33482",
+					"172.26.0.1:33482",
+					"172.27.0.1:33482"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:20:13.793051139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3728127632591665,
+				"StableID":   "nnH6XHbU7W11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0797ee832fe82382a6615c6473fb459180162c3ff4e39648b7f862a2a5b69728",
+				"DiscoKey":   "discokey:3bf1a1b263d46f5efc3cf70eb676068d295c24ab3b7ceac5bf47cf33b387b947",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43932",
+					"10.65.0.27:43932",
+					"172.17.0.1:43932",
+					"172.18.0.1:43932",
+					"172.19.0.1:43932",
+					"172.20.0.1:43932",
+					"172.21.0.1:43932",
+					"172.22.0.1:43932",
+					"172.23.0.1:43932",
+					"172.24.0.1:43932",
+					"172.25.0.1:43932",
+					"172.26.0.1:43932",
+					"172.27.0.1:43932"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 61279},
+					{"Proto": "peerapi6", "Port": 61279}
+				]},
+				"Created":              "2026-05-13T09:20:14.320444224Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5422722565230377,
+				"StableID":   "n4vCr8jxLj11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2d8d4b21ddedd6b252a02d3f99201a1915fe7c3db8d90f760d7def3914bae02c",
+				"DiscoKey":   "discokey:145deabf4a2c0578c9c17c72d9707716f1107557b60ecad31fa043c4bc20b411",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56850",
+					"10.65.0.27:56850",
+					"172.17.0.1:56850",
+					"172.18.0.1:56850",
+					"172.19.0.1:56850",
+					"172.20.0.1:56850",
+					"172.21.0.1:56850",
+					"172.22.0.1:56850",
+					"172.23.0.1:56850",
+					"172.24.0.1:56850",
+					"172.25.0.1:56850",
+					"172.26.0.1:56850",
+					"172.27.0.1:56850"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:20:14.874131744Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         223842005373187,
+				"StableID":   "nN6EW6xNk211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f866d0f9775dc9e6b2dfdf1a990f7c7290860438ffd5aad1ade28dc9f5684574",
+				"DiscoKey":   "discokey:7e6c001fb872587ec1d56ee4959502f8301d9bc3beebc703802591ccd256f96c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58583",
+					"10.65.0.27:58583",
+					"172.17.0.1:58583",
+					"172.18.0.1:58583",
+					"172.19.0.1:58583",
+					"172.20.0.1:58583",
+					"172.21.0.1:58583",
+					"172.22.0.1:58583",
+					"172.23.0.1:58583",
+					"172.24.0.1:58583",
+					"172.25.0.1:58583",
+					"172.26.0.1:58583",
+					"172.27.0.1:58583"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:20:15.40948102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3621397242307042,
+				"StableID":   "nTdoQxx8HV11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31b110aebcd4347f8f8a6026f4a2320aa6744b73e52992be0393fc13f868860a",
+				"DiscoKey":   "discokey:41fe86fa0f5dbce075f479b14c12551dd88cddb6952a72cdd88fd0ae82a94601",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40342",
+					"10.65.0.27:40342",
+					"172.17.0.1:40342",
+					"172.18.0.1:40342",
+					"172.19.0.1:40342",
+					"172.20.0.1:40342",
+					"172.21.0.1:40342",
+					"172.22.0.1:40342",
+					"172.23.0.1:40342",
+					"172.24.0.1:40342",
+					"172.25.0.1:40342",
+					"172.26.0.1:40342",
+					"172.27.0.1:40342"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:20:15.952792861Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6918226251818639,
+				"StableID":   "nLbBXC5H2w11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e761b2e36f09a65b4d8f1131ab0f29ea7239d0827f225a576f4cc83609900d24",
+				"DiscoKey":   "discokey:2e8579339f36c79810d79d625c72432868aac339d087f082b3b18923b465176f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33617",
+					"10.65.0.27:33617",
+					"172.17.0.1:33617",
+					"172.18.0.1:33617",
+					"172.19.0.1:33617",
+					"172.20.0.1:33617",
+					"172.21.0.1:33617",
+					"172.22.0.1:33617",
+					"172.23.0.1:33617",
+					"172.24.0.1:33617",
+					"172.25.0.1:33617",
+					"172.26.0.1:33617",
+					"172.27.0.1:33617"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:20:16.480390963Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5513145568722149,
+				"StableID":   "nLtc2Azu3k11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b7321b72b53ed6d4b99319f01f9078da60d83b36a22957586588fc005dc12349",
+				"DiscoKey":   "discokey:0d5760bad884b761b1d7db181534b466d21d1682fdf136c6619af55ef105fa30",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:56195",
+					"10.65.0.27:56195",
+					"172.17.0.1:56195",
+					"172.18.0.1:56195",
+					"172.19.0.1:56195",
+					"172.20.0.1:56195",
+					"172.21.0.1:56195",
+					"172.22.0.1:56195",
+					"172.23.0.1:56195",
+					"172.24.0.1:56195",
+					"172.25.0.1:56195",
+					"172.26.0.1:56195",
+					"172.27.0.1:56195"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:20:17.022800848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6848992150805548,
+				"StableID":   "nuFW6nQvUv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:899992820f50c78bf4646efad1893b89a60a15df44e06db67d72585791846916",
+				"DiscoKey":   "discokey:a34dd419cb3a8b7b93c3e9cc6c8b2423283fb191a9e82b104762b77ed9710e66",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38971",
+					"10.65.0.27:38971",
+					"172.17.0.1:38971",
+					"172.18.0.1:38971",
+					"172.19.0.1:38971",
+					"172.20.0.1:38971",
+					"172.21.0.1:38971",
+					"172.22.0.1:38971",
+					"172.23.0.1:38971",
+					"172.24.0.1:38971",
+					"172.25.0.1:38971",
+					"172.26.0.1:38971",
+					"172.27.0.1:38971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:20:17.555162972Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8617791652858649,
+				"StableID":   "nUQ58sm1JA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:301b52d255de5155bf0fe437dbc13959816f1ae31366aafddb69e522dba6571d",
+				"DiscoKey":   "discokey:5c583dfe16347d721fe2bfd96c9593016019e9bd14ea24d4be63acc99ed07034",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:40764",
+					"10.65.0.27:40764",
+					"172.17.0.1:40764",
+					"172.18.0.1:40764",
+					"172.19.0.1:40764",
+					"172.20.0.1:40764",
+					"172.21.0.1:40764",
+					"172.22.0.1:40764",
+					"172.23.0.1:40764",
+					"172.24.0.1:40764",
+					"172.25.0.1:40764",
+					"172.26.0.1:40764",
+					"172.27.0.1:40764"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:20:18.087199406Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2636814795393374,
+				"StableID":   "nTX18ueDbM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:55ec9abc4d4be42720a8d87cba7a8743c8d0ee9dc1d49ce069eae57fb62f246c",
+				"DiscoKey":   "discokey:3b8fb56895becef1724c093636ac2ec730bacc423e6c57684f61fb866ab58849",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35228",
+					"10.65.0.27:35228",
+					"172.17.0.1:35228",
+					"172.18.0.1:35228",
+					"172.19.0.1:35228",
+					"172.20.0.1:35228",
+					"172.21.0.1:35228",
+					"172.22.0.1:35228",
+					"172.23.0.1:35228",
+					"172.24.0.1:35228",
+					"172.25.0.1:35228",
+					"172.26.0.1:35228",
+					"172.27.0.1:35228"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:20:18.627896651Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7627873531149537,
+				"StableID":   "najGXaJgZ221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:75e0d4f15bd5339407df21ed895b3e113329a82d5746611816261dfaa5a79c59",
+				"DiscoKey":   "discokey:7690567f0f5dc181b8c6fdfc5b003a161ce3a1d2befe75eb2952a3b5cd948264",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43330",
+					"10.65.0.27:43330",
+					"172.17.0.1:43330",
+					"172.18.0.1:43330",
+					"172.19.0.1:43330",
+					"172.20.0.1:43330",
+					"172.21.0.1:43330",
+					"172.22.0.1:43330",
+					"172.23.0.1:43330",
+					"172.24.0.1:43330",
+					"172.25.0.1:43330",
+					"172.26.0.1:43330",
+					"172.27.0.1:43330"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:20:19.183110945Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5525645567720675,
+				"StableID":   "nriq8gLa9k11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:adccd261ee5560558a2c08fe6d70415ee0c39f3b804d7f872b9503ebd06b445d",
+				"KeyExpiry":  "2026-11-09T09:20:20Z",
+				"DiscoKey":   "discokey:4586ef29b9329cf1a1c6cbcb9f3df9108674160a9fe26ecb48f1d431d7657744",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40287",
+					"10.65.0.27:40287",
+					"172.17.0.1:40287",
+					"172.18.0.1:40287",
+					"172.19.0.1:40287",
+					"172.20.0.1:40287",
+					"172.21.0.1:40287",
+					"172.22.0.1:40287",
+					"172.23.0.1:40287",
+					"172.24.0.1:40287",
+					"172.25.0.1:40287",
+					"172.26.0.1:40287",
+					"172.27.0.1:40287"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:20:20.251293676Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1545417971442506,
+				"StableID":   "nuGs6ZWv4D11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5da9ac437b55667d69d41d8084de52f0c051d481b3cac7100a7de8e067120322",
+				"KeyExpiry":  "2026-11-09T09:20:20Z",
+				"DiscoKey":   "discokey:9d22489b975e567d77dcd2b5823a2a32977c7346dc5b1840c4cba4a220729f68",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60732",
+					"10.65.0.27:60732",
+					"172.17.0.1:60732",
+					"172.18.0.1:60732",
+					"172.19.0.1:60732",
+					"172.20.0.1:60732",
+					"172.21.0.1:60732",
+					"172.22.0.1:60732",
+					"172.23.0.1:60732",
+					"172.24.0.1:60732",
+					"172.25.0.1:60732",
+					"172.26.0.1:60732",
+					"172.27.0.1:60732"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:20:20.802684287Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8839325176815582,
+				"StableID":   "nKjd2r5M2C21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5ccc1e2806b7dba12fb9a1a87a8f0eaf68e13336b8836703c3435ae05bb30761",
+				"KeyExpiry":  "2026-11-09T09:20:21Z",
+				"DiscoKey":   "discokey:4b567c71b0bbb40126611349579c08cca63f90ce7b3753721266cf1a30c1df6e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41279",
+					"10.65.0.27:41279",
+					"172.17.0.1:41279",
+					"172.18.0.1:41279",
+					"172.19.0.1:41279",
+					"172.20.0.1:41279",
+					"172.21.0.1:41279",
+					"172.22.0.1:41279",
+					"172.23.0.1:41279",
+					"172.24.0.1:41279",
+					"172.25.0.1:41279",
+					"172.26.0.1:41279",
+					"172.27.0.1:41279"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:20:21.338069367Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{"principals": [
+				{"nodeIP": "100.64.0.11"},
+				{"nodeIP": "100.64.0.12"},
+				{"nodeIP": "100.64.0.13"},
+				{"nodeIP": "100.64.0.14"},
+				{"nodeIP": "100.64.0.15"},
+				{"nodeIP": "100.64.0.16"},
+				{"nodeIP": "100.64.0.2"},
+				{"nodeIP": "100.64.0.3"},
+				{"nodeIP": "100.64.0.4"},
+				{"nodeIP": "100.64.0.5"},
+				{"nodeIP": "100.64.0.6"},
+				{"nodeIP": "100.64.0.9"},
+				{"nodeIP": "100.64.0.9"},
+				{"nodeIP": "fd7a:115c:a1e0::4"},
+				{"nodeIP": "fd7a:115c:a1e0::2"},
+				{"nodeIP": "fd7a:115c:a1e0::b"},
+				{"nodeIP": "fd7a:115c:a1e0::c"},
+				{"nodeIP": "fd7a:115c:a1e0::9"},
+				{"nodeIP": "fd7a:115c:a1e0::9"},
+				{"nodeIP": "fd7a:115c:a1e0::10"},
+				{"nodeIP": "fd7a:115c:a1e0::3"},
+				{"nodeIP": "fd7a:115c:a1e0::f"},
+				{"nodeIP": "fd7a:115c:a1e0::e"},
+				{"nodeIP": "fd7a:115c:a1e0::d"},
+				{"nodeIP": "fd7a:115c:a1e0::5"},
+				{"nodeIP": "fd7a:115c:a1e0::6"}
+			], "sshUsers": {"root": "root"}, "action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8570237187749009": {
+				"ID":          8570237187749009,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		},
+		"ssh_rules": [{"principals": [
+			{"nodeIP": "100.64.0.11"},
+			{"nodeIP": "100.64.0.12"},
+			{"nodeIP": "100.64.0.13"},
+			{"nodeIP": "100.64.0.14"},
+			{"nodeIP": "100.64.0.15"},
+			{"nodeIP": "100.64.0.16"},
+			{"nodeIP": "100.64.0.2"},
+			{"nodeIP": "100.64.0.3"},
+			{"nodeIP": "100.64.0.4"},
+			{"nodeIP": "100.64.0.5"},
+			{"nodeIP": "100.64.0.6"},
+			{"nodeIP": "100.64.0.9"},
+			{"nodeIP": "100.64.0.9"},
+			{"nodeIP": "fd7a:115c:a1e0::4"},
+			{"nodeIP": "fd7a:115c:a1e0::2"},
+			{"nodeIP": "fd7a:115c:a1e0::b"},
+			{"nodeIP": "fd7a:115c:a1e0::c"},
+			{"nodeIP": "fd7a:115c:a1e0::9"},
+			{"nodeIP": "fd7a:115c:a1e0::9"},
+			{"nodeIP": "fd7a:115c:a1e0::10"},
+			{"nodeIP": "fd7a:115c:a1e0::3"},
+			{"nodeIP": "fd7a:115c:a1e0::f"},
+			{"nodeIP": "fd7a:115c:a1e0::e"},
+			{"nodeIP": "fd7a:115c:a1e0::d"},
+			{"nodeIP": "fd7a:115c:a1e0::5"},
+			{"nodeIP": "fd7a:115c:a1e0::6"}
+		], "sshUsers": {"root": "root"}, "action": {
+			"accept":                    true,
+			"allowAgentForwarding":      true,
+			"allowLocalPortForwarding":  true,
+			"allowRemotePortForwarding": true
+		}}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6918226251818639,
+				"StableID":   "nLbBXC5H2w11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       6918226251818639,
+				"Key":        "nodekey:e761b2e36f09a65b4d8f1131ab0f29ea7239d0827f225a576f4cc83609900d24",
+				"DiscoKey":   "discokey:2e8579339f36c79810d79d625c72432868aac339d087f082b3b18923b465176f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33617",
+					"10.65.0.27:33617",
+					"172.17.0.1:33617",
+					"172.18.0.1:33617",
+					"172.19.0.1:33617",
+					"172.20.0.1:33617",
+					"172.21.0.1:33617",
+					"172.22.0.1:33617",
+					"172.23.0.1:33617",
+					"172.24.0.1:33617",
+					"172.25.0.1:33617",
+					"172.26.0.1:33617",
+					"172.27.0.1:33617"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:20:16.480390963Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e761b2e36f09a65b4d8f1131ab0f29ea7239d0827f225a576f4cc83609900d24",
+			"MachineKey": "mkey:1c35241e4fbbe2ecd39ecf6bedd26e1fb574a4882136c326851e92b3ce84ea7d",
+			"Peers": [{
+				"ID":         6830305435958871,
+				"StableID":   "n6iR6RYTLv11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1676c76341ac59f3e5436c2389eb994e0306eb4d24995af57c238ed23999494d",
+				"DiscoKey":   "discokey:0e653906e350a03c3cedd9442690eff3a20d007add6c275a9cf80dc8d388fc38",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33482",
+					"10.65.0.27:33482",
+					"172.17.0.1:33482",
+					"172.18.0.1:33482",
+					"172.19.0.1:33482",
+					"172.20.0.1:33482",
+					"172.21.0.1:33482",
+					"172.22.0.1:33482",
+					"172.23.0.1:33482",
+					"172.24.0.1:33482",
+					"172.25.0.1:33482",
+					"172.26.0.1:33482",
+					"172.27.0.1:33482"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:20:13.793051139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3728127632591665,
+				"StableID":   "nnH6XHbU7W11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0797ee832fe82382a6615c6473fb459180162c3ff4e39648b7f862a2a5b69728",
+				"DiscoKey":   "discokey:3bf1a1b263d46f5efc3cf70eb676068d295c24ab3b7ceac5bf47cf33b387b947",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43932",
+					"10.65.0.27:43932",
+					"172.17.0.1:43932",
+					"172.18.0.1:43932",
+					"172.19.0.1:43932",
+					"172.20.0.1:43932",
+					"172.21.0.1:43932",
+					"172.22.0.1:43932",
+					"172.23.0.1:43932",
+					"172.24.0.1:43932",
+					"172.25.0.1:43932",
+					"172.26.0.1:43932",
+					"172.27.0.1:43932"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 61279},
+					{"Proto": "peerapi6", "Port": 61279}
+				]},
+				"Created":              "2026-05-13T09:20:14.320444224Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5422722565230377,
+				"StableID":   "n4vCr8jxLj11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2d8d4b21ddedd6b252a02d3f99201a1915fe7c3db8d90f760d7def3914bae02c",
+				"DiscoKey":   "discokey:145deabf4a2c0578c9c17c72d9707716f1107557b60ecad31fa043c4bc20b411",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56850",
+					"10.65.0.27:56850",
+					"172.17.0.1:56850",
+					"172.18.0.1:56850",
+					"172.19.0.1:56850",
+					"172.20.0.1:56850",
+					"172.21.0.1:56850",
+					"172.22.0.1:56850",
+					"172.23.0.1:56850",
+					"172.24.0.1:56850",
+					"172.25.0.1:56850",
+					"172.26.0.1:56850",
+					"172.27.0.1:56850"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:20:14.874131744Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         223842005373187,
+				"StableID":   "nN6EW6xNk211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f866d0f9775dc9e6b2dfdf1a990f7c7290860438ffd5aad1ade28dc9f5684574",
+				"DiscoKey":   "discokey:7e6c001fb872587ec1d56ee4959502f8301d9bc3beebc703802591ccd256f96c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58583",
+					"10.65.0.27:58583",
+					"172.17.0.1:58583",
+					"172.18.0.1:58583",
+					"172.19.0.1:58583",
+					"172.20.0.1:58583",
+					"172.21.0.1:58583",
+					"172.22.0.1:58583",
+					"172.23.0.1:58583",
+					"172.24.0.1:58583",
+					"172.25.0.1:58583",
+					"172.26.0.1:58583",
+					"172.27.0.1:58583"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:20:15.40948102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3621397242307042,
+				"StableID":   "nTdoQxx8HV11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31b110aebcd4347f8f8a6026f4a2320aa6744b73e52992be0393fc13f868860a",
+				"DiscoKey":   "discokey:41fe86fa0f5dbce075f479b14c12551dd88cddb6952a72cdd88fd0ae82a94601",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40342",
+					"10.65.0.27:40342",
+					"172.17.0.1:40342",
+					"172.18.0.1:40342",
+					"172.19.0.1:40342",
+					"172.20.0.1:40342",
+					"172.21.0.1:40342",
+					"172.22.0.1:40342",
+					"172.23.0.1:40342",
+					"172.24.0.1:40342",
+					"172.25.0.1:40342",
+					"172.26.0.1:40342",
+					"172.27.0.1:40342"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:20:15.952792861Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5513145568722149,
+				"StableID":   "nLtc2Azu3k11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b7321b72b53ed6d4b99319f01f9078da60d83b36a22957586588fc005dc12349",
+				"DiscoKey":   "discokey:0d5760bad884b761b1d7db181534b466d21d1682fdf136c6619af55ef105fa30",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:56195",
+					"10.65.0.27:56195",
+					"172.17.0.1:56195",
+					"172.18.0.1:56195",
+					"172.19.0.1:56195",
+					"172.20.0.1:56195",
+					"172.21.0.1:56195",
+					"172.22.0.1:56195",
+					"172.23.0.1:56195",
+					"172.24.0.1:56195",
+					"172.25.0.1:56195",
+					"172.26.0.1:56195",
+					"172.27.0.1:56195"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:20:17.022800848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6848992150805548,
+				"StableID":   "nuFW6nQvUv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:899992820f50c78bf4646efad1893b89a60a15df44e06db67d72585791846916",
+				"DiscoKey":   "discokey:a34dd419cb3a8b7b93c3e9cc6c8b2423283fb191a9e82b104762b77ed9710e66",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38971",
+					"10.65.0.27:38971",
+					"172.17.0.1:38971",
+					"172.18.0.1:38971",
+					"172.19.0.1:38971",
+					"172.20.0.1:38971",
+					"172.21.0.1:38971",
+					"172.22.0.1:38971",
+					"172.23.0.1:38971",
+					"172.24.0.1:38971",
+					"172.25.0.1:38971",
+					"172.26.0.1:38971",
+					"172.27.0.1:38971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:20:17.555162972Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8617791652858649,
+				"StableID":   "nUQ58sm1JA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:301b52d255de5155bf0fe437dbc13959816f1ae31366aafddb69e522dba6571d",
+				"DiscoKey":   "discokey:5c583dfe16347d721fe2bfd96c9593016019e9bd14ea24d4be63acc99ed07034",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:40764",
+					"10.65.0.27:40764",
+					"172.17.0.1:40764",
+					"172.18.0.1:40764",
+					"172.19.0.1:40764",
+					"172.20.0.1:40764",
+					"172.21.0.1:40764",
+					"172.22.0.1:40764",
+					"172.23.0.1:40764",
+					"172.24.0.1:40764",
+					"172.25.0.1:40764",
+					"172.26.0.1:40764",
+					"172.27.0.1:40764"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:20:18.087199406Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2636814795393374,
+				"StableID":   "nTX18ueDbM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:55ec9abc4d4be42720a8d87cba7a8743c8d0ee9dc1d49ce069eae57fb62f246c",
+				"DiscoKey":   "discokey:3b8fb56895becef1724c093636ac2ec730bacc423e6c57684f61fb866ab58849",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35228",
+					"10.65.0.27:35228",
+					"172.17.0.1:35228",
+					"172.18.0.1:35228",
+					"172.19.0.1:35228",
+					"172.20.0.1:35228",
+					"172.21.0.1:35228",
+					"172.22.0.1:35228",
+					"172.23.0.1:35228",
+					"172.24.0.1:35228",
+					"172.25.0.1:35228",
+					"172.26.0.1:35228",
+					"172.27.0.1:35228"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:20:18.627896651Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7627873531149537,
+				"StableID":   "najGXaJgZ221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:75e0d4f15bd5339407df21ed895b3e113329a82d5746611816261dfaa5a79c59",
+				"DiscoKey":   "discokey:7690567f0f5dc181b8c6fdfc5b003a161ce3a1d2befe75eb2952a3b5cd948264",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43330",
+					"10.65.0.27:43330",
+					"172.17.0.1:43330",
+					"172.18.0.1:43330",
+					"172.19.0.1:43330",
+					"172.20.0.1:43330",
+					"172.21.0.1:43330",
+					"172.22.0.1:43330",
+					"172.23.0.1:43330",
+					"172.24.0.1:43330",
+					"172.25.0.1:43330",
+					"172.26.0.1:43330",
+					"172.27.0.1:43330"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:20:19.183110945Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8570237187749009,
+				"StableID":   "nczCthbUv921CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5a1a1fd1951cf4e6dce860f46d77baded0e023223abff26ecda38d139dd83c72",
+				"DiscoKey":   "discokey:16e8d2427e69b9d2cac1673da23765fa701b04a5ce3d28530f70b820741dc90c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:51710",
+					"10.65.0.27:51710",
+					"172.17.0.1:51710",
+					"172.18.0.1:51710",
+					"172.19.0.1:51710",
+					"172.20.0.1:51710",
+					"172.21.0.1:51710",
+					"172.22.0.1:51710",
+					"172.23.0.1:51710",
+					"172.24.0.1:51710",
+					"172.25.0.1:51710",
+					"172.26.0.1:51710",
+					"172.27.0.1:51710"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:20:19.72301037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5525645567720675,
+				"StableID":   "nriq8gLa9k11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:adccd261ee5560558a2c08fe6d70415ee0c39f3b804d7f872b9503ebd06b445d",
+				"KeyExpiry":  "2026-11-09T09:20:20Z",
+				"DiscoKey":   "discokey:4586ef29b9329cf1a1c6cbcb9f3df9108674160a9fe26ecb48f1d431d7657744",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40287",
+					"10.65.0.27:40287",
+					"172.17.0.1:40287",
+					"172.18.0.1:40287",
+					"172.19.0.1:40287",
+					"172.20.0.1:40287",
+					"172.21.0.1:40287",
+					"172.22.0.1:40287",
+					"172.23.0.1:40287",
+					"172.24.0.1:40287",
+					"172.25.0.1:40287",
+					"172.26.0.1:40287",
+					"172.27.0.1:40287"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:20:20.251293676Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1545417971442506,
+				"StableID":   "nuGs6ZWv4D11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5da9ac437b55667d69d41d8084de52f0c051d481b3cac7100a7de8e067120322",
+				"KeyExpiry":  "2026-11-09T09:20:20Z",
+				"DiscoKey":   "discokey:9d22489b975e567d77dcd2b5823a2a32977c7346dc5b1840c4cba4a220729f68",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60732",
+					"10.65.0.27:60732",
+					"172.17.0.1:60732",
+					"172.18.0.1:60732",
+					"172.19.0.1:60732",
+					"172.20.0.1:60732",
+					"172.21.0.1:60732",
+					"172.22.0.1:60732",
+					"172.23.0.1:60732",
+					"172.24.0.1:60732",
+					"172.25.0.1:60732",
+					"172.26.0.1:60732",
+					"172.27.0.1:60732"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:20:20.802684287Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8839325176815582,
+				"StableID":   "nKjd2r5M2C21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5ccc1e2806b7dba12fb9a1a87a8f0eaf68e13336b8836703c3435ae05bb30761",
+				"KeyExpiry":  "2026-11-09T09:20:21Z",
+				"DiscoKey":   "discokey:4b567c71b0bbb40126611349579c08cca63f90ce7b3753721266cf1a30c1df6e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41279",
+					"10.65.0.27:41279",
+					"172.17.0.1:41279",
+					"172.18.0.1:41279",
+					"172.19.0.1:41279",
+					"172.20.0.1:41279",
+					"172.21.0.1:41279",
+					"172.22.0.1:41279",
+					"172.23.0.1:41279",
+					"172.24.0.1:41279",
+					"172.25.0.1:41279",
+					"172.26.0.1:41279",
+					"172.27.0.1:41279"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:20:21.338069367Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6918226251818639": {
+				"ID":          6918226251818639,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8839325176815582,
+				"StableID":   "nKjd2r5M2C21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5ccc1e2806b7dba12fb9a1a87a8f0eaf68e13336b8836703c3435ae05bb30761",
+				"KeyExpiry":  "2026-11-09T09:20:21Z",
+				"DiscoKey":   "discokey:4b567c71b0bbb40126611349579c08cca63f90ce7b3753721266cf1a30c1df6e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41279",
+					"10.65.0.27:41279",
+					"172.17.0.1:41279",
+					"172.18.0.1:41279",
+					"172.19.0.1:41279",
+					"172.20.0.1:41279",
+					"172.21.0.1:41279",
+					"172.22.0.1:41279",
+					"172.23.0.1:41279",
+					"172.24.0.1:41279",
+					"172.25.0.1:41279",
+					"172.26.0.1:41279",
+					"172.27.0.1:41279"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:20:21.338069367Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5ccc1e2806b7dba12fb9a1a87a8f0eaf68e13336b8836703c3435ae05bb30761",
+			"MachineKey": "mkey:07c1bfe810ba88c4c2c9aaaf239f5e108217d9273ddce701e5dd9424fd6a1207",
+			"Peers": [{
+				"ID":         6830305435958871,
+				"StableID":   "n6iR6RYTLv11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1676c76341ac59f3e5436c2389eb994e0306eb4d24995af57c238ed23999494d",
+				"DiscoKey":   "discokey:0e653906e350a03c3cedd9442690eff3a20d007add6c275a9cf80dc8d388fc38",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33482",
+					"10.65.0.27:33482",
+					"172.17.0.1:33482",
+					"172.18.0.1:33482",
+					"172.19.0.1:33482",
+					"172.20.0.1:33482",
+					"172.21.0.1:33482",
+					"172.22.0.1:33482",
+					"172.23.0.1:33482",
+					"172.24.0.1:33482",
+					"172.25.0.1:33482",
+					"172.26.0.1:33482",
+					"172.27.0.1:33482"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:20:13.793051139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3728127632591665,
+				"StableID":   "nnH6XHbU7W11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0797ee832fe82382a6615c6473fb459180162c3ff4e39648b7f862a2a5b69728",
+				"DiscoKey":   "discokey:3bf1a1b263d46f5efc3cf70eb676068d295c24ab3b7ceac5bf47cf33b387b947",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43932",
+					"10.65.0.27:43932",
+					"172.17.0.1:43932",
+					"172.18.0.1:43932",
+					"172.19.0.1:43932",
+					"172.20.0.1:43932",
+					"172.21.0.1:43932",
+					"172.22.0.1:43932",
+					"172.23.0.1:43932",
+					"172.24.0.1:43932",
+					"172.25.0.1:43932",
+					"172.26.0.1:43932",
+					"172.27.0.1:43932"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 61279},
+					{"Proto": "peerapi6", "Port": 61279}
+				]},
+				"Created":              "2026-05-13T09:20:14.320444224Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5422722565230377,
+				"StableID":   "n4vCr8jxLj11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2d8d4b21ddedd6b252a02d3f99201a1915fe7c3db8d90f760d7def3914bae02c",
+				"DiscoKey":   "discokey:145deabf4a2c0578c9c17c72d9707716f1107557b60ecad31fa043c4bc20b411",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56850",
+					"10.65.0.27:56850",
+					"172.17.0.1:56850",
+					"172.18.0.1:56850",
+					"172.19.0.1:56850",
+					"172.20.0.1:56850",
+					"172.21.0.1:56850",
+					"172.22.0.1:56850",
+					"172.23.0.1:56850",
+					"172.24.0.1:56850",
+					"172.25.0.1:56850",
+					"172.26.0.1:56850",
+					"172.27.0.1:56850"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:20:14.874131744Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         223842005373187,
+				"StableID":   "nN6EW6xNk211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f866d0f9775dc9e6b2dfdf1a990f7c7290860438ffd5aad1ade28dc9f5684574",
+				"DiscoKey":   "discokey:7e6c001fb872587ec1d56ee4959502f8301d9bc3beebc703802591ccd256f96c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58583",
+					"10.65.0.27:58583",
+					"172.17.0.1:58583",
+					"172.18.0.1:58583",
+					"172.19.0.1:58583",
+					"172.20.0.1:58583",
+					"172.21.0.1:58583",
+					"172.22.0.1:58583",
+					"172.23.0.1:58583",
+					"172.24.0.1:58583",
+					"172.25.0.1:58583",
+					"172.26.0.1:58583",
+					"172.27.0.1:58583"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:20:15.40948102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3621397242307042,
+				"StableID":   "nTdoQxx8HV11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31b110aebcd4347f8f8a6026f4a2320aa6744b73e52992be0393fc13f868860a",
+				"DiscoKey":   "discokey:41fe86fa0f5dbce075f479b14c12551dd88cddb6952a72cdd88fd0ae82a94601",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40342",
+					"10.65.0.27:40342",
+					"172.17.0.1:40342",
+					"172.18.0.1:40342",
+					"172.19.0.1:40342",
+					"172.20.0.1:40342",
+					"172.21.0.1:40342",
+					"172.22.0.1:40342",
+					"172.23.0.1:40342",
+					"172.24.0.1:40342",
+					"172.25.0.1:40342",
+					"172.26.0.1:40342",
+					"172.27.0.1:40342"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:20:15.952792861Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6918226251818639,
+				"StableID":   "nLbBXC5H2w11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e761b2e36f09a65b4d8f1131ab0f29ea7239d0827f225a576f4cc83609900d24",
+				"DiscoKey":   "discokey:2e8579339f36c79810d79d625c72432868aac339d087f082b3b18923b465176f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33617",
+					"10.65.0.27:33617",
+					"172.17.0.1:33617",
+					"172.18.0.1:33617",
+					"172.19.0.1:33617",
+					"172.20.0.1:33617",
+					"172.21.0.1:33617",
+					"172.22.0.1:33617",
+					"172.23.0.1:33617",
+					"172.24.0.1:33617",
+					"172.25.0.1:33617",
+					"172.26.0.1:33617",
+					"172.27.0.1:33617"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:20:16.480390963Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5513145568722149,
+				"StableID":   "nLtc2Azu3k11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b7321b72b53ed6d4b99319f01f9078da60d83b36a22957586588fc005dc12349",
+				"DiscoKey":   "discokey:0d5760bad884b761b1d7db181534b466d21d1682fdf136c6619af55ef105fa30",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:56195",
+					"10.65.0.27:56195",
+					"172.17.0.1:56195",
+					"172.18.0.1:56195",
+					"172.19.0.1:56195",
+					"172.20.0.1:56195",
+					"172.21.0.1:56195",
+					"172.22.0.1:56195",
+					"172.23.0.1:56195",
+					"172.24.0.1:56195",
+					"172.25.0.1:56195",
+					"172.26.0.1:56195",
+					"172.27.0.1:56195"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:20:17.022800848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6848992150805548,
+				"StableID":   "nuFW6nQvUv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:899992820f50c78bf4646efad1893b89a60a15df44e06db67d72585791846916",
+				"DiscoKey":   "discokey:a34dd419cb3a8b7b93c3e9cc6c8b2423283fb191a9e82b104762b77ed9710e66",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38971",
+					"10.65.0.27:38971",
+					"172.17.0.1:38971",
+					"172.18.0.1:38971",
+					"172.19.0.1:38971",
+					"172.20.0.1:38971",
+					"172.21.0.1:38971",
+					"172.22.0.1:38971",
+					"172.23.0.1:38971",
+					"172.24.0.1:38971",
+					"172.25.0.1:38971",
+					"172.26.0.1:38971",
+					"172.27.0.1:38971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:20:17.555162972Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8617791652858649,
+				"StableID":   "nUQ58sm1JA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:301b52d255de5155bf0fe437dbc13959816f1ae31366aafddb69e522dba6571d",
+				"DiscoKey":   "discokey:5c583dfe16347d721fe2bfd96c9593016019e9bd14ea24d4be63acc99ed07034",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:40764",
+					"10.65.0.27:40764",
+					"172.17.0.1:40764",
+					"172.18.0.1:40764",
+					"172.19.0.1:40764",
+					"172.20.0.1:40764",
+					"172.21.0.1:40764",
+					"172.22.0.1:40764",
+					"172.23.0.1:40764",
+					"172.24.0.1:40764",
+					"172.25.0.1:40764",
+					"172.26.0.1:40764",
+					"172.27.0.1:40764"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:20:18.087199406Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2636814795393374,
+				"StableID":   "nTX18ueDbM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:55ec9abc4d4be42720a8d87cba7a8743c8d0ee9dc1d49ce069eae57fb62f246c",
+				"DiscoKey":   "discokey:3b8fb56895becef1724c093636ac2ec730bacc423e6c57684f61fb866ab58849",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35228",
+					"10.65.0.27:35228",
+					"172.17.0.1:35228",
+					"172.18.0.1:35228",
+					"172.19.0.1:35228",
+					"172.20.0.1:35228",
+					"172.21.0.1:35228",
+					"172.22.0.1:35228",
+					"172.23.0.1:35228",
+					"172.24.0.1:35228",
+					"172.25.0.1:35228",
+					"172.26.0.1:35228",
+					"172.27.0.1:35228"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:20:18.627896651Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7627873531149537,
+				"StableID":   "najGXaJgZ221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:75e0d4f15bd5339407df21ed895b3e113329a82d5746611816261dfaa5a79c59",
+				"DiscoKey":   "discokey:7690567f0f5dc181b8c6fdfc5b003a161ce3a1d2befe75eb2952a3b5cd948264",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43330",
+					"10.65.0.27:43330",
+					"172.17.0.1:43330",
+					"172.18.0.1:43330",
+					"172.19.0.1:43330",
+					"172.20.0.1:43330",
+					"172.21.0.1:43330",
+					"172.22.0.1:43330",
+					"172.23.0.1:43330",
+					"172.24.0.1:43330",
+					"172.25.0.1:43330",
+					"172.26.0.1:43330",
+					"172.27.0.1:43330"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:20:19.183110945Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8570237187749009,
+				"StableID":   "nczCthbUv921CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5a1a1fd1951cf4e6dce860f46d77baded0e023223abff26ecda38d139dd83c72",
+				"DiscoKey":   "discokey:16e8d2427e69b9d2cac1673da23765fa701b04a5ce3d28530f70b820741dc90c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:51710",
+					"10.65.0.27:51710",
+					"172.17.0.1:51710",
+					"172.18.0.1:51710",
+					"172.19.0.1:51710",
+					"172.20.0.1:51710",
+					"172.21.0.1:51710",
+					"172.22.0.1:51710",
+					"172.23.0.1:51710",
+					"172.24.0.1:51710",
+					"172.25.0.1:51710",
+					"172.26.0.1:51710",
+					"172.27.0.1:51710"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:20:19.72301037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5525645567720675,
+				"StableID":   "nriq8gLa9k11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:adccd261ee5560558a2c08fe6d70415ee0c39f3b804d7f872b9503ebd06b445d",
+				"KeyExpiry":  "2026-11-09T09:20:20Z",
+				"DiscoKey":   "discokey:4586ef29b9329cf1a1c6cbcb9f3df9108674160a9fe26ecb48f1d431d7657744",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40287",
+					"10.65.0.27:40287",
+					"172.17.0.1:40287",
+					"172.18.0.1:40287",
+					"172.19.0.1:40287",
+					"172.20.0.1:40287",
+					"172.21.0.1:40287",
+					"172.22.0.1:40287",
+					"172.23.0.1:40287",
+					"172.24.0.1:40287",
+					"172.25.0.1:40287",
+					"172.26.0.1:40287",
+					"172.27.0.1:40287"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:20:20.251293676Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1545417971442506,
+				"StableID":   "nuGs6ZWv4D11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5da9ac437b55667d69d41d8084de52f0c051d481b3cac7100a7de8e067120322",
+				"KeyExpiry":  "2026-11-09T09:20:20Z",
+				"DiscoKey":   "discokey:9d22489b975e567d77dcd2b5823a2a32977c7346dc5b1840c4cba4a220729f68",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60732",
+					"10.65.0.27:60732",
+					"172.17.0.1:60732",
+					"172.18.0.1:60732",
+					"172.19.0.1:60732",
+					"172.20.0.1:60732",
+					"172.21.0.1:60732",
+					"172.22.0.1:60732",
+					"172.23.0.1:60732",
+					"172.24.0.1:60732",
+					"172.25.0.1:60732",
+					"172.26.0.1:60732",
+					"172.27.0.1:60732"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:20:20.802684287Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5422722565230377,
+				"StableID":   "n4vCr8jxLj11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       5422722565230377,
+				"Key":        "nodekey:2d8d4b21ddedd6b252a02d3f99201a1915fe7c3db8d90f760d7def3914bae02c",
+				"DiscoKey":   "discokey:145deabf4a2c0578c9c17c72d9707716f1107557b60ecad31fa043c4bc20b411",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56850",
+					"10.65.0.27:56850",
+					"172.17.0.1:56850",
+					"172.18.0.1:56850",
+					"172.19.0.1:56850",
+					"172.20.0.1:56850",
+					"172.21.0.1:56850",
+					"172.22.0.1:56850",
+					"172.23.0.1:56850",
+					"172.24.0.1:56850",
+					"172.25.0.1:56850",
+					"172.26.0.1:56850",
+					"172.27.0.1:56850"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:20:14.874131744Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2d8d4b21ddedd6b252a02d3f99201a1915fe7c3db8d90f760d7def3914bae02c",
+			"MachineKey": "mkey:0cce1936aee6ea560dabe822d007a20c54956133eb7bc93286db206948b2336c",
+			"Peers": [{
+				"ID":         6830305435958871,
+				"StableID":   "n6iR6RYTLv11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1676c76341ac59f3e5436c2389eb994e0306eb4d24995af57c238ed23999494d",
+				"DiscoKey":   "discokey:0e653906e350a03c3cedd9442690eff3a20d007add6c275a9cf80dc8d388fc38",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33482",
+					"10.65.0.27:33482",
+					"172.17.0.1:33482",
+					"172.18.0.1:33482",
+					"172.19.0.1:33482",
+					"172.20.0.1:33482",
+					"172.21.0.1:33482",
+					"172.22.0.1:33482",
+					"172.23.0.1:33482",
+					"172.24.0.1:33482",
+					"172.25.0.1:33482",
+					"172.26.0.1:33482",
+					"172.27.0.1:33482"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:20:13.793051139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3728127632591665,
+				"StableID":   "nnH6XHbU7W11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0797ee832fe82382a6615c6473fb459180162c3ff4e39648b7f862a2a5b69728",
+				"DiscoKey":   "discokey:3bf1a1b263d46f5efc3cf70eb676068d295c24ab3b7ceac5bf47cf33b387b947",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43932",
+					"10.65.0.27:43932",
+					"172.17.0.1:43932",
+					"172.18.0.1:43932",
+					"172.19.0.1:43932",
+					"172.20.0.1:43932",
+					"172.21.0.1:43932",
+					"172.22.0.1:43932",
+					"172.23.0.1:43932",
+					"172.24.0.1:43932",
+					"172.25.0.1:43932",
+					"172.26.0.1:43932",
+					"172.27.0.1:43932"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 61279},
+					{"Proto": "peerapi6", "Port": 61279}
+				]},
+				"Created":              "2026-05-13T09:20:14.320444224Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         223842005373187,
+				"StableID":   "nN6EW6xNk211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f866d0f9775dc9e6b2dfdf1a990f7c7290860438ffd5aad1ade28dc9f5684574",
+				"DiscoKey":   "discokey:7e6c001fb872587ec1d56ee4959502f8301d9bc3beebc703802591ccd256f96c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58583",
+					"10.65.0.27:58583",
+					"172.17.0.1:58583",
+					"172.18.0.1:58583",
+					"172.19.0.1:58583",
+					"172.20.0.1:58583",
+					"172.21.0.1:58583",
+					"172.22.0.1:58583",
+					"172.23.0.1:58583",
+					"172.24.0.1:58583",
+					"172.25.0.1:58583",
+					"172.26.0.1:58583",
+					"172.27.0.1:58583"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:20:15.40948102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3621397242307042,
+				"StableID":   "nTdoQxx8HV11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31b110aebcd4347f8f8a6026f4a2320aa6744b73e52992be0393fc13f868860a",
+				"DiscoKey":   "discokey:41fe86fa0f5dbce075f479b14c12551dd88cddb6952a72cdd88fd0ae82a94601",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40342",
+					"10.65.0.27:40342",
+					"172.17.0.1:40342",
+					"172.18.0.1:40342",
+					"172.19.0.1:40342",
+					"172.20.0.1:40342",
+					"172.21.0.1:40342",
+					"172.22.0.1:40342",
+					"172.23.0.1:40342",
+					"172.24.0.1:40342",
+					"172.25.0.1:40342",
+					"172.26.0.1:40342",
+					"172.27.0.1:40342"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:20:15.952792861Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6918226251818639,
+				"StableID":   "nLbBXC5H2w11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e761b2e36f09a65b4d8f1131ab0f29ea7239d0827f225a576f4cc83609900d24",
+				"DiscoKey":   "discokey:2e8579339f36c79810d79d625c72432868aac339d087f082b3b18923b465176f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33617",
+					"10.65.0.27:33617",
+					"172.17.0.1:33617",
+					"172.18.0.1:33617",
+					"172.19.0.1:33617",
+					"172.20.0.1:33617",
+					"172.21.0.1:33617",
+					"172.22.0.1:33617",
+					"172.23.0.1:33617",
+					"172.24.0.1:33617",
+					"172.25.0.1:33617",
+					"172.26.0.1:33617",
+					"172.27.0.1:33617"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:20:16.480390963Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5513145568722149,
+				"StableID":   "nLtc2Azu3k11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b7321b72b53ed6d4b99319f01f9078da60d83b36a22957586588fc005dc12349",
+				"DiscoKey":   "discokey:0d5760bad884b761b1d7db181534b466d21d1682fdf136c6619af55ef105fa30",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:56195",
+					"10.65.0.27:56195",
+					"172.17.0.1:56195",
+					"172.18.0.1:56195",
+					"172.19.0.1:56195",
+					"172.20.0.1:56195",
+					"172.21.0.1:56195",
+					"172.22.0.1:56195",
+					"172.23.0.1:56195",
+					"172.24.0.1:56195",
+					"172.25.0.1:56195",
+					"172.26.0.1:56195",
+					"172.27.0.1:56195"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:20:17.022800848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6848992150805548,
+				"StableID":   "nuFW6nQvUv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:899992820f50c78bf4646efad1893b89a60a15df44e06db67d72585791846916",
+				"DiscoKey":   "discokey:a34dd419cb3a8b7b93c3e9cc6c8b2423283fb191a9e82b104762b77ed9710e66",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38971",
+					"10.65.0.27:38971",
+					"172.17.0.1:38971",
+					"172.18.0.1:38971",
+					"172.19.0.1:38971",
+					"172.20.0.1:38971",
+					"172.21.0.1:38971",
+					"172.22.0.1:38971",
+					"172.23.0.1:38971",
+					"172.24.0.1:38971",
+					"172.25.0.1:38971",
+					"172.26.0.1:38971",
+					"172.27.0.1:38971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:20:17.555162972Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8617791652858649,
+				"StableID":   "nUQ58sm1JA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:301b52d255de5155bf0fe437dbc13959816f1ae31366aafddb69e522dba6571d",
+				"DiscoKey":   "discokey:5c583dfe16347d721fe2bfd96c9593016019e9bd14ea24d4be63acc99ed07034",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:40764",
+					"10.65.0.27:40764",
+					"172.17.0.1:40764",
+					"172.18.0.1:40764",
+					"172.19.0.1:40764",
+					"172.20.0.1:40764",
+					"172.21.0.1:40764",
+					"172.22.0.1:40764",
+					"172.23.0.1:40764",
+					"172.24.0.1:40764",
+					"172.25.0.1:40764",
+					"172.26.0.1:40764",
+					"172.27.0.1:40764"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:20:18.087199406Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2636814795393374,
+				"StableID":   "nTX18ueDbM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:55ec9abc4d4be42720a8d87cba7a8743c8d0ee9dc1d49ce069eae57fb62f246c",
+				"DiscoKey":   "discokey:3b8fb56895becef1724c093636ac2ec730bacc423e6c57684f61fb866ab58849",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35228",
+					"10.65.0.27:35228",
+					"172.17.0.1:35228",
+					"172.18.0.1:35228",
+					"172.19.0.1:35228",
+					"172.20.0.1:35228",
+					"172.21.0.1:35228",
+					"172.22.0.1:35228",
+					"172.23.0.1:35228",
+					"172.24.0.1:35228",
+					"172.25.0.1:35228",
+					"172.26.0.1:35228",
+					"172.27.0.1:35228"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:20:18.627896651Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7627873531149537,
+				"StableID":   "najGXaJgZ221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:75e0d4f15bd5339407df21ed895b3e113329a82d5746611816261dfaa5a79c59",
+				"DiscoKey":   "discokey:7690567f0f5dc181b8c6fdfc5b003a161ce3a1d2befe75eb2952a3b5cd948264",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43330",
+					"10.65.0.27:43330",
+					"172.17.0.1:43330",
+					"172.18.0.1:43330",
+					"172.19.0.1:43330",
+					"172.20.0.1:43330",
+					"172.21.0.1:43330",
+					"172.22.0.1:43330",
+					"172.23.0.1:43330",
+					"172.24.0.1:43330",
+					"172.25.0.1:43330",
+					"172.26.0.1:43330",
+					"172.27.0.1:43330"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:20:19.183110945Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8570237187749009,
+				"StableID":   "nczCthbUv921CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5a1a1fd1951cf4e6dce860f46d77baded0e023223abff26ecda38d139dd83c72",
+				"DiscoKey":   "discokey:16e8d2427e69b9d2cac1673da23765fa701b04a5ce3d28530f70b820741dc90c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:51710",
+					"10.65.0.27:51710",
+					"172.17.0.1:51710",
+					"172.18.0.1:51710",
+					"172.19.0.1:51710",
+					"172.20.0.1:51710",
+					"172.21.0.1:51710",
+					"172.22.0.1:51710",
+					"172.23.0.1:51710",
+					"172.24.0.1:51710",
+					"172.25.0.1:51710",
+					"172.26.0.1:51710",
+					"172.27.0.1:51710"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:20:19.72301037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5525645567720675,
+				"StableID":   "nriq8gLa9k11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:adccd261ee5560558a2c08fe6d70415ee0c39f3b804d7f872b9503ebd06b445d",
+				"KeyExpiry":  "2026-11-09T09:20:20Z",
+				"DiscoKey":   "discokey:4586ef29b9329cf1a1c6cbcb9f3df9108674160a9fe26ecb48f1d431d7657744",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40287",
+					"10.65.0.27:40287",
+					"172.17.0.1:40287",
+					"172.18.0.1:40287",
+					"172.19.0.1:40287",
+					"172.20.0.1:40287",
+					"172.21.0.1:40287",
+					"172.22.0.1:40287",
+					"172.23.0.1:40287",
+					"172.24.0.1:40287",
+					"172.25.0.1:40287",
+					"172.26.0.1:40287",
+					"172.27.0.1:40287"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:20:20.251293676Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1545417971442506,
+				"StableID":   "nuGs6ZWv4D11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5da9ac437b55667d69d41d8084de52f0c051d481b3cac7100a7de8e067120322",
+				"KeyExpiry":  "2026-11-09T09:20:20Z",
+				"DiscoKey":   "discokey:9d22489b975e567d77dcd2b5823a2a32977c7346dc5b1840c4cba4a220729f68",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60732",
+					"10.65.0.27:60732",
+					"172.17.0.1:60732",
+					"172.18.0.1:60732",
+					"172.19.0.1:60732",
+					"172.20.0.1:60732",
+					"172.21.0.1:60732",
+					"172.22.0.1:60732",
+					"172.23.0.1:60732",
+					"172.24.0.1:60732",
+					"172.25.0.1:60732",
+					"172.26.0.1:60732",
+					"172.27.0.1:60732"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:20:20.802684287Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8839325176815582,
+				"StableID":   "nKjd2r5M2C21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5ccc1e2806b7dba12fb9a1a87a8f0eaf68e13336b8836703c3435ae05bb30761",
+				"KeyExpiry":  "2026-11-09T09:20:21Z",
+				"DiscoKey":   "discokey:4b567c71b0bbb40126611349579c08cca63f90ce7b3753721266cf1a30c1df6e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41279",
+					"10.65.0.27:41279",
+					"172.17.0.1:41279",
+					"172.18.0.1:41279",
+					"172.19.0.1:41279",
+					"172.20.0.1:41279",
+					"172.21.0.1:41279",
+					"172.22.0.1:41279",
+					"172.23.0.1:41279",
+					"172.24.0.1:41279",
+					"172.25.0.1:41279",
+					"172.26.0.1:41279",
+					"172.27.0.1:41279"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:20:21.338069367Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5422722565230377": {
+				"ID":          5422722565230377,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6848992150805548,
+				"StableID":   "nuFW6nQvUv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       6848992150805548,
+				"Key":        "nodekey:899992820f50c78bf4646efad1893b89a60a15df44e06db67d72585791846916",
+				"DiscoKey":   "discokey:a34dd419cb3a8b7b93c3e9cc6c8b2423283fb191a9e82b104762b77ed9710e66",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38971",
+					"10.65.0.27:38971",
+					"172.17.0.1:38971",
+					"172.18.0.1:38971",
+					"172.19.0.1:38971",
+					"172.20.0.1:38971",
+					"172.21.0.1:38971",
+					"172.22.0.1:38971",
+					"172.23.0.1:38971",
+					"172.24.0.1:38971",
+					"172.25.0.1:38971",
+					"172.26.0.1:38971",
+					"172.27.0.1:38971"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:20:17.555162972Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:899992820f50c78bf4646efad1893b89a60a15df44e06db67d72585791846916",
+			"MachineKey": "mkey:6782e8e74806a12067f7c9513bbd890e29ef4afec50e66ef110e0daabee4326c",
+			"Peers": [{
+				"ID":         6830305435958871,
+				"StableID":   "n6iR6RYTLv11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1676c76341ac59f3e5436c2389eb994e0306eb4d24995af57c238ed23999494d",
+				"DiscoKey":   "discokey:0e653906e350a03c3cedd9442690eff3a20d007add6c275a9cf80dc8d388fc38",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33482",
+					"10.65.0.27:33482",
+					"172.17.0.1:33482",
+					"172.18.0.1:33482",
+					"172.19.0.1:33482",
+					"172.20.0.1:33482",
+					"172.21.0.1:33482",
+					"172.22.0.1:33482",
+					"172.23.0.1:33482",
+					"172.24.0.1:33482",
+					"172.25.0.1:33482",
+					"172.26.0.1:33482",
+					"172.27.0.1:33482"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:20:13.793051139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3728127632591665,
+				"StableID":   "nnH6XHbU7W11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0797ee832fe82382a6615c6473fb459180162c3ff4e39648b7f862a2a5b69728",
+				"DiscoKey":   "discokey:3bf1a1b263d46f5efc3cf70eb676068d295c24ab3b7ceac5bf47cf33b387b947",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43932",
+					"10.65.0.27:43932",
+					"172.17.0.1:43932",
+					"172.18.0.1:43932",
+					"172.19.0.1:43932",
+					"172.20.0.1:43932",
+					"172.21.0.1:43932",
+					"172.22.0.1:43932",
+					"172.23.0.1:43932",
+					"172.24.0.1:43932",
+					"172.25.0.1:43932",
+					"172.26.0.1:43932",
+					"172.27.0.1:43932"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 61279},
+					{"Proto": "peerapi6", "Port": 61279}
+				]},
+				"Created":              "2026-05-13T09:20:14.320444224Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5422722565230377,
+				"StableID":   "n4vCr8jxLj11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2d8d4b21ddedd6b252a02d3f99201a1915fe7c3db8d90f760d7def3914bae02c",
+				"DiscoKey":   "discokey:145deabf4a2c0578c9c17c72d9707716f1107557b60ecad31fa043c4bc20b411",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56850",
+					"10.65.0.27:56850",
+					"172.17.0.1:56850",
+					"172.18.0.1:56850",
+					"172.19.0.1:56850",
+					"172.20.0.1:56850",
+					"172.21.0.1:56850",
+					"172.22.0.1:56850",
+					"172.23.0.1:56850",
+					"172.24.0.1:56850",
+					"172.25.0.1:56850",
+					"172.26.0.1:56850",
+					"172.27.0.1:56850"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:20:14.874131744Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         223842005373187,
+				"StableID":   "nN6EW6xNk211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f866d0f9775dc9e6b2dfdf1a990f7c7290860438ffd5aad1ade28dc9f5684574",
+				"DiscoKey":   "discokey:7e6c001fb872587ec1d56ee4959502f8301d9bc3beebc703802591ccd256f96c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58583",
+					"10.65.0.27:58583",
+					"172.17.0.1:58583",
+					"172.18.0.1:58583",
+					"172.19.0.1:58583",
+					"172.20.0.1:58583",
+					"172.21.0.1:58583",
+					"172.22.0.1:58583",
+					"172.23.0.1:58583",
+					"172.24.0.1:58583",
+					"172.25.0.1:58583",
+					"172.26.0.1:58583",
+					"172.27.0.1:58583"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:20:15.40948102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3621397242307042,
+				"StableID":   "nTdoQxx8HV11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31b110aebcd4347f8f8a6026f4a2320aa6744b73e52992be0393fc13f868860a",
+				"DiscoKey":   "discokey:41fe86fa0f5dbce075f479b14c12551dd88cddb6952a72cdd88fd0ae82a94601",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40342",
+					"10.65.0.27:40342",
+					"172.17.0.1:40342",
+					"172.18.0.1:40342",
+					"172.19.0.1:40342",
+					"172.20.0.1:40342",
+					"172.21.0.1:40342",
+					"172.22.0.1:40342",
+					"172.23.0.1:40342",
+					"172.24.0.1:40342",
+					"172.25.0.1:40342",
+					"172.26.0.1:40342",
+					"172.27.0.1:40342"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:20:15.952792861Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6918226251818639,
+				"StableID":   "nLbBXC5H2w11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e761b2e36f09a65b4d8f1131ab0f29ea7239d0827f225a576f4cc83609900d24",
+				"DiscoKey":   "discokey:2e8579339f36c79810d79d625c72432868aac339d087f082b3b18923b465176f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33617",
+					"10.65.0.27:33617",
+					"172.17.0.1:33617",
+					"172.18.0.1:33617",
+					"172.19.0.1:33617",
+					"172.20.0.1:33617",
+					"172.21.0.1:33617",
+					"172.22.0.1:33617",
+					"172.23.0.1:33617",
+					"172.24.0.1:33617",
+					"172.25.0.1:33617",
+					"172.26.0.1:33617",
+					"172.27.0.1:33617"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:20:16.480390963Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5513145568722149,
+				"StableID":   "nLtc2Azu3k11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b7321b72b53ed6d4b99319f01f9078da60d83b36a22957586588fc005dc12349",
+				"DiscoKey":   "discokey:0d5760bad884b761b1d7db181534b466d21d1682fdf136c6619af55ef105fa30",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:56195",
+					"10.65.0.27:56195",
+					"172.17.0.1:56195",
+					"172.18.0.1:56195",
+					"172.19.0.1:56195",
+					"172.20.0.1:56195",
+					"172.21.0.1:56195",
+					"172.22.0.1:56195",
+					"172.23.0.1:56195",
+					"172.24.0.1:56195",
+					"172.25.0.1:56195",
+					"172.26.0.1:56195",
+					"172.27.0.1:56195"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:20:17.022800848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8617791652858649,
+				"StableID":   "nUQ58sm1JA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:301b52d255de5155bf0fe437dbc13959816f1ae31366aafddb69e522dba6571d",
+				"DiscoKey":   "discokey:5c583dfe16347d721fe2bfd96c9593016019e9bd14ea24d4be63acc99ed07034",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:40764",
+					"10.65.0.27:40764",
+					"172.17.0.1:40764",
+					"172.18.0.1:40764",
+					"172.19.0.1:40764",
+					"172.20.0.1:40764",
+					"172.21.0.1:40764",
+					"172.22.0.1:40764",
+					"172.23.0.1:40764",
+					"172.24.0.1:40764",
+					"172.25.0.1:40764",
+					"172.26.0.1:40764",
+					"172.27.0.1:40764"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:20:18.087199406Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2636814795393374,
+				"StableID":   "nTX18ueDbM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:55ec9abc4d4be42720a8d87cba7a8743c8d0ee9dc1d49ce069eae57fb62f246c",
+				"DiscoKey":   "discokey:3b8fb56895becef1724c093636ac2ec730bacc423e6c57684f61fb866ab58849",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35228",
+					"10.65.0.27:35228",
+					"172.17.0.1:35228",
+					"172.18.0.1:35228",
+					"172.19.0.1:35228",
+					"172.20.0.1:35228",
+					"172.21.0.1:35228",
+					"172.22.0.1:35228",
+					"172.23.0.1:35228",
+					"172.24.0.1:35228",
+					"172.25.0.1:35228",
+					"172.26.0.1:35228",
+					"172.27.0.1:35228"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:20:18.627896651Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7627873531149537,
+				"StableID":   "najGXaJgZ221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:75e0d4f15bd5339407df21ed895b3e113329a82d5746611816261dfaa5a79c59",
+				"DiscoKey":   "discokey:7690567f0f5dc181b8c6fdfc5b003a161ce3a1d2befe75eb2952a3b5cd948264",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43330",
+					"10.65.0.27:43330",
+					"172.17.0.1:43330",
+					"172.18.0.1:43330",
+					"172.19.0.1:43330",
+					"172.20.0.1:43330",
+					"172.21.0.1:43330",
+					"172.22.0.1:43330",
+					"172.23.0.1:43330",
+					"172.24.0.1:43330",
+					"172.25.0.1:43330",
+					"172.26.0.1:43330",
+					"172.27.0.1:43330"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:20:19.183110945Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8570237187749009,
+				"StableID":   "nczCthbUv921CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5a1a1fd1951cf4e6dce860f46d77baded0e023223abff26ecda38d139dd83c72",
+				"DiscoKey":   "discokey:16e8d2427e69b9d2cac1673da23765fa701b04a5ce3d28530f70b820741dc90c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:51710",
+					"10.65.0.27:51710",
+					"172.17.0.1:51710",
+					"172.18.0.1:51710",
+					"172.19.0.1:51710",
+					"172.20.0.1:51710",
+					"172.21.0.1:51710",
+					"172.22.0.1:51710",
+					"172.23.0.1:51710",
+					"172.24.0.1:51710",
+					"172.25.0.1:51710",
+					"172.26.0.1:51710",
+					"172.27.0.1:51710"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:20:19.72301037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5525645567720675,
+				"StableID":   "nriq8gLa9k11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:adccd261ee5560558a2c08fe6d70415ee0c39f3b804d7f872b9503ebd06b445d",
+				"KeyExpiry":  "2026-11-09T09:20:20Z",
+				"DiscoKey":   "discokey:4586ef29b9329cf1a1c6cbcb9f3df9108674160a9fe26ecb48f1d431d7657744",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40287",
+					"10.65.0.27:40287",
+					"172.17.0.1:40287",
+					"172.18.0.1:40287",
+					"172.19.0.1:40287",
+					"172.20.0.1:40287",
+					"172.21.0.1:40287",
+					"172.22.0.1:40287",
+					"172.23.0.1:40287",
+					"172.24.0.1:40287",
+					"172.25.0.1:40287",
+					"172.26.0.1:40287",
+					"172.27.0.1:40287"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:20:20.251293676Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1545417971442506,
+				"StableID":   "nuGs6ZWv4D11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5da9ac437b55667d69d41d8084de52f0c051d481b3cac7100a7de8e067120322",
+				"KeyExpiry":  "2026-11-09T09:20:20Z",
+				"DiscoKey":   "discokey:9d22489b975e567d77dcd2b5823a2a32977c7346dc5b1840c4cba4a220729f68",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60732",
+					"10.65.0.27:60732",
+					"172.17.0.1:60732",
+					"172.18.0.1:60732",
+					"172.19.0.1:60732",
+					"172.20.0.1:60732",
+					"172.21.0.1:60732",
+					"172.22.0.1:60732",
+					"172.23.0.1:60732",
+					"172.24.0.1:60732",
+					"172.25.0.1:60732",
+					"172.26.0.1:60732",
+					"172.27.0.1:60732"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:20:20.802684287Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8839325176815582,
+				"StableID":   "nKjd2r5M2C21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5ccc1e2806b7dba12fb9a1a87a8f0eaf68e13336b8836703c3435ae05bb30761",
+				"KeyExpiry":  "2026-11-09T09:20:21Z",
+				"DiscoKey":   "discokey:4b567c71b0bbb40126611349579c08cca63f90ce7b3753721266cf1a30c1df6e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41279",
+					"10.65.0.27:41279",
+					"172.17.0.1:41279",
+					"172.18.0.1:41279",
+					"172.19.0.1:41279",
+					"172.20.0.1:41279",
+					"172.21.0.1:41279",
+					"172.22.0.1:41279",
+					"172.23.0.1:41279",
+					"172.24.0.1:41279",
+					"172.25.0.1:41279",
+					"172.26.0.1:41279",
+					"172.27.0.1:41279"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:20:21.338069367Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6848992150805548": {
+				"ID":          6848992150805548,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5525645567720675,
+				"StableID":   "nriq8gLa9k11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:adccd261ee5560558a2c08fe6d70415ee0c39f3b804d7f872b9503ebd06b445d",
+				"KeyExpiry":  "2026-11-09T09:20:20Z",
+				"DiscoKey":   "discokey:4586ef29b9329cf1a1c6cbcb9f3df9108674160a9fe26ecb48f1d431d7657744",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40287",
+					"10.65.0.27:40287",
+					"172.17.0.1:40287",
+					"172.18.0.1:40287",
+					"172.19.0.1:40287",
+					"172.20.0.1:40287",
+					"172.21.0.1:40287",
+					"172.22.0.1:40287",
+					"172.23.0.1:40287",
+					"172.24.0.1:40287",
+					"172.25.0.1:40287",
+					"172.26.0.1:40287",
+					"172.27.0.1:40287"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:20:20.251293676Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:adccd261ee5560558a2c08fe6d70415ee0c39f3b804d7f872b9503ebd06b445d",
+			"MachineKey": "mkey:d1c25fe8747c1e510df9b9ca78af1bab655a751b29447cfdb276e657e3d8e05e",
+			"Peers": [{
+				"ID":         6830305435958871,
+				"StableID":   "n6iR6RYTLv11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1676c76341ac59f3e5436c2389eb994e0306eb4d24995af57c238ed23999494d",
+				"DiscoKey":   "discokey:0e653906e350a03c3cedd9442690eff3a20d007add6c275a9cf80dc8d388fc38",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33482",
+					"10.65.0.27:33482",
+					"172.17.0.1:33482",
+					"172.18.0.1:33482",
+					"172.19.0.1:33482",
+					"172.20.0.1:33482",
+					"172.21.0.1:33482",
+					"172.22.0.1:33482",
+					"172.23.0.1:33482",
+					"172.24.0.1:33482",
+					"172.25.0.1:33482",
+					"172.26.0.1:33482",
+					"172.27.0.1:33482"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:20:13.793051139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3728127632591665,
+				"StableID":   "nnH6XHbU7W11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0797ee832fe82382a6615c6473fb459180162c3ff4e39648b7f862a2a5b69728",
+				"DiscoKey":   "discokey:3bf1a1b263d46f5efc3cf70eb676068d295c24ab3b7ceac5bf47cf33b387b947",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43932",
+					"10.65.0.27:43932",
+					"172.17.0.1:43932",
+					"172.18.0.1:43932",
+					"172.19.0.1:43932",
+					"172.20.0.1:43932",
+					"172.21.0.1:43932",
+					"172.22.0.1:43932",
+					"172.23.0.1:43932",
+					"172.24.0.1:43932",
+					"172.25.0.1:43932",
+					"172.26.0.1:43932",
+					"172.27.0.1:43932"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 61279},
+					{"Proto": "peerapi6", "Port": 61279}
+				]},
+				"Created":              "2026-05-13T09:20:14.320444224Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5422722565230377,
+				"StableID":   "n4vCr8jxLj11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2d8d4b21ddedd6b252a02d3f99201a1915fe7c3db8d90f760d7def3914bae02c",
+				"DiscoKey":   "discokey:145deabf4a2c0578c9c17c72d9707716f1107557b60ecad31fa043c4bc20b411",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56850",
+					"10.65.0.27:56850",
+					"172.17.0.1:56850",
+					"172.18.0.1:56850",
+					"172.19.0.1:56850",
+					"172.20.0.1:56850",
+					"172.21.0.1:56850",
+					"172.22.0.1:56850",
+					"172.23.0.1:56850",
+					"172.24.0.1:56850",
+					"172.25.0.1:56850",
+					"172.26.0.1:56850",
+					"172.27.0.1:56850"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:20:14.874131744Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         223842005373187,
+				"StableID":   "nN6EW6xNk211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f866d0f9775dc9e6b2dfdf1a990f7c7290860438ffd5aad1ade28dc9f5684574",
+				"DiscoKey":   "discokey:7e6c001fb872587ec1d56ee4959502f8301d9bc3beebc703802591ccd256f96c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58583",
+					"10.65.0.27:58583",
+					"172.17.0.1:58583",
+					"172.18.0.1:58583",
+					"172.19.0.1:58583",
+					"172.20.0.1:58583",
+					"172.21.0.1:58583",
+					"172.22.0.1:58583",
+					"172.23.0.1:58583",
+					"172.24.0.1:58583",
+					"172.25.0.1:58583",
+					"172.26.0.1:58583",
+					"172.27.0.1:58583"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:20:15.40948102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3621397242307042,
+				"StableID":   "nTdoQxx8HV11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31b110aebcd4347f8f8a6026f4a2320aa6744b73e52992be0393fc13f868860a",
+				"DiscoKey":   "discokey:41fe86fa0f5dbce075f479b14c12551dd88cddb6952a72cdd88fd0ae82a94601",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40342",
+					"10.65.0.27:40342",
+					"172.17.0.1:40342",
+					"172.18.0.1:40342",
+					"172.19.0.1:40342",
+					"172.20.0.1:40342",
+					"172.21.0.1:40342",
+					"172.22.0.1:40342",
+					"172.23.0.1:40342",
+					"172.24.0.1:40342",
+					"172.25.0.1:40342",
+					"172.26.0.1:40342",
+					"172.27.0.1:40342"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:20:15.952792861Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6918226251818639,
+				"StableID":   "nLbBXC5H2w11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e761b2e36f09a65b4d8f1131ab0f29ea7239d0827f225a576f4cc83609900d24",
+				"DiscoKey":   "discokey:2e8579339f36c79810d79d625c72432868aac339d087f082b3b18923b465176f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33617",
+					"10.65.0.27:33617",
+					"172.17.0.1:33617",
+					"172.18.0.1:33617",
+					"172.19.0.1:33617",
+					"172.20.0.1:33617",
+					"172.21.0.1:33617",
+					"172.22.0.1:33617",
+					"172.23.0.1:33617",
+					"172.24.0.1:33617",
+					"172.25.0.1:33617",
+					"172.26.0.1:33617",
+					"172.27.0.1:33617"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:20:16.480390963Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5513145568722149,
+				"StableID":   "nLtc2Azu3k11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b7321b72b53ed6d4b99319f01f9078da60d83b36a22957586588fc005dc12349",
+				"DiscoKey":   "discokey:0d5760bad884b761b1d7db181534b466d21d1682fdf136c6619af55ef105fa30",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:56195",
+					"10.65.0.27:56195",
+					"172.17.0.1:56195",
+					"172.18.0.1:56195",
+					"172.19.0.1:56195",
+					"172.20.0.1:56195",
+					"172.21.0.1:56195",
+					"172.22.0.1:56195",
+					"172.23.0.1:56195",
+					"172.24.0.1:56195",
+					"172.25.0.1:56195",
+					"172.26.0.1:56195",
+					"172.27.0.1:56195"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:20:17.022800848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6848992150805548,
+				"StableID":   "nuFW6nQvUv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:899992820f50c78bf4646efad1893b89a60a15df44e06db67d72585791846916",
+				"DiscoKey":   "discokey:a34dd419cb3a8b7b93c3e9cc6c8b2423283fb191a9e82b104762b77ed9710e66",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38971",
+					"10.65.0.27:38971",
+					"172.17.0.1:38971",
+					"172.18.0.1:38971",
+					"172.19.0.1:38971",
+					"172.20.0.1:38971",
+					"172.21.0.1:38971",
+					"172.22.0.1:38971",
+					"172.23.0.1:38971",
+					"172.24.0.1:38971",
+					"172.25.0.1:38971",
+					"172.26.0.1:38971",
+					"172.27.0.1:38971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:20:17.555162972Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8617791652858649,
+				"StableID":   "nUQ58sm1JA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:301b52d255de5155bf0fe437dbc13959816f1ae31366aafddb69e522dba6571d",
+				"DiscoKey":   "discokey:5c583dfe16347d721fe2bfd96c9593016019e9bd14ea24d4be63acc99ed07034",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:40764",
+					"10.65.0.27:40764",
+					"172.17.0.1:40764",
+					"172.18.0.1:40764",
+					"172.19.0.1:40764",
+					"172.20.0.1:40764",
+					"172.21.0.1:40764",
+					"172.22.0.1:40764",
+					"172.23.0.1:40764",
+					"172.24.0.1:40764",
+					"172.25.0.1:40764",
+					"172.26.0.1:40764",
+					"172.27.0.1:40764"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:20:18.087199406Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2636814795393374,
+				"StableID":   "nTX18ueDbM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:55ec9abc4d4be42720a8d87cba7a8743c8d0ee9dc1d49ce069eae57fb62f246c",
+				"DiscoKey":   "discokey:3b8fb56895becef1724c093636ac2ec730bacc423e6c57684f61fb866ab58849",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35228",
+					"10.65.0.27:35228",
+					"172.17.0.1:35228",
+					"172.18.0.1:35228",
+					"172.19.0.1:35228",
+					"172.20.0.1:35228",
+					"172.21.0.1:35228",
+					"172.22.0.1:35228",
+					"172.23.0.1:35228",
+					"172.24.0.1:35228",
+					"172.25.0.1:35228",
+					"172.26.0.1:35228",
+					"172.27.0.1:35228"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:20:18.627896651Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7627873531149537,
+				"StableID":   "najGXaJgZ221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:75e0d4f15bd5339407df21ed895b3e113329a82d5746611816261dfaa5a79c59",
+				"DiscoKey":   "discokey:7690567f0f5dc181b8c6fdfc5b003a161ce3a1d2befe75eb2952a3b5cd948264",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43330",
+					"10.65.0.27:43330",
+					"172.17.0.1:43330",
+					"172.18.0.1:43330",
+					"172.19.0.1:43330",
+					"172.20.0.1:43330",
+					"172.21.0.1:43330",
+					"172.22.0.1:43330",
+					"172.23.0.1:43330",
+					"172.24.0.1:43330",
+					"172.25.0.1:43330",
+					"172.26.0.1:43330",
+					"172.27.0.1:43330"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:20:19.183110945Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8570237187749009,
+				"StableID":   "nczCthbUv921CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5a1a1fd1951cf4e6dce860f46d77baded0e023223abff26ecda38d139dd83c72",
+				"DiscoKey":   "discokey:16e8d2427e69b9d2cac1673da23765fa701b04a5ce3d28530f70b820741dc90c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:51710",
+					"10.65.0.27:51710",
+					"172.17.0.1:51710",
+					"172.18.0.1:51710",
+					"172.19.0.1:51710",
+					"172.20.0.1:51710",
+					"172.21.0.1:51710",
+					"172.22.0.1:51710",
+					"172.23.0.1:51710",
+					"172.24.0.1:51710",
+					"172.25.0.1:51710",
+					"172.26.0.1:51710",
+					"172.27.0.1:51710"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:20:19.72301037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1545417971442506,
+				"StableID":   "nuGs6ZWv4D11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5da9ac437b55667d69d41d8084de52f0c051d481b3cac7100a7de8e067120322",
+				"KeyExpiry":  "2026-11-09T09:20:20Z",
+				"DiscoKey":   "discokey:9d22489b975e567d77dcd2b5823a2a32977c7346dc5b1840c4cba4a220729f68",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60732",
+					"10.65.0.27:60732",
+					"172.17.0.1:60732",
+					"172.18.0.1:60732",
+					"172.19.0.1:60732",
+					"172.20.0.1:60732",
+					"172.21.0.1:60732",
+					"172.22.0.1:60732",
+					"172.23.0.1:60732",
+					"172.24.0.1:60732",
+					"172.25.0.1:60732",
+					"172.26.0.1:60732",
+					"172.27.0.1:60732"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:20:20.802684287Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8839325176815582,
+				"StableID":   "nKjd2r5M2C21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5ccc1e2806b7dba12fb9a1a87a8f0eaf68e13336b8836703c3435ae05bb30761",
+				"KeyExpiry":  "2026-11-09T09:20:21Z",
+				"DiscoKey":   "discokey:4b567c71b0bbb40126611349579c08cca63f90ce7b3753721266cf1a30c1df6e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41279",
+					"10.65.0.27:41279",
+					"172.17.0.1:41279",
+					"172.18.0.1:41279",
+					"172.19.0.1:41279",
+					"172.20.0.1:41279",
+					"172.21.0.1:41279",
+					"172.22.0.1:41279",
+					"172.23.0.1:41279",
+					"172.24.0.1:41279",
+					"172.25.0.1:41279",
+					"172.26.0.1:41279",
+					"172.27.0.1:41279"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:20:21.338069367Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7627873531149537,
+				"StableID":   "najGXaJgZ221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       7627873531149537,
+				"Key":        "nodekey:75e0d4f15bd5339407df21ed895b3e113329a82d5746611816261dfaa5a79c59",
+				"DiscoKey":   "discokey:7690567f0f5dc181b8c6fdfc5b003a161ce3a1d2befe75eb2952a3b5cd948264",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43330",
+					"10.65.0.27:43330",
+					"172.17.0.1:43330",
+					"172.18.0.1:43330",
+					"172.19.0.1:43330",
+					"172.20.0.1:43330",
+					"172.21.0.1:43330",
+					"172.22.0.1:43330",
+					"172.23.0.1:43330",
+					"172.24.0.1:43330",
+					"172.25.0.1:43330",
+					"172.26.0.1:43330",
+					"172.27.0.1:43330"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:20:19.183110945Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:75e0d4f15bd5339407df21ed895b3e113329a82d5746611816261dfaa5a79c59",
+			"MachineKey": "mkey:cbd56290cf3b25d90599b11b5981da38c0092facda69a7aa1835fde71a64a614",
+			"Peers": [{
+				"ID":         6830305435958871,
+				"StableID":   "n6iR6RYTLv11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1676c76341ac59f3e5436c2389eb994e0306eb4d24995af57c238ed23999494d",
+				"DiscoKey":   "discokey:0e653906e350a03c3cedd9442690eff3a20d007add6c275a9cf80dc8d388fc38",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33482",
+					"10.65.0.27:33482",
+					"172.17.0.1:33482",
+					"172.18.0.1:33482",
+					"172.19.0.1:33482",
+					"172.20.0.1:33482",
+					"172.21.0.1:33482",
+					"172.22.0.1:33482",
+					"172.23.0.1:33482",
+					"172.24.0.1:33482",
+					"172.25.0.1:33482",
+					"172.26.0.1:33482",
+					"172.27.0.1:33482"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:20:13.793051139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3728127632591665,
+				"StableID":   "nnH6XHbU7W11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0797ee832fe82382a6615c6473fb459180162c3ff4e39648b7f862a2a5b69728",
+				"DiscoKey":   "discokey:3bf1a1b263d46f5efc3cf70eb676068d295c24ab3b7ceac5bf47cf33b387b947",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43932",
+					"10.65.0.27:43932",
+					"172.17.0.1:43932",
+					"172.18.0.1:43932",
+					"172.19.0.1:43932",
+					"172.20.0.1:43932",
+					"172.21.0.1:43932",
+					"172.22.0.1:43932",
+					"172.23.0.1:43932",
+					"172.24.0.1:43932",
+					"172.25.0.1:43932",
+					"172.26.0.1:43932",
+					"172.27.0.1:43932"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 61279},
+					{"Proto": "peerapi6", "Port": 61279}
+				]},
+				"Created":              "2026-05-13T09:20:14.320444224Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5422722565230377,
+				"StableID":   "n4vCr8jxLj11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2d8d4b21ddedd6b252a02d3f99201a1915fe7c3db8d90f760d7def3914bae02c",
+				"DiscoKey":   "discokey:145deabf4a2c0578c9c17c72d9707716f1107557b60ecad31fa043c4bc20b411",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56850",
+					"10.65.0.27:56850",
+					"172.17.0.1:56850",
+					"172.18.0.1:56850",
+					"172.19.0.1:56850",
+					"172.20.0.1:56850",
+					"172.21.0.1:56850",
+					"172.22.0.1:56850",
+					"172.23.0.1:56850",
+					"172.24.0.1:56850",
+					"172.25.0.1:56850",
+					"172.26.0.1:56850",
+					"172.27.0.1:56850"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:20:14.874131744Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         223842005373187,
+				"StableID":   "nN6EW6xNk211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f866d0f9775dc9e6b2dfdf1a990f7c7290860438ffd5aad1ade28dc9f5684574",
+				"DiscoKey":   "discokey:7e6c001fb872587ec1d56ee4959502f8301d9bc3beebc703802591ccd256f96c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58583",
+					"10.65.0.27:58583",
+					"172.17.0.1:58583",
+					"172.18.0.1:58583",
+					"172.19.0.1:58583",
+					"172.20.0.1:58583",
+					"172.21.0.1:58583",
+					"172.22.0.1:58583",
+					"172.23.0.1:58583",
+					"172.24.0.1:58583",
+					"172.25.0.1:58583",
+					"172.26.0.1:58583",
+					"172.27.0.1:58583"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:20:15.40948102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3621397242307042,
+				"StableID":   "nTdoQxx8HV11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31b110aebcd4347f8f8a6026f4a2320aa6744b73e52992be0393fc13f868860a",
+				"DiscoKey":   "discokey:41fe86fa0f5dbce075f479b14c12551dd88cddb6952a72cdd88fd0ae82a94601",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40342",
+					"10.65.0.27:40342",
+					"172.17.0.1:40342",
+					"172.18.0.1:40342",
+					"172.19.0.1:40342",
+					"172.20.0.1:40342",
+					"172.21.0.1:40342",
+					"172.22.0.1:40342",
+					"172.23.0.1:40342",
+					"172.24.0.1:40342",
+					"172.25.0.1:40342",
+					"172.26.0.1:40342",
+					"172.27.0.1:40342"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:20:15.952792861Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6918226251818639,
+				"StableID":   "nLbBXC5H2w11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e761b2e36f09a65b4d8f1131ab0f29ea7239d0827f225a576f4cc83609900d24",
+				"DiscoKey":   "discokey:2e8579339f36c79810d79d625c72432868aac339d087f082b3b18923b465176f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33617",
+					"10.65.0.27:33617",
+					"172.17.0.1:33617",
+					"172.18.0.1:33617",
+					"172.19.0.1:33617",
+					"172.20.0.1:33617",
+					"172.21.0.1:33617",
+					"172.22.0.1:33617",
+					"172.23.0.1:33617",
+					"172.24.0.1:33617",
+					"172.25.0.1:33617",
+					"172.26.0.1:33617",
+					"172.27.0.1:33617"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:20:16.480390963Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5513145568722149,
+				"StableID":   "nLtc2Azu3k11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b7321b72b53ed6d4b99319f01f9078da60d83b36a22957586588fc005dc12349",
+				"DiscoKey":   "discokey:0d5760bad884b761b1d7db181534b466d21d1682fdf136c6619af55ef105fa30",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:56195",
+					"10.65.0.27:56195",
+					"172.17.0.1:56195",
+					"172.18.0.1:56195",
+					"172.19.0.1:56195",
+					"172.20.0.1:56195",
+					"172.21.0.1:56195",
+					"172.22.0.1:56195",
+					"172.23.0.1:56195",
+					"172.24.0.1:56195",
+					"172.25.0.1:56195",
+					"172.26.0.1:56195",
+					"172.27.0.1:56195"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:20:17.022800848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6848992150805548,
+				"StableID":   "nuFW6nQvUv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:899992820f50c78bf4646efad1893b89a60a15df44e06db67d72585791846916",
+				"DiscoKey":   "discokey:a34dd419cb3a8b7b93c3e9cc6c8b2423283fb191a9e82b104762b77ed9710e66",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38971",
+					"10.65.0.27:38971",
+					"172.17.0.1:38971",
+					"172.18.0.1:38971",
+					"172.19.0.1:38971",
+					"172.20.0.1:38971",
+					"172.21.0.1:38971",
+					"172.22.0.1:38971",
+					"172.23.0.1:38971",
+					"172.24.0.1:38971",
+					"172.25.0.1:38971",
+					"172.26.0.1:38971",
+					"172.27.0.1:38971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:20:17.555162972Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8617791652858649,
+				"StableID":   "nUQ58sm1JA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:301b52d255de5155bf0fe437dbc13959816f1ae31366aafddb69e522dba6571d",
+				"DiscoKey":   "discokey:5c583dfe16347d721fe2bfd96c9593016019e9bd14ea24d4be63acc99ed07034",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:40764",
+					"10.65.0.27:40764",
+					"172.17.0.1:40764",
+					"172.18.0.1:40764",
+					"172.19.0.1:40764",
+					"172.20.0.1:40764",
+					"172.21.0.1:40764",
+					"172.22.0.1:40764",
+					"172.23.0.1:40764",
+					"172.24.0.1:40764",
+					"172.25.0.1:40764",
+					"172.26.0.1:40764",
+					"172.27.0.1:40764"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:20:18.087199406Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2636814795393374,
+				"StableID":   "nTX18ueDbM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:55ec9abc4d4be42720a8d87cba7a8743c8d0ee9dc1d49ce069eae57fb62f246c",
+				"DiscoKey":   "discokey:3b8fb56895becef1724c093636ac2ec730bacc423e6c57684f61fb866ab58849",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35228",
+					"10.65.0.27:35228",
+					"172.17.0.1:35228",
+					"172.18.0.1:35228",
+					"172.19.0.1:35228",
+					"172.20.0.1:35228",
+					"172.21.0.1:35228",
+					"172.22.0.1:35228",
+					"172.23.0.1:35228",
+					"172.24.0.1:35228",
+					"172.25.0.1:35228",
+					"172.26.0.1:35228",
+					"172.27.0.1:35228"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:20:18.627896651Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8570237187749009,
+				"StableID":   "nczCthbUv921CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5a1a1fd1951cf4e6dce860f46d77baded0e023223abff26ecda38d139dd83c72",
+				"DiscoKey":   "discokey:16e8d2427e69b9d2cac1673da23765fa701b04a5ce3d28530f70b820741dc90c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:51710",
+					"10.65.0.27:51710",
+					"172.17.0.1:51710",
+					"172.18.0.1:51710",
+					"172.19.0.1:51710",
+					"172.20.0.1:51710",
+					"172.21.0.1:51710",
+					"172.22.0.1:51710",
+					"172.23.0.1:51710",
+					"172.24.0.1:51710",
+					"172.25.0.1:51710",
+					"172.26.0.1:51710",
+					"172.27.0.1:51710"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:20:19.72301037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5525645567720675,
+				"StableID":   "nriq8gLa9k11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:adccd261ee5560558a2c08fe6d70415ee0c39f3b804d7f872b9503ebd06b445d",
+				"KeyExpiry":  "2026-11-09T09:20:20Z",
+				"DiscoKey":   "discokey:4586ef29b9329cf1a1c6cbcb9f3df9108674160a9fe26ecb48f1d431d7657744",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40287",
+					"10.65.0.27:40287",
+					"172.17.0.1:40287",
+					"172.18.0.1:40287",
+					"172.19.0.1:40287",
+					"172.20.0.1:40287",
+					"172.21.0.1:40287",
+					"172.22.0.1:40287",
+					"172.23.0.1:40287",
+					"172.24.0.1:40287",
+					"172.25.0.1:40287",
+					"172.26.0.1:40287",
+					"172.27.0.1:40287"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:20:20.251293676Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1545417971442506,
+				"StableID":   "nuGs6ZWv4D11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5da9ac437b55667d69d41d8084de52f0c051d481b3cac7100a7de8e067120322",
+				"KeyExpiry":  "2026-11-09T09:20:20Z",
+				"DiscoKey":   "discokey:9d22489b975e567d77dcd2b5823a2a32977c7346dc5b1840c4cba4a220729f68",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60732",
+					"10.65.0.27:60732",
+					"172.17.0.1:60732",
+					"172.18.0.1:60732",
+					"172.19.0.1:60732",
+					"172.20.0.1:60732",
+					"172.21.0.1:60732",
+					"172.22.0.1:60732",
+					"172.23.0.1:60732",
+					"172.24.0.1:60732",
+					"172.25.0.1:60732",
+					"172.26.0.1:60732",
+					"172.27.0.1:60732"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:20:20.802684287Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8839325176815582,
+				"StableID":   "nKjd2r5M2C21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5ccc1e2806b7dba12fb9a1a87a8f0eaf68e13336b8836703c3435ae05bb30761",
+				"KeyExpiry":  "2026-11-09T09:20:21Z",
+				"DiscoKey":   "discokey:4b567c71b0bbb40126611349579c08cca63f90ce7b3753721266cf1a30c1df6e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41279",
+					"10.65.0.27:41279",
+					"172.17.0.1:41279",
+					"172.18.0.1:41279",
+					"172.19.0.1:41279",
+					"172.20.0.1:41279",
+					"172.21.0.1:41279",
+					"172.22.0.1:41279",
+					"172.23.0.1:41279",
+					"172.24.0.1:41279",
+					"172.25.0.1:41279",
+					"172.26.0.1:41279",
+					"172.27.0.1:41279"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:20:21.338069367Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7627873531149537": {
+				"ID":          7627873531149537,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3728127632591665,
+				"StableID":   "nnH6XHbU7W11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       3728127632591665,
+				"Key":        "nodekey:0797ee832fe82382a6615c6473fb459180162c3ff4e39648b7f862a2a5b69728",
+				"DiscoKey":   "discokey:3bf1a1b263d46f5efc3cf70eb676068d295c24ab3b7ceac5bf47cf33b387b947",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43932",
+					"10.65.0.27:43932",
+					"172.17.0.1:43932",
+					"172.18.0.1:43932",
+					"172.19.0.1:43932",
+					"172.20.0.1:43932",
+					"172.21.0.1:43932",
+					"172.22.0.1:43932",
+					"172.23.0.1:43932",
+					"172.24.0.1:43932",
+					"172.25.0.1:43932",
+					"172.26.0.1:43932",
+					"172.27.0.1:43932"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 61279},
+						{"Proto": "peerapi6", "Port": 61279},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:20:14.320444224Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0797ee832fe82382a6615c6473fb459180162c3ff4e39648b7f862a2a5b69728",
+			"MachineKey": "mkey:53f2b2e80de9cef62f1b088af0f20961fe02fbb62d2f69af6474fc21ce8b5314",
+			"Peers": [{
+				"ID":         6830305435958871,
+				"StableID":   "n6iR6RYTLv11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1676c76341ac59f3e5436c2389eb994e0306eb4d24995af57c238ed23999494d",
+				"DiscoKey":   "discokey:0e653906e350a03c3cedd9442690eff3a20d007add6c275a9cf80dc8d388fc38",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33482",
+					"10.65.0.27:33482",
+					"172.17.0.1:33482",
+					"172.18.0.1:33482",
+					"172.19.0.1:33482",
+					"172.20.0.1:33482",
+					"172.21.0.1:33482",
+					"172.22.0.1:33482",
+					"172.23.0.1:33482",
+					"172.24.0.1:33482",
+					"172.25.0.1:33482",
+					"172.26.0.1:33482",
+					"172.27.0.1:33482"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:20:13.793051139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5422722565230377,
+				"StableID":   "n4vCr8jxLj11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2d8d4b21ddedd6b252a02d3f99201a1915fe7c3db8d90f760d7def3914bae02c",
+				"DiscoKey":   "discokey:145deabf4a2c0578c9c17c72d9707716f1107557b60ecad31fa043c4bc20b411",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56850",
+					"10.65.0.27:56850",
+					"172.17.0.1:56850",
+					"172.18.0.1:56850",
+					"172.19.0.1:56850",
+					"172.20.0.1:56850",
+					"172.21.0.1:56850",
+					"172.22.0.1:56850",
+					"172.23.0.1:56850",
+					"172.24.0.1:56850",
+					"172.25.0.1:56850",
+					"172.26.0.1:56850",
+					"172.27.0.1:56850"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:20:14.874131744Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         223842005373187,
+				"StableID":   "nN6EW6xNk211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f866d0f9775dc9e6b2dfdf1a990f7c7290860438ffd5aad1ade28dc9f5684574",
+				"DiscoKey":   "discokey:7e6c001fb872587ec1d56ee4959502f8301d9bc3beebc703802591ccd256f96c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58583",
+					"10.65.0.27:58583",
+					"172.17.0.1:58583",
+					"172.18.0.1:58583",
+					"172.19.0.1:58583",
+					"172.20.0.1:58583",
+					"172.21.0.1:58583",
+					"172.22.0.1:58583",
+					"172.23.0.1:58583",
+					"172.24.0.1:58583",
+					"172.25.0.1:58583",
+					"172.26.0.1:58583",
+					"172.27.0.1:58583"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:20:15.40948102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3621397242307042,
+				"StableID":   "nTdoQxx8HV11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31b110aebcd4347f8f8a6026f4a2320aa6744b73e52992be0393fc13f868860a",
+				"DiscoKey":   "discokey:41fe86fa0f5dbce075f479b14c12551dd88cddb6952a72cdd88fd0ae82a94601",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40342",
+					"10.65.0.27:40342",
+					"172.17.0.1:40342",
+					"172.18.0.1:40342",
+					"172.19.0.1:40342",
+					"172.20.0.1:40342",
+					"172.21.0.1:40342",
+					"172.22.0.1:40342",
+					"172.23.0.1:40342",
+					"172.24.0.1:40342",
+					"172.25.0.1:40342",
+					"172.26.0.1:40342",
+					"172.27.0.1:40342"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:20:15.952792861Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6918226251818639,
+				"StableID":   "nLbBXC5H2w11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e761b2e36f09a65b4d8f1131ab0f29ea7239d0827f225a576f4cc83609900d24",
+				"DiscoKey":   "discokey:2e8579339f36c79810d79d625c72432868aac339d087f082b3b18923b465176f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33617",
+					"10.65.0.27:33617",
+					"172.17.0.1:33617",
+					"172.18.0.1:33617",
+					"172.19.0.1:33617",
+					"172.20.0.1:33617",
+					"172.21.0.1:33617",
+					"172.22.0.1:33617",
+					"172.23.0.1:33617",
+					"172.24.0.1:33617",
+					"172.25.0.1:33617",
+					"172.26.0.1:33617",
+					"172.27.0.1:33617"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:20:16.480390963Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5513145568722149,
+				"StableID":   "nLtc2Azu3k11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b7321b72b53ed6d4b99319f01f9078da60d83b36a22957586588fc005dc12349",
+				"DiscoKey":   "discokey:0d5760bad884b761b1d7db181534b466d21d1682fdf136c6619af55ef105fa30",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:56195",
+					"10.65.0.27:56195",
+					"172.17.0.1:56195",
+					"172.18.0.1:56195",
+					"172.19.0.1:56195",
+					"172.20.0.1:56195",
+					"172.21.0.1:56195",
+					"172.22.0.1:56195",
+					"172.23.0.1:56195",
+					"172.24.0.1:56195",
+					"172.25.0.1:56195",
+					"172.26.0.1:56195",
+					"172.27.0.1:56195"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:20:17.022800848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6848992150805548,
+				"StableID":   "nuFW6nQvUv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:899992820f50c78bf4646efad1893b89a60a15df44e06db67d72585791846916",
+				"DiscoKey":   "discokey:a34dd419cb3a8b7b93c3e9cc6c8b2423283fb191a9e82b104762b77ed9710e66",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38971",
+					"10.65.0.27:38971",
+					"172.17.0.1:38971",
+					"172.18.0.1:38971",
+					"172.19.0.1:38971",
+					"172.20.0.1:38971",
+					"172.21.0.1:38971",
+					"172.22.0.1:38971",
+					"172.23.0.1:38971",
+					"172.24.0.1:38971",
+					"172.25.0.1:38971",
+					"172.26.0.1:38971",
+					"172.27.0.1:38971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:20:17.555162972Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8617791652858649,
+				"StableID":   "nUQ58sm1JA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:301b52d255de5155bf0fe437dbc13959816f1ae31366aafddb69e522dba6571d",
+				"DiscoKey":   "discokey:5c583dfe16347d721fe2bfd96c9593016019e9bd14ea24d4be63acc99ed07034",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:40764",
+					"10.65.0.27:40764",
+					"172.17.0.1:40764",
+					"172.18.0.1:40764",
+					"172.19.0.1:40764",
+					"172.20.0.1:40764",
+					"172.21.0.1:40764",
+					"172.22.0.1:40764",
+					"172.23.0.1:40764",
+					"172.24.0.1:40764",
+					"172.25.0.1:40764",
+					"172.26.0.1:40764",
+					"172.27.0.1:40764"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:20:18.087199406Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2636814795393374,
+				"StableID":   "nTX18ueDbM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:55ec9abc4d4be42720a8d87cba7a8743c8d0ee9dc1d49ce069eae57fb62f246c",
+				"DiscoKey":   "discokey:3b8fb56895becef1724c093636ac2ec730bacc423e6c57684f61fb866ab58849",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35228",
+					"10.65.0.27:35228",
+					"172.17.0.1:35228",
+					"172.18.0.1:35228",
+					"172.19.0.1:35228",
+					"172.20.0.1:35228",
+					"172.21.0.1:35228",
+					"172.22.0.1:35228",
+					"172.23.0.1:35228",
+					"172.24.0.1:35228",
+					"172.25.0.1:35228",
+					"172.26.0.1:35228",
+					"172.27.0.1:35228"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:20:18.627896651Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7627873531149537,
+				"StableID":   "najGXaJgZ221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:75e0d4f15bd5339407df21ed895b3e113329a82d5746611816261dfaa5a79c59",
+				"DiscoKey":   "discokey:7690567f0f5dc181b8c6fdfc5b003a161ce3a1d2befe75eb2952a3b5cd948264",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43330",
+					"10.65.0.27:43330",
+					"172.17.0.1:43330",
+					"172.18.0.1:43330",
+					"172.19.0.1:43330",
+					"172.20.0.1:43330",
+					"172.21.0.1:43330",
+					"172.22.0.1:43330",
+					"172.23.0.1:43330",
+					"172.24.0.1:43330",
+					"172.25.0.1:43330",
+					"172.26.0.1:43330",
+					"172.27.0.1:43330"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:20:19.183110945Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8570237187749009,
+				"StableID":   "nczCthbUv921CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5a1a1fd1951cf4e6dce860f46d77baded0e023223abff26ecda38d139dd83c72",
+				"DiscoKey":   "discokey:16e8d2427e69b9d2cac1673da23765fa701b04a5ce3d28530f70b820741dc90c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:51710",
+					"10.65.0.27:51710",
+					"172.17.0.1:51710",
+					"172.18.0.1:51710",
+					"172.19.0.1:51710",
+					"172.20.0.1:51710",
+					"172.21.0.1:51710",
+					"172.22.0.1:51710",
+					"172.23.0.1:51710",
+					"172.24.0.1:51710",
+					"172.25.0.1:51710",
+					"172.26.0.1:51710",
+					"172.27.0.1:51710"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:20:19.72301037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5525645567720675,
+				"StableID":   "nriq8gLa9k11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:adccd261ee5560558a2c08fe6d70415ee0c39f3b804d7f872b9503ebd06b445d",
+				"KeyExpiry":  "2026-11-09T09:20:20Z",
+				"DiscoKey":   "discokey:4586ef29b9329cf1a1c6cbcb9f3df9108674160a9fe26ecb48f1d431d7657744",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40287",
+					"10.65.0.27:40287",
+					"172.17.0.1:40287",
+					"172.18.0.1:40287",
+					"172.19.0.1:40287",
+					"172.20.0.1:40287",
+					"172.21.0.1:40287",
+					"172.22.0.1:40287",
+					"172.23.0.1:40287",
+					"172.24.0.1:40287",
+					"172.25.0.1:40287",
+					"172.26.0.1:40287",
+					"172.27.0.1:40287"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:20:20.251293676Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1545417971442506,
+				"StableID":   "nuGs6ZWv4D11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5da9ac437b55667d69d41d8084de52f0c051d481b3cac7100a7de8e067120322",
+				"KeyExpiry":  "2026-11-09T09:20:20Z",
+				"DiscoKey":   "discokey:9d22489b975e567d77dcd2b5823a2a32977c7346dc5b1840c4cba4a220729f68",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60732",
+					"10.65.0.27:60732",
+					"172.17.0.1:60732",
+					"172.18.0.1:60732",
+					"172.19.0.1:60732",
+					"172.20.0.1:60732",
+					"172.21.0.1:60732",
+					"172.22.0.1:60732",
+					"172.23.0.1:60732",
+					"172.24.0.1:60732",
+					"172.25.0.1:60732",
+					"172.26.0.1:60732",
+					"172.27.0.1:60732"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:20:20.802684287Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8839325176815582,
+				"StableID":   "nKjd2r5M2C21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5ccc1e2806b7dba12fb9a1a87a8f0eaf68e13336b8836703c3435ae05bb30761",
+				"KeyExpiry":  "2026-11-09T09:20:21Z",
+				"DiscoKey":   "discokey:4b567c71b0bbb40126611349579c08cca63f90ce7b3753721266cf1a30c1df6e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41279",
+					"10.65.0.27:41279",
+					"172.17.0.1:41279",
+					"172.18.0.1:41279",
+					"172.19.0.1:41279",
+					"172.20.0.1:41279",
+					"172.21.0.1:41279",
+					"172.22.0.1:41279",
+					"172.23.0.1:41279",
+					"172.24.0.1:41279",
+					"172.25.0.1:41279",
+					"172.26.0.1:41279",
+					"172.27.0.1:41279"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:20:21.338069367Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3728127632591665": {
+				"ID":          3728127632591665,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6830305435958871,
+				"StableID":   "n6iR6RYTLv11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       6830305435958871,
+				"Key":        "nodekey:1676c76341ac59f3e5436c2389eb994e0306eb4d24995af57c238ed23999494d",
+				"DiscoKey":   "discokey:0e653906e350a03c3cedd9442690eff3a20d007add6c275a9cf80dc8d388fc38",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33482",
+					"10.65.0.27:33482",
+					"172.17.0.1:33482",
+					"172.18.0.1:33482",
+					"172.19.0.1:33482",
+					"172.20.0.1:33482",
+					"172.21.0.1:33482",
+					"172.22.0.1:33482",
+					"172.23.0.1:33482",
+					"172.24.0.1:33482",
+					"172.25.0.1:33482",
+					"172.26.0.1:33482",
+					"172.27.0.1:33482"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:20:13.793051139Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1676c76341ac59f3e5436c2389eb994e0306eb4d24995af57c238ed23999494d",
+			"MachineKey": "mkey:eb999226eede2e2362e1fa941c7ce3e5869e0a61eadf8c573d6a0bb86370d351",
+			"Peers": [{
+				"ID":         3728127632591665,
+				"StableID":   "nnH6XHbU7W11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0797ee832fe82382a6615c6473fb459180162c3ff4e39648b7f862a2a5b69728",
+				"DiscoKey":   "discokey:3bf1a1b263d46f5efc3cf70eb676068d295c24ab3b7ceac5bf47cf33b387b947",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43932",
+					"10.65.0.27:43932",
+					"172.17.0.1:43932",
+					"172.18.0.1:43932",
+					"172.19.0.1:43932",
+					"172.20.0.1:43932",
+					"172.21.0.1:43932",
+					"172.22.0.1:43932",
+					"172.23.0.1:43932",
+					"172.24.0.1:43932",
+					"172.25.0.1:43932",
+					"172.26.0.1:43932",
+					"172.27.0.1:43932"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 61279},
+					{"Proto": "peerapi6", "Port": 61279}
+				]},
+				"Created":              "2026-05-13T09:20:14.320444224Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5422722565230377,
+				"StableID":   "n4vCr8jxLj11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2d8d4b21ddedd6b252a02d3f99201a1915fe7c3db8d90f760d7def3914bae02c",
+				"DiscoKey":   "discokey:145deabf4a2c0578c9c17c72d9707716f1107557b60ecad31fa043c4bc20b411",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56850",
+					"10.65.0.27:56850",
+					"172.17.0.1:56850",
+					"172.18.0.1:56850",
+					"172.19.0.1:56850",
+					"172.20.0.1:56850",
+					"172.21.0.1:56850",
+					"172.22.0.1:56850",
+					"172.23.0.1:56850",
+					"172.24.0.1:56850",
+					"172.25.0.1:56850",
+					"172.26.0.1:56850",
+					"172.27.0.1:56850"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:20:14.874131744Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         223842005373187,
+				"StableID":   "nN6EW6xNk211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f866d0f9775dc9e6b2dfdf1a990f7c7290860438ffd5aad1ade28dc9f5684574",
+				"DiscoKey":   "discokey:7e6c001fb872587ec1d56ee4959502f8301d9bc3beebc703802591ccd256f96c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58583",
+					"10.65.0.27:58583",
+					"172.17.0.1:58583",
+					"172.18.0.1:58583",
+					"172.19.0.1:58583",
+					"172.20.0.1:58583",
+					"172.21.0.1:58583",
+					"172.22.0.1:58583",
+					"172.23.0.1:58583",
+					"172.24.0.1:58583",
+					"172.25.0.1:58583",
+					"172.26.0.1:58583",
+					"172.27.0.1:58583"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:20:15.40948102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3621397242307042,
+				"StableID":   "nTdoQxx8HV11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31b110aebcd4347f8f8a6026f4a2320aa6744b73e52992be0393fc13f868860a",
+				"DiscoKey":   "discokey:41fe86fa0f5dbce075f479b14c12551dd88cddb6952a72cdd88fd0ae82a94601",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40342",
+					"10.65.0.27:40342",
+					"172.17.0.1:40342",
+					"172.18.0.1:40342",
+					"172.19.0.1:40342",
+					"172.20.0.1:40342",
+					"172.21.0.1:40342",
+					"172.22.0.1:40342",
+					"172.23.0.1:40342",
+					"172.24.0.1:40342",
+					"172.25.0.1:40342",
+					"172.26.0.1:40342",
+					"172.27.0.1:40342"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:20:15.952792861Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6918226251818639,
+				"StableID":   "nLbBXC5H2w11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e761b2e36f09a65b4d8f1131ab0f29ea7239d0827f225a576f4cc83609900d24",
+				"DiscoKey":   "discokey:2e8579339f36c79810d79d625c72432868aac339d087f082b3b18923b465176f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33617",
+					"10.65.0.27:33617",
+					"172.17.0.1:33617",
+					"172.18.0.1:33617",
+					"172.19.0.1:33617",
+					"172.20.0.1:33617",
+					"172.21.0.1:33617",
+					"172.22.0.1:33617",
+					"172.23.0.1:33617",
+					"172.24.0.1:33617",
+					"172.25.0.1:33617",
+					"172.26.0.1:33617",
+					"172.27.0.1:33617"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:20:16.480390963Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5513145568722149,
+				"StableID":   "nLtc2Azu3k11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b7321b72b53ed6d4b99319f01f9078da60d83b36a22957586588fc005dc12349",
+				"DiscoKey":   "discokey:0d5760bad884b761b1d7db181534b466d21d1682fdf136c6619af55ef105fa30",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:56195",
+					"10.65.0.27:56195",
+					"172.17.0.1:56195",
+					"172.18.0.1:56195",
+					"172.19.0.1:56195",
+					"172.20.0.1:56195",
+					"172.21.0.1:56195",
+					"172.22.0.1:56195",
+					"172.23.0.1:56195",
+					"172.24.0.1:56195",
+					"172.25.0.1:56195",
+					"172.26.0.1:56195",
+					"172.27.0.1:56195"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:20:17.022800848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6848992150805548,
+				"StableID":   "nuFW6nQvUv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:899992820f50c78bf4646efad1893b89a60a15df44e06db67d72585791846916",
+				"DiscoKey":   "discokey:a34dd419cb3a8b7b93c3e9cc6c8b2423283fb191a9e82b104762b77ed9710e66",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38971",
+					"10.65.0.27:38971",
+					"172.17.0.1:38971",
+					"172.18.0.1:38971",
+					"172.19.0.1:38971",
+					"172.20.0.1:38971",
+					"172.21.0.1:38971",
+					"172.22.0.1:38971",
+					"172.23.0.1:38971",
+					"172.24.0.1:38971",
+					"172.25.0.1:38971",
+					"172.26.0.1:38971",
+					"172.27.0.1:38971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:20:17.555162972Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8617791652858649,
+				"StableID":   "nUQ58sm1JA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:301b52d255de5155bf0fe437dbc13959816f1ae31366aafddb69e522dba6571d",
+				"DiscoKey":   "discokey:5c583dfe16347d721fe2bfd96c9593016019e9bd14ea24d4be63acc99ed07034",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:40764",
+					"10.65.0.27:40764",
+					"172.17.0.1:40764",
+					"172.18.0.1:40764",
+					"172.19.0.1:40764",
+					"172.20.0.1:40764",
+					"172.21.0.1:40764",
+					"172.22.0.1:40764",
+					"172.23.0.1:40764",
+					"172.24.0.1:40764",
+					"172.25.0.1:40764",
+					"172.26.0.1:40764",
+					"172.27.0.1:40764"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:20:18.087199406Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2636814795393374,
+				"StableID":   "nTX18ueDbM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:55ec9abc4d4be42720a8d87cba7a8743c8d0ee9dc1d49ce069eae57fb62f246c",
+				"DiscoKey":   "discokey:3b8fb56895becef1724c093636ac2ec730bacc423e6c57684f61fb866ab58849",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35228",
+					"10.65.0.27:35228",
+					"172.17.0.1:35228",
+					"172.18.0.1:35228",
+					"172.19.0.1:35228",
+					"172.20.0.1:35228",
+					"172.21.0.1:35228",
+					"172.22.0.1:35228",
+					"172.23.0.1:35228",
+					"172.24.0.1:35228",
+					"172.25.0.1:35228",
+					"172.26.0.1:35228",
+					"172.27.0.1:35228"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:20:18.627896651Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7627873531149537,
+				"StableID":   "najGXaJgZ221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:75e0d4f15bd5339407df21ed895b3e113329a82d5746611816261dfaa5a79c59",
+				"DiscoKey":   "discokey:7690567f0f5dc181b8c6fdfc5b003a161ce3a1d2befe75eb2952a3b5cd948264",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43330",
+					"10.65.0.27:43330",
+					"172.17.0.1:43330",
+					"172.18.0.1:43330",
+					"172.19.0.1:43330",
+					"172.20.0.1:43330",
+					"172.21.0.1:43330",
+					"172.22.0.1:43330",
+					"172.23.0.1:43330",
+					"172.24.0.1:43330",
+					"172.25.0.1:43330",
+					"172.26.0.1:43330",
+					"172.27.0.1:43330"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:20:19.183110945Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8570237187749009,
+				"StableID":   "nczCthbUv921CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5a1a1fd1951cf4e6dce860f46d77baded0e023223abff26ecda38d139dd83c72",
+				"DiscoKey":   "discokey:16e8d2427e69b9d2cac1673da23765fa701b04a5ce3d28530f70b820741dc90c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:51710",
+					"10.65.0.27:51710",
+					"172.17.0.1:51710",
+					"172.18.0.1:51710",
+					"172.19.0.1:51710",
+					"172.20.0.1:51710",
+					"172.21.0.1:51710",
+					"172.22.0.1:51710",
+					"172.23.0.1:51710",
+					"172.24.0.1:51710",
+					"172.25.0.1:51710",
+					"172.26.0.1:51710",
+					"172.27.0.1:51710"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:20:19.72301037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5525645567720675,
+				"StableID":   "nriq8gLa9k11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:adccd261ee5560558a2c08fe6d70415ee0c39f3b804d7f872b9503ebd06b445d",
+				"KeyExpiry":  "2026-11-09T09:20:20Z",
+				"DiscoKey":   "discokey:4586ef29b9329cf1a1c6cbcb9f3df9108674160a9fe26ecb48f1d431d7657744",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40287",
+					"10.65.0.27:40287",
+					"172.17.0.1:40287",
+					"172.18.0.1:40287",
+					"172.19.0.1:40287",
+					"172.20.0.1:40287",
+					"172.21.0.1:40287",
+					"172.22.0.1:40287",
+					"172.23.0.1:40287",
+					"172.24.0.1:40287",
+					"172.25.0.1:40287",
+					"172.26.0.1:40287",
+					"172.27.0.1:40287"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:20:20.251293676Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1545417971442506,
+				"StableID":   "nuGs6ZWv4D11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5da9ac437b55667d69d41d8084de52f0c051d481b3cac7100a7de8e067120322",
+				"KeyExpiry":  "2026-11-09T09:20:20Z",
+				"DiscoKey":   "discokey:9d22489b975e567d77dcd2b5823a2a32977c7346dc5b1840c4cba4a220729f68",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60732",
+					"10.65.0.27:60732",
+					"172.17.0.1:60732",
+					"172.18.0.1:60732",
+					"172.19.0.1:60732",
+					"172.20.0.1:60732",
+					"172.21.0.1:60732",
+					"172.22.0.1:60732",
+					"172.23.0.1:60732",
+					"172.24.0.1:60732",
+					"172.25.0.1:60732",
+					"172.26.0.1:60732",
+					"172.27.0.1:60732"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:20:20.802684287Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8839325176815582,
+				"StableID":   "nKjd2r5M2C21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5ccc1e2806b7dba12fb9a1a87a8f0eaf68e13336b8836703c3435ae05bb30761",
+				"KeyExpiry":  "2026-11-09T09:20:21Z",
+				"DiscoKey":   "discokey:4b567c71b0bbb40126611349579c08cca63f90ce7b3753721266cf1a30c1df6e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41279",
+					"10.65.0.27:41279",
+					"172.17.0.1:41279",
+					"172.18.0.1:41279",
+					"172.19.0.1:41279",
+					"172.20.0.1:41279",
+					"172.21.0.1:41279",
+					"172.22.0.1:41279",
+					"172.23.0.1:41279",
+					"172.24.0.1:41279",
+					"172.25.0.1:41279",
+					"172.26.0.1:41279",
+					"172.27.0.1:41279"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:20:21.338069367Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6830305435958871": {
+				"ID":          6830305435958871,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3621397242307042,
+				"StableID":   "nTdoQxx8HV11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       3621397242307042,
+				"Key":        "nodekey:31b110aebcd4347f8f8a6026f4a2320aa6744b73e52992be0393fc13f868860a",
+				"DiscoKey":   "discokey:41fe86fa0f5dbce075f479b14c12551dd88cddb6952a72cdd88fd0ae82a94601",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40342",
+					"10.65.0.27:40342",
+					"172.17.0.1:40342",
+					"172.18.0.1:40342",
+					"172.19.0.1:40342",
+					"172.20.0.1:40342",
+					"172.21.0.1:40342",
+					"172.22.0.1:40342",
+					"172.23.0.1:40342",
+					"172.24.0.1:40342",
+					"172.25.0.1:40342",
+					"172.26.0.1:40342",
+					"172.27.0.1:40342"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:20:15.952792861Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:31b110aebcd4347f8f8a6026f4a2320aa6744b73e52992be0393fc13f868860a",
+			"MachineKey": "mkey:0c4456401d465890309f164c093c97a5027618dc8b47724b0dc6feceed140f1d",
+			"Peers": [{
+				"ID":         6830305435958871,
+				"StableID":   "n6iR6RYTLv11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1676c76341ac59f3e5436c2389eb994e0306eb4d24995af57c238ed23999494d",
+				"DiscoKey":   "discokey:0e653906e350a03c3cedd9442690eff3a20d007add6c275a9cf80dc8d388fc38",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33482",
+					"10.65.0.27:33482",
+					"172.17.0.1:33482",
+					"172.18.0.1:33482",
+					"172.19.0.1:33482",
+					"172.20.0.1:33482",
+					"172.21.0.1:33482",
+					"172.22.0.1:33482",
+					"172.23.0.1:33482",
+					"172.24.0.1:33482",
+					"172.25.0.1:33482",
+					"172.26.0.1:33482",
+					"172.27.0.1:33482"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:20:13.793051139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3728127632591665,
+				"StableID":   "nnH6XHbU7W11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0797ee832fe82382a6615c6473fb459180162c3ff4e39648b7f862a2a5b69728",
+				"DiscoKey":   "discokey:3bf1a1b263d46f5efc3cf70eb676068d295c24ab3b7ceac5bf47cf33b387b947",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43932",
+					"10.65.0.27:43932",
+					"172.17.0.1:43932",
+					"172.18.0.1:43932",
+					"172.19.0.1:43932",
+					"172.20.0.1:43932",
+					"172.21.0.1:43932",
+					"172.22.0.1:43932",
+					"172.23.0.1:43932",
+					"172.24.0.1:43932",
+					"172.25.0.1:43932",
+					"172.26.0.1:43932",
+					"172.27.0.1:43932"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 61279},
+					{"Proto": "peerapi6", "Port": 61279}
+				]},
+				"Created":              "2026-05-13T09:20:14.320444224Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5422722565230377,
+				"StableID":   "n4vCr8jxLj11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2d8d4b21ddedd6b252a02d3f99201a1915fe7c3db8d90f760d7def3914bae02c",
+				"DiscoKey":   "discokey:145deabf4a2c0578c9c17c72d9707716f1107557b60ecad31fa043c4bc20b411",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56850",
+					"10.65.0.27:56850",
+					"172.17.0.1:56850",
+					"172.18.0.1:56850",
+					"172.19.0.1:56850",
+					"172.20.0.1:56850",
+					"172.21.0.1:56850",
+					"172.22.0.1:56850",
+					"172.23.0.1:56850",
+					"172.24.0.1:56850",
+					"172.25.0.1:56850",
+					"172.26.0.1:56850",
+					"172.27.0.1:56850"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:20:14.874131744Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         223842005373187,
+				"StableID":   "nN6EW6xNk211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f866d0f9775dc9e6b2dfdf1a990f7c7290860438ffd5aad1ade28dc9f5684574",
+				"DiscoKey":   "discokey:7e6c001fb872587ec1d56ee4959502f8301d9bc3beebc703802591ccd256f96c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58583",
+					"10.65.0.27:58583",
+					"172.17.0.1:58583",
+					"172.18.0.1:58583",
+					"172.19.0.1:58583",
+					"172.20.0.1:58583",
+					"172.21.0.1:58583",
+					"172.22.0.1:58583",
+					"172.23.0.1:58583",
+					"172.24.0.1:58583",
+					"172.25.0.1:58583",
+					"172.26.0.1:58583",
+					"172.27.0.1:58583"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:20:15.40948102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6918226251818639,
+				"StableID":   "nLbBXC5H2w11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e761b2e36f09a65b4d8f1131ab0f29ea7239d0827f225a576f4cc83609900d24",
+				"DiscoKey":   "discokey:2e8579339f36c79810d79d625c72432868aac339d087f082b3b18923b465176f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33617",
+					"10.65.0.27:33617",
+					"172.17.0.1:33617",
+					"172.18.0.1:33617",
+					"172.19.0.1:33617",
+					"172.20.0.1:33617",
+					"172.21.0.1:33617",
+					"172.22.0.1:33617",
+					"172.23.0.1:33617",
+					"172.24.0.1:33617",
+					"172.25.0.1:33617",
+					"172.26.0.1:33617",
+					"172.27.0.1:33617"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:20:16.480390963Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5513145568722149,
+				"StableID":   "nLtc2Azu3k11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b7321b72b53ed6d4b99319f01f9078da60d83b36a22957586588fc005dc12349",
+				"DiscoKey":   "discokey:0d5760bad884b761b1d7db181534b466d21d1682fdf136c6619af55ef105fa30",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:56195",
+					"10.65.0.27:56195",
+					"172.17.0.1:56195",
+					"172.18.0.1:56195",
+					"172.19.0.1:56195",
+					"172.20.0.1:56195",
+					"172.21.0.1:56195",
+					"172.22.0.1:56195",
+					"172.23.0.1:56195",
+					"172.24.0.1:56195",
+					"172.25.0.1:56195",
+					"172.26.0.1:56195",
+					"172.27.0.1:56195"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:20:17.022800848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6848992150805548,
+				"StableID":   "nuFW6nQvUv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:899992820f50c78bf4646efad1893b89a60a15df44e06db67d72585791846916",
+				"DiscoKey":   "discokey:a34dd419cb3a8b7b93c3e9cc6c8b2423283fb191a9e82b104762b77ed9710e66",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38971",
+					"10.65.0.27:38971",
+					"172.17.0.1:38971",
+					"172.18.0.1:38971",
+					"172.19.0.1:38971",
+					"172.20.0.1:38971",
+					"172.21.0.1:38971",
+					"172.22.0.1:38971",
+					"172.23.0.1:38971",
+					"172.24.0.1:38971",
+					"172.25.0.1:38971",
+					"172.26.0.1:38971",
+					"172.27.0.1:38971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:20:17.555162972Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8617791652858649,
+				"StableID":   "nUQ58sm1JA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:301b52d255de5155bf0fe437dbc13959816f1ae31366aafddb69e522dba6571d",
+				"DiscoKey":   "discokey:5c583dfe16347d721fe2bfd96c9593016019e9bd14ea24d4be63acc99ed07034",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:40764",
+					"10.65.0.27:40764",
+					"172.17.0.1:40764",
+					"172.18.0.1:40764",
+					"172.19.0.1:40764",
+					"172.20.0.1:40764",
+					"172.21.0.1:40764",
+					"172.22.0.1:40764",
+					"172.23.0.1:40764",
+					"172.24.0.1:40764",
+					"172.25.0.1:40764",
+					"172.26.0.1:40764",
+					"172.27.0.1:40764"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:20:18.087199406Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2636814795393374,
+				"StableID":   "nTX18ueDbM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:55ec9abc4d4be42720a8d87cba7a8743c8d0ee9dc1d49ce069eae57fb62f246c",
+				"DiscoKey":   "discokey:3b8fb56895becef1724c093636ac2ec730bacc423e6c57684f61fb866ab58849",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35228",
+					"10.65.0.27:35228",
+					"172.17.0.1:35228",
+					"172.18.0.1:35228",
+					"172.19.0.1:35228",
+					"172.20.0.1:35228",
+					"172.21.0.1:35228",
+					"172.22.0.1:35228",
+					"172.23.0.1:35228",
+					"172.24.0.1:35228",
+					"172.25.0.1:35228",
+					"172.26.0.1:35228",
+					"172.27.0.1:35228"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:20:18.627896651Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7627873531149537,
+				"StableID":   "najGXaJgZ221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:75e0d4f15bd5339407df21ed895b3e113329a82d5746611816261dfaa5a79c59",
+				"DiscoKey":   "discokey:7690567f0f5dc181b8c6fdfc5b003a161ce3a1d2befe75eb2952a3b5cd948264",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43330",
+					"10.65.0.27:43330",
+					"172.17.0.1:43330",
+					"172.18.0.1:43330",
+					"172.19.0.1:43330",
+					"172.20.0.1:43330",
+					"172.21.0.1:43330",
+					"172.22.0.1:43330",
+					"172.23.0.1:43330",
+					"172.24.0.1:43330",
+					"172.25.0.1:43330",
+					"172.26.0.1:43330",
+					"172.27.0.1:43330"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:20:19.183110945Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8570237187749009,
+				"StableID":   "nczCthbUv921CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5a1a1fd1951cf4e6dce860f46d77baded0e023223abff26ecda38d139dd83c72",
+				"DiscoKey":   "discokey:16e8d2427e69b9d2cac1673da23765fa701b04a5ce3d28530f70b820741dc90c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:51710",
+					"10.65.0.27:51710",
+					"172.17.0.1:51710",
+					"172.18.0.1:51710",
+					"172.19.0.1:51710",
+					"172.20.0.1:51710",
+					"172.21.0.1:51710",
+					"172.22.0.1:51710",
+					"172.23.0.1:51710",
+					"172.24.0.1:51710",
+					"172.25.0.1:51710",
+					"172.26.0.1:51710",
+					"172.27.0.1:51710"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:20:19.72301037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5525645567720675,
+				"StableID":   "nriq8gLa9k11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:adccd261ee5560558a2c08fe6d70415ee0c39f3b804d7f872b9503ebd06b445d",
+				"KeyExpiry":  "2026-11-09T09:20:20Z",
+				"DiscoKey":   "discokey:4586ef29b9329cf1a1c6cbcb9f3df9108674160a9fe26ecb48f1d431d7657744",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40287",
+					"10.65.0.27:40287",
+					"172.17.0.1:40287",
+					"172.18.0.1:40287",
+					"172.19.0.1:40287",
+					"172.20.0.1:40287",
+					"172.21.0.1:40287",
+					"172.22.0.1:40287",
+					"172.23.0.1:40287",
+					"172.24.0.1:40287",
+					"172.25.0.1:40287",
+					"172.26.0.1:40287",
+					"172.27.0.1:40287"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:20:20.251293676Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1545417971442506,
+				"StableID":   "nuGs6ZWv4D11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5da9ac437b55667d69d41d8084de52f0c051d481b3cac7100a7de8e067120322",
+				"KeyExpiry":  "2026-11-09T09:20:20Z",
+				"DiscoKey":   "discokey:9d22489b975e567d77dcd2b5823a2a32977c7346dc5b1840c4cba4a220729f68",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60732",
+					"10.65.0.27:60732",
+					"172.17.0.1:60732",
+					"172.18.0.1:60732",
+					"172.19.0.1:60732",
+					"172.20.0.1:60732",
+					"172.21.0.1:60732",
+					"172.22.0.1:60732",
+					"172.23.0.1:60732",
+					"172.24.0.1:60732",
+					"172.25.0.1:60732",
+					"172.26.0.1:60732",
+					"172.27.0.1:60732"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:20:20.802684287Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8839325176815582,
+				"StableID":   "nKjd2r5M2C21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5ccc1e2806b7dba12fb9a1a87a8f0eaf68e13336b8836703c3435ae05bb30761",
+				"KeyExpiry":  "2026-11-09T09:20:21Z",
+				"DiscoKey":   "discokey:4b567c71b0bbb40126611349579c08cca63f90ce7b3753721266cf1a30c1df6e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41279",
+					"10.65.0.27:41279",
+					"172.17.0.1:41279",
+					"172.18.0.1:41279",
+					"172.19.0.1:41279",
+					"172.20.0.1:41279",
+					"172.21.0.1:41279",
+					"172.22.0.1:41279",
+					"172.23.0.1:41279",
+					"172.24.0.1:41279",
+					"172.25.0.1:41279",
+					"172.26.0.1:41279",
+					"172.27.0.1:41279"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:20:21.338069367Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3621397242307042": {
+				"ID":          3621397242307042,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         223842005373187,
+				"StableID":   "nN6EW6xNk211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       223842005373187,
+				"Key":        "nodekey:f866d0f9775dc9e6b2dfdf1a990f7c7290860438ffd5aad1ade28dc9f5684574",
+				"DiscoKey":   "discokey:7e6c001fb872587ec1d56ee4959502f8301d9bc3beebc703802591ccd256f96c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58583",
+					"10.65.0.27:58583",
+					"172.17.0.1:58583",
+					"172.18.0.1:58583",
+					"172.19.0.1:58583",
+					"172.20.0.1:58583",
+					"172.21.0.1:58583",
+					"172.22.0.1:58583",
+					"172.23.0.1:58583",
+					"172.24.0.1:58583",
+					"172.25.0.1:58583",
+					"172.26.0.1:58583",
+					"172.27.0.1:58583"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:20:15.40948102Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f866d0f9775dc9e6b2dfdf1a990f7c7290860438ffd5aad1ade28dc9f5684574",
+			"MachineKey": "mkey:b12459bc4b647c1d66e901189bdc8b440084ec552a85ae512644888d299e9a37",
+			"Peers": [{
+				"ID":         6830305435958871,
+				"StableID":   "n6iR6RYTLv11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1676c76341ac59f3e5436c2389eb994e0306eb4d24995af57c238ed23999494d",
+				"DiscoKey":   "discokey:0e653906e350a03c3cedd9442690eff3a20d007add6c275a9cf80dc8d388fc38",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33482",
+					"10.65.0.27:33482",
+					"172.17.0.1:33482",
+					"172.18.0.1:33482",
+					"172.19.0.1:33482",
+					"172.20.0.1:33482",
+					"172.21.0.1:33482",
+					"172.22.0.1:33482",
+					"172.23.0.1:33482",
+					"172.24.0.1:33482",
+					"172.25.0.1:33482",
+					"172.26.0.1:33482",
+					"172.27.0.1:33482"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:20:13.793051139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3728127632591665,
+				"StableID":   "nnH6XHbU7W11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0797ee832fe82382a6615c6473fb459180162c3ff4e39648b7f862a2a5b69728",
+				"DiscoKey":   "discokey:3bf1a1b263d46f5efc3cf70eb676068d295c24ab3b7ceac5bf47cf33b387b947",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43932",
+					"10.65.0.27:43932",
+					"172.17.0.1:43932",
+					"172.18.0.1:43932",
+					"172.19.0.1:43932",
+					"172.20.0.1:43932",
+					"172.21.0.1:43932",
+					"172.22.0.1:43932",
+					"172.23.0.1:43932",
+					"172.24.0.1:43932",
+					"172.25.0.1:43932",
+					"172.26.0.1:43932",
+					"172.27.0.1:43932"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 61279},
+					{"Proto": "peerapi6", "Port": 61279}
+				]},
+				"Created":              "2026-05-13T09:20:14.320444224Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5422722565230377,
+				"StableID":   "n4vCr8jxLj11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2d8d4b21ddedd6b252a02d3f99201a1915fe7c3db8d90f760d7def3914bae02c",
+				"DiscoKey":   "discokey:145deabf4a2c0578c9c17c72d9707716f1107557b60ecad31fa043c4bc20b411",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56850",
+					"10.65.0.27:56850",
+					"172.17.0.1:56850",
+					"172.18.0.1:56850",
+					"172.19.0.1:56850",
+					"172.20.0.1:56850",
+					"172.21.0.1:56850",
+					"172.22.0.1:56850",
+					"172.23.0.1:56850",
+					"172.24.0.1:56850",
+					"172.25.0.1:56850",
+					"172.26.0.1:56850",
+					"172.27.0.1:56850"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:20:14.874131744Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3621397242307042,
+				"StableID":   "nTdoQxx8HV11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31b110aebcd4347f8f8a6026f4a2320aa6744b73e52992be0393fc13f868860a",
+				"DiscoKey":   "discokey:41fe86fa0f5dbce075f479b14c12551dd88cddb6952a72cdd88fd0ae82a94601",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40342",
+					"10.65.0.27:40342",
+					"172.17.0.1:40342",
+					"172.18.0.1:40342",
+					"172.19.0.1:40342",
+					"172.20.0.1:40342",
+					"172.21.0.1:40342",
+					"172.22.0.1:40342",
+					"172.23.0.1:40342",
+					"172.24.0.1:40342",
+					"172.25.0.1:40342",
+					"172.26.0.1:40342",
+					"172.27.0.1:40342"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:20:15.952792861Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6918226251818639,
+				"StableID":   "nLbBXC5H2w11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e761b2e36f09a65b4d8f1131ab0f29ea7239d0827f225a576f4cc83609900d24",
+				"DiscoKey":   "discokey:2e8579339f36c79810d79d625c72432868aac339d087f082b3b18923b465176f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33617",
+					"10.65.0.27:33617",
+					"172.17.0.1:33617",
+					"172.18.0.1:33617",
+					"172.19.0.1:33617",
+					"172.20.0.1:33617",
+					"172.21.0.1:33617",
+					"172.22.0.1:33617",
+					"172.23.0.1:33617",
+					"172.24.0.1:33617",
+					"172.25.0.1:33617",
+					"172.26.0.1:33617",
+					"172.27.0.1:33617"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:20:16.480390963Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5513145568722149,
+				"StableID":   "nLtc2Azu3k11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b7321b72b53ed6d4b99319f01f9078da60d83b36a22957586588fc005dc12349",
+				"DiscoKey":   "discokey:0d5760bad884b761b1d7db181534b466d21d1682fdf136c6619af55ef105fa30",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:56195",
+					"10.65.0.27:56195",
+					"172.17.0.1:56195",
+					"172.18.0.1:56195",
+					"172.19.0.1:56195",
+					"172.20.0.1:56195",
+					"172.21.0.1:56195",
+					"172.22.0.1:56195",
+					"172.23.0.1:56195",
+					"172.24.0.1:56195",
+					"172.25.0.1:56195",
+					"172.26.0.1:56195",
+					"172.27.0.1:56195"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:20:17.022800848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6848992150805548,
+				"StableID":   "nuFW6nQvUv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:899992820f50c78bf4646efad1893b89a60a15df44e06db67d72585791846916",
+				"DiscoKey":   "discokey:a34dd419cb3a8b7b93c3e9cc6c8b2423283fb191a9e82b104762b77ed9710e66",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38971",
+					"10.65.0.27:38971",
+					"172.17.0.1:38971",
+					"172.18.0.1:38971",
+					"172.19.0.1:38971",
+					"172.20.0.1:38971",
+					"172.21.0.1:38971",
+					"172.22.0.1:38971",
+					"172.23.0.1:38971",
+					"172.24.0.1:38971",
+					"172.25.0.1:38971",
+					"172.26.0.1:38971",
+					"172.27.0.1:38971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:20:17.555162972Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8617791652858649,
+				"StableID":   "nUQ58sm1JA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:301b52d255de5155bf0fe437dbc13959816f1ae31366aafddb69e522dba6571d",
+				"DiscoKey":   "discokey:5c583dfe16347d721fe2bfd96c9593016019e9bd14ea24d4be63acc99ed07034",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:40764",
+					"10.65.0.27:40764",
+					"172.17.0.1:40764",
+					"172.18.0.1:40764",
+					"172.19.0.1:40764",
+					"172.20.0.1:40764",
+					"172.21.0.1:40764",
+					"172.22.0.1:40764",
+					"172.23.0.1:40764",
+					"172.24.0.1:40764",
+					"172.25.0.1:40764",
+					"172.26.0.1:40764",
+					"172.27.0.1:40764"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:20:18.087199406Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2636814795393374,
+				"StableID":   "nTX18ueDbM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:55ec9abc4d4be42720a8d87cba7a8743c8d0ee9dc1d49ce069eae57fb62f246c",
+				"DiscoKey":   "discokey:3b8fb56895becef1724c093636ac2ec730bacc423e6c57684f61fb866ab58849",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35228",
+					"10.65.0.27:35228",
+					"172.17.0.1:35228",
+					"172.18.0.1:35228",
+					"172.19.0.1:35228",
+					"172.20.0.1:35228",
+					"172.21.0.1:35228",
+					"172.22.0.1:35228",
+					"172.23.0.1:35228",
+					"172.24.0.1:35228",
+					"172.25.0.1:35228",
+					"172.26.0.1:35228",
+					"172.27.0.1:35228"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:20:18.627896651Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7627873531149537,
+				"StableID":   "najGXaJgZ221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:75e0d4f15bd5339407df21ed895b3e113329a82d5746611816261dfaa5a79c59",
+				"DiscoKey":   "discokey:7690567f0f5dc181b8c6fdfc5b003a161ce3a1d2befe75eb2952a3b5cd948264",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43330",
+					"10.65.0.27:43330",
+					"172.17.0.1:43330",
+					"172.18.0.1:43330",
+					"172.19.0.1:43330",
+					"172.20.0.1:43330",
+					"172.21.0.1:43330",
+					"172.22.0.1:43330",
+					"172.23.0.1:43330",
+					"172.24.0.1:43330",
+					"172.25.0.1:43330",
+					"172.26.0.1:43330",
+					"172.27.0.1:43330"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:20:19.183110945Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8570237187749009,
+				"StableID":   "nczCthbUv921CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5a1a1fd1951cf4e6dce860f46d77baded0e023223abff26ecda38d139dd83c72",
+				"DiscoKey":   "discokey:16e8d2427e69b9d2cac1673da23765fa701b04a5ce3d28530f70b820741dc90c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:51710",
+					"10.65.0.27:51710",
+					"172.17.0.1:51710",
+					"172.18.0.1:51710",
+					"172.19.0.1:51710",
+					"172.20.0.1:51710",
+					"172.21.0.1:51710",
+					"172.22.0.1:51710",
+					"172.23.0.1:51710",
+					"172.24.0.1:51710",
+					"172.25.0.1:51710",
+					"172.26.0.1:51710",
+					"172.27.0.1:51710"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:20:19.72301037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5525645567720675,
+				"StableID":   "nriq8gLa9k11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:adccd261ee5560558a2c08fe6d70415ee0c39f3b804d7f872b9503ebd06b445d",
+				"KeyExpiry":  "2026-11-09T09:20:20Z",
+				"DiscoKey":   "discokey:4586ef29b9329cf1a1c6cbcb9f3df9108674160a9fe26ecb48f1d431d7657744",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40287",
+					"10.65.0.27:40287",
+					"172.17.0.1:40287",
+					"172.18.0.1:40287",
+					"172.19.0.1:40287",
+					"172.20.0.1:40287",
+					"172.21.0.1:40287",
+					"172.22.0.1:40287",
+					"172.23.0.1:40287",
+					"172.24.0.1:40287",
+					"172.25.0.1:40287",
+					"172.26.0.1:40287",
+					"172.27.0.1:40287"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:20:20.251293676Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1545417971442506,
+				"StableID":   "nuGs6ZWv4D11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5da9ac437b55667d69d41d8084de52f0c051d481b3cac7100a7de8e067120322",
+				"KeyExpiry":  "2026-11-09T09:20:20Z",
+				"DiscoKey":   "discokey:9d22489b975e567d77dcd2b5823a2a32977c7346dc5b1840c4cba4a220729f68",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60732",
+					"10.65.0.27:60732",
+					"172.17.0.1:60732",
+					"172.18.0.1:60732",
+					"172.19.0.1:60732",
+					"172.20.0.1:60732",
+					"172.21.0.1:60732",
+					"172.22.0.1:60732",
+					"172.23.0.1:60732",
+					"172.24.0.1:60732",
+					"172.25.0.1:60732",
+					"172.26.0.1:60732",
+					"172.27.0.1:60732"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:20:20.802684287Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8839325176815582,
+				"StableID":   "nKjd2r5M2C21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5ccc1e2806b7dba12fb9a1a87a8f0eaf68e13336b8836703c3435ae05bb30761",
+				"KeyExpiry":  "2026-11-09T09:20:21Z",
+				"DiscoKey":   "discokey:4b567c71b0bbb40126611349579c08cca63f90ce7b3753721266cf1a30c1df6e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41279",
+					"10.65.0.27:41279",
+					"172.17.0.1:41279",
+					"172.18.0.1:41279",
+					"172.19.0.1:41279",
+					"172.20.0.1:41279",
+					"172.21.0.1:41279",
+					"172.22.0.1:41279",
+					"172.23.0.1:41279",
+					"172.24.0.1:41279",
+					"172.25.0.1:41279",
+					"172.26.0.1:41279",
+					"172.27.0.1:41279"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:20:21.338069367Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "223842005373187": {
+				"ID":          223842005373187,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5513145568722149,
+				"StableID":   "nLtc2Azu3k11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       5513145568722149,
+				"Key":        "nodekey:b7321b72b53ed6d4b99319f01f9078da60d83b36a22957586588fc005dc12349",
+				"DiscoKey":   "discokey:0d5760bad884b761b1d7db181534b466d21d1682fdf136c6619af55ef105fa30",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:56195",
+					"10.65.0.27:56195",
+					"172.17.0.1:56195",
+					"172.18.0.1:56195",
+					"172.19.0.1:56195",
+					"172.20.0.1:56195",
+					"172.21.0.1:56195",
+					"172.22.0.1:56195",
+					"172.23.0.1:56195",
+					"172.24.0.1:56195",
+					"172.25.0.1:56195",
+					"172.26.0.1:56195",
+					"172.27.0.1:56195"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:20:17.022800848Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b7321b72b53ed6d4b99319f01f9078da60d83b36a22957586588fc005dc12349",
+			"MachineKey": "mkey:7977bed9e59db3cdef0b4e0a8f499840b301e7ec6bf59904bb9fff742b1bde2c",
+			"Peers": [{
+				"ID":         6830305435958871,
+				"StableID":   "n6iR6RYTLv11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1676c76341ac59f3e5436c2389eb994e0306eb4d24995af57c238ed23999494d",
+				"DiscoKey":   "discokey:0e653906e350a03c3cedd9442690eff3a20d007add6c275a9cf80dc8d388fc38",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33482",
+					"10.65.0.27:33482",
+					"172.17.0.1:33482",
+					"172.18.0.1:33482",
+					"172.19.0.1:33482",
+					"172.20.0.1:33482",
+					"172.21.0.1:33482",
+					"172.22.0.1:33482",
+					"172.23.0.1:33482",
+					"172.24.0.1:33482",
+					"172.25.0.1:33482",
+					"172.26.0.1:33482",
+					"172.27.0.1:33482"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:20:13.793051139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3728127632591665,
+				"StableID":   "nnH6XHbU7W11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0797ee832fe82382a6615c6473fb459180162c3ff4e39648b7f862a2a5b69728",
+				"DiscoKey":   "discokey:3bf1a1b263d46f5efc3cf70eb676068d295c24ab3b7ceac5bf47cf33b387b947",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43932",
+					"10.65.0.27:43932",
+					"172.17.0.1:43932",
+					"172.18.0.1:43932",
+					"172.19.0.1:43932",
+					"172.20.0.1:43932",
+					"172.21.0.1:43932",
+					"172.22.0.1:43932",
+					"172.23.0.1:43932",
+					"172.24.0.1:43932",
+					"172.25.0.1:43932",
+					"172.26.0.1:43932",
+					"172.27.0.1:43932"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 61279},
+					{"Proto": "peerapi6", "Port": 61279}
+				]},
+				"Created":              "2026-05-13T09:20:14.320444224Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5422722565230377,
+				"StableID":   "n4vCr8jxLj11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2d8d4b21ddedd6b252a02d3f99201a1915fe7c3db8d90f760d7def3914bae02c",
+				"DiscoKey":   "discokey:145deabf4a2c0578c9c17c72d9707716f1107557b60ecad31fa043c4bc20b411",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56850",
+					"10.65.0.27:56850",
+					"172.17.0.1:56850",
+					"172.18.0.1:56850",
+					"172.19.0.1:56850",
+					"172.20.0.1:56850",
+					"172.21.0.1:56850",
+					"172.22.0.1:56850",
+					"172.23.0.1:56850",
+					"172.24.0.1:56850",
+					"172.25.0.1:56850",
+					"172.26.0.1:56850",
+					"172.27.0.1:56850"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:20:14.874131744Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         223842005373187,
+				"StableID":   "nN6EW6xNk211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f866d0f9775dc9e6b2dfdf1a990f7c7290860438ffd5aad1ade28dc9f5684574",
+				"DiscoKey":   "discokey:7e6c001fb872587ec1d56ee4959502f8301d9bc3beebc703802591ccd256f96c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58583",
+					"10.65.0.27:58583",
+					"172.17.0.1:58583",
+					"172.18.0.1:58583",
+					"172.19.0.1:58583",
+					"172.20.0.1:58583",
+					"172.21.0.1:58583",
+					"172.22.0.1:58583",
+					"172.23.0.1:58583",
+					"172.24.0.1:58583",
+					"172.25.0.1:58583",
+					"172.26.0.1:58583",
+					"172.27.0.1:58583"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:20:15.40948102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3621397242307042,
+				"StableID":   "nTdoQxx8HV11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31b110aebcd4347f8f8a6026f4a2320aa6744b73e52992be0393fc13f868860a",
+				"DiscoKey":   "discokey:41fe86fa0f5dbce075f479b14c12551dd88cddb6952a72cdd88fd0ae82a94601",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40342",
+					"10.65.0.27:40342",
+					"172.17.0.1:40342",
+					"172.18.0.1:40342",
+					"172.19.0.1:40342",
+					"172.20.0.1:40342",
+					"172.21.0.1:40342",
+					"172.22.0.1:40342",
+					"172.23.0.1:40342",
+					"172.24.0.1:40342",
+					"172.25.0.1:40342",
+					"172.26.0.1:40342",
+					"172.27.0.1:40342"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:20:15.952792861Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6918226251818639,
+				"StableID":   "nLbBXC5H2w11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e761b2e36f09a65b4d8f1131ab0f29ea7239d0827f225a576f4cc83609900d24",
+				"DiscoKey":   "discokey:2e8579339f36c79810d79d625c72432868aac339d087f082b3b18923b465176f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33617",
+					"10.65.0.27:33617",
+					"172.17.0.1:33617",
+					"172.18.0.1:33617",
+					"172.19.0.1:33617",
+					"172.20.0.1:33617",
+					"172.21.0.1:33617",
+					"172.22.0.1:33617",
+					"172.23.0.1:33617",
+					"172.24.0.1:33617",
+					"172.25.0.1:33617",
+					"172.26.0.1:33617",
+					"172.27.0.1:33617"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:20:16.480390963Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6848992150805548,
+				"StableID":   "nuFW6nQvUv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:899992820f50c78bf4646efad1893b89a60a15df44e06db67d72585791846916",
+				"DiscoKey":   "discokey:a34dd419cb3a8b7b93c3e9cc6c8b2423283fb191a9e82b104762b77ed9710e66",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38971",
+					"10.65.0.27:38971",
+					"172.17.0.1:38971",
+					"172.18.0.1:38971",
+					"172.19.0.1:38971",
+					"172.20.0.1:38971",
+					"172.21.0.1:38971",
+					"172.22.0.1:38971",
+					"172.23.0.1:38971",
+					"172.24.0.1:38971",
+					"172.25.0.1:38971",
+					"172.26.0.1:38971",
+					"172.27.0.1:38971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:20:17.555162972Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8617791652858649,
+				"StableID":   "nUQ58sm1JA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:301b52d255de5155bf0fe437dbc13959816f1ae31366aafddb69e522dba6571d",
+				"DiscoKey":   "discokey:5c583dfe16347d721fe2bfd96c9593016019e9bd14ea24d4be63acc99ed07034",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:40764",
+					"10.65.0.27:40764",
+					"172.17.0.1:40764",
+					"172.18.0.1:40764",
+					"172.19.0.1:40764",
+					"172.20.0.1:40764",
+					"172.21.0.1:40764",
+					"172.22.0.1:40764",
+					"172.23.0.1:40764",
+					"172.24.0.1:40764",
+					"172.25.0.1:40764",
+					"172.26.0.1:40764",
+					"172.27.0.1:40764"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:20:18.087199406Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2636814795393374,
+				"StableID":   "nTX18ueDbM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:55ec9abc4d4be42720a8d87cba7a8743c8d0ee9dc1d49ce069eae57fb62f246c",
+				"DiscoKey":   "discokey:3b8fb56895becef1724c093636ac2ec730bacc423e6c57684f61fb866ab58849",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35228",
+					"10.65.0.27:35228",
+					"172.17.0.1:35228",
+					"172.18.0.1:35228",
+					"172.19.0.1:35228",
+					"172.20.0.1:35228",
+					"172.21.0.1:35228",
+					"172.22.0.1:35228",
+					"172.23.0.1:35228",
+					"172.24.0.1:35228",
+					"172.25.0.1:35228",
+					"172.26.0.1:35228",
+					"172.27.0.1:35228"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:20:18.627896651Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7627873531149537,
+				"StableID":   "najGXaJgZ221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:75e0d4f15bd5339407df21ed895b3e113329a82d5746611816261dfaa5a79c59",
+				"DiscoKey":   "discokey:7690567f0f5dc181b8c6fdfc5b003a161ce3a1d2befe75eb2952a3b5cd948264",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43330",
+					"10.65.0.27:43330",
+					"172.17.0.1:43330",
+					"172.18.0.1:43330",
+					"172.19.0.1:43330",
+					"172.20.0.1:43330",
+					"172.21.0.1:43330",
+					"172.22.0.1:43330",
+					"172.23.0.1:43330",
+					"172.24.0.1:43330",
+					"172.25.0.1:43330",
+					"172.26.0.1:43330",
+					"172.27.0.1:43330"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:20:19.183110945Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8570237187749009,
+				"StableID":   "nczCthbUv921CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5a1a1fd1951cf4e6dce860f46d77baded0e023223abff26ecda38d139dd83c72",
+				"DiscoKey":   "discokey:16e8d2427e69b9d2cac1673da23765fa701b04a5ce3d28530f70b820741dc90c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:51710",
+					"10.65.0.27:51710",
+					"172.17.0.1:51710",
+					"172.18.0.1:51710",
+					"172.19.0.1:51710",
+					"172.20.0.1:51710",
+					"172.21.0.1:51710",
+					"172.22.0.1:51710",
+					"172.23.0.1:51710",
+					"172.24.0.1:51710",
+					"172.25.0.1:51710",
+					"172.26.0.1:51710",
+					"172.27.0.1:51710"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:20:19.72301037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5525645567720675,
+				"StableID":   "nriq8gLa9k11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:adccd261ee5560558a2c08fe6d70415ee0c39f3b804d7f872b9503ebd06b445d",
+				"KeyExpiry":  "2026-11-09T09:20:20Z",
+				"DiscoKey":   "discokey:4586ef29b9329cf1a1c6cbcb9f3df9108674160a9fe26ecb48f1d431d7657744",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40287",
+					"10.65.0.27:40287",
+					"172.17.0.1:40287",
+					"172.18.0.1:40287",
+					"172.19.0.1:40287",
+					"172.20.0.1:40287",
+					"172.21.0.1:40287",
+					"172.22.0.1:40287",
+					"172.23.0.1:40287",
+					"172.24.0.1:40287",
+					"172.25.0.1:40287",
+					"172.26.0.1:40287",
+					"172.27.0.1:40287"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:20:20.251293676Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1545417971442506,
+				"StableID":   "nuGs6ZWv4D11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5da9ac437b55667d69d41d8084de52f0c051d481b3cac7100a7de8e067120322",
+				"KeyExpiry":  "2026-11-09T09:20:20Z",
+				"DiscoKey":   "discokey:9d22489b975e567d77dcd2b5823a2a32977c7346dc5b1840c4cba4a220729f68",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60732",
+					"10.65.0.27:60732",
+					"172.17.0.1:60732",
+					"172.18.0.1:60732",
+					"172.19.0.1:60732",
+					"172.20.0.1:60732",
+					"172.21.0.1:60732",
+					"172.22.0.1:60732",
+					"172.23.0.1:60732",
+					"172.24.0.1:60732",
+					"172.25.0.1:60732",
+					"172.26.0.1:60732",
+					"172.27.0.1:60732"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:20:20.802684287Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8839325176815582,
+				"StableID":   "nKjd2r5M2C21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5ccc1e2806b7dba12fb9a1a87a8f0eaf68e13336b8836703c3435ae05bb30761",
+				"KeyExpiry":  "2026-11-09T09:20:21Z",
+				"DiscoKey":   "discokey:4b567c71b0bbb40126611349579c08cca63f90ce7b3753721266cf1a30c1df6e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41279",
+					"10.65.0.27:41279",
+					"172.17.0.1:41279",
+					"172.18.0.1:41279",
+					"172.19.0.1:41279",
+					"172.20.0.1:41279",
+					"172.21.0.1:41279",
+					"172.22.0.1:41279",
+					"172.23.0.1:41279",
+					"172.24.0.1:41279",
+					"172.25.0.1:41279",
+					"172.26.0.1:41279",
+					"172.27.0.1:41279"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:20:21.338069367Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5513145568722149": {
+				"ID":          5513145568722149,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8617791652858649,
+				"StableID":   "nUQ58sm1JA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       8617791652858649,
+				"Key":        "nodekey:301b52d255de5155bf0fe437dbc13959816f1ae31366aafddb69e522dba6571d",
+				"DiscoKey":   "discokey:5c583dfe16347d721fe2bfd96c9593016019e9bd14ea24d4be63acc99ed07034",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:40764",
+					"10.65.0.27:40764",
+					"172.17.0.1:40764",
+					"172.18.0.1:40764",
+					"172.19.0.1:40764",
+					"172.20.0.1:40764",
+					"172.21.0.1:40764",
+					"172.22.0.1:40764",
+					"172.23.0.1:40764",
+					"172.24.0.1:40764",
+					"172.25.0.1:40764",
+					"172.26.0.1:40764",
+					"172.27.0.1:40764"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:20:18.087199406Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:301b52d255de5155bf0fe437dbc13959816f1ae31366aafddb69e522dba6571d",
+			"MachineKey": "mkey:eb40c8f91c70965f002ed207609c607216dc773a079138284117ce6cc8237342",
+			"Peers": [{
+				"ID":         6830305435958871,
+				"StableID":   "n6iR6RYTLv11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1676c76341ac59f3e5436c2389eb994e0306eb4d24995af57c238ed23999494d",
+				"DiscoKey":   "discokey:0e653906e350a03c3cedd9442690eff3a20d007add6c275a9cf80dc8d388fc38",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33482",
+					"10.65.0.27:33482",
+					"172.17.0.1:33482",
+					"172.18.0.1:33482",
+					"172.19.0.1:33482",
+					"172.20.0.1:33482",
+					"172.21.0.1:33482",
+					"172.22.0.1:33482",
+					"172.23.0.1:33482",
+					"172.24.0.1:33482",
+					"172.25.0.1:33482",
+					"172.26.0.1:33482",
+					"172.27.0.1:33482"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:20:13.793051139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3728127632591665,
+				"StableID":   "nnH6XHbU7W11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0797ee832fe82382a6615c6473fb459180162c3ff4e39648b7f862a2a5b69728",
+				"DiscoKey":   "discokey:3bf1a1b263d46f5efc3cf70eb676068d295c24ab3b7ceac5bf47cf33b387b947",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43932",
+					"10.65.0.27:43932",
+					"172.17.0.1:43932",
+					"172.18.0.1:43932",
+					"172.19.0.1:43932",
+					"172.20.0.1:43932",
+					"172.21.0.1:43932",
+					"172.22.0.1:43932",
+					"172.23.0.1:43932",
+					"172.24.0.1:43932",
+					"172.25.0.1:43932",
+					"172.26.0.1:43932",
+					"172.27.0.1:43932"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 61279},
+					{"Proto": "peerapi6", "Port": 61279}
+				]},
+				"Created":              "2026-05-13T09:20:14.320444224Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5422722565230377,
+				"StableID":   "n4vCr8jxLj11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2d8d4b21ddedd6b252a02d3f99201a1915fe7c3db8d90f760d7def3914bae02c",
+				"DiscoKey":   "discokey:145deabf4a2c0578c9c17c72d9707716f1107557b60ecad31fa043c4bc20b411",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56850",
+					"10.65.0.27:56850",
+					"172.17.0.1:56850",
+					"172.18.0.1:56850",
+					"172.19.0.1:56850",
+					"172.20.0.1:56850",
+					"172.21.0.1:56850",
+					"172.22.0.1:56850",
+					"172.23.0.1:56850",
+					"172.24.0.1:56850",
+					"172.25.0.1:56850",
+					"172.26.0.1:56850",
+					"172.27.0.1:56850"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:20:14.874131744Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         223842005373187,
+				"StableID":   "nN6EW6xNk211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f866d0f9775dc9e6b2dfdf1a990f7c7290860438ffd5aad1ade28dc9f5684574",
+				"DiscoKey":   "discokey:7e6c001fb872587ec1d56ee4959502f8301d9bc3beebc703802591ccd256f96c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58583",
+					"10.65.0.27:58583",
+					"172.17.0.1:58583",
+					"172.18.0.1:58583",
+					"172.19.0.1:58583",
+					"172.20.0.1:58583",
+					"172.21.0.1:58583",
+					"172.22.0.1:58583",
+					"172.23.0.1:58583",
+					"172.24.0.1:58583",
+					"172.25.0.1:58583",
+					"172.26.0.1:58583",
+					"172.27.0.1:58583"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:20:15.40948102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3621397242307042,
+				"StableID":   "nTdoQxx8HV11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31b110aebcd4347f8f8a6026f4a2320aa6744b73e52992be0393fc13f868860a",
+				"DiscoKey":   "discokey:41fe86fa0f5dbce075f479b14c12551dd88cddb6952a72cdd88fd0ae82a94601",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40342",
+					"10.65.0.27:40342",
+					"172.17.0.1:40342",
+					"172.18.0.1:40342",
+					"172.19.0.1:40342",
+					"172.20.0.1:40342",
+					"172.21.0.1:40342",
+					"172.22.0.1:40342",
+					"172.23.0.1:40342",
+					"172.24.0.1:40342",
+					"172.25.0.1:40342",
+					"172.26.0.1:40342",
+					"172.27.0.1:40342"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:20:15.952792861Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6918226251818639,
+				"StableID":   "nLbBXC5H2w11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e761b2e36f09a65b4d8f1131ab0f29ea7239d0827f225a576f4cc83609900d24",
+				"DiscoKey":   "discokey:2e8579339f36c79810d79d625c72432868aac339d087f082b3b18923b465176f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33617",
+					"10.65.0.27:33617",
+					"172.17.0.1:33617",
+					"172.18.0.1:33617",
+					"172.19.0.1:33617",
+					"172.20.0.1:33617",
+					"172.21.0.1:33617",
+					"172.22.0.1:33617",
+					"172.23.0.1:33617",
+					"172.24.0.1:33617",
+					"172.25.0.1:33617",
+					"172.26.0.1:33617",
+					"172.27.0.1:33617"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:20:16.480390963Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5513145568722149,
+				"StableID":   "nLtc2Azu3k11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b7321b72b53ed6d4b99319f01f9078da60d83b36a22957586588fc005dc12349",
+				"DiscoKey":   "discokey:0d5760bad884b761b1d7db181534b466d21d1682fdf136c6619af55ef105fa30",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:56195",
+					"10.65.0.27:56195",
+					"172.17.0.1:56195",
+					"172.18.0.1:56195",
+					"172.19.0.1:56195",
+					"172.20.0.1:56195",
+					"172.21.0.1:56195",
+					"172.22.0.1:56195",
+					"172.23.0.1:56195",
+					"172.24.0.1:56195",
+					"172.25.0.1:56195",
+					"172.26.0.1:56195",
+					"172.27.0.1:56195"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:20:17.022800848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6848992150805548,
+				"StableID":   "nuFW6nQvUv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:899992820f50c78bf4646efad1893b89a60a15df44e06db67d72585791846916",
+				"DiscoKey":   "discokey:a34dd419cb3a8b7b93c3e9cc6c8b2423283fb191a9e82b104762b77ed9710e66",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38971",
+					"10.65.0.27:38971",
+					"172.17.0.1:38971",
+					"172.18.0.1:38971",
+					"172.19.0.1:38971",
+					"172.20.0.1:38971",
+					"172.21.0.1:38971",
+					"172.22.0.1:38971",
+					"172.23.0.1:38971",
+					"172.24.0.1:38971",
+					"172.25.0.1:38971",
+					"172.26.0.1:38971",
+					"172.27.0.1:38971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:20:17.555162972Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2636814795393374,
+				"StableID":   "nTX18ueDbM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:55ec9abc4d4be42720a8d87cba7a8743c8d0ee9dc1d49ce069eae57fb62f246c",
+				"DiscoKey":   "discokey:3b8fb56895becef1724c093636ac2ec730bacc423e6c57684f61fb866ab58849",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35228",
+					"10.65.0.27:35228",
+					"172.17.0.1:35228",
+					"172.18.0.1:35228",
+					"172.19.0.1:35228",
+					"172.20.0.1:35228",
+					"172.21.0.1:35228",
+					"172.22.0.1:35228",
+					"172.23.0.1:35228",
+					"172.24.0.1:35228",
+					"172.25.0.1:35228",
+					"172.26.0.1:35228",
+					"172.27.0.1:35228"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:20:18.627896651Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7627873531149537,
+				"StableID":   "najGXaJgZ221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:75e0d4f15bd5339407df21ed895b3e113329a82d5746611816261dfaa5a79c59",
+				"DiscoKey":   "discokey:7690567f0f5dc181b8c6fdfc5b003a161ce3a1d2befe75eb2952a3b5cd948264",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43330",
+					"10.65.0.27:43330",
+					"172.17.0.1:43330",
+					"172.18.0.1:43330",
+					"172.19.0.1:43330",
+					"172.20.0.1:43330",
+					"172.21.0.1:43330",
+					"172.22.0.1:43330",
+					"172.23.0.1:43330",
+					"172.24.0.1:43330",
+					"172.25.0.1:43330",
+					"172.26.0.1:43330",
+					"172.27.0.1:43330"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:20:19.183110945Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8570237187749009,
+				"StableID":   "nczCthbUv921CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5a1a1fd1951cf4e6dce860f46d77baded0e023223abff26ecda38d139dd83c72",
+				"DiscoKey":   "discokey:16e8d2427e69b9d2cac1673da23765fa701b04a5ce3d28530f70b820741dc90c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:51710",
+					"10.65.0.27:51710",
+					"172.17.0.1:51710",
+					"172.18.0.1:51710",
+					"172.19.0.1:51710",
+					"172.20.0.1:51710",
+					"172.21.0.1:51710",
+					"172.22.0.1:51710",
+					"172.23.0.1:51710",
+					"172.24.0.1:51710",
+					"172.25.0.1:51710",
+					"172.26.0.1:51710",
+					"172.27.0.1:51710"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:20:19.72301037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5525645567720675,
+				"StableID":   "nriq8gLa9k11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:adccd261ee5560558a2c08fe6d70415ee0c39f3b804d7f872b9503ebd06b445d",
+				"KeyExpiry":  "2026-11-09T09:20:20Z",
+				"DiscoKey":   "discokey:4586ef29b9329cf1a1c6cbcb9f3df9108674160a9fe26ecb48f1d431d7657744",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40287",
+					"10.65.0.27:40287",
+					"172.17.0.1:40287",
+					"172.18.0.1:40287",
+					"172.19.0.1:40287",
+					"172.20.0.1:40287",
+					"172.21.0.1:40287",
+					"172.22.0.1:40287",
+					"172.23.0.1:40287",
+					"172.24.0.1:40287",
+					"172.25.0.1:40287",
+					"172.26.0.1:40287",
+					"172.27.0.1:40287"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:20:20.251293676Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1545417971442506,
+				"StableID":   "nuGs6ZWv4D11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5da9ac437b55667d69d41d8084de52f0c051d481b3cac7100a7de8e067120322",
+				"KeyExpiry":  "2026-11-09T09:20:20Z",
+				"DiscoKey":   "discokey:9d22489b975e567d77dcd2b5823a2a32977c7346dc5b1840c4cba4a220729f68",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60732",
+					"10.65.0.27:60732",
+					"172.17.0.1:60732",
+					"172.18.0.1:60732",
+					"172.19.0.1:60732",
+					"172.20.0.1:60732",
+					"172.21.0.1:60732",
+					"172.22.0.1:60732",
+					"172.23.0.1:60732",
+					"172.24.0.1:60732",
+					"172.25.0.1:60732",
+					"172.26.0.1:60732",
+					"172.27.0.1:60732"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:20:20.802684287Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8839325176815582,
+				"StableID":   "nKjd2r5M2C21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5ccc1e2806b7dba12fb9a1a87a8f0eaf68e13336b8836703c3435ae05bb30761",
+				"KeyExpiry":  "2026-11-09T09:20:21Z",
+				"DiscoKey":   "discokey:4b567c71b0bbb40126611349579c08cca63f90ce7b3753721266cf1a30c1df6e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41279",
+					"10.65.0.27:41279",
+					"172.17.0.1:41279",
+					"172.18.0.1:41279",
+					"172.19.0.1:41279",
+					"172.20.0.1:41279",
+					"172.21.0.1:41279",
+					"172.22.0.1:41279",
+					"172.23.0.1:41279",
+					"172.24.0.1:41279",
+					"172.25.0.1:41279",
+					"172.26.0.1:41279",
+					"172.27.0.1:41279"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:20:21.338069367Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8617791652858649": {
+				"ID":          8617791652858649,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1545417971442506,
+				"StableID":   "nuGs6ZWv4D11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5da9ac437b55667d69d41d8084de52f0c051d481b3cac7100a7de8e067120322",
+				"KeyExpiry":  "2026-11-09T09:20:20Z",
+				"DiscoKey":   "discokey:9d22489b975e567d77dcd2b5823a2a32977c7346dc5b1840c4cba4a220729f68",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60732",
+					"10.65.0.27:60732",
+					"172.17.0.1:60732",
+					"172.18.0.1:60732",
+					"172.19.0.1:60732",
+					"172.20.0.1:60732",
+					"172.21.0.1:60732",
+					"172.22.0.1:60732",
+					"172.23.0.1:60732",
+					"172.24.0.1:60732",
+					"172.25.0.1:60732",
+					"172.26.0.1:60732",
+					"172.27.0.1:60732"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:20:20.802684287Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5da9ac437b55667d69d41d8084de52f0c051d481b3cac7100a7de8e067120322",
+			"MachineKey": "mkey:fdc22e2b068b310040cc10b1bf23632fce203678fcf3893aee7ec23a135eed31",
+			"Peers": [{
+				"ID":         6830305435958871,
+				"StableID":   "n6iR6RYTLv11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1676c76341ac59f3e5436c2389eb994e0306eb4d24995af57c238ed23999494d",
+				"DiscoKey":   "discokey:0e653906e350a03c3cedd9442690eff3a20d007add6c275a9cf80dc8d388fc38",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33482",
+					"10.65.0.27:33482",
+					"172.17.0.1:33482",
+					"172.18.0.1:33482",
+					"172.19.0.1:33482",
+					"172.20.0.1:33482",
+					"172.21.0.1:33482",
+					"172.22.0.1:33482",
+					"172.23.0.1:33482",
+					"172.24.0.1:33482",
+					"172.25.0.1:33482",
+					"172.26.0.1:33482",
+					"172.27.0.1:33482"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:20:13.793051139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3728127632591665,
+				"StableID":   "nnH6XHbU7W11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0797ee832fe82382a6615c6473fb459180162c3ff4e39648b7f862a2a5b69728",
+				"DiscoKey":   "discokey:3bf1a1b263d46f5efc3cf70eb676068d295c24ab3b7ceac5bf47cf33b387b947",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43932",
+					"10.65.0.27:43932",
+					"172.17.0.1:43932",
+					"172.18.0.1:43932",
+					"172.19.0.1:43932",
+					"172.20.0.1:43932",
+					"172.21.0.1:43932",
+					"172.22.0.1:43932",
+					"172.23.0.1:43932",
+					"172.24.0.1:43932",
+					"172.25.0.1:43932",
+					"172.26.0.1:43932",
+					"172.27.0.1:43932"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 61279},
+					{"Proto": "peerapi6", "Port": 61279}
+				]},
+				"Created":              "2026-05-13T09:20:14.320444224Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5422722565230377,
+				"StableID":   "n4vCr8jxLj11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2d8d4b21ddedd6b252a02d3f99201a1915fe7c3db8d90f760d7def3914bae02c",
+				"DiscoKey":   "discokey:145deabf4a2c0578c9c17c72d9707716f1107557b60ecad31fa043c4bc20b411",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56850",
+					"10.65.0.27:56850",
+					"172.17.0.1:56850",
+					"172.18.0.1:56850",
+					"172.19.0.1:56850",
+					"172.20.0.1:56850",
+					"172.21.0.1:56850",
+					"172.22.0.1:56850",
+					"172.23.0.1:56850",
+					"172.24.0.1:56850",
+					"172.25.0.1:56850",
+					"172.26.0.1:56850",
+					"172.27.0.1:56850"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:20:14.874131744Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         223842005373187,
+				"StableID":   "nN6EW6xNk211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f866d0f9775dc9e6b2dfdf1a990f7c7290860438ffd5aad1ade28dc9f5684574",
+				"DiscoKey":   "discokey:7e6c001fb872587ec1d56ee4959502f8301d9bc3beebc703802591ccd256f96c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58583",
+					"10.65.0.27:58583",
+					"172.17.0.1:58583",
+					"172.18.0.1:58583",
+					"172.19.0.1:58583",
+					"172.20.0.1:58583",
+					"172.21.0.1:58583",
+					"172.22.0.1:58583",
+					"172.23.0.1:58583",
+					"172.24.0.1:58583",
+					"172.25.0.1:58583",
+					"172.26.0.1:58583",
+					"172.27.0.1:58583"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:20:15.40948102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3621397242307042,
+				"StableID":   "nTdoQxx8HV11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31b110aebcd4347f8f8a6026f4a2320aa6744b73e52992be0393fc13f868860a",
+				"DiscoKey":   "discokey:41fe86fa0f5dbce075f479b14c12551dd88cddb6952a72cdd88fd0ae82a94601",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40342",
+					"10.65.0.27:40342",
+					"172.17.0.1:40342",
+					"172.18.0.1:40342",
+					"172.19.0.1:40342",
+					"172.20.0.1:40342",
+					"172.21.0.1:40342",
+					"172.22.0.1:40342",
+					"172.23.0.1:40342",
+					"172.24.0.1:40342",
+					"172.25.0.1:40342",
+					"172.26.0.1:40342",
+					"172.27.0.1:40342"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:20:15.952792861Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6918226251818639,
+				"StableID":   "nLbBXC5H2w11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e761b2e36f09a65b4d8f1131ab0f29ea7239d0827f225a576f4cc83609900d24",
+				"DiscoKey":   "discokey:2e8579339f36c79810d79d625c72432868aac339d087f082b3b18923b465176f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33617",
+					"10.65.0.27:33617",
+					"172.17.0.1:33617",
+					"172.18.0.1:33617",
+					"172.19.0.1:33617",
+					"172.20.0.1:33617",
+					"172.21.0.1:33617",
+					"172.22.0.1:33617",
+					"172.23.0.1:33617",
+					"172.24.0.1:33617",
+					"172.25.0.1:33617",
+					"172.26.0.1:33617",
+					"172.27.0.1:33617"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:20:16.480390963Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5513145568722149,
+				"StableID":   "nLtc2Azu3k11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b7321b72b53ed6d4b99319f01f9078da60d83b36a22957586588fc005dc12349",
+				"DiscoKey":   "discokey:0d5760bad884b761b1d7db181534b466d21d1682fdf136c6619af55ef105fa30",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:56195",
+					"10.65.0.27:56195",
+					"172.17.0.1:56195",
+					"172.18.0.1:56195",
+					"172.19.0.1:56195",
+					"172.20.0.1:56195",
+					"172.21.0.1:56195",
+					"172.22.0.1:56195",
+					"172.23.0.1:56195",
+					"172.24.0.1:56195",
+					"172.25.0.1:56195",
+					"172.26.0.1:56195",
+					"172.27.0.1:56195"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:20:17.022800848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6848992150805548,
+				"StableID":   "nuFW6nQvUv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:899992820f50c78bf4646efad1893b89a60a15df44e06db67d72585791846916",
+				"DiscoKey":   "discokey:a34dd419cb3a8b7b93c3e9cc6c8b2423283fb191a9e82b104762b77ed9710e66",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38971",
+					"10.65.0.27:38971",
+					"172.17.0.1:38971",
+					"172.18.0.1:38971",
+					"172.19.0.1:38971",
+					"172.20.0.1:38971",
+					"172.21.0.1:38971",
+					"172.22.0.1:38971",
+					"172.23.0.1:38971",
+					"172.24.0.1:38971",
+					"172.25.0.1:38971",
+					"172.26.0.1:38971",
+					"172.27.0.1:38971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:20:17.555162972Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8617791652858649,
+				"StableID":   "nUQ58sm1JA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:301b52d255de5155bf0fe437dbc13959816f1ae31366aafddb69e522dba6571d",
+				"DiscoKey":   "discokey:5c583dfe16347d721fe2bfd96c9593016019e9bd14ea24d4be63acc99ed07034",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:40764",
+					"10.65.0.27:40764",
+					"172.17.0.1:40764",
+					"172.18.0.1:40764",
+					"172.19.0.1:40764",
+					"172.20.0.1:40764",
+					"172.21.0.1:40764",
+					"172.22.0.1:40764",
+					"172.23.0.1:40764",
+					"172.24.0.1:40764",
+					"172.25.0.1:40764",
+					"172.26.0.1:40764",
+					"172.27.0.1:40764"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:20:18.087199406Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2636814795393374,
+				"StableID":   "nTX18ueDbM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:55ec9abc4d4be42720a8d87cba7a8743c8d0ee9dc1d49ce069eae57fb62f246c",
+				"DiscoKey":   "discokey:3b8fb56895becef1724c093636ac2ec730bacc423e6c57684f61fb866ab58849",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35228",
+					"10.65.0.27:35228",
+					"172.17.0.1:35228",
+					"172.18.0.1:35228",
+					"172.19.0.1:35228",
+					"172.20.0.1:35228",
+					"172.21.0.1:35228",
+					"172.22.0.1:35228",
+					"172.23.0.1:35228",
+					"172.24.0.1:35228",
+					"172.25.0.1:35228",
+					"172.26.0.1:35228",
+					"172.27.0.1:35228"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:20:18.627896651Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7627873531149537,
+				"StableID":   "najGXaJgZ221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:75e0d4f15bd5339407df21ed895b3e113329a82d5746611816261dfaa5a79c59",
+				"DiscoKey":   "discokey:7690567f0f5dc181b8c6fdfc5b003a161ce3a1d2befe75eb2952a3b5cd948264",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43330",
+					"10.65.0.27:43330",
+					"172.17.0.1:43330",
+					"172.18.0.1:43330",
+					"172.19.0.1:43330",
+					"172.20.0.1:43330",
+					"172.21.0.1:43330",
+					"172.22.0.1:43330",
+					"172.23.0.1:43330",
+					"172.24.0.1:43330",
+					"172.25.0.1:43330",
+					"172.26.0.1:43330",
+					"172.27.0.1:43330"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:20:19.183110945Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8570237187749009,
+				"StableID":   "nczCthbUv921CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5a1a1fd1951cf4e6dce860f46d77baded0e023223abff26ecda38d139dd83c72",
+				"DiscoKey":   "discokey:16e8d2427e69b9d2cac1673da23765fa701b04a5ce3d28530f70b820741dc90c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:51710",
+					"10.65.0.27:51710",
+					"172.17.0.1:51710",
+					"172.18.0.1:51710",
+					"172.19.0.1:51710",
+					"172.20.0.1:51710",
+					"172.21.0.1:51710",
+					"172.22.0.1:51710",
+					"172.23.0.1:51710",
+					"172.24.0.1:51710",
+					"172.25.0.1:51710",
+					"172.26.0.1:51710",
+					"172.27.0.1:51710"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:20:19.72301037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5525645567720675,
+				"StableID":   "nriq8gLa9k11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:adccd261ee5560558a2c08fe6d70415ee0c39f3b804d7f872b9503ebd06b445d",
+				"KeyExpiry":  "2026-11-09T09:20:20Z",
+				"DiscoKey":   "discokey:4586ef29b9329cf1a1c6cbcb9f3df9108674160a9fe26ecb48f1d431d7657744",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40287",
+					"10.65.0.27:40287",
+					"172.17.0.1:40287",
+					"172.18.0.1:40287",
+					"172.19.0.1:40287",
+					"172.20.0.1:40287",
+					"172.21.0.1:40287",
+					"172.22.0.1:40287",
+					"172.23.0.1:40287",
+					"172.24.0.1:40287",
+					"172.25.0.1:40287",
+					"172.26.0.1:40287",
+					"172.27.0.1:40287"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:20:20.251293676Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8839325176815582,
+				"StableID":   "nKjd2r5M2C21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5ccc1e2806b7dba12fb9a1a87a8f0eaf68e13336b8836703c3435ae05bb30761",
+				"KeyExpiry":  "2026-11-09T09:20:21Z",
+				"DiscoKey":   "discokey:4b567c71b0bbb40126611349579c08cca63f90ce7b3753721266cf1a30c1df6e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41279",
+					"10.65.0.27:41279",
+					"172.17.0.1:41279",
+					"172.18.0.1:41279",
+					"172.19.0.1:41279",
+					"172.20.0.1:41279",
+					"172.21.0.1:41279",
+					"172.22.0.1:41279",
+					"172.23.0.1:41279",
+					"172.24.0.1:41279",
+					"172.25.0.1:41279",
+					"172.26.0.1:41279",
+					"172.27.0.1:41279"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:20:21.338069367Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2636814795393374,
+				"StableID":   "nTX18ueDbM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       2636814795393374,
+				"Key":        "nodekey:55ec9abc4d4be42720a8d87cba7a8743c8d0ee9dc1d49ce069eae57fb62f246c",
+				"DiscoKey":   "discokey:3b8fb56895becef1724c093636ac2ec730bacc423e6c57684f61fb866ab58849",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:35228",
+					"10.65.0.27:35228",
+					"172.17.0.1:35228",
+					"172.18.0.1:35228",
+					"172.19.0.1:35228",
+					"172.20.0.1:35228",
+					"172.21.0.1:35228",
+					"172.22.0.1:35228",
+					"172.23.0.1:35228",
+					"172.24.0.1:35228",
+					"172.25.0.1:35228",
+					"172.26.0.1:35228",
+					"172.27.0.1:35228"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:20:18.627896651Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:55ec9abc4d4be42720a8d87cba7a8743c8d0ee9dc1d49ce069eae57fb62f246c",
+			"MachineKey": "mkey:1b875dba471a4203c84267dcce4e52ac7cf7eacbcb47583f20942aca3428870c",
+			"Peers": [{
+				"ID":         6830305435958871,
+				"StableID":   "n6iR6RYTLv11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1676c76341ac59f3e5436c2389eb994e0306eb4d24995af57c238ed23999494d",
+				"DiscoKey":   "discokey:0e653906e350a03c3cedd9442690eff3a20d007add6c275a9cf80dc8d388fc38",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33482",
+					"10.65.0.27:33482",
+					"172.17.0.1:33482",
+					"172.18.0.1:33482",
+					"172.19.0.1:33482",
+					"172.20.0.1:33482",
+					"172.21.0.1:33482",
+					"172.22.0.1:33482",
+					"172.23.0.1:33482",
+					"172.24.0.1:33482",
+					"172.25.0.1:33482",
+					"172.26.0.1:33482",
+					"172.27.0.1:33482"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:20:13.793051139Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3728127632591665,
+				"StableID":   "nnH6XHbU7W11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0797ee832fe82382a6615c6473fb459180162c3ff4e39648b7f862a2a5b69728",
+				"DiscoKey":   "discokey:3bf1a1b263d46f5efc3cf70eb676068d295c24ab3b7ceac5bf47cf33b387b947",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43932",
+					"10.65.0.27:43932",
+					"172.17.0.1:43932",
+					"172.18.0.1:43932",
+					"172.19.0.1:43932",
+					"172.20.0.1:43932",
+					"172.21.0.1:43932",
+					"172.22.0.1:43932",
+					"172.23.0.1:43932",
+					"172.24.0.1:43932",
+					"172.25.0.1:43932",
+					"172.26.0.1:43932",
+					"172.27.0.1:43932"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 61279},
+					{"Proto": "peerapi6", "Port": 61279}
+				]},
+				"Created":              "2026-05-13T09:20:14.320444224Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5422722565230377,
+				"StableID":   "n4vCr8jxLj11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2d8d4b21ddedd6b252a02d3f99201a1915fe7c3db8d90f760d7def3914bae02c",
+				"DiscoKey":   "discokey:145deabf4a2c0578c9c17c72d9707716f1107557b60ecad31fa043c4bc20b411",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56850",
+					"10.65.0.27:56850",
+					"172.17.0.1:56850",
+					"172.18.0.1:56850",
+					"172.19.0.1:56850",
+					"172.20.0.1:56850",
+					"172.21.0.1:56850",
+					"172.22.0.1:56850",
+					"172.23.0.1:56850",
+					"172.24.0.1:56850",
+					"172.25.0.1:56850",
+					"172.26.0.1:56850",
+					"172.27.0.1:56850"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:20:14.874131744Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         223842005373187,
+				"StableID":   "nN6EW6xNk211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f866d0f9775dc9e6b2dfdf1a990f7c7290860438ffd5aad1ade28dc9f5684574",
+				"DiscoKey":   "discokey:7e6c001fb872587ec1d56ee4959502f8301d9bc3beebc703802591ccd256f96c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58583",
+					"10.65.0.27:58583",
+					"172.17.0.1:58583",
+					"172.18.0.1:58583",
+					"172.19.0.1:58583",
+					"172.20.0.1:58583",
+					"172.21.0.1:58583",
+					"172.22.0.1:58583",
+					"172.23.0.1:58583",
+					"172.24.0.1:58583",
+					"172.25.0.1:58583",
+					"172.26.0.1:58583",
+					"172.27.0.1:58583"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:20:15.40948102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3621397242307042,
+				"StableID":   "nTdoQxx8HV11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31b110aebcd4347f8f8a6026f4a2320aa6744b73e52992be0393fc13f868860a",
+				"DiscoKey":   "discokey:41fe86fa0f5dbce075f479b14c12551dd88cddb6952a72cdd88fd0ae82a94601",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:40342",
+					"10.65.0.27:40342",
+					"172.17.0.1:40342",
+					"172.18.0.1:40342",
+					"172.19.0.1:40342",
+					"172.20.0.1:40342",
+					"172.21.0.1:40342",
+					"172.22.0.1:40342",
+					"172.23.0.1:40342",
+					"172.24.0.1:40342",
+					"172.25.0.1:40342",
+					"172.26.0.1:40342",
+					"172.27.0.1:40342"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:20:15.952792861Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6918226251818639,
+				"StableID":   "nLbBXC5H2w11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e761b2e36f09a65b4d8f1131ab0f29ea7239d0827f225a576f4cc83609900d24",
+				"DiscoKey":   "discokey:2e8579339f36c79810d79d625c72432868aac339d087f082b3b18923b465176f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33617",
+					"10.65.0.27:33617",
+					"172.17.0.1:33617",
+					"172.18.0.1:33617",
+					"172.19.0.1:33617",
+					"172.20.0.1:33617",
+					"172.21.0.1:33617",
+					"172.22.0.1:33617",
+					"172.23.0.1:33617",
+					"172.24.0.1:33617",
+					"172.25.0.1:33617",
+					"172.26.0.1:33617",
+					"172.27.0.1:33617"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:20:16.480390963Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5513145568722149,
+				"StableID":   "nLtc2Azu3k11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b7321b72b53ed6d4b99319f01f9078da60d83b36a22957586588fc005dc12349",
+				"DiscoKey":   "discokey:0d5760bad884b761b1d7db181534b466d21d1682fdf136c6619af55ef105fa30",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:56195",
+					"10.65.0.27:56195",
+					"172.17.0.1:56195",
+					"172.18.0.1:56195",
+					"172.19.0.1:56195",
+					"172.20.0.1:56195",
+					"172.21.0.1:56195",
+					"172.22.0.1:56195",
+					"172.23.0.1:56195",
+					"172.24.0.1:56195",
+					"172.25.0.1:56195",
+					"172.26.0.1:56195",
+					"172.27.0.1:56195"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:20:17.022800848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6848992150805548,
+				"StableID":   "nuFW6nQvUv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:899992820f50c78bf4646efad1893b89a60a15df44e06db67d72585791846916",
+				"DiscoKey":   "discokey:a34dd419cb3a8b7b93c3e9cc6c8b2423283fb191a9e82b104762b77ed9710e66",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:38971",
+					"10.65.0.27:38971",
+					"172.17.0.1:38971",
+					"172.18.0.1:38971",
+					"172.19.0.1:38971",
+					"172.20.0.1:38971",
+					"172.21.0.1:38971",
+					"172.22.0.1:38971",
+					"172.23.0.1:38971",
+					"172.24.0.1:38971",
+					"172.25.0.1:38971",
+					"172.26.0.1:38971",
+					"172.27.0.1:38971"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:20:17.555162972Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8617791652858649,
+				"StableID":   "nUQ58sm1JA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:301b52d255de5155bf0fe437dbc13959816f1ae31366aafddb69e522dba6571d",
+				"DiscoKey":   "discokey:5c583dfe16347d721fe2bfd96c9593016019e9bd14ea24d4be63acc99ed07034",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:40764",
+					"10.65.0.27:40764",
+					"172.17.0.1:40764",
+					"172.18.0.1:40764",
+					"172.19.0.1:40764",
+					"172.20.0.1:40764",
+					"172.21.0.1:40764",
+					"172.22.0.1:40764",
+					"172.23.0.1:40764",
+					"172.24.0.1:40764",
+					"172.25.0.1:40764",
+					"172.26.0.1:40764",
+					"172.27.0.1:40764"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:20:18.087199406Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7627873531149537,
+				"StableID":   "najGXaJgZ221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:75e0d4f15bd5339407df21ed895b3e113329a82d5746611816261dfaa5a79c59",
+				"DiscoKey":   "discokey:7690567f0f5dc181b8c6fdfc5b003a161ce3a1d2befe75eb2952a3b5cd948264",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43330",
+					"10.65.0.27:43330",
+					"172.17.0.1:43330",
+					"172.18.0.1:43330",
+					"172.19.0.1:43330",
+					"172.20.0.1:43330",
+					"172.21.0.1:43330",
+					"172.22.0.1:43330",
+					"172.23.0.1:43330",
+					"172.24.0.1:43330",
+					"172.25.0.1:43330",
+					"172.26.0.1:43330",
+					"172.27.0.1:43330"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:20:19.183110945Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8570237187749009,
+				"StableID":   "nczCthbUv921CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5a1a1fd1951cf4e6dce860f46d77baded0e023223abff26ecda38d139dd83c72",
+				"DiscoKey":   "discokey:16e8d2427e69b9d2cac1673da23765fa701b04a5ce3d28530f70b820741dc90c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:51710",
+					"10.65.0.27:51710",
+					"172.17.0.1:51710",
+					"172.18.0.1:51710",
+					"172.19.0.1:51710",
+					"172.20.0.1:51710",
+					"172.21.0.1:51710",
+					"172.22.0.1:51710",
+					"172.23.0.1:51710",
+					"172.24.0.1:51710",
+					"172.25.0.1:51710",
+					"172.26.0.1:51710",
+					"172.27.0.1:51710"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:20:19.72301037Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5525645567720675,
+				"StableID":   "nriq8gLa9k11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:adccd261ee5560558a2c08fe6d70415ee0c39f3b804d7f872b9503ebd06b445d",
+				"KeyExpiry":  "2026-11-09T09:20:20Z",
+				"DiscoKey":   "discokey:4586ef29b9329cf1a1c6cbcb9f3df9108674160a9fe26ecb48f1d431d7657744",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40287",
+					"10.65.0.27:40287",
+					"172.17.0.1:40287",
+					"172.18.0.1:40287",
+					"172.19.0.1:40287",
+					"172.20.0.1:40287",
+					"172.21.0.1:40287",
+					"172.22.0.1:40287",
+					"172.23.0.1:40287",
+					"172.24.0.1:40287",
+					"172.25.0.1:40287",
+					"172.26.0.1:40287",
+					"172.27.0.1:40287"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:20:20.251293676Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1545417971442506,
+				"StableID":   "nuGs6ZWv4D11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5da9ac437b55667d69d41d8084de52f0c051d481b3cac7100a7de8e067120322",
+				"KeyExpiry":  "2026-11-09T09:20:20Z",
+				"DiscoKey":   "discokey:9d22489b975e567d77dcd2b5823a2a32977c7346dc5b1840c4cba4a220729f68",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60732",
+					"10.65.0.27:60732",
+					"172.17.0.1:60732",
+					"172.18.0.1:60732",
+					"172.19.0.1:60732",
+					"172.20.0.1:60732",
+					"172.21.0.1:60732",
+					"172.22.0.1:60732",
+					"172.23.0.1:60732",
+					"172.24.0.1:60732",
+					"172.25.0.1:60732",
+					"172.26.0.1:60732",
+					"172.27.0.1:60732"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:20:20.802684287Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8839325176815582,
+				"StableID":   "nKjd2r5M2C21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:5ccc1e2806b7dba12fb9a1a87a8f0eaf68e13336b8836703c3435ae05bb30761",
+				"KeyExpiry":  "2026-11-09T09:20:21Z",
+				"DiscoKey":   "discokey:4b567c71b0bbb40126611349579c08cca63f90ce7b3753721266cf1a30c1df6e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41279",
+					"10.65.0.27:41279",
+					"172.17.0.1:41279",
+					"172.18.0.1:41279",
+					"172.19.0.1:41279",
+					"172.20.0.1:41279",
+					"172.21.0.1:41279",
+					"172.22.0.1:41279",
+					"172.23.0.1:41279",
+					"172.24.0.1:41279",
+					"172.25.0.1:41279",
+					"172.26.0.1:41279",
+					"172.27.0.1:41279"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:20:21.338069367Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2636814795393374": {
+				"ID":          2636814795393374,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-src-empty-group.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-src-empty-group.hujson
@@ -1,0 +1,22105 @@
+// ssh-src-empty-group
+//
+// ssh src = empty group, dst = tag:server
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-13T09:21:06Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-src-empty-group",
+	"description":    "ssh src = empty group, dst = tag:server",
+	"category":       "ssh",
+	"captured_at":    "2026-05-13T09:21:06.611022727Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                      \n  \n                                                                      \n                                                           \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh src = empty group, dst = tag:server\",\n\t\"id\":          \"ssh-src-empty-group\",\n\t\"policy\": {\"groups\": {\"group:empty\": []}, \"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"group:empty\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-edges/ssh-src-empty-group.hujson",
+		"full_policy": {
+			"groups": {"group:empty": []},
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["group:empty"],
+				"users":  ["root"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1500340108592974,
+				"StableID":   "nRGwiePWiC11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1500340108592974,
+				"Key":        "nodekey:005e465b964cc904806f5161328c8f685fd1e56b59f30ea0d13cad619bd75e7b",
+				"DiscoKey":   "discokey:23354def6c19b41d12b50b428bb2b86a4e2cb7471abf9f39a4e93fa76040f810",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:34139",
+					"10.65.0.27:34139",
+					"172.17.0.1:34139",
+					"172.18.0.1:34139",
+					"172.19.0.1:34139",
+					"172.20.0.1:34139",
+					"172.21.0.1:34139",
+					"172.22.0.1:34139",
+					"172.23.0.1:34139",
+					"172.24.0.1:34139",
+					"172.25.0.1:34139",
+					"172.26.0.1:34139",
+					"172.27.0.1:34139",
+					"172.28.0.1:34139"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:21:25.660717434Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:005e465b964cc904806f5161328c8f685fd1e56b59f30ea0d13cad619bd75e7b",
+			"MachineKey": "mkey:6d8572f82dcaa49c4023b37ea4348dd25c9415ab9f3ace844cf1ffb497dfec50",
+			"Peers": [{
+				"ID":         8290277898300682,
+				"StableID":   "nPBh9UYgj721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:daf9699563bb8d8e86135a3eb1c6b4ca20670b36e6a6d87f7984fa2450dfe020",
+				"DiscoKey":   "discokey:cb20bf5e7e12b719e58613631bf8b830411be943c45ab7d2012c0f7256a01c1a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53542",
+					"10.65.0.27:53542",
+					"172.17.0.1:53542",
+					"172.18.0.1:53542",
+					"172.19.0.1:53542",
+					"172.20.0.1:53542",
+					"172.21.0.1:53542",
+					"172.22.0.1:53542",
+					"172.23.0.1:53542",
+					"172.24.0.1:53542",
+					"172.25.0.1:53542",
+					"172.26.0.1:53542",
+					"172.27.0.1:53542",
+					"172.28.0.1:53542"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:21:09.574498768Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3616621037328237,
+				"StableID":   "nvuqX7WyEV11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c2487b3a38488d006f9a28c6d9b90b5afdcc68a260cf02b1b7aa3d559f145e32",
+				"DiscoKey":   "discokey:b6300c737099421c5a52b06c2d6aad403b1f076f0f7debe347671b4eb63a7839",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33348",
+					"10.65.0.27:33348",
+					"172.17.0.1:33348",
+					"172.18.0.1:33348",
+					"172.19.0.1:33348",
+					"172.20.0.1:33348",
+					"172.21.0.1:33348",
+					"172.22.0.1:33348",
+					"172.23.0.1:33348",
+					"172.24.0.1:33348",
+					"172.25.0.1:33348",
+					"172.26.0.1:33348",
+					"172.27.0.1:33348",
+					"172.28.0.1:33348"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:21:15.566085445Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5655179600283341,
+				"StableID":   "nLgQ2myEAm11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:133c74cdf13dcb6f236645b723c019ea0eb574dd2c988e6aaebd0c202f7abc72",
+				"DiscoKey":   "discokey:7ede0fad082f1f4540afd15d339f4f14498fd7a2f6253565fc59cc8020788c3a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57092",
+					"10.65.0.27:57092",
+					"172.17.0.1:57092",
+					"172.18.0.1:57092",
+					"172.19.0.1:57092",
+					"172.20.0.1:57092",
+					"172.21.0.1:57092",
+					"172.22.0.1:57092",
+					"172.23.0.1:57092",
+					"172.24.0.1:57092",
+					"172.25.0.1:57092",
+					"172.26.0.1:57092",
+					"172.27.0.1:57092",
+					"172.28.0.1:57092"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:21:17.347104171Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5800192544056745,
+				"StableID":   "nJRwHvDvHn11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:73aa857fa92ce648735d5f6f595ac8b3078b14a194f56f72cee66647746ac61c",
+				"DiscoKey":   "discokey:ac62f171220e6de996c3a9a4719ae5fcbf913f3fedc5c0a98e110490ab01cf4a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42661",
+					"10.65.0.27:42661",
+					"172.17.0.1:42661",
+					"172.18.0.1:42661",
+					"172.19.0.1:42661",
+					"172.20.0.1:42661",
+					"172.21.0.1:42661",
+					"172.22.0.1:42661",
+					"172.23.0.1:42661",
+					"172.24.0.1:42661",
+					"172.25.0.1:42661",
+					"172.26.0.1:42661",
+					"172.27.0.1:42661",
+					"172.28.0.1:42661"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:21:21.012421424Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4725532368819453,
+				"StableID":   "nWdDctiCud11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec327910540dbdc61464d526ac9800df50d6b956244da10af3ea424102e7d30e",
+				"DiscoKey":   "discokey:4d276da3bd54817b6af5ed9d3da58b57c6a09de2b4bb7f94656e3175bb93175a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58383",
+					"10.65.0.27:58383",
+					"172.17.0.1:58383",
+					"172.18.0.1:58383",
+					"172.19.0.1:58383",
+					"172.20.0.1:58383",
+					"172.21.0.1:58383",
+					"172.22.0.1:58383",
+					"172.23.0.1:58383",
+					"172.24.0.1:58383",
+					"172.25.0.1:58383",
+					"172.26.0.1:58383",
+					"172.27.0.1:58383",
+					"172.28.0.1:58383"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:21:21.550796677Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6882282173853531,
+				"StableID":   "nJSFSBtzjv11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe5dd419cfaf8151c09428107e4ee85c074928fd9f8fe3da73694074121cf72d",
+				"DiscoKey":   "discokey:298f317d964805d70c955707e74cc3a06589f35df730a2211e9d99a2c7f5103a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50289",
+					"10.65.0.27:50289",
+					"172.17.0.1:50289",
+					"172.18.0.1:50289",
+					"172.19.0.1:50289",
+					"172.20.0.1:50289",
+					"172.21.0.1:50289",
+					"172.22.0.1:50289",
+					"172.23.0.1:50289",
+					"172.24.0.1:50289",
+					"172.25.0.1:50289",
+					"172.26.0.1:50289",
+					"172.27.0.1:50289",
+					"172.28.0.1:50289"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:21:22.075465365Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8302794691259322,
+				"StableID":   "nMGMHaLMq721CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc0f150fc848435ae963f263bbb5b44c14b4de07c306da65f1d9d65dba8aa915",
+				"DiscoKey":   "discokey:e715d93aeac9eec6096a3e18131bd442fe35e13a0347123bcfe21723c9cfbc1c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37978",
+					"10.65.0.27:37978",
+					"172.17.0.1:37978",
+					"172.18.0.1:37978",
+					"172.19.0.1:37978",
+					"172.20.0.1:37978",
+					"172.21.0.1:37978",
+					"172.22.0.1:37978",
+					"172.23.0.1:37978",
+					"172.24.0.1:37978",
+					"172.25.0.1:37978",
+					"172.26.0.1:37978",
+					"172.27.0.1:37978",
+					"172.28.0.1:37978"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:21:22.617210394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6814575453737212,
+				"StableID":   "nVZuRpLLDv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db04fe21e83f45ddbed5b8446f6a92caf01754c38ed27c782c26b81abb977210",
+				"DiscoKey":   "discokey:d554e83b854f98f53fbf98046b8bb4d073b7afa017c42441270fdfbfbba39e44",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33457",
+					"10.65.0.27:33457",
+					"172.17.0.1:33457",
+					"172.18.0.1:33457",
+					"172.19.0.1:33457",
+					"172.20.0.1:33457",
+					"172.21.0.1:33457",
+					"172.22.0.1:33457",
+					"172.23.0.1:33457",
+					"172.24.0.1:33457",
+					"172.25.0.1:33457",
+					"172.26.0.1:33457",
+					"172.27.0.1:33457",
+					"172.28.0.1:33457"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:21:23.460129792Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3971972035245068,
+				"StableID":   "nZjmNGyu1Y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:64e3c927a0d8a260091b63aedddce84cff7d3e81f07ea13778ccc698c7e98b43",
+				"DiscoKey":   "discokey:67171f195393cdbd79f7ad13688070985774fe21be0cedac150777af6508354f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38948",
+					"10.65.0.27:38948",
+					"172.17.0.1:38948",
+					"172.18.0.1:38948",
+					"172.19.0.1:38948",
+					"172.20.0.1:38948",
+					"172.21.0.1:38948",
+					"172.22.0.1:38948",
+					"172.23.0.1:38948",
+					"172.24.0.1:38948",
+					"172.25.0.1:38948",
+					"172.26.0.1:38948",
+					"172.27.0.1:38948",
+					"172.28.0.1:38948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:21:23.937568907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4372583465575495,
+				"StableID":   "nELNeUMM9b11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a3e5671fbb6f6c658d6e163b7bd993cced8c022df31b868e10c82fba42286347",
+				"DiscoKey":   "discokey:54b578d48e785aa696d2ee85a5a3bda9a5179f5a57705e00de174e882e2f5071",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51405",
+					"10.65.0.27:51405",
+					"172.17.0.1:51405",
+					"172.18.0.1:51405",
+					"172.19.0.1:51405",
+					"172.20.0.1:51405",
+					"172.21.0.1:51405",
+					"172.22.0.1:51405",
+					"172.23.0.1:51405",
+					"172.24.0.1:51405",
+					"172.25.0.1:51405",
+					"172.26.0.1:51405",
+					"172.27.0.1:51405",
+					"172.28.0.1:51405"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:21:24.602179146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4608126954712804,
+				"StableID":   "nfvWCWg2zc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ed292b4cfa8d08d12bc6fe9b393fad60418df600a2e19127099519a3fa1db3f",
+				"DiscoKey":   "discokey:fb18e1047c814faa1936128cd722a341358c30909e998cbd856d38e7658bc216",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44111",
+					"10.65.0.27:44111",
+					"172.17.0.1:44111",
+					"172.18.0.1:44111",
+					"172.19.0.1:44111",
+					"172.20.0.1:44111",
+					"172.21.0.1:44111",
+					"172.22.0.1:44111",
+					"172.23.0.1:44111",
+					"172.24.0.1:44111",
+					"172.25.0.1:44111",
+					"172.26.0.1:44111",
+					"172.27.0.1:44111",
+					"172.28.0.1:44111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:21:25.133517278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         521955752537854,
+				"StableID":   "ndAuVmtP5511CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:cc439a49e3f189d63a5a8b0deff24686018316cc041e6495c7dbab9074185e52",
+				"KeyExpiry":  "2026-11-09T09:21:26Z",
+				"DiscoKey":   "discokey:9373753ec674e553510849fb70c3d11a030a8ebdb697b79811e40fb34e754b34",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:36848",
+					"10.65.0.27:36848",
+					"172.17.0.1:36848",
+					"172.18.0.1:36848",
+					"172.19.0.1:36848",
+					"172.20.0.1:36848",
+					"172.21.0.1:36848",
+					"172.22.0.1:36848",
+					"172.23.0.1:36848",
+					"172.24.0.1:36848",
+					"172.25.0.1:36848",
+					"172.26.0.1:36848",
+					"172.27.0.1:36848",
+					"172.28.0.1:36848"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:21:26.194723126Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4523172015074948,
+				"StableID":   "nwEe6R4ZKc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:43722a1489ece323af8ed65ad9fef1a309afef19f60109cf84536abd2f108c30",
+				"KeyExpiry":  "2026-11-09T09:21:26Z",
+				"DiscoKey":   "discokey:b905104a3ce14244a835cd8c1bce75dac82376d0fac4110c36a649a3b7f5c456",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49558",
+					"10.65.0.27:49558",
+					"172.17.0.1:49558",
+					"172.18.0.1:49558",
+					"172.19.0.1:49558",
+					"172.20.0.1:49558",
+					"172.21.0.1:49558",
+					"172.22.0.1:49558",
+					"172.23.0.1:49558",
+					"172.24.0.1:49558",
+					"172.25.0.1:49558",
+					"172.26.0.1:49558",
+					"172.27.0.1:49558",
+					"172.28.0.1:49558"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:21:26.723487548Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5848785703371618,
+				"StableID":   "n3V7Pbgvfn11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:61125883643bf13373afbfcc258f7ea148cd326b1273f337857ee86144c0521d",
+				"KeyExpiry":  "2026-11-09T09:21:27Z",
+				"DiscoKey":   "discokey:dc748887d44370c813a5e037e52b40bf597c6088551a43de750344a550be1a55",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55204",
+					"10.65.0.27:55204",
+					"172.17.0.1:55204",
+					"172.18.0.1:55204",
+					"172.19.0.1:55204",
+					"172.20.0.1:55204",
+					"172.21.0.1:55204",
+					"172.22.0.1:55204",
+					"172.23.0.1:55204",
+					"172.24.0.1:55204",
+					"172.25.0.1:55204",
+					"172.26.0.1:55204",
+					"172.27.0.1:55204",
+					"172.28.0.1:55204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:21:27.254674699Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1500340108592974": {
+				"ID":          1500340108592974,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6882282173853531,
+				"StableID":   "nJSFSBtzjv11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       6882282173853531,
+				"Key":        "nodekey:fe5dd419cfaf8151c09428107e4ee85c074928fd9f8fe3da73694074121cf72d",
+				"DiscoKey":   "discokey:298f317d964805d70c955707e74cc3a06589f35df730a2211e9d99a2c7f5103a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50289",
+					"10.65.0.27:50289",
+					"172.17.0.1:50289",
+					"172.18.0.1:50289",
+					"172.19.0.1:50289",
+					"172.20.0.1:50289",
+					"172.21.0.1:50289",
+					"172.22.0.1:50289",
+					"172.23.0.1:50289",
+					"172.24.0.1:50289",
+					"172.25.0.1:50289",
+					"172.26.0.1:50289",
+					"172.27.0.1:50289",
+					"172.28.0.1:50289"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:21:22.075465365Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:fe5dd419cfaf8151c09428107e4ee85c074928fd9f8fe3da73694074121cf72d",
+			"MachineKey": "mkey:1f457381e447f967399fe20bc85dcb9edc5c6b0dc5abbcea77f2e73004d7b86b",
+			"Peers": [{
+				"ID":         8290277898300682,
+				"StableID":   "nPBh9UYgj721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:daf9699563bb8d8e86135a3eb1c6b4ca20670b36e6a6d87f7984fa2450dfe020",
+				"DiscoKey":   "discokey:cb20bf5e7e12b719e58613631bf8b830411be943c45ab7d2012c0f7256a01c1a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53542",
+					"10.65.0.27:53542",
+					"172.17.0.1:53542",
+					"172.18.0.1:53542",
+					"172.19.0.1:53542",
+					"172.20.0.1:53542",
+					"172.21.0.1:53542",
+					"172.22.0.1:53542",
+					"172.23.0.1:53542",
+					"172.24.0.1:53542",
+					"172.25.0.1:53542",
+					"172.26.0.1:53542",
+					"172.27.0.1:53542",
+					"172.28.0.1:53542"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:21:09.574498768Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3616621037328237,
+				"StableID":   "nvuqX7WyEV11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c2487b3a38488d006f9a28c6d9b90b5afdcc68a260cf02b1b7aa3d559f145e32",
+				"DiscoKey":   "discokey:b6300c737099421c5a52b06c2d6aad403b1f076f0f7debe347671b4eb63a7839",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33348",
+					"10.65.0.27:33348",
+					"172.17.0.1:33348",
+					"172.18.0.1:33348",
+					"172.19.0.1:33348",
+					"172.20.0.1:33348",
+					"172.21.0.1:33348",
+					"172.22.0.1:33348",
+					"172.23.0.1:33348",
+					"172.24.0.1:33348",
+					"172.25.0.1:33348",
+					"172.26.0.1:33348",
+					"172.27.0.1:33348",
+					"172.28.0.1:33348"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:21:15.566085445Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5655179600283341,
+				"StableID":   "nLgQ2myEAm11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:133c74cdf13dcb6f236645b723c019ea0eb574dd2c988e6aaebd0c202f7abc72",
+				"DiscoKey":   "discokey:7ede0fad082f1f4540afd15d339f4f14498fd7a2f6253565fc59cc8020788c3a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57092",
+					"10.65.0.27:57092",
+					"172.17.0.1:57092",
+					"172.18.0.1:57092",
+					"172.19.0.1:57092",
+					"172.20.0.1:57092",
+					"172.21.0.1:57092",
+					"172.22.0.1:57092",
+					"172.23.0.1:57092",
+					"172.24.0.1:57092",
+					"172.25.0.1:57092",
+					"172.26.0.1:57092",
+					"172.27.0.1:57092",
+					"172.28.0.1:57092"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:21:17.347104171Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5800192544056745,
+				"StableID":   "nJRwHvDvHn11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:73aa857fa92ce648735d5f6f595ac8b3078b14a194f56f72cee66647746ac61c",
+				"DiscoKey":   "discokey:ac62f171220e6de996c3a9a4719ae5fcbf913f3fedc5c0a98e110490ab01cf4a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42661",
+					"10.65.0.27:42661",
+					"172.17.0.1:42661",
+					"172.18.0.1:42661",
+					"172.19.0.1:42661",
+					"172.20.0.1:42661",
+					"172.21.0.1:42661",
+					"172.22.0.1:42661",
+					"172.23.0.1:42661",
+					"172.24.0.1:42661",
+					"172.25.0.1:42661",
+					"172.26.0.1:42661",
+					"172.27.0.1:42661",
+					"172.28.0.1:42661"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:21:21.012421424Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4725532368819453,
+				"StableID":   "nWdDctiCud11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec327910540dbdc61464d526ac9800df50d6b956244da10af3ea424102e7d30e",
+				"DiscoKey":   "discokey:4d276da3bd54817b6af5ed9d3da58b57c6a09de2b4bb7f94656e3175bb93175a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58383",
+					"10.65.0.27:58383",
+					"172.17.0.1:58383",
+					"172.18.0.1:58383",
+					"172.19.0.1:58383",
+					"172.20.0.1:58383",
+					"172.21.0.1:58383",
+					"172.22.0.1:58383",
+					"172.23.0.1:58383",
+					"172.24.0.1:58383",
+					"172.25.0.1:58383",
+					"172.26.0.1:58383",
+					"172.27.0.1:58383",
+					"172.28.0.1:58383"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:21:21.550796677Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8302794691259322,
+				"StableID":   "nMGMHaLMq721CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc0f150fc848435ae963f263bbb5b44c14b4de07c306da65f1d9d65dba8aa915",
+				"DiscoKey":   "discokey:e715d93aeac9eec6096a3e18131bd442fe35e13a0347123bcfe21723c9cfbc1c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37978",
+					"10.65.0.27:37978",
+					"172.17.0.1:37978",
+					"172.18.0.1:37978",
+					"172.19.0.1:37978",
+					"172.20.0.1:37978",
+					"172.21.0.1:37978",
+					"172.22.0.1:37978",
+					"172.23.0.1:37978",
+					"172.24.0.1:37978",
+					"172.25.0.1:37978",
+					"172.26.0.1:37978",
+					"172.27.0.1:37978",
+					"172.28.0.1:37978"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:21:22.617210394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6814575453737212,
+				"StableID":   "nVZuRpLLDv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db04fe21e83f45ddbed5b8446f6a92caf01754c38ed27c782c26b81abb977210",
+				"DiscoKey":   "discokey:d554e83b854f98f53fbf98046b8bb4d073b7afa017c42441270fdfbfbba39e44",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33457",
+					"10.65.0.27:33457",
+					"172.17.0.1:33457",
+					"172.18.0.1:33457",
+					"172.19.0.1:33457",
+					"172.20.0.1:33457",
+					"172.21.0.1:33457",
+					"172.22.0.1:33457",
+					"172.23.0.1:33457",
+					"172.24.0.1:33457",
+					"172.25.0.1:33457",
+					"172.26.0.1:33457",
+					"172.27.0.1:33457",
+					"172.28.0.1:33457"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:21:23.460129792Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3971972035245068,
+				"StableID":   "nZjmNGyu1Y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:64e3c927a0d8a260091b63aedddce84cff7d3e81f07ea13778ccc698c7e98b43",
+				"DiscoKey":   "discokey:67171f195393cdbd79f7ad13688070985774fe21be0cedac150777af6508354f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38948",
+					"10.65.0.27:38948",
+					"172.17.0.1:38948",
+					"172.18.0.1:38948",
+					"172.19.0.1:38948",
+					"172.20.0.1:38948",
+					"172.21.0.1:38948",
+					"172.22.0.1:38948",
+					"172.23.0.1:38948",
+					"172.24.0.1:38948",
+					"172.25.0.1:38948",
+					"172.26.0.1:38948",
+					"172.27.0.1:38948",
+					"172.28.0.1:38948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:21:23.937568907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4372583465575495,
+				"StableID":   "nELNeUMM9b11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a3e5671fbb6f6c658d6e163b7bd993cced8c022df31b868e10c82fba42286347",
+				"DiscoKey":   "discokey:54b578d48e785aa696d2ee85a5a3bda9a5179f5a57705e00de174e882e2f5071",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51405",
+					"10.65.0.27:51405",
+					"172.17.0.1:51405",
+					"172.18.0.1:51405",
+					"172.19.0.1:51405",
+					"172.20.0.1:51405",
+					"172.21.0.1:51405",
+					"172.22.0.1:51405",
+					"172.23.0.1:51405",
+					"172.24.0.1:51405",
+					"172.25.0.1:51405",
+					"172.26.0.1:51405",
+					"172.27.0.1:51405",
+					"172.28.0.1:51405"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:21:24.602179146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4608126954712804,
+				"StableID":   "nfvWCWg2zc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ed292b4cfa8d08d12bc6fe9b393fad60418df600a2e19127099519a3fa1db3f",
+				"DiscoKey":   "discokey:fb18e1047c814faa1936128cd722a341358c30909e998cbd856d38e7658bc216",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44111",
+					"10.65.0.27:44111",
+					"172.17.0.1:44111",
+					"172.18.0.1:44111",
+					"172.19.0.1:44111",
+					"172.20.0.1:44111",
+					"172.21.0.1:44111",
+					"172.22.0.1:44111",
+					"172.23.0.1:44111",
+					"172.24.0.1:44111",
+					"172.25.0.1:44111",
+					"172.26.0.1:44111",
+					"172.27.0.1:44111",
+					"172.28.0.1:44111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:21:25.133517278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1500340108592974,
+				"StableID":   "nRGwiePWiC11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:005e465b964cc904806f5161328c8f685fd1e56b59f30ea0d13cad619bd75e7b",
+				"DiscoKey":   "discokey:23354def6c19b41d12b50b428bb2b86a4e2cb7471abf9f39a4e93fa76040f810",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:34139",
+					"10.65.0.27:34139",
+					"172.17.0.1:34139",
+					"172.18.0.1:34139",
+					"172.19.0.1:34139",
+					"172.20.0.1:34139",
+					"172.21.0.1:34139",
+					"172.22.0.1:34139",
+					"172.23.0.1:34139",
+					"172.24.0.1:34139",
+					"172.25.0.1:34139",
+					"172.26.0.1:34139",
+					"172.27.0.1:34139",
+					"172.28.0.1:34139"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:21:25.660717434Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         521955752537854,
+				"StableID":   "ndAuVmtP5511CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:cc439a49e3f189d63a5a8b0deff24686018316cc041e6495c7dbab9074185e52",
+				"KeyExpiry":  "2026-11-09T09:21:26Z",
+				"DiscoKey":   "discokey:9373753ec674e553510849fb70c3d11a030a8ebdb697b79811e40fb34e754b34",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:36848",
+					"10.65.0.27:36848",
+					"172.17.0.1:36848",
+					"172.18.0.1:36848",
+					"172.19.0.1:36848",
+					"172.20.0.1:36848",
+					"172.21.0.1:36848",
+					"172.22.0.1:36848",
+					"172.23.0.1:36848",
+					"172.24.0.1:36848",
+					"172.25.0.1:36848",
+					"172.26.0.1:36848",
+					"172.27.0.1:36848",
+					"172.28.0.1:36848"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:21:26.194723126Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4523172015074948,
+				"StableID":   "nwEe6R4ZKc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:43722a1489ece323af8ed65ad9fef1a309afef19f60109cf84536abd2f108c30",
+				"KeyExpiry":  "2026-11-09T09:21:26Z",
+				"DiscoKey":   "discokey:b905104a3ce14244a835cd8c1bce75dac82376d0fac4110c36a649a3b7f5c456",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49558",
+					"10.65.0.27:49558",
+					"172.17.0.1:49558",
+					"172.18.0.1:49558",
+					"172.19.0.1:49558",
+					"172.20.0.1:49558",
+					"172.21.0.1:49558",
+					"172.22.0.1:49558",
+					"172.23.0.1:49558",
+					"172.24.0.1:49558",
+					"172.25.0.1:49558",
+					"172.26.0.1:49558",
+					"172.27.0.1:49558",
+					"172.28.0.1:49558"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:21:26.723487548Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5848785703371618,
+				"StableID":   "n3V7Pbgvfn11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:61125883643bf13373afbfcc258f7ea148cd326b1273f337857ee86144c0521d",
+				"KeyExpiry":  "2026-11-09T09:21:27Z",
+				"DiscoKey":   "discokey:dc748887d44370c813a5e037e52b40bf597c6088551a43de750344a550be1a55",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55204",
+					"10.65.0.27:55204",
+					"172.17.0.1:55204",
+					"172.18.0.1:55204",
+					"172.19.0.1:55204",
+					"172.20.0.1:55204",
+					"172.21.0.1:55204",
+					"172.22.0.1:55204",
+					"172.23.0.1:55204",
+					"172.24.0.1:55204",
+					"172.25.0.1:55204",
+					"172.26.0.1:55204",
+					"172.27.0.1:55204",
+					"172.28.0.1:55204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:21:27.254674699Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6882282173853531": {
+				"ID":          6882282173853531,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5848785703371618,
+				"StableID":   "n3V7Pbgvfn11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:61125883643bf13373afbfcc258f7ea148cd326b1273f337857ee86144c0521d",
+				"KeyExpiry":  "2026-11-09T09:21:27Z",
+				"DiscoKey":   "discokey:dc748887d44370c813a5e037e52b40bf597c6088551a43de750344a550be1a55",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55204",
+					"10.65.0.27:55204",
+					"172.17.0.1:55204",
+					"172.18.0.1:55204",
+					"172.19.0.1:55204",
+					"172.20.0.1:55204",
+					"172.21.0.1:55204",
+					"172.22.0.1:55204",
+					"172.23.0.1:55204",
+					"172.24.0.1:55204",
+					"172.25.0.1:55204",
+					"172.26.0.1:55204",
+					"172.27.0.1:55204",
+					"172.28.0.1:55204"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:21:27.254674699Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:61125883643bf13373afbfcc258f7ea148cd326b1273f337857ee86144c0521d",
+			"MachineKey": "mkey:33394264ea61a563b7b4054fbd643e754f8ac5feebb9fc42bce7bb56313d4017",
+			"Peers": [{
+				"ID":         8290277898300682,
+				"StableID":   "nPBh9UYgj721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:daf9699563bb8d8e86135a3eb1c6b4ca20670b36e6a6d87f7984fa2450dfe020",
+				"DiscoKey":   "discokey:cb20bf5e7e12b719e58613631bf8b830411be943c45ab7d2012c0f7256a01c1a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53542",
+					"10.65.0.27:53542",
+					"172.17.0.1:53542",
+					"172.18.0.1:53542",
+					"172.19.0.1:53542",
+					"172.20.0.1:53542",
+					"172.21.0.1:53542",
+					"172.22.0.1:53542",
+					"172.23.0.1:53542",
+					"172.24.0.1:53542",
+					"172.25.0.1:53542",
+					"172.26.0.1:53542",
+					"172.27.0.1:53542",
+					"172.28.0.1:53542"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:21:09.574498768Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3616621037328237,
+				"StableID":   "nvuqX7WyEV11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c2487b3a38488d006f9a28c6d9b90b5afdcc68a260cf02b1b7aa3d559f145e32",
+				"DiscoKey":   "discokey:b6300c737099421c5a52b06c2d6aad403b1f076f0f7debe347671b4eb63a7839",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33348",
+					"10.65.0.27:33348",
+					"172.17.0.1:33348",
+					"172.18.0.1:33348",
+					"172.19.0.1:33348",
+					"172.20.0.1:33348",
+					"172.21.0.1:33348",
+					"172.22.0.1:33348",
+					"172.23.0.1:33348",
+					"172.24.0.1:33348",
+					"172.25.0.1:33348",
+					"172.26.0.1:33348",
+					"172.27.0.1:33348",
+					"172.28.0.1:33348"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:21:15.566085445Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5655179600283341,
+				"StableID":   "nLgQ2myEAm11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:133c74cdf13dcb6f236645b723c019ea0eb574dd2c988e6aaebd0c202f7abc72",
+				"DiscoKey":   "discokey:7ede0fad082f1f4540afd15d339f4f14498fd7a2f6253565fc59cc8020788c3a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57092",
+					"10.65.0.27:57092",
+					"172.17.0.1:57092",
+					"172.18.0.1:57092",
+					"172.19.0.1:57092",
+					"172.20.0.1:57092",
+					"172.21.0.1:57092",
+					"172.22.0.1:57092",
+					"172.23.0.1:57092",
+					"172.24.0.1:57092",
+					"172.25.0.1:57092",
+					"172.26.0.1:57092",
+					"172.27.0.1:57092",
+					"172.28.0.1:57092"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:21:17.347104171Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5800192544056745,
+				"StableID":   "nJRwHvDvHn11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:73aa857fa92ce648735d5f6f595ac8b3078b14a194f56f72cee66647746ac61c",
+				"DiscoKey":   "discokey:ac62f171220e6de996c3a9a4719ae5fcbf913f3fedc5c0a98e110490ab01cf4a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42661",
+					"10.65.0.27:42661",
+					"172.17.0.1:42661",
+					"172.18.0.1:42661",
+					"172.19.0.1:42661",
+					"172.20.0.1:42661",
+					"172.21.0.1:42661",
+					"172.22.0.1:42661",
+					"172.23.0.1:42661",
+					"172.24.0.1:42661",
+					"172.25.0.1:42661",
+					"172.26.0.1:42661",
+					"172.27.0.1:42661",
+					"172.28.0.1:42661"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:21:21.012421424Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4725532368819453,
+				"StableID":   "nWdDctiCud11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec327910540dbdc61464d526ac9800df50d6b956244da10af3ea424102e7d30e",
+				"DiscoKey":   "discokey:4d276da3bd54817b6af5ed9d3da58b57c6a09de2b4bb7f94656e3175bb93175a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58383",
+					"10.65.0.27:58383",
+					"172.17.0.1:58383",
+					"172.18.0.1:58383",
+					"172.19.0.1:58383",
+					"172.20.0.1:58383",
+					"172.21.0.1:58383",
+					"172.22.0.1:58383",
+					"172.23.0.1:58383",
+					"172.24.0.1:58383",
+					"172.25.0.1:58383",
+					"172.26.0.1:58383",
+					"172.27.0.1:58383",
+					"172.28.0.1:58383"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:21:21.550796677Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6882282173853531,
+				"StableID":   "nJSFSBtzjv11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe5dd419cfaf8151c09428107e4ee85c074928fd9f8fe3da73694074121cf72d",
+				"DiscoKey":   "discokey:298f317d964805d70c955707e74cc3a06589f35df730a2211e9d99a2c7f5103a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50289",
+					"10.65.0.27:50289",
+					"172.17.0.1:50289",
+					"172.18.0.1:50289",
+					"172.19.0.1:50289",
+					"172.20.0.1:50289",
+					"172.21.0.1:50289",
+					"172.22.0.1:50289",
+					"172.23.0.1:50289",
+					"172.24.0.1:50289",
+					"172.25.0.1:50289",
+					"172.26.0.1:50289",
+					"172.27.0.1:50289",
+					"172.28.0.1:50289"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:21:22.075465365Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8302794691259322,
+				"StableID":   "nMGMHaLMq721CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc0f150fc848435ae963f263bbb5b44c14b4de07c306da65f1d9d65dba8aa915",
+				"DiscoKey":   "discokey:e715d93aeac9eec6096a3e18131bd442fe35e13a0347123bcfe21723c9cfbc1c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37978",
+					"10.65.0.27:37978",
+					"172.17.0.1:37978",
+					"172.18.0.1:37978",
+					"172.19.0.1:37978",
+					"172.20.0.1:37978",
+					"172.21.0.1:37978",
+					"172.22.0.1:37978",
+					"172.23.0.1:37978",
+					"172.24.0.1:37978",
+					"172.25.0.1:37978",
+					"172.26.0.1:37978",
+					"172.27.0.1:37978",
+					"172.28.0.1:37978"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:21:22.617210394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6814575453737212,
+				"StableID":   "nVZuRpLLDv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db04fe21e83f45ddbed5b8446f6a92caf01754c38ed27c782c26b81abb977210",
+				"DiscoKey":   "discokey:d554e83b854f98f53fbf98046b8bb4d073b7afa017c42441270fdfbfbba39e44",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33457",
+					"10.65.0.27:33457",
+					"172.17.0.1:33457",
+					"172.18.0.1:33457",
+					"172.19.0.1:33457",
+					"172.20.0.1:33457",
+					"172.21.0.1:33457",
+					"172.22.0.1:33457",
+					"172.23.0.1:33457",
+					"172.24.0.1:33457",
+					"172.25.0.1:33457",
+					"172.26.0.1:33457",
+					"172.27.0.1:33457",
+					"172.28.0.1:33457"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:21:23.460129792Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3971972035245068,
+				"StableID":   "nZjmNGyu1Y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:64e3c927a0d8a260091b63aedddce84cff7d3e81f07ea13778ccc698c7e98b43",
+				"DiscoKey":   "discokey:67171f195393cdbd79f7ad13688070985774fe21be0cedac150777af6508354f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38948",
+					"10.65.0.27:38948",
+					"172.17.0.1:38948",
+					"172.18.0.1:38948",
+					"172.19.0.1:38948",
+					"172.20.0.1:38948",
+					"172.21.0.1:38948",
+					"172.22.0.1:38948",
+					"172.23.0.1:38948",
+					"172.24.0.1:38948",
+					"172.25.0.1:38948",
+					"172.26.0.1:38948",
+					"172.27.0.1:38948",
+					"172.28.0.1:38948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:21:23.937568907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4372583465575495,
+				"StableID":   "nELNeUMM9b11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a3e5671fbb6f6c658d6e163b7bd993cced8c022df31b868e10c82fba42286347",
+				"DiscoKey":   "discokey:54b578d48e785aa696d2ee85a5a3bda9a5179f5a57705e00de174e882e2f5071",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51405",
+					"10.65.0.27:51405",
+					"172.17.0.1:51405",
+					"172.18.0.1:51405",
+					"172.19.0.1:51405",
+					"172.20.0.1:51405",
+					"172.21.0.1:51405",
+					"172.22.0.1:51405",
+					"172.23.0.1:51405",
+					"172.24.0.1:51405",
+					"172.25.0.1:51405",
+					"172.26.0.1:51405",
+					"172.27.0.1:51405",
+					"172.28.0.1:51405"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:21:24.602179146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4608126954712804,
+				"StableID":   "nfvWCWg2zc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ed292b4cfa8d08d12bc6fe9b393fad60418df600a2e19127099519a3fa1db3f",
+				"DiscoKey":   "discokey:fb18e1047c814faa1936128cd722a341358c30909e998cbd856d38e7658bc216",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44111",
+					"10.65.0.27:44111",
+					"172.17.0.1:44111",
+					"172.18.0.1:44111",
+					"172.19.0.1:44111",
+					"172.20.0.1:44111",
+					"172.21.0.1:44111",
+					"172.22.0.1:44111",
+					"172.23.0.1:44111",
+					"172.24.0.1:44111",
+					"172.25.0.1:44111",
+					"172.26.0.1:44111",
+					"172.27.0.1:44111",
+					"172.28.0.1:44111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:21:25.133517278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1500340108592974,
+				"StableID":   "nRGwiePWiC11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:005e465b964cc904806f5161328c8f685fd1e56b59f30ea0d13cad619bd75e7b",
+				"DiscoKey":   "discokey:23354def6c19b41d12b50b428bb2b86a4e2cb7471abf9f39a4e93fa76040f810",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:34139",
+					"10.65.0.27:34139",
+					"172.17.0.1:34139",
+					"172.18.0.1:34139",
+					"172.19.0.1:34139",
+					"172.20.0.1:34139",
+					"172.21.0.1:34139",
+					"172.22.0.1:34139",
+					"172.23.0.1:34139",
+					"172.24.0.1:34139",
+					"172.25.0.1:34139",
+					"172.26.0.1:34139",
+					"172.27.0.1:34139",
+					"172.28.0.1:34139"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:21:25.660717434Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         521955752537854,
+				"StableID":   "ndAuVmtP5511CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:cc439a49e3f189d63a5a8b0deff24686018316cc041e6495c7dbab9074185e52",
+				"KeyExpiry":  "2026-11-09T09:21:26Z",
+				"DiscoKey":   "discokey:9373753ec674e553510849fb70c3d11a030a8ebdb697b79811e40fb34e754b34",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:36848",
+					"10.65.0.27:36848",
+					"172.17.0.1:36848",
+					"172.18.0.1:36848",
+					"172.19.0.1:36848",
+					"172.20.0.1:36848",
+					"172.21.0.1:36848",
+					"172.22.0.1:36848",
+					"172.23.0.1:36848",
+					"172.24.0.1:36848",
+					"172.25.0.1:36848",
+					"172.26.0.1:36848",
+					"172.27.0.1:36848",
+					"172.28.0.1:36848"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:21:26.194723126Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4523172015074948,
+				"StableID":   "nwEe6R4ZKc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:43722a1489ece323af8ed65ad9fef1a309afef19f60109cf84536abd2f108c30",
+				"KeyExpiry":  "2026-11-09T09:21:26Z",
+				"DiscoKey":   "discokey:b905104a3ce14244a835cd8c1bce75dac82376d0fac4110c36a649a3b7f5c456",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49558",
+					"10.65.0.27:49558",
+					"172.17.0.1:49558",
+					"172.18.0.1:49558",
+					"172.19.0.1:49558",
+					"172.20.0.1:49558",
+					"172.21.0.1:49558",
+					"172.22.0.1:49558",
+					"172.23.0.1:49558",
+					"172.24.0.1:49558",
+					"172.25.0.1:49558",
+					"172.26.0.1:49558",
+					"172.27.0.1:49558",
+					"172.28.0.1:49558"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:21:26.723487548Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5655179600283341,
+				"StableID":   "nLgQ2myEAm11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       5655179600283341,
+				"Key":        "nodekey:133c74cdf13dcb6f236645b723c019ea0eb574dd2c988e6aaebd0c202f7abc72",
+				"DiscoKey":   "discokey:7ede0fad082f1f4540afd15d339f4f14498fd7a2f6253565fc59cc8020788c3a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57092",
+					"10.65.0.27:57092",
+					"172.17.0.1:57092",
+					"172.18.0.1:57092",
+					"172.19.0.1:57092",
+					"172.20.0.1:57092",
+					"172.21.0.1:57092",
+					"172.22.0.1:57092",
+					"172.23.0.1:57092",
+					"172.24.0.1:57092",
+					"172.25.0.1:57092",
+					"172.26.0.1:57092",
+					"172.27.0.1:57092",
+					"172.28.0.1:57092"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:21:17.347104171Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:133c74cdf13dcb6f236645b723c019ea0eb574dd2c988e6aaebd0c202f7abc72",
+			"MachineKey": "mkey:25d72481cc668640690bbec362325838745e9e45b57a41513cfdd497d3b21962",
+			"Peers": [{
+				"ID":         8290277898300682,
+				"StableID":   "nPBh9UYgj721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:daf9699563bb8d8e86135a3eb1c6b4ca20670b36e6a6d87f7984fa2450dfe020",
+				"DiscoKey":   "discokey:cb20bf5e7e12b719e58613631bf8b830411be943c45ab7d2012c0f7256a01c1a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53542",
+					"10.65.0.27:53542",
+					"172.17.0.1:53542",
+					"172.18.0.1:53542",
+					"172.19.0.1:53542",
+					"172.20.0.1:53542",
+					"172.21.0.1:53542",
+					"172.22.0.1:53542",
+					"172.23.0.1:53542",
+					"172.24.0.1:53542",
+					"172.25.0.1:53542",
+					"172.26.0.1:53542",
+					"172.27.0.1:53542",
+					"172.28.0.1:53542"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:21:09.574498768Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3616621037328237,
+				"StableID":   "nvuqX7WyEV11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c2487b3a38488d006f9a28c6d9b90b5afdcc68a260cf02b1b7aa3d559f145e32",
+				"DiscoKey":   "discokey:b6300c737099421c5a52b06c2d6aad403b1f076f0f7debe347671b4eb63a7839",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33348",
+					"10.65.0.27:33348",
+					"172.17.0.1:33348",
+					"172.18.0.1:33348",
+					"172.19.0.1:33348",
+					"172.20.0.1:33348",
+					"172.21.0.1:33348",
+					"172.22.0.1:33348",
+					"172.23.0.1:33348",
+					"172.24.0.1:33348",
+					"172.25.0.1:33348",
+					"172.26.0.1:33348",
+					"172.27.0.1:33348",
+					"172.28.0.1:33348"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:21:15.566085445Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5800192544056745,
+				"StableID":   "nJRwHvDvHn11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:73aa857fa92ce648735d5f6f595ac8b3078b14a194f56f72cee66647746ac61c",
+				"DiscoKey":   "discokey:ac62f171220e6de996c3a9a4719ae5fcbf913f3fedc5c0a98e110490ab01cf4a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42661",
+					"10.65.0.27:42661",
+					"172.17.0.1:42661",
+					"172.18.0.1:42661",
+					"172.19.0.1:42661",
+					"172.20.0.1:42661",
+					"172.21.0.1:42661",
+					"172.22.0.1:42661",
+					"172.23.0.1:42661",
+					"172.24.0.1:42661",
+					"172.25.0.1:42661",
+					"172.26.0.1:42661",
+					"172.27.0.1:42661",
+					"172.28.0.1:42661"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:21:21.012421424Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4725532368819453,
+				"StableID":   "nWdDctiCud11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec327910540dbdc61464d526ac9800df50d6b956244da10af3ea424102e7d30e",
+				"DiscoKey":   "discokey:4d276da3bd54817b6af5ed9d3da58b57c6a09de2b4bb7f94656e3175bb93175a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58383",
+					"10.65.0.27:58383",
+					"172.17.0.1:58383",
+					"172.18.0.1:58383",
+					"172.19.0.1:58383",
+					"172.20.0.1:58383",
+					"172.21.0.1:58383",
+					"172.22.0.1:58383",
+					"172.23.0.1:58383",
+					"172.24.0.1:58383",
+					"172.25.0.1:58383",
+					"172.26.0.1:58383",
+					"172.27.0.1:58383",
+					"172.28.0.1:58383"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:21:21.550796677Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6882282173853531,
+				"StableID":   "nJSFSBtzjv11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe5dd419cfaf8151c09428107e4ee85c074928fd9f8fe3da73694074121cf72d",
+				"DiscoKey":   "discokey:298f317d964805d70c955707e74cc3a06589f35df730a2211e9d99a2c7f5103a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50289",
+					"10.65.0.27:50289",
+					"172.17.0.1:50289",
+					"172.18.0.1:50289",
+					"172.19.0.1:50289",
+					"172.20.0.1:50289",
+					"172.21.0.1:50289",
+					"172.22.0.1:50289",
+					"172.23.0.1:50289",
+					"172.24.0.1:50289",
+					"172.25.0.1:50289",
+					"172.26.0.1:50289",
+					"172.27.0.1:50289",
+					"172.28.0.1:50289"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:21:22.075465365Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8302794691259322,
+				"StableID":   "nMGMHaLMq721CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc0f150fc848435ae963f263bbb5b44c14b4de07c306da65f1d9d65dba8aa915",
+				"DiscoKey":   "discokey:e715d93aeac9eec6096a3e18131bd442fe35e13a0347123bcfe21723c9cfbc1c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37978",
+					"10.65.0.27:37978",
+					"172.17.0.1:37978",
+					"172.18.0.1:37978",
+					"172.19.0.1:37978",
+					"172.20.0.1:37978",
+					"172.21.0.1:37978",
+					"172.22.0.1:37978",
+					"172.23.0.1:37978",
+					"172.24.0.1:37978",
+					"172.25.0.1:37978",
+					"172.26.0.1:37978",
+					"172.27.0.1:37978",
+					"172.28.0.1:37978"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:21:22.617210394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6814575453737212,
+				"StableID":   "nVZuRpLLDv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db04fe21e83f45ddbed5b8446f6a92caf01754c38ed27c782c26b81abb977210",
+				"DiscoKey":   "discokey:d554e83b854f98f53fbf98046b8bb4d073b7afa017c42441270fdfbfbba39e44",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33457",
+					"10.65.0.27:33457",
+					"172.17.0.1:33457",
+					"172.18.0.1:33457",
+					"172.19.0.1:33457",
+					"172.20.0.1:33457",
+					"172.21.0.1:33457",
+					"172.22.0.1:33457",
+					"172.23.0.1:33457",
+					"172.24.0.1:33457",
+					"172.25.0.1:33457",
+					"172.26.0.1:33457",
+					"172.27.0.1:33457",
+					"172.28.0.1:33457"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:21:23.460129792Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3971972035245068,
+				"StableID":   "nZjmNGyu1Y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:64e3c927a0d8a260091b63aedddce84cff7d3e81f07ea13778ccc698c7e98b43",
+				"DiscoKey":   "discokey:67171f195393cdbd79f7ad13688070985774fe21be0cedac150777af6508354f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38948",
+					"10.65.0.27:38948",
+					"172.17.0.1:38948",
+					"172.18.0.1:38948",
+					"172.19.0.1:38948",
+					"172.20.0.1:38948",
+					"172.21.0.1:38948",
+					"172.22.0.1:38948",
+					"172.23.0.1:38948",
+					"172.24.0.1:38948",
+					"172.25.0.1:38948",
+					"172.26.0.1:38948",
+					"172.27.0.1:38948",
+					"172.28.0.1:38948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:21:23.937568907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4372583465575495,
+				"StableID":   "nELNeUMM9b11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a3e5671fbb6f6c658d6e163b7bd993cced8c022df31b868e10c82fba42286347",
+				"DiscoKey":   "discokey:54b578d48e785aa696d2ee85a5a3bda9a5179f5a57705e00de174e882e2f5071",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51405",
+					"10.65.0.27:51405",
+					"172.17.0.1:51405",
+					"172.18.0.1:51405",
+					"172.19.0.1:51405",
+					"172.20.0.1:51405",
+					"172.21.0.1:51405",
+					"172.22.0.1:51405",
+					"172.23.0.1:51405",
+					"172.24.0.1:51405",
+					"172.25.0.1:51405",
+					"172.26.0.1:51405",
+					"172.27.0.1:51405",
+					"172.28.0.1:51405"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:21:24.602179146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4608126954712804,
+				"StableID":   "nfvWCWg2zc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ed292b4cfa8d08d12bc6fe9b393fad60418df600a2e19127099519a3fa1db3f",
+				"DiscoKey":   "discokey:fb18e1047c814faa1936128cd722a341358c30909e998cbd856d38e7658bc216",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44111",
+					"10.65.0.27:44111",
+					"172.17.0.1:44111",
+					"172.18.0.1:44111",
+					"172.19.0.1:44111",
+					"172.20.0.1:44111",
+					"172.21.0.1:44111",
+					"172.22.0.1:44111",
+					"172.23.0.1:44111",
+					"172.24.0.1:44111",
+					"172.25.0.1:44111",
+					"172.26.0.1:44111",
+					"172.27.0.1:44111",
+					"172.28.0.1:44111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:21:25.133517278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1500340108592974,
+				"StableID":   "nRGwiePWiC11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:005e465b964cc904806f5161328c8f685fd1e56b59f30ea0d13cad619bd75e7b",
+				"DiscoKey":   "discokey:23354def6c19b41d12b50b428bb2b86a4e2cb7471abf9f39a4e93fa76040f810",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:34139",
+					"10.65.0.27:34139",
+					"172.17.0.1:34139",
+					"172.18.0.1:34139",
+					"172.19.0.1:34139",
+					"172.20.0.1:34139",
+					"172.21.0.1:34139",
+					"172.22.0.1:34139",
+					"172.23.0.1:34139",
+					"172.24.0.1:34139",
+					"172.25.0.1:34139",
+					"172.26.0.1:34139",
+					"172.27.0.1:34139",
+					"172.28.0.1:34139"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:21:25.660717434Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         521955752537854,
+				"StableID":   "ndAuVmtP5511CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:cc439a49e3f189d63a5a8b0deff24686018316cc041e6495c7dbab9074185e52",
+				"KeyExpiry":  "2026-11-09T09:21:26Z",
+				"DiscoKey":   "discokey:9373753ec674e553510849fb70c3d11a030a8ebdb697b79811e40fb34e754b34",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:36848",
+					"10.65.0.27:36848",
+					"172.17.0.1:36848",
+					"172.18.0.1:36848",
+					"172.19.0.1:36848",
+					"172.20.0.1:36848",
+					"172.21.0.1:36848",
+					"172.22.0.1:36848",
+					"172.23.0.1:36848",
+					"172.24.0.1:36848",
+					"172.25.0.1:36848",
+					"172.26.0.1:36848",
+					"172.27.0.1:36848",
+					"172.28.0.1:36848"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:21:26.194723126Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4523172015074948,
+				"StableID":   "nwEe6R4ZKc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:43722a1489ece323af8ed65ad9fef1a309afef19f60109cf84536abd2f108c30",
+				"KeyExpiry":  "2026-11-09T09:21:26Z",
+				"DiscoKey":   "discokey:b905104a3ce14244a835cd8c1bce75dac82376d0fac4110c36a649a3b7f5c456",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49558",
+					"10.65.0.27:49558",
+					"172.17.0.1:49558",
+					"172.18.0.1:49558",
+					"172.19.0.1:49558",
+					"172.20.0.1:49558",
+					"172.21.0.1:49558",
+					"172.22.0.1:49558",
+					"172.23.0.1:49558",
+					"172.24.0.1:49558",
+					"172.25.0.1:49558",
+					"172.26.0.1:49558",
+					"172.27.0.1:49558",
+					"172.28.0.1:49558"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:21:26.723487548Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5848785703371618,
+				"StableID":   "n3V7Pbgvfn11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:61125883643bf13373afbfcc258f7ea148cd326b1273f337857ee86144c0521d",
+				"KeyExpiry":  "2026-11-09T09:21:27Z",
+				"DiscoKey":   "discokey:dc748887d44370c813a5e037e52b40bf597c6088551a43de750344a550be1a55",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55204",
+					"10.65.0.27:55204",
+					"172.17.0.1:55204",
+					"172.18.0.1:55204",
+					"172.19.0.1:55204",
+					"172.20.0.1:55204",
+					"172.21.0.1:55204",
+					"172.22.0.1:55204",
+					"172.23.0.1:55204",
+					"172.24.0.1:55204",
+					"172.25.0.1:55204",
+					"172.26.0.1:55204",
+					"172.27.0.1:55204",
+					"172.28.0.1:55204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:21:27.254674699Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5655179600283341": {
+				"ID":          5655179600283341,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6814575453737212,
+				"StableID":   "nVZuRpLLDv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       6814575453737212,
+				"Key":        "nodekey:db04fe21e83f45ddbed5b8446f6a92caf01754c38ed27c782c26b81abb977210",
+				"DiscoKey":   "discokey:d554e83b854f98f53fbf98046b8bb4d073b7afa017c42441270fdfbfbba39e44",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33457",
+					"10.65.0.27:33457",
+					"172.17.0.1:33457",
+					"172.18.0.1:33457",
+					"172.19.0.1:33457",
+					"172.20.0.1:33457",
+					"172.21.0.1:33457",
+					"172.22.0.1:33457",
+					"172.23.0.1:33457",
+					"172.24.0.1:33457",
+					"172.25.0.1:33457",
+					"172.26.0.1:33457",
+					"172.27.0.1:33457",
+					"172.28.0.1:33457"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:21:23.460129792Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:db04fe21e83f45ddbed5b8446f6a92caf01754c38ed27c782c26b81abb977210",
+			"MachineKey": "mkey:c8ffa5c2df0054afa4ec5f267c72855d1f4db80cc195cbdb6ae613a4a8c40210",
+			"Peers": [{
+				"ID":         8290277898300682,
+				"StableID":   "nPBh9UYgj721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:daf9699563bb8d8e86135a3eb1c6b4ca20670b36e6a6d87f7984fa2450dfe020",
+				"DiscoKey":   "discokey:cb20bf5e7e12b719e58613631bf8b830411be943c45ab7d2012c0f7256a01c1a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53542",
+					"10.65.0.27:53542",
+					"172.17.0.1:53542",
+					"172.18.0.1:53542",
+					"172.19.0.1:53542",
+					"172.20.0.1:53542",
+					"172.21.0.1:53542",
+					"172.22.0.1:53542",
+					"172.23.0.1:53542",
+					"172.24.0.1:53542",
+					"172.25.0.1:53542",
+					"172.26.0.1:53542",
+					"172.27.0.1:53542",
+					"172.28.0.1:53542"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:21:09.574498768Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3616621037328237,
+				"StableID":   "nvuqX7WyEV11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c2487b3a38488d006f9a28c6d9b90b5afdcc68a260cf02b1b7aa3d559f145e32",
+				"DiscoKey":   "discokey:b6300c737099421c5a52b06c2d6aad403b1f076f0f7debe347671b4eb63a7839",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33348",
+					"10.65.0.27:33348",
+					"172.17.0.1:33348",
+					"172.18.0.1:33348",
+					"172.19.0.1:33348",
+					"172.20.0.1:33348",
+					"172.21.0.1:33348",
+					"172.22.0.1:33348",
+					"172.23.0.1:33348",
+					"172.24.0.1:33348",
+					"172.25.0.1:33348",
+					"172.26.0.1:33348",
+					"172.27.0.1:33348",
+					"172.28.0.1:33348"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:21:15.566085445Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5655179600283341,
+				"StableID":   "nLgQ2myEAm11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:133c74cdf13dcb6f236645b723c019ea0eb574dd2c988e6aaebd0c202f7abc72",
+				"DiscoKey":   "discokey:7ede0fad082f1f4540afd15d339f4f14498fd7a2f6253565fc59cc8020788c3a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57092",
+					"10.65.0.27:57092",
+					"172.17.0.1:57092",
+					"172.18.0.1:57092",
+					"172.19.0.1:57092",
+					"172.20.0.1:57092",
+					"172.21.0.1:57092",
+					"172.22.0.1:57092",
+					"172.23.0.1:57092",
+					"172.24.0.1:57092",
+					"172.25.0.1:57092",
+					"172.26.0.1:57092",
+					"172.27.0.1:57092",
+					"172.28.0.1:57092"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:21:17.347104171Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5800192544056745,
+				"StableID":   "nJRwHvDvHn11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:73aa857fa92ce648735d5f6f595ac8b3078b14a194f56f72cee66647746ac61c",
+				"DiscoKey":   "discokey:ac62f171220e6de996c3a9a4719ae5fcbf913f3fedc5c0a98e110490ab01cf4a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42661",
+					"10.65.0.27:42661",
+					"172.17.0.1:42661",
+					"172.18.0.1:42661",
+					"172.19.0.1:42661",
+					"172.20.0.1:42661",
+					"172.21.0.1:42661",
+					"172.22.0.1:42661",
+					"172.23.0.1:42661",
+					"172.24.0.1:42661",
+					"172.25.0.1:42661",
+					"172.26.0.1:42661",
+					"172.27.0.1:42661",
+					"172.28.0.1:42661"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:21:21.012421424Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4725532368819453,
+				"StableID":   "nWdDctiCud11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec327910540dbdc61464d526ac9800df50d6b956244da10af3ea424102e7d30e",
+				"DiscoKey":   "discokey:4d276da3bd54817b6af5ed9d3da58b57c6a09de2b4bb7f94656e3175bb93175a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58383",
+					"10.65.0.27:58383",
+					"172.17.0.1:58383",
+					"172.18.0.1:58383",
+					"172.19.0.1:58383",
+					"172.20.0.1:58383",
+					"172.21.0.1:58383",
+					"172.22.0.1:58383",
+					"172.23.0.1:58383",
+					"172.24.0.1:58383",
+					"172.25.0.1:58383",
+					"172.26.0.1:58383",
+					"172.27.0.1:58383",
+					"172.28.0.1:58383"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:21:21.550796677Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6882282173853531,
+				"StableID":   "nJSFSBtzjv11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe5dd419cfaf8151c09428107e4ee85c074928fd9f8fe3da73694074121cf72d",
+				"DiscoKey":   "discokey:298f317d964805d70c955707e74cc3a06589f35df730a2211e9d99a2c7f5103a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50289",
+					"10.65.0.27:50289",
+					"172.17.0.1:50289",
+					"172.18.0.1:50289",
+					"172.19.0.1:50289",
+					"172.20.0.1:50289",
+					"172.21.0.1:50289",
+					"172.22.0.1:50289",
+					"172.23.0.1:50289",
+					"172.24.0.1:50289",
+					"172.25.0.1:50289",
+					"172.26.0.1:50289",
+					"172.27.0.1:50289",
+					"172.28.0.1:50289"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:21:22.075465365Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8302794691259322,
+				"StableID":   "nMGMHaLMq721CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc0f150fc848435ae963f263bbb5b44c14b4de07c306da65f1d9d65dba8aa915",
+				"DiscoKey":   "discokey:e715d93aeac9eec6096a3e18131bd442fe35e13a0347123bcfe21723c9cfbc1c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37978",
+					"10.65.0.27:37978",
+					"172.17.0.1:37978",
+					"172.18.0.1:37978",
+					"172.19.0.1:37978",
+					"172.20.0.1:37978",
+					"172.21.0.1:37978",
+					"172.22.0.1:37978",
+					"172.23.0.1:37978",
+					"172.24.0.1:37978",
+					"172.25.0.1:37978",
+					"172.26.0.1:37978",
+					"172.27.0.1:37978",
+					"172.28.0.1:37978"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:21:22.617210394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3971972035245068,
+				"StableID":   "nZjmNGyu1Y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:64e3c927a0d8a260091b63aedddce84cff7d3e81f07ea13778ccc698c7e98b43",
+				"DiscoKey":   "discokey:67171f195393cdbd79f7ad13688070985774fe21be0cedac150777af6508354f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38948",
+					"10.65.0.27:38948",
+					"172.17.0.1:38948",
+					"172.18.0.1:38948",
+					"172.19.0.1:38948",
+					"172.20.0.1:38948",
+					"172.21.0.1:38948",
+					"172.22.0.1:38948",
+					"172.23.0.1:38948",
+					"172.24.0.1:38948",
+					"172.25.0.1:38948",
+					"172.26.0.1:38948",
+					"172.27.0.1:38948",
+					"172.28.0.1:38948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:21:23.937568907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4372583465575495,
+				"StableID":   "nELNeUMM9b11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a3e5671fbb6f6c658d6e163b7bd993cced8c022df31b868e10c82fba42286347",
+				"DiscoKey":   "discokey:54b578d48e785aa696d2ee85a5a3bda9a5179f5a57705e00de174e882e2f5071",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51405",
+					"10.65.0.27:51405",
+					"172.17.0.1:51405",
+					"172.18.0.1:51405",
+					"172.19.0.1:51405",
+					"172.20.0.1:51405",
+					"172.21.0.1:51405",
+					"172.22.0.1:51405",
+					"172.23.0.1:51405",
+					"172.24.0.1:51405",
+					"172.25.0.1:51405",
+					"172.26.0.1:51405",
+					"172.27.0.1:51405",
+					"172.28.0.1:51405"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:21:24.602179146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4608126954712804,
+				"StableID":   "nfvWCWg2zc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ed292b4cfa8d08d12bc6fe9b393fad60418df600a2e19127099519a3fa1db3f",
+				"DiscoKey":   "discokey:fb18e1047c814faa1936128cd722a341358c30909e998cbd856d38e7658bc216",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44111",
+					"10.65.0.27:44111",
+					"172.17.0.1:44111",
+					"172.18.0.1:44111",
+					"172.19.0.1:44111",
+					"172.20.0.1:44111",
+					"172.21.0.1:44111",
+					"172.22.0.1:44111",
+					"172.23.0.1:44111",
+					"172.24.0.1:44111",
+					"172.25.0.1:44111",
+					"172.26.0.1:44111",
+					"172.27.0.1:44111",
+					"172.28.0.1:44111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:21:25.133517278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1500340108592974,
+				"StableID":   "nRGwiePWiC11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:005e465b964cc904806f5161328c8f685fd1e56b59f30ea0d13cad619bd75e7b",
+				"DiscoKey":   "discokey:23354def6c19b41d12b50b428bb2b86a4e2cb7471abf9f39a4e93fa76040f810",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:34139",
+					"10.65.0.27:34139",
+					"172.17.0.1:34139",
+					"172.18.0.1:34139",
+					"172.19.0.1:34139",
+					"172.20.0.1:34139",
+					"172.21.0.1:34139",
+					"172.22.0.1:34139",
+					"172.23.0.1:34139",
+					"172.24.0.1:34139",
+					"172.25.0.1:34139",
+					"172.26.0.1:34139",
+					"172.27.0.1:34139",
+					"172.28.0.1:34139"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:21:25.660717434Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         521955752537854,
+				"StableID":   "ndAuVmtP5511CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:cc439a49e3f189d63a5a8b0deff24686018316cc041e6495c7dbab9074185e52",
+				"KeyExpiry":  "2026-11-09T09:21:26Z",
+				"DiscoKey":   "discokey:9373753ec674e553510849fb70c3d11a030a8ebdb697b79811e40fb34e754b34",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:36848",
+					"10.65.0.27:36848",
+					"172.17.0.1:36848",
+					"172.18.0.1:36848",
+					"172.19.0.1:36848",
+					"172.20.0.1:36848",
+					"172.21.0.1:36848",
+					"172.22.0.1:36848",
+					"172.23.0.1:36848",
+					"172.24.0.1:36848",
+					"172.25.0.1:36848",
+					"172.26.0.1:36848",
+					"172.27.0.1:36848",
+					"172.28.0.1:36848"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:21:26.194723126Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4523172015074948,
+				"StableID":   "nwEe6R4ZKc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:43722a1489ece323af8ed65ad9fef1a309afef19f60109cf84536abd2f108c30",
+				"KeyExpiry":  "2026-11-09T09:21:26Z",
+				"DiscoKey":   "discokey:b905104a3ce14244a835cd8c1bce75dac82376d0fac4110c36a649a3b7f5c456",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49558",
+					"10.65.0.27:49558",
+					"172.17.0.1:49558",
+					"172.18.0.1:49558",
+					"172.19.0.1:49558",
+					"172.20.0.1:49558",
+					"172.21.0.1:49558",
+					"172.22.0.1:49558",
+					"172.23.0.1:49558",
+					"172.24.0.1:49558",
+					"172.25.0.1:49558",
+					"172.26.0.1:49558",
+					"172.27.0.1:49558",
+					"172.28.0.1:49558"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:21:26.723487548Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5848785703371618,
+				"StableID":   "n3V7Pbgvfn11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:61125883643bf13373afbfcc258f7ea148cd326b1273f337857ee86144c0521d",
+				"KeyExpiry":  "2026-11-09T09:21:27Z",
+				"DiscoKey":   "discokey:dc748887d44370c813a5e037e52b40bf597c6088551a43de750344a550be1a55",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55204",
+					"10.65.0.27:55204",
+					"172.17.0.1:55204",
+					"172.18.0.1:55204",
+					"172.19.0.1:55204",
+					"172.20.0.1:55204",
+					"172.21.0.1:55204",
+					"172.22.0.1:55204",
+					"172.23.0.1:55204",
+					"172.24.0.1:55204",
+					"172.25.0.1:55204",
+					"172.26.0.1:55204",
+					"172.27.0.1:55204",
+					"172.28.0.1:55204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:21:27.254674699Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6814575453737212": {
+				"ID":          6814575453737212,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         521955752537854,
+				"StableID":   "ndAuVmtP5511CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:cc439a49e3f189d63a5a8b0deff24686018316cc041e6495c7dbab9074185e52",
+				"KeyExpiry":  "2026-11-09T09:21:26Z",
+				"DiscoKey":   "discokey:9373753ec674e553510849fb70c3d11a030a8ebdb697b79811e40fb34e754b34",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:36848",
+					"10.65.0.27:36848",
+					"172.17.0.1:36848",
+					"172.18.0.1:36848",
+					"172.19.0.1:36848",
+					"172.20.0.1:36848",
+					"172.21.0.1:36848",
+					"172.22.0.1:36848",
+					"172.23.0.1:36848",
+					"172.24.0.1:36848",
+					"172.25.0.1:36848",
+					"172.26.0.1:36848",
+					"172.27.0.1:36848",
+					"172.28.0.1:36848"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:21:26.194723126Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:cc439a49e3f189d63a5a8b0deff24686018316cc041e6495c7dbab9074185e52",
+			"MachineKey": "mkey:692e9e3e0366733361b998ce9c3b9cfa2c41d60d083115bb8f302e8f59e96857",
+			"Peers": [{
+				"ID":         8290277898300682,
+				"StableID":   "nPBh9UYgj721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:daf9699563bb8d8e86135a3eb1c6b4ca20670b36e6a6d87f7984fa2450dfe020",
+				"DiscoKey":   "discokey:cb20bf5e7e12b719e58613631bf8b830411be943c45ab7d2012c0f7256a01c1a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53542",
+					"10.65.0.27:53542",
+					"172.17.0.1:53542",
+					"172.18.0.1:53542",
+					"172.19.0.1:53542",
+					"172.20.0.1:53542",
+					"172.21.0.1:53542",
+					"172.22.0.1:53542",
+					"172.23.0.1:53542",
+					"172.24.0.1:53542",
+					"172.25.0.1:53542",
+					"172.26.0.1:53542",
+					"172.27.0.1:53542",
+					"172.28.0.1:53542"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:21:09.574498768Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3616621037328237,
+				"StableID":   "nvuqX7WyEV11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c2487b3a38488d006f9a28c6d9b90b5afdcc68a260cf02b1b7aa3d559f145e32",
+				"DiscoKey":   "discokey:b6300c737099421c5a52b06c2d6aad403b1f076f0f7debe347671b4eb63a7839",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33348",
+					"10.65.0.27:33348",
+					"172.17.0.1:33348",
+					"172.18.0.1:33348",
+					"172.19.0.1:33348",
+					"172.20.0.1:33348",
+					"172.21.0.1:33348",
+					"172.22.0.1:33348",
+					"172.23.0.1:33348",
+					"172.24.0.1:33348",
+					"172.25.0.1:33348",
+					"172.26.0.1:33348",
+					"172.27.0.1:33348",
+					"172.28.0.1:33348"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:21:15.566085445Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5655179600283341,
+				"StableID":   "nLgQ2myEAm11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:133c74cdf13dcb6f236645b723c019ea0eb574dd2c988e6aaebd0c202f7abc72",
+				"DiscoKey":   "discokey:7ede0fad082f1f4540afd15d339f4f14498fd7a2f6253565fc59cc8020788c3a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57092",
+					"10.65.0.27:57092",
+					"172.17.0.1:57092",
+					"172.18.0.1:57092",
+					"172.19.0.1:57092",
+					"172.20.0.1:57092",
+					"172.21.0.1:57092",
+					"172.22.0.1:57092",
+					"172.23.0.1:57092",
+					"172.24.0.1:57092",
+					"172.25.0.1:57092",
+					"172.26.0.1:57092",
+					"172.27.0.1:57092",
+					"172.28.0.1:57092"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:21:17.347104171Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5800192544056745,
+				"StableID":   "nJRwHvDvHn11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:73aa857fa92ce648735d5f6f595ac8b3078b14a194f56f72cee66647746ac61c",
+				"DiscoKey":   "discokey:ac62f171220e6de996c3a9a4719ae5fcbf913f3fedc5c0a98e110490ab01cf4a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42661",
+					"10.65.0.27:42661",
+					"172.17.0.1:42661",
+					"172.18.0.1:42661",
+					"172.19.0.1:42661",
+					"172.20.0.1:42661",
+					"172.21.0.1:42661",
+					"172.22.0.1:42661",
+					"172.23.0.1:42661",
+					"172.24.0.1:42661",
+					"172.25.0.1:42661",
+					"172.26.0.1:42661",
+					"172.27.0.1:42661",
+					"172.28.0.1:42661"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:21:21.012421424Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4725532368819453,
+				"StableID":   "nWdDctiCud11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec327910540dbdc61464d526ac9800df50d6b956244da10af3ea424102e7d30e",
+				"DiscoKey":   "discokey:4d276da3bd54817b6af5ed9d3da58b57c6a09de2b4bb7f94656e3175bb93175a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58383",
+					"10.65.0.27:58383",
+					"172.17.0.1:58383",
+					"172.18.0.1:58383",
+					"172.19.0.1:58383",
+					"172.20.0.1:58383",
+					"172.21.0.1:58383",
+					"172.22.0.1:58383",
+					"172.23.0.1:58383",
+					"172.24.0.1:58383",
+					"172.25.0.1:58383",
+					"172.26.0.1:58383",
+					"172.27.0.1:58383",
+					"172.28.0.1:58383"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:21:21.550796677Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6882282173853531,
+				"StableID":   "nJSFSBtzjv11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe5dd419cfaf8151c09428107e4ee85c074928fd9f8fe3da73694074121cf72d",
+				"DiscoKey":   "discokey:298f317d964805d70c955707e74cc3a06589f35df730a2211e9d99a2c7f5103a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50289",
+					"10.65.0.27:50289",
+					"172.17.0.1:50289",
+					"172.18.0.1:50289",
+					"172.19.0.1:50289",
+					"172.20.0.1:50289",
+					"172.21.0.1:50289",
+					"172.22.0.1:50289",
+					"172.23.0.1:50289",
+					"172.24.0.1:50289",
+					"172.25.0.1:50289",
+					"172.26.0.1:50289",
+					"172.27.0.1:50289",
+					"172.28.0.1:50289"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:21:22.075465365Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8302794691259322,
+				"StableID":   "nMGMHaLMq721CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc0f150fc848435ae963f263bbb5b44c14b4de07c306da65f1d9d65dba8aa915",
+				"DiscoKey":   "discokey:e715d93aeac9eec6096a3e18131bd442fe35e13a0347123bcfe21723c9cfbc1c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37978",
+					"10.65.0.27:37978",
+					"172.17.0.1:37978",
+					"172.18.0.1:37978",
+					"172.19.0.1:37978",
+					"172.20.0.1:37978",
+					"172.21.0.1:37978",
+					"172.22.0.1:37978",
+					"172.23.0.1:37978",
+					"172.24.0.1:37978",
+					"172.25.0.1:37978",
+					"172.26.0.1:37978",
+					"172.27.0.1:37978",
+					"172.28.0.1:37978"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:21:22.617210394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6814575453737212,
+				"StableID":   "nVZuRpLLDv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db04fe21e83f45ddbed5b8446f6a92caf01754c38ed27c782c26b81abb977210",
+				"DiscoKey":   "discokey:d554e83b854f98f53fbf98046b8bb4d073b7afa017c42441270fdfbfbba39e44",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33457",
+					"10.65.0.27:33457",
+					"172.17.0.1:33457",
+					"172.18.0.1:33457",
+					"172.19.0.1:33457",
+					"172.20.0.1:33457",
+					"172.21.0.1:33457",
+					"172.22.0.1:33457",
+					"172.23.0.1:33457",
+					"172.24.0.1:33457",
+					"172.25.0.1:33457",
+					"172.26.0.1:33457",
+					"172.27.0.1:33457",
+					"172.28.0.1:33457"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:21:23.460129792Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3971972035245068,
+				"StableID":   "nZjmNGyu1Y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:64e3c927a0d8a260091b63aedddce84cff7d3e81f07ea13778ccc698c7e98b43",
+				"DiscoKey":   "discokey:67171f195393cdbd79f7ad13688070985774fe21be0cedac150777af6508354f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38948",
+					"10.65.0.27:38948",
+					"172.17.0.1:38948",
+					"172.18.0.1:38948",
+					"172.19.0.1:38948",
+					"172.20.0.1:38948",
+					"172.21.0.1:38948",
+					"172.22.0.1:38948",
+					"172.23.0.1:38948",
+					"172.24.0.1:38948",
+					"172.25.0.1:38948",
+					"172.26.0.1:38948",
+					"172.27.0.1:38948",
+					"172.28.0.1:38948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:21:23.937568907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4372583465575495,
+				"StableID":   "nELNeUMM9b11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a3e5671fbb6f6c658d6e163b7bd993cced8c022df31b868e10c82fba42286347",
+				"DiscoKey":   "discokey:54b578d48e785aa696d2ee85a5a3bda9a5179f5a57705e00de174e882e2f5071",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51405",
+					"10.65.0.27:51405",
+					"172.17.0.1:51405",
+					"172.18.0.1:51405",
+					"172.19.0.1:51405",
+					"172.20.0.1:51405",
+					"172.21.0.1:51405",
+					"172.22.0.1:51405",
+					"172.23.0.1:51405",
+					"172.24.0.1:51405",
+					"172.25.0.1:51405",
+					"172.26.0.1:51405",
+					"172.27.0.1:51405",
+					"172.28.0.1:51405"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:21:24.602179146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4608126954712804,
+				"StableID":   "nfvWCWg2zc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ed292b4cfa8d08d12bc6fe9b393fad60418df600a2e19127099519a3fa1db3f",
+				"DiscoKey":   "discokey:fb18e1047c814faa1936128cd722a341358c30909e998cbd856d38e7658bc216",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44111",
+					"10.65.0.27:44111",
+					"172.17.0.1:44111",
+					"172.18.0.1:44111",
+					"172.19.0.1:44111",
+					"172.20.0.1:44111",
+					"172.21.0.1:44111",
+					"172.22.0.1:44111",
+					"172.23.0.1:44111",
+					"172.24.0.1:44111",
+					"172.25.0.1:44111",
+					"172.26.0.1:44111",
+					"172.27.0.1:44111",
+					"172.28.0.1:44111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:21:25.133517278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1500340108592974,
+				"StableID":   "nRGwiePWiC11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:005e465b964cc904806f5161328c8f685fd1e56b59f30ea0d13cad619bd75e7b",
+				"DiscoKey":   "discokey:23354def6c19b41d12b50b428bb2b86a4e2cb7471abf9f39a4e93fa76040f810",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:34139",
+					"10.65.0.27:34139",
+					"172.17.0.1:34139",
+					"172.18.0.1:34139",
+					"172.19.0.1:34139",
+					"172.20.0.1:34139",
+					"172.21.0.1:34139",
+					"172.22.0.1:34139",
+					"172.23.0.1:34139",
+					"172.24.0.1:34139",
+					"172.25.0.1:34139",
+					"172.26.0.1:34139",
+					"172.27.0.1:34139",
+					"172.28.0.1:34139"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:21:25.660717434Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4523172015074948,
+				"StableID":   "nwEe6R4ZKc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:43722a1489ece323af8ed65ad9fef1a309afef19f60109cf84536abd2f108c30",
+				"KeyExpiry":  "2026-11-09T09:21:26Z",
+				"DiscoKey":   "discokey:b905104a3ce14244a835cd8c1bce75dac82376d0fac4110c36a649a3b7f5c456",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49558",
+					"10.65.0.27:49558",
+					"172.17.0.1:49558",
+					"172.18.0.1:49558",
+					"172.19.0.1:49558",
+					"172.20.0.1:49558",
+					"172.21.0.1:49558",
+					"172.22.0.1:49558",
+					"172.23.0.1:49558",
+					"172.24.0.1:49558",
+					"172.25.0.1:49558",
+					"172.26.0.1:49558",
+					"172.27.0.1:49558",
+					"172.28.0.1:49558"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:21:26.723487548Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5848785703371618,
+				"StableID":   "n3V7Pbgvfn11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:61125883643bf13373afbfcc258f7ea148cd326b1273f337857ee86144c0521d",
+				"KeyExpiry":  "2026-11-09T09:21:27Z",
+				"DiscoKey":   "discokey:dc748887d44370c813a5e037e52b40bf597c6088551a43de750344a550be1a55",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55204",
+					"10.65.0.27:55204",
+					"172.17.0.1:55204",
+					"172.18.0.1:55204",
+					"172.19.0.1:55204",
+					"172.20.0.1:55204",
+					"172.21.0.1:55204",
+					"172.22.0.1:55204",
+					"172.23.0.1:55204",
+					"172.24.0.1:55204",
+					"172.25.0.1:55204",
+					"172.26.0.1:55204",
+					"172.27.0.1:55204",
+					"172.28.0.1:55204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:21:27.254674699Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4608126954712804,
+				"StableID":   "nfvWCWg2zc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       4608126954712804,
+				"Key":        "nodekey:4ed292b4cfa8d08d12bc6fe9b393fad60418df600a2e19127099519a3fa1db3f",
+				"DiscoKey":   "discokey:fb18e1047c814faa1936128cd722a341358c30909e998cbd856d38e7658bc216",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44111",
+					"10.65.0.27:44111",
+					"172.17.0.1:44111",
+					"172.18.0.1:44111",
+					"172.19.0.1:44111",
+					"172.20.0.1:44111",
+					"172.21.0.1:44111",
+					"172.22.0.1:44111",
+					"172.23.0.1:44111",
+					"172.24.0.1:44111",
+					"172.25.0.1:44111",
+					"172.26.0.1:44111",
+					"172.27.0.1:44111",
+					"172.28.0.1:44111"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:21:25.133517278Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4ed292b4cfa8d08d12bc6fe9b393fad60418df600a2e19127099519a3fa1db3f",
+			"MachineKey": "mkey:22bfbd6ef059d2a87a06f53cfcdae0a16671ad3c46c745bcddd2271897ed851e",
+			"Peers": [{
+				"ID":         8290277898300682,
+				"StableID":   "nPBh9UYgj721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:daf9699563bb8d8e86135a3eb1c6b4ca20670b36e6a6d87f7984fa2450dfe020",
+				"DiscoKey":   "discokey:cb20bf5e7e12b719e58613631bf8b830411be943c45ab7d2012c0f7256a01c1a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53542",
+					"10.65.0.27:53542",
+					"172.17.0.1:53542",
+					"172.18.0.1:53542",
+					"172.19.0.1:53542",
+					"172.20.0.1:53542",
+					"172.21.0.1:53542",
+					"172.22.0.1:53542",
+					"172.23.0.1:53542",
+					"172.24.0.1:53542",
+					"172.25.0.1:53542",
+					"172.26.0.1:53542",
+					"172.27.0.1:53542",
+					"172.28.0.1:53542"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:21:09.574498768Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3616621037328237,
+				"StableID":   "nvuqX7WyEV11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c2487b3a38488d006f9a28c6d9b90b5afdcc68a260cf02b1b7aa3d559f145e32",
+				"DiscoKey":   "discokey:b6300c737099421c5a52b06c2d6aad403b1f076f0f7debe347671b4eb63a7839",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33348",
+					"10.65.0.27:33348",
+					"172.17.0.1:33348",
+					"172.18.0.1:33348",
+					"172.19.0.1:33348",
+					"172.20.0.1:33348",
+					"172.21.0.1:33348",
+					"172.22.0.1:33348",
+					"172.23.0.1:33348",
+					"172.24.0.1:33348",
+					"172.25.0.1:33348",
+					"172.26.0.1:33348",
+					"172.27.0.1:33348",
+					"172.28.0.1:33348"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:21:15.566085445Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5655179600283341,
+				"StableID":   "nLgQ2myEAm11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:133c74cdf13dcb6f236645b723c019ea0eb574dd2c988e6aaebd0c202f7abc72",
+				"DiscoKey":   "discokey:7ede0fad082f1f4540afd15d339f4f14498fd7a2f6253565fc59cc8020788c3a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57092",
+					"10.65.0.27:57092",
+					"172.17.0.1:57092",
+					"172.18.0.1:57092",
+					"172.19.0.1:57092",
+					"172.20.0.1:57092",
+					"172.21.0.1:57092",
+					"172.22.0.1:57092",
+					"172.23.0.1:57092",
+					"172.24.0.1:57092",
+					"172.25.0.1:57092",
+					"172.26.0.1:57092",
+					"172.27.0.1:57092",
+					"172.28.0.1:57092"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:21:17.347104171Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5800192544056745,
+				"StableID":   "nJRwHvDvHn11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:73aa857fa92ce648735d5f6f595ac8b3078b14a194f56f72cee66647746ac61c",
+				"DiscoKey":   "discokey:ac62f171220e6de996c3a9a4719ae5fcbf913f3fedc5c0a98e110490ab01cf4a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42661",
+					"10.65.0.27:42661",
+					"172.17.0.1:42661",
+					"172.18.0.1:42661",
+					"172.19.0.1:42661",
+					"172.20.0.1:42661",
+					"172.21.0.1:42661",
+					"172.22.0.1:42661",
+					"172.23.0.1:42661",
+					"172.24.0.1:42661",
+					"172.25.0.1:42661",
+					"172.26.0.1:42661",
+					"172.27.0.1:42661",
+					"172.28.0.1:42661"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:21:21.012421424Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4725532368819453,
+				"StableID":   "nWdDctiCud11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec327910540dbdc61464d526ac9800df50d6b956244da10af3ea424102e7d30e",
+				"DiscoKey":   "discokey:4d276da3bd54817b6af5ed9d3da58b57c6a09de2b4bb7f94656e3175bb93175a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58383",
+					"10.65.0.27:58383",
+					"172.17.0.1:58383",
+					"172.18.0.1:58383",
+					"172.19.0.1:58383",
+					"172.20.0.1:58383",
+					"172.21.0.1:58383",
+					"172.22.0.1:58383",
+					"172.23.0.1:58383",
+					"172.24.0.1:58383",
+					"172.25.0.1:58383",
+					"172.26.0.1:58383",
+					"172.27.0.1:58383",
+					"172.28.0.1:58383"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:21:21.550796677Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6882282173853531,
+				"StableID":   "nJSFSBtzjv11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe5dd419cfaf8151c09428107e4ee85c074928fd9f8fe3da73694074121cf72d",
+				"DiscoKey":   "discokey:298f317d964805d70c955707e74cc3a06589f35df730a2211e9d99a2c7f5103a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50289",
+					"10.65.0.27:50289",
+					"172.17.0.1:50289",
+					"172.18.0.1:50289",
+					"172.19.0.1:50289",
+					"172.20.0.1:50289",
+					"172.21.0.1:50289",
+					"172.22.0.1:50289",
+					"172.23.0.1:50289",
+					"172.24.0.1:50289",
+					"172.25.0.1:50289",
+					"172.26.0.1:50289",
+					"172.27.0.1:50289",
+					"172.28.0.1:50289"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:21:22.075465365Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8302794691259322,
+				"StableID":   "nMGMHaLMq721CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc0f150fc848435ae963f263bbb5b44c14b4de07c306da65f1d9d65dba8aa915",
+				"DiscoKey":   "discokey:e715d93aeac9eec6096a3e18131bd442fe35e13a0347123bcfe21723c9cfbc1c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37978",
+					"10.65.0.27:37978",
+					"172.17.0.1:37978",
+					"172.18.0.1:37978",
+					"172.19.0.1:37978",
+					"172.20.0.1:37978",
+					"172.21.0.1:37978",
+					"172.22.0.1:37978",
+					"172.23.0.1:37978",
+					"172.24.0.1:37978",
+					"172.25.0.1:37978",
+					"172.26.0.1:37978",
+					"172.27.0.1:37978",
+					"172.28.0.1:37978"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:21:22.617210394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6814575453737212,
+				"StableID":   "nVZuRpLLDv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db04fe21e83f45ddbed5b8446f6a92caf01754c38ed27c782c26b81abb977210",
+				"DiscoKey":   "discokey:d554e83b854f98f53fbf98046b8bb4d073b7afa017c42441270fdfbfbba39e44",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33457",
+					"10.65.0.27:33457",
+					"172.17.0.1:33457",
+					"172.18.0.1:33457",
+					"172.19.0.1:33457",
+					"172.20.0.1:33457",
+					"172.21.0.1:33457",
+					"172.22.0.1:33457",
+					"172.23.0.1:33457",
+					"172.24.0.1:33457",
+					"172.25.0.1:33457",
+					"172.26.0.1:33457",
+					"172.27.0.1:33457",
+					"172.28.0.1:33457"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:21:23.460129792Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3971972035245068,
+				"StableID":   "nZjmNGyu1Y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:64e3c927a0d8a260091b63aedddce84cff7d3e81f07ea13778ccc698c7e98b43",
+				"DiscoKey":   "discokey:67171f195393cdbd79f7ad13688070985774fe21be0cedac150777af6508354f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38948",
+					"10.65.0.27:38948",
+					"172.17.0.1:38948",
+					"172.18.0.1:38948",
+					"172.19.0.1:38948",
+					"172.20.0.1:38948",
+					"172.21.0.1:38948",
+					"172.22.0.1:38948",
+					"172.23.0.1:38948",
+					"172.24.0.1:38948",
+					"172.25.0.1:38948",
+					"172.26.0.1:38948",
+					"172.27.0.1:38948",
+					"172.28.0.1:38948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:21:23.937568907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4372583465575495,
+				"StableID":   "nELNeUMM9b11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a3e5671fbb6f6c658d6e163b7bd993cced8c022df31b868e10c82fba42286347",
+				"DiscoKey":   "discokey:54b578d48e785aa696d2ee85a5a3bda9a5179f5a57705e00de174e882e2f5071",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51405",
+					"10.65.0.27:51405",
+					"172.17.0.1:51405",
+					"172.18.0.1:51405",
+					"172.19.0.1:51405",
+					"172.20.0.1:51405",
+					"172.21.0.1:51405",
+					"172.22.0.1:51405",
+					"172.23.0.1:51405",
+					"172.24.0.1:51405",
+					"172.25.0.1:51405",
+					"172.26.0.1:51405",
+					"172.27.0.1:51405",
+					"172.28.0.1:51405"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:21:24.602179146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1500340108592974,
+				"StableID":   "nRGwiePWiC11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:005e465b964cc904806f5161328c8f685fd1e56b59f30ea0d13cad619bd75e7b",
+				"DiscoKey":   "discokey:23354def6c19b41d12b50b428bb2b86a4e2cb7471abf9f39a4e93fa76040f810",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:34139",
+					"10.65.0.27:34139",
+					"172.17.0.1:34139",
+					"172.18.0.1:34139",
+					"172.19.0.1:34139",
+					"172.20.0.1:34139",
+					"172.21.0.1:34139",
+					"172.22.0.1:34139",
+					"172.23.0.1:34139",
+					"172.24.0.1:34139",
+					"172.25.0.1:34139",
+					"172.26.0.1:34139",
+					"172.27.0.1:34139",
+					"172.28.0.1:34139"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:21:25.660717434Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         521955752537854,
+				"StableID":   "ndAuVmtP5511CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:cc439a49e3f189d63a5a8b0deff24686018316cc041e6495c7dbab9074185e52",
+				"KeyExpiry":  "2026-11-09T09:21:26Z",
+				"DiscoKey":   "discokey:9373753ec674e553510849fb70c3d11a030a8ebdb697b79811e40fb34e754b34",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:36848",
+					"10.65.0.27:36848",
+					"172.17.0.1:36848",
+					"172.18.0.1:36848",
+					"172.19.0.1:36848",
+					"172.20.0.1:36848",
+					"172.21.0.1:36848",
+					"172.22.0.1:36848",
+					"172.23.0.1:36848",
+					"172.24.0.1:36848",
+					"172.25.0.1:36848",
+					"172.26.0.1:36848",
+					"172.27.0.1:36848",
+					"172.28.0.1:36848"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:21:26.194723126Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4523172015074948,
+				"StableID":   "nwEe6R4ZKc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:43722a1489ece323af8ed65ad9fef1a309afef19f60109cf84536abd2f108c30",
+				"KeyExpiry":  "2026-11-09T09:21:26Z",
+				"DiscoKey":   "discokey:b905104a3ce14244a835cd8c1bce75dac82376d0fac4110c36a649a3b7f5c456",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49558",
+					"10.65.0.27:49558",
+					"172.17.0.1:49558",
+					"172.18.0.1:49558",
+					"172.19.0.1:49558",
+					"172.20.0.1:49558",
+					"172.21.0.1:49558",
+					"172.22.0.1:49558",
+					"172.23.0.1:49558",
+					"172.24.0.1:49558",
+					"172.25.0.1:49558",
+					"172.26.0.1:49558",
+					"172.27.0.1:49558",
+					"172.28.0.1:49558"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:21:26.723487548Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5848785703371618,
+				"StableID":   "n3V7Pbgvfn11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:61125883643bf13373afbfcc258f7ea148cd326b1273f337857ee86144c0521d",
+				"KeyExpiry":  "2026-11-09T09:21:27Z",
+				"DiscoKey":   "discokey:dc748887d44370c813a5e037e52b40bf597c6088551a43de750344a550be1a55",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55204",
+					"10.65.0.27:55204",
+					"172.17.0.1:55204",
+					"172.18.0.1:55204",
+					"172.19.0.1:55204",
+					"172.20.0.1:55204",
+					"172.21.0.1:55204",
+					"172.22.0.1:55204",
+					"172.23.0.1:55204",
+					"172.24.0.1:55204",
+					"172.25.0.1:55204",
+					"172.26.0.1:55204",
+					"172.27.0.1:55204",
+					"172.28.0.1:55204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:21:27.254674699Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4608126954712804": {
+				"ID":          4608126954712804,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3616621037328237,
+				"StableID":   "nvuqX7WyEV11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       3616621037328237,
+				"Key":        "nodekey:c2487b3a38488d006f9a28c6d9b90b5afdcc68a260cf02b1b7aa3d559f145e32",
+				"DiscoKey":   "discokey:b6300c737099421c5a52b06c2d6aad403b1f076f0f7debe347671b4eb63a7839",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33348",
+					"10.65.0.27:33348",
+					"172.17.0.1:33348",
+					"172.18.0.1:33348",
+					"172.19.0.1:33348",
+					"172.20.0.1:33348",
+					"172.21.0.1:33348",
+					"172.22.0.1:33348",
+					"172.23.0.1:33348",
+					"172.24.0.1:33348",
+					"172.25.0.1:33348",
+					"172.26.0.1:33348",
+					"172.27.0.1:33348",
+					"172.28.0.1:33348"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:21:15.566085445Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c2487b3a38488d006f9a28c6d9b90b5afdcc68a260cf02b1b7aa3d559f145e32",
+			"MachineKey": "mkey:6b71bdc48f5f97b58222dd5760caf0ad388d853b5be7fa6056ebbd589a13fa12",
+			"Peers": [{
+				"ID":         8290277898300682,
+				"StableID":   "nPBh9UYgj721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:daf9699563bb8d8e86135a3eb1c6b4ca20670b36e6a6d87f7984fa2450dfe020",
+				"DiscoKey":   "discokey:cb20bf5e7e12b719e58613631bf8b830411be943c45ab7d2012c0f7256a01c1a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53542",
+					"10.65.0.27:53542",
+					"172.17.0.1:53542",
+					"172.18.0.1:53542",
+					"172.19.0.1:53542",
+					"172.20.0.1:53542",
+					"172.21.0.1:53542",
+					"172.22.0.1:53542",
+					"172.23.0.1:53542",
+					"172.24.0.1:53542",
+					"172.25.0.1:53542",
+					"172.26.0.1:53542",
+					"172.27.0.1:53542",
+					"172.28.0.1:53542"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:21:09.574498768Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5655179600283341,
+				"StableID":   "nLgQ2myEAm11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:133c74cdf13dcb6f236645b723c019ea0eb574dd2c988e6aaebd0c202f7abc72",
+				"DiscoKey":   "discokey:7ede0fad082f1f4540afd15d339f4f14498fd7a2f6253565fc59cc8020788c3a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57092",
+					"10.65.0.27:57092",
+					"172.17.0.1:57092",
+					"172.18.0.1:57092",
+					"172.19.0.1:57092",
+					"172.20.0.1:57092",
+					"172.21.0.1:57092",
+					"172.22.0.1:57092",
+					"172.23.0.1:57092",
+					"172.24.0.1:57092",
+					"172.25.0.1:57092",
+					"172.26.0.1:57092",
+					"172.27.0.1:57092",
+					"172.28.0.1:57092"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:21:17.347104171Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5800192544056745,
+				"StableID":   "nJRwHvDvHn11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:73aa857fa92ce648735d5f6f595ac8b3078b14a194f56f72cee66647746ac61c",
+				"DiscoKey":   "discokey:ac62f171220e6de996c3a9a4719ae5fcbf913f3fedc5c0a98e110490ab01cf4a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42661",
+					"10.65.0.27:42661",
+					"172.17.0.1:42661",
+					"172.18.0.1:42661",
+					"172.19.0.1:42661",
+					"172.20.0.1:42661",
+					"172.21.0.1:42661",
+					"172.22.0.1:42661",
+					"172.23.0.1:42661",
+					"172.24.0.1:42661",
+					"172.25.0.1:42661",
+					"172.26.0.1:42661",
+					"172.27.0.1:42661",
+					"172.28.0.1:42661"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:21:21.012421424Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4725532368819453,
+				"StableID":   "nWdDctiCud11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec327910540dbdc61464d526ac9800df50d6b956244da10af3ea424102e7d30e",
+				"DiscoKey":   "discokey:4d276da3bd54817b6af5ed9d3da58b57c6a09de2b4bb7f94656e3175bb93175a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58383",
+					"10.65.0.27:58383",
+					"172.17.0.1:58383",
+					"172.18.0.1:58383",
+					"172.19.0.1:58383",
+					"172.20.0.1:58383",
+					"172.21.0.1:58383",
+					"172.22.0.1:58383",
+					"172.23.0.1:58383",
+					"172.24.0.1:58383",
+					"172.25.0.1:58383",
+					"172.26.0.1:58383",
+					"172.27.0.1:58383",
+					"172.28.0.1:58383"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:21:21.550796677Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6882282173853531,
+				"StableID":   "nJSFSBtzjv11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe5dd419cfaf8151c09428107e4ee85c074928fd9f8fe3da73694074121cf72d",
+				"DiscoKey":   "discokey:298f317d964805d70c955707e74cc3a06589f35df730a2211e9d99a2c7f5103a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50289",
+					"10.65.0.27:50289",
+					"172.17.0.1:50289",
+					"172.18.0.1:50289",
+					"172.19.0.1:50289",
+					"172.20.0.1:50289",
+					"172.21.0.1:50289",
+					"172.22.0.1:50289",
+					"172.23.0.1:50289",
+					"172.24.0.1:50289",
+					"172.25.0.1:50289",
+					"172.26.0.1:50289",
+					"172.27.0.1:50289",
+					"172.28.0.1:50289"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:21:22.075465365Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8302794691259322,
+				"StableID":   "nMGMHaLMq721CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc0f150fc848435ae963f263bbb5b44c14b4de07c306da65f1d9d65dba8aa915",
+				"DiscoKey":   "discokey:e715d93aeac9eec6096a3e18131bd442fe35e13a0347123bcfe21723c9cfbc1c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37978",
+					"10.65.0.27:37978",
+					"172.17.0.1:37978",
+					"172.18.0.1:37978",
+					"172.19.0.1:37978",
+					"172.20.0.1:37978",
+					"172.21.0.1:37978",
+					"172.22.0.1:37978",
+					"172.23.0.1:37978",
+					"172.24.0.1:37978",
+					"172.25.0.1:37978",
+					"172.26.0.1:37978",
+					"172.27.0.1:37978",
+					"172.28.0.1:37978"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:21:22.617210394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6814575453737212,
+				"StableID":   "nVZuRpLLDv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db04fe21e83f45ddbed5b8446f6a92caf01754c38ed27c782c26b81abb977210",
+				"DiscoKey":   "discokey:d554e83b854f98f53fbf98046b8bb4d073b7afa017c42441270fdfbfbba39e44",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33457",
+					"10.65.0.27:33457",
+					"172.17.0.1:33457",
+					"172.18.0.1:33457",
+					"172.19.0.1:33457",
+					"172.20.0.1:33457",
+					"172.21.0.1:33457",
+					"172.22.0.1:33457",
+					"172.23.0.1:33457",
+					"172.24.0.1:33457",
+					"172.25.0.1:33457",
+					"172.26.0.1:33457",
+					"172.27.0.1:33457",
+					"172.28.0.1:33457"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:21:23.460129792Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3971972035245068,
+				"StableID":   "nZjmNGyu1Y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:64e3c927a0d8a260091b63aedddce84cff7d3e81f07ea13778ccc698c7e98b43",
+				"DiscoKey":   "discokey:67171f195393cdbd79f7ad13688070985774fe21be0cedac150777af6508354f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38948",
+					"10.65.0.27:38948",
+					"172.17.0.1:38948",
+					"172.18.0.1:38948",
+					"172.19.0.1:38948",
+					"172.20.0.1:38948",
+					"172.21.0.1:38948",
+					"172.22.0.1:38948",
+					"172.23.0.1:38948",
+					"172.24.0.1:38948",
+					"172.25.0.1:38948",
+					"172.26.0.1:38948",
+					"172.27.0.1:38948",
+					"172.28.0.1:38948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:21:23.937568907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4372583465575495,
+				"StableID":   "nELNeUMM9b11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a3e5671fbb6f6c658d6e163b7bd993cced8c022df31b868e10c82fba42286347",
+				"DiscoKey":   "discokey:54b578d48e785aa696d2ee85a5a3bda9a5179f5a57705e00de174e882e2f5071",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51405",
+					"10.65.0.27:51405",
+					"172.17.0.1:51405",
+					"172.18.0.1:51405",
+					"172.19.0.1:51405",
+					"172.20.0.1:51405",
+					"172.21.0.1:51405",
+					"172.22.0.1:51405",
+					"172.23.0.1:51405",
+					"172.24.0.1:51405",
+					"172.25.0.1:51405",
+					"172.26.0.1:51405",
+					"172.27.0.1:51405",
+					"172.28.0.1:51405"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:21:24.602179146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4608126954712804,
+				"StableID":   "nfvWCWg2zc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ed292b4cfa8d08d12bc6fe9b393fad60418df600a2e19127099519a3fa1db3f",
+				"DiscoKey":   "discokey:fb18e1047c814faa1936128cd722a341358c30909e998cbd856d38e7658bc216",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44111",
+					"10.65.0.27:44111",
+					"172.17.0.1:44111",
+					"172.18.0.1:44111",
+					"172.19.0.1:44111",
+					"172.20.0.1:44111",
+					"172.21.0.1:44111",
+					"172.22.0.1:44111",
+					"172.23.0.1:44111",
+					"172.24.0.1:44111",
+					"172.25.0.1:44111",
+					"172.26.0.1:44111",
+					"172.27.0.1:44111",
+					"172.28.0.1:44111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:21:25.133517278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1500340108592974,
+				"StableID":   "nRGwiePWiC11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:005e465b964cc904806f5161328c8f685fd1e56b59f30ea0d13cad619bd75e7b",
+				"DiscoKey":   "discokey:23354def6c19b41d12b50b428bb2b86a4e2cb7471abf9f39a4e93fa76040f810",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:34139",
+					"10.65.0.27:34139",
+					"172.17.0.1:34139",
+					"172.18.0.1:34139",
+					"172.19.0.1:34139",
+					"172.20.0.1:34139",
+					"172.21.0.1:34139",
+					"172.22.0.1:34139",
+					"172.23.0.1:34139",
+					"172.24.0.1:34139",
+					"172.25.0.1:34139",
+					"172.26.0.1:34139",
+					"172.27.0.1:34139",
+					"172.28.0.1:34139"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:21:25.660717434Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         521955752537854,
+				"StableID":   "ndAuVmtP5511CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:cc439a49e3f189d63a5a8b0deff24686018316cc041e6495c7dbab9074185e52",
+				"KeyExpiry":  "2026-11-09T09:21:26Z",
+				"DiscoKey":   "discokey:9373753ec674e553510849fb70c3d11a030a8ebdb697b79811e40fb34e754b34",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:36848",
+					"10.65.0.27:36848",
+					"172.17.0.1:36848",
+					"172.18.0.1:36848",
+					"172.19.0.1:36848",
+					"172.20.0.1:36848",
+					"172.21.0.1:36848",
+					"172.22.0.1:36848",
+					"172.23.0.1:36848",
+					"172.24.0.1:36848",
+					"172.25.0.1:36848",
+					"172.26.0.1:36848",
+					"172.27.0.1:36848",
+					"172.28.0.1:36848"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:21:26.194723126Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4523172015074948,
+				"StableID":   "nwEe6R4ZKc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:43722a1489ece323af8ed65ad9fef1a309afef19f60109cf84536abd2f108c30",
+				"KeyExpiry":  "2026-11-09T09:21:26Z",
+				"DiscoKey":   "discokey:b905104a3ce14244a835cd8c1bce75dac82376d0fac4110c36a649a3b7f5c456",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49558",
+					"10.65.0.27:49558",
+					"172.17.0.1:49558",
+					"172.18.0.1:49558",
+					"172.19.0.1:49558",
+					"172.20.0.1:49558",
+					"172.21.0.1:49558",
+					"172.22.0.1:49558",
+					"172.23.0.1:49558",
+					"172.24.0.1:49558",
+					"172.25.0.1:49558",
+					"172.26.0.1:49558",
+					"172.27.0.1:49558",
+					"172.28.0.1:49558"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:21:26.723487548Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5848785703371618,
+				"StableID":   "n3V7Pbgvfn11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:61125883643bf13373afbfcc258f7ea148cd326b1273f337857ee86144c0521d",
+				"KeyExpiry":  "2026-11-09T09:21:27Z",
+				"DiscoKey":   "discokey:dc748887d44370c813a5e037e52b40bf597c6088551a43de750344a550be1a55",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55204",
+					"10.65.0.27:55204",
+					"172.17.0.1:55204",
+					"172.18.0.1:55204",
+					"172.19.0.1:55204",
+					"172.20.0.1:55204",
+					"172.21.0.1:55204",
+					"172.22.0.1:55204",
+					"172.23.0.1:55204",
+					"172.24.0.1:55204",
+					"172.25.0.1:55204",
+					"172.26.0.1:55204",
+					"172.27.0.1:55204",
+					"172.28.0.1:55204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:21:27.254674699Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3616621037328237": {
+				"ID":          3616621037328237,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8290277898300682,
+				"StableID":   "nPBh9UYgj721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       8290277898300682,
+				"Key":        "nodekey:daf9699563bb8d8e86135a3eb1c6b4ca20670b36e6a6d87f7984fa2450dfe020",
+				"DiscoKey":   "discokey:cb20bf5e7e12b719e58613631bf8b830411be943c45ab7d2012c0f7256a01c1a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53542",
+					"10.65.0.27:53542",
+					"172.17.0.1:53542",
+					"172.18.0.1:53542",
+					"172.19.0.1:53542",
+					"172.20.0.1:53542",
+					"172.21.0.1:53542",
+					"172.22.0.1:53542",
+					"172.23.0.1:53542",
+					"172.24.0.1:53542",
+					"172.25.0.1:53542",
+					"172.26.0.1:53542",
+					"172.27.0.1:53542",
+					"172.28.0.1:53542"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:21:09.574498768Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:daf9699563bb8d8e86135a3eb1c6b4ca20670b36e6a6d87f7984fa2450dfe020",
+			"MachineKey": "mkey:bafe5bf9594f395c147437ccbe9717b783b2bc261ba132f14bc9ba71891fa918",
+			"Peers": [{
+				"ID":         3616621037328237,
+				"StableID":   "nvuqX7WyEV11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c2487b3a38488d006f9a28c6d9b90b5afdcc68a260cf02b1b7aa3d559f145e32",
+				"DiscoKey":   "discokey:b6300c737099421c5a52b06c2d6aad403b1f076f0f7debe347671b4eb63a7839",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33348",
+					"10.65.0.27:33348",
+					"172.17.0.1:33348",
+					"172.18.0.1:33348",
+					"172.19.0.1:33348",
+					"172.20.0.1:33348",
+					"172.21.0.1:33348",
+					"172.22.0.1:33348",
+					"172.23.0.1:33348",
+					"172.24.0.1:33348",
+					"172.25.0.1:33348",
+					"172.26.0.1:33348",
+					"172.27.0.1:33348",
+					"172.28.0.1:33348"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:21:15.566085445Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5655179600283341,
+				"StableID":   "nLgQ2myEAm11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:133c74cdf13dcb6f236645b723c019ea0eb574dd2c988e6aaebd0c202f7abc72",
+				"DiscoKey":   "discokey:7ede0fad082f1f4540afd15d339f4f14498fd7a2f6253565fc59cc8020788c3a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57092",
+					"10.65.0.27:57092",
+					"172.17.0.1:57092",
+					"172.18.0.1:57092",
+					"172.19.0.1:57092",
+					"172.20.0.1:57092",
+					"172.21.0.1:57092",
+					"172.22.0.1:57092",
+					"172.23.0.1:57092",
+					"172.24.0.1:57092",
+					"172.25.0.1:57092",
+					"172.26.0.1:57092",
+					"172.27.0.1:57092",
+					"172.28.0.1:57092"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:21:17.347104171Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5800192544056745,
+				"StableID":   "nJRwHvDvHn11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:73aa857fa92ce648735d5f6f595ac8b3078b14a194f56f72cee66647746ac61c",
+				"DiscoKey":   "discokey:ac62f171220e6de996c3a9a4719ae5fcbf913f3fedc5c0a98e110490ab01cf4a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42661",
+					"10.65.0.27:42661",
+					"172.17.0.1:42661",
+					"172.18.0.1:42661",
+					"172.19.0.1:42661",
+					"172.20.0.1:42661",
+					"172.21.0.1:42661",
+					"172.22.0.1:42661",
+					"172.23.0.1:42661",
+					"172.24.0.1:42661",
+					"172.25.0.1:42661",
+					"172.26.0.1:42661",
+					"172.27.0.1:42661",
+					"172.28.0.1:42661"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:21:21.012421424Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4725532368819453,
+				"StableID":   "nWdDctiCud11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec327910540dbdc61464d526ac9800df50d6b956244da10af3ea424102e7d30e",
+				"DiscoKey":   "discokey:4d276da3bd54817b6af5ed9d3da58b57c6a09de2b4bb7f94656e3175bb93175a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58383",
+					"10.65.0.27:58383",
+					"172.17.0.1:58383",
+					"172.18.0.1:58383",
+					"172.19.0.1:58383",
+					"172.20.0.1:58383",
+					"172.21.0.1:58383",
+					"172.22.0.1:58383",
+					"172.23.0.1:58383",
+					"172.24.0.1:58383",
+					"172.25.0.1:58383",
+					"172.26.0.1:58383",
+					"172.27.0.1:58383",
+					"172.28.0.1:58383"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:21:21.550796677Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6882282173853531,
+				"StableID":   "nJSFSBtzjv11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe5dd419cfaf8151c09428107e4ee85c074928fd9f8fe3da73694074121cf72d",
+				"DiscoKey":   "discokey:298f317d964805d70c955707e74cc3a06589f35df730a2211e9d99a2c7f5103a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50289",
+					"10.65.0.27:50289",
+					"172.17.0.1:50289",
+					"172.18.0.1:50289",
+					"172.19.0.1:50289",
+					"172.20.0.1:50289",
+					"172.21.0.1:50289",
+					"172.22.0.1:50289",
+					"172.23.0.1:50289",
+					"172.24.0.1:50289",
+					"172.25.0.1:50289",
+					"172.26.0.1:50289",
+					"172.27.0.1:50289",
+					"172.28.0.1:50289"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:21:22.075465365Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8302794691259322,
+				"StableID":   "nMGMHaLMq721CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc0f150fc848435ae963f263bbb5b44c14b4de07c306da65f1d9d65dba8aa915",
+				"DiscoKey":   "discokey:e715d93aeac9eec6096a3e18131bd442fe35e13a0347123bcfe21723c9cfbc1c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37978",
+					"10.65.0.27:37978",
+					"172.17.0.1:37978",
+					"172.18.0.1:37978",
+					"172.19.0.1:37978",
+					"172.20.0.1:37978",
+					"172.21.0.1:37978",
+					"172.22.0.1:37978",
+					"172.23.0.1:37978",
+					"172.24.0.1:37978",
+					"172.25.0.1:37978",
+					"172.26.0.1:37978",
+					"172.27.0.1:37978",
+					"172.28.0.1:37978"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:21:22.617210394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6814575453737212,
+				"StableID":   "nVZuRpLLDv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db04fe21e83f45ddbed5b8446f6a92caf01754c38ed27c782c26b81abb977210",
+				"DiscoKey":   "discokey:d554e83b854f98f53fbf98046b8bb4d073b7afa017c42441270fdfbfbba39e44",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33457",
+					"10.65.0.27:33457",
+					"172.17.0.1:33457",
+					"172.18.0.1:33457",
+					"172.19.0.1:33457",
+					"172.20.0.1:33457",
+					"172.21.0.1:33457",
+					"172.22.0.1:33457",
+					"172.23.0.1:33457",
+					"172.24.0.1:33457",
+					"172.25.0.1:33457",
+					"172.26.0.1:33457",
+					"172.27.0.1:33457",
+					"172.28.0.1:33457"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:21:23.460129792Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3971972035245068,
+				"StableID":   "nZjmNGyu1Y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:64e3c927a0d8a260091b63aedddce84cff7d3e81f07ea13778ccc698c7e98b43",
+				"DiscoKey":   "discokey:67171f195393cdbd79f7ad13688070985774fe21be0cedac150777af6508354f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38948",
+					"10.65.0.27:38948",
+					"172.17.0.1:38948",
+					"172.18.0.1:38948",
+					"172.19.0.1:38948",
+					"172.20.0.1:38948",
+					"172.21.0.1:38948",
+					"172.22.0.1:38948",
+					"172.23.0.1:38948",
+					"172.24.0.1:38948",
+					"172.25.0.1:38948",
+					"172.26.0.1:38948",
+					"172.27.0.1:38948",
+					"172.28.0.1:38948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:21:23.937568907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4372583465575495,
+				"StableID":   "nELNeUMM9b11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a3e5671fbb6f6c658d6e163b7bd993cced8c022df31b868e10c82fba42286347",
+				"DiscoKey":   "discokey:54b578d48e785aa696d2ee85a5a3bda9a5179f5a57705e00de174e882e2f5071",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51405",
+					"10.65.0.27:51405",
+					"172.17.0.1:51405",
+					"172.18.0.1:51405",
+					"172.19.0.1:51405",
+					"172.20.0.1:51405",
+					"172.21.0.1:51405",
+					"172.22.0.1:51405",
+					"172.23.0.1:51405",
+					"172.24.0.1:51405",
+					"172.25.0.1:51405",
+					"172.26.0.1:51405",
+					"172.27.0.1:51405",
+					"172.28.0.1:51405"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:21:24.602179146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4608126954712804,
+				"StableID":   "nfvWCWg2zc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ed292b4cfa8d08d12bc6fe9b393fad60418df600a2e19127099519a3fa1db3f",
+				"DiscoKey":   "discokey:fb18e1047c814faa1936128cd722a341358c30909e998cbd856d38e7658bc216",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44111",
+					"10.65.0.27:44111",
+					"172.17.0.1:44111",
+					"172.18.0.1:44111",
+					"172.19.0.1:44111",
+					"172.20.0.1:44111",
+					"172.21.0.1:44111",
+					"172.22.0.1:44111",
+					"172.23.0.1:44111",
+					"172.24.0.1:44111",
+					"172.25.0.1:44111",
+					"172.26.0.1:44111",
+					"172.27.0.1:44111",
+					"172.28.0.1:44111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:21:25.133517278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1500340108592974,
+				"StableID":   "nRGwiePWiC11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:005e465b964cc904806f5161328c8f685fd1e56b59f30ea0d13cad619bd75e7b",
+				"DiscoKey":   "discokey:23354def6c19b41d12b50b428bb2b86a4e2cb7471abf9f39a4e93fa76040f810",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:34139",
+					"10.65.0.27:34139",
+					"172.17.0.1:34139",
+					"172.18.0.1:34139",
+					"172.19.0.1:34139",
+					"172.20.0.1:34139",
+					"172.21.0.1:34139",
+					"172.22.0.1:34139",
+					"172.23.0.1:34139",
+					"172.24.0.1:34139",
+					"172.25.0.1:34139",
+					"172.26.0.1:34139",
+					"172.27.0.1:34139",
+					"172.28.0.1:34139"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:21:25.660717434Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         521955752537854,
+				"StableID":   "ndAuVmtP5511CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:cc439a49e3f189d63a5a8b0deff24686018316cc041e6495c7dbab9074185e52",
+				"KeyExpiry":  "2026-11-09T09:21:26Z",
+				"DiscoKey":   "discokey:9373753ec674e553510849fb70c3d11a030a8ebdb697b79811e40fb34e754b34",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:36848",
+					"10.65.0.27:36848",
+					"172.17.0.1:36848",
+					"172.18.0.1:36848",
+					"172.19.0.1:36848",
+					"172.20.0.1:36848",
+					"172.21.0.1:36848",
+					"172.22.0.1:36848",
+					"172.23.0.1:36848",
+					"172.24.0.1:36848",
+					"172.25.0.1:36848",
+					"172.26.0.1:36848",
+					"172.27.0.1:36848",
+					"172.28.0.1:36848"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:21:26.194723126Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4523172015074948,
+				"StableID":   "nwEe6R4ZKc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:43722a1489ece323af8ed65ad9fef1a309afef19f60109cf84536abd2f108c30",
+				"KeyExpiry":  "2026-11-09T09:21:26Z",
+				"DiscoKey":   "discokey:b905104a3ce14244a835cd8c1bce75dac82376d0fac4110c36a649a3b7f5c456",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49558",
+					"10.65.0.27:49558",
+					"172.17.0.1:49558",
+					"172.18.0.1:49558",
+					"172.19.0.1:49558",
+					"172.20.0.1:49558",
+					"172.21.0.1:49558",
+					"172.22.0.1:49558",
+					"172.23.0.1:49558",
+					"172.24.0.1:49558",
+					"172.25.0.1:49558",
+					"172.26.0.1:49558",
+					"172.27.0.1:49558",
+					"172.28.0.1:49558"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:21:26.723487548Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5848785703371618,
+				"StableID":   "n3V7Pbgvfn11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:61125883643bf13373afbfcc258f7ea148cd326b1273f337857ee86144c0521d",
+				"KeyExpiry":  "2026-11-09T09:21:27Z",
+				"DiscoKey":   "discokey:dc748887d44370c813a5e037e52b40bf597c6088551a43de750344a550be1a55",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55204",
+					"10.65.0.27:55204",
+					"172.17.0.1:55204",
+					"172.18.0.1:55204",
+					"172.19.0.1:55204",
+					"172.20.0.1:55204",
+					"172.21.0.1:55204",
+					"172.22.0.1:55204",
+					"172.23.0.1:55204",
+					"172.24.0.1:55204",
+					"172.25.0.1:55204",
+					"172.26.0.1:55204",
+					"172.27.0.1:55204",
+					"172.28.0.1:55204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:21:27.254674699Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8290277898300682": {
+				"ID":          8290277898300682,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4725532368819453,
+				"StableID":   "nWdDctiCud11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       4725532368819453,
+				"Key":        "nodekey:ec327910540dbdc61464d526ac9800df50d6b956244da10af3ea424102e7d30e",
+				"DiscoKey":   "discokey:4d276da3bd54817b6af5ed9d3da58b57c6a09de2b4bb7f94656e3175bb93175a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58383",
+					"10.65.0.27:58383",
+					"172.17.0.1:58383",
+					"172.18.0.1:58383",
+					"172.19.0.1:58383",
+					"172.20.0.1:58383",
+					"172.21.0.1:58383",
+					"172.22.0.1:58383",
+					"172.23.0.1:58383",
+					"172.24.0.1:58383",
+					"172.25.0.1:58383",
+					"172.26.0.1:58383",
+					"172.27.0.1:58383",
+					"172.28.0.1:58383"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:21:21.550796677Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ec327910540dbdc61464d526ac9800df50d6b956244da10af3ea424102e7d30e",
+			"MachineKey": "mkey:e51d12b234c9af44e30848e1a12b809bd5e1d7af442c625553c670671d08df16",
+			"Peers": [{
+				"ID":         8290277898300682,
+				"StableID":   "nPBh9UYgj721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:daf9699563bb8d8e86135a3eb1c6b4ca20670b36e6a6d87f7984fa2450dfe020",
+				"DiscoKey":   "discokey:cb20bf5e7e12b719e58613631bf8b830411be943c45ab7d2012c0f7256a01c1a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53542",
+					"10.65.0.27:53542",
+					"172.17.0.1:53542",
+					"172.18.0.1:53542",
+					"172.19.0.1:53542",
+					"172.20.0.1:53542",
+					"172.21.0.1:53542",
+					"172.22.0.1:53542",
+					"172.23.0.1:53542",
+					"172.24.0.1:53542",
+					"172.25.0.1:53542",
+					"172.26.0.1:53542",
+					"172.27.0.1:53542",
+					"172.28.0.1:53542"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:21:09.574498768Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3616621037328237,
+				"StableID":   "nvuqX7WyEV11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c2487b3a38488d006f9a28c6d9b90b5afdcc68a260cf02b1b7aa3d559f145e32",
+				"DiscoKey":   "discokey:b6300c737099421c5a52b06c2d6aad403b1f076f0f7debe347671b4eb63a7839",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33348",
+					"10.65.0.27:33348",
+					"172.17.0.1:33348",
+					"172.18.0.1:33348",
+					"172.19.0.1:33348",
+					"172.20.0.1:33348",
+					"172.21.0.1:33348",
+					"172.22.0.1:33348",
+					"172.23.0.1:33348",
+					"172.24.0.1:33348",
+					"172.25.0.1:33348",
+					"172.26.0.1:33348",
+					"172.27.0.1:33348",
+					"172.28.0.1:33348"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:21:15.566085445Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5655179600283341,
+				"StableID":   "nLgQ2myEAm11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:133c74cdf13dcb6f236645b723c019ea0eb574dd2c988e6aaebd0c202f7abc72",
+				"DiscoKey":   "discokey:7ede0fad082f1f4540afd15d339f4f14498fd7a2f6253565fc59cc8020788c3a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57092",
+					"10.65.0.27:57092",
+					"172.17.0.1:57092",
+					"172.18.0.1:57092",
+					"172.19.0.1:57092",
+					"172.20.0.1:57092",
+					"172.21.0.1:57092",
+					"172.22.0.1:57092",
+					"172.23.0.1:57092",
+					"172.24.0.1:57092",
+					"172.25.0.1:57092",
+					"172.26.0.1:57092",
+					"172.27.0.1:57092",
+					"172.28.0.1:57092"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:21:17.347104171Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5800192544056745,
+				"StableID":   "nJRwHvDvHn11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:73aa857fa92ce648735d5f6f595ac8b3078b14a194f56f72cee66647746ac61c",
+				"DiscoKey":   "discokey:ac62f171220e6de996c3a9a4719ae5fcbf913f3fedc5c0a98e110490ab01cf4a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42661",
+					"10.65.0.27:42661",
+					"172.17.0.1:42661",
+					"172.18.0.1:42661",
+					"172.19.0.1:42661",
+					"172.20.0.1:42661",
+					"172.21.0.1:42661",
+					"172.22.0.1:42661",
+					"172.23.0.1:42661",
+					"172.24.0.1:42661",
+					"172.25.0.1:42661",
+					"172.26.0.1:42661",
+					"172.27.0.1:42661",
+					"172.28.0.1:42661"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:21:21.012421424Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6882282173853531,
+				"StableID":   "nJSFSBtzjv11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe5dd419cfaf8151c09428107e4ee85c074928fd9f8fe3da73694074121cf72d",
+				"DiscoKey":   "discokey:298f317d964805d70c955707e74cc3a06589f35df730a2211e9d99a2c7f5103a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50289",
+					"10.65.0.27:50289",
+					"172.17.0.1:50289",
+					"172.18.0.1:50289",
+					"172.19.0.1:50289",
+					"172.20.0.1:50289",
+					"172.21.0.1:50289",
+					"172.22.0.1:50289",
+					"172.23.0.1:50289",
+					"172.24.0.1:50289",
+					"172.25.0.1:50289",
+					"172.26.0.1:50289",
+					"172.27.0.1:50289",
+					"172.28.0.1:50289"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:21:22.075465365Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8302794691259322,
+				"StableID":   "nMGMHaLMq721CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc0f150fc848435ae963f263bbb5b44c14b4de07c306da65f1d9d65dba8aa915",
+				"DiscoKey":   "discokey:e715d93aeac9eec6096a3e18131bd442fe35e13a0347123bcfe21723c9cfbc1c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37978",
+					"10.65.0.27:37978",
+					"172.17.0.1:37978",
+					"172.18.0.1:37978",
+					"172.19.0.1:37978",
+					"172.20.0.1:37978",
+					"172.21.0.1:37978",
+					"172.22.0.1:37978",
+					"172.23.0.1:37978",
+					"172.24.0.1:37978",
+					"172.25.0.1:37978",
+					"172.26.0.1:37978",
+					"172.27.0.1:37978",
+					"172.28.0.1:37978"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:21:22.617210394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6814575453737212,
+				"StableID":   "nVZuRpLLDv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db04fe21e83f45ddbed5b8446f6a92caf01754c38ed27c782c26b81abb977210",
+				"DiscoKey":   "discokey:d554e83b854f98f53fbf98046b8bb4d073b7afa017c42441270fdfbfbba39e44",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33457",
+					"10.65.0.27:33457",
+					"172.17.0.1:33457",
+					"172.18.0.1:33457",
+					"172.19.0.1:33457",
+					"172.20.0.1:33457",
+					"172.21.0.1:33457",
+					"172.22.0.1:33457",
+					"172.23.0.1:33457",
+					"172.24.0.1:33457",
+					"172.25.0.1:33457",
+					"172.26.0.1:33457",
+					"172.27.0.1:33457",
+					"172.28.0.1:33457"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:21:23.460129792Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3971972035245068,
+				"StableID":   "nZjmNGyu1Y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:64e3c927a0d8a260091b63aedddce84cff7d3e81f07ea13778ccc698c7e98b43",
+				"DiscoKey":   "discokey:67171f195393cdbd79f7ad13688070985774fe21be0cedac150777af6508354f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38948",
+					"10.65.0.27:38948",
+					"172.17.0.1:38948",
+					"172.18.0.1:38948",
+					"172.19.0.1:38948",
+					"172.20.0.1:38948",
+					"172.21.0.1:38948",
+					"172.22.0.1:38948",
+					"172.23.0.1:38948",
+					"172.24.0.1:38948",
+					"172.25.0.1:38948",
+					"172.26.0.1:38948",
+					"172.27.0.1:38948",
+					"172.28.0.1:38948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:21:23.937568907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4372583465575495,
+				"StableID":   "nELNeUMM9b11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a3e5671fbb6f6c658d6e163b7bd993cced8c022df31b868e10c82fba42286347",
+				"DiscoKey":   "discokey:54b578d48e785aa696d2ee85a5a3bda9a5179f5a57705e00de174e882e2f5071",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51405",
+					"10.65.0.27:51405",
+					"172.17.0.1:51405",
+					"172.18.0.1:51405",
+					"172.19.0.1:51405",
+					"172.20.0.1:51405",
+					"172.21.0.1:51405",
+					"172.22.0.1:51405",
+					"172.23.0.1:51405",
+					"172.24.0.1:51405",
+					"172.25.0.1:51405",
+					"172.26.0.1:51405",
+					"172.27.0.1:51405",
+					"172.28.0.1:51405"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:21:24.602179146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4608126954712804,
+				"StableID":   "nfvWCWg2zc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ed292b4cfa8d08d12bc6fe9b393fad60418df600a2e19127099519a3fa1db3f",
+				"DiscoKey":   "discokey:fb18e1047c814faa1936128cd722a341358c30909e998cbd856d38e7658bc216",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44111",
+					"10.65.0.27:44111",
+					"172.17.0.1:44111",
+					"172.18.0.1:44111",
+					"172.19.0.1:44111",
+					"172.20.0.1:44111",
+					"172.21.0.1:44111",
+					"172.22.0.1:44111",
+					"172.23.0.1:44111",
+					"172.24.0.1:44111",
+					"172.25.0.1:44111",
+					"172.26.0.1:44111",
+					"172.27.0.1:44111",
+					"172.28.0.1:44111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:21:25.133517278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1500340108592974,
+				"StableID":   "nRGwiePWiC11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:005e465b964cc904806f5161328c8f685fd1e56b59f30ea0d13cad619bd75e7b",
+				"DiscoKey":   "discokey:23354def6c19b41d12b50b428bb2b86a4e2cb7471abf9f39a4e93fa76040f810",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:34139",
+					"10.65.0.27:34139",
+					"172.17.0.1:34139",
+					"172.18.0.1:34139",
+					"172.19.0.1:34139",
+					"172.20.0.1:34139",
+					"172.21.0.1:34139",
+					"172.22.0.1:34139",
+					"172.23.0.1:34139",
+					"172.24.0.1:34139",
+					"172.25.0.1:34139",
+					"172.26.0.1:34139",
+					"172.27.0.1:34139",
+					"172.28.0.1:34139"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:21:25.660717434Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         521955752537854,
+				"StableID":   "ndAuVmtP5511CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:cc439a49e3f189d63a5a8b0deff24686018316cc041e6495c7dbab9074185e52",
+				"KeyExpiry":  "2026-11-09T09:21:26Z",
+				"DiscoKey":   "discokey:9373753ec674e553510849fb70c3d11a030a8ebdb697b79811e40fb34e754b34",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:36848",
+					"10.65.0.27:36848",
+					"172.17.0.1:36848",
+					"172.18.0.1:36848",
+					"172.19.0.1:36848",
+					"172.20.0.1:36848",
+					"172.21.0.1:36848",
+					"172.22.0.1:36848",
+					"172.23.0.1:36848",
+					"172.24.0.1:36848",
+					"172.25.0.1:36848",
+					"172.26.0.1:36848",
+					"172.27.0.1:36848",
+					"172.28.0.1:36848"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:21:26.194723126Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4523172015074948,
+				"StableID":   "nwEe6R4ZKc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:43722a1489ece323af8ed65ad9fef1a309afef19f60109cf84536abd2f108c30",
+				"KeyExpiry":  "2026-11-09T09:21:26Z",
+				"DiscoKey":   "discokey:b905104a3ce14244a835cd8c1bce75dac82376d0fac4110c36a649a3b7f5c456",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49558",
+					"10.65.0.27:49558",
+					"172.17.0.1:49558",
+					"172.18.0.1:49558",
+					"172.19.0.1:49558",
+					"172.20.0.1:49558",
+					"172.21.0.1:49558",
+					"172.22.0.1:49558",
+					"172.23.0.1:49558",
+					"172.24.0.1:49558",
+					"172.25.0.1:49558",
+					"172.26.0.1:49558",
+					"172.27.0.1:49558",
+					"172.28.0.1:49558"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:21:26.723487548Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5848785703371618,
+				"StableID":   "n3V7Pbgvfn11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:61125883643bf13373afbfcc258f7ea148cd326b1273f337857ee86144c0521d",
+				"KeyExpiry":  "2026-11-09T09:21:27Z",
+				"DiscoKey":   "discokey:dc748887d44370c813a5e037e52b40bf597c6088551a43de750344a550be1a55",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55204",
+					"10.65.0.27:55204",
+					"172.17.0.1:55204",
+					"172.18.0.1:55204",
+					"172.19.0.1:55204",
+					"172.20.0.1:55204",
+					"172.21.0.1:55204",
+					"172.22.0.1:55204",
+					"172.23.0.1:55204",
+					"172.24.0.1:55204",
+					"172.25.0.1:55204",
+					"172.26.0.1:55204",
+					"172.27.0.1:55204",
+					"172.28.0.1:55204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:21:27.254674699Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4725532368819453": {
+				"ID":          4725532368819453,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5800192544056745,
+				"StableID":   "nJRwHvDvHn11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       5800192544056745,
+				"Key":        "nodekey:73aa857fa92ce648735d5f6f595ac8b3078b14a194f56f72cee66647746ac61c",
+				"DiscoKey":   "discokey:ac62f171220e6de996c3a9a4719ae5fcbf913f3fedc5c0a98e110490ab01cf4a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42661",
+					"10.65.0.27:42661",
+					"172.17.0.1:42661",
+					"172.18.0.1:42661",
+					"172.19.0.1:42661",
+					"172.20.0.1:42661",
+					"172.21.0.1:42661",
+					"172.22.0.1:42661",
+					"172.23.0.1:42661",
+					"172.24.0.1:42661",
+					"172.25.0.1:42661",
+					"172.26.0.1:42661",
+					"172.27.0.1:42661",
+					"172.28.0.1:42661"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:21:21.012421424Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:73aa857fa92ce648735d5f6f595ac8b3078b14a194f56f72cee66647746ac61c",
+			"MachineKey": "mkey:2592aa41aa5c25ad6196d37a83ed44eca3d5b4e0b7f8f27f5a97e7a4fbbbc201",
+			"Peers": [{
+				"ID":         8290277898300682,
+				"StableID":   "nPBh9UYgj721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:daf9699563bb8d8e86135a3eb1c6b4ca20670b36e6a6d87f7984fa2450dfe020",
+				"DiscoKey":   "discokey:cb20bf5e7e12b719e58613631bf8b830411be943c45ab7d2012c0f7256a01c1a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53542",
+					"10.65.0.27:53542",
+					"172.17.0.1:53542",
+					"172.18.0.1:53542",
+					"172.19.0.1:53542",
+					"172.20.0.1:53542",
+					"172.21.0.1:53542",
+					"172.22.0.1:53542",
+					"172.23.0.1:53542",
+					"172.24.0.1:53542",
+					"172.25.0.1:53542",
+					"172.26.0.1:53542",
+					"172.27.0.1:53542",
+					"172.28.0.1:53542"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:21:09.574498768Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3616621037328237,
+				"StableID":   "nvuqX7WyEV11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c2487b3a38488d006f9a28c6d9b90b5afdcc68a260cf02b1b7aa3d559f145e32",
+				"DiscoKey":   "discokey:b6300c737099421c5a52b06c2d6aad403b1f076f0f7debe347671b4eb63a7839",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33348",
+					"10.65.0.27:33348",
+					"172.17.0.1:33348",
+					"172.18.0.1:33348",
+					"172.19.0.1:33348",
+					"172.20.0.1:33348",
+					"172.21.0.1:33348",
+					"172.22.0.1:33348",
+					"172.23.0.1:33348",
+					"172.24.0.1:33348",
+					"172.25.0.1:33348",
+					"172.26.0.1:33348",
+					"172.27.0.1:33348",
+					"172.28.0.1:33348"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:21:15.566085445Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5655179600283341,
+				"StableID":   "nLgQ2myEAm11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:133c74cdf13dcb6f236645b723c019ea0eb574dd2c988e6aaebd0c202f7abc72",
+				"DiscoKey":   "discokey:7ede0fad082f1f4540afd15d339f4f14498fd7a2f6253565fc59cc8020788c3a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57092",
+					"10.65.0.27:57092",
+					"172.17.0.1:57092",
+					"172.18.0.1:57092",
+					"172.19.0.1:57092",
+					"172.20.0.1:57092",
+					"172.21.0.1:57092",
+					"172.22.0.1:57092",
+					"172.23.0.1:57092",
+					"172.24.0.1:57092",
+					"172.25.0.1:57092",
+					"172.26.0.1:57092",
+					"172.27.0.1:57092",
+					"172.28.0.1:57092"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:21:17.347104171Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4725532368819453,
+				"StableID":   "nWdDctiCud11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec327910540dbdc61464d526ac9800df50d6b956244da10af3ea424102e7d30e",
+				"DiscoKey":   "discokey:4d276da3bd54817b6af5ed9d3da58b57c6a09de2b4bb7f94656e3175bb93175a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58383",
+					"10.65.0.27:58383",
+					"172.17.0.1:58383",
+					"172.18.0.1:58383",
+					"172.19.0.1:58383",
+					"172.20.0.1:58383",
+					"172.21.0.1:58383",
+					"172.22.0.1:58383",
+					"172.23.0.1:58383",
+					"172.24.0.1:58383",
+					"172.25.0.1:58383",
+					"172.26.0.1:58383",
+					"172.27.0.1:58383",
+					"172.28.0.1:58383"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:21:21.550796677Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6882282173853531,
+				"StableID":   "nJSFSBtzjv11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe5dd419cfaf8151c09428107e4ee85c074928fd9f8fe3da73694074121cf72d",
+				"DiscoKey":   "discokey:298f317d964805d70c955707e74cc3a06589f35df730a2211e9d99a2c7f5103a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50289",
+					"10.65.0.27:50289",
+					"172.17.0.1:50289",
+					"172.18.0.1:50289",
+					"172.19.0.1:50289",
+					"172.20.0.1:50289",
+					"172.21.0.1:50289",
+					"172.22.0.1:50289",
+					"172.23.0.1:50289",
+					"172.24.0.1:50289",
+					"172.25.0.1:50289",
+					"172.26.0.1:50289",
+					"172.27.0.1:50289",
+					"172.28.0.1:50289"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:21:22.075465365Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8302794691259322,
+				"StableID":   "nMGMHaLMq721CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc0f150fc848435ae963f263bbb5b44c14b4de07c306da65f1d9d65dba8aa915",
+				"DiscoKey":   "discokey:e715d93aeac9eec6096a3e18131bd442fe35e13a0347123bcfe21723c9cfbc1c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37978",
+					"10.65.0.27:37978",
+					"172.17.0.1:37978",
+					"172.18.0.1:37978",
+					"172.19.0.1:37978",
+					"172.20.0.1:37978",
+					"172.21.0.1:37978",
+					"172.22.0.1:37978",
+					"172.23.0.1:37978",
+					"172.24.0.1:37978",
+					"172.25.0.1:37978",
+					"172.26.0.1:37978",
+					"172.27.0.1:37978",
+					"172.28.0.1:37978"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:21:22.617210394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6814575453737212,
+				"StableID":   "nVZuRpLLDv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db04fe21e83f45ddbed5b8446f6a92caf01754c38ed27c782c26b81abb977210",
+				"DiscoKey":   "discokey:d554e83b854f98f53fbf98046b8bb4d073b7afa017c42441270fdfbfbba39e44",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33457",
+					"10.65.0.27:33457",
+					"172.17.0.1:33457",
+					"172.18.0.1:33457",
+					"172.19.0.1:33457",
+					"172.20.0.1:33457",
+					"172.21.0.1:33457",
+					"172.22.0.1:33457",
+					"172.23.0.1:33457",
+					"172.24.0.1:33457",
+					"172.25.0.1:33457",
+					"172.26.0.1:33457",
+					"172.27.0.1:33457",
+					"172.28.0.1:33457"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:21:23.460129792Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3971972035245068,
+				"StableID":   "nZjmNGyu1Y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:64e3c927a0d8a260091b63aedddce84cff7d3e81f07ea13778ccc698c7e98b43",
+				"DiscoKey":   "discokey:67171f195393cdbd79f7ad13688070985774fe21be0cedac150777af6508354f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38948",
+					"10.65.0.27:38948",
+					"172.17.0.1:38948",
+					"172.18.0.1:38948",
+					"172.19.0.1:38948",
+					"172.20.0.1:38948",
+					"172.21.0.1:38948",
+					"172.22.0.1:38948",
+					"172.23.0.1:38948",
+					"172.24.0.1:38948",
+					"172.25.0.1:38948",
+					"172.26.0.1:38948",
+					"172.27.0.1:38948",
+					"172.28.0.1:38948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:21:23.937568907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4372583465575495,
+				"StableID":   "nELNeUMM9b11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a3e5671fbb6f6c658d6e163b7bd993cced8c022df31b868e10c82fba42286347",
+				"DiscoKey":   "discokey:54b578d48e785aa696d2ee85a5a3bda9a5179f5a57705e00de174e882e2f5071",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51405",
+					"10.65.0.27:51405",
+					"172.17.0.1:51405",
+					"172.18.0.1:51405",
+					"172.19.0.1:51405",
+					"172.20.0.1:51405",
+					"172.21.0.1:51405",
+					"172.22.0.1:51405",
+					"172.23.0.1:51405",
+					"172.24.0.1:51405",
+					"172.25.0.1:51405",
+					"172.26.0.1:51405",
+					"172.27.0.1:51405",
+					"172.28.0.1:51405"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:21:24.602179146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4608126954712804,
+				"StableID":   "nfvWCWg2zc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ed292b4cfa8d08d12bc6fe9b393fad60418df600a2e19127099519a3fa1db3f",
+				"DiscoKey":   "discokey:fb18e1047c814faa1936128cd722a341358c30909e998cbd856d38e7658bc216",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44111",
+					"10.65.0.27:44111",
+					"172.17.0.1:44111",
+					"172.18.0.1:44111",
+					"172.19.0.1:44111",
+					"172.20.0.1:44111",
+					"172.21.0.1:44111",
+					"172.22.0.1:44111",
+					"172.23.0.1:44111",
+					"172.24.0.1:44111",
+					"172.25.0.1:44111",
+					"172.26.0.1:44111",
+					"172.27.0.1:44111",
+					"172.28.0.1:44111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:21:25.133517278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1500340108592974,
+				"StableID":   "nRGwiePWiC11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:005e465b964cc904806f5161328c8f685fd1e56b59f30ea0d13cad619bd75e7b",
+				"DiscoKey":   "discokey:23354def6c19b41d12b50b428bb2b86a4e2cb7471abf9f39a4e93fa76040f810",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:34139",
+					"10.65.0.27:34139",
+					"172.17.0.1:34139",
+					"172.18.0.1:34139",
+					"172.19.0.1:34139",
+					"172.20.0.1:34139",
+					"172.21.0.1:34139",
+					"172.22.0.1:34139",
+					"172.23.0.1:34139",
+					"172.24.0.1:34139",
+					"172.25.0.1:34139",
+					"172.26.0.1:34139",
+					"172.27.0.1:34139",
+					"172.28.0.1:34139"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:21:25.660717434Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         521955752537854,
+				"StableID":   "ndAuVmtP5511CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:cc439a49e3f189d63a5a8b0deff24686018316cc041e6495c7dbab9074185e52",
+				"KeyExpiry":  "2026-11-09T09:21:26Z",
+				"DiscoKey":   "discokey:9373753ec674e553510849fb70c3d11a030a8ebdb697b79811e40fb34e754b34",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:36848",
+					"10.65.0.27:36848",
+					"172.17.0.1:36848",
+					"172.18.0.1:36848",
+					"172.19.0.1:36848",
+					"172.20.0.1:36848",
+					"172.21.0.1:36848",
+					"172.22.0.1:36848",
+					"172.23.0.1:36848",
+					"172.24.0.1:36848",
+					"172.25.0.1:36848",
+					"172.26.0.1:36848",
+					"172.27.0.1:36848",
+					"172.28.0.1:36848"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:21:26.194723126Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4523172015074948,
+				"StableID":   "nwEe6R4ZKc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:43722a1489ece323af8ed65ad9fef1a309afef19f60109cf84536abd2f108c30",
+				"KeyExpiry":  "2026-11-09T09:21:26Z",
+				"DiscoKey":   "discokey:b905104a3ce14244a835cd8c1bce75dac82376d0fac4110c36a649a3b7f5c456",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49558",
+					"10.65.0.27:49558",
+					"172.17.0.1:49558",
+					"172.18.0.1:49558",
+					"172.19.0.1:49558",
+					"172.20.0.1:49558",
+					"172.21.0.1:49558",
+					"172.22.0.1:49558",
+					"172.23.0.1:49558",
+					"172.24.0.1:49558",
+					"172.25.0.1:49558",
+					"172.26.0.1:49558",
+					"172.27.0.1:49558",
+					"172.28.0.1:49558"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:21:26.723487548Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5848785703371618,
+				"StableID":   "n3V7Pbgvfn11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:61125883643bf13373afbfcc258f7ea148cd326b1273f337857ee86144c0521d",
+				"KeyExpiry":  "2026-11-09T09:21:27Z",
+				"DiscoKey":   "discokey:dc748887d44370c813a5e037e52b40bf597c6088551a43de750344a550be1a55",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55204",
+					"10.65.0.27:55204",
+					"172.17.0.1:55204",
+					"172.18.0.1:55204",
+					"172.19.0.1:55204",
+					"172.20.0.1:55204",
+					"172.21.0.1:55204",
+					"172.22.0.1:55204",
+					"172.23.0.1:55204",
+					"172.24.0.1:55204",
+					"172.25.0.1:55204",
+					"172.26.0.1:55204",
+					"172.27.0.1:55204",
+					"172.28.0.1:55204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:21:27.254674699Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5800192544056745": {
+				"ID":          5800192544056745,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8302794691259322,
+				"StableID":   "nMGMHaLMq721CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       8302794691259322,
+				"Key":        "nodekey:fc0f150fc848435ae963f263bbb5b44c14b4de07c306da65f1d9d65dba8aa915",
+				"DiscoKey":   "discokey:e715d93aeac9eec6096a3e18131bd442fe35e13a0347123bcfe21723c9cfbc1c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37978",
+					"10.65.0.27:37978",
+					"172.17.0.1:37978",
+					"172.18.0.1:37978",
+					"172.19.0.1:37978",
+					"172.20.0.1:37978",
+					"172.21.0.1:37978",
+					"172.22.0.1:37978",
+					"172.23.0.1:37978",
+					"172.24.0.1:37978",
+					"172.25.0.1:37978",
+					"172.26.0.1:37978",
+					"172.27.0.1:37978",
+					"172.28.0.1:37978"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:21:22.617210394Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:fc0f150fc848435ae963f263bbb5b44c14b4de07c306da65f1d9d65dba8aa915",
+			"MachineKey": "mkey:656d1c7996dca7ddb643ac1932a4fb99b5d50339b534ea6c1cb97099e6f67c76",
+			"Peers": [{
+				"ID":         8290277898300682,
+				"StableID":   "nPBh9UYgj721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:daf9699563bb8d8e86135a3eb1c6b4ca20670b36e6a6d87f7984fa2450dfe020",
+				"DiscoKey":   "discokey:cb20bf5e7e12b719e58613631bf8b830411be943c45ab7d2012c0f7256a01c1a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53542",
+					"10.65.0.27:53542",
+					"172.17.0.1:53542",
+					"172.18.0.1:53542",
+					"172.19.0.1:53542",
+					"172.20.0.1:53542",
+					"172.21.0.1:53542",
+					"172.22.0.1:53542",
+					"172.23.0.1:53542",
+					"172.24.0.1:53542",
+					"172.25.0.1:53542",
+					"172.26.0.1:53542",
+					"172.27.0.1:53542",
+					"172.28.0.1:53542"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:21:09.574498768Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3616621037328237,
+				"StableID":   "nvuqX7WyEV11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c2487b3a38488d006f9a28c6d9b90b5afdcc68a260cf02b1b7aa3d559f145e32",
+				"DiscoKey":   "discokey:b6300c737099421c5a52b06c2d6aad403b1f076f0f7debe347671b4eb63a7839",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33348",
+					"10.65.0.27:33348",
+					"172.17.0.1:33348",
+					"172.18.0.1:33348",
+					"172.19.0.1:33348",
+					"172.20.0.1:33348",
+					"172.21.0.1:33348",
+					"172.22.0.1:33348",
+					"172.23.0.1:33348",
+					"172.24.0.1:33348",
+					"172.25.0.1:33348",
+					"172.26.0.1:33348",
+					"172.27.0.1:33348",
+					"172.28.0.1:33348"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:21:15.566085445Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5655179600283341,
+				"StableID":   "nLgQ2myEAm11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:133c74cdf13dcb6f236645b723c019ea0eb574dd2c988e6aaebd0c202f7abc72",
+				"DiscoKey":   "discokey:7ede0fad082f1f4540afd15d339f4f14498fd7a2f6253565fc59cc8020788c3a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57092",
+					"10.65.0.27:57092",
+					"172.17.0.1:57092",
+					"172.18.0.1:57092",
+					"172.19.0.1:57092",
+					"172.20.0.1:57092",
+					"172.21.0.1:57092",
+					"172.22.0.1:57092",
+					"172.23.0.1:57092",
+					"172.24.0.1:57092",
+					"172.25.0.1:57092",
+					"172.26.0.1:57092",
+					"172.27.0.1:57092",
+					"172.28.0.1:57092"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:21:17.347104171Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5800192544056745,
+				"StableID":   "nJRwHvDvHn11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:73aa857fa92ce648735d5f6f595ac8b3078b14a194f56f72cee66647746ac61c",
+				"DiscoKey":   "discokey:ac62f171220e6de996c3a9a4719ae5fcbf913f3fedc5c0a98e110490ab01cf4a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42661",
+					"10.65.0.27:42661",
+					"172.17.0.1:42661",
+					"172.18.0.1:42661",
+					"172.19.0.1:42661",
+					"172.20.0.1:42661",
+					"172.21.0.1:42661",
+					"172.22.0.1:42661",
+					"172.23.0.1:42661",
+					"172.24.0.1:42661",
+					"172.25.0.1:42661",
+					"172.26.0.1:42661",
+					"172.27.0.1:42661",
+					"172.28.0.1:42661"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:21:21.012421424Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4725532368819453,
+				"StableID":   "nWdDctiCud11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec327910540dbdc61464d526ac9800df50d6b956244da10af3ea424102e7d30e",
+				"DiscoKey":   "discokey:4d276da3bd54817b6af5ed9d3da58b57c6a09de2b4bb7f94656e3175bb93175a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58383",
+					"10.65.0.27:58383",
+					"172.17.0.1:58383",
+					"172.18.0.1:58383",
+					"172.19.0.1:58383",
+					"172.20.0.1:58383",
+					"172.21.0.1:58383",
+					"172.22.0.1:58383",
+					"172.23.0.1:58383",
+					"172.24.0.1:58383",
+					"172.25.0.1:58383",
+					"172.26.0.1:58383",
+					"172.27.0.1:58383",
+					"172.28.0.1:58383"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:21:21.550796677Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6882282173853531,
+				"StableID":   "nJSFSBtzjv11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe5dd419cfaf8151c09428107e4ee85c074928fd9f8fe3da73694074121cf72d",
+				"DiscoKey":   "discokey:298f317d964805d70c955707e74cc3a06589f35df730a2211e9d99a2c7f5103a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50289",
+					"10.65.0.27:50289",
+					"172.17.0.1:50289",
+					"172.18.0.1:50289",
+					"172.19.0.1:50289",
+					"172.20.0.1:50289",
+					"172.21.0.1:50289",
+					"172.22.0.1:50289",
+					"172.23.0.1:50289",
+					"172.24.0.1:50289",
+					"172.25.0.1:50289",
+					"172.26.0.1:50289",
+					"172.27.0.1:50289",
+					"172.28.0.1:50289"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:21:22.075465365Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6814575453737212,
+				"StableID":   "nVZuRpLLDv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db04fe21e83f45ddbed5b8446f6a92caf01754c38ed27c782c26b81abb977210",
+				"DiscoKey":   "discokey:d554e83b854f98f53fbf98046b8bb4d073b7afa017c42441270fdfbfbba39e44",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33457",
+					"10.65.0.27:33457",
+					"172.17.0.1:33457",
+					"172.18.0.1:33457",
+					"172.19.0.1:33457",
+					"172.20.0.1:33457",
+					"172.21.0.1:33457",
+					"172.22.0.1:33457",
+					"172.23.0.1:33457",
+					"172.24.0.1:33457",
+					"172.25.0.1:33457",
+					"172.26.0.1:33457",
+					"172.27.0.1:33457",
+					"172.28.0.1:33457"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:21:23.460129792Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3971972035245068,
+				"StableID":   "nZjmNGyu1Y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:64e3c927a0d8a260091b63aedddce84cff7d3e81f07ea13778ccc698c7e98b43",
+				"DiscoKey":   "discokey:67171f195393cdbd79f7ad13688070985774fe21be0cedac150777af6508354f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38948",
+					"10.65.0.27:38948",
+					"172.17.0.1:38948",
+					"172.18.0.1:38948",
+					"172.19.0.1:38948",
+					"172.20.0.1:38948",
+					"172.21.0.1:38948",
+					"172.22.0.1:38948",
+					"172.23.0.1:38948",
+					"172.24.0.1:38948",
+					"172.25.0.1:38948",
+					"172.26.0.1:38948",
+					"172.27.0.1:38948",
+					"172.28.0.1:38948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:21:23.937568907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4372583465575495,
+				"StableID":   "nELNeUMM9b11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a3e5671fbb6f6c658d6e163b7bd993cced8c022df31b868e10c82fba42286347",
+				"DiscoKey":   "discokey:54b578d48e785aa696d2ee85a5a3bda9a5179f5a57705e00de174e882e2f5071",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51405",
+					"10.65.0.27:51405",
+					"172.17.0.1:51405",
+					"172.18.0.1:51405",
+					"172.19.0.1:51405",
+					"172.20.0.1:51405",
+					"172.21.0.1:51405",
+					"172.22.0.1:51405",
+					"172.23.0.1:51405",
+					"172.24.0.1:51405",
+					"172.25.0.1:51405",
+					"172.26.0.1:51405",
+					"172.27.0.1:51405",
+					"172.28.0.1:51405"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:21:24.602179146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4608126954712804,
+				"StableID":   "nfvWCWg2zc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ed292b4cfa8d08d12bc6fe9b393fad60418df600a2e19127099519a3fa1db3f",
+				"DiscoKey":   "discokey:fb18e1047c814faa1936128cd722a341358c30909e998cbd856d38e7658bc216",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44111",
+					"10.65.0.27:44111",
+					"172.17.0.1:44111",
+					"172.18.0.1:44111",
+					"172.19.0.1:44111",
+					"172.20.0.1:44111",
+					"172.21.0.1:44111",
+					"172.22.0.1:44111",
+					"172.23.0.1:44111",
+					"172.24.0.1:44111",
+					"172.25.0.1:44111",
+					"172.26.0.1:44111",
+					"172.27.0.1:44111",
+					"172.28.0.1:44111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:21:25.133517278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1500340108592974,
+				"StableID":   "nRGwiePWiC11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:005e465b964cc904806f5161328c8f685fd1e56b59f30ea0d13cad619bd75e7b",
+				"DiscoKey":   "discokey:23354def6c19b41d12b50b428bb2b86a4e2cb7471abf9f39a4e93fa76040f810",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:34139",
+					"10.65.0.27:34139",
+					"172.17.0.1:34139",
+					"172.18.0.1:34139",
+					"172.19.0.1:34139",
+					"172.20.0.1:34139",
+					"172.21.0.1:34139",
+					"172.22.0.1:34139",
+					"172.23.0.1:34139",
+					"172.24.0.1:34139",
+					"172.25.0.1:34139",
+					"172.26.0.1:34139",
+					"172.27.0.1:34139",
+					"172.28.0.1:34139"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:21:25.660717434Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         521955752537854,
+				"StableID":   "ndAuVmtP5511CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:cc439a49e3f189d63a5a8b0deff24686018316cc041e6495c7dbab9074185e52",
+				"KeyExpiry":  "2026-11-09T09:21:26Z",
+				"DiscoKey":   "discokey:9373753ec674e553510849fb70c3d11a030a8ebdb697b79811e40fb34e754b34",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:36848",
+					"10.65.0.27:36848",
+					"172.17.0.1:36848",
+					"172.18.0.1:36848",
+					"172.19.0.1:36848",
+					"172.20.0.1:36848",
+					"172.21.0.1:36848",
+					"172.22.0.1:36848",
+					"172.23.0.1:36848",
+					"172.24.0.1:36848",
+					"172.25.0.1:36848",
+					"172.26.0.1:36848",
+					"172.27.0.1:36848",
+					"172.28.0.1:36848"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:21:26.194723126Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4523172015074948,
+				"StableID":   "nwEe6R4ZKc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:43722a1489ece323af8ed65ad9fef1a309afef19f60109cf84536abd2f108c30",
+				"KeyExpiry":  "2026-11-09T09:21:26Z",
+				"DiscoKey":   "discokey:b905104a3ce14244a835cd8c1bce75dac82376d0fac4110c36a649a3b7f5c456",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49558",
+					"10.65.0.27:49558",
+					"172.17.0.1:49558",
+					"172.18.0.1:49558",
+					"172.19.0.1:49558",
+					"172.20.0.1:49558",
+					"172.21.0.1:49558",
+					"172.22.0.1:49558",
+					"172.23.0.1:49558",
+					"172.24.0.1:49558",
+					"172.25.0.1:49558",
+					"172.26.0.1:49558",
+					"172.27.0.1:49558",
+					"172.28.0.1:49558"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:21:26.723487548Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5848785703371618,
+				"StableID":   "n3V7Pbgvfn11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:61125883643bf13373afbfcc258f7ea148cd326b1273f337857ee86144c0521d",
+				"KeyExpiry":  "2026-11-09T09:21:27Z",
+				"DiscoKey":   "discokey:dc748887d44370c813a5e037e52b40bf597c6088551a43de750344a550be1a55",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55204",
+					"10.65.0.27:55204",
+					"172.17.0.1:55204",
+					"172.18.0.1:55204",
+					"172.19.0.1:55204",
+					"172.20.0.1:55204",
+					"172.21.0.1:55204",
+					"172.22.0.1:55204",
+					"172.23.0.1:55204",
+					"172.24.0.1:55204",
+					"172.25.0.1:55204",
+					"172.26.0.1:55204",
+					"172.27.0.1:55204",
+					"172.28.0.1:55204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:21:27.254674699Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8302794691259322": {
+				"ID":          8302794691259322,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3971972035245068,
+				"StableID":   "nZjmNGyu1Y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       3971972035245068,
+				"Key":        "nodekey:64e3c927a0d8a260091b63aedddce84cff7d3e81f07ea13778ccc698c7e98b43",
+				"DiscoKey":   "discokey:67171f195393cdbd79f7ad13688070985774fe21be0cedac150777af6508354f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38948",
+					"10.65.0.27:38948",
+					"172.17.0.1:38948",
+					"172.18.0.1:38948",
+					"172.19.0.1:38948",
+					"172.20.0.1:38948",
+					"172.21.0.1:38948",
+					"172.22.0.1:38948",
+					"172.23.0.1:38948",
+					"172.24.0.1:38948",
+					"172.25.0.1:38948",
+					"172.26.0.1:38948",
+					"172.27.0.1:38948",
+					"172.28.0.1:38948"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:21:23.937568907Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:64e3c927a0d8a260091b63aedddce84cff7d3e81f07ea13778ccc698c7e98b43",
+			"MachineKey": "mkey:be1ee52cccd623028a6401e4122e80e02a59e085fcd5d27b9bd271a3a33a5217",
+			"Peers": [{
+				"ID":         8290277898300682,
+				"StableID":   "nPBh9UYgj721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:daf9699563bb8d8e86135a3eb1c6b4ca20670b36e6a6d87f7984fa2450dfe020",
+				"DiscoKey":   "discokey:cb20bf5e7e12b719e58613631bf8b830411be943c45ab7d2012c0f7256a01c1a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53542",
+					"10.65.0.27:53542",
+					"172.17.0.1:53542",
+					"172.18.0.1:53542",
+					"172.19.0.1:53542",
+					"172.20.0.1:53542",
+					"172.21.0.1:53542",
+					"172.22.0.1:53542",
+					"172.23.0.1:53542",
+					"172.24.0.1:53542",
+					"172.25.0.1:53542",
+					"172.26.0.1:53542",
+					"172.27.0.1:53542",
+					"172.28.0.1:53542"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:21:09.574498768Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3616621037328237,
+				"StableID":   "nvuqX7WyEV11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c2487b3a38488d006f9a28c6d9b90b5afdcc68a260cf02b1b7aa3d559f145e32",
+				"DiscoKey":   "discokey:b6300c737099421c5a52b06c2d6aad403b1f076f0f7debe347671b4eb63a7839",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33348",
+					"10.65.0.27:33348",
+					"172.17.0.1:33348",
+					"172.18.0.1:33348",
+					"172.19.0.1:33348",
+					"172.20.0.1:33348",
+					"172.21.0.1:33348",
+					"172.22.0.1:33348",
+					"172.23.0.1:33348",
+					"172.24.0.1:33348",
+					"172.25.0.1:33348",
+					"172.26.0.1:33348",
+					"172.27.0.1:33348",
+					"172.28.0.1:33348"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:21:15.566085445Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5655179600283341,
+				"StableID":   "nLgQ2myEAm11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:133c74cdf13dcb6f236645b723c019ea0eb574dd2c988e6aaebd0c202f7abc72",
+				"DiscoKey":   "discokey:7ede0fad082f1f4540afd15d339f4f14498fd7a2f6253565fc59cc8020788c3a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57092",
+					"10.65.0.27:57092",
+					"172.17.0.1:57092",
+					"172.18.0.1:57092",
+					"172.19.0.1:57092",
+					"172.20.0.1:57092",
+					"172.21.0.1:57092",
+					"172.22.0.1:57092",
+					"172.23.0.1:57092",
+					"172.24.0.1:57092",
+					"172.25.0.1:57092",
+					"172.26.0.1:57092",
+					"172.27.0.1:57092",
+					"172.28.0.1:57092"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:21:17.347104171Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5800192544056745,
+				"StableID":   "nJRwHvDvHn11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:73aa857fa92ce648735d5f6f595ac8b3078b14a194f56f72cee66647746ac61c",
+				"DiscoKey":   "discokey:ac62f171220e6de996c3a9a4719ae5fcbf913f3fedc5c0a98e110490ab01cf4a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42661",
+					"10.65.0.27:42661",
+					"172.17.0.1:42661",
+					"172.18.0.1:42661",
+					"172.19.0.1:42661",
+					"172.20.0.1:42661",
+					"172.21.0.1:42661",
+					"172.22.0.1:42661",
+					"172.23.0.1:42661",
+					"172.24.0.1:42661",
+					"172.25.0.1:42661",
+					"172.26.0.1:42661",
+					"172.27.0.1:42661",
+					"172.28.0.1:42661"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:21:21.012421424Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4725532368819453,
+				"StableID":   "nWdDctiCud11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec327910540dbdc61464d526ac9800df50d6b956244da10af3ea424102e7d30e",
+				"DiscoKey":   "discokey:4d276da3bd54817b6af5ed9d3da58b57c6a09de2b4bb7f94656e3175bb93175a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58383",
+					"10.65.0.27:58383",
+					"172.17.0.1:58383",
+					"172.18.0.1:58383",
+					"172.19.0.1:58383",
+					"172.20.0.1:58383",
+					"172.21.0.1:58383",
+					"172.22.0.1:58383",
+					"172.23.0.1:58383",
+					"172.24.0.1:58383",
+					"172.25.0.1:58383",
+					"172.26.0.1:58383",
+					"172.27.0.1:58383",
+					"172.28.0.1:58383"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:21:21.550796677Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6882282173853531,
+				"StableID":   "nJSFSBtzjv11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe5dd419cfaf8151c09428107e4ee85c074928fd9f8fe3da73694074121cf72d",
+				"DiscoKey":   "discokey:298f317d964805d70c955707e74cc3a06589f35df730a2211e9d99a2c7f5103a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50289",
+					"10.65.0.27:50289",
+					"172.17.0.1:50289",
+					"172.18.0.1:50289",
+					"172.19.0.1:50289",
+					"172.20.0.1:50289",
+					"172.21.0.1:50289",
+					"172.22.0.1:50289",
+					"172.23.0.1:50289",
+					"172.24.0.1:50289",
+					"172.25.0.1:50289",
+					"172.26.0.1:50289",
+					"172.27.0.1:50289",
+					"172.28.0.1:50289"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:21:22.075465365Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8302794691259322,
+				"StableID":   "nMGMHaLMq721CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc0f150fc848435ae963f263bbb5b44c14b4de07c306da65f1d9d65dba8aa915",
+				"DiscoKey":   "discokey:e715d93aeac9eec6096a3e18131bd442fe35e13a0347123bcfe21723c9cfbc1c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37978",
+					"10.65.0.27:37978",
+					"172.17.0.1:37978",
+					"172.18.0.1:37978",
+					"172.19.0.1:37978",
+					"172.20.0.1:37978",
+					"172.21.0.1:37978",
+					"172.22.0.1:37978",
+					"172.23.0.1:37978",
+					"172.24.0.1:37978",
+					"172.25.0.1:37978",
+					"172.26.0.1:37978",
+					"172.27.0.1:37978",
+					"172.28.0.1:37978"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:21:22.617210394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6814575453737212,
+				"StableID":   "nVZuRpLLDv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db04fe21e83f45ddbed5b8446f6a92caf01754c38ed27c782c26b81abb977210",
+				"DiscoKey":   "discokey:d554e83b854f98f53fbf98046b8bb4d073b7afa017c42441270fdfbfbba39e44",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33457",
+					"10.65.0.27:33457",
+					"172.17.0.1:33457",
+					"172.18.0.1:33457",
+					"172.19.0.1:33457",
+					"172.20.0.1:33457",
+					"172.21.0.1:33457",
+					"172.22.0.1:33457",
+					"172.23.0.1:33457",
+					"172.24.0.1:33457",
+					"172.25.0.1:33457",
+					"172.26.0.1:33457",
+					"172.27.0.1:33457",
+					"172.28.0.1:33457"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:21:23.460129792Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4372583465575495,
+				"StableID":   "nELNeUMM9b11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a3e5671fbb6f6c658d6e163b7bd993cced8c022df31b868e10c82fba42286347",
+				"DiscoKey":   "discokey:54b578d48e785aa696d2ee85a5a3bda9a5179f5a57705e00de174e882e2f5071",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51405",
+					"10.65.0.27:51405",
+					"172.17.0.1:51405",
+					"172.18.0.1:51405",
+					"172.19.0.1:51405",
+					"172.20.0.1:51405",
+					"172.21.0.1:51405",
+					"172.22.0.1:51405",
+					"172.23.0.1:51405",
+					"172.24.0.1:51405",
+					"172.25.0.1:51405",
+					"172.26.0.1:51405",
+					"172.27.0.1:51405",
+					"172.28.0.1:51405"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:21:24.602179146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4608126954712804,
+				"StableID":   "nfvWCWg2zc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ed292b4cfa8d08d12bc6fe9b393fad60418df600a2e19127099519a3fa1db3f",
+				"DiscoKey":   "discokey:fb18e1047c814faa1936128cd722a341358c30909e998cbd856d38e7658bc216",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44111",
+					"10.65.0.27:44111",
+					"172.17.0.1:44111",
+					"172.18.0.1:44111",
+					"172.19.0.1:44111",
+					"172.20.0.1:44111",
+					"172.21.0.1:44111",
+					"172.22.0.1:44111",
+					"172.23.0.1:44111",
+					"172.24.0.1:44111",
+					"172.25.0.1:44111",
+					"172.26.0.1:44111",
+					"172.27.0.1:44111",
+					"172.28.0.1:44111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:21:25.133517278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1500340108592974,
+				"StableID":   "nRGwiePWiC11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:005e465b964cc904806f5161328c8f685fd1e56b59f30ea0d13cad619bd75e7b",
+				"DiscoKey":   "discokey:23354def6c19b41d12b50b428bb2b86a4e2cb7471abf9f39a4e93fa76040f810",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:34139",
+					"10.65.0.27:34139",
+					"172.17.0.1:34139",
+					"172.18.0.1:34139",
+					"172.19.0.1:34139",
+					"172.20.0.1:34139",
+					"172.21.0.1:34139",
+					"172.22.0.1:34139",
+					"172.23.0.1:34139",
+					"172.24.0.1:34139",
+					"172.25.0.1:34139",
+					"172.26.0.1:34139",
+					"172.27.0.1:34139",
+					"172.28.0.1:34139"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:21:25.660717434Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         521955752537854,
+				"StableID":   "ndAuVmtP5511CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:cc439a49e3f189d63a5a8b0deff24686018316cc041e6495c7dbab9074185e52",
+				"KeyExpiry":  "2026-11-09T09:21:26Z",
+				"DiscoKey":   "discokey:9373753ec674e553510849fb70c3d11a030a8ebdb697b79811e40fb34e754b34",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:36848",
+					"10.65.0.27:36848",
+					"172.17.0.1:36848",
+					"172.18.0.1:36848",
+					"172.19.0.1:36848",
+					"172.20.0.1:36848",
+					"172.21.0.1:36848",
+					"172.22.0.1:36848",
+					"172.23.0.1:36848",
+					"172.24.0.1:36848",
+					"172.25.0.1:36848",
+					"172.26.0.1:36848",
+					"172.27.0.1:36848",
+					"172.28.0.1:36848"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:21:26.194723126Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4523172015074948,
+				"StableID":   "nwEe6R4ZKc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:43722a1489ece323af8ed65ad9fef1a309afef19f60109cf84536abd2f108c30",
+				"KeyExpiry":  "2026-11-09T09:21:26Z",
+				"DiscoKey":   "discokey:b905104a3ce14244a835cd8c1bce75dac82376d0fac4110c36a649a3b7f5c456",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49558",
+					"10.65.0.27:49558",
+					"172.17.0.1:49558",
+					"172.18.0.1:49558",
+					"172.19.0.1:49558",
+					"172.20.0.1:49558",
+					"172.21.0.1:49558",
+					"172.22.0.1:49558",
+					"172.23.0.1:49558",
+					"172.24.0.1:49558",
+					"172.25.0.1:49558",
+					"172.26.0.1:49558",
+					"172.27.0.1:49558",
+					"172.28.0.1:49558"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:21:26.723487548Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5848785703371618,
+				"StableID":   "n3V7Pbgvfn11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:61125883643bf13373afbfcc258f7ea148cd326b1273f337857ee86144c0521d",
+				"KeyExpiry":  "2026-11-09T09:21:27Z",
+				"DiscoKey":   "discokey:dc748887d44370c813a5e037e52b40bf597c6088551a43de750344a550be1a55",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55204",
+					"10.65.0.27:55204",
+					"172.17.0.1:55204",
+					"172.18.0.1:55204",
+					"172.19.0.1:55204",
+					"172.20.0.1:55204",
+					"172.21.0.1:55204",
+					"172.22.0.1:55204",
+					"172.23.0.1:55204",
+					"172.24.0.1:55204",
+					"172.25.0.1:55204",
+					"172.26.0.1:55204",
+					"172.27.0.1:55204",
+					"172.28.0.1:55204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:21:27.254674699Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3971972035245068": {
+				"ID":          3971972035245068,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4523172015074948,
+				"StableID":   "nwEe6R4ZKc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:43722a1489ece323af8ed65ad9fef1a309afef19f60109cf84536abd2f108c30",
+				"KeyExpiry":  "2026-11-09T09:21:26Z",
+				"DiscoKey":   "discokey:b905104a3ce14244a835cd8c1bce75dac82376d0fac4110c36a649a3b7f5c456",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49558",
+					"10.65.0.27:49558",
+					"172.17.0.1:49558",
+					"172.18.0.1:49558",
+					"172.19.0.1:49558",
+					"172.20.0.1:49558",
+					"172.21.0.1:49558",
+					"172.22.0.1:49558",
+					"172.23.0.1:49558",
+					"172.24.0.1:49558",
+					"172.25.0.1:49558",
+					"172.26.0.1:49558",
+					"172.27.0.1:49558",
+					"172.28.0.1:49558"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:21:26.723487548Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:43722a1489ece323af8ed65ad9fef1a309afef19f60109cf84536abd2f108c30",
+			"MachineKey": "mkey:420de8185fe9cc10154cb5219c745808f9817c206f12d1372998214046403d09",
+			"Peers": [{
+				"ID":         8290277898300682,
+				"StableID":   "nPBh9UYgj721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:daf9699563bb8d8e86135a3eb1c6b4ca20670b36e6a6d87f7984fa2450dfe020",
+				"DiscoKey":   "discokey:cb20bf5e7e12b719e58613631bf8b830411be943c45ab7d2012c0f7256a01c1a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53542",
+					"10.65.0.27:53542",
+					"172.17.0.1:53542",
+					"172.18.0.1:53542",
+					"172.19.0.1:53542",
+					"172.20.0.1:53542",
+					"172.21.0.1:53542",
+					"172.22.0.1:53542",
+					"172.23.0.1:53542",
+					"172.24.0.1:53542",
+					"172.25.0.1:53542",
+					"172.26.0.1:53542",
+					"172.27.0.1:53542",
+					"172.28.0.1:53542"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:21:09.574498768Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3616621037328237,
+				"StableID":   "nvuqX7WyEV11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c2487b3a38488d006f9a28c6d9b90b5afdcc68a260cf02b1b7aa3d559f145e32",
+				"DiscoKey":   "discokey:b6300c737099421c5a52b06c2d6aad403b1f076f0f7debe347671b4eb63a7839",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33348",
+					"10.65.0.27:33348",
+					"172.17.0.1:33348",
+					"172.18.0.1:33348",
+					"172.19.0.1:33348",
+					"172.20.0.1:33348",
+					"172.21.0.1:33348",
+					"172.22.0.1:33348",
+					"172.23.0.1:33348",
+					"172.24.0.1:33348",
+					"172.25.0.1:33348",
+					"172.26.0.1:33348",
+					"172.27.0.1:33348",
+					"172.28.0.1:33348"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:21:15.566085445Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5655179600283341,
+				"StableID":   "nLgQ2myEAm11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:133c74cdf13dcb6f236645b723c019ea0eb574dd2c988e6aaebd0c202f7abc72",
+				"DiscoKey":   "discokey:7ede0fad082f1f4540afd15d339f4f14498fd7a2f6253565fc59cc8020788c3a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57092",
+					"10.65.0.27:57092",
+					"172.17.0.1:57092",
+					"172.18.0.1:57092",
+					"172.19.0.1:57092",
+					"172.20.0.1:57092",
+					"172.21.0.1:57092",
+					"172.22.0.1:57092",
+					"172.23.0.1:57092",
+					"172.24.0.1:57092",
+					"172.25.0.1:57092",
+					"172.26.0.1:57092",
+					"172.27.0.1:57092",
+					"172.28.0.1:57092"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:21:17.347104171Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5800192544056745,
+				"StableID":   "nJRwHvDvHn11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:73aa857fa92ce648735d5f6f595ac8b3078b14a194f56f72cee66647746ac61c",
+				"DiscoKey":   "discokey:ac62f171220e6de996c3a9a4719ae5fcbf913f3fedc5c0a98e110490ab01cf4a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42661",
+					"10.65.0.27:42661",
+					"172.17.0.1:42661",
+					"172.18.0.1:42661",
+					"172.19.0.1:42661",
+					"172.20.0.1:42661",
+					"172.21.0.1:42661",
+					"172.22.0.1:42661",
+					"172.23.0.1:42661",
+					"172.24.0.1:42661",
+					"172.25.0.1:42661",
+					"172.26.0.1:42661",
+					"172.27.0.1:42661",
+					"172.28.0.1:42661"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:21:21.012421424Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4725532368819453,
+				"StableID":   "nWdDctiCud11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec327910540dbdc61464d526ac9800df50d6b956244da10af3ea424102e7d30e",
+				"DiscoKey":   "discokey:4d276da3bd54817b6af5ed9d3da58b57c6a09de2b4bb7f94656e3175bb93175a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58383",
+					"10.65.0.27:58383",
+					"172.17.0.1:58383",
+					"172.18.0.1:58383",
+					"172.19.0.1:58383",
+					"172.20.0.1:58383",
+					"172.21.0.1:58383",
+					"172.22.0.1:58383",
+					"172.23.0.1:58383",
+					"172.24.0.1:58383",
+					"172.25.0.1:58383",
+					"172.26.0.1:58383",
+					"172.27.0.1:58383",
+					"172.28.0.1:58383"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:21:21.550796677Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6882282173853531,
+				"StableID":   "nJSFSBtzjv11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe5dd419cfaf8151c09428107e4ee85c074928fd9f8fe3da73694074121cf72d",
+				"DiscoKey":   "discokey:298f317d964805d70c955707e74cc3a06589f35df730a2211e9d99a2c7f5103a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50289",
+					"10.65.0.27:50289",
+					"172.17.0.1:50289",
+					"172.18.0.1:50289",
+					"172.19.0.1:50289",
+					"172.20.0.1:50289",
+					"172.21.0.1:50289",
+					"172.22.0.1:50289",
+					"172.23.0.1:50289",
+					"172.24.0.1:50289",
+					"172.25.0.1:50289",
+					"172.26.0.1:50289",
+					"172.27.0.1:50289",
+					"172.28.0.1:50289"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:21:22.075465365Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8302794691259322,
+				"StableID":   "nMGMHaLMq721CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc0f150fc848435ae963f263bbb5b44c14b4de07c306da65f1d9d65dba8aa915",
+				"DiscoKey":   "discokey:e715d93aeac9eec6096a3e18131bd442fe35e13a0347123bcfe21723c9cfbc1c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37978",
+					"10.65.0.27:37978",
+					"172.17.0.1:37978",
+					"172.18.0.1:37978",
+					"172.19.0.1:37978",
+					"172.20.0.1:37978",
+					"172.21.0.1:37978",
+					"172.22.0.1:37978",
+					"172.23.0.1:37978",
+					"172.24.0.1:37978",
+					"172.25.0.1:37978",
+					"172.26.0.1:37978",
+					"172.27.0.1:37978",
+					"172.28.0.1:37978"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:21:22.617210394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6814575453737212,
+				"StableID":   "nVZuRpLLDv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db04fe21e83f45ddbed5b8446f6a92caf01754c38ed27c782c26b81abb977210",
+				"DiscoKey":   "discokey:d554e83b854f98f53fbf98046b8bb4d073b7afa017c42441270fdfbfbba39e44",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33457",
+					"10.65.0.27:33457",
+					"172.17.0.1:33457",
+					"172.18.0.1:33457",
+					"172.19.0.1:33457",
+					"172.20.0.1:33457",
+					"172.21.0.1:33457",
+					"172.22.0.1:33457",
+					"172.23.0.1:33457",
+					"172.24.0.1:33457",
+					"172.25.0.1:33457",
+					"172.26.0.1:33457",
+					"172.27.0.1:33457",
+					"172.28.0.1:33457"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:21:23.460129792Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3971972035245068,
+				"StableID":   "nZjmNGyu1Y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:64e3c927a0d8a260091b63aedddce84cff7d3e81f07ea13778ccc698c7e98b43",
+				"DiscoKey":   "discokey:67171f195393cdbd79f7ad13688070985774fe21be0cedac150777af6508354f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38948",
+					"10.65.0.27:38948",
+					"172.17.0.1:38948",
+					"172.18.0.1:38948",
+					"172.19.0.1:38948",
+					"172.20.0.1:38948",
+					"172.21.0.1:38948",
+					"172.22.0.1:38948",
+					"172.23.0.1:38948",
+					"172.24.0.1:38948",
+					"172.25.0.1:38948",
+					"172.26.0.1:38948",
+					"172.27.0.1:38948",
+					"172.28.0.1:38948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:21:23.937568907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4372583465575495,
+				"StableID":   "nELNeUMM9b11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a3e5671fbb6f6c658d6e163b7bd993cced8c022df31b868e10c82fba42286347",
+				"DiscoKey":   "discokey:54b578d48e785aa696d2ee85a5a3bda9a5179f5a57705e00de174e882e2f5071",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51405",
+					"10.65.0.27:51405",
+					"172.17.0.1:51405",
+					"172.18.0.1:51405",
+					"172.19.0.1:51405",
+					"172.20.0.1:51405",
+					"172.21.0.1:51405",
+					"172.22.0.1:51405",
+					"172.23.0.1:51405",
+					"172.24.0.1:51405",
+					"172.25.0.1:51405",
+					"172.26.0.1:51405",
+					"172.27.0.1:51405",
+					"172.28.0.1:51405"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:21:24.602179146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4608126954712804,
+				"StableID":   "nfvWCWg2zc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ed292b4cfa8d08d12bc6fe9b393fad60418df600a2e19127099519a3fa1db3f",
+				"DiscoKey":   "discokey:fb18e1047c814faa1936128cd722a341358c30909e998cbd856d38e7658bc216",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44111",
+					"10.65.0.27:44111",
+					"172.17.0.1:44111",
+					"172.18.0.1:44111",
+					"172.19.0.1:44111",
+					"172.20.0.1:44111",
+					"172.21.0.1:44111",
+					"172.22.0.1:44111",
+					"172.23.0.1:44111",
+					"172.24.0.1:44111",
+					"172.25.0.1:44111",
+					"172.26.0.1:44111",
+					"172.27.0.1:44111",
+					"172.28.0.1:44111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:21:25.133517278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1500340108592974,
+				"StableID":   "nRGwiePWiC11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:005e465b964cc904806f5161328c8f685fd1e56b59f30ea0d13cad619bd75e7b",
+				"DiscoKey":   "discokey:23354def6c19b41d12b50b428bb2b86a4e2cb7471abf9f39a4e93fa76040f810",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:34139",
+					"10.65.0.27:34139",
+					"172.17.0.1:34139",
+					"172.18.0.1:34139",
+					"172.19.0.1:34139",
+					"172.20.0.1:34139",
+					"172.21.0.1:34139",
+					"172.22.0.1:34139",
+					"172.23.0.1:34139",
+					"172.24.0.1:34139",
+					"172.25.0.1:34139",
+					"172.26.0.1:34139",
+					"172.27.0.1:34139",
+					"172.28.0.1:34139"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:21:25.660717434Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         521955752537854,
+				"StableID":   "ndAuVmtP5511CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:cc439a49e3f189d63a5a8b0deff24686018316cc041e6495c7dbab9074185e52",
+				"KeyExpiry":  "2026-11-09T09:21:26Z",
+				"DiscoKey":   "discokey:9373753ec674e553510849fb70c3d11a030a8ebdb697b79811e40fb34e754b34",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:36848",
+					"10.65.0.27:36848",
+					"172.17.0.1:36848",
+					"172.18.0.1:36848",
+					"172.19.0.1:36848",
+					"172.20.0.1:36848",
+					"172.21.0.1:36848",
+					"172.22.0.1:36848",
+					"172.23.0.1:36848",
+					"172.24.0.1:36848",
+					"172.25.0.1:36848",
+					"172.26.0.1:36848",
+					"172.27.0.1:36848",
+					"172.28.0.1:36848"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:21:26.194723126Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5848785703371618,
+				"StableID":   "n3V7Pbgvfn11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:61125883643bf13373afbfcc258f7ea148cd326b1273f337857ee86144c0521d",
+				"KeyExpiry":  "2026-11-09T09:21:27Z",
+				"DiscoKey":   "discokey:dc748887d44370c813a5e037e52b40bf597c6088551a43de750344a550be1a55",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55204",
+					"10.65.0.27:55204",
+					"172.17.0.1:55204",
+					"172.18.0.1:55204",
+					"172.19.0.1:55204",
+					"172.20.0.1:55204",
+					"172.21.0.1:55204",
+					"172.22.0.1:55204",
+					"172.23.0.1:55204",
+					"172.24.0.1:55204",
+					"172.25.0.1:55204",
+					"172.26.0.1:55204",
+					"172.27.0.1:55204",
+					"172.28.0.1:55204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:21:27.254674699Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4372583465575495,
+				"StableID":   "nELNeUMM9b11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       4372583465575495,
+				"Key":        "nodekey:a3e5671fbb6f6c658d6e163b7bd993cced8c022df31b868e10c82fba42286347",
+				"DiscoKey":   "discokey:54b578d48e785aa696d2ee85a5a3bda9a5179f5a57705e00de174e882e2f5071",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51405",
+					"10.65.0.27:51405",
+					"172.17.0.1:51405",
+					"172.18.0.1:51405",
+					"172.19.0.1:51405",
+					"172.20.0.1:51405",
+					"172.21.0.1:51405",
+					"172.22.0.1:51405",
+					"172.23.0.1:51405",
+					"172.24.0.1:51405",
+					"172.25.0.1:51405",
+					"172.26.0.1:51405",
+					"172.27.0.1:51405",
+					"172.28.0.1:51405"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:21:24.602179146Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a3e5671fbb6f6c658d6e163b7bd993cced8c022df31b868e10c82fba42286347",
+			"MachineKey": "mkey:76da317173218a89bf8bbab023809824d614bda9871dd94100d5cf93173c333c",
+			"Peers": [{
+				"ID":         8290277898300682,
+				"StableID":   "nPBh9UYgj721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:daf9699563bb8d8e86135a3eb1c6b4ca20670b36e6a6d87f7984fa2450dfe020",
+				"DiscoKey":   "discokey:cb20bf5e7e12b719e58613631bf8b830411be943c45ab7d2012c0f7256a01c1a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:53542",
+					"10.65.0.27:53542",
+					"172.17.0.1:53542",
+					"172.18.0.1:53542",
+					"172.19.0.1:53542",
+					"172.20.0.1:53542",
+					"172.21.0.1:53542",
+					"172.22.0.1:53542",
+					"172.23.0.1:53542",
+					"172.24.0.1:53542",
+					"172.25.0.1:53542",
+					"172.26.0.1:53542",
+					"172.27.0.1:53542",
+					"172.28.0.1:53542"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:21:09.574498768Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3616621037328237,
+				"StableID":   "nvuqX7WyEV11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c2487b3a38488d006f9a28c6d9b90b5afdcc68a260cf02b1b7aa3d559f145e32",
+				"DiscoKey":   "discokey:b6300c737099421c5a52b06c2d6aad403b1f076f0f7debe347671b4eb63a7839",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33348",
+					"10.65.0.27:33348",
+					"172.17.0.1:33348",
+					"172.18.0.1:33348",
+					"172.19.0.1:33348",
+					"172.20.0.1:33348",
+					"172.21.0.1:33348",
+					"172.22.0.1:33348",
+					"172.23.0.1:33348",
+					"172.24.0.1:33348",
+					"172.25.0.1:33348",
+					"172.26.0.1:33348",
+					"172.27.0.1:33348",
+					"172.28.0.1:33348"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:21:15.566085445Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5655179600283341,
+				"StableID":   "nLgQ2myEAm11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:133c74cdf13dcb6f236645b723c019ea0eb574dd2c988e6aaebd0c202f7abc72",
+				"DiscoKey":   "discokey:7ede0fad082f1f4540afd15d339f4f14498fd7a2f6253565fc59cc8020788c3a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57092",
+					"10.65.0.27:57092",
+					"172.17.0.1:57092",
+					"172.18.0.1:57092",
+					"172.19.0.1:57092",
+					"172.20.0.1:57092",
+					"172.21.0.1:57092",
+					"172.22.0.1:57092",
+					"172.23.0.1:57092",
+					"172.24.0.1:57092",
+					"172.25.0.1:57092",
+					"172.26.0.1:57092",
+					"172.27.0.1:57092",
+					"172.28.0.1:57092"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:21:17.347104171Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5800192544056745,
+				"StableID":   "nJRwHvDvHn11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:73aa857fa92ce648735d5f6f595ac8b3078b14a194f56f72cee66647746ac61c",
+				"DiscoKey":   "discokey:ac62f171220e6de996c3a9a4719ae5fcbf913f3fedc5c0a98e110490ab01cf4a",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42661",
+					"10.65.0.27:42661",
+					"172.17.0.1:42661",
+					"172.18.0.1:42661",
+					"172.19.0.1:42661",
+					"172.20.0.1:42661",
+					"172.21.0.1:42661",
+					"172.22.0.1:42661",
+					"172.23.0.1:42661",
+					"172.24.0.1:42661",
+					"172.25.0.1:42661",
+					"172.26.0.1:42661",
+					"172.27.0.1:42661",
+					"172.28.0.1:42661"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:21:21.012421424Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4725532368819453,
+				"StableID":   "nWdDctiCud11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ec327910540dbdc61464d526ac9800df50d6b956244da10af3ea424102e7d30e",
+				"DiscoKey":   "discokey:4d276da3bd54817b6af5ed9d3da58b57c6a09de2b4bb7f94656e3175bb93175a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58383",
+					"10.65.0.27:58383",
+					"172.17.0.1:58383",
+					"172.18.0.1:58383",
+					"172.19.0.1:58383",
+					"172.20.0.1:58383",
+					"172.21.0.1:58383",
+					"172.22.0.1:58383",
+					"172.23.0.1:58383",
+					"172.24.0.1:58383",
+					"172.25.0.1:58383",
+					"172.26.0.1:58383",
+					"172.27.0.1:58383",
+					"172.28.0.1:58383"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:21:21.550796677Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6882282173853531,
+				"StableID":   "nJSFSBtzjv11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe5dd419cfaf8151c09428107e4ee85c074928fd9f8fe3da73694074121cf72d",
+				"DiscoKey":   "discokey:298f317d964805d70c955707e74cc3a06589f35df730a2211e9d99a2c7f5103a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50289",
+					"10.65.0.27:50289",
+					"172.17.0.1:50289",
+					"172.18.0.1:50289",
+					"172.19.0.1:50289",
+					"172.20.0.1:50289",
+					"172.21.0.1:50289",
+					"172.22.0.1:50289",
+					"172.23.0.1:50289",
+					"172.24.0.1:50289",
+					"172.25.0.1:50289",
+					"172.26.0.1:50289",
+					"172.27.0.1:50289",
+					"172.28.0.1:50289"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:21:22.075465365Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8302794691259322,
+				"StableID":   "nMGMHaLMq721CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc0f150fc848435ae963f263bbb5b44c14b4de07c306da65f1d9d65dba8aa915",
+				"DiscoKey":   "discokey:e715d93aeac9eec6096a3e18131bd442fe35e13a0347123bcfe21723c9cfbc1c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:37978",
+					"10.65.0.27:37978",
+					"172.17.0.1:37978",
+					"172.18.0.1:37978",
+					"172.19.0.1:37978",
+					"172.20.0.1:37978",
+					"172.21.0.1:37978",
+					"172.22.0.1:37978",
+					"172.23.0.1:37978",
+					"172.24.0.1:37978",
+					"172.25.0.1:37978",
+					"172.26.0.1:37978",
+					"172.27.0.1:37978",
+					"172.28.0.1:37978"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:21:22.617210394Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6814575453737212,
+				"StableID":   "nVZuRpLLDv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db04fe21e83f45ddbed5b8446f6a92caf01754c38ed27c782c26b81abb977210",
+				"DiscoKey":   "discokey:d554e83b854f98f53fbf98046b8bb4d073b7afa017c42441270fdfbfbba39e44",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33457",
+					"10.65.0.27:33457",
+					"172.17.0.1:33457",
+					"172.18.0.1:33457",
+					"172.19.0.1:33457",
+					"172.20.0.1:33457",
+					"172.21.0.1:33457",
+					"172.22.0.1:33457",
+					"172.23.0.1:33457",
+					"172.24.0.1:33457",
+					"172.25.0.1:33457",
+					"172.26.0.1:33457",
+					"172.27.0.1:33457",
+					"172.28.0.1:33457"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:21:23.460129792Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3971972035245068,
+				"StableID":   "nZjmNGyu1Y11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:64e3c927a0d8a260091b63aedddce84cff7d3e81f07ea13778ccc698c7e98b43",
+				"DiscoKey":   "discokey:67171f195393cdbd79f7ad13688070985774fe21be0cedac150777af6508354f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38948",
+					"10.65.0.27:38948",
+					"172.17.0.1:38948",
+					"172.18.0.1:38948",
+					"172.19.0.1:38948",
+					"172.20.0.1:38948",
+					"172.21.0.1:38948",
+					"172.22.0.1:38948",
+					"172.23.0.1:38948",
+					"172.24.0.1:38948",
+					"172.25.0.1:38948",
+					"172.26.0.1:38948",
+					"172.27.0.1:38948",
+					"172.28.0.1:38948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:21:23.937568907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4608126954712804,
+				"StableID":   "nfvWCWg2zc11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4ed292b4cfa8d08d12bc6fe9b393fad60418df600a2e19127099519a3fa1db3f",
+				"DiscoKey":   "discokey:fb18e1047c814faa1936128cd722a341358c30909e998cbd856d38e7658bc216",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44111",
+					"10.65.0.27:44111",
+					"172.17.0.1:44111",
+					"172.18.0.1:44111",
+					"172.19.0.1:44111",
+					"172.20.0.1:44111",
+					"172.21.0.1:44111",
+					"172.22.0.1:44111",
+					"172.23.0.1:44111",
+					"172.24.0.1:44111",
+					"172.25.0.1:44111",
+					"172.26.0.1:44111",
+					"172.27.0.1:44111",
+					"172.28.0.1:44111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:21:25.133517278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1500340108592974,
+				"StableID":   "nRGwiePWiC11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:005e465b964cc904806f5161328c8f685fd1e56b59f30ea0d13cad619bd75e7b",
+				"DiscoKey":   "discokey:23354def6c19b41d12b50b428bb2b86a4e2cb7471abf9f39a4e93fa76040f810",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:34139",
+					"10.65.0.27:34139",
+					"172.17.0.1:34139",
+					"172.18.0.1:34139",
+					"172.19.0.1:34139",
+					"172.20.0.1:34139",
+					"172.21.0.1:34139",
+					"172.22.0.1:34139",
+					"172.23.0.1:34139",
+					"172.24.0.1:34139",
+					"172.25.0.1:34139",
+					"172.26.0.1:34139",
+					"172.27.0.1:34139",
+					"172.28.0.1:34139"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:21:25.660717434Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         521955752537854,
+				"StableID":   "ndAuVmtP5511CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:cc439a49e3f189d63a5a8b0deff24686018316cc041e6495c7dbab9074185e52",
+				"KeyExpiry":  "2026-11-09T09:21:26Z",
+				"DiscoKey":   "discokey:9373753ec674e553510849fb70c3d11a030a8ebdb697b79811e40fb34e754b34",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:36848",
+					"10.65.0.27:36848",
+					"172.17.0.1:36848",
+					"172.18.0.1:36848",
+					"172.19.0.1:36848",
+					"172.20.0.1:36848",
+					"172.21.0.1:36848",
+					"172.22.0.1:36848",
+					"172.23.0.1:36848",
+					"172.24.0.1:36848",
+					"172.25.0.1:36848",
+					"172.26.0.1:36848",
+					"172.27.0.1:36848",
+					"172.28.0.1:36848"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:21:26.194723126Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4523172015074948,
+				"StableID":   "nwEe6R4ZKc11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:43722a1489ece323af8ed65ad9fef1a309afef19f60109cf84536abd2f108c30",
+				"KeyExpiry":  "2026-11-09T09:21:26Z",
+				"DiscoKey":   "discokey:b905104a3ce14244a835cd8c1bce75dac82376d0fac4110c36a649a3b7f5c456",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49558",
+					"10.65.0.27:49558",
+					"172.17.0.1:49558",
+					"172.18.0.1:49558",
+					"172.19.0.1:49558",
+					"172.20.0.1:49558",
+					"172.21.0.1:49558",
+					"172.22.0.1:49558",
+					"172.23.0.1:49558",
+					"172.24.0.1:49558",
+					"172.25.0.1:49558",
+					"172.26.0.1:49558",
+					"172.27.0.1:49558",
+					"172.28.0.1:49558"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:21:26.723487548Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5848785703371618,
+				"StableID":   "n3V7Pbgvfn11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:61125883643bf13373afbfcc258f7ea148cd326b1273f337857ee86144c0521d",
+				"KeyExpiry":  "2026-11-09T09:21:27Z",
+				"DiscoKey":   "discokey:dc748887d44370c813a5e037e52b40bf597c6088551a43de750344a550be1a55",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:55204",
+					"10.65.0.27:55204",
+					"172.17.0.1:55204",
+					"172.18.0.1:55204",
+					"172.19.0.1:55204",
+					"172.20.0.1:55204",
+					"172.21.0.1:55204",
+					"172.22.0.1:55204",
+					"172.23.0.1:55204",
+					"172.24.0.1:55204",
+					"172.25.0.1:55204",
+					"172.26.0.1:55204",
+					"172.27.0.1:55204",
+					"172.28.0.1:55204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:21:27.254674699Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4372583465575495": {
+				"ID":          4372583465575495,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-src-leading-whitespace.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-src-leading-whitespace.hujson
@@ -1,0 +1,22123 @@
+// ssh-src-leading-whitespace
+//
+// ssh src has leading whitespace
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-13T09:22:12Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-src-leading-whitespace",
+	"description":    "ssh src has leading whitespace",
+	"category":       "ssh",
+	"captured_at":    "2026-05-13T09:22:12.527314213Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                             \n  \n                                                                 \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh src has leading whitespace\",\n\t\"id\":          \"ssh-src-leading-whitespace\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\" odin@example.com\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-edges/ssh-src-leading-whitespace.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    [" odin@example.com"],
+				"users":  ["root"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7000699690251896,
+				"StableID":   "nVMkrZWdfw11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       7000699690251896,
+				"Key":        "nodekey:1af67b633fce2aa5dd3d1c22557a42939a55de468eee10b89c0e3f3d8a7f1f08",
+				"DiscoKey":   "discokey:ca263f641228d82e7ba561ce1fdc498a4ac6b7a9d1bf1ab6e3b56f0b22abb818",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35249",
+					"10.65.0.27:35249",
+					"172.17.0.1:35249",
+					"172.18.0.1:35249",
+					"172.19.0.1:35249",
+					"172.20.0.1:35249",
+					"172.21.0.1:35249",
+					"172.22.0.1:35249",
+					"172.23.0.1:35249",
+					"172.24.0.1:35249",
+					"172.25.0.1:35249",
+					"172.26.0.1:35249",
+					"172.27.0.1:35249",
+					"172.28.0.1:35249"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:22:21.464954476Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1af67b633fce2aa5dd3d1c22557a42939a55de468eee10b89c0e3f3d8a7f1f08",
+			"MachineKey": "mkey:037acc072f5f75d30193e376458ab524393e53bff3426bc9e6141b5ae406c40b",
+			"Peers": [{
+				"ID":         8143243316789368,
+				"StableID":   "n1mKgDC6b621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39f74a3cfcbcd2d85a0505acd7608c438d8b75f75bc73d973c69ffefca1d7b35",
+				"DiscoKey":   "discokey:b286192a70d77992ae5e2c3e46bf90bdcf13cbec61579caf2e3806f562ae5c30",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52300",
+					"10.65.0.27:52300",
+					"172.17.0.1:52300",
+					"172.18.0.1:52300",
+					"172.19.0.1:52300",
+					"172.20.0.1:52300",
+					"172.21.0.1:52300",
+					"172.22.0.1:52300",
+					"172.23.0.1:52300",
+					"172.24.0.1:52300",
+					"172.25.0.1:52300",
+					"172.26.0.1:52300",
+					"172.27.0.1:52300",
+					"172.28.0.1:52300"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:22:15.112140752Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         113860257757471,
+				"StableID":   "nCVk58vZt111CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2842a72c6a80f763919802b778551075f77872ad7370c9a2de933018cdf143a",
+				"DiscoKey":   "discokey:484ac995502db71932de00d90d5d0d156a7f026ca5364ef3dbe3ae81bafc1476",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33365",
+					"10.65.0.27:33365",
+					"172.17.0.1:33365",
+					"172.18.0.1:33365",
+					"172.19.0.1:33365",
+					"172.20.0.1:33365",
+					"172.21.0.1:33365",
+					"172.22.0.1:33365",
+					"172.23.0.1:33365",
+					"172.24.0.1:33365",
+					"172.25.0.1:33365",
+					"172.26.0.1:33365",
+					"172.27.0.1:33365",
+					"172.28.0.1:33365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:22:15.844852796Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8677184893301866,
+				"StableID":   "nVk3Q8wukA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0d962c6fb4822dd3f7d040f87a7cf03159c7e110abed635b06e5be1ea044a4b",
+				"DiscoKey":   "discokey:99083f7b395bb3d58c747b2924bf09cd845be26dd013e76cb8897949bded4378",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34443",
+					"10.65.0.27:34443",
+					"172.17.0.1:34443",
+					"172.18.0.1:34443",
+					"172.19.0.1:34443",
+					"172.20.0.1:34443",
+					"172.21.0.1:34443",
+					"172.22.0.1:34443",
+					"172.23.0.1:34443",
+					"172.24.0.1:34443",
+					"172.25.0.1:34443",
+					"172.26.0.1:34443",
+					"172.27.0.1:34443",
+					"172.28.0.1:34443"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:22:16.376358719Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5650061022717349,
+				"StableID":   "nesSrHXv7m11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7e2046717ee3fa271fb28b7c09fa35fcb67bbebf2c25495eff616e3ef30c079",
+				"DiscoKey":   "discokey:1ec584995763f070c9b9b759453ff4e2c4fedd6e5dcc2736bb30a081dafda228",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:54222",
+					"10.65.0.27:54222",
+					"172.17.0.1:54222",
+					"172.18.0.1:54222",
+					"172.19.0.1:54222",
+					"172.20.0.1:54222",
+					"172.21.0.1:54222",
+					"172.22.0.1:54222",
+					"172.23.0.1:54222",
+					"172.24.0.1:54222",
+					"172.25.0.1:54222",
+					"172.26.0.1:54222",
+					"172.27.0.1:54222",
+					"172.28.0.1:54222"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:22:16.91735265Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5333300322750175,
+				"StableID":   "nGhZVqkTei11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:04046ddc32a46ab98f6736d52022153d1f7925d49a894c69149f193f03fb8f4e",
+				"DiscoKey":   "discokey:04a4340cf2ab637b906d2ca8d7211a892219b154aced487018f475b0a673ca3b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42920",
+					"10.65.0.27:42920",
+					"172.17.0.1:42920",
+					"172.18.0.1:42920",
+					"172.19.0.1:42920",
+					"172.20.0.1:42920",
+					"172.21.0.1:42920",
+					"172.22.0.1:42920",
+					"172.23.0.1:42920",
+					"172.24.0.1:42920",
+					"172.25.0.1:42920",
+					"172.26.0.1:42920",
+					"172.27.0.1:42920",
+					"172.28.0.1:42920"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:22:17.457951971Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         185841476911834,
+				"StableID":   "nd4yvwjAT211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4238e5a1a2f60912dd33750eaba2e9ade234e967f531034c8a2815df697adb14",
+				"DiscoKey":   "discokey:54f707cb1a422b733807276e804ce659bada6eb39062823fe48a5d80b6df1b47",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58427",
+					"10.65.0.27:58427",
+					"172.17.0.1:58427",
+					"172.18.0.1:58427",
+					"172.19.0.1:58427",
+					"172.20.0.1:58427",
+					"172.21.0.1:58427",
+					"172.22.0.1:58427",
+					"172.23.0.1:58427",
+					"172.24.0.1:58427",
+					"172.25.0.1:58427",
+					"172.26.0.1:58427",
+					"172.27.0.1:58427",
+					"172.28.0.1:58427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:22:17.99921398Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7323377596879331,
+				"StableID":   "n8FTWFimBz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0909da237b2e808c61e8de74434b2b9d9aecb4ee43065089ece5204b6b9b5629",
+				"DiscoKey":   "discokey:a32b59e0d33e2ded107b39b22960633cdd1f0abc18f36f57d5e21c7640a93149",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38227",
+					"10.65.0.27:38227",
+					"172.17.0.1:38227",
+					"172.18.0.1:38227",
+					"172.19.0.1:38227",
+					"172.20.0.1:38227",
+					"172.21.0.1:38227",
+					"172.22.0.1:38227",
+					"172.23.0.1:38227",
+					"172.24.0.1:38227",
+					"172.25.0.1:38227",
+					"172.26.0.1:38227",
+					"172.27.0.1:38227",
+					"172.28.0.1:38227"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:22:18.625515705Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6552951513903457,
+				"StableID":   "ntApkcvqAt11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:931685473e4f205d62413ac4d2c3ebcf8458908f94f8eb83c4775c87a115ad17",
+				"DiscoKey":   "discokey:bc9c50ba82975f34422b2beb098bf1de48b763f778361a0252ffd5220a0f7403",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55202",
+					"10.65.0.27:55202",
+					"172.17.0.1:55202",
+					"172.18.0.1:55202",
+					"172.19.0.1:55202",
+					"172.20.0.1:55202",
+					"172.21.0.1:55202",
+					"172.22.0.1:55202",
+					"172.23.0.1:55202",
+					"172.24.0.1:55202",
+					"172.25.0.1:55202",
+					"172.26.0.1:55202",
+					"172.27.0.1:55202",
+					"172.28.0.1:55202"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:22:19.337487583Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         270807153993723,
+				"StableID":   "nkm3sPee7311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87c7f40fb532366935ad5214207388a29031d359001b49634cc910f135465f6d",
+				"DiscoKey":   "discokey:501b1dad6def0edb6ba5a26e86ca442aa8a2151e84fceea8132f51fb2d1e956e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44002",
+					"10.65.0.27:44002",
+					"172.17.0.1:44002",
+					"172.18.0.1:44002",
+					"172.19.0.1:44002",
+					"172.20.0.1:44002",
+					"172.21.0.1:44002",
+					"172.22.0.1:44002",
+					"172.23.0.1:44002",
+					"172.24.0.1:44002",
+					"172.25.0.1:44002",
+					"172.26.0.1:44002",
+					"172.27.0.1:44002",
+					"172.28.0.1:44002"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:22:19.865837519Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6705106736621230,
+				"StableID":   "n1pqkUnkMu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6a64002270eca2ff6d91bc9adda789c18c32581d805ba41c1d548b4675348229",
+				"DiscoKey":   "discokey:35cf0dffa25ba0e1150a8ef1336210509b79e4a6618b4dc5c12f327147d8d55a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53680",
+					"10.65.0.27:53680",
+					"172.17.0.1:53680",
+					"172.18.0.1:53680",
+					"172.19.0.1:53680",
+					"172.20.0.1:53680",
+					"172.21.0.1:53680",
+					"172.22.0.1:53680",
+					"172.23.0.1:53680",
+					"172.24.0.1:53680",
+					"172.25.0.1:53680",
+					"172.26.0.1:53680",
+					"172.27.0.1:53680",
+					"172.28.0.1:53680"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:22:20.398552469Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7667948310719536,
+				"StableID":   "nPYeZyzps221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0ce1ba6d4cbbcf9decf7a9f01ad378411022ffd5e9eef94809593172fa1af69",
+				"DiscoKey":   "discokey:995e138a0bc7c2d6a53c165e23b474940593333d62d90528cee068a4e18a2b0e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56289",
+					"10.65.0.27:56289",
+					"172.17.0.1:56289",
+					"172.18.0.1:56289",
+					"172.19.0.1:56289",
+					"172.20.0.1:56289",
+					"172.21.0.1:56289",
+					"172.22.0.1:56289",
+					"172.23.0.1:56289",
+					"172.24.0.1:56289",
+					"172.25.0.1:56289",
+					"172.26.0.1:56289",
+					"172.27.0.1:56289",
+					"172.28.0.1:56289"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:22:20.937449274Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4284797806903681,
+				"StableID":   "n2dXbcNbTa11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a7a8458270cc82b0625a3ebd79c3e5af5e040c4219deba360979d91f965a6476",
+				"KeyExpiry":  "2026-11-09T09:22:21Z",
+				"DiscoKey":   "discokey:9616211d17ab9697e7fa55165294efc168d482ee06724751e93efbeed324fd76",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50158",
+					"10.65.0.27:50158",
+					"172.17.0.1:50158",
+					"172.18.0.1:50158",
+					"172.19.0.1:50158",
+					"172.20.0.1:50158",
+					"172.21.0.1:50158",
+					"172.22.0.1:50158",
+					"172.23.0.1:50158",
+					"172.24.0.1:50158",
+					"172.25.0.1:50158",
+					"172.26.0.1:50158",
+					"172.27.0.1:50158",
+					"172.28.0.1:50158"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:22:21.988373309Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6444602222931293,
+				"StableID":   "ntkLwnmmKs11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b654ef19ce6bebdfc6c755e04f8696d3bed3d99477bd5f05716627c739453476",
+				"KeyExpiry":  "2026-11-09T09:22:22Z",
+				"DiscoKey":   "discokey:afb4f3c13a03175eb745bc3dc0ee942c876b1e75571d99756f7af5701a4dc06b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50042",
+					"10.65.0.27:50042",
+					"172.17.0.1:50042",
+					"172.18.0.1:50042",
+					"172.19.0.1:50042",
+					"172.20.0.1:50042",
+					"172.21.0.1:50042",
+					"172.22.0.1:50042",
+					"172.23.0.1:50042",
+					"172.24.0.1:50042",
+					"172.25.0.1:50042",
+					"172.26.0.1:50042",
+					"172.27.0.1:50042",
+					"172.28.0.1:50042"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:22:22.530433778Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5578350789120784,
+				"StableID":   "nqd35LpSZk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1f50fdcd08b5a717d0aec4e3b425a7e9a16c73233d894e71323c69ea2a7e2e1b",
+				"KeyExpiry":  "2026-11-09T09:22:23Z",
+				"DiscoKey":   "discokey:a6853978df9b5a349793b1a03dbdf09ba43ae156e43dd71f0042377af70b9b7c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49037",
+					"10.65.0.27:49037",
+					"172.17.0.1:49037",
+					"172.18.0.1:49037",
+					"172.19.0.1:49037",
+					"172.20.0.1:49037",
+					"172.21.0.1:49037",
+					"172.22.0.1:49037",
+					"172.23.0.1:49037",
+					"172.24.0.1:49037",
+					"172.25.0.1:49037",
+					"172.26.0.1:49037",
+					"172.27.0.1:49037",
+					"172.28.0.1:49037"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:22:23.062857052Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{
+				"principals": [{"nodeIP": "100.64.0.19"}, {"nodeIP": "fd7a:115c:a1e0::13"}],
+				"sshUsers":   {"root": "root"},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				}
+			}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7000699690251896": {
+				"ID":          7000699690251896,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		},
+		"ssh_rules": [{
+			"principals": [{"nodeIP": "100.64.0.19"}, {"nodeIP": "fd7a:115c:a1e0::13"}],
+			"sshUsers":   {"root": "root"},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}
+		}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         185841476911834,
+				"StableID":   "nd4yvwjAT211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       185841476911834,
+				"Key":        "nodekey:4238e5a1a2f60912dd33750eaba2e9ade234e967f531034c8a2815df697adb14",
+				"DiscoKey":   "discokey:54f707cb1a422b733807276e804ce659bada6eb39062823fe48a5d80b6df1b47",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58427",
+					"10.65.0.27:58427",
+					"172.17.0.1:58427",
+					"172.18.0.1:58427",
+					"172.19.0.1:58427",
+					"172.20.0.1:58427",
+					"172.21.0.1:58427",
+					"172.22.0.1:58427",
+					"172.23.0.1:58427",
+					"172.24.0.1:58427",
+					"172.25.0.1:58427",
+					"172.26.0.1:58427",
+					"172.27.0.1:58427",
+					"172.28.0.1:58427"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:22:17.99921398Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4238e5a1a2f60912dd33750eaba2e9ade234e967f531034c8a2815df697adb14",
+			"MachineKey": "mkey:e5dd003afd4457d6e5e6430be1dc7d0b22642f864fdb53389102efb45c722d1c",
+			"Peers": [{
+				"ID":         8143243316789368,
+				"StableID":   "n1mKgDC6b621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39f74a3cfcbcd2d85a0505acd7608c438d8b75f75bc73d973c69ffefca1d7b35",
+				"DiscoKey":   "discokey:b286192a70d77992ae5e2c3e46bf90bdcf13cbec61579caf2e3806f562ae5c30",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52300",
+					"10.65.0.27:52300",
+					"172.17.0.1:52300",
+					"172.18.0.1:52300",
+					"172.19.0.1:52300",
+					"172.20.0.1:52300",
+					"172.21.0.1:52300",
+					"172.22.0.1:52300",
+					"172.23.0.1:52300",
+					"172.24.0.1:52300",
+					"172.25.0.1:52300",
+					"172.26.0.1:52300",
+					"172.27.0.1:52300",
+					"172.28.0.1:52300"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:22:15.112140752Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         113860257757471,
+				"StableID":   "nCVk58vZt111CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2842a72c6a80f763919802b778551075f77872ad7370c9a2de933018cdf143a",
+				"DiscoKey":   "discokey:484ac995502db71932de00d90d5d0d156a7f026ca5364ef3dbe3ae81bafc1476",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33365",
+					"10.65.0.27:33365",
+					"172.17.0.1:33365",
+					"172.18.0.1:33365",
+					"172.19.0.1:33365",
+					"172.20.0.1:33365",
+					"172.21.0.1:33365",
+					"172.22.0.1:33365",
+					"172.23.0.1:33365",
+					"172.24.0.1:33365",
+					"172.25.0.1:33365",
+					"172.26.0.1:33365",
+					"172.27.0.1:33365",
+					"172.28.0.1:33365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:22:15.844852796Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8677184893301866,
+				"StableID":   "nVk3Q8wukA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0d962c6fb4822dd3f7d040f87a7cf03159c7e110abed635b06e5be1ea044a4b",
+				"DiscoKey":   "discokey:99083f7b395bb3d58c747b2924bf09cd845be26dd013e76cb8897949bded4378",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34443",
+					"10.65.0.27:34443",
+					"172.17.0.1:34443",
+					"172.18.0.1:34443",
+					"172.19.0.1:34443",
+					"172.20.0.1:34443",
+					"172.21.0.1:34443",
+					"172.22.0.1:34443",
+					"172.23.0.1:34443",
+					"172.24.0.1:34443",
+					"172.25.0.1:34443",
+					"172.26.0.1:34443",
+					"172.27.0.1:34443",
+					"172.28.0.1:34443"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:22:16.376358719Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5650061022717349,
+				"StableID":   "nesSrHXv7m11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7e2046717ee3fa271fb28b7c09fa35fcb67bbebf2c25495eff616e3ef30c079",
+				"DiscoKey":   "discokey:1ec584995763f070c9b9b759453ff4e2c4fedd6e5dcc2736bb30a081dafda228",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:54222",
+					"10.65.0.27:54222",
+					"172.17.0.1:54222",
+					"172.18.0.1:54222",
+					"172.19.0.1:54222",
+					"172.20.0.1:54222",
+					"172.21.0.1:54222",
+					"172.22.0.1:54222",
+					"172.23.0.1:54222",
+					"172.24.0.1:54222",
+					"172.25.0.1:54222",
+					"172.26.0.1:54222",
+					"172.27.0.1:54222",
+					"172.28.0.1:54222"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:22:16.91735265Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5333300322750175,
+				"StableID":   "nGhZVqkTei11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:04046ddc32a46ab98f6736d52022153d1f7925d49a894c69149f193f03fb8f4e",
+				"DiscoKey":   "discokey:04a4340cf2ab637b906d2ca8d7211a892219b154aced487018f475b0a673ca3b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42920",
+					"10.65.0.27:42920",
+					"172.17.0.1:42920",
+					"172.18.0.1:42920",
+					"172.19.0.1:42920",
+					"172.20.0.1:42920",
+					"172.21.0.1:42920",
+					"172.22.0.1:42920",
+					"172.23.0.1:42920",
+					"172.24.0.1:42920",
+					"172.25.0.1:42920",
+					"172.26.0.1:42920",
+					"172.27.0.1:42920",
+					"172.28.0.1:42920"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:22:17.457951971Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7323377596879331,
+				"StableID":   "n8FTWFimBz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0909da237b2e808c61e8de74434b2b9d9aecb4ee43065089ece5204b6b9b5629",
+				"DiscoKey":   "discokey:a32b59e0d33e2ded107b39b22960633cdd1f0abc18f36f57d5e21c7640a93149",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38227",
+					"10.65.0.27:38227",
+					"172.17.0.1:38227",
+					"172.18.0.1:38227",
+					"172.19.0.1:38227",
+					"172.20.0.1:38227",
+					"172.21.0.1:38227",
+					"172.22.0.1:38227",
+					"172.23.0.1:38227",
+					"172.24.0.1:38227",
+					"172.25.0.1:38227",
+					"172.26.0.1:38227",
+					"172.27.0.1:38227",
+					"172.28.0.1:38227"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:22:18.625515705Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6552951513903457,
+				"StableID":   "ntApkcvqAt11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:931685473e4f205d62413ac4d2c3ebcf8458908f94f8eb83c4775c87a115ad17",
+				"DiscoKey":   "discokey:bc9c50ba82975f34422b2beb098bf1de48b763f778361a0252ffd5220a0f7403",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55202",
+					"10.65.0.27:55202",
+					"172.17.0.1:55202",
+					"172.18.0.1:55202",
+					"172.19.0.1:55202",
+					"172.20.0.1:55202",
+					"172.21.0.1:55202",
+					"172.22.0.1:55202",
+					"172.23.0.1:55202",
+					"172.24.0.1:55202",
+					"172.25.0.1:55202",
+					"172.26.0.1:55202",
+					"172.27.0.1:55202",
+					"172.28.0.1:55202"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:22:19.337487583Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         270807153993723,
+				"StableID":   "nkm3sPee7311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87c7f40fb532366935ad5214207388a29031d359001b49634cc910f135465f6d",
+				"DiscoKey":   "discokey:501b1dad6def0edb6ba5a26e86ca442aa8a2151e84fceea8132f51fb2d1e956e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44002",
+					"10.65.0.27:44002",
+					"172.17.0.1:44002",
+					"172.18.0.1:44002",
+					"172.19.0.1:44002",
+					"172.20.0.1:44002",
+					"172.21.0.1:44002",
+					"172.22.0.1:44002",
+					"172.23.0.1:44002",
+					"172.24.0.1:44002",
+					"172.25.0.1:44002",
+					"172.26.0.1:44002",
+					"172.27.0.1:44002",
+					"172.28.0.1:44002"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:22:19.865837519Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6705106736621230,
+				"StableID":   "n1pqkUnkMu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6a64002270eca2ff6d91bc9adda789c18c32581d805ba41c1d548b4675348229",
+				"DiscoKey":   "discokey:35cf0dffa25ba0e1150a8ef1336210509b79e4a6618b4dc5c12f327147d8d55a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53680",
+					"10.65.0.27:53680",
+					"172.17.0.1:53680",
+					"172.18.0.1:53680",
+					"172.19.0.1:53680",
+					"172.20.0.1:53680",
+					"172.21.0.1:53680",
+					"172.22.0.1:53680",
+					"172.23.0.1:53680",
+					"172.24.0.1:53680",
+					"172.25.0.1:53680",
+					"172.26.0.1:53680",
+					"172.27.0.1:53680",
+					"172.28.0.1:53680"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:22:20.398552469Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7667948310719536,
+				"StableID":   "nPYeZyzps221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0ce1ba6d4cbbcf9decf7a9f01ad378411022ffd5e9eef94809593172fa1af69",
+				"DiscoKey":   "discokey:995e138a0bc7c2d6a53c165e23b474940593333d62d90528cee068a4e18a2b0e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56289",
+					"10.65.0.27:56289",
+					"172.17.0.1:56289",
+					"172.18.0.1:56289",
+					"172.19.0.1:56289",
+					"172.20.0.1:56289",
+					"172.21.0.1:56289",
+					"172.22.0.1:56289",
+					"172.23.0.1:56289",
+					"172.24.0.1:56289",
+					"172.25.0.1:56289",
+					"172.26.0.1:56289",
+					"172.27.0.1:56289",
+					"172.28.0.1:56289"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:22:20.937449274Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7000699690251896,
+				"StableID":   "nVMkrZWdfw11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1af67b633fce2aa5dd3d1c22557a42939a55de468eee10b89c0e3f3d8a7f1f08",
+				"DiscoKey":   "discokey:ca263f641228d82e7ba561ce1fdc498a4ac6b7a9d1bf1ab6e3b56f0b22abb818",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35249",
+					"10.65.0.27:35249",
+					"172.17.0.1:35249",
+					"172.18.0.1:35249",
+					"172.19.0.1:35249",
+					"172.20.0.1:35249",
+					"172.21.0.1:35249",
+					"172.22.0.1:35249",
+					"172.23.0.1:35249",
+					"172.24.0.1:35249",
+					"172.25.0.1:35249",
+					"172.26.0.1:35249",
+					"172.27.0.1:35249",
+					"172.28.0.1:35249"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:22:21.464954476Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4284797806903681,
+				"StableID":   "n2dXbcNbTa11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a7a8458270cc82b0625a3ebd79c3e5af5e040c4219deba360979d91f965a6476",
+				"KeyExpiry":  "2026-11-09T09:22:21Z",
+				"DiscoKey":   "discokey:9616211d17ab9697e7fa55165294efc168d482ee06724751e93efbeed324fd76",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50158",
+					"10.65.0.27:50158",
+					"172.17.0.1:50158",
+					"172.18.0.1:50158",
+					"172.19.0.1:50158",
+					"172.20.0.1:50158",
+					"172.21.0.1:50158",
+					"172.22.0.1:50158",
+					"172.23.0.1:50158",
+					"172.24.0.1:50158",
+					"172.25.0.1:50158",
+					"172.26.0.1:50158",
+					"172.27.0.1:50158",
+					"172.28.0.1:50158"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:22:21.988373309Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6444602222931293,
+				"StableID":   "ntkLwnmmKs11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b654ef19ce6bebdfc6c755e04f8696d3bed3d99477bd5f05716627c739453476",
+				"KeyExpiry":  "2026-11-09T09:22:22Z",
+				"DiscoKey":   "discokey:afb4f3c13a03175eb745bc3dc0ee942c876b1e75571d99756f7af5701a4dc06b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50042",
+					"10.65.0.27:50042",
+					"172.17.0.1:50042",
+					"172.18.0.1:50042",
+					"172.19.0.1:50042",
+					"172.20.0.1:50042",
+					"172.21.0.1:50042",
+					"172.22.0.1:50042",
+					"172.23.0.1:50042",
+					"172.24.0.1:50042",
+					"172.25.0.1:50042",
+					"172.26.0.1:50042",
+					"172.27.0.1:50042",
+					"172.28.0.1:50042"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:22:22.530433778Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5578350789120784,
+				"StableID":   "nqd35LpSZk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1f50fdcd08b5a717d0aec4e3b425a7e9a16c73233d894e71323c69ea2a7e2e1b",
+				"KeyExpiry":  "2026-11-09T09:22:23Z",
+				"DiscoKey":   "discokey:a6853978df9b5a349793b1a03dbdf09ba43ae156e43dd71f0042377af70b9b7c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49037",
+					"10.65.0.27:49037",
+					"172.17.0.1:49037",
+					"172.18.0.1:49037",
+					"172.19.0.1:49037",
+					"172.20.0.1:49037",
+					"172.21.0.1:49037",
+					"172.22.0.1:49037",
+					"172.23.0.1:49037",
+					"172.24.0.1:49037",
+					"172.25.0.1:49037",
+					"172.26.0.1:49037",
+					"172.27.0.1:49037",
+					"172.28.0.1:49037"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:22:23.062857052Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "185841476911834": {
+				"ID":          185841476911834,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5578350789120784,
+				"StableID":   "nqd35LpSZk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1f50fdcd08b5a717d0aec4e3b425a7e9a16c73233d894e71323c69ea2a7e2e1b",
+				"KeyExpiry":  "2026-11-09T09:22:23Z",
+				"DiscoKey":   "discokey:a6853978df9b5a349793b1a03dbdf09ba43ae156e43dd71f0042377af70b9b7c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49037",
+					"10.65.0.27:49037",
+					"172.17.0.1:49037",
+					"172.18.0.1:49037",
+					"172.19.0.1:49037",
+					"172.20.0.1:49037",
+					"172.21.0.1:49037",
+					"172.22.0.1:49037",
+					"172.23.0.1:49037",
+					"172.24.0.1:49037",
+					"172.25.0.1:49037",
+					"172.26.0.1:49037",
+					"172.27.0.1:49037",
+					"172.28.0.1:49037"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:22:23.062857052Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1f50fdcd08b5a717d0aec4e3b425a7e9a16c73233d894e71323c69ea2a7e2e1b",
+			"MachineKey": "mkey:ba28786048eb4f409d9decff8cf2e8fc51f5551d6e5135196f7437c3e1591078",
+			"Peers": [{
+				"ID":         8143243316789368,
+				"StableID":   "n1mKgDC6b621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39f74a3cfcbcd2d85a0505acd7608c438d8b75f75bc73d973c69ffefca1d7b35",
+				"DiscoKey":   "discokey:b286192a70d77992ae5e2c3e46bf90bdcf13cbec61579caf2e3806f562ae5c30",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52300",
+					"10.65.0.27:52300",
+					"172.17.0.1:52300",
+					"172.18.0.1:52300",
+					"172.19.0.1:52300",
+					"172.20.0.1:52300",
+					"172.21.0.1:52300",
+					"172.22.0.1:52300",
+					"172.23.0.1:52300",
+					"172.24.0.1:52300",
+					"172.25.0.1:52300",
+					"172.26.0.1:52300",
+					"172.27.0.1:52300",
+					"172.28.0.1:52300"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:22:15.112140752Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         113860257757471,
+				"StableID":   "nCVk58vZt111CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2842a72c6a80f763919802b778551075f77872ad7370c9a2de933018cdf143a",
+				"DiscoKey":   "discokey:484ac995502db71932de00d90d5d0d156a7f026ca5364ef3dbe3ae81bafc1476",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33365",
+					"10.65.0.27:33365",
+					"172.17.0.1:33365",
+					"172.18.0.1:33365",
+					"172.19.0.1:33365",
+					"172.20.0.1:33365",
+					"172.21.0.1:33365",
+					"172.22.0.1:33365",
+					"172.23.0.1:33365",
+					"172.24.0.1:33365",
+					"172.25.0.1:33365",
+					"172.26.0.1:33365",
+					"172.27.0.1:33365",
+					"172.28.0.1:33365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:22:15.844852796Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8677184893301866,
+				"StableID":   "nVk3Q8wukA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0d962c6fb4822dd3f7d040f87a7cf03159c7e110abed635b06e5be1ea044a4b",
+				"DiscoKey":   "discokey:99083f7b395bb3d58c747b2924bf09cd845be26dd013e76cb8897949bded4378",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34443",
+					"10.65.0.27:34443",
+					"172.17.0.1:34443",
+					"172.18.0.1:34443",
+					"172.19.0.1:34443",
+					"172.20.0.1:34443",
+					"172.21.0.1:34443",
+					"172.22.0.1:34443",
+					"172.23.0.1:34443",
+					"172.24.0.1:34443",
+					"172.25.0.1:34443",
+					"172.26.0.1:34443",
+					"172.27.0.1:34443",
+					"172.28.0.1:34443"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:22:16.376358719Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5650061022717349,
+				"StableID":   "nesSrHXv7m11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7e2046717ee3fa271fb28b7c09fa35fcb67bbebf2c25495eff616e3ef30c079",
+				"DiscoKey":   "discokey:1ec584995763f070c9b9b759453ff4e2c4fedd6e5dcc2736bb30a081dafda228",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:54222",
+					"10.65.0.27:54222",
+					"172.17.0.1:54222",
+					"172.18.0.1:54222",
+					"172.19.0.1:54222",
+					"172.20.0.1:54222",
+					"172.21.0.1:54222",
+					"172.22.0.1:54222",
+					"172.23.0.1:54222",
+					"172.24.0.1:54222",
+					"172.25.0.1:54222",
+					"172.26.0.1:54222",
+					"172.27.0.1:54222",
+					"172.28.0.1:54222"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:22:16.91735265Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5333300322750175,
+				"StableID":   "nGhZVqkTei11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:04046ddc32a46ab98f6736d52022153d1f7925d49a894c69149f193f03fb8f4e",
+				"DiscoKey":   "discokey:04a4340cf2ab637b906d2ca8d7211a892219b154aced487018f475b0a673ca3b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42920",
+					"10.65.0.27:42920",
+					"172.17.0.1:42920",
+					"172.18.0.1:42920",
+					"172.19.0.1:42920",
+					"172.20.0.1:42920",
+					"172.21.0.1:42920",
+					"172.22.0.1:42920",
+					"172.23.0.1:42920",
+					"172.24.0.1:42920",
+					"172.25.0.1:42920",
+					"172.26.0.1:42920",
+					"172.27.0.1:42920",
+					"172.28.0.1:42920"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:22:17.457951971Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         185841476911834,
+				"StableID":   "nd4yvwjAT211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4238e5a1a2f60912dd33750eaba2e9ade234e967f531034c8a2815df697adb14",
+				"DiscoKey":   "discokey:54f707cb1a422b733807276e804ce659bada6eb39062823fe48a5d80b6df1b47",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58427",
+					"10.65.0.27:58427",
+					"172.17.0.1:58427",
+					"172.18.0.1:58427",
+					"172.19.0.1:58427",
+					"172.20.0.1:58427",
+					"172.21.0.1:58427",
+					"172.22.0.1:58427",
+					"172.23.0.1:58427",
+					"172.24.0.1:58427",
+					"172.25.0.1:58427",
+					"172.26.0.1:58427",
+					"172.27.0.1:58427",
+					"172.28.0.1:58427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:22:17.99921398Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7323377596879331,
+				"StableID":   "n8FTWFimBz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0909da237b2e808c61e8de74434b2b9d9aecb4ee43065089ece5204b6b9b5629",
+				"DiscoKey":   "discokey:a32b59e0d33e2ded107b39b22960633cdd1f0abc18f36f57d5e21c7640a93149",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38227",
+					"10.65.0.27:38227",
+					"172.17.0.1:38227",
+					"172.18.0.1:38227",
+					"172.19.0.1:38227",
+					"172.20.0.1:38227",
+					"172.21.0.1:38227",
+					"172.22.0.1:38227",
+					"172.23.0.1:38227",
+					"172.24.0.1:38227",
+					"172.25.0.1:38227",
+					"172.26.0.1:38227",
+					"172.27.0.1:38227",
+					"172.28.0.1:38227"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:22:18.625515705Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6552951513903457,
+				"StableID":   "ntApkcvqAt11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:931685473e4f205d62413ac4d2c3ebcf8458908f94f8eb83c4775c87a115ad17",
+				"DiscoKey":   "discokey:bc9c50ba82975f34422b2beb098bf1de48b763f778361a0252ffd5220a0f7403",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55202",
+					"10.65.0.27:55202",
+					"172.17.0.1:55202",
+					"172.18.0.1:55202",
+					"172.19.0.1:55202",
+					"172.20.0.1:55202",
+					"172.21.0.1:55202",
+					"172.22.0.1:55202",
+					"172.23.0.1:55202",
+					"172.24.0.1:55202",
+					"172.25.0.1:55202",
+					"172.26.0.1:55202",
+					"172.27.0.1:55202",
+					"172.28.0.1:55202"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:22:19.337487583Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         270807153993723,
+				"StableID":   "nkm3sPee7311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87c7f40fb532366935ad5214207388a29031d359001b49634cc910f135465f6d",
+				"DiscoKey":   "discokey:501b1dad6def0edb6ba5a26e86ca442aa8a2151e84fceea8132f51fb2d1e956e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44002",
+					"10.65.0.27:44002",
+					"172.17.0.1:44002",
+					"172.18.0.1:44002",
+					"172.19.0.1:44002",
+					"172.20.0.1:44002",
+					"172.21.0.1:44002",
+					"172.22.0.1:44002",
+					"172.23.0.1:44002",
+					"172.24.0.1:44002",
+					"172.25.0.1:44002",
+					"172.26.0.1:44002",
+					"172.27.0.1:44002",
+					"172.28.0.1:44002"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:22:19.865837519Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6705106736621230,
+				"StableID":   "n1pqkUnkMu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6a64002270eca2ff6d91bc9adda789c18c32581d805ba41c1d548b4675348229",
+				"DiscoKey":   "discokey:35cf0dffa25ba0e1150a8ef1336210509b79e4a6618b4dc5c12f327147d8d55a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53680",
+					"10.65.0.27:53680",
+					"172.17.0.1:53680",
+					"172.18.0.1:53680",
+					"172.19.0.1:53680",
+					"172.20.0.1:53680",
+					"172.21.0.1:53680",
+					"172.22.0.1:53680",
+					"172.23.0.1:53680",
+					"172.24.0.1:53680",
+					"172.25.0.1:53680",
+					"172.26.0.1:53680",
+					"172.27.0.1:53680",
+					"172.28.0.1:53680"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:22:20.398552469Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7667948310719536,
+				"StableID":   "nPYeZyzps221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0ce1ba6d4cbbcf9decf7a9f01ad378411022ffd5e9eef94809593172fa1af69",
+				"DiscoKey":   "discokey:995e138a0bc7c2d6a53c165e23b474940593333d62d90528cee068a4e18a2b0e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56289",
+					"10.65.0.27:56289",
+					"172.17.0.1:56289",
+					"172.18.0.1:56289",
+					"172.19.0.1:56289",
+					"172.20.0.1:56289",
+					"172.21.0.1:56289",
+					"172.22.0.1:56289",
+					"172.23.0.1:56289",
+					"172.24.0.1:56289",
+					"172.25.0.1:56289",
+					"172.26.0.1:56289",
+					"172.27.0.1:56289",
+					"172.28.0.1:56289"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:22:20.937449274Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7000699690251896,
+				"StableID":   "nVMkrZWdfw11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1af67b633fce2aa5dd3d1c22557a42939a55de468eee10b89c0e3f3d8a7f1f08",
+				"DiscoKey":   "discokey:ca263f641228d82e7ba561ce1fdc498a4ac6b7a9d1bf1ab6e3b56f0b22abb818",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35249",
+					"10.65.0.27:35249",
+					"172.17.0.1:35249",
+					"172.18.0.1:35249",
+					"172.19.0.1:35249",
+					"172.20.0.1:35249",
+					"172.21.0.1:35249",
+					"172.22.0.1:35249",
+					"172.23.0.1:35249",
+					"172.24.0.1:35249",
+					"172.25.0.1:35249",
+					"172.26.0.1:35249",
+					"172.27.0.1:35249",
+					"172.28.0.1:35249"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:22:21.464954476Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4284797806903681,
+				"StableID":   "n2dXbcNbTa11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a7a8458270cc82b0625a3ebd79c3e5af5e040c4219deba360979d91f965a6476",
+				"KeyExpiry":  "2026-11-09T09:22:21Z",
+				"DiscoKey":   "discokey:9616211d17ab9697e7fa55165294efc168d482ee06724751e93efbeed324fd76",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50158",
+					"10.65.0.27:50158",
+					"172.17.0.1:50158",
+					"172.18.0.1:50158",
+					"172.19.0.1:50158",
+					"172.20.0.1:50158",
+					"172.21.0.1:50158",
+					"172.22.0.1:50158",
+					"172.23.0.1:50158",
+					"172.24.0.1:50158",
+					"172.25.0.1:50158",
+					"172.26.0.1:50158",
+					"172.27.0.1:50158",
+					"172.28.0.1:50158"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:22:21.988373309Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6444602222931293,
+				"StableID":   "ntkLwnmmKs11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b654ef19ce6bebdfc6c755e04f8696d3bed3d99477bd5f05716627c739453476",
+				"KeyExpiry":  "2026-11-09T09:22:22Z",
+				"DiscoKey":   "discokey:afb4f3c13a03175eb745bc3dc0ee942c876b1e75571d99756f7af5701a4dc06b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50042",
+					"10.65.0.27:50042",
+					"172.17.0.1:50042",
+					"172.18.0.1:50042",
+					"172.19.0.1:50042",
+					"172.20.0.1:50042",
+					"172.21.0.1:50042",
+					"172.22.0.1:50042",
+					"172.23.0.1:50042",
+					"172.24.0.1:50042",
+					"172.25.0.1:50042",
+					"172.26.0.1:50042",
+					"172.27.0.1:50042",
+					"172.28.0.1:50042"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:22:22.530433778Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8677184893301866,
+				"StableID":   "nVk3Q8wukA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       8677184893301866,
+				"Key":        "nodekey:e0d962c6fb4822dd3f7d040f87a7cf03159c7e110abed635b06e5be1ea044a4b",
+				"DiscoKey":   "discokey:99083f7b395bb3d58c747b2924bf09cd845be26dd013e76cb8897949bded4378",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34443",
+					"10.65.0.27:34443",
+					"172.17.0.1:34443",
+					"172.18.0.1:34443",
+					"172.19.0.1:34443",
+					"172.20.0.1:34443",
+					"172.21.0.1:34443",
+					"172.22.0.1:34443",
+					"172.23.0.1:34443",
+					"172.24.0.1:34443",
+					"172.25.0.1:34443",
+					"172.26.0.1:34443",
+					"172.27.0.1:34443",
+					"172.28.0.1:34443"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:22:16.376358719Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e0d962c6fb4822dd3f7d040f87a7cf03159c7e110abed635b06e5be1ea044a4b",
+			"MachineKey": "mkey:005ecdcb9ca03cf3afc7e3379654780e98f47741e82dc98e031084ec89b2bc50",
+			"Peers": [{
+				"ID":         8143243316789368,
+				"StableID":   "n1mKgDC6b621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39f74a3cfcbcd2d85a0505acd7608c438d8b75f75bc73d973c69ffefca1d7b35",
+				"DiscoKey":   "discokey:b286192a70d77992ae5e2c3e46bf90bdcf13cbec61579caf2e3806f562ae5c30",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52300",
+					"10.65.0.27:52300",
+					"172.17.0.1:52300",
+					"172.18.0.1:52300",
+					"172.19.0.1:52300",
+					"172.20.0.1:52300",
+					"172.21.0.1:52300",
+					"172.22.0.1:52300",
+					"172.23.0.1:52300",
+					"172.24.0.1:52300",
+					"172.25.0.1:52300",
+					"172.26.0.1:52300",
+					"172.27.0.1:52300",
+					"172.28.0.1:52300"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:22:15.112140752Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         113860257757471,
+				"StableID":   "nCVk58vZt111CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2842a72c6a80f763919802b778551075f77872ad7370c9a2de933018cdf143a",
+				"DiscoKey":   "discokey:484ac995502db71932de00d90d5d0d156a7f026ca5364ef3dbe3ae81bafc1476",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33365",
+					"10.65.0.27:33365",
+					"172.17.0.1:33365",
+					"172.18.0.1:33365",
+					"172.19.0.1:33365",
+					"172.20.0.1:33365",
+					"172.21.0.1:33365",
+					"172.22.0.1:33365",
+					"172.23.0.1:33365",
+					"172.24.0.1:33365",
+					"172.25.0.1:33365",
+					"172.26.0.1:33365",
+					"172.27.0.1:33365",
+					"172.28.0.1:33365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:22:15.844852796Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5650061022717349,
+				"StableID":   "nesSrHXv7m11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7e2046717ee3fa271fb28b7c09fa35fcb67bbebf2c25495eff616e3ef30c079",
+				"DiscoKey":   "discokey:1ec584995763f070c9b9b759453ff4e2c4fedd6e5dcc2736bb30a081dafda228",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:54222",
+					"10.65.0.27:54222",
+					"172.17.0.1:54222",
+					"172.18.0.1:54222",
+					"172.19.0.1:54222",
+					"172.20.0.1:54222",
+					"172.21.0.1:54222",
+					"172.22.0.1:54222",
+					"172.23.0.1:54222",
+					"172.24.0.1:54222",
+					"172.25.0.1:54222",
+					"172.26.0.1:54222",
+					"172.27.0.1:54222",
+					"172.28.0.1:54222"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:22:16.91735265Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5333300322750175,
+				"StableID":   "nGhZVqkTei11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:04046ddc32a46ab98f6736d52022153d1f7925d49a894c69149f193f03fb8f4e",
+				"DiscoKey":   "discokey:04a4340cf2ab637b906d2ca8d7211a892219b154aced487018f475b0a673ca3b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42920",
+					"10.65.0.27:42920",
+					"172.17.0.1:42920",
+					"172.18.0.1:42920",
+					"172.19.0.1:42920",
+					"172.20.0.1:42920",
+					"172.21.0.1:42920",
+					"172.22.0.1:42920",
+					"172.23.0.1:42920",
+					"172.24.0.1:42920",
+					"172.25.0.1:42920",
+					"172.26.0.1:42920",
+					"172.27.0.1:42920",
+					"172.28.0.1:42920"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:22:17.457951971Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         185841476911834,
+				"StableID":   "nd4yvwjAT211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4238e5a1a2f60912dd33750eaba2e9ade234e967f531034c8a2815df697adb14",
+				"DiscoKey":   "discokey:54f707cb1a422b733807276e804ce659bada6eb39062823fe48a5d80b6df1b47",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58427",
+					"10.65.0.27:58427",
+					"172.17.0.1:58427",
+					"172.18.0.1:58427",
+					"172.19.0.1:58427",
+					"172.20.0.1:58427",
+					"172.21.0.1:58427",
+					"172.22.0.1:58427",
+					"172.23.0.1:58427",
+					"172.24.0.1:58427",
+					"172.25.0.1:58427",
+					"172.26.0.1:58427",
+					"172.27.0.1:58427",
+					"172.28.0.1:58427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:22:17.99921398Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7323377596879331,
+				"StableID":   "n8FTWFimBz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0909da237b2e808c61e8de74434b2b9d9aecb4ee43065089ece5204b6b9b5629",
+				"DiscoKey":   "discokey:a32b59e0d33e2ded107b39b22960633cdd1f0abc18f36f57d5e21c7640a93149",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38227",
+					"10.65.0.27:38227",
+					"172.17.0.1:38227",
+					"172.18.0.1:38227",
+					"172.19.0.1:38227",
+					"172.20.0.1:38227",
+					"172.21.0.1:38227",
+					"172.22.0.1:38227",
+					"172.23.0.1:38227",
+					"172.24.0.1:38227",
+					"172.25.0.1:38227",
+					"172.26.0.1:38227",
+					"172.27.0.1:38227",
+					"172.28.0.1:38227"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:22:18.625515705Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6552951513903457,
+				"StableID":   "ntApkcvqAt11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:931685473e4f205d62413ac4d2c3ebcf8458908f94f8eb83c4775c87a115ad17",
+				"DiscoKey":   "discokey:bc9c50ba82975f34422b2beb098bf1de48b763f778361a0252ffd5220a0f7403",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55202",
+					"10.65.0.27:55202",
+					"172.17.0.1:55202",
+					"172.18.0.1:55202",
+					"172.19.0.1:55202",
+					"172.20.0.1:55202",
+					"172.21.0.1:55202",
+					"172.22.0.1:55202",
+					"172.23.0.1:55202",
+					"172.24.0.1:55202",
+					"172.25.0.1:55202",
+					"172.26.0.1:55202",
+					"172.27.0.1:55202",
+					"172.28.0.1:55202"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:22:19.337487583Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         270807153993723,
+				"StableID":   "nkm3sPee7311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87c7f40fb532366935ad5214207388a29031d359001b49634cc910f135465f6d",
+				"DiscoKey":   "discokey:501b1dad6def0edb6ba5a26e86ca442aa8a2151e84fceea8132f51fb2d1e956e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44002",
+					"10.65.0.27:44002",
+					"172.17.0.1:44002",
+					"172.18.0.1:44002",
+					"172.19.0.1:44002",
+					"172.20.0.1:44002",
+					"172.21.0.1:44002",
+					"172.22.0.1:44002",
+					"172.23.0.1:44002",
+					"172.24.0.1:44002",
+					"172.25.0.1:44002",
+					"172.26.0.1:44002",
+					"172.27.0.1:44002",
+					"172.28.0.1:44002"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:22:19.865837519Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6705106736621230,
+				"StableID":   "n1pqkUnkMu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6a64002270eca2ff6d91bc9adda789c18c32581d805ba41c1d548b4675348229",
+				"DiscoKey":   "discokey:35cf0dffa25ba0e1150a8ef1336210509b79e4a6618b4dc5c12f327147d8d55a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53680",
+					"10.65.0.27:53680",
+					"172.17.0.1:53680",
+					"172.18.0.1:53680",
+					"172.19.0.1:53680",
+					"172.20.0.1:53680",
+					"172.21.0.1:53680",
+					"172.22.0.1:53680",
+					"172.23.0.1:53680",
+					"172.24.0.1:53680",
+					"172.25.0.1:53680",
+					"172.26.0.1:53680",
+					"172.27.0.1:53680",
+					"172.28.0.1:53680"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:22:20.398552469Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7667948310719536,
+				"StableID":   "nPYeZyzps221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0ce1ba6d4cbbcf9decf7a9f01ad378411022ffd5e9eef94809593172fa1af69",
+				"DiscoKey":   "discokey:995e138a0bc7c2d6a53c165e23b474940593333d62d90528cee068a4e18a2b0e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56289",
+					"10.65.0.27:56289",
+					"172.17.0.1:56289",
+					"172.18.0.1:56289",
+					"172.19.0.1:56289",
+					"172.20.0.1:56289",
+					"172.21.0.1:56289",
+					"172.22.0.1:56289",
+					"172.23.0.1:56289",
+					"172.24.0.1:56289",
+					"172.25.0.1:56289",
+					"172.26.0.1:56289",
+					"172.27.0.1:56289",
+					"172.28.0.1:56289"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:22:20.937449274Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7000699690251896,
+				"StableID":   "nVMkrZWdfw11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1af67b633fce2aa5dd3d1c22557a42939a55de468eee10b89c0e3f3d8a7f1f08",
+				"DiscoKey":   "discokey:ca263f641228d82e7ba561ce1fdc498a4ac6b7a9d1bf1ab6e3b56f0b22abb818",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35249",
+					"10.65.0.27:35249",
+					"172.17.0.1:35249",
+					"172.18.0.1:35249",
+					"172.19.0.1:35249",
+					"172.20.0.1:35249",
+					"172.21.0.1:35249",
+					"172.22.0.1:35249",
+					"172.23.0.1:35249",
+					"172.24.0.1:35249",
+					"172.25.0.1:35249",
+					"172.26.0.1:35249",
+					"172.27.0.1:35249",
+					"172.28.0.1:35249"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:22:21.464954476Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4284797806903681,
+				"StableID":   "n2dXbcNbTa11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a7a8458270cc82b0625a3ebd79c3e5af5e040c4219deba360979d91f965a6476",
+				"KeyExpiry":  "2026-11-09T09:22:21Z",
+				"DiscoKey":   "discokey:9616211d17ab9697e7fa55165294efc168d482ee06724751e93efbeed324fd76",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50158",
+					"10.65.0.27:50158",
+					"172.17.0.1:50158",
+					"172.18.0.1:50158",
+					"172.19.0.1:50158",
+					"172.20.0.1:50158",
+					"172.21.0.1:50158",
+					"172.22.0.1:50158",
+					"172.23.0.1:50158",
+					"172.24.0.1:50158",
+					"172.25.0.1:50158",
+					"172.26.0.1:50158",
+					"172.27.0.1:50158",
+					"172.28.0.1:50158"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:22:21.988373309Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6444602222931293,
+				"StableID":   "ntkLwnmmKs11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b654ef19ce6bebdfc6c755e04f8696d3bed3d99477bd5f05716627c739453476",
+				"KeyExpiry":  "2026-11-09T09:22:22Z",
+				"DiscoKey":   "discokey:afb4f3c13a03175eb745bc3dc0ee942c876b1e75571d99756f7af5701a4dc06b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50042",
+					"10.65.0.27:50042",
+					"172.17.0.1:50042",
+					"172.18.0.1:50042",
+					"172.19.0.1:50042",
+					"172.20.0.1:50042",
+					"172.21.0.1:50042",
+					"172.22.0.1:50042",
+					"172.23.0.1:50042",
+					"172.24.0.1:50042",
+					"172.25.0.1:50042",
+					"172.26.0.1:50042",
+					"172.27.0.1:50042",
+					"172.28.0.1:50042"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:22:22.530433778Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5578350789120784,
+				"StableID":   "nqd35LpSZk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1f50fdcd08b5a717d0aec4e3b425a7e9a16c73233d894e71323c69ea2a7e2e1b",
+				"KeyExpiry":  "2026-11-09T09:22:23Z",
+				"DiscoKey":   "discokey:a6853978df9b5a349793b1a03dbdf09ba43ae156e43dd71f0042377af70b9b7c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49037",
+					"10.65.0.27:49037",
+					"172.17.0.1:49037",
+					"172.18.0.1:49037",
+					"172.19.0.1:49037",
+					"172.20.0.1:49037",
+					"172.21.0.1:49037",
+					"172.22.0.1:49037",
+					"172.23.0.1:49037",
+					"172.24.0.1:49037",
+					"172.25.0.1:49037",
+					"172.26.0.1:49037",
+					"172.27.0.1:49037",
+					"172.28.0.1:49037"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:22:23.062857052Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8677184893301866": {
+				"ID":          8677184893301866,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6552951513903457,
+				"StableID":   "ntApkcvqAt11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       6552951513903457,
+				"Key":        "nodekey:931685473e4f205d62413ac4d2c3ebcf8458908f94f8eb83c4775c87a115ad17",
+				"DiscoKey":   "discokey:bc9c50ba82975f34422b2beb098bf1de48b763f778361a0252ffd5220a0f7403",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55202",
+					"10.65.0.27:55202",
+					"172.17.0.1:55202",
+					"172.18.0.1:55202",
+					"172.19.0.1:55202",
+					"172.20.0.1:55202",
+					"172.21.0.1:55202",
+					"172.22.0.1:55202",
+					"172.23.0.1:55202",
+					"172.24.0.1:55202",
+					"172.25.0.1:55202",
+					"172.26.0.1:55202",
+					"172.27.0.1:55202",
+					"172.28.0.1:55202"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:22:19.337487583Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:931685473e4f205d62413ac4d2c3ebcf8458908f94f8eb83c4775c87a115ad17",
+			"MachineKey": "mkey:162194bb6d6fad856d0acb209e827a3d13e0dab9c24eb42581d18274814d8949",
+			"Peers": [{
+				"ID":         8143243316789368,
+				"StableID":   "n1mKgDC6b621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39f74a3cfcbcd2d85a0505acd7608c438d8b75f75bc73d973c69ffefca1d7b35",
+				"DiscoKey":   "discokey:b286192a70d77992ae5e2c3e46bf90bdcf13cbec61579caf2e3806f562ae5c30",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52300",
+					"10.65.0.27:52300",
+					"172.17.0.1:52300",
+					"172.18.0.1:52300",
+					"172.19.0.1:52300",
+					"172.20.0.1:52300",
+					"172.21.0.1:52300",
+					"172.22.0.1:52300",
+					"172.23.0.1:52300",
+					"172.24.0.1:52300",
+					"172.25.0.1:52300",
+					"172.26.0.1:52300",
+					"172.27.0.1:52300",
+					"172.28.0.1:52300"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:22:15.112140752Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         113860257757471,
+				"StableID":   "nCVk58vZt111CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2842a72c6a80f763919802b778551075f77872ad7370c9a2de933018cdf143a",
+				"DiscoKey":   "discokey:484ac995502db71932de00d90d5d0d156a7f026ca5364ef3dbe3ae81bafc1476",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33365",
+					"10.65.0.27:33365",
+					"172.17.0.1:33365",
+					"172.18.0.1:33365",
+					"172.19.0.1:33365",
+					"172.20.0.1:33365",
+					"172.21.0.1:33365",
+					"172.22.0.1:33365",
+					"172.23.0.1:33365",
+					"172.24.0.1:33365",
+					"172.25.0.1:33365",
+					"172.26.0.1:33365",
+					"172.27.0.1:33365",
+					"172.28.0.1:33365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:22:15.844852796Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8677184893301866,
+				"StableID":   "nVk3Q8wukA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0d962c6fb4822dd3f7d040f87a7cf03159c7e110abed635b06e5be1ea044a4b",
+				"DiscoKey":   "discokey:99083f7b395bb3d58c747b2924bf09cd845be26dd013e76cb8897949bded4378",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34443",
+					"10.65.0.27:34443",
+					"172.17.0.1:34443",
+					"172.18.0.1:34443",
+					"172.19.0.1:34443",
+					"172.20.0.1:34443",
+					"172.21.0.1:34443",
+					"172.22.0.1:34443",
+					"172.23.0.1:34443",
+					"172.24.0.1:34443",
+					"172.25.0.1:34443",
+					"172.26.0.1:34443",
+					"172.27.0.1:34443",
+					"172.28.0.1:34443"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:22:16.376358719Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5650061022717349,
+				"StableID":   "nesSrHXv7m11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7e2046717ee3fa271fb28b7c09fa35fcb67bbebf2c25495eff616e3ef30c079",
+				"DiscoKey":   "discokey:1ec584995763f070c9b9b759453ff4e2c4fedd6e5dcc2736bb30a081dafda228",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:54222",
+					"10.65.0.27:54222",
+					"172.17.0.1:54222",
+					"172.18.0.1:54222",
+					"172.19.0.1:54222",
+					"172.20.0.1:54222",
+					"172.21.0.1:54222",
+					"172.22.0.1:54222",
+					"172.23.0.1:54222",
+					"172.24.0.1:54222",
+					"172.25.0.1:54222",
+					"172.26.0.1:54222",
+					"172.27.0.1:54222",
+					"172.28.0.1:54222"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:22:16.91735265Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5333300322750175,
+				"StableID":   "nGhZVqkTei11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:04046ddc32a46ab98f6736d52022153d1f7925d49a894c69149f193f03fb8f4e",
+				"DiscoKey":   "discokey:04a4340cf2ab637b906d2ca8d7211a892219b154aced487018f475b0a673ca3b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42920",
+					"10.65.0.27:42920",
+					"172.17.0.1:42920",
+					"172.18.0.1:42920",
+					"172.19.0.1:42920",
+					"172.20.0.1:42920",
+					"172.21.0.1:42920",
+					"172.22.0.1:42920",
+					"172.23.0.1:42920",
+					"172.24.0.1:42920",
+					"172.25.0.1:42920",
+					"172.26.0.1:42920",
+					"172.27.0.1:42920",
+					"172.28.0.1:42920"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:22:17.457951971Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         185841476911834,
+				"StableID":   "nd4yvwjAT211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4238e5a1a2f60912dd33750eaba2e9ade234e967f531034c8a2815df697adb14",
+				"DiscoKey":   "discokey:54f707cb1a422b733807276e804ce659bada6eb39062823fe48a5d80b6df1b47",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58427",
+					"10.65.0.27:58427",
+					"172.17.0.1:58427",
+					"172.18.0.1:58427",
+					"172.19.0.1:58427",
+					"172.20.0.1:58427",
+					"172.21.0.1:58427",
+					"172.22.0.1:58427",
+					"172.23.0.1:58427",
+					"172.24.0.1:58427",
+					"172.25.0.1:58427",
+					"172.26.0.1:58427",
+					"172.27.0.1:58427",
+					"172.28.0.1:58427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:22:17.99921398Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7323377596879331,
+				"StableID":   "n8FTWFimBz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0909da237b2e808c61e8de74434b2b9d9aecb4ee43065089ece5204b6b9b5629",
+				"DiscoKey":   "discokey:a32b59e0d33e2ded107b39b22960633cdd1f0abc18f36f57d5e21c7640a93149",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38227",
+					"10.65.0.27:38227",
+					"172.17.0.1:38227",
+					"172.18.0.1:38227",
+					"172.19.0.1:38227",
+					"172.20.0.1:38227",
+					"172.21.0.1:38227",
+					"172.22.0.1:38227",
+					"172.23.0.1:38227",
+					"172.24.0.1:38227",
+					"172.25.0.1:38227",
+					"172.26.0.1:38227",
+					"172.27.0.1:38227",
+					"172.28.0.1:38227"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:22:18.625515705Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         270807153993723,
+				"StableID":   "nkm3sPee7311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87c7f40fb532366935ad5214207388a29031d359001b49634cc910f135465f6d",
+				"DiscoKey":   "discokey:501b1dad6def0edb6ba5a26e86ca442aa8a2151e84fceea8132f51fb2d1e956e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44002",
+					"10.65.0.27:44002",
+					"172.17.0.1:44002",
+					"172.18.0.1:44002",
+					"172.19.0.1:44002",
+					"172.20.0.1:44002",
+					"172.21.0.1:44002",
+					"172.22.0.1:44002",
+					"172.23.0.1:44002",
+					"172.24.0.1:44002",
+					"172.25.0.1:44002",
+					"172.26.0.1:44002",
+					"172.27.0.1:44002",
+					"172.28.0.1:44002"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:22:19.865837519Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6705106736621230,
+				"StableID":   "n1pqkUnkMu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6a64002270eca2ff6d91bc9adda789c18c32581d805ba41c1d548b4675348229",
+				"DiscoKey":   "discokey:35cf0dffa25ba0e1150a8ef1336210509b79e4a6618b4dc5c12f327147d8d55a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53680",
+					"10.65.0.27:53680",
+					"172.17.0.1:53680",
+					"172.18.0.1:53680",
+					"172.19.0.1:53680",
+					"172.20.0.1:53680",
+					"172.21.0.1:53680",
+					"172.22.0.1:53680",
+					"172.23.0.1:53680",
+					"172.24.0.1:53680",
+					"172.25.0.1:53680",
+					"172.26.0.1:53680",
+					"172.27.0.1:53680",
+					"172.28.0.1:53680"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:22:20.398552469Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7667948310719536,
+				"StableID":   "nPYeZyzps221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0ce1ba6d4cbbcf9decf7a9f01ad378411022ffd5e9eef94809593172fa1af69",
+				"DiscoKey":   "discokey:995e138a0bc7c2d6a53c165e23b474940593333d62d90528cee068a4e18a2b0e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56289",
+					"10.65.0.27:56289",
+					"172.17.0.1:56289",
+					"172.18.0.1:56289",
+					"172.19.0.1:56289",
+					"172.20.0.1:56289",
+					"172.21.0.1:56289",
+					"172.22.0.1:56289",
+					"172.23.0.1:56289",
+					"172.24.0.1:56289",
+					"172.25.0.1:56289",
+					"172.26.0.1:56289",
+					"172.27.0.1:56289",
+					"172.28.0.1:56289"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:22:20.937449274Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7000699690251896,
+				"StableID":   "nVMkrZWdfw11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1af67b633fce2aa5dd3d1c22557a42939a55de468eee10b89c0e3f3d8a7f1f08",
+				"DiscoKey":   "discokey:ca263f641228d82e7ba561ce1fdc498a4ac6b7a9d1bf1ab6e3b56f0b22abb818",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35249",
+					"10.65.0.27:35249",
+					"172.17.0.1:35249",
+					"172.18.0.1:35249",
+					"172.19.0.1:35249",
+					"172.20.0.1:35249",
+					"172.21.0.1:35249",
+					"172.22.0.1:35249",
+					"172.23.0.1:35249",
+					"172.24.0.1:35249",
+					"172.25.0.1:35249",
+					"172.26.0.1:35249",
+					"172.27.0.1:35249",
+					"172.28.0.1:35249"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:22:21.464954476Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4284797806903681,
+				"StableID":   "n2dXbcNbTa11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a7a8458270cc82b0625a3ebd79c3e5af5e040c4219deba360979d91f965a6476",
+				"KeyExpiry":  "2026-11-09T09:22:21Z",
+				"DiscoKey":   "discokey:9616211d17ab9697e7fa55165294efc168d482ee06724751e93efbeed324fd76",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50158",
+					"10.65.0.27:50158",
+					"172.17.0.1:50158",
+					"172.18.0.1:50158",
+					"172.19.0.1:50158",
+					"172.20.0.1:50158",
+					"172.21.0.1:50158",
+					"172.22.0.1:50158",
+					"172.23.0.1:50158",
+					"172.24.0.1:50158",
+					"172.25.0.1:50158",
+					"172.26.0.1:50158",
+					"172.27.0.1:50158",
+					"172.28.0.1:50158"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:22:21.988373309Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6444602222931293,
+				"StableID":   "ntkLwnmmKs11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b654ef19ce6bebdfc6c755e04f8696d3bed3d99477bd5f05716627c739453476",
+				"KeyExpiry":  "2026-11-09T09:22:22Z",
+				"DiscoKey":   "discokey:afb4f3c13a03175eb745bc3dc0ee942c876b1e75571d99756f7af5701a4dc06b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50042",
+					"10.65.0.27:50042",
+					"172.17.0.1:50042",
+					"172.18.0.1:50042",
+					"172.19.0.1:50042",
+					"172.20.0.1:50042",
+					"172.21.0.1:50042",
+					"172.22.0.1:50042",
+					"172.23.0.1:50042",
+					"172.24.0.1:50042",
+					"172.25.0.1:50042",
+					"172.26.0.1:50042",
+					"172.27.0.1:50042",
+					"172.28.0.1:50042"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:22:22.530433778Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5578350789120784,
+				"StableID":   "nqd35LpSZk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1f50fdcd08b5a717d0aec4e3b425a7e9a16c73233d894e71323c69ea2a7e2e1b",
+				"KeyExpiry":  "2026-11-09T09:22:23Z",
+				"DiscoKey":   "discokey:a6853978df9b5a349793b1a03dbdf09ba43ae156e43dd71f0042377af70b9b7c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49037",
+					"10.65.0.27:49037",
+					"172.17.0.1:49037",
+					"172.18.0.1:49037",
+					"172.19.0.1:49037",
+					"172.20.0.1:49037",
+					"172.21.0.1:49037",
+					"172.22.0.1:49037",
+					"172.23.0.1:49037",
+					"172.24.0.1:49037",
+					"172.25.0.1:49037",
+					"172.26.0.1:49037",
+					"172.27.0.1:49037",
+					"172.28.0.1:49037"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:22:23.062857052Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6552951513903457": {
+				"ID":          6552951513903457,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4284797806903681,
+				"StableID":   "n2dXbcNbTa11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a7a8458270cc82b0625a3ebd79c3e5af5e040c4219deba360979d91f965a6476",
+				"KeyExpiry":  "2026-11-09T09:22:21Z",
+				"DiscoKey":   "discokey:9616211d17ab9697e7fa55165294efc168d482ee06724751e93efbeed324fd76",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50158",
+					"10.65.0.27:50158",
+					"172.17.0.1:50158",
+					"172.18.0.1:50158",
+					"172.19.0.1:50158",
+					"172.20.0.1:50158",
+					"172.21.0.1:50158",
+					"172.22.0.1:50158",
+					"172.23.0.1:50158",
+					"172.24.0.1:50158",
+					"172.25.0.1:50158",
+					"172.26.0.1:50158",
+					"172.27.0.1:50158",
+					"172.28.0.1:50158"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:22:21.988373309Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a7a8458270cc82b0625a3ebd79c3e5af5e040c4219deba360979d91f965a6476",
+			"MachineKey": "mkey:394365434dc2c4ba097c10f8db6de1bad9712e7254524c8d49d81231ec229f3f",
+			"Peers": [{
+				"ID":         8143243316789368,
+				"StableID":   "n1mKgDC6b621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39f74a3cfcbcd2d85a0505acd7608c438d8b75f75bc73d973c69ffefca1d7b35",
+				"DiscoKey":   "discokey:b286192a70d77992ae5e2c3e46bf90bdcf13cbec61579caf2e3806f562ae5c30",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52300",
+					"10.65.0.27:52300",
+					"172.17.0.1:52300",
+					"172.18.0.1:52300",
+					"172.19.0.1:52300",
+					"172.20.0.1:52300",
+					"172.21.0.1:52300",
+					"172.22.0.1:52300",
+					"172.23.0.1:52300",
+					"172.24.0.1:52300",
+					"172.25.0.1:52300",
+					"172.26.0.1:52300",
+					"172.27.0.1:52300",
+					"172.28.0.1:52300"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:22:15.112140752Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         113860257757471,
+				"StableID":   "nCVk58vZt111CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2842a72c6a80f763919802b778551075f77872ad7370c9a2de933018cdf143a",
+				"DiscoKey":   "discokey:484ac995502db71932de00d90d5d0d156a7f026ca5364ef3dbe3ae81bafc1476",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33365",
+					"10.65.0.27:33365",
+					"172.17.0.1:33365",
+					"172.18.0.1:33365",
+					"172.19.0.1:33365",
+					"172.20.0.1:33365",
+					"172.21.0.1:33365",
+					"172.22.0.1:33365",
+					"172.23.0.1:33365",
+					"172.24.0.1:33365",
+					"172.25.0.1:33365",
+					"172.26.0.1:33365",
+					"172.27.0.1:33365",
+					"172.28.0.1:33365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:22:15.844852796Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8677184893301866,
+				"StableID":   "nVk3Q8wukA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0d962c6fb4822dd3f7d040f87a7cf03159c7e110abed635b06e5be1ea044a4b",
+				"DiscoKey":   "discokey:99083f7b395bb3d58c747b2924bf09cd845be26dd013e76cb8897949bded4378",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34443",
+					"10.65.0.27:34443",
+					"172.17.0.1:34443",
+					"172.18.0.1:34443",
+					"172.19.0.1:34443",
+					"172.20.0.1:34443",
+					"172.21.0.1:34443",
+					"172.22.0.1:34443",
+					"172.23.0.1:34443",
+					"172.24.0.1:34443",
+					"172.25.0.1:34443",
+					"172.26.0.1:34443",
+					"172.27.0.1:34443",
+					"172.28.0.1:34443"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:22:16.376358719Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5650061022717349,
+				"StableID":   "nesSrHXv7m11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7e2046717ee3fa271fb28b7c09fa35fcb67bbebf2c25495eff616e3ef30c079",
+				"DiscoKey":   "discokey:1ec584995763f070c9b9b759453ff4e2c4fedd6e5dcc2736bb30a081dafda228",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:54222",
+					"10.65.0.27:54222",
+					"172.17.0.1:54222",
+					"172.18.0.1:54222",
+					"172.19.0.1:54222",
+					"172.20.0.1:54222",
+					"172.21.0.1:54222",
+					"172.22.0.1:54222",
+					"172.23.0.1:54222",
+					"172.24.0.1:54222",
+					"172.25.0.1:54222",
+					"172.26.0.1:54222",
+					"172.27.0.1:54222",
+					"172.28.0.1:54222"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:22:16.91735265Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5333300322750175,
+				"StableID":   "nGhZVqkTei11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:04046ddc32a46ab98f6736d52022153d1f7925d49a894c69149f193f03fb8f4e",
+				"DiscoKey":   "discokey:04a4340cf2ab637b906d2ca8d7211a892219b154aced487018f475b0a673ca3b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42920",
+					"10.65.0.27:42920",
+					"172.17.0.1:42920",
+					"172.18.0.1:42920",
+					"172.19.0.1:42920",
+					"172.20.0.1:42920",
+					"172.21.0.1:42920",
+					"172.22.0.1:42920",
+					"172.23.0.1:42920",
+					"172.24.0.1:42920",
+					"172.25.0.1:42920",
+					"172.26.0.1:42920",
+					"172.27.0.1:42920",
+					"172.28.0.1:42920"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:22:17.457951971Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         185841476911834,
+				"StableID":   "nd4yvwjAT211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4238e5a1a2f60912dd33750eaba2e9ade234e967f531034c8a2815df697adb14",
+				"DiscoKey":   "discokey:54f707cb1a422b733807276e804ce659bada6eb39062823fe48a5d80b6df1b47",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58427",
+					"10.65.0.27:58427",
+					"172.17.0.1:58427",
+					"172.18.0.1:58427",
+					"172.19.0.1:58427",
+					"172.20.0.1:58427",
+					"172.21.0.1:58427",
+					"172.22.0.1:58427",
+					"172.23.0.1:58427",
+					"172.24.0.1:58427",
+					"172.25.0.1:58427",
+					"172.26.0.1:58427",
+					"172.27.0.1:58427",
+					"172.28.0.1:58427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:22:17.99921398Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7323377596879331,
+				"StableID":   "n8FTWFimBz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0909da237b2e808c61e8de74434b2b9d9aecb4ee43065089ece5204b6b9b5629",
+				"DiscoKey":   "discokey:a32b59e0d33e2ded107b39b22960633cdd1f0abc18f36f57d5e21c7640a93149",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38227",
+					"10.65.0.27:38227",
+					"172.17.0.1:38227",
+					"172.18.0.1:38227",
+					"172.19.0.1:38227",
+					"172.20.0.1:38227",
+					"172.21.0.1:38227",
+					"172.22.0.1:38227",
+					"172.23.0.1:38227",
+					"172.24.0.1:38227",
+					"172.25.0.1:38227",
+					"172.26.0.1:38227",
+					"172.27.0.1:38227",
+					"172.28.0.1:38227"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:22:18.625515705Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6552951513903457,
+				"StableID":   "ntApkcvqAt11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:931685473e4f205d62413ac4d2c3ebcf8458908f94f8eb83c4775c87a115ad17",
+				"DiscoKey":   "discokey:bc9c50ba82975f34422b2beb098bf1de48b763f778361a0252ffd5220a0f7403",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55202",
+					"10.65.0.27:55202",
+					"172.17.0.1:55202",
+					"172.18.0.1:55202",
+					"172.19.0.1:55202",
+					"172.20.0.1:55202",
+					"172.21.0.1:55202",
+					"172.22.0.1:55202",
+					"172.23.0.1:55202",
+					"172.24.0.1:55202",
+					"172.25.0.1:55202",
+					"172.26.0.1:55202",
+					"172.27.0.1:55202",
+					"172.28.0.1:55202"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:22:19.337487583Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         270807153993723,
+				"StableID":   "nkm3sPee7311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87c7f40fb532366935ad5214207388a29031d359001b49634cc910f135465f6d",
+				"DiscoKey":   "discokey:501b1dad6def0edb6ba5a26e86ca442aa8a2151e84fceea8132f51fb2d1e956e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44002",
+					"10.65.0.27:44002",
+					"172.17.0.1:44002",
+					"172.18.0.1:44002",
+					"172.19.0.1:44002",
+					"172.20.0.1:44002",
+					"172.21.0.1:44002",
+					"172.22.0.1:44002",
+					"172.23.0.1:44002",
+					"172.24.0.1:44002",
+					"172.25.0.1:44002",
+					"172.26.0.1:44002",
+					"172.27.0.1:44002",
+					"172.28.0.1:44002"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:22:19.865837519Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6705106736621230,
+				"StableID":   "n1pqkUnkMu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6a64002270eca2ff6d91bc9adda789c18c32581d805ba41c1d548b4675348229",
+				"DiscoKey":   "discokey:35cf0dffa25ba0e1150a8ef1336210509b79e4a6618b4dc5c12f327147d8d55a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53680",
+					"10.65.0.27:53680",
+					"172.17.0.1:53680",
+					"172.18.0.1:53680",
+					"172.19.0.1:53680",
+					"172.20.0.1:53680",
+					"172.21.0.1:53680",
+					"172.22.0.1:53680",
+					"172.23.0.1:53680",
+					"172.24.0.1:53680",
+					"172.25.0.1:53680",
+					"172.26.0.1:53680",
+					"172.27.0.1:53680",
+					"172.28.0.1:53680"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:22:20.398552469Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7667948310719536,
+				"StableID":   "nPYeZyzps221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0ce1ba6d4cbbcf9decf7a9f01ad378411022ffd5e9eef94809593172fa1af69",
+				"DiscoKey":   "discokey:995e138a0bc7c2d6a53c165e23b474940593333d62d90528cee068a4e18a2b0e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56289",
+					"10.65.0.27:56289",
+					"172.17.0.1:56289",
+					"172.18.0.1:56289",
+					"172.19.0.1:56289",
+					"172.20.0.1:56289",
+					"172.21.0.1:56289",
+					"172.22.0.1:56289",
+					"172.23.0.1:56289",
+					"172.24.0.1:56289",
+					"172.25.0.1:56289",
+					"172.26.0.1:56289",
+					"172.27.0.1:56289",
+					"172.28.0.1:56289"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:22:20.937449274Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7000699690251896,
+				"StableID":   "nVMkrZWdfw11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1af67b633fce2aa5dd3d1c22557a42939a55de468eee10b89c0e3f3d8a7f1f08",
+				"DiscoKey":   "discokey:ca263f641228d82e7ba561ce1fdc498a4ac6b7a9d1bf1ab6e3b56f0b22abb818",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35249",
+					"10.65.0.27:35249",
+					"172.17.0.1:35249",
+					"172.18.0.1:35249",
+					"172.19.0.1:35249",
+					"172.20.0.1:35249",
+					"172.21.0.1:35249",
+					"172.22.0.1:35249",
+					"172.23.0.1:35249",
+					"172.24.0.1:35249",
+					"172.25.0.1:35249",
+					"172.26.0.1:35249",
+					"172.27.0.1:35249",
+					"172.28.0.1:35249"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:22:21.464954476Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6444602222931293,
+				"StableID":   "ntkLwnmmKs11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b654ef19ce6bebdfc6c755e04f8696d3bed3d99477bd5f05716627c739453476",
+				"KeyExpiry":  "2026-11-09T09:22:22Z",
+				"DiscoKey":   "discokey:afb4f3c13a03175eb745bc3dc0ee942c876b1e75571d99756f7af5701a4dc06b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50042",
+					"10.65.0.27:50042",
+					"172.17.0.1:50042",
+					"172.18.0.1:50042",
+					"172.19.0.1:50042",
+					"172.20.0.1:50042",
+					"172.21.0.1:50042",
+					"172.22.0.1:50042",
+					"172.23.0.1:50042",
+					"172.24.0.1:50042",
+					"172.25.0.1:50042",
+					"172.26.0.1:50042",
+					"172.27.0.1:50042",
+					"172.28.0.1:50042"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:22:22.530433778Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5578350789120784,
+				"StableID":   "nqd35LpSZk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1f50fdcd08b5a717d0aec4e3b425a7e9a16c73233d894e71323c69ea2a7e2e1b",
+				"KeyExpiry":  "2026-11-09T09:22:23Z",
+				"DiscoKey":   "discokey:a6853978df9b5a349793b1a03dbdf09ba43ae156e43dd71f0042377af70b9b7c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49037",
+					"10.65.0.27:49037",
+					"172.17.0.1:49037",
+					"172.18.0.1:49037",
+					"172.19.0.1:49037",
+					"172.20.0.1:49037",
+					"172.21.0.1:49037",
+					"172.22.0.1:49037",
+					"172.23.0.1:49037",
+					"172.24.0.1:49037",
+					"172.25.0.1:49037",
+					"172.26.0.1:49037",
+					"172.27.0.1:49037",
+					"172.28.0.1:49037"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:22:23.062857052Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7667948310719536,
+				"StableID":   "nPYeZyzps221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       7667948310719536,
+				"Key":        "nodekey:d0ce1ba6d4cbbcf9decf7a9f01ad378411022ffd5e9eef94809593172fa1af69",
+				"DiscoKey":   "discokey:995e138a0bc7c2d6a53c165e23b474940593333d62d90528cee068a4e18a2b0e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56289",
+					"10.65.0.27:56289",
+					"172.17.0.1:56289",
+					"172.18.0.1:56289",
+					"172.19.0.1:56289",
+					"172.20.0.1:56289",
+					"172.21.0.1:56289",
+					"172.22.0.1:56289",
+					"172.23.0.1:56289",
+					"172.24.0.1:56289",
+					"172.25.0.1:56289",
+					"172.26.0.1:56289",
+					"172.27.0.1:56289",
+					"172.28.0.1:56289"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:22:20.937449274Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d0ce1ba6d4cbbcf9decf7a9f01ad378411022ffd5e9eef94809593172fa1af69",
+			"MachineKey": "mkey:92c4a479a7ec32d8444ff29896c34e0c6d8a5ee8d47bb12297176cace5201168",
+			"Peers": [{
+				"ID":         8143243316789368,
+				"StableID":   "n1mKgDC6b621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39f74a3cfcbcd2d85a0505acd7608c438d8b75f75bc73d973c69ffefca1d7b35",
+				"DiscoKey":   "discokey:b286192a70d77992ae5e2c3e46bf90bdcf13cbec61579caf2e3806f562ae5c30",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52300",
+					"10.65.0.27:52300",
+					"172.17.0.1:52300",
+					"172.18.0.1:52300",
+					"172.19.0.1:52300",
+					"172.20.0.1:52300",
+					"172.21.0.1:52300",
+					"172.22.0.1:52300",
+					"172.23.0.1:52300",
+					"172.24.0.1:52300",
+					"172.25.0.1:52300",
+					"172.26.0.1:52300",
+					"172.27.0.1:52300",
+					"172.28.0.1:52300"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:22:15.112140752Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         113860257757471,
+				"StableID":   "nCVk58vZt111CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2842a72c6a80f763919802b778551075f77872ad7370c9a2de933018cdf143a",
+				"DiscoKey":   "discokey:484ac995502db71932de00d90d5d0d156a7f026ca5364ef3dbe3ae81bafc1476",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33365",
+					"10.65.0.27:33365",
+					"172.17.0.1:33365",
+					"172.18.0.1:33365",
+					"172.19.0.1:33365",
+					"172.20.0.1:33365",
+					"172.21.0.1:33365",
+					"172.22.0.1:33365",
+					"172.23.0.1:33365",
+					"172.24.0.1:33365",
+					"172.25.0.1:33365",
+					"172.26.0.1:33365",
+					"172.27.0.1:33365",
+					"172.28.0.1:33365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:22:15.844852796Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8677184893301866,
+				"StableID":   "nVk3Q8wukA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0d962c6fb4822dd3f7d040f87a7cf03159c7e110abed635b06e5be1ea044a4b",
+				"DiscoKey":   "discokey:99083f7b395bb3d58c747b2924bf09cd845be26dd013e76cb8897949bded4378",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34443",
+					"10.65.0.27:34443",
+					"172.17.0.1:34443",
+					"172.18.0.1:34443",
+					"172.19.0.1:34443",
+					"172.20.0.1:34443",
+					"172.21.0.1:34443",
+					"172.22.0.1:34443",
+					"172.23.0.1:34443",
+					"172.24.0.1:34443",
+					"172.25.0.1:34443",
+					"172.26.0.1:34443",
+					"172.27.0.1:34443",
+					"172.28.0.1:34443"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:22:16.376358719Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5650061022717349,
+				"StableID":   "nesSrHXv7m11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7e2046717ee3fa271fb28b7c09fa35fcb67bbebf2c25495eff616e3ef30c079",
+				"DiscoKey":   "discokey:1ec584995763f070c9b9b759453ff4e2c4fedd6e5dcc2736bb30a081dafda228",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:54222",
+					"10.65.0.27:54222",
+					"172.17.0.1:54222",
+					"172.18.0.1:54222",
+					"172.19.0.1:54222",
+					"172.20.0.1:54222",
+					"172.21.0.1:54222",
+					"172.22.0.1:54222",
+					"172.23.0.1:54222",
+					"172.24.0.1:54222",
+					"172.25.0.1:54222",
+					"172.26.0.1:54222",
+					"172.27.0.1:54222",
+					"172.28.0.1:54222"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:22:16.91735265Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5333300322750175,
+				"StableID":   "nGhZVqkTei11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:04046ddc32a46ab98f6736d52022153d1f7925d49a894c69149f193f03fb8f4e",
+				"DiscoKey":   "discokey:04a4340cf2ab637b906d2ca8d7211a892219b154aced487018f475b0a673ca3b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42920",
+					"10.65.0.27:42920",
+					"172.17.0.1:42920",
+					"172.18.0.1:42920",
+					"172.19.0.1:42920",
+					"172.20.0.1:42920",
+					"172.21.0.1:42920",
+					"172.22.0.1:42920",
+					"172.23.0.1:42920",
+					"172.24.0.1:42920",
+					"172.25.0.1:42920",
+					"172.26.0.1:42920",
+					"172.27.0.1:42920",
+					"172.28.0.1:42920"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:22:17.457951971Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         185841476911834,
+				"StableID":   "nd4yvwjAT211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4238e5a1a2f60912dd33750eaba2e9ade234e967f531034c8a2815df697adb14",
+				"DiscoKey":   "discokey:54f707cb1a422b733807276e804ce659bada6eb39062823fe48a5d80b6df1b47",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58427",
+					"10.65.0.27:58427",
+					"172.17.0.1:58427",
+					"172.18.0.1:58427",
+					"172.19.0.1:58427",
+					"172.20.0.1:58427",
+					"172.21.0.1:58427",
+					"172.22.0.1:58427",
+					"172.23.0.1:58427",
+					"172.24.0.1:58427",
+					"172.25.0.1:58427",
+					"172.26.0.1:58427",
+					"172.27.0.1:58427",
+					"172.28.0.1:58427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:22:17.99921398Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7323377596879331,
+				"StableID":   "n8FTWFimBz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0909da237b2e808c61e8de74434b2b9d9aecb4ee43065089ece5204b6b9b5629",
+				"DiscoKey":   "discokey:a32b59e0d33e2ded107b39b22960633cdd1f0abc18f36f57d5e21c7640a93149",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38227",
+					"10.65.0.27:38227",
+					"172.17.0.1:38227",
+					"172.18.0.1:38227",
+					"172.19.0.1:38227",
+					"172.20.0.1:38227",
+					"172.21.0.1:38227",
+					"172.22.0.1:38227",
+					"172.23.0.1:38227",
+					"172.24.0.1:38227",
+					"172.25.0.1:38227",
+					"172.26.0.1:38227",
+					"172.27.0.1:38227",
+					"172.28.0.1:38227"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:22:18.625515705Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6552951513903457,
+				"StableID":   "ntApkcvqAt11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:931685473e4f205d62413ac4d2c3ebcf8458908f94f8eb83c4775c87a115ad17",
+				"DiscoKey":   "discokey:bc9c50ba82975f34422b2beb098bf1de48b763f778361a0252ffd5220a0f7403",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55202",
+					"10.65.0.27:55202",
+					"172.17.0.1:55202",
+					"172.18.0.1:55202",
+					"172.19.0.1:55202",
+					"172.20.0.1:55202",
+					"172.21.0.1:55202",
+					"172.22.0.1:55202",
+					"172.23.0.1:55202",
+					"172.24.0.1:55202",
+					"172.25.0.1:55202",
+					"172.26.0.1:55202",
+					"172.27.0.1:55202",
+					"172.28.0.1:55202"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:22:19.337487583Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         270807153993723,
+				"StableID":   "nkm3sPee7311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87c7f40fb532366935ad5214207388a29031d359001b49634cc910f135465f6d",
+				"DiscoKey":   "discokey:501b1dad6def0edb6ba5a26e86ca442aa8a2151e84fceea8132f51fb2d1e956e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44002",
+					"10.65.0.27:44002",
+					"172.17.0.1:44002",
+					"172.18.0.1:44002",
+					"172.19.0.1:44002",
+					"172.20.0.1:44002",
+					"172.21.0.1:44002",
+					"172.22.0.1:44002",
+					"172.23.0.1:44002",
+					"172.24.0.1:44002",
+					"172.25.0.1:44002",
+					"172.26.0.1:44002",
+					"172.27.0.1:44002",
+					"172.28.0.1:44002"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:22:19.865837519Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6705106736621230,
+				"StableID":   "n1pqkUnkMu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6a64002270eca2ff6d91bc9adda789c18c32581d805ba41c1d548b4675348229",
+				"DiscoKey":   "discokey:35cf0dffa25ba0e1150a8ef1336210509b79e4a6618b4dc5c12f327147d8d55a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53680",
+					"10.65.0.27:53680",
+					"172.17.0.1:53680",
+					"172.18.0.1:53680",
+					"172.19.0.1:53680",
+					"172.20.0.1:53680",
+					"172.21.0.1:53680",
+					"172.22.0.1:53680",
+					"172.23.0.1:53680",
+					"172.24.0.1:53680",
+					"172.25.0.1:53680",
+					"172.26.0.1:53680",
+					"172.27.0.1:53680",
+					"172.28.0.1:53680"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:22:20.398552469Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7000699690251896,
+				"StableID":   "nVMkrZWdfw11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1af67b633fce2aa5dd3d1c22557a42939a55de468eee10b89c0e3f3d8a7f1f08",
+				"DiscoKey":   "discokey:ca263f641228d82e7ba561ce1fdc498a4ac6b7a9d1bf1ab6e3b56f0b22abb818",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35249",
+					"10.65.0.27:35249",
+					"172.17.0.1:35249",
+					"172.18.0.1:35249",
+					"172.19.0.1:35249",
+					"172.20.0.1:35249",
+					"172.21.0.1:35249",
+					"172.22.0.1:35249",
+					"172.23.0.1:35249",
+					"172.24.0.1:35249",
+					"172.25.0.1:35249",
+					"172.26.0.1:35249",
+					"172.27.0.1:35249",
+					"172.28.0.1:35249"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:22:21.464954476Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4284797806903681,
+				"StableID":   "n2dXbcNbTa11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a7a8458270cc82b0625a3ebd79c3e5af5e040c4219deba360979d91f965a6476",
+				"KeyExpiry":  "2026-11-09T09:22:21Z",
+				"DiscoKey":   "discokey:9616211d17ab9697e7fa55165294efc168d482ee06724751e93efbeed324fd76",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50158",
+					"10.65.0.27:50158",
+					"172.17.0.1:50158",
+					"172.18.0.1:50158",
+					"172.19.0.1:50158",
+					"172.20.0.1:50158",
+					"172.21.0.1:50158",
+					"172.22.0.1:50158",
+					"172.23.0.1:50158",
+					"172.24.0.1:50158",
+					"172.25.0.1:50158",
+					"172.26.0.1:50158",
+					"172.27.0.1:50158",
+					"172.28.0.1:50158"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:22:21.988373309Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6444602222931293,
+				"StableID":   "ntkLwnmmKs11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b654ef19ce6bebdfc6c755e04f8696d3bed3d99477bd5f05716627c739453476",
+				"KeyExpiry":  "2026-11-09T09:22:22Z",
+				"DiscoKey":   "discokey:afb4f3c13a03175eb745bc3dc0ee942c876b1e75571d99756f7af5701a4dc06b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50042",
+					"10.65.0.27:50042",
+					"172.17.0.1:50042",
+					"172.18.0.1:50042",
+					"172.19.0.1:50042",
+					"172.20.0.1:50042",
+					"172.21.0.1:50042",
+					"172.22.0.1:50042",
+					"172.23.0.1:50042",
+					"172.24.0.1:50042",
+					"172.25.0.1:50042",
+					"172.26.0.1:50042",
+					"172.27.0.1:50042",
+					"172.28.0.1:50042"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:22:22.530433778Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5578350789120784,
+				"StableID":   "nqd35LpSZk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1f50fdcd08b5a717d0aec4e3b425a7e9a16c73233d894e71323c69ea2a7e2e1b",
+				"KeyExpiry":  "2026-11-09T09:22:23Z",
+				"DiscoKey":   "discokey:a6853978df9b5a349793b1a03dbdf09ba43ae156e43dd71f0042377af70b9b7c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49037",
+					"10.65.0.27:49037",
+					"172.17.0.1:49037",
+					"172.18.0.1:49037",
+					"172.19.0.1:49037",
+					"172.20.0.1:49037",
+					"172.21.0.1:49037",
+					"172.22.0.1:49037",
+					"172.23.0.1:49037",
+					"172.24.0.1:49037",
+					"172.25.0.1:49037",
+					"172.26.0.1:49037",
+					"172.27.0.1:49037",
+					"172.28.0.1:49037"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:22:23.062857052Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7667948310719536": {
+				"ID":          7667948310719536,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         113860257757471,
+				"StableID":   "nCVk58vZt111CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       113860257757471,
+				"Key":        "nodekey:e2842a72c6a80f763919802b778551075f77872ad7370c9a2de933018cdf143a",
+				"DiscoKey":   "discokey:484ac995502db71932de00d90d5d0d156a7f026ca5364ef3dbe3ae81bafc1476",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33365",
+					"10.65.0.27:33365",
+					"172.17.0.1:33365",
+					"172.18.0.1:33365",
+					"172.19.0.1:33365",
+					"172.20.0.1:33365",
+					"172.21.0.1:33365",
+					"172.22.0.1:33365",
+					"172.23.0.1:33365",
+					"172.24.0.1:33365",
+					"172.25.0.1:33365",
+					"172.26.0.1:33365",
+					"172.27.0.1:33365",
+					"172.28.0.1:33365"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:22:15.844852796Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e2842a72c6a80f763919802b778551075f77872ad7370c9a2de933018cdf143a",
+			"MachineKey": "mkey:1c9c9e35a7e0bff58975bb59c5a82471702fc69170b0f6773b7e122d192a4744",
+			"Peers": [{
+				"ID":         8143243316789368,
+				"StableID":   "n1mKgDC6b621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39f74a3cfcbcd2d85a0505acd7608c438d8b75f75bc73d973c69ffefca1d7b35",
+				"DiscoKey":   "discokey:b286192a70d77992ae5e2c3e46bf90bdcf13cbec61579caf2e3806f562ae5c30",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52300",
+					"10.65.0.27:52300",
+					"172.17.0.1:52300",
+					"172.18.0.1:52300",
+					"172.19.0.1:52300",
+					"172.20.0.1:52300",
+					"172.21.0.1:52300",
+					"172.22.0.1:52300",
+					"172.23.0.1:52300",
+					"172.24.0.1:52300",
+					"172.25.0.1:52300",
+					"172.26.0.1:52300",
+					"172.27.0.1:52300",
+					"172.28.0.1:52300"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:22:15.112140752Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8677184893301866,
+				"StableID":   "nVk3Q8wukA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0d962c6fb4822dd3f7d040f87a7cf03159c7e110abed635b06e5be1ea044a4b",
+				"DiscoKey":   "discokey:99083f7b395bb3d58c747b2924bf09cd845be26dd013e76cb8897949bded4378",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34443",
+					"10.65.0.27:34443",
+					"172.17.0.1:34443",
+					"172.18.0.1:34443",
+					"172.19.0.1:34443",
+					"172.20.0.1:34443",
+					"172.21.0.1:34443",
+					"172.22.0.1:34443",
+					"172.23.0.1:34443",
+					"172.24.0.1:34443",
+					"172.25.0.1:34443",
+					"172.26.0.1:34443",
+					"172.27.0.1:34443",
+					"172.28.0.1:34443"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:22:16.376358719Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5650061022717349,
+				"StableID":   "nesSrHXv7m11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7e2046717ee3fa271fb28b7c09fa35fcb67bbebf2c25495eff616e3ef30c079",
+				"DiscoKey":   "discokey:1ec584995763f070c9b9b759453ff4e2c4fedd6e5dcc2736bb30a081dafda228",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:54222",
+					"10.65.0.27:54222",
+					"172.17.0.1:54222",
+					"172.18.0.1:54222",
+					"172.19.0.1:54222",
+					"172.20.0.1:54222",
+					"172.21.0.1:54222",
+					"172.22.0.1:54222",
+					"172.23.0.1:54222",
+					"172.24.0.1:54222",
+					"172.25.0.1:54222",
+					"172.26.0.1:54222",
+					"172.27.0.1:54222",
+					"172.28.0.1:54222"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:22:16.91735265Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5333300322750175,
+				"StableID":   "nGhZVqkTei11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:04046ddc32a46ab98f6736d52022153d1f7925d49a894c69149f193f03fb8f4e",
+				"DiscoKey":   "discokey:04a4340cf2ab637b906d2ca8d7211a892219b154aced487018f475b0a673ca3b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42920",
+					"10.65.0.27:42920",
+					"172.17.0.1:42920",
+					"172.18.0.1:42920",
+					"172.19.0.1:42920",
+					"172.20.0.1:42920",
+					"172.21.0.1:42920",
+					"172.22.0.1:42920",
+					"172.23.0.1:42920",
+					"172.24.0.1:42920",
+					"172.25.0.1:42920",
+					"172.26.0.1:42920",
+					"172.27.0.1:42920",
+					"172.28.0.1:42920"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:22:17.457951971Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         185841476911834,
+				"StableID":   "nd4yvwjAT211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4238e5a1a2f60912dd33750eaba2e9ade234e967f531034c8a2815df697adb14",
+				"DiscoKey":   "discokey:54f707cb1a422b733807276e804ce659bada6eb39062823fe48a5d80b6df1b47",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58427",
+					"10.65.0.27:58427",
+					"172.17.0.1:58427",
+					"172.18.0.1:58427",
+					"172.19.0.1:58427",
+					"172.20.0.1:58427",
+					"172.21.0.1:58427",
+					"172.22.0.1:58427",
+					"172.23.0.1:58427",
+					"172.24.0.1:58427",
+					"172.25.0.1:58427",
+					"172.26.0.1:58427",
+					"172.27.0.1:58427",
+					"172.28.0.1:58427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:22:17.99921398Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7323377596879331,
+				"StableID":   "n8FTWFimBz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0909da237b2e808c61e8de74434b2b9d9aecb4ee43065089ece5204b6b9b5629",
+				"DiscoKey":   "discokey:a32b59e0d33e2ded107b39b22960633cdd1f0abc18f36f57d5e21c7640a93149",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38227",
+					"10.65.0.27:38227",
+					"172.17.0.1:38227",
+					"172.18.0.1:38227",
+					"172.19.0.1:38227",
+					"172.20.0.1:38227",
+					"172.21.0.1:38227",
+					"172.22.0.1:38227",
+					"172.23.0.1:38227",
+					"172.24.0.1:38227",
+					"172.25.0.1:38227",
+					"172.26.0.1:38227",
+					"172.27.0.1:38227",
+					"172.28.0.1:38227"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:22:18.625515705Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6552951513903457,
+				"StableID":   "ntApkcvqAt11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:931685473e4f205d62413ac4d2c3ebcf8458908f94f8eb83c4775c87a115ad17",
+				"DiscoKey":   "discokey:bc9c50ba82975f34422b2beb098bf1de48b763f778361a0252ffd5220a0f7403",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55202",
+					"10.65.0.27:55202",
+					"172.17.0.1:55202",
+					"172.18.0.1:55202",
+					"172.19.0.1:55202",
+					"172.20.0.1:55202",
+					"172.21.0.1:55202",
+					"172.22.0.1:55202",
+					"172.23.0.1:55202",
+					"172.24.0.1:55202",
+					"172.25.0.1:55202",
+					"172.26.0.1:55202",
+					"172.27.0.1:55202",
+					"172.28.0.1:55202"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:22:19.337487583Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         270807153993723,
+				"StableID":   "nkm3sPee7311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87c7f40fb532366935ad5214207388a29031d359001b49634cc910f135465f6d",
+				"DiscoKey":   "discokey:501b1dad6def0edb6ba5a26e86ca442aa8a2151e84fceea8132f51fb2d1e956e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44002",
+					"10.65.0.27:44002",
+					"172.17.0.1:44002",
+					"172.18.0.1:44002",
+					"172.19.0.1:44002",
+					"172.20.0.1:44002",
+					"172.21.0.1:44002",
+					"172.22.0.1:44002",
+					"172.23.0.1:44002",
+					"172.24.0.1:44002",
+					"172.25.0.1:44002",
+					"172.26.0.1:44002",
+					"172.27.0.1:44002",
+					"172.28.0.1:44002"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:22:19.865837519Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6705106736621230,
+				"StableID":   "n1pqkUnkMu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6a64002270eca2ff6d91bc9adda789c18c32581d805ba41c1d548b4675348229",
+				"DiscoKey":   "discokey:35cf0dffa25ba0e1150a8ef1336210509b79e4a6618b4dc5c12f327147d8d55a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53680",
+					"10.65.0.27:53680",
+					"172.17.0.1:53680",
+					"172.18.0.1:53680",
+					"172.19.0.1:53680",
+					"172.20.0.1:53680",
+					"172.21.0.1:53680",
+					"172.22.0.1:53680",
+					"172.23.0.1:53680",
+					"172.24.0.1:53680",
+					"172.25.0.1:53680",
+					"172.26.0.1:53680",
+					"172.27.0.1:53680",
+					"172.28.0.1:53680"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:22:20.398552469Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7667948310719536,
+				"StableID":   "nPYeZyzps221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0ce1ba6d4cbbcf9decf7a9f01ad378411022ffd5e9eef94809593172fa1af69",
+				"DiscoKey":   "discokey:995e138a0bc7c2d6a53c165e23b474940593333d62d90528cee068a4e18a2b0e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56289",
+					"10.65.0.27:56289",
+					"172.17.0.1:56289",
+					"172.18.0.1:56289",
+					"172.19.0.1:56289",
+					"172.20.0.1:56289",
+					"172.21.0.1:56289",
+					"172.22.0.1:56289",
+					"172.23.0.1:56289",
+					"172.24.0.1:56289",
+					"172.25.0.1:56289",
+					"172.26.0.1:56289",
+					"172.27.0.1:56289",
+					"172.28.0.1:56289"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:22:20.937449274Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7000699690251896,
+				"StableID":   "nVMkrZWdfw11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1af67b633fce2aa5dd3d1c22557a42939a55de468eee10b89c0e3f3d8a7f1f08",
+				"DiscoKey":   "discokey:ca263f641228d82e7ba561ce1fdc498a4ac6b7a9d1bf1ab6e3b56f0b22abb818",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35249",
+					"10.65.0.27:35249",
+					"172.17.0.1:35249",
+					"172.18.0.1:35249",
+					"172.19.0.1:35249",
+					"172.20.0.1:35249",
+					"172.21.0.1:35249",
+					"172.22.0.1:35249",
+					"172.23.0.1:35249",
+					"172.24.0.1:35249",
+					"172.25.0.1:35249",
+					"172.26.0.1:35249",
+					"172.27.0.1:35249",
+					"172.28.0.1:35249"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:22:21.464954476Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4284797806903681,
+				"StableID":   "n2dXbcNbTa11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a7a8458270cc82b0625a3ebd79c3e5af5e040c4219deba360979d91f965a6476",
+				"KeyExpiry":  "2026-11-09T09:22:21Z",
+				"DiscoKey":   "discokey:9616211d17ab9697e7fa55165294efc168d482ee06724751e93efbeed324fd76",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50158",
+					"10.65.0.27:50158",
+					"172.17.0.1:50158",
+					"172.18.0.1:50158",
+					"172.19.0.1:50158",
+					"172.20.0.1:50158",
+					"172.21.0.1:50158",
+					"172.22.0.1:50158",
+					"172.23.0.1:50158",
+					"172.24.0.1:50158",
+					"172.25.0.1:50158",
+					"172.26.0.1:50158",
+					"172.27.0.1:50158",
+					"172.28.0.1:50158"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:22:21.988373309Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6444602222931293,
+				"StableID":   "ntkLwnmmKs11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b654ef19ce6bebdfc6c755e04f8696d3bed3d99477bd5f05716627c739453476",
+				"KeyExpiry":  "2026-11-09T09:22:22Z",
+				"DiscoKey":   "discokey:afb4f3c13a03175eb745bc3dc0ee942c876b1e75571d99756f7af5701a4dc06b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50042",
+					"10.65.0.27:50042",
+					"172.17.0.1:50042",
+					"172.18.0.1:50042",
+					"172.19.0.1:50042",
+					"172.20.0.1:50042",
+					"172.21.0.1:50042",
+					"172.22.0.1:50042",
+					"172.23.0.1:50042",
+					"172.24.0.1:50042",
+					"172.25.0.1:50042",
+					"172.26.0.1:50042",
+					"172.27.0.1:50042",
+					"172.28.0.1:50042"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:22:22.530433778Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5578350789120784,
+				"StableID":   "nqd35LpSZk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1f50fdcd08b5a717d0aec4e3b425a7e9a16c73233d894e71323c69ea2a7e2e1b",
+				"KeyExpiry":  "2026-11-09T09:22:23Z",
+				"DiscoKey":   "discokey:a6853978df9b5a349793b1a03dbdf09ba43ae156e43dd71f0042377af70b9b7c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49037",
+					"10.65.0.27:49037",
+					"172.17.0.1:49037",
+					"172.18.0.1:49037",
+					"172.19.0.1:49037",
+					"172.20.0.1:49037",
+					"172.21.0.1:49037",
+					"172.22.0.1:49037",
+					"172.23.0.1:49037",
+					"172.24.0.1:49037",
+					"172.25.0.1:49037",
+					"172.26.0.1:49037",
+					"172.27.0.1:49037",
+					"172.28.0.1:49037"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:22:23.062857052Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"113860257757471": {
+				"ID":          113860257757471,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8143243316789368,
+				"StableID":   "n1mKgDC6b621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       8143243316789368,
+				"Key":        "nodekey:39f74a3cfcbcd2d85a0505acd7608c438d8b75f75bc73d973c69ffefca1d7b35",
+				"DiscoKey":   "discokey:b286192a70d77992ae5e2c3e46bf90bdcf13cbec61579caf2e3806f562ae5c30",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52300",
+					"10.65.0.27:52300",
+					"172.17.0.1:52300",
+					"172.18.0.1:52300",
+					"172.19.0.1:52300",
+					"172.20.0.1:52300",
+					"172.21.0.1:52300",
+					"172.22.0.1:52300",
+					"172.23.0.1:52300",
+					"172.24.0.1:52300",
+					"172.25.0.1:52300",
+					"172.26.0.1:52300",
+					"172.27.0.1:52300",
+					"172.28.0.1:52300"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:22:15.112140752Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:39f74a3cfcbcd2d85a0505acd7608c438d8b75f75bc73d973c69ffefca1d7b35",
+			"MachineKey": "mkey:1d6d54ac92ff7156027b568a1dafc8f7b4735e9f41bfd40ec0c791065e93b031",
+			"Peers": [{
+				"ID":         113860257757471,
+				"StableID":   "nCVk58vZt111CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2842a72c6a80f763919802b778551075f77872ad7370c9a2de933018cdf143a",
+				"DiscoKey":   "discokey:484ac995502db71932de00d90d5d0d156a7f026ca5364ef3dbe3ae81bafc1476",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33365",
+					"10.65.0.27:33365",
+					"172.17.0.1:33365",
+					"172.18.0.1:33365",
+					"172.19.0.1:33365",
+					"172.20.0.1:33365",
+					"172.21.0.1:33365",
+					"172.22.0.1:33365",
+					"172.23.0.1:33365",
+					"172.24.0.1:33365",
+					"172.25.0.1:33365",
+					"172.26.0.1:33365",
+					"172.27.0.1:33365",
+					"172.28.0.1:33365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:22:15.844852796Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8677184893301866,
+				"StableID":   "nVk3Q8wukA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0d962c6fb4822dd3f7d040f87a7cf03159c7e110abed635b06e5be1ea044a4b",
+				"DiscoKey":   "discokey:99083f7b395bb3d58c747b2924bf09cd845be26dd013e76cb8897949bded4378",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34443",
+					"10.65.0.27:34443",
+					"172.17.0.1:34443",
+					"172.18.0.1:34443",
+					"172.19.0.1:34443",
+					"172.20.0.1:34443",
+					"172.21.0.1:34443",
+					"172.22.0.1:34443",
+					"172.23.0.1:34443",
+					"172.24.0.1:34443",
+					"172.25.0.1:34443",
+					"172.26.0.1:34443",
+					"172.27.0.1:34443",
+					"172.28.0.1:34443"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:22:16.376358719Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5650061022717349,
+				"StableID":   "nesSrHXv7m11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7e2046717ee3fa271fb28b7c09fa35fcb67bbebf2c25495eff616e3ef30c079",
+				"DiscoKey":   "discokey:1ec584995763f070c9b9b759453ff4e2c4fedd6e5dcc2736bb30a081dafda228",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:54222",
+					"10.65.0.27:54222",
+					"172.17.0.1:54222",
+					"172.18.0.1:54222",
+					"172.19.0.1:54222",
+					"172.20.0.1:54222",
+					"172.21.0.1:54222",
+					"172.22.0.1:54222",
+					"172.23.0.1:54222",
+					"172.24.0.1:54222",
+					"172.25.0.1:54222",
+					"172.26.0.1:54222",
+					"172.27.0.1:54222",
+					"172.28.0.1:54222"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:22:16.91735265Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5333300322750175,
+				"StableID":   "nGhZVqkTei11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:04046ddc32a46ab98f6736d52022153d1f7925d49a894c69149f193f03fb8f4e",
+				"DiscoKey":   "discokey:04a4340cf2ab637b906d2ca8d7211a892219b154aced487018f475b0a673ca3b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42920",
+					"10.65.0.27:42920",
+					"172.17.0.1:42920",
+					"172.18.0.1:42920",
+					"172.19.0.1:42920",
+					"172.20.0.1:42920",
+					"172.21.0.1:42920",
+					"172.22.0.1:42920",
+					"172.23.0.1:42920",
+					"172.24.0.1:42920",
+					"172.25.0.1:42920",
+					"172.26.0.1:42920",
+					"172.27.0.1:42920",
+					"172.28.0.1:42920"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:22:17.457951971Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         185841476911834,
+				"StableID":   "nd4yvwjAT211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4238e5a1a2f60912dd33750eaba2e9ade234e967f531034c8a2815df697adb14",
+				"DiscoKey":   "discokey:54f707cb1a422b733807276e804ce659bada6eb39062823fe48a5d80b6df1b47",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58427",
+					"10.65.0.27:58427",
+					"172.17.0.1:58427",
+					"172.18.0.1:58427",
+					"172.19.0.1:58427",
+					"172.20.0.1:58427",
+					"172.21.0.1:58427",
+					"172.22.0.1:58427",
+					"172.23.0.1:58427",
+					"172.24.0.1:58427",
+					"172.25.0.1:58427",
+					"172.26.0.1:58427",
+					"172.27.0.1:58427",
+					"172.28.0.1:58427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:22:17.99921398Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7323377596879331,
+				"StableID":   "n8FTWFimBz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0909da237b2e808c61e8de74434b2b9d9aecb4ee43065089ece5204b6b9b5629",
+				"DiscoKey":   "discokey:a32b59e0d33e2ded107b39b22960633cdd1f0abc18f36f57d5e21c7640a93149",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38227",
+					"10.65.0.27:38227",
+					"172.17.0.1:38227",
+					"172.18.0.1:38227",
+					"172.19.0.1:38227",
+					"172.20.0.1:38227",
+					"172.21.0.1:38227",
+					"172.22.0.1:38227",
+					"172.23.0.1:38227",
+					"172.24.0.1:38227",
+					"172.25.0.1:38227",
+					"172.26.0.1:38227",
+					"172.27.0.1:38227",
+					"172.28.0.1:38227"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:22:18.625515705Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6552951513903457,
+				"StableID":   "ntApkcvqAt11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:931685473e4f205d62413ac4d2c3ebcf8458908f94f8eb83c4775c87a115ad17",
+				"DiscoKey":   "discokey:bc9c50ba82975f34422b2beb098bf1de48b763f778361a0252ffd5220a0f7403",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55202",
+					"10.65.0.27:55202",
+					"172.17.0.1:55202",
+					"172.18.0.1:55202",
+					"172.19.0.1:55202",
+					"172.20.0.1:55202",
+					"172.21.0.1:55202",
+					"172.22.0.1:55202",
+					"172.23.0.1:55202",
+					"172.24.0.1:55202",
+					"172.25.0.1:55202",
+					"172.26.0.1:55202",
+					"172.27.0.1:55202",
+					"172.28.0.1:55202"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:22:19.337487583Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         270807153993723,
+				"StableID":   "nkm3sPee7311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87c7f40fb532366935ad5214207388a29031d359001b49634cc910f135465f6d",
+				"DiscoKey":   "discokey:501b1dad6def0edb6ba5a26e86ca442aa8a2151e84fceea8132f51fb2d1e956e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44002",
+					"10.65.0.27:44002",
+					"172.17.0.1:44002",
+					"172.18.0.1:44002",
+					"172.19.0.1:44002",
+					"172.20.0.1:44002",
+					"172.21.0.1:44002",
+					"172.22.0.1:44002",
+					"172.23.0.1:44002",
+					"172.24.0.1:44002",
+					"172.25.0.1:44002",
+					"172.26.0.1:44002",
+					"172.27.0.1:44002",
+					"172.28.0.1:44002"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:22:19.865837519Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6705106736621230,
+				"StableID":   "n1pqkUnkMu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6a64002270eca2ff6d91bc9adda789c18c32581d805ba41c1d548b4675348229",
+				"DiscoKey":   "discokey:35cf0dffa25ba0e1150a8ef1336210509b79e4a6618b4dc5c12f327147d8d55a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53680",
+					"10.65.0.27:53680",
+					"172.17.0.1:53680",
+					"172.18.0.1:53680",
+					"172.19.0.1:53680",
+					"172.20.0.1:53680",
+					"172.21.0.1:53680",
+					"172.22.0.1:53680",
+					"172.23.0.1:53680",
+					"172.24.0.1:53680",
+					"172.25.0.1:53680",
+					"172.26.0.1:53680",
+					"172.27.0.1:53680",
+					"172.28.0.1:53680"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:22:20.398552469Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7667948310719536,
+				"StableID":   "nPYeZyzps221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0ce1ba6d4cbbcf9decf7a9f01ad378411022ffd5e9eef94809593172fa1af69",
+				"DiscoKey":   "discokey:995e138a0bc7c2d6a53c165e23b474940593333d62d90528cee068a4e18a2b0e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56289",
+					"10.65.0.27:56289",
+					"172.17.0.1:56289",
+					"172.18.0.1:56289",
+					"172.19.0.1:56289",
+					"172.20.0.1:56289",
+					"172.21.0.1:56289",
+					"172.22.0.1:56289",
+					"172.23.0.1:56289",
+					"172.24.0.1:56289",
+					"172.25.0.1:56289",
+					"172.26.0.1:56289",
+					"172.27.0.1:56289",
+					"172.28.0.1:56289"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:22:20.937449274Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7000699690251896,
+				"StableID":   "nVMkrZWdfw11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1af67b633fce2aa5dd3d1c22557a42939a55de468eee10b89c0e3f3d8a7f1f08",
+				"DiscoKey":   "discokey:ca263f641228d82e7ba561ce1fdc498a4ac6b7a9d1bf1ab6e3b56f0b22abb818",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35249",
+					"10.65.0.27:35249",
+					"172.17.0.1:35249",
+					"172.18.0.1:35249",
+					"172.19.0.1:35249",
+					"172.20.0.1:35249",
+					"172.21.0.1:35249",
+					"172.22.0.1:35249",
+					"172.23.0.1:35249",
+					"172.24.0.1:35249",
+					"172.25.0.1:35249",
+					"172.26.0.1:35249",
+					"172.27.0.1:35249",
+					"172.28.0.1:35249"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:22:21.464954476Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4284797806903681,
+				"StableID":   "n2dXbcNbTa11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a7a8458270cc82b0625a3ebd79c3e5af5e040c4219deba360979d91f965a6476",
+				"KeyExpiry":  "2026-11-09T09:22:21Z",
+				"DiscoKey":   "discokey:9616211d17ab9697e7fa55165294efc168d482ee06724751e93efbeed324fd76",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50158",
+					"10.65.0.27:50158",
+					"172.17.0.1:50158",
+					"172.18.0.1:50158",
+					"172.19.0.1:50158",
+					"172.20.0.1:50158",
+					"172.21.0.1:50158",
+					"172.22.0.1:50158",
+					"172.23.0.1:50158",
+					"172.24.0.1:50158",
+					"172.25.0.1:50158",
+					"172.26.0.1:50158",
+					"172.27.0.1:50158",
+					"172.28.0.1:50158"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:22:21.988373309Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6444602222931293,
+				"StableID":   "ntkLwnmmKs11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b654ef19ce6bebdfc6c755e04f8696d3bed3d99477bd5f05716627c739453476",
+				"KeyExpiry":  "2026-11-09T09:22:22Z",
+				"DiscoKey":   "discokey:afb4f3c13a03175eb745bc3dc0ee942c876b1e75571d99756f7af5701a4dc06b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50042",
+					"10.65.0.27:50042",
+					"172.17.0.1:50042",
+					"172.18.0.1:50042",
+					"172.19.0.1:50042",
+					"172.20.0.1:50042",
+					"172.21.0.1:50042",
+					"172.22.0.1:50042",
+					"172.23.0.1:50042",
+					"172.24.0.1:50042",
+					"172.25.0.1:50042",
+					"172.26.0.1:50042",
+					"172.27.0.1:50042",
+					"172.28.0.1:50042"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:22:22.530433778Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5578350789120784,
+				"StableID":   "nqd35LpSZk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1f50fdcd08b5a717d0aec4e3b425a7e9a16c73233d894e71323c69ea2a7e2e1b",
+				"KeyExpiry":  "2026-11-09T09:22:23Z",
+				"DiscoKey":   "discokey:a6853978df9b5a349793b1a03dbdf09ba43ae156e43dd71f0042377af70b9b7c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49037",
+					"10.65.0.27:49037",
+					"172.17.0.1:49037",
+					"172.18.0.1:49037",
+					"172.19.0.1:49037",
+					"172.20.0.1:49037",
+					"172.21.0.1:49037",
+					"172.22.0.1:49037",
+					"172.23.0.1:49037",
+					"172.24.0.1:49037",
+					"172.25.0.1:49037",
+					"172.26.0.1:49037",
+					"172.27.0.1:49037",
+					"172.28.0.1:49037"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:22:23.062857052Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8143243316789368": {
+				"ID":          8143243316789368,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5333300322750175,
+				"StableID":   "nGhZVqkTei11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       5333300322750175,
+				"Key":        "nodekey:04046ddc32a46ab98f6736d52022153d1f7925d49a894c69149f193f03fb8f4e",
+				"DiscoKey":   "discokey:04a4340cf2ab637b906d2ca8d7211a892219b154aced487018f475b0a673ca3b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42920",
+					"10.65.0.27:42920",
+					"172.17.0.1:42920",
+					"172.18.0.1:42920",
+					"172.19.0.1:42920",
+					"172.20.0.1:42920",
+					"172.21.0.1:42920",
+					"172.22.0.1:42920",
+					"172.23.0.1:42920",
+					"172.24.0.1:42920",
+					"172.25.0.1:42920",
+					"172.26.0.1:42920",
+					"172.27.0.1:42920",
+					"172.28.0.1:42920"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:22:17.457951971Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:04046ddc32a46ab98f6736d52022153d1f7925d49a894c69149f193f03fb8f4e",
+			"MachineKey": "mkey:168b426ac11ba1322b3b9d79e6f979d6659d8c876839aabfd166774f70d53452",
+			"Peers": [{
+				"ID":         8143243316789368,
+				"StableID":   "n1mKgDC6b621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39f74a3cfcbcd2d85a0505acd7608c438d8b75f75bc73d973c69ffefca1d7b35",
+				"DiscoKey":   "discokey:b286192a70d77992ae5e2c3e46bf90bdcf13cbec61579caf2e3806f562ae5c30",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52300",
+					"10.65.0.27:52300",
+					"172.17.0.1:52300",
+					"172.18.0.1:52300",
+					"172.19.0.1:52300",
+					"172.20.0.1:52300",
+					"172.21.0.1:52300",
+					"172.22.0.1:52300",
+					"172.23.0.1:52300",
+					"172.24.0.1:52300",
+					"172.25.0.1:52300",
+					"172.26.0.1:52300",
+					"172.27.0.1:52300",
+					"172.28.0.1:52300"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:22:15.112140752Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         113860257757471,
+				"StableID":   "nCVk58vZt111CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2842a72c6a80f763919802b778551075f77872ad7370c9a2de933018cdf143a",
+				"DiscoKey":   "discokey:484ac995502db71932de00d90d5d0d156a7f026ca5364ef3dbe3ae81bafc1476",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33365",
+					"10.65.0.27:33365",
+					"172.17.0.1:33365",
+					"172.18.0.1:33365",
+					"172.19.0.1:33365",
+					"172.20.0.1:33365",
+					"172.21.0.1:33365",
+					"172.22.0.1:33365",
+					"172.23.0.1:33365",
+					"172.24.0.1:33365",
+					"172.25.0.1:33365",
+					"172.26.0.1:33365",
+					"172.27.0.1:33365",
+					"172.28.0.1:33365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:22:15.844852796Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8677184893301866,
+				"StableID":   "nVk3Q8wukA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0d962c6fb4822dd3f7d040f87a7cf03159c7e110abed635b06e5be1ea044a4b",
+				"DiscoKey":   "discokey:99083f7b395bb3d58c747b2924bf09cd845be26dd013e76cb8897949bded4378",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34443",
+					"10.65.0.27:34443",
+					"172.17.0.1:34443",
+					"172.18.0.1:34443",
+					"172.19.0.1:34443",
+					"172.20.0.1:34443",
+					"172.21.0.1:34443",
+					"172.22.0.1:34443",
+					"172.23.0.1:34443",
+					"172.24.0.1:34443",
+					"172.25.0.1:34443",
+					"172.26.0.1:34443",
+					"172.27.0.1:34443",
+					"172.28.0.1:34443"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:22:16.376358719Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5650061022717349,
+				"StableID":   "nesSrHXv7m11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7e2046717ee3fa271fb28b7c09fa35fcb67bbebf2c25495eff616e3ef30c079",
+				"DiscoKey":   "discokey:1ec584995763f070c9b9b759453ff4e2c4fedd6e5dcc2736bb30a081dafda228",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:54222",
+					"10.65.0.27:54222",
+					"172.17.0.1:54222",
+					"172.18.0.1:54222",
+					"172.19.0.1:54222",
+					"172.20.0.1:54222",
+					"172.21.0.1:54222",
+					"172.22.0.1:54222",
+					"172.23.0.1:54222",
+					"172.24.0.1:54222",
+					"172.25.0.1:54222",
+					"172.26.0.1:54222",
+					"172.27.0.1:54222",
+					"172.28.0.1:54222"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:22:16.91735265Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         185841476911834,
+				"StableID":   "nd4yvwjAT211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4238e5a1a2f60912dd33750eaba2e9ade234e967f531034c8a2815df697adb14",
+				"DiscoKey":   "discokey:54f707cb1a422b733807276e804ce659bada6eb39062823fe48a5d80b6df1b47",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58427",
+					"10.65.0.27:58427",
+					"172.17.0.1:58427",
+					"172.18.0.1:58427",
+					"172.19.0.1:58427",
+					"172.20.0.1:58427",
+					"172.21.0.1:58427",
+					"172.22.0.1:58427",
+					"172.23.0.1:58427",
+					"172.24.0.1:58427",
+					"172.25.0.1:58427",
+					"172.26.0.1:58427",
+					"172.27.0.1:58427",
+					"172.28.0.1:58427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:22:17.99921398Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7323377596879331,
+				"StableID":   "n8FTWFimBz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0909da237b2e808c61e8de74434b2b9d9aecb4ee43065089ece5204b6b9b5629",
+				"DiscoKey":   "discokey:a32b59e0d33e2ded107b39b22960633cdd1f0abc18f36f57d5e21c7640a93149",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38227",
+					"10.65.0.27:38227",
+					"172.17.0.1:38227",
+					"172.18.0.1:38227",
+					"172.19.0.1:38227",
+					"172.20.0.1:38227",
+					"172.21.0.1:38227",
+					"172.22.0.1:38227",
+					"172.23.0.1:38227",
+					"172.24.0.1:38227",
+					"172.25.0.1:38227",
+					"172.26.0.1:38227",
+					"172.27.0.1:38227",
+					"172.28.0.1:38227"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:22:18.625515705Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6552951513903457,
+				"StableID":   "ntApkcvqAt11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:931685473e4f205d62413ac4d2c3ebcf8458908f94f8eb83c4775c87a115ad17",
+				"DiscoKey":   "discokey:bc9c50ba82975f34422b2beb098bf1de48b763f778361a0252ffd5220a0f7403",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55202",
+					"10.65.0.27:55202",
+					"172.17.0.1:55202",
+					"172.18.0.1:55202",
+					"172.19.0.1:55202",
+					"172.20.0.1:55202",
+					"172.21.0.1:55202",
+					"172.22.0.1:55202",
+					"172.23.0.1:55202",
+					"172.24.0.1:55202",
+					"172.25.0.1:55202",
+					"172.26.0.1:55202",
+					"172.27.0.1:55202",
+					"172.28.0.1:55202"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:22:19.337487583Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         270807153993723,
+				"StableID":   "nkm3sPee7311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87c7f40fb532366935ad5214207388a29031d359001b49634cc910f135465f6d",
+				"DiscoKey":   "discokey:501b1dad6def0edb6ba5a26e86ca442aa8a2151e84fceea8132f51fb2d1e956e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44002",
+					"10.65.0.27:44002",
+					"172.17.0.1:44002",
+					"172.18.0.1:44002",
+					"172.19.0.1:44002",
+					"172.20.0.1:44002",
+					"172.21.0.1:44002",
+					"172.22.0.1:44002",
+					"172.23.0.1:44002",
+					"172.24.0.1:44002",
+					"172.25.0.1:44002",
+					"172.26.0.1:44002",
+					"172.27.0.1:44002",
+					"172.28.0.1:44002"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:22:19.865837519Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6705106736621230,
+				"StableID":   "n1pqkUnkMu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6a64002270eca2ff6d91bc9adda789c18c32581d805ba41c1d548b4675348229",
+				"DiscoKey":   "discokey:35cf0dffa25ba0e1150a8ef1336210509b79e4a6618b4dc5c12f327147d8d55a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53680",
+					"10.65.0.27:53680",
+					"172.17.0.1:53680",
+					"172.18.0.1:53680",
+					"172.19.0.1:53680",
+					"172.20.0.1:53680",
+					"172.21.0.1:53680",
+					"172.22.0.1:53680",
+					"172.23.0.1:53680",
+					"172.24.0.1:53680",
+					"172.25.0.1:53680",
+					"172.26.0.1:53680",
+					"172.27.0.1:53680",
+					"172.28.0.1:53680"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:22:20.398552469Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7667948310719536,
+				"StableID":   "nPYeZyzps221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0ce1ba6d4cbbcf9decf7a9f01ad378411022ffd5e9eef94809593172fa1af69",
+				"DiscoKey":   "discokey:995e138a0bc7c2d6a53c165e23b474940593333d62d90528cee068a4e18a2b0e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56289",
+					"10.65.0.27:56289",
+					"172.17.0.1:56289",
+					"172.18.0.1:56289",
+					"172.19.0.1:56289",
+					"172.20.0.1:56289",
+					"172.21.0.1:56289",
+					"172.22.0.1:56289",
+					"172.23.0.1:56289",
+					"172.24.0.1:56289",
+					"172.25.0.1:56289",
+					"172.26.0.1:56289",
+					"172.27.0.1:56289",
+					"172.28.0.1:56289"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:22:20.937449274Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7000699690251896,
+				"StableID":   "nVMkrZWdfw11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1af67b633fce2aa5dd3d1c22557a42939a55de468eee10b89c0e3f3d8a7f1f08",
+				"DiscoKey":   "discokey:ca263f641228d82e7ba561ce1fdc498a4ac6b7a9d1bf1ab6e3b56f0b22abb818",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35249",
+					"10.65.0.27:35249",
+					"172.17.0.1:35249",
+					"172.18.0.1:35249",
+					"172.19.0.1:35249",
+					"172.20.0.1:35249",
+					"172.21.0.1:35249",
+					"172.22.0.1:35249",
+					"172.23.0.1:35249",
+					"172.24.0.1:35249",
+					"172.25.0.1:35249",
+					"172.26.0.1:35249",
+					"172.27.0.1:35249",
+					"172.28.0.1:35249"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:22:21.464954476Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4284797806903681,
+				"StableID":   "n2dXbcNbTa11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a7a8458270cc82b0625a3ebd79c3e5af5e040c4219deba360979d91f965a6476",
+				"KeyExpiry":  "2026-11-09T09:22:21Z",
+				"DiscoKey":   "discokey:9616211d17ab9697e7fa55165294efc168d482ee06724751e93efbeed324fd76",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50158",
+					"10.65.0.27:50158",
+					"172.17.0.1:50158",
+					"172.18.0.1:50158",
+					"172.19.0.1:50158",
+					"172.20.0.1:50158",
+					"172.21.0.1:50158",
+					"172.22.0.1:50158",
+					"172.23.0.1:50158",
+					"172.24.0.1:50158",
+					"172.25.0.1:50158",
+					"172.26.0.1:50158",
+					"172.27.0.1:50158",
+					"172.28.0.1:50158"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:22:21.988373309Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6444602222931293,
+				"StableID":   "ntkLwnmmKs11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b654ef19ce6bebdfc6c755e04f8696d3bed3d99477bd5f05716627c739453476",
+				"KeyExpiry":  "2026-11-09T09:22:22Z",
+				"DiscoKey":   "discokey:afb4f3c13a03175eb745bc3dc0ee942c876b1e75571d99756f7af5701a4dc06b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50042",
+					"10.65.0.27:50042",
+					"172.17.0.1:50042",
+					"172.18.0.1:50042",
+					"172.19.0.1:50042",
+					"172.20.0.1:50042",
+					"172.21.0.1:50042",
+					"172.22.0.1:50042",
+					"172.23.0.1:50042",
+					"172.24.0.1:50042",
+					"172.25.0.1:50042",
+					"172.26.0.1:50042",
+					"172.27.0.1:50042",
+					"172.28.0.1:50042"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:22:22.530433778Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5578350789120784,
+				"StableID":   "nqd35LpSZk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1f50fdcd08b5a717d0aec4e3b425a7e9a16c73233d894e71323c69ea2a7e2e1b",
+				"KeyExpiry":  "2026-11-09T09:22:23Z",
+				"DiscoKey":   "discokey:a6853978df9b5a349793b1a03dbdf09ba43ae156e43dd71f0042377af70b9b7c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49037",
+					"10.65.0.27:49037",
+					"172.17.0.1:49037",
+					"172.18.0.1:49037",
+					"172.19.0.1:49037",
+					"172.20.0.1:49037",
+					"172.21.0.1:49037",
+					"172.22.0.1:49037",
+					"172.23.0.1:49037",
+					"172.24.0.1:49037",
+					"172.25.0.1:49037",
+					"172.26.0.1:49037",
+					"172.27.0.1:49037",
+					"172.28.0.1:49037"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:22:23.062857052Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5333300322750175": {
+				"ID":          5333300322750175,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5650061022717349,
+				"StableID":   "nesSrHXv7m11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       5650061022717349,
+				"Key":        "nodekey:e7e2046717ee3fa271fb28b7c09fa35fcb67bbebf2c25495eff616e3ef30c079",
+				"DiscoKey":   "discokey:1ec584995763f070c9b9b759453ff4e2c4fedd6e5dcc2736bb30a081dafda228",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:54222",
+					"10.65.0.27:54222",
+					"172.17.0.1:54222",
+					"172.18.0.1:54222",
+					"172.19.0.1:54222",
+					"172.20.0.1:54222",
+					"172.21.0.1:54222",
+					"172.22.0.1:54222",
+					"172.23.0.1:54222",
+					"172.24.0.1:54222",
+					"172.25.0.1:54222",
+					"172.26.0.1:54222",
+					"172.27.0.1:54222",
+					"172.28.0.1:54222"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:22:16.91735265Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e7e2046717ee3fa271fb28b7c09fa35fcb67bbebf2c25495eff616e3ef30c079",
+			"MachineKey": "mkey:8a6125c21893da3c503057e1a48c0c912c0fd765d28c44f003e10d7262cb1c15",
+			"Peers": [{
+				"ID":         8143243316789368,
+				"StableID":   "n1mKgDC6b621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39f74a3cfcbcd2d85a0505acd7608c438d8b75f75bc73d973c69ffefca1d7b35",
+				"DiscoKey":   "discokey:b286192a70d77992ae5e2c3e46bf90bdcf13cbec61579caf2e3806f562ae5c30",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52300",
+					"10.65.0.27:52300",
+					"172.17.0.1:52300",
+					"172.18.0.1:52300",
+					"172.19.0.1:52300",
+					"172.20.0.1:52300",
+					"172.21.0.1:52300",
+					"172.22.0.1:52300",
+					"172.23.0.1:52300",
+					"172.24.0.1:52300",
+					"172.25.0.1:52300",
+					"172.26.0.1:52300",
+					"172.27.0.1:52300",
+					"172.28.0.1:52300"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:22:15.112140752Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         113860257757471,
+				"StableID":   "nCVk58vZt111CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2842a72c6a80f763919802b778551075f77872ad7370c9a2de933018cdf143a",
+				"DiscoKey":   "discokey:484ac995502db71932de00d90d5d0d156a7f026ca5364ef3dbe3ae81bafc1476",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33365",
+					"10.65.0.27:33365",
+					"172.17.0.1:33365",
+					"172.18.0.1:33365",
+					"172.19.0.1:33365",
+					"172.20.0.1:33365",
+					"172.21.0.1:33365",
+					"172.22.0.1:33365",
+					"172.23.0.1:33365",
+					"172.24.0.1:33365",
+					"172.25.0.1:33365",
+					"172.26.0.1:33365",
+					"172.27.0.1:33365",
+					"172.28.0.1:33365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:22:15.844852796Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8677184893301866,
+				"StableID":   "nVk3Q8wukA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0d962c6fb4822dd3f7d040f87a7cf03159c7e110abed635b06e5be1ea044a4b",
+				"DiscoKey":   "discokey:99083f7b395bb3d58c747b2924bf09cd845be26dd013e76cb8897949bded4378",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34443",
+					"10.65.0.27:34443",
+					"172.17.0.1:34443",
+					"172.18.0.1:34443",
+					"172.19.0.1:34443",
+					"172.20.0.1:34443",
+					"172.21.0.1:34443",
+					"172.22.0.1:34443",
+					"172.23.0.1:34443",
+					"172.24.0.1:34443",
+					"172.25.0.1:34443",
+					"172.26.0.1:34443",
+					"172.27.0.1:34443",
+					"172.28.0.1:34443"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:22:16.376358719Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5333300322750175,
+				"StableID":   "nGhZVqkTei11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:04046ddc32a46ab98f6736d52022153d1f7925d49a894c69149f193f03fb8f4e",
+				"DiscoKey":   "discokey:04a4340cf2ab637b906d2ca8d7211a892219b154aced487018f475b0a673ca3b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42920",
+					"10.65.0.27:42920",
+					"172.17.0.1:42920",
+					"172.18.0.1:42920",
+					"172.19.0.1:42920",
+					"172.20.0.1:42920",
+					"172.21.0.1:42920",
+					"172.22.0.1:42920",
+					"172.23.0.1:42920",
+					"172.24.0.1:42920",
+					"172.25.0.1:42920",
+					"172.26.0.1:42920",
+					"172.27.0.1:42920",
+					"172.28.0.1:42920"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:22:17.457951971Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         185841476911834,
+				"StableID":   "nd4yvwjAT211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4238e5a1a2f60912dd33750eaba2e9ade234e967f531034c8a2815df697adb14",
+				"DiscoKey":   "discokey:54f707cb1a422b733807276e804ce659bada6eb39062823fe48a5d80b6df1b47",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58427",
+					"10.65.0.27:58427",
+					"172.17.0.1:58427",
+					"172.18.0.1:58427",
+					"172.19.0.1:58427",
+					"172.20.0.1:58427",
+					"172.21.0.1:58427",
+					"172.22.0.1:58427",
+					"172.23.0.1:58427",
+					"172.24.0.1:58427",
+					"172.25.0.1:58427",
+					"172.26.0.1:58427",
+					"172.27.0.1:58427",
+					"172.28.0.1:58427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:22:17.99921398Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7323377596879331,
+				"StableID":   "n8FTWFimBz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0909da237b2e808c61e8de74434b2b9d9aecb4ee43065089ece5204b6b9b5629",
+				"DiscoKey":   "discokey:a32b59e0d33e2ded107b39b22960633cdd1f0abc18f36f57d5e21c7640a93149",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38227",
+					"10.65.0.27:38227",
+					"172.17.0.1:38227",
+					"172.18.0.1:38227",
+					"172.19.0.1:38227",
+					"172.20.0.1:38227",
+					"172.21.0.1:38227",
+					"172.22.0.1:38227",
+					"172.23.0.1:38227",
+					"172.24.0.1:38227",
+					"172.25.0.1:38227",
+					"172.26.0.1:38227",
+					"172.27.0.1:38227",
+					"172.28.0.1:38227"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:22:18.625515705Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6552951513903457,
+				"StableID":   "ntApkcvqAt11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:931685473e4f205d62413ac4d2c3ebcf8458908f94f8eb83c4775c87a115ad17",
+				"DiscoKey":   "discokey:bc9c50ba82975f34422b2beb098bf1de48b763f778361a0252ffd5220a0f7403",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55202",
+					"10.65.0.27:55202",
+					"172.17.0.1:55202",
+					"172.18.0.1:55202",
+					"172.19.0.1:55202",
+					"172.20.0.1:55202",
+					"172.21.0.1:55202",
+					"172.22.0.1:55202",
+					"172.23.0.1:55202",
+					"172.24.0.1:55202",
+					"172.25.0.1:55202",
+					"172.26.0.1:55202",
+					"172.27.0.1:55202",
+					"172.28.0.1:55202"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:22:19.337487583Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         270807153993723,
+				"StableID":   "nkm3sPee7311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87c7f40fb532366935ad5214207388a29031d359001b49634cc910f135465f6d",
+				"DiscoKey":   "discokey:501b1dad6def0edb6ba5a26e86ca442aa8a2151e84fceea8132f51fb2d1e956e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44002",
+					"10.65.0.27:44002",
+					"172.17.0.1:44002",
+					"172.18.0.1:44002",
+					"172.19.0.1:44002",
+					"172.20.0.1:44002",
+					"172.21.0.1:44002",
+					"172.22.0.1:44002",
+					"172.23.0.1:44002",
+					"172.24.0.1:44002",
+					"172.25.0.1:44002",
+					"172.26.0.1:44002",
+					"172.27.0.1:44002",
+					"172.28.0.1:44002"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:22:19.865837519Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6705106736621230,
+				"StableID":   "n1pqkUnkMu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6a64002270eca2ff6d91bc9adda789c18c32581d805ba41c1d548b4675348229",
+				"DiscoKey":   "discokey:35cf0dffa25ba0e1150a8ef1336210509b79e4a6618b4dc5c12f327147d8d55a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53680",
+					"10.65.0.27:53680",
+					"172.17.0.1:53680",
+					"172.18.0.1:53680",
+					"172.19.0.1:53680",
+					"172.20.0.1:53680",
+					"172.21.0.1:53680",
+					"172.22.0.1:53680",
+					"172.23.0.1:53680",
+					"172.24.0.1:53680",
+					"172.25.0.1:53680",
+					"172.26.0.1:53680",
+					"172.27.0.1:53680",
+					"172.28.0.1:53680"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:22:20.398552469Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7667948310719536,
+				"StableID":   "nPYeZyzps221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0ce1ba6d4cbbcf9decf7a9f01ad378411022ffd5e9eef94809593172fa1af69",
+				"DiscoKey":   "discokey:995e138a0bc7c2d6a53c165e23b474940593333d62d90528cee068a4e18a2b0e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56289",
+					"10.65.0.27:56289",
+					"172.17.0.1:56289",
+					"172.18.0.1:56289",
+					"172.19.0.1:56289",
+					"172.20.0.1:56289",
+					"172.21.0.1:56289",
+					"172.22.0.1:56289",
+					"172.23.0.1:56289",
+					"172.24.0.1:56289",
+					"172.25.0.1:56289",
+					"172.26.0.1:56289",
+					"172.27.0.1:56289",
+					"172.28.0.1:56289"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:22:20.937449274Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7000699690251896,
+				"StableID":   "nVMkrZWdfw11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1af67b633fce2aa5dd3d1c22557a42939a55de468eee10b89c0e3f3d8a7f1f08",
+				"DiscoKey":   "discokey:ca263f641228d82e7ba561ce1fdc498a4ac6b7a9d1bf1ab6e3b56f0b22abb818",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35249",
+					"10.65.0.27:35249",
+					"172.17.0.1:35249",
+					"172.18.0.1:35249",
+					"172.19.0.1:35249",
+					"172.20.0.1:35249",
+					"172.21.0.1:35249",
+					"172.22.0.1:35249",
+					"172.23.0.1:35249",
+					"172.24.0.1:35249",
+					"172.25.0.1:35249",
+					"172.26.0.1:35249",
+					"172.27.0.1:35249",
+					"172.28.0.1:35249"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:22:21.464954476Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4284797806903681,
+				"StableID":   "n2dXbcNbTa11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a7a8458270cc82b0625a3ebd79c3e5af5e040c4219deba360979d91f965a6476",
+				"KeyExpiry":  "2026-11-09T09:22:21Z",
+				"DiscoKey":   "discokey:9616211d17ab9697e7fa55165294efc168d482ee06724751e93efbeed324fd76",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50158",
+					"10.65.0.27:50158",
+					"172.17.0.1:50158",
+					"172.18.0.1:50158",
+					"172.19.0.1:50158",
+					"172.20.0.1:50158",
+					"172.21.0.1:50158",
+					"172.22.0.1:50158",
+					"172.23.0.1:50158",
+					"172.24.0.1:50158",
+					"172.25.0.1:50158",
+					"172.26.0.1:50158",
+					"172.27.0.1:50158",
+					"172.28.0.1:50158"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:22:21.988373309Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6444602222931293,
+				"StableID":   "ntkLwnmmKs11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b654ef19ce6bebdfc6c755e04f8696d3bed3d99477bd5f05716627c739453476",
+				"KeyExpiry":  "2026-11-09T09:22:22Z",
+				"DiscoKey":   "discokey:afb4f3c13a03175eb745bc3dc0ee942c876b1e75571d99756f7af5701a4dc06b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50042",
+					"10.65.0.27:50042",
+					"172.17.0.1:50042",
+					"172.18.0.1:50042",
+					"172.19.0.1:50042",
+					"172.20.0.1:50042",
+					"172.21.0.1:50042",
+					"172.22.0.1:50042",
+					"172.23.0.1:50042",
+					"172.24.0.1:50042",
+					"172.25.0.1:50042",
+					"172.26.0.1:50042",
+					"172.27.0.1:50042",
+					"172.28.0.1:50042"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:22:22.530433778Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5578350789120784,
+				"StableID":   "nqd35LpSZk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1f50fdcd08b5a717d0aec4e3b425a7e9a16c73233d894e71323c69ea2a7e2e1b",
+				"KeyExpiry":  "2026-11-09T09:22:23Z",
+				"DiscoKey":   "discokey:a6853978df9b5a349793b1a03dbdf09ba43ae156e43dd71f0042377af70b9b7c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49037",
+					"10.65.0.27:49037",
+					"172.17.0.1:49037",
+					"172.18.0.1:49037",
+					"172.19.0.1:49037",
+					"172.20.0.1:49037",
+					"172.21.0.1:49037",
+					"172.22.0.1:49037",
+					"172.23.0.1:49037",
+					"172.24.0.1:49037",
+					"172.25.0.1:49037",
+					"172.26.0.1:49037",
+					"172.27.0.1:49037",
+					"172.28.0.1:49037"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:22:23.062857052Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5650061022717349": {
+				"ID":          5650061022717349,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7323377596879331,
+				"StableID":   "n8FTWFimBz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       7323377596879331,
+				"Key":        "nodekey:0909da237b2e808c61e8de74434b2b9d9aecb4ee43065089ece5204b6b9b5629",
+				"DiscoKey":   "discokey:a32b59e0d33e2ded107b39b22960633cdd1f0abc18f36f57d5e21c7640a93149",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38227",
+					"10.65.0.27:38227",
+					"172.17.0.1:38227",
+					"172.18.0.1:38227",
+					"172.19.0.1:38227",
+					"172.20.0.1:38227",
+					"172.21.0.1:38227",
+					"172.22.0.1:38227",
+					"172.23.0.1:38227",
+					"172.24.0.1:38227",
+					"172.25.0.1:38227",
+					"172.26.0.1:38227",
+					"172.27.0.1:38227",
+					"172.28.0.1:38227"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:22:18.625515705Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0909da237b2e808c61e8de74434b2b9d9aecb4ee43065089ece5204b6b9b5629",
+			"MachineKey": "mkey:c134290f2a766788c5eeef1c38dbd30b9102d76e12baddeacf94d7b815edf673",
+			"Peers": [{
+				"ID":         8143243316789368,
+				"StableID":   "n1mKgDC6b621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39f74a3cfcbcd2d85a0505acd7608c438d8b75f75bc73d973c69ffefca1d7b35",
+				"DiscoKey":   "discokey:b286192a70d77992ae5e2c3e46bf90bdcf13cbec61579caf2e3806f562ae5c30",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52300",
+					"10.65.0.27:52300",
+					"172.17.0.1:52300",
+					"172.18.0.1:52300",
+					"172.19.0.1:52300",
+					"172.20.0.1:52300",
+					"172.21.0.1:52300",
+					"172.22.0.1:52300",
+					"172.23.0.1:52300",
+					"172.24.0.1:52300",
+					"172.25.0.1:52300",
+					"172.26.0.1:52300",
+					"172.27.0.1:52300",
+					"172.28.0.1:52300"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:22:15.112140752Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         113860257757471,
+				"StableID":   "nCVk58vZt111CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2842a72c6a80f763919802b778551075f77872ad7370c9a2de933018cdf143a",
+				"DiscoKey":   "discokey:484ac995502db71932de00d90d5d0d156a7f026ca5364ef3dbe3ae81bafc1476",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33365",
+					"10.65.0.27:33365",
+					"172.17.0.1:33365",
+					"172.18.0.1:33365",
+					"172.19.0.1:33365",
+					"172.20.0.1:33365",
+					"172.21.0.1:33365",
+					"172.22.0.1:33365",
+					"172.23.0.1:33365",
+					"172.24.0.1:33365",
+					"172.25.0.1:33365",
+					"172.26.0.1:33365",
+					"172.27.0.1:33365",
+					"172.28.0.1:33365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:22:15.844852796Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8677184893301866,
+				"StableID":   "nVk3Q8wukA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0d962c6fb4822dd3f7d040f87a7cf03159c7e110abed635b06e5be1ea044a4b",
+				"DiscoKey":   "discokey:99083f7b395bb3d58c747b2924bf09cd845be26dd013e76cb8897949bded4378",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34443",
+					"10.65.0.27:34443",
+					"172.17.0.1:34443",
+					"172.18.0.1:34443",
+					"172.19.0.1:34443",
+					"172.20.0.1:34443",
+					"172.21.0.1:34443",
+					"172.22.0.1:34443",
+					"172.23.0.1:34443",
+					"172.24.0.1:34443",
+					"172.25.0.1:34443",
+					"172.26.0.1:34443",
+					"172.27.0.1:34443",
+					"172.28.0.1:34443"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:22:16.376358719Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5650061022717349,
+				"StableID":   "nesSrHXv7m11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7e2046717ee3fa271fb28b7c09fa35fcb67bbebf2c25495eff616e3ef30c079",
+				"DiscoKey":   "discokey:1ec584995763f070c9b9b759453ff4e2c4fedd6e5dcc2736bb30a081dafda228",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:54222",
+					"10.65.0.27:54222",
+					"172.17.0.1:54222",
+					"172.18.0.1:54222",
+					"172.19.0.1:54222",
+					"172.20.0.1:54222",
+					"172.21.0.1:54222",
+					"172.22.0.1:54222",
+					"172.23.0.1:54222",
+					"172.24.0.1:54222",
+					"172.25.0.1:54222",
+					"172.26.0.1:54222",
+					"172.27.0.1:54222",
+					"172.28.0.1:54222"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:22:16.91735265Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5333300322750175,
+				"StableID":   "nGhZVqkTei11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:04046ddc32a46ab98f6736d52022153d1f7925d49a894c69149f193f03fb8f4e",
+				"DiscoKey":   "discokey:04a4340cf2ab637b906d2ca8d7211a892219b154aced487018f475b0a673ca3b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42920",
+					"10.65.0.27:42920",
+					"172.17.0.1:42920",
+					"172.18.0.1:42920",
+					"172.19.0.1:42920",
+					"172.20.0.1:42920",
+					"172.21.0.1:42920",
+					"172.22.0.1:42920",
+					"172.23.0.1:42920",
+					"172.24.0.1:42920",
+					"172.25.0.1:42920",
+					"172.26.0.1:42920",
+					"172.27.0.1:42920",
+					"172.28.0.1:42920"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:22:17.457951971Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         185841476911834,
+				"StableID":   "nd4yvwjAT211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4238e5a1a2f60912dd33750eaba2e9ade234e967f531034c8a2815df697adb14",
+				"DiscoKey":   "discokey:54f707cb1a422b733807276e804ce659bada6eb39062823fe48a5d80b6df1b47",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58427",
+					"10.65.0.27:58427",
+					"172.17.0.1:58427",
+					"172.18.0.1:58427",
+					"172.19.0.1:58427",
+					"172.20.0.1:58427",
+					"172.21.0.1:58427",
+					"172.22.0.1:58427",
+					"172.23.0.1:58427",
+					"172.24.0.1:58427",
+					"172.25.0.1:58427",
+					"172.26.0.1:58427",
+					"172.27.0.1:58427",
+					"172.28.0.1:58427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:22:17.99921398Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6552951513903457,
+				"StableID":   "ntApkcvqAt11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:931685473e4f205d62413ac4d2c3ebcf8458908f94f8eb83c4775c87a115ad17",
+				"DiscoKey":   "discokey:bc9c50ba82975f34422b2beb098bf1de48b763f778361a0252ffd5220a0f7403",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55202",
+					"10.65.0.27:55202",
+					"172.17.0.1:55202",
+					"172.18.0.1:55202",
+					"172.19.0.1:55202",
+					"172.20.0.1:55202",
+					"172.21.0.1:55202",
+					"172.22.0.1:55202",
+					"172.23.0.1:55202",
+					"172.24.0.1:55202",
+					"172.25.0.1:55202",
+					"172.26.0.1:55202",
+					"172.27.0.1:55202",
+					"172.28.0.1:55202"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:22:19.337487583Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         270807153993723,
+				"StableID":   "nkm3sPee7311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87c7f40fb532366935ad5214207388a29031d359001b49634cc910f135465f6d",
+				"DiscoKey":   "discokey:501b1dad6def0edb6ba5a26e86ca442aa8a2151e84fceea8132f51fb2d1e956e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44002",
+					"10.65.0.27:44002",
+					"172.17.0.1:44002",
+					"172.18.0.1:44002",
+					"172.19.0.1:44002",
+					"172.20.0.1:44002",
+					"172.21.0.1:44002",
+					"172.22.0.1:44002",
+					"172.23.0.1:44002",
+					"172.24.0.1:44002",
+					"172.25.0.1:44002",
+					"172.26.0.1:44002",
+					"172.27.0.1:44002",
+					"172.28.0.1:44002"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:22:19.865837519Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6705106736621230,
+				"StableID":   "n1pqkUnkMu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6a64002270eca2ff6d91bc9adda789c18c32581d805ba41c1d548b4675348229",
+				"DiscoKey":   "discokey:35cf0dffa25ba0e1150a8ef1336210509b79e4a6618b4dc5c12f327147d8d55a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53680",
+					"10.65.0.27:53680",
+					"172.17.0.1:53680",
+					"172.18.0.1:53680",
+					"172.19.0.1:53680",
+					"172.20.0.1:53680",
+					"172.21.0.1:53680",
+					"172.22.0.1:53680",
+					"172.23.0.1:53680",
+					"172.24.0.1:53680",
+					"172.25.0.1:53680",
+					"172.26.0.1:53680",
+					"172.27.0.1:53680",
+					"172.28.0.1:53680"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:22:20.398552469Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7667948310719536,
+				"StableID":   "nPYeZyzps221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0ce1ba6d4cbbcf9decf7a9f01ad378411022ffd5e9eef94809593172fa1af69",
+				"DiscoKey":   "discokey:995e138a0bc7c2d6a53c165e23b474940593333d62d90528cee068a4e18a2b0e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56289",
+					"10.65.0.27:56289",
+					"172.17.0.1:56289",
+					"172.18.0.1:56289",
+					"172.19.0.1:56289",
+					"172.20.0.1:56289",
+					"172.21.0.1:56289",
+					"172.22.0.1:56289",
+					"172.23.0.1:56289",
+					"172.24.0.1:56289",
+					"172.25.0.1:56289",
+					"172.26.0.1:56289",
+					"172.27.0.1:56289",
+					"172.28.0.1:56289"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:22:20.937449274Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7000699690251896,
+				"StableID":   "nVMkrZWdfw11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1af67b633fce2aa5dd3d1c22557a42939a55de468eee10b89c0e3f3d8a7f1f08",
+				"DiscoKey":   "discokey:ca263f641228d82e7ba561ce1fdc498a4ac6b7a9d1bf1ab6e3b56f0b22abb818",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35249",
+					"10.65.0.27:35249",
+					"172.17.0.1:35249",
+					"172.18.0.1:35249",
+					"172.19.0.1:35249",
+					"172.20.0.1:35249",
+					"172.21.0.1:35249",
+					"172.22.0.1:35249",
+					"172.23.0.1:35249",
+					"172.24.0.1:35249",
+					"172.25.0.1:35249",
+					"172.26.0.1:35249",
+					"172.27.0.1:35249",
+					"172.28.0.1:35249"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:22:21.464954476Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4284797806903681,
+				"StableID":   "n2dXbcNbTa11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a7a8458270cc82b0625a3ebd79c3e5af5e040c4219deba360979d91f965a6476",
+				"KeyExpiry":  "2026-11-09T09:22:21Z",
+				"DiscoKey":   "discokey:9616211d17ab9697e7fa55165294efc168d482ee06724751e93efbeed324fd76",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50158",
+					"10.65.0.27:50158",
+					"172.17.0.1:50158",
+					"172.18.0.1:50158",
+					"172.19.0.1:50158",
+					"172.20.0.1:50158",
+					"172.21.0.1:50158",
+					"172.22.0.1:50158",
+					"172.23.0.1:50158",
+					"172.24.0.1:50158",
+					"172.25.0.1:50158",
+					"172.26.0.1:50158",
+					"172.27.0.1:50158",
+					"172.28.0.1:50158"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:22:21.988373309Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6444602222931293,
+				"StableID":   "ntkLwnmmKs11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b654ef19ce6bebdfc6c755e04f8696d3bed3d99477bd5f05716627c739453476",
+				"KeyExpiry":  "2026-11-09T09:22:22Z",
+				"DiscoKey":   "discokey:afb4f3c13a03175eb745bc3dc0ee942c876b1e75571d99756f7af5701a4dc06b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50042",
+					"10.65.0.27:50042",
+					"172.17.0.1:50042",
+					"172.18.0.1:50042",
+					"172.19.0.1:50042",
+					"172.20.0.1:50042",
+					"172.21.0.1:50042",
+					"172.22.0.1:50042",
+					"172.23.0.1:50042",
+					"172.24.0.1:50042",
+					"172.25.0.1:50042",
+					"172.26.0.1:50042",
+					"172.27.0.1:50042",
+					"172.28.0.1:50042"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:22:22.530433778Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5578350789120784,
+				"StableID":   "nqd35LpSZk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1f50fdcd08b5a717d0aec4e3b425a7e9a16c73233d894e71323c69ea2a7e2e1b",
+				"KeyExpiry":  "2026-11-09T09:22:23Z",
+				"DiscoKey":   "discokey:a6853978df9b5a349793b1a03dbdf09ba43ae156e43dd71f0042377af70b9b7c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49037",
+					"10.65.0.27:49037",
+					"172.17.0.1:49037",
+					"172.18.0.1:49037",
+					"172.19.0.1:49037",
+					"172.20.0.1:49037",
+					"172.21.0.1:49037",
+					"172.22.0.1:49037",
+					"172.23.0.1:49037",
+					"172.24.0.1:49037",
+					"172.25.0.1:49037",
+					"172.26.0.1:49037",
+					"172.27.0.1:49037",
+					"172.28.0.1:49037"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:22:23.062857052Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7323377596879331": {
+				"ID":          7323377596879331,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         270807153993723,
+				"StableID":   "nkm3sPee7311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       270807153993723,
+				"Key":        "nodekey:87c7f40fb532366935ad5214207388a29031d359001b49634cc910f135465f6d",
+				"DiscoKey":   "discokey:501b1dad6def0edb6ba5a26e86ca442aa8a2151e84fceea8132f51fb2d1e956e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44002",
+					"10.65.0.27:44002",
+					"172.17.0.1:44002",
+					"172.18.0.1:44002",
+					"172.19.0.1:44002",
+					"172.20.0.1:44002",
+					"172.21.0.1:44002",
+					"172.22.0.1:44002",
+					"172.23.0.1:44002",
+					"172.24.0.1:44002",
+					"172.25.0.1:44002",
+					"172.26.0.1:44002",
+					"172.27.0.1:44002",
+					"172.28.0.1:44002"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:22:19.865837519Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:87c7f40fb532366935ad5214207388a29031d359001b49634cc910f135465f6d",
+			"MachineKey": "mkey:a33e13c079a2082fc643cb298aa84139c100975f7e13c823d464ae67b5eb7d2c",
+			"Peers": [{
+				"ID":         8143243316789368,
+				"StableID":   "n1mKgDC6b621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39f74a3cfcbcd2d85a0505acd7608c438d8b75f75bc73d973c69ffefca1d7b35",
+				"DiscoKey":   "discokey:b286192a70d77992ae5e2c3e46bf90bdcf13cbec61579caf2e3806f562ae5c30",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52300",
+					"10.65.0.27:52300",
+					"172.17.0.1:52300",
+					"172.18.0.1:52300",
+					"172.19.0.1:52300",
+					"172.20.0.1:52300",
+					"172.21.0.1:52300",
+					"172.22.0.1:52300",
+					"172.23.0.1:52300",
+					"172.24.0.1:52300",
+					"172.25.0.1:52300",
+					"172.26.0.1:52300",
+					"172.27.0.1:52300",
+					"172.28.0.1:52300"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:22:15.112140752Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         113860257757471,
+				"StableID":   "nCVk58vZt111CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2842a72c6a80f763919802b778551075f77872ad7370c9a2de933018cdf143a",
+				"DiscoKey":   "discokey:484ac995502db71932de00d90d5d0d156a7f026ca5364ef3dbe3ae81bafc1476",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33365",
+					"10.65.0.27:33365",
+					"172.17.0.1:33365",
+					"172.18.0.1:33365",
+					"172.19.0.1:33365",
+					"172.20.0.1:33365",
+					"172.21.0.1:33365",
+					"172.22.0.1:33365",
+					"172.23.0.1:33365",
+					"172.24.0.1:33365",
+					"172.25.0.1:33365",
+					"172.26.0.1:33365",
+					"172.27.0.1:33365",
+					"172.28.0.1:33365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:22:15.844852796Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8677184893301866,
+				"StableID":   "nVk3Q8wukA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0d962c6fb4822dd3f7d040f87a7cf03159c7e110abed635b06e5be1ea044a4b",
+				"DiscoKey":   "discokey:99083f7b395bb3d58c747b2924bf09cd845be26dd013e76cb8897949bded4378",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34443",
+					"10.65.0.27:34443",
+					"172.17.0.1:34443",
+					"172.18.0.1:34443",
+					"172.19.0.1:34443",
+					"172.20.0.1:34443",
+					"172.21.0.1:34443",
+					"172.22.0.1:34443",
+					"172.23.0.1:34443",
+					"172.24.0.1:34443",
+					"172.25.0.1:34443",
+					"172.26.0.1:34443",
+					"172.27.0.1:34443",
+					"172.28.0.1:34443"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:22:16.376358719Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5650061022717349,
+				"StableID":   "nesSrHXv7m11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7e2046717ee3fa271fb28b7c09fa35fcb67bbebf2c25495eff616e3ef30c079",
+				"DiscoKey":   "discokey:1ec584995763f070c9b9b759453ff4e2c4fedd6e5dcc2736bb30a081dafda228",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:54222",
+					"10.65.0.27:54222",
+					"172.17.0.1:54222",
+					"172.18.0.1:54222",
+					"172.19.0.1:54222",
+					"172.20.0.1:54222",
+					"172.21.0.1:54222",
+					"172.22.0.1:54222",
+					"172.23.0.1:54222",
+					"172.24.0.1:54222",
+					"172.25.0.1:54222",
+					"172.26.0.1:54222",
+					"172.27.0.1:54222",
+					"172.28.0.1:54222"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:22:16.91735265Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5333300322750175,
+				"StableID":   "nGhZVqkTei11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:04046ddc32a46ab98f6736d52022153d1f7925d49a894c69149f193f03fb8f4e",
+				"DiscoKey":   "discokey:04a4340cf2ab637b906d2ca8d7211a892219b154aced487018f475b0a673ca3b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42920",
+					"10.65.0.27:42920",
+					"172.17.0.1:42920",
+					"172.18.0.1:42920",
+					"172.19.0.1:42920",
+					"172.20.0.1:42920",
+					"172.21.0.1:42920",
+					"172.22.0.1:42920",
+					"172.23.0.1:42920",
+					"172.24.0.1:42920",
+					"172.25.0.1:42920",
+					"172.26.0.1:42920",
+					"172.27.0.1:42920",
+					"172.28.0.1:42920"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:22:17.457951971Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         185841476911834,
+				"StableID":   "nd4yvwjAT211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4238e5a1a2f60912dd33750eaba2e9ade234e967f531034c8a2815df697adb14",
+				"DiscoKey":   "discokey:54f707cb1a422b733807276e804ce659bada6eb39062823fe48a5d80b6df1b47",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58427",
+					"10.65.0.27:58427",
+					"172.17.0.1:58427",
+					"172.18.0.1:58427",
+					"172.19.0.1:58427",
+					"172.20.0.1:58427",
+					"172.21.0.1:58427",
+					"172.22.0.1:58427",
+					"172.23.0.1:58427",
+					"172.24.0.1:58427",
+					"172.25.0.1:58427",
+					"172.26.0.1:58427",
+					"172.27.0.1:58427",
+					"172.28.0.1:58427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:22:17.99921398Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7323377596879331,
+				"StableID":   "n8FTWFimBz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0909da237b2e808c61e8de74434b2b9d9aecb4ee43065089ece5204b6b9b5629",
+				"DiscoKey":   "discokey:a32b59e0d33e2ded107b39b22960633cdd1f0abc18f36f57d5e21c7640a93149",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38227",
+					"10.65.0.27:38227",
+					"172.17.0.1:38227",
+					"172.18.0.1:38227",
+					"172.19.0.1:38227",
+					"172.20.0.1:38227",
+					"172.21.0.1:38227",
+					"172.22.0.1:38227",
+					"172.23.0.1:38227",
+					"172.24.0.1:38227",
+					"172.25.0.1:38227",
+					"172.26.0.1:38227",
+					"172.27.0.1:38227",
+					"172.28.0.1:38227"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:22:18.625515705Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6552951513903457,
+				"StableID":   "ntApkcvqAt11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:931685473e4f205d62413ac4d2c3ebcf8458908f94f8eb83c4775c87a115ad17",
+				"DiscoKey":   "discokey:bc9c50ba82975f34422b2beb098bf1de48b763f778361a0252ffd5220a0f7403",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55202",
+					"10.65.0.27:55202",
+					"172.17.0.1:55202",
+					"172.18.0.1:55202",
+					"172.19.0.1:55202",
+					"172.20.0.1:55202",
+					"172.21.0.1:55202",
+					"172.22.0.1:55202",
+					"172.23.0.1:55202",
+					"172.24.0.1:55202",
+					"172.25.0.1:55202",
+					"172.26.0.1:55202",
+					"172.27.0.1:55202",
+					"172.28.0.1:55202"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:22:19.337487583Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6705106736621230,
+				"StableID":   "n1pqkUnkMu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6a64002270eca2ff6d91bc9adda789c18c32581d805ba41c1d548b4675348229",
+				"DiscoKey":   "discokey:35cf0dffa25ba0e1150a8ef1336210509b79e4a6618b4dc5c12f327147d8d55a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53680",
+					"10.65.0.27:53680",
+					"172.17.0.1:53680",
+					"172.18.0.1:53680",
+					"172.19.0.1:53680",
+					"172.20.0.1:53680",
+					"172.21.0.1:53680",
+					"172.22.0.1:53680",
+					"172.23.0.1:53680",
+					"172.24.0.1:53680",
+					"172.25.0.1:53680",
+					"172.26.0.1:53680",
+					"172.27.0.1:53680",
+					"172.28.0.1:53680"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:22:20.398552469Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7667948310719536,
+				"StableID":   "nPYeZyzps221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0ce1ba6d4cbbcf9decf7a9f01ad378411022ffd5e9eef94809593172fa1af69",
+				"DiscoKey":   "discokey:995e138a0bc7c2d6a53c165e23b474940593333d62d90528cee068a4e18a2b0e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56289",
+					"10.65.0.27:56289",
+					"172.17.0.1:56289",
+					"172.18.0.1:56289",
+					"172.19.0.1:56289",
+					"172.20.0.1:56289",
+					"172.21.0.1:56289",
+					"172.22.0.1:56289",
+					"172.23.0.1:56289",
+					"172.24.0.1:56289",
+					"172.25.0.1:56289",
+					"172.26.0.1:56289",
+					"172.27.0.1:56289",
+					"172.28.0.1:56289"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:22:20.937449274Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7000699690251896,
+				"StableID":   "nVMkrZWdfw11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1af67b633fce2aa5dd3d1c22557a42939a55de468eee10b89c0e3f3d8a7f1f08",
+				"DiscoKey":   "discokey:ca263f641228d82e7ba561ce1fdc498a4ac6b7a9d1bf1ab6e3b56f0b22abb818",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35249",
+					"10.65.0.27:35249",
+					"172.17.0.1:35249",
+					"172.18.0.1:35249",
+					"172.19.0.1:35249",
+					"172.20.0.1:35249",
+					"172.21.0.1:35249",
+					"172.22.0.1:35249",
+					"172.23.0.1:35249",
+					"172.24.0.1:35249",
+					"172.25.0.1:35249",
+					"172.26.0.1:35249",
+					"172.27.0.1:35249",
+					"172.28.0.1:35249"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:22:21.464954476Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4284797806903681,
+				"StableID":   "n2dXbcNbTa11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a7a8458270cc82b0625a3ebd79c3e5af5e040c4219deba360979d91f965a6476",
+				"KeyExpiry":  "2026-11-09T09:22:21Z",
+				"DiscoKey":   "discokey:9616211d17ab9697e7fa55165294efc168d482ee06724751e93efbeed324fd76",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50158",
+					"10.65.0.27:50158",
+					"172.17.0.1:50158",
+					"172.18.0.1:50158",
+					"172.19.0.1:50158",
+					"172.20.0.1:50158",
+					"172.21.0.1:50158",
+					"172.22.0.1:50158",
+					"172.23.0.1:50158",
+					"172.24.0.1:50158",
+					"172.25.0.1:50158",
+					"172.26.0.1:50158",
+					"172.27.0.1:50158",
+					"172.28.0.1:50158"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:22:21.988373309Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6444602222931293,
+				"StableID":   "ntkLwnmmKs11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b654ef19ce6bebdfc6c755e04f8696d3bed3d99477bd5f05716627c739453476",
+				"KeyExpiry":  "2026-11-09T09:22:22Z",
+				"DiscoKey":   "discokey:afb4f3c13a03175eb745bc3dc0ee942c876b1e75571d99756f7af5701a4dc06b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50042",
+					"10.65.0.27:50042",
+					"172.17.0.1:50042",
+					"172.18.0.1:50042",
+					"172.19.0.1:50042",
+					"172.20.0.1:50042",
+					"172.21.0.1:50042",
+					"172.22.0.1:50042",
+					"172.23.0.1:50042",
+					"172.24.0.1:50042",
+					"172.25.0.1:50042",
+					"172.26.0.1:50042",
+					"172.27.0.1:50042",
+					"172.28.0.1:50042"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:22:22.530433778Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5578350789120784,
+				"StableID":   "nqd35LpSZk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1f50fdcd08b5a717d0aec4e3b425a7e9a16c73233d894e71323c69ea2a7e2e1b",
+				"KeyExpiry":  "2026-11-09T09:22:23Z",
+				"DiscoKey":   "discokey:a6853978df9b5a349793b1a03dbdf09ba43ae156e43dd71f0042377af70b9b7c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49037",
+					"10.65.0.27:49037",
+					"172.17.0.1:49037",
+					"172.18.0.1:49037",
+					"172.19.0.1:49037",
+					"172.20.0.1:49037",
+					"172.21.0.1:49037",
+					"172.22.0.1:49037",
+					"172.23.0.1:49037",
+					"172.24.0.1:49037",
+					"172.25.0.1:49037",
+					"172.26.0.1:49037",
+					"172.27.0.1:49037",
+					"172.28.0.1:49037"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:22:23.062857052Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "270807153993723": {
+				"ID":          270807153993723,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6444602222931293,
+				"StableID":   "ntkLwnmmKs11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b654ef19ce6bebdfc6c755e04f8696d3bed3d99477bd5f05716627c739453476",
+				"KeyExpiry":  "2026-11-09T09:22:22Z",
+				"DiscoKey":   "discokey:afb4f3c13a03175eb745bc3dc0ee942c876b1e75571d99756f7af5701a4dc06b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50042",
+					"10.65.0.27:50042",
+					"172.17.0.1:50042",
+					"172.18.0.1:50042",
+					"172.19.0.1:50042",
+					"172.20.0.1:50042",
+					"172.21.0.1:50042",
+					"172.22.0.1:50042",
+					"172.23.0.1:50042",
+					"172.24.0.1:50042",
+					"172.25.0.1:50042",
+					"172.26.0.1:50042",
+					"172.27.0.1:50042",
+					"172.28.0.1:50042"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:22:22.530433778Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b654ef19ce6bebdfc6c755e04f8696d3bed3d99477bd5f05716627c739453476",
+			"MachineKey": "mkey:64c77aabfaf4fc7419f98e25e1ae065ee6f4dbe0a7399aa6605dcac91c1a202d",
+			"Peers": [{
+				"ID":         8143243316789368,
+				"StableID":   "n1mKgDC6b621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39f74a3cfcbcd2d85a0505acd7608c438d8b75f75bc73d973c69ffefca1d7b35",
+				"DiscoKey":   "discokey:b286192a70d77992ae5e2c3e46bf90bdcf13cbec61579caf2e3806f562ae5c30",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52300",
+					"10.65.0.27:52300",
+					"172.17.0.1:52300",
+					"172.18.0.1:52300",
+					"172.19.0.1:52300",
+					"172.20.0.1:52300",
+					"172.21.0.1:52300",
+					"172.22.0.1:52300",
+					"172.23.0.1:52300",
+					"172.24.0.1:52300",
+					"172.25.0.1:52300",
+					"172.26.0.1:52300",
+					"172.27.0.1:52300",
+					"172.28.0.1:52300"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:22:15.112140752Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         113860257757471,
+				"StableID":   "nCVk58vZt111CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2842a72c6a80f763919802b778551075f77872ad7370c9a2de933018cdf143a",
+				"DiscoKey":   "discokey:484ac995502db71932de00d90d5d0d156a7f026ca5364ef3dbe3ae81bafc1476",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33365",
+					"10.65.0.27:33365",
+					"172.17.0.1:33365",
+					"172.18.0.1:33365",
+					"172.19.0.1:33365",
+					"172.20.0.1:33365",
+					"172.21.0.1:33365",
+					"172.22.0.1:33365",
+					"172.23.0.1:33365",
+					"172.24.0.1:33365",
+					"172.25.0.1:33365",
+					"172.26.0.1:33365",
+					"172.27.0.1:33365",
+					"172.28.0.1:33365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:22:15.844852796Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8677184893301866,
+				"StableID":   "nVk3Q8wukA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0d962c6fb4822dd3f7d040f87a7cf03159c7e110abed635b06e5be1ea044a4b",
+				"DiscoKey":   "discokey:99083f7b395bb3d58c747b2924bf09cd845be26dd013e76cb8897949bded4378",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34443",
+					"10.65.0.27:34443",
+					"172.17.0.1:34443",
+					"172.18.0.1:34443",
+					"172.19.0.1:34443",
+					"172.20.0.1:34443",
+					"172.21.0.1:34443",
+					"172.22.0.1:34443",
+					"172.23.0.1:34443",
+					"172.24.0.1:34443",
+					"172.25.0.1:34443",
+					"172.26.0.1:34443",
+					"172.27.0.1:34443",
+					"172.28.0.1:34443"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:22:16.376358719Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5650061022717349,
+				"StableID":   "nesSrHXv7m11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7e2046717ee3fa271fb28b7c09fa35fcb67bbebf2c25495eff616e3ef30c079",
+				"DiscoKey":   "discokey:1ec584995763f070c9b9b759453ff4e2c4fedd6e5dcc2736bb30a081dafda228",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:54222",
+					"10.65.0.27:54222",
+					"172.17.0.1:54222",
+					"172.18.0.1:54222",
+					"172.19.0.1:54222",
+					"172.20.0.1:54222",
+					"172.21.0.1:54222",
+					"172.22.0.1:54222",
+					"172.23.0.1:54222",
+					"172.24.0.1:54222",
+					"172.25.0.1:54222",
+					"172.26.0.1:54222",
+					"172.27.0.1:54222",
+					"172.28.0.1:54222"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:22:16.91735265Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5333300322750175,
+				"StableID":   "nGhZVqkTei11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:04046ddc32a46ab98f6736d52022153d1f7925d49a894c69149f193f03fb8f4e",
+				"DiscoKey":   "discokey:04a4340cf2ab637b906d2ca8d7211a892219b154aced487018f475b0a673ca3b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42920",
+					"10.65.0.27:42920",
+					"172.17.0.1:42920",
+					"172.18.0.1:42920",
+					"172.19.0.1:42920",
+					"172.20.0.1:42920",
+					"172.21.0.1:42920",
+					"172.22.0.1:42920",
+					"172.23.0.1:42920",
+					"172.24.0.1:42920",
+					"172.25.0.1:42920",
+					"172.26.0.1:42920",
+					"172.27.0.1:42920",
+					"172.28.0.1:42920"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:22:17.457951971Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         185841476911834,
+				"StableID":   "nd4yvwjAT211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4238e5a1a2f60912dd33750eaba2e9ade234e967f531034c8a2815df697adb14",
+				"DiscoKey":   "discokey:54f707cb1a422b733807276e804ce659bada6eb39062823fe48a5d80b6df1b47",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58427",
+					"10.65.0.27:58427",
+					"172.17.0.1:58427",
+					"172.18.0.1:58427",
+					"172.19.0.1:58427",
+					"172.20.0.1:58427",
+					"172.21.0.1:58427",
+					"172.22.0.1:58427",
+					"172.23.0.1:58427",
+					"172.24.0.1:58427",
+					"172.25.0.1:58427",
+					"172.26.0.1:58427",
+					"172.27.0.1:58427",
+					"172.28.0.1:58427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:22:17.99921398Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7323377596879331,
+				"StableID":   "n8FTWFimBz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0909da237b2e808c61e8de74434b2b9d9aecb4ee43065089ece5204b6b9b5629",
+				"DiscoKey":   "discokey:a32b59e0d33e2ded107b39b22960633cdd1f0abc18f36f57d5e21c7640a93149",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38227",
+					"10.65.0.27:38227",
+					"172.17.0.1:38227",
+					"172.18.0.1:38227",
+					"172.19.0.1:38227",
+					"172.20.0.1:38227",
+					"172.21.0.1:38227",
+					"172.22.0.1:38227",
+					"172.23.0.1:38227",
+					"172.24.0.1:38227",
+					"172.25.0.1:38227",
+					"172.26.0.1:38227",
+					"172.27.0.1:38227",
+					"172.28.0.1:38227"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:22:18.625515705Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6552951513903457,
+				"StableID":   "ntApkcvqAt11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:931685473e4f205d62413ac4d2c3ebcf8458908f94f8eb83c4775c87a115ad17",
+				"DiscoKey":   "discokey:bc9c50ba82975f34422b2beb098bf1de48b763f778361a0252ffd5220a0f7403",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55202",
+					"10.65.0.27:55202",
+					"172.17.0.1:55202",
+					"172.18.0.1:55202",
+					"172.19.0.1:55202",
+					"172.20.0.1:55202",
+					"172.21.0.1:55202",
+					"172.22.0.1:55202",
+					"172.23.0.1:55202",
+					"172.24.0.1:55202",
+					"172.25.0.1:55202",
+					"172.26.0.1:55202",
+					"172.27.0.1:55202",
+					"172.28.0.1:55202"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:22:19.337487583Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         270807153993723,
+				"StableID":   "nkm3sPee7311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87c7f40fb532366935ad5214207388a29031d359001b49634cc910f135465f6d",
+				"DiscoKey":   "discokey:501b1dad6def0edb6ba5a26e86ca442aa8a2151e84fceea8132f51fb2d1e956e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44002",
+					"10.65.0.27:44002",
+					"172.17.0.1:44002",
+					"172.18.0.1:44002",
+					"172.19.0.1:44002",
+					"172.20.0.1:44002",
+					"172.21.0.1:44002",
+					"172.22.0.1:44002",
+					"172.23.0.1:44002",
+					"172.24.0.1:44002",
+					"172.25.0.1:44002",
+					"172.26.0.1:44002",
+					"172.27.0.1:44002",
+					"172.28.0.1:44002"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:22:19.865837519Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6705106736621230,
+				"StableID":   "n1pqkUnkMu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6a64002270eca2ff6d91bc9adda789c18c32581d805ba41c1d548b4675348229",
+				"DiscoKey":   "discokey:35cf0dffa25ba0e1150a8ef1336210509b79e4a6618b4dc5c12f327147d8d55a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53680",
+					"10.65.0.27:53680",
+					"172.17.0.1:53680",
+					"172.18.0.1:53680",
+					"172.19.0.1:53680",
+					"172.20.0.1:53680",
+					"172.21.0.1:53680",
+					"172.22.0.1:53680",
+					"172.23.0.1:53680",
+					"172.24.0.1:53680",
+					"172.25.0.1:53680",
+					"172.26.0.1:53680",
+					"172.27.0.1:53680",
+					"172.28.0.1:53680"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:22:20.398552469Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7667948310719536,
+				"StableID":   "nPYeZyzps221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0ce1ba6d4cbbcf9decf7a9f01ad378411022ffd5e9eef94809593172fa1af69",
+				"DiscoKey":   "discokey:995e138a0bc7c2d6a53c165e23b474940593333d62d90528cee068a4e18a2b0e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56289",
+					"10.65.0.27:56289",
+					"172.17.0.1:56289",
+					"172.18.0.1:56289",
+					"172.19.0.1:56289",
+					"172.20.0.1:56289",
+					"172.21.0.1:56289",
+					"172.22.0.1:56289",
+					"172.23.0.1:56289",
+					"172.24.0.1:56289",
+					"172.25.0.1:56289",
+					"172.26.0.1:56289",
+					"172.27.0.1:56289",
+					"172.28.0.1:56289"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:22:20.937449274Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7000699690251896,
+				"StableID":   "nVMkrZWdfw11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1af67b633fce2aa5dd3d1c22557a42939a55de468eee10b89c0e3f3d8a7f1f08",
+				"DiscoKey":   "discokey:ca263f641228d82e7ba561ce1fdc498a4ac6b7a9d1bf1ab6e3b56f0b22abb818",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35249",
+					"10.65.0.27:35249",
+					"172.17.0.1:35249",
+					"172.18.0.1:35249",
+					"172.19.0.1:35249",
+					"172.20.0.1:35249",
+					"172.21.0.1:35249",
+					"172.22.0.1:35249",
+					"172.23.0.1:35249",
+					"172.24.0.1:35249",
+					"172.25.0.1:35249",
+					"172.26.0.1:35249",
+					"172.27.0.1:35249",
+					"172.28.0.1:35249"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:22:21.464954476Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4284797806903681,
+				"StableID":   "n2dXbcNbTa11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a7a8458270cc82b0625a3ebd79c3e5af5e040c4219deba360979d91f965a6476",
+				"KeyExpiry":  "2026-11-09T09:22:21Z",
+				"DiscoKey":   "discokey:9616211d17ab9697e7fa55165294efc168d482ee06724751e93efbeed324fd76",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50158",
+					"10.65.0.27:50158",
+					"172.17.0.1:50158",
+					"172.18.0.1:50158",
+					"172.19.0.1:50158",
+					"172.20.0.1:50158",
+					"172.21.0.1:50158",
+					"172.22.0.1:50158",
+					"172.23.0.1:50158",
+					"172.24.0.1:50158",
+					"172.25.0.1:50158",
+					"172.26.0.1:50158",
+					"172.27.0.1:50158",
+					"172.28.0.1:50158"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:22:21.988373309Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5578350789120784,
+				"StableID":   "nqd35LpSZk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1f50fdcd08b5a717d0aec4e3b425a7e9a16c73233d894e71323c69ea2a7e2e1b",
+				"KeyExpiry":  "2026-11-09T09:22:23Z",
+				"DiscoKey":   "discokey:a6853978df9b5a349793b1a03dbdf09ba43ae156e43dd71f0042377af70b9b7c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49037",
+					"10.65.0.27:49037",
+					"172.17.0.1:49037",
+					"172.18.0.1:49037",
+					"172.19.0.1:49037",
+					"172.20.0.1:49037",
+					"172.21.0.1:49037",
+					"172.22.0.1:49037",
+					"172.23.0.1:49037",
+					"172.24.0.1:49037",
+					"172.25.0.1:49037",
+					"172.26.0.1:49037",
+					"172.27.0.1:49037",
+					"172.28.0.1:49037"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:22:23.062857052Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6705106736621230,
+				"StableID":   "n1pqkUnkMu11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       6705106736621230,
+				"Key":        "nodekey:6a64002270eca2ff6d91bc9adda789c18c32581d805ba41c1d548b4675348229",
+				"DiscoKey":   "discokey:35cf0dffa25ba0e1150a8ef1336210509b79e4a6618b4dc5c12f327147d8d55a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53680",
+					"10.65.0.27:53680",
+					"172.17.0.1:53680",
+					"172.18.0.1:53680",
+					"172.19.0.1:53680",
+					"172.20.0.1:53680",
+					"172.21.0.1:53680",
+					"172.22.0.1:53680",
+					"172.23.0.1:53680",
+					"172.24.0.1:53680",
+					"172.25.0.1:53680",
+					"172.26.0.1:53680",
+					"172.27.0.1:53680",
+					"172.28.0.1:53680"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:22:20.398552469Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6a64002270eca2ff6d91bc9adda789c18c32581d805ba41c1d548b4675348229",
+			"MachineKey": "mkey:5b3e374b47fb3477899edd0fab6787a0ff49e0baf1aa866bf324267e23e9291c",
+			"Peers": [{
+				"ID":         8143243316789368,
+				"StableID":   "n1mKgDC6b621CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39f74a3cfcbcd2d85a0505acd7608c438d8b75f75bc73d973c69ffefca1d7b35",
+				"DiscoKey":   "discokey:b286192a70d77992ae5e2c3e46bf90bdcf13cbec61579caf2e3806f562ae5c30",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:52300",
+					"10.65.0.27:52300",
+					"172.17.0.1:52300",
+					"172.18.0.1:52300",
+					"172.19.0.1:52300",
+					"172.20.0.1:52300",
+					"172.21.0.1:52300",
+					"172.22.0.1:52300",
+					"172.23.0.1:52300",
+					"172.24.0.1:52300",
+					"172.25.0.1:52300",
+					"172.26.0.1:52300",
+					"172.27.0.1:52300",
+					"172.28.0.1:52300"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:22:15.112140752Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         113860257757471,
+				"StableID":   "nCVk58vZt111CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2842a72c6a80f763919802b778551075f77872ad7370c9a2de933018cdf143a",
+				"DiscoKey":   "discokey:484ac995502db71932de00d90d5d0d156a7f026ca5364ef3dbe3ae81bafc1476",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33365",
+					"10.65.0.27:33365",
+					"172.17.0.1:33365",
+					"172.18.0.1:33365",
+					"172.19.0.1:33365",
+					"172.20.0.1:33365",
+					"172.21.0.1:33365",
+					"172.22.0.1:33365",
+					"172.23.0.1:33365",
+					"172.24.0.1:33365",
+					"172.25.0.1:33365",
+					"172.26.0.1:33365",
+					"172.27.0.1:33365",
+					"172.28.0.1:33365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:22:15.844852796Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8677184893301866,
+				"StableID":   "nVk3Q8wukA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0d962c6fb4822dd3f7d040f87a7cf03159c7e110abed635b06e5be1ea044a4b",
+				"DiscoKey":   "discokey:99083f7b395bb3d58c747b2924bf09cd845be26dd013e76cb8897949bded4378",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34443",
+					"10.65.0.27:34443",
+					"172.17.0.1:34443",
+					"172.18.0.1:34443",
+					"172.19.0.1:34443",
+					"172.20.0.1:34443",
+					"172.21.0.1:34443",
+					"172.22.0.1:34443",
+					"172.23.0.1:34443",
+					"172.24.0.1:34443",
+					"172.25.0.1:34443",
+					"172.26.0.1:34443",
+					"172.27.0.1:34443",
+					"172.28.0.1:34443"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:22:16.376358719Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5650061022717349,
+				"StableID":   "nesSrHXv7m11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7e2046717ee3fa271fb28b7c09fa35fcb67bbebf2c25495eff616e3ef30c079",
+				"DiscoKey":   "discokey:1ec584995763f070c9b9b759453ff4e2c4fedd6e5dcc2736bb30a081dafda228",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:54222",
+					"10.65.0.27:54222",
+					"172.17.0.1:54222",
+					"172.18.0.1:54222",
+					"172.19.0.1:54222",
+					"172.20.0.1:54222",
+					"172.21.0.1:54222",
+					"172.22.0.1:54222",
+					"172.23.0.1:54222",
+					"172.24.0.1:54222",
+					"172.25.0.1:54222",
+					"172.26.0.1:54222",
+					"172.27.0.1:54222",
+					"172.28.0.1:54222"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:22:16.91735265Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5333300322750175,
+				"StableID":   "nGhZVqkTei11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:04046ddc32a46ab98f6736d52022153d1f7925d49a894c69149f193f03fb8f4e",
+				"DiscoKey":   "discokey:04a4340cf2ab637b906d2ca8d7211a892219b154aced487018f475b0a673ca3b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42920",
+					"10.65.0.27:42920",
+					"172.17.0.1:42920",
+					"172.18.0.1:42920",
+					"172.19.0.1:42920",
+					"172.20.0.1:42920",
+					"172.21.0.1:42920",
+					"172.22.0.1:42920",
+					"172.23.0.1:42920",
+					"172.24.0.1:42920",
+					"172.25.0.1:42920",
+					"172.26.0.1:42920",
+					"172.27.0.1:42920",
+					"172.28.0.1:42920"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:22:17.457951971Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         185841476911834,
+				"StableID":   "nd4yvwjAT211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4238e5a1a2f60912dd33750eaba2e9ade234e967f531034c8a2815df697adb14",
+				"DiscoKey":   "discokey:54f707cb1a422b733807276e804ce659bada6eb39062823fe48a5d80b6df1b47",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:58427",
+					"10.65.0.27:58427",
+					"172.17.0.1:58427",
+					"172.18.0.1:58427",
+					"172.19.0.1:58427",
+					"172.20.0.1:58427",
+					"172.21.0.1:58427",
+					"172.22.0.1:58427",
+					"172.23.0.1:58427",
+					"172.24.0.1:58427",
+					"172.25.0.1:58427",
+					"172.26.0.1:58427",
+					"172.27.0.1:58427",
+					"172.28.0.1:58427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:22:17.99921398Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7323377596879331,
+				"StableID":   "n8FTWFimBz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0909da237b2e808c61e8de74434b2b9d9aecb4ee43065089ece5204b6b9b5629",
+				"DiscoKey":   "discokey:a32b59e0d33e2ded107b39b22960633cdd1f0abc18f36f57d5e21c7640a93149",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38227",
+					"10.65.0.27:38227",
+					"172.17.0.1:38227",
+					"172.18.0.1:38227",
+					"172.19.0.1:38227",
+					"172.20.0.1:38227",
+					"172.21.0.1:38227",
+					"172.22.0.1:38227",
+					"172.23.0.1:38227",
+					"172.24.0.1:38227",
+					"172.25.0.1:38227",
+					"172.26.0.1:38227",
+					"172.27.0.1:38227",
+					"172.28.0.1:38227"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:22:18.625515705Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6552951513903457,
+				"StableID":   "ntApkcvqAt11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:931685473e4f205d62413ac4d2c3ebcf8458908f94f8eb83c4775c87a115ad17",
+				"DiscoKey":   "discokey:bc9c50ba82975f34422b2beb098bf1de48b763f778361a0252ffd5220a0f7403",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:55202",
+					"10.65.0.27:55202",
+					"172.17.0.1:55202",
+					"172.18.0.1:55202",
+					"172.19.0.1:55202",
+					"172.20.0.1:55202",
+					"172.21.0.1:55202",
+					"172.22.0.1:55202",
+					"172.23.0.1:55202",
+					"172.24.0.1:55202",
+					"172.25.0.1:55202",
+					"172.26.0.1:55202",
+					"172.27.0.1:55202",
+					"172.28.0.1:55202"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:22:19.337487583Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         270807153993723,
+				"StableID":   "nkm3sPee7311CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87c7f40fb532366935ad5214207388a29031d359001b49634cc910f135465f6d",
+				"DiscoKey":   "discokey:501b1dad6def0edb6ba5a26e86ca442aa8a2151e84fceea8132f51fb2d1e956e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44002",
+					"10.65.0.27:44002",
+					"172.17.0.1:44002",
+					"172.18.0.1:44002",
+					"172.19.0.1:44002",
+					"172.20.0.1:44002",
+					"172.21.0.1:44002",
+					"172.22.0.1:44002",
+					"172.23.0.1:44002",
+					"172.24.0.1:44002",
+					"172.25.0.1:44002",
+					"172.26.0.1:44002",
+					"172.27.0.1:44002",
+					"172.28.0.1:44002"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:22:19.865837519Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7667948310719536,
+				"StableID":   "nPYeZyzps221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d0ce1ba6d4cbbcf9decf7a9f01ad378411022ffd5e9eef94809593172fa1af69",
+				"DiscoKey":   "discokey:995e138a0bc7c2d6a53c165e23b474940593333d62d90528cee068a4e18a2b0e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:56289",
+					"10.65.0.27:56289",
+					"172.17.0.1:56289",
+					"172.18.0.1:56289",
+					"172.19.0.1:56289",
+					"172.20.0.1:56289",
+					"172.21.0.1:56289",
+					"172.22.0.1:56289",
+					"172.23.0.1:56289",
+					"172.24.0.1:56289",
+					"172.25.0.1:56289",
+					"172.26.0.1:56289",
+					"172.27.0.1:56289",
+					"172.28.0.1:56289"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:22:20.937449274Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7000699690251896,
+				"StableID":   "nVMkrZWdfw11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1af67b633fce2aa5dd3d1c22557a42939a55de468eee10b89c0e3f3d8a7f1f08",
+				"DiscoKey":   "discokey:ca263f641228d82e7ba561ce1fdc498a4ac6b7a9d1bf1ab6e3b56f0b22abb818",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35249",
+					"10.65.0.27:35249",
+					"172.17.0.1:35249",
+					"172.18.0.1:35249",
+					"172.19.0.1:35249",
+					"172.20.0.1:35249",
+					"172.21.0.1:35249",
+					"172.22.0.1:35249",
+					"172.23.0.1:35249",
+					"172.24.0.1:35249",
+					"172.25.0.1:35249",
+					"172.26.0.1:35249",
+					"172.27.0.1:35249",
+					"172.28.0.1:35249"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:22:21.464954476Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4284797806903681,
+				"StableID":   "n2dXbcNbTa11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a7a8458270cc82b0625a3ebd79c3e5af5e040c4219deba360979d91f965a6476",
+				"KeyExpiry":  "2026-11-09T09:22:21Z",
+				"DiscoKey":   "discokey:9616211d17ab9697e7fa55165294efc168d482ee06724751e93efbeed324fd76",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50158",
+					"10.65.0.27:50158",
+					"172.17.0.1:50158",
+					"172.18.0.1:50158",
+					"172.19.0.1:50158",
+					"172.20.0.1:50158",
+					"172.21.0.1:50158",
+					"172.22.0.1:50158",
+					"172.23.0.1:50158",
+					"172.24.0.1:50158",
+					"172.25.0.1:50158",
+					"172.26.0.1:50158",
+					"172.27.0.1:50158",
+					"172.28.0.1:50158"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:22:21.988373309Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6444602222931293,
+				"StableID":   "ntkLwnmmKs11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b654ef19ce6bebdfc6c755e04f8696d3bed3d99477bd5f05716627c739453476",
+				"KeyExpiry":  "2026-11-09T09:22:22Z",
+				"DiscoKey":   "discokey:afb4f3c13a03175eb745bc3dc0ee942c876b1e75571d99756f7af5701a4dc06b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50042",
+					"10.65.0.27:50042",
+					"172.17.0.1:50042",
+					"172.18.0.1:50042",
+					"172.19.0.1:50042",
+					"172.20.0.1:50042",
+					"172.21.0.1:50042",
+					"172.22.0.1:50042",
+					"172.23.0.1:50042",
+					"172.24.0.1:50042",
+					"172.25.0.1:50042",
+					"172.26.0.1:50042",
+					"172.27.0.1:50042",
+					"172.28.0.1:50042"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:22:22.530433778Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5578350789120784,
+				"StableID":   "nqd35LpSZk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:1f50fdcd08b5a717d0aec4e3b425a7e9a16c73233d894e71323c69ea2a7e2e1b",
+				"KeyExpiry":  "2026-11-09T09:22:23Z",
+				"DiscoKey":   "discokey:a6853978df9b5a349793b1a03dbdf09ba43ae156e43dd71f0042377af70b9b7c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:49037",
+					"10.65.0.27:49037",
+					"172.17.0.1:49037",
+					"172.18.0.1:49037",
+					"172.19.0.1:49037",
+					"172.20.0.1:49037",
+					"172.21.0.1:49037",
+					"172.22.0.1:49037",
+					"172.23.0.1:49037",
+					"172.24.0.1:49037",
+					"172.25.0.1:49037",
+					"172.26.0.1:49037",
+					"172.27.0.1:49037",
+					"172.28.0.1:49037"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:22:23.062857052Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6705106736621230": {
+				"ID":          6705106736621230,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-tab-in-user.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-tab-in-user.hujson
@@ -1,0 +1,22123 @@
+// ssh-tab-in-user
+//
+// ssh users contains TAB-prefixed root
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-13T09:23:08Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-tab-in-user",
+	"description":    "ssh users contains TAB-prefixed root",
+	"category":       "ssh",
+	"captured_at":    "2026-05-13T09:23:08.327706461Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                  \n  \n                                                                 \n                                                  \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh users contains TAB-prefixed root\",\n\t\"id\":          \"ssh-tab-in-user\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"thor@example.org\"],\n\t\t\"users\":  [\"\\troot\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-edges/ssh-tab-in-user.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["thor@example.org"],
+				"users":  ["\troot"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6890529266015242,
+				"StableID":   "njjGj8Xjov11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       6890529266015242,
+				"Key":        "nodekey:fa77ba1ae5462136c471ac93af15f5068029374a1cea5e4a38cf009a43c0363b",
+				"DiscoKey":   "discokey:50a6ae6716b1268e344eb542a019872f708b18a580cef5eaf74e3a291761cd13",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47165",
+					"10.65.0.27:47165",
+					"172.17.0.1:47165",
+					"172.18.0.1:47165",
+					"172.19.0.1:47165",
+					"172.20.0.1:47165",
+					"172.21.0.1:47165",
+					"172.22.0.1:47165",
+					"172.23.0.1:47165",
+					"172.24.0.1:47165",
+					"172.25.0.1:47165",
+					"172.26.0.1:47165",
+					"172.27.0.1:47165",
+					"172.28.0.1:47165"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:23:16.812549339Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:fa77ba1ae5462136c471ac93af15f5068029374a1cea5e4a38cf009a43c0363b",
+			"MachineKey": "mkey:a6db6410bf00a5bb2999e1a982b5ea8786fffd7b655de3bfca9f647f68ed2c3b",
+			"Peers": [{
+				"ID":         8673558682620626,
+				"StableID":   "n1WTaNgGjA21CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f00a22b63ecf5bc2688aba213366853cf5c120d6bac8738fbc5a706658fb23e",
+				"DiscoKey":   "discokey:56d85cc4c1ea85c5f209b585febfc4cc1c25e41fedc71a0a1f1f062aacd2a947",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35255",
+					"10.65.0.27:35255",
+					"172.17.0.1:35255",
+					"172.18.0.1:35255",
+					"172.19.0.1:35255",
+					"172.20.0.1:35255",
+					"172.21.0.1:35255",
+					"172.22.0.1:35255",
+					"172.23.0.1:35255",
+					"172.24.0.1:35255",
+					"172.25.0.1:35255",
+					"172.26.0.1:35255",
+					"172.27.0.1:35255",
+					"172.28.0.1:35255"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:23:10.945165275Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6650671549347752,
+				"StableID":   "nKrLf7s6wt11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ebc5c4959628162357c3f14e501c639a1154fdf39560ef130402725d30440727",
+				"DiscoKey":   "discokey:f7b1fbd9c6a742c4ebfbedaf3f878bd7979dad7c56ee5ac0c6d041dcb004b131",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39009",
+					"10.65.0.27:39009",
+					"172.17.0.1:39009",
+					"172.18.0.1:39009",
+					"172.19.0.1:39009",
+					"172.20.0.1:39009",
+					"172.21.0.1:39009",
+					"172.22.0.1:39009",
+					"172.23.0.1:39009",
+					"172.24.0.1:39009",
+					"172.25.0.1:39009",
+					"172.26.0.1:39009",
+					"172.27.0.1:39009",
+					"172.28.0.1:39009"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:23:11.41795637Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2244976255107421,
+				"StableID":   "nWF27jikXJ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e213578e1372213514a5bbf56f33e6d77ba8cc7d0d5c2f3e46c456d2f1badc74",
+				"DiscoKey":   "discokey:579e729d1cbfc797d173f11d5f46fc7ad83de9e9b283aeca2a49a9b7d98d777e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57102",
+					"10.65.0.27:57102",
+					"172.17.0.1:57102",
+					"172.18.0.1:57102",
+					"172.19.0.1:57102",
+					"172.20.0.1:57102",
+					"172.21.0.1:57102",
+					"172.22.0.1:57102",
+					"172.23.0.1:57102",
+					"172.24.0.1:57102",
+					"172.25.0.1:57102",
+					"172.26.0.1:57102",
+					"172.27.0.1:57102",
+					"172.28.0.1:57102"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:23:11.958807186Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6171263541698332,
+				"StableID":   "nyqUgTdyBq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2476445888a7ca1728e3a0079cd670cda161d965e846d0373587b3caf9332009",
+				"DiscoKey":   "discokey:051f68b19f9b4fe635977bacb1bfca1fc040739145365fe63dfc0a2a89605e65",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59814",
+					"10.65.0.27:59814",
+					"172.17.0.1:59814",
+					"172.18.0.1:59814",
+					"172.19.0.1:59814",
+					"172.20.0.1:59814",
+					"172.21.0.1:59814",
+					"172.22.0.1:59814",
+					"172.23.0.1:59814",
+					"172.24.0.1:59814",
+					"172.25.0.1:59814",
+					"172.26.0.1:59814",
+					"172.27.0.1:59814",
+					"172.28.0.1:59814"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:23:12.481223468Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1551577726279602,
+				"StableID":   "n1iVYKKi7D11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e2756e136ea21c6bba471c8eedc1b06e23d3057cd90791fdba9d597d5069278",
+				"DiscoKey":   "discokey:ff70c080835318aa43fe94f70fe48347c70516f329050e97b76af662e29c5061",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38162",
+					"10.65.0.27:38162",
+					"172.17.0.1:38162",
+					"172.18.0.1:38162",
+					"172.19.0.1:38162",
+					"172.20.0.1:38162",
+					"172.21.0.1:38162",
+					"172.22.0.1:38162",
+					"172.23.0.1:38162",
+					"172.24.0.1:38162",
+					"172.25.0.1:38162",
+					"172.26.0.1:38162",
+					"172.27.0.1:38162",
+					"172.28.0.1:38162"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:23:13.023253255Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4706334284422163,
+				"StableID":   "npXXdRRWkd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:66893666f17620d3860ab0b16935eed4471d801b7b4b95872179883c4357e878",
+				"DiscoKey":   "discokey:dd7fc7c929f67d2317804d1f0a9a7d3bc39925f2aae88771d6ff942d5e20a518",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54233",
+					"10.65.0.27:54233",
+					"172.17.0.1:54233",
+					"172.18.0.1:54233",
+					"172.19.0.1:54233",
+					"172.20.0.1:54233",
+					"172.21.0.1:54233",
+					"172.22.0.1:54233",
+					"172.23.0.1:54233",
+					"172.24.0.1:54233",
+					"172.25.0.1:54233",
+					"172.26.0.1:54233",
+					"172.27.0.1:54233",
+					"172.28.0.1:54233"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:23:13.597689279Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8005462359786735,
+				"StableID":   "nJLMKSvgW521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39d88542309654ce8a973e34fe7d60ca5c47b575af7da6afd2b4d6eae2f9077f",
+				"DiscoKey":   "discokey:ccf844837e56d79c3e457d101f3df115b40532363613164c1b758e722a773c5b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:42546",
+					"10.65.0.27:42546",
+					"172.17.0.1:42546",
+					"172.18.0.1:42546",
+					"172.19.0.1:42546",
+					"172.20.0.1:42546",
+					"172.21.0.1:42546",
+					"172.22.0.1:42546",
+					"172.23.0.1:42546",
+					"172.24.0.1:42546",
+					"172.25.0.1:42546",
+					"172.26.0.1:42546",
+					"172.27.0.1:42546",
+					"172.28.0.1:42546"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:23:14.075062687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7744074492126791,
+				"StableID":   "nzarXuhJU321CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e8a1584616730ff02f1e350a676ebcb776286c99b21d9313107fb43bf4d2032f",
+				"DiscoKey":   "discokey:0d68505902bbd77439edae3e449038195517a929ecca862c7d712af7ffdde475",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47693",
+					"10.65.0.27:47693",
+					"172.17.0.1:47693",
+					"172.18.0.1:47693",
+					"172.19.0.1:47693",
+					"172.20.0.1:47693",
+					"172.21.0.1:47693",
+					"172.22.0.1:47693",
+					"172.23.0.1:47693",
+					"172.24.0.1:47693",
+					"172.25.0.1:47693",
+					"172.26.0.1:47693",
+					"172.27.0.1:47693",
+					"172.28.0.1:47693"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:23:14.62767129Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6412229175349026,
+				"StableID":   "nBbYaTP75s11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f22067dadfa55846929e0cfddf14c47b05658a445e07f7954469c9c292e1dc1a",
+				"DiscoKey":   "discokey:f60ee33c0459fd7b7b865488e0b1850cc4173fb84b24b086608db7df18ca2a3d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43955",
+					"10.65.0.27:43955",
+					"172.17.0.1:43955",
+					"172.18.0.1:43955",
+					"172.19.0.1:43955",
+					"172.20.0.1:43955",
+					"172.21.0.1:43955",
+					"172.22.0.1:43955",
+					"172.23.0.1:43955",
+					"172.24.0.1:43955",
+					"172.25.0.1:43955",
+					"172.26.0.1:43955",
+					"172.27.0.1:43955",
+					"172.28.0.1:43955"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:23:15.166947237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3022813035734529,
+				"StableID":   "nxCCq1B3cQ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:deaef98e694a8ed3cf1430888f79c8c8f3c5ec6542f273f3740f9fe5d508f440",
+				"DiscoKey":   "discokey:9d2611b6b1d2248a398e7b4284d3874cf7a252c80a0a4613068d1405daf09331",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38713",
+					"10.65.0.27:38713",
+					"172.17.0.1:38713",
+					"172.18.0.1:38713",
+					"172.19.0.1:38713",
+					"172.20.0.1:38713",
+					"172.21.0.1:38713",
+					"172.22.0.1:38713",
+					"172.23.0.1:38713",
+					"172.24.0.1:38713",
+					"172.25.0.1:38713",
+					"172.26.0.1:38713",
+					"172.27.0.1:38713",
+					"172.28.0.1:38713"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:23:15.70111166Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1160940652807591,
+				"StableID":   "n2ky2fwn4A11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db23f3d887aabec31020ab17cae9b6c74e1617b0749b9dd6b10b7022f8dd5a26",
+				"DiscoKey":   "discokey:611122099078911c2f25b44a0fe16a33cf3fcf7bde707a0f7a24c047fd83703c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35943",
+					"10.65.0.27:35943",
+					"172.17.0.1:35943",
+					"172.18.0.1:35943",
+					"172.19.0.1:35943",
+					"172.20.0.1:35943",
+					"172.21.0.1:35943",
+					"172.22.0.1:35943",
+					"172.23.0.1:35943",
+					"172.24.0.1:35943",
+					"172.25.0.1:35943",
+					"172.26.0.1:35943",
+					"172.27.0.1:35943",
+					"172.28.0.1:35943"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:23:16.221695078Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4114028313391231,
+				"StableID":   "nQB8EmYF8Z11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8623229a8a613c18bd53d3c987b6ba01dcd0b16cd90c6802bd5bf42267ce1a20",
+				"KeyExpiry":  "2026-11-09T09:23:17Z",
+				"DiscoKey":   "discokey:fbe0efc3b993550e256e689a828f5ea7d719b06c319f84655b2621b9895ed200",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:57427",
+					"10.65.0.27:57427",
+					"172.17.0.1:57427",
+					"172.18.0.1:57427",
+					"172.19.0.1:57427",
+					"172.20.0.1:57427",
+					"172.21.0.1:57427",
+					"172.22.0.1:57427",
+					"172.23.0.1:57427",
+					"172.24.0.1:57427",
+					"172.25.0.1:57427",
+					"172.26.0.1:57427",
+					"172.27.0.1:57427",
+					"172.28.0.1:57427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:23:17.296247424Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6744843673391373,
+				"StableID":   "nEVZn9ckfu11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:195ea1120c871dd9ccd872e67e374c7c5f3456dda9df7d44540f5c366f666c07",
+				"KeyExpiry":  "2026-11-09T09:23:17Z",
+				"DiscoKey":   "discokey:65c5e068b41990e85d8537c6ba5f5ea56b0deed6cf03ea79b232d472359a195e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48844",
+					"10.65.0.27:48844",
+					"172.17.0.1:48844",
+					"172.18.0.1:48844",
+					"172.19.0.1:48844",
+					"172.20.0.1:48844",
+					"172.21.0.1:48844",
+					"172.22.0.1:48844",
+					"172.23.0.1:48844",
+					"172.24.0.1:48844",
+					"172.25.0.1:48844",
+					"172.26.0.1:48844",
+					"172.27.0.1:48844",
+					"172.28.0.1:48844"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:23:17.844641649Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7244862843203504,
+				"StableID":   "nuM2bBGDay11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:29a2762352fe54e950f8d2f12e037313ca0737eb42976406472da0fc67ad875f",
+				"KeyExpiry":  "2026-11-09T09:23:18Z",
+				"DiscoKey":   "discokey:357b53e43c03765f7001405e3e0d7f129a0859a8e35353a200220c73e84ea37d",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36932",
+					"10.65.0.27:36932",
+					"172.17.0.1:36932",
+					"172.18.0.1:36932",
+					"172.19.0.1:36932",
+					"172.20.0.1:36932",
+					"172.21.0.1:36932",
+					"172.22.0.1:36932",
+					"172.23.0.1:36932",
+					"172.24.0.1:36932",
+					"172.25.0.1:36932",
+					"172.26.0.1:36932",
+					"172.27.0.1:36932",
+					"172.28.0.1:36932"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:23:18.39324553Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{
+				"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+				"sshUsers":   {"root": "root"},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				}
+			}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6890529266015242": {
+				"ID":          6890529266015242,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		},
+		"ssh_rules": [{
+			"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+			"sshUsers":   {"root": "root"},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}
+		}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4706334284422163,
+				"StableID":   "npXXdRRWkd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       4706334284422163,
+				"Key":        "nodekey:66893666f17620d3860ab0b16935eed4471d801b7b4b95872179883c4357e878",
+				"DiscoKey":   "discokey:dd7fc7c929f67d2317804d1f0a9a7d3bc39925f2aae88771d6ff942d5e20a518",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54233",
+					"10.65.0.27:54233",
+					"172.17.0.1:54233",
+					"172.18.0.1:54233",
+					"172.19.0.1:54233",
+					"172.20.0.1:54233",
+					"172.21.0.1:54233",
+					"172.22.0.1:54233",
+					"172.23.0.1:54233",
+					"172.24.0.1:54233",
+					"172.25.0.1:54233",
+					"172.26.0.1:54233",
+					"172.27.0.1:54233",
+					"172.28.0.1:54233"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:23:13.597689279Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:66893666f17620d3860ab0b16935eed4471d801b7b4b95872179883c4357e878",
+			"MachineKey": "mkey:8202d91dd6dd1e2a6ec8c2031892d1bc04adeeb3c44fa5812bb8f16ec209f17c",
+			"Peers": [{
+				"ID":         8673558682620626,
+				"StableID":   "n1WTaNgGjA21CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f00a22b63ecf5bc2688aba213366853cf5c120d6bac8738fbc5a706658fb23e",
+				"DiscoKey":   "discokey:56d85cc4c1ea85c5f209b585febfc4cc1c25e41fedc71a0a1f1f062aacd2a947",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35255",
+					"10.65.0.27:35255",
+					"172.17.0.1:35255",
+					"172.18.0.1:35255",
+					"172.19.0.1:35255",
+					"172.20.0.1:35255",
+					"172.21.0.1:35255",
+					"172.22.0.1:35255",
+					"172.23.0.1:35255",
+					"172.24.0.1:35255",
+					"172.25.0.1:35255",
+					"172.26.0.1:35255",
+					"172.27.0.1:35255",
+					"172.28.0.1:35255"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:23:10.945165275Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6650671549347752,
+				"StableID":   "nKrLf7s6wt11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ebc5c4959628162357c3f14e501c639a1154fdf39560ef130402725d30440727",
+				"DiscoKey":   "discokey:f7b1fbd9c6a742c4ebfbedaf3f878bd7979dad7c56ee5ac0c6d041dcb004b131",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39009",
+					"10.65.0.27:39009",
+					"172.17.0.1:39009",
+					"172.18.0.1:39009",
+					"172.19.0.1:39009",
+					"172.20.0.1:39009",
+					"172.21.0.1:39009",
+					"172.22.0.1:39009",
+					"172.23.0.1:39009",
+					"172.24.0.1:39009",
+					"172.25.0.1:39009",
+					"172.26.0.1:39009",
+					"172.27.0.1:39009",
+					"172.28.0.1:39009"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:23:11.41795637Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2244976255107421,
+				"StableID":   "nWF27jikXJ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e213578e1372213514a5bbf56f33e6d77ba8cc7d0d5c2f3e46c456d2f1badc74",
+				"DiscoKey":   "discokey:579e729d1cbfc797d173f11d5f46fc7ad83de9e9b283aeca2a49a9b7d98d777e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57102",
+					"10.65.0.27:57102",
+					"172.17.0.1:57102",
+					"172.18.0.1:57102",
+					"172.19.0.1:57102",
+					"172.20.0.1:57102",
+					"172.21.0.1:57102",
+					"172.22.0.1:57102",
+					"172.23.0.1:57102",
+					"172.24.0.1:57102",
+					"172.25.0.1:57102",
+					"172.26.0.1:57102",
+					"172.27.0.1:57102",
+					"172.28.0.1:57102"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:23:11.958807186Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6171263541698332,
+				"StableID":   "nyqUgTdyBq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2476445888a7ca1728e3a0079cd670cda161d965e846d0373587b3caf9332009",
+				"DiscoKey":   "discokey:051f68b19f9b4fe635977bacb1bfca1fc040739145365fe63dfc0a2a89605e65",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59814",
+					"10.65.0.27:59814",
+					"172.17.0.1:59814",
+					"172.18.0.1:59814",
+					"172.19.0.1:59814",
+					"172.20.0.1:59814",
+					"172.21.0.1:59814",
+					"172.22.0.1:59814",
+					"172.23.0.1:59814",
+					"172.24.0.1:59814",
+					"172.25.0.1:59814",
+					"172.26.0.1:59814",
+					"172.27.0.1:59814",
+					"172.28.0.1:59814"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:23:12.481223468Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1551577726279602,
+				"StableID":   "n1iVYKKi7D11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e2756e136ea21c6bba471c8eedc1b06e23d3057cd90791fdba9d597d5069278",
+				"DiscoKey":   "discokey:ff70c080835318aa43fe94f70fe48347c70516f329050e97b76af662e29c5061",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38162",
+					"10.65.0.27:38162",
+					"172.17.0.1:38162",
+					"172.18.0.1:38162",
+					"172.19.0.1:38162",
+					"172.20.0.1:38162",
+					"172.21.0.1:38162",
+					"172.22.0.1:38162",
+					"172.23.0.1:38162",
+					"172.24.0.1:38162",
+					"172.25.0.1:38162",
+					"172.26.0.1:38162",
+					"172.27.0.1:38162",
+					"172.28.0.1:38162"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:23:13.023253255Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8005462359786735,
+				"StableID":   "nJLMKSvgW521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39d88542309654ce8a973e34fe7d60ca5c47b575af7da6afd2b4d6eae2f9077f",
+				"DiscoKey":   "discokey:ccf844837e56d79c3e457d101f3df115b40532363613164c1b758e722a773c5b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:42546",
+					"10.65.0.27:42546",
+					"172.17.0.1:42546",
+					"172.18.0.1:42546",
+					"172.19.0.1:42546",
+					"172.20.0.1:42546",
+					"172.21.0.1:42546",
+					"172.22.0.1:42546",
+					"172.23.0.1:42546",
+					"172.24.0.1:42546",
+					"172.25.0.1:42546",
+					"172.26.0.1:42546",
+					"172.27.0.1:42546",
+					"172.28.0.1:42546"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:23:14.075062687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7744074492126791,
+				"StableID":   "nzarXuhJU321CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e8a1584616730ff02f1e350a676ebcb776286c99b21d9313107fb43bf4d2032f",
+				"DiscoKey":   "discokey:0d68505902bbd77439edae3e449038195517a929ecca862c7d712af7ffdde475",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47693",
+					"10.65.0.27:47693",
+					"172.17.0.1:47693",
+					"172.18.0.1:47693",
+					"172.19.0.1:47693",
+					"172.20.0.1:47693",
+					"172.21.0.1:47693",
+					"172.22.0.1:47693",
+					"172.23.0.1:47693",
+					"172.24.0.1:47693",
+					"172.25.0.1:47693",
+					"172.26.0.1:47693",
+					"172.27.0.1:47693",
+					"172.28.0.1:47693"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:23:14.62767129Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6412229175349026,
+				"StableID":   "nBbYaTP75s11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f22067dadfa55846929e0cfddf14c47b05658a445e07f7954469c9c292e1dc1a",
+				"DiscoKey":   "discokey:f60ee33c0459fd7b7b865488e0b1850cc4173fb84b24b086608db7df18ca2a3d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43955",
+					"10.65.0.27:43955",
+					"172.17.0.1:43955",
+					"172.18.0.1:43955",
+					"172.19.0.1:43955",
+					"172.20.0.1:43955",
+					"172.21.0.1:43955",
+					"172.22.0.1:43955",
+					"172.23.0.1:43955",
+					"172.24.0.1:43955",
+					"172.25.0.1:43955",
+					"172.26.0.1:43955",
+					"172.27.0.1:43955",
+					"172.28.0.1:43955"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:23:15.166947237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3022813035734529,
+				"StableID":   "nxCCq1B3cQ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:deaef98e694a8ed3cf1430888f79c8c8f3c5ec6542f273f3740f9fe5d508f440",
+				"DiscoKey":   "discokey:9d2611b6b1d2248a398e7b4284d3874cf7a252c80a0a4613068d1405daf09331",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38713",
+					"10.65.0.27:38713",
+					"172.17.0.1:38713",
+					"172.18.0.1:38713",
+					"172.19.0.1:38713",
+					"172.20.0.1:38713",
+					"172.21.0.1:38713",
+					"172.22.0.1:38713",
+					"172.23.0.1:38713",
+					"172.24.0.1:38713",
+					"172.25.0.1:38713",
+					"172.26.0.1:38713",
+					"172.27.0.1:38713",
+					"172.28.0.1:38713"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:23:15.70111166Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1160940652807591,
+				"StableID":   "n2ky2fwn4A11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db23f3d887aabec31020ab17cae9b6c74e1617b0749b9dd6b10b7022f8dd5a26",
+				"DiscoKey":   "discokey:611122099078911c2f25b44a0fe16a33cf3fcf7bde707a0f7a24c047fd83703c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35943",
+					"10.65.0.27:35943",
+					"172.17.0.1:35943",
+					"172.18.0.1:35943",
+					"172.19.0.1:35943",
+					"172.20.0.1:35943",
+					"172.21.0.1:35943",
+					"172.22.0.1:35943",
+					"172.23.0.1:35943",
+					"172.24.0.1:35943",
+					"172.25.0.1:35943",
+					"172.26.0.1:35943",
+					"172.27.0.1:35943",
+					"172.28.0.1:35943"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:23:16.221695078Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6890529266015242,
+				"StableID":   "njjGj8Xjov11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fa77ba1ae5462136c471ac93af15f5068029374a1cea5e4a38cf009a43c0363b",
+				"DiscoKey":   "discokey:50a6ae6716b1268e344eb542a019872f708b18a580cef5eaf74e3a291761cd13",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47165",
+					"10.65.0.27:47165",
+					"172.17.0.1:47165",
+					"172.18.0.1:47165",
+					"172.19.0.1:47165",
+					"172.20.0.1:47165",
+					"172.21.0.1:47165",
+					"172.22.0.1:47165",
+					"172.23.0.1:47165",
+					"172.24.0.1:47165",
+					"172.25.0.1:47165",
+					"172.26.0.1:47165",
+					"172.27.0.1:47165",
+					"172.28.0.1:47165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:23:16.812549339Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4114028313391231,
+				"StableID":   "nQB8EmYF8Z11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8623229a8a613c18bd53d3c987b6ba01dcd0b16cd90c6802bd5bf42267ce1a20",
+				"KeyExpiry":  "2026-11-09T09:23:17Z",
+				"DiscoKey":   "discokey:fbe0efc3b993550e256e689a828f5ea7d719b06c319f84655b2621b9895ed200",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:57427",
+					"10.65.0.27:57427",
+					"172.17.0.1:57427",
+					"172.18.0.1:57427",
+					"172.19.0.1:57427",
+					"172.20.0.1:57427",
+					"172.21.0.1:57427",
+					"172.22.0.1:57427",
+					"172.23.0.1:57427",
+					"172.24.0.1:57427",
+					"172.25.0.1:57427",
+					"172.26.0.1:57427",
+					"172.27.0.1:57427",
+					"172.28.0.1:57427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:23:17.296247424Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6744843673391373,
+				"StableID":   "nEVZn9ckfu11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:195ea1120c871dd9ccd872e67e374c7c5f3456dda9df7d44540f5c366f666c07",
+				"KeyExpiry":  "2026-11-09T09:23:17Z",
+				"DiscoKey":   "discokey:65c5e068b41990e85d8537c6ba5f5ea56b0deed6cf03ea79b232d472359a195e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48844",
+					"10.65.0.27:48844",
+					"172.17.0.1:48844",
+					"172.18.0.1:48844",
+					"172.19.0.1:48844",
+					"172.20.0.1:48844",
+					"172.21.0.1:48844",
+					"172.22.0.1:48844",
+					"172.23.0.1:48844",
+					"172.24.0.1:48844",
+					"172.25.0.1:48844",
+					"172.26.0.1:48844",
+					"172.27.0.1:48844",
+					"172.28.0.1:48844"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:23:17.844641649Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7244862843203504,
+				"StableID":   "nuM2bBGDay11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:29a2762352fe54e950f8d2f12e037313ca0737eb42976406472da0fc67ad875f",
+				"KeyExpiry":  "2026-11-09T09:23:18Z",
+				"DiscoKey":   "discokey:357b53e43c03765f7001405e3e0d7f129a0859a8e35353a200220c73e84ea37d",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36932",
+					"10.65.0.27:36932",
+					"172.17.0.1:36932",
+					"172.18.0.1:36932",
+					"172.19.0.1:36932",
+					"172.20.0.1:36932",
+					"172.21.0.1:36932",
+					"172.22.0.1:36932",
+					"172.23.0.1:36932",
+					"172.24.0.1:36932",
+					"172.25.0.1:36932",
+					"172.26.0.1:36932",
+					"172.27.0.1:36932",
+					"172.28.0.1:36932"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:23:18.39324553Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4706334284422163": {
+				"ID":          4706334284422163,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7244862843203504,
+				"StableID":   "nuM2bBGDay11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:29a2762352fe54e950f8d2f12e037313ca0737eb42976406472da0fc67ad875f",
+				"KeyExpiry":  "2026-11-09T09:23:18Z",
+				"DiscoKey":   "discokey:357b53e43c03765f7001405e3e0d7f129a0859a8e35353a200220c73e84ea37d",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36932",
+					"10.65.0.27:36932",
+					"172.17.0.1:36932",
+					"172.18.0.1:36932",
+					"172.19.0.1:36932",
+					"172.20.0.1:36932",
+					"172.21.0.1:36932",
+					"172.22.0.1:36932",
+					"172.23.0.1:36932",
+					"172.24.0.1:36932",
+					"172.25.0.1:36932",
+					"172.26.0.1:36932",
+					"172.27.0.1:36932",
+					"172.28.0.1:36932"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:23:18.39324553Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:29a2762352fe54e950f8d2f12e037313ca0737eb42976406472da0fc67ad875f",
+			"MachineKey": "mkey:6552ac96e39b31858a51425360c704bd8d47c1a0586512c3a7f1751348ae893d",
+			"Peers": [{
+				"ID":         8673558682620626,
+				"StableID":   "n1WTaNgGjA21CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f00a22b63ecf5bc2688aba213366853cf5c120d6bac8738fbc5a706658fb23e",
+				"DiscoKey":   "discokey:56d85cc4c1ea85c5f209b585febfc4cc1c25e41fedc71a0a1f1f062aacd2a947",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35255",
+					"10.65.0.27:35255",
+					"172.17.0.1:35255",
+					"172.18.0.1:35255",
+					"172.19.0.1:35255",
+					"172.20.0.1:35255",
+					"172.21.0.1:35255",
+					"172.22.0.1:35255",
+					"172.23.0.1:35255",
+					"172.24.0.1:35255",
+					"172.25.0.1:35255",
+					"172.26.0.1:35255",
+					"172.27.0.1:35255",
+					"172.28.0.1:35255"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:23:10.945165275Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6650671549347752,
+				"StableID":   "nKrLf7s6wt11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ebc5c4959628162357c3f14e501c639a1154fdf39560ef130402725d30440727",
+				"DiscoKey":   "discokey:f7b1fbd9c6a742c4ebfbedaf3f878bd7979dad7c56ee5ac0c6d041dcb004b131",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39009",
+					"10.65.0.27:39009",
+					"172.17.0.1:39009",
+					"172.18.0.1:39009",
+					"172.19.0.1:39009",
+					"172.20.0.1:39009",
+					"172.21.0.1:39009",
+					"172.22.0.1:39009",
+					"172.23.0.1:39009",
+					"172.24.0.1:39009",
+					"172.25.0.1:39009",
+					"172.26.0.1:39009",
+					"172.27.0.1:39009",
+					"172.28.0.1:39009"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:23:11.41795637Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2244976255107421,
+				"StableID":   "nWF27jikXJ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e213578e1372213514a5bbf56f33e6d77ba8cc7d0d5c2f3e46c456d2f1badc74",
+				"DiscoKey":   "discokey:579e729d1cbfc797d173f11d5f46fc7ad83de9e9b283aeca2a49a9b7d98d777e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57102",
+					"10.65.0.27:57102",
+					"172.17.0.1:57102",
+					"172.18.0.1:57102",
+					"172.19.0.1:57102",
+					"172.20.0.1:57102",
+					"172.21.0.1:57102",
+					"172.22.0.1:57102",
+					"172.23.0.1:57102",
+					"172.24.0.1:57102",
+					"172.25.0.1:57102",
+					"172.26.0.1:57102",
+					"172.27.0.1:57102",
+					"172.28.0.1:57102"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:23:11.958807186Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6171263541698332,
+				"StableID":   "nyqUgTdyBq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2476445888a7ca1728e3a0079cd670cda161d965e846d0373587b3caf9332009",
+				"DiscoKey":   "discokey:051f68b19f9b4fe635977bacb1bfca1fc040739145365fe63dfc0a2a89605e65",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59814",
+					"10.65.0.27:59814",
+					"172.17.0.1:59814",
+					"172.18.0.1:59814",
+					"172.19.0.1:59814",
+					"172.20.0.1:59814",
+					"172.21.0.1:59814",
+					"172.22.0.1:59814",
+					"172.23.0.1:59814",
+					"172.24.0.1:59814",
+					"172.25.0.1:59814",
+					"172.26.0.1:59814",
+					"172.27.0.1:59814",
+					"172.28.0.1:59814"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:23:12.481223468Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1551577726279602,
+				"StableID":   "n1iVYKKi7D11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e2756e136ea21c6bba471c8eedc1b06e23d3057cd90791fdba9d597d5069278",
+				"DiscoKey":   "discokey:ff70c080835318aa43fe94f70fe48347c70516f329050e97b76af662e29c5061",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38162",
+					"10.65.0.27:38162",
+					"172.17.0.1:38162",
+					"172.18.0.1:38162",
+					"172.19.0.1:38162",
+					"172.20.0.1:38162",
+					"172.21.0.1:38162",
+					"172.22.0.1:38162",
+					"172.23.0.1:38162",
+					"172.24.0.1:38162",
+					"172.25.0.1:38162",
+					"172.26.0.1:38162",
+					"172.27.0.1:38162",
+					"172.28.0.1:38162"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:23:13.023253255Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4706334284422163,
+				"StableID":   "npXXdRRWkd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:66893666f17620d3860ab0b16935eed4471d801b7b4b95872179883c4357e878",
+				"DiscoKey":   "discokey:dd7fc7c929f67d2317804d1f0a9a7d3bc39925f2aae88771d6ff942d5e20a518",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54233",
+					"10.65.0.27:54233",
+					"172.17.0.1:54233",
+					"172.18.0.1:54233",
+					"172.19.0.1:54233",
+					"172.20.0.1:54233",
+					"172.21.0.1:54233",
+					"172.22.0.1:54233",
+					"172.23.0.1:54233",
+					"172.24.0.1:54233",
+					"172.25.0.1:54233",
+					"172.26.0.1:54233",
+					"172.27.0.1:54233",
+					"172.28.0.1:54233"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:23:13.597689279Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8005462359786735,
+				"StableID":   "nJLMKSvgW521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39d88542309654ce8a973e34fe7d60ca5c47b575af7da6afd2b4d6eae2f9077f",
+				"DiscoKey":   "discokey:ccf844837e56d79c3e457d101f3df115b40532363613164c1b758e722a773c5b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:42546",
+					"10.65.0.27:42546",
+					"172.17.0.1:42546",
+					"172.18.0.1:42546",
+					"172.19.0.1:42546",
+					"172.20.0.1:42546",
+					"172.21.0.1:42546",
+					"172.22.0.1:42546",
+					"172.23.0.1:42546",
+					"172.24.0.1:42546",
+					"172.25.0.1:42546",
+					"172.26.0.1:42546",
+					"172.27.0.1:42546",
+					"172.28.0.1:42546"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:23:14.075062687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7744074492126791,
+				"StableID":   "nzarXuhJU321CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e8a1584616730ff02f1e350a676ebcb776286c99b21d9313107fb43bf4d2032f",
+				"DiscoKey":   "discokey:0d68505902bbd77439edae3e449038195517a929ecca862c7d712af7ffdde475",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47693",
+					"10.65.0.27:47693",
+					"172.17.0.1:47693",
+					"172.18.0.1:47693",
+					"172.19.0.1:47693",
+					"172.20.0.1:47693",
+					"172.21.0.1:47693",
+					"172.22.0.1:47693",
+					"172.23.0.1:47693",
+					"172.24.0.1:47693",
+					"172.25.0.1:47693",
+					"172.26.0.1:47693",
+					"172.27.0.1:47693",
+					"172.28.0.1:47693"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:23:14.62767129Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6412229175349026,
+				"StableID":   "nBbYaTP75s11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f22067dadfa55846929e0cfddf14c47b05658a445e07f7954469c9c292e1dc1a",
+				"DiscoKey":   "discokey:f60ee33c0459fd7b7b865488e0b1850cc4173fb84b24b086608db7df18ca2a3d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43955",
+					"10.65.0.27:43955",
+					"172.17.0.1:43955",
+					"172.18.0.1:43955",
+					"172.19.0.1:43955",
+					"172.20.0.1:43955",
+					"172.21.0.1:43955",
+					"172.22.0.1:43955",
+					"172.23.0.1:43955",
+					"172.24.0.1:43955",
+					"172.25.0.1:43955",
+					"172.26.0.1:43955",
+					"172.27.0.1:43955",
+					"172.28.0.1:43955"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:23:15.166947237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3022813035734529,
+				"StableID":   "nxCCq1B3cQ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:deaef98e694a8ed3cf1430888f79c8c8f3c5ec6542f273f3740f9fe5d508f440",
+				"DiscoKey":   "discokey:9d2611b6b1d2248a398e7b4284d3874cf7a252c80a0a4613068d1405daf09331",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38713",
+					"10.65.0.27:38713",
+					"172.17.0.1:38713",
+					"172.18.0.1:38713",
+					"172.19.0.1:38713",
+					"172.20.0.1:38713",
+					"172.21.0.1:38713",
+					"172.22.0.1:38713",
+					"172.23.0.1:38713",
+					"172.24.0.1:38713",
+					"172.25.0.1:38713",
+					"172.26.0.1:38713",
+					"172.27.0.1:38713",
+					"172.28.0.1:38713"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:23:15.70111166Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1160940652807591,
+				"StableID":   "n2ky2fwn4A11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db23f3d887aabec31020ab17cae9b6c74e1617b0749b9dd6b10b7022f8dd5a26",
+				"DiscoKey":   "discokey:611122099078911c2f25b44a0fe16a33cf3fcf7bde707a0f7a24c047fd83703c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35943",
+					"10.65.0.27:35943",
+					"172.17.0.1:35943",
+					"172.18.0.1:35943",
+					"172.19.0.1:35943",
+					"172.20.0.1:35943",
+					"172.21.0.1:35943",
+					"172.22.0.1:35943",
+					"172.23.0.1:35943",
+					"172.24.0.1:35943",
+					"172.25.0.1:35943",
+					"172.26.0.1:35943",
+					"172.27.0.1:35943",
+					"172.28.0.1:35943"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:23:16.221695078Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6890529266015242,
+				"StableID":   "njjGj8Xjov11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fa77ba1ae5462136c471ac93af15f5068029374a1cea5e4a38cf009a43c0363b",
+				"DiscoKey":   "discokey:50a6ae6716b1268e344eb542a019872f708b18a580cef5eaf74e3a291761cd13",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47165",
+					"10.65.0.27:47165",
+					"172.17.0.1:47165",
+					"172.18.0.1:47165",
+					"172.19.0.1:47165",
+					"172.20.0.1:47165",
+					"172.21.0.1:47165",
+					"172.22.0.1:47165",
+					"172.23.0.1:47165",
+					"172.24.0.1:47165",
+					"172.25.0.1:47165",
+					"172.26.0.1:47165",
+					"172.27.0.1:47165",
+					"172.28.0.1:47165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:23:16.812549339Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4114028313391231,
+				"StableID":   "nQB8EmYF8Z11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8623229a8a613c18bd53d3c987b6ba01dcd0b16cd90c6802bd5bf42267ce1a20",
+				"KeyExpiry":  "2026-11-09T09:23:17Z",
+				"DiscoKey":   "discokey:fbe0efc3b993550e256e689a828f5ea7d719b06c319f84655b2621b9895ed200",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:57427",
+					"10.65.0.27:57427",
+					"172.17.0.1:57427",
+					"172.18.0.1:57427",
+					"172.19.0.1:57427",
+					"172.20.0.1:57427",
+					"172.21.0.1:57427",
+					"172.22.0.1:57427",
+					"172.23.0.1:57427",
+					"172.24.0.1:57427",
+					"172.25.0.1:57427",
+					"172.26.0.1:57427",
+					"172.27.0.1:57427",
+					"172.28.0.1:57427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:23:17.296247424Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6744843673391373,
+				"StableID":   "nEVZn9ckfu11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:195ea1120c871dd9ccd872e67e374c7c5f3456dda9df7d44540f5c366f666c07",
+				"KeyExpiry":  "2026-11-09T09:23:17Z",
+				"DiscoKey":   "discokey:65c5e068b41990e85d8537c6ba5f5ea56b0deed6cf03ea79b232d472359a195e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48844",
+					"10.65.0.27:48844",
+					"172.17.0.1:48844",
+					"172.18.0.1:48844",
+					"172.19.0.1:48844",
+					"172.20.0.1:48844",
+					"172.21.0.1:48844",
+					"172.22.0.1:48844",
+					"172.23.0.1:48844",
+					"172.24.0.1:48844",
+					"172.25.0.1:48844",
+					"172.26.0.1:48844",
+					"172.27.0.1:48844",
+					"172.28.0.1:48844"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:23:17.844641649Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2244976255107421,
+				"StableID":   "nWF27jikXJ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       2244976255107421,
+				"Key":        "nodekey:e213578e1372213514a5bbf56f33e6d77ba8cc7d0d5c2f3e46c456d2f1badc74",
+				"DiscoKey":   "discokey:579e729d1cbfc797d173f11d5f46fc7ad83de9e9b283aeca2a49a9b7d98d777e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57102",
+					"10.65.0.27:57102",
+					"172.17.0.1:57102",
+					"172.18.0.1:57102",
+					"172.19.0.1:57102",
+					"172.20.0.1:57102",
+					"172.21.0.1:57102",
+					"172.22.0.1:57102",
+					"172.23.0.1:57102",
+					"172.24.0.1:57102",
+					"172.25.0.1:57102",
+					"172.26.0.1:57102",
+					"172.27.0.1:57102",
+					"172.28.0.1:57102"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:23:11.958807186Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e213578e1372213514a5bbf56f33e6d77ba8cc7d0d5c2f3e46c456d2f1badc74",
+			"MachineKey": "mkey:debecdb4d56800bc4878340c767d5eea9b14538aee52e74ed7c02642544db643",
+			"Peers": [{
+				"ID":         8673558682620626,
+				"StableID":   "n1WTaNgGjA21CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f00a22b63ecf5bc2688aba213366853cf5c120d6bac8738fbc5a706658fb23e",
+				"DiscoKey":   "discokey:56d85cc4c1ea85c5f209b585febfc4cc1c25e41fedc71a0a1f1f062aacd2a947",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35255",
+					"10.65.0.27:35255",
+					"172.17.0.1:35255",
+					"172.18.0.1:35255",
+					"172.19.0.1:35255",
+					"172.20.0.1:35255",
+					"172.21.0.1:35255",
+					"172.22.0.1:35255",
+					"172.23.0.1:35255",
+					"172.24.0.1:35255",
+					"172.25.0.1:35255",
+					"172.26.0.1:35255",
+					"172.27.0.1:35255",
+					"172.28.0.1:35255"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:23:10.945165275Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6650671549347752,
+				"StableID":   "nKrLf7s6wt11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ebc5c4959628162357c3f14e501c639a1154fdf39560ef130402725d30440727",
+				"DiscoKey":   "discokey:f7b1fbd9c6a742c4ebfbedaf3f878bd7979dad7c56ee5ac0c6d041dcb004b131",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39009",
+					"10.65.0.27:39009",
+					"172.17.0.1:39009",
+					"172.18.0.1:39009",
+					"172.19.0.1:39009",
+					"172.20.0.1:39009",
+					"172.21.0.1:39009",
+					"172.22.0.1:39009",
+					"172.23.0.1:39009",
+					"172.24.0.1:39009",
+					"172.25.0.1:39009",
+					"172.26.0.1:39009",
+					"172.27.0.1:39009",
+					"172.28.0.1:39009"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:23:11.41795637Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6171263541698332,
+				"StableID":   "nyqUgTdyBq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2476445888a7ca1728e3a0079cd670cda161d965e846d0373587b3caf9332009",
+				"DiscoKey":   "discokey:051f68b19f9b4fe635977bacb1bfca1fc040739145365fe63dfc0a2a89605e65",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59814",
+					"10.65.0.27:59814",
+					"172.17.0.1:59814",
+					"172.18.0.1:59814",
+					"172.19.0.1:59814",
+					"172.20.0.1:59814",
+					"172.21.0.1:59814",
+					"172.22.0.1:59814",
+					"172.23.0.1:59814",
+					"172.24.0.1:59814",
+					"172.25.0.1:59814",
+					"172.26.0.1:59814",
+					"172.27.0.1:59814",
+					"172.28.0.1:59814"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:23:12.481223468Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1551577726279602,
+				"StableID":   "n1iVYKKi7D11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e2756e136ea21c6bba471c8eedc1b06e23d3057cd90791fdba9d597d5069278",
+				"DiscoKey":   "discokey:ff70c080835318aa43fe94f70fe48347c70516f329050e97b76af662e29c5061",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38162",
+					"10.65.0.27:38162",
+					"172.17.0.1:38162",
+					"172.18.0.1:38162",
+					"172.19.0.1:38162",
+					"172.20.0.1:38162",
+					"172.21.0.1:38162",
+					"172.22.0.1:38162",
+					"172.23.0.1:38162",
+					"172.24.0.1:38162",
+					"172.25.0.1:38162",
+					"172.26.0.1:38162",
+					"172.27.0.1:38162",
+					"172.28.0.1:38162"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:23:13.023253255Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4706334284422163,
+				"StableID":   "npXXdRRWkd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:66893666f17620d3860ab0b16935eed4471d801b7b4b95872179883c4357e878",
+				"DiscoKey":   "discokey:dd7fc7c929f67d2317804d1f0a9a7d3bc39925f2aae88771d6ff942d5e20a518",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54233",
+					"10.65.0.27:54233",
+					"172.17.0.1:54233",
+					"172.18.0.1:54233",
+					"172.19.0.1:54233",
+					"172.20.0.1:54233",
+					"172.21.0.1:54233",
+					"172.22.0.1:54233",
+					"172.23.0.1:54233",
+					"172.24.0.1:54233",
+					"172.25.0.1:54233",
+					"172.26.0.1:54233",
+					"172.27.0.1:54233",
+					"172.28.0.1:54233"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:23:13.597689279Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8005462359786735,
+				"StableID":   "nJLMKSvgW521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39d88542309654ce8a973e34fe7d60ca5c47b575af7da6afd2b4d6eae2f9077f",
+				"DiscoKey":   "discokey:ccf844837e56d79c3e457d101f3df115b40532363613164c1b758e722a773c5b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:42546",
+					"10.65.0.27:42546",
+					"172.17.0.1:42546",
+					"172.18.0.1:42546",
+					"172.19.0.1:42546",
+					"172.20.0.1:42546",
+					"172.21.0.1:42546",
+					"172.22.0.1:42546",
+					"172.23.0.1:42546",
+					"172.24.0.1:42546",
+					"172.25.0.1:42546",
+					"172.26.0.1:42546",
+					"172.27.0.1:42546",
+					"172.28.0.1:42546"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:23:14.075062687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7744074492126791,
+				"StableID":   "nzarXuhJU321CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e8a1584616730ff02f1e350a676ebcb776286c99b21d9313107fb43bf4d2032f",
+				"DiscoKey":   "discokey:0d68505902bbd77439edae3e449038195517a929ecca862c7d712af7ffdde475",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47693",
+					"10.65.0.27:47693",
+					"172.17.0.1:47693",
+					"172.18.0.1:47693",
+					"172.19.0.1:47693",
+					"172.20.0.1:47693",
+					"172.21.0.1:47693",
+					"172.22.0.1:47693",
+					"172.23.0.1:47693",
+					"172.24.0.1:47693",
+					"172.25.0.1:47693",
+					"172.26.0.1:47693",
+					"172.27.0.1:47693",
+					"172.28.0.1:47693"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:23:14.62767129Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6412229175349026,
+				"StableID":   "nBbYaTP75s11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f22067dadfa55846929e0cfddf14c47b05658a445e07f7954469c9c292e1dc1a",
+				"DiscoKey":   "discokey:f60ee33c0459fd7b7b865488e0b1850cc4173fb84b24b086608db7df18ca2a3d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43955",
+					"10.65.0.27:43955",
+					"172.17.0.1:43955",
+					"172.18.0.1:43955",
+					"172.19.0.1:43955",
+					"172.20.0.1:43955",
+					"172.21.0.1:43955",
+					"172.22.0.1:43955",
+					"172.23.0.1:43955",
+					"172.24.0.1:43955",
+					"172.25.0.1:43955",
+					"172.26.0.1:43955",
+					"172.27.0.1:43955",
+					"172.28.0.1:43955"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:23:15.166947237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3022813035734529,
+				"StableID":   "nxCCq1B3cQ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:deaef98e694a8ed3cf1430888f79c8c8f3c5ec6542f273f3740f9fe5d508f440",
+				"DiscoKey":   "discokey:9d2611b6b1d2248a398e7b4284d3874cf7a252c80a0a4613068d1405daf09331",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38713",
+					"10.65.0.27:38713",
+					"172.17.0.1:38713",
+					"172.18.0.1:38713",
+					"172.19.0.1:38713",
+					"172.20.0.1:38713",
+					"172.21.0.1:38713",
+					"172.22.0.1:38713",
+					"172.23.0.1:38713",
+					"172.24.0.1:38713",
+					"172.25.0.1:38713",
+					"172.26.0.1:38713",
+					"172.27.0.1:38713",
+					"172.28.0.1:38713"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:23:15.70111166Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1160940652807591,
+				"StableID":   "n2ky2fwn4A11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db23f3d887aabec31020ab17cae9b6c74e1617b0749b9dd6b10b7022f8dd5a26",
+				"DiscoKey":   "discokey:611122099078911c2f25b44a0fe16a33cf3fcf7bde707a0f7a24c047fd83703c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35943",
+					"10.65.0.27:35943",
+					"172.17.0.1:35943",
+					"172.18.0.1:35943",
+					"172.19.0.1:35943",
+					"172.20.0.1:35943",
+					"172.21.0.1:35943",
+					"172.22.0.1:35943",
+					"172.23.0.1:35943",
+					"172.24.0.1:35943",
+					"172.25.0.1:35943",
+					"172.26.0.1:35943",
+					"172.27.0.1:35943",
+					"172.28.0.1:35943"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:23:16.221695078Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6890529266015242,
+				"StableID":   "njjGj8Xjov11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fa77ba1ae5462136c471ac93af15f5068029374a1cea5e4a38cf009a43c0363b",
+				"DiscoKey":   "discokey:50a6ae6716b1268e344eb542a019872f708b18a580cef5eaf74e3a291761cd13",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47165",
+					"10.65.0.27:47165",
+					"172.17.0.1:47165",
+					"172.18.0.1:47165",
+					"172.19.0.1:47165",
+					"172.20.0.1:47165",
+					"172.21.0.1:47165",
+					"172.22.0.1:47165",
+					"172.23.0.1:47165",
+					"172.24.0.1:47165",
+					"172.25.0.1:47165",
+					"172.26.0.1:47165",
+					"172.27.0.1:47165",
+					"172.28.0.1:47165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:23:16.812549339Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4114028313391231,
+				"StableID":   "nQB8EmYF8Z11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8623229a8a613c18bd53d3c987b6ba01dcd0b16cd90c6802bd5bf42267ce1a20",
+				"KeyExpiry":  "2026-11-09T09:23:17Z",
+				"DiscoKey":   "discokey:fbe0efc3b993550e256e689a828f5ea7d719b06c319f84655b2621b9895ed200",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:57427",
+					"10.65.0.27:57427",
+					"172.17.0.1:57427",
+					"172.18.0.1:57427",
+					"172.19.0.1:57427",
+					"172.20.0.1:57427",
+					"172.21.0.1:57427",
+					"172.22.0.1:57427",
+					"172.23.0.1:57427",
+					"172.24.0.1:57427",
+					"172.25.0.1:57427",
+					"172.26.0.1:57427",
+					"172.27.0.1:57427",
+					"172.28.0.1:57427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:23:17.296247424Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6744843673391373,
+				"StableID":   "nEVZn9ckfu11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:195ea1120c871dd9ccd872e67e374c7c5f3456dda9df7d44540f5c366f666c07",
+				"KeyExpiry":  "2026-11-09T09:23:17Z",
+				"DiscoKey":   "discokey:65c5e068b41990e85d8537c6ba5f5ea56b0deed6cf03ea79b232d472359a195e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48844",
+					"10.65.0.27:48844",
+					"172.17.0.1:48844",
+					"172.18.0.1:48844",
+					"172.19.0.1:48844",
+					"172.20.0.1:48844",
+					"172.21.0.1:48844",
+					"172.22.0.1:48844",
+					"172.23.0.1:48844",
+					"172.24.0.1:48844",
+					"172.25.0.1:48844",
+					"172.26.0.1:48844",
+					"172.27.0.1:48844",
+					"172.28.0.1:48844"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:23:17.844641649Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7244862843203504,
+				"StableID":   "nuM2bBGDay11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:29a2762352fe54e950f8d2f12e037313ca0737eb42976406472da0fc67ad875f",
+				"KeyExpiry":  "2026-11-09T09:23:18Z",
+				"DiscoKey":   "discokey:357b53e43c03765f7001405e3e0d7f129a0859a8e35353a200220c73e84ea37d",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36932",
+					"10.65.0.27:36932",
+					"172.17.0.1:36932",
+					"172.18.0.1:36932",
+					"172.19.0.1:36932",
+					"172.20.0.1:36932",
+					"172.21.0.1:36932",
+					"172.22.0.1:36932",
+					"172.23.0.1:36932",
+					"172.24.0.1:36932",
+					"172.25.0.1:36932",
+					"172.26.0.1:36932",
+					"172.27.0.1:36932",
+					"172.28.0.1:36932"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:23:18.39324553Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2244976255107421": {
+				"ID":          2244976255107421,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7744074492126791,
+				"StableID":   "nzarXuhJU321CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       7744074492126791,
+				"Key":        "nodekey:e8a1584616730ff02f1e350a676ebcb776286c99b21d9313107fb43bf4d2032f",
+				"DiscoKey":   "discokey:0d68505902bbd77439edae3e449038195517a929ecca862c7d712af7ffdde475",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47693",
+					"10.65.0.27:47693",
+					"172.17.0.1:47693",
+					"172.18.0.1:47693",
+					"172.19.0.1:47693",
+					"172.20.0.1:47693",
+					"172.21.0.1:47693",
+					"172.22.0.1:47693",
+					"172.23.0.1:47693",
+					"172.24.0.1:47693",
+					"172.25.0.1:47693",
+					"172.26.0.1:47693",
+					"172.27.0.1:47693",
+					"172.28.0.1:47693"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:23:14.62767129Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e8a1584616730ff02f1e350a676ebcb776286c99b21d9313107fb43bf4d2032f",
+			"MachineKey": "mkey:671a8a28ef7627b4fa8365473b3ff47ef93fe6a5639bf19fdc1cbbdf34eed75a",
+			"Peers": [{
+				"ID":         8673558682620626,
+				"StableID":   "n1WTaNgGjA21CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f00a22b63ecf5bc2688aba213366853cf5c120d6bac8738fbc5a706658fb23e",
+				"DiscoKey":   "discokey:56d85cc4c1ea85c5f209b585febfc4cc1c25e41fedc71a0a1f1f062aacd2a947",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35255",
+					"10.65.0.27:35255",
+					"172.17.0.1:35255",
+					"172.18.0.1:35255",
+					"172.19.0.1:35255",
+					"172.20.0.1:35255",
+					"172.21.0.1:35255",
+					"172.22.0.1:35255",
+					"172.23.0.1:35255",
+					"172.24.0.1:35255",
+					"172.25.0.1:35255",
+					"172.26.0.1:35255",
+					"172.27.0.1:35255",
+					"172.28.0.1:35255"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:23:10.945165275Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6650671549347752,
+				"StableID":   "nKrLf7s6wt11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ebc5c4959628162357c3f14e501c639a1154fdf39560ef130402725d30440727",
+				"DiscoKey":   "discokey:f7b1fbd9c6a742c4ebfbedaf3f878bd7979dad7c56ee5ac0c6d041dcb004b131",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39009",
+					"10.65.0.27:39009",
+					"172.17.0.1:39009",
+					"172.18.0.1:39009",
+					"172.19.0.1:39009",
+					"172.20.0.1:39009",
+					"172.21.0.1:39009",
+					"172.22.0.1:39009",
+					"172.23.0.1:39009",
+					"172.24.0.1:39009",
+					"172.25.0.1:39009",
+					"172.26.0.1:39009",
+					"172.27.0.1:39009",
+					"172.28.0.1:39009"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:23:11.41795637Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2244976255107421,
+				"StableID":   "nWF27jikXJ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e213578e1372213514a5bbf56f33e6d77ba8cc7d0d5c2f3e46c456d2f1badc74",
+				"DiscoKey":   "discokey:579e729d1cbfc797d173f11d5f46fc7ad83de9e9b283aeca2a49a9b7d98d777e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57102",
+					"10.65.0.27:57102",
+					"172.17.0.1:57102",
+					"172.18.0.1:57102",
+					"172.19.0.1:57102",
+					"172.20.0.1:57102",
+					"172.21.0.1:57102",
+					"172.22.0.1:57102",
+					"172.23.0.1:57102",
+					"172.24.0.1:57102",
+					"172.25.0.1:57102",
+					"172.26.0.1:57102",
+					"172.27.0.1:57102",
+					"172.28.0.1:57102"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:23:11.958807186Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6171263541698332,
+				"StableID":   "nyqUgTdyBq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2476445888a7ca1728e3a0079cd670cda161d965e846d0373587b3caf9332009",
+				"DiscoKey":   "discokey:051f68b19f9b4fe635977bacb1bfca1fc040739145365fe63dfc0a2a89605e65",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59814",
+					"10.65.0.27:59814",
+					"172.17.0.1:59814",
+					"172.18.0.1:59814",
+					"172.19.0.1:59814",
+					"172.20.0.1:59814",
+					"172.21.0.1:59814",
+					"172.22.0.1:59814",
+					"172.23.0.1:59814",
+					"172.24.0.1:59814",
+					"172.25.0.1:59814",
+					"172.26.0.1:59814",
+					"172.27.0.1:59814",
+					"172.28.0.1:59814"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:23:12.481223468Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1551577726279602,
+				"StableID":   "n1iVYKKi7D11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e2756e136ea21c6bba471c8eedc1b06e23d3057cd90791fdba9d597d5069278",
+				"DiscoKey":   "discokey:ff70c080835318aa43fe94f70fe48347c70516f329050e97b76af662e29c5061",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38162",
+					"10.65.0.27:38162",
+					"172.17.0.1:38162",
+					"172.18.0.1:38162",
+					"172.19.0.1:38162",
+					"172.20.0.1:38162",
+					"172.21.0.1:38162",
+					"172.22.0.1:38162",
+					"172.23.0.1:38162",
+					"172.24.0.1:38162",
+					"172.25.0.1:38162",
+					"172.26.0.1:38162",
+					"172.27.0.1:38162",
+					"172.28.0.1:38162"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:23:13.023253255Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4706334284422163,
+				"StableID":   "npXXdRRWkd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:66893666f17620d3860ab0b16935eed4471d801b7b4b95872179883c4357e878",
+				"DiscoKey":   "discokey:dd7fc7c929f67d2317804d1f0a9a7d3bc39925f2aae88771d6ff942d5e20a518",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54233",
+					"10.65.0.27:54233",
+					"172.17.0.1:54233",
+					"172.18.0.1:54233",
+					"172.19.0.1:54233",
+					"172.20.0.1:54233",
+					"172.21.0.1:54233",
+					"172.22.0.1:54233",
+					"172.23.0.1:54233",
+					"172.24.0.1:54233",
+					"172.25.0.1:54233",
+					"172.26.0.1:54233",
+					"172.27.0.1:54233",
+					"172.28.0.1:54233"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:23:13.597689279Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8005462359786735,
+				"StableID":   "nJLMKSvgW521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39d88542309654ce8a973e34fe7d60ca5c47b575af7da6afd2b4d6eae2f9077f",
+				"DiscoKey":   "discokey:ccf844837e56d79c3e457d101f3df115b40532363613164c1b758e722a773c5b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:42546",
+					"10.65.0.27:42546",
+					"172.17.0.1:42546",
+					"172.18.0.1:42546",
+					"172.19.0.1:42546",
+					"172.20.0.1:42546",
+					"172.21.0.1:42546",
+					"172.22.0.1:42546",
+					"172.23.0.1:42546",
+					"172.24.0.1:42546",
+					"172.25.0.1:42546",
+					"172.26.0.1:42546",
+					"172.27.0.1:42546",
+					"172.28.0.1:42546"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:23:14.075062687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6412229175349026,
+				"StableID":   "nBbYaTP75s11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f22067dadfa55846929e0cfddf14c47b05658a445e07f7954469c9c292e1dc1a",
+				"DiscoKey":   "discokey:f60ee33c0459fd7b7b865488e0b1850cc4173fb84b24b086608db7df18ca2a3d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43955",
+					"10.65.0.27:43955",
+					"172.17.0.1:43955",
+					"172.18.0.1:43955",
+					"172.19.0.1:43955",
+					"172.20.0.1:43955",
+					"172.21.0.1:43955",
+					"172.22.0.1:43955",
+					"172.23.0.1:43955",
+					"172.24.0.1:43955",
+					"172.25.0.1:43955",
+					"172.26.0.1:43955",
+					"172.27.0.1:43955",
+					"172.28.0.1:43955"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:23:15.166947237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3022813035734529,
+				"StableID":   "nxCCq1B3cQ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:deaef98e694a8ed3cf1430888f79c8c8f3c5ec6542f273f3740f9fe5d508f440",
+				"DiscoKey":   "discokey:9d2611b6b1d2248a398e7b4284d3874cf7a252c80a0a4613068d1405daf09331",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38713",
+					"10.65.0.27:38713",
+					"172.17.0.1:38713",
+					"172.18.0.1:38713",
+					"172.19.0.1:38713",
+					"172.20.0.1:38713",
+					"172.21.0.1:38713",
+					"172.22.0.1:38713",
+					"172.23.0.1:38713",
+					"172.24.0.1:38713",
+					"172.25.0.1:38713",
+					"172.26.0.1:38713",
+					"172.27.0.1:38713",
+					"172.28.0.1:38713"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:23:15.70111166Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1160940652807591,
+				"StableID":   "n2ky2fwn4A11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db23f3d887aabec31020ab17cae9b6c74e1617b0749b9dd6b10b7022f8dd5a26",
+				"DiscoKey":   "discokey:611122099078911c2f25b44a0fe16a33cf3fcf7bde707a0f7a24c047fd83703c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35943",
+					"10.65.0.27:35943",
+					"172.17.0.1:35943",
+					"172.18.0.1:35943",
+					"172.19.0.1:35943",
+					"172.20.0.1:35943",
+					"172.21.0.1:35943",
+					"172.22.0.1:35943",
+					"172.23.0.1:35943",
+					"172.24.0.1:35943",
+					"172.25.0.1:35943",
+					"172.26.0.1:35943",
+					"172.27.0.1:35943",
+					"172.28.0.1:35943"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:23:16.221695078Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6890529266015242,
+				"StableID":   "njjGj8Xjov11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fa77ba1ae5462136c471ac93af15f5068029374a1cea5e4a38cf009a43c0363b",
+				"DiscoKey":   "discokey:50a6ae6716b1268e344eb542a019872f708b18a580cef5eaf74e3a291761cd13",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47165",
+					"10.65.0.27:47165",
+					"172.17.0.1:47165",
+					"172.18.0.1:47165",
+					"172.19.0.1:47165",
+					"172.20.0.1:47165",
+					"172.21.0.1:47165",
+					"172.22.0.1:47165",
+					"172.23.0.1:47165",
+					"172.24.0.1:47165",
+					"172.25.0.1:47165",
+					"172.26.0.1:47165",
+					"172.27.0.1:47165",
+					"172.28.0.1:47165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:23:16.812549339Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4114028313391231,
+				"StableID":   "nQB8EmYF8Z11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8623229a8a613c18bd53d3c987b6ba01dcd0b16cd90c6802bd5bf42267ce1a20",
+				"KeyExpiry":  "2026-11-09T09:23:17Z",
+				"DiscoKey":   "discokey:fbe0efc3b993550e256e689a828f5ea7d719b06c319f84655b2621b9895ed200",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:57427",
+					"10.65.0.27:57427",
+					"172.17.0.1:57427",
+					"172.18.0.1:57427",
+					"172.19.0.1:57427",
+					"172.20.0.1:57427",
+					"172.21.0.1:57427",
+					"172.22.0.1:57427",
+					"172.23.0.1:57427",
+					"172.24.0.1:57427",
+					"172.25.0.1:57427",
+					"172.26.0.1:57427",
+					"172.27.0.1:57427",
+					"172.28.0.1:57427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:23:17.296247424Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6744843673391373,
+				"StableID":   "nEVZn9ckfu11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:195ea1120c871dd9ccd872e67e374c7c5f3456dda9df7d44540f5c366f666c07",
+				"KeyExpiry":  "2026-11-09T09:23:17Z",
+				"DiscoKey":   "discokey:65c5e068b41990e85d8537c6ba5f5ea56b0deed6cf03ea79b232d472359a195e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48844",
+					"10.65.0.27:48844",
+					"172.17.0.1:48844",
+					"172.18.0.1:48844",
+					"172.19.0.1:48844",
+					"172.20.0.1:48844",
+					"172.21.0.1:48844",
+					"172.22.0.1:48844",
+					"172.23.0.1:48844",
+					"172.24.0.1:48844",
+					"172.25.0.1:48844",
+					"172.26.0.1:48844",
+					"172.27.0.1:48844",
+					"172.28.0.1:48844"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:23:17.844641649Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7244862843203504,
+				"StableID":   "nuM2bBGDay11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:29a2762352fe54e950f8d2f12e037313ca0737eb42976406472da0fc67ad875f",
+				"KeyExpiry":  "2026-11-09T09:23:18Z",
+				"DiscoKey":   "discokey:357b53e43c03765f7001405e3e0d7f129a0859a8e35353a200220c73e84ea37d",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36932",
+					"10.65.0.27:36932",
+					"172.17.0.1:36932",
+					"172.18.0.1:36932",
+					"172.19.0.1:36932",
+					"172.20.0.1:36932",
+					"172.21.0.1:36932",
+					"172.22.0.1:36932",
+					"172.23.0.1:36932",
+					"172.24.0.1:36932",
+					"172.25.0.1:36932",
+					"172.26.0.1:36932",
+					"172.27.0.1:36932",
+					"172.28.0.1:36932"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:23:18.39324553Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7744074492126791": {
+				"ID":          7744074492126791,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4114028313391231,
+				"StableID":   "nQB8EmYF8Z11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8623229a8a613c18bd53d3c987b6ba01dcd0b16cd90c6802bd5bf42267ce1a20",
+				"KeyExpiry":  "2026-11-09T09:23:17Z",
+				"DiscoKey":   "discokey:fbe0efc3b993550e256e689a828f5ea7d719b06c319f84655b2621b9895ed200",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:57427",
+					"10.65.0.27:57427",
+					"172.17.0.1:57427",
+					"172.18.0.1:57427",
+					"172.19.0.1:57427",
+					"172.20.0.1:57427",
+					"172.21.0.1:57427",
+					"172.22.0.1:57427",
+					"172.23.0.1:57427",
+					"172.24.0.1:57427",
+					"172.25.0.1:57427",
+					"172.26.0.1:57427",
+					"172.27.0.1:57427",
+					"172.28.0.1:57427"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:23:17.296247424Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8623229a8a613c18bd53d3c987b6ba01dcd0b16cd90c6802bd5bf42267ce1a20",
+			"MachineKey": "mkey:530b2c2594af8c208e53557b8666a2645f90255dbc5fc47835cb5520c3d04860",
+			"Peers": [{
+				"ID":         8673558682620626,
+				"StableID":   "n1WTaNgGjA21CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f00a22b63ecf5bc2688aba213366853cf5c120d6bac8738fbc5a706658fb23e",
+				"DiscoKey":   "discokey:56d85cc4c1ea85c5f209b585febfc4cc1c25e41fedc71a0a1f1f062aacd2a947",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35255",
+					"10.65.0.27:35255",
+					"172.17.0.1:35255",
+					"172.18.0.1:35255",
+					"172.19.0.1:35255",
+					"172.20.0.1:35255",
+					"172.21.0.1:35255",
+					"172.22.0.1:35255",
+					"172.23.0.1:35255",
+					"172.24.0.1:35255",
+					"172.25.0.1:35255",
+					"172.26.0.1:35255",
+					"172.27.0.1:35255",
+					"172.28.0.1:35255"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:23:10.945165275Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6650671549347752,
+				"StableID":   "nKrLf7s6wt11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ebc5c4959628162357c3f14e501c639a1154fdf39560ef130402725d30440727",
+				"DiscoKey":   "discokey:f7b1fbd9c6a742c4ebfbedaf3f878bd7979dad7c56ee5ac0c6d041dcb004b131",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39009",
+					"10.65.0.27:39009",
+					"172.17.0.1:39009",
+					"172.18.0.1:39009",
+					"172.19.0.1:39009",
+					"172.20.0.1:39009",
+					"172.21.0.1:39009",
+					"172.22.0.1:39009",
+					"172.23.0.1:39009",
+					"172.24.0.1:39009",
+					"172.25.0.1:39009",
+					"172.26.0.1:39009",
+					"172.27.0.1:39009",
+					"172.28.0.1:39009"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:23:11.41795637Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2244976255107421,
+				"StableID":   "nWF27jikXJ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e213578e1372213514a5bbf56f33e6d77ba8cc7d0d5c2f3e46c456d2f1badc74",
+				"DiscoKey":   "discokey:579e729d1cbfc797d173f11d5f46fc7ad83de9e9b283aeca2a49a9b7d98d777e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57102",
+					"10.65.0.27:57102",
+					"172.17.0.1:57102",
+					"172.18.0.1:57102",
+					"172.19.0.1:57102",
+					"172.20.0.1:57102",
+					"172.21.0.1:57102",
+					"172.22.0.1:57102",
+					"172.23.0.1:57102",
+					"172.24.0.1:57102",
+					"172.25.0.1:57102",
+					"172.26.0.1:57102",
+					"172.27.0.1:57102",
+					"172.28.0.1:57102"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:23:11.958807186Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6171263541698332,
+				"StableID":   "nyqUgTdyBq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2476445888a7ca1728e3a0079cd670cda161d965e846d0373587b3caf9332009",
+				"DiscoKey":   "discokey:051f68b19f9b4fe635977bacb1bfca1fc040739145365fe63dfc0a2a89605e65",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59814",
+					"10.65.0.27:59814",
+					"172.17.0.1:59814",
+					"172.18.0.1:59814",
+					"172.19.0.1:59814",
+					"172.20.0.1:59814",
+					"172.21.0.1:59814",
+					"172.22.0.1:59814",
+					"172.23.0.1:59814",
+					"172.24.0.1:59814",
+					"172.25.0.1:59814",
+					"172.26.0.1:59814",
+					"172.27.0.1:59814",
+					"172.28.0.1:59814"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:23:12.481223468Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1551577726279602,
+				"StableID":   "n1iVYKKi7D11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e2756e136ea21c6bba471c8eedc1b06e23d3057cd90791fdba9d597d5069278",
+				"DiscoKey":   "discokey:ff70c080835318aa43fe94f70fe48347c70516f329050e97b76af662e29c5061",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38162",
+					"10.65.0.27:38162",
+					"172.17.0.1:38162",
+					"172.18.0.1:38162",
+					"172.19.0.1:38162",
+					"172.20.0.1:38162",
+					"172.21.0.1:38162",
+					"172.22.0.1:38162",
+					"172.23.0.1:38162",
+					"172.24.0.1:38162",
+					"172.25.0.1:38162",
+					"172.26.0.1:38162",
+					"172.27.0.1:38162",
+					"172.28.0.1:38162"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:23:13.023253255Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4706334284422163,
+				"StableID":   "npXXdRRWkd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:66893666f17620d3860ab0b16935eed4471d801b7b4b95872179883c4357e878",
+				"DiscoKey":   "discokey:dd7fc7c929f67d2317804d1f0a9a7d3bc39925f2aae88771d6ff942d5e20a518",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54233",
+					"10.65.0.27:54233",
+					"172.17.0.1:54233",
+					"172.18.0.1:54233",
+					"172.19.0.1:54233",
+					"172.20.0.1:54233",
+					"172.21.0.1:54233",
+					"172.22.0.1:54233",
+					"172.23.0.1:54233",
+					"172.24.0.1:54233",
+					"172.25.0.1:54233",
+					"172.26.0.1:54233",
+					"172.27.0.1:54233",
+					"172.28.0.1:54233"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:23:13.597689279Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8005462359786735,
+				"StableID":   "nJLMKSvgW521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39d88542309654ce8a973e34fe7d60ca5c47b575af7da6afd2b4d6eae2f9077f",
+				"DiscoKey":   "discokey:ccf844837e56d79c3e457d101f3df115b40532363613164c1b758e722a773c5b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:42546",
+					"10.65.0.27:42546",
+					"172.17.0.1:42546",
+					"172.18.0.1:42546",
+					"172.19.0.1:42546",
+					"172.20.0.1:42546",
+					"172.21.0.1:42546",
+					"172.22.0.1:42546",
+					"172.23.0.1:42546",
+					"172.24.0.1:42546",
+					"172.25.0.1:42546",
+					"172.26.0.1:42546",
+					"172.27.0.1:42546",
+					"172.28.0.1:42546"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:23:14.075062687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7744074492126791,
+				"StableID":   "nzarXuhJU321CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e8a1584616730ff02f1e350a676ebcb776286c99b21d9313107fb43bf4d2032f",
+				"DiscoKey":   "discokey:0d68505902bbd77439edae3e449038195517a929ecca862c7d712af7ffdde475",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47693",
+					"10.65.0.27:47693",
+					"172.17.0.1:47693",
+					"172.18.0.1:47693",
+					"172.19.0.1:47693",
+					"172.20.0.1:47693",
+					"172.21.0.1:47693",
+					"172.22.0.1:47693",
+					"172.23.0.1:47693",
+					"172.24.0.1:47693",
+					"172.25.0.1:47693",
+					"172.26.0.1:47693",
+					"172.27.0.1:47693",
+					"172.28.0.1:47693"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:23:14.62767129Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6412229175349026,
+				"StableID":   "nBbYaTP75s11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f22067dadfa55846929e0cfddf14c47b05658a445e07f7954469c9c292e1dc1a",
+				"DiscoKey":   "discokey:f60ee33c0459fd7b7b865488e0b1850cc4173fb84b24b086608db7df18ca2a3d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43955",
+					"10.65.0.27:43955",
+					"172.17.0.1:43955",
+					"172.18.0.1:43955",
+					"172.19.0.1:43955",
+					"172.20.0.1:43955",
+					"172.21.0.1:43955",
+					"172.22.0.1:43955",
+					"172.23.0.1:43955",
+					"172.24.0.1:43955",
+					"172.25.0.1:43955",
+					"172.26.0.1:43955",
+					"172.27.0.1:43955",
+					"172.28.0.1:43955"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:23:15.166947237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3022813035734529,
+				"StableID":   "nxCCq1B3cQ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:deaef98e694a8ed3cf1430888f79c8c8f3c5ec6542f273f3740f9fe5d508f440",
+				"DiscoKey":   "discokey:9d2611b6b1d2248a398e7b4284d3874cf7a252c80a0a4613068d1405daf09331",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38713",
+					"10.65.0.27:38713",
+					"172.17.0.1:38713",
+					"172.18.0.1:38713",
+					"172.19.0.1:38713",
+					"172.20.0.1:38713",
+					"172.21.0.1:38713",
+					"172.22.0.1:38713",
+					"172.23.0.1:38713",
+					"172.24.0.1:38713",
+					"172.25.0.1:38713",
+					"172.26.0.1:38713",
+					"172.27.0.1:38713",
+					"172.28.0.1:38713"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:23:15.70111166Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1160940652807591,
+				"StableID":   "n2ky2fwn4A11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db23f3d887aabec31020ab17cae9b6c74e1617b0749b9dd6b10b7022f8dd5a26",
+				"DiscoKey":   "discokey:611122099078911c2f25b44a0fe16a33cf3fcf7bde707a0f7a24c047fd83703c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35943",
+					"10.65.0.27:35943",
+					"172.17.0.1:35943",
+					"172.18.0.1:35943",
+					"172.19.0.1:35943",
+					"172.20.0.1:35943",
+					"172.21.0.1:35943",
+					"172.22.0.1:35943",
+					"172.23.0.1:35943",
+					"172.24.0.1:35943",
+					"172.25.0.1:35943",
+					"172.26.0.1:35943",
+					"172.27.0.1:35943",
+					"172.28.0.1:35943"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:23:16.221695078Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6890529266015242,
+				"StableID":   "njjGj8Xjov11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fa77ba1ae5462136c471ac93af15f5068029374a1cea5e4a38cf009a43c0363b",
+				"DiscoKey":   "discokey:50a6ae6716b1268e344eb542a019872f708b18a580cef5eaf74e3a291761cd13",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47165",
+					"10.65.0.27:47165",
+					"172.17.0.1:47165",
+					"172.18.0.1:47165",
+					"172.19.0.1:47165",
+					"172.20.0.1:47165",
+					"172.21.0.1:47165",
+					"172.22.0.1:47165",
+					"172.23.0.1:47165",
+					"172.24.0.1:47165",
+					"172.25.0.1:47165",
+					"172.26.0.1:47165",
+					"172.27.0.1:47165",
+					"172.28.0.1:47165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:23:16.812549339Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6744843673391373,
+				"StableID":   "nEVZn9ckfu11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:195ea1120c871dd9ccd872e67e374c7c5f3456dda9df7d44540f5c366f666c07",
+				"KeyExpiry":  "2026-11-09T09:23:17Z",
+				"DiscoKey":   "discokey:65c5e068b41990e85d8537c6ba5f5ea56b0deed6cf03ea79b232d472359a195e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48844",
+					"10.65.0.27:48844",
+					"172.17.0.1:48844",
+					"172.18.0.1:48844",
+					"172.19.0.1:48844",
+					"172.20.0.1:48844",
+					"172.21.0.1:48844",
+					"172.22.0.1:48844",
+					"172.23.0.1:48844",
+					"172.24.0.1:48844",
+					"172.25.0.1:48844",
+					"172.26.0.1:48844",
+					"172.27.0.1:48844",
+					"172.28.0.1:48844"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:23:17.844641649Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7244862843203504,
+				"StableID":   "nuM2bBGDay11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:29a2762352fe54e950f8d2f12e037313ca0737eb42976406472da0fc67ad875f",
+				"KeyExpiry":  "2026-11-09T09:23:18Z",
+				"DiscoKey":   "discokey:357b53e43c03765f7001405e3e0d7f129a0859a8e35353a200220c73e84ea37d",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36932",
+					"10.65.0.27:36932",
+					"172.17.0.1:36932",
+					"172.18.0.1:36932",
+					"172.19.0.1:36932",
+					"172.20.0.1:36932",
+					"172.21.0.1:36932",
+					"172.22.0.1:36932",
+					"172.23.0.1:36932",
+					"172.24.0.1:36932",
+					"172.25.0.1:36932",
+					"172.26.0.1:36932",
+					"172.27.0.1:36932",
+					"172.28.0.1:36932"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:23:18.39324553Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1160940652807591,
+				"StableID":   "n2ky2fwn4A11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1160940652807591,
+				"Key":        "nodekey:db23f3d887aabec31020ab17cae9b6c74e1617b0749b9dd6b10b7022f8dd5a26",
+				"DiscoKey":   "discokey:611122099078911c2f25b44a0fe16a33cf3fcf7bde707a0f7a24c047fd83703c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35943",
+					"10.65.0.27:35943",
+					"172.17.0.1:35943",
+					"172.18.0.1:35943",
+					"172.19.0.1:35943",
+					"172.20.0.1:35943",
+					"172.21.0.1:35943",
+					"172.22.0.1:35943",
+					"172.23.0.1:35943",
+					"172.24.0.1:35943",
+					"172.25.0.1:35943",
+					"172.26.0.1:35943",
+					"172.27.0.1:35943",
+					"172.28.0.1:35943"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:23:16.221695078Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:db23f3d887aabec31020ab17cae9b6c74e1617b0749b9dd6b10b7022f8dd5a26",
+			"MachineKey": "mkey:ea7901365114b38bfb0ebb96d5d77d7c170947d3158e3e4330ff0b8a6df8b503",
+			"Peers": [{
+				"ID":         8673558682620626,
+				"StableID":   "n1WTaNgGjA21CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f00a22b63ecf5bc2688aba213366853cf5c120d6bac8738fbc5a706658fb23e",
+				"DiscoKey":   "discokey:56d85cc4c1ea85c5f209b585febfc4cc1c25e41fedc71a0a1f1f062aacd2a947",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35255",
+					"10.65.0.27:35255",
+					"172.17.0.1:35255",
+					"172.18.0.1:35255",
+					"172.19.0.1:35255",
+					"172.20.0.1:35255",
+					"172.21.0.1:35255",
+					"172.22.0.1:35255",
+					"172.23.0.1:35255",
+					"172.24.0.1:35255",
+					"172.25.0.1:35255",
+					"172.26.0.1:35255",
+					"172.27.0.1:35255",
+					"172.28.0.1:35255"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:23:10.945165275Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6650671549347752,
+				"StableID":   "nKrLf7s6wt11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ebc5c4959628162357c3f14e501c639a1154fdf39560ef130402725d30440727",
+				"DiscoKey":   "discokey:f7b1fbd9c6a742c4ebfbedaf3f878bd7979dad7c56ee5ac0c6d041dcb004b131",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39009",
+					"10.65.0.27:39009",
+					"172.17.0.1:39009",
+					"172.18.0.1:39009",
+					"172.19.0.1:39009",
+					"172.20.0.1:39009",
+					"172.21.0.1:39009",
+					"172.22.0.1:39009",
+					"172.23.0.1:39009",
+					"172.24.0.1:39009",
+					"172.25.0.1:39009",
+					"172.26.0.1:39009",
+					"172.27.0.1:39009",
+					"172.28.0.1:39009"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:23:11.41795637Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2244976255107421,
+				"StableID":   "nWF27jikXJ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e213578e1372213514a5bbf56f33e6d77ba8cc7d0d5c2f3e46c456d2f1badc74",
+				"DiscoKey":   "discokey:579e729d1cbfc797d173f11d5f46fc7ad83de9e9b283aeca2a49a9b7d98d777e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57102",
+					"10.65.0.27:57102",
+					"172.17.0.1:57102",
+					"172.18.0.1:57102",
+					"172.19.0.1:57102",
+					"172.20.0.1:57102",
+					"172.21.0.1:57102",
+					"172.22.0.1:57102",
+					"172.23.0.1:57102",
+					"172.24.0.1:57102",
+					"172.25.0.1:57102",
+					"172.26.0.1:57102",
+					"172.27.0.1:57102",
+					"172.28.0.1:57102"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:23:11.958807186Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6171263541698332,
+				"StableID":   "nyqUgTdyBq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2476445888a7ca1728e3a0079cd670cda161d965e846d0373587b3caf9332009",
+				"DiscoKey":   "discokey:051f68b19f9b4fe635977bacb1bfca1fc040739145365fe63dfc0a2a89605e65",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59814",
+					"10.65.0.27:59814",
+					"172.17.0.1:59814",
+					"172.18.0.1:59814",
+					"172.19.0.1:59814",
+					"172.20.0.1:59814",
+					"172.21.0.1:59814",
+					"172.22.0.1:59814",
+					"172.23.0.1:59814",
+					"172.24.0.1:59814",
+					"172.25.0.1:59814",
+					"172.26.0.1:59814",
+					"172.27.0.1:59814",
+					"172.28.0.1:59814"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:23:12.481223468Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1551577726279602,
+				"StableID":   "n1iVYKKi7D11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e2756e136ea21c6bba471c8eedc1b06e23d3057cd90791fdba9d597d5069278",
+				"DiscoKey":   "discokey:ff70c080835318aa43fe94f70fe48347c70516f329050e97b76af662e29c5061",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38162",
+					"10.65.0.27:38162",
+					"172.17.0.1:38162",
+					"172.18.0.1:38162",
+					"172.19.0.1:38162",
+					"172.20.0.1:38162",
+					"172.21.0.1:38162",
+					"172.22.0.1:38162",
+					"172.23.0.1:38162",
+					"172.24.0.1:38162",
+					"172.25.0.1:38162",
+					"172.26.0.1:38162",
+					"172.27.0.1:38162",
+					"172.28.0.1:38162"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:23:13.023253255Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4706334284422163,
+				"StableID":   "npXXdRRWkd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:66893666f17620d3860ab0b16935eed4471d801b7b4b95872179883c4357e878",
+				"DiscoKey":   "discokey:dd7fc7c929f67d2317804d1f0a9a7d3bc39925f2aae88771d6ff942d5e20a518",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54233",
+					"10.65.0.27:54233",
+					"172.17.0.1:54233",
+					"172.18.0.1:54233",
+					"172.19.0.1:54233",
+					"172.20.0.1:54233",
+					"172.21.0.1:54233",
+					"172.22.0.1:54233",
+					"172.23.0.1:54233",
+					"172.24.0.1:54233",
+					"172.25.0.1:54233",
+					"172.26.0.1:54233",
+					"172.27.0.1:54233",
+					"172.28.0.1:54233"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:23:13.597689279Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8005462359786735,
+				"StableID":   "nJLMKSvgW521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39d88542309654ce8a973e34fe7d60ca5c47b575af7da6afd2b4d6eae2f9077f",
+				"DiscoKey":   "discokey:ccf844837e56d79c3e457d101f3df115b40532363613164c1b758e722a773c5b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:42546",
+					"10.65.0.27:42546",
+					"172.17.0.1:42546",
+					"172.18.0.1:42546",
+					"172.19.0.1:42546",
+					"172.20.0.1:42546",
+					"172.21.0.1:42546",
+					"172.22.0.1:42546",
+					"172.23.0.1:42546",
+					"172.24.0.1:42546",
+					"172.25.0.1:42546",
+					"172.26.0.1:42546",
+					"172.27.0.1:42546",
+					"172.28.0.1:42546"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:23:14.075062687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7744074492126791,
+				"StableID":   "nzarXuhJU321CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e8a1584616730ff02f1e350a676ebcb776286c99b21d9313107fb43bf4d2032f",
+				"DiscoKey":   "discokey:0d68505902bbd77439edae3e449038195517a929ecca862c7d712af7ffdde475",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47693",
+					"10.65.0.27:47693",
+					"172.17.0.1:47693",
+					"172.18.0.1:47693",
+					"172.19.0.1:47693",
+					"172.20.0.1:47693",
+					"172.21.0.1:47693",
+					"172.22.0.1:47693",
+					"172.23.0.1:47693",
+					"172.24.0.1:47693",
+					"172.25.0.1:47693",
+					"172.26.0.1:47693",
+					"172.27.0.1:47693",
+					"172.28.0.1:47693"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:23:14.62767129Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6412229175349026,
+				"StableID":   "nBbYaTP75s11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f22067dadfa55846929e0cfddf14c47b05658a445e07f7954469c9c292e1dc1a",
+				"DiscoKey":   "discokey:f60ee33c0459fd7b7b865488e0b1850cc4173fb84b24b086608db7df18ca2a3d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43955",
+					"10.65.0.27:43955",
+					"172.17.0.1:43955",
+					"172.18.0.1:43955",
+					"172.19.0.1:43955",
+					"172.20.0.1:43955",
+					"172.21.0.1:43955",
+					"172.22.0.1:43955",
+					"172.23.0.1:43955",
+					"172.24.0.1:43955",
+					"172.25.0.1:43955",
+					"172.26.0.1:43955",
+					"172.27.0.1:43955",
+					"172.28.0.1:43955"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:23:15.166947237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3022813035734529,
+				"StableID":   "nxCCq1B3cQ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:deaef98e694a8ed3cf1430888f79c8c8f3c5ec6542f273f3740f9fe5d508f440",
+				"DiscoKey":   "discokey:9d2611b6b1d2248a398e7b4284d3874cf7a252c80a0a4613068d1405daf09331",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38713",
+					"10.65.0.27:38713",
+					"172.17.0.1:38713",
+					"172.18.0.1:38713",
+					"172.19.0.1:38713",
+					"172.20.0.1:38713",
+					"172.21.0.1:38713",
+					"172.22.0.1:38713",
+					"172.23.0.1:38713",
+					"172.24.0.1:38713",
+					"172.25.0.1:38713",
+					"172.26.0.1:38713",
+					"172.27.0.1:38713",
+					"172.28.0.1:38713"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:23:15.70111166Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6890529266015242,
+				"StableID":   "njjGj8Xjov11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fa77ba1ae5462136c471ac93af15f5068029374a1cea5e4a38cf009a43c0363b",
+				"DiscoKey":   "discokey:50a6ae6716b1268e344eb542a019872f708b18a580cef5eaf74e3a291761cd13",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47165",
+					"10.65.0.27:47165",
+					"172.17.0.1:47165",
+					"172.18.0.1:47165",
+					"172.19.0.1:47165",
+					"172.20.0.1:47165",
+					"172.21.0.1:47165",
+					"172.22.0.1:47165",
+					"172.23.0.1:47165",
+					"172.24.0.1:47165",
+					"172.25.0.1:47165",
+					"172.26.0.1:47165",
+					"172.27.0.1:47165",
+					"172.28.0.1:47165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:23:16.812549339Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4114028313391231,
+				"StableID":   "nQB8EmYF8Z11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8623229a8a613c18bd53d3c987b6ba01dcd0b16cd90c6802bd5bf42267ce1a20",
+				"KeyExpiry":  "2026-11-09T09:23:17Z",
+				"DiscoKey":   "discokey:fbe0efc3b993550e256e689a828f5ea7d719b06c319f84655b2621b9895ed200",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:57427",
+					"10.65.0.27:57427",
+					"172.17.0.1:57427",
+					"172.18.0.1:57427",
+					"172.19.0.1:57427",
+					"172.20.0.1:57427",
+					"172.21.0.1:57427",
+					"172.22.0.1:57427",
+					"172.23.0.1:57427",
+					"172.24.0.1:57427",
+					"172.25.0.1:57427",
+					"172.26.0.1:57427",
+					"172.27.0.1:57427",
+					"172.28.0.1:57427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:23:17.296247424Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6744843673391373,
+				"StableID":   "nEVZn9ckfu11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:195ea1120c871dd9ccd872e67e374c7c5f3456dda9df7d44540f5c366f666c07",
+				"KeyExpiry":  "2026-11-09T09:23:17Z",
+				"DiscoKey":   "discokey:65c5e068b41990e85d8537c6ba5f5ea56b0deed6cf03ea79b232d472359a195e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48844",
+					"10.65.0.27:48844",
+					"172.17.0.1:48844",
+					"172.18.0.1:48844",
+					"172.19.0.1:48844",
+					"172.20.0.1:48844",
+					"172.21.0.1:48844",
+					"172.22.0.1:48844",
+					"172.23.0.1:48844",
+					"172.24.0.1:48844",
+					"172.25.0.1:48844",
+					"172.26.0.1:48844",
+					"172.27.0.1:48844",
+					"172.28.0.1:48844"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:23:17.844641649Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7244862843203504,
+				"StableID":   "nuM2bBGDay11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:29a2762352fe54e950f8d2f12e037313ca0737eb42976406472da0fc67ad875f",
+				"KeyExpiry":  "2026-11-09T09:23:18Z",
+				"DiscoKey":   "discokey:357b53e43c03765f7001405e3e0d7f129a0859a8e35353a200220c73e84ea37d",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36932",
+					"10.65.0.27:36932",
+					"172.17.0.1:36932",
+					"172.18.0.1:36932",
+					"172.19.0.1:36932",
+					"172.20.0.1:36932",
+					"172.21.0.1:36932",
+					"172.22.0.1:36932",
+					"172.23.0.1:36932",
+					"172.24.0.1:36932",
+					"172.25.0.1:36932",
+					"172.26.0.1:36932",
+					"172.27.0.1:36932",
+					"172.28.0.1:36932"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:23:18.39324553Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1160940652807591": {
+				"ID":          1160940652807591,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6650671549347752,
+				"StableID":   "nKrLf7s6wt11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       6650671549347752,
+				"Key":        "nodekey:ebc5c4959628162357c3f14e501c639a1154fdf39560ef130402725d30440727",
+				"DiscoKey":   "discokey:f7b1fbd9c6a742c4ebfbedaf3f878bd7979dad7c56ee5ac0c6d041dcb004b131",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39009",
+					"10.65.0.27:39009",
+					"172.17.0.1:39009",
+					"172.18.0.1:39009",
+					"172.19.0.1:39009",
+					"172.20.0.1:39009",
+					"172.21.0.1:39009",
+					"172.22.0.1:39009",
+					"172.23.0.1:39009",
+					"172.24.0.1:39009",
+					"172.25.0.1:39009",
+					"172.26.0.1:39009",
+					"172.27.0.1:39009",
+					"172.28.0.1:39009"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:23:11.41795637Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ebc5c4959628162357c3f14e501c639a1154fdf39560ef130402725d30440727",
+			"MachineKey": "mkey:059b50b06cda80374fc72d48d2593a5b46fedc198a330044bbba080f220e863c",
+			"Peers": [{
+				"ID":         8673558682620626,
+				"StableID":   "n1WTaNgGjA21CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f00a22b63ecf5bc2688aba213366853cf5c120d6bac8738fbc5a706658fb23e",
+				"DiscoKey":   "discokey:56d85cc4c1ea85c5f209b585febfc4cc1c25e41fedc71a0a1f1f062aacd2a947",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35255",
+					"10.65.0.27:35255",
+					"172.17.0.1:35255",
+					"172.18.0.1:35255",
+					"172.19.0.1:35255",
+					"172.20.0.1:35255",
+					"172.21.0.1:35255",
+					"172.22.0.1:35255",
+					"172.23.0.1:35255",
+					"172.24.0.1:35255",
+					"172.25.0.1:35255",
+					"172.26.0.1:35255",
+					"172.27.0.1:35255",
+					"172.28.0.1:35255"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:23:10.945165275Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2244976255107421,
+				"StableID":   "nWF27jikXJ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e213578e1372213514a5bbf56f33e6d77ba8cc7d0d5c2f3e46c456d2f1badc74",
+				"DiscoKey":   "discokey:579e729d1cbfc797d173f11d5f46fc7ad83de9e9b283aeca2a49a9b7d98d777e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57102",
+					"10.65.0.27:57102",
+					"172.17.0.1:57102",
+					"172.18.0.1:57102",
+					"172.19.0.1:57102",
+					"172.20.0.1:57102",
+					"172.21.0.1:57102",
+					"172.22.0.1:57102",
+					"172.23.0.1:57102",
+					"172.24.0.1:57102",
+					"172.25.0.1:57102",
+					"172.26.0.1:57102",
+					"172.27.0.1:57102",
+					"172.28.0.1:57102"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:23:11.958807186Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6171263541698332,
+				"StableID":   "nyqUgTdyBq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2476445888a7ca1728e3a0079cd670cda161d965e846d0373587b3caf9332009",
+				"DiscoKey":   "discokey:051f68b19f9b4fe635977bacb1bfca1fc040739145365fe63dfc0a2a89605e65",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59814",
+					"10.65.0.27:59814",
+					"172.17.0.1:59814",
+					"172.18.0.1:59814",
+					"172.19.0.1:59814",
+					"172.20.0.1:59814",
+					"172.21.0.1:59814",
+					"172.22.0.1:59814",
+					"172.23.0.1:59814",
+					"172.24.0.1:59814",
+					"172.25.0.1:59814",
+					"172.26.0.1:59814",
+					"172.27.0.1:59814",
+					"172.28.0.1:59814"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:23:12.481223468Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1551577726279602,
+				"StableID":   "n1iVYKKi7D11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e2756e136ea21c6bba471c8eedc1b06e23d3057cd90791fdba9d597d5069278",
+				"DiscoKey":   "discokey:ff70c080835318aa43fe94f70fe48347c70516f329050e97b76af662e29c5061",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38162",
+					"10.65.0.27:38162",
+					"172.17.0.1:38162",
+					"172.18.0.1:38162",
+					"172.19.0.1:38162",
+					"172.20.0.1:38162",
+					"172.21.0.1:38162",
+					"172.22.0.1:38162",
+					"172.23.0.1:38162",
+					"172.24.0.1:38162",
+					"172.25.0.1:38162",
+					"172.26.0.1:38162",
+					"172.27.0.1:38162",
+					"172.28.0.1:38162"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:23:13.023253255Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4706334284422163,
+				"StableID":   "npXXdRRWkd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:66893666f17620d3860ab0b16935eed4471d801b7b4b95872179883c4357e878",
+				"DiscoKey":   "discokey:dd7fc7c929f67d2317804d1f0a9a7d3bc39925f2aae88771d6ff942d5e20a518",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54233",
+					"10.65.0.27:54233",
+					"172.17.0.1:54233",
+					"172.18.0.1:54233",
+					"172.19.0.1:54233",
+					"172.20.0.1:54233",
+					"172.21.0.1:54233",
+					"172.22.0.1:54233",
+					"172.23.0.1:54233",
+					"172.24.0.1:54233",
+					"172.25.0.1:54233",
+					"172.26.0.1:54233",
+					"172.27.0.1:54233",
+					"172.28.0.1:54233"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:23:13.597689279Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8005462359786735,
+				"StableID":   "nJLMKSvgW521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39d88542309654ce8a973e34fe7d60ca5c47b575af7da6afd2b4d6eae2f9077f",
+				"DiscoKey":   "discokey:ccf844837e56d79c3e457d101f3df115b40532363613164c1b758e722a773c5b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:42546",
+					"10.65.0.27:42546",
+					"172.17.0.1:42546",
+					"172.18.0.1:42546",
+					"172.19.0.1:42546",
+					"172.20.0.1:42546",
+					"172.21.0.1:42546",
+					"172.22.0.1:42546",
+					"172.23.0.1:42546",
+					"172.24.0.1:42546",
+					"172.25.0.1:42546",
+					"172.26.0.1:42546",
+					"172.27.0.1:42546",
+					"172.28.0.1:42546"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:23:14.075062687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7744074492126791,
+				"StableID":   "nzarXuhJU321CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e8a1584616730ff02f1e350a676ebcb776286c99b21d9313107fb43bf4d2032f",
+				"DiscoKey":   "discokey:0d68505902bbd77439edae3e449038195517a929ecca862c7d712af7ffdde475",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47693",
+					"10.65.0.27:47693",
+					"172.17.0.1:47693",
+					"172.18.0.1:47693",
+					"172.19.0.1:47693",
+					"172.20.0.1:47693",
+					"172.21.0.1:47693",
+					"172.22.0.1:47693",
+					"172.23.0.1:47693",
+					"172.24.0.1:47693",
+					"172.25.0.1:47693",
+					"172.26.0.1:47693",
+					"172.27.0.1:47693",
+					"172.28.0.1:47693"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:23:14.62767129Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6412229175349026,
+				"StableID":   "nBbYaTP75s11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f22067dadfa55846929e0cfddf14c47b05658a445e07f7954469c9c292e1dc1a",
+				"DiscoKey":   "discokey:f60ee33c0459fd7b7b865488e0b1850cc4173fb84b24b086608db7df18ca2a3d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43955",
+					"10.65.0.27:43955",
+					"172.17.0.1:43955",
+					"172.18.0.1:43955",
+					"172.19.0.1:43955",
+					"172.20.0.1:43955",
+					"172.21.0.1:43955",
+					"172.22.0.1:43955",
+					"172.23.0.1:43955",
+					"172.24.0.1:43955",
+					"172.25.0.1:43955",
+					"172.26.0.1:43955",
+					"172.27.0.1:43955",
+					"172.28.0.1:43955"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:23:15.166947237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3022813035734529,
+				"StableID":   "nxCCq1B3cQ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:deaef98e694a8ed3cf1430888f79c8c8f3c5ec6542f273f3740f9fe5d508f440",
+				"DiscoKey":   "discokey:9d2611b6b1d2248a398e7b4284d3874cf7a252c80a0a4613068d1405daf09331",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38713",
+					"10.65.0.27:38713",
+					"172.17.0.1:38713",
+					"172.18.0.1:38713",
+					"172.19.0.1:38713",
+					"172.20.0.1:38713",
+					"172.21.0.1:38713",
+					"172.22.0.1:38713",
+					"172.23.0.1:38713",
+					"172.24.0.1:38713",
+					"172.25.0.1:38713",
+					"172.26.0.1:38713",
+					"172.27.0.1:38713",
+					"172.28.0.1:38713"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:23:15.70111166Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1160940652807591,
+				"StableID":   "n2ky2fwn4A11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db23f3d887aabec31020ab17cae9b6c74e1617b0749b9dd6b10b7022f8dd5a26",
+				"DiscoKey":   "discokey:611122099078911c2f25b44a0fe16a33cf3fcf7bde707a0f7a24c047fd83703c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35943",
+					"10.65.0.27:35943",
+					"172.17.0.1:35943",
+					"172.18.0.1:35943",
+					"172.19.0.1:35943",
+					"172.20.0.1:35943",
+					"172.21.0.1:35943",
+					"172.22.0.1:35943",
+					"172.23.0.1:35943",
+					"172.24.0.1:35943",
+					"172.25.0.1:35943",
+					"172.26.0.1:35943",
+					"172.27.0.1:35943",
+					"172.28.0.1:35943"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:23:16.221695078Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6890529266015242,
+				"StableID":   "njjGj8Xjov11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fa77ba1ae5462136c471ac93af15f5068029374a1cea5e4a38cf009a43c0363b",
+				"DiscoKey":   "discokey:50a6ae6716b1268e344eb542a019872f708b18a580cef5eaf74e3a291761cd13",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47165",
+					"10.65.0.27:47165",
+					"172.17.0.1:47165",
+					"172.18.0.1:47165",
+					"172.19.0.1:47165",
+					"172.20.0.1:47165",
+					"172.21.0.1:47165",
+					"172.22.0.1:47165",
+					"172.23.0.1:47165",
+					"172.24.0.1:47165",
+					"172.25.0.1:47165",
+					"172.26.0.1:47165",
+					"172.27.0.1:47165",
+					"172.28.0.1:47165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:23:16.812549339Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4114028313391231,
+				"StableID":   "nQB8EmYF8Z11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8623229a8a613c18bd53d3c987b6ba01dcd0b16cd90c6802bd5bf42267ce1a20",
+				"KeyExpiry":  "2026-11-09T09:23:17Z",
+				"DiscoKey":   "discokey:fbe0efc3b993550e256e689a828f5ea7d719b06c319f84655b2621b9895ed200",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:57427",
+					"10.65.0.27:57427",
+					"172.17.0.1:57427",
+					"172.18.0.1:57427",
+					"172.19.0.1:57427",
+					"172.20.0.1:57427",
+					"172.21.0.1:57427",
+					"172.22.0.1:57427",
+					"172.23.0.1:57427",
+					"172.24.0.1:57427",
+					"172.25.0.1:57427",
+					"172.26.0.1:57427",
+					"172.27.0.1:57427",
+					"172.28.0.1:57427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:23:17.296247424Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6744843673391373,
+				"StableID":   "nEVZn9ckfu11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:195ea1120c871dd9ccd872e67e374c7c5f3456dda9df7d44540f5c366f666c07",
+				"KeyExpiry":  "2026-11-09T09:23:17Z",
+				"DiscoKey":   "discokey:65c5e068b41990e85d8537c6ba5f5ea56b0deed6cf03ea79b232d472359a195e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48844",
+					"10.65.0.27:48844",
+					"172.17.0.1:48844",
+					"172.18.0.1:48844",
+					"172.19.0.1:48844",
+					"172.20.0.1:48844",
+					"172.21.0.1:48844",
+					"172.22.0.1:48844",
+					"172.23.0.1:48844",
+					"172.24.0.1:48844",
+					"172.25.0.1:48844",
+					"172.26.0.1:48844",
+					"172.27.0.1:48844",
+					"172.28.0.1:48844"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:23:17.844641649Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7244862843203504,
+				"StableID":   "nuM2bBGDay11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:29a2762352fe54e950f8d2f12e037313ca0737eb42976406472da0fc67ad875f",
+				"KeyExpiry":  "2026-11-09T09:23:18Z",
+				"DiscoKey":   "discokey:357b53e43c03765f7001405e3e0d7f129a0859a8e35353a200220c73e84ea37d",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36932",
+					"10.65.0.27:36932",
+					"172.17.0.1:36932",
+					"172.18.0.1:36932",
+					"172.19.0.1:36932",
+					"172.20.0.1:36932",
+					"172.21.0.1:36932",
+					"172.22.0.1:36932",
+					"172.23.0.1:36932",
+					"172.24.0.1:36932",
+					"172.25.0.1:36932",
+					"172.26.0.1:36932",
+					"172.27.0.1:36932",
+					"172.28.0.1:36932"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:23:18.39324553Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6650671549347752": {
+				"ID":          6650671549347752,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8673558682620626,
+				"StableID":   "n1WTaNgGjA21CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       8673558682620626,
+				"Key":        "nodekey:0f00a22b63ecf5bc2688aba213366853cf5c120d6bac8738fbc5a706658fb23e",
+				"DiscoKey":   "discokey:56d85cc4c1ea85c5f209b585febfc4cc1c25e41fedc71a0a1f1f062aacd2a947",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35255",
+					"10.65.0.27:35255",
+					"172.17.0.1:35255",
+					"172.18.0.1:35255",
+					"172.19.0.1:35255",
+					"172.20.0.1:35255",
+					"172.21.0.1:35255",
+					"172.22.0.1:35255",
+					"172.23.0.1:35255",
+					"172.24.0.1:35255",
+					"172.25.0.1:35255",
+					"172.26.0.1:35255",
+					"172.27.0.1:35255",
+					"172.28.0.1:35255"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:23:10.945165275Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0f00a22b63ecf5bc2688aba213366853cf5c120d6bac8738fbc5a706658fb23e",
+			"MachineKey": "mkey:45426e64470b72574136b5f4c7b1585db37d2db52241213b045d0fc37eee235a",
+			"Peers": [{
+				"ID":         6650671549347752,
+				"StableID":   "nKrLf7s6wt11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ebc5c4959628162357c3f14e501c639a1154fdf39560ef130402725d30440727",
+				"DiscoKey":   "discokey:f7b1fbd9c6a742c4ebfbedaf3f878bd7979dad7c56ee5ac0c6d041dcb004b131",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39009",
+					"10.65.0.27:39009",
+					"172.17.0.1:39009",
+					"172.18.0.1:39009",
+					"172.19.0.1:39009",
+					"172.20.0.1:39009",
+					"172.21.0.1:39009",
+					"172.22.0.1:39009",
+					"172.23.0.1:39009",
+					"172.24.0.1:39009",
+					"172.25.0.1:39009",
+					"172.26.0.1:39009",
+					"172.27.0.1:39009",
+					"172.28.0.1:39009"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:23:11.41795637Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2244976255107421,
+				"StableID":   "nWF27jikXJ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e213578e1372213514a5bbf56f33e6d77ba8cc7d0d5c2f3e46c456d2f1badc74",
+				"DiscoKey":   "discokey:579e729d1cbfc797d173f11d5f46fc7ad83de9e9b283aeca2a49a9b7d98d777e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57102",
+					"10.65.0.27:57102",
+					"172.17.0.1:57102",
+					"172.18.0.1:57102",
+					"172.19.0.1:57102",
+					"172.20.0.1:57102",
+					"172.21.0.1:57102",
+					"172.22.0.1:57102",
+					"172.23.0.1:57102",
+					"172.24.0.1:57102",
+					"172.25.0.1:57102",
+					"172.26.0.1:57102",
+					"172.27.0.1:57102",
+					"172.28.0.1:57102"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:23:11.958807186Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6171263541698332,
+				"StableID":   "nyqUgTdyBq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2476445888a7ca1728e3a0079cd670cda161d965e846d0373587b3caf9332009",
+				"DiscoKey":   "discokey:051f68b19f9b4fe635977bacb1bfca1fc040739145365fe63dfc0a2a89605e65",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59814",
+					"10.65.0.27:59814",
+					"172.17.0.1:59814",
+					"172.18.0.1:59814",
+					"172.19.0.1:59814",
+					"172.20.0.1:59814",
+					"172.21.0.1:59814",
+					"172.22.0.1:59814",
+					"172.23.0.1:59814",
+					"172.24.0.1:59814",
+					"172.25.0.1:59814",
+					"172.26.0.1:59814",
+					"172.27.0.1:59814",
+					"172.28.0.1:59814"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:23:12.481223468Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1551577726279602,
+				"StableID":   "n1iVYKKi7D11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e2756e136ea21c6bba471c8eedc1b06e23d3057cd90791fdba9d597d5069278",
+				"DiscoKey":   "discokey:ff70c080835318aa43fe94f70fe48347c70516f329050e97b76af662e29c5061",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38162",
+					"10.65.0.27:38162",
+					"172.17.0.1:38162",
+					"172.18.0.1:38162",
+					"172.19.0.1:38162",
+					"172.20.0.1:38162",
+					"172.21.0.1:38162",
+					"172.22.0.1:38162",
+					"172.23.0.1:38162",
+					"172.24.0.1:38162",
+					"172.25.0.1:38162",
+					"172.26.0.1:38162",
+					"172.27.0.1:38162",
+					"172.28.0.1:38162"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:23:13.023253255Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4706334284422163,
+				"StableID":   "npXXdRRWkd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:66893666f17620d3860ab0b16935eed4471d801b7b4b95872179883c4357e878",
+				"DiscoKey":   "discokey:dd7fc7c929f67d2317804d1f0a9a7d3bc39925f2aae88771d6ff942d5e20a518",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54233",
+					"10.65.0.27:54233",
+					"172.17.0.1:54233",
+					"172.18.0.1:54233",
+					"172.19.0.1:54233",
+					"172.20.0.1:54233",
+					"172.21.0.1:54233",
+					"172.22.0.1:54233",
+					"172.23.0.1:54233",
+					"172.24.0.1:54233",
+					"172.25.0.1:54233",
+					"172.26.0.1:54233",
+					"172.27.0.1:54233",
+					"172.28.0.1:54233"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:23:13.597689279Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8005462359786735,
+				"StableID":   "nJLMKSvgW521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39d88542309654ce8a973e34fe7d60ca5c47b575af7da6afd2b4d6eae2f9077f",
+				"DiscoKey":   "discokey:ccf844837e56d79c3e457d101f3df115b40532363613164c1b758e722a773c5b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:42546",
+					"10.65.0.27:42546",
+					"172.17.0.1:42546",
+					"172.18.0.1:42546",
+					"172.19.0.1:42546",
+					"172.20.0.1:42546",
+					"172.21.0.1:42546",
+					"172.22.0.1:42546",
+					"172.23.0.1:42546",
+					"172.24.0.1:42546",
+					"172.25.0.1:42546",
+					"172.26.0.1:42546",
+					"172.27.0.1:42546",
+					"172.28.0.1:42546"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:23:14.075062687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7744074492126791,
+				"StableID":   "nzarXuhJU321CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e8a1584616730ff02f1e350a676ebcb776286c99b21d9313107fb43bf4d2032f",
+				"DiscoKey":   "discokey:0d68505902bbd77439edae3e449038195517a929ecca862c7d712af7ffdde475",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47693",
+					"10.65.0.27:47693",
+					"172.17.0.1:47693",
+					"172.18.0.1:47693",
+					"172.19.0.1:47693",
+					"172.20.0.1:47693",
+					"172.21.0.1:47693",
+					"172.22.0.1:47693",
+					"172.23.0.1:47693",
+					"172.24.0.1:47693",
+					"172.25.0.1:47693",
+					"172.26.0.1:47693",
+					"172.27.0.1:47693",
+					"172.28.0.1:47693"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:23:14.62767129Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6412229175349026,
+				"StableID":   "nBbYaTP75s11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f22067dadfa55846929e0cfddf14c47b05658a445e07f7954469c9c292e1dc1a",
+				"DiscoKey":   "discokey:f60ee33c0459fd7b7b865488e0b1850cc4173fb84b24b086608db7df18ca2a3d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43955",
+					"10.65.0.27:43955",
+					"172.17.0.1:43955",
+					"172.18.0.1:43955",
+					"172.19.0.1:43955",
+					"172.20.0.1:43955",
+					"172.21.0.1:43955",
+					"172.22.0.1:43955",
+					"172.23.0.1:43955",
+					"172.24.0.1:43955",
+					"172.25.0.1:43955",
+					"172.26.0.1:43955",
+					"172.27.0.1:43955",
+					"172.28.0.1:43955"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:23:15.166947237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3022813035734529,
+				"StableID":   "nxCCq1B3cQ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:deaef98e694a8ed3cf1430888f79c8c8f3c5ec6542f273f3740f9fe5d508f440",
+				"DiscoKey":   "discokey:9d2611b6b1d2248a398e7b4284d3874cf7a252c80a0a4613068d1405daf09331",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38713",
+					"10.65.0.27:38713",
+					"172.17.0.1:38713",
+					"172.18.0.1:38713",
+					"172.19.0.1:38713",
+					"172.20.0.1:38713",
+					"172.21.0.1:38713",
+					"172.22.0.1:38713",
+					"172.23.0.1:38713",
+					"172.24.0.1:38713",
+					"172.25.0.1:38713",
+					"172.26.0.1:38713",
+					"172.27.0.1:38713",
+					"172.28.0.1:38713"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:23:15.70111166Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1160940652807591,
+				"StableID":   "n2ky2fwn4A11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db23f3d887aabec31020ab17cae9b6c74e1617b0749b9dd6b10b7022f8dd5a26",
+				"DiscoKey":   "discokey:611122099078911c2f25b44a0fe16a33cf3fcf7bde707a0f7a24c047fd83703c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35943",
+					"10.65.0.27:35943",
+					"172.17.0.1:35943",
+					"172.18.0.1:35943",
+					"172.19.0.1:35943",
+					"172.20.0.1:35943",
+					"172.21.0.1:35943",
+					"172.22.0.1:35943",
+					"172.23.0.1:35943",
+					"172.24.0.1:35943",
+					"172.25.0.1:35943",
+					"172.26.0.1:35943",
+					"172.27.0.1:35943",
+					"172.28.0.1:35943"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:23:16.221695078Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6890529266015242,
+				"StableID":   "njjGj8Xjov11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fa77ba1ae5462136c471ac93af15f5068029374a1cea5e4a38cf009a43c0363b",
+				"DiscoKey":   "discokey:50a6ae6716b1268e344eb542a019872f708b18a580cef5eaf74e3a291761cd13",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47165",
+					"10.65.0.27:47165",
+					"172.17.0.1:47165",
+					"172.18.0.1:47165",
+					"172.19.0.1:47165",
+					"172.20.0.1:47165",
+					"172.21.0.1:47165",
+					"172.22.0.1:47165",
+					"172.23.0.1:47165",
+					"172.24.0.1:47165",
+					"172.25.0.1:47165",
+					"172.26.0.1:47165",
+					"172.27.0.1:47165",
+					"172.28.0.1:47165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:23:16.812549339Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4114028313391231,
+				"StableID":   "nQB8EmYF8Z11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8623229a8a613c18bd53d3c987b6ba01dcd0b16cd90c6802bd5bf42267ce1a20",
+				"KeyExpiry":  "2026-11-09T09:23:17Z",
+				"DiscoKey":   "discokey:fbe0efc3b993550e256e689a828f5ea7d719b06c319f84655b2621b9895ed200",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:57427",
+					"10.65.0.27:57427",
+					"172.17.0.1:57427",
+					"172.18.0.1:57427",
+					"172.19.0.1:57427",
+					"172.20.0.1:57427",
+					"172.21.0.1:57427",
+					"172.22.0.1:57427",
+					"172.23.0.1:57427",
+					"172.24.0.1:57427",
+					"172.25.0.1:57427",
+					"172.26.0.1:57427",
+					"172.27.0.1:57427",
+					"172.28.0.1:57427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:23:17.296247424Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6744843673391373,
+				"StableID":   "nEVZn9ckfu11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:195ea1120c871dd9ccd872e67e374c7c5f3456dda9df7d44540f5c366f666c07",
+				"KeyExpiry":  "2026-11-09T09:23:17Z",
+				"DiscoKey":   "discokey:65c5e068b41990e85d8537c6ba5f5ea56b0deed6cf03ea79b232d472359a195e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48844",
+					"10.65.0.27:48844",
+					"172.17.0.1:48844",
+					"172.18.0.1:48844",
+					"172.19.0.1:48844",
+					"172.20.0.1:48844",
+					"172.21.0.1:48844",
+					"172.22.0.1:48844",
+					"172.23.0.1:48844",
+					"172.24.0.1:48844",
+					"172.25.0.1:48844",
+					"172.26.0.1:48844",
+					"172.27.0.1:48844",
+					"172.28.0.1:48844"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:23:17.844641649Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7244862843203504,
+				"StableID":   "nuM2bBGDay11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:29a2762352fe54e950f8d2f12e037313ca0737eb42976406472da0fc67ad875f",
+				"KeyExpiry":  "2026-11-09T09:23:18Z",
+				"DiscoKey":   "discokey:357b53e43c03765f7001405e3e0d7f129a0859a8e35353a200220c73e84ea37d",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36932",
+					"10.65.0.27:36932",
+					"172.17.0.1:36932",
+					"172.18.0.1:36932",
+					"172.19.0.1:36932",
+					"172.20.0.1:36932",
+					"172.21.0.1:36932",
+					"172.22.0.1:36932",
+					"172.23.0.1:36932",
+					"172.24.0.1:36932",
+					"172.25.0.1:36932",
+					"172.26.0.1:36932",
+					"172.27.0.1:36932",
+					"172.28.0.1:36932"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:23:18.39324553Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8673558682620626": {
+				"ID":          8673558682620626,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1551577726279602,
+				"StableID":   "n1iVYKKi7D11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1551577726279602,
+				"Key":        "nodekey:8e2756e136ea21c6bba471c8eedc1b06e23d3057cd90791fdba9d597d5069278",
+				"DiscoKey":   "discokey:ff70c080835318aa43fe94f70fe48347c70516f329050e97b76af662e29c5061",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38162",
+					"10.65.0.27:38162",
+					"172.17.0.1:38162",
+					"172.18.0.1:38162",
+					"172.19.0.1:38162",
+					"172.20.0.1:38162",
+					"172.21.0.1:38162",
+					"172.22.0.1:38162",
+					"172.23.0.1:38162",
+					"172.24.0.1:38162",
+					"172.25.0.1:38162",
+					"172.26.0.1:38162",
+					"172.27.0.1:38162",
+					"172.28.0.1:38162"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:23:13.023253255Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8e2756e136ea21c6bba471c8eedc1b06e23d3057cd90791fdba9d597d5069278",
+			"MachineKey": "mkey:b9a9c563b4af05e238ae98466d954f0886aa4817cc07ffaeacf2467789f4a301",
+			"Peers": [{
+				"ID":         8673558682620626,
+				"StableID":   "n1WTaNgGjA21CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f00a22b63ecf5bc2688aba213366853cf5c120d6bac8738fbc5a706658fb23e",
+				"DiscoKey":   "discokey:56d85cc4c1ea85c5f209b585febfc4cc1c25e41fedc71a0a1f1f062aacd2a947",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35255",
+					"10.65.0.27:35255",
+					"172.17.0.1:35255",
+					"172.18.0.1:35255",
+					"172.19.0.1:35255",
+					"172.20.0.1:35255",
+					"172.21.0.1:35255",
+					"172.22.0.1:35255",
+					"172.23.0.1:35255",
+					"172.24.0.1:35255",
+					"172.25.0.1:35255",
+					"172.26.0.1:35255",
+					"172.27.0.1:35255",
+					"172.28.0.1:35255"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:23:10.945165275Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6650671549347752,
+				"StableID":   "nKrLf7s6wt11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ebc5c4959628162357c3f14e501c639a1154fdf39560ef130402725d30440727",
+				"DiscoKey":   "discokey:f7b1fbd9c6a742c4ebfbedaf3f878bd7979dad7c56ee5ac0c6d041dcb004b131",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39009",
+					"10.65.0.27:39009",
+					"172.17.0.1:39009",
+					"172.18.0.1:39009",
+					"172.19.0.1:39009",
+					"172.20.0.1:39009",
+					"172.21.0.1:39009",
+					"172.22.0.1:39009",
+					"172.23.0.1:39009",
+					"172.24.0.1:39009",
+					"172.25.0.1:39009",
+					"172.26.0.1:39009",
+					"172.27.0.1:39009",
+					"172.28.0.1:39009"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:23:11.41795637Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2244976255107421,
+				"StableID":   "nWF27jikXJ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e213578e1372213514a5bbf56f33e6d77ba8cc7d0d5c2f3e46c456d2f1badc74",
+				"DiscoKey":   "discokey:579e729d1cbfc797d173f11d5f46fc7ad83de9e9b283aeca2a49a9b7d98d777e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57102",
+					"10.65.0.27:57102",
+					"172.17.0.1:57102",
+					"172.18.0.1:57102",
+					"172.19.0.1:57102",
+					"172.20.0.1:57102",
+					"172.21.0.1:57102",
+					"172.22.0.1:57102",
+					"172.23.0.1:57102",
+					"172.24.0.1:57102",
+					"172.25.0.1:57102",
+					"172.26.0.1:57102",
+					"172.27.0.1:57102",
+					"172.28.0.1:57102"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:23:11.958807186Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6171263541698332,
+				"StableID":   "nyqUgTdyBq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2476445888a7ca1728e3a0079cd670cda161d965e846d0373587b3caf9332009",
+				"DiscoKey":   "discokey:051f68b19f9b4fe635977bacb1bfca1fc040739145365fe63dfc0a2a89605e65",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59814",
+					"10.65.0.27:59814",
+					"172.17.0.1:59814",
+					"172.18.0.1:59814",
+					"172.19.0.1:59814",
+					"172.20.0.1:59814",
+					"172.21.0.1:59814",
+					"172.22.0.1:59814",
+					"172.23.0.1:59814",
+					"172.24.0.1:59814",
+					"172.25.0.1:59814",
+					"172.26.0.1:59814",
+					"172.27.0.1:59814",
+					"172.28.0.1:59814"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:23:12.481223468Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4706334284422163,
+				"StableID":   "npXXdRRWkd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:66893666f17620d3860ab0b16935eed4471d801b7b4b95872179883c4357e878",
+				"DiscoKey":   "discokey:dd7fc7c929f67d2317804d1f0a9a7d3bc39925f2aae88771d6ff942d5e20a518",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54233",
+					"10.65.0.27:54233",
+					"172.17.0.1:54233",
+					"172.18.0.1:54233",
+					"172.19.0.1:54233",
+					"172.20.0.1:54233",
+					"172.21.0.1:54233",
+					"172.22.0.1:54233",
+					"172.23.0.1:54233",
+					"172.24.0.1:54233",
+					"172.25.0.1:54233",
+					"172.26.0.1:54233",
+					"172.27.0.1:54233",
+					"172.28.0.1:54233"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:23:13.597689279Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8005462359786735,
+				"StableID":   "nJLMKSvgW521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39d88542309654ce8a973e34fe7d60ca5c47b575af7da6afd2b4d6eae2f9077f",
+				"DiscoKey":   "discokey:ccf844837e56d79c3e457d101f3df115b40532363613164c1b758e722a773c5b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:42546",
+					"10.65.0.27:42546",
+					"172.17.0.1:42546",
+					"172.18.0.1:42546",
+					"172.19.0.1:42546",
+					"172.20.0.1:42546",
+					"172.21.0.1:42546",
+					"172.22.0.1:42546",
+					"172.23.0.1:42546",
+					"172.24.0.1:42546",
+					"172.25.0.1:42546",
+					"172.26.0.1:42546",
+					"172.27.0.1:42546",
+					"172.28.0.1:42546"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:23:14.075062687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7744074492126791,
+				"StableID":   "nzarXuhJU321CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e8a1584616730ff02f1e350a676ebcb776286c99b21d9313107fb43bf4d2032f",
+				"DiscoKey":   "discokey:0d68505902bbd77439edae3e449038195517a929ecca862c7d712af7ffdde475",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47693",
+					"10.65.0.27:47693",
+					"172.17.0.1:47693",
+					"172.18.0.1:47693",
+					"172.19.0.1:47693",
+					"172.20.0.1:47693",
+					"172.21.0.1:47693",
+					"172.22.0.1:47693",
+					"172.23.0.1:47693",
+					"172.24.0.1:47693",
+					"172.25.0.1:47693",
+					"172.26.0.1:47693",
+					"172.27.0.1:47693",
+					"172.28.0.1:47693"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:23:14.62767129Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6412229175349026,
+				"StableID":   "nBbYaTP75s11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f22067dadfa55846929e0cfddf14c47b05658a445e07f7954469c9c292e1dc1a",
+				"DiscoKey":   "discokey:f60ee33c0459fd7b7b865488e0b1850cc4173fb84b24b086608db7df18ca2a3d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43955",
+					"10.65.0.27:43955",
+					"172.17.0.1:43955",
+					"172.18.0.1:43955",
+					"172.19.0.1:43955",
+					"172.20.0.1:43955",
+					"172.21.0.1:43955",
+					"172.22.0.1:43955",
+					"172.23.0.1:43955",
+					"172.24.0.1:43955",
+					"172.25.0.1:43955",
+					"172.26.0.1:43955",
+					"172.27.0.1:43955",
+					"172.28.0.1:43955"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:23:15.166947237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3022813035734529,
+				"StableID":   "nxCCq1B3cQ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:deaef98e694a8ed3cf1430888f79c8c8f3c5ec6542f273f3740f9fe5d508f440",
+				"DiscoKey":   "discokey:9d2611b6b1d2248a398e7b4284d3874cf7a252c80a0a4613068d1405daf09331",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38713",
+					"10.65.0.27:38713",
+					"172.17.0.1:38713",
+					"172.18.0.1:38713",
+					"172.19.0.1:38713",
+					"172.20.0.1:38713",
+					"172.21.0.1:38713",
+					"172.22.0.1:38713",
+					"172.23.0.1:38713",
+					"172.24.0.1:38713",
+					"172.25.0.1:38713",
+					"172.26.0.1:38713",
+					"172.27.0.1:38713",
+					"172.28.0.1:38713"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:23:15.70111166Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1160940652807591,
+				"StableID":   "n2ky2fwn4A11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db23f3d887aabec31020ab17cae9b6c74e1617b0749b9dd6b10b7022f8dd5a26",
+				"DiscoKey":   "discokey:611122099078911c2f25b44a0fe16a33cf3fcf7bde707a0f7a24c047fd83703c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35943",
+					"10.65.0.27:35943",
+					"172.17.0.1:35943",
+					"172.18.0.1:35943",
+					"172.19.0.1:35943",
+					"172.20.0.1:35943",
+					"172.21.0.1:35943",
+					"172.22.0.1:35943",
+					"172.23.0.1:35943",
+					"172.24.0.1:35943",
+					"172.25.0.1:35943",
+					"172.26.0.1:35943",
+					"172.27.0.1:35943",
+					"172.28.0.1:35943"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:23:16.221695078Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6890529266015242,
+				"StableID":   "njjGj8Xjov11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fa77ba1ae5462136c471ac93af15f5068029374a1cea5e4a38cf009a43c0363b",
+				"DiscoKey":   "discokey:50a6ae6716b1268e344eb542a019872f708b18a580cef5eaf74e3a291761cd13",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47165",
+					"10.65.0.27:47165",
+					"172.17.0.1:47165",
+					"172.18.0.1:47165",
+					"172.19.0.1:47165",
+					"172.20.0.1:47165",
+					"172.21.0.1:47165",
+					"172.22.0.1:47165",
+					"172.23.0.1:47165",
+					"172.24.0.1:47165",
+					"172.25.0.1:47165",
+					"172.26.0.1:47165",
+					"172.27.0.1:47165",
+					"172.28.0.1:47165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:23:16.812549339Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4114028313391231,
+				"StableID":   "nQB8EmYF8Z11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8623229a8a613c18bd53d3c987b6ba01dcd0b16cd90c6802bd5bf42267ce1a20",
+				"KeyExpiry":  "2026-11-09T09:23:17Z",
+				"DiscoKey":   "discokey:fbe0efc3b993550e256e689a828f5ea7d719b06c319f84655b2621b9895ed200",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:57427",
+					"10.65.0.27:57427",
+					"172.17.0.1:57427",
+					"172.18.0.1:57427",
+					"172.19.0.1:57427",
+					"172.20.0.1:57427",
+					"172.21.0.1:57427",
+					"172.22.0.1:57427",
+					"172.23.0.1:57427",
+					"172.24.0.1:57427",
+					"172.25.0.1:57427",
+					"172.26.0.1:57427",
+					"172.27.0.1:57427",
+					"172.28.0.1:57427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:23:17.296247424Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6744843673391373,
+				"StableID":   "nEVZn9ckfu11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:195ea1120c871dd9ccd872e67e374c7c5f3456dda9df7d44540f5c366f666c07",
+				"KeyExpiry":  "2026-11-09T09:23:17Z",
+				"DiscoKey":   "discokey:65c5e068b41990e85d8537c6ba5f5ea56b0deed6cf03ea79b232d472359a195e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48844",
+					"10.65.0.27:48844",
+					"172.17.0.1:48844",
+					"172.18.0.1:48844",
+					"172.19.0.1:48844",
+					"172.20.0.1:48844",
+					"172.21.0.1:48844",
+					"172.22.0.1:48844",
+					"172.23.0.1:48844",
+					"172.24.0.1:48844",
+					"172.25.0.1:48844",
+					"172.26.0.1:48844",
+					"172.27.0.1:48844",
+					"172.28.0.1:48844"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:23:17.844641649Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7244862843203504,
+				"StableID":   "nuM2bBGDay11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:29a2762352fe54e950f8d2f12e037313ca0737eb42976406472da0fc67ad875f",
+				"KeyExpiry":  "2026-11-09T09:23:18Z",
+				"DiscoKey":   "discokey:357b53e43c03765f7001405e3e0d7f129a0859a8e35353a200220c73e84ea37d",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36932",
+					"10.65.0.27:36932",
+					"172.17.0.1:36932",
+					"172.18.0.1:36932",
+					"172.19.0.1:36932",
+					"172.20.0.1:36932",
+					"172.21.0.1:36932",
+					"172.22.0.1:36932",
+					"172.23.0.1:36932",
+					"172.24.0.1:36932",
+					"172.25.0.1:36932",
+					"172.26.0.1:36932",
+					"172.27.0.1:36932",
+					"172.28.0.1:36932"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:23:18.39324553Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1551577726279602": {
+				"ID":          1551577726279602,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6171263541698332,
+				"StableID":   "nyqUgTdyBq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       6171263541698332,
+				"Key":        "nodekey:2476445888a7ca1728e3a0079cd670cda161d965e846d0373587b3caf9332009",
+				"DiscoKey":   "discokey:051f68b19f9b4fe635977bacb1bfca1fc040739145365fe63dfc0a2a89605e65",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59814",
+					"10.65.0.27:59814",
+					"172.17.0.1:59814",
+					"172.18.0.1:59814",
+					"172.19.0.1:59814",
+					"172.20.0.1:59814",
+					"172.21.0.1:59814",
+					"172.22.0.1:59814",
+					"172.23.0.1:59814",
+					"172.24.0.1:59814",
+					"172.25.0.1:59814",
+					"172.26.0.1:59814",
+					"172.27.0.1:59814",
+					"172.28.0.1:59814"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:23:12.481223468Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2476445888a7ca1728e3a0079cd670cda161d965e846d0373587b3caf9332009",
+			"MachineKey": "mkey:fade11273f884c3ef5793bd44cce8226981c52048adea017095c3aec5de9990b",
+			"Peers": [{
+				"ID":         8673558682620626,
+				"StableID":   "n1WTaNgGjA21CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f00a22b63ecf5bc2688aba213366853cf5c120d6bac8738fbc5a706658fb23e",
+				"DiscoKey":   "discokey:56d85cc4c1ea85c5f209b585febfc4cc1c25e41fedc71a0a1f1f062aacd2a947",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35255",
+					"10.65.0.27:35255",
+					"172.17.0.1:35255",
+					"172.18.0.1:35255",
+					"172.19.0.1:35255",
+					"172.20.0.1:35255",
+					"172.21.0.1:35255",
+					"172.22.0.1:35255",
+					"172.23.0.1:35255",
+					"172.24.0.1:35255",
+					"172.25.0.1:35255",
+					"172.26.0.1:35255",
+					"172.27.0.1:35255",
+					"172.28.0.1:35255"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:23:10.945165275Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6650671549347752,
+				"StableID":   "nKrLf7s6wt11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ebc5c4959628162357c3f14e501c639a1154fdf39560ef130402725d30440727",
+				"DiscoKey":   "discokey:f7b1fbd9c6a742c4ebfbedaf3f878bd7979dad7c56ee5ac0c6d041dcb004b131",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39009",
+					"10.65.0.27:39009",
+					"172.17.0.1:39009",
+					"172.18.0.1:39009",
+					"172.19.0.1:39009",
+					"172.20.0.1:39009",
+					"172.21.0.1:39009",
+					"172.22.0.1:39009",
+					"172.23.0.1:39009",
+					"172.24.0.1:39009",
+					"172.25.0.1:39009",
+					"172.26.0.1:39009",
+					"172.27.0.1:39009",
+					"172.28.0.1:39009"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:23:11.41795637Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2244976255107421,
+				"StableID":   "nWF27jikXJ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e213578e1372213514a5bbf56f33e6d77ba8cc7d0d5c2f3e46c456d2f1badc74",
+				"DiscoKey":   "discokey:579e729d1cbfc797d173f11d5f46fc7ad83de9e9b283aeca2a49a9b7d98d777e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57102",
+					"10.65.0.27:57102",
+					"172.17.0.1:57102",
+					"172.18.0.1:57102",
+					"172.19.0.1:57102",
+					"172.20.0.1:57102",
+					"172.21.0.1:57102",
+					"172.22.0.1:57102",
+					"172.23.0.1:57102",
+					"172.24.0.1:57102",
+					"172.25.0.1:57102",
+					"172.26.0.1:57102",
+					"172.27.0.1:57102",
+					"172.28.0.1:57102"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:23:11.958807186Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1551577726279602,
+				"StableID":   "n1iVYKKi7D11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e2756e136ea21c6bba471c8eedc1b06e23d3057cd90791fdba9d597d5069278",
+				"DiscoKey":   "discokey:ff70c080835318aa43fe94f70fe48347c70516f329050e97b76af662e29c5061",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38162",
+					"10.65.0.27:38162",
+					"172.17.0.1:38162",
+					"172.18.0.1:38162",
+					"172.19.0.1:38162",
+					"172.20.0.1:38162",
+					"172.21.0.1:38162",
+					"172.22.0.1:38162",
+					"172.23.0.1:38162",
+					"172.24.0.1:38162",
+					"172.25.0.1:38162",
+					"172.26.0.1:38162",
+					"172.27.0.1:38162",
+					"172.28.0.1:38162"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:23:13.023253255Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4706334284422163,
+				"StableID":   "npXXdRRWkd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:66893666f17620d3860ab0b16935eed4471d801b7b4b95872179883c4357e878",
+				"DiscoKey":   "discokey:dd7fc7c929f67d2317804d1f0a9a7d3bc39925f2aae88771d6ff942d5e20a518",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54233",
+					"10.65.0.27:54233",
+					"172.17.0.1:54233",
+					"172.18.0.1:54233",
+					"172.19.0.1:54233",
+					"172.20.0.1:54233",
+					"172.21.0.1:54233",
+					"172.22.0.1:54233",
+					"172.23.0.1:54233",
+					"172.24.0.1:54233",
+					"172.25.0.1:54233",
+					"172.26.0.1:54233",
+					"172.27.0.1:54233",
+					"172.28.0.1:54233"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:23:13.597689279Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8005462359786735,
+				"StableID":   "nJLMKSvgW521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39d88542309654ce8a973e34fe7d60ca5c47b575af7da6afd2b4d6eae2f9077f",
+				"DiscoKey":   "discokey:ccf844837e56d79c3e457d101f3df115b40532363613164c1b758e722a773c5b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:42546",
+					"10.65.0.27:42546",
+					"172.17.0.1:42546",
+					"172.18.0.1:42546",
+					"172.19.0.1:42546",
+					"172.20.0.1:42546",
+					"172.21.0.1:42546",
+					"172.22.0.1:42546",
+					"172.23.0.1:42546",
+					"172.24.0.1:42546",
+					"172.25.0.1:42546",
+					"172.26.0.1:42546",
+					"172.27.0.1:42546",
+					"172.28.0.1:42546"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:23:14.075062687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7744074492126791,
+				"StableID":   "nzarXuhJU321CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e8a1584616730ff02f1e350a676ebcb776286c99b21d9313107fb43bf4d2032f",
+				"DiscoKey":   "discokey:0d68505902bbd77439edae3e449038195517a929ecca862c7d712af7ffdde475",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47693",
+					"10.65.0.27:47693",
+					"172.17.0.1:47693",
+					"172.18.0.1:47693",
+					"172.19.0.1:47693",
+					"172.20.0.1:47693",
+					"172.21.0.1:47693",
+					"172.22.0.1:47693",
+					"172.23.0.1:47693",
+					"172.24.0.1:47693",
+					"172.25.0.1:47693",
+					"172.26.0.1:47693",
+					"172.27.0.1:47693",
+					"172.28.0.1:47693"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:23:14.62767129Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6412229175349026,
+				"StableID":   "nBbYaTP75s11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f22067dadfa55846929e0cfddf14c47b05658a445e07f7954469c9c292e1dc1a",
+				"DiscoKey":   "discokey:f60ee33c0459fd7b7b865488e0b1850cc4173fb84b24b086608db7df18ca2a3d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43955",
+					"10.65.0.27:43955",
+					"172.17.0.1:43955",
+					"172.18.0.1:43955",
+					"172.19.0.1:43955",
+					"172.20.0.1:43955",
+					"172.21.0.1:43955",
+					"172.22.0.1:43955",
+					"172.23.0.1:43955",
+					"172.24.0.1:43955",
+					"172.25.0.1:43955",
+					"172.26.0.1:43955",
+					"172.27.0.1:43955",
+					"172.28.0.1:43955"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:23:15.166947237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3022813035734529,
+				"StableID":   "nxCCq1B3cQ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:deaef98e694a8ed3cf1430888f79c8c8f3c5ec6542f273f3740f9fe5d508f440",
+				"DiscoKey":   "discokey:9d2611b6b1d2248a398e7b4284d3874cf7a252c80a0a4613068d1405daf09331",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38713",
+					"10.65.0.27:38713",
+					"172.17.0.1:38713",
+					"172.18.0.1:38713",
+					"172.19.0.1:38713",
+					"172.20.0.1:38713",
+					"172.21.0.1:38713",
+					"172.22.0.1:38713",
+					"172.23.0.1:38713",
+					"172.24.0.1:38713",
+					"172.25.0.1:38713",
+					"172.26.0.1:38713",
+					"172.27.0.1:38713",
+					"172.28.0.1:38713"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:23:15.70111166Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1160940652807591,
+				"StableID":   "n2ky2fwn4A11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db23f3d887aabec31020ab17cae9b6c74e1617b0749b9dd6b10b7022f8dd5a26",
+				"DiscoKey":   "discokey:611122099078911c2f25b44a0fe16a33cf3fcf7bde707a0f7a24c047fd83703c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35943",
+					"10.65.0.27:35943",
+					"172.17.0.1:35943",
+					"172.18.0.1:35943",
+					"172.19.0.1:35943",
+					"172.20.0.1:35943",
+					"172.21.0.1:35943",
+					"172.22.0.1:35943",
+					"172.23.0.1:35943",
+					"172.24.0.1:35943",
+					"172.25.0.1:35943",
+					"172.26.0.1:35943",
+					"172.27.0.1:35943",
+					"172.28.0.1:35943"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:23:16.221695078Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6890529266015242,
+				"StableID":   "njjGj8Xjov11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fa77ba1ae5462136c471ac93af15f5068029374a1cea5e4a38cf009a43c0363b",
+				"DiscoKey":   "discokey:50a6ae6716b1268e344eb542a019872f708b18a580cef5eaf74e3a291761cd13",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47165",
+					"10.65.0.27:47165",
+					"172.17.0.1:47165",
+					"172.18.0.1:47165",
+					"172.19.0.1:47165",
+					"172.20.0.1:47165",
+					"172.21.0.1:47165",
+					"172.22.0.1:47165",
+					"172.23.0.1:47165",
+					"172.24.0.1:47165",
+					"172.25.0.1:47165",
+					"172.26.0.1:47165",
+					"172.27.0.1:47165",
+					"172.28.0.1:47165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:23:16.812549339Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4114028313391231,
+				"StableID":   "nQB8EmYF8Z11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8623229a8a613c18bd53d3c987b6ba01dcd0b16cd90c6802bd5bf42267ce1a20",
+				"KeyExpiry":  "2026-11-09T09:23:17Z",
+				"DiscoKey":   "discokey:fbe0efc3b993550e256e689a828f5ea7d719b06c319f84655b2621b9895ed200",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:57427",
+					"10.65.0.27:57427",
+					"172.17.0.1:57427",
+					"172.18.0.1:57427",
+					"172.19.0.1:57427",
+					"172.20.0.1:57427",
+					"172.21.0.1:57427",
+					"172.22.0.1:57427",
+					"172.23.0.1:57427",
+					"172.24.0.1:57427",
+					"172.25.0.1:57427",
+					"172.26.0.1:57427",
+					"172.27.0.1:57427",
+					"172.28.0.1:57427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:23:17.296247424Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6744843673391373,
+				"StableID":   "nEVZn9ckfu11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:195ea1120c871dd9ccd872e67e374c7c5f3456dda9df7d44540f5c366f666c07",
+				"KeyExpiry":  "2026-11-09T09:23:17Z",
+				"DiscoKey":   "discokey:65c5e068b41990e85d8537c6ba5f5ea56b0deed6cf03ea79b232d472359a195e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48844",
+					"10.65.0.27:48844",
+					"172.17.0.1:48844",
+					"172.18.0.1:48844",
+					"172.19.0.1:48844",
+					"172.20.0.1:48844",
+					"172.21.0.1:48844",
+					"172.22.0.1:48844",
+					"172.23.0.1:48844",
+					"172.24.0.1:48844",
+					"172.25.0.1:48844",
+					"172.26.0.1:48844",
+					"172.27.0.1:48844",
+					"172.28.0.1:48844"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:23:17.844641649Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7244862843203504,
+				"StableID":   "nuM2bBGDay11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:29a2762352fe54e950f8d2f12e037313ca0737eb42976406472da0fc67ad875f",
+				"KeyExpiry":  "2026-11-09T09:23:18Z",
+				"DiscoKey":   "discokey:357b53e43c03765f7001405e3e0d7f129a0859a8e35353a200220c73e84ea37d",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36932",
+					"10.65.0.27:36932",
+					"172.17.0.1:36932",
+					"172.18.0.1:36932",
+					"172.19.0.1:36932",
+					"172.20.0.1:36932",
+					"172.21.0.1:36932",
+					"172.22.0.1:36932",
+					"172.23.0.1:36932",
+					"172.24.0.1:36932",
+					"172.25.0.1:36932",
+					"172.26.0.1:36932",
+					"172.27.0.1:36932",
+					"172.28.0.1:36932"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:23:18.39324553Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6171263541698332": {
+				"ID":          6171263541698332,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8005462359786735,
+				"StableID":   "nJLMKSvgW521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       8005462359786735,
+				"Key":        "nodekey:39d88542309654ce8a973e34fe7d60ca5c47b575af7da6afd2b4d6eae2f9077f",
+				"DiscoKey":   "discokey:ccf844837e56d79c3e457d101f3df115b40532363613164c1b758e722a773c5b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:42546",
+					"10.65.0.27:42546",
+					"172.17.0.1:42546",
+					"172.18.0.1:42546",
+					"172.19.0.1:42546",
+					"172.20.0.1:42546",
+					"172.21.0.1:42546",
+					"172.22.0.1:42546",
+					"172.23.0.1:42546",
+					"172.24.0.1:42546",
+					"172.25.0.1:42546",
+					"172.26.0.1:42546",
+					"172.27.0.1:42546",
+					"172.28.0.1:42546"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:23:14.075062687Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:39d88542309654ce8a973e34fe7d60ca5c47b575af7da6afd2b4d6eae2f9077f",
+			"MachineKey": "mkey:cb556d2fd5bb0bb416bf38d8e92d3a931ed439de33ba57e8359949152ef05d18",
+			"Peers": [{
+				"ID":         8673558682620626,
+				"StableID":   "n1WTaNgGjA21CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f00a22b63ecf5bc2688aba213366853cf5c120d6bac8738fbc5a706658fb23e",
+				"DiscoKey":   "discokey:56d85cc4c1ea85c5f209b585febfc4cc1c25e41fedc71a0a1f1f062aacd2a947",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35255",
+					"10.65.0.27:35255",
+					"172.17.0.1:35255",
+					"172.18.0.1:35255",
+					"172.19.0.1:35255",
+					"172.20.0.1:35255",
+					"172.21.0.1:35255",
+					"172.22.0.1:35255",
+					"172.23.0.1:35255",
+					"172.24.0.1:35255",
+					"172.25.0.1:35255",
+					"172.26.0.1:35255",
+					"172.27.0.1:35255",
+					"172.28.0.1:35255"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:23:10.945165275Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6650671549347752,
+				"StableID":   "nKrLf7s6wt11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ebc5c4959628162357c3f14e501c639a1154fdf39560ef130402725d30440727",
+				"DiscoKey":   "discokey:f7b1fbd9c6a742c4ebfbedaf3f878bd7979dad7c56ee5ac0c6d041dcb004b131",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39009",
+					"10.65.0.27:39009",
+					"172.17.0.1:39009",
+					"172.18.0.1:39009",
+					"172.19.0.1:39009",
+					"172.20.0.1:39009",
+					"172.21.0.1:39009",
+					"172.22.0.1:39009",
+					"172.23.0.1:39009",
+					"172.24.0.1:39009",
+					"172.25.0.1:39009",
+					"172.26.0.1:39009",
+					"172.27.0.1:39009",
+					"172.28.0.1:39009"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:23:11.41795637Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2244976255107421,
+				"StableID":   "nWF27jikXJ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e213578e1372213514a5bbf56f33e6d77ba8cc7d0d5c2f3e46c456d2f1badc74",
+				"DiscoKey":   "discokey:579e729d1cbfc797d173f11d5f46fc7ad83de9e9b283aeca2a49a9b7d98d777e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57102",
+					"10.65.0.27:57102",
+					"172.17.0.1:57102",
+					"172.18.0.1:57102",
+					"172.19.0.1:57102",
+					"172.20.0.1:57102",
+					"172.21.0.1:57102",
+					"172.22.0.1:57102",
+					"172.23.0.1:57102",
+					"172.24.0.1:57102",
+					"172.25.0.1:57102",
+					"172.26.0.1:57102",
+					"172.27.0.1:57102",
+					"172.28.0.1:57102"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:23:11.958807186Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6171263541698332,
+				"StableID":   "nyqUgTdyBq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2476445888a7ca1728e3a0079cd670cda161d965e846d0373587b3caf9332009",
+				"DiscoKey":   "discokey:051f68b19f9b4fe635977bacb1bfca1fc040739145365fe63dfc0a2a89605e65",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59814",
+					"10.65.0.27:59814",
+					"172.17.0.1:59814",
+					"172.18.0.1:59814",
+					"172.19.0.1:59814",
+					"172.20.0.1:59814",
+					"172.21.0.1:59814",
+					"172.22.0.1:59814",
+					"172.23.0.1:59814",
+					"172.24.0.1:59814",
+					"172.25.0.1:59814",
+					"172.26.0.1:59814",
+					"172.27.0.1:59814",
+					"172.28.0.1:59814"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:23:12.481223468Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1551577726279602,
+				"StableID":   "n1iVYKKi7D11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e2756e136ea21c6bba471c8eedc1b06e23d3057cd90791fdba9d597d5069278",
+				"DiscoKey":   "discokey:ff70c080835318aa43fe94f70fe48347c70516f329050e97b76af662e29c5061",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38162",
+					"10.65.0.27:38162",
+					"172.17.0.1:38162",
+					"172.18.0.1:38162",
+					"172.19.0.1:38162",
+					"172.20.0.1:38162",
+					"172.21.0.1:38162",
+					"172.22.0.1:38162",
+					"172.23.0.1:38162",
+					"172.24.0.1:38162",
+					"172.25.0.1:38162",
+					"172.26.0.1:38162",
+					"172.27.0.1:38162",
+					"172.28.0.1:38162"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:23:13.023253255Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4706334284422163,
+				"StableID":   "npXXdRRWkd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:66893666f17620d3860ab0b16935eed4471d801b7b4b95872179883c4357e878",
+				"DiscoKey":   "discokey:dd7fc7c929f67d2317804d1f0a9a7d3bc39925f2aae88771d6ff942d5e20a518",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54233",
+					"10.65.0.27:54233",
+					"172.17.0.1:54233",
+					"172.18.0.1:54233",
+					"172.19.0.1:54233",
+					"172.20.0.1:54233",
+					"172.21.0.1:54233",
+					"172.22.0.1:54233",
+					"172.23.0.1:54233",
+					"172.24.0.1:54233",
+					"172.25.0.1:54233",
+					"172.26.0.1:54233",
+					"172.27.0.1:54233",
+					"172.28.0.1:54233"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:23:13.597689279Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7744074492126791,
+				"StableID":   "nzarXuhJU321CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e8a1584616730ff02f1e350a676ebcb776286c99b21d9313107fb43bf4d2032f",
+				"DiscoKey":   "discokey:0d68505902bbd77439edae3e449038195517a929ecca862c7d712af7ffdde475",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47693",
+					"10.65.0.27:47693",
+					"172.17.0.1:47693",
+					"172.18.0.1:47693",
+					"172.19.0.1:47693",
+					"172.20.0.1:47693",
+					"172.21.0.1:47693",
+					"172.22.0.1:47693",
+					"172.23.0.1:47693",
+					"172.24.0.1:47693",
+					"172.25.0.1:47693",
+					"172.26.0.1:47693",
+					"172.27.0.1:47693",
+					"172.28.0.1:47693"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:23:14.62767129Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6412229175349026,
+				"StableID":   "nBbYaTP75s11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f22067dadfa55846929e0cfddf14c47b05658a445e07f7954469c9c292e1dc1a",
+				"DiscoKey":   "discokey:f60ee33c0459fd7b7b865488e0b1850cc4173fb84b24b086608db7df18ca2a3d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43955",
+					"10.65.0.27:43955",
+					"172.17.0.1:43955",
+					"172.18.0.1:43955",
+					"172.19.0.1:43955",
+					"172.20.0.1:43955",
+					"172.21.0.1:43955",
+					"172.22.0.1:43955",
+					"172.23.0.1:43955",
+					"172.24.0.1:43955",
+					"172.25.0.1:43955",
+					"172.26.0.1:43955",
+					"172.27.0.1:43955",
+					"172.28.0.1:43955"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:23:15.166947237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3022813035734529,
+				"StableID":   "nxCCq1B3cQ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:deaef98e694a8ed3cf1430888f79c8c8f3c5ec6542f273f3740f9fe5d508f440",
+				"DiscoKey":   "discokey:9d2611b6b1d2248a398e7b4284d3874cf7a252c80a0a4613068d1405daf09331",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38713",
+					"10.65.0.27:38713",
+					"172.17.0.1:38713",
+					"172.18.0.1:38713",
+					"172.19.0.1:38713",
+					"172.20.0.1:38713",
+					"172.21.0.1:38713",
+					"172.22.0.1:38713",
+					"172.23.0.1:38713",
+					"172.24.0.1:38713",
+					"172.25.0.1:38713",
+					"172.26.0.1:38713",
+					"172.27.0.1:38713",
+					"172.28.0.1:38713"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:23:15.70111166Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1160940652807591,
+				"StableID":   "n2ky2fwn4A11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db23f3d887aabec31020ab17cae9b6c74e1617b0749b9dd6b10b7022f8dd5a26",
+				"DiscoKey":   "discokey:611122099078911c2f25b44a0fe16a33cf3fcf7bde707a0f7a24c047fd83703c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35943",
+					"10.65.0.27:35943",
+					"172.17.0.1:35943",
+					"172.18.0.1:35943",
+					"172.19.0.1:35943",
+					"172.20.0.1:35943",
+					"172.21.0.1:35943",
+					"172.22.0.1:35943",
+					"172.23.0.1:35943",
+					"172.24.0.1:35943",
+					"172.25.0.1:35943",
+					"172.26.0.1:35943",
+					"172.27.0.1:35943",
+					"172.28.0.1:35943"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:23:16.221695078Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6890529266015242,
+				"StableID":   "njjGj8Xjov11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fa77ba1ae5462136c471ac93af15f5068029374a1cea5e4a38cf009a43c0363b",
+				"DiscoKey":   "discokey:50a6ae6716b1268e344eb542a019872f708b18a580cef5eaf74e3a291761cd13",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47165",
+					"10.65.0.27:47165",
+					"172.17.0.1:47165",
+					"172.18.0.1:47165",
+					"172.19.0.1:47165",
+					"172.20.0.1:47165",
+					"172.21.0.1:47165",
+					"172.22.0.1:47165",
+					"172.23.0.1:47165",
+					"172.24.0.1:47165",
+					"172.25.0.1:47165",
+					"172.26.0.1:47165",
+					"172.27.0.1:47165",
+					"172.28.0.1:47165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:23:16.812549339Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4114028313391231,
+				"StableID":   "nQB8EmYF8Z11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8623229a8a613c18bd53d3c987b6ba01dcd0b16cd90c6802bd5bf42267ce1a20",
+				"KeyExpiry":  "2026-11-09T09:23:17Z",
+				"DiscoKey":   "discokey:fbe0efc3b993550e256e689a828f5ea7d719b06c319f84655b2621b9895ed200",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:57427",
+					"10.65.0.27:57427",
+					"172.17.0.1:57427",
+					"172.18.0.1:57427",
+					"172.19.0.1:57427",
+					"172.20.0.1:57427",
+					"172.21.0.1:57427",
+					"172.22.0.1:57427",
+					"172.23.0.1:57427",
+					"172.24.0.1:57427",
+					"172.25.0.1:57427",
+					"172.26.0.1:57427",
+					"172.27.0.1:57427",
+					"172.28.0.1:57427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:23:17.296247424Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6744843673391373,
+				"StableID":   "nEVZn9ckfu11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:195ea1120c871dd9ccd872e67e374c7c5f3456dda9df7d44540f5c366f666c07",
+				"KeyExpiry":  "2026-11-09T09:23:17Z",
+				"DiscoKey":   "discokey:65c5e068b41990e85d8537c6ba5f5ea56b0deed6cf03ea79b232d472359a195e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48844",
+					"10.65.0.27:48844",
+					"172.17.0.1:48844",
+					"172.18.0.1:48844",
+					"172.19.0.1:48844",
+					"172.20.0.1:48844",
+					"172.21.0.1:48844",
+					"172.22.0.1:48844",
+					"172.23.0.1:48844",
+					"172.24.0.1:48844",
+					"172.25.0.1:48844",
+					"172.26.0.1:48844",
+					"172.27.0.1:48844",
+					"172.28.0.1:48844"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:23:17.844641649Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7244862843203504,
+				"StableID":   "nuM2bBGDay11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:29a2762352fe54e950f8d2f12e037313ca0737eb42976406472da0fc67ad875f",
+				"KeyExpiry":  "2026-11-09T09:23:18Z",
+				"DiscoKey":   "discokey:357b53e43c03765f7001405e3e0d7f129a0859a8e35353a200220c73e84ea37d",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36932",
+					"10.65.0.27:36932",
+					"172.17.0.1:36932",
+					"172.18.0.1:36932",
+					"172.19.0.1:36932",
+					"172.20.0.1:36932",
+					"172.21.0.1:36932",
+					"172.22.0.1:36932",
+					"172.23.0.1:36932",
+					"172.24.0.1:36932",
+					"172.25.0.1:36932",
+					"172.26.0.1:36932",
+					"172.27.0.1:36932",
+					"172.28.0.1:36932"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:23:18.39324553Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8005462359786735": {
+				"ID":          8005462359786735,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6412229175349026,
+				"StableID":   "nBbYaTP75s11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       6412229175349026,
+				"Key":        "nodekey:f22067dadfa55846929e0cfddf14c47b05658a445e07f7954469c9c292e1dc1a",
+				"DiscoKey":   "discokey:f60ee33c0459fd7b7b865488e0b1850cc4173fb84b24b086608db7df18ca2a3d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43955",
+					"10.65.0.27:43955",
+					"172.17.0.1:43955",
+					"172.18.0.1:43955",
+					"172.19.0.1:43955",
+					"172.20.0.1:43955",
+					"172.21.0.1:43955",
+					"172.22.0.1:43955",
+					"172.23.0.1:43955",
+					"172.24.0.1:43955",
+					"172.25.0.1:43955",
+					"172.26.0.1:43955",
+					"172.27.0.1:43955",
+					"172.28.0.1:43955"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:23:15.166947237Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f22067dadfa55846929e0cfddf14c47b05658a445e07f7954469c9c292e1dc1a",
+			"MachineKey": "mkey:8cec90bf14ff6cba32b7ffe123efc08252239af6316597d7c6f1aa17fa20cc36",
+			"Peers": [{
+				"ID":         8673558682620626,
+				"StableID":   "n1WTaNgGjA21CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f00a22b63ecf5bc2688aba213366853cf5c120d6bac8738fbc5a706658fb23e",
+				"DiscoKey":   "discokey:56d85cc4c1ea85c5f209b585febfc4cc1c25e41fedc71a0a1f1f062aacd2a947",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35255",
+					"10.65.0.27:35255",
+					"172.17.0.1:35255",
+					"172.18.0.1:35255",
+					"172.19.0.1:35255",
+					"172.20.0.1:35255",
+					"172.21.0.1:35255",
+					"172.22.0.1:35255",
+					"172.23.0.1:35255",
+					"172.24.0.1:35255",
+					"172.25.0.1:35255",
+					"172.26.0.1:35255",
+					"172.27.0.1:35255",
+					"172.28.0.1:35255"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:23:10.945165275Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6650671549347752,
+				"StableID":   "nKrLf7s6wt11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ebc5c4959628162357c3f14e501c639a1154fdf39560ef130402725d30440727",
+				"DiscoKey":   "discokey:f7b1fbd9c6a742c4ebfbedaf3f878bd7979dad7c56ee5ac0c6d041dcb004b131",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39009",
+					"10.65.0.27:39009",
+					"172.17.0.1:39009",
+					"172.18.0.1:39009",
+					"172.19.0.1:39009",
+					"172.20.0.1:39009",
+					"172.21.0.1:39009",
+					"172.22.0.1:39009",
+					"172.23.0.1:39009",
+					"172.24.0.1:39009",
+					"172.25.0.1:39009",
+					"172.26.0.1:39009",
+					"172.27.0.1:39009",
+					"172.28.0.1:39009"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:23:11.41795637Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2244976255107421,
+				"StableID":   "nWF27jikXJ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e213578e1372213514a5bbf56f33e6d77ba8cc7d0d5c2f3e46c456d2f1badc74",
+				"DiscoKey":   "discokey:579e729d1cbfc797d173f11d5f46fc7ad83de9e9b283aeca2a49a9b7d98d777e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57102",
+					"10.65.0.27:57102",
+					"172.17.0.1:57102",
+					"172.18.0.1:57102",
+					"172.19.0.1:57102",
+					"172.20.0.1:57102",
+					"172.21.0.1:57102",
+					"172.22.0.1:57102",
+					"172.23.0.1:57102",
+					"172.24.0.1:57102",
+					"172.25.0.1:57102",
+					"172.26.0.1:57102",
+					"172.27.0.1:57102",
+					"172.28.0.1:57102"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:23:11.958807186Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6171263541698332,
+				"StableID":   "nyqUgTdyBq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2476445888a7ca1728e3a0079cd670cda161d965e846d0373587b3caf9332009",
+				"DiscoKey":   "discokey:051f68b19f9b4fe635977bacb1bfca1fc040739145365fe63dfc0a2a89605e65",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59814",
+					"10.65.0.27:59814",
+					"172.17.0.1:59814",
+					"172.18.0.1:59814",
+					"172.19.0.1:59814",
+					"172.20.0.1:59814",
+					"172.21.0.1:59814",
+					"172.22.0.1:59814",
+					"172.23.0.1:59814",
+					"172.24.0.1:59814",
+					"172.25.0.1:59814",
+					"172.26.0.1:59814",
+					"172.27.0.1:59814",
+					"172.28.0.1:59814"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:23:12.481223468Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1551577726279602,
+				"StableID":   "n1iVYKKi7D11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e2756e136ea21c6bba471c8eedc1b06e23d3057cd90791fdba9d597d5069278",
+				"DiscoKey":   "discokey:ff70c080835318aa43fe94f70fe48347c70516f329050e97b76af662e29c5061",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38162",
+					"10.65.0.27:38162",
+					"172.17.0.1:38162",
+					"172.18.0.1:38162",
+					"172.19.0.1:38162",
+					"172.20.0.1:38162",
+					"172.21.0.1:38162",
+					"172.22.0.1:38162",
+					"172.23.0.1:38162",
+					"172.24.0.1:38162",
+					"172.25.0.1:38162",
+					"172.26.0.1:38162",
+					"172.27.0.1:38162",
+					"172.28.0.1:38162"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:23:13.023253255Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4706334284422163,
+				"StableID":   "npXXdRRWkd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:66893666f17620d3860ab0b16935eed4471d801b7b4b95872179883c4357e878",
+				"DiscoKey":   "discokey:dd7fc7c929f67d2317804d1f0a9a7d3bc39925f2aae88771d6ff942d5e20a518",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54233",
+					"10.65.0.27:54233",
+					"172.17.0.1:54233",
+					"172.18.0.1:54233",
+					"172.19.0.1:54233",
+					"172.20.0.1:54233",
+					"172.21.0.1:54233",
+					"172.22.0.1:54233",
+					"172.23.0.1:54233",
+					"172.24.0.1:54233",
+					"172.25.0.1:54233",
+					"172.26.0.1:54233",
+					"172.27.0.1:54233",
+					"172.28.0.1:54233"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:23:13.597689279Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8005462359786735,
+				"StableID":   "nJLMKSvgW521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39d88542309654ce8a973e34fe7d60ca5c47b575af7da6afd2b4d6eae2f9077f",
+				"DiscoKey":   "discokey:ccf844837e56d79c3e457d101f3df115b40532363613164c1b758e722a773c5b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:42546",
+					"10.65.0.27:42546",
+					"172.17.0.1:42546",
+					"172.18.0.1:42546",
+					"172.19.0.1:42546",
+					"172.20.0.1:42546",
+					"172.21.0.1:42546",
+					"172.22.0.1:42546",
+					"172.23.0.1:42546",
+					"172.24.0.1:42546",
+					"172.25.0.1:42546",
+					"172.26.0.1:42546",
+					"172.27.0.1:42546",
+					"172.28.0.1:42546"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:23:14.075062687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7744074492126791,
+				"StableID":   "nzarXuhJU321CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e8a1584616730ff02f1e350a676ebcb776286c99b21d9313107fb43bf4d2032f",
+				"DiscoKey":   "discokey:0d68505902bbd77439edae3e449038195517a929ecca862c7d712af7ffdde475",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47693",
+					"10.65.0.27:47693",
+					"172.17.0.1:47693",
+					"172.18.0.1:47693",
+					"172.19.0.1:47693",
+					"172.20.0.1:47693",
+					"172.21.0.1:47693",
+					"172.22.0.1:47693",
+					"172.23.0.1:47693",
+					"172.24.0.1:47693",
+					"172.25.0.1:47693",
+					"172.26.0.1:47693",
+					"172.27.0.1:47693",
+					"172.28.0.1:47693"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:23:14.62767129Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3022813035734529,
+				"StableID":   "nxCCq1B3cQ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:deaef98e694a8ed3cf1430888f79c8c8f3c5ec6542f273f3740f9fe5d508f440",
+				"DiscoKey":   "discokey:9d2611b6b1d2248a398e7b4284d3874cf7a252c80a0a4613068d1405daf09331",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38713",
+					"10.65.0.27:38713",
+					"172.17.0.1:38713",
+					"172.18.0.1:38713",
+					"172.19.0.1:38713",
+					"172.20.0.1:38713",
+					"172.21.0.1:38713",
+					"172.22.0.1:38713",
+					"172.23.0.1:38713",
+					"172.24.0.1:38713",
+					"172.25.0.1:38713",
+					"172.26.0.1:38713",
+					"172.27.0.1:38713",
+					"172.28.0.1:38713"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:23:15.70111166Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1160940652807591,
+				"StableID":   "n2ky2fwn4A11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db23f3d887aabec31020ab17cae9b6c74e1617b0749b9dd6b10b7022f8dd5a26",
+				"DiscoKey":   "discokey:611122099078911c2f25b44a0fe16a33cf3fcf7bde707a0f7a24c047fd83703c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35943",
+					"10.65.0.27:35943",
+					"172.17.0.1:35943",
+					"172.18.0.1:35943",
+					"172.19.0.1:35943",
+					"172.20.0.1:35943",
+					"172.21.0.1:35943",
+					"172.22.0.1:35943",
+					"172.23.0.1:35943",
+					"172.24.0.1:35943",
+					"172.25.0.1:35943",
+					"172.26.0.1:35943",
+					"172.27.0.1:35943",
+					"172.28.0.1:35943"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:23:16.221695078Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6890529266015242,
+				"StableID":   "njjGj8Xjov11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fa77ba1ae5462136c471ac93af15f5068029374a1cea5e4a38cf009a43c0363b",
+				"DiscoKey":   "discokey:50a6ae6716b1268e344eb542a019872f708b18a580cef5eaf74e3a291761cd13",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47165",
+					"10.65.0.27:47165",
+					"172.17.0.1:47165",
+					"172.18.0.1:47165",
+					"172.19.0.1:47165",
+					"172.20.0.1:47165",
+					"172.21.0.1:47165",
+					"172.22.0.1:47165",
+					"172.23.0.1:47165",
+					"172.24.0.1:47165",
+					"172.25.0.1:47165",
+					"172.26.0.1:47165",
+					"172.27.0.1:47165",
+					"172.28.0.1:47165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:23:16.812549339Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4114028313391231,
+				"StableID":   "nQB8EmYF8Z11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8623229a8a613c18bd53d3c987b6ba01dcd0b16cd90c6802bd5bf42267ce1a20",
+				"KeyExpiry":  "2026-11-09T09:23:17Z",
+				"DiscoKey":   "discokey:fbe0efc3b993550e256e689a828f5ea7d719b06c319f84655b2621b9895ed200",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:57427",
+					"10.65.0.27:57427",
+					"172.17.0.1:57427",
+					"172.18.0.1:57427",
+					"172.19.0.1:57427",
+					"172.20.0.1:57427",
+					"172.21.0.1:57427",
+					"172.22.0.1:57427",
+					"172.23.0.1:57427",
+					"172.24.0.1:57427",
+					"172.25.0.1:57427",
+					"172.26.0.1:57427",
+					"172.27.0.1:57427",
+					"172.28.0.1:57427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:23:17.296247424Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6744843673391373,
+				"StableID":   "nEVZn9ckfu11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:195ea1120c871dd9ccd872e67e374c7c5f3456dda9df7d44540f5c366f666c07",
+				"KeyExpiry":  "2026-11-09T09:23:17Z",
+				"DiscoKey":   "discokey:65c5e068b41990e85d8537c6ba5f5ea56b0deed6cf03ea79b232d472359a195e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48844",
+					"10.65.0.27:48844",
+					"172.17.0.1:48844",
+					"172.18.0.1:48844",
+					"172.19.0.1:48844",
+					"172.20.0.1:48844",
+					"172.21.0.1:48844",
+					"172.22.0.1:48844",
+					"172.23.0.1:48844",
+					"172.24.0.1:48844",
+					"172.25.0.1:48844",
+					"172.26.0.1:48844",
+					"172.27.0.1:48844",
+					"172.28.0.1:48844"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:23:17.844641649Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7244862843203504,
+				"StableID":   "nuM2bBGDay11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:29a2762352fe54e950f8d2f12e037313ca0737eb42976406472da0fc67ad875f",
+				"KeyExpiry":  "2026-11-09T09:23:18Z",
+				"DiscoKey":   "discokey:357b53e43c03765f7001405e3e0d7f129a0859a8e35353a200220c73e84ea37d",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36932",
+					"10.65.0.27:36932",
+					"172.17.0.1:36932",
+					"172.18.0.1:36932",
+					"172.19.0.1:36932",
+					"172.20.0.1:36932",
+					"172.21.0.1:36932",
+					"172.22.0.1:36932",
+					"172.23.0.1:36932",
+					"172.24.0.1:36932",
+					"172.25.0.1:36932",
+					"172.26.0.1:36932",
+					"172.27.0.1:36932",
+					"172.28.0.1:36932"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:23:18.39324553Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6412229175349026": {
+				"ID":          6412229175349026,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6744843673391373,
+				"StableID":   "nEVZn9ckfu11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:195ea1120c871dd9ccd872e67e374c7c5f3456dda9df7d44540f5c366f666c07",
+				"KeyExpiry":  "2026-11-09T09:23:17Z",
+				"DiscoKey":   "discokey:65c5e068b41990e85d8537c6ba5f5ea56b0deed6cf03ea79b232d472359a195e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48844",
+					"10.65.0.27:48844",
+					"172.17.0.1:48844",
+					"172.18.0.1:48844",
+					"172.19.0.1:48844",
+					"172.20.0.1:48844",
+					"172.21.0.1:48844",
+					"172.22.0.1:48844",
+					"172.23.0.1:48844",
+					"172.24.0.1:48844",
+					"172.25.0.1:48844",
+					"172.26.0.1:48844",
+					"172.27.0.1:48844",
+					"172.28.0.1:48844"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:23:17.844641649Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:195ea1120c871dd9ccd872e67e374c7c5f3456dda9df7d44540f5c366f666c07",
+			"MachineKey": "mkey:e15511deeb0604871d4264f41e2503cfd14e9339579ea7914ad3710c3b6db547",
+			"Peers": [{
+				"ID":         8673558682620626,
+				"StableID":   "n1WTaNgGjA21CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f00a22b63ecf5bc2688aba213366853cf5c120d6bac8738fbc5a706658fb23e",
+				"DiscoKey":   "discokey:56d85cc4c1ea85c5f209b585febfc4cc1c25e41fedc71a0a1f1f062aacd2a947",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35255",
+					"10.65.0.27:35255",
+					"172.17.0.1:35255",
+					"172.18.0.1:35255",
+					"172.19.0.1:35255",
+					"172.20.0.1:35255",
+					"172.21.0.1:35255",
+					"172.22.0.1:35255",
+					"172.23.0.1:35255",
+					"172.24.0.1:35255",
+					"172.25.0.1:35255",
+					"172.26.0.1:35255",
+					"172.27.0.1:35255",
+					"172.28.0.1:35255"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:23:10.945165275Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6650671549347752,
+				"StableID":   "nKrLf7s6wt11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ebc5c4959628162357c3f14e501c639a1154fdf39560ef130402725d30440727",
+				"DiscoKey":   "discokey:f7b1fbd9c6a742c4ebfbedaf3f878bd7979dad7c56ee5ac0c6d041dcb004b131",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39009",
+					"10.65.0.27:39009",
+					"172.17.0.1:39009",
+					"172.18.0.1:39009",
+					"172.19.0.1:39009",
+					"172.20.0.1:39009",
+					"172.21.0.1:39009",
+					"172.22.0.1:39009",
+					"172.23.0.1:39009",
+					"172.24.0.1:39009",
+					"172.25.0.1:39009",
+					"172.26.0.1:39009",
+					"172.27.0.1:39009",
+					"172.28.0.1:39009"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:23:11.41795637Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2244976255107421,
+				"StableID":   "nWF27jikXJ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e213578e1372213514a5bbf56f33e6d77ba8cc7d0d5c2f3e46c456d2f1badc74",
+				"DiscoKey":   "discokey:579e729d1cbfc797d173f11d5f46fc7ad83de9e9b283aeca2a49a9b7d98d777e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57102",
+					"10.65.0.27:57102",
+					"172.17.0.1:57102",
+					"172.18.0.1:57102",
+					"172.19.0.1:57102",
+					"172.20.0.1:57102",
+					"172.21.0.1:57102",
+					"172.22.0.1:57102",
+					"172.23.0.1:57102",
+					"172.24.0.1:57102",
+					"172.25.0.1:57102",
+					"172.26.0.1:57102",
+					"172.27.0.1:57102",
+					"172.28.0.1:57102"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:23:11.958807186Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6171263541698332,
+				"StableID":   "nyqUgTdyBq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2476445888a7ca1728e3a0079cd670cda161d965e846d0373587b3caf9332009",
+				"DiscoKey":   "discokey:051f68b19f9b4fe635977bacb1bfca1fc040739145365fe63dfc0a2a89605e65",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59814",
+					"10.65.0.27:59814",
+					"172.17.0.1:59814",
+					"172.18.0.1:59814",
+					"172.19.0.1:59814",
+					"172.20.0.1:59814",
+					"172.21.0.1:59814",
+					"172.22.0.1:59814",
+					"172.23.0.1:59814",
+					"172.24.0.1:59814",
+					"172.25.0.1:59814",
+					"172.26.0.1:59814",
+					"172.27.0.1:59814",
+					"172.28.0.1:59814"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:23:12.481223468Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1551577726279602,
+				"StableID":   "n1iVYKKi7D11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e2756e136ea21c6bba471c8eedc1b06e23d3057cd90791fdba9d597d5069278",
+				"DiscoKey":   "discokey:ff70c080835318aa43fe94f70fe48347c70516f329050e97b76af662e29c5061",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38162",
+					"10.65.0.27:38162",
+					"172.17.0.1:38162",
+					"172.18.0.1:38162",
+					"172.19.0.1:38162",
+					"172.20.0.1:38162",
+					"172.21.0.1:38162",
+					"172.22.0.1:38162",
+					"172.23.0.1:38162",
+					"172.24.0.1:38162",
+					"172.25.0.1:38162",
+					"172.26.0.1:38162",
+					"172.27.0.1:38162",
+					"172.28.0.1:38162"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:23:13.023253255Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4706334284422163,
+				"StableID":   "npXXdRRWkd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:66893666f17620d3860ab0b16935eed4471d801b7b4b95872179883c4357e878",
+				"DiscoKey":   "discokey:dd7fc7c929f67d2317804d1f0a9a7d3bc39925f2aae88771d6ff942d5e20a518",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54233",
+					"10.65.0.27:54233",
+					"172.17.0.1:54233",
+					"172.18.0.1:54233",
+					"172.19.0.1:54233",
+					"172.20.0.1:54233",
+					"172.21.0.1:54233",
+					"172.22.0.1:54233",
+					"172.23.0.1:54233",
+					"172.24.0.1:54233",
+					"172.25.0.1:54233",
+					"172.26.0.1:54233",
+					"172.27.0.1:54233",
+					"172.28.0.1:54233"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:23:13.597689279Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8005462359786735,
+				"StableID":   "nJLMKSvgW521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39d88542309654ce8a973e34fe7d60ca5c47b575af7da6afd2b4d6eae2f9077f",
+				"DiscoKey":   "discokey:ccf844837e56d79c3e457d101f3df115b40532363613164c1b758e722a773c5b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:42546",
+					"10.65.0.27:42546",
+					"172.17.0.1:42546",
+					"172.18.0.1:42546",
+					"172.19.0.1:42546",
+					"172.20.0.1:42546",
+					"172.21.0.1:42546",
+					"172.22.0.1:42546",
+					"172.23.0.1:42546",
+					"172.24.0.1:42546",
+					"172.25.0.1:42546",
+					"172.26.0.1:42546",
+					"172.27.0.1:42546",
+					"172.28.0.1:42546"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:23:14.075062687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7744074492126791,
+				"StableID":   "nzarXuhJU321CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e8a1584616730ff02f1e350a676ebcb776286c99b21d9313107fb43bf4d2032f",
+				"DiscoKey":   "discokey:0d68505902bbd77439edae3e449038195517a929ecca862c7d712af7ffdde475",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47693",
+					"10.65.0.27:47693",
+					"172.17.0.1:47693",
+					"172.18.0.1:47693",
+					"172.19.0.1:47693",
+					"172.20.0.1:47693",
+					"172.21.0.1:47693",
+					"172.22.0.1:47693",
+					"172.23.0.1:47693",
+					"172.24.0.1:47693",
+					"172.25.0.1:47693",
+					"172.26.0.1:47693",
+					"172.27.0.1:47693",
+					"172.28.0.1:47693"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:23:14.62767129Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6412229175349026,
+				"StableID":   "nBbYaTP75s11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f22067dadfa55846929e0cfddf14c47b05658a445e07f7954469c9c292e1dc1a",
+				"DiscoKey":   "discokey:f60ee33c0459fd7b7b865488e0b1850cc4173fb84b24b086608db7df18ca2a3d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43955",
+					"10.65.0.27:43955",
+					"172.17.0.1:43955",
+					"172.18.0.1:43955",
+					"172.19.0.1:43955",
+					"172.20.0.1:43955",
+					"172.21.0.1:43955",
+					"172.22.0.1:43955",
+					"172.23.0.1:43955",
+					"172.24.0.1:43955",
+					"172.25.0.1:43955",
+					"172.26.0.1:43955",
+					"172.27.0.1:43955",
+					"172.28.0.1:43955"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:23:15.166947237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3022813035734529,
+				"StableID":   "nxCCq1B3cQ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:deaef98e694a8ed3cf1430888f79c8c8f3c5ec6542f273f3740f9fe5d508f440",
+				"DiscoKey":   "discokey:9d2611b6b1d2248a398e7b4284d3874cf7a252c80a0a4613068d1405daf09331",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38713",
+					"10.65.0.27:38713",
+					"172.17.0.1:38713",
+					"172.18.0.1:38713",
+					"172.19.0.1:38713",
+					"172.20.0.1:38713",
+					"172.21.0.1:38713",
+					"172.22.0.1:38713",
+					"172.23.0.1:38713",
+					"172.24.0.1:38713",
+					"172.25.0.1:38713",
+					"172.26.0.1:38713",
+					"172.27.0.1:38713",
+					"172.28.0.1:38713"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:23:15.70111166Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1160940652807591,
+				"StableID":   "n2ky2fwn4A11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db23f3d887aabec31020ab17cae9b6c74e1617b0749b9dd6b10b7022f8dd5a26",
+				"DiscoKey":   "discokey:611122099078911c2f25b44a0fe16a33cf3fcf7bde707a0f7a24c047fd83703c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35943",
+					"10.65.0.27:35943",
+					"172.17.0.1:35943",
+					"172.18.0.1:35943",
+					"172.19.0.1:35943",
+					"172.20.0.1:35943",
+					"172.21.0.1:35943",
+					"172.22.0.1:35943",
+					"172.23.0.1:35943",
+					"172.24.0.1:35943",
+					"172.25.0.1:35943",
+					"172.26.0.1:35943",
+					"172.27.0.1:35943",
+					"172.28.0.1:35943"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:23:16.221695078Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6890529266015242,
+				"StableID":   "njjGj8Xjov11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fa77ba1ae5462136c471ac93af15f5068029374a1cea5e4a38cf009a43c0363b",
+				"DiscoKey":   "discokey:50a6ae6716b1268e344eb542a019872f708b18a580cef5eaf74e3a291761cd13",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47165",
+					"10.65.0.27:47165",
+					"172.17.0.1:47165",
+					"172.18.0.1:47165",
+					"172.19.0.1:47165",
+					"172.20.0.1:47165",
+					"172.21.0.1:47165",
+					"172.22.0.1:47165",
+					"172.23.0.1:47165",
+					"172.24.0.1:47165",
+					"172.25.0.1:47165",
+					"172.26.0.1:47165",
+					"172.27.0.1:47165",
+					"172.28.0.1:47165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:23:16.812549339Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4114028313391231,
+				"StableID":   "nQB8EmYF8Z11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8623229a8a613c18bd53d3c987b6ba01dcd0b16cd90c6802bd5bf42267ce1a20",
+				"KeyExpiry":  "2026-11-09T09:23:17Z",
+				"DiscoKey":   "discokey:fbe0efc3b993550e256e689a828f5ea7d719b06c319f84655b2621b9895ed200",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:57427",
+					"10.65.0.27:57427",
+					"172.17.0.1:57427",
+					"172.18.0.1:57427",
+					"172.19.0.1:57427",
+					"172.20.0.1:57427",
+					"172.21.0.1:57427",
+					"172.22.0.1:57427",
+					"172.23.0.1:57427",
+					"172.24.0.1:57427",
+					"172.25.0.1:57427",
+					"172.26.0.1:57427",
+					"172.27.0.1:57427",
+					"172.28.0.1:57427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:23:17.296247424Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7244862843203504,
+				"StableID":   "nuM2bBGDay11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:29a2762352fe54e950f8d2f12e037313ca0737eb42976406472da0fc67ad875f",
+				"KeyExpiry":  "2026-11-09T09:23:18Z",
+				"DiscoKey":   "discokey:357b53e43c03765f7001405e3e0d7f129a0859a8e35353a200220c73e84ea37d",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36932",
+					"10.65.0.27:36932",
+					"172.17.0.1:36932",
+					"172.18.0.1:36932",
+					"172.19.0.1:36932",
+					"172.20.0.1:36932",
+					"172.21.0.1:36932",
+					"172.22.0.1:36932",
+					"172.23.0.1:36932",
+					"172.24.0.1:36932",
+					"172.25.0.1:36932",
+					"172.26.0.1:36932",
+					"172.27.0.1:36932",
+					"172.28.0.1:36932"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:23:18.39324553Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3022813035734529,
+				"StableID":   "nxCCq1B3cQ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       3022813035734529,
+				"Key":        "nodekey:deaef98e694a8ed3cf1430888f79c8c8f3c5ec6542f273f3740f9fe5d508f440",
+				"DiscoKey":   "discokey:9d2611b6b1d2248a398e7b4284d3874cf7a252c80a0a4613068d1405daf09331",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38713",
+					"10.65.0.27:38713",
+					"172.17.0.1:38713",
+					"172.18.0.1:38713",
+					"172.19.0.1:38713",
+					"172.20.0.1:38713",
+					"172.21.0.1:38713",
+					"172.22.0.1:38713",
+					"172.23.0.1:38713",
+					"172.24.0.1:38713",
+					"172.25.0.1:38713",
+					"172.26.0.1:38713",
+					"172.27.0.1:38713",
+					"172.28.0.1:38713"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:23:15.70111166Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:deaef98e694a8ed3cf1430888f79c8c8f3c5ec6542f273f3740f9fe5d508f440",
+			"MachineKey": "mkey:b397bb98ed53cf6600818972b5475fde1e68faefdc9bae80852edecae7063b4d",
+			"Peers": [{
+				"ID":         8673558682620626,
+				"StableID":   "n1WTaNgGjA21CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0f00a22b63ecf5bc2688aba213366853cf5c120d6bac8738fbc5a706658fb23e",
+				"DiscoKey":   "discokey:56d85cc4c1ea85c5f209b585febfc4cc1c25e41fedc71a0a1f1f062aacd2a947",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35255",
+					"10.65.0.27:35255",
+					"172.17.0.1:35255",
+					"172.18.0.1:35255",
+					"172.19.0.1:35255",
+					"172.20.0.1:35255",
+					"172.21.0.1:35255",
+					"172.22.0.1:35255",
+					"172.23.0.1:35255",
+					"172.24.0.1:35255",
+					"172.25.0.1:35255",
+					"172.26.0.1:35255",
+					"172.27.0.1:35255",
+					"172.28.0.1:35255"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:23:10.945165275Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6650671549347752,
+				"StableID":   "nKrLf7s6wt11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ebc5c4959628162357c3f14e501c639a1154fdf39560ef130402725d30440727",
+				"DiscoKey":   "discokey:f7b1fbd9c6a742c4ebfbedaf3f878bd7979dad7c56ee5ac0c6d041dcb004b131",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39009",
+					"10.65.0.27:39009",
+					"172.17.0.1:39009",
+					"172.18.0.1:39009",
+					"172.19.0.1:39009",
+					"172.20.0.1:39009",
+					"172.21.0.1:39009",
+					"172.22.0.1:39009",
+					"172.23.0.1:39009",
+					"172.24.0.1:39009",
+					"172.25.0.1:39009",
+					"172.26.0.1:39009",
+					"172.27.0.1:39009",
+					"172.28.0.1:39009"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:23:11.41795637Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2244976255107421,
+				"StableID":   "nWF27jikXJ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e213578e1372213514a5bbf56f33e6d77ba8cc7d0d5c2f3e46c456d2f1badc74",
+				"DiscoKey":   "discokey:579e729d1cbfc797d173f11d5f46fc7ad83de9e9b283aeca2a49a9b7d98d777e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57102",
+					"10.65.0.27:57102",
+					"172.17.0.1:57102",
+					"172.18.0.1:57102",
+					"172.19.0.1:57102",
+					"172.20.0.1:57102",
+					"172.21.0.1:57102",
+					"172.22.0.1:57102",
+					"172.23.0.1:57102",
+					"172.24.0.1:57102",
+					"172.25.0.1:57102",
+					"172.26.0.1:57102",
+					"172.27.0.1:57102",
+					"172.28.0.1:57102"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:23:11.958807186Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6171263541698332,
+				"StableID":   "nyqUgTdyBq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2476445888a7ca1728e3a0079cd670cda161d965e846d0373587b3caf9332009",
+				"DiscoKey":   "discokey:051f68b19f9b4fe635977bacb1bfca1fc040739145365fe63dfc0a2a89605e65",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59814",
+					"10.65.0.27:59814",
+					"172.17.0.1:59814",
+					"172.18.0.1:59814",
+					"172.19.0.1:59814",
+					"172.20.0.1:59814",
+					"172.21.0.1:59814",
+					"172.22.0.1:59814",
+					"172.23.0.1:59814",
+					"172.24.0.1:59814",
+					"172.25.0.1:59814",
+					"172.26.0.1:59814",
+					"172.27.0.1:59814",
+					"172.28.0.1:59814"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:23:12.481223468Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1551577726279602,
+				"StableID":   "n1iVYKKi7D11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e2756e136ea21c6bba471c8eedc1b06e23d3057cd90791fdba9d597d5069278",
+				"DiscoKey":   "discokey:ff70c080835318aa43fe94f70fe48347c70516f329050e97b76af662e29c5061",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38162",
+					"10.65.0.27:38162",
+					"172.17.0.1:38162",
+					"172.18.0.1:38162",
+					"172.19.0.1:38162",
+					"172.20.0.1:38162",
+					"172.21.0.1:38162",
+					"172.22.0.1:38162",
+					"172.23.0.1:38162",
+					"172.24.0.1:38162",
+					"172.25.0.1:38162",
+					"172.26.0.1:38162",
+					"172.27.0.1:38162",
+					"172.28.0.1:38162"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:23:13.023253255Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4706334284422163,
+				"StableID":   "npXXdRRWkd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:66893666f17620d3860ab0b16935eed4471d801b7b4b95872179883c4357e878",
+				"DiscoKey":   "discokey:dd7fc7c929f67d2317804d1f0a9a7d3bc39925f2aae88771d6ff942d5e20a518",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54233",
+					"10.65.0.27:54233",
+					"172.17.0.1:54233",
+					"172.18.0.1:54233",
+					"172.19.0.1:54233",
+					"172.20.0.1:54233",
+					"172.21.0.1:54233",
+					"172.22.0.1:54233",
+					"172.23.0.1:54233",
+					"172.24.0.1:54233",
+					"172.25.0.1:54233",
+					"172.26.0.1:54233",
+					"172.27.0.1:54233",
+					"172.28.0.1:54233"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:23:13.597689279Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8005462359786735,
+				"StableID":   "nJLMKSvgW521CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39d88542309654ce8a973e34fe7d60ca5c47b575af7da6afd2b4d6eae2f9077f",
+				"DiscoKey":   "discokey:ccf844837e56d79c3e457d101f3df115b40532363613164c1b758e722a773c5b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:42546",
+					"10.65.0.27:42546",
+					"172.17.0.1:42546",
+					"172.18.0.1:42546",
+					"172.19.0.1:42546",
+					"172.20.0.1:42546",
+					"172.21.0.1:42546",
+					"172.22.0.1:42546",
+					"172.23.0.1:42546",
+					"172.24.0.1:42546",
+					"172.25.0.1:42546",
+					"172.26.0.1:42546",
+					"172.27.0.1:42546",
+					"172.28.0.1:42546"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:23:14.075062687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7744074492126791,
+				"StableID":   "nzarXuhJU321CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e8a1584616730ff02f1e350a676ebcb776286c99b21d9313107fb43bf4d2032f",
+				"DiscoKey":   "discokey:0d68505902bbd77439edae3e449038195517a929ecca862c7d712af7ffdde475",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:47693",
+					"10.65.0.27:47693",
+					"172.17.0.1:47693",
+					"172.18.0.1:47693",
+					"172.19.0.1:47693",
+					"172.20.0.1:47693",
+					"172.21.0.1:47693",
+					"172.22.0.1:47693",
+					"172.23.0.1:47693",
+					"172.24.0.1:47693",
+					"172.25.0.1:47693",
+					"172.26.0.1:47693",
+					"172.27.0.1:47693",
+					"172.28.0.1:47693"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:23:14.62767129Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6412229175349026,
+				"StableID":   "nBbYaTP75s11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f22067dadfa55846929e0cfddf14c47b05658a445e07f7954469c9c292e1dc1a",
+				"DiscoKey":   "discokey:f60ee33c0459fd7b7b865488e0b1850cc4173fb84b24b086608db7df18ca2a3d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:43955",
+					"10.65.0.27:43955",
+					"172.17.0.1:43955",
+					"172.18.0.1:43955",
+					"172.19.0.1:43955",
+					"172.20.0.1:43955",
+					"172.21.0.1:43955",
+					"172.22.0.1:43955",
+					"172.23.0.1:43955",
+					"172.24.0.1:43955",
+					"172.25.0.1:43955",
+					"172.26.0.1:43955",
+					"172.27.0.1:43955",
+					"172.28.0.1:43955"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:23:15.166947237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1160940652807591,
+				"StableID":   "n2ky2fwn4A11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db23f3d887aabec31020ab17cae9b6c74e1617b0749b9dd6b10b7022f8dd5a26",
+				"DiscoKey":   "discokey:611122099078911c2f25b44a0fe16a33cf3fcf7bde707a0f7a24c047fd83703c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35943",
+					"10.65.0.27:35943",
+					"172.17.0.1:35943",
+					"172.18.0.1:35943",
+					"172.19.0.1:35943",
+					"172.20.0.1:35943",
+					"172.21.0.1:35943",
+					"172.22.0.1:35943",
+					"172.23.0.1:35943",
+					"172.24.0.1:35943",
+					"172.25.0.1:35943",
+					"172.26.0.1:35943",
+					"172.27.0.1:35943",
+					"172.28.0.1:35943"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:23:16.221695078Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6890529266015242,
+				"StableID":   "njjGj8Xjov11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fa77ba1ae5462136c471ac93af15f5068029374a1cea5e4a38cf009a43c0363b",
+				"DiscoKey":   "discokey:50a6ae6716b1268e344eb542a019872f708b18a580cef5eaf74e3a291761cd13",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47165",
+					"10.65.0.27:47165",
+					"172.17.0.1:47165",
+					"172.18.0.1:47165",
+					"172.19.0.1:47165",
+					"172.20.0.1:47165",
+					"172.21.0.1:47165",
+					"172.22.0.1:47165",
+					"172.23.0.1:47165",
+					"172.24.0.1:47165",
+					"172.25.0.1:47165",
+					"172.26.0.1:47165",
+					"172.27.0.1:47165",
+					"172.28.0.1:47165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:23:16.812549339Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4114028313391231,
+				"StableID":   "nQB8EmYF8Z11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:8623229a8a613c18bd53d3c987b6ba01dcd0b16cd90c6802bd5bf42267ce1a20",
+				"KeyExpiry":  "2026-11-09T09:23:17Z",
+				"DiscoKey":   "discokey:fbe0efc3b993550e256e689a828f5ea7d719b06c319f84655b2621b9895ed200",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:57427",
+					"10.65.0.27:57427",
+					"172.17.0.1:57427",
+					"172.18.0.1:57427",
+					"172.19.0.1:57427",
+					"172.20.0.1:57427",
+					"172.21.0.1:57427",
+					"172.22.0.1:57427",
+					"172.23.0.1:57427",
+					"172.24.0.1:57427",
+					"172.25.0.1:57427",
+					"172.26.0.1:57427",
+					"172.27.0.1:57427",
+					"172.28.0.1:57427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:23:17.296247424Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6744843673391373,
+				"StableID":   "nEVZn9ckfu11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:195ea1120c871dd9ccd872e67e374c7c5f3456dda9df7d44540f5c366f666c07",
+				"KeyExpiry":  "2026-11-09T09:23:17Z",
+				"DiscoKey":   "discokey:65c5e068b41990e85d8537c6ba5f5ea56b0deed6cf03ea79b232d472359a195e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48844",
+					"10.65.0.27:48844",
+					"172.17.0.1:48844",
+					"172.18.0.1:48844",
+					"172.19.0.1:48844",
+					"172.20.0.1:48844",
+					"172.21.0.1:48844",
+					"172.22.0.1:48844",
+					"172.23.0.1:48844",
+					"172.24.0.1:48844",
+					"172.25.0.1:48844",
+					"172.26.0.1:48844",
+					"172.27.0.1:48844",
+					"172.28.0.1:48844"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:23:17.844641649Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7244862843203504,
+				"StableID":   "nuM2bBGDay11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:29a2762352fe54e950f8d2f12e037313ca0737eb42976406472da0fc67ad875f",
+				"KeyExpiry":  "2026-11-09T09:23:18Z",
+				"DiscoKey":   "discokey:357b53e43c03765f7001405e3e0d7f129a0859a8e35353a200220c73e84ea37d",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36932",
+					"10.65.0.27:36932",
+					"172.17.0.1:36932",
+					"172.18.0.1:36932",
+					"172.19.0.1:36932",
+					"172.20.0.1:36932",
+					"172.21.0.1:36932",
+					"172.22.0.1:36932",
+					"172.23.0.1:36932",
+					"172.24.0.1:36932",
+					"172.25.0.1:36932",
+					"172.26.0.1:36932",
+					"172.27.0.1:36932",
+					"172.28.0.1:36932"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:23:18.39324553Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3022813035734529": {
+				"ID":          3022813035734529,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-tag-owner-cycle.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-tag-owner-cycle.hujson
@@ -1,0 +1,22101 @@
+// ssh-tag-owner-cycle
+//
+// ssh tagOwner cycle tag:a <-> tag:b
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-13T09:24:03Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-tag-owner-cycle",
+	"description":    "ssh tagOwner cycle tag:a <-> tag:b",
+	"category":       "ssh",
+	"captured_at":    "2026-05-13T09:24:03.646919869Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                      \n  \n                                                                       \n                        \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh tagOwner cycle tag:a <-> tag:b\",\n\t\"id\":          \"ssh-tag-owner-cycle\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:a\"],\n\t\t\"src\":    [\"thor@example.org\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:a\": [\"tag:b\"],\n\t\t\"tag:b\": [\"tag:a\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-edges/ssh-tag-owner-cycle.hujson",
+		"full_policy": {"ssh": [{
+			"action": "accept",
+			"dst":    ["tag:a"],
+			"src":    ["thor@example.org"],
+			"users":  ["root"]
+		}], "tagOwners": {"tag:a": ["tag:b"], "tag:b": ["tag:a"]}}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8110806700351409,
+				"StableID":   "nzVXx29QL621CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       8110806700351409,
+				"Key":        "nodekey:db3a3e21ceff1453eae1946b6242c8f2847640e647cb3e4d378c17215f4e1f6d",
+				"DiscoKey":   "discokey:ca8b5774f2d197c6b2274e73f3b53ddd6f6a63a98f4e54b8dbfc11e8504c7415",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52722",
+					"10.65.0.27:52722",
+					"172.17.0.1:52722",
+					"172.18.0.1:52722",
+					"172.19.0.1:52722",
+					"172.20.0.1:52722",
+					"172.21.0.1:52722",
+					"172.22.0.1:52722",
+					"172.23.0.1:52722",
+					"172.24.0.1:52722",
+					"172.25.0.1:52722",
+					"172.26.0.1:52722",
+					"172.27.0.1:52722",
+					"172.28.0.1:52722"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:24:12.280445949Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:db3a3e21ceff1453eae1946b6242c8f2847640e647cb3e4d378c17215f4e1f6d",
+			"MachineKey": "mkey:c3afa0f76aa27cf9dd5103516693fb4cf429e084b9cc1dd1735c005d1b774602",
+			"Peers": [{
+				"ID":         8852797214098944,
+				"StableID":   "nsL9qKyS8C21CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:524472cc908505d8c2b933fbf66218530af01354309e2d410c3a42176ce93f17",
+				"DiscoKey":   "discokey:54f7309e4a27192ce49a9ed6edd02fbb3295a50b7182e52954cad977267ac25a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46458",
+					"10.65.0.27:46458",
+					"172.17.0.1:46458",
+					"172.18.0.1:46458",
+					"172.19.0.1:46458",
+					"172.20.0.1:46458",
+					"172.21.0.1:46458",
+					"172.22.0.1:46458",
+					"172.23.0.1:46458",
+					"172.24.0.1:46458",
+					"172.25.0.1:46458",
+					"172.26.0.1:46458",
+					"172.27.0.1:46458",
+					"172.28.0.1:46458"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:24:06.126972468Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8968980206677632,
+				"StableID":   "n1Kz2Hu43D21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:860d008513f7b02d0a70b650f48eaa40cc05d249c02a0877e97d17a253821720",
+				"DiscoKey":   "discokey:d157596b73eaf98a21b0daacea12dfea0f3c8b8f854126fefeb4968d06366820",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33002",
+					"10.65.0.27:33002",
+					"172.17.0.1:33002",
+					"172.18.0.1:33002",
+					"172.19.0.1:33002",
+					"172.20.0.1:33002",
+					"172.21.0.1:33002",
+					"172.22.0.1:33002",
+					"172.23.0.1:33002",
+					"172.24.0.1:33002",
+					"172.25.0.1:33002",
+					"172.26.0.1:33002",
+					"172.27.0.1:33002",
+					"172.28.0.1:33002"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:24:06.680153848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         603882840863826,
+				"StableID":   "nqaMkjyVi511CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e929fa420a5ac3c2c084b5c80b440e3f80d58ef45d5ac8e145bf65fdd11b5e7b",
+				"DiscoKey":   "discokey:358b2ab39e415ebdc7471c49b650e805fe0d0d6f33d8dfd124169c9b6bb1684b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33719",
+					"10.65.0.27:33719",
+					"172.17.0.1:33719",
+					"172.18.0.1:33719",
+					"172.19.0.1:33719",
+					"172.20.0.1:33719",
+					"172.21.0.1:33719",
+					"172.22.0.1:33719",
+					"172.23.0.1:33719",
+					"172.24.0.1:33719",
+					"172.25.0.1:33719",
+					"172.26.0.1:33719",
+					"172.27.0.1:33719",
+					"172.28.0.1:33719"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:24:07.218494291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1542387268041600,
+				"StableID":   "njJkD6uY3D11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30c10631a9260ca93f94386fb6f4d62bcbb72858875ca4c98ff5ee5d4b93e131",
+				"DiscoKey":   "discokey:dc146092255dbfba27de767a419e3ac1c4c7b61cebfcd8d00b6484d49b6ee04d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43605",
+					"10.65.0.27:43605",
+					"172.17.0.1:43605",
+					"172.18.0.1:43605",
+					"172.19.0.1:43605",
+					"172.20.0.1:43605",
+					"172.21.0.1:43605",
+					"172.22.0.1:43605",
+					"172.23.0.1:43605",
+					"172.24.0.1:43605",
+					"172.25.0.1:43605",
+					"172.26.0.1:43605",
+					"172.27.0.1:43605",
+					"172.28.0.1:43605"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:24:07.754657886Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3050105237621357,
+				"StableID":   "nG8jFN6QpQ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0a4410d42b4a3e7fd02c5a4c62cda3b640a4888dcec5334f09710a580f5875b",
+				"DiscoKey":   "discokey:8ecf3f58b84c46a014b0ce8c4977bfc179b4fca7ba60ce99f42d4a4384f86d7a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50119",
+					"10.65.0.27:50119",
+					"172.17.0.1:50119",
+					"172.18.0.1:50119",
+					"172.19.0.1:50119",
+					"172.20.0.1:50119",
+					"172.21.0.1:50119",
+					"172.22.0.1:50119",
+					"172.23.0.1:50119",
+					"172.24.0.1:50119",
+					"172.25.0.1:50119",
+					"172.26.0.1:50119",
+					"172.27.0.1:50119",
+					"172.28.0.1:50119"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:24:08.290665789Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5908834782017552,
+				"StableID":   "nKSJq4589o11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ef1c7321d2d26fddc9c4c3791e54897c29d4b0189f08b406ce04895a58955f57",
+				"DiscoKey":   "discokey:343ba7821e2d7da59dd1d12c1387ed9a02c44c38be9c1282582a13461ec3a548",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53871",
+					"10.65.0.27:53871",
+					"172.17.0.1:53871",
+					"172.18.0.1:53871",
+					"172.19.0.1:53871",
+					"172.20.0.1:53871",
+					"172.21.0.1:53871",
+					"172.22.0.1:53871",
+					"172.23.0.1:53871",
+					"172.24.0.1:53871",
+					"172.25.0.1:53871",
+					"172.26.0.1:53871",
+					"172.27.0.1:53871",
+					"172.28.0.1:53871"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:24:08.828683247Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4968903788143197,
+				"StableID":   "nAfhYFgRof11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86959c2cd704dba34b57adb66ca9e9c0a90ae73ff2d09233311f52fc34a4c32e",
+				"DiscoKey":   "discokey:798a2ab402471e9dd56c6be429e465d2f19c45d1b668cf1ef6093c0b71655f5c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:55645",
+					"10.65.0.27:55645",
+					"172.17.0.1:55645",
+					"172.18.0.1:55645",
+					"172.19.0.1:55645",
+					"172.20.0.1:55645",
+					"172.21.0.1:55645",
+					"172.22.0.1:55645",
+					"172.23.0.1:55645",
+					"172.24.0.1:55645",
+					"172.25.0.1:55645",
+					"172.26.0.1:55645",
+					"172.27.0.1:55645",
+					"172.28.0.1:55645"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:24:09.362144056Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6018109940402123,
+				"StableID":   "nipGPWYczo11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a183704c0861d35acfa31c9f5ed6a2199e095c0fcfac4b5d2a6951ecf768139",
+				"DiscoKey":   "discokey:64af28387bd93e699d7c0363fc13f26dc07ef91e6cce3b08fee5b175d0062247",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49274",
+					"10.65.0.27:49274",
+					"172.17.0.1:49274",
+					"172.18.0.1:49274",
+					"172.19.0.1:49274",
+					"172.20.0.1:49274",
+					"172.21.0.1:49274",
+					"172.22.0.1:49274",
+					"172.23.0.1:49274",
+					"172.24.0.1:49274",
+					"172.25.0.1:49274",
+					"172.26.0.1:49274",
+					"172.27.0.1:49274",
+					"172.28.0.1:49274"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:24:09.971537728Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6557715354076671,
+				"StableID":   "n8yuzc41Dt11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3eb6f8275da0adde2bee63fb41cf92926a6924615b6077412b7d969a6b533330",
+				"DiscoKey":   "discokey:066bd933775f7ba53cecf0fe43999b3114b3342513419f8e9fd3c16e8c592a7d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:49132",
+					"10.65.0.27:49132",
+					"172.17.0.1:49132",
+					"172.18.0.1:49132",
+					"172.19.0.1:49132",
+					"172.20.0.1:49132",
+					"172.21.0.1:49132",
+					"172.22.0.1:49132",
+					"172.23.0.1:49132",
+					"172.24.0.1:49132",
+					"172.25.0.1:49132",
+					"172.26.0.1:49132",
+					"172.27.0.1:49132",
+					"172.28.0.1:49132"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:24:10.672282502Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2315680359056086,
+				"StableID":   "nVCzenzm5K11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f91ee73dc631d6b698a5a33a0786329e14ad4ad68e2277c74740893c9b49d29",
+				"DiscoKey":   "discokey:8cf6dd2e9840e337ae21faf5a65fa2875f2fb3c21e689ac082aa267f9f1ea471",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47187",
+					"10.65.0.27:47187",
+					"172.17.0.1:47187",
+					"172.18.0.1:47187",
+					"172.19.0.1:47187",
+					"172.20.0.1:47187",
+					"172.21.0.1:47187",
+					"172.22.0.1:47187",
+					"172.23.0.1:47187",
+					"172.24.0.1:47187",
+					"172.25.0.1:47187",
+					"172.26.0.1:47187",
+					"172.27.0.1:47187",
+					"172.28.0.1:47187"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:24:11.275495561Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6221106268074116,
+				"StableID":   "nbrTjvuYaq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc164e344ad1d3e907815bee1caef8d2bf1c459cf17e5f029d6db5cf5bbe654f",
+				"DiscoKey":   "discokey:6db67aaebcc475a1d9f246c3e5987ce57fe81f2c6aaa03b8509d5f6fdcd8b64c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60632",
+					"10.65.0.27:60632",
+					"172.17.0.1:60632",
+					"172.18.0.1:60632",
+					"172.19.0.1:60632",
+					"172.20.0.1:60632",
+					"172.21.0.1:60632",
+					"172.22.0.1:60632",
+					"172.23.0.1:60632",
+					"172.24.0.1:60632",
+					"172.25.0.1:60632",
+					"172.26.0.1:60632",
+					"172.27.0.1:60632",
+					"172.28.0.1:60632"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:24:11.827580036Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2113418688973880,
+				"StableID":   "nMXyUfvAWH11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3fcc86ca96b1b33f08204c73a717d366c3f0d3eb786d0a25335535f627ca933d",
+				"KeyExpiry":  "2026-11-09T09:24:12Z",
+				"DiscoKey":   "discokey:0c2f3cb6e7e4ee067d28f26839c5deaf9b98b6eaf8e01b5d525149c354e2dd63",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54053",
+					"10.65.0.27:54053",
+					"172.17.0.1:54053",
+					"172.18.0.1:54053",
+					"172.19.0.1:54053",
+					"172.20.0.1:54053",
+					"172.21.0.1:54053",
+					"172.22.0.1:54053",
+					"172.23.0.1:54053",
+					"172.24.0.1:54053",
+					"172.25.0.1:54053",
+					"172.26.0.1:54053",
+					"172.27.0.1:54053",
+					"172.28.0.1:54053"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:24:12.808963992Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4134718395602339,
+				"StableID":   "nLubwN3dHZ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:accba65175ac92d9b1d02ae3d950da7197cb08ff9dc11a0e58fc1fa11a85852b",
+				"KeyExpiry":  "2026-11-09T09:24:13Z",
+				"DiscoKey":   "discokey:62f296b87d06f1987e44ba1a93ee923344b5576c4d985b9212f35b9703125e19",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36710",
+					"10.65.0.27:36710",
+					"172.17.0.1:36710",
+					"172.18.0.1:36710",
+					"172.19.0.1:36710",
+					"172.20.0.1:36710",
+					"172.21.0.1:36710",
+					"172.22.0.1:36710",
+					"172.23.0.1:36710",
+					"172.24.0.1:36710",
+					"172.25.0.1:36710",
+					"172.26.0.1:36710",
+					"172.27.0.1:36710",
+					"172.28.0.1:36710"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:24:13.422850666Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3335087524911416,
+				"StableID":   "nqf87T6U3T11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ef9ff38f930098d723106d9a3ec4837d1c7bd45534dd70c42bc3543639c27f77",
+				"KeyExpiry":  "2026-11-09T09:24:13Z",
+				"DiscoKey":   "discokey:91bb747b6ec3f7dc64c5b9f2b783542884f0ca2db20bc4955c80a2e5dafa284e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38868",
+					"10.65.0.27:38868",
+					"172.17.0.1:38868",
+					"172.18.0.1:38868",
+					"172.19.0.1:38868",
+					"172.20.0.1:38868",
+					"172.21.0.1:38868",
+					"172.22.0.1:38868",
+					"172.23.0.1:38868",
+					"172.24.0.1:38868",
+					"172.25.0.1:38868",
+					"172.26.0.1:38868",
+					"172.27.0.1:38868",
+					"172.28.0.1:38868"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:24:13.893056144Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8110806700351409": {
+				"ID":          8110806700351409,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5908834782017552,
+				"StableID":   "nKSJq4589o11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       5908834782017552,
+				"Key":        "nodekey:ef1c7321d2d26fddc9c4c3791e54897c29d4b0189f08b406ce04895a58955f57",
+				"DiscoKey":   "discokey:343ba7821e2d7da59dd1d12c1387ed9a02c44c38be9c1282582a13461ec3a548",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53871",
+					"10.65.0.27:53871",
+					"172.17.0.1:53871",
+					"172.18.0.1:53871",
+					"172.19.0.1:53871",
+					"172.20.0.1:53871",
+					"172.21.0.1:53871",
+					"172.22.0.1:53871",
+					"172.23.0.1:53871",
+					"172.24.0.1:53871",
+					"172.25.0.1:53871",
+					"172.26.0.1:53871",
+					"172.27.0.1:53871",
+					"172.28.0.1:53871"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:24:08.828683247Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ef1c7321d2d26fddc9c4c3791e54897c29d4b0189f08b406ce04895a58955f57",
+			"MachineKey": "mkey:0cecd62406942981ef1b6ba692b22d5c1c91466ee5d54eba6a9117acd500ee0b",
+			"Peers": [{
+				"ID":         8852797214098944,
+				"StableID":   "nsL9qKyS8C21CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:524472cc908505d8c2b933fbf66218530af01354309e2d410c3a42176ce93f17",
+				"DiscoKey":   "discokey:54f7309e4a27192ce49a9ed6edd02fbb3295a50b7182e52954cad977267ac25a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46458",
+					"10.65.0.27:46458",
+					"172.17.0.1:46458",
+					"172.18.0.1:46458",
+					"172.19.0.1:46458",
+					"172.20.0.1:46458",
+					"172.21.0.1:46458",
+					"172.22.0.1:46458",
+					"172.23.0.1:46458",
+					"172.24.0.1:46458",
+					"172.25.0.1:46458",
+					"172.26.0.1:46458",
+					"172.27.0.1:46458",
+					"172.28.0.1:46458"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:24:06.126972468Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8968980206677632,
+				"StableID":   "n1Kz2Hu43D21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:860d008513f7b02d0a70b650f48eaa40cc05d249c02a0877e97d17a253821720",
+				"DiscoKey":   "discokey:d157596b73eaf98a21b0daacea12dfea0f3c8b8f854126fefeb4968d06366820",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33002",
+					"10.65.0.27:33002",
+					"172.17.0.1:33002",
+					"172.18.0.1:33002",
+					"172.19.0.1:33002",
+					"172.20.0.1:33002",
+					"172.21.0.1:33002",
+					"172.22.0.1:33002",
+					"172.23.0.1:33002",
+					"172.24.0.1:33002",
+					"172.25.0.1:33002",
+					"172.26.0.1:33002",
+					"172.27.0.1:33002",
+					"172.28.0.1:33002"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:24:06.680153848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         603882840863826,
+				"StableID":   "nqaMkjyVi511CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e929fa420a5ac3c2c084b5c80b440e3f80d58ef45d5ac8e145bf65fdd11b5e7b",
+				"DiscoKey":   "discokey:358b2ab39e415ebdc7471c49b650e805fe0d0d6f33d8dfd124169c9b6bb1684b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33719",
+					"10.65.0.27:33719",
+					"172.17.0.1:33719",
+					"172.18.0.1:33719",
+					"172.19.0.1:33719",
+					"172.20.0.1:33719",
+					"172.21.0.1:33719",
+					"172.22.0.1:33719",
+					"172.23.0.1:33719",
+					"172.24.0.1:33719",
+					"172.25.0.1:33719",
+					"172.26.0.1:33719",
+					"172.27.0.1:33719",
+					"172.28.0.1:33719"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:24:07.218494291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1542387268041600,
+				"StableID":   "njJkD6uY3D11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30c10631a9260ca93f94386fb6f4d62bcbb72858875ca4c98ff5ee5d4b93e131",
+				"DiscoKey":   "discokey:dc146092255dbfba27de767a419e3ac1c4c7b61cebfcd8d00b6484d49b6ee04d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43605",
+					"10.65.0.27:43605",
+					"172.17.0.1:43605",
+					"172.18.0.1:43605",
+					"172.19.0.1:43605",
+					"172.20.0.1:43605",
+					"172.21.0.1:43605",
+					"172.22.0.1:43605",
+					"172.23.0.1:43605",
+					"172.24.0.1:43605",
+					"172.25.0.1:43605",
+					"172.26.0.1:43605",
+					"172.27.0.1:43605",
+					"172.28.0.1:43605"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:24:07.754657886Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3050105237621357,
+				"StableID":   "nG8jFN6QpQ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0a4410d42b4a3e7fd02c5a4c62cda3b640a4888dcec5334f09710a580f5875b",
+				"DiscoKey":   "discokey:8ecf3f58b84c46a014b0ce8c4977bfc179b4fca7ba60ce99f42d4a4384f86d7a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50119",
+					"10.65.0.27:50119",
+					"172.17.0.1:50119",
+					"172.18.0.1:50119",
+					"172.19.0.1:50119",
+					"172.20.0.1:50119",
+					"172.21.0.1:50119",
+					"172.22.0.1:50119",
+					"172.23.0.1:50119",
+					"172.24.0.1:50119",
+					"172.25.0.1:50119",
+					"172.26.0.1:50119",
+					"172.27.0.1:50119",
+					"172.28.0.1:50119"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:24:08.290665789Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4968903788143197,
+				"StableID":   "nAfhYFgRof11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86959c2cd704dba34b57adb66ca9e9c0a90ae73ff2d09233311f52fc34a4c32e",
+				"DiscoKey":   "discokey:798a2ab402471e9dd56c6be429e465d2f19c45d1b668cf1ef6093c0b71655f5c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:55645",
+					"10.65.0.27:55645",
+					"172.17.0.1:55645",
+					"172.18.0.1:55645",
+					"172.19.0.1:55645",
+					"172.20.0.1:55645",
+					"172.21.0.1:55645",
+					"172.22.0.1:55645",
+					"172.23.0.1:55645",
+					"172.24.0.1:55645",
+					"172.25.0.1:55645",
+					"172.26.0.1:55645",
+					"172.27.0.1:55645",
+					"172.28.0.1:55645"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:24:09.362144056Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6018109940402123,
+				"StableID":   "nipGPWYczo11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a183704c0861d35acfa31c9f5ed6a2199e095c0fcfac4b5d2a6951ecf768139",
+				"DiscoKey":   "discokey:64af28387bd93e699d7c0363fc13f26dc07ef91e6cce3b08fee5b175d0062247",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49274",
+					"10.65.0.27:49274",
+					"172.17.0.1:49274",
+					"172.18.0.1:49274",
+					"172.19.0.1:49274",
+					"172.20.0.1:49274",
+					"172.21.0.1:49274",
+					"172.22.0.1:49274",
+					"172.23.0.1:49274",
+					"172.24.0.1:49274",
+					"172.25.0.1:49274",
+					"172.26.0.1:49274",
+					"172.27.0.1:49274",
+					"172.28.0.1:49274"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:24:09.971537728Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6557715354076671,
+				"StableID":   "n8yuzc41Dt11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3eb6f8275da0adde2bee63fb41cf92926a6924615b6077412b7d969a6b533330",
+				"DiscoKey":   "discokey:066bd933775f7ba53cecf0fe43999b3114b3342513419f8e9fd3c16e8c592a7d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:49132",
+					"10.65.0.27:49132",
+					"172.17.0.1:49132",
+					"172.18.0.1:49132",
+					"172.19.0.1:49132",
+					"172.20.0.1:49132",
+					"172.21.0.1:49132",
+					"172.22.0.1:49132",
+					"172.23.0.1:49132",
+					"172.24.0.1:49132",
+					"172.25.0.1:49132",
+					"172.26.0.1:49132",
+					"172.27.0.1:49132",
+					"172.28.0.1:49132"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:24:10.672282502Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2315680359056086,
+				"StableID":   "nVCzenzm5K11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f91ee73dc631d6b698a5a33a0786329e14ad4ad68e2277c74740893c9b49d29",
+				"DiscoKey":   "discokey:8cf6dd2e9840e337ae21faf5a65fa2875f2fb3c21e689ac082aa267f9f1ea471",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47187",
+					"10.65.0.27:47187",
+					"172.17.0.1:47187",
+					"172.18.0.1:47187",
+					"172.19.0.1:47187",
+					"172.20.0.1:47187",
+					"172.21.0.1:47187",
+					"172.22.0.1:47187",
+					"172.23.0.1:47187",
+					"172.24.0.1:47187",
+					"172.25.0.1:47187",
+					"172.26.0.1:47187",
+					"172.27.0.1:47187",
+					"172.28.0.1:47187"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:24:11.275495561Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6221106268074116,
+				"StableID":   "nbrTjvuYaq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc164e344ad1d3e907815bee1caef8d2bf1c459cf17e5f029d6db5cf5bbe654f",
+				"DiscoKey":   "discokey:6db67aaebcc475a1d9f246c3e5987ce57fe81f2c6aaa03b8509d5f6fdcd8b64c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60632",
+					"10.65.0.27:60632",
+					"172.17.0.1:60632",
+					"172.18.0.1:60632",
+					"172.19.0.1:60632",
+					"172.20.0.1:60632",
+					"172.21.0.1:60632",
+					"172.22.0.1:60632",
+					"172.23.0.1:60632",
+					"172.24.0.1:60632",
+					"172.25.0.1:60632",
+					"172.26.0.1:60632",
+					"172.27.0.1:60632",
+					"172.28.0.1:60632"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:24:11.827580036Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8110806700351409,
+				"StableID":   "nzVXx29QL621CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db3a3e21ceff1453eae1946b6242c8f2847640e647cb3e4d378c17215f4e1f6d",
+				"DiscoKey":   "discokey:ca8b5774f2d197c6b2274e73f3b53ddd6f6a63a98f4e54b8dbfc11e8504c7415",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52722",
+					"10.65.0.27:52722",
+					"172.17.0.1:52722",
+					"172.18.0.1:52722",
+					"172.19.0.1:52722",
+					"172.20.0.1:52722",
+					"172.21.0.1:52722",
+					"172.22.0.1:52722",
+					"172.23.0.1:52722",
+					"172.24.0.1:52722",
+					"172.25.0.1:52722",
+					"172.26.0.1:52722",
+					"172.27.0.1:52722",
+					"172.28.0.1:52722"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:24:12.280445949Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2113418688973880,
+				"StableID":   "nMXyUfvAWH11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3fcc86ca96b1b33f08204c73a717d366c3f0d3eb786d0a25335535f627ca933d",
+				"KeyExpiry":  "2026-11-09T09:24:12Z",
+				"DiscoKey":   "discokey:0c2f3cb6e7e4ee067d28f26839c5deaf9b98b6eaf8e01b5d525149c354e2dd63",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54053",
+					"10.65.0.27:54053",
+					"172.17.0.1:54053",
+					"172.18.0.1:54053",
+					"172.19.0.1:54053",
+					"172.20.0.1:54053",
+					"172.21.0.1:54053",
+					"172.22.0.1:54053",
+					"172.23.0.1:54053",
+					"172.24.0.1:54053",
+					"172.25.0.1:54053",
+					"172.26.0.1:54053",
+					"172.27.0.1:54053",
+					"172.28.0.1:54053"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:24:12.808963992Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4134718395602339,
+				"StableID":   "nLubwN3dHZ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:accba65175ac92d9b1d02ae3d950da7197cb08ff9dc11a0e58fc1fa11a85852b",
+				"KeyExpiry":  "2026-11-09T09:24:13Z",
+				"DiscoKey":   "discokey:62f296b87d06f1987e44ba1a93ee923344b5576c4d985b9212f35b9703125e19",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36710",
+					"10.65.0.27:36710",
+					"172.17.0.1:36710",
+					"172.18.0.1:36710",
+					"172.19.0.1:36710",
+					"172.20.0.1:36710",
+					"172.21.0.1:36710",
+					"172.22.0.1:36710",
+					"172.23.0.1:36710",
+					"172.24.0.1:36710",
+					"172.25.0.1:36710",
+					"172.26.0.1:36710",
+					"172.27.0.1:36710",
+					"172.28.0.1:36710"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:24:13.422850666Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3335087524911416,
+				"StableID":   "nqf87T6U3T11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ef9ff38f930098d723106d9a3ec4837d1c7bd45534dd70c42bc3543639c27f77",
+				"KeyExpiry":  "2026-11-09T09:24:13Z",
+				"DiscoKey":   "discokey:91bb747b6ec3f7dc64c5b9f2b783542884f0ca2db20bc4955c80a2e5dafa284e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38868",
+					"10.65.0.27:38868",
+					"172.17.0.1:38868",
+					"172.18.0.1:38868",
+					"172.19.0.1:38868",
+					"172.20.0.1:38868",
+					"172.21.0.1:38868",
+					"172.22.0.1:38868",
+					"172.23.0.1:38868",
+					"172.24.0.1:38868",
+					"172.25.0.1:38868",
+					"172.26.0.1:38868",
+					"172.27.0.1:38868",
+					"172.28.0.1:38868"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:24:13.893056144Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5908834782017552": {
+				"ID":          5908834782017552,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3335087524911416,
+				"StableID":   "nqf87T6U3T11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ef9ff38f930098d723106d9a3ec4837d1c7bd45534dd70c42bc3543639c27f77",
+				"KeyExpiry":  "2026-11-09T09:24:13Z",
+				"DiscoKey":   "discokey:91bb747b6ec3f7dc64c5b9f2b783542884f0ca2db20bc4955c80a2e5dafa284e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38868",
+					"10.65.0.27:38868",
+					"172.17.0.1:38868",
+					"172.18.0.1:38868",
+					"172.19.0.1:38868",
+					"172.20.0.1:38868",
+					"172.21.0.1:38868",
+					"172.22.0.1:38868",
+					"172.23.0.1:38868",
+					"172.24.0.1:38868",
+					"172.25.0.1:38868",
+					"172.26.0.1:38868",
+					"172.27.0.1:38868",
+					"172.28.0.1:38868"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:24:13.893056144Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ef9ff38f930098d723106d9a3ec4837d1c7bd45534dd70c42bc3543639c27f77",
+			"MachineKey": "mkey:171c6ebce4676adeaadef279bcf7cec529f58894aaf556283278d28522b6a60d",
+			"Peers": [{
+				"ID":         8852797214098944,
+				"StableID":   "nsL9qKyS8C21CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:524472cc908505d8c2b933fbf66218530af01354309e2d410c3a42176ce93f17",
+				"DiscoKey":   "discokey:54f7309e4a27192ce49a9ed6edd02fbb3295a50b7182e52954cad977267ac25a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46458",
+					"10.65.0.27:46458",
+					"172.17.0.1:46458",
+					"172.18.0.1:46458",
+					"172.19.0.1:46458",
+					"172.20.0.1:46458",
+					"172.21.0.1:46458",
+					"172.22.0.1:46458",
+					"172.23.0.1:46458",
+					"172.24.0.1:46458",
+					"172.25.0.1:46458",
+					"172.26.0.1:46458",
+					"172.27.0.1:46458",
+					"172.28.0.1:46458"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:24:06.126972468Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8968980206677632,
+				"StableID":   "n1Kz2Hu43D21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:860d008513f7b02d0a70b650f48eaa40cc05d249c02a0877e97d17a253821720",
+				"DiscoKey":   "discokey:d157596b73eaf98a21b0daacea12dfea0f3c8b8f854126fefeb4968d06366820",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33002",
+					"10.65.0.27:33002",
+					"172.17.0.1:33002",
+					"172.18.0.1:33002",
+					"172.19.0.1:33002",
+					"172.20.0.1:33002",
+					"172.21.0.1:33002",
+					"172.22.0.1:33002",
+					"172.23.0.1:33002",
+					"172.24.0.1:33002",
+					"172.25.0.1:33002",
+					"172.26.0.1:33002",
+					"172.27.0.1:33002",
+					"172.28.0.1:33002"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:24:06.680153848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         603882840863826,
+				"StableID":   "nqaMkjyVi511CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e929fa420a5ac3c2c084b5c80b440e3f80d58ef45d5ac8e145bf65fdd11b5e7b",
+				"DiscoKey":   "discokey:358b2ab39e415ebdc7471c49b650e805fe0d0d6f33d8dfd124169c9b6bb1684b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33719",
+					"10.65.0.27:33719",
+					"172.17.0.1:33719",
+					"172.18.0.1:33719",
+					"172.19.0.1:33719",
+					"172.20.0.1:33719",
+					"172.21.0.1:33719",
+					"172.22.0.1:33719",
+					"172.23.0.1:33719",
+					"172.24.0.1:33719",
+					"172.25.0.1:33719",
+					"172.26.0.1:33719",
+					"172.27.0.1:33719",
+					"172.28.0.1:33719"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:24:07.218494291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1542387268041600,
+				"StableID":   "njJkD6uY3D11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30c10631a9260ca93f94386fb6f4d62bcbb72858875ca4c98ff5ee5d4b93e131",
+				"DiscoKey":   "discokey:dc146092255dbfba27de767a419e3ac1c4c7b61cebfcd8d00b6484d49b6ee04d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43605",
+					"10.65.0.27:43605",
+					"172.17.0.1:43605",
+					"172.18.0.1:43605",
+					"172.19.0.1:43605",
+					"172.20.0.1:43605",
+					"172.21.0.1:43605",
+					"172.22.0.1:43605",
+					"172.23.0.1:43605",
+					"172.24.0.1:43605",
+					"172.25.0.1:43605",
+					"172.26.0.1:43605",
+					"172.27.0.1:43605",
+					"172.28.0.1:43605"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:24:07.754657886Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3050105237621357,
+				"StableID":   "nG8jFN6QpQ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0a4410d42b4a3e7fd02c5a4c62cda3b640a4888dcec5334f09710a580f5875b",
+				"DiscoKey":   "discokey:8ecf3f58b84c46a014b0ce8c4977bfc179b4fca7ba60ce99f42d4a4384f86d7a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50119",
+					"10.65.0.27:50119",
+					"172.17.0.1:50119",
+					"172.18.0.1:50119",
+					"172.19.0.1:50119",
+					"172.20.0.1:50119",
+					"172.21.0.1:50119",
+					"172.22.0.1:50119",
+					"172.23.0.1:50119",
+					"172.24.0.1:50119",
+					"172.25.0.1:50119",
+					"172.26.0.1:50119",
+					"172.27.0.1:50119",
+					"172.28.0.1:50119"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:24:08.290665789Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5908834782017552,
+				"StableID":   "nKSJq4589o11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ef1c7321d2d26fddc9c4c3791e54897c29d4b0189f08b406ce04895a58955f57",
+				"DiscoKey":   "discokey:343ba7821e2d7da59dd1d12c1387ed9a02c44c38be9c1282582a13461ec3a548",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53871",
+					"10.65.0.27:53871",
+					"172.17.0.1:53871",
+					"172.18.0.1:53871",
+					"172.19.0.1:53871",
+					"172.20.0.1:53871",
+					"172.21.0.1:53871",
+					"172.22.0.1:53871",
+					"172.23.0.1:53871",
+					"172.24.0.1:53871",
+					"172.25.0.1:53871",
+					"172.26.0.1:53871",
+					"172.27.0.1:53871",
+					"172.28.0.1:53871"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:24:08.828683247Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4968903788143197,
+				"StableID":   "nAfhYFgRof11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86959c2cd704dba34b57adb66ca9e9c0a90ae73ff2d09233311f52fc34a4c32e",
+				"DiscoKey":   "discokey:798a2ab402471e9dd56c6be429e465d2f19c45d1b668cf1ef6093c0b71655f5c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:55645",
+					"10.65.0.27:55645",
+					"172.17.0.1:55645",
+					"172.18.0.1:55645",
+					"172.19.0.1:55645",
+					"172.20.0.1:55645",
+					"172.21.0.1:55645",
+					"172.22.0.1:55645",
+					"172.23.0.1:55645",
+					"172.24.0.1:55645",
+					"172.25.0.1:55645",
+					"172.26.0.1:55645",
+					"172.27.0.1:55645",
+					"172.28.0.1:55645"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:24:09.362144056Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6018109940402123,
+				"StableID":   "nipGPWYczo11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a183704c0861d35acfa31c9f5ed6a2199e095c0fcfac4b5d2a6951ecf768139",
+				"DiscoKey":   "discokey:64af28387bd93e699d7c0363fc13f26dc07ef91e6cce3b08fee5b175d0062247",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49274",
+					"10.65.0.27:49274",
+					"172.17.0.1:49274",
+					"172.18.0.1:49274",
+					"172.19.0.1:49274",
+					"172.20.0.1:49274",
+					"172.21.0.1:49274",
+					"172.22.0.1:49274",
+					"172.23.0.1:49274",
+					"172.24.0.1:49274",
+					"172.25.0.1:49274",
+					"172.26.0.1:49274",
+					"172.27.0.1:49274",
+					"172.28.0.1:49274"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:24:09.971537728Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6557715354076671,
+				"StableID":   "n8yuzc41Dt11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3eb6f8275da0adde2bee63fb41cf92926a6924615b6077412b7d969a6b533330",
+				"DiscoKey":   "discokey:066bd933775f7ba53cecf0fe43999b3114b3342513419f8e9fd3c16e8c592a7d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:49132",
+					"10.65.0.27:49132",
+					"172.17.0.1:49132",
+					"172.18.0.1:49132",
+					"172.19.0.1:49132",
+					"172.20.0.1:49132",
+					"172.21.0.1:49132",
+					"172.22.0.1:49132",
+					"172.23.0.1:49132",
+					"172.24.0.1:49132",
+					"172.25.0.1:49132",
+					"172.26.0.1:49132",
+					"172.27.0.1:49132",
+					"172.28.0.1:49132"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:24:10.672282502Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2315680359056086,
+				"StableID":   "nVCzenzm5K11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f91ee73dc631d6b698a5a33a0786329e14ad4ad68e2277c74740893c9b49d29",
+				"DiscoKey":   "discokey:8cf6dd2e9840e337ae21faf5a65fa2875f2fb3c21e689ac082aa267f9f1ea471",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47187",
+					"10.65.0.27:47187",
+					"172.17.0.1:47187",
+					"172.18.0.1:47187",
+					"172.19.0.1:47187",
+					"172.20.0.1:47187",
+					"172.21.0.1:47187",
+					"172.22.0.1:47187",
+					"172.23.0.1:47187",
+					"172.24.0.1:47187",
+					"172.25.0.1:47187",
+					"172.26.0.1:47187",
+					"172.27.0.1:47187",
+					"172.28.0.1:47187"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:24:11.275495561Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6221106268074116,
+				"StableID":   "nbrTjvuYaq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc164e344ad1d3e907815bee1caef8d2bf1c459cf17e5f029d6db5cf5bbe654f",
+				"DiscoKey":   "discokey:6db67aaebcc475a1d9f246c3e5987ce57fe81f2c6aaa03b8509d5f6fdcd8b64c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60632",
+					"10.65.0.27:60632",
+					"172.17.0.1:60632",
+					"172.18.0.1:60632",
+					"172.19.0.1:60632",
+					"172.20.0.1:60632",
+					"172.21.0.1:60632",
+					"172.22.0.1:60632",
+					"172.23.0.1:60632",
+					"172.24.0.1:60632",
+					"172.25.0.1:60632",
+					"172.26.0.1:60632",
+					"172.27.0.1:60632",
+					"172.28.0.1:60632"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:24:11.827580036Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8110806700351409,
+				"StableID":   "nzVXx29QL621CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db3a3e21ceff1453eae1946b6242c8f2847640e647cb3e4d378c17215f4e1f6d",
+				"DiscoKey":   "discokey:ca8b5774f2d197c6b2274e73f3b53ddd6f6a63a98f4e54b8dbfc11e8504c7415",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52722",
+					"10.65.0.27:52722",
+					"172.17.0.1:52722",
+					"172.18.0.1:52722",
+					"172.19.0.1:52722",
+					"172.20.0.1:52722",
+					"172.21.0.1:52722",
+					"172.22.0.1:52722",
+					"172.23.0.1:52722",
+					"172.24.0.1:52722",
+					"172.25.0.1:52722",
+					"172.26.0.1:52722",
+					"172.27.0.1:52722",
+					"172.28.0.1:52722"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:24:12.280445949Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2113418688973880,
+				"StableID":   "nMXyUfvAWH11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3fcc86ca96b1b33f08204c73a717d366c3f0d3eb786d0a25335535f627ca933d",
+				"KeyExpiry":  "2026-11-09T09:24:12Z",
+				"DiscoKey":   "discokey:0c2f3cb6e7e4ee067d28f26839c5deaf9b98b6eaf8e01b5d525149c354e2dd63",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54053",
+					"10.65.0.27:54053",
+					"172.17.0.1:54053",
+					"172.18.0.1:54053",
+					"172.19.0.1:54053",
+					"172.20.0.1:54053",
+					"172.21.0.1:54053",
+					"172.22.0.1:54053",
+					"172.23.0.1:54053",
+					"172.24.0.1:54053",
+					"172.25.0.1:54053",
+					"172.26.0.1:54053",
+					"172.27.0.1:54053",
+					"172.28.0.1:54053"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:24:12.808963992Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4134718395602339,
+				"StableID":   "nLubwN3dHZ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:accba65175ac92d9b1d02ae3d950da7197cb08ff9dc11a0e58fc1fa11a85852b",
+				"KeyExpiry":  "2026-11-09T09:24:13Z",
+				"DiscoKey":   "discokey:62f296b87d06f1987e44ba1a93ee923344b5576c4d985b9212f35b9703125e19",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36710",
+					"10.65.0.27:36710",
+					"172.17.0.1:36710",
+					"172.18.0.1:36710",
+					"172.19.0.1:36710",
+					"172.20.0.1:36710",
+					"172.21.0.1:36710",
+					"172.22.0.1:36710",
+					"172.23.0.1:36710",
+					"172.24.0.1:36710",
+					"172.25.0.1:36710",
+					"172.26.0.1:36710",
+					"172.27.0.1:36710",
+					"172.28.0.1:36710"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:24:13.422850666Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         603882840863826,
+				"StableID":   "nqaMkjyVi511CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       603882840863826,
+				"Key":        "nodekey:e929fa420a5ac3c2c084b5c80b440e3f80d58ef45d5ac8e145bf65fdd11b5e7b",
+				"DiscoKey":   "discokey:358b2ab39e415ebdc7471c49b650e805fe0d0d6f33d8dfd124169c9b6bb1684b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33719",
+					"10.65.0.27:33719",
+					"172.17.0.1:33719",
+					"172.18.0.1:33719",
+					"172.19.0.1:33719",
+					"172.20.0.1:33719",
+					"172.21.0.1:33719",
+					"172.22.0.1:33719",
+					"172.23.0.1:33719",
+					"172.24.0.1:33719",
+					"172.25.0.1:33719",
+					"172.26.0.1:33719",
+					"172.27.0.1:33719",
+					"172.28.0.1:33719"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:24:07.218494291Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e929fa420a5ac3c2c084b5c80b440e3f80d58ef45d5ac8e145bf65fdd11b5e7b",
+			"MachineKey": "mkey:4865eb7e1108176593773b11df4af1dcb6c69cb313f85888efddae4784f5d556",
+			"Peers": [{
+				"ID":         8852797214098944,
+				"StableID":   "nsL9qKyS8C21CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:524472cc908505d8c2b933fbf66218530af01354309e2d410c3a42176ce93f17",
+				"DiscoKey":   "discokey:54f7309e4a27192ce49a9ed6edd02fbb3295a50b7182e52954cad977267ac25a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46458",
+					"10.65.0.27:46458",
+					"172.17.0.1:46458",
+					"172.18.0.1:46458",
+					"172.19.0.1:46458",
+					"172.20.0.1:46458",
+					"172.21.0.1:46458",
+					"172.22.0.1:46458",
+					"172.23.0.1:46458",
+					"172.24.0.1:46458",
+					"172.25.0.1:46458",
+					"172.26.0.1:46458",
+					"172.27.0.1:46458",
+					"172.28.0.1:46458"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:24:06.126972468Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8968980206677632,
+				"StableID":   "n1Kz2Hu43D21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:860d008513f7b02d0a70b650f48eaa40cc05d249c02a0877e97d17a253821720",
+				"DiscoKey":   "discokey:d157596b73eaf98a21b0daacea12dfea0f3c8b8f854126fefeb4968d06366820",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33002",
+					"10.65.0.27:33002",
+					"172.17.0.1:33002",
+					"172.18.0.1:33002",
+					"172.19.0.1:33002",
+					"172.20.0.1:33002",
+					"172.21.0.1:33002",
+					"172.22.0.1:33002",
+					"172.23.0.1:33002",
+					"172.24.0.1:33002",
+					"172.25.0.1:33002",
+					"172.26.0.1:33002",
+					"172.27.0.1:33002",
+					"172.28.0.1:33002"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:24:06.680153848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1542387268041600,
+				"StableID":   "njJkD6uY3D11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30c10631a9260ca93f94386fb6f4d62bcbb72858875ca4c98ff5ee5d4b93e131",
+				"DiscoKey":   "discokey:dc146092255dbfba27de767a419e3ac1c4c7b61cebfcd8d00b6484d49b6ee04d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43605",
+					"10.65.0.27:43605",
+					"172.17.0.1:43605",
+					"172.18.0.1:43605",
+					"172.19.0.1:43605",
+					"172.20.0.1:43605",
+					"172.21.0.1:43605",
+					"172.22.0.1:43605",
+					"172.23.0.1:43605",
+					"172.24.0.1:43605",
+					"172.25.0.1:43605",
+					"172.26.0.1:43605",
+					"172.27.0.1:43605",
+					"172.28.0.1:43605"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:24:07.754657886Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3050105237621357,
+				"StableID":   "nG8jFN6QpQ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0a4410d42b4a3e7fd02c5a4c62cda3b640a4888dcec5334f09710a580f5875b",
+				"DiscoKey":   "discokey:8ecf3f58b84c46a014b0ce8c4977bfc179b4fca7ba60ce99f42d4a4384f86d7a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50119",
+					"10.65.0.27:50119",
+					"172.17.0.1:50119",
+					"172.18.0.1:50119",
+					"172.19.0.1:50119",
+					"172.20.0.1:50119",
+					"172.21.0.1:50119",
+					"172.22.0.1:50119",
+					"172.23.0.1:50119",
+					"172.24.0.1:50119",
+					"172.25.0.1:50119",
+					"172.26.0.1:50119",
+					"172.27.0.1:50119",
+					"172.28.0.1:50119"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:24:08.290665789Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5908834782017552,
+				"StableID":   "nKSJq4589o11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ef1c7321d2d26fddc9c4c3791e54897c29d4b0189f08b406ce04895a58955f57",
+				"DiscoKey":   "discokey:343ba7821e2d7da59dd1d12c1387ed9a02c44c38be9c1282582a13461ec3a548",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53871",
+					"10.65.0.27:53871",
+					"172.17.0.1:53871",
+					"172.18.0.1:53871",
+					"172.19.0.1:53871",
+					"172.20.0.1:53871",
+					"172.21.0.1:53871",
+					"172.22.0.1:53871",
+					"172.23.0.1:53871",
+					"172.24.0.1:53871",
+					"172.25.0.1:53871",
+					"172.26.0.1:53871",
+					"172.27.0.1:53871",
+					"172.28.0.1:53871"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:24:08.828683247Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4968903788143197,
+				"StableID":   "nAfhYFgRof11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86959c2cd704dba34b57adb66ca9e9c0a90ae73ff2d09233311f52fc34a4c32e",
+				"DiscoKey":   "discokey:798a2ab402471e9dd56c6be429e465d2f19c45d1b668cf1ef6093c0b71655f5c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:55645",
+					"10.65.0.27:55645",
+					"172.17.0.1:55645",
+					"172.18.0.1:55645",
+					"172.19.0.1:55645",
+					"172.20.0.1:55645",
+					"172.21.0.1:55645",
+					"172.22.0.1:55645",
+					"172.23.0.1:55645",
+					"172.24.0.1:55645",
+					"172.25.0.1:55645",
+					"172.26.0.1:55645",
+					"172.27.0.1:55645",
+					"172.28.0.1:55645"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:24:09.362144056Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6018109940402123,
+				"StableID":   "nipGPWYczo11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a183704c0861d35acfa31c9f5ed6a2199e095c0fcfac4b5d2a6951ecf768139",
+				"DiscoKey":   "discokey:64af28387bd93e699d7c0363fc13f26dc07ef91e6cce3b08fee5b175d0062247",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49274",
+					"10.65.0.27:49274",
+					"172.17.0.1:49274",
+					"172.18.0.1:49274",
+					"172.19.0.1:49274",
+					"172.20.0.1:49274",
+					"172.21.0.1:49274",
+					"172.22.0.1:49274",
+					"172.23.0.1:49274",
+					"172.24.0.1:49274",
+					"172.25.0.1:49274",
+					"172.26.0.1:49274",
+					"172.27.0.1:49274",
+					"172.28.0.1:49274"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:24:09.971537728Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6557715354076671,
+				"StableID":   "n8yuzc41Dt11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3eb6f8275da0adde2bee63fb41cf92926a6924615b6077412b7d969a6b533330",
+				"DiscoKey":   "discokey:066bd933775f7ba53cecf0fe43999b3114b3342513419f8e9fd3c16e8c592a7d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:49132",
+					"10.65.0.27:49132",
+					"172.17.0.1:49132",
+					"172.18.0.1:49132",
+					"172.19.0.1:49132",
+					"172.20.0.1:49132",
+					"172.21.0.1:49132",
+					"172.22.0.1:49132",
+					"172.23.0.1:49132",
+					"172.24.0.1:49132",
+					"172.25.0.1:49132",
+					"172.26.0.1:49132",
+					"172.27.0.1:49132",
+					"172.28.0.1:49132"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:24:10.672282502Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2315680359056086,
+				"StableID":   "nVCzenzm5K11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f91ee73dc631d6b698a5a33a0786329e14ad4ad68e2277c74740893c9b49d29",
+				"DiscoKey":   "discokey:8cf6dd2e9840e337ae21faf5a65fa2875f2fb3c21e689ac082aa267f9f1ea471",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47187",
+					"10.65.0.27:47187",
+					"172.17.0.1:47187",
+					"172.18.0.1:47187",
+					"172.19.0.1:47187",
+					"172.20.0.1:47187",
+					"172.21.0.1:47187",
+					"172.22.0.1:47187",
+					"172.23.0.1:47187",
+					"172.24.0.1:47187",
+					"172.25.0.1:47187",
+					"172.26.0.1:47187",
+					"172.27.0.1:47187",
+					"172.28.0.1:47187"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:24:11.275495561Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6221106268074116,
+				"StableID":   "nbrTjvuYaq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc164e344ad1d3e907815bee1caef8d2bf1c459cf17e5f029d6db5cf5bbe654f",
+				"DiscoKey":   "discokey:6db67aaebcc475a1d9f246c3e5987ce57fe81f2c6aaa03b8509d5f6fdcd8b64c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60632",
+					"10.65.0.27:60632",
+					"172.17.0.1:60632",
+					"172.18.0.1:60632",
+					"172.19.0.1:60632",
+					"172.20.0.1:60632",
+					"172.21.0.1:60632",
+					"172.22.0.1:60632",
+					"172.23.0.1:60632",
+					"172.24.0.1:60632",
+					"172.25.0.1:60632",
+					"172.26.0.1:60632",
+					"172.27.0.1:60632",
+					"172.28.0.1:60632"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:24:11.827580036Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8110806700351409,
+				"StableID":   "nzVXx29QL621CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db3a3e21ceff1453eae1946b6242c8f2847640e647cb3e4d378c17215f4e1f6d",
+				"DiscoKey":   "discokey:ca8b5774f2d197c6b2274e73f3b53ddd6f6a63a98f4e54b8dbfc11e8504c7415",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52722",
+					"10.65.0.27:52722",
+					"172.17.0.1:52722",
+					"172.18.0.1:52722",
+					"172.19.0.1:52722",
+					"172.20.0.1:52722",
+					"172.21.0.1:52722",
+					"172.22.0.1:52722",
+					"172.23.0.1:52722",
+					"172.24.0.1:52722",
+					"172.25.0.1:52722",
+					"172.26.0.1:52722",
+					"172.27.0.1:52722",
+					"172.28.0.1:52722"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:24:12.280445949Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2113418688973880,
+				"StableID":   "nMXyUfvAWH11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3fcc86ca96b1b33f08204c73a717d366c3f0d3eb786d0a25335535f627ca933d",
+				"KeyExpiry":  "2026-11-09T09:24:12Z",
+				"DiscoKey":   "discokey:0c2f3cb6e7e4ee067d28f26839c5deaf9b98b6eaf8e01b5d525149c354e2dd63",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54053",
+					"10.65.0.27:54053",
+					"172.17.0.1:54053",
+					"172.18.0.1:54053",
+					"172.19.0.1:54053",
+					"172.20.0.1:54053",
+					"172.21.0.1:54053",
+					"172.22.0.1:54053",
+					"172.23.0.1:54053",
+					"172.24.0.1:54053",
+					"172.25.0.1:54053",
+					"172.26.0.1:54053",
+					"172.27.0.1:54053",
+					"172.28.0.1:54053"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:24:12.808963992Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4134718395602339,
+				"StableID":   "nLubwN3dHZ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:accba65175ac92d9b1d02ae3d950da7197cb08ff9dc11a0e58fc1fa11a85852b",
+				"KeyExpiry":  "2026-11-09T09:24:13Z",
+				"DiscoKey":   "discokey:62f296b87d06f1987e44ba1a93ee923344b5576c4d985b9212f35b9703125e19",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36710",
+					"10.65.0.27:36710",
+					"172.17.0.1:36710",
+					"172.18.0.1:36710",
+					"172.19.0.1:36710",
+					"172.20.0.1:36710",
+					"172.21.0.1:36710",
+					"172.22.0.1:36710",
+					"172.23.0.1:36710",
+					"172.24.0.1:36710",
+					"172.25.0.1:36710",
+					"172.26.0.1:36710",
+					"172.27.0.1:36710",
+					"172.28.0.1:36710"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:24:13.422850666Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3335087524911416,
+				"StableID":   "nqf87T6U3T11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ef9ff38f930098d723106d9a3ec4837d1c7bd45534dd70c42bc3543639c27f77",
+				"KeyExpiry":  "2026-11-09T09:24:13Z",
+				"DiscoKey":   "discokey:91bb747b6ec3f7dc64c5b9f2b783542884f0ca2db20bc4955c80a2e5dafa284e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38868",
+					"10.65.0.27:38868",
+					"172.17.0.1:38868",
+					"172.18.0.1:38868",
+					"172.19.0.1:38868",
+					"172.20.0.1:38868",
+					"172.21.0.1:38868",
+					"172.22.0.1:38868",
+					"172.23.0.1:38868",
+					"172.24.0.1:38868",
+					"172.25.0.1:38868",
+					"172.26.0.1:38868",
+					"172.27.0.1:38868",
+					"172.28.0.1:38868"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:24:13.893056144Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "603882840863826": {
+				"ID":          603882840863826,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6018109940402123,
+				"StableID":   "nipGPWYczo11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       6018109940402123,
+				"Key":        "nodekey:3a183704c0861d35acfa31c9f5ed6a2199e095c0fcfac4b5d2a6951ecf768139",
+				"DiscoKey":   "discokey:64af28387bd93e699d7c0363fc13f26dc07ef91e6cce3b08fee5b175d0062247",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49274",
+					"10.65.0.27:49274",
+					"172.17.0.1:49274",
+					"172.18.0.1:49274",
+					"172.19.0.1:49274",
+					"172.20.0.1:49274",
+					"172.21.0.1:49274",
+					"172.22.0.1:49274",
+					"172.23.0.1:49274",
+					"172.24.0.1:49274",
+					"172.25.0.1:49274",
+					"172.26.0.1:49274",
+					"172.27.0.1:49274",
+					"172.28.0.1:49274"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:24:09.971537728Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3a183704c0861d35acfa31c9f5ed6a2199e095c0fcfac4b5d2a6951ecf768139",
+			"MachineKey": "mkey:7ccdcb07d1d47661d0be5db81fcfb8ce43eaee1f1151bf6c2633fb3826c86a1e",
+			"Peers": [{
+				"ID":         8852797214098944,
+				"StableID":   "nsL9qKyS8C21CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:524472cc908505d8c2b933fbf66218530af01354309e2d410c3a42176ce93f17",
+				"DiscoKey":   "discokey:54f7309e4a27192ce49a9ed6edd02fbb3295a50b7182e52954cad977267ac25a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46458",
+					"10.65.0.27:46458",
+					"172.17.0.1:46458",
+					"172.18.0.1:46458",
+					"172.19.0.1:46458",
+					"172.20.0.1:46458",
+					"172.21.0.1:46458",
+					"172.22.0.1:46458",
+					"172.23.0.1:46458",
+					"172.24.0.1:46458",
+					"172.25.0.1:46458",
+					"172.26.0.1:46458",
+					"172.27.0.1:46458",
+					"172.28.0.1:46458"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:24:06.126972468Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8968980206677632,
+				"StableID":   "n1Kz2Hu43D21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:860d008513f7b02d0a70b650f48eaa40cc05d249c02a0877e97d17a253821720",
+				"DiscoKey":   "discokey:d157596b73eaf98a21b0daacea12dfea0f3c8b8f854126fefeb4968d06366820",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33002",
+					"10.65.0.27:33002",
+					"172.17.0.1:33002",
+					"172.18.0.1:33002",
+					"172.19.0.1:33002",
+					"172.20.0.1:33002",
+					"172.21.0.1:33002",
+					"172.22.0.1:33002",
+					"172.23.0.1:33002",
+					"172.24.0.1:33002",
+					"172.25.0.1:33002",
+					"172.26.0.1:33002",
+					"172.27.0.1:33002",
+					"172.28.0.1:33002"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:24:06.680153848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         603882840863826,
+				"StableID":   "nqaMkjyVi511CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e929fa420a5ac3c2c084b5c80b440e3f80d58ef45d5ac8e145bf65fdd11b5e7b",
+				"DiscoKey":   "discokey:358b2ab39e415ebdc7471c49b650e805fe0d0d6f33d8dfd124169c9b6bb1684b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33719",
+					"10.65.0.27:33719",
+					"172.17.0.1:33719",
+					"172.18.0.1:33719",
+					"172.19.0.1:33719",
+					"172.20.0.1:33719",
+					"172.21.0.1:33719",
+					"172.22.0.1:33719",
+					"172.23.0.1:33719",
+					"172.24.0.1:33719",
+					"172.25.0.1:33719",
+					"172.26.0.1:33719",
+					"172.27.0.1:33719",
+					"172.28.0.1:33719"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:24:07.218494291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1542387268041600,
+				"StableID":   "njJkD6uY3D11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30c10631a9260ca93f94386fb6f4d62bcbb72858875ca4c98ff5ee5d4b93e131",
+				"DiscoKey":   "discokey:dc146092255dbfba27de767a419e3ac1c4c7b61cebfcd8d00b6484d49b6ee04d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43605",
+					"10.65.0.27:43605",
+					"172.17.0.1:43605",
+					"172.18.0.1:43605",
+					"172.19.0.1:43605",
+					"172.20.0.1:43605",
+					"172.21.0.1:43605",
+					"172.22.0.1:43605",
+					"172.23.0.1:43605",
+					"172.24.0.1:43605",
+					"172.25.0.1:43605",
+					"172.26.0.1:43605",
+					"172.27.0.1:43605",
+					"172.28.0.1:43605"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:24:07.754657886Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3050105237621357,
+				"StableID":   "nG8jFN6QpQ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0a4410d42b4a3e7fd02c5a4c62cda3b640a4888dcec5334f09710a580f5875b",
+				"DiscoKey":   "discokey:8ecf3f58b84c46a014b0ce8c4977bfc179b4fca7ba60ce99f42d4a4384f86d7a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50119",
+					"10.65.0.27:50119",
+					"172.17.0.1:50119",
+					"172.18.0.1:50119",
+					"172.19.0.1:50119",
+					"172.20.0.1:50119",
+					"172.21.0.1:50119",
+					"172.22.0.1:50119",
+					"172.23.0.1:50119",
+					"172.24.0.1:50119",
+					"172.25.0.1:50119",
+					"172.26.0.1:50119",
+					"172.27.0.1:50119",
+					"172.28.0.1:50119"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:24:08.290665789Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5908834782017552,
+				"StableID":   "nKSJq4589o11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ef1c7321d2d26fddc9c4c3791e54897c29d4b0189f08b406ce04895a58955f57",
+				"DiscoKey":   "discokey:343ba7821e2d7da59dd1d12c1387ed9a02c44c38be9c1282582a13461ec3a548",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53871",
+					"10.65.0.27:53871",
+					"172.17.0.1:53871",
+					"172.18.0.1:53871",
+					"172.19.0.1:53871",
+					"172.20.0.1:53871",
+					"172.21.0.1:53871",
+					"172.22.0.1:53871",
+					"172.23.0.1:53871",
+					"172.24.0.1:53871",
+					"172.25.0.1:53871",
+					"172.26.0.1:53871",
+					"172.27.0.1:53871",
+					"172.28.0.1:53871"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:24:08.828683247Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4968903788143197,
+				"StableID":   "nAfhYFgRof11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86959c2cd704dba34b57adb66ca9e9c0a90ae73ff2d09233311f52fc34a4c32e",
+				"DiscoKey":   "discokey:798a2ab402471e9dd56c6be429e465d2f19c45d1b668cf1ef6093c0b71655f5c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:55645",
+					"10.65.0.27:55645",
+					"172.17.0.1:55645",
+					"172.18.0.1:55645",
+					"172.19.0.1:55645",
+					"172.20.0.1:55645",
+					"172.21.0.1:55645",
+					"172.22.0.1:55645",
+					"172.23.0.1:55645",
+					"172.24.0.1:55645",
+					"172.25.0.1:55645",
+					"172.26.0.1:55645",
+					"172.27.0.1:55645",
+					"172.28.0.1:55645"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:24:09.362144056Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6557715354076671,
+				"StableID":   "n8yuzc41Dt11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3eb6f8275da0adde2bee63fb41cf92926a6924615b6077412b7d969a6b533330",
+				"DiscoKey":   "discokey:066bd933775f7ba53cecf0fe43999b3114b3342513419f8e9fd3c16e8c592a7d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:49132",
+					"10.65.0.27:49132",
+					"172.17.0.1:49132",
+					"172.18.0.1:49132",
+					"172.19.0.1:49132",
+					"172.20.0.1:49132",
+					"172.21.0.1:49132",
+					"172.22.0.1:49132",
+					"172.23.0.1:49132",
+					"172.24.0.1:49132",
+					"172.25.0.1:49132",
+					"172.26.0.1:49132",
+					"172.27.0.1:49132",
+					"172.28.0.1:49132"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:24:10.672282502Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2315680359056086,
+				"StableID":   "nVCzenzm5K11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f91ee73dc631d6b698a5a33a0786329e14ad4ad68e2277c74740893c9b49d29",
+				"DiscoKey":   "discokey:8cf6dd2e9840e337ae21faf5a65fa2875f2fb3c21e689ac082aa267f9f1ea471",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47187",
+					"10.65.0.27:47187",
+					"172.17.0.1:47187",
+					"172.18.0.1:47187",
+					"172.19.0.1:47187",
+					"172.20.0.1:47187",
+					"172.21.0.1:47187",
+					"172.22.0.1:47187",
+					"172.23.0.1:47187",
+					"172.24.0.1:47187",
+					"172.25.0.1:47187",
+					"172.26.0.1:47187",
+					"172.27.0.1:47187",
+					"172.28.0.1:47187"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:24:11.275495561Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6221106268074116,
+				"StableID":   "nbrTjvuYaq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc164e344ad1d3e907815bee1caef8d2bf1c459cf17e5f029d6db5cf5bbe654f",
+				"DiscoKey":   "discokey:6db67aaebcc475a1d9f246c3e5987ce57fe81f2c6aaa03b8509d5f6fdcd8b64c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60632",
+					"10.65.0.27:60632",
+					"172.17.0.1:60632",
+					"172.18.0.1:60632",
+					"172.19.0.1:60632",
+					"172.20.0.1:60632",
+					"172.21.0.1:60632",
+					"172.22.0.1:60632",
+					"172.23.0.1:60632",
+					"172.24.0.1:60632",
+					"172.25.0.1:60632",
+					"172.26.0.1:60632",
+					"172.27.0.1:60632",
+					"172.28.0.1:60632"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:24:11.827580036Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8110806700351409,
+				"StableID":   "nzVXx29QL621CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db3a3e21ceff1453eae1946b6242c8f2847640e647cb3e4d378c17215f4e1f6d",
+				"DiscoKey":   "discokey:ca8b5774f2d197c6b2274e73f3b53ddd6f6a63a98f4e54b8dbfc11e8504c7415",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52722",
+					"10.65.0.27:52722",
+					"172.17.0.1:52722",
+					"172.18.0.1:52722",
+					"172.19.0.1:52722",
+					"172.20.0.1:52722",
+					"172.21.0.1:52722",
+					"172.22.0.1:52722",
+					"172.23.0.1:52722",
+					"172.24.0.1:52722",
+					"172.25.0.1:52722",
+					"172.26.0.1:52722",
+					"172.27.0.1:52722",
+					"172.28.0.1:52722"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:24:12.280445949Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2113418688973880,
+				"StableID":   "nMXyUfvAWH11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3fcc86ca96b1b33f08204c73a717d366c3f0d3eb786d0a25335535f627ca933d",
+				"KeyExpiry":  "2026-11-09T09:24:12Z",
+				"DiscoKey":   "discokey:0c2f3cb6e7e4ee067d28f26839c5deaf9b98b6eaf8e01b5d525149c354e2dd63",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54053",
+					"10.65.0.27:54053",
+					"172.17.0.1:54053",
+					"172.18.0.1:54053",
+					"172.19.0.1:54053",
+					"172.20.0.1:54053",
+					"172.21.0.1:54053",
+					"172.22.0.1:54053",
+					"172.23.0.1:54053",
+					"172.24.0.1:54053",
+					"172.25.0.1:54053",
+					"172.26.0.1:54053",
+					"172.27.0.1:54053",
+					"172.28.0.1:54053"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:24:12.808963992Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4134718395602339,
+				"StableID":   "nLubwN3dHZ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:accba65175ac92d9b1d02ae3d950da7197cb08ff9dc11a0e58fc1fa11a85852b",
+				"KeyExpiry":  "2026-11-09T09:24:13Z",
+				"DiscoKey":   "discokey:62f296b87d06f1987e44ba1a93ee923344b5576c4d985b9212f35b9703125e19",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36710",
+					"10.65.0.27:36710",
+					"172.17.0.1:36710",
+					"172.18.0.1:36710",
+					"172.19.0.1:36710",
+					"172.20.0.1:36710",
+					"172.21.0.1:36710",
+					"172.22.0.1:36710",
+					"172.23.0.1:36710",
+					"172.24.0.1:36710",
+					"172.25.0.1:36710",
+					"172.26.0.1:36710",
+					"172.27.0.1:36710",
+					"172.28.0.1:36710"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:24:13.422850666Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3335087524911416,
+				"StableID":   "nqf87T6U3T11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ef9ff38f930098d723106d9a3ec4837d1c7bd45534dd70c42bc3543639c27f77",
+				"KeyExpiry":  "2026-11-09T09:24:13Z",
+				"DiscoKey":   "discokey:91bb747b6ec3f7dc64c5b9f2b783542884f0ca2db20bc4955c80a2e5dafa284e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38868",
+					"10.65.0.27:38868",
+					"172.17.0.1:38868",
+					"172.18.0.1:38868",
+					"172.19.0.1:38868",
+					"172.20.0.1:38868",
+					"172.21.0.1:38868",
+					"172.22.0.1:38868",
+					"172.23.0.1:38868",
+					"172.24.0.1:38868",
+					"172.25.0.1:38868",
+					"172.26.0.1:38868",
+					"172.27.0.1:38868",
+					"172.28.0.1:38868"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:24:13.893056144Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6018109940402123": {
+				"ID":          6018109940402123,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2113418688973880,
+				"StableID":   "nMXyUfvAWH11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3fcc86ca96b1b33f08204c73a717d366c3f0d3eb786d0a25335535f627ca933d",
+				"KeyExpiry":  "2026-11-09T09:24:12Z",
+				"DiscoKey":   "discokey:0c2f3cb6e7e4ee067d28f26839c5deaf9b98b6eaf8e01b5d525149c354e2dd63",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54053",
+					"10.65.0.27:54053",
+					"172.17.0.1:54053",
+					"172.18.0.1:54053",
+					"172.19.0.1:54053",
+					"172.20.0.1:54053",
+					"172.21.0.1:54053",
+					"172.22.0.1:54053",
+					"172.23.0.1:54053",
+					"172.24.0.1:54053",
+					"172.25.0.1:54053",
+					"172.26.0.1:54053",
+					"172.27.0.1:54053",
+					"172.28.0.1:54053"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:24:12.808963992Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3fcc86ca96b1b33f08204c73a717d366c3f0d3eb786d0a25335535f627ca933d",
+			"MachineKey": "mkey:c9a545d6cb83eca969df83edf219c6f16b4dcce24ddae6e7771ba8bf0064bb6f",
+			"Peers": [{
+				"ID":         8852797214098944,
+				"StableID":   "nsL9qKyS8C21CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:524472cc908505d8c2b933fbf66218530af01354309e2d410c3a42176ce93f17",
+				"DiscoKey":   "discokey:54f7309e4a27192ce49a9ed6edd02fbb3295a50b7182e52954cad977267ac25a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46458",
+					"10.65.0.27:46458",
+					"172.17.0.1:46458",
+					"172.18.0.1:46458",
+					"172.19.0.1:46458",
+					"172.20.0.1:46458",
+					"172.21.0.1:46458",
+					"172.22.0.1:46458",
+					"172.23.0.1:46458",
+					"172.24.0.1:46458",
+					"172.25.0.1:46458",
+					"172.26.0.1:46458",
+					"172.27.0.1:46458",
+					"172.28.0.1:46458"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:24:06.126972468Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8968980206677632,
+				"StableID":   "n1Kz2Hu43D21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:860d008513f7b02d0a70b650f48eaa40cc05d249c02a0877e97d17a253821720",
+				"DiscoKey":   "discokey:d157596b73eaf98a21b0daacea12dfea0f3c8b8f854126fefeb4968d06366820",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33002",
+					"10.65.0.27:33002",
+					"172.17.0.1:33002",
+					"172.18.0.1:33002",
+					"172.19.0.1:33002",
+					"172.20.0.1:33002",
+					"172.21.0.1:33002",
+					"172.22.0.1:33002",
+					"172.23.0.1:33002",
+					"172.24.0.1:33002",
+					"172.25.0.1:33002",
+					"172.26.0.1:33002",
+					"172.27.0.1:33002",
+					"172.28.0.1:33002"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:24:06.680153848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         603882840863826,
+				"StableID":   "nqaMkjyVi511CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e929fa420a5ac3c2c084b5c80b440e3f80d58ef45d5ac8e145bf65fdd11b5e7b",
+				"DiscoKey":   "discokey:358b2ab39e415ebdc7471c49b650e805fe0d0d6f33d8dfd124169c9b6bb1684b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33719",
+					"10.65.0.27:33719",
+					"172.17.0.1:33719",
+					"172.18.0.1:33719",
+					"172.19.0.1:33719",
+					"172.20.0.1:33719",
+					"172.21.0.1:33719",
+					"172.22.0.1:33719",
+					"172.23.0.1:33719",
+					"172.24.0.1:33719",
+					"172.25.0.1:33719",
+					"172.26.0.1:33719",
+					"172.27.0.1:33719",
+					"172.28.0.1:33719"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:24:07.218494291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1542387268041600,
+				"StableID":   "njJkD6uY3D11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30c10631a9260ca93f94386fb6f4d62bcbb72858875ca4c98ff5ee5d4b93e131",
+				"DiscoKey":   "discokey:dc146092255dbfba27de767a419e3ac1c4c7b61cebfcd8d00b6484d49b6ee04d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43605",
+					"10.65.0.27:43605",
+					"172.17.0.1:43605",
+					"172.18.0.1:43605",
+					"172.19.0.1:43605",
+					"172.20.0.1:43605",
+					"172.21.0.1:43605",
+					"172.22.0.1:43605",
+					"172.23.0.1:43605",
+					"172.24.0.1:43605",
+					"172.25.0.1:43605",
+					"172.26.0.1:43605",
+					"172.27.0.1:43605",
+					"172.28.0.1:43605"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:24:07.754657886Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3050105237621357,
+				"StableID":   "nG8jFN6QpQ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0a4410d42b4a3e7fd02c5a4c62cda3b640a4888dcec5334f09710a580f5875b",
+				"DiscoKey":   "discokey:8ecf3f58b84c46a014b0ce8c4977bfc179b4fca7ba60ce99f42d4a4384f86d7a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50119",
+					"10.65.0.27:50119",
+					"172.17.0.1:50119",
+					"172.18.0.1:50119",
+					"172.19.0.1:50119",
+					"172.20.0.1:50119",
+					"172.21.0.1:50119",
+					"172.22.0.1:50119",
+					"172.23.0.1:50119",
+					"172.24.0.1:50119",
+					"172.25.0.1:50119",
+					"172.26.0.1:50119",
+					"172.27.0.1:50119",
+					"172.28.0.1:50119"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:24:08.290665789Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5908834782017552,
+				"StableID":   "nKSJq4589o11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ef1c7321d2d26fddc9c4c3791e54897c29d4b0189f08b406ce04895a58955f57",
+				"DiscoKey":   "discokey:343ba7821e2d7da59dd1d12c1387ed9a02c44c38be9c1282582a13461ec3a548",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53871",
+					"10.65.0.27:53871",
+					"172.17.0.1:53871",
+					"172.18.0.1:53871",
+					"172.19.0.1:53871",
+					"172.20.0.1:53871",
+					"172.21.0.1:53871",
+					"172.22.0.1:53871",
+					"172.23.0.1:53871",
+					"172.24.0.1:53871",
+					"172.25.0.1:53871",
+					"172.26.0.1:53871",
+					"172.27.0.1:53871",
+					"172.28.0.1:53871"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:24:08.828683247Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4968903788143197,
+				"StableID":   "nAfhYFgRof11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86959c2cd704dba34b57adb66ca9e9c0a90ae73ff2d09233311f52fc34a4c32e",
+				"DiscoKey":   "discokey:798a2ab402471e9dd56c6be429e465d2f19c45d1b668cf1ef6093c0b71655f5c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:55645",
+					"10.65.0.27:55645",
+					"172.17.0.1:55645",
+					"172.18.0.1:55645",
+					"172.19.0.1:55645",
+					"172.20.0.1:55645",
+					"172.21.0.1:55645",
+					"172.22.0.1:55645",
+					"172.23.0.1:55645",
+					"172.24.0.1:55645",
+					"172.25.0.1:55645",
+					"172.26.0.1:55645",
+					"172.27.0.1:55645",
+					"172.28.0.1:55645"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:24:09.362144056Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6018109940402123,
+				"StableID":   "nipGPWYczo11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a183704c0861d35acfa31c9f5ed6a2199e095c0fcfac4b5d2a6951ecf768139",
+				"DiscoKey":   "discokey:64af28387bd93e699d7c0363fc13f26dc07ef91e6cce3b08fee5b175d0062247",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49274",
+					"10.65.0.27:49274",
+					"172.17.0.1:49274",
+					"172.18.0.1:49274",
+					"172.19.0.1:49274",
+					"172.20.0.1:49274",
+					"172.21.0.1:49274",
+					"172.22.0.1:49274",
+					"172.23.0.1:49274",
+					"172.24.0.1:49274",
+					"172.25.0.1:49274",
+					"172.26.0.1:49274",
+					"172.27.0.1:49274",
+					"172.28.0.1:49274"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:24:09.971537728Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6557715354076671,
+				"StableID":   "n8yuzc41Dt11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3eb6f8275da0adde2bee63fb41cf92926a6924615b6077412b7d969a6b533330",
+				"DiscoKey":   "discokey:066bd933775f7ba53cecf0fe43999b3114b3342513419f8e9fd3c16e8c592a7d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:49132",
+					"10.65.0.27:49132",
+					"172.17.0.1:49132",
+					"172.18.0.1:49132",
+					"172.19.0.1:49132",
+					"172.20.0.1:49132",
+					"172.21.0.1:49132",
+					"172.22.0.1:49132",
+					"172.23.0.1:49132",
+					"172.24.0.1:49132",
+					"172.25.0.1:49132",
+					"172.26.0.1:49132",
+					"172.27.0.1:49132",
+					"172.28.0.1:49132"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:24:10.672282502Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2315680359056086,
+				"StableID":   "nVCzenzm5K11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f91ee73dc631d6b698a5a33a0786329e14ad4ad68e2277c74740893c9b49d29",
+				"DiscoKey":   "discokey:8cf6dd2e9840e337ae21faf5a65fa2875f2fb3c21e689ac082aa267f9f1ea471",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47187",
+					"10.65.0.27:47187",
+					"172.17.0.1:47187",
+					"172.18.0.1:47187",
+					"172.19.0.1:47187",
+					"172.20.0.1:47187",
+					"172.21.0.1:47187",
+					"172.22.0.1:47187",
+					"172.23.0.1:47187",
+					"172.24.0.1:47187",
+					"172.25.0.1:47187",
+					"172.26.0.1:47187",
+					"172.27.0.1:47187",
+					"172.28.0.1:47187"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:24:11.275495561Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6221106268074116,
+				"StableID":   "nbrTjvuYaq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc164e344ad1d3e907815bee1caef8d2bf1c459cf17e5f029d6db5cf5bbe654f",
+				"DiscoKey":   "discokey:6db67aaebcc475a1d9f246c3e5987ce57fe81f2c6aaa03b8509d5f6fdcd8b64c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60632",
+					"10.65.0.27:60632",
+					"172.17.0.1:60632",
+					"172.18.0.1:60632",
+					"172.19.0.1:60632",
+					"172.20.0.1:60632",
+					"172.21.0.1:60632",
+					"172.22.0.1:60632",
+					"172.23.0.1:60632",
+					"172.24.0.1:60632",
+					"172.25.0.1:60632",
+					"172.26.0.1:60632",
+					"172.27.0.1:60632",
+					"172.28.0.1:60632"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:24:11.827580036Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8110806700351409,
+				"StableID":   "nzVXx29QL621CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db3a3e21ceff1453eae1946b6242c8f2847640e647cb3e4d378c17215f4e1f6d",
+				"DiscoKey":   "discokey:ca8b5774f2d197c6b2274e73f3b53ddd6f6a63a98f4e54b8dbfc11e8504c7415",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52722",
+					"10.65.0.27:52722",
+					"172.17.0.1:52722",
+					"172.18.0.1:52722",
+					"172.19.0.1:52722",
+					"172.20.0.1:52722",
+					"172.21.0.1:52722",
+					"172.22.0.1:52722",
+					"172.23.0.1:52722",
+					"172.24.0.1:52722",
+					"172.25.0.1:52722",
+					"172.26.0.1:52722",
+					"172.27.0.1:52722",
+					"172.28.0.1:52722"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:24:12.280445949Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4134718395602339,
+				"StableID":   "nLubwN3dHZ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:accba65175ac92d9b1d02ae3d950da7197cb08ff9dc11a0e58fc1fa11a85852b",
+				"KeyExpiry":  "2026-11-09T09:24:13Z",
+				"DiscoKey":   "discokey:62f296b87d06f1987e44ba1a93ee923344b5576c4d985b9212f35b9703125e19",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36710",
+					"10.65.0.27:36710",
+					"172.17.0.1:36710",
+					"172.18.0.1:36710",
+					"172.19.0.1:36710",
+					"172.20.0.1:36710",
+					"172.21.0.1:36710",
+					"172.22.0.1:36710",
+					"172.23.0.1:36710",
+					"172.24.0.1:36710",
+					"172.25.0.1:36710",
+					"172.26.0.1:36710",
+					"172.27.0.1:36710",
+					"172.28.0.1:36710"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:24:13.422850666Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3335087524911416,
+				"StableID":   "nqf87T6U3T11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ef9ff38f930098d723106d9a3ec4837d1c7bd45534dd70c42bc3543639c27f77",
+				"KeyExpiry":  "2026-11-09T09:24:13Z",
+				"DiscoKey":   "discokey:91bb747b6ec3f7dc64c5b9f2b783542884f0ca2db20bc4955c80a2e5dafa284e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38868",
+					"10.65.0.27:38868",
+					"172.17.0.1:38868",
+					"172.18.0.1:38868",
+					"172.19.0.1:38868",
+					"172.20.0.1:38868",
+					"172.21.0.1:38868",
+					"172.22.0.1:38868",
+					"172.23.0.1:38868",
+					"172.24.0.1:38868",
+					"172.25.0.1:38868",
+					"172.26.0.1:38868",
+					"172.27.0.1:38868",
+					"172.28.0.1:38868"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:24:13.893056144Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6221106268074116,
+				"StableID":   "nbrTjvuYaq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       6221106268074116,
+				"Key":        "nodekey:fc164e344ad1d3e907815bee1caef8d2bf1c459cf17e5f029d6db5cf5bbe654f",
+				"DiscoKey":   "discokey:6db67aaebcc475a1d9f246c3e5987ce57fe81f2c6aaa03b8509d5f6fdcd8b64c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60632",
+					"10.65.0.27:60632",
+					"172.17.0.1:60632",
+					"172.18.0.1:60632",
+					"172.19.0.1:60632",
+					"172.20.0.1:60632",
+					"172.21.0.1:60632",
+					"172.22.0.1:60632",
+					"172.23.0.1:60632",
+					"172.24.0.1:60632",
+					"172.25.0.1:60632",
+					"172.26.0.1:60632",
+					"172.27.0.1:60632",
+					"172.28.0.1:60632"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:24:11.827580036Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:fc164e344ad1d3e907815bee1caef8d2bf1c459cf17e5f029d6db5cf5bbe654f",
+			"MachineKey": "mkey:18708ac322b36537a7c36c26345e469c15f86a829829736454d946faf7384e5b",
+			"Peers": [{
+				"ID":         8852797214098944,
+				"StableID":   "nsL9qKyS8C21CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:524472cc908505d8c2b933fbf66218530af01354309e2d410c3a42176ce93f17",
+				"DiscoKey":   "discokey:54f7309e4a27192ce49a9ed6edd02fbb3295a50b7182e52954cad977267ac25a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46458",
+					"10.65.0.27:46458",
+					"172.17.0.1:46458",
+					"172.18.0.1:46458",
+					"172.19.0.1:46458",
+					"172.20.0.1:46458",
+					"172.21.0.1:46458",
+					"172.22.0.1:46458",
+					"172.23.0.1:46458",
+					"172.24.0.1:46458",
+					"172.25.0.1:46458",
+					"172.26.0.1:46458",
+					"172.27.0.1:46458",
+					"172.28.0.1:46458"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:24:06.126972468Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8968980206677632,
+				"StableID":   "n1Kz2Hu43D21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:860d008513f7b02d0a70b650f48eaa40cc05d249c02a0877e97d17a253821720",
+				"DiscoKey":   "discokey:d157596b73eaf98a21b0daacea12dfea0f3c8b8f854126fefeb4968d06366820",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33002",
+					"10.65.0.27:33002",
+					"172.17.0.1:33002",
+					"172.18.0.1:33002",
+					"172.19.0.1:33002",
+					"172.20.0.1:33002",
+					"172.21.0.1:33002",
+					"172.22.0.1:33002",
+					"172.23.0.1:33002",
+					"172.24.0.1:33002",
+					"172.25.0.1:33002",
+					"172.26.0.1:33002",
+					"172.27.0.1:33002",
+					"172.28.0.1:33002"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:24:06.680153848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         603882840863826,
+				"StableID":   "nqaMkjyVi511CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e929fa420a5ac3c2c084b5c80b440e3f80d58ef45d5ac8e145bf65fdd11b5e7b",
+				"DiscoKey":   "discokey:358b2ab39e415ebdc7471c49b650e805fe0d0d6f33d8dfd124169c9b6bb1684b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33719",
+					"10.65.0.27:33719",
+					"172.17.0.1:33719",
+					"172.18.0.1:33719",
+					"172.19.0.1:33719",
+					"172.20.0.1:33719",
+					"172.21.0.1:33719",
+					"172.22.0.1:33719",
+					"172.23.0.1:33719",
+					"172.24.0.1:33719",
+					"172.25.0.1:33719",
+					"172.26.0.1:33719",
+					"172.27.0.1:33719",
+					"172.28.0.1:33719"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:24:07.218494291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1542387268041600,
+				"StableID":   "njJkD6uY3D11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30c10631a9260ca93f94386fb6f4d62bcbb72858875ca4c98ff5ee5d4b93e131",
+				"DiscoKey":   "discokey:dc146092255dbfba27de767a419e3ac1c4c7b61cebfcd8d00b6484d49b6ee04d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43605",
+					"10.65.0.27:43605",
+					"172.17.0.1:43605",
+					"172.18.0.1:43605",
+					"172.19.0.1:43605",
+					"172.20.0.1:43605",
+					"172.21.0.1:43605",
+					"172.22.0.1:43605",
+					"172.23.0.1:43605",
+					"172.24.0.1:43605",
+					"172.25.0.1:43605",
+					"172.26.0.1:43605",
+					"172.27.0.1:43605",
+					"172.28.0.1:43605"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:24:07.754657886Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3050105237621357,
+				"StableID":   "nG8jFN6QpQ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0a4410d42b4a3e7fd02c5a4c62cda3b640a4888dcec5334f09710a580f5875b",
+				"DiscoKey":   "discokey:8ecf3f58b84c46a014b0ce8c4977bfc179b4fca7ba60ce99f42d4a4384f86d7a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50119",
+					"10.65.0.27:50119",
+					"172.17.0.1:50119",
+					"172.18.0.1:50119",
+					"172.19.0.1:50119",
+					"172.20.0.1:50119",
+					"172.21.0.1:50119",
+					"172.22.0.1:50119",
+					"172.23.0.1:50119",
+					"172.24.0.1:50119",
+					"172.25.0.1:50119",
+					"172.26.0.1:50119",
+					"172.27.0.1:50119",
+					"172.28.0.1:50119"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:24:08.290665789Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5908834782017552,
+				"StableID":   "nKSJq4589o11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ef1c7321d2d26fddc9c4c3791e54897c29d4b0189f08b406ce04895a58955f57",
+				"DiscoKey":   "discokey:343ba7821e2d7da59dd1d12c1387ed9a02c44c38be9c1282582a13461ec3a548",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53871",
+					"10.65.0.27:53871",
+					"172.17.0.1:53871",
+					"172.18.0.1:53871",
+					"172.19.0.1:53871",
+					"172.20.0.1:53871",
+					"172.21.0.1:53871",
+					"172.22.0.1:53871",
+					"172.23.0.1:53871",
+					"172.24.0.1:53871",
+					"172.25.0.1:53871",
+					"172.26.0.1:53871",
+					"172.27.0.1:53871",
+					"172.28.0.1:53871"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:24:08.828683247Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4968903788143197,
+				"StableID":   "nAfhYFgRof11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86959c2cd704dba34b57adb66ca9e9c0a90ae73ff2d09233311f52fc34a4c32e",
+				"DiscoKey":   "discokey:798a2ab402471e9dd56c6be429e465d2f19c45d1b668cf1ef6093c0b71655f5c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:55645",
+					"10.65.0.27:55645",
+					"172.17.0.1:55645",
+					"172.18.0.1:55645",
+					"172.19.0.1:55645",
+					"172.20.0.1:55645",
+					"172.21.0.1:55645",
+					"172.22.0.1:55645",
+					"172.23.0.1:55645",
+					"172.24.0.1:55645",
+					"172.25.0.1:55645",
+					"172.26.0.1:55645",
+					"172.27.0.1:55645",
+					"172.28.0.1:55645"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:24:09.362144056Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6018109940402123,
+				"StableID":   "nipGPWYczo11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a183704c0861d35acfa31c9f5ed6a2199e095c0fcfac4b5d2a6951ecf768139",
+				"DiscoKey":   "discokey:64af28387bd93e699d7c0363fc13f26dc07ef91e6cce3b08fee5b175d0062247",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49274",
+					"10.65.0.27:49274",
+					"172.17.0.1:49274",
+					"172.18.0.1:49274",
+					"172.19.0.1:49274",
+					"172.20.0.1:49274",
+					"172.21.0.1:49274",
+					"172.22.0.1:49274",
+					"172.23.0.1:49274",
+					"172.24.0.1:49274",
+					"172.25.0.1:49274",
+					"172.26.0.1:49274",
+					"172.27.0.1:49274",
+					"172.28.0.1:49274"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:24:09.971537728Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6557715354076671,
+				"StableID":   "n8yuzc41Dt11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3eb6f8275da0adde2bee63fb41cf92926a6924615b6077412b7d969a6b533330",
+				"DiscoKey":   "discokey:066bd933775f7ba53cecf0fe43999b3114b3342513419f8e9fd3c16e8c592a7d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:49132",
+					"10.65.0.27:49132",
+					"172.17.0.1:49132",
+					"172.18.0.1:49132",
+					"172.19.0.1:49132",
+					"172.20.0.1:49132",
+					"172.21.0.1:49132",
+					"172.22.0.1:49132",
+					"172.23.0.1:49132",
+					"172.24.0.1:49132",
+					"172.25.0.1:49132",
+					"172.26.0.1:49132",
+					"172.27.0.1:49132",
+					"172.28.0.1:49132"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:24:10.672282502Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2315680359056086,
+				"StableID":   "nVCzenzm5K11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f91ee73dc631d6b698a5a33a0786329e14ad4ad68e2277c74740893c9b49d29",
+				"DiscoKey":   "discokey:8cf6dd2e9840e337ae21faf5a65fa2875f2fb3c21e689ac082aa267f9f1ea471",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47187",
+					"10.65.0.27:47187",
+					"172.17.0.1:47187",
+					"172.18.0.1:47187",
+					"172.19.0.1:47187",
+					"172.20.0.1:47187",
+					"172.21.0.1:47187",
+					"172.22.0.1:47187",
+					"172.23.0.1:47187",
+					"172.24.0.1:47187",
+					"172.25.0.1:47187",
+					"172.26.0.1:47187",
+					"172.27.0.1:47187",
+					"172.28.0.1:47187"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:24:11.275495561Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8110806700351409,
+				"StableID":   "nzVXx29QL621CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db3a3e21ceff1453eae1946b6242c8f2847640e647cb3e4d378c17215f4e1f6d",
+				"DiscoKey":   "discokey:ca8b5774f2d197c6b2274e73f3b53ddd6f6a63a98f4e54b8dbfc11e8504c7415",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52722",
+					"10.65.0.27:52722",
+					"172.17.0.1:52722",
+					"172.18.0.1:52722",
+					"172.19.0.1:52722",
+					"172.20.0.1:52722",
+					"172.21.0.1:52722",
+					"172.22.0.1:52722",
+					"172.23.0.1:52722",
+					"172.24.0.1:52722",
+					"172.25.0.1:52722",
+					"172.26.0.1:52722",
+					"172.27.0.1:52722",
+					"172.28.0.1:52722"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:24:12.280445949Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2113418688973880,
+				"StableID":   "nMXyUfvAWH11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3fcc86ca96b1b33f08204c73a717d366c3f0d3eb786d0a25335535f627ca933d",
+				"KeyExpiry":  "2026-11-09T09:24:12Z",
+				"DiscoKey":   "discokey:0c2f3cb6e7e4ee067d28f26839c5deaf9b98b6eaf8e01b5d525149c354e2dd63",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54053",
+					"10.65.0.27:54053",
+					"172.17.0.1:54053",
+					"172.18.0.1:54053",
+					"172.19.0.1:54053",
+					"172.20.0.1:54053",
+					"172.21.0.1:54053",
+					"172.22.0.1:54053",
+					"172.23.0.1:54053",
+					"172.24.0.1:54053",
+					"172.25.0.1:54053",
+					"172.26.0.1:54053",
+					"172.27.0.1:54053",
+					"172.28.0.1:54053"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:24:12.808963992Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4134718395602339,
+				"StableID":   "nLubwN3dHZ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:accba65175ac92d9b1d02ae3d950da7197cb08ff9dc11a0e58fc1fa11a85852b",
+				"KeyExpiry":  "2026-11-09T09:24:13Z",
+				"DiscoKey":   "discokey:62f296b87d06f1987e44ba1a93ee923344b5576c4d985b9212f35b9703125e19",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36710",
+					"10.65.0.27:36710",
+					"172.17.0.1:36710",
+					"172.18.0.1:36710",
+					"172.19.0.1:36710",
+					"172.20.0.1:36710",
+					"172.21.0.1:36710",
+					"172.22.0.1:36710",
+					"172.23.0.1:36710",
+					"172.24.0.1:36710",
+					"172.25.0.1:36710",
+					"172.26.0.1:36710",
+					"172.27.0.1:36710",
+					"172.28.0.1:36710"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:24:13.422850666Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3335087524911416,
+				"StableID":   "nqf87T6U3T11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ef9ff38f930098d723106d9a3ec4837d1c7bd45534dd70c42bc3543639c27f77",
+				"KeyExpiry":  "2026-11-09T09:24:13Z",
+				"DiscoKey":   "discokey:91bb747b6ec3f7dc64c5b9f2b783542884f0ca2db20bc4955c80a2e5dafa284e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38868",
+					"10.65.0.27:38868",
+					"172.17.0.1:38868",
+					"172.18.0.1:38868",
+					"172.19.0.1:38868",
+					"172.20.0.1:38868",
+					"172.21.0.1:38868",
+					"172.22.0.1:38868",
+					"172.23.0.1:38868",
+					"172.24.0.1:38868",
+					"172.25.0.1:38868",
+					"172.26.0.1:38868",
+					"172.27.0.1:38868",
+					"172.28.0.1:38868"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:24:13.893056144Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6221106268074116": {
+				"ID":          6221106268074116,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8968980206677632,
+				"StableID":   "n1Kz2Hu43D21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       8968980206677632,
+				"Key":        "nodekey:860d008513f7b02d0a70b650f48eaa40cc05d249c02a0877e97d17a253821720",
+				"DiscoKey":   "discokey:d157596b73eaf98a21b0daacea12dfea0f3c8b8f854126fefeb4968d06366820",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33002",
+					"10.65.0.27:33002",
+					"172.17.0.1:33002",
+					"172.18.0.1:33002",
+					"172.19.0.1:33002",
+					"172.20.0.1:33002",
+					"172.21.0.1:33002",
+					"172.22.0.1:33002",
+					"172.23.0.1:33002",
+					"172.24.0.1:33002",
+					"172.25.0.1:33002",
+					"172.26.0.1:33002",
+					"172.27.0.1:33002",
+					"172.28.0.1:33002"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:24:06.680153848Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:860d008513f7b02d0a70b650f48eaa40cc05d249c02a0877e97d17a253821720",
+			"MachineKey": "mkey:284d98a247441e0cf1776e84da70d3e27f4ba5fc208dc3ce7ff8bdd9aa0f0a1b",
+			"Peers": [{
+				"ID":         8852797214098944,
+				"StableID":   "nsL9qKyS8C21CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:524472cc908505d8c2b933fbf66218530af01354309e2d410c3a42176ce93f17",
+				"DiscoKey":   "discokey:54f7309e4a27192ce49a9ed6edd02fbb3295a50b7182e52954cad977267ac25a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46458",
+					"10.65.0.27:46458",
+					"172.17.0.1:46458",
+					"172.18.0.1:46458",
+					"172.19.0.1:46458",
+					"172.20.0.1:46458",
+					"172.21.0.1:46458",
+					"172.22.0.1:46458",
+					"172.23.0.1:46458",
+					"172.24.0.1:46458",
+					"172.25.0.1:46458",
+					"172.26.0.1:46458",
+					"172.27.0.1:46458",
+					"172.28.0.1:46458"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:24:06.126972468Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         603882840863826,
+				"StableID":   "nqaMkjyVi511CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e929fa420a5ac3c2c084b5c80b440e3f80d58ef45d5ac8e145bf65fdd11b5e7b",
+				"DiscoKey":   "discokey:358b2ab39e415ebdc7471c49b650e805fe0d0d6f33d8dfd124169c9b6bb1684b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33719",
+					"10.65.0.27:33719",
+					"172.17.0.1:33719",
+					"172.18.0.1:33719",
+					"172.19.0.1:33719",
+					"172.20.0.1:33719",
+					"172.21.0.1:33719",
+					"172.22.0.1:33719",
+					"172.23.0.1:33719",
+					"172.24.0.1:33719",
+					"172.25.0.1:33719",
+					"172.26.0.1:33719",
+					"172.27.0.1:33719",
+					"172.28.0.1:33719"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:24:07.218494291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1542387268041600,
+				"StableID":   "njJkD6uY3D11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30c10631a9260ca93f94386fb6f4d62bcbb72858875ca4c98ff5ee5d4b93e131",
+				"DiscoKey":   "discokey:dc146092255dbfba27de767a419e3ac1c4c7b61cebfcd8d00b6484d49b6ee04d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43605",
+					"10.65.0.27:43605",
+					"172.17.0.1:43605",
+					"172.18.0.1:43605",
+					"172.19.0.1:43605",
+					"172.20.0.1:43605",
+					"172.21.0.1:43605",
+					"172.22.0.1:43605",
+					"172.23.0.1:43605",
+					"172.24.0.1:43605",
+					"172.25.0.1:43605",
+					"172.26.0.1:43605",
+					"172.27.0.1:43605",
+					"172.28.0.1:43605"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:24:07.754657886Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3050105237621357,
+				"StableID":   "nG8jFN6QpQ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0a4410d42b4a3e7fd02c5a4c62cda3b640a4888dcec5334f09710a580f5875b",
+				"DiscoKey":   "discokey:8ecf3f58b84c46a014b0ce8c4977bfc179b4fca7ba60ce99f42d4a4384f86d7a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50119",
+					"10.65.0.27:50119",
+					"172.17.0.1:50119",
+					"172.18.0.1:50119",
+					"172.19.0.1:50119",
+					"172.20.0.1:50119",
+					"172.21.0.1:50119",
+					"172.22.0.1:50119",
+					"172.23.0.1:50119",
+					"172.24.0.1:50119",
+					"172.25.0.1:50119",
+					"172.26.0.1:50119",
+					"172.27.0.1:50119",
+					"172.28.0.1:50119"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:24:08.290665789Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5908834782017552,
+				"StableID":   "nKSJq4589o11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ef1c7321d2d26fddc9c4c3791e54897c29d4b0189f08b406ce04895a58955f57",
+				"DiscoKey":   "discokey:343ba7821e2d7da59dd1d12c1387ed9a02c44c38be9c1282582a13461ec3a548",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53871",
+					"10.65.0.27:53871",
+					"172.17.0.1:53871",
+					"172.18.0.1:53871",
+					"172.19.0.1:53871",
+					"172.20.0.1:53871",
+					"172.21.0.1:53871",
+					"172.22.0.1:53871",
+					"172.23.0.1:53871",
+					"172.24.0.1:53871",
+					"172.25.0.1:53871",
+					"172.26.0.1:53871",
+					"172.27.0.1:53871",
+					"172.28.0.1:53871"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:24:08.828683247Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4968903788143197,
+				"StableID":   "nAfhYFgRof11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86959c2cd704dba34b57adb66ca9e9c0a90ae73ff2d09233311f52fc34a4c32e",
+				"DiscoKey":   "discokey:798a2ab402471e9dd56c6be429e465d2f19c45d1b668cf1ef6093c0b71655f5c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:55645",
+					"10.65.0.27:55645",
+					"172.17.0.1:55645",
+					"172.18.0.1:55645",
+					"172.19.0.1:55645",
+					"172.20.0.1:55645",
+					"172.21.0.1:55645",
+					"172.22.0.1:55645",
+					"172.23.0.1:55645",
+					"172.24.0.1:55645",
+					"172.25.0.1:55645",
+					"172.26.0.1:55645",
+					"172.27.0.1:55645",
+					"172.28.0.1:55645"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:24:09.362144056Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6018109940402123,
+				"StableID":   "nipGPWYczo11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a183704c0861d35acfa31c9f5ed6a2199e095c0fcfac4b5d2a6951ecf768139",
+				"DiscoKey":   "discokey:64af28387bd93e699d7c0363fc13f26dc07ef91e6cce3b08fee5b175d0062247",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49274",
+					"10.65.0.27:49274",
+					"172.17.0.1:49274",
+					"172.18.0.1:49274",
+					"172.19.0.1:49274",
+					"172.20.0.1:49274",
+					"172.21.0.1:49274",
+					"172.22.0.1:49274",
+					"172.23.0.1:49274",
+					"172.24.0.1:49274",
+					"172.25.0.1:49274",
+					"172.26.0.1:49274",
+					"172.27.0.1:49274",
+					"172.28.0.1:49274"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:24:09.971537728Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6557715354076671,
+				"StableID":   "n8yuzc41Dt11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3eb6f8275da0adde2bee63fb41cf92926a6924615b6077412b7d969a6b533330",
+				"DiscoKey":   "discokey:066bd933775f7ba53cecf0fe43999b3114b3342513419f8e9fd3c16e8c592a7d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:49132",
+					"10.65.0.27:49132",
+					"172.17.0.1:49132",
+					"172.18.0.1:49132",
+					"172.19.0.1:49132",
+					"172.20.0.1:49132",
+					"172.21.0.1:49132",
+					"172.22.0.1:49132",
+					"172.23.0.1:49132",
+					"172.24.0.1:49132",
+					"172.25.0.1:49132",
+					"172.26.0.1:49132",
+					"172.27.0.1:49132",
+					"172.28.0.1:49132"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:24:10.672282502Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2315680359056086,
+				"StableID":   "nVCzenzm5K11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f91ee73dc631d6b698a5a33a0786329e14ad4ad68e2277c74740893c9b49d29",
+				"DiscoKey":   "discokey:8cf6dd2e9840e337ae21faf5a65fa2875f2fb3c21e689ac082aa267f9f1ea471",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47187",
+					"10.65.0.27:47187",
+					"172.17.0.1:47187",
+					"172.18.0.1:47187",
+					"172.19.0.1:47187",
+					"172.20.0.1:47187",
+					"172.21.0.1:47187",
+					"172.22.0.1:47187",
+					"172.23.0.1:47187",
+					"172.24.0.1:47187",
+					"172.25.0.1:47187",
+					"172.26.0.1:47187",
+					"172.27.0.1:47187",
+					"172.28.0.1:47187"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:24:11.275495561Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6221106268074116,
+				"StableID":   "nbrTjvuYaq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc164e344ad1d3e907815bee1caef8d2bf1c459cf17e5f029d6db5cf5bbe654f",
+				"DiscoKey":   "discokey:6db67aaebcc475a1d9f246c3e5987ce57fe81f2c6aaa03b8509d5f6fdcd8b64c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60632",
+					"10.65.0.27:60632",
+					"172.17.0.1:60632",
+					"172.18.0.1:60632",
+					"172.19.0.1:60632",
+					"172.20.0.1:60632",
+					"172.21.0.1:60632",
+					"172.22.0.1:60632",
+					"172.23.0.1:60632",
+					"172.24.0.1:60632",
+					"172.25.0.1:60632",
+					"172.26.0.1:60632",
+					"172.27.0.1:60632",
+					"172.28.0.1:60632"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:24:11.827580036Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8110806700351409,
+				"StableID":   "nzVXx29QL621CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db3a3e21ceff1453eae1946b6242c8f2847640e647cb3e4d378c17215f4e1f6d",
+				"DiscoKey":   "discokey:ca8b5774f2d197c6b2274e73f3b53ddd6f6a63a98f4e54b8dbfc11e8504c7415",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52722",
+					"10.65.0.27:52722",
+					"172.17.0.1:52722",
+					"172.18.0.1:52722",
+					"172.19.0.1:52722",
+					"172.20.0.1:52722",
+					"172.21.0.1:52722",
+					"172.22.0.1:52722",
+					"172.23.0.1:52722",
+					"172.24.0.1:52722",
+					"172.25.0.1:52722",
+					"172.26.0.1:52722",
+					"172.27.0.1:52722",
+					"172.28.0.1:52722"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:24:12.280445949Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2113418688973880,
+				"StableID":   "nMXyUfvAWH11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3fcc86ca96b1b33f08204c73a717d366c3f0d3eb786d0a25335535f627ca933d",
+				"KeyExpiry":  "2026-11-09T09:24:12Z",
+				"DiscoKey":   "discokey:0c2f3cb6e7e4ee067d28f26839c5deaf9b98b6eaf8e01b5d525149c354e2dd63",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54053",
+					"10.65.0.27:54053",
+					"172.17.0.1:54053",
+					"172.18.0.1:54053",
+					"172.19.0.1:54053",
+					"172.20.0.1:54053",
+					"172.21.0.1:54053",
+					"172.22.0.1:54053",
+					"172.23.0.1:54053",
+					"172.24.0.1:54053",
+					"172.25.0.1:54053",
+					"172.26.0.1:54053",
+					"172.27.0.1:54053",
+					"172.28.0.1:54053"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:24:12.808963992Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4134718395602339,
+				"StableID":   "nLubwN3dHZ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:accba65175ac92d9b1d02ae3d950da7197cb08ff9dc11a0e58fc1fa11a85852b",
+				"KeyExpiry":  "2026-11-09T09:24:13Z",
+				"DiscoKey":   "discokey:62f296b87d06f1987e44ba1a93ee923344b5576c4d985b9212f35b9703125e19",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36710",
+					"10.65.0.27:36710",
+					"172.17.0.1:36710",
+					"172.18.0.1:36710",
+					"172.19.0.1:36710",
+					"172.20.0.1:36710",
+					"172.21.0.1:36710",
+					"172.22.0.1:36710",
+					"172.23.0.1:36710",
+					"172.24.0.1:36710",
+					"172.25.0.1:36710",
+					"172.26.0.1:36710",
+					"172.27.0.1:36710",
+					"172.28.0.1:36710"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:24:13.422850666Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3335087524911416,
+				"StableID":   "nqf87T6U3T11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ef9ff38f930098d723106d9a3ec4837d1c7bd45534dd70c42bc3543639c27f77",
+				"KeyExpiry":  "2026-11-09T09:24:13Z",
+				"DiscoKey":   "discokey:91bb747b6ec3f7dc64c5b9f2b783542884f0ca2db20bc4955c80a2e5dafa284e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38868",
+					"10.65.0.27:38868",
+					"172.17.0.1:38868",
+					"172.18.0.1:38868",
+					"172.19.0.1:38868",
+					"172.20.0.1:38868",
+					"172.21.0.1:38868",
+					"172.22.0.1:38868",
+					"172.23.0.1:38868",
+					"172.24.0.1:38868",
+					"172.25.0.1:38868",
+					"172.26.0.1:38868",
+					"172.27.0.1:38868",
+					"172.28.0.1:38868"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:24:13.893056144Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8968980206677632": {
+				"ID":          8968980206677632,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8852797214098944,
+				"StableID":   "nsL9qKyS8C21CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       8852797214098944,
+				"Key":        "nodekey:524472cc908505d8c2b933fbf66218530af01354309e2d410c3a42176ce93f17",
+				"DiscoKey":   "discokey:54f7309e4a27192ce49a9ed6edd02fbb3295a50b7182e52954cad977267ac25a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46458",
+					"10.65.0.27:46458",
+					"172.17.0.1:46458",
+					"172.18.0.1:46458",
+					"172.19.0.1:46458",
+					"172.20.0.1:46458",
+					"172.21.0.1:46458",
+					"172.22.0.1:46458",
+					"172.23.0.1:46458",
+					"172.24.0.1:46458",
+					"172.25.0.1:46458",
+					"172.26.0.1:46458",
+					"172.27.0.1:46458",
+					"172.28.0.1:46458"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:24:06.126972468Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:524472cc908505d8c2b933fbf66218530af01354309e2d410c3a42176ce93f17",
+			"MachineKey": "mkey:4e8133e3b19b3905cfe3ca79571bd68d38acc04f5845631cf3777bb42b5c6a1d",
+			"Peers": [{
+				"ID":         8968980206677632,
+				"StableID":   "n1Kz2Hu43D21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:860d008513f7b02d0a70b650f48eaa40cc05d249c02a0877e97d17a253821720",
+				"DiscoKey":   "discokey:d157596b73eaf98a21b0daacea12dfea0f3c8b8f854126fefeb4968d06366820",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33002",
+					"10.65.0.27:33002",
+					"172.17.0.1:33002",
+					"172.18.0.1:33002",
+					"172.19.0.1:33002",
+					"172.20.0.1:33002",
+					"172.21.0.1:33002",
+					"172.22.0.1:33002",
+					"172.23.0.1:33002",
+					"172.24.0.1:33002",
+					"172.25.0.1:33002",
+					"172.26.0.1:33002",
+					"172.27.0.1:33002",
+					"172.28.0.1:33002"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:24:06.680153848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         603882840863826,
+				"StableID":   "nqaMkjyVi511CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e929fa420a5ac3c2c084b5c80b440e3f80d58ef45d5ac8e145bf65fdd11b5e7b",
+				"DiscoKey":   "discokey:358b2ab39e415ebdc7471c49b650e805fe0d0d6f33d8dfd124169c9b6bb1684b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33719",
+					"10.65.0.27:33719",
+					"172.17.0.1:33719",
+					"172.18.0.1:33719",
+					"172.19.0.1:33719",
+					"172.20.0.1:33719",
+					"172.21.0.1:33719",
+					"172.22.0.1:33719",
+					"172.23.0.1:33719",
+					"172.24.0.1:33719",
+					"172.25.0.1:33719",
+					"172.26.0.1:33719",
+					"172.27.0.1:33719",
+					"172.28.0.1:33719"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:24:07.218494291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1542387268041600,
+				"StableID":   "njJkD6uY3D11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30c10631a9260ca93f94386fb6f4d62bcbb72858875ca4c98ff5ee5d4b93e131",
+				"DiscoKey":   "discokey:dc146092255dbfba27de767a419e3ac1c4c7b61cebfcd8d00b6484d49b6ee04d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43605",
+					"10.65.0.27:43605",
+					"172.17.0.1:43605",
+					"172.18.0.1:43605",
+					"172.19.0.1:43605",
+					"172.20.0.1:43605",
+					"172.21.0.1:43605",
+					"172.22.0.1:43605",
+					"172.23.0.1:43605",
+					"172.24.0.1:43605",
+					"172.25.0.1:43605",
+					"172.26.0.1:43605",
+					"172.27.0.1:43605",
+					"172.28.0.1:43605"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:24:07.754657886Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3050105237621357,
+				"StableID":   "nG8jFN6QpQ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0a4410d42b4a3e7fd02c5a4c62cda3b640a4888dcec5334f09710a580f5875b",
+				"DiscoKey":   "discokey:8ecf3f58b84c46a014b0ce8c4977bfc179b4fca7ba60ce99f42d4a4384f86d7a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50119",
+					"10.65.0.27:50119",
+					"172.17.0.1:50119",
+					"172.18.0.1:50119",
+					"172.19.0.1:50119",
+					"172.20.0.1:50119",
+					"172.21.0.1:50119",
+					"172.22.0.1:50119",
+					"172.23.0.1:50119",
+					"172.24.0.1:50119",
+					"172.25.0.1:50119",
+					"172.26.0.1:50119",
+					"172.27.0.1:50119",
+					"172.28.0.1:50119"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:24:08.290665789Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5908834782017552,
+				"StableID":   "nKSJq4589o11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ef1c7321d2d26fddc9c4c3791e54897c29d4b0189f08b406ce04895a58955f57",
+				"DiscoKey":   "discokey:343ba7821e2d7da59dd1d12c1387ed9a02c44c38be9c1282582a13461ec3a548",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53871",
+					"10.65.0.27:53871",
+					"172.17.0.1:53871",
+					"172.18.0.1:53871",
+					"172.19.0.1:53871",
+					"172.20.0.1:53871",
+					"172.21.0.1:53871",
+					"172.22.0.1:53871",
+					"172.23.0.1:53871",
+					"172.24.0.1:53871",
+					"172.25.0.1:53871",
+					"172.26.0.1:53871",
+					"172.27.0.1:53871",
+					"172.28.0.1:53871"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:24:08.828683247Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4968903788143197,
+				"StableID":   "nAfhYFgRof11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86959c2cd704dba34b57adb66ca9e9c0a90ae73ff2d09233311f52fc34a4c32e",
+				"DiscoKey":   "discokey:798a2ab402471e9dd56c6be429e465d2f19c45d1b668cf1ef6093c0b71655f5c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:55645",
+					"10.65.0.27:55645",
+					"172.17.0.1:55645",
+					"172.18.0.1:55645",
+					"172.19.0.1:55645",
+					"172.20.0.1:55645",
+					"172.21.0.1:55645",
+					"172.22.0.1:55645",
+					"172.23.0.1:55645",
+					"172.24.0.1:55645",
+					"172.25.0.1:55645",
+					"172.26.0.1:55645",
+					"172.27.0.1:55645",
+					"172.28.0.1:55645"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:24:09.362144056Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6018109940402123,
+				"StableID":   "nipGPWYczo11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a183704c0861d35acfa31c9f5ed6a2199e095c0fcfac4b5d2a6951ecf768139",
+				"DiscoKey":   "discokey:64af28387bd93e699d7c0363fc13f26dc07ef91e6cce3b08fee5b175d0062247",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49274",
+					"10.65.0.27:49274",
+					"172.17.0.1:49274",
+					"172.18.0.1:49274",
+					"172.19.0.1:49274",
+					"172.20.0.1:49274",
+					"172.21.0.1:49274",
+					"172.22.0.1:49274",
+					"172.23.0.1:49274",
+					"172.24.0.1:49274",
+					"172.25.0.1:49274",
+					"172.26.0.1:49274",
+					"172.27.0.1:49274",
+					"172.28.0.1:49274"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:24:09.971537728Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6557715354076671,
+				"StableID":   "n8yuzc41Dt11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3eb6f8275da0adde2bee63fb41cf92926a6924615b6077412b7d969a6b533330",
+				"DiscoKey":   "discokey:066bd933775f7ba53cecf0fe43999b3114b3342513419f8e9fd3c16e8c592a7d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:49132",
+					"10.65.0.27:49132",
+					"172.17.0.1:49132",
+					"172.18.0.1:49132",
+					"172.19.0.1:49132",
+					"172.20.0.1:49132",
+					"172.21.0.1:49132",
+					"172.22.0.1:49132",
+					"172.23.0.1:49132",
+					"172.24.0.1:49132",
+					"172.25.0.1:49132",
+					"172.26.0.1:49132",
+					"172.27.0.1:49132",
+					"172.28.0.1:49132"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:24:10.672282502Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2315680359056086,
+				"StableID":   "nVCzenzm5K11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f91ee73dc631d6b698a5a33a0786329e14ad4ad68e2277c74740893c9b49d29",
+				"DiscoKey":   "discokey:8cf6dd2e9840e337ae21faf5a65fa2875f2fb3c21e689ac082aa267f9f1ea471",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47187",
+					"10.65.0.27:47187",
+					"172.17.0.1:47187",
+					"172.18.0.1:47187",
+					"172.19.0.1:47187",
+					"172.20.0.1:47187",
+					"172.21.0.1:47187",
+					"172.22.0.1:47187",
+					"172.23.0.1:47187",
+					"172.24.0.1:47187",
+					"172.25.0.1:47187",
+					"172.26.0.1:47187",
+					"172.27.0.1:47187",
+					"172.28.0.1:47187"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:24:11.275495561Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6221106268074116,
+				"StableID":   "nbrTjvuYaq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc164e344ad1d3e907815bee1caef8d2bf1c459cf17e5f029d6db5cf5bbe654f",
+				"DiscoKey":   "discokey:6db67aaebcc475a1d9f246c3e5987ce57fe81f2c6aaa03b8509d5f6fdcd8b64c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60632",
+					"10.65.0.27:60632",
+					"172.17.0.1:60632",
+					"172.18.0.1:60632",
+					"172.19.0.1:60632",
+					"172.20.0.1:60632",
+					"172.21.0.1:60632",
+					"172.22.0.1:60632",
+					"172.23.0.1:60632",
+					"172.24.0.1:60632",
+					"172.25.0.1:60632",
+					"172.26.0.1:60632",
+					"172.27.0.1:60632",
+					"172.28.0.1:60632"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:24:11.827580036Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8110806700351409,
+				"StableID":   "nzVXx29QL621CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db3a3e21ceff1453eae1946b6242c8f2847640e647cb3e4d378c17215f4e1f6d",
+				"DiscoKey":   "discokey:ca8b5774f2d197c6b2274e73f3b53ddd6f6a63a98f4e54b8dbfc11e8504c7415",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52722",
+					"10.65.0.27:52722",
+					"172.17.0.1:52722",
+					"172.18.0.1:52722",
+					"172.19.0.1:52722",
+					"172.20.0.1:52722",
+					"172.21.0.1:52722",
+					"172.22.0.1:52722",
+					"172.23.0.1:52722",
+					"172.24.0.1:52722",
+					"172.25.0.1:52722",
+					"172.26.0.1:52722",
+					"172.27.0.1:52722",
+					"172.28.0.1:52722"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:24:12.280445949Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2113418688973880,
+				"StableID":   "nMXyUfvAWH11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3fcc86ca96b1b33f08204c73a717d366c3f0d3eb786d0a25335535f627ca933d",
+				"KeyExpiry":  "2026-11-09T09:24:12Z",
+				"DiscoKey":   "discokey:0c2f3cb6e7e4ee067d28f26839c5deaf9b98b6eaf8e01b5d525149c354e2dd63",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54053",
+					"10.65.0.27:54053",
+					"172.17.0.1:54053",
+					"172.18.0.1:54053",
+					"172.19.0.1:54053",
+					"172.20.0.1:54053",
+					"172.21.0.1:54053",
+					"172.22.0.1:54053",
+					"172.23.0.1:54053",
+					"172.24.0.1:54053",
+					"172.25.0.1:54053",
+					"172.26.0.1:54053",
+					"172.27.0.1:54053",
+					"172.28.0.1:54053"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:24:12.808963992Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4134718395602339,
+				"StableID":   "nLubwN3dHZ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:accba65175ac92d9b1d02ae3d950da7197cb08ff9dc11a0e58fc1fa11a85852b",
+				"KeyExpiry":  "2026-11-09T09:24:13Z",
+				"DiscoKey":   "discokey:62f296b87d06f1987e44ba1a93ee923344b5576c4d985b9212f35b9703125e19",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36710",
+					"10.65.0.27:36710",
+					"172.17.0.1:36710",
+					"172.18.0.1:36710",
+					"172.19.0.1:36710",
+					"172.20.0.1:36710",
+					"172.21.0.1:36710",
+					"172.22.0.1:36710",
+					"172.23.0.1:36710",
+					"172.24.0.1:36710",
+					"172.25.0.1:36710",
+					"172.26.0.1:36710",
+					"172.27.0.1:36710",
+					"172.28.0.1:36710"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:24:13.422850666Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3335087524911416,
+				"StableID":   "nqf87T6U3T11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ef9ff38f930098d723106d9a3ec4837d1c7bd45534dd70c42bc3543639c27f77",
+				"KeyExpiry":  "2026-11-09T09:24:13Z",
+				"DiscoKey":   "discokey:91bb747b6ec3f7dc64c5b9f2b783542884f0ca2db20bc4955c80a2e5dafa284e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38868",
+					"10.65.0.27:38868",
+					"172.17.0.1:38868",
+					"172.18.0.1:38868",
+					"172.19.0.1:38868",
+					"172.20.0.1:38868",
+					"172.21.0.1:38868",
+					"172.22.0.1:38868",
+					"172.23.0.1:38868",
+					"172.24.0.1:38868",
+					"172.25.0.1:38868",
+					"172.26.0.1:38868",
+					"172.27.0.1:38868",
+					"172.28.0.1:38868"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:24:13.893056144Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8852797214098944": {
+				"ID":          8852797214098944,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3050105237621357,
+				"StableID":   "nG8jFN6QpQ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       3050105237621357,
+				"Key":        "nodekey:b0a4410d42b4a3e7fd02c5a4c62cda3b640a4888dcec5334f09710a580f5875b",
+				"DiscoKey":   "discokey:8ecf3f58b84c46a014b0ce8c4977bfc179b4fca7ba60ce99f42d4a4384f86d7a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50119",
+					"10.65.0.27:50119",
+					"172.17.0.1:50119",
+					"172.18.0.1:50119",
+					"172.19.0.1:50119",
+					"172.20.0.1:50119",
+					"172.21.0.1:50119",
+					"172.22.0.1:50119",
+					"172.23.0.1:50119",
+					"172.24.0.1:50119",
+					"172.25.0.1:50119",
+					"172.26.0.1:50119",
+					"172.27.0.1:50119",
+					"172.28.0.1:50119"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:24:08.290665789Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b0a4410d42b4a3e7fd02c5a4c62cda3b640a4888dcec5334f09710a580f5875b",
+			"MachineKey": "mkey:94f5953cd10c3220f6d38f1ae366343c46fbee1751c06ecf2bed94c0509a8844",
+			"Peers": [{
+				"ID":         8852797214098944,
+				"StableID":   "nsL9qKyS8C21CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:524472cc908505d8c2b933fbf66218530af01354309e2d410c3a42176ce93f17",
+				"DiscoKey":   "discokey:54f7309e4a27192ce49a9ed6edd02fbb3295a50b7182e52954cad977267ac25a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46458",
+					"10.65.0.27:46458",
+					"172.17.0.1:46458",
+					"172.18.0.1:46458",
+					"172.19.0.1:46458",
+					"172.20.0.1:46458",
+					"172.21.0.1:46458",
+					"172.22.0.1:46458",
+					"172.23.0.1:46458",
+					"172.24.0.1:46458",
+					"172.25.0.1:46458",
+					"172.26.0.1:46458",
+					"172.27.0.1:46458",
+					"172.28.0.1:46458"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:24:06.126972468Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8968980206677632,
+				"StableID":   "n1Kz2Hu43D21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:860d008513f7b02d0a70b650f48eaa40cc05d249c02a0877e97d17a253821720",
+				"DiscoKey":   "discokey:d157596b73eaf98a21b0daacea12dfea0f3c8b8f854126fefeb4968d06366820",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33002",
+					"10.65.0.27:33002",
+					"172.17.0.1:33002",
+					"172.18.0.1:33002",
+					"172.19.0.1:33002",
+					"172.20.0.1:33002",
+					"172.21.0.1:33002",
+					"172.22.0.1:33002",
+					"172.23.0.1:33002",
+					"172.24.0.1:33002",
+					"172.25.0.1:33002",
+					"172.26.0.1:33002",
+					"172.27.0.1:33002",
+					"172.28.0.1:33002"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:24:06.680153848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         603882840863826,
+				"StableID":   "nqaMkjyVi511CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e929fa420a5ac3c2c084b5c80b440e3f80d58ef45d5ac8e145bf65fdd11b5e7b",
+				"DiscoKey":   "discokey:358b2ab39e415ebdc7471c49b650e805fe0d0d6f33d8dfd124169c9b6bb1684b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33719",
+					"10.65.0.27:33719",
+					"172.17.0.1:33719",
+					"172.18.0.1:33719",
+					"172.19.0.1:33719",
+					"172.20.0.1:33719",
+					"172.21.0.1:33719",
+					"172.22.0.1:33719",
+					"172.23.0.1:33719",
+					"172.24.0.1:33719",
+					"172.25.0.1:33719",
+					"172.26.0.1:33719",
+					"172.27.0.1:33719",
+					"172.28.0.1:33719"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:24:07.218494291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1542387268041600,
+				"StableID":   "njJkD6uY3D11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30c10631a9260ca93f94386fb6f4d62bcbb72858875ca4c98ff5ee5d4b93e131",
+				"DiscoKey":   "discokey:dc146092255dbfba27de767a419e3ac1c4c7b61cebfcd8d00b6484d49b6ee04d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43605",
+					"10.65.0.27:43605",
+					"172.17.0.1:43605",
+					"172.18.0.1:43605",
+					"172.19.0.1:43605",
+					"172.20.0.1:43605",
+					"172.21.0.1:43605",
+					"172.22.0.1:43605",
+					"172.23.0.1:43605",
+					"172.24.0.1:43605",
+					"172.25.0.1:43605",
+					"172.26.0.1:43605",
+					"172.27.0.1:43605",
+					"172.28.0.1:43605"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:24:07.754657886Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5908834782017552,
+				"StableID":   "nKSJq4589o11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ef1c7321d2d26fddc9c4c3791e54897c29d4b0189f08b406ce04895a58955f57",
+				"DiscoKey":   "discokey:343ba7821e2d7da59dd1d12c1387ed9a02c44c38be9c1282582a13461ec3a548",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53871",
+					"10.65.0.27:53871",
+					"172.17.0.1:53871",
+					"172.18.0.1:53871",
+					"172.19.0.1:53871",
+					"172.20.0.1:53871",
+					"172.21.0.1:53871",
+					"172.22.0.1:53871",
+					"172.23.0.1:53871",
+					"172.24.0.1:53871",
+					"172.25.0.1:53871",
+					"172.26.0.1:53871",
+					"172.27.0.1:53871",
+					"172.28.0.1:53871"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:24:08.828683247Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4968903788143197,
+				"StableID":   "nAfhYFgRof11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86959c2cd704dba34b57adb66ca9e9c0a90ae73ff2d09233311f52fc34a4c32e",
+				"DiscoKey":   "discokey:798a2ab402471e9dd56c6be429e465d2f19c45d1b668cf1ef6093c0b71655f5c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:55645",
+					"10.65.0.27:55645",
+					"172.17.0.1:55645",
+					"172.18.0.1:55645",
+					"172.19.0.1:55645",
+					"172.20.0.1:55645",
+					"172.21.0.1:55645",
+					"172.22.0.1:55645",
+					"172.23.0.1:55645",
+					"172.24.0.1:55645",
+					"172.25.0.1:55645",
+					"172.26.0.1:55645",
+					"172.27.0.1:55645",
+					"172.28.0.1:55645"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:24:09.362144056Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6018109940402123,
+				"StableID":   "nipGPWYczo11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a183704c0861d35acfa31c9f5ed6a2199e095c0fcfac4b5d2a6951ecf768139",
+				"DiscoKey":   "discokey:64af28387bd93e699d7c0363fc13f26dc07ef91e6cce3b08fee5b175d0062247",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49274",
+					"10.65.0.27:49274",
+					"172.17.0.1:49274",
+					"172.18.0.1:49274",
+					"172.19.0.1:49274",
+					"172.20.0.1:49274",
+					"172.21.0.1:49274",
+					"172.22.0.1:49274",
+					"172.23.0.1:49274",
+					"172.24.0.1:49274",
+					"172.25.0.1:49274",
+					"172.26.0.1:49274",
+					"172.27.0.1:49274",
+					"172.28.0.1:49274"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:24:09.971537728Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6557715354076671,
+				"StableID":   "n8yuzc41Dt11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3eb6f8275da0adde2bee63fb41cf92926a6924615b6077412b7d969a6b533330",
+				"DiscoKey":   "discokey:066bd933775f7ba53cecf0fe43999b3114b3342513419f8e9fd3c16e8c592a7d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:49132",
+					"10.65.0.27:49132",
+					"172.17.0.1:49132",
+					"172.18.0.1:49132",
+					"172.19.0.1:49132",
+					"172.20.0.1:49132",
+					"172.21.0.1:49132",
+					"172.22.0.1:49132",
+					"172.23.0.1:49132",
+					"172.24.0.1:49132",
+					"172.25.0.1:49132",
+					"172.26.0.1:49132",
+					"172.27.0.1:49132",
+					"172.28.0.1:49132"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:24:10.672282502Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2315680359056086,
+				"StableID":   "nVCzenzm5K11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f91ee73dc631d6b698a5a33a0786329e14ad4ad68e2277c74740893c9b49d29",
+				"DiscoKey":   "discokey:8cf6dd2e9840e337ae21faf5a65fa2875f2fb3c21e689ac082aa267f9f1ea471",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47187",
+					"10.65.0.27:47187",
+					"172.17.0.1:47187",
+					"172.18.0.1:47187",
+					"172.19.0.1:47187",
+					"172.20.0.1:47187",
+					"172.21.0.1:47187",
+					"172.22.0.1:47187",
+					"172.23.0.1:47187",
+					"172.24.0.1:47187",
+					"172.25.0.1:47187",
+					"172.26.0.1:47187",
+					"172.27.0.1:47187",
+					"172.28.0.1:47187"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:24:11.275495561Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6221106268074116,
+				"StableID":   "nbrTjvuYaq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc164e344ad1d3e907815bee1caef8d2bf1c459cf17e5f029d6db5cf5bbe654f",
+				"DiscoKey":   "discokey:6db67aaebcc475a1d9f246c3e5987ce57fe81f2c6aaa03b8509d5f6fdcd8b64c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60632",
+					"10.65.0.27:60632",
+					"172.17.0.1:60632",
+					"172.18.0.1:60632",
+					"172.19.0.1:60632",
+					"172.20.0.1:60632",
+					"172.21.0.1:60632",
+					"172.22.0.1:60632",
+					"172.23.0.1:60632",
+					"172.24.0.1:60632",
+					"172.25.0.1:60632",
+					"172.26.0.1:60632",
+					"172.27.0.1:60632",
+					"172.28.0.1:60632"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:24:11.827580036Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8110806700351409,
+				"StableID":   "nzVXx29QL621CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db3a3e21ceff1453eae1946b6242c8f2847640e647cb3e4d378c17215f4e1f6d",
+				"DiscoKey":   "discokey:ca8b5774f2d197c6b2274e73f3b53ddd6f6a63a98f4e54b8dbfc11e8504c7415",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52722",
+					"10.65.0.27:52722",
+					"172.17.0.1:52722",
+					"172.18.0.1:52722",
+					"172.19.0.1:52722",
+					"172.20.0.1:52722",
+					"172.21.0.1:52722",
+					"172.22.0.1:52722",
+					"172.23.0.1:52722",
+					"172.24.0.1:52722",
+					"172.25.0.1:52722",
+					"172.26.0.1:52722",
+					"172.27.0.1:52722",
+					"172.28.0.1:52722"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:24:12.280445949Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2113418688973880,
+				"StableID":   "nMXyUfvAWH11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3fcc86ca96b1b33f08204c73a717d366c3f0d3eb786d0a25335535f627ca933d",
+				"KeyExpiry":  "2026-11-09T09:24:12Z",
+				"DiscoKey":   "discokey:0c2f3cb6e7e4ee067d28f26839c5deaf9b98b6eaf8e01b5d525149c354e2dd63",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54053",
+					"10.65.0.27:54053",
+					"172.17.0.1:54053",
+					"172.18.0.1:54053",
+					"172.19.0.1:54053",
+					"172.20.0.1:54053",
+					"172.21.0.1:54053",
+					"172.22.0.1:54053",
+					"172.23.0.1:54053",
+					"172.24.0.1:54053",
+					"172.25.0.1:54053",
+					"172.26.0.1:54053",
+					"172.27.0.1:54053",
+					"172.28.0.1:54053"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:24:12.808963992Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4134718395602339,
+				"StableID":   "nLubwN3dHZ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:accba65175ac92d9b1d02ae3d950da7197cb08ff9dc11a0e58fc1fa11a85852b",
+				"KeyExpiry":  "2026-11-09T09:24:13Z",
+				"DiscoKey":   "discokey:62f296b87d06f1987e44ba1a93ee923344b5576c4d985b9212f35b9703125e19",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36710",
+					"10.65.0.27:36710",
+					"172.17.0.1:36710",
+					"172.18.0.1:36710",
+					"172.19.0.1:36710",
+					"172.20.0.1:36710",
+					"172.21.0.1:36710",
+					"172.22.0.1:36710",
+					"172.23.0.1:36710",
+					"172.24.0.1:36710",
+					"172.25.0.1:36710",
+					"172.26.0.1:36710",
+					"172.27.0.1:36710",
+					"172.28.0.1:36710"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:24:13.422850666Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3335087524911416,
+				"StableID":   "nqf87T6U3T11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ef9ff38f930098d723106d9a3ec4837d1c7bd45534dd70c42bc3543639c27f77",
+				"KeyExpiry":  "2026-11-09T09:24:13Z",
+				"DiscoKey":   "discokey:91bb747b6ec3f7dc64c5b9f2b783542884f0ca2db20bc4955c80a2e5dafa284e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38868",
+					"10.65.0.27:38868",
+					"172.17.0.1:38868",
+					"172.18.0.1:38868",
+					"172.19.0.1:38868",
+					"172.20.0.1:38868",
+					"172.21.0.1:38868",
+					"172.22.0.1:38868",
+					"172.23.0.1:38868",
+					"172.24.0.1:38868",
+					"172.25.0.1:38868",
+					"172.26.0.1:38868",
+					"172.27.0.1:38868",
+					"172.28.0.1:38868"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:24:13.893056144Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3050105237621357": {
+				"ID":          3050105237621357,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1542387268041600,
+				"StableID":   "njJkD6uY3D11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1542387268041600,
+				"Key":        "nodekey:30c10631a9260ca93f94386fb6f4d62bcbb72858875ca4c98ff5ee5d4b93e131",
+				"DiscoKey":   "discokey:dc146092255dbfba27de767a419e3ac1c4c7b61cebfcd8d00b6484d49b6ee04d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43605",
+					"10.65.0.27:43605",
+					"172.17.0.1:43605",
+					"172.18.0.1:43605",
+					"172.19.0.1:43605",
+					"172.20.0.1:43605",
+					"172.21.0.1:43605",
+					"172.22.0.1:43605",
+					"172.23.0.1:43605",
+					"172.24.0.1:43605",
+					"172.25.0.1:43605",
+					"172.26.0.1:43605",
+					"172.27.0.1:43605",
+					"172.28.0.1:43605"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:24:07.754657886Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:30c10631a9260ca93f94386fb6f4d62bcbb72858875ca4c98ff5ee5d4b93e131",
+			"MachineKey": "mkey:624bcb46a500afd639f9ba6ce06417558f6e26f390ebeee32228aafafa764b35",
+			"Peers": [{
+				"ID":         8852797214098944,
+				"StableID":   "nsL9qKyS8C21CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:524472cc908505d8c2b933fbf66218530af01354309e2d410c3a42176ce93f17",
+				"DiscoKey":   "discokey:54f7309e4a27192ce49a9ed6edd02fbb3295a50b7182e52954cad977267ac25a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46458",
+					"10.65.0.27:46458",
+					"172.17.0.1:46458",
+					"172.18.0.1:46458",
+					"172.19.0.1:46458",
+					"172.20.0.1:46458",
+					"172.21.0.1:46458",
+					"172.22.0.1:46458",
+					"172.23.0.1:46458",
+					"172.24.0.1:46458",
+					"172.25.0.1:46458",
+					"172.26.0.1:46458",
+					"172.27.0.1:46458",
+					"172.28.0.1:46458"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:24:06.126972468Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8968980206677632,
+				"StableID":   "n1Kz2Hu43D21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:860d008513f7b02d0a70b650f48eaa40cc05d249c02a0877e97d17a253821720",
+				"DiscoKey":   "discokey:d157596b73eaf98a21b0daacea12dfea0f3c8b8f854126fefeb4968d06366820",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33002",
+					"10.65.0.27:33002",
+					"172.17.0.1:33002",
+					"172.18.0.1:33002",
+					"172.19.0.1:33002",
+					"172.20.0.1:33002",
+					"172.21.0.1:33002",
+					"172.22.0.1:33002",
+					"172.23.0.1:33002",
+					"172.24.0.1:33002",
+					"172.25.0.1:33002",
+					"172.26.0.1:33002",
+					"172.27.0.1:33002",
+					"172.28.0.1:33002"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:24:06.680153848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         603882840863826,
+				"StableID":   "nqaMkjyVi511CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e929fa420a5ac3c2c084b5c80b440e3f80d58ef45d5ac8e145bf65fdd11b5e7b",
+				"DiscoKey":   "discokey:358b2ab39e415ebdc7471c49b650e805fe0d0d6f33d8dfd124169c9b6bb1684b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33719",
+					"10.65.0.27:33719",
+					"172.17.0.1:33719",
+					"172.18.0.1:33719",
+					"172.19.0.1:33719",
+					"172.20.0.1:33719",
+					"172.21.0.1:33719",
+					"172.22.0.1:33719",
+					"172.23.0.1:33719",
+					"172.24.0.1:33719",
+					"172.25.0.1:33719",
+					"172.26.0.1:33719",
+					"172.27.0.1:33719",
+					"172.28.0.1:33719"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:24:07.218494291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3050105237621357,
+				"StableID":   "nG8jFN6QpQ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0a4410d42b4a3e7fd02c5a4c62cda3b640a4888dcec5334f09710a580f5875b",
+				"DiscoKey":   "discokey:8ecf3f58b84c46a014b0ce8c4977bfc179b4fca7ba60ce99f42d4a4384f86d7a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50119",
+					"10.65.0.27:50119",
+					"172.17.0.1:50119",
+					"172.18.0.1:50119",
+					"172.19.0.1:50119",
+					"172.20.0.1:50119",
+					"172.21.0.1:50119",
+					"172.22.0.1:50119",
+					"172.23.0.1:50119",
+					"172.24.0.1:50119",
+					"172.25.0.1:50119",
+					"172.26.0.1:50119",
+					"172.27.0.1:50119",
+					"172.28.0.1:50119"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:24:08.290665789Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5908834782017552,
+				"StableID":   "nKSJq4589o11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ef1c7321d2d26fddc9c4c3791e54897c29d4b0189f08b406ce04895a58955f57",
+				"DiscoKey":   "discokey:343ba7821e2d7da59dd1d12c1387ed9a02c44c38be9c1282582a13461ec3a548",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53871",
+					"10.65.0.27:53871",
+					"172.17.0.1:53871",
+					"172.18.0.1:53871",
+					"172.19.0.1:53871",
+					"172.20.0.1:53871",
+					"172.21.0.1:53871",
+					"172.22.0.1:53871",
+					"172.23.0.1:53871",
+					"172.24.0.1:53871",
+					"172.25.0.1:53871",
+					"172.26.0.1:53871",
+					"172.27.0.1:53871",
+					"172.28.0.1:53871"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:24:08.828683247Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4968903788143197,
+				"StableID":   "nAfhYFgRof11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86959c2cd704dba34b57adb66ca9e9c0a90ae73ff2d09233311f52fc34a4c32e",
+				"DiscoKey":   "discokey:798a2ab402471e9dd56c6be429e465d2f19c45d1b668cf1ef6093c0b71655f5c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:55645",
+					"10.65.0.27:55645",
+					"172.17.0.1:55645",
+					"172.18.0.1:55645",
+					"172.19.0.1:55645",
+					"172.20.0.1:55645",
+					"172.21.0.1:55645",
+					"172.22.0.1:55645",
+					"172.23.0.1:55645",
+					"172.24.0.1:55645",
+					"172.25.0.1:55645",
+					"172.26.0.1:55645",
+					"172.27.0.1:55645",
+					"172.28.0.1:55645"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:24:09.362144056Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6018109940402123,
+				"StableID":   "nipGPWYczo11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a183704c0861d35acfa31c9f5ed6a2199e095c0fcfac4b5d2a6951ecf768139",
+				"DiscoKey":   "discokey:64af28387bd93e699d7c0363fc13f26dc07ef91e6cce3b08fee5b175d0062247",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49274",
+					"10.65.0.27:49274",
+					"172.17.0.1:49274",
+					"172.18.0.1:49274",
+					"172.19.0.1:49274",
+					"172.20.0.1:49274",
+					"172.21.0.1:49274",
+					"172.22.0.1:49274",
+					"172.23.0.1:49274",
+					"172.24.0.1:49274",
+					"172.25.0.1:49274",
+					"172.26.0.1:49274",
+					"172.27.0.1:49274",
+					"172.28.0.1:49274"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:24:09.971537728Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6557715354076671,
+				"StableID":   "n8yuzc41Dt11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3eb6f8275da0adde2bee63fb41cf92926a6924615b6077412b7d969a6b533330",
+				"DiscoKey":   "discokey:066bd933775f7ba53cecf0fe43999b3114b3342513419f8e9fd3c16e8c592a7d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:49132",
+					"10.65.0.27:49132",
+					"172.17.0.1:49132",
+					"172.18.0.1:49132",
+					"172.19.0.1:49132",
+					"172.20.0.1:49132",
+					"172.21.0.1:49132",
+					"172.22.0.1:49132",
+					"172.23.0.1:49132",
+					"172.24.0.1:49132",
+					"172.25.0.1:49132",
+					"172.26.0.1:49132",
+					"172.27.0.1:49132",
+					"172.28.0.1:49132"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:24:10.672282502Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2315680359056086,
+				"StableID":   "nVCzenzm5K11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f91ee73dc631d6b698a5a33a0786329e14ad4ad68e2277c74740893c9b49d29",
+				"DiscoKey":   "discokey:8cf6dd2e9840e337ae21faf5a65fa2875f2fb3c21e689ac082aa267f9f1ea471",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47187",
+					"10.65.0.27:47187",
+					"172.17.0.1:47187",
+					"172.18.0.1:47187",
+					"172.19.0.1:47187",
+					"172.20.0.1:47187",
+					"172.21.0.1:47187",
+					"172.22.0.1:47187",
+					"172.23.0.1:47187",
+					"172.24.0.1:47187",
+					"172.25.0.1:47187",
+					"172.26.0.1:47187",
+					"172.27.0.1:47187",
+					"172.28.0.1:47187"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:24:11.275495561Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6221106268074116,
+				"StableID":   "nbrTjvuYaq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc164e344ad1d3e907815bee1caef8d2bf1c459cf17e5f029d6db5cf5bbe654f",
+				"DiscoKey":   "discokey:6db67aaebcc475a1d9f246c3e5987ce57fe81f2c6aaa03b8509d5f6fdcd8b64c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60632",
+					"10.65.0.27:60632",
+					"172.17.0.1:60632",
+					"172.18.0.1:60632",
+					"172.19.0.1:60632",
+					"172.20.0.1:60632",
+					"172.21.0.1:60632",
+					"172.22.0.1:60632",
+					"172.23.0.1:60632",
+					"172.24.0.1:60632",
+					"172.25.0.1:60632",
+					"172.26.0.1:60632",
+					"172.27.0.1:60632",
+					"172.28.0.1:60632"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:24:11.827580036Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8110806700351409,
+				"StableID":   "nzVXx29QL621CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db3a3e21ceff1453eae1946b6242c8f2847640e647cb3e4d378c17215f4e1f6d",
+				"DiscoKey":   "discokey:ca8b5774f2d197c6b2274e73f3b53ddd6f6a63a98f4e54b8dbfc11e8504c7415",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52722",
+					"10.65.0.27:52722",
+					"172.17.0.1:52722",
+					"172.18.0.1:52722",
+					"172.19.0.1:52722",
+					"172.20.0.1:52722",
+					"172.21.0.1:52722",
+					"172.22.0.1:52722",
+					"172.23.0.1:52722",
+					"172.24.0.1:52722",
+					"172.25.0.1:52722",
+					"172.26.0.1:52722",
+					"172.27.0.1:52722",
+					"172.28.0.1:52722"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:24:12.280445949Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2113418688973880,
+				"StableID":   "nMXyUfvAWH11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3fcc86ca96b1b33f08204c73a717d366c3f0d3eb786d0a25335535f627ca933d",
+				"KeyExpiry":  "2026-11-09T09:24:12Z",
+				"DiscoKey":   "discokey:0c2f3cb6e7e4ee067d28f26839c5deaf9b98b6eaf8e01b5d525149c354e2dd63",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54053",
+					"10.65.0.27:54053",
+					"172.17.0.1:54053",
+					"172.18.0.1:54053",
+					"172.19.0.1:54053",
+					"172.20.0.1:54053",
+					"172.21.0.1:54053",
+					"172.22.0.1:54053",
+					"172.23.0.1:54053",
+					"172.24.0.1:54053",
+					"172.25.0.1:54053",
+					"172.26.0.1:54053",
+					"172.27.0.1:54053",
+					"172.28.0.1:54053"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:24:12.808963992Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4134718395602339,
+				"StableID":   "nLubwN3dHZ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:accba65175ac92d9b1d02ae3d950da7197cb08ff9dc11a0e58fc1fa11a85852b",
+				"KeyExpiry":  "2026-11-09T09:24:13Z",
+				"DiscoKey":   "discokey:62f296b87d06f1987e44ba1a93ee923344b5576c4d985b9212f35b9703125e19",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36710",
+					"10.65.0.27:36710",
+					"172.17.0.1:36710",
+					"172.18.0.1:36710",
+					"172.19.0.1:36710",
+					"172.20.0.1:36710",
+					"172.21.0.1:36710",
+					"172.22.0.1:36710",
+					"172.23.0.1:36710",
+					"172.24.0.1:36710",
+					"172.25.0.1:36710",
+					"172.26.0.1:36710",
+					"172.27.0.1:36710",
+					"172.28.0.1:36710"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:24:13.422850666Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3335087524911416,
+				"StableID":   "nqf87T6U3T11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ef9ff38f930098d723106d9a3ec4837d1c7bd45534dd70c42bc3543639c27f77",
+				"KeyExpiry":  "2026-11-09T09:24:13Z",
+				"DiscoKey":   "discokey:91bb747b6ec3f7dc64c5b9f2b783542884f0ca2db20bc4955c80a2e5dafa284e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38868",
+					"10.65.0.27:38868",
+					"172.17.0.1:38868",
+					"172.18.0.1:38868",
+					"172.19.0.1:38868",
+					"172.20.0.1:38868",
+					"172.21.0.1:38868",
+					"172.22.0.1:38868",
+					"172.23.0.1:38868",
+					"172.24.0.1:38868",
+					"172.25.0.1:38868",
+					"172.26.0.1:38868",
+					"172.27.0.1:38868",
+					"172.28.0.1:38868"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:24:13.893056144Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1542387268041600": {
+				"ID":          1542387268041600,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4968903788143197,
+				"StableID":   "nAfhYFgRof11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       4968903788143197,
+				"Key":        "nodekey:86959c2cd704dba34b57adb66ca9e9c0a90ae73ff2d09233311f52fc34a4c32e",
+				"DiscoKey":   "discokey:798a2ab402471e9dd56c6be429e465d2f19c45d1b668cf1ef6093c0b71655f5c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:55645",
+					"10.65.0.27:55645",
+					"172.17.0.1:55645",
+					"172.18.0.1:55645",
+					"172.19.0.1:55645",
+					"172.20.0.1:55645",
+					"172.21.0.1:55645",
+					"172.22.0.1:55645",
+					"172.23.0.1:55645",
+					"172.24.0.1:55645",
+					"172.25.0.1:55645",
+					"172.26.0.1:55645",
+					"172.27.0.1:55645",
+					"172.28.0.1:55645"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:24:09.362144056Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:86959c2cd704dba34b57adb66ca9e9c0a90ae73ff2d09233311f52fc34a4c32e",
+			"MachineKey": "mkey:552558a80e84548b4ba47924369a311811eb4361c6267fe4618d345ec4c76e76",
+			"Peers": [{
+				"ID":         8852797214098944,
+				"StableID":   "nsL9qKyS8C21CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:524472cc908505d8c2b933fbf66218530af01354309e2d410c3a42176ce93f17",
+				"DiscoKey":   "discokey:54f7309e4a27192ce49a9ed6edd02fbb3295a50b7182e52954cad977267ac25a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46458",
+					"10.65.0.27:46458",
+					"172.17.0.1:46458",
+					"172.18.0.1:46458",
+					"172.19.0.1:46458",
+					"172.20.0.1:46458",
+					"172.21.0.1:46458",
+					"172.22.0.1:46458",
+					"172.23.0.1:46458",
+					"172.24.0.1:46458",
+					"172.25.0.1:46458",
+					"172.26.0.1:46458",
+					"172.27.0.1:46458",
+					"172.28.0.1:46458"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:24:06.126972468Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8968980206677632,
+				"StableID":   "n1Kz2Hu43D21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:860d008513f7b02d0a70b650f48eaa40cc05d249c02a0877e97d17a253821720",
+				"DiscoKey":   "discokey:d157596b73eaf98a21b0daacea12dfea0f3c8b8f854126fefeb4968d06366820",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33002",
+					"10.65.0.27:33002",
+					"172.17.0.1:33002",
+					"172.18.0.1:33002",
+					"172.19.0.1:33002",
+					"172.20.0.1:33002",
+					"172.21.0.1:33002",
+					"172.22.0.1:33002",
+					"172.23.0.1:33002",
+					"172.24.0.1:33002",
+					"172.25.0.1:33002",
+					"172.26.0.1:33002",
+					"172.27.0.1:33002",
+					"172.28.0.1:33002"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:24:06.680153848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         603882840863826,
+				"StableID":   "nqaMkjyVi511CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e929fa420a5ac3c2c084b5c80b440e3f80d58ef45d5ac8e145bf65fdd11b5e7b",
+				"DiscoKey":   "discokey:358b2ab39e415ebdc7471c49b650e805fe0d0d6f33d8dfd124169c9b6bb1684b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33719",
+					"10.65.0.27:33719",
+					"172.17.0.1:33719",
+					"172.18.0.1:33719",
+					"172.19.0.1:33719",
+					"172.20.0.1:33719",
+					"172.21.0.1:33719",
+					"172.22.0.1:33719",
+					"172.23.0.1:33719",
+					"172.24.0.1:33719",
+					"172.25.0.1:33719",
+					"172.26.0.1:33719",
+					"172.27.0.1:33719",
+					"172.28.0.1:33719"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:24:07.218494291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1542387268041600,
+				"StableID":   "njJkD6uY3D11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30c10631a9260ca93f94386fb6f4d62bcbb72858875ca4c98ff5ee5d4b93e131",
+				"DiscoKey":   "discokey:dc146092255dbfba27de767a419e3ac1c4c7b61cebfcd8d00b6484d49b6ee04d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43605",
+					"10.65.0.27:43605",
+					"172.17.0.1:43605",
+					"172.18.0.1:43605",
+					"172.19.0.1:43605",
+					"172.20.0.1:43605",
+					"172.21.0.1:43605",
+					"172.22.0.1:43605",
+					"172.23.0.1:43605",
+					"172.24.0.1:43605",
+					"172.25.0.1:43605",
+					"172.26.0.1:43605",
+					"172.27.0.1:43605",
+					"172.28.0.1:43605"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:24:07.754657886Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3050105237621357,
+				"StableID":   "nG8jFN6QpQ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0a4410d42b4a3e7fd02c5a4c62cda3b640a4888dcec5334f09710a580f5875b",
+				"DiscoKey":   "discokey:8ecf3f58b84c46a014b0ce8c4977bfc179b4fca7ba60ce99f42d4a4384f86d7a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50119",
+					"10.65.0.27:50119",
+					"172.17.0.1:50119",
+					"172.18.0.1:50119",
+					"172.19.0.1:50119",
+					"172.20.0.1:50119",
+					"172.21.0.1:50119",
+					"172.22.0.1:50119",
+					"172.23.0.1:50119",
+					"172.24.0.1:50119",
+					"172.25.0.1:50119",
+					"172.26.0.1:50119",
+					"172.27.0.1:50119",
+					"172.28.0.1:50119"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:24:08.290665789Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5908834782017552,
+				"StableID":   "nKSJq4589o11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ef1c7321d2d26fddc9c4c3791e54897c29d4b0189f08b406ce04895a58955f57",
+				"DiscoKey":   "discokey:343ba7821e2d7da59dd1d12c1387ed9a02c44c38be9c1282582a13461ec3a548",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53871",
+					"10.65.0.27:53871",
+					"172.17.0.1:53871",
+					"172.18.0.1:53871",
+					"172.19.0.1:53871",
+					"172.20.0.1:53871",
+					"172.21.0.1:53871",
+					"172.22.0.1:53871",
+					"172.23.0.1:53871",
+					"172.24.0.1:53871",
+					"172.25.0.1:53871",
+					"172.26.0.1:53871",
+					"172.27.0.1:53871",
+					"172.28.0.1:53871"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:24:08.828683247Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6018109940402123,
+				"StableID":   "nipGPWYczo11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a183704c0861d35acfa31c9f5ed6a2199e095c0fcfac4b5d2a6951ecf768139",
+				"DiscoKey":   "discokey:64af28387bd93e699d7c0363fc13f26dc07ef91e6cce3b08fee5b175d0062247",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49274",
+					"10.65.0.27:49274",
+					"172.17.0.1:49274",
+					"172.18.0.1:49274",
+					"172.19.0.1:49274",
+					"172.20.0.1:49274",
+					"172.21.0.1:49274",
+					"172.22.0.1:49274",
+					"172.23.0.1:49274",
+					"172.24.0.1:49274",
+					"172.25.0.1:49274",
+					"172.26.0.1:49274",
+					"172.27.0.1:49274",
+					"172.28.0.1:49274"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:24:09.971537728Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6557715354076671,
+				"StableID":   "n8yuzc41Dt11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3eb6f8275da0adde2bee63fb41cf92926a6924615b6077412b7d969a6b533330",
+				"DiscoKey":   "discokey:066bd933775f7ba53cecf0fe43999b3114b3342513419f8e9fd3c16e8c592a7d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:49132",
+					"10.65.0.27:49132",
+					"172.17.0.1:49132",
+					"172.18.0.1:49132",
+					"172.19.0.1:49132",
+					"172.20.0.1:49132",
+					"172.21.0.1:49132",
+					"172.22.0.1:49132",
+					"172.23.0.1:49132",
+					"172.24.0.1:49132",
+					"172.25.0.1:49132",
+					"172.26.0.1:49132",
+					"172.27.0.1:49132",
+					"172.28.0.1:49132"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:24:10.672282502Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2315680359056086,
+				"StableID":   "nVCzenzm5K11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f91ee73dc631d6b698a5a33a0786329e14ad4ad68e2277c74740893c9b49d29",
+				"DiscoKey":   "discokey:8cf6dd2e9840e337ae21faf5a65fa2875f2fb3c21e689ac082aa267f9f1ea471",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47187",
+					"10.65.0.27:47187",
+					"172.17.0.1:47187",
+					"172.18.0.1:47187",
+					"172.19.0.1:47187",
+					"172.20.0.1:47187",
+					"172.21.0.1:47187",
+					"172.22.0.1:47187",
+					"172.23.0.1:47187",
+					"172.24.0.1:47187",
+					"172.25.0.1:47187",
+					"172.26.0.1:47187",
+					"172.27.0.1:47187",
+					"172.28.0.1:47187"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:24:11.275495561Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6221106268074116,
+				"StableID":   "nbrTjvuYaq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc164e344ad1d3e907815bee1caef8d2bf1c459cf17e5f029d6db5cf5bbe654f",
+				"DiscoKey":   "discokey:6db67aaebcc475a1d9f246c3e5987ce57fe81f2c6aaa03b8509d5f6fdcd8b64c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60632",
+					"10.65.0.27:60632",
+					"172.17.0.1:60632",
+					"172.18.0.1:60632",
+					"172.19.0.1:60632",
+					"172.20.0.1:60632",
+					"172.21.0.1:60632",
+					"172.22.0.1:60632",
+					"172.23.0.1:60632",
+					"172.24.0.1:60632",
+					"172.25.0.1:60632",
+					"172.26.0.1:60632",
+					"172.27.0.1:60632",
+					"172.28.0.1:60632"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:24:11.827580036Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8110806700351409,
+				"StableID":   "nzVXx29QL621CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db3a3e21ceff1453eae1946b6242c8f2847640e647cb3e4d378c17215f4e1f6d",
+				"DiscoKey":   "discokey:ca8b5774f2d197c6b2274e73f3b53ddd6f6a63a98f4e54b8dbfc11e8504c7415",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52722",
+					"10.65.0.27:52722",
+					"172.17.0.1:52722",
+					"172.18.0.1:52722",
+					"172.19.0.1:52722",
+					"172.20.0.1:52722",
+					"172.21.0.1:52722",
+					"172.22.0.1:52722",
+					"172.23.0.1:52722",
+					"172.24.0.1:52722",
+					"172.25.0.1:52722",
+					"172.26.0.1:52722",
+					"172.27.0.1:52722",
+					"172.28.0.1:52722"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:24:12.280445949Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2113418688973880,
+				"StableID":   "nMXyUfvAWH11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3fcc86ca96b1b33f08204c73a717d366c3f0d3eb786d0a25335535f627ca933d",
+				"KeyExpiry":  "2026-11-09T09:24:12Z",
+				"DiscoKey":   "discokey:0c2f3cb6e7e4ee067d28f26839c5deaf9b98b6eaf8e01b5d525149c354e2dd63",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54053",
+					"10.65.0.27:54053",
+					"172.17.0.1:54053",
+					"172.18.0.1:54053",
+					"172.19.0.1:54053",
+					"172.20.0.1:54053",
+					"172.21.0.1:54053",
+					"172.22.0.1:54053",
+					"172.23.0.1:54053",
+					"172.24.0.1:54053",
+					"172.25.0.1:54053",
+					"172.26.0.1:54053",
+					"172.27.0.1:54053",
+					"172.28.0.1:54053"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:24:12.808963992Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4134718395602339,
+				"StableID":   "nLubwN3dHZ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:accba65175ac92d9b1d02ae3d950da7197cb08ff9dc11a0e58fc1fa11a85852b",
+				"KeyExpiry":  "2026-11-09T09:24:13Z",
+				"DiscoKey":   "discokey:62f296b87d06f1987e44ba1a93ee923344b5576c4d985b9212f35b9703125e19",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36710",
+					"10.65.0.27:36710",
+					"172.17.0.1:36710",
+					"172.18.0.1:36710",
+					"172.19.0.1:36710",
+					"172.20.0.1:36710",
+					"172.21.0.1:36710",
+					"172.22.0.1:36710",
+					"172.23.0.1:36710",
+					"172.24.0.1:36710",
+					"172.25.0.1:36710",
+					"172.26.0.1:36710",
+					"172.27.0.1:36710",
+					"172.28.0.1:36710"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:24:13.422850666Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3335087524911416,
+				"StableID":   "nqf87T6U3T11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ef9ff38f930098d723106d9a3ec4837d1c7bd45534dd70c42bc3543639c27f77",
+				"KeyExpiry":  "2026-11-09T09:24:13Z",
+				"DiscoKey":   "discokey:91bb747b6ec3f7dc64c5b9f2b783542884f0ca2db20bc4955c80a2e5dafa284e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38868",
+					"10.65.0.27:38868",
+					"172.17.0.1:38868",
+					"172.18.0.1:38868",
+					"172.19.0.1:38868",
+					"172.20.0.1:38868",
+					"172.21.0.1:38868",
+					"172.22.0.1:38868",
+					"172.23.0.1:38868",
+					"172.24.0.1:38868",
+					"172.25.0.1:38868",
+					"172.26.0.1:38868",
+					"172.27.0.1:38868",
+					"172.28.0.1:38868"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:24:13.893056144Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4968903788143197": {
+				"ID":          4968903788143197,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6557715354076671,
+				"StableID":   "n8yuzc41Dt11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       6557715354076671,
+				"Key":        "nodekey:3eb6f8275da0adde2bee63fb41cf92926a6924615b6077412b7d969a6b533330",
+				"DiscoKey":   "discokey:066bd933775f7ba53cecf0fe43999b3114b3342513419f8e9fd3c16e8c592a7d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:49132",
+					"10.65.0.27:49132",
+					"172.17.0.1:49132",
+					"172.18.0.1:49132",
+					"172.19.0.1:49132",
+					"172.20.0.1:49132",
+					"172.21.0.1:49132",
+					"172.22.0.1:49132",
+					"172.23.0.1:49132",
+					"172.24.0.1:49132",
+					"172.25.0.1:49132",
+					"172.26.0.1:49132",
+					"172.27.0.1:49132",
+					"172.28.0.1:49132"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:24:10.672282502Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3eb6f8275da0adde2bee63fb41cf92926a6924615b6077412b7d969a6b533330",
+			"MachineKey": "mkey:2c17de36e56bbd622575056051062f363f1f50fa46cf7d0842cd91c1e2b38144",
+			"Peers": [{
+				"ID":         8852797214098944,
+				"StableID":   "nsL9qKyS8C21CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:524472cc908505d8c2b933fbf66218530af01354309e2d410c3a42176ce93f17",
+				"DiscoKey":   "discokey:54f7309e4a27192ce49a9ed6edd02fbb3295a50b7182e52954cad977267ac25a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46458",
+					"10.65.0.27:46458",
+					"172.17.0.1:46458",
+					"172.18.0.1:46458",
+					"172.19.0.1:46458",
+					"172.20.0.1:46458",
+					"172.21.0.1:46458",
+					"172.22.0.1:46458",
+					"172.23.0.1:46458",
+					"172.24.0.1:46458",
+					"172.25.0.1:46458",
+					"172.26.0.1:46458",
+					"172.27.0.1:46458",
+					"172.28.0.1:46458"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:24:06.126972468Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8968980206677632,
+				"StableID":   "n1Kz2Hu43D21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:860d008513f7b02d0a70b650f48eaa40cc05d249c02a0877e97d17a253821720",
+				"DiscoKey":   "discokey:d157596b73eaf98a21b0daacea12dfea0f3c8b8f854126fefeb4968d06366820",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33002",
+					"10.65.0.27:33002",
+					"172.17.0.1:33002",
+					"172.18.0.1:33002",
+					"172.19.0.1:33002",
+					"172.20.0.1:33002",
+					"172.21.0.1:33002",
+					"172.22.0.1:33002",
+					"172.23.0.1:33002",
+					"172.24.0.1:33002",
+					"172.25.0.1:33002",
+					"172.26.0.1:33002",
+					"172.27.0.1:33002",
+					"172.28.0.1:33002"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:24:06.680153848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         603882840863826,
+				"StableID":   "nqaMkjyVi511CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e929fa420a5ac3c2c084b5c80b440e3f80d58ef45d5ac8e145bf65fdd11b5e7b",
+				"DiscoKey":   "discokey:358b2ab39e415ebdc7471c49b650e805fe0d0d6f33d8dfd124169c9b6bb1684b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33719",
+					"10.65.0.27:33719",
+					"172.17.0.1:33719",
+					"172.18.0.1:33719",
+					"172.19.0.1:33719",
+					"172.20.0.1:33719",
+					"172.21.0.1:33719",
+					"172.22.0.1:33719",
+					"172.23.0.1:33719",
+					"172.24.0.1:33719",
+					"172.25.0.1:33719",
+					"172.26.0.1:33719",
+					"172.27.0.1:33719",
+					"172.28.0.1:33719"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:24:07.218494291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1542387268041600,
+				"StableID":   "njJkD6uY3D11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30c10631a9260ca93f94386fb6f4d62bcbb72858875ca4c98ff5ee5d4b93e131",
+				"DiscoKey":   "discokey:dc146092255dbfba27de767a419e3ac1c4c7b61cebfcd8d00b6484d49b6ee04d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43605",
+					"10.65.0.27:43605",
+					"172.17.0.1:43605",
+					"172.18.0.1:43605",
+					"172.19.0.1:43605",
+					"172.20.0.1:43605",
+					"172.21.0.1:43605",
+					"172.22.0.1:43605",
+					"172.23.0.1:43605",
+					"172.24.0.1:43605",
+					"172.25.0.1:43605",
+					"172.26.0.1:43605",
+					"172.27.0.1:43605",
+					"172.28.0.1:43605"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:24:07.754657886Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3050105237621357,
+				"StableID":   "nG8jFN6QpQ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0a4410d42b4a3e7fd02c5a4c62cda3b640a4888dcec5334f09710a580f5875b",
+				"DiscoKey":   "discokey:8ecf3f58b84c46a014b0ce8c4977bfc179b4fca7ba60ce99f42d4a4384f86d7a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50119",
+					"10.65.0.27:50119",
+					"172.17.0.1:50119",
+					"172.18.0.1:50119",
+					"172.19.0.1:50119",
+					"172.20.0.1:50119",
+					"172.21.0.1:50119",
+					"172.22.0.1:50119",
+					"172.23.0.1:50119",
+					"172.24.0.1:50119",
+					"172.25.0.1:50119",
+					"172.26.0.1:50119",
+					"172.27.0.1:50119",
+					"172.28.0.1:50119"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:24:08.290665789Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5908834782017552,
+				"StableID":   "nKSJq4589o11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ef1c7321d2d26fddc9c4c3791e54897c29d4b0189f08b406ce04895a58955f57",
+				"DiscoKey":   "discokey:343ba7821e2d7da59dd1d12c1387ed9a02c44c38be9c1282582a13461ec3a548",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53871",
+					"10.65.0.27:53871",
+					"172.17.0.1:53871",
+					"172.18.0.1:53871",
+					"172.19.0.1:53871",
+					"172.20.0.1:53871",
+					"172.21.0.1:53871",
+					"172.22.0.1:53871",
+					"172.23.0.1:53871",
+					"172.24.0.1:53871",
+					"172.25.0.1:53871",
+					"172.26.0.1:53871",
+					"172.27.0.1:53871",
+					"172.28.0.1:53871"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:24:08.828683247Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4968903788143197,
+				"StableID":   "nAfhYFgRof11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86959c2cd704dba34b57adb66ca9e9c0a90ae73ff2d09233311f52fc34a4c32e",
+				"DiscoKey":   "discokey:798a2ab402471e9dd56c6be429e465d2f19c45d1b668cf1ef6093c0b71655f5c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:55645",
+					"10.65.0.27:55645",
+					"172.17.0.1:55645",
+					"172.18.0.1:55645",
+					"172.19.0.1:55645",
+					"172.20.0.1:55645",
+					"172.21.0.1:55645",
+					"172.22.0.1:55645",
+					"172.23.0.1:55645",
+					"172.24.0.1:55645",
+					"172.25.0.1:55645",
+					"172.26.0.1:55645",
+					"172.27.0.1:55645",
+					"172.28.0.1:55645"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:24:09.362144056Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6018109940402123,
+				"StableID":   "nipGPWYczo11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a183704c0861d35acfa31c9f5ed6a2199e095c0fcfac4b5d2a6951ecf768139",
+				"DiscoKey":   "discokey:64af28387bd93e699d7c0363fc13f26dc07ef91e6cce3b08fee5b175d0062247",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49274",
+					"10.65.0.27:49274",
+					"172.17.0.1:49274",
+					"172.18.0.1:49274",
+					"172.19.0.1:49274",
+					"172.20.0.1:49274",
+					"172.21.0.1:49274",
+					"172.22.0.1:49274",
+					"172.23.0.1:49274",
+					"172.24.0.1:49274",
+					"172.25.0.1:49274",
+					"172.26.0.1:49274",
+					"172.27.0.1:49274",
+					"172.28.0.1:49274"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:24:09.971537728Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2315680359056086,
+				"StableID":   "nVCzenzm5K11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f91ee73dc631d6b698a5a33a0786329e14ad4ad68e2277c74740893c9b49d29",
+				"DiscoKey":   "discokey:8cf6dd2e9840e337ae21faf5a65fa2875f2fb3c21e689ac082aa267f9f1ea471",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47187",
+					"10.65.0.27:47187",
+					"172.17.0.1:47187",
+					"172.18.0.1:47187",
+					"172.19.0.1:47187",
+					"172.20.0.1:47187",
+					"172.21.0.1:47187",
+					"172.22.0.1:47187",
+					"172.23.0.1:47187",
+					"172.24.0.1:47187",
+					"172.25.0.1:47187",
+					"172.26.0.1:47187",
+					"172.27.0.1:47187",
+					"172.28.0.1:47187"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:24:11.275495561Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6221106268074116,
+				"StableID":   "nbrTjvuYaq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc164e344ad1d3e907815bee1caef8d2bf1c459cf17e5f029d6db5cf5bbe654f",
+				"DiscoKey":   "discokey:6db67aaebcc475a1d9f246c3e5987ce57fe81f2c6aaa03b8509d5f6fdcd8b64c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60632",
+					"10.65.0.27:60632",
+					"172.17.0.1:60632",
+					"172.18.0.1:60632",
+					"172.19.0.1:60632",
+					"172.20.0.1:60632",
+					"172.21.0.1:60632",
+					"172.22.0.1:60632",
+					"172.23.0.1:60632",
+					"172.24.0.1:60632",
+					"172.25.0.1:60632",
+					"172.26.0.1:60632",
+					"172.27.0.1:60632",
+					"172.28.0.1:60632"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:24:11.827580036Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8110806700351409,
+				"StableID":   "nzVXx29QL621CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db3a3e21ceff1453eae1946b6242c8f2847640e647cb3e4d378c17215f4e1f6d",
+				"DiscoKey":   "discokey:ca8b5774f2d197c6b2274e73f3b53ddd6f6a63a98f4e54b8dbfc11e8504c7415",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52722",
+					"10.65.0.27:52722",
+					"172.17.0.1:52722",
+					"172.18.0.1:52722",
+					"172.19.0.1:52722",
+					"172.20.0.1:52722",
+					"172.21.0.1:52722",
+					"172.22.0.1:52722",
+					"172.23.0.1:52722",
+					"172.24.0.1:52722",
+					"172.25.0.1:52722",
+					"172.26.0.1:52722",
+					"172.27.0.1:52722",
+					"172.28.0.1:52722"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:24:12.280445949Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2113418688973880,
+				"StableID":   "nMXyUfvAWH11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3fcc86ca96b1b33f08204c73a717d366c3f0d3eb786d0a25335535f627ca933d",
+				"KeyExpiry":  "2026-11-09T09:24:12Z",
+				"DiscoKey":   "discokey:0c2f3cb6e7e4ee067d28f26839c5deaf9b98b6eaf8e01b5d525149c354e2dd63",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54053",
+					"10.65.0.27:54053",
+					"172.17.0.1:54053",
+					"172.18.0.1:54053",
+					"172.19.0.1:54053",
+					"172.20.0.1:54053",
+					"172.21.0.1:54053",
+					"172.22.0.1:54053",
+					"172.23.0.1:54053",
+					"172.24.0.1:54053",
+					"172.25.0.1:54053",
+					"172.26.0.1:54053",
+					"172.27.0.1:54053",
+					"172.28.0.1:54053"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:24:12.808963992Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4134718395602339,
+				"StableID":   "nLubwN3dHZ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:accba65175ac92d9b1d02ae3d950da7197cb08ff9dc11a0e58fc1fa11a85852b",
+				"KeyExpiry":  "2026-11-09T09:24:13Z",
+				"DiscoKey":   "discokey:62f296b87d06f1987e44ba1a93ee923344b5576c4d985b9212f35b9703125e19",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36710",
+					"10.65.0.27:36710",
+					"172.17.0.1:36710",
+					"172.18.0.1:36710",
+					"172.19.0.1:36710",
+					"172.20.0.1:36710",
+					"172.21.0.1:36710",
+					"172.22.0.1:36710",
+					"172.23.0.1:36710",
+					"172.24.0.1:36710",
+					"172.25.0.1:36710",
+					"172.26.0.1:36710",
+					"172.27.0.1:36710",
+					"172.28.0.1:36710"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:24:13.422850666Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3335087524911416,
+				"StableID":   "nqf87T6U3T11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ef9ff38f930098d723106d9a3ec4837d1c7bd45534dd70c42bc3543639c27f77",
+				"KeyExpiry":  "2026-11-09T09:24:13Z",
+				"DiscoKey":   "discokey:91bb747b6ec3f7dc64c5b9f2b783542884f0ca2db20bc4955c80a2e5dafa284e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38868",
+					"10.65.0.27:38868",
+					"172.17.0.1:38868",
+					"172.18.0.1:38868",
+					"172.19.0.1:38868",
+					"172.20.0.1:38868",
+					"172.21.0.1:38868",
+					"172.22.0.1:38868",
+					"172.23.0.1:38868",
+					"172.24.0.1:38868",
+					"172.25.0.1:38868",
+					"172.26.0.1:38868",
+					"172.27.0.1:38868",
+					"172.28.0.1:38868"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:24:13.893056144Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6557715354076671": {
+				"ID":          6557715354076671,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4134718395602339,
+				"StableID":   "nLubwN3dHZ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:accba65175ac92d9b1d02ae3d950da7197cb08ff9dc11a0e58fc1fa11a85852b",
+				"KeyExpiry":  "2026-11-09T09:24:13Z",
+				"DiscoKey":   "discokey:62f296b87d06f1987e44ba1a93ee923344b5576c4d985b9212f35b9703125e19",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36710",
+					"10.65.0.27:36710",
+					"172.17.0.1:36710",
+					"172.18.0.1:36710",
+					"172.19.0.1:36710",
+					"172.20.0.1:36710",
+					"172.21.0.1:36710",
+					"172.22.0.1:36710",
+					"172.23.0.1:36710",
+					"172.24.0.1:36710",
+					"172.25.0.1:36710",
+					"172.26.0.1:36710",
+					"172.27.0.1:36710",
+					"172.28.0.1:36710"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:24:13.422850666Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:accba65175ac92d9b1d02ae3d950da7197cb08ff9dc11a0e58fc1fa11a85852b",
+			"MachineKey": "mkey:faa21da7f3003761f45b5dc4b29535af7271f4ac3184e3d61de53cba696eee07",
+			"Peers": [{
+				"ID":         8852797214098944,
+				"StableID":   "nsL9qKyS8C21CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:524472cc908505d8c2b933fbf66218530af01354309e2d410c3a42176ce93f17",
+				"DiscoKey":   "discokey:54f7309e4a27192ce49a9ed6edd02fbb3295a50b7182e52954cad977267ac25a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46458",
+					"10.65.0.27:46458",
+					"172.17.0.1:46458",
+					"172.18.0.1:46458",
+					"172.19.0.1:46458",
+					"172.20.0.1:46458",
+					"172.21.0.1:46458",
+					"172.22.0.1:46458",
+					"172.23.0.1:46458",
+					"172.24.0.1:46458",
+					"172.25.0.1:46458",
+					"172.26.0.1:46458",
+					"172.27.0.1:46458",
+					"172.28.0.1:46458"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:24:06.126972468Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8968980206677632,
+				"StableID":   "n1Kz2Hu43D21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:860d008513f7b02d0a70b650f48eaa40cc05d249c02a0877e97d17a253821720",
+				"DiscoKey":   "discokey:d157596b73eaf98a21b0daacea12dfea0f3c8b8f854126fefeb4968d06366820",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33002",
+					"10.65.0.27:33002",
+					"172.17.0.1:33002",
+					"172.18.0.1:33002",
+					"172.19.0.1:33002",
+					"172.20.0.1:33002",
+					"172.21.0.1:33002",
+					"172.22.0.1:33002",
+					"172.23.0.1:33002",
+					"172.24.0.1:33002",
+					"172.25.0.1:33002",
+					"172.26.0.1:33002",
+					"172.27.0.1:33002",
+					"172.28.0.1:33002"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:24:06.680153848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         603882840863826,
+				"StableID":   "nqaMkjyVi511CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e929fa420a5ac3c2c084b5c80b440e3f80d58ef45d5ac8e145bf65fdd11b5e7b",
+				"DiscoKey":   "discokey:358b2ab39e415ebdc7471c49b650e805fe0d0d6f33d8dfd124169c9b6bb1684b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33719",
+					"10.65.0.27:33719",
+					"172.17.0.1:33719",
+					"172.18.0.1:33719",
+					"172.19.0.1:33719",
+					"172.20.0.1:33719",
+					"172.21.0.1:33719",
+					"172.22.0.1:33719",
+					"172.23.0.1:33719",
+					"172.24.0.1:33719",
+					"172.25.0.1:33719",
+					"172.26.0.1:33719",
+					"172.27.0.1:33719",
+					"172.28.0.1:33719"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:24:07.218494291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1542387268041600,
+				"StableID":   "njJkD6uY3D11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30c10631a9260ca93f94386fb6f4d62bcbb72858875ca4c98ff5ee5d4b93e131",
+				"DiscoKey":   "discokey:dc146092255dbfba27de767a419e3ac1c4c7b61cebfcd8d00b6484d49b6ee04d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43605",
+					"10.65.0.27:43605",
+					"172.17.0.1:43605",
+					"172.18.0.1:43605",
+					"172.19.0.1:43605",
+					"172.20.0.1:43605",
+					"172.21.0.1:43605",
+					"172.22.0.1:43605",
+					"172.23.0.1:43605",
+					"172.24.0.1:43605",
+					"172.25.0.1:43605",
+					"172.26.0.1:43605",
+					"172.27.0.1:43605",
+					"172.28.0.1:43605"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:24:07.754657886Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3050105237621357,
+				"StableID":   "nG8jFN6QpQ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0a4410d42b4a3e7fd02c5a4c62cda3b640a4888dcec5334f09710a580f5875b",
+				"DiscoKey":   "discokey:8ecf3f58b84c46a014b0ce8c4977bfc179b4fca7ba60ce99f42d4a4384f86d7a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50119",
+					"10.65.0.27:50119",
+					"172.17.0.1:50119",
+					"172.18.0.1:50119",
+					"172.19.0.1:50119",
+					"172.20.0.1:50119",
+					"172.21.0.1:50119",
+					"172.22.0.1:50119",
+					"172.23.0.1:50119",
+					"172.24.0.1:50119",
+					"172.25.0.1:50119",
+					"172.26.0.1:50119",
+					"172.27.0.1:50119",
+					"172.28.0.1:50119"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:24:08.290665789Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5908834782017552,
+				"StableID":   "nKSJq4589o11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ef1c7321d2d26fddc9c4c3791e54897c29d4b0189f08b406ce04895a58955f57",
+				"DiscoKey":   "discokey:343ba7821e2d7da59dd1d12c1387ed9a02c44c38be9c1282582a13461ec3a548",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53871",
+					"10.65.0.27:53871",
+					"172.17.0.1:53871",
+					"172.18.0.1:53871",
+					"172.19.0.1:53871",
+					"172.20.0.1:53871",
+					"172.21.0.1:53871",
+					"172.22.0.1:53871",
+					"172.23.0.1:53871",
+					"172.24.0.1:53871",
+					"172.25.0.1:53871",
+					"172.26.0.1:53871",
+					"172.27.0.1:53871",
+					"172.28.0.1:53871"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:24:08.828683247Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4968903788143197,
+				"StableID":   "nAfhYFgRof11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86959c2cd704dba34b57adb66ca9e9c0a90ae73ff2d09233311f52fc34a4c32e",
+				"DiscoKey":   "discokey:798a2ab402471e9dd56c6be429e465d2f19c45d1b668cf1ef6093c0b71655f5c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:55645",
+					"10.65.0.27:55645",
+					"172.17.0.1:55645",
+					"172.18.0.1:55645",
+					"172.19.0.1:55645",
+					"172.20.0.1:55645",
+					"172.21.0.1:55645",
+					"172.22.0.1:55645",
+					"172.23.0.1:55645",
+					"172.24.0.1:55645",
+					"172.25.0.1:55645",
+					"172.26.0.1:55645",
+					"172.27.0.1:55645",
+					"172.28.0.1:55645"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:24:09.362144056Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6018109940402123,
+				"StableID":   "nipGPWYczo11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a183704c0861d35acfa31c9f5ed6a2199e095c0fcfac4b5d2a6951ecf768139",
+				"DiscoKey":   "discokey:64af28387bd93e699d7c0363fc13f26dc07ef91e6cce3b08fee5b175d0062247",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49274",
+					"10.65.0.27:49274",
+					"172.17.0.1:49274",
+					"172.18.0.1:49274",
+					"172.19.0.1:49274",
+					"172.20.0.1:49274",
+					"172.21.0.1:49274",
+					"172.22.0.1:49274",
+					"172.23.0.1:49274",
+					"172.24.0.1:49274",
+					"172.25.0.1:49274",
+					"172.26.0.1:49274",
+					"172.27.0.1:49274",
+					"172.28.0.1:49274"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:24:09.971537728Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6557715354076671,
+				"StableID":   "n8yuzc41Dt11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3eb6f8275da0adde2bee63fb41cf92926a6924615b6077412b7d969a6b533330",
+				"DiscoKey":   "discokey:066bd933775f7ba53cecf0fe43999b3114b3342513419f8e9fd3c16e8c592a7d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:49132",
+					"10.65.0.27:49132",
+					"172.17.0.1:49132",
+					"172.18.0.1:49132",
+					"172.19.0.1:49132",
+					"172.20.0.1:49132",
+					"172.21.0.1:49132",
+					"172.22.0.1:49132",
+					"172.23.0.1:49132",
+					"172.24.0.1:49132",
+					"172.25.0.1:49132",
+					"172.26.0.1:49132",
+					"172.27.0.1:49132",
+					"172.28.0.1:49132"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:24:10.672282502Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2315680359056086,
+				"StableID":   "nVCzenzm5K11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f91ee73dc631d6b698a5a33a0786329e14ad4ad68e2277c74740893c9b49d29",
+				"DiscoKey":   "discokey:8cf6dd2e9840e337ae21faf5a65fa2875f2fb3c21e689ac082aa267f9f1ea471",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47187",
+					"10.65.0.27:47187",
+					"172.17.0.1:47187",
+					"172.18.0.1:47187",
+					"172.19.0.1:47187",
+					"172.20.0.1:47187",
+					"172.21.0.1:47187",
+					"172.22.0.1:47187",
+					"172.23.0.1:47187",
+					"172.24.0.1:47187",
+					"172.25.0.1:47187",
+					"172.26.0.1:47187",
+					"172.27.0.1:47187",
+					"172.28.0.1:47187"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:24:11.275495561Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6221106268074116,
+				"StableID":   "nbrTjvuYaq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc164e344ad1d3e907815bee1caef8d2bf1c459cf17e5f029d6db5cf5bbe654f",
+				"DiscoKey":   "discokey:6db67aaebcc475a1d9f246c3e5987ce57fe81f2c6aaa03b8509d5f6fdcd8b64c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60632",
+					"10.65.0.27:60632",
+					"172.17.0.1:60632",
+					"172.18.0.1:60632",
+					"172.19.0.1:60632",
+					"172.20.0.1:60632",
+					"172.21.0.1:60632",
+					"172.22.0.1:60632",
+					"172.23.0.1:60632",
+					"172.24.0.1:60632",
+					"172.25.0.1:60632",
+					"172.26.0.1:60632",
+					"172.27.0.1:60632",
+					"172.28.0.1:60632"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:24:11.827580036Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8110806700351409,
+				"StableID":   "nzVXx29QL621CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db3a3e21ceff1453eae1946b6242c8f2847640e647cb3e4d378c17215f4e1f6d",
+				"DiscoKey":   "discokey:ca8b5774f2d197c6b2274e73f3b53ddd6f6a63a98f4e54b8dbfc11e8504c7415",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52722",
+					"10.65.0.27:52722",
+					"172.17.0.1:52722",
+					"172.18.0.1:52722",
+					"172.19.0.1:52722",
+					"172.20.0.1:52722",
+					"172.21.0.1:52722",
+					"172.22.0.1:52722",
+					"172.23.0.1:52722",
+					"172.24.0.1:52722",
+					"172.25.0.1:52722",
+					"172.26.0.1:52722",
+					"172.27.0.1:52722",
+					"172.28.0.1:52722"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:24:12.280445949Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2113418688973880,
+				"StableID":   "nMXyUfvAWH11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3fcc86ca96b1b33f08204c73a717d366c3f0d3eb786d0a25335535f627ca933d",
+				"KeyExpiry":  "2026-11-09T09:24:12Z",
+				"DiscoKey":   "discokey:0c2f3cb6e7e4ee067d28f26839c5deaf9b98b6eaf8e01b5d525149c354e2dd63",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54053",
+					"10.65.0.27:54053",
+					"172.17.0.1:54053",
+					"172.18.0.1:54053",
+					"172.19.0.1:54053",
+					"172.20.0.1:54053",
+					"172.21.0.1:54053",
+					"172.22.0.1:54053",
+					"172.23.0.1:54053",
+					"172.24.0.1:54053",
+					"172.25.0.1:54053",
+					"172.26.0.1:54053",
+					"172.27.0.1:54053",
+					"172.28.0.1:54053"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:24:12.808963992Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3335087524911416,
+				"StableID":   "nqf87T6U3T11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ef9ff38f930098d723106d9a3ec4837d1c7bd45534dd70c42bc3543639c27f77",
+				"KeyExpiry":  "2026-11-09T09:24:13Z",
+				"DiscoKey":   "discokey:91bb747b6ec3f7dc64c5b9f2b783542884f0ca2db20bc4955c80a2e5dafa284e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38868",
+					"10.65.0.27:38868",
+					"172.17.0.1:38868",
+					"172.18.0.1:38868",
+					"172.19.0.1:38868",
+					"172.20.0.1:38868",
+					"172.21.0.1:38868",
+					"172.22.0.1:38868",
+					"172.23.0.1:38868",
+					"172.24.0.1:38868",
+					"172.25.0.1:38868",
+					"172.26.0.1:38868",
+					"172.27.0.1:38868",
+					"172.28.0.1:38868"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:24:13.893056144Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2315680359056086,
+				"StableID":   "nVCzenzm5K11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       2315680359056086,
+				"Key":        "nodekey:9f91ee73dc631d6b698a5a33a0786329e14ad4ad68e2277c74740893c9b49d29",
+				"DiscoKey":   "discokey:8cf6dd2e9840e337ae21faf5a65fa2875f2fb3c21e689ac082aa267f9f1ea471",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47187",
+					"10.65.0.27:47187",
+					"172.17.0.1:47187",
+					"172.18.0.1:47187",
+					"172.19.0.1:47187",
+					"172.20.0.1:47187",
+					"172.21.0.1:47187",
+					"172.22.0.1:47187",
+					"172.23.0.1:47187",
+					"172.24.0.1:47187",
+					"172.25.0.1:47187",
+					"172.26.0.1:47187",
+					"172.27.0.1:47187",
+					"172.28.0.1:47187"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:24:11.275495561Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9f91ee73dc631d6b698a5a33a0786329e14ad4ad68e2277c74740893c9b49d29",
+			"MachineKey": "mkey:ab9250eee0f2df4f1dac009dab485845f0d49268e476c2e9ede18c0f59b3645d",
+			"Peers": [{
+				"ID":         8852797214098944,
+				"StableID":   "nsL9qKyS8C21CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:524472cc908505d8c2b933fbf66218530af01354309e2d410c3a42176ce93f17",
+				"DiscoKey":   "discokey:54f7309e4a27192ce49a9ed6edd02fbb3295a50b7182e52954cad977267ac25a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46458",
+					"10.65.0.27:46458",
+					"172.17.0.1:46458",
+					"172.18.0.1:46458",
+					"172.19.0.1:46458",
+					"172.20.0.1:46458",
+					"172.21.0.1:46458",
+					"172.22.0.1:46458",
+					"172.23.0.1:46458",
+					"172.24.0.1:46458",
+					"172.25.0.1:46458",
+					"172.26.0.1:46458",
+					"172.27.0.1:46458",
+					"172.28.0.1:46458"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:24:06.126972468Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8968980206677632,
+				"StableID":   "n1Kz2Hu43D21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:860d008513f7b02d0a70b650f48eaa40cc05d249c02a0877e97d17a253821720",
+				"DiscoKey":   "discokey:d157596b73eaf98a21b0daacea12dfea0f3c8b8f854126fefeb4968d06366820",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33002",
+					"10.65.0.27:33002",
+					"172.17.0.1:33002",
+					"172.18.0.1:33002",
+					"172.19.0.1:33002",
+					"172.20.0.1:33002",
+					"172.21.0.1:33002",
+					"172.22.0.1:33002",
+					"172.23.0.1:33002",
+					"172.24.0.1:33002",
+					"172.25.0.1:33002",
+					"172.26.0.1:33002",
+					"172.27.0.1:33002",
+					"172.28.0.1:33002"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:24:06.680153848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         603882840863826,
+				"StableID":   "nqaMkjyVi511CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e929fa420a5ac3c2c084b5c80b440e3f80d58ef45d5ac8e145bf65fdd11b5e7b",
+				"DiscoKey":   "discokey:358b2ab39e415ebdc7471c49b650e805fe0d0d6f33d8dfd124169c9b6bb1684b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:33719",
+					"10.65.0.27:33719",
+					"172.17.0.1:33719",
+					"172.18.0.1:33719",
+					"172.19.0.1:33719",
+					"172.20.0.1:33719",
+					"172.21.0.1:33719",
+					"172.22.0.1:33719",
+					"172.23.0.1:33719",
+					"172.24.0.1:33719",
+					"172.25.0.1:33719",
+					"172.26.0.1:33719",
+					"172.27.0.1:33719",
+					"172.28.0.1:33719"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:24:07.218494291Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1542387268041600,
+				"StableID":   "njJkD6uY3D11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:30c10631a9260ca93f94386fb6f4d62bcbb72858875ca4c98ff5ee5d4b93e131",
+				"DiscoKey":   "discokey:dc146092255dbfba27de767a419e3ac1c4c7b61cebfcd8d00b6484d49b6ee04d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43605",
+					"10.65.0.27:43605",
+					"172.17.0.1:43605",
+					"172.18.0.1:43605",
+					"172.19.0.1:43605",
+					"172.20.0.1:43605",
+					"172.21.0.1:43605",
+					"172.22.0.1:43605",
+					"172.23.0.1:43605",
+					"172.24.0.1:43605",
+					"172.25.0.1:43605",
+					"172.26.0.1:43605",
+					"172.27.0.1:43605",
+					"172.28.0.1:43605"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:24:07.754657886Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3050105237621357,
+				"StableID":   "nG8jFN6QpQ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0a4410d42b4a3e7fd02c5a4c62cda3b640a4888dcec5334f09710a580f5875b",
+				"DiscoKey":   "discokey:8ecf3f58b84c46a014b0ce8c4977bfc179b4fca7ba60ce99f42d4a4384f86d7a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50119",
+					"10.65.0.27:50119",
+					"172.17.0.1:50119",
+					"172.18.0.1:50119",
+					"172.19.0.1:50119",
+					"172.20.0.1:50119",
+					"172.21.0.1:50119",
+					"172.22.0.1:50119",
+					"172.23.0.1:50119",
+					"172.24.0.1:50119",
+					"172.25.0.1:50119",
+					"172.26.0.1:50119",
+					"172.27.0.1:50119",
+					"172.28.0.1:50119"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:24:08.290665789Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5908834782017552,
+				"StableID":   "nKSJq4589o11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ef1c7321d2d26fddc9c4c3791e54897c29d4b0189f08b406ce04895a58955f57",
+				"DiscoKey":   "discokey:343ba7821e2d7da59dd1d12c1387ed9a02c44c38be9c1282582a13461ec3a548",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53871",
+					"10.65.0.27:53871",
+					"172.17.0.1:53871",
+					"172.18.0.1:53871",
+					"172.19.0.1:53871",
+					"172.20.0.1:53871",
+					"172.21.0.1:53871",
+					"172.22.0.1:53871",
+					"172.23.0.1:53871",
+					"172.24.0.1:53871",
+					"172.25.0.1:53871",
+					"172.26.0.1:53871",
+					"172.27.0.1:53871",
+					"172.28.0.1:53871"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:24:08.828683247Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4968903788143197,
+				"StableID":   "nAfhYFgRof11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:86959c2cd704dba34b57adb66ca9e9c0a90ae73ff2d09233311f52fc34a4c32e",
+				"DiscoKey":   "discokey:798a2ab402471e9dd56c6be429e465d2f19c45d1b668cf1ef6093c0b71655f5c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:55645",
+					"10.65.0.27:55645",
+					"172.17.0.1:55645",
+					"172.18.0.1:55645",
+					"172.19.0.1:55645",
+					"172.20.0.1:55645",
+					"172.21.0.1:55645",
+					"172.22.0.1:55645",
+					"172.23.0.1:55645",
+					"172.24.0.1:55645",
+					"172.25.0.1:55645",
+					"172.26.0.1:55645",
+					"172.27.0.1:55645",
+					"172.28.0.1:55645"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:24:09.362144056Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6018109940402123,
+				"StableID":   "nipGPWYczo11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a183704c0861d35acfa31c9f5ed6a2199e095c0fcfac4b5d2a6951ecf768139",
+				"DiscoKey":   "discokey:64af28387bd93e699d7c0363fc13f26dc07ef91e6cce3b08fee5b175d0062247",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49274",
+					"10.65.0.27:49274",
+					"172.17.0.1:49274",
+					"172.18.0.1:49274",
+					"172.19.0.1:49274",
+					"172.20.0.1:49274",
+					"172.21.0.1:49274",
+					"172.22.0.1:49274",
+					"172.23.0.1:49274",
+					"172.24.0.1:49274",
+					"172.25.0.1:49274",
+					"172.26.0.1:49274",
+					"172.27.0.1:49274",
+					"172.28.0.1:49274"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:24:09.971537728Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6557715354076671,
+				"StableID":   "n8yuzc41Dt11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3eb6f8275da0adde2bee63fb41cf92926a6924615b6077412b7d969a6b533330",
+				"DiscoKey":   "discokey:066bd933775f7ba53cecf0fe43999b3114b3342513419f8e9fd3c16e8c592a7d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:49132",
+					"10.65.0.27:49132",
+					"172.17.0.1:49132",
+					"172.18.0.1:49132",
+					"172.19.0.1:49132",
+					"172.20.0.1:49132",
+					"172.21.0.1:49132",
+					"172.22.0.1:49132",
+					"172.23.0.1:49132",
+					"172.24.0.1:49132",
+					"172.25.0.1:49132",
+					"172.26.0.1:49132",
+					"172.27.0.1:49132",
+					"172.28.0.1:49132"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:24:10.672282502Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6221106268074116,
+				"StableID":   "nbrTjvuYaq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc164e344ad1d3e907815bee1caef8d2bf1c459cf17e5f029d6db5cf5bbe654f",
+				"DiscoKey":   "discokey:6db67aaebcc475a1d9f246c3e5987ce57fe81f2c6aaa03b8509d5f6fdcd8b64c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60632",
+					"10.65.0.27:60632",
+					"172.17.0.1:60632",
+					"172.18.0.1:60632",
+					"172.19.0.1:60632",
+					"172.20.0.1:60632",
+					"172.21.0.1:60632",
+					"172.22.0.1:60632",
+					"172.23.0.1:60632",
+					"172.24.0.1:60632",
+					"172.25.0.1:60632",
+					"172.26.0.1:60632",
+					"172.27.0.1:60632",
+					"172.28.0.1:60632"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:24:11.827580036Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8110806700351409,
+				"StableID":   "nzVXx29QL621CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db3a3e21ceff1453eae1946b6242c8f2847640e647cb3e4d378c17215f4e1f6d",
+				"DiscoKey":   "discokey:ca8b5774f2d197c6b2274e73f3b53ddd6f6a63a98f4e54b8dbfc11e8504c7415",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52722",
+					"10.65.0.27:52722",
+					"172.17.0.1:52722",
+					"172.18.0.1:52722",
+					"172.19.0.1:52722",
+					"172.20.0.1:52722",
+					"172.21.0.1:52722",
+					"172.22.0.1:52722",
+					"172.23.0.1:52722",
+					"172.24.0.1:52722",
+					"172.25.0.1:52722",
+					"172.26.0.1:52722",
+					"172.27.0.1:52722",
+					"172.28.0.1:52722"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:24:12.280445949Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2113418688973880,
+				"StableID":   "nMXyUfvAWH11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3fcc86ca96b1b33f08204c73a717d366c3f0d3eb786d0a25335535f627ca933d",
+				"KeyExpiry":  "2026-11-09T09:24:12Z",
+				"DiscoKey":   "discokey:0c2f3cb6e7e4ee067d28f26839c5deaf9b98b6eaf8e01b5d525149c354e2dd63",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54053",
+					"10.65.0.27:54053",
+					"172.17.0.1:54053",
+					"172.18.0.1:54053",
+					"172.19.0.1:54053",
+					"172.20.0.1:54053",
+					"172.21.0.1:54053",
+					"172.22.0.1:54053",
+					"172.23.0.1:54053",
+					"172.24.0.1:54053",
+					"172.25.0.1:54053",
+					"172.26.0.1:54053",
+					"172.27.0.1:54053",
+					"172.28.0.1:54053"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:24:12.808963992Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4134718395602339,
+				"StableID":   "nLubwN3dHZ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:accba65175ac92d9b1d02ae3d950da7197cb08ff9dc11a0e58fc1fa11a85852b",
+				"KeyExpiry":  "2026-11-09T09:24:13Z",
+				"DiscoKey":   "discokey:62f296b87d06f1987e44ba1a93ee923344b5576c4d985b9212f35b9703125e19",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:36710",
+					"10.65.0.27:36710",
+					"172.17.0.1:36710",
+					"172.18.0.1:36710",
+					"172.19.0.1:36710",
+					"172.20.0.1:36710",
+					"172.21.0.1:36710",
+					"172.22.0.1:36710",
+					"172.23.0.1:36710",
+					"172.24.0.1:36710",
+					"172.25.0.1:36710",
+					"172.26.0.1:36710",
+					"172.27.0.1:36710",
+					"172.28.0.1:36710"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:24:13.422850666Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3335087524911416,
+				"StableID":   "nqf87T6U3T11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ef9ff38f930098d723106d9a3ec4837d1c7bd45534dd70c42bc3543639c27f77",
+				"KeyExpiry":  "2026-11-09T09:24:13Z",
+				"DiscoKey":   "discokey:91bb747b6ec3f7dc64c5b9f2b783542884f0ca2db20bc4955c80a2e5dafa284e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38868",
+					"10.65.0.27:38868",
+					"172.17.0.1:38868",
+					"172.18.0.1:38868",
+					"172.19.0.1:38868",
+					"172.20.0.1:38868",
+					"172.21.0.1:38868",
+					"172.22.0.1:38868",
+					"172.23.0.1:38868",
+					"172.24.0.1:38868",
+					"172.25.0.1:38868",
+					"172.26.0.1:38868",
+					"172.27.0.1:38868",
+					"172.28.0.1:38868"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:24:13.893056144Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2315680359056086": {
+				"ID":          2315680359056086,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-tag-owner-self-reference.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-tag-owner-self-reference.hujson
@@ -1,0 +1,22101 @@
+// ssh-tag-owner-self-reference
+//
+// ssh tagOwner self-reference tag:a -> tag:a
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-13T09:24:59Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-tag-owner-self-reference",
+	"description":    "ssh tagOwner self-reference tag:a -> tag:a",
+	"category":       "ssh",
+	"captured_at":    "2026-05-13T09:24:59.171963477Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                               \n  \n                                                                      \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh tagOwner self-reference tag:a -> tag:a\",\n\t\"id\":          \"ssh-tag-owner-self-reference\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:a\"],\n\t\t\"src\":    [\"thor@example.org\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"tagOwners\": {\"tag:a\": [\"tag:a\"]}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-edges/ssh-tag-owner-self-reference.hujson",
+		"full_policy": {"ssh": [{
+			"action": "accept",
+			"dst":    ["tag:a"],
+			"src":    ["thor@example.org"],
+			"users":  ["root"]
+		}], "tagOwners": {"tag:a": ["tag:a"]}}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3566739387837422,
+				"StableID":   "n7siyLCPrU11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       3566739387837422,
+				"Key":        "nodekey:c50af58ec7631da2d9fb93f381d3ef00558a79c3ddff106abdb731b28a292045",
+				"DiscoKey":   "discokey:d55a9a8c3cdd8905df9995e60657c20f92cdea45279a7acfa7151a8b8f737456",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36435",
+					"10.65.0.27:36435",
+					"172.17.0.1:36435",
+					"172.18.0.1:36435",
+					"172.19.0.1:36435",
+					"172.20.0.1:36435",
+					"172.21.0.1:36435",
+					"172.22.0.1:36435",
+					"172.23.0.1:36435",
+					"172.24.0.1:36435",
+					"172.25.0.1:36435",
+					"172.26.0.1:36435",
+					"172.27.0.1:36435",
+					"172.28.0.1:36435"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:25:07.591294584Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c50af58ec7631da2d9fb93f381d3ef00558a79c3ddff106abdb731b28a292045",
+			"MachineKey": "mkey:b551c3359f2506245d60c55ea493d759660fd0dfe5ad3e0d19a078de9b5ba074",
+			"Peers": [{
+				"ID":         1111701973359323,
+				"StableID":   "nxbPYVXVg911CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e451839222d4d0713b74c367f2714ddd0bbc70c54470b84db70ade576bcb3674",
+				"DiscoKey":   "discokey:8594fe0f810f0cb338cc9b9eddc9d062a26c3e1408a5f7b137bbf475a2fb4d18",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51347",
+					"10.65.0.27:51347",
+					"172.17.0.1:51347",
+					"172.18.0.1:51347",
+					"172.19.0.1:51347",
+					"172.20.0.1:51347",
+					"172.21.0.1:51347",
+					"172.22.0.1:51347",
+					"172.23.0.1:51347",
+					"172.24.0.1:51347",
+					"172.25.0.1:51347",
+					"172.26.0.1:51347",
+					"172.27.0.1:51347",
+					"172.28.0.1:51347"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:25:01.694585935Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4911415734779420,
+				"StableID":   "nwJW8fZPMf11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a35ed5a6673587fb5a0a1a04d02e4797e00124b4ef17eb052758c4adde12e232",
+				"DiscoKey":   "discokey:616122b0d87095d607218d9afb941629599e5f2d1958837f66276d16e575543c",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51664",
+					"10.65.0.27:51664",
+					"172.17.0.1:51664",
+					"172.18.0.1:51664",
+					"172.19.0.1:51664",
+					"172.20.0.1:51664",
+					"172.21.0.1:51664",
+					"172.22.0.1:51664",
+					"172.23.0.1:51664",
+					"172.24.0.1:51664",
+					"172.25.0.1:51664",
+					"172.26.0.1:51664",
+					"172.27.0.1:51664",
+					"172.28.0.1:51664"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:25:02.221499655Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8500624626227658,
+				"StableID":   "nHvVCgzwN921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06edbf91eb3ed22390fb155c2c3f4b29a20ca960e48cd2fe0102f64b3598b95c",
+				"DiscoKey":   "discokey:aad7c92a930aa89b46a180ac2de0219e76fe01418f9646d5fdb4f786cdf71b7b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35814",
+					"10.65.0.27:35814",
+					"172.17.0.1:35814",
+					"172.18.0.1:35814",
+					"172.19.0.1:35814",
+					"172.20.0.1:35814",
+					"172.21.0.1:35814",
+					"172.22.0.1:35814",
+					"172.23.0.1:35814",
+					"172.24.0.1:35814",
+					"172.25.0.1:35814",
+					"172.26.0.1:35814",
+					"172.27.0.1:35814",
+					"172.28.0.1:35814"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:25:02.753722365Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1833936728053849,
+				"StableID":   "n8JwdfQbKF11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4ac4692d470556d42f3f9d60a06f76a58452b1337fdec16e3a9838624751253",
+				"DiscoKey":   "discokey:9d2eaceeeb7d9c286601d66c410db58faf4b79837cfdfff0dd71db7eb418030c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53948",
+					"10.65.0.27:53948",
+					"172.17.0.1:53948",
+					"172.18.0.1:53948",
+					"172.19.0.1:53948",
+					"172.20.0.1:53948",
+					"172.21.0.1:53948",
+					"172.22.0.1:53948",
+					"172.23.0.1:53948",
+					"172.24.0.1:53948",
+					"172.25.0.1:53948",
+					"172.26.0.1:53948",
+					"172.27.0.1:53948",
+					"172.28.0.1:53948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:25:03.362885203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8916891682166105,
+				"StableID":   "nayXVCdUdC21CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7396a8e888bab44894aad53453f03dcc72e221b3ceacf0b3d64b70718c10397f",
+				"DiscoKey":   "discokey:69257e4deb9e19803fae62e451670f1fd3fe61b0701827622f2345839e887e31",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:39392",
+					"10.65.0.27:39392",
+					"172.17.0.1:39392",
+					"172.18.0.1:39392",
+					"172.19.0.1:39392",
+					"172.20.0.1:39392",
+					"172.21.0.1:39392",
+					"172.22.0.1:39392",
+					"172.23.0.1:39392",
+					"172.24.0.1:39392",
+					"172.25.0.1:39392",
+					"172.26.0.1:39392",
+					"172.27.0.1:39392",
+					"172.28.0.1:39392"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:25:03.823761506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3571740558468309,
+				"StableID":   "nzFTJwZetU11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f1a595f39e675a814bb45e8ef0eea10d795175ef850c32620bf1bf9506171f0e",
+				"DiscoKey":   "discokey:061847f57788a4bebc9c47608e46578df9d315d7ac49e0234e7f8d5f60413016",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:56939",
+					"10.65.0.27:56939",
+					"172.17.0.1:56939",
+					"172.18.0.1:56939",
+					"172.19.0.1:56939",
+					"172.20.0.1:56939",
+					"172.21.0.1:56939",
+					"172.22.0.1:56939",
+					"172.23.0.1:56939",
+					"172.24.0.1:56939",
+					"172.25.0.1:56939",
+					"172.26.0.1:56939",
+					"172.27.0.1:56939",
+					"172.28.0.1:56939"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:25:04.395397488Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4425484544229752,
+				"StableID":   "nfLCpXyJZb11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:827790f023e92b68fba0a68dd08e08a55e2237015cd17fba5f99c71bb5250757",
+				"DiscoKey":   "discokey:7f1bc9df669823b23999208b378ab60dd73cf61507878580423ad35a7642ca11",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50699",
+					"10.65.0.27:50699",
+					"172.17.0.1:50699",
+					"172.18.0.1:50699",
+					"172.19.0.1:50699",
+					"172.20.0.1:50699",
+					"172.21.0.1:50699",
+					"172.22.0.1:50699",
+					"172.23.0.1:50699",
+					"172.24.0.1:50699",
+					"172.25.0.1:50699",
+					"172.26.0.1:50699",
+					"172.27.0.1:50699",
+					"172.28.0.1:50699"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:25:04.904792855Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1770706487984919,
+				"StableID":   "nYHwqVTxpE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e779f6731d4c1c49201d941277821cbd0c66668270bd929ac782f4d4b8210572",
+				"DiscoKey":   "discokey:27b9b505ae1072e38ca8d662cc96cf2dd56e65363f2ee504621b48563b2c6648",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:60880",
+					"10.65.0.27:60880",
+					"172.17.0.1:60880",
+					"172.18.0.1:60880",
+					"172.19.0.1:60880",
+					"172.20.0.1:60880",
+					"172.21.0.1:60880",
+					"172.22.0.1:60880",
+					"172.23.0.1:60880",
+					"172.24.0.1:60880",
+					"172.25.0.1:60880",
+					"172.26.0.1:60880",
+					"172.27.0.1:60880",
+					"172.28.0.1:60880"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:25:05.445033397Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7025241854797289,
+				"StableID":   "nWX5u4Ckrw11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2c0ec942bf61a2a90eeacfe4925005a662c17e91b350e3e74bbd3e5e758b639",
+				"DiscoKey":   "discokey:decf0e5cbfefeb892ca3bee860ea419e05f6bbb97a944741661991384fdb7e75",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37443",
+					"10.65.0.27:37443",
+					"172.17.0.1:37443",
+					"172.18.0.1:37443",
+					"172.19.0.1:37443",
+					"172.20.0.1:37443",
+					"172.21.0.1:37443",
+					"172.22.0.1:37443",
+					"172.23.0.1:37443",
+					"172.24.0.1:37443",
+					"172.25.0.1:37443",
+					"172.26.0.1:37443",
+					"172.27.0.1:37443",
+					"172.28.0.1:37443"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:25:05.979820657Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5187642462783807,
+				"StableID":   "n2LyB7aVWh11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4657a71f34c78df771f1f45e9e45bdd6d62e633fdb4b25b05812361ab22ce93d",
+				"DiscoKey":   "discokey:609aa9d2ed0bc217b56060ec3565a4010763a35a88b658c697dcee707074ed6f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:48858",
+					"10.65.0.27:48858",
+					"172.17.0.1:48858",
+					"172.18.0.1:48858",
+					"172.19.0.1:48858",
+					"172.20.0.1:48858",
+					"172.21.0.1:48858",
+					"172.22.0.1:48858",
+					"172.23.0.1:48858",
+					"172.24.0.1:48858",
+					"172.25.0.1:48858",
+					"172.26.0.1:48858",
+					"172.27.0.1:48858",
+					"172.28.0.1:48858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:25:06.511793624Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8893129674967036,
+				"StableID":   "nHbXHKSiSC21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90e1c8e418c74a15316c5382799838ea1f2355157bd129ac34e0f75d78f4572f",
+				"DiscoKey":   "discokey:7eabf39cbd7e2d3bc60a8e36c0e71262c3c5e436c53669a241166a454def3b06",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38891",
+					"10.65.0.27:38891",
+					"172.17.0.1:38891",
+					"172.18.0.1:38891",
+					"172.19.0.1:38891",
+					"172.20.0.1:38891",
+					"172.21.0.1:38891",
+					"172.22.0.1:38891",
+					"172.23.0.1:38891",
+					"172.24.0.1:38891",
+					"172.25.0.1:38891",
+					"172.26.0.1:38891",
+					"172.27.0.1:38891",
+					"172.28.0.1:38891"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:25:07.062390075Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5747196086914171,
+				"StableID":   "nkmRrY6vsm11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:761ed02ba5ec891d31c733faea100d9b97cb2198399bac790e4ff5e144759974",
+				"KeyExpiry":  "2026-11-09T09:25:08Z",
+				"DiscoKey":   "discokey:4d7f7844bdfd4e84f6911d922f22f859b56d90898ceab7c4bf12028eb12e8a0e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:42656",
+					"10.65.0.27:42656",
+					"172.17.0.1:42656",
+					"172.18.0.1:42656",
+					"172.19.0.1:42656",
+					"172.20.0.1:42656",
+					"172.21.0.1:42656",
+					"172.22.0.1:42656",
+					"172.23.0.1:42656",
+					"172.24.0.1:42656",
+					"172.25.0.1:42656",
+					"172.26.0.1:42656",
+					"172.27.0.1:42656",
+					"172.28.0.1:42656"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:25:08.122619339Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1118669416952970,
+				"StableID":   "nTu1gpYej911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5e0da8da6fca608299c957b185242f8e3f4d8c577f50a403fd129ce4f6683203",
+				"KeyExpiry":  "2026-11-09T09:25:08Z",
+				"DiscoKey":   "discokey:d440fb256198020553b4f2eb0bdb3303b74c122673c4f11887d71d5b10f1c75c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59342",
+					"10.65.0.27:59342",
+					"172.17.0.1:59342",
+					"172.18.0.1:59342",
+					"172.19.0.1:59342",
+					"172.20.0.1:59342",
+					"172.21.0.1:59342",
+					"172.22.0.1:59342",
+					"172.23.0.1:59342",
+					"172.24.0.1:59342",
+					"172.25.0.1:59342",
+					"172.26.0.1:59342",
+					"172.27.0.1:59342",
+					"172.28.0.1:59342"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:25:08.655311712Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8926419916096414,
+				"StableID":   "njmzt3vnhC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:cb4ba8073d974c29b0a43072c97be73251548d8cb6f1701240a43a8a0fbb227f",
+				"KeyExpiry":  "2026-11-09T09:25:09Z",
+				"DiscoKey":   "discokey:a13760fbbdedb482e330b42110a2dbfe37899ac465cf55b34483336eb9761d72",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58696",
+					"10.65.0.27:58696",
+					"172.17.0.1:58696",
+					"172.18.0.1:58696",
+					"172.19.0.1:58696",
+					"172.20.0.1:58696",
+					"172.21.0.1:58696",
+					"172.22.0.1:58696",
+					"172.23.0.1:58696",
+					"172.24.0.1:58696",
+					"172.25.0.1:58696",
+					"172.26.0.1:58696",
+					"172.27.0.1:58696",
+					"172.28.0.1:58696"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:25:09.187973528Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3566739387837422": {
+				"ID":          3566739387837422,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3571740558468309,
+				"StableID":   "nzFTJwZetU11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       3571740558468309,
+				"Key":        "nodekey:f1a595f39e675a814bb45e8ef0eea10d795175ef850c32620bf1bf9506171f0e",
+				"DiscoKey":   "discokey:061847f57788a4bebc9c47608e46578df9d315d7ac49e0234e7f8d5f60413016",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:56939",
+					"10.65.0.27:56939",
+					"172.17.0.1:56939",
+					"172.18.0.1:56939",
+					"172.19.0.1:56939",
+					"172.20.0.1:56939",
+					"172.21.0.1:56939",
+					"172.22.0.1:56939",
+					"172.23.0.1:56939",
+					"172.24.0.1:56939",
+					"172.25.0.1:56939",
+					"172.26.0.1:56939",
+					"172.27.0.1:56939",
+					"172.28.0.1:56939"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:25:04.395397488Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f1a595f39e675a814bb45e8ef0eea10d795175ef850c32620bf1bf9506171f0e",
+			"MachineKey": "mkey:ebb9e7f0552ef08412373cbda0086ea1360493760391ea7b169328d2d67ae909",
+			"Peers": [{
+				"ID":         1111701973359323,
+				"StableID":   "nxbPYVXVg911CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e451839222d4d0713b74c367f2714ddd0bbc70c54470b84db70ade576bcb3674",
+				"DiscoKey":   "discokey:8594fe0f810f0cb338cc9b9eddc9d062a26c3e1408a5f7b137bbf475a2fb4d18",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51347",
+					"10.65.0.27:51347",
+					"172.17.0.1:51347",
+					"172.18.0.1:51347",
+					"172.19.0.1:51347",
+					"172.20.0.1:51347",
+					"172.21.0.1:51347",
+					"172.22.0.1:51347",
+					"172.23.0.1:51347",
+					"172.24.0.1:51347",
+					"172.25.0.1:51347",
+					"172.26.0.1:51347",
+					"172.27.0.1:51347",
+					"172.28.0.1:51347"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:25:01.694585935Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4911415734779420,
+				"StableID":   "nwJW8fZPMf11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a35ed5a6673587fb5a0a1a04d02e4797e00124b4ef17eb052758c4adde12e232",
+				"DiscoKey":   "discokey:616122b0d87095d607218d9afb941629599e5f2d1958837f66276d16e575543c",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51664",
+					"10.65.0.27:51664",
+					"172.17.0.1:51664",
+					"172.18.0.1:51664",
+					"172.19.0.1:51664",
+					"172.20.0.1:51664",
+					"172.21.0.1:51664",
+					"172.22.0.1:51664",
+					"172.23.0.1:51664",
+					"172.24.0.1:51664",
+					"172.25.0.1:51664",
+					"172.26.0.1:51664",
+					"172.27.0.1:51664",
+					"172.28.0.1:51664"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:25:02.221499655Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8500624626227658,
+				"StableID":   "nHvVCgzwN921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06edbf91eb3ed22390fb155c2c3f4b29a20ca960e48cd2fe0102f64b3598b95c",
+				"DiscoKey":   "discokey:aad7c92a930aa89b46a180ac2de0219e76fe01418f9646d5fdb4f786cdf71b7b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35814",
+					"10.65.0.27:35814",
+					"172.17.0.1:35814",
+					"172.18.0.1:35814",
+					"172.19.0.1:35814",
+					"172.20.0.1:35814",
+					"172.21.0.1:35814",
+					"172.22.0.1:35814",
+					"172.23.0.1:35814",
+					"172.24.0.1:35814",
+					"172.25.0.1:35814",
+					"172.26.0.1:35814",
+					"172.27.0.1:35814",
+					"172.28.0.1:35814"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:25:02.753722365Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1833936728053849,
+				"StableID":   "n8JwdfQbKF11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4ac4692d470556d42f3f9d60a06f76a58452b1337fdec16e3a9838624751253",
+				"DiscoKey":   "discokey:9d2eaceeeb7d9c286601d66c410db58faf4b79837cfdfff0dd71db7eb418030c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53948",
+					"10.65.0.27:53948",
+					"172.17.0.1:53948",
+					"172.18.0.1:53948",
+					"172.19.0.1:53948",
+					"172.20.0.1:53948",
+					"172.21.0.1:53948",
+					"172.22.0.1:53948",
+					"172.23.0.1:53948",
+					"172.24.0.1:53948",
+					"172.25.0.1:53948",
+					"172.26.0.1:53948",
+					"172.27.0.1:53948",
+					"172.28.0.1:53948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:25:03.362885203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8916891682166105,
+				"StableID":   "nayXVCdUdC21CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7396a8e888bab44894aad53453f03dcc72e221b3ceacf0b3d64b70718c10397f",
+				"DiscoKey":   "discokey:69257e4deb9e19803fae62e451670f1fd3fe61b0701827622f2345839e887e31",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:39392",
+					"10.65.0.27:39392",
+					"172.17.0.1:39392",
+					"172.18.0.1:39392",
+					"172.19.0.1:39392",
+					"172.20.0.1:39392",
+					"172.21.0.1:39392",
+					"172.22.0.1:39392",
+					"172.23.0.1:39392",
+					"172.24.0.1:39392",
+					"172.25.0.1:39392",
+					"172.26.0.1:39392",
+					"172.27.0.1:39392",
+					"172.28.0.1:39392"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:25:03.823761506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4425484544229752,
+				"StableID":   "nfLCpXyJZb11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:827790f023e92b68fba0a68dd08e08a55e2237015cd17fba5f99c71bb5250757",
+				"DiscoKey":   "discokey:7f1bc9df669823b23999208b378ab60dd73cf61507878580423ad35a7642ca11",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50699",
+					"10.65.0.27:50699",
+					"172.17.0.1:50699",
+					"172.18.0.1:50699",
+					"172.19.0.1:50699",
+					"172.20.0.1:50699",
+					"172.21.0.1:50699",
+					"172.22.0.1:50699",
+					"172.23.0.1:50699",
+					"172.24.0.1:50699",
+					"172.25.0.1:50699",
+					"172.26.0.1:50699",
+					"172.27.0.1:50699",
+					"172.28.0.1:50699"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:25:04.904792855Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1770706487984919,
+				"StableID":   "nYHwqVTxpE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e779f6731d4c1c49201d941277821cbd0c66668270bd929ac782f4d4b8210572",
+				"DiscoKey":   "discokey:27b9b505ae1072e38ca8d662cc96cf2dd56e65363f2ee504621b48563b2c6648",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:60880",
+					"10.65.0.27:60880",
+					"172.17.0.1:60880",
+					"172.18.0.1:60880",
+					"172.19.0.1:60880",
+					"172.20.0.1:60880",
+					"172.21.0.1:60880",
+					"172.22.0.1:60880",
+					"172.23.0.1:60880",
+					"172.24.0.1:60880",
+					"172.25.0.1:60880",
+					"172.26.0.1:60880",
+					"172.27.0.1:60880",
+					"172.28.0.1:60880"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:25:05.445033397Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7025241854797289,
+				"StableID":   "nWX5u4Ckrw11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2c0ec942bf61a2a90eeacfe4925005a662c17e91b350e3e74bbd3e5e758b639",
+				"DiscoKey":   "discokey:decf0e5cbfefeb892ca3bee860ea419e05f6bbb97a944741661991384fdb7e75",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37443",
+					"10.65.0.27:37443",
+					"172.17.0.1:37443",
+					"172.18.0.1:37443",
+					"172.19.0.1:37443",
+					"172.20.0.1:37443",
+					"172.21.0.1:37443",
+					"172.22.0.1:37443",
+					"172.23.0.1:37443",
+					"172.24.0.1:37443",
+					"172.25.0.1:37443",
+					"172.26.0.1:37443",
+					"172.27.0.1:37443",
+					"172.28.0.1:37443"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:25:05.979820657Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5187642462783807,
+				"StableID":   "n2LyB7aVWh11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4657a71f34c78df771f1f45e9e45bdd6d62e633fdb4b25b05812361ab22ce93d",
+				"DiscoKey":   "discokey:609aa9d2ed0bc217b56060ec3565a4010763a35a88b658c697dcee707074ed6f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:48858",
+					"10.65.0.27:48858",
+					"172.17.0.1:48858",
+					"172.18.0.1:48858",
+					"172.19.0.1:48858",
+					"172.20.0.1:48858",
+					"172.21.0.1:48858",
+					"172.22.0.1:48858",
+					"172.23.0.1:48858",
+					"172.24.0.1:48858",
+					"172.25.0.1:48858",
+					"172.26.0.1:48858",
+					"172.27.0.1:48858",
+					"172.28.0.1:48858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:25:06.511793624Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8893129674967036,
+				"StableID":   "nHbXHKSiSC21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90e1c8e418c74a15316c5382799838ea1f2355157bd129ac34e0f75d78f4572f",
+				"DiscoKey":   "discokey:7eabf39cbd7e2d3bc60a8e36c0e71262c3c5e436c53669a241166a454def3b06",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38891",
+					"10.65.0.27:38891",
+					"172.17.0.1:38891",
+					"172.18.0.1:38891",
+					"172.19.0.1:38891",
+					"172.20.0.1:38891",
+					"172.21.0.1:38891",
+					"172.22.0.1:38891",
+					"172.23.0.1:38891",
+					"172.24.0.1:38891",
+					"172.25.0.1:38891",
+					"172.26.0.1:38891",
+					"172.27.0.1:38891",
+					"172.28.0.1:38891"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:25:07.062390075Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3566739387837422,
+				"StableID":   "n7siyLCPrU11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c50af58ec7631da2d9fb93f381d3ef00558a79c3ddff106abdb731b28a292045",
+				"DiscoKey":   "discokey:d55a9a8c3cdd8905df9995e60657c20f92cdea45279a7acfa7151a8b8f737456",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36435",
+					"10.65.0.27:36435",
+					"172.17.0.1:36435",
+					"172.18.0.1:36435",
+					"172.19.0.1:36435",
+					"172.20.0.1:36435",
+					"172.21.0.1:36435",
+					"172.22.0.1:36435",
+					"172.23.0.1:36435",
+					"172.24.0.1:36435",
+					"172.25.0.1:36435",
+					"172.26.0.1:36435",
+					"172.27.0.1:36435",
+					"172.28.0.1:36435"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:25:07.591294584Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5747196086914171,
+				"StableID":   "nkmRrY6vsm11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:761ed02ba5ec891d31c733faea100d9b97cb2198399bac790e4ff5e144759974",
+				"KeyExpiry":  "2026-11-09T09:25:08Z",
+				"DiscoKey":   "discokey:4d7f7844bdfd4e84f6911d922f22f859b56d90898ceab7c4bf12028eb12e8a0e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:42656",
+					"10.65.0.27:42656",
+					"172.17.0.1:42656",
+					"172.18.0.1:42656",
+					"172.19.0.1:42656",
+					"172.20.0.1:42656",
+					"172.21.0.1:42656",
+					"172.22.0.1:42656",
+					"172.23.0.1:42656",
+					"172.24.0.1:42656",
+					"172.25.0.1:42656",
+					"172.26.0.1:42656",
+					"172.27.0.1:42656",
+					"172.28.0.1:42656"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:25:08.122619339Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1118669416952970,
+				"StableID":   "nTu1gpYej911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5e0da8da6fca608299c957b185242f8e3f4d8c577f50a403fd129ce4f6683203",
+				"KeyExpiry":  "2026-11-09T09:25:08Z",
+				"DiscoKey":   "discokey:d440fb256198020553b4f2eb0bdb3303b74c122673c4f11887d71d5b10f1c75c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59342",
+					"10.65.0.27:59342",
+					"172.17.0.1:59342",
+					"172.18.0.1:59342",
+					"172.19.0.1:59342",
+					"172.20.0.1:59342",
+					"172.21.0.1:59342",
+					"172.22.0.1:59342",
+					"172.23.0.1:59342",
+					"172.24.0.1:59342",
+					"172.25.0.1:59342",
+					"172.26.0.1:59342",
+					"172.27.0.1:59342",
+					"172.28.0.1:59342"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:25:08.655311712Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8926419916096414,
+				"StableID":   "njmzt3vnhC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:cb4ba8073d974c29b0a43072c97be73251548d8cb6f1701240a43a8a0fbb227f",
+				"KeyExpiry":  "2026-11-09T09:25:09Z",
+				"DiscoKey":   "discokey:a13760fbbdedb482e330b42110a2dbfe37899ac465cf55b34483336eb9761d72",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58696",
+					"10.65.0.27:58696",
+					"172.17.0.1:58696",
+					"172.18.0.1:58696",
+					"172.19.0.1:58696",
+					"172.20.0.1:58696",
+					"172.21.0.1:58696",
+					"172.22.0.1:58696",
+					"172.23.0.1:58696",
+					"172.24.0.1:58696",
+					"172.25.0.1:58696",
+					"172.26.0.1:58696",
+					"172.27.0.1:58696",
+					"172.28.0.1:58696"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:25:09.187973528Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3571740558468309": {
+				"ID":          3571740558468309,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8926419916096414,
+				"StableID":   "njmzt3vnhC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:cb4ba8073d974c29b0a43072c97be73251548d8cb6f1701240a43a8a0fbb227f",
+				"KeyExpiry":  "2026-11-09T09:25:09Z",
+				"DiscoKey":   "discokey:a13760fbbdedb482e330b42110a2dbfe37899ac465cf55b34483336eb9761d72",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58696",
+					"10.65.0.27:58696",
+					"172.17.0.1:58696",
+					"172.18.0.1:58696",
+					"172.19.0.1:58696",
+					"172.20.0.1:58696",
+					"172.21.0.1:58696",
+					"172.22.0.1:58696",
+					"172.23.0.1:58696",
+					"172.24.0.1:58696",
+					"172.25.0.1:58696",
+					"172.26.0.1:58696",
+					"172.27.0.1:58696",
+					"172.28.0.1:58696"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:25:09.187973528Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:cb4ba8073d974c29b0a43072c97be73251548d8cb6f1701240a43a8a0fbb227f",
+			"MachineKey": "mkey:57191f7a42be58abeaaf3aae90c4bcc00f1f83318f00fb1fd08a255f5ee21826",
+			"Peers": [{
+				"ID":         1111701973359323,
+				"StableID":   "nxbPYVXVg911CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e451839222d4d0713b74c367f2714ddd0bbc70c54470b84db70ade576bcb3674",
+				"DiscoKey":   "discokey:8594fe0f810f0cb338cc9b9eddc9d062a26c3e1408a5f7b137bbf475a2fb4d18",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51347",
+					"10.65.0.27:51347",
+					"172.17.0.1:51347",
+					"172.18.0.1:51347",
+					"172.19.0.1:51347",
+					"172.20.0.1:51347",
+					"172.21.0.1:51347",
+					"172.22.0.1:51347",
+					"172.23.0.1:51347",
+					"172.24.0.1:51347",
+					"172.25.0.1:51347",
+					"172.26.0.1:51347",
+					"172.27.0.1:51347",
+					"172.28.0.1:51347"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:25:01.694585935Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4911415734779420,
+				"StableID":   "nwJW8fZPMf11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a35ed5a6673587fb5a0a1a04d02e4797e00124b4ef17eb052758c4adde12e232",
+				"DiscoKey":   "discokey:616122b0d87095d607218d9afb941629599e5f2d1958837f66276d16e575543c",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51664",
+					"10.65.0.27:51664",
+					"172.17.0.1:51664",
+					"172.18.0.1:51664",
+					"172.19.0.1:51664",
+					"172.20.0.1:51664",
+					"172.21.0.1:51664",
+					"172.22.0.1:51664",
+					"172.23.0.1:51664",
+					"172.24.0.1:51664",
+					"172.25.0.1:51664",
+					"172.26.0.1:51664",
+					"172.27.0.1:51664",
+					"172.28.0.1:51664"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:25:02.221499655Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8500624626227658,
+				"StableID":   "nHvVCgzwN921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06edbf91eb3ed22390fb155c2c3f4b29a20ca960e48cd2fe0102f64b3598b95c",
+				"DiscoKey":   "discokey:aad7c92a930aa89b46a180ac2de0219e76fe01418f9646d5fdb4f786cdf71b7b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35814",
+					"10.65.0.27:35814",
+					"172.17.0.1:35814",
+					"172.18.0.1:35814",
+					"172.19.0.1:35814",
+					"172.20.0.1:35814",
+					"172.21.0.1:35814",
+					"172.22.0.1:35814",
+					"172.23.0.1:35814",
+					"172.24.0.1:35814",
+					"172.25.0.1:35814",
+					"172.26.0.1:35814",
+					"172.27.0.1:35814",
+					"172.28.0.1:35814"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:25:02.753722365Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1833936728053849,
+				"StableID":   "n8JwdfQbKF11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4ac4692d470556d42f3f9d60a06f76a58452b1337fdec16e3a9838624751253",
+				"DiscoKey":   "discokey:9d2eaceeeb7d9c286601d66c410db58faf4b79837cfdfff0dd71db7eb418030c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53948",
+					"10.65.0.27:53948",
+					"172.17.0.1:53948",
+					"172.18.0.1:53948",
+					"172.19.0.1:53948",
+					"172.20.0.1:53948",
+					"172.21.0.1:53948",
+					"172.22.0.1:53948",
+					"172.23.0.1:53948",
+					"172.24.0.1:53948",
+					"172.25.0.1:53948",
+					"172.26.0.1:53948",
+					"172.27.0.1:53948",
+					"172.28.0.1:53948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:25:03.362885203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8916891682166105,
+				"StableID":   "nayXVCdUdC21CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7396a8e888bab44894aad53453f03dcc72e221b3ceacf0b3d64b70718c10397f",
+				"DiscoKey":   "discokey:69257e4deb9e19803fae62e451670f1fd3fe61b0701827622f2345839e887e31",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:39392",
+					"10.65.0.27:39392",
+					"172.17.0.1:39392",
+					"172.18.0.1:39392",
+					"172.19.0.1:39392",
+					"172.20.0.1:39392",
+					"172.21.0.1:39392",
+					"172.22.0.1:39392",
+					"172.23.0.1:39392",
+					"172.24.0.1:39392",
+					"172.25.0.1:39392",
+					"172.26.0.1:39392",
+					"172.27.0.1:39392",
+					"172.28.0.1:39392"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:25:03.823761506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3571740558468309,
+				"StableID":   "nzFTJwZetU11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f1a595f39e675a814bb45e8ef0eea10d795175ef850c32620bf1bf9506171f0e",
+				"DiscoKey":   "discokey:061847f57788a4bebc9c47608e46578df9d315d7ac49e0234e7f8d5f60413016",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:56939",
+					"10.65.0.27:56939",
+					"172.17.0.1:56939",
+					"172.18.0.1:56939",
+					"172.19.0.1:56939",
+					"172.20.0.1:56939",
+					"172.21.0.1:56939",
+					"172.22.0.1:56939",
+					"172.23.0.1:56939",
+					"172.24.0.1:56939",
+					"172.25.0.1:56939",
+					"172.26.0.1:56939",
+					"172.27.0.1:56939",
+					"172.28.0.1:56939"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:25:04.395397488Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4425484544229752,
+				"StableID":   "nfLCpXyJZb11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:827790f023e92b68fba0a68dd08e08a55e2237015cd17fba5f99c71bb5250757",
+				"DiscoKey":   "discokey:7f1bc9df669823b23999208b378ab60dd73cf61507878580423ad35a7642ca11",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50699",
+					"10.65.0.27:50699",
+					"172.17.0.1:50699",
+					"172.18.0.1:50699",
+					"172.19.0.1:50699",
+					"172.20.0.1:50699",
+					"172.21.0.1:50699",
+					"172.22.0.1:50699",
+					"172.23.0.1:50699",
+					"172.24.0.1:50699",
+					"172.25.0.1:50699",
+					"172.26.0.1:50699",
+					"172.27.0.1:50699",
+					"172.28.0.1:50699"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:25:04.904792855Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1770706487984919,
+				"StableID":   "nYHwqVTxpE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e779f6731d4c1c49201d941277821cbd0c66668270bd929ac782f4d4b8210572",
+				"DiscoKey":   "discokey:27b9b505ae1072e38ca8d662cc96cf2dd56e65363f2ee504621b48563b2c6648",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:60880",
+					"10.65.0.27:60880",
+					"172.17.0.1:60880",
+					"172.18.0.1:60880",
+					"172.19.0.1:60880",
+					"172.20.0.1:60880",
+					"172.21.0.1:60880",
+					"172.22.0.1:60880",
+					"172.23.0.1:60880",
+					"172.24.0.1:60880",
+					"172.25.0.1:60880",
+					"172.26.0.1:60880",
+					"172.27.0.1:60880",
+					"172.28.0.1:60880"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:25:05.445033397Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7025241854797289,
+				"StableID":   "nWX5u4Ckrw11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2c0ec942bf61a2a90eeacfe4925005a662c17e91b350e3e74bbd3e5e758b639",
+				"DiscoKey":   "discokey:decf0e5cbfefeb892ca3bee860ea419e05f6bbb97a944741661991384fdb7e75",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37443",
+					"10.65.0.27:37443",
+					"172.17.0.1:37443",
+					"172.18.0.1:37443",
+					"172.19.0.1:37443",
+					"172.20.0.1:37443",
+					"172.21.0.1:37443",
+					"172.22.0.1:37443",
+					"172.23.0.1:37443",
+					"172.24.0.1:37443",
+					"172.25.0.1:37443",
+					"172.26.0.1:37443",
+					"172.27.0.1:37443",
+					"172.28.0.1:37443"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:25:05.979820657Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5187642462783807,
+				"StableID":   "n2LyB7aVWh11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4657a71f34c78df771f1f45e9e45bdd6d62e633fdb4b25b05812361ab22ce93d",
+				"DiscoKey":   "discokey:609aa9d2ed0bc217b56060ec3565a4010763a35a88b658c697dcee707074ed6f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:48858",
+					"10.65.0.27:48858",
+					"172.17.0.1:48858",
+					"172.18.0.1:48858",
+					"172.19.0.1:48858",
+					"172.20.0.1:48858",
+					"172.21.0.1:48858",
+					"172.22.0.1:48858",
+					"172.23.0.1:48858",
+					"172.24.0.1:48858",
+					"172.25.0.1:48858",
+					"172.26.0.1:48858",
+					"172.27.0.1:48858",
+					"172.28.0.1:48858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:25:06.511793624Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8893129674967036,
+				"StableID":   "nHbXHKSiSC21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90e1c8e418c74a15316c5382799838ea1f2355157bd129ac34e0f75d78f4572f",
+				"DiscoKey":   "discokey:7eabf39cbd7e2d3bc60a8e36c0e71262c3c5e436c53669a241166a454def3b06",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38891",
+					"10.65.0.27:38891",
+					"172.17.0.1:38891",
+					"172.18.0.1:38891",
+					"172.19.0.1:38891",
+					"172.20.0.1:38891",
+					"172.21.0.1:38891",
+					"172.22.0.1:38891",
+					"172.23.0.1:38891",
+					"172.24.0.1:38891",
+					"172.25.0.1:38891",
+					"172.26.0.1:38891",
+					"172.27.0.1:38891",
+					"172.28.0.1:38891"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:25:07.062390075Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3566739387837422,
+				"StableID":   "n7siyLCPrU11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c50af58ec7631da2d9fb93f381d3ef00558a79c3ddff106abdb731b28a292045",
+				"DiscoKey":   "discokey:d55a9a8c3cdd8905df9995e60657c20f92cdea45279a7acfa7151a8b8f737456",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36435",
+					"10.65.0.27:36435",
+					"172.17.0.1:36435",
+					"172.18.0.1:36435",
+					"172.19.0.1:36435",
+					"172.20.0.1:36435",
+					"172.21.0.1:36435",
+					"172.22.0.1:36435",
+					"172.23.0.1:36435",
+					"172.24.0.1:36435",
+					"172.25.0.1:36435",
+					"172.26.0.1:36435",
+					"172.27.0.1:36435",
+					"172.28.0.1:36435"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:25:07.591294584Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5747196086914171,
+				"StableID":   "nkmRrY6vsm11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:761ed02ba5ec891d31c733faea100d9b97cb2198399bac790e4ff5e144759974",
+				"KeyExpiry":  "2026-11-09T09:25:08Z",
+				"DiscoKey":   "discokey:4d7f7844bdfd4e84f6911d922f22f859b56d90898ceab7c4bf12028eb12e8a0e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:42656",
+					"10.65.0.27:42656",
+					"172.17.0.1:42656",
+					"172.18.0.1:42656",
+					"172.19.0.1:42656",
+					"172.20.0.1:42656",
+					"172.21.0.1:42656",
+					"172.22.0.1:42656",
+					"172.23.0.1:42656",
+					"172.24.0.1:42656",
+					"172.25.0.1:42656",
+					"172.26.0.1:42656",
+					"172.27.0.1:42656",
+					"172.28.0.1:42656"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:25:08.122619339Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1118669416952970,
+				"StableID":   "nTu1gpYej911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5e0da8da6fca608299c957b185242f8e3f4d8c577f50a403fd129ce4f6683203",
+				"KeyExpiry":  "2026-11-09T09:25:08Z",
+				"DiscoKey":   "discokey:d440fb256198020553b4f2eb0bdb3303b74c122673c4f11887d71d5b10f1c75c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59342",
+					"10.65.0.27:59342",
+					"172.17.0.1:59342",
+					"172.18.0.1:59342",
+					"172.19.0.1:59342",
+					"172.20.0.1:59342",
+					"172.21.0.1:59342",
+					"172.22.0.1:59342",
+					"172.23.0.1:59342",
+					"172.24.0.1:59342",
+					"172.25.0.1:59342",
+					"172.26.0.1:59342",
+					"172.27.0.1:59342",
+					"172.28.0.1:59342"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:25:08.655311712Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8500624626227658,
+				"StableID":   "nHvVCgzwN921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       8500624626227658,
+				"Key":        "nodekey:06edbf91eb3ed22390fb155c2c3f4b29a20ca960e48cd2fe0102f64b3598b95c",
+				"DiscoKey":   "discokey:aad7c92a930aa89b46a180ac2de0219e76fe01418f9646d5fdb4f786cdf71b7b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35814",
+					"10.65.0.27:35814",
+					"172.17.0.1:35814",
+					"172.18.0.1:35814",
+					"172.19.0.1:35814",
+					"172.20.0.1:35814",
+					"172.21.0.1:35814",
+					"172.22.0.1:35814",
+					"172.23.0.1:35814",
+					"172.24.0.1:35814",
+					"172.25.0.1:35814",
+					"172.26.0.1:35814",
+					"172.27.0.1:35814",
+					"172.28.0.1:35814"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:25:02.753722365Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:06edbf91eb3ed22390fb155c2c3f4b29a20ca960e48cd2fe0102f64b3598b95c",
+			"MachineKey": "mkey:d13dd7b879fb5cd831b5c605636cf28f23ae9ca853539a5c7e1cc5c127eab03b",
+			"Peers": [{
+				"ID":         1111701973359323,
+				"StableID":   "nxbPYVXVg911CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e451839222d4d0713b74c367f2714ddd0bbc70c54470b84db70ade576bcb3674",
+				"DiscoKey":   "discokey:8594fe0f810f0cb338cc9b9eddc9d062a26c3e1408a5f7b137bbf475a2fb4d18",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51347",
+					"10.65.0.27:51347",
+					"172.17.0.1:51347",
+					"172.18.0.1:51347",
+					"172.19.0.1:51347",
+					"172.20.0.1:51347",
+					"172.21.0.1:51347",
+					"172.22.0.1:51347",
+					"172.23.0.1:51347",
+					"172.24.0.1:51347",
+					"172.25.0.1:51347",
+					"172.26.0.1:51347",
+					"172.27.0.1:51347",
+					"172.28.0.1:51347"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:25:01.694585935Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4911415734779420,
+				"StableID":   "nwJW8fZPMf11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a35ed5a6673587fb5a0a1a04d02e4797e00124b4ef17eb052758c4adde12e232",
+				"DiscoKey":   "discokey:616122b0d87095d607218d9afb941629599e5f2d1958837f66276d16e575543c",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51664",
+					"10.65.0.27:51664",
+					"172.17.0.1:51664",
+					"172.18.0.1:51664",
+					"172.19.0.1:51664",
+					"172.20.0.1:51664",
+					"172.21.0.1:51664",
+					"172.22.0.1:51664",
+					"172.23.0.1:51664",
+					"172.24.0.1:51664",
+					"172.25.0.1:51664",
+					"172.26.0.1:51664",
+					"172.27.0.1:51664",
+					"172.28.0.1:51664"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:25:02.221499655Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1833936728053849,
+				"StableID":   "n8JwdfQbKF11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4ac4692d470556d42f3f9d60a06f76a58452b1337fdec16e3a9838624751253",
+				"DiscoKey":   "discokey:9d2eaceeeb7d9c286601d66c410db58faf4b79837cfdfff0dd71db7eb418030c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53948",
+					"10.65.0.27:53948",
+					"172.17.0.1:53948",
+					"172.18.0.1:53948",
+					"172.19.0.1:53948",
+					"172.20.0.1:53948",
+					"172.21.0.1:53948",
+					"172.22.0.1:53948",
+					"172.23.0.1:53948",
+					"172.24.0.1:53948",
+					"172.25.0.1:53948",
+					"172.26.0.1:53948",
+					"172.27.0.1:53948",
+					"172.28.0.1:53948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:25:03.362885203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8916891682166105,
+				"StableID":   "nayXVCdUdC21CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7396a8e888bab44894aad53453f03dcc72e221b3ceacf0b3d64b70718c10397f",
+				"DiscoKey":   "discokey:69257e4deb9e19803fae62e451670f1fd3fe61b0701827622f2345839e887e31",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:39392",
+					"10.65.0.27:39392",
+					"172.17.0.1:39392",
+					"172.18.0.1:39392",
+					"172.19.0.1:39392",
+					"172.20.0.1:39392",
+					"172.21.0.1:39392",
+					"172.22.0.1:39392",
+					"172.23.0.1:39392",
+					"172.24.0.1:39392",
+					"172.25.0.1:39392",
+					"172.26.0.1:39392",
+					"172.27.0.1:39392",
+					"172.28.0.1:39392"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:25:03.823761506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3571740558468309,
+				"StableID":   "nzFTJwZetU11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f1a595f39e675a814bb45e8ef0eea10d795175ef850c32620bf1bf9506171f0e",
+				"DiscoKey":   "discokey:061847f57788a4bebc9c47608e46578df9d315d7ac49e0234e7f8d5f60413016",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:56939",
+					"10.65.0.27:56939",
+					"172.17.0.1:56939",
+					"172.18.0.1:56939",
+					"172.19.0.1:56939",
+					"172.20.0.1:56939",
+					"172.21.0.1:56939",
+					"172.22.0.1:56939",
+					"172.23.0.1:56939",
+					"172.24.0.1:56939",
+					"172.25.0.1:56939",
+					"172.26.0.1:56939",
+					"172.27.0.1:56939",
+					"172.28.0.1:56939"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:25:04.395397488Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4425484544229752,
+				"StableID":   "nfLCpXyJZb11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:827790f023e92b68fba0a68dd08e08a55e2237015cd17fba5f99c71bb5250757",
+				"DiscoKey":   "discokey:7f1bc9df669823b23999208b378ab60dd73cf61507878580423ad35a7642ca11",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50699",
+					"10.65.0.27:50699",
+					"172.17.0.1:50699",
+					"172.18.0.1:50699",
+					"172.19.0.1:50699",
+					"172.20.0.1:50699",
+					"172.21.0.1:50699",
+					"172.22.0.1:50699",
+					"172.23.0.1:50699",
+					"172.24.0.1:50699",
+					"172.25.0.1:50699",
+					"172.26.0.1:50699",
+					"172.27.0.1:50699",
+					"172.28.0.1:50699"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:25:04.904792855Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1770706487984919,
+				"StableID":   "nYHwqVTxpE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e779f6731d4c1c49201d941277821cbd0c66668270bd929ac782f4d4b8210572",
+				"DiscoKey":   "discokey:27b9b505ae1072e38ca8d662cc96cf2dd56e65363f2ee504621b48563b2c6648",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:60880",
+					"10.65.0.27:60880",
+					"172.17.0.1:60880",
+					"172.18.0.1:60880",
+					"172.19.0.1:60880",
+					"172.20.0.1:60880",
+					"172.21.0.1:60880",
+					"172.22.0.1:60880",
+					"172.23.0.1:60880",
+					"172.24.0.1:60880",
+					"172.25.0.1:60880",
+					"172.26.0.1:60880",
+					"172.27.0.1:60880",
+					"172.28.0.1:60880"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:25:05.445033397Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7025241854797289,
+				"StableID":   "nWX5u4Ckrw11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2c0ec942bf61a2a90eeacfe4925005a662c17e91b350e3e74bbd3e5e758b639",
+				"DiscoKey":   "discokey:decf0e5cbfefeb892ca3bee860ea419e05f6bbb97a944741661991384fdb7e75",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37443",
+					"10.65.0.27:37443",
+					"172.17.0.1:37443",
+					"172.18.0.1:37443",
+					"172.19.0.1:37443",
+					"172.20.0.1:37443",
+					"172.21.0.1:37443",
+					"172.22.0.1:37443",
+					"172.23.0.1:37443",
+					"172.24.0.1:37443",
+					"172.25.0.1:37443",
+					"172.26.0.1:37443",
+					"172.27.0.1:37443",
+					"172.28.0.1:37443"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:25:05.979820657Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5187642462783807,
+				"StableID":   "n2LyB7aVWh11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4657a71f34c78df771f1f45e9e45bdd6d62e633fdb4b25b05812361ab22ce93d",
+				"DiscoKey":   "discokey:609aa9d2ed0bc217b56060ec3565a4010763a35a88b658c697dcee707074ed6f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:48858",
+					"10.65.0.27:48858",
+					"172.17.0.1:48858",
+					"172.18.0.1:48858",
+					"172.19.0.1:48858",
+					"172.20.0.1:48858",
+					"172.21.0.1:48858",
+					"172.22.0.1:48858",
+					"172.23.0.1:48858",
+					"172.24.0.1:48858",
+					"172.25.0.1:48858",
+					"172.26.0.1:48858",
+					"172.27.0.1:48858",
+					"172.28.0.1:48858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:25:06.511793624Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8893129674967036,
+				"StableID":   "nHbXHKSiSC21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90e1c8e418c74a15316c5382799838ea1f2355157bd129ac34e0f75d78f4572f",
+				"DiscoKey":   "discokey:7eabf39cbd7e2d3bc60a8e36c0e71262c3c5e436c53669a241166a454def3b06",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38891",
+					"10.65.0.27:38891",
+					"172.17.0.1:38891",
+					"172.18.0.1:38891",
+					"172.19.0.1:38891",
+					"172.20.0.1:38891",
+					"172.21.0.1:38891",
+					"172.22.0.1:38891",
+					"172.23.0.1:38891",
+					"172.24.0.1:38891",
+					"172.25.0.1:38891",
+					"172.26.0.1:38891",
+					"172.27.0.1:38891",
+					"172.28.0.1:38891"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:25:07.062390075Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3566739387837422,
+				"StableID":   "n7siyLCPrU11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c50af58ec7631da2d9fb93f381d3ef00558a79c3ddff106abdb731b28a292045",
+				"DiscoKey":   "discokey:d55a9a8c3cdd8905df9995e60657c20f92cdea45279a7acfa7151a8b8f737456",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36435",
+					"10.65.0.27:36435",
+					"172.17.0.1:36435",
+					"172.18.0.1:36435",
+					"172.19.0.1:36435",
+					"172.20.0.1:36435",
+					"172.21.0.1:36435",
+					"172.22.0.1:36435",
+					"172.23.0.1:36435",
+					"172.24.0.1:36435",
+					"172.25.0.1:36435",
+					"172.26.0.1:36435",
+					"172.27.0.1:36435",
+					"172.28.0.1:36435"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:25:07.591294584Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5747196086914171,
+				"StableID":   "nkmRrY6vsm11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:761ed02ba5ec891d31c733faea100d9b97cb2198399bac790e4ff5e144759974",
+				"KeyExpiry":  "2026-11-09T09:25:08Z",
+				"DiscoKey":   "discokey:4d7f7844bdfd4e84f6911d922f22f859b56d90898ceab7c4bf12028eb12e8a0e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:42656",
+					"10.65.0.27:42656",
+					"172.17.0.1:42656",
+					"172.18.0.1:42656",
+					"172.19.0.1:42656",
+					"172.20.0.1:42656",
+					"172.21.0.1:42656",
+					"172.22.0.1:42656",
+					"172.23.0.1:42656",
+					"172.24.0.1:42656",
+					"172.25.0.1:42656",
+					"172.26.0.1:42656",
+					"172.27.0.1:42656",
+					"172.28.0.1:42656"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:25:08.122619339Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1118669416952970,
+				"StableID":   "nTu1gpYej911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5e0da8da6fca608299c957b185242f8e3f4d8c577f50a403fd129ce4f6683203",
+				"KeyExpiry":  "2026-11-09T09:25:08Z",
+				"DiscoKey":   "discokey:d440fb256198020553b4f2eb0bdb3303b74c122673c4f11887d71d5b10f1c75c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59342",
+					"10.65.0.27:59342",
+					"172.17.0.1:59342",
+					"172.18.0.1:59342",
+					"172.19.0.1:59342",
+					"172.20.0.1:59342",
+					"172.21.0.1:59342",
+					"172.22.0.1:59342",
+					"172.23.0.1:59342",
+					"172.24.0.1:59342",
+					"172.25.0.1:59342",
+					"172.26.0.1:59342",
+					"172.27.0.1:59342",
+					"172.28.0.1:59342"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:25:08.655311712Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8926419916096414,
+				"StableID":   "njmzt3vnhC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:cb4ba8073d974c29b0a43072c97be73251548d8cb6f1701240a43a8a0fbb227f",
+				"KeyExpiry":  "2026-11-09T09:25:09Z",
+				"DiscoKey":   "discokey:a13760fbbdedb482e330b42110a2dbfe37899ac465cf55b34483336eb9761d72",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58696",
+					"10.65.0.27:58696",
+					"172.17.0.1:58696",
+					"172.18.0.1:58696",
+					"172.19.0.1:58696",
+					"172.20.0.1:58696",
+					"172.21.0.1:58696",
+					"172.22.0.1:58696",
+					"172.23.0.1:58696",
+					"172.24.0.1:58696",
+					"172.25.0.1:58696",
+					"172.26.0.1:58696",
+					"172.27.0.1:58696",
+					"172.28.0.1:58696"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:25:09.187973528Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8500624626227658": {
+				"ID":          8500624626227658,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1770706487984919,
+				"StableID":   "nYHwqVTxpE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1770706487984919,
+				"Key":        "nodekey:e779f6731d4c1c49201d941277821cbd0c66668270bd929ac782f4d4b8210572",
+				"DiscoKey":   "discokey:27b9b505ae1072e38ca8d662cc96cf2dd56e65363f2ee504621b48563b2c6648",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:60880",
+					"10.65.0.27:60880",
+					"172.17.0.1:60880",
+					"172.18.0.1:60880",
+					"172.19.0.1:60880",
+					"172.20.0.1:60880",
+					"172.21.0.1:60880",
+					"172.22.0.1:60880",
+					"172.23.0.1:60880",
+					"172.24.0.1:60880",
+					"172.25.0.1:60880",
+					"172.26.0.1:60880",
+					"172.27.0.1:60880",
+					"172.28.0.1:60880"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:25:05.445033397Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e779f6731d4c1c49201d941277821cbd0c66668270bd929ac782f4d4b8210572",
+			"MachineKey": "mkey:c0cc79c4db181dae43a3d8e52155e020496245839c3a3a0d2ba7ab5eb0d3860e",
+			"Peers": [{
+				"ID":         1111701973359323,
+				"StableID":   "nxbPYVXVg911CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e451839222d4d0713b74c367f2714ddd0bbc70c54470b84db70ade576bcb3674",
+				"DiscoKey":   "discokey:8594fe0f810f0cb338cc9b9eddc9d062a26c3e1408a5f7b137bbf475a2fb4d18",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51347",
+					"10.65.0.27:51347",
+					"172.17.0.1:51347",
+					"172.18.0.1:51347",
+					"172.19.0.1:51347",
+					"172.20.0.1:51347",
+					"172.21.0.1:51347",
+					"172.22.0.1:51347",
+					"172.23.0.1:51347",
+					"172.24.0.1:51347",
+					"172.25.0.1:51347",
+					"172.26.0.1:51347",
+					"172.27.0.1:51347",
+					"172.28.0.1:51347"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:25:01.694585935Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4911415734779420,
+				"StableID":   "nwJW8fZPMf11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a35ed5a6673587fb5a0a1a04d02e4797e00124b4ef17eb052758c4adde12e232",
+				"DiscoKey":   "discokey:616122b0d87095d607218d9afb941629599e5f2d1958837f66276d16e575543c",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51664",
+					"10.65.0.27:51664",
+					"172.17.0.1:51664",
+					"172.18.0.1:51664",
+					"172.19.0.1:51664",
+					"172.20.0.1:51664",
+					"172.21.0.1:51664",
+					"172.22.0.1:51664",
+					"172.23.0.1:51664",
+					"172.24.0.1:51664",
+					"172.25.0.1:51664",
+					"172.26.0.1:51664",
+					"172.27.0.1:51664",
+					"172.28.0.1:51664"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:25:02.221499655Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8500624626227658,
+				"StableID":   "nHvVCgzwN921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06edbf91eb3ed22390fb155c2c3f4b29a20ca960e48cd2fe0102f64b3598b95c",
+				"DiscoKey":   "discokey:aad7c92a930aa89b46a180ac2de0219e76fe01418f9646d5fdb4f786cdf71b7b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35814",
+					"10.65.0.27:35814",
+					"172.17.0.1:35814",
+					"172.18.0.1:35814",
+					"172.19.0.1:35814",
+					"172.20.0.1:35814",
+					"172.21.0.1:35814",
+					"172.22.0.1:35814",
+					"172.23.0.1:35814",
+					"172.24.0.1:35814",
+					"172.25.0.1:35814",
+					"172.26.0.1:35814",
+					"172.27.0.1:35814",
+					"172.28.0.1:35814"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:25:02.753722365Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1833936728053849,
+				"StableID":   "n8JwdfQbKF11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4ac4692d470556d42f3f9d60a06f76a58452b1337fdec16e3a9838624751253",
+				"DiscoKey":   "discokey:9d2eaceeeb7d9c286601d66c410db58faf4b79837cfdfff0dd71db7eb418030c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53948",
+					"10.65.0.27:53948",
+					"172.17.0.1:53948",
+					"172.18.0.1:53948",
+					"172.19.0.1:53948",
+					"172.20.0.1:53948",
+					"172.21.0.1:53948",
+					"172.22.0.1:53948",
+					"172.23.0.1:53948",
+					"172.24.0.1:53948",
+					"172.25.0.1:53948",
+					"172.26.0.1:53948",
+					"172.27.0.1:53948",
+					"172.28.0.1:53948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:25:03.362885203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8916891682166105,
+				"StableID":   "nayXVCdUdC21CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7396a8e888bab44894aad53453f03dcc72e221b3ceacf0b3d64b70718c10397f",
+				"DiscoKey":   "discokey:69257e4deb9e19803fae62e451670f1fd3fe61b0701827622f2345839e887e31",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:39392",
+					"10.65.0.27:39392",
+					"172.17.0.1:39392",
+					"172.18.0.1:39392",
+					"172.19.0.1:39392",
+					"172.20.0.1:39392",
+					"172.21.0.1:39392",
+					"172.22.0.1:39392",
+					"172.23.0.1:39392",
+					"172.24.0.1:39392",
+					"172.25.0.1:39392",
+					"172.26.0.1:39392",
+					"172.27.0.1:39392",
+					"172.28.0.1:39392"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:25:03.823761506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3571740558468309,
+				"StableID":   "nzFTJwZetU11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f1a595f39e675a814bb45e8ef0eea10d795175ef850c32620bf1bf9506171f0e",
+				"DiscoKey":   "discokey:061847f57788a4bebc9c47608e46578df9d315d7ac49e0234e7f8d5f60413016",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:56939",
+					"10.65.0.27:56939",
+					"172.17.0.1:56939",
+					"172.18.0.1:56939",
+					"172.19.0.1:56939",
+					"172.20.0.1:56939",
+					"172.21.0.1:56939",
+					"172.22.0.1:56939",
+					"172.23.0.1:56939",
+					"172.24.0.1:56939",
+					"172.25.0.1:56939",
+					"172.26.0.1:56939",
+					"172.27.0.1:56939",
+					"172.28.0.1:56939"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:25:04.395397488Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4425484544229752,
+				"StableID":   "nfLCpXyJZb11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:827790f023e92b68fba0a68dd08e08a55e2237015cd17fba5f99c71bb5250757",
+				"DiscoKey":   "discokey:7f1bc9df669823b23999208b378ab60dd73cf61507878580423ad35a7642ca11",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50699",
+					"10.65.0.27:50699",
+					"172.17.0.1:50699",
+					"172.18.0.1:50699",
+					"172.19.0.1:50699",
+					"172.20.0.1:50699",
+					"172.21.0.1:50699",
+					"172.22.0.1:50699",
+					"172.23.0.1:50699",
+					"172.24.0.1:50699",
+					"172.25.0.1:50699",
+					"172.26.0.1:50699",
+					"172.27.0.1:50699",
+					"172.28.0.1:50699"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:25:04.904792855Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7025241854797289,
+				"StableID":   "nWX5u4Ckrw11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2c0ec942bf61a2a90eeacfe4925005a662c17e91b350e3e74bbd3e5e758b639",
+				"DiscoKey":   "discokey:decf0e5cbfefeb892ca3bee860ea419e05f6bbb97a944741661991384fdb7e75",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37443",
+					"10.65.0.27:37443",
+					"172.17.0.1:37443",
+					"172.18.0.1:37443",
+					"172.19.0.1:37443",
+					"172.20.0.1:37443",
+					"172.21.0.1:37443",
+					"172.22.0.1:37443",
+					"172.23.0.1:37443",
+					"172.24.0.1:37443",
+					"172.25.0.1:37443",
+					"172.26.0.1:37443",
+					"172.27.0.1:37443",
+					"172.28.0.1:37443"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:25:05.979820657Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5187642462783807,
+				"StableID":   "n2LyB7aVWh11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4657a71f34c78df771f1f45e9e45bdd6d62e633fdb4b25b05812361ab22ce93d",
+				"DiscoKey":   "discokey:609aa9d2ed0bc217b56060ec3565a4010763a35a88b658c697dcee707074ed6f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:48858",
+					"10.65.0.27:48858",
+					"172.17.0.1:48858",
+					"172.18.0.1:48858",
+					"172.19.0.1:48858",
+					"172.20.0.1:48858",
+					"172.21.0.1:48858",
+					"172.22.0.1:48858",
+					"172.23.0.1:48858",
+					"172.24.0.1:48858",
+					"172.25.0.1:48858",
+					"172.26.0.1:48858",
+					"172.27.0.1:48858",
+					"172.28.0.1:48858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:25:06.511793624Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8893129674967036,
+				"StableID":   "nHbXHKSiSC21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90e1c8e418c74a15316c5382799838ea1f2355157bd129ac34e0f75d78f4572f",
+				"DiscoKey":   "discokey:7eabf39cbd7e2d3bc60a8e36c0e71262c3c5e436c53669a241166a454def3b06",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38891",
+					"10.65.0.27:38891",
+					"172.17.0.1:38891",
+					"172.18.0.1:38891",
+					"172.19.0.1:38891",
+					"172.20.0.1:38891",
+					"172.21.0.1:38891",
+					"172.22.0.1:38891",
+					"172.23.0.1:38891",
+					"172.24.0.1:38891",
+					"172.25.0.1:38891",
+					"172.26.0.1:38891",
+					"172.27.0.1:38891",
+					"172.28.0.1:38891"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:25:07.062390075Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3566739387837422,
+				"StableID":   "n7siyLCPrU11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c50af58ec7631da2d9fb93f381d3ef00558a79c3ddff106abdb731b28a292045",
+				"DiscoKey":   "discokey:d55a9a8c3cdd8905df9995e60657c20f92cdea45279a7acfa7151a8b8f737456",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36435",
+					"10.65.0.27:36435",
+					"172.17.0.1:36435",
+					"172.18.0.1:36435",
+					"172.19.0.1:36435",
+					"172.20.0.1:36435",
+					"172.21.0.1:36435",
+					"172.22.0.1:36435",
+					"172.23.0.1:36435",
+					"172.24.0.1:36435",
+					"172.25.0.1:36435",
+					"172.26.0.1:36435",
+					"172.27.0.1:36435",
+					"172.28.0.1:36435"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:25:07.591294584Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5747196086914171,
+				"StableID":   "nkmRrY6vsm11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:761ed02ba5ec891d31c733faea100d9b97cb2198399bac790e4ff5e144759974",
+				"KeyExpiry":  "2026-11-09T09:25:08Z",
+				"DiscoKey":   "discokey:4d7f7844bdfd4e84f6911d922f22f859b56d90898ceab7c4bf12028eb12e8a0e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:42656",
+					"10.65.0.27:42656",
+					"172.17.0.1:42656",
+					"172.18.0.1:42656",
+					"172.19.0.1:42656",
+					"172.20.0.1:42656",
+					"172.21.0.1:42656",
+					"172.22.0.1:42656",
+					"172.23.0.1:42656",
+					"172.24.0.1:42656",
+					"172.25.0.1:42656",
+					"172.26.0.1:42656",
+					"172.27.0.1:42656",
+					"172.28.0.1:42656"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:25:08.122619339Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1118669416952970,
+				"StableID":   "nTu1gpYej911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5e0da8da6fca608299c957b185242f8e3f4d8c577f50a403fd129ce4f6683203",
+				"KeyExpiry":  "2026-11-09T09:25:08Z",
+				"DiscoKey":   "discokey:d440fb256198020553b4f2eb0bdb3303b74c122673c4f11887d71d5b10f1c75c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59342",
+					"10.65.0.27:59342",
+					"172.17.0.1:59342",
+					"172.18.0.1:59342",
+					"172.19.0.1:59342",
+					"172.20.0.1:59342",
+					"172.21.0.1:59342",
+					"172.22.0.1:59342",
+					"172.23.0.1:59342",
+					"172.24.0.1:59342",
+					"172.25.0.1:59342",
+					"172.26.0.1:59342",
+					"172.27.0.1:59342",
+					"172.28.0.1:59342"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:25:08.655311712Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8926419916096414,
+				"StableID":   "njmzt3vnhC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:cb4ba8073d974c29b0a43072c97be73251548d8cb6f1701240a43a8a0fbb227f",
+				"KeyExpiry":  "2026-11-09T09:25:09Z",
+				"DiscoKey":   "discokey:a13760fbbdedb482e330b42110a2dbfe37899ac465cf55b34483336eb9761d72",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58696",
+					"10.65.0.27:58696",
+					"172.17.0.1:58696",
+					"172.18.0.1:58696",
+					"172.19.0.1:58696",
+					"172.20.0.1:58696",
+					"172.21.0.1:58696",
+					"172.22.0.1:58696",
+					"172.23.0.1:58696",
+					"172.24.0.1:58696",
+					"172.25.0.1:58696",
+					"172.26.0.1:58696",
+					"172.27.0.1:58696",
+					"172.28.0.1:58696"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:25:09.187973528Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1770706487984919": {
+				"ID":          1770706487984919,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5747196086914171,
+				"StableID":   "nkmRrY6vsm11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:761ed02ba5ec891d31c733faea100d9b97cb2198399bac790e4ff5e144759974",
+				"KeyExpiry":  "2026-11-09T09:25:08Z",
+				"DiscoKey":   "discokey:4d7f7844bdfd4e84f6911d922f22f859b56d90898ceab7c4bf12028eb12e8a0e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:42656",
+					"10.65.0.27:42656",
+					"172.17.0.1:42656",
+					"172.18.0.1:42656",
+					"172.19.0.1:42656",
+					"172.20.0.1:42656",
+					"172.21.0.1:42656",
+					"172.22.0.1:42656",
+					"172.23.0.1:42656",
+					"172.24.0.1:42656",
+					"172.25.0.1:42656",
+					"172.26.0.1:42656",
+					"172.27.0.1:42656",
+					"172.28.0.1:42656"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:25:08.122619339Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:761ed02ba5ec891d31c733faea100d9b97cb2198399bac790e4ff5e144759974",
+			"MachineKey": "mkey:a41bba7c09e64db880b31094585d159a432cf000f747b4c0a831cf509f5a3415",
+			"Peers": [{
+				"ID":         1111701973359323,
+				"StableID":   "nxbPYVXVg911CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e451839222d4d0713b74c367f2714ddd0bbc70c54470b84db70ade576bcb3674",
+				"DiscoKey":   "discokey:8594fe0f810f0cb338cc9b9eddc9d062a26c3e1408a5f7b137bbf475a2fb4d18",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51347",
+					"10.65.0.27:51347",
+					"172.17.0.1:51347",
+					"172.18.0.1:51347",
+					"172.19.0.1:51347",
+					"172.20.0.1:51347",
+					"172.21.0.1:51347",
+					"172.22.0.1:51347",
+					"172.23.0.1:51347",
+					"172.24.0.1:51347",
+					"172.25.0.1:51347",
+					"172.26.0.1:51347",
+					"172.27.0.1:51347",
+					"172.28.0.1:51347"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:25:01.694585935Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4911415734779420,
+				"StableID":   "nwJW8fZPMf11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a35ed5a6673587fb5a0a1a04d02e4797e00124b4ef17eb052758c4adde12e232",
+				"DiscoKey":   "discokey:616122b0d87095d607218d9afb941629599e5f2d1958837f66276d16e575543c",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51664",
+					"10.65.0.27:51664",
+					"172.17.0.1:51664",
+					"172.18.0.1:51664",
+					"172.19.0.1:51664",
+					"172.20.0.1:51664",
+					"172.21.0.1:51664",
+					"172.22.0.1:51664",
+					"172.23.0.1:51664",
+					"172.24.0.1:51664",
+					"172.25.0.1:51664",
+					"172.26.0.1:51664",
+					"172.27.0.1:51664",
+					"172.28.0.1:51664"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:25:02.221499655Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8500624626227658,
+				"StableID":   "nHvVCgzwN921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06edbf91eb3ed22390fb155c2c3f4b29a20ca960e48cd2fe0102f64b3598b95c",
+				"DiscoKey":   "discokey:aad7c92a930aa89b46a180ac2de0219e76fe01418f9646d5fdb4f786cdf71b7b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35814",
+					"10.65.0.27:35814",
+					"172.17.0.1:35814",
+					"172.18.0.1:35814",
+					"172.19.0.1:35814",
+					"172.20.0.1:35814",
+					"172.21.0.1:35814",
+					"172.22.0.1:35814",
+					"172.23.0.1:35814",
+					"172.24.0.1:35814",
+					"172.25.0.1:35814",
+					"172.26.0.1:35814",
+					"172.27.0.1:35814",
+					"172.28.0.1:35814"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:25:02.753722365Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1833936728053849,
+				"StableID":   "n8JwdfQbKF11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4ac4692d470556d42f3f9d60a06f76a58452b1337fdec16e3a9838624751253",
+				"DiscoKey":   "discokey:9d2eaceeeb7d9c286601d66c410db58faf4b79837cfdfff0dd71db7eb418030c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53948",
+					"10.65.0.27:53948",
+					"172.17.0.1:53948",
+					"172.18.0.1:53948",
+					"172.19.0.1:53948",
+					"172.20.0.1:53948",
+					"172.21.0.1:53948",
+					"172.22.0.1:53948",
+					"172.23.0.1:53948",
+					"172.24.0.1:53948",
+					"172.25.0.1:53948",
+					"172.26.0.1:53948",
+					"172.27.0.1:53948",
+					"172.28.0.1:53948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:25:03.362885203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8916891682166105,
+				"StableID":   "nayXVCdUdC21CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7396a8e888bab44894aad53453f03dcc72e221b3ceacf0b3d64b70718c10397f",
+				"DiscoKey":   "discokey:69257e4deb9e19803fae62e451670f1fd3fe61b0701827622f2345839e887e31",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:39392",
+					"10.65.0.27:39392",
+					"172.17.0.1:39392",
+					"172.18.0.1:39392",
+					"172.19.0.1:39392",
+					"172.20.0.1:39392",
+					"172.21.0.1:39392",
+					"172.22.0.1:39392",
+					"172.23.0.1:39392",
+					"172.24.0.1:39392",
+					"172.25.0.1:39392",
+					"172.26.0.1:39392",
+					"172.27.0.1:39392",
+					"172.28.0.1:39392"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:25:03.823761506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3571740558468309,
+				"StableID":   "nzFTJwZetU11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f1a595f39e675a814bb45e8ef0eea10d795175ef850c32620bf1bf9506171f0e",
+				"DiscoKey":   "discokey:061847f57788a4bebc9c47608e46578df9d315d7ac49e0234e7f8d5f60413016",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:56939",
+					"10.65.0.27:56939",
+					"172.17.0.1:56939",
+					"172.18.0.1:56939",
+					"172.19.0.1:56939",
+					"172.20.0.1:56939",
+					"172.21.0.1:56939",
+					"172.22.0.1:56939",
+					"172.23.0.1:56939",
+					"172.24.0.1:56939",
+					"172.25.0.1:56939",
+					"172.26.0.1:56939",
+					"172.27.0.1:56939",
+					"172.28.0.1:56939"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:25:04.395397488Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4425484544229752,
+				"StableID":   "nfLCpXyJZb11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:827790f023e92b68fba0a68dd08e08a55e2237015cd17fba5f99c71bb5250757",
+				"DiscoKey":   "discokey:7f1bc9df669823b23999208b378ab60dd73cf61507878580423ad35a7642ca11",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50699",
+					"10.65.0.27:50699",
+					"172.17.0.1:50699",
+					"172.18.0.1:50699",
+					"172.19.0.1:50699",
+					"172.20.0.1:50699",
+					"172.21.0.1:50699",
+					"172.22.0.1:50699",
+					"172.23.0.1:50699",
+					"172.24.0.1:50699",
+					"172.25.0.1:50699",
+					"172.26.0.1:50699",
+					"172.27.0.1:50699",
+					"172.28.0.1:50699"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:25:04.904792855Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1770706487984919,
+				"StableID":   "nYHwqVTxpE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e779f6731d4c1c49201d941277821cbd0c66668270bd929ac782f4d4b8210572",
+				"DiscoKey":   "discokey:27b9b505ae1072e38ca8d662cc96cf2dd56e65363f2ee504621b48563b2c6648",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:60880",
+					"10.65.0.27:60880",
+					"172.17.0.1:60880",
+					"172.18.0.1:60880",
+					"172.19.0.1:60880",
+					"172.20.0.1:60880",
+					"172.21.0.1:60880",
+					"172.22.0.1:60880",
+					"172.23.0.1:60880",
+					"172.24.0.1:60880",
+					"172.25.0.1:60880",
+					"172.26.0.1:60880",
+					"172.27.0.1:60880",
+					"172.28.0.1:60880"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:25:05.445033397Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7025241854797289,
+				"StableID":   "nWX5u4Ckrw11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2c0ec942bf61a2a90eeacfe4925005a662c17e91b350e3e74bbd3e5e758b639",
+				"DiscoKey":   "discokey:decf0e5cbfefeb892ca3bee860ea419e05f6bbb97a944741661991384fdb7e75",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37443",
+					"10.65.0.27:37443",
+					"172.17.0.1:37443",
+					"172.18.0.1:37443",
+					"172.19.0.1:37443",
+					"172.20.0.1:37443",
+					"172.21.0.1:37443",
+					"172.22.0.1:37443",
+					"172.23.0.1:37443",
+					"172.24.0.1:37443",
+					"172.25.0.1:37443",
+					"172.26.0.1:37443",
+					"172.27.0.1:37443",
+					"172.28.0.1:37443"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:25:05.979820657Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5187642462783807,
+				"StableID":   "n2LyB7aVWh11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4657a71f34c78df771f1f45e9e45bdd6d62e633fdb4b25b05812361ab22ce93d",
+				"DiscoKey":   "discokey:609aa9d2ed0bc217b56060ec3565a4010763a35a88b658c697dcee707074ed6f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:48858",
+					"10.65.0.27:48858",
+					"172.17.0.1:48858",
+					"172.18.0.1:48858",
+					"172.19.0.1:48858",
+					"172.20.0.1:48858",
+					"172.21.0.1:48858",
+					"172.22.0.1:48858",
+					"172.23.0.1:48858",
+					"172.24.0.1:48858",
+					"172.25.0.1:48858",
+					"172.26.0.1:48858",
+					"172.27.0.1:48858",
+					"172.28.0.1:48858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:25:06.511793624Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8893129674967036,
+				"StableID":   "nHbXHKSiSC21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90e1c8e418c74a15316c5382799838ea1f2355157bd129ac34e0f75d78f4572f",
+				"DiscoKey":   "discokey:7eabf39cbd7e2d3bc60a8e36c0e71262c3c5e436c53669a241166a454def3b06",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38891",
+					"10.65.0.27:38891",
+					"172.17.0.1:38891",
+					"172.18.0.1:38891",
+					"172.19.0.1:38891",
+					"172.20.0.1:38891",
+					"172.21.0.1:38891",
+					"172.22.0.1:38891",
+					"172.23.0.1:38891",
+					"172.24.0.1:38891",
+					"172.25.0.1:38891",
+					"172.26.0.1:38891",
+					"172.27.0.1:38891",
+					"172.28.0.1:38891"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:25:07.062390075Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3566739387837422,
+				"StableID":   "n7siyLCPrU11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c50af58ec7631da2d9fb93f381d3ef00558a79c3ddff106abdb731b28a292045",
+				"DiscoKey":   "discokey:d55a9a8c3cdd8905df9995e60657c20f92cdea45279a7acfa7151a8b8f737456",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36435",
+					"10.65.0.27:36435",
+					"172.17.0.1:36435",
+					"172.18.0.1:36435",
+					"172.19.0.1:36435",
+					"172.20.0.1:36435",
+					"172.21.0.1:36435",
+					"172.22.0.1:36435",
+					"172.23.0.1:36435",
+					"172.24.0.1:36435",
+					"172.25.0.1:36435",
+					"172.26.0.1:36435",
+					"172.27.0.1:36435",
+					"172.28.0.1:36435"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:25:07.591294584Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1118669416952970,
+				"StableID":   "nTu1gpYej911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5e0da8da6fca608299c957b185242f8e3f4d8c577f50a403fd129ce4f6683203",
+				"KeyExpiry":  "2026-11-09T09:25:08Z",
+				"DiscoKey":   "discokey:d440fb256198020553b4f2eb0bdb3303b74c122673c4f11887d71d5b10f1c75c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59342",
+					"10.65.0.27:59342",
+					"172.17.0.1:59342",
+					"172.18.0.1:59342",
+					"172.19.0.1:59342",
+					"172.20.0.1:59342",
+					"172.21.0.1:59342",
+					"172.22.0.1:59342",
+					"172.23.0.1:59342",
+					"172.24.0.1:59342",
+					"172.25.0.1:59342",
+					"172.26.0.1:59342",
+					"172.27.0.1:59342",
+					"172.28.0.1:59342"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:25:08.655311712Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8926419916096414,
+				"StableID":   "njmzt3vnhC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:cb4ba8073d974c29b0a43072c97be73251548d8cb6f1701240a43a8a0fbb227f",
+				"KeyExpiry":  "2026-11-09T09:25:09Z",
+				"DiscoKey":   "discokey:a13760fbbdedb482e330b42110a2dbfe37899ac465cf55b34483336eb9761d72",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58696",
+					"10.65.0.27:58696",
+					"172.17.0.1:58696",
+					"172.18.0.1:58696",
+					"172.19.0.1:58696",
+					"172.20.0.1:58696",
+					"172.21.0.1:58696",
+					"172.22.0.1:58696",
+					"172.23.0.1:58696",
+					"172.24.0.1:58696",
+					"172.25.0.1:58696",
+					"172.26.0.1:58696",
+					"172.27.0.1:58696",
+					"172.28.0.1:58696"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:25:09.187973528Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8893129674967036,
+				"StableID":   "nHbXHKSiSC21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       8893129674967036,
+				"Key":        "nodekey:90e1c8e418c74a15316c5382799838ea1f2355157bd129ac34e0f75d78f4572f",
+				"DiscoKey":   "discokey:7eabf39cbd7e2d3bc60a8e36c0e71262c3c5e436c53669a241166a454def3b06",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38891",
+					"10.65.0.27:38891",
+					"172.17.0.1:38891",
+					"172.18.0.1:38891",
+					"172.19.0.1:38891",
+					"172.20.0.1:38891",
+					"172.21.0.1:38891",
+					"172.22.0.1:38891",
+					"172.23.0.1:38891",
+					"172.24.0.1:38891",
+					"172.25.0.1:38891",
+					"172.26.0.1:38891",
+					"172.27.0.1:38891",
+					"172.28.0.1:38891"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:25:07.062390075Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:90e1c8e418c74a15316c5382799838ea1f2355157bd129ac34e0f75d78f4572f",
+			"MachineKey": "mkey:0ddf367cb4c4237c12462c70403fcf28c13c3eb5fee2cebcdf5a4ddbf2fcd20a",
+			"Peers": [{
+				"ID":         1111701973359323,
+				"StableID":   "nxbPYVXVg911CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e451839222d4d0713b74c367f2714ddd0bbc70c54470b84db70ade576bcb3674",
+				"DiscoKey":   "discokey:8594fe0f810f0cb338cc9b9eddc9d062a26c3e1408a5f7b137bbf475a2fb4d18",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51347",
+					"10.65.0.27:51347",
+					"172.17.0.1:51347",
+					"172.18.0.1:51347",
+					"172.19.0.1:51347",
+					"172.20.0.1:51347",
+					"172.21.0.1:51347",
+					"172.22.0.1:51347",
+					"172.23.0.1:51347",
+					"172.24.0.1:51347",
+					"172.25.0.1:51347",
+					"172.26.0.1:51347",
+					"172.27.0.1:51347",
+					"172.28.0.1:51347"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:25:01.694585935Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4911415734779420,
+				"StableID":   "nwJW8fZPMf11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a35ed5a6673587fb5a0a1a04d02e4797e00124b4ef17eb052758c4adde12e232",
+				"DiscoKey":   "discokey:616122b0d87095d607218d9afb941629599e5f2d1958837f66276d16e575543c",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51664",
+					"10.65.0.27:51664",
+					"172.17.0.1:51664",
+					"172.18.0.1:51664",
+					"172.19.0.1:51664",
+					"172.20.0.1:51664",
+					"172.21.0.1:51664",
+					"172.22.0.1:51664",
+					"172.23.0.1:51664",
+					"172.24.0.1:51664",
+					"172.25.0.1:51664",
+					"172.26.0.1:51664",
+					"172.27.0.1:51664",
+					"172.28.0.1:51664"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:25:02.221499655Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8500624626227658,
+				"StableID":   "nHvVCgzwN921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06edbf91eb3ed22390fb155c2c3f4b29a20ca960e48cd2fe0102f64b3598b95c",
+				"DiscoKey":   "discokey:aad7c92a930aa89b46a180ac2de0219e76fe01418f9646d5fdb4f786cdf71b7b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35814",
+					"10.65.0.27:35814",
+					"172.17.0.1:35814",
+					"172.18.0.1:35814",
+					"172.19.0.1:35814",
+					"172.20.0.1:35814",
+					"172.21.0.1:35814",
+					"172.22.0.1:35814",
+					"172.23.0.1:35814",
+					"172.24.0.1:35814",
+					"172.25.0.1:35814",
+					"172.26.0.1:35814",
+					"172.27.0.1:35814",
+					"172.28.0.1:35814"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:25:02.753722365Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1833936728053849,
+				"StableID":   "n8JwdfQbKF11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4ac4692d470556d42f3f9d60a06f76a58452b1337fdec16e3a9838624751253",
+				"DiscoKey":   "discokey:9d2eaceeeb7d9c286601d66c410db58faf4b79837cfdfff0dd71db7eb418030c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53948",
+					"10.65.0.27:53948",
+					"172.17.0.1:53948",
+					"172.18.0.1:53948",
+					"172.19.0.1:53948",
+					"172.20.0.1:53948",
+					"172.21.0.1:53948",
+					"172.22.0.1:53948",
+					"172.23.0.1:53948",
+					"172.24.0.1:53948",
+					"172.25.0.1:53948",
+					"172.26.0.1:53948",
+					"172.27.0.1:53948",
+					"172.28.0.1:53948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:25:03.362885203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8916891682166105,
+				"StableID":   "nayXVCdUdC21CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7396a8e888bab44894aad53453f03dcc72e221b3ceacf0b3d64b70718c10397f",
+				"DiscoKey":   "discokey:69257e4deb9e19803fae62e451670f1fd3fe61b0701827622f2345839e887e31",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:39392",
+					"10.65.0.27:39392",
+					"172.17.0.1:39392",
+					"172.18.0.1:39392",
+					"172.19.0.1:39392",
+					"172.20.0.1:39392",
+					"172.21.0.1:39392",
+					"172.22.0.1:39392",
+					"172.23.0.1:39392",
+					"172.24.0.1:39392",
+					"172.25.0.1:39392",
+					"172.26.0.1:39392",
+					"172.27.0.1:39392",
+					"172.28.0.1:39392"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:25:03.823761506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3571740558468309,
+				"StableID":   "nzFTJwZetU11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f1a595f39e675a814bb45e8ef0eea10d795175ef850c32620bf1bf9506171f0e",
+				"DiscoKey":   "discokey:061847f57788a4bebc9c47608e46578df9d315d7ac49e0234e7f8d5f60413016",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:56939",
+					"10.65.0.27:56939",
+					"172.17.0.1:56939",
+					"172.18.0.1:56939",
+					"172.19.0.1:56939",
+					"172.20.0.1:56939",
+					"172.21.0.1:56939",
+					"172.22.0.1:56939",
+					"172.23.0.1:56939",
+					"172.24.0.1:56939",
+					"172.25.0.1:56939",
+					"172.26.0.1:56939",
+					"172.27.0.1:56939",
+					"172.28.0.1:56939"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:25:04.395397488Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4425484544229752,
+				"StableID":   "nfLCpXyJZb11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:827790f023e92b68fba0a68dd08e08a55e2237015cd17fba5f99c71bb5250757",
+				"DiscoKey":   "discokey:7f1bc9df669823b23999208b378ab60dd73cf61507878580423ad35a7642ca11",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50699",
+					"10.65.0.27:50699",
+					"172.17.0.1:50699",
+					"172.18.0.1:50699",
+					"172.19.0.1:50699",
+					"172.20.0.1:50699",
+					"172.21.0.1:50699",
+					"172.22.0.1:50699",
+					"172.23.0.1:50699",
+					"172.24.0.1:50699",
+					"172.25.0.1:50699",
+					"172.26.0.1:50699",
+					"172.27.0.1:50699",
+					"172.28.0.1:50699"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:25:04.904792855Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1770706487984919,
+				"StableID":   "nYHwqVTxpE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e779f6731d4c1c49201d941277821cbd0c66668270bd929ac782f4d4b8210572",
+				"DiscoKey":   "discokey:27b9b505ae1072e38ca8d662cc96cf2dd56e65363f2ee504621b48563b2c6648",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:60880",
+					"10.65.0.27:60880",
+					"172.17.0.1:60880",
+					"172.18.0.1:60880",
+					"172.19.0.1:60880",
+					"172.20.0.1:60880",
+					"172.21.0.1:60880",
+					"172.22.0.1:60880",
+					"172.23.0.1:60880",
+					"172.24.0.1:60880",
+					"172.25.0.1:60880",
+					"172.26.0.1:60880",
+					"172.27.0.1:60880",
+					"172.28.0.1:60880"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:25:05.445033397Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7025241854797289,
+				"StableID":   "nWX5u4Ckrw11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2c0ec942bf61a2a90eeacfe4925005a662c17e91b350e3e74bbd3e5e758b639",
+				"DiscoKey":   "discokey:decf0e5cbfefeb892ca3bee860ea419e05f6bbb97a944741661991384fdb7e75",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37443",
+					"10.65.0.27:37443",
+					"172.17.0.1:37443",
+					"172.18.0.1:37443",
+					"172.19.0.1:37443",
+					"172.20.0.1:37443",
+					"172.21.0.1:37443",
+					"172.22.0.1:37443",
+					"172.23.0.1:37443",
+					"172.24.0.1:37443",
+					"172.25.0.1:37443",
+					"172.26.0.1:37443",
+					"172.27.0.1:37443",
+					"172.28.0.1:37443"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:25:05.979820657Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5187642462783807,
+				"StableID":   "n2LyB7aVWh11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4657a71f34c78df771f1f45e9e45bdd6d62e633fdb4b25b05812361ab22ce93d",
+				"DiscoKey":   "discokey:609aa9d2ed0bc217b56060ec3565a4010763a35a88b658c697dcee707074ed6f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:48858",
+					"10.65.0.27:48858",
+					"172.17.0.1:48858",
+					"172.18.0.1:48858",
+					"172.19.0.1:48858",
+					"172.20.0.1:48858",
+					"172.21.0.1:48858",
+					"172.22.0.1:48858",
+					"172.23.0.1:48858",
+					"172.24.0.1:48858",
+					"172.25.0.1:48858",
+					"172.26.0.1:48858",
+					"172.27.0.1:48858",
+					"172.28.0.1:48858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:25:06.511793624Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3566739387837422,
+				"StableID":   "n7siyLCPrU11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c50af58ec7631da2d9fb93f381d3ef00558a79c3ddff106abdb731b28a292045",
+				"DiscoKey":   "discokey:d55a9a8c3cdd8905df9995e60657c20f92cdea45279a7acfa7151a8b8f737456",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36435",
+					"10.65.0.27:36435",
+					"172.17.0.1:36435",
+					"172.18.0.1:36435",
+					"172.19.0.1:36435",
+					"172.20.0.1:36435",
+					"172.21.0.1:36435",
+					"172.22.0.1:36435",
+					"172.23.0.1:36435",
+					"172.24.0.1:36435",
+					"172.25.0.1:36435",
+					"172.26.0.1:36435",
+					"172.27.0.1:36435",
+					"172.28.0.1:36435"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:25:07.591294584Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5747196086914171,
+				"StableID":   "nkmRrY6vsm11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:761ed02ba5ec891d31c733faea100d9b97cb2198399bac790e4ff5e144759974",
+				"KeyExpiry":  "2026-11-09T09:25:08Z",
+				"DiscoKey":   "discokey:4d7f7844bdfd4e84f6911d922f22f859b56d90898ceab7c4bf12028eb12e8a0e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:42656",
+					"10.65.0.27:42656",
+					"172.17.0.1:42656",
+					"172.18.0.1:42656",
+					"172.19.0.1:42656",
+					"172.20.0.1:42656",
+					"172.21.0.1:42656",
+					"172.22.0.1:42656",
+					"172.23.0.1:42656",
+					"172.24.0.1:42656",
+					"172.25.0.1:42656",
+					"172.26.0.1:42656",
+					"172.27.0.1:42656",
+					"172.28.0.1:42656"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:25:08.122619339Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1118669416952970,
+				"StableID":   "nTu1gpYej911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5e0da8da6fca608299c957b185242f8e3f4d8c577f50a403fd129ce4f6683203",
+				"KeyExpiry":  "2026-11-09T09:25:08Z",
+				"DiscoKey":   "discokey:d440fb256198020553b4f2eb0bdb3303b74c122673c4f11887d71d5b10f1c75c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59342",
+					"10.65.0.27:59342",
+					"172.17.0.1:59342",
+					"172.18.0.1:59342",
+					"172.19.0.1:59342",
+					"172.20.0.1:59342",
+					"172.21.0.1:59342",
+					"172.22.0.1:59342",
+					"172.23.0.1:59342",
+					"172.24.0.1:59342",
+					"172.25.0.1:59342",
+					"172.26.0.1:59342",
+					"172.27.0.1:59342",
+					"172.28.0.1:59342"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:25:08.655311712Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8926419916096414,
+				"StableID":   "njmzt3vnhC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:cb4ba8073d974c29b0a43072c97be73251548d8cb6f1701240a43a8a0fbb227f",
+				"KeyExpiry":  "2026-11-09T09:25:09Z",
+				"DiscoKey":   "discokey:a13760fbbdedb482e330b42110a2dbfe37899ac465cf55b34483336eb9761d72",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58696",
+					"10.65.0.27:58696",
+					"172.17.0.1:58696",
+					"172.18.0.1:58696",
+					"172.19.0.1:58696",
+					"172.20.0.1:58696",
+					"172.21.0.1:58696",
+					"172.22.0.1:58696",
+					"172.23.0.1:58696",
+					"172.24.0.1:58696",
+					"172.25.0.1:58696",
+					"172.26.0.1:58696",
+					"172.27.0.1:58696",
+					"172.28.0.1:58696"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:25:09.187973528Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8893129674967036": {
+				"ID":          8893129674967036,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4911415734779420,
+				"StableID":   "nwJW8fZPMf11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       4911415734779420,
+				"Key":        "nodekey:a35ed5a6673587fb5a0a1a04d02e4797e00124b4ef17eb052758c4adde12e232",
+				"DiscoKey":   "discokey:616122b0d87095d607218d9afb941629599e5f2d1958837f66276d16e575543c",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51664",
+					"10.65.0.27:51664",
+					"172.17.0.1:51664",
+					"172.18.0.1:51664",
+					"172.19.0.1:51664",
+					"172.20.0.1:51664",
+					"172.21.0.1:51664",
+					"172.22.0.1:51664",
+					"172.23.0.1:51664",
+					"172.24.0.1:51664",
+					"172.25.0.1:51664",
+					"172.26.0.1:51664",
+					"172.27.0.1:51664",
+					"172.28.0.1:51664"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:25:02.221499655Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a35ed5a6673587fb5a0a1a04d02e4797e00124b4ef17eb052758c4adde12e232",
+			"MachineKey": "mkey:209854344ca5b304603390fd6398591bed5a623c94c3fe936a3cc6bd488e5154",
+			"Peers": [{
+				"ID":         1111701973359323,
+				"StableID":   "nxbPYVXVg911CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e451839222d4d0713b74c367f2714ddd0bbc70c54470b84db70ade576bcb3674",
+				"DiscoKey":   "discokey:8594fe0f810f0cb338cc9b9eddc9d062a26c3e1408a5f7b137bbf475a2fb4d18",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51347",
+					"10.65.0.27:51347",
+					"172.17.0.1:51347",
+					"172.18.0.1:51347",
+					"172.19.0.1:51347",
+					"172.20.0.1:51347",
+					"172.21.0.1:51347",
+					"172.22.0.1:51347",
+					"172.23.0.1:51347",
+					"172.24.0.1:51347",
+					"172.25.0.1:51347",
+					"172.26.0.1:51347",
+					"172.27.0.1:51347",
+					"172.28.0.1:51347"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:25:01.694585935Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8500624626227658,
+				"StableID":   "nHvVCgzwN921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06edbf91eb3ed22390fb155c2c3f4b29a20ca960e48cd2fe0102f64b3598b95c",
+				"DiscoKey":   "discokey:aad7c92a930aa89b46a180ac2de0219e76fe01418f9646d5fdb4f786cdf71b7b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35814",
+					"10.65.0.27:35814",
+					"172.17.0.1:35814",
+					"172.18.0.1:35814",
+					"172.19.0.1:35814",
+					"172.20.0.1:35814",
+					"172.21.0.1:35814",
+					"172.22.0.1:35814",
+					"172.23.0.1:35814",
+					"172.24.0.1:35814",
+					"172.25.0.1:35814",
+					"172.26.0.1:35814",
+					"172.27.0.1:35814",
+					"172.28.0.1:35814"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:25:02.753722365Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1833936728053849,
+				"StableID":   "n8JwdfQbKF11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4ac4692d470556d42f3f9d60a06f76a58452b1337fdec16e3a9838624751253",
+				"DiscoKey":   "discokey:9d2eaceeeb7d9c286601d66c410db58faf4b79837cfdfff0dd71db7eb418030c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53948",
+					"10.65.0.27:53948",
+					"172.17.0.1:53948",
+					"172.18.0.1:53948",
+					"172.19.0.1:53948",
+					"172.20.0.1:53948",
+					"172.21.0.1:53948",
+					"172.22.0.1:53948",
+					"172.23.0.1:53948",
+					"172.24.0.1:53948",
+					"172.25.0.1:53948",
+					"172.26.0.1:53948",
+					"172.27.0.1:53948",
+					"172.28.0.1:53948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:25:03.362885203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8916891682166105,
+				"StableID":   "nayXVCdUdC21CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7396a8e888bab44894aad53453f03dcc72e221b3ceacf0b3d64b70718c10397f",
+				"DiscoKey":   "discokey:69257e4deb9e19803fae62e451670f1fd3fe61b0701827622f2345839e887e31",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:39392",
+					"10.65.0.27:39392",
+					"172.17.0.1:39392",
+					"172.18.0.1:39392",
+					"172.19.0.1:39392",
+					"172.20.0.1:39392",
+					"172.21.0.1:39392",
+					"172.22.0.1:39392",
+					"172.23.0.1:39392",
+					"172.24.0.1:39392",
+					"172.25.0.1:39392",
+					"172.26.0.1:39392",
+					"172.27.0.1:39392",
+					"172.28.0.1:39392"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:25:03.823761506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3571740558468309,
+				"StableID":   "nzFTJwZetU11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f1a595f39e675a814bb45e8ef0eea10d795175ef850c32620bf1bf9506171f0e",
+				"DiscoKey":   "discokey:061847f57788a4bebc9c47608e46578df9d315d7ac49e0234e7f8d5f60413016",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:56939",
+					"10.65.0.27:56939",
+					"172.17.0.1:56939",
+					"172.18.0.1:56939",
+					"172.19.0.1:56939",
+					"172.20.0.1:56939",
+					"172.21.0.1:56939",
+					"172.22.0.1:56939",
+					"172.23.0.1:56939",
+					"172.24.0.1:56939",
+					"172.25.0.1:56939",
+					"172.26.0.1:56939",
+					"172.27.0.1:56939",
+					"172.28.0.1:56939"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:25:04.395397488Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4425484544229752,
+				"StableID":   "nfLCpXyJZb11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:827790f023e92b68fba0a68dd08e08a55e2237015cd17fba5f99c71bb5250757",
+				"DiscoKey":   "discokey:7f1bc9df669823b23999208b378ab60dd73cf61507878580423ad35a7642ca11",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50699",
+					"10.65.0.27:50699",
+					"172.17.0.1:50699",
+					"172.18.0.1:50699",
+					"172.19.0.1:50699",
+					"172.20.0.1:50699",
+					"172.21.0.1:50699",
+					"172.22.0.1:50699",
+					"172.23.0.1:50699",
+					"172.24.0.1:50699",
+					"172.25.0.1:50699",
+					"172.26.0.1:50699",
+					"172.27.0.1:50699",
+					"172.28.0.1:50699"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:25:04.904792855Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1770706487984919,
+				"StableID":   "nYHwqVTxpE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e779f6731d4c1c49201d941277821cbd0c66668270bd929ac782f4d4b8210572",
+				"DiscoKey":   "discokey:27b9b505ae1072e38ca8d662cc96cf2dd56e65363f2ee504621b48563b2c6648",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:60880",
+					"10.65.0.27:60880",
+					"172.17.0.1:60880",
+					"172.18.0.1:60880",
+					"172.19.0.1:60880",
+					"172.20.0.1:60880",
+					"172.21.0.1:60880",
+					"172.22.0.1:60880",
+					"172.23.0.1:60880",
+					"172.24.0.1:60880",
+					"172.25.0.1:60880",
+					"172.26.0.1:60880",
+					"172.27.0.1:60880",
+					"172.28.0.1:60880"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:25:05.445033397Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7025241854797289,
+				"StableID":   "nWX5u4Ckrw11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2c0ec942bf61a2a90eeacfe4925005a662c17e91b350e3e74bbd3e5e758b639",
+				"DiscoKey":   "discokey:decf0e5cbfefeb892ca3bee860ea419e05f6bbb97a944741661991384fdb7e75",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37443",
+					"10.65.0.27:37443",
+					"172.17.0.1:37443",
+					"172.18.0.1:37443",
+					"172.19.0.1:37443",
+					"172.20.0.1:37443",
+					"172.21.0.1:37443",
+					"172.22.0.1:37443",
+					"172.23.0.1:37443",
+					"172.24.0.1:37443",
+					"172.25.0.1:37443",
+					"172.26.0.1:37443",
+					"172.27.0.1:37443",
+					"172.28.0.1:37443"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:25:05.979820657Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5187642462783807,
+				"StableID":   "n2LyB7aVWh11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4657a71f34c78df771f1f45e9e45bdd6d62e633fdb4b25b05812361ab22ce93d",
+				"DiscoKey":   "discokey:609aa9d2ed0bc217b56060ec3565a4010763a35a88b658c697dcee707074ed6f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:48858",
+					"10.65.0.27:48858",
+					"172.17.0.1:48858",
+					"172.18.0.1:48858",
+					"172.19.0.1:48858",
+					"172.20.0.1:48858",
+					"172.21.0.1:48858",
+					"172.22.0.1:48858",
+					"172.23.0.1:48858",
+					"172.24.0.1:48858",
+					"172.25.0.1:48858",
+					"172.26.0.1:48858",
+					"172.27.0.1:48858",
+					"172.28.0.1:48858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:25:06.511793624Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8893129674967036,
+				"StableID":   "nHbXHKSiSC21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90e1c8e418c74a15316c5382799838ea1f2355157bd129ac34e0f75d78f4572f",
+				"DiscoKey":   "discokey:7eabf39cbd7e2d3bc60a8e36c0e71262c3c5e436c53669a241166a454def3b06",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38891",
+					"10.65.0.27:38891",
+					"172.17.0.1:38891",
+					"172.18.0.1:38891",
+					"172.19.0.1:38891",
+					"172.20.0.1:38891",
+					"172.21.0.1:38891",
+					"172.22.0.1:38891",
+					"172.23.0.1:38891",
+					"172.24.0.1:38891",
+					"172.25.0.1:38891",
+					"172.26.0.1:38891",
+					"172.27.0.1:38891",
+					"172.28.0.1:38891"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:25:07.062390075Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3566739387837422,
+				"StableID":   "n7siyLCPrU11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c50af58ec7631da2d9fb93f381d3ef00558a79c3ddff106abdb731b28a292045",
+				"DiscoKey":   "discokey:d55a9a8c3cdd8905df9995e60657c20f92cdea45279a7acfa7151a8b8f737456",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36435",
+					"10.65.0.27:36435",
+					"172.17.0.1:36435",
+					"172.18.0.1:36435",
+					"172.19.0.1:36435",
+					"172.20.0.1:36435",
+					"172.21.0.1:36435",
+					"172.22.0.1:36435",
+					"172.23.0.1:36435",
+					"172.24.0.1:36435",
+					"172.25.0.1:36435",
+					"172.26.0.1:36435",
+					"172.27.0.1:36435",
+					"172.28.0.1:36435"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:25:07.591294584Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5747196086914171,
+				"StableID":   "nkmRrY6vsm11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:761ed02ba5ec891d31c733faea100d9b97cb2198399bac790e4ff5e144759974",
+				"KeyExpiry":  "2026-11-09T09:25:08Z",
+				"DiscoKey":   "discokey:4d7f7844bdfd4e84f6911d922f22f859b56d90898ceab7c4bf12028eb12e8a0e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:42656",
+					"10.65.0.27:42656",
+					"172.17.0.1:42656",
+					"172.18.0.1:42656",
+					"172.19.0.1:42656",
+					"172.20.0.1:42656",
+					"172.21.0.1:42656",
+					"172.22.0.1:42656",
+					"172.23.0.1:42656",
+					"172.24.0.1:42656",
+					"172.25.0.1:42656",
+					"172.26.0.1:42656",
+					"172.27.0.1:42656",
+					"172.28.0.1:42656"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:25:08.122619339Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1118669416952970,
+				"StableID":   "nTu1gpYej911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5e0da8da6fca608299c957b185242f8e3f4d8c577f50a403fd129ce4f6683203",
+				"KeyExpiry":  "2026-11-09T09:25:08Z",
+				"DiscoKey":   "discokey:d440fb256198020553b4f2eb0bdb3303b74c122673c4f11887d71d5b10f1c75c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59342",
+					"10.65.0.27:59342",
+					"172.17.0.1:59342",
+					"172.18.0.1:59342",
+					"172.19.0.1:59342",
+					"172.20.0.1:59342",
+					"172.21.0.1:59342",
+					"172.22.0.1:59342",
+					"172.23.0.1:59342",
+					"172.24.0.1:59342",
+					"172.25.0.1:59342",
+					"172.26.0.1:59342",
+					"172.27.0.1:59342",
+					"172.28.0.1:59342"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:25:08.655311712Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8926419916096414,
+				"StableID":   "njmzt3vnhC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:cb4ba8073d974c29b0a43072c97be73251548d8cb6f1701240a43a8a0fbb227f",
+				"KeyExpiry":  "2026-11-09T09:25:09Z",
+				"DiscoKey":   "discokey:a13760fbbdedb482e330b42110a2dbfe37899ac465cf55b34483336eb9761d72",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58696",
+					"10.65.0.27:58696",
+					"172.17.0.1:58696",
+					"172.18.0.1:58696",
+					"172.19.0.1:58696",
+					"172.20.0.1:58696",
+					"172.21.0.1:58696",
+					"172.22.0.1:58696",
+					"172.23.0.1:58696",
+					"172.24.0.1:58696",
+					"172.25.0.1:58696",
+					"172.26.0.1:58696",
+					"172.27.0.1:58696",
+					"172.28.0.1:58696"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:25:09.187973528Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4911415734779420": {
+				"ID":          4911415734779420,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1111701973359323,
+				"StableID":   "nxbPYVXVg911CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1111701973359323,
+				"Key":        "nodekey:e451839222d4d0713b74c367f2714ddd0bbc70c54470b84db70ade576bcb3674",
+				"DiscoKey":   "discokey:8594fe0f810f0cb338cc9b9eddc9d062a26c3e1408a5f7b137bbf475a2fb4d18",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51347",
+					"10.65.0.27:51347",
+					"172.17.0.1:51347",
+					"172.18.0.1:51347",
+					"172.19.0.1:51347",
+					"172.20.0.1:51347",
+					"172.21.0.1:51347",
+					"172.22.0.1:51347",
+					"172.23.0.1:51347",
+					"172.24.0.1:51347",
+					"172.25.0.1:51347",
+					"172.26.0.1:51347",
+					"172.27.0.1:51347",
+					"172.28.0.1:51347"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:25:01.694585935Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e451839222d4d0713b74c367f2714ddd0bbc70c54470b84db70ade576bcb3674",
+			"MachineKey": "mkey:b4129cab40ccb147d257d4d89b3a3bdac913afc5f4d6fe7cade35086d1072807",
+			"Peers": [{
+				"ID":         4911415734779420,
+				"StableID":   "nwJW8fZPMf11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a35ed5a6673587fb5a0a1a04d02e4797e00124b4ef17eb052758c4adde12e232",
+				"DiscoKey":   "discokey:616122b0d87095d607218d9afb941629599e5f2d1958837f66276d16e575543c",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51664",
+					"10.65.0.27:51664",
+					"172.17.0.1:51664",
+					"172.18.0.1:51664",
+					"172.19.0.1:51664",
+					"172.20.0.1:51664",
+					"172.21.0.1:51664",
+					"172.22.0.1:51664",
+					"172.23.0.1:51664",
+					"172.24.0.1:51664",
+					"172.25.0.1:51664",
+					"172.26.0.1:51664",
+					"172.27.0.1:51664",
+					"172.28.0.1:51664"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:25:02.221499655Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8500624626227658,
+				"StableID":   "nHvVCgzwN921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06edbf91eb3ed22390fb155c2c3f4b29a20ca960e48cd2fe0102f64b3598b95c",
+				"DiscoKey":   "discokey:aad7c92a930aa89b46a180ac2de0219e76fe01418f9646d5fdb4f786cdf71b7b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35814",
+					"10.65.0.27:35814",
+					"172.17.0.1:35814",
+					"172.18.0.1:35814",
+					"172.19.0.1:35814",
+					"172.20.0.1:35814",
+					"172.21.0.1:35814",
+					"172.22.0.1:35814",
+					"172.23.0.1:35814",
+					"172.24.0.1:35814",
+					"172.25.0.1:35814",
+					"172.26.0.1:35814",
+					"172.27.0.1:35814",
+					"172.28.0.1:35814"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:25:02.753722365Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1833936728053849,
+				"StableID":   "n8JwdfQbKF11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4ac4692d470556d42f3f9d60a06f76a58452b1337fdec16e3a9838624751253",
+				"DiscoKey":   "discokey:9d2eaceeeb7d9c286601d66c410db58faf4b79837cfdfff0dd71db7eb418030c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53948",
+					"10.65.0.27:53948",
+					"172.17.0.1:53948",
+					"172.18.0.1:53948",
+					"172.19.0.1:53948",
+					"172.20.0.1:53948",
+					"172.21.0.1:53948",
+					"172.22.0.1:53948",
+					"172.23.0.1:53948",
+					"172.24.0.1:53948",
+					"172.25.0.1:53948",
+					"172.26.0.1:53948",
+					"172.27.0.1:53948",
+					"172.28.0.1:53948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:25:03.362885203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8916891682166105,
+				"StableID":   "nayXVCdUdC21CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7396a8e888bab44894aad53453f03dcc72e221b3ceacf0b3d64b70718c10397f",
+				"DiscoKey":   "discokey:69257e4deb9e19803fae62e451670f1fd3fe61b0701827622f2345839e887e31",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:39392",
+					"10.65.0.27:39392",
+					"172.17.0.1:39392",
+					"172.18.0.1:39392",
+					"172.19.0.1:39392",
+					"172.20.0.1:39392",
+					"172.21.0.1:39392",
+					"172.22.0.1:39392",
+					"172.23.0.1:39392",
+					"172.24.0.1:39392",
+					"172.25.0.1:39392",
+					"172.26.0.1:39392",
+					"172.27.0.1:39392",
+					"172.28.0.1:39392"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:25:03.823761506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3571740558468309,
+				"StableID":   "nzFTJwZetU11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f1a595f39e675a814bb45e8ef0eea10d795175ef850c32620bf1bf9506171f0e",
+				"DiscoKey":   "discokey:061847f57788a4bebc9c47608e46578df9d315d7ac49e0234e7f8d5f60413016",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:56939",
+					"10.65.0.27:56939",
+					"172.17.0.1:56939",
+					"172.18.0.1:56939",
+					"172.19.0.1:56939",
+					"172.20.0.1:56939",
+					"172.21.0.1:56939",
+					"172.22.0.1:56939",
+					"172.23.0.1:56939",
+					"172.24.0.1:56939",
+					"172.25.0.1:56939",
+					"172.26.0.1:56939",
+					"172.27.0.1:56939",
+					"172.28.0.1:56939"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:25:04.395397488Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4425484544229752,
+				"StableID":   "nfLCpXyJZb11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:827790f023e92b68fba0a68dd08e08a55e2237015cd17fba5f99c71bb5250757",
+				"DiscoKey":   "discokey:7f1bc9df669823b23999208b378ab60dd73cf61507878580423ad35a7642ca11",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50699",
+					"10.65.0.27:50699",
+					"172.17.0.1:50699",
+					"172.18.0.1:50699",
+					"172.19.0.1:50699",
+					"172.20.0.1:50699",
+					"172.21.0.1:50699",
+					"172.22.0.1:50699",
+					"172.23.0.1:50699",
+					"172.24.0.1:50699",
+					"172.25.0.1:50699",
+					"172.26.0.1:50699",
+					"172.27.0.1:50699",
+					"172.28.0.1:50699"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:25:04.904792855Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1770706487984919,
+				"StableID":   "nYHwqVTxpE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e779f6731d4c1c49201d941277821cbd0c66668270bd929ac782f4d4b8210572",
+				"DiscoKey":   "discokey:27b9b505ae1072e38ca8d662cc96cf2dd56e65363f2ee504621b48563b2c6648",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:60880",
+					"10.65.0.27:60880",
+					"172.17.0.1:60880",
+					"172.18.0.1:60880",
+					"172.19.0.1:60880",
+					"172.20.0.1:60880",
+					"172.21.0.1:60880",
+					"172.22.0.1:60880",
+					"172.23.0.1:60880",
+					"172.24.0.1:60880",
+					"172.25.0.1:60880",
+					"172.26.0.1:60880",
+					"172.27.0.1:60880",
+					"172.28.0.1:60880"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:25:05.445033397Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7025241854797289,
+				"StableID":   "nWX5u4Ckrw11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2c0ec942bf61a2a90eeacfe4925005a662c17e91b350e3e74bbd3e5e758b639",
+				"DiscoKey":   "discokey:decf0e5cbfefeb892ca3bee860ea419e05f6bbb97a944741661991384fdb7e75",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37443",
+					"10.65.0.27:37443",
+					"172.17.0.1:37443",
+					"172.18.0.1:37443",
+					"172.19.0.1:37443",
+					"172.20.0.1:37443",
+					"172.21.0.1:37443",
+					"172.22.0.1:37443",
+					"172.23.0.1:37443",
+					"172.24.0.1:37443",
+					"172.25.0.1:37443",
+					"172.26.0.1:37443",
+					"172.27.0.1:37443",
+					"172.28.0.1:37443"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:25:05.979820657Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5187642462783807,
+				"StableID":   "n2LyB7aVWh11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4657a71f34c78df771f1f45e9e45bdd6d62e633fdb4b25b05812361ab22ce93d",
+				"DiscoKey":   "discokey:609aa9d2ed0bc217b56060ec3565a4010763a35a88b658c697dcee707074ed6f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:48858",
+					"10.65.0.27:48858",
+					"172.17.0.1:48858",
+					"172.18.0.1:48858",
+					"172.19.0.1:48858",
+					"172.20.0.1:48858",
+					"172.21.0.1:48858",
+					"172.22.0.1:48858",
+					"172.23.0.1:48858",
+					"172.24.0.1:48858",
+					"172.25.0.1:48858",
+					"172.26.0.1:48858",
+					"172.27.0.1:48858",
+					"172.28.0.1:48858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:25:06.511793624Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8893129674967036,
+				"StableID":   "nHbXHKSiSC21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90e1c8e418c74a15316c5382799838ea1f2355157bd129ac34e0f75d78f4572f",
+				"DiscoKey":   "discokey:7eabf39cbd7e2d3bc60a8e36c0e71262c3c5e436c53669a241166a454def3b06",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38891",
+					"10.65.0.27:38891",
+					"172.17.0.1:38891",
+					"172.18.0.1:38891",
+					"172.19.0.1:38891",
+					"172.20.0.1:38891",
+					"172.21.0.1:38891",
+					"172.22.0.1:38891",
+					"172.23.0.1:38891",
+					"172.24.0.1:38891",
+					"172.25.0.1:38891",
+					"172.26.0.1:38891",
+					"172.27.0.1:38891",
+					"172.28.0.1:38891"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:25:07.062390075Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3566739387837422,
+				"StableID":   "n7siyLCPrU11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c50af58ec7631da2d9fb93f381d3ef00558a79c3ddff106abdb731b28a292045",
+				"DiscoKey":   "discokey:d55a9a8c3cdd8905df9995e60657c20f92cdea45279a7acfa7151a8b8f737456",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36435",
+					"10.65.0.27:36435",
+					"172.17.0.1:36435",
+					"172.18.0.1:36435",
+					"172.19.0.1:36435",
+					"172.20.0.1:36435",
+					"172.21.0.1:36435",
+					"172.22.0.1:36435",
+					"172.23.0.1:36435",
+					"172.24.0.1:36435",
+					"172.25.0.1:36435",
+					"172.26.0.1:36435",
+					"172.27.0.1:36435",
+					"172.28.0.1:36435"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:25:07.591294584Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5747196086914171,
+				"StableID":   "nkmRrY6vsm11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:761ed02ba5ec891d31c733faea100d9b97cb2198399bac790e4ff5e144759974",
+				"KeyExpiry":  "2026-11-09T09:25:08Z",
+				"DiscoKey":   "discokey:4d7f7844bdfd4e84f6911d922f22f859b56d90898ceab7c4bf12028eb12e8a0e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:42656",
+					"10.65.0.27:42656",
+					"172.17.0.1:42656",
+					"172.18.0.1:42656",
+					"172.19.0.1:42656",
+					"172.20.0.1:42656",
+					"172.21.0.1:42656",
+					"172.22.0.1:42656",
+					"172.23.0.1:42656",
+					"172.24.0.1:42656",
+					"172.25.0.1:42656",
+					"172.26.0.1:42656",
+					"172.27.0.1:42656",
+					"172.28.0.1:42656"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:25:08.122619339Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1118669416952970,
+				"StableID":   "nTu1gpYej911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5e0da8da6fca608299c957b185242f8e3f4d8c577f50a403fd129ce4f6683203",
+				"KeyExpiry":  "2026-11-09T09:25:08Z",
+				"DiscoKey":   "discokey:d440fb256198020553b4f2eb0bdb3303b74c122673c4f11887d71d5b10f1c75c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59342",
+					"10.65.0.27:59342",
+					"172.17.0.1:59342",
+					"172.18.0.1:59342",
+					"172.19.0.1:59342",
+					"172.20.0.1:59342",
+					"172.21.0.1:59342",
+					"172.22.0.1:59342",
+					"172.23.0.1:59342",
+					"172.24.0.1:59342",
+					"172.25.0.1:59342",
+					"172.26.0.1:59342",
+					"172.27.0.1:59342",
+					"172.28.0.1:59342"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:25:08.655311712Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8926419916096414,
+				"StableID":   "njmzt3vnhC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:cb4ba8073d974c29b0a43072c97be73251548d8cb6f1701240a43a8a0fbb227f",
+				"KeyExpiry":  "2026-11-09T09:25:09Z",
+				"DiscoKey":   "discokey:a13760fbbdedb482e330b42110a2dbfe37899ac465cf55b34483336eb9761d72",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58696",
+					"10.65.0.27:58696",
+					"172.17.0.1:58696",
+					"172.18.0.1:58696",
+					"172.19.0.1:58696",
+					"172.20.0.1:58696",
+					"172.21.0.1:58696",
+					"172.22.0.1:58696",
+					"172.23.0.1:58696",
+					"172.24.0.1:58696",
+					"172.25.0.1:58696",
+					"172.26.0.1:58696",
+					"172.27.0.1:58696",
+					"172.28.0.1:58696"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:25:09.187973528Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1111701973359323": {
+				"ID":          1111701973359323,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}, "1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8916891682166105,
+				"StableID":   "nayXVCdUdC21CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       8916891682166105,
+				"Key":        "nodekey:7396a8e888bab44894aad53453f03dcc72e221b3ceacf0b3d64b70718c10397f",
+				"DiscoKey":   "discokey:69257e4deb9e19803fae62e451670f1fd3fe61b0701827622f2345839e887e31",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:39392",
+					"10.65.0.27:39392",
+					"172.17.0.1:39392",
+					"172.18.0.1:39392",
+					"172.19.0.1:39392",
+					"172.20.0.1:39392",
+					"172.21.0.1:39392",
+					"172.22.0.1:39392",
+					"172.23.0.1:39392",
+					"172.24.0.1:39392",
+					"172.25.0.1:39392",
+					"172.26.0.1:39392",
+					"172.27.0.1:39392",
+					"172.28.0.1:39392"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:25:03.823761506Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7396a8e888bab44894aad53453f03dcc72e221b3ceacf0b3d64b70718c10397f",
+			"MachineKey": "mkey:6d3a5f49f4a40cde82c507ff967862f76e5d7b4830ed81475d630f1ddc59e842",
+			"Peers": [{
+				"ID":         1111701973359323,
+				"StableID":   "nxbPYVXVg911CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e451839222d4d0713b74c367f2714ddd0bbc70c54470b84db70ade576bcb3674",
+				"DiscoKey":   "discokey:8594fe0f810f0cb338cc9b9eddc9d062a26c3e1408a5f7b137bbf475a2fb4d18",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51347",
+					"10.65.0.27:51347",
+					"172.17.0.1:51347",
+					"172.18.0.1:51347",
+					"172.19.0.1:51347",
+					"172.20.0.1:51347",
+					"172.21.0.1:51347",
+					"172.22.0.1:51347",
+					"172.23.0.1:51347",
+					"172.24.0.1:51347",
+					"172.25.0.1:51347",
+					"172.26.0.1:51347",
+					"172.27.0.1:51347",
+					"172.28.0.1:51347"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:25:01.694585935Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4911415734779420,
+				"StableID":   "nwJW8fZPMf11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a35ed5a6673587fb5a0a1a04d02e4797e00124b4ef17eb052758c4adde12e232",
+				"DiscoKey":   "discokey:616122b0d87095d607218d9afb941629599e5f2d1958837f66276d16e575543c",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51664",
+					"10.65.0.27:51664",
+					"172.17.0.1:51664",
+					"172.18.0.1:51664",
+					"172.19.0.1:51664",
+					"172.20.0.1:51664",
+					"172.21.0.1:51664",
+					"172.22.0.1:51664",
+					"172.23.0.1:51664",
+					"172.24.0.1:51664",
+					"172.25.0.1:51664",
+					"172.26.0.1:51664",
+					"172.27.0.1:51664",
+					"172.28.0.1:51664"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:25:02.221499655Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8500624626227658,
+				"StableID":   "nHvVCgzwN921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06edbf91eb3ed22390fb155c2c3f4b29a20ca960e48cd2fe0102f64b3598b95c",
+				"DiscoKey":   "discokey:aad7c92a930aa89b46a180ac2de0219e76fe01418f9646d5fdb4f786cdf71b7b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35814",
+					"10.65.0.27:35814",
+					"172.17.0.1:35814",
+					"172.18.0.1:35814",
+					"172.19.0.1:35814",
+					"172.20.0.1:35814",
+					"172.21.0.1:35814",
+					"172.22.0.1:35814",
+					"172.23.0.1:35814",
+					"172.24.0.1:35814",
+					"172.25.0.1:35814",
+					"172.26.0.1:35814",
+					"172.27.0.1:35814",
+					"172.28.0.1:35814"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:25:02.753722365Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1833936728053849,
+				"StableID":   "n8JwdfQbKF11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4ac4692d470556d42f3f9d60a06f76a58452b1337fdec16e3a9838624751253",
+				"DiscoKey":   "discokey:9d2eaceeeb7d9c286601d66c410db58faf4b79837cfdfff0dd71db7eb418030c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53948",
+					"10.65.0.27:53948",
+					"172.17.0.1:53948",
+					"172.18.0.1:53948",
+					"172.19.0.1:53948",
+					"172.20.0.1:53948",
+					"172.21.0.1:53948",
+					"172.22.0.1:53948",
+					"172.23.0.1:53948",
+					"172.24.0.1:53948",
+					"172.25.0.1:53948",
+					"172.26.0.1:53948",
+					"172.27.0.1:53948",
+					"172.28.0.1:53948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:25:03.362885203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3571740558468309,
+				"StableID":   "nzFTJwZetU11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f1a595f39e675a814bb45e8ef0eea10d795175ef850c32620bf1bf9506171f0e",
+				"DiscoKey":   "discokey:061847f57788a4bebc9c47608e46578df9d315d7ac49e0234e7f8d5f60413016",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:56939",
+					"10.65.0.27:56939",
+					"172.17.0.1:56939",
+					"172.18.0.1:56939",
+					"172.19.0.1:56939",
+					"172.20.0.1:56939",
+					"172.21.0.1:56939",
+					"172.22.0.1:56939",
+					"172.23.0.1:56939",
+					"172.24.0.1:56939",
+					"172.25.0.1:56939",
+					"172.26.0.1:56939",
+					"172.27.0.1:56939",
+					"172.28.0.1:56939"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:25:04.395397488Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4425484544229752,
+				"StableID":   "nfLCpXyJZb11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:827790f023e92b68fba0a68dd08e08a55e2237015cd17fba5f99c71bb5250757",
+				"DiscoKey":   "discokey:7f1bc9df669823b23999208b378ab60dd73cf61507878580423ad35a7642ca11",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50699",
+					"10.65.0.27:50699",
+					"172.17.0.1:50699",
+					"172.18.0.1:50699",
+					"172.19.0.1:50699",
+					"172.20.0.1:50699",
+					"172.21.0.1:50699",
+					"172.22.0.1:50699",
+					"172.23.0.1:50699",
+					"172.24.0.1:50699",
+					"172.25.0.1:50699",
+					"172.26.0.1:50699",
+					"172.27.0.1:50699",
+					"172.28.0.1:50699"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:25:04.904792855Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1770706487984919,
+				"StableID":   "nYHwqVTxpE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e779f6731d4c1c49201d941277821cbd0c66668270bd929ac782f4d4b8210572",
+				"DiscoKey":   "discokey:27b9b505ae1072e38ca8d662cc96cf2dd56e65363f2ee504621b48563b2c6648",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:60880",
+					"10.65.0.27:60880",
+					"172.17.0.1:60880",
+					"172.18.0.1:60880",
+					"172.19.0.1:60880",
+					"172.20.0.1:60880",
+					"172.21.0.1:60880",
+					"172.22.0.1:60880",
+					"172.23.0.1:60880",
+					"172.24.0.1:60880",
+					"172.25.0.1:60880",
+					"172.26.0.1:60880",
+					"172.27.0.1:60880",
+					"172.28.0.1:60880"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:25:05.445033397Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7025241854797289,
+				"StableID":   "nWX5u4Ckrw11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2c0ec942bf61a2a90eeacfe4925005a662c17e91b350e3e74bbd3e5e758b639",
+				"DiscoKey":   "discokey:decf0e5cbfefeb892ca3bee860ea419e05f6bbb97a944741661991384fdb7e75",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37443",
+					"10.65.0.27:37443",
+					"172.17.0.1:37443",
+					"172.18.0.1:37443",
+					"172.19.0.1:37443",
+					"172.20.0.1:37443",
+					"172.21.0.1:37443",
+					"172.22.0.1:37443",
+					"172.23.0.1:37443",
+					"172.24.0.1:37443",
+					"172.25.0.1:37443",
+					"172.26.0.1:37443",
+					"172.27.0.1:37443",
+					"172.28.0.1:37443"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:25:05.979820657Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5187642462783807,
+				"StableID":   "n2LyB7aVWh11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4657a71f34c78df771f1f45e9e45bdd6d62e633fdb4b25b05812361ab22ce93d",
+				"DiscoKey":   "discokey:609aa9d2ed0bc217b56060ec3565a4010763a35a88b658c697dcee707074ed6f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:48858",
+					"10.65.0.27:48858",
+					"172.17.0.1:48858",
+					"172.18.0.1:48858",
+					"172.19.0.1:48858",
+					"172.20.0.1:48858",
+					"172.21.0.1:48858",
+					"172.22.0.1:48858",
+					"172.23.0.1:48858",
+					"172.24.0.1:48858",
+					"172.25.0.1:48858",
+					"172.26.0.1:48858",
+					"172.27.0.1:48858",
+					"172.28.0.1:48858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:25:06.511793624Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8893129674967036,
+				"StableID":   "nHbXHKSiSC21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90e1c8e418c74a15316c5382799838ea1f2355157bd129ac34e0f75d78f4572f",
+				"DiscoKey":   "discokey:7eabf39cbd7e2d3bc60a8e36c0e71262c3c5e436c53669a241166a454def3b06",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38891",
+					"10.65.0.27:38891",
+					"172.17.0.1:38891",
+					"172.18.0.1:38891",
+					"172.19.0.1:38891",
+					"172.20.0.1:38891",
+					"172.21.0.1:38891",
+					"172.22.0.1:38891",
+					"172.23.0.1:38891",
+					"172.24.0.1:38891",
+					"172.25.0.1:38891",
+					"172.26.0.1:38891",
+					"172.27.0.1:38891",
+					"172.28.0.1:38891"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:25:07.062390075Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3566739387837422,
+				"StableID":   "n7siyLCPrU11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c50af58ec7631da2d9fb93f381d3ef00558a79c3ddff106abdb731b28a292045",
+				"DiscoKey":   "discokey:d55a9a8c3cdd8905df9995e60657c20f92cdea45279a7acfa7151a8b8f737456",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36435",
+					"10.65.0.27:36435",
+					"172.17.0.1:36435",
+					"172.18.0.1:36435",
+					"172.19.0.1:36435",
+					"172.20.0.1:36435",
+					"172.21.0.1:36435",
+					"172.22.0.1:36435",
+					"172.23.0.1:36435",
+					"172.24.0.1:36435",
+					"172.25.0.1:36435",
+					"172.26.0.1:36435",
+					"172.27.0.1:36435",
+					"172.28.0.1:36435"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:25:07.591294584Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5747196086914171,
+				"StableID":   "nkmRrY6vsm11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:761ed02ba5ec891d31c733faea100d9b97cb2198399bac790e4ff5e144759974",
+				"KeyExpiry":  "2026-11-09T09:25:08Z",
+				"DiscoKey":   "discokey:4d7f7844bdfd4e84f6911d922f22f859b56d90898ceab7c4bf12028eb12e8a0e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:42656",
+					"10.65.0.27:42656",
+					"172.17.0.1:42656",
+					"172.18.0.1:42656",
+					"172.19.0.1:42656",
+					"172.20.0.1:42656",
+					"172.21.0.1:42656",
+					"172.22.0.1:42656",
+					"172.23.0.1:42656",
+					"172.24.0.1:42656",
+					"172.25.0.1:42656",
+					"172.26.0.1:42656",
+					"172.27.0.1:42656",
+					"172.28.0.1:42656"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:25:08.122619339Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1118669416952970,
+				"StableID":   "nTu1gpYej911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5e0da8da6fca608299c957b185242f8e3f4d8c577f50a403fd129ce4f6683203",
+				"KeyExpiry":  "2026-11-09T09:25:08Z",
+				"DiscoKey":   "discokey:d440fb256198020553b4f2eb0bdb3303b74c122673c4f11887d71d5b10f1c75c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59342",
+					"10.65.0.27:59342",
+					"172.17.0.1:59342",
+					"172.18.0.1:59342",
+					"172.19.0.1:59342",
+					"172.20.0.1:59342",
+					"172.21.0.1:59342",
+					"172.22.0.1:59342",
+					"172.23.0.1:59342",
+					"172.24.0.1:59342",
+					"172.25.0.1:59342",
+					"172.26.0.1:59342",
+					"172.27.0.1:59342",
+					"172.28.0.1:59342"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:25:08.655311712Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8926419916096414,
+				"StableID":   "njmzt3vnhC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:cb4ba8073d974c29b0a43072c97be73251548d8cb6f1701240a43a8a0fbb227f",
+				"KeyExpiry":  "2026-11-09T09:25:09Z",
+				"DiscoKey":   "discokey:a13760fbbdedb482e330b42110a2dbfe37899ac465cf55b34483336eb9761d72",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58696",
+					"10.65.0.27:58696",
+					"172.17.0.1:58696",
+					"172.18.0.1:58696",
+					"172.19.0.1:58696",
+					"172.20.0.1:58696",
+					"172.21.0.1:58696",
+					"172.22.0.1:58696",
+					"172.23.0.1:58696",
+					"172.24.0.1:58696",
+					"172.25.0.1:58696",
+					"172.26.0.1:58696",
+					"172.27.0.1:58696",
+					"172.28.0.1:58696"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:25:09.187973528Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8916891682166105": {
+				"ID":          8916891682166105,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1833936728053849,
+				"StableID":   "n8JwdfQbKF11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1833936728053849,
+				"Key":        "nodekey:a4ac4692d470556d42f3f9d60a06f76a58452b1337fdec16e3a9838624751253",
+				"DiscoKey":   "discokey:9d2eaceeeb7d9c286601d66c410db58faf4b79837cfdfff0dd71db7eb418030c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53948",
+					"10.65.0.27:53948",
+					"172.17.0.1:53948",
+					"172.18.0.1:53948",
+					"172.19.0.1:53948",
+					"172.20.0.1:53948",
+					"172.21.0.1:53948",
+					"172.22.0.1:53948",
+					"172.23.0.1:53948",
+					"172.24.0.1:53948",
+					"172.25.0.1:53948",
+					"172.26.0.1:53948",
+					"172.27.0.1:53948",
+					"172.28.0.1:53948"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:25:03.362885203Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a4ac4692d470556d42f3f9d60a06f76a58452b1337fdec16e3a9838624751253",
+			"MachineKey": "mkey:1011aa9d0cf3e618cd27d940f1e22a4bab3195f3352f0dbb8f5b1f3f3a5ba35d",
+			"Peers": [{
+				"ID":         1111701973359323,
+				"StableID":   "nxbPYVXVg911CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e451839222d4d0713b74c367f2714ddd0bbc70c54470b84db70ade576bcb3674",
+				"DiscoKey":   "discokey:8594fe0f810f0cb338cc9b9eddc9d062a26c3e1408a5f7b137bbf475a2fb4d18",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51347",
+					"10.65.0.27:51347",
+					"172.17.0.1:51347",
+					"172.18.0.1:51347",
+					"172.19.0.1:51347",
+					"172.20.0.1:51347",
+					"172.21.0.1:51347",
+					"172.22.0.1:51347",
+					"172.23.0.1:51347",
+					"172.24.0.1:51347",
+					"172.25.0.1:51347",
+					"172.26.0.1:51347",
+					"172.27.0.1:51347",
+					"172.28.0.1:51347"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:25:01.694585935Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4911415734779420,
+				"StableID":   "nwJW8fZPMf11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a35ed5a6673587fb5a0a1a04d02e4797e00124b4ef17eb052758c4adde12e232",
+				"DiscoKey":   "discokey:616122b0d87095d607218d9afb941629599e5f2d1958837f66276d16e575543c",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51664",
+					"10.65.0.27:51664",
+					"172.17.0.1:51664",
+					"172.18.0.1:51664",
+					"172.19.0.1:51664",
+					"172.20.0.1:51664",
+					"172.21.0.1:51664",
+					"172.22.0.1:51664",
+					"172.23.0.1:51664",
+					"172.24.0.1:51664",
+					"172.25.0.1:51664",
+					"172.26.0.1:51664",
+					"172.27.0.1:51664",
+					"172.28.0.1:51664"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:25:02.221499655Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8500624626227658,
+				"StableID":   "nHvVCgzwN921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06edbf91eb3ed22390fb155c2c3f4b29a20ca960e48cd2fe0102f64b3598b95c",
+				"DiscoKey":   "discokey:aad7c92a930aa89b46a180ac2de0219e76fe01418f9646d5fdb4f786cdf71b7b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35814",
+					"10.65.0.27:35814",
+					"172.17.0.1:35814",
+					"172.18.0.1:35814",
+					"172.19.0.1:35814",
+					"172.20.0.1:35814",
+					"172.21.0.1:35814",
+					"172.22.0.1:35814",
+					"172.23.0.1:35814",
+					"172.24.0.1:35814",
+					"172.25.0.1:35814",
+					"172.26.0.1:35814",
+					"172.27.0.1:35814",
+					"172.28.0.1:35814"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:25:02.753722365Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8916891682166105,
+				"StableID":   "nayXVCdUdC21CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7396a8e888bab44894aad53453f03dcc72e221b3ceacf0b3d64b70718c10397f",
+				"DiscoKey":   "discokey:69257e4deb9e19803fae62e451670f1fd3fe61b0701827622f2345839e887e31",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:39392",
+					"10.65.0.27:39392",
+					"172.17.0.1:39392",
+					"172.18.0.1:39392",
+					"172.19.0.1:39392",
+					"172.20.0.1:39392",
+					"172.21.0.1:39392",
+					"172.22.0.1:39392",
+					"172.23.0.1:39392",
+					"172.24.0.1:39392",
+					"172.25.0.1:39392",
+					"172.26.0.1:39392",
+					"172.27.0.1:39392",
+					"172.28.0.1:39392"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:25:03.823761506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3571740558468309,
+				"StableID":   "nzFTJwZetU11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f1a595f39e675a814bb45e8ef0eea10d795175ef850c32620bf1bf9506171f0e",
+				"DiscoKey":   "discokey:061847f57788a4bebc9c47608e46578df9d315d7ac49e0234e7f8d5f60413016",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:56939",
+					"10.65.0.27:56939",
+					"172.17.0.1:56939",
+					"172.18.0.1:56939",
+					"172.19.0.1:56939",
+					"172.20.0.1:56939",
+					"172.21.0.1:56939",
+					"172.22.0.1:56939",
+					"172.23.0.1:56939",
+					"172.24.0.1:56939",
+					"172.25.0.1:56939",
+					"172.26.0.1:56939",
+					"172.27.0.1:56939",
+					"172.28.0.1:56939"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:25:04.395397488Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4425484544229752,
+				"StableID":   "nfLCpXyJZb11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:827790f023e92b68fba0a68dd08e08a55e2237015cd17fba5f99c71bb5250757",
+				"DiscoKey":   "discokey:7f1bc9df669823b23999208b378ab60dd73cf61507878580423ad35a7642ca11",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50699",
+					"10.65.0.27:50699",
+					"172.17.0.1:50699",
+					"172.18.0.1:50699",
+					"172.19.0.1:50699",
+					"172.20.0.1:50699",
+					"172.21.0.1:50699",
+					"172.22.0.1:50699",
+					"172.23.0.1:50699",
+					"172.24.0.1:50699",
+					"172.25.0.1:50699",
+					"172.26.0.1:50699",
+					"172.27.0.1:50699",
+					"172.28.0.1:50699"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:25:04.904792855Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1770706487984919,
+				"StableID":   "nYHwqVTxpE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e779f6731d4c1c49201d941277821cbd0c66668270bd929ac782f4d4b8210572",
+				"DiscoKey":   "discokey:27b9b505ae1072e38ca8d662cc96cf2dd56e65363f2ee504621b48563b2c6648",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:60880",
+					"10.65.0.27:60880",
+					"172.17.0.1:60880",
+					"172.18.0.1:60880",
+					"172.19.0.1:60880",
+					"172.20.0.1:60880",
+					"172.21.0.1:60880",
+					"172.22.0.1:60880",
+					"172.23.0.1:60880",
+					"172.24.0.1:60880",
+					"172.25.0.1:60880",
+					"172.26.0.1:60880",
+					"172.27.0.1:60880",
+					"172.28.0.1:60880"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:25:05.445033397Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7025241854797289,
+				"StableID":   "nWX5u4Ckrw11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2c0ec942bf61a2a90eeacfe4925005a662c17e91b350e3e74bbd3e5e758b639",
+				"DiscoKey":   "discokey:decf0e5cbfefeb892ca3bee860ea419e05f6bbb97a944741661991384fdb7e75",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37443",
+					"10.65.0.27:37443",
+					"172.17.0.1:37443",
+					"172.18.0.1:37443",
+					"172.19.0.1:37443",
+					"172.20.0.1:37443",
+					"172.21.0.1:37443",
+					"172.22.0.1:37443",
+					"172.23.0.1:37443",
+					"172.24.0.1:37443",
+					"172.25.0.1:37443",
+					"172.26.0.1:37443",
+					"172.27.0.1:37443",
+					"172.28.0.1:37443"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:25:05.979820657Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5187642462783807,
+				"StableID":   "n2LyB7aVWh11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4657a71f34c78df771f1f45e9e45bdd6d62e633fdb4b25b05812361ab22ce93d",
+				"DiscoKey":   "discokey:609aa9d2ed0bc217b56060ec3565a4010763a35a88b658c697dcee707074ed6f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:48858",
+					"10.65.0.27:48858",
+					"172.17.0.1:48858",
+					"172.18.0.1:48858",
+					"172.19.0.1:48858",
+					"172.20.0.1:48858",
+					"172.21.0.1:48858",
+					"172.22.0.1:48858",
+					"172.23.0.1:48858",
+					"172.24.0.1:48858",
+					"172.25.0.1:48858",
+					"172.26.0.1:48858",
+					"172.27.0.1:48858",
+					"172.28.0.1:48858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:25:06.511793624Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8893129674967036,
+				"StableID":   "nHbXHKSiSC21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90e1c8e418c74a15316c5382799838ea1f2355157bd129ac34e0f75d78f4572f",
+				"DiscoKey":   "discokey:7eabf39cbd7e2d3bc60a8e36c0e71262c3c5e436c53669a241166a454def3b06",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38891",
+					"10.65.0.27:38891",
+					"172.17.0.1:38891",
+					"172.18.0.1:38891",
+					"172.19.0.1:38891",
+					"172.20.0.1:38891",
+					"172.21.0.1:38891",
+					"172.22.0.1:38891",
+					"172.23.0.1:38891",
+					"172.24.0.1:38891",
+					"172.25.0.1:38891",
+					"172.26.0.1:38891",
+					"172.27.0.1:38891",
+					"172.28.0.1:38891"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:25:07.062390075Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3566739387837422,
+				"StableID":   "n7siyLCPrU11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c50af58ec7631da2d9fb93f381d3ef00558a79c3ddff106abdb731b28a292045",
+				"DiscoKey":   "discokey:d55a9a8c3cdd8905df9995e60657c20f92cdea45279a7acfa7151a8b8f737456",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36435",
+					"10.65.0.27:36435",
+					"172.17.0.1:36435",
+					"172.18.0.1:36435",
+					"172.19.0.1:36435",
+					"172.20.0.1:36435",
+					"172.21.0.1:36435",
+					"172.22.0.1:36435",
+					"172.23.0.1:36435",
+					"172.24.0.1:36435",
+					"172.25.0.1:36435",
+					"172.26.0.1:36435",
+					"172.27.0.1:36435",
+					"172.28.0.1:36435"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:25:07.591294584Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5747196086914171,
+				"StableID":   "nkmRrY6vsm11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:761ed02ba5ec891d31c733faea100d9b97cb2198399bac790e4ff5e144759974",
+				"KeyExpiry":  "2026-11-09T09:25:08Z",
+				"DiscoKey":   "discokey:4d7f7844bdfd4e84f6911d922f22f859b56d90898ceab7c4bf12028eb12e8a0e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:42656",
+					"10.65.0.27:42656",
+					"172.17.0.1:42656",
+					"172.18.0.1:42656",
+					"172.19.0.1:42656",
+					"172.20.0.1:42656",
+					"172.21.0.1:42656",
+					"172.22.0.1:42656",
+					"172.23.0.1:42656",
+					"172.24.0.1:42656",
+					"172.25.0.1:42656",
+					"172.26.0.1:42656",
+					"172.27.0.1:42656",
+					"172.28.0.1:42656"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:25:08.122619339Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1118669416952970,
+				"StableID":   "nTu1gpYej911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5e0da8da6fca608299c957b185242f8e3f4d8c577f50a403fd129ce4f6683203",
+				"KeyExpiry":  "2026-11-09T09:25:08Z",
+				"DiscoKey":   "discokey:d440fb256198020553b4f2eb0bdb3303b74c122673c4f11887d71d5b10f1c75c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59342",
+					"10.65.0.27:59342",
+					"172.17.0.1:59342",
+					"172.18.0.1:59342",
+					"172.19.0.1:59342",
+					"172.20.0.1:59342",
+					"172.21.0.1:59342",
+					"172.22.0.1:59342",
+					"172.23.0.1:59342",
+					"172.24.0.1:59342",
+					"172.25.0.1:59342",
+					"172.26.0.1:59342",
+					"172.27.0.1:59342",
+					"172.28.0.1:59342"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:25:08.655311712Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8926419916096414,
+				"StableID":   "njmzt3vnhC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:cb4ba8073d974c29b0a43072c97be73251548d8cb6f1701240a43a8a0fbb227f",
+				"KeyExpiry":  "2026-11-09T09:25:09Z",
+				"DiscoKey":   "discokey:a13760fbbdedb482e330b42110a2dbfe37899ac465cf55b34483336eb9761d72",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58696",
+					"10.65.0.27:58696",
+					"172.17.0.1:58696",
+					"172.18.0.1:58696",
+					"172.19.0.1:58696",
+					"172.20.0.1:58696",
+					"172.21.0.1:58696",
+					"172.22.0.1:58696",
+					"172.23.0.1:58696",
+					"172.24.0.1:58696",
+					"172.25.0.1:58696",
+					"172.26.0.1:58696",
+					"172.27.0.1:58696",
+					"172.28.0.1:58696"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:25:09.187973528Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1833936728053849": {
+				"ID":          1833936728053849,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4425484544229752,
+				"StableID":   "nfLCpXyJZb11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       4425484544229752,
+				"Key":        "nodekey:827790f023e92b68fba0a68dd08e08a55e2237015cd17fba5f99c71bb5250757",
+				"DiscoKey":   "discokey:7f1bc9df669823b23999208b378ab60dd73cf61507878580423ad35a7642ca11",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50699",
+					"10.65.0.27:50699",
+					"172.17.0.1:50699",
+					"172.18.0.1:50699",
+					"172.19.0.1:50699",
+					"172.20.0.1:50699",
+					"172.21.0.1:50699",
+					"172.22.0.1:50699",
+					"172.23.0.1:50699",
+					"172.24.0.1:50699",
+					"172.25.0.1:50699",
+					"172.26.0.1:50699",
+					"172.27.0.1:50699",
+					"172.28.0.1:50699"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:25:04.904792855Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:827790f023e92b68fba0a68dd08e08a55e2237015cd17fba5f99c71bb5250757",
+			"MachineKey": "mkey:7235a4e7a715ebb2e32cf455ff19aebedf41731d06299b778ed01ee82d8aec67",
+			"Peers": [{
+				"ID":         1111701973359323,
+				"StableID":   "nxbPYVXVg911CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e451839222d4d0713b74c367f2714ddd0bbc70c54470b84db70ade576bcb3674",
+				"DiscoKey":   "discokey:8594fe0f810f0cb338cc9b9eddc9d062a26c3e1408a5f7b137bbf475a2fb4d18",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51347",
+					"10.65.0.27:51347",
+					"172.17.0.1:51347",
+					"172.18.0.1:51347",
+					"172.19.0.1:51347",
+					"172.20.0.1:51347",
+					"172.21.0.1:51347",
+					"172.22.0.1:51347",
+					"172.23.0.1:51347",
+					"172.24.0.1:51347",
+					"172.25.0.1:51347",
+					"172.26.0.1:51347",
+					"172.27.0.1:51347",
+					"172.28.0.1:51347"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:25:01.694585935Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4911415734779420,
+				"StableID":   "nwJW8fZPMf11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a35ed5a6673587fb5a0a1a04d02e4797e00124b4ef17eb052758c4adde12e232",
+				"DiscoKey":   "discokey:616122b0d87095d607218d9afb941629599e5f2d1958837f66276d16e575543c",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51664",
+					"10.65.0.27:51664",
+					"172.17.0.1:51664",
+					"172.18.0.1:51664",
+					"172.19.0.1:51664",
+					"172.20.0.1:51664",
+					"172.21.0.1:51664",
+					"172.22.0.1:51664",
+					"172.23.0.1:51664",
+					"172.24.0.1:51664",
+					"172.25.0.1:51664",
+					"172.26.0.1:51664",
+					"172.27.0.1:51664",
+					"172.28.0.1:51664"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:25:02.221499655Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8500624626227658,
+				"StableID":   "nHvVCgzwN921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06edbf91eb3ed22390fb155c2c3f4b29a20ca960e48cd2fe0102f64b3598b95c",
+				"DiscoKey":   "discokey:aad7c92a930aa89b46a180ac2de0219e76fe01418f9646d5fdb4f786cdf71b7b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35814",
+					"10.65.0.27:35814",
+					"172.17.0.1:35814",
+					"172.18.0.1:35814",
+					"172.19.0.1:35814",
+					"172.20.0.1:35814",
+					"172.21.0.1:35814",
+					"172.22.0.1:35814",
+					"172.23.0.1:35814",
+					"172.24.0.1:35814",
+					"172.25.0.1:35814",
+					"172.26.0.1:35814",
+					"172.27.0.1:35814",
+					"172.28.0.1:35814"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:25:02.753722365Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1833936728053849,
+				"StableID":   "n8JwdfQbKF11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4ac4692d470556d42f3f9d60a06f76a58452b1337fdec16e3a9838624751253",
+				"DiscoKey":   "discokey:9d2eaceeeb7d9c286601d66c410db58faf4b79837cfdfff0dd71db7eb418030c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53948",
+					"10.65.0.27:53948",
+					"172.17.0.1:53948",
+					"172.18.0.1:53948",
+					"172.19.0.1:53948",
+					"172.20.0.1:53948",
+					"172.21.0.1:53948",
+					"172.22.0.1:53948",
+					"172.23.0.1:53948",
+					"172.24.0.1:53948",
+					"172.25.0.1:53948",
+					"172.26.0.1:53948",
+					"172.27.0.1:53948",
+					"172.28.0.1:53948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:25:03.362885203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8916891682166105,
+				"StableID":   "nayXVCdUdC21CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7396a8e888bab44894aad53453f03dcc72e221b3ceacf0b3d64b70718c10397f",
+				"DiscoKey":   "discokey:69257e4deb9e19803fae62e451670f1fd3fe61b0701827622f2345839e887e31",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:39392",
+					"10.65.0.27:39392",
+					"172.17.0.1:39392",
+					"172.18.0.1:39392",
+					"172.19.0.1:39392",
+					"172.20.0.1:39392",
+					"172.21.0.1:39392",
+					"172.22.0.1:39392",
+					"172.23.0.1:39392",
+					"172.24.0.1:39392",
+					"172.25.0.1:39392",
+					"172.26.0.1:39392",
+					"172.27.0.1:39392",
+					"172.28.0.1:39392"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:25:03.823761506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3571740558468309,
+				"StableID":   "nzFTJwZetU11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f1a595f39e675a814bb45e8ef0eea10d795175ef850c32620bf1bf9506171f0e",
+				"DiscoKey":   "discokey:061847f57788a4bebc9c47608e46578df9d315d7ac49e0234e7f8d5f60413016",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:56939",
+					"10.65.0.27:56939",
+					"172.17.0.1:56939",
+					"172.18.0.1:56939",
+					"172.19.0.1:56939",
+					"172.20.0.1:56939",
+					"172.21.0.1:56939",
+					"172.22.0.1:56939",
+					"172.23.0.1:56939",
+					"172.24.0.1:56939",
+					"172.25.0.1:56939",
+					"172.26.0.1:56939",
+					"172.27.0.1:56939",
+					"172.28.0.1:56939"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:25:04.395397488Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1770706487984919,
+				"StableID":   "nYHwqVTxpE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e779f6731d4c1c49201d941277821cbd0c66668270bd929ac782f4d4b8210572",
+				"DiscoKey":   "discokey:27b9b505ae1072e38ca8d662cc96cf2dd56e65363f2ee504621b48563b2c6648",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:60880",
+					"10.65.0.27:60880",
+					"172.17.0.1:60880",
+					"172.18.0.1:60880",
+					"172.19.0.1:60880",
+					"172.20.0.1:60880",
+					"172.21.0.1:60880",
+					"172.22.0.1:60880",
+					"172.23.0.1:60880",
+					"172.24.0.1:60880",
+					"172.25.0.1:60880",
+					"172.26.0.1:60880",
+					"172.27.0.1:60880",
+					"172.28.0.1:60880"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:25:05.445033397Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7025241854797289,
+				"StableID":   "nWX5u4Ckrw11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2c0ec942bf61a2a90eeacfe4925005a662c17e91b350e3e74bbd3e5e758b639",
+				"DiscoKey":   "discokey:decf0e5cbfefeb892ca3bee860ea419e05f6bbb97a944741661991384fdb7e75",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37443",
+					"10.65.0.27:37443",
+					"172.17.0.1:37443",
+					"172.18.0.1:37443",
+					"172.19.0.1:37443",
+					"172.20.0.1:37443",
+					"172.21.0.1:37443",
+					"172.22.0.1:37443",
+					"172.23.0.1:37443",
+					"172.24.0.1:37443",
+					"172.25.0.1:37443",
+					"172.26.0.1:37443",
+					"172.27.0.1:37443",
+					"172.28.0.1:37443"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:25:05.979820657Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5187642462783807,
+				"StableID":   "n2LyB7aVWh11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4657a71f34c78df771f1f45e9e45bdd6d62e633fdb4b25b05812361ab22ce93d",
+				"DiscoKey":   "discokey:609aa9d2ed0bc217b56060ec3565a4010763a35a88b658c697dcee707074ed6f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:48858",
+					"10.65.0.27:48858",
+					"172.17.0.1:48858",
+					"172.18.0.1:48858",
+					"172.19.0.1:48858",
+					"172.20.0.1:48858",
+					"172.21.0.1:48858",
+					"172.22.0.1:48858",
+					"172.23.0.1:48858",
+					"172.24.0.1:48858",
+					"172.25.0.1:48858",
+					"172.26.0.1:48858",
+					"172.27.0.1:48858",
+					"172.28.0.1:48858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:25:06.511793624Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8893129674967036,
+				"StableID":   "nHbXHKSiSC21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90e1c8e418c74a15316c5382799838ea1f2355157bd129ac34e0f75d78f4572f",
+				"DiscoKey":   "discokey:7eabf39cbd7e2d3bc60a8e36c0e71262c3c5e436c53669a241166a454def3b06",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38891",
+					"10.65.0.27:38891",
+					"172.17.0.1:38891",
+					"172.18.0.1:38891",
+					"172.19.0.1:38891",
+					"172.20.0.1:38891",
+					"172.21.0.1:38891",
+					"172.22.0.1:38891",
+					"172.23.0.1:38891",
+					"172.24.0.1:38891",
+					"172.25.0.1:38891",
+					"172.26.0.1:38891",
+					"172.27.0.1:38891",
+					"172.28.0.1:38891"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:25:07.062390075Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3566739387837422,
+				"StableID":   "n7siyLCPrU11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c50af58ec7631da2d9fb93f381d3ef00558a79c3ddff106abdb731b28a292045",
+				"DiscoKey":   "discokey:d55a9a8c3cdd8905df9995e60657c20f92cdea45279a7acfa7151a8b8f737456",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36435",
+					"10.65.0.27:36435",
+					"172.17.0.1:36435",
+					"172.18.0.1:36435",
+					"172.19.0.1:36435",
+					"172.20.0.1:36435",
+					"172.21.0.1:36435",
+					"172.22.0.1:36435",
+					"172.23.0.1:36435",
+					"172.24.0.1:36435",
+					"172.25.0.1:36435",
+					"172.26.0.1:36435",
+					"172.27.0.1:36435",
+					"172.28.0.1:36435"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:25:07.591294584Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5747196086914171,
+				"StableID":   "nkmRrY6vsm11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:761ed02ba5ec891d31c733faea100d9b97cb2198399bac790e4ff5e144759974",
+				"KeyExpiry":  "2026-11-09T09:25:08Z",
+				"DiscoKey":   "discokey:4d7f7844bdfd4e84f6911d922f22f859b56d90898ceab7c4bf12028eb12e8a0e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:42656",
+					"10.65.0.27:42656",
+					"172.17.0.1:42656",
+					"172.18.0.1:42656",
+					"172.19.0.1:42656",
+					"172.20.0.1:42656",
+					"172.21.0.1:42656",
+					"172.22.0.1:42656",
+					"172.23.0.1:42656",
+					"172.24.0.1:42656",
+					"172.25.0.1:42656",
+					"172.26.0.1:42656",
+					"172.27.0.1:42656",
+					"172.28.0.1:42656"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:25:08.122619339Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1118669416952970,
+				"StableID":   "nTu1gpYej911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5e0da8da6fca608299c957b185242f8e3f4d8c577f50a403fd129ce4f6683203",
+				"KeyExpiry":  "2026-11-09T09:25:08Z",
+				"DiscoKey":   "discokey:d440fb256198020553b4f2eb0bdb3303b74c122673c4f11887d71d5b10f1c75c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59342",
+					"10.65.0.27:59342",
+					"172.17.0.1:59342",
+					"172.18.0.1:59342",
+					"172.19.0.1:59342",
+					"172.20.0.1:59342",
+					"172.21.0.1:59342",
+					"172.22.0.1:59342",
+					"172.23.0.1:59342",
+					"172.24.0.1:59342",
+					"172.25.0.1:59342",
+					"172.26.0.1:59342",
+					"172.27.0.1:59342",
+					"172.28.0.1:59342"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:25:08.655311712Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8926419916096414,
+				"StableID":   "njmzt3vnhC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:cb4ba8073d974c29b0a43072c97be73251548d8cb6f1701240a43a8a0fbb227f",
+				"KeyExpiry":  "2026-11-09T09:25:09Z",
+				"DiscoKey":   "discokey:a13760fbbdedb482e330b42110a2dbfe37899ac465cf55b34483336eb9761d72",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58696",
+					"10.65.0.27:58696",
+					"172.17.0.1:58696",
+					"172.18.0.1:58696",
+					"172.19.0.1:58696",
+					"172.20.0.1:58696",
+					"172.21.0.1:58696",
+					"172.22.0.1:58696",
+					"172.23.0.1:58696",
+					"172.24.0.1:58696",
+					"172.25.0.1:58696",
+					"172.26.0.1:58696",
+					"172.27.0.1:58696",
+					"172.28.0.1:58696"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:25:09.187973528Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4425484544229752": {
+				"ID":          4425484544229752,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7025241854797289,
+				"StableID":   "nWX5u4Ckrw11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       7025241854797289,
+				"Key":        "nodekey:e2c0ec942bf61a2a90eeacfe4925005a662c17e91b350e3e74bbd3e5e758b639",
+				"DiscoKey":   "discokey:decf0e5cbfefeb892ca3bee860ea419e05f6bbb97a944741661991384fdb7e75",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37443",
+					"10.65.0.27:37443",
+					"172.17.0.1:37443",
+					"172.18.0.1:37443",
+					"172.19.0.1:37443",
+					"172.20.0.1:37443",
+					"172.21.0.1:37443",
+					"172.22.0.1:37443",
+					"172.23.0.1:37443",
+					"172.24.0.1:37443",
+					"172.25.0.1:37443",
+					"172.26.0.1:37443",
+					"172.27.0.1:37443",
+					"172.28.0.1:37443"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:25:05.979820657Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e2c0ec942bf61a2a90eeacfe4925005a662c17e91b350e3e74bbd3e5e758b639",
+			"MachineKey": "mkey:9cfb8f69d2ee98b857fd6077cf81943f7269efff8016be92fb719c94d416a025",
+			"Peers": [{
+				"ID":         1111701973359323,
+				"StableID":   "nxbPYVXVg911CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e451839222d4d0713b74c367f2714ddd0bbc70c54470b84db70ade576bcb3674",
+				"DiscoKey":   "discokey:8594fe0f810f0cb338cc9b9eddc9d062a26c3e1408a5f7b137bbf475a2fb4d18",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51347",
+					"10.65.0.27:51347",
+					"172.17.0.1:51347",
+					"172.18.0.1:51347",
+					"172.19.0.1:51347",
+					"172.20.0.1:51347",
+					"172.21.0.1:51347",
+					"172.22.0.1:51347",
+					"172.23.0.1:51347",
+					"172.24.0.1:51347",
+					"172.25.0.1:51347",
+					"172.26.0.1:51347",
+					"172.27.0.1:51347",
+					"172.28.0.1:51347"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:25:01.694585935Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4911415734779420,
+				"StableID":   "nwJW8fZPMf11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a35ed5a6673587fb5a0a1a04d02e4797e00124b4ef17eb052758c4adde12e232",
+				"DiscoKey":   "discokey:616122b0d87095d607218d9afb941629599e5f2d1958837f66276d16e575543c",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51664",
+					"10.65.0.27:51664",
+					"172.17.0.1:51664",
+					"172.18.0.1:51664",
+					"172.19.0.1:51664",
+					"172.20.0.1:51664",
+					"172.21.0.1:51664",
+					"172.22.0.1:51664",
+					"172.23.0.1:51664",
+					"172.24.0.1:51664",
+					"172.25.0.1:51664",
+					"172.26.0.1:51664",
+					"172.27.0.1:51664",
+					"172.28.0.1:51664"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:25:02.221499655Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8500624626227658,
+				"StableID":   "nHvVCgzwN921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06edbf91eb3ed22390fb155c2c3f4b29a20ca960e48cd2fe0102f64b3598b95c",
+				"DiscoKey":   "discokey:aad7c92a930aa89b46a180ac2de0219e76fe01418f9646d5fdb4f786cdf71b7b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35814",
+					"10.65.0.27:35814",
+					"172.17.0.1:35814",
+					"172.18.0.1:35814",
+					"172.19.0.1:35814",
+					"172.20.0.1:35814",
+					"172.21.0.1:35814",
+					"172.22.0.1:35814",
+					"172.23.0.1:35814",
+					"172.24.0.1:35814",
+					"172.25.0.1:35814",
+					"172.26.0.1:35814",
+					"172.27.0.1:35814",
+					"172.28.0.1:35814"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:25:02.753722365Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1833936728053849,
+				"StableID":   "n8JwdfQbKF11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4ac4692d470556d42f3f9d60a06f76a58452b1337fdec16e3a9838624751253",
+				"DiscoKey":   "discokey:9d2eaceeeb7d9c286601d66c410db58faf4b79837cfdfff0dd71db7eb418030c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53948",
+					"10.65.0.27:53948",
+					"172.17.0.1:53948",
+					"172.18.0.1:53948",
+					"172.19.0.1:53948",
+					"172.20.0.1:53948",
+					"172.21.0.1:53948",
+					"172.22.0.1:53948",
+					"172.23.0.1:53948",
+					"172.24.0.1:53948",
+					"172.25.0.1:53948",
+					"172.26.0.1:53948",
+					"172.27.0.1:53948",
+					"172.28.0.1:53948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:25:03.362885203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8916891682166105,
+				"StableID":   "nayXVCdUdC21CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7396a8e888bab44894aad53453f03dcc72e221b3ceacf0b3d64b70718c10397f",
+				"DiscoKey":   "discokey:69257e4deb9e19803fae62e451670f1fd3fe61b0701827622f2345839e887e31",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:39392",
+					"10.65.0.27:39392",
+					"172.17.0.1:39392",
+					"172.18.0.1:39392",
+					"172.19.0.1:39392",
+					"172.20.0.1:39392",
+					"172.21.0.1:39392",
+					"172.22.0.1:39392",
+					"172.23.0.1:39392",
+					"172.24.0.1:39392",
+					"172.25.0.1:39392",
+					"172.26.0.1:39392",
+					"172.27.0.1:39392",
+					"172.28.0.1:39392"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:25:03.823761506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3571740558468309,
+				"StableID":   "nzFTJwZetU11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f1a595f39e675a814bb45e8ef0eea10d795175ef850c32620bf1bf9506171f0e",
+				"DiscoKey":   "discokey:061847f57788a4bebc9c47608e46578df9d315d7ac49e0234e7f8d5f60413016",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:56939",
+					"10.65.0.27:56939",
+					"172.17.0.1:56939",
+					"172.18.0.1:56939",
+					"172.19.0.1:56939",
+					"172.20.0.1:56939",
+					"172.21.0.1:56939",
+					"172.22.0.1:56939",
+					"172.23.0.1:56939",
+					"172.24.0.1:56939",
+					"172.25.0.1:56939",
+					"172.26.0.1:56939",
+					"172.27.0.1:56939",
+					"172.28.0.1:56939"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:25:04.395397488Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4425484544229752,
+				"StableID":   "nfLCpXyJZb11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:827790f023e92b68fba0a68dd08e08a55e2237015cd17fba5f99c71bb5250757",
+				"DiscoKey":   "discokey:7f1bc9df669823b23999208b378ab60dd73cf61507878580423ad35a7642ca11",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50699",
+					"10.65.0.27:50699",
+					"172.17.0.1:50699",
+					"172.18.0.1:50699",
+					"172.19.0.1:50699",
+					"172.20.0.1:50699",
+					"172.21.0.1:50699",
+					"172.22.0.1:50699",
+					"172.23.0.1:50699",
+					"172.24.0.1:50699",
+					"172.25.0.1:50699",
+					"172.26.0.1:50699",
+					"172.27.0.1:50699",
+					"172.28.0.1:50699"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:25:04.904792855Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1770706487984919,
+				"StableID":   "nYHwqVTxpE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e779f6731d4c1c49201d941277821cbd0c66668270bd929ac782f4d4b8210572",
+				"DiscoKey":   "discokey:27b9b505ae1072e38ca8d662cc96cf2dd56e65363f2ee504621b48563b2c6648",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:60880",
+					"10.65.0.27:60880",
+					"172.17.0.1:60880",
+					"172.18.0.1:60880",
+					"172.19.0.1:60880",
+					"172.20.0.1:60880",
+					"172.21.0.1:60880",
+					"172.22.0.1:60880",
+					"172.23.0.1:60880",
+					"172.24.0.1:60880",
+					"172.25.0.1:60880",
+					"172.26.0.1:60880",
+					"172.27.0.1:60880",
+					"172.28.0.1:60880"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:25:05.445033397Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5187642462783807,
+				"StableID":   "n2LyB7aVWh11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4657a71f34c78df771f1f45e9e45bdd6d62e633fdb4b25b05812361ab22ce93d",
+				"DiscoKey":   "discokey:609aa9d2ed0bc217b56060ec3565a4010763a35a88b658c697dcee707074ed6f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:48858",
+					"10.65.0.27:48858",
+					"172.17.0.1:48858",
+					"172.18.0.1:48858",
+					"172.19.0.1:48858",
+					"172.20.0.1:48858",
+					"172.21.0.1:48858",
+					"172.22.0.1:48858",
+					"172.23.0.1:48858",
+					"172.24.0.1:48858",
+					"172.25.0.1:48858",
+					"172.26.0.1:48858",
+					"172.27.0.1:48858",
+					"172.28.0.1:48858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:25:06.511793624Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8893129674967036,
+				"StableID":   "nHbXHKSiSC21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90e1c8e418c74a15316c5382799838ea1f2355157bd129ac34e0f75d78f4572f",
+				"DiscoKey":   "discokey:7eabf39cbd7e2d3bc60a8e36c0e71262c3c5e436c53669a241166a454def3b06",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38891",
+					"10.65.0.27:38891",
+					"172.17.0.1:38891",
+					"172.18.0.1:38891",
+					"172.19.0.1:38891",
+					"172.20.0.1:38891",
+					"172.21.0.1:38891",
+					"172.22.0.1:38891",
+					"172.23.0.1:38891",
+					"172.24.0.1:38891",
+					"172.25.0.1:38891",
+					"172.26.0.1:38891",
+					"172.27.0.1:38891",
+					"172.28.0.1:38891"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:25:07.062390075Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3566739387837422,
+				"StableID":   "n7siyLCPrU11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c50af58ec7631da2d9fb93f381d3ef00558a79c3ddff106abdb731b28a292045",
+				"DiscoKey":   "discokey:d55a9a8c3cdd8905df9995e60657c20f92cdea45279a7acfa7151a8b8f737456",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36435",
+					"10.65.0.27:36435",
+					"172.17.0.1:36435",
+					"172.18.0.1:36435",
+					"172.19.0.1:36435",
+					"172.20.0.1:36435",
+					"172.21.0.1:36435",
+					"172.22.0.1:36435",
+					"172.23.0.1:36435",
+					"172.24.0.1:36435",
+					"172.25.0.1:36435",
+					"172.26.0.1:36435",
+					"172.27.0.1:36435",
+					"172.28.0.1:36435"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:25:07.591294584Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5747196086914171,
+				"StableID":   "nkmRrY6vsm11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:761ed02ba5ec891d31c733faea100d9b97cb2198399bac790e4ff5e144759974",
+				"KeyExpiry":  "2026-11-09T09:25:08Z",
+				"DiscoKey":   "discokey:4d7f7844bdfd4e84f6911d922f22f859b56d90898ceab7c4bf12028eb12e8a0e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:42656",
+					"10.65.0.27:42656",
+					"172.17.0.1:42656",
+					"172.18.0.1:42656",
+					"172.19.0.1:42656",
+					"172.20.0.1:42656",
+					"172.21.0.1:42656",
+					"172.22.0.1:42656",
+					"172.23.0.1:42656",
+					"172.24.0.1:42656",
+					"172.25.0.1:42656",
+					"172.26.0.1:42656",
+					"172.27.0.1:42656",
+					"172.28.0.1:42656"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:25:08.122619339Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1118669416952970,
+				"StableID":   "nTu1gpYej911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5e0da8da6fca608299c957b185242f8e3f4d8c577f50a403fd129ce4f6683203",
+				"KeyExpiry":  "2026-11-09T09:25:08Z",
+				"DiscoKey":   "discokey:d440fb256198020553b4f2eb0bdb3303b74c122673c4f11887d71d5b10f1c75c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59342",
+					"10.65.0.27:59342",
+					"172.17.0.1:59342",
+					"172.18.0.1:59342",
+					"172.19.0.1:59342",
+					"172.20.0.1:59342",
+					"172.21.0.1:59342",
+					"172.22.0.1:59342",
+					"172.23.0.1:59342",
+					"172.24.0.1:59342",
+					"172.25.0.1:59342",
+					"172.26.0.1:59342",
+					"172.27.0.1:59342",
+					"172.28.0.1:59342"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:25:08.655311712Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8926419916096414,
+				"StableID":   "njmzt3vnhC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:cb4ba8073d974c29b0a43072c97be73251548d8cb6f1701240a43a8a0fbb227f",
+				"KeyExpiry":  "2026-11-09T09:25:09Z",
+				"DiscoKey":   "discokey:a13760fbbdedb482e330b42110a2dbfe37899ac465cf55b34483336eb9761d72",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58696",
+					"10.65.0.27:58696",
+					"172.17.0.1:58696",
+					"172.18.0.1:58696",
+					"172.19.0.1:58696",
+					"172.20.0.1:58696",
+					"172.21.0.1:58696",
+					"172.22.0.1:58696",
+					"172.23.0.1:58696",
+					"172.24.0.1:58696",
+					"172.25.0.1:58696",
+					"172.26.0.1:58696",
+					"172.27.0.1:58696",
+					"172.28.0.1:58696"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:25:09.187973528Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7025241854797289": {
+				"ID":          7025241854797289,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1118669416952970,
+				"StableID":   "nTu1gpYej911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5e0da8da6fca608299c957b185242f8e3f4d8c577f50a403fd129ce4f6683203",
+				"KeyExpiry":  "2026-11-09T09:25:08Z",
+				"DiscoKey":   "discokey:d440fb256198020553b4f2eb0bdb3303b74c122673c4f11887d71d5b10f1c75c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59342",
+					"10.65.0.27:59342",
+					"172.17.0.1:59342",
+					"172.18.0.1:59342",
+					"172.19.0.1:59342",
+					"172.20.0.1:59342",
+					"172.21.0.1:59342",
+					"172.22.0.1:59342",
+					"172.23.0.1:59342",
+					"172.24.0.1:59342",
+					"172.25.0.1:59342",
+					"172.26.0.1:59342",
+					"172.27.0.1:59342",
+					"172.28.0.1:59342"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:25:08.655311712Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5e0da8da6fca608299c957b185242f8e3f4d8c577f50a403fd129ce4f6683203",
+			"MachineKey": "mkey:725bdb6a3e7b4744ec1069f020ddba55a3c54518dc87f63e439f532e831ff02e",
+			"Peers": [{
+				"ID":         1111701973359323,
+				"StableID":   "nxbPYVXVg911CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e451839222d4d0713b74c367f2714ddd0bbc70c54470b84db70ade576bcb3674",
+				"DiscoKey":   "discokey:8594fe0f810f0cb338cc9b9eddc9d062a26c3e1408a5f7b137bbf475a2fb4d18",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51347",
+					"10.65.0.27:51347",
+					"172.17.0.1:51347",
+					"172.18.0.1:51347",
+					"172.19.0.1:51347",
+					"172.20.0.1:51347",
+					"172.21.0.1:51347",
+					"172.22.0.1:51347",
+					"172.23.0.1:51347",
+					"172.24.0.1:51347",
+					"172.25.0.1:51347",
+					"172.26.0.1:51347",
+					"172.27.0.1:51347",
+					"172.28.0.1:51347"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:25:01.694585935Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4911415734779420,
+				"StableID":   "nwJW8fZPMf11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a35ed5a6673587fb5a0a1a04d02e4797e00124b4ef17eb052758c4adde12e232",
+				"DiscoKey":   "discokey:616122b0d87095d607218d9afb941629599e5f2d1958837f66276d16e575543c",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51664",
+					"10.65.0.27:51664",
+					"172.17.0.1:51664",
+					"172.18.0.1:51664",
+					"172.19.0.1:51664",
+					"172.20.0.1:51664",
+					"172.21.0.1:51664",
+					"172.22.0.1:51664",
+					"172.23.0.1:51664",
+					"172.24.0.1:51664",
+					"172.25.0.1:51664",
+					"172.26.0.1:51664",
+					"172.27.0.1:51664",
+					"172.28.0.1:51664"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:25:02.221499655Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8500624626227658,
+				"StableID":   "nHvVCgzwN921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06edbf91eb3ed22390fb155c2c3f4b29a20ca960e48cd2fe0102f64b3598b95c",
+				"DiscoKey":   "discokey:aad7c92a930aa89b46a180ac2de0219e76fe01418f9646d5fdb4f786cdf71b7b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35814",
+					"10.65.0.27:35814",
+					"172.17.0.1:35814",
+					"172.18.0.1:35814",
+					"172.19.0.1:35814",
+					"172.20.0.1:35814",
+					"172.21.0.1:35814",
+					"172.22.0.1:35814",
+					"172.23.0.1:35814",
+					"172.24.0.1:35814",
+					"172.25.0.1:35814",
+					"172.26.0.1:35814",
+					"172.27.0.1:35814",
+					"172.28.0.1:35814"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:25:02.753722365Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1833936728053849,
+				"StableID":   "n8JwdfQbKF11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4ac4692d470556d42f3f9d60a06f76a58452b1337fdec16e3a9838624751253",
+				"DiscoKey":   "discokey:9d2eaceeeb7d9c286601d66c410db58faf4b79837cfdfff0dd71db7eb418030c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53948",
+					"10.65.0.27:53948",
+					"172.17.0.1:53948",
+					"172.18.0.1:53948",
+					"172.19.0.1:53948",
+					"172.20.0.1:53948",
+					"172.21.0.1:53948",
+					"172.22.0.1:53948",
+					"172.23.0.1:53948",
+					"172.24.0.1:53948",
+					"172.25.0.1:53948",
+					"172.26.0.1:53948",
+					"172.27.0.1:53948",
+					"172.28.0.1:53948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:25:03.362885203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8916891682166105,
+				"StableID":   "nayXVCdUdC21CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7396a8e888bab44894aad53453f03dcc72e221b3ceacf0b3d64b70718c10397f",
+				"DiscoKey":   "discokey:69257e4deb9e19803fae62e451670f1fd3fe61b0701827622f2345839e887e31",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:39392",
+					"10.65.0.27:39392",
+					"172.17.0.1:39392",
+					"172.18.0.1:39392",
+					"172.19.0.1:39392",
+					"172.20.0.1:39392",
+					"172.21.0.1:39392",
+					"172.22.0.1:39392",
+					"172.23.0.1:39392",
+					"172.24.0.1:39392",
+					"172.25.0.1:39392",
+					"172.26.0.1:39392",
+					"172.27.0.1:39392",
+					"172.28.0.1:39392"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:25:03.823761506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3571740558468309,
+				"StableID":   "nzFTJwZetU11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f1a595f39e675a814bb45e8ef0eea10d795175ef850c32620bf1bf9506171f0e",
+				"DiscoKey":   "discokey:061847f57788a4bebc9c47608e46578df9d315d7ac49e0234e7f8d5f60413016",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:56939",
+					"10.65.0.27:56939",
+					"172.17.0.1:56939",
+					"172.18.0.1:56939",
+					"172.19.0.1:56939",
+					"172.20.0.1:56939",
+					"172.21.0.1:56939",
+					"172.22.0.1:56939",
+					"172.23.0.1:56939",
+					"172.24.0.1:56939",
+					"172.25.0.1:56939",
+					"172.26.0.1:56939",
+					"172.27.0.1:56939",
+					"172.28.0.1:56939"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:25:04.395397488Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4425484544229752,
+				"StableID":   "nfLCpXyJZb11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:827790f023e92b68fba0a68dd08e08a55e2237015cd17fba5f99c71bb5250757",
+				"DiscoKey":   "discokey:7f1bc9df669823b23999208b378ab60dd73cf61507878580423ad35a7642ca11",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50699",
+					"10.65.0.27:50699",
+					"172.17.0.1:50699",
+					"172.18.0.1:50699",
+					"172.19.0.1:50699",
+					"172.20.0.1:50699",
+					"172.21.0.1:50699",
+					"172.22.0.1:50699",
+					"172.23.0.1:50699",
+					"172.24.0.1:50699",
+					"172.25.0.1:50699",
+					"172.26.0.1:50699",
+					"172.27.0.1:50699",
+					"172.28.0.1:50699"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:25:04.904792855Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1770706487984919,
+				"StableID":   "nYHwqVTxpE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e779f6731d4c1c49201d941277821cbd0c66668270bd929ac782f4d4b8210572",
+				"DiscoKey":   "discokey:27b9b505ae1072e38ca8d662cc96cf2dd56e65363f2ee504621b48563b2c6648",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:60880",
+					"10.65.0.27:60880",
+					"172.17.0.1:60880",
+					"172.18.0.1:60880",
+					"172.19.0.1:60880",
+					"172.20.0.1:60880",
+					"172.21.0.1:60880",
+					"172.22.0.1:60880",
+					"172.23.0.1:60880",
+					"172.24.0.1:60880",
+					"172.25.0.1:60880",
+					"172.26.0.1:60880",
+					"172.27.0.1:60880",
+					"172.28.0.1:60880"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:25:05.445033397Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7025241854797289,
+				"StableID":   "nWX5u4Ckrw11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2c0ec942bf61a2a90eeacfe4925005a662c17e91b350e3e74bbd3e5e758b639",
+				"DiscoKey":   "discokey:decf0e5cbfefeb892ca3bee860ea419e05f6bbb97a944741661991384fdb7e75",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37443",
+					"10.65.0.27:37443",
+					"172.17.0.1:37443",
+					"172.18.0.1:37443",
+					"172.19.0.1:37443",
+					"172.20.0.1:37443",
+					"172.21.0.1:37443",
+					"172.22.0.1:37443",
+					"172.23.0.1:37443",
+					"172.24.0.1:37443",
+					"172.25.0.1:37443",
+					"172.26.0.1:37443",
+					"172.27.0.1:37443",
+					"172.28.0.1:37443"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:25:05.979820657Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5187642462783807,
+				"StableID":   "n2LyB7aVWh11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4657a71f34c78df771f1f45e9e45bdd6d62e633fdb4b25b05812361ab22ce93d",
+				"DiscoKey":   "discokey:609aa9d2ed0bc217b56060ec3565a4010763a35a88b658c697dcee707074ed6f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:48858",
+					"10.65.0.27:48858",
+					"172.17.0.1:48858",
+					"172.18.0.1:48858",
+					"172.19.0.1:48858",
+					"172.20.0.1:48858",
+					"172.21.0.1:48858",
+					"172.22.0.1:48858",
+					"172.23.0.1:48858",
+					"172.24.0.1:48858",
+					"172.25.0.1:48858",
+					"172.26.0.1:48858",
+					"172.27.0.1:48858",
+					"172.28.0.1:48858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:25:06.511793624Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8893129674967036,
+				"StableID":   "nHbXHKSiSC21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90e1c8e418c74a15316c5382799838ea1f2355157bd129ac34e0f75d78f4572f",
+				"DiscoKey":   "discokey:7eabf39cbd7e2d3bc60a8e36c0e71262c3c5e436c53669a241166a454def3b06",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38891",
+					"10.65.0.27:38891",
+					"172.17.0.1:38891",
+					"172.18.0.1:38891",
+					"172.19.0.1:38891",
+					"172.20.0.1:38891",
+					"172.21.0.1:38891",
+					"172.22.0.1:38891",
+					"172.23.0.1:38891",
+					"172.24.0.1:38891",
+					"172.25.0.1:38891",
+					"172.26.0.1:38891",
+					"172.27.0.1:38891",
+					"172.28.0.1:38891"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:25:07.062390075Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3566739387837422,
+				"StableID":   "n7siyLCPrU11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c50af58ec7631da2d9fb93f381d3ef00558a79c3ddff106abdb731b28a292045",
+				"DiscoKey":   "discokey:d55a9a8c3cdd8905df9995e60657c20f92cdea45279a7acfa7151a8b8f737456",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36435",
+					"10.65.0.27:36435",
+					"172.17.0.1:36435",
+					"172.18.0.1:36435",
+					"172.19.0.1:36435",
+					"172.20.0.1:36435",
+					"172.21.0.1:36435",
+					"172.22.0.1:36435",
+					"172.23.0.1:36435",
+					"172.24.0.1:36435",
+					"172.25.0.1:36435",
+					"172.26.0.1:36435",
+					"172.27.0.1:36435",
+					"172.28.0.1:36435"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:25:07.591294584Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5747196086914171,
+				"StableID":   "nkmRrY6vsm11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:761ed02ba5ec891d31c733faea100d9b97cb2198399bac790e4ff5e144759974",
+				"KeyExpiry":  "2026-11-09T09:25:08Z",
+				"DiscoKey":   "discokey:4d7f7844bdfd4e84f6911d922f22f859b56d90898ceab7c4bf12028eb12e8a0e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:42656",
+					"10.65.0.27:42656",
+					"172.17.0.1:42656",
+					"172.18.0.1:42656",
+					"172.19.0.1:42656",
+					"172.20.0.1:42656",
+					"172.21.0.1:42656",
+					"172.22.0.1:42656",
+					"172.23.0.1:42656",
+					"172.24.0.1:42656",
+					"172.25.0.1:42656",
+					"172.26.0.1:42656",
+					"172.27.0.1:42656",
+					"172.28.0.1:42656"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:25:08.122619339Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8926419916096414,
+				"StableID":   "njmzt3vnhC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:cb4ba8073d974c29b0a43072c97be73251548d8cb6f1701240a43a8a0fbb227f",
+				"KeyExpiry":  "2026-11-09T09:25:09Z",
+				"DiscoKey":   "discokey:a13760fbbdedb482e330b42110a2dbfe37899ac465cf55b34483336eb9761d72",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58696",
+					"10.65.0.27:58696",
+					"172.17.0.1:58696",
+					"172.18.0.1:58696",
+					"172.19.0.1:58696",
+					"172.20.0.1:58696",
+					"172.21.0.1:58696",
+					"172.22.0.1:58696",
+					"172.23.0.1:58696",
+					"172.24.0.1:58696",
+					"172.25.0.1:58696",
+					"172.26.0.1:58696",
+					"172.27.0.1:58696",
+					"172.28.0.1:58696"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:25:09.187973528Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5187642462783807,
+				"StableID":   "n2LyB7aVWh11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       5187642462783807,
+				"Key":        "nodekey:4657a71f34c78df771f1f45e9e45bdd6d62e633fdb4b25b05812361ab22ce93d",
+				"DiscoKey":   "discokey:609aa9d2ed0bc217b56060ec3565a4010763a35a88b658c697dcee707074ed6f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:48858",
+					"10.65.0.27:48858",
+					"172.17.0.1:48858",
+					"172.18.0.1:48858",
+					"172.19.0.1:48858",
+					"172.20.0.1:48858",
+					"172.21.0.1:48858",
+					"172.22.0.1:48858",
+					"172.23.0.1:48858",
+					"172.24.0.1:48858",
+					"172.25.0.1:48858",
+					"172.26.0.1:48858",
+					"172.27.0.1:48858",
+					"172.28.0.1:48858"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:25:06.511793624Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4657a71f34c78df771f1f45e9e45bdd6d62e633fdb4b25b05812361ab22ce93d",
+			"MachineKey": "mkey:ca76640fd1a93837bbc5208a2c74b87d08aec6c2e100eb5977fa19e1e0680b48",
+			"Peers": [{
+				"ID":         1111701973359323,
+				"StableID":   "nxbPYVXVg911CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e451839222d4d0713b74c367f2714ddd0bbc70c54470b84db70ade576bcb3674",
+				"DiscoKey":   "discokey:8594fe0f810f0cb338cc9b9eddc9d062a26c3e1408a5f7b137bbf475a2fb4d18",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:51347",
+					"10.65.0.27:51347",
+					"172.17.0.1:51347",
+					"172.18.0.1:51347",
+					"172.19.0.1:51347",
+					"172.20.0.1:51347",
+					"172.21.0.1:51347",
+					"172.22.0.1:51347",
+					"172.23.0.1:51347",
+					"172.24.0.1:51347",
+					"172.25.0.1:51347",
+					"172.26.0.1:51347",
+					"172.27.0.1:51347",
+					"172.28.0.1:51347"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:25:01.694585935Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4911415734779420,
+				"StableID":   "nwJW8fZPMf11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a35ed5a6673587fb5a0a1a04d02e4797e00124b4ef17eb052758c4adde12e232",
+				"DiscoKey":   "discokey:616122b0d87095d607218d9afb941629599e5f2d1958837f66276d16e575543c",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:51664",
+					"10.65.0.27:51664",
+					"172.17.0.1:51664",
+					"172.18.0.1:51664",
+					"172.19.0.1:51664",
+					"172.20.0.1:51664",
+					"172.21.0.1:51664",
+					"172.22.0.1:51664",
+					"172.23.0.1:51664",
+					"172.24.0.1:51664",
+					"172.25.0.1:51664",
+					"172.26.0.1:51664",
+					"172.27.0.1:51664",
+					"172.28.0.1:51664"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:25:02.221499655Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8500624626227658,
+				"StableID":   "nHvVCgzwN921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:06edbf91eb3ed22390fb155c2c3f4b29a20ca960e48cd2fe0102f64b3598b95c",
+				"DiscoKey":   "discokey:aad7c92a930aa89b46a180ac2de0219e76fe01418f9646d5fdb4f786cdf71b7b",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35814",
+					"10.65.0.27:35814",
+					"172.17.0.1:35814",
+					"172.18.0.1:35814",
+					"172.19.0.1:35814",
+					"172.20.0.1:35814",
+					"172.21.0.1:35814",
+					"172.22.0.1:35814",
+					"172.23.0.1:35814",
+					"172.24.0.1:35814",
+					"172.25.0.1:35814",
+					"172.26.0.1:35814",
+					"172.27.0.1:35814",
+					"172.28.0.1:35814"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:25:02.753722365Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1833936728053849,
+				"StableID":   "n8JwdfQbKF11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4ac4692d470556d42f3f9d60a06f76a58452b1337fdec16e3a9838624751253",
+				"DiscoKey":   "discokey:9d2eaceeeb7d9c286601d66c410db58faf4b79837cfdfff0dd71db7eb418030c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53948",
+					"10.65.0.27:53948",
+					"172.17.0.1:53948",
+					"172.18.0.1:53948",
+					"172.19.0.1:53948",
+					"172.20.0.1:53948",
+					"172.21.0.1:53948",
+					"172.22.0.1:53948",
+					"172.23.0.1:53948",
+					"172.24.0.1:53948",
+					"172.25.0.1:53948",
+					"172.26.0.1:53948",
+					"172.27.0.1:53948",
+					"172.28.0.1:53948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:25:03.362885203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8916891682166105,
+				"StableID":   "nayXVCdUdC21CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7396a8e888bab44894aad53453f03dcc72e221b3ceacf0b3d64b70718c10397f",
+				"DiscoKey":   "discokey:69257e4deb9e19803fae62e451670f1fd3fe61b0701827622f2345839e887e31",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:39392",
+					"10.65.0.27:39392",
+					"172.17.0.1:39392",
+					"172.18.0.1:39392",
+					"172.19.0.1:39392",
+					"172.20.0.1:39392",
+					"172.21.0.1:39392",
+					"172.22.0.1:39392",
+					"172.23.0.1:39392",
+					"172.24.0.1:39392",
+					"172.25.0.1:39392",
+					"172.26.0.1:39392",
+					"172.27.0.1:39392",
+					"172.28.0.1:39392"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:25:03.823761506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3571740558468309,
+				"StableID":   "nzFTJwZetU11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f1a595f39e675a814bb45e8ef0eea10d795175ef850c32620bf1bf9506171f0e",
+				"DiscoKey":   "discokey:061847f57788a4bebc9c47608e46578df9d315d7ac49e0234e7f8d5f60413016",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:56939",
+					"10.65.0.27:56939",
+					"172.17.0.1:56939",
+					"172.18.0.1:56939",
+					"172.19.0.1:56939",
+					"172.20.0.1:56939",
+					"172.21.0.1:56939",
+					"172.22.0.1:56939",
+					"172.23.0.1:56939",
+					"172.24.0.1:56939",
+					"172.25.0.1:56939",
+					"172.26.0.1:56939",
+					"172.27.0.1:56939",
+					"172.28.0.1:56939"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:25:04.395397488Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4425484544229752,
+				"StableID":   "nfLCpXyJZb11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:827790f023e92b68fba0a68dd08e08a55e2237015cd17fba5f99c71bb5250757",
+				"DiscoKey":   "discokey:7f1bc9df669823b23999208b378ab60dd73cf61507878580423ad35a7642ca11",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50699",
+					"10.65.0.27:50699",
+					"172.17.0.1:50699",
+					"172.18.0.1:50699",
+					"172.19.0.1:50699",
+					"172.20.0.1:50699",
+					"172.21.0.1:50699",
+					"172.22.0.1:50699",
+					"172.23.0.1:50699",
+					"172.24.0.1:50699",
+					"172.25.0.1:50699",
+					"172.26.0.1:50699",
+					"172.27.0.1:50699",
+					"172.28.0.1:50699"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:25:04.904792855Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1770706487984919,
+				"StableID":   "nYHwqVTxpE11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e779f6731d4c1c49201d941277821cbd0c66668270bd929ac782f4d4b8210572",
+				"DiscoKey":   "discokey:27b9b505ae1072e38ca8d662cc96cf2dd56e65363f2ee504621b48563b2c6648",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:60880",
+					"10.65.0.27:60880",
+					"172.17.0.1:60880",
+					"172.18.0.1:60880",
+					"172.19.0.1:60880",
+					"172.20.0.1:60880",
+					"172.21.0.1:60880",
+					"172.22.0.1:60880",
+					"172.23.0.1:60880",
+					"172.24.0.1:60880",
+					"172.25.0.1:60880",
+					"172.26.0.1:60880",
+					"172.27.0.1:60880",
+					"172.28.0.1:60880"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:25:05.445033397Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7025241854797289,
+				"StableID":   "nWX5u4Ckrw11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2c0ec942bf61a2a90eeacfe4925005a662c17e91b350e3e74bbd3e5e758b639",
+				"DiscoKey":   "discokey:decf0e5cbfefeb892ca3bee860ea419e05f6bbb97a944741661991384fdb7e75",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37443",
+					"10.65.0.27:37443",
+					"172.17.0.1:37443",
+					"172.18.0.1:37443",
+					"172.19.0.1:37443",
+					"172.20.0.1:37443",
+					"172.21.0.1:37443",
+					"172.22.0.1:37443",
+					"172.23.0.1:37443",
+					"172.24.0.1:37443",
+					"172.25.0.1:37443",
+					"172.26.0.1:37443",
+					"172.27.0.1:37443",
+					"172.28.0.1:37443"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:25:05.979820657Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8893129674967036,
+				"StableID":   "nHbXHKSiSC21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90e1c8e418c74a15316c5382799838ea1f2355157bd129ac34e0f75d78f4572f",
+				"DiscoKey":   "discokey:7eabf39cbd7e2d3bc60a8e36c0e71262c3c5e436c53669a241166a454def3b06",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38891",
+					"10.65.0.27:38891",
+					"172.17.0.1:38891",
+					"172.18.0.1:38891",
+					"172.19.0.1:38891",
+					"172.20.0.1:38891",
+					"172.21.0.1:38891",
+					"172.22.0.1:38891",
+					"172.23.0.1:38891",
+					"172.24.0.1:38891",
+					"172.25.0.1:38891",
+					"172.26.0.1:38891",
+					"172.27.0.1:38891",
+					"172.28.0.1:38891"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:25:07.062390075Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3566739387837422,
+				"StableID":   "n7siyLCPrU11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c50af58ec7631da2d9fb93f381d3ef00558a79c3ddff106abdb731b28a292045",
+				"DiscoKey":   "discokey:d55a9a8c3cdd8905df9995e60657c20f92cdea45279a7acfa7151a8b8f737456",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:36435",
+					"10.65.0.27:36435",
+					"172.17.0.1:36435",
+					"172.18.0.1:36435",
+					"172.19.0.1:36435",
+					"172.20.0.1:36435",
+					"172.21.0.1:36435",
+					"172.22.0.1:36435",
+					"172.23.0.1:36435",
+					"172.24.0.1:36435",
+					"172.25.0.1:36435",
+					"172.26.0.1:36435",
+					"172.27.0.1:36435",
+					"172.28.0.1:36435"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:25:07.591294584Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5747196086914171,
+				"StableID":   "nkmRrY6vsm11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:761ed02ba5ec891d31c733faea100d9b97cb2198399bac790e4ff5e144759974",
+				"KeyExpiry":  "2026-11-09T09:25:08Z",
+				"DiscoKey":   "discokey:4d7f7844bdfd4e84f6911d922f22f859b56d90898ceab7c4bf12028eb12e8a0e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:42656",
+					"10.65.0.27:42656",
+					"172.17.0.1:42656",
+					"172.18.0.1:42656",
+					"172.19.0.1:42656",
+					"172.20.0.1:42656",
+					"172.21.0.1:42656",
+					"172.22.0.1:42656",
+					"172.23.0.1:42656",
+					"172.24.0.1:42656",
+					"172.25.0.1:42656",
+					"172.26.0.1:42656",
+					"172.27.0.1:42656",
+					"172.28.0.1:42656"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:25:08.122619339Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1118669416952970,
+				"StableID":   "nTu1gpYej911CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5e0da8da6fca608299c957b185242f8e3f4d8c577f50a403fd129ce4f6683203",
+				"KeyExpiry":  "2026-11-09T09:25:08Z",
+				"DiscoKey":   "discokey:d440fb256198020553b4f2eb0bdb3303b74c122673c4f11887d71d5b10f1c75c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59342",
+					"10.65.0.27:59342",
+					"172.17.0.1:59342",
+					"172.18.0.1:59342",
+					"172.19.0.1:59342",
+					"172.20.0.1:59342",
+					"172.21.0.1:59342",
+					"172.22.0.1:59342",
+					"172.23.0.1:59342",
+					"172.24.0.1:59342",
+					"172.25.0.1:59342",
+					"172.26.0.1:59342",
+					"172.27.0.1:59342",
+					"172.28.0.1:59342"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:25:08.655311712Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8926419916096414,
+				"StableID":   "njmzt3vnhC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:cb4ba8073d974c29b0a43072c97be73251548d8cb6f1701240a43a8a0fbb227f",
+				"KeyExpiry":  "2026-11-09T09:25:09Z",
+				"DiscoKey":   "discokey:a13760fbbdedb482e330b42110a2dbfe37899ac465cf55b34483336eb9761d72",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:58696",
+					"10.65.0.27:58696",
+					"172.17.0.1:58696",
+					"172.18.0.1:58696",
+					"172.19.0.1:58696",
+					"172.20.0.1:58696",
+					"172.21.0.1:58696",
+					"172.22.0.1:58696",
+					"172.23.0.1:58696",
+					"172.24.0.1:58696",
+					"172.25.0.1:58696",
+					"172.26.0.1:58696",
+					"172.27.0.1:58696",
+					"172.28.0.1:58696"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:25:09.187973528Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5187642462783807": {
+				"ID":          5187642462783807,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-unicode-cyrillic-tag.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-unicode-cyrillic-tag.hujson
@@ -1,0 +1,21880 @@
+// ssh-unicode-cyrillic-tag
+//
+// ssh tag with Cyrillic letters
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-13T09:25:55Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-unicode-cyrillic-tag",
+	"description":    "ssh tag with Cyrillic letters",
+	"category":       "ssh",
+	"captured_at":    "2026-05-13T09:25:55.16616756Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {
+			"message": "tagOwners[\"tag:сервер\"]: tag names must start with a letter, after 'tag:'"
+		},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                           \n  \n                                                                         \n                                                          \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh tag with Cyrillic letters\",\n\t\"id\":          \"ssh-unicode-cyrillic-tag\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:сервер\"],\n\t\t\"src\":    [\"thor@example.org\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"tagOwners\": {\"tag:сервер\": [\"odin@example.com\"]}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-edges/ssh-unicode-cyrillic-tag.hujson",
+		"full_policy": {"ssh": [{
+			"action": "accept",
+			"dst":    ["tag:сервер"],
+			"src":    ["thor@example.org"],
+			"users":  ["root"]
+		}], "tagOwners": {"tag:сервер": ["odin@example.com"]}}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5988788433583050,
+				"StableID":   "nDUXEPKLmo11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       5988788433583050,
+				"Key":        "nodekey:d03a57906aa1dcff0d05193c0435a9eb9d64922dad7b8feb5dfbaaef357a497a",
+				"DiscoKey":   "discokey:6276f751d145f796fb617ea1cfdf067350d436709901b15750b0bbb8f80c2a59",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35096",
+					"10.65.0.27:35096",
+					"172.17.0.1:35096",
+					"172.18.0.1:35096",
+					"172.19.0.1:35096",
+					"172.20.0.1:35096",
+					"172.21.0.1:35096",
+					"172.22.0.1:35096",
+					"172.23.0.1:35096",
+					"172.24.0.1:35096",
+					"172.25.0.1:35096",
+					"172.26.0.1:35096",
+					"172.27.0.1:35096"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:26:03.441102354Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d03a57906aa1dcff0d05193c0435a9eb9d64922dad7b8feb5dfbaaef357a497a",
+			"MachineKey": "mkey:279ebbed8a5801f4251035b37fcc5cddca311b2f483503d97ead41f1b5289c2f",
+			"Peers": [{
+				"ID":         8343158374485682,
+				"StableID":   "ndrUk8dd9821CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41ae8133c03d911c119ed6427c57aa9fcbba2adb85e87163d8111c4e5161e777",
+				"DiscoKey":   "discokey:d3a70a3ff5144854a72d56fff7286ea9a81736378d5c2eac81eef0b6f329ef1b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49601",
+					"10.65.0.27:49601",
+					"172.17.0.1:49601",
+					"172.18.0.1:49601",
+					"172.19.0.1:49601",
+					"172.20.0.1:49601",
+					"172.21.0.1:49601",
+					"172.22.0.1:49601",
+					"172.23.0.1:49601",
+					"172.24.0.1:49601",
+					"172.25.0.1:49601",
+					"172.26.0.1:49601",
+					"172.27.0.1:49601"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:25:57.623851595Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1754521776149444,
+				"StableID":   "nVVHH6KdhE11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89d04b3ec1cd953acfced2752023c96f358c21e6117595e9a9a9193468f8ea40",
+				"DiscoKey":   "discokey:6330fc9c2de6eeb836b51a009212d34d93735f8cacde169d5126d1827a105014",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54805",
+					"10.65.0.27:54805",
+					"172.17.0.1:54805",
+					"172.18.0.1:54805",
+					"172.19.0.1:54805",
+					"172.20.0.1:54805",
+					"172.21.0.1:54805",
+					"172.22.0.1:54805",
+					"172.23.0.1:54805",
+					"172.24.0.1:54805",
+					"172.25.0.1:54805",
+					"172.26.0.1:54805",
+					"172.27.0.1:54805"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:25:58.168865723Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5991564693681578,
+				"StableID":   "n7KDqBFbno11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ccd4e67a2cc70de546e3cd7fe6b30ea45e5ed9900de9b80d893d63d685f44a05",
+				"DiscoKey":   "discokey:25b6576979922c201647204426ff0e3cf2dfe09aa9c47690d712cd588f5e2062",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60155",
+					"10.65.0.27:60155",
+					"172.17.0.1:60155",
+					"172.18.0.1:60155",
+					"172.19.0.1:60155",
+					"172.20.0.1:60155",
+					"172.21.0.1:60155",
+					"172.22.0.1:60155",
+					"172.23.0.1:60155",
+					"172.24.0.1:60155",
+					"172.25.0.1:60155",
+					"172.26.0.1:60155",
+					"172.27.0.1:60155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:25:58.693234704Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2467040710852722,
+				"StableID":   "nXsmdcyKGL11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6dd39de776307c6ec64b0ddd8ecae095d339c62f436ef04ecb4e31d07dcffc13",
+				"DiscoKey":   "discokey:b90b6767cbba1ab4d3580a3576b354813d757de6812cbb7a094e811c9c002c3f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50824",
+					"10.65.0.27:50824",
+					"172.17.0.1:50824",
+					"172.18.0.1:50824",
+					"172.19.0.1:50824",
+					"172.20.0.1:50824",
+					"172.21.0.1:50824",
+					"172.22.0.1:50824",
+					"172.23.0.1:50824",
+					"172.24.0.1:50824",
+					"172.25.0.1:50824",
+					"172.26.0.1:50824",
+					"172.27.0.1:50824"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:25:59.212390098Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7791884088342646,
+				"StableID":   "nyELqmaxq321CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51972f61ed25c9c9b251d581a32faccf2c919c8ecd47e01b6c7d0b5645002d4b",
+				"DiscoKey":   "discokey:1db365b71d0c552f0e10d299e592bd6209faa3f034b3c7a23847858e5708b61a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42275",
+					"10.65.0.27:42275",
+					"172.17.0.1:42275",
+					"172.18.0.1:42275",
+					"172.19.0.1:42275",
+					"172.20.0.1:42275",
+					"172.21.0.1:42275",
+					"172.22.0.1:42275",
+					"172.23.0.1:42275",
+					"172.24.0.1:42275",
+					"172.25.0.1:42275",
+					"172.26.0.1:42275",
+					"172.27.0.1:42275"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:25:59.746462998Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6389966061376616,
+				"StableID":   "nRq7SEa2ur11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2a8c6a87d0b42f0ce0fd039261c721d78966aa3c47321dd82ed5ab588a55ba55",
+				"DiscoKey":   "discokey:a5f67056c66182b1ece69b43998cdeb29cf4839ce15a7ea113b8ab322c2e4924",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54787",
+					"10.65.0.27:54787",
+					"172.17.0.1:54787",
+					"172.18.0.1:54787",
+					"172.19.0.1:54787",
+					"172.20.0.1:54787",
+					"172.21.0.1:54787",
+					"172.22.0.1:54787",
+					"172.23.0.1:54787",
+					"172.24.0.1:54787",
+					"172.25.0.1:54787",
+					"172.26.0.1:54787",
+					"172.27.0.1:54787"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:26:00.274096536Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1055306989129197,
+				"StableID":   "nSjDuF8xE911CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3593bf7bbeeeec26dc7ee462cea1a75809c7ae458f6ec35c05d63e2e9bca1877",
+				"DiscoKey":   "discokey:63de9e2f1c401c0046477ea78ec96e4a6fee5686a14957ca476453d50b648d65",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58374",
+					"10.65.0.27:58374",
+					"172.17.0.1:58374",
+					"172.18.0.1:58374",
+					"172.19.0.1:58374",
+					"172.20.0.1:58374",
+					"172.21.0.1:58374",
+					"172.22.0.1:58374",
+					"172.23.0.1:58374",
+					"172.24.0.1:58374",
+					"172.25.0.1:58374",
+					"172.26.0.1:58374",
+					"172.27.0.1:58374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:26:00.872732453Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3737616221991531,
+				"StableID":   "nzNyfjqmBW11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e9a602a93d0357af740fc7e394645f4e174709cd2026835debd5bff455779369",
+				"DiscoKey":   "discokey:94c064a50634869029fc6e962946859bf642c8d4747f2f505d81635d3351612e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:44914",
+					"10.65.0.27:44914",
+					"172.17.0.1:44914",
+					"172.18.0.1:44914",
+					"172.19.0.1:44914",
+					"172.20.0.1:44914",
+					"172.21.0.1:44914",
+					"172.22.0.1:44914",
+					"172.23.0.1:44914",
+					"172.24.0.1:44914",
+					"172.25.0.1:44914",
+					"172.26.0.1:44914",
+					"172.27.0.1:44914"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:26:01.325879553Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5059147728361694,
+				"StableID":   "nMx2XTEJWg11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:011542c0cfbeb754e87234b0e6040cfbc21db3d227952120fd87272c72c9bd4a",
+				"DiscoKey":   "discokey:83d245de9eba2b009641cabdbf824d745958ab96fde3e94fae1e408bf5a00d7c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35319",
+					"10.65.0.27:35319",
+					"172.17.0.1:35319",
+					"172.18.0.1:35319",
+					"172.19.0.1:35319",
+					"172.20.0.1:35319",
+					"172.21.0.1:35319",
+					"172.22.0.1:35319",
+					"172.23.0.1:35319",
+					"172.24.0.1:35319",
+					"172.25.0.1:35319",
+					"172.26.0.1:35319",
+					"172.27.0.1:35319"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:26:01.860130237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6314986434931921,
+				"StableID":   "nUnnb9z4Kr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:884ac400784500c4ac7062eb5dfc130a336d9131ea1670647a26c6c735eeba1d",
+				"DiscoKey":   "discokey:74b3c7a3c909080c0803aefae71022600746afe32320a7a00aea188f2b8d5051",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38181",
+					"10.65.0.27:38181",
+					"172.17.0.1:38181",
+					"172.18.0.1:38181",
+					"172.19.0.1:38181",
+					"172.20.0.1:38181",
+					"172.21.0.1:38181",
+					"172.22.0.1:38181",
+					"172.23.0.1:38181",
+					"172.24.0.1:38181",
+					"172.25.0.1:38181",
+					"172.26.0.1:38181",
+					"172.27.0.1:38181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:26:02.386361251Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3027636418233653,
+				"StableID":   "nE5HdjsDeQ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:57cc21672c69b7a5b2af5b17ac0dd70d4d3c104ba149a207c4818f4c0edf331f",
+				"DiscoKey":   "discokey:4d1307114289a331544162ec0264cfb4f2469406c7dfaee44c0e6c744ce4b156",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57818",
+					"10.65.0.27:57818",
+					"172.17.0.1:57818",
+					"172.18.0.1:57818",
+					"172.19.0.1:57818",
+					"172.20.0.1:57818",
+					"172.21.0.1:57818",
+					"172.22.0.1:57818",
+					"172.23.0.1:57818",
+					"172.24.0.1:57818",
+					"172.25.0.1:57818",
+					"172.26.0.1:57818",
+					"172.27.0.1:57818"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:26:02.90258067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3391484253904715,
+				"StableID":   "n2rfvLY1VT11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:2140010fd9cc6364dfa817bba059f6d3b83dacbf862ec711267a0f9fc95dba29",
+				"KeyExpiry":  "2026-11-09T09:26:03Z",
+				"DiscoKey":   "discokey:7541ee0f3d8a5a48a8370943d56f58d226ac09650ecfc16378e29d7b9218ab0f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47234",
+					"10.65.0.27:47234",
+					"172.17.0.1:47234",
+					"172.18.0.1:47234",
+					"172.19.0.1:47234",
+					"172.20.0.1:47234",
+					"172.21.0.1:47234",
+					"172.22.0.1:47234",
+					"172.23.0.1:47234",
+					"172.24.0.1:47234",
+					"172.25.0.1:47234",
+					"172.26.0.1:47234",
+					"172.27.0.1:47234"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:26:03.97812334Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8822860486792403,
+				"StableID":   "nS2bksattB21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:728287e19d4cf728efeb2fa5b1e13c83f59d0face81ca1f7451e3c63e855c500",
+				"KeyExpiry":  "2026-11-09T09:26:04Z",
+				"DiscoKey":   "discokey:86995fce0a1e74e4ccfd4994883888bdd16cf0f5dff4d77371e879dc7739b40e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48280",
+					"10.65.0.27:48280",
+					"172.17.0.1:48280",
+					"172.18.0.1:48280",
+					"172.19.0.1:48280",
+					"172.20.0.1:48280",
+					"172.21.0.1:48280",
+					"172.22.0.1:48280",
+					"172.23.0.1:48280",
+					"172.24.0.1:48280",
+					"172.25.0.1:48280",
+					"172.26.0.1:48280",
+					"172.27.0.1:48280"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:26:04.52785528Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4012558335314868,
+				"StableID":   "nT2Rjz6JLY11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e4cb2902e1b8f1d2a56ce7d6cb2ddcaa2e0456dd44e034e41e010f058a849054",
+				"KeyExpiry":  "2026-11-09T09:26:05Z",
+				"DiscoKey":   "discokey:3cdbe56232a3c233d2ffbe22d84cbe0916646cce682d5b8ee703e1bb314fa078",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:40522",
+					"10.65.0.27:40522",
+					"172.17.0.1:40522",
+					"172.18.0.1:40522",
+					"172.19.0.1:40522",
+					"172.20.0.1:40522",
+					"172.21.0.1:40522",
+					"172.22.0.1:40522",
+					"172.23.0.1:40522",
+					"172.24.0.1:40522",
+					"172.25.0.1:40522",
+					"172.26.0.1:40522",
+					"172.27.0.1:40522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:26:05.324315528Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5988788433583050": {
+				"ID":          5988788433583050,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6389966061376616,
+				"StableID":   "nRq7SEa2ur11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       6389966061376616,
+				"Key":        "nodekey:2a8c6a87d0b42f0ce0fd039261c721d78966aa3c47321dd82ed5ab588a55ba55",
+				"DiscoKey":   "discokey:a5f67056c66182b1ece69b43998cdeb29cf4839ce15a7ea113b8ab322c2e4924",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54787",
+					"10.65.0.27:54787",
+					"172.17.0.1:54787",
+					"172.18.0.1:54787",
+					"172.19.0.1:54787",
+					"172.20.0.1:54787",
+					"172.21.0.1:54787",
+					"172.22.0.1:54787",
+					"172.23.0.1:54787",
+					"172.24.0.1:54787",
+					"172.25.0.1:54787",
+					"172.26.0.1:54787",
+					"172.27.0.1:54787"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:26:00.274096536Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2a8c6a87d0b42f0ce0fd039261c721d78966aa3c47321dd82ed5ab588a55ba55",
+			"MachineKey": "mkey:c5edc1694b6dbd1f0e018021eac6d84707509d494a90e7ccd239441ffdea3239",
+			"Peers": [{
+				"ID":         8343158374485682,
+				"StableID":   "ndrUk8dd9821CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41ae8133c03d911c119ed6427c57aa9fcbba2adb85e87163d8111c4e5161e777",
+				"DiscoKey":   "discokey:d3a70a3ff5144854a72d56fff7286ea9a81736378d5c2eac81eef0b6f329ef1b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49601",
+					"10.65.0.27:49601",
+					"172.17.0.1:49601",
+					"172.18.0.1:49601",
+					"172.19.0.1:49601",
+					"172.20.0.1:49601",
+					"172.21.0.1:49601",
+					"172.22.0.1:49601",
+					"172.23.0.1:49601",
+					"172.24.0.1:49601",
+					"172.25.0.1:49601",
+					"172.26.0.1:49601",
+					"172.27.0.1:49601"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:25:57.623851595Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1754521776149444,
+				"StableID":   "nVVHH6KdhE11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89d04b3ec1cd953acfced2752023c96f358c21e6117595e9a9a9193468f8ea40",
+				"DiscoKey":   "discokey:6330fc9c2de6eeb836b51a009212d34d93735f8cacde169d5126d1827a105014",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54805",
+					"10.65.0.27:54805",
+					"172.17.0.1:54805",
+					"172.18.0.1:54805",
+					"172.19.0.1:54805",
+					"172.20.0.1:54805",
+					"172.21.0.1:54805",
+					"172.22.0.1:54805",
+					"172.23.0.1:54805",
+					"172.24.0.1:54805",
+					"172.25.0.1:54805",
+					"172.26.0.1:54805",
+					"172.27.0.1:54805"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:25:58.168865723Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5991564693681578,
+				"StableID":   "n7KDqBFbno11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ccd4e67a2cc70de546e3cd7fe6b30ea45e5ed9900de9b80d893d63d685f44a05",
+				"DiscoKey":   "discokey:25b6576979922c201647204426ff0e3cf2dfe09aa9c47690d712cd588f5e2062",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60155",
+					"10.65.0.27:60155",
+					"172.17.0.1:60155",
+					"172.18.0.1:60155",
+					"172.19.0.1:60155",
+					"172.20.0.1:60155",
+					"172.21.0.1:60155",
+					"172.22.0.1:60155",
+					"172.23.0.1:60155",
+					"172.24.0.1:60155",
+					"172.25.0.1:60155",
+					"172.26.0.1:60155",
+					"172.27.0.1:60155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:25:58.693234704Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2467040710852722,
+				"StableID":   "nXsmdcyKGL11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6dd39de776307c6ec64b0ddd8ecae095d339c62f436ef04ecb4e31d07dcffc13",
+				"DiscoKey":   "discokey:b90b6767cbba1ab4d3580a3576b354813d757de6812cbb7a094e811c9c002c3f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50824",
+					"10.65.0.27:50824",
+					"172.17.0.1:50824",
+					"172.18.0.1:50824",
+					"172.19.0.1:50824",
+					"172.20.0.1:50824",
+					"172.21.0.1:50824",
+					"172.22.0.1:50824",
+					"172.23.0.1:50824",
+					"172.24.0.1:50824",
+					"172.25.0.1:50824",
+					"172.26.0.1:50824",
+					"172.27.0.1:50824"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:25:59.212390098Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7791884088342646,
+				"StableID":   "nyELqmaxq321CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51972f61ed25c9c9b251d581a32faccf2c919c8ecd47e01b6c7d0b5645002d4b",
+				"DiscoKey":   "discokey:1db365b71d0c552f0e10d299e592bd6209faa3f034b3c7a23847858e5708b61a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42275",
+					"10.65.0.27:42275",
+					"172.17.0.1:42275",
+					"172.18.0.1:42275",
+					"172.19.0.1:42275",
+					"172.20.0.1:42275",
+					"172.21.0.1:42275",
+					"172.22.0.1:42275",
+					"172.23.0.1:42275",
+					"172.24.0.1:42275",
+					"172.25.0.1:42275",
+					"172.26.0.1:42275",
+					"172.27.0.1:42275"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:25:59.746462998Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1055306989129197,
+				"StableID":   "nSjDuF8xE911CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3593bf7bbeeeec26dc7ee462cea1a75809c7ae458f6ec35c05d63e2e9bca1877",
+				"DiscoKey":   "discokey:63de9e2f1c401c0046477ea78ec96e4a6fee5686a14957ca476453d50b648d65",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58374",
+					"10.65.0.27:58374",
+					"172.17.0.1:58374",
+					"172.18.0.1:58374",
+					"172.19.0.1:58374",
+					"172.20.0.1:58374",
+					"172.21.0.1:58374",
+					"172.22.0.1:58374",
+					"172.23.0.1:58374",
+					"172.24.0.1:58374",
+					"172.25.0.1:58374",
+					"172.26.0.1:58374",
+					"172.27.0.1:58374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:26:00.872732453Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3737616221991531,
+				"StableID":   "nzNyfjqmBW11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e9a602a93d0357af740fc7e394645f4e174709cd2026835debd5bff455779369",
+				"DiscoKey":   "discokey:94c064a50634869029fc6e962946859bf642c8d4747f2f505d81635d3351612e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:44914",
+					"10.65.0.27:44914",
+					"172.17.0.1:44914",
+					"172.18.0.1:44914",
+					"172.19.0.1:44914",
+					"172.20.0.1:44914",
+					"172.21.0.1:44914",
+					"172.22.0.1:44914",
+					"172.23.0.1:44914",
+					"172.24.0.1:44914",
+					"172.25.0.1:44914",
+					"172.26.0.1:44914",
+					"172.27.0.1:44914"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:26:01.325879553Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5059147728361694,
+				"StableID":   "nMx2XTEJWg11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:011542c0cfbeb754e87234b0e6040cfbc21db3d227952120fd87272c72c9bd4a",
+				"DiscoKey":   "discokey:83d245de9eba2b009641cabdbf824d745958ab96fde3e94fae1e408bf5a00d7c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35319",
+					"10.65.0.27:35319",
+					"172.17.0.1:35319",
+					"172.18.0.1:35319",
+					"172.19.0.1:35319",
+					"172.20.0.1:35319",
+					"172.21.0.1:35319",
+					"172.22.0.1:35319",
+					"172.23.0.1:35319",
+					"172.24.0.1:35319",
+					"172.25.0.1:35319",
+					"172.26.0.1:35319",
+					"172.27.0.1:35319"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:26:01.860130237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6314986434931921,
+				"StableID":   "nUnnb9z4Kr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:884ac400784500c4ac7062eb5dfc130a336d9131ea1670647a26c6c735eeba1d",
+				"DiscoKey":   "discokey:74b3c7a3c909080c0803aefae71022600746afe32320a7a00aea188f2b8d5051",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38181",
+					"10.65.0.27:38181",
+					"172.17.0.1:38181",
+					"172.18.0.1:38181",
+					"172.19.0.1:38181",
+					"172.20.0.1:38181",
+					"172.21.0.1:38181",
+					"172.22.0.1:38181",
+					"172.23.0.1:38181",
+					"172.24.0.1:38181",
+					"172.25.0.1:38181",
+					"172.26.0.1:38181",
+					"172.27.0.1:38181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:26:02.386361251Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3027636418233653,
+				"StableID":   "nE5HdjsDeQ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:57cc21672c69b7a5b2af5b17ac0dd70d4d3c104ba149a207c4818f4c0edf331f",
+				"DiscoKey":   "discokey:4d1307114289a331544162ec0264cfb4f2469406c7dfaee44c0e6c744ce4b156",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57818",
+					"10.65.0.27:57818",
+					"172.17.0.1:57818",
+					"172.18.0.1:57818",
+					"172.19.0.1:57818",
+					"172.20.0.1:57818",
+					"172.21.0.1:57818",
+					"172.22.0.1:57818",
+					"172.23.0.1:57818",
+					"172.24.0.1:57818",
+					"172.25.0.1:57818",
+					"172.26.0.1:57818",
+					"172.27.0.1:57818"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:26:02.90258067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5988788433583050,
+				"StableID":   "nDUXEPKLmo11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d03a57906aa1dcff0d05193c0435a9eb9d64922dad7b8feb5dfbaaef357a497a",
+				"DiscoKey":   "discokey:6276f751d145f796fb617ea1cfdf067350d436709901b15750b0bbb8f80c2a59",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35096",
+					"10.65.0.27:35096",
+					"172.17.0.1:35096",
+					"172.18.0.1:35096",
+					"172.19.0.1:35096",
+					"172.20.0.1:35096",
+					"172.21.0.1:35096",
+					"172.22.0.1:35096",
+					"172.23.0.1:35096",
+					"172.24.0.1:35096",
+					"172.25.0.1:35096",
+					"172.26.0.1:35096",
+					"172.27.0.1:35096"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:26:03.441102354Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3391484253904715,
+				"StableID":   "n2rfvLY1VT11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:2140010fd9cc6364dfa817bba059f6d3b83dacbf862ec711267a0f9fc95dba29",
+				"KeyExpiry":  "2026-11-09T09:26:03Z",
+				"DiscoKey":   "discokey:7541ee0f3d8a5a48a8370943d56f58d226ac09650ecfc16378e29d7b9218ab0f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47234",
+					"10.65.0.27:47234",
+					"172.17.0.1:47234",
+					"172.18.0.1:47234",
+					"172.19.0.1:47234",
+					"172.20.0.1:47234",
+					"172.21.0.1:47234",
+					"172.22.0.1:47234",
+					"172.23.0.1:47234",
+					"172.24.0.1:47234",
+					"172.25.0.1:47234",
+					"172.26.0.1:47234",
+					"172.27.0.1:47234"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:26:03.97812334Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8822860486792403,
+				"StableID":   "nS2bksattB21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:728287e19d4cf728efeb2fa5b1e13c83f59d0face81ca1f7451e3c63e855c500",
+				"KeyExpiry":  "2026-11-09T09:26:04Z",
+				"DiscoKey":   "discokey:86995fce0a1e74e4ccfd4994883888bdd16cf0f5dff4d77371e879dc7739b40e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48280",
+					"10.65.0.27:48280",
+					"172.17.0.1:48280",
+					"172.18.0.1:48280",
+					"172.19.0.1:48280",
+					"172.20.0.1:48280",
+					"172.21.0.1:48280",
+					"172.22.0.1:48280",
+					"172.23.0.1:48280",
+					"172.24.0.1:48280",
+					"172.25.0.1:48280",
+					"172.26.0.1:48280",
+					"172.27.0.1:48280"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:26:04.52785528Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4012558335314868,
+				"StableID":   "nT2Rjz6JLY11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e4cb2902e1b8f1d2a56ce7d6cb2ddcaa2e0456dd44e034e41e010f058a849054",
+				"KeyExpiry":  "2026-11-09T09:26:05Z",
+				"DiscoKey":   "discokey:3cdbe56232a3c233d2ffbe22d84cbe0916646cce682d5b8ee703e1bb314fa078",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:40522",
+					"10.65.0.27:40522",
+					"172.17.0.1:40522",
+					"172.18.0.1:40522",
+					"172.19.0.1:40522",
+					"172.20.0.1:40522",
+					"172.21.0.1:40522",
+					"172.22.0.1:40522",
+					"172.23.0.1:40522",
+					"172.24.0.1:40522",
+					"172.25.0.1:40522",
+					"172.26.0.1:40522",
+					"172.27.0.1:40522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:26:05.324315528Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6389966061376616": {
+				"ID":          6389966061376616,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4012558335314868,
+				"StableID":   "nT2Rjz6JLY11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e4cb2902e1b8f1d2a56ce7d6cb2ddcaa2e0456dd44e034e41e010f058a849054",
+				"KeyExpiry":  "2026-11-09T09:26:05Z",
+				"DiscoKey":   "discokey:3cdbe56232a3c233d2ffbe22d84cbe0916646cce682d5b8ee703e1bb314fa078",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:40522",
+					"10.65.0.27:40522",
+					"172.17.0.1:40522",
+					"172.18.0.1:40522",
+					"172.19.0.1:40522",
+					"172.20.0.1:40522",
+					"172.21.0.1:40522",
+					"172.22.0.1:40522",
+					"172.23.0.1:40522",
+					"172.24.0.1:40522",
+					"172.25.0.1:40522",
+					"172.26.0.1:40522",
+					"172.27.0.1:40522"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:26:05.324315528Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e4cb2902e1b8f1d2a56ce7d6cb2ddcaa2e0456dd44e034e41e010f058a849054",
+			"MachineKey": "mkey:10616b8e8c72a4a98f21d78fb14130c82b79a4ee2c1d42a13932eef16fbd6315",
+			"Peers": [{
+				"ID":         8343158374485682,
+				"StableID":   "ndrUk8dd9821CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41ae8133c03d911c119ed6427c57aa9fcbba2adb85e87163d8111c4e5161e777",
+				"DiscoKey":   "discokey:d3a70a3ff5144854a72d56fff7286ea9a81736378d5c2eac81eef0b6f329ef1b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49601",
+					"10.65.0.27:49601",
+					"172.17.0.1:49601",
+					"172.18.0.1:49601",
+					"172.19.0.1:49601",
+					"172.20.0.1:49601",
+					"172.21.0.1:49601",
+					"172.22.0.1:49601",
+					"172.23.0.1:49601",
+					"172.24.0.1:49601",
+					"172.25.0.1:49601",
+					"172.26.0.1:49601",
+					"172.27.0.1:49601"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:25:57.623851595Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1754521776149444,
+				"StableID":   "nVVHH6KdhE11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89d04b3ec1cd953acfced2752023c96f358c21e6117595e9a9a9193468f8ea40",
+				"DiscoKey":   "discokey:6330fc9c2de6eeb836b51a009212d34d93735f8cacde169d5126d1827a105014",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54805",
+					"10.65.0.27:54805",
+					"172.17.0.1:54805",
+					"172.18.0.1:54805",
+					"172.19.0.1:54805",
+					"172.20.0.1:54805",
+					"172.21.0.1:54805",
+					"172.22.0.1:54805",
+					"172.23.0.1:54805",
+					"172.24.0.1:54805",
+					"172.25.0.1:54805",
+					"172.26.0.1:54805",
+					"172.27.0.1:54805"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:25:58.168865723Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5991564693681578,
+				"StableID":   "n7KDqBFbno11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ccd4e67a2cc70de546e3cd7fe6b30ea45e5ed9900de9b80d893d63d685f44a05",
+				"DiscoKey":   "discokey:25b6576979922c201647204426ff0e3cf2dfe09aa9c47690d712cd588f5e2062",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60155",
+					"10.65.0.27:60155",
+					"172.17.0.1:60155",
+					"172.18.0.1:60155",
+					"172.19.0.1:60155",
+					"172.20.0.1:60155",
+					"172.21.0.1:60155",
+					"172.22.0.1:60155",
+					"172.23.0.1:60155",
+					"172.24.0.1:60155",
+					"172.25.0.1:60155",
+					"172.26.0.1:60155",
+					"172.27.0.1:60155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:25:58.693234704Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2467040710852722,
+				"StableID":   "nXsmdcyKGL11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6dd39de776307c6ec64b0ddd8ecae095d339c62f436ef04ecb4e31d07dcffc13",
+				"DiscoKey":   "discokey:b90b6767cbba1ab4d3580a3576b354813d757de6812cbb7a094e811c9c002c3f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50824",
+					"10.65.0.27:50824",
+					"172.17.0.1:50824",
+					"172.18.0.1:50824",
+					"172.19.0.1:50824",
+					"172.20.0.1:50824",
+					"172.21.0.1:50824",
+					"172.22.0.1:50824",
+					"172.23.0.1:50824",
+					"172.24.0.1:50824",
+					"172.25.0.1:50824",
+					"172.26.0.1:50824",
+					"172.27.0.1:50824"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:25:59.212390098Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7791884088342646,
+				"StableID":   "nyELqmaxq321CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51972f61ed25c9c9b251d581a32faccf2c919c8ecd47e01b6c7d0b5645002d4b",
+				"DiscoKey":   "discokey:1db365b71d0c552f0e10d299e592bd6209faa3f034b3c7a23847858e5708b61a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42275",
+					"10.65.0.27:42275",
+					"172.17.0.1:42275",
+					"172.18.0.1:42275",
+					"172.19.0.1:42275",
+					"172.20.0.1:42275",
+					"172.21.0.1:42275",
+					"172.22.0.1:42275",
+					"172.23.0.1:42275",
+					"172.24.0.1:42275",
+					"172.25.0.1:42275",
+					"172.26.0.1:42275",
+					"172.27.0.1:42275"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:25:59.746462998Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6389966061376616,
+				"StableID":   "nRq7SEa2ur11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2a8c6a87d0b42f0ce0fd039261c721d78966aa3c47321dd82ed5ab588a55ba55",
+				"DiscoKey":   "discokey:a5f67056c66182b1ece69b43998cdeb29cf4839ce15a7ea113b8ab322c2e4924",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54787",
+					"10.65.0.27:54787",
+					"172.17.0.1:54787",
+					"172.18.0.1:54787",
+					"172.19.0.1:54787",
+					"172.20.0.1:54787",
+					"172.21.0.1:54787",
+					"172.22.0.1:54787",
+					"172.23.0.1:54787",
+					"172.24.0.1:54787",
+					"172.25.0.1:54787",
+					"172.26.0.1:54787",
+					"172.27.0.1:54787"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:26:00.274096536Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1055306989129197,
+				"StableID":   "nSjDuF8xE911CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3593bf7bbeeeec26dc7ee462cea1a75809c7ae458f6ec35c05d63e2e9bca1877",
+				"DiscoKey":   "discokey:63de9e2f1c401c0046477ea78ec96e4a6fee5686a14957ca476453d50b648d65",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58374",
+					"10.65.0.27:58374",
+					"172.17.0.1:58374",
+					"172.18.0.1:58374",
+					"172.19.0.1:58374",
+					"172.20.0.1:58374",
+					"172.21.0.1:58374",
+					"172.22.0.1:58374",
+					"172.23.0.1:58374",
+					"172.24.0.1:58374",
+					"172.25.0.1:58374",
+					"172.26.0.1:58374",
+					"172.27.0.1:58374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:26:00.872732453Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3737616221991531,
+				"StableID":   "nzNyfjqmBW11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e9a602a93d0357af740fc7e394645f4e174709cd2026835debd5bff455779369",
+				"DiscoKey":   "discokey:94c064a50634869029fc6e962946859bf642c8d4747f2f505d81635d3351612e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:44914",
+					"10.65.0.27:44914",
+					"172.17.0.1:44914",
+					"172.18.0.1:44914",
+					"172.19.0.1:44914",
+					"172.20.0.1:44914",
+					"172.21.0.1:44914",
+					"172.22.0.1:44914",
+					"172.23.0.1:44914",
+					"172.24.0.1:44914",
+					"172.25.0.1:44914",
+					"172.26.0.1:44914",
+					"172.27.0.1:44914"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:26:01.325879553Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5059147728361694,
+				"StableID":   "nMx2XTEJWg11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:011542c0cfbeb754e87234b0e6040cfbc21db3d227952120fd87272c72c9bd4a",
+				"DiscoKey":   "discokey:83d245de9eba2b009641cabdbf824d745958ab96fde3e94fae1e408bf5a00d7c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35319",
+					"10.65.0.27:35319",
+					"172.17.0.1:35319",
+					"172.18.0.1:35319",
+					"172.19.0.1:35319",
+					"172.20.0.1:35319",
+					"172.21.0.1:35319",
+					"172.22.0.1:35319",
+					"172.23.0.1:35319",
+					"172.24.0.1:35319",
+					"172.25.0.1:35319",
+					"172.26.0.1:35319",
+					"172.27.0.1:35319"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:26:01.860130237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6314986434931921,
+				"StableID":   "nUnnb9z4Kr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:884ac400784500c4ac7062eb5dfc130a336d9131ea1670647a26c6c735eeba1d",
+				"DiscoKey":   "discokey:74b3c7a3c909080c0803aefae71022600746afe32320a7a00aea188f2b8d5051",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38181",
+					"10.65.0.27:38181",
+					"172.17.0.1:38181",
+					"172.18.0.1:38181",
+					"172.19.0.1:38181",
+					"172.20.0.1:38181",
+					"172.21.0.1:38181",
+					"172.22.0.1:38181",
+					"172.23.0.1:38181",
+					"172.24.0.1:38181",
+					"172.25.0.1:38181",
+					"172.26.0.1:38181",
+					"172.27.0.1:38181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:26:02.386361251Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3027636418233653,
+				"StableID":   "nE5HdjsDeQ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:57cc21672c69b7a5b2af5b17ac0dd70d4d3c104ba149a207c4818f4c0edf331f",
+				"DiscoKey":   "discokey:4d1307114289a331544162ec0264cfb4f2469406c7dfaee44c0e6c744ce4b156",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57818",
+					"10.65.0.27:57818",
+					"172.17.0.1:57818",
+					"172.18.0.1:57818",
+					"172.19.0.1:57818",
+					"172.20.0.1:57818",
+					"172.21.0.1:57818",
+					"172.22.0.1:57818",
+					"172.23.0.1:57818",
+					"172.24.0.1:57818",
+					"172.25.0.1:57818",
+					"172.26.0.1:57818",
+					"172.27.0.1:57818"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:26:02.90258067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5988788433583050,
+				"StableID":   "nDUXEPKLmo11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d03a57906aa1dcff0d05193c0435a9eb9d64922dad7b8feb5dfbaaef357a497a",
+				"DiscoKey":   "discokey:6276f751d145f796fb617ea1cfdf067350d436709901b15750b0bbb8f80c2a59",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35096",
+					"10.65.0.27:35096",
+					"172.17.0.1:35096",
+					"172.18.0.1:35096",
+					"172.19.0.1:35096",
+					"172.20.0.1:35096",
+					"172.21.0.1:35096",
+					"172.22.0.1:35096",
+					"172.23.0.1:35096",
+					"172.24.0.1:35096",
+					"172.25.0.1:35096",
+					"172.26.0.1:35096",
+					"172.27.0.1:35096"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:26:03.441102354Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3391484253904715,
+				"StableID":   "n2rfvLY1VT11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:2140010fd9cc6364dfa817bba059f6d3b83dacbf862ec711267a0f9fc95dba29",
+				"KeyExpiry":  "2026-11-09T09:26:03Z",
+				"DiscoKey":   "discokey:7541ee0f3d8a5a48a8370943d56f58d226ac09650ecfc16378e29d7b9218ab0f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47234",
+					"10.65.0.27:47234",
+					"172.17.0.1:47234",
+					"172.18.0.1:47234",
+					"172.19.0.1:47234",
+					"172.20.0.1:47234",
+					"172.21.0.1:47234",
+					"172.22.0.1:47234",
+					"172.23.0.1:47234",
+					"172.24.0.1:47234",
+					"172.25.0.1:47234",
+					"172.26.0.1:47234",
+					"172.27.0.1:47234"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:26:03.97812334Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8822860486792403,
+				"StableID":   "nS2bksattB21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:728287e19d4cf728efeb2fa5b1e13c83f59d0face81ca1f7451e3c63e855c500",
+				"KeyExpiry":  "2026-11-09T09:26:04Z",
+				"DiscoKey":   "discokey:86995fce0a1e74e4ccfd4994883888bdd16cf0f5dff4d77371e879dc7739b40e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48280",
+					"10.65.0.27:48280",
+					"172.17.0.1:48280",
+					"172.18.0.1:48280",
+					"172.19.0.1:48280",
+					"172.20.0.1:48280",
+					"172.21.0.1:48280",
+					"172.22.0.1:48280",
+					"172.23.0.1:48280",
+					"172.24.0.1:48280",
+					"172.25.0.1:48280",
+					"172.26.0.1:48280",
+					"172.27.0.1:48280"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:26:04.52785528Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5991564693681578,
+				"StableID":   "n7KDqBFbno11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       5991564693681578,
+				"Key":        "nodekey:ccd4e67a2cc70de546e3cd7fe6b30ea45e5ed9900de9b80d893d63d685f44a05",
+				"DiscoKey":   "discokey:25b6576979922c201647204426ff0e3cf2dfe09aa9c47690d712cd588f5e2062",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60155",
+					"10.65.0.27:60155",
+					"172.17.0.1:60155",
+					"172.18.0.1:60155",
+					"172.19.0.1:60155",
+					"172.20.0.1:60155",
+					"172.21.0.1:60155",
+					"172.22.0.1:60155",
+					"172.23.0.1:60155",
+					"172.24.0.1:60155",
+					"172.25.0.1:60155",
+					"172.26.0.1:60155",
+					"172.27.0.1:60155"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:25:58.693234704Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ccd4e67a2cc70de546e3cd7fe6b30ea45e5ed9900de9b80d893d63d685f44a05",
+			"MachineKey": "mkey:1d181862e8d697811e680dcf3eacc69ce6249061389960d6aad1dc406d24db43",
+			"Peers": [{
+				"ID":         8343158374485682,
+				"StableID":   "ndrUk8dd9821CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41ae8133c03d911c119ed6427c57aa9fcbba2adb85e87163d8111c4e5161e777",
+				"DiscoKey":   "discokey:d3a70a3ff5144854a72d56fff7286ea9a81736378d5c2eac81eef0b6f329ef1b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49601",
+					"10.65.0.27:49601",
+					"172.17.0.1:49601",
+					"172.18.0.1:49601",
+					"172.19.0.1:49601",
+					"172.20.0.1:49601",
+					"172.21.0.1:49601",
+					"172.22.0.1:49601",
+					"172.23.0.1:49601",
+					"172.24.0.1:49601",
+					"172.25.0.1:49601",
+					"172.26.0.1:49601",
+					"172.27.0.1:49601"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:25:57.623851595Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1754521776149444,
+				"StableID":   "nVVHH6KdhE11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89d04b3ec1cd953acfced2752023c96f358c21e6117595e9a9a9193468f8ea40",
+				"DiscoKey":   "discokey:6330fc9c2de6eeb836b51a009212d34d93735f8cacde169d5126d1827a105014",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54805",
+					"10.65.0.27:54805",
+					"172.17.0.1:54805",
+					"172.18.0.1:54805",
+					"172.19.0.1:54805",
+					"172.20.0.1:54805",
+					"172.21.0.1:54805",
+					"172.22.0.1:54805",
+					"172.23.0.1:54805",
+					"172.24.0.1:54805",
+					"172.25.0.1:54805",
+					"172.26.0.1:54805",
+					"172.27.0.1:54805"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:25:58.168865723Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2467040710852722,
+				"StableID":   "nXsmdcyKGL11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6dd39de776307c6ec64b0ddd8ecae095d339c62f436ef04ecb4e31d07dcffc13",
+				"DiscoKey":   "discokey:b90b6767cbba1ab4d3580a3576b354813d757de6812cbb7a094e811c9c002c3f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50824",
+					"10.65.0.27:50824",
+					"172.17.0.1:50824",
+					"172.18.0.1:50824",
+					"172.19.0.1:50824",
+					"172.20.0.1:50824",
+					"172.21.0.1:50824",
+					"172.22.0.1:50824",
+					"172.23.0.1:50824",
+					"172.24.0.1:50824",
+					"172.25.0.1:50824",
+					"172.26.0.1:50824",
+					"172.27.0.1:50824"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:25:59.212390098Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7791884088342646,
+				"StableID":   "nyELqmaxq321CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51972f61ed25c9c9b251d581a32faccf2c919c8ecd47e01b6c7d0b5645002d4b",
+				"DiscoKey":   "discokey:1db365b71d0c552f0e10d299e592bd6209faa3f034b3c7a23847858e5708b61a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42275",
+					"10.65.0.27:42275",
+					"172.17.0.1:42275",
+					"172.18.0.1:42275",
+					"172.19.0.1:42275",
+					"172.20.0.1:42275",
+					"172.21.0.1:42275",
+					"172.22.0.1:42275",
+					"172.23.0.1:42275",
+					"172.24.0.1:42275",
+					"172.25.0.1:42275",
+					"172.26.0.1:42275",
+					"172.27.0.1:42275"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:25:59.746462998Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6389966061376616,
+				"StableID":   "nRq7SEa2ur11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2a8c6a87d0b42f0ce0fd039261c721d78966aa3c47321dd82ed5ab588a55ba55",
+				"DiscoKey":   "discokey:a5f67056c66182b1ece69b43998cdeb29cf4839ce15a7ea113b8ab322c2e4924",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54787",
+					"10.65.0.27:54787",
+					"172.17.0.1:54787",
+					"172.18.0.1:54787",
+					"172.19.0.1:54787",
+					"172.20.0.1:54787",
+					"172.21.0.1:54787",
+					"172.22.0.1:54787",
+					"172.23.0.1:54787",
+					"172.24.0.1:54787",
+					"172.25.0.1:54787",
+					"172.26.0.1:54787",
+					"172.27.0.1:54787"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:26:00.274096536Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1055306989129197,
+				"StableID":   "nSjDuF8xE911CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3593bf7bbeeeec26dc7ee462cea1a75809c7ae458f6ec35c05d63e2e9bca1877",
+				"DiscoKey":   "discokey:63de9e2f1c401c0046477ea78ec96e4a6fee5686a14957ca476453d50b648d65",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58374",
+					"10.65.0.27:58374",
+					"172.17.0.1:58374",
+					"172.18.0.1:58374",
+					"172.19.0.1:58374",
+					"172.20.0.1:58374",
+					"172.21.0.1:58374",
+					"172.22.0.1:58374",
+					"172.23.0.1:58374",
+					"172.24.0.1:58374",
+					"172.25.0.1:58374",
+					"172.26.0.1:58374",
+					"172.27.0.1:58374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:26:00.872732453Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3737616221991531,
+				"StableID":   "nzNyfjqmBW11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e9a602a93d0357af740fc7e394645f4e174709cd2026835debd5bff455779369",
+				"DiscoKey":   "discokey:94c064a50634869029fc6e962946859bf642c8d4747f2f505d81635d3351612e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:44914",
+					"10.65.0.27:44914",
+					"172.17.0.1:44914",
+					"172.18.0.1:44914",
+					"172.19.0.1:44914",
+					"172.20.0.1:44914",
+					"172.21.0.1:44914",
+					"172.22.0.1:44914",
+					"172.23.0.1:44914",
+					"172.24.0.1:44914",
+					"172.25.0.1:44914",
+					"172.26.0.1:44914",
+					"172.27.0.1:44914"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:26:01.325879553Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5059147728361694,
+				"StableID":   "nMx2XTEJWg11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:011542c0cfbeb754e87234b0e6040cfbc21db3d227952120fd87272c72c9bd4a",
+				"DiscoKey":   "discokey:83d245de9eba2b009641cabdbf824d745958ab96fde3e94fae1e408bf5a00d7c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35319",
+					"10.65.0.27:35319",
+					"172.17.0.1:35319",
+					"172.18.0.1:35319",
+					"172.19.0.1:35319",
+					"172.20.0.1:35319",
+					"172.21.0.1:35319",
+					"172.22.0.1:35319",
+					"172.23.0.1:35319",
+					"172.24.0.1:35319",
+					"172.25.0.1:35319",
+					"172.26.0.1:35319",
+					"172.27.0.1:35319"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:26:01.860130237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6314986434931921,
+				"StableID":   "nUnnb9z4Kr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:884ac400784500c4ac7062eb5dfc130a336d9131ea1670647a26c6c735eeba1d",
+				"DiscoKey":   "discokey:74b3c7a3c909080c0803aefae71022600746afe32320a7a00aea188f2b8d5051",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38181",
+					"10.65.0.27:38181",
+					"172.17.0.1:38181",
+					"172.18.0.1:38181",
+					"172.19.0.1:38181",
+					"172.20.0.1:38181",
+					"172.21.0.1:38181",
+					"172.22.0.1:38181",
+					"172.23.0.1:38181",
+					"172.24.0.1:38181",
+					"172.25.0.1:38181",
+					"172.26.0.1:38181",
+					"172.27.0.1:38181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:26:02.386361251Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3027636418233653,
+				"StableID":   "nE5HdjsDeQ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:57cc21672c69b7a5b2af5b17ac0dd70d4d3c104ba149a207c4818f4c0edf331f",
+				"DiscoKey":   "discokey:4d1307114289a331544162ec0264cfb4f2469406c7dfaee44c0e6c744ce4b156",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57818",
+					"10.65.0.27:57818",
+					"172.17.0.1:57818",
+					"172.18.0.1:57818",
+					"172.19.0.1:57818",
+					"172.20.0.1:57818",
+					"172.21.0.1:57818",
+					"172.22.0.1:57818",
+					"172.23.0.1:57818",
+					"172.24.0.1:57818",
+					"172.25.0.1:57818",
+					"172.26.0.1:57818",
+					"172.27.0.1:57818"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:26:02.90258067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5988788433583050,
+				"StableID":   "nDUXEPKLmo11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d03a57906aa1dcff0d05193c0435a9eb9d64922dad7b8feb5dfbaaef357a497a",
+				"DiscoKey":   "discokey:6276f751d145f796fb617ea1cfdf067350d436709901b15750b0bbb8f80c2a59",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35096",
+					"10.65.0.27:35096",
+					"172.17.0.1:35096",
+					"172.18.0.1:35096",
+					"172.19.0.1:35096",
+					"172.20.0.1:35096",
+					"172.21.0.1:35096",
+					"172.22.0.1:35096",
+					"172.23.0.1:35096",
+					"172.24.0.1:35096",
+					"172.25.0.1:35096",
+					"172.26.0.1:35096",
+					"172.27.0.1:35096"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:26:03.441102354Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3391484253904715,
+				"StableID":   "n2rfvLY1VT11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:2140010fd9cc6364dfa817bba059f6d3b83dacbf862ec711267a0f9fc95dba29",
+				"KeyExpiry":  "2026-11-09T09:26:03Z",
+				"DiscoKey":   "discokey:7541ee0f3d8a5a48a8370943d56f58d226ac09650ecfc16378e29d7b9218ab0f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47234",
+					"10.65.0.27:47234",
+					"172.17.0.1:47234",
+					"172.18.0.1:47234",
+					"172.19.0.1:47234",
+					"172.20.0.1:47234",
+					"172.21.0.1:47234",
+					"172.22.0.1:47234",
+					"172.23.0.1:47234",
+					"172.24.0.1:47234",
+					"172.25.0.1:47234",
+					"172.26.0.1:47234",
+					"172.27.0.1:47234"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:26:03.97812334Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8822860486792403,
+				"StableID":   "nS2bksattB21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:728287e19d4cf728efeb2fa5b1e13c83f59d0face81ca1f7451e3c63e855c500",
+				"KeyExpiry":  "2026-11-09T09:26:04Z",
+				"DiscoKey":   "discokey:86995fce0a1e74e4ccfd4994883888bdd16cf0f5dff4d77371e879dc7739b40e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48280",
+					"10.65.0.27:48280",
+					"172.17.0.1:48280",
+					"172.18.0.1:48280",
+					"172.19.0.1:48280",
+					"172.20.0.1:48280",
+					"172.21.0.1:48280",
+					"172.22.0.1:48280",
+					"172.23.0.1:48280",
+					"172.24.0.1:48280",
+					"172.25.0.1:48280",
+					"172.26.0.1:48280",
+					"172.27.0.1:48280"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:26:04.52785528Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4012558335314868,
+				"StableID":   "nT2Rjz6JLY11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e4cb2902e1b8f1d2a56ce7d6cb2ddcaa2e0456dd44e034e41e010f058a849054",
+				"KeyExpiry":  "2026-11-09T09:26:05Z",
+				"DiscoKey":   "discokey:3cdbe56232a3c233d2ffbe22d84cbe0916646cce682d5b8ee703e1bb314fa078",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:40522",
+					"10.65.0.27:40522",
+					"172.17.0.1:40522",
+					"172.18.0.1:40522",
+					"172.19.0.1:40522",
+					"172.20.0.1:40522",
+					"172.21.0.1:40522",
+					"172.22.0.1:40522",
+					"172.23.0.1:40522",
+					"172.24.0.1:40522",
+					"172.25.0.1:40522",
+					"172.26.0.1:40522",
+					"172.27.0.1:40522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:26:05.324315528Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5991564693681578": {
+				"ID":          5991564693681578,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3737616221991531,
+				"StableID":   "nzNyfjqmBW11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       3737616221991531,
+				"Key":        "nodekey:e9a602a93d0357af740fc7e394645f4e174709cd2026835debd5bff455779369",
+				"DiscoKey":   "discokey:94c064a50634869029fc6e962946859bf642c8d4747f2f505d81635d3351612e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:44914",
+					"10.65.0.27:44914",
+					"172.17.0.1:44914",
+					"172.18.0.1:44914",
+					"172.19.0.1:44914",
+					"172.20.0.1:44914",
+					"172.21.0.1:44914",
+					"172.22.0.1:44914",
+					"172.23.0.1:44914",
+					"172.24.0.1:44914",
+					"172.25.0.1:44914",
+					"172.26.0.1:44914",
+					"172.27.0.1:44914"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:26:01.325879553Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e9a602a93d0357af740fc7e394645f4e174709cd2026835debd5bff455779369",
+			"MachineKey": "mkey:892a41beb8e8367329107801a61307fc46b6a265e36818dbd0f067f7a69c7b11",
+			"Peers": [{
+				"ID":         8343158374485682,
+				"StableID":   "ndrUk8dd9821CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41ae8133c03d911c119ed6427c57aa9fcbba2adb85e87163d8111c4e5161e777",
+				"DiscoKey":   "discokey:d3a70a3ff5144854a72d56fff7286ea9a81736378d5c2eac81eef0b6f329ef1b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49601",
+					"10.65.0.27:49601",
+					"172.17.0.1:49601",
+					"172.18.0.1:49601",
+					"172.19.0.1:49601",
+					"172.20.0.1:49601",
+					"172.21.0.1:49601",
+					"172.22.0.1:49601",
+					"172.23.0.1:49601",
+					"172.24.0.1:49601",
+					"172.25.0.1:49601",
+					"172.26.0.1:49601",
+					"172.27.0.1:49601"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:25:57.623851595Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1754521776149444,
+				"StableID":   "nVVHH6KdhE11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89d04b3ec1cd953acfced2752023c96f358c21e6117595e9a9a9193468f8ea40",
+				"DiscoKey":   "discokey:6330fc9c2de6eeb836b51a009212d34d93735f8cacde169d5126d1827a105014",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54805",
+					"10.65.0.27:54805",
+					"172.17.0.1:54805",
+					"172.18.0.1:54805",
+					"172.19.0.1:54805",
+					"172.20.0.1:54805",
+					"172.21.0.1:54805",
+					"172.22.0.1:54805",
+					"172.23.0.1:54805",
+					"172.24.0.1:54805",
+					"172.25.0.1:54805",
+					"172.26.0.1:54805",
+					"172.27.0.1:54805"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:25:58.168865723Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5991564693681578,
+				"StableID":   "n7KDqBFbno11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ccd4e67a2cc70de546e3cd7fe6b30ea45e5ed9900de9b80d893d63d685f44a05",
+				"DiscoKey":   "discokey:25b6576979922c201647204426ff0e3cf2dfe09aa9c47690d712cd588f5e2062",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60155",
+					"10.65.0.27:60155",
+					"172.17.0.1:60155",
+					"172.18.0.1:60155",
+					"172.19.0.1:60155",
+					"172.20.0.1:60155",
+					"172.21.0.1:60155",
+					"172.22.0.1:60155",
+					"172.23.0.1:60155",
+					"172.24.0.1:60155",
+					"172.25.0.1:60155",
+					"172.26.0.1:60155",
+					"172.27.0.1:60155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:25:58.693234704Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2467040710852722,
+				"StableID":   "nXsmdcyKGL11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6dd39de776307c6ec64b0ddd8ecae095d339c62f436ef04ecb4e31d07dcffc13",
+				"DiscoKey":   "discokey:b90b6767cbba1ab4d3580a3576b354813d757de6812cbb7a094e811c9c002c3f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50824",
+					"10.65.0.27:50824",
+					"172.17.0.1:50824",
+					"172.18.0.1:50824",
+					"172.19.0.1:50824",
+					"172.20.0.1:50824",
+					"172.21.0.1:50824",
+					"172.22.0.1:50824",
+					"172.23.0.1:50824",
+					"172.24.0.1:50824",
+					"172.25.0.1:50824",
+					"172.26.0.1:50824",
+					"172.27.0.1:50824"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:25:59.212390098Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7791884088342646,
+				"StableID":   "nyELqmaxq321CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51972f61ed25c9c9b251d581a32faccf2c919c8ecd47e01b6c7d0b5645002d4b",
+				"DiscoKey":   "discokey:1db365b71d0c552f0e10d299e592bd6209faa3f034b3c7a23847858e5708b61a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42275",
+					"10.65.0.27:42275",
+					"172.17.0.1:42275",
+					"172.18.0.1:42275",
+					"172.19.0.1:42275",
+					"172.20.0.1:42275",
+					"172.21.0.1:42275",
+					"172.22.0.1:42275",
+					"172.23.0.1:42275",
+					"172.24.0.1:42275",
+					"172.25.0.1:42275",
+					"172.26.0.1:42275",
+					"172.27.0.1:42275"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:25:59.746462998Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6389966061376616,
+				"StableID":   "nRq7SEa2ur11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2a8c6a87d0b42f0ce0fd039261c721d78966aa3c47321dd82ed5ab588a55ba55",
+				"DiscoKey":   "discokey:a5f67056c66182b1ece69b43998cdeb29cf4839ce15a7ea113b8ab322c2e4924",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54787",
+					"10.65.0.27:54787",
+					"172.17.0.1:54787",
+					"172.18.0.1:54787",
+					"172.19.0.1:54787",
+					"172.20.0.1:54787",
+					"172.21.0.1:54787",
+					"172.22.0.1:54787",
+					"172.23.0.1:54787",
+					"172.24.0.1:54787",
+					"172.25.0.1:54787",
+					"172.26.0.1:54787",
+					"172.27.0.1:54787"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:26:00.274096536Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1055306989129197,
+				"StableID":   "nSjDuF8xE911CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3593bf7bbeeeec26dc7ee462cea1a75809c7ae458f6ec35c05d63e2e9bca1877",
+				"DiscoKey":   "discokey:63de9e2f1c401c0046477ea78ec96e4a6fee5686a14957ca476453d50b648d65",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58374",
+					"10.65.0.27:58374",
+					"172.17.0.1:58374",
+					"172.18.0.1:58374",
+					"172.19.0.1:58374",
+					"172.20.0.1:58374",
+					"172.21.0.1:58374",
+					"172.22.0.1:58374",
+					"172.23.0.1:58374",
+					"172.24.0.1:58374",
+					"172.25.0.1:58374",
+					"172.26.0.1:58374",
+					"172.27.0.1:58374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:26:00.872732453Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5059147728361694,
+				"StableID":   "nMx2XTEJWg11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:011542c0cfbeb754e87234b0e6040cfbc21db3d227952120fd87272c72c9bd4a",
+				"DiscoKey":   "discokey:83d245de9eba2b009641cabdbf824d745958ab96fde3e94fae1e408bf5a00d7c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35319",
+					"10.65.0.27:35319",
+					"172.17.0.1:35319",
+					"172.18.0.1:35319",
+					"172.19.0.1:35319",
+					"172.20.0.1:35319",
+					"172.21.0.1:35319",
+					"172.22.0.1:35319",
+					"172.23.0.1:35319",
+					"172.24.0.1:35319",
+					"172.25.0.1:35319",
+					"172.26.0.1:35319",
+					"172.27.0.1:35319"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:26:01.860130237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6314986434931921,
+				"StableID":   "nUnnb9z4Kr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:884ac400784500c4ac7062eb5dfc130a336d9131ea1670647a26c6c735eeba1d",
+				"DiscoKey":   "discokey:74b3c7a3c909080c0803aefae71022600746afe32320a7a00aea188f2b8d5051",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38181",
+					"10.65.0.27:38181",
+					"172.17.0.1:38181",
+					"172.18.0.1:38181",
+					"172.19.0.1:38181",
+					"172.20.0.1:38181",
+					"172.21.0.1:38181",
+					"172.22.0.1:38181",
+					"172.23.0.1:38181",
+					"172.24.0.1:38181",
+					"172.25.0.1:38181",
+					"172.26.0.1:38181",
+					"172.27.0.1:38181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:26:02.386361251Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3027636418233653,
+				"StableID":   "nE5HdjsDeQ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:57cc21672c69b7a5b2af5b17ac0dd70d4d3c104ba149a207c4818f4c0edf331f",
+				"DiscoKey":   "discokey:4d1307114289a331544162ec0264cfb4f2469406c7dfaee44c0e6c744ce4b156",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57818",
+					"10.65.0.27:57818",
+					"172.17.0.1:57818",
+					"172.18.0.1:57818",
+					"172.19.0.1:57818",
+					"172.20.0.1:57818",
+					"172.21.0.1:57818",
+					"172.22.0.1:57818",
+					"172.23.0.1:57818",
+					"172.24.0.1:57818",
+					"172.25.0.1:57818",
+					"172.26.0.1:57818",
+					"172.27.0.1:57818"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:26:02.90258067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5988788433583050,
+				"StableID":   "nDUXEPKLmo11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d03a57906aa1dcff0d05193c0435a9eb9d64922dad7b8feb5dfbaaef357a497a",
+				"DiscoKey":   "discokey:6276f751d145f796fb617ea1cfdf067350d436709901b15750b0bbb8f80c2a59",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35096",
+					"10.65.0.27:35096",
+					"172.17.0.1:35096",
+					"172.18.0.1:35096",
+					"172.19.0.1:35096",
+					"172.20.0.1:35096",
+					"172.21.0.1:35096",
+					"172.22.0.1:35096",
+					"172.23.0.1:35096",
+					"172.24.0.1:35096",
+					"172.25.0.1:35096",
+					"172.26.0.1:35096",
+					"172.27.0.1:35096"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:26:03.441102354Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3391484253904715,
+				"StableID":   "n2rfvLY1VT11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:2140010fd9cc6364dfa817bba059f6d3b83dacbf862ec711267a0f9fc95dba29",
+				"KeyExpiry":  "2026-11-09T09:26:03Z",
+				"DiscoKey":   "discokey:7541ee0f3d8a5a48a8370943d56f58d226ac09650ecfc16378e29d7b9218ab0f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47234",
+					"10.65.0.27:47234",
+					"172.17.0.1:47234",
+					"172.18.0.1:47234",
+					"172.19.0.1:47234",
+					"172.20.0.1:47234",
+					"172.21.0.1:47234",
+					"172.22.0.1:47234",
+					"172.23.0.1:47234",
+					"172.24.0.1:47234",
+					"172.25.0.1:47234",
+					"172.26.0.1:47234",
+					"172.27.0.1:47234"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:26:03.97812334Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8822860486792403,
+				"StableID":   "nS2bksattB21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:728287e19d4cf728efeb2fa5b1e13c83f59d0face81ca1f7451e3c63e855c500",
+				"KeyExpiry":  "2026-11-09T09:26:04Z",
+				"DiscoKey":   "discokey:86995fce0a1e74e4ccfd4994883888bdd16cf0f5dff4d77371e879dc7739b40e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48280",
+					"10.65.0.27:48280",
+					"172.17.0.1:48280",
+					"172.18.0.1:48280",
+					"172.19.0.1:48280",
+					"172.20.0.1:48280",
+					"172.21.0.1:48280",
+					"172.22.0.1:48280",
+					"172.23.0.1:48280",
+					"172.24.0.1:48280",
+					"172.25.0.1:48280",
+					"172.26.0.1:48280",
+					"172.27.0.1:48280"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:26:04.52785528Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4012558335314868,
+				"StableID":   "nT2Rjz6JLY11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e4cb2902e1b8f1d2a56ce7d6cb2ddcaa2e0456dd44e034e41e010f058a849054",
+				"KeyExpiry":  "2026-11-09T09:26:05Z",
+				"DiscoKey":   "discokey:3cdbe56232a3c233d2ffbe22d84cbe0916646cce682d5b8ee703e1bb314fa078",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:40522",
+					"10.65.0.27:40522",
+					"172.17.0.1:40522",
+					"172.18.0.1:40522",
+					"172.19.0.1:40522",
+					"172.20.0.1:40522",
+					"172.21.0.1:40522",
+					"172.22.0.1:40522",
+					"172.23.0.1:40522",
+					"172.24.0.1:40522",
+					"172.25.0.1:40522",
+					"172.26.0.1:40522",
+					"172.27.0.1:40522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:26:05.324315528Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3737616221991531": {
+				"ID":          3737616221991531,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3391484253904715,
+				"StableID":   "n2rfvLY1VT11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:2140010fd9cc6364dfa817bba059f6d3b83dacbf862ec711267a0f9fc95dba29",
+				"KeyExpiry":  "2026-11-09T09:26:03Z",
+				"DiscoKey":   "discokey:7541ee0f3d8a5a48a8370943d56f58d226ac09650ecfc16378e29d7b9218ab0f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47234",
+					"10.65.0.27:47234",
+					"172.17.0.1:47234",
+					"172.18.0.1:47234",
+					"172.19.0.1:47234",
+					"172.20.0.1:47234",
+					"172.21.0.1:47234",
+					"172.22.0.1:47234",
+					"172.23.0.1:47234",
+					"172.24.0.1:47234",
+					"172.25.0.1:47234",
+					"172.26.0.1:47234",
+					"172.27.0.1:47234"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:26:03.97812334Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2140010fd9cc6364dfa817bba059f6d3b83dacbf862ec711267a0f9fc95dba29",
+			"MachineKey": "mkey:f43bb4f1849e29be74f3cf592be2988c2904520ad41d3ffce885285cb5b52815",
+			"Peers": [{
+				"ID":         8343158374485682,
+				"StableID":   "ndrUk8dd9821CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41ae8133c03d911c119ed6427c57aa9fcbba2adb85e87163d8111c4e5161e777",
+				"DiscoKey":   "discokey:d3a70a3ff5144854a72d56fff7286ea9a81736378d5c2eac81eef0b6f329ef1b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49601",
+					"10.65.0.27:49601",
+					"172.17.0.1:49601",
+					"172.18.0.1:49601",
+					"172.19.0.1:49601",
+					"172.20.0.1:49601",
+					"172.21.0.1:49601",
+					"172.22.0.1:49601",
+					"172.23.0.1:49601",
+					"172.24.0.1:49601",
+					"172.25.0.1:49601",
+					"172.26.0.1:49601",
+					"172.27.0.1:49601"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:25:57.623851595Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1754521776149444,
+				"StableID":   "nVVHH6KdhE11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89d04b3ec1cd953acfced2752023c96f358c21e6117595e9a9a9193468f8ea40",
+				"DiscoKey":   "discokey:6330fc9c2de6eeb836b51a009212d34d93735f8cacde169d5126d1827a105014",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54805",
+					"10.65.0.27:54805",
+					"172.17.0.1:54805",
+					"172.18.0.1:54805",
+					"172.19.0.1:54805",
+					"172.20.0.1:54805",
+					"172.21.0.1:54805",
+					"172.22.0.1:54805",
+					"172.23.0.1:54805",
+					"172.24.0.1:54805",
+					"172.25.0.1:54805",
+					"172.26.0.1:54805",
+					"172.27.0.1:54805"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:25:58.168865723Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5991564693681578,
+				"StableID":   "n7KDqBFbno11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ccd4e67a2cc70de546e3cd7fe6b30ea45e5ed9900de9b80d893d63d685f44a05",
+				"DiscoKey":   "discokey:25b6576979922c201647204426ff0e3cf2dfe09aa9c47690d712cd588f5e2062",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60155",
+					"10.65.0.27:60155",
+					"172.17.0.1:60155",
+					"172.18.0.1:60155",
+					"172.19.0.1:60155",
+					"172.20.0.1:60155",
+					"172.21.0.1:60155",
+					"172.22.0.1:60155",
+					"172.23.0.1:60155",
+					"172.24.0.1:60155",
+					"172.25.0.1:60155",
+					"172.26.0.1:60155",
+					"172.27.0.1:60155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:25:58.693234704Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2467040710852722,
+				"StableID":   "nXsmdcyKGL11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6dd39de776307c6ec64b0ddd8ecae095d339c62f436ef04ecb4e31d07dcffc13",
+				"DiscoKey":   "discokey:b90b6767cbba1ab4d3580a3576b354813d757de6812cbb7a094e811c9c002c3f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50824",
+					"10.65.0.27:50824",
+					"172.17.0.1:50824",
+					"172.18.0.1:50824",
+					"172.19.0.1:50824",
+					"172.20.0.1:50824",
+					"172.21.0.1:50824",
+					"172.22.0.1:50824",
+					"172.23.0.1:50824",
+					"172.24.0.1:50824",
+					"172.25.0.1:50824",
+					"172.26.0.1:50824",
+					"172.27.0.1:50824"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:25:59.212390098Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7791884088342646,
+				"StableID":   "nyELqmaxq321CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51972f61ed25c9c9b251d581a32faccf2c919c8ecd47e01b6c7d0b5645002d4b",
+				"DiscoKey":   "discokey:1db365b71d0c552f0e10d299e592bd6209faa3f034b3c7a23847858e5708b61a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42275",
+					"10.65.0.27:42275",
+					"172.17.0.1:42275",
+					"172.18.0.1:42275",
+					"172.19.0.1:42275",
+					"172.20.0.1:42275",
+					"172.21.0.1:42275",
+					"172.22.0.1:42275",
+					"172.23.0.1:42275",
+					"172.24.0.1:42275",
+					"172.25.0.1:42275",
+					"172.26.0.1:42275",
+					"172.27.0.1:42275"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:25:59.746462998Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6389966061376616,
+				"StableID":   "nRq7SEa2ur11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2a8c6a87d0b42f0ce0fd039261c721d78966aa3c47321dd82ed5ab588a55ba55",
+				"DiscoKey":   "discokey:a5f67056c66182b1ece69b43998cdeb29cf4839ce15a7ea113b8ab322c2e4924",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54787",
+					"10.65.0.27:54787",
+					"172.17.0.1:54787",
+					"172.18.0.1:54787",
+					"172.19.0.1:54787",
+					"172.20.0.1:54787",
+					"172.21.0.1:54787",
+					"172.22.0.1:54787",
+					"172.23.0.1:54787",
+					"172.24.0.1:54787",
+					"172.25.0.1:54787",
+					"172.26.0.1:54787",
+					"172.27.0.1:54787"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:26:00.274096536Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1055306989129197,
+				"StableID":   "nSjDuF8xE911CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3593bf7bbeeeec26dc7ee462cea1a75809c7ae458f6ec35c05d63e2e9bca1877",
+				"DiscoKey":   "discokey:63de9e2f1c401c0046477ea78ec96e4a6fee5686a14957ca476453d50b648d65",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58374",
+					"10.65.0.27:58374",
+					"172.17.0.1:58374",
+					"172.18.0.1:58374",
+					"172.19.0.1:58374",
+					"172.20.0.1:58374",
+					"172.21.0.1:58374",
+					"172.22.0.1:58374",
+					"172.23.0.1:58374",
+					"172.24.0.1:58374",
+					"172.25.0.1:58374",
+					"172.26.0.1:58374",
+					"172.27.0.1:58374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:26:00.872732453Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3737616221991531,
+				"StableID":   "nzNyfjqmBW11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e9a602a93d0357af740fc7e394645f4e174709cd2026835debd5bff455779369",
+				"DiscoKey":   "discokey:94c064a50634869029fc6e962946859bf642c8d4747f2f505d81635d3351612e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:44914",
+					"10.65.0.27:44914",
+					"172.17.0.1:44914",
+					"172.18.0.1:44914",
+					"172.19.0.1:44914",
+					"172.20.0.1:44914",
+					"172.21.0.1:44914",
+					"172.22.0.1:44914",
+					"172.23.0.1:44914",
+					"172.24.0.1:44914",
+					"172.25.0.1:44914",
+					"172.26.0.1:44914",
+					"172.27.0.1:44914"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:26:01.325879553Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5059147728361694,
+				"StableID":   "nMx2XTEJWg11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:011542c0cfbeb754e87234b0e6040cfbc21db3d227952120fd87272c72c9bd4a",
+				"DiscoKey":   "discokey:83d245de9eba2b009641cabdbf824d745958ab96fde3e94fae1e408bf5a00d7c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35319",
+					"10.65.0.27:35319",
+					"172.17.0.1:35319",
+					"172.18.0.1:35319",
+					"172.19.0.1:35319",
+					"172.20.0.1:35319",
+					"172.21.0.1:35319",
+					"172.22.0.1:35319",
+					"172.23.0.1:35319",
+					"172.24.0.1:35319",
+					"172.25.0.1:35319",
+					"172.26.0.1:35319",
+					"172.27.0.1:35319"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:26:01.860130237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6314986434931921,
+				"StableID":   "nUnnb9z4Kr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:884ac400784500c4ac7062eb5dfc130a336d9131ea1670647a26c6c735eeba1d",
+				"DiscoKey":   "discokey:74b3c7a3c909080c0803aefae71022600746afe32320a7a00aea188f2b8d5051",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38181",
+					"10.65.0.27:38181",
+					"172.17.0.1:38181",
+					"172.18.0.1:38181",
+					"172.19.0.1:38181",
+					"172.20.0.1:38181",
+					"172.21.0.1:38181",
+					"172.22.0.1:38181",
+					"172.23.0.1:38181",
+					"172.24.0.1:38181",
+					"172.25.0.1:38181",
+					"172.26.0.1:38181",
+					"172.27.0.1:38181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:26:02.386361251Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3027636418233653,
+				"StableID":   "nE5HdjsDeQ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:57cc21672c69b7a5b2af5b17ac0dd70d4d3c104ba149a207c4818f4c0edf331f",
+				"DiscoKey":   "discokey:4d1307114289a331544162ec0264cfb4f2469406c7dfaee44c0e6c744ce4b156",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57818",
+					"10.65.0.27:57818",
+					"172.17.0.1:57818",
+					"172.18.0.1:57818",
+					"172.19.0.1:57818",
+					"172.20.0.1:57818",
+					"172.21.0.1:57818",
+					"172.22.0.1:57818",
+					"172.23.0.1:57818",
+					"172.24.0.1:57818",
+					"172.25.0.1:57818",
+					"172.26.0.1:57818",
+					"172.27.0.1:57818"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:26:02.90258067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5988788433583050,
+				"StableID":   "nDUXEPKLmo11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d03a57906aa1dcff0d05193c0435a9eb9d64922dad7b8feb5dfbaaef357a497a",
+				"DiscoKey":   "discokey:6276f751d145f796fb617ea1cfdf067350d436709901b15750b0bbb8f80c2a59",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35096",
+					"10.65.0.27:35096",
+					"172.17.0.1:35096",
+					"172.18.0.1:35096",
+					"172.19.0.1:35096",
+					"172.20.0.1:35096",
+					"172.21.0.1:35096",
+					"172.22.0.1:35096",
+					"172.23.0.1:35096",
+					"172.24.0.1:35096",
+					"172.25.0.1:35096",
+					"172.26.0.1:35096",
+					"172.27.0.1:35096"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:26:03.441102354Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8822860486792403,
+				"StableID":   "nS2bksattB21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:728287e19d4cf728efeb2fa5b1e13c83f59d0face81ca1f7451e3c63e855c500",
+				"KeyExpiry":  "2026-11-09T09:26:04Z",
+				"DiscoKey":   "discokey:86995fce0a1e74e4ccfd4994883888bdd16cf0f5dff4d77371e879dc7739b40e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48280",
+					"10.65.0.27:48280",
+					"172.17.0.1:48280",
+					"172.18.0.1:48280",
+					"172.19.0.1:48280",
+					"172.20.0.1:48280",
+					"172.21.0.1:48280",
+					"172.22.0.1:48280",
+					"172.23.0.1:48280",
+					"172.24.0.1:48280",
+					"172.25.0.1:48280",
+					"172.26.0.1:48280",
+					"172.27.0.1:48280"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:26:04.52785528Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4012558335314868,
+				"StableID":   "nT2Rjz6JLY11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e4cb2902e1b8f1d2a56ce7d6cb2ddcaa2e0456dd44e034e41e010f058a849054",
+				"KeyExpiry":  "2026-11-09T09:26:05Z",
+				"DiscoKey":   "discokey:3cdbe56232a3c233d2ffbe22d84cbe0916646cce682d5b8ee703e1bb314fa078",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:40522",
+					"10.65.0.27:40522",
+					"172.17.0.1:40522",
+					"172.18.0.1:40522",
+					"172.19.0.1:40522",
+					"172.20.0.1:40522",
+					"172.21.0.1:40522",
+					"172.22.0.1:40522",
+					"172.23.0.1:40522",
+					"172.24.0.1:40522",
+					"172.25.0.1:40522",
+					"172.26.0.1:40522",
+					"172.27.0.1:40522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:26:05.324315528Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3027636418233653,
+				"StableID":   "nE5HdjsDeQ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       3027636418233653,
+				"Key":        "nodekey:57cc21672c69b7a5b2af5b17ac0dd70d4d3c104ba149a207c4818f4c0edf331f",
+				"DiscoKey":   "discokey:4d1307114289a331544162ec0264cfb4f2469406c7dfaee44c0e6c744ce4b156",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57818",
+					"10.65.0.27:57818",
+					"172.17.0.1:57818",
+					"172.18.0.1:57818",
+					"172.19.0.1:57818",
+					"172.20.0.1:57818",
+					"172.21.0.1:57818",
+					"172.22.0.1:57818",
+					"172.23.0.1:57818",
+					"172.24.0.1:57818",
+					"172.25.0.1:57818",
+					"172.26.0.1:57818",
+					"172.27.0.1:57818"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:26:02.90258067Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:57cc21672c69b7a5b2af5b17ac0dd70d4d3c104ba149a207c4818f4c0edf331f",
+			"MachineKey": "mkey:5a9cfc2c0a160c91aaa6e353cde46aa5736298ba3411336433ab20fd601d1719",
+			"Peers": [{
+				"ID":         8343158374485682,
+				"StableID":   "ndrUk8dd9821CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41ae8133c03d911c119ed6427c57aa9fcbba2adb85e87163d8111c4e5161e777",
+				"DiscoKey":   "discokey:d3a70a3ff5144854a72d56fff7286ea9a81736378d5c2eac81eef0b6f329ef1b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49601",
+					"10.65.0.27:49601",
+					"172.17.0.1:49601",
+					"172.18.0.1:49601",
+					"172.19.0.1:49601",
+					"172.20.0.1:49601",
+					"172.21.0.1:49601",
+					"172.22.0.1:49601",
+					"172.23.0.1:49601",
+					"172.24.0.1:49601",
+					"172.25.0.1:49601",
+					"172.26.0.1:49601",
+					"172.27.0.1:49601"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:25:57.623851595Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1754521776149444,
+				"StableID":   "nVVHH6KdhE11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89d04b3ec1cd953acfced2752023c96f358c21e6117595e9a9a9193468f8ea40",
+				"DiscoKey":   "discokey:6330fc9c2de6eeb836b51a009212d34d93735f8cacde169d5126d1827a105014",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54805",
+					"10.65.0.27:54805",
+					"172.17.0.1:54805",
+					"172.18.0.1:54805",
+					"172.19.0.1:54805",
+					"172.20.0.1:54805",
+					"172.21.0.1:54805",
+					"172.22.0.1:54805",
+					"172.23.0.1:54805",
+					"172.24.0.1:54805",
+					"172.25.0.1:54805",
+					"172.26.0.1:54805",
+					"172.27.0.1:54805"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:25:58.168865723Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5991564693681578,
+				"StableID":   "n7KDqBFbno11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ccd4e67a2cc70de546e3cd7fe6b30ea45e5ed9900de9b80d893d63d685f44a05",
+				"DiscoKey":   "discokey:25b6576979922c201647204426ff0e3cf2dfe09aa9c47690d712cd588f5e2062",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60155",
+					"10.65.0.27:60155",
+					"172.17.0.1:60155",
+					"172.18.0.1:60155",
+					"172.19.0.1:60155",
+					"172.20.0.1:60155",
+					"172.21.0.1:60155",
+					"172.22.0.1:60155",
+					"172.23.0.1:60155",
+					"172.24.0.1:60155",
+					"172.25.0.1:60155",
+					"172.26.0.1:60155",
+					"172.27.0.1:60155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:25:58.693234704Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2467040710852722,
+				"StableID":   "nXsmdcyKGL11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6dd39de776307c6ec64b0ddd8ecae095d339c62f436ef04ecb4e31d07dcffc13",
+				"DiscoKey":   "discokey:b90b6767cbba1ab4d3580a3576b354813d757de6812cbb7a094e811c9c002c3f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50824",
+					"10.65.0.27:50824",
+					"172.17.0.1:50824",
+					"172.18.0.1:50824",
+					"172.19.0.1:50824",
+					"172.20.0.1:50824",
+					"172.21.0.1:50824",
+					"172.22.0.1:50824",
+					"172.23.0.1:50824",
+					"172.24.0.1:50824",
+					"172.25.0.1:50824",
+					"172.26.0.1:50824",
+					"172.27.0.1:50824"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:25:59.212390098Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7791884088342646,
+				"StableID":   "nyELqmaxq321CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51972f61ed25c9c9b251d581a32faccf2c919c8ecd47e01b6c7d0b5645002d4b",
+				"DiscoKey":   "discokey:1db365b71d0c552f0e10d299e592bd6209faa3f034b3c7a23847858e5708b61a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42275",
+					"10.65.0.27:42275",
+					"172.17.0.1:42275",
+					"172.18.0.1:42275",
+					"172.19.0.1:42275",
+					"172.20.0.1:42275",
+					"172.21.0.1:42275",
+					"172.22.0.1:42275",
+					"172.23.0.1:42275",
+					"172.24.0.1:42275",
+					"172.25.0.1:42275",
+					"172.26.0.1:42275",
+					"172.27.0.1:42275"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:25:59.746462998Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6389966061376616,
+				"StableID":   "nRq7SEa2ur11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2a8c6a87d0b42f0ce0fd039261c721d78966aa3c47321dd82ed5ab588a55ba55",
+				"DiscoKey":   "discokey:a5f67056c66182b1ece69b43998cdeb29cf4839ce15a7ea113b8ab322c2e4924",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54787",
+					"10.65.0.27:54787",
+					"172.17.0.1:54787",
+					"172.18.0.1:54787",
+					"172.19.0.1:54787",
+					"172.20.0.1:54787",
+					"172.21.0.1:54787",
+					"172.22.0.1:54787",
+					"172.23.0.1:54787",
+					"172.24.0.1:54787",
+					"172.25.0.1:54787",
+					"172.26.0.1:54787",
+					"172.27.0.1:54787"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:26:00.274096536Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1055306989129197,
+				"StableID":   "nSjDuF8xE911CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3593bf7bbeeeec26dc7ee462cea1a75809c7ae458f6ec35c05d63e2e9bca1877",
+				"DiscoKey":   "discokey:63de9e2f1c401c0046477ea78ec96e4a6fee5686a14957ca476453d50b648d65",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58374",
+					"10.65.0.27:58374",
+					"172.17.0.1:58374",
+					"172.18.0.1:58374",
+					"172.19.0.1:58374",
+					"172.20.0.1:58374",
+					"172.21.0.1:58374",
+					"172.22.0.1:58374",
+					"172.23.0.1:58374",
+					"172.24.0.1:58374",
+					"172.25.0.1:58374",
+					"172.26.0.1:58374",
+					"172.27.0.1:58374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:26:00.872732453Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3737616221991531,
+				"StableID":   "nzNyfjqmBW11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e9a602a93d0357af740fc7e394645f4e174709cd2026835debd5bff455779369",
+				"DiscoKey":   "discokey:94c064a50634869029fc6e962946859bf642c8d4747f2f505d81635d3351612e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:44914",
+					"10.65.0.27:44914",
+					"172.17.0.1:44914",
+					"172.18.0.1:44914",
+					"172.19.0.1:44914",
+					"172.20.0.1:44914",
+					"172.21.0.1:44914",
+					"172.22.0.1:44914",
+					"172.23.0.1:44914",
+					"172.24.0.1:44914",
+					"172.25.0.1:44914",
+					"172.26.0.1:44914",
+					"172.27.0.1:44914"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:26:01.325879553Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5059147728361694,
+				"StableID":   "nMx2XTEJWg11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:011542c0cfbeb754e87234b0e6040cfbc21db3d227952120fd87272c72c9bd4a",
+				"DiscoKey":   "discokey:83d245de9eba2b009641cabdbf824d745958ab96fde3e94fae1e408bf5a00d7c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35319",
+					"10.65.0.27:35319",
+					"172.17.0.1:35319",
+					"172.18.0.1:35319",
+					"172.19.0.1:35319",
+					"172.20.0.1:35319",
+					"172.21.0.1:35319",
+					"172.22.0.1:35319",
+					"172.23.0.1:35319",
+					"172.24.0.1:35319",
+					"172.25.0.1:35319",
+					"172.26.0.1:35319",
+					"172.27.0.1:35319"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:26:01.860130237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6314986434931921,
+				"StableID":   "nUnnb9z4Kr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:884ac400784500c4ac7062eb5dfc130a336d9131ea1670647a26c6c735eeba1d",
+				"DiscoKey":   "discokey:74b3c7a3c909080c0803aefae71022600746afe32320a7a00aea188f2b8d5051",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38181",
+					"10.65.0.27:38181",
+					"172.17.0.1:38181",
+					"172.18.0.1:38181",
+					"172.19.0.1:38181",
+					"172.20.0.1:38181",
+					"172.21.0.1:38181",
+					"172.22.0.1:38181",
+					"172.23.0.1:38181",
+					"172.24.0.1:38181",
+					"172.25.0.1:38181",
+					"172.26.0.1:38181",
+					"172.27.0.1:38181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:26:02.386361251Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5988788433583050,
+				"StableID":   "nDUXEPKLmo11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d03a57906aa1dcff0d05193c0435a9eb9d64922dad7b8feb5dfbaaef357a497a",
+				"DiscoKey":   "discokey:6276f751d145f796fb617ea1cfdf067350d436709901b15750b0bbb8f80c2a59",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35096",
+					"10.65.0.27:35096",
+					"172.17.0.1:35096",
+					"172.18.0.1:35096",
+					"172.19.0.1:35096",
+					"172.20.0.1:35096",
+					"172.21.0.1:35096",
+					"172.22.0.1:35096",
+					"172.23.0.1:35096",
+					"172.24.0.1:35096",
+					"172.25.0.1:35096",
+					"172.26.0.1:35096",
+					"172.27.0.1:35096"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:26:03.441102354Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3391484253904715,
+				"StableID":   "n2rfvLY1VT11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:2140010fd9cc6364dfa817bba059f6d3b83dacbf862ec711267a0f9fc95dba29",
+				"KeyExpiry":  "2026-11-09T09:26:03Z",
+				"DiscoKey":   "discokey:7541ee0f3d8a5a48a8370943d56f58d226ac09650ecfc16378e29d7b9218ab0f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47234",
+					"10.65.0.27:47234",
+					"172.17.0.1:47234",
+					"172.18.0.1:47234",
+					"172.19.0.1:47234",
+					"172.20.0.1:47234",
+					"172.21.0.1:47234",
+					"172.22.0.1:47234",
+					"172.23.0.1:47234",
+					"172.24.0.1:47234",
+					"172.25.0.1:47234",
+					"172.26.0.1:47234",
+					"172.27.0.1:47234"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:26:03.97812334Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8822860486792403,
+				"StableID":   "nS2bksattB21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:728287e19d4cf728efeb2fa5b1e13c83f59d0face81ca1f7451e3c63e855c500",
+				"KeyExpiry":  "2026-11-09T09:26:04Z",
+				"DiscoKey":   "discokey:86995fce0a1e74e4ccfd4994883888bdd16cf0f5dff4d77371e879dc7739b40e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48280",
+					"10.65.0.27:48280",
+					"172.17.0.1:48280",
+					"172.18.0.1:48280",
+					"172.19.0.1:48280",
+					"172.20.0.1:48280",
+					"172.21.0.1:48280",
+					"172.22.0.1:48280",
+					"172.23.0.1:48280",
+					"172.24.0.1:48280",
+					"172.25.0.1:48280",
+					"172.26.0.1:48280",
+					"172.27.0.1:48280"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:26:04.52785528Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4012558335314868,
+				"StableID":   "nT2Rjz6JLY11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e4cb2902e1b8f1d2a56ce7d6cb2ddcaa2e0456dd44e034e41e010f058a849054",
+				"KeyExpiry":  "2026-11-09T09:26:05Z",
+				"DiscoKey":   "discokey:3cdbe56232a3c233d2ffbe22d84cbe0916646cce682d5b8ee703e1bb314fa078",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:40522",
+					"10.65.0.27:40522",
+					"172.17.0.1:40522",
+					"172.18.0.1:40522",
+					"172.19.0.1:40522",
+					"172.20.0.1:40522",
+					"172.21.0.1:40522",
+					"172.22.0.1:40522",
+					"172.23.0.1:40522",
+					"172.24.0.1:40522",
+					"172.25.0.1:40522",
+					"172.26.0.1:40522",
+					"172.27.0.1:40522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:26:05.324315528Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3027636418233653": {
+				"ID":          3027636418233653,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1754521776149444,
+				"StableID":   "nVVHH6KdhE11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1754521776149444,
+				"Key":        "nodekey:89d04b3ec1cd953acfced2752023c96f358c21e6117595e9a9a9193468f8ea40",
+				"DiscoKey":   "discokey:6330fc9c2de6eeb836b51a009212d34d93735f8cacde169d5126d1827a105014",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54805",
+					"10.65.0.27:54805",
+					"172.17.0.1:54805",
+					"172.18.0.1:54805",
+					"172.19.0.1:54805",
+					"172.20.0.1:54805",
+					"172.21.0.1:54805",
+					"172.22.0.1:54805",
+					"172.23.0.1:54805",
+					"172.24.0.1:54805",
+					"172.25.0.1:54805",
+					"172.26.0.1:54805",
+					"172.27.0.1:54805"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:25:58.168865723Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:89d04b3ec1cd953acfced2752023c96f358c21e6117595e9a9a9193468f8ea40",
+			"MachineKey": "mkey:0ef0b18dd438848faf63f9507db2c12163074ae834bcdb190dff35aa2587ff65",
+			"Peers": [{
+				"ID":         8343158374485682,
+				"StableID":   "ndrUk8dd9821CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41ae8133c03d911c119ed6427c57aa9fcbba2adb85e87163d8111c4e5161e777",
+				"DiscoKey":   "discokey:d3a70a3ff5144854a72d56fff7286ea9a81736378d5c2eac81eef0b6f329ef1b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49601",
+					"10.65.0.27:49601",
+					"172.17.0.1:49601",
+					"172.18.0.1:49601",
+					"172.19.0.1:49601",
+					"172.20.0.1:49601",
+					"172.21.0.1:49601",
+					"172.22.0.1:49601",
+					"172.23.0.1:49601",
+					"172.24.0.1:49601",
+					"172.25.0.1:49601",
+					"172.26.0.1:49601",
+					"172.27.0.1:49601"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:25:57.623851595Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5991564693681578,
+				"StableID":   "n7KDqBFbno11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ccd4e67a2cc70de546e3cd7fe6b30ea45e5ed9900de9b80d893d63d685f44a05",
+				"DiscoKey":   "discokey:25b6576979922c201647204426ff0e3cf2dfe09aa9c47690d712cd588f5e2062",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60155",
+					"10.65.0.27:60155",
+					"172.17.0.1:60155",
+					"172.18.0.1:60155",
+					"172.19.0.1:60155",
+					"172.20.0.1:60155",
+					"172.21.0.1:60155",
+					"172.22.0.1:60155",
+					"172.23.0.1:60155",
+					"172.24.0.1:60155",
+					"172.25.0.1:60155",
+					"172.26.0.1:60155",
+					"172.27.0.1:60155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:25:58.693234704Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2467040710852722,
+				"StableID":   "nXsmdcyKGL11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6dd39de776307c6ec64b0ddd8ecae095d339c62f436ef04ecb4e31d07dcffc13",
+				"DiscoKey":   "discokey:b90b6767cbba1ab4d3580a3576b354813d757de6812cbb7a094e811c9c002c3f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50824",
+					"10.65.0.27:50824",
+					"172.17.0.1:50824",
+					"172.18.0.1:50824",
+					"172.19.0.1:50824",
+					"172.20.0.1:50824",
+					"172.21.0.1:50824",
+					"172.22.0.1:50824",
+					"172.23.0.1:50824",
+					"172.24.0.1:50824",
+					"172.25.0.1:50824",
+					"172.26.0.1:50824",
+					"172.27.0.1:50824"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:25:59.212390098Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7791884088342646,
+				"StableID":   "nyELqmaxq321CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51972f61ed25c9c9b251d581a32faccf2c919c8ecd47e01b6c7d0b5645002d4b",
+				"DiscoKey":   "discokey:1db365b71d0c552f0e10d299e592bd6209faa3f034b3c7a23847858e5708b61a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42275",
+					"10.65.0.27:42275",
+					"172.17.0.1:42275",
+					"172.18.0.1:42275",
+					"172.19.0.1:42275",
+					"172.20.0.1:42275",
+					"172.21.0.1:42275",
+					"172.22.0.1:42275",
+					"172.23.0.1:42275",
+					"172.24.0.1:42275",
+					"172.25.0.1:42275",
+					"172.26.0.1:42275",
+					"172.27.0.1:42275"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:25:59.746462998Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6389966061376616,
+				"StableID":   "nRq7SEa2ur11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2a8c6a87d0b42f0ce0fd039261c721d78966aa3c47321dd82ed5ab588a55ba55",
+				"DiscoKey":   "discokey:a5f67056c66182b1ece69b43998cdeb29cf4839ce15a7ea113b8ab322c2e4924",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54787",
+					"10.65.0.27:54787",
+					"172.17.0.1:54787",
+					"172.18.0.1:54787",
+					"172.19.0.1:54787",
+					"172.20.0.1:54787",
+					"172.21.0.1:54787",
+					"172.22.0.1:54787",
+					"172.23.0.1:54787",
+					"172.24.0.1:54787",
+					"172.25.0.1:54787",
+					"172.26.0.1:54787",
+					"172.27.0.1:54787"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:26:00.274096536Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1055306989129197,
+				"StableID":   "nSjDuF8xE911CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3593bf7bbeeeec26dc7ee462cea1a75809c7ae458f6ec35c05d63e2e9bca1877",
+				"DiscoKey":   "discokey:63de9e2f1c401c0046477ea78ec96e4a6fee5686a14957ca476453d50b648d65",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58374",
+					"10.65.0.27:58374",
+					"172.17.0.1:58374",
+					"172.18.0.1:58374",
+					"172.19.0.1:58374",
+					"172.20.0.1:58374",
+					"172.21.0.1:58374",
+					"172.22.0.1:58374",
+					"172.23.0.1:58374",
+					"172.24.0.1:58374",
+					"172.25.0.1:58374",
+					"172.26.0.1:58374",
+					"172.27.0.1:58374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:26:00.872732453Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3737616221991531,
+				"StableID":   "nzNyfjqmBW11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e9a602a93d0357af740fc7e394645f4e174709cd2026835debd5bff455779369",
+				"DiscoKey":   "discokey:94c064a50634869029fc6e962946859bf642c8d4747f2f505d81635d3351612e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:44914",
+					"10.65.0.27:44914",
+					"172.17.0.1:44914",
+					"172.18.0.1:44914",
+					"172.19.0.1:44914",
+					"172.20.0.1:44914",
+					"172.21.0.1:44914",
+					"172.22.0.1:44914",
+					"172.23.0.1:44914",
+					"172.24.0.1:44914",
+					"172.25.0.1:44914",
+					"172.26.0.1:44914",
+					"172.27.0.1:44914"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:26:01.325879553Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5059147728361694,
+				"StableID":   "nMx2XTEJWg11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:011542c0cfbeb754e87234b0e6040cfbc21db3d227952120fd87272c72c9bd4a",
+				"DiscoKey":   "discokey:83d245de9eba2b009641cabdbf824d745958ab96fde3e94fae1e408bf5a00d7c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35319",
+					"10.65.0.27:35319",
+					"172.17.0.1:35319",
+					"172.18.0.1:35319",
+					"172.19.0.1:35319",
+					"172.20.0.1:35319",
+					"172.21.0.1:35319",
+					"172.22.0.1:35319",
+					"172.23.0.1:35319",
+					"172.24.0.1:35319",
+					"172.25.0.1:35319",
+					"172.26.0.1:35319",
+					"172.27.0.1:35319"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:26:01.860130237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6314986434931921,
+				"StableID":   "nUnnb9z4Kr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:884ac400784500c4ac7062eb5dfc130a336d9131ea1670647a26c6c735eeba1d",
+				"DiscoKey":   "discokey:74b3c7a3c909080c0803aefae71022600746afe32320a7a00aea188f2b8d5051",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38181",
+					"10.65.0.27:38181",
+					"172.17.0.1:38181",
+					"172.18.0.1:38181",
+					"172.19.0.1:38181",
+					"172.20.0.1:38181",
+					"172.21.0.1:38181",
+					"172.22.0.1:38181",
+					"172.23.0.1:38181",
+					"172.24.0.1:38181",
+					"172.25.0.1:38181",
+					"172.26.0.1:38181",
+					"172.27.0.1:38181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:26:02.386361251Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3027636418233653,
+				"StableID":   "nE5HdjsDeQ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:57cc21672c69b7a5b2af5b17ac0dd70d4d3c104ba149a207c4818f4c0edf331f",
+				"DiscoKey":   "discokey:4d1307114289a331544162ec0264cfb4f2469406c7dfaee44c0e6c744ce4b156",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57818",
+					"10.65.0.27:57818",
+					"172.17.0.1:57818",
+					"172.18.0.1:57818",
+					"172.19.0.1:57818",
+					"172.20.0.1:57818",
+					"172.21.0.1:57818",
+					"172.22.0.1:57818",
+					"172.23.0.1:57818",
+					"172.24.0.1:57818",
+					"172.25.0.1:57818",
+					"172.26.0.1:57818",
+					"172.27.0.1:57818"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:26:02.90258067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5988788433583050,
+				"StableID":   "nDUXEPKLmo11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d03a57906aa1dcff0d05193c0435a9eb9d64922dad7b8feb5dfbaaef357a497a",
+				"DiscoKey":   "discokey:6276f751d145f796fb617ea1cfdf067350d436709901b15750b0bbb8f80c2a59",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35096",
+					"10.65.0.27:35096",
+					"172.17.0.1:35096",
+					"172.18.0.1:35096",
+					"172.19.0.1:35096",
+					"172.20.0.1:35096",
+					"172.21.0.1:35096",
+					"172.22.0.1:35096",
+					"172.23.0.1:35096",
+					"172.24.0.1:35096",
+					"172.25.0.1:35096",
+					"172.26.0.1:35096",
+					"172.27.0.1:35096"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:26:03.441102354Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3391484253904715,
+				"StableID":   "n2rfvLY1VT11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:2140010fd9cc6364dfa817bba059f6d3b83dacbf862ec711267a0f9fc95dba29",
+				"KeyExpiry":  "2026-11-09T09:26:03Z",
+				"DiscoKey":   "discokey:7541ee0f3d8a5a48a8370943d56f58d226ac09650ecfc16378e29d7b9218ab0f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47234",
+					"10.65.0.27:47234",
+					"172.17.0.1:47234",
+					"172.18.0.1:47234",
+					"172.19.0.1:47234",
+					"172.20.0.1:47234",
+					"172.21.0.1:47234",
+					"172.22.0.1:47234",
+					"172.23.0.1:47234",
+					"172.24.0.1:47234",
+					"172.25.0.1:47234",
+					"172.26.0.1:47234",
+					"172.27.0.1:47234"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:26:03.97812334Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8822860486792403,
+				"StableID":   "nS2bksattB21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:728287e19d4cf728efeb2fa5b1e13c83f59d0face81ca1f7451e3c63e855c500",
+				"KeyExpiry":  "2026-11-09T09:26:04Z",
+				"DiscoKey":   "discokey:86995fce0a1e74e4ccfd4994883888bdd16cf0f5dff4d77371e879dc7739b40e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48280",
+					"10.65.0.27:48280",
+					"172.17.0.1:48280",
+					"172.18.0.1:48280",
+					"172.19.0.1:48280",
+					"172.20.0.1:48280",
+					"172.21.0.1:48280",
+					"172.22.0.1:48280",
+					"172.23.0.1:48280",
+					"172.24.0.1:48280",
+					"172.25.0.1:48280",
+					"172.26.0.1:48280",
+					"172.27.0.1:48280"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:26:04.52785528Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4012558335314868,
+				"StableID":   "nT2Rjz6JLY11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e4cb2902e1b8f1d2a56ce7d6cb2ddcaa2e0456dd44e034e41e010f058a849054",
+				"KeyExpiry":  "2026-11-09T09:26:05Z",
+				"DiscoKey":   "discokey:3cdbe56232a3c233d2ffbe22d84cbe0916646cce682d5b8ee703e1bb314fa078",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:40522",
+					"10.65.0.27:40522",
+					"172.17.0.1:40522",
+					"172.18.0.1:40522",
+					"172.19.0.1:40522",
+					"172.20.0.1:40522",
+					"172.21.0.1:40522",
+					"172.22.0.1:40522",
+					"172.23.0.1:40522",
+					"172.24.0.1:40522",
+					"172.25.0.1:40522",
+					"172.26.0.1:40522",
+					"172.27.0.1:40522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:26:05.324315528Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1754521776149444": {
+				"ID":          1754521776149444,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8343158374485682,
+				"StableID":   "ndrUk8dd9821CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       8343158374485682,
+				"Key":        "nodekey:41ae8133c03d911c119ed6427c57aa9fcbba2adb85e87163d8111c4e5161e777",
+				"DiscoKey":   "discokey:d3a70a3ff5144854a72d56fff7286ea9a81736378d5c2eac81eef0b6f329ef1b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49601",
+					"10.65.0.27:49601",
+					"172.17.0.1:49601",
+					"172.18.0.1:49601",
+					"172.19.0.1:49601",
+					"172.20.0.1:49601",
+					"172.21.0.1:49601",
+					"172.22.0.1:49601",
+					"172.23.0.1:49601",
+					"172.24.0.1:49601",
+					"172.25.0.1:49601",
+					"172.26.0.1:49601",
+					"172.27.0.1:49601"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:25:57.623851595Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:41ae8133c03d911c119ed6427c57aa9fcbba2adb85e87163d8111c4e5161e777",
+			"MachineKey": "mkey:2ad46dfa4d7064a4bd2bd3e9ccc29501c5145ac62c7c18cf371b1051764e8925",
+			"Peers": [{
+				"ID":         1754521776149444,
+				"StableID":   "nVVHH6KdhE11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89d04b3ec1cd953acfced2752023c96f358c21e6117595e9a9a9193468f8ea40",
+				"DiscoKey":   "discokey:6330fc9c2de6eeb836b51a009212d34d93735f8cacde169d5126d1827a105014",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54805",
+					"10.65.0.27:54805",
+					"172.17.0.1:54805",
+					"172.18.0.1:54805",
+					"172.19.0.1:54805",
+					"172.20.0.1:54805",
+					"172.21.0.1:54805",
+					"172.22.0.1:54805",
+					"172.23.0.1:54805",
+					"172.24.0.1:54805",
+					"172.25.0.1:54805",
+					"172.26.0.1:54805",
+					"172.27.0.1:54805"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:25:58.168865723Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5991564693681578,
+				"StableID":   "n7KDqBFbno11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ccd4e67a2cc70de546e3cd7fe6b30ea45e5ed9900de9b80d893d63d685f44a05",
+				"DiscoKey":   "discokey:25b6576979922c201647204426ff0e3cf2dfe09aa9c47690d712cd588f5e2062",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60155",
+					"10.65.0.27:60155",
+					"172.17.0.1:60155",
+					"172.18.0.1:60155",
+					"172.19.0.1:60155",
+					"172.20.0.1:60155",
+					"172.21.0.1:60155",
+					"172.22.0.1:60155",
+					"172.23.0.1:60155",
+					"172.24.0.1:60155",
+					"172.25.0.1:60155",
+					"172.26.0.1:60155",
+					"172.27.0.1:60155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:25:58.693234704Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2467040710852722,
+				"StableID":   "nXsmdcyKGL11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6dd39de776307c6ec64b0ddd8ecae095d339c62f436ef04ecb4e31d07dcffc13",
+				"DiscoKey":   "discokey:b90b6767cbba1ab4d3580a3576b354813d757de6812cbb7a094e811c9c002c3f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50824",
+					"10.65.0.27:50824",
+					"172.17.0.1:50824",
+					"172.18.0.1:50824",
+					"172.19.0.1:50824",
+					"172.20.0.1:50824",
+					"172.21.0.1:50824",
+					"172.22.0.1:50824",
+					"172.23.0.1:50824",
+					"172.24.0.1:50824",
+					"172.25.0.1:50824",
+					"172.26.0.1:50824",
+					"172.27.0.1:50824"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:25:59.212390098Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7791884088342646,
+				"StableID":   "nyELqmaxq321CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51972f61ed25c9c9b251d581a32faccf2c919c8ecd47e01b6c7d0b5645002d4b",
+				"DiscoKey":   "discokey:1db365b71d0c552f0e10d299e592bd6209faa3f034b3c7a23847858e5708b61a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42275",
+					"10.65.0.27:42275",
+					"172.17.0.1:42275",
+					"172.18.0.1:42275",
+					"172.19.0.1:42275",
+					"172.20.0.1:42275",
+					"172.21.0.1:42275",
+					"172.22.0.1:42275",
+					"172.23.0.1:42275",
+					"172.24.0.1:42275",
+					"172.25.0.1:42275",
+					"172.26.0.1:42275",
+					"172.27.0.1:42275"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:25:59.746462998Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6389966061376616,
+				"StableID":   "nRq7SEa2ur11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2a8c6a87d0b42f0ce0fd039261c721d78966aa3c47321dd82ed5ab588a55ba55",
+				"DiscoKey":   "discokey:a5f67056c66182b1ece69b43998cdeb29cf4839ce15a7ea113b8ab322c2e4924",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54787",
+					"10.65.0.27:54787",
+					"172.17.0.1:54787",
+					"172.18.0.1:54787",
+					"172.19.0.1:54787",
+					"172.20.0.1:54787",
+					"172.21.0.1:54787",
+					"172.22.0.1:54787",
+					"172.23.0.1:54787",
+					"172.24.0.1:54787",
+					"172.25.0.1:54787",
+					"172.26.0.1:54787",
+					"172.27.0.1:54787"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:26:00.274096536Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1055306989129197,
+				"StableID":   "nSjDuF8xE911CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3593bf7bbeeeec26dc7ee462cea1a75809c7ae458f6ec35c05d63e2e9bca1877",
+				"DiscoKey":   "discokey:63de9e2f1c401c0046477ea78ec96e4a6fee5686a14957ca476453d50b648d65",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58374",
+					"10.65.0.27:58374",
+					"172.17.0.1:58374",
+					"172.18.0.1:58374",
+					"172.19.0.1:58374",
+					"172.20.0.1:58374",
+					"172.21.0.1:58374",
+					"172.22.0.1:58374",
+					"172.23.0.1:58374",
+					"172.24.0.1:58374",
+					"172.25.0.1:58374",
+					"172.26.0.1:58374",
+					"172.27.0.1:58374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:26:00.872732453Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3737616221991531,
+				"StableID":   "nzNyfjqmBW11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e9a602a93d0357af740fc7e394645f4e174709cd2026835debd5bff455779369",
+				"DiscoKey":   "discokey:94c064a50634869029fc6e962946859bf642c8d4747f2f505d81635d3351612e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:44914",
+					"10.65.0.27:44914",
+					"172.17.0.1:44914",
+					"172.18.0.1:44914",
+					"172.19.0.1:44914",
+					"172.20.0.1:44914",
+					"172.21.0.1:44914",
+					"172.22.0.1:44914",
+					"172.23.0.1:44914",
+					"172.24.0.1:44914",
+					"172.25.0.1:44914",
+					"172.26.0.1:44914",
+					"172.27.0.1:44914"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:26:01.325879553Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5059147728361694,
+				"StableID":   "nMx2XTEJWg11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:011542c0cfbeb754e87234b0e6040cfbc21db3d227952120fd87272c72c9bd4a",
+				"DiscoKey":   "discokey:83d245de9eba2b009641cabdbf824d745958ab96fde3e94fae1e408bf5a00d7c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35319",
+					"10.65.0.27:35319",
+					"172.17.0.1:35319",
+					"172.18.0.1:35319",
+					"172.19.0.1:35319",
+					"172.20.0.1:35319",
+					"172.21.0.1:35319",
+					"172.22.0.1:35319",
+					"172.23.0.1:35319",
+					"172.24.0.1:35319",
+					"172.25.0.1:35319",
+					"172.26.0.1:35319",
+					"172.27.0.1:35319"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:26:01.860130237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6314986434931921,
+				"StableID":   "nUnnb9z4Kr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:884ac400784500c4ac7062eb5dfc130a336d9131ea1670647a26c6c735eeba1d",
+				"DiscoKey":   "discokey:74b3c7a3c909080c0803aefae71022600746afe32320a7a00aea188f2b8d5051",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38181",
+					"10.65.0.27:38181",
+					"172.17.0.1:38181",
+					"172.18.0.1:38181",
+					"172.19.0.1:38181",
+					"172.20.0.1:38181",
+					"172.21.0.1:38181",
+					"172.22.0.1:38181",
+					"172.23.0.1:38181",
+					"172.24.0.1:38181",
+					"172.25.0.1:38181",
+					"172.26.0.1:38181",
+					"172.27.0.1:38181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:26:02.386361251Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3027636418233653,
+				"StableID":   "nE5HdjsDeQ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:57cc21672c69b7a5b2af5b17ac0dd70d4d3c104ba149a207c4818f4c0edf331f",
+				"DiscoKey":   "discokey:4d1307114289a331544162ec0264cfb4f2469406c7dfaee44c0e6c744ce4b156",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57818",
+					"10.65.0.27:57818",
+					"172.17.0.1:57818",
+					"172.18.0.1:57818",
+					"172.19.0.1:57818",
+					"172.20.0.1:57818",
+					"172.21.0.1:57818",
+					"172.22.0.1:57818",
+					"172.23.0.1:57818",
+					"172.24.0.1:57818",
+					"172.25.0.1:57818",
+					"172.26.0.1:57818",
+					"172.27.0.1:57818"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:26:02.90258067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5988788433583050,
+				"StableID":   "nDUXEPKLmo11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d03a57906aa1dcff0d05193c0435a9eb9d64922dad7b8feb5dfbaaef357a497a",
+				"DiscoKey":   "discokey:6276f751d145f796fb617ea1cfdf067350d436709901b15750b0bbb8f80c2a59",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35096",
+					"10.65.0.27:35096",
+					"172.17.0.1:35096",
+					"172.18.0.1:35096",
+					"172.19.0.1:35096",
+					"172.20.0.1:35096",
+					"172.21.0.1:35096",
+					"172.22.0.1:35096",
+					"172.23.0.1:35096",
+					"172.24.0.1:35096",
+					"172.25.0.1:35096",
+					"172.26.0.1:35096",
+					"172.27.0.1:35096"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:26:03.441102354Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3391484253904715,
+				"StableID":   "n2rfvLY1VT11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:2140010fd9cc6364dfa817bba059f6d3b83dacbf862ec711267a0f9fc95dba29",
+				"KeyExpiry":  "2026-11-09T09:26:03Z",
+				"DiscoKey":   "discokey:7541ee0f3d8a5a48a8370943d56f58d226ac09650ecfc16378e29d7b9218ab0f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47234",
+					"10.65.0.27:47234",
+					"172.17.0.1:47234",
+					"172.18.0.1:47234",
+					"172.19.0.1:47234",
+					"172.20.0.1:47234",
+					"172.21.0.1:47234",
+					"172.22.0.1:47234",
+					"172.23.0.1:47234",
+					"172.24.0.1:47234",
+					"172.25.0.1:47234",
+					"172.26.0.1:47234",
+					"172.27.0.1:47234"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:26:03.97812334Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8822860486792403,
+				"StableID":   "nS2bksattB21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:728287e19d4cf728efeb2fa5b1e13c83f59d0face81ca1f7451e3c63e855c500",
+				"KeyExpiry":  "2026-11-09T09:26:04Z",
+				"DiscoKey":   "discokey:86995fce0a1e74e4ccfd4994883888bdd16cf0f5dff4d77371e879dc7739b40e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48280",
+					"10.65.0.27:48280",
+					"172.17.0.1:48280",
+					"172.18.0.1:48280",
+					"172.19.0.1:48280",
+					"172.20.0.1:48280",
+					"172.21.0.1:48280",
+					"172.22.0.1:48280",
+					"172.23.0.1:48280",
+					"172.24.0.1:48280",
+					"172.25.0.1:48280",
+					"172.26.0.1:48280",
+					"172.27.0.1:48280"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:26:04.52785528Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4012558335314868,
+				"StableID":   "nT2Rjz6JLY11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e4cb2902e1b8f1d2a56ce7d6cb2ddcaa2e0456dd44e034e41e010f058a849054",
+				"KeyExpiry":  "2026-11-09T09:26:05Z",
+				"DiscoKey":   "discokey:3cdbe56232a3c233d2ffbe22d84cbe0916646cce682d5b8ee703e1bb314fa078",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:40522",
+					"10.65.0.27:40522",
+					"172.17.0.1:40522",
+					"172.18.0.1:40522",
+					"172.19.0.1:40522",
+					"172.20.0.1:40522",
+					"172.21.0.1:40522",
+					"172.22.0.1:40522",
+					"172.23.0.1:40522",
+					"172.24.0.1:40522",
+					"172.25.0.1:40522",
+					"172.26.0.1:40522",
+					"172.27.0.1:40522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:26:05.324315528Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8343158374485682": {
+				"ID":          8343158374485682,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7791884088342646,
+				"StableID":   "nyELqmaxq321CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       7791884088342646,
+				"Key":        "nodekey:51972f61ed25c9c9b251d581a32faccf2c919c8ecd47e01b6c7d0b5645002d4b",
+				"DiscoKey":   "discokey:1db365b71d0c552f0e10d299e592bd6209faa3f034b3c7a23847858e5708b61a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42275",
+					"10.65.0.27:42275",
+					"172.17.0.1:42275",
+					"172.18.0.1:42275",
+					"172.19.0.1:42275",
+					"172.20.0.1:42275",
+					"172.21.0.1:42275",
+					"172.22.0.1:42275",
+					"172.23.0.1:42275",
+					"172.24.0.1:42275",
+					"172.25.0.1:42275",
+					"172.26.0.1:42275",
+					"172.27.0.1:42275"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:25:59.746462998Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:51972f61ed25c9c9b251d581a32faccf2c919c8ecd47e01b6c7d0b5645002d4b",
+			"MachineKey": "mkey:755565e189ab0a65ca185ddf279f6a74d1d12fc8743dcf8d411d9dffe729ec02",
+			"Peers": [{
+				"ID":         8343158374485682,
+				"StableID":   "ndrUk8dd9821CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41ae8133c03d911c119ed6427c57aa9fcbba2adb85e87163d8111c4e5161e777",
+				"DiscoKey":   "discokey:d3a70a3ff5144854a72d56fff7286ea9a81736378d5c2eac81eef0b6f329ef1b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49601",
+					"10.65.0.27:49601",
+					"172.17.0.1:49601",
+					"172.18.0.1:49601",
+					"172.19.0.1:49601",
+					"172.20.0.1:49601",
+					"172.21.0.1:49601",
+					"172.22.0.1:49601",
+					"172.23.0.1:49601",
+					"172.24.0.1:49601",
+					"172.25.0.1:49601",
+					"172.26.0.1:49601",
+					"172.27.0.1:49601"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:25:57.623851595Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1754521776149444,
+				"StableID":   "nVVHH6KdhE11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89d04b3ec1cd953acfced2752023c96f358c21e6117595e9a9a9193468f8ea40",
+				"DiscoKey":   "discokey:6330fc9c2de6eeb836b51a009212d34d93735f8cacde169d5126d1827a105014",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54805",
+					"10.65.0.27:54805",
+					"172.17.0.1:54805",
+					"172.18.0.1:54805",
+					"172.19.0.1:54805",
+					"172.20.0.1:54805",
+					"172.21.0.1:54805",
+					"172.22.0.1:54805",
+					"172.23.0.1:54805",
+					"172.24.0.1:54805",
+					"172.25.0.1:54805",
+					"172.26.0.1:54805",
+					"172.27.0.1:54805"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:25:58.168865723Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5991564693681578,
+				"StableID":   "n7KDqBFbno11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ccd4e67a2cc70de546e3cd7fe6b30ea45e5ed9900de9b80d893d63d685f44a05",
+				"DiscoKey":   "discokey:25b6576979922c201647204426ff0e3cf2dfe09aa9c47690d712cd588f5e2062",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60155",
+					"10.65.0.27:60155",
+					"172.17.0.1:60155",
+					"172.18.0.1:60155",
+					"172.19.0.1:60155",
+					"172.20.0.1:60155",
+					"172.21.0.1:60155",
+					"172.22.0.1:60155",
+					"172.23.0.1:60155",
+					"172.24.0.1:60155",
+					"172.25.0.1:60155",
+					"172.26.0.1:60155",
+					"172.27.0.1:60155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:25:58.693234704Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2467040710852722,
+				"StableID":   "nXsmdcyKGL11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6dd39de776307c6ec64b0ddd8ecae095d339c62f436ef04ecb4e31d07dcffc13",
+				"DiscoKey":   "discokey:b90b6767cbba1ab4d3580a3576b354813d757de6812cbb7a094e811c9c002c3f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50824",
+					"10.65.0.27:50824",
+					"172.17.0.1:50824",
+					"172.18.0.1:50824",
+					"172.19.0.1:50824",
+					"172.20.0.1:50824",
+					"172.21.0.1:50824",
+					"172.22.0.1:50824",
+					"172.23.0.1:50824",
+					"172.24.0.1:50824",
+					"172.25.0.1:50824",
+					"172.26.0.1:50824",
+					"172.27.0.1:50824"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:25:59.212390098Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6389966061376616,
+				"StableID":   "nRq7SEa2ur11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2a8c6a87d0b42f0ce0fd039261c721d78966aa3c47321dd82ed5ab588a55ba55",
+				"DiscoKey":   "discokey:a5f67056c66182b1ece69b43998cdeb29cf4839ce15a7ea113b8ab322c2e4924",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54787",
+					"10.65.0.27:54787",
+					"172.17.0.1:54787",
+					"172.18.0.1:54787",
+					"172.19.0.1:54787",
+					"172.20.0.1:54787",
+					"172.21.0.1:54787",
+					"172.22.0.1:54787",
+					"172.23.0.1:54787",
+					"172.24.0.1:54787",
+					"172.25.0.1:54787",
+					"172.26.0.1:54787",
+					"172.27.0.1:54787"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:26:00.274096536Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1055306989129197,
+				"StableID":   "nSjDuF8xE911CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3593bf7bbeeeec26dc7ee462cea1a75809c7ae458f6ec35c05d63e2e9bca1877",
+				"DiscoKey":   "discokey:63de9e2f1c401c0046477ea78ec96e4a6fee5686a14957ca476453d50b648d65",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58374",
+					"10.65.0.27:58374",
+					"172.17.0.1:58374",
+					"172.18.0.1:58374",
+					"172.19.0.1:58374",
+					"172.20.0.1:58374",
+					"172.21.0.1:58374",
+					"172.22.0.1:58374",
+					"172.23.0.1:58374",
+					"172.24.0.1:58374",
+					"172.25.0.1:58374",
+					"172.26.0.1:58374",
+					"172.27.0.1:58374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:26:00.872732453Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3737616221991531,
+				"StableID":   "nzNyfjqmBW11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e9a602a93d0357af740fc7e394645f4e174709cd2026835debd5bff455779369",
+				"DiscoKey":   "discokey:94c064a50634869029fc6e962946859bf642c8d4747f2f505d81635d3351612e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:44914",
+					"10.65.0.27:44914",
+					"172.17.0.1:44914",
+					"172.18.0.1:44914",
+					"172.19.0.1:44914",
+					"172.20.0.1:44914",
+					"172.21.0.1:44914",
+					"172.22.0.1:44914",
+					"172.23.0.1:44914",
+					"172.24.0.1:44914",
+					"172.25.0.1:44914",
+					"172.26.0.1:44914",
+					"172.27.0.1:44914"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:26:01.325879553Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5059147728361694,
+				"StableID":   "nMx2XTEJWg11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:011542c0cfbeb754e87234b0e6040cfbc21db3d227952120fd87272c72c9bd4a",
+				"DiscoKey":   "discokey:83d245de9eba2b009641cabdbf824d745958ab96fde3e94fae1e408bf5a00d7c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35319",
+					"10.65.0.27:35319",
+					"172.17.0.1:35319",
+					"172.18.0.1:35319",
+					"172.19.0.1:35319",
+					"172.20.0.1:35319",
+					"172.21.0.1:35319",
+					"172.22.0.1:35319",
+					"172.23.0.1:35319",
+					"172.24.0.1:35319",
+					"172.25.0.1:35319",
+					"172.26.0.1:35319",
+					"172.27.0.1:35319"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:26:01.860130237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6314986434931921,
+				"StableID":   "nUnnb9z4Kr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:884ac400784500c4ac7062eb5dfc130a336d9131ea1670647a26c6c735eeba1d",
+				"DiscoKey":   "discokey:74b3c7a3c909080c0803aefae71022600746afe32320a7a00aea188f2b8d5051",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38181",
+					"10.65.0.27:38181",
+					"172.17.0.1:38181",
+					"172.18.0.1:38181",
+					"172.19.0.1:38181",
+					"172.20.0.1:38181",
+					"172.21.0.1:38181",
+					"172.22.0.1:38181",
+					"172.23.0.1:38181",
+					"172.24.0.1:38181",
+					"172.25.0.1:38181",
+					"172.26.0.1:38181",
+					"172.27.0.1:38181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:26:02.386361251Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3027636418233653,
+				"StableID":   "nE5HdjsDeQ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:57cc21672c69b7a5b2af5b17ac0dd70d4d3c104ba149a207c4818f4c0edf331f",
+				"DiscoKey":   "discokey:4d1307114289a331544162ec0264cfb4f2469406c7dfaee44c0e6c744ce4b156",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57818",
+					"10.65.0.27:57818",
+					"172.17.0.1:57818",
+					"172.18.0.1:57818",
+					"172.19.0.1:57818",
+					"172.20.0.1:57818",
+					"172.21.0.1:57818",
+					"172.22.0.1:57818",
+					"172.23.0.1:57818",
+					"172.24.0.1:57818",
+					"172.25.0.1:57818",
+					"172.26.0.1:57818",
+					"172.27.0.1:57818"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:26:02.90258067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5988788433583050,
+				"StableID":   "nDUXEPKLmo11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d03a57906aa1dcff0d05193c0435a9eb9d64922dad7b8feb5dfbaaef357a497a",
+				"DiscoKey":   "discokey:6276f751d145f796fb617ea1cfdf067350d436709901b15750b0bbb8f80c2a59",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35096",
+					"10.65.0.27:35096",
+					"172.17.0.1:35096",
+					"172.18.0.1:35096",
+					"172.19.0.1:35096",
+					"172.20.0.1:35096",
+					"172.21.0.1:35096",
+					"172.22.0.1:35096",
+					"172.23.0.1:35096",
+					"172.24.0.1:35096",
+					"172.25.0.1:35096",
+					"172.26.0.1:35096",
+					"172.27.0.1:35096"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:26:03.441102354Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3391484253904715,
+				"StableID":   "n2rfvLY1VT11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:2140010fd9cc6364dfa817bba059f6d3b83dacbf862ec711267a0f9fc95dba29",
+				"KeyExpiry":  "2026-11-09T09:26:03Z",
+				"DiscoKey":   "discokey:7541ee0f3d8a5a48a8370943d56f58d226ac09650ecfc16378e29d7b9218ab0f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47234",
+					"10.65.0.27:47234",
+					"172.17.0.1:47234",
+					"172.18.0.1:47234",
+					"172.19.0.1:47234",
+					"172.20.0.1:47234",
+					"172.21.0.1:47234",
+					"172.22.0.1:47234",
+					"172.23.0.1:47234",
+					"172.24.0.1:47234",
+					"172.25.0.1:47234",
+					"172.26.0.1:47234",
+					"172.27.0.1:47234"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:26:03.97812334Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8822860486792403,
+				"StableID":   "nS2bksattB21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:728287e19d4cf728efeb2fa5b1e13c83f59d0face81ca1f7451e3c63e855c500",
+				"KeyExpiry":  "2026-11-09T09:26:04Z",
+				"DiscoKey":   "discokey:86995fce0a1e74e4ccfd4994883888bdd16cf0f5dff4d77371e879dc7739b40e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48280",
+					"10.65.0.27:48280",
+					"172.17.0.1:48280",
+					"172.18.0.1:48280",
+					"172.19.0.1:48280",
+					"172.20.0.1:48280",
+					"172.21.0.1:48280",
+					"172.22.0.1:48280",
+					"172.23.0.1:48280",
+					"172.24.0.1:48280",
+					"172.25.0.1:48280",
+					"172.26.0.1:48280",
+					"172.27.0.1:48280"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:26:04.52785528Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4012558335314868,
+				"StableID":   "nT2Rjz6JLY11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e4cb2902e1b8f1d2a56ce7d6cb2ddcaa2e0456dd44e034e41e010f058a849054",
+				"KeyExpiry":  "2026-11-09T09:26:05Z",
+				"DiscoKey":   "discokey:3cdbe56232a3c233d2ffbe22d84cbe0916646cce682d5b8ee703e1bb314fa078",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:40522",
+					"10.65.0.27:40522",
+					"172.17.0.1:40522",
+					"172.18.0.1:40522",
+					"172.19.0.1:40522",
+					"172.20.0.1:40522",
+					"172.21.0.1:40522",
+					"172.22.0.1:40522",
+					"172.23.0.1:40522",
+					"172.24.0.1:40522",
+					"172.25.0.1:40522",
+					"172.26.0.1:40522",
+					"172.27.0.1:40522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:26:05.324315528Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7791884088342646": {
+				"ID":          7791884088342646,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2467040710852722,
+				"StableID":   "nXsmdcyKGL11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       2467040710852722,
+				"Key":        "nodekey:6dd39de776307c6ec64b0ddd8ecae095d339c62f436ef04ecb4e31d07dcffc13",
+				"DiscoKey":   "discokey:b90b6767cbba1ab4d3580a3576b354813d757de6812cbb7a094e811c9c002c3f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50824",
+					"10.65.0.27:50824",
+					"172.17.0.1:50824",
+					"172.18.0.1:50824",
+					"172.19.0.1:50824",
+					"172.20.0.1:50824",
+					"172.21.0.1:50824",
+					"172.22.0.1:50824",
+					"172.23.0.1:50824",
+					"172.24.0.1:50824",
+					"172.25.0.1:50824",
+					"172.26.0.1:50824",
+					"172.27.0.1:50824"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:25:59.212390098Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6dd39de776307c6ec64b0ddd8ecae095d339c62f436ef04ecb4e31d07dcffc13",
+			"MachineKey": "mkey:4b9c8185ada1c9ceb51152737374200945c8dc758a488f13fe3a713311ec3676",
+			"Peers": [{
+				"ID":         8343158374485682,
+				"StableID":   "ndrUk8dd9821CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41ae8133c03d911c119ed6427c57aa9fcbba2adb85e87163d8111c4e5161e777",
+				"DiscoKey":   "discokey:d3a70a3ff5144854a72d56fff7286ea9a81736378d5c2eac81eef0b6f329ef1b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49601",
+					"10.65.0.27:49601",
+					"172.17.0.1:49601",
+					"172.18.0.1:49601",
+					"172.19.0.1:49601",
+					"172.20.0.1:49601",
+					"172.21.0.1:49601",
+					"172.22.0.1:49601",
+					"172.23.0.1:49601",
+					"172.24.0.1:49601",
+					"172.25.0.1:49601",
+					"172.26.0.1:49601",
+					"172.27.0.1:49601"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:25:57.623851595Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1754521776149444,
+				"StableID":   "nVVHH6KdhE11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89d04b3ec1cd953acfced2752023c96f358c21e6117595e9a9a9193468f8ea40",
+				"DiscoKey":   "discokey:6330fc9c2de6eeb836b51a009212d34d93735f8cacde169d5126d1827a105014",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54805",
+					"10.65.0.27:54805",
+					"172.17.0.1:54805",
+					"172.18.0.1:54805",
+					"172.19.0.1:54805",
+					"172.20.0.1:54805",
+					"172.21.0.1:54805",
+					"172.22.0.1:54805",
+					"172.23.0.1:54805",
+					"172.24.0.1:54805",
+					"172.25.0.1:54805",
+					"172.26.0.1:54805",
+					"172.27.0.1:54805"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:25:58.168865723Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5991564693681578,
+				"StableID":   "n7KDqBFbno11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ccd4e67a2cc70de546e3cd7fe6b30ea45e5ed9900de9b80d893d63d685f44a05",
+				"DiscoKey":   "discokey:25b6576979922c201647204426ff0e3cf2dfe09aa9c47690d712cd588f5e2062",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60155",
+					"10.65.0.27:60155",
+					"172.17.0.1:60155",
+					"172.18.0.1:60155",
+					"172.19.0.1:60155",
+					"172.20.0.1:60155",
+					"172.21.0.1:60155",
+					"172.22.0.1:60155",
+					"172.23.0.1:60155",
+					"172.24.0.1:60155",
+					"172.25.0.1:60155",
+					"172.26.0.1:60155",
+					"172.27.0.1:60155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:25:58.693234704Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7791884088342646,
+				"StableID":   "nyELqmaxq321CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51972f61ed25c9c9b251d581a32faccf2c919c8ecd47e01b6c7d0b5645002d4b",
+				"DiscoKey":   "discokey:1db365b71d0c552f0e10d299e592bd6209faa3f034b3c7a23847858e5708b61a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42275",
+					"10.65.0.27:42275",
+					"172.17.0.1:42275",
+					"172.18.0.1:42275",
+					"172.19.0.1:42275",
+					"172.20.0.1:42275",
+					"172.21.0.1:42275",
+					"172.22.0.1:42275",
+					"172.23.0.1:42275",
+					"172.24.0.1:42275",
+					"172.25.0.1:42275",
+					"172.26.0.1:42275",
+					"172.27.0.1:42275"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:25:59.746462998Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6389966061376616,
+				"StableID":   "nRq7SEa2ur11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2a8c6a87d0b42f0ce0fd039261c721d78966aa3c47321dd82ed5ab588a55ba55",
+				"DiscoKey":   "discokey:a5f67056c66182b1ece69b43998cdeb29cf4839ce15a7ea113b8ab322c2e4924",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54787",
+					"10.65.0.27:54787",
+					"172.17.0.1:54787",
+					"172.18.0.1:54787",
+					"172.19.0.1:54787",
+					"172.20.0.1:54787",
+					"172.21.0.1:54787",
+					"172.22.0.1:54787",
+					"172.23.0.1:54787",
+					"172.24.0.1:54787",
+					"172.25.0.1:54787",
+					"172.26.0.1:54787",
+					"172.27.0.1:54787"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:26:00.274096536Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1055306989129197,
+				"StableID":   "nSjDuF8xE911CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3593bf7bbeeeec26dc7ee462cea1a75809c7ae458f6ec35c05d63e2e9bca1877",
+				"DiscoKey":   "discokey:63de9e2f1c401c0046477ea78ec96e4a6fee5686a14957ca476453d50b648d65",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58374",
+					"10.65.0.27:58374",
+					"172.17.0.1:58374",
+					"172.18.0.1:58374",
+					"172.19.0.1:58374",
+					"172.20.0.1:58374",
+					"172.21.0.1:58374",
+					"172.22.0.1:58374",
+					"172.23.0.1:58374",
+					"172.24.0.1:58374",
+					"172.25.0.1:58374",
+					"172.26.0.1:58374",
+					"172.27.0.1:58374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:26:00.872732453Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3737616221991531,
+				"StableID":   "nzNyfjqmBW11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e9a602a93d0357af740fc7e394645f4e174709cd2026835debd5bff455779369",
+				"DiscoKey":   "discokey:94c064a50634869029fc6e962946859bf642c8d4747f2f505d81635d3351612e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:44914",
+					"10.65.0.27:44914",
+					"172.17.0.1:44914",
+					"172.18.0.1:44914",
+					"172.19.0.1:44914",
+					"172.20.0.1:44914",
+					"172.21.0.1:44914",
+					"172.22.0.1:44914",
+					"172.23.0.1:44914",
+					"172.24.0.1:44914",
+					"172.25.0.1:44914",
+					"172.26.0.1:44914",
+					"172.27.0.1:44914"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:26:01.325879553Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5059147728361694,
+				"StableID":   "nMx2XTEJWg11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:011542c0cfbeb754e87234b0e6040cfbc21db3d227952120fd87272c72c9bd4a",
+				"DiscoKey":   "discokey:83d245de9eba2b009641cabdbf824d745958ab96fde3e94fae1e408bf5a00d7c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35319",
+					"10.65.0.27:35319",
+					"172.17.0.1:35319",
+					"172.18.0.1:35319",
+					"172.19.0.1:35319",
+					"172.20.0.1:35319",
+					"172.21.0.1:35319",
+					"172.22.0.1:35319",
+					"172.23.0.1:35319",
+					"172.24.0.1:35319",
+					"172.25.0.1:35319",
+					"172.26.0.1:35319",
+					"172.27.0.1:35319"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:26:01.860130237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6314986434931921,
+				"StableID":   "nUnnb9z4Kr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:884ac400784500c4ac7062eb5dfc130a336d9131ea1670647a26c6c735eeba1d",
+				"DiscoKey":   "discokey:74b3c7a3c909080c0803aefae71022600746afe32320a7a00aea188f2b8d5051",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38181",
+					"10.65.0.27:38181",
+					"172.17.0.1:38181",
+					"172.18.0.1:38181",
+					"172.19.0.1:38181",
+					"172.20.0.1:38181",
+					"172.21.0.1:38181",
+					"172.22.0.1:38181",
+					"172.23.0.1:38181",
+					"172.24.0.1:38181",
+					"172.25.0.1:38181",
+					"172.26.0.1:38181",
+					"172.27.0.1:38181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:26:02.386361251Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3027636418233653,
+				"StableID":   "nE5HdjsDeQ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:57cc21672c69b7a5b2af5b17ac0dd70d4d3c104ba149a207c4818f4c0edf331f",
+				"DiscoKey":   "discokey:4d1307114289a331544162ec0264cfb4f2469406c7dfaee44c0e6c744ce4b156",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57818",
+					"10.65.0.27:57818",
+					"172.17.0.1:57818",
+					"172.18.0.1:57818",
+					"172.19.0.1:57818",
+					"172.20.0.1:57818",
+					"172.21.0.1:57818",
+					"172.22.0.1:57818",
+					"172.23.0.1:57818",
+					"172.24.0.1:57818",
+					"172.25.0.1:57818",
+					"172.26.0.1:57818",
+					"172.27.0.1:57818"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:26:02.90258067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5988788433583050,
+				"StableID":   "nDUXEPKLmo11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d03a57906aa1dcff0d05193c0435a9eb9d64922dad7b8feb5dfbaaef357a497a",
+				"DiscoKey":   "discokey:6276f751d145f796fb617ea1cfdf067350d436709901b15750b0bbb8f80c2a59",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35096",
+					"10.65.0.27:35096",
+					"172.17.0.1:35096",
+					"172.18.0.1:35096",
+					"172.19.0.1:35096",
+					"172.20.0.1:35096",
+					"172.21.0.1:35096",
+					"172.22.0.1:35096",
+					"172.23.0.1:35096",
+					"172.24.0.1:35096",
+					"172.25.0.1:35096",
+					"172.26.0.1:35096",
+					"172.27.0.1:35096"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:26:03.441102354Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3391484253904715,
+				"StableID":   "n2rfvLY1VT11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:2140010fd9cc6364dfa817bba059f6d3b83dacbf862ec711267a0f9fc95dba29",
+				"KeyExpiry":  "2026-11-09T09:26:03Z",
+				"DiscoKey":   "discokey:7541ee0f3d8a5a48a8370943d56f58d226ac09650ecfc16378e29d7b9218ab0f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47234",
+					"10.65.0.27:47234",
+					"172.17.0.1:47234",
+					"172.18.0.1:47234",
+					"172.19.0.1:47234",
+					"172.20.0.1:47234",
+					"172.21.0.1:47234",
+					"172.22.0.1:47234",
+					"172.23.0.1:47234",
+					"172.24.0.1:47234",
+					"172.25.0.1:47234",
+					"172.26.0.1:47234",
+					"172.27.0.1:47234"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:26:03.97812334Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8822860486792403,
+				"StableID":   "nS2bksattB21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:728287e19d4cf728efeb2fa5b1e13c83f59d0face81ca1f7451e3c63e855c500",
+				"KeyExpiry":  "2026-11-09T09:26:04Z",
+				"DiscoKey":   "discokey:86995fce0a1e74e4ccfd4994883888bdd16cf0f5dff4d77371e879dc7739b40e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48280",
+					"10.65.0.27:48280",
+					"172.17.0.1:48280",
+					"172.18.0.1:48280",
+					"172.19.0.1:48280",
+					"172.20.0.1:48280",
+					"172.21.0.1:48280",
+					"172.22.0.1:48280",
+					"172.23.0.1:48280",
+					"172.24.0.1:48280",
+					"172.25.0.1:48280",
+					"172.26.0.1:48280",
+					"172.27.0.1:48280"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:26:04.52785528Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4012558335314868,
+				"StableID":   "nT2Rjz6JLY11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e4cb2902e1b8f1d2a56ce7d6cb2ddcaa2e0456dd44e034e41e010f058a849054",
+				"KeyExpiry":  "2026-11-09T09:26:05Z",
+				"DiscoKey":   "discokey:3cdbe56232a3c233d2ffbe22d84cbe0916646cce682d5b8ee703e1bb314fa078",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:40522",
+					"10.65.0.27:40522",
+					"172.17.0.1:40522",
+					"172.18.0.1:40522",
+					"172.19.0.1:40522",
+					"172.20.0.1:40522",
+					"172.21.0.1:40522",
+					"172.22.0.1:40522",
+					"172.23.0.1:40522",
+					"172.24.0.1:40522",
+					"172.25.0.1:40522",
+					"172.26.0.1:40522",
+					"172.27.0.1:40522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:26:05.324315528Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2467040710852722": {
+				"ID":          2467040710852722,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1055306989129197,
+				"StableID":   "nSjDuF8xE911CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1055306989129197,
+				"Key":        "nodekey:3593bf7bbeeeec26dc7ee462cea1a75809c7ae458f6ec35c05d63e2e9bca1877",
+				"DiscoKey":   "discokey:63de9e2f1c401c0046477ea78ec96e4a6fee5686a14957ca476453d50b648d65",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58374",
+					"10.65.0.27:58374",
+					"172.17.0.1:58374",
+					"172.18.0.1:58374",
+					"172.19.0.1:58374",
+					"172.20.0.1:58374",
+					"172.21.0.1:58374",
+					"172.22.0.1:58374",
+					"172.23.0.1:58374",
+					"172.24.0.1:58374",
+					"172.25.0.1:58374",
+					"172.26.0.1:58374",
+					"172.27.0.1:58374"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:26:00.872732453Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3593bf7bbeeeec26dc7ee462cea1a75809c7ae458f6ec35c05d63e2e9bca1877",
+			"MachineKey": "mkey:b40e17b190b11c68c1fe40eb372f61c282bca571ed898b72b9fa1adf0a57bc4f",
+			"Peers": [{
+				"ID":         8343158374485682,
+				"StableID":   "ndrUk8dd9821CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41ae8133c03d911c119ed6427c57aa9fcbba2adb85e87163d8111c4e5161e777",
+				"DiscoKey":   "discokey:d3a70a3ff5144854a72d56fff7286ea9a81736378d5c2eac81eef0b6f329ef1b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49601",
+					"10.65.0.27:49601",
+					"172.17.0.1:49601",
+					"172.18.0.1:49601",
+					"172.19.0.1:49601",
+					"172.20.0.1:49601",
+					"172.21.0.1:49601",
+					"172.22.0.1:49601",
+					"172.23.0.1:49601",
+					"172.24.0.1:49601",
+					"172.25.0.1:49601",
+					"172.26.0.1:49601",
+					"172.27.0.1:49601"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:25:57.623851595Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1754521776149444,
+				"StableID":   "nVVHH6KdhE11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89d04b3ec1cd953acfced2752023c96f358c21e6117595e9a9a9193468f8ea40",
+				"DiscoKey":   "discokey:6330fc9c2de6eeb836b51a009212d34d93735f8cacde169d5126d1827a105014",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54805",
+					"10.65.0.27:54805",
+					"172.17.0.1:54805",
+					"172.18.0.1:54805",
+					"172.19.0.1:54805",
+					"172.20.0.1:54805",
+					"172.21.0.1:54805",
+					"172.22.0.1:54805",
+					"172.23.0.1:54805",
+					"172.24.0.1:54805",
+					"172.25.0.1:54805",
+					"172.26.0.1:54805",
+					"172.27.0.1:54805"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:25:58.168865723Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5991564693681578,
+				"StableID":   "n7KDqBFbno11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ccd4e67a2cc70de546e3cd7fe6b30ea45e5ed9900de9b80d893d63d685f44a05",
+				"DiscoKey":   "discokey:25b6576979922c201647204426ff0e3cf2dfe09aa9c47690d712cd588f5e2062",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60155",
+					"10.65.0.27:60155",
+					"172.17.0.1:60155",
+					"172.18.0.1:60155",
+					"172.19.0.1:60155",
+					"172.20.0.1:60155",
+					"172.21.0.1:60155",
+					"172.22.0.1:60155",
+					"172.23.0.1:60155",
+					"172.24.0.1:60155",
+					"172.25.0.1:60155",
+					"172.26.0.1:60155",
+					"172.27.0.1:60155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:25:58.693234704Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2467040710852722,
+				"StableID":   "nXsmdcyKGL11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6dd39de776307c6ec64b0ddd8ecae095d339c62f436ef04ecb4e31d07dcffc13",
+				"DiscoKey":   "discokey:b90b6767cbba1ab4d3580a3576b354813d757de6812cbb7a094e811c9c002c3f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50824",
+					"10.65.0.27:50824",
+					"172.17.0.1:50824",
+					"172.18.0.1:50824",
+					"172.19.0.1:50824",
+					"172.20.0.1:50824",
+					"172.21.0.1:50824",
+					"172.22.0.1:50824",
+					"172.23.0.1:50824",
+					"172.24.0.1:50824",
+					"172.25.0.1:50824",
+					"172.26.0.1:50824",
+					"172.27.0.1:50824"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:25:59.212390098Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7791884088342646,
+				"StableID":   "nyELqmaxq321CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51972f61ed25c9c9b251d581a32faccf2c919c8ecd47e01b6c7d0b5645002d4b",
+				"DiscoKey":   "discokey:1db365b71d0c552f0e10d299e592bd6209faa3f034b3c7a23847858e5708b61a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42275",
+					"10.65.0.27:42275",
+					"172.17.0.1:42275",
+					"172.18.0.1:42275",
+					"172.19.0.1:42275",
+					"172.20.0.1:42275",
+					"172.21.0.1:42275",
+					"172.22.0.1:42275",
+					"172.23.0.1:42275",
+					"172.24.0.1:42275",
+					"172.25.0.1:42275",
+					"172.26.0.1:42275",
+					"172.27.0.1:42275"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:25:59.746462998Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6389966061376616,
+				"StableID":   "nRq7SEa2ur11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2a8c6a87d0b42f0ce0fd039261c721d78966aa3c47321dd82ed5ab588a55ba55",
+				"DiscoKey":   "discokey:a5f67056c66182b1ece69b43998cdeb29cf4839ce15a7ea113b8ab322c2e4924",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54787",
+					"10.65.0.27:54787",
+					"172.17.0.1:54787",
+					"172.18.0.1:54787",
+					"172.19.0.1:54787",
+					"172.20.0.1:54787",
+					"172.21.0.1:54787",
+					"172.22.0.1:54787",
+					"172.23.0.1:54787",
+					"172.24.0.1:54787",
+					"172.25.0.1:54787",
+					"172.26.0.1:54787",
+					"172.27.0.1:54787"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:26:00.274096536Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3737616221991531,
+				"StableID":   "nzNyfjqmBW11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e9a602a93d0357af740fc7e394645f4e174709cd2026835debd5bff455779369",
+				"DiscoKey":   "discokey:94c064a50634869029fc6e962946859bf642c8d4747f2f505d81635d3351612e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:44914",
+					"10.65.0.27:44914",
+					"172.17.0.1:44914",
+					"172.18.0.1:44914",
+					"172.19.0.1:44914",
+					"172.20.0.1:44914",
+					"172.21.0.1:44914",
+					"172.22.0.1:44914",
+					"172.23.0.1:44914",
+					"172.24.0.1:44914",
+					"172.25.0.1:44914",
+					"172.26.0.1:44914",
+					"172.27.0.1:44914"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:26:01.325879553Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5059147728361694,
+				"StableID":   "nMx2XTEJWg11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:011542c0cfbeb754e87234b0e6040cfbc21db3d227952120fd87272c72c9bd4a",
+				"DiscoKey":   "discokey:83d245de9eba2b009641cabdbf824d745958ab96fde3e94fae1e408bf5a00d7c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35319",
+					"10.65.0.27:35319",
+					"172.17.0.1:35319",
+					"172.18.0.1:35319",
+					"172.19.0.1:35319",
+					"172.20.0.1:35319",
+					"172.21.0.1:35319",
+					"172.22.0.1:35319",
+					"172.23.0.1:35319",
+					"172.24.0.1:35319",
+					"172.25.0.1:35319",
+					"172.26.0.1:35319",
+					"172.27.0.1:35319"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:26:01.860130237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6314986434931921,
+				"StableID":   "nUnnb9z4Kr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:884ac400784500c4ac7062eb5dfc130a336d9131ea1670647a26c6c735eeba1d",
+				"DiscoKey":   "discokey:74b3c7a3c909080c0803aefae71022600746afe32320a7a00aea188f2b8d5051",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38181",
+					"10.65.0.27:38181",
+					"172.17.0.1:38181",
+					"172.18.0.1:38181",
+					"172.19.0.1:38181",
+					"172.20.0.1:38181",
+					"172.21.0.1:38181",
+					"172.22.0.1:38181",
+					"172.23.0.1:38181",
+					"172.24.0.1:38181",
+					"172.25.0.1:38181",
+					"172.26.0.1:38181",
+					"172.27.0.1:38181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:26:02.386361251Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3027636418233653,
+				"StableID":   "nE5HdjsDeQ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:57cc21672c69b7a5b2af5b17ac0dd70d4d3c104ba149a207c4818f4c0edf331f",
+				"DiscoKey":   "discokey:4d1307114289a331544162ec0264cfb4f2469406c7dfaee44c0e6c744ce4b156",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57818",
+					"10.65.0.27:57818",
+					"172.17.0.1:57818",
+					"172.18.0.1:57818",
+					"172.19.0.1:57818",
+					"172.20.0.1:57818",
+					"172.21.0.1:57818",
+					"172.22.0.1:57818",
+					"172.23.0.1:57818",
+					"172.24.0.1:57818",
+					"172.25.0.1:57818",
+					"172.26.0.1:57818",
+					"172.27.0.1:57818"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:26:02.90258067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5988788433583050,
+				"StableID":   "nDUXEPKLmo11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d03a57906aa1dcff0d05193c0435a9eb9d64922dad7b8feb5dfbaaef357a497a",
+				"DiscoKey":   "discokey:6276f751d145f796fb617ea1cfdf067350d436709901b15750b0bbb8f80c2a59",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35096",
+					"10.65.0.27:35096",
+					"172.17.0.1:35096",
+					"172.18.0.1:35096",
+					"172.19.0.1:35096",
+					"172.20.0.1:35096",
+					"172.21.0.1:35096",
+					"172.22.0.1:35096",
+					"172.23.0.1:35096",
+					"172.24.0.1:35096",
+					"172.25.0.1:35096",
+					"172.26.0.1:35096",
+					"172.27.0.1:35096"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:26:03.441102354Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3391484253904715,
+				"StableID":   "n2rfvLY1VT11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:2140010fd9cc6364dfa817bba059f6d3b83dacbf862ec711267a0f9fc95dba29",
+				"KeyExpiry":  "2026-11-09T09:26:03Z",
+				"DiscoKey":   "discokey:7541ee0f3d8a5a48a8370943d56f58d226ac09650ecfc16378e29d7b9218ab0f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47234",
+					"10.65.0.27:47234",
+					"172.17.0.1:47234",
+					"172.18.0.1:47234",
+					"172.19.0.1:47234",
+					"172.20.0.1:47234",
+					"172.21.0.1:47234",
+					"172.22.0.1:47234",
+					"172.23.0.1:47234",
+					"172.24.0.1:47234",
+					"172.25.0.1:47234",
+					"172.26.0.1:47234",
+					"172.27.0.1:47234"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:26:03.97812334Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8822860486792403,
+				"StableID":   "nS2bksattB21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:728287e19d4cf728efeb2fa5b1e13c83f59d0face81ca1f7451e3c63e855c500",
+				"KeyExpiry":  "2026-11-09T09:26:04Z",
+				"DiscoKey":   "discokey:86995fce0a1e74e4ccfd4994883888bdd16cf0f5dff4d77371e879dc7739b40e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48280",
+					"10.65.0.27:48280",
+					"172.17.0.1:48280",
+					"172.18.0.1:48280",
+					"172.19.0.1:48280",
+					"172.20.0.1:48280",
+					"172.21.0.1:48280",
+					"172.22.0.1:48280",
+					"172.23.0.1:48280",
+					"172.24.0.1:48280",
+					"172.25.0.1:48280",
+					"172.26.0.1:48280",
+					"172.27.0.1:48280"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:26:04.52785528Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4012558335314868,
+				"StableID":   "nT2Rjz6JLY11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e4cb2902e1b8f1d2a56ce7d6cb2ddcaa2e0456dd44e034e41e010f058a849054",
+				"KeyExpiry":  "2026-11-09T09:26:05Z",
+				"DiscoKey":   "discokey:3cdbe56232a3c233d2ffbe22d84cbe0916646cce682d5b8ee703e1bb314fa078",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:40522",
+					"10.65.0.27:40522",
+					"172.17.0.1:40522",
+					"172.18.0.1:40522",
+					"172.19.0.1:40522",
+					"172.20.0.1:40522",
+					"172.21.0.1:40522",
+					"172.22.0.1:40522",
+					"172.23.0.1:40522",
+					"172.24.0.1:40522",
+					"172.25.0.1:40522",
+					"172.26.0.1:40522",
+					"172.27.0.1:40522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:26:05.324315528Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1055306989129197": {
+				"ID":          1055306989129197,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}, "1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5059147728361694,
+				"StableID":   "nMx2XTEJWg11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       5059147728361694,
+				"Key":        "nodekey:011542c0cfbeb754e87234b0e6040cfbc21db3d227952120fd87272c72c9bd4a",
+				"DiscoKey":   "discokey:83d245de9eba2b009641cabdbf824d745958ab96fde3e94fae1e408bf5a00d7c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35319",
+					"10.65.0.27:35319",
+					"172.17.0.1:35319",
+					"172.18.0.1:35319",
+					"172.19.0.1:35319",
+					"172.20.0.1:35319",
+					"172.21.0.1:35319",
+					"172.22.0.1:35319",
+					"172.23.0.1:35319",
+					"172.24.0.1:35319",
+					"172.25.0.1:35319",
+					"172.26.0.1:35319",
+					"172.27.0.1:35319"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:26:01.860130237Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:011542c0cfbeb754e87234b0e6040cfbc21db3d227952120fd87272c72c9bd4a",
+			"MachineKey": "mkey:e4ab2b1f7cd56f84552d0710ba87c30d9e67bb34d62176492e47332c68653b25",
+			"Peers": [{
+				"ID":         8343158374485682,
+				"StableID":   "ndrUk8dd9821CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41ae8133c03d911c119ed6427c57aa9fcbba2adb85e87163d8111c4e5161e777",
+				"DiscoKey":   "discokey:d3a70a3ff5144854a72d56fff7286ea9a81736378d5c2eac81eef0b6f329ef1b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49601",
+					"10.65.0.27:49601",
+					"172.17.0.1:49601",
+					"172.18.0.1:49601",
+					"172.19.0.1:49601",
+					"172.20.0.1:49601",
+					"172.21.0.1:49601",
+					"172.22.0.1:49601",
+					"172.23.0.1:49601",
+					"172.24.0.1:49601",
+					"172.25.0.1:49601",
+					"172.26.0.1:49601",
+					"172.27.0.1:49601"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:25:57.623851595Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1754521776149444,
+				"StableID":   "nVVHH6KdhE11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89d04b3ec1cd953acfced2752023c96f358c21e6117595e9a9a9193468f8ea40",
+				"DiscoKey":   "discokey:6330fc9c2de6eeb836b51a009212d34d93735f8cacde169d5126d1827a105014",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54805",
+					"10.65.0.27:54805",
+					"172.17.0.1:54805",
+					"172.18.0.1:54805",
+					"172.19.0.1:54805",
+					"172.20.0.1:54805",
+					"172.21.0.1:54805",
+					"172.22.0.1:54805",
+					"172.23.0.1:54805",
+					"172.24.0.1:54805",
+					"172.25.0.1:54805",
+					"172.26.0.1:54805",
+					"172.27.0.1:54805"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:25:58.168865723Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5991564693681578,
+				"StableID":   "n7KDqBFbno11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ccd4e67a2cc70de546e3cd7fe6b30ea45e5ed9900de9b80d893d63d685f44a05",
+				"DiscoKey":   "discokey:25b6576979922c201647204426ff0e3cf2dfe09aa9c47690d712cd588f5e2062",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60155",
+					"10.65.0.27:60155",
+					"172.17.0.1:60155",
+					"172.18.0.1:60155",
+					"172.19.0.1:60155",
+					"172.20.0.1:60155",
+					"172.21.0.1:60155",
+					"172.22.0.1:60155",
+					"172.23.0.1:60155",
+					"172.24.0.1:60155",
+					"172.25.0.1:60155",
+					"172.26.0.1:60155",
+					"172.27.0.1:60155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:25:58.693234704Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2467040710852722,
+				"StableID":   "nXsmdcyKGL11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6dd39de776307c6ec64b0ddd8ecae095d339c62f436ef04ecb4e31d07dcffc13",
+				"DiscoKey":   "discokey:b90b6767cbba1ab4d3580a3576b354813d757de6812cbb7a094e811c9c002c3f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50824",
+					"10.65.0.27:50824",
+					"172.17.0.1:50824",
+					"172.18.0.1:50824",
+					"172.19.0.1:50824",
+					"172.20.0.1:50824",
+					"172.21.0.1:50824",
+					"172.22.0.1:50824",
+					"172.23.0.1:50824",
+					"172.24.0.1:50824",
+					"172.25.0.1:50824",
+					"172.26.0.1:50824",
+					"172.27.0.1:50824"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:25:59.212390098Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7791884088342646,
+				"StableID":   "nyELqmaxq321CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51972f61ed25c9c9b251d581a32faccf2c919c8ecd47e01b6c7d0b5645002d4b",
+				"DiscoKey":   "discokey:1db365b71d0c552f0e10d299e592bd6209faa3f034b3c7a23847858e5708b61a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42275",
+					"10.65.0.27:42275",
+					"172.17.0.1:42275",
+					"172.18.0.1:42275",
+					"172.19.0.1:42275",
+					"172.20.0.1:42275",
+					"172.21.0.1:42275",
+					"172.22.0.1:42275",
+					"172.23.0.1:42275",
+					"172.24.0.1:42275",
+					"172.25.0.1:42275",
+					"172.26.0.1:42275",
+					"172.27.0.1:42275"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:25:59.746462998Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6389966061376616,
+				"StableID":   "nRq7SEa2ur11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2a8c6a87d0b42f0ce0fd039261c721d78966aa3c47321dd82ed5ab588a55ba55",
+				"DiscoKey":   "discokey:a5f67056c66182b1ece69b43998cdeb29cf4839ce15a7ea113b8ab322c2e4924",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54787",
+					"10.65.0.27:54787",
+					"172.17.0.1:54787",
+					"172.18.0.1:54787",
+					"172.19.0.1:54787",
+					"172.20.0.1:54787",
+					"172.21.0.1:54787",
+					"172.22.0.1:54787",
+					"172.23.0.1:54787",
+					"172.24.0.1:54787",
+					"172.25.0.1:54787",
+					"172.26.0.1:54787",
+					"172.27.0.1:54787"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:26:00.274096536Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1055306989129197,
+				"StableID":   "nSjDuF8xE911CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3593bf7bbeeeec26dc7ee462cea1a75809c7ae458f6ec35c05d63e2e9bca1877",
+				"DiscoKey":   "discokey:63de9e2f1c401c0046477ea78ec96e4a6fee5686a14957ca476453d50b648d65",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58374",
+					"10.65.0.27:58374",
+					"172.17.0.1:58374",
+					"172.18.0.1:58374",
+					"172.19.0.1:58374",
+					"172.20.0.1:58374",
+					"172.21.0.1:58374",
+					"172.22.0.1:58374",
+					"172.23.0.1:58374",
+					"172.24.0.1:58374",
+					"172.25.0.1:58374",
+					"172.26.0.1:58374",
+					"172.27.0.1:58374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:26:00.872732453Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3737616221991531,
+				"StableID":   "nzNyfjqmBW11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e9a602a93d0357af740fc7e394645f4e174709cd2026835debd5bff455779369",
+				"DiscoKey":   "discokey:94c064a50634869029fc6e962946859bf642c8d4747f2f505d81635d3351612e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:44914",
+					"10.65.0.27:44914",
+					"172.17.0.1:44914",
+					"172.18.0.1:44914",
+					"172.19.0.1:44914",
+					"172.20.0.1:44914",
+					"172.21.0.1:44914",
+					"172.22.0.1:44914",
+					"172.23.0.1:44914",
+					"172.24.0.1:44914",
+					"172.25.0.1:44914",
+					"172.26.0.1:44914",
+					"172.27.0.1:44914"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:26:01.325879553Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6314986434931921,
+				"StableID":   "nUnnb9z4Kr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:884ac400784500c4ac7062eb5dfc130a336d9131ea1670647a26c6c735eeba1d",
+				"DiscoKey":   "discokey:74b3c7a3c909080c0803aefae71022600746afe32320a7a00aea188f2b8d5051",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38181",
+					"10.65.0.27:38181",
+					"172.17.0.1:38181",
+					"172.18.0.1:38181",
+					"172.19.0.1:38181",
+					"172.20.0.1:38181",
+					"172.21.0.1:38181",
+					"172.22.0.1:38181",
+					"172.23.0.1:38181",
+					"172.24.0.1:38181",
+					"172.25.0.1:38181",
+					"172.26.0.1:38181",
+					"172.27.0.1:38181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:26:02.386361251Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3027636418233653,
+				"StableID":   "nE5HdjsDeQ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:57cc21672c69b7a5b2af5b17ac0dd70d4d3c104ba149a207c4818f4c0edf331f",
+				"DiscoKey":   "discokey:4d1307114289a331544162ec0264cfb4f2469406c7dfaee44c0e6c744ce4b156",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57818",
+					"10.65.0.27:57818",
+					"172.17.0.1:57818",
+					"172.18.0.1:57818",
+					"172.19.0.1:57818",
+					"172.20.0.1:57818",
+					"172.21.0.1:57818",
+					"172.22.0.1:57818",
+					"172.23.0.1:57818",
+					"172.24.0.1:57818",
+					"172.25.0.1:57818",
+					"172.26.0.1:57818",
+					"172.27.0.1:57818"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:26:02.90258067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5988788433583050,
+				"StableID":   "nDUXEPKLmo11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d03a57906aa1dcff0d05193c0435a9eb9d64922dad7b8feb5dfbaaef357a497a",
+				"DiscoKey":   "discokey:6276f751d145f796fb617ea1cfdf067350d436709901b15750b0bbb8f80c2a59",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35096",
+					"10.65.0.27:35096",
+					"172.17.0.1:35096",
+					"172.18.0.1:35096",
+					"172.19.0.1:35096",
+					"172.20.0.1:35096",
+					"172.21.0.1:35096",
+					"172.22.0.1:35096",
+					"172.23.0.1:35096",
+					"172.24.0.1:35096",
+					"172.25.0.1:35096",
+					"172.26.0.1:35096",
+					"172.27.0.1:35096"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:26:03.441102354Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3391484253904715,
+				"StableID":   "n2rfvLY1VT11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:2140010fd9cc6364dfa817bba059f6d3b83dacbf862ec711267a0f9fc95dba29",
+				"KeyExpiry":  "2026-11-09T09:26:03Z",
+				"DiscoKey":   "discokey:7541ee0f3d8a5a48a8370943d56f58d226ac09650ecfc16378e29d7b9218ab0f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47234",
+					"10.65.0.27:47234",
+					"172.17.0.1:47234",
+					"172.18.0.1:47234",
+					"172.19.0.1:47234",
+					"172.20.0.1:47234",
+					"172.21.0.1:47234",
+					"172.22.0.1:47234",
+					"172.23.0.1:47234",
+					"172.24.0.1:47234",
+					"172.25.0.1:47234",
+					"172.26.0.1:47234",
+					"172.27.0.1:47234"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:26:03.97812334Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8822860486792403,
+				"StableID":   "nS2bksattB21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:728287e19d4cf728efeb2fa5b1e13c83f59d0face81ca1f7451e3c63e855c500",
+				"KeyExpiry":  "2026-11-09T09:26:04Z",
+				"DiscoKey":   "discokey:86995fce0a1e74e4ccfd4994883888bdd16cf0f5dff4d77371e879dc7739b40e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48280",
+					"10.65.0.27:48280",
+					"172.17.0.1:48280",
+					"172.18.0.1:48280",
+					"172.19.0.1:48280",
+					"172.20.0.1:48280",
+					"172.21.0.1:48280",
+					"172.22.0.1:48280",
+					"172.23.0.1:48280",
+					"172.24.0.1:48280",
+					"172.25.0.1:48280",
+					"172.26.0.1:48280",
+					"172.27.0.1:48280"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:26:04.52785528Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4012558335314868,
+				"StableID":   "nT2Rjz6JLY11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e4cb2902e1b8f1d2a56ce7d6cb2ddcaa2e0456dd44e034e41e010f058a849054",
+				"KeyExpiry":  "2026-11-09T09:26:05Z",
+				"DiscoKey":   "discokey:3cdbe56232a3c233d2ffbe22d84cbe0916646cce682d5b8ee703e1bb314fa078",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:40522",
+					"10.65.0.27:40522",
+					"172.17.0.1:40522",
+					"172.18.0.1:40522",
+					"172.19.0.1:40522",
+					"172.20.0.1:40522",
+					"172.21.0.1:40522",
+					"172.22.0.1:40522",
+					"172.23.0.1:40522",
+					"172.24.0.1:40522",
+					"172.25.0.1:40522",
+					"172.26.0.1:40522",
+					"172.27.0.1:40522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:26:05.324315528Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5059147728361694": {
+				"ID":          5059147728361694,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8822860486792403,
+				"StableID":   "nS2bksattB21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:728287e19d4cf728efeb2fa5b1e13c83f59d0face81ca1f7451e3c63e855c500",
+				"KeyExpiry":  "2026-11-09T09:26:04Z",
+				"DiscoKey":   "discokey:86995fce0a1e74e4ccfd4994883888bdd16cf0f5dff4d77371e879dc7739b40e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48280",
+					"10.65.0.27:48280",
+					"172.17.0.1:48280",
+					"172.18.0.1:48280",
+					"172.19.0.1:48280",
+					"172.20.0.1:48280",
+					"172.21.0.1:48280",
+					"172.22.0.1:48280",
+					"172.23.0.1:48280",
+					"172.24.0.1:48280",
+					"172.25.0.1:48280",
+					"172.26.0.1:48280",
+					"172.27.0.1:48280"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:26:04.52785528Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:728287e19d4cf728efeb2fa5b1e13c83f59d0face81ca1f7451e3c63e855c500",
+			"MachineKey": "mkey:c6a76fbd006f18a222765392741f86aac8c286f7ddfaf26dd2a53498933dd175",
+			"Peers": [{
+				"ID":         8343158374485682,
+				"StableID":   "ndrUk8dd9821CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41ae8133c03d911c119ed6427c57aa9fcbba2adb85e87163d8111c4e5161e777",
+				"DiscoKey":   "discokey:d3a70a3ff5144854a72d56fff7286ea9a81736378d5c2eac81eef0b6f329ef1b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49601",
+					"10.65.0.27:49601",
+					"172.17.0.1:49601",
+					"172.18.0.1:49601",
+					"172.19.0.1:49601",
+					"172.20.0.1:49601",
+					"172.21.0.1:49601",
+					"172.22.0.1:49601",
+					"172.23.0.1:49601",
+					"172.24.0.1:49601",
+					"172.25.0.1:49601",
+					"172.26.0.1:49601",
+					"172.27.0.1:49601"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:25:57.623851595Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1754521776149444,
+				"StableID":   "nVVHH6KdhE11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89d04b3ec1cd953acfced2752023c96f358c21e6117595e9a9a9193468f8ea40",
+				"DiscoKey":   "discokey:6330fc9c2de6eeb836b51a009212d34d93735f8cacde169d5126d1827a105014",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54805",
+					"10.65.0.27:54805",
+					"172.17.0.1:54805",
+					"172.18.0.1:54805",
+					"172.19.0.1:54805",
+					"172.20.0.1:54805",
+					"172.21.0.1:54805",
+					"172.22.0.1:54805",
+					"172.23.0.1:54805",
+					"172.24.0.1:54805",
+					"172.25.0.1:54805",
+					"172.26.0.1:54805",
+					"172.27.0.1:54805"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:25:58.168865723Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5991564693681578,
+				"StableID":   "n7KDqBFbno11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ccd4e67a2cc70de546e3cd7fe6b30ea45e5ed9900de9b80d893d63d685f44a05",
+				"DiscoKey":   "discokey:25b6576979922c201647204426ff0e3cf2dfe09aa9c47690d712cd588f5e2062",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60155",
+					"10.65.0.27:60155",
+					"172.17.0.1:60155",
+					"172.18.0.1:60155",
+					"172.19.0.1:60155",
+					"172.20.0.1:60155",
+					"172.21.0.1:60155",
+					"172.22.0.1:60155",
+					"172.23.0.1:60155",
+					"172.24.0.1:60155",
+					"172.25.0.1:60155",
+					"172.26.0.1:60155",
+					"172.27.0.1:60155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:25:58.693234704Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2467040710852722,
+				"StableID":   "nXsmdcyKGL11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6dd39de776307c6ec64b0ddd8ecae095d339c62f436ef04ecb4e31d07dcffc13",
+				"DiscoKey":   "discokey:b90b6767cbba1ab4d3580a3576b354813d757de6812cbb7a094e811c9c002c3f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50824",
+					"10.65.0.27:50824",
+					"172.17.0.1:50824",
+					"172.18.0.1:50824",
+					"172.19.0.1:50824",
+					"172.20.0.1:50824",
+					"172.21.0.1:50824",
+					"172.22.0.1:50824",
+					"172.23.0.1:50824",
+					"172.24.0.1:50824",
+					"172.25.0.1:50824",
+					"172.26.0.1:50824",
+					"172.27.0.1:50824"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:25:59.212390098Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7791884088342646,
+				"StableID":   "nyELqmaxq321CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51972f61ed25c9c9b251d581a32faccf2c919c8ecd47e01b6c7d0b5645002d4b",
+				"DiscoKey":   "discokey:1db365b71d0c552f0e10d299e592bd6209faa3f034b3c7a23847858e5708b61a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42275",
+					"10.65.0.27:42275",
+					"172.17.0.1:42275",
+					"172.18.0.1:42275",
+					"172.19.0.1:42275",
+					"172.20.0.1:42275",
+					"172.21.0.1:42275",
+					"172.22.0.1:42275",
+					"172.23.0.1:42275",
+					"172.24.0.1:42275",
+					"172.25.0.1:42275",
+					"172.26.0.1:42275",
+					"172.27.0.1:42275"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:25:59.746462998Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6389966061376616,
+				"StableID":   "nRq7SEa2ur11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2a8c6a87d0b42f0ce0fd039261c721d78966aa3c47321dd82ed5ab588a55ba55",
+				"DiscoKey":   "discokey:a5f67056c66182b1ece69b43998cdeb29cf4839ce15a7ea113b8ab322c2e4924",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54787",
+					"10.65.0.27:54787",
+					"172.17.0.1:54787",
+					"172.18.0.1:54787",
+					"172.19.0.1:54787",
+					"172.20.0.1:54787",
+					"172.21.0.1:54787",
+					"172.22.0.1:54787",
+					"172.23.0.1:54787",
+					"172.24.0.1:54787",
+					"172.25.0.1:54787",
+					"172.26.0.1:54787",
+					"172.27.0.1:54787"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:26:00.274096536Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1055306989129197,
+				"StableID":   "nSjDuF8xE911CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3593bf7bbeeeec26dc7ee462cea1a75809c7ae458f6ec35c05d63e2e9bca1877",
+				"DiscoKey":   "discokey:63de9e2f1c401c0046477ea78ec96e4a6fee5686a14957ca476453d50b648d65",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58374",
+					"10.65.0.27:58374",
+					"172.17.0.1:58374",
+					"172.18.0.1:58374",
+					"172.19.0.1:58374",
+					"172.20.0.1:58374",
+					"172.21.0.1:58374",
+					"172.22.0.1:58374",
+					"172.23.0.1:58374",
+					"172.24.0.1:58374",
+					"172.25.0.1:58374",
+					"172.26.0.1:58374",
+					"172.27.0.1:58374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:26:00.872732453Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3737616221991531,
+				"StableID":   "nzNyfjqmBW11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e9a602a93d0357af740fc7e394645f4e174709cd2026835debd5bff455779369",
+				"DiscoKey":   "discokey:94c064a50634869029fc6e962946859bf642c8d4747f2f505d81635d3351612e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:44914",
+					"10.65.0.27:44914",
+					"172.17.0.1:44914",
+					"172.18.0.1:44914",
+					"172.19.0.1:44914",
+					"172.20.0.1:44914",
+					"172.21.0.1:44914",
+					"172.22.0.1:44914",
+					"172.23.0.1:44914",
+					"172.24.0.1:44914",
+					"172.25.0.1:44914",
+					"172.26.0.1:44914",
+					"172.27.0.1:44914"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:26:01.325879553Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5059147728361694,
+				"StableID":   "nMx2XTEJWg11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:011542c0cfbeb754e87234b0e6040cfbc21db3d227952120fd87272c72c9bd4a",
+				"DiscoKey":   "discokey:83d245de9eba2b009641cabdbf824d745958ab96fde3e94fae1e408bf5a00d7c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35319",
+					"10.65.0.27:35319",
+					"172.17.0.1:35319",
+					"172.18.0.1:35319",
+					"172.19.0.1:35319",
+					"172.20.0.1:35319",
+					"172.21.0.1:35319",
+					"172.22.0.1:35319",
+					"172.23.0.1:35319",
+					"172.24.0.1:35319",
+					"172.25.0.1:35319",
+					"172.26.0.1:35319",
+					"172.27.0.1:35319"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:26:01.860130237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6314986434931921,
+				"StableID":   "nUnnb9z4Kr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:884ac400784500c4ac7062eb5dfc130a336d9131ea1670647a26c6c735eeba1d",
+				"DiscoKey":   "discokey:74b3c7a3c909080c0803aefae71022600746afe32320a7a00aea188f2b8d5051",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38181",
+					"10.65.0.27:38181",
+					"172.17.0.1:38181",
+					"172.18.0.1:38181",
+					"172.19.0.1:38181",
+					"172.20.0.1:38181",
+					"172.21.0.1:38181",
+					"172.22.0.1:38181",
+					"172.23.0.1:38181",
+					"172.24.0.1:38181",
+					"172.25.0.1:38181",
+					"172.26.0.1:38181",
+					"172.27.0.1:38181"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:26:02.386361251Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3027636418233653,
+				"StableID":   "nE5HdjsDeQ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:57cc21672c69b7a5b2af5b17ac0dd70d4d3c104ba149a207c4818f4c0edf331f",
+				"DiscoKey":   "discokey:4d1307114289a331544162ec0264cfb4f2469406c7dfaee44c0e6c744ce4b156",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57818",
+					"10.65.0.27:57818",
+					"172.17.0.1:57818",
+					"172.18.0.1:57818",
+					"172.19.0.1:57818",
+					"172.20.0.1:57818",
+					"172.21.0.1:57818",
+					"172.22.0.1:57818",
+					"172.23.0.1:57818",
+					"172.24.0.1:57818",
+					"172.25.0.1:57818",
+					"172.26.0.1:57818",
+					"172.27.0.1:57818"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:26:02.90258067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5988788433583050,
+				"StableID":   "nDUXEPKLmo11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d03a57906aa1dcff0d05193c0435a9eb9d64922dad7b8feb5dfbaaef357a497a",
+				"DiscoKey":   "discokey:6276f751d145f796fb617ea1cfdf067350d436709901b15750b0bbb8f80c2a59",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35096",
+					"10.65.0.27:35096",
+					"172.17.0.1:35096",
+					"172.18.0.1:35096",
+					"172.19.0.1:35096",
+					"172.20.0.1:35096",
+					"172.21.0.1:35096",
+					"172.22.0.1:35096",
+					"172.23.0.1:35096",
+					"172.24.0.1:35096",
+					"172.25.0.1:35096",
+					"172.26.0.1:35096",
+					"172.27.0.1:35096"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:26:03.441102354Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3391484253904715,
+				"StableID":   "n2rfvLY1VT11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:2140010fd9cc6364dfa817bba059f6d3b83dacbf862ec711267a0f9fc95dba29",
+				"KeyExpiry":  "2026-11-09T09:26:03Z",
+				"DiscoKey":   "discokey:7541ee0f3d8a5a48a8370943d56f58d226ac09650ecfc16378e29d7b9218ab0f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47234",
+					"10.65.0.27:47234",
+					"172.17.0.1:47234",
+					"172.18.0.1:47234",
+					"172.19.0.1:47234",
+					"172.20.0.1:47234",
+					"172.21.0.1:47234",
+					"172.22.0.1:47234",
+					"172.23.0.1:47234",
+					"172.24.0.1:47234",
+					"172.25.0.1:47234",
+					"172.26.0.1:47234",
+					"172.27.0.1:47234"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:26:03.97812334Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4012558335314868,
+				"StableID":   "nT2Rjz6JLY11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e4cb2902e1b8f1d2a56ce7d6cb2ddcaa2e0456dd44e034e41e010f058a849054",
+				"KeyExpiry":  "2026-11-09T09:26:05Z",
+				"DiscoKey":   "discokey:3cdbe56232a3c233d2ffbe22d84cbe0916646cce682d5b8ee703e1bb314fa078",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:40522",
+					"10.65.0.27:40522",
+					"172.17.0.1:40522",
+					"172.18.0.1:40522",
+					"172.19.0.1:40522",
+					"172.20.0.1:40522",
+					"172.21.0.1:40522",
+					"172.22.0.1:40522",
+					"172.23.0.1:40522",
+					"172.24.0.1:40522",
+					"172.25.0.1:40522",
+					"172.26.0.1:40522",
+					"172.27.0.1:40522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:26:05.324315528Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6314986434931921,
+				"StableID":   "nUnnb9z4Kr11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       6314986434931921,
+				"Key":        "nodekey:884ac400784500c4ac7062eb5dfc130a336d9131ea1670647a26c6c735eeba1d",
+				"DiscoKey":   "discokey:74b3c7a3c909080c0803aefae71022600746afe32320a7a00aea188f2b8d5051",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38181",
+					"10.65.0.27:38181",
+					"172.17.0.1:38181",
+					"172.18.0.1:38181",
+					"172.19.0.1:38181",
+					"172.20.0.1:38181",
+					"172.21.0.1:38181",
+					"172.22.0.1:38181",
+					"172.23.0.1:38181",
+					"172.24.0.1:38181",
+					"172.25.0.1:38181",
+					"172.26.0.1:38181",
+					"172.27.0.1:38181"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:26:02.386361251Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:884ac400784500c4ac7062eb5dfc130a336d9131ea1670647a26c6c735eeba1d",
+			"MachineKey": "mkey:4b50f89ad247624092a454f8ebc9149c367c6d9b53968ae2cac61fa5e3b98315",
+			"Peers": [{
+				"ID":         8343158374485682,
+				"StableID":   "ndrUk8dd9821CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41ae8133c03d911c119ed6427c57aa9fcbba2adb85e87163d8111c4e5161e777",
+				"DiscoKey":   "discokey:d3a70a3ff5144854a72d56fff7286ea9a81736378d5c2eac81eef0b6f329ef1b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:49601",
+					"10.65.0.27:49601",
+					"172.17.0.1:49601",
+					"172.18.0.1:49601",
+					"172.19.0.1:49601",
+					"172.20.0.1:49601",
+					"172.21.0.1:49601",
+					"172.22.0.1:49601",
+					"172.23.0.1:49601",
+					"172.24.0.1:49601",
+					"172.25.0.1:49601",
+					"172.26.0.1:49601",
+					"172.27.0.1:49601"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:25:57.623851595Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1754521776149444,
+				"StableID":   "nVVHH6KdhE11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89d04b3ec1cd953acfced2752023c96f358c21e6117595e9a9a9193468f8ea40",
+				"DiscoKey":   "discokey:6330fc9c2de6eeb836b51a009212d34d93735f8cacde169d5126d1827a105014",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54805",
+					"10.65.0.27:54805",
+					"172.17.0.1:54805",
+					"172.18.0.1:54805",
+					"172.19.0.1:54805",
+					"172.20.0.1:54805",
+					"172.21.0.1:54805",
+					"172.22.0.1:54805",
+					"172.23.0.1:54805",
+					"172.24.0.1:54805",
+					"172.25.0.1:54805",
+					"172.26.0.1:54805",
+					"172.27.0.1:54805"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:25:58.168865723Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5991564693681578,
+				"StableID":   "n7KDqBFbno11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ccd4e67a2cc70de546e3cd7fe6b30ea45e5ed9900de9b80d893d63d685f44a05",
+				"DiscoKey":   "discokey:25b6576979922c201647204426ff0e3cf2dfe09aa9c47690d712cd588f5e2062",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60155",
+					"10.65.0.27:60155",
+					"172.17.0.1:60155",
+					"172.18.0.1:60155",
+					"172.19.0.1:60155",
+					"172.20.0.1:60155",
+					"172.21.0.1:60155",
+					"172.22.0.1:60155",
+					"172.23.0.1:60155",
+					"172.24.0.1:60155",
+					"172.25.0.1:60155",
+					"172.26.0.1:60155",
+					"172.27.0.1:60155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:25:58.693234704Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2467040710852722,
+				"StableID":   "nXsmdcyKGL11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6dd39de776307c6ec64b0ddd8ecae095d339c62f436ef04ecb4e31d07dcffc13",
+				"DiscoKey":   "discokey:b90b6767cbba1ab4d3580a3576b354813d757de6812cbb7a094e811c9c002c3f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50824",
+					"10.65.0.27:50824",
+					"172.17.0.1:50824",
+					"172.18.0.1:50824",
+					"172.19.0.1:50824",
+					"172.20.0.1:50824",
+					"172.21.0.1:50824",
+					"172.22.0.1:50824",
+					"172.23.0.1:50824",
+					"172.24.0.1:50824",
+					"172.25.0.1:50824",
+					"172.26.0.1:50824",
+					"172.27.0.1:50824"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:25:59.212390098Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7791884088342646,
+				"StableID":   "nyELqmaxq321CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51972f61ed25c9c9b251d581a32faccf2c919c8ecd47e01b6c7d0b5645002d4b",
+				"DiscoKey":   "discokey:1db365b71d0c552f0e10d299e592bd6209faa3f034b3c7a23847858e5708b61a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:42275",
+					"10.65.0.27:42275",
+					"172.17.0.1:42275",
+					"172.18.0.1:42275",
+					"172.19.0.1:42275",
+					"172.20.0.1:42275",
+					"172.21.0.1:42275",
+					"172.22.0.1:42275",
+					"172.23.0.1:42275",
+					"172.24.0.1:42275",
+					"172.25.0.1:42275",
+					"172.26.0.1:42275",
+					"172.27.0.1:42275"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:25:59.746462998Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6389966061376616,
+				"StableID":   "nRq7SEa2ur11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2a8c6a87d0b42f0ce0fd039261c721d78966aa3c47321dd82ed5ab588a55ba55",
+				"DiscoKey":   "discokey:a5f67056c66182b1ece69b43998cdeb29cf4839ce15a7ea113b8ab322c2e4924",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:54787",
+					"10.65.0.27:54787",
+					"172.17.0.1:54787",
+					"172.18.0.1:54787",
+					"172.19.0.1:54787",
+					"172.20.0.1:54787",
+					"172.21.0.1:54787",
+					"172.22.0.1:54787",
+					"172.23.0.1:54787",
+					"172.24.0.1:54787",
+					"172.25.0.1:54787",
+					"172.26.0.1:54787",
+					"172.27.0.1:54787"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:26:00.274096536Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1055306989129197,
+				"StableID":   "nSjDuF8xE911CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3593bf7bbeeeec26dc7ee462cea1a75809c7ae458f6ec35c05d63e2e9bca1877",
+				"DiscoKey":   "discokey:63de9e2f1c401c0046477ea78ec96e4a6fee5686a14957ca476453d50b648d65",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:58374",
+					"10.65.0.27:58374",
+					"172.17.0.1:58374",
+					"172.18.0.1:58374",
+					"172.19.0.1:58374",
+					"172.20.0.1:58374",
+					"172.21.0.1:58374",
+					"172.22.0.1:58374",
+					"172.23.0.1:58374",
+					"172.24.0.1:58374",
+					"172.25.0.1:58374",
+					"172.26.0.1:58374",
+					"172.27.0.1:58374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:26:00.872732453Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3737616221991531,
+				"StableID":   "nzNyfjqmBW11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e9a602a93d0357af740fc7e394645f4e174709cd2026835debd5bff455779369",
+				"DiscoKey":   "discokey:94c064a50634869029fc6e962946859bf642c8d4747f2f505d81635d3351612e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:44914",
+					"10.65.0.27:44914",
+					"172.17.0.1:44914",
+					"172.18.0.1:44914",
+					"172.19.0.1:44914",
+					"172.20.0.1:44914",
+					"172.21.0.1:44914",
+					"172.22.0.1:44914",
+					"172.23.0.1:44914",
+					"172.24.0.1:44914",
+					"172.25.0.1:44914",
+					"172.26.0.1:44914",
+					"172.27.0.1:44914"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:26:01.325879553Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5059147728361694,
+				"StableID":   "nMx2XTEJWg11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:011542c0cfbeb754e87234b0e6040cfbc21db3d227952120fd87272c72c9bd4a",
+				"DiscoKey":   "discokey:83d245de9eba2b009641cabdbf824d745958ab96fde3e94fae1e408bf5a00d7c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35319",
+					"10.65.0.27:35319",
+					"172.17.0.1:35319",
+					"172.18.0.1:35319",
+					"172.19.0.1:35319",
+					"172.20.0.1:35319",
+					"172.21.0.1:35319",
+					"172.22.0.1:35319",
+					"172.23.0.1:35319",
+					"172.24.0.1:35319",
+					"172.25.0.1:35319",
+					"172.26.0.1:35319",
+					"172.27.0.1:35319"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:26:01.860130237Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3027636418233653,
+				"StableID":   "nE5HdjsDeQ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:57cc21672c69b7a5b2af5b17ac0dd70d4d3c104ba149a207c4818f4c0edf331f",
+				"DiscoKey":   "discokey:4d1307114289a331544162ec0264cfb4f2469406c7dfaee44c0e6c744ce4b156",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:57818",
+					"10.65.0.27:57818",
+					"172.17.0.1:57818",
+					"172.18.0.1:57818",
+					"172.19.0.1:57818",
+					"172.20.0.1:57818",
+					"172.21.0.1:57818",
+					"172.22.0.1:57818",
+					"172.23.0.1:57818",
+					"172.24.0.1:57818",
+					"172.25.0.1:57818",
+					"172.26.0.1:57818",
+					"172.27.0.1:57818"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:26:02.90258067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5988788433583050,
+				"StableID":   "nDUXEPKLmo11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d03a57906aa1dcff0d05193c0435a9eb9d64922dad7b8feb5dfbaaef357a497a",
+				"DiscoKey":   "discokey:6276f751d145f796fb617ea1cfdf067350d436709901b15750b0bbb8f80c2a59",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:35096",
+					"10.65.0.27:35096",
+					"172.17.0.1:35096",
+					"172.18.0.1:35096",
+					"172.19.0.1:35096",
+					"172.20.0.1:35096",
+					"172.21.0.1:35096",
+					"172.22.0.1:35096",
+					"172.23.0.1:35096",
+					"172.24.0.1:35096",
+					"172.25.0.1:35096",
+					"172.26.0.1:35096",
+					"172.27.0.1:35096"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:26:03.441102354Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3391484253904715,
+				"StableID":   "n2rfvLY1VT11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:2140010fd9cc6364dfa817bba059f6d3b83dacbf862ec711267a0f9fc95dba29",
+				"KeyExpiry":  "2026-11-09T09:26:03Z",
+				"DiscoKey":   "discokey:7541ee0f3d8a5a48a8370943d56f58d226ac09650ecfc16378e29d7b9218ab0f",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47234",
+					"10.65.0.27:47234",
+					"172.17.0.1:47234",
+					"172.18.0.1:47234",
+					"172.19.0.1:47234",
+					"172.20.0.1:47234",
+					"172.21.0.1:47234",
+					"172.22.0.1:47234",
+					"172.23.0.1:47234",
+					"172.24.0.1:47234",
+					"172.25.0.1:47234",
+					"172.26.0.1:47234",
+					"172.27.0.1:47234"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:26:03.97812334Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8822860486792403,
+				"StableID":   "nS2bksattB21CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:728287e19d4cf728efeb2fa5b1e13c83f59d0face81ca1f7451e3c63e855c500",
+				"KeyExpiry":  "2026-11-09T09:26:04Z",
+				"DiscoKey":   "discokey:86995fce0a1e74e4ccfd4994883888bdd16cf0f5dff4d77371e879dc7739b40e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:48280",
+					"10.65.0.27:48280",
+					"172.17.0.1:48280",
+					"172.18.0.1:48280",
+					"172.19.0.1:48280",
+					"172.20.0.1:48280",
+					"172.21.0.1:48280",
+					"172.22.0.1:48280",
+					"172.23.0.1:48280",
+					"172.24.0.1:48280",
+					"172.25.0.1:48280",
+					"172.26.0.1:48280",
+					"172.27.0.1:48280"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:26:04.52785528Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4012558335314868,
+				"StableID":   "nT2Rjz6JLY11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e4cb2902e1b8f1d2a56ce7d6cb2ddcaa2e0456dd44e034e41e010f058a849054",
+				"KeyExpiry":  "2026-11-09T09:26:05Z",
+				"DiscoKey":   "discokey:3cdbe56232a3c233d2ffbe22d84cbe0916646cce682d5b8ee703e1bb314fa078",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:40522",
+					"10.65.0.27:40522",
+					"172.17.0.1:40522",
+					"172.18.0.1:40522",
+					"172.19.0.1:40522",
+					"172.20.0.1:40522",
+					"172.21.0.1:40522",
+					"172.22.0.1:40522",
+					"172.23.0.1:40522",
+					"172.24.0.1:40522",
+					"172.25.0.1:40522",
+					"172.26.0.1:40522",
+					"172.27.0.1:40522"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:26:05.324315528Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6314986434931921": {
+				"ID":          6314986434931921,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-unicode-emoji-user.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-unicode-emoji-user.hujson
@@ -1,0 +1,21898 @@
+// ssh-unicode-emoji-user
+//
+// ssh users contains emoji
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-13T09:26:41Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-unicode-emoji-user",
+	"description":    "ssh users contains emoji",
+	"category":       "ssh",
+	"captured_at":    "2026-05-13T09:26:41.285906252Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                         \n  \n                                                                      \n                                                                      \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh users contains emoji\",\n\t\"id\":          \"ssh-unicode-emoji-user\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"thor@example.org\"],\n\t\t\"users\":  [\"🚀\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-edges/ssh-unicode-emoji-user.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["thor@example.org"],
+				"users":  ["🚀"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3872874892352138,
+				"StableID":   "n7HcCfr2FX11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       3872874892352138,
+				"Key":        "nodekey:bb0b1e2d6305e56a36d3fc3126ad2defd58cb2e80cd01330773b5d4d194c6b1e",
+				"DiscoKey":   "discokey:ffbbd6f2ea536de55895dba0eb5fc0c698a2137c22cf8702f641363083038f49",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39492",
+					"10.65.0.27:39492",
+					"172.17.0.1:39492",
+					"172.18.0.1:39492",
+					"172.19.0.1:39492",
+					"172.20.0.1:39492",
+					"172.21.0.1:39492",
+					"172.22.0.1:39492",
+					"172.23.0.1:39492",
+					"172.24.0.1:39492",
+					"172.25.0.1:39492",
+					"172.26.0.1:39492",
+					"172.27.0.1:39492"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:26:50.088026002Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:bb0b1e2d6305e56a36d3fc3126ad2defd58cb2e80cd01330773b5d4d194c6b1e",
+			"MachineKey": "mkey:c5570b69f0b94ac6631b1185dcdcd40b042da58cfdebe96cff1d658307753768",
+			"Peers": [{
+				"ID":         4073872181115765,
+				"StableID":   "niKsKRi4pY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b2fd2227e6fef920dcfdb9f6d6a0d42f87084effc364c1b744fa7cedf95a428",
+				"DiscoKey":   "discokey:b2d54fb79cbf2a8bd5a81e9b41af84b420fdb150cc7429978e83df6b19e39765",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:39258",
+					"10.65.0.27:39258",
+					"172.17.0.1:39258",
+					"172.18.0.1:39258",
+					"172.19.0.1:39258",
+					"172.20.0.1:39258",
+					"172.21.0.1:39258",
+					"172.22.0.1:39258",
+					"172.23.0.1:39258",
+					"172.24.0.1:39258",
+					"172.25.0.1:39258",
+					"172.26.0.1:39258",
+					"172.27.0.1:39258"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:26:44.000588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8598559577817578,
+				"StableID":   "nM8TWcaJ9A21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47838c310880c867cfeb9afb9db7ced8f4cd1938891cecf346829319db07ef5a",
+				"DiscoKey":   "discokey:68601797acf56fec44fcf8dd0ab187da02b05a2d9b3f92ba81af8b7484e37e12",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:49374",
+					"10.65.0.27:49374",
+					"172.17.0.1:49374",
+					"172.18.0.1:49374",
+					"172.19.0.1:49374",
+					"172.20.0.1:49374",
+					"172.21.0.1:49374",
+					"172.22.0.1:49374",
+					"172.23.0.1:49374",
+					"172.24.0.1:49374",
+					"172.25.0.1:49374",
+					"172.26.0.1:49374",
+					"172.27.0.1:49374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:26:44.478308406Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4243276445468940,
+				"StableID":   "njay4Ggn8a11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c656e7bfd9a437d724205617492efe06e1d4eed75586962cdb3ab9bd152f3506",
+				"DiscoKey":   "discokey:f048658f0714e5620642955ddcd960d2c70b73a7ddba7ebe3f14680cf3c3551f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40353",
+					"10.65.0.27:40353",
+					"172.17.0.1:40353",
+					"172.18.0.1:40353",
+					"172.19.0.1:40353",
+					"172.20.0.1:40353",
+					"172.21.0.1:40353",
+					"172.22.0.1:40353",
+					"172.23.0.1:40353",
+					"172.24.0.1:40353",
+					"172.25.0.1:40353",
+					"172.26.0.1:40353",
+					"172.27.0.1:40353"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:26:45.020203919Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6613494429872618,
+				"StableID":   "nXHNvUHGet11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e23b31364641820a02bf84ae75c2f74bf050eb491036e06b9589eee46625a313",
+				"DiscoKey":   "discokey:c10be57a23131c1477628c58655db1b3a9e396a0c16fb14d282f19971dcb2f0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42128",
+					"10.65.0.27:42128",
+					"172.17.0.1:42128",
+					"172.18.0.1:42128",
+					"172.19.0.1:42128",
+					"172.20.0.1:42128",
+					"172.21.0.1:42128",
+					"172.22.0.1:42128",
+					"172.23.0.1:42128",
+					"172.24.0.1:42128",
+					"172.25.0.1:42128",
+					"172.26.0.1:42128",
+					"172.27.0.1:42128"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:26:45.551366518Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         903866408710325,
+				"StableID":   "ntnmPC3N4811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97624f7f91a2f10b47cf34387e3e55428057bd22642256d082331c143a468333",
+				"DiscoKey":   "discokey:b0b7aaa631a463a7c1bf9ba092e1c4da6a41e0816b9f755a0842331584f80a1f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55472",
+					"10.65.0.27:55472",
+					"172.17.0.1:55472",
+					"172.18.0.1:55472",
+					"172.19.0.1:55472",
+					"172.20.0.1:55472",
+					"172.21.0.1:55472",
+					"172.22.0.1:55472",
+					"172.23.0.1:55472",
+					"172.24.0.1:55472",
+					"172.25.0.1:55472",
+					"172.26.0.1:55472",
+					"172.27.0.1:55472"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:26:46.075189134Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7270970070352609,
+				"StableID":   "nxeHr943ny11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:49cc0e9f5deba8ec8fadecc8c3fb07b06936f07ef415d102b7f4a951f02f2374",
+				"DiscoKey":   "discokey:ea14ab63d3cf23bbc45e630019938965bfafb81a1eca0f91ccc4d44255f42448",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44012",
+					"10.65.0.27:44012",
+					"172.17.0.1:44012",
+					"172.18.0.1:44012",
+					"172.19.0.1:44012",
+					"172.20.0.1:44012",
+					"172.21.0.1:44012",
+					"172.22.0.1:44012",
+					"172.23.0.1:44012",
+					"172.24.0.1:44012",
+					"172.25.0.1:44012",
+					"172.26.0.1:44012",
+					"172.27.0.1:44012"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:26:46.720919897Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8700466115858341,
+				"StableID":   "nEB6KWVTwA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:585bfffa5ac2a6323e7469c2ec38bf68b5ba6e5417def1a435b89cdb226e016f",
+				"DiscoKey":   "discokey:eddcc88f73426a19162116bcb1af08400f8a4dc410f6ab4f913a2bdaf2b3705d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51046",
+					"10.65.0.27:51046",
+					"172.17.0.1:51046",
+					"172.18.0.1:51046",
+					"172.19.0.1:51046",
+					"172.20.0.1:51046",
+					"172.21.0.1:51046",
+					"172.22.0.1:51046",
+					"172.23.0.1:51046",
+					"172.24.0.1:51046",
+					"172.25.0.1:51046",
+					"172.26.0.1:51046",
+					"172.27.0.1:51046"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:26:47.395944594Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         979170825313379,
+				"StableID":   "nNQZp7AUe811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4720f19dfaf5895ce1bb1c8ac02ea32afe6f2af424cec20d8304f6abee01b417",
+				"DiscoKey":   "discokey:d7c02f2d59fa01b134c3917b68a15623829e1e963ae773062b7be5ca262aa63d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:41076",
+					"10.65.0.27:41076",
+					"172.17.0.1:41076",
+					"172.18.0.1:41076",
+					"172.19.0.1:41076",
+					"172.20.0.1:41076",
+					"172.21.0.1:41076",
+					"172.22.0.1:41076",
+					"172.23.0.1:41076",
+					"172.24.0.1:41076",
+					"172.25.0.1:41076",
+					"172.26.0.1:41076",
+					"172.27.0.1:41076"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:26:47.935685625Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4850606547643342,
+				"StableID":   "n52dV7Drse11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dd4e65691316056a84098ba81af4208c614c566a22694d65084822d41d1bf339",
+				"DiscoKey":   "discokey:e3e00787e8a2ad677cfb632dbe719e5713471febb8fb3cea8fb02799aed64543",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42728",
+					"10.65.0.27:42728",
+					"172.17.0.1:42728",
+					"172.18.0.1:42728",
+					"172.19.0.1:42728",
+					"172.20.0.1:42728",
+					"172.21.0.1:42728",
+					"172.22.0.1:42728",
+					"172.23.0.1:42728",
+					"172.24.0.1:42728",
+					"172.25.0.1:42728",
+					"172.26.0.1:42728",
+					"172.27.0.1:42728"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:26:48.476260994Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         648454568615411,
+				"StableID":   "nLTchWog4611CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2b57d1fab7444bf5dab9a10ca383fad7c0ca4cd7aff3465dd79e9cd6f14d77f",
+				"DiscoKey":   "discokey:607988909e98850adf4c13d013b0815fc7594f7cfceefab7351a2e947864c170",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49898",
+					"10.65.0.27:49898",
+					"172.17.0.1:49898",
+					"172.18.0.1:49898",
+					"172.19.0.1:49898",
+					"172.20.0.1:49898",
+					"172.21.0.1:49898",
+					"172.22.0.1:49898",
+					"172.23.0.1:49898",
+					"172.24.0.1:49898",
+					"172.25.0.1:49898",
+					"172.26.0.1:49898",
+					"172.27.0.1:49898"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:26:49.010607278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8000392402528055,
+				"StableID":   "nAzAZ3kPU521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:04bf6c9ab1aadb71cbbd84cd40623055f633397b0e05275318af91fd82868931",
+				"DiscoKey":   "discokey:cefa23898be4a9b12faa7b74ae10597785131a147db84bd977d984e4b22b5267",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48857",
+					"10.65.0.27:48857",
+					"172.17.0.1:48857",
+					"172.18.0.1:48857",
+					"172.19.0.1:48857",
+					"172.20.0.1:48857",
+					"172.21.0.1:48857",
+					"172.22.0.1:48857",
+					"172.23.0.1:48857",
+					"172.24.0.1:48857",
+					"172.25.0.1:48857",
+					"172.26.0.1:48857",
+					"172.27.0.1:48857"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:26:49.559589908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6493343994844945,
+				"StableID":   "nUrvQt8rhs11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04e296ec0576179648249da90227a94bf11e1deecc7a4de2c5f41c676b404d2b",
+				"KeyExpiry":  "2026-11-09T09:26:50Z",
+				"DiscoKey":   "discokey:76b933c86179621b333b43e7bf1bb84886973c6ca03eeffc6a6f712361f5ce46",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38220",
+					"10.65.0.27:38220",
+					"172.17.0.1:38220",
+					"172.18.0.1:38220",
+					"172.19.0.1:38220",
+					"172.20.0.1:38220",
+					"172.21.0.1:38220",
+					"172.22.0.1:38220",
+					"172.23.0.1:38220",
+					"172.24.0.1:38220",
+					"172.25.0.1:38220",
+					"172.26.0.1:38220",
+					"172.27.0.1:38220"
+				],
+				"HomeDERP": 18,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:26:50.613723105Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1496113877603016,
+				"StableID":   "nRdRAjNbgC11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:0ca2fa43faf6a93e863ff07417d8496270d56033cad4f88a990899845ad87418",
+				"KeyExpiry":  "2026-11-09T09:26:51Z",
+				"DiscoKey":   "discokey:c0ef6602bbddbf283bfe884e9673655c88bfb59dec98eb666002d1d0fd671646",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49007",
+					"10.65.0.27:49007",
+					"172.17.0.1:49007",
+					"172.18.0.1:49007",
+					"172.19.0.1:49007",
+					"172.20.0.1:49007",
+					"172.21.0.1:49007",
+					"172.22.0.1:49007",
+					"172.23.0.1:49007",
+					"172.24.0.1:49007",
+					"172.25.0.1:49007",
+					"172.26.0.1:49007",
+					"172.27.0.1:49007"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:26:51.146399576Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1641192705435100,
+				"StableID":   "nbeyNGMJpD11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:54fb5e0ac9bb3bfeced3d1b6f8f0250beb855298fe37be15afd2b532c333bd24",
+				"KeyExpiry":  "2026-11-09T09:26:51Z",
+				"DiscoKey":   "discokey:e21c2954729dc0ec4daacf8ba6bb199ed78b61ba605db2937a27bf8841cbcf1c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47645",
+					"10.65.0.27:47645",
+					"172.17.0.1:47645",
+					"172.18.0.1:47645",
+					"172.19.0.1:47645",
+					"172.20.0.1:47645",
+					"172.21.0.1:47645",
+					"172.22.0.1:47645",
+					"172.23.0.1:47645",
+					"172.24.0.1:47645",
+					"172.25.0.1:47645",
+					"172.26.0.1:47645",
+					"172.27.0.1:47645"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:26:51.689141853Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{
+				"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+				"sshUsers":   {"root": "", "🚀": "🚀"},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				}
+			}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3872874892352138": {
+				"ID":          3872874892352138,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		},
+		"ssh_rules": [{
+			"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+			"sshUsers":   {"root": "", "🚀": "🚀"},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}
+		}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7270970070352609,
+				"StableID":   "nxeHr943ny11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       7270970070352609,
+				"Key":        "nodekey:49cc0e9f5deba8ec8fadecc8c3fb07b06936f07ef415d102b7f4a951f02f2374",
+				"DiscoKey":   "discokey:ea14ab63d3cf23bbc45e630019938965bfafb81a1eca0f91ccc4d44255f42448",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44012",
+					"10.65.0.27:44012",
+					"172.17.0.1:44012",
+					"172.18.0.1:44012",
+					"172.19.0.1:44012",
+					"172.20.0.1:44012",
+					"172.21.0.1:44012",
+					"172.22.0.1:44012",
+					"172.23.0.1:44012",
+					"172.24.0.1:44012",
+					"172.25.0.1:44012",
+					"172.26.0.1:44012",
+					"172.27.0.1:44012"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:26:46.720919897Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:49cc0e9f5deba8ec8fadecc8c3fb07b06936f07ef415d102b7f4a951f02f2374",
+			"MachineKey": "mkey:30d51a2a5ea7c4357f147e88ef86118700c5c12acf46316b358a15c623836923",
+			"Peers": [{
+				"ID":         4073872181115765,
+				"StableID":   "niKsKRi4pY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b2fd2227e6fef920dcfdb9f6d6a0d42f87084effc364c1b744fa7cedf95a428",
+				"DiscoKey":   "discokey:b2d54fb79cbf2a8bd5a81e9b41af84b420fdb150cc7429978e83df6b19e39765",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:39258",
+					"10.65.0.27:39258",
+					"172.17.0.1:39258",
+					"172.18.0.1:39258",
+					"172.19.0.1:39258",
+					"172.20.0.1:39258",
+					"172.21.0.1:39258",
+					"172.22.0.1:39258",
+					"172.23.0.1:39258",
+					"172.24.0.1:39258",
+					"172.25.0.1:39258",
+					"172.26.0.1:39258",
+					"172.27.0.1:39258"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:26:44.000588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8598559577817578,
+				"StableID":   "nM8TWcaJ9A21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47838c310880c867cfeb9afb9db7ced8f4cd1938891cecf346829319db07ef5a",
+				"DiscoKey":   "discokey:68601797acf56fec44fcf8dd0ab187da02b05a2d9b3f92ba81af8b7484e37e12",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:49374",
+					"10.65.0.27:49374",
+					"172.17.0.1:49374",
+					"172.18.0.1:49374",
+					"172.19.0.1:49374",
+					"172.20.0.1:49374",
+					"172.21.0.1:49374",
+					"172.22.0.1:49374",
+					"172.23.0.1:49374",
+					"172.24.0.1:49374",
+					"172.25.0.1:49374",
+					"172.26.0.1:49374",
+					"172.27.0.1:49374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:26:44.478308406Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4243276445468940,
+				"StableID":   "njay4Ggn8a11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c656e7bfd9a437d724205617492efe06e1d4eed75586962cdb3ab9bd152f3506",
+				"DiscoKey":   "discokey:f048658f0714e5620642955ddcd960d2c70b73a7ddba7ebe3f14680cf3c3551f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40353",
+					"10.65.0.27:40353",
+					"172.17.0.1:40353",
+					"172.18.0.1:40353",
+					"172.19.0.1:40353",
+					"172.20.0.1:40353",
+					"172.21.0.1:40353",
+					"172.22.0.1:40353",
+					"172.23.0.1:40353",
+					"172.24.0.1:40353",
+					"172.25.0.1:40353",
+					"172.26.0.1:40353",
+					"172.27.0.1:40353"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:26:45.020203919Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6613494429872618,
+				"StableID":   "nXHNvUHGet11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e23b31364641820a02bf84ae75c2f74bf050eb491036e06b9589eee46625a313",
+				"DiscoKey":   "discokey:c10be57a23131c1477628c58655db1b3a9e396a0c16fb14d282f19971dcb2f0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42128",
+					"10.65.0.27:42128",
+					"172.17.0.1:42128",
+					"172.18.0.1:42128",
+					"172.19.0.1:42128",
+					"172.20.0.1:42128",
+					"172.21.0.1:42128",
+					"172.22.0.1:42128",
+					"172.23.0.1:42128",
+					"172.24.0.1:42128",
+					"172.25.0.1:42128",
+					"172.26.0.1:42128",
+					"172.27.0.1:42128"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:26:45.551366518Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         903866408710325,
+				"StableID":   "ntnmPC3N4811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97624f7f91a2f10b47cf34387e3e55428057bd22642256d082331c143a468333",
+				"DiscoKey":   "discokey:b0b7aaa631a463a7c1bf9ba092e1c4da6a41e0816b9f755a0842331584f80a1f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55472",
+					"10.65.0.27:55472",
+					"172.17.0.1:55472",
+					"172.18.0.1:55472",
+					"172.19.0.1:55472",
+					"172.20.0.1:55472",
+					"172.21.0.1:55472",
+					"172.22.0.1:55472",
+					"172.23.0.1:55472",
+					"172.24.0.1:55472",
+					"172.25.0.1:55472",
+					"172.26.0.1:55472",
+					"172.27.0.1:55472"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:26:46.075189134Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8700466115858341,
+				"StableID":   "nEB6KWVTwA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:585bfffa5ac2a6323e7469c2ec38bf68b5ba6e5417def1a435b89cdb226e016f",
+				"DiscoKey":   "discokey:eddcc88f73426a19162116bcb1af08400f8a4dc410f6ab4f913a2bdaf2b3705d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51046",
+					"10.65.0.27:51046",
+					"172.17.0.1:51046",
+					"172.18.0.1:51046",
+					"172.19.0.1:51046",
+					"172.20.0.1:51046",
+					"172.21.0.1:51046",
+					"172.22.0.1:51046",
+					"172.23.0.1:51046",
+					"172.24.0.1:51046",
+					"172.25.0.1:51046",
+					"172.26.0.1:51046",
+					"172.27.0.1:51046"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:26:47.395944594Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         979170825313379,
+				"StableID":   "nNQZp7AUe811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4720f19dfaf5895ce1bb1c8ac02ea32afe6f2af424cec20d8304f6abee01b417",
+				"DiscoKey":   "discokey:d7c02f2d59fa01b134c3917b68a15623829e1e963ae773062b7be5ca262aa63d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:41076",
+					"10.65.0.27:41076",
+					"172.17.0.1:41076",
+					"172.18.0.1:41076",
+					"172.19.0.1:41076",
+					"172.20.0.1:41076",
+					"172.21.0.1:41076",
+					"172.22.0.1:41076",
+					"172.23.0.1:41076",
+					"172.24.0.1:41076",
+					"172.25.0.1:41076",
+					"172.26.0.1:41076",
+					"172.27.0.1:41076"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:26:47.935685625Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4850606547643342,
+				"StableID":   "n52dV7Drse11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dd4e65691316056a84098ba81af4208c614c566a22694d65084822d41d1bf339",
+				"DiscoKey":   "discokey:e3e00787e8a2ad677cfb632dbe719e5713471febb8fb3cea8fb02799aed64543",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42728",
+					"10.65.0.27:42728",
+					"172.17.0.1:42728",
+					"172.18.0.1:42728",
+					"172.19.0.1:42728",
+					"172.20.0.1:42728",
+					"172.21.0.1:42728",
+					"172.22.0.1:42728",
+					"172.23.0.1:42728",
+					"172.24.0.1:42728",
+					"172.25.0.1:42728",
+					"172.26.0.1:42728",
+					"172.27.0.1:42728"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:26:48.476260994Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         648454568615411,
+				"StableID":   "nLTchWog4611CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2b57d1fab7444bf5dab9a10ca383fad7c0ca4cd7aff3465dd79e9cd6f14d77f",
+				"DiscoKey":   "discokey:607988909e98850adf4c13d013b0815fc7594f7cfceefab7351a2e947864c170",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49898",
+					"10.65.0.27:49898",
+					"172.17.0.1:49898",
+					"172.18.0.1:49898",
+					"172.19.0.1:49898",
+					"172.20.0.1:49898",
+					"172.21.0.1:49898",
+					"172.22.0.1:49898",
+					"172.23.0.1:49898",
+					"172.24.0.1:49898",
+					"172.25.0.1:49898",
+					"172.26.0.1:49898",
+					"172.27.0.1:49898"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:26:49.010607278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8000392402528055,
+				"StableID":   "nAzAZ3kPU521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:04bf6c9ab1aadb71cbbd84cd40623055f633397b0e05275318af91fd82868931",
+				"DiscoKey":   "discokey:cefa23898be4a9b12faa7b74ae10597785131a147db84bd977d984e4b22b5267",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48857",
+					"10.65.0.27:48857",
+					"172.17.0.1:48857",
+					"172.18.0.1:48857",
+					"172.19.0.1:48857",
+					"172.20.0.1:48857",
+					"172.21.0.1:48857",
+					"172.22.0.1:48857",
+					"172.23.0.1:48857",
+					"172.24.0.1:48857",
+					"172.25.0.1:48857",
+					"172.26.0.1:48857",
+					"172.27.0.1:48857"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:26:49.559589908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3872874892352138,
+				"StableID":   "n7HcCfr2FX11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bb0b1e2d6305e56a36d3fc3126ad2defd58cb2e80cd01330773b5d4d194c6b1e",
+				"DiscoKey":   "discokey:ffbbd6f2ea536de55895dba0eb5fc0c698a2137c22cf8702f641363083038f49",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39492",
+					"10.65.0.27:39492",
+					"172.17.0.1:39492",
+					"172.18.0.1:39492",
+					"172.19.0.1:39492",
+					"172.20.0.1:39492",
+					"172.21.0.1:39492",
+					"172.22.0.1:39492",
+					"172.23.0.1:39492",
+					"172.24.0.1:39492",
+					"172.25.0.1:39492",
+					"172.26.0.1:39492",
+					"172.27.0.1:39492"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:26:50.088026002Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6493343994844945,
+				"StableID":   "nUrvQt8rhs11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04e296ec0576179648249da90227a94bf11e1deecc7a4de2c5f41c676b404d2b",
+				"KeyExpiry":  "2026-11-09T09:26:50Z",
+				"DiscoKey":   "discokey:76b933c86179621b333b43e7bf1bb84886973c6ca03eeffc6a6f712361f5ce46",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38220",
+					"10.65.0.27:38220",
+					"172.17.0.1:38220",
+					"172.18.0.1:38220",
+					"172.19.0.1:38220",
+					"172.20.0.1:38220",
+					"172.21.0.1:38220",
+					"172.22.0.1:38220",
+					"172.23.0.1:38220",
+					"172.24.0.1:38220",
+					"172.25.0.1:38220",
+					"172.26.0.1:38220",
+					"172.27.0.1:38220"
+				],
+				"HomeDERP": 18,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:26:50.613723105Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1496113877603016,
+				"StableID":   "nRdRAjNbgC11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:0ca2fa43faf6a93e863ff07417d8496270d56033cad4f88a990899845ad87418",
+				"KeyExpiry":  "2026-11-09T09:26:51Z",
+				"DiscoKey":   "discokey:c0ef6602bbddbf283bfe884e9673655c88bfb59dec98eb666002d1d0fd671646",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49007",
+					"10.65.0.27:49007",
+					"172.17.0.1:49007",
+					"172.18.0.1:49007",
+					"172.19.0.1:49007",
+					"172.20.0.1:49007",
+					"172.21.0.1:49007",
+					"172.22.0.1:49007",
+					"172.23.0.1:49007",
+					"172.24.0.1:49007",
+					"172.25.0.1:49007",
+					"172.26.0.1:49007",
+					"172.27.0.1:49007"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:26:51.146399576Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1641192705435100,
+				"StableID":   "nbeyNGMJpD11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:54fb5e0ac9bb3bfeced3d1b6f8f0250beb855298fe37be15afd2b532c333bd24",
+				"KeyExpiry":  "2026-11-09T09:26:51Z",
+				"DiscoKey":   "discokey:e21c2954729dc0ec4daacf8ba6bb199ed78b61ba605db2937a27bf8841cbcf1c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47645",
+					"10.65.0.27:47645",
+					"172.17.0.1:47645",
+					"172.18.0.1:47645",
+					"172.19.0.1:47645",
+					"172.20.0.1:47645",
+					"172.21.0.1:47645",
+					"172.22.0.1:47645",
+					"172.23.0.1:47645",
+					"172.24.0.1:47645",
+					"172.25.0.1:47645",
+					"172.26.0.1:47645",
+					"172.27.0.1:47645"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:26:51.689141853Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7270970070352609": {
+				"ID":          7270970070352609,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1641192705435100,
+				"StableID":   "nbeyNGMJpD11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:54fb5e0ac9bb3bfeced3d1b6f8f0250beb855298fe37be15afd2b532c333bd24",
+				"KeyExpiry":  "2026-11-09T09:26:51Z",
+				"DiscoKey":   "discokey:e21c2954729dc0ec4daacf8ba6bb199ed78b61ba605db2937a27bf8841cbcf1c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47645",
+					"10.65.0.27:47645",
+					"172.17.0.1:47645",
+					"172.18.0.1:47645",
+					"172.19.0.1:47645",
+					"172.20.0.1:47645",
+					"172.21.0.1:47645",
+					"172.22.0.1:47645",
+					"172.23.0.1:47645",
+					"172.24.0.1:47645",
+					"172.25.0.1:47645",
+					"172.26.0.1:47645",
+					"172.27.0.1:47645"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:26:51.689141853Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:54fb5e0ac9bb3bfeced3d1b6f8f0250beb855298fe37be15afd2b532c333bd24",
+			"MachineKey": "mkey:5e82c2509e8f238e4720ff798f2e4a95f116deb009af421239b6cb3433355b26",
+			"Peers": [{
+				"ID":         4073872181115765,
+				"StableID":   "niKsKRi4pY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b2fd2227e6fef920dcfdb9f6d6a0d42f87084effc364c1b744fa7cedf95a428",
+				"DiscoKey":   "discokey:b2d54fb79cbf2a8bd5a81e9b41af84b420fdb150cc7429978e83df6b19e39765",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:39258",
+					"10.65.0.27:39258",
+					"172.17.0.1:39258",
+					"172.18.0.1:39258",
+					"172.19.0.1:39258",
+					"172.20.0.1:39258",
+					"172.21.0.1:39258",
+					"172.22.0.1:39258",
+					"172.23.0.1:39258",
+					"172.24.0.1:39258",
+					"172.25.0.1:39258",
+					"172.26.0.1:39258",
+					"172.27.0.1:39258"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:26:44.000588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8598559577817578,
+				"StableID":   "nM8TWcaJ9A21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47838c310880c867cfeb9afb9db7ced8f4cd1938891cecf346829319db07ef5a",
+				"DiscoKey":   "discokey:68601797acf56fec44fcf8dd0ab187da02b05a2d9b3f92ba81af8b7484e37e12",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:49374",
+					"10.65.0.27:49374",
+					"172.17.0.1:49374",
+					"172.18.0.1:49374",
+					"172.19.0.1:49374",
+					"172.20.0.1:49374",
+					"172.21.0.1:49374",
+					"172.22.0.1:49374",
+					"172.23.0.1:49374",
+					"172.24.0.1:49374",
+					"172.25.0.1:49374",
+					"172.26.0.1:49374",
+					"172.27.0.1:49374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:26:44.478308406Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4243276445468940,
+				"StableID":   "njay4Ggn8a11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c656e7bfd9a437d724205617492efe06e1d4eed75586962cdb3ab9bd152f3506",
+				"DiscoKey":   "discokey:f048658f0714e5620642955ddcd960d2c70b73a7ddba7ebe3f14680cf3c3551f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40353",
+					"10.65.0.27:40353",
+					"172.17.0.1:40353",
+					"172.18.0.1:40353",
+					"172.19.0.1:40353",
+					"172.20.0.1:40353",
+					"172.21.0.1:40353",
+					"172.22.0.1:40353",
+					"172.23.0.1:40353",
+					"172.24.0.1:40353",
+					"172.25.0.1:40353",
+					"172.26.0.1:40353",
+					"172.27.0.1:40353"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:26:45.020203919Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6613494429872618,
+				"StableID":   "nXHNvUHGet11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e23b31364641820a02bf84ae75c2f74bf050eb491036e06b9589eee46625a313",
+				"DiscoKey":   "discokey:c10be57a23131c1477628c58655db1b3a9e396a0c16fb14d282f19971dcb2f0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42128",
+					"10.65.0.27:42128",
+					"172.17.0.1:42128",
+					"172.18.0.1:42128",
+					"172.19.0.1:42128",
+					"172.20.0.1:42128",
+					"172.21.0.1:42128",
+					"172.22.0.1:42128",
+					"172.23.0.1:42128",
+					"172.24.0.1:42128",
+					"172.25.0.1:42128",
+					"172.26.0.1:42128",
+					"172.27.0.1:42128"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:26:45.551366518Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         903866408710325,
+				"StableID":   "ntnmPC3N4811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97624f7f91a2f10b47cf34387e3e55428057bd22642256d082331c143a468333",
+				"DiscoKey":   "discokey:b0b7aaa631a463a7c1bf9ba092e1c4da6a41e0816b9f755a0842331584f80a1f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55472",
+					"10.65.0.27:55472",
+					"172.17.0.1:55472",
+					"172.18.0.1:55472",
+					"172.19.0.1:55472",
+					"172.20.0.1:55472",
+					"172.21.0.1:55472",
+					"172.22.0.1:55472",
+					"172.23.0.1:55472",
+					"172.24.0.1:55472",
+					"172.25.0.1:55472",
+					"172.26.0.1:55472",
+					"172.27.0.1:55472"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:26:46.075189134Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7270970070352609,
+				"StableID":   "nxeHr943ny11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:49cc0e9f5deba8ec8fadecc8c3fb07b06936f07ef415d102b7f4a951f02f2374",
+				"DiscoKey":   "discokey:ea14ab63d3cf23bbc45e630019938965bfafb81a1eca0f91ccc4d44255f42448",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44012",
+					"10.65.0.27:44012",
+					"172.17.0.1:44012",
+					"172.18.0.1:44012",
+					"172.19.0.1:44012",
+					"172.20.0.1:44012",
+					"172.21.0.1:44012",
+					"172.22.0.1:44012",
+					"172.23.0.1:44012",
+					"172.24.0.1:44012",
+					"172.25.0.1:44012",
+					"172.26.0.1:44012",
+					"172.27.0.1:44012"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:26:46.720919897Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8700466115858341,
+				"StableID":   "nEB6KWVTwA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:585bfffa5ac2a6323e7469c2ec38bf68b5ba6e5417def1a435b89cdb226e016f",
+				"DiscoKey":   "discokey:eddcc88f73426a19162116bcb1af08400f8a4dc410f6ab4f913a2bdaf2b3705d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51046",
+					"10.65.0.27:51046",
+					"172.17.0.1:51046",
+					"172.18.0.1:51046",
+					"172.19.0.1:51046",
+					"172.20.0.1:51046",
+					"172.21.0.1:51046",
+					"172.22.0.1:51046",
+					"172.23.0.1:51046",
+					"172.24.0.1:51046",
+					"172.25.0.1:51046",
+					"172.26.0.1:51046",
+					"172.27.0.1:51046"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:26:47.395944594Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         979170825313379,
+				"StableID":   "nNQZp7AUe811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4720f19dfaf5895ce1bb1c8ac02ea32afe6f2af424cec20d8304f6abee01b417",
+				"DiscoKey":   "discokey:d7c02f2d59fa01b134c3917b68a15623829e1e963ae773062b7be5ca262aa63d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:41076",
+					"10.65.0.27:41076",
+					"172.17.0.1:41076",
+					"172.18.0.1:41076",
+					"172.19.0.1:41076",
+					"172.20.0.1:41076",
+					"172.21.0.1:41076",
+					"172.22.0.1:41076",
+					"172.23.0.1:41076",
+					"172.24.0.1:41076",
+					"172.25.0.1:41076",
+					"172.26.0.1:41076",
+					"172.27.0.1:41076"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:26:47.935685625Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4850606547643342,
+				"StableID":   "n52dV7Drse11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dd4e65691316056a84098ba81af4208c614c566a22694d65084822d41d1bf339",
+				"DiscoKey":   "discokey:e3e00787e8a2ad677cfb632dbe719e5713471febb8fb3cea8fb02799aed64543",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42728",
+					"10.65.0.27:42728",
+					"172.17.0.1:42728",
+					"172.18.0.1:42728",
+					"172.19.0.1:42728",
+					"172.20.0.1:42728",
+					"172.21.0.1:42728",
+					"172.22.0.1:42728",
+					"172.23.0.1:42728",
+					"172.24.0.1:42728",
+					"172.25.0.1:42728",
+					"172.26.0.1:42728",
+					"172.27.0.1:42728"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:26:48.476260994Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         648454568615411,
+				"StableID":   "nLTchWog4611CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2b57d1fab7444bf5dab9a10ca383fad7c0ca4cd7aff3465dd79e9cd6f14d77f",
+				"DiscoKey":   "discokey:607988909e98850adf4c13d013b0815fc7594f7cfceefab7351a2e947864c170",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49898",
+					"10.65.0.27:49898",
+					"172.17.0.1:49898",
+					"172.18.0.1:49898",
+					"172.19.0.1:49898",
+					"172.20.0.1:49898",
+					"172.21.0.1:49898",
+					"172.22.0.1:49898",
+					"172.23.0.1:49898",
+					"172.24.0.1:49898",
+					"172.25.0.1:49898",
+					"172.26.0.1:49898",
+					"172.27.0.1:49898"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:26:49.010607278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8000392402528055,
+				"StableID":   "nAzAZ3kPU521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:04bf6c9ab1aadb71cbbd84cd40623055f633397b0e05275318af91fd82868931",
+				"DiscoKey":   "discokey:cefa23898be4a9b12faa7b74ae10597785131a147db84bd977d984e4b22b5267",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48857",
+					"10.65.0.27:48857",
+					"172.17.0.1:48857",
+					"172.18.0.1:48857",
+					"172.19.0.1:48857",
+					"172.20.0.1:48857",
+					"172.21.0.1:48857",
+					"172.22.0.1:48857",
+					"172.23.0.1:48857",
+					"172.24.0.1:48857",
+					"172.25.0.1:48857",
+					"172.26.0.1:48857",
+					"172.27.0.1:48857"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:26:49.559589908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3872874892352138,
+				"StableID":   "n7HcCfr2FX11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bb0b1e2d6305e56a36d3fc3126ad2defd58cb2e80cd01330773b5d4d194c6b1e",
+				"DiscoKey":   "discokey:ffbbd6f2ea536de55895dba0eb5fc0c698a2137c22cf8702f641363083038f49",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39492",
+					"10.65.0.27:39492",
+					"172.17.0.1:39492",
+					"172.18.0.1:39492",
+					"172.19.0.1:39492",
+					"172.20.0.1:39492",
+					"172.21.0.1:39492",
+					"172.22.0.1:39492",
+					"172.23.0.1:39492",
+					"172.24.0.1:39492",
+					"172.25.0.1:39492",
+					"172.26.0.1:39492",
+					"172.27.0.1:39492"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:26:50.088026002Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6493343994844945,
+				"StableID":   "nUrvQt8rhs11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04e296ec0576179648249da90227a94bf11e1deecc7a4de2c5f41c676b404d2b",
+				"KeyExpiry":  "2026-11-09T09:26:50Z",
+				"DiscoKey":   "discokey:76b933c86179621b333b43e7bf1bb84886973c6ca03eeffc6a6f712361f5ce46",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38220",
+					"10.65.0.27:38220",
+					"172.17.0.1:38220",
+					"172.18.0.1:38220",
+					"172.19.0.1:38220",
+					"172.20.0.1:38220",
+					"172.21.0.1:38220",
+					"172.22.0.1:38220",
+					"172.23.0.1:38220",
+					"172.24.0.1:38220",
+					"172.25.0.1:38220",
+					"172.26.0.1:38220",
+					"172.27.0.1:38220"
+				],
+				"HomeDERP": 18,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:26:50.613723105Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1496113877603016,
+				"StableID":   "nRdRAjNbgC11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:0ca2fa43faf6a93e863ff07417d8496270d56033cad4f88a990899845ad87418",
+				"KeyExpiry":  "2026-11-09T09:26:51Z",
+				"DiscoKey":   "discokey:c0ef6602bbddbf283bfe884e9673655c88bfb59dec98eb666002d1d0fd671646",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49007",
+					"10.65.0.27:49007",
+					"172.17.0.1:49007",
+					"172.18.0.1:49007",
+					"172.19.0.1:49007",
+					"172.20.0.1:49007",
+					"172.21.0.1:49007",
+					"172.22.0.1:49007",
+					"172.23.0.1:49007",
+					"172.24.0.1:49007",
+					"172.25.0.1:49007",
+					"172.26.0.1:49007",
+					"172.27.0.1:49007"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:26:51.146399576Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4243276445468940,
+				"StableID":   "njay4Ggn8a11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       4243276445468940,
+				"Key":        "nodekey:c656e7bfd9a437d724205617492efe06e1d4eed75586962cdb3ab9bd152f3506",
+				"DiscoKey":   "discokey:f048658f0714e5620642955ddcd960d2c70b73a7ddba7ebe3f14680cf3c3551f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40353",
+					"10.65.0.27:40353",
+					"172.17.0.1:40353",
+					"172.18.0.1:40353",
+					"172.19.0.1:40353",
+					"172.20.0.1:40353",
+					"172.21.0.1:40353",
+					"172.22.0.1:40353",
+					"172.23.0.1:40353",
+					"172.24.0.1:40353",
+					"172.25.0.1:40353",
+					"172.26.0.1:40353",
+					"172.27.0.1:40353"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:26:45.020203919Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c656e7bfd9a437d724205617492efe06e1d4eed75586962cdb3ab9bd152f3506",
+			"MachineKey": "mkey:86504cd153f9d3c25e25ce8af55c47641b40cf23af9ffbf6c6e7077e8640c714",
+			"Peers": [{
+				"ID":         4073872181115765,
+				"StableID":   "niKsKRi4pY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b2fd2227e6fef920dcfdb9f6d6a0d42f87084effc364c1b744fa7cedf95a428",
+				"DiscoKey":   "discokey:b2d54fb79cbf2a8bd5a81e9b41af84b420fdb150cc7429978e83df6b19e39765",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:39258",
+					"10.65.0.27:39258",
+					"172.17.0.1:39258",
+					"172.18.0.1:39258",
+					"172.19.0.1:39258",
+					"172.20.0.1:39258",
+					"172.21.0.1:39258",
+					"172.22.0.1:39258",
+					"172.23.0.1:39258",
+					"172.24.0.1:39258",
+					"172.25.0.1:39258",
+					"172.26.0.1:39258",
+					"172.27.0.1:39258"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:26:44.000588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8598559577817578,
+				"StableID":   "nM8TWcaJ9A21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47838c310880c867cfeb9afb9db7ced8f4cd1938891cecf346829319db07ef5a",
+				"DiscoKey":   "discokey:68601797acf56fec44fcf8dd0ab187da02b05a2d9b3f92ba81af8b7484e37e12",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:49374",
+					"10.65.0.27:49374",
+					"172.17.0.1:49374",
+					"172.18.0.1:49374",
+					"172.19.0.1:49374",
+					"172.20.0.1:49374",
+					"172.21.0.1:49374",
+					"172.22.0.1:49374",
+					"172.23.0.1:49374",
+					"172.24.0.1:49374",
+					"172.25.0.1:49374",
+					"172.26.0.1:49374",
+					"172.27.0.1:49374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:26:44.478308406Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6613494429872618,
+				"StableID":   "nXHNvUHGet11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e23b31364641820a02bf84ae75c2f74bf050eb491036e06b9589eee46625a313",
+				"DiscoKey":   "discokey:c10be57a23131c1477628c58655db1b3a9e396a0c16fb14d282f19971dcb2f0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42128",
+					"10.65.0.27:42128",
+					"172.17.0.1:42128",
+					"172.18.0.1:42128",
+					"172.19.0.1:42128",
+					"172.20.0.1:42128",
+					"172.21.0.1:42128",
+					"172.22.0.1:42128",
+					"172.23.0.1:42128",
+					"172.24.0.1:42128",
+					"172.25.0.1:42128",
+					"172.26.0.1:42128",
+					"172.27.0.1:42128"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:26:45.551366518Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         903866408710325,
+				"StableID":   "ntnmPC3N4811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97624f7f91a2f10b47cf34387e3e55428057bd22642256d082331c143a468333",
+				"DiscoKey":   "discokey:b0b7aaa631a463a7c1bf9ba092e1c4da6a41e0816b9f755a0842331584f80a1f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55472",
+					"10.65.0.27:55472",
+					"172.17.0.1:55472",
+					"172.18.0.1:55472",
+					"172.19.0.1:55472",
+					"172.20.0.1:55472",
+					"172.21.0.1:55472",
+					"172.22.0.1:55472",
+					"172.23.0.1:55472",
+					"172.24.0.1:55472",
+					"172.25.0.1:55472",
+					"172.26.0.1:55472",
+					"172.27.0.1:55472"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:26:46.075189134Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7270970070352609,
+				"StableID":   "nxeHr943ny11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:49cc0e9f5deba8ec8fadecc8c3fb07b06936f07ef415d102b7f4a951f02f2374",
+				"DiscoKey":   "discokey:ea14ab63d3cf23bbc45e630019938965bfafb81a1eca0f91ccc4d44255f42448",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44012",
+					"10.65.0.27:44012",
+					"172.17.0.1:44012",
+					"172.18.0.1:44012",
+					"172.19.0.1:44012",
+					"172.20.0.1:44012",
+					"172.21.0.1:44012",
+					"172.22.0.1:44012",
+					"172.23.0.1:44012",
+					"172.24.0.1:44012",
+					"172.25.0.1:44012",
+					"172.26.0.1:44012",
+					"172.27.0.1:44012"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:26:46.720919897Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8700466115858341,
+				"StableID":   "nEB6KWVTwA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:585bfffa5ac2a6323e7469c2ec38bf68b5ba6e5417def1a435b89cdb226e016f",
+				"DiscoKey":   "discokey:eddcc88f73426a19162116bcb1af08400f8a4dc410f6ab4f913a2bdaf2b3705d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51046",
+					"10.65.0.27:51046",
+					"172.17.0.1:51046",
+					"172.18.0.1:51046",
+					"172.19.0.1:51046",
+					"172.20.0.1:51046",
+					"172.21.0.1:51046",
+					"172.22.0.1:51046",
+					"172.23.0.1:51046",
+					"172.24.0.1:51046",
+					"172.25.0.1:51046",
+					"172.26.0.1:51046",
+					"172.27.0.1:51046"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:26:47.395944594Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         979170825313379,
+				"StableID":   "nNQZp7AUe811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4720f19dfaf5895ce1bb1c8ac02ea32afe6f2af424cec20d8304f6abee01b417",
+				"DiscoKey":   "discokey:d7c02f2d59fa01b134c3917b68a15623829e1e963ae773062b7be5ca262aa63d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:41076",
+					"10.65.0.27:41076",
+					"172.17.0.1:41076",
+					"172.18.0.1:41076",
+					"172.19.0.1:41076",
+					"172.20.0.1:41076",
+					"172.21.0.1:41076",
+					"172.22.0.1:41076",
+					"172.23.0.1:41076",
+					"172.24.0.1:41076",
+					"172.25.0.1:41076",
+					"172.26.0.1:41076",
+					"172.27.0.1:41076"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:26:47.935685625Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4850606547643342,
+				"StableID":   "n52dV7Drse11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dd4e65691316056a84098ba81af4208c614c566a22694d65084822d41d1bf339",
+				"DiscoKey":   "discokey:e3e00787e8a2ad677cfb632dbe719e5713471febb8fb3cea8fb02799aed64543",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42728",
+					"10.65.0.27:42728",
+					"172.17.0.1:42728",
+					"172.18.0.1:42728",
+					"172.19.0.1:42728",
+					"172.20.0.1:42728",
+					"172.21.0.1:42728",
+					"172.22.0.1:42728",
+					"172.23.0.1:42728",
+					"172.24.0.1:42728",
+					"172.25.0.1:42728",
+					"172.26.0.1:42728",
+					"172.27.0.1:42728"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:26:48.476260994Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         648454568615411,
+				"StableID":   "nLTchWog4611CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2b57d1fab7444bf5dab9a10ca383fad7c0ca4cd7aff3465dd79e9cd6f14d77f",
+				"DiscoKey":   "discokey:607988909e98850adf4c13d013b0815fc7594f7cfceefab7351a2e947864c170",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49898",
+					"10.65.0.27:49898",
+					"172.17.0.1:49898",
+					"172.18.0.1:49898",
+					"172.19.0.1:49898",
+					"172.20.0.1:49898",
+					"172.21.0.1:49898",
+					"172.22.0.1:49898",
+					"172.23.0.1:49898",
+					"172.24.0.1:49898",
+					"172.25.0.1:49898",
+					"172.26.0.1:49898",
+					"172.27.0.1:49898"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:26:49.010607278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8000392402528055,
+				"StableID":   "nAzAZ3kPU521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:04bf6c9ab1aadb71cbbd84cd40623055f633397b0e05275318af91fd82868931",
+				"DiscoKey":   "discokey:cefa23898be4a9b12faa7b74ae10597785131a147db84bd977d984e4b22b5267",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48857",
+					"10.65.0.27:48857",
+					"172.17.0.1:48857",
+					"172.18.0.1:48857",
+					"172.19.0.1:48857",
+					"172.20.0.1:48857",
+					"172.21.0.1:48857",
+					"172.22.0.1:48857",
+					"172.23.0.1:48857",
+					"172.24.0.1:48857",
+					"172.25.0.1:48857",
+					"172.26.0.1:48857",
+					"172.27.0.1:48857"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:26:49.559589908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3872874892352138,
+				"StableID":   "n7HcCfr2FX11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bb0b1e2d6305e56a36d3fc3126ad2defd58cb2e80cd01330773b5d4d194c6b1e",
+				"DiscoKey":   "discokey:ffbbd6f2ea536de55895dba0eb5fc0c698a2137c22cf8702f641363083038f49",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39492",
+					"10.65.0.27:39492",
+					"172.17.0.1:39492",
+					"172.18.0.1:39492",
+					"172.19.0.1:39492",
+					"172.20.0.1:39492",
+					"172.21.0.1:39492",
+					"172.22.0.1:39492",
+					"172.23.0.1:39492",
+					"172.24.0.1:39492",
+					"172.25.0.1:39492",
+					"172.26.0.1:39492",
+					"172.27.0.1:39492"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:26:50.088026002Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6493343994844945,
+				"StableID":   "nUrvQt8rhs11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04e296ec0576179648249da90227a94bf11e1deecc7a4de2c5f41c676b404d2b",
+				"KeyExpiry":  "2026-11-09T09:26:50Z",
+				"DiscoKey":   "discokey:76b933c86179621b333b43e7bf1bb84886973c6ca03eeffc6a6f712361f5ce46",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38220",
+					"10.65.0.27:38220",
+					"172.17.0.1:38220",
+					"172.18.0.1:38220",
+					"172.19.0.1:38220",
+					"172.20.0.1:38220",
+					"172.21.0.1:38220",
+					"172.22.0.1:38220",
+					"172.23.0.1:38220",
+					"172.24.0.1:38220",
+					"172.25.0.1:38220",
+					"172.26.0.1:38220",
+					"172.27.0.1:38220"
+				],
+				"HomeDERP": 18,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:26:50.613723105Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1496113877603016,
+				"StableID":   "nRdRAjNbgC11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:0ca2fa43faf6a93e863ff07417d8496270d56033cad4f88a990899845ad87418",
+				"KeyExpiry":  "2026-11-09T09:26:51Z",
+				"DiscoKey":   "discokey:c0ef6602bbddbf283bfe884e9673655c88bfb59dec98eb666002d1d0fd671646",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49007",
+					"10.65.0.27:49007",
+					"172.17.0.1:49007",
+					"172.18.0.1:49007",
+					"172.19.0.1:49007",
+					"172.20.0.1:49007",
+					"172.21.0.1:49007",
+					"172.22.0.1:49007",
+					"172.23.0.1:49007",
+					"172.24.0.1:49007",
+					"172.25.0.1:49007",
+					"172.26.0.1:49007",
+					"172.27.0.1:49007"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:26:51.146399576Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1641192705435100,
+				"StableID":   "nbeyNGMJpD11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:54fb5e0ac9bb3bfeced3d1b6f8f0250beb855298fe37be15afd2b532c333bd24",
+				"KeyExpiry":  "2026-11-09T09:26:51Z",
+				"DiscoKey":   "discokey:e21c2954729dc0ec4daacf8ba6bb199ed78b61ba605db2937a27bf8841cbcf1c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47645",
+					"10.65.0.27:47645",
+					"172.17.0.1:47645",
+					"172.18.0.1:47645",
+					"172.19.0.1:47645",
+					"172.20.0.1:47645",
+					"172.21.0.1:47645",
+					"172.22.0.1:47645",
+					"172.23.0.1:47645",
+					"172.24.0.1:47645",
+					"172.25.0.1:47645",
+					"172.26.0.1:47645",
+					"172.27.0.1:47645"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:26:51.689141853Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4243276445468940": {
+				"ID":          4243276445468940,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         979170825313379,
+				"StableID":   "nNQZp7AUe811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       979170825313379,
+				"Key":        "nodekey:4720f19dfaf5895ce1bb1c8ac02ea32afe6f2af424cec20d8304f6abee01b417",
+				"DiscoKey":   "discokey:d7c02f2d59fa01b134c3917b68a15623829e1e963ae773062b7be5ca262aa63d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:41076",
+					"10.65.0.27:41076",
+					"172.17.0.1:41076",
+					"172.18.0.1:41076",
+					"172.19.0.1:41076",
+					"172.20.0.1:41076",
+					"172.21.0.1:41076",
+					"172.22.0.1:41076",
+					"172.23.0.1:41076",
+					"172.24.0.1:41076",
+					"172.25.0.1:41076",
+					"172.26.0.1:41076",
+					"172.27.0.1:41076"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:26:47.935685625Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4720f19dfaf5895ce1bb1c8ac02ea32afe6f2af424cec20d8304f6abee01b417",
+			"MachineKey": "mkey:de357f3b201161fe8529a0a046bc2f12fe8300d7ed9d7a61bd293dfa4d657b52",
+			"Peers": [{
+				"ID":         4073872181115765,
+				"StableID":   "niKsKRi4pY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b2fd2227e6fef920dcfdb9f6d6a0d42f87084effc364c1b744fa7cedf95a428",
+				"DiscoKey":   "discokey:b2d54fb79cbf2a8bd5a81e9b41af84b420fdb150cc7429978e83df6b19e39765",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:39258",
+					"10.65.0.27:39258",
+					"172.17.0.1:39258",
+					"172.18.0.1:39258",
+					"172.19.0.1:39258",
+					"172.20.0.1:39258",
+					"172.21.0.1:39258",
+					"172.22.0.1:39258",
+					"172.23.0.1:39258",
+					"172.24.0.1:39258",
+					"172.25.0.1:39258",
+					"172.26.0.1:39258",
+					"172.27.0.1:39258"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:26:44.000588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8598559577817578,
+				"StableID":   "nM8TWcaJ9A21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47838c310880c867cfeb9afb9db7ced8f4cd1938891cecf346829319db07ef5a",
+				"DiscoKey":   "discokey:68601797acf56fec44fcf8dd0ab187da02b05a2d9b3f92ba81af8b7484e37e12",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:49374",
+					"10.65.0.27:49374",
+					"172.17.0.1:49374",
+					"172.18.0.1:49374",
+					"172.19.0.1:49374",
+					"172.20.0.1:49374",
+					"172.21.0.1:49374",
+					"172.22.0.1:49374",
+					"172.23.0.1:49374",
+					"172.24.0.1:49374",
+					"172.25.0.1:49374",
+					"172.26.0.1:49374",
+					"172.27.0.1:49374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:26:44.478308406Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4243276445468940,
+				"StableID":   "njay4Ggn8a11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c656e7bfd9a437d724205617492efe06e1d4eed75586962cdb3ab9bd152f3506",
+				"DiscoKey":   "discokey:f048658f0714e5620642955ddcd960d2c70b73a7ddba7ebe3f14680cf3c3551f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40353",
+					"10.65.0.27:40353",
+					"172.17.0.1:40353",
+					"172.18.0.1:40353",
+					"172.19.0.1:40353",
+					"172.20.0.1:40353",
+					"172.21.0.1:40353",
+					"172.22.0.1:40353",
+					"172.23.0.1:40353",
+					"172.24.0.1:40353",
+					"172.25.0.1:40353",
+					"172.26.0.1:40353",
+					"172.27.0.1:40353"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:26:45.020203919Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6613494429872618,
+				"StableID":   "nXHNvUHGet11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e23b31364641820a02bf84ae75c2f74bf050eb491036e06b9589eee46625a313",
+				"DiscoKey":   "discokey:c10be57a23131c1477628c58655db1b3a9e396a0c16fb14d282f19971dcb2f0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42128",
+					"10.65.0.27:42128",
+					"172.17.0.1:42128",
+					"172.18.0.1:42128",
+					"172.19.0.1:42128",
+					"172.20.0.1:42128",
+					"172.21.0.1:42128",
+					"172.22.0.1:42128",
+					"172.23.0.1:42128",
+					"172.24.0.1:42128",
+					"172.25.0.1:42128",
+					"172.26.0.1:42128",
+					"172.27.0.1:42128"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:26:45.551366518Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         903866408710325,
+				"StableID":   "ntnmPC3N4811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97624f7f91a2f10b47cf34387e3e55428057bd22642256d082331c143a468333",
+				"DiscoKey":   "discokey:b0b7aaa631a463a7c1bf9ba092e1c4da6a41e0816b9f755a0842331584f80a1f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55472",
+					"10.65.0.27:55472",
+					"172.17.0.1:55472",
+					"172.18.0.1:55472",
+					"172.19.0.1:55472",
+					"172.20.0.1:55472",
+					"172.21.0.1:55472",
+					"172.22.0.1:55472",
+					"172.23.0.1:55472",
+					"172.24.0.1:55472",
+					"172.25.0.1:55472",
+					"172.26.0.1:55472",
+					"172.27.0.1:55472"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:26:46.075189134Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7270970070352609,
+				"StableID":   "nxeHr943ny11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:49cc0e9f5deba8ec8fadecc8c3fb07b06936f07ef415d102b7f4a951f02f2374",
+				"DiscoKey":   "discokey:ea14ab63d3cf23bbc45e630019938965bfafb81a1eca0f91ccc4d44255f42448",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44012",
+					"10.65.0.27:44012",
+					"172.17.0.1:44012",
+					"172.18.0.1:44012",
+					"172.19.0.1:44012",
+					"172.20.0.1:44012",
+					"172.21.0.1:44012",
+					"172.22.0.1:44012",
+					"172.23.0.1:44012",
+					"172.24.0.1:44012",
+					"172.25.0.1:44012",
+					"172.26.0.1:44012",
+					"172.27.0.1:44012"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:26:46.720919897Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8700466115858341,
+				"StableID":   "nEB6KWVTwA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:585bfffa5ac2a6323e7469c2ec38bf68b5ba6e5417def1a435b89cdb226e016f",
+				"DiscoKey":   "discokey:eddcc88f73426a19162116bcb1af08400f8a4dc410f6ab4f913a2bdaf2b3705d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51046",
+					"10.65.0.27:51046",
+					"172.17.0.1:51046",
+					"172.18.0.1:51046",
+					"172.19.0.1:51046",
+					"172.20.0.1:51046",
+					"172.21.0.1:51046",
+					"172.22.0.1:51046",
+					"172.23.0.1:51046",
+					"172.24.0.1:51046",
+					"172.25.0.1:51046",
+					"172.26.0.1:51046",
+					"172.27.0.1:51046"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:26:47.395944594Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4850606547643342,
+				"StableID":   "n52dV7Drse11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dd4e65691316056a84098ba81af4208c614c566a22694d65084822d41d1bf339",
+				"DiscoKey":   "discokey:e3e00787e8a2ad677cfb632dbe719e5713471febb8fb3cea8fb02799aed64543",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42728",
+					"10.65.0.27:42728",
+					"172.17.0.1:42728",
+					"172.18.0.1:42728",
+					"172.19.0.1:42728",
+					"172.20.0.1:42728",
+					"172.21.0.1:42728",
+					"172.22.0.1:42728",
+					"172.23.0.1:42728",
+					"172.24.0.1:42728",
+					"172.25.0.1:42728",
+					"172.26.0.1:42728",
+					"172.27.0.1:42728"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:26:48.476260994Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         648454568615411,
+				"StableID":   "nLTchWog4611CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2b57d1fab7444bf5dab9a10ca383fad7c0ca4cd7aff3465dd79e9cd6f14d77f",
+				"DiscoKey":   "discokey:607988909e98850adf4c13d013b0815fc7594f7cfceefab7351a2e947864c170",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49898",
+					"10.65.0.27:49898",
+					"172.17.0.1:49898",
+					"172.18.0.1:49898",
+					"172.19.0.1:49898",
+					"172.20.0.1:49898",
+					"172.21.0.1:49898",
+					"172.22.0.1:49898",
+					"172.23.0.1:49898",
+					"172.24.0.1:49898",
+					"172.25.0.1:49898",
+					"172.26.0.1:49898",
+					"172.27.0.1:49898"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:26:49.010607278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8000392402528055,
+				"StableID":   "nAzAZ3kPU521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:04bf6c9ab1aadb71cbbd84cd40623055f633397b0e05275318af91fd82868931",
+				"DiscoKey":   "discokey:cefa23898be4a9b12faa7b74ae10597785131a147db84bd977d984e4b22b5267",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48857",
+					"10.65.0.27:48857",
+					"172.17.0.1:48857",
+					"172.18.0.1:48857",
+					"172.19.0.1:48857",
+					"172.20.0.1:48857",
+					"172.21.0.1:48857",
+					"172.22.0.1:48857",
+					"172.23.0.1:48857",
+					"172.24.0.1:48857",
+					"172.25.0.1:48857",
+					"172.26.0.1:48857",
+					"172.27.0.1:48857"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:26:49.559589908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3872874892352138,
+				"StableID":   "n7HcCfr2FX11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bb0b1e2d6305e56a36d3fc3126ad2defd58cb2e80cd01330773b5d4d194c6b1e",
+				"DiscoKey":   "discokey:ffbbd6f2ea536de55895dba0eb5fc0c698a2137c22cf8702f641363083038f49",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39492",
+					"10.65.0.27:39492",
+					"172.17.0.1:39492",
+					"172.18.0.1:39492",
+					"172.19.0.1:39492",
+					"172.20.0.1:39492",
+					"172.21.0.1:39492",
+					"172.22.0.1:39492",
+					"172.23.0.1:39492",
+					"172.24.0.1:39492",
+					"172.25.0.1:39492",
+					"172.26.0.1:39492",
+					"172.27.0.1:39492"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:26:50.088026002Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6493343994844945,
+				"StableID":   "nUrvQt8rhs11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04e296ec0576179648249da90227a94bf11e1deecc7a4de2c5f41c676b404d2b",
+				"KeyExpiry":  "2026-11-09T09:26:50Z",
+				"DiscoKey":   "discokey:76b933c86179621b333b43e7bf1bb84886973c6ca03eeffc6a6f712361f5ce46",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38220",
+					"10.65.0.27:38220",
+					"172.17.0.1:38220",
+					"172.18.0.1:38220",
+					"172.19.0.1:38220",
+					"172.20.0.1:38220",
+					"172.21.0.1:38220",
+					"172.22.0.1:38220",
+					"172.23.0.1:38220",
+					"172.24.0.1:38220",
+					"172.25.0.1:38220",
+					"172.26.0.1:38220",
+					"172.27.0.1:38220"
+				],
+				"HomeDERP": 18,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:26:50.613723105Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1496113877603016,
+				"StableID":   "nRdRAjNbgC11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:0ca2fa43faf6a93e863ff07417d8496270d56033cad4f88a990899845ad87418",
+				"KeyExpiry":  "2026-11-09T09:26:51Z",
+				"DiscoKey":   "discokey:c0ef6602bbddbf283bfe884e9673655c88bfb59dec98eb666002d1d0fd671646",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49007",
+					"10.65.0.27:49007",
+					"172.17.0.1:49007",
+					"172.18.0.1:49007",
+					"172.19.0.1:49007",
+					"172.20.0.1:49007",
+					"172.21.0.1:49007",
+					"172.22.0.1:49007",
+					"172.23.0.1:49007",
+					"172.24.0.1:49007",
+					"172.25.0.1:49007",
+					"172.26.0.1:49007",
+					"172.27.0.1:49007"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:26:51.146399576Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1641192705435100,
+				"StableID":   "nbeyNGMJpD11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:54fb5e0ac9bb3bfeced3d1b6f8f0250beb855298fe37be15afd2b532c333bd24",
+				"KeyExpiry":  "2026-11-09T09:26:51Z",
+				"DiscoKey":   "discokey:e21c2954729dc0ec4daacf8ba6bb199ed78b61ba605db2937a27bf8841cbcf1c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47645",
+					"10.65.0.27:47645",
+					"172.17.0.1:47645",
+					"172.18.0.1:47645",
+					"172.19.0.1:47645",
+					"172.20.0.1:47645",
+					"172.21.0.1:47645",
+					"172.22.0.1:47645",
+					"172.23.0.1:47645",
+					"172.24.0.1:47645",
+					"172.25.0.1:47645",
+					"172.26.0.1:47645",
+					"172.27.0.1:47645"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:26:51.689141853Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "979170825313379": {
+				"ID":          979170825313379,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6493343994844945,
+				"StableID":   "nUrvQt8rhs11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04e296ec0576179648249da90227a94bf11e1deecc7a4de2c5f41c676b404d2b",
+				"KeyExpiry":  "2026-11-09T09:26:50Z",
+				"DiscoKey":   "discokey:76b933c86179621b333b43e7bf1bb84886973c6ca03eeffc6a6f712361f5ce46",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38220",
+					"10.65.0.27:38220",
+					"172.17.0.1:38220",
+					"172.18.0.1:38220",
+					"172.19.0.1:38220",
+					"172.20.0.1:38220",
+					"172.21.0.1:38220",
+					"172.22.0.1:38220",
+					"172.23.0.1:38220",
+					"172.24.0.1:38220",
+					"172.25.0.1:38220",
+					"172.26.0.1:38220",
+					"172.27.0.1:38220"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:26:50.613723105Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:04e296ec0576179648249da90227a94bf11e1deecc7a4de2c5f41c676b404d2b",
+			"MachineKey": "mkey:0eec570666a5b676a78effcf91c26530de5e86a266e7fd484347d5abbe31800c",
+			"Peers": [{
+				"ID":         4073872181115765,
+				"StableID":   "niKsKRi4pY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b2fd2227e6fef920dcfdb9f6d6a0d42f87084effc364c1b744fa7cedf95a428",
+				"DiscoKey":   "discokey:b2d54fb79cbf2a8bd5a81e9b41af84b420fdb150cc7429978e83df6b19e39765",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:39258",
+					"10.65.0.27:39258",
+					"172.17.0.1:39258",
+					"172.18.0.1:39258",
+					"172.19.0.1:39258",
+					"172.20.0.1:39258",
+					"172.21.0.1:39258",
+					"172.22.0.1:39258",
+					"172.23.0.1:39258",
+					"172.24.0.1:39258",
+					"172.25.0.1:39258",
+					"172.26.0.1:39258",
+					"172.27.0.1:39258"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:26:44.000588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8598559577817578,
+				"StableID":   "nM8TWcaJ9A21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47838c310880c867cfeb9afb9db7ced8f4cd1938891cecf346829319db07ef5a",
+				"DiscoKey":   "discokey:68601797acf56fec44fcf8dd0ab187da02b05a2d9b3f92ba81af8b7484e37e12",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:49374",
+					"10.65.0.27:49374",
+					"172.17.0.1:49374",
+					"172.18.0.1:49374",
+					"172.19.0.1:49374",
+					"172.20.0.1:49374",
+					"172.21.0.1:49374",
+					"172.22.0.1:49374",
+					"172.23.0.1:49374",
+					"172.24.0.1:49374",
+					"172.25.0.1:49374",
+					"172.26.0.1:49374",
+					"172.27.0.1:49374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:26:44.478308406Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4243276445468940,
+				"StableID":   "njay4Ggn8a11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c656e7bfd9a437d724205617492efe06e1d4eed75586962cdb3ab9bd152f3506",
+				"DiscoKey":   "discokey:f048658f0714e5620642955ddcd960d2c70b73a7ddba7ebe3f14680cf3c3551f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40353",
+					"10.65.0.27:40353",
+					"172.17.0.1:40353",
+					"172.18.0.1:40353",
+					"172.19.0.1:40353",
+					"172.20.0.1:40353",
+					"172.21.0.1:40353",
+					"172.22.0.1:40353",
+					"172.23.0.1:40353",
+					"172.24.0.1:40353",
+					"172.25.0.1:40353",
+					"172.26.0.1:40353",
+					"172.27.0.1:40353"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:26:45.020203919Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6613494429872618,
+				"StableID":   "nXHNvUHGet11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e23b31364641820a02bf84ae75c2f74bf050eb491036e06b9589eee46625a313",
+				"DiscoKey":   "discokey:c10be57a23131c1477628c58655db1b3a9e396a0c16fb14d282f19971dcb2f0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42128",
+					"10.65.0.27:42128",
+					"172.17.0.1:42128",
+					"172.18.0.1:42128",
+					"172.19.0.1:42128",
+					"172.20.0.1:42128",
+					"172.21.0.1:42128",
+					"172.22.0.1:42128",
+					"172.23.0.1:42128",
+					"172.24.0.1:42128",
+					"172.25.0.1:42128",
+					"172.26.0.1:42128",
+					"172.27.0.1:42128"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:26:45.551366518Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         903866408710325,
+				"StableID":   "ntnmPC3N4811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97624f7f91a2f10b47cf34387e3e55428057bd22642256d082331c143a468333",
+				"DiscoKey":   "discokey:b0b7aaa631a463a7c1bf9ba092e1c4da6a41e0816b9f755a0842331584f80a1f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55472",
+					"10.65.0.27:55472",
+					"172.17.0.1:55472",
+					"172.18.0.1:55472",
+					"172.19.0.1:55472",
+					"172.20.0.1:55472",
+					"172.21.0.1:55472",
+					"172.22.0.1:55472",
+					"172.23.0.1:55472",
+					"172.24.0.1:55472",
+					"172.25.0.1:55472",
+					"172.26.0.1:55472",
+					"172.27.0.1:55472"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:26:46.075189134Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7270970070352609,
+				"StableID":   "nxeHr943ny11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:49cc0e9f5deba8ec8fadecc8c3fb07b06936f07ef415d102b7f4a951f02f2374",
+				"DiscoKey":   "discokey:ea14ab63d3cf23bbc45e630019938965bfafb81a1eca0f91ccc4d44255f42448",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44012",
+					"10.65.0.27:44012",
+					"172.17.0.1:44012",
+					"172.18.0.1:44012",
+					"172.19.0.1:44012",
+					"172.20.0.1:44012",
+					"172.21.0.1:44012",
+					"172.22.0.1:44012",
+					"172.23.0.1:44012",
+					"172.24.0.1:44012",
+					"172.25.0.1:44012",
+					"172.26.0.1:44012",
+					"172.27.0.1:44012"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:26:46.720919897Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8700466115858341,
+				"StableID":   "nEB6KWVTwA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:585bfffa5ac2a6323e7469c2ec38bf68b5ba6e5417def1a435b89cdb226e016f",
+				"DiscoKey":   "discokey:eddcc88f73426a19162116bcb1af08400f8a4dc410f6ab4f913a2bdaf2b3705d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51046",
+					"10.65.0.27:51046",
+					"172.17.0.1:51046",
+					"172.18.0.1:51046",
+					"172.19.0.1:51046",
+					"172.20.0.1:51046",
+					"172.21.0.1:51046",
+					"172.22.0.1:51046",
+					"172.23.0.1:51046",
+					"172.24.0.1:51046",
+					"172.25.0.1:51046",
+					"172.26.0.1:51046",
+					"172.27.0.1:51046"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:26:47.395944594Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         979170825313379,
+				"StableID":   "nNQZp7AUe811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4720f19dfaf5895ce1bb1c8ac02ea32afe6f2af424cec20d8304f6abee01b417",
+				"DiscoKey":   "discokey:d7c02f2d59fa01b134c3917b68a15623829e1e963ae773062b7be5ca262aa63d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:41076",
+					"10.65.0.27:41076",
+					"172.17.0.1:41076",
+					"172.18.0.1:41076",
+					"172.19.0.1:41076",
+					"172.20.0.1:41076",
+					"172.21.0.1:41076",
+					"172.22.0.1:41076",
+					"172.23.0.1:41076",
+					"172.24.0.1:41076",
+					"172.25.0.1:41076",
+					"172.26.0.1:41076",
+					"172.27.0.1:41076"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:26:47.935685625Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4850606547643342,
+				"StableID":   "n52dV7Drse11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dd4e65691316056a84098ba81af4208c614c566a22694d65084822d41d1bf339",
+				"DiscoKey":   "discokey:e3e00787e8a2ad677cfb632dbe719e5713471febb8fb3cea8fb02799aed64543",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42728",
+					"10.65.0.27:42728",
+					"172.17.0.1:42728",
+					"172.18.0.1:42728",
+					"172.19.0.1:42728",
+					"172.20.0.1:42728",
+					"172.21.0.1:42728",
+					"172.22.0.1:42728",
+					"172.23.0.1:42728",
+					"172.24.0.1:42728",
+					"172.25.0.1:42728",
+					"172.26.0.1:42728",
+					"172.27.0.1:42728"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:26:48.476260994Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         648454568615411,
+				"StableID":   "nLTchWog4611CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2b57d1fab7444bf5dab9a10ca383fad7c0ca4cd7aff3465dd79e9cd6f14d77f",
+				"DiscoKey":   "discokey:607988909e98850adf4c13d013b0815fc7594f7cfceefab7351a2e947864c170",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49898",
+					"10.65.0.27:49898",
+					"172.17.0.1:49898",
+					"172.18.0.1:49898",
+					"172.19.0.1:49898",
+					"172.20.0.1:49898",
+					"172.21.0.1:49898",
+					"172.22.0.1:49898",
+					"172.23.0.1:49898",
+					"172.24.0.1:49898",
+					"172.25.0.1:49898",
+					"172.26.0.1:49898",
+					"172.27.0.1:49898"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:26:49.010607278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8000392402528055,
+				"StableID":   "nAzAZ3kPU521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:04bf6c9ab1aadb71cbbd84cd40623055f633397b0e05275318af91fd82868931",
+				"DiscoKey":   "discokey:cefa23898be4a9b12faa7b74ae10597785131a147db84bd977d984e4b22b5267",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48857",
+					"10.65.0.27:48857",
+					"172.17.0.1:48857",
+					"172.18.0.1:48857",
+					"172.19.0.1:48857",
+					"172.20.0.1:48857",
+					"172.21.0.1:48857",
+					"172.22.0.1:48857",
+					"172.23.0.1:48857",
+					"172.24.0.1:48857",
+					"172.25.0.1:48857",
+					"172.26.0.1:48857",
+					"172.27.0.1:48857"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:26:49.559589908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3872874892352138,
+				"StableID":   "n7HcCfr2FX11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bb0b1e2d6305e56a36d3fc3126ad2defd58cb2e80cd01330773b5d4d194c6b1e",
+				"DiscoKey":   "discokey:ffbbd6f2ea536de55895dba0eb5fc0c698a2137c22cf8702f641363083038f49",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39492",
+					"10.65.0.27:39492",
+					"172.17.0.1:39492",
+					"172.18.0.1:39492",
+					"172.19.0.1:39492",
+					"172.20.0.1:39492",
+					"172.21.0.1:39492",
+					"172.22.0.1:39492",
+					"172.23.0.1:39492",
+					"172.24.0.1:39492",
+					"172.25.0.1:39492",
+					"172.26.0.1:39492",
+					"172.27.0.1:39492"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:26:50.088026002Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1496113877603016,
+				"StableID":   "nRdRAjNbgC11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:0ca2fa43faf6a93e863ff07417d8496270d56033cad4f88a990899845ad87418",
+				"KeyExpiry":  "2026-11-09T09:26:51Z",
+				"DiscoKey":   "discokey:c0ef6602bbddbf283bfe884e9673655c88bfb59dec98eb666002d1d0fd671646",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49007",
+					"10.65.0.27:49007",
+					"172.17.0.1:49007",
+					"172.18.0.1:49007",
+					"172.19.0.1:49007",
+					"172.20.0.1:49007",
+					"172.21.0.1:49007",
+					"172.22.0.1:49007",
+					"172.23.0.1:49007",
+					"172.24.0.1:49007",
+					"172.25.0.1:49007",
+					"172.26.0.1:49007",
+					"172.27.0.1:49007"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:26:51.146399576Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1641192705435100,
+				"StableID":   "nbeyNGMJpD11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:54fb5e0ac9bb3bfeced3d1b6f8f0250beb855298fe37be15afd2b532c333bd24",
+				"KeyExpiry":  "2026-11-09T09:26:51Z",
+				"DiscoKey":   "discokey:e21c2954729dc0ec4daacf8ba6bb199ed78b61ba605db2937a27bf8841cbcf1c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47645",
+					"10.65.0.27:47645",
+					"172.17.0.1:47645",
+					"172.18.0.1:47645",
+					"172.19.0.1:47645",
+					"172.20.0.1:47645",
+					"172.21.0.1:47645",
+					"172.22.0.1:47645",
+					"172.23.0.1:47645",
+					"172.24.0.1:47645",
+					"172.25.0.1:47645",
+					"172.26.0.1:47645",
+					"172.27.0.1:47645"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:26:51.689141853Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8000392402528055,
+				"StableID":   "nAzAZ3kPU521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       8000392402528055,
+				"Key":        "nodekey:04bf6c9ab1aadb71cbbd84cd40623055f633397b0e05275318af91fd82868931",
+				"DiscoKey":   "discokey:cefa23898be4a9b12faa7b74ae10597785131a147db84bd977d984e4b22b5267",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48857",
+					"10.65.0.27:48857",
+					"172.17.0.1:48857",
+					"172.18.0.1:48857",
+					"172.19.0.1:48857",
+					"172.20.0.1:48857",
+					"172.21.0.1:48857",
+					"172.22.0.1:48857",
+					"172.23.0.1:48857",
+					"172.24.0.1:48857",
+					"172.25.0.1:48857",
+					"172.26.0.1:48857",
+					"172.27.0.1:48857"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:26:49.559589908Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:04bf6c9ab1aadb71cbbd84cd40623055f633397b0e05275318af91fd82868931",
+			"MachineKey": "mkey:3f9e5c9249adb6b0cdb1342e3cd1775bc1cbc2aaf1495a45dae37e7c9847314d",
+			"Peers": [{
+				"ID":         4073872181115765,
+				"StableID":   "niKsKRi4pY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b2fd2227e6fef920dcfdb9f6d6a0d42f87084effc364c1b744fa7cedf95a428",
+				"DiscoKey":   "discokey:b2d54fb79cbf2a8bd5a81e9b41af84b420fdb150cc7429978e83df6b19e39765",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:39258",
+					"10.65.0.27:39258",
+					"172.17.0.1:39258",
+					"172.18.0.1:39258",
+					"172.19.0.1:39258",
+					"172.20.0.1:39258",
+					"172.21.0.1:39258",
+					"172.22.0.1:39258",
+					"172.23.0.1:39258",
+					"172.24.0.1:39258",
+					"172.25.0.1:39258",
+					"172.26.0.1:39258",
+					"172.27.0.1:39258"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:26:44.000588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8598559577817578,
+				"StableID":   "nM8TWcaJ9A21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47838c310880c867cfeb9afb9db7ced8f4cd1938891cecf346829319db07ef5a",
+				"DiscoKey":   "discokey:68601797acf56fec44fcf8dd0ab187da02b05a2d9b3f92ba81af8b7484e37e12",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:49374",
+					"10.65.0.27:49374",
+					"172.17.0.1:49374",
+					"172.18.0.1:49374",
+					"172.19.0.1:49374",
+					"172.20.0.1:49374",
+					"172.21.0.1:49374",
+					"172.22.0.1:49374",
+					"172.23.0.1:49374",
+					"172.24.0.1:49374",
+					"172.25.0.1:49374",
+					"172.26.0.1:49374",
+					"172.27.0.1:49374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:26:44.478308406Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4243276445468940,
+				"StableID":   "njay4Ggn8a11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c656e7bfd9a437d724205617492efe06e1d4eed75586962cdb3ab9bd152f3506",
+				"DiscoKey":   "discokey:f048658f0714e5620642955ddcd960d2c70b73a7ddba7ebe3f14680cf3c3551f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40353",
+					"10.65.0.27:40353",
+					"172.17.0.1:40353",
+					"172.18.0.1:40353",
+					"172.19.0.1:40353",
+					"172.20.0.1:40353",
+					"172.21.0.1:40353",
+					"172.22.0.1:40353",
+					"172.23.0.1:40353",
+					"172.24.0.1:40353",
+					"172.25.0.1:40353",
+					"172.26.0.1:40353",
+					"172.27.0.1:40353"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:26:45.020203919Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6613494429872618,
+				"StableID":   "nXHNvUHGet11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e23b31364641820a02bf84ae75c2f74bf050eb491036e06b9589eee46625a313",
+				"DiscoKey":   "discokey:c10be57a23131c1477628c58655db1b3a9e396a0c16fb14d282f19971dcb2f0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42128",
+					"10.65.0.27:42128",
+					"172.17.0.1:42128",
+					"172.18.0.1:42128",
+					"172.19.0.1:42128",
+					"172.20.0.1:42128",
+					"172.21.0.1:42128",
+					"172.22.0.1:42128",
+					"172.23.0.1:42128",
+					"172.24.0.1:42128",
+					"172.25.0.1:42128",
+					"172.26.0.1:42128",
+					"172.27.0.1:42128"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:26:45.551366518Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         903866408710325,
+				"StableID":   "ntnmPC3N4811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97624f7f91a2f10b47cf34387e3e55428057bd22642256d082331c143a468333",
+				"DiscoKey":   "discokey:b0b7aaa631a463a7c1bf9ba092e1c4da6a41e0816b9f755a0842331584f80a1f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55472",
+					"10.65.0.27:55472",
+					"172.17.0.1:55472",
+					"172.18.0.1:55472",
+					"172.19.0.1:55472",
+					"172.20.0.1:55472",
+					"172.21.0.1:55472",
+					"172.22.0.1:55472",
+					"172.23.0.1:55472",
+					"172.24.0.1:55472",
+					"172.25.0.1:55472",
+					"172.26.0.1:55472",
+					"172.27.0.1:55472"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:26:46.075189134Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7270970070352609,
+				"StableID":   "nxeHr943ny11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:49cc0e9f5deba8ec8fadecc8c3fb07b06936f07ef415d102b7f4a951f02f2374",
+				"DiscoKey":   "discokey:ea14ab63d3cf23bbc45e630019938965bfafb81a1eca0f91ccc4d44255f42448",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44012",
+					"10.65.0.27:44012",
+					"172.17.0.1:44012",
+					"172.18.0.1:44012",
+					"172.19.0.1:44012",
+					"172.20.0.1:44012",
+					"172.21.0.1:44012",
+					"172.22.0.1:44012",
+					"172.23.0.1:44012",
+					"172.24.0.1:44012",
+					"172.25.0.1:44012",
+					"172.26.0.1:44012",
+					"172.27.0.1:44012"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:26:46.720919897Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8700466115858341,
+				"StableID":   "nEB6KWVTwA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:585bfffa5ac2a6323e7469c2ec38bf68b5ba6e5417def1a435b89cdb226e016f",
+				"DiscoKey":   "discokey:eddcc88f73426a19162116bcb1af08400f8a4dc410f6ab4f913a2bdaf2b3705d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51046",
+					"10.65.0.27:51046",
+					"172.17.0.1:51046",
+					"172.18.0.1:51046",
+					"172.19.0.1:51046",
+					"172.20.0.1:51046",
+					"172.21.0.1:51046",
+					"172.22.0.1:51046",
+					"172.23.0.1:51046",
+					"172.24.0.1:51046",
+					"172.25.0.1:51046",
+					"172.26.0.1:51046",
+					"172.27.0.1:51046"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:26:47.395944594Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         979170825313379,
+				"StableID":   "nNQZp7AUe811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4720f19dfaf5895ce1bb1c8ac02ea32afe6f2af424cec20d8304f6abee01b417",
+				"DiscoKey":   "discokey:d7c02f2d59fa01b134c3917b68a15623829e1e963ae773062b7be5ca262aa63d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:41076",
+					"10.65.0.27:41076",
+					"172.17.0.1:41076",
+					"172.18.0.1:41076",
+					"172.19.0.1:41076",
+					"172.20.0.1:41076",
+					"172.21.0.1:41076",
+					"172.22.0.1:41076",
+					"172.23.0.1:41076",
+					"172.24.0.1:41076",
+					"172.25.0.1:41076",
+					"172.26.0.1:41076",
+					"172.27.0.1:41076"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:26:47.935685625Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4850606547643342,
+				"StableID":   "n52dV7Drse11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dd4e65691316056a84098ba81af4208c614c566a22694d65084822d41d1bf339",
+				"DiscoKey":   "discokey:e3e00787e8a2ad677cfb632dbe719e5713471febb8fb3cea8fb02799aed64543",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42728",
+					"10.65.0.27:42728",
+					"172.17.0.1:42728",
+					"172.18.0.1:42728",
+					"172.19.0.1:42728",
+					"172.20.0.1:42728",
+					"172.21.0.1:42728",
+					"172.22.0.1:42728",
+					"172.23.0.1:42728",
+					"172.24.0.1:42728",
+					"172.25.0.1:42728",
+					"172.26.0.1:42728",
+					"172.27.0.1:42728"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:26:48.476260994Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         648454568615411,
+				"StableID":   "nLTchWog4611CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2b57d1fab7444bf5dab9a10ca383fad7c0ca4cd7aff3465dd79e9cd6f14d77f",
+				"DiscoKey":   "discokey:607988909e98850adf4c13d013b0815fc7594f7cfceefab7351a2e947864c170",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49898",
+					"10.65.0.27:49898",
+					"172.17.0.1:49898",
+					"172.18.0.1:49898",
+					"172.19.0.1:49898",
+					"172.20.0.1:49898",
+					"172.21.0.1:49898",
+					"172.22.0.1:49898",
+					"172.23.0.1:49898",
+					"172.24.0.1:49898",
+					"172.25.0.1:49898",
+					"172.26.0.1:49898",
+					"172.27.0.1:49898"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:26:49.010607278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3872874892352138,
+				"StableID":   "n7HcCfr2FX11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bb0b1e2d6305e56a36d3fc3126ad2defd58cb2e80cd01330773b5d4d194c6b1e",
+				"DiscoKey":   "discokey:ffbbd6f2ea536de55895dba0eb5fc0c698a2137c22cf8702f641363083038f49",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39492",
+					"10.65.0.27:39492",
+					"172.17.0.1:39492",
+					"172.18.0.1:39492",
+					"172.19.0.1:39492",
+					"172.20.0.1:39492",
+					"172.21.0.1:39492",
+					"172.22.0.1:39492",
+					"172.23.0.1:39492",
+					"172.24.0.1:39492",
+					"172.25.0.1:39492",
+					"172.26.0.1:39492",
+					"172.27.0.1:39492"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:26:50.088026002Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6493343994844945,
+				"StableID":   "nUrvQt8rhs11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04e296ec0576179648249da90227a94bf11e1deecc7a4de2c5f41c676b404d2b",
+				"KeyExpiry":  "2026-11-09T09:26:50Z",
+				"DiscoKey":   "discokey:76b933c86179621b333b43e7bf1bb84886973c6ca03eeffc6a6f712361f5ce46",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38220",
+					"10.65.0.27:38220",
+					"172.17.0.1:38220",
+					"172.18.0.1:38220",
+					"172.19.0.1:38220",
+					"172.20.0.1:38220",
+					"172.21.0.1:38220",
+					"172.22.0.1:38220",
+					"172.23.0.1:38220",
+					"172.24.0.1:38220",
+					"172.25.0.1:38220",
+					"172.26.0.1:38220",
+					"172.27.0.1:38220"
+				],
+				"HomeDERP": 18,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:26:50.613723105Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1496113877603016,
+				"StableID":   "nRdRAjNbgC11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:0ca2fa43faf6a93e863ff07417d8496270d56033cad4f88a990899845ad87418",
+				"KeyExpiry":  "2026-11-09T09:26:51Z",
+				"DiscoKey":   "discokey:c0ef6602bbddbf283bfe884e9673655c88bfb59dec98eb666002d1d0fd671646",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49007",
+					"10.65.0.27:49007",
+					"172.17.0.1:49007",
+					"172.18.0.1:49007",
+					"172.19.0.1:49007",
+					"172.20.0.1:49007",
+					"172.21.0.1:49007",
+					"172.22.0.1:49007",
+					"172.23.0.1:49007",
+					"172.24.0.1:49007",
+					"172.25.0.1:49007",
+					"172.26.0.1:49007",
+					"172.27.0.1:49007"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:26:51.146399576Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1641192705435100,
+				"StableID":   "nbeyNGMJpD11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:54fb5e0ac9bb3bfeced3d1b6f8f0250beb855298fe37be15afd2b532c333bd24",
+				"KeyExpiry":  "2026-11-09T09:26:51Z",
+				"DiscoKey":   "discokey:e21c2954729dc0ec4daacf8ba6bb199ed78b61ba605db2937a27bf8841cbcf1c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47645",
+					"10.65.0.27:47645",
+					"172.17.0.1:47645",
+					"172.18.0.1:47645",
+					"172.19.0.1:47645",
+					"172.20.0.1:47645",
+					"172.21.0.1:47645",
+					"172.22.0.1:47645",
+					"172.23.0.1:47645",
+					"172.24.0.1:47645",
+					"172.25.0.1:47645",
+					"172.26.0.1:47645",
+					"172.27.0.1:47645"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:26:51.689141853Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8000392402528055": {
+				"ID":          8000392402528055,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8598559577817578,
+				"StableID":   "nM8TWcaJ9A21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       8598559577817578,
+				"Key":        "nodekey:47838c310880c867cfeb9afb9db7ced8f4cd1938891cecf346829319db07ef5a",
+				"DiscoKey":   "discokey:68601797acf56fec44fcf8dd0ab187da02b05a2d9b3f92ba81af8b7484e37e12",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:49374",
+					"10.65.0.27:49374",
+					"172.17.0.1:49374",
+					"172.18.0.1:49374",
+					"172.19.0.1:49374",
+					"172.20.0.1:49374",
+					"172.21.0.1:49374",
+					"172.22.0.1:49374",
+					"172.23.0.1:49374",
+					"172.24.0.1:49374",
+					"172.25.0.1:49374",
+					"172.26.0.1:49374",
+					"172.27.0.1:49374"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:26:44.478308406Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:47838c310880c867cfeb9afb9db7ced8f4cd1938891cecf346829319db07ef5a",
+			"MachineKey": "mkey:cfcf8d4a3fc4be290db0b6ea8dc9685d1416909039d2da4c5593ef5abadd8f05",
+			"Peers": [{
+				"ID":         4073872181115765,
+				"StableID":   "niKsKRi4pY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b2fd2227e6fef920dcfdb9f6d6a0d42f87084effc364c1b744fa7cedf95a428",
+				"DiscoKey":   "discokey:b2d54fb79cbf2a8bd5a81e9b41af84b420fdb150cc7429978e83df6b19e39765",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:39258",
+					"10.65.0.27:39258",
+					"172.17.0.1:39258",
+					"172.18.0.1:39258",
+					"172.19.0.1:39258",
+					"172.20.0.1:39258",
+					"172.21.0.1:39258",
+					"172.22.0.1:39258",
+					"172.23.0.1:39258",
+					"172.24.0.1:39258",
+					"172.25.0.1:39258",
+					"172.26.0.1:39258",
+					"172.27.0.1:39258"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:26:44.000588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4243276445468940,
+				"StableID":   "njay4Ggn8a11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c656e7bfd9a437d724205617492efe06e1d4eed75586962cdb3ab9bd152f3506",
+				"DiscoKey":   "discokey:f048658f0714e5620642955ddcd960d2c70b73a7ddba7ebe3f14680cf3c3551f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40353",
+					"10.65.0.27:40353",
+					"172.17.0.1:40353",
+					"172.18.0.1:40353",
+					"172.19.0.1:40353",
+					"172.20.0.1:40353",
+					"172.21.0.1:40353",
+					"172.22.0.1:40353",
+					"172.23.0.1:40353",
+					"172.24.0.1:40353",
+					"172.25.0.1:40353",
+					"172.26.0.1:40353",
+					"172.27.0.1:40353"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:26:45.020203919Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6613494429872618,
+				"StableID":   "nXHNvUHGet11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e23b31364641820a02bf84ae75c2f74bf050eb491036e06b9589eee46625a313",
+				"DiscoKey":   "discokey:c10be57a23131c1477628c58655db1b3a9e396a0c16fb14d282f19971dcb2f0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42128",
+					"10.65.0.27:42128",
+					"172.17.0.1:42128",
+					"172.18.0.1:42128",
+					"172.19.0.1:42128",
+					"172.20.0.1:42128",
+					"172.21.0.1:42128",
+					"172.22.0.1:42128",
+					"172.23.0.1:42128",
+					"172.24.0.1:42128",
+					"172.25.0.1:42128",
+					"172.26.0.1:42128",
+					"172.27.0.1:42128"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:26:45.551366518Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         903866408710325,
+				"StableID":   "ntnmPC3N4811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97624f7f91a2f10b47cf34387e3e55428057bd22642256d082331c143a468333",
+				"DiscoKey":   "discokey:b0b7aaa631a463a7c1bf9ba092e1c4da6a41e0816b9f755a0842331584f80a1f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55472",
+					"10.65.0.27:55472",
+					"172.17.0.1:55472",
+					"172.18.0.1:55472",
+					"172.19.0.1:55472",
+					"172.20.0.1:55472",
+					"172.21.0.1:55472",
+					"172.22.0.1:55472",
+					"172.23.0.1:55472",
+					"172.24.0.1:55472",
+					"172.25.0.1:55472",
+					"172.26.0.1:55472",
+					"172.27.0.1:55472"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:26:46.075189134Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7270970070352609,
+				"StableID":   "nxeHr943ny11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:49cc0e9f5deba8ec8fadecc8c3fb07b06936f07ef415d102b7f4a951f02f2374",
+				"DiscoKey":   "discokey:ea14ab63d3cf23bbc45e630019938965bfafb81a1eca0f91ccc4d44255f42448",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44012",
+					"10.65.0.27:44012",
+					"172.17.0.1:44012",
+					"172.18.0.1:44012",
+					"172.19.0.1:44012",
+					"172.20.0.1:44012",
+					"172.21.0.1:44012",
+					"172.22.0.1:44012",
+					"172.23.0.1:44012",
+					"172.24.0.1:44012",
+					"172.25.0.1:44012",
+					"172.26.0.1:44012",
+					"172.27.0.1:44012"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:26:46.720919897Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8700466115858341,
+				"StableID":   "nEB6KWVTwA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:585bfffa5ac2a6323e7469c2ec38bf68b5ba6e5417def1a435b89cdb226e016f",
+				"DiscoKey":   "discokey:eddcc88f73426a19162116bcb1af08400f8a4dc410f6ab4f913a2bdaf2b3705d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51046",
+					"10.65.0.27:51046",
+					"172.17.0.1:51046",
+					"172.18.0.1:51046",
+					"172.19.0.1:51046",
+					"172.20.0.1:51046",
+					"172.21.0.1:51046",
+					"172.22.0.1:51046",
+					"172.23.0.1:51046",
+					"172.24.0.1:51046",
+					"172.25.0.1:51046",
+					"172.26.0.1:51046",
+					"172.27.0.1:51046"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:26:47.395944594Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         979170825313379,
+				"StableID":   "nNQZp7AUe811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4720f19dfaf5895ce1bb1c8ac02ea32afe6f2af424cec20d8304f6abee01b417",
+				"DiscoKey":   "discokey:d7c02f2d59fa01b134c3917b68a15623829e1e963ae773062b7be5ca262aa63d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:41076",
+					"10.65.0.27:41076",
+					"172.17.0.1:41076",
+					"172.18.0.1:41076",
+					"172.19.0.1:41076",
+					"172.20.0.1:41076",
+					"172.21.0.1:41076",
+					"172.22.0.1:41076",
+					"172.23.0.1:41076",
+					"172.24.0.1:41076",
+					"172.25.0.1:41076",
+					"172.26.0.1:41076",
+					"172.27.0.1:41076"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:26:47.935685625Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4850606547643342,
+				"StableID":   "n52dV7Drse11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dd4e65691316056a84098ba81af4208c614c566a22694d65084822d41d1bf339",
+				"DiscoKey":   "discokey:e3e00787e8a2ad677cfb632dbe719e5713471febb8fb3cea8fb02799aed64543",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42728",
+					"10.65.0.27:42728",
+					"172.17.0.1:42728",
+					"172.18.0.1:42728",
+					"172.19.0.1:42728",
+					"172.20.0.1:42728",
+					"172.21.0.1:42728",
+					"172.22.0.1:42728",
+					"172.23.0.1:42728",
+					"172.24.0.1:42728",
+					"172.25.0.1:42728",
+					"172.26.0.1:42728",
+					"172.27.0.1:42728"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:26:48.476260994Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         648454568615411,
+				"StableID":   "nLTchWog4611CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2b57d1fab7444bf5dab9a10ca383fad7c0ca4cd7aff3465dd79e9cd6f14d77f",
+				"DiscoKey":   "discokey:607988909e98850adf4c13d013b0815fc7594f7cfceefab7351a2e947864c170",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49898",
+					"10.65.0.27:49898",
+					"172.17.0.1:49898",
+					"172.18.0.1:49898",
+					"172.19.0.1:49898",
+					"172.20.0.1:49898",
+					"172.21.0.1:49898",
+					"172.22.0.1:49898",
+					"172.23.0.1:49898",
+					"172.24.0.1:49898",
+					"172.25.0.1:49898",
+					"172.26.0.1:49898",
+					"172.27.0.1:49898"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:26:49.010607278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8000392402528055,
+				"StableID":   "nAzAZ3kPU521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:04bf6c9ab1aadb71cbbd84cd40623055f633397b0e05275318af91fd82868931",
+				"DiscoKey":   "discokey:cefa23898be4a9b12faa7b74ae10597785131a147db84bd977d984e4b22b5267",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48857",
+					"10.65.0.27:48857",
+					"172.17.0.1:48857",
+					"172.18.0.1:48857",
+					"172.19.0.1:48857",
+					"172.20.0.1:48857",
+					"172.21.0.1:48857",
+					"172.22.0.1:48857",
+					"172.23.0.1:48857",
+					"172.24.0.1:48857",
+					"172.25.0.1:48857",
+					"172.26.0.1:48857",
+					"172.27.0.1:48857"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:26:49.559589908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3872874892352138,
+				"StableID":   "n7HcCfr2FX11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bb0b1e2d6305e56a36d3fc3126ad2defd58cb2e80cd01330773b5d4d194c6b1e",
+				"DiscoKey":   "discokey:ffbbd6f2ea536de55895dba0eb5fc0c698a2137c22cf8702f641363083038f49",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39492",
+					"10.65.0.27:39492",
+					"172.17.0.1:39492",
+					"172.18.0.1:39492",
+					"172.19.0.1:39492",
+					"172.20.0.1:39492",
+					"172.21.0.1:39492",
+					"172.22.0.1:39492",
+					"172.23.0.1:39492",
+					"172.24.0.1:39492",
+					"172.25.0.1:39492",
+					"172.26.0.1:39492",
+					"172.27.0.1:39492"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:26:50.088026002Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6493343994844945,
+				"StableID":   "nUrvQt8rhs11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04e296ec0576179648249da90227a94bf11e1deecc7a4de2c5f41c676b404d2b",
+				"KeyExpiry":  "2026-11-09T09:26:50Z",
+				"DiscoKey":   "discokey:76b933c86179621b333b43e7bf1bb84886973c6ca03eeffc6a6f712361f5ce46",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38220",
+					"10.65.0.27:38220",
+					"172.17.0.1:38220",
+					"172.18.0.1:38220",
+					"172.19.0.1:38220",
+					"172.20.0.1:38220",
+					"172.21.0.1:38220",
+					"172.22.0.1:38220",
+					"172.23.0.1:38220",
+					"172.24.0.1:38220",
+					"172.25.0.1:38220",
+					"172.26.0.1:38220",
+					"172.27.0.1:38220"
+				],
+				"HomeDERP": 18,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:26:50.613723105Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1496113877603016,
+				"StableID":   "nRdRAjNbgC11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:0ca2fa43faf6a93e863ff07417d8496270d56033cad4f88a990899845ad87418",
+				"KeyExpiry":  "2026-11-09T09:26:51Z",
+				"DiscoKey":   "discokey:c0ef6602bbddbf283bfe884e9673655c88bfb59dec98eb666002d1d0fd671646",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49007",
+					"10.65.0.27:49007",
+					"172.17.0.1:49007",
+					"172.18.0.1:49007",
+					"172.19.0.1:49007",
+					"172.20.0.1:49007",
+					"172.21.0.1:49007",
+					"172.22.0.1:49007",
+					"172.23.0.1:49007",
+					"172.24.0.1:49007",
+					"172.25.0.1:49007",
+					"172.26.0.1:49007",
+					"172.27.0.1:49007"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:26:51.146399576Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1641192705435100,
+				"StableID":   "nbeyNGMJpD11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:54fb5e0ac9bb3bfeced3d1b6f8f0250beb855298fe37be15afd2b532c333bd24",
+				"KeyExpiry":  "2026-11-09T09:26:51Z",
+				"DiscoKey":   "discokey:e21c2954729dc0ec4daacf8ba6bb199ed78b61ba605db2937a27bf8841cbcf1c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47645",
+					"10.65.0.27:47645",
+					"172.17.0.1:47645",
+					"172.18.0.1:47645",
+					"172.19.0.1:47645",
+					"172.20.0.1:47645",
+					"172.21.0.1:47645",
+					"172.22.0.1:47645",
+					"172.23.0.1:47645",
+					"172.24.0.1:47645",
+					"172.25.0.1:47645",
+					"172.26.0.1:47645",
+					"172.27.0.1:47645"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:26:51.689141853Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8598559577817578": {
+				"ID":          8598559577817578,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4073872181115765,
+				"StableID":   "niKsKRi4pY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       4073872181115765,
+				"Key":        "nodekey:0b2fd2227e6fef920dcfdb9f6d6a0d42f87084effc364c1b744fa7cedf95a428",
+				"DiscoKey":   "discokey:b2d54fb79cbf2a8bd5a81e9b41af84b420fdb150cc7429978e83df6b19e39765",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:39258",
+					"10.65.0.27:39258",
+					"172.17.0.1:39258",
+					"172.18.0.1:39258",
+					"172.19.0.1:39258",
+					"172.20.0.1:39258",
+					"172.21.0.1:39258",
+					"172.22.0.1:39258",
+					"172.23.0.1:39258",
+					"172.24.0.1:39258",
+					"172.25.0.1:39258",
+					"172.26.0.1:39258",
+					"172.27.0.1:39258"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:26:44.000588Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0b2fd2227e6fef920dcfdb9f6d6a0d42f87084effc364c1b744fa7cedf95a428",
+			"MachineKey": "mkey:160d94b495d6cfe4b28dc12de5d2c45ce45acf1f983041865d8d2da4136c696f",
+			"Peers": [{
+				"ID":         8598559577817578,
+				"StableID":   "nM8TWcaJ9A21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47838c310880c867cfeb9afb9db7ced8f4cd1938891cecf346829319db07ef5a",
+				"DiscoKey":   "discokey:68601797acf56fec44fcf8dd0ab187da02b05a2d9b3f92ba81af8b7484e37e12",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:49374",
+					"10.65.0.27:49374",
+					"172.17.0.1:49374",
+					"172.18.0.1:49374",
+					"172.19.0.1:49374",
+					"172.20.0.1:49374",
+					"172.21.0.1:49374",
+					"172.22.0.1:49374",
+					"172.23.0.1:49374",
+					"172.24.0.1:49374",
+					"172.25.0.1:49374",
+					"172.26.0.1:49374",
+					"172.27.0.1:49374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:26:44.478308406Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4243276445468940,
+				"StableID":   "njay4Ggn8a11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c656e7bfd9a437d724205617492efe06e1d4eed75586962cdb3ab9bd152f3506",
+				"DiscoKey":   "discokey:f048658f0714e5620642955ddcd960d2c70b73a7ddba7ebe3f14680cf3c3551f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40353",
+					"10.65.0.27:40353",
+					"172.17.0.1:40353",
+					"172.18.0.1:40353",
+					"172.19.0.1:40353",
+					"172.20.0.1:40353",
+					"172.21.0.1:40353",
+					"172.22.0.1:40353",
+					"172.23.0.1:40353",
+					"172.24.0.1:40353",
+					"172.25.0.1:40353",
+					"172.26.0.1:40353",
+					"172.27.0.1:40353"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:26:45.020203919Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6613494429872618,
+				"StableID":   "nXHNvUHGet11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e23b31364641820a02bf84ae75c2f74bf050eb491036e06b9589eee46625a313",
+				"DiscoKey":   "discokey:c10be57a23131c1477628c58655db1b3a9e396a0c16fb14d282f19971dcb2f0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42128",
+					"10.65.0.27:42128",
+					"172.17.0.1:42128",
+					"172.18.0.1:42128",
+					"172.19.0.1:42128",
+					"172.20.0.1:42128",
+					"172.21.0.1:42128",
+					"172.22.0.1:42128",
+					"172.23.0.1:42128",
+					"172.24.0.1:42128",
+					"172.25.0.1:42128",
+					"172.26.0.1:42128",
+					"172.27.0.1:42128"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:26:45.551366518Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         903866408710325,
+				"StableID":   "ntnmPC3N4811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97624f7f91a2f10b47cf34387e3e55428057bd22642256d082331c143a468333",
+				"DiscoKey":   "discokey:b0b7aaa631a463a7c1bf9ba092e1c4da6a41e0816b9f755a0842331584f80a1f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55472",
+					"10.65.0.27:55472",
+					"172.17.0.1:55472",
+					"172.18.0.1:55472",
+					"172.19.0.1:55472",
+					"172.20.0.1:55472",
+					"172.21.0.1:55472",
+					"172.22.0.1:55472",
+					"172.23.0.1:55472",
+					"172.24.0.1:55472",
+					"172.25.0.1:55472",
+					"172.26.0.1:55472",
+					"172.27.0.1:55472"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:26:46.075189134Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7270970070352609,
+				"StableID":   "nxeHr943ny11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:49cc0e9f5deba8ec8fadecc8c3fb07b06936f07ef415d102b7f4a951f02f2374",
+				"DiscoKey":   "discokey:ea14ab63d3cf23bbc45e630019938965bfafb81a1eca0f91ccc4d44255f42448",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44012",
+					"10.65.0.27:44012",
+					"172.17.0.1:44012",
+					"172.18.0.1:44012",
+					"172.19.0.1:44012",
+					"172.20.0.1:44012",
+					"172.21.0.1:44012",
+					"172.22.0.1:44012",
+					"172.23.0.1:44012",
+					"172.24.0.1:44012",
+					"172.25.0.1:44012",
+					"172.26.0.1:44012",
+					"172.27.0.1:44012"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:26:46.720919897Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8700466115858341,
+				"StableID":   "nEB6KWVTwA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:585bfffa5ac2a6323e7469c2ec38bf68b5ba6e5417def1a435b89cdb226e016f",
+				"DiscoKey":   "discokey:eddcc88f73426a19162116bcb1af08400f8a4dc410f6ab4f913a2bdaf2b3705d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51046",
+					"10.65.0.27:51046",
+					"172.17.0.1:51046",
+					"172.18.0.1:51046",
+					"172.19.0.1:51046",
+					"172.20.0.1:51046",
+					"172.21.0.1:51046",
+					"172.22.0.1:51046",
+					"172.23.0.1:51046",
+					"172.24.0.1:51046",
+					"172.25.0.1:51046",
+					"172.26.0.1:51046",
+					"172.27.0.1:51046"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:26:47.395944594Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         979170825313379,
+				"StableID":   "nNQZp7AUe811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4720f19dfaf5895ce1bb1c8ac02ea32afe6f2af424cec20d8304f6abee01b417",
+				"DiscoKey":   "discokey:d7c02f2d59fa01b134c3917b68a15623829e1e963ae773062b7be5ca262aa63d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:41076",
+					"10.65.0.27:41076",
+					"172.17.0.1:41076",
+					"172.18.0.1:41076",
+					"172.19.0.1:41076",
+					"172.20.0.1:41076",
+					"172.21.0.1:41076",
+					"172.22.0.1:41076",
+					"172.23.0.1:41076",
+					"172.24.0.1:41076",
+					"172.25.0.1:41076",
+					"172.26.0.1:41076",
+					"172.27.0.1:41076"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:26:47.935685625Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4850606547643342,
+				"StableID":   "n52dV7Drse11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dd4e65691316056a84098ba81af4208c614c566a22694d65084822d41d1bf339",
+				"DiscoKey":   "discokey:e3e00787e8a2ad677cfb632dbe719e5713471febb8fb3cea8fb02799aed64543",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42728",
+					"10.65.0.27:42728",
+					"172.17.0.1:42728",
+					"172.18.0.1:42728",
+					"172.19.0.1:42728",
+					"172.20.0.1:42728",
+					"172.21.0.1:42728",
+					"172.22.0.1:42728",
+					"172.23.0.1:42728",
+					"172.24.0.1:42728",
+					"172.25.0.1:42728",
+					"172.26.0.1:42728",
+					"172.27.0.1:42728"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:26:48.476260994Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         648454568615411,
+				"StableID":   "nLTchWog4611CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2b57d1fab7444bf5dab9a10ca383fad7c0ca4cd7aff3465dd79e9cd6f14d77f",
+				"DiscoKey":   "discokey:607988909e98850adf4c13d013b0815fc7594f7cfceefab7351a2e947864c170",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49898",
+					"10.65.0.27:49898",
+					"172.17.0.1:49898",
+					"172.18.0.1:49898",
+					"172.19.0.1:49898",
+					"172.20.0.1:49898",
+					"172.21.0.1:49898",
+					"172.22.0.1:49898",
+					"172.23.0.1:49898",
+					"172.24.0.1:49898",
+					"172.25.0.1:49898",
+					"172.26.0.1:49898",
+					"172.27.0.1:49898"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:26:49.010607278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8000392402528055,
+				"StableID":   "nAzAZ3kPU521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:04bf6c9ab1aadb71cbbd84cd40623055f633397b0e05275318af91fd82868931",
+				"DiscoKey":   "discokey:cefa23898be4a9b12faa7b74ae10597785131a147db84bd977d984e4b22b5267",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48857",
+					"10.65.0.27:48857",
+					"172.17.0.1:48857",
+					"172.18.0.1:48857",
+					"172.19.0.1:48857",
+					"172.20.0.1:48857",
+					"172.21.0.1:48857",
+					"172.22.0.1:48857",
+					"172.23.0.1:48857",
+					"172.24.0.1:48857",
+					"172.25.0.1:48857",
+					"172.26.0.1:48857",
+					"172.27.0.1:48857"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:26:49.559589908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3872874892352138,
+				"StableID":   "n7HcCfr2FX11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bb0b1e2d6305e56a36d3fc3126ad2defd58cb2e80cd01330773b5d4d194c6b1e",
+				"DiscoKey":   "discokey:ffbbd6f2ea536de55895dba0eb5fc0c698a2137c22cf8702f641363083038f49",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39492",
+					"10.65.0.27:39492",
+					"172.17.0.1:39492",
+					"172.18.0.1:39492",
+					"172.19.0.1:39492",
+					"172.20.0.1:39492",
+					"172.21.0.1:39492",
+					"172.22.0.1:39492",
+					"172.23.0.1:39492",
+					"172.24.0.1:39492",
+					"172.25.0.1:39492",
+					"172.26.0.1:39492",
+					"172.27.0.1:39492"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:26:50.088026002Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6493343994844945,
+				"StableID":   "nUrvQt8rhs11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04e296ec0576179648249da90227a94bf11e1deecc7a4de2c5f41c676b404d2b",
+				"KeyExpiry":  "2026-11-09T09:26:50Z",
+				"DiscoKey":   "discokey:76b933c86179621b333b43e7bf1bb84886973c6ca03eeffc6a6f712361f5ce46",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38220",
+					"10.65.0.27:38220",
+					"172.17.0.1:38220",
+					"172.18.0.1:38220",
+					"172.19.0.1:38220",
+					"172.20.0.1:38220",
+					"172.21.0.1:38220",
+					"172.22.0.1:38220",
+					"172.23.0.1:38220",
+					"172.24.0.1:38220",
+					"172.25.0.1:38220",
+					"172.26.0.1:38220",
+					"172.27.0.1:38220"
+				],
+				"HomeDERP": 18,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:26:50.613723105Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1496113877603016,
+				"StableID":   "nRdRAjNbgC11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:0ca2fa43faf6a93e863ff07417d8496270d56033cad4f88a990899845ad87418",
+				"KeyExpiry":  "2026-11-09T09:26:51Z",
+				"DiscoKey":   "discokey:c0ef6602bbddbf283bfe884e9673655c88bfb59dec98eb666002d1d0fd671646",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49007",
+					"10.65.0.27:49007",
+					"172.17.0.1:49007",
+					"172.18.0.1:49007",
+					"172.19.0.1:49007",
+					"172.20.0.1:49007",
+					"172.21.0.1:49007",
+					"172.22.0.1:49007",
+					"172.23.0.1:49007",
+					"172.24.0.1:49007",
+					"172.25.0.1:49007",
+					"172.26.0.1:49007",
+					"172.27.0.1:49007"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:26:51.146399576Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1641192705435100,
+				"StableID":   "nbeyNGMJpD11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:54fb5e0ac9bb3bfeced3d1b6f8f0250beb855298fe37be15afd2b532c333bd24",
+				"KeyExpiry":  "2026-11-09T09:26:51Z",
+				"DiscoKey":   "discokey:e21c2954729dc0ec4daacf8ba6bb199ed78b61ba605db2937a27bf8841cbcf1c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47645",
+					"10.65.0.27:47645",
+					"172.17.0.1:47645",
+					"172.18.0.1:47645",
+					"172.19.0.1:47645",
+					"172.20.0.1:47645",
+					"172.21.0.1:47645",
+					"172.22.0.1:47645",
+					"172.23.0.1:47645",
+					"172.24.0.1:47645",
+					"172.25.0.1:47645",
+					"172.26.0.1:47645",
+					"172.27.0.1:47645"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:26:51.689141853Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4073872181115765": {
+				"ID":          4073872181115765,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         903866408710325,
+				"StableID":   "ntnmPC3N4811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       903866408710325,
+				"Key":        "nodekey:97624f7f91a2f10b47cf34387e3e55428057bd22642256d082331c143a468333",
+				"DiscoKey":   "discokey:b0b7aaa631a463a7c1bf9ba092e1c4da6a41e0816b9f755a0842331584f80a1f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55472",
+					"10.65.0.27:55472",
+					"172.17.0.1:55472",
+					"172.18.0.1:55472",
+					"172.19.0.1:55472",
+					"172.20.0.1:55472",
+					"172.21.0.1:55472",
+					"172.22.0.1:55472",
+					"172.23.0.1:55472",
+					"172.24.0.1:55472",
+					"172.25.0.1:55472",
+					"172.26.0.1:55472",
+					"172.27.0.1:55472"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:26:46.075189134Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:97624f7f91a2f10b47cf34387e3e55428057bd22642256d082331c143a468333",
+			"MachineKey": "mkey:751713041bf0dd3dc18606d058e98ede29a49eaac27940de3e3c3bf2c8a90c1d",
+			"Peers": [{
+				"ID":         4073872181115765,
+				"StableID":   "niKsKRi4pY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b2fd2227e6fef920dcfdb9f6d6a0d42f87084effc364c1b744fa7cedf95a428",
+				"DiscoKey":   "discokey:b2d54fb79cbf2a8bd5a81e9b41af84b420fdb150cc7429978e83df6b19e39765",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:39258",
+					"10.65.0.27:39258",
+					"172.17.0.1:39258",
+					"172.18.0.1:39258",
+					"172.19.0.1:39258",
+					"172.20.0.1:39258",
+					"172.21.0.1:39258",
+					"172.22.0.1:39258",
+					"172.23.0.1:39258",
+					"172.24.0.1:39258",
+					"172.25.0.1:39258",
+					"172.26.0.1:39258",
+					"172.27.0.1:39258"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:26:44.000588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8598559577817578,
+				"StableID":   "nM8TWcaJ9A21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47838c310880c867cfeb9afb9db7ced8f4cd1938891cecf346829319db07ef5a",
+				"DiscoKey":   "discokey:68601797acf56fec44fcf8dd0ab187da02b05a2d9b3f92ba81af8b7484e37e12",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:49374",
+					"10.65.0.27:49374",
+					"172.17.0.1:49374",
+					"172.18.0.1:49374",
+					"172.19.0.1:49374",
+					"172.20.0.1:49374",
+					"172.21.0.1:49374",
+					"172.22.0.1:49374",
+					"172.23.0.1:49374",
+					"172.24.0.1:49374",
+					"172.25.0.1:49374",
+					"172.26.0.1:49374",
+					"172.27.0.1:49374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:26:44.478308406Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4243276445468940,
+				"StableID":   "njay4Ggn8a11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c656e7bfd9a437d724205617492efe06e1d4eed75586962cdb3ab9bd152f3506",
+				"DiscoKey":   "discokey:f048658f0714e5620642955ddcd960d2c70b73a7ddba7ebe3f14680cf3c3551f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40353",
+					"10.65.0.27:40353",
+					"172.17.0.1:40353",
+					"172.18.0.1:40353",
+					"172.19.0.1:40353",
+					"172.20.0.1:40353",
+					"172.21.0.1:40353",
+					"172.22.0.1:40353",
+					"172.23.0.1:40353",
+					"172.24.0.1:40353",
+					"172.25.0.1:40353",
+					"172.26.0.1:40353",
+					"172.27.0.1:40353"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:26:45.020203919Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6613494429872618,
+				"StableID":   "nXHNvUHGet11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e23b31364641820a02bf84ae75c2f74bf050eb491036e06b9589eee46625a313",
+				"DiscoKey":   "discokey:c10be57a23131c1477628c58655db1b3a9e396a0c16fb14d282f19971dcb2f0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42128",
+					"10.65.0.27:42128",
+					"172.17.0.1:42128",
+					"172.18.0.1:42128",
+					"172.19.0.1:42128",
+					"172.20.0.1:42128",
+					"172.21.0.1:42128",
+					"172.22.0.1:42128",
+					"172.23.0.1:42128",
+					"172.24.0.1:42128",
+					"172.25.0.1:42128",
+					"172.26.0.1:42128",
+					"172.27.0.1:42128"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:26:45.551366518Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7270970070352609,
+				"StableID":   "nxeHr943ny11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:49cc0e9f5deba8ec8fadecc8c3fb07b06936f07ef415d102b7f4a951f02f2374",
+				"DiscoKey":   "discokey:ea14ab63d3cf23bbc45e630019938965bfafb81a1eca0f91ccc4d44255f42448",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44012",
+					"10.65.0.27:44012",
+					"172.17.0.1:44012",
+					"172.18.0.1:44012",
+					"172.19.0.1:44012",
+					"172.20.0.1:44012",
+					"172.21.0.1:44012",
+					"172.22.0.1:44012",
+					"172.23.0.1:44012",
+					"172.24.0.1:44012",
+					"172.25.0.1:44012",
+					"172.26.0.1:44012",
+					"172.27.0.1:44012"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:26:46.720919897Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8700466115858341,
+				"StableID":   "nEB6KWVTwA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:585bfffa5ac2a6323e7469c2ec38bf68b5ba6e5417def1a435b89cdb226e016f",
+				"DiscoKey":   "discokey:eddcc88f73426a19162116bcb1af08400f8a4dc410f6ab4f913a2bdaf2b3705d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51046",
+					"10.65.0.27:51046",
+					"172.17.0.1:51046",
+					"172.18.0.1:51046",
+					"172.19.0.1:51046",
+					"172.20.0.1:51046",
+					"172.21.0.1:51046",
+					"172.22.0.1:51046",
+					"172.23.0.1:51046",
+					"172.24.0.1:51046",
+					"172.25.0.1:51046",
+					"172.26.0.1:51046",
+					"172.27.0.1:51046"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:26:47.395944594Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         979170825313379,
+				"StableID":   "nNQZp7AUe811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4720f19dfaf5895ce1bb1c8ac02ea32afe6f2af424cec20d8304f6abee01b417",
+				"DiscoKey":   "discokey:d7c02f2d59fa01b134c3917b68a15623829e1e963ae773062b7be5ca262aa63d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:41076",
+					"10.65.0.27:41076",
+					"172.17.0.1:41076",
+					"172.18.0.1:41076",
+					"172.19.0.1:41076",
+					"172.20.0.1:41076",
+					"172.21.0.1:41076",
+					"172.22.0.1:41076",
+					"172.23.0.1:41076",
+					"172.24.0.1:41076",
+					"172.25.0.1:41076",
+					"172.26.0.1:41076",
+					"172.27.0.1:41076"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:26:47.935685625Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4850606547643342,
+				"StableID":   "n52dV7Drse11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dd4e65691316056a84098ba81af4208c614c566a22694d65084822d41d1bf339",
+				"DiscoKey":   "discokey:e3e00787e8a2ad677cfb632dbe719e5713471febb8fb3cea8fb02799aed64543",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42728",
+					"10.65.0.27:42728",
+					"172.17.0.1:42728",
+					"172.18.0.1:42728",
+					"172.19.0.1:42728",
+					"172.20.0.1:42728",
+					"172.21.0.1:42728",
+					"172.22.0.1:42728",
+					"172.23.0.1:42728",
+					"172.24.0.1:42728",
+					"172.25.0.1:42728",
+					"172.26.0.1:42728",
+					"172.27.0.1:42728"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:26:48.476260994Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         648454568615411,
+				"StableID":   "nLTchWog4611CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2b57d1fab7444bf5dab9a10ca383fad7c0ca4cd7aff3465dd79e9cd6f14d77f",
+				"DiscoKey":   "discokey:607988909e98850adf4c13d013b0815fc7594f7cfceefab7351a2e947864c170",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49898",
+					"10.65.0.27:49898",
+					"172.17.0.1:49898",
+					"172.18.0.1:49898",
+					"172.19.0.1:49898",
+					"172.20.0.1:49898",
+					"172.21.0.1:49898",
+					"172.22.0.1:49898",
+					"172.23.0.1:49898",
+					"172.24.0.1:49898",
+					"172.25.0.1:49898",
+					"172.26.0.1:49898",
+					"172.27.0.1:49898"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:26:49.010607278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8000392402528055,
+				"StableID":   "nAzAZ3kPU521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:04bf6c9ab1aadb71cbbd84cd40623055f633397b0e05275318af91fd82868931",
+				"DiscoKey":   "discokey:cefa23898be4a9b12faa7b74ae10597785131a147db84bd977d984e4b22b5267",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48857",
+					"10.65.0.27:48857",
+					"172.17.0.1:48857",
+					"172.18.0.1:48857",
+					"172.19.0.1:48857",
+					"172.20.0.1:48857",
+					"172.21.0.1:48857",
+					"172.22.0.1:48857",
+					"172.23.0.1:48857",
+					"172.24.0.1:48857",
+					"172.25.0.1:48857",
+					"172.26.0.1:48857",
+					"172.27.0.1:48857"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:26:49.559589908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3872874892352138,
+				"StableID":   "n7HcCfr2FX11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bb0b1e2d6305e56a36d3fc3126ad2defd58cb2e80cd01330773b5d4d194c6b1e",
+				"DiscoKey":   "discokey:ffbbd6f2ea536de55895dba0eb5fc0c698a2137c22cf8702f641363083038f49",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39492",
+					"10.65.0.27:39492",
+					"172.17.0.1:39492",
+					"172.18.0.1:39492",
+					"172.19.0.1:39492",
+					"172.20.0.1:39492",
+					"172.21.0.1:39492",
+					"172.22.0.1:39492",
+					"172.23.0.1:39492",
+					"172.24.0.1:39492",
+					"172.25.0.1:39492",
+					"172.26.0.1:39492",
+					"172.27.0.1:39492"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:26:50.088026002Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6493343994844945,
+				"StableID":   "nUrvQt8rhs11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04e296ec0576179648249da90227a94bf11e1deecc7a4de2c5f41c676b404d2b",
+				"KeyExpiry":  "2026-11-09T09:26:50Z",
+				"DiscoKey":   "discokey:76b933c86179621b333b43e7bf1bb84886973c6ca03eeffc6a6f712361f5ce46",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38220",
+					"10.65.0.27:38220",
+					"172.17.0.1:38220",
+					"172.18.0.1:38220",
+					"172.19.0.1:38220",
+					"172.20.0.1:38220",
+					"172.21.0.1:38220",
+					"172.22.0.1:38220",
+					"172.23.0.1:38220",
+					"172.24.0.1:38220",
+					"172.25.0.1:38220",
+					"172.26.0.1:38220",
+					"172.27.0.1:38220"
+				],
+				"HomeDERP": 18,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:26:50.613723105Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1496113877603016,
+				"StableID":   "nRdRAjNbgC11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:0ca2fa43faf6a93e863ff07417d8496270d56033cad4f88a990899845ad87418",
+				"KeyExpiry":  "2026-11-09T09:26:51Z",
+				"DiscoKey":   "discokey:c0ef6602bbddbf283bfe884e9673655c88bfb59dec98eb666002d1d0fd671646",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49007",
+					"10.65.0.27:49007",
+					"172.17.0.1:49007",
+					"172.18.0.1:49007",
+					"172.19.0.1:49007",
+					"172.20.0.1:49007",
+					"172.21.0.1:49007",
+					"172.22.0.1:49007",
+					"172.23.0.1:49007",
+					"172.24.0.1:49007",
+					"172.25.0.1:49007",
+					"172.26.0.1:49007",
+					"172.27.0.1:49007"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:26:51.146399576Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1641192705435100,
+				"StableID":   "nbeyNGMJpD11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:54fb5e0ac9bb3bfeced3d1b6f8f0250beb855298fe37be15afd2b532c333bd24",
+				"KeyExpiry":  "2026-11-09T09:26:51Z",
+				"DiscoKey":   "discokey:e21c2954729dc0ec4daacf8ba6bb199ed78b61ba605db2937a27bf8841cbcf1c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47645",
+					"10.65.0.27:47645",
+					"172.17.0.1:47645",
+					"172.18.0.1:47645",
+					"172.19.0.1:47645",
+					"172.20.0.1:47645",
+					"172.21.0.1:47645",
+					"172.22.0.1:47645",
+					"172.23.0.1:47645",
+					"172.24.0.1:47645",
+					"172.25.0.1:47645",
+					"172.26.0.1:47645",
+					"172.27.0.1:47645"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:26:51.689141853Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "903866408710325": {
+				"ID":          903866408710325,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6613494429872618,
+				"StableID":   "nXHNvUHGet11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       6613494429872618,
+				"Key":        "nodekey:e23b31364641820a02bf84ae75c2f74bf050eb491036e06b9589eee46625a313",
+				"DiscoKey":   "discokey:c10be57a23131c1477628c58655db1b3a9e396a0c16fb14d282f19971dcb2f0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42128",
+					"10.65.0.27:42128",
+					"172.17.0.1:42128",
+					"172.18.0.1:42128",
+					"172.19.0.1:42128",
+					"172.20.0.1:42128",
+					"172.21.0.1:42128",
+					"172.22.0.1:42128",
+					"172.23.0.1:42128",
+					"172.24.0.1:42128",
+					"172.25.0.1:42128",
+					"172.26.0.1:42128",
+					"172.27.0.1:42128"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:26:45.551366518Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e23b31364641820a02bf84ae75c2f74bf050eb491036e06b9589eee46625a313",
+			"MachineKey": "mkey:38e168a8f183b793c82e195c8e2731b5bbc7c91629658d7ee71e7695dea0ea2a",
+			"Peers": [{
+				"ID":         4073872181115765,
+				"StableID":   "niKsKRi4pY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b2fd2227e6fef920dcfdb9f6d6a0d42f87084effc364c1b744fa7cedf95a428",
+				"DiscoKey":   "discokey:b2d54fb79cbf2a8bd5a81e9b41af84b420fdb150cc7429978e83df6b19e39765",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:39258",
+					"10.65.0.27:39258",
+					"172.17.0.1:39258",
+					"172.18.0.1:39258",
+					"172.19.0.1:39258",
+					"172.20.0.1:39258",
+					"172.21.0.1:39258",
+					"172.22.0.1:39258",
+					"172.23.0.1:39258",
+					"172.24.0.1:39258",
+					"172.25.0.1:39258",
+					"172.26.0.1:39258",
+					"172.27.0.1:39258"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:26:44.000588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8598559577817578,
+				"StableID":   "nM8TWcaJ9A21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47838c310880c867cfeb9afb9db7ced8f4cd1938891cecf346829319db07ef5a",
+				"DiscoKey":   "discokey:68601797acf56fec44fcf8dd0ab187da02b05a2d9b3f92ba81af8b7484e37e12",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:49374",
+					"10.65.0.27:49374",
+					"172.17.0.1:49374",
+					"172.18.0.1:49374",
+					"172.19.0.1:49374",
+					"172.20.0.1:49374",
+					"172.21.0.1:49374",
+					"172.22.0.1:49374",
+					"172.23.0.1:49374",
+					"172.24.0.1:49374",
+					"172.25.0.1:49374",
+					"172.26.0.1:49374",
+					"172.27.0.1:49374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:26:44.478308406Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4243276445468940,
+				"StableID":   "njay4Ggn8a11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c656e7bfd9a437d724205617492efe06e1d4eed75586962cdb3ab9bd152f3506",
+				"DiscoKey":   "discokey:f048658f0714e5620642955ddcd960d2c70b73a7ddba7ebe3f14680cf3c3551f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40353",
+					"10.65.0.27:40353",
+					"172.17.0.1:40353",
+					"172.18.0.1:40353",
+					"172.19.0.1:40353",
+					"172.20.0.1:40353",
+					"172.21.0.1:40353",
+					"172.22.0.1:40353",
+					"172.23.0.1:40353",
+					"172.24.0.1:40353",
+					"172.25.0.1:40353",
+					"172.26.0.1:40353",
+					"172.27.0.1:40353"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:26:45.020203919Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         903866408710325,
+				"StableID":   "ntnmPC3N4811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97624f7f91a2f10b47cf34387e3e55428057bd22642256d082331c143a468333",
+				"DiscoKey":   "discokey:b0b7aaa631a463a7c1bf9ba092e1c4da6a41e0816b9f755a0842331584f80a1f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55472",
+					"10.65.0.27:55472",
+					"172.17.0.1:55472",
+					"172.18.0.1:55472",
+					"172.19.0.1:55472",
+					"172.20.0.1:55472",
+					"172.21.0.1:55472",
+					"172.22.0.1:55472",
+					"172.23.0.1:55472",
+					"172.24.0.1:55472",
+					"172.25.0.1:55472",
+					"172.26.0.1:55472",
+					"172.27.0.1:55472"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:26:46.075189134Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7270970070352609,
+				"StableID":   "nxeHr943ny11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:49cc0e9f5deba8ec8fadecc8c3fb07b06936f07ef415d102b7f4a951f02f2374",
+				"DiscoKey":   "discokey:ea14ab63d3cf23bbc45e630019938965bfafb81a1eca0f91ccc4d44255f42448",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44012",
+					"10.65.0.27:44012",
+					"172.17.0.1:44012",
+					"172.18.0.1:44012",
+					"172.19.0.1:44012",
+					"172.20.0.1:44012",
+					"172.21.0.1:44012",
+					"172.22.0.1:44012",
+					"172.23.0.1:44012",
+					"172.24.0.1:44012",
+					"172.25.0.1:44012",
+					"172.26.0.1:44012",
+					"172.27.0.1:44012"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:26:46.720919897Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8700466115858341,
+				"StableID":   "nEB6KWVTwA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:585bfffa5ac2a6323e7469c2ec38bf68b5ba6e5417def1a435b89cdb226e016f",
+				"DiscoKey":   "discokey:eddcc88f73426a19162116bcb1af08400f8a4dc410f6ab4f913a2bdaf2b3705d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51046",
+					"10.65.0.27:51046",
+					"172.17.0.1:51046",
+					"172.18.0.1:51046",
+					"172.19.0.1:51046",
+					"172.20.0.1:51046",
+					"172.21.0.1:51046",
+					"172.22.0.1:51046",
+					"172.23.0.1:51046",
+					"172.24.0.1:51046",
+					"172.25.0.1:51046",
+					"172.26.0.1:51046",
+					"172.27.0.1:51046"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:26:47.395944594Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         979170825313379,
+				"StableID":   "nNQZp7AUe811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4720f19dfaf5895ce1bb1c8ac02ea32afe6f2af424cec20d8304f6abee01b417",
+				"DiscoKey":   "discokey:d7c02f2d59fa01b134c3917b68a15623829e1e963ae773062b7be5ca262aa63d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:41076",
+					"10.65.0.27:41076",
+					"172.17.0.1:41076",
+					"172.18.0.1:41076",
+					"172.19.0.1:41076",
+					"172.20.0.1:41076",
+					"172.21.0.1:41076",
+					"172.22.0.1:41076",
+					"172.23.0.1:41076",
+					"172.24.0.1:41076",
+					"172.25.0.1:41076",
+					"172.26.0.1:41076",
+					"172.27.0.1:41076"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:26:47.935685625Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4850606547643342,
+				"StableID":   "n52dV7Drse11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dd4e65691316056a84098ba81af4208c614c566a22694d65084822d41d1bf339",
+				"DiscoKey":   "discokey:e3e00787e8a2ad677cfb632dbe719e5713471febb8fb3cea8fb02799aed64543",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42728",
+					"10.65.0.27:42728",
+					"172.17.0.1:42728",
+					"172.18.0.1:42728",
+					"172.19.0.1:42728",
+					"172.20.0.1:42728",
+					"172.21.0.1:42728",
+					"172.22.0.1:42728",
+					"172.23.0.1:42728",
+					"172.24.0.1:42728",
+					"172.25.0.1:42728",
+					"172.26.0.1:42728",
+					"172.27.0.1:42728"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:26:48.476260994Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         648454568615411,
+				"StableID":   "nLTchWog4611CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2b57d1fab7444bf5dab9a10ca383fad7c0ca4cd7aff3465dd79e9cd6f14d77f",
+				"DiscoKey":   "discokey:607988909e98850adf4c13d013b0815fc7594f7cfceefab7351a2e947864c170",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49898",
+					"10.65.0.27:49898",
+					"172.17.0.1:49898",
+					"172.18.0.1:49898",
+					"172.19.0.1:49898",
+					"172.20.0.1:49898",
+					"172.21.0.1:49898",
+					"172.22.0.1:49898",
+					"172.23.0.1:49898",
+					"172.24.0.1:49898",
+					"172.25.0.1:49898",
+					"172.26.0.1:49898",
+					"172.27.0.1:49898"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:26:49.010607278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8000392402528055,
+				"StableID":   "nAzAZ3kPU521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:04bf6c9ab1aadb71cbbd84cd40623055f633397b0e05275318af91fd82868931",
+				"DiscoKey":   "discokey:cefa23898be4a9b12faa7b74ae10597785131a147db84bd977d984e4b22b5267",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48857",
+					"10.65.0.27:48857",
+					"172.17.0.1:48857",
+					"172.18.0.1:48857",
+					"172.19.0.1:48857",
+					"172.20.0.1:48857",
+					"172.21.0.1:48857",
+					"172.22.0.1:48857",
+					"172.23.0.1:48857",
+					"172.24.0.1:48857",
+					"172.25.0.1:48857",
+					"172.26.0.1:48857",
+					"172.27.0.1:48857"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:26:49.559589908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3872874892352138,
+				"StableID":   "n7HcCfr2FX11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bb0b1e2d6305e56a36d3fc3126ad2defd58cb2e80cd01330773b5d4d194c6b1e",
+				"DiscoKey":   "discokey:ffbbd6f2ea536de55895dba0eb5fc0c698a2137c22cf8702f641363083038f49",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39492",
+					"10.65.0.27:39492",
+					"172.17.0.1:39492",
+					"172.18.0.1:39492",
+					"172.19.0.1:39492",
+					"172.20.0.1:39492",
+					"172.21.0.1:39492",
+					"172.22.0.1:39492",
+					"172.23.0.1:39492",
+					"172.24.0.1:39492",
+					"172.25.0.1:39492",
+					"172.26.0.1:39492",
+					"172.27.0.1:39492"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:26:50.088026002Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6493343994844945,
+				"StableID":   "nUrvQt8rhs11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04e296ec0576179648249da90227a94bf11e1deecc7a4de2c5f41c676b404d2b",
+				"KeyExpiry":  "2026-11-09T09:26:50Z",
+				"DiscoKey":   "discokey:76b933c86179621b333b43e7bf1bb84886973c6ca03eeffc6a6f712361f5ce46",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38220",
+					"10.65.0.27:38220",
+					"172.17.0.1:38220",
+					"172.18.0.1:38220",
+					"172.19.0.1:38220",
+					"172.20.0.1:38220",
+					"172.21.0.1:38220",
+					"172.22.0.1:38220",
+					"172.23.0.1:38220",
+					"172.24.0.1:38220",
+					"172.25.0.1:38220",
+					"172.26.0.1:38220",
+					"172.27.0.1:38220"
+				],
+				"HomeDERP": 18,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:26:50.613723105Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1496113877603016,
+				"StableID":   "nRdRAjNbgC11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:0ca2fa43faf6a93e863ff07417d8496270d56033cad4f88a990899845ad87418",
+				"KeyExpiry":  "2026-11-09T09:26:51Z",
+				"DiscoKey":   "discokey:c0ef6602bbddbf283bfe884e9673655c88bfb59dec98eb666002d1d0fd671646",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49007",
+					"10.65.0.27:49007",
+					"172.17.0.1:49007",
+					"172.18.0.1:49007",
+					"172.19.0.1:49007",
+					"172.20.0.1:49007",
+					"172.21.0.1:49007",
+					"172.22.0.1:49007",
+					"172.23.0.1:49007",
+					"172.24.0.1:49007",
+					"172.25.0.1:49007",
+					"172.26.0.1:49007",
+					"172.27.0.1:49007"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:26:51.146399576Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1641192705435100,
+				"StableID":   "nbeyNGMJpD11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:54fb5e0ac9bb3bfeced3d1b6f8f0250beb855298fe37be15afd2b532c333bd24",
+				"KeyExpiry":  "2026-11-09T09:26:51Z",
+				"DiscoKey":   "discokey:e21c2954729dc0ec4daacf8ba6bb199ed78b61ba605db2937a27bf8841cbcf1c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47645",
+					"10.65.0.27:47645",
+					"172.17.0.1:47645",
+					"172.18.0.1:47645",
+					"172.19.0.1:47645",
+					"172.20.0.1:47645",
+					"172.21.0.1:47645",
+					"172.22.0.1:47645",
+					"172.23.0.1:47645",
+					"172.24.0.1:47645",
+					"172.25.0.1:47645",
+					"172.26.0.1:47645",
+					"172.27.0.1:47645"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:26:51.689141853Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6613494429872618": {
+				"ID":          6613494429872618,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8700466115858341,
+				"StableID":   "nEB6KWVTwA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       8700466115858341,
+				"Key":        "nodekey:585bfffa5ac2a6323e7469c2ec38bf68b5ba6e5417def1a435b89cdb226e016f",
+				"DiscoKey":   "discokey:eddcc88f73426a19162116bcb1af08400f8a4dc410f6ab4f913a2bdaf2b3705d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51046",
+					"10.65.0.27:51046",
+					"172.17.0.1:51046",
+					"172.18.0.1:51046",
+					"172.19.0.1:51046",
+					"172.20.0.1:51046",
+					"172.21.0.1:51046",
+					"172.22.0.1:51046",
+					"172.23.0.1:51046",
+					"172.24.0.1:51046",
+					"172.25.0.1:51046",
+					"172.26.0.1:51046",
+					"172.27.0.1:51046"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:26:47.395944594Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:585bfffa5ac2a6323e7469c2ec38bf68b5ba6e5417def1a435b89cdb226e016f",
+			"MachineKey": "mkey:91efc16a3799cd415f91609345b4e41e0ad1e1537e370c923ab735d3e8ae8031",
+			"Peers": [{
+				"ID":         4073872181115765,
+				"StableID":   "niKsKRi4pY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b2fd2227e6fef920dcfdb9f6d6a0d42f87084effc364c1b744fa7cedf95a428",
+				"DiscoKey":   "discokey:b2d54fb79cbf2a8bd5a81e9b41af84b420fdb150cc7429978e83df6b19e39765",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:39258",
+					"10.65.0.27:39258",
+					"172.17.0.1:39258",
+					"172.18.0.1:39258",
+					"172.19.0.1:39258",
+					"172.20.0.1:39258",
+					"172.21.0.1:39258",
+					"172.22.0.1:39258",
+					"172.23.0.1:39258",
+					"172.24.0.1:39258",
+					"172.25.0.1:39258",
+					"172.26.0.1:39258",
+					"172.27.0.1:39258"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:26:44.000588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8598559577817578,
+				"StableID":   "nM8TWcaJ9A21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47838c310880c867cfeb9afb9db7ced8f4cd1938891cecf346829319db07ef5a",
+				"DiscoKey":   "discokey:68601797acf56fec44fcf8dd0ab187da02b05a2d9b3f92ba81af8b7484e37e12",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:49374",
+					"10.65.0.27:49374",
+					"172.17.0.1:49374",
+					"172.18.0.1:49374",
+					"172.19.0.1:49374",
+					"172.20.0.1:49374",
+					"172.21.0.1:49374",
+					"172.22.0.1:49374",
+					"172.23.0.1:49374",
+					"172.24.0.1:49374",
+					"172.25.0.1:49374",
+					"172.26.0.1:49374",
+					"172.27.0.1:49374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:26:44.478308406Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4243276445468940,
+				"StableID":   "njay4Ggn8a11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c656e7bfd9a437d724205617492efe06e1d4eed75586962cdb3ab9bd152f3506",
+				"DiscoKey":   "discokey:f048658f0714e5620642955ddcd960d2c70b73a7ddba7ebe3f14680cf3c3551f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40353",
+					"10.65.0.27:40353",
+					"172.17.0.1:40353",
+					"172.18.0.1:40353",
+					"172.19.0.1:40353",
+					"172.20.0.1:40353",
+					"172.21.0.1:40353",
+					"172.22.0.1:40353",
+					"172.23.0.1:40353",
+					"172.24.0.1:40353",
+					"172.25.0.1:40353",
+					"172.26.0.1:40353",
+					"172.27.0.1:40353"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:26:45.020203919Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6613494429872618,
+				"StableID":   "nXHNvUHGet11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e23b31364641820a02bf84ae75c2f74bf050eb491036e06b9589eee46625a313",
+				"DiscoKey":   "discokey:c10be57a23131c1477628c58655db1b3a9e396a0c16fb14d282f19971dcb2f0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42128",
+					"10.65.0.27:42128",
+					"172.17.0.1:42128",
+					"172.18.0.1:42128",
+					"172.19.0.1:42128",
+					"172.20.0.1:42128",
+					"172.21.0.1:42128",
+					"172.22.0.1:42128",
+					"172.23.0.1:42128",
+					"172.24.0.1:42128",
+					"172.25.0.1:42128",
+					"172.26.0.1:42128",
+					"172.27.0.1:42128"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:26:45.551366518Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         903866408710325,
+				"StableID":   "ntnmPC3N4811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97624f7f91a2f10b47cf34387e3e55428057bd22642256d082331c143a468333",
+				"DiscoKey":   "discokey:b0b7aaa631a463a7c1bf9ba092e1c4da6a41e0816b9f755a0842331584f80a1f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55472",
+					"10.65.0.27:55472",
+					"172.17.0.1:55472",
+					"172.18.0.1:55472",
+					"172.19.0.1:55472",
+					"172.20.0.1:55472",
+					"172.21.0.1:55472",
+					"172.22.0.1:55472",
+					"172.23.0.1:55472",
+					"172.24.0.1:55472",
+					"172.25.0.1:55472",
+					"172.26.0.1:55472",
+					"172.27.0.1:55472"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:26:46.075189134Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7270970070352609,
+				"StableID":   "nxeHr943ny11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:49cc0e9f5deba8ec8fadecc8c3fb07b06936f07ef415d102b7f4a951f02f2374",
+				"DiscoKey":   "discokey:ea14ab63d3cf23bbc45e630019938965bfafb81a1eca0f91ccc4d44255f42448",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44012",
+					"10.65.0.27:44012",
+					"172.17.0.1:44012",
+					"172.18.0.1:44012",
+					"172.19.0.1:44012",
+					"172.20.0.1:44012",
+					"172.21.0.1:44012",
+					"172.22.0.1:44012",
+					"172.23.0.1:44012",
+					"172.24.0.1:44012",
+					"172.25.0.1:44012",
+					"172.26.0.1:44012",
+					"172.27.0.1:44012"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:26:46.720919897Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         979170825313379,
+				"StableID":   "nNQZp7AUe811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4720f19dfaf5895ce1bb1c8ac02ea32afe6f2af424cec20d8304f6abee01b417",
+				"DiscoKey":   "discokey:d7c02f2d59fa01b134c3917b68a15623829e1e963ae773062b7be5ca262aa63d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:41076",
+					"10.65.0.27:41076",
+					"172.17.0.1:41076",
+					"172.18.0.1:41076",
+					"172.19.0.1:41076",
+					"172.20.0.1:41076",
+					"172.21.0.1:41076",
+					"172.22.0.1:41076",
+					"172.23.0.1:41076",
+					"172.24.0.1:41076",
+					"172.25.0.1:41076",
+					"172.26.0.1:41076",
+					"172.27.0.1:41076"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:26:47.935685625Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4850606547643342,
+				"StableID":   "n52dV7Drse11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dd4e65691316056a84098ba81af4208c614c566a22694d65084822d41d1bf339",
+				"DiscoKey":   "discokey:e3e00787e8a2ad677cfb632dbe719e5713471febb8fb3cea8fb02799aed64543",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42728",
+					"10.65.0.27:42728",
+					"172.17.0.1:42728",
+					"172.18.0.1:42728",
+					"172.19.0.1:42728",
+					"172.20.0.1:42728",
+					"172.21.0.1:42728",
+					"172.22.0.1:42728",
+					"172.23.0.1:42728",
+					"172.24.0.1:42728",
+					"172.25.0.1:42728",
+					"172.26.0.1:42728",
+					"172.27.0.1:42728"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:26:48.476260994Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         648454568615411,
+				"StableID":   "nLTchWog4611CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2b57d1fab7444bf5dab9a10ca383fad7c0ca4cd7aff3465dd79e9cd6f14d77f",
+				"DiscoKey":   "discokey:607988909e98850adf4c13d013b0815fc7594f7cfceefab7351a2e947864c170",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49898",
+					"10.65.0.27:49898",
+					"172.17.0.1:49898",
+					"172.18.0.1:49898",
+					"172.19.0.1:49898",
+					"172.20.0.1:49898",
+					"172.21.0.1:49898",
+					"172.22.0.1:49898",
+					"172.23.0.1:49898",
+					"172.24.0.1:49898",
+					"172.25.0.1:49898",
+					"172.26.0.1:49898",
+					"172.27.0.1:49898"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:26:49.010607278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8000392402528055,
+				"StableID":   "nAzAZ3kPU521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:04bf6c9ab1aadb71cbbd84cd40623055f633397b0e05275318af91fd82868931",
+				"DiscoKey":   "discokey:cefa23898be4a9b12faa7b74ae10597785131a147db84bd977d984e4b22b5267",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48857",
+					"10.65.0.27:48857",
+					"172.17.0.1:48857",
+					"172.18.0.1:48857",
+					"172.19.0.1:48857",
+					"172.20.0.1:48857",
+					"172.21.0.1:48857",
+					"172.22.0.1:48857",
+					"172.23.0.1:48857",
+					"172.24.0.1:48857",
+					"172.25.0.1:48857",
+					"172.26.0.1:48857",
+					"172.27.0.1:48857"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:26:49.559589908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3872874892352138,
+				"StableID":   "n7HcCfr2FX11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bb0b1e2d6305e56a36d3fc3126ad2defd58cb2e80cd01330773b5d4d194c6b1e",
+				"DiscoKey":   "discokey:ffbbd6f2ea536de55895dba0eb5fc0c698a2137c22cf8702f641363083038f49",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39492",
+					"10.65.0.27:39492",
+					"172.17.0.1:39492",
+					"172.18.0.1:39492",
+					"172.19.0.1:39492",
+					"172.20.0.1:39492",
+					"172.21.0.1:39492",
+					"172.22.0.1:39492",
+					"172.23.0.1:39492",
+					"172.24.0.1:39492",
+					"172.25.0.1:39492",
+					"172.26.0.1:39492",
+					"172.27.0.1:39492"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:26:50.088026002Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6493343994844945,
+				"StableID":   "nUrvQt8rhs11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04e296ec0576179648249da90227a94bf11e1deecc7a4de2c5f41c676b404d2b",
+				"KeyExpiry":  "2026-11-09T09:26:50Z",
+				"DiscoKey":   "discokey:76b933c86179621b333b43e7bf1bb84886973c6ca03eeffc6a6f712361f5ce46",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38220",
+					"10.65.0.27:38220",
+					"172.17.0.1:38220",
+					"172.18.0.1:38220",
+					"172.19.0.1:38220",
+					"172.20.0.1:38220",
+					"172.21.0.1:38220",
+					"172.22.0.1:38220",
+					"172.23.0.1:38220",
+					"172.24.0.1:38220",
+					"172.25.0.1:38220",
+					"172.26.0.1:38220",
+					"172.27.0.1:38220"
+				],
+				"HomeDERP": 18,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:26:50.613723105Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1496113877603016,
+				"StableID":   "nRdRAjNbgC11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:0ca2fa43faf6a93e863ff07417d8496270d56033cad4f88a990899845ad87418",
+				"KeyExpiry":  "2026-11-09T09:26:51Z",
+				"DiscoKey":   "discokey:c0ef6602bbddbf283bfe884e9673655c88bfb59dec98eb666002d1d0fd671646",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49007",
+					"10.65.0.27:49007",
+					"172.17.0.1:49007",
+					"172.18.0.1:49007",
+					"172.19.0.1:49007",
+					"172.20.0.1:49007",
+					"172.21.0.1:49007",
+					"172.22.0.1:49007",
+					"172.23.0.1:49007",
+					"172.24.0.1:49007",
+					"172.25.0.1:49007",
+					"172.26.0.1:49007",
+					"172.27.0.1:49007"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:26:51.146399576Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1641192705435100,
+				"StableID":   "nbeyNGMJpD11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:54fb5e0ac9bb3bfeced3d1b6f8f0250beb855298fe37be15afd2b532c333bd24",
+				"KeyExpiry":  "2026-11-09T09:26:51Z",
+				"DiscoKey":   "discokey:e21c2954729dc0ec4daacf8ba6bb199ed78b61ba605db2937a27bf8841cbcf1c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47645",
+					"10.65.0.27:47645",
+					"172.17.0.1:47645",
+					"172.18.0.1:47645",
+					"172.19.0.1:47645",
+					"172.20.0.1:47645",
+					"172.21.0.1:47645",
+					"172.22.0.1:47645",
+					"172.23.0.1:47645",
+					"172.24.0.1:47645",
+					"172.25.0.1:47645",
+					"172.26.0.1:47645",
+					"172.27.0.1:47645"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:26:51.689141853Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8700466115858341": {
+				"ID":          8700466115858341,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4850606547643342,
+				"StableID":   "n52dV7Drse11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       4850606547643342,
+				"Key":        "nodekey:dd4e65691316056a84098ba81af4208c614c566a22694d65084822d41d1bf339",
+				"DiscoKey":   "discokey:e3e00787e8a2ad677cfb632dbe719e5713471febb8fb3cea8fb02799aed64543",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42728",
+					"10.65.0.27:42728",
+					"172.17.0.1:42728",
+					"172.18.0.1:42728",
+					"172.19.0.1:42728",
+					"172.20.0.1:42728",
+					"172.21.0.1:42728",
+					"172.22.0.1:42728",
+					"172.23.0.1:42728",
+					"172.24.0.1:42728",
+					"172.25.0.1:42728",
+					"172.26.0.1:42728",
+					"172.27.0.1:42728"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:26:48.476260994Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:dd4e65691316056a84098ba81af4208c614c566a22694d65084822d41d1bf339",
+			"MachineKey": "mkey:7184d5d53b45eeb965a39f57b31325e83c0a68608d06c0df9b13c6f838c2330d",
+			"Peers": [{
+				"ID":         4073872181115765,
+				"StableID":   "niKsKRi4pY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b2fd2227e6fef920dcfdb9f6d6a0d42f87084effc364c1b744fa7cedf95a428",
+				"DiscoKey":   "discokey:b2d54fb79cbf2a8bd5a81e9b41af84b420fdb150cc7429978e83df6b19e39765",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:39258",
+					"10.65.0.27:39258",
+					"172.17.0.1:39258",
+					"172.18.0.1:39258",
+					"172.19.0.1:39258",
+					"172.20.0.1:39258",
+					"172.21.0.1:39258",
+					"172.22.0.1:39258",
+					"172.23.0.1:39258",
+					"172.24.0.1:39258",
+					"172.25.0.1:39258",
+					"172.26.0.1:39258",
+					"172.27.0.1:39258"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:26:44.000588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8598559577817578,
+				"StableID":   "nM8TWcaJ9A21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47838c310880c867cfeb9afb9db7ced8f4cd1938891cecf346829319db07ef5a",
+				"DiscoKey":   "discokey:68601797acf56fec44fcf8dd0ab187da02b05a2d9b3f92ba81af8b7484e37e12",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:49374",
+					"10.65.0.27:49374",
+					"172.17.0.1:49374",
+					"172.18.0.1:49374",
+					"172.19.0.1:49374",
+					"172.20.0.1:49374",
+					"172.21.0.1:49374",
+					"172.22.0.1:49374",
+					"172.23.0.1:49374",
+					"172.24.0.1:49374",
+					"172.25.0.1:49374",
+					"172.26.0.1:49374",
+					"172.27.0.1:49374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:26:44.478308406Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4243276445468940,
+				"StableID":   "njay4Ggn8a11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c656e7bfd9a437d724205617492efe06e1d4eed75586962cdb3ab9bd152f3506",
+				"DiscoKey":   "discokey:f048658f0714e5620642955ddcd960d2c70b73a7ddba7ebe3f14680cf3c3551f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40353",
+					"10.65.0.27:40353",
+					"172.17.0.1:40353",
+					"172.18.0.1:40353",
+					"172.19.0.1:40353",
+					"172.20.0.1:40353",
+					"172.21.0.1:40353",
+					"172.22.0.1:40353",
+					"172.23.0.1:40353",
+					"172.24.0.1:40353",
+					"172.25.0.1:40353",
+					"172.26.0.1:40353",
+					"172.27.0.1:40353"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:26:45.020203919Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6613494429872618,
+				"StableID":   "nXHNvUHGet11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e23b31364641820a02bf84ae75c2f74bf050eb491036e06b9589eee46625a313",
+				"DiscoKey":   "discokey:c10be57a23131c1477628c58655db1b3a9e396a0c16fb14d282f19971dcb2f0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42128",
+					"10.65.0.27:42128",
+					"172.17.0.1:42128",
+					"172.18.0.1:42128",
+					"172.19.0.1:42128",
+					"172.20.0.1:42128",
+					"172.21.0.1:42128",
+					"172.22.0.1:42128",
+					"172.23.0.1:42128",
+					"172.24.0.1:42128",
+					"172.25.0.1:42128",
+					"172.26.0.1:42128",
+					"172.27.0.1:42128"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:26:45.551366518Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         903866408710325,
+				"StableID":   "ntnmPC3N4811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97624f7f91a2f10b47cf34387e3e55428057bd22642256d082331c143a468333",
+				"DiscoKey":   "discokey:b0b7aaa631a463a7c1bf9ba092e1c4da6a41e0816b9f755a0842331584f80a1f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55472",
+					"10.65.0.27:55472",
+					"172.17.0.1:55472",
+					"172.18.0.1:55472",
+					"172.19.0.1:55472",
+					"172.20.0.1:55472",
+					"172.21.0.1:55472",
+					"172.22.0.1:55472",
+					"172.23.0.1:55472",
+					"172.24.0.1:55472",
+					"172.25.0.1:55472",
+					"172.26.0.1:55472",
+					"172.27.0.1:55472"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:26:46.075189134Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7270970070352609,
+				"StableID":   "nxeHr943ny11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:49cc0e9f5deba8ec8fadecc8c3fb07b06936f07ef415d102b7f4a951f02f2374",
+				"DiscoKey":   "discokey:ea14ab63d3cf23bbc45e630019938965bfafb81a1eca0f91ccc4d44255f42448",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44012",
+					"10.65.0.27:44012",
+					"172.17.0.1:44012",
+					"172.18.0.1:44012",
+					"172.19.0.1:44012",
+					"172.20.0.1:44012",
+					"172.21.0.1:44012",
+					"172.22.0.1:44012",
+					"172.23.0.1:44012",
+					"172.24.0.1:44012",
+					"172.25.0.1:44012",
+					"172.26.0.1:44012",
+					"172.27.0.1:44012"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:26:46.720919897Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8700466115858341,
+				"StableID":   "nEB6KWVTwA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:585bfffa5ac2a6323e7469c2ec38bf68b5ba6e5417def1a435b89cdb226e016f",
+				"DiscoKey":   "discokey:eddcc88f73426a19162116bcb1af08400f8a4dc410f6ab4f913a2bdaf2b3705d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51046",
+					"10.65.0.27:51046",
+					"172.17.0.1:51046",
+					"172.18.0.1:51046",
+					"172.19.0.1:51046",
+					"172.20.0.1:51046",
+					"172.21.0.1:51046",
+					"172.22.0.1:51046",
+					"172.23.0.1:51046",
+					"172.24.0.1:51046",
+					"172.25.0.1:51046",
+					"172.26.0.1:51046",
+					"172.27.0.1:51046"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:26:47.395944594Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         979170825313379,
+				"StableID":   "nNQZp7AUe811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4720f19dfaf5895ce1bb1c8ac02ea32afe6f2af424cec20d8304f6abee01b417",
+				"DiscoKey":   "discokey:d7c02f2d59fa01b134c3917b68a15623829e1e963ae773062b7be5ca262aa63d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:41076",
+					"10.65.0.27:41076",
+					"172.17.0.1:41076",
+					"172.18.0.1:41076",
+					"172.19.0.1:41076",
+					"172.20.0.1:41076",
+					"172.21.0.1:41076",
+					"172.22.0.1:41076",
+					"172.23.0.1:41076",
+					"172.24.0.1:41076",
+					"172.25.0.1:41076",
+					"172.26.0.1:41076",
+					"172.27.0.1:41076"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:26:47.935685625Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         648454568615411,
+				"StableID":   "nLTchWog4611CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2b57d1fab7444bf5dab9a10ca383fad7c0ca4cd7aff3465dd79e9cd6f14d77f",
+				"DiscoKey":   "discokey:607988909e98850adf4c13d013b0815fc7594f7cfceefab7351a2e947864c170",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49898",
+					"10.65.0.27:49898",
+					"172.17.0.1:49898",
+					"172.18.0.1:49898",
+					"172.19.0.1:49898",
+					"172.20.0.1:49898",
+					"172.21.0.1:49898",
+					"172.22.0.1:49898",
+					"172.23.0.1:49898",
+					"172.24.0.1:49898",
+					"172.25.0.1:49898",
+					"172.26.0.1:49898",
+					"172.27.0.1:49898"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:26:49.010607278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8000392402528055,
+				"StableID":   "nAzAZ3kPU521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:04bf6c9ab1aadb71cbbd84cd40623055f633397b0e05275318af91fd82868931",
+				"DiscoKey":   "discokey:cefa23898be4a9b12faa7b74ae10597785131a147db84bd977d984e4b22b5267",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48857",
+					"10.65.0.27:48857",
+					"172.17.0.1:48857",
+					"172.18.0.1:48857",
+					"172.19.0.1:48857",
+					"172.20.0.1:48857",
+					"172.21.0.1:48857",
+					"172.22.0.1:48857",
+					"172.23.0.1:48857",
+					"172.24.0.1:48857",
+					"172.25.0.1:48857",
+					"172.26.0.1:48857",
+					"172.27.0.1:48857"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:26:49.559589908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3872874892352138,
+				"StableID":   "n7HcCfr2FX11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bb0b1e2d6305e56a36d3fc3126ad2defd58cb2e80cd01330773b5d4d194c6b1e",
+				"DiscoKey":   "discokey:ffbbd6f2ea536de55895dba0eb5fc0c698a2137c22cf8702f641363083038f49",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39492",
+					"10.65.0.27:39492",
+					"172.17.0.1:39492",
+					"172.18.0.1:39492",
+					"172.19.0.1:39492",
+					"172.20.0.1:39492",
+					"172.21.0.1:39492",
+					"172.22.0.1:39492",
+					"172.23.0.1:39492",
+					"172.24.0.1:39492",
+					"172.25.0.1:39492",
+					"172.26.0.1:39492",
+					"172.27.0.1:39492"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:26:50.088026002Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6493343994844945,
+				"StableID":   "nUrvQt8rhs11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04e296ec0576179648249da90227a94bf11e1deecc7a4de2c5f41c676b404d2b",
+				"KeyExpiry":  "2026-11-09T09:26:50Z",
+				"DiscoKey":   "discokey:76b933c86179621b333b43e7bf1bb84886973c6ca03eeffc6a6f712361f5ce46",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38220",
+					"10.65.0.27:38220",
+					"172.17.0.1:38220",
+					"172.18.0.1:38220",
+					"172.19.0.1:38220",
+					"172.20.0.1:38220",
+					"172.21.0.1:38220",
+					"172.22.0.1:38220",
+					"172.23.0.1:38220",
+					"172.24.0.1:38220",
+					"172.25.0.1:38220",
+					"172.26.0.1:38220",
+					"172.27.0.1:38220"
+				],
+				"HomeDERP": 18,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:26:50.613723105Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1496113877603016,
+				"StableID":   "nRdRAjNbgC11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:0ca2fa43faf6a93e863ff07417d8496270d56033cad4f88a990899845ad87418",
+				"KeyExpiry":  "2026-11-09T09:26:51Z",
+				"DiscoKey":   "discokey:c0ef6602bbddbf283bfe884e9673655c88bfb59dec98eb666002d1d0fd671646",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49007",
+					"10.65.0.27:49007",
+					"172.17.0.1:49007",
+					"172.18.0.1:49007",
+					"172.19.0.1:49007",
+					"172.20.0.1:49007",
+					"172.21.0.1:49007",
+					"172.22.0.1:49007",
+					"172.23.0.1:49007",
+					"172.24.0.1:49007",
+					"172.25.0.1:49007",
+					"172.26.0.1:49007",
+					"172.27.0.1:49007"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:26:51.146399576Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1641192705435100,
+				"StableID":   "nbeyNGMJpD11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:54fb5e0ac9bb3bfeced3d1b6f8f0250beb855298fe37be15afd2b532c333bd24",
+				"KeyExpiry":  "2026-11-09T09:26:51Z",
+				"DiscoKey":   "discokey:e21c2954729dc0ec4daacf8ba6bb199ed78b61ba605db2937a27bf8841cbcf1c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47645",
+					"10.65.0.27:47645",
+					"172.17.0.1:47645",
+					"172.18.0.1:47645",
+					"172.19.0.1:47645",
+					"172.20.0.1:47645",
+					"172.21.0.1:47645",
+					"172.22.0.1:47645",
+					"172.23.0.1:47645",
+					"172.24.0.1:47645",
+					"172.25.0.1:47645",
+					"172.26.0.1:47645",
+					"172.27.0.1:47645"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:26:51.689141853Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4850606547643342": {
+				"ID":          4850606547643342,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1496113877603016,
+				"StableID":   "nRdRAjNbgC11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:0ca2fa43faf6a93e863ff07417d8496270d56033cad4f88a990899845ad87418",
+				"KeyExpiry":  "2026-11-09T09:26:51Z",
+				"DiscoKey":   "discokey:c0ef6602bbddbf283bfe884e9673655c88bfb59dec98eb666002d1d0fd671646",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49007",
+					"10.65.0.27:49007",
+					"172.17.0.1:49007",
+					"172.18.0.1:49007",
+					"172.19.0.1:49007",
+					"172.20.0.1:49007",
+					"172.21.0.1:49007",
+					"172.22.0.1:49007",
+					"172.23.0.1:49007",
+					"172.24.0.1:49007",
+					"172.25.0.1:49007",
+					"172.26.0.1:49007",
+					"172.27.0.1:49007"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:26:51.146399576Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0ca2fa43faf6a93e863ff07417d8496270d56033cad4f88a990899845ad87418",
+			"MachineKey": "mkey:6178b626f3a41c835c97e0967ce4e46b1445f2b00b7c929fdf2a5805d4cefc64",
+			"Peers": [{
+				"ID":         4073872181115765,
+				"StableID":   "niKsKRi4pY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b2fd2227e6fef920dcfdb9f6d6a0d42f87084effc364c1b744fa7cedf95a428",
+				"DiscoKey":   "discokey:b2d54fb79cbf2a8bd5a81e9b41af84b420fdb150cc7429978e83df6b19e39765",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:39258",
+					"10.65.0.27:39258",
+					"172.17.0.1:39258",
+					"172.18.0.1:39258",
+					"172.19.0.1:39258",
+					"172.20.0.1:39258",
+					"172.21.0.1:39258",
+					"172.22.0.1:39258",
+					"172.23.0.1:39258",
+					"172.24.0.1:39258",
+					"172.25.0.1:39258",
+					"172.26.0.1:39258",
+					"172.27.0.1:39258"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:26:44.000588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8598559577817578,
+				"StableID":   "nM8TWcaJ9A21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47838c310880c867cfeb9afb9db7ced8f4cd1938891cecf346829319db07ef5a",
+				"DiscoKey":   "discokey:68601797acf56fec44fcf8dd0ab187da02b05a2d9b3f92ba81af8b7484e37e12",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:49374",
+					"10.65.0.27:49374",
+					"172.17.0.1:49374",
+					"172.18.0.1:49374",
+					"172.19.0.1:49374",
+					"172.20.0.1:49374",
+					"172.21.0.1:49374",
+					"172.22.0.1:49374",
+					"172.23.0.1:49374",
+					"172.24.0.1:49374",
+					"172.25.0.1:49374",
+					"172.26.0.1:49374",
+					"172.27.0.1:49374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:26:44.478308406Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4243276445468940,
+				"StableID":   "njay4Ggn8a11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c656e7bfd9a437d724205617492efe06e1d4eed75586962cdb3ab9bd152f3506",
+				"DiscoKey":   "discokey:f048658f0714e5620642955ddcd960d2c70b73a7ddba7ebe3f14680cf3c3551f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40353",
+					"10.65.0.27:40353",
+					"172.17.0.1:40353",
+					"172.18.0.1:40353",
+					"172.19.0.1:40353",
+					"172.20.0.1:40353",
+					"172.21.0.1:40353",
+					"172.22.0.1:40353",
+					"172.23.0.1:40353",
+					"172.24.0.1:40353",
+					"172.25.0.1:40353",
+					"172.26.0.1:40353",
+					"172.27.0.1:40353"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:26:45.020203919Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6613494429872618,
+				"StableID":   "nXHNvUHGet11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e23b31364641820a02bf84ae75c2f74bf050eb491036e06b9589eee46625a313",
+				"DiscoKey":   "discokey:c10be57a23131c1477628c58655db1b3a9e396a0c16fb14d282f19971dcb2f0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42128",
+					"10.65.0.27:42128",
+					"172.17.0.1:42128",
+					"172.18.0.1:42128",
+					"172.19.0.1:42128",
+					"172.20.0.1:42128",
+					"172.21.0.1:42128",
+					"172.22.0.1:42128",
+					"172.23.0.1:42128",
+					"172.24.0.1:42128",
+					"172.25.0.1:42128",
+					"172.26.0.1:42128",
+					"172.27.0.1:42128"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:26:45.551366518Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         903866408710325,
+				"StableID":   "ntnmPC3N4811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97624f7f91a2f10b47cf34387e3e55428057bd22642256d082331c143a468333",
+				"DiscoKey":   "discokey:b0b7aaa631a463a7c1bf9ba092e1c4da6a41e0816b9f755a0842331584f80a1f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55472",
+					"10.65.0.27:55472",
+					"172.17.0.1:55472",
+					"172.18.0.1:55472",
+					"172.19.0.1:55472",
+					"172.20.0.1:55472",
+					"172.21.0.1:55472",
+					"172.22.0.1:55472",
+					"172.23.0.1:55472",
+					"172.24.0.1:55472",
+					"172.25.0.1:55472",
+					"172.26.0.1:55472",
+					"172.27.0.1:55472"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:26:46.075189134Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7270970070352609,
+				"StableID":   "nxeHr943ny11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:49cc0e9f5deba8ec8fadecc8c3fb07b06936f07ef415d102b7f4a951f02f2374",
+				"DiscoKey":   "discokey:ea14ab63d3cf23bbc45e630019938965bfafb81a1eca0f91ccc4d44255f42448",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44012",
+					"10.65.0.27:44012",
+					"172.17.0.1:44012",
+					"172.18.0.1:44012",
+					"172.19.0.1:44012",
+					"172.20.0.1:44012",
+					"172.21.0.1:44012",
+					"172.22.0.1:44012",
+					"172.23.0.1:44012",
+					"172.24.0.1:44012",
+					"172.25.0.1:44012",
+					"172.26.0.1:44012",
+					"172.27.0.1:44012"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:26:46.720919897Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8700466115858341,
+				"StableID":   "nEB6KWVTwA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:585bfffa5ac2a6323e7469c2ec38bf68b5ba6e5417def1a435b89cdb226e016f",
+				"DiscoKey":   "discokey:eddcc88f73426a19162116bcb1af08400f8a4dc410f6ab4f913a2bdaf2b3705d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51046",
+					"10.65.0.27:51046",
+					"172.17.0.1:51046",
+					"172.18.0.1:51046",
+					"172.19.0.1:51046",
+					"172.20.0.1:51046",
+					"172.21.0.1:51046",
+					"172.22.0.1:51046",
+					"172.23.0.1:51046",
+					"172.24.0.1:51046",
+					"172.25.0.1:51046",
+					"172.26.0.1:51046",
+					"172.27.0.1:51046"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:26:47.395944594Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         979170825313379,
+				"StableID":   "nNQZp7AUe811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4720f19dfaf5895ce1bb1c8ac02ea32afe6f2af424cec20d8304f6abee01b417",
+				"DiscoKey":   "discokey:d7c02f2d59fa01b134c3917b68a15623829e1e963ae773062b7be5ca262aa63d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:41076",
+					"10.65.0.27:41076",
+					"172.17.0.1:41076",
+					"172.18.0.1:41076",
+					"172.19.0.1:41076",
+					"172.20.0.1:41076",
+					"172.21.0.1:41076",
+					"172.22.0.1:41076",
+					"172.23.0.1:41076",
+					"172.24.0.1:41076",
+					"172.25.0.1:41076",
+					"172.26.0.1:41076",
+					"172.27.0.1:41076"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:26:47.935685625Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4850606547643342,
+				"StableID":   "n52dV7Drse11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dd4e65691316056a84098ba81af4208c614c566a22694d65084822d41d1bf339",
+				"DiscoKey":   "discokey:e3e00787e8a2ad677cfb632dbe719e5713471febb8fb3cea8fb02799aed64543",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42728",
+					"10.65.0.27:42728",
+					"172.17.0.1:42728",
+					"172.18.0.1:42728",
+					"172.19.0.1:42728",
+					"172.20.0.1:42728",
+					"172.21.0.1:42728",
+					"172.22.0.1:42728",
+					"172.23.0.1:42728",
+					"172.24.0.1:42728",
+					"172.25.0.1:42728",
+					"172.26.0.1:42728",
+					"172.27.0.1:42728"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:26:48.476260994Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         648454568615411,
+				"StableID":   "nLTchWog4611CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e2b57d1fab7444bf5dab9a10ca383fad7c0ca4cd7aff3465dd79e9cd6f14d77f",
+				"DiscoKey":   "discokey:607988909e98850adf4c13d013b0815fc7594f7cfceefab7351a2e947864c170",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49898",
+					"10.65.0.27:49898",
+					"172.17.0.1:49898",
+					"172.18.0.1:49898",
+					"172.19.0.1:49898",
+					"172.20.0.1:49898",
+					"172.21.0.1:49898",
+					"172.22.0.1:49898",
+					"172.23.0.1:49898",
+					"172.24.0.1:49898",
+					"172.25.0.1:49898",
+					"172.26.0.1:49898",
+					"172.27.0.1:49898"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:26:49.010607278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8000392402528055,
+				"StableID":   "nAzAZ3kPU521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:04bf6c9ab1aadb71cbbd84cd40623055f633397b0e05275318af91fd82868931",
+				"DiscoKey":   "discokey:cefa23898be4a9b12faa7b74ae10597785131a147db84bd977d984e4b22b5267",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48857",
+					"10.65.0.27:48857",
+					"172.17.0.1:48857",
+					"172.18.0.1:48857",
+					"172.19.0.1:48857",
+					"172.20.0.1:48857",
+					"172.21.0.1:48857",
+					"172.22.0.1:48857",
+					"172.23.0.1:48857",
+					"172.24.0.1:48857",
+					"172.25.0.1:48857",
+					"172.26.0.1:48857",
+					"172.27.0.1:48857"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:26:49.559589908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3872874892352138,
+				"StableID":   "n7HcCfr2FX11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bb0b1e2d6305e56a36d3fc3126ad2defd58cb2e80cd01330773b5d4d194c6b1e",
+				"DiscoKey":   "discokey:ffbbd6f2ea536de55895dba0eb5fc0c698a2137c22cf8702f641363083038f49",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39492",
+					"10.65.0.27:39492",
+					"172.17.0.1:39492",
+					"172.18.0.1:39492",
+					"172.19.0.1:39492",
+					"172.20.0.1:39492",
+					"172.21.0.1:39492",
+					"172.22.0.1:39492",
+					"172.23.0.1:39492",
+					"172.24.0.1:39492",
+					"172.25.0.1:39492",
+					"172.26.0.1:39492",
+					"172.27.0.1:39492"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:26:50.088026002Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6493343994844945,
+				"StableID":   "nUrvQt8rhs11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04e296ec0576179648249da90227a94bf11e1deecc7a4de2c5f41c676b404d2b",
+				"KeyExpiry":  "2026-11-09T09:26:50Z",
+				"DiscoKey":   "discokey:76b933c86179621b333b43e7bf1bb84886973c6ca03eeffc6a6f712361f5ce46",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38220",
+					"10.65.0.27:38220",
+					"172.17.0.1:38220",
+					"172.18.0.1:38220",
+					"172.19.0.1:38220",
+					"172.20.0.1:38220",
+					"172.21.0.1:38220",
+					"172.22.0.1:38220",
+					"172.23.0.1:38220",
+					"172.24.0.1:38220",
+					"172.25.0.1:38220",
+					"172.26.0.1:38220",
+					"172.27.0.1:38220"
+				],
+				"HomeDERP": 18,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:26:50.613723105Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1641192705435100,
+				"StableID":   "nbeyNGMJpD11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:54fb5e0ac9bb3bfeced3d1b6f8f0250beb855298fe37be15afd2b532c333bd24",
+				"KeyExpiry":  "2026-11-09T09:26:51Z",
+				"DiscoKey":   "discokey:e21c2954729dc0ec4daacf8ba6bb199ed78b61ba605db2937a27bf8841cbcf1c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47645",
+					"10.65.0.27:47645",
+					"172.17.0.1:47645",
+					"172.18.0.1:47645",
+					"172.19.0.1:47645",
+					"172.20.0.1:47645",
+					"172.21.0.1:47645",
+					"172.22.0.1:47645",
+					"172.23.0.1:47645",
+					"172.24.0.1:47645",
+					"172.25.0.1:47645",
+					"172.26.0.1:47645",
+					"172.27.0.1:47645"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:26:51.689141853Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         648454568615411,
+				"StableID":   "nLTchWog4611CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       648454568615411,
+				"Key":        "nodekey:e2b57d1fab7444bf5dab9a10ca383fad7c0ca4cd7aff3465dd79e9cd6f14d77f",
+				"DiscoKey":   "discokey:607988909e98850adf4c13d013b0815fc7594f7cfceefab7351a2e947864c170",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49898",
+					"10.65.0.27:49898",
+					"172.17.0.1:49898",
+					"172.18.0.1:49898",
+					"172.19.0.1:49898",
+					"172.20.0.1:49898",
+					"172.21.0.1:49898",
+					"172.22.0.1:49898",
+					"172.23.0.1:49898",
+					"172.24.0.1:49898",
+					"172.25.0.1:49898",
+					"172.26.0.1:49898",
+					"172.27.0.1:49898"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:26:49.010607278Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e2b57d1fab7444bf5dab9a10ca383fad7c0ca4cd7aff3465dd79e9cd6f14d77f",
+			"MachineKey": "mkey:cbb89cca75e7bb79021662f070215fe552be698922f6ac89ae7a7937d1b17a3c",
+			"Peers": [{
+				"ID":         4073872181115765,
+				"StableID":   "niKsKRi4pY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b2fd2227e6fef920dcfdb9f6d6a0d42f87084effc364c1b744fa7cedf95a428",
+				"DiscoKey":   "discokey:b2d54fb79cbf2a8bd5a81e9b41af84b420fdb150cc7429978e83df6b19e39765",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:39258",
+					"10.65.0.27:39258",
+					"172.17.0.1:39258",
+					"172.18.0.1:39258",
+					"172.19.0.1:39258",
+					"172.20.0.1:39258",
+					"172.21.0.1:39258",
+					"172.22.0.1:39258",
+					"172.23.0.1:39258",
+					"172.24.0.1:39258",
+					"172.25.0.1:39258",
+					"172.26.0.1:39258",
+					"172.27.0.1:39258"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:26:44.000588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8598559577817578,
+				"StableID":   "nM8TWcaJ9A21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47838c310880c867cfeb9afb9db7ced8f4cd1938891cecf346829319db07ef5a",
+				"DiscoKey":   "discokey:68601797acf56fec44fcf8dd0ab187da02b05a2d9b3f92ba81af8b7484e37e12",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:49374",
+					"10.65.0.27:49374",
+					"172.17.0.1:49374",
+					"172.18.0.1:49374",
+					"172.19.0.1:49374",
+					"172.20.0.1:49374",
+					"172.21.0.1:49374",
+					"172.22.0.1:49374",
+					"172.23.0.1:49374",
+					"172.24.0.1:49374",
+					"172.25.0.1:49374",
+					"172.26.0.1:49374",
+					"172.27.0.1:49374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:26:44.478308406Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4243276445468940,
+				"StableID":   "njay4Ggn8a11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c656e7bfd9a437d724205617492efe06e1d4eed75586962cdb3ab9bd152f3506",
+				"DiscoKey":   "discokey:f048658f0714e5620642955ddcd960d2c70b73a7ddba7ebe3f14680cf3c3551f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:40353",
+					"10.65.0.27:40353",
+					"172.17.0.1:40353",
+					"172.18.0.1:40353",
+					"172.19.0.1:40353",
+					"172.20.0.1:40353",
+					"172.21.0.1:40353",
+					"172.22.0.1:40353",
+					"172.23.0.1:40353",
+					"172.24.0.1:40353",
+					"172.25.0.1:40353",
+					"172.26.0.1:40353",
+					"172.27.0.1:40353"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:26:45.020203919Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6613494429872618,
+				"StableID":   "nXHNvUHGet11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e23b31364641820a02bf84ae75c2f74bf050eb491036e06b9589eee46625a313",
+				"DiscoKey":   "discokey:c10be57a23131c1477628c58655db1b3a9e396a0c16fb14d282f19971dcb2f0c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:42128",
+					"10.65.0.27:42128",
+					"172.17.0.1:42128",
+					"172.18.0.1:42128",
+					"172.19.0.1:42128",
+					"172.20.0.1:42128",
+					"172.21.0.1:42128",
+					"172.22.0.1:42128",
+					"172.23.0.1:42128",
+					"172.24.0.1:42128",
+					"172.25.0.1:42128",
+					"172.26.0.1:42128",
+					"172.27.0.1:42128"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:26:45.551366518Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         903866408710325,
+				"StableID":   "ntnmPC3N4811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:97624f7f91a2f10b47cf34387e3e55428057bd22642256d082331c143a468333",
+				"DiscoKey":   "discokey:b0b7aaa631a463a7c1bf9ba092e1c4da6a41e0816b9f755a0842331584f80a1f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55472",
+					"10.65.0.27:55472",
+					"172.17.0.1:55472",
+					"172.18.0.1:55472",
+					"172.19.0.1:55472",
+					"172.20.0.1:55472",
+					"172.21.0.1:55472",
+					"172.22.0.1:55472",
+					"172.23.0.1:55472",
+					"172.24.0.1:55472",
+					"172.25.0.1:55472",
+					"172.26.0.1:55472",
+					"172.27.0.1:55472"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:26:46.075189134Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7270970070352609,
+				"StableID":   "nxeHr943ny11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:49cc0e9f5deba8ec8fadecc8c3fb07b06936f07ef415d102b7f4a951f02f2374",
+				"DiscoKey":   "discokey:ea14ab63d3cf23bbc45e630019938965bfafb81a1eca0f91ccc4d44255f42448",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:44012",
+					"10.65.0.27:44012",
+					"172.17.0.1:44012",
+					"172.18.0.1:44012",
+					"172.19.0.1:44012",
+					"172.20.0.1:44012",
+					"172.21.0.1:44012",
+					"172.22.0.1:44012",
+					"172.23.0.1:44012",
+					"172.24.0.1:44012",
+					"172.25.0.1:44012",
+					"172.26.0.1:44012",
+					"172.27.0.1:44012"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:26:46.720919897Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8700466115858341,
+				"StableID":   "nEB6KWVTwA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:585bfffa5ac2a6323e7469c2ec38bf68b5ba6e5417def1a435b89cdb226e016f",
+				"DiscoKey":   "discokey:eddcc88f73426a19162116bcb1af08400f8a4dc410f6ab4f913a2bdaf2b3705d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51046",
+					"10.65.0.27:51046",
+					"172.17.0.1:51046",
+					"172.18.0.1:51046",
+					"172.19.0.1:51046",
+					"172.20.0.1:51046",
+					"172.21.0.1:51046",
+					"172.22.0.1:51046",
+					"172.23.0.1:51046",
+					"172.24.0.1:51046",
+					"172.25.0.1:51046",
+					"172.26.0.1:51046",
+					"172.27.0.1:51046"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:26:47.395944594Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         979170825313379,
+				"StableID":   "nNQZp7AUe811CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4720f19dfaf5895ce1bb1c8ac02ea32afe6f2af424cec20d8304f6abee01b417",
+				"DiscoKey":   "discokey:d7c02f2d59fa01b134c3917b68a15623829e1e963ae773062b7be5ca262aa63d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:41076",
+					"10.65.0.27:41076",
+					"172.17.0.1:41076",
+					"172.18.0.1:41076",
+					"172.19.0.1:41076",
+					"172.20.0.1:41076",
+					"172.21.0.1:41076",
+					"172.22.0.1:41076",
+					"172.23.0.1:41076",
+					"172.24.0.1:41076",
+					"172.25.0.1:41076",
+					"172.26.0.1:41076",
+					"172.27.0.1:41076"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:26:47.935685625Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4850606547643342,
+				"StableID":   "n52dV7Drse11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dd4e65691316056a84098ba81af4208c614c566a22694d65084822d41d1bf339",
+				"DiscoKey":   "discokey:e3e00787e8a2ad677cfb632dbe719e5713471febb8fb3cea8fb02799aed64543",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42728",
+					"10.65.0.27:42728",
+					"172.17.0.1:42728",
+					"172.18.0.1:42728",
+					"172.19.0.1:42728",
+					"172.20.0.1:42728",
+					"172.21.0.1:42728",
+					"172.22.0.1:42728",
+					"172.23.0.1:42728",
+					"172.24.0.1:42728",
+					"172.25.0.1:42728",
+					"172.26.0.1:42728",
+					"172.27.0.1:42728"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:26:48.476260994Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8000392402528055,
+				"StableID":   "nAzAZ3kPU521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:04bf6c9ab1aadb71cbbd84cd40623055f633397b0e05275318af91fd82868931",
+				"DiscoKey":   "discokey:cefa23898be4a9b12faa7b74ae10597785131a147db84bd977d984e4b22b5267",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:48857",
+					"10.65.0.27:48857",
+					"172.17.0.1:48857",
+					"172.18.0.1:48857",
+					"172.19.0.1:48857",
+					"172.20.0.1:48857",
+					"172.21.0.1:48857",
+					"172.22.0.1:48857",
+					"172.23.0.1:48857",
+					"172.24.0.1:48857",
+					"172.25.0.1:48857",
+					"172.26.0.1:48857",
+					"172.27.0.1:48857"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:26:49.559589908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3872874892352138,
+				"StableID":   "n7HcCfr2FX11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bb0b1e2d6305e56a36d3fc3126ad2defd58cb2e80cd01330773b5d4d194c6b1e",
+				"DiscoKey":   "discokey:ffbbd6f2ea536de55895dba0eb5fc0c698a2137c22cf8702f641363083038f49",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:39492",
+					"10.65.0.27:39492",
+					"172.17.0.1:39492",
+					"172.18.0.1:39492",
+					"172.19.0.1:39492",
+					"172.20.0.1:39492",
+					"172.21.0.1:39492",
+					"172.22.0.1:39492",
+					"172.23.0.1:39492",
+					"172.24.0.1:39492",
+					"172.25.0.1:39492",
+					"172.26.0.1:39492",
+					"172.27.0.1:39492"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:26:50.088026002Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6493343994844945,
+				"StableID":   "nUrvQt8rhs11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04e296ec0576179648249da90227a94bf11e1deecc7a4de2c5f41c676b404d2b",
+				"KeyExpiry":  "2026-11-09T09:26:50Z",
+				"DiscoKey":   "discokey:76b933c86179621b333b43e7bf1bb84886973c6ca03eeffc6a6f712361f5ce46",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:38220",
+					"10.65.0.27:38220",
+					"172.17.0.1:38220",
+					"172.18.0.1:38220",
+					"172.19.0.1:38220",
+					"172.20.0.1:38220",
+					"172.21.0.1:38220",
+					"172.22.0.1:38220",
+					"172.23.0.1:38220",
+					"172.24.0.1:38220",
+					"172.25.0.1:38220",
+					"172.26.0.1:38220",
+					"172.27.0.1:38220"
+				],
+				"HomeDERP": 18,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:26:50.613723105Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1496113877603016,
+				"StableID":   "nRdRAjNbgC11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:0ca2fa43faf6a93e863ff07417d8496270d56033cad4f88a990899845ad87418",
+				"KeyExpiry":  "2026-11-09T09:26:51Z",
+				"DiscoKey":   "discokey:c0ef6602bbddbf283bfe884e9673655c88bfb59dec98eb666002d1d0fd671646",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49007",
+					"10.65.0.27:49007",
+					"172.17.0.1:49007",
+					"172.18.0.1:49007",
+					"172.19.0.1:49007",
+					"172.20.0.1:49007",
+					"172.21.0.1:49007",
+					"172.22.0.1:49007",
+					"172.23.0.1:49007",
+					"172.24.0.1:49007",
+					"172.25.0.1:49007",
+					"172.26.0.1:49007",
+					"172.27.0.1:49007"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:26:51.146399576Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1641192705435100,
+				"StableID":   "nbeyNGMJpD11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:54fb5e0ac9bb3bfeced3d1b6f8f0250beb855298fe37be15afd2b532c333bd24",
+				"KeyExpiry":  "2026-11-09T09:26:51Z",
+				"DiscoKey":   "discokey:e21c2954729dc0ec4daacf8ba6bb199ed78b61ba605db2937a27bf8841cbcf1c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47645",
+					"10.65.0.27:47645",
+					"172.17.0.1:47645",
+					"172.18.0.1:47645",
+					"172.19.0.1:47645",
+					"172.20.0.1:47645",
+					"172.21.0.1:47645",
+					"172.22.0.1:47645",
+					"172.23.0.1:47645",
+					"172.24.0.1:47645",
+					"172.25.0.1:47645",
+					"172.26.0.1:47645",
+					"172.27.0.1:47645"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:26:51.689141853Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "648454568615411": {
+				"ID":          648454568615411,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-unicode-rtl-user.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-unicode-rtl-user.hujson
@@ -1,0 +1,22123 @@
+// ssh-unicode-rtl-user
+//
+// ssh users contains Arabic RTL identifier
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-13T09:27:38Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-unicode-rtl-user",
+	"description":    "ssh users contains Arabic RTL identifier",
+	"category":       "ssh",
+	"captured_at":    "2026-05-13T09:27:38.620241554Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                       \n  \n                                                                           \n                                                          \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh users contains Arabic RTL identifier\",\n\t\"id\":          \"ssh-unicode-rtl-user\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"thor@example.org\"],\n\t\t\"users\":  [\"مستخدم\"]\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-edges/ssh-unicode-rtl-user.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["thor@example.org"],
+				"users":  ["مستخدم"]
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6185889331350142,
+				"StableID":   "n9UTdkpbJq11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       6185889331350142,
+				"Key":        "nodekey:446c96b7c7aede556af9e96ec9eccdf3d9f562e4cb5457f06f8de776c27a6345",
+				"DiscoKey":   "discokey:4b6c28c4897b5bffd47568cbd543a2024b4286618b27e08520bf776760e6ce5d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41767",
+					"10.65.0.27:41767",
+					"172.17.0.1:41767",
+					"172.18.0.1:41767",
+					"172.19.0.1:41767",
+					"172.20.0.1:41767",
+					"172.21.0.1:41767",
+					"172.22.0.1:41767",
+					"172.23.0.1:41767",
+					"172.24.0.1:41767",
+					"172.25.0.1:41767",
+					"172.26.0.1:41767",
+					"172.27.0.1:41767",
+					"172.28.0.1:41767"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:27:57.314877464Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:446c96b7c7aede556af9e96ec9eccdf3d9f562e4cb5457f06f8de776c27a6345",
+			"MachineKey": "mkey:a6fa0041f67729d7409ecc2656bb4705f23905da2ecae9572b30e1cd3425d111",
+			"Peers": [{
+				"ID":         3211934370887534,
+				"StableID":   "nmpxb25h5S11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8909caa169b036242fb39f8e7a2946e135629cda6ba651e1384d85d76bb2e136",
+				"DiscoKey":   "discokey:38fd4ff4c3a2aaad2e0f94b4909d579e3ef424f630ef5bb61f7fa7624a0fe109",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43670",
+					"10.65.0.27:43670",
+					"172.17.0.1:43670",
+					"172.18.0.1:43670",
+					"172.19.0.1:43670",
+					"172.20.0.1:43670",
+					"172.21.0.1:43670",
+					"172.22.0.1:43670",
+					"172.23.0.1:43670",
+					"172.24.0.1:43670",
+					"172.25.0.1:43670",
+					"172.26.0.1:43670",
+					"172.27.0.1:43670",
+					"172.28.0.1:43670"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:27:41.096838369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         891554532683498,
+				"StableID":   "nRLx4Jdnx711CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:23e96a59a7758c8da3db258d7f24b285bd64f69005cfa7c69e081e5fe9166551",
+				"DiscoKey":   "discokey:f087a58298acc65bd5501f49f37f76b59980305c151c6bb69fbf28441b311136",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44596",
+					"10.65.0.27:44596",
+					"172.17.0.1:44596",
+					"172.18.0.1:44596",
+					"172.19.0.1:44596",
+					"172.20.0.1:44596",
+					"172.21.0.1:44596",
+					"172.22.0.1:44596",
+					"172.23.0.1:44596",
+					"172.24.0.1:44596",
+					"172.25.0.1:44596",
+					"172.26.0.1:44596",
+					"172.27.0.1:44596",
+					"172.28.0.1:44596"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:27:47.813891908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8689261536074906,
+				"StableID":   "n1GxxdAPrA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:beda087a1c0dfbd3e69290651073d64f0cf47cdf855cd2d0d2737bdf33d1000e",
+				"DiscoKey":   "discokey:00fe6422316407aaf964073d6b97637a0e30319a4f8b1bf482ca3e2e2d943451",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56267",
+					"10.65.0.27:56267",
+					"172.17.0.1:56267",
+					"172.18.0.1:56267",
+					"172.19.0.1:56267",
+					"172.20.0.1:56267",
+					"172.21.0.1:56267",
+					"172.22.0.1:56267",
+					"172.23.0.1:56267",
+					"172.24.0.1:56267",
+					"172.25.0.1:56267",
+					"172.26.0.1:56267",
+					"172.27.0.1:56267",
+					"172.28.0.1:56267"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:27:48.810842495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3080881849207967,
+				"StableID":   "nAnk2SYL4R11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0fa2626d84f36e0d07b5a50dba3b05306e4c229b92bd8790839fc32a8d0f33f",
+				"DiscoKey":   "discokey:fde3fbd4008cd54458dec2da09d8c84027adf0722a1af2fc7144fb9dd6c44236",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53414",
+					"10.65.0.27:53414",
+					"172.17.0.1:53414",
+					"172.18.0.1:53414",
+					"172.19.0.1:53414",
+					"172.20.0.1:53414",
+					"172.21.0.1:53414",
+					"172.22.0.1:53414",
+					"172.23.0.1:53414",
+					"172.24.0.1:53414",
+					"172.25.0.1:53414",
+					"172.26.0.1:53414",
+					"172.27.0.1:53414",
+					"172.28.0.1:53414"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:27:49.543578532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3079523750338012,
+				"StableID":   "nKC4VHsi3R11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:052d60473f81adf1a8658eb19285774bd4bd3c10acaa8e02fcc1532c909ee524",
+				"DiscoKey":   "discokey:9865c36aab8fbeb0a68e8152af473b50f9ae7249bc2330c6c8ab5717c961b527",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41888",
+					"10.65.0.27:41888",
+					"172.17.0.1:41888",
+					"172.18.0.1:41888",
+					"172.19.0.1:41888",
+					"172.20.0.1:41888",
+					"172.21.0.1:41888",
+					"172.22.0.1:41888",
+					"172.23.0.1:41888",
+					"172.24.0.1:41888",
+					"172.25.0.1:41888",
+					"172.26.0.1:41888",
+					"172.27.0.1:41888",
+					"172.28.0.1:41888"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:27:50.064703038Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3602096095486955,
+				"StableID":   "ngsFAUxP8V11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9ce396b31072e6bd0d6b6e4c20bc97d5a18dad911feb4f6da36e046a0cba1546",
+				"DiscoKey":   "discokey:8d3634650d1b920b7a16ea4c19d4febd02fb93bfe75919faf5cd2000a86f9f18",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:43362",
+					"10.65.0.27:43362",
+					"172.17.0.1:43362",
+					"172.18.0.1:43362",
+					"172.19.0.1:43362",
+					"172.20.0.1:43362",
+					"172.21.0.1:43362",
+					"172.22.0.1:43362",
+					"172.23.0.1:43362",
+					"172.24.0.1:43362",
+					"172.25.0.1:43362",
+					"172.26.0.1:43362",
+					"172.27.0.1:43362",
+					"172.28.0.1:43362"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:27:50.594356405Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4621335723968074,
+				"StableID":   "nbuZuse16d11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6b1098d726fc23a014b70951f9ca8272e5eb3eab41d30834dc0a67ea82bd4a72",
+				"DiscoKey":   "discokey:baaefb4b196af32b3f2430e34a79b21553ab27250a737094c30696ab818b616f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41690",
+					"10.65.0.27:41690",
+					"172.17.0.1:41690",
+					"172.18.0.1:41690",
+					"172.19.0.1:41690",
+					"172.20.0.1:41690",
+					"172.21.0.1:41690",
+					"172.22.0.1:41690",
+					"172.23.0.1:41690",
+					"172.24.0.1:41690",
+					"172.25.0.1:41690",
+					"172.26.0.1:41690",
+					"172.27.0.1:41690",
+					"172.28.0.1:41690"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:27:51.126268674Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1051500490490188,
+				"StableID":   "nymiep8ED911CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6c65c498ef62b3adf215c967ac5ebdee5e33836347a24713776cb447b489253",
+				"DiscoKey":   "discokey:205d80fafa08f1ff3f806eea5b4e585e7d0575d4a725e4cfc74dafe8ec4c2967",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57470",
+					"10.65.0.27:57470",
+					"172.17.0.1:57470",
+					"172.18.0.1:57470",
+					"172.19.0.1:57470",
+					"172.20.0.1:57470",
+					"172.21.0.1:57470",
+					"172.22.0.1:57470",
+					"172.23.0.1:57470",
+					"172.24.0.1:57470",
+					"172.25.0.1:57470",
+					"172.26.0.1:57470",
+					"172.27.0.1:57470",
+					"172.28.0.1:57470"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:27:51.657982734Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5664970112452116,
+				"StableID":   "nj8Q4DAgEm11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8d7322fce72a08ee2effd3c1d63fc112136850ac34b734881dbc5ce4d2be8d54",
+				"DiscoKey":   "discokey:c899d2b9244acd1648d804efa21ac482b91d0b1ade8054a2087004afa6abc33b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34978",
+					"10.65.0.27:34978",
+					"172.17.0.1:34978",
+					"172.18.0.1:34978",
+					"172.19.0.1:34978",
+					"172.20.0.1:34978",
+					"172.21.0.1:34978",
+					"172.22.0.1:34978",
+					"172.23.0.1:34978",
+					"172.24.0.1:34978",
+					"172.25.0.1:34978",
+					"172.26.0.1:34978",
+					"172.27.0.1:34978",
+					"172.28.0.1:34978"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:27:55.675123474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2152360805118066,
+				"StableID":   "nmEEwNsooH11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:671d85e034256a660bbe26fed087a45f1f1127bccc46559c889f8df5b8d2486b",
+				"DiscoKey":   "discokey:0fd70a6fb6cc6e8210d93caa64e83e7d07f766953afa34d530ed0e331ef6c034",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50128",
+					"10.65.0.27:50128",
+					"172.17.0.1:50128",
+					"172.18.0.1:50128",
+					"172.19.0.1:50128",
+					"172.20.0.1:50128",
+					"172.21.0.1:50128",
+					"172.22.0.1:50128",
+					"172.23.0.1:50128",
+					"172.24.0.1:50128",
+					"172.25.0.1:50128",
+					"172.26.0.1:50128",
+					"172.27.0.1:50128",
+					"172.28.0.1:50128"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:27:56.228560725Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         738223294216272,
+				"StableID":   "n3ApahsLm611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:05f60a2cc279aac711826029360dbe5d03d4bc630e10fb78a55420305c541653",
+				"DiscoKey":   "discokey:b1d89b9ad9ccde697334200260bfb9d508e8877e862b0dfbe2167ce03896c416",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:49690",
+					"10.65.0.27:49690",
+					"172.17.0.1:49690",
+					"172.18.0.1:49690",
+					"172.19.0.1:49690",
+					"172.20.0.1:49690",
+					"172.21.0.1:49690",
+					"172.22.0.1:49690",
+					"172.23.0.1:49690",
+					"172.24.0.1:49690",
+					"172.25.0.1:49690",
+					"172.26.0.1:49690",
+					"172.27.0.1:49690",
+					"172.28.0.1:49690"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:27:56.757475702Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         743480569061735,
+				"StableID":   "nQ1bxUyio611CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:af4abc7df7d7f0622554c62ffaeeabe61e1ff5de99260371a766f809b4fb897f",
+				"KeyExpiry":  "2026-11-09T09:27:57Z",
+				"DiscoKey":   "discokey:2a4ffef40aa02f91c0537b4698a85c49c0cfcb2541a06e66a74e352cd7e6d005",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51143",
+					"10.65.0.27:51143",
+					"172.17.0.1:51143",
+					"172.18.0.1:51143",
+					"172.19.0.1:51143",
+					"172.20.0.1:51143",
+					"172.21.0.1:51143",
+					"172.22.0.1:51143",
+					"172.23.0.1:51143",
+					"172.24.0.1:51143",
+					"172.25.0.1:51143",
+					"172.26.0.1:51143",
+					"172.27.0.1:51143",
+					"172.28.0.1:51143"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:27:57.824662269Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         161569710742361,
+				"StableID":   "nkWz4RABG211CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3dde659be7ae0292fda9c505e6b8eea725150988d9fb52dd59f83689a89e0d5b",
+				"KeyExpiry":  "2026-11-09T09:27:58Z",
+				"DiscoKey":   "discokey:127b04aecd80109be87aeb2dd29e672a503ddd35c7ef15eab179c76b8393ac1a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:42123",
+					"10.65.0.27:42123",
+					"172.17.0.1:42123",
+					"172.18.0.1:42123",
+					"172.19.0.1:42123",
+					"172.20.0.1:42123",
+					"172.21.0.1:42123",
+					"172.22.0.1:42123",
+					"172.23.0.1:42123",
+					"172.24.0.1:42123",
+					"172.25.0.1:42123",
+					"172.26.0.1:42123",
+					"172.27.0.1:42123",
+					"172.28.0.1:42123"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:27:58.358268966Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2697352476831753,
+				"StableID":   "nN1Ejnsd4N11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dc0edc563a9b0dfb4b1a1d97ad5047d664e387978bc4af2c41e5c3f655548d4d",
+				"KeyExpiry":  "2026-11-09T09:27:58Z",
+				"DiscoKey":   "discokey:1c9c6f15805c22bd74092f63f6285a3372189de31b4e80e5179251f7c7d0ae76",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59836",
+					"10.65.0.27:59836",
+					"172.17.0.1:59836",
+					"172.18.0.1:59836",
+					"172.19.0.1:59836",
+					"172.20.0.1:59836",
+					"172.21.0.1:59836",
+					"172.22.0.1:59836",
+					"172.23.0.1:59836",
+					"172.24.0.1:59836",
+					"172.25.0.1:59836",
+					"172.26.0.1:59836",
+					"172.27.0.1:59836",
+					"172.28.0.1:59836"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:27:58.881120954Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{
+				"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+				"sshUsers":   {"root": "", "مستخدم": "مستخدم"},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				}
+			}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6185889331350142": {
+				"ID":          6185889331350142,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		},
+		"ssh_rules": [{
+			"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+			"sshUsers":   {"root": "", "مستخدم": "مستخدم"},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}
+		}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3602096095486955,
+				"StableID":   "ngsFAUxP8V11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       3602096095486955,
+				"Key":        "nodekey:9ce396b31072e6bd0d6b6e4c20bc97d5a18dad911feb4f6da36e046a0cba1546",
+				"DiscoKey":   "discokey:8d3634650d1b920b7a16ea4c19d4febd02fb93bfe75919faf5cd2000a86f9f18",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:43362",
+					"10.65.0.27:43362",
+					"172.17.0.1:43362",
+					"172.18.0.1:43362",
+					"172.19.0.1:43362",
+					"172.20.0.1:43362",
+					"172.21.0.1:43362",
+					"172.22.0.1:43362",
+					"172.23.0.1:43362",
+					"172.24.0.1:43362",
+					"172.25.0.1:43362",
+					"172.26.0.1:43362",
+					"172.27.0.1:43362",
+					"172.28.0.1:43362"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:27:50.594356405Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9ce396b31072e6bd0d6b6e4c20bc97d5a18dad911feb4f6da36e046a0cba1546",
+			"MachineKey": "mkey:a64f2688b40dc888be92e93faf0c86c57c3bd2801d15850d689e0f12dbeb1f4d",
+			"Peers": [{
+				"ID":         3211934370887534,
+				"StableID":   "nmpxb25h5S11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8909caa169b036242fb39f8e7a2946e135629cda6ba651e1384d85d76bb2e136",
+				"DiscoKey":   "discokey:38fd4ff4c3a2aaad2e0f94b4909d579e3ef424f630ef5bb61f7fa7624a0fe109",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43670",
+					"10.65.0.27:43670",
+					"172.17.0.1:43670",
+					"172.18.0.1:43670",
+					"172.19.0.1:43670",
+					"172.20.0.1:43670",
+					"172.21.0.1:43670",
+					"172.22.0.1:43670",
+					"172.23.0.1:43670",
+					"172.24.0.1:43670",
+					"172.25.0.1:43670",
+					"172.26.0.1:43670",
+					"172.27.0.1:43670",
+					"172.28.0.1:43670"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:27:41.096838369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         891554532683498,
+				"StableID":   "nRLx4Jdnx711CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:23e96a59a7758c8da3db258d7f24b285bd64f69005cfa7c69e081e5fe9166551",
+				"DiscoKey":   "discokey:f087a58298acc65bd5501f49f37f76b59980305c151c6bb69fbf28441b311136",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44596",
+					"10.65.0.27:44596",
+					"172.17.0.1:44596",
+					"172.18.0.1:44596",
+					"172.19.0.1:44596",
+					"172.20.0.1:44596",
+					"172.21.0.1:44596",
+					"172.22.0.1:44596",
+					"172.23.0.1:44596",
+					"172.24.0.1:44596",
+					"172.25.0.1:44596",
+					"172.26.0.1:44596",
+					"172.27.0.1:44596",
+					"172.28.0.1:44596"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:27:47.813891908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8689261536074906,
+				"StableID":   "n1GxxdAPrA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:beda087a1c0dfbd3e69290651073d64f0cf47cdf855cd2d0d2737bdf33d1000e",
+				"DiscoKey":   "discokey:00fe6422316407aaf964073d6b97637a0e30319a4f8b1bf482ca3e2e2d943451",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56267",
+					"10.65.0.27:56267",
+					"172.17.0.1:56267",
+					"172.18.0.1:56267",
+					"172.19.0.1:56267",
+					"172.20.0.1:56267",
+					"172.21.0.1:56267",
+					"172.22.0.1:56267",
+					"172.23.0.1:56267",
+					"172.24.0.1:56267",
+					"172.25.0.1:56267",
+					"172.26.0.1:56267",
+					"172.27.0.1:56267",
+					"172.28.0.1:56267"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:27:48.810842495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3080881849207967,
+				"StableID":   "nAnk2SYL4R11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0fa2626d84f36e0d07b5a50dba3b05306e4c229b92bd8790839fc32a8d0f33f",
+				"DiscoKey":   "discokey:fde3fbd4008cd54458dec2da09d8c84027adf0722a1af2fc7144fb9dd6c44236",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53414",
+					"10.65.0.27:53414",
+					"172.17.0.1:53414",
+					"172.18.0.1:53414",
+					"172.19.0.1:53414",
+					"172.20.0.1:53414",
+					"172.21.0.1:53414",
+					"172.22.0.1:53414",
+					"172.23.0.1:53414",
+					"172.24.0.1:53414",
+					"172.25.0.1:53414",
+					"172.26.0.1:53414",
+					"172.27.0.1:53414",
+					"172.28.0.1:53414"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:27:49.543578532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3079523750338012,
+				"StableID":   "nKC4VHsi3R11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:052d60473f81adf1a8658eb19285774bd4bd3c10acaa8e02fcc1532c909ee524",
+				"DiscoKey":   "discokey:9865c36aab8fbeb0a68e8152af473b50f9ae7249bc2330c6c8ab5717c961b527",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41888",
+					"10.65.0.27:41888",
+					"172.17.0.1:41888",
+					"172.18.0.1:41888",
+					"172.19.0.1:41888",
+					"172.20.0.1:41888",
+					"172.21.0.1:41888",
+					"172.22.0.1:41888",
+					"172.23.0.1:41888",
+					"172.24.0.1:41888",
+					"172.25.0.1:41888",
+					"172.26.0.1:41888",
+					"172.27.0.1:41888",
+					"172.28.0.1:41888"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:27:50.064703038Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4621335723968074,
+				"StableID":   "nbuZuse16d11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6b1098d726fc23a014b70951f9ca8272e5eb3eab41d30834dc0a67ea82bd4a72",
+				"DiscoKey":   "discokey:baaefb4b196af32b3f2430e34a79b21553ab27250a737094c30696ab818b616f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41690",
+					"10.65.0.27:41690",
+					"172.17.0.1:41690",
+					"172.18.0.1:41690",
+					"172.19.0.1:41690",
+					"172.20.0.1:41690",
+					"172.21.0.1:41690",
+					"172.22.0.1:41690",
+					"172.23.0.1:41690",
+					"172.24.0.1:41690",
+					"172.25.0.1:41690",
+					"172.26.0.1:41690",
+					"172.27.0.1:41690",
+					"172.28.0.1:41690"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:27:51.126268674Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1051500490490188,
+				"StableID":   "nymiep8ED911CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6c65c498ef62b3adf215c967ac5ebdee5e33836347a24713776cb447b489253",
+				"DiscoKey":   "discokey:205d80fafa08f1ff3f806eea5b4e585e7d0575d4a725e4cfc74dafe8ec4c2967",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57470",
+					"10.65.0.27:57470",
+					"172.17.0.1:57470",
+					"172.18.0.1:57470",
+					"172.19.0.1:57470",
+					"172.20.0.1:57470",
+					"172.21.0.1:57470",
+					"172.22.0.1:57470",
+					"172.23.0.1:57470",
+					"172.24.0.1:57470",
+					"172.25.0.1:57470",
+					"172.26.0.1:57470",
+					"172.27.0.1:57470",
+					"172.28.0.1:57470"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:27:51.657982734Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5664970112452116,
+				"StableID":   "nj8Q4DAgEm11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8d7322fce72a08ee2effd3c1d63fc112136850ac34b734881dbc5ce4d2be8d54",
+				"DiscoKey":   "discokey:c899d2b9244acd1648d804efa21ac482b91d0b1ade8054a2087004afa6abc33b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34978",
+					"10.65.0.27:34978",
+					"172.17.0.1:34978",
+					"172.18.0.1:34978",
+					"172.19.0.1:34978",
+					"172.20.0.1:34978",
+					"172.21.0.1:34978",
+					"172.22.0.1:34978",
+					"172.23.0.1:34978",
+					"172.24.0.1:34978",
+					"172.25.0.1:34978",
+					"172.26.0.1:34978",
+					"172.27.0.1:34978",
+					"172.28.0.1:34978"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:27:55.675123474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2152360805118066,
+				"StableID":   "nmEEwNsooH11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:671d85e034256a660bbe26fed087a45f1f1127bccc46559c889f8df5b8d2486b",
+				"DiscoKey":   "discokey:0fd70a6fb6cc6e8210d93caa64e83e7d07f766953afa34d530ed0e331ef6c034",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50128",
+					"10.65.0.27:50128",
+					"172.17.0.1:50128",
+					"172.18.0.1:50128",
+					"172.19.0.1:50128",
+					"172.20.0.1:50128",
+					"172.21.0.1:50128",
+					"172.22.0.1:50128",
+					"172.23.0.1:50128",
+					"172.24.0.1:50128",
+					"172.25.0.1:50128",
+					"172.26.0.1:50128",
+					"172.27.0.1:50128",
+					"172.28.0.1:50128"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:27:56.228560725Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         738223294216272,
+				"StableID":   "n3ApahsLm611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:05f60a2cc279aac711826029360dbe5d03d4bc630e10fb78a55420305c541653",
+				"DiscoKey":   "discokey:b1d89b9ad9ccde697334200260bfb9d508e8877e862b0dfbe2167ce03896c416",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:49690",
+					"10.65.0.27:49690",
+					"172.17.0.1:49690",
+					"172.18.0.1:49690",
+					"172.19.0.1:49690",
+					"172.20.0.1:49690",
+					"172.21.0.1:49690",
+					"172.22.0.1:49690",
+					"172.23.0.1:49690",
+					"172.24.0.1:49690",
+					"172.25.0.1:49690",
+					"172.26.0.1:49690",
+					"172.27.0.1:49690",
+					"172.28.0.1:49690"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:27:56.757475702Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6185889331350142,
+				"StableID":   "n9UTdkpbJq11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:446c96b7c7aede556af9e96ec9eccdf3d9f562e4cb5457f06f8de776c27a6345",
+				"DiscoKey":   "discokey:4b6c28c4897b5bffd47568cbd543a2024b4286618b27e08520bf776760e6ce5d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41767",
+					"10.65.0.27:41767",
+					"172.17.0.1:41767",
+					"172.18.0.1:41767",
+					"172.19.0.1:41767",
+					"172.20.0.1:41767",
+					"172.21.0.1:41767",
+					"172.22.0.1:41767",
+					"172.23.0.1:41767",
+					"172.24.0.1:41767",
+					"172.25.0.1:41767",
+					"172.26.0.1:41767",
+					"172.27.0.1:41767",
+					"172.28.0.1:41767"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:27:57.314877464Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         743480569061735,
+				"StableID":   "nQ1bxUyio611CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:af4abc7df7d7f0622554c62ffaeeabe61e1ff5de99260371a766f809b4fb897f",
+				"KeyExpiry":  "2026-11-09T09:27:57Z",
+				"DiscoKey":   "discokey:2a4ffef40aa02f91c0537b4698a85c49c0cfcb2541a06e66a74e352cd7e6d005",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51143",
+					"10.65.0.27:51143",
+					"172.17.0.1:51143",
+					"172.18.0.1:51143",
+					"172.19.0.1:51143",
+					"172.20.0.1:51143",
+					"172.21.0.1:51143",
+					"172.22.0.1:51143",
+					"172.23.0.1:51143",
+					"172.24.0.1:51143",
+					"172.25.0.1:51143",
+					"172.26.0.1:51143",
+					"172.27.0.1:51143",
+					"172.28.0.1:51143"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:27:57.824662269Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         161569710742361,
+				"StableID":   "nkWz4RABG211CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3dde659be7ae0292fda9c505e6b8eea725150988d9fb52dd59f83689a89e0d5b",
+				"KeyExpiry":  "2026-11-09T09:27:58Z",
+				"DiscoKey":   "discokey:127b04aecd80109be87aeb2dd29e672a503ddd35c7ef15eab179c76b8393ac1a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:42123",
+					"10.65.0.27:42123",
+					"172.17.0.1:42123",
+					"172.18.0.1:42123",
+					"172.19.0.1:42123",
+					"172.20.0.1:42123",
+					"172.21.0.1:42123",
+					"172.22.0.1:42123",
+					"172.23.0.1:42123",
+					"172.24.0.1:42123",
+					"172.25.0.1:42123",
+					"172.26.0.1:42123",
+					"172.27.0.1:42123",
+					"172.28.0.1:42123"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:27:58.358268966Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2697352476831753,
+				"StableID":   "nN1Ejnsd4N11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dc0edc563a9b0dfb4b1a1d97ad5047d664e387978bc4af2c41e5c3f655548d4d",
+				"KeyExpiry":  "2026-11-09T09:27:58Z",
+				"DiscoKey":   "discokey:1c9c6f15805c22bd74092f63f6285a3372189de31b4e80e5179251f7c7d0ae76",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59836",
+					"10.65.0.27:59836",
+					"172.17.0.1:59836",
+					"172.18.0.1:59836",
+					"172.19.0.1:59836",
+					"172.20.0.1:59836",
+					"172.21.0.1:59836",
+					"172.22.0.1:59836",
+					"172.23.0.1:59836",
+					"172.24.0.1:59836",
+					"172.25.0.1:59836",
+					"172.26.0.1:59836",
+					"172.27.0.1:59836",
+					"172.28.0.1:59836"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:27:58.881120954Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3602096095486955": {
+				"ID":          3602096095486955,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2697352476831753,
+				"StableID":   "nN1Ejnsd4N11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dc0edc563a9b0dfb4b1a1d97ad5047d664e387978bc4af2c41e5c3f655548d4d",
+				"KeyExpiry":  "2026-11-09T09:27:58Z",
+				"DiscoKey":   "discokey:1c9c6f15805c22bd74092f63f6285a3372189de31b4e80e5179251f7c7d0ae76",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59836",
+					"10.65.0.27:59836",
+					"172.17.0.1:59836",
+					"172.18.0.1:59836",
+					"172.19.0.1:59836",
+					"172.20.0.1:59836",
+					"172.21.0.1:59836",
+					"172.22.0.1:59836",
+					"172.23.0.1:59836",
+					"172.24.0.1:59836",
+					"172.25.0.1:59836",
+					"172.26.0.1:59836",
+					"172.27.0.1:59836",
+					"172.28.0.1:59836"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:27:58.881120954Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:dc0edc563a9b0dfb4b1a1d97ad5047d664e387978bc4af2c41e5c3f655548d4d",
+			"MachineKey": "mkey:8344537282903ca80e1d76299b1ac4d791a95dd36cfb4489ad859134c81a7c51",
+			"Peers": [{
+				"ID":         3211934370887534,
+				"StableID":   "nmpxb25h5S11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8909caa169b036242fb39f8e7a2946e135629cda6ba651e1384d85d76bb2e136",
+				"DiscoKey":   "discokey:38fd4ff4c3a2aaad2e0f94b4909d579e3ef424f630ef5bb61f7fa7624a0fe109",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43670",
+					"10.65.0.27:43670",
+					"172.17.0.1:43670",
+					"172.18.0.1:43670",
+					"172.19.0.1:43670",
+					"172.20.0.1:43670",
+					"172.21.0.1:43670",
+					"172.22.0.1:43670",
+					"172.23.0.1:43670",
+					"172.24.0.1:43670",
+					"172.25.0.1:43670",
+					"172.26.0.1:43670",
+					"172.27.0.1:43670",
+					"172.28.0.1:43670"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:27:41.096838369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         891554532683498,
+				"StableID":   "nRLx4Jdnx711CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:23e96a59a7758c8da3db258d7f24b285bd64f69005cfa7c69e081e5fe9166551",
+				"DiscoKey":   "discokey:f087a58298acc65bd5501f49f37f76b59980305c151c6bb69fbf28441b311136",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44596",
+					"10.65.0.27:44596",
+					"172.17.0.1:44596",
+					"172.18.0.1:44596",
+					"172.19.0.1:44596",
+					"172.20.0.1:44596",
+					"172.21.0.1:44596",
+					"172.22.0.1:44596",
+					"172.23.0.1:44596",
+					"172.24.0.1:44596",
+					"172.25.0.1:44596",
+					"172.26.0.1:44596",
+					"172.27.0.1:44596",
+					"172.28.0.1:44596"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:27:47.813891908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8689261536074906,
+				"StableID":   "n1GxxdAPrA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:beda087a1c0dfbd3e69290651073d64f0cf47cdf855cd2d0d2737bdf33d1000e",
+				"DiscoKey":   "discokey:00fe6422316407aaf964073d6b97637a0e30319a4f8b1bf482ca3e2e2d943451",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56267",
+					"10.65.0.27:56267",
+					"172.17.0.1:56267",
+					"172.18.0.1:56267",
+					"172.19.0.1:56267",
+					"172.20.0.1:56267",
+					"172.21.0.1:56267",
+					"172.22.0.1:56267",
+					"172.23.0.1:56267",
+					"172.24.0.1:56267",
+					"172.25.0.1:56267",
+					"172.26.0.1:56267",
+					"172.27.0.1:56267",
+					"172.28.0.1:56267"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:27:48.810842495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3080881849207967,
+				"StableID":   "nAnk2SYL4R11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0fa2626d84f36e0d07b5a50dba3b05306e4c229b92bd8790839fc32a8d0f33f",
+				"DiscoKey":   "discokey:fde3fbd4008cd54458dec2da09d8c84027adf0722a1af2fc7144fb9dd6c44236",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53414",
+					"10.65.0.27:53414",
+					"172.17.0.1:53414",
+					"172.18.0.1:53414",
+					"172.19.0.1:53414",
+					"172.20.0.1:53414",
+					"172.21.0.1:53414",
+					"172.22.0.1:53414",
+					"172.23.0.1:53414",
+					"172.24.0.1:53414",
+					"172.25.0.1:53414",
+					"172.26.0.1:53414",
+					"172.27.0.1:53414",
+					"172.28.0.1:53414"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:27:49.543578532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3079523750338012,
+				"StableID":   "nKC4VHsi3R11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:052d60473f81adf1a8658eb19285774bd4bd3c10acaa8e02fcc1532c909ee524",
+				"DiscoKey":   "discokey:9865c36aab8fbeb0a68e8152af473b50f9ae7249bc2330c6c8ab5717c961b527",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41888",
+					"10.65.0.27:41888",
+					"172.17.0.1:41888",
+					"172.18.0.1:41888",
+					"172.19.0.1:41888",
+					"172.20.0.1:41888",
+					"172.21.0.1:41888",
+					"172.22.0.1:41888",
+					"172.23.0.1:41888",
+					"172.24.0.1:41888",
+					"172.25.0.1:41888",
+					"172.26.0.1:41888",
+					"172.27.0.1:41888",
+					"172.28.0.1:41888"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:27:50.064703038Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3602096095486955,
+				"StableID":   "ngsFAUxP8V11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9ce396b31072e6bd0d6b6e4c20bc97d5a18dad911feb4f6da36e046a0cba1546",
+				"DiscoKey":   "discokey:8d3634650d1b920b7a16ea4c19d4febd02fb93bfe75919faf5cd2000a86f9f18",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:43362",
+					"10.65.0.27:43362",
+					"172.17.0.1:43362",
+					"172.18.0.1:43362",
+					"172.19.0.1:43362",
+					"172.20.0.1:43362",
+					"172.21.0.1:43362",
+					"172.22.0.1:43362",
+					"172.23.0.1:43362",
+					"172.24.0.1:43362",
+					"172.25.0.1:43362",
+					"172.26.0.1:43362",
+					"172.27.0.1:43362",
+					"172.28.0.1:43362"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:27:50.594356405Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4621335723968074,
+				"StableID":   "nbuZuse16d11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6b1098d726fc23a014b70951f9ca8272e5eb3eab41d30834dc0a67ea82bd4a72",
+				"DiscoKey":   "discokey:baaefb4b196af32b3f2430e34a79b21553ab27250a737094c30696ab818b616f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41690",
+					"10.65.0.27:41690",
+					"172.17.0.1:41690",
+					"172.18.0.1:41690",
+					"172.19.0.1:41690",
+					"172.20.0.1:41690",
+					"172.21.0.1:41690",
+					"172.22.0.1:41690",
+					"172.23.0.1:41690",
+					"172.24.0.1:41690",
+					"172.25.0.1:41690",
+					"172.26.0.1:41690",
+					"172.27.0.1:41690",
+					"172.28.0.1:41690"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:27:51.126268674Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1051500490490188,
+				"StableID":   "nymiep8ED911CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6c65c498ef62b3adf215c967ac5ebdee5e33836347a24713776cb447b489253",
+				"DiscoKey":   "discokey:205d80fafa08f1ff3f806eea5b4e585e7d0575d4a725e4cfc74dafe8ec4c2967",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57470",
+					"10.65.0.27:57470",
+					"172.17.0.1:57470",
+					"172.18.0.1:57470",
+					"172.19.0.1:57470",
+					"172.20.0.1:57470",
+					"172.21.0.1:57470",
+					"172.22.0.1:57470",
+					"172.23.0.1:57470",
+					"172.24.0.1:57470",
+					"172.25.0.1:57470",
+					"172.26.0.1:57470",
+					"172.27.0.1:57470",
+					"172.28.0.1:57470"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:27:51.657982734Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5664970112452116,
+				"StableID":   "nj8Q4DAgEm11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8d7322fce72a08ee2effd3c1d63fc112136850ac34b734881dbc5ce4d2be8d54",
+				"DiscoKey":   "discokey:c899d2b9244acd1648d804efa21ac482b91d0b1ade8054a2087004afa6abc33b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34978",
+					"10.65.0.27:34978",
+					"172.17.0.1:34978",
+					"172.18.0.1:34978",
+					"172.19.0.1:34978",
+					"172.20.0.1:34978",
+					"172.21.0.1:34978",
+					"172.22.0.1:34978",
+					"172.23.0.1:34978",
+					"172.24.0.1:34978",
+					"172.25.0.1:34978",
+					"172.26.0.1:34978",
+					"172.27.0.1:34978",
+					"172.28.0.1:34978"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:27:55.675123474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2152360805118066,
+				"StableID":   "nmEEwNsooH11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:671d85e034256a660bbe26fed087a45f1f1127bccc46559c889f8df5b8d2486b",
+				"DiscoKey":   "discokey:0fd70a6fb6cc6e8210d93caa64e83e7d07f766953afa34d530ed0e331ef6c034",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50128",
+					"10.65.0.27:50128",
+					"172.17.0.1:50128",
+					"172.18.0.1:50128",
+					"172.19.0.1:50128",
+					"172.20.0.1:50128",
+					"172.21.0.1:50128",
+					"172.22.0.1:50128",
+					"172.23.0.1:50128",
+					"172.24.0.1:50128",
+					"172.25.0.1:50128",
+					"172.26.0.1:50128",
+					"172.27.0.1:50128",
+					"172.28.0.1:50128"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:27:56.228560725Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         738223294216272,
+				"StableID":   "n3ApahsLm611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:05f60a2cc279aac711826029360dbe5d03d4bc630e10fb78a55420305c541653",
+				"DiscoKey":   "discokey:b1d89b9ad9ccde697334200260bfb9d508e8877e862b0dfbe2167ce03896c416",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:49690",
+					"10.65.0.27:49690",
+					"172.17.0.1:49690",
+					"172.18.0.1:49690",
+					"172.19.0.1:49690",
+					"172.20.0.1:49690",
+					"172.21.0.1:49690",
+					"172.22.0.1:49690",
+					"172.23.0.1:49690",
+					"172.24.0.1:49690",
+					"172.25.0.1:49690",
+					"172.26.0.1:49690",
+					"172.27.0.1:49690",
+					"172.28.0.1:49690"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:27:56.757475702Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6185889331350142,
+				"StableID":   "n9UTdkpbJq11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:446c96b7c7aede556af9e96ec9eccdf3d9f562e4cb5457f06f8de776c27a6345",
+				"DiscoKey":   "discokey:4b6c28c4897b5bffd47568cbd543a2024b4286618b27e08520bf776760e6ce5d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41767",
+					"10.65.0.27:41767",
+					"172.17.0.1:41767",
+					"172.18.0.1:41767",
+					"172.19.0.1:41767",
+					"172.20.0.1:41767",
+					"172.21.0.1:41767",
+					"172.22.0.1:41767",
+					"172.23.0.1:41767",
+					"172.24.0.1:41767",
+					"172.25.0.1:41767",
+					"172.26.0.1:41767",
+					"172.27.0.1:41767",
+					"172.28.0.1:41767"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:27:57.314877464Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         743480569061735,
+				"StableID":   "nQ1bxUyio611CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:af4abc7df7d7f0622554c62ffaeeabe61e1ff5de99260371a766f809b4fb897f",
+				"KeyExpiry":  "2026-11-09T09:27:57Z",
+				"DiscoKey":   "discokey:2a4ffef40aa02f91c0537b4698a85c49c0cfcb2541a06e66a74e352cd7e6d005",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51143",
+					"10.65.0.27:51143",
+					"172.17.0.1:51143",
+					"172.18.0.1:51143",
+					"172.19.0.1:51143",
+					"172.20.0.1:51143",
+					"172.21.0.1:51143",
+					"172.22.0.1:51143",
+					"172.23.0.1:51143",
+					"172.24.0.1:51143",
+					"172.25.0.1:51143",
+					"172.26.0.1:51143",
+					"172.27.0.1:51143",
+					"172.28.0.1:51143"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:27:57.824662269Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         161569710742361,
+				"StableID":   "nkWz4RABG211CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3dde659be7ae0292fda9c505e6b8eea725150988d9fb52dd59f83689a89e0d5b",
+				"KeyExpiry":  "2026-11-09T09:27:58Z",
+				"DiscoKey":   "discokey:127b04aecd80109be87aeb2dd29e672a503ddd35c7ef15eab179c76b8393ac1a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:42123",
+					"10.65.0.27:42123",
+					"172.17.0.1:42123",
+					"172.18.0.1:42123",
+					"172.19.0.1:42123",
+					"172.20.0.1:42123",
+					"172.21.0.1:42123",
+					"172.22.0.1:42123",
+					"172.23.0.1:42123",
+					"172.24.0.1:42123",
+					"172.25.0.1:42123",
+					"172.26.0.1:42123",
+					"172.27.0.1:42123",
+					"172.28.0.1:42123"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:27:58.358268966Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8689261536074906,
+				"StableID":   "n1GxxdAPrA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       8689261536074906,
+				"Key":        "nodekey:beda087a1c0dfbd3e69290651073d64f0cf47cdf855cd2d0d2737bdf33d1000e",
+				"DiscoKey":   "discokey:00fe6422316407aaf964073d6b97637a0e30319a4f8b1bf482ca3e2e2d943451",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56267",
+					"10.65.0.27:56267",
+					"172.17.0.1:56267",
+					"172.18.0.1:56267",
+					"172.19.0.1:56267",
+					"172.20.0.1:56267",
+					"172.21.0.1:56267",
+					"172.22.0.1:56267",
+					"172.23.0.1:56267",
+					"172.24.0.1:56267",
+					"172.25.0.1:56267",
+					"172.26.0.1:56267",
+					"172.27.0.1:56267",
+					"172.28.0.1:56267"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:27:48.810842495Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:beda087a1c0dfbd3e69290651073d64f0cf47cdf855cd2d0d2737bdf33d1000e",
+			"MachineKey": "mkey:b8e98f137e5dee09b41782ac54e4490224fa442cc014b41d702f3b86ded70e59",
+			"Peers": [{
+				"ID":         3211934370887534,
+				"StableID":   "nmpxb25h5S11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8909caa169b036242fb39f8e7a2946e135629cda6ba651e1384d85d76bb2e136",
+				"DiscoKey":   "discokey:38fd4ff4c3a2aaad2e0f94b4909d579e3ef424f630ef5bb61f7fa7624a0fe109",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43670",
+					"10.65.0.27:43670",
+					"172.17.0.1:43670",
+					"172.18.0.1:43670",
+					"172.19.0.1:43670",
+					"172.20.0.1:43670",
+					"172.21.0.1:43670",
+					"172.22.0.1:43670",
+					"172.23.0.1:43670",
+					"172.24.0.1:43670",
+					"172.25.0.1:43670",
+					"172.26.0.1:43670",
+					"172.27.0.1:43670",
+					"172.28.0.1:43670"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:27:41.096838369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         891554532683498,
+				"StableID":   "nRLx4Jdnx711CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:23e96a59a7758c8da3db258d7f24b285bd64f69005cfa7c69e081e5fe9166551",
+				"DiscoKey":   "discokey:f087a58298acc65bd5501f49f37f76b59980305c151c6bb69fbf28441b311136",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44596",
+					"10.65.0.27:44596",
+					"172.17.0.1:44596",
+					"172.18.0.1:44596",
+					"172.19.0.1:44596",
+					"172.20.0.1:44596",
+					"172.21.0.1:44596",
+					"172.22.0.1:44596",
+					"172.23.0.1:44596",
+					"172.24.0.1:44596",
+					"172.25.0.1:44596",
+					"172.26.0.1:44596",
+					"172.27.0.1:44596",
+					"172.28.0.1:44596"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:27:47.813891908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3080881849207967,
+				"StableID":   "nAnk2SYL4R11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0fa2626d84f36e0d07b5a50dba3b05306e4c229b92bd8790839fc32a8d0f33f",
+				"DiscoKey":   "discokey:fde3fbd4008cd54458dec2da09d8c84027adf0722a1af2fc7144fb9dd6c44236",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53414",
+					"10.65.0.27:53414",
+					"172.17.0.1:53414",
+					"172.18.0.1:53414",
+					"172.19.0.1:53414",
+					"172.20.0.1:53414",
+					"172.21.0.1:53414",
+					"172.22.0.1:53414",
+					"172.23.0.1:53414",
+					"172.24.0.1:53414",
+					"172.25.0.1:53414",
+					"172.26.0.1:53414",
+					"172.27.0.1:53414",
+					"172.28.0.1:53414"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:27:49.543578532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3079523750338012,
+				"StableID":   "nKC4VHsi3R11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:052d60473f81adf1a8658eb19285774bd4bd3c10acaa8e02fcc1532c909ee524",
+				"DiscoKey":   "discokey:9865c36aab8fbeb0a68e8152af473b50f9ae7249bc2330c6c8ab5717c961b527",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41888",
+					"10.65.0.27:41888",
+					"172.17.0.1:41888",
+					"172.18.0.1:41888",
+					"172.19.0.1:41888",
+					"172.20.0.1:41888",
+					"172.21.0.1:41888",
+					"172.22.0.1:41888",
+					"172.23.0.1:41888",
+					"172.24.0.1:41888",
+					"172.25.0.1:41888",
+					"172.26.0.1:41888",
+					"172.27.0.1:41888",
+					"172.28.0.1:41888"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:27:50.064703038Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3602096095486955,
+				"StableID":   "ngsFAUxP8V11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9ce396b31072e6bd0d6b6e4c20bc97d5a18dad911feb4f6da36e046a0cba1546",
+				"DiscoKey":   "discokey:8d3634650d1b920b7a16ea4c19d4febd02fb93bfe75919faf5cd2000a86f9f18",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:43362",
+					"10.65.0.27:43362",
+					"172.17.0.1:43362",
+					"172.18.0.1:43362",
+					"172.19.0.1:43362",
+					"172.20.0.1:43362",
+					"172.21.0.1:43362",
+					"172.22.0.1:43362",
+					"172.23.0.1:43362",
+					"172.24.0.1:43362",
+					"172.25.0.1:43362",
+					"172.26.0.1:43362",
+					"172.27.0.1:43362",
+					"172.28.0.1:43362"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:27:50.594356405Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4621335723968074,
+				"StableID":   "nbuZuse16d11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6b1098d726fc23a014b70951f9ca8272e5eb3eab41d30834dc0a67ea82bd4a72",
+				"DiscoKey":   "discokey:baaefb4b196af32b3f2430e34a79b21553ab27250a737094c30696ab818b616f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41690",
+					"10.65.0.27:41690",
+					"172.17.0.1:41690",
+					"172.18.0.1:41690",
+					"172.19.0.1:41690",
+					"172.20.0.1:41690",
+					"172.21.0.1:41690",
+					"172.22.0.1:41690",
+					"172.23.0.1:41690",
+					"172.24.0.1:41690",
+					"172.25.0.1:41690",
+					"172.26.0.1:41690",
+					"172.27.0.1:41690",
+					"172.28.0.1:41690"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:27:51.126268674Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1051500490490188,
+				"StableID":   "nymiep8ED911CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6c65c498ef62b3adf215c967ac5ebdee5e33836347a24713776cb447b489253",
+				"DiscoKey":   "discokey:205d80fafa08f1ff3f806eea5b4e585e7d0575d4a725e4cfc74dafe8ec4c2967",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57470",
+					"10.65.0.27:57470",
+					"172.17.0.1:57470",
+					"172.18.0.1:57470",
+					"172.19.0.1:57470",
+					"172.20.0.1:57470",
+					"172.21.0.1:57470",
+					"172.22.0.1:57470",
+					"172.23.0.1:57470",
+					"172.24.0.1:57470",
+					"172.25.0.1:57470",
+					"172.26.0.1:57470",
+					"172.27.0.1:57470",
+					"172.28.0.1:57470"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:27:51.657982734Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5664970112452116,
+				"StableID":   "nj8Q4DAgEm11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8d7322fce72a08ee2effd3c1d63fc112136850ac34b734881dbc5ce4d2be8d54",
+				"DiscoKey":   "discokey:c899d2b9244acd1648d804efa21ac482b91d0b1ade8054a2087004afa6abc33b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34978",
+					"10.65.0.27:34978",
+					"172.17.0.1:34978",
+					"172.18.0.1:34978",
+					"172.19.0.1:34978",
+					"172.20.0.1:34978",
+					"172.21.0.1:34978",
+					"172.22.0.1:34978",
+					"172.23.0.1:34978",
+					"172.24.0.1:34978",
+					"172.25.0.1:34978",
+					"172.26.0.1:34978",
+					"172.27.0.1:34978",
+					"172.28.0.1:34978"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:27:55.675123474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2152360805118066,
+				"StableID":   "nmEEwNsooH11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:671d85e034256a660bbe26fed087a45f1f1127bccc46559c889f8df5b8d2486b",
+				"DiscoKey":   "discokey:0fd70a6fb6cc6e8210d93caa64e83e7d07f766953afa34d530ed0e331ef6c034",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50128",
+					"10.65.0.27:50128",
+					"172.17.0.1:50128",
+					"172.18.0.1:50128",
+					"172.19.0.1:50128",
+					"172.20.0.1:50128",
+					"172.21.0.1:50128",
+					"172.22.0.1:50128",
+					"172.23.0.1:50128",
+					"172.24.0.1:50128",
+					"172.25.0.1:50128",
+					"172.26.0.1:50128",
+					"172.27.0.1:50128",
+					"172.28.0.1:50128"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:27:56.228560725Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         738223294216272,
+				"StableID":   "n3ApahsLm611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:05f60a2cc279aac711826029360dbe5d03d4bc630e10fb78a55420305c541653",
+				"DiscoKey":   "discokey:b1d89b9ad9ccde697334200260bfb9d508e8877e862b0dfbe2167ce03896c416",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:49690",
+					"10.65.0.27:49690",
+					"172.17.0.1:49690",
+					"172.18.0.1:49690",
+					"172.19.0.1:49690",
+					"172.20.0.1:49690",
+					"172.21.0.1:49690",
+					"172.22.0.1:49690",
+					"172.23.0.1:49690",
+					"172.24.0.1:49690",
+					"172.25.0.1:49690",
+					"172.26.0.1:49690",
+					"172.27.0.1:49690",
+					"172.28.0.1:49690"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:27:56.757475702Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6185889331350142,
+				"StableID":   "n9UTdkpbJq11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:446c96b7c7aede556af9e96ec9eccdf3d9f562e4cb5457f06f8de776c27a6345",
+				"DiscoKey":   "discokey:4b6c28c4897b5bffd47568cbd543a2024b4286618b27e08520bf776760e6ce5d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41767",
+					"10.65.0.27:41767",
+					"172.17.0.1:41767",
+					"172.18.0.1:41767",
+					"172.19.0.1:41767",
+					"172.20.0.1:41767",
+					"172.21.0.1:41767",
+					"172.22.0.1:41767",
+					"172.23.0.1:41767",
+					"172.24.0.1:41767",
+					"172.25.0.1:41767",
+					"172.26.0.1:41767",
+					"172.27.0.1:41767",
+					"172.28.0.1:41767"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:27:57.314877464Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         743480569061735,
+				"StableID":   "nQ1bxUyio611CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:af4abc7df7d7f0622554c62ffaeeabe61e1ff5de99260371a766f809b4fb897f",
+				"KeyExpiry":  "2026-11-09T09:27:57Z",
+				"DiscoKey":   "discokey:2a4ffef40aa02f91c0537b4698a85c49c0cfcb2541a06e66a74e352cd7e6d005",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51143",
+					"10.65.0.27:51143",
+					"172.17.0.1:51143",
+					"172.18.0.1:51143",
+					"172.19.0.1:51143",
+					"172.20.0.1:51143",
+					"172.21.0.1:51143",
+					"172.22.0.1:51143",
+					"172.23.0.1:51143",
+					"172.24.0.1:51143",
+					"172.25.0.1:51143",
+					"172.26.0.1:51143",
+					"172.27.0.1:51143",
+					"172.28.0.1:51143"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:27:57.824662269Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         161569710742361,
+				"StableID":   "nkWz4RABG211CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3dde659be7ae0292fda9c505e6b8eea725150988d9fb52dd59f83689a89e0d5b",
+				"KeyExpiry":  "2026-11-09T09:27:58Z",
+				"DiscoKey":   "discokey:127b04aecd80109be87aeb2dd29e672a503ddd35c7ef15eab179c76b8393ac1a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:42123",
+					"10.65.0.27:42123",
+					"172.17.0.1:42123",
+					"172.18.0.1:42123",
+					"172.19.0.1:42123",
+					"172.20.0.1:42123",
+					"172.21.0.1:42123",
+					"172.22.0.1:42123",
+					"172.23.0.1:42123",
+					"172.24.0.1:42123",
+					"172.25.0.1:42123",
+					"172.26.0.1:42123",
+					"172.27.0.1:42123",
+					"172.28.0.1:42123"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:27:58.358268966Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2697352476831753,
+				"StableID":   "nN1Ejnsd4N11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dc0edc563a9b0dfb4b1a1d97ad5047d664e387978bc4af2c41e5c3f655548d4d",
+				"KeyExpiry":  "2026-11-09T09:27:58Z",
+				"DiscoKey":   "discokey:1c9c6f15805c22bd74092f63f6285a3372189de31b4e80e5179251f7c7d0ae76",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59836",
+					"10.65.0.27:59836",
+					"172.17.0.1:59836",
+					"172.18.0.1:59836",
+					"172.19.0.1:59836",
+					"172.20.0.1:59836",
+					"172.21.0.1:59836",
+					"172.22.0.1:59836",
+					"172.23.0.1:59836",
+					"172.24.0.1:59836",
+					"172.25.0.1:59836",
+					"172.26.0.1:59836",
+					"172.27.0.1:59836",
+					"172.28.0.1:59836"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:27:58.881120954Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8689261536074906": {
+				"ID":          8689261536074906,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1051500490490188,
+				"StableID":   "nymiep8ED911CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1051500490490188,
+				"Key":        "nodekey:a6c65c498ef62b3adf215c967ac5ebdee5e33836347a24713776cb447b489253",
+				"DiscoKey":   "discokey:205d80fafa08f1ff3f806eea5b4e585e7d0575d4a725e4cfc74dafe8ec4c2967",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57470",
+					"10.65.0.27:57470",
+					"172.17.0.1:57470",
+					"172.18.0.1:57470",
+					"172.19.0.1:57470",
+					"172.20.0.1:57470",
+					"172.21.0.1:57470",
+					"172.22.0.1:57470",
+					"172.23.0.1:57470",
+					"172.24.0.1:57470",
+					"172.25.0.1:57470",
+					"172.26.0.1:57470",
+					"172.27.0.1:57470",
+					"172.28.0.1:57470"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:27:51.657982734Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a6c65c498ef62b3adf215c967ac5ebdee5e33836347a24713776cb447b489253",
+			"MachineKey": "mkey:1c78e395e6dbbfdb7f9c39b4690484abc5689cf37b82adc714f02437eb468529",
+			"Peers": [{
+				"ID":         3211934370887534,
+				"StableID":   "nmpxb25h5S11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8909caa169b036242fb39f8e7a2946e135629cda6ba651e1384d85d76bb2e136",
+				"DiscoKey":   "discokey:38fd4ff4c3a2aaad2e0f94b4909d579e3ef424f630ef5bb61f7fa7624a0fe109",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43670",
+					"10.65.0.27:43670",
+					"172.17.0.1:43670",
+					"172.18.0.1:43670",
+					"172.19.0.1:43670",
+					"172.20.0.1:43670",
+					"172.21.0.1:43670",
+					"172.22.0.1:43670",
+					"172.23.0.1:43670",
+					"172.24.0.1:43670",
+					"172.25.0.1:43670",
+					"172.26.0.1:43670",
+					"172.27.0.1:43670",
+					"172.28.0.1:43670"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:27:41.096838369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         891554532683498,
+				"StableID":   "nRLx4Jdnx711CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:23e96a59a7758c8da3db258d7f24b285bd64f69005cfa7c69e081e5fe9166551",
+				"DiscoKey":   "discokey:f087a58298acc65bd5501f49f37f76b59980305c151c6bb69fbf28441b311136",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44596",
+					"10.65.0.27:44596",
+					"172.17.0.1:44596",
+					"172.18.0.1:44596",
+					"172.19.0.1:44596",
+					"172.20.0.1:44596",
+					"172.21.0.1:44596",
+					"172.22.0.1:44596",
+					"172.23.0.1:44596",
+					"172.24.0.1:44596",
+					"172.25.0.1:44596",
+					"172.26.0.1:44596",
+					"172.27.0.1:44596",
+					"172.28.0.1:44596"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:27:47.813891908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8689261536074906,
+				"StableID":   "n1GxxdAPrA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:beda087a1c0dfbd3e69290651073d64f0cf47cdf855cd2d0d2737bdf33d1000e",
+				"DiscoKey":   "discokey:00fe6422316407aaf964073d6b97637a0e30319a4f8b1bf482ca3e2e2d943451",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56267",
+					"10.65.0.27:56267",
+					"172.17.0.1:56267",
+					"172.18.0.1:56267",
+					"172.19.0.1:56267",
+					"172.20.0.1:56267",
+					"172.21.0.1:56267",
+					"172.22.0.1:56267",
+					"172.23.0.1:56267",
+					"172.24.0.1:56267",
+					"172.25.0.1:56267",
+					"172.26.0.1:56267",
+					"172.27.0.1:56267",
+					"172.28.0.1:56267"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:27:48.810842495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3080881849207967,
+				"StableID":   "nAnk2SYL4R11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0fa2626d84f36e0d07b5a50dba3b05306e4c229b92bd8790839fc32a8d0f33f",
+				"DiscoKey":   "discokey:fde3fbd4008cd54458dec2da09d8c84027adf0722a1af2fc7144fb9dd6c44236",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53414",
+					"10.65.0.27:53414",
+					"172.17.0.1:53414",
+					"172.18.0.1:53414",
+					"172.19.0.1:53414",
+					"172.20.0.1:53414",
+					"172.21.0.1:53414",
+					"172.22.0.1:53414",
+					"172.23.0.1:53414",
+					"172.24.0.1:53414",
+					"172.25.0.1:53414",
+					"172.26.0.1:53414",
+					"172.27.0.1:53414",
+					"172.28.0.1:53414"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:27:49.543578532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3079523750338012,
+				"StableID":   "nKC4VHsi3R11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:052d60473f81adf1a8658eb19285774bd4bd3c10acaa8e02fcc1532c909ee524",
+				"DiscoKey":   "discokey:9865c36aab8fbeb0a68e8152af473b50f9ae7249bc2330c6c8ab5717c961b527",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41888",
+					"10.65.0.27:41888",
+					"172.17.0.1:41888",
+					"172.18.0.1:41888",
+					"172.19.0.1:41888",
+					"172.20.0.1:41888",
+					"172.21.0.1:41888",
+					"172.22.0.1:41888",
+					"172.23.0.1:41888",
+					"172.24.0.1:41888",
+					"172.25.0.1:41888",
+					"172.26.0.1:41888",
+					"172.27.0.1:41888",
+					"172.28.0.1:41888"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:27:50.064703038Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3602096095486955,
+				"StableID":   "ngsFAUxP8V11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9ce396b31072e6bd0d6b6e4c20bc97d5a18dad911feb4f6da36e046a0cba1546",
+				"DiscoKey":   "discokey:8d3634650d1b920b7a16ea4c19d4febd02fb93bfe75919faf5cd2000a86f9f18",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:43362",
+					"10.65.0.27:43362",
+					"172.17.0.1:43362",
+					"172.18.0.1:43362",
+					"172.19.0.1:43362",
+					"172.20.0.1:43362",
+					"172.21.0.1:43362",
+					"172.22.0.1:43362",
+					"172.23.0.1:43362",
+					"172.24.0.1:43362",
+					"172.25.0.1:43362",
+					"172.26.0.1:43362",
+					"172.27.0.1:43362",
+					"172.28.0.1:43362"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:27:50.594356405Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4621335723968074,
+				"StableID":   "nbuZuse16d11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6b1098d726fc23a014b70951f9ca8272e5eb3eab41d30834dc0a67ea82bd4a72",
+				"DiscoKey":   "discokey:baaefb4b196af32b3f2430e34a79b21553ab27250a737094c30696ab818b616f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41690",
+					"10.65.0.27:41690",
+					"172.17.0.1:41690",
+					"172.18.0.1:41690",
+					"172.19.0.1:41690",
+					"172.20.0.1:41690",
+					"172.21.0.1:41690",
+					"172.22.0.1:41690",
+					"172.23.0.1:41690",
+					"172.24.0.1:41690",
+					"172.25.0.1:41690",
+					"172.26.0.1:41690",
+					"172.27.0.1:41690",
+					"172.28.0.1:41690"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:27:51.126268674Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5664970112452116,
+				"StableID":   "nj8Q4DAgEm11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8d7322fce72a08ee2effd3c1d63fc112136850ac34b734881dbc5ce4d2be8d54",
+				"DiscoKey":   "discokey:c899d2b9244acd1648d804efa21ac482b91d0b1ade8054a2087004afa6abc33b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34978",
+					"10.65.0.27:34978",
+					"172.17.0.1:34978",
+					"172.18.0.1:34978",
+					"172.19.0.1:34978",
+					"172.20.0.1:34978",
+					"172.21.0.1:34978",
+					"172.22.0.1:34978",
+					"172.23.0.1:34978",
+					"172.24.0.1:34978",
+					"172.25.0.1:34978",
+					"172.26.0.1:34978",
+					"172.27.0.1:34978",
+					"172.28.0.1:34978"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:27:55.675123474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2152360805118066,
+				"StableID":   "nmEEwNsooH11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:671d85e034256a660bbe26fed087a45f1f1127bccc46559c889f8df5b8d2486b",
+				"DiscoKey":   "discokey:0fd70a6fb6cc6e8210d93caa64e83e7d07f766953afa34d530ed0e331ef6c034",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50128",
+					"10.65.0.27:50128",
+					"172.17.0.1:50128",
+					"172.18.0.1:50128",
+					"172.19.0.1:50128",
+					"172.20.0.1:50128",
+					"172.21.0.1:50128",
+					"172.22.0.1:50128",
+					"172.23.0.1:50128",
+					"172.24.0.1:50128",
+					"172.25.0.1:50128",
+					"172.26.0.1:50128",
+					"172.27.0.1:50128",
+					"172.28.0.1:50128"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:27:56.228560725Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         738223294216272,
+				"StableID":   "n3ApahsLm611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:05f60a2cc279aac711826029360dbe5d03d4bc630e10fb78a55420305c541653",
+				"DiscoKey":   "discokey:b1d89b9ad9ccde697334200260bfb9d508e8877e862b0dfbe2167ce03896c416",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:49690",
+					"10.65.0.27:49690",
+					"172.17.0.1:49690",
+					"172.18.0.1:49690",
+					"172.19.0.1:49690",
+					"172.20.0.1:49690",
+					"172.21.0.1:49690",
+					"172.22.0.1:49690",
+					"172.23.0.1:49690",
+					"172.24.0.1:49690",
+					"172.25.0.1:49690",
+					"172.26.0.1:49690",
+					"172.27.0.1:49690",
+					"172.28.0.1:49690"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:27:56.757475702Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6185889331350142,
+				"StableID":   "n9UTdkpbJq11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:446c96b7c7aede556af9e96ec9eccdf3d9f562e4cb5457f06f8de776c27a6345",
+				"DiscoKey":   "discokey:4b6c28c4897b5bffd47568cbd543a2024b4286618b27e08520bf776760e6ce5d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41767",
+					"10.65.0.27:41767",
+					"172.17.0.1:41767",
+					"172.18.0.1:41767",
+					"172.19.0.1:41767",
+					"172.20.0.1:41767",
+					"172.21.0.1:41767",
+					"172.22.0.1:41767",
+					"172.23.0.1:41767",
+					"172.24.0.1:41767",
+					"172.25.0.1:41767",
+					"172.26.0.1:41767",
+					"172.27.0.1:41767",
+					"172.28.0.1:41767"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:27:57.314877464Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         743480569061735,
+				"StableID":   "nQ1bxUyio611CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:af4abc7df7d7f0622554c62ffaeeabe61e1ff5de99260371a766f809b4fb897f",
+				"KeyExpiry":  "2026-11-09T09:27:57Z",
+				"DiscoKey":   "discokey:2a4ffef40aa02f91c0537b4698a85c49c0cfcb2541a06e66a74e352cd7e6d005",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51143",
+					"10.65.0.27:51143",
+					"172.17.0.1:51143",
+					"172.18.0.1:51143",
+					"172.19.0.1:51143",
+					"172.20.0.1:51143",
+					"172.21.0.1:51143",
+					"172.22.0.1:51143",
+					"172.23.0.1:51143",
+					"172.24.0.1:51143",
+					"172.25.0.1:51143",
+					"172.26.0.1:51143",
+					"172.27.0.1:51143",
+					"172.28.0.1:51143"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:27:57.824662269Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         161569710742361,
+				"StableID":   "nkWz4RABG211CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3dde659be7ae0292fda9c505e6b8eea725150988d9fb52dd59f83689a89e0d5b",
+				"KeyExpiry":  "2026-11-09T09:27:58Z",
+				"DiscoKey":   "discokey:127b04aecd80109be87aeb2dd29e672a503ddd35c7ef15eab179c76b8393ac1a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:42123",
+					"10.65.0.27:42123",
+					"172.17.0.1:42123",
+					"172.18.0.1:42123",
+					"172.19.0.1:42123",
+					"172.20.0.1:42123",
+					"172.21.0.1:42123",
+					"172.22.0.1:42123",
+					"172.23.0.1:42123",
+					"172.24.0.1:42123",
+					"172.25.0.1:42123",
+					"172.26.0.1:42123",
+					"172.27.0.1:42123",
+					"172.28.0.1:42123"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:27:58.358268966Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2697352476831753,
+				"StableID":   "nN1Ejnsd4N11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dc0edc563a9b0dfb4b1a1d97ad5047d664e387978bc4af2c41e5c3f655548d4d",
+				"KeyExpiry":  "2026-11-09T09:27:58Z",
+				"DiscoKey":   "discokey:1c9c6f15805c22bd74092f63f6285a3372189de31b4e80e5179251f7c7d0ae76",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59836",
+					"10.65.0.27:59836",
+					"172.17.0.1:59836",
+					"172.18.0.1:59836",
+					"172.19.0.1:59836",
+					"172.20.0.1:59836",
+					"172.21.0.1:59836",
+					"172.22.0.1:59836",
+					"172.23.0.1:59836",
+					"172.24.0.1:59836",
+					"172.25.0.1:59836",
+					"172.26.0.1:59836",
+					"172.27.0.1:59836",
+					"172.28.0.1:59836"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:27:58.881120954Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1051500490490188": {
+				"ID":          1051500490490188,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         743480569061735,
+				"StableID":   "nQ1bxUyio611CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:af4abc7df7d7f0622554c62ffaeeabe61e1ff5de99260371a766f809b4fb897f",
+				"KeyExpiry":  "2026-11-09T09:27:57Z",
+				"DiscoKey":   "discokey:2a4ffef40aa02f91c0537b4698a85c49c0cfcb2541a06e66a74e352cd7e6d005",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51143",
+					"10.65.0.27:51143",
+					"172.17.0.1:51143",
+					"172.18.0.1:51143",
+					"172.19.0.1:51143",
+					"172.20.0.1:51143",
+					"172.21.0.1:51143",
+					"172.22.0.1:51143",
+					"172.23.0.1:51143",
+					"172.24.0.1:51143",
+					"172.25.0.1:51143",
+					"172.26.0.1:51143",
+					"172.27.0.1:51143",
+					"172.28.0.1:51143"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:27:57.824662269Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:af4abc7df7d7f0622554c62ffaeeabe61e1ff5de99260371a766f809b4fb897f",
+			"MachineKey": "mkey:3059c3739e5181dc837c0a999bf0d0588b718c136d40085f644e3b2aee286c59",
+			"Peers": [{
+				"ID":         3211934370887534,
+				"StableID":   "nmpxb25h5S11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8909caa169b036242fb39f8e7a2946e135629cda6ba651e1384d85d76bb2e136",
+				"DiscoKey":   "discokey:38fd4ff4c3a2aaad2e0f94b4909d579e3ef424f630ef5bb61f7fa7624a0fe109",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43670",
+					"10.65.0.27:43670",
+					"172.17.0.1:43670",
+					"172.18.0.1:43670",
+					"172.19.0.1:43670",
+					"172.20.0.1:43670",
+					"172.21.0.1:43670",
+					"172.22.0.1:43670",
+					"172.23.0.1:43670",
+					"172.24.0.1:43670",
+					"172.25.0.1:43670",
+					"172.26.0.1:43670",
+					"172.27.0.1:43670",
+					"172.28.0.1:43670"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:27:41.096838369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         891554532683498,
+				"StableID":   "nRLx4Jdnx711CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:23e96a59a7758c8da3db258d7f24b285bd64f69005cfa7c69e081e5fe9166551",
+				"DiscoKey":   "discokey:f087a58298acc65bd5501f49f37f76b59980305c151c6bb69fbf28441b311136",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44596",
+					"10.65.0.27:44596",
+					"172.17.0.1:44596",
+					"172.18.0.1:44596",
+					"172.19.0.1:44596",
+					"172.20.0.1:44596",
+					"172.21.0.1:44596",
+					"172.22.0.1:44596",
+					"172.23.0.1:44596",
+					"172.24.0.1:44596",
+					"172.25.0.1:44596",
+					"172.26.0.1:44596",
+					"172.27.0.1:44596",
+					"172.28.0.1:44596"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:27:47.813891908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8689261536074906,
+				"StableID":   "n1GxxdAPrA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:beda087a1c0dfbd3e69290651073d64f0cf47cdf855cd2d0d2737bdf33d1000e",
+				"DiscoKey":   "discokey:00fe6422316407aaf964073d6b97637a0e30319a4f8b1bf482ca3e2e2d943451",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56267",
+					"10.65.0.27:56267",
+					"172.17.0.1:56267",
+					"172.18.0.1:56267",
+					"172.19.0.1:56267",
+					"172.20.0.1:56267",
+					"172.21.0.1:56267",
+					"172.22.0.1:56267",
+					"172.23.0.1:56267",
+					"172.24.0.1:56267",
+					"172.25.0.1:56267",
+					"172.26.0.1:56267",
+					"172.27.0.1:56267",
+					"172.28.0.1:56267"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:27:48.810842495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3080881849207967,
+				"StableID":   "nAnk2SYL4R11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0fa2626d84f36e0d07b5a50dba3b05306e4c229b92bd8790839fc32a8d0f33f",
+				"DiscoKey":   "discokey:fde3fbd4008cd54458dec2da09d8c84027adf0722a1af2fc7144fb9dd6c44236",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53414",
+					"10.65.0.27:53414",
+					"172.17.0.1:53414",
+					"172.18.0.1:53414",
+					"172.19.0.1:53414",
+					"172.20.0.1:53414",
+					"172.21.0.1:53414",
+					"172.22.0.1:53414",
+					"172.23.0.1:53414",
+					"172.24.0.1:53414",
+					"172.25.0.1:53414",
+					"172.26.0.1:53414",
+					"172.27.0.1:53414",
+					"172.28.0.1:53414"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:27:49.543578532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3079523750338012,
+				"StableID":   "nKC4VHsi3R11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:052d60473f81adf1a8658eb19285774bd4bd3c10acaa8e02fcc1532c909ee524",
+				"DiscoKey":   "discokey:9865c36aab8fbeb0a68e8152af473b50f9ae7249bc2330c6c8ab5717c961b527",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41888",
+					"10.65.0.27:41888",
+					"172.17.0.1:41888",
+					"172.18.0.1:41888",
+					"172.19.0.1:41888",
+					"172.20.0.1:41888",
+					"172.21.0.1:41888",
+					"172.22.0.1:41888",
+					"172.23.0.1:41888",
+					"172.24.0.1:41888",
+					"172.25.0.1:41888",
+					"172.26.0.1:41888",
+					"172.27.0.1:41888",
+					"172.28.0.1:41888"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:27:50.064703038Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3602096095486955,
+				"StableID":   "ngsFAUxP8V11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9ce396b31072e6bd0d6b6e4c20bc97d5a18dad911feb4f6da36e046a0cba1546",
+				"DiscoKey":   "discokey:8d3634650d1b920b7a16ea4c19d4febd02fb93bfe75919faf5cd2000a86f9f18",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:43362",
+					"10.65.0.27:43362",
+					"172.17.0.1:43362",
+					"172.18.0.1:43362",
+					"172.19.0.1:43362",
+					"172.20.0.1:43362",
+					"172.21.0.1:43362",
+					"172.22.0.1:43362",
+					"172.23.0.1:43362",
+					"172.24.0.1:43362",
+					"172.25.0.1:43362",
+					"172.26.0.1:43362",
+					"172.27.0.1:43362",
+					"172.28.0.1:43362"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:27:50.594356405Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4621335723968074,
+				"StableID":   "nbuZuse16d11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6b1098d726fc23a014b70951f9ca8272e5eb3eab41d30834dc0a67ea82bd4a72",
+				"DiscoKey":   "discokey:baaefb4b196af32b3f2430e34a79b21553ab27250a737094c30696ab818b616f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41690",
+					"10.65.0.27:41690",
+					"172.17.0.1:41690",
+					"172.18.0.1:41690",
+					"172.19.0.1:41690",
+					"172.20.0.1:41690",
+					"172.21.0.1:41690",
+					"172.22.0.1:41690",
+					"172.23.0.1:41690",
+					"172.24.0.1:41690",
+					"172.25.0.1:41690",
+					"172.26.0.1:41690",
+					"172.27.0.1:41690",
+					"172.28.0.1:41690"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:27:51.126268674Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1051500490490188,
+				"StableID":   "nymiep8ED911CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6c65c498ef62b3adf215c967ac5ebdee5e33836347a24713776cb447b489253",
+				"DiscoKey":   "discokey:205d80fafa08f1ff3f806eea5b4e585e7d0575d4a725e4cfc74dafe8ec4c2967",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57470",
+					"10.65.0.27:57470",
+					"172.17.0.1:57470",
+					"172.18.0.1:57470",
+					"172.19.0.1:57470",
+					"172.20.0.1:57470",
+					"172.21.0.1:57470",
+					"172.22.0.1:57470",
+					"172.23.0.1:57470",
+					"172.24.0.1:57470",
+					"172.25.0.1:57470",
+					"172.26.0.1:57470",
+					"172.27.0.1:57470",
+					"172.28.0.1:57470"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:27:51.657982734Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5664970112452116,
+				"StableID":   "nj8Q4DAgEm11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8d7322fce72a08ee2effd3c1d63fc112136850ac34b734881dbc5ce4d2be8d54",
+				"DiscoKey":   "discokey:c899d2b9244acd1648d804efa21ac482b91d0b1ade8054a2087004afa6abc33b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34978",
+					"10.65.0.27:34978",
+					"172.17.0.1:34978",
+					"172.18.0.1:34978",
+					"172.19.0.1:34978",
+					"172.20.0.1:34978",
+					"172.21.0.1:34978",
+					"172.22.0.1:34978",
+					"172.23.0.1:34978",
+					"172.24.0.1:34978",
+					"172.25.0.1:34978",
+					"172.26.0.1:34978",
+					"172.27.0.1:34978",
+					"172.28.0.1:34978"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:27:55.675123474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2152360805118066,
+				"StableID":   "nmEEwNsooH11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:671d85e034256a660bbe26fed087a45f1f1127bccc46559c889f8df5b8d2486b",
+				"DiscoKey":   "discokey:0fd70a6fb6cc6e8210d93caa64e83e7d07f766953afa34d530ed0e331ef6c034",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50128",
+					"10.65.0.27:50128",
+					"172.17.0.1:50128",
+					"172.18.0.1:50128",
+					"172.19.0.1:50128",
+					"172.20.0.1:50128",
+					"172.21.0.1:50128",
+					"172.22.0.1:50128",
+					"172.23.0.1:50128",
+					"172.24.0.1:50128",
+					"172.25.0.1:50128",
+					"172.26.0.1:50128",
+					"172.27.0.1:50128",
+					"172.28.0.1:50128"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:27:56.228560725Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         738223294216272,
+				"StableID":   "n3ApahsLm611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:05f60a2cc279aac711826029360dbe5d03d4bc630e10fb78a55420305c541653",
+				"DiscoKey":   "discokey:b1d89b9ad9ccde697334200260bfb9d508e8877e862b0dfbe2167ce03896c416",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:49690",
+					"10.65.0.27:49690",
+					"172.17.0.1:49690",
+					"172.18.0.1:49690",
+					"172.19.0.1:49690",
+					"172.20.0.1:49690",
+					"172.21.0.1:49690",
+					"172.22.0.1:49690",
+					"172.23.0.1:49690",
+					"172.24.0.1:49690",
+					"172.25.0.1:49690",
+					"172.26.0.1:49690",
+					"172.27.0.1:49690",
+					"172.28.0.1:49690"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:27:56.757475702Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6185889331350142,
+				"StableID":   "n9UTdkpbJq11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:446c96b7c7aede556af9e96ec9eccdf3d9f562e4cb5457f06f8de776c27a6345",
+				"DiscoKey":   "discokey:4b6c28c4897b5bffd47568cbd543a2024b4286618b27e08520bf776760e6ce5d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41767",
+					"10.65.0.27:41767",
+					"172.17.0.1:41767",
+					"172.18.0.1:41767",
+					"172.19.0.1:41767",
+					"172.20.0.1:41767",
+					"172.21.0.1:41767",
+					"172.22.0.1:41767",
+					"172.23.0.1:41767",
+					"172.24.0.1:41767",
+					"172.25.0.1:41767",
+					"172.26.0.1:41767",
+					"172.27.0.1:41767",
+					"172.28.0.1:41767"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:27:57.314877464Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         161569710742361,
+				"StableID":   "nkWz4RABG211CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3dde659be7ae0292fda9c505e6b8eea725150988d9fb52dd59f83689a89e0d5b",
+				"KeyExpiry":  "2026-11-09T09:27:58Z",
+				"DiscoKey":   "discokey:127b04aecd80109be87aeb2dd29e672a503ddd35c7ef15eab179c76b8393ac1a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:42123",
+					"10.65.0.27:42123",
+					"172.17.0.1:42123",
+					"172.18.0.1:42123",
+					"172.19.0.1:42123",
+					"172.20.0.1:42123",
+					"172.21.0.1:42123",
+					"172.22.0.1:42123",
+					"172.23.0.1:42123",
+					"172.24.0.1:42123",
+					"172.25.0.1:42123",
+					"172.26.0.1:42123",
+					"172.27.0.1:42123",
+					"172.28.0.1:42123"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:27:58.358268966Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2697352476831753,
+				"StableID":   "nN1Ejnsd4N11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dc0edc563a9b0dfb4b1a1d97ad5047d664e387978bc4af2c41e5c3f655548d4d",
+				"KeyExpiry":  "2026-11-09T09:27:58Z",
+				"DiscoKey":   "discokey:1c9c6f15805c22bd74092f63f6285a3372189de31b4e80e5179251f7c7d0ae76",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59836",
+					"10.65.0.27:59836",
+					"172.17.0.1:59836",
+					"172.18.0.1:59836",
+					"172.19.0.1:59836",
+					"172.20.0.1:59836",
+					"172.21.0.1:59836",
+					"172.22.0.1:59836",
+					"172.23.0.1:59836",
+					"172.24.0.1:59836",
+					"172.25.0.1:59836",
+					"172.26.0.1:59836",
+					"172.27.0.1:59836",
+					"172.28.0.1:59836"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:27:58.881120954Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         738223294216272,
+				"StableID":   "n3ApahsLm611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       738223294216272,
+				"Key":        "nodekey:05f60a2cc279aac711826029360dbe5d03d4bc630e10fb78a55420305c541653",
+				"DiscoKey":   "discokey:b1d89b9ad9ccde697334200260bfb9d508e8877e862b0dfbe2167ce03896c416",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:49690",
+					"10.65.0.27:49690",
+					"172.17.0.1:49690",
+					"172.18.0.1:49690",
+					"172.19.0.1:49690",
+					"172.20.0.1:49690",
+					"172.21.0.1:49690",
+					"172.22.0.1:49690",
+					"172.23.0.1:49690",
+					"172.24.0.1:49690",
+					"172.25.0.1:49690",
+					"172.26.0.1:49690",
+					"172.27.0.1:49690",
+					"172.28.0.1:49690"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:27:56.757475702Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:05f60a2cc279aac711826029360dbe5d03d4bc630e10fb78a55420305c541653",
+			"MachineKey": "mkey:7f2906e87e5504849d525bc3be14f072e4910efccec37ea3273381fec9995811",
+			"Peers": [{
+				"ID":         3211934370887534,
+				"StableID":   "nmpxb25h5S11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8909caa169b036242fb39f8e7a2946e135629cda6ba651e1384d85d76bb2e136",
+				"DiscoKey":   "discokey:38fd4ff4c3a2aaad2e0f94b4909d579e3ef424f630ef5bb61f7fa7624a0fe109",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43670",
+					"10.65.0.27:43670",
+					"172.17.0.1:43670",
+					"172.18.0.1:43670",
+					"172.19.0.1:43670",
+					"172.20.0.1:43670",
+					"172.21.0.1:43670",
+					"172.22.0.1:43670",
+					"172.23.0.1:43670",
+					"172.24.0.1:43670",
+					"172.25.0.1:43670",
+					"172.26.0.1:43670",
+					"172.27.0.1:43670",
+					"172.28.0.1:43670"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:27:41.096838369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         891554532683498,
+				"StableID":   "nRLx4Jdnx711CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:23e96a59a7758c8da3db258d7f24b285bd64f69005cfa7c69e081e5fe9166551",
+				"DiscoKey":   "discokey:f087a58298acc65bd5501f49f37f76b59980305c151c6bb69fbf28441b311136",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44596",
+					"10.65.0.27:44596",
+					"172.17.0.1:44596",
+					"172.18.0.1:44596",
+					"172.19.0.1:44596",
+					"172.20.0.1:44596",
+					"172.21.0.1:44596",
+					"172.22.0.1:44596",
+					"172.23.0.1:44596",
+					"172.24.0.1:44596",
+					"172.25.0.1:44596",
+					"172.26.0.1:44596",
+					"172.27.0.1:44596",
+					"172.28.0.1:44596"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:27:47.813891908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8689261536074906,
+				"StableID":   "n1GxxdAPrA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:beda087a1c0dfbd3e69290651073d64f0cf47cdf855cd2d0d2737bdf33d1000e",
+				"DiscoKey":   "discokey:00fe6422316407aaf964073d6b97637a0e30319a4f8b1bf482ca3e2e2d943451",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56267",
+					"10.65.0.27:56267",
+					"172.17.0.1:56267",
+					"172.18.0.1:56267",
+					"172.19.0.1:56267",
+					"172.20.0.1:56267",
+					"172.21.0.1:56267",
+					"172.22.0.1:56267",
+					"172.23.0.1:56267",
+					"172.24.0.1:56267",
+					"172.25.0.1:56267",
+					"172.26.0.1:56267",
+					"172.27.0.1:56267",
+					"172.28.0.1:56267"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:27:48.810842495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3080881849207967,
+				"StableID":   "nAnk2SYL4R11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0fa2626d84f36e0d07b5a50dba3b05306e4c229b92bd8790839fc32a8d0f33f",
+				"DiscoKey":   "discokey:fde3fbd4008cd54458dec2da09d8c84027adf0722a1af2fc7144fb9dd6c44236",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53414",
+					"10.65.0.27:53414",
+					"172.17.0.1:53414",
+					"172.18.0.1:53414",
+					"172.19.0.1:53414",
+					"172.20.0.1:53414",
+					"172.21.0.1:53414",
+					"172.22.0.1:53414",
+					"172.23.0.1:53414",
+					"172.24.0.1:53414",
+					"172.25.0.1:53414",
+					"172.26.0.1:53414",
+					"172.27.0.1:53414",
+					"172.28.0.1:53414"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:27:49.543578532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3079523750338012,
+				"StableID":   "nKC4VHsi3R11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:052d60473f81adf1a8658eb19285774bd4bd3c10acaa8e02fcc1532c909ee524",
+				"DiscoKey":   "discokey:9865c36aab8fbeb0a68e8152af473b50f9ae7249bc2330c6c8ab5717c961b527",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41888",
+					"10.65.0.27:41888",
+					"172.17.0.1:41888",
+					"172.18.0.1:41888",
+					"172.19.0.1:41888",
+					"172.20.0.1:41888",
+					"172.21.0.1:41888",
+					"172.22.0.1:41888",
+					"172.23.0.1:41888",
+					"172.24.0.1:41888",
+					"172.25.0.1:41888",
+					"172.26.0.1:41888",
+					"172.27.0.1:41888",
+					"172.28.0.1:41888"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:27:50.064703038Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3602096095486955,
+				"StableID":   "ngsFAUxP8V11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9ce396b31072e6bd0d6b6e4c20bc97d5a18dad911feb4f6da36e046a0cba1546",
+				"DiscoKey":   "discokey:8d3634650d1b920b7a16ea4c19d4febd02fb93bfe75919faf5cd2000a86f9f18",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:43362",
+					"10.65.0.27:43362",
+					"172.17.0.1:43362",
+					"172.18.0.1:43362",
+					"172.19.0.1:43362",
+					"172.20.0.1:43362",
+					"172.21.0.1:43362",
+					"172.22.0.1:43362",
+					"172.23.0.1:43362",
+					"172.24.0.1:43362",
+					"172.25.0.1:43362",
+					"172.26.0.1:43362",
+					"172.27.0.1:43362",
+					"172.28.0.1:43362"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:27:50.594356405Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4621335723968074,
+				"StableID":   "nbuZuse16d11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6b1098d726fc23a014b70951f9ca8272e5eb3eab41d30834dc0a67ea82bd4a72",
+				"DiscoKey":   "discokey:baaefb4b196af32b3f2430e34a79b21553ab27250a737094c30696ab818b616f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41690",
+					"10.65.0.27:41690",
+					"172.17.0.1:41690",
+					"172.18.0.1:41690",
+					"172.19.0.1:41690",
+					"172.20.0.1:41690",
+					"172.21.0.1:41690",
+					"172.22.0.1:41690",
+					"172.23.0.1:41690",
+					"172.24.0.1:41690",
+					"172.25.0.1:41690",
+					"172.26.0.1:41690",
+					"172.27.0.1:41690",
+					"172.28.0.1:41690"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:27:51.126268674Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1051500490490188,
+				"StableID":   "nymiep8ED911CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6c65c498ef62b3adf215c967ac5ebdee5e33836347a24713776cb447b489253",
+				"DiscoKey":   "discokey:205d80fafa08f1ff3f806eea5b4e585e7d0575d4a725e4cfc74dafe8ec4c2967",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57470",
+					"10.65.0.27:57470",
+					"172.17.0.1:57470",
+					"172.18.0.1:57470",
+					"172.19.0.1:57470",
+					"172.20.0.1:57470",
+					"172.21.0.1:57470",
+					"172.22.0.1:57470",
+					"172.23.0.1:57470",
+					"172.24.0.1:57470",
+					"172.25.0.1:57470",
+					"172.26.0.1:57470",
+					"172.27.0.1:57470",
+					"172.28.0.1:57470"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:27:51.657982734Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5664970112452116,
+				"StableID":   "nj8Q4DAgEm11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8d7322fce72a08ee2effd3c1d63fc112136850ac34b734881dbc5ce4d2be8d54",
+				"DiscoKey":   "discokey:c899d2b9244acd1648d804efa21ac482b91d0b1ade8054a2087004afa6abc33b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34978",
+					"10.65.0.27:34978",
+					"172.17.0.1:34978",
+					"172.18.0.1:34978",
+					"172.19.0.1:34978",
+					"172.20.0.1:34978",
+					"172.21.0.1:34978",
+					"172.22.0.1:34978",
+					"172.23.0.1:34978",
+					"172.24.0.1:34978",
+					"172.25.0.1:34978",
+					"172.26.0.1:34978",
+					"172.27.0.1:34978",
+					"172.28.0.1:34978"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:27:55.675123474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2152360805118066,
+				"StableID":   "nmEEwNsooH11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:671d85e034256a660bbe26fed087a45f1f1127bccc46559c889f8df5b8d2486b",
+				"DiscoKey":   "discokey:0fd70a6fb6cc6e8210d93caa64e83e7d07f766953afa34d530ed0e331ef6c034",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50128",
+					"10.65.0.27:50128",
+					"172.17.0.1:50128",
+					"172.18.0.1:50128",
+					"172.19.0.1:50128",
+					"172.20.0.1:50128",
+					"172.21.0.1:50128",
+					"172.22.0.1:50128",
+					"172.23.0.1:50128",
+					"172.24.0.1:50128",
+					"172.25.0.1:50128",
+					"172.26.0.1:50128",
+					"172.27.0.1:50128",
+					"172.28.0.1:50128"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:27:56.228560725Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6185889331350142,
+				"StableID":   "n9UTdkpbJq11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:446c96b7c7aede556af9e96ec9eccdf3d9f562e4cb5457f06f8de776c27a6345",
+				"DiscoKey":   "discokey:4b6c28c4897b5bffd47568cbd543a2024b4286618b27e08520bf776760e6ce5d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41767",
+					"10.65.0.27:41767",
+					"172.17.0.1:41767",
+					"172.18.0.1:41767",
+					"172.19.0.1:41767",
+					"172.20.0.1:41767",
+					"172.21.0.1:41767",
+					"172.22.0.1:41767",
+					"172.23.0.1:41767",
+					"172.24.0.1:41767",
+					"172.25.0.1:41767",
+					"172.26.0.1:41767",
+					"172.27.0.1:41767",
+					"172.28.0.1:41767"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:27:57.314877464Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         743480569061735,
+				"StableID":   "nQ1bxUyio611CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:af4abc7df7d7f0622554c62ffaeeabe61e1ff5de99260371a766f809b4fb897f",
+				"KeyExpiry":  "2026-11-09T09:27:57Z",
+				"DiscoKey":   "discokey:2a4ffef40aa02f91c0537b4698a85c49c0cfcb2541a06e66a74e352cd7e6d005",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51143",
+					"10.65.0.27:51143",
+					"172.17.0.1:51143",
+					"172.18.0.1:51143",
+					"172.19.0.1:51143",
+					"172.20.0.1:51143",
+					"172.21.0.1:51143",
+					"172.22.0.1:51143",
+					"172.23.0.1:51143",
+					"172.24.0.1:51143",
+					"172.25.0.1:51143",
+					"172.26.0.1:51143",
+					"172.27.0.1:51143",
+					"172.28.0.1:51143"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:27:57.824662269Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         161569710742361,
+				"StableID":   "nkWz4RABG211CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3dde659be7ae0292fda9c505e6b8eea725150988d9fb52dd59f83689a89e0d5b",
+				"KeyExpiry":  "2026-11-09T09:27:58Z",
+				"DiscoKey":   "discokey:127b04aecd80109be87aeb2dd29e672a503ddd35c7ef15eab179c76b8393ac1a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:42123",
+					"10.65.0.27:42123",
+					"172.17.0.1:42123",
+					"172.18.0.1:42123",
+					"172.19.0.1:42123",
+					"172.20.0.1:42123",
+					"172.21.0.1:42123",
+					"172.22.0.1:42123",
+					"172.23.0.1:42123",
+					"172.24.0.1:42123",
+					"172.25.0.1:42123",
+					"172.26.0.1:42123",
+					"172.27.0.1:42123",
+					"172.28.0.1:42123"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:27:58.358268966Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2697352476831753,
+				"StableID":   "nN1Ejnsd4N11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dc0edc563a9b0dfb4b1a1d97ad5047d664e387978bc4af2c41e5c3f655548d4d",
+				"KeyExpiry":  "2026-11-09T09:27:58Z",
+				"DiscoKey":   "discokey:1c9c6f15805c22bd74092f63f6285a3372189de31b4e80e5179251f7c7d0ae76",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59836",
+					"10.65.0.27:59836",
+					"172.17.0.1:59836",
+					"172.18.0.1:59836",
+					"172.19.0.1:59836",
+					"172.20.0.1:59836",
+					"172.21.0.1:59836",
+					"172.22.0.1:59836",
+					"172.23.0.1:59836",
+					"172.24.0.1:59836",
+					"172.25.0.1:59836",
+					"172.26.0.1:59836",
+					"172.27.0.1:59836",
+					"172.28.0.1:59836"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:27:58.881120954Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "738223294216272": {
+				"ID":          738223294216272,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         891554532683498,
+				"StableID":   "nRLx4Jdnx711CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       891554532683498,
+				"Key":        "nodekey:23e96a59a7758c8da3db258d7f24b285bd64f69005cfa7c69e081e5fe9166551",
+				"DiscoKey":   "discokey:f087a58298acc65bd5501f49f37f76b59980305c151c6bb69fbf28441b311136",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44596",
+					"10.65.0.27:44596",
+					"172.17.0.1:44596",
+					"172.18.0.1:44596",
+					"172.19.0.1:44596",
+					"172.20.0.1:44596",
+					"172.21.0.1:44596",
+					"172.22.0.1:44596",
+					"172.23.0.1:44596",
+					"172.24.0.1:44596",
+					"172.25.0.1:44596",
+					"172.26.0.1:44596",
+					"172.27.0.1:44596",
+					"172.28.0.1:44596"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:27:47.813891908Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:23e96a59a7758c8da3db258d7f24b285bd64f69005cfa7c69e081e5fe9166551",
+			"MachineKey": "mkey:703cf0482d63e13c3b7fdfcb1576bf9436926e3c9c86ec42140bd46a7dd1f343",
+			"Peers": [{
+				"ID":         3211934370887534,
+				"StableID":   "nmpxb25h5S11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8909caa169b036242fb39f8e7a2946e135629cda6ba651e1384d85d76bb2e136",
+				"DiscoKey":   "discokey:38fd4ff4c3a2aaad2e0f94b4909d579e3ef424f630ef5bb61f7fa7624a0fe109",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43670",
+					"10.65.0.27:43670",
+					"172.17.0.1:43670",
+					"172.18.0.1:43670",
+					"172.19.0.1:43670",
+					"172.20.0.1:43670",
+					"172.21.0.1:43670",
+					"172.22.0.1:43670",
+					"172.23.0.1:43670",
+					"172.24.0.1:43670",
+					"172.25.0.1:43670",
+					"172.26.0.1:43670",
+					"172.27.0.1:43670",
+					"172.28.0.1:43670"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:27:41.096838369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8689261536074906,
+				"StableID":   "n1GxxdAPrA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:beda087a1c0dfbd3e69290651073d64f0cf47cdf855cd2d0d2737bdf33d1000e",
+				"DiscoKey":   "discokey:00fe6422316407aaf964073d6b97637a0e30319a4f8b1bf482ca3e2e2d943451",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56267",
+					"10.65.0.27:56267",
+					"172.17.0.1:56267",
+					"172.18.0.1:56267",
+					"172.19.0.1:56267",
+					"172.20.0.1:56267",
+					"172.21.0.1:56267",
+					"172.22.0.1:56267",
+					"172.23.0.1:56267",
+					"172.24.0.1:56267",
+					"172.25.0.1:56267",
+					"172.26.0.1:56267",
+					"172.27.0.1:56267",
+					"172.28.0.1:56267"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:27:48.810842495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3080881849207967,
+				"StableID":   "nAnk2SYL4R11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0fa2626d84f36e0d07b5a50dba3b05306e4c229b92bd8790839fc32a8d0f33f",
+				"DiscoKey":   "discokey:fde3fbd4008cd54458dec2da09d8c84027adf0722a1af2fc7144fb9dd6c44236",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53414",
+					"10.65.0.27:53414",
+					"172.17.0.1:53414",
+					"172.18.0.1:53414",
+					"172.19.0.1:53414",
+					"172.20.0.1:53414",
+					"172.21.0.1:53414",
+					"172.22.0.1:53414",
+					"172.23.0.1:53414",
+					"172.24.0.1:53414",
+					"172.25.0.1:53414",
+					"172.26.0.1:53414",
+					"172.27.0.1:53414",
+					"172.28.0.1:53414"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:27:49.543578532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3079523750338012,
+				"StableID":   "nKC4VHsi3R11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:052d60473f81adf1a8658eb19285774bd4bd3c10acaa8e02fcc1532c909ee524",
+				"DiscoKey":   "discokey:9865c36aab8fbeb0a68e8152af473b50f9ae7249bc2330c6c8ab5717c961b527",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41888",
+					"10.65.0.27:41888",
+					"172.17.0.1:41888",
+					"172.18.0.1:41888",
+					"172.19.0.1:41888",
+					"172.20.0.1:41888",
+					"172.21.0.1:41888",
+					"172.22.0.1:41888",
+					"172.23.0.1:41888",
+					"172.24.0.1:41888",
+					"172.25.0.1:41888",
+					"172.26.0.1:41888",
+					"172.27.0.1:41888",
+					"172.28.0.1:41888"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:27:50.064703038Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3602096095486955,
+				"StableID":   "ngsFAUxP8V11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9ce396b31072e6bd0d6b6e4c20bc97d5a18dad911feb4f6da36e046a0cba1546",
+				"DiscoKey":   "discokey:8d3634650d1b920b7a16ea4c19d4febd02fb93bfe75919faf5cd2000a86f9f18",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:43362",
+					"10.65.0.27:43362",
+					"172.17.0.1:43362",
+					"172.18.0.1:43362",
+					"172.19.0.1:43362",
+					"172.20.0.1:43362",
+					"172.21.0.1:43362",
+					"172.22.0.1:43362",
+					"172.23.0.1:43362",
+					"172.24.0.1:43362",
+					"172.25.0.1:43362",
+					"172.26.0.1:43362",
+					"172.27.0.1:43362",
+					"172.28.0.1:43362"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:27:50.594356405Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4621335723968074,
+				"StableID":   "nbuZuse16d11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6b1098d726fc23a014b70951f9ca8272e5eb3eab41d30834dc0a67ea82bd4a72",
+				"DiscoKey":   "discokey:baaefb4b196af32b3f2430e34a79b21553ab27250a737094c30696ab818b616f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41690",
+					"10.65.0.27:41690",
+					"172.17.0.1:41690",
+					"172.18.0.1:41690",
+					"172.19.0.1:41690",
+					"172.20.0.1:41690",
+					"172.21.0.1:41690",
+					"172.22.0.1:41690",
+					"172.23.0.1:41690",
+					"172.24.0.1:41690",
+					"172.25.0.1:41690",
+					"172.26.0.1:41690",
+					"172.27.0.1:41690",
+					"172.28.0.1:41690"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:27:51.126268674Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1051500490490188,
+				"StableID":   "nymiep8ED911CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6c65c498ef62b3adf215c967ac5ebdee5e33836347a24713776cb447b489253",
+				"DiscoKey":   "discokey:205d80fafa08f1ff3f806eea5b4e585e7d0575d4a725e4cfc74dafe8ec4c2967",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57470",
+					"10.65.0.27:57470",
+					"172.17.0.1:57470",
+					"172.18.0.1:57470",
+					"172.19.0.1:57470",
+					"172.20.0.1:57470",
+					"172.21.0.1:57470",
+					"172.22.0.1:57470",
+					"172.23.0.1:57470",
+					"172.24.0.1:57470",
+					"172.25.0.1:57470",
+					"172.26.0.1:57470",
+					"172.27.0.1:57470",
+					"172.28.0.1:57470"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:27:51.657982734Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5664970112452116,
+				"StableID":   "nj8Q4DAgEm11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8d7322fce72a08ee2effd3c1d63fc112136850ac34b734881dbc5ce4d2be8d54",
+				"DiscoKey":   "discokey:c899d2b9244acd1648d804efa21ac482b91d0b1ade8054a2087004afa6abc33b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34978",
+					"10.65.0.27:34978",
+					"172.17.0.1:34978",
+					"172.18.0.1:34978",
+					"172.19.0.1:34978",
+					"172.20.0.1:34978",
+					"172.21.0.1:34978",
+					"172.22.0.1:34978",
+					"172.23.0.1:34978",
+					"172.24.0.1:34978",
+					"172.25.0.1:34978",
+					"172.26.0.1:34978",
+					"172.27.0.1:34978",
+					"172.28.0.1:34978"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:27:55.675123474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2152360805118066,
+				"StableID":   "nmEEwNsooH11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:671d85e034256a660bbe26fed087a45f1f1127bccc46559c889f8df5b8d2486b",
+				"DiscoKey":   "discokey:0fd70a6fb6cc6e8210d93caa64e83e7d07f766953afa34d530ed0e331ef6c034",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50128",
+					"10.65.0.27:50128",
+					"172.17.0.1:50128",
+					"172.18.0.1:50128",
+					"172.19.0.1:50128",
+					"172.20.0.1:50128",
+					"172.21.0.1:50128",
+					"172.22.0.1:50128",
+					"172.23.0.1:50128",
+					"172.24.0.1:50128",
+					"172.25.0.1:50128",
+					"172.26.0.1:50128",
+					"172.27.0.1:50128",
+					"172.28.0.1:50128"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:27:56.228560725Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         738223294216272,
+				"StableID":   "n3ApahsLm611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:05f60a2cc279aac711826029360dbe5d03d4bc630e10fb78a55420305c541653",
+				"DiscoKey":   "discokey:b1d89b9ad9ccde697334200260bfb9d508e8877e862b0dfbe2167ce03896c416",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:49690",
+					"10.65.0.27:49690",
+					"172.17.0.1:49690",
+					"172.18.0.1:49690",
+					"172.19.0.1:49690",
+					"172.20.0.1:49690",
+					"172.21.0.1:49690",
+					"172.22.0.1:49690",
+					"172.23.0.1:49690",
+					"172.24.0.1:49690",
+					"172.25.0.1:49690",
+					"172.26.0.1:49690",
+					"172.27.0.1:49690",
+					"172.28.0.1:49690"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:27:56.757475702Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6185889331350142,
+				"StableID":   "n9UTdkpbJq11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:446c96b7c7aede556af9e96ec9eccdf3d9f562e4cb5457f06f8de776c27a6345",
+				"DiscoKey":   "discokey:4b6c28c4897b5bffd47568cbd543a2024b4286618b27e08520bf776760e6ce5d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41767",
+					"10.65.0.27:41767",
+					"172.17.0.1:41767",
+					"172.18.0.1:41767",
+					"172.19.0.1:41767",
+					"172.20.0.1:41767",
+					"172.21.0.1:41767",
+					"172.22.0.1:41767",
+					"172.23.0.1:41767",
+					"172.24.0.1:41767",
+					"172.25.0.1:41767",
+					"172.26.0.1:41767",
+					"172.27.0.1:41767",
+					"172.28.0.1:41767"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:27:57.314877464Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         743480569061735,
+				"StableID":   "nQ1bxUyio611CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:af4abc7df7d7f0622554c62ffaeeabe61e1ff5de99260371a766f809b4fb897f",
+				"KeyExpiry":  "2026-11-09T09:27:57Z",
+				"DiscoKey":   "discokey:2a4ffef40aa02f91c0537b4698a85c49c0cfcb2541a06e66a74e352cd7e6d005",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51143",
+					"10.65.0.27:51143",
+					"172.17.0.1:51143",
+					"172.18.0.1:51143",
+					"172.19.0.1:51143",
+					"172.20.0.1:51143",
+					"172.21.0.1:51143",
+					"172.22.0.1:51143",
+					"172.23.0.1:51143",
+					"172.24.0.1:51143",
+					"172.25.0.1:51143",
+					"172.26.0.1:51143",
+					"172.27.0.1:51143",
+					"172.28.0.1:51143"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:27:57.824662269Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         161569710742361,
+				"StableID":   "nkWz4RABG211CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3dde659be7ae0292fda9c505e6b8eea725150988d9fb52dd59f83689a89e0d5b",
+				"KeyExpiry":  "2026-11-09T09:27:58Z",
+				"DiscoKey":   "discokey:127b04aecd80109be87aeb2dd29e672a503ddd35c7ef15eab179c76b8393ac1a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:42123",
+					"10.65.0.27:42123",
+					"172.17.0.1:42123",
+					"172.18.0.1:42123",
+					"172.19.0.1:42123",
+					"172.20.0.1:42123",
+					"172.21.0.1:42123",
+					"172.22.0.1:42123",
+					"172.23.0.1:42123",
+					"172.24.0.1:42123",
+					"172.25.0.1:42123",
+					"172.26.0.1:42123",
+					"172.27.0.1:42123",
+					"172.28.0.1:42123"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:27:58.358268966Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2697352476831753,
+				"StableID":   "nN1Ejnsd4N11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dc0edc563a9b0dfb4b1a1d97ad5047d664e387978bc4af2c41e5c3f655548d4d",
+				"KeyExpiry":  "2026-11-09T09:27:58Z",
+				"DiscoKey":   "discokey:1c9c6f15805c22bd74092f63f6285a3372189de31b4e80e5179251f7c7d0ae76",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59836",
+					"10.65.0.27:59836",
+					"172.17.0.1:59836",
+					"172.18.0.1:59836",
+					"172.19.0.1:59836",
+					"172.20.0.1:59836",
+					"172.21.0.1:59836",
+					"172.22.0.1:59836",
+					"172.23.0.1:59836",
+					"172.24.0.1:59836",
+					"172.25.0.1:59836",
+					"172.26.0.1:59836",
+					"172.27.0.1:59836",
+					"172.28.0.1:59836"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:27:58.881120954Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "891554532683498": {
+				"ID":          891554532683498,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3211934370887534,
+				"StableID":   "nmpxb25h5S11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       3211934370887534,
+				"Key":        "nodekey:8909caa169b036242fb39f8e7a2946e135629cda6ba651e1384d85d76bb2e136",
+				"DiscoKey":   "discokey:38fd4ff4c3a2aaad2e0f94b4909d579e3ef424f630ef5bb61f7fa7624a0fe109",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43670",
+					"10.65.0.27:43670",
+					"172.17.0.1:43670",
+					"172.18.0.1:43670",
+					"172.19.0.1:43670",
+					"172.20.0.1:43670",
+					"172.21.0.1:43670",
+					"172.22.0.1:43670",
+					"172.23.0.1:43670",
+					"172.24.0.1:43670",
+					"172.25.0.1:43670",
+					"172.26.0.1:43670",
+					"172.27.0.1:43670",
+					"172.28.0.1:43670"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:27:41.096838369Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8909caa169b036242fb39f8e7a2946e135629cda6ba651e1384d85d76bb2e136",
+			"MachineKey": "mkey:2189c3b1d5a329cb5ab08daf33f0519720aecf5c4a0960435fac3d821ce2a03c",
+			"Peers": [{
+				"ID":         891554532683498,
+				"StableID":   "nRLx4Jdnx711CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:23e96a59a7758c8da3db258d7f24b285bd64f69005cfa7c69e081e5fe9166551",
+				"DiscoKey":   "discokey:f087a58298acc65bd5501f49f37f76b59980305c151c6bb69fbf28441b311136",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44596",
+					"10.65.0.27:44596",
+					"172.17.0.1:44596",
+					"172.18.0.1:44596",
+					"172.19.0.1:44596",
+					"172.20.0.1:44596",
+					"172.21.0.1:44596",
+					"172.22.0.1:44596",
+					"172.23.0.1:44596",
+					"172.24.0.1:44596",
+					"172.25.0.1:44596",
+					"172.26.0.1:44596",
+					"172.27.0.1:44596",
+					"172.28.0.1:44596"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:27:47.813891908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8689261536074906,
+				"StableID":   "n1GxxdAPrA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:beda087a1c0dfbd3e69290651073d64f0cf47cdf855cd2d0d2737bdf33d1000e",
+				"DiscoKey":   "discokey:00fe6422316407aaf964073d6b97637a0e30319a4f8b1bf482ca3e2e2d943451",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56267",
+					"10.65.0.27:56267",
+					"172.17.0.1:56267",
+					"172.18.0.1:56267",
+					"172.19.0.1:56267",
+					"172.20.0.1:56267",
+					"172.21.0.1:56267",
+					"172.22.0.1:56267",
+					"172.23.0.1:56267",
+					"172.24.0.1:56267",
+					"172.25.0.1:56267",
+					"172.26.0.1:56267",
+					"172.27.0.1:56267",
+					"172.28.0.1:56267"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:27:48.810842495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3080881849207967,
+				"StableID":   "nAnk2SYL4R11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0fa2626d84f36e0d07b5a50dba3b05306e4c229b92bd8790839fc32a8d0f33f",
+				"DiscoKey":   "discokey:fde3fbd4008cd54458dec2da09d8c84027adf0722a1af2fc7144fb9dd6c44236",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53414",
+					"10.65.0.27:53414",
+					"172.17.0.1:53414",
+					"172.18.0.1:53414",
+					"172.19.0.1:53414",
+					"172.20.0.1:53414",
+					"172.21.0.1:53414",
+					"172.22.0.1:53414",
+					"172.23.0.1:53414",
+					"172.24.0.1:53414",
+					"172.25.0.1:53414",
+					"172.26.0.1:53414",
+					"172.27.0.1:53414",
+					"172.28.0.1:53414"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:27:49.543578532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3079523750338012,
+				"StableID":   "nKC4VHsi3R11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:052d60473f81adf1a8658eb19285774bd4bd3c10acaa8e02fcc1532c909ee524",
+				"DiscoKey":   "discokey:9865c36aab8fbeb0a68e8152af473b50f9ae7249bc2330c6c8ab5717c961b527",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41888",
+					"10.65.0.27:41888",
+					"172.17.0.1:41888",
+					"172.18.0.1:41888",
+					"172.19.0.1:41888",
+					"172.20.0.1:41888",
+					"172.21.0.1:41888",
+					"172.22.0.1:41888",
+					"172.23.0.1:41888",
+					"172.24.0.1:41888",
+					"172.25.0.1:41888",
+					"172.26.0.1:41888",
+					"172.27.0.1:41888",
+					"172.28.0.1:41888"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:27:50.064703038Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3602096095486955,
+				"StableID":   "ngsFAUxP8V11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9ce396b31072e6bd0d6b6e4c20bc97d5a18dad911feb4f6da36e046a0cba1546",
+				"DiscoKey":   "discokey:8d3634650d1b920b7a16ea4c19d4febd02fb93bfe75919faf5cd2000a86f9f18",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:43362",
+					"10.65.0.27:43362",
+					"172.17.0.1:43362",
+					"172.18.0.1:43362",
+					"172.19.0.1:43362",
+					"172.20.0.1:43362",
+					"172.21.0.1:43362",
+					"172.22.0.1:43362",
+					"172.23.0.1:43362",
+					"172.24.0.1:43362",
+					"172.25.0.1:43362",
+					"172.26.0.1:43362",
+					"172.27.0.1:43362",
+					"172.28.0.1:43362"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:27:50.594356405Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4621335723968074,
+				"StableID":   "nbuZuse16d11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6b1098d726fc23a014b70951f9ca8272e5eb3eab41d30834dc0a67ea82bd4a72",
+				"DiscoKey":   "discokey:baaefb4b196af32b3f2430e34a79b21553ab27250a737094c30696ab818b616f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41690",
+					"10.65.0.27:41690",
+					"172.17.0.1:41690",
+					"172.18.0.1:41690",
+					"172.19.0.1:41690",
+					"172.20.0.1:41690",
+					"172.21.0.1:41690",
+					"172.22.0.1:41690",
+					"172.23.0.1:41690",
+					"172.24.0.1:41690",
+					"172.25.0.1:41690",
+					"172.26.0.1:41690",
+					"172.27.0.1:41690",
+					"172.28.0.1:41690"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:27:51.126268674Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1051500490490188,
+				"StableID":   "nymiep8ED911CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6c65c498ef62b3adf215c967ac5ebdee5e33836347a24713776cb447b489253",
+				"DiscoKey":   "discokey:205d80fafa08f1ff3f806eea5b4e585e7d0575d4a725e4cfc74dafe8ec4c2967",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57470",
+					"10.65.0.27:57470",
+					"172.17.0.1:57470",
+					"172.18.0.1:57470",
+					"172.19.0.1:57470",
+					"172.20.0.1:57470",
+					"172.21.0.1:57470",
+					"172.22.0.1:57470",
+					"172.23.0.1:57470",
+					"172.24.0.1:57470",
+					"172.25.0.1:57470",
+					"172.26.0.1:57470",
+					"172.27.0.1:57470",
+					"172.28.0.1:57470"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:27:51.657982734Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5664970112452116,
+				"StableID":   "nj8Q4DAgEm11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8d7322fce72a08ee2effd3c1d63fc112136850ac34b734881dbc5ce4d2be8d54",
+				"DiscoKey":   "discokey:c899d2b9244acd1648d804efa21ac482b91d0b1ade8054a2087004afa6abc33b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34978",
+					"10.65.0.27:34978",
+					"172.17.0.1:34978",
+					"172.18.0.1:34978",
+					"172.19.0.1:34978",
+					"172.20.0.1:34978",
+					"172.21.0.1:34978",
+					"172.22.0.1:34978",
+					"172.23.0.1:34978",
+					"172.24.0.1:34978",
+					"172.25.0.1:34978",
+					"172.26.0.1:34978",
+					"172.27.0.1:34978",
+					"172.28.0.1:34978"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:27:55.675123474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2152360805118066,
+				"StableID":   "nmEEwNsooH11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:671d85e034256a660bbe26fed087a45f1f1127bccc46559c889f8df5b8d2486b",
+				"DiscoKey":   "discokey:0fd70a6fb6cc6e8210d93caa64e83e7d07f766953afa34d530ed0e331ef6c034",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50128",
+					"10.65.0.27:50128",
+					"172.17.0.1:50128",
+					"172.18.0.1:50128",
+					"172.19.0.1:50128",
+					"172.20.0.1:50128",
+					"172.21.0.1:50128",
+					"172.22.0.1:50128",
+					"172.23.0.1:50128",
+					"172.24.0.1:50128",
+					"172.25.0.1:50128",
+					"172.26.0.1:50128",
+					"172.27.0.1:50128",
+					"172.28.0.1:50128"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:27:56.228560725Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         738223294216272,
+				"StableID":   "n3ApahsLm611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:05f60a2cc279aac711826029360dbe5d03d4bc630e10fb78a55420305c541653",
+				"DiscoKey":   "discokey:b1d89b9ad9ccde697334200260bfb9d508e8877e862b0dfbe2167ce03896c416",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:49690",
+					"10.65.0.27:49690",
+					"172.17.0.1:49690",
+					"172.18.0.1:49690",
+					"172.19.0.1:49690",
+					"172.20.0.1:49690",
+					"172.21.0.1:49690",
+					"172.22.0.1:49690",
+					"172.23.0.1:49690",
+					"172.24.0.1:49690",
+					"172.25.0.1:49690",
+					"172.26.0.1:49690",
+					"172.27.0.1:49690",
+					"172.28.0.1:49690"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:27:56.757475702Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6185889331350142,
+				"StableID":   "n9UTdkpbJq11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:446c96b7c7aede556af9e96ec9eccdf3d9f562e4cb5457f06f8de776c27a6345",
+				"DiscoKey":   "discokey:4b6c28c4897b5bffd47568cbd543a2024b4286618b27e08520bf776760e6ce5d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41767",
+					"10.65.0.27:41767",
+					"172.17.0.1:41767",
+					"172.18.0.1:41767",
+					"172.19.0.1:41767",
+					"172.20.0.1:41767",
+					"172.21.0.1:41767",
+					"172.22.0.1:41767",
+					"172.23.0.1:41767",
+					"172.24.0.1:41767",
+					"172.25.0.1:41767",
+					"172.26.0.1:41767",
+					"172.27.0.1:41767",
+					"172.28.0.1:41767"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:27:57.314877464Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         743480569061735,
+				"StableID":   "nQ1bxUyio611CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:af4abc7df7d7f0622554c62ffaeeabe61e1ff5de99260371a766f809b4fb897f",
+				"KeyExpiry":  "2026-11-09T09:27:57Z",
+				"DiscoKey":   "discokey:2a4ffef40aa02f91c0537b4698a85c49c0cfcb2541a06e66a74e352cd7e6d005",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51143",
+					"10.65.0.27:51143",
+					"172.17.0.1:51143",
+					"172.18.0.1:51143",
+					"172.19.0.1:51143",
+					"172.20.0.1:51143",
+					"172.21.0.1:51143",
+					"172.22.0.1:51143",
+					"172.23.0.1:51143",
+					"172.24.0.1:51143",
+					"172.25.0.1:51143",
+					"172.26.0.1:51143",
+					"172.27.0.1:51143",
+					"172.28.0.1:51143"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:27:57.824662269Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         161569710742361,
+				"StableID":   "nkWz4RABG211CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3dde659be7ae0292fda9c505e6b8eea725150988d9fb52dd59f83689a89e0d5b",
+				"KeyExpiry":  "2026-11-09T09:27:58Z",
+				"DiscoKey":   "discokey:127b04aecd80109be87aeb2dd29e672a503ddd35c7ef15eab179c76b8393ac1a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:42123",
+					"10.65.0.27:42123",
+					"172.17.0.1:42123",
+					"172.18.0.1:42123",
+					"172.19.0.1:42123",
+					"172.20.0.1:42123",
+					"172.21.0.1:42123",
+					"172.22.0.1:42123",
+					"172.23.0.1:42123",
+					"172.24.0.1:42123",
+					"172.25.0.1:42123",
+					"172.26.0.1:42123",
+					"172.27.0.1:42123",
+					"172.28.0.1:42123"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:27:58.358268966Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2697352476831753,
+				"StableID":   "nN1Ejnsd4N11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dc0edc563a9b0dfb4b1a1d97ad5047d664e387978bc4af2c41e5c3f655548d4d",
+				"KeyExpiry":  "2026-11-09T09:27:58Z",
+				"DiscoKey":   "discokey:1c9c6f15805c22bd74092f63f6285a3372189de31b4e80e5179251f7c7d0ae76",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59836",
+					"10.65.0.27:59836",
+					"172.17.0.1:59836",
+					"172.18.0.1:59836",
+					"172.19.0.1:59836",
+					"172.20.0.1:59836",
+					"172.21.0.1:59836",
+					"172.22.0.1:59836",
+					"172.23.0.1:59836",
+					"172.24.0.1:59836",
+					"172.25.0.1:59836",
+					"172.26.0.1:59836",
+					"172.27.0.1:59836",
+					"172.28.0.1:59836"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:27:58.881120954Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3211934370887534": {
+				"ID":          3211934370887534,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3079523750338012,
+				"StableID":   "nKC4VHsi3R11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       3079523750338012,
+				"Key":        "nodekey:052d60473f81adf1a8658eb19285774bd4bd3c10acaa8e02fcc1532c909ee524",
+				"DiscoKey":   "discokey:9865c36aab8fbeb0a68e8152af473b50f9ae7249bc2330c6c8ab5717c961b527",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41888",
+					"10.65.0.27:41888",
+					"172.17.0.1:41888",
+					"172.18.0.1:41888",
+					"172.19.0.1:41888",
+					"172.20.0.1:41888",
+					"172.21.0.1:41888",
+					"172.22.0.1:41888",
+					"172.23.0.1:41888",
+					"172.24.0.1:41888",
+					"172.25.0.1:41888",
+					"172.26.0.1:41888",
+					"172.27.0.1:41888",
+					"172.28.0.1:41888"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:27:50.064703038Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:052d60473f81adf1a8658eb19285774bd4bd3c10acaa8e02fcc1532c909ee524",
+			"MachineKey": "mkey:9fae195680fc441f953b56c3fa89e17a6ca6d430e7eb524acba78f73907b6143",
+			"Peers": [{
+				"ID":         3211934370887534,
+				"StableID":   "nmpxb25h5S11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8909caa169b036242fb39f8e7a2946e135629cda6ba651e1384d85d76bb2e136",
+				"DiscoKey":   "discokey:38fd4ff4c3a2aaad2e0f94b4909d579e3ef424f630ef5bb61f7fa7624a0fe109",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43670",
+					"10.65.0.27:43670",
+					"172.17.0.1:43670",
+					"172.18.0.1:43670",
+					"172.19.0.1:43670",
+					"172.20.0.1:43670",
+					"172.21.0.1:43670",
+					"172.22.0.1:43670",
+					"172.23.0.1:43670",
+					"172.24.0.1:43670",
+					"172.25.0.1:43670",
+					"172.26.0.1:43670",
+					"172.27.0.1:43670",
+					"172.28.0.1:43670"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:27:41.096838369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         891554532683498,
+				"StableID":   "nRLx4Jdnx711CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:23e96a59a7758c8da3db258d7f24b285bd64f69005cfa7c69e081e5fe9166551",
+				"DiscoKey":   "discokey:f087a58298acc65bd5501f49f37f76b59980305c151c6bb69fbf28441b311136",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44596",
+					"10.65.0.27:44596",
+					"172.17.0.1:44596",
+					"172.18.0.1:44596",
+					"172.19.0.1:44596",
+					"172.20.0.1:44596",
+					"172.21.0.1:44596",
+					"172.22.0.1:44596",
+					"172.23.0.1:44596",
+					"172.24.0.1:44596",
+					"172.25.0.1:44596",
+					"172.26.0.1:44596",
+					"172.27.0.1:44596",
+					"172.28.0.1:44596"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:27:47.813891908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8689261536074906,
+				"StableID":   "n1GxxdAPrA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:beda087a1c0dfbd3e69290651073d64f0cf47cdf855cd2d0d2737bdf33d1000e",
+				"DiscoKey":   "discokey:00fe6422316407aaf964073d6b97637a0e30319a4f8b1bf482ca3e2e2d943451",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56267",
+					"10.65.0.27:56267",
+					"172.17.0.1:56267",
+					"172.18.0.1:56267",
+					"172.19.0.1:56267",
+					"172.20.0.1:56267",
+					"172.21.0.1:56267",
+					"172.22.0.1:56267",
+					"172.23.0.1:56267",
+					"172.24.0.1:56267",
+					"172.25.0.1:56267",
+					"172.26.0.1:56267",
+					"172.27.0.1:56267",
+					"172.28.0.1:56267"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:27:48.810842495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3080881849207967,
+				"StableID":   "nAnk2SYL4R11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0fa2626d84f36e0d07b5a50dba3b05306e4c229b92bd8790839fc32a8d0f33f",
+				"DiscoKey":   "discokey:fde3fbd4008cd54458dec2da09d8c84027adf0722a1af2fc7144fb9dd6c44236",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53414",
+					"10.65.0.27:53414",
+					"172.17.0.1:53414",
+					"172.18.0.1:53414",
+					"172.19.0.1:53414",
+					"172.20.0.1:53414",
+					"172.21.0.1:53414",
+					"172.22.0.1:53414",
+					"172.23.0.1:53414",
+					"172.24.0.1:53414",
+					"172.25.0.1:53414",
+					"172.26.0.1:53414",
+					"172.27.0.1:53414",
+					"172.28.0.1:53414"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:27:49.543578532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3602096095486955,
+				"StableID":   "ngsFAUxP8V11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9ce396b31072e6bd0d6b6e4c20bc97d5a18dad911feb4f6da36e046a0cba1546",
+				"DiscoKey":   "discokey:8d3634650d1b920b7a16ea4c19d4febd02fb93bfe75919faf5cd2000a86f9f18",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:43362",
+					"10.65.0.27:43362",
+					"172.17.0.1:43362",
+					"172.18.0.1:43362",
+					"172.19.0.1:43362",
+					"172.20.0.1:43362",
+					"172.21.0.1:43362",
+					"172.22.0.1:43362",
+					"172.23.0.1:43362",
+					"172.24.0.1:43362",
+					"172.25.0.1:43362",
+					"172.26.0.1:43362",
+					"172.27.0.1:43362",
+					"172.28.0.1:43362"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:27:50.594356405Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4621335723968074,
+				"StableID":   "nbuZuse16d11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6b1098d726fc23a014b70951f9ca8272e5eb3eab41d30834dc0a67ea82bd4a72",
+				"DiscoKey":   "discokey:baaefb4b196af32b3f2430e34a79b21553ab27250a737094c30696ab818b616f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41690",
+					"10.65.0.27:41690",
+					"172.17.0.1:41690",
+					"172.18.0.1:41690",
+					"172.19.0.1:41690",
+					"172.20.0.1:41690",
+					"172.21.0.1:41690",
+					"172.22.0.1:41690",
+					"172.23.0.1:41690",
+					"172.24.0.1:41690",
+					"172.25.0.1:41690",
+					"172.26.0.1:41690",
+					"172.27.0.1:41690",
+					"172.28.0.1:41690"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:27:51.126268674Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1051500490490188,
+				"StableID":   "nymiep8ED911CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6c65c498ef62b3adf215c967ac5ebdee5e33836347a24713776cb447b489253",
+				"DiscoKey":   "discokey:205d80fafa08f1ff3f806eea5b4e585e7d0575d4a725e4cfc74dafe8ec4c2967",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57470",
+					"10.65.0.27:57470",
+					"172.17.0.1:57470",
+					"172.18.0.1:57470",
+					"172.19.0.1:57470",
+					"172.20.0.1:57470",
+					"172.21.0.1:57470",
+					"172.22.0.1:57470",
+					"172.23.0.1:57470",
+					"172.24.0.1:57470",
+					"172.25.0.1:57470",
+					"172.26.0.1:57470",
+					"172.27.0.1:57470",
+					"172.28.0.1:57470"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:27:51.657982734Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5664970112452116,
+				"StableID":   "nj8Q4DAgEm11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8d7322fce72a08ee2effd3c1d63fc112136850ac34b734881dbc5ce4d2be8d54",
+				"DiscoKey":   "discokey:c899d2b9244acd1648d804efa21ac482b91d0b1ade8054a2087004afa6abc33b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34978",
+					"10.65.0.27:34978",
+					"172.17.0.1:34978",
+					"172.18.0.1:34978",
+					"172.19.0.1:34978",
+					"172.20.0.1:34978",
+					"172.21.0.1:34978",
+					"172.22.0.1:34978",
+					"172.23.0.1:34978",
+					"172.24.0.1:34978",
+					"172.25.0.1:34978",
+					"172.26.0.1:34978",
+					"172.27.0.1:34978",
+					"172.28.0.1:34978"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:27:55.675123474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2152360805118066,
+				"StableID":   "nmEEwNsooH11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:671d85e034256a660bbe26fed087a45f1f1127bccc46559c889f8df5b8d2486b",
+				"DiscoKey":   "discokey:0fd70a6fb6cc6e8210d93caa64e83e7d07f766953afa34d530ed0e331ef6c034",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50128",
+					"10.65.0.27:50128",
+					"172.17.0.1:50128",
+					"172.18.0.1:50128",
+					"172.19.0.1:50128",
+					"172.20.0.1:50128",
+					"172.21.0.1:50128",
+					"172.22.0.1:50128",
+					"172.23.0.1:50128",
+					"172.24.0.1:50128",
+					"172.25.0.1:50128",
+					"172.26.0.1:50128",
+					"172.27.0.1:50128",
+					"172.28.0.1:50128"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:27:56.228560725Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         738223294216272,
+				"StableID":   "n3ApahsLm611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:05f60a2cc279aac711826029360dbe5d03d4bc630e10fb78a55420305c541653",
+				"DiscoKey":   "discokey:b1d89b9ad9ccde697334200260bfb9d508e8877e862b0dfbe2167ce03896c416",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:49690",
+					"10.65.0.27:49690",
+					"172.17.0.1:49690",
+					"172.18.0.1:49690",
+					"172.19.0.1:49690",
+					"172.20.0.1:49690",
+					"172.21.0.1:49690",
+					"172.22.0.1:49690",
+					"172.23.0.1:49690",
+					"172.24.0.1:49690",
+					"172.25.0.1:49690",
+					"172.26.0.1:49690",
+					"172.27.0.1:49690",
+					"172.28.0.1:49690"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:27:56.757475702Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6185889331350142,
+				"StableID":   "n9UTdkpbJq11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:446c96b7c7aede556af9e96ec9eccdf3d9f562e4cb5457f06f8de776c27a6345",
+				"DiscoKey":   "discokey:4b6c28c4897b5bffd47568cbd543a2024b4286618b27e08520bf776760e6ce5d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41767",
+					"10.65.0.27:41767",
+					"172.17.0.1:41767",
+					"172.18.0.1:41767",
+					"172.19.0.1:41767",
+					"172.20.0.1:41767",
+					"172.21.0.1:41767",
+					"172.22.0.1:41767",
+					"172.23.0.1:41767",
+					"172.24.0.1:41767",
+					"172.25.0.1:41767",
+					"172.26.0.1:41767",
+					"172.27.0.1:41767",
+					"172.28.0.1:41767"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:27:57.314877464Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         743480569061735,
+				"StableID":   "nQ1bxUyio611CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:af4abc7df7d7f0622554c62ffaeeabe61e1ff5de99260371a766f809b4fb897f",
+				"KeyExpiry":  "2026-11-09T09:27:57Z",
+				"DiscoKey":   "discokey:2a4ffef40aa02f91c0537b4698a85c49c0cfcb2541a06e66a74e352cd7e6d005",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51143",
+					"10.65.0.27:51143",
+					"172.17.0.1:51143",
+					"172.18.0.1:51143",
+					"172.19.0.1:51143",
+					"172.20.0.1:51143",
+					"172.21.0.1:51143",
+					"172.22.0.1:51143",
+					"172.23.0.1:51143",
+					"172.24.0.1:51143",
+					"172.25.0.1:51143",
+					"172.26.0.1:51143",
+					"172.27.0.1:51143",
+					"172.28.0.1:51143"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:27:57.824662269Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         161569710742361,
+				"StableID":   "nkWz4RABG211CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3dde659be7ae0292fda9c505e6b8eea725150988d9fb52dd59f83689a89e0d5b",
+				"KeyExpiry":  "2026-11-09T09:27:58Z",
+				"DiscoKey":   "discokey:127b04aecd80109be87aeb2dd29e672a503ddd35c7ef15eab179c76b8393ac1a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:42123",
+					"10.65.0.27:42123",
+					"172.17.0.1:42123",
+					"172.18.0.1:42123",
+					"172.19.0.1:42123",
+					"172.20.0.1:42123",
+					"172.21.0.1:42123",
+					"172.22.0.1:42123",
+					"172.23.0.1:42123",
+					"172.24.0.1:42123",
+					"172.25.0.1:42123",
+					"172.26.0.1:42123",
+					"172.27.0.1:42123",
+					"172.28.0.1:42123"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:27:58.358268966Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2697352476831753,
+				"StableID":   "nN1Ejnsd4N11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dc0edc563a9b0dfb4b1a1d97ad5047d664e387978bc4af2c41e5c3f655548d4d",
+				"KeyExpiry":  "2026-11-09T09:27:58Z",
+				"DiscoKey":   "discokey:1c9c6f15805c22bd74092f63f6285a3372189de31b4e80e5179251f7c7d0ae76",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59836",
+					"10.65.0.27:59836",
+					"172.17.0.1:59836",
+					"172.18.0.1:59836",
+					"172.19.0.1:59836",
+					"172.20.0.1:59836",
+					"172.21.0.1:59836",
+					"172.22.0.1:59836",
+					"172.23.0.1:59836",
+					"172.24.0.1:59836",
+					"172.25.0.1:59836",
+					"172.26.0.1:59836",
+					"172.27.0.1:59836",
+					"172.28.0.1:59836"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:27:58.881120954Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3079523750338012": {
+				"ID":          3079523750338012,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3080881849207967,
+				"StableID":   "nAnk2SYL4R11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       3080881849207967,
+				"Key":        "nodekey:b0fa2626d84f36e0d07b5a50dba3b05306e4c229b92bd8790839fc32a8d0f33f",
+				"DiscoKey":   "discokey:fde3fbd4008cd54458dec2da09d8c84027adf0722a1af2fc7144fb9dd6c44236",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53414",
+					"10.65.0.27:53414",
+					"172.17.0.1:53414",
+					"172.18.0.1:53414",
+					"172.19.0.1:53414",
+					"172.20.0.1:53414",
+					"172.21.0.1:53414",
+					"172.22.0.1:53414",
+					"172.23.0.1:53414",
+					"172.24.0.1:53414",
+					"172.25.0.1:53414",
+					"172.26.0.1:53414",
+					"172.27.0.1:53414",
+					"172.28.0.1:53414"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:27:49.543578532Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b0fa2626d84f36e0d07b5a50dba3b05306e4c229b92bd8790839fc32a8d0f33f",
+			"MachineKey": "mkey:0ceaee28df9ac656866105eacb1c88f15532b76345067dbe3b7610551c7f6702",
+			"Peers": [{
+				"ID":         3211934370887534,
+				"StableID":   "nmpxb25h5S11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8909caa169b036242fb39f8e7a2946e135629cda6ba651e1384d85d76bb2e136",
+				"DiscoKey":   "discokey:38fd4ff4c3a2aaad2e0f94b4909d579e3ef424f630ef5bb61f7fa7624a0fe109",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43670",
+					"10.65.0.27:43670",
+					"172.17.0.1:43670",
+					"172.18.0.1:43670",
+					"172.19.0.1:43670",
+					"172.20.0.1:43670",
+					"172.21.0.1:43670",
+					"172.22.0.1:43670",
+					"172.23.0.1:43670",
+					"172.24.0.1:43670",
+					"172.25.0.1:43670",
+					"172.26.0.1:43670",
+					"172.27.0.1:43670",
+					"172.28.0.1:43670"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:27:41.096838369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         891554532683498,
+				"StableID":   "nRLx4Jdnx711CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:23e96a59a7758c8da3db258d7f24b285bd64f69005cfa7c69e081e5fe9166551",
+				"DiscoKey":   "discokey:f087a58298acc65bd5501f49f37f76b59980305c151c6bb69fbf28441b311136",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44596",
+					"10.65.0.27:44596",
+					"172.17.0.1:44596",
+					"172.18.0.1:44596",
+					"172.19.0.1:44596",
+					"172.20.0.1:44596",
+					"172.21.0.1:44596",
+					"172.22.0.1:44596",
+					"172.23.0.1:44596",
+					"172.24.0.1:44596",
+					"172.25.0.1:44596",
+					"172.26.0.1:44596",
+					"172.27.0.1:44596",
+					"172.28.0.1:44596"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:27:47.813891908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8689261536074906,
+				"StableID":   "n1GxxdAPrA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:beda087a1c0dfbd3e69290651073d64f0cf47cdf855cd2d0d2737bdf33d1000e",
+				"DiscoKey":   "discokey:00fe6422316407aaf964073d6b97637a0e30319a4f8b1bf482ca3e2e2d943451",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56267",
+					"10.65.0.27:56267",
+					"172.17.0.1:56267",
+					"172.18.0.1:56267",
+					"172.19.0.1:56267",
+					"172.20.0.1:56267",
+					"172.21.0.1:56267",
+					"172.22.0.1:56267",
+					"172.23.0.1:56267",
+					"172.24.0.1:56267",
+					"172.25.0.1:56267",
+					"172.26.0.1:56267",
+					"172.27.0.1:56267",
+					"172.28.0.1:56267"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:27:48.810842495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3079523750338012,
+				"StableID":   "nKC4VHsi3R11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:052d60473f81adf1a8658eb19285774bd4bd3c10acaa8e02fcc1532c909ee524",
+				"DiscoKey":   "discokey:9865c36aab8fbeb0a68e8152af473b50f9ae7249bc2330c6c8ab5717c961b527",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41888",
+					"10.65.0.27:41888",
+					"172.17.0.1:41888",
+					"172.18.0.1:41888",
+					"172.19.0.1:41888",
+					"172.20.0.1:41888",
+					"172.21.0.1:41888",
+					"172.22.0.1:41888",
+					"172.23.0.1:41888",
+					"172.24.0.1:41888",
+					"172.25.0.1:41888",
+					"172.26.0.1:41888",
+					"172.27.0.1:41888",
+					"172.28.0.1:41888"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:27:50.064703038Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3602096095486955,
+				"StableID":   "ngsFAUxP8V11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9ce396b31072e6bd0d6b6e4c20bc97d5a18dad911feb4f6da36e046a0cba1546",
+				"DiscoKey":   "discokey:8d3634650d1b920b7a16ea4c19d4febd02fb93bfe75919faf5cd2000a86f9f18",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:43362",
+					"10.65.0.27:43362",
+					"172.17.0.1:43362",
+					"172.18.0.1:43362",
+					"172.19.0.1:43362",
+					"172.20.0.1:43362",
+					"172.21.0.1:43362",
+					"172.22.0.1:43362",
+					"172.23.0.1:43362",
+					"172.24.0.1:43362",
+					"172.25.0.1:43362",
+					"172.26.0.1:43362",
+					"172.27.0.1:43362",
+					"172.28.0.1:43362"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:27:50.594356405Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4621335723968074,
+				"StableID":   "nbuZuse16d11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6b1098d726fc23a014b70951f9ca8272e5eb3eab41d30834dc0a67ea82bd4a72",
+				"DiscoKey":   "discokey:baaefb4b196af32b3f2430e34a79b21553ab27250a737094c30696ab818b616f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41690",
+					"10.65.0.27:41690",
+					"172.17.0.1:41690",
+					"172.18.0.1:41690",
+					"172.19.0.1:41690",
+					"172.20.0.1:41690",
+					"172.21.0.1:41690",
+					"172.22.0.1:41690",
+					"172.23.0.1:41690",
+					"172.24.0.1:41690",
+					"172.25.0.1:41690",
+					"172.26.0.1:41690",
+					"172.27.0.1:41690",
+					"172.28.0.1:41690"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:27:51.126268674Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1051500490490188,
+				"StableID":   "nymiep8ED911CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6c65c498ef62b3adf215c967ac5ebdee5e33836347a24713776cb447b489253",
+				"DiscoKey":   "discokey:205d80fafa08f1ff3f806eea5b4e585e7d0575d4a725e4cfc74dafe8ec4c2967",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57470",
+					"10.65.0.27:57470",
+					"172.17.0.1:57470",
+					"172.18.0.1:57470",
+					"172.19.0.1:57470",
+					"172.20.0.1:57470",
+					"172.21.0.1:57470",
+					"172.22.0.1:57470",
+					"172.23.0.1:57470",
+					"172.24.0.1:57470",
+					"172.25.0.1:57470",
+					"172.26.0.1:57470",
+					"172.27.0.1:57470",
+					"172.28.0.1:57470"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:27:51.657982734Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5664970112452116,
+				"StableID":   "nj8Q4DAgEm11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8d7322fce72a08ee2effd3c1d63fc112136850ac34b734881dbc5ce4d2be8d54",
+				"DiscoKey":   "discokey:c899d2b9244acd1648d804efa21ac482b91d0b1ade8054a2087004afa6abc33b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34978",
+					"10.65.0.27:34978",
+					"172.17.0.1:34978",
+					"172.18.0.1:34978",
+					"172.19.0.1:34978",
+					"172.20.0.1:34978",
+					"172.21.0.1:34978",
+					"172.22.0.1:34978",
+					"172.23.0.1:34978",
+					"172.24.0.1:34978",
+					"172.25.0.1:34978",
+					"172.26.0.1:34978",
+					"172.27.0.1:34978",
+					"172.28.0.1:34978"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:27:55.675123474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2152360805118066,
+				"StableID":   "nmEEwNsooH11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:671d85e034256a660bbe26fed087a45f1f1127bccc46559c889f8df5b8d2486b",
+				"DiscoKey":   "discokey:0fd70a6fb6cc6e8210d93caa64e83e7d07f766953afa34d530ed0e331ef6c034",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50128",
+					"10.65.0.27:50128",
+					"172.17.0.1:50128",
+					"172.18.0.1:50128",
+					"172.19.0.1:50128",
+					"172.20.0.1:50128",
+					"172.21.0.1:50128",
+					"172.22.0.1:50128",
+					"172.23.0.1:50128",
+					"172.24.0.1:50128",
+					"172.25.0.1:50128",
+					"172.26.0.1:50128",
+					"172.27.0.1:50128",
+					"172.28.0.1:50128"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:27:56.228560725Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         738223294216272,
+				"StableID":   "n3ApahsLm611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:05f60a2cc279aac711826029360dbe5d03d4bc630e10fb78a55420305c541653",
+				"DiscoKey":   "discokey:b1d89b9ad9ccde697334200260bfb9d508e8877e862b0dfbe2167ce03896c416",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:49690",
+					"10.65.0.27:49690",
+					"172.17.0.1:49690",
+					"172.18.0.1:49690",
+					"172.19.0.1:49690",
+					"172.20.0.1:49690",
+					"172.21.0.1:49690",
+					"172.22.0.1:49690",
+					"172.23.0.1:49690",
+					"172.24.0.1:49690",
+					"172.25.0.1:49690",
+					"172.26.0.1:49690",
+					"172.27.0.1:49690",
+					"172.28.0.1:49690"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:27:56.757475702Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6185889331350142,
+				"StableID":   "n9UTdkpbJq11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:446c96b7c7aede556af9e96ec9eccdf3d9f562e4cb5457f06f8de776c27a6345",
+				"DiscoKey":   "discokey:4b6c28c4897b5bffd47568cbd543a2024b4286618b27e08520bf776760e6ce5d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41767",
+					"10.65.0.27:41767",
+					"172.17.0.1:41767",
+					"172.18.0.1:41767",
+					"172.19.0.1:41767",
+					"172.20.0.1:41767",
+					"172.21.0.1:41767",
+					"172.22.0.1:41767",
+					"172.23.0.1:41767",
+					"172.24.0.1:41767",
+					"172.25.0.1:41767",
+					"172.26.0.1:41767",
+					"172.27.0.1:41767",
+					"172.28.0.1:41767"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:27:57.314877464Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         743480569061735,
+				"StableID":   "nQ1bxUyio611CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:af4abc7df7d7f0622554c62ffaeeabe61e1ff5de99260371a766f809b4fb897f",
+				"KeyExpiry":  "2026-11-09T09:27:57Z",
+				"DiscoKey":   "discokey:2a4ffef40aa02f91c0537b4698a85c49c0cfcb2541a06e66a74e352cd7e6d005",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51143",
+					"10.65.0.27:51143",
+					"172.17.0.1:51143",
+					"172.18.0.1:51143",
+					"172.19.0.1:51143",
+					"172.20.0.1:51143",
+					"172.21.0.1:51143",
+					"172.22.0.1:51143",
+					"172.23.0.1:51143",
+					"172.24.0.1:51143",
+					"172.25.0.1:51143",
+					"172.26.0.1:51143",
+					"172.27.0.1:51143",
+					"172.28.0.1:51143"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:27:57.824662269Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         161569710742361,
+				"StableID":   "nkWz4RABG211CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3dde659be7ae0292fda9c505e6b8eea725150988d9fb52dd59f83689a89e0d5b",
+				"KeyExpiry":  "2026-11-09T09:27:58Z",
+				"DiscoKey":   "discokey:127b04aecd80109be87aeb2dd29e672a503ddd35c7ef15eab179c76b8393ac1a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:42123",
+					"10.65.0.27:42123",
+					"172.17.0.1:42123",
+					"172.18.0.1:42123",
+					"172.19.0.1:42123",
+					"172.20.0.1:42123",
+					"172.21.0.1:42123",
+					"172.22.0.1:42123",
+					"172.23.0.1:42123",
+					"172.24.0.1:42123",
+					"172.25.0.1:42123",
+					"172.26.0.1:42123",
+					"172.27.0.1:42123",
+					"172.28.0.1:42123"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:27:58.358268966Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2697352476831753,
+				"StableID":   "nN1Ejnsd4N11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dc0edc563a9b0dfb4b1a1d97ad5047d664e387978bc4af2c41e5c3f655548d4d",
+				"KeyExpiry":  "2026-11-09T09:27:58Z",
+				"DiscoKey":   "discokey:1c9c6f15805c22bd74092f63f6285a3372189de31b4e80e5179251f7c7d0ae76",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59836",
+					"10.65.0.27:59836",
+					"172.17.0.1:59836",
+					"172.18.0.1:59836",
+					"172.19.0.1:59836",
+					"172.20.0.1:59836",
+					"172.21.0.1:59836",
+					"172.22.0.1:59836",
+					"172.23.0.1:59836",
+					"172.24.0.1:59836",
+					"172.25.0.1:59836",
+					"172.26.0.1:59836",
+					"172.27.0.1:59836",
+					"172.28.0.1:59836"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:27:58.881120954Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3080881849207967": {
+				"ID":          3080881849207967,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4621335723968074,
+				"StableID":   "nbuZuse16d11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       4621335723968074,
+				"Key":        "nodekey:6b1098d726fc23a014b70951f9ca8272e5eb3eab41d30834dc0a67ea82bd4a72",
+				"DiscoKey":   "discokey:baaefb4b196af32b3f2430e34a79b21553ab27250a737094c30696ab818b616f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41690",
+					"10.65.0.27:41690",
+					"172.17.0.1:41690",
+					"172.18.0.1:41690",
+					"172.19.0.1:41690",
+					"172.20.0.1:41690",
+					"172.21.0.1:41690",
+					"172.22.0.1:41690",
+					"172.23.0.1:41690",
+					"172.24.0.1:41690",
+					"172.25.0.1:41690",
+					"172.26.0.1:41690",
+					"172.27.0.1:41690",
+					"172.28.0.1:41690"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:27:51.126268674Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6b1098d726fc23a014b70951f9ca8272e5eb3eab41d30834dc0a67ea82bd4a72",
+			"MachineKey": "mkey:bd5e3509bf488afde76c34d4d27256962930541fbeb6ab19b0e3e7c8ea333428",
+			"Peers": [{
+				"ID":         3211934370887534,
+				"StableID":   "nmpxb25h5S11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8909caa169b036242fb39f8e7a2946e135629cda6ba651e1384d85d76bb2e136",
+				"DiscoKey":   "discokey:38fd4ff4c3a2aaad2e0f94b4909d579e3ef424f630ef5bb61f7fa7624a0fe109",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43670",
+					"10.65.0.27:43670",
+					"172.17.0.1:43670",
+					"172.18.0.1:43670",
+					"172.19.0.1:43670",
+					"172.20.0.1:43670",
+					"172.21.0.1:43670",
+					"172.22.0.1:43670",
+					"172.23.0.1:43670",
+					"172.24.0.1:43670",
+					"172.25.0.1:43670",
+					"172.26.0.1:43670",
+					"172.27.0.1:43670",
+					"172.28.0.1:43670"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:27:41.096838369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         891554532683498,
+				"StableID":   "nRLx4Jdnx711CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:23e96a59a7758c8da3db258d7f24b285bd64f69005cfa7c69e081e5fe9166551",
+				"DiscoKey":   "discokey:f087a58298acc65bd5501f49f37f76b59980305c151c6bb69fbf28441b311136",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44596",
+					"10.65.0.27:44596",
+					"172.17.0.1:44596",
+					"172.18.0.1:44596",
+					"172.19.0.1:44596",
+					"172.20.0.1:44596",
+					"172.21.0.1:44596",
+					"172.22.0.1:44596",
+					"172.23.0.1:44596",
+					"172.24.0.1:44596",
+					"172.25.0.1:44596",
+					"172.26.0.1:44596",
+					"172.27.0.1:44596",
+					"172.28.0.1:44596"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:27:47.813891908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8689261536074906,
+				"StableID":   "n1GxxdAPrA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:beda087a1c0dfbd3e69290651073d64f0cf47cdf855cd2d0d2737bdf33d1000e",
+				"DiscoKey":   "discokey:00fe6422316407aaf964073d6b97637a0e30319a4f8b1bf482ca3e2e2d943451",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56267",
+					"10.65.0.27:56267",
+					"172.17.0.1:56267",
+					"172.18.0.1:56267",
+					"172.19.0.1:56267",
+					"172.20.0.1:56267",
+					"172.21.0.1:56267",
+					"172.22.0.1:56267",
+					"172.23.0.1:56267",
+					"172.24.0.1:56267",
+					"172.25.0.1:56267",
+					"172.26.0.1:56267",
+					"172.27.0.1:56267",
+					"172.28.0.1:56267"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:27:48.810842495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3080881849207967,
+				"StableID":   "nAnk2SYL4R11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0fa2626d84f36e0d07b5a50dba3b05306e4c229b92bd8790839fc32a8d0f33f",
+				"DiscoKey":   "discokey:fde3fbd4008cd54458dec2da09d8c84027adf0722a1af2fc7144fb9dd6c44236",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53414",
+					"10.65.0.27:53414",
+					"172.17.0.1:53414",
+					"172.18.0.1:53414",
+					"172.19.0.1:53414",
+					"172.20.0.1:53414",
+					"172.21.0.1:53414",
+					"172.22.0.1:53414",
+					"172.23.0.1:53414",
+					"172.24.0.1:53414",
+					"172.25.0.1:53414",
+					"172.26.0.1:53414",
+					"172.27.0.1:53414",
+					"172.28.0.1:53414"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:27:49.543578532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3079523750338012,
+				"StableID":   "nKC4VHsi3R11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:052d60473f81adf1a8658eb19285774bd4bd3c10acaa8e02fcc1532c909ee524",
+				"DiscoKey":   "discokey:9865c36aab8fbeb0a68e8152af473b50f9ae7249bc2330c6c8ab5717c961b527",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41888",
+					"10.65.0.27:41888",
+					"172.17.0.1:41888",
+					"172.18.0.1:41888",
+					"172.19.0.1:41888",
+					"172.20.0.1:41888",
+					"172.21.0.1:41888",
+					"172.22.0.1:41888",
+					"172.23.0.1:41888",
+					"172.24.0.1:41888",
+					"172.25.0.1:41888",
+					"172.26.0.1:41888",
+					"172.27.0.1:41888",
+					"172.28.0.1:41888"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:27:50.064703038Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3602096095486955,
+				"StableID":   "ngsFAUxP8V11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9ce396b31072e6bd0d6b6e4c20bc97d5a18dad911feb4f6da36e046a0cba1546",
+				"DiscoKey":   "discokey:8d3634650d1b920b7a16ea4c19d4febd02fb93bfe75919faf5cd2000a86f9f18",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:43362",
+					"10.65.0.27:43362",
+					"172.17.0.1:43362",
+					"172.18.0.1:43362",
+					"172.19.0.1:43362",
+					"172.20.0.1:43362",
+					"172.21.0.1:43362",
+					"172.22.0.1:43362",
+					"172.23.0.1:43362",
+					"172.24.0.1:43362",
+					"172.25.0.1:43362",
+					"172.26.0.1:43362",
+					"172.27.0.1:43362",
+					"172.28.0.1:43362"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:27:50.594356405Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1051500490490188,
+				"StableID":   "nymiep8ED911CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6c65c498ef62b3adf215c967ac5ebdee5e33836347a24713776cb447b489253",
+				"DiscoKey":   "discokey:205d80fafa08f1ff3f806eea5b4e585e7d0575d4a725e4cfc74dafe8ec4c2967",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57470",
+					"10.65.0.27:57470",
+					"172.17.0.1:57470",
+					"172.18.0.1:57470",
+					"172.19.0.1:57470",
+					"172.20.0.1:57470",
+					"172.21.0.1:57470",
+					"172.22.0.1:57470",
+					"172.23.0.1:57470",
+					"172.24.0.1:57470",
+					"172.25.0.1:57470",
+					"172.26.0.1:57470",
+					"172.27.0.1:57470",
+					"172.28.0.1:57470"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:27:51.657982734Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5664970112452116,
+				"StableID":   "nj8Q4DAgEm11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8d7322fce72a08ee2effd3c1d63fc112136850ac34b734881dbc5ce4d2be8d54",
+				"DiscoKey":   "discokey:c899d2b9244acd1648d804efa21ac482b91d0b1ade8054a2087004afa6abc33b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34978",
+					"10.65.0.27:34978",
+					"172.17.0.1:34978",
+					"172.18.0.1:34978",
+					"172.19.0.1:34978",
+					"172.20.0.1:34978",
+					"172.21.0.1:34978",
+					"172.22.0.1:34978",
+					"172.23.0.1:34978",
+					"172.24.0.1:34978",
+					"172.25.0.1:34978",
+					"172.26.0.1:34978",
+					"172.27.0.1:34978",
+					"172.28.0.1:34978"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:27:55.675123474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2152360805118066,
+				"StableID":   "nmEEwNsooH11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:671d85e034256a660bbe26fed087a45f1f1127bccc46559c889f8df5b8d2486b",
+				"DiscoKey":   "discokey:0fd70a6fb6cc6e8210d93caa64e83e7d07f766953afa34d530ed0e331ef6c034",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50128",
+					"10.65.0.27:50128",
+					"172.17.0.1:50128",
+					"172.18.0.1:50128",
+					"172.19.0.1:50128",
+					"172.20.0.1:50128",
+					"172.21.0.1:50128",
+					"172.22.0.1:50128",
+					"172.23.0.1:50128",
+					"172.24.0.1:50128",
+					"172.25.0.1:50128",
+					"172.26.0.1:50128",
+					"172.27.0.1:50128",
+					"172.28.0.1:50128"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:27:56.228560725Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         738223294216272,
+				"StableID":   "n3ApahsLm611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:05f60a2cc279aac711826029360dbe5d03d4bc630e10fb78a55420305c541653",
+				"DiscoKey":   "discokey:b1d89b9ad9ccde697334200260bfb9d508e8877e862b0dfbe2167ce03896c416",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:49690",
+					"10.65.0.27:49690",
+					"172.17.0.1:49690",
+					"172.18.0.1:49690",
+					"172.19.0.1:49690",
+					"172.20.0.1:49690",
+					"172.21.0.1:49690",
+					"172.22.0.1:49690",
+					"172.23.0.1:49690",
+					"172.24.0.1:49690",
+					"172.25.0.1:49690",
+					"172.26.0.1:49690",
+					"172.27.0.1:49690",
+					"172.28.0.1:49690"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:27:56.757475702Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6185889331350142,
+				"StableID":   "n9UTdkpbJq11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:446c96b7c7aede556af9e96ec9eccdf3d9f562e4cb5457f06f8de776c27a6345",
+				"DiscoKey":   "discokey:4b6c28c4897b5bffd47568cbd543a2024b4286618b27e08520bf776760e6ce5d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41767",
+					"10.65.0.27:41767",
+					"172.17.0.1:41767",
+					"172.18.0.1:41767",
+					"172.19.0.1:41767",
+					"172.20.0.1:41767",
+					"172.21.0.1:41767",
+					"172.22.0.1:41767",
+					"172.23.0.1:41767",
+					"172.24.0.1:41767",
+					"172.25.0.1:41767",
+					"172.26.0.1:41767",
+					"172.27.0.1:41767",
+					"172.28.0.1:41767"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:27:57.314877464Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         743480569061735,
+				"StableID":   "nQ1bxUyio611CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:af4abc7df7d7f0622554c62ffaeeabe61e1ff5de99260371a766f809b4fb897f",
+				"KeyExpiry":  "2026-11-09T09:27:57Z",
+				"DiscoKey":   "discokey:2a4ffef40aa02f91c0537b4698a85c49c0cfcb2541a06e66a74e352cd7e6d005",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51143",
+					"10.65.0.27:51143",
+					"172.17.0.1:51143",
+					"172.18.0.1:51143",
+					"172.19.0.1:51143",
+					"172.20.0.1:51143",
+					"172.21.0.1:51143",
+					"172.22.0.1:51143",
+					"172.23.0.1:51143",
+					"172.24.0.1:51143",
+					"172.25.0.1:51143",
+					"172.26.0.1:51143",
+					"172.27.0.1:51143",
+					"172.28.0.1:51143"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:27:57.824662269Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         161569710742361,
+				"StableID":   "nkWz4RABG211CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3dde659be7ae0292fda9c505e6b8eea725150988d9fb52dd59f83689a89e0d5b",
+				"KeyExpiry":  "2026-11-09T09:27:58Z",
+				"DiscoKey":   "discokey:127b04aecd80109be87aeb2dd29e672a503ddd35c7ef15eab179c76b8393ac1a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:42123",
+					"10.65.0.27:42123",
+					"172.17.0.1:42123",
+					"172.18.0.1:42123",
+					"172.19.0.1:42123",
+					"172.20.0.1:42123",
+					"172.21.0.1:42123",
+					"172.22.0.1:42123",
+					"172.23.0.1:42123",
+					"172.24.0.1:42123",
+					"172.25.0.1:42123",
+					"172.26.0.1:42123",
+					"172.27.0.1:42123",
+					"172.28.0.1:42123"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:27:58.358268966Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2697352476831753,
+				"StableID":   "nN1Ejnsd4N11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dc0edc563a9b0dfb4b1a1d97ad5047d664e387978bc4af2c41e5c3f655548d4d",
+				"KeyExpiry":  "2026-11-09T09:27:58Z",
+				"DiscoKey":   "discokey:1c9c6f15805c22bd74092f63f6285a3372189de31b4e80e5179251f7c7d0ae76",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59836",
+					"10.65.0.27:59836",
+					"172.17.0.1:59836",
+					"172.18.0.1:59836",
+					"172.19.0.1:59836",
+					"172.20.0.1:59836",
+					"172.21.0.1:59836",
+					"172.22.0.1:59836",
+					"172.23.0.1:59836",
+					"172.24.0.1:59836",
+					"172.25.0.1:59836",
+					"172.26.0.1:59836",
+					"172.27.0.1:59836",
+					"172.28.0.1:59836"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:27:58.881120954Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4621335723968074": {
+				"ID":          4621335723968074,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5664970112452116,
+				"StableID":   "nj8Q4DAgEm11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       5664970112452116,
+				"Key":        "nodekey:8d7322fce72a08ee2effd3c1d63fc112136850ac34b734881dbc5ce4d2be8d54",
+				"DiscoKey":   "discokey:c899d2b9244acd1648d804efa21ac482b91d0b1ade8054a2087004afa6abc33b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34978",
+					"10.65.0.27:34978",
+					"172.17.0.1:34978",
+					"172.18.0.1:34978",
+					"172.19.0.1:34978",
+					"172.20.0.1:34978",
+					"172.21.0.1:34978",
+					"172.22.0.1:34978",
+					"172.23.0.1:34978",
+					"172.24.0.1:34978",
+					"172.25.0.1:34978",
+					"172.26.0.1:34978",
+					"172.27.0.1:34978",
+					"172.28.0.1:34978"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:27:55.675123474Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8d7322fce72a08ee2effd3c1d63fc112136850ac34b734881dbc5ce4d2be8d54",
+			"MachineKey": "mkey:872c3a6b92796b81bf9a16556361e81df28d921f369c6b9dea40cb1aa5bbc15c",
+			"Peers": [{
+				"ID":         3211934370887534,
+				"StableID":   "nmpxb25h5S11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8909caa169b036242fb39f8e7a2946e135629cda6ba651e1384d85d76bb2e136",
+				"DiscoKey":   "discokey:38fd4ff4c3a2aaad2e0f94b4909d579e3ef424f630ef5bb61f7fa7624a0fe109",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43670",
+					"10.65.0.27:43670",
+					"172.17.0.1:43670",
+					"172.18.0.1:43670",
+					"172.19.0.1:43670",
+					"172.20.0.1:43670",
+					"172.21.0.1:43670",
+					"172.22.0.1:43670",
+					"172.23.0.1:43670",
+					"172.24.0.1:43670",
+					"172.25.0.1:43670",
+					"172.26.0.1:43670",
+					"172.27.0.1:43670",
+					"172.28.0.1:43670"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:27:41.096838369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         891554532683498,
+				"StableID":   "nRLx4Jdnx711CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:23e96a59a7758c8da3db258d7f24b285bd64f69005cfa7c69e081e5fe9166551",
+				"DiscoKey":   "discokey:f087a58298acc65bd5501f49f37f76b59980305c151c6bb69fbf28441b311136",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44596",
+					"10.65.0.27:44596",
+					"172.17.0.1:44596",
+					"172.18.0.1:44596",
+					"172.19.0.1:44596",
+					"172.20.0.1:44596",
+					"172.21.0.1:44596",
+					"172.22.0.1:44596",
+					"172.23.0.1:44596",
+					"172.24.0.1:44596",
+					"172.25.0.1:44596",
+					"172.26.0.1:44596",
+					"172.27.0.1:44596",
+					"172.28.0.1:44596"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:27:47.813891908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8689261536074906,
+				"StableID":   "n1GxxdAPrA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:beda087a1c0dfbd3e69290651073d64f0cf47cdf855cd2d0d2737bdf33d1000e",
+				"DiscoKey":   "discokey:00fe6422316407aaf964073d6b97637a0e30319a4f8b1bf482ca3e2e2d943451",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56267",
+					"10.65.0.27:56267",
+					"172.17.0.1:56267",
+					"172.18.0.1:56267",
+					"172.19.0.1:56267",
+					"172.20.0.1:56267",
+					"172.21.0.1:56267",
+					"172.22.0.1:56267",
+					"172.23.0.1:56267",
+					"172.24.0.1:56267",
+					"172.25.0.1:56267",
+					"172.26.0.1:56267",
+					"172.27.0.1:56267",
+					"172.28.0.1:56267"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:27:48.810842495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3080881849207967,
+				"StableID":   "nAnk2SYL4R11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0fa2626d84f36e0d07b5a50dba3b05306e4c229b92bd8790839fc32a8d0f33f",
+				"DiscoKey":   "discokey:fde3fbd4008cd54458dec2da09d8c84027adf0722a1af2fc7144fb9dd6c44236",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53414",
+					"10.65.0.27:53414",
+					"172.17.0.1:53414",
+					"172.18.0.1:53414",
+					"172.19.0.1:53414",
+					"172.20.0.1:53414",
+					"172.21.0.1:53414",
+					"172.22.0.1:53414",
+					"172.23.0.1:53414",
+					"172.24.0.1:53414",
+					"172.25.0.1:53414",
+					"172.26.0.1:53414",
+					"172.27.0.1:53414",
+					"172.28.0.1:53414"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:27:49.543578532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3079523750338012,
+				"StableID":   "nKC4VHsi3R11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:052d60473f81adf1a8658eb19285774bd4bd3c10acaa8e02fcc1532c909ee524",
+				"DiscoKey":   "discokey:9865c36aab8fbeb0a68e8152af473b50f9ae7249bc2330c6c8ab5717c961b527",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41888",
+					"10.65.0.27:41888",
+					"172.17.0.1:41888",
+					"172.18.0.1:41888",
+					"172.19.0.1:41888",
+					"172.20.0.1:41888",
+					"172.21.0.1:41888",
+					"172.22.0.1:41888",
+					"172.23.0.1:41888",
+					"172.24.0.1:41888",
+					"172.25.0.1:41888",
+					"172.26.0.1:41888",
+					"172.27.0.1:41888",
+					"172.28.0.1:41888"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:27:50.064703038Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3602096095486955,
+				"StableID":   "ngsFAUxP8V11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9ce396b31072e6bd0d6b6e4c20bc97d5a18dad911feb4f6da36e046a0cba1546",
+				"DiscoKey":   "discokey:8d3634650d1b920b7a16ea4c19d4febd02fb93bfe75919faf5cd2000a86f9f18",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:43362",
+					"10.65.0.27:43362",
+					"172.17.0.1:43362",
+					"172.18.0.1:43362",
+					"172.19.0.1:43362",
+					"172.20.0.1:43362",
+					"172.21.0.1:43362",
+					"172.22.0.1:43362",
+					"172.23.0.1:43362",
+					"172.24.0.1:43362",
+					"172.25.0.1:43362",
+					"172.26.0.1:43362",
+					"172.27.0.1:43362",
+					"172.28.0.1:43362"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:27:50.594356405Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4621335723968074,
+				"StableID":   "nbuZuse16d11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6b1098d726fc23a014b70951f9ca8272e5eb3eab41d30834dc0a67ea82bd4a72",
+				"DiscoKey":   "discokey:baaefb4b196af32b3f2430e34a79b21553ab27250a737094c30696ab818b616f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41690",
+					"10.65.0.27:41690",
+					"172.17.0.1:41690",
+					"172.18.0.1:41690",
+					"172.19.0.1:41690",
+					"172.20.0.1:41690",
+					"172.21.0.1:41690",
+					"172.22.0.1:41690",
+					"172.23.0.1:41690",
+					"172.24.0.1:41690",
+					"172.25.0.1:41690",
+					"172.26.0.1:41690",
+					"172.27.0.1:41690",
+					"172.28.0.1:41690"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:27:51.126268674Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1051500490490188,
+				"StableID":   "nymiep8ED911CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6c65c498ef62b3adf215c967ac5ebdee5e33836347a24713776cb447b489253",
+				"DiscoKey":   "discokey:205d80fafa08f1ff3f806eea5b4e585e7d0575d4a725e4cfc74dafe8ec4c2967",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57470",
+					"10.65.0.27:57470",
+					"172.17.0.1:57470",
+					"172.18.0.1:57470",
+					"172.19.0.1:57470",
+					"172.20.0.1:57470",
+					"172.21.0.1:57470",
+					"172.22.0.1:57470",
+					"172.23.0.1:57470",
+					"172.24.0.1:57470",
+					"172.25.0.1:57470",
+					"172.26.0.1:57470",
+					"172.27.0.1:57470",
+					"172.28.0.1:57470"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:27:51.657982734Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2152360805118066,
+				"StableID":   "nmEEwNsooH11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:671d85e034256a660bbe26fed087a45f1f1127bccc46559c889f8df5b8d2486b",
+				"DiscoKey":   "discokey:0fd70a6fb6cc6e8210d93caa64e83e7d07f766953afa34d530ed0e331ef6c034",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50128",
+					"10.65.0.27:50128",
+					"172.17.0.1:50128",
+					"172.18.0.1:50128",
+					"172.19.0.1:50128",
+					"172.20.0.1:50128",
+					"172.21.0.1:50128",
+					"172.22.0.1:50128",
+					"172.23.0.1:50128",
+					"172.24.0.1:50128",
+					"172.25.0.1:50128",
+					"172.26.0.1:50128",
+					"172.27.0.1:50128",
+					"172.28.0.1:50128"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:27:56.228560725Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         738223294216272,
+				"StableID":   "n3ApahsLm611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:05f60a2cc279aac711826029360dbe5d03d4bc630e10fb78a55420305c541653",
+				"DiscoKey":   "discokey:b1d89b9ad9ccde697334200260bfb9d508e8877e862b0dfbe2167ce03896c416",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:49690",
+					"10.65.0.27:49690",
+					"172.17.0.1:49690",
+					"172.18.0.1:49690",
+					"172.19.0.1:49690",
+					"172.20.0.1:49690",
+					"172.21.0.1:49690",
+					"172.22.0.1:49690",
+					"172.23.0.1:49690",
+					"172.24.0.1:49690",
+					"172.25.0.1:49690",
+					"172.26.0.1:49690",
+					"172.27.0.1:49690",
+					"172.28.0.1:49690"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:27:56.757475702Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6185889331350142,
+				"StableID":   "n9UTdkpbJq11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:446c96b7c7aede556af9e96ec9eccdf3d9f562e4cb5457f06f8de776c27a6345",
+				"DiscoKey":   "discokey:4b6c28c4897b5bffd47568cbd543a2024b4286618b27e08520bf776760e6ce5d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41767",
+					"10.65.0.27:41767",
+					"172.17.0.1:41767",
+					"172.18.0.1:41767",
+					"172.19.0.1:41767",
+					"172.20.0.1:41767",
+					"172.21.0.1:41767",
+					"172.22.0.1:41767",
+					"172.23.0.1:41767",
+					"172.24.0.1:41767",
+					"172.25.0.1:41767",
+					"172.26.0.1:41767",
+					"172.27.0.1:41767",
+					"172.28.0.1:41767"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:27:57.314877464Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         743480569061735,
+				"StableID":   "nQ1bxUyio611CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:af4abc7df7d7f0622554c62ffaeeabe61e1ff5de99260371a766f809b4fb897f",
+				"KeyExpiry":  "2026-11-09T09:27:57Z",
+				"DiscoKey":   "discokey:2a4ffef40aa02f91c0537b4698a85c49c0cfcb2541a06e66a74e352cd7e6d005",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51143",
+					"10.65.0.27:51143",
+					"172.17.0.1:51143",
+					"172.18.0.1:51143",
+					"172.19.0.1:51143",
+					"172.20.0.1:51143",
+					"172.21.0.1:51143",
+					"172.22.0.1:51143",
+					"172.23.0.1:51143",
+					"172.24.0.1:51143",
+					"172.25.0.1:51143",
+					"172.26.0.1:51143",
+					"172.27.0.1:51143",
+					"172.28.0.1:51143"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:27:57.824662269Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         161569710742361,
+				"StableID":   "nkWz4RABG211CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3dde659be7ae0292fda9c505e6b8eea725150988d9fb52dd59f83689a89e0d5b",
+				"KeyExpiry":  "2026-11-09T09:27:58Z",
+				"DiscoKey":   "discokey:127b04aecd80109be87aeb2dd29e672a503ddd35c7ef15eab179c76b8393ac1a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:42123",
+					"10.65.0.27:42123",
+					"172.17.0.1:42123",
+					"172.18.0.1:42123",
+					"172.19.0.1:42123",
+					"172.20.0.1:42123",
+					"172.21.0.1:42123",
+					"172.22.0.1:42123",
+					"172.23.0.1:42123",
+					"172.24.0.1:42123",
+					"172.25.0.1:42123",
+					"172.26.0.1:42123",
+					"172.27.0.1:42123",
+					"172.28.0.1:42123"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:27:58.358268966Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2697352476831753,
+				"StableID":   "nN1Ejnsd4N11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dc0edc563a9b0dfb4b1a1d97ad5047d664e387978bc4af2c41e5c3f655548d4d",
+				"KeyExpiry":  "2026-11-09T09:27:58Z",
+				"DiscoKey":   "discokey:1c9c6f15805c22bd74092f63f6285a3372189de31b4e80e5179251f7c7d0ae76",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59836",
+					"10.65.0.27:59836",
+					"172.17.0.1:59836",
+					"172.18.0.1:59836",
+					"172.19.0.1:59836",
+					"172.20.0.1:59836",
+					"172.21.0.1:59836",
+					"172.22.0.1:59836",
+					"172.23.0.1:59836",
+					"172.24.0.1:59836",
+					"172.25.0.1:59836",
+					"172.26.0.1:59836",
+					"172.27.0.1:59836",
+					"172.28.0.1:59836"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:27:58.881120954Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5664970112452116": {
+				"ID":          5664970112452116,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         161569710742361,
+				"StableID":   "nkWz4RABG211CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3dde659be7ae0292fda9c505e6b8eea725150988d9fb52dd59f83689a89e0d5b",
+				"KeyExpiry":  "2026-11-09T09:27:58Z",
+				"DiscoKey":   "discokey:127b04aecd80109be87aeb2dd29e672a503ddd35c7ef15eab179c76b8393ac1a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:42123",
+					"10.65.0.27:42123",
+					"172.17.0.1:42123",
+					"172.18.0.1:42123",
+					"172.19.0.1:42123",
+					"172.20.0.1:42123",
+					"172.21.0.1:42123",
+					"172.22.0.1:42123",
+					"172.23.0.1:42123",
+					"172.24.0.1:42123",
+					"172.25.0.1:42123",
+					"172.26.0.1:42123",
+					"172.27.0.1:42123",
+					"172.28.0.1:42123"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:27:58.358268966Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3dde659be7ae0292fda9c505e6b8eea725150988d9fb52dd59f83689a89e0d5b",
+			"MachineKey": "mkey:98c1e71e417312ec797e2b8684304dc2840f6e848995ad5c44deac2ff4276b68",
+			"Peers": [{
+				"ID":         3211934370887534,
+				"StableID":   "nmpxb25h5S11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8909caa169b036242fb39f8e7a2946e135629cda6ba651e1384d85d76bb2e136",
+				"DiscoKey":   "discokey:38fd4ff4c3a2aaad2e0f94b4909d579e3ef424f630ef5bb61f7fa7624a0fe109",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43670",
+					"10.65.0.27:43670",
+					"172.17.0.1:43670",
+					"172.18.0.1:43670",
+					"172.19.0.1:43670",
+					"172.20.0.1:43670",
+					"172.21.0.1:43670",
+					"172.22.0.1:43670",
+					"172.23.0.1:43670",
+					"172.24.0.1:43670",
+					"172.25.0.1:43670",
+					"172.26.0.1:43670",
+					"172.27.0.1:43670",
+					"172.28.0.1:43670"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:27:41.096838369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         891554532683498,
+				"StableID":   "nRLx4Jdnx711CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:23e96a59a7758c8da3db258d7f24b285bd64f69005cfa7c69e081e5fe9166551",
+				"DiscoKey":   "discokey:f087a58298acc65bd5501f49f37f76b59980305c151c6bb69fbf28441b311136",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44596",
+					"10.65.0.27:44596",
+					"172.17.0.1:44596",
+					"172.18.0.1:44596",
+					"172.19.0.1:44596",
+					"172.20.0.1:44596",
+					"172.21.0.1:44596",
+					"172.22.0.1:44596",
+					"172.23.0.1:44596",
+					"172.24.0.1:44596",
+					"172.25.0.1:44596",
+					"172.26.0.1:44596",
+					"172.27.0.1:44596",
+					"172.28.0.1:44596"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:27:47.813891908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8689261536074906,
+				"StableID":   "n1GxxdAPrA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:beda087a1c0dfbd3e69290651073d64f0cf47cdf855cd2d0d2737bdf33d1000e",
+				"DiscoKey":   "discokey:00fe6422316407aaf964073d6b97637a0e30319a4f8b1bf482ca3e2e2d943451",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56267",
+					"10.65.0.27:56267",
+					"172.17.0.1:56267",
+					"172.18.0.1:56267",
+					"172.19.0.1:56267",
+					"172.20.0.1:56267",
+					"172.21.0.1:56267",
+					"172.22.0.1:56267",
+					"172.23.0.1:56267",
+					"172.24.0.1:56267",
+					"172.25.0.1:56267",
+					"172.26.0.1:56267",
+					"172.27.0.1:56267",
+					"172.28.0.1:56267"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:27:48.810842495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3080881849207967,
+				"StableID":   "nAnk2SYL4R11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0fa2626d84f36e0d07b5a50dba3b05306e4c229b92bd8790839fc32a8d0f33f",
+				"DiscoKey":   "discokey:fde3fbd4008cd54458dec2da09d8c84027adf0722a1af2fc7144fb9dd6c44236",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53414",
+					"10.65.0.27:53414",
+					"172.17.0.1:53414",
+					"172.18.0.1:53414",
+					"172.19.0.1:53414",
+					"172.20.0.1:53414",
+					"172.21.0.1:53414",
+					"172.22.0.1:53414",
+					"172.23.0.1:53414",
+					"172.24.0.1:53414",
+					"172.25.0.1:53414",
+					"172.26.0.1:53414",
+					"172.27.0.1:53414",
+					"172.28.0.1:53414"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:27:49.543578532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3079523750338012,
+				"StableID":   "nKC4VHsi3R11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:052d60473f81adf1a8658eb19285774bd4bd3c10acaa8e02fcc1532c909ee524",
+				"DiscoKey":   "discokey:9865c36aab8fbeb0a68e8152af473b50f9ae7249bc2330c6c8ab5717c961b527",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41888",
+					"10.65.0.27:41888",
+					"172.17.0.1:41888",
+					"172.18.0.1:41888",
+					"172.19.0.1:41888",
+					"172.20.0.1:41888",
+					"172.21.0.1:41888",
+					"172.22.0.1:41888",
+					"172.23.0.1:41888",
+					"172.24.0.1:41888",
+					"172.25.0.1:41888",
+					"172.26.0.1:41888",
+					"172.27.0.1:41888",
+					"172.28.0.1:41888"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:27:50.064703038Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3602096095486955,
+				"StableID":   "ngsFAUxP8V11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9ce396b31072e6bd0d6b6e4c20bc97d5a18dad911feb4f6da36e046a0cba1546",
+				"DiscoKey":   "discokey:8d3634650d1b920b7a16ea4c19d4febd02fb93bfe75919faf5cd2000a86f9f18",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:43362",
+					"10.65.0.27:43362",
+					"172.17.0.1:43362",
+					"172.18.0.1:43362",
+					"172.19.0.1:43362",
+					"172.20.0.1:43362",
+					"172.21.0.1:43362",
+					"172.22.0.1:43362",
+					"172.23.0.1:43362",
+					"172.24.0.1:43362",
+					"172.25.0.1:43362",
+					"172.26.0.1:43362",
+					"172.27.0.1:43362",
+					"172.28.0.1:43362"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:27:50.594356405Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4621335723968074,
+				"StableID":   "nbuZuse16d11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6b1098d726fc23a014b70951f9ca8272e5eb3eab41d30834dc0a67ea82bd4a72",
+				"DiscoKey":   "discokey:baaefb4b196af32b3f2430e34a79b21553ab27250a737094c30696ab818b616f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41690",
+					"10.65.0.27:41690",
+					"172.17.0.1:41690",
+					"172.18.0.1:41690",
+					"172.19.0.1:41690",
+					"172.20.0.1:41690",
+					"172.21.0.1:41690",
+					"172.22.0.1:41690",
+					"172.23.0.1:41690",
+					"172.24.0.1:41690",
+					"172.25.0.1:41690",
+					"172.26.0.1:41690",
+					"172.27.0.1:41690",
+					"172.28.0.1:41690"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:27:51.126268674Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1051500490490188,
+				"StableID":   "nymiep8ED911CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6c65c498ef62b3adf215c967ac5ebdee5e33836347a24713776cb447b489253",
+				"DiscoKey":   "discokey:205d80fafa08f1ff3f806eea5b4e585e7d0575d4a725e4cfc74dafe8ec4c2967",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57470",
+					"10.65.0.27:57470",
+					"172.17.0.1:57470",
+					"172.18.0.1:57470",
+					"172.19.0.1:57470",
+					"172.20.0.1:57470",
+					"172.21.0.1:57470",
+					"172.22.0.1:57470",
+					"172.23.0.1:57470",
+					"172.24.0.1:57470",
+					"172.25.0.1:57470",
+					"172.26.0.1:57470",
+					"172.27.0.1:57470",
+					"172.28.0.1:57470"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:27:51.657982734Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5664970112452116,
+				"StableID":   "nj8Q4DAgEm11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8d7322fce72a08ee2effd3c1d63fc112136850ac34b734881dbc5ce4d2be8d54",
+				"DiscoKey":   "discokey:c899d2b9244acd1648d804efa21ac482b91d0b1ade8054a2087004afa6abc33b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34978",
+					"10.65.0.27:34978",
+					"172.17.0.1:34978",
+					"172.18.0.1:34978",
+					"172.19.0.1:34978",
+					"172.20.0.1:34978",
+					"172.21.0.1:34978",
+					"172.22.0.1:34978",
+					"172.23.0.1:34978",
+					"172.24.0.1:34978",
+					"172.25.0.1:34978",
+					"172.26.0.1:34978",
+					"172.27.0.1:34978",
+					"172.28.0.1:34978"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:27:55.675123474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2152360805118066,
+				"StableID":   "nmEEwNsooH11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:671d85e034256a660bbe26fed087a45f1f1127bccc46559c889f8df5b8d2486b",
+				"DiscoKey":   "discokey:0fd70a6fb6cc6e8210d93caa64e83e7d07f766953afa34d530ed0e331ef6c034",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50128",
+					"10.65.0.27:50128",
+					"172.17.0.1:50128",
+					"172.18.0.1:50128",
+					"172.19.0.1:50128",
+					"172.20.0.1:50128",
+					"172.21.0.1:50128",
+					"172.22.0.1:50128",
+					"172.23.0.1:50128",
+					"172.24.0.1:50128",
+					"172.25.0.1:50128",
+					"172.26.0.1:50128",
+					"172.27.0.1:50128",
+					"172.28.0.1:50128"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:27:56.228560725Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         738223294216272,
+				"StableID":   "n3ApahsLm611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:05f60a2cc279aac711826029360dbe5d03d4bc630e10fb78a55420305c541653",
+				"DiscoKey":   "discokey:b1d89b9ad9ccde697334200260bfb9d508e8877e862b0dfbe2167ce03896c416",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:49690",
+					"10.65.0.27:49690",
+					"172.17.0.1:49690",
+					"172.18.0.1:49690",
+					"172.19.0.1:49690",
+					"172.20.0.1:49690",
+					"172.21.0.1:49690",
+					"172.22.0.1:49690",
+					"172.23.0.1:49690",
+					"172.24.0.1:49690",
+					"172.25.0.1:49690",
+					"172.26.0.1:49690",
+					"172.27.0.1:49690",
+					"172.28.0.1:49690"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:27:56.757475702Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6185889331350142,
+				"StableID":   "n9UTdkpbJq11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:446c96b7c7aede556af9e96ec9eccdf3d9f562e4cb5457f06f8de776c27a6345",
+				"DiscoKey":   "discokey:4b6c28c4897b5bffd47568cbd543a2024b4286618b27e08520bf776760e6ce5d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41767",
+					"10.65.0.27:41767",
+					"172.17.0.1:41767",
+					"172.18.0.1:41767",
+					"172.19.0.1:41767",
+					"172.20.0.1:41767",
+					"172.21.0.1:41767",
+					"172.22.0.1:41767",
+					"172.23.0.1:41767",
+					"172.24.0.1:41767",
+					"172.25.0.1:41767",
+					"172.26.0.1:41767",
+					"172.27.0.1:41767",
+					"172.28.0.1:41767"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:27:57.314877464Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         743480569061735,
+				"StableID":   "nQ1bxUyio611CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:af4abc7df7d7f0622554c62ffaeeabe61e1ff5de99260371a766f809b4fb897f",
+				"KeyExpiry":  "2026-11-09T09:27:57Z",
+				"DiscoKey":   "discokey:2a4ffef40aa02f91c0537b4698a85c49c0cfcb2541a06e66a74e352cd7e6d005",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51143",
+					"10.65.0.27:51143",
+					"172.17.0.1:51143",
+					"172.18.0.1:51143",
+					"172.19.0.1:51143",
+					"172.20.0.1:51143",
+					"172.21.0.1:51143",
+					"172.22.0.1:51143",
+					"172.23.0.1:51143",
+					"172.24.0.1:51143",
+					"172.25.0.1:51143",
+					"172.26.0.1:51143",
+					"172.27.0.1:51143",
+					"172.28.0.1:51143"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:27:57.824662269Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2697352476831753,
+				"StableID":   "nN1Ejnsd4N11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dc0edc563a9b0dfb4b1a1d97ad5047d664e387978bc4af2c41e5c3f655548d4d",
+				"KeyExpiry":  "2026-11-09T09:27:58Z",
+				"DiscoKey":   "discokey:1c9c6f15805c22bd74092f63f6285a3372189de31b4e80e5179251f7c7d0ae76",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59836",
+					"10.65.0.27:59836",
+					"172.17.0.1:59836",
+					"172.18.0.1:59836",
+					"172.19.0.1:59836",
+					"172.20.0.1:59836",
+					"172.21.0.1:59836",
+					"172.22.0.1:59836",
+					"172.23.0.1:59836",
+					"172.24.0.1:59836",
+					"172.25.0.1:59836",
+					"172.26.0.1:59836",
+					"172.27.0.1:59836",
+					"172.28.0.1:59836"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:27:58.881120954Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2152360805118066,
+				"StableID":   "nmEEwNsooH11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       2152360805118066,
+				"Key":        "nodekey:671d85e034256a660bbe26fed087a45f1f1127bccc46559c889f8df5b8d2486b",
+				"DiscoKey":   "discokey:0fd70a6fb6cc6e8210d93caa64e83e7d07f766953afa34d530ed0e331ef6c034",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50128",
+					"10.65.0.27:50128",
+					"172.17.0.1:50128",
+					"172.18.0.1:50128",
+					"172.19.0.1:50128",
+					"172.20.0.1:50128",
+					"172.21.0.1:50128",
+					"172.22.0.1:50128",
+					"172.23.0.1:50128",
+					"172.24.0.1:50128",
+					"172.25.0.1:50128",
+					"172.26.0.1:50128",
+					"172.27.0.1:50128",
+					"172.28.0.1:50128"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:27:56.228560725Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:671d85e034256a660bbe26fed087a45f1f1127bccc46559c889f8df5b8d2486b",
+			"MachineKey": "mkey:54cb9eecceb939c7bfc677ded35d763983f4f2b45d0ba8a7ca2629e58dc0424b",
+			"Peers": [{
+				"ID":         3211934370887534,
+				"StableID":   "nmpxb25h5S11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8909caa169b036242fb39f8e7a2946e135629cda6ba651e1384d85d76bb2e136",
+				"DiscoKey":   "discokey:38fd4ff4c3a2aaad2e0f94b4909d579e3ef424f630ef5bb61f7fa7624a0fe109",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43670",
+					"10.65.0.27:43670",
+					"172.17.0.1:43670",
+					"172.18.0.1:43670",
+					"172.19.0.1:43670",
+					"172.20.0.1:43670",
+					"172.21.0.1:43670",
+					"172.22.0.1:43670",
+					"172.23.0.1:43670",
+					"172.24.0.1:43670",
+					"172.25.0.1:43670",
+					"172.26.0.1:43670",
+					"172.27.0.1:43670",
+					"172.28.0.1:43670"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:27:41.096838369Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         891554532683498,
+				"StableID":   "nRLx4Jdnx711CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:23e96a59a7758c8da3db258d7f24b285bd64f69005cfa7c69e081e5fe9166551",
+				"DiscoKey":   "discokey:f087a58298acc65bd5501f49f37f76b59980305c151c6bb69fbf28441b311136",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44596",
+					"10.65.0.27:44596",
+					"172.17.0.1:44596",
+					"172.18.0.1:44596",
+					"172.19.0.1:44596",
+					"172.20.0.1:44596",
+					"172.21.0.1:44596",
+					"172.22.0.1:44596",
+					"172.23.0.1:44596",
+					"172.24.0.1:44596",
+					"172.25.0.1:44596",
+					"172.26.0.1:44596",
+					"172.27.0.1:44596",
+					"172.28.0.1:44596"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:27:47.813891908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8689261536074906,
+				"StableID":   "n1GxxdAPrA21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:beda087a1c0dfbd3e69290651073d64f0cf47cdf855cd2d0d2737bdf33d1000e",
+				"DiscoKey":   "discokey:00fe6422316407aaf964073d6b97637a0e30319a4f8b1bf482ca3e2e2d943451",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56267",
+					"10.65.0.27:56267",
+					"172.17.0.1:56267",
+					"172.18.0.1:56267",
+					"172.19.0.1:56267",
+					"172.20.0.1:56267",
+					"172.21.0.1:56267",
+					"172.22.0.1:56267",
+					"172.23.0.1:56267",
+					"172.24.0.1:56267",
+					"172.25.0.1:56267",
+					"172.26.0.1:56267",
+					"172.27.0.1:56267",
+					"172.28.0.1:56267"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:27:48.810842495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3080881849207967,
+				"StableID":   "nAnk2SYL4R11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0fa2626d84f36e0d07b5a50dba3b05306e4c229b92bd8790839fc32a8d0f33f",
+				"DiscoKey":   "discokey:fde3fbd4008cd54458dec2da09d8c84027adf0722a1af2fc7144fb9dd6c44236",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:53414",
+					"10.65.0.27:53414",
+					"172.17.0.1:53414",
+					"172.18.0.1:53414",
+					"172.19.0.1:53414",
+					"172.20.0.1:53414",
+					"172.21.0.1:53414",
+					"172.22.0.1:53414",
+					"172.23.0.1:53414",
+					"172.24.0.1:53414",
+					"172.25.0.1:53414",
+					"172.26.0.1:53414",
+					"172.27.0.1:53414",
+					"172.28.0.1:53414"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:27:49.543578532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3079523750338012,
+				"StableID":   "nKC4VHsi3R11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:052d60473f81adf1a8658eb19285774bd4bd3c10acaa8e02fcc1532c909ee524",
+				"DiscoKey":   "discokey:9865c36aab8fbeb0a68e8152af473b50f9ae7249bc2330c6c8ab5717c961b527",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41888",
+					"10.65.0.27:41888",
+					"172.17.0.1:41888",
+					"172.18.0.1:41888",
+					"172.19.0.1:41888",
+					"172.20.0.1:41888",
+					"172.21.0.1:41888",
+					"172.22.0.1:41888",
+					"172.23.0.1:41888",
+					"172.24.0.1:41888",
+					"172.25.0.1:41888",
+					"172.26.0.1:41888",
+					"172.27.0.1:41888",
+					"172.28.0.1:41888"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:27:50.064703038Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3602096095486955,
+				"StableID":   "ngsFAUxP8V11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9ce396b31072e6bd0d6b6e4c20bc97d5a18dad911feb4f6da36e046a0cba1546",
+				"DiscoKey":   "discokey:8d3634650d1b920b7a16ea4c19d4febd02fb93bfe75919faf5cd2000a86f9f18",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:43362",
+					"10.65.0.27:43362",
+					"172.17.0.1:43362",
+					"172.18.0.1:43362",
+					"172.19.0.1:43362",
+					"172.20.0.1:43362",
+					"172.21.0.1:43362",
+					"172.22.0.1:43362",
+					"172.23.0.1:43362",
+					"172.24.0.1:43362",
+					"172.25.0.1:43362",
+					"172.26.0.1:43362",
+					"172.27.0.1:43362",
+					"172.28.0.1:43362"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:27:50.594356405Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4621335723968074,
+				"StableID":   "nbuZuse16d11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6b1098d726fc23a014b70951f9ca8272e5eb3eab41d30834dc0a67ea82bd4a72",
+				"DiscoKey":   "discokey:baaefb4b196af32b3f2430e34a79b21553ab27250a737094c30696ab818b616f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:41690",
+					"10.65.0.27:41690",
+					"172.17.0.1:41690",
+					"172.18.0.1:41690",
+					"172.19.0.1:41690",
+					"172.20.0.1:41690",
+					"172.21.0.1:41690",
+					"172.22.0.1:41690",
+					"172.23.0.1:41690",
+					"172.24.0.1:41690",
+					"172.25.0.1:41690",
+					"172.26.0.1:41690",
+					"172.27.0.1:41690",
+					"172.28.0.1:41690"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:27:51.126268674Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1051500490490188,
+				"StableID":   "nymiep8ED911CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6c65c498ef62b3adf215c967ac5ebdee5e33836347a24713776cb447b489253",
+				"DiscoKey":   "discokey:205d80fafa08f1ff3f806eea5b4e585e7d0575d4a725e4cfc74dafe8ec4c2967",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:57470",
+					"10.65.0.27:57470",
+					"172.17.0.1:57470",
+					"172.18.0.1:57470",
+					"172.19.0.1:57470",
+					"172.20.0.1:57470",
+					"172.21.0.1:57470",
+					"172.22.0.1:57470",
+					"172.23.0.1:57470",
+					"172.24.0.1:57470",
+					"172.25.0.1:57470",
+					"172.26.0.1:57470",
+					"172.27.0.1:57470",
+					"172.28.0.1:57470"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:27:51.657982734Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5664970112452116,
+				"StableID":   "nj8Q4DAgEm11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8d7322fce72a08ee2effd3c1d63fc112136850ac34b734881dbc5ce4d2be8d54",
+				"DiscoKey":   "discokey:c899d2b9244acd1648d804efa21ac482b91d0b1ade8054a2087004afa6abc33b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34978",
+					"10.65.0.27:34978",
+					"172.17.0.1:34978",
+					"172.18.0.1:34978",
+					"172.19.0.1:34978",
+					"172.20.0.1:34978",
+					"172.21.0.1:34978",
+					"172.22.0.1:34978",
+					"172.23.0.1:34978",
+					"172.24.0.1:34978",
+					"172.25.0.1:34978",
+					"172.26.0.1:34978",
+					"172.27.0.1:34978",
+					"172.28.0.1:34978"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:27:55.675123474Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         738223294216272,
+				"StableID":   "n3ApahsLm611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:05f60a2cc279aac711826029360dbe5d03d4bc630e10fb78a55420305c541653",
+				"DiscoKey":   "discokey:b1d89b9ad9ccde697334200260bfb9d508e8877e862b0dfbe2167ce03896c416",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:49690",
+					"10.65.0.27:49690",
+					"172.17.0.1:49690",
+					"172.18.0.1:49690",
+					"172.19.0.1:49690",
+					"172.20.0.1:49690",
+					"172.21.0.1:49690",
+					"172.22.0.1:49690",
+					"172.23.0.1:49690",
+					"172.24.0.1:49690",
+					"172.25.0.1:49690",
+					"172.26.0.1:49690",
+					"172.27.0.1:49690",
+					"172.28.0.1:49690"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:27:56.757475702Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6185889331350142,
+				"StableID":   "n9UTdkpbJq11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:446c96b7c7aede556af9e96ec9eccdf3d9f562e4cb5457f06f8de776c27a6345",
+				"DiscoKey":   "discokey:4b6c28c4897b5bffd47568cbd543a2024b4286618b27e08520bf776760e6ce5d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41767",
+					"10.65.0.27:41767",
+					"172.17.0.1:41767",
+					"172.18.0.1:41767",
+					"172.19.0.1:41767",
+					"172.20.0.1:41767",
+					"172.21.0.1:41767",
+					"172.22.0.1:41767",
+					"172.23.0.1:41767",
+					"172.24.0.1:41767",
+					"172.25.0.1:41767",
+					"172.26.0.1:41767",
+					"172.27.0.1:41767",
+					"172.28.0.1:41767"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:27:57.314877464Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         743480569061735,
+				"StableID":   "nQ1bxUyio611CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:af4abc7df7d7f0622554c62ffaeeabe61e1ff5de99260371a766f809b4fb897f",
+				"KeyExpiry":  "2026-11-09T09:27:57Z",
+				"DiscoKey":   "discokey:2a4ffef40aa02f91c0537b4698a85c49c0cfcb2541a06e66a74e352cd7e6d005",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51143",
+					"10.65.0.27:51143",
+					"172.17.0.1:51143",
+					"172.18.0.1:51143",
+					"172.19.0.1:51143",
+					"172.20.0.1:51143",
+					"172.21.0.1:51143",
+					"172.22.0.1:51143",
+					"172.23.0.1:51143",
+					"172.24.0.1:51143",
+					"172.25.0.1:51143",
+					"172.26.0.1:51143",
+					"172.27.0.1:51143",
+					"172.28.0.1:51143"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:27:57.824662269Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         161569710742361,
+				"StableID":   "nkWz4RABG211CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3dde659be7ae0292fda9c505e6b8eea725150988d9fb52dd59f83689a89e0d5b",
+				"KeyExpiry":  "2026-11-09T09:27:58Z",
+				"DiscoKey":   "discokey:127b04aecd80109be87aeb2dd29e672a503ddd35c7ef15eab179c76b8393ac1a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:42123",
+					"10.65.0.27:42123",
+					"172.17.0.1:42123",
+					"172.18.0.1:42123",
+					"172.19.0.1:42123",
+					"172.20.0.1:42123",
+					"172.21.0.1:42123",
+					"172.22.0.1:42123",
+					"172.23.0.1:42123",
+					"172.24.0.1:42123",
+					"172.25.0.1:42123",
+					"172.26.0.1:42123",
+					"172.27.0.1:42123",
+					"172.28.0.1:42123"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:27:58.358268966Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2697352476831753,
+				"StableID":   "nN1Ejnsd4N11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:dc0edc563a9b0dfb4b1a1d97ad5047d664e387978bc4af2c41e5c3f655548d4d",
+				"KeyExpiry":  "2026-11-09T09:27:58Z",
+				"DiscoKey":   "discokey:1c9c6f15805c22bd74092f63f6285a3372189de31b4e80e5179251f7c7d0ae76",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59836",
+					"10.65.0.27:59836",
+					"172.17.0.1:59836",
+					"172.18.0.1:59836",
+					"172.19.0.1:59836",
+					"172.20.0.1:59836",
+					"172.21.0.1:59836",
+					"172.22.0.1:59836",
+					"172.23.0.1:59836",
+					"172.24.0.1:59836",
+					"172.25.0.1:59836",
+					"172.26.0.1:59836",
+					"172.27.0.1:59836",
+					"172.28.0.1:59836"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:27:58.881120954Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2152360805118066": {
+				"ID":          2152360805118066,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/ssh_results/ssh-users-null.hujson
+++ b/hscontrol/policy/v2/testdata/ssh_results/ssh-users-null.hujson
@@ -1,0 +1,22106 @@
+// ssh-users-null
+//
+// ssh users = JSON null
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-13T09:28:44Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "ssh-users-null",
+	"description":    "ssh users = JSON null",
+	"category":       "ssh",
+	"captured_at":    "2026-05-13T09:28:44.147044743Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "users must be specified"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                 \n  \n                                                                       \n{\n\t\"category\":    \"ssh\",\n\t\"description\": \"ssh users = JSON null\",\n\t\"id\":          \"ssh-users-null\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"thor@example.org\"],\n\t\t\"users\":  null\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-edges/ssh-users-null.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["thor@example.org"],
+				"users":  null
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7226997624776993,
+				"StableID":   "nG2qQRy7Sy11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       7226997624776993,
+				"Key":        "nodekey:50a36e28a806c2fd2dd02c48f3bc1cae71ed401b7ba78dfafe77eb5754bc2046",
+				"DiscoKey":   "discokey:6accaa0042f08166c86b4f758fb3dd8596e84d791ddbd3d081517267f9243d74",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41999",
+					"10.65.0.27:41999",
+					"172.17.0.1:41999",
+					"172.18.0.1:41999",
+					"172.19.0.1:41999",
+					"172.20.0.1:41999",
+					"172.21.0.1:41999",
+					"172.22.0.1:41999",
+					"172.23.0.1:41999",
+					"172.24.0.1:41999",
+					"172.25.0.1:41999",
+					"172.26.0.1:41999",
+					"172.27.0.1:41999",
+					"172.28.0.1:41999"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:28:52.888604203Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:50a36e28a806c2fd2dd02c48f3bc1cae71ed401b7ba78dfafe77eb5754bc2046",
+			"MachineKey": "mkey:d120afc2f2a88f921e8d215a27ed8efc157f7c138300a22fece4ad04bf12671e",
+			"Peers": [{
+				"ID":         5957838597252230,
+				"StableID":   "nTRQBQKKXo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:568fc47fb0b6966e883cb8e1cb7081f92bd09663eb43b1cdc5cda20a22e7922f",
+				"DiscoKey":   "discokey:80f8ed39da13b7bcbaeb85bcc66add4a5a7ca06df7cee5efc95ee395b4df4704",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46427",
+					"10.65.0.27:46427",
+					"172.17.0.1:46427",
+					"172.18.0.1:46427",
+					"172.19.0.1:46427",
+					"172.20.0.1:46427",
+					"172.21.0.1:46427",
+					"172.22.0.1:46427",
+					"172.23.0.1:46427",
+					"172.24.0.1:46427",
+					"172.25.0.1:46427",
+					"172.26.0.1:46427",
+					"172.27.0.1:46427",
+					"172.28.0.1:46427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:28:46.697626311Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7491435254768900,
+				"StableID":   "nMwSFTJtV121CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f57470fdb5acc6ffcb1afd1bcb9852dff1bcb2e4c1c8bdb33e1974c11186632a",
+				"DiscoKey":   "discokey:d30496c97aa5d06bc840ed4cb8c86dd86d73762309fb655839cba15275465719",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:57165",
+					"10.65.0.27:57165",
+					"172.17.0.1:57165",
+					"172.18.0.1:57165",
+					"172.19.0.1:57165",
+					"172.20.0.1:57165",
+					"172.21.0.1:57165",
+					"172.22.0.1:57165",
+					"172.23.0.1:57165",
+					"172.24.0.1:57165",
+					"172.25.0.1:57165",
+					"172.26.0.1:57165",
+					"172.27.0.1:57165",
+					"172.28.0.1:57165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:28:47.21316036Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5240277471551194,
+				"StableID":   "nsh5gnCLvh11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6133fe33ffa51e5444886acb1b9ccdfe163a3bc1b7a092b170b0300b2e327e62",
+				"DiscoKey":   "discokey:9dbf998e101d3701c08c6c150915a9c614a8e4d2184679e09f44cdd38877fb37",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:37400",
+					"10.65.0.27:37400",
+					"172.17.0.1:37400",
+					"172.18.0.1:37400",
+					"172.19.0.1:37400",
+					"172.20.0.1:37400",
+					"172.21.0.1:37400",
+					"172.22.0.1:37400",
+					"172.23.0.1:37400",
+					"172.24.0.1:37400",
+					"172.25.0.1:37400",
+					"172.26.0.1:37400",
+					"172.27.0.1:37400",
+					"172.28.0.1:37400"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:28:47.75087018Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4363475266036325,
+				"StableID":   "n6FxEa6E5b11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4ab3b25c361ce76192c7bb7de4eaa52edb2b609db7ab3e9c5cd27b5b48ea641",
+				"DiscoKey":   "discokey:8c690d866f20c3667bb18a3c9b5e7ec12bddc21a0a8c4cac482632d646491e11",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43562",
+					"10.65.0.27:43562",
+					"172.17.0.1:43562",
+					"172.18.0.1:43562",
+					"172.19.0.1:43562",
+					"172.20.0.1:43562",
+					"172.21.0.1:43562",
+					"172.22.0.1:43562",
+					"172.23.0.1:43562",
+					"172.24.0.1:43562",
+					"172.25.0.1:43562",
+					"172.26.0.1:43562",
+					"172.27.0.1:43562",
+					"172.28.0.1:43562"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:28:48.280253327Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         909310783077211,
+				"StableID":   "ntuV734q6811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8edca3deebe2ceaea15075262b354da60313aa6201f2f1493a0e8684b0fe207c",
+				"DiscoKey":   "discokey:46fd17122baeabb311910115ef13847ad90880c90487487905ee812f07d37447",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52004",
+					"10.65.0.27:52004",
+					"172.17.0.1:52004",
+					"172.18.0.1:52004",
+					"172.19.0.1:52004",
+					"172.20.0.1:52004",
+					"172.21.0.1:52004",
+					"172.22.0.1:52004",
+					"172.23.0.1:52004",
+					"172.24.0.1:52004",
+					"172.25.0.1:52004",
+					"172.26.0.1:52004",
+					"172.27.0.1:52004",
+					"172.28.0.1:52004"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:28:48.908611477Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7745891296835908,
+				"StableID":   "nh5tLvR8V321CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41f059a70061d6f70e7197367d3731145e6ab586cb69825226a952ce53669f3d",
+				"DiscoKey":   "discokey:2dcf4e0fb98d432ccc7a62c1dbc721ab09f388cb22f559fbd24e1a71c6cdfb0c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52807",
+					"10.65.0.27:52807",
+					"172.17.0.1:52807",
+					"172.18.0.1:52807",
+					"172.19.0.1:52807",
+					"172.20.0.1:52807",
+					"172.21.0.1:52807",
+					"172.22.0.1:52807",
+					"172.23.0.1:52807",
+					"172.24.0.1:52807",
+					"172.25.0.1:52807",
+					"172.26.0.1:52807",
+					"172.27.0.1:52807",
+					"172.28.0.1:52807"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:28:49.610332949Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2710951987489957,
+				"StableID":   "nYr6vU7oAN11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f5c60b60b29ffdd49afe634a54b157d9e559467c4756f3e3bb748f1f8e67ee29",
+				"DiscoKey":   "discokey:071b44d9f2887164b4bb56d67ac0ca7118bc4f88b350fa2751d3995a78574b40",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50109",
+					"10.65.0.27:50109",
+					"172.17.0.1:50109",
+					"172.18.0.1:50109",
+					"172.19.0.1:50109",
+					"172.20.0.1:50109",
+					"172.21.0.1:50109",
+					"172.22.0.1:50109",
+					"172.23.0.1:50109",
+					"172.24.0.1:50109",
+					"172.25.0.1:50109",
+					"172.26.0.1:50109",
+					"172.27.0.1:50109",
+					"172.28.0.1:50109"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:28:50.142420965Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4259375241172312,
+				"StableID":   "nKazWmZ5Ga11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51e0e9a2becd35f2a5b892a48c67966775919aa302d974845a96427888200b6d",
+				"DiscoKey":   "discokey:d5cbaebd55f16bc0bbe00f5c938d9b390d3bf766cc342f53b6dbaebaa543dd15",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45948",
+					"10.65.0.27:45948",
+					"172.17.0.1:45948",
+					"172.18.0.1:45948",
+					"172.19.0.1:45948",
+					"172.20.0.1:45948",
+					"172.21.0.1:45948",
+					"172.22.0.1:45948",
+					"172.23.0.1:45948",
+					"172.24.0.1:45948",
+					"172.25.0.1:45948",
+					"172.26.0.1:45948",
+					"172.27.0.1:45948",
+					"172.28.0.1:45948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:28:50.670295722Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3941036375649528,
+				"StableID":   "n9B85tLumX11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:517ab7e4d00428dcd9d4a9cc5439f9d83c76abaf94bb540b37f797fda655397b",
+				"DiscoKey":   "discokey:9458a746831846e5bace91cdf1333b8adb80e8cf3ecd4d24431b7cc36284c62c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:57560",
+					"10.65.0.27:57560",
+					"172.17.0.1:57560",
+					"172.18.0.1:57560",
+					"172.19.0.1:57560",
+					"172.20.0.1:57560",
+					"172.21.0.1:57560",
+					"172.22.0.1:57560",
+					"172.23.0.1:57560",
+					"172.24.0.1:57560",
+					"172.25.0.1:57560",
+					"172.26.0.1:57560",
+					"172.27.0.1:57560",
+					"172.28.0.1:57560"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:28:51.206482784Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8935913823923919,
+				"StableID":   "nC7D2cJ6nC21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c182045ac1a949ea6f5b9935e4797df1b236ad608c930c5756582b22d25a274e",
+				"DiscoKey":   "discokey:e50b97a3e204250db28ba9718c6ea1359b5ee9d40ebab0409c8161ccb2d63754",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53787",
+					"10.65.0.27:53787",
+					"172.17.0.1:53787",
+					"172.18.0.1:53787",
+					"172.19.0.1:53787",
+					"172.20.0.1:53787",
+					"172.21.0.1:53787",
+					"172.22.0.1:53787",
+					"172.23.0.1:53787",
+					"172.24.0.1:53787",
+					"172.25.0.1:53787",
+					"172.26.0.1:53787",
+					"172.27.0.1:53787",
+					"172.28.0.1:53787"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:28:51.81673023Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4091099345258174,
+				"StableID":   "nZU5q4FswY11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c7390a9fcadbb2338b0bba0fb361116b27d7e1130a39482e15c45b36a88eb0e",
+				"DiscoKey":   "discokey:dbb9c86e8c66e6d3a23242cc8a8a0ffc8c62fce8b92641d51e1fed860fe33046",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55414",
+					"10.65.0.27:55414",
+					"172.17.0.1:55414",
+					"172.18.0.1:55414",
+					"172.19.0.1:55414",
+					"172.20.0.1:55414",
+					"172.21.0.1:55414",
+					"172.22.0.1:55414",
+					"172.23.0.1:55414",
+					"172.24.0.1:55414",
+					"172.25.0.1:55414",
+					"172.26.0.1:55414",
+					"172.27.0.1:55414",
+					"172.28.0.1:55414"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:28:52.352784952Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3753295234958883,
+				"StableID":   "nvxjMghsJW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a51ba4c771f8e5dccbe174bb608c8b39a571f610f4f5f37723a5ffa87fcf3364",
+				"KeyExpiry":  "2026-11-09T09:28:53Z",
+				"DiscoKey":   "discokey:6fa64763400c756c62d2abd5afb60ff5d637ee94214416082f546399f8f4ca2c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:37685",
+					"10.65.0.27:37685",
+					"172.17.0.1:37685",
+					"172.18.0.1:37685",
+					"172.19.0.1:37685",
+					"172.20.0.1:37685",
+					"172.21.0.1:37685",
+					"172.22.0.1:37685",
+					"172.23.0.1:37685",
+					"172.24.0.1:37685",
+					"172.25.0.1:37685",
+					"172.26.0.1:37685",
+					"172.27.0.1:37685",
+					"172.28.0.1:37685"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:28:53.423566519Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7899574873613674,
+				"StableID":   "nfhxkKSjg421CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:badae06a11903c36804634dd8e953652d6f0a06466abca3ddc1b582502db841d",
+				"KeyExpiry":  "2026-11-09T09:28:53Z",
+				"DiscoKey":   "discokey:05c3975fd2b82ae84653c9ea53e1969ce520b61a56d15335f69c8e594ff8d551",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:43857",
+					"10.65.0.27:43857",
+					"172.17.0.1:43857",
+					"172.18.0.1:43857",
+					"172.19.0.1:43857",
+					"172.20.0.1:43857",
+					"172.21.0.1:43857",
+					"172.22.0.1:43857",
+					"172.23.0.1:43857",
+					"172.24.0.1:43857",
+					"172.25.0.1:43857",
+					"172.26.0.1:43857",
+					"172.27.0.1:43857",
+					"172.28.0.1:43857"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:28:53.958495612Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5592242659501955,
+				"StableID":   "nkTv5Tjjfk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a81dc878ad9dae73b27a4940f9e3fb7b38d13cbaa36157c8e261292fa79dac51",
+				"KeyExpiry":  "2026-11-09T09:28:54Z",
+				"DiscoKey":   "discokey:5d5e468fd860cd130fc7e408223346f08ea9681b78eef3f4766d828179144d5f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59674",
+					"10.65.0.27:59674",
+					"172.17.0.1:59674",
+					"172.18.0.1:59674",
+					"172.19.0.1:59674",
+					"172.20.0.1:59674",
+					"172.21.0.1:59674",
+					"172.22.0.1:59674",
+					"172.23.0.1:59674",
+					"172.24.0.1:59674",
+					"172.25.0.1:59674",
+					"172.26.0.1:59674",
+					"172.27.0.1:59674",
+					"172.28.0.1:59674"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:28:54.496611041Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7226997624776993": {
+				"ID":          7226997624776993,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7745891296835908,
+				"StableID":   "nh5tLvR8V321CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       7745891296835908,
+				"Key":        "nodekey:41f059a70061d6f70e7197367d3731145e6ab586cb69825226a952ce53669f3d",
+				"DiscoKey":   "discokey:2dcf4e0fb98d432ccc7a62c1dbc721ab09f388cb22f559fbd24e1a71c6cdfb0c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52807",
+					"10.65.0.27:52807",
+					"172.17.0.1:52807",
+					"172.18.0.1:52807",
+					"172.19.0.1:52807",
+					"172.20.0.1:52807",
+					"172.21.0.1:52807",
+					"172.22.0.1:52807",
+					"172.23.0.1:52807",
+					"172.24.0.1:52807",
+					"172.25.0.1:52807",
+					"172.26.0.1:52807",
+					"172.27.0.1:52807",
+					"172.28.0.1:52807"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:28:49.610332949Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:41f059a70061d6f70e7197367d3731145e6ab586cb69825226a952ce53669f3d",
+			"MachineKey": "mkey:570a45bfd84db37ad38b3c255ef5d5a086acdb211142ff2da85a82276eb14b3b",
+			"Peers": [{
+				"ID":         5957838597252230,
+				"StableID":   "nTRQBQKKXo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:568fc47fb0b6966e883cb8e1cb7081f92bd09663eb43b1cdc5cda20a22e7922f",
+				"DiscoKey":   "discokey:80f8ed39da13b7bcbaeb85bcc66add4a5a7ca06df7cee5efc95ee395b4df4704",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46427",
+					"10.65.0.27:46427",
+					"172.17.0.1:46427",
+					"172.18.0.1:46427",
+					"172.19.0.1:46427",
+					"172.20.0.1:46427",
+					"172.21.0.1:46427",
+					"172.22.0.1:46427",
+					"172.23.0.1:46427",
+					"172.24.0.1:46427",
+					"172.25.0.1:46427",
+					"172.26.0.1:46427",
+					"172.27.0.1:46427",
+					"172.28.0.1:46427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:28:46.697626311Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7491435254768900,
+				"StableID":   "nMwSFTJtV121CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f57470fdb5acc6ffcb1afd1bcb9852dff1bcb2e4c1c8bdb33e1974c11186632a",
+				"DiscoKey":   "discokey:d30496c97aa5d06bc840ed4cb8c86dd86d73762309fb655839cba15275465719",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:57165",
+					"10.65.0.27:57165",
+					"172.17.0.1:57165",
+					"172.18.0.1:57165",
+					"172.19.0.1:57165",
+					"172.20.0.1:57165",
+					"172.21.0.1:57165",
+					"172.22.0.1:57165",
+					"172.23.0.1:57165",
+					"172.24.0.1:57165",
+					"172.25.0.1:57165",
+					"172.26.0.1:57165",
+					"172.27.0.1:57165",
+					"172.28.0.1:57165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:28:47.21316036Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5240277471551194,
+				"StableID":   "nsh5gnCLvh11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6133fe33ffa51e5444886acb1b9ccdfe163a3bc1b7a092b170b0300b2e327e62",
+				"DiscoKey":   "discokey:9dbf998e101d3701c08c6c150915a9c614a8e4d2184679e09f44cdd38877fb37",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:37400",
+					"10.65.0.27:37400",
+					"172.17.0.1:37400",
+					"172.18.0.1:37400",
+					"172.19.0.1:37400",
+					"172.20.0.1:37400",
+					"172.21.0.1:37400",
+					"172.22.0.1:37400",
+					"172.23.0.1:37400",
+					"172.24.0.1:37400",
+					"172.25.0.1:37400",
+					"172.26.0.1:37400",
+					"172.27.0.1:37400",
+					"172.28.0.1:37400"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:28:47.75087018Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4363475266036325,
+				"StableID":   "n6FxEa6E5b11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4ab3b25c361ce76192c7bb7de4eaa52edb2b609db7ab3e9c5cd27b5b48ea641",
+				"DiscoKey":   "discokey:8c690d866f20c3667bb18a3c9b5e7ec12bddc21a0a8c4cac482632d646491e11",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43562",
+					"10.65.0.27:43562",
+					"172.17.0.1:43562",
+					"172.18.0.1:43562",
+					"172.19.0.1:43562",
+					"172.20.0.1:43562",
+					"172.21.0.1:43562",
+					"172.22.0.1:43562",
+					"172.23.0.1:43562",
+					"172.24.0.1:43562",
+					"172.25.0.1:43562",
+					"172.26.0.1:43562",
+					"172.27.0.1:43562",
+					"172.28.0.1:43562"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:28:48.280253327Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         909310783077211,
+				"StableID":   "ntuV734q6811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8edca3deebe2ceaea15075262b354da60313aa6201f2f1493a0e8684b0fe207c",
+				"DiscoKey":   "discokey:46fd17122baeabb311910115ef13847ad90880c90487487905ee812f07d37447",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52004",
+					"10.65.0.27:52004",
+					"172.17.0.1:52004",
+					"172.18.0.1:52004",
+					"172.19.0.1:52004",
+					"172.20.0.1:52004",
+					"172.21.0.1:52004",
+					"172.22.0.1:52004",
+					"172.23.0.1:52004",
+					"172.24.0.1:52004",
+					"172.25.0.1:52004",
+					"172.26.0.1:52004",
+					"172.27.0.1:52004",
+					"172.28.0.1:52004"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:28:48.908611477Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2710951987489957,
+				"StableID":   "nYr6vU7oAN11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f5c60b60b29ffdd49afe634a54b157d9e559467c4756f3e3bb748f1f8e67ee29",
+				"DiscoKey":   "discokey:071b44d9f2887164b4bb56d67ac0ca7118bc4f88b350fa2751d3995a78574b40",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50109",
+					"10.65.0.27:50109",
+					"172.17.0.1:50109",
+					"172.18.0.1:50109",
+					"172.19.0.1:50109",
+					"172.20.0.1:50109",
+					"172.21.0.1:50109",
+					"172.22.0.1:50109",
+					"172.23.0.1:50109",
+					"172.24.0.1:50109",
+					"172.25.0.1:50109",
+					"172.26.0.1:50109",
+					"172.27.0.1:50109",
+					"172.28.0.1:50109"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:28:50.142420965Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4259375241172312,
+				"StableID":   "nKazWmZ5Ga11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51e0e9a2becd35f2a5b892a48c67966775919aa302d974845a96427888200b6d",
+				"DiscoKey":   "discokey:d5cbaebd55f16bc0bbe00f5c938d9b390d3bf766cc342f53b6dbaebaa543dd15",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45948",
+					"10.65.0.27:45948",
+					"172.17.0.1:45948",
+					"172.18.0.1:45948",
+					"172.19.0.1:45948",
+					"172.20.0.1:45948",
+					"172.21.0.1:45948",
+					"172.22.0.1:45948",
+					"172.23.0.1:45948",
+					"172.24.0.1:45948",
+					"172.25.0.1:45948",
+					"172.26.0.1:45948",
+					"172.27.0.1:45948",
+					"172.28.0.1:45948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:28:50.670295722Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3941036375649528,
+				"StableID":   "n9B85tLumX11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:517ab7e4d00428dcd9d4a9cc5439f9d83c76abaf94bb540b37f797fda655397b",
+				"DiscoKey":   "discokey:9458a746831846e5bace91cdf1333b8adb80e8cf3ecd4d24431b7cc36284c62c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:57560",
+					"10.65.0.27:57560",
+					"172.17.0.1:57560",
+					"172.18.0.1:57560",
+					"172.19.0.1:57560",
+					"172.20.0.1:57560",
+					"172.21.0.1:57560",
+					"172.22.0.1:57560",
+					"172.23.0.1:57560",
+					"172.24.0.1:57560",
+					"172.25.0.1:57560",
+					"172.26.0.1:57560",
+					"172.27.0.1:57560",
+					"172.28.0.1:57560"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:28:51.206482784Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8935913823923919,
+				"StableID":   "nC7D2cJ6nC21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c182045ac1a949ea6f5b9935e4797df1b236ad608c930c5756582b22d25a274e",
+				"DiscoKey":   "discokey:e50b97a3e204250db28ba9718c6ea1359b5ee9d40ebab0409c8161ccb2d63754",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53787",
+					"10.65.0.27:53787",
+					"172.17.0.1:53787",
+					"172.18.0.1:53787",
+					"172.19.0.1:53787",
+					"172.20.0.1:53787",
+					"172.21.0.1:53787",
+					"172.22.0.1:53787",
+					"172.23.0.1:53787",
+					"172.24.0.1:53787",
+					"172.25.0.1:53787",
+					"172.26.0.1:53787",
+					"172.27.0.1:53787",
+					"172.28.0.1:53787"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:28:51.81673023Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4091099345258174,
+				"StableID":   "nZU5q4FswY11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c7390a9fcadbb2338b0bba0fb361116b27d7e1130a39482e15c45b36a88eb0e",
+				"DiscoKey":   "discokey:dbb9c86e8c66e6d3a23242cc8a8a0ffc8c62fce8b92641d51e1fed860fe33046",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55414",
+					"10.65.0.27:55414",
+					"172.17.0.1:55414",
+					"172.18.0.1:55414",
+					"172.19.0.1:55414",
+					"172.20.0.1:55414",
+					"172.21.0.1:55414",
+					"172.22.0.1:55414",
+					"172.23.0.1:55414",
+					"172.24.0.1:55414",
+					"172.25.0.1:55414",
+					"172.26.0.1:55414",
+					"172.27.0.1:55414",
+					"172.28.0.1:55414"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:28:52.352784952Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7226997624776993,
+				"StableID":   "nG2qQRy7Sy11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:50a36e28a806c2fd2dd02c48f3bc1cae71ed401b7ba78dfafe77eb5754bc2046",
+				"DiscoKey":   "discokey:6accaa0042f08166c86b4f758fb3dd8596e84d791ddbd3d081517267f9243d74",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41999",
+					"10.65.0.27:41999",
+					"172.17.0.1:41999",
+					"172.18.0.1:41999",
+					"172.19.0.1:41999",
+					"172.20.0.1:41999",
+					"172.21.0.1:41999",
+					"172.22.0.1:41999",
+					"172.23.0.1:41999",
+					"172.24.0.1:41999",
+					"172.25.0.1:41999",
+					"172.26.0.1:41999",
+					"172.27.0.1:41999",
+					"172.28.0.1:41999"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:28:52.888604203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3753295234958883,
+				"StableID":   "nvxjMghsJW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a51ba4c771f8e5dccbe174bb608c8b39a571f610f4f5f37723a5ffa87fcf3364",
+				"KeyExpiry":  "2026-11-09T09:28:53Z",
+				"DiscoKey":   "discokey:6fa64763400c756c62d2abd5afb60ff5d637ee94214416082f546399f8f4ca2c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:37685",
+					"10.65.0.27:37685",
+					"172.17.0.1:37685",
+					"172.18.0.1:37685",
+					"172.19.0.1:37685",
+					"172.20.0.1:37685",
+					"172.21.0.1:37685",
+					"172.22.0.1:37685",
+					"172.23.0.1:37685",
+					"172.24.0.1:37685",
+					"172.25.0.1:37685",
+					"172.26.0.1:37685",
+					"172.27.0.1:37685",
+					"172.28.0.1:37685"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:28:53.423566519Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7899574873613674,
+				"StableID":   "nfhxkKSjg421CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:badae06a11903c36804634dd8e953652d6f0a06466abca3ddc1b582502db841d",
+				"KeyExpiry":  "2026-11-09T09:28:53Z",
+				"DiscoKey":   "discokey:05c3975fd2b82ae84653c9ea53e1969ce520b61a56d15335f69c8e594ff8d551",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:43857",
+					"10.65.0.27:43857",
+					"172.17.0.1:43857",
+					"172.18.0.1:43857",
+					"172.19.0.1:43857",
+					"172.20.0.1:43857",
+					"172.21.0.1:43857",
+					"172.22.0.1:43857",
+					"172.23.0.1:43857",
+					"172.24.0.1:43857",
+					"172.25.0.1:43857",
+					"172.26.0.1:43857",
+					"172.27.0.1:43857",
+					"172.28.0.1:43857"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:28:53.958495612Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5592242659501955,
+				"StableID":   "nkTv5Tjjfk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a81dc878ad9dae73b27a4940f9e3fb7b38d13cbaa36157c8e261292fa79dac51",
+				"KeyExpiry":  "2026-11-09T09:28:54Z",
+				"DiscoKey":   "discokey:5d5e468fd860cd130fc7e408223346f08ea9681b78eef3f4766d828179144d5f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59674",
+					"10.65.0.27:59674",
+					"172.17.0.1:59674",
+					"172.18.0.1:59674",
+					"172.19.0.1:59674",
+					"172.20.0.1:59674",
+					"172.21.0.1:59674",
+					"172.22.0.1:59674",
+					"172.23.0.1:59674",
+					"172.24.0.1:59674",
+					"172.25.0.1:59674",
+					"172.26.0.1:59674",
+					"172.27.0.1:59674",
+					"172.28.0.1:59674"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:28:54.496611041Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7745891296835908": {
+				"ID":          7745891296835908,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5592242659501955,
+				"StableID":   "nkTv5Tjjfk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a81dc878ad9dae73b27a4940f9e3fb7b38d13cbaa36157c8e261292fa79dac51",
+				"KeyExpiry":  "2026-11-09T09:28:54Z",
+				"DiscoKey":   "discokey:5d5e468fd860cd130fc7e408223346f08ea9681b78eef3f4766d828179144d5f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59674",
+					"10.65.0.27:59674",
+					"172.17.0.1:59674",
+					"172.18.0.1:59674",
+					"172.19.0.1:59674",
+					"172.20.0.1:59674",
+					"172.21.0.1:59674",
+					"172.22.0.1:59674",
+					"172.23.0.1:59674",
+					"172.24.0.1:59674",
+					"172.25.0.1:59674",
+					"172.26.0.1:59674",
+					"172.27.0.1:59674",
+					"172.28.0.1:59674"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:28:54.496611041Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a81dc878ad9dae73b27a4940f9e3fb7b38d13cbaa36157c8e261292fa79dac51",
+			"MachineKey": "mkey:1a4b1d6cc1fbbdba90886b24ee5d993c46048aac5c52aa377c0392d83116e007",
+			"Peers": [{
+				"ID":         5957838597252230,
+				"StableID":   "nTRQBQKKXo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:568fc47fb0b6966e883cb8e1cb7081f92bd09663eb43b1cdc5cda20a22e7922f",
+				"DiscoKey":   "discokey:80f8ed39da13b7bcbaeb85bcc66add4a5a7ca06df7cee5efc95ee395b4df4704",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46427",
+					"10.65.0.27:46427",
+					"172.17.0.1:46427",
+					"172.18.0.1:46427",
+					"172.19.0.1:46427",
+					"172.20.0.1:46427",
+					"172.21.0.1:46427",
+					"172.22.0.1:46427",
+					"172.23.0.1:46427",
+					"172.24.0.1:46427",
+					"172.25.0.1:46427",
+					"172.26.0.1:46427",
+					"172.27.0.1:46427",
+					"172.28.0.1:46427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:28:46.697626311Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7491435254768900,
+				"StableID":   "nMwSFTJtV121CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f57470fdb5acc6ffcb1afd1bcb9852dff1bcb2e4c1c8bdb33e1974c11186632a",
+				"DiscoKey":   "discokey:d30496c97aa5d06bc840ed4cb8c86dd86d73762309fb655839cba15275465719",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:57165",
+					"10.65.0.27:57165",
+					"172.17.0.1:57165",
+					"172.18.0.1:57165",
+					"172.19.0.1:57165",
+					"172.20.0.1:57165",
+					"172.21.0.1:57165",
+					"172.22.0.1:57165",
+					"172.23.0.1:57165",
+					"172.24.0.1:57165",
+					"172.25.0.1:57165",
+					"172.26.0.1:57165",
+					"172.27.0.1:57165",
+					"172.28.0.1:57165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:28:47.21316036Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5240277471551194,
+				"StableID":   "nsh5gnCLvh11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6133fe33ffa51e5444886acb1b9ccdfe163a3bc1b7a092b170b0300b2e327e62",
+				"DiscoKey":   "discokey:9dbf998e101d3701c08c6c150915a9c614a8e4d2184679e09f44cdd38877fb37",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:37400",
+					"10.65.0.27:37400",
+					"172.17.0.1:37400",
+					"172.18.0.1:37400",
+					"172.19.0.1:37400",
+					"172.20.0.1:37400",
+					"172.21.0.1:37400",
+					"172.22.0.1:37400",
+					"172.23.0.1:37400",
+					"172.24.0.1:37400",
+					"172.25.0.1:37400",
+					"172.26.0.1:37400",
+					"172.27.0.1:37400",
+					"172.28.0.1:37400"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:28:47.75087018Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4363475266036325,
+				"StableID":   "n6FxEa6E5b11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4ab3b25c361ce76192c7bb7de4eaa52edb2b609db7ab3e9c5cd27b5b48ea641",
+				"DiscoKey":   "discokey:8c690d866f20c3667bb18a3c9b5e7ec12bddc21a0a8c4cac482632d646491e11",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43562",
+					"10.65.0.27:43562",
+					"172.17.0.1:43562",
+					"172.18.0.1:43562",
+					"172.19.0.1:43562",
+					"172.20.0.1:43562",
+					"172.21.0.1:43562",
+					"172.22.0.1:43562",
+					"172.23.0.1:43562",
+					"172.24.0.1:43562",
+					"172.25.0.1:43562",
+					"172.26.0.1:43562",
+					"172.27.0.1:43562",
+					"172.28.0.1:43562"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:28:48.280253327Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         909310783077211,
+				"StableID":   "ntuV734q6811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8edca3deebe2ceaea15075262b354da60313aa6201f2f1493a0e8684b0fe207c",
+				"DiscoKey":   "discokey:46fd17122baeabb311910115ef13847ad90880c90487487905ee812f07d37447",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52004",
+					"10.65.0.27:52004",
+					"172.17.0.1:52004",
+					"172.18.0.1:52004",
+					"172.19.0.1:52004",
+					"172.20.0.1:52004",
+					"172.21.0.1:52004",
+					"172.22.0.1:52004",
+					"172.23.0.1:52004",
+					"172.24.0.1:52004",
+					"172.25.0.1:52004",
+					"172.26.0.1:52004",
+					"172.27.0.1:52004",
+					"172.28.0.1:52004"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:28:48.908611477Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7745891296835908,
+				"StableID":   "nh5tLvR8V321CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41f059a70061d6f70e7197367d3731145e6ab586cb69825226a952ce53669f3d",
+				"DiscoKey":   "discokey:2dcf4e0fb98d432ccc7a62c1dbc721ab09f388cb22f559fbd24e1a71c6cdfb0c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52807",
+					"10.65.0.27:52807",
+					"172.17.0.1:52807",
+					"172.18.0.1:52807",
+					"172.19.0.1:52807",
+					"172.20.0.1:52807",
+					"172.21.0.1:52807",
+					"172.22.0.1:52807",
+					"172.23.0.1:52807",
+					"172.24.0.1:52807",
+					"172.25.0.1:52807",
+					"172.26.0.1:52807",
+					"172.27.0.1:52807",
+					"172.28.0.1:52807"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:28:49.610332949Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2710951987489957,
+				"StableID":   "nYr6vU7oAN11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f5c60b60b29ffdd49afe634a54b157d9e559467c4756f3e3bb748f1f8e67ee29",
+				"DiscoKey":   "discokey:071b44d9f2887164b4bb56d67ac0ca7118bc4f88b350fa2751d3995a78574b40",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50109",
+					"10.65.0.27:50109",
+					"172.17.0.1:50109",
+					"172.18.0.1:50109",
+					"172.19.0.1:50109",
+					"172.20.0.1:50109",
+					"172.21.0.1:50109",
+					"172.22.0.1:50109",
+					"172.23.0.1:50109",
+					"172.24.0.1:50109",
+					"172.25.0.1:50109",
+					"172.26.0.1:50109",
+					"172.27.0.1:50109",
+					"172.28.0.1:50109"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:28:50.142420965Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4259375241172312,
+				"StableID":   "nKazWmZ5Ga11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51e0e9a2becd35f2a5b892a48c67966775919aa302d974845a96427888200b6d",
+				"DiscoKey":   "discokey:d5cbaebd55f16bc0bbe00f5c938d9b390d3bf766cc342f53b6dbaebaa543dd15",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45948",
+					"10.65.0.27:45948",
+					"172.17.0.1:45948",
+					"172.18.0.1:45948",
+					"172.19.0.1:45948",
+					"172.20.0.1:45948",
+					"172.21.0.1:45948",
+					"172.22.0.1:45948",
+					"172.23.0.1:45948",
+					"172.24.0.1:45948",
+					"172.25.0.1:45948",
+					"172.26.0.1:45948",
+					"172.27.0.1:45948",
+					"172.28.0.1:45948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:28:50.670295722Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3941036375649528,
+				"StableID":   "n9B85tLumX11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:517ab7e4d00428dcd9d4a9cc5439f9d83c76abaf94bb540b37f797fda655397b",
+				"DiscoKey":   "discokey:9458a746831846e5bace91cdf1333b8adb80e8cf3ecd4d24431b7cc36284c62c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:57560",
+					"10.65.0.27:57560",
+					"172.17.0.1:57560",
+					"172.18.0.1:57560",
+					"172.19.0.1:57560",
+					"172.20.0.1:57560",
+					"172.21.0.1:57560",
+					"172.22.0.1:57560",
+					"172.23.0.1:57560",
+					"172.24.0.1:57560",
+					"172.25.0.1:57560",
+					"172.26.0.1:57560",
+					"172.27.0.1:57560",
+					"172.28.0.1:57560"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:28:51.206482784Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8935913823923919,
+				"StableID":   "nC7D2cJ6nC21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c182045ac1a949ea6f5b9935e4797df1b236ad608c930c5756582b22d25a274e",
+				"DiscoKey":   "discokey:e50b97a3e204250db28ba9718c6ea1359b5ee9d40ebab0409c8161ccb2d63754",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53787",
+					"10.65.0.27:53787",
+					"172.17.0.1:53787",
+					"172.18.0.1:53787",
+					"172.19.0.1:53787",
+					"172.20.0.1:53787",
+					"172.21.0.1:53787",
+					"172.22.0.1:53787",
+					"172.23.0.1:53787",
+					"172.24.0.1:53787",
+					"172.25.0.1:53787",
+					"172.26.0.1:53787",
+					"172.27.0.1:53787",
+					"172.28.0.1:53787"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:28:51.81673023Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4091099345258174,
+				"StableID":   "nZU5q4FswY11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c7390a9fcadbb2338b0bba0fb361116b27d7e1130a39482e15c45b36a88eb0e",
+				"DiscoKey":   "discokey:dbb9c86e8c66e6d3a23242cc8a8a0ffc8c62fce8b92641d51e1fed860fe33046",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55414",
+					"10.65.0.27:55414",
+					"172.17.0.1:55414",
+					"172.18.0.1:55414",
+					"172.19.0.1:55414",
+					"172.20.0.1:55414",
+					"172.21.0.1:55414",
+					"172.22.0.1:55414",
+					"172.23.0.1:55414",
+					"172.24.0.1:55414",
+					"172.25.0.1:55414",
+					"172.26.0.1:55414",
+					"172.27.0.1:55414",
+					"172.28.0.1:55414"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:28:52.352784952Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7226997624776993,
+				"StableID":   "nG2qQRy7Sy11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:50a36e28a806c2fd2dd02c48f3bc1cae71ed401b7ba78dfafe77eb5754bc2046",
+				"DiscoKey":   "discokey:6accaa0042f08166c86b4f758fb3dd8596e84d791ddbd3d081517267f9243d74",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41999",
+					"10.65.0.27:41999",
+					"172.17.0.1:41999",
+					"172.18.0.1:41999",
+					"172.19.0.1:41999",
+					"172.20.0.1:41999",
+					"172.21.0.1:41999",
+					"172.22.0.1:41999",
+					"172.23.0.1:41999",
+					"172.24.0.1:41999",
+					"172.25.0.1:41999",
+					"172.26.0.1:41999",
+					"172.27.0.1:41999",
+					"172.28.0.1:41999"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:28:52.888604203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3753295234958883,
+				"StableID":   "nvxjMghsJW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a51ba4c771f8e5dccbe174bb608c8b39a571f610f4f5f37723a5ffa87fcf3364",
+				"KeyExpiry":  "2026-11-09T09:28:53Z",
+				"DiscoKey":   "discokey:6fa64763400c756c62d2abd5afb60ff5d637ee94214416082f546399f8f4ca2c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:37685",
+					"10.65.0.27:37685",
+					"172.17.0.1:37685",
+					"172.18.0.1:37685",
+					"172.19.0.1:37685",
+					"172.20.0.1:37685",
+					"172.21.0.1:37685",
+					"172.22.0.1:37685",
+					"172.23.0.1:37685",
+					"172.24.0.1:37685",
+					"172.25.0.1:37685",
+					"172.26.0.1:37685",
+					"172.27.0.1:37685",
+					"172.28.0.1:37685"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:28:53.423566519Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7899574873613674,
+				"StableID":   "nfhxkKSjg421CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:badae06a11903c36804634dd8e953652d6f0a06466abca3ddc1b582502db841d",
+				"KeyExpiry":  "2026-11-09T09:28:53Z",
+				"DiscoKey":   "discokey:05c3975fd2b82ae84653c9ea53e1969ce520b61a56d15335f69c8e594ff8d551",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:43857",
+					"10.65.0.27:43857",
+					"172.17.0.1:43857",
+					"172.18.0.1:43857",
+					"172.19.0.1:43857",
+					"172.20.0.1:43857",
+					"172.21.0.1:43857",
+					"172.22.0.1:43857",
+					"172.23.0.1:43857",
+					"172.24.0.1:43857",
+					"172.25.0.1:43857",
+					"172.26.0.1:43857",
+					"172.27.0.1:43857",
+					"172.28.0.1:43857"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:28:53.958495612Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5240277471551194,
+				"StableID":   "nsh5gnCLvh11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       5240277471551194,
+				"Key":        "nodekey:6133fe33ffa51e5444886acb1b9ccdfe163a3bc1b7a092b170b0300b2e327e62",
+				"DiscoKey":   "discokey:9dbf998e101d3701c08c6c150915a9c614a8e4d2184679e09f44cdd38877fb37",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:37400",
+					"10.65.0.27:37400",
+					"172.17.0.1:37400",
+					"172.18.0.1:37400",
+					"172.19.0.1:37400",
+					"172.20.0.1:37400",
+					"172.21.0.1:37400",
+					"172.22.0.1:37400",
+					"172.23.0.1:37400",
+					"172.24.0.1:37400",
+					"172.25.0.1:37400",
+					"172.26.0.1:37400",
+					"172.27.0.1:37400",
+					"172.28.0.1:37400"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:28:47.75087018Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6133fe33ffa51e5444886acb1b9ccdfe163a3bc1b7a092b170b0300b2e327e62",
+			"MachineKey": "mkey:01e37820ca28728f74e2e71c1f5f65a3b060478efbf4ad639661115b09e2c877",
+			"Peers": [{
+				"ID":         5957838597252230,
+				"StableID":   "nTRQBQKKXo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:568fc47fb0b6966e883cb8e1cb7081f92bd09663eb43b1cdc5cda20a22e7922f",
+				"DiscoKey":   "discokey:80f8ed39da13b7bcbaeb85bcc66add4a5a7ca06df7cee5efc95ee395b4df4704",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46427",
+					"10.65.0.27:46427",
+					"172.17.0.1:46427",
+					"172.18.0.1:46427",
+					"172.19.0.1:46427",
+					"172.20.0.1:46427",
+					"172.21.0.1:46427",
+					"172.22.0.1:46427",
+					"172.23.0.1:46427",
+					"172.24.0.1:46427",
+					"172.25.0.1:46427",
+					"172.26.0.1:46427",
+					"172.27.0.1:46427",
+					"172.28.0.1:46427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:28:46.697626311Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7491435254768900,
+				"StableID":   "nMwSFTJtV121CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f57470fdb5acc6ffcb1afd1bcb9852dff1bcb2e4c1c8bdb33e1974c11186632a",
+				"DiscoKey":   "discokey:d30496c97aa5d06bc840ed4cb8c86dd86d73762309fb655839cba15275465719",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:57165",
+					"10.65.0.27:57165",
+					"172.17.0.1:57165",
+					"172.18.0.1:57165",
+					"172.19.0.1:57165",
+					"172.20.0.1:57165",
+					"172.21.0.1:57165",
+					"172.22.0.1:57165",
+					"172.23.0.1:57165",
+					"172.24.0.1:57165",
+					"172.25.0.1:57165",
+					"172.26.0.1:57165",
+					"172.27.0.1:57165",
+					"172.28.0.1:57165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:28:47.21316036Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4363475266036325,
+				"StableID":   "n6FxEa6E5b11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4ab3b25c361ce76192c7bb7de4eaa52edb2b609db7ab3e9c5cd27b5b48ea641",
+				"DiscoKey":   "discokey:8c690d866f20c3667bb18a3c9b5e7ec12bddc21a0a8c4cac482632d646491e11",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43562",
+					"10.65.0.27:43562",
+					"172.17.0.1:43562",
+					"172.18.0.1:43562",
+					"172.19.0.1:43562",
+					"172.20.0.1:43562",
+					"172.21.0.1:43562",
+					"172.22.0.1:43562",
+					"172.23.0.1:43562",
+					"172.24.0.1:43562",
+					"172.25.0.1:43562",
+					"172.26.0.1:43562",
+					"172.27.0.1:43562",
+					"172.28.0.1:43562"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:28:48.280253327Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         909310783077211,
+				"StableID":   "ntuV734q6811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8edca3deebe2ceaea15075262b354da60313aa6201f2f1493a0e8684b0fe207c",
+				"DiscoKey":   "discokey:46fd17122baeabb311910115ef13847ad90880c90487487905ee812f07d37447",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52004",
+					"10.65.0.27:52004",
+					"172.17.0.1:52004",
+					"172.18.0.1:52004",
+					"172.19.0.1:52004",
+					"172.20.0.1:52004",
+					"172.21.0.1:52004",
+					"172.22.0.1:52004",
+					"172.23.0.1:52004",
+					"172.24.0.1:52004",
+					"172.25.0.1:52004",
+					"172.26.0.1:52004",
+					"172.27.0.1:52004",
+					"172.28.0.1:52004"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:28:48.908611477Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7745891296835908,
+				"StableID":   "nh5tLvR8V321CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41f059a70061d6f70e7197367d3731145e6ab586cb69825226a952ce53669f3d",
+				"DiscoKey":   "discokey:2dcf4e0fb98d432ccc7a62c1dbc721ab09f388cb22f559fbd24e1a71c6cdfb0c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52807",
+					"10.65.0.27:52807",
+					"172.17.0.1:52807",
+					"172.18.0.1:52807",
+					"172.19.0.1:52807",
+					"172.20.0.1:52807",
+					"172.21.0.1:52807",
+					"172.22.0.1:52807",
+					"172.23.0.1:52807",
+					"172.24.0.1:52807",
+					"172.25.0.1:52807",
+					"172.26.0.1:52807",
+					"172.27.0.1:52807",
+					"172.28.0.1:52807"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:28:49.610332949Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2710951987489957,
+				"StableID":   "nYr6vU7oAN11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f5c60b60b29ffdd49afe634a54b157d9e559467c4756f3e3bb748f1f8e67ee29",
+				"DiscoKey":   "discokey:071b44d9f2887164b4bb56d67ac0ca7118bc4f88b350fa2751d3995a78574b40",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50109",
+					"10.65.0.27:50109",
+					"172.17.0.1:50109",
+					"172.18.0.1:50109",
+					"172.19.0.1:50109",
+					"172.20.0.1:50109",
+					"172.21.0.1:50109",
+					"172.22.0.1:50109",
+					"172.23.0.1:50109",
+					"172.24.0.1:50109",
+					"172.25.0.1:50109",
+					"172.26.0.1:50109",
+					"172.27.0.1:50109",
+					"172.28.0.1:50109"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:28:50.142420965Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4259375241172312,
+				"StableID":   "nKazWmZ5Ga11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51e0e9a2becd35f2a5b892a48c67966775919aa302d974845a96427888200b6d",
+				"DiscoKey":   "discokey:d5cbaebd55f16bc0bbe00f5c938d9b390d3bf766cc342f53b6dbaebaa543dd15",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45948",
+					"10.65.0.27:45948",
+					"172.17.0.1:45948",
+					"172.18.0.1:45948",
+					"172.19.0.1:45948",
+					"172.20.0.1:45948",
+					"172.21.0.1:45948",
+					"172.22.0.1:45948",
+					"172.23.0.1:45948",
+					"172.24.0.1:45948",
+					"172.25.0.1:45948",
+					"172.26.0.1:45948",
+					"172.27.0.1:45948",
+					"172.28.0.1:45948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:28:50.670295722Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3941036375649528,
+				"StableID":   "n9B85tLumX11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:517ab7e4d00428dcd9d4a9cc5439f9d83c76abaf94bb540b37f797fda655397b",
+				"DiscoKey":   "discokey:9458a746831846e5bace91cdf1333b8adb80e8cf3ecd4d24431b7cc36284c62c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:57560",
+					"10.65.0.27:57560",
+					"172.17.0.1:57560",
+					"172.18.0.1:57560",
+					"172.19.0.1:57560",
+					"172.20.0.1:57560",
+					"172.21.0.1:57560",
+					"172.22.0.1:57560",
+					"172.23.0.1:57560",
+					"172.24.0.1:57560",
+					"172.25.0.1:57560",
+					"172.26.0.1:57560",
+					"172.27.0.1:57560",
+					"172.28.0.1:57560"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:28:51.206482784Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8935913823923919,
+				"StableID":   "nC7D2cJ6nC21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c182045ac1a949ea6f5b9935e4797df1b236ad608c930c5756582b22d25a274e",
+				"DiscoKey":   "discokey:e50b97a3e204250db28ba9718c6ea1359b5ee9d40ebab0409c8161ccb2d63754",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53787",
+					"10.65.0.27:53787",
+					"172.17.0.1:53787",
+					"172.18.0.1:53787",
+					"172.19.0.1:53787",
+					"172.20.0.1:53787",
+					"172.21.0.1:53787",
+					"172.22.0.1:53787",
+					"172.23.0.1:53787",
+					"172.24.0.1:53787",
+					"172.25.0.1:53787",
+					"172.26.0.1:53787",
+					"172.27.0.1:53787",
+					"172.28.0.1:53787"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:28:51.81673023Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4091099345258174,
+				"StableID":   "nZU5q4FswY11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c7390a9fcadbb2338b0bba0fb361116b27d7e1130a39482e15c45b36a88eb0e",
+				"DiscoKey":   "discokey:dbb9c86e8c66e6d3a23242cc8a8a0ffc8c62fce8b92641d51e1fed860fe33046",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55414",
+					"10.65.0.27:55414",
+					"172.17.0.1:55414",
+					"172.18.0.1:55414",
+					"172.19.0.1:55414",
+					"172.20.0.1:55414",
+					"172.21.0.1:55414",
+					"172.22.0.1:55414",
+					"172.23.0.1:55414",
+					"172.24.0.1:55414",
+					"172.25.0.1:55414",
+					"172.26.0.1:55414",
+					"172.27.0.1:55414",
+					"172.28.0.1:55414"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:28:52.352784952Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7226997624776993,
+				"StableID":   "nG2qQRy7Sy11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:50a36e28a806c2fd2dd02c48f3bc1cae71ed401b7ba78dfafe77eb5754bc2046",
+				"DiscoKey":   "discokey:6accaa0042f08166c86b4f758fb3dd8596e84d791ddbd3d081517267f9243d74",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41999",
+					"10.65.0.27:41999",
+					"172.17.0.1:41999",
+					"172.18.0.1:41999",
+					"172.19.0.1:41999",
+					"172.20.0.1:41999",
+					"172.21.0.1:41999",
+					"172.22.0.1:41999",
+					"172.23.0.1:41999",
+					"172.24.0.1:41999",
+					"172.25.0.1:41999",
+					"172.26.0.1:41999",
+					"172.27.0.1:41999",
+					"172.28.0.1:41999"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:28:52.888604203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3753295234958883,
+				"StableID":   "nvxjMghsJW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a51ba4c771f8e5dccbe174bb608c8b39a571f610f4f5f37723a5ffa87fcf3364",
+				"KeyExpiry":  "2026-11-09T09:28:53Z",
+				"DiscoKey":   "discokey:6fa64763400c756c62d2abd5afb60ff5d637ee94214416082f546399f8f4ca2c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:37685",
+					"10.65.0.27:37685",
+					"172.17.0.1:37685",
+					"172.18.0.1:37685",
+					"172.19.0.1:37685",
+					"172.20.0.1:37685",
+					"172.21.0.1:37685",
+					"172.22.0.1:37685",
+					"172.23.0.1:37685",
+					"172.24.0.1:37685",
+					"172.25.0.1:37685",
+					"172.26.0.1:37685",
+					"172.27.0.1:37685",
+					"172.28.0.1:37685"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:28:53.423566519Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7899574873613674,
+				"StableID":   "nfhxkKSjg421CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:badae06a11903c36804634dd8e953652d6f0a06466abca3ddc1b582502db841d",
+				"KeyExpiry":  "2026-11-09T09:28:53Z",
+				"DiscoKey":   "discokey:05c3975fd2b82ae84653c9ea53e1969ce520b61a56d15335f69c8e594ff8d551",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:43857",
+					"10.65.0.27:43857",
+					"172.17.0.1:43857",
+					"172.18.0.1:43857",
+					"172.19.0.1:43857",
+					"172.20.0.1:43857",
+					"172.21.0.1:43857",
+					"172.22.0.1:43857",
+					"172.23.0.1:43857",
+					"172.24.0.1:43857",
+					"172.25.0.1:43857",
+					"172.26.0.1:43857",
+					"172.27.0.1:43857",
+					"172.28.0.1:43857"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:28:53.958495612Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5592242659501955,
+				"StableID":   "nkTv5Tjjfk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a81dc878ad9dae73b27a4940f9e3fb7b38d13cbaa36157c8e261292fa79dac51",
+				"KeyExpiry":  "2026-11-09T09:28:54Z",
+				"DiscoKey":   "discokey:5d5e468fd860cd130fc7e408223346f08ea9681b78eef3f4766d828179144d5f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59674",
+					"10.65.0.27:59674",
+					"172.17.0.1:59674",
+					"172.18.0.1:59674",
+					"172.19.0.1:59674",
+					"172.20.0.1:59674",
+					"172.21.0.1:59674",
+					"172.22.0.1:59674",
+					"172.23.0.1:59674",
+					"172.24.0.1:59674",
+					"172.25.0.1:59674",
+					"172.26.0.1:59674",
+					"172.27.0.1:59674",
+					"172.28.0.1:59674"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:28:54.496611041Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5240277471551194": {
+				"ID":          5240277471551194,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4259375241172312,
+				"StableID":   "nKazWmZ5Ga11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       4259375241172312,
+				"Key":        "nodekey:51e0e9a2becd35f2a5b892a48c67966775919aa302d974845a96427888200b6d",
+				"DiscoKey":   "discokey:d5cbaebd55f16bc0bbe00f5c938d9b390d3bf766cc342f53b6dbaebaa543dd15",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45948",
+					"10.65.0.27:45948",
+					"172.17.0.1:45948",
+					"172.18.0.1:45948",
+					"172.19.0.1:45948",
+					"172.20.0.1:45948",
+					"172.21.0.1:45948",
+					"172.22.0.1:45948",
+					"172.23.0.1:45948",
+					"172.24.0.1:45948",
+					"172.25.0.1:45948",
+					"172.26.0.1:45948",
+					"172.27.0.1:45948",
+					"172.28.0.1:45948"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:28:50.670295722Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:51e0e9a2becd35f2a5b892a48c67966775919aa302d974845a96427888200b6d",
+			"MachineKey": "mkey:7e7b3f4aa28f4286e8fd1d57ea6ff25a6c0deda681a9da3ecac5b20bf1c49d4e",
+			"Peers": [{
+				"ID":         5957838597252230,
+				"StableID":   "nTRQBQKKXo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:568fc47fb0b6966e883cb8e1cb7081f92bd09663eb43b1cdc5cda20a22e7922f",
+				"DiscoKey":   "discokey:80f8ed39da13b7bcbaeb85bcc66add4a5a7ca06df7cee5efc95ee395b4df4704",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46427",
+					"10.65.0.27:46427",
+					"172.17.0.1:46427",
+					"172.18.0.1:46427",
+					"172.19.0.1:46427",
+					"172.20.0.1:46427",
+					"172.21.0.1:46427",
+					"172.22.0.1:46427",
+					"172.23.0.1:46427",
+					"172.24.0.1:46427",
+					"172.25.0.1:46427",
+					"172.26.0.1:46427",
+					"172.27.0.1:46427",
+					"172.28.0.1:46427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:28:46.697626311Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7491435254768900,
+				"StableID":   "nMwSFTJtV121CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f57470fdb5acc6ffcb1afd1bcb9852dff1bcb2e4c1c8bdb33e1974c11186632a",
+				"DiscoKey":   "discokey:d30496c97aa5d06bc840ed4cb8c86dd86d73762309fb655839cba15275465719",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:57165",
+					"10.65.0.27:57165",
+					"172.17.0.1:57165",
+					"172.18.0.1:57165",
+					"172.19.0.1:57165",
+					"172.20.0.1:57165",
+					"172.21.0.1:57165",
+					"172.22.0.1:57165",
+					"172.23.0.1:57165",
+					"172.24.0.1:57165",
+					"172.25.0.1:57165",
+					"172.26.0.1:57165",
+					"172.27.0.1:57165",
+					"172.28.0.1:57165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:28:47.21316036Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5240277471551194,
+				"StableID":   "nsh5gnCLvh11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6133fe33ffa51e5444886acb1b9ccdfe163a3bc1b7a092b170b0300b2e327e62",
+				"DiscoKey":   "discokey:9dbf998e101d3701c08c6c150915a9c614a8e4d2184679e09f44cdd38877fb37",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:37400",
+					"10.65.0.27:37400",
+					"172.17.0.1:37400",
+					"172.18.0.1:37400",
+					"172.19.0.1:37400",
+					"172.20.0.1:37400",
+					"172.21.0.1:37400",
+					"172.22.0.1:37400",
+					"172.23.0.1:37400",
+					"172.24.0.1:37400",
+					"172.25.0.1:37400",
+					"172.26.0.1:37400",
+					"172.27.0.1:37400",
+					"172.28.0.1:37400"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:28:47.75087018Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4363475266036325,
+				"StableID":   "n6FxEa6E5b11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4ab3b25c361ce76192c7bb7de4eaa52edb2b609db7ab3e9c5cd27b5b48ea641",
+				"DiscoKey":   "discokey:8c690d866f20c3667bb18a3c9b5e7ec12bddc21a0a8c4cac482632d646491e11",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43562",
+					"10.65.0.27:43562",
+					"172.17.0.1:43562",
+					"172.18.0.1:43562",
+					"172.19.0.1:43562",
+					"172.20.0.1:43562",
+					"172.21.0.1:43562",
+					"172.22.0.1:43562",
+					"172.23.0.1:43562",
+					"172.24.0.1:43562",
+					"172.25.0.1:43562",
+					"172.26.0.1:43562",
+					"172.27.0.1:43562",
+					"172.28.0.1:43562"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:28:48.280253327Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         909310783077211,
+				"StableID":   "ntuV734q6811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8edca3deebe2ceaea15075262b354da60313aa6201f2f1493a0e8684b0fe207c",
+				"DiscoKey":   "discokey:46fd17122baeabb311910115ef13847ad90880c90487487905ee812f07d37447",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52004",
+					"10.65.0.27:52004",
+					"172.17.0.1:52004",
+					"172.18.0.1:52004",
+					"172.19.0.1:52004",
+					"172.20.0.1:52004",
+					"172.21.0.1:52004",
+					"172.22.0.1:52004",
+					"172.23.0.1:52004",
+					"172.24.0.1:52004",
+					"172.25.0.1:52004",
+					"172.26.0.1:52004",
+					"172.27.0.1:52004",
+					"172.28.0.1:52004"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:28:48.908611477Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7745891296835908,
+				"StableID":   "nh5tLvR8V321CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41f059a70061d6f70e7197367d3731145e6ab586cb69825226a952ce53669f3d",
+				"DiscoKey":   "discokey:2dcf4e0fb98d432ccc7a62c1dbc721ab09f388cb22f559fbd24e1a71c6cdfb0c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52807",
+					"10.65.0.27:52807",
+					"172.17.0.1:52807",
+					"172.18.0.1:52807",
+					"172.19.0.1:52807",
+					"172.20.0.1:52807",
+					"172.21.0.1:52807",
+					"172.22.0.1:52807",
+					"172.23.0.1:52807",
+					"172.24.0.1:52807",
+					"172.25.0.1:52807",
+					"172.26.0.1:52807",
+					"172.27.0.1:52807",
+					"172.28.0.1:52807"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:28:49.610332949Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2710951987489957,
+				"StableID":   "nYr6vU7oAN11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f5c60b60b29ffdd49afe634a54b157d9e559467c4756f3e3bb748f1f8e67ee29",
+				"DiscoKey":   "discokey:071b44d9f2887164b4bb56d67ac0ca7118bc4f88b350fa2751d3995a78574b40",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50109",
+					"10.65.0.27:50109",
+					"172.17.0.1:50109",
+					"172.18.0.1:50109",
+					"172.19.0.1:50109",
+					"172.20.0.1:50109",
+					"172.21.0.1:50109",
+					"172.22.0.1:50109",
+					"172.23.0.1:50109",
+					"172.24.0.1:50109",
+					"172.25.0.1:50109",
+					"172.26.0.1:50109",
+					"172.27.0.1:50109",
+					"172.28.0.1:50109"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:28:50.142420965Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3941036375649528,
+				"StableID":   "n9B85tLumX11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:517ab7e4d00428dcd9d4a9cc5439f9d83c76abaf94bb540b37f797fda655397b",
+				"DiscoKey":   "discokey:9458a746831846e5bace91cdf1333b8adb80e8cf3ecd4d24431b7cc36284c62c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:57560",
+					"10.65.0.27:57560",
+					"172.17.0.1:57560",
+					"172.18.0.1:57560",
+					"172.19.0.1:57560",
+					"172.20.0.1:57560",
+					"172.21.0.1:57560",
+					"172.22.0.1:57560",
+					"172.23.0.1:57560",
+					"172.24.0.1:57560",
+					"172.25.0.1:57560",
+					"172.26.0.1:57560",
+					"172.27.0.1:57560",
+					"172.28.0.1:57560"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:28:51.206482784Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8935913823923919,
+				"StableID":   "nC7D2cJ6nC21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c182045ac1a949ea6f5b9935e4797df1b236ad608c930c5756582b22d25a274e",
+				"DiscoKey":   "discokey:e50b97a3e204250db28ba9718c6ea1359b5ee9d40ebab0409c8161ccb2d63754",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53787",
+					"10.65.0.27:53787",
+					"172.17.0.1:53787",
+					"172.18.0.1:53787",
+					"172.19.0.1:53787",
+					"172.20.0.1:53787",
+					"172.21.0.1:53787",
+					"172.22.0.1:53787",
+					"172.23.0.1:53787",
+					"172.24.0.1:53787",
+					"172.25.0.1:53787",
+					"172.26.0.1:53787",
+					"172.27.0.1:53787",
+					"172.28.0.1:53787"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:28:51.81673023Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4091099345258174,
+				"StableID":   "nZU5q4FswY11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c7390a9fcadbb2338b0bba0fb361116b27d7e1130a39482e15c45b36a88eb0e",
+				"DiscoKey":   "discokey:dbb9c86e8c66e6d3a23242cc8a8a0ffc8c62fce8b92641d51e1fed860fe33046",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55414",
+					"10.65.0.27:55414",
+					"172.17.0.1:55414",
+					"172.18.0.1:55414",
+					"172.19.0.1:55414",
+					"172.20.0.1:55414",
+					"172.21.0.1:55414",
+					"172.22.0.1:55414",
+					"172.23.0.1:55414",
+					"172.24.0.1:55414",
+					"172.25.0.1:55414",
+					"172.26.0.1:55414",
+					"172.27.0.1:55414",
+					"172.28.0.1:55414"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:28:52.352784952Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7226997624776993,
+				"StableID":   "nG2qQRy7Sy11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:50a36e28a806c2fd2dd02c48f3bc1cae71ed401b7ba78dfafe77eb5754bc2046",
+				"DiscoKey":   "discokey:6accaa0042f08166c86b4f758fb3dd8596e84d791ddbd3d081517267f9243d74",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41999",
+					"10.65.0.27:41999",
+					"172.17.0.1:41999",
+					"172.18.0.1:41999",
+					"172.19.0.1:41999",
+					"172.20.0.1:41999",
+					"172.21.0.1:41999",
+					"172.22.0.1:41999",
+					"172.23.0.1:41999",
+					"172.24.0.1:41999",
+					"172.25.0.1:41999",
+					"172.26.0.1:41999",
+					"172.27.0.1:41999",
+					"172.28.0.1:41999"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:28:52.888604203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3753295234958883,
+				"StableID":   "nvxjMghsJW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a51ba4c771f8e5dccbe174bb608c8b39a571f610f4f5f37723a5ffa87fcf3364",
+				"KeyExpiry":  "2026-11-09T09:28:53Z",
+				"DiscoKey":   "discokey:6fa64763400c756c62d2abd5afb60ff5d637ee94214416082f546399f8f4ca2c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:37685",
+					"10.65.0.27:37685",
+					"172.17.0.1:37685",
+					"172.18.0.1:37685",
+					"172.19.0.1:37685",
+					"172.20.0.1:37685",
+					"172.21.0.1:37685",
+					"172.22.0.1:37685",
+					"172.23.0.1:37685",
+					"172.24.0.1:37685",
+					"172.25.0.1:37685",
+					"172.26.0.1:37685",
+					"172.27.0.1:37685",
+					"172.28.0.1:37685"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:28:53.423566519Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7899574873613674,
+				"StableID":   "nfhxkKSjg421CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:badae06a11903c36804634dd8e953652d6f0a06466abca3ddc1b582502db841d",
+				"KeyExpiry":  "2026-11-09T09:28:53Z",
+				"DiscoKey":   "discokey:05c3975fd2b82ae84653c9ea53e1969ce520b61a56d15335f69c8e594ff8d551",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:43857",
+					"10.65.0.27:43857",
+					"172.17.0.1:43857",
+					"172.18.0.1:43857",
+					"172.19.0.1:43857",
+					"172.20.0.1:43857",
+					"172.21.0.1:43857",
+					"172.22.0.1:43857",
+					"172.23.0.1:43857",
+					"172.24.0.1:43857",
+					"172.25.0.1:43857",
+					"172.26.0.1:43857",
+					"172.27.0.1:43857",
+					"172.28.0.1:43857"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:28:53.958495612Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5592242659501955,
+				"StableID":   "nkTv5Tjjfk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a81dc878ad9dae73b27a4940f9e3fb7b38d13cbaa36157c8e261292fa79dac51",
+				"KeyExpiry":  "2026-11-09T09:28:54Z",
+				"DiscoKey":   "discokey:5d5e468fd860cd130fc7e408223346f08ea9681b78eef3f4766d828179144d5f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59674",
+					"10.65.0.27:59674",
+					"172.17.0.1:59674",
+					"172.18.0.1:59674",
+					"172.19.0.1:59674",
+					"172.20.0.1:59674",
+					"172.21.0.1:59674",
+					"172.22.0.1:59674",
+					"172.23.0.1:59674",
+					"172.24.0.1:59674",
+					"172.25.0.1:59674",
+					"172.26.0.1:59674",
+					"172.27.0.1:59674",
+					"172.28.0.1:59674"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:28:54.496611041Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4259375241172312": {
+				"ID":          4259375241172312,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3753295234958883,
+				"StableID":   "nvxjMghsJW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a51ba4c771f8e5dccbe174bb608c8b39a571f610f4f5f37723a5ffa87fcf3364",
+				"KeyExpiry":  "2026-11-09T09:28:53Z",
+				"DiscoKey":   "discokey:6fa64763400c756c62d2abd5afb60ff5d637ee94214416082f546399f8f4ca2c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:37685",
+					"10.65.0.27:37685",
+					"172.17.0.1:37685",
+					"172.18.0.1:37685",
+					"172.19.0.1:37685",
+					"172.20.0.1:37685",
+					"172.21.0.1:37685",
+					"172.22.0.1:37685",
+					"172.23.0.1:37685",
+					"172.24.0.1:37685",
+					"172.25.0.1:37685",
+					"172.26.0.1:37685",
+					"172.27.0.1:37685",
+					"172.28.0.1:37685"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:28:53.423566519Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a51ba4c771f8e5dccbe174bb608c8b39a571f610f4f5f37723a5ffa87fcf3364",
+			"MachineKey": "mkey:334cc242ff3f8b7d2c0d6f5e2b88c3875b42e047a24d7e521b757c4962981268",
+			"Peers": [{
+				"ID":         5957838597252230,
+				"StableID":   "nTRQBQKKXo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:568fc47fb0b6966e883cb8e1cb7081f92bd09663eb43b1cdc5cda20a22e7922f",
+				"DiscoKey":   "discokey:80f8ed39da13b7bcbaeb85bcc66add4a5a7ca06df7cee5efc95ee395b4df4704",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46427",
+					"10.65.0.27:46427",
+					"172.17.0.1:46427",
+					"172.18.0.1:46427",
+					"172.19.0.1:46427",
+					"172.20.0.1:46427",
+					"172.21.0.1:46427",
+					"172.22.0.1:46427",
+					"172.23.0.1:46427",
+					"172.24.0.1:46427",
+					"172.25.0.1:46427",
+					"172.26.0.1:46427",
+					"172.27.0.1:46427",
+					"172.28.0.1:46427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:28:46.697626311Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7491435254768900,
+				"StableID":   "nMwSFTJtV121CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f57470fdb5acc6ffcb1afd1bcb9852dff1bcb2e4c1c8bdb33e1974c11186632a",
+				"DiscoKey":   "discokey:d30496c97aa5d06bc840ed4cb8c86dd86d73762309fb655839cba15275465719",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:57165",
+					"10.65.0.27:57165",
+					"172.17.0.1:57165",
+					"172.18.0.1:57165",
+					"172.19.0.1:57165",
+					"172.20.0.1:57165",
+					"172.21.0.1:57165",
+					"172.22.0.1:57165",
+					"172.23.0.1:57165",
+					"172.24.0.1:57165",
+					"172.25.0.1:57165",
+					"172.26.0.1:57165",
+					"172.27.0.1:57165",
+					"172.28.0.1:57165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:28:47.21316036Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5240277471551194,
+				"StableID":   "nsh5gnCLvh11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6133fe33ffa51e5444886acb1b9ccdfe163a3bc1b7a092b170b0300b2e327e62",
+				"DiscoKey":   "discokey:9dbf998e101d3701c08c6c150915a9c614a8e4d2184679e09f44cdd38877fb37",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:37400",
+					"10.65.0.27:37400",
+					"172.17.0.1:37400",
+					"172.18.0.1:37400",
+					"172.19.0.1:37400",
+					"172.20.0.1:37400",
+					"172.21.0.1:37400",
+					"172.22.0.1:37400",
+					"172.23.0.1:37400",
+					"172.24.0.1:37400",
+					"172.25.0.1:37400",
+					"172.26.0.1:37400",
+					"172.27.0.1:37400",
+					"172.28.0.1:37400"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:28:47.75087018Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4363475266036325,
+				"StableID":   "n6FxEa6E5b11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4ab3b25c361ce76192c7bb7de4eaa52edb2b609db7ab3e9c5cd27b5b48ea641",
+				"DiscoKey":   "discokey:8c690d866f20c3667bb18a3c9b5e7ec12bddc21a0a8c4cac482632d646491e11",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43562",
+					"10.65.0.27:43562",
+					"172.17.0.1:43562",
+					"172.18.0.1:43562",
+					"172.19.0.1:43562",
+					"172.20.0.1:43562",
+					"172.21.0.1:43562",
+					"172.22.0.1:43562",
+					"172.23.0.1:43562",
+					"172.24.0.1:43562",
+					"172.25.0.1:43562",
+					"172.26.0.1:43562",
+					"172.27.0.1:43562",
+					"172.28.0.1:43562"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:28:48.280253327Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         909310783077211,
+				"StableID":   "ntuV734q6811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8edca3deebe2ceaea15075262b354da60313aa6201f2f1493a0e8684b0fe207c",
+				"DiscoKey":   "discokey:46fd17122baeabb311910115ef13847ad90880c90487487905ee812f07d37447",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52004",
+					"10.65.0.27:52004",
+					"172.17.0.1:52004",
+					"172.18.0.1:52004",
+					"172.19.0.1:52004",
+					"172.20.0.1:52004",
+					"172.21.0.1:52004",
+					"172.22.0.1:52004",
+					"172.23.0.1:52004",
+					"172.24.0.1:52004",
+					"172.25.0.1:52004",
+					"172.26.0.1:52004",
+					"172.27.0.1:52004",
+					"172.28.0.1:52004"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:28:48.908611477Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7745891296835908,
+				"StableID":   "nh5tLvR8V321CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41f059a70061d6f70e7197367d3731145e6ab586cb69825226a952ce53669f3d",
+				"DiscoKey":   "discokey:2dcf4e0fb98d432ccc7a62c1dbc721ab09f388cb22f559fbd24e1a71c6cdfb0c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52807",
+					"10.65.0.27:52807",
+					"172.17.0.1:52807",
+					"172.18.0.1:52807",
+					"172.19.0.1:52807",
+					"172.20.0.1:52807",
+					"172.21.0.1:52807",
+					"172.22.0.1:52807",
+					"172.23.0.1:52807",
+					"172.24.0.1:52807",
+					"172.25.0.1:52807",
+					"172.26.0.1:52807",
+					"172.27.0.1:52807",
+					"172.28.0.1:52807"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:28:49.610332949Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2710951987489957,
+				"StableID":   "nYr6vU7oAN11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f5c60b60b29ffdd49afe634a54b157d9e559467c4756f3e3bb748f1f8e67ee29",
+				"DiscoKey":   "discokey:071b44d9f2887164b4bb56d67ac0ca7118bc4f88b350fa2751d3995a78574b40",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50109",
+					"10.65.0.27:50109",
+					"172.17.0.1:50109",
+					"172.18.0.1:50109",
+					"172.19.0.1:50109",
+					"172.20.0.1:50109",
+					"172.21.0.1:50109",
+					"172.22.0.1:50109",
+					"172.23.0.1:50109",
+					"172.24.0.1:50109",
+					"172.25.0.1:50109",
+					"172.26.0.1:50109",
+					"172.27.0.1:50109",
+					"172.28.0.1:50109"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:28:50.142420965Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4259375241172312,
+				"StableID":   "nKazWmZ5Ga11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51e0e9a2becd35f2a5b892a48c67966775919aa302d974845a96427888200b6d",
+				"DiscoKey":   "discokey:d5cbaebd55f16bc0bbe00f5c938d9b390d3bf766cc342f53b6dbaebaa543dd15",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45948",
+					"10.65.0.27:45948",
+					"172.17.0.1:45948",
+					"172.18.0.1:45948",
+					"172.19.0.1:45948",
+					"172.20.0.1:45948",
+					"172.21.0.1:45948",
+					"172.22.0.1:45948",
+					"172.23.0.1:45948",
+					"172.24.0.1:45948",
+					"172.25.0.1:45948",
+					"172.26.0.1:45948",
+					"172.27.0.1:45948",
+					"172.28.0.1:45948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:28:50.670295722Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3941036375649528,
+				"StableID":   "n9B85tLumX11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:517ab7e4d00428dcd9d4a9cc5439f9d83c76abaf94bb540b37f797fda655397b",
+				"DiscoKey":   "discokey:9458a746831846e5bace91cdf1333b8adb80e8cf3ecd4d24431b7cc36284c62c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:57560",
+					"10.65.0.27:57560",
+					"172.17.0.1:57560",
+					"172.18.0.1:57560",
+					"172.19.0.1:57560",
+					"172.20.0.1:57560",
+					"172.21.0.1:57560",
+					"172.22.0.1:57560",
+					"172.23.0.1:57560",
+					"172.24.0.1:57560",
+					"172.25.0.1:57560",
+					"172.26.0.1:57560",
+					"172.27.0.1:57560",
+					"172.28.0.1:57560"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:28:51.206482784Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8935913823923919,
+				"StableID":   "nC7D2cJ6nC21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c182045ac1a949ea6f5b9935e4797df1b236ad608c930c5756582b22d25a274e",
+				"DiscoKey":   "discokey:e50b97a3e204250db28ba9718c6ea1359b5ee9d40ebab0409c8161ccb2d63754",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53787",
+					"10.65.0.27:53787",
+					"172.17.0.1:53787",
+					"172.18.0.1:53787",
+					"172.19.0.1:53787",
+					"172.20.0.1:53787",
+					"172.21.0.1:53787",
+					"172.22.0.1:53787",
+					"172.23.0.1:53787",
+					"172.24.0.1:53787",
+					"172.25.0.1:53787",
+					"172.26.0.1:53787",
+					"172.27.0.1:53787",
+					"172.28.0.1:53787"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:28:51.81673023Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4091099345258174,
+				"StableID":   "nZU5q4FswY11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c7390a9fcadbb2338b0bba0fb361116b27d7e1130a39482e15c45b36a88eb0e",
+				"DiscoKey":   "discokey:dbb9c86e8c66e6d3a23242cc8a8a0ffc8c62fce8b92641d51e1fed860fe33046",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55414",
+					"10.65.0.27:55414",
+					"172.17.0.1:55414",
+					"172.18.0.1:55414",
+					"172.19.0.1:55414",
+					"172.20.0.1:55414",
+					"172.21.0.1:55414",
+					"172.22.0.1:55414",
+					"172.23.0.1:55414",
+					"172.24.0.1:55414",
+					"172.25.0.1:55414",
+					"172.26.0.1:55414",
+					"172.27.0.1:55414",
+					"172.28.0.1:55414"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:28:52.352784952Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7226997624776993,
+				"StableID":   "nG2qQRy7Sy11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:50a36e28a806c2fd2dd02c48f3bc1cae71ed401b7ba78dfafe77eb5754bc2046",
+				"DiscoKey":   "discokey:6accaa0042f08166c86b4f758fb3dd8596e84d791ddbd3d081517267f9243d74",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41999",
+					"10.65.0.27:41999",
+					"172.17.0.1:41999",
+					"172.18.0.1:41999",
+					"172.19.0.1:41999",
+					"172.20.0.1:41999",
+					"172.21.0.1:41999",
+					"172.22.0.1:41999",
+					"172.23.0.1:41999",
+					"172.24.0.1:41999",
+					"172.25.0.1:41999",
+					"172.26.0.1:41999",
+					"172.27.0.1:41999",
+					"172.28.0.1:41999"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:28:52.888604203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7899574873613674,
+				"StableID":   "nfhxkKSjg421CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:badae06a11903c36804634dd8e953652d6f0a06466abca3ddc1b582502db841d",
+				"KeyExpiry":  "2026-11-09T09:28:53Z",
+				"DiscoKey":   "discokey:05c3975fd2b82ae84653c9ea53e1969ce520b61a56d15335f69c8e594ff8d551",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:43857",
+					"10.65.0.27:43857",
+					"172.17.0.1:43857",
+					"172.18.0.1:43857",
+					"172.19.0.1:43857",
+					"172.20.0.1:43857",
+					"172.21.0.1:43857",
+					"172.22.0.1:43857",
+					"172.23.0.1:43857",
+					"172.24.0.1:43857",
+					"172.25.0.1:43857",
+					"172.26.0.1:43857",
+					"172.27.0.1:43857",
+					"172.28.0.1:43857"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:28:53.958495612Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5592242659501955,
+				"StableID":   "nkTv5Tjjfk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a81dc878ad9dae73b27a4940f9e3fb7b38d13cbaa36157c8e261292fa79dac51",
+				"KeyExpiry":  "2026-11-09T09:28:54Z",
+				"DiscoKey":   "discokey:5d5e468fd860cd130fc7e408223346f08ea9681b78eef3f4766d828179144d5f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59674",
+					"10.65.0.27:59674",
+					"172.17.0.1:59674",
+					"172.18.0.1:59674",
+					"172.19.0.1:59674",
+					"172.20.0.1:59674",
+					"172.21.0.1:59674",
+					"172.22.0.1:59674",
+					"172.23.0.1:59674",
+					"172.24.0.1:59674",
+					"172.25.0.1:59674",
+					"172.26.0.1:59674",
+					"172.27.0.1:59674",
+					"172.28.0.1:59674"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:28:54.496611041Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4091099345258174,
+				"StableID":   "nZU5q4FswY11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       4091099345258174,
+				"Key":        "nodekey:2c7390a9fcadbb2338b0bba0fb361116b27d7e1130a39482e15c45b36a88eb0e",
+				"DiscoKey":   "discokey:dbb9c86e8c66e6d3a23242cc8a8a0ffc8c62fce8b92641d51e1fed860fe33046",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55414",
+					"10.65.0.27:55414",
+					"172.17.0.1:55414",
+					"172.18.0.1:55414",
+					"172.19.0.1:55414",
+					"172.20.0.1:55414",
+					"172.21.0.1:55414",
+					"172.22.0.1:55414",
+					"172.23.0.1:55414",
+					"172.24.0.1:55414",
+					"172.25.0.1:55414",
+					"172.26.0.1:55414",
+					"172.27.0.1:55414",
+					"172.28.0.1:55414"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:28:52.352784952Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2c7390a9fcadbb2338b0bba0fb361116b27d7e1130a39482e15c45b36a88eb0e",
+			"MachineKey": "mkey:68c8d6eb20494cafbae06275b0a6f266357760b50db1dd48a90deb1a52c20b08",
+			"Peers": [{
+				"ID":         5957838597252230,
+				"StableID":   "nTRQBQKKXo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:568fc47fb0b6966e883cb8e1cb7081f92bd09663eb43b1cdc5cda20a22e7922f",
+				"DiscoKey":   "discokey:80f8ed39da13b7bcbaeb85bcc66add4a5a7ca06df7cee5efc95ee395b4df4704",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46427",
+					"10.65.0.27:46427",
+					"172.17.0.1:46427",
+					"172.18.0.1:46427",
+					"172.19.0.1:46427",
+					"172.20.0.1:46427",
+					"172.21.0.1:46427",
+					"172.22.0.1:46427",
+					"172.23.0.1:46427",
+					"172.24.0.1:46427",
+					"172.25.0.1:46427",
+					"172.26.0.1:46427",
+					"172.27.0.1:46427",
+					"172.28.0.1:46427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:28:46.697626311Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7491435254768900,
+				"StableID":   "nMwSFTJtV121CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f57470fdb5acc6ffcb1afd1bcb9852dff1bcb2e4c1c8bdb33e1974c11186632a",
+				"DiscoKey":   "discokey:d30496c97aa5d06bc840ed4cb8c86dd86d73762309fb655839cba15275465719",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:57165",
+					"10.65.0.27:57165",
+					"172.17.0.1:57165",
+					"172.18.0.1:57165",
+					"172.19.0.1:57165",
+					"172.20.0.1:57165",
+					"172.21.0.1:57165",
+					"172.22.0.1:57165",
+					"172.23.0.1:57165",
+					"172.24.0.1:57165",
+					"172.25.0.1:57165",
+					"172.26.0.1:57165",
+					"172.27.0.1:57165",
+					"172.28.0.1:57165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:28:47.21316036Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5240277471551194,
+				"StableID":   "nsh5gnCLvh11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6133fe33ffa51e5444886acb1b9ccdfe163a3bc1b7a092b170b0300b2e327e62",
+				"DiscoKey":   "discokey:9dbf998e101d3701c08c6c150915a9c614a8e4d2184679e09f44cdd38877fb37",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:37400",
+					"10.65.0.27:37400",
+					"172.17.0.1:37400",
+					"172.18.0.1:37400",
+					"172.19.0.1:37400",
+					"172.20.0.1:37400",
+					"172.21.0.1:37400",
+					"172.22.0.1:37400",
+					"172.23.0.1:37400",
+					"172.24.0.1:37400",
+					"172.25.0.1:37400",
+					"172.26.0.1:37400",
+					"172.27.0.1:37400",
+					"172.28.0.1:37400"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:28:47.75087018Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4363475266036325,
+				"StableID":   "n6FxEa6E5b11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4ab3b25c361ce76192c7bb7de4eaa52edb2b609db7ab3e9c5cd27b5b48ea641",
+				"DiscoKey":   "discokey:8c690d866f20c3667bb18a3c9b5e7ec12bddc21a0a8c4cac482632d646491e11",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43562",
+					"10.65.0.27:43562",
+					"172.17.0.1:43562",
+					"172.18.0.1:43562",
+					"172.19.0.1:43562",
+					"172.20.0.1:43562",
+					"172.21.0.1:43562",
+					"172.22.0.1:43562",
+					"172.23.0.1:43562",
+					"172.24.0.1:43562",
+					"172.25.0.1:43562",
+					"172.26.0.1:43562",
+					"172.27.0.1:43562",
+					"172.28.0.1:43562"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:28:48.280253327Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         909310783077211,
+				"StableID":   "ntuV734q6811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8edca3deebe2ceaea15075262b354da60313aa6201f2f1493a0e8684b0fe207c",
+				"DiscoKey":   "discokey:46fd17122baeabb311910115ef13847ad90880c90487487905ee812f07d37447",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52004",
+					"10.65.0.27:52004",
+					"172.17.0.1:52004",
+					"172.18.0.1:52004",
+					"172.19.0.1:52004",
+					"172.20.0.1:52004",
+					"172.21.0.1:52004",
+					"172.22.0.1:52004",
+					"172.23.0.1:52004",
+					"172.24.0.1:52004",
+					"172.25.0.1:52004",
+					"172.26.0.1:52004",
+					"172.27.0.1:52004",
+					"172.28.0.1:52004"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:28:48.908611477Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7745891296835908,
+				"StableID":   "nh5tLvR8V321CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41f059a70061d6f70e7197367d3731145e6ab586cb69825226a952ce53669f3d",
+				"DiscoKey":   "discokey:2dcf4e0fb98d432ccc7a62c1dbc721ab09f388cb22f559fbd24e1a71c6cdfb0c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52807",
+					"10.65.0.27:52807",
+					"172.17.0.1:52807",
+					"172.18.0.1:52807",
+					"172.19.0.1:52807",
+					"172.20.0.1:52807",
+					"172.21.0.1:52807",
+					"172.22.0.1:52807",
+					"172.23.0.1:52807",
+					"172.24.0.1:52807",
+					"172.25.0.1:52807",
+					"172.26.0.1:52807",
+					"172.27.0.1:52807",
+					"172.28.0.1:52807"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:28:49.610332949Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2710951987489957,
+				"StableID":   "nYr6vU7oAN11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f5c60b60b29ffdd49afe634a54b157d9e559467c4756f3e3bb748f1f8e67ee29",
+				"DiscoKey":   "discokey:071b44d9f2887164b4bb56d67ac0ca7118bc4f88b350fa2751d3995a78574b40",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50109",
+					"10.65.0.27:50109",
+					"172.17.0.1:50109",
+					"172.18.0.1:50109",
+					"172.19.0.1:50109",
+					"172.20.0.1:50109",
+					"172.21.0.1:50109",
+					"172.22.0.1:50109",
+					"172.23.0.1:50109",
+					"172.24.0.1:50109",
+					"172.25.0.1:50109",
+					"172.26.0.1:50109",
+					"172.27.0.1:50109",
+					"172.28.0.1:50109"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:28:50.142420965Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4259375241172312,
+				"StableID":   "nKazWmZ5Ga11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51e0e9a2becd35f2a5b892a48c67966775919aa302d974845a96427888200b6d",
+				"DiscoKey":   "discokey:d5cbaebd55f16bc0bbe00f5c938d9b390d3bf766cc342f53b6dbaebaa543dd15",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45948",
+					"10.65.0.27:45948",
+					"172.17.0.1:45948",
+					"172.18.0.1:45948",
+					"172.19.0.1:45948",
+					"172.20.0.1:45948",
+					"172.21.0.1:45948",
+					"172.22.0.1:45948",
+					"172.23.0.1:45948",
+					"172.24.0.1:45948",
+					"172.25.0.1:45948",
+					"172.26.0.1:45948",
+					"172.27.0.1:45948",
+					"172.28.0.1:45948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:28:50.670295722Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3941036375649528,
+				"StableID":   "n9B85tLumX11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:517ab7e4d00428dcd9d4a9cc5439f9d83c76abaf94bb540b37f797fda655397b",
+				"DiscoKey":   "discokey:9458a746831846e5bace91cdf1333b8adb80e8cf3ecd4d24431b7cc36284c62c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:57560",
+					"10.65.0.27:57560",
+					"172.17.0.1:57560",
+					"172.18.0.1:57560",
+					"172.19.0.1:57560",
+					"172.20.0.1:57560",
+					"172.21.0.1:57560",
+					"172.22.0.1:57560",
+					"172.23.0.1:57560",
+					"172.24.0.1:57560",
+					"172.25.0.1:57560",
+					"172.26.0.1:57560",
+					"172.27.0.1:57560",
+					"172.28.0.1:57560"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:28:51.206482784Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8935913823923919,
+				"StableID":   "nC7D2cJ6nC21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c182045ac1a949ea6f5b9935e4797df1b236ad608c930c5756582b22d25a274e",
+				"DiscoKey":   "discokey:e50b97a3e204250db28ba9718c6ea1359b5ee9d40ebab0409c8161ccb2d63754",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53787",
+					"10.65.0.27:53787",
+					"172.17.0.1:53787",
+					"172.18.0.1:53787",
+					"172.19.0.1:53787",
+					"172.20.0.1:53787",
+					"172.21.0.1:53787",
+					"172.22.0.1:53787",
+					"172.23.0.1:53787",
+					"172.24.0.1:53787",
+					"172.25.0.1:53787",
+					"172.26.0.1:53787",
+					"172.27.0.1:53787",
+					"172.28.0.1:53787"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:28:51.81673023Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7226997624776993,
+				"StableID":   "nG2qQRy7Sy11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:50a36e28a806c2fd2dd02c48f3bc1cae71ed401b7ba78dfafe77eb5754bc2046",
+				"DiscoKey":   "discokey:6accaa0042f08166c86b4f758fb3dd8596e84d791ddbd3d081517267f9243d74",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41999",
+					"10.65.0.27:41999",
+					"172.17.0.1:41999",
+					"172.18.0.1:41999",
+					"172.19.0.1:41999",
+					"172.20.0.1:41999",
+					"172.21.0.1:41999",
+					"172.22.0.1:41999",
+					"172.23.0.1:41999",
+					"172.24.0.1:41999",
+					"172.25.0.1:41999",
+					"172.26.0.1:41999",
+					"172.27.0.1:41999",
+					"172.28.0.1:41999"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:28:52.888604203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3753295234958883,
+				"StableID":   "nvxjMghsJW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a51ba4c771f8e5dccbe174bb608c8b39a571f610f4f5f37723a5ffa87fcf3364",
+				"KeyExpiry":  "2026-11-09T09:28:53Z",
+				"DiscoKey":   "discokey:6fa64763400c756c62d2abd5afb60ff5d637ee94214416082f546399f8f4ca2c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:37685",
+					"10.65.0.27:37685",
+					"172.17.0.1:37685",
+					"172.18.0.1:37685",
+					"172.19.0.1:37685",
+					"172.20.0.1:37685",
+					"172.21.0.1:37685",
+					"172.22.0.1:37685",
+					"172.23.0.1:37685",
+					"172.24.0.1:37685",
+					"172.25.0.1:37685",
+					"172.26.0.1:37685",
+					"172.27.0.1:37685",
+					"172.28.0.1:37685"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:28:53.423566519Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7899574873613674,
+				"StableID":   "nfhxkKSjg421CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:badae06a11903c36804634dd8e953652d6f0a06466abca3ddc1b582502db841d",
+				"KeyExpiry":  "2026-11-09T09:28:53Z",
+				"DiscoKey":   "discokey:05c3975fd2b82ae84653c9ea53e1969ce520b61a56d15335f69c8e594ff8d551",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:43857",
+					"10.65.0.27:43857",
+					"172.17.0.1:43857",
+					"172.18.0.1:43857",
+					"172.19.0.1:43857",
+					"172.20.0.1:43857",
+					"172.21.0.1:43857",
+					"172.22.0.1:43857",
+					"172.23.0.1:43857",
+					"172.24.0.1:43857",
+					"172.25.0.1:43857",
+					"172.26.0.1:43857",
+					"172.27.0.1:43857",
+					"172.28.0.1:43857"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:28:53.958495612Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5592242659501955,
+				"StableID":   "nkTv5Tjjfk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a81dc878ad9dae73b27a4940f9e3fb7b38d13cbaa36157c8e261292fa79dac51",
+				"KeyExpiry":  "2026-11-09T09:28:54Z",
+				"DiscoKey":   "discokey:5d5e468fd860cd130fc7e408223346f08ea9681b78eef3f4766d828179144d5f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59674",
+					"10.65.0.27:59674",
+					"172.17.0.1:59674",
+					"172.18.0.1:59674",
+					"172.19.0.1:59674",
+					"172.20.0.1:59674",
+					"172.21.0.1:59674",
+					"172.22.0.1:59674",
+					"172.23.0.1:59674",
+					"172.24.0.1:59674",
+					"172.25.0.1:59674",
+					"172.26.0.1:59674",
+					"172.27.0.1:59674",
+					"172.28.0.1:59674"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:28:54.496611041Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4091099345258174": {
+				"ID":          4091099345258174,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7491435254768900,
+				"StableID":   "nMwSFTJtV121CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       7491435254768900,
+				"Key":        "nodekey:f57470fdb5acc6ffcb1afd1bcb9852dff1bcb2e4c1c8bdb33e1974c11186632a",
+				"DiscoKey":   "discokey:d30496c97aa5d06bc840ed4cb8c86dd86d73762309fb655839cba15275465719",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:57165",
+					"10.65.0.27:57165",
+					"172.17.0.1:57165",
+					"172.18.0.1:57165",
+					"172.19.0.1:57165",
+					"172.20.0.1:57165",
+					"172.21.0.1:57165",
+					"172.22.0.1:57165",
+					"172.23.0.1:57165",
+					"172.24.0.1:57165",
+					"172.25.0.1:57165",
+					"172.26.0.1:57165",
+					"172.27.0.1:57165",
+					"172.28.0.1:57165"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:28:47.21316036Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f57470fdb5acc6ffcb1afd1bcb9852dff1bcb2e4c1c8bdb33e1974c11186632a",
+			"MachineKey": "mkey:79f844bdbe9e64ecec656666ffd8df7471ebdaa12f75a441a5bd92083430863c",
+			"Peers": [{
+				"ID":         5957838597252230,
+				"StableID":   "nTRQBQKKXo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:568fc47fb0b6966e883cb8e1cb7081f92bd09663eb43b1cdc5cda20a22e7922f",
+				"DiscoKey":   "discokey:80f8ed39da13b7bcbaeb85bcc66add4a5a7ca06df7cee5efc95ee395b4df4704",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46427",
+					"10.65.0.27:46427",
+					"172.17.0.1:46427",
+					"172.18.0.1:46427",
+					"172.19.0.1:46427",
+					"172.20.0.1:46427",
+					"172.21.0.1:46427",
+					"172.22.0.1:46427",
+					"172.23.0.1:46427",
+					"172.24.0.1:46427",
+					"172.25.0.1:46427",
+					"172.26.0.1:46427",
+					"172.27.0.1:46427",
+					"172.28.0.1:46427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:28:46.697626311Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5240277471551194,
+				"StableID":   "nsh5gnCLvh11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6133fe33ffa51e5444886acb1b9ccdfe163a3bc1b7a092b170b0300b2e327e62",
+				"DiscoKey":   "discokey:9dbf998e101d3701c08c6c150915a9c614a8e4d2184679e09f44cdd38877fb37",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:37400",
+					"10.65.0.27:37400",
+					"172.17.0.1:37400",
+					"172.18.0.1:37400",
+					"172.19.0.1:37400",
+					"172.20.0.1:37400",
+					"172.21.0.1:37400",
+					"172.22.0.1:37400",
+					"172.23.0.1:37400",
+					"172.24.0.1:37400",
+					"172.25.0.1:37400",
+					"172.26.0.1:37400",
+					"172.27.0.1:37400",
+					"172.28.0.1:37400"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:28:47.75087018Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4363475266036325,
+				"StableID":   "n6FxEa6E5b11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4ab3b25c361ce76192c7bb7de4eaa52edb2b609db7ab3e9c5cd27b5b48ea641",
+				"DiscoKey":   "discokey:8c690d866f20c3667bb18a3c9b5e7ec12bddc21a0a8c4cac482632d646491e11",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43562",
+					"10.65.0.27:43562",
+					"172.17.0.1:43562",
+					"172.18.0.1:43562",
+					"172.19.0.1:43562",
+					"172.20.0.1:43562",
+					"172.21.0.1:43562",
+					"172.22.0.1:43562",
+					"172.23.0.1:43562",
+					"172.24.0.1:43562",
+					"172.25.0.1:43562",
+					"172.26.0.1:43562",
+					"172.27.0.1:43562",
+					"172.28.0.1:43562"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:28:48.280253327Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         909310783077211,
+				"StableID":   "ntuV734q6811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8edca3deebe2ceaea15075262b354da60313aa6201f2f1493a0e8684b0fe207c",
+				"DiscoKey":   "discokey:46fd17122baeabb311910115ef13847ad90880c90487487905ee812f07d37447",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52004",
+					"10.65.0.27:52004",
+					"172.17.0.1:52004",
+					"172.18.0.1:52004",
+					"172.19.0.1:52004",
+					"172.20.0.1:52004",
+					"172.21.0.1:52004",
+					"172.22.0.1:52004",
+					"172.23.0.1:52004",
+					"172.24.0.1:52004",
+					"172.25.0.1:52004",
+					"172.26.0.1:52004",
+					"172.27.0.1:52004",
+					"172.28.0.1:52004"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:28:48.908611477Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7745891296835908,
+				"StableID":   "nh5tLvR8V321CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41f059a70061d6f70e7197367d3731145e6ab586cb69825226a952ce53669f3d",
+				"DiscoKey":   "discokey:2dcf4e0fb98d432ccc7a62c1dbc721ab09f388cb22f559fbd24e1a71c6cdfb0c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52807",
+					"10.65.0.27:52807",
+					"172.17.0.1:52807",
+					"172.18.0.1:52807",
+					"172.19.0.1:52807",
+					"172.20.0.1:52807",
+					"172.21.0.1:52807",
+					"172.22.0.1:52807",
+					"172.23.0.1:52807",
+					"172.24.0.1:52807",
+					"172.25.0.1:52807",
+					"172.26.0.1:52807",
+					"172.27.0.1:52807",
+					"172.28.0.1:52807"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:28:49.610332949Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2710951987489957,
+				"StableID":   "nYr6vU7oAN11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f5c60b60b29ffdd49afe634a54b157d9e559467c4756f3e3bb748f1f8e67ee29",
+				"DiscoKey":   "discokey:071b44d9f2887164b4bb56d67ac0ca7118bc4f88b350fa2751d3995a78574b40",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50109",
+					"10.65.0.27:50109",
+					"172.17.0.1:50109",
+					"172.18.0.1:50109",
+					"172.19.0.1:50109",
+					"172.20.0.1:50109",
+					"172.21.0.1:50109",
+					"172.22.0.1:50109",
+					"172.23.0.1:50109",
+					"172.24.0.1:50109",
+					"172.25.0.1:50109",
+					"172.26.0.1:50109",
+					"172.27.0.1:50109",
+					"172.28.0.1:50109"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:28:50.142420965Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4259375241172312,
+				"StableID":   "nKazWmZ5Ga11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51e0e9a2becd35f2a5b892a48c67966775919aa302d974845a96427888200b6d",
+				"DiscoKey":   "discokey:d5cbaebd55f16bc0bbe00f5c938d9b390d3bf766cc342f53b6dbaebaa543dd15",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45948",
+					"10.65.0.27:45948",
+					"172.17.0.1:45948",
+					"172.18.0.1:45948",
+					"172.19.0.1:45948",
+					"172.20.0.1:45948",
+					"172.21.0.1:45948",
+					"172.22.0.1:45948",
+					"172.23.0.1:45948",
+					"172.24.0.1:45948",
+					"172.25.0.1:45948",
+					"172.26.0.1:45948",
+					"172.27.0.1:45948",
+					"172.28.0.1:45948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:28:50.670295722Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3941036375649528,
+				"StableID":   "n9B85tLumX11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:517ab7e4d00428dcd9d4a9cc5439f9d83c76abaf94bb540b37f797fda655397b",
+				"DiscoKey":   "discokey:9458a746831846e5bace91cdf1333b8adb80e8cf3ecd4d24431b7cc36284c62c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:57560",
+					"10.65.0.27:57560",
+					"172.17.0.1:57560",
+					"172.18.0.1:57560",
+					"172.19.0.1:57560",
+					"172.20.0.1:57560",
+					"172.21.0.1:57560",
+					"172.22.0.1:57560",
+					"172.23.0.1:57560",
+					"172.24.0.1:57560",
+					"172.25.0.1:57560",
+					"172.26.0.1:57560",
+					"172.27.0.1:57560",
+					"172.28.0.1:57560"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:28:51.206482784Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8935913823923919,
+				"StableID":   "nC7D2cJ6nC21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c182045ac1a949ea6f5b9935e4797df1b236ad608c930c5756582b22d25a274e",
+				"DiscoKey":   "discokey:e50b97a3e204250db28ba9718c6ea1359b5ee9d40ebab0409c8161ccb2d63754",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53787",
+					"10.65.0.27:53787",
+					"172.17.0.1:53787",
+					"172.18.0.1:53787",
+					"172.19.0.1:53787",
+					"172.20.0.1:53787",
+					"172.21.0.1:53787",
+					"172.22.0.1:53787",
+					"172.23.0.1:53787",
+					"172.24.0.1:53787",
+					"172.25.0.1:53787",
+					"172.26.0.1:53787",
+					"172.27.0.1:53787",
+					"172.28.0.1:53787"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:28:51.81673023Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4091099345258174,
+				"StableID":   "nZU5q4FswY11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c7390a9fcadbb2338b0bba0fb361116b27d7e1130a39482e15c45b36a88eb0e",
+				"DiscoKey":   "discokey:dbb9c86e8c66e6d3a23242cc8a8a0ffc8c62fce8b92641d51e1fed860fe33046",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55414",
+					"10.65.0.27:55414",
+					"172.17.0.1:55414",
+					"172.18.0.1:55414",
+					"172.19.0.1:55414",
+					"172.20.0.1:55414",
+					"172.21.0.1:55414",
+					"172.22.0.1:55414",
+					"172.23.0.1:55414",
+					"172.24.0.1:55414",
+					"172.25.0.1:55414",
+					"172.26.0.1:55414",
+					"172.27.0.1:55414",
+					"172.28.0.1:55414"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:28:52.352784952Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7226997624776993,
+				"StableID":   "nG2qQRy7Sy11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:50a36e28a806c2fd2dd02c48f3bc1cae71ed401b7ba78dfafe77eb5754bc2046",
+				"DiscoKey":   "discokey:6accaa0042f08166c86b4f758fb3dd8596e84d791ddbd3d081517267f9243d74",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41999",
+					"10.65.0.27:41999",
+					"172.17.0.1:41999",
+					"172.18.0.1:41999",
+					"172.19.0.1:41999",
+					"172.20.0.1:41999",
+					"172.21.0.1:41999",
+					"172.22.0.1:41999",
+					"172.23.0.1:41999",
+					"172.24.0.1:41999",
+					"172.25.0.1:41999",
+					"172.26.0.1:41999",
+					"172.27.0.1:41999",
+					"172.28.0.1:41999"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:28:52.888604203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3753295234958883,
+				"StableID":   "nvxjMghsJW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a51ba4c771f8e5dccbe174bb608c8b39a571f610f4f5f37723a5ffa87fcf3364",
+				"KeyExpiry":  "2026-11-09T09:28:53Z",
+				"DiscoKey":   "discokey:6fa64763400c756c62d2abd5afb60ff5d637ee94214416082f546399f8f4ca2c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:37685",
+					"10.65.0.27:37685",
+					"172.17.0.1:37685",
+					"172.18.0.1:37685",
+					"172.19.0.1:37685",
+					"172.20.0.1:37685",
+					"172.21.0.1:37685",
+					"172.22.0.1:37685",
+					"172.23.0.1:37685",
+					"172.24.0.1:37685",
+					"172.25.0.1:37685",
+					"172.26.0.1:37685",
+					"172.27.0.1:37685",
+					"172.28.0.1:37685"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:28:53.423566519Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7899574873613674,
+				"StableID":   "nfhxkKSjg421CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:badae06a11903c36804634dd8e953652d6f0a06466abca3ddc1b582502db841d",
+				"KeyExpiry":  "2026-11-09T09:28:53Z",
+				"DiscoKey":   "discokey:05c3975fd2b82ae84653c9ea53e1969ce520b61a56d15335f69c8e594ff8d551",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:43857",
+					"10.65.0.27:43857",
+					"172.17.0.1:43857",
+					"172.18.0.1:43857",
+					"172.19.0.1:43857",
+					"172.20.0.1:43857",
+					"172.21.0.1:43857",
+					"172.22.0.1:43857",
+					"172.23.0.1:43857",
+					"172.24.0.1:43857",
+					"172.25.0.1:43857",
+					"172.26.0.1:43857",
+					"172.27.0.1:43857",
+					"172.28.0.1:43857"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:28:53.958495612Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5592242659501955,
+				"StableID":   "nkTv5Tjjfk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a81dc878ad9dae73b27a4940f9e3fb7b38d13cbaa36157c8e261292fa79dac51",
+				"KeyExpiry":  "2026-11-09T09:28:54Z",
+				"DiscoKey":   "discokey:5d5e468fd860cd130fc7e408223346f08ea9681b78eef3f4766d828179144d5f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59674",
+					"10.65.0.27:59674",
+					"172.17.0.1:59674",
+					"172.18.0.1:59674",
+					"172.19.0.1:59674",
+					"172.20.0.1:59674",
+					"172.21.0.1:59674",
+					"172.22.0.1:59674",
+					"172.23.0.1:59674",
+					"172.24.0.1:59674",
+					"172.25.0.1:59674",
+					"172.26.0.1:59674",
+					"172.27.0.1:59674",
+					"172.28.0.1:59674"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:28:54.496611041Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7491435254768900": {
+				"ID":          7491435254768900,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5957838597252230,
+				"StableID":   "nTRQBQKKXo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       5957838597252230,
+				"Key":        "nodekey:568fc47fb0b6966e883cb8e1cb7081f92bd09663eb43b1cdc5cda20a22e7922f",
+				"DiscoKey":   "discokey:80f8ed39da13b7bcbaeb85bcc66add4a5a7ca06df7cee5efc95ee395b4df4704",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46427",
+					"10.65.0.27:46427",
+					"172.17.0.1:46427",
+					"172.18.0.1:46427",
+					"172.19.0.1:46427",
+					"172.20.0.1:46427",
+					"172.21.0.1:46427",
+					"172.22.0.1:46427",
+					"172.23.0.1:46427",
+					"172.24.0.1:46427",
+					"172.25.0.1:46427",
+					"172.26.0.1:46427",
+					"172.27.0.1:46427",
+					"172.28.0.1:46427"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:28:46.697626311Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:568fc47fb0b6966e883cb8e1cb7081f92bd09663eb43b1cdc5cda20a22e7922f",
+			"MachineKey": "mkey:c9df98d9323412a993062dfbbde0fb86b68c382a7767108881649d24b0df7f63",
+			"Peers": [{
+				"ID":         7491435254768900,
+				"StableID":   "nMwSFTJtV121CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f57470fdb5acc6ffcb1afd1bcb9852dff1bcb2e4c1c8bdb33e1974c11186632a",
+				"DiscoKey":   "discokey:d30496c97aa5d06bc840ed4cb8c86dd86d73762309fb655839cba15275465719",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:57165",
+					"10.65.0.27:57165",
+					"172.17.0.1:57165",
+					"172.18.0.1:57165",
+					"172.19.0.1:57165",
+					"172.20.0.1:57165",
+					"172.21.0.1:57165",
+					"172.22.0.1:57165",
+					"172.23.0.1:57165",
+					"172.24.0.1:57165",
+					"172.25.0.1:57165",
+					"172.26.0.1:57165",
+					"172.27.0.1:57165",
+					"172.28.0.1:57165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:28:47.21316036Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5240277471551194,
+				"StableID":   "nsh5gnCLvh11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6133fe33ffa51e5444886acb1b9ccdfe163a3bc1b7a092b170b0300b2e327e62",
+				"DiscoKey":   "discokey:9dbf998e101d3701c08c6c150915a9c614a8e4d2184679e09f44cdd38877fb37",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:37400",
+					"10.65.0.27:37400",
+					"172.17.0.1:37400",
+					"172.18.0.1:37400",
+					"172.19.0.1:37400",
+					"172.20.0.1:37400",
+					"172.21.0.1:37400",
+					"172.22.0.1:37400",
+					"172.23.0.1:37400",
+					"172.24.0.1:37400",
+					"172.25.0.1:37400",
+					"172.26.0.1:37400",
+					"172.27.0.1:37400",
+					"172.28.0.1:37400"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:28:47.75087018Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4363475266036325,
+				"StableID":   "n6FxEa6E5b11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4ab3b25c361ce76192c7bb7de4eaa52edb2b609db7ab3e9c5cd27b5b48ea641",
+				"DiscoKey":   "discokey:8c690d866f20c3667bb18a3c9b5e7ec12bddc21a0a8c4cac482632d646491e11",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43562",
+					"10.65.0.27:43562",
+					"172.17.0.1:43562",
+					"172.18.0.1:43562",
+					"172.19.0.1:43562",
+					"172.20.0.1:43562",
+					"172.21.0.1:43562",
+					"172.22.0.1:43562",
+					"172.23.0.1:43562",
+					"172.24.0.1:43562",
+					"172.25.0.1:43562",
+					"172.26.0.1:43562",
+					"172.27.0.1:43562",
+					"172.28.0.1:43562"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:28:48.280253327Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         909310783077211,
+				"StableID":   "ntuV734q6811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8edca3deebe2ceaea15075262b354da60313aa6201f2f1493a0e8684b0fe207c",
+				"DiscoKey":   "discokey:46fd17122baeabb311910115ef13847ad90880c90487487905ee812f07d37447",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52004",
+					"10.65.0.27:52004",
+					"172.17.0.1:52004",
+					"172.18.0.1:52004",
+					"172.19.0.1:52004",
+					"172.20.0.1:52004",
+					"172.21.0.1:52004",
+					"172.22.0.1:52004",
+					"172.23.0.1:52004",
+					"172.24.0.1:52004",
+					"172.25.0.1:52004",
+					"172.26.0.1:52004",
+					"172.27.0.1:52004",
+					"172.28.0.1:52004"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:28:48.908611477Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7745891296835908,
+				"StableID":   "nh5tLvR8V321CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41f059a70061d6f70e7197367d3731145e6ab586cb69825226a952ce53669f3d",
+				"DiscoKey":   "discokey:2dcf4e0fb98d432ccc7a62c1dbc721ab09f388cb22f559fbd24e1a71c6cdfb0c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52807",
+					"10.65.0.27:52807",
+					"172.17.0.1:52807",
+					"172.18.0.1:52807",
+					"172.19.0.1:52807",
+					"172.20.0.1:52807",
+					"172.21.0.1:52807",
+					"172.22.0.1:52807",
+					"172.23.0.1:52807",
+					"172.24.0.1:52807",
+					"172.25.0.1:52807",
+					"172.26.0.1:52807",
+					"172.27.0.1:52807",
+					"172.28.0.1:52807"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:28:49.610332949Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2710951987489957,
+				"StableID":   "nYr6vU7oAN11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f5c60b60b29ffdd49afe634a54b157d9e559467c4756f3e3bb748f1f8e67ee29",
+				"DiscoKey":   "discokey:071b44d9f2887164b4bb56d67ac0ca7118bc4f88b350fa2751d3995a78574b40",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50109",
+					"10.65.0.27:50109",
+					"172.17.0.1:50109",
+					"172.18.0.1:50109",
+					"172.19.0.1:50109",
+					"172.20.0.1:50109",
+					"172.21.0.1:50109",
+					"172.22.0.1:50109",
+					"172.23.0.1:50109",
+					"172.24.0.1:50109",
+					"172.25.0.1:50109",
+					"172.26.0.1:50109",
+					"172.27.0.1:50109",
+					"172.28.0.1:50109"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:28:50.142420965Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4259375241172312,
+				"StableID":   "nKazWmZ5Ga11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51e0e9a2becd35f2a5b892a48c67966775919aa302d974845a96427888200b6d",
+				"DiscoKey":   "discokey:d5cbaebd55f16bc0bbe00f5c938d9b390d3bf766cc342f53b6dbaebaa543dd15",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45948",
+					"10.65.0.27:45948",
+					"172.17.0.1:45948",
+					"172.18.0.1:45948",
+					"172.19.0.1:45948",
+					"172.20.0.1:45948",
+					"172.21.0.1:45948",
+					"172.22.0.1:45948",
+					"172.23.0.1:45948",
+					"172.24.0.1:45948",
+					"172.25.0.1:45948",
+					"172.26.0.1:45948",
+					"172.27.0.1:45948",
+					"172.28.0.1:45948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:28:50.670295722Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3941036375649528,
+				"StableID":   "n9B85tLumX11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:517ab7e4d00428dcd9d4a9cc5439f9d83c76abaf94bb540b37f797fda655397b",
+				"DiscoKey":   "discokey:9458a746831846e5bace91cdf1333b8adb80e8cf3ecd4d24431b7cc36284c62c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:57560",
+					"10.65.0.27:57560",
+					"172.17.0.1:57560",
+					"172.18.0.1:57560",
+					"172.19.0.1:57560",
+					"172.20.0.1:57560",
+					"172.21.0.1:57560",
+					"172.22.0.1:57560",
+					"172.23.0.1:57560",
+					"172.24.0.1:57560",
+					"172.25.0.1:57560",
+					"172.26.0.1:57560",
+					"172.27.0.1:57560",
+					"172.28.0.1:57560"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:28:51.206482784Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8935913823923919,
+				"StableID":   "nC7D2cJ6nC21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c182045ac1a949ea6f5b9935e4797df1b236ad608c930c5756582b22d25a274e",
+				"DiscoKey":   "discokey:e50b97a3e204250db28ba9718c6ea1359b5ee9d40ebab0409c8161ccb2d63754",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53787",
+					"10.65.0.27:53787",
+					"172.17.0.1:53787",
+					"172.18.0.1:53787",
+					"172.19.0.1:53787",
+					"172.20.0.1:53787",
+					"172.21.0.1:53787",
+					"172.22.0.1:53787",
+					"172.23.0.1:53787",
+					"172.24.0.1:53787",
+					"172.25.0.1:53787",
+					"172.26.0.1:53787",
+					"172.27.0.1:53787",
+					"172.28.0.1:53787"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:28:51.81673023Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4091099345258174,
+				"StableID":   "nZU5q4FswY11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c7390a9fcadbb2338b0bba0fb361116b27d7e1130a39482e15c45b36a88eb0e",
+				"DiscoKey":   "discokey:dbb9c86e8c66e6d3a23242cc8a8a0ffc8c62fce8b92641d51e1fed860fe33046",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55414",
+					"10.65.0.27:55414",
+					"172.17.0.1:55414",
+					"172.18.0.1:55414",
+					"172.19.0.1:55414",
+					"172.20.0.1:55414",
+					"172.21.0.1:55414",
+					"172.22.0.1:55414",
+					"172.23.0.1:55414",
+					"172.24.0.1:55414",
+					"172.25.0.1:55414",
+					"172.26.0.1:55414",
+					"172.27.0.1:55414",
+					"172.28.0.1:55414"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:28:52.352784952Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7226997624776993,
+				"StableID":   "nG2qQRy7Sy11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:50a36e28a806c2fd2dd02c48f3bc1cae71ed401b7ba78dfafe77eb5754bc2046",
+				"DiscoKey":   "discokey:6accaa0042f08166c86b4f758fb3dd8596e84d791ddbd3d081517267f9243d74",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41999",
+					"10.65.0.27:41999",
+					"172.17.0.1:41999",
+					"172.18.0.1:41999",
+					"172.19.0.1:41999",
+					"172.20.0.1:41999",
+					"172.21.0.1:41999",
+					"172.22.0.1:41999",
+					"172.23.0.1:41999",
+					"172.24.0.1:41999",
+					"172.25.0.1:41999",
+					"172.26.0.1:41999",
+					"172.27.0.1:41999",
+					"172.28.0.1:41999"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:28:52.888604203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3753295234958883,
+				"StableID":   "nvxjMghsJW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a51ba4c771f8e5dccbe174bb608c8b39a571f610f4f5f37723a5ffa87fcf3364",
+				"KeyExpiry":  "2026-11-09T09:28:53Z",
+				"DiscoKey":   "discokey:6fa64763400c756c62d2abd5afb60ff5d637ee94214416082f546399f8f4ca2c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:37685",
+					"10.65.0.27:37685",
+					"172.17.0.1:37685",
+					"172.18.0.1:37685",
+					"172.19.0.1:37685",
+					"172.20.0.1:37685",
+					"172.21.0.1:37685",
+					"172.22.0.1:37685",
+					"172.23.0.1:37685",
+					"172.24.0.1:37685",
+					"172.25.0.1:37685",
+					"172.26.0.1:37685",
+					"172.27.0.1:37685",
+					"172.28.0.1:37685"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:28:53.423566519Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7899574873613674,
+				"StableID":   "nfhxkKSjg421CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:badae06a11903c36804634dd8e953652d6f0a06466abca3ddc1b582502db841d",
+				"KeyExpiry":  "2026-11-09T09:28:53Z",
+				"DiscoKey":   "discokey:05c3975fd2b82ae84653c9ea53e1969ce520b61a56d15335f69c8e594ff8d551",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:43857",
+					"10.65.0.27:43857",
+					"172.17.0.1:43857",
+					"172.18.0.1:43857",
+					"172.19.0.1:43857",
+					"172.20.0.1:43857",
+					"172.21.0.1:43857",
+					"172.22.0.1:43857",
+					"172.23.0.1:43857",
+					"172.24.0.1:43857",
+					"172.25.0.1:43857",
+					"172.26.0.1:43857",
+					"172.27.0.1:43857",
+					"172.28.0.1:43857"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:28:53.958495612Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5592242659501955,
+				"StableID":   "nkTv5Tjjfk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a81dc878ad9dae73b27a4940f9e3fb7b38d13cbaa36157c8e261292fa79dac51",
+				"KeyExpiry":  "2026-11-09T09:28:54Z",
+				"DiscoKey":   "discokey:5d5e468fd860cd130fc7e408223346f08ea9681b78eef3f4766d828179144d5f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59674",
+					"10.65.0.27:59674",
+					"172.17.0.1:59674",
+					"172.18.0.1:59674",
+					"172.19.0.1:59674",
+					"172.20.0.1:59674",
+					"172.21.0.1:59674",
+					"172.22.0.1:59674",
+					"172.23.0.1:59674",
+					"172.24.0.1:59674",
+					"172.25.0.1:59674",
+					"172.26.0.1:59674",
+					"172.27.0.1:59674",
+					"172.28.0.1:59674"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:28:54.496611041Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5957838597252230": {
+				"ID":          5957838597252230,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         909310783077211,
+				"StableID":   "ntuV734q6811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       909310783077211,
+				"Key":        "nodekey:8edca3deebe2ceaea15075262b354da60313aa6201f2f1493a0e8684b0fe207c",
+				"DiscoKey":   "discokey:46fd17122baeabb311910115ef13847ad90880c90487487905ee812f07d37447",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52004",
+					"10.65.0.27:52004",
+					"172.17.0.1:52004",
+					"172.18.0.1:52004",
+					"172.19.0.1:52004",
+					"172.20.0.1:52004",
+					"172.21.0.1:52004",
+					"172.22.0.1:52004",
+					"172.23.0.1:52004",
+					"172.24.0.1:52004",
+					"172.25.0.1:52004",
+					"172.26.0.1:52004",
+					"172.27.0.1:52004",
+					"172.28.0.1:52004"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:28:48.908611477Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8edca3deebe2ceaea15075262b354da60313aa6201f2f1493a0e8684b0fe207c",
+			"MachineKey": "mkey:15abe5e5a2bd0589b94c566d2103df0e3405de6f1e33f760183c124bab029f58",
+			"Peers": [{
+				"ID":         5957838597252230,
+				"StableID":   "nTRQBQKKXo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:568fc47fb0b6966e883cb8e1cb7081f92bd09663eb43b1cdc5cda20a22e7922f",
+				"DiscoKey":   "discokey:80f8ed39da13b7bcbaeb85bcc66add4a5a7ca06df7cee5efc95ee395b4df4704",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46427",
+					"10.65.0.27:46427",
+					"172.17.0.1:46427",
+					"172.18.0.1:46427",
+					"172.19.0.1:46427",
+					"172.20.0.1:46427",
+					"172.21.0.1:46427",
+					"172.22.0.1:46427",
+					"172.23.0.1:46427",
+					"172.24.0.1:46427",
+					"172.25.0.1:46427",
+					"172.26.0.1:46427",
+					"172.27.0.1:46427",
+					"172.28.0.1:46427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:28:46.697626311Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7491435254768900,
+				"StableID":   "nMwSFTJtV121CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f57470fdb5acc6ffcb1afd1bcb9852dff1bcb2e4c1c8bdb33e1974c11186632a",
+				"DiscoKey":   "discokey:d30496c97aa5d06bc840ed4cb8c86dd86d73762309fb655839cba15275465719",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:57165",
+					"10.65.0.27:57165",
+					"172.17.0.1:57165",
+					"172.18.0.1:57165",
+					"172.19.0.1:57165",
+					"172.20.0.1:57165",
+					"172.21.0.1:57165",
+					"172.22.0.1:57165",
+					"172.23.0.1:57165",
+					"172.24.0.1:57165",
+					"172.25.0.1:57165",
+					"172.26.0.1:57165",
+					"172.27.0.1:57165",
+					"172.28.0.1:57165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:28:47.21316036Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5240277471551194,
+				"StableID":   "nsh5gnCLvh11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6133fe33ffa51e5444886acb1b9ccdfe163a3bc1b7a092b170b0300b2e327e62",
+				"DiscoKey":   "discokey:9dbf998e101d3701c08c6c150915a9c614a8e4d2184679e09f44cdd38877fb37",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:37400",
+					"10.65.0.27:37400",
+					"172.17.0.1:37400",
+					"172.18.0.1:37400",
+					"172.19.0.1:37400",
+					"172.20.0.1:37400",
+					"172.21.0.1:37400",
+					"172.22.0.1:37400",
+					"172.23.0.1:37400",
+					"172.24.0.1:37400",
+					"172.25.0.1:37400",
+					"172.26.0.1:37400",
+					"172.27.0.1:37400",
+					"172.28.0.1:37400"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:28:47.75087018Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4363475266036325,
+				"StableID":   "n6FxEa6E5b11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4ab3b25c361ce76192c7bb7de4eaa52edb2b609db7ab3e9c5cd27b5b48ea641",
+				"DiscoKey":   "discokey:8c690d866f20c3667bb18a3c9b5e7ec12bddc21a0a8c4cac482632d646491e11",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43562",
+					"10.65.0.27:43562",
+					"172.17.0.1:43562",
+					"172.18.0.1:43562",
+					"172.19.0.1:43562",
+					"172.20.0.1:43562",
+					"172.21.0.1:43562",
+					"172.22.0.1:43562",
+					"172.23.0.1:43562",
+					"172.24.0.1:43562",
+					"172.25.0.1:43562",
+					"172.26.0.1:43562",
+					"172.27.0.1:43562",
+					"172.28.0.1:43562"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:28:48.280253327Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7745891296835908,
+				"StableID":   "nh5tLvR8V321CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41f059a70061d6f70e7197367d3731145e6ab586cb69825226a952ce53669f3d",
+				"DiscoKey":   "discokey:2dcf4e0fb98d432ccc7a62c1dbc721ab09f388cb22f559fbd24e1a71c6cdfb0c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52807",
+					"10.65.0.27:52807",
+					"172.17.0.1:52807",
+					"172.18.0.1:52807",
+					"172.19.0.1:52807",
+					"172.20.0.1:52807",
+					"172.21.0.1:52807",
+					"172.22.0.1:52807",
+					"172.23.0.1:52807",
+					"172.24.0.1:52807",
+					"172.25.0.1:52807",
+					"172.26.0.1:52807",
+					"172.27.0.1:52807",
+					"172.28.0.1:52807"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:28:49.610332949Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2710951987489957,
+				"StableID":   "nYr6vU7oAN11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f5c60b60b29ffdd49afe634a54b157d9e559467c4756f3e3bb748f1f8e67ee29",
+				"DiscoKey":   "discokey:071b44d9f2887164b4bb56d67ac0ca7118bc4f88b350fa2751d3995a78574b40",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50109",
+					"10.65.0.27:50109",
+					"172.17.0.1:50109",
+					"172.18.0.1:50109",
+					"172.19.0.1:50109",
+					"172.20.0.1:50109",
+					"172.21.0.1:50109",
+					"172.22.0.1:50109",
+					"172.23.0.1:50109",
+					"172.24.0.1:50109",
+					"172.25.0.1:50109",
+					"172.26.0.1:50109",
+					"172.27.0.1:50109",
+					"172.28.0.1:50109"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:28:50.142420965Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4259375241172312,
+				"StableID":   "nKazWmZ5Ga11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51e0e9a2becd35f2a5b892a48c67966775919aa302d974845a96427888200b6d",
+				"DiscoKey":   "discokey:d5cbaebd55f16bc0bbe00f5c938d9b390d3bf766cc342f53b6dbaebaa543dd15",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45948",
+					"10.65.0.27:45948",
+					"172.17.0.1:45948",
+					"172.18.0.1:45948",
+					"172.19.0.1:45948",
+					"172.20.0.1:45948",
+					"172.21.0.1:45948",
+					"172.22.0.1:45948",
+					"172.23.0.1:45948",
+					"172.24.0.1:45948",
+					"172.25.0.1:45948",
+					"172.26.0.1:45948",
+					"172.27.0.1:45948",
+					"172.28.0.1:45948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:28:50.670295722Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3941036375649528,
+				"StableID":   "n9B85tLumX11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:517ab7e4d00428dcd9d4a9cc5439f9d83c76abaf94bb540b37f797fda655397b",
+				"DiscoKey":   "discokey:9458a746831846e5bace91cdf1333b8adb80e8cf3ecd4d24431b7cc36284c62c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:57560",
+					"10.65.0.27:57560",
+					"172.17.0.1:57560",
+					"172.18.0.1:57560",
+					"172.19.0.1:57560",
+					"172.20.0.1:57560",
+					"172.21.0.1:57560",
+					"172.22.0.1:57560",
+					"172.23.0.1:57560",
+					"172.24.0.1:57560",
+					"172.25.0.1:57560",
+					"172.26.0.1:57560",
+					"172.27.0.1:57560",
+					"172.28.0.1:57560"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:28:51.206482784Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8935913823923919,
+				"StableID":   "nC7D2cJ6nC21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c182045ac1a949ea6f5b9935e4797df1b236ad608c930c5756582b22d25a274e",
+				"DiscoKey":   "discokey:e50b97a3e204250db28ba9718c6ea1359b5ee9d40ebab0409c8161ccb2d63754",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53787",
+					"10.65.0.27:53787",
+					"172.17.0.1:53787",
+					"172.18.0.1:53787",
+					"172.19.0.1:53787",
+					"172.20.0.1:53787",
+					"172.21.0.1:53787",
+					"172.22.0.1:53787",
+					"172.23.0.1:53787",
+					"172.24.0.1:53787",
+					"172.25.0.1:53787",
+					"172.26.0.1:53787",
+					"172.27.0.1:53787",
+					"172.28.0.1:53787"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:28:51.81673023Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4091099345258174,
+				"StableID":   "nZU5q4FswY11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c7390a9fcadbb2338b0bba0fb361116b27d7e1130a39482e15c45b36a88eb0e",
+				"DiscoKey":   "discokey:dbb9c86e8c66e6d3a23242cc8a8a0ffc8c62fce8b92641d51e1fed860fe33046",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55414",
+					"10.65.0.27:55414",
+					"172.17.0.1:55414",
+					"172.18.0.1:55414",
+					"172.19.0.1:55414",
+					"172.20.0.1:55414",
+					"172.21.0.1:55414",
+					"172.22.0.1:55414",
+					"172.23.0.1:55414",
+					"172.24.0.1:55414",
+					"172.25.0.1:55414",
+					"172.26.0.1:55414",
+					"172.27.0.1:55414",
+					"172.28.0.1:55414"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:28:52.352784952Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7226997624776993,
+				"StableID":   "nG2qQRy7Sy11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:50a36e28a806c2fd2dd02c48f3bc1cae71ed401b7ba78dfafe77eb5754bc2046",
+				"DiscoKey":   "discokey:6accaa0042f08166c86b4f758fb3dd8596e84d791ddbd3d081517267f9243d74",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41999",
+					"10.65.0.27:41999",
+					"172.17.0.1:41999",
+					"172.18.0.1:41999",
+					"172.19.0.1:41999",
+					"172.20.0.1:41999",
+					"172.21.0.1:41999",
+					"172.22.0.1:41999",
+					"172.23.0.1:41999",
+					"172.24.0.1:41999",
+					"172.25.0.1:41999",
+					"172.26.0.1:41999",
+					"172.27.0.1:41999",
+					"172.28.0.1:41999"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:28:52.888604203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3753295234958883,
+				"StableID":   "nvxjMghsJW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a51ba4c771f8e5dccbe174bb608c8b39a571f610f4f5f37723a5ffa87fcf3364",
+				"KeyExpiry":  "2026-11-09T09:28:53Z",
+				"DiscoKey":   "discokey:6fa64763400c756c62d2abd5afb60ff5d637ee94214416082f546399f8f4ca2c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:37685",
+					"10.65.0.27:37685",
+					"172.17.0.1:37685",
+					"172.18.0.1:37685",
+					"172.19.0.1:37685",
+					"172.20.0.1:37685",
+					"172.21.0.1:37685",
+					"172.22.0.1:37685",
+					"172.23.0.1:37685",
+					"172.24.0.1:37685",
+					"172.25.0.1:37685",
+					"172.26.0.1:37685",
+					"172.27.0.1:37685",
+					"172.28.0.1:37685"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:28:53.423566519Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7899574873613674,
+				"StableID":   "nfhxkKSjg421CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:badae06a11903c36804634dd8e953652d6f0a06466abca3ddc1b582502db841d",
+				"KeyExpiry":  "2026-11-09T09:28:53Z",
+				"DiscoKey":   "discokey:05c3975fd2b82ae84653c9ea53e1969ce520b61a56d15335f69c8e594ff8d551",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:43857",
+					"10.65.0.27:43857",
+					"172.17.0.1:43857",
+					"172.18.0.1:43857",
+					"172.19.0.1:43857",
+					"172.20.0.1:43857",
+					"172.21.0.1:43857",
+					"172.22.0.1:43857",
+					"172.23.0.1:43857",
+					"172.24.0.1:43857",
+					"172.25.0.1:43857",
+					"172.26.0.1:43857",
+					"172.27.0.1:43857",
+					"172.28.0.1:43857"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:28:53.958495612Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5592242659501955,
+				"StableID":   "nkTv5Tjjfk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a81dc878ad9dae73b27a4940f9e3fb7b38d13cbaa36157c8e261292fa79dac51",
+				"KeyExpiry":  "2026-11-09T09:28:54Z",
+				"DiscoKey":   "discokey:5d5e468fd860cd130fc7e408223346f08ea9681b78eef3f4766d828179144d5f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59674",
+					"10.65.0.27:59674",
+					"172.17.0.1:59674",
+					"172.18.0.1:59674",
+					"172.19.0.1:59674",
+					"172.20.0.1:59674",
+					"172.21.0.1:59674",
+					"172.22.0.1:59674",
+					"172.23.0.1:59674",
+					"172.24.0.1:59674",
+					"172.25.0.1:59674",
+					"172.26.0.1:59674",
+					"172.27.0.1:59674",
+					"172.28.0.1:59674"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:28:54.496611041Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "909310783077211": {
+				"ID":          909310783077211,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4363475266036325,
+				"StableID":   "n6FxEa6E5b11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       4363475266036325,
+				"Key":        "nodekey:a4ab3b25c361ce76192c7bb7de4eaa52edb2b609db7ab3e9c5cd27b5b48ea641",
+				"DiscoKey":   "discokey:8c690d866f20c3667bb18a3c9b5e7ec12bddc21a0a8c4cac482632d646491e11",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43562",
+					"10.65.0.27:43562",
+					"172.17.0.1:43562",
+					"172.18.0.1:43562",
+					"172.19.0.1:43562",
+					"172.20.0.1:43562",
+					"172.21.0.1:43562",
+					"172.22.0.1:43562",
+					"172.23.0.1:43562",
+					"172.24.0.1:43562",
+					"172.25.0.1:43562",
+					"172.26.0.1:43562",
+					"172.27.0.1:43562",
+					"172.28.0.1:43562"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:28:48.280253327Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a4ab3b25c361ce76192c7bb7de4eaa52edb2b609db7ab3e9c5cd27b5b48ea641",
+			"MachineKey": "mkey:d442f6772b03e767e6d15bedeb84f8cabd85c55354bac5e2fe0413f518c66975",
+			"Peers": [{
+				"ID":         5957838597252230,
+				"StableID":   "nTRQBQKKXo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:568fc47fb0b6966e883cb8e1cb7081f92bd09663eb43b1cdc5cda20a22e7922f",
+				"DiscoKey":   "discokey:80f8ed39da13b7bcbaeb85bcc66add4a5a7ca06df7cee5efc95ee395b4df4704",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46427",
+					"10.65.0.27:46427",
+					"172.17.0.1:46427",
+					"172.18.0.1:46427",
+					"172.19.0.1:46427",
+					"172.20.0.1:46427",
+					"172.21.0.1:46427",
+					"172.22.0.1:46427",
+					"172.23.0.1:46427",
+					"172.24.0.1:46427",
+					"172.25.0.1:46427",
+					"172.26.0.1:46427",
+					"172.27.0.1:46427",
+					"172.28.0.1:46427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:28:46.697626311Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7491435254768900,
+				"StableID":   "nMwSFTJtV121CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f57470fdb5acc6ffcb1afd1bcb9852dff1bcb2e4c1c8bdb33e1974c11186632a",
+				"DiscoKey":   "discokey:d30496c97aa5d06bc840ed4cb8c86dd86d73762309fb655839cba15275465719",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:57165",
+					"10.65.0.27:57165",
+					"172.17.0.1:57165",
+					"172.18.0.1:57165",
+					"172.19.0.1:57165",
+					"172.20.0.1:57165",
+					"172.21.0.1:57165",
+					"172.22.0.1:57165",
+					"172.23.0.1:57165",
+					"172.24.0.1:57165",
+					"172.25.0.1:57165",
+					"172.26.0.1:57165",
+					"172.27.0.1:57165",
+					"172.28.0.1:57165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:28:47.21316036Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5240277471551194,
+				"StableID":   "nsh5gnCLvh11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6133fe33ffa51e5444886acb1b9ccdfe163a3bc1b7a092b170b0300b2e327e62",
+				"DiscoKey":   "discokey:9dbf998e101d3701c08c6c150915a9c614a8e4d2184679e09f44cdd38877fb37",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:37400",
+					"10.65.0.27:37400",
+					"172.17.0.1:37400",
+					"172.18.0.1:37400",
+					"172.19.0.1:37400",
+					"172.20.0.1:37400",
+					"172.21.0.1:37400",
+					"172.22.0.1:37400",
+					"172.23.0.1:37400",
+					"172.24.0.1:37400",
+					"172.25.0.1:37400",
+					"172.26.0.1:37400",
+					"172.27.0.1:37400",
+					"172.28.0.1:37400"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:28:47.75087018Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         909310783077211,
+				"StableID":   "ntuV734q6811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8edca3deebe2ceaea15075262b354da60313aa6201f2f1493a0e8684b0fe207c",
+				"DiscoKey":   "discokey:46fd17122baeabb311910115ef13847ad90880c90487487905ee812f07d37447",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52004",
+					"10.65.0.27:52004",
+					"172.17.0.1:52004",
+					"172.18.0.1:52004",
+					"172.19.0.1:52004",
+					"172.20.0.1:52004",
+					"172.21.0.1:52004",
+					"172.22.0.1:52004",
+					"172.23.0.1:52004",
+					"172.24.0.1:52004",
+					"172.25.0.1:52004",
+					"172.26.0.1:52004",
+					"172.27.0.1:52004",
+					"172.28.0.1:52004"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:28:48.908611477Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7745891296835908,
+				"StableID":   "nh5tLvR8V321CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41f059a70061d6f70e7197367d3731145e6ab586cb69825226a952ce53669f3d",
+				"DiscoKey":   "discokey:2dcf4e0fb98d432ccc7a62c1dbc721ab09f388cb22f559fbd24e1a71c6cdfb0c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52807",
+					"10.65.0.27:52807",
+					"172.17.0.1:52807",
+					"172.18.0.1:52807",
+					"172.19.0.1:52807",
+					"172.20.0.1:52807",
+					"172.21.0.1:52807",
+					"172.22.0.1:52807",
+					"172.23.0.1:52807",
+					"172.24.0.1:52807",
+					"172.25.0.1:52807",
+					"172.26.0.1:52807",
+					"172.27.0.1:52807",
+					"172.28.0.1:52807"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:28:49.610332949Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2710951987489957,
+				"StableID":   "nYr6vU7oAN11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f5c60b60b29ffdd49afe634a54b157d9e559467c4756f3e3bb748f1f8e67ee29",
+				"DiscoKey":   "discokey:071b44d9f2887164b4bb56d67ac0ca7118bc4f88b350fa2751d3995a78574b40",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50109",
+					"10.65.0.27:50109",
+					"172.17.0.1:50109",
+					"172.18.0.1:50109",
+					"172.19.0.1:50109",
+					"172.20.0.1:50109",
+					"172.21.0.1:50109",
+					"172.22.0.1:50109",
+					"172.23.0.1:50109",
+					"172.24.0.1:50109",
+					"172.25.0.1:50109",
+					"172.26.0.1:50109",
+					"172.27.0.1:50109",
+					"172.28.0.1:50109"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:28:50.142420965Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4259375241172312,
+				"StableID":   "nKazWmZ5Ga11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51e0e9a2becd35f2a5b892a48c67966775919aa302d974845a96427888200b6d",
+				"DiscoKey":   "discokey:d5cbaebd55f16bc0bbe00f5c938d9b390d3bf766cc342f53b6dbaebaa543dd15",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45948",
+					"10.65.0.27:45948",
+					"172.17.0.1:45948",
+					"172.18.0.1:45948",
+					"172.19.0.1:45948",
+					"172.20.0.1:45948",
+					"172.21.0.1:45948",
+					"172.22.0.1:45948",
+					"172.23.0.1:45948",
+					"172.24.0.1:45948",
+					"172.25.0.1:45948",
+					"172.26.0.1:45948",
+					"172.27.0.1:45948",
+					"172.28.0.1:45948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:28:50.670295722Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3941036375649528,
+				"StableID":   "n9B85tLumX11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:517ab7e4d00428dcd9d4a9cc5439f9d83c76abaf94bb540b37f797fda655397b",
+				"DiscoKey":   "discokey:9458a746831846e5bace91cdf1333b8adb80e8cf3ecd4d24431b7cc36284c62c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:57560",
+					"10.65.0.27:57560",
+					"172.17.0.1:57560",
+					"172.18.0.1:57560",
+					"172.19.0.1:57560",
+					"172.20.0.1:57560",
+					"172.21.0.1:57560",
+					"172.22.0.1:57560",
+					"172.23.0.1:57560",
+					"172.24.0.1:57560",
+					"172.25.0.1:57560",
+					"172.26.0.1:57560",
+					"172.27.0.1:57560",
+					"172.28.0.1:57560"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:28:51.206482784Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8935913823923919,
+				"StableID":   "nC7D2cJ6nC21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c182045ac1a949ea6f5b9935e4797df1b236ad608c930c5756582b22d25a274e",
+				"DiscoKey":   "discokey:e50b97a3e204250db28ba9718c6ea1359b5ee9d40ebab0409c8161ccb2d63754",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53787",
+					"10.65.0.27:53787",
+					"172.17.0.1:53787",
+					"172.18.0.1:53787",
+					"172.19.0.1:53787",
+					"172.20.0.1:53787",
+					"172.21.0.1:53787",
+					"172.22.0.1:53787",
+					"172.23.0.1:53787",
+					"172.24.0.1:53787",
+					"172.25.0.1:53787",
+					"172.26.0.1:53787",
+					"172.27.0.1:53787",
+					"172.28.0.1:53787"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:28:51.81673023Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4091099345258174,
+				"StableID":   "nZU5q4FswY11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c7390a9fcadbb2338b0bba0fb361116b27d7e1130a39482e15c45b36a88eb0e",
+				"DiscoKey":   "discokey:dbb9c86e8c66e6d3a23242cc8a8a0ffc8c62fce8b92641d51e1fed860fe33046",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55414",
+					"10.65.0.27:55414",
+					"172.17.0.1:55414",
+					"172.18.0.1:55414",
+					"172.19.0.1:55414",
+					"172.20.0.1:55414",
+					"172.21.0.1:55414",
+					"172.22.0.1:55414",
+					"172.23.0.1:55414",
+					"172.24.0.1:55414",
+					"172.25.0.1:55414",
+					"172.26.0.1:55414",
+					"172.27.0.1:55414",
+					"172.28.0.1:55414"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:28:52.352784952Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7226997624776993,
+				"StableID":   "nG2qQRy7Sy11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:50a36e28a806c2fd2dd02c48f3bc1cae71ed401b7ba78dfafe77eb5754bc2046",
+				"DiscoKey":   "discokey:6accaa0042f08166c86b4f758fb3dd8596e84d791ddbd3d081517267f9243d74",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41999",
+					"10.65.0.27:41999",
+					"172.17.0.1:41999",
+					"172.18.0.1:41999",
+					"172.19.0.1:41999",
+					"172.20.0.1:41999",
+					"172.21.0.1:41999",
+					"172.22.0.1:41999",
+					"172.23.0.1:41999",
+					"172.24.0.1:41999",
+					"172.25.0.1:41999",
+					"172.26.0.1:41999",
+					"172.27.0.1:41999",
+					"172.28.0.1:41999"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:28:52.888604203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3753295234958883,
+				"StableID":   "nvxjMghsJW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a51ba4c771f8e5dccbe174bb608c8b39a571f610f4f5f37723a5ffa87fcf3364",
+				"KeyExpiry":  "2026-11-09T09:28:53Z",
+				"DiscoKey":   "discokey:6fa64763400c756c62d2abd5afb60ff5d637ee94214416082f546399f8f4ca2c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:37685",
+					"10.65.0.27:37685",
+					"172.17.0.1:37685",
+					"172.18.0.1:37685",
+					"172.19.0.1:37685",
+					"172.20.0.1:37685",
+					"172.21.0.1:37685",
+					"172.22.0.1:37685",
+					"172.23.0.1:37685",
+					"172.24.0.1:37685",
+					"172.25.0.1:37685",
+					"172.26.0.1:37685",
+					"172.27.0.1:37685",
+					"172.28.0.1:37685"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:28:53.423566519Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7899574873613674,
+				"StableID":   "nfhxkKSjg421CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:badae06a11903c36804634dd8e953652d6f0a06466abca3ddc1b582502db841d",
+				"KeyExpiry":  "2026-11-09T09:28:53Z",
+				"DiscoKey":   "discokey:05c3975fd2b82ae84653c9ea53e1969ce520b61a56d15335f69c8e594ff8d551",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:43857",
+					"10.65.0.27:43857",
+					"172.17.0.1:43857",
+					"172.18.0.1:43857",
+					"172.19.0.1:43857",
+					"172.20.0.1:43857",
+					"172.21.0.1:43857",
+					"172.22.0.1:43857",
+					"172.23.0.1:43857",
+					"172.24.0.1:43857",
+					"172.25.0.1:43857",
+					"172.26.0.1:43857",
+					"172.27.0.1:43857",
+					"172.28.0.1:43857"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:28:53.958495612Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5592242659501955,
+				"StableID":   "nkTv5Tjjfk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a81dc878ad9dae73b27a4940f9e3fb7b38d13cbaa36157c8e261292fa79dac51",
+				"KeyExpiry":  "2026-11-09T09:28:54Z",
+				"DiscoKey":   "discokey:5d5e468fd860cd130fc7e408223346f08ea9681b78eef3f4766d828179144d5f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59674",
+					"10.65.0.27:59674",
+					"172.17.0.1:59674",
+					"172.18.0.1:59674",
+					"172.19.0.1:59674",
+					"172.20.0.1:59674",
+					"172.21.0.1:59674",
+					"172.22.0.1:59674",
+					"172.23.0.1:59674",
+					"172.24.0.1:59674",
+					"172.25.0.1:59674",
+					"172.26.0.1:59674",
+					"172.27.0.1:59674",
+					"172.28.0.1:59674"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:28:54.496611041Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4363475266036325": {
+				"ID":          4363475266036325,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2710951987489957,
+				"StableID":   "nYr6vU7oAN11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       2710951987489957,
+				"Key":        "nodekey:f5c60b60b29ffdd49afe634a54b157d9e559467c4756f3e3bb748f1f8e67ee29",
+				"DiscoKey":   "discokey:071b44d9f2887164b4bb56d67ac0ca7118bc4f88b350fa2751d3995a78574b40",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50109",
+					"10.65.0.27:50109",
+					"172.17.0.1:50109",
+					"172.18.0.1:50109",
+					"172.19.0.1:50109",
+					"172.20.0.1:50109",
+					"172.21.0.1:50109",
+					"172.22.0.1:50109",
+					"172.23.0.1:50109",
+					"172.24.0.1:50109",
+					"172.25.0.1:50109",
+					"172.26.0.1:50109",
+					"172.27.0.1:50109",
+					"172.28.0.1:50109"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:28:50.142420965Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f5c60b60b29ffdd49afe634a54b157d9e559467c4756f3e3bb748f1f8e67ee29",
+			"MachineKey": "mkey:07877f24499bc5b9ad15439a29b167b174a47074ad25a673f4a9bcc435d05234",
+			"Peers": [{
+				"ID":         5957838597252230,
+				"StableID":   "nTRQBQKKXo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:568fc47fb0b6966e883cb8e1cb7081f92bd09663eb43b1cdc5cda20a22e7922f",
+				"DiscoKey":   "discokey:80f8ed39da13b7bcbaeb85bcc66add4a5a7ca06df7cee5efc95ee395b4df4704",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46427",
+					"10.65.0.27:46427",
+					"172.17.0.1:46427",
+					"172.18.0.1:46427",
+					"172.19.0.1:46427",
+					"172.20.0.1:46427",
+					"172.21.0.1:46427",
+					"172.22.0.1:46427",
+					"172.23.0.1:46427",
+					"172.24.0.1:46427",
+					"172.25.0.1:46427",
+					"172.26.0.1:46427",
+					"172.27.0.1:46427",
+					"172.28.0.1:46427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:28:46.697626311Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7491435254768900,
+				"StableID":   "nMwSFTJtV121CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f57470fdb5acc6ffcb1afd1bcb9852dff1bcb2e4c1c8bdb33e1974c11186632a",
+				"DiscoKey":   "discokey:d30496c97aa5d06bc840ed4cb8c86dd86d73762309fb655839cba15275465719",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:57165",
+					"10.65.0.27:57165",
+					"172.17.0.1:57165",
+					"172.18.0.1:57165",
+					"172.19.0.1:57165",
+					"172.20.0.1:57165",
+					"172.21.0.1:57165",
+					"172.22.0.1:57165",
+					"172.23.0.1:57165",
+					"172.24.0.1:57165",
+					"172.25.0.1:57165",
+					"172.26.0.1:57165",
+					"172.27.0.1:57165",
+					"172.28.0.1:57165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:28:47.21316036Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5240277471551194,
+				"StableID":   "nsh5gnCLvh11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6133fe33ffa51e5444886acb1b9ccdfe163a3bc1b7a092b170b0300b2e327e62",
+				"DiscoKey":   "discokey:9dbf998e101d3701c08c6c150915a9c614a8e4d2184679e09f44cdd38877fb37",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:37400",
+					"10.65.0.27:37400",
+					"172.17.0.1:37400",
+					"172.18.0.1:37400",
+					"172.19.0.1:37400",
+					"172.20.0.1:37400",
+					"172.21.0.1:37400",
+					"172.22.0.1:37400",
+					"172.23.0.1:37400",
+					"172.24.0.1:37400",
+					"172.25.0.1:37400",
+					"172.26.0.1:37400",
+					"172.27.0.1:37400",
+					"172.28.0.1:37400"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:28:47.75087018Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4363475266036325,
+				"StableID":   "n6FxEa6E5b11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4ab3b25c361ce76192c7bb7de4eaa52edb2b609db7ab3e9c5cd27b5b48ea641",
+				"DiscoKey":   "discokey:8c690d866f20c3667bb18a3c9b5e7ec12bddc21a0a8c4cac482632d646491e11",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43562",
+					"10.65.0.27:43562",
+					"172.17.0.1:43562",
+					"172.18.0.1:43562",
+					"172.19.0.1:43562",
+					"172.20.0.1:43562",
+					"172.21.0.1:43562",
+					"172.22.0.1:43562",
+					"172.23.0.1:43562",
+					"172.24.0.1:43562",
+					"172.25.0.1:43562",
+					"172.26.0.1:43562",
+					"172.27.0.1:43562",
+					"172.28.0.1:43562"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:28:48.280253327Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         909310783077211,
+				"StableID":   "ntuV734q6811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8edca3deebe2ceaea15075262b354da60313aa6201f2f1493a0e8684b0fe207c",
+				"DiscoKey":   "discokey:46fd17122baeabb311910115ef13847ad90880c90487487905ee812f07d37447",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52004",
+					"10.65.0.27:52004",
+					"172.17.0.1:52004",
+					"172.18.0.1:52004",
+					"172.19.0.1:52004",
+					"172.20.0.1:52004",
+					"172.21.0.1:52004",
+					"172.22.0.1:52004",
+					"172.23.0.1:52004",
+					"172.24.0.1:52004",
+					"172.25.0.1:52004",
+					"172.26.0.1:52004",
+					"172.27.0.1:52004",
+					"172.28.0.1:52004"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:28:48.908611477Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7745891296835908,
+				"StableID":   "nh5tLvR8V321CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41f059a70061d6f70e7197367d3731145e6ab586cb69825226a952ce53669f3d",
+				"DiscoKey":   "discokey:2dcf4e0fb98d432ccc7a62c1dbc721ab09f388cb22f559fbd24e1a71c6cdfb0c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52807",
+					"10.65.0.27:52807",
+					"172.17.0.1:52807",
+					"172.18.0.1:52807",
+					"172.19.0.1:52807",
+					"172.20.0.1:52807",
+					"172.21.0.1:52807",
+					"172.22.0.1:52807",
+					"172.23.0.1:52807",
+					"172.24.0.1:52807",
+					"172.25.0.1:52807",
+					"172.26.0.1:52807",
+					"172.27.0.1:52807",
+					"172.28.0.1:52807"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:28:49.610332949Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4259375241172312,
+				"StableID":   "nKazWmZ5Ga11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51e0e9a2becd35f2a5b892a48c67966775919aa302d974845a96427888200b6d",
+				"DiscoKey":   "discokey:d5cbaebd55f16bc0bbe00f5c938d9b390d3bf766cc342f53b6dbaebaa543dd15",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45948",
+					"10.65.0.27:45948",
+					"172.17.0.1:45948",
+					"172.18.0.1:45948",
+					"172.19.0.1:45948",
+					"172.20.0.1:45948",
+					"172.21.0.1:45948",
+					"172.22.0.1:45948",
+					"172.23.0.1:45948",
+					"172.24.0.1:45948",
+					"172.25.0.1:45948",
+					"172.26.0.1:45948",
+					"172.27.0.1:45948",
+					"172.28.0.1:45948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:28:50.670295722Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3941036375649528,
+				"StableID":   "n9B85tLumX11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:517ab7e4d00428dcd9d4a9cc5439f9d83c76abaf94bb540b37f797fda655397b",
+				"DiscoKey":   "discokey:9458a746831846e5bace91cdf1333b8adb80e8cf3ecd4d24431b7cc36284c62c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:57560",
+					"10.65.0.27:57560",
+					"172.17.0.1:57560",
+					"172.18.0.1:57560",
+					"172.19.0.1:57560",
+					"172.20.0.1:57560",
+					"172.21.0.1:57560",
+					"172.22.0.1:57560",
+					"172.23.0.1:57560",
+					"172.24.0.1:57560",
+					"172.25.0.1:57560",
+					"172.26.0.1:57560",
+					"172.27.0.1:57560",
+					"172.28.0.1:57560"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:28:51.206482784Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8935913823923919,
+				"StableID":   "nC7D2cJ6nC21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c182045ac1a949ea6f5b9935e4797df1b236ad608c930c5756582b22d25a274e",
+				"DiscoKey":   "discokey:e50b97a3e204250db28ba9718c6ea1359b5ee9d40ebab0409c8161ccb2d63754",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53787",
+					"10.65.0.27:53787",
+					"172.17.0.1:53787",
+					"172.18.0.1:53787",
+					"172.19.0.1:53787",
+					"172.20.0.1:53787",
+					"172.21.0.1:53787",
+					"172.22.0.1:53787",
+					"172.23.0.1:53787",
+					"172.24.0.1:53787",
+					"172.25.0.1:53787",
+					"172.26.0.1:53787",
+					"172.27.0.1:53787",
+					"172.28.0.1:53787"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:28:51.81673023Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4091099345258174,
+				"StableID":   "nZU5q4FswY11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c7390a9fcadbb2338b0bba0fb361116b27d7e1130a39482e15c45b36a88eb0e",
+				"DiscoKey":   "discokey:dbb9c86e8c66e6d3a23242cc8a8a0ffc8c62fce8b92641d51e1fed860fe33046",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55414",
+					"10.65.0.27:55414",
+					"172.17.0.1:55414",
+					"172.18.0.1:55414",
+					"172.19.0.1:55414",
+					"172.20.0.1:55414",
+					"172.21.0.1:55414",
+					"172.22.0.1:55414",
+					"172.23.0.1:55414",
+					"172.24.0.1:55414",
+					"172.25.0.1:55414",
+					"172.26.0.1:55414",
+					"172.27.0.1:55414",
+					"172.28.0.1:55414"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:28:52.352784952Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7226997624776993,
+				"StableID":   "nG2qQRy7Sy11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:50a36e28a806c2fd2dd02c48f3bc1cae71ed401b7ba78dfafe77eb5754bc2046",
+				"DiscoKey":   "discokey:6accaa0042f08166c86b4f758fb3dd8596e84d791ddbd3d081517267f9243d74",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41999",
+					"10.65.0.27:41999",
+					"172.17.0.1:41999",
+					"172.18.0.1:41999",
+					"172.19.0.1:41999",
+					"172.20.0.1:41999",
+					"172.21.0.1:41999",
+					"172.22.0.1:41999",
+					"172.23.0.1:41999",
+					"172.24.0.1:41999",
+					"172.25.0.1:41999",
+					"172.26.0.1:41999",
+					"172.27.0.1:41999",
+					"172.28.0.1:41999"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:28:52.888604203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3753295234958883,
+				"StableID":   "nvxjMghsJW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a51ba4c771f8e5dccbe174bb608c8b39a571f610f4f5f37723a5ffa87fcf3364",
+				"KeyExpiry":  "2026-11-09T09:28:53Z",
+				"DiscoKey":   "discokey:6fa64763400c756c62d2abd5afb60ff5d637ee94214416082f546399f8f4ca2c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:37685",
+					"10.65.0.27:37685",
+					"172.17.0.1:37685",
+					"172.18.0.1:37685",
+					"172.19.0.1:37685",
+					"172.20.0.1:37685",
+					"172.21.0.1:37685",
+					"172.22.0.1:37685",
+					"172.23.0.1:37685",
+					"172.24.0.1:37685",
+					"172.25.0.1:37685",
+					"172.26.0.1:37685",
+					"172.27.0.1:37685",
+					"172.28.0.1:37685"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:28:53.423566519Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7899574873613674,
+				"StableID":   "nfhxkKSjg421CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:badae06a11903c36804634dd8e953652d6f0a06466abca3ddc1b582502db841d",
+				"KeyExpiry":  "2026-11-09T09:28:53Z",
+				"DiscoKey":   "discokey:05c3975fd2b82ae84653c9ea53e1969ce520b61a56d15335f69c8e594ff8d551",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:43857",
+					"10.65.0.27:43857",
+					"172.17.0.1:43857",
+					"172.18.0.1:43857",
+					"172.19.0.1:43857",
+					"172.20.0.1:43857",
+					"172.21.0.1:43857",
+					"172.22.0.1:43857",
+					"172.23.0.1:43857",
+					"172.24.0.1:43857",
+					"172.25.0.1:43857",
+					"172.26.0.1:43857",
+					"172.27.0.1:43857",
+					"172.28.0.1:43857"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:28:53.958495612Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5592242659501955,
+				"StableID":   "nkTv5Tjjfk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a81dc878ad9dae73b27a4940f9e3fb7b38d13cbaa36157c8e261292fa79dac51",
+				"KeyExpiry":  "2026-11-09T09:28:54Z",
+				"DiscoKey":   "discokey:5d5e468fd860cd130fc7e408223346f08ea9681b78eef3f4766d828179144d5f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59674",
+					"10.65.0.27:59674",
+					"172.17.0.1:59674",
+					"172.18.0.1:59674",
+					"172.19.0.1:59674",
+					"172.20.0.1:59674",
+					"172.21.0.1:59674",
+					"172.22.0.1:59674",
+					"172.23.0.1:59674",
+					"172.24.0.1:59674",
+					"172.25.0.1:59674",
+					"172.26.0.1:59674",
+					"172.27.0.1:59674",
+					"172.28.0.1:59674"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:28:54.496611041Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2710951987489957": {
+				"ID":          2710951987489957,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3941036375649528,
+				"StableID":   "n9B85tLumX11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       3941036375649528,
+				"Key":        "nodekey:517ab7e4d00428dcd9d4a9cc5439f9d83c76abaf94bb540b37f797fda655397b",
+				"DiscoKey":   "discokey:9458a746831846e5bace91cdf1333b8adb80e8cf3ecd4d24431b7cc36284c62c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:57560",
+					"10.65.0.27:57560",
+					"172.17.0.1:57560",
+					"172.18.0.1:57560",
+					"172.19.0.1:57560",
+					"172.20.0.1:57560",
+					"172.21.0.1:57560",
+					"172.22.0.1:57560",
+					"172.23.0.1:57560",
+					"172.24.0.1:57560",
+					"172.25.0.1:57560",
+					"172.26.0.1:57560",
+					"172.27.0.1:57560",
+					"172.28.0.1:57560"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:28:51.206482784Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:517ab7e4d00428dcd9d4a9cc5439f9d83c76abaf94bb540b37f797fda655397b",
+			"MachineKey": "mkey:fcedf4c9b1f42dd90d11518e76487183c6de2fa34196dd57b4732e3969a7f414",
+			"Peers": [{
+				"ID":         5957838597252230,
+				"StableID":   "nTRQBQKKXo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:568fc47fb0b6966e883cb8e1cb7081f92bd09663eb43b1cdc5cda20a22e7922f",
+				"DiscoKey":   "discokey:80f8ed39da13b7bcbaeb85bcc66add4a5a7ca06df7cee5efc95ee395b4df4704",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46427",
+					"10.65.0.27:46427",
+					"172.17.0.1:46427",
+					"172.18.0.1:46427",
+					"172.19.0.1:46427",
+					"172.20.0.1:46427",
+					"172.21.0.1:46427",
+					"172.22.0.1:46427",
+					"172.23.0.1:46427",
+					"172.24.0.1:46427",
+					"172.25.0.1:46427",
+					"172.26.0.1:46427",
+					"172.27.0.1:46427",
+					"172.28.0.1:46427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:28:46.697626311Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7491435254768900,
+				"StableID":   "nMwSFTJtV121CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f57470fdb5acc6ffcb1afd1bcb9852dff1bcb2e4c1c8bdb33e1974c11186632a",
+				"DiscoKey":   "discokey:d30496c97aa5d06bc840ed4cb8c86dd86d73762309fb655839cba15275465719",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:57165",
+					"10.65.0.27:57165",
+					"172.17.0.1:57165",
+					"172.18.0.1:57165",
+					"172.19.0.1:57165",
+					"172.20.0.1:57165",
+					"172.21.0.1:57165",
+					"172.22.0.1:57165",
+					"172.23.0.1:57165",
+					"172.24.0.1:57165",
+					"172.25.0.1:57165",
+					"172.26.0.1:57165",
+					"172.27.0.1:57165",
+					"172.28.0.1:57165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:28:47.21316036Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5240277471551194,
+				"StableID":   "nsh5gnCLvh11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6133fe33ffa51e5444886acb1b9ccdfe163a3bc1b7a092b170b0300b2e327e62",
+				"DiscoKey":   "discokey:9dbf998e101d3701c08c6c150915a9c614a8e4d2184679e09f44cdd38877fb37",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:37400",
+					"10.65.0.27:37400",
+					"172.17.0.1:37400",
+					"172.18.0.1:37400",
+					"172.19.0.1:37400",
+					"172.20.0.1:37400",
+					"172.21.0.1:37400",
+					"172.22.0.1:37400",
+					"172.23.0.1:37400",
+					"172.24.0.1:37400",
+					"172.25.0.1:37400",
+					"172.26.0.1:37400",
+					"172.27.0.1:37400",
+					"172.28.0.1:37400"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:28:47.75087018Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4363475266036325,
+				"StableID":   "n6FxEa6E5b11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4ab3b25c361ce76192c7bb7de4eaa52edb2b609db7ab3e9c5cd27b5b48ea641",
+				"DiscoKey":   "discokey:8c690d866f20c3667bb18a3c9b5e7ec12bddc21a0a8c4cac482632d646491e11",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43562",
+					"10.65.0.27:43562",
+					"172.17.0.1:43562",
+					"172.18.0.1:43562",
+					"172.19.0.1:43562",
+					"172.20.0.1:43562",
+					"172.21.0.1:43562",
+					"172.22.0.1:43562",
+					"172.23.0.1:43562",
+					"172.24.0.1:43562",
+					"172.25.0.1:43562",
+					"172.26.0.1:43562",
+					"172.27.0.1:43562",
+					"172.28.0.1:43562"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:28:48.280253327Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         909310783077211,
+				"StableID":   "ntuV734q6811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8edca3deebe2ceaea15075262b354da60313aa6201f2f1493a0e8684b0fe207c",
+				"DiscoKey":   "discokey:46fd17122baeabb311910115ef13847ad90880c90487487905ee812f07d37447",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52004",
+					"10.65.0.27:52004",
+					"172.17.0.1:52004",
+					"172.18.0.1:52004",
+					"172.19.0.1:52004",
+					"172.20.0.1:52004",
+					"172.21.0.1:52004",
+					"172.22.0.1:52004",
+					"172.23.0.1:52004",
+					"172.24.0.1:52004",
+					"172.25.0.1:52004",
+					"172.26.0.1:52004",
+					"172.27.0.1:52004",
+					"172.28.0.1:52004"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:28:48.908611477Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7745891296835908,
+				"StableID":   "nh5tLvR8V321CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41f059a70061d6f70e7197367d3731145e6ab586cb69825226a952ce53669f3d",
+				"DiscoKey":   "discokey:2dcf4e0fb98d432ccc7a62c1dbc721ab09f388cb22f559fbd24e1a71c6cdfb0c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52807",
+					"10.65.0.27:52807",
+					"172.17.0.1:52807",
+					"172.18.0.1:52807",
+					"172.19.0.1:52807",
+					"172.20.0.1:52807",
+					"172.21.0.1:52807",
+					"172.22.0.1:52807",
+					"172.23.0.1:52807",
+					"172.24.0.1:52807",
+					"172.25.0.1:52807",
+					"172.26.0.1:52807",
+					"172.27.0.1:52807",
+					"172.28.0.1:52807"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:28:49.610332949Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2710951987489957,
+				"StableID":   "nYr6vU7oAN11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f5c60b60b29ffdd49afe634a54b157d9e559467c4756f3e3bb748f1f8e67ee29",
+				"DiscoKey":   "discokey:071b44d9f2887164b4bb56d67ac0ca7118bc4f88b350fa2751d3995a78574b40",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50109",
+					"10.65.0.27:50109",
+					"172.17.0.1:50109",
+					"172.18.0.1:50109",
+					"172.19.0.1:50109",
+					"172.20.0.1:50109",
+					"172.21.0.1:50109",
+					"172.22.0.1:50109",
+					"172.23.0.1:50109",
+					"172.24.0.1:50109",
+					"172.25.0.1:50109",
+					"172.26.0.1:50109",
+					"172.27.0.1:50109",
+					"172.28.0.1:50109"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:28:50.142420965Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4259375241172312,
+				"StableID":   "nKazWmZ5Ga11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51e0e9a2becd35f2a5b892a48c67966775919aa302d974845a96427888200b6d",
+				"DiscoKey":   "discokey:d5cbaebd55f16bc0bbe00f5c938d9b390d3bf766cc342f53b6dbaebaa543dd15",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45948",
+					"10.65.0.27:45948",
+					"172.17.0.1:45948",
+					"172.18.0.1:45948",
+					"172.19.0.1:45948",
+					"172.20.0.1:45948",
+					"172.21.0.1:45948",
+					"172.22.0.1:45948",
+					"172.23.0.1:45948",
+					"172.24.0.1:45948",
+					"172.25.0.1:45948",
+					"172.26.0.1:45948",
+					"172.27.0.1:45948",
+					"172.28.0.1:45948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:28:50.670295722Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8935913823923919,
+				"StableID":   "nC7D2cJ6nC21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c182045ac1a949ea6f5b9935e4797df1b236ad608c930c5756582b22d25a274e",
+				"DiscoKey":   "discokey:e50b97a3e204250db28ba9718c6ea1359b5ee9d40ebab0409c8161ccb2d63754",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53787",
+					"10.65.0.27:53787",
+					"172.17.0.1:53787",
+					"172.18.0.1:53787",
+					"172.19.0.1:53787",
+					"172.20.0.1:53787",
+					"172.21.0.1:53787",
+					"172.22.0.1:53787",
+					"172.23.0.1:53787",
+					"172.24.0.1:53787",
+					"172.25.0.1:53787",
+					"172.26.0.1:53787",
+					"172.27.0.1:53787",
+					"172.28.0.1:53787"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:28:51.81673023Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4091099345258174,
+				"StableID":   "nZU5q4FswY11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c7390a9fcadbb2338b0bba0fb361116b27d7e1130a39482e15c45b36a88eb0e",
+				"DiscoKey":   "discokey:dbb9c86e8c66e6d3a23242cc8a8a0ffc8c62fce8b92641d51e1fed860fe33046",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55414",
+					"10.65.0.27:55414",
+					"172.17.0.1:55414",
+					"172.18.0.1:55414",
+					"172.19.0.1:55414",
+					"172.20.0.1:55414",
+					"172.21.0.1:55414",
+					"172.22.0.1:55414",
+					"172.23.0.1:55414",
+					"172.24.0.1:55414",
+					"172.25.0.1:55414",
+					"172.26.0.1:55414",
+					"172.27.0.1:55414",
+					"172.28.0.1:55414"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:28:52.352784952Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7226997624776993,
+				"StableID":   "nG2qQRy7Sy11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:50a36e28a806c2fd2dd02c48f3bc1cae71ed401b7ba78dfafe77eb5754bc2046",
+				"DiscoKey":   "discokey:6accaa0042f08166c86b4f758fb3dd8596e84d791ddbd3d081517267f9243d74",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41999",
+					"10.65.0.27:41999",
+					"172.17.0.1:41999",
+					"172.18.0.1:41999",
+					"172.19.0.1:41999",
+					"172.20.0.1:41999",
+					"172.21.0.1:41999",
+					"172.22.0.1:41999",
+					"172.23.0.1:41999",
+					"172.24.0.1:41999",
+					"172.25.0.1:41999",
+					"172.26.0.1:41999",
+					"172.27.0.1:41999",
+					"172.28.0.1:41999"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:28:52.888604203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3753295234958883,
+				"StableID":   "nvxjMghsJW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a51ba4c771f8e5dccbe174bb608c8b39a571f610f4f5f37723a5ffa87fcf3364",
+				"KeyExpiry":  "2026-11-09T09:28:53Z",
+				"DiscoKey":   "discokey:6fa64763400c756c62d2abd5afb60ff5d637ee94214416082f546399f8f4ca2c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:37685",
+					"10.65.0.27:37685",
+					"172.17.0.1:37685",
+					"172.18.0.1:37685",
+					"172.19.0.1:37685",
+					"172.20.0.1:37685",
+					"172.21.0.1:37685",
+					"172.22.0.1:37685",
+					"172.23.0.1:37685",
+					"172.24.0.1:37685",
+					"172.25.0.1:37685",
+					"172.26.0.1:37685",
+					"172.27.0.1:37685",
+					"172.28.0.1:37685"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:28:53.423566519Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7899574873613674,
+				"StableID":   "nfhxkKSjg421CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:badae06a11903c36804634dd8e953652d6f0a06466abca3ddc1b582502db841d",
+				"KeyExpiry":  "2026-11-09T09:28:53Z",
+				"DiscoKey":   "discokey:05c3975fd2b82ae84653c9ea53e1969ce520b61a56d15335f69c8e594ff8d551",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:43857",
+					"10.65.0.27:43857",
+					"172.17.0.1:43857",
+					"172.18.0.1:43857",
+					"172.19.0.1:43857",
+					"172.20.0.1:43857",
+					"172.21.0.1:43857",
+					"172.22.0.1:43857",
+					"172.23.0.1:43857",
+					"172.24.0.1:43857",
+					"172.25.0.1:43857",
+					"172.26.0.1:43857",
+					"172.27.0.1:43857",
+					"172.28.0.1:43857"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:28:53.958495612Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5592242659501955,
+				"StableID":   "nkTv5Tjjfk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a81dc878ad9dae73b27a4940f9e3fb7b38d13cbaa36157c8e261292fa79dac51",
+				"KeyExpiry":  "2026-11-09T09:28:54Z",
+				"DiscoKey":   "discokey:5d5e468fd860cd130fc7e408223346f08ea9681b78eef3f4766d828179144d5f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59674",
+					"10.65.0.27:59674",
+					"172.17.0.1:59674",
+					"172.18.0.1:59674",
+					"172.19.0.1:59674",
+					"172.20.0.1:59674",
+					"172.21.0.1:59674",
+					"172.22.0.1:59674",
+					"172.23.0.1:59674",
+					"172.24.0.1:59674",
+					"172.25.0.1:59674",
+					"172.26.0.1:59674",
+					"172.27.0.1:59674",
+					"172.28.0.1:59674"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:28:54.496611041Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3941036375649528": {
+				"ID":          3941036375649528,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7899574873613674,
+				"StableID":   "nfhxkKSjg421CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:badae06a11903c36804634dd8e953652d6f0a06466abca3ddc1b582502db841d",
+				"KeyExpiry":  "2026-11-09T09:28:53Z",
+				"DiscoKey":   "discokey:05c3975fd2b82ae84653c9ea53e1969ce520b61a56d15335f69c8e594ff8d551",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:43857",
+					"10.65.0.27:43857",
+					"172.17.0.1:43857",
+					"172.18.0.1:43857",
+					"172.19.0.1:43857",
+					"172.20.0.1:43857",
+					"172.21.0.1:43857",
+					"172.22.0.1:43857",
+					"172.23.0.1:43857",
+					"172.24.0.1:43857",
+					"172.25.0.1:43857",
+					"172.26.0.1:43857",
+					"172.27.0.1:43857",
+					"172.28.0.1:43857"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:28:53.958495612Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:badae06a11903c36804634dd8e953652d6f0a06466abca3ddc1b582502db841d",
+			"MachineKey": "mkey:679eb79795d10e2e69ba431070d485cf97fbc7522d814020063c3a97f53d2a27",
+			"Peers": [{
+				"ID":         5957838597252230,
+				"StableID":   "nTRQBQKKXo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:568fc47fb0b6966e883cb8e1cb7081f92bd09663eb43b1cdc5cda20a22e7922f",
+				"DiscoKey":   "discokey:80f8ed39da13b7bcbaeb85bcc66add4a5a7ca06df7cee5efc95ee395b4df4704",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46427",
+					"10.65.0.27:46427",
+					"172.17.0.1:46427",
+					"172.18.0.1:46427",
+					"172.19.0.1:46427",
+					"172.20.0.1:46427",
+					"172.21.0.1:46427",
+					"172.22.0.1:46427",
+					"172.23.0.1:46427",
+					"172.24.0.1:46427",
+					"172.25.0.1:46427",
+					"172.26.0.1:46427",
+					"172.27.0.1:46427",
+					"172.28.0.1:46427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:28:46.697626311Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7491435254768900,
+				"StableID":   "nMwSFTJtV121CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f57470fdb5acc6ffcb1afd1bcb9852dff1bcb2e4c1c8bdb33e1974c11186632a",
+				"DiscoKey":   "discokey:d30496c97aa5d06bc840ed4cb8c86dd86d73762309fb655839cba15275465719",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:57165",
+					"10.65.0.27:57165",
+					"172.17.0.1:57165",
+					"172.18.0.1:57165",
+					"172.19.0.1:57165",
+					"172.20.0.1:57165",
+					"172.21.0.1:57165",
+					"172.22.0.1:57165",
+					"172.23.0.1:57165",
+					"172.24.0.1:57165",
+					"172.25.0.1:57165",
+					"172.26.0.1:57165",
+					"172.27.0.1:57165",
+					"172.28.0.1:57165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:28:47.21316036Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5240277471551194,
+				"StableID":   "nsh5gnCLvh11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6133fe33ffa51e5444886acb1b9ccdfe163a3bc1b7a092b170b0300b2e327e62",
+				"DiscoKey":   "discokey:9dbf998e101d3701c08c6c150915a9c614a8e4d2184679e09f44cdd38877fb37",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:37400",
+					"10.65.0.27:37400",
+					"172.17.0.1:37400",
+					"172.18.0.1:37400",
+					"172.19.0.1:37400",
+					"172.20.0.1:37400",
+					"172.21.0.1:37400",
+					"172.22.0.1:37400",
+					"172.23.0.1:37400",
+					"172.24.0.1:37400",
+					"172.25.0.1:37400",
+					"172.26.0.1:37400",
+					"172.27.0.1:37400",
+					"172.28.0.1:37400"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:28:47.75087018Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4363475266036325,
+				"StableID":   "n6FxEa6E5b11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4ab3b25c361ce76192c7bb7de4eaa52edb2b609db7ab3e9c5cd27b5b48ea641",
+				"DiscoKey":   "discokey:8c690d866f20c3667bb18a3c9b5e7ec12bddc21a0a8c4cac482632d646491e11",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43562",
+					"10.65.0.27:43562",
+					"172.17.0.1:43562",
+					"172.18.0.1:43562",
+					"172.19.0.1:43562",
+					"172.20.0.1:43562",
+					"172.21.0.1:43562",
+					"172.22.0.1:43562",
+					"172.23.0.1:43562",
+					"172.24.0.1:43562",
+					"172.25.0.1:43562",
+					"172.26.0.1:43562",
+					"172.27.0.1:43562",
+					"172.28.0.1:43562"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:28:48.280253327Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         909310783077211,
+				"StableID":   "ntuV734q6811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8edca3deebe2ceaea15075262b354da60313aa6201f2f1493a0e8684b0fe207c",
+				"DiscoKey":   "discokey:46fd17122baeabb311910115ef13847ad90880c90487487905ee812f07d37447",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52004",
+					"10.65.0.27:52004",
+					"172.17.0.1:52004",
+					"172.18.0.1:52004",
+					"172.19.0.1:52004",
+					"172.20.0.1:52004",
+					"172.21.0.1:52004",
+					"172.22.0.1:52004",
+					"172.23.0.1:52004",
+					"172.24.0.1:52004",
+					"172.25.0.1:52004",
+					"172.26.0.1:52004",
+					"172.27.0.1:52004",
+					"172.28.0.1:52004"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:28:48.908611477Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7745891296835908,
+				"StableID":   "nh5tLvR8V321CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41f059a70061d6f70e7197367d3731145e6ab586cb69825226a952ce53669f3d",
+				"DiscoKey":   "discokey:2dcf4e0fb98d432ccc7a62c1dbc721ab09f388cb22f559fbd24e1a71c6cdfb0c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52807",
+					"10.65.0.27:52807",
+					"172.17.0.1:52807",
+					"172.18.0.1:52807",
+					"172.19.0.1:52807",
+					"172.20.0.1:52807",
+					"172.21.0.1:52807",
+					"172.22.0.1:52807",
+					"172.23.0.1:52807",
+					"172.24.0.1:52807",
+					"172.25.0.1:52807",
+					"172.26.0.1:52807",
+					"172.27.0.1:52807",
+					"172.28.0.1:52807"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:28:49.610332949Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2710951987489957,
+				"StableID":   "nYr6vU7oAN11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f5c60b60b29ffdd49afe634a54b157d9e559467c4756f3e3bb748f1f8e67ee29",
+				"DiscoKey":   "discokey:071b44d9f2887164b4bb56d67ac0ca7118bc4f88b350fa2751d3995a78574b40",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50109",
+					"10.65.0.27:50109",
+					"172.17.0.1:50109",
+					"172.18.0.1:50109",
+					"172.19.0.1:50109",
+					"172.20.0.1:50109",
+					"172.21.0.1:50109",
+					"172.22.0.1:50109",
+					"172.23.0.1:50109",
+					"172.24.0.1:50109",
+					"172.25.0.1:50109",
+					"172.26.0.1:50109",
+					"172.27.0.1:50109",
+					"172.28.0.1:50109"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:28:50.142420965Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4259375241172312,
+				"StableID":   "nKazWmZ5Ga11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51e0e9a2becd35f2a5b892a48c67966775919aa302d974845a96427888200b6d",
+				"DiscoKey":   "discokey:d5cbaebd55f16bc0bbe00f5c938d9b390d3bf766cc342f53b6dbaebaa543dd15",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45948",
+					"10.65.0.27:45948",
+					"172.17.0.1:45948",
+					"172.18.0.1:45948",
+					"172.19.0.1:45948",
+					"172.20.0.1:45948",
+					"172.21.0.1:45948",
+					"172.22.0.1:45948",
+					"172.23.0.1:45948",
+					"172.24.0.1:45948",
+					"172.25.0.1:45948",
+					"172.26.0.1:45948",
+					"172.27.0.1:45948",
+					"172.28.0.1:45948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:28:50.670295722Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3941036375649528,
+				"StableID":   "n9B85tLumX11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:517ab7e4d00428dcd9d4a9cc5439f9d83c76abaf94bb540b37f797fda655397b",
+				"DiscoKey":   "discokey:9458a746831846e5bace91cdf1333b8adb80e8cf3ecd4d24431b7cc36284c62c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:57560",
+					"10.65.0.27:57560",
+					"172.17.0.1:57560",
+					"172.18.0.1:57560",
+					"172.19.0.1:57560",
+					"172.20.0.1:57560",
+					"172.21.0.1:57560",
+					"172.22.0.1:57560",
+					"172.23.0.1:57560",
+					"172.24.0.1:57560",
+					"172.25.0.1:57560",
+					"172.26.0.1:57560",
+					"172.27.0.1:57560",
+					"172.28.0.1:57560"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:28:51.206482784Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8935913823923919,
+				"StableID":   "nC7D2cJ6nC21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c182045ac1a949ea6f5b9935e4797df1b236ad608c930c5756582b22d25a274e",
+				"DiscoKey":   "discokey:e50b97a3e204250db28ba9718c6ea1359b5ee9d40ebab0409c8161ccb2d63754",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53787",
+					"10.65.0.27:53787",
+					"172.17.0.1:53787",
+					"172.18.0.1:53787",
+					"172.19.0.1:53787",
+					"172.20.0.1:53787",
+					"172.21.0.1:53787",
+					"172.22.0.1:53787",
+					"172.23.0.1:53787",
+					"172.24.0.1:53787",
+					"172.25.0.1:53787",
+					"172.26.0.1:53787",
+					"172.27.0.1:53787",
+					"172.28.0.1:53787"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:28:51.81673023Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4091099345258174,
+				"StableID":   "nZU5q4FswY11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c7390a9fcadbb2338b0bba0fb361116b27d7e1130a39482e15c45b36a88eb0e",
+				"DiscoKey":   "discokey:dbb9c86e8c66e6d3a23242cc8a8a0ffc8c62fce8b92641d51e1fed860fe33046",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55414",
+					"10.65.0.27:55414",
+					"172.17.0.1:55414",
+					"172.18.0.1:55414",
+					"172.19.0.1:55414",
+					"172.20.0.1:55414",
+					"172.21.0.1:55414",
+					"172.22.0.1:55414",
+					"172.23.0.1:55414",
+					"172.24.0.1:55414",
+					"172.25.0.1:55414",
+					"172.26.0.1:55414",
+					"172.27.0.1:55414",
+					"172.28.0.1:55414"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:28:52.352784952Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7226997624776993,
+				"StableID":   "nG2qQRy7Sy11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:50a36e28a806c2fd2dd02c48f3bc1cae71ed401b7ba78dfafe77eb5754bc2046",
+				"DiscoKey":   "discokey:6accaa0042f08166c86b4f758fb3dd8596e84d791ddbd3d081517267f9243d74",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41999",
+					"10.65.0.27:41999",
+					"172.17.0.1:41999",
+					"172.18.0.1:41999",
+					"172.19.0.1:41999",
+					"172.20.0.1:41999",
+					"172.21.0.1:41999",
+					"172.22.0.1:41999",
+					"172.23.0.1:41999",
+					"172.24.0.1:41999",
+					"172.25.0.1:41999",
+					"172.26.0.1:41999",
+					"172.27.0.1:41999",
+					"172.28.0.1:41999"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:28:52.888604203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3753295234958883,
+				"StableID":   "nvxjMghsJW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a51ba4c771f8e5dccbe174bb608c8b39a571f610f4f5f37723a5ffa87fcf3364",
+				"KeyExpiry":  "2026-11-09T09:28:53Z",
+				"DiscoKey":   "discokey:6fa64763400c756c62d2abd5afb60ff5d637ee94214416082f546399f8f4ca2c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:37685",
+					"10.65.0.27:37685",
+					"172.17.0.1:37685",
+					"172.18.0.1:37685",
+					"172.19.0.1:37685",
+					"172.20.0.1:37685",
+					"172.21.0.1:37685",
+					"172.22.0.1:37685",
+					"172.23.0.1:37685",
+					"172.24.0.1:37685",
+					"172.25.0.1:37685",
+					"172.26.0.1:37685",
+					"172.27.0.1:37685",
+					"172.28.0.1:37685"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:28:53.423566519Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5592242659501955,
+				"StableID":   "nkTv5Tjjfk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a81dc878ad9dae73b27a4940f9e3fb7b38d13cbaa36157c8e261292fa79dac51",
+				"KeyExpiry":  "2026-11-09T09:28:54Z",
+				"DiscoKey":   "discokey:5d5e468fd860cd130fc7e408223346f08ea9681b78eef3f4766d828179144d5f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59674",
+					"10.65.0.27:59674",
+					"172.17.0.1:59674",
+					"172.18.0.1:59674",
+					"172.19.0.1:59674",
+					"172.20.0.1:59674",
+					"172.21.0.1:59674",
+					"172.22.0.1:59674",
+					"172.23.0.1:59674",
+					"172.24.0.1:59674",
+					"172.25.0.1:59674",
+					"172.26.0.1:59674",
+					"172.27.0.1:59674",
+					"172.28.0.1:59674"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:28:54.496611041Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8935913823923919,
+				"StableID":   "nC7D2cJ6nC21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       8935913823923919,
+				"Key":        "nodekey:c182045ac1a949ea6f5b9935e4797df1b236ad608c930c5756582b22d25a274e",
+				"DiscoKey":   "discokey:e50b97a3e204250db28ba9718c6ea1359b5ee9d40ebab0409c8161ccb2d63754",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53787",
+					"10.65.0.27:53787",
+					"172.17.0.1:53787",
+					"172.18.0.1:53787",
+					"172.19.0.1:53787",
+					"172.20.0.1:53787",
+					"172.21.0.1:53787",
+					"172.22.0.1:53787",
+					"172.23.0.1:53787",
+					"172.24.0.1:53787",
+					"172.25.0.1:53787",
+					"172.26.0.1:53787",
+					"172.27.0.1:53787",
+					"172.28.0.1:53787"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:28:51.81673023Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c182045ac1a949ea6f5b9935e4797df1b236ad608c930c5756582b22d25a274e",
+			"MachineKey": "mkey:a2eb291ce5a0ddcf3fdc803cbb8c4f14cdd5237d3d4dbe469446fa077b734a20",
+			"Peers": [{
+				"ID":         5957838597252230,
+				"StableID":   "nTRQBQKKXo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:568fc47fb0b6966e883cb8e1cb7081f92bd09663eb43b1cdc5cda20a22e7922f",
+				"DiscoKey":   "discokey:80f8ed39da13b7bcbaeb85bcc66add4a5a7ca06df7cee5efc95ee395b4df4704",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46427",
+					"10.65.0.27:46427",
+					"172.17.0.1:46427",
+					"172.18.0.1:46427",
+					"172.19.0.1:46427",
+					"172.20.0.1:46427",
+					"172.21.0.1:46427",
+					"172.22.0.1:46427",
+					"172.23.0.1:46427",
+					"172.24.0.1:46427",
+					"172.25.0.1:46427",
+					"172.26.0.1:46427",
+					"172.27.0.1:46427",
+					"172.28.0.1:46427"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:28:46.697626311Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7491435254768900,
+				"StableID":   "nMwSFTJtV121CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f57470fdb5acc6ffcb1afd1bcb9852dff1bcb2e4c1c8bdb33e1974c11186632a",
+				"DiscoKey":   "discokey:d30496c97aa5d06bc840ed4cb8c86dd86d73762309fb655839cba15275465719",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:57165",
+					"10.65.0.27:57165",
+					"172.17.0.1:57165",
+					"172.18.0.1:57165",
+					"172.19.0.1:57165",
+					"172.20.0.1:57165",
+					"172.21.0.1:57165",
+					"172.22.0.1:57165",
+					"172.23.0.1:57165",
+					"172.24.0.1:57165",
+					"172.25.0.1:57165",
+					"172.26.0.1:57165",
+					"172.27.0.1:57165",
+					"172.28.0.1:57165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:28:47.21316036Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5240277471551194,
+				"StableID":   "nsh5gnCLvh11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6133fe33ffa51e5444886acb1b9ccdfe163a3bc1b7a092b170b0300b2e327e62",
+				"DiscoKey":   "discokey:9dbf998e101d3701c08c6c150915a9c614a8e4d2184679e09f44cdd38877fb37",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:37400",
+					"10.65.0.27:37400",
+					"172.17.0.1:37400",
+					"172.18.0.1:37400",
+					"172.19.0.1:37400",
+					"172.20.0.1:37400",
+					"172.21.0.1:37400",
+					"172.22.0.1:37400",
+					"172.23.0.1:37400",
+					"172.24.0.1:37400",
+					"172.25.0.1:37400",
+					"172.26.0.1:37400",
+					"172.27.0.1:37400",
+					"172.28.0.1:37400"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:28:47.75087018Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4363475266036325,
+				"StableID":   "n6FxEa6E5b11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a4ab3b25c361ce76192c7bb7de4eaa52edb2b609db7ab3e9c5cd27b5b48ea641",
+				"DiscoKey":   "discokey:8c690d866f20c3667bb18a3c9b5e7ec12bddc21a0a8c4cac482632d646491e11",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43562",
+					"10.65.0.27:43562",
+					"172.17.0.1:43562",
+					"172.18.0.1:43562",
+					"172.19.0.1:43562",
+					"172.20.0.1:43562",
+					"172.21.0.1:43562",
+					"172.22.0.1:43562",
+					"172.23.0.1:43562",
+					"172.24.0.1:43562",
+					"172.25.0.1:43562",
+					"172.26.0.1:43562",
+					"172.27.0.1:43562",
+					"172.28.0.1:43562"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:28:48.280253327Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         909310783077211,
+				"StableID":   "ntuV734q6811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8edca3deebe2ceaea15075262b354da60313aa6201f2f1493a0e8684b0fe207c",
+				"DiscoKey":   "discokey:46fd17122baeabb311910115ef13847ad90880c90487487905ee812f07d37447",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52004",
+					"10.65.0.27:52004",
+					"172.17.0.1:52004",
+					"172.18.0.1:52004",
+					"172.19.0.1:52004",
+					"172.20.0.1:52004",
+					"172.21.0.1:52004",
+					"172.22.0.1:52004",
+					"172.23.0.1:52004",
+					"172.24.0.1:52004",
+					"172.25.0.1:52004",
+					"172.26.0.1:52004",
+					"172.27.0.1:52004",
+					"172.28.0.1:52004"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:28:48.908611477Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7745891296835908,
+				"StableID":   "nh5tLvR8V321CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41f059a70061d6f70e7197367d3731145e6ab586cb69825226a952ce53669f3d",
+				"DiscoKey":   "discokey:2dcf4e0fb98d432ccc7a62c1dbc721ab09f388cb22f559fbd24e1a71c6cdfb0c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:52807",
+					"10.65.0.27:52807",
+					"172.17.0.1:52807",
+					"172.18.0.1:52807",
+					"172.19.0.1:52807",
+					"172.20.0.1:52807",
+					"172.21.0.1:52807",
+					"172.22.0.1:52807",
+					"172.23.0.1:52807",
+					"172.24.0.1:52807",
+					"172.25.0.1:52807",
+					"172.26.0.1:52807",
+					"172.27.0.1:52807",
+					"172.28.0.1:52807"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:28:49.610332949Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2710951987489957,
+				"StableID":   "nYr6vU7oAN11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f5c60b60b29ffdd49afe634a54b157d9e559467c4756f3e3bb748f1f8e67ee29",
+				"DiscoKey":   "discokey:071b44d9f2887164b4bb56d67ac0ca7118bc4f88b350fa2751d3995a78574b40",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50109",
+					"10.65.0.27:50109",
+					"172.17.0.1:50109",
+					"172.18.0.1:50109",
+					"172.19.0.1:50109",
+					"172.20.0.1:50109",
+					"172.21.0.1:50109",
+					"172.22.0.1:50109",
+					"172.23.0.1:50109",
+					"172.24.0.1:50109",
+					"172.25.0.1:50109",
+					"172.26.0.1:50109",
+					"172.27.0.1:50109",
+					"172.28.0.1:50109"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:28:50.142420965Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4259375241172312,
+				"StableID":   "nKazWmZ5Ga11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51e0e9a2becd35f2a5b892a48c67966775919aa302d974845a96427888200b6d",
+				"DiscoKey":   "discokey:d5cbaebd55f16bc0bbe00f5c938d9b390d3bf766cc342f53b6dbaebaa543dd15",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:45948",
+					"10.65.0.27:45948",
+					"172.17.0.1:45948",
+					"172.18.0.1:45948",
+					"172.19.0.1:45948",
+					"172.20.0.1:45948",
+					"172.21.0.1:45948",
+					"172.22.0.1:45948",
+					"172.23.0.1:45948",
+					"172.24.0.1:45948",
+					"172.25.0.1:45948",
+					"172.26.0.1:45948",
+					"172.27.0.1:45948",
+					"172.28.0.1:45948"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:28:50.670295722Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3941036375649528,
+				"StableID":   "n9B85tLumX11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:517ab7e4d00428dcd9d4a9cc5439f9d83c76abaf94bb540b37f797fda655397b",
+				"DiscoKey":   "discokey:9458a746831846e5bace91cdf1333b8adb80e8cf3ecd4d24431b7cc36284c62c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:57560",
+					"10.65.0.27:57560",
+					"172.17.0.1:57560",
+					"172.18.0.1:57560",
+					"172.19.0.1:57560",
+					"172.20.0.1:57560",
+					"172.21.0.1:57560",
+					"172.22.0.1:57560",
+					"172.23.0.1:57560",
+					"172.24.0.1:57560",
+					"172.25.0.1:57560",
+					"172.26.0.1:57560",
+					"172.27.0.1:57560",
+					"172.28.0.1:57560"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:28:51.206482784Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4091099345258174,
+				"StableID":   "nZU5q4FswY11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c7390a9fcadbb2338b0bba0fb361116b27d7e1130a39482e15c45b36a88eb0e",
+				"DiscoKey":   "discokey:dbb9c86e8c66e6d3a23242cc8a8a0ffc8c62fce8b92641d51e1fed860fe33046",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55414",
+					"10.65.0.27:55414",
+					"172.17.0.1:55414",
+					"172.18.0.1:55414",
+					"172.19.0.1:55414",
+					"172.20.0.1:55414",
+					"172.21.0.1:55414",
+					"172.22.0.1:55414",
+					"172.23.0.1:55414",
+					"172.24.0.1:55414",
+					"172.25.0.1:55414",
+					"172.26.0.1:55414",
+					"172.27.0.1:55414",
+					"172.28.0.1:55414"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:28:52.352784952Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7226997624776993,
+				"StableID":   "nG2qQRy7Sy11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:50a36e28a806c2fd2dd02c48f3bc1cae71ed401b7ba78dfafe77eb5754bc2046",
+				"DiscoKey":   "discokey:6accaa0042f08166c86b4f758fb3dd8596e84d791ddbd3d081517267f9243d74",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41999",
+					"10.65.0.27:41999",
+					"172.17.0.1:41999",
+					"172.18.0.1:41999",
+					"172.19.0.1:41999",
+					"172.20.0.1:41999",
+					"172.21.0.1:41999",
+					"172.22.0.1:41999",
+					"172.23.0.1:41999",
+					"172.24.0.1:41999",
+					"172.25.0.1:41999",
+					"172.26.0.1:41999",
+					"172.27.0.1:41999",
+					"172.28.0.1:41999"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:28:52.888604203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3753295234958883,
+				"StableID":   "nvxjMghsJW11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a51ba4c771f8e5dccbe174bb608c8b39a571f610f4f5f37723a5ffa87fcf3364",
+				"KeyExpiry":  "2026-11-09T09:28:53Z",
+				"DiscoKey":   "discokey:6fa64763400c756c62d2abd5afb60ff5d637ee94214416082f546399f8f4ca2c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:37685",
+					"10.65.0.27:37685",
+					"172.17.0.1:37685",
+					"172.18.0.1:37685",
+					"172.19.0.1:37685",
+					"172.20.0.1:37685",
+					"172.21.0.1:37685",
+					"172.22.0.1:37685",
+					"172.23.0.1:37685",
+					"172.24.0.1:37685",
+					"172.25.0.1:37685",
+					"172.26.0.1:37685",
+					"172.27.0.1:37685",
+					"172.28.0.1:37685"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:28:53.423566519Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7899574873613674,
+				"StableID":   "nfhxkKSjg421CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:badae06a11903c36804634dd8e953652d6f0a06466abca3ddc1b582502db841d",
+				"KeyExpiry":  "2026-11-09T09:28:53Z",
+				"DiscoKey":   "discokey:05c3975fd2b82ae84653c9ea53e1969ce520b61a56d15335f69c8e594ff8d551",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:43857",
+					"10.65.0.27:43857",
+					"172.17.0.1:43857",
+					"172.18.0.1:43857",
+					"172.19.0.1:43857",
+					"172.20.0.1:43857",
+					"172.21.0.1:43857",
+					"172.22.0.1:43857",
+					"172.23.0.1:43857",
+					"172.24.0.1:43857",
+					"172.25.0.1:43857",
+					"172.26.0.1:43857",
+					"172.27.0.1:43857",
+					"172.28.0.1:43857"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:28:53.958495612Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5592242659501955,
+				"StableID":   "nkTv5Tjjfk11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:a81dc878ad9dae73b27a4940f9e3fb7b38d13cbaa36157c8e261292fa79dac51",
+				"KeyExpiry":  "2026-11-09T09:28:54Z",
+				"DiscoKey":   "discokey:5d5e468fd860cd130fc7e408223346f08ea9681b78eef3f4766d828179144d5f",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59674",
+					"10.65.0.27:59674",
+					"172.17.0.1:59674",
+					"172.18.0.1:59674",
+					"172.19.0.1:59674",
+					"172.20.0.1:59674",
+					"172.21.0.1:59674",
+					"172.22.0.1:59674",
+					"172.23.0.1:59674",
+					"172.24.0.1:59674",
+					"172.25.0.1:59674",
+					"172.26.0.1:59674",
+					"172.27.0.1:59674",
+					"172.28.0.1:59674"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:28:54.496611041Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8935913823923919": {
+				"ID":          8935913823923919,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/sshtest_results/sshtest-accept-and-deny-same-user.hujson
+++ b/hscontrol/policy/v2/testdata/sshtest_results/sshtest-accept-and-deny-same-user.hujson
@@ -1,0 +1,21887 @@
+// sshtest-accept-and-deny-same-user
+//
+// sshTests accept and deny same user
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-13T09:29:30Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "sshtest-accept-and-deny-same-user",
+	"description":    "sshTests accept and deny same user",
+	"category":       "sshtest",
+	"captured_at":    "2026-05-13T09:29:30.484173416Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                    \n  \n                                                                 \n                                                           \n{\n\t\"category\":    \"sshtest\",\n\t\"description\": \"sshTests accept and deny same user\",\n\t\"id\":          \"sshtest-accept-and-deny-same-user\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"thor@example.org\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"sshTests\": [{\n\t\t\"accept\": [\"root\"],\n\t\t\"deny\":   [\"root\"],\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    \"thor@example.org\"\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-edges/sshtest-accept-and-deny-same-user.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["thor@example.org"],
+				"users":  ["root"]
+			}],
+			"sshTests": [{
+				"accept": ["root"],
+				"deny":   ["root"],
+				"dst":    ["tag:server"],
+				"src":    "thor@example.org"
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2490480947865966,
+				"StableID":   "nFKU7GiwSL11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       2490480947865966,
+				"Key":        "nodekey:cb405c595cd71a6fd381cd46bec02addb0728794748e0f330f2b75861235d600",
+				"DiscoKey":   "discokey:7a3d09ff217e504c0b86360bd0d1aab6ba2719a28217d8a6850330843e296165",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:37486",
+					"10.65.0.27:37486",
+					"172.17.0.1:37486",
+					"172.18.0.1:37486",
+					"172.19.0.1:37486",
+					"172.20.0.1:37486",
+					"172.21.0.1:37486",
+					"172.22.0.1:37486",
+					"172.23.0.1:37486",
+					"172.24.0.1:37486",
+					"172.25.0.1:37486",
+					"172.26.0.1:37486",
+					"172.27.0.1:37486"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:29:39.168681166Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:cb405c595cd71a6fd381cd46bec02addb0728794748e0f330f2b75861235d600",
+			"MachineKey": "mkey:e789755c833c6a7a59e1eeeebe5427f1c61ca60a05a26b7c5aff2c148e045860",
+			"Peers": [{
+				"ID":         2859212664711574,
+				"StableID":   "n3RUGmfwKP11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:257f18e69b65ec0c700b7e2184bca19a3cf77826021794928f6980d4ef38b248",
+				"DiscoKey":   "discokey:44fd7f4dd7476297d1221f7d99732c75a33da40d06f1c636d0c4f27698923b71",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43150",
+					"10.65.0.27:43150",
+					"172.17.0.1:43150",
+					"172.18.0.1:43150",
+					"172.19.0.1:43150",
+					"172.20.0.1:43150",
+					"172.21.0.1:43150",
+					"172.22.0.1:43150",
+					"172.23.0.1:43150",
+					"172.24.0.1:43150",
+					"172.25.0.1:43150",
+					"172.26.0.1:43150",
+					"172.27.0.1:43150"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:29:33.270318864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6209384882856680,
+				"StableID":   "n7eP4g1FVq11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f9506ef72035485fc2d27b1036bba84c599ee143c5e5db39f83b16e1c7c3d204",
+				"DiscoKey":   "discokey:56bfd065fbf9aded449df431842d4e6b4e7d44457ad503c42380ad737c3c3669",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44553",
+					"10.65.0.27:44553",
+					"172.17.0.1:44553",
+					"172.18.0.1:44553",
+					"172.19.0.1:44553",
+					"172.20.0.1:44553",
+					"172.21.0.1:44553",
+					"172.22.0.1:44553",
+					"172.23.0.1:44553",
+					"172.24.0.1:44553",
+					"172.25.0.1:44553",
+					"172.26.0.1:44553",
+					"172.27.0.1:44553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:29:33.764228462Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4937306133179357,
+				"StableID":   "nCgkyGf7Zf11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ccfd85a67c2ae7d59bd0dc941483f6764942db4d3e3473d6e3ea72dd8f4db405",
+				"DiscoKey":   "discokey:9e488e31b507cc05ebb6ac225a6e756e8de09f01ac7e1425f097e7eee2c0970d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53179",
+					"10.65.0.27:53179",
+					"172.17.0.1:53179",
+					"172.18.0.1:53179",
+					"172.19.0.1:53179",
+					"172.20.0.1:53179",
+					"172.21.0.1:53179",
+					"172.22.0.1:53179",
+					"172.23.0.1:53179",
+					"172.24.0.1:53179",
+					"172.25.0.1:53179",
+					"172.26.0.1:53179",
+					"172.27.0.1:53179"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:29:34.31032901Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         493614118971451,
+				"StableID":   "nUZhPYQZr411CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1f09659d9ff3cde7edaf8075269b59c8bac1f27bc88b3fbc0a27fadbca2e54b",
+				"DiscoKey":   "discokey:260fcd6a36050179da5c80d9561e7fc2361abfa0031182fc42a9975284ef484e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60113",
+					"10.65.0.27:60113",
+					"172.17.0.1:60113",
+					"172.18.0.1:60113",
+					"172.19.0.1:60113",
+					"172.20.0.1:60113",
+					"172.21.0.1:60113",
+					"172.22.0.1:60113",
+					"172.23.0.1:60113",
+					"172.24.0.1:60113",
+					"172.25.0.1:60113",
+					"172.26.0.1:60113",
+					"172.27.0.1:60113"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:29:34.841487957Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         188686204918932,
+				"StableID":   "nmjao4UTU211CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90929a1c49724dcf491f4acc8a70e70f4917540d41fefb552b2781a75cad4643",
+				"DiscoKey":   "discokey:916e878a92a884cf8fbbc9bcb52a4206be177185311ad7bff9f62f5218030632",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50198",
+					"10.65.0.27:50198",
+					"172.17.0.1:50198",
+					"172.18.0.1:50198",
+					"172.19.0.1:50198",
+					"172.20.0.1:50198",
+					"172.21.0.1:50198",
+					"172.22.0.1:50198",
+					"172.23.0.1:50198",
+					"172.24.0.1:50198",
+					"172.25.0.1:50198",
+					"172.26.0.1:50198",
+					"172.27.0.1:50198"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:29:35.35868711Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1431992482076218,
+				"StableID":   "nFPm1q1ZBC11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:599a1b94de977777f3d8c3a8e0b472a2664b1edeb03e8da4bcd89c8c6b23a825",
+				"DiscoKey":   "discokey:ce753b107bd5f488e3b6a7325ffd0442f0debe5213132977e2f95c8bd763884b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:47841",
+					"10.65.0.27:47841",
+					"172.17.0.1:47841",
+					"172.18.0.1:47841",
+					"172.19.0.1:47841",
+					"172.20.0.1:47841",
+					"172.21.0.1:47841",
+					"172.22.0.1:47841",
+					"172.23.0.1:47841",
+					"172.24.0.1:47841",
+					"172.25.0.1:47841",
+					"172.26.0.1:47841",
+					"172.27.0.1:47841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:29:35.901475059Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2215287914480306,
+				"StableID":   "nh487irJJJ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b064330c9f805ad51a4b3336b5d3687be97805d2c12670d472d6fdb9e000015",
+				"DiscoKey":   "discokey:d569f11adb20bdbd3997acdebf4a11d7aab3609cd661e9f4e1862f858a9d2230",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50524",
+					"10.65.0.27:50524",
+					"172.17.0.1:50524",
+					"172.18.0.1:50524",
+					"172.19.0.1:50524",
+					"172.20.0.1:50524",
+					"172.21.0.1:50524",
+					"172.22.0.1:50524",
+					"172.23.0.1:50524",
+					"172.24.0.1:50524",
+					"172.25.0.1:50524",
+					"172.26.0.1:50524",
+					"172.27.0.1:50524"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:29:36.429659202Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5481495937921774,
+				"StableID":   "nhWvXzbaoj11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:645ef6e18e733de4391cc50812baa95407a0cdba46a222b12872e3c92b64b447",
+				"DiscoKey":   "discokey:eade7d7c765e230e0a081b4dca22080209816989c9309c0ca23ba874a7382b0c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36768",
+					"10.65.0.27:36768",
+					"172.17.0.1:36768",
+					"172.18.0.1:36768",
+					"172.19.0.1:36768",
+					"172.20.0.1:36768",
+					"172.21.0.1:36768",
+					"172.22.0.1:36768",
+					"172.23.0.1:36768",
+					"172.24.0.1:36768",
+					"172.25.0.1:36768",
+					"172.26.0.1:36768",
+					"172.27.0.1:36768"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:29:36.978336642Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5181403855005874,
+				"StableID":   "nDnQnChfTh11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7af9bedfaf13444d28e1664137504d38acd3737d8df9eeac69018992665b601c",
+				"DiscoKey":   "discokey:717cb5a3f65595c24e1a225bd4211fdd0022216d9e6268eef2344181e8b0cf72",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36746",
+					"10.65.0.27:36746",
+					"172.17.0.1:36746",
+					"172.18.0.1:36746",
+					"172.19.0.1:36746",
+					"172.20.0.1:36746",
+					"172.21.0.1:36746",
+					"172.22.0.1:36746",
+					"172.23.0.1:36746",
+					"172.24.0.1:36746",
+					"172.25.0.1:36746",
+					"172.26.0.1:36746",
+					"172.27.0.1:36746"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:29:37.52519162Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5947777451816847,
+				"StableID":   "nUXBDd2mSo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9320fbe912baef9f83844e8f5526b56748d328d5ad9bcf9d4f76a3e855cb2147",
+				"DiscoKey":   "discokey:821b02cb0acf6fc1a36d2c95273c0663e0233c9d928fe1bdb60b6d57fa2c6f22",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50083",
+					"10.65.0.27:50083",
+					"172.17.0.1:50083",
+					"172.18.0.1:50083",
+					"172.19.0.1:50083",
+					"172.20.0.1:50083",
+					"172.21.0.1:50083",
+					"172.22.0.1:50083",
+					"172.23.0.1:50083",
+					"172.24.0.1:50083",
+					"172.25.0.1:50083",
+					"172.26.0.1:50083",
+					"172.27.0.1:50083"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:29:38.144998256Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8028973883170165,
+				"StableID":   "n44L8hXLh521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3e1a94c6101554334d973f8d28097a3b1c352efc44b034ba9a3f710c9a378d00",
+				"DiscoKey":   "discokey:80529a51f5492a8b47068444185c7f283fb9f84399ce6b3b5c5d218785df054b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35325",
+					"10.65.0.27:35325",
+					"172.17.0.1:35325",
+					"172.18.0.1:35325",
+					"172.19.0.1:35325",
+					"172.20.0.1:35325",
+					"172.21.0.1:35325",
+					"172.22.0.1:35325",
+					"172.23.0.1:35325",
+					"172.24.0.1:35325",
+					"172.25.0.1:35325",
+					"172.26.0.1:35325",
+					"172.27.0.1:35325"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:29:38.639659064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1589114381480400,
+				"StableID":   "nbU3EjLiQD11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1f3efd3a35eeb9304e0cdc3813584d87a6cf3e40c6119240a5e09ae92e650f5e",
+				"KeyExpiry":  "2026-11-09T09:29:39Z",
+				"DiscoKey":   "discokey:7522b0531b5612e3170073daedefc46bc57348b91dce68cc9e07e9d087c43654",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48794",
+					"10.65.0.27:48794",
+					"172.17.0.1:48794",
+					"172.18.0.1:48794",
+					"172.19.0.1:48794",
+					"172.20.0.1:48794",
+					"172.21.0.1:48794",
+					"172.22.0.1:48794",
+					"172.23.0.1:48794",
+					"172.24.0.1:48794",
+					"172.25.0.1:48794",
+					"172.26.0.1:48794",
+					"172.27.0.1:48794"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:29:39.725982612Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5862924467252071,
+				"StableID":   "nL1iXs5Lnn11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1f2c54610b5c60ba0546dd2bcd5fc248ef5cdbf8949dd63e2f18f0856bb04514",
+				"KeyExpiry":  "2026-11-09T09:29:40Z",
+				"DiscoKey":   "discokey:38f7d9eda3690c65f595e42a0b2ed1b62379bb50523217184d143ab5c5691a5b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52155",
+					"10.65.0.27:52155",
+					"172.17.0.1:52155",
+					"172.18.0.1:52155",
+					"172.19.0.1:52155",
+					"172.20.0.1:52155",
+					"172.21.0.1:52155",
+					"172.22.0.1:52155",
+					"172.23.0.1:52155",
+					"172.24.0.1:52155",
+					"172.25.0.1:52155",
+					"172.26.0.1:52155",
+					"172.27.0.1:52155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:29:40.256259971Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3805678568696981,
+				"StableID":   "nrMYBvibiW11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:86c8345c3f407d8c6754e1ca156e1e299ad3b89dcb1d7aa937a6fa86cf03e532",
+				"KeyExpiry":  "2026-11-09T09:29:40Z",
+				"DiscoKey":   "discokey:4c23e8fbff3d7396d8260e6958541aa6749b7cc97d868d7a020ab6568befc97a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50255",
+					"10.65.0.27:50255",
+					"172.17.0.1:50255",
+					"172.18.0.1:50255",
+					"172.19.0.1:50255",
+					"172.20.0.1:50255",
+					"172.21.0.1:50255",
+					"172.22.0.1:50255",
+					"172.23.0.1:50255",
+					"172.24.0.1:50255",
+					"172.25.0.1:50255",
+					"172.26.0.1:50255",
+					"172.27.0.1:50255"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:29:40.787905965Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2490480947865966": {
+				"ID":          2490480947865966,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1431992482076218,
+				"StableID":   "nFPm1q1ZBC11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1431992482076218,
+				"Key":        "nodekey:599a1b94de977777f3d8c3a8e0b472a2664b1edeb03e8da4bcd89c8c6b23a825",
+				"DiscoKey":   "discokey:ce753b107bd5f488e3b6a7325ffd0442f0debe5213132977e2f95c8bd763884b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:47841",
+					"10.65.0.27:47841",
+					"172.17.0.1:47841",
+					"172.18.0.1:47841",
+					"172.19.0.1:47841",
+					"172.20.0.1:47841",
+					"172.21.0.1:47841",
+					"172.22.0.1:47841",
+					"172.23.0.1:47841",
+					"172.24.0.1:47841",
+					"172.25.0.1:47841",
+					"172.26.0.1:47841",
+					"172.27.0.1:47841"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:29:35.901475059Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:599a1b94de977777f3d8c3a8e0b472a2664b1edeb03e8da4bcd89c8c6b23a825",
+			"MachineKey": "mkey:ccc0bbc48f9fc9c5ee19f7bfeefdff39274dab9b426f1bb2f9d3a16fde72e32b",
+			"Peers": [{
+				"ID":         2859212664711574,
+				"StableID":   "n3RUGmfwKP11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:257f18e69b65ec0c700b7e2184bca19a3cf77826021794928f6980d4ef38b248",
+				"DiscoKey":   "discokey:44fd7f4dd7476297d1221f7d99732c75a33da40d06f1c636d0c4f27698923b71",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43150",
+					"10.65.0.27:43150",
+					"172.17.0.1:43150",
+					"172.18.0.1:43150",
+					"172.19.0.1:43150",
+					"172.20.0.1:43150",
+					"172.21.0.1:43150",
+					"172.22.0.1:43150",
+					"172.23.0.1:43150",
+					"172.24.0.1:43150",
+					"172.25.0.1:43150",
+					"172.26.0.1:43150",
+					"172.27.0.1:43150"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:29:33.270318864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6209384882856680,
+				"StableID":   "n7eP4g1FVq11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f9506ef72035485fc2d27b1036bba84c599ee143c5e5db39f83b16e1c7c3d204",
+				"DiscoKey":   "discokey:56bfd065fbf9aded449df431842d4e6b4e7d44457ad503c42380ad737c3c3669",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44553",
+					"10.65.0.27:44553",
+					"172.17.0.1:44553",
+					"172.18.0.1:44553",
+					"172.19.0.1:44553",
+					"172.20.0.1:44553",
+					"172.21.0.1:44553",
+					"172.22.0.1:44553",
+					"172.23.0.1:44553",
+					"172.24.0.1:44553",
+					"172.25.0.1:44553",
+					"172.26.0.1:44553",
+					"172.27.0.1:44553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:29:33.764228462Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4937306133179357,
+				"StableID":   "nCgkyGf7Zf11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ccfd85a67c2ae7d59bd0dc941483f6764942db4d3e3473d6e3ea72dd8f4db405",
+				"DiscoKey":   "discokey:9e488e31b507cc05ebb6ac225a6e756e8de09f01ac7e1425f097e7eee2c0970d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53179",
+					"10.65.0.27:53179",
+					"172.17.0.1:53179",
+					"172.18.0.1:53179",
+					"172.19.0.1:53179",
+					"172.20.0.1:53179",
+					"172.21.0.1:53179",
+					"172.22.0.1:53179",
+					"172.23.0.1:53179",
+					"172.24.0.1:53179",
+					"172.25.0.1:53179",
+					"172.26.0.1:53179",
+					"172.27.0.1:53179"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:29:34.31032901Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         493614118971451,
+				"StableID":   "nUZhPYQZr411CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1f09659d9ff3cde7edaf8075269b59c8bac1f27bc88b3fbc0a27fadbca2e54b",
+				"DiscoKey":   "discokey:260fcd6a36050179da5c80d9561e7fc2361abfa0031182fc42a9975284ef484e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60113",
+					"10.65.0.27:60113",
+					"172.17.0.1:60113",
+					"172.18.0.1:60113",
+					"172.19.0.1:60113",
+					"172.20.0.1:60113",
+					"172.21.0.1:60113",
+					"172.22.0.1:60113",
+					"172.23.0.1:60113",
+					"172.24.0.1:60113",
+					"172.25.0.1:60113",
+					"172.26.0.1:60113",
+					"172.27.0.1:60113"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:29:34.841487957Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         188686204918932,
+				"StableID":   "nmjao4UTU211CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90929a1c49724dcf491f4acc8a70e70f4917540d41fefb552b2781a75cad4643",
+				"DiscoKey":   "discokey:916e878a92a884cf8fbbc9bcb52a4206be177185311ad7bff9f62f5218030632",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50198",
+					"10.65.0.27:50198",
+					"172.17.0.1:50198",
+					"172.18.0.1:50198",
+					"172.19.0.1:50198",
+					"172.20.0.1:50198",
+					"172.21.0.1:50198",
+					"172.22.0.1:50198",
+					"172.23.0.1:50198",
+					"172.24.0.1:50198",
+					"172.25.0.1:50198",
+					"172.26.0.1:50198",
+					"172.27.0.1:50198"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:29:35.35868711Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2215287914480306,
+				"StableID":   "nh487irJJJ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b064330c9f805ad51a4b3336b5d3687be97805d2c12670d472d6fdb9e000015",
+				"DiscoKey":   "discokey:d569f11adb20bdbd3997acdebf4a11d7aab3609cd661e9f4e1862f858a9d2230",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50524",
+					"10.65.0.27:50524",
+					"172.17.0.1:50524",
+					"172.18.0.1:50524",
+					"172.19.0.1:50524",
+					"172.20.0.1:50524",
+					"172.21.0.1:50524",
+					"172.22.0.1:50524",
+					"172.23.0.1:50524",
+					"172.24.0.1:50524",
+					"172.25.0.1:50524",
+					"172.26.0.1:50524",
+					"172.27.0.1:50524"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:29:36.429659202Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5481495937921774,
+				"StableID":   "nhWvXzbaoj11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:645ef6e18e733de4391cc50812baa95407a0cdba46a222b12872e3c92b64b447",
+				"DiscoKey":   "discokey:eade7d7c765e230e0a081b4dca22080209816989c9309c0ca23ba874a7382b0c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36768",
+					"10.65.0.27:36768",
+					"172.17.0.1:36768",
+					"172.18.0.1:36768",
+					"172.19.0.1:36768",
+					"172.20.0.1:36768",
+					"172.21.0.1:36768",
+					"172.22.0.1:36768",
+					"172.23.0.1:36768",
+					"172.24.0.1:36768",
+					"172.25.0.1:36768",
+					"172.26.0.1:36768",
+					"172.27.0.1:36768"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:29:36.978336642Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5181403855005874,
+				"StableID":   "nDnQnChfTh11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7af9bedfaf13444d28e1664137504d38acd3737d8df9eeac69018992665b601c",
+				"DiscoKey":   "discokey:717cb5a3f65595c24e1a225bd4211fdd0022216d9e6268eef2344181e8b0cf72",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36746",
+					"10.65.0.27:36746",
+					"172.17.0.1:36746",
+					"172.18.0.1:36746",
+					"172.19.0.1:36746",
+					"172.20.0.1:36746",
+					"172.21.0.1:36746",
+					"172.22.0.1:36746",
+					"172.23.0.1:36746",
+					"172.24.0.1:36746",
+					"172.25.0.1:36746",
+					"172.26.0.1:36746",
+					"172.27.0.1:36746"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:29:37.52519162Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5947777451816847,
+				"StableID":   "nUXBDd2mSo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9320fbe912baef9f83844e8f5526b56748d328d5ad9bcf9d4f76a3e855cb2147",
+				"DiscoKey":   "discokey:821b02cb0acf6fc1a36d2c95273c0663e0233c9d928fe1bdb60b6d57fa2c6f22",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50083",
+					"10.65.0.27:50083",
+					"172.17.0.1:50083",
+					"172.18.0.1:50083",
+					"172.19.0.1:50083",
+					"172.20.0.1:50083",
+					"172.21.0.1:50083",
+					"172.22.0.1:50083",
+					"172.23.0.1:50083",
+					"172.24.0.1:50083",
+					"172.25.0.1:50083",
+					"172.26.0.1:50083",
+					"172.27.0.1:50083"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:29:38.144998256Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8028973883170165,
+				"StableID":   "n44L8hXLh521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3e1a94c6101554334d973f8d28097a3b1c352efc44b034ba9a3f710c9a378d00",
+				"DiscoKey":   "discokey:80529a51f5492a8b47068444185c7f283fb9f84399ce6b3b5c5d218785df054b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35325",
+					"10.65.0.27:35325",
+					"172.17.0.1:35325",
+					"172.18.0.1:35325",
+					"172.19.0.1:35325",
+					"172.20.0.1:35325",
+					"172.21.0.1:35325",
+					"172.22.0.1:35325",
+					"172.23.0.1:35325",
+					"172.24.0.1:35325",
+					"172.25.0.1:35325",
+					"172.26.0.1:35325",
+					"172.27.0.1:35325"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:29:38.639659064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2490480947865966,
+				"StableID":   "nFKU7GiwSL11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb405c595cd71a6fd381cd46bec02addb0728794748e0f330f2b75861235d600",
+				"DiscoKey":   "discokey:7a3d09ff217e504c0b86360bd0d1aab6ba2719a28217d8a6850330843e296165",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:37486",
+					"10.65.0.27:37486",
+					"172.17.0.1:37486",
+					"172.18.0.1:37486",
+					"172.19.0.1:37486",
+					"172.20.0.1:37486",
+					"172.21.0.1:37486",
+					"172.22.0.1:37486",
+					"172.23.0.1:37486",
+					"172.24.0.1:37486",
+					"172.25.0.1:37486",
+					"172.26.0.1:37486",
+					"172.27.0.1:37486"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:29:39.168681166Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1589114381480400,
+				"StableID":   "nbU3EjLiQD11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1f3efd3a35eeb9304e0cdc3813584d87a6cf3e40c6119240a5e09ae92e650f5e",
+				"KeyExpiry":  "2026-11-09T09:29:39Z",
+				"DiscoKey":   "discokey:7522b0531b5612e3170073daedefc46bc57348b91dce68cc9e07e9d087c43654",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48794",
+					"10.65.0.27:48794",
+					"172.17.0.1:48794",
+					"172.18.0.1:48794",
+					"172.19.0.1:48794",
+					"172.20.0.1:48794",
+					"172.21.0.1:48794",
+					"172.22.0.1:48794",
+					"172.23.0.1:48794",
+					"172.24.0.1:48794",
+					"172.25.0.1:48794",
+					"172.26.0.1:48794",
+					"172.27.0.1:48794"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:29:39.725982612Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5862924467252071,
+				"StableID":   "nL1iXs5Lnn11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1f2c54610b5c60ba0546dd2bcd5fc248ef5cdbf8949dd63e2f18f0856bb04514",
+				"KeyExpiry":  "2026-11-09T09:29:40Z",
+				"DiscoKey":   "discokey:38f7d9eda3690c65f595e42a0b2ed1b62379bb50523217184d143ab5c5691a5b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52155",
+					"10.65.0.27:52155",
+					"172.17.0.1:52155",
+					"172.18.0.1:52155",
+					"172.19.0.1:52155",
+					"172.20.0.1:52155",
+					"172.21.0.1:52155",
+					"172.22.0.1:52155",
+					"172.23.0.1:52155",
+					"172.24.0.1:52155",
+					"172.25.0.1:52155",
+					"172.26.0.1:52155",
+					"172.27.0.1:52155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:29:40.256259971Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3805678568696981,
+				"StableID":   "nrMYBvibiW11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:86c8345c3f407d8c6754e1ca156e1e299ad3b89dcb1d7aa937a6fa86cf03e532",
+				"KeyExpiry":  "2026-11-09T09:29:40Z",
+				"DiscoKey":   "discokey:4c23e8fbff3d7396d8260e6958541aa6749b7cc97d868d7a020ab6568befc97a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50255",
+					"10.65.0.27:50255",
+					"172.17.0.1:50255",
+					"172.18.0.1:50255",
+					"172.19.0.1:50255",
+					"172.20.0.1:50255",
+					"172.21.0.1:50255",
+					"172.22.0.1:50255",
+					"172.23.0.1:50255",
+					"172.24.0.1:50255",
+					"172.25.0.1:50255",
+					"172.26.0.1:50255",
+					"172.27.0.1:50255"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:29:40.787905965Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1431992482076218": {
+				"ID":          1431992482076218,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3805678568696981,
+				"StableID":   "nrMYBvibiW11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:86c8345c3f407d8c6754e1ca156e1e299ad3b89dcb1d7aa937a6fa86cf03e532",
+				"KeyExpiry":  "2026-11-09T09:29:40Z",
+				"DiscoKey":   "discokey:4c23e8fbff3d7396d8260e6958541aa6749b7cc97d868d7a020ab6568befc97a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50255",
+					"10.65.0.27:50255",
+					"172.17.0.1:50255",
+					"172.18.0.1:50255",
+					"172.19.0.1:50255",
+					"172.20.0.1:50255",
+					"172.21.0.1:50255",
+					"172.22.0.1:50255",
+					"172.23.0.1:50255",
+					"172.24.0.1:50255",
+					"172.25.0.1:50255",
+					"172.26.0.1:50255",
+					"172.27.0.1:50255"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:29:40.787905965Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:86c8345c3f407d8c6754e1ca156e1e299ad3b89dcb1d7aa937a6fa86cf03e532",
+			"MachineKey": "mkey:41b9f335ce3dcd09e212283f0ef5c79460f9d7187a965d137d9cc36191dd4434",
+			"Peers": [{
+				"ID":         2859212664711574,
+				"StableID":   "n3RUGmfwKP11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:257f18e69b65ec0c700b7e2184bca19a3cf77826021794928f6980d4ef38b248",
+				"DiscoKey":   "discokey:44fd7f4dd7476297d1221f7d99732c75a33da40d06f1c636d0c4f27698923b71",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43150",
+					"10.65.0.27:43150",
+					"172.17.0.1:43150",
+					"172.18.0.1:43150",
+					"172.19.0.1:43150",
+					"172.20.0.1:43150",
+					"172.21.0.1:43150",
+					"172.22.0.1:43150",
+					"172.23.0.1:43150",
+					"172.24.0.1:43150",
+					"172.25.0.1:43150",
+					"172.26.0.1:43150",
+					"172.27.0.1:43150"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:29:33.270318864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6209384882856680,
+				"StableID":   "n7eP4g1FVq11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f9506ef72035485fc2d27b1036bba84c599ee143c5e5db39f83b16e1c7c3d204",
+				"DiscoKey":   "discokey:56bfd065fbf9aded449df431842d4e6b4e7d44457ad503c42380ad737c3c3669",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44553",
+					"10.65.0.27:44553",
+					"172.17.0.1:44553",
+					"172.18.0.1:44553",
+					"172.19.0.1:44553",
+					"172.20.0.1:44553",
+					"172.21.0.1:44553",
+					"172.22.0.1:44553",
+					"172.23.0.1:44553",
+					"172.24.0.1:44553",
+					"172.25.0.1:44553",
+					"172.26.0.1:44553",
+					"172.27.0.1:44553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:29:33.764228462Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4937306133179357,
+				"StableID":   "nCgkyGf7Zf11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ccfd85a67c2ae7d59bd0dc941483f6764942db4d3e3473d6e3ea72dd8f4db405",
+				"DiscoKey":   "discokey:9e488e31b507cc05ebb6ac225a6e756e8de09f01ac7e1425f097e7eee2c0970d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53179",
+					"10.65.0.27:53179",
+					"172.17.0.1:53179",
+					"172.18.0.1:53179",
+					"172.19.0.1:53179",
+					"172.20.0.1:53179",
+					"172.21.0.1:53179",
+					"172.22.0.1:53179",
+					"172.23.0.1:53179",
+					"172.24.0.1:53179",
+					"172.25.0.1:53179",
+					"172.26.0.1:53179",
+					"172.27.0.1:53179"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:29:34.31032901Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         493614118971451,
+				"StableID":   "nUZhPYQZr411CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1f09659d9ff3cde7edaf8075269b59c8bac1f27bc88b3fbc0a27fadbca2e54b",
+				"DiscoKey":   "discokey:260fcd6a36050179da5c80d9561e7fc2361abfa0031182fc42a9975284ef484e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60113",
+					"10.65.0.27:60113",
+					"172.17.0.1:60113",
+					"172.18.0.1:60113",
+					"172.19.0.1:60113",
+					"172.20.0.1:60113",
+					"172.21.0.1:60113",
+					"172.22.0.1:60113",
+					"172.23.0.1:60113",
+					"172.24.0.1:60113",
+					"172.25.0.1:60113",
+					"172.26.0.1:60113",
+					"172.27.0.1:60113"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:29:34.841487957Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         188686204918932,
+				"StableID":   "nmjao4UTU211CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90929a1c49724dcf491f4acc8a70e70f4917540d41fefb552b2781a75cad4643",
+				"DiscoKey":   "discokey:916e878a92a884cf8fbbc9bcb52a4206be177185311ad7bff9f62f5218030632",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50198",
+					"10.65.0.27:50198",
+					"172.17.0.1:50198",
+					"172.18.0.1:50198",
+					"172.19.0.1:50198",
+					"172.20.0.1:50198",
+					"172.21.0.1:50198",
+					"172.22.0.1:50198",
+					"172.23.0.1:50198",
+					"172.24.0.1:50198",
+					"172.25.0.1:50198",
+					"172.26.0.1:50198",
+					"172.27.0.1:50198"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:29:35.35868711Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1431992482076218,
+				"StableID":   "nFPm1q1ZBC11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:599a1b94de977777f3d8c3a8e0b472a2664b1edeb03e8da4bcd89c8c6b23a825",
+				"DiscoKey":   "discokey:ce753b107bd5f488e3b6a7325ffd0442f0debe5213132977e2f95c8bd763884b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:47841",
+					"10.65.0.27:47841",
+					"172.17.0.1:47841",
+					"172.18.0.1:47841",
+					"172.19.0.1:47841",
+					"172.20.0.1:47841",
+					"172.21.0.1:47841",
+					"172.22.0.1:47841",
+					"172.23.0.1:47841",
+					"172.24.0.1:47841",
+					"172.25.0.1:47841",
+					"172.26.0.1:47841",
+					"172.27.0.1:47841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:29:35.901475059Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2215287914480306,
+				"StableID":   "nh487irJJJ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b064330c9f805ad51a4b3336b5d3687be97805d2c12670d472d6fdb9e000015",
+				"DiscoKey":   "discokey:d569f11adb20bdbd3997acdebf4a11d7aab3609cd661e9f4e1862f858a9d2230",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50524",
+					"10.65.0.27:50524",
+					"172.17.0.1:50524",
+					"172.18.0.1:50524",
+					"172.19.0.1:50524",
+					"172.20.0.1:50524",
+					"172.21.0.1:50524",
+					"172.22.0.1:50524",
+					"172.23.0.1:50524",
+					"172.24.0.1:50524",
+					"172.25.0.1:50524",
+					"172.26.0.1:50524",
+					"172.27.0.1:50524"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:29:36.429659202Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5481495937921774,
+				"StableID":   "nhWvXzbaoj11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:645ef6e18e733de4391cc50812baa95407a0cdba46a222b12872e3c92b64b447",
+				"DiscoKey":   "discokey:eade7d7c765e230e0a081b4dca22080209816989c9309c0ca23ba874a7382b0c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36768",
+					"10.65.0.27:36768",
+					"172.17.0.1:36768",
+					"172.18.0.1:36768",
+					"172.19.0.1:36768",
+					"172.20.0.1:36768",
+					"172.21.0.1:36768",
+					"172.22.0.1:36768",
+					"172.23.0.1:36768",
+					"172.24.0.1:36768",
+					"172.25.0.1:36768",
+					"172.26.0.1:36768",
+					"172.27.0.1:36768"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:29:36.978336642Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5181403855005874,
+				"StableID":   "nDnQnChfTh11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7af9bedfaf13444d28e1664137504d38acd3737d8df9eeac69018992665b601c",
+				"DiscoKey":   "discokey:717cb5a3f65595c24e1a225bd4211fdd0022216d9e6268eef2344181e8b0cf72",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36746",
+					"10.65.0.27:36746",
+					"172.17.0.1:36746",
+					"172.18.0.1:36746",
+					"172.19.0.1:36746",
+					"172.20.0.1:36746",
+					"172.21.0.1:36746",
+					"172.22.0.1:36746",
+					"172.23.0.1:36746",
+					"172.24.0.1:36746",
+					"172.25.0.1:36746",
+					"172.26.0.1:36746",
+					"172.27.0.1:36746"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:29:37.52519162Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5947777451816847,
+				"StableID":   "nUXBDd2mSo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9320fbe912baef9f83844e8f5526b56748d328d5ad9bcf9d4f76a3e855cb2147",
+				"DiscoKey":   "discokey:821b02cb0acf6fc1a36d2c95273c0663e0233c9d928fe1bdb60b6d57fa2c6f22",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50083",
+					"10.65.0.27:50083",
+					"172.17.0.1:50083",
+					"172.18.0.1:50083",
+					"172.19.0.1:50083",
+					"172.20.0.1:50083",
+					"172.21.0.1:50083",
+					"172.22.0.1:50083",
+					"172.23.0.1:50083",
+					"172.24.0.1:50083",
+					"172.25.0.1:50083",
+					"172.26.0.1:50083",
+					"172.27.0.1:50083"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:29:38.144998256Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8028973883170165,
+				"StableID":   "n44L8hXLh521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3e1a94c6101554334d973f8d28097a3b1c352efc44b034ba9a3f710c9a378d00",
+				"DiscoKey":   "discokey:80529a51f5492a8b47068444185c7f283fb9f84399ce6b3b5c5d218785df054b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35325",
+					"10.65.0.27:35325",
+					"172.17.0.1:35325",
+					"172.18.0.1:35325",
+					"172.19.0.1:35325",
+					"172.20.0.1:35325",
+					"172.21.0.1:35325",
+					"172.22.0.1:35325",
+					"172.23.0.1:35325",
+					"172.24.0.1:35325",
+					"172.25.0.1:35325",
+					"172.26.0.1:35325",
+					"172.27.0.1:35325"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:29:38.639659064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2490480947865966,
+				"StableID":   "nFKU7GiwSL11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb405c595cd71a6fd381cd46bec02addb0728794748e0f330f2b75861235d600",
+				"DiscoKey":   "discokey:7a3d09ff217e504c0b86360bd0d1aab6ba2719a28217d8a6850330843e296165",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:37486",
+					"10.65.0.27:37486",
+					"172.17.0.1:37486",
+					"172.18.0.1:37486",
+					"172.19.0.1:37486",
+					"172.20.0.1:37486",
+					"172.21.0.1:37486",
+					"172.22.0.1:37486",
+					"172.23.0.1:37486",
+					"172.24.0.1:37486",
+					"172.25.0.1:37486",
+					"172.26.0.1:37486",
+					"172.27.0.1:37486"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:29:39.168681166Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1589114381480400,
+				"StableID":   "nbU3EjLiQD11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1f3efd3a35eeb9304e0cdc3813584d87a6cf3e40c6119240a5e09ae92e650f5e",
+				"KeyExpiry":  "2026-11-09T09:29:39Z",
+				"DiscoKey":   "discokey:7522b0531b5612e3170073daedefc46bc57348b91dce68cc9e07e9d087c43654",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48794",
+					"10.65.0.27:48794",
+					"172.17.0.1:48794",
+					"172.18.0.1:48794",
+					"172.19.0.1:48794",
+					"172.20.0.1:48794",
+					"172.21.0.1:48794",
+					"172.22.0.1:48794",
+					"172.23.0.1:48794",
+					"172.24.0.1:48794",
+					"172.25.0.1:48794",
+					"172.26.0.1:48794",
+					"172.27.0.1:48794"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:29:39.725982612Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5862924467252071,
+				"StableID":   "nL1iXs5Lnn11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1f2c54610b5c60ba0546dd2bcd5fc248ef5cdbf8949dd63e2f18f0856bb04514",
+				"KeyExpiry":  "2026-11-09T09:29:40Z",
+				"DiscoKey":   "discokey:38f7d9eda3690c65f595e42a0b2ed1b62379bb50523217184d143ab5c5691a5b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52155",
+					"10.65.0.27:52155",
+					"172.17.0.1:52155",
+					"172.18.0.1:52155",
+					"172.19.0.1:52155",
+					"172.20.0.1:52155",
+					"172.21.0.1:52155",
+					"172.22.0.1:52155",
+					"172.23.0.1:52155",
+					"172.24.0.1:52155",
+					"172.25.0.1:52155",
+					"172.26.0.1:52155",
+					"172.27.0.1:52155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:29:40.256259971Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4937306133179357,
+				"StableID":   "nCgkyGf7Zf11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       4937306133179357,
+				"Key":        "nodekey:ccfd85a67c2ae7d59bd0dc941483f6764942db4d3e3473d6e3ea72dd8f4db405",
+				"DiscoKey":   "discokey:9e488e31b507cc05ebb6ac225a6e756e8de09f01ac7e1425f097e7eee2c0970d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53179",
+					"10.65.0.27:53179",
+					"172.17.0.1:53179",
+					"172.18.0.1:53179",
+					"172.19.0.1:53179",
+					"172.20.0.1:53179",
+					"172.21.0.1:53179",
+					"172.22.0.1:53179",
+					"172.23.0.1:53179",
+					"172.24.0.1:53179",
+					"172.25.0.1:53179",
+					"172.26.0.1:53179",
+					"172.27.0.1:53179"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:29:34.31032901Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ccfd85a67c2ae7d59bd0dc941483f6764942db4d3e3473d6e3ea72dd8f4db405",
+			"MachineKey": "mkey:a690f5c3222b7c555232db4514008d74e5680f01b190141d5ca2b610bb7a1f3e",
+			"Peers": [{
+				"ID":         2859212664711574,
+				"StableID":   "n3RUGmfwKP11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:257f18e69b65ec0c700b7e2184bca19a3cf77826021794928f6980d4ef38b248",
+				"DiscoKey":   "discokey:44fd7f4dd7476297d1221f7d99732c75a33da40d06f1c636d0c4f27698923b71",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43150",
+					"10.65.0.27:43150",
+					"172.17.0.1:43150",
+					"172.18.0.1:43150",
+					"172.19.0.1:43150",
+					"172.20.0.1:43150",
+					"172.21.0.1:43150",
+					"172.22.0.1:43150",
+					"172.23.0.1:43150",
+					"172.24.0.1:43150",
+					"172.25.0.1:43150",
+					"172.26.0.1:43150",
+					"172.27.0.1:43150"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:29:33.270318864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6209384882856680,
+				"StableID":   "n7eP4g1FVq11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f9506ef72035485fc2d27b1036bba84c599ee143c5e5db39f83b16e1c7c3d204",
+				"DiscoKey":   "discokey:56bfd065fbf9aded449df431842d4e6b4e7d44457ad503c42380ad737c3c3669",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44553",
+					"10.65.0.27:44553",
+					"172.17.0.1:44553",
+					"172.18.0.1:44553",
+					"172.19.0.1:44553",
+					"172.20.0.1:44553",
+					"172.21.0.1:44553",
+					"172.22.0.1:44553",
+					"172.23.0.1:44553",
+					"172.24.0.1:44553",
+					"172.25.0.1:44553",
+					"172.26.0.1:44553",
+					"172.27.0.1:44553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:29:33.764228462Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         493614118971451,
+				"StableID":   "nUZhPYQZr411CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1f09659d9ff3cde7edaf8075269b59c8bac1f27bc88b3fbc0a27fadbca2e54b",
+				"DiscoKey":   "discokey:260fcd6a36050179da5c80d9561e7fc2361abfa0031182fc42a9975284ef484e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60113",
+					"10.65.0.27:60113",
+					"172.17.0.1:60113",
+					"172.18.0.1:60113",
+					"172.19.0.1:60113",
+					"172.20.0.1:60113",
+					"172.21.0.1:60113",
+					"172.22.0.1:60113",
+					"172.23.0.1:60113",
+					"172.24.0.1:60113",
+					"172.25.0.1:60113",
+					"172.26.0.1:60113",
+					"172.27.0.1:60113"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:29:34.841487957Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         188686204918932,
+				"StableID":   "nmjao4UTU211CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90929a1c49724dcf491f4acc8a70e70f4917540d41fefb552b2781a75cad4643",
+				"DiscoKey":   "discokey:916e878a92a884cf8fbbc9bcb52a4206be177185311ad7bff9f62f5218030632",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50198",
+					"10.65.0.27:50198",
+					"172.17.0.1:50198",
+					"172.18.0.1:50198",
+					"172.19.0.1:50198",
+					"172.20.0.1:50198",
+					"172.21.0.1:50198",
+					"172.22.0.1:50198",
+					"172.23.0.1:50198",
+					"172.24.0.1:50198",
+					"172.25.0.1:50198",
+					"172.26.0.1:50198",
+					"172.27.0.1:50198"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:29:35.35868711Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1431992482076218,
+				"StableID":   "nFPm1q1ZBC11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:599a1b94de977777f3d8c3a8e0b472a2664b1edeb03e8da4bcd89c8c6b23a825",
+				"DiscoKey":   "discokey:ce753b107bd5f488e3b6a7325ffd0442f0debe5213132977e2f95c8bd763884b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:47841",
+					"10.65.0.27:47841",
+					"172.17.0.1:47841",
+					"172.18.0.1:47841",
+					"172.19.0.1:47841",
+					"172.20.0.1:47841",
+					"172.21.0.1:47841",
+					"172.22.0.1:47841",
+					"172.23.0.1:47841",
+					"172.24.0.1:47841",
+					"172.25.0.1:47841",
+					"172.26.0.1:47841",
+					"172.27.0.1:47841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:29:35.901475059Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2215287914480306,
+				"StableID":   "nh487irJJJ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b064330c9f805ad51a4b3336b5d3687be97805d2c12670d472d6fdb9e000015",
+				"DiscoKey":   "discokey:d569f11adb20bdbd3997acdebf4a11d7aab3609cd661e9f4e1862f858a9d2230",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50524",
+					"10.65.0.27:50524",
+					"172.17.0.1:50524",
+					"172.18.0.1:50524",
+					"172.19.0.1:50524",
+					"172.20.0.1:50524",
+					"172.21.0.1:50524",
+					"172.22.0.1:50524",
+					"172.23.0.1:50524",
+					"172.24.0.1:50524",
+					"172.25.0.1:50524",
+					"172.26.0.1:50524",
+					"172.27.0.1:50524"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:29:36.429659202Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5481495937921774,
+				"StableID":   "nhWvXzbaoj11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:645ef6e18e733de4391cc50812baa95407a0cdba46a222b12872e3c92b64b447",
+				"DiscoKey":   "discokey:eade7d7c765e230e0a081b4dca22080209816989c9309c0ca23ba874a7382b0c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36768",
+					"10.65.0.27:36768",
+					"172.17.0.1:36768",
+					"172.18.0.1:36768",
+					"172.19.0.1:36768",
+					"172.20.0.1:36768",
+					"172.21.0.1:36768",
+					"172.22.0.1:36768",
+					"172.23.0.1:36768",
+					"172.24.0.1:36768",
+					"172.25.0.1:36768",
+					"172.26.0.1:36768",
+					"172.27.0.1:36768"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:29:36.978336642Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5181403855005874,
+				"StableID":   "nDnQnChfTh11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7af9bedfaf13444d28e1664137504d38acd3737d8df9eeac69018992665b601c",
+				"DiscoKey":   "discokey:717cb5a3f65595c24e1a225bd4211fdd0022216d9e6268eef2344181e8b0cf72",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36746",
+					"10.65.0.27:36746",
+					"172.17.0.1:36746",
+					"172.18.0.1:36746",
+					"172.19.0.1:36746",
+					"172.20.0.1:36746",
+					"172.21.0.1:36746",
+					"172.22.0.1:36746",
+					"172.23.0.1:36746",
+					"172.24.0.1:36746",
+					"172.25.0.1:36746",
+					"172.26.0.1:36746",
+					"172.27.0.1:36746"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:29:37.52519162Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5947777451816847,
+				"StableID":   "nUXBDd2mSo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9320fbe912baef9f83844e8f5526b56748d328d5ad9bcf9d4f76a3e855cb2147",
+				"DiscoKey":   "discokey:821b02cb0acf6fc1a36d2c95273c0663e0233c9d928fe1bdb60b6d57fa2c6f22",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50083",
+					"10.65.0.27:50083",
+					"172.17.0.1:50083",
+					"172.18.0.1:50083",
+					"172.19.0.1:50083",
+					"172.20.0.1:50083",
+					"172.21.0.1:50083",
+					"172.22.0.1:50083",
+					"172.23.0.1:50083",
+					"172.24.0.1:50083",
+					"172.25.0.1:50083",
+					"172.26.0.1:50083",
+					"172.27.0.1:50083"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:29:38.144998256Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8028973883170165,
+				"StableID":   "n44L8hXLh521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3e1a94c6101554334d973f8d28097a3b1c352efc44b034ba9a3f710c9a378d00",
+				"DiscoKey":   "discokey:80529a51f5492a8b47068444185c7f283fb9f84399ce6b3b5c5d218785df054b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35325",
+					"10.65.0.27:35325",
+					"172.17.0.1:35325",
+					"172.18.0.1:35325",
+					"172.19.0.1:35325",
+					"172.20.0.1:35325",
+					"172.21.0.1:35325",
+					"172.22.0.1:35325",
+					"172.23.0.1:35325",
+					"172.24.0.1:35325",
+					"172.25.0.1:35325",
+					"172.26.0.1:35325",
+					"172.27.0.1:35325"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:29:38.639659064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2490480947865966,
+				"StableID":   "nFKU7GiwSL11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb405c595cd71a6fd381cd46bec02addb0728794748e0f330f2b75861235d600",
+				"DiscoKey":   "discokey:7a3d09ff217e504c0b86360bd0d1aab6ba2719a28217d8a6850330843e296165",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:37486",
+					"10.65.0.27:37486",
+					"172.17.0.1:37486",
+					"172.18.0.1:37486",
+					"172.19.0.1:37486",
+					"172.20.0.1:37486",
+					"172.21.0.1:37486",
+					"172.22.0.1:37486",
+					"172.23.0.1:37486",
+					"172.24.0.1:37486",
+					"172.25.0.1:37486",
+					"172.26.0.1:37486",
+					"172.27.0.1:37486"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:29:39.168681166Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1589114381480400,
+				"StableID":   "nbU3EjLiQD11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1f3efd3a35eeb9304e0cdc3813584d87a6cf3e40c6119240a5e09ae92e650f5e",
+				"KeyExpiry":  "2026-11-09T09:29:39Z",
+				"DiscoKey":   "discokey:7522b0531b5612e3170073daedefc46bc57348b91dce68cc9e07e9d087c43654",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48794",
+					"10.65.0.27:48794",
+					"172.17.0.1:48794",
+					"172.18.0.1:48794",
+					"172.19.0.1:48794",
+					"172.20.0.1:48794",
+					"172.21.0.1:48794",
+					"172.22.0.1:48794",
+					"172.23.0.1:48794",
+					"172.24.0.1:48794",
+					"172.25.0.1:48794",
+					"172.26.0.1:48794",
+					"172.27.0.1:48794"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:29:39.725982612Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5862924467252071,
+				"StableID":   "nL1iXs5Lnn11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1f2c54610b5c60ba0546dd2bcd5fc248ef5cdbf8949dd63e2f18f0856bb04514",
+				"KeyExpiry":  "2026-11-09T09:29:40Z",
+				"DiscoKey":   "discokey:38f7d9eda3690c65f595e42a0b2ed1b62379bb50523217184d143ab5c5691a5b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52155",
+					"10.65.0.27:52155",
+					"172.17.0.1:52155",
+					"172.18.0.1:52155",
+					"172.19.0.1:52155",
+					"172.20.0.1:52155",
+					"172.21.0.1:52155",
+					"172.22.0.1:52155",
+					"172.23.0.1:52155",
+					"172.24.0.1:52155",
+					"172.25.0.1:52155",
+					"172.26.0.1:52155",
+					"172.27.0.1:52155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:29:40.256259971Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3805678568696981,
+				"StableID":   "nrMYBvibiW11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:86c8345c3f407d8c6754e1ca156e1e299ad3b89dcb1d7aa937a6fa86cf03e532",
+				"KeyExpiry":  "2026-11-09T09:29:40Z",
+				"DiscoKey":   "discokey:4c23e8fbff3d7396d8260e6958541aa6749b7cc97d868d7a020ab6568befc97a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50255",
+					"10.65.0.27:50255",
+					"172.17.0.1:50255",
+					"172.18.0.1:50255",
+					"172.19.0.1:50255",
+					"172.20.0.1:50255",
+					"172.21.0.1:50255",
+					"172.22.0.1:50255",
+					"172.23.0.1:50255",
+					"172.24.0.1:50255",
+					"172.25.0.1:50255",
+					"172.26.0.1:50255",
+					"172.27.0.1:50255"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:29:40.787905965Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4937306133179357": {
+				"ID":          4937306133179357,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5481495937921774,
+				"StableID":   "nhWvXzbaoj11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       5481495937921774,
+				"Key":        "nodekey:645ef6e18e733de4391cc50812baa95407a0cdba46a222b12872e3c92b64b447",
+				"DiscoKey":   "discokey:eade7d7c765e230e0a081b4dca22080209816989c9309c0ca23ba874a7382b0c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36768",
+					"10.65.0.27:36768",
+					"172.17.0.1:36768",
+					"172.18.0.1:36768",
+					"172.19.0.1:36768",
+					"172.20.0.1:36768",
+					"172.21.0.1:36768",
+					"172.22.0.1:36768",
+					"172.23.0.1:36768",
+					"172.24.0.1:36768",
+					"172.25.0.1:36768",
+					"172.26.0.1:36768",
+					"172.27.0.1:36768"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:29:36.978336642Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:645ef6e18e733de4391cc50812baa95407a0cdba46a222b12872e3c92b64b447",
+			"MachineKey": "mkey:d4e4cef8367d4179df1f3f6eab01f0c027a4af4676aa02f8cb000d691dbf4663",
+			"Peers": [{
+				"ID":         2859212664711574,
+				"StableID":   "n3RUGmfwKP11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:257f18e69b65ec0c700b7e2184bca19a3cf77826021794928f6980d4ef38b248",
+				"DiscoKey":   "discokey:44fd7f4dd7476297d1221f7d99732c75a33da40d06f1c636d0c4f27698923b71",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43150",
+					"10.65.0.27:43150",
+					"172.17.0.1:43150",
+					"172.18.0.1:43150",
+					"172.19.0.1:43150",
+					"172.20.0.1:43150",
+					"172.21.0.1:43150",
+					"172.22.0.1:43150",
+					"172.23.0.1:43150",
+					"172.24.0.1:43150",
+					"172.25.0.1:43150",
+					"172.26.0.1:43150",
+					"172.27.0.1:43150"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:29:33.270318864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6209384882856680,
+				"StableID":   "n7eP4g1FVq11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f9506ef72035485fc2d27b1036bba84c599ee143c5e5db39f83b16e1c7c3d204",
+				"DiscoKey":   "discokey:56bfd065fbf9aded449df431842d4e6b4e7d44457ad503c42380ad737c3c3669",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44553",
+					"10.65.0.27:44553",
+					"172.17.0.1:44553",
+					"172.18.0.1:44553",
+					"172.19.0.1:44553",
+					"172.20.0.1:44553",
+					"172.21.0.1:44553",
+					"172.22.0.1:44553",
+					"172.23.0.1:44553",
+					"172.24.0.1:44553",
+					"172.25.0.1:44553",
+					"172.26.0.1:44553",
+					"172.27.0.1:44553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:29:33.764228462Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4937306133179357,
+				"StableID":   "nCgkyGf7Zf11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ccfd85a67c2ae7d59bd0dc941483f6764942db4d3e3473d6e3ea72dd8f4db405",
+				"DiscoKey":   "discokey:9e488e31b507cc05ebb6ac225a6e756e8de09f01ac7e1425f097e7eee2c0970d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53179",
+					"10.65.0.27:53179",
+					"172.17.0.1:53179",
+					"172.18.0.1:53179",
+					"172.19.0.1:53179",
+					"172.20.0.1:53179",
+					"172.21.0.1:53179",
+					"172.22.0.1:53179",
+					"172.23.0.1:53179",
+					"172.24.0.1:53179",
+					"172.25.0.1:53179",
+					"172.26.0.1:53179",
+					"172.27.0.1:53179"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:29:34.31032901Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         493614118971451,
+				"StableID":   "nUZhPYQZr411CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1f09659d9ff3cde7edaf8075269b59c8bac1f27bc88b3fbc0a27fadbca2e54b",
+				"DiscoKey":   "discokey:260fcd6a36050179da5c80d9561e7fc2361abfa0031182fc42a9975284ef484e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60113",
+					"10.65.0.27:60113",
+					"172.17.0.1:60113",
+					"172.18.0.1:60113",
+					"172.19.0.1:60113",
+					"172.20.0.1:60113",
+					"172.21.0.1:60113",
+					"172.22.0.1:60113",
+					"172.23.0.1:60113",
+					"172.24.0.1:60113",
+					"172.25.0.1:60113",
+					"172.26.0.1:60113",
+					"172.27.0.1:60113"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:29:34.841487957Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         188686204918932,
+				"StableID":   "nmjao4UTU211CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90929a1c49724dcf491f4acc8a70e70f4917540d41fefb552b2781a75cad4643",
+				"DiscoKey":   "discokey:916e878a92a884cf8fbbc9bcb52a4206be177185311ad7bff9f62f5218030632",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50198",
+					"10.65.0.27:50198",
+					"172.17.0.1:50198",
+					"172.18.0.1:50198",
+					"172.19.0.1:50198",
+					"172.20.0.1:50198",
+					"172.21.0.1:50198",
+					"172.22.0.1:50198",
+					"172.23.0.1:50198",
+					"172.24.0.1:50198",
+					"172.25.0.1:50198",
+					"172.26.0.1:50198",
+					"172.27.0.1:50198"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:29:35.35868711Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1431992482076218,
+				"StableID":   "nFPm1q1ZBC11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:599a1b94de977777f3d8c3a8e0b472a2664b1edeb03e8da4bcd89c8c6b23a825",
+				"DiscoKey":   "discokey:ce753b107bd5f488e3b6a7325ffd0442f0debe5213132977e2f95c8bd763884b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:47841",
+					"10.65.0.27:47841",
+					"172.17.0.1:47841",
+					"172.18.0.1:47841",
+					"172.19.0.1:47841",
+					"172.20.0.1:47841",
+					"172.21.0.1:47841",
+					"172.22.0.1:47841",
+					"172.23.0.1:47841",
+					"172.24.0.1:47841",
+					"172.25.0.1:47841",
+					"172.26.0.1:47841",
+					"172.27.0.1:47841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:29:35.901475059Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2215287914480306,
+				"StableID":   "nh487irJJJ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b064330c9f805ad51a4b3336b5d3687be97805d2c12670d472d6fdb9e000015",
+				"DiscoKey":   "discokey:d569f11adb20bdbd3997acdebf4a11d7aab3609cd661e9f4e1862f858a9d2230",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50524",
+					"10.65.0.27:50524",
+					"172.17.0.1:50524",
+					"172.18.0.1:50524",
+					"172.19.0.1:50524",
+					"172.20.0.1:50524",
+					"172.21.0.1:50524",
+					"172.22.0.1:50524",
+					"172.23.0.1:50524",
+					"172.24.0.1:50524",
+					"172.25.0.1:50524",
+					"172.26.0.1:50524",
+					"172.27.0.1:50524"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:29:36.429659202Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5181403855005874,
+				"StableID":   "nDnQnChfTh11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7af9bedfaf13444d28e1664137504d38acd3737d8df9eeac69018992665b601c",
+				"DiscoKey":   "discokey:717cb5a3f65595c24e1a225bd4211fdd0022216d9e6268eef2344181e8b0cf72",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36746",
+					"10.65.0.27:36746",
+					"172.17.0.1:36746",
+					"172.18.0.1:36746",
+					"172.19.0.1:36746",
+					"172.20.0.1:36746",
+					"172.21.0.1:36746",
+					"172.22.0.1:36746",
+					"172.23.0.1:36746",
+					"172.24.0.1:36746",
+					"172.25.0.1:36746",
+					"172.26.0.1:36746",
+					"172.27.0.1:36746"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:29:37.52519162Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5947777451816847,
+				"StableID":   "nUXBDd2mSo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9320fbe912baef9f83844e8f5526b56748d328d5ad9bcf9d4f76a3e855cb2147",
+				"DiscoKey":   "discokey:821b02cb0acf6fc1a36d2c95273c0663e0233c9d928fe1bdb60b6d57fa2c6f22",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50083",
+					"10.65.0.27:50083",
+					"172.17.0.1:50083",
+					"172.18.0.1:50083",
+					"172.19.0.1:50083",
+					"172.20.0.1:50083",
+					"172.21.0.1:50083",
+					"172.22.0.1:50083",
+					"172.23.0.1:50083",
+					"172.24.0.1:50083",
+					"172.25.0.1:50083",
+					"172.26.0.1:50083",
+					"172.27.0.1:50083"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:29:38.144998256Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8028973883170165,
+				"StableID":   "n44L8hXLh521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3e1a94c6101554334d973f8d28097a3b1c352efc44b034ba9a3f710c9a378d00",
+				"DiscoKey":   "discokey:80529a51f5492a8b47068444185c7f283fb9f84399ce6b3b5c5d218785df054b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35325",
+					"10.65.0.27:35325",
+					"172.17.0.1:35325",
+					"172.18.0.1:35325",
+					"172.19.0.1:35325",
+					"172.20.0.1:35325",
+					"172.21.0.1:35325",
+					"172.22.0.1:35325",
+					"172.23.0.1:35325",
+					"172.24.0.1:35325",
+					"172.25.0.1:35325",
+					"172.26.0.1:35325",
+					"172.27.0.1:35325"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:29:38.639659064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2490480947865966,
+				"StableID":   "nFKU7GiwSL11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb405c595cd71a6fd381cd46bec02addb0728794748e0f330f2b75861235d600",
+				"DiscoKey":   "discokey:7a3d09ff217e504c0b86360bd0d1aab6ba2719a28217d8a6850330843e296165",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:37486",
+					"10.65.0.27:37486",
+					"172.17.0.1:37486",
+					"172.18.0.1:37486",
+					"172.19.0.1:37486",
+					"172.20.0.1:37486",
+					"172.21.0.1:37486",
+					"172.22.0.1:37486",
+					"172.23.0.1:37486",
+					"172.24.0.1:37486",
+					"172.25.0.1:37486",
+					"172.26.0.1:37486",
+					"172.27.0.1:37486"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:29:39.168681166Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1589114381480400,
+				"StableID":   "nbU3EjLiQD11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1f3efd3a35eeb9304e0cdc3813584d87a6cf3e40c6119240a5e09ae92e650f5e",
+				"KeyExpiry":  "2026-11-09T09:29:39Z",
+				"DiscoKey":   "discokey:7522b0531b5612e3170073daedefc46bc57348b91dce68cc9e07e9d087c43654",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48794",
+					"10.65.0.27:48794",
+					"172.17.0.1:48794",
+					"172.18.0.1:48794",
+					"172.19.0.1:48794",
+					"172.20.0.1:48794",
+					"172.21.0.1:48794",
+					"172.22.0.1:48794",
+					"172.23.0.1:48794",
+					"172.24.0.1:48794",
+					"172.25.0.1:48794",
+					"172.26.0.1:48794",
+					"172.27.0.1:48794"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:29:39.725982612Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5862924467252071,
+				"StableID":   "nL1iXs5Lnn11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1f2c54610b5c60ba0546dd2bcd5fc248ef5cdbf8949dd63e2f18f0856bb04514",
+				"KeyExpiry":  "2026-11-09T09:29:40Z",
+				"DiscoKey":   "discokey:38f7d9eda3690c65f595e42a0b2ed1b62379bb50523217184d143ab5c5691a5b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52155",
+					"10.65.0.27:52155",
+					"172.17.0.1:52155",
+					"172.18.0.1:52155",
+					"172.19.0.1:52155",
+					"172.20.0.1:52155",
+					"172.21.0.1:52155",
+					"172.22.0.1:52155",
+					"172.23.0.1:52155",
+					"172.24.0.1:52155",
+					"172.25.0.1:52155",
+					"172.26.0.1:52155",
+					"172.27.0.1:52155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:29:40.256259971Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3805678568696981,
+				"StableID":   "nrMYBvibiW11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:86c8345c3f407d8c6754e1ca156e1e299ad3b89dcb1d7aa937a6fa86cf03e532",
+				"KeyExpiry":  "2026-11-09T09:29:40Z",
+				"DiscoKey":   "discokey:4c23e8fbff3d7396d8260e6958541aa6749b7cc97d868d7a020ab6568befc97a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50255",
+					"10.65.0.27:50255",
+					"172.17.0.1:50255",
+					"172.18.0.1:50255",
+					"172.19.0.1:50255",
+					"172.20.0.1:50255",
+					"172.21.0.1:50255",
+					"172.22.0.1:50255",
+					"172.23.0.1:50255",
+					"172.24.0.1:50255",
+					"172.25.0.1:50255",
+					"172.26.0.1:50255",
+					"172.27.0.1:50255"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:29:40.787905965Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5481495937921774": {
+				"ID":          5481495937921774,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1589114381480400,
+				"StableID":   "nbU3EjLiQD11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1f3efd3a35eeb9304e0cdc3813584d87a6cf3e40c6119240a5e09ae92e650f5e",
+				"KeyExpiry":  "2026-11-09T09:29:39Z",
+				"DiscoKey":   "discokey:7522b0531b5612e3170073daedefc46bc57348b91dce68cc9e07e9d087c43654",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48794",
+					"10.65.0.27:48794",
+					"172.17.0.1:48794",
+					"172.18.0.1:48794",
+					"172.19.0.1:48794",
+					"172.20.0.1:48794",
+					"172.21.0.1:48794",
+					"172.22.0.1:48794",
+					"172.23.0.1:48794",
+					"172.24.0.1:48794",
+					"172.25.0.1:48794",
+					"172.26.0.1:48794",
+					"172.27.0.1:48794"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:29:39.725982612Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1f3efd3a35eeb9304e0cdc3813584d87a6cf3e40c6119240a5e09ae92e650f5e",
+			"MachineKey": "mkey:073951eaa0cce8fff7ce4baddc2761675b5dad8e4aad59c7759aabc4f6e00738",
+			"Peers": [{
+				"ID":         2859212664711574,
+				"StableID":   "n3RUGmfwKP11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:257f18e69b65ec0c700b7e2184bca19a3cf77826021794928f6980d4ef38b248",
+				"DiscoKey":   "discokey:44fd7f4dd7476297d1221f7d99732c75a33da40d06f1c636d0c4f27698923b71",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43150",
+					"10.65.0.27:43150",
+					"172.17.0.1:43150",
+					"172.18.0.1:43150",
+					"172.19.0.1:43150",
+					"172.20.0.1:43150",
+					"172.21.0.1:43150",
+					"172.22.0.1:43150",
+					"172.23.0.1:43150",
+					"172.24.0.1:43150",
+					"172.25.0.1:43150",
+					"172.26.0.1:43150",
+					"172.27.0.1:43150"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:29:33.270318864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6209384882856680,
+				"StableID":   "n7eP4g1FVq11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f9506ef72035485fc2d27b1036bba84c599ee143c5e5db39f83b16e1c7c3d204",
+				"DiscoKey":   "discokey:56bfd065fbf9aded449df431842d4e6b4e7d44457ad503c42380ad737c3c3669",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44553",
+					"10.65.0.27:44553",
+					"172.17.0.1:44553",
+					"172.18.0.1:44553",
+					"172.19.0.1:44553",
+					"172.20.0.1:44553",
+					"172.21.0.1:44553",
+					"172.22.0.1:44553",
+					"172.23.0.1:44553",
+					"172.24.0.1:44553",
+					"172.25.0.1:44553",
+					"172.26.0.1:44553",
+					"172.27.0.1:44553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:29:33.764228462Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4937306133179357,
+				"StableID":   "nCgkyGf7Zf11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ccfd85a67c2ae7d59bd0dc941483f6764942db4d3e3473d6e3ea72dd8f4db405",
+				"DiscoKey":   "discokey:9e488e31b507cc05ebb6ac225a6e756e8de09f01ac7e1425f097e7eee2c0970d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53179",
+					"10.65.0.27:53179",
+					"172.17.0.1:53179",
+					"172.18.0.1:53179",
+					"172.19.0.1:53179",
+					"172.20.0.1:53179",
+					"172.21.0.1:53179",
+					"172.22.0.1:53179",
+					"172.23.0.1:53179",
+					"172.24.0.1:53179",
+					"172.25.0.1:53179",
+					"172.26.0.1:53179",
+					"172.27.0.1:53179"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:29:34.31032901Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         493614118971451,
+				"StableID":   "nUZhPYQZr411CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1f09659d9ff3cde7edaf8075269b59c8bac1f27bc88b3fbc0a27fadbca2e54b",
+				"DiscoKey":   "discokey:260fcd6a36050179da5c80d9561e7fc2361abfa0031182fc42a9975284ef484e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60113",
+					"10.65.0.27:60113",
+					"172.17.0.1:60113",
+					"172.18.0.1:60113",
+					"172.19.0.1:60113",
+					"172.20.0.1:60113",
+					"172.21.0.1:60113",
+					"172.22.0.1:60113",
+					"172.23.0.1:60113",
+					"172.24.0.1:60113",
+					"172.25.0.1:60113",
+					"172.26.0.1:60113",
+					"172.27.0.1:60113"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:29:34.841487957Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         188686204918932,
+				"StableID":   "nmjao4UTU211CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90929a1c49724dcf491f4acc8a70e70f4917540d41fefb552b2781a75cad4643",
+				"DiscoKey":   "discokey:916e878a92a884cf8fbbc9bcb52a4206be177185311ad7bff9f62f5218030632",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50198",
+					"10.65.0.27:50198",
+					"172.17.0.1:50198",
+					"172.18.0.1:50198",
+					"172.19.0.1:50198",
+					"172.20.0.1:50198",
+					"172.21.0.1:50198",
+					"172.22.0.1:50198",
+					"172.23.0.1:50198",
+					"172.24.0.1:50198",
+					"172.25.0.1:50198",
+					"172.26.0.1:50198",
+					"172.27.0.1:50198"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:29:35.35868711Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1431992482076218,
+				"StableID":   "nFPm1q1ZBC11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:599a1b94de977777f3d8c3a8e0b472a2664b1edeb03e8da4bcd89c8c6b23a825",
+				"DiscoKey":   "discokey:ce753b107bd5f488e3b6a7325ffd0442f0debe5213132977e2f95c8bd763884b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:47841",
+					"10.65.0.27:47841",
+					"172.17.0.1:47841",
+					"172.18.0.1:47841",
+					"172.19.0.1:47841",
+					"172.20.0.1:47841",
+					"172.21.0.1:47841",
+					"172.22.0.1:47841",
+					"172.23.0.1:47841",
+					"172.24.0.1:47841",
+					"172.25.0.1:47841",
+					"172.26.0.1:47841",
+					"172.27.0.1:47841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:29:35.901475059Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2215287914480306,
+				"StableID":   "nh487irJJJ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b064330c9f805ad51a4b3336b5d3687be97805d2c12670d472d6fdb9e000015",
+				"DiscoKey":   "discokey:d569f11adb20bdbd3997acdebf4a11d7aab3609cd661e9f4e1862f858a9d2230",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50524",
+					"10.65.0.27:50524",
+					"172.17.0.1:50524",
+					"172.18.0.1:50524",
+					"172.19.0.1:50524",
+					"172.20.0.1:50524",
+					"172.21.0.1:50524",
+					"172.22.0.1:50524",
+					"172.23.0.1:50524",
+					"172.24.0.1:50524",
+					"172.25.0.1:50524",
+					"172.26.0.1:50524",
+					"172.27.0.1:50524"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:29:36.429659202Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5481495937921774,
+				"StableID":   "nhWvXzbaoj11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:645ef6e18e733de4391cc50812baa95407a0cdba46a222b12872e3c92b64b447",
+				"DiscoKey":   "discokey:eade7d7c765e230e0a081b4dca22080209816989c9309c0ca23ba874a7382b0c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36768",
+					"10.65.0.27:36768",
+					"172.17.0.1:36768",
+					"172.18.0.1:36768",
+					"172.19.0.1:36768",
+					"172.20.0.1:36768",
+					"172.21.0.1:36768",
+					"172.22.0.1:36768",
+					"172.23.0.1:36768",
+					"172.24.0.1:36768",
+					"172.25.0.1:36768",
+					"172.26.0.1:36768",
+					"172.27.0.1:36768"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:29:36.978336642Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5181403855005874,
+				"StableID":   "nDnQnChfTh11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7af9bedfaf13444d28e1664137504d38acd3737d8df9eeac69018992665b601c",
+				"DiscoKey":   "discokey:717cb5a3f65595c24e1a225bd4211fdd0022216d9e6268eef2344181e8b0cf72",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36746",
+					"10.65.0.27:36746",
+					"172.17.0.1:36746",
+					"172.18.0.1:36746",
+					"172.19.0.1:36746",
+					"172.20.0.1:36746",
+					"172.21.0.1:36746",
+					"172.22.0.1:36746",
+					"172.23.0.1:36746",
+					"172.24.0.1:36746",
+					"172.25.0.1:36746",
+					"172.26.0.1:36746",
+					"172.27.0.1:36746"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:29:37.52519162Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5947777451816847,
+				"StableID":   "nUXBDd2mSo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9320fbe912baef9f83844e8f5526b56748d328d5ad9bcf9d4f76a3e855cb2147",
+				"DiscoKey":   "discokey:821b02cb0acf6fc1a36d2c95273c0663e0233c9d928fe1bdb60b6d57fa2c6f22",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50083",
+					"10.65.0.27:50083",
+					"172.17.0.1:50083",
+					"172.18.0.1:50083",
+					"172.19.0.1:50083",
+					"172.20.0.1:50083",
+					"172.21.0.1:50083",
+					"172.22.0.1:50083",
+					"172.23.0.1:50083",
+					"172.24.0.1:50083",
+					"172.25.0.1:50083",
+					"172.26.0.1:50083",
+					"172.27.0.1:50083"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:29:38.144998256Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8028973883170165,
+				"StableID":   "n44L8hXLh521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3e1a94c6101554334d973f8d28097a3b1c352efc44b034ba9a3f710c9a378d00",
+				"DiscoKey":   "discokey:80529a51f5492a8b47068444185c7f283fb9f84399ce6b3b5c5d218785df054b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35325",
+					"10.65.0.27:35325",
+					"172.17.0.1:35325",
+					"172.18.0.1:35325",
+					"172.19.0.1:35325",
+					"172.20.0.1:35325",
+					"172.21.0.1:35325",
+					"172.22.0.1:35325",
+					"172.23.0.1:35325",
+					"172.24.0.1:35325",
+					"172.25.0.1:35325",
+					"172.26.0.1:35325",
+					"172.27.0.1:35325"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:29:38.639659064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2490480947865966,
+				"StableID":   "nFKU7GiwSL11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb405c595cd71a6fd381cd46bec02addb0728794748e0f330f2b75861235d600",
+				"DiscoKey":   "discokey:7a3d09ff217e504c0b86360bd0d1aab6ba2719a28217d8a6850330843e296165",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:37486",
+					"10.65.0.27:37486",
+					"172.17.0.1:37486",
+					"172.18.0.1:37486",
+					"172.19.0.1:37486",
+					"172.20.0.1:37486",
+					"172.21.0.1:37486",
+					"172.22.0.1:37486",
+					"172.23.0.1:37486",
+					"172.24.0.1:37486",
+					"172.25.0.1:37486",
+					"172.26.0.1:37486",
+					"172.27.0.1:37486"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:29:39.168681166Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5862924467252071,
+				"StableID":   "nL1iXs5Lnn11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1f2c54610b5c60ba0546dd2bcd5fc248ef5cdbf8949dd63e2f18f0856bb04514",
+				"KeyExpiry":  "2026-11-09T09:29:40Z",
+				"DiscoKey":   "discokey:38f7d9eda3690c65f595e42a0b2ed1b62379bb50523217184d143ab5c5691a5b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52155",
+					"10.65.0.27:52155",
+					"172.17.0.1:52155",
+					"172.18.0.1:52155",
+					"172.19.0.1:52155",
+					"172.20.0.1:52155",
+					"172.21.0.1:52155",
+					"172.22.0.1:52155",
+					"172.23.0.1:52155",
+					"172.24.0.1:52155",
+					"172.25.0.1:52155",
+					"172.26.0.1:52155",
+					"172.27.0.1:52155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:29:40.256259971Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3805678568696981,
+				"StableID":   "nrMYBvibiW11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:86c8345c3f407d8c6754e1ca156e1e299ad3b89dcb1d7aa937a6fa86cf03e532",
+				"KeyExpiry":  "2026-11-09T09:29:40Z",
+				"DiscoKey":   "discokey:4c23e8fbff3d7396d8260e6958541aa6749b7cc97d868d7a020ab6568befc97a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50255",
+					"10.65.0.27:50255",
+					"172.17.0.1:50255",
+					"172.18.0.1:50255",
+					"172.19.0.1:50255",
+					"172.20.0.1:50255",
+					"172.21.0.1:50255",
+					"172.22.0.1:50255",
+					"172.23.0.1:50255",
+					"172.24.0.1:50255",
+					"172.25.0.1:50255",
+					"172.26.0.1:50255",
+					"172.27.0.1:50255"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:29:40.787905965Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8028973883170165,
+				"StableID":   "n44L8hXLh521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       8028973883170165,
+				"Key":        "nodekey:3e1a94c6101554334d973f8d28097a3b1c352efc44b034ba9a3f710c9a378d00",
+				"DiscoKey":   "discokey:80529a51f5492a8b47068444185c7f283fb9f84399ce6b3b5c5d218785df054b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35325",
+					"10.65.0.27:35325",
+					"172.17.0.1:35325",
+					"172.18.0.1:35325",
+					"172.19.0.1:35325",
+					"172.20.0.1:35325",
+					"172.21.0.1:35325",
+					"172.22.0.1:35325",
+					"172.23.0.1:35325",
+					"172.24.0.1:35325",
+					"172.25.0.1:35325",
+					"172.26.0.1:35325",
+					"172.27.0.1:35325"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:29:38.639659064Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3e1a94c6101554334d973f8d28097a3b1c352efc44b034ba9a3f710c9a378d00",
+			"MachineKey": "mkey:bf1fec9e3f2468c824b136d52213782f032be319a754215216e8a3b29e1f1230",
+			"Peers": [{
+				"ID":         2859212664711574,
+				"StableID":   "n3RUGmfwKP11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:257f18e69b65ec0c700b7e2184bca19a3cf77826021794928f6980d4ef38b248",
+				"DiscoKey":   "discokey:44fd7f4dd7476297d1221f7d99732c75a33da40d06f1c636d0c4f27698923b71",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43150",
+					"10.65.0.27:43150",
+					"172.17.0.1:43150",
+					"172.18.0.1:43150",
+					"172.19.0.1:43150",
+					"172.20.0.1:43150",
+					"172.21.0.1:43150",
+					"172.22.0.1:43150",
+					"172.23.0.1:43150",
+					"172.24.0.1:43150",
+					"172.25.0.1:43150",
+					"172.26.0.1:43150",
+					"172.27.0.1:43150"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:29:33.270318864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6209384882856680,
+				"StableID":   "n7eP4g1FVq11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f9506ef72035485fc2d27b1036bba84c599ee143c5e5db39f83b16e1c7c3d204",
+				"DiscoKey":   "discokey:56bfd065fbf9aded449df431842d4e6b4e7d44457ad503c42380ad737c3c3669",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44553",
+					"10.65.0.27:44553",
+					"172.17.0.1:44553",
+					"172.18.0.1:44553",
+					"172.19.0.1:44553",
+					"172.20.0.1:44553",
+					"172.21.0.1:44553",
+					"172.22.0.1:44553",
+					"172.23.0.1:44553",
+					"172.24.0.1:44553",
+					"172.25.0.1:44553",
+					"172.26.0.1:44553",
+					"172.27.0.1:44553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:29:33.764228462Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4937306133179357,
+				"StableID":   "nCgkyGf7Zf11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ccfd85a67c2ae7d59bd0dc941483f6764942db4d3e3473d6e3ea72dd8f4db405",
+				"DiscoKey":   "discokey:9e488e31b507cc05ebb6ac225a6e756e8de09f01ac7e1425f097e7eee2c0970d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53179",
+					"10.65.0.27:53179",
+					"172.17.0.1:53179",
+					"172.18.0.1:53179",
+					"172.19.0.1:53179",
+					"172.20.0.1:53179",
+					"172.21.0.1:53179",
+					"172.22.0.1:53179",
+					"172.23.0.1:53179",
+					"172.24.0.1:53179",
+					"172.25.0.1:53179",
+					"172.26.0.1:53179",
+					"172.27.0.1:53179"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:29:34.31032901Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         493614118971451,
+				"StableID":   "nUZhPYQZr411CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1f09659d9ff3cde7edaf8075269b59c8bac1f27bc88b3fbc0a27fadbca2e54b",
+				"DiscoKey":   "discokey:260fcd6a36050179da5c80d9561e7fc2361abfa0031182fc42a9975284ef484e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60113",
+					"10.65.0.27:60113",
+					"172.17.0.1:60113",
+					"172.18.0.1:60113",
+					"172.19.0.1:60113",
+					"172.20.0.1:60113",
+					"172.21.0.1:60113",
+					"172.22.0.1:60113",
+					"172.23.0.1:60113",
+					"172.24.0.1:60113",
+					"172.25.0.1:60113",
+					"172.26.0.1:60113",
+					"172.27.0.1:60113"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:29:34.841487957Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         188686204918932,
+				"StableID":   "nmjao4UTU211CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90929a1c49724dcf491f4acc8a70e70f4917540d41fefb552b2781a75cad4643",
+				"DiscoKey":   "discokey:916e878a92a884cf8fbbc9bcb52a4206be177185311ad7bff9f62f5218030632",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50198",
+					"10.65.0.27:50198",
+					"172.17.0.1:50198",
+					"172.18.0.1:50198",
+					"172.19.0.1:50198",
+					"172.20.0.1:50198",
+					"172.21.0.1:50198",
+					"172.22.0.1:50198",
+					"172.23.0.1:50198",
+					"172.24.0.1:50198",
+					"172.25.0.1:50198",
+					"172.26.0.1:50198",
+					"172.27.0.1:50198"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:29:35.35868711Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1431992482076218,
+				"StableID":   "nFPm1q1ZBC11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:599a1b94de977777f3d8c3a8e0b472a2664b1edeb03e8da4bcd89c8c6b23a825",
+				"DiscoKey":   "discokey:ce753b107bd5f488e3b6a7325ffd0442f0debe5213132977e2f95c8bd763884b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:47841",
+					"10.65.0.27:47841",
+					"172.17.0.1:47841",
+					"172.18.0.1:47841",
+					"172.19.0.1:47841",
+					"172.20.0.1:47841",
+					"172.21.0.1:47841",
+					"172.22.0.1:47841",
+					"172.23.0.1:47841",
+					"172.24.0.1:47841",
+					"172.25.0.1:47841",
+					"172.26.0.1:47841",
+					"172.27.0.1:47841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:29:35.901475059Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2215287914480306,
+				"StableID":   "nh487irJJJ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b064330c9f805ad51a4b3336b5d3687be97805d2c12670d472d6fdb9e000015",
+				"DiscoKey":   "discokey:d569f11adb20bdbd3997acdebf4a11d7aab3609cd661e9f4e1862f858a9d2230",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50524",
+					"10.65.0.27:50524",
+					"172.17.0.1:50524",
+					"172.18.0.1:50524",
+					"172.19.0.1:50524",
+					"172.20.0.1:50524",
+					"172.21.0.1:50524",
+					"172.22.0.1:50524",
+					"172.23.0.1:50524",
+					"172.24.0.1:50524",
+					"172.25.0.1:50524",
+					"172.26.0.1:50524",
+					"172.27.0.1:50524"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:29:36.429659202Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5481495937921774,
+				"StableID":   "nhWvXzbaoj11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:645ef6e18e733de4391cc50812baa95407a0cdba46a222b12872e3c92b64b447",
+				"DiscoKey":   "discokey:eade7d7c765e230e0a081b4dca22080209816989c9309c0ca23ba874a7382b0c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36768",
+					"10.65.0.27:36768",
+					"172.17.0.1:36768",
+					"172.18.0.1:36768",
+					"172.19.0.1:36768",
+					"172.20.0.1:36768",
+					"172.21.0.1:36768",
+					"172.22.0.1:36768",
+					"172.23.0.1:36768",
+					"172.24.0.1:36768",
+					"172.25.0.1:36768",
+					"172.26.0.1:36768",
+					"172.27.0.1:36768"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:29:36.978336642Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5181403855005874,
+				"StableID":   "nDnQnChfTh11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7af9bedfaf13444d28e1664137504d38acd3737d8df9eeac69018992665b601c",
+				"DiscoKey":   "discokey:717cb5a3f65595c24e1a225bd4211fdd0022216d9e6268eef2344181e8b0cf72",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36746",
+					"10.65.0.27:36746",
+					"172.17.0.1:36746",
+					"172.18.0.1:36746",
+					"172.19.0.1:36746",
+					"172.20.0.1:36746",
+					"172.21.0.1:36746",
+					"172.22.0.1:36746",
+					"172.23.0.1:36746",
+					"172.24.0.1:36746",
+					"172.25.0.1:36746",
+					"172.26.0.1:36746",
+					"172.27.0.1:36746"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:29:37.52519162Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5947777451816847,
+				"StableID":   "nUXBDd2mSo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9320fbe912baef9f83844e8f5526b56748d328d5ad9bcf9d4f76a3e855cb2147",
+				"DiscoKey":   "discokey:821b02cb0acf6fc1a36d2c95273c0663e0233c9d928fe1bdb60b6d57fa2c6f22",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50083",
+					"10.65.0.27:50083",
+					"172.17.0.1:50083",
+					"172.18.0.1:50083",
+					"172.19.0.1:50083",
+					"172.20.0.1:50083",
+					"172.21.0.1:50083",
+					"172.22.0.1:50083",
+					"172.23.0.1:50083",
+					"172.24.0.1:50083",
+					"172.25.0.1:50083",
+					"172.26.0.1:50083",
+					"172.27.0.1:50083"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:29:38.144998256Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2490480947865966,
+				"StableID":   "nFKU7GiwSL11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb405c595cd71a6fd381cd46bec02addb0728794748e0f330f2b75861235d600",
+				"DiscoKey":   "discokey:7a3d09ff217e504c0b86360bd0d1aab6ba2719a28217d8a6850330843e296165",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:37486",
+					"10.65.0.27:37486",
+					"172.17.0.1:37486",
+					"172.18.0.1:37486",
+					"172.19.0.1:37486",
+					"172.20.0.1:37486",
+					"172.21.0.1:37486",
+					"172.22.0.1:37486",
+					"172.23.0.1:37486",
+					"172.24.0.1:37486",
+					"172.25.0.1:37486",
+					"172.26.0.1:37486",
+					"172.27.0.1:37486"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:29:39.168681166Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1589114381480400,
+				"StableID":   "nbU3EjLiQD11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1f3efd3a35eeb9304e0cdc3813584d87a6cf3e40c6119240a5e09ae92e650f5e",
+				"KeyExpiry":  "2026-11-09T09:29:39Z",
+				"DiscoKey":   "discokey:7522b0531b5612e3170073daedefc46bc57348b91dce68cc9e07e9d087c43654",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48794",
+					"10.65.0.27:48794",
+					"172.17.0.1:48794",
+					"172.18.0.1:48794",
+					"172.19.0.1:48794",
+					"172.20.0.1:48794",
+					"172.21.0.1:48794",
+					"172.22.0.1:48794",
+					"172.23.0.1:48794",
+					"172.24.0.1:48794",
+					"172.25.0.1:48794",
+					"172.26.0.1:48794",
+					"172.27.0.1:48794"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:29:39.725982612Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5862924467252071,
+				"StableID":   "nL1iXs5Lnn11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1f2c54610b5c60ba0546dd2bcd5fc248ef5cdbf8949dd63e2f18f0856bb04514",
+				"KeyExpiry":  "2026-11-09T09:29:40Z",
+				"DiscoKey":   "discokey:38f7d9eda3690c65f595e42a0b2ed1b62379bb50523217184d143ab5c5691a5b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52155",
+					"10.65.0.27:52155",
+					"172.17.0.1:52155",
+					"172.18.0.1:52155",
+					"172.19.0.1:52155",
+					"172.20.0.1:52155",
+					"172.21.0.1:52155",
+					"172.22.0.1:52155",
+					"172.23.0.1:52155",
+					"172.24.0.1:52155",
+					"172.25.0.1:52155",
+					"172.26.0.1:52155",
+					"172.27.0.1:52155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:29:40.256259971Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3805678568696981,
+				"StableID":   "nrMYBvibiW11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:86c8345c3f407d8c6754e1ca156e1e299ad3b89dcb1d7aa937a6fa86cf03e532",
+				"KeyExpiry":  "2026-11-09T09:29:40Z",
+				"DiscoKey":   "discokey:4c23e8fbff3d7396d8260e6958541aa6749b7cc97d868d7a020ab6568befc97a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50255",
+					"10.65.0.27:50255",
+					"172.17.0.1:50255",
+					"172.18.0.1:50255",
+					"172.19.0.1:50255",
+					"172.20.0.1:50255",
+					"172.21.0.1:50255",
+					"172.22.0.1:50255",
+					"172.23.0.1:50255",
+					"172.24.0.1:50255",
+					"172.25.0.1:50255",
+					"172.26.0.1:50255",
+					"172.27.0.1:50255"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:29:40.787905965Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8028973883170165": {
+				"ID":          8028973883170165,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6209384882856680,
+				"StableID":   "n7eP4g1FVq11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       6209384882856680,
+				"Key":        "nodekey:f9506ef72035485fc2d27b1036bba84c599ee143c5e5db39f83b16e1c7c3d204",
+				"DiscoKey":   "discokey:56bfd065fbf9aded449df431842d4e6b4e7d44457ad503c42380ad737c3c3669",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44553",
+					"10.65.0.27:44553",
+					"172.17.0.1:44553",
+					"172.18.0.1:44553",
+					"172.19.0.1:44553",
+					"172.20.0.1:44553",
+					"172.21.0.1:44553",
+					"172.22.0.1:44553",
+					"172.23.0.1:44553",
+					"172.24.0.1:44553",
+					"172.25.0.1:44553",
+					"172.26.0.1:44553",
+					"172.27.0.1:44553"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:29:33.764228462Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f9506ef72035485fc2d27b1036bba84c599ee143c5e5db39f83b16e1c7c3d204",
+			"MachineKey": "mkey:d42d20dcf211a7991b14926851e4a2b602d88e78adbaf6d8429f4cdb6a127f37",
+			"Peers": [{
+				"ID":         2859212664711574,
+				"StableID":   "n3RUGmfwKP11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:257f18e69b65ec0c700b7e2184bca19a3cf77826021794928f6980d4ef38b248",
+				"DiscoKey":   "discokey:44fd7f4dd7476297d1221f7d99732c75a33da40d06f1c636d0c4f27698923b71",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43150",
+					"10.65.0.27:43150",
+					"172.17.0.1:43150",
+					"172.18.0.1:43150",
+					"172.19.0.1:43150",
+					"172.20.0.1:43150",
+					"172.21.0.1:43150",
+					"172.22.0.1:43150",
+					"172.23.0.1:43150",
+					"172.24.0.1:43150",
+					"172.25.0.1:43150",
+					"172.26.0.1:43150",
+					"172.27.0.1:43150"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:29:33.270318864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4937306133179357,
+				"StableID":   "nCgkyGf7Zf11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ccfd85a67c2ae7d59bd0dc941483f6764942db4d3e3473d6e3ea72dd8f4db405",
+				"DiscoKey":   "discokey:9e488e31b507cc05ebb6ac225a6e756e8de09f01ac7e1425f097e7eee2c0970d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53179",
+					"10.65.0.27:53179",
+					"172.17.0.1:53179",
+					"172.18.0.1:53179",
+					"172.19.0.1:53179",
+					"172.20.0.1:53179",
+					"172.21.0.1:53179",
+					"172.22.0.1:53179",
+					"172.23.0.1:53179",
+					"172.24.0.1:53179",
+					"172.25.0.1:53179",
+					"172.26.0.1:53179",
+					"172.27.0.1:53179"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:29:34.31032901Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         493614118971451,
+				"StableID":   "nUZhPYQZr411CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1f09659d9ff3cde7edaf8075269b59c8bac1f27bc88b3fbc0a27fadbca2e54b",
+				"DiscoKey":   "discokey:260fcd6a36050179da5c80d9561e7fc2361abfa0031182fc42a9975284ef484e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60113",
+					"10.65.0.27:60113",
+					"172.17.0.1:60113",
+					"172.18.0.1:60113",
+					"172.19.0.1:60113",
+					"172.20.0.1:60113",
+					"172.21.0.1:60113",
+					"172.22.0.1:60113",
+					"172.23.0.1:60113",
+					"172.24.0.1:60113",
+					"172.25.0.1:60113",
+					"172.26.0.1:60113",
+					"172.27.0.1:60113"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:29:34.841487957Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         188686204918932,
+				"StableID":   "nmjao4UTU211CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90929a1c49724dcf491f4acc8a70e70f4917540d41fefb552b2781a75cad4643",
+				"DiscoKey":   "discokey:916e878a92a884cf8fbbc9bcb52a4206be177185311ad7bff9f62f5218030632",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50198",
+					"10.65.0.27:50198",
+					"172.17.0.1:50198",
+					"172.18.0.1:50198",
+					"172.19.0.1:50198",
+					"172.20.0.1:50198",
+					"172.21.0.1:50198",
+					"172.22.0.1:50198",
+					"172.23.0.1:50198",
+					"172.24.0.1:50198",
+					"172.25.0.1:50198",
+					"172.26.0.1:50198",
+					"172.27.0.1:50198"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:29:35.35868711Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1431992482076218,
+				"StableID":   "nFPm1q1ZBC11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:599a1b94de977777f3d8c3a8e0b472a2664b1edeb03e8da4bcd89c8c6b23a825",
+				"DiscoKey":   "discokey:ce753b107bd5f488e3b6a7325ffd0442f0debe5213132977e2f95c8bd763884b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:47841",
+					"10.65.0.27:47841",
+					"172.17.0.1:47841",
+					"172.18.0.1:47841",
+					"172.19.0.1:47841",
+					"172.20.0.1:47841",
+					"172.21.0.1:47841",
+					"172.22.0.1:47841",
+					"172.23.0.1:47841",
+					"172.24.0.1:47841",
+					"172.25.0.1:47841",
+					"172.26.0.1:47841",
+					"172.27.0.1:47841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:29:35.901475059Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2215287914480306,
+				"StableID":   "nh487irJJJ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b064330c9f805ad51a4b3336b5d3687be97805d2c12670d472d6fdb9e000015",
+				"DiscoKey":   "discokey:d569f11adb20bdbd3997acdebf4a11d7aab3609cd661e9f4e1862f858a9d2230",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50524",
+					"10.65.0.27:50524",
+					"172.17.0.1:50524",
+					"172.18.0.1:50524",
+					"172.19.0.1:50524",
+					"172.20.0.1:50524",
+					"172.21.0.1:50524",
+					"172.22.0.1:50524",
+					"172.23.0.1:50524",
+					"172.24.0.1:50524",
+					"172.25.0.1:50524",
+					"172.26.0.1:50524",
+					"172.27.0.1:50524"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:29:36.429659202Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5481495937921774,
+				"StableID":   "nhWvXzbaoj11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:645ef6e18e733de4391cc50812baa95407a0cdba46a222b12872e3c92b64b447",
+				"DiscoKey":   "discokey:eade7d7c765e230e0a081b4dca22080209816989c9309c0ca23ba874a7382b0c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36768",
+					"10.65.0.27:36768",
+					"172.17.0.1:36768",
+					"172.18.0.1:36768",
+					"172.19.0.1:36768",
+					"172.20.0.1:36768",
+					"172.21.0.1:36768",
+					"172.22.0.1:36768",
+					"172.23.0.1:36768",
+					"172.24.0.1:36768",
+					"172.25.0.1:36768",
+					"172.26.0.1:36768",
+					"172.27.0.1:36768"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:29:36.978336642Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5181403855005874,
+				"StableID":   "nDnQnChfTh11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7af9bedfaf13444d28e1664137504d38acd3737d8df9eeac69018992665b601c",
+				"DiscoKey":   "discokey:717cb5a3f65595c24e1a225bd4211fdd0022216d9e6268eef2344181e8b0cf72",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36746",
+					"10.65.0.27:36746",
+					"172.17.0.1:36746",
+					"172.18.0.1:36746",
+					"172.19.0.1:36746",
+					"172.20.0.1:36746",
+					"172.21.0.1:36746",
+					"172.22.0.1:36746",
+					"172.23.0.1:36746",
+					"172.24.0.1:36746",
+					"172.25.0.1:36746",
+					"172.26.0.1:36746",
+					"172.27.0.1:36746"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:29:37.52519162Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5947777451816847,
+				"StableID":   "nUXBDd2mSo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9320fbe912baef9f83844e8f5526b56748d328d5ad9bcf9d4f76a3e855cb2147",
+				"DiscoKey":   "discokey:821b02cb0acf6fc1a36d2c95273c0663e0233c9d928fe1bdb60b6d57fa2c6f22",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50083",
+					"10.65.0.27:50083",
+					"172.17.0.1:50083",
+					"172.18.0.1:50083",
+					"172.19.0.1:50083",
+					"172.20.0.1:50083",
+					"172.21.0.1:50083",
+					"172.22.0.1:50083",
+					"172.23.0.1:50083",
+					"172.24.0.1:50083",
+					"172.25.0.1:50083",
+					"172.26.0.1:50083",
+					"172.27.0.1:50083"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:29:38.144998256Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8028973883170165,
+				"StableID":   "n44L8hXLh521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3e1a94c6101554334d973f8d28097a3b1c352efc44b034ba9a3f710c9a378d00",
+				"DiscoKey":   "discokey:80529a51f5492a8b47068444185c7f283fb9f84399ce6b3b5c5d218785df054b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35325",
+					"10.65.0.27:35325",
+					"172.17.0.1:35325",
+					"172.18.0.1:35325",
+					"172.19.0.1:35325",
+					"172.20.0.1:35325",
+					"172.21.0.1:35325",
+					"172.22.0.1:35325",
+					"172.23.0.1:35325",
+					"172.24.0.1:35325",
+					"172.25.0.1:35325",
+					"172.26.0.1:35325",
+					"172.27.0.1:35325"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:29:38.639659064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2490480947865966,
+				"StableID":   "nFKU7GiwSL11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb405c595cd71a6fd381cd46bec02addb0728794748e0f330f2b75861235d600",
+				"DiscoKey":   "discokey:7a3d09ff217e504c0b86360bd0d1aab6ba2719a28217d8a6850330843e296165",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:37486",
+					"10.65.0.27:37486",
+					"172.17.0.1:37486",
+					"172.18.0.1:37486",
+					"172.19.0.1:37486",
+					"172.20.0.1:37486",
+					"172.21.0.1:37486",
+					"172.22.0.1:37486",
+					"172.23.0.1:37486",
+					"172.24.0.1:37486",
+					"172.25.0.1:37486",
+					"172.26.0.1:37486",
+					"172.27.0.1:37486"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:29:39.168681166Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1589114381480400,
+				"StableID":   "nbU3EjLiQD11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1f3efd3a35eeb9304e0cdc3813584d87a6cf3e40c6119240a5e09ae92e650f5e",
+				"KeyExpiry":  "2026-11-09T09:29:39Z",
+				"DiscoKey":   "discokey:7522b0531b5612e3170073daedefc46bc57348b91dce68cc9e07e9d087c43654",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48794",
+					"10.65.0.27:48794",
+					"172.17.0.1:48794",
+					"172.18.0.1:48794",
+					"172.19.0.1:48794",
+					"172.20.0.1:48794",
+					"172.21.0.1:48794",
+					"172.22.0.1:48794",
+					"172.23.0.1:48794",
+					"172.24.0.1:48794",
+					"172.25.0.1:48794",
+					"172.26.0.1:48794",
+					"172.27.0.1:48794"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:29:39.725982612Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5862924467252071,
+				"StableID":   "nL1iXs5Lnn11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1f2c54610b5c60ba0546dd2bcd5fc248ef5cdbf8949dd63e2f18f0856bb04514",
+				"KeyExpiry":  "2026-11-09T09:29:40Z",
+				"DiscoKey":   "discokey:38f7d9eda3690c65f595e42a0b2ed1b62379bb50523217184d143ab5c5691a5b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52155",
+					"10.65.0.27:52155",
+					"172.17.0.1:52155",
+					"172.18.0.1:52155",
+					"172.19.0.1:52155",
+					"172.20.0.1:52155",
+					"172.21.0.1:52155",
+					"172.22.0.1:52155",
+					"172.23.0.1:52155",
+					"172.24.0.1:52155",
+					"172.25.0.1:52155",
+					"172.26.0.1:52155",
+					"172.27.0.1:52155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:29:40.256259971Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3805678568696981,
+				"StableID":   "nrMYBvibiW11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:86c8345c3f407d8c6754e1ca156e1e299ad3b89dcb1d7aa937a6fa86cf03e532",
+				"KeyExpiry":  "2026-11-09T09:29:40Z",
+				"DiscoKey":   "discokey:4c23e8fbff3d7396d8260e6958541aa6749b7cc97d868d7a020ab6568befc97a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50255",
+					"10.65.0.27:50255",
+					"172.17.0.1:50255",
+					"172.18.0.1:50255",
+					"172.19.0.1:50255",
+					"172.20.0.1:50255",
+					"172.21.0.1:50255",
+					"172.22.0.1:50255",
+					"172.23.0.1:50255",
+					"172.24.0.1:50255",
+					"172.25.0.1:50255",
+					"172.26.0.1:50255",
+					"172.27.0.1:50255"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:29:40.787905965Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6209384882856680": {
+				"ID":          6209384882856680,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2859212664711574,
+				"StableID":   "n3RUGmfwKP11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       2859212664711574,
+				"Key":        "nodekey:257f18e69b65ec0c700b7e2184bca19a3cf77826021794928f6980d4ef38b248",
+				"DiscoKey":   "discokey:44fd7f4dd7476297d1221f7d99732c75a33da40d06f1c636d0c4f27698923b71",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43150",
+					"10.65.0.27:43150",
+					"172.17.0.1:43150",
+					"172.18.0.1:43150",
+					"172.19.0.1:43150",
+					"172.20.0.1:43150",
+					"172.21.0.1:43150",
+					"172.22.0.1:43150",
+					"172.23.0.1:43150",
+					"172.24.0.1:43150",
+					"172.25.0.1:43150",
+					"172.26.0.1:43150",
+					"172.27.0.1:43150"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:29:33.270318864Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:257f18e69b65ec0c700b7e2184bca19a3cf77826021794928f6980d4ef38b248",
+			"MachineKey": "mkey:fde774de496b45f37b87433f85b1a5b8c7230580071846d9782da312b62f333d",
+			"Peers": [{
+				"ID":         6209384882856680,
+				"StableID":   "n7eP4g1FVq11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f9506ef72035485fc2d27b1036bba84c599ee143c5e5db39f83b16e1c7c3d204",
+				"DiscoKey":   "discokey:56bfd065fbf9aded449df431842d4e6b4e7d44457ad503c42380ad737c3c3669",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44553",
+					"10.65.0.27:44553",
+					"172.17.0.1:44553",
+					"172.18.0.1:44553",
+					"172.19.0.1:44553",
+					"172.20.0.1:44553",
+					"172.21.0.1:44553",
+					"172.22.0.1:44553",
+					"172.23.0.1:44553",
+					"172.24.0.1:44553",
+					"172.25.0.1:44553",
+					"172.26.0.1:44553",
+					"172.27.0.1:44553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:29:33.764228462Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4937306133179357,
+				"StableID":   "nCgkyGf7Zf11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ccfd85a67c2ae7d59bd0dc941483f6764942db4d3e3473d6e3ea72dd8f4db405",
+				"DiscoKey":   "discokey:9e488e31b507cc05ebb6ac225a6e756e8de09f01ac7e1425f097e7eee2c0970d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53179",
+					"10.65.0.27:53179",
+					"172.17.0.1:53179",
+					"172.18.0.1:53179",
+					"172.19.0.1:53179",
+					"172.20.0.1:53179",
+					"172.21.0.1:53179",
+					"172.22.0.1:53179",
+					"172.23.0.1:53179",
+					"172.24.0.1:53179",
+					"172.25.0.1:53179",
+					"172.26.0.1:53179",
+					"172.27.0.1:53179"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:29:34.31032901Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         493614118971451,
+				"StableID":   "nUZhPYQZr411CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1f09659d9ff3cde7edaf8075269b59c8bac1f27bc88b3fbc0a27fadbca2e54b",
+				"DiscoKey":   "discokey:260fcd6a36050179da5c80d9561e7fc2361abfa0031182fc42a9975284ef484e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60113",
+					"10.65.0.27:60113",
+					"172.17.0.1:60113",
+					"172.18.0.1:60113",
+					"172.19.0.1:60113",
+					"172.20.0.1:60113",
+					"172.21.0.1:60113",
+					"172.22.0.1:60113",
+					"172.23.0.1:60113",
+					"172.24.0.1:60113",
+					"172.25.0.1:60113",
+					"172.26.0.1:60113",
+					"172.27.0.1:60113"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:29:34.841487957Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         188686204918932,
+				"StableID":   "nmjao4UTU211CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90929a1c49724dcf491f4acc8a70e70f4917540d41fefb552b2781a75cad4643",
+				"DiscoKey":   "discokey:916e878a92a884cf8fbbc9bcb52a4206be177185311ad7bff9f62f5218030632",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50198",
+					"10.65.0.27:50198",
+					"172.17.0.1:50198",
+					"172.18.0.1:50198",
+					"172.19.0.1:50198",
+					"172.20.0.1:50198",
+					"172.21.0.1:50198",
+					"172.22.0.1:50198",
+					"172.23.0.1:50198",
+					"172.24.0.1:50198",
+					"172.25.0.1:50198",
+					"172.26.0.1:50198",
+					"172.27.0.1:50198"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:29:35.35868711Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1431992482076218,
+				"StableID":   "nFPm1q1ZBC11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:599a1b94de977777f3d8c3a8e0b472a2664b1edeb03e8da4bcd89c8c6b23a825",
+				"DiscoKey":   "discokey:ce753b107bd5f488e3b6a7325ffd0442f0debe5213132977e2f95c8bd763884b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:47841",
+					"10.65.0.27:47841",
+					"172.17.0.1:47841",
+					"172.18.0.1:47841",
+					"172.19.0.1:47841",
+					"172.20.0.1:47841",
+					"172.21.0.1:47841",
+					"172.22.0.1:47841",
+					"172.23.0.1:47841",
+					"172.24.0.1:47841",
+					"172.25.0.1:47841",
+					"172.26.0.1:47841",
+					"172.27.0.1:47841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:29:35.901475059Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2215287914480306,
+				"StableID":   "nh487irJJJ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b064330c9f805ad51a4b3336b5d3687be97805d2c12670d472d6fdb9e000015",
+				"DiscoKey":   "discokey:d569f11adb20bdbd3997acdebf4a11d7aab3609cd661e9f4e1862f858a9d2230",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50524",
+					"10.65.0.27:50524",
+					"172.17.0.1:50524",
+					"172.18.0.1:50524",
+					"172.19.0.1:50524",
+					"172.20.0.1:50524",
+					"172.21.0.1:50524",
+					"172.22.0.1:50524",
+					"172.23.0.1:50524",
+					"172.24.0.1:50524",
+					"172.25.0.1:50524",
+					"172.26.0.1:50524",
+					"172.27.0.1:50524"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:29:36.429659202Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5481495937921774,
+				"StableID":   "nhWvXzbaoj11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:645ef6e18e733de4391cc50812baa95407a0cdba46a222b12872e3c92b64b447",
+				"DiscoKey":   "discokey:eade7d7c765e230e0a081b4dca22080209816989c9309c0ca23ba874a7382b0c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36768",
+					"10.65.0.27:36768",
+					"172.17.0.1:36768",
+					"172.18.0.1:36768",
+					"172.19.0.1:36768",
+					"172.20.0.1:36768",
+					"172.21.0.1:36768",
+					"172.22.0.1:36768",
+					"172.23.0.1:36768",
+					"172.24.0.1:36768",
+					"172.25.0.1:36768",
+					"172.26.0.1:36768",
+					"172.27.0.1:36768"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:29:36.978336642Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5181403855005874,
+				"StableID":   "nDnQnChfTh11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7af9bedfaf13444d28e1664137504d38acd3737d8df9eeac69018992665b601c",
+				"DiscoKey":   "discokey:717cb5a3f65595c24e1a225bd4211fdd0022216d9e6268eef2344181e8b0cf72",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36746",
+					"10.65.0.27:36746",
+					"172.17.0.1:36746",
+					"172.18.0.1:36746",
+					"172.19.0.1:36746",
+					"172.20.0.1:36746",
+					"172.21.0.1:36746",
+					"172.22.0.1:36746",
+					"172.23.0.1:36746",
+					"172.24.0.1:36746",
+					"172.25.0.1:36746",
+					"172.26.0.1:36746",
+					"172.27.0.1:36746"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:29:37.52519162Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5947777451816847,
+				"StableID":   "nUXBDd2mSo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9320fbe912baef9f83844e8f5526b56748d328d5ad9bcf9d4f76a3e855cb2147",
+				"DiscoKey":   "discokey:821b02cb0acf6fc1a36d2c95273c0663e0233c9d928fe1bdb60b6d57fa2c6f22",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50083",
+					"10.65.0.27:50083",
+					"172.17.0.1:50083",
+					"172.18.0.1:50083",
+					"172.19.0.1:50083",
+					"172.20.0.1:50083",
+					"172.21.0.1:50083",
+					"172.22.0.1:50083",
+					"172.23.0.1:50083",
+					"172.24.0.1:50083",
+					"172.25.0.1:50083",
+					"172.26.0.1:50083",
+					"172.27.0.1:50083"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:29:38.144998256Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8028973883170165,
+				"StableID":   "n44L8hXLh521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3e1a94c6101554334d973f8d28097a3b1c352efc44b034ba9a3f710c9a378d00",
+				"DiscoKey":   "discokey:80529a51f5492a8b47068444185c7f283fb9f84399ce6b3b5c5d218785df054b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35325",
+					"10.65.0.27:35325",
+					"172.17.0.1:35325",
+					"172.18.0.1:35325",
+					"172.19.0.1:35325",
+					"172.20.0.1:35325",
+					"172.21.0.1:35325",
+					"172.22.0.1:35325",
+					"172.23.0.1:35325",
+					"172.24.0.1:35325",
+					"172.25.0.1:35325",
+					"172.26.0.1:35325",
+					"172.27.0.1:35325"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:29:38.639659064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2490480947865966,
+				"StableID":   "nFKU7GiwSL11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb405c595cd71a6fd381cd46bec02addb0728794748e0f330f2b75861235d600",
+				"DiscoKey":   "discokey:7a3d09ff217e504c0b86360bd0d1aab6ba2719a28217d8a6850330843e296165",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:37486",
+					"10.65.0.27:37486",
+					"172.17.0.1:37486",
+					"172.18.0.1:37486",
+					"172.19.0.1:37486",
+					"172.20.0.1:37486",
+					"172.21.0.1:37486",
+					"172.22.0.1:37486",
+					"172.23.0.1:37486",
+					"172.24.0.1:37486",
+					"172.25.0.1:37486",
+					"172.26.0.1:37486",
+					"172.27.0.1:37486"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:29:39.168681166Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1589114381480400,
+				"StableID":   "nbU3EjLiQD11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1f3efd3a35eeb9304e0cdc3813584d87a6cf3e40c6119240a5e09ae92e650f5e",
+				"KeyExpiry":  "2026-11-09T09:29:39Z",
+				"DiscoKey":   "discokey:7522b0531b5612e3170073daedefc46bc57348b91dce68cc9e07e9d087c43654",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48794",
+					"10.65.0.27:48794",
+					"172.17.0.1:48794",
+					"172.18.0.1:48794",
+					"172.19.0.1:48794",
+					"172.20.0.1:48794",
+					"172.21.0.1:48794",
+					"172.22.0.1:48794",
+					"172.23.0.1:48794",
+					"172.24.0.1:48794",
+					"172.25.0.1:48794",
+					"172.26.0.1:48794",
+					"172.27.0.1:48794"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:29:39.725982612Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5862924467252071,
+				"StableID":   "nL1iXs5Lnn11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1f2c54610b5c60ba0546dd2bcd5fc248ef5cdbf8949dd63e2f18f0856bb04514",
+				"KeyExpiry":  "2026-11-09T09:29:40Z",
+				"DiscoKey":   "discokey:38f7d9eda3690c65f595e42a0b2ed1b62379bb50523217184d143ab5c5691a5b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52155",
+					"10.65.0.27:52155",
+					"172.17.0.1:52155",
+					"172.18.0.1:52155",
+					"172.19.0.1:52155",
+					"172.20.0.1:52155",
+					"172.21.0.1:52155",
+					"172.22.0.1:52155",
+					"172.23.0.1:52155",
+					"172.24.0.1:52155",
+					"172.25.0.1:52155",
+					"172.26.0.1:52155",
+					"172.27.0.1:52155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:29:40.256259971Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3805678568696981,
+				"StableID":   "nrMYBvibiW11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:86c8345c3f407d8c6754e1ca156e1e299ad3b89dcb1d7aa937a6fa86cf03e532",
+				"KeyExpiry":  "2026-11-09T09:29:40Z",
+				"DiscoKey":   "discokey:4c23e8fbff3d7396d8260e6958541aa6749b7cc97d868d7a020ab6568befc97a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50255",
+					"10.65.0.27:50255",
+					"172.17.0.1:50255",
+					"172.18.0.1:50255",
+					"172.19.0.1:50255",
+					"172.20.0.1:50255",
+					"172.21.0.1:50255",
+					"172.22.0.1:50255",
+					"172.23.0.1:50255",
+					"172.24.0.1:50255",
+					"172.25.0.1:50255",
+					"172.26.0.1:50255",
+					"172.27.0.1:50255"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:29:40.787905965Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2859212664711574": {
+				"ID":          2859212664711574,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         188686204918932,
+				"StableID":   "nmjao4UTU211CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       188686204918932,
+				"Key":        "nodekey:90929a1c49724dcf491f4acc8a70e70f4917540d41fefb552b2781a75cad4643",
+				"DiscoKey":   "discokey:916e878a92a884cf8fbbc9bcb52a4206be177185311ad7bff9f62f5218030632",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50198",
+					"10.65.0.27:50198",
+					"172.17.0.1:50198",
+					"172.18.0.1:50198",
+					"172.19.0.1:50198",
+					"172.20.0.1:50198",
+					"172.21.0.1:50198",
+					"172.22.0.1:50198",
+					"172.23.0.1:50198",
+					"172.24.0.1:50198",
+					"172.25.0.1:50198",
+					"172.26.0.1:50198",
+					"172.27.0.1:50198"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:29:35.35868711Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:90929a1c49724dcf491f4acc8a70e70f4917540d41fefb552b2781a75cad4643",
+			"MachineKey": "mkey:5cda7b69260f3746f07290b2af2bd64d3d3d4eb73ae4a66ebe96f9a16f00f35a",
+			"Peers": [{
+				"ID":         2859212664711574,
+				"StableID":   "n3RUGmfwKP11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:257f18e69b65ec0c700b7e2184bca19a3cf77826021794928f6980d4ef38b248",
+				"DiscoKey":   "discokey:44fd7f4dd7476297d1221f7d99732c75a33da40d06f1c636d0c4f27698923b71",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43150",
+					"10.65.0.27:43150",
+					"172.17.0.1:43150",
+					"172.18.0.1:43150",
+					"172.19.0.1:43150",
+					"172.20.0.1:43150",
+					"172.21.0.1:43150",
+					"172.22.0.1:43150",
+					"172.23.0.1:43150",
+					"172.24.0.1:43150",
+					"172.25.0.1:43150",
+					"172.26.0.1:43150",
+					"172.27.0.1:43150"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:29:33.270318864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6209384882856680,
+				"StableID":   "n7eP4g1FVq11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f9506ef72035485fc2d27b1036bba84c599ee143c5e5db39f83b16e1c7c3d204",
+				"DiscoKey":   "discokey:56bfd065fbf9aded449df431842d4e6b4e7d44457ad503c42380ad737c3c3669",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44553",
+					"10.65.0.27:44553",
+					"172.17.0.1:44553",
+					"172.18.0.1:44553",
+					"172.19.0.1:44553",
+					"172.20.0.1:44553",
+					"172.21.0.1:44553",
+					"172.22.0.1:44553",
+					"172.23.0.1:44553",
+					"172.24.0.1:44553",
+					"172.25.0.1:44553",
+					"172.26.0.1:44553",
+					"172.27.0.1:44553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:29:33.764228462Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4937306133179357,
+				"StableID":   "nCgkyGf7Zf11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ccfd85a67c2ae7d59bd0dc941483f6764942db4d3e3473d6e3ea72dd8f4db405",
+				"DiscoKey":   "discokey:9e488e31b507cc05ebb6ac225a6e756e8de09f01ac7e1425f097e7eee2c0970d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53179",
+					"10.65.0.27:53179",
+					"172.17.0.1:53179",
+					"172.18.0.1:53179",
+					"172.19.0.1:53179",
+					"172.20.0.1:53179",
+					"172.21.0.1:53179",
+					"172.22.0.1:53179",
+					"172.23.0.1:53179",
+					"172.24.0.1:53179",
+					"172.25.0.1:53179",
+					"172.26.0.1:53179",
+					"172.27.0.1:53179"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:29:34.31032901Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         493614118971451,
+				"StableID":   "nUZhPYQZr411CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1f09659d9ff3cde7edaf8075269b59c8bac1f27bc88b3fbc0a27fadbca2e54b",
+				"DiscoKey":   "discokey:260fcd6a36050179da5c80d9561e7fc2361abfa0031182fc42a9975284ef484e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60113",
+					"10.65.0.27:60113",
+					"172.17.0.1:60113",
+					"172.18.0.1:60113",
+					"172.19.0.1:60113",
+					"172.20.0.1:60113",
+					"172.21.0.1:60113",
+					"172.22.0.1:60113",
+					"172.23.0.1:60113",
+					"172.24.0.1:60113",
+					"172.25.0.1:60113",
+					"172.26.0.1:60113",
+					"172.27.0.1:60113"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:29:34.841487957Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1431992482076218,
+				"StableID":   "nFPm1q1ZBC11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:599a1b94de977777f3d8c3a8e0b472a2664b1edeb03e8da4bcd89c8c6b23a825",
+				"DiscoKey":   "discokey:ce753b107bd5f488e3b6a7325ffd0442f0debe5213132977e2f95c8bd763884b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:47841",
+					"10.65.0.27:47841",
+					"172.17.0.1:47841",
+					"172.18.0.1:47841",
+					"172.19.0.1:47841",
+					"172.20.0.1:47841",
+					"172.21.0.1:47841",
+					"172.22.0.1:47841",
+					"172.23.0.1:47841",
+					"172.24.0.1:47841",
+					"172.25.0.1:47841",
+					"172.26.0.1:47841",
+					"172.27.0.1:47841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:29:35.901475059Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2215287914480306,
+				"StableID":   "nh487irJJJ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b064330c9f805ad51a4b3336b5d3687be97805d2c12670d472d6fdb9e000015",
+				"DiscoKey":   "discokey:d569f11adb20bdbd3997acdebf4a11d7aab3609cd661e9f4e1862f858a9d2230",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50524",
+					"10.65.0.27:50524",
+					"172.17.0.1:50524",
+					"172.18.0.1:50524",
+					"172.19.0.1:50524",
+					"172.20.0.1:50524",
+					"172.21.0.1:50524",
+					"172.22.0.1:50524",
+					"172.23.0.1:50524",
+					"172.24.0.1:50524",
+					"172.25.0.1:50524",
+					"172.26.0.1:50524",
+					"172.27.0.1:50524"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:29:36.429659202Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5481495937921774,
+				"StableID":   "nhWvXzbaoj11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:645ef6e18e733de4391cc50812baa95407a0cdba46a222b12872e3c92b64b447",
+				"DiscoKey":   "discokey:eade7d7c765e230e0a081b4dca22080209816989c9309c0ca23ba874a7382b0c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36768",
+					"10.65.0.27:36768",
+					"172.17.0.1:36768",
+					"172.18.0.1:36768",
+					"172.19.0.1:36768",
+					"172.20.0.1:36768",
+					"172.21.0.1:36768",
+					"172.22.0.1:36768",
+					"172.23.0.1:36768",
+					"172.24.0.1:36768",
+					"172.25.0.1:36768",
+					"172.26.0.1:36768",
+					"172.27.0.1:36768"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:29:36.978336642Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5181403855005874,
+				"StableID":   "nDnQnChfTh11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7af9bedfaf13444d28e1664137504d38acd3737d8df9eeac69018992665b601c",
+				"DiscoKey":   "discokey:717cb5a3f65595c24e1a225bd4211fdd0022216d9e6268eef2344181e8b0cf72",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36746",
+					"10.65.0.27:36746",
+					"172.17.0.1:36746",
+					"172.18.0.1:36746",
+					"172.19.0.1:36746",
+					"172.20.0.1:36746",
+					"172.21.0.1:36746",
+					"172.22.0.1:36746",
+					"172.23.0.1:36746",
+					"172.24.0.1:36746",
+					"172.25.0.1:36746",
+					"172.26.0.1:36746",
+					"172.27.0.1:36746"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:29:37.52519162Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5947777451816847,
+				"StableID":   "nUXBDd2mSo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9320fbe912baef9f83844e8f5526b56748d328d5ad9bcf9d4f76a3e855cb2147",
+				"DiscoKey":   "discokey:821b02cb0acf6fc1a36d2c95273c0663e0233c9d928fe1bdb60b6d57fa2c6f22",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50083",
+					"10.65.0.27:50083",
+					"172.17.0.1:50083",
+					"172.18.0.1:50083",
+					"172.19.0.1:50083",
+					"172.20.0.1:50083",
+					"172.21.0.1:50083",
+					"172.22.0.1:50083",
+					"172.23.0.1:50083",
+					"172.24.0.1:50083",
+					"172.25.0.1:50083",
+					"172.26.0.1:50083",
+					"172.27.0.1:50083"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:29:38.144998256Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8028973883170165,
+				"StableID":   "n44L8hXLh521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3e1a94c6101554334d973f8d28097a3b1c352efc44b034ba9a3f710c9a378d00",
+				"DiscoKey":   "discokey:80529a51f5492a8b47068444185c7f283fb9f84399ce6b3b5c5d218785df054b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35325",
+					"10.65.0.27:35325",
+					"172.17.0.1:35325",
+					"172.18.0.1:35325",
+					"172.19.0.1:35325",
+					"172.20.0.1:35325",
+					"172.21.0.1:35325",
+					"172.22.0.1:35325",
+					"172.23.0.1:35325",
+					"172.24.0.1:35325",
+					"172.25.0.1:35325",
+					"172.26.0.1:35325",
+					"172.27.0.1:35325"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:29:38.639659064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2490480947865966,
+				"StableID":   "nFKU7GiwSL11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb405c595cd71a6fd381cd46bec02addb0728794748e0f330f2b75861235d600",
+				"DiscoKey":   "discokey:7a3d09ff217e504c0b86360bd0d1aab6ba2719a28217d8a6850330843e296165",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:37486",
+					"10.65.0.27:37486",
+					"172.17.0.1:37486",
+					"172.18.0.1:37486",
+					"172.19.0.1:37486",
+					"172.20.0.1:37486",
+					"172.21.0.1:37486",
+					"172.22.0.1:37486",
+					"172.23.0.1:37486",
+					"172.24.0.1:37486",
+					"172.25.0.1:37486",
+					"172.26.0.1:37486",
+					"172.27.0.1:37486"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:29:39.168681166Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1589114381480400,
+				"StableID":   "nbU3EjLiQD11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1f3efd3a35eeb9304e0cdc3813584d87a6cf3e40c6119240a5e09ae92e650f5e",
+				"KeyExpiry":  "2026-11-09T09:29:39Z",
+				"DiscoKey":   "discokey:7522b0531b5612e3170073daedefc46bc57348b91dce68cc9e07e9d087c43654",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48794",
+					"10.65.0.27:48794",
+					"172.17.0.1:48794",
+					"172.18.0.1:48794",
+					"172.19.0.1:48794",
+					"172.20.0.1:48794",
+					"172.21.0.1:48794",
+					"172.22.0.1:48794",
+					"172.23.0.1:48794",
+					"172.24.0.1:48794",
+					"172.25.0.1:48794",
+					"172.26.0.1:48794",
+					"172.27.0.1:48794"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:29:39.725982612Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5862924467252071,
+				"StableID":   "nL1iXs5Lnn11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1f2c54610b5c60ba0546dd2bcd5fc248ef5cdbf8949dd63e2f18f0856bb04514",
+				"KeyExpiry":  "2026-11-09T09:29:40Z",
+				"DiscoKey":   "discokey:38f7d9eda3690c65f595e42a0b2ed1b62379bb50523217184d143ab5c5691a5b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52155",
+					"10.65.0.27:52155",
+					"172.17.0.1:52155",
+					"172.18.0.1:52155",
+					"172.19.0.1:52155",
+					"172.20.0.1:52155",
+					"172.21.0.1:52155",
+					"172.22.0.1:52155",
+					"172.23.0.1:52155",
+					"172.24.0.1:52155",
+					"172.25.0.1:52155",
+					"172.26.0.1:52155",
+					"172.27.0.1:52155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:29:40.256259971Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3805678568696981,
+				"StableID":   "nrMYBvibiW11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:86c8345c3f407d8c6754e1ca156e1e299ad3b89dcb1d7aa937a6fa86cf03e532",
+				"KeyExpiry":  "2026-11-09T09:29:40Z",
+				"DiscoKey":   "discokey:4c23e8fbff3d7396d8260e6958541aa6749b7cc97d868d7a020ab6568befc97a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50255",
+					"10.65.0.27:50255",
+					"172.17.0.1:50255",
+					"172.18.0.1:50255",
+					"172.19.0.1:50255",
+					"172.20.0.1:50255",
+					"172.21.0.1:50255",
+					"172.22.0.1:50255",
+					"172.23.0.1:50255",
+					"172.24.0.1:50255",
+					"172.25.0.1:50255",
+					"172.26.0.1:50255",
+					"172.27.0.1:50255"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:29:40.787905965Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "188686204918932": {
+				"ID":          188686204918932,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         493614118971451,
+				"StableID":   "nUZhPYQZr411CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       493614118971451,
+				"Key":        "nodekey:d1f09659d9ff3cde7edaf8075269b59c8bac1f27bc88b3fbc0a27fadbca2e54b",
+				"DiscoKey":   "discokey:260fcd6a36050179da5c80d9561e7fc2361abfa0031182fc42a9975284ef484e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60113",
+					"10.65.0.27:60113",
+					"172.17.0.1:60113",
+					"172.18.0.1:60113",
+					"172.19.0.1:60113",
+					"172.20.0.1:60113",
+					"172.21.0.1:60113",
+					"172.22.0.1:60113",
+					"172.23.0.1:60113",
+					"172.24.0.1:60113",
+					"172.25.0.1:60113",
+					"172.26.0.1:60113",
+					"172.27.0.1:60113"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:29:34.841487957Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d1f09659d9ff3cde7edaf8075269b59c8bac1f27bc88b3fbc0a27fadbca2e54b",
+			"MachineKey": "mkey:c2313e64fc87f0087095531735c008cc6b6770b953c049b19923e68e7359b609",
+			"Peers": [{
+				"ID":         2859212664711574,
+				"StableID":   "n3RUGmfwKP11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:257f18e69b65ec0c700b7e2184bca19a3cf77826021794928f6980d4ef38b248",
+				"DiscoKey":   "discokey:44fd7f4dd7476297d1221f7d99732c75a33da40d06f1c636d0c4f27698923b71",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43150",
+					"10.65.0.27:43150",
+					"172.17.0.1:43150",
+					"172.18.0.1:43150",
+					"172.19.0.1:43150",
+					"172.20.0.1:43150",
+					"172.21.0.1:43150",
+					"172.22.0.1:43150",
+					"172.23.0.1:43150",
+					"172.24.0.1:43150",
+					"172.25.0.1:43150",
+					"172.26.0.1:43150",
+					"172.27.0.1:43150"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:29:33.270318864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6209384882856680,
+				"StableID":   "n7eP4g1FVq11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f9506ef72035485fc2d27b1036bba84c599ee143c5e5db39f83b16e1c7c3d204",
+				"DiscoKey":   "discokey:56bfd065fbf9aded449df431842d4e6b4e7d44457ad503c42380ad737c3c3669",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44553",
+					"10.65.0.27:44553",
+					"172.17.0.1:44553",
+					"172.18.0.1:44553",
+					"172.19.0.1:44553",
+					"172.20.0.1:44553",
+					"172.21.0.1:44553",
+					"172.22.0.1:44553",
+					"172.23.0.1:44553",
+					"172.24.0.1:44553",
+					"172.25.0.1:44553",
+					"172.26.0.1:44553",
+					"172.27.0.1:44553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:29:33.764228462Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4937306133179357,
+				"StableID":   "nCgkyGf7Zf11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ccfd85a67c2ae7d59bd0dc941483f6764942db4d3e3473d6e3ea72dd8f4db405",
+				"DiscoKey":   "discokey:9e488e31b507cc05ebb6ac225a6e756e8de09f01ac7e1425f097e7eee2c0970d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53179",
+					"10.65.0.27:53179",
+					"172.17.0.1:53179",
+					"172.18.0.1:53179",
+					"172.19.0.1:53179",
+					"172.20.0.1:53179",
+					"172.21.0.1:53179",
+					"172.22.0.1:53179",
+					"172.23.0.1:53179",
+					"172.24.0.1:53179",
+					"172.25.0.1:53179",
+					"172.26.0.1:53179",
+					"172.27.0.1:53179"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:29:34.31032901Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         188686204918932,
+				"StableID":   "nmjao4UTU211CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90929a1c49724dcf491f4acc8a70e70f4917540d41fefb552b2781a75cad4643",
+				"DiscoKey":   "discokey:916e878a92a884cf8fbbc9bcb52a4206be177185311ad7bff9f62f5218030632",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50198",
+					"10.65.0.27:50198",
+					"172.17.0.1:50198",
+					"172.18.0.1:50198",
+					"172.19.0.1:50198",
+					"172.20.0.1:50198",
+					"172.21.0.1:50198",
+					"172.22.0.1:50198",
+					"172.23.0.1:50198",
+					"172.24.0.1:50198",
+					"172.25.0.1:50198",
+					"172.26.0.1:50198",
+					"172.27.0.1:50198"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:29:35.35868711Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1431992482076218,
+				"StableID":   "nFPm1q1ZBC11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:599a1b94de977777f3d8c3a8e0b472a2664b1edeb03e8da4bcd89c8c6b23a825",
+				"DiscoKey":   "discokey:ce753b107bd5f488e3b6a7325ffd0442f0debe5213132977e2f95c8bd763884b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:47841",
+					"10.65.0.27:47841",
+					"172.17.0.1:47841",
+					"172.18.0.1:47841",
+					"172.19.0.1:47841",
+					"172.20.0.1:47841",
+					"172.21.0.1:47841",
+					"172.22.0.1:47841",
+					"172.23.0.1:47841",
+					"172.24.0.1:47841",
+					"172.25.0.1:47841",
+					"172.26.0.1:47841",
+					"172.27.0.1:47841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:29:35.901475059Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2215287914480306,
+				"StableID":   "nh487irJJJ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b064330c9f805ad51a4b3336b5d3687be97805d2c12670d472d6fdb9e000015",
+				"DiscoKey":   "discokey:d569f11adb20bdbd3997acdebf4a11d7aab3609cd661e9f4e1862f858a9d2230",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50524",
+					"10.65.0.27:50524",
+					"172.17.0.1:50524",
+					"172.18.0.1:50524",
+					"172.19.0.1:50524",
+					"172.20.0.1:50524",
+					"172.21.0.1:50524",
+					"172.22.0.1:50524",
+					"172.23.0.1:50524",
+					"172.24.0.1:50524",
+					"172.25.0.1:50524",
+					"172.26.0.1:50524",
+					"172.27.0.1:50524"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:29:36.429659202Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5481495937921774,
+				"StableID":   "nhWvXzbaoj11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:645ef6e18e733de4391cc50812baa95407a0cdba46a222b12872e3c92b64b447",
+				"DiscoKey":   "discokey:eade7d7c765e230e0a081b4dca22080209816989c9309c0ca23ba874a7382b0c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36768",
+					"10.65.0.27:36768",
+					"172.17.0.1:36768",
+					"172.18.0.1:36768",
+					"172.19.0.1:36768",
+					"172.20.0.1:36768",
+					"172.21.0.1:36768",
+					"172.22.0.1:36768",
+					"172.23.0.1:36768",
+					"172.24.0.1:36768",
+					"172.25.0.1:36768",
+					"172.26.0.1:36768",
+					"172.27.0.1:36768"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:29:36.978336642Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5181403855005874,
+				"StableID":   "nDnQnChfTh11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7af9bedfaf13444d28e1664137504d38acd3737d8df9eeac69018992665b601c",
+				"DiscoKey":   "discokey:717cb5a3f65595c24e1a225bd4211fdd0022216d9e6268eef2344181e8b0cf72",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36746",
+					"10.65.0.27:36746",
+					"172.17.0.1:36746",
+					"172.18.0.1:36746",
+					"172.19.0.1:36746",
+					"172.20.0.1:36746",
+					"172.21.0.1:36746",
+					"172.22.0.1:36746",
+					"172.23.0.1:36746",
+					"172.24.0.1:36746",
+					"172.25.0.1:36746",
+					"172.26.0.1:36746",
+					"172.27.0.1:36746"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:29:37.52519162Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5947777451816847,
+				"StableID":   "nUXBDd2mSo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9320fbe912baef9f83844e8f5526b56748d328d5ad9bcf9d4f76a3e855cb2147",
+				"DiscoKey":   "discokey:821b02cb0acf6fc1a36d2c95273c0663e0233c9d928fe1bdb60b6d57fa2c6f22",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50083",
+					"10.65.0.27:50083",
+					"172.17.0.1:50083",
+					"172.18.0.1:50083",
+					"172.19.0.1:50083",
+					"172.20.0.1:50083",
+					"172.21.0.1:50083",
+					"172.22.0.1:50083",
+					"172.23.0.1:50083",
+					"172.24.0.1:50083",
+					"172.25.0.1:50083",
+					"172.26.0.1:50083",
+					"172.27.0.1:50083"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:29:38.144998256Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8028973883170165,
+				"StableID":   "n44L8hXLh521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3e1a94c6101554334d973f8d28097a3b1c352efc44b034ba9a3f710c9a378d00",
+				"DiscoKey":   "discokey:80529a51f5492a8b47068444185c7f283fb9f84399ce6b3b5c5d218785df054b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35325",
+					"10.65.0.27:35325",
+					"172.17.0.1:35325",
+					"172.18.0.1:35325",
+					"172.19.0.1:35325",
+					"172.20.0.1:35325",
+					"172.21.0.1:35325",
+					"172.22.0.1:35325",
+					"172.23.0.1:35325",
+					"172.24.0.1:35325",
+					"172.25.0.1:35325",
+					"172.26.0.1:35325",
+					"172.27.0.1:35325"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:29:38.639659064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2490480947865966,
+				"StableID":   "nFKU7GiwSL11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb405c595cd71a6fd381cd46bec02addb0728794748e0f330f2b75861235d600",
+				"DiscoKey":   "discokey:7a3d09ff217e504c0b86360bd0d1aab6ba2719a28217d8a6850330843e296165",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:37486",
+					"10.65.0.27:37486",
+					"172.17.0.1:37486",
+					"172.18.0.1:37486",
+					"172.19.0.1:37486",
+					"172.20.0.1:37486",
+					"172.21.0.1:37486",
+					"172.22.0.1:37486",
+					"172.23.0.1:37486",
+					"172.24.0.1:37486",
+					"172.25.0.1:37486",
+					"172.26.0.1:37486",
+					"172.27.0.1:37486"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:29:39.168681166Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1589114381480400,
+				"StableID":   "nbU3EjLiQD11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1f3efd3a35eeb9304e0cdc3813584d87a6cf3e40c6119240a5e09ae92e650f5e",
+				"KeyExpiry":  "2026-11-09T09:29:39Z",
+				"DiscoKey":   "discokey:7522b0531b5612e3170073daedefc46bc57348b91dce68cc9e07e9d087c43654",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48794",
+					"10.65.0.27:48794",
+					"172.17.0.1:48794",
+					"172.18.0.1:48794",
+					"172.19.0.1:48794",
+					"172.20.0.1:48794",
+					"172.21.0.1:48794",
+					"172.22.0.1:48794",
+					"172.23.0.1:48794",
+					"172.24.0.1:48794",
+					"172.25.0.1:48794",
+					"172.26.0.1:48794",
+					"172.27.0.1:48794"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:29:39.725982612Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5862924467252071,
+				"StableID":   "nL1iXs5Lnn11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1f2c54610b5c60ba0546dd2bcd5fc248ef5cdbf8949dd63e2f18f0856bb04514",
+				"KeyExpiry":  "2026-11-09T09:29:40Z",
+				"DiscoKey":   "discokey:38f7d9eda3690c65f595e42a0b2ed1b62379bb50523217184d143ab5c5691a5b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52155",
+					"10.65.0.27:52155",
+					"172.17.0.1:52155",
+					"172.18.0.1:52155",
+					"172.19.0.1:52155",
+					"172.20.0.1:52155",
+					"172.21.0.1:52155",
+					"172.22.0.1:52155",
+					"172.23.0.1:52155",
+					"172.24.0.1:52155",
+					"172.25.0.1:52155",
+					"172.26.0.1:52155",
+					"172.27.0.1:52155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:29:40.256259971Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3805678568696981,
+				"StableID":   "nrMYBvibiW11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:86c8345c3f407d8c6754e1ca156e1e299ad3b89dcb1d7aa937a6fa86cf03e532",
+				"KeyExpiry":  "2026-11-09T09:29:40Z",
+				"DiscoKey":   "discokey:4c23e8fbff3d7396d8260e6958541aa6749b7cc97d868d7a020ab6568befc97a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50255",
+					"10.65.0.27:50255",
+					"172.17.0.1:50255",
+					"172.18.0.1:50255",
+					"172.19.0.1:50255",
+					"172.20.0.1:50255",
+					"172.21.0.1:50255",
+					"172.22.0.1:50255",
+					"172.23.0.1:50255",
+					"172.24.0.1:50255",
+					"172.25.0.1:50255",
+					"172.26.0.1:50255",
+					"172.27.0.1:50255"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:29:40.787905965Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "493614118971451": {
+				"ID":          493614118971451,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2215287914480306,
+				"StableID":   "nh487irJJJ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       2215287914480306,
+				"Key":        "nodekey:4b064330c9f805ad51a4b3336b5d3687be97805d2c12670d472d6fdb9e000015",
+				"DiscoKey":   "discokey:d569f11adb20bdbd3997acdebf4a11d7aab3609cd661e9f4e1862f858a9d2230",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50524",
+					"10.65.0.27:50524",
+					"172.17.0.1:50524",
+					"172.18.0.1:50524",
+					"172.19.0.1:50524",
+					"172.20.0.1:50524",
+					"172.21.0.1:50524",
+					"172.22.0.1:50524",
+					"172.23.0.1:50524",
+					"172.24.0.1:50524",
+					"172.25.0.1:50524",
+					"172.26.0.1:50524",
+					"172.27.0.1:50524"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:29:36.429659202Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4b064330c9f805ad51a4b3336b5d3687be97805d2c12670d472d6fdb9e000015",
+			"MachineKey": "mkey:03c14990d7385d3f338c92a84b8c28ea2ad118b13428944e47ea332e7ca1470f",
+			"Peers": [{
+				"ID":         2859212664711574,
+				"StableID":   "n3RUGmfwKP11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:257f18e69b65ec0c700b7e2184bca19a3cf77826021794928f6980d4ef38b248",
+				"DiscoKey":   "discokey:44fd7f4dd7476297d1221f7d99732c75a33da40d06f1c636d0c4f27698923b71",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43150",
+					"10.65.0.27:43150",
+					"172.17.0.1:43150",
+					"172.18.0.1:43150",
+					"172.19.0.1:43150",
+					"172.20.0.1:43150",
+					"172.21.0.1:43150",
+					"172.22.0.1:43150",
+					"172.23.0.1:43150",
+					"172.24.0.1:43150",
+					"172.25.0.1:43150",
+					"172.26.0.1:43150",
+					"172.27.0.1:43150"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:29:33.270318864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6209384882856680,
+				"StableID":   "n7eP4g1FVq11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f9506ef72035485fc2d27b1036bba84c599ee143c5e5db39f83b16e1c7c3d204",
+				"DiscoKey":   "discokey:56bfd065fbf9aded449df431842d4e6b4e7d44457ad503c42380ad737c3c3669",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44553",
+					"10.65.0.27:44553",
+					"172.17.0.1:44553",
+					"172.18.0.1:44553",
+					"172.19.0.1:44553",
+					"172.20.0.1:44553",
+					"172.21.0.1:44553",
+					"172.22.0.1:44553",
+					"172.23.0.1:44553",
+					"172.24.0.1:44553",
+					"172.25.0.1:44553",
+					"172.26.0.1:44553",
+					"172.27.0.1:44553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:29:33.764228462Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4937306133179357,
+				"StableID":   "nCgkyGf7Zf11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ccfd85a67c2ae7d59bd0dc941483f6764942db4d3e3473d6e3ea72dd8f4db405",
+				"DiscoKey":   "discokey:9e488e31b507cc05ebb6ac225a6e756e8de09f01ac7e1425f097e7eee2c0970d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53179",
+					"10.65.0.27:53179",
+					"172.17.0.1:53179",
+					"172.18.0.1:53179",
+					"172.19.0.1:53179",
+					"172.20.0.1:53179",
+					"172.21.0.1:53179",
+					"172.22.0.1:53179",
+					"172.23.0.1:53179",
+					"172.24.0.1:53179",
+					"172.25.0.1:53179",
+					"172.26.0.1:53179",
+					"172.27.0.1:53179"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:29:34.31032901Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         493614118971451,
+				"StableID":   "nUZhPYQZr411CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1f09659d9ff3cde7edaf8075269b59c8bac1f27bc88b3fbc0a27fadbca2e54b",
+				"DiscoKey":   "discokey:260fcd6a36050179da5c80d9561e7fc2361abfa0031182fc42a9975284ef484e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60113",
+					"10.65.0.27:60113",
+					"172.17.0.1:60113",
+					"172.18.0.1:60113",
+					"172.19.0.1:60113",
+					"172.20.0.1:60113",
+					"172.21.0.1:60113",
+					"172.22.0.1:60113",
+					"172.23.0.1:60113",
+					"172.24.0.1:60113",
+					"172.25.0.1:60113",
+					"172.26.0.1:60113",
+					"172.27.0.1:60113"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:29:34.841487957Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         188686204918932,
+				"StableID":   "nmjao4UTU211CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90929a1c49724dcf491f4acc8a70e70f4917540d41fefb552b2781a75cad4643",
+				"DiscoKey":   "discokey:916e878a92a884cf8fbbc9bcb52a4206be177185311ad7bff9f62f5218030632",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50198",
+					"10.65.0.27:50198",
+					"172.17.0.1:50198",
+					"172.18.0.1:50198",
+					"172.19.0.1:50198",
+					"172.20.0.1:50198",
+					"172.21.0.1:50198",
+					"172.22.0.1:50198",
+					"172.23.0.1:50198",
+					"172.24.0.1:50198",
+					"172.25.0.1:50198",
+					"172.26.0.1:50198",
+					"172.27.0.1:50198"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:29:35.35868711Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1431992482076218,
+				"StableID":   "nFPm1q1ZBC11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:599a1b94de977777f3d8c3a8e0b472a2664b1edeb03e8da4bcd89c8c6b23a825",
+				"DiscoKey":   "discokey:ce753b107bd5f488e3b6a7325ffd0442f0debe5213132977e2f95c8bd763884b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:47841",
+					"10.65.0.27:47841",
+					"172.17.0.1:47841",
+					"172.18.0.1:47841",
+					"172.19.0.1:47841",
+					"172.20.0.1:47841",
+					"172.21.0.1:47841",
+					"172.22.0.1:47841",
+					"172.23.0.1:47841",
+					"172.24.0.1:47841",
+					"172.25.0.1:47841",
+					"172.26.0.1:47841",
+					"172.27.0.1:47841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:29:35.901475059Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5481495937921774,
+				"StableID":   "nhWvXzbaoj11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:645ef6e18e733de4391cc50812baa95407a0cdba46a222b12872e3c92b64b447",
+				"DiscoKey":   "discokey:eade7d7c765e230e0a081b4dca22080209816989c9309c0ca23ba874a7382b0c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36768",
+					"10.65.0.27:36768",
+					"172.17.0.1:36768",
+					"172.18.0.1:36768",
+					"172.19.0.1:36768",
+					"172.20.0.1:36768",
+					"172.21.0.1:36768",
+					"172.22.0.1:36768",
+					"172.23.0.1:36768",
+					"172.24.0.1:36768",
+					"172.25.0.1:36768",
+					"172.26.0.1:36768",
+					"172.27.0.1:36768"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:29:36.978336642Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5181403855005874,
+				"StableID":   "nDnQnChfTh11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7af9bedfaf13444d28e1664137504d38acd3737d8df9eeac69018992665b601c",
+				"DiscoKey":   "discokey:717cb5a3f65595c24e1a225bd4211fdd0022216d9e6268eef2344181e8b0cf72",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36746",
+					"10.65.0.27:36746",
+					"172.17.0.1:36746",
+					"172.18.0.1:36746",
+					"172.19.0.1:36746",
+					"172.20.0.1:36746",
+					"172.21.0.1:36746",
+					"172.22.0.1:36746",
+					"172.23.0.1:36746",
+					"172.24.0.1:36746",
+					"172.25.0.1:36746",
+					"172.26.0.1:36746",
+					"172.27.0.1:36746"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:29:37.52519162Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5947777451816847,
+				"StableID":   "nUXBDd2mSo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9320fbe912baef9f83844e8f5526b56748d328d5ad9bcf9d4f76a3e855cb2147",
+				"DiscoKey":   "discokey:821b02cb0acf6fc1a36d2c95273c0663e0233c9d928fe1bdb60b6d57fa2c6f22",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50083",
+					"10.65.0.27:50083",
+					"172.17.0.1:50083",
+					"172.18.0.1:50083",
+					"172.19.0.1:50083",
+					"172.20.0.1:50083",
+					"172.21.0.1:50083",
+					"172.22.0.1:50083",
+					"172.23.0.1:50083",
+					"172.24.0.1:50083",
+					"172.25.0.1:50083",
+					"172.26.0.1:50083",
+					"172.27.0.1:50083"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:29:38.144998256Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8028973883170165,
+				"StableID":   "n44L8hXLh521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3e1a94c6101554334d973f8d28097a3b1c352efc44b034ba9a3f710c9a378d00",
+				"DiscoKey":   "discokey:80529a51f5492a8b47068444185c7f283fb9f84399ce6b3b5c5d218785df054b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35325",
+					"10.65.0.27:35325",
+					"172.17.0.1:35325",
+					"172.18.0.1:35325",
+					"172.19.0.1:35325",
+					"172.20.0.1:35325",
+					"172.21.0.1:35325",
+					"172.22.0.1:35325",
+					"172.23.0.1:35325",
+					"172.24.0.1:35325",
+					"172.25.0.1:35325",
+					"172.26.0.1:35325",
+					"172.27.0.1:35325"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:29:38.639659064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2490480947865966,
+				"StableID":   "nFKU7GiwSL11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb405c595cd71a6fd381cd46bec02addb0728794748e0f330f2b75861235d600",
+				"DiscoKey":   "discokey:7a3d09ff217e504c0b86360bd0d1aab6ba2719a28217d8a6850330843e296165",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:37486",
+					"10.65.0.27:37486",
+					"172.17.0.1:37486",
+					"172.18.0.1:37486",
+					"172.19.0.1:37486",
+					"172.20.0.1:37486",
+					"172.21.0.1:37486",
+					"172.22.0.1:37486",
+					"172.23.0.1:37486",
+					"172.24.0.1:37486",
+					"172.25.0.1:37486",
+					"172.26.0.1:37486",
+					"172.27.0.1:37486"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:29:39.168681166Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1589114381480400,
+				"StableID":   "nbU3EjLiQD11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1f3efd3a35eeb9304e0cdc3813584d87a6cf3e40c6119240a5e09ae92e650f5e",
+				"KeyExpiry":  "2026-11-09T09:29:39Z",
+				"DiscoKey":   "discokey:7522b0531b5612e3170073daedefc46bc57348b91dce68cc9e07e9d087c43654",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48794",
+					"10.65.0.27:48794",
+					"172.17.0.1:48794",
+					"172.18.0.1:48794",
+					"172.19.0.1:48794",
+					"172.20.0.1:48794",
+					"172.21.0.1:48794",
+					"172.22.0.1:48794",
+					"172.23.0.1:48794",
+					"172.24.0.1:48794",
+					"172.25.0.1:48794",
+					"172.26.0.1:48794",
+					"172.27.0.1:48794"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:29:39.725982612Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5862924467252071,
+				"StableID":   "nL1iXs5Lnn11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1f2c54610b5c60ba0546dd2bcd5fc248ef5cdbf8949dd63e2f18f0856bb04514",
+				"KeyExpiry":  "2026-11-09T09:29:40Z",
+				"DiscoKey":   "discokey:38f7d9eda3690c65f595e42a0b2ed1b62379bb50523217184d143ab5c5691a5b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52155",
+					"10.65.0.27:52155",
+					"172.17.0.1:52155",
+					"172.18.0.1:52155",
+					"172.19.0.1:52155",
+					"172.20.0.1:52155",
+					"172.21.0.1:52155",
+					"172.22.0.1:52155",
+					"172.23.0.1:52155",
+					"172.24.0.1:52155",
+					"172.25.0.1:52155",
+					"172.26.0.1:52155",
+					"172.27.0.1:52155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:29:40.256259971Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3805678568696981,
+				"StableID":   "nrMYBvibiW11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:86c8345c3f407d8c6754e1ca156e1e299ad3b89dcb1d7aa937a6fa86cf03e532",
+				"KeyExpiry":  "2026-11-09T09:29:40Z",
+				"DiscoKey":   "discokey:4c23e8fbff3d7396d8260e6958541aa6749b7cc97d868d7a020ab6568befc97a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50255",
+					"10.65.0.27:50255",
+					"172.17.0.1:50255",
+					"172.18.0.1:50255",
+					"172.19.0.1:50255",
+					"172.20.0.1:50255",
+					"172.21.0.1:50255",
+					"172.22.0.1:50255",
+					"172.23.0.1:50255",
+					"172.24.0.1:50255",
+					"172.25.0.1:50255",
+					"172.26.0.1:50255",
+					"172.27.0.1:50255"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:29:40.787905965Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2215287914480306": {
+				"ID":          2215287914480306,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5181403855005874,
+				"StableID":   "nDnQnChfTh11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       5181403855005874,
+				"Key":        "nodekey:7af9bedfaf13444d28e1664137504d38acd3737d8df9eeac69018992665b601c",
+				"DiscoKey":   "discokey:717cb5a3f65595c24e1a225bd4211fdd0022216d9e6268eef2344181e8b0cf72",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36746",
+					"10.65.0.27:36746",
+					"172.17.0.1:36746",
+					"172.18.0.1:36746",
+					"172.19.0.1:36746",
+					"172.20.0.1:36746",
+					"172.21.0.1:36746",
+					"172.22.0.1:36746",
+					"172.23.0.1:36746",
+					"172.24.0.1:36746",
+					"172.25.0.1:36746",
+					"172.26.0.1:36746",
+					"172.27.0.1:36746"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:29:37.52519162Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7af9bedfaf13444d28e1664137504d38acd3737d8df9eeac69018992665b601c",
+			"MachineKey": "mkey:c5c986715d5e2dabc33583f6c8177b695455f0680097ce0a717b2c7c6b59f268",
+			"Peers": [{
+				"ID":         2859212664711574,
+				"StableID":   "n3RUGmfwKP11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:257f18e69b65ec0c700b7e2184bca19a3cf77826021794928f6980d4ef38b248",
+				"DiscoKey":   "discokey:44fd7f4dd7476297d1221f7d99732c75a33da40d06f1c636d0c4f27698923b71",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43150",
+					"10.65.0.27:43150",
+					"172.17.0.1:43150",
+					"172.18.0.1:43150",
+					"172.19.0.1:43150",
+					"172.20.0.1:43150",
+					"172.21.0.1:43150",
+					"172.22.0.1:43150",
+					"172.23.0.1:43150",
+					"172.24.0.1:43150",
+					"172.25.0.1:43150",
+					"172.26.0.1:43150",
+					"172.27.0.1:43150"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:29:33.270318864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6209384882856680,
+				"StableID":   "n7eP4g1FVq11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f9506ef72035485fc2d27b1036bba84c599ee143c5e5db39f83b16e1c7c3d204",
+				"DiscoKey":   "discokey:56bfd065fbf9aded449df431842d4e6b4e7d44457ad503c42380ad737c3c3669",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44553",
+					"10.65.0.27:44553",
+					"172.17.0.1:44553",
+					"172.18.0.1:44553",
+					"172.19.0.1:44553",
+					"172.20.0.1:44553",
+					"172.21.0.1:44553",
+					"172.22.0.1:44553",
+					"172.23.0.1:44553",
+					"172.24.0.1:44553",
+					"172.25.0.1:44553",
+					"172.26.0.1:44553",
+					"172.27.0.1:44553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:29:33.764228462Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4937306133179357,
+				"StableID":   "nCgkyGf7Zf11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ccfd85a67c2ae7d59bd0dc941483f6764942db4d3e3473d6e3ea72dd8f4db405",
+				"DiscoKey":   "discokey:9e488e31b507cc05ebb6ac225a6e756e8de09f01ac7e1425f097e7eee2c0970d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53179",
+					"10.65.0.27:53179",
+					"172.17.0.1:53179",
+					"172.18.0.1:53179",
+					"172.19.0.1:53179",
+					"172.20.0.1:53179",
+					"172.21.0.1:53179",
+					"172.22.0.1:53179",
+					"172.23.0.1:53179",
+					"172.24.0.1:53179",
+					"172.25.0.1:53179",
+					"172.26.0.1:53179",
+					"172.27.0.1:53179"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:29:34.31032901Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         493614118971451,
+				"StableID":   "nUZhPYQZr411CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1f09659d9ff3cde7edaf8075269b59c8bac1f27bc88b3fbc0a27fadbca2e54b",
+				"DiscoKey":   "discokey:260fcd6a36050179da5c80d9561e7fc2361abfa0031182fc42a9975284ef484e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60113",
+					"10.65.0.27:60113",
+					"172.17.0.1:60113",
+					"172.18.0.1:60113",
+					"172.19.0.1:60113",
+					"172.20.0.1:60113",
+					"172.21.0.1:60113",
+					"172.22.0.1:60113",
+					"172.23.0.1:60113",
+					"172.24.0.1:60113",
+					"172.25.0.1:60113",
+					"172.26.0.1:60113",
+					"172.27.0.1:60113"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:29:34.841487957Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         188686204918932,
+				"StableID":   "nmjao4UTU211CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90929a1c49724dcf491f4acc8a70e70f4917540d41fefb552b2781a75cad4643",
+				"DiscoKey":   "discokey:916e878a92a884cf8fbbc9bcb52a4206be177185311ad7bff9f62f5218030632",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50198",
+					"10.65.0.27:50198",
+					"172.17.0.1:50198",
+					"172.18.0.1:50198",
+					"172.19.0.1:50198",
+					"172.20.0.1:50198",
+					"172.21.0.1:50198",
+					"172.22.0.1:50198",
+					"172.23.0.1:50198",
+					"172.24.0.1:50198",
+					"172.25.0.1:50198",
+					"172.26.0.1:50198",
+					"172.27.0.1:50198"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:29:35.35868711Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1431992482076218,
+				"StableID":   "nFPm1q1ZBC11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:599a1b94de977777f3d8c3a8e0b472a2664b1edeb03e8da4bcd89c8c6b23a825",
+				"DiscoKey":   "discokey:ce753b107bd5f488e3b6a7325ffd0442f0debe5213132977e2f95c8bd763884b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:47841",
+					"10.65.0.27:47841",
+					"172.17.0.1:47841",
+					"172.18.0.1:47841",
+					"172.19.0.1:47841",
+					"172.20.0.1:47841",
+					"172.21.0.1:47841",
+					"172.22.0.1:47841",
+					"172.23.0.1:47841",
+					"172.24.0.1:47841",
+					"172.25.0.1:47841",
+					"172.26.0.1:47841",
+					"172.27.0.1:47841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:29:35.901475059Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2215287914480306,
+				"StableID":   "nh487irJJJ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b064330c9f805ad51a4b3336b5d3687be97805d2c12670d472d6fdb9e000015",
+				"DiscoKey":   "discokey:d569f11adb20bdbd3997acdebf4a11d7aab3609cd661e9f4e1862f858a9d2230",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50524",
+					"10.65.0.27:50524",
+					"172.17.0.1:50524",
+					"172.18.0.1:50524",
+					"172.19.0.1:50524",
+					"172.20.0.1:50524",
+					"172.21.0.1:50524",
+					"172.22.0.1:50524",
+					"172.23.0.1:50524",
+					"172.24.0.1:50524",
+					"172.25.0.1:50524",
+					"172.26.0.1:50524",
+					"172.27.0.1:50524"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:29:36.429659202Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5481495937921774,
+				"StableID":   "nhWvXzbaoj11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:645ef6e18e733de4391cc50812baa95407a0cdba46a222b12872e3c92b64b447",
+				"DiscoKey":   "discokey:eade7d7c765e230e0a081b4dca22080209816989c9309c0ca23ba874a7382b0c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36768",
+					"10.65.0.27:36768",
+					"172.17.0.1:36768",
+					"172.18.0.1:36768",
+					"172.19.0.1:36768",
+					"172.20.0.1:36768",
+					"172.21.0.1:36768",
+					"172.22.0.1:36768",
+					"172.23.0.1:36768",
+					"172.24.0.1:36768",
+					"172.25.0.1:36768",
+					"172.26.0.1:36768",
+					"172.27.0.1:36768"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:29:36.978336642Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5947777451816847,
+				"StableID":   "nUXBDd2mSo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9320fbe912baef9f83844e8f5526b56748d328d5ad9bcf9d4f76a3e855cb2147",
+				"DiscoKey":   "discokey:821b02cb0acf6fc1a36d2c95273c0663e0233c9d928fe1bdb60b6d57fa2c6f22",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50083",
+					"10.65.0.27:50083",
+					"172.17.0.1:50083",
+					"172.18.0.1:50083",
+					"172.19.0.1:50083",
+					"172.20.0.1:50083",
+					"172.21.0.1:50083",
+					"172.22.0.1:50083",
+					"172.23.0.1:50083",
+					"172.24.0.1:50083",
+					"172.25.0.1:50083",
+					"172.26.0.1:50083",
+					"172.27.0.1:50083"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:29:38.144998256Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8028973883170165,
+				"StableID":   "n44L8hXLh521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3e1a94c6101554334d973f8d28097a3b1c352efc44b034ba9a3f710c9a378d00",
+				"DiscoKey":   "discokey:80529a51f5492a8b47068444185c7f283fb9f84399ce6b3b5c5d218785df054b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35325",
+					"10.65.0.27:35325",
+					"172.17.0.1:35325",
+					"172.18.0.1:35325",
+					"172.19.0.1:35325",
+					"172.20.0.1:35325",
+					"172.21.0.1:35325",
+					"172.22.0.1:35325",
+					"172.23.0.1:35325",
+					"172.24.0.1:35325",
+					"172.25.0.1:35325",
+					"172.26.0.1:35325",
+					"172.27.0.1:35325"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:29:38.639659064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2490480947865966,
+				"StableID":   "nFKU7GiwSL11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb405c595cd71a6fd381cd46bec02addb0728794748e0f330f2b75861235d600",
+				"DiscoKey":   "discokey:7a3d09ff217e504c0b86360bd0d1aab6ba2719a28217d8a6850330843e296165",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:37486",
+					"10.65.0.27:37486",
+					"172.17.0.1:37486",
+					"172.18.0.1:37486",
+					"172.19.0.1:37486",
+					"172.20.0.1:37486",
+					"172.21.0.1:37486",
+					"172.22.0.1:37486",
+					"172.23.0.1:37486",
+					"172.24.0.1:37486",
+					"172.25.0.1:37486",
+					"172.26.0.1:37486",
+					"172.27.0.1:37486"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:29:39.168681166Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1589114381480400,
+				"StableID":   "nbU3EjLiQD11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1f3efd3a35eeb9304e0cdc3813584d87a6cf3e40c6119240a5e09ae92e650f5e",
+				"KeyExpiry":  "2026-11-09T09:29:39Z",
+				"DiscoKey":   "discokey:7522b0531b5612e3170073daedefc46bc57348b91dce68cc9e07e9d087c43654",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48794",
+					"10.65.0.27:48794",
+					"172.17.0.1:48794",
+					"172.18.0.1:48794",
+					"172.19.0.1:48794",
+					"172.20.0.1:48794",
+					"172.21.0.1:48794",
+					"172.22.0.1:48794",
+					"172.23.0.1:48794",
+					"172.24.0.1:48794",
+					"172.25.0.1:48794",
+					"172.26.0.1:48794",
+					"172.27.0.1:48794"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:29:39.725982612Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5862924467252071,
+				"StableID":   "nL1iXs5Lnn11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1f2c54610b5c60ba0546dd2bcd5fc248ef5cdbf8949dd63e2f18f0856bb04514",
+				"KeyExpiry":  "2026-11-09T09:29:40Z",
+				"DiscoKey":   "discokey:38f7d9eda3690c65f595e42a0b2ed1b62379bb50523217184d143ab5c5691a5b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52155",
+					"10.65.0.27:52155",
+					"172.17.0.1:52155",
+					"172.18.0.1:52155",
+					"172.19.0.1:52155",
+					"172.20.0.1:52155",
+					"172.21.0.1:52155",
+					"172.22.0.1:52155",
+					"172.23.0.1:52155",
+					"172.24.0.1:52155",
+					"172.25.0.1:52155",
+					"172.26.0.1:52155",
+					"172.27.0.1:52155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:29:40.256259971Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3805678568696981,
+				"StableID":   "nrMYBvibiW11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:86c8345c3f407d8c6754e1ca156e1e299ad3b89dcb1d7aa937a6fa86cf03e532",
+				"KeyExpiry":  "2026-11-09T09:29:40Z",
+				"DiscoKey":   "discokey:4c23e8fbff3d7396d8260e6958541aa6749b7cc97d868d7a020ab6568befc97a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50255",
+					"10.65.0.27:50255",
+					"172.17.0.1:50255",
+					"172.18.0.1:50255",
+					"172.19.0.1:50255",
+					"172.20.0.1:50255",
+					"172.21.0.1:50255",
+					"172.22.0.1:50255",
+					"172.23.0.1:50255",
+					"172.24.0.1:50255",
+					"172.25.0.1:50255",
+					"172.26.0.1:50255",
+					"172.27.0.1:50255"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:29:40.787905965Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5181403855005874": {
+				"ID":          5181403855005874,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5862924467252071,
+				"StableID":   "nL1iXs5Lnn11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1f2c54610b5c60ba0546dd2bcd5fc248ef5cdbf8949dd63e2f18f0856bb04514",
+				"KeyExpiry":  "2026-11-09T09:29:40Z",
+				"DiscoKey":   "discokey:38f7d9eda3690c65f595e42a0b2ed1b62379bb50523217184d143ab5c5691a5b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52155",
+					"10.65.0.27:52155",
+					"172.17.0.1:52155",
+					"172.18.0.1:52155",
+					"172.19.0.1:52155",
+					"172.20.0.1:52155",
+					"172.21.0.1:52155",
+					"172.22.0.1:52155",
+					"172.23.0.1:52155",
+					"172.24.0.1:52155",
+					"172.25.0.1:52155",
+					"172.26.0.1:52155",
+					"172.27.0.1:52155"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:29:40.256259971Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1f2c54610b5c60ba0546dd2bcd5fc248ef5cdbf8949dd63e2f18f0856bb04514",
+			"MachineKey": "mkey:109dddfe3baf86bc889d781da383735af5d286dffa18d660f151ea6eddfff64f",
+			"Peers": [{
+				"ID":         2859212664711574,
+				"StableID":   "n3RUGmfwKP11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:257f18e69b65ec0c700b7e2184bca19a3cf77826021794928f6980d4ef38b248",
+				"DiscoKey":   "discokey:44fd7f4dd7476297d1221f7d99732c75a33da40d06f1c636d0c4f27698923b71",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43150",
+					"10.65.0.27:43150",
+					"172.17.0.1:43150",
+					"172.18.0.1:43150",
+					"172.19.0.1:43150",
+					"172.20.0.1:43150",
+					"172.21.0.1:43150",
+					"172.22.0.1:43150",
+					"172.23.0.1:43150",
+					"172.24.0.1:43150",
+					"172.25.0.1:43150",
+					"172.26.0.1:43150",
+					"172.27.0.1:43150"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:29:33.270318864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6209384882856680,
+				"StableID":   "n7eP4g1FVq11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f9506ef72035485fc2d27b1036bba84c599ee143c5e5db39f83b16e1c7c3d204",
+				"DiscoKey":   "discokey:56bfd065fbf9aded449df431842d4e6b4e7d44457ad503c42380ad737c3c3669",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44553",
+					"10.65.0.27:44553",
+					"172.17.0.1:44553",
+					"172.18.0.1:44553",
+					"172.19.0.1:44553",
+					"172.20.0.1:44553",
+					"172.21.0.1:44553",
+					"172.22.0.1:44553",
+					"172.23.0.1:44553",
+					"172.24.0.1:44553",
+					"172.25.0.1:44553",
+					"172.26.0.1:44553",
+					"172.27.0.1:44553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:29:33.764228462Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4937306133179357,
+				"StableID":   "nCgkyGf7Zf11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ccfd85a67c2ae7d59bd0dc941483f6764942db4d3e3473d6e3ea72dd8f4db405",
+				"DiscoKey":   "discokey:9e488e31b507cc05ebb6ac225a6e756e8de09f01ac7e1425f097e7eee2c0970d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53179",
+					"10.65.0.27:53179",
+					"172.17.0.1:53179",
+					"172.18.0.1:53179",
+					"172.19.0.1:53179",
+					"172.20.0.1:53179",
+					"172.21.0.1:53179",
+					"172.22.0.1:53179",
+					"172.23.0.1:53179",
+					"172.24.0.1:53179",
+					"172.25.0.1:53179",
+					"172.26.0.1:53179",
+					"172.27.0.1:53179"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:29:34.31032901Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         493614118971451,
+				"StableID":   "nUZhPYQZr411CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1f09659d9ff3cde7edaf8075269b59c8bac1f27bc88b3fbc0a27fadbca2e54b",
+				"DiscoKey":   "discokey:260fcd6a36050179da5c80d9561e7fc2361abfa0031182fc42a9975284ef484e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60113",
+					"10.65.0.27:60113",
+					"172.17.0.1:60113",
+					"172.18.0.1:60113",
+					"172.19.0.1:60113",
+					"172.20.0.1:60113",
+					"172.21.0.1:60113",
+					"172.22.0.1:60113",
+					"172.23.0.1:60113",
+					"172.24.0.1:60113",
+					"172.25.0.1:60113",
+					"172.26.0.1:60113",
+					"172.27.0.1:60113"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:29:34.841487957Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         188686204918932,
+				"StableID":   "nmjao4UTU211CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90929a1c49724dcf491f4acc8a70e70f4917540d41fefb552b2781a75cad4643",
+				"DiscoKey":   "discokey:916e878a92a884cf8fbbc9bcb52a4206be177185311ad7bff9f62f5218030632",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50198",
+					"10.65.0.27:50198",
+					"172.17.0.1:50198",
+					"172.18.0.1:50198",
+					"172.19.0.1:50198",
+					"172.20.0.1:50198",
+					"172.21.0.1:50198",
+					"172.22.0.1:50198",
+					"172.23.0.1:50198",
+					"172.24.0.1:50198",
+					"172.25.0.1:50198",
+					"172.26.0.1:50198",
+					"172.27.0.1:50198"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:29:35.35868711Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1431992482076218,
+				"StableID":   "nFPm1q1ZBC11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:599a1b94de977777f3d8c3a8e0b472a2664b1edeb03e8da4bcd89c8c6b23a825",
+				"DiscoKey":   "discokey:ce753b107bd5f488e3b6a7325ffd0442f0debe5213132977e2f95c8bd763884b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:47841",
+					"10.65.0.27:47841",
+					"172.17.0.1:47841",
+					"172.18.0.1:47841",
+					"172.19.0.1:47841",
+					"172.20.0.1:47841",
+					"172.21.0.1:47841",
+					"172.22.0.1:47841",
+					"172.23.0.1:47841",
+					"172.24.0.1:47841",
+					"172.25.0.1:47841",
+					"172.26.0.1:47841",
+					"172.27.0.1:47841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:29:35.901475059Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2215287914480306,
+				"StableID":   "nh487irJJJ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b064330c9f805ad51a4b3336b5d3687be97805d2c12670d472d6fdb9e000015",
+				"DiscoKey":   "discokey:d569f11adb20bdbd3997acdebf4a11d7aab3609cd661e9f4e1862f858a9d2230",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50524",
+					"10.65.0.27:50524",
+					"172.17.0.1:50524",
+					"172.18.0.1:50524",
+					"172.19.0.1:50524",
+					"172.20.0.1:50524",
+					"172.21.0.1:50524",
+					"172.22.0.1:50524",
+					"172.23.0.1:50524",
+					"172.24.0.1:50524",
+					"172.25.0.1:50524",
+					"172.26.0.1:50524",
+					"172.27.0.1:50524"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:29:36.429659202Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5481495937921774,
+				"StableID":   "nhWvXzbaoj11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:645ef6e18e733de4391cc50812baa95407a0cdba46a222b12872e3c92b64b447",
+				"DiscoKey":   "discokey:eade7d7c765e230e0a081b4dca22080209816989c9309c0ca23ba874a7382b0c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36768",
+					"10.65.0.27:36768",
+					"172.17.0.1:36768",
+					"172.18.0.1:36768",
+					"172.19.0.1:36768",
+					"172.20.0.1:36768",
+					"172.21.0.1:36768",
+					"172.22.0.1:36768",
+					"172.23.0.1:36768",
+					"172.24.0.1:36768",
+					"172.25.0.1:36768",
+					"172.26.0.1:36768",
+					"172.27.0.1:36768"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:29:36.978336642Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5181403855005874,
+				"StableID":   "nDnQnChfTh11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7af9bedfaf13444d28e1664137504d38acd3737d8df9eeac69018992665b601c",
+				"DiscoKey":   "discokey:717cb5a3f65595c24e1a225bd4211fdd0022216d9e6268eef2344181e8b0cf72",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36746",
+					"10.65.0.27:36746",
+					"172.17.0.1:36746",
+					"172.18.0.1:36746",
+					"172.19.0.1:36746",
+					"172.20.0.1:36746",
+					"172.21.0.1:36746",
+					"172.22.0.1:36746",
+					"172.23.0.1:36746",
+					"172.24.0.1:36746",
+					"172.25.0.1:36746",
+					"172.26.0.1:36746",
+					"172.27.0.1:36746"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:29:37.52519162Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5947777451816847,
+				"StableID":   "nUXBDd2mSo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9320fbe912baef9f83844e8f5526b56748d328d5ad9bcf9d4f76a3e855cb2147",
+				"DiscoKey":   "discokey:821b02cb0acf6fc1a36d2c95273c0663e0233c9d928fe1bdb60b6d57fa2c6f22",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50083",
+					"10.65.0.27:50083",
+					"172.17.0.1:50083",
+					"172.18.0.1:50083",
+					"172.19.0.1:50083",
+					"172.20.0.1:50083",
+					"172.21.0.1:50083",
+					"172.22.0.1:50083",
+					"172.23.0.1:50083",
+					"172.24.0.1:50083",
+					"172.25.0.1:50083",
+					"172.26.0.1:50083",
+					"172.27.0.1:50083"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:29:38.144998256Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8028973883170165,
+				"StableID":   "n44L8hXLh521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3e1a94c6101554334d973f8d28097a3b1c352efc44b034ba9a3f710c9a378d00",
+				"DiscoKey":   "discokey:80529a51f5492a8b47068444185c7f283fb9f84399ce6b3b5c5d218785df054b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35325",
+					"10.65.0.27:35325",
+					"172.17.0.1:35325",
+					"172.18.0.1:35325",
+					"172.19.0.1:35325",
+					"172.20.0.1:35325",
+					"172.21.0.1:35325",
+					"172.22.0.1:35325",
+					"172.23.0.1:35325",
+					"172.24.0.1:35325",
+					"172.25.0.1:35325",
+					"172.26.0.1:35325",
+					"172.27.0.1:35325"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:29:38.639659064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2490480947865966,
+				"StableID":   "nFKU7GiwSL11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb405c595cd71a6fd381cd46bec02addb0728794748e0f330f2b75861235d600",
+				"DiscoKey":   "discokey:7a3d09ff217e504c0b86360bd0d1aab6ba2719a28217d8a6850330843e296165",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:37486",
+					"10.65.0.27:37486",
+					"172.17.0.1:37486",
+					"172.18.0.1:37486",
+					"172.19.0.1:37486",
+					"172.20.0.1:37486",
+					"172.21.0.1:37486",
+					"172.22.0.1:37486",
+					"172.23.0.1:37486",
+					"172.24.0.1:37486",
+					"172.25.0.1:37486",
+					"172.26.0.1:37486",
+					"172.27.0.1:37486"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:29:39.168681166Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1589114381480400,
+				"StableID":   "nbU3EjLiQD11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1f3efd3a35eeb9304e0cdc3813584d87a6cf3e40c6119240a5e09ae92e650f5e",
+				"KeyExpiry":  "2026-11-09T09:29:39Z",
+				"DiscoKey":   "discokey:7522b0531b5612e3170073daedefc46bc57348b91dce68cc9e07e9d087c43654",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48794",
+					"10.65.0.27:48794",
+					"172.17.0.1:48794",
+					"172.18.0.1:48794",
+					"172.19.0.1:48794",
+					"172.20.0.1:48794",
+					"172.21.0.1:48794",
+					"172.22.0.1:48794",
+					"172.23.0.1:48794",
+					"172.24.0.1:48794",
+					"172.25.0.1:48794",
+					"172.26.0.1:48794",
+					"172.27.0.1:48794"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:29:39.725982612Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3805678568696981,
+				"StableID":   "nrMYBvibiW11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:86c8345c3f407d8c6754e1ca156e1e299ad3b89dcb1d7aa937a6fa86cf03e532",
+				"KeyExpiry":  "2026-11-09T09:29:40Z",
+				"DiscoKey":   "discokey:4c23e8fbff3d7396d8260e6958541aa6749b7cc97d868d7a020ab6568befc97a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50255",
+					"10.65.0.27:50255",
+					"172.17.0.1:50255",
+					"172.18.0.1:50255",
+					"172.19.0.1:50255",
+					"172.20.0.1:50255",
+					"172.21.0.1:50255",
+					"172.22.0.1:50255",
+					"172.23.0.1:50255",
+					"172.24.0.1:50255",
+					"172.25.0.1:50255",
+					"172.26.0.1:50255",
+					"172.27.0.1:50255"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:29:40.787905965Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5947777451816847,
+				"StableID":   "nUXBDd2mSo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       5947777451816847,
+				"Key":        "nodekey:9320fbe912baef9f83844e8f5526b56748d328d5ad9bcf9d4f76a3e855cb2147",
+				"DiscoKey":   "discokey:821b02cb0acf6fc1a36d2c95273c0663e0233c9d928fe1bdb60b6d57fa2c6f22",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50083",
+					"10.65.0.27:50083",
+					"172.17.0.1:50083",
+					"172.18.0.1:50083",
+					"172.19.0.1:50083",
+					"172.20.0.1:50083",
+					"172.21.0.1:50083",
+					"172.22.0.1:50083",
+					"172.23.0.1:50083",
+					"172.24.0.1:50083",
+					"172.25.0.1:50083",
+					"172.26.0.1:50083",
+					"172.27.0.1:50083"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:29:38.144998256Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9320fbe912baef9f83844e8f5526b56748d328d5ad9bcf9d4f76a3e855cb2147",
+			"MachineKey": "mkey:bdf859b2a1c0a38e4a22c649769e058a62ab6b18a421cb3b1914c18cc352a37b",
+			"Peers": [{
+				"ID":         2859212664711574,
+				"StableID":   "n3RUGmfwKP11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:257f18e69b65ec0c700b7e2184bca19a3cf77826021794928f6980d4ef38b248",
+				"DiscoKey":   "discokey:44fd7f4dd7476297d1221f7d99732c75a33da40d06f1c636d0c4f27698923b71",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43150",
+					"10.65.0.27:43150",
+					"172.17.0.1:43150",
+					"172.18.0.1:43150",
+					"172.19.0.1:43150",
+					"172.20.0.1:43150",
+					"172.21.0.1:43150",
+					"172.22.0.1:43150",
+					"172.23.0.1:43150",
+					"172.24.0.1:43150",
+					"172.25.0.1:43150",
+					"172.26.0.1:43150",
+					"172.27.0.1:43150"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:29:33.270318864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6209384882856680,
+				"StableID":   "n7eP4g1FVq11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f9506ef72035485fc2d27b1036bba84c599ee143c5e5db39f83b16e1c7c3d204",
+				"DiscoKey":   "discokey:56bfd065fbf9aded449df431842d4e6b4e7d44457ad503c42380ad737c3c3669",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:44553",
+					"10.65.0.27:44553",
+					"172.17.0.1:44553",
+					"172.18.0.1:44553",
+					"172.19.0.1:44553",
+					"172.20.0.1:44553",
+					"172.21.0.1:44553",
+					"172.22.0.1:44553",
+					"172.23.0.1:44553",
+					"172.24.0.1:44553",
+					"172.25.0.1:44553",
+					"172.26.0.1:44553",
+					"172.27.0.1:44553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:29:33.764228462Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4937306133179357,
+				"StableID":   "nCgkyGf7Zf11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ccfd85a67c2ae7d59bd0dc941483f6764942db4d3e3473d6e3ea72dd8f4db405",
+				"DiscoKey":   "discokey:9e488e31b507cc05ebb6ac225a6e756e8de09f01ac7e1425f097e7eee2c0970d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53179",
+					"10.65.0.27:53179",
+					"172.17.0.1:53179",
+					"172.18.0.1:53179",
+					"172.19.0.1:53179",
+					"172.20.0.1:53179",
+					"172.21.0.1:53179",
+					"172.22.0.1:53179",
+					"172.23.0.1:53179",
+					"172.24.0.1:53179",
+					"172.25.0.1:53179",
+					"172.26.0.1:53179",
+					"172.27.0.1:53179"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:29:34.31032901Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         493614118971451,
+				"StableID":   "nUZhPYQZr411CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d1f09659d9ff3cde7edaf8075269b59c8bac1f27bc88b3fbc0a27fadbca2e54b",
+				"DiscoKey":   "discokey:260fcd6a36050179da5c80d9561e7fc2361abfa0031182fc42a9975284ef484e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:60113",
+					"10.65.0.27:60113",
+					"172.17.0.1:60113",
+					"172.18.0.1:60113",
+					"172.19.0.1:60113",
+					"172.20.0.1:60113",
+					"172.21.0.1:60113",
+					"172.22.0.1:60113",
+					"172.23.0.1:60113",
+					"172.24.0.1:60113",
+					"172.25.0.1:60113",
+					"172.26.0.1:60113",
+					"172.27.0.1:60113"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:29:34.841487957Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         188686204918932,
+				"StableID":   "nmjao4UTU211CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90929a1c49724dcf491f4acc8a70e70f4917540d41fefb552b2781a75cad4643",
+				"DiscoKey":   "discokey:916e878a92a884cf8fbbc9bcb52a4206be177185311ad7bff9f62f5218030632",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:50198",
+					"10.65.0.27:50198",
+					"172.17.0.1:50198",
+					"172.18.0.1:50198",
+					"172.19.0.1:50198",
+					"172.20.0.1:50198",
+					"172.21.0.1:50198",
+					"172.22.0.1:50198",
+					"172.23.0.1:50198",
+					"172.24.0.1:50198",
+					"172.25.0.1:50198",
+					"172.26.0.1:50198",
+					"172.27.0.1:50198"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:29:35.35868711Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1431992482076218,
+				"StableID":   "nFPm1q1ZBC11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:599a1b94de977777f3d8c3a8e0b472a2664b1edeb03e8da4bcd89c8c6b23a825",
+				"DiscoKey":   "discokey:ce753b107bd5f488e3b6a7325ffd0442f0debe5213132977e2f95c8bd763884b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:47841",
+					"10.65.0.27:47841",
+					"172.17.0.1:47841",
+					"172.18.0.1:47841",
+					"172.19.0.1:47841",
+					"172.20.0.1:47841",
+					"172.21.0.1:47841",
+					"172.22.0.1:47841",
+					"172.23.0.1:47841",
+					"172.24.0.1:47841",
+					"172.25.0.1:47841",
+					"172.26.0.1:47841",
+					"172.27.0.1:47841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:29:35.901475059Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2215287914480306,
+				"StableID":   "nh487irJJJ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b064330c9f805ad51a4b3336b5d3687be97805d2c12670d472d6fdb9e000015",
+				"DiscoKey":   "discokey:d569f11adb20bdbd3997acdebf4a11d7aab3609cd661e9f4e1862f858a9d2230",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50524",
+					"10.65.0.27:50524",
+					"172.17.0.1:50524",
+					"172.18.0.1:50524",
+					"172.19.0.1:50524",
+					"172.20.0.1:50524",
+					"172.21.0.1:50524",
+					"172.22.0.1:50524",
+					"172.23.0.1:50524",
+					"172.24.0.1:50524",
+					"172.25.0.1:50524",
+					"172.26.0.1:50524",
+					"172.27.0.1:50524"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:29:36.429659202Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5481495937921774,
+				"StableID":   "nhWvXzbaoj11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:645ef6e18e733de4391cc50812baa95407a0cdba46a222b12872e3c92b64b447",
+				"DiscoKey":   "discokey:eade7d7c765e230e0a081b4dca22080209816989c9309c0ca23ba874a7382b0c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36768",
+					"10.65.0.27:36768",
+					"172.17.0.1:36768",
+					"172.18.0.1:36768",
+					"172.19.0.1:36768",
+					"172.20.0.1:36768",
+					"172.21.0.1:36768",
+					"172.22.0.1:36768",
+					"172.23.0.1:36768",
+					"172.24.0.1:36768",
+					"172.25.0.1:36768",
+					"172.26.0.1:36768",
+					"172.27.0.1:36768"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:29:36.978336642Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5181403855005874,
+				"StableID":   "nDnQnChfTh11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7af9bedfaf13444d28e1664137504d38acd3737d8df9eeac69018992665b601c",
+				"DiscoKey":   "discokey:717cb5a3f65595c24e1a225bd4211fdd0022216d9e6268eef2344181e8b0cf72",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:36746",
+					"10.65.0.27:36746",
+					"172.17.0.1:36746",
+					"172.18.0.1:36746",
+					"172.19.0.1:36746",
+					"172.20.0.1:36746",
+					"172.21.0.1:36746",
+					"172.22.0.1:36746",
+					"172.23.0.1:36746",
+					"172.24.0.1:36746",
+					"172.25.0.1:36746",
+					"172.26.0.1:36746",
+					"172.27.0.1:36746"
+				],
+				"HomeDERP": 4,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:29:37.52519162Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8028973883170165,
+				"StableID":   "n44L8hXLh521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3e1a94c6101554334d973f8d28097a3b1c352efc44b034ba9a3f710c9a378d00",
+				"DiscoKey":   "discokey:80529a51f5492a8b47068444185c7f283fb9f84399ce6b3b5c5d218785df054b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35325",
+					"10.65.0.27:35325",
+					"172.17.0.1:35325",
+					"172.18.0.1:35325",
+					"172.19.0.1:35325",
+					"172.20.0.1:35325",
+					"172.21.0.1:35325",
+					"172.22.0.1:35325",
+					"172.23.0.1:35325",
+					"172.24.0.1:35325",
+					"172.25.0.1:35325",
+					"172.26.0.1:35325",
+					"172.27.0.1:35325"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:29:38.639659064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2490480947865966,
+				"StableID":   "nFKU7GiwSL11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb405c595cd71a6fd381cd46bec02addb0728794748e0f330f2b75861235d600",
+				"DiscoKey":   "discokey:7a3d09ff217e504c0b86360bd0d1aab6ba2719a28217d8a6850330843e296165",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:37486",
+					"10.65.0.27:37486",
+					"172.17.0.1:37486",
+					"172.18.0.1:37486",
+					"172.19.0.1:37486",
+					"172.20.0.1:37486",
+					"172.21.0.1:37486",
+					"172.22.0.1:37486",
+					"172.23.0.1:37486",
+					"172.24.0.1:37486",
+					"172.25.0.1:37486",
+					"172.26.0.1:37486",
+					"172.27.0.1:37486"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:29:39.168681166Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1589114381480400,
+				"StableID":   "nbU3EjLiQD11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1f3efd3a35eeb9304e0cdc3813584d87a6cf3e40c6119240a5e09ae92e650f5e",
+				"KeyExpiry":  "2026-11-09T09:29:39Z",
+				"DiscoKey":   "discokey:7522b0531b5612e3170073daedefc46bc57348b91dce68cc9e07e9d087c43654",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:48794",
+					"10.65.0.27:48794",
+					"172.17.0.1:48794",
+					"172.18.0.1:48794",
+					"172.19.0.1:48794",
+					"172.20.0.1:48794",
+					"172.21.0.1:48794",
+					"172.22.0.1:48794",
+					"172.23.0.1:48794",
+					"172.24.0.1:48794",
+					"172.25.0.1:48794",
+					"172.26.0.1:48794",
+					"172.27.0.1:48794"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:29:39.725982612Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5862924467252071,
+				"StableID":   "nL1iXs5Lnn11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1f2c54610b5c60ba0546dd2bcd5fc248ef5cdbf8949dd63e2f18f0856bb04514",
+				"KeyExpiry":  "2026-11-09T09:29:40Z",
+				"DiscoKey":   "discokey:38f7d9eda3690c65f595e42a0b2ed1b62379bb50523217184d143ab5c5691a5b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:52155",
+					"10.65.0.27:52155",
+					"172.17.0.1:52155",
+					"172.18.0.1:52155",
+					"172.19.0.1:52155",
+					"172.20.0.1:52155",
+					"172.21.0.1:52155",
+					"172.22.0.1:52155",
+					"172.23.0.1:52155",
+					"172.24.0.1:52155",
+					"172.25.0.1:52155",
+					"172.26.0.1:52155",
+					"172.27.0.1:52155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:29:40.256259971Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3805678568696981,
+				"StableID":   "nrMYBvibiW11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:86c8345c3f407d8c6754e1ca156e1e299ad3b89dcb1d7aa937a6fa86cf03e532",
+				"KeyExpiry":  "2026-11-09T09:29:40Z",
+				"DiscoKey":   "discokey:4c23e8fbff3d7396d8260e6958541aa6749b7cc97d868d7a020ab6568befc97a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50255",
+					"10.65.0.27:50255",
+					"172.17.0.1:50255",
+					"172.18.0.1:50255",
+					"172.19.0.1:50255",
+					"172.20.0.1:50255",
+					"172.21.0.1:50255",
+					"172.22.0.1:50255",
+					"172.23.0.1:50255",
+					"172.24.0.1:50255",
+					"172.25.0.1:50255",
+					"172.26.0.1:50255",
+					"172.27.0.1:50255"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:29:40.787905965Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5947777451816847": {
+				"ID":          5947777451816847,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/sshtest_results/sshtest-accept-fail-no-ssh-rule.hujson
+++ b/hscontrol/policy/v2/testdata/sshtest_results/sshtest-accept-fail-no-ssh-rule.hujson
@@ -1,0 +1,20077 @@
+// sshtest-accept-fail-no-ssh-rule
+//
+// sshTests accept with no ssh rule must fail
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T18:29:38Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "sshtest-accept-fail-no-ssh-rule",
+	"description":    "sshTests accept with no ssh rule must fail",
+	"category":       "sshtest",
+	"captured_at":    "2026-05-12T18:29:38.665047946Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                  \n  \n                                                                        \n                                 \n{\n\t\"category\":    \"sshtest\",\n\t\"description\": \"sshTests accept with no ssh rule must fail\",\n\t\"id\":          \"sshtest-accept-fail-no-ssh-rule\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [], \"sshTests\": [{\n\t\t\"accept\": [\"root\"],\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    \"thor@example.org\"\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/sshtest/sshtest-accept-fail-no-ssh-rule.hujson",
+		"full_policy": {
+			"ssh":       [],
+			"sshTests":  [{"accept": ["root"], "dst": ["tag:server"], "src": "thor@example.org"}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4158246360674193,
+				"StableID":   "nimXeg5HUZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       4158246360674193,
+				"Key":        "nodekey:b95c99803bbab152bcf29b617c9a892b9a0c1bb2b8dfce49ccc0dafeab68eb1d",
+				"DiscoKey":   "discokey:b0c1cc1752892ea1ec226710b1cf111166ca6a9934b1c3e2e4a33d4cae6da971",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:42622",
+					"10.65.0.27:42622",
+					"172.17.0.1:42622",
+					"172.19.0.1:42622",
+					"172.20.0.1:42622"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:29:51.168298214Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b95c99803bbab152bcf29b617c9a892b9a0c1bb2b8dfce49ccc0dafeab68eb1d",
+			"MachineKey": "mkey:58e2e2ae3e5041934671a821efa9afdb7dab0c74df7f8a9d93f8f7173ec17748",
+			"Peers": [{
+				"ID":         8234662870115732,
+				"StableID":   "n9H8ZYdVJ721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0eee01ac22303d4bc8f22385fa59fdb650a2e6d7aee6081c8dfa91bdc30b256b",
+				"DiscoKey":   "discokey:04b3124736af5aeb3bd59fc85dc63f072b182adac193c5d7af2f390f8c6e4212",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43199",
+					"10.65.0.27:43199",
+					"172.17.0.1:43199",
+					"172.19.0.1:43199",
+					"172.20.0.1:43199"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:29:45.219812301Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6544588742819998,
+				"StableID":   "nPd5KRF47t11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb390f698893a62c7cb05680d1b71899216076979c708e8410f8a40231dd555f",
+				"DiscoKey":   "discokey:9f7ba6818ea891dc602ec49f439bdb83aee27946c9852551b671dbca3378ef4f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45163",
+					"10.65.0.27:45163",
+					"172.17.0.1:45163",
+					"172.19.0.1:45163",
+					"172.20.0.1:45163"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:29:45.751618181Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5315396181138127,
+				"StableID":   "npMsomSMWi11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6cc5c0e825391acf368cad164685681fe8774e1d4d9f44c1a481dcc14a75e20f",
+				"DiscoKey":   "discokey:520ee0662f4ba22489d0080953eefb314817ddc5c528a83209894b76f5fda147",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53984",
+					"10.65.0.27:53984",
+					"172.17.0.1:53984",
+					"172.19.0.1:53984",
+					"172.20.0.1:53984"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:29:46.290093148Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4296533335278602,
+				"StableID":   "nMpy3ReuYa11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b474d4ace3796ba7f27ecd64e6a0cc8c7af1e2c182889c56bf968c661f581259",
+				"DiscoKey":   "discokey:e914b70c34379bed721108b6f8456cfd6779db1b7d9010537ffad8e5eb91a071",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39652",
+					"10.65.0.27:39652",
+					"172.17.0.1:39652",
+					"172.19.0.1:39652",
+					"172.20.0.1:39652"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:29:46.834499654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1291891487792929,
+				"StableID":   "ncJJuKo66B11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:268c2b658a8d975c5f9578bbc186c816623320edb4ce04bb85a4410d1179d635",
+				"DiscoKey":   "discokey:944ad6dcef0b6e6c43ce6b4c3afca444bb4df653f2dc7aa2937c68043245e55a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49120",
+					"10.65.0.27:49120",
+					"172.17.0.1:49120",
+					"172.19.0.1:49120",
+					"172.20.0.1:49120"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:29:47.36869129Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4129052562030129,
+				"StableID":   "naZZd8D4FZ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f0020008d79fc356acec4b437434237f16cccbfb13038eee35dc490ea3a6a35",
+				"DiscoKey":   "discokey:730ffd40f7b9c2914d87f4eac6ea4721101dc29642d8da3048c6240b0a7bfe46",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:55643",
+					"10.65.0.27:55643",
+					"172.17.0.1:55643",
+					"172.19.0.1:55643",
+					"172.20.0.1:55643"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:29:47.909061857Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6667782799698745,
+				"StableID":   "n4C5GAMr4u11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:58a20b8362ec35dddffa799f562078c8f1dd7b25e54740f6c3a15211da41de45",
+				"DiscoKey":   "discokey:bc11bf8887195e4c69e6ddd75816e05f628dc7b4e435e7468e830275f3556861",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35504",
+					"10.65.0.27:35504",
+					"172.17.0.1:35504",
+					"172.19.0.1:35504",
+					"172.20.0.1:35504"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:29:48.453548721Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2817208958256072,
+				"StableID":   "nMMcZXJvzN11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e548e82d1bcc53e06a1f93c241028d475fc567ccf450fb65cf69f698b0acfd43",
+				"DiscoKey":   "discokey:cdfc8ad0ce6a5e374ff826e87a31bf71a48007822eeacc57f0e831ec3e19e642",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:39234",
+					"10.65.0.27:39234",
+					"172.17.0.1:39234",
+					"172.19.0.1:39234",
+					"172.20.0.1:39234"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:29:49.003378971Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3390625595990804,
+				"StableID":   "nTERG8zcUT11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9e5744db825918d533b11008551fe192931e9d5554aae3fc7b6b9fae00ac850c",
+				"DiscoKey":   "discokey:e0dea56a0b0dec9fc73b8e052ad9211dd45bd273cdf91226d1bee31d0f22416c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44834",
+					"10.65.0.27:44834",
+					"172.17.0.1:44834",
+					"172.19.0.1:44834",
+					"172.20.0.1:44834"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:29:49.548056599Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         968689913947377,
+				"StableID":   "n2mDaoqiZ811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3504874d4beabc3f316508828cf6e3b3c0d61207393456020411756e4ad1c80f",
+				"DiscoKey":   "discokey:db65dacd234ebf899d396a3c6c91dfec91f70caf4e3d178cba7c401f09dd0610",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:37873",
+					"10.65.0.27:37873",
+					"172.17.0.1:37873",
+					"172.19.0.1:37873",
+					"172.20.0.1:37873"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:29:50.104620665Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         696938256648319,
+				"StableID":   "n8KrBQPeS611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d7c2f0198ee19b1ae6b07b3a470b23368cac1875c0dde0cb50a1f8083c170978",
+				"DiscoKey":   "discokey:81c1f42387f94b3ed445863fcca52c83f8de5644c77aa3645fc597f0cf2b446c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:59009",
+					"10.65.0.27:59009",
+					"172.17.0.1:59009",
+					"172.19.0.1:59009",
+					"172.20.0.1:59009"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:29:50.623715041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         744157076743230,
+				"StableID":   "nRYHdBk2p611CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1ff44fded80c2abafaf7bba3dbe770f48b6d15fb2d25cfeda41fb64b3451c20d",
+				"KeyExpiry":  "2026-11-08T18:29:51Z",
+				"DiscoKey":   "discokey:d2e3a51a40e760d410dbeae843738de1274df9313f2cdd526c493041b89b0572",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51111",
+					"10.65.0.27:51111",
+					"172.17.0.1:51111",
+					"172.19.0.1:51111",
+					"172.20.0.1:51111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:29:51.705572614Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8177835151153133,
+				"StableID":   "nJhLd1skr621CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8285c8594b27158736a2574bdb57211c19da7a66693e8fb6447e54d509ce8b24",
+				"KeyExpiry":  "2026-11-08T18:29:52Z",
+				"DiscoKey":   "discokey:36c5c6a88f700cb4e8373031e54573a4526b1cd7f347b57e3aeb4f907a3f184a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34782",
+					"10.65.0.27:34782",
+					"172.17.0.1:34782",
+					"172.19.0.1:34782",
+					"172.20.0.1:34782"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:29:52.243200577Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5362337086668675,
+				"StableID":   "n41Xt8Wcsi11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7740b711db64b821c69fdcc8cba5b32289fb5e8974ee1654c1710c55fe902214",
+				"KeyExpiry":  "2026-11-08T18:29:52Z",
+				"DiscoKey":   "discokey:770afaea00abc31a0aae3ee7b14ed172f15e838d88051e6f4dc77edb110fb532",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53150",
+					"10.65.0.27:53150",
+					"172.17.0.1:53150",
+					"172.19.0.1:53150",
+					"172.20.0.1:53150"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:29:52.783028805Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4158246360674193": {
+				"ID":          4158246360674193,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4129052562030129,
+				"StableID":   "naZZd8D4FZ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       4129052562030129,
+				"Key":        "nodekey:9f0020008d79fc356acec4b437434237f16cccbfb13038eee35dc490ea3a6a35",
+				"DiscoKey":   "discokey:730ffd40f7b9c2914d87f4eac6ea4721101dc29642d8da3048c6240b0a7bfe46",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:55643",
+					"10.65.0.27:55643",
+					"172.17.0.1:55643",
+					"172.19.0.1:55643",
+					"172.20.0.1:55643"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:29:47.909061857Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9f0020008d79fc356acec4b437434237f16cccbfb13038eee35dc490ea3a6a35",
+			"MachineKey": "mkey:c820ee08f9482a3f52880f8e170caa867e8765d8f919817d13611554a6495f5e",
+			"Peers": [{
+				"ID":         8234662870115732,
+				"StableID":   "n9H8ZYdVJ721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0eee01ac22303d4bc8f22385fa59fdb650a2e6d7aee6081c8dfa91bdc30b256b",
+				"DiscoKey":   "discokey:04b3124736af5aeb3bd59fc85dc63f072b182adac193c5d7af2f390f8c6e4212",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43199",
+					"10.65.0.27:43199",
+					"172.17.0.1:43199",
+					"172.19.0.1:43199",
+					"172.20.0.1:43199"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:29:45.219812301Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6544588742819998,
+				"StableID":   "nPd5KRF47t11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb390f698893a62c7cb05680d1b71899216076979c708e8410f8a40231dd555f",
+				"DiscoKey":   "discokey:9f7ba6818ea891dc602ec49f439bdb83aee27946c9852551b671dbca3378ef4f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45163",
+					"10.65.0.27:45163",
+					"172.17.0.1:45163",
+					"172.19.0.1:45163",
+					"172.20.0.1:45163"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:29:45.751618181Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5315396181138127,
+				"StableID":   "npMsomSMWi11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6cc5c0e825391acf368cad164685681fe8774e1d4d9f44c1a481dcc14a75e20f",
+				"DiscoKey":   "discokey:520ee0662f4ba22489d0080953eefb314817ddc5c528a83209894b76f5fda147",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53984",
+					"10.65.0.27:53984",
+					"172.17.0.1:53984",
+					"172.19.0.1:53984",
+					"172.20.0.1:53984"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:29:46.290093148Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4296533335278602,
+				"StableID":   "nMpy3ReuYa11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b474d4ace3796ba7f27ecd64e6a0cc8c7af1e2c182889c56bf968c661f581259",
+				"DiscoKey":   "discokey:e914b70c34379bed721108b6f8456cfd6779db1b7d9010537ffad8e5eb91a071",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39652",
+					"10.65.0.27:39652",
+					"172.17.0.1:39652",
+					"172.19.0.1:39652",
+					"172.20.0.1:39652"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:29:46.834499654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1291891487792929,
+				"StableID":   "ncJJuKo66B11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:268c2b658a8d975c5f9578bbc186c816623320edb4ce04bb85a4410d1179d635",
+				"DiscoKey":   "discokey:944ad6dcef0b6e6c43ce6b4c3afca444bb4df653f2dc7aa2937c68043245e55a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49120",
+					"10.65.0.27:49120",
+					"172.17.0.1:49120",
+					"172.19.0.1:49120",
+					"172.20.0.1:49120"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:29:47.36869129Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6667782799698745,
+				"StableID":   "n4C5GAMr4u11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:58a20b8362ec35dddffa799f562078c8f1dd7b25e54740f6c3a15211da41de45",
+				"DiscoKey":   "discokey:bc11bf8887195e4c69e6ddd75816e05f628dc7b4e435e7468e830275f3556861",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35504",
+					"10.65.0.27:35504",
+					"172.17.0.1:35504",
+					"172.19.0.1:35504",
+					"172.20.0.1:35504"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:29:48.453548721Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2817208958256072,
+				"StableID":   "nMMcZXJvzN11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e548e82d1bcc53e06a1f93c241028d475fc567ccf450fb65cf69f698b0acfd43",
+				"DiscoKey":   "discokey:cdfc8ad0ce6a5e374ff826e87a31bf71a48007822eeacc57f0e831ec3e19e642",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:39234",
+					"10.65.0.27:39234",
+					"172.17.0.1:39234",
+					"172.19.0.1:39234",
+					"172.20.0.1:39234"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:29:49.003378971Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3390625595990804,
+				"StableID":   "nTERG8zcUT11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9e5744db825918d533b11008551fe192931e9d5554aae3fc7b6b9fae00ac850c",
+				"DiscoKey":   "discokey:e0dea56a0b0dec9fc73b8e052ad9211dd45bd273cdf91226d1bee31d0f22416c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44834",
+					"10.65.0.27:44834",
+					"172.17.0.1:44834",
+					"172.19.0.1:44834",
+					"172.20.0.1:44834"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:29:49.548056599Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         968689913947377,
+				"StableID":   "n2mDaoqiZ811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3504874d4beabc3f316508828cf6e3b3c0d61207393456020411756e4ad1c80f",
+				"DiscoKey":   "discokey:db65dacd234ebf899d396a3c6c91dfec91f70caf4e3d178cba7c401f09dd0610",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:37873",
+					"10.65.0.27:37873",
+					"172.17.0.1:37873",
+					"172.19.0.1:37873",
+					"172.20.0.1:37873"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:29:50.104620665Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         696938256648319,
+				"StableID":   "n8KrBQPeS611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d7c2f0198ee19b1ae6b07b3a470b23368cac1875c0dde0cb50a1f8083c170978",
+				"DiscoKey":   "discokey:81c1f42387f94b3ed445863fcca52c83f8de5644c77aa3645fc597f0cf2b446c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:59009",
+					"10.65.0.27:59009",
+					"172.17.0.1:59009",
+					"172.19.0.1:59009",
+					"172.20.0.1:59009"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:29:50.623715041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4158246360674193,
+				"StableID":   "nimXeg5HUZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b95c99803bbab152bcf29b617c9a892b9a0c1bb2b8dfce49ccc0dafeab68eb1d",
+				"DiscoKey":   "discokey:b0c1cc1752892ea1ec226710b1cf111166ca6a9934b1c3e2e4a33d4cae6da971",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:42622",
+					"10.65.0.27:42622",
+					"172.17.0.1:42622",
+					"172.19.0.1:42622",
+					"172.20.0.1:42622"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:29:51.168298214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         744157076743230,
+				"StableID":   "nRYHdBk2p611CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1ff44fded80c2abafaf7bba3dbe770f48b6d15fb2d25cfeda41fb64b3451c20d",
+				"KeyExpiry":  "2026-11-08T18:29:51Z",
+				"DiscoKey":   "discokey:d2e3a51a40e760d410dbeae843738de1274df9313f2cdd526c493041b89b0572",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51111",
+					"10.65.0.27:51111",
+					"172.17.0.1:51111",
+					"172.19.0.1:51111",
+					"172.20.0.1:51111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:29:51.705572614Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8177835151153133,
+				"StableID":   "nJhLd1skr621CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8285c8594b27158736a2574bdb57211c19da7a66693e8fb6447e54d509ce8b24",
+				"KeyExpiry":  "2026-11-08T18:29:52Z",
+				"DiscoKey":   "discokey:36c5c6a88f700cb4e8373031e54573a4526b1cd7f347b57e3aeb4f907a3f184a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34782",
+					"10.65.0.27:34782",
+					"172.17.0.1:34782",
+					"172.19.0.1:34782",
+					"172.20.0.1:34782"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:29:52.243200577Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5362337086668675,
+				"StableID":   "n41Xt8Wcsi11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7740b711db64b821c69fdcc8cba5b32289fb5e8974ee1654c1710c55fe902214",
+				"KeyExpiry":  "2026-11-08T18:29:52Z",
+				"DiscoKey":   "discokey:770afaea00abc31a0aae3ee7b14ed172f15e838d88051e6f4dc77edb110fb532",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53150",
+					"10.65.0.27:53150",
+					"172.17.0.1:53150",
+					"172.19.0.1:53150",
+					"172.20.0.1:53150"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:29:52.783028805Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4129052562030129": {
+				"ID":          4129052562030129,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5362337086668675,
+				"StableID":   "n41Xt8Wcsi11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7740b711db64b821c69fdcc8cba5b32289fb5e8974ee1654c1710c55fe902214",
+				"KeyExpiry":  "2026-11-08T18:29:52Z",
+				"DiscoKey":   "discokey:770afaea00abc31a0aae3ee7b14ed172f15e838d88051e6f4dc77edb110fb532",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53150",
+					"10.65.0.27:53150",
+					"172.17.0.1:53150",
+					"172.19.0.1:53150",
+					"172.20.0.1:53150"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:29:52.783028805Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7740b711db64b821c69fdcc8cba5b32289fb5e8974ee1654c1710c55fe902214",
+			"MachineKey": "mkey:156aed518eca3143c0a29c34093bdfd64c198154c6803db69397a6acc78b3113",
+			"Peers": [{
+				"ID":         8234662870115732,
+				"StableID":   "n9H8ZYdVJ721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0eee01ac22303d4bc8f22385fa59fdb650a2e6d7aee6081c8dfa91bdc30b256b",
+				"DiscoKey":   "discokey:04b3124736af5aeb3bd59fc85dc63f072b182adac193c5d7af2f390f8c6e4212",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43199",
+					"10.65.0.27:43199",
+					"172.17.0.1:43199",
+					"172.19.0.1:43199",
+					"172.20.0.1:43199"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:29:45.219812301Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6544588742819998,
+				"StableID":   "nPd5KRF47t11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb390f698893a62c7cb05680d1b71899216076979c708e8410f8a40231dd555f",
+				"DiscoKey":   "discokey:9f7ba6818ea891dc602ec49f439bdb83aee27946c9852551b671dbca3378ef4f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45163",
+					"10.65.0.27:45163",
+					"172.17.0.1:45163",
+					"172.19.0.1:45163",
+					"172.20.0.1:45163"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:29:45.751618181Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5315396181138127,
+				"StableID":   "npMsomSMWi11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6cc5c0e825391acf368cad164685681fe8774e1d4d9f44c1a481dcc14a75e20f",
+				"DiscoKey":   "discokey:520ee0662f4ba22489d0080953eefb314817ddc5c528a83209894b76f5fda147",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53984",
+					"10.65.0.27:53984",
+					"172.17.0.1:53984",
+					"172.19.0.1:53984",
+					"172.20.0.1:53984"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:29:46.290093148Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4296533335278602,
+				"StableID":   "nMpy3ReuYa11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b474d4ace3796ba7f27ecd64e6a0cc8c7af1e2c182889c56bf968c661f581259",
+				"DiscoKey":   "discokey:e914b70c34379bed721108b6f8456cfd6779db1b7d9010537ffad8e5eb91a071",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39652",
+					"10.65.0.27:39652",
+					"172.17.0.1:39652",
+					"172.19.0.1:39652",
+					"172.20.0.1:39652"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:29:46.834499654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1291891487792929,
+				"StableID":   "ncJJuKo66B11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:268c2b658a8d975c5f9578bbc186c816623320edb4ce04bb85a4410d1179d635",
+				"DiscoKey":   "discokey:944ad6dcef0b6e6c43ce6b4c3afca444bb4df653f2dc7aa2937c68043245e55a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49120",
+					"10.65.0.27:49120",
+					"172.17.0.1:49120",
+					"172.19.0.1:49120",
+					"172.20.0.1:49120"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:29:47.36869129Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4129052562030129,
+				"StableID":   "naZZd8D4FZ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f0020008d79fc356acec4b437434237f16cccbfb13038eee35dc490ea3a6a35",
+				"DiscoKey":   "discokey:730ffd40f7b9c2914d87f4eac6ea4721101dc29642d8da3048c6240b0a7bfe46",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:55643",
+					"10.65.0.27:55643",
+					"172.17.0.1:55643",
+					"172.19.0.1:55643",
+					"172.20.0.1:55643"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:29:47.909061857Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6667782799698745,
+				"StableID":   "n4C5GAMr4u11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:58a20b8362ec35dddffa799f562078c8f1dd7b25e54740f6c3a15211da41de45",
+				"DiscoKey":   "discokey:bc11bf8887195e4c69e6ddd75816e05f628dc7b4e435e7468e830275f3556861",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35504",
+					"10.65.0.27:35504",
+					"172.17.0.1:35504",
+					"172.19.0.1:35504",
+					"172.20.0.1:35504"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:29:48.453548721Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2817208958256072,
+				"StableID":   "nMMcZXJvzN11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e548e82d1bcc53e06a1f93c241028d475fc567ccf450fb65cf69f698b0acfd43",
+				"DiscoKey":   "discokey:cdfc8ad0ce6a5e374ff826e87a31bf71a48007822eeacc57f0e831ec3e19e642",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:39234",
+					"10.65.0.27:39234",
+					"172.17.0.1:39234",
+					"172.19.0.1:39234",
+					"172.20.0.1:39234"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:29:49.003378971Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3390625595990804,
+				"StableID":   "nTERG8zcUT11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9e5744db825918d533b11008551fe192931e9d5554aae3fc7b6b9fae00ac850c",
+				"DiscoKey":   "discokey:e0dea56a0b0dec9fc73b8e052ad9211dd45bd273cdf91226d1bee31d0f22416c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44834",
+					"10.65.0.27:44834",
+					"172.17.0.1:44834",
+					"172.19.0.1:44834",
+					"172.20.0.1:44834"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:29:49.548056599Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         968689913947377,
+				"StableID":   "n2mDaoqiZ811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3504874d4beabc3f316508828cf6e3b3c0d61207393456020411756e4ad1c80f",
+				"DiscoKey":   "discokey:db65dacd234ebf899d396a3c6c91dfec91f70caf4e3d178cba7c401f09dd0610",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:37873",
+					"10.65.0.27:37873",
+					"172.17.0.1:37873",
+					"172.19.0.1:37873",
+					"172.20.0.1:37873"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:29:50.104620665Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         696938256648319,
+				"StableID":   "n8KrBQPeS611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d7c2f0198ee19b1ae6b07b3a470b23368cac1875c0dde0cb50a1f8083c170978",
+				"DiscoKey":   "discokey:81c1f42387f94b3ed445863fcca52c83f8de5644c77aa3645fc597f0cf2b446c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:59009",
+					"10.65.0.27:59009",
+					"172.17.0.1:59009",
+					"172.19.0.1:59009",
+					"172.20.0.1:59009"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:29:50.623715041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4158246360674193,
+				"StableID":   "nimXeg5HUZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b95c99803bbab152bcf29b617c9a892b9a0c1bb2b8dfce49ccc0dafeab68eb1d",
+				"DiscoKey":   "discokey:b0c1cc1752892ea1ec226710b1cf111166ca6a9934b1c3e2e4a33d4cae6da971",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:42622",
+					"10.65.0.27:42622",
+					"172.17.0.1:42622",
+					"172.19.0.1:42622",
+					"172.20.0.1:42622"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:29:51.168298214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         744157076743230,
+				"StableID":   "nRYHdBk2p611CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1ff44fded80c2abafaf7bba3dbe770f48b6d15fb2d25cfeda41fb64b3451c20d",
+				"KeyExpiry":  "2026-11-08T18:29:51Z",
+				"DiscoKey":   "discokey:d2e3a51a40e760d410dbeae843738de1274df9313f2cdd526c493041b89b0572",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51111",
+					"10.65.0.27:51111",
+					"172.17.0.1:51111",
+					"172.19.0.1:51111",
+					"172.20.0.1:51111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:29:51.705572614Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8177835151153133,
+				"StableID":   "nJhLd1skr621CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8285c8594b27158736a2574bdb57211c19da7a66693e8fb6447e54d509ce8b24",
+				"KeyExpiry":  "2026-11-08T18:29:52Z",
+				"DiscoKey":   "discokey:36c5c6a88f700cb4e8373031e54573a4526b1cd7f347b57e3aeb4f907a3f184a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34782",
+					"10.65.0.27:34782",
+					"172.17.0.1:34782",
+					"172.19.0.1:34782",
+					"172.20.0.1:34782"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:29:52.243200577Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5315396181138127,
+				"StableID":   "npMsomSMWi11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       5315396181138127,
+				"Key":        "nodekey:6cc5c0e825391acf368cad164685681fe8774e1d4d9f44c1a481dcc14a75e20f",
+				"DiscoKey":   "discokey:520ee0662f4ba22489d0080953eefb314817ddc5c528a83209894b76f5fda147",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53984",
+					"10.65.0.27:53984",
+					"172.17.0.1:53984",
+					"172.19.0.1:53984",
+					"172.20.0.1:53984"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:29:46.290093148Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6cc5c0e825391acf368cad164685681fe8774e1d4d9f44c1a481dcc14a75e20f",
+			"MachineKey": "mkey:fde8f2abd23cde044f5a5538813ee0675a0f1ff666a1b70dbd6431f3d5ea2954",
+			"Peers": [{
+				"ID":         8234662870115732,
+				"StableID":   "n9H8ZYdVJ721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0eee01ac22303d4bc8f22385fa59fdb650a2e6d7aee6081c8dfa91bdc30b256b",
+				"DiscoKey":   "discokey:04b3124736af5aeb3bd59fc85dc63f072b182adac193c5d7af2f390f8c6e4212",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43199",
+					"10.65.0.27:43199",
+					"172.17.0.1:43199",
+					"172.19.0.1:43199",
+					"172.20.0.1:43199"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:29:45.219812301Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6544588742819998,
+				"StableID":   "nPd5KRF47t11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb390f698893a62c7cb05680d1b71899216076979c708e8410f8a40231dd555f",
+				"DiscoKey":   "discokey:9f7ba6818ea891dc602ec49f439bdb83aee27946c9852551b671dbca3378ef4f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45163",
+					"10.65.0.27:45163",
+					"172.17.0.1:45163",
+					"172.19.0.1:45163",
+					"172.20.0.1:45163"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:29:45.751618181Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4296533335278602,
+				"StableID":   "nMpy3ReuYa11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b474d4ace3796ba7f27ecd64e6a0cc8c7af1e2c182889c56bf968c661f581259",
+				"DiscoKey":   "discokey:e914b70c34379bed721108b6f8456cfd6779db1b7d9010537ffad8e5eb91a071",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39652",
+					"10.65.0.27:39652",
+					"172.17.0.1:39652",
+					"172.19.0.1:39652",
+					"172.20.0.1:39652"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:29:46.834499654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1291891487792929,
+				"StableID":   "ncJJuKo66B11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:268c2b658a8d975c5f9578bbc186c816623320edb4ce04bb85a4410d1179d635",
+				"DiscoKey":   "discokey:944ad6dcef0b6e6c43ce6b4c3afca444bb4df653f2dc7aa2937c68043245e55a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49120",
+					"10.65.0.27:49120",
+					"172.17.0.1:49120",
+					"172.19.0.1:49120",
+					"172.20.0.1:49120"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:29:47.36869129Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4129052562030129,
+				"StableID":   "naZZd8D4FZ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f0020008d79fc356acec4b437434237f16cccbfb13038eee35dc490ea3a6a35",
+				"DiscoKey":   "discokey:730ffd40f7b9c2914d87f4eac6ea4721101dc29642d8da3048c6240b0a7bfe46",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:55643",
+					"10.65.0.27:55643",
+					"172.17.0.1:55643",
+					"172.19.0.1:55643",
+					"172.20.0.1:55643"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:29:47.909061857Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6667782799698745,
+				"StableID":   "n4C5GAMr4u11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:58a20b8362ec35dddffa799f562078c8f1dd7b25e54740f6c3a15211da41de45",
+				"DiscoKey":   "discokey:bc11bf8887195e4c69e6ddd75816e05f628dc7b4e435e7468e830275f3556861",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35504",
+					"10.65.0.27:35504",
+					"172.17.0.1:35504",
+					"172.19.0.1:35504",
+					"172.20.0.1:35504"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:29:48.453548721Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2817208958256072,
+				"StableID":   "nMMcZXJvzN11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e548e82d1bcc53e06a1f93c241028d475fc567ccf450fb65cf69f698b0acfd43",
+				"DiscoKey":   "discokey:cdfc8ad0ce6a5e374ff826e87a31bf71a48007822eeacc57f0e831ec3e19e642",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:39234",
+					"10.65.0.27:39234",
+					"172.17.0.1:39234",
+					"172.19.0.1:39234",
+					"172.20.0.1:39234"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:29:49.003378971Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3390625595990804,
+				"StableID":   "nTERG8zcUT11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9e5744db825918d533b11008551fe192931e9d5554aae3fc7b6b9fae00ac850c",
+				"DiscoKey":   "discokey:e0dea56a0b0dec9fc73b8e052ad9211dd45bd273cdf91226d1bee31d0f22416c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44834",
+					"10.65.0.27:44834",
+					"172.17.0.1:44834",
+					"172.19.0.1:44834",
+					"172.20.0.1:44834"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:29:49.548056599Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         968689913947377,
+				"StableID":   "n2mDaoqiZ811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3504874d4beabc3f316508828cf6e3b3c0d61207393456020411756e4ad1c80f",
+				"DiscoKey":   "discokey:db65dacd234ebf899d396a3c6c91dfec91f70caf4e3d178cba7c401f09dd0610",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:37873",
+					"10.65.0.27:37873",
+					"172.17.0.1:37873",
+					"172.19.0.1:37873",
+					"172.20.0.1:37873"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:29:50.104620665Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         696938256648319,
+				"StableID":   "n8KrBQPeS611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d7c2f0198ee19b1ae6b07b3a470b23368cac1875c0dde0cb50a1f8083c170978",
+				"DiscoKey":   "discokey:81c1f42387f94b3ed445863fcca52c83f8de5644c77aa3645fc597f0cf2b446c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:59009",
+					"10.65.0.27:59009",
+					"172.17.0.1:59009",
+					"172.19.0.1:59009",
+					"172.20.0.1:59009"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:29:50.623715041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4158246360674193,
+				"StableID":   "nimXeg5HUZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b95c99803bbab152bcf29b617c9a892b9a0c1bb2b8dfce49ccc0dafeab68eb1d",
+				"DiscoKey":   "discokey:b0c1cc1752892ea1ec226710b1cf111166ca6a9934b1c3e2e4a33d4cae6da971",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:42622",
+					"10.65.0.27:42622",
+					"172.17.0.1:42622",
+					"172.19.0.1:42622",
+					"172.20.0.1:42622"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:29:51.168298214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         744157076743230,
+				"StableID":   "nRYHdBk2p611CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1ff44fded80c2abafaf7bba3dbe770f48b6d15fb2d25cfeda41fb64b3451c20d",
+				"KeyExpiry":  "2026-11-08T18:29:51Z",
+				"DiscoKey":   "discokey:d2e3a51a40e760d410dbeae843738de1274df9313f2cdd526c493041b89b0572",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51111",
+					"10.65.0.27:51111",
+					"172.17.0.1:51111",
+					"172.19.0.1:51111",
+					"172.20.0.1:51111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:29:51.705572614Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8177835151153133,
+				"StableID":   "nJhLd1skr621CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8285c8594b27158736a2574bdb57211c19da7a66693e8fb6447e54d509ce8b24",
+				"KeyExpiry":  "2026-11-08T18:29:52Z",
+				"DiscoKey":   "discokey:36c5c6a88f700cb4e8373031e54573a4526b1cd7f347b57e3aeb4f907a3f184a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34782",
+					"10.65.0.27:34782",
+					"172.17.0.1:34782",
+					"172.19.0.1:34782",
+					"172.20.0.1:34782"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:29:52.243200577Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5362337086668675,
+				"StableID":   "n41Xt8Wcsi11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7740b711db64b821c69fdcc8cba5b32289fb5e8974ee1654c1710c55fe902214",
+				"KeyExpiry":  "2026-11-08T18:29:52Z",
+				"DiscoKey":   "discokey:770afaea00abc31a0aae3ee7b14ed172f15e838d88051e6f4dc77edb110fb532",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53150",
+					"10.65.0.27:53150",
+					"172.17.0.1:53150",
+					"172.19.0.1:53150",
+					"172.20.0.1:53150"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:29:52.783028805Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5315396181138127": {
+				"ID":          5315396181138127,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2817208958256072,
+				"StableID":   "nMMcZXJvzN11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       2817208958256072,
+				"Key":        "nodekey:e548e82d1bcc53e06a1f93c241028d475fc567ccf450fb65cf69f698b0acfd43",
+				"DiscoKey":   "discokey:cdfc8ad0ce6a5e374ff826e87a31bf71a48007822eeacc57f0e831ec3e19e642",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:39234",
+					"10.65.0.27:39234",
+					"172.17.0.1:39234",
+					"172.19.0.1:39234",
+					"172.20.0.1:39234"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:29:49.003378971Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e548e82d1bcc53e06a1f93c241028d475fc567ccf450fb65cf69f698b0acfd43",
+			"MachineKey": "mkey:8d8afc592ad8edd897ca0581d0e95464b59adf2376b0715399053ec799659244",
+			"Peers": [{
+				"ID":         8234662870115732,
+				"StableID":   "n9H8ZYdVJ721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0eee01ac22303d4bc8f22385fa59fdb650a2e6d7aee6081c8dfa91bdc30b256b",
+				"DiscoKey":   "discokey:04b3124736af5aeb3bd59fc85dc63f072b182adac193c5d7af2f390f8c6e4212",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43199",
+					"10.65.0.27:43199",
+					"172.17.0.1:43199",
+					"172.19.0.1:43199",
+					"172.20.0.1:43199"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:29:45.219812301Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6544588742819998,
+				"StableID":   "nPd5KRF47t11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb390f698893a62c7cb05680d1b71899216076979c708e8410f8a40231dd555f",
+				"DiscoKey":   "discokey:9f7ba6818ea891dc602ec49f439bdb83aee27946c9852551b671dbca3378ef4f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45163",
+					"10.65.0.27:45163",
+					"172.17.0.1:45163",
+					"172.19.0.1:45163",
+					"172.20.0.1:45163"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:29:45.751618181Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5315396181138127,
+				"StableID":   "npMsomSMWi11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6cc5c0e825391acf368cad164685681fe8774e1d4d9f44c1a481dcc14a75e20f",
+				"DiscoKey":   "discokey:520ee0662f4ba22489d0080953eefb314817ddc5c528a83209894b76f5fda147",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53984",
+					"10.65.0.27:53984",
+					"172.17.0.1:53984",
+					"172.19.0.1:53984",
+					"172.20.0.1:53984"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:29:46.290093148Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4296533335278602,
+				"StableID":   "nMpy3ReuYa11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b474d4ace3796ba7f27ecd64e6a0cc8c7af1e2c182889c56bf968c661f581259",
+				"DiscoKey":   "discokey:e914b70c34379bed721108b6f8456cfd6779db1b7d9010537ffad8e5eb91a071",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39652",
+					"10.65.0.27:39652",
+					"172.17.0.1:39652",
+					"172.19.0.1:39652",
+					"172.20.0.1:39652"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:29:46.834499654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1291891487792929,
+				"StableID":   "ncJJuKo66B11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:268c2b658a8d975c5f9578bbc186c816623320edb4ce04bb85a4410d1179d635",
+				"DiscoKey":   "discokey:944ad6dcef0b6e6c43ce6b4c3afca444bb4df653f2dc7aa2937c68043245e55a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49120",
+					"10.65.0.27:49120",
+					"172.17.0.1:49120",
+					"172.19.0.1:49120",
+					"172.20.0.1:49120"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:29:47.36869129Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4129052562030129,
+				"StableID":   "naZZd8D4FZ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f0020008d79fc356acec4b437434237f16cccbfb13038eee35dc490ea3a6a35",
+				"DiscoKey":   "discokey:730ffd40f7b9c2914d87f4eac6ea4721101dc29642d8da3048c6240b0a7bfe46",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:55643",
+					"10.65.0.27:55643",
+					"172.17.0.1:55643",
+					"172.19.0.1:55643",
+					"172.20.0.1:55643"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:29:47.909061857Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6667782799698745,
+				"StableID":   "n4C5GAMr4u11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:58a20b8362ec35dddffa799f562078c8f1dd7b25e54740f6c3a15211da41de45",
+				"DiscoKey":   "discokey:bc11bf8887195e4c69e6ddd75816e05f628dc7b4e435e7468e830275f3556861",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35504",
+					"10.65.0.27:35504",
+					"172.17.0.1:35504",
+					"172.19.0.1:35504",
+					"172.20.0.1:35504"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:29:48.453548721Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3390625595990804,
+				"StableID":   "nTERG8zcUT11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9e5744db825918d533b11008551fe192931e9d5554aae3fc7b6b9fae00ac850c",
+				"DiscoKey":   "discokey:e0dea56a0b0dec9fc73b8e052ad9211dd45bd273cdf91226d1bee31d0f22416c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44834",
+					"10.65.0.27:44834",
+					"172.17.0.1:44834",
+					"172.19.0.1:44834",
+					"172.20.0.1:44834"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:29:49.548056599Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         968689913947377,
+				"StableID":   "n2mDaoqiZ811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3504874d4beabc3f316508828cf6e3b3c0d61207393456020411756e4ad1c80f",
+				"DiscoKey":   "discokey:db65dacd234ebf899d396a3c6c91dfec91f70caf4e3d178cba7c401f09dd0610",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:37873",
+					"10.65.0.27:37873",
+					"172.17.0.1:37873",
+					"172.19.0.1:37873",
+					"172.20.0.1:37873"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:29:50.104620665Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         696938256648319,
+				"StableID":   "n8KrBQPeS611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d7c2f0198ee19b1ae6b07b3a470b23368cac1875c0dde0cb50a1f8083c170978",
+				"DiscoKey":   "discokey:81c1f42387f94b3ed445863fcca52c83f8de5644c77aa3645fc597f0cf2b446c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:59009",
+					"10.65.0.27:59009",
+					"172.17.0.1:59009",
+					"172.19.0.1:59009",
+					"172.20.0.1:59009"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:29:50.623715041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4158246360674193,
+				"StableID":   "nimXeg5HUZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b95c99803bbab152bcf29b617c9a892b9a0c1bb2b8dfce49ccc0dafeab68eb1d",
+				"DiscoKey":   "discokey:b0c1cc1752892ea1ec226710b1cf111166ca6a9934b1c3e2e4a33d4cae6da971",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:42622",
+					"10.65.0.27:42622",
+					"172.17.0.1:42622",
+					"172.19.0.1:42622",
+					"172.20.0.1:42622"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:29:51.168298214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         744157076743230,
+				"StableID":   "nRYHdBk2p611CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1ff44fded80c2abafaf7bba3dbe770f48b6d15fb2d25cfeda41fb64b3451c20d",
+				"KeyExpiry":  "2026-11-08T18:29:51Z",
+				"DiscoKey":   "discokey:d2e3a51a40e760d410dbeae843738de1274df9313f2cdd526c493041b89b0572",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51111",
+					"10.65.0.27:51111",
+					"172.17.0.1:51111",
+					"172.19.0.1:51111",
+					"172.20.0.1:51111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:29:51.705572614Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8177835151153133,
+				"StableID":   "nJhLd1skr621CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8285c8594b27158736a2574bdb57211c19da7a66693e8fb6447e54d509ce8b24",
+				"KeyExpiry":  "2026-11-08T18:29:52Z",
+				"DiscoKey":   "discokey:36c5c6a88f700cb4e8373031e54573a4526b1cd7f347b57e3aeb4f907a3f184a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34782",
+					"10.65.0.27:34782",
+					"172.17.0.1:34782",
+					"172.19.0.1:34782",
+					"172.20.0.1:34782"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:29:52.243200577Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5362337086668675,
+				"StableID":   "n41Xt8Wcsi11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7740b711db64b821c69fdcc8cba5b32289fb5e8974ee1654c1710c55fe902214",
+				"KeyExpiry":  "2026-11-08T18:29:52Z",
+				"DiscoKey":   "discokey:770afaea00abc31a0aae3ee7b14ed172f15e838d88051e6f4dc77edb110fb532",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53150",
+					"10.65.0.27:53150",
+					"172.17.0.1:53150",
+					"172.19.0.1:53150",
+					"172.20.0.1:53150"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:29:52.783028805Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2817208958256072": {
+				"ID":          2817208958256072,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         744157076743230,
+				"StableID":   "nRYHdBk2p611CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1ff44fded80c2abafaf7bba3dbe770f48b6d15fb2d25cfeda41fb64b3451c20d",
+				"KeyExpiry":  "2026-11-08T18:29:51Z",
+				"DiscoKey":   "discokey:d2e3a51a40e760d410dbeae843738de1274df9313f2cdd526c493041b89b0572",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51111",
+					"10.65.0.27:51111",
+					"172.17.0.1:51111",
+					"172.19.0.1:51111",
+					"172.20.0.1:51111"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:29:51.705572614Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1ff44fded80c2abafaf7bba3dbe770f48b6d15fb2d25cfeda41fb64b3451c20d",
+			"MachineKey": "mkey:f33fd2b9ddaf813895c2ad80702d9143f30051736d69a94b4fe8b92a8291206d",
+			"Peers": [{
+				"ID":         8234662870115732,
+				"StableID":   "n9H8ZYdVJ721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0eee01ac22303d4bc8f22385fa59fdb650a2e6d7aee6081c8dfa91bdc30b256b",
+				"DiscoKey":   "discokey:04b3124736af5aeb3bd59fc85dc63f072b182adac193c5d7af2f390f8c6e4212",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43199",
+					"10.65.0.27:43199",
+					"172.17.0.1:43199",
+					"172.19.0.1:43199",
+					"172.20.0.1:43199"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:29:45.219812301Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6544588742819998,
+				"StableID":   "nPd5KRF47t11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb390f698893a62c7cb05680d1b71899216076979c708e8410f8a40231dd555f",
+				"DiscoKey":   "discokey:9f7ba6818ea891dc602ec49f439bdb83aee27946c9852551b671dbca3378ef4f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45163",
+					"10.65.0.27:45163",
+					"172.17.0.1:45163",
+					"172.19.0.1:45163",
+					"172.20.0.1:45163"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:29:45.751618181Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5315396181138127,
+				"StableID":   "npMsomSMWi11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6cc5c0e825391acf368cad164685681fe8774e1d4d9f44c1a481dcc14a75e20f",
+				"DiscoKey":   "discokey:520ee0662f4ba22489d0080953eefb314817ddc5c528a83209894b76f5fda147",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53984",
+					"10.65.0.27:53984",
+					"172.17.0.1:53984",
+					"172.19.0.1:53984",
+					"172.20.0.1:53984"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:29:46.290093148Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4296533335278602,
+				"StableID":   "nMpy3ReuYa11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b474d4ace3796ba7f27ecd64e6a0cc8c7af1e2c182889c56bf968c661f581259",
+				"DiscoKey":   "discokey:e914b70c34379bed721108b6f8456cfd6779db1b7d9010537ffad8e5eb91a071",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39652",
+					"10.65.0.27:39652",
+					"172.17.0.1:39652",
+					"172.19.0.1:39652",
+					"172.20.0.1:39652"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:29:46.834499654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1291891487792929,
+				"StableID":   "ncJJuKo66B11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:268c2b658a8d975c5f9578bbc186c816623320edb4ce04bb85a4410d1179d635",
+				"DiscoKey":   "discokey:944ad6dcef0b6e6c43ce6b4c3afca444bb4df653f2dc7aa2937c68043245e55a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49120",
+					"10.65.0.27:49120",
+					"172.17.0.1:49120",
+					"172.19.0.1:49120",
+					"172.20.0.1:49120"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:29:47.36869129Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4129052562030129,
+				"StableID":   "naZZd8D4FZ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f0020008d79fc356acec4b437434237f16cccbfb13038eee35dc490ea3a6a35",
+				"DiscoKey":   "discokey:730ffd40f7b9c2914d87f4eac6ea4721101dc29642d8da3048c6240b0a7bfe46",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:55643",
+					"10.65.0.27:55643",
+					"172.17.0.1:55643",
+					"172.19.0.1:55643",
+					"172.20.0.1:55643"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:29:47.909061857Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6667782799698745,
+				"StableID":   "n4C5GAMr4u11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:58a20b8362ec35dddffa799f562078c8f1dd7b25e54740f6c3a15211da41de45",
+				"DiscoKey":   "discokey:bc11bf8887195e4c69e6ddd75816e05f628dc7b4e435e7468e830275f3556861",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35504",
+					"10.65.0.27:35504",
+					"172.17.0.1:35504",
+					"172.19.0.1:35504",
+					"172.20.0.1:35504"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:29:48.453548721Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2817208958256072,
+				"StableID":   "nMMcZXJvzN11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e548e82d1bcc53e06a1f93c241028d475fc567ccf450fb65cf69f698b0acfd43",
+				"DiscoKey":   "discokey:cdfc8ad0ce6a5e374ff826e87a31bf71a48007822eeacc57f0e831ec3e19e642",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:39234",
+					"10.65.0.27:39234",
+					"172.17.0.1:39234",
+					"172.19.0.1:39234",
+					"172.20.0.1:39234"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:29:49.003378971Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3390625595990804,
+				"StableID":   "nTERG8zcUT11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9e5744db825918d533b11008551fe192931e9d5554aae3fc7b6b9fae00ac850c",
+				"DiscoKey":   "discokey:e0dea56a0b0dec9fc73b8e052ad9211dd45bd273cdf91226d1bee31d0f22416c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44834",
+					"10.65.0.27:44834",
+					"172.17.0.1:44834",
+					"172.19.0.1:44834",
+					"172.20.0.1:44834"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:29:49.548056599Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         968689913947377,
+				"StableID":   "n2mDaoqiZ811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3504874d4beabc3f316508828cf6e3b3c0d61207393456020411756e4ad1c80f",
+				"DiscoKey":   "discokey:db65dacd234ebf899d396a3c6c91dfec91f70caf4e3d178cba7c401f09dd0610",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:37873",
+					"10.65.0.27:37873",
+					"172.17.0.1:37873",
+					"172.19.0.1:37873",
+					"172.20.0.1:37873"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:29:50.104620665Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         696938256648319,
+				"StableID":   "n8KrBQPeS611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d7c2f0198ee19b1ae6b07b3a470b23368cac1875c0dde0cb50a1f8083c170978",
+				"DiscoKey":   "discokey:81c1f42387f94b3ed445863fcca52c83f8de5644c77aa3645fc597f0cf2b446c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:59009",
+					"10.65.0.27:59009",
+					"172.17.0.1:59009",
+					"172.19.0.1:59009",
+					"172.20.0.1:59009"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:29:50.623715041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4158246360674193,
+				"StableID":   "nimXeg5HUZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b95c99803bbab152bcf29b617c9a892b9a0c1bb2b8dfce49ccc0dafeab68eb1d",
+				"DiscoKey":   "discokey:b0c1cc1752892ea1ec226710b1cf111166ca6a9934b1c3e2e4a33d4cae6da971",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:42622",
+					"10.65.0.27:42622",
+					"172.17.0.1:42622",
+					"172.19.0.1:42622",
+					"172.20.0.1:42622"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:29:51.168298214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8177835151153133,
+				"StableID":   "nJhLd1skr621CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8285c8594b27158736a2574bdb57211c19da7a66693e8fb6447e54d509ce8b24",
+				"KeyExpiry":  "2026-11-08T18:29:52Z",
+				"DiscoKey":   "discokey:36c5c6a88f700cb4e8373031e54573a4526b1cd7f347b57e3aeb4f907a3f184a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34782",
+					"10.65.0.27:34782",
+					"172.17.0.1:34782",
+					"172.19.0.1:34782",
+					"172.20.0.1:34782"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:29:52.243200577Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5362337086668675,
+				"StableID":   "n41Xt8Wcsi11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7740b711db64b821c69fdcc8cba5b32289fb5e8974ee1654c1710c55fe902214",
+				"KeyExpiry":  "2026-11-08T18:29:52Z",
+				"DiscoKey":   "discokey:770afaea00abc31a0aae3ee7b14ed172f15e838d88051e6f4dc77edb110fb532",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53150",
+					"10.65.0.27:53150",
+					"172.17.0.1:53150",
+					"172.19.0.1:53150",
+					"172.20.0.1:53150"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:29:52.783028805Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         696938256648319,
+				"StableID":   "n8KrBQPeS611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       696938256648319,
+				"Key":        "nodekey:d7c2f0198ee19b1ae6b07b3a470b23368cac1875c0dde0cb50a1f8083c170978",
+				"DiscoKey":   "discokey:81c1f42387f94b3ed445863fcca52c83f8de5644c77aa3645fc597f0cf2b446c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:59009",
+					"10.65.0.27:59009",
+					"172.17.0.1:59009",
+					"172.19.0.1:59009",
+					"172.20.0.1:59009"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:29:50.623715041Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d7c2f0198ee19b1ae6b07b3a470b23368cac1875c0dde0cb50a1f8083c170978",
+			"MachineKey": "mkey:5c45f39db5e80d8f41f9b5848d7fe0eda1c04273baf5ac30bfb1eb240bcc7317",
+			"Peers": [{
+				"ID":         8234662870115732,
+				"StableID":   "n9H8ZYdVJ721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0eee01ac22303d4bc8f22385fa59fdb650a2e6d7aee6081c8dfa91bdc30b256b",
+				"DiscoKey":   "discokey:04b3124736af5aeb3bd59fc85dc63f072b182adac193c5d7af2f390f8c6e4212",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43199",
+					"10.65.0.27:43199",
+					"172.17.0.1:43199",
+					"172.19.0.1:43199",
+					"172.20.0.1:43199"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:29:45.219812301Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6544588742819998,
+				"StableID":   "nPd5KRF47t11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb390f698893a62c7cb05680d1b71899216076979c708e8410f8a40231dd555f",
+				"DiscoKey":   "discokey:9f7ba6818ea891dc602ec49f439bdb83aee27946c9852551b671dbca3378ef4f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45163",
+					"10.65.0.27:45163",
+					"172.17.0.1:45163",
+					"172.19.0.1:45163",
+					"172.20.0.1:45163"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:29:45.751618181Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5315396181138127,
+				"StableID":   "npMsomSMWi11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6cc5c0e825391acf368cad164685681fe8774e1d4d9f44c1a481dcc14a75e20f",
+				"DiscoKey":   "discokey:520ee0662f4ba22489d0080953eefb314817ddc5c528a83209894b76f5fda147",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53984",
+					"10.65.0.27:53984",
+					"172.17.0.1:53984",
+					"172.19.0.1:53984",
+					"172.20.0.1:53984"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:29:46.290093148Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4296533335278602,
+				"StableID":   "nMpy3ReuYa11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b474d4ace3796ba7f27ecd64e6a0cc8c7af1e2c182889c56bf968c661f581259",
+				"DiscoKey":   "discokey:e914b70c34379bed721108b6f8456cfd6779db1b7d9010537ffad8e5eb91a071",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39652",
+					"10.65.0.27:39652",
+					"172.17.0.1:39652",
+					"172.19.0.1:39652",
+					"172.20.0.1:39652"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:29:46.834499654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1291891487792929,
+				"StableID":   "ncJJuKo66B11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:268c2b658a8d975c5f9578bbc186c816623320edb4ce04bb85a4410d1179d635",
+				"DiscoKey":   "discokey:944ad6dcef0b6e6c43ce6b4c3afca444bb4df653f2dc7aa2937c68043245e55a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49120",
+					"10.65.0.27:49120",
+					"172.17.0.1:49120",
+					"172.19.0.1:49120",
+					"172.20.0.1:49120"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:29:47.36869129Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4129052562030129,
+				"StableID":   "naZZd8D4FZ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f0020008d79fc356acec4b437434237f16cccbfb13038eee35dc490ea3a6a35",
+				"DiscoKey":   "discokey:730ffd40f7b9c2914d87f4eac6ea4721101dc29642d8da3048c6240b0a7bfe46",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:55643",
+					"10.65.0.27:55643",
+					"172.17.0.1:55643",
+					"172.19.0.1:55643",
+					"172.20.0.1:55643"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:29:47.909061857Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6667782799698745,
+				"StableID":   "n4C5GAMr4u11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:58a20b8362ec35dddffa799f562078c8f1dd7b25e54740f6c3a15211da41de45",
+				"DiscoKey":   "discokey:bc11bf8887195e4c69e6ddd75816e05f628dc7b4e435e7468e830275f3556861",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35504",
+					"10.65.0.27:35504",
+					"172.17.0.1:35504",
+					"172.19.0.1:35504",
+					"172.20.0.1:35504"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:29:48.453548721Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2817208958256072,
+				"StableID":   "nMMcZXJvzN11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e548e82d1bcc53e06a1f93c241028d475fc567ccf450fb65cf69f698b0acfd43",
+				"DiscoKey":   "discokey:cdfc8ad0ce6a5e374ff826e87a31bf71a48007822eeacc57f0e831ec3e19e642",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:39234",
+					"10.65.0.27:39234",
+					"172.17.0.1:39234",
+					"172.19.0.1:39234",
+					"172.20.0.1:39234"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:29:49.003378971Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3390625595990804,
+				"StableID":   "nTERG8zcUT11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9e5744db825918d533b11008551fe192931e9d5554aae3fc7b6b9fae00ac850c",
+				"DiscoKey":   "discokey:e0dea56a0b0dec9fc73b8e052ad9211dd45bd273cdf91226d1bee31d0f22416c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44834",
+					"10.65.0.27:44834",
+					"172.17.0.1:44834",
+					"172.19.0.1:44834",
+					"172.20.0.1:44834"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:29:49.548056599Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         968689913947377,
+				"StableID":   "n2mDaoqiZ811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3504874d4beabc3f316508828cf6e3b3c0d61207393456020411756e4ad1c80f",
+				"DiscoKey":   "discokey:db65dacd234ebf899d396a3c6c91dfec91f70caf4e3d178cba7c401f09dd0610",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:37873",
+					"10.65.0.27:37873",
+					"172.17.0.1:37873",
+					"172.19.0.1:37873",
+					"172.20.0.1:37873"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:29:50.104620665Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4158246360674193,
+				"StableID":   "nimXeg5HUZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b95c99803bbab152bcf29b617c9a892b9a0c1bb2b8dfce49ccc0dafeab68eb1d",
+				"DiscoKey":   "discokey:b0c1cc1752892ea1ec226710b1cf111166ca6a9934b1c3e2e4a33d4cae6da971",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:42622",
+					"10.65.0.27:42622",
+					"172.17.0.1:42622",
+					"172.19.0.1:42622",
+					"172.20.0.1:42622"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:29:51.168298214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         744157076743230,
+				"StableID":   "nRYHdBk2p611CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1ff44fded80c2abafaf7bba3dbe770f48b6d15fb2d25cfeda41fb64b3451c20d",
+				"KeyExpiry":  "2026-11-08T18:29:51Z",
+				"DiscoKey":   "discokey:d2e3a51a40e760d410dbeae843738de1274df9313f2cdd526c493041b89b0572",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51111",
+					"10.65.0.27:51111",
+					"172.17.0.1:51111",
+					"172.19.0.1:51111",
+					"172.20.0.1:51111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:29:51.705572614Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8177835151153133,
+				"StableID":   "nJhLd1skr621CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8285c8594b27158736a2574bdb57211c19da7a66693e8fb6447e54d509ce8b24",
+				"KeyExpiry":  "2026-11-08T18:29:52Z",
+				"DiscoKey":   "discokey:36c5c6a88f700cb4e8373031e54573a4526b1cd7f347b57e3aeb4f907a3f184a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34782",
+					"10.65.0.27:34782",
+					"172.17.0.1:34782",
+					"172.19.0.1:34782",
+					"172.20.0.1:34782"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:29:52.243200577Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5362337086668675,
+				"StableID":   "n41Xt8Wcsi11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7740b711db64b821c69fdcc8cba5b32289fb5e8974ee1654c1710c55fe902214",
+				"KeyExpiry":  "2026-11-08T18:29:52Z",
+				"DiscoKey":   "discokey:770afaea00abc31a0aae3ee7b14ed172f15e838d88051e6f4dc77edb110fb532",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53150",
+					"10.65.0.27:53150",
+					"172.17.0.1:53150",
+					"172.19.0.1:53150",
+					"172.20.0.1:53150"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:29:52.783028805Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "696938256648319": {
+				"ID":          696938256648319,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6544588742819998,
+				"StableID":   "nPd5KRF47t11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       6544588742819998,
+				"Key":        "nodekey:fb390f698893a62c7cb05680d1b71899216076979c708e8410f8a40231dd555f",
+				"DiscoKey":   "discokey:9f7ba6818ea891dc602ec49f439bdb83aee27946c9852551b671dbca3378ef4f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45163",
+					"10.65.0.27:45163",
+					"172.17.0.1:45163",
+					"172.19.0.1:45163",
+					"172.20.0.1:45163"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:29:45.751618181Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:fb390f698893a62c7cb05680d1b71899216076979c708e8410f8a40231dd555f",
+			"MachineKey": "mkey:bf27c9cceb9c858396cede804d4efd115f07937a53651208943a235ed44cfb0b",
+			"Peers": [{
+				"ID":         8234662870115732,
+				"StableID":   "n9H8ZYdVJ721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0eee01ac22303d4bc8f22385fa59fdb650a2e6d7aee6081c8dfa91bdc30b256b",
+				"DiscoKey":   "discokey:04b3124736af5aeb3bd59fc85dc63f072b182adac193c5d7af2f390f8c6e4212",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43199",
+					"10.65.0.27:43199",
+					"172.17.0.1:43199",
+					"172.19.0.1:43199",
+					"172.20.0.1:43199"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:29:45.219812301Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5315396181138127,
+				"StableID":   "npMsomSMWi11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6cc5c0e825391acf368cad164685681fe8774e1d4d9f44c1a481dcc14a75e20f",
+				"DiscoKey":   "discokey:520ee0662f4ba22489d0080953eefb314817ddc5c528a83209894b76f5fda147",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53984",
+					"10.65.0.27:53984",
+					"172.17.0.1:53984",
+					"172.19.0.1:53984",
+					"172.20.0.1:53984"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:29:46.290093148Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4296533335278602,
+				"StableID":   "nMpy3ReuYa11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b474d4ace3796ba7f27ecd64e6a0cc8c7af1e2c182889c56bf968c661f581259",
+				"DiscoKey":   "discokey:e914b70c34379bed721108b6f8456cfd6779db1b7d9010537ffad8e5eb91a071",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39652",
+					"10.65.0.27:39652",
+					"172.17.0.1:39652",
+					"172.19.0.1:39652",
+					"172.20.0.1:39652"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:29:46.834499654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1291891487792929,
+				"StableID":   "ncJJuKo66B11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:268c2b658a8d975c5f9578bbc186c816623320edb4ce04bb85a4410d1179d635",
+				"DiscoKey":   "discokey:944ad6dcef0b6e6c43ce6b4c3afca444bb4df653f2dc7aa2937c68043245e55a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49120",
+					"10.65.0.27:49120",
+					"172.17.0.1:49120",
+					"172.19.0.1:49120",
+					"172.20.0.1:49120"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:29:47.36869129Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4129052562030129,
+				"StableID":   "naZZd8D4FZ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f0020008d79fc356acec4b437434237f16cccbfb13038eee35dc490ea3a6a35",
+				"DiscoKey":   "discokey:730ffd40f7b9c2914d87f4eac6ea4721101dc29642d8da3048c6240b0a7bfe46",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:55643",
+					"10.65.0.27:55643",
+					"172.17.0.1:55643",
+					"172.19.0.1:55643",
+					"172.20.0.1:55643"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:29:47.909061857Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6667782799698745,
+				"StableID":   "n4C5GAMr4u11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:58a20b8362ec35dddffa799f562078c8f1dd7b25e54740f6c3a15211da41de45",
+				"DiscoKey":   "discokey:bc11bf8887195e4c69e6ddd75816e05f628dc7b4e435e7468e830275f3556861",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35504",
+					"10.65.0.27:35504",
+					"172.17.0.1:35504",
+					"172.19.0.1:35504",
+					"172.20.0.1:35504"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:29:48.453548721Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2817208958256072,
+				"StableID":   "nMMcZXJvzN11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e548e82d1bcc53e06a1f93c241028d475fc567ccf450fb65cf69f698b0acfd43",
+				"DiscoKey":   "discokey:cdfc8ad0ce6a5e374ff826e87a31bf71a48007822eeacc57f0e831ec3e19e642",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:39234",
+					"10.65.0.27:39234",
+					"172.17.0.1:39234",
+					"172.19.0.1:39234",
+					"172.20.0.1:39234"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:29:49.003378971Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3390625595990804,
+				"StableID":   "nTERG8zcUT11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9e5744db825918d533b11008551fe192931e9d5554aae3fc7b6b9fae00ac850c",
+				"DiscoKey":   "discokey:e0dea56a0b0dec9fc73b8e052ad9211dd45bd273cdf91226d1bee31d0f22416c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44834",
+					"10.65.0.27:44834",
+					"172.17.0.1:44834",
+					"172.19.0.1:44834",
+					"172.20.0.1:44834"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:29:49.548056599Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         968689913947377,
+				"StableID":   "n2mDaoqiZ811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3504874d4beabc3f316508828cf6e3b3c0d61207393456020411756e4ad1c80f",
+				"DiscoKey":   "discokey:db65dacd234ebf899d396a3c6c91dfec91f70caf4e3d178cba7c401f09dd0610",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:37873",
+					"10.65.0.27:37873",
+					"172.17.0.1:37873",
+					"172.19.0.1:37873",
+					"172.20.0.1:37873"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:29:50.104620665Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         696938256648319,
+				"StableID":   "n8KrBQPeS611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d7c2f0198ee19b1ae6b07b3a470b23368cac1875c0dde0cb50a1f8083c170978",
+				"DiscoKey":   "discokey:81c1f42387f94b3ed445863fcca52c83f8de5644c77aa3645fc597f0cf2b446c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:59009",
+					"10.65.0.27:59009",
+					"172.17.0.1:59009",
+					"172.19.0.1:59009",
+					"172.20.0.1:59009"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:29:50.623715041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4158246360674193,
+				"StableID":   "nimXeg5HUZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b95c99803bbab152bcf29b617c9a892b9a0c1bb2b8dfce49ccc0dafeab68eb1d",
+				"DiscoKey":   "discokey:b0c1cc1752892ea1ec226710b1cf111166ca6a9934b1c3e2e4a33d4cae6da971",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:42622",
+					"10.65.0.27:42622",
+					"172.17.0.1:42622",
+					"172.19.0.1:42622",
+					"172.20.0.1:42622"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:29:51.168298214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         744157076743230,
+				"StableID":   "nRYHdBk2p611CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1ff44fded80c2abafaf7bba3dbe770f48b6d15fb2d25cfeda41fb64b3451c20d",
+				"KeyExpiry":  "2026-11-08T18:29:51Z",
+				"DiscoKey":   "discokey:d2e3a51a40e760d410dbeae843738de1274df9313f2cdd526c493041b89b0572",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51111",
+					"10.65.0.27:51111",
+					"172.17.0.1:51111",
+					"172.19.0.1:51111",
+					"172.20.0.1:51111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:29:51.705572614Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8177835151153133,
+				"StableID":   "nJhLd1skr621CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8285c8594b27158736a2574bdb57211c19da7a66693e8fb6447e54d509ce8b24",
+				"KeyExpiry":  "2026-11-08T18:29:52Z",
+				"DiscoKey":   "discokey:36c5c6a88f700cb4e8373031e54573a4526b1cd7f347b57e3aeb4f907a3f184a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34782",
+					"10.65.0.27:34782",
+					"172.17.0.1:34782",
+					"172.19.0.1:34782",
+					"172.20.0.1:34782"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:29:52.243200577Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5362337086668675,
+				"StableID":   "n41Xt8Wcsi11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7740b711db64b821c69fdcc8cba5b32289fb5e8974ee1654c1710c55fe902214",
+				"KeyExpiry":  "2026-11-08T18:29:52Z",
+				"DiscoKey":   "discokey:770afaea00abc31a0aae3ee7b14ed172f15e838d88051e6f4dc77edb110fb532",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53150",
+					"10.65.0.27:53150",
+					"172.17.0.1:53150",
+					"172.19.0.1:53150",
+					"172.20.0.1:53150"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:29:52.783028805Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6544588742819998": {
+				"ID":          6544588742819998,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8234662870115732,
+				"StableID":   "n9H8ZYdVJ721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       8234662870115732,
+				"Key":        "nodekey:0eee01ac22303d4bc8f22385fa59fdb650a2e6d7aee6081c8dfa91bdc30b256b",
+				"DiscoKey":   "discokey:04b3124736af5aeb3bd59fc85dc63f072b182adac193c5d7af2f390f8c6e4212",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43199",
+					"10.65.0.27:43199",
+					"172.17.0.1:43199",
+					"172.19.0.1:43199",
+					"172.20.0.1:43199"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:29:45.219812301Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0eee01ac22303d4bc8f22385fa59fdb650a2e6d7aee6081c8dfa91bdc30b256b",
+			"MachineKey": "mkey:a7481a801a85acbfbfd61b2accb3a1362c7059f1d86e2f9cf44f69b4cdd5682b",
+			"Peers": [{
+				"ID":         6544588742819998,
+				"StableID":   "nPd5KRF47t11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb390f698893a62c7cb05680d1b71899216076979c708e8410f8a40231dd555f",
+				"DiscoKey":   "discokey:9f7ba6818ea891dc602ec49f439bdb83aee27946c9852551b671dbca3378ef4f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45163",
+					"10.65.0.27:45163",
+					"172.17.0.1:45163",
+					"172.19.0.1:45163",
+					"172.20.0.1:45163"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:29:45.751618181Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5315396181138127,
+				"StableID":   "npMsomSMWi11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6cc5c0e825391acf368cad164685681fe8774e1d4d9f44c1a481dcc14a75e20f",
+				"DiscoKey":   "discokey:520ee0662f4ba22489d0080953eefb314817ddc5c528a83209894b76f5fda147",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53984",
+					"10.65.0.27:53984",
+					"172.17.0.1:53984",
+					"172.19.0.1:53984",
+					"172.20.0.1:53984"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:29:46.290093148Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4296533335278602,
+				"StableID":   "nMpy3ReuYa11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b474d4ace3796ba7f27ecd64e6a0cc8c7af1e2c182889c56bf968c661f581259",
+				"DiscoKey":   "discokey:e914b70c34379bed721108b6f8456cfd6779db1b7d9010537ffad8e5eb91a071",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39652",
+					"10.65.0.27:39652",
+					"172.17.0.1:39652",
+					"172.19.0.1:39652",
+					"172.20.0.1:39652"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:29:46.834499654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1291891487792929,
+				"StableID":   "ncJJuKo66B11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:268c2b658a8d975c5f9578bbc186c816623320edb4ce04bb85a4410d1179d635",
+				"DiscoKey":   "discokey:944ad6dcef0b6e6c43ce6b4c3afca444bb4df653f2dc7aa2937c68043245e55a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49120",
+					"10.65.0.27:49120",
+					"172.17.0.1:49120",
+					"172.19.0.1:49120",
+					"172.20.0.1:49120"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:29:47.36869129Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4129052562030129,
+				"StableID":   "naZZd8D4FZ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f0020008d79fc356acec4b437434237f16cccbfb13038eee35dc490ea3a6a35",
+				"DiscoKey":   "discokey:730ffd40f7b9c2914d87f4eac6ea4721101dc29642d8da3048c6240b0a7bfe46",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:55643",
+					"10.65.0.27:55643",
+					"172.17.0.1:55643",
+					"172.19.0.1:55643",
+					"172.20.0.1:55643"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:29:47.909061857Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6667782799698745,
+				"StableID":   "n4C5GAMr4u11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:58a20b8362ec35dddffa799f562078c8f1dd7b25e54740f6c3a15211da41de45",
+				"DiscoKey":   "discokey:bc11bf8887195e4c69e6ddd75816e05f628dc7b4e435e7468e830275f3556861",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35504",
+					"10.65.0.27:35504",
+					"172.17.0.1:35504",
+					"172.19.0.1:35504",
+					"172.20.0.1:35504"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:29:48.453548721Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2817208958256072,
+				"StableID":   "nMMcZXJvzN11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e548e82d1bcc53e06a1f93c241028d475fc567ccf450fb65cf69f698b0acfd43",
+				"DiscoKey":   "discokey:cdfc8ad0ce6a5e374ff826e87a31bf71a48007822eeacc57f0e831ec3e19e642",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:39234",
+					"10.65.0.27:39234",
+					"172.17.0.1:39234",
+					"172.19.0.1:39234",
+					"172.20.0.1:39234"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:29:49.003378971Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3390625595990804,
+				"StableID":   "nTERG8zcUT11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9e5744db825918d533b11008551fe192931e9d5554aae3fc7b6b9fae00ac850c",
+				"DiscoKey":   "discokey:e0dea56a0b0dec9fc73b8e052ad9211dd45bd273cdf91226d1bee31d0f22416c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44834",
+					"10.65.0.27:44834",
+					"172.17.0.1:44834",
+					"172.19.0.1:44834",
+					"172.20.0.1:44834"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:29:49.548056599Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         968689913947377,
+				"StableID":   "n2mDaoqiZ811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3504874d4beabc3f316508828cf6e3b3c0d61207393456020411756e4ad1c80f",
+				"DiscoKey":   "discokey:db65dacd234ebf899d396a3c6c91dfec91f70caf4e3d178cba7c401f09dd0610",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:37873",
+					"10.65.0.27:37873",
+					"172.17.0.1:37873",
+					"172.19.0.1:37873",
+					"172.20.0.1:37873"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:29:50.104620665Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         696938256648319,
+				"StableID":   "n8KrBQPeS611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d7c2f0198ee19b1ae6b07b3a470b23368cac1875c0dde0cb50a1f8083c170978",
+				"DiscoKey":   "discokey:81c1f42387f94b3ed445863fcca52c83f8de5644c77aa3645fc597f0cf2b446c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:59009",
+					"10.65.0.27:59009",
+					"172.17.0.1:59009",
+					"172.19.0.1:59009",
+					"172.20.0.1:59009"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:29:50.623715041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4158246360674193,
+				"StableID":   "nimXeg5HUZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b95c99803bbab152bcf29b617c9a892b9a0c1bb2b8dfce49ccc0dafeab68eb1d",
+				"DiscoKey":   "discokey:b0c1cc1752892ea1ec226710b1cf111166ca6a9934b1c3e2e4a33d4cae6da971",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:42622",
+					"10.65.0.27:42622",
+					"172.17.0.1:42622",
+					"172.19.0.1:42622",
+					"172.20.0.1:42622"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:29:51.168298214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         744157076743230,
+				"StableID":   "nRYHdBk2p611CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1ff44fded80c2abafaf7bba3dbe770f48b6d15fb2d25cfeda41fb64b3451c20d",
+				"KeyExpiry":  "2026-11-08T18:29:51Z",
+				"DiscoKey":   "discokey:d2e3a51a40e760d410dbeae843738de1274df9313f2cdd526c493041b89b0572",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51111",
+					"10.65.0.27:51111",
+					"172.17.0.1:51111",
+					"172.19.0.1:51111",
+					"172.20.0.1:51111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:29:51.705572614Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8177835151153133,
+				"StableID":   "nJhLd1skr621CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8285c8594b27158736a2574bdb57211c19da7a66693e8fb6447e54d509ce8b24",
+				"KeyExpiry":  "2026-11-08T18:29:52Z",
+				"DiscoKey":   "discokey:36c5c6a88f700cb4e8373031e54573a4526b1cd7f347b57e3aeb4f907a3f184a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34782",
+					"10.65.0.27:34782",
+					"172.17.0.1:34782",
+					"172.19.0.1:34782",
+					"172.20.0.1:34782"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:29:52.243200577Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5362337086668675,
+				"StableID":   "n41Xt8Wcsi11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7740b711db64b821c69fdcc8cba5b32289fb5e8974ee1654c1710c55fe902214",
+				"KeyExpiry":  "2026-11-08T18:29:52Z",
+				"DiscoKey":   "discokey:770afaea00abc31a0aae3ee7b14ed172f15e838d88051e6f4dc77edb110fb532",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53150",
+					"10.65.0.27:53150",
+					"172.17.0.1:53150",
+					"172.19.0.1:53150",
+					"172.20.0.1:53150"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:29:52.783028805Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8234662870115732": {
+				"ID":          8234662870115732,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1291891487792929,
+				"StableID":   "ncJJuKo66B11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1291891487792929,
+				"Key":        "nodekey:268c2b658a8d975c5f9578bbc186c816623320edb4ce04bb85a4410d1179d635",
+				"DiscoKey":   "discokey:944ad6dcef0b6e6c43ce6b4c3afca444bb4df653f2dc7aa2937c68043245e55a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49120",
+					"10.65.0.27:49120",
+					"172.17.0.1:49120",
+					"172.19.0.1:49120",
+					"172.20.0.1:49120"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:29:47.36869129Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:268c2b658a8d975c5f9578bbc186c816623320edb4ce04bb85a4410d1179d635",
+			"MachineKey": "mkey:b410f5f31059b5165fcfdc26165ed2fc22da312848ea528b467b08b2a4b3d46a",
+			"Peers": [{
+				"ID":         8234662870115732,
+				"StableID":   "n9H8ZYdVJ721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0eee01ac22303d4bc8f22385fa59fdb650a2e6d7aee6081c8dfa91bdc30b256b",
+				"DiscoKey":   "discokey:04b3124736af5aeb3bd59fc85dc63f072b182adac193c5d7af2f390f8c6e4212",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43199",
+					"10.65.0.27:43199",
+					"172.17.0.1:43199",
+					"172.19.0.1:43199",
+					"172.20.0.1:43199"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:29:45.219812301Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6544588742819998,
+				"StableID":   "nPd5KRF47t11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb390f698893a62c7cb05680d1b71899216076979c708e8410f8a40231dd555f",
+				"DiscoKey":   "discokey:9f7ba6818ea891dc602ec49f439bdb83aee27946c9852551b671dbca3378ef4f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45163",
+					"10.65.0.27:45163",
+					"172.17.0.1:45163",
+					"172.19.0.1:45163",
+					"172.20.0.1:45163"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:29:45.751618181Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5315396181138127,
+				"StableID":   "npMsomSMWi11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6cc5c0e825391acf368cad164685681fe8774e1d4d9f44c1a481dcc14a75e20f",
+				"DiscoKey":   "discokey:520ee0662f4ba22489d0080953eefb314817ddc5c528a83209894b76f5fda147",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53984",
+					"10.65.0.27:53984",
+					"172.17.0.1:53984",
+					"172.19.0.1:53984",
+					"172.20.0.1:53984"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:29:46.290093148Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4296533335278602,
+				"StableID":   "nMpy3ReuYa11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b474d4ace3796ba7f27ecd64e6a0cc8c7af1e2c182889c56bf968c661f581259",
+				"DiscoKey":   "discokey:e914b70c34379bed721108b6f8456cfd6779db1b7d9010537ffad8e5eb91a071",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39652",
+					"10.65.0.27:39652",
+					"172.17.0.1:39652",
+					"172.19.0.1:39652",
+					"172.20.0.1:39652"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:29:46.834499654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4129052562030129,
+				"StableID":   "naZZd8D4FZ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f0020008d79fc356acec4b437434237f16cccbfb13038eee35dc490ea3a6a35",
+				"DiscoKey":   "discokey:730ffd40f7b9c2914d87f4eac6ea4721101dc29642d8da3048c6240b0a7bfe46",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:55643",
+					"10.65.0.27:55643",
+					"172.17.0.1:55643",
+					"172.19.0.1:55643",
+					"172.20.0.1:55643"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:29:47.909061857Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6667782799698745,
+				"StableID":   "n4C5GAMr4u11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:58a20b8362ec35dddffa799f562078c8f1dd7b25e54740f6c3a15211da41de45",
+				"DiscoKey":   "discokey:bc11bf8887195e4c69e6ddd75816e05f628dc7b4e435e7468e830275f3556861",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35504",
+					"10.65.0.27:35504",
+					"172.17.0.1:35504",
+					"172.19.0.1:35504",
+					"172.20.0.1:35504"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:29:48.453548721Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2817208958256072,
+				"StableID":   "nMMcZXJvzN11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e548e82d1bcc53e06a1f93c241028d475fc567ccf450fb65cf69f698b0acfd43",
+				"DiscoKey":   "discokey:cdfc8ad0ce6a5e374ff826e87a31bf71a48007822eeacc57f0e831ec3e19e642",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:39234",
+					"10.65.0.27:39234",
+					"172.17.0.1:39234",
+					"172.19.0.1:39234",
+					"172.20.0.1:39234"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:29:49.003378971Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3390625595990804,
+				"StableID":   "nTERG8zcUT11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9e5744db825918d533b11008551fe192931e9d5554aae3fc7b6b9fae00ac850c",
+				"DiscoKey":   "discokey:e0dea56a0b0dec9fc73b8e052ad9211dd45bd273cdf91226d1bee31d0f22416c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44834",
+					"10.65.0.27:44834",
+					"172.17.0.1:44834",
+					"172.19.0.1:44834",
+					"172.20.0.1:44834"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:29:49.548056599Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         968689913947377,
+				"StableID":   "n2mDaoqiZ811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3504874d4beabc3f316508828cf6e3b3c0d61207393456020411756e4ad1c80f",
+				"DiscoKey":   "discokey:db65dacd234ebf899d396a3c6c91dfec91f70caf4e3d178cba7c401f09dd0610",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:37873",
+					"10.65.0.27:37873",
+					"172.17.0.1:37873",
+					"172.19.0.1:37873",
+					"172.20.0.1:37873"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:29:50.104620665Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         696938256648319,
+				"StableID":   "n8KrBQPeS611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d7c2f0198ee19b1ae6b07b3a470b23368cac1875c0dde0cb50a1f8083c170978",
+				"DiscoKey":   "discokey:81c1f42387f94b3ed445863fcca52c83f8de5644c77aa3645fc597f0cf2b446c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:59009",
+					"10.65.0.27:59009",
+					"172.17.0.1:59009",
+					"172.19.0.1:59009",
+					"172.20.0.1:59009"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:29:50.623715041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4158246360674193,
+				"StableID":   "nimXeg5HUZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b95c99803bbab152bcf29b617c9a892b9a0c1bb2b8dfce49ccc0dafeab68eb1d",
+				"DiscoKey":   "discokey:b0c1cc1752892ea1ec226710b1cf111166ca6a9934b1c3e2e4a33d4cae6da971",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:42622",
+					"10.65.0.27:42622",
+					"172.17.0.1:42622",
+					"172.19.0.1:42622",
+					"172.20.0.1:42622"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:29:51.168298214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         744157076743230,
+				"StableID":   "nRYHdBk2p611CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1ff44fded80c2abafaf7bba3dbe770f48b6d15fb2d25cfeda41fb64b3451c20d",
+				"KeyExpiry":  "2026-11-08T18:29:51Z",
+				"DiscoKey":   "discokey:d2e3a51a40e760d410dbeae843738de1274df9313f2cdd526c493041b89b0572",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51111",
+					"10.65.0.27:51111",
+					"172.17.0.1:51111",
+					"172.19.0.1:51111",
+					"172.20.0.1:51111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:29:51.705572614Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8177835151153133,
+				"StableID":   "nJhLd1skr621CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8285c8594b27158736a2574bdb57211c19da7a66693e8fb6447e54d509ce8b24",
+				"KeyExpiry":  "2026-11-08T18:29:52Z",
+				"DiscoKey":   "discokey:36c5c6a88f700cb4e8373031e54573a4526b1cd7f347b57e3aeb4f907a3f184a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34782",
+					"10.65.0.27:34782",
+					"172.17.0.1:34782",
+					"172.19.0.1:34782",
+					"172.20.0.1:34782"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:29:52.243200577Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5362337086668675,
+				"StableID":   "n41Xt8Wcsi11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7740b711db64b821c69fdcc8cba5b32289fb5e8974ee1654c1710c55fe902214",
+				"KeyExpiry":  "2026-11-08T18:29:52Z",
+				"DiscoKey":   "discokey:770afaea00abc31a0aae3ee7b14ed172f15e838d88051e6f4dc77edb110fb532",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53150",
+					"10.65.0.27:53150",
+					"172.17.0.1:53150",
+					"172.19.0.1:53150",
+					"172.20.0.1:53150"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:29:52.783028805Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1291891487792929": {
+				"ID":          1291891487792929,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4296533335278602,
+				"StableID":   "nMpy3ReuYa11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       4296533335278602,
+				"Key":        "nodekey:b474d4ace3796ba7f27ecd64e6a0cc8c7af1e2c182889c56bf968c661f581259",
+				"DiscoKey":   "discokey:e914b70c34379bed721108b6f8456cfd6779db1b7d9010537ffad8e5eb91a071",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39652",
+					"10.65.0.27:39652",
+					"172.17.0.1:39652",
+					"172.19.0.1:39652",
+					"172.20.0.1:39652"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:29:46.834499654Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b474d4ace3796ba7f27ecd64e6a0cc8c7af1e2c182889c56bf968c661f581259",
+			"MachineKey": "mkey:2c12ad9e9bd1cc11eca136411bfb9b395f58f7f327dad061fb98d2fda901a34b",
+			"Peers": [{
+				"ID":         8234662870115732,
+				"StableID":   "n9H8ZYdVJ721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0eee01ac22303d4bc8f22385fa59fdb650a2e6d7aee6081c8dfa91bdc30b256b",
+				"DiscoKey":   "discokey:04b3124736af5aeb3bd59fc85dc63f072b182adac193c5d7af2f390f8c6e4212",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43199",
+					"10.65.0.27:43199",
+					"172.17.0.1:43199",
+					"172.19.0.1:43199",
+					"172.20.0.1:43199"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:29:45.219812301Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6544588742819998,
+				"StableID":   "nPd5KRF47t11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb390f698893a62c7cb05680d1b71899216076979c708e8410f8a40231dd555f",
+				"DiscoKey":   "discokey:9f7ba6818ea891dc602ec49f439bdb83aee27946c9852551b671dbca3378ef4f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45163",
+					"10.65.0.27:45163",
+					"172.17.0.1:45163",
+					"172.19.0.1:45163",
+					"172.20.0.1:45163"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:29:45.751618181Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5315396181138127,
+				"StableID":   "npMsomSMWi11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6cc5c0e825391acf368cad164685681fe8774e1d4d9f44c1a481dcc14a75e20f",
+				"DiscoKey":   "discokey:520ee0662f4ba22489d0080953eefb314817ddc5c528a83209894b76f5fda147",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53984",
+					"10.65.0.27:53984",
+					"172.17.0.1:53984",
+					"172.19.0.1:53984",
+					"172.20.0.1:53984"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:29:46.290093148Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1291891487792929,
+				"StableID":   "ncJJuKo66B11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:268c2b658a8d975c5f9578bbc186c816623320edb4ce04bb85a4410d1179d635",
+				"DiscoKey":   "discokey:944ad6dcef0b6e6c43ce6b4c3afca444bb4df653f2dc7aa2937c68043245e55a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49120",
+					"10.65.0.27:49120",
+					"172.17.0.1:49120",
+					"172.19.0.1:49120",
+					"172.20.0.1:49120"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:29:47.36869129Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4129052562030129,
+				"StableID":   "naZZd8D4FZ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f0020008d79fc356acec4b437434237f16cccbfb13038eee35dc490ea3a6a35",
+				"DiscoKey":   "discokey:730ffd40f7b9c2914d87f4eac6ea4721101dc29642d8da3048c6240b0a7bfe46",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:55643",
+					"10.65.0.27:55643",
+					"172.17.0.1:55643",
+					"172.19.0.1:55643",
+					"172.20.0.1:55643"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:29:47.909061857Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6667782799698745,
+				"StableID":   "n4C5GAMr4u11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:58a20b8362ec35dddffa799f562078c8f1dd7b25e54740f6c3a15211da41de45",
+				"DiscoKey":   "discokey:bc11bf8887195e4c69e6ddd75816e05f628dc7b4e435e7468e830275f3556861",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35504",
+					"10.65.0.27:35504",
+					"172.17.0.1:35504",
+					"172.19.0.1:35504",
+					"172.20.0.1:35504"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:29:48.453548721Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2817208958256072,
+				"StableID":   "nMMcZXJvzN11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e548e82d1bcc53e06a1f93c241028d475fc567ccf450fb65cf69f698b0acfd43",
+				"DiscoKey":   "discokey:cdfc8ad0ce6a5e374ff826e87a31bf71a48007822eeacc57f0e831ec3e19e642",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:39234",
+					"10.65.0.27:39234",
+					"172.17.0.1:39234",
+					"172.19.0.1:39234",
+					"172.20.0.1:39234"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:29:49.003378971Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3390625595990804,
+				"StableID":   "nTERG8zcUT11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9e5744db825918d533b11008551fe192931e9d5554aae3fc7b6b9fae00ac850c",
+				"DiscoKey":   "discokey:e0dea56a0b0dec9fc73b8e052ad9211dd45bd273cdf91226d1bee31d0f22416c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44834",
+					"10.65.0.27:44834",
+					"172.17.0.1:44834",
+					"172.19.0.1:44834",
+					"172.20.0.1:44834"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:29:49.548056599Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         968689913947377,
+				"StableID":   "n2mDaoqiZ811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3504874d4beabc3f316508828cf6e3b3c0d61207393456020411756e4ad1c80f",
+				"DiscoKey":   "discokey:db65dacd234ebf899d396a3c6c91dfec91f70caf4e3d178cba7c401f09dd0610",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:37873",
+					"10.65.0.27:37873",
+					"172.17.0.1:37873",
+					"172.19.0.1:37873",
+					"172.20.0.1:37873"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:29:50.104620665Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         696938256648319,
+				"StableID":   "n8KrBQPeS611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d7c2f0198ee19b1ae6b07b3a470b23368cac1875c0dde0cb50a1f8083c170978",
+				"DiscoKey":   "discokey:81c1f42387f94b3ed445863fcca52c83f8de5644c77aa3645fc597f0cf2b446c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:59009",
+					"10.65.0.27:59009",
+					"172.17.0.1:59009",
+					"172.19.0.1:59009",
+					"172.20.0.1:59009"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:29:50.623715041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4158246360674193,
+				"StableID":   "nimXeg5HUZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b95c99803bbab152bcf29b617c9a892b9a0c1bb2b8dfce49ccc0dafeab68eb1d",
+				"DiscoKey":   "discokey:b0c1cc1752892ea1ec226710b1cf111166ca6a9934b1c3e2e4a33d4cae6da971",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:42622",
+					"10.65.0.27:42622",
+					"172.17.0.1:42622",
+					"172.19.0.1:42622",
+					"172.20.0.1:42622"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:29:51.168298214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         744157076743230,
+				"StableID":   "nRYHdBk2p611CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1ff44fded80c2abafaf7bba3dbe770f48b6d15fb2d25cfeda41fb64b3451c20d",
+				"KeyExpiry":  "2026-11-08T18:29:51Z",
+				"DiscoKey":   "discokey:d2e3a51a40e760d410dbeae843738de1274df9313f2cdd526c493041b89b0572",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51111",
+					"10.65.0.27:51111",
+					"172.17.0.1:51111",
+					"172.19.0.1:51111",
+					"172.20.0.1:51111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:29:51.705572614Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8177835151153133,
+				"StableID":   "nJhLd1skr621CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8285c8594b27158736a2574bdb57211c19da7a66693e8fb6447e54d509ce8b24",
+				"KeyExpiry":  "2026-11-08T18:29:52Z",
+				"DiscoKey":   "discokey:36c5c6a88f700cb4e8373031e54573a4526b1cd7f347b57e3aeb4f907a3f184a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34782",
+					"10.65.0.27:34782",
+					"172.17.0.1:34782",
+					"172.19.0.1:34782",
+					"172.20.0.1:34782"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:29:52.243200577Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5362337086668675,
+				"StableID":   "n41Xt8Wcsi11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7740b711db64b821c69fdcc8cba5b32289fb5e8974ee1654c1710c55fe902214",
+				"KeyExpiry":  "2026-11-08T18:29:52Z",
+				"DiscoKey":   "discokey:770afaea00abc31a0aae3ee7b14ed172f15e838d88051e6f4dc77edb110fb532",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53150",
+					"10.65.0.27:53150",
+					"172.17.0.1:53150",
+					"172.19.0.1:53150",
+					"172.20.0.1:53150"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:29:52.783028805Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4296533335278602": {
+				"ID":          4296533335278602,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6667782799698745,
+				"StableID":   "n4C5GAMr4u11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       6667782799698745,
+				"Key":        "nodekey:58a20b8362ec35dddffa799f562078c8f1dd7b25e54740f6c3a15211da41de45",
+				"DiscoKey":   "discokey:bc11bf8887195e4c69e6ddd75816e05f628dc7b4e435e7468e830275f3556861",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35504",
+					"10.65.0.27:35504",
+					"172.17.0.1:35504",
+					"172.19.0.1:35504",
+					"172.20.0.1:35504"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:29:48.453548721Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:58a20b8362ec35dddffa799f562078c8f1dd7b25e54740f6c3a15211da41de45",
+			"MachineKey": "mkey:0f3d44fdc0417ac9ca4cd7724302ca0623276429b755a109dd465e9c6c6e716e",
+			"Peers": [{
+				"ID":         8234662870115732,
+				"StableID":   "n9H8ZYdVJ721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0eee01ac22303d4bc8f22385fa59fdb650a2e6d7aee6081c8dfa91bdc30b256b",
+				"DiscoKey":   "discokey:04b3124736af5aeb3bd59fc85dc63f072b182adac193c5d7af2f390f8c6e4212",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43199",
+					"10.65.0.27:43199",
+					"172.17.0.1:43199",
+					"172.19.0.1:43199",
+					"172.20.0.1:43199"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:29:45.219812301Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6544588742819998,
+				"StableID":   "nPd5KRF47t11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb390f698893a62c7cb05680d1b71899216076979c708e8410f8a40231dd555f",
+				"DiscoKey":   "discokey:9f7ba6818ea891dc602ec49f439bdb83aee27946c9852551b671dbca3378ef4f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45163",
+					"10.65.0.27:45163",
+					"172.17.0.1:45163",
+					"172.19.0.1:45163",
+					"172.20.0.1:45163"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:29:45.751618181Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5315396181138127,
+				"StableID":   "npMsomSMWi11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6cc5c0e825391acf368cad164685681fe8774e1d4d9f44c1a481dcc14a75e20f",
+				"DiscoKey":   "discokey:520ee0662f4ba22489d0080953eefb314817ddc5c528a83209894b76f5fda147",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53984",
+					"10.65.0.27:53984",
+					"172.17.0.1:53984",
+					"172.19.0.1:53984",
+					"172.20.0.1:53984"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:29:46.290093148Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4296533335278602,
+				"StableID":   "nMpy3ReuYa11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b474d4ace3796ba7f27ecd64e6a0cc8c7af1e2c182889c56bf968c661f581259",
+				"DiscoKey":   "discokey:e914b70c34379bed721108b6f8456cfd6779db1b7d9010537ffad8e5eb91a071",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39652",
+					"10.65.0.27:39652",
+					"172.17.0.1:39652",
+					"172.19.0.1:39652",
+					"172.20.0.1:39652"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:29:46.834499654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1291891487792929,
+				"StableID":   "ncJJuKo66B11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:268c2b658a8d975c5f9578bbc186c816623320edb4ce04bb85a4410d1179d635",
+				"DiscoKey":   "discokey:944ad6dcef0b6e6c43ce6b4c3afca444bb4df653f2dc7aa2937c68043245e55a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49120",
+					"10.65.0.27:49120",
+					"172.17.0.1:49120",
+					"172.19.0.1:49120",
+					"172.20.0.1:49120"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:29:47.36869129Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4129052562030129,
+				"StableID":   "naZZd8D4FZ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f0020008d79fc356acec4b437434237f16cccbfb13038eee35dc490ea3a6a35",
+				"DiscoKey":   "discokey:730ffd40f7b9c2914d87f4eac6ea4721101dc29642d8da3048c6240b0a7bfe46",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:55643",
+					"10.65.0.27:55643",
+					"172.17.0.1:55643",
+					"172.19.0.1:55643",
+					"172.20.0.1:55643"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:29:47.909061857Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2817208958256072,
+				"StableID":   "nMMcZXJvzN11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e548e82d1bcc53e06a1f93c241028d475fc567ccf450fb65cf69f698b0acfd43",
+				"DiscoKey":   "discokey:cdfc8ad0ce6a5e374ff826e87a31bf71a48007822eeacc57f0e831ec3e19e642",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:39234",
+					"10.65.0.27:39234",
+					"172.17.0.1:39234",
+					"172.19.0.1:39234",
+					"172.20.0.1:39234"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:29:49.003378971Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3390625595990804,
+				"StableID":   "nTERG8zcUT11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9e5744db825918d533b11008551fe192931e9d5554aae3fc7b6b9fae00ac850c",
+				"DiscoKey":   "discokey:e0dea56a0b0dec9fc73b8e052ad9211dd45bd273cdf91226d1bee31d0f22416c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44834",
+					"10.65.0.27:44834",
+					"172.17.0.1:44834",
+					"172.19.0.1:44834",
+					"172.20.0.1:44834"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:29:49.548056599Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         968689913947377,
+				"StableID":   "n2mDaoqiZ811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3504874d4beabc3f316508828cf6e3b3c0d61207393456020411756e4ad1c80f",
+				"DiscoKey":   "discokey:db65dacd234ebf899d396a3c6c91dfec91f70caf4e3d178cba7c401f09dd0610",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:37873",
+					"10.65.0.27:37873",
+					"172.17.0.1:37873",
+					"172.19.0.1:37873",
+					"172.20.0.1:37873"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:29:50.104620665Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         696938256648319,
+				"StableID":   "n8KrBQPeS611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d7c2f0198ee19b1ae6b07b3a470b23368cac1875c0dde0cb50a1f8083c170978",
+				"DiscoKey":   "discokey:81c1f42387f94b3ed445863fcca52c83f8de5644c77aa3645fc597f0cf2b446c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:59009",
+					"10.65.0.27:59009",
+					"172.17.0.1:59009",
+					"172.19.0.1:59009",
+					"172.20.0.1:59009"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:29:50.623715041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4158246360674193,
+				"StableID":   "nimXeg5HUZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b95c99803bbab152bcf29b617c9a892b9a0c1bb2b8dfce49ccc0dafeab68eb1d",
+				"DiscoKey":   "discokey:b0c1cc1752892ea1ec226710b1cf111166ca6a9934b1c3e2e4a33d4cae6da971",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:42622",
+					"10.65.0.27:42622",
+					"172.17.0.1:42622",
+					"172.19.0.1:42622",
+					"172.20.0.1:42622"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:29:51.168298214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         744157076743230,
+				"StableID":   "nRYHdBk2p611CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1ff44fded80c2abafaf7bba3dbe770f48b6d15fb2d25cfeda41fb64b3451c20d",
+				"KeyExpiry":  "2026-11-08T18:29:51Z",
+				"DiscoKey":   "discokey:d2e3a51a40e760d410dbeae843738de1274df9313f2cdd526c493041b89b0572",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51111",
+					"10.65.0.27:51111",
+					"172.17.0.1:51111",
+					"172.19.0.1:51111",
+					"172.20.0.1:51111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:29:51.705572614Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8177835151153133,
+				"StableID":   "nJhLd1skr621CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8285c8594b27158736a2574bdb57211c19da7a66693e8fb6447e54d509ce8b24",
+				"KeyExpiry":  "2026-11-08T18:29:52Z",
+				"DiscoKey":   "discokey:36c5c6a88f700cb4e8373031e54573a4526b1cd7f347b57e3aeb4f907a3f184a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34782",
+					"10.65.0.27:34782",
+					"172.17.0.1:34782",
+					"172.19.0.1:34782",
+					"172.20.0.1:34782"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:29:52.243200577Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5362337086668675,
+				"StableID":   "n41Xt8Wcsi11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7740b711db64b821c69fdcc8cba5b32289fb5e8974ee1654c1710c55fe902214",
+				"KeyExpiry":  "2026-11-08T18:29:52Z",
+				"DiscoKey":   "discokey:770afaea00abc31a0aae3ee7b14ed172f15e838d88051e6f4dc77edb110fb532",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53150",
+					"10.65.0.27:53150",
+					"172.17.0.1:53150",
+					"172.19.0.1:53150",
+					"172.20.0.1:53150"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:29:52.783028805Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6667782799698745": {
+				"ID":          6667782799698745,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3390625595990804,
+				"StableID":   "nTERG8zcUT11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       3390625595990804,
+				"Key":        "nodekey:9e5744db825918d533b11008551fe192931e9d5554aae3fc7b6b9fae00ac850c",
+				"DiscoKey":   "discokey:e0dea56a0b0dec9fc73b8e052ad9211dd45bd273cdf91226d1bee31d0f22416c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44834",
+					"10.65.0.27:44834",
+					"172.17.0.1:44834",
+					"172.19.0.1:44834",
+					"172.20.0.1:44834"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:29:49.548056599Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9e5744db825918d533b11008551fe192931e9d5554aae3fc7b6b9fae00ac850c",
+			"MachineKey": "mkey:d2cb0ad5c80770369b72ab2bb71cfa4abfd7dc3878e8a65df3b60f0785acfc42",
+			"Peers": [{
+				"ID":         8234662870115732,
+				"StableID":   "n9H8ZYdVJ721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0eee01ac22303d4bc8f22385fa59fdb650a2e6d7aee6081c8dfa91bdc30b256b",
+				"DiscoKey":   "discokey:04b3124736af5aeb3bd59fc85dc63f072b182adac193c5d7af2f390f8c6e4212",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43199",
+					"10.65.0.27:43199",
+					"172.17.0.1:43199",
+					"172.19.0.1:43199",
+					"172.20.0.1:43199"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:29:45.219812301Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6544588742819998,
+				"StableID":   "nPd5KRF47t11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb390f698893a62c7cb05680d1b71899216076979c708e8410f8a40231dd555f",
+				"DiscoKey":   "discokey:9f7ba6818ea891dc602ec49f439bdb83aee27946c9852551b671dbca3378ef4f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45163",
+					"10.65.0.27:45163",
+					"172.17.0.1:45163",
+					"172.19.0.1:45163",
+					"172.20.0.1:45163"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:29:45.751618181Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5315396181138127,
+				"StableID":   "npMsomSMWi11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6cc5c0e825391acf368cad164685681fe8774e1d4d9f44c1a481dcc14a75e20f",
+				"DiscoKey":   "discokey:520ee0662f4ba22489d0080953eefb314817ddc5c528a83209894b76f5fda147",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53984",
+					"10.65.0.27:53984",
+					"172.17.0.1:53984",
+					"172.19.0.1:53984",
+					"172.20.0.1:53984"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:29:46.290093148Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4296533335278602,
+				"StableID":   "nMpy3ReuYa11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b474d4ace3796ba7f27ecd64e6a0cc8c7af1e2c182889c56bf968c661f581259",
+				"DiscoKey":   "discokey:e914b70c34379bed721108b6f8456cfd6779db1b7d9010537ffad8e5eb91a071",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39652",
+					"10.65.0.27:39652",
+					"172.17.0.1:39652",
+					"172.19.0.1:39652",
+					"172.20.0.1:39652"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:29:46.834499654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1291891487792929,
+				"StableID":   "ncJJuKo66B11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:268c2b658a8d975c5f9578bbc186c816623320edb4ce04bb85a4410d1179d635",
+				"DiscoKey":   "discokey:944ad6dcef0b6e6c43ce6b4c3afca444bb4df653f2dc7aa2937c68043245e55a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49120",
+					"10.65.0.27:49120",
+					"172.17.0.1:49120",
+					"172.19.0.1:49120",
+					"172.20.0.1:49120"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:29:47.36869129Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4129052562030129,
+				"StableID":   "naZZd8D4FZ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f0020008d79fc356acec4b437434237f16cccbfb13038eee35dc490ea3a6a35",
+				"DiscoKey":   "discokey:730ffd40f7b9c2914d87f4eac6ea4721101dc29642d8da3048c6240b0a7bfe46",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:55643",
+					"10.65.0.27:55643",
+					"172.17.0.1:55643",
+					"172.19.0.1:55643",
+					"172.20.0.1:55643"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:29:47.909061857Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6667782799698745,
+				"StableID":   "n4C5GAMr4u11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:58a20b8362ec35dddffa799f562078c8f1dd7b25e54740f6c3a15211da41de45",
+				"DiscoKey":   "discokey:bc11bf8887195e4c69e6ddd75816e05f628dc7b4e435e7468e830275f3556861",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35504",
+					"10.65.0.27:35504",
+					"172.17.0.1:35504",
+					"172.19.0.1:35504",
+					"172.20.0.1:35504"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:29:48.453548721Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2817208958256072,
+				"StableID":   "nMMcZXJvzN11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e548e82d1bcc53e06a1f93c241028d475fc567ccf450fb65cf69f698b0acfd43",
+				"DiscoKey":   "discokey:cdfc8ad0ce6a5e374ff826e87a31bf71a48007822eeacc57f0e831ec3e19e642",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:39234",
+					"10.65.0.27:39234",
+					"172.17.0.1:39234",
+					"172.19.0.1:39234",
+					"172.20.0.1:39234"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:29:49.003378971Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         968689913947377,
+				"StableID":   "n2mDaoqiZ811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3504874d4beabc3f316508828cf6e3b3c0d61207393456020411756e4ad1c80f",
+				"DiscoKey":   "discokey:db65dacd234ebf899d396a3c6c91dfec91f70caf4e3d178cba7c401f09dd0610",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:37873",
+					"10.65.0.27:37873",
+					"172.17.0.1:37873",
+					"172.19.0.1:37873",
+					"172.20.0.1:37873"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:29:50.104620665Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         696938256648319,
+				"StableID":   "n8KrBQPeS611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d7c2f0198ee19b1ae6b07b3a470b23368cac1875c0dde0cb50a1f8083c170978",
+				"DiscoKey":   "discokey:81c1f42387f94b3ed445863fcca52c83f8de5644c77aa3645fc597f0cf2b446c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:59009",
+					"10.65.0.27:59009",
+					"172.17.0.1:59009",
+					"172.19.0.1:59009",
+					"172.20.0.1:59009"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:29:50.623715041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4158246360674193,
+				"StableID":   "nimXeg5HUZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b95c99803bbab152bcf29b617c9a892b9a0c1bb2b8dfce49ccc0dafeab68eb1d",
+				"DiscoKey":   "discokey:b0c1cc1752892ea1ec226710b1cf111166ca6a9934b1c3e2e4a33d4cae6da971",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:42622",
+					"10.65.0.27:42622",
+					"172.17.0.1:42622",
+					"172.19.0.1:42622",
+					"172.20.0.1:42622"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:29:51.168298214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         744157076743230,
+				"StableID":   "nRYHdBk2p611CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1ff44fded80c2abafaf7bba3dbe770f48b6d15fb2d25cfeda41fb64b3451c20d",
+				"KeyExpiry":  "2026-11-08T18:29:51Z",
+				"DiscoKey":   "discokey:d2e3a51a40e760d410dbeae843738de1274df9313f2cdd526c493041b89b0572",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51111",
+					"10.65.0.27:51111",
+					"172.17.0.1:51111",
+					"172.19.0.1:51111",
+					"172.20.0.1:51111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:29:51.705572614Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8177835151153133,
+				"StableID":   "nJhLd1skr621CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8285c8594b27158736a2574bdb57211c19da7a66693e8fb6447e54d509ce8b24",
+				"KeyExpiry":  "2026-11-08T18:29:52Z",
+				"DiscoKey":   "discokey:36c5c6a88f700cb4e8373031e54573a4526b1cd7f347b57e3aeb4f907a3f184a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34782",
+					"10.65.0.27:34782",
+					"172.17.0.1:34782",
+					"172.19.0.1:34782",
+					"172.20.0.1:34782"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:29:52.243200577Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5362337086668675,
+				"StableID":   "n41Xt8Wcsi11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7740b711db64b821c69fdcc8cba5b32289fb5e8974ee1654c1710c55fe902214",
+				"KeyExpiry":  "2026-11-08T18:29:52Z",
+				"DiscoKey":   "discokey:770afaea00abc31a0aae3ee7b14ed172f15e838d88051e6f4dc77edb110fb532",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53150",
+					"10.65.0.27:53150",
+					"172.17.0.1:53150",
+					"172.19.0.1:53150",
+					"172.20.0.1:53150"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:29:52.783028805Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3390625595990804": {
+				"ID":          3390625595990804,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8177835151153133,
+				"StableID":   "nJhLd1skr621CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8285c8594b27158736a2574bdb57211c19da7a66693e8fb6447e54d509ce8b24",
+				"KeyExpiry":  "2026-11-08T18:29:52Z",
+				"DiscoKey":   "discokey:36c5c6a88f700cb4e8373031e54573a4526b1cd7f347b57e3aeb4f907a3f184a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34782",
+					"10.65.0.27:34782",
+					"172.17.0.1:34782",
+					"172.19.0.1:34782",
+					"172.20.0.1:34782"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:29:52.243200577Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8285c8594b27158736a2574bdb57211c19da7a66693e8fb6447e54d509ce8b24",
+			"MachineKey": "mkey:42fa16389e46e55739a419d83e29a38612c838c8a608879ef61293937bad4c33",
+			"Peers": [{
+				"ID":         8234662870115732,
+				"StableID":   "n9H8ZYdVJ721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0eee01ac22303d4bc8f22385fa59fdb650a2e6d7aee6081c8dfa91bdc30b256b",
+				"DiscoKey":   "discokey:04b3124736af5aeb3bd59fc85dc63f072b182adac193c5d7af2f390f8c6e4212",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43199",
+					"10.65.0.27:43199",
+					"172.17.0.1:43199",
+					"172.19.0.1:43199",
+					"172.20.0.1:43199"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:29:45.219812301Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6544588742819998,
+				"StableID":   "nPd5KRF47t11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb390f698893a62c7cb05680d1b71899216076979c708e8410f8a40231dd555f",
+				"DiscoKey":   "discokey:9f7ba6818ea891dc602ec49f439bdb83aee27946c9852551b671dbca3378ef4f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45163",
+					"10.65.0.27:45163",
+					"172.17.0.1:45163",
+					"172.19.0.1:45163",
+					"172.20.0.1:45163"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:29:45.751618181Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5315396181138127,
+				"StableID":   "npMsomSMWi11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6cc5c0e825391acf368cad164685681fe8774e1d4d9f44c1a481dcc14a75e20f",
+				"DiscoKey":   "discokey:520ee0662f4ba22489d0080953eefb314817ddc5c528a83209894b76f5fda147",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53984",
+					"10.65.0.27:53984",
+					"172.17.0.1:53984",
+					"172.19.0.1:53984",
+					"172.20.0.1:53984"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:29:46.290093148Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4296533335278602,
+				"StableID":   "nMpy3ReuYa11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b474d4ace3796ba7f27ecd64e6a0cc8c7af1e2c182889c56bf968c661f581259",
+				"DiscoKey":   "discokey:e914b70c34379bed721108b6f8456cfd6779db1b7d9010537ffad8e5eb91a071",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39652",
+					"10.65.0.27:39652",
+					"172.17.0.1:39652",
+					"172.19.0.1:39652",
+					"172.20.0.1:39652"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:29:46.834499654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1291891487792929,
+				"StableID":   "ncJJuKo66B11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:268c2b658a8d975c5f9578bbc186c816623320edb4ce04bb85a4410d1179d635",
+				"DiscoKey":   "discokey:944ad6dcef0b6e6c43ce6b4c3afca444bb4df653f2dc7aa2937c68043245e55a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49120",
+					"10.65.0.27:49120",
+					"172.17.0.1:49120",
+					"172.19.0.1:49120",
+					"172.20.0.1:49120"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:29:47.36869129Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4129052562030129,
+				"StableID":   "naZZd8D4FZ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f0020008d79fc356acec4b437434237f16cccbfb13038eee35dc490ea3a6a35",
+				"DiscoKey":   "discokey:730ffd40f7b9c2914d87f4eac6ea4721101dc29642d8da3048c6240b0a7bfe46",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:55643",
+					"10.65.0.27:55643",
+					"172.17.0.1:55643",
+					"172.19.0.1:55643",
+					"172.20.0.1:55643"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:29:47.909061857Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6667782799698745,
+				"StableID":   "n4C5GAMr4u11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:58a20b8362ec35dddffa799f562078c8f1dd7b25e54740f6c3a15211da41de45",
+				"DiscoKey":   "discokey:bc11bf8887195e4c69e6ddd75816e05f628dc7b4e435e7468e830275f3556861",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35504",
+					"10.65.0.27:35504",
+					"172.17.0.1:35504",
+					"172.19.0.1:35504",
+					"172.20.0.1:35504"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:29:48.453548721Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2817208958256072,
+				"StableID":   "nMMcZXJvzN11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e548e82d1bcc53e06a1f93c241028d475fc567ccf450fb65cf69f698b0acfd43",
+				"DiscoKey":   "discokey:cdfc8ad0ce6a5e374ff826e87a31bf71a48007822eeacc57f0e831ec3e19e642",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:39234",
+					"10.65.0.27:39234",
+					"172.17.0.1:39234",
+					"172.19.0.1:39234",
+					"172.20.0.1:39234"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:29:49.003378971Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3390625595990804,
+				"StableID":   "nTERG8zcUT11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9e5744db825918d533b11008551fe192931e9d5554aae3fc7b6b9fae00ac850c",
+				"DiscoKey":   "discokey:e0dea56a0b0dec9fc73b8e052ad9211dd45bd273cdf91226d1bee31d0f22416c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44834",
+					"10.65.0.27:44834",
+					"172.17.0.1:44834",
+					"172.19.0.1:44834",
+					"172.20.0.1:44834"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:29:49.548056599Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         968689913947377,
+				"StableID":   "n2mDaoqiZ811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3504874d4beabc3f316508828cf6e3b3c0d61207393456020411756e4ad1c80f",
+				"DiscoKey":   "discokey:db65dacd234ebf899d396a3c6c91dfec91f70caf4e3d178cba7c401f09dd0610",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:37873",
+					"10.65.0.27:37873",
+					"172.17.0.1:37873",
+					"172.19.0.1:37873",
+					"172.20.0.1:37873"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:29:50.104620665Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         696938256648319,
+				"StableID":   "n8KrBQPeS611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d7c2f0198ee19b1ae6b07b3a470b23368cac1875c0dde0cb50a1f8083c170978",
+				"DiscoKey":   "discokey:81c1f42387f94b3ed445863fcca52c83f8de5644c77aa3645fc597f0cf2b446c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:59009",
+					"10.65.0.27:59009",
+					"172.17.0.1:59009",
+					"172.19.0.1:59009",
+					"172.20.0.1:59009"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:29:50.623715041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4158246360674193,
+				"StableID":   "nimXeg5HUZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b95c99803bbab152bcf29b617c9a892b9a0c1bb2b8dfce49ccc0dafeab68eb1d",
+				"DiscoKey":   "discokey:b0c1cc1752892ea1ec226710b1cf111166ca6a9934b1c3e2e4a33d4cae6da971",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:42622",
+					"10.65.0.27:42622",
+					"172.17.0.1:42622",
+					"172.19.0.1:42622",
+					"172.20.0.1:42622"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:29:51.168298214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         744157076743230,
+				"StableID":   "nRYHdBk2p611CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1ff44fded80c2abafaf7bba3dbe770f48b6d15fb2d25cfeda41fb64b3451c20d",
+				"KeyExpiry":  "2026-11-08T18:29:51Z",
+				"DiscoKey":   "discokey:d2e3a51a40e760d410dbeae843738de1274df9313f2cdd526c493041b89b0572",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51111",
+					"10.65.0.27:51111",
+					"172.17.0.1:51111",
+					"172.19.0.1:51111",
+					"172.20.0.1:51111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:29:51.705572614Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5362337086668675,
+				"StableID":   "n41Xt8Wcsi11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7740b711db64b821c69fdcc8cba5b32289fb5e8974ee1654c1710c55fe902214",
+				"KeyExpiry":  "2026-11-08T18:29:52Z",
+				"DiscoKey":   "discokey:770afaea00abc31a0aae3ee7b14ed172f15e838d88051e6f4dc77edb110fb532",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53150",
+					"10.65.0.27:53150",
+					"172.17.0.1:53150",
+					"172.19.0.1:53150",
+					"172.20.0.1:53150"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:29:52.783028805Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         968689913947377,
+				"StableID":   "n2mDaoqiZ811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       968689913947377,
+				"Key":        "nodekey:3504874d4beabc3f316508828cf6e3b3c0d61207393456020411756e4ad1c80f",
+				"DiscoKey":   "discokey:db65dacd234ebf899d396a3c6c91dfec91f70caf4e3d178cba7c401f09dd0610",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:37873",
+					"10.65.0.27:37873",
+					"172.17.0.1:37873",
+					"172.19.0.1:37873",
+					"172.20.0.1:37873"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:29:50.104620665Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3504874d4beabc3f316508828cf6e3b3c0d61207393456020411756e4ad1c80f",
+			"MachineKey": "mkey:5484d91b0cc7f221c0abbf8d8f3eec1bea72bc0c48c582452372c5f7e3dbe43f",
+			"Peers": [{
+				"ID":         8234662870115732,
+				"StableID":   "n9H8ZYdVJ721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0eee01ac22303d4bc8f22385fa59fdb650a2e6d7aee6081c8dfa91bdc30b256b",
+				"DiscoKey":   "discokey:04b3124736af5aeb3bd59fc85dc63f072b182adac193c5d7af2f390f8c6e4212",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:43199",
+					"10.65.0.27:43199",
+					"172.17.0.1:43199",
+					"172.19.0.1:43199",
+					"172.20.0.1:43199"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:29:45.219812301Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6544588742819998,
+				"StableID":   "nPd5KRF47t11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fb390f698893a62c7cb05680d1b71899216076979c708e8410f8a40231dd555f",
+				"DiscoKey":   "discokey:9f7ba6818ea891dc602ec49f439bdb83aee27946c9852551b671dbca3378ef4f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45163",
+					"10.65.0.27:45163",
+					"172.17.0.1:45163",
+					"172.19.0.1:45163",
+					"172.20.0.1:45163"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:29:45.751618181Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5315396181138127,
+				"StableID":   "npMsomSMWi11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6cc5c0e825391acf368cad164685681fe8774e1d4d9f44c1a481dcc14a75e20f",
+				"DiscoKey":   "discokey:520ee0662f4ba22489d0080953eefb314817ddc5c528a83209894b76f5fda147",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53984",
+					"10.65.0.27:53984",
+					"172.17.0.1:53984",
+					"172.19.0.1:53984",
+					"172.20.0.1:53984"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:29:46.290093148Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4296533335278602,
+				"StableID":   "nMpy3ReuYa11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b474d4ace3796ba7f27ecd64e6a0cc8c7af1e2c182889c56bf968c661f581259",
+				"DiscoKey":   "discokey:e914b70c34379bed721108b6f8456cfd6779db1b7d9010537ffad8e5eb91a071",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39652",
+					"10.65.0.27:39652",
+					"172.17.0.1:39652",
+					"172.19.0.1:39652",
+					"172.20.0.1:39652"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:29:46.834499654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1291891487792929,
+				"StableID":   "ncJJuKo66B11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:268c2b658a8d975c5f9578bbc186c816623320edb4ce04bb85a4410d1179d635",
+				"DiscoKey":   "discokey:944ad6dcef0b6e6c43ce6b4c3afca444bb4df653f2dc7aa2937c68043245e55a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:49120",
+					"10.65.0.27:49120",
+					"172.17.0.1:49120",
+					"172.19.0.1:49120",
+					"172.20.0.1:49120"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:29:47.36869129Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4129052562030129,
+				"StableID":   "naZZd8D4FZ11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f0020008d79fc356acec4b437434237f16cccbfb13038eee35dc490ea3a6a35",
+				"DiscoKey":   "discokey:730ffd40f7b9c2914d87f4eac6ea4721101dc29642d8da3048c6240b0a7bfe46",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:55643",
+					"10.65.0.27:55643",
+					"172.17.0.1:55643",
+					"172.19.0.1:55643",
+					"172.20.0.1:55643"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:29:47.909061857Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6667782799698745,
+				"StableID":   "n4C5GAMr4u11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:58a20b8362ec35dddffa799f562078c8f1dd7b25e54740f6c3a15211da41de45",
+				"DiscoKey":   "discokey:bc11bf8887195e4c69e6ddd75816e05f628dc7b4e435e7468e830275f3556861",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35504",
+					"10.65.0.27:35504",
+					"172.17.0.1:35504",
+					"172.19.0.1:35504",
+					"172.20.0.1:35504"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:29:48.453548721Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2817208958256072,
+				"StableID":   "nMMcZXJvzN11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e548e82d1bcc53e06a1f93c241028d475fc567ccf450fb65cf69f698b0acfd43",
+				"DiscoKey":   "discokey:cdfc8ad0ce6a5e374ff826e87a31bf71a48007822eeacc57f0e831ec3e19e642",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:39234",
+					"10.65.0.27:39234",
+					"172.17.0.1:39234",
+					"172.19.0.1:39234",
+					"172.20.0.1:39234"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:29:49.003378971Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3390625595990804,
+				"StableID":   "nTERG8zcUT11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9e5744db825918d533b11008551fe192931e9d5554aae3fc7b6b9fae00ac850c",
+				"DiscoKey":   "discokey:e0dea56a0b0dec9fc73b8e052ad9211dd45bd273cdf91226d1bee31d0f22416c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44834",
+					"10.65.0.27:44834",
+					"172.17.0.1:44834",
+					"172.19.0.1:44834",
+					"172.20.0.1:44834"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:29:49.548056599Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         696938256648319,
+				"StableID":   "n8KrBQPeS611CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d7c2f0198ee19b1ae6b07b3a470b23368cac1875c0dde0cb50a1f8083c170978",
+				"DiscoKey":   "discokey:81c1f42387f94b3ed445863fcca52c83f8de5644c77aa3645fc597f0cf2b446c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:59009",
+					"10.65.0.27:59009",
+					"172.17.0.1:59009",
+					"172.19.0.1:59009",
+					"172.20.0.1:59009"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:29:50.623715041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4158246360674193,
+				"StableID":   "nimXeg5HUZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b95c99803bbab152bcf29b617c9a892b9a0c1bb2b8dfce49ccc0dafeab68eb1d",
+				"DiscoKey":   "discokey:b0c1cc1752892ea1ec226710b1cf111166ca6a9934b1c3e2e4a33d4cae6da971",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:42622",
+					"10.65.0.27:42622",
+					"172.17.0.1:42622",
+					"172.19.0.1:42622",
+					"172.20.0.1:42622"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:29:51.168298214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         744157076743230,
+				"StableID":   "nRYHdBk2p611CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1ff44fded80c2abafaf7bba3dbe770f48b6d15fb2d25cfeda41fb64b3451c20d",
+				"KeyExpiry":  "2026-11-08T18:29:51Z",
+				"DiscoKey":   "discokey:d2e3a51a40e760d410dbeae843738de1274df9313f2cdd526c493041b89b0572",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:51111",
+					"10.65.0.27:51111",
+					"172.17.0.1:51111",
+					"172.19.0.1:51111",
+					"172.20.0.1:51111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:29:51.705572614Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8177835151153133,
+				"StableID":   "nJhLd1skr621CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8285c8594b27158736a2574bdb57211c19da7a66693e8fb6447e54d509ce8b24",
+				"KeyExpiry":  "2026-11-08T18:29:52Z",
+				"DiscoKey":   "discokey:36c5c6a88f700cb4e8373031e54573a4526b1cd7f347b57e3aeb4f907a3f184a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:34782",
+					"10.65.0.27:34782",
+					"172.17.0.1:34782",
+					"172.19.0.1:34782",
+					"172.20.0.1:34782"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:29:52.243200577Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5362337086668675,
+				"StableID":   "n41Xt8Wcsi11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:7740b711db64b821c69fdcc8cba5b32289fb5e8974ee1654c1710c55fe902214",
+				"KeyExpiry":  "2026-11-08T18:29:52Z",
+				"DiscoKey":   "discokey:770afaea00abc31a0aae3ee7b14ed172f15e838d88051e6f4dc77edb110fb532",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53150",
+					"10.65.0.27:53150",
+					"172.17.0.1:53150",
+					"172.19.0.1:53150",
+					"172.20.0.1:53150"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:29:52.783028805Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "968689913947377": {
+				"ID":          968689913947377,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/sshtest_results/sshtest-accept-fail-wrong-login-user.hujson
+++ b/hscontrol/policy/v2/testdata/sshtest_results/sshtest-accept-fail-wrong-login-user.hujson
@@ -1,0 +1,20084 @@
+// sshtest-accept-fail-wrong-login-user
+//
+// users:[root] rule, sshTests accept=[ubuntu] must fail
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T18:30:28Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "sshtest-accept-fail-wrong-login-user",
+	"description":    "users:[root] rule, sshTests accept=[ubuntu] must fail",
+	"category":       "sshtest",
+	"captured_at":    "2026-05-12T18:30:28.840019036Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                       \n  \n                                                                    \n                                                                        \n{\n\t\"category\":    \"sshtest\",\n\t\"description\": \"users:[root] rule, sshTests accept=[ubuntu] must fail\",\n\t\"id\":          \"sshtest-accept-fail-wrong-login-user\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"thor@example.org\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"sshTests\": [{\n\t\t\"accept\": [\"ubuntu\"],\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    \"thor@example.org\"\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/sshtest/sshtest-accept-fail-wrong-login-user.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["thor@example.org"],
+				"users":  ["root"]
+			}],
+			"sshTests": [
+				{"accept": ["ubuntu"], "dst": ["tag:server"], "src": "thor@example.org"}
+			],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1008581452722319,
+				"StableID":   "n8DdF2jns811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1008581452722319,
+				"Key":        "nodekey:8c3c632a9519153d4f33a975ef9cade7a321451f65845b41329a627043bd077a",
+				"DiscoKey":   "discokey:fef1c431d8bdd764f364efe8d9dfc9eb6b8e18699dfe2aab4e4ec25a07e4ec6b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49399",
+					"10.65.0.27:49399",
+					"172.17.0.1:49399",
+					"172.19.0.1:49399",
+					"172.20.0.1:49399"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:30:37.300468924Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8c3c632a9519153d4f33a975ef9cade7a321451f65845b41329a627043bd077a",
+			"MachineKey": "mkey:2bd28a66a085057e2630d4fd6fef17296f68fc898f73cdaf4797910a3778e76d",
+			"Peers": [{
+				"ID":         5007491183657601,
+				"StableID":   "nJR1ZXJu6g11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47d178e9b9e748f3ae355d756df6434419f7e9bd55bbc6fdd25156d9a342363d",
+				"DiscoKey":   "discokey:2460330d63a76e823a3f98165fa17178474baf3a31eaff731969eb9ba46a0309",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54223",
+					"10.65.0.27:54223",
+					"172.17.0.1:54223",
+					"172.19.0.1:54223",
+					"172.20.0.1:54223"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:30:31.395098446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1600955304356651,
+				"StableID":   "na2s27P5WD11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:694893f9ac0523b45ab8fc1fd601b5d441c7a4c8fa7e28eb60a76521416fe116",
+				"DiscoKey":   "discokey:ff47fa2f29cd43a00292e51b8bf0999867fd5a6c88aaf49964d94ef3d9fe3159",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:60037",
+					"10.65.0.27:60037",
+					"172.17.0.1:60037",
+					"172.19.0.1:60037",
+					"172.20.0.1:60037"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:30:31.886043888Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6973050553104759,
+				"StableID":   "nxyhHQD7Tw11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6cd5fae42b55f6d8b7001477a548eb5a7aec0aa8a16cfdf944ea2799387c948",
+				"DiscoKey":   "discokey:49de72c308cdec88226e01edb1c33edffddd3dc3afd2d4a29645abbfad541725",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52458",
+					"10.65.0.27:52458",
+					"172.17.0.1:52458",
+					"172.19.0.1:52458",
+					"172.20.0.1:52458"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:30:32.422535926Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4428690401772650,
+				"StableID":   "nhS5UrBmab11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15fac8db70d5dbd3b27be9dbcdaa661332294805f913a2b186af07dd1a387854",
+				"DiscoKey":   "discokey:bb7470c216c71114a920d314ea855fbbfa860a4198790e64c3b4d87493d1641e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:48320",
+					"10.65.0.27:48320",
+					"172.17.0.1:48320",
+					"172.19.0.1:48320",
+					"172.20.0.1:48320"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:30:32.969308024Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         957733553012456,
+				"StableID":   "n1hZU73mU811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:05e508ebfad6e975e6003ada3235266c8498d9108649ea3798bfc31a59c49878",
+				"DiscoKey":   "discokey:0b2dd2ea0e752e5902f9f1436088b3da3cee3b0d992fcd64fab560a67b048621",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:47543",
+					"10.65.0.27:47543",
+					"172.17.0.1:47543",
+					"172.19.0.1:47543",
+					"172.20.0.1:47543"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:30:33.503510604Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8734601593202560,
+				"StableID":   "nbS6Z1BvCB21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ddff768b7e33513753a7b38139cd479da7b209817d953dc9a61f57e210a9d403",
+				"DiscoKey":   "discokey:93aeadd32435e3f75d5c3ec90297cb8c184410468b1b9fd83fde573693b73e7e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53457",
+					"10.65.0.27:53457",
+					"172.17.0.1:53457",
+					"172.19.0.1:53457",
+					"172.20.0.1:53457"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:30:34.050014495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2488164668628094,
+				"StableID":   "nRrvSGstRL11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5ce13076f2d0ed4b7a84934b2a3214d4aad67b1623869e511692c811b5db22a",
+				"DiscoKey":   "discokey:1adab87cde21a4395f5036c1907bf6f72047605537a07d13a7a6b23fc4a95241",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38627",
+					"10.65.0.27:38627",
+					"172.17.0.1:38627",
+					"172.19.0.1:38627",
+					"172.20.0.1:38627"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:30:34.598387549Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1579363899754636,
+				"StableID":   "n76YYGDJLD11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:932d3ac7832270215c5b8f0558f8bad279056ee4e2cde027398cfbc01a1fc66a",
+				"DiscoKey":   "discokey:98b2080865a81ffe871b4c0afbea4d43fcf1b09afcc248cc86185f064b21e04c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52139",
+					"10.65.0.27:52139",
+					"172.17.0.1:52139",
+					"172.19.0.1:52139",
+					"172.20.0.1:52139"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:30:35.134095492Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8669919100511088,
+				"StableID":   "nKUoAF5dhA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:502e27edb456871dfff33390d2cca574ef4ee79a1f56e3193b3f58a1ad376149",
+				"DiscoKey":   "discokey:4140be309403eda64e4d7c5f2bdb8817beec499a2a79ad2c10577b82ffe98351",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52374",
+					"10.65.0.27:52374",
+					"172.17.0.1:52374",
+					"172.19.0.1:52374",
+					"172.20.0.1:52374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:30:35.678520401Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         969928810643158,
+				"StableID":   "nKucdLPHa811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5dd36071b1b456463149c5b40f638cff3e0498394dab85728a153e9e8258657",
+				"DiscoKey":   "discokey:5cebf3fc7c1f56b675dc5343a203ee77a80c29ebfc2a7b2b77e5c257bef30536",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40855",
+					"10.65.0.27:40855",
+					"172.17.0.1:40855",
+					"172.19.0.1:40855",
+					"172.20.0.1:40855"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:30:36.218015923Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7820106284878854,
+				"StableID":   "nqtXh2wj4421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7b8a80bcb3b4c6d225d7bb66fe70dd52cf6f77e60acbaf44646ea3b450aa7829",
+				"DiscoKey":   "discokey:34824ac9df5c4c5e251c904d9fbdebad405008a2d18bc51ad5950eafef0cd330",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51912",
+					"10.65.0.27:51912",
+					"172.17.0.1:51912",
+					"172.19.0.1:51912",
+					"172.20.0.1:51912"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:30:36.75475336Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4655736851755124,
+				"StableID":   "nmhXm7KbMd11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d11dac4aeca6bb34ea4e64d686799c6fca97e91cc689eba4060a36da0f4cae32",
+				"KeyExpiry":  "2026-11-08T18:30:37Z",
+				"DiscoKey":   "discokey:e0ba0bcef9432eeef592fa6dade559a10d1741bcf8cbba9af1f2091f86fff525",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49951",
+					"10.65.0.27:49951",
+					"172.17.0.1:49951",
+					"172.19.0.1:49951",
+					"172.20.0.1:49951"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:30:37.818654505Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7329705459394441,
+				"StableID":   "nrZs39wdEz11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e99e6cba82c38f5a505e3401d384750b9ef784b53e71cad7f8e1bb3413e46763",
+				"KeyExpiry":  "2026-11-08T18:30:38Z",
+				"DiscoKey":   "discokey:47c8fa02a310fbd9d2949a99051af5c43ac46a26a07c69cc2798e47f69068352",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40177",
+					"10.65.0.27:40177",
+					"172.17.0.1:40177",
+					"172.19.0.1:40177",
+					"172.20.0.1:40177"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:30:38.354009418Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         79729377405882,
+				"StableID":   "nTyX4dM7d111CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3931ec386abc6c1ca559a70fd4ca19d69920542b52554543319104514f2e6927",
+				"KeyExpiry":  "2026-11-08T18:30:38Z",
+				"DiscoKey":   "discokey:b96a12dca8f83ea66fe8e455935a8bae3c7303875bd64dfdf17c5d1260e0a75b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59975",
+					"10.65.0.27:59975",
+					"172.17.0.1:59975",
+					"172.19.0.1:59975",
+					"172.20.0.1:59975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:30:38.89461838Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1008581452722319": {
+				"ID":          1008581452722319,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8734601593202560,
+				"StableID":   "nbS6Z1BvCB21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       8734601593202560,
+				"Key":        "nodekey:ddff768b7e33513753a7b38139cd479da7b209817d953dc9a61f57e210a9d403",
+				"DiscoKey":   "discokey:93aeadd32435e3f75d5c3ec90297cb8c184410468b1b9fd83fde573693b73e7e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53457",
+					"10.65.0.27:53457",
+					"172.17.0.1:53457",
+					"172.19.0.1:53457",
+					"172.20.0.1:53457"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:30:34.050014495Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ddff768b7e33513753a7b38139cd479da7b209817d953dc9a61f57e210a9d403",
+			"MachineKey": "mkey:c5a29f769a336ccf9e225af85b1edc8f87b91b53590a5ecac3814f499a5c7725",
+			"Peers": [{
+				"ID":         5007491183657601,
+				"StableID":   "nJR1ZXJu6g11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47d178e9b9e748f3ae355d756df6434419f7e9bd55bbc6fdd25156d9a342363d",
+				"DiscoKey":   "discokey:2460330d63a76e823a3f98165fa17178474baf3a31eaff731969eb9ba46a0309",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54223",
+					"10.65.0.27:54223",
+					"172.17.0.1:54223",
+					"172.19.0.1:54223",
+					"172.20.0.1:54223"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:30:31.395098446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1600955304356651,
+				"StableID":   "na2s27P5WD11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:694893f9ac0523b45ab8fc1fd601b5d441c7a4c8fa7e28eb60a76521416fe116",
+				"DiscoKey":   "discokey:ff47fa2f29cd43a00292e51b8bf0999867fd5a6c88aaf49964d94ef3d9fe3159",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:60037",
+					"10.65.0.27:60037",
+					"172.17.0.1:60037",
+					"172.19.0.1:60037",
+					"172.20.0.1:60037"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:30:31.886043888Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6973050553104759,
+				"StableID":   "nxyhHQD7Tw11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6cd5fae42b55f6d8b7001477a548eb5a7aec0aa8a16cfdf944ea2799387c948",
+				"DiscoKey":   "discokey:49de72c308cdec88226e01edb1c33edffddd3dc3afd2d4a29645abbfad541725",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52458",
+					"10.65.0.27:52458",
+					"172.17.0.1:52458",
+					"172.19.0.1:52458",
+					"172.20.0.1:52458"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:30:32.422535926Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4428690401772650,
+				"StableID":   "nhS5UrBmab11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15fac8db70d5dbd3b27be9dbcdaa661332294805f913a2b186af07dd1a387854",
+				"DiscoKey":   "discokey:bb7470c216c71114a920d314ea855fbbfa860a4198790e64c3b4d87493d1641e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:48320",
+					"10.65.0.27:48320",
+					"172.17.0.1:48320",
+					"172.19.0.1:48320",
+					"172.20.0.1:48320"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:30:32.969308024Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         957733553012456,
+				"StableID":   "n1hZU73mU811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:05e508ebfad6e975e6003ada3235266c8498d9108649ea3798bfc31a59c49878",
+				"DiscoKey":   "discokey:0b2dd2ea0e752e5902f9f1436088b3da3cee3b0d992fcd64fab560a67b048621",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:47543",
+					"10.65.0.27:47543",
+					"172.17.0.1:47543",
+					"172.19.0.1:47543",
+					"172.20.0.1:47543"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:30:33.503510604Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2488164668628094,
+				"StableID":   "nRrvSGstRL11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5ce13076f2d0ed4b7a84934b2a3214d4aad67b1623869e511692c811b5db22a",
+				"DiscoKey":   "discokey:1adab87cde21a4395f5036c1907bf6f72047605537a07d13a7a6b23fc4a95241",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38627",
+					"10.65.0.27:38627",
+					"172.17.0.1:38627",
+					"172.19.0.1:38627",
+					"172.20.0.1:38627"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:30:34.598387549Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1579363899754636,
+				"StableID":   "n76YYGDJLD11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:932d3ac7832270215c5b8f0558f8bad279056ee4e2cde027398cfbc01a1fc66a",
+				"DiscoKey":   "discokey:98b2080865a81ffe871b4c0afbea4d43fcf1b09afcc248cc86185f064b21e04c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52139",
+					"10.65.0.27:52139",
+					"172.17.0.1:52139",
+					"172.19.0.1:52139",
+					"172.20.0.1:52139"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:30:35.134095492Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8669919100511088,
+				"StableID":   "nKUoAF5dhA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:502e27edb456871dfff33390d2cca574ef4ee79a1f56e3193b3f58a1ad376149",
+				"DiscoKey":   "discokey:4140be309403eda64e4d7c5f2bdb8817beec499a2a79ad2c10577b82ffe98351",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52374",
+					"10.65.0.27:52374",
+					"172.17.0.1:52374",
+					"172.19.0.1:52374",
+					"172.20.0.1:52374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:30:35.678520401Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         969928810643158,
+				"StableID":   "nKucdLPHa811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5dd36071b1b456463149c5b40f638cff3e0498394dab85728a153e9e8258657",
+				"DiscoKey":   "discokey:5cebf3fc7c1f56b675dc5343a203ee77a80c29ebfc2a7b2b77e5c257bef30536",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40855",
+					"10.65.0.27:40855",
+					"172.17.0.1:40855",
+					"172.19.0.1:40855",
+					"172.20.0.1:40855"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:30:36.218015923Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7820106284878854,
+				"StableID":   "nqtXh2wj4421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7b8a80bcb3b4c6d225d7bb66fe70dd52cf6f77e60acbaf44646ea3b450aa7829",
+				"DiscoKey":   "discokey:34824ac9df5c4c5e251c904d9fbdebad405008a2d18bc51ad5950eafef0cd330",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51912",
+					"10.65.0.27:51912",
+					"172.17.0.1:51912",
+					"172.19.0.1:51912",
+					"172.20.0.1:51912"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:30:36.75475336Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1008581452722319,
+				"StableID":   "n8DdF2jns811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c3c632a9519153d4f33a975ef9cade7a321451f65845b41329a627043bd077a",
+				"DiscoKey":   "discokey:fef1c431d8bdd764f364efe8d9dfc9eb6b8e18699dfe2aab4e4ec25a07e4ec6b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49399",
+					"10.65.0.27:49399",
+					"172.17.0.1:49399",
+					"172.19.0.1:49399",
+					"172.20.0.1:49399"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:30:37.300468924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4655736851755124,
+				"StableID":   "nmhXm7KbMd11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d11dac4aeca6bb34ea4e64d686799c6fca97e91cc689eba4060a36da0f4cae32",
+				"KeyExpiry":  "2026-11-08T18:30:37Z",
+				"DiscoKey":   "discokey:e0ba0bcef9432eeef592fa6dade559a10d1741bcf8cbba9af1f2091f86fff525",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49951",
+					"10.65.0.27:49951",
+					"172.17.0.1:49951",
+					"172.19.0.1:49951",
+					"172.20.0.1:49951"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:30:37.818654505Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7329705459394441,
+				"StableID":   "nrZs39wdEz11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e99e6cba82c38f5a505e3401d384750b9ef784b53e71cad7f8e1bb3413e46763",
+				"KeyExpiry":  "2026-11-08T18:30:38Z",
+				"DiscoKey":   "discokey:47c8fa02a310fbd9d2949a99051af5c43ac46a26a07c69cc2798e47f69068352",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40177",
+					"10.65.0.27:40177",
+					"172.17.0.1:40177",
+					"172.19.0.1:40177",
+					"172.20.0.1:40177"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:30:38.354009418Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         79729377405882,
+				"StableID":   "nTyX4dM7d111CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3931ec386abc6c1ca559a70fd4ca19d69920542b52554543319104514f2e6927",
+				"KeyExpiry":  "2026-11-08T18:30:38Z",
+				"DiscoKey":   "discokey:b96a12dca8f83ea66fe8e455935a8bae3c7303875bd64dfdf17c5d1260e0a75b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59975",
+					"10.65.0.27:59975",
+					"172.17.0.1:59975",
+					"172.19.0.1:59975",
+					"172.20.0.1:59975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:30:38.89461838Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8734601593202560": {
+				"ID":          8734601593202560,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         79729377405882,
+				"StableID":   "nTyX4dM7d111CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3931ec386abc6c1ca559a70fd4ca19d69920542b52554543319104514f2e6927",
+				"KeyExpiry":  "2026-11-08T18:30:38Z",
+				"DiscoKey":   "discokey:b96a12dca8f83ea66fe8e455935a8bae3c7303875bd64dfdf17c5d1260e0a75b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59975",
+					"10.65.0.27:59975",
+					"172.17.0.1:59975",
+					"172.19.0.1:59975",
+					"172.20.0.1:59975"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:30:38.89461838Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3931ec386abc6c1ca559a70fd4ca19d69920542b52554543319104514f2e6927",
+			"MachineKey": "mkey:42cd01a0032b272d2a16abdac108d0ca9a033688dce3c8e3e4980fb71a74e577",
+			"Peers": [{
+				"ID":         5007491183657601,
+				"StableID":   "nJR1ZXJu6g11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47d178e9b9e748f3ae355d756df6434419f7e9bd55bbc6fdd25156d9a342363d",
+				"DiscoKey":   "discokey:2460330d63a76e823a3f98165fa17178474baf3a31eaff731969eb9ba46a0309",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54223",
+					"10.65.0.27:54223",
+					"172.17.0.1:54223",
+					"172.19.0.1:54223",
+					"172.20.0.1:54223"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:30:31.395098446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1600955304356651,
+				"StableID":   "na2s27P5WD11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:694893f9ac0523b45ab8fc1fd601b5d441c7a4c8fa7e28eb60a76521416fe116",
+				"DiscoKey":   "discokey:ff47fa2f29cd43a00292e51b8bf0999867fd5a6c88aaf49964d94ef3d9fe3159",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:60037",
+					"10.65.0.27:60037",
+					"172.17.0.1:60037",
+					"172.19.0.1:60037",
+					"172.20.0.1:60037"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:30:31.886043888Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6973050553104759,
+				"StableID":   "nxyhHQD7Tw11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6cd5fae42b55f6d8b7001477a548eb5a7aec0aa8a16cfdf944ea2799387c948",
+				"DiscoKey":   "discokey:49de72c308cdec88226e01edb1c33edffddd3dc3afd2d4a29645abbfad541725",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52458",
+					"10.65.0.27:52458",
+					"172.17.0.1:52458",
+					"172.19.0.1:52458",
+					"172.20.0.1:52458"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:30:32.422535926Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4428690401772650,
+				"StableID":   "nhS5UrBmab11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15fac8db70d5dbd3b27be9dbcdaa661332294805f913a2b186af07dd1a387854",
+				"DiscoKey":   "discokey:bb7470c216c71114a920d314ea855fbbfa860a4198790e64c3b4d87493d1641e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:48320",
+					"10.65.0.27:48320",
+					"172.17.0.1:48320",
+					"172.19.0.1:48320",
+					"172.20.0.1:48320"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:30:32.969308024Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         957733553012456,
+				"StableID":   "n1hZU73mU811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:05e508ebfad6e975e6003ada3235266c8498d9108649ea3798bfc31a59c49878",
+				"DiscoKey":   "discokey:0b2dd2ea0e752e5902f9f1436088b3da3cee3b0d992fcd64fab560a67b048621",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:47543",
+					"10.65.0.27:47543",
+					"172.17.0.1:47543",
+					"172.19.0.1:47543",
+					"172.20.0.1:47543"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:30:33.503510604Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8734601593202560,
+				"StableID":   "nbS6Z1BvCB21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ddff768b7e33513753a7b38139cd479da7b209817d953dc9a61f57e210a9d403",
+				"DiscoKey":   "discokey:93aeadd32435e3f75d5c3ec90297cb8c184410468b1b9fd83fde573693b73e7e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53457",
+					"10.65.0.27:53457",
+					"172.17.0.1:53457",
+					"172.19.0.1:53457",
+					"172.20.0.1:53457"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:30:34.050014495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2488164668628094,
+				"StableID":   "nRrvSGstRL11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5ce13076f2d0ed4b7a84934b2a3214d4aad67b1623869e511692c811b5db22a",
+				"DiscoKey":   "discokey:1adab87cde21a4395f5036c1907bf6f72047605537a07d13a7a6b23fc4a95241",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38627",
+					"10.65.0.27:38627",
+					"172.17.0.1:38627",
+					"172.19.0.1:38627",
+					"172.20.0.1:38627"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:30:34.598387549Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1579363899754636,
+				"StableID":   "n76YYGDJLD11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:932d3ac7832270215c5b8f0558f8bad279056ee4e2cde027398cfbc01a1fc66a",
+				"DiscoKey":   "discokey:98b2080865a81ffe871b4c0afbea4d43fcf1b09afcc248cc86185f064b21e04c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52139",
+					"10.65.0.27:52139",
+					"172.17.0.1:52139",
+					"172.19.0.1:52139",
+					"172.20.0.1:52139"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:30:35.134095492Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8669919100511088,
+				"StableID":   "nKUoAF5dhA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:502e27edb456871dfff33390d2cca574ef4ee79a1f56e3193b3f58a1ad376149",
+				"DiscoKey":   "discokey:4140be309403eda64e4d7c5f2bdb8817beec499a2a79ad2c10577b82ffe98351",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52374",
+					"10.65.0.27:52374",
+					"172.17.0.1:52374",
+					"172.19.0.1:52374",
+					"172.20.0.1:52374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:30:35.678520401Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         969928810643158,
+				"StableID":   "nKucdLPHa811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5dd36071b1b456463149c5b40f638cff3e0498394dab85728a153e9e8258657",
+				"DiscoKey":   "discokey:5cebf3fc7c1f56b675dc5343a203ee77a80c29ebfc2a7b2b77e5c257bef30536",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40855",
+					"10.65.0.27:40855",
+					"172.17.0.1:40855",
+					"172.19.0.1:40855",
+					"172.20.0.1:40855"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:30:36.218015923Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7820106284878854,
+				"StableID":   "nqtXh2wj4421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7b8a80bcb3b4c6d225d7bb66fe70dd52cf6f77e60acbaf44646ea3b450aa7829",
+				"DiscoKey":   "discokey:34824ac9df5c4c5e251c904d9fbdebad405008a2d18bc51ad5950eafef0cd330",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51912",
+					"10.65.0.27:51912",
+					"172.17.0.1:51912",
+					"172.19.0.1:51912",
+					"172.20.0.1:51912"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:30:36.75475336Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1008581452722319,
+				"StableID":   "n8DdF2jns811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c3c632a9519153d4f33a975ef9cade7a321451f65845b41329a627043bd077a",
+				"DiscoKey":   "discokey:fef1c431d8bdd764f364efe8d9dfc9eb6b8e18699dfe2aab4e4ec25a07e4ec6b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49399",
+					"10.65.0.27:49399",
+					"172.17.0.1:49399",
+					"172.19.0.1:49399",
+					"172.20.0.1:49399"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:30:37.300468924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4655736851755124,
+				"StableID":   "nmhXm7KbMd11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d11dac4aeca6bb34ea4e64d686799c6fca97e91cc689eba4060a36da0f4cae32",
+				"KeyExpiry":  "2026-11-08T18:30:37Z",
+				"DiscoKey":   "discokey:e0ba0bcef9432eeef592fa6dade559a10d1741bcf8cbba9af1f2091f86fff525",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49951",
+					"10.65.0.27:49951",
+					"172.17.0.1:49951",
+					"172.19.0.1:49951",
+					"172.20.0.1:49951"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:30:37.818654505Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7329705459394441,
+				"StableID":   "nrZs39wdEz11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e99e6cba82c38f5a505e3401d384750b9ef784b53e71cad7f8e1bb3413e46763",
+				"KeyExpiry":  "2026-11-08T18:30:38Z",
+				"DiscoKey":   "discokey:47c8fa02a310fbd9d2949a99051af5c43ac46a26a07c69cc2798e47f69068352",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40177",
+					"10.65.0.27:40177",
+					"172.17.0.1:40177",
+					"172.19.0.1:40177",
+					"172.20.0.1:40177"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:30:38.354009418Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6973050553104759,
+				"StableID":   "nxyhHQD7Tw11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       6973050553104759,
+				"Key":        "nodekey:d6cd5fae42b55f6d8b7001477a548eb5a7aec0aa8a16cfdf944ea2799387c948",
+				"DiscoKey":   "discokey:49de72c308cdec88226e01edb1c33edffddd3dc3afd2d4a29645abbfad541725",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52458",
+					"10.65.0.27:52458",
+					"172.17.0.1:52458",
+					"172.19.0.1:52458",
+					"172.20.0.1:52458"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:30:32.422535926Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d6cd5fae42b55f6d8b7001477a548eb5a7aec0aa8a16cfdf944ea2799387c948",
+			"MachineKey": "mkey:476dd9c12817c0a9dcaaa19155f637f2d2e0c7f3d5ed30e9029532d687110817",
+			"Peers": [{
+				"ID":         5007491183657601,
+				"StableID":   "nJR1ZXJu6g11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47d178e9b9e748f3ae355d756df6434419f7e9bd55bbc6fdd25156d9a342363d",
+				"DiscoKey":   "discokey:2460330d63a76e823a3f98165fa17178474baf3a31eaff731969eb9ba46a0309",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54223",
+					"10.65.0.27:54223",
+					"172.17.0.1:54223",
+					"172.19.0.1:54223",
+					"172.20.0.1:54223"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:30:31.395098446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1600955304356651,
+				"StableID":   "na2s27P5WD11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:694893f9ac0523b45ab8fc1fd601b5d441c7a4c8fa7e28eb60a76521416fe116",
+				"DiscoKey":   "discokey:ff47fa2f29cd43a00292e51b8bf0999867fd5a6c88aaf49964d94ef3d9fe3159",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:60037",
+					"10.65.0.27:60037",
+					"172.17.0.1:60037",
+					"172.19.0.1:60037",
+					"172.20.0.1:60037"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:30:31.886043888Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4428690401772650,
+				"StableID":   "nhS5UrBmab11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15fac8db70d5dbd3b27be9dbcdaa661332294805f913a2b186af07dd1a387854",
+				"DiscoKey":   "discokey:bb7470c216c71114a920d314ea855fbbfa860a4198790e64c3b4d87493d1641e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:48320",
+					"10.65.0.27:48320",
+					"172.17.0.1:48320",
+					"172.19.0.1:48320",
+					"172.20.0.1:48320"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:30:32.969308024Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         957733553012456,
+				"StableID":   "n1hZU73mU811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:05e508ebfad6e975e6003ada3235266c8498d9108649ea3798bfc31a59c49878",
+				"DiscoKey":   "discokey:0b2dd2ea0e752e5902f9f1436088b3da3cee3b0d992fcd64fab560a67b048621",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:47543",
+					"10.65.0.27:47543",
+					"172.17.0.1:47543",
+					"172.19.0.1:47543",
+					"172.20.0.1:47543"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:30:33.503510604Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8734601593202560,
+				"StableID":   "nbS6Z1BvCB21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ddff768b7e33513753a7b38139cd479da7b209817d953dc9a61f57e210a9d403",
+				"DiscoKey":   "discokey:93aeadd32435e3f75d5c3ec90297cb8c184410468b1b9fd83fde573693b73e7e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53457",
+					"10.65.0.27:53457",
+					"172.17.0.1:53457",
+					"172.19.0.1:53457",
+					"172.20.0.1:53457"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:30:34.050014495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2488164668628094,
+				"StableID":   "nRrvSGstRL11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5ce13076f2d0ed4b7a84934b2a3214d4aad67b1623869e511692c811b5db22a",
+				"DiscoKey":   "discokey:1adab87cde21a4395f5036c1907bf6f72047605537a07d13a7a6b23fc4a95241",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38627",
+					"10.65.0.27:38627",
+					"172.17.0.1:38627",
+					"172.19.0.1:38627",
+					"172.20.0.1:38627"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:30:34.598387549Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1579363899754636,
+				"StableID":   "n76YYGDJLD11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:932d3ac7832270215c5b8f0558f8bad279056ee4e2cde027398cfbc01a1fc66a",
+				"DiscoKey":   "discokey:98b2080865a81ffe871b4c0afbea4d43fcf1b09afcc248cc86185f064b21e04c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52139",
+					"10.65.0.27:52139",
+					"172.17.0.1:52139",
+					"172.19.0.1:52139",
+					"172.20.0.1:52139"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:30:35.134095492Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8669919100511088,
+				"StableID":   "nKUoAF5dhA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:502e27edb456871dfff33390d2cca574ef4ee79a1f56e3193b3f58a1ad376149",
+				"DiscoKey":   "discokey:4140be309403eda64e4d7c5f2bdb8817beec499a2a79ad2c10577b82ffe98351",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52374",
+					"10.65.0.27:52374",
+					"172.17.0.1:52374",
+					"172.19.0.1:52374",
+					"172.20.0.1:52374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:30:35.678520401Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         969928810643158,
+				"StableID":   "nKucdLPHa811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5dd36071b1b456463149c5b40f638cff3e0498394dab85728a153e9e8258657",
+				"DiscoKey":   "discokey:5cebf3fc7c1f56b675dc5343a203ee77a80c29ebfc2a7b2b77e5c257bef30536",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40855",
+					"10.65.0.27:40855",
+					"172.17.0.1:40855",
+					"172.19.0.1:40855",
+					"172.20.0.1:40855"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:30:36.218015923Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7820106284878854,
+				"StableID":   "nqtXh2wj4421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7b8a80bcb3b4c6d225d7bb66fe70dd52cf6f77e60acbaf44646ea3b450aa7829",
+				"DiscoKey":   "discokey:34824ac9df5c4c5e251c904d9fbdebad405008a2d18bc51ad5950eafef0cd330",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51912",
+					"10.65.0.27:51912",
+					"172.17.0.1:51912",
+					"172.19.0.1:51912",
+					"172.20.0.1:51912"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:30:36.75475336Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1008581452722319,
+				"StableID":   "n8DdF2jns811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c3c632a9519153d4f33a975ef9cade7a321451f65845b41329a627043bd077a",
+				"DiscoKey":   "discokey:fef1c431d8bdd764f364efe8d9dfc9eb6b8e18699dfe2aab4e4ec25a07e4ec6b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49399",
+					"10.65.0.27:49399",
+					"172.17.0.1:49399",
+					"172.19.0.1:49399",
+					"172.20.0.1:49399"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:30:37.300468924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4655736851755124,
+				"StableID":   "nmhXm7KbMd11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d11dac4aeca6bb34ea4e64d686799c6fca97e91cc689eba4060a36da0f4cae32",
+				"KeyExpiry":  "2026-11-08T18:30:37Z",
+				"DiscoKey":   "discokey:e0ba0bcef9432eeef592fa6dade559a10d1741bcf8cbba9af1f2091f86fff525",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49951",
+					"10.65.0.27:49951",
+					"172.17.0.1:49951",
+					"172.19.0.1:49951",
+					"172.20.0.1:49951"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:30:37.818654505Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7329705459394441,
+				"StableID":   "nrZs39wdEz11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e99e6cba82c38f5a505e3401d384750b9ef784b53e71cad7f8e1bb3413e46763",
+				"KeyExpiry":  "2026-11-08T18:30:38Z",
+				"DiscoKey":   "discokey:47c8fa02a310fbd9d2949a99051af5c43ac46a26a07c69cc2798e47f69068352",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40177",
+					"10.65.0.27:40177",
+					"172.17.0.1:40177",
+					"172.19.0.1:40177",
+					"172.20.0.1:40177"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:30:38.354009418Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         79729377405882,
+				"StableID":   "nTyX4dM7d111CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3931ec386abc6c1ca559a70fd4ca19d69920542b52554543319104514f2e6927",
+				"KeyExpiry":  "2026-11-08T18:30:38Z",
+				"DiscoKey":   "discokey:b96a12dca8f83ea66fe8e455935a8bae3c7303875bd64dfdf17c5d1260e0a75b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59975",
+					"10.65.0.27:59975",
+					"172.17.0.1:59975",
+					"172.19.0.1:59975",
+					"172.20.0.1:59975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:30:38.89461838Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6973050553104759": {
+				"ID":          6973050553104759,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1579363899754636,
+				"StableID":   "n76YYGDJLD11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1579363899754636,
+				"Key":        "nodekey:932d3ac7832270215c5b8f0558f8bad279056ee4e2cde027398cfbc01a1fc66a",
+				"DiscoKey":   "discokey:98b2080865a81ffe871b4c0afbea4d43fcf1b09afcc248cc86185f064b21e04c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52139",
+					"10.65.0.27:52139",
+					"172.17.0.1:52139",
+					"172.19.0.1:52139",
+					"172.20.0.1:52139"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:30:35.134095492Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:932d3ac7832270215c5b8f0558f8bad279056ee4e2cde027398cfbc01a1fc66a",
+			"MachineKey": "mkey:90e278f91e5b97d830ef300cc3b93601b53d60a5951318dc87733ebd48f4db1b",
+			"Peers": [{
+				"ID":         5007491183657601,
+				"StableID":   "nJR1ZXJu6g11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47d178e9b9e748f3ae355d756df6434419f7e9bd55bbc6fdd25156d9a342363d",
+				"DiscoKey":   "discokey:2460330d63a76e823a3f98165fa17178474baf3a31eaff731969eb9ba46a0309",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54223",
+					"10.65.0.27:54223",
+					"172.17.0.1:54223",
+					"172.19.0.1:54223",
+					"172.20.0.1:54223"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:30:31.395098446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1600955304356651,
+				"StableID":   "na2s27P5WD11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:694893f9ac0523b45ab8fc1fd601b5d441c7a4c8fa7e28eb60a76521416fe116",
+				"DiscoKey":   "discokey:ff47fa2f29cd43a00292e51b8bf0999867fd5a6c88aaf49964d94ef3d9fe3159",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:60037",
+					"10.65.0.27:60037",
+					"172.17.0.1:60037",
+					"172.19.0.1:60037",
+					"172.20.0.1:60037"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:30:31.886043888Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6973050553104759,
+				"StableID":   "nxyhHQD7Tw11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6cd5fae42b55f6d8b7001477a548eb5a7aec0aa8a16cfdf944ea2799387c948",
+				"DiscoKey":   "discokey:49de72c308cdec88226e01edb1c33edffddd3dc3afd2d4a29645abbfad541725",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52458",
+					"10.65.0.27:52458",
+					"172.17.0.1:52458",
+					"172.19.0.1:52458",
+					"172.20.0.1:52458"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:30:32.422535926Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4428690401772650,
+				"StableID":   "nhS5UrBmab11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15fac8db70d5dbd3b27be9dbcdaa661332294805f913a2b186af07dd1a387854",
+				"DiscoKey":   "discokey:bb7470c216c71114a920d314ea855fbbfa860a4198790e64c3b4d87493d1641e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:48320",
+					"10.65.0.27:48320",
+					"172.17.0.1:48320",
+					"172.19.0.1:48320",
+					"172.20.0.1:48320"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:30:32.969308024Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         957733553012456,
+				"StableID":   "n1hZU73mU811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:05e508ebfad6e975e6003ada3235266c8498d9108649ea3798bfc31a59c49878",
+				"DiscoKey":   "discokey:0b2dd2ea0e752e5902f9f1436088b3da3cee3b0d992fcd64fab560a67b048621",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:47543",
+					"10.65.0.27:47543",
+					"172.17.0.1:47543",
+					"172.19.0.1:47543",
+					"172.20.0.1:47543"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:30:33.503510604Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8734601593202560,
+				"StableID":   "nbS6Z1BvCB21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ddff768b7e33513753a7b38139cd479da7b209817d953dc9a61f57e210a9d403",
+				"DiscoKey":   "discokey:93aeadd32435e3f75d5c3ec90297cb8c184410468b1b9fd83fde573693b73e7e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53457",
+					"10.65.0.27:53457",
+					"172.17.0.1:53457",
+					"172.19.0.1:53457",
+					"172.20.0.1:53457"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:30:34.050014495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2488164668628094,
+				"StableID":   "nRrvSGstRL11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5ce13076f2d0ed4b7a84934b2a3214d4aad67b1623869e511692c811b5db22a",
+				"DiscoKey":   "discokey:1adab87cde21a4395f5036c1907bf6f72047605537a07d13a7a6b23fc4a95241",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38627",
+					"10.65.0.27:38627",
+					"172.17.0.1:38627",
+					"172.19.0.1:38627",
+					"172.20.0.1:38627"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:30:34.598387549Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8669919100511088,
+				"StableID":   "nKUoAF5dhA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:502e27edb456871dfff33390d2cca574ef4ee79a1f56e3193b3f58a1ad376149",
+				"DiscoKey":   "discokey:4140be309403eda64e4d7c5f2bdb8817beec499a2a79ad2c10577b82ffe98351",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52374",
+					"10.65.0.27:52374",
+					"172.17.0.1:52374",
+					"172.19.0.1:52374",
+					"172.20.0.1:52374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:30:35.678520401Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         969928810643158,
+				"StableID":   "nKucdLPHa811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5dd36071b1b456463149c5b40f638cff3e0498394dab85728a153e9e8258657",
+				"DiscoKey":   "discokey:5cebf3fc7c1f56b675dc5343a203ee77a80c29ebfc2a7b2b77e5c257bef30536",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40855",
+					"10.65.0.27:40855",
+					"172.17.0.1:40855",
+					"172.19.0.1:40855",
+					"172.20.0.1:40855"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:30:36.218015923Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7820106284878854,
+				"StableID":   "nqtXh2wj4421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7b8a80bcb3b4c6d225d7bb66fe70dd52cf6f77e60acbaf44646ea3b450aa7829",
+				"DiscoKey":   "discokey:34824ac9df5c4c5e251c904d9fbdebad405008a2d18bc51ad5950eafef0cd330",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51912",
+					"10.65.0.27:51912",
+					"172.17.0.1:51912",
+					"172.19.0.1:51912",
+					"172.20.0.1:51912"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:30:36.75475336Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1008581452722319,
+				"StableID":   "n8DdF2jns811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c3c632a9519153d4f33a975ef9cade7a321451f65845b41329a627043bd077a",
+				"DiscoKey":   "discokey:fef1c431d8bdd764f364efe8d9dfc9eb6b8e18699dfe2aab4e4ec25a07e4ec6b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49399",
+					"10.65.0.27:49399",
+					"172.17.0.1:49399",
+					"172.19.0.1:49399",
+					"172.20.0.1:49399"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:30:37.300468924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4655736851755124,
+				"StableID":   "nmhXm7KbMd11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d11dac4aeca6bb34ea4e64d686799c6fca97e91cc689eba4060a36da0f4cae32",
+				"KeyExpiry":  "2026-11-08T18:30:37Z",
+				"DiscoKey":   "discokey:e0ba0bcef9432eeef592fa6dade559a10d1741bcf8cbba9af1f2091f86fff525",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49951",
+					"10.65.0.27:49951",
+					"172.17.0.1:49951",
+					"172.19.0.1:49951",
+					"172.20.0.1:49951"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:30:37.818654505Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7329705459394441,
+				"StableID":   "nrZs39wdEz11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e99e6cba82c38f5a505e3401d384750b9ef784b53e71cad7f8e1bb3413e46763",
+				"KeyExpiry":  "2026-11-08T18:30:38Z",
+				"DiscoKey":   "discokey:47c8fa02a310fbd9d2949a99051af5c43ac46a26a07c69cc2798e47f69068352",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40177",
+					"10.65.0.27:40177",
+					"172.17.0.1:40177",
+					"172.19.0.1:40177",
+					"172.20.0.1:40177"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:30:38.354009418Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         79729377405882,
+				"StableID":   "nTyX4dM7d111CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3931ec386abc6c1ca559a70fd4ca19d69920542b52554543319104514f2e6927",
+				"KeyExpiry":  "2026-11-08T18:30:38Z",
+				"DiscoKey":   "discokey:b96a12dca8f83ea66fe8e455935a8bae3c7303875bd64dfdf17c5d1260e0a75b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59975",
+					"10.65.0.27:59975",
+					"172.17.0.1:59975",
+					"172.19.0.1:59975",
+					"172.20.0.1:59975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:30:38.89461838Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1579363899754636": {
+				"ID":          1579363899754636,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4655736851755124,
+				"StableID":   "nmhXm7KbMd11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d11dac4aeca6bb34ea4e64d686799c6fca97e91cc689eba4060a36da0f4cae32",
+				"KeyExpiry":  "2026-11-08T18:30:37Z",
+				"DiscoKey":   "discokey:e0ba0bcef9432eeef592fa6dade559a10d1741bcf8cbba9af1f2091f86fff525",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49951",
+					"10.65.0.27:49951",
+					"172.17.0.1:49951",
+					"172.19.0.1:49951",
+					"172.20.0.1:49951"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:30:37.818654505Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d11dac4aeca6bb34ea4e64d686799c6fca97e91cc689eba4060a36da0f4cae32",
+			"MachineKey": "mkey:c3f77c7324b4b2f229e55199c3d5dd00beab942b751fd1b3227d02ea3172cf61",
+			"Peers": [{
+				"ID":         5007491183657601,
+				"StableID":   "nJR1ZXJu6g11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47d178e9b9e748f3ae355d756df6434419f7e9bd55bbc6fdd25156d9a342363d",
+				"DiscoKey":   "discokey:2460330d63a76e823a3f98165fa17178474baf3a31eaff731969eb9ba46a0309",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54223",
+					"10.65.0.27:54223",
+					"172.17.0.1:54223",
+					"172.19.0.1:54223",
+					"172.20.0.1:54223"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:30:31.395098446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1600955304356651,
+				"StableID":   "na2s27P5WD11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:694893f9ac0523b45ab8fc1fd601b5d441c7a4c8fa7e28eb60a76521416fe116",
+				"DiscoKey":   "discokey:ff47fa2f29cd43a00292e51b8bf0999867fd5a6c88aaf49964d94ef3d9fe3159",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:60037",
+					"10.65.0.27:60037",
+					"172.17.0.1:60037",
+					"172.19.0.1:60037",
+					"172.20.0.1:60037"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:30:31.886043888Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6973050553104759,
+				"StableID":   "nxyhHQD7Tw11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6cd5fae42b55f6d8b7001477a548eb5a7aec0aa8a16cfdf944ea2799387c948",
+				"DiscoKey":   "discokey:49de72c308cdec88226e01edb1c33edffddd3dc3afd2d4a29645abbfad541725",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52458",
+					"10.65.0.27:52458",
+					"172.17.0.1:52458",
+					"172.19.0.1:52458",
+					"172.20.0.1:52458"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:30:32.422535926Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4428690401772650,
+				"StableID":   "nhS5UrBmab11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15fac8db70d5dbd3b27be9dbcdaa661332294805f913a2b186af07dd1a387854",
+				"DiscoKey":   "discokey:bb7470c216c71114a920d314ea855fbbfa860a4198790e64c3b4d87493d1641e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:48320",
+					"10.65.0.27:48320",
+					"172.17.0.1:48320",
+					"172.19.0.1:48320",
+					"172.20.0.1:48320"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:30:32.969308024Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         957733553012456,
+				"StableID":   "n1hZU73mU811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:05e508ebfad6e975e6003ada3235266c8498d9108649ea3798bfc31a59c49878",
+				"DiscoKey":   "discokey:0b2dd2ea0e752e5902f9f1436088b3da3cee3b0d992fcd64fab560a67b048621",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:47543",
+					"10.65.0.27:47543",
+					"172.17.0.1:47543",
+					"172.19.0.1:47543",
+					"172.20.0.1:47543"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:30:33.503510604Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8734601593202560,
+				"StableID":   "nbS6Z1BvCB21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ddff768b7e33513753a7b38139cd479da7b209817d953dc9a61f57e210a9d403",
+				"DiscoKey":   "discokey:93aeadd32435e3f75d5c3ec90297cb8c184410468b1b9fd83fde573693b73e7e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53457",
+					"10.65.0.27:53457",
+					"172.17.0.1:53457",
+					"172.19.0.1:53457",
+					"172.20.0.1:53457"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:30:34.050014495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2488164668628094,
+				"StableID":   "nRrvSGstRL11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5ce13076f2d0ed4b7a84934b2a3214d4aad67b1623869e511692c811b5db22a",
+				"DiscoKey":   "discokey:1adab87cde21a4395f5036c1907bf6f72047605537a07d13a7a6b23fc4a95241",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38627",
+					"10.65.0.27:38627",
+					"172.17.0.1:38627",
+					"172.19.0.1:38627",
+					"172.20.0.1:38627"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:30:34.598387549Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1579363899754636,
+				"StableID":   "n76YYGDJLD11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:932d3ac7832270215c5b8f0558f8bad279056ee4e2cde027398cfbc01a1fc66a",
+				"DiscoKey":   "discokey:98b2080865a81ffe871b4c0afbea4d43fcf1b09afcc248cc86185f064b21e04c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52139",
+					"10.65.0.27:52139",
+					"172.17.0.1:52139",
+					"172.19.0.1:52139",
+					"172.20.0.1:52139"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:30:35.134095492Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8669919100511088,
+				"StableID":   "nKUoAF5dhA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:502e27edb456871dfff33390d2cca574ef4ee79a1f56e3193b3f58a1ad376149",
+				"DiscoKey":   "discokey:4140be309403eda64e4d7c5f2bdb8817beec499a2a79ad2c10577b82ffe98351",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52374",
+					"10.65.0.27:52374",
+					"172.17.0.1:52374",
+					"172.19.0.1:52374",
+					"172.20.0.1:52374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:30:35.678520401Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         969928810643158,
+				"StableID":   "nKucdLPHa811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5dd36071b1b456463149c5b40f638cff3e0498394dab85728a153e9e8258657",
+				"DiscoKey":   "discokey:5cebf3fc7c1f56b675dc5343a203ee77a80c29ebfc2a7b2b77e5c257bef30536",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40855",
+					"10.65.0.27:40855",
+					"172.17.0.1:40855",
+					"172.19.0.1:40855",
+					"172.20.0.1:40855"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:30:36.218015923Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7820106284878854,
+				"StableID":   "nqtXh2wj4421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7b8a80bcb3b4c6d225d7bb66fe70dd52cf6f77e60acbaf44646ea3b450aa7829",
+				"DiscoKey":   "discokey:34824ac9df5c4c5e251c904d9fbdebad405008a2d18bc51ad5950eafef0cd330",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51912",
+					"10.65.0.27:51912",
+					"172.17.0.1:51912",
+					"172.19.0.1:51912",
+					"172.20.0.1:51912"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:30:36.75475336Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1008581452722319,
+				"StableID":   "n8DdF2jns811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c3c632a9519153d4f33a975ef9cade7a321451f65845b41329a627043bd077a",
+				"DiscoKey":   "discokey:fef1c431d8bdd764f364efe8d9dfc9eb6b8e18699dfe2aab4e4ec25a07e4ec6b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49399",
+					"10.65.0.27:49399",
+					"172.17.0.1:49399",
+					"172.19.0.1:49399",
+					"172.20.0.1:49399"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:30:37.300468924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7329705459394441,
+				"StableID":   "nrZs39wdEz11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e99e6cba82c38f5a505e3401d384750b9ef784b53e71cad7f8e1bb3413e46763",
+				"KeyExpiry":  "2026-11-08T18:30:38Z",
+				"DiscoKey":   "discokey:47c8fa02a310fbd9d2949a99051af5c43ac46a26a07c69cc2798e47f69068352",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40177",
+					"10.65.0.27:40177",
+					"172.17.0.1:40177",
+					"172.19.0.1:40177",
+					"172.20.0.1:40177"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:30:38.354009418Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         79729377405882,
+				"StableID":   "nTyX4dM7d111CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3931ec386abc6c1ca559a70fd4ca19d69920542b52554543319104514f2e6927",
+				"KeyExpiry":  "2026-11-08T18:30:38Z",
+				"DiscoKey":   "discokey:b96a12dca8f83ea66fe8e455935a8bae3c7303875bd64dfdf17c5d1260e0a75b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59975",
+					"10.65.0.27:59975",
+					"172.17.0.1:59975",
+					"172.19.0.1:59975",
+					"172.20.0.1:59975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:30:38.89461838Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7820106284878854,
+				"StableID":   "nqtXh2wj4421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       7820106284878854,
+				"Key":        "nodekey:7b8a80bcb3b4c6d225d7bb66fe70dd52cf6f77e60acbaf44646ea3b450aa7829",
+				"DiscoKey":   "discokey:34824ac9df5c4c5e251c904d9fbdebad405008a2d18bc51ad5950eafef0cd330",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51912",
+					"10.65.0.27:51912",
+					"172.17.0.1:51912",
+					"172.19.0.1:51912",
+					"172.20.0.1:51912"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:30:36.75475336Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7b8a80bcb3b4c6d225d7bb66fe70dd52cf6f77e60acbaf44646ea3b450aa7829",
+			"MachineKey": "mkey:1ce732c1765d25382b2f261c99fd55dd8d5eb8b4b03306b24e15edf247eb5748",
+			"Peers": [{
+				"ID":         5007491183657601,
+				"StableID":   "nJR1ZXJu6g11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47d178e9b9e748f3ae355d756df6434419f7e9bd55bbc6fdd25156d9a342363d",
+				"DiscoKey":   "discokey:2460330d63a76e823a3f98165fa17178474baf3a31eaff731969eb9ba46a0309",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54223",
+					"10.65.0.27:54223",
+					"172.17.0.1:54223",
+					"172.19.0.1:54223",
+					"172.20.0.1:54223"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:30:31.395098446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1600955304356651,
+				"StableID":   "na2s27P5WD11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:694893f9ac0523b45ab8fc1fd601b5d441c7a4c8fa7e28eb60a76521416fe116",
+				"DiscoKey":   "discokey:ff47fa2f29cd43a00292e51b8bf0999867fd5a6c88aaf49964d94ef3d9fe3159",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:60037",
+					"10.65.0.27:60037",
+					"172.17.0.1:60037",
+					"172.19.0.1:60037",
+					"172.20.0.1:60037"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:30:31.886043888Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6973050553104759,
+				"StableID":   "nxyhHQD7Tw11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6cd5fae42b55f6d8b7001477a548eb5a7aec0aa8a16cfdf944ea2799387c948",
+				"DiscoKey":   "discokey:49de72c308cdec88226e01edb1c33edffddd3dc3afd2d4a29645abbfad541725",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52458",
+					"10.65.0.27:52458",
+					"172.17.0.1:52458",
+					"172.19.0.1:52458",
+					"172.20.0.1:52458"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:30:32.422535926Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4428690401772650,
+				"StableID":   "nhS5UrBmab11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15fac8db70d5dbd3b27be9dbcdaa661332294805f913a2b186af07dd1a387854",
+				"DiscoKey":   "discokey:bb7470c216c71114a920d314ea855fbbfa860a4198790e64c3b4d87493d1641e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:48320",
+					"10.65.0.27:48320",
+					"172.17.0.1:48320",
+					"172.19.0.1:48320",
+					"172.20.0.1:48320"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:30:32.969308024Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         957733553012456,
+				"StableID":   "n1hZU73mU811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:05e508ebfad6e975e6003ada3235266c8498d9108649ea3798bfc31a59c49878",
+				"DiscoKey":   "discokey:0b2dd2ea0e752e5902f9f1436088b3da3cee3b0d992fcd64fab560a67b048621",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:47543",
+					"10.65.0.27:47543",
+					"172.17.0.1:47543",
+					"172.19.0.1:47543",
+					"172.20.0.1:47543"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:30:33.503510604Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8734601593202560,
+				"StableID":   "nbS6Z1BvCB21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ddff768b7e33513753a7b38139cd479da7b209817d953dc9a61f57e210a9d403",
+				"DiscoKey":   "discokey:93aeadd32435e3f75d5c3ec90297cb8c184410468b1b9fd83fde573693b73e7e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53457",
+					"10.65.0.27:53457",
+					"172.17.0.1:53457",
+					"172.19.0.1:53457",
+					"172.20.0.1:53457"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:30:34.050014495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2488164668628094,
+				"StableID":   "nRrvSGstRL11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5ce13076f2d0ed4b7a84934b2a3214d4aad67b1623869e511692c811b5db22a",
+				"DiscoKey":   "discokey:1adab87cde21a4395f5036c1907bf6f72047605537a07d13a7a6b23fc4a95241",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38627",
+					"10.65.0.27:38627",
+					"172.17.0.1:38627",
+					"172.19.0.1:38627",
+					"172.20.0.1:38627"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:30:34.598387549Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1579363899754636,
+				"StableID":   "n76YYGDJLD11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:932d3ac7832270215c5b8f0558f8bad279056ee4e2cde027398cfbc01a1fc66a",
+				"DiscoKey":   "discokey:98b2080865a81ffe871b4c0afbea4d43fcf1b09afcc248cc86185f064b21e04c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52139",
+					"10.65.0.27:52139",
+					"172.17.0.1:52139",
+					"172.19.0.1:52139",
+					"172.20.0.1:52139"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:30:35.134095492Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8669919100511088,
+				"StableID":   "nKUoAF5dhA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:502e27edb456871dfff33390d2cca574ef4ee79a1f56e3193b3f58a1ad376149",
+				"DiscoKey":   "discokey:4140be309403eda64e4d7c5f2bdb8817beec499a2a79ad2c10577b82ffe98351",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52374",
+					"10.65.0.27:52374",
+					"172.17.0.1:52374",
+					"172.19.0.1:52374",
+					"172.20.0.1:52374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:30:35.678520401Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         969928810643158,
+				"StableID":   "nKucdLPHa811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5dd36071b1b456463149c5b40f638cff3e0498394dab85728a153e9e8258657",
+				"DiscoKey":   "discokey:5cebf3fc7c1f56b675dc5343a203ee77a80c29ebfc2a7b2b77e5c257bef30536",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40855",
+					"10.65.0.27:40855",
+					"172.17.0.1:40855",
+					"172.19.0.1:40855",
+					"172.20.0.1:40855"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:30:36.218015923Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1008581452722319,
+				"StableID":   "n8DdF2jns811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c3c632a9519153d4f33a975ef9cade7a321451f65845b41329a627043bd077a",
+				"DiscoKey":   "discokey:fef1c431d8bdd764f364efe8d9dfc9eb6b8e18699dfe2aab4e4ec25a07e4ec6b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49399",
+					"10.65.0.27:49399",
+					"172.17.0.1:49399",
+					"172.19.0.1:49399",
+					"172.20.0.1:49399"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:30:37.300468924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4655736851755124,
+				"StableID":   "nmhXm7KbMd11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d11dac4aeca6bb34ea4e64d686799c6fca97e91cc689eba4060a36da0f4cae32",
+				"KeyExpiry":  "2026-11-08T18:30:37Z",
+				"DiscoKey":   "discokey:e0ba0bcef9432eeef592fa6dade559a10d1741bcf8cbba9af1f2091f86fff525",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49951",
+					"10.65.0.27:49951",
+					"172.17.0.1:49951",
+					"172.19.0.1:49951",
+					"172.20.0.1:49951"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:30:37.818654505Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7329705459394441,
+				"StableID":   "nrZs39wdEz11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e99e6cba82c38f5a505e3401d384750b9ef784b53e71cad7f8e1bb3413e46763",
+				"KeyExpiry":  "2026-11-08T18:30:38Z",
+				"DiscoKey":   "discokey:47c8fa02a310fbd9d2949a99051af5c43ac46a26a07c69cc2798e47f69068352",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40177",
+					"10.65.0.27:40177",
+					"172.17.0.1:40177",
+					"172.19.0.1:40177",
+					"172.20.0.1:40177"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:30:38.354009418Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         79729377405882,
+				"StableID":   "nTyX4dM7d111CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3931ec386abc6c1ca559a70fd4ca19d69920542b52554543319104514f2e6927",
+				"KeyExpiry":  "2026-11-08T18:30:38Z",
+				"DiscoKey":   "discokey:b96a12dca8f83ea66fe8e455935a8bae3c7303875bd64dfdf17c5d1260e0a75b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59975",
+					"10.65.0.27:59975",
+					"172.17.0.1:59975",
+					"172.19.0.1:59975",
+					"172.20.0.1:59975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:30:38.89461838Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7820106284878854": {
+				"ID":          7820106284878854,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1600955304356651,
+				"StableID":   "na2s27P5WD11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1600955304356651,
+				"Key":        "nodekey:694893f9ac0523b45ab8fc1fd601b5d441c7a4c8fa7e28eb60a76521416fe116",
+				"DiscoKey":   "discokey:ff47fa2f29cd43a00292e51b8bf0999867fd5a6c88aaf49964d94ef3d9fe3159",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:60037",
+					"10.65.0.27:60037",
+					"172.17.0.1:60037",
+					"172.19.0.1:60037",
+					"172.20.0.1:60037"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:30:31.886043888Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:694893f9ac0523b45ab8fc1fd601b5d441c7a4c8fa7e28eb60a76521416fe116",
+			"MachineKey": "mkey:49a9b0ed33a5bead75715316f4dc79e11ae6ad85f1998f19dca7876e7d48027b",
+			"Peers": [{
+				"ID":         5007491183657601,
+				"StableID":   "nJR1ZXJu6g11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47d178e9b9e748f3ae355d756df6434419f7e9bd55bbc6fdd25156d9a342363d",
+				"DiscoKey":   "discokey:2460330d63a76e823a3f98165fa17178474baf3a31eaff731969eb9ba46a0309",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54223",
+					"10.65.0.27:54223",
+					"172.17.0.1:54223",
+					"172.19.0.1:54223",
+					"172.20.0.1:54223"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:30:31.395098446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6973050553104759,
+				"StableID":   "nxyhHQD7Tw11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6cd5fae42b55f6d8b7001477a548eb5a7aec0aa8a16cfdf944ea2799387c948",
+				"DiscoKey":   "discokey:49de72c308cdec88226e01edb1c33edffddd3dc3afd2d4a29645abbfad541725",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52458",
+					"10.65.0.27:52458",
+					"172.17.0.1:52458",
+					"172.19.0.1:52458",
+					"172.20.0.1:52458"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:30:32.422535926Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4428690401772650,
+				"StableID":   "nhS5UrBmab11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15fac8db70d5dbd3b27be9dbcdaa661332294805f913a2b186af07dd1a387854",
+				"DiscoKey":   "discokey:bb7470c216c71114a920d314ea855fbbfa860a4198790e64c3b4d87493d1641e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:48320",
+					"10.65.0.27:48320",
+					"172.17.0.1:48320",
+					"172.19.0.1:48320",
+					"172.20.0.1:48320"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:30:32.969308024Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         957733553012456,
+				"StableID":   "n1hZU73mU811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:05e508ebfad6e975e6003ada3235266c8498d9108649ea3798bfc31a59c49878",
+				"DiscoKey":   "discokey:0b2dd2ea0e752e5902f9f1436088b3da3cee3b0d992fcd64fab560a67b048621",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:47543",
+					"10.65.0.27:47543",
+					"172.17.0.1:47543",
+					"172.19.0.1:47543",
+					"172.20.0.1:47543"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:30:33.503510604Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8734601593202560,
+				"StableID":   "nbS6Z1BvCB21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ddff768b7e33513753a7b38139cd479da7b209817d953dc9a61f57e210a9d403",
+				"DiscoKey":   "discokey:93aeadd32435e3f75d5c3ec90297cb8c184410468b1b9fd83fde573693b73e7e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53457",
+					"10.65.0.27:53457",
+					"172.17.0.1:53457",
+					"172.19.0.1:53457",
+					"172.20.0.1:53457"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:30:34.050014495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2488164668628094,
+				"StableID":   "nRrvSGstRL11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5ce13076f2d0ed4b7a84934b2a3214d4aad67b1623869e511692c811b5db22a",
+				"DiscoKey":   "discokey:1adab87cde21a4395f5036c1907bf6f72047605537a07d13a7a6b23fc4a95241",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38627",
+					"10.65.0.27:38627",
+					"172.17.0.1:38627",
+					"172.19.0.1:38627",
+					"172.20.0.1:38627"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:30:34.598387549Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1579363899754636,
+				"StableID":   "n76YYGDJLD11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:932d3ac7832270215c5b8f0558f8bad279056ee4e2cde027398cfbc01a1fc66a",
+				"DiscoKey":   "discokey:98b2080865a81ffe871b4c0afbea4d43fcf1b09afcc248cc86185f064b21e04c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52139",
+					"10.65.0.27:52139",
+					"172.17.0.1:52139",
+					"172.19.0.1:52139",
+					"172.20.0.1:52139"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:30:35.134095492Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8669919100511088,
+				"StableID":   "nKUoAF5dhA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:502e27edb456871dfff33390d2cca574ef4ee79a1f56e3193b3f58a1ad376149",
+				"DiscoKey":   "discokey:4140be309403eda64e4d7c5f2bdb8817beec499a2a79ad2c10577b82ffe98351",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52374",
+					"10.65.0.27:52374",
+					"172.17.0.1:52374",
+					"172.19.0.1:52374",
+					"172.20.0.1:52374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:30:35.678520401Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         969928810643158,
+				"StableID":   "nKucdLPHa811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5dd36071b1b456463149c5b40f638cff3e0498394dab85728a153e9e8258657",
+				"DiscoKey":   "discokey:5cebf3fc7c1f56b675dc5343a203ee77a80c29ebfc2a7b2b77e5c257bef30536",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40855",
+					"10.65.0.27:40855",
+					"172.17.0.1:40855",
+					"172.19.0.1:40855",
+					"172.20.0.1:40855"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:30:36.218015923Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7820106284878854,
+				"StableID":   "nqtXh2wj4421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7b8a80bcb3b4c6d225d7bb66fe70dd52cf6f77e60acbaf44646ea3b450aa7829",
+				"DiscoKey":   "discokey:34824ac9df5c4c5e251c904d9fbdebad405008a2d18bc51ad5950eafef0cd330",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51912",
+					"10.65.0.27:51912",
+					"172.17.0.1:51912",
+					"172.19.0.1:51912",
+					"172.20.0.1:51912"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:30:36.75475336Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1008581452722319,
+				"StableID":   "n8DdF2jns811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c3c632a9519153d4f33a975ef9cade7a321451f65845b41329a627043bd077a",
+				"DiscoKey":   "discokey:fef1c431d8bdd764f364efe8d9dfc9eb6b8e18699dfe2aab4e4ec25a07e4ec6b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49399",
+					"10.65.0.27:49399",
+					"172.17.0.1:49399",
+					"172.19.0.1:49399",
+					"172.20.0.1:49399"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:30:37.300468924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4655736851755124,
+				"StableID":   "nmhXm7KbMd11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d11dac4aeca6bb34ea4e64d686799c6fca97e91cc689eba4060a36da0f4cae32",
+				"KeyExpiry":  "2026-11-08T18:30:37Z",
+				"DiscoKey":   "discokey:e0ba0bcef9432eeef592fa6dade559a10d1741bcf8cbba9af1f2091f86fff525",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49951",
+					"10.65.0.27:49951",
+					"172.17.0.1:49951",
+					"172.19.0.1:49951",
+					"172.20.0.1:49951"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:30:37.818654505Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7329705459394441,
+				"StableID":   "nrZs39wdEz11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e99e6cba82c38f5a505e3401d384750b9ef784b53e71cad7f8e1bb3413e46763",
+				"KeyExpiry":  "2026-11-08T18:30:38Z",
+				"DiscoKey":   "discokey:47c8fa02a310fbd9d2949a99051af5c43ac46a26a07c69cc2798e47f69068352",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40177",
+					"10.65.0.27:40177",
+					"172.17.0.1:40177",
+					"172.19.0.1:40177",
+					"172.20.0.1:40177"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:30:38.354009418Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         79729377405882,
+				"StableID":   "nTyX4dM7d111CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3931ec386abc6c1ca559a70fd4ca19d69920542b52554543319104514f2e6927",
+				"KeyExpiry":  "2026-11-08T18:30:38Z",
+				"DiscoKey":   "discokey:b96a12dca8f83ea66fe8e455935a8bae3c7303875bd64dfdf17c5d1260e0a75b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59975",
+					"10.65.0.27:59975",
+					"172.17.0.1:59975",
+					"172.19.0.1:59975",
+					"172.20.0.1:59975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:30:38.89461838Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1600955304356651": {
+				"ID":          1600955304356651,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5007491183657601,
+				"StableID":   "nJR1ZXJu6g11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       5007491183657601,
+				"Key":        "nodekey:47d178e9b9e748f3ae355d756df6434419f7e9bd55bbc6fdd25156d9a342363d",
+				"DiscoKey":   "discokey:2460330d63a76e823a3f98165fa17178474baf3a31eaff731969eb9ba46a0309",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54223",
+					"10.65.0.27:54223",
+					"172.17.0.1:54223",
+					"172.19.0.1:54223",
+					"172.20.0.1:54223"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:30:31.395098446Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:47d178e9b9e748f3ae355d756df6434419f7e9bd55bbc6fdd25156d9a342363d",
+			"MachineKey": "mkey:6bb8b7b68efda22a3d7d9b9b7f565e6dbb9c7ee4ae490c45c63b2345f8820c01",
+			"Peers": [{
+				"ID":         1600955304356651,
+				"StableID":   "na2s27P5WD11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:694893f9ac0523b45ab8fc1fd601b5d441c7a4c8fa7e28eb60a76521416fe116",
+				"DiscoKey":   "discokey:ff47fa2f29cd43a00292e51b8bf0999867fd5a6c88aaf49964d94ef3d9fe3159",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:60037",
+					"10.65.0.27:60037",
+					"172.17.0.1:60037",
+					"172.19.0.1:60037",
+					"172.20.0.1:60037"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:30:31.886043888Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6973050553104759,
+				"StableID":   "nxyhHQD7Tw11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6cd5fae42b55f6d8b7001477a548eb5a7aec0aa8a16cfdf944ea2799387c948",
+				"DiscoKey":   "discokey:49de72c308cdec88226e01edb1c33edffddd3dc3afd2d4a29645abbfad541725",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52458",
+					"10.65.0.27:52458",
+					"172.17.0.1:52458",
+					"172.19.0.1:52458",
+					"172.20.0.1:52458"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:30:32.422535926Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4428690401772650,
+				"StableID":   "nhS5UrBmab11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15fac8db70d5dbd3b27be9dbcdaa661332294805f913a2b186af07dd1a387854",
+				"DiscoKey":   "discokey:bb7470c216c71114a920d314ea855fbbfa860a4198790e64c3b4d87493d1641e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:48320",
+					"10.65.0.27:48320",
+					"172.17.0.1:48320",
+					"172.19.0.1:48320",
+					"172.20.0.1:48320"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:30:32.969308024Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         957733553012456,
+				"StableID":   "n1hZU73mU811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:05e508ebfad6e975e6003ada3235266c8498d9108649ea3798bfc31a59c49878",
+				"DiscoKey":   "discokey:0b2dd2ea0e752e5902f9f1436088b3da3cee3b0d992fcd64fab560a67b048621",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:47543",
+					"10.65.0.27:47543",
+					"172.17.0.1:47543",
+					"172.19.0.1:47543",
+					"172.20.0.1:47543"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:30:33.503510604Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8734601593202560,
+				"StableID":   "nbS6Z1BvCB21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ddff768b7e33513753a7b38139cd479da7b209817d953dc9a61f57e210a9d403",
+				"DiscoKey":   "discokey:93aeadd32435e3f75d5c3ec90297cb8c184410468b1b9fd83fde573693b73e7e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53457",
+					"10.65.0.27:53457",
+					"172.17.0.1:53457",
+					"172.19.0.1:53457",
+					"172.20.0.1:53457"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:30:34.050014495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2488164668628094,
+				"StableID":   "nRrvSGstRL11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5ce13076f2d0ed4b7a84934b2a3214d4aad67b1623869e511692c811b5db22a",
+				"DiscoKey":   "discokey:1adab87cde21a4395f5036c1907bf6f72047605537a07d13a7a6b23fc4a95241",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38627",
+					"10.65.0.27:38627",
+					"172.17.0.1:38627",
+					"172.19.0.1:38627",
+					"172.20.0.1:38627"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:30:34.598387549Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1579363899754636,
+				"StableID":   "n76YYGDJLD11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:932d3ac7832270215c5b8f0558f8bad279056ee4e2cde027398cfbc01a1fc66a",
+				"DiscoKey":   "discokey:98b2080865a81ffe871b4c0afbea4d43fcf1b09afcc248cc86185f064b21e04c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52139",
+					"10.65.0.27:52139",
+					"172.17.0.1:52139",
+					"172.19.0.1:52139",
+					"172.20.0.1:52139"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:30:35.134095492Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8669919100511088,
+				"StableID":   "nKUoAF5dhA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:502e27edb456871dfff33390d2cca574ef4ee79a1f56e3193b3f58a1ad376149",
+				"DiscoKey":   "discokey:4140be309403eda64e4d7c5f2bdb8817beec499a2a79ad2c10577b82ffe98351",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52374",
+					"10.65.0.27:52374",
+					"172.17.0.1:52374",
+					"172.19.0.1:52374",
+					"172.20.0.1:52374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:30:35.678520401Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         969928810643158,
+				"StableID":   "nKucdLPHa811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5dd36071b1b456463149c5b40f638cff3e0498394dab85728a153e9e8258657",
+				"DiscoKey":   "discokey:5cebf3fc7c1f56b675dc5343a203ee77a80c29ebfc2a7b2b77e5c257bef30536",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40855",
+					"10.65.0.27:40855",
+					"172.17.0.1:40855",
+					"172.19.0.1:40855",
+					"172.20.0.1:40855"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:30:36.218015923Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7820106284878854,
+				"StableID":   "nqtXh2wj4421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7b8a80bcb3b4c6d225d7bb66fe70dd52cf6f77e60acbaf44646ea3b450aa7829",
+				"DiscoKey":   "discokey:34824ac9df5c4c5e251c904d9fbdebad405008a2d18bc51ad5950eafef0cd330",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51912",
+					"10.65.0.27:51912",
+					"172.17.0.1:51912",
+					"172.19.0.1:51912",
+					"172.20.0.1:51912"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:30:36.75475336Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1008581452722319,
+				"StableID":   "n8DdF2jns811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c3c632a9519153d4f33a975ef9cade7a321451f65845b41329a627043bd077a",
+				"DiscoKey":   "discokey:fef1c431d8bdd764f364efe8d9dfc9eb6b8e18699dfe2aab4e4ec25a07e4ec6b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49399",
+					"10.65.0.27:49399",
+					"172.17.0.1:49399",
+					"172.19.0.1:49399",
+					"172.20.0.1:49399"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:30:37.300468924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4655736851755124,
+				"StableID":   "nmhXm7KbMd11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d11dac4aeca6bb34ea4e64d686799c6fca97e91cc689eba4060a36da0f4cae32",
+				"KeyExpiry":  "2026-11-08T18:30:37Z",
+				"DiscoKey":   "discokey:e0ba0bcef9432eeef592fa6dade559a10d1741bcf8cbba9af1f2091f86fff525",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49951",
+					"10.65.0.27:49951",
+					"172.17.0.1:49951",
+					"172.19.0.1:49951",
+					"172.20.0.1:49951"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:30:37.818654505Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7329705459394441,
+				"StableID":   "nrZs39wdEz11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e99e6cba82c38f5a505e3401d384750b9ef784b53e71cad7f8e1bb3413e46763",
+				"KeyExpiry":  "2026-11-08T18:30:38Z",
+				"DiscoKey":   "discokey:47c8fa02a310fbd9d2949a99051af5c43ac46a26a07c69cc2798e47f69068352",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40177",
+					"10.65.0.27:40177",
+					"172.17.0.1:40177",
+					"172.19.0.1:40177",
+					"172.20.0.1:40177"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:30:38.354009418Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         79729377405882,
+				"StableID":   "nTyX4dM7d111CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3931ec386abc6c1ca559a70fd4ca19d69920542b52554543319104514f2e6927",
+				"KeyExpiry":  "2026-11-08T18:30:38Z",
+				"DiscoKey":   "discokey:b96a12dca8f83ea66fe8e455935a8bae3c7303875bd64dfdf17c5d1260e0a75b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59975",
+					"10.65.0.27:59975",
+					"172.17.0.1:59975",
+					"172.19.0.1:59975",
+					"172.20.0.1:59975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:30:38.89461838Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5007491183657601": {
+				"ID":          5007491183657601,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         957733553012456,
+				"StableID":   "n1hZU73mU811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       957733553012456,
+				"Key":        "nodekey:05e508ebfad6e975e6003ada3235266c8498d9108649ea3798bfc31a59c49878",
+				"DiscoKey":   "discokey:0b2dd2ea0e752e5902f9f1436088b3da3cee3b0d992fcd64fab560a67b048621",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:47543",
+					"10.65.0.27:47543",
+					"172.17.0.1:47543",
+					"172.19.0.1:47543",
+					"172.20.0.1:47543"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:30:33.503510604Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:05e508ebfad6e975e6003ada3235266c8498d9108649ea3798bfc31a59c49878",
+			"MachineKey": "mkey:1a6538a36383b2e67192c3788e492afdd7340f98c38cf436144fd8f82f47d711",
+			"Peers": [{
+				"ID":         5007491183657601,
+				"StableID":   "nJR1ZXJu6g11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47d178e9b9e748f3ae355d756df6434419f7e9bd55bbc6fdd25156d9a342363d",
+				"DiscoKey":   "discokey:2460330d63a76e823a3f98165fa17178474baf3a31eaff731969eb9ba46a0309",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54223",
+					"10.65.0.27:54223",
+					"172.17.0.1:54223",
+					"172.19.0.1:54223",
+					"172.20.0.1:54223"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:30:31.395098446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1600955304356651,
+				"StableID":   "na2s27P5WD11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:694893f9ac0523b45ab8fc1fd601b5d441c7a4c8fa7e28eb60a76521416fe116",
+				"DiscoKey":   "discokey:ff47fa2f29cd43a00292e51b8bf0999867fd5a6c88aaf49964d94ef3d9fe3159",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:60037",
+					"10.65.0.27:60037",
+					"172.17.0.1:60037",
+					"172.19.0.1:60037",
+					"172.20.0.1:60037"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:30:31.886043888Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6973050553104759,
+				"StableID":   "nxyhHQD7Tw11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6cd5fae42b55f6d8b7001477a548eb5a7aec0aa8a16cfdf944ea2799387c948",
+				"DiscoKey":   "discokey:49de72c308cdec88226e01edb1c33edffddd3dc3afd2d4a29645abbfad541725",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52458",
+					"10.65.0.27:52458",
+					"172.17.0.1:52458",
+					"172.19.0.1:52458",
+					"172.20.0.1:52458"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:30:32.422535926Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4428690401772650,
+				"StableID":   "nhS5UrBmab11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15fac8db70d5dbd3b27be9dbcdaa661332294805f913a2b186af07dd1a387854",
+				"DiscoKey":   "discokey:bb7470c216c71114a920d314ea855fbbfa860a4198790e64c3b4d87493d1641e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:48320",
+					"10.65.0.27:48320",
+					"172.17.0.1:48320",
+					"172.19.0.1:48320",
+					"172.20.0.1:48320"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:30:32.969308024Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8734601593202560,
+				"StableID":   "nbS6Z1BvCB21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ddff768b7e33513753a7b38139cd479da7b209817d953dc9a61f57e210a9d403",
+				"DiscoKey":   "discokey:93aeadd32435e3f75d5c3ec90297cb8c184410468b1b9fd83fde573693b73e7e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53457",
+					"10.65.0.27:53457",
+					"172.17.0.1:53457",
+					"172.19.0.1:53457",
+					"172.20.0.1:53457"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:30:34.050014495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2488164668628094,
+				"StableID":   "nRrvSGstRL11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5ce13076f2d0ed4b7a84934b2a3214d4aad67b1623869e511692c811b5db22a",
+				"DiscoKey":   "discokey:1adab87cde21a4395f5036c1907bf6f72047605537a07d13a7a6b23fc4a95241",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38627",
+					"10.65.0.27:38627",
+					"172.17.0.1:38627",
+					"172.19.0.1:38627",
+					"172.20.0.1:38627"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:30:34.598387549Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1579363899754636,
+				"StableID":   "n76YYGDJLD11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:932d3ac7832270215c5b8f0558f8bad279056ee4e2cde027398cfbc01a1fc66a",
+				"DiscoKey":   "discokey:98b2080865a81ffe871b4c0afbea4d43fcf1b09afcc248cc86185f064b21e04c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52139",
+					"10.65.0.27:52139",
+					"172.17.0.1:52139",
+					"172.19.0.1:52139",
+					"172.20.0.1:52139"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:30:35.134095492Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8669919100511088,
+				"StableID":   "nKUoAF5dhA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:502e27edb456871dfff33390d2cca574ef4ee79a1f56e3193b3f58a1ad376149",
+				"DiscoKey":   "discokey:4140be309403eda64e4d7c5f2bdb8817beec499a2a79ad2c10577b82ffe98351",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52374",
+					"10.65.0.27:52374",
+					"172.17.0.1:52374",
+					"172.19.0.1:52374",
+					"172.20.0.1:52374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:30:35.678520401Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         969928810643158,
+				"StableID":   "nKucdLPHa811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5dd36071b1b456463149c5b40f638cff3e0498394dab85728a153e9e8258657",
+				"DiscoKey":   "discokey:5cebf3fc7c1f56b675dc5343a203ee77a80c29ebfc2a7b2b77e5c257bef30536",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40855",
+					"10.65.0.27:40855",
+					"172.17.0.1:40855",
+					"172.19.0.1:40855",
+					"172.20.0.1:40855"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:30:36.218015923Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7820106284878854,
+				"StableID":   "nqtXh2wj4421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7b8a80bcb3b4c6d225d7bb66fe70dd52cf6f77e60acbaf44646ea3b450aa7829",
+				"DiscoKey":   "discokey:34824ac9df5c4c5e251c904d9fbdebad405008a2d18bc51ad5950eafef0cd330",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51912",
+					"10.65.0.27:51912",
+					"172.17.0.1:51912",
+					"172.19.0.1:51912",
+					"172.20.0.1:51912"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:30:36.75475336Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1008581452722319,
+				"StableID":   "n8DdF2jns811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c3c632a9519153d4f33a975ef9cade7a321451f65845b41329a627043bd077a",
+				"DiscoKey":   "discokey:fef1c431d8bdd764f364efe8d9dfc9eb6b8e18699dfe2aab4e4ec25a07e4ec6b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49399",
+					"10.65.0.27:49399",
+					"172.17.0.1:49399",
+					"172.19.0.1:49399",
+					"172.20.0.1:49399"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:30:37.300468924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4655736851755124,
+				"StableID":   "nmhXm7KbMd11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d11dac4aeca6bb34ea4e64d686799c6fca97e91cc689eba4060a36da0f4cae32",
+				"KeyExpiry":  "2026-11-08T18:30:37Z",
+				"DiscoKey":   "discokey:e0ba0bcef9432eeef592fa6dade559a10d1741bcf8cbba9af1f2091f86fff525",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49951",
+					"10.65.0.27:49951",
+					"172.17.0.1:49951",
+					"172.19.0.1:49951",
+					"172.20.0.1:49951"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:30:37.818654505Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7329705459394441,
+				"StableID":   "nrZs39wdEz11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e99e6cba82c38f5a505e3401d384750b9ef784b53e71cad7f8e1bb3413e46763",
+				"KeyExpiry":  "2026-11-08T18:30:38Z",
+				"DiscoKey":   "discokey:47c8fa02a310fbd9d2949a99051af5c43ac46a26a07c69cc2798e47f69068352",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40177",
+					"10.65.0.27:40177",
+					"172.17.0.1:40177",
+					"172.19.0.1:40177",
+					"172.20.0.1:40177"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:30:38.354009418Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         79729377405882,
+				"StableID":   "nTyX4dM7d111CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3931ec386abc6c1ca559a70fd4ca19d69920542b52554543319104514f2e6927",
+				"KeyExpiry":  "2026-11-08T18:30:38Z",
+				"DiscoKey":   "discokey:b96a12dca8f83ea66fe8e455935a8bae3c7303875bd64dfdf17c5d1260e0a75b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59975",
+					"10.65.0.27:59975",
+					"172.17.0.1:59975",
+					"172.19.0.1:59975",
+					"172.20.0.1:59975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:30:38.89461838Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "957733553012456": {
+				"ID":          957733553012456,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4428690401772650,
+				"StableID":   "nhS5UrBmab11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       4428690401772650,
+				"Key":        "nodekey:15fac8db70d5dbd3b27be9dbcdaa661332294805f913a2b186af07dd1a387854",
+				"DiscoKey":   "discokey:bb7470c216c71114a920d314ea855fbbfa860a4198790e64c3b4d87493d1641e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:48320",
+					"10.65.0.27:48320",
+					"172.17.0.1:48320",
+					"172.19.0.1:48320",
+					"172.20.0.1:48320"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:30:32.969308024Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:15fac8db70d5dbd3b27be9dbcdaa661332294805f913a2b186af07dd1a387854",
+			"MachineKey": "mkey:436249bbc1004482ee5fa7ced657c750f5b80dcafe770b9f7d598f8b6ba97e44",
+			"Peers": [{
+				"ID":         5007491183657601,
+				"StableID":   "nJR1ZXJu6g11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47d178e9b9e748f3ae355d756df6434419f7e9bd55bbc6fdd25156d9a342363d",
+				"DiscoKey":   "discokey:2460330d63a76e823a3f98165fa17178474baf3a31eaff731969eb9ba46a0309",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54223",
+					"10.65.0.27:54223",
+					"172.17.0.1:54223",
+					"172.19.0.1:54223",
+					"172.20.0.1:54223"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:30:31.395098446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1600955304356651,
+				"StableID":   "na2s27P5WD11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:694893f9ac0523b45ab8fc1fd601b5d441c7a4c8fa7e28eb60a76521416fe116",
+				"DiscoKey":   "discokey:ff47fa2f29cd43a00292e51b8bf0999867fd5a6c88aaf49964d94ef3d9fe3159",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:60037",
+					"10.65.0.27:60037",
+					"172.17.0.1:60037",
+					"172.19.0.1:60037",
+					"172.20.0.1:60037"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:30:31.886043888Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6973050553104759,
+				"StableID":   "nxyhHQD7Tw11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6cd5fae42b55f6d8b7001477a548eb5a7aec0aa8a16cfdf944ea2799387c948",
+				"DiscoKey":   "discokey:49de72c308cdec88226e01edb1c33edffddd3dc3afd2d4a29645abbfad541725",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52458",
+					"10.65.0.27:52458",
+					"172.17.0.1:52458",
+					"172.19.0.1:52458",
+					"172.20.0.1:52458"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:30:32.422535926Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         957733553012456,
+				"StableID":   "n1hZU73mU811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:05e508ebfad6e975e6003ada3235266c8498d9108649ea3798bfc31a59c49878",
+				"DiscoKey":   "discokey:0b2dd2ea0e752e5902f9f1436088b3da3cee3b0d992fcd64fab560a67b048621",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:47543",
+					"10.65.0.27:47543",
+					"172.17.0.1:47543",
+					"172.19.0.1:47543",
+					"172.20.0.1:47543"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:30:33.503510604Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8734601593202560,
+				"StableID":   "nbS6Z1BvCB21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ddff768b7e33513753a7b38139cd479da7b209817d953dc9a61f57e210a9d403",
+				"DiscoKey":   "discokey:93aeadd32435e3f75d5c3ec90297cb8c184410468b1b9fd83fde573693b73e7e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53457",
+					"10.65.0.27:53457",
+					"172.17.0.1:53457",
+					"172.19.0.1:53457",
+					"172.20.0.1:53457"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:30:34.050014495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2488164668628094,
+				"StableID":   "nRrvSGstRL11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5ce13076f2d0ed4b7a84934b2a3214d4aad67b1623869e511692c811b5db22a",
+				"DiscoKey":   "discokey:1adab87cde21a4395f5036c1907bf6f72047605537a07d13a7a6b23fc4a95241",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38627",
+					"10.65.0.27:38627",
+					"172.17.0.1:38627",
+					"172.19.0.1:38627",
+					"172.20.0.1:38627"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:30:34.598387549Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1579363899754636,
+				"StableID":   "n76YYGDJLD11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:932d3ac7832270215c5b8f0558f8bad279056ee4e2cde027398cfbc01a1fc66a",
+				"DiscoKey":   "discokey:98b2080865a81ffe871b4c0afbea4d43fcf1b09afcc248cc86185f064b21e04c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52139",
+					"10.65.0.27:52139",
+					"172.17.0.1:52139",
+					"172.19.0.1:52139",
+					"172.20.0.1:52139"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:30:35.134095492Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8669919100511088,
+				"StableID":   "nKUoAF5dhA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:502e27edb456871dfff33390d2cca574ef4ee79a1f56e3193b3f58a1ad376149",
+				"DiscoKey":   "discokey:4140be309403eda64e4d7c5f2bdb8817beec499a2a79ad2c10577b82ffe98351",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52374",
+					"10.65.0.27:52374",
+					"172.17.0.1:52374",
+					"172.19.0.1:52374",
+					"172.20.0.1:52374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:30:35.678520401Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         969928810643158,
+				"StableID":   "nKucdLPHa811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5dd36071b1b456463149c5b40f638cff3e0498394dab85728a153e9e8258657",
+				"DiscoKey":   "discokey:5cebf3fc7c1f56b675dc5343a203ee77a80c29ebfc2a7b2b77e5c257bef30536",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40855",
+					"10.65.0.27:40855",
+					"172.17.0.1:40855",
+					"172.19.0.1:40855",
+					"172.20.0.1:40855"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:30:36.218015923Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7820106284878854,
+				"StableID":   "nqtXh2wj4421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7b8a80bcb3b4c6d225d7bb66fe70dd52cf6f77e60acbaf44646ea3b450aa7829",
+				"DiscoKey":   "discokey:34824ac9df5c4c5e251c904d9fbdebad405008a2d18bc51ad5950eafef0cd330",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51912",
+					"10.65.0.27:51912",
+					"172.17.0.1:51912",
+					"172.19.0.1:51912",
+					"172.20.0.1:51912"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:30:36.75475336Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1008581452722319,
+				"StableID":   "n8DdF2jns811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c3c632a9519153d4f33a975ef9cade7a321451f65845b41329a627043bd077a",
+				"DiscoKey":   "discokey:fef1c431d8bdd764f364efe8d9dfc9eb6b8e18699dfe2aab4e4ec25a07e4ec6b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49399",
+					"10.65.0.27:49399",
+					"172.17.0.1:49399",
+					"172.19.0.1:49399",
+					"172.20.0.1:49399"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:30:37.300468924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4655736851755124,
+				"StableID":   "nmhXm7KbMd11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d11dac4aeca6bb34ea4e64d686799c6fca97e91cc689eba4060a36da0f4cae32",
+				"KeyExpiry":  "2026-11-08T18:30:37Z",
+				"DiscoKey":   "discokey:e0ba0bcef9432eeef592fa6dade559a10d1741bcf8cbba9af1f2091f86fff525",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49951",
+					"10.65.0.27:49951",
+					"172.17.0.1:49951",
+					"172.19.0.1:49951",
+					"172.20.0.1:49951"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:30:37.818654505Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7329705459394441,
+				"StableID":   "nrZs39wdEz11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e99e6cba82c38f5a505e3401d384750b9ef784b53e71cad7f8e1bb3413e46763",
+				"KeyExpiry":  "2026-11-08T18:30:38Z",
+				"DiscoKey":   "discokey:47c8fa02a310fbd9d2949a99051af5c43ac46a26a07c69cc2798e47f69068352",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40177",
+					"10.65.0.27:40177",
+					"172.17.0.1:40177",
+					"172.19.0.1:40177",
+					"172.20.0.1:40177"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:30:38.354009418Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         79729377405882,
+				"StableID":   "nTyX4dM7d111CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3931ec386abc6c1ca559a70fd4ca19d69920542b52554543319104514f2e6927",
+				"KeyExpiry":  "2026-11-08T18:30:38Z",
+				"DiscoKey":   "discokey:b96a12dca8f83ea66fe8e455935a8bae3c7303875bd64dfdf17c5d1260e0a75b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59975",
+					"10.65.0.27:59975",
+					"172.17.0.1:59975",
+					"172.19.0.1:59975",
+					"172.20.0.1:59975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:30:38.89461838Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4428690401772650": {
+				"ID":          4428690401772650,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2488164668628094,
+				"StableID":   "nRrvSGstRL11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       2488164668628094,
+				"Key":        "nodekey:e5ce13076f2d0ed4b7a84934b2a3214d4aad67b1623869e511692c811b5db22a",
+				"DiscoKey":   "discokey:1adab87cde21a4395f5036c1907bf6f72047605537a07d13a7a6b23fc4a95241",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38627",
+					"10.65.0.27:38627",
+					"172.17.0.1:38627",
+					"172.19.0.1:38627",
+					"172.20.0.1:38627"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:30:34.598387549Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e5ce13076f2d0ed4b7a84934b2a3214d4aad67b1623869e511692c811b5db22a",
+			"MachineKey": "mkey:d9ee67f38ea60c6d50d7ffb066413d56a2c1e6cabe677d84bd91e8ee4dc76544",
+			"Peers": [{
+				"ID":         5007491183657601,
+				"StableID":   "nJR1ZXJu6g11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47d178e9b9e748f3ae355d756df6434419f7e9bd55bbc6fdd25156d9a342363d",
+				"DiscoKey":   "discokey:2460330d63a76e823a3f98165fa17178474baf3a31eaff731969eb9ba46a0309",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54223",
+					"10.65.0.27:54223",
+					"172.17.0.1:54223",
+					"172.19.0.1:54223",
+					"172.20.0.1:54223"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:30:31.395098446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1600955304356651,
+				"StableID":   "na2s27P5WD11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:694893f9ac0523b45ab8fc1fd601b5d441c7a4c8fa7e28eb60a76521416fe116",
+				"DiscoKey":   "discokey:ff47fa2f29cd43a00292e51b8bf0999867fd5a6c88aaf49964d94ef3d9fe3159",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:60037",
+					"10.65.0.27:60037",
+					"172.17.0.1:60037",
+					"172.19.0.1:60037",
+					"172.20.0.1:60037"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:30:31.886043888Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6973050553104759,
+				"StableID":   "nxyhHQD7Tw11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6cd5fae42b55f6d8b7001477a548eb5a7aec0aa8a16cfdf944ea2799387c948",
+				"DiscoKey":   "discokey:49de72c308cdec88226e01edb1c33edffddd3dc3afd2d4a29645abbfad541725",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52458",
+					"10.65.0.27:52458",
+					"172.17.0.1:52458",
+					"172.19.0.1:52458",
+					"172.20.0.1:52458"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:30:32.422535926Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4428690401772650,
+				"StableID":   "nhS5UrBmab11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15fac8db70d5dbd3b27be9dbcdaa661332294805f913a2b186af07dd1a387854",
+				"DiscoKey":   "discokey:bb7470c216c71114a920d314ea855fbbfa860a4198790e64c3b4d87493d1641e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:48320",
+					"10.65.0.27:48320",
+					"172.17.0.1:48320",
+					"172.19.0.1:48320",
+					"172.20.0.1:48320"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:30:32.969308024Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         957733553012456,
+				"StableID":   "n1hZU73mU811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:05e508ebfad6e975e6003ada3235266c8498d9108649ea3798bfc31a59c49878",
+				"DiscoKey":   "discokey:0b2dd2ea0e752e5902f9f1436088b3da3cee3b0d992fcd64fab560a67b048621",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:47543",
+					"10.65.0.27:47543",
+					"172.17.0.1:47543",
+					"172.19.0.1:47543",
+					"172.20.0.1:47543"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:30:33.503510604Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8734601593202560,
+				"StableID":   "nbS6Z1BvCB21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ddff768b7e33513753a7b38139cd479da7b209817d953dc9a61f57e210a9d403",
+				"DiscoKey":   "discokey:93aeadd32435e3f75d5c3ec90297cb8c184410468b1b9fd83fde573693b73e7e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53457",
+					"10.65.0.27:53457",
+					"172.17.0.1:53457",
+					"172.19.0.1:53457",
+					"172.20.0.1:53457"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:30:34.050014495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1579363899754636,
+				"StableID":   "n76YYGDJLD11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:932d3ac7832270215c5b8f0558f8bad279056ee4e2cde027398cfbc01a1fc66a",
+				"DiscoKey":   "discokey:98b2080865a81ffe871b4c0afbea4d43fcf1b09afcc248cc86185f064b21e04c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52139",
+					"10.65.0.27:52139",
+					"172.17.0.1:52139",
+					"172.19.0.1:52139",
+					"172.20.0.1:52139"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:30:35.134095492Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8669919100511088,
+				"StableID":   "nKUoAF5dhA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:502e27edb456871dfff33390d2cca574ef4ee79a1f56e3193b3f58a1ad376149",
+				"DiscoKey":   "discokey:4140be309403eda64e4d7c5f2bdb8817beec499a2a79ad2c10577b82ffe98351",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52374",
+					"10.65.0.27:52374",
+					"172.17.0.1:52374",
+					"172.19.0.1:52374",
+					"172.20.0.1:52374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:30:35.678520401Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         969928810643158,
+				"StableID":   "nKucdLPHa811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5dd36071b1b456463149c5b40f638cff3e0498394dab85728a153e9e8258657",
+				"DiscoKey":   "discokey:5cebf3fc7c1f56b675dc5343a203ee77a80c29ebfc2a7b2b77e5c257bef30536",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40855",
+					"10.65.0.27:40855",
+					"172.17.0.1:40855",
+					"172.19.0.1:40855",
+					"172.20.0.1:40855"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:30:36.218015923Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7820106284878854,
+				"StableID":   "nqtXh2wj4421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7b8a80bcb3b4c6d225d7bb66fe70dd52cf6f77e60acbaf44646ea3b450aa7829",
+				"DiscoKey":   "discokey:34824ac9df5c4c5e251c904d9fbdebad405008a2d18bc51ad5950eafef0cd330",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51912",
+					"10.65.0.27:51912",
+					"172.17.0.1:51912",
+					"172.19.0.1:51912",
+					"172.20.0.1:51912"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:30:36.75475336Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1008581452722319,
+				"StableID":   "n8DdF2jns811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c3c632a9519153d4f33a975ef9cade7a321451f65845b41329a627043bd077a",
+				"DiscoKey":   "discokey:fef1c431d8bdd764f364efe8d9dfc9eb6b8e18699dfe2aab4e4ec25a07e4ec6b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49399",
+					"10.65.0.27:49399",
+					"172.17.0.1:49399",
+					"172.19.0.1:49399",
+					"172.20.0.1:49399"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:30:37.300468924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4655736851755124,
+				"StableID":   "nmhXm7KbMd11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d11dac4aeca6bb34ea4e64d686799c6fca97e91cc689eba4060a36da0f4cae32",
+				"KeyExpiry":  "2026-11-08T18:30:37Z",
+				"DiscoKey":   "discokey:e0ba0bcef9432eeef592fa6dade559a10d1741bcf8cbba9af1f2091f86fff525",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49951",
+					"10.65.0.27:49951",
+					"172.17.0.1:49951",
+					"172.19.0.1:49951",
+					"172.20.0.1:49951"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:30:37.818654505Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7329705459394441,
+				"StableID":   "nrZs39wdEz11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e99e6cba82c38f5a505e3401d384750b9ef784b53e71cad7f8e1bb3413e46763",
+				"KeyExpiry":  "2026-11-08T18:30:38Z",
+				"DiscoKey":   "discokey:47c8fa02a310fbd9d2949a99051af5c43ac46a26a07c69cc2798e47f69068352",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40177",
+					"10.65.0.27:40177",
+					"172.17.0.1:40177",
+					"172.19.0.1:40177",
+					"172.20.0.1:40177"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:30:38.354009418Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         79729377405882,
+				"StableID":   "nTyX4dM7d111CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3931ec386abc6c1ca559a70fd4ca19d69920542b52554543319104514f2e6927",
+				"KeyExpiry":  "2026-11-08T18:30:38Z",
+				"DiscoKey":   "discokey:b96a12dca8f83ea66fe8e455935a8bae3c7303875bd64dfdf17c5d1260e0a75b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59975",
+					"10.65.0.27:59975",
+					"172.17.0.1:59975",
+					"172.19.0.1:59975",
+					"172.20.0.1:59975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:30:38.89461838Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2488164668628094": {
+				"ID":          2488164668628094,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8669919100511088,
+				"StableID":   "nKUoAF5dhA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       8669919100511088,
+				"Key":        "nodekey:502e27edb456871dfff33390d2cca574ef4ee79a1f56e3193b3f58a1ad376149",
+				"DiscoKey":   "discokey:4140be309403eda64e4d7c5f2bdb8817beec499a2a79ad2c10577b82ffe98351",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52374",
+					"10.65.0.27:52374",
+					"172.17.0.1:52374",
+					"172.19.0.1:52374",
+					"172.20.0.1:52374"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:30:35.678520401Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:502e27edb456871dfff33390d2cca574ef4ee79a1f56e3193b3f58a1ad376149",
+			"MachineKey": "mkey:36b4fe9a2c886365ee10a469407e8eead7ce697994792067b4d9bc4ce536d022",
+			"Peers": [{
+				"ID":         5007491183657601,
+				"StableID":   "nJR1ZXJu6g11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47d178e9b9e748f3ae355d756df6434419f7e9bd55bbc6fdd25156d9a342363d",
+				"DiscoKey":   "discokey:2460330d63a76e823a3f98165fa17178474baf3a31eaff731969eb9ba46a0309",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54223",
+					"10.65.0.27:54223",
+					"172.17.0.1:54223",
+					"172.19.0.1:54223",
+					"172.20.0.1:54223"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:30:31.395098446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1600955304356651,
+				"StableID":   "na2s27P5WD11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:694893f9ac0523b45ab8fc1fd601b5d441c7a4c8fa7e28eb60a76521416fe116",
+				"DiscoKey":   "discokey:ff47fa2f29cd43a00292e51b8bf0999867fd5a6c88aaf49964d94ef3d9fe3159",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:60037",
+					"10.65.0.27:60037",
+					"172.17.0.1:60037",
+					"172.19.0.1:60037",
+					"172.20.0.1:60037"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:30:31.886043888Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6973050553104759,
+				"StableID":   "nxyhHQD7Tw11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6cd5fae42b55f6d8b7001477a548eb5a7aec0aa8a16cfdf944ea2799387c948",
+				"DiscoKey":   "discokey:49de72c308cdec88226e01edb1c33edffddd3dc3afd2d4a29645abbfad541725",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52458",
+					"10.65.0.27:52458",
+					"172.17.0.1:52458",
+					"172.19.0.1:52458",
+					"172.20.0.1:52458"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:30:32.422535926Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4428690401772650,
+				"StableID":   "nhS5UrBmab11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15fac8db70d5dbd3b27be9dbcdaa661332294805f913a2b186af07dd1a387854",
+				"DiscoKey":   "discokey:bb7470c216c71114a920d314ea855fbbfa860a4198790e64c3b4d87493d1641e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:48320",
+					"10.65.0.27:48320",
+					"172.17.0.1:48320",
+					"172.19.0.1:48320",
+					"172.20.0.1:48320"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:30:32.969308024Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         957733553012456,
+				"StableID":   "n1hZU73mU811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:05e508ebfad6e975e6003ada3235266c8498d9108649ea3798bfc31a59c49878",
+				"DiscoKey":   "discokey:0b2dd2ea0e752e5902f9f1436088b3da3cee3b0d992fcd64fab560a67b048621",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:47543",
+					"10.65.0.27:47543",
+					"172.17.0.1:47543",
+					"172.19.0.1:47543",
+					"172.20.0.1:47543"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:30:33.503510604Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8734601593202560,
+				"StableID":   "nbS6Z1BvCB21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ddff768b7e33513753a7b38139cd479da7b209817d953dc9a61f57e210a9d403",
+				"DiscoKey":   "discokey:93aeadd32435e3f75d5c3ec90297cb8c184410468b1b9fd83fde573693b73e7e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53457",
+					"10.65.0.27:53457",
+					"172.17.0.1:53457",
+					"172.19.0.1:53457",
+					"172.20.0.1:53457"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:30:34.050014495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2488164668628094,
+				"StableID":   "nRrvSGstRL11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5ce13076f2d0ed4b7a84934b2a3214d4aad67b1623869e511692c811b5db22a",
+				"DiscoKey":   "discokey:1adab87cde21a4395f5036c1907bf6f72047605537a07d13a7a6b23fc4a95241",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38627",
+					"10.65.0.27:38627",
+					"172.17.0.1:38627",
+					"172.19.0.1:38627",
+					"172.20.0.1:38627"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:30:34.598387549Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1579363899754636,
+				"StableID":   "n76YYGDJLD11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:932d3ac7832270215c5b8f0558f8bad279056ee4e2cde027398cfbc01a1fc66a",
+				"DiscoKey":   "discokey:98b2080865a81ffe871b4c0afbea4d43fcf1b09afcc248cc86185f064b21e04c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52139",
+					"10.65.0.27:52139",
+					"172.17.0.1:52139",
+					"172.19.0.1:52139",
+					"172.20.0.1:52139"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:30:35.134095492Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         969928810643158,
+				"StableID":   "nKucdLPHa811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5dd36071b1b456463149c5b40f638cff3e0498394dab85728a153e9e8258657",
+				"DiscoKey":   "discokey:5cebf3fc7c1f56b675dc5343a203ee77a80c29ebfc2a7b2b77e5c257bef30536",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40855",
+					"10.65.0.27:40855",
+					"172.17.0.1:40855",
+					"172.19.0.1:40855",
+					"172.20.0.1:40855"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:30:36.218015923Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7820106284878854,
+				"StableID":   "nqtXh2wj4421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7b8a80bcb3b4c6d225d7bb66fe70dd52cf6f77e60acbaf44646ea3b450aa7829",
+				"DiscoKey":   "discokey:34824ac9df5c4c5e251c904d9fbdebad405008a2d18bc51ad5950eafef0cd330",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51912",
+					"10.65.0.27:51912",
+					"172.17.0.1:51912",
+					"172.19.0.1:51912",
+					"172.20.0.1:51912"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:30:36.75475336Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1008581452722319,
+				"StableID":   "n8DdF2jns811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c3c632a9519153d4f33a975ef9cade7a321451f65845b41329a627043bd077a",
+				"DiscoKey":   "discokey:fef1c431d8bdd764f364efe8d9dfc9eb6b8e18699dfe2aab4e4ec25a07e4ec6b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49399",
+					"10.65.0.27:49399",
+					"172.17.0.1:49399",
+					"172.19.0.1:49399",
+					"172.20.0.1:49399"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:30:37.300468924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4655736851755124,
+				"StableID":   "nmhXm7KbMd11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d11dac4aeca6bb34ea4e64d686799c6fca97e91cc689eba4060a36da0f4cae32",
+				"KeyExpiry":  "2026-11-08T18:30:37Z",
+				"DiscoKey":   "discokey:e0ba0bcef9432eeef592fa6dade559a10d1741bcf8cbba9af1f2091f86fff525",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49951",
+					"10.65.0.27:49951",
+					"172.17.0.1:49951",
+					"172.19.0.1:49951",
+					"172.20.0.1:49951"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:30:37.818654505Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7329705459394441,
+				"StableID":   "nrZs39wdEz11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e99e6cba82c38f5a505e3401d384750b9ef784b53e71cad7f8e1bb3413e46763",
+				"KeyExpiry":  "2026-11-08T18:30:38Z",
+				"DiscoKey":   "discokey:47c8fa02a310fbd9d2949a99051af5c43ac46a26a07c69cc2798e47f69068352",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40177",
+					"10.65.0.27:40177",
+					"172.17.0.1:40177",
+					"172.19.0.1:40177",
+					"172.20.0.1:40177"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:30:38.354009418Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         79729377405882,
+				"StableID":   "nTyX4dM7d111CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3931ec386abc6c1ca559a70fd4ca19d69920542b52554543319104514f2e6927",
+				"KeyExpiry":  "2026-11-08T18:30:38Z",
+				"DiscoKey":   "discokey:b96a12dca8f83ea66fe8e455935a8bae3c7303875bd64dfdf17c5d1260e0a75b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59975",
+					"10.65.0.27:59975",
+					"172.17.0.1:59975",
+					"172.19.0.1:59975",
+					"172.20.0.1:59975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:30:38.89461838Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8669919100511088": {
+				"ID":          8669919100511088,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7329705459394441,
+				"StableID":   "nrZs39wdEz11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e99e6cba82c38f5a505e3401d384750b9ef784b53e71cad7f8e1bb3413e46763",
+				"KeyExpiry":  "2026-11-08T18:30:38Z",
+				"DiscoKey":   "discokey:47c8fa02a310fbd9d2949a99051af5c43ac46a26a07c69cc2798e47f69068352",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40177",
+					"10.65.0.27:40177",
+					"172.17.0.1:40177",
+					"172.19.0.1:40177",
+					"172.20.0.1:40177"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:30:38.354009418Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e99e6cba82c38f5a505e3401d384750b9ef784b53e71cad7f8e1bb3413e46763",
+			"MachineKey": "mkey:734d095cb26a34eb31dfba8b4ca9ec83d86718cb1ea5e3b861b344aa5f238237",
+			"Peers": [{
+				"ID":         5007491183657601,
+				"StableID":   "nJR1ZXJu6g11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47d178e9b9e748f3ae355d756df6434419f7e9bd55bbc6fdd25156d9a342363d",
+				"DiscoKey":   "discokey:2460330d63a76e823a3f98165fa17178474baf3a31eaff731969eb9ba46a0309",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54223",
+					"10.65.0.27:54223",
+					"172.17.0.1:54223",
+					"172.19.0.1:54223",
+					"172.20.0.1:54223"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:30:31.395098446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1600955304356651,
+				"StableID":   "na2s27P5WD11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:694893f9ac0523b45ab8fc1fd601b5d441c7a4c8fa7e28eb60a76521416fe116",
+				"DiscoKey":   "discokey:ff47fa2f29cd43a00292e51b8bf0999867fd5a6c88aaf49964d94ef3d9fe3159",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:60037",
+					"10.65.0.27:60037",
+					"172.17.0.1:60037",
+					"172.19.0.1:60037",
+					"172.20.0.1:60037"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:30:31.886043888Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6973050553104759,
+				"StableID":   "nxyhHQD7Tw11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6cd5fae42b55f6d8b7001477a548eb5a7aec0aa8a16cfdf944ea2799387c948",
+				"DiscoKey":   "discokey:49de72c308cdec88226e01edb1c33edffddd3dc3afd2d4a29645abbfad541725",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52458",
+					"10.65.0.27:52458",
+					"172.17.0.1:52458",
+					"172.19.0.1:52458",
+					"172.20.0.1:52458"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:30:32.422535926Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4428690401772650,
+				"StableID":   "nhS5UrBmab11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15fac8db70d5dbd3b27be9dbcdaa661332294805f913a2b186af07dd1a387854",
+				"DiscoKey":   "discokey:bb7470c216c71114a920d314ea855fbbfa860a4198790e64c3b4d87493d1641e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:48320",
+					"10.65.0.27:48320",
+					"172.17.0.1:48320",
+					"172.19.0.1:48320",
+					"172.20.0.1:48320"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:30:32.969308024Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         957733553012456,
+				"StableID":   "n1hZU73mU811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:05e508ebfad6e975e6003ada3235266c8498d9108649ea3798bfc31a59c49878",
+				"DiscoKey":   "discokey:0b2dd2ea0e752e5902f9f1436088b3da3cee3b0d992fcd64fab560a67b048621",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:47543",
+					"10.65.0.27:47543",
+					"172.17.0.1:47543",
+					"172.19.0.1:47543",
+					"172.20.0.1:47543"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:30:33.503510604Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8734601593202560,
+				"StableID":   "nbS6Z1BvCB21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ddff768b7e33513753a7b38139cd479da7b209817d953dc9a61f57e210a9d403",
+				"DiscoKey":   "discokey:93aeadd32435e3f75d5c3ec90297cb8c184410468b1b9fd83fde573693b73e7e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53457",
+					"10.65.0.27:53457",
+					"172.17.0.1:53457",
+					"172.19.0.1:53457",
+					"172.20.0.1:53457"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:30:34.050014495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2488164668628094,
+				"StableID":   "nRrvSGstRL11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5ce13076f2d0ed4b7a84934b2a3214d4aad67b1623869e511692c811b5db22a",
+				"DiscoKey":   "discokey:1adab87cde21a4395f5036c1907bf6f72047605537a07d13a7a6b23fc4a95241",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38627",
+					"10.65.0.27:38627",
+					"172.17.0.1:38627",
+					"172.19.0.1:38627",
+					"172.20.0.1:38627"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:30:34.598387549Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1579363899754636,
+				"StableID":   "n76YYGDJLD11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:932d3ac7832270215c5b8f0558f8bad279056ee4e2cde027398cfbc01a1fc66a",
+				"DiscoKey":   "discokey:98b2080865a81ffe871b4c0afbea4d43fcf1b09afcc248cc86185f064b21e04c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52139",
+					"10.65.0.27:52139",
+					"172.17.0.1:52139",
+					"172.19.0.1:52139",
+					"172.20.0.1:52139"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:30:35.134095492Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8669919100511088,
+				"StableID":   "nKUoAF5dhA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:502e27edb456871dfff33390d2cca574ef4ee79a1f56e3193b3f58a1ad376149",
+				"DiscoKey":   "discokey:4140be309403eda64e4d7c5f2bdb8817beec499a2a79ad2c10577b82ffe98351",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52374",
+					"10.65.0.27:52374",
+					"172.17.0.1:52374",
+					"172.19.0.1:52374",
+					"172.20.0.1:52374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:30:35.678520401Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         969928810643158,
+				"StableID":   "nKucdLPHa811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5dd36071b1b456463149c5b40f638cff3e0498394dab85728a153e9e8258657",
+				"DiscoKey":   "discokey:5cebf3fc7c1f56b675dc5343a203ee77a80c29ebfc2a7b2b77e5c257bef30536",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40855",
+					"10.65.0.27:40855",
+					"172.17.0.1:40855",
+					"172.19.0.1:40855",
+					"172.20.0.1:40855"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:30:36.218015923Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7820106284878854,
+				"StableID":   "nqtXh2wj4421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7b8a80bcb3b4c6d225d7bb66fe70dd52cf6f77e60acbaf44646ea3b450aa7829",
+				"DiscoKey":   "discokey:34824ac9df5c4c5e251c904d9fbdebad405008a2d18bc51ad5950eafef0cd330",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51912",
+					"10.65.0.27:51912",
+					"172.17.0.1:51912",
+					"172.19.0.1:51912",
+					"172.20.0.1:51912"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:30:36.75475336Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1008581452722319,
+				"StableID":   "n8DdF2jns811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c3c632a9519153d4f33a975ef9cade7a321451f65845b41329a627043bd077a",
+				"DiscoKey":   "discokey:fef1c431d8bdd764f364efe8d9dfc9eb6b8e18699dfe2aab4e4ec25a07e4ec6b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49399",
+					"10.65.0.27:49399",
+					"172.17.0.1:49399",
+					"172.19.0.1:49399",
+					"172.20.0.1:49399"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:30:37.300468924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4655736851755124,
+				"StableID":   "nmhXm7KbMd11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d11dac4aeca6bb34ea4e64d686799c6fca97e91cc689eba4060a36da0f4cae32",
+				"KeyExpiry":  "2026-11-08T18:30:37Z",
+				"DiscoKey":   "discokey:e0ba0bcef9432eeef592fa6dade559a10d1741bcf8cbba9af1f2091f86fff525",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49951",
+					"10.65.0.27:49951",
+					"172.17.0.1:49951",
+					"172.19.0.1:49951",
+					"172.20.0.1:49951"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:30:37.818654505Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         79729377405882,
+				"StableID":   "nTyX4dM7d111CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3931ec386abc6c1ca559a70fd4ca19d69920542b52554543319104514f2e6927",
+				"KeyExpiry":  "2026-11-08T18:30:38Z",
+				"DiscoKey":   "discokey:b96a12dca8f83ea66fe8e455935a8bae3c7303875bd64dfdf17c5d1260e0a75b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59975",
+					"10.65.0.27:59975",
+					"172.17.0.1:59975",
+					"172.19.0.1:59975",
+					"172.20.0.1:59975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:30:38.89461838Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         969928810643158,
+				"StableID":   "nKucdLPHa811CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       969928810643158,
+				"Key":        "nodekey:c5dd36071b1b456463149c5b40f638cff3e0498394dab85728a153e9e8258657",
+				"DiscoKey":   "discokey:5cebf3fc7c1f56b675dc5343a203ee77a80c29ebfc2a7b2b77e5c257bef30536",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:40855",
+					"10.65.0.27:40855",
+					"172.17.0.1:40855",
+					"172.19.0.1:40855",
+					"172.20.0.1:40855"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:30:36.218015923Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c5dd36071b1b456463149c5b40f638cff3e0498394dab85728a153e9e8258657",
+			"MachineKey": "mkey:e58c8f94708cf5468521667993fc026532b7e3548a2a1b2a1bd1c3834bb45f67",
+			"Peers": [{
+				"ID":         5007491183657601,
+				"StableID":   "nJR1ZXJu6g11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47d178e9b9e748f3ae355d756df6434419f7e9bd55bbc6fdd25156d9a342363d",
+				"DiscoKey":   "discokey:2460330d63a76e823a3f98165fa17178474baf3a31eaff731969eb9ba46a0309",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54223",
+					"10.65.0.27:54223",
+					"172.17.0.1:54223",
+					"172.19.0.1:54223",
+					"172.20.0.1:54223"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:30:31.395098446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1600955304356651,
+				"StableID":   "na2s27P5WD11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:694893f9ac0523b45ab8fc1fd601b5d441c7a4c8fa7e28eb60a76521416fe116",
+				"DiscoKey":   "discokey:ff47fa2f29cd43a00292e51b8bf0999867fd5a6c88aaf49964d94ef3d9fe3159",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:60037",
+					"10.65.0.27:60037",
+					"172.17.0.1:60037",
+					"172.19.0.1:60037",
+					"172.20.0.1:60037"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:30:31.886043888Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6973050553104759,
+				"StableID":   "nxyhHQD7Tw11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6cd5fae42b55f6d8b7001477a548eb5a7aec0aa8a16cfdf944ea2799387c948",
+				"DiscoKey":   "discokey:49de72c308cdec88226e01edb1c33edffddd3dc3afd2d4a29645abbfad541725",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52458",
+					"10.65.0.27:52458",
+					"172.17.0.1:52458",
+					"172.19.0.1:52458",
+					"172.20.0.1:52458"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:30:32.422535926Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4428690401772650,
+				"StableID":   "nhS5UrBmab11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15fac8db70d5dbd3b27be9dbcdaa661332294805f913a2b186af07dd1a387854",
+				"DiscoKey":   "discokey:bb7470c216c71114a920d314ea855fbbfa860a4198790e64c3b4d87493d1641e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:48320",
+					"10.65.0.27:48320",
+					"172.17.0.1:48320",
+					"172.19.0.1:48320",
+					"172.20.0.1:48320"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:30:32.969308024Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         957733553012456,
+				"StableID":   "n1hZU73mU811CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:05e508ebfad6e975e6003ada3235266c8498d9108649ea3798bfc31a59c49878",
+				"DiscoKey":   "discokey:0b2dd2ea0e752e5902f9f1436088b3da3cee3b0d992fcd64fab560a67b048621",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:47543",
+					"10.65.0.27:47543",
+					"172.17.0.1:47543",
+					"172.19.0.1:47543",
+					"172.20.0.1:47543"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:30:33.503510604Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8734601593202560,
+				"StableID":   "nbS6Z1BvCB21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ddff768b7e33513753a7b38139cd479da7b209817d953dc9a61f57e210a9d403",
+				"DiscoKey":   "discokey:93aeadd32435e3f75d5c3ec90297cb8c184410468b1b9fd83fde573693b73e7e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53457",
+					"10.65.0.27:53457",
+					"172.17.0.1:53457",
+					"172.19.0.1:53457",
+					"172.20.0.1:53457"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:30:34.050014495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2488164668628094,
+				"StableID":   "nRrvSGstRL11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5ce13076f2d0ed4b7a84934b2a3214d4aad67b1623869e511692c811b5db22a",
+				"DiscoKey":   "discokey:1adab87cde21a4395f5036c1907bf6f72047605537a07d13a7a6b23fc4a95241",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38627",
+					"10.65.0.27:38627",
+					"172.17.0.1:38627",
+					"172.19.0.1:38627",
+					"172.20.0.1:38627"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:30:34.598387549Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1579363899754636,
+				"StableID":   "n76YYGDJLD11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:932d3ac7832270215c5b8f0558f8bad279056ee4e2cde027398cfbc01a1fc66a",
+				"DiscoKey":   "discokey:98b2080865a81ffe871b4c0afbea4d43fcf1b09afcc248cc86185f064b21e04c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52139",
+					"10.65.0.27:52139",
+					"172.17.0.1:52139",
+					"172.19.0.1:52139",
+					"172.20.0.1:52139"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:30:35.134095492Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8669919100511088,
+				"StableID":   "nKUoAF5dhA21CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:502e27edb456871dfff33390d2cca574ef4ee79a1f56e3193b3f58a1ad376149",
+				"DiscoKey":   "discokey:4140be309403eda64e4d7c5f2bdb8817beec499a2a79ad2c10577b82ffe98351",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52374",
+					"10.65.0.27:52374",
+					"172.17.0.1:52374",
+					"172.19.0.1:52374",
+					"172.20.0.1:52374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:30:35.678520401Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7820106284878854,
+				"StableID":   "nqtXh2wj4421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7b8a80bcb3b4c6d225d7bb66fe70dd52cf6f77e60acbaf44646ea3b450aa7829",
+				"DiscoKey":   "discokey:34824ac9df5c4c5e251c904d9fbdebad405008a2d18bc51ad5950eafef0cd330",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:51912",
+					"10.65.0.27:51912",
+					"172.17.0.1:51912",
+					"172.19.0.1:51912",
+					"172.20.0.1:51912"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:30:36.75475336Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1008581452722319,
+				"StableID":   "n8DdF2jns811CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8c3c632a9519153d4f33a975ef9cade7a321451f65845b41329a627043bd077a",
+				"DiscoKey":   "discokey:fef1c431d8bdd764f364efe8d9dfc9eb6b8e18699dfe2aab4e4ec25a07e4ec6b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:49399",
+					"10.65.0.27:49399",
+					"172.17.0.1:49399",
+					"172.19.0.1:49399",
+					"172.20.0.1:49399"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:30:37.300468924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4655736851755124,
+				"StableID":   "nmhXm7KbMd11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d11dac4aeca6bb34ea4e64d686799c6fca97e91cc689eba4060a36da0f4cae32",
+				"KeyExpiry":  "2026-11-08T18:30:37Z",
+				"DiscoKey":   "discokey:e0ba0bcef9432eeef592fa6dade559a10d1741bcf8cbba9af1f2091f86fff525",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:49951",
+					"10.65.0.27:49951",
+					"172.17.0.1:49951",
+					"172.19.0.1:49951",
+					"172.20.0.1:49951"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:30:37.818654505Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7329705459394441,
+				"StableID":   "nrZs39wdEz11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:e99e6cba82c38f5a505e3401d384750b9ef784b53e71cad7f8e1bb3413e46763",
+				"KeyExpiry":  "2026-11-08T18:30:38Z",
+				"DiscoKey":   "discokey:47c8fa02a310fbd9d2949a99051af5c43ac46a26a07c69cc2798e47f69068352",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:40177",
+					"10.65.0.27:40177",
+					"172.17.0.1:40177",
+					"172.19.0.1:40177",
+					"172.20.0.1:40177"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:30:38.354009418Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         79729377405882,
+				"StableID":   "nTyX4dM7d111CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3931ec386abc6c1ca559a70fd4ca19d69920542b52554543319104514f2e6927",
+				"KeyExpiry":  "2026-11-08T18:30:38Z",
+				"DiscoKey":   "discokey:b96a12dca8f83ea66fe8e455935a8bae3c7303875bd64dfdf17c5d1260e0a75b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:59975",
+					"10.65.0.27:59975",
+					"172.17.0.1:59975",
+					"172.19.0.1:59975",
+					"172.20.0.1:59975"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:30:38.89461838Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "969928810643158": {
+				"ID":          969928810643158,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/sshtest_results/sshtest-acceptenv-no-effect.hujson
+++ b/hscontrol/policy/v2/testdata/sshtest_results/sshtest-acceptenv-no-effect.hujson
@@ -1,0 +1,20102 @@
+// sshtest-acceptenv-no-effect
+//
+// rule has acceptEnv, sshTests still passes
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T18:31:14Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "sshtest-acceptenv-no-effect",
+	"description":    "rule has acceptEnv, sshTests still passes",
+	"category":       "sshtest",
+	"captured_at":    "2026-05-12T18:31:14.917171486Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                              \n  \n                                                                      \n                                               \n{\n\t\"category\":    \"sshtest\",\n\t\"description\": \"rule has acceptEnv, sshTests still passes\",\n\t\"id\":          \"sshtest-acceptenv-no-effect\",\n\t\"policy\": {\"ssh\": [{\n\t\t\"acceptEnv\": [\"GIT_EDITOR\", \"TERM\"],\n\t\t\"action\":    \"accept\",\n\t\t\"dst\":       [\"tag:server\"],\n\t\t\"src\":       [\"thor@example.org\"],\n\t\t\"users\":     [\"root\"]\n\t}], \"sshTests\": [{\n\t\t\"accept\": [\"root\"],\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    \"thor@example.org\"\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/sshtest/sshtest-acceptenv-no-effect.hujson",
+		"full_policy": {
+			"ssh": [{
+				"acceptEnv": ["GIT_EDITOR", "TERM"],
+				"action":    "accept",
+				"dst":       ["tag:server"],
+				"src":       ["thor@example.org"],
+				"users":     ["root"]
+			}],
+			"sshTests":  [{"accept": ["root"], "dst": ["tag:server"], "src": "thor@example.org"}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4667506974766359,
+				"StableID":   "nt1YEdVvSd11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       4667506974766359,
+				"Key":        "nodekey:3b7d072cb98b6d6774773a5165f2132f9d55b6b4d46b910e35b7a20965447b29",
+				"DiscoKey":   "discokey:8bc0ed9fcccced5638d6d75cda6e94e4384788feab31f83488c0389be373fd23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59438",
+					"10.65.0.27:59438",
+					"172.17.0.1:59438",
+					"172.19.0.1:59438",
+					"172.20.0.1:59438"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 44673},
+					{"Proto": "peerapi6", "Port": 44673},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:31:23.438919322Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3b7d072cb98b6d6774773a5165f2132f9d55b6b4d46b910e35b7a20965447b29",
+			"MachineKey": "mkey:e0a9e3a5ee52f70d47154c4c0f19a7991f6edb988f679542bd4007f1ff4afc57",
+			"Peers": [{
+				"ID":         7670108461148667,
+				"StableID":   "nScEf6kot221CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c2f5bfb985df504c47aa946680050a72bdf6c812b49183059793aa98030b331",
+				"DiscoKey":   "discokey:6d1d0f0458f5966eb167cb7e078a25bdf21007c1a9cdd8d7ebe8f2b3b0ab1a3f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47632",
+					"10.65.0.27:47632",
+					"172.17.0.1:47632",
+					"172.19.0.1:47632",
+					"172.20.0.1:47632"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:31:17.420686103Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7320267184871858,
+				"StableID":   "nqYt3M1NAz11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f02f389197bd1d118452e8758b2fcb44ad2beb3088a68fb0695f472d31f8b1b",
+				"DiscoKey":   "discokey:33267cbb9428670ab6cf6f216938f45d7285cc7ad632cb90d5fc554b14f9c34f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48235",
+					"10.65.0.27:48235",
+					"172.17.0.1:48235",
+					"172.19.0.1:48235",
+					"172.20.0.1:48235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:31:17.952478308Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6064876782325360,
+				"StableID":   "nBJS4g2oMp11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4f043bb6583ee4142b9216a0dd574b0ef2a839f8fa13e656aa5487ecf8c9262",
+				"DiscoKey":   "discokey:0b5399a0fda2d5705b425c517d97909c42a2fb72936d4e788cc61849b5c93a3f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60028",
+					"10.65.0.27:60028",
+					"172.17.0.1:60028",
+					"172.19.0.1:60028",
+					"172.20.0.1:60028"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:31:18.487616053Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6190575241389124,
+				"StableID":   "nPQFT2viLq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c06b267227d9b73a85495fb249f3b000ee88a5eac0da0216f6ae589e9effb72",
+				"DiscoKey":   "discokey:63a10159bf1cd849e9ac89670a8f3bafa8864a77b3a0474e3aaf02f4d3f7da74",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50799",
+					"10.65.0.27:50799",
+					"172.17.0.1:50799",
+					"172.19.0.1:50799",
+					"172.20.0.1:50799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:31:19.020986912Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2500128367141695,
+				"StableID":   "n2xyWh8KXL11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc14403de5b59f17c25ceffcbfbde553514bd0c83b3862a1066fd3a178966900",
+				"DiscoKey":   "discokey:e97c2ec9624e6491617befca8c2bc7fe18a7c555d3284736eea2c57a64719718",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38979",
+					"10.65.0.27:38979",
+					"172.17.0.1:38979",
+					"172.19.0.1:38979",
+					"172.20.0.1:38979"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:31:19.572625618Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6018771449274370,
+				"StableID":   "nHv9fMvuzo11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:75272388961ad9efc493bba573435087058742a534c6a7b0cd0020a5fba9f903",
+				"DiscoKey":   "discokey:00b87658bf77e6c7d3ae42fe86cab4230ac7869ff45c560c9ff4aea51b70966a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50649",
+					"10.65.0.27:50649",
+					"172.17.0.1:50649",
+					"172.19.0.1:50649",
+					"172.20.0.1:50649"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:31:20.115834221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5801633623032776,
+				"StableID":   "nDZNWV5aJn11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d445ba4f790f1ab053099b3a82e60082b5e5b41a247dc22bba6c735fe16ec24f",
+				"DiscoKey":   "discokey:f6fb2588937a6447413bc04f8ad4d498c7beb8bfe9adcf2f6baad0d882c0de39",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:34062",
+					"10.65.0.27:34062",
+					"172.17.0.1:34062",
+					"172.19.0.1:34062",
+					"172.20.0.1:34062"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:31:20.659145763Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8600735414959657,
+				"StableID":   "nUSYndjHAA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d66ecff48c953fe69cf0da5173bbc34fd97307a3118e886219f315611c45707",
+				"DiscoKey":   "discokey:f1453fe54b873844a5c21cab00f409d855a8cc8a0453cbfa666baf20a57f057b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:59992",
+					"10.65.0.27:59992",
+					"172.17.0.1:59992",
+					"172.19.0.1:59992",
+					"172.20.0.1:59992"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:31:21.201561884Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2484612260952031,
+				"StableID":   "nSn2MxYHQL11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:84a6dab801169010044a05832995689e030afc0f607076b8f298079bc69b8f3c",
+				"DiscoKey":   "discokey:06e16102adc9a946ed52b76f475f005ba5b6cc70e67462032aa5832310a5af15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34171",
+					"10.65.0.27:34171",
+					"172.17.0.1:34171",
+					"172.19.0.1:34171",
+					"172.20.0.1:34171"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:31:21.815156604Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5912791772272414,
+				"StableID":   "njjfWn1vAo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea18f42406c5fd8bf4a12593e1c896cda202c9b4f7374bfec9a89b8baf7ad852",
+				"DiscoKey":   "discokey:01c020f68d3ad4ad4b755b2acd7062095e779b5e01dd2544901305482f2d3300",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44665",
+					"10.65.0.27:44665",
+					"172.17.0.1:44665",
+					"172.19.0.1:44665",
+					"172.20.0.1:44665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:31:22.325651843Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6676408452980474,
+				"StableID":   "nsbnhsvk8u11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c7ca6fa6e3399e64976fcc16d503a8cc59a7380448551f159fc8bc469efa458",
+				"DiscoKey":   "discokey:7d9db05cad84fdefd39a9e1d005bb9f6e32030fadb1c732b69eaa2f7b3d3156a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38499",
+					"10.65.0.27:38499",
+					"172.17.0.1:38499",
+					"172.19.0.1:38499",
+					"172.20.0.1:38499"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:31:22.883829276Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7168621603691798,
+				"StableID":   "njRxKxXgyx11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:503db194f16af28c09dedfa8702935d75335fc61867678e6888e734cd1929554",
+				"KeyExpiry":  "2026-11-08T18:31:23Z",
+				"DiscoKey":   "discokey:6dec407066cdcff25f069f3dfed86c15a80789e88428f7fb4055a3b9eb04081e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43354",
+					"10.65.0.27:43354",
+					"172.17.0.1:43354",
+					"172.19.0.1:43354",
+					"172.20.0.1:43354"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:31:23.98046685Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4220893357629997,
+				"StableID":   "nk88FFiexZ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1260c1a536f9f3de750f1ae0a95155e60503bfccc0ac0dc041a3cf283117974b",
+				"KeyExpiry":  "2026-11-08T18:31:24Z",
+				"DiscoKey":   "discokey:18dbf645ab26e3a5d998c824ed14146ba1cd3a5499572db6aff614b0e5d9607e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47150",
+					"10.65.0.27:47150",
+					"172.17.0.1:47150",
+					"172.19.0.1:47150",
+					"172.20.0.1:47150"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:31:24.505613019Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5071721211584182,
+				"StableID":   "nXR7BwWzbg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:47e209951198d8a52b7011240da1b24d5a2f566db27d53c4c46b528b692bd613",
+				"KeyExpiry":  "2026-11-08T18:31:25Z",
+				"DiscoKey":   "discokey:e4582b9d1355eed3a618c201ff4ccb666c8e0611da5531d32714ea9e2891d975",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38513",
+					"10.65.0.27:38513",
+					"172.17.0.1:38513",
+					"172.19.0.1:38513",
+					"172.20.0.1:38513"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:31:25.037664448Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{
+				"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+				"sshUsers":   {"root": "root"},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				},
+				"acceptEnv": ["GIT_EDITOR", "TERM"]
+			}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4667506974766359": {
+				"ID":          4667506974766359,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		},
+		"ssh_rules": [{
+			"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+			"sshUsers":   {"root": "root"},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			},
+			"acceptEnv": ["GIT_EDITOR", "TERM"]
+		}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6018771449274370,
+				"StableID":   "nHv9fMvuzo11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       6018771449274370,
+				"Key":        "nodekey:75272388961ad9efc493bba573435087058742a534c6a7b0cd0020a5fba9f903",
+				"DiscoKey":   "discokey:00b87658bf77e6c7d3ae42fe86cab4230ac7869ff45c560c9ff4aea51b70966a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50649",
+					"10.65.0.27:50649",
+					"172.17.0.1:50649",
+					"172.19.0.1:50649",
+					"172.20.0.1:50649"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:31:20.115834221Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:75272388961ad9efc493bba573435087058742a534c6a7b0cd0020a5fba9f903",
+			"MachineKey": "mkey:7bba3d2f25d0f7cb85847ae12ca9ff8adb4143b6365dbac43e5d7712ab3a9e4b",
+			"Peers": [{
+				"ID":         7670108461148667,
+				"StableID":   "nScEf6kot221CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c2f5bfb985df504c47aa946680050a72bdf6c812b49183059793aa98030b331",
+				"DiscoKey":   "discokey:6d1d0f0458f5966eb167cb7e078a25bdf21007c1a9cdd8d7ebe8f2b3b0ab1a3f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47632",
+					"10.65.0.27:47632",
+					"172.17.0.1:47632",
+					"172.19.0.1:47632",
+					"172.20.0.1:47632"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:31:17.420686103Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7320267184871858,
+				"StableID":   "nqYt3M1NAz11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f02f389197bd1d118452e8758b2fcb44ad2beb3088a68fb0695f472d31f8b1b",
+				"DiscoKey":   "discokey:33267cbb9428670ab6cf6f216938f45d7285cc7ad632cb90d5fc554b14f9c34f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48235",
+					"10.65.0.27:48235",
+					"172.17.0.1:48235",
+					"172.19.0.1:48235",
+					"172.20.0.1:48235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:31:17.952478308Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6064876782325360,
+				"StableID":   "nBJS4g2oMp11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4f043bb6583ee4142b9216a0dd574b0ef2a839f8fa13e656aa5487ecf8c9262",
+				"DiscoKey":   "discokey:0b5399a0fda2d5705b425c517d97909c42a2fb72936d4e788cc61849b5c93a3f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60028",
+					"10.65.0.27:60028",
+					"172.17.0.1:60028",
+					"172.19.0.1:60028",
+					"172.20.0.1:60028"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:31:18.487616053Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6190575241389124,
+				"StableID":   "nPQFT2viLq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c06b267227d9b73a85495fb249f3b000ee88a5eac0da0216f6ae589e9effb72",
+				"DiscoKey":   "discokey:63a10159bf1cd849e9ac89670a8f3bafa8864a77b3a0474e3aaf02f4d3f7da74",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50799",
+					"10.65.0.27:50799",
+					"172.17.0.1:50799",
+					"172.19.0.1:50799",
+					"172.20.0.1:50799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:31:19.020986912Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2500128367141695,
+				"StableID":   "n2xyWh8KXL11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc14403de5b59f17c25ceffcbfbde553514bd0c83b3862a1066fd3a178966900",
+				"DiscoKey":   "discokey:e97c2ec9624e6491617befca8c2bc7fe18a7c555d3284736eea2c57a64719718",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38979",
+					"10.65.0.27:38979",
+					"172.17.0.1:38979",
+					"172.19.0.1:38979",
+					"172.20.0.1:38979"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:31:19.572625618Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5801633623032776,
+				"StableID":   "nDZNWV5aJn11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d445ba4f790f1ab053099b3a82e60082b5e5b41a247dc22bba6c735fe16ec24f",
+				"DiscoKey":   "discokey:f6fb2588937a6447413bc04f8ad4d498c7beb8bfe9adcf2f6baad0d882c0de39",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:34062",
+					"10.65.0.27:34062",
+					"172.17.0.1:34062",
+					"172.19.0.1:34062",
+					"172.20.0.1:34062"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:31:20.659145763Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8600735414959657,
+				"StableID":   "nUSYndjHAA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d66ecff48c953fe69cf0da5173bbc34fd97307a3118e886219f315611c45707",
+				"DiscoKey":   "discokey:f1453fe54b873844a5c21cab00f409d855a8cc8a0453cbfa666baf20a57f057b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:59992",
+					"10.65.0.27:59992",
+					"172.17.0.1:59992",
+					"172.19.0.1:59992",
+					"172.20.0.1:59992"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:31:21.201561884Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2484612260952031,
+				"StableID":   "nSn2MxYHQL11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:84a6dab801169010044a05832995689e030afc0f607076b8f298079bc69b8f3c",
+				"DiscoKey":   "discokey:06e16102adc9a946ed52b76f475f005ba5b6cc70e67462032aa5832310a5af15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34171",
+					"10.65.0.27:34171",
+					"172.17.0.1:34171",
+					"172.19.0.1:34171",
+					"172.20.0.1:34171"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:31:21.815156604Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5912791772272414,
+				"StableID":   "njjfWn1vAo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea18f42406c5fd8bf4a12593e1c896cda202c9b4f7374bfec9a89b8baf7ad852",
+				"DiscoKey":   "discokey:01c020f68d3ad4ad4b755b2acd7062095e779b5e01dd2544901305482f2d3300",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44665",
+					"10.65.0.27:44665",
+					"172.17.0.1:44665",
+					"172.19.0.1:44665",
+					"172.20.0.1:44665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:31:22.325651843Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6676408452980474,
+				"StableID":   "nsbnhsvk8u11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c7ca6fa6e3399e64976fcc16d503a8cc59a7380448551f159fc8bc469efa458",
+				"DiscoKey":   "discokey:7d9db05cad84fdefd39a9e1d005bb9f6e32030fadb1c732b69eaa2f7b3d3156a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38499",
+					"10.65.0.27:38499",
+					"172.17.0.1:38499",
+					"172.19.0.1:38499",
+					"172.20.0.1:38499"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:31:22.883829276Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4667506974766359,
+				"StableID":   "nt1YEdVvSd11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b7d072cb98b6d6774773a5165f2132f9d55b6b4d46b910e35b7a20965447b29",
+				"DiscoKey":   "discokey:8bc0ed9fcccced5638d6d75cda6e94e4384788feab31f83488c0389be373fd23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59438",
+					"10.65.0.27:59438",
+					"172.17.0.1:59438",
+					"172.19.0.1:59438",
+					"172.20.0.1:59438"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 44673},
+					{"Proto": "peerapi6", "Port": 44673}
+				]},
+				"Created":              "2026-05-12T18:31:23.438919322Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7168621603691798,
+				"StableID":   "njRxKxXgyx11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:503db194f16af28c09dedfa8702935d75335fc61867678e6888e734cd1929554",
+				"KeyExpiry":  "2026-11-08T18:31:23Z",
+				"DiscoKey":   "discokey:6dec407066cdcff25f069f3dfed86c15a80789e88428f7fb4055a3b9eb04081e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43354",
+					"10.65.0.27:43354",
+					"172.17.0.1:43354",
+					"172.19.0.1:43354",
+					"172.20.0.1:43354"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:31:23.98046685Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4220893357629997,
+				"StableID":   "nk88FFiexZ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1260c1a536f9f3de750f1ae0a95155e60503bfccc0ac0dc041a3cf283117974b",
+				"KeyExpiry":  "2026-11-08T18:31:24Z",
+				"DiscoKey":   "discokey:18dbf645ab26e3a5d998c824ed14146ba1cd3a5499572db6aff614b0e5d9607e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47150",
+					"10.65.0.27:47150",
+					"172.17.0.1:47150",
+					"172.19.0.1:47150",
+					"172.20.0.1:47150"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:31:24.505613019Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5071721211584182,
+				"StableID":   "nXR7BwWzbg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:47e209951198d8a52b7011240da1b24d5a2f566db27d53c4c46b528b692bd613",
+				"KeyExpiry":  "2026-11-08T18:31:25Z",
+				"DiscoKey":   "discokey:e4582b9d1355eed3a618c201ff4ccb666c8e0611da5531d32714ea9e2891d975",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38513",
+					"10.65.0.27:38513",
+					"172.17.0.1:38513",
+					"172.19.0.1:38513",
+					"172.20.0.1:38513"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:31:25.037664448Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6018771449274370": {
+				"ID":          6018771449274370,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5071721211584182,
+				"StableID":   "nXR7BwWzbg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:47e209951198d8a52b7011240da1b24d5a2f566db27d53c4c46b528b692bd613",
+				"KeyExpiry":  "2026-11-08T18:31:25Z",
+				"DiscoKey":   "discokey:e4582b9d1355eed3a618c201ff4ccb666c8e0611da5531d32714ea9e2891d975",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38513",
+					"10.65.0.27:38513",
+					"172.17.0.1:38513",
+					"172.19.0.1:38513",
+					"172.20.0.1:38513"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:31:25.037664448Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:47e209951198d8a52b7011240da1b24d5a2f566db27d53c4c46b528b692bd613",
+			"MachineKey": "mkey:b2f394324b884f2659e60f3278253e71f468535f5f914f6723ce0ace9a287d3e",
+			"Peers": [{
+				"ID":         7670108461148667,
+				"StableID":   "nScEf6kot221CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c2f5bfb985df504c47aa946680050a72bdf6c812b49183059793aa98030b331",
+				"DiscoKey":   "discokey:6d1d0f0458f5966eb167cb7e078a25bdf21007c1a9cdd8d7ebe8f2b3b0ab1a3f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47632",
+					"10.65.0.27:47632",
+					"172.17.0.1:47632",
+					"172.19.0.1:47632",
+					"172.20.0.1:47632"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:31:17.420686103Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7320267184871858,
+				"StableID":   "nqYt3M1NAz11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f02f389197bd1d118452e8758b2fcb44ad2beb3088a68fb0695f472d31f8b1b",
+				"DiscoKey":   "discokey:33267cbb9428670ab6cf6f216938f45d7285cc7ad632cb90d5fc554b14f9c34f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48235",
+					"10.65.0.27:48235",
+					"172.17.0.1:48235",
+					"172.19.0.1:48235",
+					"172.20.0.1:48235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:31:17.952478308Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6064876782325360,
+				"StableID":   "nBJS4g2oMp11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4f043bb6583ee4142b9216a0dd574b0ef2a839f8fa13e656aa5487ecf8c9262",
+				"DiscoKey":   "discokey:0b5399a0fda2d5705b425c517d97909c42a2fb72936d4e788cc61849b5c93a3f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60028",
+					"10.65.0.27:60028",
+					"172.17.0.1:60028",
+					"172.19.0.1:60028",
+					"172.20.0.1:60028"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:31:18.487616053Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6190575241389124,
+				"StableID":   "nPQFT2viLq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c06b267227d9b73a85495fb249f3b000ee88a5eac0da0216f6ae589e9effb72",
+				"DiscoKey":   "discokey:63a10159bf1cd849e9ac89670a8f3bafa8864a77b3a0474e3aaf02f4d3f7da74",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50799",
+					"10.65.0.27:50799",
+					"172.17.0.1:50799",
+					"172.19.0.1:50799",
+					"172.20.0.1:50799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:31:19.020986912Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2500128367141695,
+				"StableID":   "n2xyWh8KXL11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc14403de5b59f17c25ceffcbfbde553514bd0c83b3862a1066fd3a178966900",
+				"DiscoKey":   "discokey:e97c2ec9624e6491617befca8c2bc7fe18a7c555d3284736eea2c57a64719718",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38979",
+					"10.65.0.27:38979",
+					"172.17.0.1:38979",
+					"172.19.0.1:38979",
+					"172.20.0.1:38979"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:31:19.572625618Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6018771449274370,
+				"StableID":   "nHv9fMvuzo11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:75272388961ad9efc493bba573435087058742a534c6a7b0cd0020a5fba9f903",
+				"DiscoKey":   "discokey:00b87658bf77e6c7d3ae42fe86cab4230ac7869ff45c560c9ff4aea51b70966a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50649",
+					"10.65.0.27:50649",
+					"172.17.0.1:50649",
+					"172.19.0.1:50649",
+					"172.20.0.1:50649"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:31:20.115834221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5801633623032776,
+				"StableID":   "nDZNWV5aJn11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d445ba4f790f1ab053099b3a82e60082b5e5b41a247dc22bba6c735fe16ec24f",
+				"DiscoKey":   "discokey:f6fb2588937a6447413bc04f8ad4d498c7beb8bfe9adcf2f6baad0d882c0de39",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:34062",
+					"10.65.0.27:34062",
+					"172.17.0.1:34062",
+					"172.19.0.1:34062",
+					"172.20.0.1:34062"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:31:20.659145763Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8600735414959657,
+				"StableID":   "nUSYndjHAA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d66ecff48c953fe69cf0da5173bbc34fd97307a3118e886219f315611c45707",
+				"DiscoKey":   "discokey:f1453fe54b873844a5c21cab00f409d855a8cc8a0453cbfa666baf20a57f057b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:59992",
+					"10.65.0.27:59992",
+					"172.17.0.1:59992",
+					"172.19.0.1:59992",
+					"172.20.0.1:59992"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:31:21.201561884Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2484612260952031,
+				"StableID":   "nSn2MxYHQL11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:84a6dab801169010044a05832995689e030afc0f607076b8f298079bc69b8f3c",
+				"DiscoKey":   "discokey:06e16102adc9a946ed52b76f475f005ba5b6cc70e67462032aa5832310a5af15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34171",
+					"10.65.0.27:34171",
+					"172.17.0.1:34171",
+					"172.19.0.1:34171",
+					"172.20.0.1:34171"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:31:21.815156604Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5912791772272414,
+				"StableID":   "njjfWn1vAo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea18f42406c5fd8bf4a12593e1c896cda202c9b4f7374bfec9a89b8baf7ad852",
+				"DiscoKey":   "discokey:01c020f68d3ad4ad4b755b2acd7062095e779b5e01dd2544901305482f2d3300",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44665",
+					"10.65.0.27:44665",
+					"172.17.0.1:44665",
+					"172.19.0.1:44665",
+					"172.20.0.1:44665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:31:22.325651843Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6676408452980474,
+				"StableID":   "nsbnhsvk8u11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c7ca6fa6e3399e64976fcc16d503a8cc59a7380448551f159fc8bc469efa458",
+				"DiscoKey":   "discokey:7d9db05cad84fdefd39a9e1d005bb9f6e32030fadb1c732b69eaa2f7b3d3156a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38499",
+					"10.65.0.27:38499",
+					"172.17.0.1:38499",
+					"172.19.0.1:38499",
+					"172.20.0.1:38499"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:31:22.883829276Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4667506974766359,
+				"StableID":   "nt1YEdVvSd11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b7d072cb98b6d6774773a5165f2132f9d55b6b4d46b910e35b7a20965447b29",
+				"DiscoKey":   "discokey:8bc0ed9fcccced5638d6d75cda6e94e4384788feab31f83488c0389be373fd23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59438",
+					"10.65.0.27:59438",
+					"172.17.0.1:59438",
+					"172.19.0.1:59438",
+					"172.20.0.1:59438"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 44673},
+					{"Proto": "peerapi6", "Port": 44673}
+				]},
+				"Created":              "2026-05-12T18:31:23.438919322Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7168621603691798,
+				"StableID":   "njRxKxXgyx11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:503db194f16af28c09dedfa8702935d75335fc61867678e6888e734cd1929554",
+				"KeyExpiry":  "2026-11-08T18:31:23Z",
+				"DiscoKey":   "discokey:6dec407066cdcff25f069f3dfed86c15a80789e88428f7fb4055a3b9eb04081e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43354",
+					"10.65.0.27:43354",
+					"172.17.0.1:43354",
+					"172.19.0.1:43354",
+					"172.20.0.1:43354"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:31:23.98046685Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4220893357629997,
+				"StableID":   "nk88FFiexZ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1260c1a536f9f3de750f1ae0a95155e60503bfccc0ac0dc041a3cf283117974b",
+				"KeyExpiry":  "2026-11-08T18:31:24Z",
+				"DiscoKey":   "discokey:18dbf645ab26e3a5d998c824ed14146ba1cd3a5499572db6aff614b0e5d9607e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47150",
+					"10.65.0.27:47150",
+					"172.17.0.1:47150",
+					"172.19.0.1:47150",
+					"172.20.0.1:47150"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:31:24.505613019Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6064876782325360,
+				"StableID":   "nBJS4g2oMp11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       6064876782325360,
+				"Key":        "nodekey:e4f043bb6583ee4142b9216a0dd574b0ef2a839f8fa13e656aa5487ecf8c9262",
+				"DiscoKey":   "discokey:0b5399a0fda2d5705b425c517d97909c42a2fb72936d4e788cc61849b5c93a3f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60028",
+					"10.65.0.27:60028",
+					"172.17.0.1:60028",
+					"172.19.0.1:60028",
+					"172.20.0.1:60028"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:31:18.487616053Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e4f043bb6583ee4142b9216a0dd574b0ef2a839f8fa13e656aa5487ecf8c9262",
+			"MachineKey": "mkey:5a2fbc08a48568e2d5bb22ac8f1fc78feb8eaee2af21897f43a85922fc2bc13b",
+			"Peers": [{
+				"ID":         7670108461148667,
+				"StableID":   "nScEf6kot221CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c2f5bfb985df504c47aa946680050a72bdf6c812b49183059793aa98030b331",
+				"DiscoKey":   "discokey:6d1d0f0458f5966eb167cb7e078a25bdf21007c1a9cdd8d7ebe8f2b3b0ab1a3f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47632",
+					"10.65.0.27:47632",
+					"172.17.0.1:47632",
+					"172.19.0.1:47632",
+					"172.20.0.1:47632"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:31:17.420686103Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7320267184871858,
+				"StableID":   "nqYt3M1NAz11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f02f389197bd1d118452e8758b2fcb44ad2beb3088a68fb0695f472d31f8b1b",
+				"DiscoKey":   "discokey:33267cbb9428670ab6cf6f216938f45d7285cc7ad632cb90d5fc554b14f9c34f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48235",
+					"10.65.0.27:48235",
+					"172.17.0.1:48235",
+					"172.19.0.1:48235",
+					"172.20.0.1:48235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:31:17.952478308Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6190575241389124,
+				"StableID":   "nPQFT2viLq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c06b267227d9b73a85495fb249f3b000ee88a5eac0da0216f6ae589e9effb72",
+				"DiscoKey":   "discokey:63a10159bf1cd849e9ac89670a8f3bafa8864a77b3a0474e3aaf02f4d3f7da74",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50799",
+					"10.65.0.27:50799",
+					"172.17.0.1:50799",
+					"172.19.0.1:50799",
+					"172.20.0.1:50799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:31:19.020986912Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2500128367141695,
+				"StableID":   "n2xyWh8KXL11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc14403de5b59f17c25ceffcbfbde553514bd0c83b3862a1066fd3a178966900",
+				"DiscoKey":   "discokey:e97c2ec9624e6491617befca8c2bc7fe18a7c555d3284736eea2c57a64719718",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38979",
+					"10.65.0.27:38979",
+					"172.17.0.1:38979",
+					"172.19.0.1:38979",
+					"172.20.0.1:38979"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:31:19.572625618Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6018771449274370,
+				"StableID":   "nHv9fMvuzo11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:75272388961ad9efc493bba573435087058742a534c6a7b0cd0020a5fba9f903",
+				"DiscoKey":   "discokey:00b87658bf77e6c7d3ae42fe86cab4230ac7869ff45c560c9ff4aea51b70966a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50649",
+					"10.65.0.27:50649",
+					"172.17.0.1:50649",
+					"172.19.0.1:50649",
+					"172.20.0.1:50649"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:31:20.115834221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5801633623032776,
+				"StableID":   "nDZNWV5aJn11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d445ba4f790f1ab053099b3a82e60082b5e5b41a247dc22bba6c735fe16ec24f",
+				"DiscoKey":   "discokey:f6fb2588937a6447413bc04f8ad4d498c7beb8bfe9adcf2f6baad0d882c0de39",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:34062",
+					"10.65.0.27:34062",
+					"172.17.0.1:34062",
+					"172.19.0.1:34062",
+					"172.20.0.1:34062"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:31:20.659145763Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8600735414959657,
+				"StableID":   "nUSYndjHAA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d66ecff48c953fe69cf0da5173bbc34fd97307a3118e886219f315611c45707",
+				"DiscoKey":   "discokey:f1453fe54b873844a5c21cab00f409d855a8cc8a0453cbfa666baf20a57f057b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:59992",
+					"10.65.0.27:59992",
+					"172.17.0.1:59992",
+					"172.19.0.1:59992",
+					"172.20.0.1:59992"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:31:21.201561884Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2484612260952031,
+				"StableID":   "nSn2MxYHQL11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:84a6dab801169010044a05832995689e030afc0f607076b8f298079bc69b8f3c",
+				"DiscoKey":   "discokey:06e16102adc9a946ed52b76f475f005ba5b6cc70e67462032aa5832310a5af15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34171",
+					"10.65.0.27:34171",
+					"172.17.0.1:34171",
+					"172.19.0.1:34171",
+					"172.20.0.1:34171"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:31:21.815156604Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5912791772272414,
+				"StableID":   "njjfWn1vAo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea18f42406c5fd8bf4a12593e1c896cda202c9b4f7374bfec9a89b8baf7ad852",
+				"DiscoKey":   "discokey:01c020f68d3ad4ad4b755b2acd7062095e779b5e01dd2544901305482f2d3300",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44665",
+					"10.65.0.27:44665",
+					"172.17.0.1:44665",
+					"172.19.0.1:44665",
+					"172.20.0.1:44665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:31:22.325651843Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6676408452980474,
+				"StableID":   "nsbnhsvk8u11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c7ca6fa6e3399e64976fcc16d503a8cc59a7380448551f159fc8bc469efa458",
+				"DiscoKey":   "discokey:7d9db05cad84fdefd39a9e1d005bb9f6e32030fadb1c732b69eaa2f7b3d3156a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38499",
+					"10.65.0.27:38499",
+					"172.17.0.1:38499",
+					"172.19.0.1:38499",
+					"172.20.0.1:38499"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:31:22.883829276Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4667506974766359,
+				"StableID":   "nt1YEdVvSd11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b7d072cb98b6d6774773a5165f2132f9d55b6b4d46b910e35b7a20965447b29",
+				"DiscoKey":   "discokey:8bc0ed9fcccced5638d6d75cda6e94e4384788feab31f83488c0389be373fd23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59438",
+					"10.65.0.27:59438",
+					"172.17.0.1:59438",
+					"172.19.0.1:59438",
+					"172.20.0.1:59438"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 44673},
+					{"Proto": "peerapi6", "Port": 44673}
+				]},
+				"Created":              "2026-05-12T18:31:23.438919322Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7168621603691798,
+				"StableID":   "njRxKxXgyx11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:503db194f16af28c09dedfa8702935d75335fc61867678e6888e734cd1929554",
+				"KeyExpiry":  "2026-11-08T18:31:23Z",
+				"DiscoKey":   "discokey:6dec407066cdcff25f069f3dfed86c15a80789e88428f7fb4055a3b9eb04081e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43354",
+					"10.65.0.27:43354",
+					"172.17.0.1:43354",
+					"172.19.0.1:43354",
+					"172.20.0.1:43354"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:31:23.98046685Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4220893357629997,
+				"StableID":   "nk88FFiexZ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1260c1a536f9f3de750f1ae0a95155e60503bfccc0ac0dc041a3cf283117974b",
+				"KeyExpiry":  "2026-11-08T18:31:24Z",
+				"DiscoKey":   "discokey:18dbf645ab26e3a5d998c824ed14146ba1cd3a5499572db6aff614b0e5d9607e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47150",
+					"10.65.0.27:47150",
+					"172.17.0.1:47150",
+					"172.19.0.1:47150",
+					"172.20.0.1:47150"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:31:24.505613019Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5071721211584182,
+				"StableID":   "nXR7BwWzbg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:47e209951198d8a52b7011240da1b24d5a2f566db27d53c4c46b528b692bd613",
+				"KeyExpiry":  "2026-11-08T18:31:25Z",
+				"DiscoKey":   "discokey:e4582b9d1355eed3a618c201ff4ccb666c8e0611da5531d32714ea9e2891d975",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38513",
+					"10.65.0.27:38513",
+					"172.17.0.1:38513",
+					"172.19.0.1:38513",
+					"172.20.0.1:38513"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:31:25.037664448Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6064876782325360": {
+				"ID":          6064876782325360,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8600735414959657,
+				"StableID":   "nUSYndjHAA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       8600735414959657,
+				"Key":        "nodekey:4d66ecff48c953fe69cf0da5173bbc34fd97307a3118e886219f315611c45707",
+				"DiscoKey":   "discokey:f1453fe54b873844a5c21cab00f409d855a8cc8a0453cbfa666baf20a57f057b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:59992",
+					"10.65.0.27:59992",
+					"172.17.0.1:59992",
+					"172.19.0.1:59992",
+					"172.20.0.1:59992"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:31:21.201561884Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4d66ecff48c953fe69cf0da5173bbc34fd97307a3118e886219f315611c45707",
+			"MachineKey": "mkey:ffa77d3b47bc18ffcfc10f60d615b45ff7e9407c8ebd131290e09238cc772c4c",
+			"Peers": [{
+				"ID":         7670108461148667,
+				"StableID":   "nScEf6kot221CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c2f5bfb985df504c47aa946680050a72bdf6c812b49183059793aa98030b331",
+				"DiscoKey":   "discokey:6d1d0f0458f5966eb167cb7e078a25bdf21007c1a9cdd8d7ebe8f2b3b0ab1a3f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47632",
+					"10.65.0.27:47632",
+					"172.17.0.1:47632",
+					"172.19.0.1:47632",
+					"172.20.0.1:47632"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:31:17.420686103Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7320267184871858,
+				"StableID":   "nqYt3M1NAz11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f02f389197bd1d118452e8758b2fcb44ad2beb3088a68fb0695f472d31f8b1b",
+				"DiscoKey":   "discokey:33267cbb9428670ab6cf6f216938f45d7285cc7ad632cb90d5fc554b14f9c34f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48235",
+					"10.65.0.27:48235",
+					"172.17.0.1:48235",
+					"172.19.0.1:48235",
+					"172.20.0.1:48235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:31:17.952478308Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6064876782325360,
+				"StableID":   "nBJS4g2oMp11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4f043bb6583ee4142b9216a0dd574b0ef2a839f8fa13e656aa5487ecf8c9262",
+				"DiscoKey":   "discokey:0b5399a0fda2d5705b425c517d97909c42a2fb72936d4e788cc61849b5c93a3f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60028",
+					"10.65.0.27:60028",
+					"172.17.0.1:60028",
+					"172.19.0.1:60028",
+					"172.20.0.1:60028"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:31:18.487616053Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6190575241389124,
+				"StableID":   "nPQFT2viLq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c06b267227d9b73a85495fb249f3b000ee88a5eac0da0216f6ae589e9effb72",
+				"DiscoKey":   "discokey:63a10159bf1cd849e9ac89670a8f3bafa8864a77b3a0474e3aaf02f4d3f7da74",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50799",
+					"10.65.0.27:50799",
+					"172.17.0.1:50799",
+					"172.19.0.1:50799",
+					"172.20.0.1:50799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:31:19.020986912Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2500128367141695,
+				"StableID":   "n2xyWh8KXL11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc14403de5b59f17c25ceffcbfbde553514bd0c83b3862a1066fd3a178966900",
+				"DiscoKey":   "discokey:e97c2ec9624e6491617befca8c2bc7fe18a7c555d3284736eea2c57a64719718",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38979",
+					"10.65.0.27:38979",
+					"172.17.0.1:38979",
+					"172.19.0.1:38979",
+					"172.20.0.1:38979"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:31:19.572625618Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6018771449274370,
+				"StableID":   "nHv9fMvuzo11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:75272388961ad9efc493bba573435087058742a534c6a7b0cd0020a5fba9f903",
+				"DiscoKey":   "discokey:00b87658bf77e6c7d3ae42fe86cab4230ac7869ff45c560c9ff4aea51b70966a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50649",
+					"10.65.0.27:50649",
+					"172.17.0.1:50649",
+					"172.19.0.1:50649",
+					"172.20.0.1:50649"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:31:20.115834221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5801633623032776,
+				"StableID":   "nDZNWV5aJn11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d445ba4f790f1ab053099b3a82e60082b5e5b41a247dc22bba6c735fe16ec24f",
+				"DiscoKey":   "discokey:f6fb2588937a6447413bc04f8ad4d498c7beb8bfe9adcf2f6baad0d882c0de39",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:34062",
+					"10.65.0.27:34062",
+					"172.17.0.1:34062",
+					"172.19.0.1:34062",
+					"172.20.0.1:34062"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:31:20.659145763Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2484612260952031,
+				"StableID":   "nSn2MxYHQL11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:84a6dab801169010044a05832995689e030afc0f607076b8f298079bc69b8f3c",
+				"DiscoKey":   "discokey:06e16102adc9a946ed52b76f475f005ba5b6cc70e67462032aa5832310a5af15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34171",
+					"10.65.0.27:34171",
+					"172.17.0.1:34171",
+					"172.19.0.1:34171",
+					"172.20.0.1:34171"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:31:21.815156604Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5912791772272414,
+				"StableID":   "njjfWn1vAo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea18f42406c5fd8bf4a12593e1c896cda202c9b4f7374bfec9a89b8baf7ad852",
+				"DiscoKey":   "discokey:01c020f68d3ad4ad4b755b2acd7062095e779b5e01dd2544901305482f2d3300",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44665",
+					"10.65.0.27:44665",
+					"172.17.0.1:44665",
+					"172.19.0.1:44665",
+					"172.20.0.1:44665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:31:22.325651843Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6676408452980474,
+				"StableID":   "nsbnhsvk8u11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c7ca6fa6e3399e64976fcc16d503a8cc59a7380448551f159fc8bc469efa458",
+				"DiscoKey":   "discokey:7d9db05cad84fdefd39a9e1d005bb9f6e32030fadb1c732b69eaa2f7b3d3156a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38499",
+					"10.65.0.27:38499",
+					"172.17.0.1:38499",
+					"172.19.0.1:38499",
+					"172.20.0.1:38499"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:31:22.883829276Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4667506974766359,
+				"StableID":   "nt1YEdVvSd11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b7d072cb98b6d6774773a5165f2132f9d55b6b4d46b910e35b7a20965447b29",
+				"DiscoKey":   "discokey:8bc0ed9fcccced5638d6d75cda6e94e4384788feab31f83488c0389be373fd23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59438",
+					"10.65.0.27:59438",
+					"172.17.0.1:59438",
+					"172.19.0.1:59438",
+					"172.20.0.1:59438"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 44673},
+					{"Proto": "peerapi6", "Port": 44673}
+				]},
+				"Created":              "2026-05-12T18:31:23.438919322Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7168621603691798,
+				"StableID":   "njRxKxXgyx11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:503db194f16af28c09dedfa8702935d75335fc61867678e6888e734cd1929554",
+				"KeyExpiry":  "2026-11-08T18:31:23Z",
+				"DiscoKey":   "discokey:6dec407066cdcff25f069f3dfed86c15a80789e88428f7fb4055a3b9eb04081e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43354",
+					"10.65.0.27:43354",
+					"172.17.0.1:43354",
+					"172.19.0.1:43354",
+					"172.20.0.1:43354"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:31:23.98046685Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4220893357629997,
+				"StableID":   "nk88FFiexZ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1260c1a536f9f3de750f1ae0a95155e60503bfccc0ac0dc041a3cf283117974b",
+				"KeyExpiry":  "2026-11-08T18:31:24Z",
+				"DiscoKey":   "discokey:18dbf645ab26e3a5d998c824ed14146ba1cd3a5499572db6aff614b0e5d9607e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47150",
+					"10.65.0.27:47150",
+					"172.17.0.1:47150",
+					"172.19.0.1:47150",
+					"172.20.0.1:47150"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:31:24.505613019Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5071721211584182,
+				"StableID":   "nXR7BwWzbg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:47e209951198d8a52b7011240da1b24d5a2f566db27d53c4c46b528b692bd613",
+				"KeyExpiry":  "2026-11-08T18:31:25Z",
+				"DiscoKey":   "discokey:e4582b9d1355eed3a618c201ff4ccb666c8e0611da5531d32714ea9e2891d975",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38513",
+					"10.65.0.27:38513",
+					"172.17.0.1:38513",
+					"172.19.0.1:38513",
+					"172.20.0.1:38513"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:31:25.037664448Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8600735414959657": {
+				"ID":          8600735414959657,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7168621603691798,
+				"StableID":   "njRxKxXgyx11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:503db194f16af28c09dedfa8702935d75335fc61867678e6888e734cd1929554",
+				"KeyExpiry":  "2026-11-08T18:31:23Z",
+				"DiscoKey":   "discokey:6dec407066cdcff25f069f3dfed86c15a80789e88428f7fb4055a3b9eb04081e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43354",
+					"10.65.0.27:43354",
+					"172.17.0.1:43354",
+					"172.19.0.1:43354",
+					"172.20.0.1:43354"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:31:23.98046685Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:503db194f16af28c09dedfa8702935d75335fc61867678e6888e734cd1929554",
+			"MachineKey": "mkey:470e98906e1199e86615425c3a005716a49e401349e42dd4b5502e5df3ab0f62",
+			"Peers": [{
+				"ID":         7670108461148667,
+				"StableID":   "nScEf6kot221CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c2f5bfb985df504c47aa946680050a72bdf6c812b49183059793aa98030b331",
+				"DiscoKey":   "discokey:6d1d0f0458f5966eb167cb7e078a25bdf21007c1a9cdd8d7ebe8f2b3b0ab1a3f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47632",
+					"10.65.0.27:47632",
+					"172.17.0.1:47632",
+					"172.19.0.1:47632",
+					"172.20.0.1:47632"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:31:17.420686103Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7320267184871858,
+				"StableID":   "nqYt3M1NAz11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f02f389197bd1d118452e8758b2fcb44ad2beb3088a68fb0695f472d31f8b1b",
+				"DiscoKey":   "discokey:33267cbb9428670ab6cf6f216938f45d7285cc7ad632cb90d5fc554b14f9c34f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48235",
+					"10.65.0.27:48235",
+					"172.17.0.1:48235",
+					"172.19.0.1:48235",
+					"172.20.0.1:48235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:31:17.952478308Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6064876782325360,
+				"StableID":   "nBJS4g2oMp11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4f043bb6583ee4142b9216a0dd574b0ef2a839f8fa13e656aa5487ecf8c9262",
+				"DiscoKey":   "discokey:0b5399a0fda2d5705b425c517d97909c42a2fb72936d4e788cc61849b5c93a3f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60028",
+					"10.65.0.27:60028",
+					"172.17.0.1:60028",
+					"172.19.0.1:60028",
+					"172.20.0.1:60028"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:31:18.487616053Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6190575241389124,
+				"StableID":   "nPQFT2viLq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c06b267227d9b73a85495fb249f3b000ee88a5eac0da0216f6ae589e9effb72",
+				"DiscoKey":   "discokey:63a10159bf1cd849e9ac89670a8f3bafa8864a77b3a0474e3aaf02f4d3f7da74",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50799",
+					"10.65.0.27:50799",
+					"172.17.0.1:50799",
+					"172.19.0.1:50799",
+					"172.20.0.1:50799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:31:19.020986912Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2500128367141695,
+				"StableID":   "n2xyWh8KXL11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc14403de5b59f17c25ceffcbfbde553514bd0c83b3862a1066fd3a178966900",
+				"DiscoKey":   "discokey:e97c2ec9624e6491617befca8c2bc7fe18a7c555d3284736eea2c57a64719718",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38979",
+					"10.65.0.27:38979",
+					"172.17.0.1:38979",
+					"172.19.0.1:38979",
+					"172.20.0.1:38979"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:31:19.572625618Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6018771449274370,
+				"StableID":   "nHv9fMvuzo11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:75272388961ad9efc493bba573435087058742a534c6a7b0cd0020a5fba9f903",
+				"DiscoKey":   "discokey:00b87658bf77e6c7d3ae42fe86cab4230ac7869ff45c560c9ff4aea51b70966a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50649",
+					"10.65.0.27:50649",
+					"172.17.0.1:50649",
+					"172.19.0.1:50649",
+					"172.20.0.1:50649"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:31:20.115834221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5801633623032776,
+				"StableID":   "nDZNWV5aJn11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d445ba4f790f1ab053099b3a82e60082b5e5b41a247dc22bba6c735fe16ec24f",
+				"DiscoKey":   "discokey:f6fb2588937a6447413bc04f8ad4d498c7beb8bfe9adcf2f6baad0d882c0de39",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:34062",
+					"10.65.0.27:34062",
+					"172.17.0.1:34062",
+					"172.19.0.1:34062",
+					"172.20.0.1:34062"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:31:20.659145763Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8600735414959657,
+				"StableID":   "nUSYndjHAA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d66ecff48c953fe69cf0da5173bbc34fd97307a3118e886219f315611c45707",
+				"DiscoKey":   "discokey:f1453fe54b873844a5c21cab00f409d855a8cc8a0453cbfa666baf20a57f057b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:59992",
+					"10.65.0.27:59992",
+					"172.17.0.1:59992",
+					"172.19.0.1:59992",
+					"172.20.0.1:59992"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:31:21.201561884Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2484612260952031,
+				"StableID":   "nSn2MxYHQL11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:84a6dab801169010044a05832995689e030afc0f607076b8f298079bc69b8f3c",
+				"DiscoKey":   "discokey:06e16102adc9a946ed52b76f475f005ba5b6cc70e67462032aa5832310a5af15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34171",
+					"10.65.0.27:34171",
+					"172.17.0.1:34171",
+					"172.19.0.1:34171",
+					"172.20.0.1:34171"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:31:21.815156604Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5912791772272414,
+				"StableID":   "njjfWn1vAo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea18f42406c5fd8bf4a12593e1c896cda202c9b4f7374bfec9a89b8baf7ad852",
+				"DiscoKey":   "discokey:01c020f68d3ad4ad4b755b2acd7062095e779b5e01dd2544901305482f2d3300",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44665",
+					"10.65.0.27:44665",
+					"172.17.0.1:44665",
+					"172.19.0.1:44665",
+					"172.20.0.1:44665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:31:22.325651843Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6676408452980474,
+				"StableID":   "nsbnhsvk8u11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c7ca6fa6e3399e64976fcc16d503a8cc59a7380448551f159fc8bc469efa458",
+				"DiscoKey":   "discokey:7d9db05cad84fdefd39a9e1d005bb9f6e32030fadb1c732b69eaa2f7b3d3156a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38499",
+					"10.65.0.27:38499",
+					"172.17.0.1:38499",
+					"172.19.0.1:38499",
+					"172.20.0.1:38499"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:31:22.883829276Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4667506974766359,
+				"StableID":   "nt1YEdVvSd11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b7d072cb98b6d6774773a5165f2132f9d55b6b4d46b910e35b7a20965447b29",
+				"DiscoKey":   "discokey:8bc0ed9fcccced5638d6d75cda6e94e4384788feab31f83488c0389be373fd23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59438",
+					"10.65.0.27:59438",
+					"172.17.0.1:59438",
+					"172.19.0.1:59438",
+					"172.20.0.1:59438"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 44673},
+					{"Proto": "peerapi6", "Port": 44673}
+				]},
+				"Created":              "2026-05-12T18:31:23.438919322Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4220893357629997,
+				"StableID":   "nk88FFiexZ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1260c1a536f9f3de750f1ae0a95155e60503bfccc0ac0dc041a3cf283117974b",
+				"KeyExpiry":  "2026-11-08T18:31:24Z",
+				"DiscoKey":   "discokey:18dbf645ab26e3a5d998c824ed14146ba1cd3a5499572db6aff614b0e5d9607e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47150",
+					"10.65.0.27:47150",
+					"172.17.0.1:47150",
+					"172.19.0.1:47150",
+					"172.20.0.1:47150"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:31:24.505613019Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5071721211584182,
+				"StableID":   "nXR7BwWzbg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:47e209951198d8a52b7011240da1b24d5a2f566db27d53c4c46b528b692bd613",
+				"KeyExpiry":  "2026-11-08T18:31:25Z",
+				"DiscoKey":   "discokey:e4582b9d1355eed3a618c201ff4ccb666c8e0611da5531d32714ea9e2891d975",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38513",
+					"10.65.0.27:38513",
+					"172.17.0.1:38513",
+					"172.19.0.1:38513",
+					"172.20.0.1:38513"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:31:25.037664448Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6676408452980474,
+				"StableID":   "nsbnhsvk8u11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       6676408452980474,
+				"Key":        "nodekey:2c7ca6fa6e3399e64976fcc16d503a8cc59a7380448551f159fc8bc469efa458",
+				"DiscoKey":   "discokey:7d9db05cad84fdefd39a9e1d005bb9f6e32030fadb1c732b69eaa2f7b3d3156a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38499",
+					"10.65.0.27:38499",
+					"172.17.0.1:38499",
+					"172.19.0.1:38499",
+					"172.20.0.1:38499"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:31:22.883829276Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2c7ca6fa6e3399e64976fcc16d503a8cc59a7380448551f159fc8bc469efa458",
+			"MachineKey": "mkey:1bd72de062bd9c03fd5a25a4cae0a1a39caf46d37c205262be07e561d4de4b24",
+			"Peers": [{
+				"ID":         7670108461148667,
+				"StableID":   "nScEf6kot221CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c2f5bfb985df504c47aa946680050a72bdf6c812b49183059793aa98030b331",
+				"DiscoKey":   "discokey:6d1d0f0458f5966eb167cb7e078a25bdf21007c1a9cdd8d7ebe8f2b3b0ab1a3f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47632",
+					"10.65.0.27:47632",
+					"172.17.0.1:47632",
+					"172.19.0.1:47632",
+					"172.20.0.1:47632"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:31:17.420686103Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7320267184871858,
+				"StableID":   "nqYt3M1NAz11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f02f389197bd1d118452e8758b2fcb44ad2beb3088a68fb0695f472d31f8b1b",
+				"DiscoKey":   "discokey:33267cbb9428670ab6cf6f216938f45d7285cc7ad632cb90d5fc554b14f9c34f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48235",
+					"10.65.0.27:48235",
+					"172.17.0.1:48235",
+					"172.19.0.1:48235",
+					"172.20.0.1:48235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:31:17.952478308Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6064876782325360,
+				"StableID":   "nBJS4g2oMp11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4f043bb6583ee4142b9216a0dd574b0ef2a839f8fa13e656aa5487ecf8c9262",
+				"DiscoKey":   "discokey:0b5399a0fda2d5705b425c517d97909c42a2fb72936d4e788cc61849b5c93a3f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60028",
+					"10.65.0.27:60028",
+					"172.17.0.1:60028",
+					"172.19.0.1:60028",
+					"172.20.0.1:60028"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:31:18.487616053Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6190575241389124,
+				"StableID":   "nPQFT2viLq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c06b267227d9b73a85495fb249f3b000ee88a5eac0da0216f6ae589e9effb72",
+				"DiscoKey":   "discokey:63a10159bf1cd849e9ac89670a8f3bafa8864a77b3a0474e3aaf02f4d3f7da74",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50799",
+					"10.65.0.27:50799",
+					"172.17.0.1:50799",
+					"172.19.0.1:50799",
+					"172.20.0.1:50799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:31:19.020986912Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2500128367141695,
+				"StableID":   "n2xyWh8KXL11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc14403de5b59f17c25ceffcbfbde553514bd0c83b3862a1066fd3a178966900",
+				"DiscoKey":   "discokey:e97c2ec9624e6491617befca8c2bc7fe18a7c555d3284736eea2c57a64719718",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38979",
+					"10.65.0.27:38979",
+					"172.17.0.1:38979",
+					"172.19.0.1:38979",
+					"172.20.0.1:38979"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:31:19.572625618Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6018771449274370,
+				"StableID":   "nHv9fMvuzo11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:75272388961ad9efc493bba573435087058742a534c6a7b0cd0020a5fba9f903",
+				"DiscoKey":   "discokey:00b87658bf77e6c7d3ae42fe86cab4230ac7869ff45c560c9ff4aea51b70966a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50649",
+					"10.65.0.27:50649",
+					"172.17.0.1:50649",
+					"172.19.0.1:50649",
+					"172.20.0.1:50649"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:31:20.115834221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5801633623032776,
+				"StableID":   "nDZNWV5aJn11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d445ba4f790f1ab053099b3a82e60082b5e5b41a247dc22bba6c735fe16ec24f",
+				"DiscoKey":   "discokey:f6fb2588937a6447413bc04f8ad4d498c7beb8bfe9adcf2f6baad0d882c0de39",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:34062",
+					"10.65.0.27:34062",
+					"172.17.0.1:34062",
+					"172.19.0.1:34062",
+					"172.20.0.1:34062"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:31:20.659145763Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8600735414959657,
+				"StableID":   "nUSYndjHAA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d66ecff48c953fe69cf0da5173bbc34fd97307a3118e886219f315611c45707",
+				"DiscoKey":   "discokey:f1453fe54b873844a5c21cab00f409d855a8cc8a0453cbfa666baf20a57f057b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:59992",
+					"10.65.0.27:59992",
+					"172.17.0.1:59992",
+					"172.19.0.1:59992",
+					"172.20.0.1:59992"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:31:21.201561884Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2484612260952031,
+				"StableID":   "nSn2MxYHQL11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:84a6dab801169010044a05832995689e030afc0f607076b8f298079bc69b8f3c",
+				"DiscoKey":   "discokey:06e16102adc9a946ed52b76f475f005ba5b6cc70e67462032aa5832310a5af15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34171",
+					"10.65.0.27:34171",
+					"172.17.0.1:34171",
+					"172.19.0.1:34171",
+					"172.20.0.1:34171"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:31:21.815156604Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5912791772272414,
+				"StableID":   "njjfWn1vAo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea18f42406c5fd8bf4a12593e1c896cda202c9b4f7374bfec9a89b8baf7ad852",
+				"DiscoKey":   "discokey:01c020f68d3ad4ad4b755b2acd7062095e779b5e01dd2544901305482f2d3300",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44665",
+					"10.65.0.27:44665",
+					"172.17.0.1:44665",
+					"172.19.0.1:44665",
+					"172.20.0.1:44665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:31:22.325651843Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4667506974766359,
+				"StableID":   "nt1YEdVvSd11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b7d072cb98b6d6774773a5165f2132f9d55b6b4d46b910e35b7a20965447b29",
+				"DiscoKey":   "discokey:8bc0ed9fcccced5638d6d75cda6e94e4384788feab31f83488c0389be373fd23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59438",
+					"10.65.0.27:59438",
+					"172.17.0.1:59438",
+					"172.19.0.1:59438",
+					"172.20.0.1:59438"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 44673},
+					{"Proto": "peerapi6", "Port": 44673}
+				]},
+				"Created":              "2026-05-12T18:31:23.438919322Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7168621603691798,
+				"StableID":   "njRxKxXgyx11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:503db194f16af28c09dedfa8702935d75335fc61867678e6888e734cd1929554",
+				"KeyExpiry":  "2026-11-08T18:31:23Z",
+				"DiscoKey":   "discokey:6dec407066cdcff25f069f3dfed86c15a80789e88428f7fb4055a3b9eb04081e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43354",
+					"10.65.0.27:43354",
+					"172.17.0.1:43354",
+					"172.19.0.1:43354",
+					"172.20.0.1:43354"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:31:23.98046685Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4220893357629997,
+				"StableID":   "nk88FFiexZ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1260c1a536f9f3de750f1ae0a95155e60503bfccc0ac0dc041a3cf283117974b",
+				"KeyExpiry":  "2026-11-08T18:31:24Z",
+				"DiscoKey":   "discokey:18dbf645ab26e3a5d998c824ed14146ba1cd3a5499572db6aff614b0e5d9607e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47150",
+					"10.65.0.27:47150",
+					"172.17.0.1:47150",
+					"172.19.0.1:47150",
+					"172.20.0.1:47150"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:31:24.505613019Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5071721211584182,
+				"StableID":   "nXR7BwWzbg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:47e209951198d8a52b7011240da1b24d5a2f566db27d53c4c46b528b692bd613",
+				"KeyExpiry":  "2026-11-08T18:31:25Z",
+				"DiscoKey":   "discokey:e4582b9d1355eed3a618c201ff4ccb666c8e0611da5531d32714ea9e2891d975",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38513",
+					"10.65.0.27:38513",
+					"172.17.0.1:38513",
+					"172.19.0.1:38513",
+					"172.20.0.1:38513"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:31:25.037664448Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6676408452980474": {
+				"ID":          6676408452980474,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7320267184871858,
+				"StableID":   "nqYt3M1NAz11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       7320267184871858,
+				"Key":        "nodekey:9f02f389197bd1d118452e8758b2fcb44ad2beb3088a68fb0695f472d31f8b1b",
+				"DiscoKey":   "discokey:33267cbb9428670ab6cf6f216938f45d7285cc7ad632cb90d5fc554b14f9c34f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48235",
+					"10.65.0.27:48235",
+					"172.17.0.1:48235",
+					"172.19.0.1:48235",
+					"172.20.0.1:48235"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:31:17.952478308Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9f02f389197bd1d118452e8758b2fcb44ad2beb3088a68fb0695f472d31f8b1b",
+			"MachineKey": "mkey:f8055189ced23a49d87aa83d00e15900b5f3e0700da7bcc21ea526fb89879b43",
+			"Peers": [{
+				"ID":         7670108461148667,
+				"StableID":   "nScEf6kot221CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c2f5bfb985df504c47aa946680050a72bdf6c812b49183059793aa98030b331",
+				"DiscoKey":   "discokey:6d1d0f0458f5966eb167cb7e078a25bdf21007c1a9cdd8d7ebe8f2b3b0ab1a3f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47632",
+					"10.65.0.27:47632",
+					"172.17.0.1:47632",
+					"172.19.0.1:47632",
+					"172.20.0.1:47632"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:31:17.420686103Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6064876782325360,
+				"StableID":   "nBJS4g2oMp11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4f043bb6583ee4142b9216a0dd574b0ef2a839f8fa13e656aa5487ecf8c9262",
+				"DiscoKey":   "discokey:0b5399a0fda2d5705b425c517d97909c42a2fb72936d4e788cc61849b5c93a3f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60028",
+					"10.65.0.27:60028",
+					"172.17.0.1:60028",
+					"172.19.0.1:60028",
+					"172.20.0.1:60028"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:31:18.487616053Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6190575241389124,
+				"StableID":   "nPQFT2viLq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c06b267227d9b73a85495fb249f3b000ee88a5eac0da0216f6ae589e9effb72",
+				"DiscoKey":   "discokey:63a10159bf1cd849e9ac89670a8f3bafa8864a77b3a0474e3aaf02f4d3f7da74",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50799",
+					"10.65.0.27:50799",
+					"172.17.0.1:50799",
+					"172.19.0.1:50799",
+					"172.20.0.1:50799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:31:19.020986912Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2500128367141695,
+				"StableID":   "n2xyWh8KXL11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc14403de5b59f17c25ceffcbfbde553514bd0c83b3862a1066fd3a178966900",
+				"DiscoKey":   "discokey:e97c2ec9624e6491617befca8c2bc7fe18a7c555d3284736eea2c57a64719718",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38979",
+					"10.65.0.27:38979",
+					"172.17.0.1:38979",
+					"172.19.0.1:38979",
+					"172.20.0.1:38979"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:31:19.572625618Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6018771449274370,
+				"StableID":   "nHv9fMvuzo11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:75272388961ad9efc493bba573435087058742a534c6a7b0cd0020a5fba9f903",
+				"DiscoKey":   "discokey:00b87658bf77e6c7d3ae42fe86cab4230ac7869ff45c560c9ff4aea51b70966a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50649",
+					"10.65.0.27:50649",
+					"172.17.0.1:50649",
+					"172.19.0.1:50649",
+					"172.20.0.1:50649"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:31:20.115834221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5801633623032776,
+				"StableID":   "nDZNWV5aJn11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d445ba4f790f1ab053099b3a82e60082b5e5b41a247dc22bba6c735fe16ec24f",
+				"DiscoKey":   "discokey:f6fb2588937a6447413bc04f8ad4d498c7beb8bfe9adcf2f6baad0d882c0de39",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:34062",
+					"10.65.0.27:34062",
+					"172.17.0.1:34062",
+					"172.19.0.1:34062",
+					"172.20.0.1:34062"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:31:20.659145763Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8600735414959657,
+				"StableID":   "nUSYndjHAA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d66ecff48c953fe69cf0da5173bbc34fd97307a3118e886219f315611c45707",
+				"DiscoKey":   "discokey:f1453fe54b873844a5c21cab00f409d855a8cc8a0453cbfa666baf20a57f057b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:59992",
+					"10.65.0.27:59992",
+					"172.17.0.1:59992",
+					"172.19.0.1:59992",
+					"172.20.0.1:59992"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:31:21.201561884Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2484612260952031,
+				"StableID":   "nSn2MxYHQL11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:84a6dab801169010044a05832995689e030afc0f607076b8f298079bc69b8f3c",
+				"DiscoKey":   "discokey:06e16102adc9a946ed52b76f475f005ba5b6cc70e67462032aa5832310a5af15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34171",
+					"10.65.0.27:34171",
+					"172.17.0.1:34171",
+					"172.19.0.1:34171",
+					"172.20.0.1:34171"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:31:21.815156604Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5912791772272414,
+				"StableID":   "njjfWn1vAo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea18f42406c5fd8bf4a12593e1c896cda202c9b4f7374bfec9a89b8baf7ad852",
+				"DiscoKey":   "discokey:01c020f68d3ad4ad4b755b2acd7062095e779b5e01dd2544901305482f2d3300",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44665",
+					"10.65.0.27:44665",
+					"172.17.0.1:44665",
+					"172.19.0.1:44665",
+					"172.20.0.1:44665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:31:22.325651843Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6676408452980474,
+				"StableID":   "nsbnhsvk8u11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c7ca6fa6e3399e64976fcc16d503a8cc59a7380448551f159fc8bc469efa458",
+				"DiscoKey":   "discokey:7d9db05cad84fdefd39a9e1d005bb9f6e32030fadb1c732b69eaa2f7b3d3156a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38499",
+					"10.65.0.27:38499",
+					"172.17.0.1:38499",
+					"172.19.0.1:38499",
+					"172.20.0.1:38499"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:31:22.883829276Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4667506974766359,
+				"StableID":   "nt1YEdVvSd11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b7d072cb98b6d6774773a5165f2132f9d55b6b4d46b910e35b7a20965447b29",
+				"DiscoKey":   "discokey:8bc0ed9fcccced5638d6d75cda6e94e4384788feab31f83488c0389be373fd23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59438",
+					"10.65.0.27:59438",
+					"172.17.0.1:59438",
+					"172.19.0.1:59438",
+					"172.20.0.1:59438"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 44673},
+					{"Proto": "peerapi6", "Port": 44673}
+				]},
+				"Created":              "2026-05-12T18:31:23.438919322Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7168621603691798,
+				"StableID":   "njRxKxXgyx11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:503db194f16af28c09dedfa8702935d75335fc61867678e6888e734cd1929554",
+				"KeyExpiry":  "2026-11-08T18:31:23Z",
+				"DiscoKey":   "discokey:6dec407066cdcff25f069f3dfed86c15a80789e88428f7fb4055a3b9eb04081e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43354",
+					"10.65.0.27:43354",
+					"172.17.0.1:43354",
+					"172.19.0.1:43354",
+					"172.20.0.1:43354"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:31:23.98046685Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4220893357629997,
+				"StableID":   "nk88FFiexZ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1260c1a536f9f3de750f1ae0a95155e60503bfccc0ac0dc041a3cf283117974b",
+				"KeyExpiry":  "2026-11-08T18:31:24Z",
+				"DiscoKey":   "discokey:18dbf645ab26e3a5d998c824ed14146ba1cd3a5499572db6aff614b0e5d9607e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47150",
+					"10.65.0.27:47150",
+					"172.17.0.1:47150",
+					"172.19.0.1:47150",
+					"172.20.0.1:47150"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:31:24.505613019Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5071721211584182,
+				"StableID":   "nXR7BwWzbg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:47e209951198d8a52b7011240da1b24d5a2f566db27d53c4c46b528b692bd613",
+				"KeyExpiry":  "2026-11-08T18:31:25Z",
+				"DiscoKey":   "discokey:e4582b9d1355eed3a618c201ff4ccb666c8e0611da5531d32714ea9e2891d975",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38513",
+					"10.65.0.27:38513",
+					"172.17.0.1:38513",
+					"172.19.0.1:38513",
+					"172.20.0.1:38513"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:31:25.037664448Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7320267184871858": {
+				"ID":          7320267184871858,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7670108461148667,
+				"StableID":   "nScEf6kot221CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       7670108461148667,
+				"Key":        "nodekey:0c2f5bfb985df504c47aa946680050a72bdf6c812b49183059793aa98030b331",
+				"DiscoKey":   "discokey:6d1d0f0458f5966eb167cb7e078a25bdf21007c1a9cdd8d7ebe8f2b3b0ab1a3f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47632",
+					"10.65.0.27:47632",
+					"172.17.0.1:47632",
+					"172.19.0.1:47632",
+					"172.20.0.1:47632"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:31:17.420686103Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0c2f5bfb985df504c47aa946680050a72bdf6c812b49183059793aa98030b331",
+			"MachineKey": "mkey:783f135c0f5a08e8aa94ae4f3ea6a82aca3a24721ff637e2cf8d05ed3a199a6f",
+			"Peers": [{
+				"ID":         7320267184871858,
+				"StableID":   "nqYt3M1NAz11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f02f389197bd1d118452e8758b2fcb44ad2beb3088a68fb0695f472d31f8b1b",
+				"DiscoKey":   "discokey:33267cbb9428670ab6cf6f216938f45d7285cc7ad632cb90d5fc554b14f9c34f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48235",
+					"10.65.0.27:48235",
+					"172.17.0.1:48235",
+					"172.19.0.1:48235",
+					"172.20.0.1:48235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:31:17.952478308Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6064876782325360,
+				"StableID":   "nBJS4g2oMp11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4f043bb6583ee4142b9216a0dd574b0ef2a839f8fa13e656aa5487ecf8c9262",
+				"DiscoKey":   "discokey:0b5399a0fda2d5705b425c517d97909c42a2fb72936d4e788cc61849b5c93a3f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60028",
+					"10.65.0.27:60028",
+					"172.17.0.1:60028",
+					"172.19.0.1:60028",
+					"172.20.0.1:60028"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:31:18.487616053Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6190575241389124,
+				"StableID":   "nPQFT2viLq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c06b267227d9b73a85495fb249f3b000ee88a5eac0da0216f6ae589e9effb72",
+				"DiscoKey":   "discokey:63a10159bf1cd849e9ac89670a8f3bafa8864a77b3a0474e3aaf02f4d3f7da74",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50799",
+					"10.65.0.27:50799",
+					"172.17.0.1:50799",
+					"172.19.0.1:50799",
+					"172.20.0.1:50799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:31:19.020986912Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2500128367141695,
+				"StableID":   "n2xyWh8KXL11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc14403de5b59f17c25ceffcbfbde553514bd0c83b3862a1066fd3a178966900",
+				"DiscoKey":   "discokey:e97c2ec9624e6491617befca8c2bc7fe18a7c555d3284736eea2c57a64719718",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38979",
+					"10.65.0.27:38979",
+					"172.17.0.1:38979",
+					"172.19.0.1:38979",
+					"172.20.0.1:38979"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:31:19.572625618Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6018771449274370,
+				"StableID":   "nHv9fMvuzo11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:75272388961ad9efc493bba573435087058742a534c6a7b0cd0020a5fba9f903",
+				"DiscoKey":   "discokey:00b87658bf77e6c7d3ae42fe86cab4230ac7869ff45c560c9ff4aea51b70966a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50649",
+					"10.65.0.27:50649",
+					"172.17.0.1:50649",
+					"172.19.0.1:50649",
+					"172.20.0.1:50649"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:31:20.115834221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5801633623032776,
+				"StableID":   "nDZNWV5aJn11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d445ba4f790f1ab053099b3a82e60082b5e5b41a247dc22bba6c735fe16ec24f",
+				"DiscoKey":   "discokey:f6fb2588937a6447413bc04f8ad4d498c7beb8bfe9adcf2f6baad0d882c0de39",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:34062",
+					"10.65.0.27:34062",
+					"172.17.0.1:34062",
+					"172.19.0.1:34062",
+					"172.20.0.1:34062"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:31:20.659145763Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8600735414959657,
+				"StableID":   "nUSYndjHAA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d66ecff48c953fe69cf0da5173bbc34fd97307a3118e886219f315611c45707",
+				"DiscoKey":   "discokey:f1453fe54b873844a5c21cab00f409d855a8cc8a0453cbfa666baf20a57f057b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:59992",
+					"10.65.0.27:59992",
+					"172.17.0.1:59992",
+					"172.19.0.1:59992",
+					"172.20.0.1:59992"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:31:21.201561884Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2484612260952031,
+				"StableID":   "nSn2MxYHQL11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:84a6dab801169010044a05832995689e030afc0f607076b8f298079bc69b8f3c",
+				"DiscoKey":   "discokey:06e16102adc9a946ed52b76f475f005ba5b6cc70e67462032aa5832310a5af15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34171",
+					"10.65.0.27:34171",
+					"172.17.0.1:34171",
+					"172.19.0.1:34171",
+					"172.20.0.1:34171"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:31:21.815156604Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5912791772272414,
+				"StableID":   "njjfWn1vAo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea18f42406c5fd8bf4a12593e1c896cda202c9b4f7374bfec9a89b8baf7ad852",
+				"DiscoKey":   "discokey:01c020f68d3ad4ad4b755b2acd7062095e779b5e01dd2544901305482f2d3300",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44665",
+					"10.65.0.27:44665",
+					"172.17.0.1:44665",
+					"172.19.0.1:44665",
+					"172.20.0.1:44665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:31:22.325651843Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6676408452980474,
+				"StableID":   "nsbnhsvk8u11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c7ca6fa6e3399e64976fcc16d503a8cc59a7380448551f159fc8bc469efa458",
+				"DiscoKey":   "discokey:7d9db05cad84fdefd39a9e1d005bb9f6e32030fadb1c732b69eaa2f7b3d3156a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38499",
+					"10.65.0.27:38499",
+					"172.17.0.1:38499",
+					"172.19.0.1:38499",
+					"172.20.0.1:38499"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:31:22.883829276Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4667506974766359,
+				"StableID":   "nt1YEdVvSd11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b7d072cb98b6d6774773a5165f2132f9d55b6b4d46b910e35b7a20965447b29",
+				"DiscoKey":   "discokey:8bc0ed9fcccced5638d6d75cda6e94e4384788feab31f83488c0389be373fd23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59438",
+					"10.65.0.27:59438",
+					"172.17.0.1:59438",
+					"172.19.0.1:59438",
+					"172.20.0.1:59438"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 44673},
+					{"Proto": "peerapi6", "Port": 44673}
+				]},
+				"Created":              "2026-05-12T18:31:23.438919322Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7168621603691798,
+				"StableID":   "njRxKxXgyx11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:503db194f16af28c09dedfa8702935d75335fc61867678e6888e734cd1929554",
+				"KeyExpiry":  "2026-11-08T18:31:23Z",
+				"DiscoKey":   "discokey:6dec407066cdcff25f069f3dfed86c15a80789e88428f7fb4055a3b9eb04081e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43354",
+					"10.65.0.27:43354",
+					"172.17.0.1:43354",
+					"172.19.0.1:43354",
+					"172.20.0.1:43354"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:31:23.98046685Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4220893357629997,
+				"StableID":   "nk88FFiexZ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1260c1a536f9f3de750f1ae0a95155e60503bfccc0ac0dc041a3cf283117974b",
+				"KeyExpiry":  "2026-11-08T18:31:24Z",
+				"DiscoKey":   "discokey:18dbf645ab26e3a5d998c824ed14146ba1cd3a5499572db6aff614b0e5d9607e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47150",
+					"10.65.0.27:47150",
+					"172.17.0.1:47150",
+					"172.19.0.1:47150",
+					"172.20.0.1:47150"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:31:24.505613019Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5071721211584182,
+				"StableID":   "nXR7BwWzbg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:47e209951198d8a52b7011240da1b24d5a2f566db27d53c4c46b528b692bd613",
+				"KeyExpiry":  "2026-11-08T18:31:25Z",
+				"DiscoKey":   "discokey:e4582b9d1355eed3a618c201ff4ccb666c8e0611da5531d32714ea9e2891d975",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38513",
+					"10.65.0.27:38513",
+					"172.17.0.1:38513",
+					"172.19.0.1:38513",
+					"172.20.0.1:38513"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:31:25.037664448Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7670108461148667": {
+				"ID":          7670108461148667,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2500128367141695,
+				"StableID":   "n2xyWh8KXL11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       2500128367141695,
+				"Key":        "nodekey:cc14403de5b59f17c25ceffcbfbde553514bd0c83b3862a1066fd3a178966900",
+				"DiscoKey":   "discokey:e97c2ec9624e6491617befca8c2bc7fe18a7c555d3284736eea2c57a64719718",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38979",
+					"10.65.0.27:38979",
+					"172.17.0.1:38979",
+					"172.19.0.1:38979",
+					"172.20.0.1:38979"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:31:19.572625618Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:cc14403de5b59f17c25ceffcbfbde553514bd0c83b3862a1066fd3a178966900",
+			"MachineKey": "mkey:f712e9ab6e0694ea0438b22f47e93e030c0486becfc779da1adfe0dec668885e",
+			"Peers": [{
+				"ID":         7670108461148667,
+				"StableID":   "nScEf6kot221CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c2f5bfb985df504c47aa946680050a72bdf6c812b49183059793aa98030b331",
+				"DiscoKey":   "discokey:6d1d0f0458f5966eb167cb7e078a25bdf21007c1a9cdd8d7ebe8f2b3b0ab1a3f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47632",
+					"10.65.0.27:47632",
+					"172.17.0.1:47632",
+					"172.19.0.1:47632",
+					"172.20.0.1:47632"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:31:17.420686103Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7320267184871858,
+				"StableID":   "nqYt3M1NAz11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f02f389197bd1d118452e8758b2fcb44ad2beb3088a68fb0695f472d31f8b1b",
+				"DiscoKey":   "discokey:33267cbb9428670ab6cf6f216938f45d7285cc7ad632cb90d5fc554b14f9c34f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48235",
+					"10.65.0.27:48235",
+					"172.17.0.1:48235",
+					"172.19.0.1:48235",
+					"172.20.0.1:48235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:31:17.952478308Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6064876782325360,
+				"StableID":   "nBJS4g2oMp11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4f043bb6583ee4142b9216a0dd574b0ef2a839f8fa13e656aa5487ecf8c9262",
+				"DiscoKey":   "discokey:0b5399a0fda2d5705b425c517d97909c42a2fb72936d4e788cc61849b5c93a3f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60028",
+					"10.65.0.27:60028",
+					"172.17.0.1:60028",
+					"172.19.0.1:60028",
+					"172.20.0.1:60028"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:31:18.487616053Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6190575241389124,
+				"StableID":   "nPQFT2viLq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c06b267227d9b73a85495fb249f3b000ee88a5eac0da0216f6ae589e9effb72",
+				"DiscoKey":   "discokey:63a10159bf1cd849e9ac89670a8f3bafa8864a77b3a0474e3aaf02f4d3f7da74",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50799",
+					"10.65.0.27:50799",
+					"172.17.0.1:50799",
+					"172.19.0.1:50799",
+					"172.20.0.1:50799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:31:19.020986912Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6018771449274370,
+				"StableID":   "nHv9fMvuzo11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:75272388961ad9efc493bba573435087058742a534c6a7b0cd0020a5fba9f903",
+				"DiscoKey":   "discokey:00b87658bf77e6c7d3ae42fe86cab4230ac7869ff45c560c9ff4aea51b70966a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50649",
+					"10.65.0.27:50649",
+					"172.17.0.1:50649",
+					"172.19.0.1:50649",
+					"172.20.0.1:50649"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:31:20.115834221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5801633623032776,
+				"StableID":   "nDZNWV5aJn11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d445ba4f790f1ab053099b3a82e60082b5e5b41a247dc22bba6c735fe16ec24f",
+				"DiscoKey":   "discokey:f6fb2588937a6447413bc04f8ad4d498c7beb8bfe9adcf2f6baad0d882c0de39",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:34062",
+					"10.65.0.27:34062",
+					"172.17.0.1:34062",
+					"172.19.0.1:34062",
+					"172.20.0.1:34062"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:31:20.659145763Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8600735414959657,
+				"StableID":   "nUSYndjHAA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d66ecff48c953fe69cf0da5173bbc34fd97307a3118e886219f315611c45707",
+				"DiscoKey":   "discokey:f1453fe54b873844a5c21cab00f409d855a8cc8a0453cbfa666baf20a57f057b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:59992",
+					"10.65.0.27:59992",
+					"172.17.0.1:59992",
+					"172.19.0.1:59992",
+					"172.20.0.1:59992"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:31:21.201561884Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2484612260952031,
+				"StableID":   "nSn2MxYHQL11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:84a6dab801169010044a05832995689e030afc0f607076b8f298079bc69b8f3c",
+				"DiscoKey":   "discokey:06e16102adc9a946ed52b76f475f005ba5b6cc70e67462032aa5832310a5af15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34171",
+					"10.65.0.27:34171",
+					"172.17.0.1:34171",
+					"172.19.0.1:34171",
+					"172.20.0.1:34171"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:31:21.815156604Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5912791772272414,
+				"StableID":   "njjfWn1vAo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea18f42406c5fd8bf4a12593e1c896cda202c9b4f7374bfec9a89b8baf7ad852",
+				"DiscoKey":   "discokey:01c020f68d3ad4ad4b755b2acd7062095e779b5e01dd2544901305482f2d3300",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44665",
+					"10.65.0.27:44665",
+					"172.17.0.1:44665",
+					"172.19.0.1:44665",
+					"172.20.0.1:44665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:31:22.325651843Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6676408452980474,
+				"StableID":   "nsbnhsvk8u11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c7ca6fa6e3399e64976fcc16d503a8cc59a7380448551f159fc8bc469efa458",
+				"DiscoKey":   "discokey:7d9db05cad84fdefd39a9e1d005bb9f6e32030fadb1c732b69eaa2f7b3d3156a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38499",
+					"10.65.0.27:38499",
+					"172.17.0.1:38499",
+					"172.19.0.1:38499",
+					"172.20.0.1:38499"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:31:22.883829276Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4667506974766359,
+				"StableID":   "nt1YEdVvSd11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b7d072cb98b6d6774773a5165f2132f9d55b6b4d46b910e35b7a20965447b29",
+				"DiscoKey":   "discokey:8bc0ed9fcccced5638d6d75cda6e94e4384788feab31f83488c0389be373fd23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59438",
+					"10.65.0.27:59438",
+					"172.17.0.1:59438",
+					"172.19.0.1:59438",
+					"172.20.0.1:59438"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 44673},
+					{"Proto": "peerapi6", "Port": 44673}
+				]},
+				"Created":              "2026-05-12T18:31:23.438919322Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7168621603691798,
+				"StableID":   "njRxKxXgyx11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:503db194f16af28c09dedfa8702935d75335fc61867678e6888e734cd1929554",
+				"KeyExpiry":  "2026-11-08T18:31:23Z",
+				"DiscoKey":   "discokey:6dec407066cdcff25f069f3dfed86c15a80789e88428f7fb4055a3b9eb04081e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43354",
+					"10.65.0.27:43354",
+					"172.17.0.1:43354",
+					"172.19.0.1:43354",
+					"172.20.0.1:43354"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:31:23.98046685Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4220893357629997,
+				"StableID":   "nk88FFiexZ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1260c1a536f9f3de750f1ae0a95155e60503bfccc0ac0dc041a3cf283117974b",
+				"KeyExpiry":  "2026-11-08T18:31:24Z",
+				"DiscoKey":   "discokey:18dbf645ab26e3a5d998c824ed14146ba1cd3a5499572db6aff614b0e5d9607e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47150",
+					"10.65.0.27:47150",
+					"172.17.0.1:47150",
+					"172.19.0.1:47150",
+					"172.20.0.1:47150"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:31:24.505613019Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5071721211584182,
+				"StableID":   "nXR7BwWzbg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:47e209951198d8a52b7011240da1b24d5a2f566db27d53c4c46b528b692bd613",
+				"KeyExpiry":  "2026-11-08T18:31:25Z",
+				"DiscoKey":   "discokey:e4582b9d1355eed3a618c201ff4ccb666c8e0611da5531d32714ea9e2891d975",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38513",
+					"10.65.0.27:38513",
+					"172.17.0.1:38513",
+					"172.19.0.1:38513",
+					"172.20.0.1:38513"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:31:25.037664448Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2500128367141695": {
+				"ID":          2500128367141695,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6190575241389124,
+				"StableID":   "nPQFT2viLq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       6190575241389124,
+				"Key":        "nodekey:5c06b267227d9b73a85495fb249f3b000ee88a5eac0da0216f6ae589e9effb72",
+				"DiscoKey":   "discokey:63a10159bf1cd849e9ac89670a8f3bafa8864a77b3a0474e3aaf02f4d3f7da74",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50799",
+					"10.65.0.27:50799",
+					"172.17.0.1:50799",
+					"172.19.0.1:50799",
+					"172.20.0.1:50799"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:31:19.020986912Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5c06b267227d9b73a85495fb249f3b000ee88a5eac0da0216f6ae589e9effb72",
+			"MachineKey": "mkey:b35fc25820a05df964468d2634051f7b126ef3d1f150f97fbd052ef2187ee22d",
+			"Peers": [{
+				"ID":         7670108461148667,
+				"StableID":   "nScEf6kot221CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c2f5bfb985df504c47aa946680050a72bdf6c812b49183059793aa98030b331",
+				"DiscoKey":   "discokey:6d1d0f0458f5966eb167cb7e078a25bdf21007c1a9cdd8d7ebe8f2b3b0ab1a3f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47632",
+					"10.65.0.27:47632",
+					"172.17.0.1:47632",
+					"172.19.0.1:47632",
+					"172.20.0.1:47632"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:31:17.420686103Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7320267184871858,
+				"StableID":   "nqYt3M1NAz11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f02f389197bd1d118452e8758b2fcb44ad2beb3088a68fb0695f472d31f8b1b",
+				"DiscoKey":   "discokey:33267cbb9428670ab6cf6f216938f45d7285cc7ad632cb90d5fc554b14f9c34f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48235",
+					"10.65.0.27:48235",
+					"172.17.0.1:48235",
+					"172.19.0.1:48235",
+					"172.20.0.1:48235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:31:17.952478308Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6064876782325360,
+				"StableID":   "nBJS4g2oMp11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4f043bb6583ee4142b9216a0dd574b0ef2a839f8fa13e656aa5487ecf8c9262",
+				"DiscoKey":   "discokey:0b5399a0fda2d5705b425c517d97909c42a2fb72936d4e788cc61849b5c93a3f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60028",
+					"10.65.0.27:60028",
+					"172.17.0.1:60028",
+					"172.19.0.1:60028",
+					"172.20.0.1:60028"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:31:18.487616053Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2500128367141695,
+				"StableID":   "n2xyWh8KXL11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc14403de5b59f17c25ceffcbfbde553514bd0c83b3862a1066fd3a178966900",
+				"DiscoKey":   "discokey:e97c2ec9624e6491617befca8c2bc7fe18a7c555d3284736eea2c57a64719718",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38979",
+					"10.65.0.27:38979",
+					"172.17.0.1:38979",
+					"172.19.0.1:38979",
+					"172.20.0.1:38979"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:31:19.572625618Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6018771449274370,
+				"StableID":   "nHv9fMvuzo11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:75272388961ad9efc493bba573435087058742a534c6a7b0cd0020a5fba9f903",
+				"DiscoKey":   "discokey:00b87658bf77e6c7d3ae42fe86cab4230ac7869ff45c560c9ff4aea51b70966a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50649",
+					"10.65.0.27:50649",
+					"172.17.0.1:50649",
+					"172.19.0.1:50649",
+					"172.20.0.1:50649"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:31:20.115834221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5801633623032776,
+				"StableID":   "nDZNWV5aJn11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d445ba4f790f1ab053099b3a82e60082b5e5b41a247dc22bba6c735fe16ec24f",
+				"DiscoKey":   "discokey:f6fb2588937a6447413bc04f8ad4d498c7beb8bfe9adcf2f6baad0d882c0de39",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:34062",
+					"10.65.0.27:34062",
+					"172.17.0.1:34062",
+					"172.19.0.1:34062",
+					"172.20.0.1:34062"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:31:20.659145763Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8600735414959657,
+				"StableID":   "nUSYndjHAA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d66ecff48c953fe69cf0da5173bbc34fd97307a3118e886219f315611c45707",
+				"DiscoKey":   "discokey:f1453fe54b873844a5c21cab00f409d855a8cc8a0453cbfa666baf20a57f057b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:59992",
+					"10.65.0.27:59992",
+					"172.17.0.1:59992",
+					"172.19.0.1:59992",
+					"172.20.0.1:59992"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:31:21.201561884Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2484612260952031,
+				"StableID":   "nSn2MxYHQL11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:84a6dab801169010044a05832995689e030afc0f607076b8f298079bc69b8f3c",
+				"DiscoKey":   "discokey:06e16102adc9a946ed52b76f475f005ba5b6cc70e67462032aa5832310a5af15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34171",
+					"10.65.0.27:34171",
+					"172.17.0.1:34171",
+					"172.19.0.1:34171",
+					"172.20.0.1:34171"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:31:21.815156604Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5912791772272414,
+				"StableID":   "njjfWn1vAo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea18f42406c5fd8bf4a12593e1c896cda202c9b4f7374bfec9a89b8baf7ad852",
+				"DiscoKey":   "discokey:01c020f68d3ad4ad4b755b2acd7062095e779b5e01dd2544901305482f2d3300",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44665",
+					"10.65.0.27:44665",
+					"172.17.0.1:44665",
+					"172.19.0.1:44665",
+					"172.20.0.1:44665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:31:22.325651843Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6676408452980474,
+				"StableID":   "nsbnhsvk8u11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c7ca6fa6e3399e64976fcc16d503a8cc59a7380448551f159fc8bc469efa458",
+				"DiscoKey":   "discokey:7d9db05cad84fdefd39a9e1d005bb9f6e32030fadb1c732b69eaa2f7b3d3156a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38499",
+					"10.65.0.27:38499",
+					"172.17.0.1:38499",
+					"172.19.0.1:38499",
+					"172.20.0.1:38499"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:31:22.883829276Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4667506974766359,
+				"StableID":   "nt1YEdVvSd11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b7d072cb98b6d6774773a5165f2132f9d55b6b4d46b910e35b7a20965447b29",
+				"DiscoKey":   "discokey:8bc0ed9fcccced5638d6d75cda6e94e4384788feab31f83488c0389be373fd23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59438",
+					"10.65.0.27:59438",
+					"172.17.0.1:59438",
+					"172.19.0.1:59438",
+					"172.20.0.1:59438"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 44673},
+					{"Proto": "peerapi6", "Port": 44673}
+				]},
+				"Created":              "2026-05-12T18:31:23.438919322Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7168621603691798,
+				"StableID":   "njRxKxXgyx11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:503db194f16af28c09dedfa8702935d75335fc61867678e6888e734cd1929554",
+				"KeyExpiry":  "2026-11-08T18:31:23Z",
+				"DiscoKey":   "discokey:6dec407066cdcff25f069f3dfed86c15a80789e88428f7fb4055a3b9eb04081e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43354",
+					"10.65.0.27:43354",
+					"172.17.0.1:43354",
+					"172.19.0.1:43354",
+					"172.20.0.1:43354"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:31:23.98046685Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4220893357629997,
+				"StableID":   "nk88FFiexZ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1260c1a536f9f3de750f1ae0a95155e60503bfccc0ac0dc041a3cf283117974b",
+				"KeyExpiry":  "2026-11-08T18:31:24Z",
+				"DiscoKey":   "discokey:18dbf645ab26e3a5d998c824ed14146ba1cd3a5499572db6aff614b0e5d9607e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47150",
+					"10.65.0.27:47150",
+					"172.17.0.1:47150",
+					"172.19.0.1:47150",
+					"172.20.0.1:47150"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:31:24.505613019Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5071721211584182,
+				"StableID":   "nXR7BwWzbg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:47e209951198d8a52b7011240da1b24d5a2f566db27d53c4c46b528b692bd613",
+				"KeyExpiry":  "2026-11-08T18:31:25Z",
+				"DiscoKey":   "discokey:e4582b9d1355eed3a618c201ff4ccb666c8e0611da5531d32714ea9e2891d975",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38513",
+					"10.65.0.27:38513",
+					"172.17.0.1:38513",
+					"172.19.0.1:38513",
+					"172.20.0.1:38513"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:31:25.037664448Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6190575241389124": {
+				"ID":          6190575241389124,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5801633623032776,
+				"StableID":   "nDZNWV5aJn11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       5801633623032776,
+				"Key":        "nodekey:d445ba4f790f1ab053099b3a82e60082b5e5b41a247dc22bba6c735fe16ec24f",
+				"DiscoKey":   "discokey:f6fb2588937a6447413bc04f8ad4d498c7beb8bfe9adcf2f6baad0d882c0de39",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:34062",
+					"10.65.0.27:34062",
+					"172.17.0.1:34062",
+					"172.19.0.1:34062",
+					"172.20.0.1:34062"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:31:20.659145763Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d445ba4f790f1ab053099b3a82e60082b5e5b41a247dc22bba6c735fe16ec24f",
+			"MachineKey": "mkey:f3fee57d7807a609bb2d1d8e4a7902fd7716e8c5e63a73be876bc9f20c44181b",
+			"Peers": [{
+				"ID":         7670108461148667,
+				"StableID":   "nScEf6kot221CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c2f5bfb985df504c47aa946680050a72bdf6c812b49183059793aa98030b331",
+				"DiscoKey":   "discokey:6d1d0f0458f5966eb167cb7e078a25bdf21007c1a9cdd8d7ebe8f2b3b0ab1a3f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47632",
+					"10.65.0.27:47632",
+					"172.17.0.1:47632",
+					"172.19.0.1:47632",
+					"172.20.0.1:47632"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:31:17.420686103Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7320267184871858,
+				"StableID":   "nqYt3M1NAz11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f02f389197bd1d118452e8758b2fcb44ad2beb3088a68fb0695f472d31f8b1b",
+				"DiscoKey":   "discokey:33267cbb9428670ab6cf6f216938f45d7285cc7ad632cb90d5fc554b14f9c34f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48235",
+					"10.65.0.27:48235",
+					"172.17.0.1:48235",
+					"172.19.0.1:48235",
+					"172.20.0.1:48235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:31:17.952478308Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6064876782325360,
+				"StableID":   "nBJS4g2oMp11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4f043bb6583ee4142b9216a0dd574b0ef2a839f8fa13e656aa5487ecf8c9262",
+				"DiscoKey":   "discokey:0b5399a0fda2d5705b425c517d97909c42a2fb72936d4e788cc61849b5c93a3f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60028",
+					"10.65.0.27:60028",
+					"172.17.0.1:60028",
+					"172.19.0.1:60028",
+					"172.20.0.1:60028"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:31:18.487616053Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6190575241389124,
+				"StableID":   "nPQFT2viLq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c06b267227d9b73a85495fb249f3b000ee88a5eac0da0216f6ae589e9effb72",
+				"DiscoKey":   "discokey:63a10159bf1cd849e9ac89670a8f3bafa8864a77b3a0474e3aaf02f4d3f7da74",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50799",
+					"10.65.0.27:50799",
+					"172.17.0.1:50799",
+					"172.19.0.1:50799",
+					"172.20.0.1:50799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:31:19.020986912Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2500128367141695,
+				"StableID":   "n2xyWh8KXL11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc14403de5b59f17c25ceffcbfbde553514bd0c83b3862a1066fd3a178966900",
+				"DiscoKey":   "discokey:e97c2ec9624e6491617befca8c2bc7fe18a7c555d3284736eea2c57a64719718",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38979",
+					"10.65.0.27:38979",
+					"172.17.0.1:38979",
+					"172.19.0.1:38979",
+					"172.20.0.1:38979"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:31:19.572625618Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6018771449274370,
+				"StableID":   "nHv9fMvuzo11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:75272388961ad9efc493bba573435087058742a534c6a7b0cd0020a5fba9f903",
+				"DiscoKey":   "discokey:00b87658bf77e6c7d3ae42fe86cab4230ac7869ff45c560c9ff4aea51b70966a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50649",
+					"10.65.0.27:50649",
+					"172.17.0.1:50649",
+					"172.19.0.1:50649",
+					"172.20.0.1:50649"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:31:20.115834221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8600735414959657,
+				"StableID":   "nUSYndjHAA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d66ecff48c953fe69cf0da5173bbc34fd97307a3118e886219f315611c45707",
+				"DiscoKey":   "discokey:f1453fe54b873844a5c21cab00f409d855a8cc8a0453cbfa666baf20a57f057b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:59992",
+					"10.65.0.27:59992",
+					"172.17.0.1:59992",
+					"172.19.0.1:59992",
+					"172.20.0.1:59992"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:31:21.201561884Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2484612260952031,
+				"StableID":   "nSn2MxYHQL11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:84a6dab801169010044a05832995689e030afc0f607076b8f298079bc69b8f3c",
+				"DiscoKey":   "discokey:06e16102adc9a946ed52b76f475f005ba5b6cc70e67462032aa5832310a5af15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34171",
+					"10.65.0.27:34171",
+					"172.17.0.1:34171",
+					"172.19.0.1:34171",
+					"172.20.0.1:34171"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:31:21.815156604Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5912791772272414,
+				"StableID":   "njjfWn1vAo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea18f42406c5fd8bf4a12593e1c896cda202c9b4f7374bfec9a89b8baf7ad852",
+				"DiscoKey":   "discokey:01c020f68d3ad4ad4b755b2acd7062095e779b5e01dd2544901305482f2d3300",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44665",
+					"10.65.0.27:44665",
+					"172.17.0.1:44665",
+					"172.19.0.1:44665",
+					"172.20.0.1:44665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:31:22.325651843Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6676408452980474,
+				"StableID":   "nsbnhsvk8u11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c7ca6fa6e3399e64976fcc16d503a8cc59a7380448551f159fc8bc469efa458",
+				"DiscoKey":   "discokey:7d9db05cad84fdefd39a9e1d005bb9f6e32030fadb1c732b69eaa2f7b3d3156a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38499",
+					"10.65.0.27:38499",
+					"172.17.0.1:38499",
+					"172.19.0.1:38499",
+					"172.20.0.1:38499"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:31:22.883829276Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4667506974766359,
+				"StableID":   "nt1YEdVvSd11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b7d072cb98b6d6774773a5165f2132f9d55b6b4d46b910e35b7a20965447b29",
+				"DiscoKey":   "discokey:8bc0ed9fcccced5638d6d75cda6e94e4384788feab31f83488c0389be373fd23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59438",
+					"10.65.0.27:59438",
+					"172.17.0.1:59438",
+					"172.19.0.1:59438",
+					"172.20.0.1:59438"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 44673},
+					{"Proto": "peerapi6", "Port": 44673}
+				]},
+				"Created":              "2026-05-12T18:31:23.438919322Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7168621603691798,
+				"StableID":   "njRxKxXgyx11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:503db194f16af28c09dedfa8702935d75335fc61867678e6888e734cd1929554",
+				"KeyExpiry":  "2026-11-08T18:31:23Z",
+				"DiscoKey":   "discokey:6dec407066cdcff25f069f3dfed86c15a80789e88428f7fb4055a3b9eb04081e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43354",
+					"10.65.0.27:43354",
+					"172.17.0.1:43354",
+					"172.19.0.1:43354",
+					"172.20.0.1:43354"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:31:23.98046685Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4220893357629997,
+				"StableID":   "nk88FFiexZ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1260c1a536f9f3de750f1ae0a95155e60503bfccc0ac0dc041a3cf283117974b",
+				"KeyExpiry":  "2026-11-08T18:31:24Z",
+				"DiscoKey":   "discokey:18dbf645ab26e3a5d998c824ed14146ba1cd3a5499572db6aff614b0e5d9607e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47150",
+					"10.65.0.27:47150",
+					"172.17.0.1:47150",
+					"172.19.0.1:47150",
+					"172.20.0.1:47150"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:31:24.505613019Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5071721211584182,
+				"StableID":   "nXR7BwWzbg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:47e209951198d8a52b7011240da1b24d5a2f566db27d53c4c46b528b692bd613",
+				"KeyExpiry":  "2026-11-08T18:31:25Z",
+				"DiscoKey":   "discokey:e4582b9d1355eed3a618c201ff4ccb666c8e0611da5531d32714ea9e2891d975",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38513",
+					"10.65.0.27:38513",
+					"172.17.0.1:38513",
+					"172.19.0.1:38513",
+					"172.20.0.1:38513"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:31:25.037664448Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5801633623032776": {
+				"ID":          5801633623032776,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2484612260952031,
+				"StableID":   "nSn2MxYHQL11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       2484612260952031,
+				"Key":        "nodekey:84a6dab801169010044a05832995689e030afc0f607076b8f298079bc69b8f3c",
+				"DiscoKey":   "discokey:06e16102adc9a946ed52b76f475f005ba5b6cc70e67462032aa5832310a5af15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34171",
+					"10.65.0.27:34171",
+					"172.17.0.1:34171",
+					"172.19.0.1:34171",
+					"172.20.0.1:34171"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:31:21.815156604Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:84a6dab801169010044a05832995689e030afc0f607076b8f298079bc69b8f3c",
+			"MachineKey": "mkey:9ebb26d2bf07ff477e0fb34d47ba4a350ead667bbb3a44a679281fbb71898f0a",
+			"Peers": [{
+				"ID":         7670108461148667,
+				"StableID":   "nScEf6kot221CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c2f5bfb985df504c47aa946680050a72bdf6c812b49183059793aa98030b331",
+				"DiscoKey":   "discokey:6d1d0f0458f5966eb167cb7e078a25bdf21007c1a9cdd8d7ebe8f2b3b0ab1a3f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47632",
+					"10.65.0.27:47632",
+					"172.17.0.1:47632",
+					"172.19.0.1:47632",
+					"172.20.0.1:47632"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:31:17.420686103Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7320267184871858,
+				"StableID":   "nqYt3M1NAz11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f02f389197bd1d118452e8758b2fcb44ad2beb3088a68fb0695f472d31f8b1b",
+				"DiscoKey":   "discokey:33267cbb9428670ab6cf6f216938f45d7285cc7ad632cb90d5fc554b14f9c34f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48235",
+					"10.65.0.27:48235",
+					"172.17.0.1:48235",
+					"172.19.0.1:48235",
+					"172.20.0.1:48235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:31:17.952478308Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6064876782325360,
+				"StableID":   "nBJS4g2oMp11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4f043bb6583ee4142b9216a0dd574b0ef2a839f8fa13e656aa5487ecf8c9262",
+				"DiscoKey":   "discokey:0b5399a0fda2d5705b425c517d97909c42a2fb72936d4e788cc61849b5c93a3f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60028",
+					"10.65.0.27:60028",
+					"172.17.0.1:60028",
+					"172.19.0.1:60028",
+					"172.20.0.1:60028"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:31:18.487616053Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6190575241389124,
+				"StableID":   "nPQFT2viLq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c06b267227d9b73a85495fb249f3b000ee88a5eac0da0216f6ae589e9effb72",
+				"DiscoKey":   "discokey:63a10159bf1cd849e9ac89670a8f3bafa8864a77b3a0474e3aaf02f4d3f7da74",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50799",
+					"10.65.0.27:50799",
+					"172.17.0.1:50799",
+					"172.19.0.1:50799",
+					"172.20.0.1:50799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:31:19.020986912Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2500128367141695,
+				"StableID":   "n2xyWh8KXL11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc14403de5b59f17c25ceffcbfbde553514bd0c83b3862a1066fd3a178966900",
+				"DiscoKey":   "discokey:e97c2ec9624e6491617befca8c2bc7fe18a7c555d3284736eea2c57a64719718",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38979",
+					"10.65.0.27:38979",
+					"172.17.0.1:38979",
+					"172.19.0.1:38979",
+					"172.20.0.1:38979"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:31:19.572625618Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6018771449274370,
+				"StableID":   "nHv9fMvuzo11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:75272388961ad9efc493bba573435087058742a534c6a7b0cd0020a5fba9f903",
+				"DiscoKey":   "discokey:00b87658bf77e6c7d3ae42fe86cab4230ac7869ff45c560c9ff4aea51b70966a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50649",
+					"10.65.0.27:50649",
+					"172.17.0.1:50649",
+					"172.19.0.1:50649",
+					"172.20.0.1:50649"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:31:20.115834221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5801633623032776,
+				"StableID":   "nDZNWV5aJn11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d445ba4f790f1ab053099b3a82e60082b5e5b41a247dc22bba6c735fe16ec24f",
+				"DiscoKey":   "discokey:f6fb2588937a6447413bc04f8ad4d498c7beb8bfe9adcf2f6baad0d882c0de39",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:34062",
+					"10.65.0.27:34062",
+					"172.17.0.1:34062",
+					"172.19.0.1:34062",
+					"172.20.0.1:34062"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:31:20.659145763Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8600735414959657,
+				"StableID":   "nUSYndjHAA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d66ecff48c953fe69cf0da5173bbc34fd97307a3118e886219f315611c45707",
+				"DiscoKey":   "discokey:f1453fe54b873844a5c21cab00f409d855a8cc8a0453cbfa666baf20a57f057b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:59992",
+					"10.65.0.27:59992",
+					"172.17.0.1:59992",
+					"172.19.0.1:59992",
+					"172.20.0.1:59992"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:31:21.201561884Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5912791772272414,
+				"StableID":   "njjfWn1vAo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea18f42406c5fd8bf4a12593e1c896cda202c9b4f7374bfec9a89b8baf7ad852",
+				"DiscoKey":   "discokey:01c020f68d3ad4ad4b755b2acd7062095e779b5e01dd2544901305482f2d3300",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44665",
+					"10.65.0.27:44665",
+					"172.17.0.1:44665",
+					"172.19.0.1:44665",
+					"172.20.0.1:44665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:31:22.325651843Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6676408452980474,
+				"StableID":   "nsbnhsvk8u11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c7ca6fa6e3399e64976fcc16d503a8cc59a7380448551f159fc8bc469efa458",
+				"DiscoKey":   "discokey:7d9db05cad84fdefd39a9e1d005bb9f6e32030fadb1c732b69eaa2f7b3d3156a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38499",
+					"10.65.0.27:38499",
+					"172.17.0.1:38499",
+					"172.19.0.1:38499",
+					"172.20.0.1:38499"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:31:22.883829276Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4667506974766359,
+				"StableID":   "nt1YEdVvSd11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b7d072cb98b6d6774773a5165f2132f9d55b6b4d46b910e35b7a20965447b29",
+				"DiscoKey":   "discokey:8bc0ed9fcccced5638d6d75cda6e94e4384788feab31f83488c0389be373fd23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59438",
+					"10.65.0.27:59438",
+					"172.17.0.1:59438",
+					"172.19.0.1:59438",
+					"172.20.0.1:59438"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 44673},
+					{"Proto": "peerapi6", "Port": 44673}
+				]},
+				"Created":              "2026-05-12T18:31:23.438919322Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7168621603691798,
+				"StableID":   "njRxKxXgyx11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:503db194f16af28c09dedfa8702935d75335fc61867678e6888e734cd1929554",
+				"KeyExpiry":  "2026-11-08T18:31:23Z",
+				"DiscoKey":   "discokey:6dec407066cdcff25f069f3dfed86c15a80789e88428f7fb4055a3b9eb04081e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43354",
+					"10.65.0.27:43354",
+					"172.17.0.1:43354",
+					"172.19.0.1:43354",
+					"172.20.0.1:43354"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:31:23.98046685Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4220893357629997,
+				"StableID":   "nk88FFiexZ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1260c1a536f9f3de750f1ae0a95155e60503bfccc0ac0dc041a3cf283117974b",
+				"KeyExpiry":  "2026-11-08T18:31:24Z",
+				"DiscoKey":   "discokey:18dbf645ab26e3a5d998c824ed14146ba1cd3a5499572db6aff614b0e5d9607e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47150",
+					"10.65.0.27:47150",
+					"172.17.0.1:47150",
+					"172.19.0.1:47150",
+					"172.20.0.1:47150"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:31:24.505613019Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5071721211584182,
+				"StableID":   "nXR7BwWzbg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:47e209951198d8a52b7011240da1b24d5a2f566db27d53c4c46b528b692bd613",
+				"KeyExpiry":  "2026-11-08T18:31:25Z",
+				"DiscoKey":   "discokey:e4582b9d1355eed3a618c201ff4ccb666c8e0611da5531d32714ea9e2891d975",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38513",
+					"10.65.0.27:38513",
+					"172.17.0.1:38513",
+					"172.19.0.1:38513",
+					"172.20.0.1:38513"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:31:25.037664448Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2484612260952031": {
+				"ID":          2484612260952031,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4220893357629997,
+				"StableID":   "nk88FFiexZ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1260c1a536f9f3de750f1ae0a95155e60503bfccc0ac0dc041a3cf283117974b",
+				"KeyExpiry":  "2026-11-08T18:31:24Z",
+				"DiscoKey":   "discokey:18dbf645ab26e3a5d998c824ed14146ba1cd3a5499572db6aff614b0e5d9607e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47150",
+					"10.65.0.27:47150",
+					"172.17.0.1:47150",
+					"172.19.0.1:47150",
+					"172.20.0.1:47150"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:31:24.505613019Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1260c1a536f9f3de750f1ae0a95155e60503bfccc0ac0dc041a3cf283117974b",
+			"MachineKey": "mkey:e76dcc47c2e2f5dc4b328f4e0c60f1f1b77256d925a56f2df6301869342ce977",
+			"Peers": [{
+				"ID":         7670108461148667,
+				"StableID":   "nScEf6kot221CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c2f5bfb985df504c47aa946680050a72bdf6c812b49183059793aa98030b331",
+				"DiscoKey":   "discokey:6d1d0f0458f5966eb167cb7e078a25bdf21007c1a9cdd8d7ebe8f2b3b0ab1a3f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47632",
+					"10.65.0.27:47632",
+					"172.17.0.1:47632",
+					"172.19.0.1:47632",
+					"172.20.0.1:47632"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:31:17.420686103Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7320267184871858,
+				"StableID":   "nqYt3M1NAz11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f02f389197bd1d118452e8758b2fcb44ad2beb3088a68fb0695f472d31f8b1b",
+				"DiscoKey":   "discokey:33267cbb9428670ab6cf6f216938f45d7285cc7ad632cb90d5fc554b14f9c34f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48235",
+					"10.65.0.27:48235",
+					"172.17.0.1:48235",
+					"172.19.0.1:48235",
+					"172.20.0.1:48235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:31:17.952478308Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6064876782325360,
+				"StableID":   "nBJS4g2oMp11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4f043bb6583ee4142b9216a0dd574b0ef2a839f8fa13e656aa5487ecf8c9262",
+				"DiscoKey":   "discokey:0b5399a0fda2d5705b425c517d97909c42a2fb72936d4e788cc61849b5c93a3f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60028",
+					"10.65.0.27:60028",
+					"172.17.0.1:60028",
+					"172.19.0.1:60028",
+					"172.20.0.1:60028"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:31:18.487616053Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6190575241389124,
+				"StableID":   "nPQFT2viLq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c06b267227d9b73a85495fb249f3b000ee88a5eac0da0216f6ae589e9effb72",
+				"DiscoKey":   "discokey:63a10159bf1cd849e9ac89670a8f3bafa8864a77b3a0474e3aaf02f4d3f7da74",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50799",
+					"10.65.0.27:50799",
+					"172.17.0.1:50799",
+					"172.19.0.1:50799",
+					"172.20.0.1:50799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:31:19.020986912Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2500128367141695,
+				"StableID":   "n2xyWh8KXL11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc14403de5b59f17c25ceffcbfbde553514bd0c83b3862a1066fd3a178966900",
+				"DiscoKey":   "discokey:e97c2ec9624e6491617befca8c2bc7fe18a7c555d3284736eea2c57a64719718",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38979",
+					"10.65.0.27:38979",
+					"172.17.0.1:38979",
+					"172.19.0.1:38979",
+					"172.20.0.1:38979"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:31:19.572625618Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6018771449274370,
+				"StableID":   "nHv9fMvuzo11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:75272388961ad9efc493bba573435087058742a534c6a7b0cd0020a5fba9f903",
+				"DiscoKey":   "discokey:00b87658bf77e6c7d3ae42fe86cab4230ac7869ff45c560c9ff4aea51b70966a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50649",
+					"10.65.0.27:50649",
+					"172.17.0.1:50649",
+					"172.19.0.1:50649",
+					"172.20.0.1:50649"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:31:20.115834221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5801633623032776,
+				"StableID":   "nDZNWV5aJn11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d445ba4f790f1ab053099b3a82e60082b5e5b41a247dc22bba6c735fe16ec24f",
+				"DiscoKey":   "discokey:f6fb2588937a6447413bc04f8ad4d498c7beb8bfe9adcf2f6baad0d882c0de39",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:34062",
+					"10.65.0.27:34062",
+					"172.17.0.1:34062",
+					"172.19.0.1:34062",
+					"172.20.0.1:34062"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:31:20.659145763Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8600735414959657,
+				"StableID":   "nUSYndjHAA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d66ecff48c953fe69cf0da5173bbc34fd97307a3118e886219f315611c45707",
+				"DiscoKey":   "discokey:f1453fe54b873844a5c21cab00f409d855a8cc8a0453cbfa666baf20a57f057b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:59992",
+					"10.65.0.27:59992",
+					"172.17.0.1:59992",
+					"172.19.0.1:59992",
+					"172.20.0.1:59992"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:31:21.201561884Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2484612260952031,
+				"StableID":   "nSn2MxYHQL11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:84a6dab801169010044a05832995689e030afc0f607076b8f298079bc69b8f3c",
+				"DiscoKey":   "discokey:06e16102adc9a946ed52b76f475f005ba5b6cc70e67462032aa5832310a5af15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34171",
+					"10.65.0.27:34171",
+					"172.17.0.1:34171",
+					"172.19.0.1:34171",
+					"172.20.0.1:34171"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:31:21.815156604Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5912791772272414,
+				"StableID":   "njjfWn1vAo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea18f42406c5fd8bf4a12593e1c896cda202c9b4f7374bfec9a89b8baf7ad852",
+				"DiscoKey":   "discokey:01c020f68d3ad4ad4b755b2acd7062095e779b5e01dd2544901305482f2d3300",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44665",
+					"10.65.0.27:44665",
+					"172.17.0.1:44665",
+					"172.19.0.1:44665",
+					"172.20.0.1:44665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:31:22.325651843Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6676408452980474,
+				"StableID":   "nsbnhsvk8u11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c7ca6fa6e3399e64976fcc16d503a8cc59a7380448551f159fc8bc469efa458",
+				"DiscoKey":   "discokey:7d9db05cad84fdefd39a9e1d005bb9f6e32030fadb1c732b69eaa2f7b3d3156a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38499",
+					"10.65.0.27:38499",
+					"172.17.0.1:38499",
+					"172.19.0.1:38499",
+					"172.20.0.1:38499"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:31:22.883829276Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4667506974766359,
+				"StableID":   "nt1YEdVvSd11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b7d072cb98b6d6774773a5165f2132f9d55b6b4d46b910e35b7a20965447b29",
+				"DiscoKey":   "discokey:8bc0ed9fcccced5638d6d75cda6e94e4384788feab31f83488c0389be373fd23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59438",
+					"10.65.0.27:59438",
+					"172.17.0.1:59438",
+					"172.19.0.1:59438",
+					"172.20.0.1:59438"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 44673},
+					{"Proto": "peerapi6", "Port": 44673}
+				]},
+				"Created":              "2026-05-12T18:31:23.438919322Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7168621603691798,
+				"StableID":   "njRxKxXgyx11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:503db194f16af28c09dedfa8702935d75335fc61867678e6888e734cd1929554",
+				"KeyExpiry":  "2026-11-08T18:31:23Z",
+				"DiscoKey":   "discokey:6dec407066cdcff25f069f3dfed86c15a80789e88428f7fb4055a3b9eb04081e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43354",
+					"10.65.0.27:43354",
+					"172.17.0.1:43354",
+					"172.19.0.1:43354",
+					"172.20.0.1:43354"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:31:23.98046685Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5071721211584182,
+				"StableID":   "nXR7BwWzbg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:47e209951198d8a52b7011240da1b24d5a2f566db27d53c4c46b528b692bd613",
+				"KeyExpiry":  "2026-11-08T18:31:25Z",
+				"DiscoKey":   "discokey:e4582b9d1355eed3a618c201ff4ccb666c8e0611da5531d32714ea9e2891d975",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38513",
+					"10.65.0.27:38513",
+					"172.17.0.1:38513",
+					"172.19.0.1:38513",
+					"172.20.0.1:38513"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:31:25.037664448Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5912791772272414,
+				"StableID":   "njjfWn1vAo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       5912791772272414,
+				"Key":        "nodekey:ea18f42406c5fd8bf4a12593e1c896cda202c9b4f7374bfec9a89b8baf7ad852",
+				"DiscoKey":   "discokey:01c020f68d3ad4ad4b755b2acd7062095e779b5e01dd2544901305482f2d3300",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44665",
+					"10.65.0.27:44665",
+					"172.17.0.1:44665",
+					"172.19.0.1:44665",
+					"172.20.0.1:44665"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:31:22.325651843Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ea18f42406c5fd8bf4a12593e1c896cda202c9b4f7374bfec9a89b8baf7ad852",
+			"MachineKey": "mkey:9f0e7dc1bfff6d087350298237e811668d3227a61b655a923448c7b177a1c317",
+			"Peers": [{
+				"ID":         7670108461148667,
+				"StableID":   "nScEf6kot221CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0c2f5bfb985df504c47aa946680050a72bdf6c812b49183059793aa98030b331",
+				"DiscoKey":   "discokey:6d1d0f0458f5966eb167cb7e078a25bdf21007c1a9cdd8d7ebe8f2b3b0ab1a3f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:47632",
+					"10.65.0.27:47632",
+					"172.17.0.1:47632",
+					"172.19.0.1:47632",
+					"172.20.0.1:47632"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:31:17.420686103Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7320267184871858,
+				"StableID":   "nqYt3M1NAz11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9f02f389197bd1d118452e8758b2fcb44ad2beb3088a68fb0695f472d31f8b1b",
+				"DiscoKey":   "discokey:33267cbb9428670ab6cf6f216938f45d7285cc7ad632cb90d5fc554b14f9c34f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48235",
+					"10.65.0.27:48235",
+					"172.17.0.1:48235",
+					"172.19.0.1:48235",
+					"172.20.0.1:48235"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:31:17.952478308Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6064876782325360,
+				"StableID":   "nBJS4g2oMp11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4f043bb6583ee4142b9216a0dd574b0ef2a839f8fa13e656aa5487ecf8c9262",
+				"DiscoKey":   "discokey:0b5399a0fda2d5705b425c517d97909c42a2fb72936d4e788cc61849b5c93a3f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:60028",
+					"10.65.0.27:60028",
+					"172.17.0.1:60028",
+					"172.19.0.1:60028",
+					"172.20.0.1:60028"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:31:18.487616053Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6190575241389124,
+				"StableID":   "nPQFT2viLq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5c06b267227d9b73a85495fb249f3b000ee88a5eac0da0216f6ae589e9effb72",
+				"DiscoKey":   "discokey:63a10159bf1cd849e9ac89670a8f3bafa8864a77b3a0474e3aaf02f4d3f7da74",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:50799",
+					"10.65.0.27:50799",
+					"172.17.0.1:50799",
+					"172.19.0.1:50799",
+					"172.20.0.1:50799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:31:19.020986912Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2500128367141695,
+				"StableID":   "n2xyWh8KXL11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cc14403de5b59f17c25ceffcbfbde553514bd0c83b3862a1066fd3a178966900",
+				"DiscoKey":   "discokey:e97c2ec9624e6491617befca8c2bc7fe18a7c555d3284736eea2c57a64719718",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:38979",
+					"10.65.0.27:38979",
+					"172.17.0.1:38979",
+					"172.19.0.1:38979",
+					"172.20.0.1:38979"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:31:19.572625618Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6018771449274370,
+				"StableID":   "nHv9fMvuzo11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:75272388961ad9efc493bba573435087058742a534c6a7b0cd0020a5fba9f903",
+				"DiscoKey":   "discokey:00b87658bf77e6c7d3ae42fe86cab4230ac7869ff45c560c9ff4aea51b70966a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50649",
+					"10.65.0.27:50649",
+					"172.17.0.1:50649",
+					"172.19.0.1:50649",
+					"172.20.0.1:50649"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:31:20.115834221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5801633623032776,
+				"StableID":   "nDZNWV5aJn11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d445ba4f790f1ab053099b3a82e60082b5e5b41a247dc22bba6c735fe16ec24f",
+				"DiscoKey":   "discokey:f6fb2588937a6447413bc04f8ad4d498c7beb8bfe9adcf2f6baad0d882c0de39",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:34062",
+					"10.65.0.27:34062",
+					"172.17.0.1:34062",
+					"172.19.0.1:34062",
+					"172.20.0.1:34062"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:31:20.659145763Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8600735414959657,
+				"StableID":   "nUSYndjHAA21CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d66ecff48c953fe69cf0da5173bbc34fd97307a3118e886219f315611c45707",
+				"DiscoKey":   "discokey:f1453fe54b873844a5c21cab00f409d855a8cc8a0453cbfa666baf20a57f057b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:59992",
+					"10.65.0.27:59992",
+					"172.17.0.1:59992",
+					"172.19.0.1:59992",
+					"172.20.0.1:59992"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:31:21.201561884Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2484612260952031,
+				"StableID":   "nSn2MxYHQL11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:84a6dab801169010044a05832995689e030afc0f607076b8f298079bc69b8f3c",
+				"DiscoKey":   "discokey:06e16102adc9a946ed52b76f475f005ba5b6cc70e67462032aa5832310a5af15",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34171",
+					"10.65.0.27:34171",
+					"172.17.0.1:34171",
+					"172.19.0.1:34171",
+					"172.20.0.1:34171"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:31:21.815156604Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6676408452980474,
+				"StableID":   "nsbnhsvk8u11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c7ca6fa6e3399e64976fcc16d503a8cc59a7380448551f159fc8bc469efa458",
+				"DiscoKey":   "discokey:7d9db05cad84fdefd39a9e1d005bb9f6e32030fadb1c732b69eaa2f7b3d3156a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38499",
+					"10.65.0.27:38499",
+					"172.17.0.1:38499",
+					"172.19.0.1:38499",
+					"172.20.0.1:38499"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:31:22.883829276Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4667506974766359,
+				"StableID":   "nt1YEdVvSd11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b7d072cb98b6d6774773a5165f2132f9d55b6b4d46b910e35b7a20965447b29",
+				"DiscoKey":   "discokey:8bc0ed9fcccced5638d6d75cda6e94e4384788feab31f83488c0389be373fd23",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59438",
+					"10.65.0.27:59438",
+					"172.17.0.1:59438",
+					"172.19.0.1:59438",
+					"172.20.0.1:59438"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 44673},
+					{"Proto": "peerapi6", "Port": 44673}
+				]},
+				"Created":              "2026-05-12T18:31:23.438919322Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7168621603691798,
+				"StableID":   "njRxKxXgyx11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:503db194f16af28c09dedfa8702935d75335fc61867678e6888e734cd1929554",
+				"KeyExpiry":  "2026-11-08T18:31:23Z",
+				"DiscoKey":   "discokey:6dec407066cdcff25f069f3dfed86c15a80789e88428f7fb4055a3b9eb04081e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43354",
+					"10.65.0.27:43354",
+					"172.17.0.1:43354",
+					"172.19.0.1:43354",
+					"172.20.0.1:43354"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:31:23.98046685Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4220893357629997,
+				"StableID":   "nk88FFiexZ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:1260c1a536f9f3de750f1ae0a95155e60503bfccc0ac0dc041a3cf283117974b",
+				"KeyExpiry":  "2026-11-08T18:31:24Z",
+				"DiscoKey":   "discokey:18dbf645ab26e3a5d998c824ed14146ba1cd3a5499572db6aff614b0e5d9607e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47150",
+					"10.65.0.27:47150",
+					"172.17.0.1:47150",
+					"172.19.0.1:47150",
+					"172.20.0.1:47150"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:31:24.505613019Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5071721211584182,
+				"StableID":   "nXR7BwWzbg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:47e209951198d8a52b7011240da1b24d5a2f566db27d53c4c46b528b692bd613",
+				"KeyExpiry":  "2026-11-08T18:31:25Z",
+				"DiscoKey":   "discokey:e4582b9d1355eed3a618c201ff4ccb666c8e0611da5531d32714ea9e2891d975",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38513",
+					"10.65.0.27:38513",
+					"172.17.0.1:38513",
+					"172.19.0.1:38513",
+					"172.20.0.1:38513"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:31:25.037664448Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5912791772272414": {
+				"ID":          5912791772272414,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/sshtest_results/sshtest-action-check-treated-as-allowed.hujson
+++ b/hscontrol/policy/v2/testdata/sshtest_results/sshtest-action-check-treated-as-allowed.hujson
@@ -1,0 +1,20094 @@
+// sshtest-action-check-treated-as-allowed
+//
+// action:check rule asserted via sshTests check[]
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T18:32:10Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "sshtest-action-check-treated-as-allowed",
+	"description":    "action:check rule asserted via sshTests check[]",
+	"category":       "sshtest",
+	"captured_at":    "2026-05-12T18:32:10.356519533Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                          \n  \n                                                                      \n                                                \n{\n\t\"category\":    \"sshtest\",\n\t\"description\": \"action:check rule asserted via sshTests check[]\",\n\t\"id\":          \"sshtest-action-check-treated-as-allowed\",\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\":      \"check\",\n\t\t\"checkPeriod\": \"12h\",\n\t\t\"dst\":         [\"tag:server\"],\n\t\t\"src\":         [\"thor@example.org\"],\n\t\t\"users\":       [\"root\"]\n\t}], \"sshTests\": [{\n\t\t\"check\": [\"root\"],\n\t\t\"dst\":   [\"tag:server\"],\n\t\t\"src\":   \"thor@example.org\"\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/sshtest/sshtest-action-check-treated-as-allowed.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action":      "check",
+				"checkPeriod": "12h",
+				"dst":         ["tag:server"],
+				"src":         ["thor@example.org"],
+				"users":       ["root"]
+			}],
+			"sshTests":  [{"check": ["root"], "dst": ["tag:server"], "src": "thor@example.org"}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7660868258443220,
+				"StableID":   "nM76b52dp221CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       7660868258443220,
+				"Key":        "nodekey:36ac8acbbdc4e7461c32670facafc19d77cc2241d2512deac8d8bfa59136ee46",
+				"DiscoKey":   "discokey:4f855703a0c6ff4548322e91cc34b324224ff4e760539143f31d1234ebd02a51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:53115",
+					"10.65.0.27:53115",
+					"172.17.0.1:53115",
+					"172.19.0.1:53115",
+					"172.20.0.1:53115"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:32:18.850273543Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:36ac8acbbdc4e7461c32670facafc19d77cc2241d2512deac8d8bfa59136ee46",
+			"MachineKey": "mkey:1a93d8952b5a1f9e7dbdc58ee296beb39c0092c9eb13edc1ae5837f8b07d4006",
+			"Peers": [{
+				"ID":         7742721577423862,
+				"StableID":   "nFFN6fAhT321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:902119616bcd067166ea48b310c7ca41b1b2ab46acf197b7d7c02bceb1e8ab0e",
+				"DiscoKey":   "discokey:cc1c3a0527f8341e7b409eb82c20bc483c43b292452d11c0fc898ba5dd6fea41",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:56470",
+					"10.65.0.27:56470",
+					"172.17.0.1:56470",
+					"172.19.0.1:56470",
+					"172.20.0.1:56470"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:32:12.903975602Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7653696384495579,
+				"StableID":   "n6pTeHdNm221CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:84305a1d96b18015840e31377e672cc896c272dac9a0dc1e5efde6ec7fb29a20",
+				"DiscoKey":   "discokey:f712525b2af2bc2d95db157980742f75ee8c0e6d6d5f73d7d4d3de71ff0f295a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37333",
+					"10.65.0.27:37333",
+					"172.17.0.1:37333",
+					"172.19.0.1:37333",
+					"172.20.0.1:37333"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:32:13.453546408Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7822788726870038,
+				"StableID":   "nqztutPx5421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7e51416a52a9110cd3fad145977448e098923c03ef2ee53f2e5cee41c6be414",
+				"DiscoKey":   "discokey:376a11ffcecd094d3066c2b7563a4ff91785dc2861cb7fa0b3746965faeab271",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41585",
+					"10.65.0.27:41585",
+					"172.17.0.1:41585",
+					"172.19.0.1:41585",
+					"172.20.0.1:41585"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:32:13.99653772Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7337416301468498,
+				"StableID":   "nqU2m5V8Jz11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4092b5c99cdb9b3757aeae27a79539cd74bd392fb3693d0535344a40c4eb37e",
+				"DiscoKey":   "discokey:f73bf845dfb061af8e8ec2b135249ac7f6b0dcfbc82fe2a24f1d10737d406801",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56017",
+					"10.65.0.27:56017",
+					"172.17.0.1:56017",
+					"172.19.0.1:56017",
+					"172.20.0.1:56017"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:32:14.526492479Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6530979098763741,
+				"StableID":   "ngatfHktzs11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:456d8df79530f5211dfd525c45e508f2cffc3578c55d161b51913e9832ca046f",
+				"DiscoKey":   "discokey:7e40a59658c0eb556738fdd5b29a9c555f62a089090fd5e691a1b1ff63e7b05f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55361",
+					"10.65.0.27:55361",
+					"172.17.0.1:55361",
+					"172.19.0.1:55361",
+					"172.20.0.1:55361"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:32:15.069827367Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2517747849710593,
+				"StableID":   "nQ8gr4yHfL11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a1ddcb033ed5e74eb456e324cdab5f412e190d072eae4f76e0769d3c095df774",
+				"DiscoKey":   "discokey:139294a6276f864da6a382192299053837018064290aef14db70c00574f2fb69",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:48760",
+					"10.65.0.27:48760",
+					"172.17.0.1:48760",
+					"172.19.0.1:48760",
+					"172.20.0.1:48760"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:32:15.597080057Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6838958301879313,
+				"StableID":   "nzX2EbqNQv11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd33a2684a4d8116ae6a9f9a29accda91ee75200b60260cd7ea7e88783b88c33",
+				"DiscoKey":   "discokey:00c85530ef7afb763e0e81875090d06ba2dcefe9f276d50fdcc1134349027764",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:46349",
+					"10.65.0.27:46349",
+					"172.17.0.1:46349",
+					"172.19.0.1:46349",
+					"172.20.0.1:46349"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:32:16.135347917Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4896979443737729,
+				"StableID":   "ncSSX5MrEf11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ed075d9376fbfc5e81ea7ab1416cf3a80b622d1c054144ee46235060a893960",
+				"DiscoKey":   "discokey:901ac3ba06b28bd5baa1c657979edc057c1cfaac3be65e0982407c8bf094a96e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49291",
+					"10.65.0.27:49291",
+					"172.17.0.1:49291",
+					"172.19.0.1:49291",
+					"172.20.0.1:49291"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:32:16.685850697Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2441314712356406,
+				"StableID":   "nBF1FUCg4L11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a126fbc286def9c48b4b6b4db77e6b8086782a1784ddaedf112f5ad3cbb4551",
+				"DiscoKey":   "discokey:7b11635a4c1c1db62d7eab3da3f42e59e5223c537d44e6314f57658af7b2570f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41076",
+					"10.65.0.27:41076",
+					"172.17.0.1:41076",
+					"172.19.0.1:41076",
+					"172.20.0.1:41076"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:32:17.221955091Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7213159542142581,
+				"StableID":   "nUNDSFUrKy11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:48deeae5d1a74e18ad2dd70c4abde674add0fb92a0602281f9d68991729fcf5e",
+				"DiscoKey":   "discokey:dbda69eb016a4822020a6c896450b7ac0ab8cc2b79c546798385d799d6baee45",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49926",
+					"10.65.0.27:49926",
+					"172.17.0.1:49926",
+					"172.19.0.1:49926",
+					"172.20.0.1:49926"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:32:17.766631203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7977055529972839,
+				"StableID":   "nWkL3tipH521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:79f06d1ed26e54319d065964d15872f2267cc1ecf7f56426de441ac4251d1773",
+				"DiscoKey":   "discokey:bac5ec857a3afad8a04ec8880a0b1e936ea161c4b271f2675c920b769282f768",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36008",
+					"10.65.0.27:36008",
+					"172.17.0.1:36008",
+					"172.19.0.1:36008",
+					"172.20.0.1:36008"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:32:18.305657926Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2198817906034593,
+				"StableID":   "nadmrdDrAJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5e34245e085df6504a6c02709d65e513f752fdcf96b7081467eb45025a397c08",
+				"KeyExpiry":  "2026-11-08T18:32:19Z",
+				"DiscoKey":   "discokey:f3b92fad07f1d3ce591182dee3eaf8dc5d1d052ba552282d6d9290fbf8a7c918",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33001",
+					"10.65.0.27:33001",
+					"172.17.0.1:33001",
+					"172.19.0.1:33001",
+					"172.20.0.1:33001"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:32:19.390793765Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8322501964150623,
+				"StableID":   "nkmAWp1Hz721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2a6aba6e59e00e32e124286cc338461a517503e3421b0aa1b4070befbf63665c",
+				"KeyExpiry":  "2026-11-08T18:32:19Z",
+				"DiscoKey":   "discokey:a002ae4629752ca3e8a7762b61d30bce26e58e63036698d42754f598df43a75e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55222",
+					"10.65.0.27:55222",
+					"172.17.0.1:55222",
+					"172.19.0.1:55222",
+					"172.20.0.1:55222"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:32:19.935418631Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1361823571364904,
+				"StableID":   "nm33fAomdB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:760e2195462306914e30e0cbf83b93eae29156b3ec710a6e754daaaee1d1731b",
+				"KeyExpiry":  "2026-11-08T18:32:20Z",
+				"DiscoKey":   "discokey:2578a9395027712379d3e4fc5af197e2e1b2e1c77e5480f6724bb2ab80f6c41c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53343",
+					"10.65.0.27:53343",
+					"172.17.0.1:53343",
+					"172.19.0.1:53343",
+					"172.20.0.1:53343"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:32:20.474345204Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{
+				"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+				"sshUsers":   {"root": "root"},
+				"action": {
+					"holdAndDelegate": "https://unused/machine/ssh/action/$SRC_NODE_ID/to/$DST_NODE_ID?local_user=$LOCAL_USER"
+				}
+			}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7660868258443220": {
+				"ID":          7660868258443220,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		},
+		"ssh_rules": [{
+			"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+			"sshUsers":   {"root": "root"},
+			"action": {
+				"holdAndDelegate": "https://unused/machine/ssh/action/$SRC_NODE_ID/to/$DST_NODE_ID?local_user=$LOCAL_USER"
+			}
+		}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2517747849710593,
+				"StableID":   "nQ8gr4yHfL11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       2517747849710593,
+				"Key":        "nodekey:a1ddcb033ed5e74eb456e324cdab5f412e190d072eae4f76e0769d3c095df774",
+				"DiscoKey":   "discokey:139294a6276f864da6a382192299053837018064290aef14db70c00574f2fb69",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:48760",
+					"10.65.0.27:48760",
+					"172.17.0.1:48760",
+					"172.19.0.1:48760",
+					"172.20.0.1:48760"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:32:15.597080057Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a1ddcb033ed5e74eb456e324cdab5f412e190d072eae4f76e0769d3c095df774",
+			"MachineKey": "mkey:3e26a812e2d6d68122392f46d2b9771b7f71b8fc80fd907739d51ab9671b9126",
+			"Peers": [{
+				"ID":         7742721577423862,
+				"StableID":   "nFFN6fAhT321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:902119616bcd067166ea48b310c7ca41b1b2ab46acf197b7d7c02bceb1e8ab0e",
+				"DiscoKey":   "discokey:cc1c3a0527f8341e7b409eb82c20bc483c43b292452d11c0fc898ba5dd6fea41",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:56470",
+					"10.65.0.27:56470",
+					"172.17.0.1:56470",
+					"172.19.0.1:56470",
+					"172.20.0.1:56470"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:32:12.903975602Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7653696384495579,
+				"StableID":   "n6pTeHdNm221CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:84305a1d96b18015840e31377e672cc896c272dac9a0dc1e5efde6ec7fb29a20",
+				"DiscoKey":   "discokey:f712525b2af2bc2d95db157980742f75ee8c0e6d6d5f73d7d4d3de71ff0f295a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37333",
+					"10.65.0.27:37333",
+					"172.17.0.1:37333",
+					"172.19.0.1:37333",
+					"172.20.0.1:37333"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:32:13.453546408Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7822788726870038,
+				"StableID":   "nqztutPx5421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7e51416a52a9110cd3fad145977448e098923c03ef2ee53f2e5cee41c6be414",
+				"DiscoKey":   "discokey:376a11ffcecd094d3066c2b7563a4ff91785dc2861cb7fa0b3746965faeab271",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41585",
+					"10.65.0.27:41585",
+					"172.17.0.1:41585",
+					"172.19.0.1:41585",
+					"172.20.0.1:41585"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:32:13.99653772Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7337416301468498,
+				"StableID":   "nqU2m5V8Jz11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4092b5c99cdb9b3757aeae27a79539cd74bd392fb3693d0535344a40c4eb37e",
+				"DiscoKey":   "discokey:f73bf845dfb061af8e8ec2b135249ac7f6b0dcfbc82fe2a24f1d10737d406801",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56017",
+					"10.65.0.27:56017",
+					"172.17.0.1:56017",
+					"172.19.0.1:56017",
+					"172.20.0.1:56017"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:32:14.526492479Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6530979098763741,
+				"StableID":   "ngatfHktzs11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:456d8df79530f5211dfd525c45e508f2cffc3578c55d161b51913e9832ca046f",
+				"DiscoKey":   "discokey:7e40a59658c0eb556738fdd5b29a9c555f62a089090fd5e691a1b1ff63e7b05f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55361",
+					"10.65.0.27:55361",
+					"172.17.0.1:55361",
+					"172.19.0.1:55361",
+					"172.20.0.1:55361"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:32:15.069827367Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6838958301879313,
+				"StableID":   "nzX2EbqNQv11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd33a2684a4d8116ae6a9f9a29accda91ee75200b60260cd7ea7e88783b88c33",
+				"DiscoKey":   "discokey:00c85530ef7afb763e0e81875090d06ba2dcefe9f276d50fdcc1134349027764",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:46349",
+					"10.65.0.27:46349",
+					"172.17.0.1:46349",
+					"172.19.0.1:46349",
+					"172.20.0.1:46349"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:32:16.135347917Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4896979443737729,
+				"StableID":   "ncSSX5MrEf11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ed075d9376fbfc5e81ea7ab1416cf3a80b622d1c054144ee46235060a893960",
+				"DiscoKey":   "discokey:901ac3ba06b28bd5baa1c657979edc057c1cfaac3be65e0982407c8bf094a96e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49291",
+					"10.65.0.27:49291",
+					"172.17.0.1:49291",
+					"172.19.0.1:49291",
+					"172.20.0.1:49291"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:32:16.685850697Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2441314712356406,
+				"StableID":   "nBF1FUCg4L11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a126fbc286def9c48b4b6b4db77e6b8086782a1784ddaedf112f5ad3cbb4551",
+				"DiscoKey":   "discokey:7b11635a4c1c1db62d7eab3da3f42e59e5223c537d44e6314f57658af7b2570f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41076",
+					"10.65.0.27:41076",
+					"172.17.0.1:41076",
+					"172.19.0.1:41076",
+					"172.20.0.1:41076"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:32:17.221955091Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7213159542142581,
+				"StableID":   "nUNDSFUrKy11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:48deeae5d1a74e18ad2dd70c4abde674add0fb92a0602281f9d68991729fcf5e",
+				"DiscoKey":   "discokey:dbda69eb016a4822020a6c896450b7ac0ab8cc2b79c546798385d799d6baee45",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49926",
+					"10.65.0.27:49926",
+					"172.17.0.1:49926",
+					"172.19.0.1:49926",
+					"172.20.0.1:49926"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:32:17.766631203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7977055529972839,
+				"StableID":   "nWkL3tipH521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:79f06d1ed26e54319d065964d15872f2267cc1ecf7f56426de441ac4251d1773",
+				"DiscoKey":   "discokey:bac5ec857a3afad8a04ec8880a0b1e936ea161c4b271f2675c920b769282f768",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36008",
+					"10.65.0.27:36008",
+					"172.17.0.1:36008",
+					"172.19.0.1:36008",
+					"172.20.0.1:36008"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:32:18.305657926Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7660868258443220,
+				"StableID":   "nM76b52dp221CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36ac8acbbdc4e7461c32670facafc19d77cc2241d2512deac8d8bfa59136ee46",
+				"DiscoKey":   "discokey:4f855703a0c6ff4548322e91cc34b324224ff4e760539143f31d1234ebd02a51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:53115",
+					"10.65.0.27:53115",
+					"172.17.0.1:53115",
+					"172.19.0.1:53115",
+					"172.20.0.1:53115"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:32:18.850273543Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2198817906034593,
+				"StableID":   "nadmrdDrAJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5e34245e085df6504a6c02709d65e513f752fdcf96b7081467eb45025a397c08",
+				"KeyExpiry":  "2026-11-08T18:32:19Z",
+				"DiscoKey":   "discokey:f3b92fad07f1d3ce591182dee3eaf8dc5d1d052ba552282d6d9290fbf8a7c918",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33001",
+					"10.65.0.27:33001",
+					"172.17.0.1:33001",
+					"172.19.0.1:33001",
+					"172.20.0.1:33001"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:32:19.390793765Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8322501964150623,
+				"StableID":   "nkmAWp1Hz721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2a6aba6e59e00e32e124286cc338461a517503e3421b0aa1b4070befbf63665c",
+				"KeyExpiry":  "2026-11-08T18:32:19Z",
+				"DiscoKey":   "discokey:a002ae4629752ca3e8a7762b61d30bce26e58e63036698d42754f598df43a75e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55222",
+					"10.65.0.27:55222",
+					"172.17.0.1:55222",
+					"172.19.0.1:55222",
+					"172.20.0.1:55222"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:32:19.935418631Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1361823571364904,
+				"StableID":   "nm33fAomdB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:760e2195462306914e30e0cbf83b93eae29156b3ec710a6e754daaaee1d1731b",
+				"KeyExpiry":  "2026-11-08T18:32:20Z",
+				"DiscoKey":   "discokey:2578a9395027712379d3e4fc5af197e2e1b2e1c77e5480f6724bb2ab80f6c41c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53343",
+					"10.65.0.27:53343",
+					"172.17.0.1:53343",
+					"172.19.0.1:53343",
+					"172.20.0.1:53343"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:32:20.474345204Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2517747849710593": {
+				"ID":          2517747849710593,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1361823571364904,
+				"StableID":   "nm33fAomdB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:760e2195462306914e30e0cbf83b93eae29156b3ec710a6e754daaaee1d1731b",
+				"KeyExpiry":  "2026-11-08T18:32:20Z",
+				"DiscoKey":   "discokey:2578a9395027712379d3e4fc5af197e2e1b2e1c77e5480f6724bb2ab80f6c41c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53343",
+					"10.65.0.27:53343",
+					"172.17.0.1:53343",
+					"172.19.0.1:53343",
+					"172.20.0.1:53343"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:32:20.474345204Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:760e2195462306914e30e0cbf83b93eae29156b3ec710a6e754daaaee1d1731b",
+			"MachineKey": "mkey:36ccb5a55400db766d7c4fc2e938f4e2bbe98b5124904c5a5eb27dd841a2c660",
+			"Peers": [{
+				"ID":         7742721577423862,
+				"StableID":   "nFFN6fAhT321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:902119616bcd067166ea48b310c7ca41b1b2ab46acf197b7d7c02bceb1e8ab0e",
+				"DiscoKey":   "discokey:cc1c3a0527f8341e7b409eb82c20bc483c43b292452d11c0fc898ba5dd6fea41",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:56470",
+					"10.65.0.27:56470",
+					"172.17.0.1:56470",
+					"172.19.0.1:56470",
+					"172.20.0.1:56470"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:32:12.903975602Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7653696384495579,
+				"StableID":   "n6pTeHdNm221CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:84305a1d96b18015840e31377e672cc896c272dac9a0dc1e5efde6ec7fb29a20",
+				"DiscoKey":   "discokey:f712525b2af2bc2d95db157980742f75ee8c0e6d6d5f73d7d4d3de71ff0f295a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37333",
+					"10.65.0.27:37333",
+					"172.17.0.1:37333",
+					"172.19.0.1:37333",
+					"172.20.0.1:37333"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:32:13.453546408Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7822788726870038,
+				"StableID":   "nqztutPx5421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7e51416a52a9110cd3fad145977448e098923c03ef2ee53f2e5cee41c6be414",
+				"DiscoKey":   "discokey:376a11ffcecd094d3066c2b7563a4ff91785dc2861cb7fa0b3746965faeab271",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41585",
+					"10.65.0.27:41585",
+					"172.17.0.1:41585",
+					"172.19.0.1:41585",
+					"172.20.0.1:41585"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:32:13.99653772Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7337416301468498,
+				"StableID":   "nqU2m5V8Jz11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4092b5c99cdb9b3757aeae27a79539cd74bd392fb3693d0535344a40c4eb37e",
+				"DiscoKey":   "discokey:f73bf845dfb061af8e8ec2b135249ac7f6b0dcfbc82fe2a24f1d10737d406801",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56017",
+					"10.65.0.27:56017",
+					"172.17.0.1:56017",
+					"172.19.0.1:56017",
+					"172.20.0.1:56017"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:32:14.526492479Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6530979098763741,
+				"StableID":   "ngatfHktzs11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:456d8df79530f5211dfd525c45e508f2cffc3578c55d161b51913e9832ca046f",
+				"DiscoKey":   "discokey:7e40a59658c0eb556738fdd5b29a9c555f62a089090fd5e691a1b1ff63e7b05f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55361",
+					"10.65.0.27:55361",
+					"172.17.0.1:55361",
+					"172.19.0.1:55361",
+					"172.20.0.1:55361"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:32:15.069827367Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2517747849710593,
+				"StableID":   "nQ8gr4yHfL11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a1ddcb033ed5e74eb456e324cdab5f412e190d072eae4f76e0769d3c095df774",
+				"DiscoKey":   "discokey:139294a6276f864da6a382192299053837018064290aef14db70c00574f2fb69",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:48760",
+					"10.65.0.27:48760",
+					"172.17.0.1:48760",
+					"172.19.0.1:48760",
+					"172.20.0.1:48760"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:32:15.597080057Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6838958301879313,
+				"StableID":   "nzX2EbqNQv11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd33a2684a4d8116ae6a9f9a29accda91ee75200b60260cd7ea7e88783b88c33",
+				"DiscoKey":   "discokey:00c85530ef7afb763e0e81875090d06ba2dcefe9f276d50fdcc1134349027764",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:46349",
+					"10.65.0.27:46349",
+					"172.17.0.1:46349",
+					"172.19.0.1:46349",
+					"172.20.0.1:46349"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:32:16.135347917Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4896979443737729,
+				"StableID":   "ncSSX5MrEf11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ed075d9376fbfc5e81ea7ab1416cf3a80b622d1c054144ee46235060a893960",
+				"DiscoKey":   "discokey:901ac3ba06b28bd5baa1c657979edc057c1cfaac3be65e0982407c8bf094a96e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49291",
+					"10.65.0.27:49291",
+					"172.17.0.1:49291",
+					"172.19.0.1:49291",
+					"172.20.0.1:49291"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:32:16.685850697Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2441314712356406,
+				"StableID":   "nBF1FUCg4L11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a126fbc286def9c48b4b6b4db77e6b8086782a1784ddaedf112f5ad3cbb4551",
+				"DiscoKey":   "discokey:7b11635a4c1c1db62d7eab3da3f42e59e5223c537d44e6314f57658af7b2570f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41076",
+					"10.65.0.27:41076",
+					"172.17.0.1:41076",
+					"172.19.0.1:41076",
+					"172.20.0.1:41076"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:32:17.221955091Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7213159542142581,
+				"StableID":   "nUNDSFUrKy11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:48deeae5d1a74e18ad2dd70c4abde674add0fb92a0602281f9d68991729fcf5e",
+				"DiscoKey":   "discokey:dbda69eb016a4822020a6c896450b7ac0ab8cc2b79c546798385d799d6baee45",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49926",
+					"10.65.0.27:49926",
+					"172.17.0.1:49926",
+					"172.19.0.1:49926",
+					"172.20.0.1:49926"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:32:17.766631203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7977055529972839,
+				"StableID":   "nWkL3tipH521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:79f06d1ed26e54319d065964d15872f2267cc1ecf7f56426de441ac4251d1773",
+				"DiscoKey":   "discokey:bac5ec857a3afad8a04ec8880a0b1e936ea161c4b271f2675c920b769282f768",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36008",
+					"10.65.0.27:36008",
+					"172.17.0.1:36008",
+					"172.19.0.1:36008",
+					"172.20.0.1:36008"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:32:18.305657926Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7660868258443220,
+				"StableID":   "nM76b52dp221CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36ac8acbbdc4e7461c32670facafc19d77cc2241d2512deac8d8bfa59136ee46",
+				"DiscoKey":   "discokey:4f855703a0c6ff4548322e91cc34b324224ff4e760539143f31d1234ebd02a51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:53115",
+					"10.65.0.27:53115",
+					"172.17.0.1:53115",
+					"172.19.0.1:53115",
+					"172.20.0.1:53115"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:32:18.850273543Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2198817906034593,
+				"StableID":   "nadmrdDrAJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5e34245e085df6504a6c02709d65e513f752fdcf96b7081467eb45025a397c08",
+				"KeyExpiry":  "2026-11-08T18:32:19Z",
+				"DiscoKey":   "discokey:f3b92fad07f1d3ce591182dee3eaf8dc5d1d052ba552282d6d9290fbf8a7c918",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33001",
+					"10.65.0.27:33001",
+					"172.17.0.1:33001",
+					"172.19.0.1:33001",
+					"172.20.0.1:33001"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:32:19.390793765Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8322501964150623,
+				"StableID":   "nkmAWp1Hz721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2a6aba6e59e00e32e124286cc338461a517503e3421b0aa1b4070befbf63665c",
+				"KeyExpiry":  "2026-11-08T18:32:19Z",
+				"DiscoKey":   "discokey:a002ae4629752ca3e8a7762b61d30bce26e58e63036698d42754f598df43a75e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55222",
+					"10.65.0.27:55222",
+					"172.17.0.1:55222",
+					"172.19.0.1:55222",
+					"172.20.0.1:55222"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:32:19.935418631Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7822788726870038,
+				"StableID":   "nqztutPx5421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       7822788726870038,
+				"Key":        "nodekey:e7e51416a52a9110cd3fad145977448e098923c03ef2ee53f2e5cee41c6be414",
+				"DiscoKey":   "discokey:376a11ffcecd094d3066c2b7563a4ff91785dc2861cb7fa0b3746965faeab271",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41585",
+					"10.65.0.27:41585",
+					"172.17.0.1:41585",
+					"172.19.0.1:41585",
+					"172.20.0.1:41585"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:32:13.99653772Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e7e51416a52a9110cd3fad145977448e098923c03ef2ee53f2e5cee41c6be414",
+			"MachineKey": "mkey:ac81039a278f678be22a2c6395279884ddde4b6a03139e2333b0d2c7e791d977",
+			"Peers": [{
+				"ID":         7742721577423862,
+				"StableID":   "nFFN6fAhT321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:902119616bcd067166ea48b310c7ca41b1b2ab46acf197b7d7c02bceb1e8ab0e",
+				"DiscoKey":   "discokey:cc1c3a0527f8341e7b409eb82c20bc483c43b292452d11c0fc898ba5dd6fea41",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:56470",
+					"10.65.0.27:56470",
+					"172.17.0.1:56470",
+					"172.19.0.1:56470",
+					"172.20.0.1:56470"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:32:12.903975602Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7653696384495579,
+				"StableID":   "n6pTeHdNm221CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:84305a1d96b18015840e31377e672cc896c272dac9a0dc1e5efde6ec7fb29a20",
+				"DiscoKey":   "discokey:f712525b2af2bc2d95db157980742f75ee8c0e6d6d5f73d7d4d3de71ff0f295a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37333",
+					"10.65.0.27:37333",
+					"172.17.0.1:37333",
+					"172.19.0.1:37333",
+					"172.20.0.1:37333"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:32:13.453546408Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7337416301468498,
+				"StableID":   "nqU2m5V8Jz11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4092b5c99cdb9b3757aeae27a79539cd74bd392fb3693d0535344a40c4eb37e",
+				"DiscoKey":   "discokey:f73bf845dfb061af8e8ec2b135249ac7f6b0dcfbc82fe2a24f1d10737d406801",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56017",
+					"10.65.0.27:56017",
+					"172.17.0.1:56017",
+					"172.19.0.1:56017",
+					"172.20.0.1:56017"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:32:14.526492479Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6530979098763741,
+				"StableID":   "ngatfHktzs11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:456d8df79530f5211dfd525c45e508f2cffc3578c55d161b51913e9832ca046f",
+				"DiscoKey":   "discokey:7e40a59658c0eb556738fdd5b29a9c555f62a089090fd5e691a1b1ff63e7b05f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55361",
+					"10.65.0.27:55361",
+					"172.17.0.1:55361",
+					"172.19.0.1:55361",
+					"172.20.0.1:55361"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:32:15.069827367Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2517747849710593,
+				"StableID":   "nQ8gr4yHfL11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a1ddcb033ed5e74eb456e324cdab5f412e190d072eae4f76e0769d3c095df774",
+				"DiscoKey":   "discokey:139294a6276f864da6a382192299053837018064290aef14db70c00574f2fb69",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:48760",
+					"10.65.0.27:48760",
+					"172.17.0.1:48760",
+					"172.19.0.1:48760",
+					"172.20.0.1:48760"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:32:15.597080057Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6838958301879313,
+				"StableID":   "nzX2EbqNQv11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd33a2684a4d8116ae6a9f9a29accda91ee75200b60260cd7ea7e88783b88c33",
+				"DiscoKey":   "discokey:00c85530ef7afb763e0e81875090d06ba2dcefe9f276d50fdcc1134349027764",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:46349",
+					"10.65.0.27:46349",
+					"172.17.0.1:46349",
+					"172.19.0.1:46349",
+					"172.20.0.1:46349"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:32:16.135347917Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4896979443737729,
+				"StableID":   "ncSSX5MrEf11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ed075d9376fbfc5e81ea7ab1416cf3a80b622d1c054144ee46235060a893960",
+				"DiscoKey":   "discokey:901ac3ba06b28bd5baa1c657979edc057c1cfaac3be65e0982407c8bf094a96e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49291",
+					"10.65.0.27:49291",
+					"172.17.0.1:49291",
+					"172.19.0.1:49291",
+					"172.20.0.1:49291"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:32:16.685850697Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2441314712356406,
+				"StableID":   "nBF1FUCg4L11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a126fbc286def9c48b4b6b4db77e6b8086782a1784ddaedf112f5ad3cbb4551",
+				"DiscoKey":   "discokey:7b11635a4c1c1db62d7eab3da3f42e59e5223c537d44e6314f57658af7b2570f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41076",
+					"10.65.0.27:41076",
+					"172.17.0.1:41076",
+					"172.19.0.1:41076",
+					"172.20.0.1:41076"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:32:17.221955091Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7213159542142581,
+				"StableID":   "nUNDSFUrKy11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:48deeae5d1a74e18ad2dd70c4abde674add0fb92a0602281f9d68991729fcf5e",
+				"DiscoKey":   "discokey:dbda69eb016a4822020a6c896450b7ac0ab8cc2b79c546798385d799d6baee45",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49926",
+					"10.65.0.27:49926",
+					"172.17.0.1:49926",
+					"172.19.0.1:49926",
+					"172.20.0.1:49926"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:32:17.766631203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7977055529972839,
+				"StableID":   "nWkL3tipH521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:79f06d1ed26e54319d065964d15872f2267cc1ecf7f56426de441ac4251d1773",
+				"DiscoKey":   "discokey:bac5ec857a3afad8a04ec8880a0b1e936ea161c4b271f2675c920b769282f768",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36008",
+					"10.65.0.27:36008",
+					"172.17.0.1:36008",
+					"172.19.0.1:36008",
+					"172.20.0.1:36008"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:32:18.305657926Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7660868258443220,
+				"StableID":   "nM76b52dp221CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36ac8acbbdc4e7461c32670facafc19d77cc2241d2512deac8d8bfa59136ee46",
+				"DiscoKey":   "discokey:4f855703a0c6ff4548322e91cc34b324224ff4e760539143f31d1234ebd02a51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:53115",
+					"10.65.0.27:53115",
+					"172.17.0.1:53115",
+					"172.19.0.1:53115",
+					"172.20.0.1:53115"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:32:18.850273543Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2198817906034593,
+				"StableID":   "nadmrdDrAJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5e34245e085df6504a6c02709d65e513f752fdcf96b7081467eb45025a397c08",
+				"KeyExpiry":  "2026-11-08T18:32:19Z",
+				"DiscoKey":   "discokey:f3b92fad07f1d3ce591182dee3eaf8dc5d1d052ba552282d6d9290fbf8a7c918",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33001",
+					"10.65.0.27:33001",
+					"172.17.0.1:33001",
+					"172.19.0.1:33001",
+					"172.20.0.1:33001"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:32:19.390793765Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8322501964150623,
+				"StableID":   "nkmAWp1Hz721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2a6aba6e59e00e32e124286cc338461a517503e3421b0aa1b4070befbf63665c",
+				"KeyExpiry":  "2026-11-08T18:32:19Z",
+				"DiscoKey":   "discokey:a002ae4629752ca3e8a7762b61d30bce26e58e63036698d42754f598df43a75e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55222",
+					"10.65.0.27:55222",
+					"172.17.0.1:55222",
+					"172.19.0.1:55222",
+					"172.20.0.1:55222"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:32:19.935418631Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1361823571364904,
+				"StableID":   "nm33fAomdB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:760e2195462306914e30e0cbf83b93eae29156b3ec710a6e754daaaee1d1731b",
+				"KeyExpiry":  "2026-11-08T18:32:20Z",
+				"DiscoKey":   "discokey:2578a9395027712379d3e4fc5af197e2e1b2e1c77e5480f6724bb2ab80f6c41c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53343",
+					"10.65.0.27:53343",
+					"172.17.0.1:53343",
+					"172.19.0.1:53343",
+					"172.20.0.1:53343"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:32:20.474345204Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7822788726870038": {
+				"ID":          7822788726870038,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4896979443737729,
+				"StableID":   "ncSSX5MrEf11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       4896979443737729,
+				"Key":        "nodekey:7ed075d9376fbfc5e81ea7ab1416cf3a80b622d1c054144ee46235060a893960",
+				"DiscoKey":   "discokey:901ac3ba06b28bd5baa1c657979edc057c1cfaac3be65e0982407c8bf094a96e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49291",
+					"10.65.0.27:49291",
+					"172.17.0.1:49291",
+					"172.19.0.1:49291",
+					"172.20.0.1:49291"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:32:16.685850697Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7ed075d9376fbfc5e81ea7ab1416cf3a80b622d1c054144ee46235060a893960",
+			"MachineKey": "mkey:a49bca8e65e9e98964d89d2eca17b8d33f511f59d1827de8e4072870d9427e34",
+			"Peers": [{
+				"ID":         7742721577423862,
+				"StableID":   "nFFN6fAhT321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:902119616bcd067166ea48b310c7ca41b1b2ab46acf197b7d7c02bceb1e8ab0e",
+				"DiscoKey":   "discokey:cc1c3a0527f8341e7b409eb82c20bc483c43b292452d11c0fc898ba5dd6fea41",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:56470",
+					"10.65.0.27:56470",
+					"172.17.0.1:56470",
+					"172.19.0.1:56470",
+					"172.20.0.1:56470"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:32:12.903975602Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7653696384495579,
+				"StableID":   "n6pTeHdNm221CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:84305a1d96b18015840e31377e672cc896c272dac9a0dc1e5efde6ec7fb29a20",
+				"DiscoKey":   "discokey:f712525b2af2bc2d95db157980742f75ee8c0e6d6d5f73d7d4d3de71ff0f295a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37333",
+					"10.65.0.27:37333",
+					"172.17.0.1:37333",
+					"172.19.0.1:37333",
+					"172.20.0.1:37333"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:32:13.453546408Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7822788726870038,
+				"StableID":   "nqztutPx5421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7e51416a52a9110cd3fad145977448e098923c03ef2ee53f2e5cee41c6be414",
+				"DiscoKey":   "discokey:376a11ffcecd094d3066c2b7563a4ff91785dc2861cb7fa0b3746965faeab271",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41585",
+					"10.65.0.27:41585",
+					"172.17.0.1:41585",
+					"172.19.0.1:41585",
+					"172.20.0.1:41585"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:32:13.99653772Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7337416301468498,
+				"StableID":   "nqU2m5V8Jz11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4092b5c99cdb9b3757aeae27a79539cd74bd392fb3693d0535344a40c4eb37e",
+				"DiscoKey":   "discokey:f73bf845dfb061af8e8ec2b135249ac7f6b0dcfbc82fe2a24f1d10737d406801",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56017",
+					"10.65.0.27:56017",
+					"172.17.0.1:56017",
+					"172.19.0.1:56017",
+					"172.20.0.1:56017"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:32:14.526492479Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6530979098763741,
+				"StableID":   "ngatfHktzs11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:456d8df79530f5211dfd525c45e508f2cffc3578c55d161b51913e9832ca046f",
+				"DiscoKey":   "discokey:7e40a59658c0eb556738fdd5b29a9c555f62a089090fd5e691a1b1ff63e7b05f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55361",
+					"10.65.0.27:55361",
+					"172.17.0.1:55361",
+					"172.19.0.1:55361",
+					"172.20.0.1:55361"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:32:15.069827367Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2517747849710593,
+				"StableID":   "nQ8gr4yHfL11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a1ddcb033ed5e74eb456e324cdab5f412e190d072eae4f76e0769d3c095df774",
+				"DiscoKey":   "discokey:139294a6276f864da6a382192299053837018064290aef14db70c00574f2fb69",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:48760",
+					"10.65.0.27:48760",
+					"172.17.0.1:48760",
+					"172.19.0.1:48760",
+					"172.20.0.1:48760"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:32:15.597080057Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6838958301879313,
+				"StableID":   "nzX2EbqNQv11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd33a2684a4d8116ae6a9f9a29accda91ee75200b60260cd7ea7e88783b88c33",
+				"DiscoKey":   "discokey:00c85530ef7afb763e0e81875090d06ba2dcefe9f276d50fdcc1134349027764",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:46349",
+					"10.65.0.27:46349",
+					"172.17.0.1:46349",
+					"172.19.0.1:46349",
+					"172.20.0.1:46349"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:32:16.135347917Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2441314712356406,
+				"StableID":   "nBF1FUCg4L11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a126fbc286def9c48b4b6b4db77e6b8086782a1784ddaedf112f5ad3cbb4551",
+				"DiscoKey":   "discokey:7b11635a4c1c1db62d7eab3da3f42e59e5223c537d44e6314f57658af7b2570f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41076",
+					"10.65.0.27:41076",
+					"172.17.0.1:41076",
+					"172.19.0.1:41076",
+					"172.20.0.1:41076"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:32:17.221955091Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7213159542142581,
+				"StableID":   "nUNDSFUrKy11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:48deeae5d1a74e18ad2dd70c4abde674add0fb92a0602281f9d68991729fcf5e",
+				"DiscoKey":   "discokey:dbda69eb016a4822020a6c896450b7ac0ab8cc2b79c546798385d799d6baee45",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49926",
+					"10.65.0.27:49926",
+					"172.17.0.1:49926",
+					"172.19.0.1:49926",
+					"172.20.0.1:49926"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:32:17.766631203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7977055529972839,
+				"StableID":   "nWkL3tipH521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:79f06d1ed26e54319d065964d15872f2267cc1ecf7f56426de441ac4251d1773",
+				"DiscoKey":   "discokey:bac5ec857a3afad8a04ec8880a0b1e936ea161c4b271f2675c920b769282f768",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36008",
+					"10.65.0.27:36008",
+					"172.17.0.1:36008",
+					"172.19.0.1:36008",
+					"172.20.0.1:36008"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:32:18.305657926Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7660868258443220,
+				"StableID":   "nM76b52dp221CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36ac8acbbdc4e7461c32670facafc19d77cc2241d2512deac8d8bfa59136ee46",
+				"DiscoKey":   "discokey:4f855703a0c6ff4548322e91cc34b324224ff4e760539143f31d1234ebd02a51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:53115",
+					"10.65.0.27:53115",
+					"172.17.0.1:53115",
+					"172.19.0.1:53115",
+					"172.20.0.1:53115"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:32:18.850273543Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2198817906034593,
+				"StableID":   "nadmrdDrAJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5e34245e085df6504a6c02709d65e513f752fdcf96b7081467eb45025a397c08",
+				"KeyExpiry":  "2026-11-08T18:32:19Z",
+				"DiscoKey":   "discokey:f3b92fad07f1d3ce591182dee3eaf8dc5d1d052ba552282d6d9290fbf8a7c918",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33001",
+					"10.65.0.27:33001",
+					"172.17.0.1:33001",
+					"172.19.0.1:33001",
+					"172.20.0.1:33001"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:32:19.390793765Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8322501964150623,
+				"StableID":   "nkmAWp1Hz721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2a6aba6e59e00e32e124286cc338461a517503e3421b0aa1b4070befbf63665c",
+				"KeyExpiry":  "2026-11-08T18:32:19Z",
+				"DiscoKey":   "discokey:a002ae4629752ca3e8a7762b61d30bce26e58e63036698d42754f598df43a75e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55222",
+					"10.65.0.27:55222",
+					"172.17.0.1:55222",
+					"172.19.0.1:55222",
+					"172.20.0.1:55222"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:32:19.935418631Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1361823571364904,
+				"StableID":   "nm33fAomdB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:760e2195462306914e30e0cbf83b93eae29156b3ec710a6e754daaaee1d1731b",
+				"KeyExpiry":  "2026-11-08T18:32:20Z",
+				"DiscoKey":   "discokey:2578a9395027712379d3e4fc5af197e2e1b2e1c77e5480f6724bb2ab80f6c41c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53343",
+					"10.65.0.27:53343",
+					"172.17.0.1:53343",
+					"172.19.0.1:53343",
+					"172.20.0.1:53343"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:32:20.474345204Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4896979443737729": {
+				"ID":          4896979443737729,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2198817906034593,
+				"StableID":   "nadmrdDrAJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5e34245e085df6504a6c02709d65e513f752fdcf96b7081467eb45025a397c08",
+				"KeyExpiry":  "2026-11-08T18:32:19Z",
+				"DiscoKey":   "discokey:f3b92fad07f1d3ce591182dee3eaf8dc5d1d052ba552282d6d9290fbf8a7c918",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33001",
+					"10.65.0.27:33001",
+					"172.17.0.1:33001",
+					"172.19.0.1:33001",
+					"172.20.0.1:33001"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:32:19.390793765Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5e34245e085df6504a6c02709d65e513f752fdcf96b7081467eb45025a397c08",
+			"MachineKey": "mkey:0a05439f0f0cdd00cb029bc805e17d8c2d73ed2bd873975543b829a987873d1b",
+			"Peers": [{
+				"ID":         7742721577423862,
+				"StableID":   "nFFN6fAhT321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:902119616bcd067166ea48b310c7ca41b1b2ab46acf197b7d7c02bceb1e8ab0e",
+				"DiscoKey":   "discokey:cc1c3a0527f8341e7b409eb82c20bc483c43b292452d11c0fc898ba5dd6fea41",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:56470",
+					"10.65.0.27:56470",
+					"172.17.0.1:56470",
+					"172.19.0.1:56470",
+					"172.20.0.1:56470"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:32:12.903975602Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7653696384495579,
+				"StableID":   "n6pTeHdNm221CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:84305a1d96b18015840e31377e672cc896c272dac9a0dc1e5efde6ec7fb29a20",
+				"DiscoKey":   "discokey:f712525b2af2bc2d95db157980742f75ee8c0e6d6d5f73d7d4d3de71ff0f295a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37333",
+					"10.65.0.27:37333",
+					"172.17.0.1:37333",
+					"172.19.0.1:37333",
+					"172.20.0.1:37333"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:32:13.453546408Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7822788726870038,
+				"StableID":   "nqztutPx5421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7e51416a52a9110cd3fad145977448e098923c03ef2ee53f2e5cee41c6be414",
+				"DiscoKey":   "discokey:376a11ffcecd094d3066c2b7563a4ff91785dc2861cb7fa0b3746965faeab271",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41585",
+					"10.65.0.27:41585",
+					"172.17.0.1:41585",
+					"172.19.0.1:41585",
+					"172.20.0.1:41585"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:32:13.99653772Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7337416301468498,
+				"StableID":   "nqU2m5V8Jz11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4092b5c99cdb9b3757aeae27a79539cd74bd392fb3693d0535344a40c4eb37e",
+				"DiscoKey":   "discokey:f73bf845dfb061af8e8ec2b135249ac7f6b0dcfbc82fe2a24f1d10737d406801",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56017",
+					"10.65.0.27:56017",
+					"172.17.0.1:56017",
+					"172.19.0.1:56017",
+					"172.20.0.1:56017"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:32:14.526492479Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6530979098763741,
+				"StableID":   "ngatfHktzs11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:456d8df79530f5211dfd525c45e508f2cffc3578c55d161b51913e9832ca046f",
+				"DiscoKey":   "discokey:7e40a59658c0eb556738fdd5b29a9c555f62a089090fd5e691a1b1ff63e7b05f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55361",
+					"10.65.0.27:55361",
+					"172.17.0.1:55361",
+					"172.19.0.1:55361",
+					"172.20.0.1:55361"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:32:15.069827367Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2517747849710593,
+				"StableID":   "nQ8gr4yHfL11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a1ddcb033ed5e74eb456e324cdab5f412e190d072eae4f76e0769d3c095df774",
+				"DiscoKey":   "discokey:139294a6276f864da6a382192299053837018064290aef14db70c00574f2fb69",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:48760",
+					"10.65.0.27:48760",
+					"172.17.0.1:48760",
+					"172.19.0.1:48760",
+					"172.20.0.1:48760"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:32:15.597080057Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6838958301879313,
+				"StableID":   "nzX2EbqNQv11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd33a2684a4d8116ae6a9f9a29accda91ee75200b60260cd7ea7e88783b88c33",
+				"DiscoKey":   "discokey:00c85530ef7afb763e0e81875090d06ba2dcefe9f276d50fdcc1134349027764",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:46349",
+					"10.65.0.27:46349",
+					"172.17.0.1:46349",
+					"172.19.0.1:46349",
+					"172.20.0.1:46349"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:32:16.135347917Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4896979443737729,
+				"StableID":   "ncSSX5MrEf11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ed075d9376fbfc5e81ea7ab1416cf3a80b622d1c054144ee46235060a893960",
+				"DiscoKey":   "discokey:901ac3ba06b28bd5baa1c657979edc057c1cfaac3be65e0982407c8bf094a96e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49291",
+					"10.65.0.27:49291",
+					"172.17.0.1:49291",
+					"172.19.0.1:49291",
+					"172.20.0.1:49291"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:32:16.685850697Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2441314712356406,
+				"StableID":   "nBF1FUCg4L11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a126fbc286def9c48b4b6b4db77e6b8086782a1784ddaedf112f5ad3cbb4551",
+				"DiscoKey":   "discokey:7b11635a4c1c1db62d7eab3da3f42e59e5223c537d44e6314f57658af7b2570f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41076",
+					"10.65.0.27:41076",
+					"172.17.0.1:41076",
+					"172.19.0.1:41076",
+					"172.20.0.1:41076"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:32:17.221955091Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7213159542142581,
+				"StableID":   "nUNDSFUrKy11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:48deeae5d1a74e18ad2dd70c4abde674add0fb92a0602281f9d68991729fcf5e",
+				"DiscoKey":   "discokey:dbda69eb016a4822020a6c896450b7ac0ab8cc2b79c546798385d799d6baee45",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49926",
+					"10.65.0.27:49926",
+					"172.17.0.1:49926",
+					"172.19.0.1:49926",
+					"172.20.0.1:49926"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:32:17.766631203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7977055529972839,
+				"StableID":   "nWkL3tipH521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:79f06d1ed26e54319d065964d15872f2267cc1ecf7f56426de441ac4251d1773",
+				"DiscoKey":   "discokey:bac5ec857a3afad8a04ec8880a0b1e936ea161c4b271f2675c920b769282f768",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36008",
+					"10.65.0.27:36008",
+					"172.17.0.1:36008",
+					"172.19.0.1:36008",
+					"172.20.0.1:36008"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:32:18.305657926Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7660868258443220,
+				"StableID":   "nM76b52dp221CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36ac8acbbdc4e7461c32670facafc19d77cc2241d2512deac8d8bfa59136ee46",
+				"DiscoKey":   "discokey:4f855703a0c6ff4548322e91cc34b324224ff4e760539143f31d1234ebd02a51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:53115",
+					"10.65.0.27:53115",
+					"172.17.0.1:53115",
+					"172.19.0.1:53115",
+					"172.20.0.1:53115"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:32:18.850273543Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8322501964150623,
+				"StableID":   "nkmAWp1Hz721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2a6aba6e59e00e32e124286cc338461a517503e3421b0aa1b4070befbf63665c",
+				"KeyExpiry":  "2026-11-08T18:32:19Z",
+				"DiscoKey":   "discokey:a002ae4629752ca3e8a7762b61d30bce26e58e63036698d42754f598df43a75e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55222",
+					"10.65.0.27:55222",
+					"172.17.0.1:55222",
+					"172.19.0.1:55222",
+					"172.20.0.1:55222"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:32:19.935418631Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1361823571364904,
+				"StableID":   "nm33fAomdB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:760e2195462306914e30e0cbf83b93eae29156b3ec710a6e754daaaee1d1731b",
+				"KeyExpiry":  "2026-11-08T18:32:20Z",
+				"DiscoKey":   "discokey:2578a9395027712379d3e4fc5af197e2e1b2e1c77e5480f6724bb2ab80f6c41c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53343",
+					"10.65.0.27:53343",
+					"172.17.0.1:53343",
+					"172.19.0.1:53343",
+					"172.20.0.1:53343"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:32:20.474345204Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7977055529972839,
+				"StableID":   "nWkL3tipH521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       7977055529972839,
+				"Key":        "nodekey:79f06d1ed26e54319d065964d15872f2267cc1ecf7f56426de441ac4251d1773",
+				"DiscoKey":   "discokey:bac5ec857a3afad8a04ec8880a0b1e936ea161c4b271f2675c920b769282f768",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36008",
+					"10.65.0.27:36008",
+					"172.17.0.1:36008",
+					"172.19.0.1:36008",
+					"172.20.0.1:36008"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:32:18.305657926Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:79f06d1ed26e54319d065964d15872f2267cc1ecf7f56426de441ac4251d1773",
+			"MachineKey": "mkey:e951e3a8d56c7881d1fcae9439fb6a26935b9c0a498e65a74eaa204d5ce05829",
+			"Peers": [{
+				"ID":         7742721577423862,
+				"StableID":   "nFFN6fAhT321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:902119616bcd067166ea48b310c7ca41b1b2ab46acf197b7d7c02bceb1e8ab0e",
+				"DiscoKey":   "discokey:cc1c3a0527f8341e7b409eb82c20bc483c43b292452d11c0fc898ba5dd6fea41",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:56470",
+					"10.65.0.27:56470",
+					"172.17.0.1:56470",
+					"172.19.0.1:56470",
+					"172.20.0.1:56470"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:32:12.903975602Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7653696384495579,
+				"StableID":   "n6pTeHdNm221CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:84305a1d96b18015840e31377e672cc896c272dac9a0dc1e5efde6ec7fb29a20",
+				"DiscoKey":   "discokey:f712525b2af2bc2d95db157980742f75ee8c0e6d6d5f73d7d4d3de71ff0f295a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37333",
+					"10.65.0.27:37333",
+					"172.17.0.1:37333",
+					"172.19.0.1:37333",
+					"172.20.0.1:37333"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:32:13.453546408Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7822788726870038,
+				"StableID":   "nqztutPx5421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7e51416a52a9110cd3fad145977448e098923c03ef2ee53f2e5cee41c6be414",
+				"DiscoKey":   "discokey:376a11ffcecd094d3066c2b7563a4ff91785dc2861cb7fa0b3746965faeab271",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41585",
+					"10.65.0.27:41585",
+					"172.17.0.1:41585",
+					"172.19.0.1:41585",
+					"172.20.0.1:41585"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:32:13.99653772Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7337416301468498,
+				"StableID":   "nqU2m5V8Jz11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4092b5c99cdb9b3757aeae27a79539cd74bd392fb3693d0535344a40c4eb37e",
+				"DiscoKey":   "discokey:f73bf845dfb061af8e8ec2b135249ac7f6b0dcfbc82fe2a24f1d10737d406801",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56017",
+					"10.65.0.27:56017",
+					"172.17.0.1:56017",
+					"172.19.0.1:56017",
+					"172.20.0.1:56017"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:32:14.526492479Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6530979098763741,
+				"StableID":   "ngatfHktzs11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:456d8df79530f5211dfd525c45e508f2cffc3578c55d161b51913e9832ca046f",
+				"DiscoKey":   "discokey:7e40a59658c0eb556738fdd5b29a9c555f62a089090fd5e691a1b1ff63e7b05f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55361",
+					"10.65.0.27:55361",
+					"172.17.0.1:55361",
+					"172.19.0.1:55361",
+					"172.20.0.1:55361"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:32:15.069827367Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2517747849710593,
+				"StableID":   "nQ8gr4yHfL11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a1ddcb033ed5e74eb456e324cdab5f412e190d072eae4f76e0769d3c095df774",
+				"DiscoKey":   "discokey:139294a6276f864da6a382192299053837018064290aef14db70c00574f2fb69",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:48760",
+					"10.65.0.27:48760",
+					"172.17.0.1:48760",
+					"172.19.0.1:48760",
+					"172.20.0.1:48760"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:32:15.597080057Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6838958301879313,
+				"StableID":   "nzX2EbqNQv11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd33a2684a4d8116ae6a9f9a29accda91ee75200b60260cd7ea7e88783b88c33",
+				"DiscoKey":   "discokey:00c85530ef7afb763e0e81875090d06ba2dcefe9f276d50fdcc1134349027764",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:46349",
+					"10.65.0.27:46349",
+					"172.17.0.1:46349",
+					"172.19.0.1:46349",
+					"172.20.0.1:46349"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:32:16.135347917Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4896979443737729,
+				"StableID":   "ncSSX5MrEf11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ed075d9376fbfc5e81ea7ab1416cf3a80b622d1c054144ee46235060a893960",
+				"DiscoKey":   "discokey:901ac3ba06b28bd5baa1c657979edc057c1cfaac3be65e0982407c8bf094a96e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49291",
+					"10.65.0.27:49291",
+					"172.17.0.1:49291",
+					"172.19.0.1:49291",
+					"172.20.0.1:49291"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:32:16.685850697Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2441314712356406,
+				"StableID":   "nBF1FUCg4L11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a126fbc286def9c48b4b6b4db77e6b8086782a1784ddaedf112f5ad3cbb4551",
+				"DiscoKey":   "discokey:7b11635a4c1c1db62d7eab3da3f42e59e5223c537d44e6314f57658af7b2570f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41076",
+					"10.65.0.27:41076",
+					"172.17.0.1:41076",
+					"172.19.0.1:41076",
+					"172.20.0.1:41076"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:32:17.221955091Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7213159542142581,
+				"StableID":   "nUNDSFUrKy11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:48deeae5d1a74e18ad2dd70c4abde674add0fb92a0602281f9d68991729fcf5e",
+				"DiscoKey":   "discokey:dbda69eb016a4822020a6c896450b7ac0ab8cc2b79c546798385d799d6baee45",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49926",
+					"10.65.0.27:49926",
+					"172.17.0.1:49926",
+					"172.19.0.1:49926",
+					"172.20.0.1:49926"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:32:17.766631203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7660868258443220,
+				"StableID":   "nM76b52dp221CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36ac8acbbdc4e7461c32670facafc19d77cc2241d2512deac8d8bfa59136ee46",
+				"DiscoKey":   "discokey:4f855703a0c6ff4548322e91cc34b324224ff4e760539143f31d1234ebd02a51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:53115",
+					"10.65.0.27:53115",
+					"172.17.0.1:53115",
+					"172.19.0.1:53115",
+					"172.20.0.1:53115"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:32:18.850273543Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2198817906034593,
+				"StableID":   "nadmrdDrAJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5e34245e085df6504a6c02709d65e513f752fdcf96b7081467eb45025a397c08",
+				"KeyExpiry":  "2026-11-08T18:32:19Z",
+				"DiscoKey":   "discokey:f3b92fad07f1d3ce591182dee3eaf8dc5d1d052ba552282d6d9290fbf8a7c918",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33001",
+					"10.65.0.27:33001",
+					"172.17.0.1:33001",
+					"172.19.0.1:33001",
+					"172.20.0.1:33001"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:32:19.390793765Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8322501964150623,
+				"StableID":   "nkmAWp1Hz721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2a6aba6e59e00e32e124286cc338461a517503e3421b0aa1b4070befbf63665c",
+				"KeyExpiry":  "2026-11-08T18:32:19Z",
+				"DiscoKey":   "discokey:a002ae4629752ca3e8a7762b61d30bce26e58e63036698d42754f598df43a75e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55222",
+					"10.65.0.27:55222",
+					"172.17.0.1:55222",
+					"172.19.0.1:55222",
+					"172.20.0.1:55222"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:32:19.935418631Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1361823571364904,
+				"StableID":   "nm33fAomdB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:760e2195462306914e30e0cbf83b93eae29156b3ec710a6e754daaaee1d1731b",
+				"KeyExpiry":  "2026-11-08T18:32:20Z",
+				"DiscoKey":   "discokey:2578a9395027712379d3e4fc5af197e2e1b2e1c77e5480f6724bb2ab80f6c41c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53343",
+					"10.65.0.27:53343",
+					"172.17.0.1:53343",
+					"172.19.0.1:53343",
+					"172.20.0.1:53343"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:32:20.474345204Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7977055529972839": {
+				"ID":          7977055529972839,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7653696384495579,
+				"StableID":   "n6pTeHdNm221CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       7653696384495579,
+				"Key":        "nodekey:84305a1d96b18015840e31377e672cc896c272dac9a0dc1e5efde6ec7fb29a20",
+				"DiscoKey":   "discokey:f712525b2af2bc2d95db157980742f75ee8c0e6d6d5f73d7d4d3de71ff0f295a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37333",
+					"10.65.0.27:37333",
+					"172.17.0.1:37333",
+					"172.19.0.1:37333",
+					"172.20.0.1:37333"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:32:13.453546408Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:84305a1d96b18015840e31377e672cc896c272dac9a0dc1e5efde6ec7fb29a20",
+			"MachineKey": "mkey:46edfa4ff18f99610e3e5d380b24a2c0efc27b076fa21fb62678adf2e4c2b570",
+			"Peers": [{
+				"ID":         7742721577423862,
+				"StableID":   "nFFN6fAhT321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:902119616bcd067166ea48b310c7ca41b1b2ab46acf197b7d7c02bceb1e8ab0e",
+				"DiscoKey":   "discokey:cc1c3a0527f8341e7b409eb82c20bc483c43b292452d11c0fc898ba5dd6fea41",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:56470",
+					"10.65.0.27:56470",
+					"172.17.0.1:56470",
+					"172.19.0.1:56470",
+					"172.20.0.1:56470"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:32:12.903975602Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7822788726870038,
+				"StableID":   "nqztutPx5421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7e51416a52a9110cd3fad145977448e098923c03ef2ee53f2e5cee41c6be414",
+				"DiscoKey":   "discokey:376a11ffcecd094d3066c2b7563a4ff91785dc2861cb7fa0b3746965faeab271",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41585",
+					"10.65.0.27:41585",
+					"172.17.0.1:41585",
+					"172.19.0.1:41585",
+					"172.20.0.1:41585"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:32:13.99653772Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7337416301468498,
+				"StableID":   "nqU2m5V8Jz11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4092b5c99cdb9b3757aeae27a79539cd74bd392fb3693d0535344a40c4eb37e",
+				"DiscoKey":   "discokey:f73bf845dfb061af8e8ec2b135249ac7f6b0dcfbc82fe2a24f1d10737d406801",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56017",
+					"10.65.0.27:56017",
+					"172.17.0.1:56017",
+					"172.19.0.1:56017",
+					"172.20.0.1:56017"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:32:14.526492479Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6530979098763741,
+				"StableID":   "ngatfHktzs11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:456d8df79530f5211dfd525c45e508f2cffc3578c55d161b51913e9832ca046f",
+				"DiscoKey":   "discokey:7e40a59658c0eb556738fdd5b29a9c555f62a089090fd5e691a1b1ff63e7b05f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55361",
+					"10.65.0.27:55361",
+					"172.17.0.1:55361",
+					"172.19.0.1:55361",
+					"172.20.0.1:55361"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:32:15.069827367Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2517747849710593,
+				"StableID":   "nQ8gr4yHfL11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a1ddcb033ed5e74eb456e324cdab5f412e190d072eae4f76e0769d3c095df774",
+				"DiscoKey":   "discokey:139294a6276f864da6a382192299053837018064290aef14db70c00574f2fb69",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:48760",
+					"10.65.0.27:48760",
+					"172.17.0.1:48760",
+					"172.19.0.1:48760",
+					"172.20.0.1:48760"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:32:15.597080057Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6838958301879313,
+				"StableID":   "nzX2EbqNQv11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd33a2684a4d8116ae6a9f9a29accda91ee75200b60260cd7ea7e88783b88c33",
+				"DiscoKey":   "discokey:00c85530ef7afb763e0e81875090d06ba2dcefe9f276d50fdcc1134349027764",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:46349",
+					"10.65.0.27:46349",
+					"172.17.0.1:46349",
+					"172.19.0.1:46349",
+					"172.20.0.1:46349"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:32:16.135347917Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4896979443737729,
+				"StableID":   "ncSSX5MrEf11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ed075d9376fbfc5e81ea7ab1416cf3a80b622d1c054144ee46235060a893960",
+				"DiscoKey":   "discokey:901ac3ba06b28bd5baa1c657979edc057c1cfaac3be65e0982407c8bf094a96e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49291",
+					"10.65.0.27:49291",
+					"172.17.0.1:49291",
+					"172.19.0.1:49291",
+					"172.20.0.1:49291"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:32:16.685850697Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2441314712356406,
+				"StableID":   "nBF1FUCg4L11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a126fbc286def9c48b4b6b4db77e6b8086782a1784ddaedf112f5ad3cbb4551",
+				"DiscoKey":   "discokey:7b11635a4c1c1db62d7eab3da3f42e59e5223c537d44e6314f57658af7b2570f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41076",
+					"10.65.0.27:41076",
+					"172.17.0.1:41076",
+					"172.19.0.1:41076",
+					"172.20.0.1:41076"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:32:17.221955091Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7213159542142581,
+				"StableID":   "nUNDSFUrKy11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:48deeae5d1a74e18ad2dd70c4abde674add0fb92a0602281f9d68991729fcf5e",
+				"DiscoKey":   "discokey:dbda69eb016a4822020a6c896450b7ac0ab8cc2b79c546798385d799d6baee45",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49926",
+					"10.65.0.27:49926",
+					"172.17.0.1:49926",
+					"172.19.0.1:49926",
+					"172.20.0.1:49926"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:32:17.766631203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7977055529972839,
+				"StableID":   "nWkL3tipH521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:79f06d1ed26e54319d065964d15872f2267cc1ecf7f56426de441ac4251d1773",
+				"DiscoKey":   "discokey:bac5ec857a3afad8a04ec8880a0b1e936ea161c4b271f2675c920b769282f768",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36008",
+					"10.65.0.27:36008",
+					"172.17.0.1:36008",
+					"172.19.0.1:36008",
+					"172.20.0.1:36008"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:32:18.305657926Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7660868258443220,
+				"StableID":   "nM76b52dp221CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36ac8acbbdc4e7461c32670facafc19d77cc2241d2512deac8d8bfa59136ee46",
+				"DiscoKey":   "discokey:4f855703a0c6ff4548322e91cc34b324224ff4e760539143f31d1234ebd02a51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:53115",
+					"10.65.0.27:53115",
+					"172.17.0.1:53115",
+					"172.19.0.1:53115",
+					"172.20.0.1:53115"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:32:18.850273543Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2198817906034593,
+				"StableID":   "nadmrdDrAJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5e34245e085df6504a6c02709d65e513f752fdcf96b7081467eb45025a397c08",
+				"KeyExpiry":  "2026-11-08T18:32:19Z",
+				"DiscoKey":   "discokey:f3b92fad07f1d3ce591182dee3eaf8dc5d1d052ba552282d6d9290fbf8a7c918",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33001",
+					"10.65.0.27:33001",
+					"172.17.0.1:33001",
+					"172.19.0.1:33001",
+					"172.20.0.1:33001"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:32:19.390793765Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8322501964150623,
+				"StableID":   "nkmAWp1Hz721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2a6aba6e59e00e32e124286cc338461a517503e3421b0aa1b4070befbf63665c",
+				"KeyExpiry":  "2026-11-08T18:32:19Z",
+				"DiscoKey":   "discokey:a002ae4629752ca3e8a7762b61d30bce26e58e63036698d42754f598df43a75e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55222",
+					"10.65.0.27:55222",
+					"172.17.0.1:55222",
+					"172.19.0.1:55222",
+					"172.20.0.1:55222"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:32:19.935418631Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1361823571364904,
+				"StableID":   "nm33fAomdB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:760e2195462306914e30e0cbf83b93eae29156b3ec710a6e754daaaee1d1731b",
+				"KeyExpiry":  "2026-11-08T18:32:20Z",
+				"DiscoKey":   "discokey:2578a9395027712379d3e4fc5af197e2e1b2e1c77e5480f6724bb2ab80f6c41c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53343",
+					"10.65.0.27:53343",
+					"172.17.0.1:53343",
+					"172.19.0.1:53343",
+					"172.20.0.1:53343"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:32:20.474345204Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7653696384495579": {
+				"ID":          7653696384495579,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7742721577423862,
+				"StableID":   "nFFN6fAhT321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       7742721577423862,
+				"Key":        "nodekey:902119616bcd067166ea48b310c7ca41b1b2ab46acf197b7d7c02bceb1e8ab0e",
+				"DiscoKey":   "discokey:cc1c3a0527f8341e7b409eb82c20bc483c43b292452d11c0fc898ba5dd6fea41",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:56470",
+					"10.65.0.27:56470",
+					"172.17.0.1:56470",
+					"172.19.0.1:56470",
+					"172.20.0.1:56470"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:32:12.903975602Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:902119616bcd067166ea48b310c7ca41b1b2ab46acf197b7d7c02bceb1e8ab0e",
+			"MachineKey": "mkey:79c5f780ab6da2acc7dbc3d0e8a35e614961890cb7296f3510b3afab98e5b577",
+			"Peers": [{
+				"ID":         7653696384495579,
+				"StableID":   "n6pTeHdNm221CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:84305a1d96b18015840e31377e672cc896c272dac9a0dc1e5efde6ec7fb29a20",
+				"DiscoKey":   "discokey:f712525b2af2bc2d95db157980742f75ee8c0e6d6d5f73d7d4d3de71ff0f295a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37333",
+					"10.65.0.27:37333",
+					"172.17.0.1:37333",
+					"172.19.0.1:37333",
+					"172.20.0.1:37333"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:32:13.453546408Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7822788726870038,
+				"StableID":   "nqztutPx5421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7e51416a52a9110cd3fad145977448e098923c03ef2ee53f2e5cee41c6be414",
+				"DiscoKey":   "discokey:376a11ffcecd094d3066c2b7563a4ff91785dc2861cb7fa0b3746965faeab271",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41585",
+					"10.65.0.27:41585",
+					"172.17.0.1:41585",
+					"172.19.0.1:41585",
+					"172.20.0.1:41585"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:32:13.99653772Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7337416301468498,
+				"StableID":   "nqU2m5V8Jz11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4092b5c99cdb9b3757aeae27a79539cd74bd392fb3693d0535344a40c4eb37e",
+				"DiscoKey":   "discokey:f73bf845dfb061af8e8ec2b135249ac7f6b0dcfbc82fe2a24f1d10737d406801",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56017",
+					"10.65.0.27:56017",
+					"172.17.0.1:56017",
+					"172.19.0.1:56017",
+					"172.20.0.1:56017"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:32:14.526492479Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6530979098763741,
+				"StableID":   "ngatfHktzs11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:456d8df79530f5211dfd525c45e508f2cffc3578c55d161b51913e9832ca046f",
+				"DiscoKey":   "discokey:7e40a59658c0eb556738fdd5b29a9c555f62a089090fd5e691a1b1ff63e7b05f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55361",
+					"10.65.0.27:55361",
+					"172.17.0.1:55361",
+					"172.19.0.1:55361",
+					"172.20.0.1:55361"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:32:15.069827367Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2517747849710593,
+				"StableID":   "nQ8gr4yHfL11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a1ddcb033ed5e74eb456e324cdab5f412e190d072eae4f76e0769d3c095df774",
+				"DiscoKey":   "discokey:139294a6276f864da6a382192299053837018064290aef14db70c00574f2fb69",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:48760",
+					"10.65.0.27:48760",
+					"172.17.0.1:48760",
+					"172.19.0.1:48760",
+					"172.20.0.1:48760"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:32:15.597080057Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6838958301879313,
+				"StableID":   "nzX2EbqNQv11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd33a2684a4d8116ae6a9f9a29accda91ee75200b60260cd7ea7e88783b88c33",
+				"DiscoKey":   "discokey:00c85530ef7afb763e0e81875090d06ba2dcefe9f276d50fdcc1134349027764",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:46349",
+					"10.65.0.27:46349",
+					"172.17.0.1:46349",
+					"172.19.0.1:46349",
+					"172.20.0.1:46349"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:32:16.135347917Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4896979443737729,
+				"StableID":   "ncSSX5MrEf11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ed075d9376fbfc5e81ea7ab1416cf3a80b622d1c054144ee46235060a893960",
+				"DiscoKey":   "discokey:901ac3ba06b28bd5baa1c657979edc057c1cfaac3be65e0982407c8bf094a96e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49291",
+					"10.65.0.27:49291",
+					"172.17.0.1:49291",
+					"172.19.0.1:49291",
+					"172.20.0.1:49291"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:32:16.685850697Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2441314712356406,
+				"StableID":   "nBF1FUCg4L11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a126fbc286def9c48b4b6b4db77e6b8086782a1784ddaedf112f5ad3cbb4551",
+				"DiscoKey":   "discokey:7b11635a4c1c1db62d7eab3da3f42e59e5223c537d44e6314f57658af7b2570f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41076",
+					"10.65.0.27:41076",
+					"172.17.0.1:41076",
+					"172.19.0.1:41076",
+					"172.20.0.1:41076"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:32:17.221955091Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7213159542142581,
+				"StableID":   "nUNDSFUrKy11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:48deeae5d1a74e18ad2dd70c4abde674add0fb92a0602281f9d68991729fcf5e",
+				"DiscoKey":   "discokey:dbda69eb016a4822020a6c896450b7ac0ab8cc2b79c546798385d799d6baee45",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49926",
+					"10.65.0.27:49926",
+					"172.17.0.1:49926",
+					"172.19.0.1:49926",
+					"172.20.0.1:49926"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:32:17.766631203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7977055529972839,
+				"StableID":   "nWkL3tipH521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:79f06d1ed26e54319d065964d15872f2267cc1ecf7f56426de441ac4251d1773",
+				"DiscoKey":   "discokey:bac5ec857a3afad8a04ec8880a0b1e936ea161c4b271f2675c920b769282f768",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36008",
+					"10.65.0.27:36008",
+					"172.17.0.1:36008",
+					"172.19.0.1:36008",
+					"172.20.0.1:36008"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:32:18.305657926Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7660868258443220,
+				"StableID":   "nM76b52dp221CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36ac8acbbdc4e7461c32670facafc19d77cc2241d2512deac8d8bfa59136ee46",
+				"DiscoKey":   "discokey:4f855703a0c6ff4548322e91cc34b324224ff4e760539143f31d1234ebd02a51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:53115",
+					"10.65.0.27:53115",
+					"172.17.0.1:53115",
+					"172.19.0.1:53115",
+					"172.20.0.1:53115"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:32:18.850273543Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2198817906034593,
+				"StableID":   "nadmrdDrAJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5e34245e085df6504a6c02709d65e513f752fdcf96b7081467eb45025a397c08",
+				"KeyExpiry":  "2026-11-08T18:32:19Z",
+				"DiscoKey":   "discokey:f3b92fad07f1d3ce591182dee3eaf8dc5d1d052ba552282d6d9290fbf8a7c918",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33001",
+					"10.65.0.27:33001",
+					"172.17.0.1:33001",
+					"172.19.0.1:33001",
+					"172.20.0.1:33001"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:32:19.390793765Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8322501964150623,
+				"StableID":   "nkmAWp1Hz721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2a6aba6e59e00e32e124286cc338461a517503e3421b0aa1b4070befbf63665c",
+				"KeyExpiry":  "2026-11-08T18:32:19Z",
+				"DiscoKey":   "discokey:a002ae4629752ca3e8a7762b61d30bce26e58e63036698d42754f598df43a75e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55222",
+					"10.65.0.27:55222",
+					"172.17.0.1:55222",
+					"172.19.0.1:55222",
+					"172.20.0.1:55222"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:32:19.935418631Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1361823571364904,
+				"StableID":   "nm33fAomdB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:760e2195462306914e30e0cbf83b93eae29156b3ec710a6e754daaaee1d1731b",
+				"KeyExpiry":  "2026-11-08T18:32:20Z",
+				"DiscoKey":   "discokey:2578a9395027712379d3e4fc5af197e2e1b2e1c77e5480f6724bb2ab80f6c41c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53343",
+					"10.65.0.27:53343",
+					"172.17.0.1:53343",
+					"172.19.0.1:53343",
+					"172.20.0.1:53343"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:32:20.474345204Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7742721577423862": {
+				"ID":          7742721577423862,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6530979098763741,
+				"StableID":   "ngatfHktzs11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       6530979098763741,
+				"Key":        "nodekey:456d8df79530f5211dfd525c45e508f2cffc3578c55d161b51913e9832ca046f",
+				"DiscoKey":   "discokey:7e40a59658c0eb556738fdd5b29a9c555f62a089090fd5e691a1b1ff63e7b05f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55361",
+					"10.65.0.27:55361",
+					"172.17.0.1:55361",
+					"172.19.0.1:55361",
+					"172.20.0.1:55361"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:32:15.069827367Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:456d8df79530f5211dfd525c45e508f2cffc3578c55d161b51913e9832ca046f",
+			"MachineKey": "mkey:ac01b231caae1349b8f642225bf828a6b4adee9432c6fa2397f7265e44adf539",
+			"Peers": [{
+				"ID":         7742721577423862,
+				"StableID":   "nFFN6fAhT321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:902119616bcd067166ea48b310c7ca41b1b2ab46acf197b7d7c02bceb1e8ab0e",
+				"DiscoKey":   "discokey:cc1c3a0527f8341e7b409eb82c20bc483c43b292452d11c0fc898ba5dd6fea41",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:56470",
+					"10.65.0.27:56470",
+					"172.17.0.1:56470",
+					"172.19.0.1:56470",
+					"172.20.0.1:56470"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:32:12.903975602Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7653696384495579,
+				"StableID":   "n6pTeHdNm221CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:84305a1d96b18015840e31377e672cc896c272dac9a0dc1e5efde6ec7fb29a20",
+				"DiscoKey":   "discokey:f712525b2af2bc2d95db157980742f75ee8c0e6d6d5f73d7d4d3de71ff0f295a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37333",
+					"10.65.0.27:37333",
+					"172.17.0.1:37333",
+					"172.19.0.1:37333",
+					"172.20.0.1:37333"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:32:13.453546408Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7822788726870038,
+				"StableID":   "nqztutPx5421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7e51416a52a9110cd3fad145977448e098923c03ef2ee53f2e5cee41c6be414",
+				"DiscoKey":   "discokey:376a11ffcecd094d3066c2b7563a4ff91785dc2861cb7fa0b3746965faeab271",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41585",
+					"10.65.0.27:41585",
+					"172.17.0.1:41585",
+					"172.19.0.1:41585",
+					"172.20.0.1:41585"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:32:13.99653772Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7337416301468498,
+				"StableID":   "nqU2m5V8Jz11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4092b5c99cdb9b3757aeae27a79539cd74bd392fb3693d0535344a40c4eb37e",
+				"DiscoKey":   "discokey:f73bf845dfb061af8e8ec2b135249ac7f6b0dcfbc82fe2a24f1d10737d406801",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56017",
+					"10.65.0.27:56017",
+					"172.17.0.1:56017",
+					"172.19.0.1:56017",
+					"172.20.0.1:56017"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:32:14.526492479Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2517747849710593,
+				"StableID":   "nQ8gr4yHfL11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a1ddcb033ed5e74eb456e324cdab5f412e190d072eae4f76e0769d3c095df774",
+				"DiscoKey":   "discokey:139294a6276f864da6a382192299053837018064290aef14db70c00574f2fb69",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:48760",
+					"10.65.0.27:48760",
+					"172.17.0.1:48760",
+					"172.19.0.1:48760",
+					"172.20.0.1:48760"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:32:15.597080057Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6838958301879313,
+				"StableID":   "nzX2EbqNQv11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd33a2684a4d8116ae6a9f9a29accda91ee75200b60260cd7ea7e88783b88c33",
+				"DiscoKey":   "discokey:00c85530ef7afb763e0e81875090d06ba2dcefe9f276d50fdcc1134349027764",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:46349",
+					"10.65.0.27:46349",
+					"172.17.0.1:46349",
+					"172.19.0.1:46349",
+					"172.20.0.1:46349"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:32:16.135347917Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4896979443737729,
+				"StableID":   "ncSSX5MrEf11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ed075d9376fbfc5e81ea7ab1416cf3a80b622d1c054144ee46235060a893960",
+				"DiscoKey":   "discokey:901ac3ba06b28bd5baa1c657979edc057c1cfaac3be65e0982407c8bf094a96e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49291",
+					"10.65.0.27:49291",
+					"172.17.0.1:49291",
+					"172.19.0.1:49291",
+					"172.20.0.1:49291"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:32:16.685850697Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2441314712356406,
+				"StableID":   "nBF1FUCg4L11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a126fbc286def9c48b4b6b4db77e6b8086782a1784ddaedf112f5ad3cbb4551",
+				"DiscoKey":   "discokey:7b11635a4c1c1db62d7eab3da3f42e59e5223c537d44e6314f57658af7b2570f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41076",
+					"10.65.0.27:41076",
+					"172.17.0.1:41076",
+					"172.19.0.1:41076",
+					"172.20.0.1:41076"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:32:17.221955091Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7213159542142581,
+				"StableID":   "nUNDSFUrKy11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:48deeae5d1a74e18ad2dd70c4abde674add0fb92a0602281f9d68991729fcf5e",
+				"DiscoKey":   "discokey:dbda69eb016a4822020a6c896450b7ac0ab8cc2b79c546798385d799d6baee45",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49926",
+					"10.65.0.27:49926",
+					"172.17.0.1:49926",
+					"172.19.0.1:49926",
+					"172.20.0.1:49926"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:32:17.766631203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7977055529972839,
+				"StableID":   "nWkL3tipH521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:79f06d1ed26e54319d065964d15872f2267cc1ecf7f56426de441ac4251d1773",
+				"DiscoKey":   "discokey:bac5ec857a3afad8a04ec8880a0b1e936ea161c4b271f2675c920b769282f768",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36008",
+					"10.65.0.27:36008",
+					"172.17.0.1:36008",
+					"172.19.0.1:36008",
+					"172.20.0.1:36008"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:32:18.305657926Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7660868258443220,
+				"StableID":   "nM76b52dp221CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36ac8acbbdc4e7461c32670facafc19d77cc2241d2512deac8d8bfa59136ee46",
+				"DiscoKey":   "discokey:4f855703a0c6ff4548322e91cc34b324224ff4e760539143f31d1234ebd02a51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:53115",
+					"10.65.0.27:53115",
+					"172.17.0.1:53115",
+					"172.19.0.1:53115",
+					"172.20.0.1:53115"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:32:18.850273543Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2198817906034593,
+				"StableID":   "nadmrdDrAJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5e34245e085df6504a6c02709d65e513f752fdcf96b7081467eb45025a397c08",
+				"KeyExpiry":  "2026-11-08T18:32:19Z",
+				"DiscoKey":   "discokey:f3b92fad07f1d3ce591182dee3eaf8dc5d1d052ba552282d6d9290fbf8a7c918",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33001",
+					"10.65.0.27:33001",
+					"172.17.0.1:33001",
+					"172.19.0.1:33001",
+					"172.20.0.1:33001"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:32:19.390793765Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8322501964150623,
+				"StableID":   "nkmAWp1Hz721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2a6aba6e59e00e32e124286cc338461a517503e3421b0aa1b4070befbf63665c",
+				"KeyExpiry":  "2026-11-08T18:32:19Z",
+				"DiscoKey":   "discokey:a002ae4629752ca3e8a7762b61d30bce26e58e63036698d42754f598df43a75e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55222",
+					"10.65.0.27:55222",
+					"172.17.0.1:55222",
+					"172.19.0.1:55222",
+					"172.20.0.1:55222"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:32:19.935418631Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1361823571364904,
+				"StableID":   "nm33fAomdB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:760e2195462306914e30e0cbf83b93eae29156b3ec710a6e754daaaee1d1731b",
+				"KeyExpiry":  "2026-11-08T18:32:20Z",
+				"DiscoKey":   "discokey:2578a9395027712379d3e4fc5af197e2e1b2e1c77e5480f6724bb2ab80f6c41c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53343",
+					"10.65.0.27:53343",
+					"172.17.0.1:53343",
+					"172.19.0.1:53343",
+					"172.20.0.1:53343"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:32:20.474345204Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6530979098763741": {
+				"ID":          6530979098763741,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7337416301468498,
+				"StableID":   "nqU2m5V8Jz11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       7337416301468498,
+				"Key":        "nodekey:b4092b5c99cdb9b3757aeae27a79539cd74bd392fb3693d0535344a40c4eb37e",
+				"DiscoKey":   "discokey:f73bf845dfb061af8e8ec2b135249ac7f6b0dcfbc82fe2a24f1d10737d406801",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56017",
+					"10.65.0.27:56017",
+					"172.17.0.1:56017",
+					"172.19.0.1:56017",
+					"172.20.0.1:56017"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:32:14.526492479Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b4092b5c99cdb9b3757aeae27a79539cd74bd392fb3693d0535344a40c4eb37e",
+			"MachineKey": "mkey:341b5bd24ee07cb208cf06e3212aabe49265af048d4cbb1f27e7f730c5f81965",
+			"Peers": [{
+				"ID":         7742721577423862,
+				"StableID":   "nFFN6fAhT321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:902119616bcd067166ea48b310c7ca41b1b2ab46acf197b7d7c02bceb1e8ab0e",
+				"DiscoKey":   "discokey:cc1c3a0527f8341e7b409eb82c20bc483c43b292452d11c0fc898ba5dd6fea41",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:56470",
+					"10.65.0.27:56470",
+					"172.17.0.1:56470",
+					"172.19.0.1:56470",
+					"172.20.0.1:56470"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:32:12.903975602Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7653696384495579,
+				"StableID":   "n6pTeHdNm221CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:84305a1d96b18015840e31377e672cc896c272dac9a0dc1e5efde6ec7fb29a20",
+				"DiscoKey":   "discokey:f712525b2af2bc2d95db157980742f75ee8c0e6d6d5f73d7d4d3de71ff0f295a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37333",
+					"10.65.0.27:37333",
+					"172.17.0.1:37333",
+					"172.19.0.1:37333",
+					"172.20.0.1:37333"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:32:13.453546408Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7822788726870038,
+				"StableID":   "nqztutPx5421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7e51416a52a9110cd3fad145977448e098923c03ef2ee53f2e5cee41c6be414",
+				"DiscoKey":   "discokey:376a11ffcecd094d3066c2b7563a4ff91785dc2861cb7fa0b3746965faeab271",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41585",
+					"10.65.0.27:41585",
+					"172.17.0.1:41585",
+					"172.19.0.1:41585",
+					"172.20.0.1:41585"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:32:13.99653772Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6530979098763741,
+				"StableID":   "ngatfHktzs11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:456d8df79530f5211dfd525c45e508f2cffc3578c55d161b51913e9832ca046f",
+				"DiscoKey":   "discokey:7e40a59658c0eb556738fdd5b29a9c555f62a089090fd5e691a1b1ff63e7b05f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55361",
+					"10.65.0.27:55361",
+					"172.17.0.1:55361",
+					"172.19.0.1:55361",
+					"172.20.0.1:55361"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:32:15.069827367Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2517747849710593,
+				"StableID":   "nQ8gr4yHfL11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a1ddcb033ed5e74eb456e324cdab5f412e190d072eae4f76e0769d3c095df774",
+				"DiscoKey":   "discokey:139294a6276f864da6a382192299053837018064290aef14db70c00574f2fb69",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:48760",
+					"10.65.0.27:48760",
+					"172.17.0.1:48760",
+					"172.19.0.1:48760",
+					"172.20.0.1:48760"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:32:15.597080057Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6838958301879313,
+				"StableID":   "nzX2EbqNQv11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd33a2684a4d8116ae6a9f9a29accda91ee75200b60260cd7ea7e88783b88c33",
+				"DiscoKey":   "discokey:00c85530ef7afb763e0e81875090d06ba2dcefe9f276d50fdcc1134349027764",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:46349",
+					"10.65.0.27:46349",
+					"172.17.0.1:46349",
+					"172.19.0.1:46349",
+					"172.20.0.1:46349"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:32:16.135347917Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4896979443737729,
+				"StableID":   "ncSSX5MrEf11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ed075d9376fbfc5e81ea7ab1416cf3a80b622d1c054144ee46235060a893960",
+				"DiscoKey":   "discokey:901ac3ba06b28bd5baa1c657979edc057c1cfaac3be65e0982407c8bf094a96e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49291",
+					"10.65.0.27:49291",
+					"172.17.0.1:49291",
+					"172.19.0.1:49291",
+					"172.20.0.1:49291"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:32:16.685850697Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2441314712356406,
+				"StableID":   "nBF1FUCg4L11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a126fbc286def9c48b4b6b4db77e6b8086782a1784ddaedf112f5ad3cbb4551",
+				"DiscoKey":   "discokey:7b11635a4c1c1db62d7eab3da3f42e59e5223c537d44e6314f57658af7b2570f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41076",
+					"10.65.0.27:41076",
+					"172.17.0.1:41076",
+					"172.19.0.1:41076",
+					"172.20.0.1:41076"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:32:17.221955091Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7213159542142581,
+				"StableID":   "nUNDSFUrKy11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:48deeae5d1a74e18ad2dd70c4abde674add0fb92a0602281f9d68991729fcf5e",
+				"DiscoKey":   "discokey:dbda69eb016a4822020a6c896450b7ac0ab8cc2b79c546798385d799d6baee45",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49926",
+					"10.65.0.27:49926",
+					"172.17.0.1:49926",
+					"172.19.0.1:49926",
+					"172.20.0.1:49926"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:32:17.766631203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7977055529972839,
+				"StableID":   "nWkL3tipH521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:79f06d1ed26e54319d065964d15872f2267cc1ecf7f56426de441ac4251d1773",
+				"DiscoKey":   "discokey:bac5ec857a3afad8a04ec8880a0b1e936ea161c4b271f2675c920b769282f768",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36008",
+					"10.65.0.27:36008",
+					"172.17.0.1:36008",
+					"172.19.0.1:36008",
+					"172.20.0.1:36008"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:32:18.305657926Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7660868258443220,
+				"StableID":   "nM76b52dp221CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36ac8acbbdc4e7461c32670facafc19d77cc2241d2512deac8d8bfa59136ee46",
+				"DiscoKey":   "discokey:4f855703a0c6ff4548322e91cc34b324224ff4e760539143f31d1234ebd02a51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:53115",
+					"10.65.0.27:53115",
+					"172.17.0.1:53115",
+					"172.19.0.1:53115",
+					"172.20.0.1:53115"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:32:18.850273543Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2198817906034593,
+				"StableID":   "nadmrdDrAJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5e34245e085df6504a6c02709d65e513f752fdcf96b7081467eb45025a397c08",
+				"KeyExpiry":  "2026-11-08T18:32:19Z",
+				"DiscoKey":   "discokey:f3b92fad07f1d3ce591182dee3eaf8dc5d1d052ba552282d6d9290fbf8a7c918",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33001",
+					"10.65.0.27:33001",
+					"172.17.0.1:33001",
+					"172.19.0.1:33001",
+					"172.20.0.1:33001"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:32:19.390793765Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8322501964150623,
+				"StableID":   "nkmAWp1Hz721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2a6aba6e59e00e32e124286cc338461a517503e3421b0aa1b4070befbf63665c",
+				"KeyExpiry":  "2026-11-08T18:32:19Z",
+				"DiscoKey":   "discokey:a002ae4629752ca3e8a7762b61d30bce26e58e63036698d42754f598df43a75e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55222",
+					"10.65.0.27:55222",
+					"172.17.0.1:55222",
+					"172.19.0.1:55222",
+					"172.20.0.1:55222"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:32:19.935418631Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1361823571364904,
+				"StableID":   "nm33fAomdB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:760e2195462306914e30e0cbf83b93eae29156b3ec710a6e754daaaee1d1731b",
+				"KeyExpiry":  "2026-11-08T18:32:20Z",
+				"DiscoKey":   "discokey:2578a9395027712379d3e4fc5af197e2e1b2e1c77e5480f6724bb2ab80f6c41c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53343",
+					"10.65.0.27:53343",
+					"172.17.0.1:53343",
+					"172.19.0.1:53343",
+					"172.20.0.1:53343"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:32:20.474345204Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7337416301468498": {
+				"ID":          7337416301468498,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6838958301879313,
+				"StableID":   "nzX2EbqNQv11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       6838958301879313,
+				"Key":        "nodekey:cd33a2684a4d8116ae6a9f9a29accda91ee75200b60260cd7ea7e88783b88c33",
+				"DiscoKey":   "discokey:00c85530ef7afb763e0e81875090d06ba2dcefe9f276d50fdcc1134349027764",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:46349",
+					"10.65.0.27:46349",
+					"172.17.0.1:46349",
+					"172.19.0.1:46349",
+					"172.20.0.1:46349"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:32:16.135347917Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:cd33a2684a4d8116ae6a9f9a29accda91ee75200b60260cd7ea7e88783b88c33",
+			"MachineKey": "mkey:cae43752189f2bda46df6164a8e04ca37e86824b4061e5f60eeb5a1c26c7bb18",
+			"Peers": [{
+				"ID":         7742721577423862,
+				"StableID":   "nFFN6fAhT321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:902119616bcd067166ea48b310c7ca41b1b2ab46acf197b7d7c02bceb1e8ab0e",
+				"DiscoKey":   "discokey:cc1c3a0527f8341e7b409eb82c20bc483c43b292452d11c0fc898ba5dd6fea41",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:56470",
+					"10.65.0.27:56470",
+					"172.17.0.1:56470",
+					"172.19.0.1:56470",
+					"172.20.0.1:56470"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:32:12.903975602Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7653696384495579,
+				"StableID":   "n6pTeHdNm221CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:84305a1d96b18015840e31377e672cc896c272dac9a0dc1e5efde6ec7fb29a20",
+				"DiscoKey":   "discokey:f712525b2af2bc2d95db157980742f75ee8c0e6d6d5f73d7d4d3de71ff0f295a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37333",
+					"10.65.0.27:37333",
+					"172.17.0.1:37333",
+					"172.19.0.1:37333",
+					"172.20.0.1:37333"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:32:13.453546408Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7822788726870038,
+				"StableID":   "nqztutPx5421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7e51416a52a9110cd3fad145977448e098923c03ef2ee53f2e5cee41c6be414",
+				"DiscoKey":   "discokey:376a11ffcecd094d3066c2b7563a4ff91785dc2861cb7fa0b3746965faeab271",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41585",
+					"10.65.0.27:41585",
+					"172.17.0.1:41585",
+					"172.19.0.1:41585",
+					"172.20.0.1:41585"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:32:13.99653772Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7337416301468498,
+				"StableID":   "nqU2m5V8Jz11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4092b5c99cdb9b3757aeae27a79539cd74bd392fb3693d0535344a40c4eb37e",
+				"DiscoKey":   "discokey:f73bf845dfb061af8e8ec2b135249ac7f6b0dcfbc82fe2a24f1d10737d406801",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56017",
+					"10.65.0.27:56017",
+					"172.17.0.1:56017",
+					"172.19.0.1:56017",
+					"172.20.0.1:56017"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:32:14.526492479Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6530979098763741,
+				"StableID":   "ngatfHktzs11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:456d8df79530f5211dfd525c45e508f2cffc3578c55d161b51913e9832ca046f",
+				"DiscoKey":   "discokey:7e40a59658c0eb556738fdd5b29a9c555f62a089090fd5e691a1b1ff63e7b05f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55361",
+					"10.65.0.27:55361",
+					"172.17.0.1:55361",
+					"172.19.0.1:55361",
+					"172.20.0.1:55361"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:32:15.069827367Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2517747849710593,
+				"StableID":   "nQ8gr4yHfL11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a1ddcb033ed5e74eb456e324cdab5f412e190d072eae4f76e0769d3c095df774",
+				"DiscoKey":   "discokey:139294a6276f864da6a382192299053837018064290aef14db70c00574f2fb69",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:48760",
+					"10.65.0.27:48760",
+					"172.17.0.1:48760",
+					"172.19.0.1:48760",
+					"172.20.0.1:48760"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:32:15.597080057Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4896979443737729,
+				"StableID":   "ncSSX5MrEf11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ed075d9376fbfc5e81ea7ab1416cf3a80b622d1c054144ee46235060a893960",
+				"DiscoKey":   "discokey:901ac3ba06b28bd5baa1c657979edc057c1cfaac3be65e0982407c8bf094a96e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49291",
+					"10.65.0.27:49291",
+					"172.17.0.1:49291",
+					"172.19.0.1:49291",
+					"172.20.0.1:49291"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:32:16.685850697Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2441314712356406,
+				"StableID":   "nBF1FUCg4L11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a126fbc286def9c48b4b6b4db77e6b8086782a1784ddaedf112f5ad3cbb4551",
+				"DiscoKey":   "discokey:7b11635a4c1c1db62d7eab3da3f42e59e5223c537d44e6314f57658af7b2570f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41076",
+					"10.65.0.27:41076",
+					"172.17.0.1:41076",
+					"172.19.0.1:41076",
+					"172.20.0.1:41076"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:32:17.221955091Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7213159542142581,
+				"StableID":   "nUNDSFUrKy11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:48deeae5d1a74e18ad2dd70c4abde674add0fb92a0602281f9d68991729fcf5e",
+				"DiscoKey":   "discokey:dbda69eb016a4822020a6c896450b7ac0ab8cc2b79c546798385d799d6baee45",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49926",
+					"10.65.0.27:49926",
+					"172.17.0.1:49926",
+					"172.19.0.1:49926",
+					"172.20.0.1:49926"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:32:17.766631203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7977055529972839,
+				"StableID":   "nWkL3tipH521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:79f06d1ed26e54319d065964d15872f2267cc1ecf7f56426de441ac4251d1773",
+				"DiscoKey":   "discokey:bac5ec857a3afad8a04ec8880a0b1e936ea161c4b271f2675c920b769282f768",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36008",
+					"10.65.0.27:36008",
+					"172.17.0.1:36008",
+					"172.19.0.1:36008",
+					"172.20.0.1:36008"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:32:18.305657926Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7660868258443220,
+				"StableID":   "nM76b52dp221CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36ac8acbbdc4e7461c32670facafc19d77cc2241d2512deac8d8bfa59136ee46",
+				"DiscoKey":   "discokey:4f855703a0c6ff4548322e91cc34b324224ff4e760539143f31d1234ebd02a51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:53115",
+					"10.65.0.27:53115",
+					"172.17.0.1:53115",
+					"172.19.0.1:53115",
+					"172.20.0.1:53115"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:32:18.850273543Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2198817906034593,
+				"StableID":   "nadmrdDrAJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5e34245e085df6504a6c02709d65e513f752fdcf96b7081467eb45025a397c08",
+				"KeyExpiry":  "2026-11-08T18:32:19Z",
+				"DiscoKey":   "discokey:f3b92fad07f1d3ce591182dee3eaf8dc5d1d052ba552282d6d9290fbf8a7c918",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33001",
+					"10.65.0.27:33001",
+					"172.17.0.1:33001",
+					"172.19.0.1:33001",
+					"172.20.0.1:33001"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:32:19.390793765Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8322501964150623,
+				"StableID":   "nkmAWp1Hz721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2a6aba6e59e00e32e124286cc338461a517503e3421b0aa1b4070befbf63665c",
+				"KeyExpiry":  "2026-11-08T18:32:19Z",
+				"DiscoKey":   "discokey:a002ae4629752ca3e8a7762b61d30bce26e58e63036698d42754f598df43a75e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55222",
+					"10.65.0.27:55222",
+					"172.17.0.1:55222",
+					"172.19.0.1:55222",
+					"172.20.0.1:55222"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:32:19.935418631Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1361823571364904,
+				"StableID":   "nm33fAomdB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:760e2195462306914e30e0cbf83b93eae29156b3ec710a6e754daaaee1d1731b",
+				"KeyExpiry":  "2026-11-08T18:32:20Z",
+				"DiscoKey":   "discokey:2578a9395027712379d3e4fc5af197e2e1b2e1c77e5480f6724bb2ab80f6c41c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53343",
+					"10.65.0.27:53343",
+					"172.17.0.1:53343",
+					"172.19.0.1:53343",
+					"172.20.0.1:53343"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:32:20.474345204Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6838958301879313": {
+				"ID":          6838958301879313,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2441314712356406,
+				"StableID":   "nBF1FUCg4L11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       2441314712356406,
+				"Key":        "nodekey:1a126fbc286def9c48b4b6b4db77e6b8086782a1784ddaedf112f5ad3cbb4551",
+				"DiscoKey":   "discokey:7b11635a4c1c1db62d7eab3da3f42e59e5223c537d44e6314f57658af7b2570f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41076",
+					"10.65.0.27:41076",
+					"172.17.0.1:41076",
+					"172.19.0.1:41076",
+					"172.20.0.1:41076"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:32:17.221955091Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1a126fbc286def9c48b4b6b4db77e6b8086782a1784ddaedf112f5ad3cbb4551",
+			"MachineKey": "mkey:83d4b5bbe449881f556f45d1b64d6993d29b5363b1dfe8b7c7f37dc7e54a5716",
+			"Peers": [{
+				"ID":         7742721577423862,
+				"StableID":   "nFFN6fAhT321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:902119616bcd067166ea48b310c7ca41b1b2ab46acf197b7d7c02bceb1e8ab0e",
+				"DiscoKey":   "discokey:cc1c3a0527f8341e7b409eb82c20bc483c43b292452d11c0fc898ba5dd6fea41",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:56470",
+					"10.65.0.27:56470",
+					"172.17.0.1:56470",
+					"172.19.0.1:56470",
+					"172.20.0.1:56470"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:32:12.903975602Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7653696384495579,
+				"StableID":   "n6pTeHdNm221CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:84305a1d96b18015840e31377e672cc896c272dac9a0dc1e5efde6ec7fb29a20",
+				"DiscoKey":   "discokey:f712525b2af2bc2d95db157980742f75ee8c0e6d6d5f73d7d4d3de71ff0f295a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37333",
+					"10.65.0.27:37333",
+					"172.17.0.1:37333",
+					"172.19.0.1:37333",
+					"172.20.0.1:37333"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:32:13.453546408Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7822788726870038,
+				"StableID":   "nqztutPx5421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7e51416a52a9110cd3fad145977448e098923c03ef2ee53f2e5cee41c6be414",
+				"DiscoKey":   "discokey:376a11ffcecd094d3066c2b7563a4ff91785dc2861cb7fa0b3746965faeab271",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41585",
+					"10.65.0.27:41585",
+					"172.17.0.1:41585",
+					"172.19.0.1:41585",
+					"172.20.0.1:41585"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:32:13.99653772Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7337416301468498,
+				"StableID":   "nqU2m5V8Jz11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4092b5c99cdb9b3757aeae27a79539cd74bd392fb3693d0535344a40c4eb37e",
+				"DiscoKey":   "discokey:f73bf845dfb061af8e8ec2b135249ac7f6b0dcfbc82fe2a24f1d10737d406801",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56017",
+					"10.65.0.27:56017",
+					"172.17.0.1:56017",
+					"172.19.0.1:56017",
+					"172.20.0.1:56017"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:32:14.526492479Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6530979098763741,
+				"StableID":   "ngatfHktzs11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:456d8df79530f5211dfd525c45e508f2cffc3578c55d161b51913e9832ca046f",
+				"DiscoKey":   "discokey:7e40a59658c0eb556738fdd5b29a9c555f62a089090fd5e691a1b1ff63e7b05f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55361",
+					"10.65.0.27:55361",
+					"172.17.0.1:55361",
+					"172.19.0.1:55361",
+					"172.20.0.1:55361"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:32:15.069827367Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2517747849710593,
+				"StableID":   "nQ8gr4yHfL11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a1ddcb033ed5e74eb456e324cdab5f412e190d072eae4f76e0769d3c095df774",
+				"DiscoKey":   "discokey:139294a6276f864da6a382192299053837018064290aef14db70c00574f2fb69",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:48760",
+					"10.65.0.27:48760",
+					"172.17.0.1:48760",
+					"172.19.0.1:48760",
+					"172.20.0.1:48760"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:32:15.597080057Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6838958301879313,
+				"StableID":   "nzX2EbqNQv11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd33a2684a4d8116ae6a9f9a29accda91ee75200b60260cd7ea7e88783b88c33",
+				"DiscoKey":   "discokey:00c85530ef7afb763e0e81875090d06ba2dcefe9f276d50fdcc1134349027764",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:46349",
+					"10.65.0.27:46349",
+					"172.17.0.1:46349",
+					"172.19.0.1:46349",
+					"172.20.0.1:46349"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:32:16.135347917Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4896979443737729,
+				"StableID":   "ncSSX5MrEf11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ed075d9376fbfc5e81ea7ab1416cf3a80b622d1c054144ee46235060a893960",
+				"DiscoKey":   "discokey:901ac3ba06b28bd5baa1c657979edc057c1cfaac3be65e0982407c8bf094a96e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49291",
+					"10.65.0.27:49291",
+					"172.17.0.1:49291",
+					"172.19.0.1:49291",
+					"172.20.0.1:49291"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:32:16.685850697Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7213159542142581,
+				"StableID":   "nUNDSFUrKy11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:48deeae5d1a74e18ad2dd70c4abde674add0fb92a0602281f9d68991729fcf5e",
+				"DiscoKey":   "discokey:dbda69eb016a4822020a6c896450b7ac0ab8cc2b79c546798385d799d6baee45",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49926",
+					"10.65.0.27:49926",
+					"172.17.0.1:49926",
+					"172.19.0.1:49926",
+					"172.20.0.1:49926"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:32:17.766631203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7977055529972839,
+				"StableID":   "nWkL3tipH521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:79f06d1ed26e54319d065964d15872f2267cc1ecf7f56426de441ac4251d1773",
+				"DiscoKey":   "discokey:bac5ec857a3afad8a04ec8880a0b1e936ea161c4b271f2675c920b769282f768",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36008",
+					"10.65.0.27:36008",
+					"172.17.0.1:36008",
+					"172.19.0.1:36008",
+					"172.20.0.1:36008"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:32:18.305657926Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7660868258443220,
+				"StableID":   "nM76b52dp221CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36ac8acbbdc4e7461c32670facafc19d77cc2241d2512deac8d8bfa59136ee46",
+				"DiscoKey":   "discokey:4f855703a0c6ff4548322e91cc34b324224ff4e760539143f31d1234ebd02a51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:53115",
+					"10.65.0.27:53115",
+					"172.17.0.1:53115",
+					"172.19.0.1:53115",
+					"172.20.0.1:53115"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:32:18.850273543Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2198817906034593,
+				"StableID":   "nadmrdDrAJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5e34245e085df6504a6c02709d65e513f752fdcf96b7081467eb45025a397c08",
+				"KeyExpiry":  "2026-11-08T18:32:19Z",
+				"DiscoKey":   "discokey:f3b92fad07f1d3ce591182dee3eaf8dc5d1d052ba552282d6d9290fbf8a7c918",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33001",
+					"10.65.0.27:33001",
+					"172.17.0.1:33001",
+					"172.19.0.1:33001",
+					"172.20.0.1:33001"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:32:19.390793765Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8322501964150623,
+				"StableID":   "nkmAWp1Hz721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2a6aba6e59e00e32e124286cc338461a517503e3421b0aa1b4070befbf63665c",
+				"KeyExpiry":  "2026-11-08T18:32:19Z",
+				"DiscoKey":   "discokey:a002ae4629752ca3e8a7762b61d30bce26e58e63036698d42754f598df43a75e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55222",
+					"10.65.0.27:55222",
+					"172.17.0.1:55222",
+					"172.19.0.1:55222",
+					"172.20.0.1:55222"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:32:19.935418631Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1361823571364904,
+				"StableID":   "nm33fAomdB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:760e2195462306914e30e0cbf83b93eae29156b3ec710a6e754daaaee1d1731b",
+				"KeyExpiry":  "2026-11-08T18:32:20Z",
+				"DiscoKey":   "discokey:2578a9395027712379d3e4fc5af197e2e1b2e1c77e5480f6724bb2ab80f6c41c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53343",
+					"10.65.0.27:53343",
+					"172.17.0.1:53343",
+					"172.19.0.1:53343",
+					"172.20.0.1:53343"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:32:20.474345204Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2441314712356406": {
+				"ID":          2441314712356406,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8322501964150623,
+				"StableID":   "nkmAWp1Hz721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2a6aba6e59e00e32e124286cc338461a517503e3421b0aa1b4070befbf63665c",
+				"KeyExpiry":  "2026-11-08T18:32:19Z",
+				"DiscoKey":   "discokey:a002ae4629752ca3e8a7762b61d30bce26e58e63036698d42754f598df43a75e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55222",
+					"10.65.0.27:55222",
+					"172.17.0.1:55222",
+					"172.19.0.1:55222",
+					"172.20.0.1:55222"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:32:19.935418631Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2a6aba6e59e00e32e124286cc338461a517503e3421b0aa1b4070befbf63665c",
+			"MachineKey": "mkey:6f86dbef8eb289b5a582228c8957d7dd42ed4c52e5f694d5876ffa9690254357",
+			"Peers": [{
+				"ID":         7742721577423862,
+				"StableID":   "nFFN6fAhT321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:902119616bcd067166ea48b310c7ca41b1b2ab46acf197b7d7c02bceb1e8ab0e",
+				"DiscoKey":   "discokey:cc1c3a0527f8341e7b409eb82c20bc483c43b292452d11c0fc898ba5dd6fea41",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:56470",
+					"10.65.0.27:56470",
+					"172.17.0.1:56470",
+					"172.19.0.1:56470",
+					"172.20.0.1:56470"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:32:12.903975602Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7653696384495579,
+				"StableID":   "n6pTeHdNm221CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:84305a1d96b18015840e31377e672cc896c272dac9a0dc1e5efde6ec7fb29a20",
+				"DiscoKey":   "discokey:f712525b2af2bc2d95db157980742f75ee8c0e6d6d5f73d7d4d3de71ff0f295a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37333",
+					"10.65.0.27:37333",
+					"172.17.0.1:37333",
+					"172.19.0.1:37333",
+					"172.20.0.1:37333"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:32:13.453546408Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7822788726870038,
+				"StableID":   "nqztutPx5421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7e51416a52a9110cd3fad145977448e098923c03ef2ee53f2e5cee41c6be414",
+				"DiscoKey":   "discokey:376a11ffcecd094d3066c2b7563a4ff91785dc2861cb7fa0b3746965faeab271",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41585",
+					"10.65.0.27:41585",
+					"172.17.0.1:41585",
+					"172.19.0.1:41585",
+					"172.20.0.1:41585"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:32:13.99653772Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7337416301468498,
+				"StableID":   "nqU2m5V8Jz11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4092b5c99cdb9b3757aeae27a79539cd74bd392fb3693d0535344a40c4eb37e",
+				"DiscoKey":   "discokey:f73bf845dfb061af8e8ec2b135249ac7f6b0dcfbc82fe2a24f1d10737d406801",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56017",
+					"10.65.0.27:56017",
+					"172.17.0.1:56017",
+					"172.19.0.1:56017",
+					"172.20.0.1:56017"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:32:14.526492479Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6530979098763741,
+				"StableID":   "ngatfHktzs11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:456d8df79530f5211dfd525c45e508f2cffc3578c55d161b51913e9832ca046f",
+				"DiscoKey":   "discokey:7e40a59658c0eb556738fdd5b29a9c555f62a089090fd5e691a1b1ff63e7b05f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55361",
+					"10.65.0.27:55361",
+					"172.17.0.1:55361",
+					"172.19.0.1:55361",
+					"172.20.0.1:55361"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:32:15.069827367Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2517747849710593,
+				"StableID":   "nQ8gr4yHfL11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a1ddcb033ed5e74eb456e324cdab5f412e190d072eae4f76e0769d3c095df774",
+				"DiscoKey":   "discokey:139294a6276f864da6a382192299053837018064290aef14db70c00574f2fb69",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:48760",
+					"10.65.0.27:48760",
+					"172.17.0.1:48760",
+					"172.19.0.1:48760",
+					"172.20.0.1:48760"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:32:15.597080057Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6838958301879313,
+				"StableID":   "nzX2EbqNQv11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd33a2684a4d8116ae6a9f9a29accda91ee75200b60260cd7ea7e88783b88c33",
+				"DiscoKey":   "discokey:00c85530ef7afb763e0e81875090d06ba2dcefe9f276d50fdcc1134349027764",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:46349",
+					"10.65.0.27:46349",
+					"172.17.0.1:46349",
+					"172.19.0.1:46349",
+					"172.20.0.1:46349"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:32:16.135347917Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4896979443737729,
+				"StableID":   "ncSSX5MrEf11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ed075d9376fbfc5e81ea7ab1416cf3a80b622d1c054144ee46235060a893960",
+				"DiscoKey":   "discokey:901ac3ba06b28bd5baa1c657979edc057c1cfaac3be65e0982407c8bf094a96e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49291",
+					"10.65.0.27:49291",
+					"172.17.0.1:49291",
+					"172.19.0.1:49291",
+					"172.20.0.1:49291"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:32:16.685850697Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2441314712356406,
+				"StableID":   "nBF1FUCg4L11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a126fbc286def9c48b4b6b4db77e6b8086782a1784ddaedf112f5ad3cbb4551",
+				"DiscoKey":   "discokey:7b11635a4c1c1db62d7eab3da3f42e59e5223c537d44e6314f57658af7b2570f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41076",
+					"10.65.0.27:41076",
+					"172.17.0.1:41076",
+					"172.19.0.1:41076",
+					"172.20.0.1:41076"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:32:17.221955091Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7213159542142581,
+				"StableID":   "nUNDSFUrKy11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:48deeae5d1a74e18ad2dd70c4abde674add0fb92a0602281f9d68991729fcf5e",
+				"DiscoKey":   "discokey:dbda69eb016a4822020a6c896450b7ac0ab8cc2b79c546798385d799d6baee45",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49926",
+					"10.65.0.27:49926",
+					"172.17.0.1:49926",
+					"172.19.0.1:49926",
+					"172.20.0.1:49926"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:32:17.766631203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7977055529972839,
+				"StableID":   "nWkL3tipH521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:79f06d1ed26e54319d065964d15872f2267cc1ecf7f56426de441ac4251d1773",
+				"DiscoKey":   "discokey:bac5ec857a3afad8a04ec8880a0b1e936ea161c4b271f2675c920b769282f768",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36008",
+					"10.65.0.27:36008",
+					"172.17.0.1:36008",
+					"172.19.0.1:36008",
+					"172.20.0.1:36008"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:32:18.305657926Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7660868258443220,
+				"StableID":   "nM76b52dp221CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36ac8acbbdc4e7461c32670facafc19d77cc2241d2512deac8d8bfa59136ee46",
+				"DiscoKey":   "discokey:4f855703a0c6ff4548322e91cc34b324224ff4e760539143f31d1234ebd02a51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:53115",
+					"10.65.0.27:53115",
+					"172.17.0.1:53115",
+					"172.19.0.1:53115",
+					"172.20.0.1:53115"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:32:18.850273543Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2198817906034593,
+				"StableID":   "nadmrdDrAJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5e34245e085df6504a6c02709d65e513f752fdcf96b7081467eb45025a397c08",
+				"KeyExpiry":  "2026-11-08T18:32:19Z",
+				"DiscoKey":   "discokey:f3b92fad07f1d3ce591182dee3eaf8dc5d1d052ba552282d6d9290fbf8a7c918",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33001",
+					"10.65.0.27:33001",
+					"172.17.0.1:33001",
+					"172.19.0.1:33001",
+					"172.20.0.1:33001"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:32:19.390793765Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1361823571364904,
+				"StableID":   "nm33fAomdB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:760e2195462306914e30e0cbf83b93eae29156b3ec710a6e754daaaee1d1731b",
+				"KeyExpiry":  "2026-11-08T18:32:20Z",
+				"DiscoKey":   "discokey:2578a9395027712379d3e4fc5af197e2e1b2e1c77e5480f6724bb2ab80f6c41c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53343",
+					"10.65.0.27:53343",
+					"172.17.0.1:53343",
+					"172.19.0.1:53343",
+					"172.20.0.1:53343"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:32:20.474345204Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7213159542142581,
+				"StableID":   "nUNDSFUrKy11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       7213159542142581,
+				"Key":        "nodekey:48deeae5d1a74e18ad2dd70c4abde674add0fb92a0602281f9d68991729fcf5e",
+				"DiscoKey":   "discokey:dbda69eb016a4822020a6c896450b7ac0ab8cc2b79c546798385d799d6baee45",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:49926",
+					"10.65.0.27:49926",
+					"172.17.0.1:49926",
+					"172.19.0.1:49926",
+					"172.20.0.1:49926"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:32:17.766631203Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:48deeae5d1a74e18ad2dd70c4abde674add0fb92a0602281f9d68991729fcf5e",
+			"MachineKey": "mkey:0c92a1df068e14357dcde79e277882611f0292943155b4ad34d4339b6c592478",
+			"Peers": [{
+				"ID":         7742721577423862,
+				"StableID":   "nFFN6fAhT321CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:902119616bcd067166ea48b310c7ca41b1b2ab46acf197b7d7c02bceb1e8ab0e",
+				"DiscoKey":   "discokey:cc1c3a0527f8341e7b409eb82c20bc483c43b292452d11c0fc898ba5dd6fea41",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:56470",
+					"10.65.0.27:56470",
+					"172.17.0.1:56470",
+					"172.19.0.1:56470",
+					"172.20.0.1:56470"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:32:12.903975602Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7653696384495579,
+				"StableID":   "n6pTeHdNm221CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:84305a1d96b18015840e31377e672cc896c272dac9a0dc1e5efde6ec7fb29a20",
+				"DiscoKey":   "discokey:f712525b2af2bc2d95db157980742f75ee8c0e6d6d5f73d7d4d3de71ff0f295a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37333",
+					"10.65.0.27:37333",
+					"172.17.0.1:37333",
+					"172.19.0.1:37333",
+					"172.20.0.1:37333"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:32:13.453546408Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7822788726870038,
+				"StableID":   "nqztutPx5421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7e51416a52a9110cd3fad145977448e098923c03ef2ee53f2e5cee41c6be414",
+				"DiscoKey":   "discokey:376a11ffcecd094d3066c2b7563a4ff91785dc2861cb7fa0b3746965faeab271",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:41585",
+					"10.65.0.27:41585",
+					"172.17.0.1:41585",
+					"172.19.0.1:41585",
+					"172.20.0.1:41585"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:32:13.99653772Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7337416301468498,
+				"StableID":   "nqU2m5V8Jz11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4092b5c99cdb9b3757aeae27a79539cd74bd392fb3693d0535344a40c4eb37e",
+				"DiscoKey":   "discokey:f73bf845dfb061af8e8ec2b135249ac7f6b0dcfbc82fe2a24f1d10737d406801",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56017",
+					"10.65.0.27:56017",
+					"172.17.0.1:56017",
+					"172.19.0.1:56017",
+					"172.20.0.1:56017"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:32:14.526492479Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6530979098763741,
+				"StableID":   "ngatfHktzs11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:456d8df79530f5211dfd525c45e508f2cffc3578c55d161b51913e9832ca046f",
+				"DiscoKey":   "discokey:7e40a59658c0eb556738fdd5b29a9c555f62a089090fd5e691a1b1ff63e7b05f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:55361",
+					"10.65.0.27:55361",
+					"172.17.0.1:55361",
+					"172.19.0.1:55361",
+					"172.20.0.1:55361"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:32:15.069827367Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2517747849710593,
+				"StableID":   "nQ8gr4yHfL11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a1ddcb033ed5e74eb456e324cdab5f412e190d072eae4f76e0769d3c095df774",
+				"DiscoKey":   "discokey:139294a6276f864da6a382192299053837018064290aef14db70c00574f2fb69",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:48760",
+					"10.65.0.27:48760",
+					"172.17.0.1:48760",
+					"172.19.0.1:48760",
+					"172.20.0.1:48760"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:32:15.597080057Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6838958301879313,
+				"StableID":   "nzX2EbqNQv11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd33a2684a4d8116ae6a9f9a29accda91ee75200b60260cd7ea7e88783b88c33",
+				"DiscoKey":   "discokey:00c85530ef7afb763e0e81875090d06ba2dcefe9f276d50fdcc1134349027764",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:46349",
+					"10.65.0.27:46349",
+					"172.17.0.1:46349",
+					"172.19.0.1:46349",
+					"172.20.0.1:46349"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:32:16.135347917Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4896979443737729,
+				"StableID":   "ncSSX5MrEf11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ed075d9376fbfc5e81ea7ab1416cf3a80b622d1c054144ee46235060a893960",
+				"DiscoKey":   "discokey:901ac3ba06b28bd5baa1c657979edc057c1cfaac3be65e0982407c8bf094a96e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49291",
+					"10.65.0.27:49291",
+					"172.17.0.1:49291",
+					"172.19.0.1:49291",
+					"172.20.0.1:49291"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:32:16.685850697Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2441314712356406,
+				"StableID":   "nBF1FUCg4L11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a126fbc286def9c48b4b6b4db77e6b8086782a1784ddaedf112f5ad3cbb4551",
+				"DiscoKey":   "discokey:7b11635a4c1c1db62d7eab3da3f42e59e5223c537d44e6314f57658af7b2570f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41076",
+					"10.65.0.27:41076",
+					"172.17.0.1:41076",
+					"172.19.0.1:41076",
+					"172.20.0.1:41076"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:32:17.221955091Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7977055529972839,
+				"StableID":   "nWkL3tipH521CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:79f06d1ed26e54319d065964d15872f2267cc1ecf7f56426de441ac4251d1773",
+				"DiscoKey":   "discokey:bac5ec857a3afad8a04ec8880a0b1e936ea161c4b271f2675c920b769282f768",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:36008",
+					"10.65.0.27:36008",
+					"172.17.0.1:36008",
+					"172.19.0.1:36008",
+					"172.20.0.1:36008"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:32:18.305657926Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7660868258443220,
+				"StableID":   "nM76b52dp221CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:36ac8acbbdc4e7461c32670facafc19d77cc2241d2512deac8d8bfa59136ee46",
+				"DiscoKey":   "discokey:4f855703a0c6ff4548322e91cc34b324224ff4e760539143f31d1234ebd02a51",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:53115",
+					"10.65.0.27:53115",
+					"172.17.0.1:53115",
+					"172.19.0.1:53115",
+					"172.20.0.1:53115"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:32:18.850273543Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2198817906034593,
+				"StableID":   "nadmrdDrAJ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5e34245e085df6504a6c02709d65e513f752fdcf96b7081467eb45025a397c08",
+				"KeyExpiry":  "2026-11-08T18:32:19Z",
+				"DiscoKey":   "discokey:f3b92fad07f1d3ce591182dee3eaf8dc5d1d052ba552282d6d9290fbf8a7c918",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33001",
+					"10.65.0.27:33001",
+					"172.17.0.1:33001",
+					"172.19.0.1:33001",
+					"172.20.0.1:33001"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:32:19.390793765Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8322501964150623,
+				"StableID":   "nkmAWp1Hz721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2a6aba6e59e00e32e124286cc338461a517503e3421b0aa1b4070befbf63665c",
+				"KeyExpiry":  "2026-11-08T18:32:19Z",
+				"DiscoKey":   "discokey:a002ae4629752ca3e8a7762b61d30bce26e58e63036698d42754f598df43a75e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55222",
+					"10.65.0.27:55222",
+					"172.17.0.1:55222",
+					"172.19.0.1:55222",
+					"172.20.0.1:55222"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:32:19.935418631Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1361823571364904,
+				"StableID":   "nm33fAomdB11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:760e2195462306914e30e0cbf83b93eae29156b3ec710a6e754daaaee1d1731b",
+				"KeyExpiry":  "2026-11-08T18:32:20Z",
+				"DiscoKey":   "discokey:2578a9395027712379d3e4fc5af197e2e1b2e1c77e5480f6724bb2ab80f6c41c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:53343",
+					"10.65.0.27:53343",
+					"172.17.0.1:53343",
+					"172.19.0.1:53343",
+					"172.20.0.1:53343"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:32:20.474345204Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7213159542142581": {
+				"ID":          7213159542142581,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/sshtest_results/sshtest-allpass-autogroup-self-same-user.hujson
+++ b/hscontrol/policy/v2/testdata/sshtest_results/sshtest-allpass-autogroup-self-same-user.hujson
@@ -1,0 +1,20036 @@
+// sshtest-allpass-autogroup-self-same-user
+//
+// autogroup:self with single-user pair, sshTests accept
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T18:33:05Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "sshtest-allpass-autogroup-self-same-user",
+	"description":    "autogroup:self with single-user pair, sshTests accept",
+	"category":       "sshtest",
+	"captured_at":    "2026-05-12T18:33:05.760476613Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                           \n  \n                                                                        \n                                         \n{\n\t\"category\":    \"sshtest\",\n\t\"description\": \"autogroup:self with single-user pair, sshTests accept\",\n\t\"id\":          \"sshtest-allpass-autogroup-self-same-user\",\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"autogroup:self\"],\n\t\t\"src\":    [\"autogroup:member\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"sshTests\": [{\n\t\t\"accept\": [\"root\"],\n\t\t\"dst\":    [\"thor@example.org\"],\n\t\t\"src\":    \"thor@example.org\"\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/sshtest/sshtest-allpass-autogroup-self-same-user.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["autogroup:self"],
+				"src":    ["autogroup:member"],
+				"users":  ["root"]
+			}],
+			"sshTests": [{
+				"accept": ["root"],
+				"dst":    ["thor@example.org"],
+				"src":    "thor@example.org"
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8833086820652244,
+				"StableID":   "nBSfrKDXyB21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       8833086820652244,
+				"Key":        "nodekey:0ba0541859c797ac5f7ec9ed9f1c188500947b3931705e9cb31b3f584ecd8861",
+				"DiscoKey":   "discokey:8839861f36c99c995cbeca958da544806ae29ff76aff636be07001939e4fcc55",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41528",
+					"10.65.0.27:41528",
+					"172.17.0.1:41528",
+					"172.19.0.1:41528",
+					"172.20.0.1:41528"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:33:14.129122113Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0ba0541859c797ac5f7ec9ed9f1c188500947b3931705e9cb31b3f584ecd8861",
+			"MachineKey": "mkey:3ed4b339e15177a63556cfc75ed10d9e8e4a3d22f2845f62157017494f1d4f0a",
+			"Peers": [{
+				"ID":         1209777249547958,
+				"StableID":   "n3BbrDouSA11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a2081c3c2709901df4690fa1b7595a51519c22ad420f2b9acddcf2fdef9d401c",
+				"DiscoKey":   "discokey:626f5816c03f257d6261f689c353f76bb515826afc2b36c2fa1cf7b515c55009",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58126",
+					"10.65.0.27:58126",
+					"172.17.0.1:58126",
+					"172.19.0.1:58126",
+					"172.20.0.1:58126"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:33:08.294290382Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4023169253352937,
+				"StableID":   "nnuvDPq6RY11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b02b36dd505ace740bb4698542b8ed81ec4095bf6531b7287cdaff894f242b42",
+				"DiscoKey":   "discokey:f15c47c262198507f69bd5014ebadb3f78efc139d16ac362a5d142b8c0c2133a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45115",
+					"10.65.0.27:45115",
+					"172.17.0.1:45115",
+					"172.19.0.1:45115",
+					"172.20.0.1:45115"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:33:08.763175709Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4652214928213325,
+				"StableID":   "nahnSFozKd11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77793ca1f48eb34568c93668af9146722be4b786bbe3398d563266b31ad4c17f",
+				"DiscoKey":   "discokey:11f3a582666ea4f24807becf4d74de0d2cc6dfb8bcb5e405e635d7e7a470c366",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:33:09.299397318Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8731075257292874,
+				"StableID":   "n1CpKRYKBB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a6ffa9cec643a3ee5c74ee56b7aff3e4f113d181292b0503b95264eb29dbf72",
+				"DiscoKey":   "discokey:6e977e9d58f6ae95801087703d09ce5b0b06646c2d44e6597ed6b441e3a8181f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:37260",
+					"10.65.0.27:37260",
+					"172.17.0.1:37260",
+					"172.19.0.1:37260",
+					"172.20.0.1:37260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:33:09.837588413Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5321503171654358,
+				"StableID":   "nqUZe9s7Zi11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6f8025967b9e427b50a5b8533fda537e864eaccce2d33a8a8e693cae1098566d",
+				"DiscoKey":   "discokey:dceded285b2d1bba3b281c50b52371b0fb12a215539817c6c3d320d634f06842",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56832",
+					"10.65.0.27:56832",
+					"172.17.0.1:56832",
+					"172.19.0.1:56832",
+					"172.20.0.1:56832"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:33:10.385856224Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4492892243963888,
+				"StableID":   "njJvQKfq5c11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5e68f80a29fce97eaab751f7dafac4f45c67790d0ec5439d3a42879dd865853e",
+				"DiscoKey":   "discokey:308832a609850e9acd8e9e8f28b0e9820c55931d854eb442a0cd3c814472757c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:34594",
+					"10.65.0.27:34594",
+					"172.17.0.1:34594",
+					"172.19.0.1:34594",
+					"172.20.0.1:34594"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:33:10.925761545Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4322992263202343,
+				"StableID":   "neLeuDgtka11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6bbf76b5ac197773c0b859a9b1c91e44b93595fa95e5a62930adfa8ec5180041",
+				"DiscoKey":   "discokey:4a33e21c16f93042152ced77f5ba089c8e4bde91258a303ed65fa20227ad8b25",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44848",
+					"10.65.0.27:44848",
+					"172.17.0.1:44848",
+					"172.19.0.1:44848",
+					"172.20.0.1:44848"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:33:11.458425053Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3081484268680458,
+				"StableID":   "nKy1nFNc4R11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1cd157428e354b28b71a831d8b65eb680e81004d6ebcc78d9309b50ee2412b2b",
+				"DiscoKey":   "discokey:6641b6c439d0d5cd5bbb7d1375e4bde3c8b4219c3c0e95951c3cf1ea0f790b05",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48756",
+					"10.65.0.27:48756",
+					"172.17.0.1:48756",
+					"172.19.0.1:48756",
+					"172.20.0.1:48756"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:33:11.999531663Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         469765205737312,
+				"StableID":   "nBiYbFwkf411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3d073dbd2e6677630b5a379c2338653747a44c303e1ca213330297865d6a17f",
+				"DiscoKey":   "discokey:c58b38472907cad9b8438598dfd3cabf76d0b4f3bda28294d711f0d2ba773242",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45167",
+					"10.65.0.27:45167",
+					"172.17.0.1:45167",
+					"172.19.0.1:45167",
+					"172.20.0.1:45167"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:33:12.531505155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8666116292854433,
+				"StableID":   "neyY5SBufA21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd7d9da01be466b8da4f4a04ab5ca3462646c23ee86179436f562659298e057a",
+				"DiscoKey":   "discokey:f147cf46411b38f2cf4f9afe7aa9fa5808876e3e3b5c3af2f9014a333f55cb56",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51954",
+					"10.65.0.27:51954",
+					"172.17.0.1:51954",
+					"172.19.0.1:51954",
+					"172.20.0.1:51954"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:33:13.069459914Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4087990560702471,
+				"StableID":   "nYVdBeaTvY11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dcd257a4b27218522012867ad3a96efce3b3fd72eb6ce226ade91bdd34f8502d",
+				"DiscoKey":   "discokey:1a10cab9938af6686b0ce2990dae2250b82a6a5d1185f99a8800f0d3c3e7eb3e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60845",
+					"10.65.0.27:60845",
+					"172.17.0.1:60845",
+					"172.19.0.1:60845",
+					"172.20.0.1:60845"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:33:13.592579815Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7035509393532425,
+				"StableID":   "neou8JuPww11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ecee0122e3a9f5a440fa5f224b7f8b73cb2c105204596b439595e9c192115624",
+				"KeyExpiry":  "2026-11-08T18:33:14Z",
+				"DiscoKey":   "discokey:0bb5fb3e7c8f425e1216249916032b6d300be145e7f518148132b57bb311dd74",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:57132",
+					"10.65.0.27:57132",
+					"172.17.0.1:57132",
+					"172.19.0.1:57132",
+					"172.20.0.1:57132"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:33:14.663005747Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6999886582499453,
+				"StableID":   "nSoyJk9Gfw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9cc889d065800d1cefd0e57538710565c901432032569b4f058c17134506fa3b",
+				"KeyExpiry":  "2026-11-08T18:33:15Z",
+				"DiscoKey":   "discokey:4982335d30436caf95bc55d8c35a748544e40eaed360384bd887f6b83e04e95d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49044",
+					"10.65.0.27:49044",
+					"172.17.0.1:49044",
+					"172.19.0.1:49044",
+					"172.20.0.1:49044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:33:15.208583828Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6808557030166489,
+				"StableID":   "nLixwNFcAv11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c8fb5923da5e2e0991e21685f89114292bbd46e101009f97de3959018275c93f",
+				"KeyExpiry":  "2026-11-08T18:33:15Z",
+				"DiscoKey":   "discokey:d1097930c9c9cdd9bfdfd05fdc5c8dc2a16e4abf5a78ee9eca7474006aae6149",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50794",
+					"10.65.0.27:50794",
+					"172.17.0.1:50794",
+					"172.19.0.1:50794",
+					"172.20.0.1:50794"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:33:15.755753394Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8833086820652244": {
+				"ID":          8833086820652244,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4492892243963888,
+				"StableID":   "njJvQKfq5c11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       4492892243963888,
+				"Key":        "nodekey:5e68f80a29fce97eaab751f7dafac4f45c67790d0ec5439d3a42879dd865853e",
+				"DiscoKey":   "discokey:308832a609850e9acd8e9e8f28b0e9820c55931d854eb442a0cd3c814472757c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:34594",
+					"10.65.0.27:34594",
+					"172.17.0.1:34594",
+					"172.19.0.1:34594",
+					"172.20.0.1:34594"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:33:10.925761545Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5e68f80a29fce97eaab751f7dafac4f45c67790d0ec5439d3a42879dd865853e",
+			"MachineKey": "mkey:990f8b80e7ac44f950ddfe2d1c845d74bdfdef30dc38d044a1ac7453e30b194a",
+			"Peers": [{
+				"ID":         1209777249547958,
+				"StableID":   "n3BbrDouSA11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a2081c3c2709901df4690fa1b7595a51519c22ad420f2b9acddcf2fdef9d401c",
+				"DiscoKey":   "discokey:626f5816c03f257d6261f689c353f76bb515826afc2b36c2fa1cf7b515c55009",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58126",
+					"10.65.0.27:58126",
+					"172.17.0.1:58126",
+					"172.19.0.1:58126",
+					"172.20.0.1:58126"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:33:08.294290382Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4023169253352937,
+				"StableID":   "nnuvDPq6RY11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b02b36dd505ace740bb4698542b8ed81ec4095bf6531b7287cdaff894f242b42",
+				"DiscoKey":   "discokey:f15c47c262198507f69bd5014ebadb3f78efc139d16ac362a5d142b8c0c2133a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45115",
+					"10.65.0.27:45115",
+					"172.17.0.1:45115",
+					"172.19.0.1:45115",
+					"172.20.0.1:45115"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:33:08.763175709Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4652214928213325,
+				"StableID":   "nahnSFozKd11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77793ca1f48eb34568c93668af9146722be4b786bbe3398d563266b31ad4c17f",
+				"DiscoKey":   "discokey:11f3a582666ea4f24807becf4d74de0d2cc6dfb8bcb5e405e635d7e7a470c366",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:33:09.299397318Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8731075257292874,
+				"StableID":   "n1CpKRYKBB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a6ffa9cec643a3ee5c74ee56b7aff3e4f113d181292b0503b95264eb29dbf72",
+				"DiscoKey":   "discokey:6e977e9d58f6ae95801087703d09ce5b0b06646c2d44e6597ed6b441e3a8181f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:37260",
+					"10.65.0.27:37260",
+					"172.17.0.1:37260",
+					"172.19.0.1:37260",
+					"172.20.0.1:37260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:33:09.837588413Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5321503171654358,
+				"StableID":   "nqUZe9s7Zi11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6f8025967b9e427b50a5b8533fda537e864eaccce2d33a8a8e693cae1098566d",
+				"DiscoKey":   "discokey:dceded285b2d1bba3b281c50b52371b0fb12a215539817c6c3d320d634f06842",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56832",
+					"10.65.0.27:56832",
+					"172.17.0.1:56832",
+					"172.19.0.1:56832",
+					"172.20.0.1:56832"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:33:10.385856224Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4322992263202343,
+				"StableID":   "neLeuDgtka11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6bbf76b5ac197773c0b859a9b1c91e44b93595fa95e5a62930adfa8ec5180041",
+				"DiscoKey":   "discokey:4a33e21c16f93042152ced77f5ba089c8e4bde91258a303ed65fa20227ad8b25",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44848",
+					"10.65.0.27:44848",
+					"172.17.0.1:44848",
+					"172.19.0.1:44848",
+					"172.20.0.1:44848"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:33:11.458425053Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3081484268680458,
+				"StableID":   "nKy1nFNc4R11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1cd157428e354b28b71a831d8b65eb680e81004d6ebcc78d9309b50ee2412b2b",
+				"DiscoKey":   "discokey:6641b6c439d0d5cd5bbb7d1375e4bde3c8b4219c3c0e95951c3cf1ea0f790b05",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48756",
+					"10.65.0.27:48756",
+					"172.17.0.1:48756",
+					"172.19.0.1:48756",
+					"172.20.0.1:48756"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:33:11.999531663Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         469765205737312,
+				"StableID":   "nBiYbFwkf411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3d073dbd2e6677630b5a379c2338653747a44c303e1ca213330297865d6a17f",
+				"DiscoKey":   "discokey:c58b38472907cad9b8438598dfd3cabf76d0b4f3bda28294d711f0d2ba773242",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45167",
+					"10.65.0.27:45167",
+					"172.17.0.1:45167",
+					"172.19.0.1:45167",
+					"172.20.0.1:45167"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:33:12.531505155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8666116292854433,
+				"StableID":   "neyY5SBufA21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd7d9da01be466b8da4f4a04ab5ca3462646c23ee86179436f562659298e057a",
+				"DiscoKey":   "discokey:f147cf46411b38f2cf4f9afe7aa9fa5808876e3e3b5c3af2f9014a333f55cb56",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51954",
+					"10.65.0.27:51954",
+					"172.17.0.1:51954",
+					"172.19.0.1:51954",
+					"172.20.0.1:51954"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:33:13.069459914Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4087990560702471,
+				"StableID":   "nYVdBeaTvY11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dcd257a4b27218522012867ad3a96efce3b3fd72eb6ce226ade91bdd34f8502d",
+				"DiscoKey":   "discokey:1a10cab9938af6686b0ce2990dae2250b82a6a5d1185f99a8800f0d3c3e7eb3e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60845",
+					"10.65.0.27:60845",
+					"172.17.0.1:60845",
+					"172.19.0.1:60845",
+					"172.20.0.1:60845"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:33:13.592579815Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8833086820652244,
+				"StableID":   "nBSfrKDXyB21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ba0541859c797ac5f7ec9ed9f1c188500947b3931705e9cb31b3f584ecd8861",
+				"DiscoKey":   "discokey:8839861f36c99c995cbeca958da544806ae29ff76aff636be07001939e4fcc55",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41528",
+					"10.65.0.27:41528",
+					"172.17.0.1:41528",
+					"172.19.0.1:41528",
+					"172.20.0.1:41528"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:33:14.129122113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7035509393532425,
+				"StableID":   "neou8JuPww11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ecee0122e3a9f5a440fa5f224b7f8b73cb2c105204596b439595e9c192115624",
+				"KeyExpiry":  "2026-11-08T18:33:14Z",
+				"DiscoKey":   "discokey:0bb5fb3e7c8f425e1216249916032b6d300be145e7f518148132b57bb311dd74",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:57132",
+					"10.65.0.27:57132",
+					"172.17.0.1:57132",
+					"172.19.0.1:57132",
+					"172.20.0.1:57132"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:33:14.663005747Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6999886582499453,
+				"StableID":   "nSoyJk9Gfw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9cc889d065800d1cefd0e57538710565c901432032569b4f058c17134506fa3b",
+				"KeyExpiry":  "2026-11-08T18:33:15Z",
+				"DiscoKey":   "discokey:4982335d30436caf95bc55d8c35a748544e40eaed360384bd887f6b83e04e95d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49044",
+					"10.65.0.27:49044",
+					"172.17.0.1:49044",
+					"172.19.0.1:49044",
+					"172.20.0.1:49044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:33:15.208583828Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6808557030166489,
+				"StableID":   "nLixwNFcAv11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c8fb5923da5e2e0991e21685f89114292bbd46e101009f97de3959018275c93f",
+				"KeyExpiry":  "2026-11-08T18:33:15Z",
+				"DiscoKey":   "discokey:d1097930c9c9cdd9bfdfd05fdc5c8dc2a16e4abf5a78ee9eca7474006aae6149",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50794",
+					"10.65.0.27:50794",
+					"172.17.0.1:50794",
+					"172.19.0.1:50794",
+					"172.20.0.1:50794"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:33:15.755753394Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4492892243963888": {
+				"ID":          4492892243963888,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6808557030166489,
+				"StableID":   "nLixwNFcAv11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c8fb5923da5e2e0991e21685f89114292bbd46e101009f97de3959018275c93f",
+				"KeyExpiry":  "2026-11-08T18:33:15Z",
+				"DiscoKey":   "discokey:d1097930c9c9cdd9bfdfd05fdc5c8dc2a16e4abf5a78ee9eca7474006aae6149",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50794",
+					"10.65.0.27:50794",
+					"172.17.0.1:50794",
+					"172.19.0.1:50794",
+					"172.20.0.1:50794"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:33:15.755753394Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c8fb5923da5e2e0991e21685f89114292bbd46e101009f97de3959018275c93f",
+			"MachineKey": "mkey:223ef523f80def19ecf729d27d15eee713692adb78a865deb191da30bddb5c0d",
+			"Peers": [{
+				"ID":         1209777249547958,
+				"StableID":   "n3BbrDouSA11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a2081c3c2709901df4690fa1b7595a51519c22ad420f2b9acddcf2fdef9d401c",
+				"DiscoKey":   "discokey:626f5816c03f257d6261f689c353f76bb515826afc2b36c2fa1cf7b515c55009",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58126",
+					"10.65.0.27:58126",
+					"172.17.0.1:58126",
+					"172.19.0.1:58126",
+					"172.20.0.1:58126"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:33:08.294290382Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4023169253352937,
+				"StableID":   "nnuvDPq6RY11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b02b36dd505ace740bb4698542b8ed81ec4095bf6531b7287cdaff894f242b42",
+				"DiscoKey":   "discokey:f15c47c262198507f69bd5014ebadb3f78efc139d16ac362a5d142b8c0c2133a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45115",
+					"10.65.0.27:45115",
+					"172.17.0.1:45115",
+					"172.19.0.1:45115",
+					"172.20.0.1:45115"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:33:08.763175709Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4652214928213325,
+				"StableID":   "nahnSFozKd11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77793ca1f48eb34568c93668af9146722be4b786bbe3398d563266b31ad4c17f",
+				"DiscoKey":   "discokey:11f3a582666ea4f24807becf4d74de0d2cc6dfb8bcb5e405e635d7e7a470c366",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:33:09.299397318Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8731075257292874,
+				"StableID":   "n1CpKRYKBB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a6ffa9cec643a3ee5c74ee56b7aff3e4f113d181292b0503b95264eb29dbf72",
+				"DiscoKey":   "discokey:6e977e9d58f6ae95801087703d09ce5b0b06646c2d44e6597ed6b441e3a8181f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:37260",
+					"10.65.0.27:37260",
+					"172.17.0.1:37260",
+					"172.19.0.1:37260",
+					"172.20.0.1:37260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:33:09.837588413Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5321503171654358,
+				"StableID":   "nqUZe9s7Zi11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6f8025967b9e427b50a5b8533fda537e864eaccce2d33a8a8e693cae1098566d",
+				"DiscoKey":   "discokey:dceded285b2d1bba3b281c50b52371b0fb12a215539817c6c3d320d634f06842",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56832",
+					"10.65.0.27:56832",
+					"172.17.0.1:56832",
+					"172.19.0.1:56832",
+					"172.20.0.1:56832"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:33:10.385856224Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4492892243963888,
+				"StableID":   "njJvQKfq5c11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5e68f80a29fce97eaab751f7dafac4f45c67790d0ec5439d3a42879dd865853e",
+				"DiscoKey":   "discokey:308832a609850e9acd8e9e8f28b0e9820c55931d854eb442a0cd3c814472757c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:34594",
+					"10.65.0.27:34594",
+					"172.17.0.1:34594",
+					"172.19.0.1:34594",
+					"172.20.0.1:34594"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:33:10.925761545Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4322992263202343,
+				"StableID":   "neLeuDgtka11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6bbf76b5ac197773c0b859a9b1c91e44b93595fa95e5a62930adfa8ec5180041",
+				"DiscoKey":   "discokey:4a33e21c16f93042152ced77f5ba089c8e4bde91258a303ed65fa20227ad8b25",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44848",
+					"10.65.0.27:44848",
+					"172.17.0.1:44848",
+					"172.19.0.1:44848",
+					"172.20.0.1:44848"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:33:11.458425053Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3081484268680458,
+				"StableID":   "nKy1nFNc4R11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1cd157428e354b28b71a831d8b65eb680e81004d6ebcc78d9309b50ee2412b2b",
+				"DiscoKey":   "discokey:6641b6c439d0d5cd5bbb7d1375e4bde3c8b4219c3c0e95951c3cf1ea0f790b05",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48756",
+					"10.65.0.27:48756",
+					"172.17.0.1:48756",
+					"172.19.0.1:48756",
+					"172.20.0.1:48756"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:33:11.999531663Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         469765205737312,
+				"StableID":   "nBiYbFwkf411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3d073dbd2e6677630b5a379c2338653747a44c303e1ca213330297865d6a17f",
+				"DiscoKey":   "discokey:c58b38472907cad9b8438598dfd3cabf76d0b4f3bda28294d711f0d2ba773242",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45167",
+					"10.65.0.27:45167",
+					"172.17.0.1:45167",
+					"172.19.0.1:45167",
+					"172.20.0.1:45167"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:33:12.531505155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8666116292854433,
+				"StableID":   "neyY5SBufA21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd7d9da01be466b8da4f4a04ab5ca3462646c23ee86179436f562659298e057a",
+				"DiscoKey":   "discokey:f147cf46411b38f2cf4f9afe7aa9fa5808876e3e3b5c3af2f9014a333f55cb56",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51954",
+					"10.65.0.27:51954",
+					"172.17.0.1:51954",
+					"172.19.0.1:51954",
+					"172.20.0.1:51954"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:33:13.069459914Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4087990560702471,
+				"StableID":   "nYVdBeaTvY11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dcd257a4b27218522012867ad3a96efce3b3fd72eb6ce226ade91bdd34f8502d",
+				"DiscoKey":   "discokey:1a10cab9938af6686b0ce2990dae2250b82a6a5d1185f99a8800f0d3c3e7eb3e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60845",
+					"10.65.0.27:60845",
+					"172.17.0.1:60845",
+					"172.19.0.1:60845",
+					"172.20.0.1:60845"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:33:13.592579815Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8833086820652244,
+				"StableID":   "nBSfrKDXyB21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ba0541859c797ac5f7ec9ed9f1c188500947b3931705e9cb31b3f584ecd8861",
+				"DiscoKey":   "discokey:8839861f36c99c995cbeca958da544806ae29ff76aff636be07001939e4fcc55",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41528",
+					"10.65.0.27:41528",
+					"172.17.0.1:41528",
+					"172.19.0.1:41528",
+					"172.20.0.1:41528"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:33:14.129122113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7035509393532425,
+				"StableID":   "neou8JuPww11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ecee0122e3a9f5a440fa5f224b7f8b73cb2c105204596b439595e9c192115624",
+				"KeyExpiry":  "2026-11-08T18:33:14Z",
+				"DiscoKey":   "discokey:0bb5fb3e7c8f425e1216249916032b6d300be145e7f518148132b57bb311dd74",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:57132",
+					"10.65.0.27:57132",
+					"172.17.0.1:57132",
+					"172.19.0.1:57132",
+					"172.20.0.1:57132"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:33:14.663005747Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6999886582499453,
+				"StableID":   "nSoyJk9Gfw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9cc889d065800d1cefd0e57538710565c901432032569b4f058c17134506fa3b",
+				"KeyExpiry":  "2026-11-08T18:33:15Z",
+				"DiscoKey":   "discokey:4982335d30436caf95bc55d8c35a748544e40eaed360384bd887f6b83e04e95d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49044",
+					"10.65.0.27:49044",
+					"172.17.0.1:49044",
+					"172.19.0.1:49044",
+					"172.20.0.1:49044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:33:15.208583828Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{
+				"principals": [{"nodeIP": "100.64.0.19"}, {"nodeIP": "fd7a:115c:a1e0::13"}],
+				"sshUsers":   {"root": "root"},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				}
+			}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		},
+		"ssh_rules": [{
+			"principals": [{"nodeIP": "100.64.0.19"}, {"nodeIP": "fd7a:115c:a1e0::13"}],
+			"sshUsers":   {"root": "root"},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}
+		}]
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4652214928213325,
+				"StableID":   "nahnSFozKd11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       4652214928213325,
+				"Key":        "nodekey:77793ca1f48eb34568c93668af9146722be4b786bbe3398d563266b31ad4c17f",
+				"DiscoKey":   "discokey:11f3a582666ea4f24807becf4d74de0d2cc6dfb8bcb5e405e635d7e7a470c366",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:33:09.299397318Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:77793ca1f48eb34568c93668af9146722be4b786bbe3398d563266b31ad4c17f",
+			"MachineKey": "mkey:ea7c26a30365a9d759e05a678504a8c20f37ded810927eb22e2f8e1b368d5c77",
+			"Peers": [{
+				"ID":         1209777249547958,
+				"StableID":   "n3BbrDouSA11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a2081c3c2709901df4690fa1b7595a51519c22ad420f2b9acddcf2fdef9d401c",
+				"DiscoKey":   "discokey:626f5816c03f257d6261f689c353f76bb515826afc2b36c2fa1cf7b515c55009",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58126",
+					"10.65.0.27:58126",
+					"172.17.0.1:58126",
+					"172.19.0.1:58126",
+					"172.20.0.1:58126"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:33:08.294290382Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4023169253352937,
+				"StableID":   "nnuvDPq6RY11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b02b36dd505ace740bb4698542b8ed81ec4095bf6531b7287cdaff894f242b42",
+				"DiscoKey":   "discokey:f15c47c262198507f69bd5014ebadb3f78efc139d16ac362a5d142b8c0c2133a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45115",
+					"10.65.0.27:45115",
+					"172.17.0.1:45115",
+					"172.19.0.1:45115",
+					"172.20.0.1:45115"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:33:08.763175709Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8731075257292874,
+				"StableID":   "n1CpKRYKBB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a6ffa9cec643a3ee5c74ee56b7aff3e4f113d181292b0503b95264eb29dbf72",
+				"DiscoKey":   "discokey:6e977e9d58f6ae95801087703d09ce5b0b06646c2d44e6597ed6b441e3a8181f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:37260",
+					"10.65.0.27:37260",
+					"172.17.0.1:37260",
+					"172.19.0.1:37260",
+					"172.20.0.1:37260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:33:09.837588413Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5321503171654358,
+				"StableID":   "nqUZe9s7Zi11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6f8025967b9e427b50a5b8533fda537e864eaccce2d33a8a8e693cae1098566d",
+				"DiscoKey":   "discokey:dceded285b2d1bba3b281c50b52371b0fb12a215539817c6c3d320d634f06842",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56832",
+					"10.65.0.27:56832",
+					"172.17.0.1:56832",
+					"172.19.0.1:56832",
+					"172.20.0.1:56832"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:33:10.385856224Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4492892243963888,
+				"StableID":   "njJvQKfq5c11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5e68f80a29fce97eaab751f7dafac4f45c67790d0ec5439d3a42879dd865853e",
+				"DiscoKey":   "discokey:308832a609850e9acd8e9e8f28b0e9820c55931d854eb442a0cd3c814472757c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:34594",
+					"10.65.0.27:34594",
+					"172.17.0.1:34594",
+					"172.19.0.1:34594",
+					"172.20.0.1:34594"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:33:10.925761545Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4322992263202343,
+				"StableID":   "neLeuDgtka11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6bbf76b5ac197773c0b859a9b1c91e44b93595fa95e5a62930adfa8ec5180041",
+				"DiscoKey":   "discokey:4a33e21c16f93042152ced77f5ba089c8e4bde91258a303ed65fa20227ad8b25",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44848",
+					"10.65.0.27:44848",
+					"172.17.0.1:44848",
+					"172.19.0.1:44848",
+					"172.20.0.1:44848"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:33:11.458425053Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3081484268680458,
+				"StableID":   "nKy1nFNc4R11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1cd157428e354b28b71a831d8b65eb680e81004d6ebcc78d9309b50ee2412b2b",
+				"DiscoKey":   "discokey:6641b6c439d0d5cd5bbb7d1375e4bde3c8b4219c3c0e95951c3cf1ea0f790b05",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48756",
+					"10.65.0.27:48756",
+					"172.17.0.1:48756",
+					"172.19.0.1:48756",
+					"172.20.0.1:48756"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:33:11.999531663Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         469765205737312,
+				"StableID":   "nBiYbFwkf411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3d073dbd2e6677630b5a379c2338653747a44c303e1ca213330297865d6a17f",
+				"DiscoKey":   "discokey:c58b38472907cad9b8438598dfd3cabf76d0b4f3bda28294d711f0d2ba773242",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45167",
+					"10.65.0.27:45167",
+					"172.17.0.1:45167",
+					"172.19.0.1:45167",
+					"172.20.0.1:45167"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:33:12.531505155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8666116292854433,
+				"StableID":   "neyY5SBufA21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd7d9da01be466b8da4f4a04ab5ca3462646c23ee86179436f562659298e057a",
+				"DiscoKey":   "discokey:f147cf46411b38f2cf4f9afe7aa9fa5808876e3e3b5c3af2f9014a333f55cb56",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51954",
+					"10.65.0.27:51954",
+					"172.17.0.1:51954",
+					"172.19.0.1:51954",
+					"172.20.0.1:51954"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:33:13.069459914Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4087990560702471,
+				"StableID":   "nYVdBeaTvY11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dcd257a4b27218522012867ad3a96efce3b3fd72eb6ce226ade91bdd34f8502d",
+				"DiscoKey":   "discokey:1a10cab9938af6686b0ce2990dae2250b82a6a5d1185f99a8800f0d3c3e7eb3e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60845",
+					"10.65.0.27:60845",
+					"172.17.0.1:60845",
+					"172.19.0.1:60845",
+					"172.20.0.1:60845"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:33:13.592579815Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8833086820652244,
+				"StableID":   "nBSfrKDXyB21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ba0541859c797ac5f7ec9ed9f1c188500947b3931705e9cb31b3f584ecd8861",
+				"DiscoKey":   "discokey:8839861f36c99c995cbeca958da544806ae29ff76aff636be07001939e4fcc55",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41528",
+					"10.65.0.27:41528",
+					"172.17.0.1:41528",
+					"172.19.0.1:41528",
+					"172.20.0.1:41528"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:33:14.129122113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7035509393532425,
+				"StableID":   "neou8JuPww11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ecee0122e3a9f5a440fa5f224b7f8b73cb2c105204596b439595e9c192115624",
+				"KeyExpiry":  "2026-11-08T18:33:14Z",
+				"DiscoKey":   "discokey:0bb5fb3e7c8f425e1216249916032b6d300be145e7f518148132b57bb311dd74",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:57132",
+					"10.65.0.27:57132",
+					"172.17.0.1:57132",
+					"172.19.0.1:57132",
+					"172.20.0.1:57132"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:33:14.663005747Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6999886582499453,
+				"StableID":   "nSoyJk9Gfw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9cc889d065800d1cefd0e57538710565c901432032569b4f058c17134506fa3b",
+				"KeyExpiry":  "2026-11-08T18:33:15Z",
+				"DiscoKey":   "discokey:4982335d30436caf95bc55d8c35a748544e40eaed360384bd887f6b83e04e95d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49044",
+					"10.65.0.27:49044",
+					"172.17.0.1:49044",
+					"172.19.0.1:49044",
+					"172.20.0.1:49044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:33:15.208583828Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6808557030166489,
+				"StableID":   "nLixwNFcAv11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c8fb5923da5e2e0991e21685f89114292bbd46e101009f97de3959018275c93f",
+				"KeyExpiry":  "2026-11-08T18:33:15Z",
+				"DiscoKey":   "discokey:d1097930c9c9cdd9bfdfd05fdc5c8dc2a16e4abf5a78ee9eca7474006aae6149",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50794",
+					"10.65.0.27:50794",
+					"172.17.0.1:50794",
+					"172.19.0.1:50794",
+					"172.20.0.1:50794"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:33:15.755753394Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4652214928213325": {
+				"ID":          4652214928213325,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3081484268680458,
+				"StableID":   "nKy1nFNc4R11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       3081484268680458,
+				"Key":        "nodekey:1cd157428e354b28b71a831d8b65eb680e81004d6ebcc78d9309b50ee2412b2b",
+				"DiscoKey":   "discokey:6641b6c439d0d5cd5bbb7d1375e4bde3c8b4219c3c0e95951c3cf1ea0f790b05",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48756",
+					"10.65.0.27:48756",
+					"172.17.0.1:48756",
+					"172.19.0.1:48756",
+					"172.20.0.1:48756"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:33:11.999531663Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1cd157428e354b28b71a831d8b65eb680e81004d6ebcc78d9309b50ee2412b2b",
+			"MachineKey": "mkey:58ed8a2b8245c6fcfe9d207252cf050fc56e96e4ce9cb56cbe79dd2895070309",
+			"Peers": [{
+				"ID":         1209777249547958,
+				"StableID":   "n3BbrDouSA11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a2081c3c2709901df4690fa1b7595a51519c22ad420f2b9acddcf2fdef9d401c",
+				"DiscoKey":   "discokey:626f5816c03f257d6261f689c353f76bb515826afc2b36c2fa1cf7b515c55009",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58126",
+					"10.65.0.27:58126",
+					"172.17.0.1:58126",
+					"172.19.0.1:58126",
+					"172.20.0.1:58126"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:33:08.294290382Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4023169253352937,
+				"StableID":   "nnuvDPq6RY11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b02b36dd505ace740bb4698542b8ed81ec4095bf6531b7287cdaff894f242b42",
+				"DiscoKey":   "discokey:f15c47c262198507f69bd5014ebadb3f78efc139d16ac362a5d142b8c0c2133a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45115",
+					"10.65.0.27:45115",
+					"172.17.0.1:45115",
+					"172.19.0.1:45115",
+					"172.20.0.1:45115"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:33:08.763175709Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4652214928213325,
+				"StableID":   "nahnSFozKd11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77793ca1f48eb34568c93668af9146722be4b786bbe3398d563266b31ad4c17f",
+				"DiscoKey":   "discokey:11f3a582666ea4f24807becf4d74de0d2cc6dfb8bcb5e405e635d7e7a470c366",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:33:09.299397318Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8731075257292874,
+				"StableID":   "n1CpKRYKBB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a6ffa9cec643a3ee5c74ee56b7aff3e4f113d181292b0503b95264eb29dbf72",
+				"DiscoKey":   "discokey:6e977e9d58f6ae95801087703d09ce5b0b06646c2d44e6597ed6b441e3a8181f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:37260",
+					"10.65.0.27:37260",
+					"172.17.0.1:37260",
+					"172.19.0.1:37260",
+					"172.20.0.1:37260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:33:09.837588413Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5321503171654358,
+				"StableID":   "nqUZe9s7Zi11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6f8025967b9e427b50a5b8533fda537e864eaccce2d33a8a8e693cae1098566d",
+				"DiscoKey":   "discokey:dceded285b2d1bba3b281c50b52371b0fb12a215539817c6c3d320d634f06842",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56832",
+					"10.65.0.27:56832",
+					"172.17.0.1:56832",
+					"172.19.0.1:56832",
+					"172.20.0.1:56832"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:33:10.385856224Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4492892243963888,
+				"StableID":   "njJvQKfq5c11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5e68f80a29fce97eaab751f7dafac4f45c67790d0ec5439d3a42879dd865853e",
+				"DiscoKey":   "discokey:308832a609850e9acd8e9e8f28b0e9820c55931d854eb442a0cd3c814472757c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:34594",
+					"10.65.0.27:34594",
+					"172.17.0.1:34594",
+					"172.19.0.1:34594",
+					"172.20.0.1:34594"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:33:10.925761545Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4322992263202343,
+				"StableID":   "neLeuDgtka11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6bbf76b5ac197773c0b859a9b1c91e44b93595fa95e5a62930adfa8ec5180041",
+				"DiscoKey":   "discokey:4a33e21c16f93042152ced77f5ba089c8e4bde91258a303ed65fa20227ad8b25",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44848",
+					"10.65.0.27:44848",
+					"172.17.0.1:44848",
+					"172.19.0.1:44848",
+					"172.20.0.1:44848"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:33:11.458425053Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         469765205737312,
+				"StableID":   "nBiYbFwkf411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3d073dbd2e6677630b5a379c2338653747a44c303e1ca213330297865d6a17f",
+				"DiscoKey":   "discokey:c58b38472907cad9b8438598dfd3cabf76d0b4f3bda28294d711f0d2ba773242",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45167",
+					"10.65.0.27:45167",
+					"172.17.0.1:45167",
+					"172.19.0.1:45167",
+					"172.20.0.1:45167"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:33:12.531505155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8666116292854433,
+				"StableID":   "neyY5SBufA21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd7d9da01be466b8da4f4a04ab5ca3462646c23ee86179436f562659298e057a",
+				"DiscoKey":   "discokey:f147cf46411b38f2cf4f9afe7aa9fa5808876e3e3b5c3af2f9014a333f55cb56",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51954",
+					"10.65.0.27:51954",
+					"172.17.0.1:51954",
+					"172.19.0.1:51954",
+					"172.20.0.1:51954"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:33:13.069459914Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4087990560702471,
+				"StableID":   "nYVdBeaTvY11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dcd257a4b27218522012867ad3a96efce3b3fd72eb6ce226ade91bdd34f8502d",
+				"DiscoKey":   "discokey:1a10cab9938af6686b0ce2990dae2250b82a6a5d1185f99a8800f0d3c3e7eb3e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60845",
+					"10.65.0.27:60845",
+					"172.17.0.1:60845",
+					"172.19.0.1:60845",
+					"172.20.0.1:60845"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:33:13.592579815Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8833086820652244,
+				"StableID":   "nBSfrKDXyB21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ba0541859c797ac5f7ec9ed9f1c188500947b3931705e9cb31b3f584ecd8861",
+				"DiscoKey":   "discokey:8839861f36c99c995cbeca958da544806ae29ff76aff636be07001939e4fcc55",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41528",
+					"10.65.0.27:41528",
+					"172.17.0.1:41528",
+					"172.19.0.1:41528",
+					"172.20.0.1:41528"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:33:14.129122113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7035509393532425,
+				"StableID":   "neou8JuPww11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ecee0122e3a9f5a440fa5f224b7f8b73cb2c105204596b439595e9c192115624",
+				"KeyExpiry":  "2026-11-08T18:33:14Z",
+				"DiscoKey":   "discokey:0bb5fb3e7c8f425e1216249916032b6d300be145e7f518148132b57bb311dd74",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:57132",
+					"10.65.0.27:57132",
+					"172.17.0.1:57132",
+					"172.19.0.1:57132",
+					"172.20.0.1:57132"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:33:14.663005747Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6999886582499453,
+				"StableID":   "nSoyJk9Gfw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9cc889d065800d1cefd0e57538710565c901432032569b4f058c17134506fa3b",
+				"KeyExpiry":  "2026-11-08T18:33:15Z",
+				"DiscoKey":   "discokey:4982335d30436caf95bc55d8c35a748544e40eaed360384bd887f6b83e04e95d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49044",
+					"10.65.0.27:49044",
+					"172.17.0.1:49044",
+					"172.19.0.1:49044",
+					"172.20.0.1:49044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:33:15.208583828Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6808557030166489,
+				"StableID":   "nLixwNFcAv11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c8fb5923da5e2e0991e21685f89114292bbd46e101009f97de3959018275c93f",
+				"KeyExpiry":  "2026-11-08T18:33:15Z",
+				"DiscoKey":   "discokey:d1097930c9c9cdd9bfdfd05fdc5c8dc2a16e4abf5a78ee9eca7474006aae6149",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50794",
+					"10.65.0.27:50794",
+					"172.17.0.1:50794",
+					"172.19.0.1:50794",
+					"172.20.0.1:50794"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:33:15.755753394Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3081484268680458": {
+				"ID":          3081484268680458,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7035509393532425,
+				"StableID":   "neou8JuPww11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ecee0122e3a9f5a440fa5f224b7f8b73cb2c105204596b439595e9c192115624",
+				"KeyExpiry":  "2026-11-08T18:33:14Z",
+				"DiscoKey":   "discokey:0bb5fb3e7c8f425e1216249916032b6d300be145e7f518148132b57bb311dd74",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:57132",
+					"10.65.0.27:57132",
+					"172.17.0.1:57132",
+					"172.19.0.1:57132",
+					"172.20.0.1:57132"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:33:14.663005747Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ecee0122e3a9f5a440fa5f224b7f8b73cb2c105204596b439595e9c192115624",
+			"MachineKey": "mkey:d58d09e1a5ecfa5d588cef567e5b8bcc807f505c37b43259def422e6457c045c",
+			"Peers": [{
+				"ID":         1209777249547958,
+				"StableID":   "n3BbrDouSA11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a2081c3c2709901df4690fa1b7595a51519c22ad420f2b9acddcf2fdef9d401c",
+				"DiscoKey":   "discokey:626f5816c03f257d6261f689c353f76bb515826afc2b36c2fa1cf7b515c55009",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58126",
+					"10.65.0.27:58126",
+					"172.17.0.1:58126",
+					"172.19.0.1:58126",
+					"172.20.0.1:58126"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:33:08.294290382Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4023169253352937,
+				"StableID":   "nnuvDPq6RY11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b02b36dd505ace740bb4698542b8ed81ec4095bf6531b7287cdaff894f242b42",
+				"DiscoKey":   "discokey:f15c47c262198507f69bd5014ebadb3f78efc139d16ac362a5d142b8c0c2133a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45115",
+					"10.65.0.27:45115",
+					"172.17.0.1:45115",
+					"172.19.0.1:45115",
+					"172.20.0.1:45115"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:33:08.763175709Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4652214928213325,
+				"StableID":   "nahnSFozKd11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77793ca1f48eb34568c93668af9146722be4b786bbe3398d563266b31ad4c17f",
+				"DiscoKey":   "discokey:11f3a582666ea4f24807becf4d74de0d2cc6dfb8bcb5e405e635d7e7a470c366",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:33:09.299397318Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8731075257292874,
+				"StableID":   "n1CpKRYKBB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a6ffa9cec643a3ee5c74ee56b7aff3e4f113d181292b0503b95264eb29dbf72",
+				"DiscoKey":   "discokey:6e977e9d58f6ae95801087703d09ce5b0b06646c2d44e6597ed6b441e3a8181f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:37260",
+					"10.65.0.27:37260",
+					"172.17.0.1:37260",
+					"172.19.0.1:37260",
+					"172.20.0.1:37260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:33:09.837588413Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5321503171654358,
+				"StableID":   "nqUZe9s7Zi11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6f8025967b9e427b50a5b8533fda537e864eaccce2d33a8a8e693cae1098566d",
+				"DiscoKey":   "discokey:dceded285b2d1bba3b281c50b52371b0fb12a215539817c6c3d320d634f06842",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56832",
+					"10.65.0.27:56832",
+					"172.17.0.1:56832",
+					"172.19.0.1:56832",
+					"172.20.0.1:56832"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:33:10.385856224Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4492892243963888,
+				"StableID":   "njJvQKfq5c11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5e68f80a29fce97eaab751f7dafac4f45c67790d0ec5439d3a42879dd865853e",
+				"DiscoKey":   "discokey:308832a609850e9acd8e9e8f28b0e9820c55931d854eb442a0cd3c814472757c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:34594",
+					"10.65.0.27:34594",
+					"172.17.0.1:34594",
+					"172.19.0.1:34594",
+					"172.20.0.1:34594"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:33:10.925761545Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4322992263202343,
+				"StableID":   "neLeuDgtka11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6bbf76b5ac197773c0b859a9b1c91e44b93595fa95e5a62930adfa8ec5180041",
+				"DiscoKey":   "discokey:4a33e21c16f93042152ced77f5ba089c8e4bde91258a303ed65fa20227ad8b25",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44848",
+					"10.65.0.27:44848",
+					"172.17.0.1:44848",
+					"172.19.0.1:44848",
+					"172.20.0.1:44848"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:33:11.458425053Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3081484268680458,
+				"StableID":   "nKy1nFNc4R11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1cd157428e354b28b71a831d8b65eb680e81004d6ebcc78d9309b50ee2412b2b",
+				"DiscoKey":   "discokey:6641b6c439d0d5cd5bbb7d1375e4bde3c8b4219c3c0e95951c3cf1ea0f790b05",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48756",
+					"10.65.0.27:48756",
+					"172.17.0.1:48756",
+					"172.19.0.1:48756",
+					"172.20.0.1:48756"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:33:11.999531663Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         469765205737312,
+				"StableID":   "nBiYbFwkf411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3d073dbd2e6677630b5a379c2338653747a44c303e1ca213330297865d6a17f",
+				"DiscoKey":   "discokey:c58b38472907cad9b8438598dfd3cabf76d0b4f3bda28294d711f0d2ba773242",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45167",
+					"10.65.0.27:45167",
+					"172.17.0.1:45167",
+					"172.19.0.1:45167",
+					"172.20.0.1:45167"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:33:12.531505155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8666116292854433,
+				"StableID":   "neyY5SBufA21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd7d9da01be466b8da4f4a04ab5ca3462646c23ee86179436f562659298e057a",
+				"DiscoKey":   "discokey:f147cf46411b38f2cf4f9afe7aa9fa5808876e3e3b5c3af2f9014a333f55cb56",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51954",
+					"10.65.0.27:51954",
+					"172.17.0.1:51954",
+					"172.19.0.1:51954",
+					"172.20.0.1:51954"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:33:13.069459914Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4087990560702471,
+				"StableID":   "nYVdBeaTvY11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dcd257a4b27218522012867ad3a96efce3b3fd72eb6ce226ade91bdd34f8502d",
+				"DiscoKey":   "discokey:1a10cab9938af6686b0ce2990dae2250b82a6a5d1185f99a8800f0d3c3e7eb3e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60845",
+					"10.65.0.27:60845",
+					"172.17.0.1:60845",
+					"172.19.0.1:60845",
+					"172.20.0.1:60845"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:33:13.592579815Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8833086820652244,
+				"StableID":   "nBSfrKDXyB21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ba0541859c797ac5f7ec9ed9f1c188500947b3931705e9cb31b3f584ecd8861",
+				"DiscoKey":   "discokey:8839861f36c99c995cbeca958da544806ae29ff76aff636be07001939e4fcc55",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41528",
+					"10.65.0.27:41528",
+					"172.17.0.1:41528",
+					"172.19.0.1:41528",
+					"172.20.0.1:41528"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:33:14.129122113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6999886582499453,
+				"StableID":   "nSoyJk9Gfw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9cc889d065800d1cefd0e57538710565c901432032569b4f058c17134506fa3b",
+				"KeyExpiry":  "2026-11-08T18:33:15Z",
+				"DiscoKey":   "discokey:4982335d30436caf95bc55d8c35a748544e40eaed360384bd887f6b83e04e95d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49044",
+					"10.65.0.27:49044",
+					"172.17.0.1:49044",
+					"172.19.0.1:49044",
+					"172.20.0.1:49044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:33:15.208583828Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6808557030166489,
+				"StableID":   "nLixwNFcAv11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c8fb5923da5e2e0991e21685f89114292bbd46e101009f97de3959018275c93f",
+				"KeyExpiry":  "2026-11-08T18:33:15Z",
+				"DiscoKey":   "discokey:d1097930c9c9cdd9bfdfd05fdc5c8dc2a16e4abf5a78ee9eca7474006aae6149",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50794",
+					"10.65.0.27:50794",
+					"172.17.0.1:50794",
+					"172.19.0.1:50794",
+					"172.20.0.1:50794"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:33:15.755753394Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{
+				"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+				"sshUsers":   {"root": "root"},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				}
+			}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		},
+		"ssh_rules": [{
+			"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+			"sshUsers":   {"root": "root"},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}
+		}]
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4087990560702471,
+				"StableID":   "nYVdBeaTvY11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       4087990560702471,
+				"Key":        "nodekey:dcd257a4b27218522012867ad3a96efce3b3fd72eb6ce226ade91bdd34f8502d",
+				"DiscoKey":   "discokey:1a10cab9938af6686b0ce2990dae2250b82a6a5d1185f99a8800f0d3c3e7eb3e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60845",
+					"10.65.0.27:60845",
+					"172.17.0.1:60845",
+					"172.19.0.1:60845",
+					"172.20.0.1:60845"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:33:13.592579815Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:dcd257a4b27218522012867ad3a96efce3b3fd72eb6ce226ade91bdd34f8502d",
+			"MachineKey": "mkey:6c829fc826a772d4e11c86e03cb5481a763de7a6d81da95d197e0b2b2c280164",
+			"Peers": [{
+				"ID":         1209777249547958,
+				"StableID":   "n3BbrDouSA11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a2081c3c2709901df4690fa1b7595a51519c22ad420f2b9acddcf2fdef9d401c",
+				"DiscoKey":   "discokey:626f5816c03f257d6261f689c353f76bb515826afc2b36c2fa1cf7b515c55009",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58126",
+					"10.65.0.27:58126",
+					"172.17.0.1:58126",
+					"172.19.0.1:58126",
+					"172.20.0.1:58126"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:33:08.294290382Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4023169253352937,
+				"StableID":   "nnuvDPq6RY11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b02b36dd505ace740bb4698542b8ed81ec4095bf6531b7287cdaff894f242b42",
+				"DiscoKey":   "discokey:f15c47c262198507f69bd5014ebadb3f78efc139d16ac362a5d142b8c0c2133a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45115",
+					"10.65.0.27:45115",
+					"172.17.0.1:45115",
+					"172.19.0.1:45115",
+					"172.20.0.1:45115"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:33:08.763175709Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4652214928213325,
+				"StableID":   "nahnSFozKd11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77793ca1f48eb34568c93668af9146722be4b786bbe3398d563266b31ad4c17f",
+				"DiscoKey":   "discokey:11f3a582666ea4f24807becf4d74de0d2cc6dfb8bcb5e405e635d7e7a470c366",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:33:09.299397318Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8731075257292874,
+				"StableID":   "n1CpKRYKBB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a6ffa9cec643a3ee5c74ee56b7aff3e4f113d181292b0503b95264eb29dbf72",
+				"DiscoKey":   "discokey:6e977e9d58f6ae95801087703d09ce5b0b06646c2d44e6597ed6b441e3a8181f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:37260",
+					"10.65.0.27:37260",
+					"172.17.0.1:37260",
+					"172.19.0.1:37260",
+					"172.20.0.1:37260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:33:09.837588413Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5321503171654358,
+				"StableID":   "nqUZe9s7Zi11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6f8025967b9e427b50a5b8533fda537e864eaccce2d33a8a8e693cae1098566d",
+				"DiscoKey":   "discokey:dceded285b2d1bba3b281c50b52371b0fb12a215539817c6c3d320d634f06842",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56832",
+					"10.65.0.27:56832",
+					"172.17.0.1:56832",
+					"172.19.0.1:56832",
+					"172.20.0.1:56832"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:33:10.385856224Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4492892243963888,
+				"StableID":   "njJvQKfq5c11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5e68f80a29fce97eaab751f7dafac4f45c67790d0ec5439d3a42879dd865853e",
+				"DiscoKey":   "discokey:308832a609850e9acd8e9e8f28b0e9820c55931d854eb442a0cd3c814472757c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:34594",
+					"10.65.0.27:34594",
+					"172.17.0.1:34594",
+					"172.19.0.1:34594",
+					"172.20.0.1:34594"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:33:10.925761545Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4322992263202343,
+				"StableID":   "neLeuDgtka11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6bbf76b5ac197773c0b859a9b1c91e44b93595fa95e5a62930adfa8ec5180041",
+				"DiscoKey":   "discokey:4a33e21c16f93042152ced77f5ba089c8e4bde91258a303ed65fa20227ad8b25",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44848",
+					"10.65.0.27:44848",
+					"172.17.0.1:44848",
+					"172.19.0.1:44848",
+					"172.20.0.1:44848"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:33:11.458425053Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3081484268680458,
+				"StableID":   "nKy1nFNc4R11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1cd157428e354b28b71a831d8b65eb680e81004d6ebcc78d9309b50ee2412b2b",
+				"DiscoKey":   "discokey:6641b6c439d0d5cd5bbb7d1375e4bde3c8b4219c3c0e95951c3cf1ea0f790b05",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48756",
+					"10.65.0.27:48756",
+					"172.17.0.1:48756",
+					"172.19.0.1:48756",
+					"172.20.0.1:48756"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:33:11.999531663Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         469765205737312,
+				"StableID":   "nBiYbFwkf411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3d073dbd2e6677630b5a379c2338653747a44c303e1ca213330297865d6a17f",
+				"DiscoKey":   "discokey:c58b38472907cad9b8438598dfd3cabf76d0b4f3bda28294d711f0d2ba773242",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45167",
+					"10.65.0.27:45167",
+					"172.17.0.1:45167",
+					"172.19.0.1:45167",
+					"172.20.0.1:45167"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:33:12.531505155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8666116292854433,
+				"StableID":   "neyY5SBufA21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd7d9da01be466b8da4f4a04ab5ca3462646c23ee86179436f562659298e057a",
+				"DiscoKey":   "discokey:f147cf46411b38f2cf4f9afe7aa9fa5808876e3e3b5c3af2f9014a333f55cb56",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51954",
+					"10.65.0.27:51954",
+					"172.17.0.1:51954",
+					"172.19.0.1:51954",
+					"172.20.0.1:51954"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:33:13.069459914Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8833086820652244,
+				"StableID":   "nBSfrKDXyB21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ba0541859c797ac5f7ec9ed9f1c188500947b3931705e9cb31b3f584ecd8861",
+				"DiscoKey":   "discokey:8839861f36c99c995cbeca958da544806ae29ff76aff636be07001939e4fcc55",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41528",
+					"10.65.0.27:41528",
+					"172.17.0.1:41528",
+					"172.19.0.1:41528",
+					"172.20.0.1:41528"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:33:14.129122113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7035509393532425,
+				"StableID":   "neou8JuPww11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ecee0122e3a9f5a440fa5f224b7f8b73cb2c105204596b439595e9c192115624",
+				"KeyExpiry":  "2026-11-08T18:33:14Z",
+				"DiscoKey":   "discokey:0bb5fb3e7c8f425e1216249916032b6d300be145e7f518148132b57bb311dd74",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:57132",
+					"10.65.0.27:57132",
+					"172.17.0.1:57132",
+					"172.19.0.1:57132",
+					"172.20.0.1:57132"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:33:14.663005747Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6999886582499453,
+				"StableID":   "nSoyJk9Gfw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9cc889d065800d1cefd0e57538710565c901432032569b4f058c17134506fa3b",
+				"KeyExpiry":  "2026-11-08T18:33:15Z",
+				"DiscoKey":   "discokey:4982335d30436caf95bc55d8c35a748544e40eaed360384bd887f6b83e04e95d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49044",
+					"10.65.0.27:49044",
+					"172.17.0.1:49044",
+					"172.19.0.1:49044",
+					"172.20.0.1:49044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:33:15.208583828Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6808557030166489,
+				"StableID":   "nLixwNFcAv11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c8fb5923da5e2e0991e21685f89114292bbd46e101009f97de3959018275c93f",
+				"KeyExpiry":  "2026-11-08T18:33:15Z",
+				"DiscoKey":   "discokey:d1097930c9c9cdd9bfdfd05fdc5c8dc2a16e4abf5a78ee9eca7474006aae6149",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50794",
+					"10.65.0.27:50794",
+					"172.17.0.1:50794",
+					"172.19.0.1:50794",
+					"172.20.0.1:50794"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:33:15.755753394Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4087990560702471": {
+				"ID":          4087990560702471,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4023169253352937,
+				"StableID":   "nnuvDPq6RY11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       4023169253352937,
+				"Key":        "nodekey:b02b36dd505ace740bb4698542b8ed81ec4095bf6531b7287cdaff894f242b42",
+				"DiscoKey":   "discokey:f15c47c262198507f69bd5014ebadb3f78efc139d16ac362a5d142b8c0c2133a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45115",
+					"10.65.0.27:45115",
+					"172.17.0.1:45115",
+					"172.19.0.1:45115",
+					"172.20.0.1:45115"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:33:08.763175709Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b02b36dd505ace740bb4698542b8ed81ec4095bf6531b7287cdaff894f242b42",
+			"MachineKey": "mkey:98060785ea4ea3c803f7adb2aef05bed58a96c1e3b907a4dda932e522b18984b",
+			"Peers": [{
+				"ID":         1209777249547958,
+				"StableID":   "n3BbrDouSA11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a2081c3c2709901df4690fa1b7595a51519c22ad420f2b9acddcf2fdef9d401c",
+				"DiscoKey":   "discokey:626f5816c03f257d6261f689c353f76bb515826afc2b36c2fa1cf7b515c55009",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58126",
+					"10.65.0.27:58126",
+					"172.17.0.1:58126",
+					"172.19.0.1:58126",
+					"172.20.0.1:58126"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:33:08.294290382Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4652214928213325,
+				"StableID":   "nahnSFozKd11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77793ca1f48eb34568c93668af9146722be4b786bbe3398d563266b31ad4c17f",
+				"DiscoKey":   "discokey:11f3a582666ea4f24807becf4d74de0d2cc6dfb8bcb5e405e635d7e7a470c366",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:33:09.299397318Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8731075257292874,
+				"StableID":   "n1CpKRYKBB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a6ffa9cec643a3ee5c74ee56b7aff3e4f113d181292b0503b95264eb29dbf72",
+				"DiscoKey":   "discokey:6e977e9d58f6ae95801087703d09ce5b0b06646c2d44e6597ed6b441e3a8181f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:37260",
+					"10.65.0.27:37260",
+					"172.17.0.1:37260",
+					"172.19.0.1:37260",
+					"172.20.0.1:37260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:33:09.837588413Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5321503171654358,
+				"StableID":   "nqUZe9s7Zi11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6f8025967b9e427b50a5b8533fda537e864eaccce2d33a8a8e693cae1098566d",
+				"DiscoKey":   "discokey:dceded285b2d1bba3b281c50b52371b0fb12a215539817c6c3d320d634f06842",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56832",
+					"10.65.0.27:56832",
+					"172.17.0.1:56832",
+					"172.19.0.1:56832",
+					"172.20.0.1:56832"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:33:10.385856224Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4492892243963888,
+				"StableID":   "njJvQKfq5c11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5e68f80a29fce97eaab751f7dafac4f45c67790d0ec5439d3a42879dd865853e",
+				"DiscoKey":   "discokey:308832a609850e9acd8e9e8f28b0e9820c55931d854eb442a0cd3c814472757c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:34594",
+					"10.65.0.27:34594",
+					"172.17.0.1:34594",
+					"172.19.0.1:34594",
+					"172.20.0.1:34594"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:33:10.925761545Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4322992263202343,
+				"StableID":   "neLeuDgtka11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6bbf76b5ac197773c0b859a9b1c91e44b93595fa95e5a62930adfa8ec5180041",
+				"DiscoKey":   "discokey:4a33e21c16f93042152ced77f5ba089c8e4bde91258a303ed65fa20227ad8b25",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44848",
+					"10.65.0.27:44848",
+					"172.17.0.1:44848",
+					"172.19.0.1:44848",
+					"172.20.0.1:44848"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:33:11.458425053Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3081484268680458,
+				"StableID":   "nKy1nFNc4R11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1cd157428e354b28b71a831d8b65eb680e81004d6ebcc78d9309b50ee2412b2b",
+				"DiscoKey":   "discokey:6641b6c439d0d5cd5bbb7d1375e4bde3c8b4219c3c0e95951c3cf1ea0f790b05",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48756",
+					"10.65.0.27:48756",
+					"172.17.0.1:48756",
+					"172.19.0.1:48756",
+					"172.20.0.1:48756"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:33:11.999531663Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         469765205737312,
+				"StableID":   "nBiYbFwkf411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3d073dbd2e6677630b5a379c2338653747a44c303e1ca213330297865d6a17f",
+				"DiscoKey":   "discokey:c58b38472907cad9b8438598dfd3cabf76d0b4f3bda28294d711f0d2ba773242",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45167",
+					"10.65.0.27:45167",
+					"172.17.0.1:45167",
+					"172.19.0.1:45167",
+					"172.20.0.1:45167"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:33:12.531505155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8666116292854433,
+				"StableID":   "neyY5SBufA21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd7d9da01be466b8da4f4a04ab5ca3462646c23ee86179436f562659298e057a",
+				"DiscoKey":   "discokey:f147cf46411b38f2cf4f9afe7aa9fa5808876e3e3b5c3af2f9014a333f55cb56",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51954",
+					"10.65.0.27:51954",
+					"172.17.0.1:51954",
+					"172.19.0.1:51954",
+					"172.20.0.1:51954"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:33:13.069459914Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4087990560702471,
+				"StableID":   "nYVdBeaTvY11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dcd257a4b27218522012867ad3a96efce3b3fd72eb6ce226ade91bdd34f8502d",
+				"DiscoKey":   "discokey:1a10cab9938af6686b0ce2990dae2250b82a6a5d1185f99a8800f0d3c3e7eb3e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60845",
+					"10.65.0.27:60845",
+					"172.17.0.1:60845",
+					"172.19.0.1:60845",
+					"172.20.0.1:60845"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:33:13.592579815Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8833086820652244,
+				"StableID":   "nBSfrKDXyB21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ba0541859c797ac5f7ec9ed9f1c188500947b3931705e9cb31b3f584ecd8861",
+				"DiscoKey":   "discokey:8839861f36c99c995cbeca958da544806ae29ff76aff636be07001939e4fcc55",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41528",
+					"10.65.0.27:41528",
+					"172.17.0.1:41528",
+					"172.19.0.1:41528",
+					"172.20.0.1:41528"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:33:14.129122113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7035509393532425,
+				"StableID":   "neou8JuPww11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ecee0122e3a9f5a440fa5f224b7f8b73cb2c105204596b439595e9c192115624",
+				"KeyExpiry":  "2026-11-08T18:33:14Z",
+				"DiscoKey":   "discokey:0bb5fb3e7c8f425e1216249916032b6d300be145e7f518148132b57bb311dd74",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:57132",
+					"10.65.0.27:57132",
+					"172.17.0.1:57132",
+					"172.19.0.1:57132",
+					"172.20.0.1:57132"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:33:14.663005747Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6999886582499453,
+				"StableID":   "nSoyJk9Gfw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9cc889d065800d1cefd0e57538710565c901432032569b4f058c17134506fa3b",
+				"KeyExpiry":  "2026-11-08T18:33:15Z",
+				"DiscoKey":   "discokey:4982335d30436caf95bc55d8c35a748544e40eaed360384bd887f6b83e04e95d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49044",
+					"10.65.0.27:49044",
+					"172.17.0.1:49044",
+					"172.19.0.1:49044",
+					"172.20.0.1:49044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:33:15.208583828Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6808557030166489,
+				"StableID":   "nLixwNFcAv11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c8fb5923da5e2e0991e21685f89114292bbd46e101009f97de3959018275c93f",
+				"KeyExpiry":  "2026-11-08T18:33:15Z",
+				"DiscoKey":   "discokey:d1097930c9c9cdd9bfdfd05fdc5c8dc2a16e4abf5a78ee9eca7474006aae6149",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50794",
+					"10.65.0.27:50794",
+					"172.17.0.1:50794",
+					"172.19.0.1:50794",
+					"172.20.0.1:50794"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:33:15.755753394Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4023169253352937": {
+				"ID":          4023169253352937,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1209777249547958,
+				"StableID":   "n3BbrDouSA11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1209777249547958,
+				"Key":        "nodekey:a2081c3c2709901df4690fa1b7595a51519c22ad420f2b9acddcf2fdef9d401c",
+				"DiscoKey":   "discokey:626f5816c03f257d6261f689c353f76bb515826afc2b36c2fa1cf7b515c55009",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58126",
+					"10.65.0.27:58126",
+					"172.17.0.1:58126",
+					"172.19.0.1:58126",
+					"172.20.0.1:58126"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:33:08.294290382Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a2081c3c2709901df4690fa1b7595a51519c22ad420f2b9acddcf2fdef9d401c",
+			"MachineKey": "mkey:081d7db2ffd8d13d9818fe27a71a59911bacda2f9b1b5b960b500efbda7e9c69",
+			"Peers": [{
+				"ID":         4023169253352937,
+				"StableID":   "nnuvDPq6RY11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b02b36dd505ace740bb4698542b8ed81ec4095bf6531b7287cdaff894f242b42",
+				"DiscoKey":   "discokey:f15c47c262198507f69bd5014ebadb3f78efc139d16ac362a5d142b8c0c2133a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45115",
+					"10.65.0.27:45115",
+					"172.17.0.1:45115",
+					"172.19.0.1:45115",
+					"172.20.0.1:45115"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:33:08.763175709Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4652214928213325,
+				"StableID":   "nahnSFozKd11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77793ca1f48eb34568c93668af9146722be4b786bbe3398d563266b31ad4c17f",
+				"DiscoKey":   "discokey:11f3a582666ea4f24807becf4d74de0d2cc6dfb8bcb5e405e635d7e7a470c366",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:33:09.299397318Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8731075257292874,
+				"StableID":   "n1CpKRYKBB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a6ffa9cec643a3ee5c74ee56b7aff3e4f113d181292b0503b95264eb29dbf72",
+				"DiscoKey":   "discokey:6e977e9d58f6ae95801087703d09ce5b0b06646c2d44e6597ed6b441e3a8181f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:37260",
+					"10.65.0.27:37260",
+					"172.17.0.1:37260",
+					"172.19.0.1:37260",
+					"172.20.0.1:37260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:33:09.837588413Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5321503171654358,
+				"StableID":   "nqUZe9s7Zi11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6f8025967b9e427b50a5b8533fda537e864eaccce2d33a8a8e693cae1098566d",
+				"DiscoKey":   "discokey:dceded285b2d1bba3b281c50b52371b0fb12a215539817c6c3d320d634f06842",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56832",
+					"10.65.0.27:56832",
+					"172.17.0.1:56832",
+					"172.19.0.1:56832",
+					"172.20.0.1:56832"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:33:10.385856224Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4492892243963888,
+				"StableID":   "njJvQKfq5c11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5e68f80a29fce97eaab751f7dafac4f45c67790d0ec5439d3a42879dd865853e",
+				"DiscoKey":   "discokey:308832a609850e9acd8e9e8f28b0e9820c55931d854eb442a0cd3c814472757c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:34594",
+					"10.65.0.27:34594",
+					"172.17.0.1:34594",
+					"172.19.0.1:34594",
+					"172.20.0.1:34594"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:33:10.925761545Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4322992263202343,
+				"StableID":   "neLeuDgtka11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6bbf76b5ac197773c0b859a9b1c91e44b93595fa95e5a62930adfa8ec5180041",
+				"DiscoKey":   "discokey:4a33e21c16f93042152ced77f5ba089c8e4bde91258a303ed65fa20227ad8b25",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44848",
+					"10.65.0.27:44848",
+					"172.17.0.1:44848",
+					"172.19.0.1:44848",
+					"172.20.0.1:44848"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:33:11.458425053Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3081484268680458,
+				"StableID":   "nKy1nFNc4R11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1cd157428e354b28b71a831d8b65eb680e81004d6ebcc78d9309b50ee2412b2b",
+				"DiscoKey":   "discokey:6641b6c439d0d5cd5bbb7d1375e4bde3c8b4219c3c0e95951c3cf1ea0f790b05",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48756",
+					"10.65.0.27:48756",
+					"172.17.0.1:48756",
+					"172.19.0.1:48756",
+					"172.20.0.1:48756"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:33:11.999531663Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         469765205737312,
+				"StableID":   "nBiYbFwkf411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3d073dbd2e6677630b5a379c2338653747a44c303e1ca213330297865d6a17f",
+				"DiscoKey":   "discokey:c58b38472907cad9b8438598dfd3cabf76d0b4f3bda28294d711f0d2ba773242",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45167",
+					"10.65.0.27:45167",
+					"172.17.0.1:45167",
+					"172.19.0.1:45167",
+					"172.20.0.1:45167"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:33:12.531505155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8666116292854433,
+				"StableID":   "neyY5SBufA21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd7d9da01be466b8da4f4a04ab5ca3462646c23ee86179436f562659298e057a",
+				"DiscoKey":   "discokey:f147cf46411b38f2cf4f9afe7aa9fa5808876e3e3b5c3af2f9014a333f55cb56",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51954",
+					"10.65.0.27:51954",
+					"172.17.0.1:51954",
+					"172.19.0.1:51954",
+					"172.20.0.1:51954"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:33:13.069459914Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4087990560702471,
+				"StableID":   "nYVdBeaTvY11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dcd257a4b27218522012867ad3a96efce3b3fd72eb6ce226ade91bdd34f8502d",
+				"DiscoKey":   "discokey:1a10cab9938af6686b0ce2990dae2250b82a6a5d1185f99a8800f0d3c3e7eb3e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60845",
+					"10.65.0.27:60845",
+					"172.17.0.1:60845",
+					"172.19.0.1:60845",
+					"172.20.0.1:60845"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:33:13.592579815Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8833086820652244,
+				"StableID":   "nBSfrKDXyB21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ba0541859c797ac5f7ec9ed9f1c188500947b3931705e9cb31b3f584ecd8861",
+				"DiscoKey":   "discokey:8839861f36c99c995cbeca958da544806ae29ff76aff636be07001939e4fcc55",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41528",
+					"10.65.0.27:41528",
+					"172.17.0.1:41528",
+					"172.19.0.1:41528",
+					"172.20.0.1:41528"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:33:14.129122113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7035509393532425,
+				"StableID":   "neou8JuPww11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ecee0122e3a9f5a440fa5f224b7f8b73cb2c105204596b439595e9c192115624",
+				"KeyExpiry":  "2026-11-08T18:33:14Z",
+				"DiscoKey":   "discokey:0bb5fb3e7c8f425e1216249916032b6d300be145e7f518148132b57bb311dd74",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:57132",
+					"10.65.0.27:57132",
+					"172.17.0.1:57132",
+					"172.19.0.1:57132",
+					"172.20.0.1:57132"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:33:14.663005747Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6999886582499453,
+				"StableID":   "nSoyJk9Gfw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9cc889d065800d1cefd0e57538710565c901432032569b4f058c17134506fa3b",
+				"KeyExpiry":  "2026-11-08T18:33:15Z",
+				"DiscoKey":   "discokey:4982335d30436caf95bc55d8c35a748544e40eaed360384bd887f6b83e04e95d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49044",
+					"10.65.0.27:49044",
+					"172.17.0.1:49044",
+					"172.19.0.1:49044",
+					"172.20.0.1:49044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:33:15.208583828Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6808557030166489,
+				"StableID":   "nLixwNFcAv11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c8fb5923da5e2e0991e21685f89114292bbd46e101009f97de3959018275c93f",
+				"KeyExpiry":  "2026-11-08T18:33:15Z",
+				"DiscoKey":   "discokey:d1097930c9c9cdd9bfdfd05fdc5c8dc2a16e4abf5a78ee9eca7474006aae6149",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50794",
+					"10.65.0.27:50794",
+					"172.17.0.1:50794",
+					"172.19.0.1:50794",
+					"172.20.0.1:50794"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:33:15.755753394Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1209777249547958": {
+				"ID":          1209777249547958,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}, "1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5321503171654358,
+				"StableID":   "nqUZe9s7Zi11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       5321503171654358,
+				"Key":        "nodekey:6f8025967b9e427b50a5b8533fda537e864eaccce2d33a8a8e693cae1098566d",
+				"DiscoKey":   "discokey:dceded285b2d1bba3b281c50b52371b0fb12a215539817c6c3d320d634f06842",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56832",
+					"10.65.0.27:56832",
+					"172.17.0.1:56832",
+					"172.19.0.1:56832",
+					"172.20.0.1:56832"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:33:10.385856224Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6f8025967b9e427b50a5b8533fda537e864eaccce2d33a8a8e693cae1098566d",
+			"MachineKey": "mkey:02fb718fbc94521f49e099247c95f6f44ec3f239bbfbebf62953e2e53b1d0942",
+			"Peers": [{
+				"ID":         1209777249547958,
+				"StableID":   "n3BbrDouSA11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a2081c3c2709901df4690fa1b7595a51519c22ad420f2b9acddcf2fdef9d401c",
+				"DiscoKey":   "discokey:626f5816c03f257d6261f689c353f76bb515826afc2b36c2fa1cf7b515c55009",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58126",
+					"10.65.0.27:58126",
+					"172.17.0.1:58126",
+					"172.19.0.1:58126",
+					"172.20.0.1:58126"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:33:08.294290382Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4023169253352937,
+				"StableID":   "nnuvDPq6RY11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b02b36dd505ace740bb4698542b8ed81ec4095bf6531b7287cdaff894f242b42",
+				"DiscoKey":   "discokey:f15c47c262198507f69bd5014ebadb3f78efc139d16ac362a5d142b8c0c2133a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45115",
+					"10.65.0.27:45115",
+					"172.17.0.1:45115",
+					"172.19.0.1:45115",
+					"172.20.0.1:45115"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:33:08.763175709Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4652214928213325,
+				"StableID":   "nahnSFozKd11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77793ca1f48eb34568c93668af9146722be4b786bbe3398d563266b31ad4c17f",
+				"DiscoKey":   "discokey:11f3a582666ea4f24807becf4d74de0d2cc6dfb8bcb5e405e635d7e7a470c366",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:33:09.299397318Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8731075257292874,
+				"StableID":   "n1CpKRYKBB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a6ffa9cec643a3ee5c74ee56b7aff3e4f113d181292b0503b95264eb29dbf72",
+				"DiscoKey":   "discokey:6e977e9d58f6ae95801087703d09ce5b0b06646c2d44e6597ed6b441e3a8181f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:37260",
+					"10.65.0.27:37260",
+					"172.17.0.1:37260",
+					"172.19.0.1:37260",
+					"172.20.0.1:37260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:33:09.837588413Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4492892243963888,
+				"StableID":   "njJvQKfq5c11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5e68f80a29fce97eaab751f7dafac4f45c67790d0ec5439d3a42879dd865853e",
+				"DiscoKey":   "discokey:308832a609850e9acd8e9e8f28b0e9820c55931d854eb442a0cd3c814472757c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:34594",
+					"10.65.0.27:34594",
+					"172.17.0.1:34594",
+					"172.19.0.1:34594",
+					"172.20.0.1:34594"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:33:10.925761545Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4322992263202343,
+				"StableID":   "neLeuDgtka11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6bbf76b5ac197773c0b859a9b1c91e44b93595fa95e5a62930adfa8ec5180041",
+				"DiscoKey":   "discokey:4a33e21c16f93042152ced77f5ba089c8e4bde91258a303ed65fa20227ad8b25",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44848",
+					"10.65.0.27:44848",
+					"172.17.0.1:44848",
+					"172.19.0.1:44848",
+					"172.20.0.1:44848"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:33:11.458425053Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3081484268680458,
+				"StableID":   "nKy1nFNc4R11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1cd157428e354b28b71a831d8b65eb680e81004d6ebcc78d9309b50ee2412b2b",
+				"DiscoKey":   "discokey:6641b6c439d0d5cd5bbb7d1375e4bde3c8b4219c3c0e95951c3cf1ea0f790b05",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48756",
+					"10.65.0.27:48756",
+					"172.17.0.1:48756",
+					"172.19.0.1:48756",
+					"172.20.0.1:48756"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:33:11.999531663Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         469765205737312,
+				"StableID":   "nBiYbFwkf411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3d073dbd2e6677630b5a379c2338653747a44c303e1ca213330297865d6a17f",
+				"DiscoKey":   "discokey:c58b38472907cad9b8438598dfd3cabf76d0b4f3bda28294d711f0d2ba773242",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45167",
+					"10.65.0.27:45167",
+					"172.17.0.1:45167",
+					"172.19.0.1:45167",
+					"172.20.0.1:45167"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:33:12.531505155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8666116292854433,
+				"StableID":   "neyY5SBufA21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd7d9da01be466b8da4f4a04ab5ca3462646c23ee86179436f562659298e057a",
+				"DiscoKey":   "discokey:f147cf46411b38f2cf4f9afe7aa9fa5808876e3e3b5c3af2f9014a333f55cb56",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51954",
+					"10.65.0.27:51954",
+					"172.17.0.1:51954",
+					"172.19.0.1:51954",
+					"172.20.0.1:51954"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:33:13.069459914Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4087990560702471,
+				"StableID":   "nYVdBeaTvY11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dcd257a4b27218522012867ad3a96efce3b3fd72eb6ce226ade91bdd34f8502d",
+				"DiscoKey":   "discokey:1a10cab9938af6686b0ce2990dae2250b82a6a5d1185f99a8800f0d3c3e7eb3e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60845",
+					"10.65.0.27:60845",
+					"172.17.0.1:60845",
+					"172.19.0.1:60845",
+					"172.20.0.1:60845"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:33:13.592579815Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8833086820652244,
+				"StableID":   "nBSfrKDXyB21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ba0541859c797ac5f7ec9ed9f1c188500947b3931705e9cb31b3f584ecd8861",
+				"DiscoKey":   "discokey:8839861f36c99c995cbeca958da544806ae29ff76aff636be07001939e4fcc55",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41528",
+					"10.65.0.27:41528",
+					"172.17.0.1:41528",
+					"172.19.0.1:41528",
+					"172.20.0.1:41528"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:33:14.129122113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7035509393532425,
+				"StableID":   "neou8JuPww11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ecee0122e3a9f5a440fa5f224b7f8b73cb2c105204596b439595e9c192115624",
+				"KeyExpiry":  "2026-11-08T18:33:14Z",
+				"DiscoKey":   "discokey:0bb5fb3e7c8f425e1216249916032b6d300be145e7f518148132b57bb311dd74",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:57132",
+					"10.65.0.27:57132",
+					"172.17.0.1:57132",
+					"172.19.0.1:57132",
+					"172.20.0.1:57132"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:33:14.663005747Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6999886582499453,
+				"StableID":   "nSoyJk9Gfw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9cc889d065800d1cefd0e57538710565c901432032569b4f058c17134506fa3b",
+				"KeyExpiry":  "2026-11-08T18:33:15Z",
+				"DiscoKey":   "discokey:4982335d30436caf95bc55d8c35a748544e40eaed360384bd887f6b83e04e95d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49044",
+					"10.65.0.27:49044",
+					"172.17.0.1:49044",
+					"172.19.0.1:49044",
+					"172.20.0.1:49044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:33:15.208583828Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6808557030166489,
+				"StableID":   "nLixwNFcAv11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c8fb5923da5e2e0991e21685f89114292bbd46e101009f97de3959018275c93f",
+				"KeyExpiry":  "2026-11-08T18:33:15Z",
+				"DiscoKey":   "discokey:d1097930c9c9cdd9bfdfd05fdc5c8dc2a16e4abf5a78ee9eca7474006aae6149",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50794",
+					"10.65.0.27:50794",
+					"172.17.0.1:50794",
+					"172.19.0.1:50794",
+					"172.20.0.1:50794"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:33:15.755753394Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5321503171654358": {
+				"ID":          5321503171654358,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8731075257292874,
+				"StableID":   "n1CpKRYKBB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       8731075257292874,
+				"Key":        "nodekey:3a6ffa9cec643a3ee5c74ee56b7aff3e4f113d181292b0503b95264eb29dbf72",
+				"DiscoKey":   "discokey:6e977e9d58f6ae95801087703d09ce5b0b06646c2d44e6597ed6b441e3a8181f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:37260",
+					"10.65.0.27:37260",
+					"172.17.0.1:37260",
+					"172.19.0.1:37260",
+					"172.20.0.1:37260"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:33:09.837588413Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3a6ffa9cec643a3ee5c74ee56b7aff3e4f113d181292b0503b95264eb29dbf72",
+			"MachineKey": "mkey:dee6a480c0694fca7dcc54f59da89d25bff2182fb921c1d36275f6e542723951",
+			"Peers": [{
+				"ID":         1209777249547958,
+				"StableID":   "n3BbrDouSA11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a2081c3c2709901df4690fa1b7595a51519c22ad420f2b9acddcf2fdef9d401c",
+				"DiscoKey":   "discokey:626f5816c03f257d6261f689c353f76bb515826afc2b36c2fa1cf7b515c55009",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58126",
+					"10.65.0.27:58126",
+					"172.17.0.1:58126",
+					"172.19.0.1:58126",
+					"172.20.0.1:58126"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:33:08.294290382Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4023169253352937,
+				"StableID":   "nnuvDPq6RY11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b02b36dd505ace740bb4698542b8ed81ec4095bf6531b7287cdaff894f242b42",
+				"DiscoKey":   "discokey:f15c47c262198507f69bd5014ebadb3f78efc139d16ac362a5d142b8c0c2133a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45115",
+					"10.65.0.27:45115",
+					"172.17.0.1:45115",
+					"172.19.0.1:45115",
+					"172.20.0.1:45115"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:33:08.763175709Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4652214928213325,
+				"StableID":   "nahnSFozKd11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77793ca1f48eb34568c93668af9146722be4b786bbe3398d563266b31ad4c17f",
+				"DiscoKey":   "discokey:11f3a582666ea4f24807becf4d74de0d2cc6dfb8bcb5e405e635d7e7a470c366",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:33:09.299397318Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5321503171654358,
+				"StableID":   "nqUZe9s7Zi11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6f8025967b9e427b50a5b8533fda537e864eaccce2d33a8a8e693cae1098566d",
+				"DiscoKey":   "discokey:dceded285b2d1bba3b281c50b52371b0fb12a215539817c6c3d320d634f06842",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56832",
+					"10.65.0.27:56832",
+					"172.17.0.1:56832",
+					"172.19.0.1:56832",
+					"172.20.0.1:56832"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:33:10.385856224Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4492892243963888,
+				"StableID":   "njJvQKfq5c11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5e68f80a29fce97eaab751f7dafac4f45c67790d0ec5439d3a42879dd865853e",
+				"DiscoKey":   "discokey:308832a609850e9acd8e9e8f28b0e9820c55931d854eb442a0cd3c814472757c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:34594",
+					"10.65.0.27:34594",
+					"172.17.0.1:34594",
+					"172.19.0.1:34594",
+					"172.20.0.1:34594"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:33:10.925761545Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4322992263202343,
+				"StableID":   "neLeuDgtka11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6bbf76b5ac197773c0b859a9b1c91e44b93595fa95e5a62930adfa8ec5180041",
+				"DiscoKey":   "discokey:4a33e21c16f93042152ced77f5ba089c8e4bde91258a303ed65fa20227ad8b25",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44848",
+					"10.65.0.27:44848",
+					"172.17.0.1:44848",
+					"172.19.0.1:44848",
+					"172.20.0.1:44848"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:33:11.458425053Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3081484268680458,
+				"StableID":   "nKy1nFNc4R11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1cd157428e354b28b71a831d8b65eb680e81004d6ebcc78d9309b50ee2412b2b",
+				"DiscoKey":   "discokey:6641b6c439d0d5cd5bbb7d1375e4bde3c8b4219c3c0e95951c3cf1ea0f790b05",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48756",
+					"10.65.0.27:48756",
+					"172.17.0.1:48756",
+					"172.19.0.1:48756",
+					"172.20.0.1:48756"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:33:11.999531663Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         469765205737312,
+				"StableID":   "nBiYbFwkf411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3d073dbd2e6677630b5a379c2338653747a44c303e1ca213330297865d6a17f",
+				"DiscoKey":   "discokey:c58b38472907cad9b8438598dfd3cabf76d0b4f3bda28294d711f0d2ba773242",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45167",
+					"10.65.0.27:45167",
+					"172.17.0.1:45167",
+					"172.19.0.1:45167",
+					"172.20.0.1:45167"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:33:12.531505155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8666116292854433,
+				"StableID":   "neyY5SBufA21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd7d9da01be466b8da4f4a04ab5ca3462646c23ee86179436f562659298e057a",
+				"DiscoKey":   "discokey:f147cf46411b38f2cf4f9afe7aa9fa5808876e3e3b5c3af2f9014a333f55cb56",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51954",
+					"10.65.0.27:51954",
+					"172.17.0.1:51954",
+					"172.19.0.1:51954",
+					"172.20.0.1:51954"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:33:13.069459914Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4087990560702471,
+				"StableID":   "nYVdBeaTvY11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dcd257a4b27218522012867ad3a96efce3b3fd72eb6ce226ade91bdd34f8502d",
+				"DiscoKey":   "discokey:1a10cab9938af6686b0ce2990dae2250b82a6a5d1185f99a8800f0d3c3e7eb3e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60845",
+					"10.65.0.27:60845",
+					"172.17.0.1:60845",
+					"172.19.0.1:60845",
+					"172.20.0.1:60845"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:33:13.592579815Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8833086820652244,
+				"StableID":   "nBSfrKDXyB21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ba0541859c797ac5f7ec9ed9f1c188500947b3931705e9cb31b3f584ecd8861",
+				"DiscoKey":   "discokey:8839861f36c99c995cbeca958da544806ae29ff76aff636be07001939e4fcc55",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41528",
+					"10.65.0.27:41528",
+					"172.17.0.1:41528",
+					"172.19.0.1:41528",
+					"172.20.0.1:41528"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:33:14.129122113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7035509393532425,
+				"StableID":   "neou8JuPww11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ecee0122e3a9f5a440fa5f224b7f8b73cb2c105204596b439595e9c192115624",
+				"KeyExpiry":  "2026-11-08T18:33:14Z",
+				"DiscoKey":   "discokey:0bb5fb3e7c8f425e1216249916032b6d300be145e7f518148132b57bb311dd74",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:57132",
+					"10.65.0.27:57132",
+					"172.17.0.1:57132",
+					"172.19.0.1:57132",
+					"172.20.0.1:57132"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:33:14.663005747Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6999886582499453,
+				"StableID":   "nSoyJk9Gfw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9cc889d065800d1cefd0e57538710565c901432032569b4f058c17134506fa3b",
+				"KeyExpiry":  "2026-11-08T18:33:15Z",
+				"DiscoKey":   "discokey:4982335d30436caf95bc55d8c35a748544e40eaed360384bd887f6b83e04e95d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49044",
+					"10.65.0.27:49044",
+					"172.17.0.1:49044",
+					"172.19.0.1:49044",
+					"172.20.0.1:49044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:33:15.208583828Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6808557030166489,
+				"StableID":   "nLixwNFcAv11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c8fb5923da5e2e0991e21685f89114292bbd46e101009f97de3959018275c93f",
+				"KeyExpiry":  "2026-11-08T18:33:15Z",
+				"DiscoKey":   "discokey:d1097930c9c9cdd9bfdfd05fdc5c8dc2a16e4abf5a78ee9eca7474006aae6149",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50794",
+					"10.65.0.27:50794",
+					"172.17.0.1:50794",
+					"172.19.0.1:50794",
+					"172.20.0.1:50794"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:33:15.755753394Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8731075257292874": {
+				"ID":          8731075257292874,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4322992263202343,
+				"StableID":   "neLeuDgtka11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       4322992263202343,
+				"Key":        "nodekey:6bbf76b5ac197773c0b859a9b1c91e44b93595fa95e5a62930adfa8ec5180041",
+				"DiscoKey":   "discokey:4a33e21c16f93042152ced77f5ba089c8e4bde91258a303ed65fa20227ad8b25",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44848",
+					"10.65.0.27:44848",
+					"172.17.0.1:44848",
+					"172.19.0.1:44848",
+					"172.20.0.1:44848"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:33:11.458425053Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6bbf76b5ac197773c0b859a9b1c91e44b93595fa95e5a62930adfa8ec5180041",
+			"MachineKey": "mkey:cd924d435fa93b10244a16b0c2c4f5916769dd4a60d13b3ecee9a4e14ad0c83a",
+			"Peers": [{
+				"ID":         1209777249547958,
+				"StableID":   "n3BbrDouSA11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a2081c3c2709901df4690fa1b7595a51519c22ad420f2b9acddcf2fdef9d401c",
+				"DiscoKey":   "discokey:626f5816c03f257d6261f689c353f76bb515826afc2b36c2fa1cf7b515c55009",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58126",
+					"10.65.0.27:58126",
+					"172.17.0.1:58126",
+					"172.19.0.1:58126",
+					"172.20.0.1:58126"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:33:08.294290382Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4023169253352937,
+				"StableID":   "nnuvDPq6RY11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b02b36dd505ace740bb4698542b8ed81ec4095bf6531b7287cdaff894f242b42",
+				"DiscoKey":   "discokey:f15c47c262198507f69bd5014ebadb3f78efc139d16ac362a5d142b8c0c2133a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45115",
+					"10.65.0.27:45115",
+					"172.17.0.1:45115",
+					"172.19.0.1:45115",
+					"172.20.0.1:45115"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:33:08.763175709Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4652214928213325,
+				"StableID":   "nahnSFozKd11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77793ca1f48eb34568c93668af9146722be4b786bbe3398d563266b31ad4c17f",
+				"DiscoKey":   "discokey:11f3a582666ea4f24807becf4d74de0d2cc6dfb8bcb5e405e635d7e7a470c366",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:33:09.299397318Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8731075257292874,
+				"StableID":   "n1CpKRYKBB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a6ffa9cec643a3ee5c74ee56b7aff3e4f113d181292b0503b95264eb29dbf72",
+				"DiscoKey":   "discokey:6e977e9d58f6ae95801087703d09ce5b0b06646c2d44e6597ed6b441e3a8181f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:37260",
+					"10.65.0.27:37260",
+					"172.17.0.1:37260",
+					"172.19.0.1:37260",
+					"172.20.0.1:37260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:33:09.837588413Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5321503171654358,
+				"StableID":   "nqUZe9s7Zi11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6f8025967b9e427b50a5b8533fda537e864eaccce2d33a8a8e693cae1098566d",
+				"DiscoKey":   "discokey:dceded285b2d1bba3b281c50b52371b0fb12a215539817c6c3d320d634f06842",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56832",
+					"10.65.0.27:56832",
+					"172.17.0.1:56832",
+					"172.19.0.1:56832",
+					"172.20.0.1:56832"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:33:10.385856224Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4492892243963888,
+				"StableID":   "njJvQKfq5c11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5e68f80a29fce97eaab751f7dafac4f45c67790d0ec5439d3a42879dd865853e",
+				"DiscoKey":   "discokey:308832a609850e9acd8e9e8f28b0e9820c55931d854eb442a0cd3c814472757c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:34594",
+					"10.65.0.27:34594",
+					"172.17.0.1:34594",
+					"172.19.0.1:34594",
+					"172.20.0.1:34594"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:33:10.925761545Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3081484268680458,
+				"StableID":   "nKy1nFNc4R11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1cd157428e354b28b71a831d8b65eb680e81004d6ebcc78d9309b50ee2412b2b",
+				"DiscoKey":   "discokey:6641b6c439d0d5cd5bbb7d1375e4bde3c8b4219c3c0e95951c3cf1ea0f790b05",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48756",
+					"10.65.0.27:48756",
+					"172.17.0.1:48756",
+					"172.19.0.1:48756",
+					"172.20.0.1:48756"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:33:11.999531663Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         469765205737312,
+				"StableID":   "nBiYbFwkf411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3d073dbd2e6677630b5a379c2338653747a44c303e1ca213330297865d6a17f",
+				"DiscoKey":   "discokey:c58b38472907cad9b8438598dfd3cabf76d0b4f3bda28294d711f0d2ba773242",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45167",
+					"10.65.0.27:45167",
+					"172.17.0.1:45167",
+					"172.19.0.1:45167",
+					"172.20.0.1:45167"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:33:12.531505155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8666116292854433,
+				"StableID":   "neyY5SBufA21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd7d9da01be466b8da4f4a04ab5ca3462646c23ee86179436f562659298e057a",
+				"DiscoKey":   "discokey:f147cf46411b38f2cf4f9afe7aa9fa5808876e3e3b5c3af2f9014a333f55cb56",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51954",
+					"10.65.0.27:51954",
+					"172.17.0.1:51954",
+					"172.19.0.1:51954",
+					"172.20.0.1:51954"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:33:13.069459914Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4087990560702471,
+				"StableID":   "nYVdBeaTvY11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dcd257a4b27218522012867ad3a96efce3b3fd72eb6ce226ade91bdd34f8502d",
+				"DiscoKey":   "discokey:1a10cab9938af6686b0ce2990dae2250b82a6a5d1185f99a8800f0d3c3e7eb3e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60845",
+					"10.65.0.27:60845",
+					"172.17.0.1:60845",
+					"172.19.0.1:60845",
+					"172.20.0.1:60845"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:33:13.592579815Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8833086820652244,
+				"StableID":   "nBSfrKDXyB21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ba0541859c797ac5f7ec9ed9f1c188500947b3931705e9cb31b3f584ecd8861",
+				"DiscoKey":   "discokey:8839861f36c99c995cbeca958da544806ae29ff76aff636be07001939e4fcc55",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41528",
+					"10.65.0.27:41528",
+					"172.17.0.1:41528",
+					"172.19.0.1:41528",
+					"172.20.0.1:41528"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:33:14.129122113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7035509393532425,
+				"StableID":   "neou8JuPww11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ecee0122e3a9f5a440fa5f224b7f8b73cb2c105204596b439595e9c192115624",
+				"KeyExpiry":  "2026-11-08T18:33:14Z",
+				"DiscoKey":   "discokey:0bb5fb3e7c8f425e1216249916032b6d300be145e7f518148132b57bb311dd74",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:57132",
+					"10.65.0.27:57132",
+					"172.17.0.1:57132",
+					"172.19.0.1:57132",
+					"172.20.0.1:57132"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:33:14.663005747Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6999886582499453,
+				"StableID":   "nSoyJk9Gfw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9cc889d065800d1cefd0e57538710565c901432032569b4f058c17134506fa3b",
+				"KeyExpiry":  "2026-11-08T18:33:15Z",
+				"DiscoKey":   "discokey:4982335d30436caf95bc55d8c35a748544e40eaed360384bd887f6b83e04e95d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49044",
+					"10.65.0.27:49044",
+					"172.17.0.1:49044",
+					"172.19.0.1:49044",
+					"172.20.0.1:49044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:33:15.208583828Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6808557030166489,
+				"StableID":   "nLixwNFcAv11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c8fb5923da5e2e0991e21685f89114292bbd46e101009f97de3959018275c93f",
+				"KeyExpiry":  "2026-11-08T18:33:15Z",
+				"DiscoKey":   "discokey:d1097930c9c9cdd9bfdfd05fdc5c8dc2a16e4abf5a78ee9eca7474006aae6149",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50794",
+					"10.65.0.27:50794",
+					"172.17.0.1:50794",
+					"172.19.0.1:50794",
+					"172.20.0.1:50794"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:33:15.755753394Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4322992263202343": {
+				"ID":          4322992263202343,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         469765205737312,
+				"StableID":   "nBiYbFwkf411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       469765205737312,
+				"Key":        "nodekey:e3d073dbd2e6677630b5a379c2338653747a44c303e1ca213330297865d6a17f",
+				"DiscoKey":   "discokey:c58b38472907cad9b8438598dfd3cabf76d0b4f3bda28294d711f0d2ba773242",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45167",
+					"10.65.0.27:45167",
+					"172.17.0.1:45167",
+					"172.19.0.1:45167",
+					"172.20.0.1:45167"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:33:12.531505155Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e3d073dbd2e6677630b5a379c2338653747a44c303e1ca213330297865d6a17f",
+			"MachineKey": "mkey:0ac0fe418d5ce743d9ba29944e2f383aaedcb71f12d65ba8154c9818520a2f27",
+			"Peers": [{
+				"ID":         1209777249547958,
+				"StableID":   "n3BbrDouSA11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a2081c3c2709901df4690fa1b7595a51519c22ad420f2b9acddcf2fdef9d401c",
+				"DiscoKey":   "discokey:626f5816c03f257d6261f689c353f76bb515826afc2b36c2fa1cf7b515c55009",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58126",
+					"10.65.0.27:58126",
+					"172.17.0.1:58126",
+					"172.19.0.1:58126",
+					"172.20.0.1:58126"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:33:08.294290382Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4023169253352937,
+				"StableID":   "nnuvDPq6RY11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b02b36dd505ace740bb4698542b8ed81ec4095bf6531b7287cdaff894f242b42",
+				"DiscoKey":   "discokey:f15c47c262198507f69bd5014ebadb3f78efc139d16ac362a5d142b8c0c2133a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45115",
+					"10.65.0.27:45115",
+					"172.17.0.1:45115",
+					"172.19.0.1:45115",
+					"172.20.0.1:45115"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:33:08.763175709Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4652214928213325,
+				"StableID":   "nahnSFozKd11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77793ca1f48eb34568c93668af9146722be4b786bbe3398d563266b31ad4c17f",
+				"DiscoKey":   "discokey:11f3a582666ea4f24807becf4d74de0d2cc6dfb8bcb5e405e635d7e7a470c366",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:33:09.299397318Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8731075257292874,
+				"StableID":   "n1CpKRYKBB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a6ffa9cec643a3ee5c74ee56b7aff3e4f113d181292b0503b95264eb29dbf72",
+				"DiscoKey":   "discokey:6e977e9d58f6ae95801087703d09ce5b0b06646c2d44e6597ed6b441e3a8181f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:37260",
+					"10.65.0.27:37260",
+					"172.17.0.1:37260",
+					"172.19.0.1:37260",
+					"172.20.0.1:37260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:33:09.837588413Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5321503171654358,
+				"StableID":   "nqUZe9s7Zi11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6f8025967b9e427b50a5b8533fda537e864eaccce2d33a8a8e693cae1098566d",
+				"DiscoKey":   "discokey:dceded285b2d1bba3b281c50b52371b0fb12a215539817c6c3d320d634f06842",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56832",
+					"10.65.0.27:56832",
+					"172.17.0.1:56832",
+					"172.19.0.1:56832",
+					"172.20.0.1:56832"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:33:10.385856224Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4492892243963888,
+				"StableID":   "njJvQKfq5c11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5e68f80a29fce97eaab751f7dafac4f45c67790d0ec5439d3a42879dd865853e",
+				"DiscoKey":   "discokey:308832a609850e9acd8e9e8f28b0e9820c55931d854eb442a0cd3c814472757c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:34594",
+					"10.65.0.27:34594",
+					"172.17.0.1:34594",
+					"172.19.0.1:34594",
+					"172.20.0.1:34594"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:33:10.925761545Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4322992263202343,
+				"StableID":   "neLeuDgtka11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6bbf76b5ac197773c0b859a9b1c91e44b93595fa95e5a62930adfa8ec5180041",
+				"DiscoKey":   "discokey:4a33e21c16f93042152ced77f5ba089c8e4bde91258a303ed65fa20227ad8b25",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44848",
+					"10.65.0.27:44848",
+					"172.17.0.1:44848",
+					"172.19.0.1:44848",
+					"172.20.0.1:44848"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:33:11.458425053Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3081484268680458,
+				"StableID":   "nKy1nFNc4R11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1cd157428e354b28b71a831d8b65eb680e81004d6ebcc78d9309b50ee2412b2b",
+				"DiscoKey":   "discokey:6641b6c439d0d5cd5bbb7d1375e4bde3c8b4219c3c0e95951c3cf1ea0f790b05",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48756",
+					"10.65.0.27:48756",
+					"172.17.0.1:48756",
+					"172.19.0.1:48756",
+					"172.20.0.1:48756"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:33:11.999531663Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8666116292854433,
+				"StableID":   "neyY5SBufA21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd7d9da01be466b8da4f4a04ab5ca3462646c23ee86179436f562659298e057a",
+				"DiscoKey":   "discokey:f147cf46411b38f2cf4f9afe7aa9fa5808876e3e3b5c3af2f9014a333f55cb56",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51954",
+					"10.65.0.27:51954",
+					"172.17.0.1:51954",
+					"172.19.0.1:51954",
+					"172.20.0.1:51954"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:33:13.069459914Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4087990560702471,
+				"StableID":   "nYVdBeaTvY11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dcd257a4b27218522012867ad3a96efce3b3fd72eb6ce226ade91bdd34f8502d",
+				"DiscoKey":   "discokey:1a10cab9938af6686b0ce2990dae2250b82a6a5d1185f99a8800f0d3c3e7eb3e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60845",
+					"10.65.0.27:60845",
+					"172.17.0.1:60845",
+					"172.19.0.1:60845",
+					"172.20.0.1:60845"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:33:13.592579815Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8833086820652244,
+				"StableID":   "nBSfrKDXyB21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ba0541859c797ac5f7ec9ed9f1c188500947b3931705e9cb31b3f584ecd8861",
+				"DiscoKey":   "discokey:8839861f36c99c995cbeca958da544806ae29ff76aff636be07001939e4fcc55",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41528",
+					"10.65.0.27:41528",
+					"172.17.0.1:41528",
+					"172.19.0.1:41528",
+					"172.20.0.1:41528"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:33:14.129122113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7035509393532425,
+				"StableID":   "neou8JuPww11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ecee0122e3a9f5a440fa5f224b7f8b73cb2c105204596b439595e9c192115624",
+				"KeyExpiry":  "2026-11-08T18:33:14Z",
+				"DiscoKey":   "discokey:0bb5fb3e7c8f425e1216249916032b6d300be145e7f518148132b57bb311dd74",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:57132",
+					"10.65.0.27:57132",
+					"172.17.0.1:57132",
+					"172.19.0.1:57132",
+					"172.20.0.1:57132"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:33:14.663005747Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6999886582499453,
+				"StableID":   "nSoyJk9Gfw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9cc889d065800d1cefd0e57538710565c901432032569b4f058c17134506fa3b",
+				"KeyExpiry":  "2026-11-08T18:33:15Z",
+				"DiscoKey":   "discokey:4982335d30436caf95bc55d8c35a748544e40eaed360384bd887f6b83e04e95d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49044",
+					"10.65.0.27:49044",
+					"172.17.0.1:49044",
+					"172.19.0.1:49044",
+					"172.20.0.1:49044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:33:15.208583828Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6808557030166489,
+				"StableID":   "nLixwNFcAv11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c8fb5923da5e2e0991e21685f89114292bbd46e101009f97de3959018275c93f",
+				"KeyExpiry":  "2026-11-08T18:33:15Z",
+				"DiscoKey":   "discokey:d1097930c9c9cdd9bfdfd05fdc5c8dc2a16e4abf5a78ee9eca7474006aae6149",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50794",
+					"10.65.0.27:50794",
+					"172.17.0.1:50794",
+					"172.19.0.1:50794",
+					"172.20.0.1:50794"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:33:15.755753394Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "469765205737312": {
+				"ID":          469765205737312,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6999886582499453,
+				"StableID":   "nSoyJk9Gfw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9cc889d065800d1cefd0e57538710565c901432032569b4f058c17134506fa3b",
+				"KeyExpiry":  "2026-11-08T18:33:15Z",
+				"DiscoKey":   "discokey:4982335d30436caf95bc55d8c35a748544e40eaed360384bd887f6b83e04e95d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49044",
+					"10.65.0.27:49044",
+					"172.17.0.1:49044",
+					"172.19.0.1:49044",
+					"172.20.0.1:49044"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:33:15.208583828Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9cc889d065800d1cefd0e57538710565c901432032569b4f058c17134506fa3b",
+			"MachineKey": "mkey:a5eb8587e0ad9dad2756407e42c016b083d37a4c86fef44f457b4bd3335f796d",
+			"Peers": [{
+				"ID":         1209777249547958,
+				"StableID":   "n3BbrDouSA11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a2081c3c2709901df4690fa1b7595a51519c22ad420f2b9acddcf2fdef9d401c",
+				"DiscoKey":   "discokey:626f5816c03f257d6261f689c353f76bb515826afc2b36c2fa1cf7b515c55009",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58126",
+					"10.65.0.27:58126",
+					"172.17.0.1:58126",
+					"172.19.0.1:58126",
+					"172.20.0.1:58126"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:33:08.294290382Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4023169253352937,
+				"StableID":   "nnuvDPq6RY11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b02b36dd505ace740bb4698542b8ed81ec4095bf6531b7287cdaff894f242b42",
+				"DiscoKey":   "discokey:f15c47c262198507f69bd5014ebadb3f78efc139d16ac362a5d142b8c0c2133a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45115",
+					"10.65.0.27:45115",
+					"172.17.0.1:45115",
+					"172.19.0.1:45115",
+					"172.20.0.1:45115"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:33:08.763175709Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4652214928213325,
+				"StableID":   "nahnSFozKd11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77793ca1f48eb34568c93668af9146722be4b786bbe3398d563266b31ad4c17f",
+				"DiscoKey":   "discokey:11f3a582666ea4f24807becf4d74de0d2cc6dfb8bcb5e405e635d7e7a470c366",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:33:09.299397318Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8731075257292874,
+				"StableID":   "n1CpKRYKBB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a6ffa9cec643a3ee5c74ee56b7aff3e4f113d181292b0503b95264eb29dbf72",
+				"DiscoKey":   "discokey:6e977e9d58f6ae95801087703d09ce5b0b06646c2d44e6597ed6b441e3a8181f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:37260",
+					"10.65.0.27:37260",
+					"172.17.0.1:37260",
+					"172.19.0.1:37260",
+					"172.20.0.1:37260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:33:09.837588413Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5321503171654358,
+				"StableID":   "nqUZe9s7Zi11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6f8025967b9e427b50a5b8533fda537e864eaccce2d33a8a8e693cae1098566d",
+				"DiscoKey":   "discokey:dceded285b2d1bba3b281c50b52371b0fb12a215539817c6c3d320d634f06842",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56832",
+					"10.65.0.27:56832",
+					"172.17.0.1:56832",
+					"172.19.0.1:56832",
+					"172.20.0.1:56832"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:33:10.385856224Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4492892243963888,
+				"StableID":   "njJvQKfq5c11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5e68f80a29fce97eaab751f7dafac4f45c67790d0ec5439d3a42879dd865853e",
+				"DiscoKey":   "discokey:308832a609850e9acd8e9e8f28b0e9820c55931d854eb442a0cd3c814472757c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:34594",
+					"10.65.0.27:34594",
+					"172.17.0.1:34594",
+					"172.19.0.1:34594",
+					"172.20.0.1:34594"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:33:10.925761545Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4322992263202343,
+				"StableID":   "neLeuDgtka11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6bbf76b5ac197773c0b859a9b1c91e44b93595fa95e5a62930adfa8ec5180041",
+				"DiscoKey":   "discokey:4a33e21c16f93042152ced77f5ba089c8e4bde91258a303ed65fa20227ad8b25",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44848",
+					"10.65.0.27:44848",
+					"172.17.0.1:44848",
+					"172.19.0.1:44848",
+					"172.20.0.1:44848"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:33:11.458425053Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3081484268680458,
+				"StableID":   "nKy1nFNc4R11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1cd157428e354b28b71a831d8b65eb680e81004d6ebcc78d9309b50ee2412b2b",
+				"DiscoKey":   "discokey:6641b6c439d0d5cd5bbb7d1375e4bde3c8b4219c3c0e95951c3cf1ea0f790b05",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48756",
+					"10.65.0.27:48756",
+					"172.17.0.1:48756",
+					"172.19.0.1:48756",
+					"172.20.0.1:48756"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:33:11.999531663Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         469765205737312,
+				"StableID":   "nBiYbFwkf411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3d073dbd2e6677630b5a379c2338653747a44c303e1ca213330297865d6a17f",
+				"DiscoKey":   "discokey:c58b38472907cad9b8438598dfd3cabf76d0b4f3bda28294d711f0d2ba773242",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45167",
+					"10.65.0.27:45167",
+					"172.17.0.1:45167",
+					"172.19.0.1:45167",
+					"172.20.0.1:45167"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:33:12.531505155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8666116292854433,
+				"StableID":   "neyY5SBufA21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd7d9da01be466b8da4f4a04ab5ca3462646c23ee86179436f562659298e057a",
+				"DiscoKey":   "discokey:f147cf46411b38f2cf4f9afe7aa9fa5808876e3e3b5c3af2f9014a333f55cb56",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51954",
+					"10.65.0.27:51954",
+					"172.17.0.1:51954",
+					"172.19.0.1:51954",
+					"172.20.0.1:51954"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:33:13.069459914Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4087990560702471,
+				"StableID":   "nYVdBeaTvY11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dcd257a4b27218522012867ad3a96efce3b3fd72eb6ce226ade91bdd34f8502d",
+				"DiscoKey":   "discokey:1a10cab9938af6686b0ce2990dae2250b82a6a5d1185f99a8800f0d3c3e7eb3e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60845",
+					"10.65.0.27:60845",
+					"172.17.0.1:60845",
+					"172.19.0.1:60845",
+					"172.20.0.1:60845"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:33:13.592579815Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8833086820652244,
+				"StableID":   "nBSfrKDXyB21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ba0541859c797ac5f7ec9ed9f1c188500947b3931705e9cb31b3f584ecd8861",
+				"DiscoKey":   "discokey:8839861f36c99c995cbeca958da544806ae29ff76aff636be07001939e4fcc55",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41528",
+					"10.65.0.27:41528",
+					"172.17.0.1:41528",
+					"172.19.0.1:41528",
+					"172.20.0.1:41528"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:33:14.129122113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7035509393532425,
+				"StableID":   "neou8JuPww11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ecee0122e3a9f5a440fa5f224b7f8b73cb2c105204596b439595e9c192115624",
+				"KeyExpiry":  "2026-11-08T18:33:14Z",
+				"DiscoKey":   "discokey:0bb5fb3e7c8f425e1216249916032b6d300be145e7f518148132b57bb311dd74",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:57132",
+					"10.65.0.27:57132",
+					"172.17.0.1:57132",
+					"172.19.0.1:57132",
+					"172.20.0.1:57132"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:33:14.663005747Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6808557030166489,
+				"StableID":   "nLixwNFcAv11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c8fb5923da5e2e0991e21685f89114292bbd46e101009f97de3959018275c93f",
+				"KeyExpiry":  "2026-11-08T18:33:15Z",
+				"DiscoKey":   "discokey:d1097930c9c9cdd9bfdfd05fdc5c8dc2a16e4abf5a78ee9eca7474006aae6149",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50794",
+					"10.65.0.27:50794",
+					"172.17.0.1:50794",
+					"172.19.0.1:50794",
+					"172.20.0.1:50794"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:33:15.755753394Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{
+				"principals": [{"nodeIP": "100.64.0.18"}, {"nodeIP": "fd7a:115c:a1e0::12"}],
+				"sshUsers":   {"root": "root"},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				}
+			}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		},
+		"ssh_rules": [{
+			"principals": [{"nodeIP": "100.64.0.18"}, {"nodeIP": "fd7a:115c:a1e0::12"}],
+			"sshUsers":   {"root": "root"},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}
+		}]
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8666116292854433,
+				"StableID":   "neyY5SBufA21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       8666116292854433,
+				"Key":        "nodekey:cd7d9da01be466b8da4f4a04ab5ca3462646c23ee86179436f562659298e057a",
+				"DiscoKey":   "discokey:f147cf46411b38f2cf4f9afe7aa9fa5808876e3e3b5c3af2f9014a333f55cb56",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51954",
+					"10.65.0.27:51954",
+					"172.17.0.1:51954",
+					"172.19.0.1:51954",
+					"172.20.0.1:51954"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:33:13.069459914Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:cd7d9da01be466b8da4f4a04ab5ca3462646c23ee86179436f562659298e057a",
+			"MachineKey": "mkey:b11a5ffab6a71a37b295fe72635686be6456b98842f58c4f5e6970b70f1c5c55",
+			"Peers": [{
+				"ID":         1209777249547958,
+				"StableID":   "n3BbrDouSA11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a2081c3c2709901df4690fa1b7595a51519c22ad420f2b9acddcf2fdef9d401c",
+				"DiscoKey":   "discokey:626f5816c03f257d6261f689c353f76bb515826afc2b36c2fa1cf7b515c55009",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58126",
+					"10.65.0.27:58126",
+					"172.17.0.1:58126",
+					"172.19.0.1:58126",
+					"172.20.0.1:58126"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:33:08.294290382Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4023169253352937,
+				"StableID":   "nnuvDPq6RY11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b02b36dd505ace740bb4698542b8ed81ec4095bf6531b7287cdaff894f242b42",
+				"DiscoKey":   "discokey:f15c47c262198507f69bd5014ebadb3f78efc139d16ac362a5d142b8c0c2133a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:45115",
+					"10.65.0.27:45115",
+					"172.17.0.1:45115",
+					"172.19.0.1:45115",
+					"172.20.0.1:45115"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:33:08.763175709Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4652214928213325,
+				"StableID":   "nahnSFozKd11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:77793ca1f48eb34568c93668af9146722be4b786bbe3398d563266b31ad4c17f",
+				"DiscoKey":   "discokey:11f3a582666ea4f24807becf4d74de0d2cc6dfb8bcb5e405e635d7e7a470c366",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:33:09.299397318Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8731075257292874,
+				"StableID":   "n1CpKRYKBB21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3a6ffa9cec643a3ee5c74ee56b7aff3e4f113d181292b0503b95264eb29dbf72",
+				"DiscoKey":   "discokey:6e977e9d58f6ae95801087703d09ce5b0b06646c2d44e6597ed6b441e3a8181f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:37260",
+					"10.65.0.27:37260",
+					"172.17.0.1:37260",
+					"172.19.0.1:37260",
+					"172.20.0.1:37260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:33:09.837588413Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5321503171654358,
+				"StableID":   "nqUZe9s7Zi11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6f8025967b9e427b50a5b8533fda537e864eaccce2d33a8a8e693cae1098566d",
+				"DiscoKey":   "discokey:dceded285b2d1bba3b281c50b52371b0fb12a215539817c6c3d320d634f06842",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:56832",
+					"10.65.0.27:56832",
+					"172.17.0.1:56832",
+					"172.19.0.1:56832",
+					"172.20.0.1:56832"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:33:10.385856224Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4492892243963888,
+				"StableID":   "njJvQKfq5c11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5e68f80a29fce97eaab751f7dafac4f45c67790d0ec5439d3a42879dd865853e",
+				"DiscoKey":   "discokey:308832a609850e9acd8e9e8f28b0e9820c55931d854eb442a0cd3c814472757c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:34594",
+					"10.65.0.27:34594",
+					"172.17.0.1:34594",
+					"172.19.0.1:34594",
+					"172.20.0.1:34594"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:33:10.925761545Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4322992263202343,
+				"StableID":   "neLeuDgtka11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6bbf76b5ac197773c0b859a9b1c91e44b93595fa95e5a62930adfa8ec5180041",
+				"DiscoKey":   "discokey:4a33e21c16f93042152ced77f5ba089c8e4bde91258a303ed65fa20227ad8b25",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44848",
+					"10.65.0.27:44848",
+					"172.17.0.1:44848",
+					"172.19.0.1:44848",
+					"172.20.0.1:44848"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:33:11.458425053Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3081484268680458,
+				"StableID":   "nKy1nFNc4R11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1cd157428e354b28b71a831d8b65eb680e81004d6ebcc78d9309b50ee2412b2b",
+				"DiscoKey":   "discokey:6641b6c439d0d5cd5bbb7d1375e4bde3c8b4219c3c0e95951c3cf1ea0f790b05",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48756",
+					"10.65.0.27:48756",
+					"172.17.0.1:48756",
+					"172.19.0.1:48756",
+					"172.20.0.1:48756"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:33:11.999531663Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         469765205737312,
+				"StableID":   "nBiYbFwkf411CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3d073dbd2e6677630b5a379c2338653747a44c303e1ca213330297865d6a17f",
+				"DiscoKey":   "discokey:c58b38472907cad9b8438598dfd3cabf76d0b4f3bda28294d711f0d2ba773242",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45167",
+					"10.65.0.27:45167",
+					"172.17.0.1:45167",
+					"172.19.0.1:45167",
+					"172.20.0.1:45167"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:33:12.531505155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4087990560702471,
+				"StableID":   "nYVdBeaTvY11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dcd257a4b27218522012867ad3a96efce3b3fd72eb6ce226ade91bdd34f8502d",
+				"DiscoKey":   "discokey:1a10cab9938af6686b0ce2990dae2250b82a6a5d1185f99a8800f0d3c3e7eb3e",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60845",
+					"10.65.0.27:60845",
+					"172.17.0.1:60845",
+					"172.19.0.1:60845",
+					"172.20.0.1:60845"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:33:13.592579815Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8833086820652244,
+				"StableID":   "nBSfrKDXyB21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ba0541859c797ac5f7ec9ed9f1c188500947b3931705e9cb31b3f584ecd8861",
+				"DiscoKey":   "discokey:8839861f36c99c995cbeca958da544806ae29ff76aff636be07001939e4fcc55",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41528",
+					"10.65.0.27:41528",
+					"172.17.0.1:41528",
+					"172.19.0.1:41528",
+					"172.20.0.1:41528"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:33:14.129122113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7035509393532425,
+				"StableID":   "neou8JuPww11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ecee0122e3a9f5a440fa5f224b7f8b73cb2c105204596b439595e9c192115624",
+				"KeyExpiry":  "2026-11-08T18:33:14Z",
+				"DiscoKey":   "discokey:0bb5fb3e7c8f425e1216249916032b6d300be145e7f518148132b57bb311dd74",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:57132",
+					"10.65.0.27:57132",
+					"172.17.0.1:57132",
+					"172.19.0.1:57132",
+					"172.20.0.1:57132"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:33:14.663005747Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6999886582499453,
+				"StableID":   "nSoyJk9Gfw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9cc889d065800d1cefd0e57538710565c901432032569b4f058c17134506fa3b",
+				"KeyExpiry":  "2026-11-08T18:33:15Z",
+				"DiscoKey":   "discokey:4982335d30436caf95bc55d8c35a748544e40eaed360384bd887f6b83e04e95d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:49044",
+					"10.65.0.27:49044",
+					"172.17.0.1:49044",
+					"172.19.0.1:49044",
+					"172.20.0.1:49044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:33:15.208583828Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6808557030166489,
+				"StableID":   "nLixwNFcAv11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c8fb5923da5e2e0991e21685f89114292bbd46e101009f97de3959018275c93f",
+				"KeyExpiry":  "2026-11-08T18:33:15Z",
+				"DiscoKey":   "discokey:d1097930c9c9cdd9bfdfd05fdc5c8dc2a16e4abf5a78ee9eca7474006aae6149",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:50794",
+					"10.65.0.27:50794",
+					"172.17.0.1:50794",
+					"172.19.0.1:50794",
+					"172.20.0.1:50794"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:33:15.755753394Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8666116292854433": {
+				"ID":          8666116292854433,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/sshtest_results/sshtest-allpass-basic-user-to-tag.hujson
+++ b/hscontrol/policy/v2/testdata/sshtest_results/sshtest-allpass-basic-user-to-tag.hujson
@@ -1,0 +1,20099 @@
+// sshtest-allpass-basic-user-to-tag
+//
+// ssh user->tag:server root, sshTests accept matches
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T18:34:00Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "sshtest-allpass-basic-user-to-tag",
+	"description":    "ssh user->tag:server root, sshTests accept matches",
+	"category":       "sshtest",
+	"captured_at":    "2026-05-12T18:34:00.947844688Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                    \n  \n                                                                     \n                                                     \n{\n\t\"category\":    \"sshtest\",\n\t\"description\": \"ssh user->tag:server root, sshTests accept matches\",\n\t\"id\":          \"sshtest-allpass-basic-user-to-tag\",\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"thor@example.org\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"sshTests\": [{\n\t\t\"accept\": [\"root\"],\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    \"thor@example.org\"\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/sshtest/sshtest-allpass-basic-user-to-tag.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["thor@example.org"],
+				"users":  ["root"]
+			}],
+			"sshTests":  [{"accept": ["root"], "dst": ["tag:server"], "src": "thor@example.org"}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7114745634573595,
+				"StableID":   "nNAgRbJHZx11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       7114745634573595,
+				"Key":        "nodekey:c4e109d06ad3ef6a3a937688201159d694d4a2880f045616e0a2299099969104",
+				"DiscoKey":   "discokey:98ab0fdfa6b6692f09484507e869de4e938ac4e5ca2f838b2fb456b9ee192b21",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:40692",
+					"10.65.0.27:40692",
+					"172.17.0.1:40692",
+					"172.19.0.1:40692",
+					"172.20.0.1:40692"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:34:09.338974089Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c4e109d06ad3ef6a3a937688201159d694d4a2880f045616e0a2299099969104",
+			"MachineKey": "mkey:9610ec18504ebe422a9b151327e0e7db62560c7f523bf8699627521f75f7730c",
+			"Peers": [{
+				"ID":         1022503236902628,
+				"StableID":   "nbLYeiR6z811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7971e8fb145a2c24201b1f3a8d324c6f84d34d51108ced31083b7945037f502",
+				"DiscoKey":   "discokey:b2f244c013b6bfe90a222534be986760343607b7ac142643850753f998c79227",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:41224",
+					"10.65.0.27:41224",
+					"172.17.0.1:41224",
+					"172.19.0.1:41224",
+					"172.20.0.1:41224"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:34:03.497685845Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8664957792496331,
+				"StableID":   "nS4QNPkNfA21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f05aa1de0102ff1818b0a21982be35047944fa5370360f47562896c88d918618",
+				"DiscoKey":   "discokey:451076ac784e15ee15e575c36ee956c35895f45df5db21bca16c6b2b0984824a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40453",
+					"10.65.0.27:40453",
+					"172.17.0.1:40453",
+					"172.19.0.1:40453",
+					"172.20.0.1:40453"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:34:04.003863683Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8235291227186960,
+				"StableID":   "nXvMKt8nJ721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae7c3fcacb00745d9f223ef9adf6c8ac66f9bc376c75dbc698299a3737327547",
+				"DiscoKey":   "discokey:0aa445872572f0accf0209866eedeeeace67c0f5aa6a2bd2daf31a3c8b28c910",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:49557",
+					"10.65.0.27:49557",
+					"172.17.0.1:49557",
+					"172.19.0.1:49557",
+					"172.20.0.1:49557"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:34:04.539409763Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8628004179095420,
+				"StableID":   "nVXU6H3eNA21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af82dd8733b5a319c76c68ba56c1b30e695445adbcf6f5e8bde557c09ae15b79",
+				"DiscoKey":   "discokey:f484aec42430b36c315eddfbbcca6edc4f8b3ff4afb12f523888659368138451",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45337",
+					"10.65.0.27:45337",
+					"172.17.0.1:45337",
+					"172.19.0.1:45337",
+					"172.20.0.1:45337"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:34:05.074221241Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6590867837531638,
+				"StableID":   "n9xHSUv1Ut11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b07c37318cc3aec00938db2817117b472bb6163c08716e84dfaa8d9267b37b32",
+				"DiscoKey":   "discokey:81b18fc56567fc8f4fcf35907d2edf91f2282b9a9b8e1b82a5e79900c4cd0821",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37862",
+					"10.65.0.27:37862",
+					"172.17.0.1:37862",
+					"172.19.0.1:37862",
+					"172.20.0.1:37862"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:34:05.611311706Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6282512707345114,
+				"StableID":   "nXueVRxM4r11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4fb6b80caba83f7bee0a74a527cd06ee3fa34d644599b2661cb936857669a3b",
+				"DiscoKey":   "discokey:f3501443371b5cc1db334be168dbde50db6c83c10f495b6337fa8694b1667445",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38866",
+					"10.65.0.27:38866",
+					"172.17.0.1:38866",
+					"172.19.0.1:38866",
+					"172.20.0.1:38866"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:34:06.140529217Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8624384377314642,
+				"StableID":   "nq6BcHxzLA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:948247711446f93b6a925fb7af24b9a1f4ec31a7f6e9b94ccbb2802bab17f97c",
+				"DiscoKey":   "discokey:6809b4aaa6f52d3c03772ec91e7d4439148e2e95f50870d89335925dfb9dc603",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50229",
+					"10.65.0.27:50229",
+					"172.17.0.1:50229",
+					"172.19.0.1:50229",
+					"172.20.0.1:50229"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:34:06.68292337Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4439328582789959,
+				"StableID":   "nEEV6ndafb11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03a511cfc1fb37f747f1e98f6e4ba40d18fbecafc21b2154ec8a849def9d736c",
+				"DiscoKey":   "discokey:a739bec3425689dad8fe6a2da36b163b1cdce535317be81e872d20d46811dc0b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48890",
+					"10.65.0.27:48890",
+					"172.17.0.1:48890",
+					"172.19.0.1:48890",
+					"172.20.0.1:48890"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:34:07.213221624Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         656941692479156,
+				"StableID":   "n3CrmAkX8611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:370de11ef28f539339bfef1ca0f5ebfdaea5c2f1019a96f38094bf6d3d493131",
+				"DiscoKey":   "discokey:678e6851568a4d9faea3c625bd3b4037bea0f989efed0ae529d68fa18fa42e1d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56057",
+					"10.65.0.27:56057",
+					"172.17.0.1:56057",
+					"172.19.0.1:56057",
+					"172.20.0.1:56057"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:34:07.735518321Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3631511856685615,
+				"StableID":   "nJWLFCfiMV11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cce483fe904609f3dd393a8b16b32befd95d164feac49fc6242c8fe9c1599265",
+				"DiscoKey":   "discokey:287d208a96d9e7506ae18ff60520103281af7c2831022945baeb2f7d84c1650f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58559",
+					"10.65.0.27:58559",
+					"172.17.0.1:58559",
+					"172.19.0.1:58559",
+					"172.20.0.1:58559"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:34:08.280233017Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1126027970937232,
+				"StableID":   "nmFdt2ryn911CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4360bf8f7aaf7df0bfb9bba0e959b82b7d0ef08422e95a5b2074e03985bf4334",
+				"DiscoKey":   "discokey:480e78aa2c2d3cf3020ed2d8c39a8ffd574e201e8e56d2ff6d54cae121947044",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35829",
+					"10.65.0.27:35829",
+					"172.17.0.1:35829",
+					"172.19.0.1:35829",
+					"172.20.0.1:35829"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:34:08.806497751Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2882053099464165,
+				"StableID":   "neZoGaeHWP11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b078a77336b1d6e1241638676dc3f5a788db64fee6130ccb5c16af411ef0616c",
+				"KeyExpiry":  "2026-11-08T18:34:09Z",
+				"DiscoKey":   "discokey:8244df2d4a4b0f214a82958cb16caa087e7ad9ab07f2c7f37ce840f43289321e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43422",
+					"10.65.0.27:43422",
+					"172.17.0.1:43422",
+					"172.19.0.1:43422",
+					"172.20.0.1:43422"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:34:09.872005789Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4945122688476289,
+				"StableID":   "ntkoCHzecf11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:59bf1bde5cc5436bb8a217cc85b22ffd556ed8cc0effd27b596cf6c510762f2c",
+				"KeyExpiry":  "2026-11-08T18:34:10Z",
+				"DiscoKey":   "discokey:30a6c6071fef8521561db58d989f8f69a77d9b5a41d47af01c8e9809ef219243",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54883",
+					"10.65.0.27:54883",
+					"172.17.0.1:54883",
+					"172.19.0.1:54883",
+					"172.20.0.1:54883"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:34:10.412326737Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1543249583393063,
+				"StableID":   "nSgK5tYw3D11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f5328c3d98f667fa716c2e3078a330c20e835c370678e906aa6eeb947fa8db2c",
+				"KeyExpiry":  "2026-11-08T18:34:11Z",
+				"DiscoKey":   "discokey:a68516c729732c39f2d1ccfd587c7ad7921ac4a48b45b50503a00f6f2281861c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:46471",
+					"10.65.0.27:46471",
+					"172.17.0.1:46471",
+					"172.19.0.1:46471",
+					"172.20.0.1:46471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:34:11.18328066Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{
+				"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+				"sshUsers":   {"root": "root"},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				}
+			}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7114745634573595": {
+				"ID":          7114745634573595,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		},
+		"ssh_rules": [{
+			"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+			"sshUsers":   {"root": "root"},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}
+		}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6282512707345114,
+				"StableID":   "nXueVRxM4r11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       6282512707345114,
+				"Key":        "nodekey:c4fb6b80caba83f7bee0a74a527cd06ee3fa34d644599b2661cb936857669a3b",
+				"DiscoKey":   "discokey:f3501443371b5cc1db334be168dbde50db6c83c10f495b6337fa8694b1667445",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38866",
+					"10.65.0.27:38866",
+					"172.17.0.1:38866",
+					"172.19.0.1:38866",
+					"172.20.0.1:38866"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:34:06.140529217Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c4fb6b80caba83f7bee0a74a527cd06ee3fa34d644599b2661cb936857669a3b",
+			"MachineKey": "mkey:f2cd3710db4d7a4a97f43a827160a88ae021d0a7dd235f98cd0664347bb60955",
+			"Peers": [{
+				"ID":         1022503236902628,
+				"StableID":   "nbLYeiR6z811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7971e8fb145a2c24201b1f3a8d324c6f84d34d51108ced31083b7945037f502",
+				"DiscoKey":   "discokey:b2f244c013b6bfe90a222534be986760343607b7ac142643850753f998c79227",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:41224",
+					"10.65.0.27:41224",
+					"172.17.0.1:41224",
+					"172.19.0.1:41224",
+					"172.20.0.1:41224"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:34:03.497685845Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8664957792496331,
+				"StableID":   "nS4QNPkNfA21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f05aa1de0102ff1818b0a21982be35047944fa5370360f47562896c88d918618",
+				"DiscoKey":   "discokey:451076ac784e15ee15e575c36ee956c35895f45df5db21bca16c6b2b0984824a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40453",
+					"10.65.0.27:40453",
+					"172.17.0.1:40453",
+					"172.19.0.1:40453",
+					"172.20.0.1:40453"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:34:04.003863683Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8235291227186960,
+				"StableID":   "nXvMKt8nJ721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae7c3fcacb00745d9f223ef9adf6c8ac66f9bc376c75dbc698299a3737327547",
+				"DiscoKey":   "discokey:0aa445872572f0accf0209866eedeeeace67c0f5aa6a2bd2daf31a3c8b28c910",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:49557",
+					"10.65.0.27:49557",
+					"172.17.0.1:49557",
+					"172.19.0.1:49557",
+					"172.20.0.1:49557"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:34:04.539409763Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8628004179095420,
+				"StableID":   "nVXU6H3eNA21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af82dd8733b5a319c76c68ba56c1b30e695445adbcf6f5e8bde557c09ae15b79",
+				"DiscoKey":   "discokey:f484aec42430b36c315eddfbbcca6edc4f8b3ff4afb12f523888659368138451",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45337",
+					"10.65.0.27:45337",
+					"172.17.0.1:45337",
+					"172.19.0.1:45337",
+					"172.20.0.1:45337"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:34:05.074221241Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6590867837531638,
+				"StableID":   "n9xHSUv1Ut11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b07c37318cc3aec00938db2817117b472bb6163c08716e84dfaa8d9267b37b32",
+				"DiscoKey":   "discokey:81b18fc56567fc8f4fcf35907d2edf91f2282b9a9b8e1b82a5e79900c4cd0821",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37862",
+					"10.65.0.27:37862",
+					"172.17.0.1:37862",
+					"172.19.0.1:37862",
+					"172.20.0.1:37862"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:34:05.611311706Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8624384377314642,
+				"StableID":   "nq6BcHxzLA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:948247711446f93b6a925fb7af24b9a1f4ec31a7f6e9b94ccbb2802bab17f97c",
+				"DiscoKey":   "discokey:6809b4aaa6f52d3c03772ec91e7d4439148e2e95f50870d89335925dfb9dc603",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50229",
+					"10.65.0.27:50229",
+					"172.17.0.1:50229",
+					"172.19.0.1:50229",
+					"172.20.0.1:50229"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:34:06.68292337Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4439328582789959,
+				"StableID":   "nEEV6ndafb11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03a511cfc1fb37f747f1e98f6e4ba40d18fbecafc21b2154ec8a849def9d736c",
+				"DiscoKey":   "discokey:a739bec3425689dad8fe6a2da36b163b1cdce535317be81e872d20d46811dc0b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48890",
+					"10.65.0.27:48890",
+					"172.17.0.1:48890",
+					"172.19.0.1:48890",
+					"172.20.0.1:48890"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:34:07.213221624Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         656941692479156,
+				"StableID":   "n3CrmAkX8611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:370de11ef28f539339bfef1ca0f5ebfdaea5c2f1019a96f38094bf6d3d493131",
+				"DiscoKey":   "discokey:678e6851568a4d9faea3c625bd3b4037bea0f989efed0ae529d68fa18fa42e1d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56057",
+					"10.65.0.27:56057",
+					"172.17.0.1:56057",
+					"172.19.0.1:56057",
+					"172.20.0.1:56057"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:34:07.735518321Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3631511856685615,
+				"StableID":   "nJWLFCfiMV11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cce483fe904609f3dd393a8b16b32befd95d164feac49fc6242c8fe9c1599265",
+				"DiscoKey":   "discokey:287d208a96d9e7506ae18ff60520103281af7c2831022945baeb2f7d84c1650f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58559",
+					"10.65.0.27:58559",
+					"172.17.0.1:58559",
+					"172.19.0.1:58559",
+					"172.20.0.1:58559"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:34:08.280233017Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1126027970937232,
+				"StableID":   "nmFdt2ryn911CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4360bf8f7aaf7df0bfb9bba0e959b82b7d0ef08422e95a5b2074e03985bf4334",
+				"DiscoKey":   "discokey:480e78aa2c2d3cf3020ed2d8c39a8ffd574e201e8e56d2ff6d54cae121947044",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35829",
+					"10.65.0.27:35829",
+					"172.17.0.1:35829",
+					"172.19.0.1:35829",
+					"172.20.0.1:35829"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:34:08.806497751Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7114745634573595,
+				"StableID":   "nNAgRbJHZx11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4e109d06ad3ef6a3a937688201159d694d4a2880f045616e0a2299099969104",
+				"DiscoKey":   "discokey:98ab0fdfa6b6692f09484507e869de4e938ac4e5ca2f838b2fb456b9ee192b21",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:40692",
+					"10.65.0.27:40692",
+					"172.17.0.1:40692",
+					"172.19.0.1:40692",
+					"172.20.0.1:40692"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:34:09.338974089Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2882053099464165,
+				"StableID":   "neZoGaeHWP11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b078a77336b1d6e1241638676dc3f5a788db64fee6130ccb5c16af411ef0616c",
+				"KeyExpiry":  "2026-11-08T18:34:09Z",
+				"DiscoKey":   "discokey:8244df2d4a4b0f214a82958cb16caa087e7ad9ab07f2c7f37ce840f43289321e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43422",
+					"10.65.0.27:43422",
+					"172.17.0.1:43422",
+					"172.19.0.1:43422",
+					"172.20.0.1:43422"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:34:09.872005789Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4945122688476289,
+				"StableID":   "ntkoCHzecf11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:59bf1bde5cc5436bb8a217cc85b22ffd556ed8cc0effd27b596cf6c510762f2c",
+				"KeyExpiry":  "2026-11-08T18:34:10Z",
+				"DiscoKey":   "discokey:30a6c6071fef8521561db58d989f8f69a77d9b5a41d47af01c8e9809ef219243",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54883",
+					"10.65.0.27:54883",
+					"172.17.0.1:54883",
+					"172.19.0.1:54883",
+					"172.20.0.1:54883"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:34:10.412326737Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1543249583393063,
+				"StableID":   "nSgK5tYw3D11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f5328c3d98f667fa716c2e3078a330c20e835c370678e906aa6eeb947fa8db2c",
+				"KeyExpiry":  "2026-11-08T18:34:11Z",
+				"DiscoKey":   "discokey:a68516c729732c39f2d1ccfd587c7ad7921ac4a48b45b50503a00f6f2281861c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:46471",
+					"10.65.0.27:46471",
+					"172.17.0.1:46471",
+					"172.19.0.1:46471",
+					"172.20.0.1:46471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:34:11.18328066Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6282512707345114": {
+				"ID":          6282512707345114,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1543249583393063,
+				"StableID":   "nSgK5tYw3D11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f5328c3d98f667fa716c2e3078a330c20e835c370678e906aa6eeb947fa8db2c",
+				"KeyExpiry":  "2026-11-08T18:34:11Z",
+				"DiscoKey":   "discokey:a68516c729732c39f2d1ccfd587c7ad7921ac4a48b45b50503a00f6f2281861c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:46471",
+					"10.65.0.27:46471",
+					"172.17.0.1:46471",
+					"172.19.0.1:46471",
+					"172.20.0.1:46471"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:34:11.18328066Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f5328c3d98f667fa716c2e3078a330c20e835c370678e906aa6eeb947fa8db2c",
+			"MachineKey": "mkey:3b55a63dc9320e382d3087eef785e906c50ebadd5b7b82a0913538d41cea8321",
+			"Peers": [{
+				"ID":         1022503236902628,
+				"StableID":   "nbLYeiR6z811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7971e8fb145a2c24201b1f3a8d324c6f84d34d51108ced31083b7945037f502",
+				"DiscoKey":   "discokey:b2f244c013b6bfe90a222534be986760343607b7ac142643850753f998c79227",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:41224",
+					"10.65.0.27:41224",
+					"172.17.0.1:41224",
+					"172.19.0.1:41224",
+					"172.20.0.1:41224"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:34:03.497685845Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8664957792496331,
+				"StableID":   "nS4QNPkNfA21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f05aa1de0102ff1818b0a21982be35047944fa5370360f47562896c88d918618",
+				"DiscoKey":   "discokey:451076ac784e15ee15e575c36ee956c35895f45df5db21bca16c6b2b0984824a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40453",
+					"10.65.0.27:40453",
+					"172.17.0.1:40453",
+					"172.19.0.1:40453",
+					"172.20.0.1:40453"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:34:04.003863683Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8235291227186960,
+				"StableID":   "nXvMKt8nJ721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae7c3fcacb00745d9f223ef9adf6c8ac66f9bc376c75dbc698299a3737327547",
+				"DiscoKey":   "discokey:0aa445872572f0accf0209866eedeeeace67c0f5aa6a2bd2daf31a3c8b28c910",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:49557",
+					"10.65.0.27:49557",
+					"172.17.0.1:49557",
+					"172.19.0.1:49557",
+					"172.20.0.1:49557"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:34:04.539409763Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8628004179095420,
+				"StableID":   "nVXU6H3eNA21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af82dd8733b5a319c76c68ba56c1b30e695445adbcf6f5e8bde557c09ae15b79",
+				"DiscoKey":   "discokey:f484aec42430b36c315eddfbbcca6edc4f8b3ff4afb12f523888659368138451",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45337",
+					"10.65.0.27:45337",
+					"172.17.0.1:45337",
+					"172.19.0.1:45337",
+					"172.20.0.1:45337"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:34:05.074221241Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6590867837531638,
+				"StableID":   "n9xHSUv1Ut11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b07c37318cc3aec00938db2817117b472bb6163c08716e84dfaa8d9267b37b32",
+				"DiscoKey":   "discokey:81b18fc56567fc8f4fcf35907d2edf91f2282b9a9b8e1b82a5e79900c4cd0821",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37862",
+					"10.65.0.27:37862",
+					"172.17.0.1:37862",
+					"172.19.0.1:37862",
+					"172.20.0.1:37862"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:34:05.611311706Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6282512707345114,
+				"StableID":   "nXueVRxM4r11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4fb6b80caba83f7bee0a74a527cd06ee3fa34d644599b2661cb936857669a3b",
+				"DiscoKey":   "discokey:f3501443371b5cc1db334be168dbde50db6c83c10f495b6337fa8694b1667445",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38866",
+					"10.65.0.27:38866",
+					"172.17.0.1:38866",
+					"172.19.0.1:38866",
+					"172.20.0.1:38866"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:34:06.140529217Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8624384377314642,
+				"StableID":   "nq6BcHxzLA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:948247711446f93b6a925fb7af24b9a1f4ec31a7f6e9b94ccbb2802bab17f97c",
+				"DiscoKey":   "discokey:6809b4aaa6f52d3c03772ec91e7d4439148e2e95f50870d89335925dfb9dc603",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50229",
+					"10.65.0.27:50229",
+					"172.17.0.1:50229",
+					"172.19.0.1:50229",
+					"172.20.0.1:50229"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:34:06.68292337Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4439328582789959,
+				"StableID":   "nEEV6ndafb11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03a511cfc1fb37f747f1e98f6e4ba40d18fbecafc21b2154ec8a849def9d736c",
+				"DiscoKey":   "discokey:a739bec3425689dad8fe6a2da36b163b1cdce535317be81e872d20d46811dc0b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48890",
+					"10.65.0.27:48890",
+					"172.17.0.1:48890",
+					"172.19.0.1:48890",
+					"172.20.0.1:48890"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:34:07.213221624Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         656941692479156,
+				"StableID":   "n3CrmAkX8611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:370de11ef28f539339bfef1ca0f5ebfdaea5c2f1019a96f38094bf6d3d493131",
+				"DiscoKey":   "discokey:678e6851568a4d9faea3c625bd3b4037bea0f989efed0ae529d68fa18fa42e1d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56057",
+					"10.65.0.27:56057",
+					"172.17.0.1:56057",
+					"172.19.0.1:56057",
+					"172.20.0.1:56057"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:34:07.735518321Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3631511856685615,
+				"StableID":   "nJWLFCfiMV11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cce483fe904609f3dd393a8b16b32befd95d164feac49fc6242c8fe9c1599265",
+				"DiscoKey":   "discokey:287d208a96d9e7506ae18ff60520103281af7c2831022945baeb2f7d84c1650f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58559",
+					"10.65.0.27:58559",
+					"172.17.0.1:58559",
+					"172.19.0.1:58559",
+					"172.20.0.1:58559"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:34:08.280233017Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1126027970937232,
+				"StableID":   "nmFdt2ryn911CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4360bf8f7aaf7df0bfb9bba0e959b82b7d0ef08422e95a5b2074e03985bf4334",
+				"DiscoKey":   "discokey:480e78aa2c2d3cf3020ed2d8c39a8ffd574e201e8e56d2ff6d54cae121947044",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35829",
+					"10.65.0.27:35829",
+					"172.17.0.1:35829",
+					"172.19.0.1:35829",
+					"172.20.0.1:35829"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:34:08.806497751Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7114745634573595,
+				"StableID":   "nNAgRbJHZx11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4e109d06ad3ef6a3a937688201159d694d4a2880f045616e0a2299099969104",
+				"DiscoKey":   "discokey:98ab0fdfa6b6692f09484507e869de4e938ac4e5ca2f838b2fb456b9ee192b21",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:40692",
+					"10.65.0.27:40692",
+					"172.17.0.1:40692",
+					"172.19.0.1:40692",
+					"172.20.0.1:40692"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:34:09.338974089Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2882053099464165,
+				"StableID":   "neZoGaeHWP11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b078a77336b1d6e1241638676dc3f5a788db64fee6130ccb5c16af411ef0616c",
+				"KeyExpiry":  "2026-11-08T18:34:09Z",
+				"DiscoKey":   "discokey:8244df2d4a4b0f214a82958cb16caa087e7ad9ab07f2c7f37ce840f43289321e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43422",
+					"10.65.0.27:43422",
+					"172.17.0.1:43422",
+					"172.19.0.1:43422",
+					"172.20.0.1:43422"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:34:09.872005789Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4945122688476289,
+				"StableID":   "ntkoCHzecf11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:59bf1bde5cc5436bb8a217cc85b22ffd556ed8cc0effd27b596cf6c510762f2c",
+				"KeyExpiry":  "2026-11-08T18:34:10Z",
+				"DiscoKey":   "discokey:30a6c6071fef8521561db58d989f8f69a77d9b5a41d47af01c8e9809ef219243",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54883",
+					"10.65.0.27:54883",
+					"172.17.0.1:54883",
+					"172.19.0.1:54883",
+					"172.20.0.1:54883"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:34:10.412326737Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8235291227186960,
+				"StableID":   "nXvMKt8nJ721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       8235291227186960,
+				"Key":        "nodekey:ae7c3fcacb00745d9f223ef9adf6c8ac66f9bc376c75dbc698299a3737327547",
+				"DiscoKey":   "discokey:0aa445872572f0accf0209866eedeeeace67c0f5aa6a2bd2daf31a3c8b28c910",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:49557",
+					"10.65.0.27:49557",
+					"172.17.0.1:49557",
+					"172.19.0.1:49557",
+					"172.20.0.1:49557"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:34:04.539409763Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ae7c3fcacb00745d9f223ef9adf6c8ac66f9bc376c75dbc698299a3737327547",
+			"MachineKey": "mkey:e795392fa1361885860f936282a7ecab9adc76dd339530bd629620323f5abb05",
+			"Peers": [{
+				"ID":         1022503236902628,
+				"StableID":   "nbLYeiR6z811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7971e8fb145a2c24201b1f3a8d324c6f84d34d51108ced31083b7945037f502",
+				"DiscoKey":   "discokey:b2f244c013b6bfe90a222534be986760343607b7ac142643850753f998c79227",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:41224",
+					"10.65.0.27:41224",
+					"172.17.0.1:41224",
+					"172.19.0.1:41224",
+					"172.20.0.1:41224"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:34:03.497685845Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8664957792496331,
+				"StableID":   "nS4QNPkNfA21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f05aa1de0102ff1818b0a21982be35047944fa5370360f47562896c88d918618",
+				"DiscoKey":   "discokey:451076ac784e15ee15e575c36ee956c35895f45df5db21bca16c6b2b0984824a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40453",
+					"10.65.0.27:40453",
+					"172.17.0.1:40453",
+					"172.19.0.1:40453",
+					"172.20.0.1:40453"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:34:04.003863683Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8628004179095420,
+				"StableID":   "nVXU6H3eNA21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af82dd8733b5a319c76c68ba56c1b30e695445adbcf6f5e8bde557c09ae15b79",
+				"DiscoKey":   "discokey:f484aec42430b36c315eddfbbcca6edc4f8b3ff4afb12f523888659368138451",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45337",
+					"10.65.0.27:45337",
+					"172.17.0.1:45337",
+					"172.19.0.1:45337",
+					"172.20.0.1:45337"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:34:05.074221241Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6590867837531638,
+				"StableID":   "n9xHSUv1Ut11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b07c37318cc3aec00938db2817117b472bb6163c08716e84dfaa8d9267b37b32",
+				"DiscoKey":   "discokey:81b18fc56567fc8f4fcf35907d2edf91f2282b9a9b8e1b82a5e79900c4cd0821",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37862",
+					"10.65.0.27:37862",
+					"172.17.0.1:37862",
+					"172.19.0.1:37862",
+					"172.20.0.1:37862"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:34:05.611311706Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6282512707345114,
+				"StableID":   "nXueVRxM4r11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4fb6b80caba83f7bee0a74a527cd06ee3fa34d644599b2661cb936857669a3b",
+				"DiscoKey":   "discokey:f3501443371b5cc1db334be168dbde50db6c83c10f495b6337fa8694b1667445",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38866",
+					"10.65.0.27:38866",
+					"172.17.0.1:38866",
+					"172.19.0.1:38866",
+					"172.20.0.1:38866"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:34:06.140529217Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8624384377314642,
+				"StableID":   "nq6BcHxzLA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:948247711446f93b6a925fb7af24b9a1f4ec31a7f6e9b94ccbb2802bab17f97c",
+				"DiscoKey":   "discokey:6809b4aaa6f52d3c03772ec91e7d4439148e2e95f50870d89335925dfb9dc603",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50229",
+					"10.65.0.27:50229",
+					"172.17.0.1:50229",
+					"172.19.0.1:50229",
+					"172.20.0.1:50229"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:34:06.68292337Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4439328582789959,
+				"StableID":   "nEEV6ndafb11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03a511cfc1fb37f747f1e98f6e4ba40d18fbecafc21b2154ec8a849def9d736c",
+				"DiscoKey":   "discokey:a739bec3425689dad8fe6a2da36b163b1cdce535317be81e872d20d46811dc0b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48890",
+					"10.65.0.27:48890",
+					"172.17.0.1:48890",
+					"172.19.0.1:48890",
+					"172.20.0.1:48890"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:34:07.213221624Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         656941692479156,
+				"StableID":   "n3CrmAkX8611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:370de11ef28f539339bfef1ca0f5ebfdaea5c2f1019a96f38094bf6d3d493131",
+				"DiscoKey":   "discokey:678e6851568a4d9faea3c625bd3b4037bea0f989efed0ae529d68fa18fa42e1d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56057",
+					"10.65.0.27:56057",
+					"172.17.0.1:56057",
+					"172.19.0.1:56057",
+					"172.20.0.1:56057"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:34:07.735518321Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3631511856685615,
+				"StableID":   "nJWLFCfiMV11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cce483fe904609f3dd393a8b16b32befd95d164feac49fc6242c8fe9c1599265",
+				"DiscoKey":   "discokey:287d208a96d9e7506ae18ff60520103281af7c2831022945baeb2f7d84c1650f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58559",
+					"10.65.0.27:58559",
+					"172.17.0.1:58559",
+					"172.19.0.1:58559",
+					"172.20.0.1:58559"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:34:08.280233017Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1126027970937232,
+				"StableID":   "nmFdt2ryn911CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4360bf8f7aaf7df0bfb9bba0e959b82b7d0ef08422e95a5b2074e03985bf4334",
+				"DiscoKey":   "discokey:480e78aa2c2d3cf3020ed2d8c39a8ffd574e201e8e56d2ff6d54cae121947044",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35829",
+					"10.65.0.27:35829",
+					"172.17.0.1:35829",
+					"172.19.0.1:35829",
+					"172.20.0.1:35829"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:34:08.806497751Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7114745634573595,
+				"StableID":   "nNAgRbJHZx11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4e109d06ad3ef6a3a937688201159d694d4a2880f045616e0a2299099969104",
+				"DiscoKey":   "discokey:98ab0fdfa6b6692f09484507e869de4e938ac4e5ca2f838b2fb456b9ee192b21",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:40692",
+					"10.65.0.27:40692",
+					"172.17.0.1:40692",
+					"172.19.0.1:40692",
+					"172.20.0.1:40692"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:34:09.338974089Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2882053099464165,
+				"StableID":   "neZoGaeHWP11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b078a77336b1d6e1241638676dc3f5a788db64fee6130ccb5c16af411ef0616c",
+				"KeyExpiry":  "2026-11-08T18:34:09Z",
+				"DiscoKey":   "discokey:8244df2d4a4b0f214a82958cb16caa087e7ad9ab07f2c7f37ce840f43289321e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43422",
+					"10.65.0.27:43422",
+					"172.17.0.1:43422",
+					"172.19.0.1:43422",
+					"172.20.0.1:43422"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:34:09.872005789Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4945122688476289,
+				"StableID":   "ntkoCHzecf11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:59bf1bde5cc5436bb8a217cc85b22ffd556ed8cc0effd27b596cf6c510762f2c",
+				"KeyExpiry":  "2026-11-08T18:34:10Z",
+				"DiscoKey":   "discokey:30a6c6071fef8521561db58d989f8f69a77d9b5a41d47af01c8e9809ef219243",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54883",
+					"10.65.0.27:54883",
+					"172.17.0.1:54883",
+					"172.19.0.1:54883",
+					"172.20.0.1:54883"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:34:10.412326737Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1543249583393063,
+				"StableID":   "nSgK5tYw3D11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f5328c3d98f667fa716c2e3078a330c20e835c370678e906aa6eeb947fa8db2c",
+				"KeyExpiry":  "2026-11-08T18:34:11Z",
+				"DiscoKey":   "discokey:a68516c729732c39f2d1ccfd587c7ad7921ac4a48b45b50503a00f6f2281861c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:46471",
+					"10.65.0.27:46471",
+					"172.17.0.1:46471",
+					"172.19.0.1:46471",
+					"172.20.0.1:46471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:34:11.18328066Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8235291227186960": {
+				"ID":          8235291227186960,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4439328582789959,
+				"StableID":   "nEEV6ndafb11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       4439328582789959,
+				"Key":        "nodekey:03a511cfc1fb37f747f1e98f6e4ba40d18fbecafc21b2154ec8a849def9d736c",
+				"DiscoKey":   "discokey:a739bec3425689dad8fe6a2da36b163b1cdce535317be81e872d20d46811dc0b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48890",
+					"10.65.0.27:48890",
+					"172.17.0.1:48890",
+					"172.19.0.1:48890",
+					"172.20.0.1:48890"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:34:07.213221624Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:03a511cfc1fb37f747f1e98f6e4ba40d18fbecafc21b2154ec8a849def9d736c",
+			"MachineKey": "mkey:01dac8ccadd77f4fe29500cc57c43f157ec6d5ed043720f622290a5c3e579a39",
+			"Peers": [{
+				"ID":         1022503236902628,
+				"StableID":   "nbLYeiR6z811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7971e8fb145a2c24201b1f3a8d324c6f84d34d51108ced31083b7945037f502",
+				"DiscoKey":   "discokey:b2f244c013b6bfe90a222534be986760343607b7ac142643850753f998c79227",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:41224",
+					"10.65.0.27:41224",
+					"172.17.0.1:41224",
+					"172.19.0.1:41224",
+					"172.20.0.1:41224"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:34:03.497685845Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8664957792496331,
+				"StableID":   "nS4QNPkNfA21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f05aa1de0102ff1818b0a21982be35047944fa5370360f47562896c88d918618",
+				"DiscoKey":   "discokey:451076ac784e15ee15e575c36ee956c35895f45df5db21bca16c6b2b0984824a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40453",
+					"10.65.0.27:40453",
+					"172.17.0.1:40453",
+					"172.19.0.1:40453",
+					"172.20.0.1:40453"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:34:04.003863683Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8235291227186960,
+				"StableID":   "nXvMKt8nJ721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae7c3fcacb00745d9f223ef9adf6c8ac66f9bc376c75dbc698299a3737327547",
+				"DiscoKey":   "discokey:0aa445872572f0accf0209866eedeeeace67c0f5aa6a2bd2daf31a3c8b28c910",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:49557",
+					"10.65.0.27:49557",
+					"172.17.0.1:49557",
+					"172.19.0.1:49557",
+					"172.20.0.1:49557"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:34:04.539409763Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8628004179095420,
+				"StableID":   "nVXU6H3eNA21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af82dd8733b5a319c76c68ba56c1b30e695445adbcf6f5e8bde557c09ae15b79",
+				"DiscoKey":   "discokey:f484aec42430b36c315eddfbbcca6edc4f8b3ff4afb12f523888659368138451",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45337",
+					"10.65.0.27:45337",
+					"172.17.0.1:45337",
+					"172.19.0.1:45337",
+					"172.20.0.1:45337"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:34:05.074221241Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6590867837531638,
+				"StableID":   "n9xHSUv1Ut11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b07c37318cc3aec00938db2817117b472bb6163c08716e84dfaa8d9267b37b32",
+				"DiscoKey":   "discokey:81b18fc56567fc8f4fcf35907d2edf91f2282b9a9b8e1b82a5e79900c4cd0821",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37862",
+					"10.65.0.27:37862",
+					"172.17.0.1:37862",
+					"172.19.0.1:37862",
+					"172.20.0.1:37862"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:34:05.611311706Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6282512707345114,
+				"StableID":   "nXueVRxM4r11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4fb6b80caba83f7bee0a74a527cd06ee3fa34d644599b2661cb936857669a3b",
+				"DiscoKey":   "discokey:f3501443371b5cc1db334be168dbde50db6c83c10f495b6337fa8694b1667445",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38866",
+					"10.65.0.27:38866",
+					"172.17.0.1:38866",
+					"172.19.0.1:38866",
+					"172.20.0.1:38866"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:34:06.140529217Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8624384377314642,
+				"StableID":   "nq6BcHxzLA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:948247711446f93b6a925fb7af24b9a1f4ec31a7f6e9b94ccbb2802bab17f97c",
+				"DiscoKey":   "discokey:6809b4aaa6f52d3c03772ec91e7d4439148e2e95f50870d89335925dfb9dc603",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50229",
+					"10.65.0.27:50229",
+					"172.17.0.1:50229",
+					"172.19.0.1:50229",
+					"172.20.0.1:50229"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:34:06.68292337Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         656941692479156,
+				"StableID":   "n3CrmAkX8611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:370de11ef28f539339bfef1ca0f5ebfdaea5c2f1019a96f38094bf6d3d493131",
+				"DiscoKey":   "discokey:678e6851568a4d9faea3c625bd3b4037bea0f989efed0ae529d68fa18fa42e1d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56057",
+					"10.65.0.27:56057",
+					"172.17.0.1:56057",
+					"172.19.0.1:56057",
+					"172.20.0.1:56057"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:34:07.735518321Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3631511856685615,
+				"StableID":   "nJWLFCfiMV11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cce483fe904609f3dd393a8b16b32befd95d164feac49fc6242c8fe9c1599265",
+				"DiscoKey":   "discokey:287d208a96d9e7506ae18ff60520103281af7c2831022945baeb2f7d84c1650f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58559",
+					"10.65.0.27:58559",
+					"172.17.0.1:58559",
+					"172.19.0.1:58559",
+					"172.20.0.1:58559"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:34:08.280233017Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1126027970937232,
+				"StableID":   "nmFdt2ryn911CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4360bf8f7aaf7df0bfb9bba0e959b82b7d0ef08422e95a5b2074e03985bf4334",
+				"DiscoKey":   "discokey:480e78aa2c2d3cf3020ed2d8c39a8ffd574e201e8e56d2ff6d54cae121947044",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35829",
+					"10.65.0.27:35829",
+					"172.17.0.1:35829",
+					"172.19.0.1:35829",
+					"172.20.0.1:35829"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:34:08.806497751Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7114745634573595,
+				"StableID":   "nNAgRbJHZx11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4e109d06ad3ef6a3a937688201159d694d4a2880f045616e0a2299099969104",
+				"DiscoKey":   "discokey:98ab0fdfa6b6692f09484507e869de4e938ac4e5ca2f838b2fb456b9ee192b21",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:40692",
+					"10.65.0.27:40692",
+					"172.17.0.1:40692",
+					"172.19.0.1:40692",
+					"172.20.0.1:40692"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:34:09.338974089Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2882053099464165,
+				"StableID":   "neZoGaeHWP11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b078a77336b1d6e1241638676dc3f5a788db64fee6130ccb5c16af411ef0616c",
+				"KeyExpiry":  "2026-11-08T18:34:09Z",
+				"DiscoKey":   "discokey:8244df2d4a4b0f214a82958cb16caa087e7ad9ab07f2c7f37ce840f43289321e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43422",
+					"10.65.0.27:43422",
+					"172.17.0.1:43422",
+					"172.19.0.1:43422",
+					"172.20.0.1:43422"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:34:09.872005789Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4945122688476289,
+				"StableID":   "ntkoCHzecf11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:59bf1bde5cc5436bb8a217cc85b22ffd556ed8cc0effd27b596cf6c510762f2c",
+				"KeyExpiry":  "2026-11-08T18:34:10Z",
+				"DiscoKey":   "discokey:30a6c6071fef8521561db58d989f8f69a77d9b5a41d47af01c8e9809ef219243",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54883",
+					"10.65.0.27:54883",
+					"172.17.0.1:54883",
+					"172.19.0.1:54883",
+					"172.20.0.1:54883"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:34:10.412326737Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1543249583393063,
+				"StableID":   "nSgK5tYw3D11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f5328c3d98f667fa716c2e3078a330c20e835c370678e906aa6eeb947fa8db2c",
+				"KeyExpiry":  "2026-11-08T18:34:11Z",
+				"DiscoKey":   "discokey:a68516c729732c39f2d1ccfd587c7ad7921ac4a48b45b50503a00f6f2281861c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:46471",
+					"10.65.0.27:46471",
+					"172.17.0.1:46471",
+					"172.19.0.1:46471",
+					"172.20.0.1:46471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:34:11.18328066Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4439328582789959": {
+				"ID":          4439328582789959,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2882053099464165,
+				"StableID":   "neZoGaeHWP11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b078a77336b1d6e1241638676dc3f5a788db64fee6130ccb5c16af411ef0616c",
+				"KeyExpiry":  "2026-11-08T18:34:09Z",
+				"DiscoKey":   "discokey:8244df2d4a4b0f214a82958cb16caa087e7ad9ab07f2c7f37ce840f43289321e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43422",
+					"10.65.0.27:43422",
+					"172.17.0.1:43422",
+					"172.19.0.1:43422",
+					"172.20.0.1:43422"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:34:09.872005789Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b078a77336b1d6e1241638676dc3f5a788db64fee6130ccb5c16af411ef0616c",
+			"MachineKey": "mkey:f3403b8d64e5d11e77689c374bee2d08e465a4e4cc9d4ec2fac245ffb6897d7a",
+			"Peers": [{
+				"ID":         1022503236902628,
+				"StableID":   "nbLYeiR6z811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7971e8fb145a2c24201b1f3a8d324c6f84d34d51108ced31083b7945037f502",
+				"DiscoKey":   "discokey:b2f244c013b6bfe90a222534be986760343607b7ac142643850753f998c79227",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:41224",
+					"10.65.0.27:41224",
+					"172.17.0.1:41224",
+					"172.19.0.1:41224",
+					"172.20.0.1:41224"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:34:03.497685845Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8664957792496331,
+				"StableID":   "nS4QNPkNfA21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f05aa1de0102ff1818b0a21982be35047944fa5370360f47562896c88d918618",
+				"DiscoKey":   "discokey:451076ac784e15ee15e575c36ee956c35895f45df5db21bca16c6b2b0984824a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40453",
+					"10.65.0.27:40453",
+					"172.17.0.1:40453",
+					"172.19.0.1:40453",
+					"172.20.0.1:40453"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:34:04.003863683Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8235291227186960,
+				"StableID":   "nXvMKt8nJ721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae7c3fcacb00745d9f223ef9adf6c8ac66f9bc376c75dbc698299a3737327547",
+				"DiscoKey":   "discokey:0aa445872572f0accf0209866eedeeeace67c0f5aa6a2bd2daf31a3c8b28c910",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:49557",
+					"10.65.0.27:49557",
+					"172.17.0.1:49557",
+					"172.19.0.1:49557",
+					"172.20.0.1:49557"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:34:04.539409763Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8628004179095420,
+				"StableID":   "nVXU6H3eNA21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af82dd8733b5a319c76c68ba56c1b30e695445adbcf6f5e8bde557c09ae15b79",
+				"DiscoKey":   "discokey:f484aec42430b36c315eddfbbcca6edc4f8b3ff4afb12f523888659368138451",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45337",
+					"10.65.0.27:45337",
+					"172.17.0.1:45337",
+					"172.19.0.1:45337",
+					"172.20.0.1:45337"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:34:05.074221241Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6590867837531638,
+				"StableID":   "n9xHSUv1Ut11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b07c37318cc3aec00938db2817117b472bb6163c08716e84dfaa8d9267b37b32",
+				"DiscoKey":   "discokey:81b18fc56567fc8f4fcf35907d2edf91f2282b9a9b8e1b82a5e79900c4cd0821",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37862",
+					"10.65.0.27:37862",
+					"172.17.0.1:37862",
+					"172.19.0.1:37862",
+					"172.20.0.1:37862"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:34:05.611311706Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6282512707345114,
+				"StableID":   "nXueVRxM4r11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4fb6b80caba83f7bee0a74a527cd06ee3fa34d644599b2661cb936857669a3b",
+				"DiscoKey":   "discokey:f3501443371b5cc1db334be168dbde50db6c83c10f495b6337fa8694b1667445",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38866",
+					"10.65.0.27:38866",
+					"172.17.0.1:38866",
+					"172.19.0.1:38866",
+					"172.20.0.1:38866"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:34:06.140529217Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8624384377314642,
+				"StableID":   "nq6BcHxzLA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:948247711446f93b6a925fb7af24b9a1f4ec31a7f6e9b94ccbb2802bab17f97c",
+				"DiscoKey":   "discokey:6809b4aaa6f52d3c03772ec91e7d4439148e2e95f50870d89335925dfb9dc603",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50229",
+					"10.65.0.27:50229",
+					"172.17.0.1:50229",
+					"172.19.0.1:50229",
+					"172.20.0.1:50229"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:34:06.68292337Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4439328582789959,
+				"StableID":   "nEEV6ndafb11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03a511cfc1fb37f747f1e98f6e4ba40d18fbecafc21b2154ec8a849def9d736c",
+				"DiscoKey":   "discokey:a739bec3425689dad8fe6a2da36b163b1cdce535317be81e872d20d46811dc0b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48890",
+					"10.65.0.27:48890",
+					"172.17.0.1:48890",
+					"172.19.0.1:48890",
+					"172.20.0.1:48890"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:34:07.213221624Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         656941692479156,
+				"StableID":   "n3CrmAkX8611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:370de11ef28f539339bfef1ca0f5ebfdaea5c2f1019a96f38094bf6d3d493131",
+				"DiscoKey":   "discokey:678e6851568a4d9faea3c625bd3b4037bea0f989efed0ae529d68fa18fa42e1d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56057",
+					"10.65.0.27:56057",
+					"172.17.0.1:56057",
+					"172.19.0.1:56057",
+					"172.20.0.1:56057"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:34:07.735518321Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3631511856685615,
+				"StableID":   "nJWLFCfiMV11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cce483fe904609f3dd393a8b16b32befd95d164feac49fc6242c8fe9c1599265",
+				"DiscoKey":   "discokey:287d208a96d9e7506ae18ff60520103281af7c2831022945baeb2f7d84c1650f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58559",
+					"10.65.0.27:58559",
+					"172.17.0.1:58559",
+					"172.19.0.1:58559",
+					"172.20.0.1:58559"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:34:08.280233017Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1126027970937232,
+				"StableID":   "nmFdt2ryn911CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4360bf8f7aaf7df0bfb9bba0e959b82b7d0ef08422e95a5b2074e03985bf4334",
+				"DiscoKey":   "discokey:480e78aa2c2d3cf3020ed2d8c39a8ffd574e201e8e56d2ff6d54cae121947044",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35829",
+					"10.65.0.27:35829",
+					"172.17.0.1:35829",
+					"172.19.0.1:35829",
+					"172.20.0.1:35829"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:34:08.806497751Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7114745634573595,
+				"StableID":   "nNAgRbJHZx11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4e109d06ad3ef6a3a937688201159d694d4a2880f045616e0a2299099969104",
+				"DiscoKey":   "discokey:98ab0fdfa6b6692f09484507e869de4e938ac4e5ca2f838b2fb456b9ee192b21",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:40692",
+					"10.65.0.27:40692",
+					"172.17.0.1:40692",
+					"172.19.0.1:40692",
+					"172.20.0.1:40692"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:34:09.338974089Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4945122688476289,
+				"StableID":   "ntkoCHzecf11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:59bf1bde5cc5436bb8a217cc85b22ffd556ed8cc0effd27b596cf6c510762f2c",
+				"KeyExpiry":  "2026-11-08T18:34:10Z",
+				"DiscoKey":   "discokey:30a6c6071fef8521561db58d989f8f69a77d9b5a41d47af01c8e9809ef219243",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54883",
+					"10.65.0.27:54883",
+					"172.17.0.1:54883",
+					"172.19.0.1:54883",
+					"172.20.0.1:54883"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:34:10.412326737Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1543249583393063,
+				"StableID":   "nSgK5tYw3D11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f5328c3d98f667fa716c2e3078a330c20e835c370678e906aa6eeb947fa8db2c",
+				"KeyExpiry":  "2026-11-08T18:34:11Z",
+				"DiscoKey":   "discokey:a68516c729732c39f2d1ccfd587c7ad7921ac4a48b45b50503a00f6f2281861c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:46471",
+					"10.65.0.27:46471",
+					"172.17.0.1:46471",
+					"172.19.0.1:46471",
+					"172.20.0.1:46471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:34:11.18328066Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1126027970937232,
+				"StableID":   "nmFdt2ryn911CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1126027970937232,
+				"Key":        "nodekey:4360bf8f7aaf7df0bfb9bba0e959b82b7d0ef08422e95a5b2074e03985bf4334",
+				"DiscoKey":   "discokey:480e78aa2c2d3cf3020ed2d8c39a8ffd574e201e8e56d2ff6d54cae121947044",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35829",
+					"10.65.0.27:35829",
+					"172.17.0.1:35829",
+					"172.19.0.1:35829",
+					"172.20.0.1:35829"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:34:08.806497751Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4360bf8f7aaf7df0bfb9bba0e959b82b7d0ef08422e95a5b2074e03985bf4334",
+			"MachineKey": "mkey:b6e0d3b5e840e94ab34be9b9f1017f5d6d78ec827953c1f30b3296e2ec403367",
+			"Peers": [{
+				"ID":         1022503236902628,
+				"StableID":   "nbLYeiR6z811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7971e8fb145a2c24201b1f3a8d324c6f84d34d51108ced31083b7945037f502",
+				"DiscoKey":   "discokey:b2f244c013b6bfe90a222534be986760343607b7ac142643850753f998c79227",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:41224",
+					"10.65.0.27:41224",
+					"172.17.0.1:41224",
+					"172.19.0.1:41224",
+					"172.20.0.1:41224"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:34:03.497685845Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8664957792496331,
+				"StableID":   "nS4QNPkNfA21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f05aa1de0102ff1818b0a21982be35047944fa5370360f47562896c88d918618",
+				"DiscoKey":   "discokey:451076ac784e15ee15e575c36ee956c35895f45df5db21bca16c6b2b0984824a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40453",
+					"10.65.0.27:40453",
+					"172.17.0.1:40453",
+					"172.19.0.1:40453",
+					"172.20.0.1:40453"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:34:04.003863683Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8235291227186960,
+				"StableID":   "nXvMKt8nJ721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae7c3fcacb00745d9f223ef9adf6c8ac66f9bc376c75dbc698299a3737327547",
+				"DiscoKey":   "discokey:0aa445872572f0accf0209866eedeeeace67c0f5aa6a2bd2daf31a3c8b28c910",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:49557",
+					"10.65.0.27:49557",
+					"172.17.0.1:49557",
+					"172.19.0.1:49557",
+					"172.20.0.1:49557"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:34:04.539409763Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8628004179095420,
+				"StableID":   "nVXU6H3eNA21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af82dd8733b5a319c76c68ba56c1b30e695445adbcf6f5e8bde557c09ae15b79",
+				"DiscoKey":   "discokey:f484aec42430b36c315eddfbbcca6edc4f8b3ff4afb12f523888659368138451",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45337",
+					"10.65.0.27:45337",
+					"172.17.0.1:45337",
+					"172.19.0.1:45337",
+					"172.20.0.1:45337"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:34:05.074221241Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6590867837531638,
+				"StableID":   "n9xHSUv1Ut11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b07c37318cc3aec00938db2817117b472bb6163c08716e84dfaa8d9267b37b32",
+				"DiscoKey":   "discokey:81b18fc56567fc8f4fcf35907d2edf91f2282b9a9b8e1b82a5e79900c4cd0821",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37862",
+					"10.65.0.27:37862",
+					"172.17.0.1:37862",
+					"172.19.0.1:37862",
+					"172.20.0.1:37862"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:34:05.611311706Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6282512707345114,
+				"StableID":   "nXueVRxM4r11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4fb6b80caba83f7bee0a74a527cd06ee3fa34d644599b2661cb936857669a3b",
+				"DiscoKey":   "discokey:f3501443371b5cc1db334be168dbde50db6c83c10f495b6337fa8694b1667445",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38866",
+					"10.65.0.27:38866",
+					"172.17.0.1:38866",
+					"172.19.0.1:38866",
+					"172.20.0.1:38866"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:34:06.140529217Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8624384377314642,
+				"StableID":   "nq6BcHxzLA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:948247711446f93b6a925fb7af24b9a1f4ec31a7f6e9b94ccbb2802bab17f97c",
+				"DiscoKey":   "discokey:6809b4aaa6f52d3c03772ec91e7d4439148e2e95f50870d89335925dfb9dc603",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50229",
+					"10.65.0.27:50229",
+					"172.17.0.1:50229",
+					"172.19.0.1:50229",
+					"172.20.0.1:50229"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:34:06.68292337Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4439328582789959,
+				"StableID":   "nEEV6ndafb11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03a511cfc1fb37f747f1e98f6e4ba40d18fbecafc21b2154ec8a849def9d736c",
+				"DiscoKey":   "discokey:a739bec3425689dad8fe6a2da36b163b1cdce535317be81e872d20d46811dc0b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48890",
+					"10.65.0.27:48890",
+					"172.17.0.1:48890",
+					"172.19.0.1:48890",
+					"172.20.0.1:48890"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:34:07.213221624Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         656941692479156,
+				"StableID":   "n3CrmAkX8611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:370de11ef28f539339bfef1ca0f5ebfdaea5c2f1019a96f38094bf6d3d493131",
+				"DiscoKey":   "discokey:678e6851568a4d9faea3c625bd3b4037bea0f989efed0ae529d68fa18fa42e1d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56057",
+					"10.65.0.27:56057",
+					"172.17.0.1:56057",
+					"172.19.0.1:56057",
+					"172.20.0.1:56057"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:34:07.735518321Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3631511856685615,
+				"StableID":   "nJWLFCfiMV11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cce483fe904609f3dd393a8b16b32befd95d164feac49fc6242c8fe9c1599265",
+				"DiscoKey":   "discokey:287d208a96d9e7506ae18ff60520103281af7c2831022945baeb2f7d84c1650f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58559",
+					"10.65.0.27:58559",
+					"172.17.0.1:58559",
+					"172.19.0.1:58559",
+					"172.20.0.1:58559"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:34:08.280233017Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7114745634573595,
+				"StableID":   "nNAgRbJHZx11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4e109d06ad3ef6a3a937688201159d694d4a2880f045616e0a2299099969104",
+				"DiscoKey":   "discokey:98ab0fdfa6b6692f09484507e869de4e938ac4e5ca2f838b2fb456b9ee192b21",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:40692",
+					"10.65.0.27:40692",
+					"172.17.0.1:40692",
+					"172.19.0.1:40692",
+					"172.20.0.1:40692"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:34:09.338974089Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2882053099464165,
+				"StableID":   "neZoGaeHWP11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b078a77336b1d6e1241638676dc3f5a788db64fee6130ccb5c16af411ef0616c",
+				"KeyExpiry":  "2026-11-08T18:34:09Z",
+				"DiscoKey":   "discokey:8244df2d4a4b0f214a82958cb16caa087e7ad9ab07f2c7f37ce840f43289321e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43422",
+					"10.65.0.27:43422",
+					"172.17.0.1:43422",
+					"172.19.0.1:43422",
+					"172.20.0.1:43422"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:34:09.872005789Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4945122688476289,
+				"StableID":   "ntkoCHzecf11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:59bf1bde5cc5436bb8a217cc85b22ffd556ed8cc0effd27b596cf6c510762f2c",
+				"KeyExpiry":  "2026-11-08T18:34:10Z",
+				"DiscoKey":   "discokey:30a6c6071fef8521561db58d989f8f69a77d9b5a41d47af01c8e9809ef219243",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54883",
+					"10.65.0.27:54883",
+					"172.17.0.1:54883",
+					"172.19.0.1:54883",
+					"172.20.0.1:54883"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:34:10.412326737Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1543249583393063,
+				"StableID":   "nSgK5tYw3D11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f5328c3d98f667fa716c2e3078a330c20e835c370678e906aa6eeb947fa8db2c",
+				"KeyExpiry":  "2026-11-08T18:34:11Z",
+				"DiscoKey":   "discokey:a68516c729732c39f2d1ccfd587c7ad7921ac4a48b45b50503a00f6f2281861c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:46471",
+					"10.65.0.27:46471",
+					"172.17.0.1:46471",
+					"172.19.0.1:46471",
+					"172.20.0.1:46471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:34:11.18328066Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1126027970937232": {
+				"ID":          1126027970937232,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8664957792496331,
+				"StableID":   "nS4QNPkNfA21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       8664957792496331,
+				"Key":        "nodekey:f05aa1de0102ff1818b0a21982be35047944fa5370360f47562896c88d918618",
+				"DiscoKey":   "discokey:451076ac784e15ee15e575c36ee956c35895f45df5db21bca16c6b2b0984824a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40453",
+					"10.65.0.27:40453",
+					"172.17.0.1:40453",
+					"172.19.0.1:40453",
+					"172.20.0.1:40453"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:34:04.003863683Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f05aa1de0102ff1818b0a21982be35047944fa5370360f47562896c88d918618",
+			"MachineKey": "mkey:8768eeb13990defd7b101462bba23285ce8aae74889c7be1c25e9d35d440e30e",
+			"Peers": [{
+				"ID":         1022503236902628,
+				"StableID":   "nbLYeiR6z811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7971e8fb145a2c24201b1f3a8d324c6f84d34d51108ced31083b7945037f502",
+				"DiscoKey":   "discokey:b2f244c013b6bfe90a222534be986760343607b7ac142643850753f998c79227",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:41224",
+					"10.65.0.27:41224",
+					"172.17.0.1:41224",
+					"172.19.0.1:41224",
+					"172.20.0.1:41224"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:34:03.497685845Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8235291227186960,
+				"StableID":   "nXvMKt8nJ721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae7c3fcacb00745d9f223ef9adf6c8ac66f9bc376c75dbc698299a3737327547",
+				"DiscoKey":   "discokey:0aa445872572f0accf0209866eedeeeace67c0f5aa6a2bd2daf31a3c8b28c910",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:49557",
+					"10.65.0.27:49557",
+					"172.17.0.1:49557",
+					"172.19.0.1:49557",
+					"172.20.0.1:49557"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:34:04.539409763Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8628004179095420,
+				"StableID":   "nVXU6H3eNA21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af82dd8733b5a319c76c68ba56c1b30e695445adbcf6f5e8bde557c09ae15b79",
+				"DiscoKey":   "discokey:f484aec42430b36c315eddfbbcca6edc4f8b3ff4afb12f523888659368138451",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45337",
+					"10.65.0.27:45337",
+					"172.17.0.1:45337",
+					"172.19.0.1:45337",
+					"172.20.0.1:45337"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:34:05.074221241Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6590867837531638,
+				"StableID":   "n9xHSUv1Ut11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b07c37318cc3aec00938db2817117b472bb6163c08716e84dfaa8d9267b37b32",
+				"DiscoKey":   "discokey:81b18fc56567fc8f4fcf35907d2edf91f2282b9a9b8e1b82a5e79900c4cd0821",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37862",
+					"10.65.0.27:37862",
+					"172.17.0.1:37862",
+					"172.19.0.1:37862",
+					"172.20.0.1:37862"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:34:05.611311706Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6282512707345114,
+				"StableID":   "nXueVRxM4r11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4fb6b80caba83f7bee0a74a527cd06ee3fa34d644599b2661cb936857669a3b",
+				"DiscoKey":   "discokey:f3501443371b5cc1db334be168dbde50db6c83c10f495b6337fa8694b1667445",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38866",
+					"10.65.0.27:38866",
+					"172.17.0.1:38866",
+					"172.19.0.1:38866",
+					"172.20.0.1:38866"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:34:06.140529217Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8624384377314642,
+				"StableID":   "nq6BcHxzLA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:948247711446f93b6a925fb7af24b9a1f4ec31a7f6e9b94ccbb2802bab17f97c",
+				"DiscoKey":   "discokey:6809b4aaa6f52d3c03772ec91e7d4439148e2e95f50870d89335925dfb9dc603",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50229",
+					"10.65.0.27:50229",
+					"172.17.0.1:50229",
+					"172.19.0.1:50229",
+					"172.20.0.1:50229"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:34:06.68292337Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4439328582789959,
+				"StableID":   "nEEV6ndafb11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03a511cfc1fb37f747f1e98f6e4ba40d18fbecafc21b2154ec8a849def9d736c",
+				"DiscoKey":   "discokey:a739bec3425689dad8fe6a2da36b163b1cdce535317be81e872d20d46811dc0b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48890",
+					"10.65.0.27:48890",
+					"172.17.0.1:48890",
+					"172.19.0.1:48890",
+					"172.20.0.1:48890"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:34:07.213221624Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         656941692479156,
+				"StableID":   "n3CrmAkX8611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:370de11ef28f539339bfef1ca0f5ebfdaea5c2f1019a96f38094bf6d3d493131",
+				"DiscoKey":   "discokey:678e6851568a4d9faea3c625bd3b4037bea0f989efed0ae529d68fa18fa42e1d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56057",
+					"10.65.0.27:56057",
+					"172.17.0.1:56057",
+					"172.19.0.1:56057",
+					"172.20.0.1:56057"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:34:07.735518321Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3631511856685615,
+				"StableID":   "nJWLFCfiMV11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cce483fe904609f3dd393a8b16b32befd95d164feac49fc6242c8fe9c1599265",
+				"DiscoKey":   "discokey:287d208a96d9e7506ae18ff60520103281af7c2831022945baeb2f7d84c1650f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58559",
+					"10.65.0.27:58559",
+					"172.17.0.1:58559",
+					"172.19.0.1:58559",
+					"172.20.0.1:58559"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:34:08.280233017Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1126027970937232,
+				"StableID":   "nmFdt2ryn911CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4360bf8f7aaf7df0bfb9bba0e959b82b7d0ef08422e95a5b2074e03985bf4334",
+				"DiscoKey":   "discokey:480e78aa2c2d3cf3020ed2d8c39a8ffd574e201e8e56d2ff6d54cae121947044",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35829",
+					"10.65.0.27:35829",
+					"172.17.0.1:35829",
+					"172.19.0.1:35829",
+					"172.20.0.1:35829"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:34:08.806497751Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7114745634573595,
+				"StableID":   "nNAgRbJHZx11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4e109d06ad3ef6a3a937688201159d694d4a2880f045616e0a2299099969104",
+				"DiscoKey":   "discokey:98ab0fdfa6b6692f09484507e869de4e938ac4e5ca2f838b2fb456b9ee192b21",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:40692",
+					"10.65.0.27:40692",
+					"172.17.0.1:40692",
+					"172.19.0.1:40692",
+					"172.20.0.1:40692"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:34:09.338974089Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2882053099464165,
+				"StableID":   "neZoGaeHWP11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b078a77336b1d6e1241638676dc3f5a788db64fee6130ccb5c16af411ef0616c",
+				"KeyExpiry":  "2026-11-08T18:34:09Z",
+				"DiscoKey":   "discokey:8244df2d4a4b0f214a82958cb16caa087e7ad9ab07f2c7f37ce840f43289321e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43422",
+					"10.65.0.27:43422",
+					"172.17.0.1:43422",
+					"172.19.0.1:43422",
+					"172.20.0.1:43422"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:34:09.872005789Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4945122688476289,
+				"StableID":   "ntkoCHzecf11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:59bf1bde5cc5436bb8a217cc85b22ffd556ed8cc0effd27b596cf6c510762f2c",
+				"KeyExpiry":  "2026-11-08T18:34:10Z",
+				"DiscoKey":   "discokey:30a6c6071fef8521561db58d989f8f69a77d9b5a41d47af01c8e9809ef219243",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54883",
+					"10.65.0.27:54883",
+					"172.17.0.1:54883",
+					"172.19.0.1:54883",
+					"172.20.0.1:54883"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:34:10.412326737Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1543249583393063,
+				"StableID":   "nSgK5tYw3D11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f5328c3d98f667fa716c2e3078a330c20e835c370678e906aa6eeb947fa8db2c",
+				"KeyExpiry":  "2026-11-08T18:34:11Z",
+				"DiscoKey":   "discokey:a68516c729732c39f2d1ccfd587c7ad7921ac4a48b45b50503a00f6f2281861c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:46471",
+					"10.65.0.27:46471",
+					"172.17.0.1:46471",
+					"172.19.0.1:46471",
+					"172.20.0.1:46471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:34:11.18328066Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8664957792496331": {
+				"ID":          8664957792496331,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1022503236902628,
+				"StableID":   "nbLYeiR6z811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1022503236902628,
+				"Key":        "nodekey:e7971e8fb145a2c24201b1f3a8d324c6f84d34d51108ced31083b7945037f502",
+				"DiscoKey":   "discokey:b2f244c013b6bfe90a222534be986760343607b7ac142643850753f998c79227",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:41224",
+					"10.65.0.27:41224",
+					"172.17.0.1:41224",
+					"172.19.0.1:41224",
+					"172.20.0.1:41224"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:34:03.497685845Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e7971e8fb145a2c24201b1f3a8d324c6f84d34d51108ced31083b7945037f502",
+			"MachineKey": "mkey:18773c1be7f508f22b46ee2c219065bd7076d6e383c3366c1ea43d526be9b50e",
+			"Peers": [{
+				"ID":         8664957792496331,
+				"StableID":   "nS4QNPkNfA21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f05aa1de0102ff1818b0a21982be35047944fa5370360f47562896c88d918618",
+				"DiscoKey":   "discokey:451076ac784e15ee15e575c36ee956c35895f45df5db21bca16c6b2b0984824a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40453",
+					"10.65.0.27:40453",
+					"172.17.0.1:40453",
+					"172.19.0.1:40453",
+					"172.20.0.1:40453"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:34:04.003863683Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8235291227186960,
+				"StableID":   "nXvMKt8nJ721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae7c3fcacb00745d9f223ef9adf6c8ac66f9bc376c75dbc698299a3737327547",
+				"DiscoKey":   "discokey:0aa445872572f0accf0209866eedeeeace67c0f5aa6a2bd2daf31a3c8b28c910",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:49557",
+					"10.65.0.27:49557",
+					"172.17.0.1:49557",
+					"172.19.0.1:49557",
+					"172.20.0.1:49557"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:34:04.539409763Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8628004179095420,
+				"StableID":   "nVXU6H3eNA21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af82dd8733b5a319c76c68ba56c1b30e695445adbcf6f5e8bde557c09ae15b79",
+				"DiscoKey":   "discokey:f484aec42430b36c315eddfbbcca6edc4f8b3ff4afb12f523888659368138451",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45337",
+					"10.65.0.27:45337",
+					"172.17.0.1:45337",
+					"172.19.0.1:45337",
+					"172.20.0.1:45337"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:34:05.074221241Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6590867837531638,
+				"StableID":   "n9xHSUv1Ut11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b07c37318cc3aec00938db2817117b472bb6163c08716e84dfaa8d9267b37b32",
+				"DiscoKey":   "discokey:81b18fc56567fc8f4fcf35907d2edf91f2282b9a9b8e1b82a5e79900c4cd0821",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37862",
+					"10.65.0.27:37862",
+					"172.17.0.1:37862",
+					"172.19.0.1:37862",
+					"172.20.0.1:37862"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:34:05.611311706Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6282512707345114,
+				"StableID":   "nXueVRxM4r11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4fb6b80caba83f7bee0a74a527cd06ee3fa34d644599b2661cb936857669a3b",
+				"DiscoKey":   "discokey:f3501443371b5cc1db334be168dbde50db6c83c10f495b6337fa8694b1667445",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38866",
+					"10.65.0.27:38866",
+					"172.17.0.1:38866",
+					"172.19.0.1:38866",
+					"172.20.0.1:38866"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:34:06.140529217Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8624384377314642,
+				"StableID":   "nq6BcHxzLA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:948247711446f93b6a925fb7af24b9a1f4ec31a7f6e9b94ccbb2802bab17f97c",
+				"DiscoKey":   "discokey:6809b4aaa6f52d3c03772ec91e7d4439148e2e95f50870d89335925dfb9dc603",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50229",
+					"10.65.0.27:50229",
+					"172.17.0.1:50229",
+					"172.19.0.1:50229",
+					"172.20.0.1:50229"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:34:06.68292337Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4439328582789959,
+				"StableID":   "nEEV6ndafb11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03a511cfc1fb37f747f1e98f6e4ba40d18fbecafc21b2154ec8a849def9d736c",
+				"DiscoKey":   "discokey:a739bec3425689dad8fe6a2da36b163b1cdce535317be81e872d20d46811dc0b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48890",
+					"10.65.0.27:48890",
+					"172.17.0.1:48890",
+					"172.19.0.1:48890",
+					"172.20.0.1:48890"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:34:07.213221624Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         656941692479156,
+				"StableID":   "n3CrmAkX8611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:370de11ef28f539339bfef1ca0f5ebfdaea5c2f1019a96f38094bf6d3d493131",
+				"DiscoKey":   "discokey:678e6851568a4d9faea3c625bd3b4037bea0f989efed0ae529d68fa18fa42e1d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56057",
+					"10.65.0.27:56057",
+					"172.17.0.1:56057",
+					"172.19.0.1:56057",
+					"172.20.0.1:56057"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:34:07.735518321Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3631511856685615,
+				"StableID":   "nJWLFCfiMV11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cce483fe904609f3dd393a8b16b32befd95d164feac49fc6242c8fe9c1599265",
+				"DiscoKey":   "discokey:287d208a96d9e7506ae18ff60520103281af7c2831022945baeb2f7d84c1650f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58559",
+					"10.65.0.27:58559",
+					"172.17.0.1:58559",
+					"172.19.0.1:58559",
+					"172.20.0.1:58559"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:34:08.280233017Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1126027970937232,
+				"StableID":   "nmFdt2ryn911CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4360bf8f7aaf7df0bfb9bba0e959b82b7d0ef08422e95a5b2074e03985bf4334",
+				"DiscoKey":   "discokey:480e78aa2c2d3cf3020ed2d8c39a8ffd574e201e8e56d2ff6d54cae121947044",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35829",
+					"10.65.0.27:35829",
+					"172.17.0.1:35829",
+					"172.19.0.1:35829",
+					"172.20.0.1:35829"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:34:08.806497751Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7114745634573595,
+				"StableID":   "nNAgRbJHZx11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4e109d06ad3ef6a3a937688201159d694d4a2880f045616e0a2299099969104",
+				"DiscoKey":   "discokey:98ab0fdfa6b6692f09484507e869de4e938ac4e5ca2f838b2fb456b9ee192b21",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:40692",
+					"10.65.0.27:40692",
+					"172.17.0.1:40692",
+					"172.19.0.1:40692",
+					"172.20.0.1:40692"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:34:09.338974089Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2882053099464165,
+				"StableID":   "neZoGaeHWP11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b078a77336b1d6e1241638676dc3f5a788db64fee6130ccb5c16af411ef0616c",
+				"KeyExpiry":  "2026-11-08T18:34:09Z",
+				"DiscoKey":   "discokey:8244df2d4a4b0f214a82958cb16caa087e7ad9ab07f2c7f37ce840f43289321e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43422",
+					"10.65.0.27:43422",
+					"172.17.0.1:43422",
+					"172.19.0.1:43422",
+					"172.20.0.1:43422"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:34:09.872005789Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4945122688476289,
+				"StableID":   "ntkoCHzecf11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:59bf1bde5cc5436bb8a217cc85b22ffd556ed8cc0effd27b596cf6c510762f2c",
+				"KeyExpiry":  "2026-11-08T18:34:10Z",
+				"DiscoKey":   "discokey:30a6c6071fef8521561db58d989f8f69a77d9b5a41d47af01c8e9809ef219243",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54883",
+					"10.65.0.27:54883",
+					"172.17.0.1:54883",
+					"172.19.0.1:54883",
+					"172.20.0.1:54883"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:34:10.412326737Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1543249583393063,
+				"StableID":   "nSgK5tYw3D11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f5328c3d98f667fa716c2e3078a330c20e835c370678e906aa6eeb947fa8db2c",
+				"KeyExpiry":  "2026-11-08T18:34:11Z",
+				"DiscoKey":   "discokey:a68516c729732c39f2d1ccfd587c7ad7921ac4a48b45b50503a00f6f2281861c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:46471",
+					"10.65.0.27:46471",
+					"172.17.0.1:46471",
+					"172.19.0.1:46471",
+					"172.20.0.1:46471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:34:11.18328066Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1022503236902628": {
+				"ID":          1022503236902628,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}, "1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6590867837531638,
+				"StableID":   "n9xHSUv1Ut11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       6590867837531638,
+				"Key":        "nodekey:b07c37318cc3aec00938db2817117b472bb6163c08716e84dfaa8d9267b37b32",
+				"DiscoKey":   "discokey:81b18fc56567fc8f4fcf35907d2edf91f2282b9a9b8e1b82a5e79900c4cd0821",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37862",
+					"10.65.0.27:37862",
+					"172.17.0.1:37862",
+					"172.19.0.1:37862",
+					"172.20.0.1:37862"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:34:05.611311706Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b07c37318cc3aec00938db2817117b472bb6163c08716e84dfaa8d9267b37b32",
+			"MachineKey": "mkey:dcb7a5be49a180d71be7cee31c9137c0e4c526d8cff81f544382055f40f96433",
+			"Peers": [{
+				"ID":         1022503236902628,
+				"StableID":   "nbLYeiR6z811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7971e8fb145a2c24201b1f3a8d324c6f84d34d51108ced31083b7945037f502",
+				"DiscoKey":   "discokey:b2f244c013b6bfe90a222534be986760343607b7ac142643850753f998c79227",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:41224",
+					"10.65.0.27:41224",
+					"172.17.0.1:41224",
+					"172.19.0.1:41224",
+					"172.20.0.1:41224"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:34:03.497685845Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8664957792496331,
+				"StableID":   "nS4QNPkNfA21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f05aa1de0102ff1818b0a21982be35047944fa5370360f47562896c88d918618",
+				"DiscoKey":   "discokey:451076ac784e15ee15e575c36ee956c35895f45df5db21bca16c6b2b0984824a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40453",
+					"10.65.0.27:40453",
+					"172.17.0.1:40453",
+					"172.19.0.1:40453",
+					"172.20.0.1:40453"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:34:04.003863683Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8235291227186960,
+				"StableID":   "nXvMKt8nJ721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae7c3fcacb00745d9f223ef9adf6c8ac66f9bc376c75dbc698299a3737327547",
+				"DiscoKey":   "discokey:0aa445872572f0accf0209866eedeeeace67c0f5aa6a2bd2daf31a3c8b28c910",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:49557",
+					"10.65.0.27:49557",
+					"172.17.0.1:49557",
+					"172.19.0.1:49557",
+					"172.20.0.1:49557"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:34:04.539409763Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8628004179095420,
+				"StableID":   "nVXU6H3eNA21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af82dd8733b5a319c76c68ba56c1b30e695445adbcf6f5e8bde557c09ae15b79",
+				"DiscoKey":   "discokey:f484aec42430b36c315eddfbbcca6edc4f8b3ff4afb12f523888659368138451",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45337",
+					"10.65.0.27:45337",
+					"172.17.0.1:45337",
+					"172.19.0.1:45337",
+					"172.20.0.1:45337"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:34:05.074221241Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6282512707345114,
+				"StableID":   "nXueVRxM4r11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4fb6b80caba83f7bee0a74a527cd06ee3fa34d644599b2661cb936857669a3b",
+				"DiscoKey":   "discokey:f3501443371b5cc1db334be168dbde50db6c83c10f495b6337fa8694b1667445",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38866",
+					"10.65.0.27:38866",
+					"172.17.0.1:38866",
+					"172.19.0.1:38866",
+					"172.20.0.1:38866"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:34:06.140529217Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8624384377314642,
+				"StableID":   "nq6BcHxzLA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:948247711446f93b6a925fb7af24b9a1f4ec31a7f6e9b94ccbb2802bab17f97c",
+				"DiscoKey":   "discokey:6809b4aaa6f52d3c03772ec91e7d4439148e2e95f50870d89335925dfb9dc603",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50229",
+					"10.65.0.27:50229",
+					"172.17.0.1:50229",
+					"172.19.0.1:50229",
+					"172.20.0.1:50229"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:34:06.68292337Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4439328582789959,
+				"StableID":   "nEEV6ndafb11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03a511cfc1fb37f747f1e98f6e4ba40d18fbecafc21b2154ec8a849def9d736c",
+				"DiscoKey":   "discokey:a739bec3425689dad8fe6a2da36b163b1cdce535317be81e872d20d46811dc0b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48890",
+					"10.65.0.27:48890",
+					"172.17.0.1:48890",
+					"172.19.0.1:48890",
+					"172.20.0.1:48890"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:34:07.213221624Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         656941692479156,
+				"StableID":   "n3CrmAkX8611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:370de11ef28f539339bfef1ca0f5ebfdaea5c2f1019a96f38094bf6d3d493131",
+				"DiscoKey":   "discokey:678e6851568a4d9faea3c625bd3b4037bea0f989efed0ae529d68fa18fa42e1d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56057",
+					"10.65.0.27:56057",
+					"172.17.0.1:56057",
+					"172.19.0.1:56057",
+					"172.20.0.1:56057"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:34:07.735518321Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3631511856685615,
+				"StableID":   "nJWLFCfiMV11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cce483fe904609f3dd393a8b16b32befd95d164feac49fc6242c8fe9c1599265",
+				"DiscoKey":   "discokey:287d208a96d9e7506ae18ff60520103281af7c2831022945baeb2f7d84c1650f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58559",
+					"10.65.0.27:58559",
+					"172.17.0.1:58559",
+					"172.19.0.1:58559",
+					"172.20.0.1:58559"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:34:08.280233017Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1126027970937232,
+				"StableID":   "nmFdt2ryn911CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4360bf8f7aaf7df0bfb9bba0e959b82b7d0ef08422e95a5b2074e03985bf4334",
+				"DiscoKey":   "discokey:480e78aa2c2d3cf3020ed2d8c39a8ffd574e201e8e56d2ff6d54cae121947044",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35829",
+					"10.65.0.27:35829",
+					"172.17.0.1:35829",
+					"172.19.0.1:35829",
+					"172.20.0.1:35829"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:34:08.806497751Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7114745634573595,
+				"StableID":   "nNAgRbJHZx11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4e109d06ad3ef6a3a937688201159d694d4a2880f045616e0a2299099969104",
+				"DiscoKey":   "discokey:98ab0fdfa6b6692f09484507e869de4e938ac4e5ca2f838b2fb456b9ee192b21",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:40692",
+					"10.65.0.27:40692",
+					"172.17.0.1:40692",
+					"172.19.0.1:40692",
+					"172.20.0.1:40692"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:34:09.338974089Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2882053099464165,
+				"StableID":   "neZoGaeHWP11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b078a77336b1d6e1241638676dc3f5a788db64fee6130ccb5c16af411ef0616c",
+				"KeyExpiry":  "2026-11-08T18:34:09Z",
+				"DiscoKey":   "discokey:8244df2d4a4b0f214a82958cb16caa087e7ad9ab07f2c7f37ce840f43289321e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43422",
+					"10.65.0.27:43422",
+					"172.17.0.1:43422",
+					"172.19.0.1:43422",
+					"172.20.0.1:43422"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:34:09.872005789Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4945122688476289,
+				"StableID":   "ntkoCHzecf11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:59bf1bde5cc5436bb8a217cc85b22ffd556ed8cc0effd27b596cf6c510762f2c",
+				"KeyExpiry":  "2026-11-08T18:34:10Z",
+				"DiscoKey":   "discokey:30a6c6071fef8521561db58d989f8f69a77d9b5a41d47af01c8e9809ef219243",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54883",
+					"10.65.0.27:54883",
+					"172.17.0.1:54883",
+					"172.19.0.1:54883",
+					"172.20.0.1:54883"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:34:10.412326737Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1543249583393063,
+				"StableID":   "nSgK5tYw3D11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f5328c3d98f667fa716c2e3078a330c20e835c370678e906aa6eeb947fa8db2c",
+				"KeyExpiry":  "2026-11-08T18:34:11Z",
+				"DiscoKey":   "discokey:a68516c729732c39f2d1ccfd587c7ad7921ac4a48b45b50503a00f6f2281861c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:46471",
+					"10.65.0.27:46471",
+					"172.17.0.1:46471",
+					"172.19.0.1:46471",
+					"172.20.0.1:46471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:34:11.18328066Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6590867837531638": {
+				"ID":          6590867837531638,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8628004179095420,
+				"StableID":   "nVXU6H3eNA21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       8628004179095420,
+				"Key":        "nodekey:af82dd8733b5a319c76c68ba56c1b30e695445adbcf6f5e8bde557c09ae15b79",
+				"DiscoKey":   "discokey:f484aec42430b36c315eddfbbcca6edc4f8b3ff4afb12f523888659368138451",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45337",
+					"10.65.0.27:45337",
+					"172.17.0.1:45337",
+					"172.19.0.1:45337",
+					"172.20.0.1:45337"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:34:05.074221241Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:af82dd8733b5a319c76c68ba56c1b30e695445adbcf6f5e8bde557c09ae15b79",
+			"MachineKey": "mkey:c06667f6c21755ab35664e1cc2e8d3c33551c085679aca4374276fda9cfd3319",
+			"Peers": [{
+				"ID":         1022503236902628,
+				"StableID":   "nbLYeiR6z811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7971e8fb145a2c24201b1f3a8d324c6f84d34d51108ced31083b7945037f502",
+				"DiscoKey":   "discokey:b2f244c013b6bfe90a222534be986760343607b7ac142643850753f998c79227",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:41224",
+					"10.65.0.27:41224",
+					"172.17.0.1:41224",
+					"172.19.0.1:41224",
+					"172.20.0.1:41224"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:34:03.497685845Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8664957792496331,
+				"StableID":   "nS4QNPkNfA21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f05aa1de0102ff1818b0a21982be35047944fa5370360f47562896c88d918618",
+				"DiscoKey":   "discokey:451076ac784e15ee15e575c36ee956c35895f45df5db21bca16c6b2b0984824a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40453",
+					"10.65.0.27:40453",
+					"172.17.0.1:40453",
+					"172.19.0.1:40453",
+					"172.20.0.1:40453"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:34:04.003863683Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8235291227186960,
+				"StableID":   "nXvMKt8nJ721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae7c3fcacb00745d9f223ef9adf6c8ac66f9bc376c75dbc698299a3737327547",
+				"DiscoKey":   "discokey:0aa445872572f0accf0209866eedeeeace67c0f5aa6a2bd2daf31a3c8b28c910",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:49557",
+					"10.65.0.27:49557",
+					"172.17.0.1:49557",
+					"172.19.0.1:49557",
+					"172.20.0.1:49557"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:34:04.539409763Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6590867837531638,
+				"StableID":   "n9xHSUv1Ut11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b07c37318cc3aec00938db2817117b472bb6163c08716e84dfaa8d9267b37b32",
+				"DiscoKey":   "discokey:81b18fc56567fc8f4fcf35907d2edf91f2282b9a9b8e1b82a5e79900c4cd0821",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37862",
+					"10.65.0.27:37862",
+					"172.17.0.1:37862",
+					"172.19.0.1:37862",
+					"172.20.0.1:37862"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:34:05.611311706Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6282512707345114,
+				"StableID":   "nXueVRxM4r11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4fb6b80caba83f7bee0a74a527cd06ee3fa34d644599b2661cb936857669a3b",
+				"DiscoKey":   "discokey:f3501443371b5cc1db334be168dbde50db6c83c10f495b6337fa8694b1667445",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38866",
+					"10.65.0.27:38866",
+					"172.17.0.1:38866",
+					"172.19.0.1:38866",
+					"172.20.0.1:38866"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:34:06.140529217Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8624384377314642,
+				"StableID":   "nq6BcHxzLA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:948247711446f93b6a925fb7af24b9a1f4ec31a7f6e9b94ccbb2802bab17f97c",
+				"DiscoKey":   "discokey:6809b4aaa6f52d3c03772ec91e7d4439148e2e95f50870d89335925dfb9dc603",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50229",
+					"10.65.0.27:50229",
+					"172.17.0.1:50229",
+					"172.19.0.1:50229",
+					"172.20.0.1:50229"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:34:06.68292337Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4439328582789959,
+				"StableID":   "nEEV6ndafb11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03a511cfc1fb37f747f1e98f6e4ba40d18fbecafc21b2154ec8a849def9d736c",
+				"DiscoKey":   "discokey:a739bec3425689dad8fe6a2da36b163b1cdce535317be81e872d20d46811dc0b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48890",
+					"10.65.0.27:48890",
+					"172.17.0.1:48890",
+					"172.19.0.1:48890",
+					"172.20.0.1:48890"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:34:07.213221624Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         656941692479156,
+				"StableID":   "n3CrmAkX8611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:370de11ef28f539339bfef1ca0f5ebfdaea5c2f1019a96f38094bf6d3d493131",
+				"DiscoKey":   "discokey:678e6851568a4d9faea3c625bd3b4037bea0f989efed0ae529d68fa18fa42e1d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56057",
+					"10.65.0.27:56057",
+					"172.17.0.1:56057",
+					"172.19.0.1:56057",
+					"172.20.0.1:56057"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:34:07.735518321Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3631511856685615,
+				"StableID":   "nJWLFCfiMV11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cce483fe904609f3dd393a8b16b32befd95d164feac49fc6242c8fe9c1599265",
+				"DiscoKey":   "discokey:287d208a96d9e7506ae18ff60520103281af7c2831022945baeb2f7d84c1650f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58559",
+					"10.65.0.27:58559",
+					"172.17.0.1:58559",
+					"172.19.0.1:58559",
+					"172.20.0.1:58559"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:34:08.280233017Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1126027970937232,
+				"StableID":   "nmFdt2ryn911CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4360bf8f7aaf7df0bfb9bba0e959b82b7d0ef08422e95a5b2074e03985bf4334",
+				"DiscoKey":   "discokey:480e78aa2c2d3cf3020ed2d8c39a8ffd574e201e8e56d2ff6d54cae121947044",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35829",
+					"10.65.0.27:35829",
+					"172.17.0.1:35829",
+					"172.19.0.1:35829",
+					"172.20.0.1:35829"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:34:08.806497751Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7114745634573595,
+				"StableID":   "nNAgRbJHZx11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4e109d06ad3ef6a3a937688201159d694d4a2880f045616e0a2299099969104",
+				"DiscoKey":   "discokey:98ab0fdfa6b6692f09484507e869de4e938ac4e5ca2f838b2fb456b9ee192b21",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:40692",
+					"10.65.0.27:40692",
+					"172.17.0.1:40692",
+					"172.19.0.1:40692",
+					"172.20.0.1:40692"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:34:09.338974089Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2882053099464165,
+				"StableID":   "neZoGaeHWP11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b078a77336b1d6e1241638676dc3f5a788db64fee6130ccb5c16af411ef0616c",
+				"KeyExpiry":  "2026-11-08T18:34:09Z",
+				"DiscoKey":   "discokey:8244df2d4a4b0f214a82958cb16caa087e7ad9ab07f2c7f37ce840f43289321e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43422",
+					"10.65.0.27:43422",
+					"172.17.0.1:43422",
+					"172.19.0.1:43422",
+					"172.20.0.1:43422"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:34:09.872005789Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4945122688476289,
+				"StableID":   "ntkoCHzecf11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:59bf1bde5cc5436bb8a217cc85b22ffd556ed8cc0effd27b596cf6c510762f2c",
+				"KeyExpiry":  "2026-11-08T18:34:10Z",
+				"DiscoKey":   "discokey:30a6c6071fef8521561db58d989f8f69a77d9b5a41d47af01c8e9809ef219243",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54883",
+					"10.65.0.27:54883",
+					"172.17.0.1:54883",
+					"172.19.0.1:54883",
+					"172.20.0.1:54883"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:34:10.412326737Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1543249583393063,
+				"StableID":   "nSgK5tYw3D11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f5328c3d98f667fa716c2e3078a330c20e835c370678e906aa6eeb947fa8db2c",
+				"KeyExpiry":  "2026-11-08T18:34:11Z",
+				"DiscoKey":   "discokey:a68516c729732c39f2d1ccfd587c7ad7921ac4a48b45b50503a00f6f2281861c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:46471",
+					"10.65.0.27:46471",
+					"172.17.0.1:46471",
+					"172.19.0.1:46471",
+					"172.20.0.1:46471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:34:11.18328066Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8628004179095420": {
+				"ID":          8628004179095420,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8624384377314642,
+				"StableID":   "nq6BcHxzLA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       8624384377314642,
+				"Key":        "nodekey:948247711446f93b6a925fb7af24b9a1f4ec31a7f6e9b94ccbb2802bab17f97c",
+				"DiscoKey":   "discokey:6809b4aaa6f52d3c03772ec91e7d4439148e2e95f50870d89335925dfb9dc603",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50229",
+					"10.65.0.27:50229",
+					"172.17.0.1:50229",
+					"172.19.0.1:50229",
+					"172.20.0.1:50229"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:34:06.68292337Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:948247711446f93b6a925fb7af24b9a1f4ec31a7f6e9b94ccbb2802bab17f97c",
+			"MachineKey": "mkey:104c0b654852910008241e2580588eebe7539090fed010b0898644fd2c53b325",
+			"Peers": [{
+				"ID":         1022503236902628,
+				"StableID":   "nbLYeiR6z811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7971e8fb145a2c24201b1f3a8d324c6f84d34d51108ced31083b7945037f502",
+				"DiscoKey":   "discokey:b2f244c013b6bfe90a222534be986760343607b7ac142643850753f998c79227",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:41224",
+					"10.65.0.27:41224",
+					"172.17.0.1:41224",
+					"172.19.0.1:41224",
+					"172.20.0.1:41224"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:34:03.497685845Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8664957792496331,
+				"StableID":   "nS4QNPkNfA21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f05aa1de0102ff1818b0a21982be35047944fa5370360f47562896c88d918618",
+				"DiscoKey":   "discokey:451076ac784e15ee15e575c36ee956c35895f45df5db21bca16c6b2b0984824a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40453",
+					"10.65.0.27:40453",
+					"172.17.0.1:40453",
+					"172.19.0.1:40453",
+					"172.20.0.1:40453"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:34:04.003863683Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8235291227186960,
+				"StableID":   "nXvMKt8nJ721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae7c3fcacb00745d9f223ef9adf6c8ac66f9bc376c75dbc698299a3737327547",
+				"DiscoKey":   "discokey:0aa445872572f0accf0209866eedeeeace67c0f5aa6a2bd2daf31a3c8b28c910",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:49557",
+					"10.65.0.27:49557",
+					"172.17.0.1:49557",
+					"172.19.0.1:49557",
+					"172.20.0.1:49557"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:34:04.539409763Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8628004179095420,
+				"StableID":   "nVXU6H3eNA21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af82dd8733b5a319c76c68ba56c1b30e695445adbcf6f5e8bde557c09ae15b79",
+				"DiscoKey":   "discokey:f484aec42430b36c315eddfbbcca6edc4f8b3ff4afb12f523888659368138451",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45337",
+					"10.65.0.27:45337",
+					"172.17.0.1:45337",
+					"172.19.0.1:45337",
+					"172.20.0.1:45337"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:34:05.074221241Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6590867837531638,
+				"StableID":   "n9xHSUv1Ut11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b07c37318cc3aec00938db2817117b472bb6163c08716e84dfaa8d9267b37b32",
+				"DiscoKey":   "discokey:81b18fc56567fc8f4fcf35907d2edf91f2282b9a9b8e1b82a5e79900c4cd0821",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37862",
+					"10.65.0.27:37862",
+					"172.17.0.1:37862",
+					"172.19.0.1:37862",
+					"172.20.0.1:37862"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:34:05.611311706Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6282512707345114,
+				"StableID":   "nXueVRxM4r11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4fb6b80caba83f7bee0a74a527cd06ee3fa34d644599b2661cb936857669a3b",
+				"DiscoKey":   "discokey:f3501443371b5cc1db334be168dbde50db6c83c10f495b6337fa8694b1667445",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38866",
+					"10.65.0.27:38866",
+					"172.17.0.1:38866",
+					"172.19.0.1:38866",
+					"172.20.0.1:38866"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:34:06.140529217Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4439328582789959,
+				"StableID":   "nEEV6ndafb11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03a511cfc1fb37f747f1e98f6e4ba40d18fbecafc21b2154ec8a849def9d736c",
+				"DiscoKey":   "discokey:a739bec3425689dad8fe6a2da36b163b1cdce535317be81e872d20d46811dc0b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48890",
+					"10.65.0.27:48890",
+					"172.17.0.1:48890",
+					"172.19.0.1:48890",
+					"172.20.0.1:48890"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:34:07.213221624Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         656941692479156,
+				"StableID":   "n3CrmAkX8611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:370de11ef28f539339bfef1ca0f5ebfdaea5c2f1019a96f38094bf6d3d493131",
+				"DiscoKey":   "discokey:678e6851568a4d9faea3c625bd3b4037bea0f989efed0ae529d68fa18fa42e1d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56057",
+					"10.65.0.27:56057",
+					"172.17.0.1:56057",
+					"172.19.0.1:56057",
+					"172.20.0.1:56057"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:34:07.735518321Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3631511856685615,
+				"StableID":   "nJWLFCfiMV11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cce483fe904609f3dd393a8b16b32befd95d164feac49fc6242c8fe9c1599265",
+				"DiscoKey":   "discokey:287d208a96d9e7506ae18ff60520103281af7c2831022945baeb2f7d84c1650f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58559",
+					"10.65.0.27:58559",
+					"172.17.0.1:58559",
+					"172.19.0.1:58559",
+					"172.20.0.1:58559"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:34:08.280233017Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1126027970937232,
+				"StableID":   "nmFdt2ryn911CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4360bf8f7aaf7df0bfb9bba0e959b82b7d0ef08422e95a5b2074e03985bf4334",
+				"DiscoKey":   "discokey:480e78aa2c2d3cf3020ed2d8c39a8ffd574e201e8e56d2ff6d54cae121947044",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35829",
+					"10.65.0.27:35829",
+					"172.17.0.1:35829",
+					"172.19.0.1:35829",
+					"172.20.0.1:35829"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:34:08.806497751Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7114745634573595,
+				"StableID":   "nNAgRbJHZx11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4e109d06ad3ef6a3a937688201159d694d4a2880f045616e0a2299099969104",
+				"DiscoKey":   "discokey:98ab0fdfa6b6692f09484507e869de4e938ac4e5ca2f838b2fb456b9ee192b21",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:40692",
+					"10.65.0.27:40692",
+					"172.17.0.1:40692",
+					"172.19.0.1:40692",
+					"172.20.0.1:40692"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:34:09.338974089Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2882053099464165,
+				"StableID":   "neZoGaeHWP11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b078a77336b1d6e1241638676dc3f5a788db64fee6130ccb5c16af411ef0616c",
+				"KeyExpiry":  "2026-11-08T18:34:09Z",
+				"DiscoKey":   "discokey:8244df2d4a4b0f214a82958cb16caa087e7ad9ab07f2c7f37ce840f43289321e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43422",
+					"10.65.0.27:43422",
+					"172.17.0.1:43422",
+					"172.19.0.1:43422",
+					"172.20.0.1:43422"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:34:09.872005789Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4945122688476289,
+				"StableID":   "ntkoCHzecf11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:59bf1bde5cc5436bb8a217cc85b22ffd556ed8cc0effd27b596cf6c510762f2c",
+				"KeyExpiry":  "2026-11-08T18:34:10Z",
+				"DiscoKey":   "discokey:30a6c6071fef8521561db58d989f8f69a77d9b5a41d47af01c8e9809ef219243",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54883",
+					"10.65.0.27:54883",
+					"172.17.0.1:54883",
+					"172.19.0.1:54883",
+					"172.20.0.1:54883"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:34:10.412326737Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1543249583393063,
+				"StableID":   "nSgK5tYw3D11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f5328c3d98f667fa716c2e3078a330c20e835c370678e906aa6eeb947fa8db2c",
+				"KeyExpiry":  "2026-11-08T18:34:11Z",
+				"DiscoKey":   "discokey:a68516c729732c39f2d1ccfd587c7ad7921ac4a48b45b50503a00f6f2281861c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:46471",
+					"10.65.0.27:46471",
+					"172.17.0.1:46471",
+					"172.19.0.1:46471",
+					"172.20.0.1:46471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:34:11.18328066Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8624384377314642": {
+				"ID":          8624384377314642,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         656941692479156,
+				"StableID":   "n3CrmAkX8611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       656941692479156,
+				"Key":        "nodekey:370de11ef28f539339bfef1ca0f5ebfdaea5c2f1019a96f38094bf6d3d493131",
+				"DiscoKey":   "discokey:678e6851568a4d9faea3c625bd3b4037bea0f989efed0ae529d68fa18fa42e1d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56057",
+					"10.65.0.27:56057",
+					"172.17.0.1:56057",
+					"172.19.0.1:56057",
+					"172.20.0.1:56057"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:34:07.735518321Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:370de11ef28f539339bfef1ca0f5ebfdaea5c2f1019a96f38094bf6d3d493131",
+			"MachineKey": "mkey:24f7f88618de3784597fdf8d3e10b5652bbd29939b15b369c0b1b0de03d6af37",
+			"Peers": [{
+				"ID":         1022503236902628,
+				"StableID":   "nbLYeiR6z811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7971e8fb145a2c24201b1f3a8d324c6f84d34d51108ced31083b7945037f502",
+				"DiscoKey":   "discokey:b2f244c013b6bfe90a222534be986760343607b7ac142643850753f998c79227",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:41224",
+					"10.65.0.27:41224",
+					"172.17.0.1:41224",
+					"172.19.0.1:41224",
+					"172.20.0.1:41224"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:34:03.497685845Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8664957792496331,
+				"StableID":   "nS4QNPkNfA21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f05aa1de0102ff1818b0a21982be35047944fa5370360f47562896c88d918618",
+				"DiscoKey":   "discokey:451076ac784e15ee15e575c36ee956c35895f45df5db21bca16c6b2b0984824a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40453",
+					"10.65.0.27:40453",
+					"172.17.0.1:40453",
+					"172.19.0.1:40453",
+					"172.20.0.1:40453"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:34:04.003863683Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8235291227186960,
+				"StableID":   "nXvMKt8nJ721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae7c3fcacb00745d9f223ef9adf6c8ac66f9bc376c75dbc698299a3737327547",
+				"DiscoKey":   "discokey:0aa445872572f0accf0209866eedeeeace67c0f5aa6a2bd2daf31a3c8b28c910",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:49557",
+					"10.65.0.27:49557",
+					"172.17.0.1:49557",
+					"172.19.0.1:49557",
+					"172.20.0.1:49557"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:34:04.539409763Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8628004179095420,
+				"StableID":   "nVXU6H3eNA21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af82dd8733b5a319c76c68ba56c1b30e695445adbcf6f5e8bde557c09ae15b79",
+				"DiscoKey":   "discokey:f484aec42430b36c315eddfbbcca6edc4f8b3ff4afb12f523888659368138451",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45337",
+					"10.65.0.27:45337",
+					"172.17.0.1:45337",
+					"172.19.0.1:45337",
+					"172.20.0.1:45337"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:34:05.074221241Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6590867837531638,
+				"StableID":   "n9xHSUv1Ut11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b07c37318cc3aec00938db2817117b472bb6163c08716e84dfaa8d9267b37b32",
+				"DiscoKey":   "discokey:81b18fc56567fc8f4fcf35907d2edf91f2282b9a9b8e1b82a5e79900c4cd0821",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37862",
+					"10.65.0.27:37862",
+					"172.17.0.1:37862",
+					"172.19.0.1:37862",
+					"172.20.0.1:37862"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:34:05.611311706Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6282512707345114,
+				"StableID":   "nXueVRxM4r11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4fb6b80caba83f7bee0a74a527cd06ee3fa34d644599b2661cb936857669a3b",
+				"DiscoKey":   "discokey:f3501443371b5cc1db334be168dbde50db6c83c10f495b6337fa8694b1667445",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38866",
+					"10.65.0.27:38866",
+					"172.17.0.1:38866",
+					"172.19.0.1:38866",
+					"172.20.0.1:38866"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:34:06.140529217Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8624384377314642,
+				"StableID":   "nq6BcHxzLA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:948247711446f93b6a925fb7af24b9a1f4ec31a7f6e9b94ccbb2802bab17f97c",
+				"DiscoKey":   "discokey:6809b4aaa6f52d3c03772ec91e7d4439148e2e95f50870d89335925dfb9dc603",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50229",
+					"10.65.0.27:50229",
+					"172.17.0.1:50229",
+					"172.19.0.1:50229",
+					"172.20.0.1:50229"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:34:06.68292337Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4439328582789959,
+				"StableID":   "nEEV6ndafb11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03a511cfc1fb37f747f1e98f6e4ba40d18fbecafc21b2154ec8a849def9d736c",
+				"DiscoKey":   "discokey:a739bec3425689dad8fe6a2da36b163b1cdce535317be81e872d20d46811dc0b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48890",
+					"10.65.0.27:48890",
+					"172.17.0.1:48890",
+					"172.19.0.1:48890",
+					"172.20.0.1:48890"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:34:07.213221624Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3631511856685615,
+				"StableID":   "nJWLFCfiMV11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cce483fe904609f3dd393a8b16b32befd95d164feac49fc6242c8fe9c1599265",
+				"DiscoKey":   "discokey:287d208a96d9e7506ae18ff60520103281af7c2831022945baeb2f7d84c1650f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58559",
+					"10.65.0.27:58559",
+					"172.17.0.1:58559",
+					"172.19.0.1:58559",
+					"172.20.0.1:58559"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:34:08.280233017Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1126027970937232,
+				"StableID":   "nmFdt2ryn911CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4360bf8f7aaf7df0bfb9bba0e959b82b7d0ef08422e95a5b2074e03985bf4334",
+				"DiscoKey":   "discokey:480e78aa2c2d3cf3020ed2d8c39a8ffd574e201e8e56d2ff6d54cae121947044",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35829",
+					"10.65.0.27:35829",
+					"172.17.0.1:35829",
+					"172.19.0.1:35829",
+					"172.20.0.1:35829"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:34:08.806497751Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7114745634573595,
+				"StableID":   "nNAgRbJHZx11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4e109d06ad3ef6a3a937688201159d694d4a2880f045616e0a2299099969104",
+				"DiscoKey":   "discokey:98ab0fdfa6b6692f09484507e869de4e938ac4e5ca2f838b2fb456b9ee192b21",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:40692",
+					"10.65.0.27:40692",
+					"172.17.0.1:40692",
+					"172.19.0.1:40692",
+					"172.20.0.1:40692"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:34:09.338974089Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2882053099464165,
+				"StableID":   "neZoGaeHWP11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b078a77336b1d6e1241638676dc3f5a788db64fee6130ccb5c16af411ef0616c",
+				"KeyExpiry":  "2026-11-08T18:34:09Z",
+				"DiscoKey":   "discokey:8244df2d4a4b0f214a82958cb16caa087e7ad9ab07f2c7f37ce840f43289321e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43422",
+					"10.65.0.27:43422",
+					"172.17.0.1:43422",
+					"172.19.0.1:43422",
+					"172.20.0.1:43422"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:34:09.872005789Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4945122688476289,
+				"StableID":   "ntkoCHzecf11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:59bf1bde5cc5436bb8a217cc85b22ffd556ed8cc0effd27b596cf6c510762f2c",
+				"KeyExpiry":  "2026-11-08T18:34:10Z",
+				"DiscoKey":   "discokey:30a6c6071fef8521561db58d989f8f69a77d9b5a41d47af01c8e9809ef219243",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54883",
+					"10.65.0.27:54883",
+					"172.17.0.1:54883",
+					"172.19.0.1:54883",
+					"172.20.0.1:54883"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:34:10.412326737Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1543249583393063,
+				"StableID":   "nSgK5tYw3D11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f5328c3d98f667fa716c2e3078a330c20e835c370678e906aa6eeb947fa8db2c",
+				"KeyExpiry":  "2026-11-08T18:34:11Z",
+				"DiscoKey":   "discokey:a68516c729732c39f2d1ccfd587c7ad7921ac4a48b45b50503a00f6f2281861c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:46471",
+					"10.65.0.27:46471",
+					"172.17.0.1:46471",
+					"172.19.0.1:46471",
+					"172.20.0.1:46471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:34:11.18328066Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "656941692479156": {
+				"ID":          656941692479156,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4945122688476289,
+				"StableID":   "ntkoCHzecf11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:59bf1bde5cc5436bb8a217cc85b22ffd556ed8cc0effd27b596cf6c510762f2c",
+				"KeyExpiry":  "2026-11-08T18:34:10Z",
+				"DiscoKey":   "discokey:30a6c6071fef8521561db58d989f8f69a77d9b5a41d47af01c8e9809ef219243",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54883",
+					"10.65.0.27:54883",
+					"172.17.0.1:54883",
+					"172.19.0.1:54883",
+					"172.20.0.1:54883"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:34:10.412326737Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:59bf1bde5cc5436bb8a217cc85b22ffd556ed8cc0effd27b596cf6c510762f2c",
+			"MachineKey": "mkey:6facbdd9b70955b9188860f987fa35d009506a4b48c3b77815e1c80c493af035",
+			"Peers": [{
+				"ID":         1022503236902628,
+				"StableID":   "nbLYeiR6z811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7971e8fb145a2c24201b1f3a8d324c6f84d34d51108ced31083b7945037f502",
+				"DiscoKey":   "discokey:b2f244c013b6bfe90a222534be986760343607b7ac142643850753f998c79227",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:41224",
+					"10.65.0.27:41224",
+					"172.17.0.1:41224",
+					"172.19.0.1:41224",
+					"172.20.0.1:41224"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:34:03.497685845Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8664957792496331,
+				"StableID":   "nS4QNPkNfA21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f05aa1de0102ff1818b0a21982be35047944fa5370360f47562896c88d918618",
+				"DiscoKey":   "discokey:451076ac784e15ee15e575c36ee956c35895f45df5db21bca16c6b2b0984824a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40453",
+					"10.65.0.27:40453",
+					"172.17.0.1:40453",
+					"172.19.0.1:40453",
+					"172.20.0.1:40453"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:34:04.003863683Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8235291227186960,
+				"StableID":   "nXvMKt8nJ721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae7c3fcacb00745d9f223ef9adf6c8ac66f9bc376c75dbc698299a3737327547",
+				"DiscoKey":   "discokey:0aa445872572f0accf0209866eedeeeace67c0f5aa6a2bd2daf31a3c8b28c910",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:49557",
+					"10.65.0.27:49557",
+					"172.17.0.1:49557",
+					"172.19.0.1:49557",
+					"172.20.0.1:49557"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:34:04.539409763Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8628004179095420,
+				"StableID":   "nVXU6H3eNA21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af82dd8733b5a319c76c68ba56c1b30e695445adbcf6f5e8bde557c09ae15b79",
+				"DiscoKey":   "discokey:f484aec42430b36c315eddfbbcca6edc4f8b3ff4afb12f523888659368138451",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45337",
+					"10.65.0.27:45337",
+					"172.17.0.1:45337",
+					"172.19.0.1:45337",
+					"172.20.0.1:45337"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:34:05.074221241Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6590867837531638,
+				"StableID":   "n9xHSUv1Ut11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b07c37318cc3aec00938db2817117b472bb6163c08716e84dfaa8d9267b37b32",
+				"DiscoKey":   "discokey:81b18fc56567fc8f4fcf35907d2edf91f2282b9a9b8e1b82a5e79900c4cd0821",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37862",
+					"10.65.0.27:37862",
+					"172.17.0.1:37862",
+					"172.19.0.1:37862",
+					"172.20.0.1:37862"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:34:05.611311706Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6282512707345114,
+				"StableID":   "nXueVRxM4r11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4fb6b80caba83f7bee0a74a527cd06ee3fa34d644599b2661cb936857669a3b",
+				"DiscoKey":   "discokey:f3501443371b5cc1db334be168dbde50db6c83c10f495b6337fa8694b1667445",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38866",
+					"10.65.0.27:38866",
+					"172.17.0.1:38866",
+					"172.19.0.1:38866",
+					"172.20.0.1:38866"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:34:06.140529217Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8624384377314642,
+				"StableID":   "nq6BcHxzLA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:948247711446f93b6a925fb7af24b9a1f4ec31a7f6e9b94ccbb2802bab17f97c",
+				"DiscoKey":   "discokey:6809b4aaa6f52d3c03772ec91e7d4439148e2e95f50870d89335925dfb9dc603",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50229",
+					"10.65.0.27:50229",
+					"172.17.0.1:50229",
+					"172.19.0.1:50229",
+					"172.20.0.1:50229"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:34:06.68292337Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4439328582789959,
+				"StableID":   "nEEV6ndafb11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03a511cfc1fb37f747f1e98f6e4ba40d18fbecafc21b2154ec8a849def9d736c",
+				"DiscoKey":   "discokey:a739bec3425689dad8fe6a2da36b163b1cdce535317be81e872d20d46811dc0b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48890",
+					"10.65.0.27:48890",
+					"172.17.0.1:48890",
+					"172.19.0.1:48890",
+					"172.20.0.1:48890"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:34:07.213221624Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         656941692479156,
+				"StableID":   "n3CrmAkX8611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:370de11ef28f539339bfef1ca0f5ebfdaea5c2f1019a96f38094bf6d3d493131",
+				"DiscoKey":   "discokey:678e6851568a4d9faea3c625bd3b4037bea0f989efed0ae529d68fa18fa42e1d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56057",
+					"10.65.0.27:56057",
+					"172.17.0.1:56057",
+					"172.19.0.1:56057",
+					"172.20.0.1:56057"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:34:07.735518321Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3631511856685615,
+				"StableID":   "nJWLFCfiMV11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cce483fe904609f3dd393a8b16b32befd95d164feac49fc6242c8fe9c1599265",
+				"DiscoKey":   "discokey:287d208a96d9e7506ae18ff60520103281af7c2831022945baeb2f7d84c1650f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58559",
+					"10.65.0.27:58559",
+					"172.17.0.1:58559",
+					"172.19.0.1:58559",
+					"172.20.0.1:58559"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:34:08.280233017Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1126027970937232,
+				"StableID":   "nmFdt2ryn911CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4360bf8f7aaf7df0bfb9bba0e959b82b7d0ef08422e95a5b2074e03985bf4334",
+				"DiscoKey":   "discokey:480e78aa2c2d3cf3020ed2d8c39a8ffd574e201e8e56d2ff6d54cae121947044",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35829",
+					"10.65.0.27:35829",
+					"172.17.0.1:35829",
+					"172.19.0.1:35829",
+					"172.20.0.1:35829"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:34:08.806497751Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7114745634573595,
+				"StableID":   "nNAgRbJHZx11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4e109d06ad3ef6a3a937688201159d694d4a2880f045616e0a2299099969104",
+				"DiscoKey":   "discokey:98ab0fdfa6b6692f09484507e869de4e938ac4e5ca2f838b2fb456b9ee192b21",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:40692",
+					"10.65.0.27:40692",
+					"172.17.0.1:40692",
+					"172.19.0.1:40692",
+					"172.20.0.1:40692"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:34:09.338974089Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2882053099464165,
+				"StableID":   "neZoGaeHWP11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b078a77336b1d6e1241638676dc3f5a788db64fee6130ccb5c16af411ef0616c",
+				"KeyExpiry":  "2026-11-08T18:34:09Z",
+				"DiscoKey":   "discokey:8244df2d4a4b0f214a82958cb16caa087e7ad9ab07f2c7f37ce840f43289321e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43422",
+					"10.65.0.27:43422",
+					"172.17.0.1:43422",
+					"172.19.0.1:43422",
+					"172.20.0.1:43422"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:34:09.872005789Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1543249583393063,
+				"StableID":   "nSgK5tYw3D11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f5328c3d98f667fa716c2e3078a330c20e835c370678e906aa6eeb947fa8db2c",
+				"KeyExpiry":  "2026-11-08T18:34:11Z",
+				"DiscoKey":   "discokey:a68516c729732c39f2d1ccfd587c7ad7921ac4a48b45b50503a00f6f2281861c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:46471",
+					"10.65.0.27:46471",
+					"172.17.0.1:46471",
+					"172.19.0.1:46471",
+					"172.20.0.1:46471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:34:11.18328066Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3631511856685615,
+				"StableID":   "nJWLFCfiMV11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       3631511856685615,
+				"Key":        "nodekey:cce483fe904609f3dd393a8b16b32befd95d164feac49fc6242c8fe9c1599265",
+				"DiscoKey":   "discokey:287d208a96d9e7506ae18ff60520103281af7c2831022945baeb2f7d84c1650f",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58559",
+					"10.65.0.27:58559",
+					"172.17.0.1:58559",
+					"172.19.0.1:58559",
+					"172.20.0.1:58559"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:34:08.280233017Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:cce483fe904609f3dd393a8b16b32befd95d164feac49fc6242c8fe9c1599265",
+			"MachineKey": "mkey:7c778452eefd84210f55a6b696c2d7785c050719e57e324144b660c8d1a1f678",
+			"Peers": [{
+				"ID":         1022503236902628,
+				"StableID":   "nbLYeiR6z811CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7971e8fb145a2c24201b1f3a8d324c6f84d34d51108ced31083b7945037f502",
+				"DiscoKey":   "discokey:b2f244c013b6bfe90a222534be986760343607b7ac142643850753f998c79227",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:41224",
+					"10.65.0.27:41224",
+					"172.17.0.1:41224",
+					"172.19.0.1:41224",
+					"172.20.0.1:41224"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:34:03.497685845Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8664957792496331,
+				"StableID":   "nS4QNPkNfA21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f05aa1de0102ff1818b0a21982be35047944fa5370360f47562896c88d918618",
+				"DiscoKey":   "discokey:451076ac784e15ee15e575c36ee956c35895f45df5db21bca16c6b2b0984824a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:40453",
+					"10.65.0.27:40453",
+					"172.17.0.1:40453",
+					"172.19.0.1:40453",
+					"172.20.0.1:40453"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:34:04.003863683Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8235291227186960,
+				"StableID":   "nXvMKt8nJ721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ae7c3fcacb00745d9f223ef9adf6c8ac66f9bc376c75dbc698299a3737327547",
+				"DiscoKey":   "discokey:0aa445872572f0accf0209866eedeeeace67c0f5aa6a2bd2daf31a3c8b28c910",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:49557",
+					"10.65.0.27:49557",
+					"172.17.0.1:49557",
+					"172.19.0.1:49557",
+					"172.20.0.1:49557"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:34:04.539409763Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8628004179095420,
+				"StableID":   "nVXU6H3eNA21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af82dd8733b5a319c76c68ba56c1b30e695445adbcf6f5e8bde557c09ae15b79",
+				"DiscoKey":   "discokey:f484aec42430b36c315eddfbbcca6edc4f8b3ff4afb12f523888659368138451",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45337",
+					"10.65.0.27:45337",
+					"172.17.0.1:45337",
+					"172.19.0.1:45337",
+					"172.20.0.1:45337"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:34:05.074221241Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6590867837531638,
+				"StableID":   "n9xHSUv1Ut11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b07c37318cc3aec00938db2817117b472bb6163c08716e84dfaa8d9267b37b32",
+				"DiscoKey":   "discokey:81b18fc56567fc8f4fcf35907d2edf91f2282b9a9b8e1b82a5e79900c4cd0821",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37862",
+					"10.65.0.27:37862",
+					"172.17.0.1:37862",
+					"172.19.0.1:37862",
+					"172.20.0.1:37862"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:34:05.611311706Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6282512707345114,
+				"StableID":   "nXueVRxM4r11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4fb6b80caba83f7bee0a74a527cd06ee3fa34d644599b2661cb936857669a3b",
+				"DiscoKey":   "discokey:f3501443371b5cc1db334be168dbde50db6c83c10f495b6337fa8694b1667445",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:38866",
+					"10.65.0.27:38866",
+					"172.17.0.1:38866",
+					"172.19.0.1:38866",
+					"172.20.0.1:38866"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:34:06.140529217Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8624384377314642,
+				"StableID":   "nq6BcHxzLA21CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:948247711446f93b6a925fb7af24b9a1f4ec31a7f6e9b94ccbb2802bab17f97c",
+				"DiscoKey":   "discokey:6809b4aaa6f52d3c03772ec91e7d4439148e2e95f50870d89335925dfb9dc603",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:50229",
+					"10.65.0.27:50229",
+					"172.17.0.1:50229",
+					"172.19.0.1:50229",
+					"172.20.0.1:50229"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:34:06.68292337Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4439328582789959,
+				"StableID":   "nEEV6ndafb11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03a511cfc1fb37f747f1e98f6e4ba40d18fbecafc21b2154ec8a849def9d736c",
+				"DiscoKey":   "discokey:a739bec3425689dad8fe6a2da36b163b1cdce535317be81e872d20d46811dc0b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:48890",
+					"10.65.0.27:48890",
+					"172.17.0.1:48890",
+					"172.19.0.1:48890",
+					"172.20.0.1:48890"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:34:07.213221624Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         656941692479156,
+				"StableID":   "n3CrmAkX8611CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:370de11ef28f539339bfef1ca0f5ebfdaea5c2f1019a96f38094bf6d3d493131",
+				"DiscoKey":   "discokey:678e6851568a4d9faea3c625bd3b4037bea0f989efed0ae529d68fa18fa42e1d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:56057",
+					"10.65.0.27:56057",
+					"172.17.0.1:56057",
+					"172.19.0.1:56057",
+					"172.20.0.1:56057"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:34:07.735518321Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1126027970937232,
+				"StableID":   "nmFdt2ryn911CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4360bf8f7aaf7df0bfb9bba0e959b82b7d0ef08422e95a5b2074e03985bf4334",
+				"DiscoKey":   "discokey:480e78aa2c2d3cf3020ed2d8c39a8ffd574e201e8e56d2ff6d54cae121947044",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35829",
+					"10.65.0.27:35829",
+					"172.17.0.1:35829",
+					"172.19.0.1:35829",
+					"172.20.0.1:35829"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:34:08.806497751Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7114745634573595,
+				"StableID":   "nNAgRbJHZx11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4e109d06ad3ef6a3a937688201159d694d4a2880f045616e0a2299099969104",
+				"DiscoKey":   "discokey:98ab0fdfa6b6692f09484507e869de4e938ac4e5ca2f838b2fb456b9ee192b21",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:40692",
+					"10.65.0.27:40692",
+					"172.17.0.1:40692",
+					"172.19.0.1:40692",
+					"172.20.0.1:40692"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:34:09.338974089Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2882053099464165,
+				"StableID":   "neZoGaeHWP11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b078a77336b1d6e1241638676dc3f5a788db64fee6130ccb5c16af411ef0616c",
+				"KeyExpiry":  "2026-11-08T18:34:09Z",
+				"DiscoKey":   "discokey:8244df2d4a4b0f214a82958cb16caa087e7ad9ab07f2c7f37ce840f43289321e",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:43422",
+					"10.65.0.27:43422",
+					"172.17.0.1:43422",
+					"172.19.0.1:43422",
+					"172.20.0.1:43422"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:34:09.872005789Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4945122688476289,
+				"StableID":   "ntkoCHzecf11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:59bf1bde5cc5436bb8a217cc85b22ffd556ed8cc0effd27b596cf6c510762f2c",
+				"KeyExpiry":  "2026-11-08T18:34:10Z",
+				"DiscoKey":   "discokey:30a6c6071fef8521561db58d989f8f69a77d9b5a41d47af01c8e9809ef219243",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54883",
+					"10.65.0.27:54883",
+					"172.17.0.1:54883",
+					"172.19.0.1:54883",
+					"172.20.0.1:54883"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:34:10.412326737Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1543249583393063,
+				"StableID":   "nSgK5tYw3D11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f5328c3d98f667fa716c2e3078a330c20e835c370678e906aa6eeb947fa8db2c",
+				"KeyExpiry":  "2026-11-08T18:34:11Z",
+				"DiscoKey":   "discokey:a68516c729732c39f2d1ccfd587c7ad7921ac4a48b45b50503a00f6f2281861c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:46471",
+					"10.65.0.27:46471",
+					"172.17.0.1:46471",
+					"172.19.0.1:46471",
+					"172.20.0.1:46471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:34:11.18328066Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3631511856685615": {
+				"ID":          3631511856685615,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/sshtest_results/sshtest-both-tests-and-sshTests-both-pass.hujson
+++ b/hscontrol/policy/v2/testdata/sshtest_results/sshtest-both-tests-and-sshTests-both-pass.hujson
@@ -1,0 +1,13577 @@
+// sshtest-both-tests-and-sshTests-both-pass
+//
+// tests and sshTests both pass in one policy
+//
+// Nodes with filter rules: 1 of 15
+// Captured at:    2026-05-12T18:34:56Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "sshtest-both-tests-and-sshTests-both-pass",
+	"description":    "tests and sshTests both pass in one policy",
+	"category":       "sshtest",
+	"captured_at":    "2026-05-12T18:34:56.419359014Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                            \n  \n                                                                        \n                                 \n{\n\t\"category\":    \"sshtest\",\n\t\"description\": \"tests and sshTests both pass in one policy\",\n\t\"id\":          \"sshtest-both-tests-and-sshTests-both-pass\",\n\t\"policy\": {\"acls\": [\n\t\t{\"action\": \"accept\", \"dst\": [\"tag:server:22\"], \"src\": [\"thor@example.org\"]}\n\t], \"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"thor@example.org\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"sshTests\": [{\n\t\t\"accept\": [\"root\"],\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    \"thor@example.org\"\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}, \"tests\": [\n\t\t{\"accept\": [\"tag:server:22\"], \"src\": \"thor@example.org\"}\n\t]},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/sshtest/sshtest-both-tests-and-sshTests-both-pass.hujson",
+		"full_policy": {
+			"acls": [{
+				"action": "accept",
+				"dst":    ["tag:server:22"],
+				"src":    ["thor@example.org"]
+			}],
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["thor@example.org"],
+				"users":  ["root"]
+			}],
+			"sshTests":  [{"accept": ["root"], "dst": ["tag:server"], "src": "thor@example.org"}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]},
+			"tests":     [{"accept": ["tag:server:22"], "src": "thor@example.org"}]
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": ["100.64.0.17", "fd7a:115c:a1e0::11"], "DstPorts": [
+			{"IP": "100.64.0.16", "Ports": {"First": 22, "Last": 22}},
+			{"IP": "fd7a:115c:a1e0::10", "Ports": {"First": 22, "Last": 22}}
+		]}],
+		"packet_filter_matches": [{
+			"IPProto": [6, 17, 1, 58],
+			"Srcs":    ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"SrcCaps": null,
+			"Dsts": [
+				{"Net": "100.64.0.16/32", "Ports": {"First": 22, "Last": 22}},
+				{"Net": "fd7a:115c:a1e0::10/128", "Ports": {"First": 22, "Last": 22}}
+			],
+			"Caps": []
+		}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3618477906027404,
+				"StableID":   "nmqHfAHpFV11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       3618477906027404,
+				"Key":        "nodekey:12dba5997ee9817b3d24531c054e450da392509c9ca68c357c3db6fabaa00d2e",
+				"DiscoKey":   "discokey:f37d8428be89acd8ee6ffd1b6c561af20f30d35d7396b5520cc3b94e9861904b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:50653",
+					"10.65.0.27:50653",
+					"172.17.0.1:50653",
+					"172.19.0.1:50653",
+					"172.20.0.1:50653"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:35:04.760855934Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:12dba5997ee9817b3d24531c054e450da392509c9ca68c357c3db6fabaa00d2e",
+			"MachineKey": "mkey:6b2dad09338ed16d125464d148c246abf928fe0cd123ed0036915509519a2508",
+			"Peers": [{
+				"ID":         3301311113576196,
+				"StableID":   "n5DHJ1rAnS11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:cf5eecd9cd6b133b6e2e0feae520fb38284a627e705af1b7ee462dc1d1407e70",
+				"KeyExpiry":  "2026-11-08T18:35:05Z",
+				"DiscoKey":   "discokey:70f50c0204f635606d77ce7344d3cc5974f9c83fc1ed4dffe8b3f65a95c7197d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:57592",
+					"10.65.0.27:57592",
+					"172.17.0.1:57592",
+					"172.19.0.1:57592",
+					"172.20.0.1:57592"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:35:05.302791065Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{
+				"IPProto": [6, 17, 1, 58],
+				"Srcs":    ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"SrcCaps": null,
+				"Dsts": [
+					{"Net": "100.64.0.16/32", "Ports": {"First": 22, "Last": 22}},
+					{"Net": "fd7a:115c:a1e0::10/128", "Ports": {"First": 22, "Last": 22}}
+				],
+				"Caps": []
+			}],
+			"PacketFilterRules": [{"SrcIPs": ["100.64.0.17", "fd7a:115c:a1e0::11"], "DstPorts": [
+				{"IP": "100.64.0.16", "Ports": {"First": 22, "Last": 22}},
+				{"IP": "fd7a:115c:a1e0::10", "Ports": {"First": 22, "Last": 22}}
+			]}],
+			"SSHPolicy": {"rules": [{
+				"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+				"sshUsers":   {"root": "root"},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				}
+			}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"3618477906027404": {
+				"ID":          3618477906027404,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		},
+		"ssh_rules": [{
+			"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+			"sshUsers":   {"root": "root"},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}
+		}]
+	}, "blastoise": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         4172979272876441,
+			"StableID":   "ngYaeB6xaZ11CNTRL",
+			"Name":       "blastoise.tail78f774.ts.net.",
+			"User":       4172979272876441,
+			"Key":        "nodekey:bab19a11c0456a1d4aeceb3a65103f58edfd7df83253b0e9c546d09bd98fed29",
+			"DiscoKey":   "discokey:d5a9756d7d5db624971e921434f22fc862396af26113d40eebe76cfa324e3e54",
+			"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+			"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+			"Endpoints": [
+				"77.164.248.136:40305",
+				"10.65.0.27:40305",
+				"172.17.0.1:40305",
+				"172.19.0.1:40305",
+				"172.20.0.1:40305"
+			],
+			"Hostinfo": {
+				"Hostname":    "blastoise",
+				"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+				"RequestTags": ["tag:exit", "tag:router"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-12T18:35:01.541787737Z",
+			"Tags":              ["tag:exit", "tag:router"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "blastoise",
+			"ComputedNameWithHost": "blastoise"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:bab19a11c0456a1d4aeceb3a65103f58edfd7df83253b0e9c546d09bd98fed29",
+		"MachineKey":        "mkey:4a84edda832f3964439cde8a21fa5bb97014e5f3136f30e9124bc4333a665212",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4172979272876441": {
+			"ID":          4172979272876441,
+			"LoginName":   "blastoise.tail78f774.ts.net",
+			"DisplayName": "blastoise"
+		}}
+	}}, "bulbasaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         8885437019420115,
+			"StableID":   "nza5f5NEPC21CNTRL",
+			"Name":       "bulbasaur.tail78f774.ts.net.",
+			"User":       4156223528223174,
+			"Key":        "nodekey:af210d2a336ebc2fb69055df6cb3eb910cc85d1510af5760c452393be0767e6f",
+			"KeyExpiry":  "2026-11-08T18:35:06Z",
+			"DiscoKey":   "discokey:124e2b111c94f2c83088aa1237feabd8722a937e1ebbe2cfd667a384093c9768",
+			"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"Endpoints": [
+				"77.164.248.136:57300",
+				"10.65.0.27:57300",
+				"172.17.0.1:57300",
+				"172.19.0.1:57300",
+				"172.20.0.1:57300"
+			],
+			"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+				{"Proto": "peerapi4", "Port": 38156},
+				{"Proto": "peerapi6", "Port": 38156},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-12T18:35:06.387329434Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "bulbasaur",
+			"ComputedNameWithHost": "bulbasaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:af210d2a336ebc2fb69055df6cb3eb910cc85d1510af5760c452393be0767e6f",
+		"MachineKey":        "mkey:a8269e41cf0a87d2dd8544a402db5684c78724e7df4235b49053dacc904c4b25",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4156223528223174": {
+			"ID":          4156223528223174,
+			"LoginName":   "odin@example.com",
+			"DisplayName": "odin"
+		}}
+	}}, "charmander": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         1447932766683258,
+			"StableID":   "n5tyNqjmJC11CNTRL",
+			"Name":       "charmander.tail78f774.ts.net.",
+			"User":       1447932766683258,
+			"Key":        "nodekey:93bd718d2d89ee3391e4b222be04c43feadfce18e09cce7fda00f6d4d0f7080c",
+			"DiscoKey":   "discokey:e7756844f0ca9d6478c3fe68e0286843ddf2a6a16e763dddcd3b91c75e425324",
+			"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"Endpoints": [
+				"77.164.248.136:45685",
+				"10.65.0.27:45685",
+				"172.17.0.1:45685",
+				"172.19.0.1:45685",
+				"172.20.0.1:45685"
+			],
+			"Hostinfo": {
+				"Hostname":    "charmander",
+				"RoutableIPs": ["0.0.0.0/0", "::/0"],
+				"RequestTags": ["tag:exit"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-12T18:34:59.90631294Z",
+			"Tags":              ["tag:exit"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "charmander",
+			"ComputedNameWithHost": "charmander"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:93bd718d2d89ee3391e4b222be04c43feadfce18e09cce7fda00f6d4d0f7080c",
+		"MachineKey":        "mkey:f905d8e3bab5a2497ab0b9f21616a847e7bbcf05ad983c802ea3121a429b5a3c",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1447932766683258": {
+			"ID":          1447932766683258,
+			"LoginName":   "charmander.tail78f774.ts.net",
+			"DisplayName": "charmander"
+		}}
+	}}, "fearow": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         5686184650465017,
+			"StableID":   "ntxw8sRHQm11CNTRL",
+			"Name":       "fearow.tail78f774.ts.net.",
+			"User":       5686184650465017,
+			"Key":        "nodekey:925fc72f5a7de7cffb2e53f6d1ade4d9897e50b3dbc478507f76df10c98d4a1d",
+			"DiscoKey":   "discokey:69d0056f02772ecf7c79c4deb2103ba83c37f890217f81b4aa3915e41381ed57",
+			"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+			"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+			"Endpoints": [
+				"77.164.248.136:55858",
+				"10.65.0.27:55858",
+				"172.17.0.1:55858",
+				"172.19.0.1:55858",
+				"172.20.0.1:55858"
+			],
+			"Hostinfo": {
+				"Hostname":    "fearow",
+				"RoutableIPs": ["10.55.0.0/16"],
+				"RequestTags": ["tag:fearow"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-12T18:35:02.595609282Z",
+			"Tags":              ["tag:fearow"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "fearow",
+			"ComputedNameWithHost": "fearow"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:925fc72f5a7de7cffb2e53f6d1ade4d9897e50b3dbc478507f76df10c98d4a1d",
+		"MachineKey":        "mkey:7bb7440693499cd173652236557c16ffcf339074e69d79bcc74ec5e5dedbe626",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"5686184650465017": {
+			"ID":          5686184650465017,
+			"LoginName":   "fearow.tail78f774.ts.net",
+			"DisplayName": "fearow"
+		}}
+	}}, "ivysaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         3301311113576196,
+			"StableID":   "n5DHJ1rAnS11CNTRL",
+			"Name":       "ivysaur.tail78f774.ts.net.",
+			"User":       4538565228176803,
+			"Key":        "nodekey:cf5eecd9cd6b133b6e2e0feae520fb38284a627e705af1b7ee462dc1d1407e70",
+			"KeyExpiry":  "2026-11-08T18:35:05Z",
+			"DiscoKey":   "discokey:70f50c0204f635606d77ce7344d3cc5974f9c83fc1ed4dffe8b3f65a95c7197d",
+			"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"Endpoints": [
+				"77.164.248.136:57592",
+				"10.65.0.27:57592",
+				"172.17.0.1:57592",
+				"172.19.0.1:57592",
+				"172.20.0.1:57592"
+			],
+			"Hostinfo": {"Hostname": "ivysaur", "Services": [
+				{"Proto": "peerapi4", "Port": 62496},
+				{"Proto": "peerapi6", "Port": 62496},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-12T18:35:05.302791065Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "ivysaur",
+			"ComputedNameWithHost": "ivysaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:cf5eecd9cd6b133b6e2e0feae520fb38284a627e705af1b7ee462dc1d1407e70",
+		"MachineKey": "mkey:c52429a3953d48bad2283ebf43ee1be98728599ed16ca1e877a74401b14bcb3a",
+		"Peers": [{
+			"ID":         3618477906027404,
+			"StableID":   "nmqHfAHpFV11CNTRL",
+			"Name":       "beedrill.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:12dba5997ee9817b3d24531c054e450da392509c9ca68c357c3db6fabaa00d2e",
+			"DiscoKey":   "discokey:f37d8428be89acd8ee6ffd1b6c561af20f30d35d7396b5520cc3b94e9861904b",
+			"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"Endpoints": [
+				"77.164.248.136:50653",
+				"10.65.0.27:50653",
+				"172.17.0.1:50653",
+				"172.19.0.1:50653",
+				"172.20.0.1:50653"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+				{"Proto": "peerapi4", "Port": 50358},
+				{"Proto": "peerapi6", "Port": 50358}
+			]},
+			"Created":              "2026-05-12T18:35:04.760855934Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:server"],
+			"Online":               true,
+			"ComputedName":         "beedrill",
+			"ComputedNameWithHost": "beedrill"
+		}],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1260082990019555": {
+			"ID":          1260082990019555,
+			"LoginName":   "tagged-devices",
+			"DisplayName": "Tagged Devices"
+		}, "4538565228176803": {
+			"ID":          4538565228176803,
+			"LoginName":   "thor@example.org",
+			"DisplayName": "thor"
+		}}
+	}}, "kakuna": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         948712158755676,
+			"StableID":   "nhoukT4gQ811CNTRL",
+			"Name":       "kakuna.tail78f774.ts.net.",
+			"User":       948712158755676,
+			"Key":        "nodekey:d23e9549411448b86b7d99f4b7b91192ea73ea0adffc5896bc386c07460d5836",
+			"DiscoKey":   "discokey:cb60cb383624d86b3199872f15e414e9bd1cd7f099586592c3c6125e8980915e",
+			"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"Endpoints": [
+				"77.164.248.136:36612",
+				"10.65.0.27:36612",
+				"172.17.0.1:36612",
+				"172.19.0.1:36612",
+				"172.20.0.1:36612"
+			],
+			"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+				{"Proto": "peerapi4", "Port": 51523},
+				{"Proto": "peerapi6", "Port": 51523},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-12T18:35:04.240197907Z",
+			"Tags":              ["tag:prod"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "kakuna",
+			"ComputedNameWithHost": "kakuna"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:d23e9549411448b86b7d99f4b7b91192ea73ea0adffc5896bc386c07460d5836",
+		"MachineKey":        "mkey:df46c85b2e14118ecc97a058b1db55a90367ff39354384f3888ee4cb9da38d2d",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"948712158755676": {
+			"ID":          948712158755676,
+			"LoginName":   "kakuna.tail78f774.ts.net",
+			"DisplayName": "kakuna"
+		}}
+	}}, "pidgeotto": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         4358040102320020,
+			"StableID":   "nTeDSmKm2b11CNTRL",
+			"Name":       "pidgeotto.tail78f774.ts.net.",
+			"User":       4358040102320020,
+			"Key":        "nodekey:b49e48e56a6993a58af3b6a482f83d60f2eb084a73baacf18c89aff6b4944a61",
+			"DiscoKey":   "discokey:4ae250b35e3e643003fb04c0cf58c0dee37ab3b9a35a4bbb4d92c842d7a55419",
+			"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+			"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+			"Endpoints": [
+				"77.164.248.136:57160",
+				"10.65.0.27:57160",
+				"172.17.0.1:57160",
+				"172.19.0.1:57160",
+				"172.20.0.1:57160"
+			],
+			"Hostinfo": {
+				"Hostname":    "pidgeotto",
+				"RoutableIPs": ["0.0.0.0/0", "::/0"],
+				"RequestTags": ["tag:pidgeotto"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-12T18:34:59.379303139Z",
+			"Tags":              ["tag:pidgeotto"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "pidgeotto",
+			"ComputedNameWithHost": "pidgeotto"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:b49e48e56a6993a58af3b6a482f83d60f2eb084a73baacf18c89aff6b4944a61",
+		"MachineKey":        "mkey:dea42895df0f9b4652a9902b2056da9d5b2fdf8edafde4c6a26ba9fafcd4625c",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4358040102320020": {
+			"ID":          4358040102320020,
+			"LoginName":   "pidgeotto.tail78f774.ts.net",
+			"DisplayName": "pidgeotto"
+		}}
+	}}, "pidgey": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         5166808499220992,
+			"StableID":   "ndVxAHJ4Mh11CNTRL",
+			"Name":       "pidgey.tail78f774.ts.net.",
+			"User":       5166808499220992,
+			"Key":        "nodekey:1e9bd7d9a03a3c63ff12bc92838e1bf60aabaaf7ca81ac7a1fedab6733dcca06",
+			"DiscoKey":   "discokey:86f6534f2942588e856b82f83fac632bc05790511db8cffcc8e8fa66b533872b",
+			"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+			"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+			"Endpoints": [
+				"77.164.248.136:48527",
+				"10.65.0.27:48527",
+				"172.17.0.1:48527",
+				"172.19.0.1:48527",
+				"172.20.0.1:48527"
+			],
+			"Hostinfo": {
+				"Hostname":    "pidgey",
+				"RoutableIPs": ["0.0.0.0/0", "::/0"],
+				"RequestTags": ["tag:pidgey"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-12T18:34:58.841426138Z",
+			"Tags":              ["tag:pidgey"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "pidgey",
+			"ComputedNameWithHost": "pidgey"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:1e9bd7d9a03a3c63ff12bc92838e1bf60aabaaf7ca81ac7a1fedab6733dcca06",
+		"MachineKey":        "mkey:ec3f6228bf56a6a9f2ce6bdb5bd7f519a8362d7ab949fa4ff20c1f90960d7b31",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"5166808499220992": {
+			"ID":          5166808499220992,
+			"LoginName":   "pidgey.tail78f774.ts.net",
+			"DisplayName": "pidgey"
+		}}
+	}}, "raticate": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         3417100059622635,
+			"StableID":   "nnWexbRcgT11CNTRL",
+			"Name":       "raticate.tail78f774.ts.net.",
+			"User":       3417100059622635,
+			"Key":        "nodekey:1a4593ac3bd0ddaa17915d42a0afa4e8c84261e485315a9d4bbf12fc3eda787c",
+			"DiscoKey":   "discokey:f016d8a3b0b9adec586c9a8178d551c594d93f7f8189cc73a7bcf1720a8b7163",
+			"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+			"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+			"Endpoints": [
+				"77.164.248.136:52486",
+				"10.65.0.27:52486",
+				"172.17.0.1:52486",
+				"172.19.0.1:52486",
+				"172.20.0.1:52486"
+			],
+			"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+				{"Proto": "peerapi4", "Port": 61927},
+				{"Proto": "peerapi6", "Port": 61927},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-12T18:35:01.003902717Z",
+			"Tags":              ["tag:group-b"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "raticate",
+			"ComputedNameWithHost": "raticate"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:1a4593ac3bd0ddaa17915d42a0afa4e8c84261e485315a9d4bbf12fc3eda787c",
+		"MachineKey":        "mkey:45eacadeb3e1dc37e61ba57f90d641816d2d82e15b6c032eabd8eee073eda538",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"3417100059622635": {
+			"ID":          3417100059622635,
+			"LoginName":   "raticate.tail78f774.ts.net",
+			"DisplayName": "raticate"
+		}}
+	}}, "rattata": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         7275076243629606,
+			"StableID":   "nfydKAvtoy11CNTRL",
+			"Name":       "rattata.tail78f774.ts.net.",
+			"User":       7275076243629606,
+			"Key":        "nodekey:647d1d249addd8de12742125014d6674aa792f9b2e2bd963d27d79b41d014c77",
+			"DiscoKey":   "discokey:42443e5c506923cbdeeae67fe106ab589ec5811fb4948457a5906c9325f75e6f",
+			"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+			"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+			"Endpoints": [
+				"77.164.248.136:37028",
+				"10.65.0.27:37028",
+				"172.17.0.1:37028",
+				"172.19.0.1:37028",
+				"172.20.0.1:37028"
+			],
+			"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+				{"Proto": "peerapi4", "Port": 41053},
+				{"Proto": "peerapi6", "Port": 41053},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-12T18:35:00.448810122Z",
+			"Tags":              ["tag:group-a"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "rattata",
+			"ComputedNameWithHost": "rattata"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:647d1d249addd8de12742125014d6674aa792f9b2e2bd963d27d79b41d014c77",
+		"MachineKey":        "mkey:55bd3f602a5675dee178d4b27ac4f572e1db1474ca4e71bb13e4c73f025e192e",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"7275076243629606": {
+			"ID":          7275076243629606,
+			"LoginName":   "rattata.tail78f774.ts.net",
+			"DisplayName": "rattata"
+		}}
+	}}, "spearow": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         7878752251363024,
+			"StableID":   "nBr8wmTJX421CNTRL",
+			"Name":       "spearow.tail78f774.ts.net.",
+			"User":       7878752251363024,
+			"Key":        "nodekey:e9855652502262efd0db7c61aef5eb82a7a992678f35e0e678c90b8fb8147511",
+			"DiscoKey":   "discokey:5a7f149c0c2084b82a99743e90b79a3b38ddd48bb51fdf32fccebb057810542e",
+			"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+			"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+			"Endpoints": [
+				"77.164.248.136:54109",
+				"10.65.0.27:54109",
+				"172.17.0.1:54109",
+				"172.19.0.1:54109",
+				"172.20.0.1:54109"
+			],
+			"Hostinfo": {
+				"Hostname":    "spearow",
+				"RoutableIPs": ["10.44.0.0/16"],
+				"RequestTags": ["tag:spearow"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-12T18:35:02.061106162Z",
+			"Tags":              ["tag:spearow"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "spearow",
+			"ComputedNameWithHost": "spearow"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:e9855652502262efd0db7c61aef5eb82a7a992678f35e0e678c90b8fb8147511",
+		"MachineKey":        "mkey:a5f4c73ef5d06ddf0f54db89694fb444800a2c38eb505f1b5fc755ecfefad850",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"7878752251363024": {
+			"ID":          7878752251363024,
+			"LoginName":   "spearow.tail78f774.ts.net",
+			"DisplayName": "spearow"
+		}}
+	}}, "squirtle": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         1201893115636145,
+			"StableID":   "nvHUwFhLPA11CNTRL",
+			"Name":       "squirtle.tail78f774.ts.net.",
+			"User":       1201893115636145,
+			"Key":        "nodekey:bdc67d3a7acf29cda4f6410c94ed9e784924c1c2deae1f93416fac73207eda5a",
+			"DiscoKey":   "discokey:856cd06ecde88f96a5b3c5bf963057662aad9839c30bc25b28ac960a1e3c7142",
+			"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+			"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+			"Endpoints": [
+				"77.164.248.136:42087",
+				"10.65.0.27:42087",
+				"172.17.0.1:42087",
+				"172.19.0.1:42087",
+				"172.20.0.1:42087"
+			],
+			"Hostinfo": {
+				"Hostname":    "squirtle",
+				"RoutableIPs": ["10.33.0.0/16"],
+				"RequestTags": ["tag:router"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-12T18:35:03.131075824Z",
+			"Tags":              ["tag:router"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "squirtle",
+			"ComputedNameWithHost": "squirtle"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:bdc67d3a7acf29cda4f6410c94ed9e784924c1c2deae1f93416fac73207eda5a",
+		"MachineKey":        "mkey:a1313a9ce8d1094208d9cdfe977a1d9e251d12a9e7354d555713ea8a1f675164",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1201893115636145": {
+			"ID":          1201893115636145,
+			"LoginName":   "squirtle.tail78f774.ts.net",
+			"DisplayName": "squirtle"
+		}}
+	}}, "venusaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         13461186144218,
+			"StableID":   "ndzavwb67111CNTRL",
+			"Name":       "venusaur.tail78f774.ts.net.",
+			"User":       3982058329734709,
+			"Key":        "nodekey:5bb31335aac015e117d3e098838fb9865cacc70a864141ed51be93886d4a2a65",
+			"KeyExpiry":  "2026-11-08T18:35:05Z",
+			"DiscoKey":   "discokey:657b254bb4b746830b34727bb4768d608751ea656b5f03d6574b6348f60fe52d",
+			"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"Endpoints": [
+				"77.164.248.136:45623",
+				"10.65.0.27:45623",
+				"172.17.0.1:45623",
+				"172.19.0.1:45623",
+				"172.20.0.1:45623"
+			],
+			"Hostinfo": {"Hostname": "venusaur", "Services": [
+				{"Proto": "peerapi4", "Port": 42394},
+				{"Proto": "peerapi6", "Port": 42394},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-12T18:35:05.846227052Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "venusaur",
+			"ComputedNameWithHost": "venusaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:5bb31335aac015e117d3e098838fb9865cacc70a864141ed51be93886d4a2a65",
+		"MachineKey":        "mkey:21c6bffb6812a2026e5bf9f5e6a9f4cee22132351721d2155722d65ff44aa753",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"3982058329734709": {
+			"ID":          3982058329734709,
+			"LoginName":   "freya@example.com",
+			"DisplayName": "freya"
+		}}
+	}}, "weedle": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         7653137166367252,
+			"StableID":   "nP8PTHw7m221CNTRL",
+			"Name":       "weedle.tail78f774.ts.net.",
+			"User":       7653137166367252,
+			"Key":        "nodekey:e86ea23726dfa5a535f09acef58ba7b75500572fcc65a5b2016a2948b4387f18",
+			"DiscoKey":   "discokey:67fa9cdcc41be72b8bcdabde1ebe0edca44615464bcb524040db6affcfa93e5a",
+			"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"Endpoints": [
+				"77.164.248.136:38444",
+				"10.65.0.27:38444",
+				"172.17.0.1:38444",
+				"172.19.0.1:38444",
+				"172.20.0.1:38444"
+			],
+			"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+				{"Proto": "peerapi4", "Port": 63957},
+				{"Proto": "peerapi6", "Port": 63957},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-12T18:35:03.690855878Z",
+			"Tags":              ["tag:client"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "weedle",
+			"ComputedNameWithHost": "weedle"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:e86ea23726dfa5a535f09acef58ba7b75500572fcc65a5b2016a2948b4387f18",
+		"MachineKey":        "mkey:ce0dcb31c85556955fd002720e9848ec21463b222892c84e52cd876cc407d671",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"7653137166367252": {
+			"ID":          7653137166367252,
+			"LoginName":   "weedle.tail78f774.ts.net",
+			"DisplayName": "weedle"
+		}}
+	}}}
+}

--- a/hscontrol/policy/v2/testdata/sshtest_results/sshtest-both-tests-pass-sshTests-fail.hujson
+++ b/hscontrol/policy/v2/testdata/sshtest_results/sshtest-both-tests-pass-sshTests-fail.hujson
@@ -1,0 +1,20090 @@
+// sshtest-both-tests-pass-sshTests-fail
+//
+// tests passes, sshTests fails -> SaaS rejects
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T18:35:51Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "sshtest-both-tests-pass-sshTests-fail",
+	"description":    "tests passes, sshTests fails -> SaaS rejects",
+	"category":       "sshtest",
+	"captured_at":    "2026-05-12T18:35:51.603668476Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                        \n  \n                                                                    \n                                                            \n{\n\t\"category\":    \"sshtest\",\n\t\"description\": \"tests passes, sshTests fails -> SaaS rejects\",\n\t\"id\":          \"sshtest-both-tests-pass-sshTests-fail\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"acls\": [\n\t\t{\"action\": \"accept\", \"dst\": [\"tag:server:22\"], \"src\": [\"thor@example.org\"]}\n\t], \"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"thor@example.org\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"sshTests\": [{\n\t\t\"accept\": [\"mallory\"],\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    \"thor@example.org\"\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}, \"tests\": [\n\t\t{\"accept\": [\"tag:server:22\"], \"src\": \"thor@example.org\"}\n\t]},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/sshtest/sshtest-both-tests-pass-sshTests-fail.hujson",
+		"full_policy": {
+			"acls": [{
+				"action": "accept",
+				"dst":    ["tag:server:22"],
+				"src":    ["thor@example.org"]
+			}],
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["thor@example.org"],
+				"users":  ["root"]
+			}],
+			"sshTests": [
+				{"accept": ["mallory"], "dst": ["tag:server"], "src": "thor@example.org"}
+			],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]},
+			"tests":     [{"accept": ["tag:server:22"], "src": "thor@example.org"}]
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3575030889276975,
+				"StableID":   "niGuZxz8vU11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       3575030889276975,
+				"Key":        "nodekey:288f9583e296edfbe8c217ea5db512d2953bc5ed35fd3b931b8bfe6de4408419",
+				"DiscoKey":   "discokey:4e783cab54c5941c5e9bf63ad04a75509b77829a1472b49be084344cd36a3151",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46705",
+					"10.65.0.27:46705",
+					"172.17.0.1:46705",
+					"172.19.0.1:46705",
+					"172.20.0.1:46705"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:36:00.068839759Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:288f9583e296edfbe8c217ea5db512d2953bc5ed35fd3b931b8bfe6de4408419",
+			"MachineKey": "mkey:40960c8829449e8d2f9efd04cc1eedd64484a25bf5340512309b6ed63b7a2006",
+			"Peers": [{
+				"ID":         7411601795144039,
+				"StableID":   "n2SLoFDjsz11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39bcb05d9e43c3e019896b3ee1d45c25d8de8157b4935cd119b532e2bee40740",
+				"DiscoKey":   "discokey:9d99beee748b0a02a460728e2e4a32eff34671fe256c25f593e5d499b7d14b32",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33962",
+					"10.65.0.27:33962",
+					"172.17.0.1:33962",
+					"172.19.0.1:33962",
+					"172.20.0.1:33962"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:35:54.138346186Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8083362849184876,
+				"StableID":   "n97oodEy7621CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b99c19c8696167b8aa649553bbc49427e4ac235a341c2b799495abcadabb752",
+				"DiscoKey":   "discokey:5fe4d987d7899019b40a5d020848d8feadcfd89064237d868314dc502e1db342",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54968",
+					"10.65.0.27:54968",
+					"172.17.0.1:54968",
+					"172.19.0.1:54968",
+					"172.20.0.1:54968"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:35:54.674766883Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8231454160451900,
+				"StableID":   "nFzNssL3H721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:33b07d001b7ddbe4ce31bad55dff70864d516ef9e9d1eb08c97741d9357b8f21",
+				"DiscoKey":   "discokey:4783c0e34488b3aba08f0aa1739c332bf76ad7a9a46052231d9f4484eb34600e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52193",
+					"10.65.0.27:52193",
+					"172.17.0.1:52193",
+					"172.19.0.1:52193",
+					"172.20.0.1:52193"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:35:55.225148997Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1295019951997443,
+				"StableID":   "nUF6ajyW7B11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bb6cf8789c71ef859aa18b6ed9dbf39f03008a7dcaef60de72ea484372472221",
+				"DiscoKey":   "discokey:b0dfe75e6f3a39d071329257e072773284cf237cbed1303973ca11f221223065",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:48991",
+					"10.65.0.27:48991",
+					"172.17.0.1:48991",
+					"172.19.0.1:48991",
+					"172.20.0.1:48991"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:35:55.762603598Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3697785131496041,
+				"StableID":   "naRobcYjsV11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:946c833d3613c50bef1739b136b074a176a56b8c0db28f0568aeba6593c7283e",
+				"DiscoKey":   "discokey:d8f4eeed4adc86c3505203fe1dd6d2c9f0d7d5bea17befe201061fff5c6c2b7a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37191",
+					"10.65.0.27:37191",
+					"172.17.0.1:37191",
+					"172.19.0.1:37191",
+					"172.20.0.1:37191"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:35:56.302977665Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3761910066954421,
+				"StableID":   "ntzXZuzmNW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5fe38d5b65c4064ccdbfeed5ba6fce51ef98aab5c9698c9a1ed75a4db3ca123",
+				"DiscoKey":   "discokey:0e3b27e92f3225273c5dd21f3305f45906d27d1f0d070372dcc3efbb5d03356c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:35061",
+					"10.65.0.27:35061",
+					"172.17.0.1:35061",
+					"172.19.0.1:35061",
+					"172.20.0.1:35061"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:35:56.83944357Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7254963029272968,
+				"StableID":   "nbchSSaney11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f520bb3a00890401189333dbfe00690b8fdda98a7d44414fd7775316fa48747",
+				"DiscoKey":   "discokey:60a9b0eda72464868b693e7168dc7888f01781780b97caa4af4d83ccc6c08212",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35085",
+					"10.65.0.27:35085",
+					"172.17.0.1:35085",
+					"172.19.0.1:35085",
+					"172.20.0.1:35085"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:35:57.385639242Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7649445423865526,
+				"StableID":   "n1k5pgxSj221CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:123f9b086c97174e156411cf94f1bda8a4b5a6652b19fe1b7dec811488b3eb69",
+				"DiscoKey":   "discokey:428c1c13dfa68666573b1119bd52c5b512626f0fcdeb903d60c45c631373041c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:53510",
+					"10.65.0.27:53510",
+					"172.17.0.1:53510",
+					"172.19.0.1:53510",
+					"172.20.0.1:53510"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:35:57.928832629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4367341642538930,
+				"StableID":   "n7w9hEfy6b11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93939eea7cc260a57cce179480eb3059180f77f95880bc399d56d028f7d26f62",
+				"DiscoKey":   "discokey:a3ff6a8f814121fc413a519f258139e9ca3d4605362a244621122e9254e3d154",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34703",
+					"10.65.0.27:34703",
+					"172.17.0.1:34703",
+					"172.19.0.1:34703",
+					"172.20.0.1:34703"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:35:58.461822087Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3836926821391324,
+				"StableID":   "nXcXGZZkxW11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:646d0687e4551d3e616df3a73a834b8a7f120d22ae098aacc97b5b12af56877e",
+				"DiscoKey":   "discokey:a42d906ca45f306be44c810cea8dcb6aa3c1dc92ccd4c3baeda4095434ae1170",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47875",
+					"10.65.0.27:47875",
+					"172.17.0.1:47875",
+					"172.19.0.1:47875",
+					"172.20.0.1:47875"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:35:59.004222599Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1397648430420696,
+				"StableID":   "nKztmYrzuB11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8ecf2dcc160d9ef0155ef29fd4f50f7776455c8764413f77779b32f40842e11e",
+				"DiscoKey":   "discokey:a2eeb418c1171d64359263940844afda5d9bd97b45e1aeb369c427b238c5c664",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50009",
+					"10.65.0.27:50009",
+					"172.17.0.1:50009",
+					"172.19.0.1:50009",
+					"172.20.0.1:50009"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:35:59.531601629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5357389921876185,
+				"StableID":   "nxppspYNqi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b774e49d8cd5f461be6f2c6718c0dc741cf6bd579d44b4e892def1ed87600824",
+				"KeyExpiry":  "2026-11-08T18:36:00Z",
+				"DiscoKey":   "discokey:37924c46e316c320bfd9ece51608310981f84e8f23b306996e8278e13ecdc816",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33630",
+					"10.65.0.27:33630",
+					"172.17.0.1:33630",
+					"172.19.0.1:33630",
+					"172.20.0.1:33630"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:36:00.613120864Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4626505136556407,
+				"StableID":   "ninJCoSM8d11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2182b351bbc58393c83327e9db319378bcfcd1eeb0f8f91004261db5d732b173",
+				"KeyExpiry":  "2026-11-08T18:36:01Z",
+				"DiscoKey":   "discokey:6ed1cf6c9216f827c713788474580dad4f04cd0504339a75569b4bdb70873870",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60453",
+					"10.65.0.27:60453",
+					"172.17.0.1:60453",
+					"172.19.0.1:60453",
+					"172.20.0.1:60453"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:36:01.152066159Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2137527263137108,
+				"StableID":   "n99GdZD6hH11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:782c40cd767b310f562618924caeb8cc7bbaa3399dfda9ecb1a8154d8fd38e17",
+				"KeyExpiry":  "2026-11-08T18:36:01Z",
+				"DiscoKey":   "discokey:681c5180c4c086e43a0102848695b9dec317228fbe5afec097c0e270ed51574a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57911",
+					"10.65.0.27:57911",
+					"172.17.0.1:57911",
+					"172.19.0.1:57911",
+					"172.20.0.1:57911"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:36:01.695480091Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3575030889276975": {
+				"ID":          3575030889276975,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3761910066954421,
+				"StableID":   "ntzXZuzmNW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       3761910066954421,
+				"Key":        "nodekey:e5fe38d5b65c4064ccdbfeed5ba6fce51ef98aab5c9698c9a1ed75a4db3ca123",
+				"DiscoKey":   "discokey:0e3b27e92f3225273c5dd21f3305f45906d27d1f0d070372dcc3efbb5d03356c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:35061",
+					"10.65.0.27:35061",
+					"172.17.0.1:35061",
+					"172.19.0.1:35061",
+					"172.20.0.1:35061"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:35:56.83944357Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e5fe38d5b65c4064ccdbfeed5ba6fce51ef98aab5c9698c9a1ed75a4db3ca123",
+			"MachineKey": "mkey:90fd2ec36ae86956a5f2a268d561051b7edd7bbae73a2fd519a82d32667de60f",
+			"Peers": [{
+				"ID":         7411601795144039,
+				"StableID":   "n2SLoFDjsz11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39bcb05d9e43c3e019896b3ee1d45c25d8de8157b4935cd119b532e2bee40740",
+				"DiscoKey":   "discokey:9d99beee748b0a02a460728e2e4a32eff34671fe256c25f593e5d499b7d14b32",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33962",
+					"10.65.0.27:33962",
+					"172.17.0.1:33962",
+					"172.19.0.1:33962",
+					"172.20.0.1:33962"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:35:54.138346186Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8083362849184876,
+				"StableID":   "n97oodEy7621CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b99c19c8696167b8aa649553bbc49427e4ac235a341c2b799495abcadabb752",
+				"DiscoKey":   "discokey:5fe4d987d7899019b40a5d020848d8feadcfd89064237d868314dc502e1db342",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54968",
+					"10.65.0.27:54968",
+					"172.17.0.1:54968",
+					"172.19.0.1:54968",
+					"172.20.0.1:54968"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:35:54.674766883Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8231454160451900,
+				"StableID":   "nFzNssL3H721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:33b07d001b7ddbe4ce31bad55dff70864d516ef9e9d1eb08c97741d9357b8f21",
+				"DiscoKey":   "discokey:4783c0e34488b3aba08f0aa1739c332bf76ad7a9a46052231d9f4484eb34600e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52193",
+					"10.65.0.27:52193",
+					"172.17.0.1:52193",
+					"172.19.0.1:52193",
+					"172.20.0.1:52193"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:35:55.225148997Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1295019951997443,
+				"StableID":   "nUF6ajyW7B11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bb6cf8789c71ef859aa18b6ed9dbf39f03008a7dcaef60de72ea484372472221",
+				"DiscoKey":   "discokey:b0dfe75e6f3a39d071329257e072773284cf237cbed1303973ca11f221223065",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:48991",
+					"10.65.0.27:48991",
+					"172.17.0.1:48991",
+					"172.19.0.1:48991",
+					"172.20.0.1:48991"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:35:55.762603598Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3697785131496041,
+				"StableID":   "naRobcYjsV11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:946c833d3613c50bef1739b136b074a176a56b8c0db28f0568aeba6593c7283e",
+				"DiscoKey":   "discokey:d8f4eeed4adc86c3505203fe1dd6d2c9f0d7d5bea17befe201061fff5c6c2b7a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37191",
+					"10.65.0.27:37191",
+					"172.17.0.1:37191",
+					"172.19.0.1:37191",
+					"172.20.0.1:37191"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:35:56.302977665Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7254963029272968,
+				"StableID":   "nbchSSaney11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f520bb3a00890401189333dbfe00690b8fdda98a7d44414fd7775316fa48747",
+				"DiscoKey":   "discokey:60a9b0eda72464868b693e7168dc7888f01781780b97caa4af4d83ccc6c08212",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35085",
+					"10.65.0.27:35085",
+					"172.17.0.1:35085",
+					"172.19.0.1:35085",
+					"172.20.0.1:35085"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:35:57.385639242Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7649445423865526,
+				"StableID":   "n1k5pgxSj221CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:123f9b086c97174e156411cf94f1bda8a4b5a6652b19fe1b7dec811488b3eb69",
+				"DiscoKey":   "discokey:428c1c13dfa68666573b1119bd52c5b512626f0fcdeb903d60c45c631373041c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:53510",
+					"10.65.0.27:53510",
+					"172.17.0.1:53510",
+					"172.19.0.1:53510",
+					"172.20.0.1:53510"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:35:57.928832629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4367341642538930,
+				"StableID":   "n7w9hEfy6b11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93939eea7cc260a57cce179480eb3059180f77f95880bc399d56d028f7d26f62",
+				"DiscoKey":   "discokey:a3ff6a8f814121fc413a519f258139e9ca3d4605362a244621122e9254e3d154",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34703",
+					"10.65.0.27:34703",
+					"172.17.0.1:34703",
+					"172.19.0.1:34703",
+					"172.20.0.1:34703"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:35:58.461822087Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3836926821391324,
+				"StableID":   "nXcXGZZkxW11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:646d0687e4551d3e616df3a73a834b8a7f120d22ae098aacc97b5b12af56877e",
+				"DiscoKey":   "discokey:a42d906ca45f306be44c810cea8dcb6aa3c1dc92ccd4c3baeda4095434ae1170",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47875",
+					"10.65.0.27:47875",
+					"172.17.0.1:47875",
+					"172.19.0.1:47875",
+					"172.20.0.1:47875"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:35:59.004222599Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1397648430420696,
+				"StableID":   "nKztmYrzuB11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8ecf2dcc160d9ef0155ef29fd4f50f7776455c8764413f77779b32f40842e11e",
+				"DiscoKey":   "discokey:a2eeb418c1171d64359263940844afda5d9bd97b45e1aeb369c427b238c5c664",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50009",
+					"10.65.0.27:50009",
+					"172.17.0.1:50009",
+					"172.19.0.1:50009",
+					"172.20.0.1:50009"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:35:59.531601629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3575030889276975,
+				"StableID":   "niGuZxz8vU11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:288f9583e296edfbe8c217ea5db512d2953bc5ed35fd3b931b8bfe6de4408419",
+				"DiscoKey":   "discokey:4e783cab54c5941c5e9bf63ad04a75509b77829a1472b49be084344cd36a3151",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46705",
+					"10.65.0.27:46705",
+					"172.17.0.1:46705",
+					"172.19.0.1:46705",
+					"172.20.0.1:46705"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:36:00.068839759Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5357389921876185,
+				"StableID":   "nxppspYNqi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b774e49d8cd5f461be6f2c6718c0dc741cf6bd579d44b4e892def1ed87600824",
+				"KeyExpiry":  "2026-11-08T18:36:00Z",
+				"DiscoKey":   "discokey:37924c46e316c320bfd9ece51608310981f84e8f23b306996e8278e13ecdc816",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33630",
+					"10.65.0.27:33630",
+					"172.17.0.1:33630",
+					"172.19.0.1:33630",
+					"172.20.0.1:33630"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:36:00.613120864Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4626505136556407,
+				"StableID":   "ninJCoSM8d11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2182b351bbc58393c83327e9db319378bcfcd1eeb0f8f91004261db5d732b173",
+				"KeyExpiry":  "2026-11-08T18:36:01Z",
+				"DiscoKey":   "discokey:6ed1cf6c9216f827c713788474580dad4f04cd0504339a75569b4bdb70873870",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60453",
+					"10.65.0.27:60453",
+					"172.17.0.1:60453",
+					"172.19.0.1:60453",
+					"172.20.0.1:60453"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:36:01.152066159Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2137527263137108,
+				"StableID":   "n99GdZD6hH11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:782c40cd767b310f562618924caeb8cc7bbaa3399dfda9ecb1a8154d8fd38e17",
+				"KeyExpiry":  "2026-11-08T18:36:01Z",
+				"DiscoKey":   "discokey:681c5180c4c086e43a0102848695b9dec317228fbe5afec097c0e270ed51574a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57911",
+					"10.65.0.27:57911",
+					"172.17.0.1:57911",
+					"172.19.0.1:57911",
+					"172.20.0.1:57911"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:36:01.695480091Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3761910066954421": {
+				"ID":          3761910066954421,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2137527263137108,
+				"StableID":   "n99GdZD6hH11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:782c40cd767b310f562618924caeb8cc7bbaa3399dfda9ecb1a8154d8fd38e17",
+				"KeyExpiry":  "2026-11-08T18:36:01Z",
+				"DiscoKey":   "discokey:681c5180c4c086e43a0102848695b9dec317228fbe5afec097c0e270ed51574a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57911",
+					"10.65.0.27:57911",
+					"172.17.0.1:57911",
+					"172.19.0.1:57911",
+					"172.20.0.1:57911"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:36:01.695480091Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:782c40cd767b310f562618924caeb8cc7bbaa3399dfda9ecb1a8154d8fd38e17",
+			"MachineKey": "mkey:6fde22073dec22acc1a759b647f591e379b47409469ae00cf2bf100d7bb8ae76",
+			"Peers": [{
+				"ID":         7411601795144039,
+				"StableID":   "n2SLoFDjsz11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39bcb05d9e43c3e019896b3ee1d45c25d8de8157b4935cd119b532e2bee40740",
+				"DiscoKey":   "discokey:9d99beee748b0a02a460728e2e4a32eff34671fe256c25f593e5d499b7d14b32",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33962",
+					"10.65.0.27:33962",
+					"172.17.0.1:33962",
+					"172.19.0.1:33962",
+					"172.20.0.1:33962"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:35:54.138346186Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8083362849184876,
+				"StableID":   "n97oodEy7621CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b99c19c8696167b8aa649553bbc49427e4ac235a341c2b799495abcadabb752",
+				"DiscoKey":   "discokey:5fe4d987d7899019b40a5d020848d8feadcfd89064237d868314dc502e1db342",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54968",
+					"10.65.0.27:54968",
+					"172.17.0.1:54968",
+					"172.19.0.1:54968",
+					"172.20.0.1:54968"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:35:54.674766883Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8231454160451900,
+				"StableID":   "nFzNssL3H721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:33b07d001b7ddbe4ce31bad55dff70864d516ef9e9d1eb08c97741d9357b8f21",
+				"DiscoKey":   "discokey:4783c0e34488b3aba08f0aa1739c332bf76ad7a9a46052231d9f4484eb34600e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52193",
+					"10.65.0.27:52193",
+					"172.17.0.1:52193",
+					"172.19.0.1:52193",
+					"172.20.0.1:52193"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:35:55.225148997Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1295019951997443,
+				"StableID":   "nUF6ajyW7B11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bb6cf8789c71ef859aa18b6ed9dbf39f03008a7dcaef60de72ea484372472221",
+				"DiscoKey":   "discokey:b0dfe75e6f3a39d071329257e072773284cf237cbed1303973ca11f221223065",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:48991",
+					"10.65.0.27:48991",
+					"172.17.0.1:48991",
+					"172.19.0.1:48991",
+					"172.20.0.1:48991"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:35:55.762603598Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3697785131496041,
+				"StableID":   "naRobcYjsV11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:946c833d3613c50bef1739b136b074a176a56b8c0db28f0568aeba6593c7283e",
+				"DiscoKey":   "discokey:d8f4eeed4adc86c3505203fe1dd6d2c9f0d7d5bea17befe201061fff5c6c2b7a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37191",
+					"10.65.0.27:37191",
+					"172.17.0.1:37191",
+					"172.19.0.1:37191",
+					"172.20.0.1:37191"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:35:56.302977665Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3761910066954421,
+				"StableID":   "ntzXZuzmNW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5fe38d5b65c4064ccdbfeed5ba6fce51ef98aab5c9698c9a1ed75a4db3ca123",
+				"DiscoKey":   "discokey:0e3b27e92f3225273c5dd21f3305f45906d27d1f0d070372dcc3efbb5d03356c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:35061",
+					"10.65.0.27:35061",
+					"172.17.0.1:35061",
+					"172.19.0.1:35061",
+					"172.20.0.1:35061"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:35:56.83944357Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7254963029272968,
+				"StableID":   "nbchSSaney11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f520bb3a00890401189333dbfe00690b8fdda98a7d44414fd7775316fa48747",
+				"DiscoKey":   "discokey:60a9b0eda72464868b693e7168dc7888f01781780b97caa4af4d83ccc6c08212",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35085",
+					"10.65.0.27:35085",
+					"172.17.0.1:35085",
+					"172.19.0.1:35085",
+					"172.20.0.1:35085"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:35:57.385639242Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7649445423865526,
+				"StableID":   "n1k5pgxSj221CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:123f9b086c97174e156411cf94f1bda8a4b5a6652b19fe1b7dec811488b3eb69",
+				"DiscoKey":   "discokey:428c1c13dfa68666573b1119bd52c5b512626f0fcdeb903d60c45c631373041c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:53510",
+					"10.65.0.27:53510",
+					"172.17.0.1:53510",
+					"172.19.0.1:53510",
+					"172.20.0.1:53510"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:35:57.928832629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4367341642538930,
+				"StableID":   "n7w9hEfy6b11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93939eea7cc260a57cce179480eb3059180f77f95880bc399d56d028f7d26f62",
+				"DiscoKey":   "discokey:a3ff6a8f814121fc413a519f258139e9ca3d4605362a244621122e9254e3d154",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34703",
+					"10.65.0.27:34703",
+					"172.17.0.1:34703",
+					"172.19.0.1:34703",
+					"172.20.0.1:34703"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:35:58.461822087Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3836926821391324,
+				"StableID":   "nXcXGZZkxW11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:646d0687e4551d3e616df3a73a834b8a7f120d22ae098aacc97b5b12af56877e",
+				"DiscoKey":   "discokey:a42d906ca45f306be44c810cea8dcb6aa3c1dc92ccd4c3baeda4095434ae1170",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47875",
+					"10.65.0.27:47875",
+					"172.17.0.1:47875",
+					"172.19.0.1:47875",
+					"172.20.0.1:47875"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:35:59.004222599Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1397648430420696,
+				"StableID":   "nKztmYrzuB11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8ecf2dcc160d9ef0155ef29fd4f50f7776455c8764413f77779b32f40842e11e",
+				"DiscoKey":   "discokey:a2eeb418c1171d64359263940844afda5d9bd97b45e1aeb369c427b238c5c664",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50009",
+					"10.65.0.27:50009",
+					"172.17.0.1:50009",
+					"172.19.0.1:50009",
+					"172.20.0.1:50009"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:35:59.531601629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3575030889276975,
+				"StableID":   "niGuZxz8vU11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:288f9583e296edfbe8c217ea5db512d2953bc5ed35fd3b931b8bfe6de4408419",
+				"DiscoKey":   "discokey:4e783cab54c5941c5e9bf63ad04a75509b77829a1472b49be084344cd36a3151",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46705",
+					"10.65.0.27:46705",
+					"172.17.0.1:46705",
+					"172.19.0.1:46705",
+					"172.20.0.1:46705"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:36:00.068839759Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5357389921876185,
+				"StableID":   "nxppspYNqi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b774e49d8cd5f461be6f2c6718c0dc741cf6bd579d44b4e892def1ed87600824",
+				"KeyExpiry":  "2026-11-08T18:36:00Z",
+				"DiscoKey":   "discokey:37924c46e316c320bfd9ece51608310981f84e8f23b306996e8278e13ecdc816",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33630",
+					"10.65.0.27:33630",
+					"172.17.0.1:33630",
+					"172.19.0.1:33630",
+					"172.20.0.1:33630"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:36:00.613120864Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4626505136556407,
+				"StableID":   "ninJCoSM8d11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2182b351bbc58393c83327e9db319378bcfcd1eeb0f8f91004261db5d732b173",
+				"KeyExpiry":  "2026-11-08T18:36:01Z",
+				"DiscoKey":   "discokey:6ed1cf6c9216f827c713788474580dad4f04cd0504339a75569b4bdb70873870",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60453",
+					"10.65.0.27:60453",
+					"172.17.0.1:60453",
+					"172.19.0.1:60453",
+					"172.20.0.1:60453"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:36:01.152066159Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8231454160451900,
+				"StableID":   "nFzNssL3H721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       8231454160451900,
+				"Key":        "nodekey:33b07d001b7ddbe4ce31bad55dff70864d516ef9e9d1eb08c97741d9357b8f21",
+				"DiscoKey":   "discokey:4783c0e34488b3aba08f0aa1739c332bf76ad7a9a46052231d9f4484eb34600e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52193",
+					"10.65.0.27:52193",
+					"172.17.0.1:52193",
+					"172.19.0.1:52193",
+					"172.20.0.1:52193"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:35:55.225148997Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:33b07d001b7ddbe4ce31bad55dff70864d516ef9e9d1eb08c97741d9357b8f21",
+			"MachineKey": "mkey:6b8794d4625d1a6770bba1d71e8d04f2092dd96481b4507a1adbda797a2cea25",
+			"Peers": [{
+				"ID":         7411601795144039,
+				"StableID":   "n2SLoFDjsz11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39bcb05d9e43c3e019896b3ee1d45c25d8de8157b4935cd119b532e2bee40740",
+				"DiscoKey":   "discokey:9d99beee748b0a02a460728e2e4a32eff34671fe256c25f593e5d499b7d14b32",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33962",
+					"10.65.0.27:33962",
+					"172.17.0.1:33962",
+					"172.19.0.1:33962",
+					"172.20.0.1:33962"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:35:54.138346186Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8083362849184876,
+				"StableID":   "n97oodEy7621CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b99c19c8696167b8aa649553bbc49427e4ac235a341c2b799495abcadabb752",
+				"DiscoKey":   "discokey:5fe4d987d7899019b40a5d020848d8feadcfd89064237d868314dc502e1db342",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54968",
+					"10.65.0.27:54968",
+					"172.17.0.1:54968",
+					"172.19.0.1:54968",
+					"172.20.0.1:54968"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:35:54.674766883Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1295019951997443,
+				"StableID":   "nUF6ajyW7B11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bb6cf8789c71ef859aa18b6ed9dbf39f03008a7dcaef60de72ea484372472221",
+				"DiscoKey":   "discokey:b0dfe75e6f3a39d071329257e072773284cf237cbed1303973ca11f221223065",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:48991",
+					"10.65.0.27:48991",
+					"172.17.0.1:48991",
+					"172.19.0.1:48991",
+					"172.20.0.1:48991"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:35:55.762603598Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3697785131496041,
+				"StableID":   "naRobcYjsV11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:946c833d3613c50bef1739b136b074a176a56b8c0db28f0568aeba6593c7283e",
+				"DiscoKey":   "discokey:d8f4eeed4adc86c3505203fe1dd6d2c9f0d7d5bea17befe201061fff5c6c2b7a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37191",
+					"10.65.0.27:37191",
+					"172.17.0.1:37191",
+					"172.19.0.1:37191",
+					"172.20.0.1:37191"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:35:56.302977665Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3761910066954421,
+				"StableID":   "ntzXZuzmNW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5fe38d5b65c4064ccdbfeed5ba6fce51ef98aab5c9698c9a1ed75a4db3ca123",
+				"DiscoKey":   "discokey:0e3b27e92f3225273c5dd21f3305f45906d27d1f0d070372dcc3efbb5d03356c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:35061",
+					"10.65.0.27:35061",
+					"172.17.0.1:35061",
+					"172.19.0.1:35061",
+					"172.20.0.1:35061"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:35:56.83944357Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7254963029272968,
+				"StableID":   "nbchSSaney11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f520bb3a00890401189333dbfe00690b8fdda98a7d44414fd7775316fa48747",
+				"DiscoKey":   "discokey:60a9b0eda72464868b693e7168dc7888f01781780b97caa4af4d83ccc6c08212",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35085",
+					"10.65.0.27:35085",
+					"172.17.0.1:35085",
+					"172.19.0.1:35085",
+					"172.20.0.1:35085"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:35:57.385639242Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7649445423865526,
+				"StableID":   "n1k5pgxSj221CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:123f9b086c97174e156411cf94f1bda8a4b5a6652b19fe1b7dec811488b3eb69",
+				"DiscoKey":   "discokey:428c1c13dfa68666573b1119bd52c5b512626f0fcdeb903d60c45c631373041c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:53510",
+					"10.65.0.27:53510",
+					"172.17.0.1:53510",
+					"172.19.0.1:53510",
+					"172.20.0.1:53510"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:35:57.928832629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4367341642538930,
+				"StableID":   "n7w9hEfy6b11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93939eea7cc260a57cce179480eb3059180f77f95880bc399d56d028f7d26f62",
+				"DiscoKey":   "discokey:a3ff6a8f814121fc413a519f258139e9ca3d4605362a244621122e9254e3d154",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34703",
+					"10.65.0.27:34703",
+					"172.17.0.1:34703",
+					"172.19.0.1:34703",
+					"172.20.0.1:34703"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:35:58.461822087Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3836926821391324,
+				"StableID":   "nXcXGZZkxW11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:646d0687e4551d3e616df3a73a834b8a7f120d22ae098aacc97b5b12af56877e",
+				"DiscoKey":   "discokey:a42d906ca45f306be44c810cea8dcb6aa3c1dc92ccd4c3baeda4095434ae1170",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47875",
+					"10.65.0.27:47875",
+					"172.17.0.1:47875",
+					"172.19.0.1:47875",
+					"172.20.0.1:47875"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:35:59.004222599Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1397648430420696,
+				"StableID":   "nKztmYrzuB11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8ecf2dcc160d9ef0155ef29fd4f50f7776455c8764413f77779b32f40842e11e",
+				"DiscoKey":   "discokey:a2eeb418c1171d64359263940844afda5d9bd97b45e1aeb369c427b238c5c664",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50009",
+					"10.65.0.27:50009",
+					"172.17.0.1:50009",
+					"172.19.0.1:50009",
+					"172.20.0.1:50009"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:35:59.531601629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3575030889276975,
+				"StableID":   "niGuZxz8vU11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:288f9583e296edfbe8c217ea5db512d2953bc5ed35fd3b931b8bfe6de4408419",
+				"DiscoKey":   "discokey:4e783cab54c5941c5e9bf63ad04a75509b77829a1472b49be084344cd36a3151",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46705",
+					"10.65.0.27:46705",
+					"172.17.0.1:46705",
+					"172.19.0.1:46705",
+					"172.20.0.1:46705"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:36:00.068839759Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5357389921876185,
+				"StableID":   "nxppspYNqi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b774e49d8cd5f461be6f2c6718c0dc741cf6bd579d44b4e892def1ed87600824",
+				"KeyExpiry":  "2026-11-08T18:36:00Z",
+				"DiscoKey":   "discokey:37924c46e316c320bfd9ece51608310981f84e8f23b306996e8278e13ecdc816",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33630",
+					"10.65.0.27:33630",
+					"172.17.0.1:33630",
+					"172.19.0.1:33630",
+					"172.20.0.1:33630"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:36:00.613120864Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4626505136556407,
+				"StableID":   "ninJCoSM8d11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2182b351bbc58393c83327e9db319378bcfcd1eeb0f8f91004261db5d732b173",
+				"KeyExpiry":  "2026-11-08T18:36:01Z",
+				"DiscoKey":   "discokey:6ed1cf6c9216f827c713788474580dad4f04cd0504339a75569b4bdb70873870",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60453",
+					"10.65.0.27:60453",
+					"172.17.0.1:60453",
+					"172.19.0.1:60453",
+					"172.20.0.1:60453"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:36:01.152066159Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2137527263137108,
+				"StableID":   "n99GdZD6hH11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:782c40cd767b310f562618924caeb8cc7bbaa3399dfda9ecb1a8154d8fd38e17",
+				"KeyExpiry":  "2026-11-08T18:36:01Z",
+				"DiscoKey":   "discokey:681c5180c4c086e43a0102848695b9dec317228fbe5afec097c0e270ed51574a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57911",
+					"10.65.0.27:57911",
+					"172.17.0.1:57911",
+					"172.19.0.1:57911",
+					"172.20.0.1:57911"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:36:01.695480091Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8231454160451900": {
+				"ID":          8231454160451900,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7649445423865526,
+				"StableID":   "n1k5pgxSj221CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       7649445423865526,
+				"Key":        "nodekey:123f9b086c97174e156411cf94f1bda8a4b5a6652b19fe1b7dec811488b3eb69",
+				"DiscoKey":   "discokey:428c1c13dfa68666573b1119bd52c5b512626f0fcdeb903d60c45c631373041c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:53510",
+					"10.65.0.27:53510",
+					"172.17.0.1:53510",
+					"172.19.0.1:53510",
+					"172.20.0.1:53510"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:35:57.928832629Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:123f9b086c97174e156411cf94f1bda8a4b5a6652b19fe1b7dec811488b3eb69",
+			"MachineKey": "mkey:e11ff8a1c7673b1474d569e58bcf03070ccef103e9f5156b037fd9fc815f2c1d",
+			"Peers": [{
+				"ID":         7411601795144039,
+				"StableID":   "n2SLoFDjsz11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39bcb05d9e43c3e019896b3ee1d45c25d8de8157b4935cd119b532e2bee40740",
+				"DiscoKey":   "discokey:9d99beee748b0a02a460728e2e4a32eff34671fe256c25f593e5d499b7d14b32",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33962",
+					"10.65.0.27:33962",
+					"172.17.0.1:33962",
+					"172.19.0.1:33962",
+					"172.20.0.1:33962"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:35:54.138346186Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8083362849184876,
+				"StableID":   "n97oodEy7621CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b99c19c8696167b8aa649553bbc49427e4ac235a341c2b799495abcadabb752",
+				"DiscoKey":   "discokey:5fe4d987d7899019b40a5d020848d8feadcfd89064237d868314dc502e1db342",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54968",
+					"10.65.0.27:54968",
+					"172.17.0.1:54968",
+					"172.19.0.1:54968",
+					"172.20.0.1:54968"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:35:54.674766883Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8231454160451900,
+				"StableID":   "nFzNssL3H721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:33b07d001b7ddbe4ce31bad55dff70864d516ef9e9d1eb08c97741d9357b8f21",
+				"DiscoKey":   "discokey:4783c0e34488b3aba08f0aa1739c332bf76ad7a9a46052231d9f4484eb34600e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52193",
+					"10.65.0.27:52193",
+					"172.17.0.1:52193",
+					"172.19.0.1:52193",
+					"172.20.0.1:52193"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:35:55.225148997Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1295019951997443,
+				"StableID":   "nUF6ajyW7B11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bb6cf8789c71ef859aa18b6ed9dbf39f03008a7dcaef60de72ea484372472221",
+				"DiscoKey":   "discokey:b0dfe75e6f3a39d071329257e072773284cf237cbed1303973ca11f221223065",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:48991",
+					"10.65.0.27:48991",
+					"172.17.0.1:48991",
+					"172.19.0.1:48991",
+					"172.20.0.1:48991"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:35:55.762603598Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3697785131496041,
+				"StableID":   "naRobcYjsV11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:946c833d3613c50bef1739b136b074a176a56b8c0db28f0568aeba6593c7283e",
+				"DiscoKey":   "discokey:d8f4eeed4adc86c3505203fe1dd6d2c9f0d7d5bea17befe201061fff5c6c2b7a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37191",
+					"10.65.0.27:37191",
+					"172.17.0.1:37191",
+					"172.19.0.1:37191",
+					"172.20.0.1:37191"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:35:56.302977665Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3761910066954421,
+				"StableID":   "ntzXZuzmNW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5fe38d5b65c4064ccdbfeed5ba6fce51ef98aab5c9698c9a1ed75a4db3ca123",
+				"DiscoKey":   "discokey:0e3b27e92f3225273c5dd21f3305f45906d27d1f0d070372dcc3efbb5d03356c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:35061",
+					"10.65.0.27:35061",
+					"172.17.0.1:35061",
+					"172.19.0.1:35061",
+					"172.20.0.1:35061"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:35:56.83944357Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7254963029272968,
+				"StableID":   "nbchSSaney11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f520bb3a00890401189333dbfe00690b8fdda98a7d44414fd7775316fa48747",
+				"DiscoKey":   "discokey:60a9b0eda72464868b693e7168dc7888f01781780b97caa4af4d83ccc6c08212",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35085",
+					"10.65.0.27:35085",
+					"172.17.0.1:35085",
+					"172.19.0.1:35085",
+					"172.20.0.1:35085"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:35:57.385639242Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4367341642538930,
+				"StableID":   "n7w9hEfy6b11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93939eea7cc260a57cce179480eb3059180f77f95880bc399d56d028f7d26f62",
+				"DiscoKey":   "discokey:a3ff6a8f814121fc413a519f258139e9ca3d4605362a244621122e9254e3d154",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34703",
+					"10.65.0.27:34703",
+					"172.17.0.1:34703",
+					"172.19.0.1:34703",
+					"172.20.0.1:34703"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:35:58.461822087Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3836926821391324,
+				"StableID":   "nXcXGZZkxW11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:646d0687e4551d3e616df3a73a834b8a7f120d22ae098aacc97b5b12af56877e",
+				"DiscoKey":   "discokey:a42d906ca45f306be44c810cea8dcb6aa3c1dc92ccd4c3baeda4095434ae1170",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47875",
+					"10.65.0.27:47875",
+					"172.17.0.1:47875",
+					"172.19.0.1:47875",
+					"172.20.0.1:47875"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:35:59.004222599Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1397648430420696,
+				"StableID":   "nKztmYrzuB11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8ecf2dcc160d9ef0155ef29fd4f50f7776455c8764413f77779b32f40842e11e",
+				"DiscoKey":   "discokey:a2eeb418c1171d64359263940844afda5d9bd97b45e1aeb369c427b238c5c664",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50009",
+					"10.65.0.27:50009",
+					"172.17.0.1:50009",
+					"172.19.0.1:50009",
+					"172.20.0.1:50009"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:35:59.531601629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3575030889276975,
+				"StableID":   "niGuZxz8vU11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:288f9583e296edfbe8c217ea5db512d2953bc5ed35fd3b931b8bfe6de4408419",
+				"DiscoKey":   "discokey:4e783cab54c5941c5e9bf63ad04a75509b77829a1472b49be084344cd36a3151",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46705",
+					"10.65.0.27:46705",
+					"172.17.0.1:46705",
+					"172.19.0.1:46705",
+					"172.20.0.1:46705"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:36:00.068839759Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5357389921876185,
+				"StableID":   "nxppspYNqi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b774e49d8cd5f461be6f2c6718c0dc741cf6bd579d44b4e892def1ed87600824",
+				"KeyExpiry":  "2026-11-08T18:36:00Z",
+				"DiscoKey":   "discokey:37924c46e316c320bfd9ece51608310981f84e8f23b306996e8278e13ecdc816",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33630",
+					"10.65.0.27:33630",
+					"172.17.0.1:33630",
+					"172.19.0.1:33630",
+					"172.20.0.1:33630"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:36:00.613120864Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4626505136556407,
+				"StableID":   "ninJCoSM8d11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2182b351bbc58393c83327e9db319378bcfcd1eeb0f8f91004261db5d732b173",
+				"KeyExpiry":  "2026-11-08T18:36:01Z",
+				"DiscoKey":   "discokey:6ed1cf6c9216f827c713788474580dad4f04cd0504339a75569b4bdb70873870",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60453",
+					"10.65.0.27:60453",
+					"172.17.0.1:60453",
+					"172.19.0.1:60453",
+					"172.20.0.1:60453"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:36:01.152066159Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2137527263137108,
+				"StableID":   "n99GdZD6hH11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:782c40cd767b310f562618924caeb8cc7bbaa3399dfda9ecb1a8154d8fd38e17",
+				"KeyExpiry":  "2026-11-08T18:36:01Z",
+				"DiscoKey":   "discokey:681c5180c4c086e43a0102848695b9dec317228fbe5afec097c0e270ed51574a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57911",
+					"10.65.0.27:57911",
+					"172.17.0.1:57911",
+					"172.19.0.1:57911",
+					"172.20.0.1:57911"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:36:01.695480091Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7649445423865526": {
+				"ID":          7649445423865526,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5357389921876185,
+				"StableID":   "nxppspYNqi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b774e49d8cd5f461be6f2c6718c0dc741cf6bd579d44b4e892def1ed87600824",
+				"KeyExpiry":  "2026-11-08T18:36:00Z",
+				"DiscoKey":   "discokey:37924c46e316c320bfd9ece51608310981f84e8f23b306996e8278e13ecdc816",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33630",
+					"10.65.0.27:33630",
+					"172.17.0.1:33630",
+					"172.19.0.1:33630",
+					"172.20.0.1:33630"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:36:00.613120864Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b774e49d8cd5f461be6f2c6718c0dc741cf6bd579d44b4e892def1ed87600824",
+			"MachineKey": "mkey:8bcc482f8199773cc7c7c7fd73101bcb6248a5397dcf98fc897123807704921d",
+			"Peers": [{
+				"ID":         7411601795144039,
+				"StableID":   "n2SLoFDjsz11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39bcb05d9e43c3e019896b3ee1d45c25d8de8157b4935cd119b532e2bee40740",
+				"DiscoKey":   "discokey:9d99beee748b0a02a460728e2e4a32eff34671fe256c25f593e5d499b7d14b32",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33962",
+					"10.65.0.27:33962",
+					"172.17.0.1:33962",
+					"172.19.0.1:33962",
+					"172.20.0.1:33962"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:35:54.138346186Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8083362849184876,
+				"StableID":   "n97oodEy7621CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b99c19c8696167b8aa649553bbc49427e4ac235a341c2b799495abcadabb752",
+				"DiscoKey":   "discokey:5fe4d987d7899019b40a5d020848d8feadcfd89064237d868314dc502e1db342",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54968",
+					"10.65.0.27:54968",
+					"172.17.0.1:54968",
+					"172.19.0.1:54968",
+					"172.20.0.1:54968"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:35:54.674766883Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8231454160451900,
+				"StableID":   "nFzNssL3H721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:33b07d001b7ddbe4ce31bad55dff70864d516ef9e9d1eb08c97741d9357b8f21",
+				"DiscoKey":   "discokey:4783c0e34488b3aba08f0aa1739c332bf76ad7a9a46052231d9f4484eb34600e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52193",
+					"10.65.0.27:52193",
+					"172.17.0.1:52193",
+					"172.19.0.1:52193",
+					"172.20.0.1:52193"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:35:55.225148997Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1295019951997443,
+				"StableID":   "nUF6ajyW7B11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bb6cf8789c71ef859aa18b6ed9dbf39f03008a7dcaef60de72ea484372472221",
+				"DiscoKey":   "discokey:b0dfe75e6f3a39d071329257e072773284cf237cbed1303973ca11f221223065",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:48991",
+					"10.65.0.27:48991",
+					"172.17.0.1:48991",
+					"172.19.0.1:48991",
+					"172.20.0.1:48991"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:35:55.762603598Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3697785131496041,
+				"StableID":   "naRobcYjsV11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:946c833d3613c50bef1739b136b074a176a56b8c0db28f0568aeba6593c7283e",
+				"DiscoKey":   "discokey:d8f4eeed4adc86c3505203fe1dd6d2c9f0d7d5bea17befe201061fff5c6c2b7a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37191",
+					"10.65.0.27:37191",
+					"172.17.0.1:37191",
+					"172.19.0.1:37191",
+					"172.20.0.1:37191"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:35:56.302977665Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3761910066954421,
+				"StableID":   "ntzXZuzmNW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5fe38d5b65c4064ccdbfeed5ba6fce51ef98aab5c9698c9a1ed75a4db3ca123",
+				"DiscoKey":   "discokey:0e3b27e92f3225273c5dd21f3305f45906d27d1f0d070372dcc3efbb5d03356c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:35061",
+					"10.65.0.27:35061",
+					"172.17.0.1:35061",
+					"172.19.0.1:35061",
+					"172.20.0.1:35061"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:35:56.83944357Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7254963029272968,
+				"StableID":   "nbchSSaney11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f520bb3a00890401189333dbfe00690b8fdda98a7d44414fd7775316fa48747",
+				"DiscoKey":   "discokey:60a9b0eda72464868b693e7168dc7888f01781780b97caa4af4d83ccc6c08212",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35085",
+					"10.65.0.27:35085",
+					"172.17.0.1:35085",
+					"172.19.0.1:35085",
+					"172.20.0.1:35085"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:35:57.385639242Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7649445423865526,
+				"StableID":   "n1k5pgxSj221CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:123f9b086c97174e156411cf94f1bda8a4b5a6652b19fe1b7dec811488b3eb69",
+				"DiscoKey":   "discokey:428c1c13dfa68666573b1119bd52c5b512626f0fcdeb903d60c45c631373041c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:53510",
+					"10.65.0.27:53510",
+					"172.17.0.1:53510",
+					"172.19.0.1:53510",
+					"172.20.0.1:53510"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:35:57.928832629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4367341642538930,
+				"StableID":   "n7w9hEfy6b11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93939eea7cc260a57cce179480eb3059180f77f95880bc399d56d028f7d26f62",
+				"DiscoKey":   "discokey:a3ff6a8f814121fc413a519f258139e9ca3d4605362a244621122e9254e3d154",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34703",
+					"10.65.0.27:34703",
+					"172.17.0.1:34703",
+					"172.19.0.1:34703",
+					"172.20.0.1:34703"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:35:58.461822087Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3836926821391324,
+				"StableID":   "nXcXGZZkxW11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:646d0687e4551d3e616df3a73a834b8a7f120d22ae098aacc97b5b12af56877e",
+				"DiscoKey":   "discokey:a42d906ca45f306be44c810cea8dcb6aa3c1dc92ccd4c3baeda4095434ae1170",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47875",
+					"10.65.0.27:47875",
+					"172.17.0.1:47875",
+					"172.19.0.1:47875",
+					"172.20.0.1:47875"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:35:59.004222599Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1397648430420696,
+				"StableID":   "nKztmYrzuB11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8ecf2dcc160d9ef0155ef29fd4f50f7776455c8764413f77779b32f40842e11e",
+				"DiscoKey":   "discokey:a2eeb418c1171d64359263940844afda5d9bd97b45e1aeb369c427b238c5c664",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50009",
+					"10.65.0.27:50009",
+					"172.17.0.1:50009",
+					"172.19.0.1:50009",
+					"172.20.0.1:50009"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:35:59.531601629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3575030889276975,
+				"StableID":   "niGuZxz8vU11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:288f9583e296edfbe8c217ea5db512d2953bc5ed35fd3b931b8bfe6de4408419",
+				"DiscoKey":   "discokey:4e783cab54c5941c5e9bf63ad04a75509b77829a1472b49be084344cd36a3151",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46705",
+					"10.65.0.27:46705",
+					"172.17.0.1:46705",
+					"172.19.0.1:46705",
+					"172.20.0.1:46705"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:36:00.068839759Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4626505136556407,
+				"StableID":   "ninJCoSM8d11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2182b351bbc58393c83327e9db319378bcfcd1eeb0f8f91004261db5d732b173",
+				"KeyExpiry":  "2026-11-08T18:36:01Z",
+				"DiscoKey":   "discokey:6ed1cf6c9216f827c713788474580dad4f04cd0504339a75569b4bdb70873870",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60453",
+					"10.65.0.27:60453",
+					"172.17.0.1:60453",
+					"172.19.0.1:60453",
+					"172.20.0.1:60453"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:36:01.152066159Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2137527263137108,
+				"StableID":   "n99GdZD6hH11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:782c40cd767b310f562618924caeb8cc7bbaa3399dfda9ecb1a8154d8fd38e17",
+				"KeyExpiry":  "2026-11-08T18:36:01Z",
+				"DiscoKey":   "discokey:681c5180c4c086e43a0102848695b9dec317228fbe5afec097c0e270ed51574a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57911",
+					"10.65.0.27:57911",
+					"172.17.0.1:57911",
+					"172.19.0.1:57911",
+					"172.20.0.1:57911"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:36:01.695480091Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1397648430420696,
+				"StableID":   "nKztmYrzuB11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1397648430420696,
+				"Key":        "nodekey:8ecf2dcc160d9ef0155ef29fd4f50f7776455c8764413f77779b32f40842e11e",
+				"DiscoKey":   "discokey:a2eeb418c1171d64359263940844afda5d9bd97b45e1aeb369c427b238c5c664",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50009",
+					"10.65.0.27:50009",
+					"172.17.0.1:50009",
+					"172.19.0.1:50009",
+					"172.20.0.1:50009"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:35:59.531601629Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8ecf2dcc160d9ef0155ef29fd4f50f7776455c8764413f77779b32f40842e11e",
+			"MachineKey": "mkey:62ef27ddbd02524fa31e7e48b8da416bf90e863eb61592fcaa6001b46f8c896e",
+			"Peers": [{
+				"ID":         7411601795144039,
+				"StableID":   "n2SLoFDjsz11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39bcb05d9e43c3e019896b3ee1d45c25d8de8157b4935cd119b532e2bee40740",
+				"DiscoKey":   "discokey:9d99beee748b0a02a460728e2e4a32eff34671fe256c25f593e5d499b7d14b32",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33962",
+					"10.65.0.27:33962",
+					"172.17.0.1:33962",
+					"172.19.0.1:33962",
+					"172.20.0.1:33962"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:35:54.138346186Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8083362849184876,
+				"StableID":   "n97oodEy7621CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b99c19c8696167b8aa649553bbc49427e4ac235a341c2b799495abcadabb752",
+				"DiscoKey":   "discokey:5fe4d987d7899019b40a5d020848d8feadcfd89064237d868314dc502e1db342",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54968",
+					"10.65.0.27:54968",
+					"172.17.0.1:54968",
+					"172.19.0.1:54968",
+					"172.20.0.1:54968"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:35:54.674766883Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8231454160451900,
+				"StableID":   "nFzNssL3H721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:33b07d001b7ddbe4ce31bad55dff70864d516ef9e9d1eb08c97741d9357b8f21",
+				"DiscoKey":   "discokey:4783c0e34488b3aba08f0aa1739c332bf76ad7a9a46052231d9f4484eb34600e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52193",
+					"10.65.0.27:52193",
+					"172.17.0.1:52193",
+					"172.19.0.1:52193",
+					"172.20.0.1:52193"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:35:55.225148997Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1295019951997443,
+				"StableID":   "nUF6ajyW7B11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bb6cf8789c71ef859aa18b6ed9dbf39f03008a7dcaef60de72ea484372472221",
+				"DiscoKey":   "discokey:b0dfe75e6f3a39d071329257e072773284cf237cbed1303973ca11f221223065",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:48991",
+					"10.65.0.27:48991",
+					"172.17.0.1:48991",
+					"172.19.0.1:48991",
+					"172.20.0.1:48991"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:35:55.762603598Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3697785131496041,
+				"StableID":   "naRobcYjsV11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:946c833d3613c50bef1739b136b074a176a56b8c0db28f0568aeba6593c7283e",
+				"DiscoKey":   "discokey:d8f4eeed4adc86c3505203fe1dd6d2c9f0d7d5bea17befe201061fff5c6c2b7a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37191",
+					"10.65.0.27:37191",
+					"172.17.0.1:37191",
+					"172.19.0.1:37191",
+					"172.20.0.1:37191"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:35:56.302977665Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3761910066954421,
+				"StableID":   "ntzXZuzmNW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5fe38d5b65c4064ccdbfeed5ba6fce51ef98aab5c9698c9a1ed75a4db3ca123",
+				"DiscoKey":   "discokey:0e3b27e92f3225273c5dd21f3305f45906d27d1f0d070372dcc3efbb5d03356c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:35061",
+					"10.65.0.27:35061",
+					"172.17.0.1:35061",
+					"172.19.0.1:35061",
+					"172.20.0.1:35061"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:35:56.83944357Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7254963029272968,
+				"StableID":   "nbchSSaney11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f520bb3a00890401189333dbfe00690b8fdda98a7d44414fd7775316fa48747",
+				"DiscoKey":   "discokey:60a9b0eda72464868b693e7168dc7888f01781780b97caa4af4d83ccc6c08212",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35085",
+					"10.65.0.27:35085",
+					"172.17.0.1:35085",
+					"172.19.0.1:35085",
+					"172.20.0.1:35085"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:35:57.385639242Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7649445423865526,
+				"StableID":   "n1k5pgxSj221CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:123f9b086c97174e156411cf94f1bda8a4b5a6652b19fe1b7dec811488b3eb69",
+				"DiscoKey":   "discokey:428c1c13dfa68666573b1119bd52c5b512626f0fcdeb903d60c45c631373041c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:53510",
+					"10.65.0.27:53510",
+					"172.17.0.1:53510",
+					"172.19.0.1:53510",
+					"172.20.0.1:53510"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:35:57.928832629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4367341642538930,
+				"StableID":   "n7w9hEfy6b11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93939eea7cc260a57cce179480eb3059180f77f95880bc399d56d028f7d26f62",
+				"DiscoKey":   "discokey:a3ff6a8f814121fc413a519f258139e9ca3d4605362a244621122e9254e3d154",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34703",
+					"10.65.0.27:34703",
+					"172.17.0.1:34703",
+					"172.19.0.1:34703",
+					"172.20.0.1:34703"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:35:58.461822087Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3836926821391324,
+				"StableID":   "nXcXGZZkxW11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:646d0687e4551d3e616df3a73a834b8a7f120d22ae098aacc97b5b12af56877e",
+				"DiscoKey":   "discokey:a42d906ca45f306be44c810cea8dcb6aa3c1dc92ccd4c3baeda4095434ae1170",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47875",
+					"10.65.0.27:47875",
+					"172.17.0.1:47875",
+					"172.19.0.1:47875",
+					"172.20.0.1:47875"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:35:59.004222599Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3575030889276975,
+				"StableID":   "niGuZxz8vU11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:288f9583e296edfbe8c217ea5db512d2953bc5ed35fd3b931b8bfe6de4408419",
+				"DiscoKey":   "discokey:4e783cab54c5941c5e9bf63ad04a75509b77829a1472b49be084344cd36a3151",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46705",
+					"10.65.0.27:46705",
+					"172.17.0.1:46705",
+					"172.19.0.1:46705",
+					"172.20.0.1:46705"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:36:00.068839759Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5357389921876185,
+				"StableID":   "nxppspYNqi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b774e49d8cd5f461be6f2c6718c0dc741cf6bd579d44b4e892def1ed87600824",
+				"KeyExpiry":  "2026-11-08T18:36:00Z",
+				"DiscoKey":   "discokey:37924c46e316c320bfd9ece51608310981f84e8f23b306996e8278e13ecdc816",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33630",
+					"10.65.0.27:33630",
+					"172.17.0.1:33630",
+					"172.19.0.1:33630",
+					"172.20.0.1:33630"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:36:00.613120864Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4626505136556407,
+				"StableID":   "ninJCoSM8d11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2182b351bbc58393c83327e9db319378bcfcd1eeb0f8f91004261db5d732b173",
+				"KeyExpiry":  "2026-11-08T18:36:01Z",
+				"DiscoKey":   "discokey:6ed1cf6c9216f827c713788474580dad4f04cd0504339a75569b4bdb70873870",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60453",
+					"10.65.0.27:60453",
+					"172.17.0.1:60453",
+					"172.19.0.1:60453",
+					"172.20.0.1:60453"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:36:01.152066159Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2137527263137108,
+				"StableID":   "n99GdZD6hH11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:782c40cd767b310f562618924caeb8cc7bbaa3399dfda9ecb1a8154d8fd38e17",
+				"KeyExpiry":  "2026-11-08T18:36:01Z",
+				"DiscoKey":   "discokey:681c5180c4c086e43a0102848695b9dec317228fbe5afec097c0e270ed51574a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57911",
+					"10.65.0.27:57911",
+					"172.17.0.1:57911",
+					"172.19.0.1:57911",
+					"172.20.0.1:57911"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:36:01.695480091Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1397648430420696": {
+				"ID":          1397648430420696,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8083362849184876,
+				"StableID":   "n97oodEy7621CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       8083362849184876,
+				"Key":        "nodekey:0b99c19c8696167b8aa649553bbc49427e4ac235a341c2b799495abcadabb752",
+				"DiscoKey":   "discokey:5fe4d987d7899019b40a5d020848d8feadcfd89064237d868314dc502e1db342",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54968",
+					"10.65.0.27:54968",
+					"172.17.0.1:54968",
+					"172.19.0.1:54968",
+					"172.20.0.1:54968"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:35:54.674766883Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0b99c19c8696167b8aa649553bbc49427e4ac235a341c2b799495abcadabb752",
+			"MachineKey": "mkey:b373f356d348427d6d581ea3ac7d995bdfd6bbc35c6f4172085e2f2f722ec45c",
+			"Peers": [{
+				"ID":         7411601795144039,
+				"StableID":   "n2SLoFDjsz11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39bcb05d9e43c3e019896b3ee1d45c25d8de8157b4935cd119b532e2bee40740",
+				"DiscoKey":   "discokey:9d99beee748b0a02a460728e2e4a32eff34671fe256c25f593e5d499b7d14b32",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33962",
+					"10.65.0.27:33962",
+					"172.17.0.1:33962",
+					"172.19.0.1:33962",
+					"172.20.0.1:33962"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:35:54.138346186Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8231454160451900,
+				"StableID":   "nFzNssL3H721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:33b07d001b7ddbe4ce31bad55dff70864d516ef9e9d1eb08c97741d9357b8f21",
+				"DiscoKey":   "discokey:4783c0e34488b3aba08f0aa1739c332bf76ad7a9a46052231d9f4484eb34600e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52193",
+					"10.65.0.27:52193",
+					"172.17.0.1:52193",
+					"172.19.0.1:52193",
+					"172.20.0.1:52193"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:35:55.225148997Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1295019951997443,
+				"StableID":   "nUF6ajyW7B11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bb6cf8789c71ef859aa18b6ed9dbf39f03008a7dcaef60de72ea484372472221",
+				"DiscoKey":   "discokey:b0dfe75e6f3a39d071329257e072773284cf237cbed1303973ca11f221223065",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:48991",
+					"10.65.0.27:48991",
+					"172.17.0.1:48991",
+					"172.19.0.1:48991",
+					"172.20.0.1:48991"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:35:55.762603598Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3697785131496041,
+				"StableID":   "naRobcYjsV11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:946c833d3613c50bef1739b136b074a176a56b8c0db28f0568aeba6593c7283e",
+				"DiscoKey":   "discokey:d8f4eeed4adc86c3505203fe1dd6d2c9f0d7d5bea17befe201061fff5c6c2b7a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37191",
+					"10.65.0.27:37191",
+					"172.17.0.1:37191",
+					"172.19.0.1:37191",
+					"172.20.0.1:37191"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:35:56.302977665Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3761910066954421,
+				"StableID":   "ntzXZuzmNW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5fe38d5b65c4064ccdbfeed5ba6fce51ef98aab5c9698c9a1ed75a4db3ca123",
+				"DiscoKey":   "discokey:0e3b27e92f3225273c5dd21f3305f45906d27d1f0d070372dcc3efbb5d03356c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:35061",
+					"10.65.0.27:35061",
+					"172.17.0.1:35061",
+					"172.19.0.1:35061",
+					"172.20.0.1:35061"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:35:56.83944357Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7254963029272968,
+				"StableID":   "nbchSSaney11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f520bb3a00890401189333dbfe00690b8fdda98a7d44414fd7775316fa48747",
+				"DiscoKey":   "discokey:60a9b0eda72464868b693e7168dc7888f01781780b97caa4af4d83ccc6c08212",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35085",
+					"10.65.0.27:35085",
+					"172.17.0.1:35085",
+					"172.19.0.1:35085",
+					"172.20.0.1:35085"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:35:57.385639242Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7649445423865526,
+				"StableID":   "n1k5pgxSj221CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:123f9b086c97174e156411cf94f1bda8a4b5a6652b19fe1b7dec811488b3eb69",
+				"DiscoKey":   "discokey:428c1c13dfa68666573b1119bd52c5b512626f0fcdeb903d60c45c631373041c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:53510",
+					"10.65.0.27:53510",
+					"172.17.0.1:53510",
+					"172.19.0.1:53510",
+					"172.20.0.1:53510"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:35:57.928832629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4367341642538930,
+				"StableID":   "n7w9hEfy6b11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93939eea7cc260a57cce179480eb3059180f77f95880bc399d56d028f7d26f62",
+				"DiscoKey":   "discokey:a3ff6a8f814121fc413a519f258139e9ca3d4605362a244621122e9254e3d154",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34703",
+					"10.65.0.27:34703",
+					"172.17.0.1:34703",
+					"172.19.0.1:34703",
+					"172.20.0.1:34703"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:35:58.461822087Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3836926821391324,
+				"StableID":   "nXcXGZZkxW11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:646d0687e4551d3e616df3a73a834b8a7f120d22ae098aacc97b5b12af56877e",
+				"DiscoKey":   "discokey:a42d906ca45f306be44c810cea8dcb6aa3c1dc92ccd4c3baeda4095434ae1170",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47875",
+					"10.65.0.27:47875",
+					"172.17.0.1:47875",
+					"172.19.0.1:47875",
+					"172.20.0.1:47875"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:35:59.004222599Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1397648430420696,
+				"StableID":   "nKztmYrzuB11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8ecf2dcc160d9ef0155ef29fd4f50f7776455c8764413f77779b32f40842e11e",
+				"DiscoKey":   "discokey:a2eeb418c1171d64359263940844afda5d9bd97b45e1aeb369c427b238c5c664",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50009",
+					"10.65.0.27:50009",
+					"172.17.0.1:50009",
+					"172.19.0.1:50009",
+					"172.20.0.1:50009"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:35:59.531601629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3575030889276975,
+				"StableID":   "niGuZxz8vU11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:288f9583e296edfbe8c217ea5db512d2953bc5ed35fd3b931b8bfe6de4408419",
+				"DiscoKey":   "discokey:4e783cab54c5941c5e9bf63ad04a75509b77829a1472b49be084344cd36a3151",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46705",
+					"10.65.0.27:46705",
+					"172.17.0.1:46705",
+					"172.19.0.1:46705",
+					"172.20.0.1:46705"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:36:00.068839759Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5357389921876185,
+				"StableID":   "nxppspYNqi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b774e49d8cd5f461be6f2c6718c0dc741cf6bd579d44b4e892def1ed87600824",
+				"KeyExpiry":  "2026-11-08T18:36:00Z",
+				"DiscoKey":   "discokey:37924c46e316c320bfd9ece51608310981f84e8f23b306996e8278e13ecdc816",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33630",
+					"10.65.0.27:33630",
+					"172.17.0.1:33630",
+					"172.19.0.1:33630",
+					"172.20.0.1:33630"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:36:00.613120864Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4626505136556407,
+				"StableID":   "ninJCoSM8d11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2182b351bbc58393c83327e9db319378bcfcd1eeb0f8f91004261db5d732b173",
+				"KeyExpiry":  "2026-11-08T18:36:01Z",
+				"DiscoKey":   "discokey:6ed1cf6c9216f827c713788474580dad4f04cd0504339a75569b4bdb70873870",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60453",
+					"10.65.0.27:60453",
+					"172.17.0.1:60453",
+					"172.19.0.1:60453",
+					"172.20.0.1:60453"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:36:01.152066159Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2137527263137108,
+				"StableID":   "n99GdZD6hH11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:782c40cd767b310f562618924caeb8cc7bbaa3399dfda9ecb1a8154d8fd38e17",
+				"KeyExpiry":  "2026-11-08T18:36:01Z",
+				"DiscoKey":   "discokey:681c5180c4c086e43a0102848695b9dec317228fbe5afec097c0e270ed51574a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57911",
+					"10.65.0.27:57911",
+					"172.17.0.1:57911",
+					"172.19.0.1:57911",
+					"172.20.0.1:57911"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:36:01.695480091Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8083362849184876": {
+				"ID":          8083362849184876,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7411601795144039,
+				"StableID":   "n2SLoFDjsz11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       7411601795144039,
+				"Key":        "nodekey:39bcb05d9e43c3e019896b3ee1d45c25d8de8157b4935cd119b532e2bee40740",
+				"DiscoKey":   "discokey:9d99beee748b0a02a460728e2e4a32eff34671fe256c25f593e5d499b7d14b32",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33962",
+					"10.65.0.27:33962",
+					"172.17.0.1:33962",
+					"172.19.0.1:33962",
+					"172.20.0.1:33962"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:35:54.138346186Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:39bcb05d9e43c3e019896b3ee1d45c25d8de8157b4935cd119b532e2bee40740",
+			"MachineKey": "mkey:fecb9923abfe5b5024dc70549da9c17a2e92abf4960ea82b9bbd959df27e5711",
+			"Peers": [{
+				"ID":         8083362849184876,
+				"StableID":   "n97oodEy7621CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b99c19c8696167b8aa649553bbc49427e4ac235a341c2b799495abcadabb752",
+				"DiscoKey":   "discokey:5fe4d987d7899019b40a5d020848d8feadcfd89064237d868314dc502e1db342",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54968",
+					"10.65.0.27:54968",
+					"172.17.0.1:54968",
+					"172.19.0.1:54968",
+					"172.20.0.1:54968"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:35:54.674766883Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8231454160451900,
+				"StableID":   "nFzNssL3H721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:33b07d001b7ddbe4ce31bad55dff70864d516ef9e9d1eb08c97741d9357b8f21",
+				"DiscoKey":   "discokey:4783c0e34488b3aba08f0aa1739c332bf76ad7a9a46052231d9f4484eb34600e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52193",
+					"10.65.0.27:52193",
+					"172.17.0.1:52193",
+					"172.19.0.1:52193",
+					"172.20.0.1:52193"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:35:55.225148997Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1295019951997443,
+				"StableID":   "nUF6ajyW7B11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bb6cf8789c71ef859aa18b6ed9dbf39f03008a7dcaef60de72ea484372472221",
+				"DiscoKey":   "discokey:b0dfe75e6f3a39d071329257e072773284cf237cbed1303973ca11f221223065",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:48991",
+					"10.65.0.27:48991",
+					"172.17.0.1:48991",
+					"172.19.0.1:48991",
+					"172.20.0.1:48991"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:35:55.762603598Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3697785131496041,
+				"StableID":   "naRobcYjsV11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:946c833d3613c50bef1739b136b074a176a56b8c0db28f0568aeba6593c7283e",
+				"DiscoKey":   "discokey:d8f4eeed4adc86c3505203fe1dd6d2c9f0d7d5bea17befe201061fff5c6c2b7a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37191",
+					"10.65.0.27:37191",
+					"172.17.0.1:37191",
+					"172.19.0.1:37191",
+					"172.20.0.1:37191"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:35:56.302977665Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3761910066954421,
+				"StableID":   "ntzXZuzmNW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5fe38d5b65c4064ccdbfeed5ba6fce51ef98aab5c9698c9a1ed75a4db3ca123",
+				"DiscoKey":   "discokey:0e3b27e92f3225273c5dd21f3305f45906d27d1f0d070372dcc3efbb5d03356c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:35061",
+					"10.65.0.27:35061",
+					"172.17.0.1:35061",
+					"172.19.0.1:35061",
+					"172.20.0.1:35061"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:35:56.83944357Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7254963029272968,
+				"StableID":   "nbchSSaney11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f520bb3a00890401189333dbfe00690b8fdda98a7d44414fd7775316fa48747",
+				"DiscoKey":   "discokey:60a9b0eda72464868b693e7168dc7888f01781780b97caa4af4d83ccc6c08212",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35085",
+					"10.65.0.27:35085",
+					"172.17.0.1:35085",
+					"172.19.0.1:35085",
+					"172.20.0.1:35085"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:35:57.385639242Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7649445423865526,
+				"StableID":   "n1k5pgxSj221CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:123f9b086c97174e156411cf94f1bda8a4b5a6652b19fe1b7dec811488b3eb69",
+				"DiscoKey":   "discokey:428c1c13dfa68666573b1119bd52c5b512626f0fcdeb903d60c45c631373041c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:53510",
+					"10.65.0.27:53510",
+					"172.17.0.1:53510",
+					"172.19.0.1:53510",
+					"172.20.0.1:53510"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:35:57.928832629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4367341642538930,
+				"StableID":   "n7w9hEfy6b11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93939eea7cc260a57cce179480eb3059180f77f95880bc399d56d028f7d26f62",
+				"DiscoKey":   "discokey:a3ff6a8f814121fc413a519f258139e9ca3d4605362a244621122e9254e3d154",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34703",
+					"10.65.0.27:34703",
+					"172.17.0.1:34703",
+					"172.19.0.1:34703",
+					"172.20.0.1:34703"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:35:58.461822087Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3836926821391324,
+				"StableID":   "nXcXGZZkxW11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:646d0687e4551d3e616df3a73a834b8a7f120d22ae098aacc97b5b12af56877e",
+				"DiscoKey":   "discokey:a42d906ca45f306be44c810cea8dcb6aa3c1dc92ccd4c3baeda4095434ae1170",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47875",
+					"10.65.0.27:47875",
+					"172.17.0.1:47875",
+					"172.19.0.1:47875",
+					"172.20.0.1:47875"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:35:59.004222599Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1397648430420696,
+				"StableID":   "nKztmYrzuB11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8ecf2dcc160d9ef0155ef29fd4f50f7776455c8764413f77779b32f40842e11e",
+				"DiscoKey":   "discokey:a2eeb418c1171d64359263940844afda5d9bd97b45e1aeb369c427b238c5c664",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50009",
+					"10.65.0.27:50009",
+					"172.17.0.1:50009",
+					"172.19.0.1:50009",
+					"172.20.0.1:50009"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:35:59.531601629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3575030889276975,
+				"StableID":   "niGuZxz8vU11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:288f9583e296edfbe8c217ea5db512d2953bc5ed35fd3b931b8bfe6de4408419",
+				"DiscoKey":   "discokey:4e783cab54c5941c5e9bf63ad04a75509b77829a1472b49be084344cd36a3151",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46705",
+					"10.65.0.27:46705",
+					"172.17.0.1:46705",
+					"172.19.0.1:46705",
+					"172.20.0.1:46705"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:36:00.068839759Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5357389921876185,
+				"StableID":   "nxppspYNqi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b774e49d8cd5f461be6f2c6718c0dc741cf6bd579d44b4e892def1ed87600824",
+				"KeyExpiry":  "2026-11-08T18:36:00Z",
+				"DiscoKey":   "discokey:37924c46e316c320bfd9ece51608310981f84e8f23b306996e8278e13ecdc816",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33630",
+					"10.65.0.27:33630",
+					"172.17.0.1:33630",
+					"172.19.0.1:33630",
+					"172.20.0.1:33630"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:36:00.613120864Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4626505136556407,
+				"StableID":   "ninJCoSM8d11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2182b351bbc58393c83327e9db319378bcfcd1eeb0f8f91004261db5d732b173",
+				"KeyExpiry":  "2026-11-08T18:36:01Z",
+				"DiscoKey":   "discokey:6ed1cf6c9216f827c713788474580dad4f04cd0504339a75569b4bdb70873870",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60453",
+					"10.65.0.27:60453",
+					"172.17.0.1:60453",
+					"172.19.0.1:60453",
+					"172.20.0.1:60453"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:36:01.152066159Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2137527263137108,
+				"StableID":   "n99GdZD6hH11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:782c40cd767b310f562618924caeb8cc7bbaa3399dfda9ecb1a8154d8fd38e17",
+				"KeyExpiry":  "2026-11-08T18:36:01Z",
+				"DiscoKey":   "discokey:681c5180c4c086e43a0102848695b9dec317228fbe5afec097c0e270ed51574a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57911",
+					"10.65.0.27:57911",
+					"172.17.0.1:57911",
+					"172.19.0.1:57911",
+					"172.20.0.1:57911"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:36:01.695480091Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7411601795144039": {
+				"ID":          7411601795144039,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3697785131496041,
+				"StableID":   "naRobcYjsV11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       3697785131496041,
+				"Key":        "nodekey:946c833d3613c50bef1739b136b074a176a56b8c0db28f0568aeba6593c7283e",
+				"DiscoKey":   "discokey:d8f4eeed4adc86c3505203fe1dd6d2c9f0d7d5bea17befe201061fff5c6c2b7a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37191",
+					"10.65.0.27:37191",
+					"172.17.0.1:37191",
+					"172.19.0.1:37191",
+					"172.20.0.1:37191"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:35:56.302977665Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:946c833d3613c50bef1739b136b074a176a56b8c0db28f0568aeba6593c7283e",
+			"MachineKey": "mkey:8df4872a1c921b86fd178a36f4f4ee246066167fff1afff59a1c605d0fb00d2e",
+			"Peers": [{
+				"ID":         7411601795144039,
+				"StableID":   "n2SLoFDjsz11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39bcb05d9e43c3e019896b3ee1d45c25d8de8157b4935cd119b532e2bee40740",
+				"DiscoKey":   "discokey:9d99beee748b0a02a460728e2e4a32eff34671fe256c25f593e5d499b7d14b32",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33962",
+					"10.65.0.27:33962",
+					"172.17.0.1:33962",
+					"172.19.0.1:33962",
+					"172.20.0.1:33962"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:35:54.138346186Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8083362849184876,
+				"StableID":   "n97oodEy7621CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b99c19c8696167b8aa649553bbc49427e4ac235a341c2b799495abcadabb752",
+				"DiscoKey":   "discokey:5fe4d987d7899019b40a5d020848d8feadcfd89064237d868314dc502e1db342",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54968",
+					"10.65.0.27:54968",
+					"172.17.0.1:54968",
+					"172.19.0.1:54968",
+					"172.20.0.1:54968"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:35:54.674766883Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8231454160451900,
+				"StableID":   "nFzNssL3H721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:33b07d001b7ddbe4ce31bad55dff70864d516ef9e9d1eb08c97741d9357b8f21",
+				"DiscoKey":   "discokey:4783c0e34488b3aba08f0aa1739c332bf76ad7a9a46052231d9f4484eb34600e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52193",
+					"10.65.0.27:52193",
+					"172.17.0.1:52193",
+					"172.19.0.1:52193",
+					"172.20.0.1:52193"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:35:55.225148997Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1295019951997443,
+				"StableID":   "nUF6ajyW7B11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bb6cf8789c71ef859aa18b6ed9dbf39f03008a7dcaef60de72ea484372472221",
+				"DiscoKey":   "discokey:b0dfe75e6f3a39d071329257e072773284cf237cbed1303973ca11f221223065",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:48991",
+					"10.65.0.27:48991",
+					"172.17.0.1:48991",
+					"172.19.0.1:48991",
+					"172.20.0.1:48991"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:35:55.762603598Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3761910066954421,
+				"StableID":   "ntzXZuzmNW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5fe38d5b65c4064ccdbfeed5ba6fce51ef98aab5c9698c9a1ed75a4db3ca123",
+				"DiscoKey":   "discokey:0e3b27e92f3225273c5dd21f3305f45906d27d1f0d070372dcc3efbb5d03356c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:35061",
+					"10.65.0.27:35061",
+					"172.17.0.1:35061",
+					"172.19.0.1:35061",
+					"172.20.0.1:35061"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:35:56.83944357Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7254963029272968,
+				"StableID":   "nbchSSaney11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f520bb3a00890401189333dbfe00690b8fdda98a7d44414fd7775316fa48747",
+				"DiscoKey":   "discokey:60a9b0eda72464868b693e7168dc7888f01781780b97caa4af4d83ccc6c08212",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35085",
+					"10.65.0.27:35085",
+					"172.17.0.1:35085",
+					"172.19.0.1:35085",
+					"172.20.0.1:35085"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:35:57.385639242Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7649445423865526,
+				"StableID":   "n1k5pgxSj221CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:123f9b086c97174e156411cf94f1bda8a4b5a6652b19fe1b7dec811488b3eb69",
+				"DiscoKey":   "discokey:428c1c13dfa68666573b1119bd52c5b512626f0fcdeb903d60c45c631373041c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:53510",
+					"10.65.0.27:53510",
+					"172.17.0.1:53510",
+					"172.19.0.1:53510",
+					"172.20.0.1:53510"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:35:57.928832629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4367341642538930,
+				"StableID":   "n7w9hEfy6b11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93939eea7cc260a57cce179480eb3059180f77f95880bc399d56d028f7d26f62",
+				"DiscoKey":   "discokey:a3ff6a8f814121fc413a519f258139e9ca3d4605362a244621122e9254e3d154",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34703",
+					"10.65.0.27:34703",
+					"172.17.0.1:34703",
+					"172.19.0.1:34703",
+					"172.20.0.1:34703"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:35:58.461822087Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3836926821391324,
+				"StableID":   "nXcXGZZkxW11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:646d0687e4551d3e616df3a73a834b8a7f120d22ae098aacc97b5b12af56877e",
+				"DiscoKey":   "discokey:a42d906ca45f306be44c810cea8dcb6aa3c1dc92ccd4c3baeda4095434ae1170",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47875",
+					"10.65.0.27:47875",
+					"172.17.0.1:47875",
+					"172.19.0.1:47875",
+					"172.20.0.1:47875"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:35:59.004222599Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1397648430420696,
+				"StableID":   "nKztmYrzuB11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8ecf2dcc160d9ef0155ef29fd4f50f7776455c8764413f77779b32f40842e11e",
+				"DiscoKey":   "discokey:a2eeb418c1171d64359263940844afda5d9bd97b45e1aeb369c427b238c5c664",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50009",
+					"10.65.0.27:50009",
+					"172.17.0.1:50009",
+					"172.19.0.1:50009",
+					"172.20.0.1:50009"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:35:59.531601629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3575030889276975,
+				"StableID":   "niGuZxz8vU11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:288f9583e296edfbe8c217ea5db512d2953bc5ed35fd3b931b8bfe6de4408419",
+				"DiscoKey":   "discokey:4e783cab54c5941c5e9bf63ad04a75509b77829a1472b49be084344cd36a3151",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46705",
+					"10.65.0.27:46705",
+					"172.17.0.1:46705",
+					"172.19.0.1:46705",
+					"172.20.0.1:46705"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:36:00.068839759Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5357389921876185,
+				"StableID":   "nxppspYNqi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b774e49d8cd5f461be6f2c6718c0dc741cf6bd579d44b4e892def1ed87600824",
+				"KeyExpiry":  "2026-11-08T18:36:00Z",
+				"DiscoKey":   "discokey:37924c46e316c320bfd9ece51608310981f84e8f23b306996e8278e13ecdc816",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33630",
+					"10.65.0.27:33630",
+					"172.17.0.1:33630",
+					"172.19.0.1:33630",
+					"172.20.0.1:33630"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:36:00.613120864Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4626505136556407,
+				"StableID":   "ninJCoSM8d11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2182b351bbc58393c83327e9db319378bcfcd1eeb0f8f91004261db5d732b173",
+				"KeyExpiry":  "2026-11-08T18:36:01Z",
+				"DiscoKey":   "discokey:6ed1cf6c9216f827c713788474580dad4f04cd0504339a75569b4bdb70873870",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60453",
+					"10.65.0.27:60453",
+					"172.17.0.1:60453",
+					"172.19.0.1:60453",
+					"172.20.0.1:60453"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:36:01.152066159Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2137527263137108,
+				"StableID":   "n99GdZD6hH11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:782c40cd767b310f562618924caeb8cc7bbaa3399dfda9ecb1a8154d8fd38e17",
+				"KeyExpiry":  "2026-11-08T18:36:01Z",
+				"DiscoKey":   "discokey:681c5180c4c086e43a0102848695b9dec317228fbe5afec097c0e270ed51574a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57911",
+					"10.65.0.27:57911",
+					"172.17.0.1:57911",
+					"172.19.0.1:57911",
+					"172.20.0.1:57911"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:36:01.695480091Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3697785131496041": {
+				"ID":          3697785131496041,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1295019951997443,
+				"StableID":   "nUF6ajyW7B11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1295019951997443,
+				"Key":        "nodekey:bb6cf8789c71ef859aa18b6ed9dbf39f03008a7dcaef60de72ea484372472221",
+				"DiscoKey":   "discokey:b0dfe75e6f3a39d071329257e072773284cf237cbed1303973ca11f221223065",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:48991",
+					"10.65.0.27:48991",
+					"172.17.0.1:48991",
+					"172.19.0.1:48991",
+					"172.20.0.1:48991"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:35:55.762603598Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:bb6cf8789c71ef859aa18b6ed9dbf39f03008a7dcaef60de72ea484372472221",
+			"MachineKey": "mkey:59080ef90a48a315a5e1bb4822c38fd88a7048cdddaadc4f6f403cf5b4b2b506",
+			"Peers": [{
+				"ID":         7411601795144039,
+				"StableID":   "n2SLoFDjsz11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39bcb05d9e43c3e019896b3ee1d45c25d8de8157b4935cd119b532e2bee40740",
+				"DiscoKey":   "discokey:9d99beee748b0a02a460728e2e4a32eff34671fe256c25f593e5d499b7d14b32",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33962",
+					"10.65.0.27:33962",
+					"172.17.0.1:33962",
+					"172.19.0.1:33962",
+					"172.20.0.1:33962"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:35:54.138346186Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8083362849184876,
+				"StableID":   "n97oodEy7621CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b99c19c8696167b8aa649553bbc49427e4ac235a341c2b799495abcadabb752",
+				"DiscoKey":   "discokey:5fe4d987d7899019b40a5d020848d8feadcfd89064237d868314dc502e1db342",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54968",
+					"10.65.0.27:54968",
+					"172.17.0.1:54968",
+					"172.19.0.1:54968",
+					"172.20.0.1:54968"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:35:54.674766883Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8231454160451900,
+				"StableID":   "nFzNssL3H721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:33b07d001b7ddbe4ce31bad55dff70864d516ef9e9d1eb08c97741d9357b8f21",
+				"DiscoKey":   "discokey:4783c0e34488b3aba08f0aa1739c332bf76ad7a9a46052231d9f4484eb34600e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52193",
+					"10.65.0.27:52193",
+					"172.17.0.1:52193",
+					"172.19.0.1:52193",
+					"172.20.0.1:52193"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:35:55.225148997Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3697785131496041,
+				"StableID":   "naRobcYjsV11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:946c833d3613c50bef1739b136b074a176a56b8c0db28f0568aeba6593c7283e",
+				"DiscoKey":   "discokey:d8f4eeed4adc86c3505203fe1dd6d2c9f0d7d5bea17befe201061fff5c6c2b7a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37191",
+					"10.65.0.27:37191",
+					"172.17.0.1:37191",
+					"172.19.0.1:37191",
+					"172.20.0.1:37191"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:35:56.302977665Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3761910066954421,
+				"StableID":   "ntzXZuzmNW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5fe38d5b65c4064ccdbfeed5ba6fce51ef98aab5c9698c9a1ed75a4db3ca123",
+				"DiscoKey":   "discokey:0e3b27e92f3225273c5dd21f3305f45906d27d1f0d070372dcc3efbb5d03356c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:35061",
+					"10.65.0.27:35061",
+					"172.17.0.1:35061",
+					"172.19.0.1:35061",
+					"172.20.0.1:35061"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:35:56.83944357Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7254963029272968,
+				"StableID":   "nbchSSaney11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f520bb3a00890401189333dbfe00690b8fdda98a7d44414fd7775316fa48747",
+				"DiscoKey":   "discokey:60a9b0eda72464868b693e7168dc7888f01781780b97caa4af4d83ccc6c08212",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35085",
+					"10.65.0.27:35085",
+					"172.17.0.1:35085",
+					"172.19.0.1:35085",
+					"172.20.0.1:35085"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:35:57.385639242Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7649445423865526,
+				"StableID":   "n1k5pgxSj221CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:123f9b086c97174e156411cf94f1bda8a4b5a6652b19fe1b7dec811488b3eb69",
+				"DiscoKey":   "discokey:428c1c13dfa68666573b1119bd52c5b512626f0fcdeb903d60c45c631373041c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:53510",
+					"10.65.0.27:53510",
+					"172.17.0.1:53510",
+					"172.19.0.1:53510",
+					"172.20.0.1:53510"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:35:57.928832629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4367341642538930,
+				"StableID":   "n7w9hEfy6b11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93939eea7cc260a57cce179480eb3059180f77f95880bc399d56d028f7d26f62",
+				"DiscoKey":   "discokey:a3ff6a8f814121fc413a519f258139e9ca3d4605362a244621122e9254e3d154",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34703",
+					"10.65.0.27:34703",
+					"172.17.0.1:34703",
+					"172.19.0.1:34703",
+					"172.20.0.1:34703"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:35:58.461822087Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3836926821391324,
+				"StableID":   "nXcXGZZkxW11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:646d0687e4551d3e616df3a73a834b8a7f120d22ae098aacc97b5b12af56877e",
+				"DiscoKey":   "discokey:a42d906ca45f306be44c810cea8dcb6aa3c1dc92ccd4c3baeda4095434ae1170",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47875",
+					"10.65.0.27:47875",
+					"172.17.0.1:47875",
+					"172.19.0.1:47875",
+					"172.20.0.1:47875"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:35:59.004222599Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1397648430420696,
+				"StableID":   "nKztmYrzuB11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8ecf2dcc160d9ef0155ef29fd4f50f7776455c8764413f77779b32f40842e11e",
+				"DiscoKey":   "discokey:a2eeb418c1171d64359263940844afda5d9bd97b45e1aeb369c427b238c5c664",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50009",
+					"10.65.0.27:50009",
+					"172.17.0.1:50009",
+					"172.19.0.1:50009",
+					"172.20.0.1:50009"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:35:59.531601629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3575030889276975,
+				"StableID":   "niGuZxz8vU11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:288f9583e296edfbe8c217ea5db512d2953bc5ed35fd3b931b8bfe6de4408419",
+				"DiscoKey":   "discokey:4e783cab54c5941c5e9bf63ad04a75509b77829a1472b49be084344cd36a3151",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46705",
+					"10.65.0.27:46705",
+					"172.17.0.1:46705",
+					"172.19.0.1:46705",
+					"172.20.0.1:46705"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:36:00.068839759Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5357389921876185,
+				"StableID":   "nxppspYNqi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b774e49d8cd5f461be6f2c6718c0dc741cf6bd579d44b4e892def1ed87600824",
+				"KeyExpiry":  "2026-11-08T18:36:00Z",
+				"DiscoKey":   "discokey:37924c46e316c320bfd9ece51608310981f84e8f23b306996e8278e13ecdc816",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33630",
+					"10.65.0.27:33630",
+					"172.17.0.1:33630",
+					"172.19.0.1:33630",
+					"172.20.0.1:33630"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:36:00.613120864Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4626505136556407,
+				"StableID":   "ninJCoSM8d11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2182b351bbc58393c83327e9db319378bcfcd1eeb0f8f91004261db5d732b173",
+				"KeyExpiry":  "2026-11-08T18:36:01Z",
+				"DiscoKey":   "discokey:6ed1cf6c9216f827c713788474580dad4f04cd0504339a75569b4bdb70873870",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60453",
+					"10.65.0.27:60453",
+					"172.17.0.1:60453",
+					"172.19.0.1:60453",
+					"172.20.0.1:60453"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:36:01.152066159Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2137527263137108,
+				"StableID":   "n99GdZD6hH11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:782c40cd767b310f562618924caeb8cc7bbaa3399dfda9ecb1a8154d8fd38e17",
+				"KeyExpiry":  "2026-11-08T18:36:01Z",
+				"DiscoKey":   "discokey:681c5180c4c086e43a0102848695b9dec317228fbe5afec097c0e270ed51574a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57911",
+					"10.65.0.27:57911",
+					"172.17.0.1:57911",
+					"172.19.0.1:57911",
+					"172.20.0.1:57911"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:36:01.695480091Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1295019951997443": {
+				"ID":          1295019951997443,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7254963029272968,
+				"StableID":   "nbchSSaney11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       7254963029272968,
+				"Key":        "nodekey:5f520bb3a00890401189333dbfe00690b8fdda98a7d44414fd7775316fa48747",
+				"DiscoKey":   "discokey:60a9b0eda72464868b693e7168dc7888f01781780b97caa4af4d83ccc6c08212",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35085",
+					"10.65.0.27:35085",
+					"172.17.0.1:35085",
+					"172.19.0.1:35085",
+					"172.20.0.1:35085"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:35:57.385639242Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5f520bb3a00890401189333dbfe00690b8fdda98a7d44414fd7775316fa48747",
+			"MachineKey": "mkey:17177f1b15e4831a26a9811f9e952513cb13c99b74b77b467e8bc6d7ed0b9714",
+			"Peers": [{
+				"ID":         7411601795144039,
+				"StableID":   "n2SLoFDjsz11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39bcb05d9e43c3e019896b3ee1d45c25d8de8157b4935cd119b532e2bee40740",
+				"DiscoKey":   "discokey:9d99beee748b0a02a460728e2e4a32eff34671fe256c25f593e5d499b7d14b32",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33962",
+					"10.65.0.27:33962",
+					"172.17.0.1:33962",
+					"172.19.0.1:33962",
+					"172.20.0.1:33962"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:35:54.138346186Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8083362849184876,
+				"StableID":   "n97oodEy7621CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b99c19c8696167b8aa649553bbc49427e4ac235a341c2b799495abcadabb752",
+				"DiscoKey":   "discokey:5fe4d987d7899019b40a5d020848d8feadcfd89064237d868314dc502e1db342",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54968",
+					"10.65.0.27:54968",
+					"172.17.0.1:54968",
+					"172.19.0.1:54968",
+					"172.20.0.1:54968"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:35:54.674766883Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8231454160451900,
+				"StableID":   "nFzNssL3H721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:33b07d001b7ddbe4ce31bad55dff70864d516ef9e9d1eb08c97741d9357b8f21",
+				"DiscoKey":   "discokey:4783c0e34488b3aba08f0aa1739c332bf76ad7a9a46052231d9f4484eb34600e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52193",
+					"10.65.0.27:52193",
+					"172.17.0.1:52193",
+					"172.19.0.1:52193",
+					"172.20.0.1:52193"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:35:55.225148997Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1295019951997443,
+				"StableID":   "nUF6ajyW7B11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bb6cf8789c71ef859aa18b6ed9dbf39f03008a7dcaef60de72ea484372472221",
+				"DiscoKey":   "discokey:b0dfe75e6f3a39d071329257e072773284cf237cbed1303973ca11f221223065",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:48991",
+					"10.65.0.27:48991",
+					"172.17.0.1:48991",
+					"172.19.0.1:48991",
+					"172.20.0.1:48991"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:35:55.762603598Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3697785131496041,
+				"StableID":   "naRobcYjsV11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:946c833d3613c50bef1739b136b074a176a56b8c0db28f0568aeba6593c7283e",
+				"DiscoKey":   "discokey:d8f4eeed4adc86c3505203fe1dd6d2c9f0d7d5bea17befe201061fff5c6c2b7a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37191",
+					"10.65.0.27:37191",
+					"172.17.0.1:37191",
+					"172.19.0.1:37191",
+					"172.20.0.1:37191"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:35:56.302977665Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3761910066954421,
+				"StableID":   "ntzXZuzmNW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5fe38d5b65c4064ccdbfeed5ba6fce51ef98aab5c9698c9a1ed75a4db3ca123",
+				"DiscoKey":   "discokey:0e3b27e92f3225273c5dd21f3305f45906d27d1f0d070372dcc3efbb5d03356c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:35061",
+					"10.65.0.27:35061",
+					"172.17.0.1:35061",
+					"172.19.0.1:35061",
+					"172.20.0.1:35061"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:35:56.83944357Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7649445423865526,
+				"StableID":   "n1k5pgxSj221CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:123f9b086c97174e156411cf94f1bda8a4b5a6652b19fe1b7dec811488b3eb69",
+				"DiscoKey":   "discokey:428c1c13dfa68666573b1119bd52c5b512626f0fcdeb903d60c45c631373041c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:53510",
+					"10.65.0.27:53510",
+					"172.17.0.1:53510",
+					"172.19.0.1:53510",
+					"172.20.0.1:53510"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:35:57.928832629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4367341642538930,
+				"StableID":   "n7w9hEfy6b11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93939eea7cc260a57cce179480eb3059180f77f95880bc399d56d028f7d26f62",
+				"DiscoKey":   "discokey:a3ff6a8f814121fc413a519f258139e9ca3d4605362a244621122e9254e3d154",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34703",
+					"10.65.0.27:34703",
+					"172.17.0.1:34703",
+					"172.19.0.1:34703",
+					"172.20.0.1:34703"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:35:58.461822087Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3836926821391324,
+				"StableID":   "nXcXGZZkxW11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:646d0687e4551d3e616df3a73a834b8a7f120d22ae098aacc97b5b12af56877e",
+				"DiscoKey":   "discokey:a42d906ca45f306be44c810cea8dcb6aa3c1dc92ccd4c3baeda4095434ae1170",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47875",
+					"10.65.0.27:47875",
+					"172.17.0.1:47875",
+					"172.19.0.1:47875",
+					"172.20.0.1:47875"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:35:59.004222599Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1397648430420696,
+				"StableID":   "nKztmYrzuB11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8ecf2dcc160d9ef0155ef29fd4f50f7776455c8764413f77779b32f40842e11e",
+				"DiscoKey":   "discokey:a2eeb418c1171d64359263940844afda5d9bd97b45e1aeb369c427b238c5c664",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50009",
+					"10.65.0.27:50009",
+					"172.17.0.1:50009",
+					"172.19.0.1:50009",
+					"172.20.0.1:50009"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:35:59.531601629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3575030889276975,
+				"StableID":   "niGuZxz8vU11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:288f9583e296edfbe8c217ea5db512d2953bc5ed35fd3b931b8bfe6de4408419",
+				"DiscoKey":   "discokey:4e783cab54c5941c5e9bf63ad04a75509b77829a1472b49be084344cd36a3151",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46705",
+					"10.65.0.27:46705",
+					"172.17.0.1:46705",
+					"172.19.0.1:46705",
+					"172.20.0.1:46705"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:36:00.068839759Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5357389921876185,
+				"StableID":   "nxppspYNqi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b774e49d8cd5f461be6f2c6718c0dc741cf6bd579d44b4e892def1ed87600824",
+				"KeyExpiry":  "2026-11-08T18:36:00Z",
+				"DiscoKey":   "discokey:37924c46e316c320bfd9ece51608310981f84e8f23b306996e8278e13ecdc816",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33630",
+					"10.65.0.27:33630",
+					"172.17.0.1:33630",
+					"172.19.0.1:33630",
+					"172.20.0.1:33630"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:36:00.613120864Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4626505136556407,
+				"StableID":   "ninJCoSM8d11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2182b351bbc58393c83327e9db319378bcfcd1eeb0f8f91004261db5d732b173",
+				"KeyExpiry":  "2026-11-08T18:36:01Z",
+				"DiscoKey":   "discokey:6ed1cf6c9216f827c713788474580dad4f04cd0504339a75569b4bdb70873870",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60453",
+					"10.65.0.27:60453",
+					"172.17.0.1:60453",
+					"172.19.0.1:60453",
+					"172.20.0.1:60453"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:36:01.152066159Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2137527263137108,
+				"StableID":   "n99GdZD6hH11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:782c40cd767b310f562618924caeb8cc7bbaa3399dfda9ecb1a8154d8fd38e17",
+				"KeyExpiry":  "2026-11-08T18:36:01Z",
+				"DiscoKey":   "discokey:681c5180c4c086e43a0102848695b9dec317228fbe5afec097c0e270ed51574a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57911",
+					"10.65.0.27:57911",
+					"172.17.0.1:57911",
+					"172.19.0.1:57911",
+					"172.20.0.1:57911"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:36:01.695480091Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7254963029272968": {
+				"ID":          7254963029272968,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4367341642538930,
+				"StableID":   "n7w9hEfy6b11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       4367341642538930,
+				"Key":        "nodekey:93939eea7cc260a57cce179480eb3059180f77f95880bc399d56d028f7d26f62",
+				"DiscoKey":   "discokey:a3ff6a8f814121fc413a519f258139e9ca3d4605362a244621122e9254e3d154",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34703",
+					"10.65.0.27:34703",
+					"172.17.0.1:34703",
+					"172.19.0.1:34703",
+					"172.20.0.1:34703"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:35:58.461822087Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:93939eea7cc260a57cce179480eb3059180f77f95880bc399d56d028f7d26f62",
+			"MachineKey": "mkey:150a178ceb8233746bd28a4f27181b1fab8e2e9187707f442f07b620cb402564",
+			"Peers": [{
+				"ID":         7411601795144039,
+				"StableID":   "n2SLoFDjsz11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39bcb05d9e43c3e019896b3ee1d45c25d8de8157b4935cd119b532e2bee40740",
+				"DiscoKey":   "discokey:9d99beee748b0a02a460728e2e4a32eff34671fe256c25f593e5d499b7d14b32",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33962",
+					"10.65.0.27:33962",
+					"172.17.0.1:33962",
+					"172.19.0.1:33962",
+					"172.20.0.1:33962"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:35:54.138346186Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8083362849184876,
+				"StableID":   "n97oodEy7621CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b99c19c8696167b8aa649553bbc49427e4ac235a341c2b799495abcadabb752",
+				"DiscoKey":   "discokey:5fe4d987d7899019b40a5d020848d8feadcfd89064237d868314dc502e1db342",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54968",
+					"10.65.0.27:54968",
+					"172.17.0.1:54968",
+					"172.19.0.1:54968",
+					"172.20.0.1:54968"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:35:54.674766883Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8231454160451900,
+				"StableID":   "nFzNssL3H721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:33b07d001b7ddbe4ce31bad55dff70864d516ef9e9d1eb08c97741d9357b8f21",
+				"DiscoKey":   "discokey:4783c0e34488b3aba08f0aa1739c332bf76ad7a9a46052231d9f4484eb34600e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52193",
+					"10.65.0.27:52193",
+					"172.17.0.1:52193",
+					"172.19.0.1:52193",
+					"172.20.0.1:52193"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:35:55.225148997Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1295019951997443,
+				"StableID":   "nUF6ajyW7B11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bb6cf8789c71ef859aa18b6ed9dbf39f03008a7dcaef60de72ea484372472221",
+				"DiscoKey":   "discokey:b0dfe75e6f3a39d071329257e072773284cf237cbed1303973ca11f221223065",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:48991",
+					"10.65.0.27:48991",
+					"172.17.0.1:48991",
+					"172.19.0.1:48991",
+					"172.20.0.1:48991"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:35:55.762603598Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3697785131496041,
+				"StableID":   "naRobcYjsV11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:946c833d3613c50bef1739b136b074a176a56b8c0db28f0568aeba6593c7283e",
+				"DiscoKey":   "discokey:d8f4eeed4adc86c3505203fe1dd6d2c9f0d7d5bea17befe201061fff5c6c2b7a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37191",
+					"10.65.0.27:37191",
+					"172.17.0.1:37191",
+					"172.19.0.1:37191",
+					"172.20.0.1:37191"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:35:56.302977665Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3761910066954421,
+				"StableID":   "ntzXZuzmNW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5fe38d5b65c4064ccdbfeed5ba6fce51ef98aab5c9698c9a1ed75a4db3ca123",
+				"DiscoKey":   "discokey:0e3b27e92f3225273c5dd21f3305f45906d27d1f0d070372dcc3efbb5d03356c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:35061",
+					"10.65.0.27:35061",
+					"172.17.0.1:35061",
+					"172.19.0.1:35061",
+					"172.20.0.1:35061"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:35:56.83944357Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7254963029272968,
+				"StableID":   "nbchSSaney11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f520bb3a00890401189333dbfe00690b8fdda98a7d44414fd7775316fa48747",
+				"DiscoKey":   "discokey:60a9b0eda72464868b693e7168dc7888f01781780b97caa4af4d83ccc6c08212",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35085",
+					"10.65.0.27:35085",
+					"172.17.0.1:35085",
+					"172.19.0.1:35085",
+					"172.20.0.1:35085"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:35:57.385639242Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7649445423865526,
+				"StableID":   "n1k5pgxSj221CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:123f9b086c97174e156411cf94f1bda8a4b5a6652b19fe1b7dec811488b3eb69",
+				"DiscoKey":   "discokey:428c1c13dfa68666573b1119bd52c5b512626f0fcdeb903d60c45c631373041c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:53510",
+					"10.65.0.27:53510",
+					"172.17.0.1:53510",
+					"172.19.0.1:53510",
+					"172.20.0.1:53510"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:35:57.928832629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3836926821391324,
+				"StableID":   "nXcXGZZkxW11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:646d0687e4551d3e616df3a73a834b8a7f120d22ae098aacc97b5b12af56877e",
+				"DiscoKey":   "discokey:a42d906ca45f306be44c810cea8dcb6aa3c1dc92ccd4c3baeda4095434ae1170",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47875",
+					"10.65.0.27:47875",
+					"172.17.0.1:47875",
+					"172.19.0.1:47875",
+					"172.20.0.1:47875"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:35:59.004222599Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1397648430420696,
+				"StableID":   "nKztmYrzuB11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8ecf2dcc160d9ef0155ef29fd4f50f7776455c8764413f77779b32f40842e11e",
+				"DiscoKey":   "discokey:a2eeb418c1171d64359263940844afda5d9bd97b45e1aeb369c427b238c5c664",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50009",
+					"10.65.0.27:50009",
+					"172.17.0.1:50009",
+					"172.19.0.1:50009",
+					"172.20.0.1:50009"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:35:59.531601629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3575030889276975,
+				"StableID":   "niGuZxz8vU11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:288f9583e296edfbe8c217ea5db512d2953bc5ed35fd3b931b8bfe6de4408419",
+				"DiscoKey":   "discokey:4e783cab54c5941c5e9bf63ad04a75509b77829a1472b49be084344cd36a3151",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46705",
+					"10.65.0.27:46705",
+					"172.17.0.1:46705",
+					"172.19.0.1:46705",
+					"172.20.0.1:46705"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:36:00.068839759Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5357389921876185,
+				"StableID":   "nxppspYNqi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b774e49d8cd5f461be6f2c6718c0dc741cf6bd579d44b4e892def1ed87600824",
+				"KeyExpiry":  "2026-11-08T18:36:00Z",
+				"DiscoKey":   "discokey:37924c46e316c320bfd9ece51608310981f84e8f23b306996e8278e13ecdc816",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33630",
+					"10.65.0.27:33630",
+					"172.17.0.1:33630",
+					"172.19.0.1:33630",
+					"172.20.0.1:33630"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:36:00.613120864Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4626505136556407,
+				"StableID":   "ninJCoSM8d11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2182b351bbc58393c83327e9db319378bcfcd1eeb0f8f91004261db5d732b173",
+				"KeyExpiry":  "2026-11-08T18:36:01Z",
+				"DiscoKey":   "discokey:6ed1cf6c9216f827c713788474580dad4f04cd0504339a75569b4bdb70873870",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60453",
+					"10.65.0.27:60453",
+					"172.17.0.1:60453",
+					"172.19.0.1:60453",
+					"172.20.0.1:60453"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:36:01.152066159Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2137527263137108,
+				"StableID":   "n99GdZD6hH11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:782c40cd767b310f562618924caeb8cc7bbaa3399dfda9ecb1a8154d8fd38e17",
+				"KeyExpiry":  "2026-11-08T18:36:01Z",
+				"DiscoKey":   "discokey:681c5180c4c086e43a0102848695b9dec317228fbe5afec097c0e270ed51574a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57911",
+					"10.65.0.27:57911",
+					"172.17.0.1:57911",
+					"172.19.0.1:57911",
+					"172.20.0.1:57911"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:36:01.695480091Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4367341642538930": {
+				"ID":          4367341642538930,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4626505136556407,
+				"StableID":   "ninJCoSM8d11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2182b351bbc58393c83327e9db319378bcfcd1eeb0f8f91004261db5d732b173",
+				"KeyExpiry":  "2026-11-08T18:36:01Z",
+				"DiscoKey":   "discokey:6ed1cf6c9216f827c713788474580dad4f04cd0504339a75569b4bdb70873870",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60453",
+					"10.65.0.27:60453",
+					"172.17.0.1:60453",
+					"172.19.0.1:60453",
+					"172.20.0.1:60453"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:36:01.152066159Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2182b351bbc58393c83327e9db319378bcfcd1eeb0f8f91004261db5d732b173",
+			"MachineKey": "mkey:77e119b0500004c86c566a733d90bed9e425059aefcd72842e6903140e5ae87b",
+			"Peers": [{
+				"ID":         7411601795144039,
+				"StableID":   "n2SLoFDjsz11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39bcb05d9e43c3e019896b3ee1d45c25d8de8157b4935cd119b532e2bee40740",
+				"DiscoKey":   "discokey:9d99beee748b0a02a460728e2e4a32eff34671fe256c25f593e5d499b7d14b32",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33962",
+					"10.65.0.27:33962",
+					"172.17.0.1:33962",
+					"172.19.0.1:33962",
+					"172.20.0.1:33962"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:35:54.138346186Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8083362849184876,
+				"StableID":   "n97oodEy7621CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b99c19c8696167b8aa649553bbc49427e4ac235a341c2b799495abcadabb752",
+				"DiscoKey":   "discokey:5fe4d987d7899019b40a5d020848d8feadcfd89064237d868314dc502e1db342",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54968",
+					"10.65.0.27:54968",
+					"172.17.0.1:54968",
+					"172.19.0.1:54968",
+					"172.20.0.1:54968"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:35:54.674766883Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8231454160451900,
+				"StableID":   "nFzNssL3H721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:33b07d001b7ddbe4ce31bad55dff70864d516ef9e9d1eb08c97741d9357b8f21",
+				"DiscoKey":   "discokey:4783c0e34488b3aba08f0aa1739c332bf76ad7a9a46052231d9f4484eb34600e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52193",
+					"10.65.0.27:52193",
+					"172.17.0.1:52193",
+					"172.19.0.1:52193",
+					"172.20.0.1:52193"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:35:55.225148997Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1295019951997443,
+				"StableID":   "nUF6ajyW7B11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bb6cf8789c71ef859aa18b6ed9dbf39f03008a7dcaef60de72ea484372472221",
+				"DiscoKey":   "discokey:b0dfe75e6f3a39d071329257e072773284cf237cbed1303973ca11f221223065",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:48991",
+					"10.65.0.27:48991",
+					"172.17.0.1:48991",
+					"172.19.0.1:48991",
+					"172.20.0.1:48991"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:35:55.762603598Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3697785131496041,
+				"StableID":   "naRobcYjsV11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:946c833d3613c50bef1739b136b074a176a56b8c0db28f0568aeba6593c7283e",
+				"DiscoKey":   "discokey:d8f4eeed4adc86c3505203fe1dd6d2c9f0d7d5bea17befe201061fff5c6c2b7a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37191",
+					"10.65.0.27:37191",
+					"172.17.0.1:37191",
+					"172.19.0.1:37191",
+					"172.20.0.1:37191"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:35:56.302977665Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3761910066954421,
+				"StableID":   "ntzXZuzmNW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5fe38d5b65c4064ccdbfeed5ba6fce51ef98aab5c9698c9a1ed75a4db3ca123",
+				"DiscoKey":   "discokey:0e3b27e92f3225273c5dd21f3305f45906d27d1f0d070372dcc3efbb5d03356c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:35061",
+					"10.65.0.27:35061",
+					"172.17.0.1:35061",
+					"172.19.0.1:35061",
+					"172.20.0.1:35061"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:35:56.83944357Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7254963029272968,
+				"StableID":   "nbchSSaney11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f520bb3a00890401189333dbfe00690b8fdda98a7d44414fd7775316fa48747",
+				"DiscoKey":   "discokey:60a9b0eda72464868b693e7168dc7888f01781780b97caa4af4d83ccc6c08212",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35085",
+					"10.65.0.27:35085",
+					"172.17.0.1:35085",
+					"172.19.0.1:35085",
+					"172.20.0.1:35085"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:35:57.385639242Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7649445423865526,
+				"StableID":   "n1k5pgxSj221CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:123f9b086c97174e156411cf94f1bda8a4b5a6652b19fe1b7dec811488b3eb69",
+				"DiscoKey":   "discokey:428c1c13dfa68666573b1119bd52c5b512626f0fcdeb903d60c45c631373041c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:53510",
+					"10.65.0.27:53510",
+					"172.17.0.1:53510",
+					"172.19.0.1:53510",
+					"172.20.0.1:53510"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:35:57.928832629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4367341642538930,
+				"StableID":   "n7w9hEfy6b11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93939eea7cc260a57cce179480eb3059180f77f95880bc399d56d028f7d26f62",
+				"DiscoKey":   "discokey:a3ff6a8f814121fc413a519f258139e9ca3d4605362a244621122e9254e3d154",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34703",
+					"10.65.0.27:34703",
+					"172.17.0.1:34703",
+					"172.19.0.1:34703",
+					"172.20.0.1:34703"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:35:58.461822087Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3836926821391324,
+				"StableID":   "nXcXGZZkxW11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:646d0687e4551d3e616df3a73a834b8a7f120d22ae098aacc97b5b12af56877e",
+				"DiscoKey":   "discokey:a42d906ca45f306be44c810cea8dcb6aa3c1dc92ccd4c3baeda4095434ae1170",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47875",
+					"10.65.0.27:47875",
+					"172.17.0.1:47875",
+					"172.19.0.1:47875",
+					"172.20.0.1:47875"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:35:59.004222599Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1397648430420696,
+				"StableID":   "nKztmYrzuB11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8ecf2dcc160d9ef0155ef29fd4f50f7776455c8764413f77779b32f40842e11e",
+				"DiscoKey":   "discokey:a2eeb418c1171d64359263940844afda5d9bd97b45e1aeb369c427b238c5c664",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50009",
+					"10.65.0.27:50009",
+					"172.17.0.1:50009",
+					"172.19.0.1:50009",
+					"172.20.0.1:50009"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:35:59.531601629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3575030889276975,
+				"StableID":   "niGuZxz8vU11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:288f9583e296edfbe8c217ea5db512d2953bc5ed35fd3b931b8bfe6de4408419",
+				"DiscoKey":   "discokey:4e783cab54c5941c5e9bf63ad04a75509b77829a1472b49be084344cd36a3151",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46705",
+					"10.65.0.27:46705",
+					"172.17.0.1:46705",
+					"172.19.0.1:46705",
+					"172.20.0.1:46705"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:36:00.068839759Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5357389921876185,
+				"StableID":   "nxppspYNqi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b774e49d8cd5f461be6f2c6718c0dc741cf6bd579d44b4e892def1ed87600824",
+				"KeyExpiry":  "2026-11-08T18:36:00Z",
+				"DiscoKey":   "discokey:37924c46e316c320bfd9ece51608310981f84e8f23b306996e8278e13ecdc816",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33630",
+					"10.65.0.27:33630",
+					"172.17.0.1:33630",
+					"172.19.0.1:33630",
+					"172.20.0.1:33630"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:36:00.613120864Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2137527263137108,
+				"StableID":   "n99GdZD6hH11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:782c40cd767b310f562618924caeb8cc7bbaa3399dfda9ecb1a8154d8fd38e17",
+				"KeyExpiry":  "2026-11-08T18:36:01Z",
+				"DiscoKey":   "discokey:681c5180c4c086e43a0102848695b9dec317228fbe5afec097c0e270ed51574a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57911",
+					"10.65.0.27:57911",
+					"172.17.0.1:57911",
+					"172.19.0.1:57911",
+					"172.20.0.1:57911"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:36:01.695480091Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3836926821391324,
+				"StableID":   "nXcXGZZkxW11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       3836926821391324,
+				"Key":        "nodekey:646d0687e4551d3e616df3a73a834b8a7f120d22ae098aacc97b5b12af56877e",
+				"DiscoKey":   "discokey:a42d906ca45f306be44c810cea8dcb6aa3c1dc92ccd4c3baeda4095434ae1170",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:47875",
+					"10.65.0.27:47875",
+					"172.17.0.1:47875",
+					"172.19.0.1:47875",
+					"172.20.0.1:47875"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:35:59.004222599Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:646d0687e4551d3e616df3a73a834b8a7f120d22ae098aacc97b5b12af56877e",
+			"MachineKey": "mkey:3fca7da10f53c312eba90373cd0651dfceda5432a602c14dfdf9d06d12c88073",
+			"Peers": [{
+				"ID":         7411601795144039,
+				"StableID":   "n2SLoFDjsz11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39bcb05d9e43c3e019896b3ee1d45c25d8de8157b4935cd119b532e2bee40740",
+				"DiscoKey":   "discokey:9d99beee748b0a02a460728e2e4a32eff34671fe256c25f593e5d499b7d14b32",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33962",
+					"10.65.0.27:33962",
+					"172.17.0.1:33962",
+					"172.19.0.1:33962",
+					"172.20.0.1:33962"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:35:54.138346186Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8083362849184876,
+				"StableID":   "n97oodEy7621CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b99c19c8696167b8aa649553bbc49427e4ac235a341c2b799495abcadabb752",
+				"DiscoKey":   "discokey:5fe4d987d7899019b40a5d020848d8feadcfd89064237d868314dc502e1db342",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:54968",
+					"10.65.0.27:54968",
+					"172.17.0.1:54968",
+					"172.19.0.1:54968",
+					"172.20.0.1:54968"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:35:54.674766883Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8231454160451900,
+				"StableID":   "nFzNssL3H721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:33b07d001b7ddbe4ce31bad55dff70864d516ef9e9d1eb08c97741d9357b8f21",
+				"DiscoKey":   "discokey:4783c0e34488b3aba08f0aa1739c332bf76ad7a9a46052231d9f4484eb34600e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52193",
+					"10.65.0.27:52193",
+					"172.17.0.1:52193",
+					"172.19.0.1:52193",
+					"172.20.0.1:52193"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:35:55.225148997Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1295019951997443,
+				"StableID":   "nUF6ajyW7B11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bb6cf8789c71ef859aa18b6ed9dbf39f03008a7dcaef60de72ea484372472221",
+				"DiscoKey":   "discokey:b0dfe75e6f3a39d071329257e072773284cf237cbed1303973ca11f221223065",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:48991",
+					"10.65.0.27:48991",
+					"172.17.0.1:48991",
+					"172.19.0.1:48991",
+					"172.20.0.1:48991"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:35:55.762603598Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3697785131496041,
+				"StableID":   "naRobcYjsV11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:946c833d3613c50bef1739b136b074a176a56b8c0db28f0568aeba6593c7283e",
+				"DiscoKey":   "discokey:d8f4eeed4adc86c3505203fe1dd6d2c9f0d7d5bea17befe201061fff5c6c2b7a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37191",
+					"10.65.0.27:37191",
+					"172.17.0.1:37191",
+					"172.19.0.1:37191",
+					"172.20.0.1:37191"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:35:56.302977665Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3761910066954421,
+				"StableID":   "ntzXZuzmNW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5fe38d5b65c4064ccdbfeed5ba6fce51ef98aab5c9698c9a1ed75a4db3ca123",
+				"DiscoKey":   "discokey:0e3b27e92f3225273c5dd21f3305f45906d27d1f0d070372dcc3efbb5d03356c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:35061",
+					"10.65.0.27:35061",
+					"172.17.0.1:35061",
+					"172.19.0.1:35061",
+					"172.20.0.1:35061"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:35:56.83944357Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7254963029272968,
+				"StableID":   "nbchSSaney11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f520bb3a00890401189333dbfe00690b8fdda98a7d44414fd7775316fa48747",
+				"DiscoKey":   "discokey:60a9b0eda72464868b693e7168dc7888f01781780b97caa4af4d83ccc6c08212",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:35085",
+					"10.65.0.27:35085",
+					"172.17.0.1:35085",
+					"172.19.0.1:35085",
+					"172.20.0.1:35085"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:35:57.385639242Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7649445423865526,
+				"StableID":   "n1k5pgxSj221CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:123f9b086c97174e156411cf94f1bda8a4b5a6652b19fe1b7dec811488b3eb69",
+				"DiscoKey":   "discokey:428c1c13dfa68666573b1119bd52c5b512626f0fcdeb903d60c45c631373041c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:53510",
+					"10.65.0.27:53510",
+					"172.17.0.1:53510",
+					"172.19.0.1:53510",
+					"172.20.0.1:53510"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:35:57.928832629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4367341642538930,
+				"StableID":   "n7w9hEfy6b11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93939eea7cc260a57cce179480eb3059180f77f95880bc399d56d028f7d26f62",
+				"DiscoKey":   "discokey:a3ff6a8f814121fc413a519f258139e9ca3d4605362a244621122e9254e3d154",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:34703",
+					"10.65.0.27:34703",
+					"172.17.0.1:34703",
+					"172.19.0.1:34703",
+					"172.20.0.1:34703"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:35:58.461822087Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1397648430420696,
+				"StableID":   "nKztmYrzuB11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8ecf2dcc160d9ef0155ef29fd4f50f7776455c8764413f77779b32f40842e11e",
+				"DiscoKey":   "discokey:a2eeb418c1171d64359263940844afda5d9bd97b45e1aeb369c427b238c5c664",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50009",
+					"10.65.0.27:50009",
+					"172.17.0.1:50009",
+					"172.19.0.1:50009",
+					"172.20.0.1:50009"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:35:59.531601629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3575030889276975,
+				"StableID":   "niGuZxz8vU11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:288f9583e296edfbe8c217ea5db512d2953bc5ed35fd3b931b8bfe6de4408419",
+				"DiscoKey":   "discokey:4e783cab54c5941c5e9bf63ad04a75509b77829a1472b49be084344cd36a3151",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46705",
+					"10.65.0.27:46705",
+					"172.17.0.1:46705",
+					"172.19.0.1:46705",
+					"172.20.0.1:46705"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:36:00.068839759Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5357389921876185,
+				"StableID":   "nxppspYNqi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:b774e49d8cd5f461be6f2c6718c0dc741cf6bd579d44b4e892def1ed87600824",
+				"KeyExpiry":  "2026-11-08T18:36:00Z",
+				"DiscoKey":   "discokey:37924c46e316c320bfd9ece51608310981f84e8f23b306996e8278e13ecdc816",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:33630",
+					"10.65.0.27:33630",
+					"172.17.0.1:33630",
+					"172.19.0.1:33630",
+					"172.20.0.1:33630"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:36:00.613120864Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4626505136556407,
+				"StableID":   "ninJCoSM8d11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2182b351bbc58393c83327e9db319378bcfcd1eeb0f8f91004261db5d732b173",
+				"KeyExpiry":  "2026-11-08T18:36:01Z",
+				"DiscoKey":   "discokey:6ed1cf6c9216f827c713788474580dad4f04cd0504339a75569b4bdb70873870",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:60453",
+					"10.65.0.27:60453",
+					"172.17.0.1:60453",
+					"172.19.0.1:60453",
+					"172.20.0.1:60453"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:36:01.152066159Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2137527263137108,
+				"StableID":   "n99GdZD6hH11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:782c40cd767b310f562618924caeb8cc7bbaa3399dfda9ecb1a8154d8fd38e17",
+				"KeyExpiry":  "2026-11-08T18:36:01Z",
+				"DiscoKey":   "discokey:681c5180c4c086e43a0102848695b9dec317228fbe5afec097c0e270ed51574a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57911",
+					"10.65.0.27:57911",
+					"172.17.0.1:57911",
+					"172.19.0.1:57911",
+					"172.20.0.1:57911"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:36:01.695480091Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3836926821391324": {
+				"ID":          3836926821391324,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/sshtest_results/sshtest-checkperiod-no-effect.hujson
+++ b/hscontrol/policy/v2/testdata/sshtest_results/sshtest-checkperiod-no-effect.hujson
@@ -1,0 +1,20094 @@
+// sshtest-checkperiod-no-effect
+//
+// action:check with checkPeriod, sshTests check[] passes
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T18:36:37Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "sshtest-checkperiod-no-effect",
+	"description":    "action:check with checkPeriod, sshTests check[] passes",
+	"category":       "sshtest",
+	"captured_at":    "2026-05-12T18:36:37.735827568Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                \n  \n                                                                      \n                 \n{\n\t\"category\":    \"sshtest\",\n\t\"description\": \"action:check with checkPeriod, sshTests check[] passes\",\n\t\"id\":          \"sshtest-checkperiod-no-effect\",\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\":      \"check\",\n\t\t\"checkPeriod\": \"24h\",\n\t\t\"dst\":         [\"tag:server\"],\n\t\t\"src\":         [\"thor@example.org\"],\n\t\t\"users\":       [\"root\"]\n\t}], \"sshTests\": [{\n\t\t\"check\": [\"root\"],\n\t\t\"dst\":   [\"tag:server\"],\n\t\t\"src\":   \"thor@example.org\"\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/sshtest/sshtest-checkperiod-no-effect.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action":      "check",
+				"checkPeriod": "24h",
+				"dst":         ["tag:server"],
+				"src":         ["thor@example.org"],
+				"users":       ["root"]
+			}],
+			"sshTests":  [{"check": ["root"], "dst": ["tag:server"], "src": "thor@example.org"}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4388674661218757,
+				"StableID":   "ngE6WQ3eGb11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       4388674661218757,
+				"Key":        "nodekey:b4f91d56dd1ea841cbe7ffab1472ff82ece2bace77f4a3f009caab96e7697f06",
+				"DiscoKey":   "discokey:30aa89a55718cecce47efd15ade388e441c99b5e331bcf624cecf6e0d0c33760",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52079",
+					"10.65.0.27:52079",
+					"172.17.0.1:52079",
+					"172.19.0.1:52079",
+					"172.20.0.1:52079"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:36:47.098952687Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b4f91d56dd1ea841cbe7ffab1472ff82ece2bace77f4a3f009caab96e7697f06",
+			"MachineKey": "mkey:54698284becdd092d264a6587ca89bca9125499187be60e9ec5c9b1f9a36a172",
+			"Peers": [{
+				"ID":         3168131240925008,
+				"StableID":   "nX6H1GSrjR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c886f1599393bfd6442fc5cd5676fc43a7a4ffb41ca8a85caa7f26b3a08055",
+				"DiscoKey":   "discokey:0eb3a1c280df196d700bb107a6721d2223c5b3991ad4bf94988024e951eecc1e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58730",
+					"10.65.0.27:58730",
+					"172.17.0.1:58730",
+					"172.19.0.1:58730",
+					"172.20.0.1:58730"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:36:40.37788928Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6245672826688978,
+				"StableID":   "nF1nPbEgmq11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a57c23204adb8aa23ed526c6ba90ae0997cd587bb7eddd7873be6fc39a140d1f",
+				"DiscoKey":   "discokey:b43c70046a13eaceea25456c33ac35fd31108f81eb652db612e306ce9d91db5d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43912",
+					"10.65.0.27:43912",
+					"172.17.0.1:43912",
+					"172.19.0.1:43912",
+					"172.20.0.1:43912"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:36:40.86868446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3983758180432024,
+				"StableID":   "nfgcfBaF7Y11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:506bf2a42965905de3fd322f0688ef00e428fba6ae84ebf09257c4e394fccf6f",
+				"DiscoKey":   "discokey:12017fb6117fe12c02bbab3bad9e428585fe81fc210e6fa8fb45624fceaaa04f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35907",
+					"10.65.0.27:35907",
+					"172.17.0.1:35907",
+					"172.19.0.1:35907",
+					"172.20.0.1:35907"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:36:41.398072621Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2791095926211361,
+				"StableID":   "nJqjLiM6oN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6729631809256061f766a87280f0b1f460bba3b8f0e97acec4ad87b04234a68",
+				"DiscoKey":   "discokey:4db96d9f99c69c4b67da309c42fd815cd2e4cae025e59358ade6321a71944601",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:41108",
+					"10.65.0.27:41108",
+					"172.17.0.1:41108",
+					"172.19.0.1:41108",
+					"172.20.0.1:41108"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:36:41.931695818Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1110201268129711,
+				"StableID":   "nCdpM57pf911CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aedbcb2d15fef85942bfccf58890590a82aacf4aee57b75681c4a529d6aa5633",
+				"DiscoKey":   "discokey:bf38a17b29854a48515c05ba77a914f8159771b2aec33b2536b353a0c00f5170",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60740",
+					"10.65.0.27:60740",
+					"172.17.0.1:60740",
+					"172.19.0.1:60740",
+					"172.20.0.1:60740"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:36:42.478410842Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7177155754033765,
+				"StableID":   "n6mByFiY3y11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea05e22aad7d12ca56e4c34f1078d44308e4199a52c1c3aaba8e63a1f0f0f239",
+				"DiscoKey":   "discokey:77c9346d6a199d7c1ead5e5bc2b3d5ec92cc860fbf5aa92594fec79e4d489708",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42457",
+					"10.65.0.27:42457",
+					"172.17.0.1:42457",
+					"172.19.0.1:42457",
+					"172.20.0.1:42457"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:36:43.025686311Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6219602308049180,
+				"StableID":   "n5dDwYQsZq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aefa52e419d267ef6b41522c3837b21964e004dc33cb63cba387eeb663bd3a43",
+				"DiscoKey":   "discokey:5c849ebeeab05b5673d956ec5d2be343b753849f2f73821369cf2dfc6402fa66",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43640",
+					"10.65.0.27:43640",
+					"172.17.0.1:43640",
+					"172.19.0.1:43640",
+					"172.20.0.1:43640"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:36:43.546884161Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5619277868006469,
+				"StableID":   "nLLCtFuysk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c2bc6893b12c60a8b4117112c48e1d0d5cd152a44fbb93bc56cdcb67361ab369",
+				"DiscoKey":   "discokey:71453ce0487ae899966e7600480dcfd921c6062aa0cdb99329acc4445a21013f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37603",
+					"10.65.0.27:37603",
+					"172.17.0.1:37603",
+					"172.19.0.1:37603",
+					"172.20.0.1:37603"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:36:44.102860155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1949930473611386,
+				"StableID":   "nF9LjHN8EG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0520a05867071797620eac590ce4721758498e15f7a5544adced085dc694c1f",
+				"DiscoKey":   "discokey:bbc4595df07fc1cd97ea97fc2139aa31d71e0517edb4b2ce22d8cb19d6be220c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45998",
+					"10.65.0.27:45998",
+					"172.17.0.1:45998",
+					"172.19.0.1:45998",
+					"172.20.0.1:45998"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:36:44.641057149Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3922831435313901,
+				"StableID":   "nQzLqX8fdX11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba7ec5111e527ac491757f4711444d81ce4324c47ab1fb152e741cf70649e662",
+				"DiscoKey":   "discokey:bfbe8d5fee913745b5adb2029691c33c8e7c893b59f07ac6b025dec9b2aaa904",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33462",
+					"10.65.0.27:33462",
+					"172.17.0.1:33462",
+					"172.19.0.1:33462",
+					"172.20.0.1:33462"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:36:45.183706915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3188966479592688,
+				"StableID":   "nZBYh2kHuR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:598fb6b7d6644fa86fa4f87f4233a8d7acf65193e8e6fa83ab4f63c1d28f8325",
+				"DiscoKey":   "discokey:2684699793fae45a134263e88c970c4fe7a21a04e14eb597ffd580e3681f4166",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38560",
+					"10.65.0.27:38560",
+					"172.17.0.1:38560",
+					"172.19.0.1:38560",
+					"172.20.0.1:38560"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:36:45.722400629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8001103941033343,
+				"StableID":   "nkyzm7SiU521CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:83b4ecf2b957218ecac739aa9b2092c8a95bc0c7e3b4326994f34b42bc0d8924",
+				"KeyExpiry":  "2026-11-08T18:36:47Z",
+				"DiscoKey":   "discokey:74d75c9bbc4beb1e985ae5c44643b5e270507e6d9ff4f827a16d932bc22a1004",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40677",
+					"10.65.0.27:40677",
+					"172.17.0.1:40677",
+					"172.19.0.1:40677",
+					"172.20.0.1:40677"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:36:47.637656119Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         922686301093192,
+				"StableID":   "nm1YqTQtC811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5fa74c00673f32839e190fe41a8a0335020af612f9536858c0d5b52f4efa9b1d",
+				"KeyExpiry":  "2026-11-08T18:36:48Z",
+				"DiscoKey":   "discokey:0a28137ce9a22ed8cced08245ddcbabbc27b6fdd0a4d8de898700d970e18c33c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38847",
+					"10.65.0.27:38847",
+					"172.17.0.1:38847",
+					"172.19.0.1:38847",
+					"172.20.0.1:38847"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:36:48.158330475Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3336477534055655,
+				"StableID":   "nW4LTDc64T11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e8a9782344aed454b2a7ed9c81a181016b8ed378c27070eb5ee653568aa22550",
+				"KeyExpiry":  "2026-11-08T18:36:48Z",
+				"DiscoKey":   "discokey:9ef60a59270caa12a3a7f1da9b29db3a6fe1d5295994ff7249bd586c30c23f21",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:48138",
+					"10.65.0.27:48138",
+					"172.17.0.1:48138",
+					"172.19.0.1:48138",
+					"172.20.0.1:48138"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:36:48.702894407Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{
+				"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+				"sshUsers":   {"root": "root"},
+				"action": {
+					"holdAndDelegate": "https://unused/machine/ssh/action/$SRC_NODE_ID/to/$DST_NODE_ID?local_user=$LOCAL_USER"
+				}
+			}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4388674661218757": {
+				"ID":          4388674661218757,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		},
+		"ssh_rules": [{
+			"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+			"sshUsers":   {"root": "root"},
+			"action": {
+				"holdAndDelegate": "https://unused/machine/ssh/action/$SRC_NODE_ID/to/$DST_NODE_ID?local_user=$LOCAL_USER"
+			}
+		}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7177155754033765,
+				"StableID":   "n6mByFiY3y11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       7177155754033765,
+				"Key":        "nodekey:ea05e22aad7d12ca56e4c34f1078d44308e4199a52c1c3aaba8e63a1f0f0f239",
+				"DiscoKey":   "discokey:77c9346d6a199d7c1ead5e5bc2b3d5ec92cc860fbf5aa92594fec79e4d489708",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42457",
+					"10.65.0.27:42457",
+					"172.17.0.1:42457",
+					"172.19.0.1:42457",
+					"172.20.0.1:42457"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:36:43.025686311Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ea05e22aad7d12ca56e4c34f1078d44308e4199a52c1c3aaba8e63a1f0f0f239",
+			"MachineKey": "mkey:fe2c202885b5592b8bb4f4f6a573967612062e4db3e9143b321be5e23dfe3c72",
+			"Peers": [{
+				"ID":         3168131240925008,
+				"StableID":   "nX6H1GSrjR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c886f1599393bfd6442fc5cd5676fc43a7a4ffb41ca8a85caa7f26b3a08055",
+				"DiscoKey":   "discokey:0eb3a1c280df196d700bb107a6721d2223c5b3991ad4bf94988024e951eecc1e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58730",
+					"10.65.0.27:58730",
+					"172.17.0.1:58730",
+					"172.19.0.1:58730",
+					"172.20.0.1:58730"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:36:40.37788928Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6245672826688978,
+				"StableID":   "nF1nPbEgmq11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a57c23204adb8aa23ed526c6ba90ae0997cd587bb7eddd7873be6fc39a140d1f",
+				"DiscoKey":   "discokey:b43c70046a13eaceea25456c33ac35fd31108f81eb652db612e306ce9d91db5d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43912",
+					"10.65.0.27:43912",
+					"172.17.0.1:43912",
+					"172.19.0.1:43912",
+					"172.20.0.1:43912"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:36:40.86868446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3983758180432024,
+				"StableID":   "nfgcfBaF7Y11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:506bf2a42965905de3fd322f0688ef00e428fba6ae84ebf09257c4e394fccf6f",
+				"DiscoKey":   "discokey:12017fb6117fe12c02bbab3bad9e428585fe81fc210e6fa8fb45624fceaaa04f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35907",
+					"10.65.0.27:35907",
+					"172.17.0.1:35907",
+					"172.19.0.1:35907",
+					"172.20.0.1:35907"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:36:41.398072621Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2791095926211361,
+				"StableID":   "nJqjLiM6oN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6729631809256061f766a87280f0b1f460bba3b8f0e97acec4ad87b04234a68",
+				"DiscoKey":   "discokey:4db96d9f99c69c4b67da309c42fd815cd2e4cae025e59358ade6321a71944601",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:41108",
+					"10.65.0.27:41108",
+					"172.17.0.1:41108",
+					"172.19.0.1:41108",
+					"172.20.0.1:41108"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:36:41.931695818Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1110201268129711,
+				"StableID":   "nCdpM57pf911CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aedbcb2d15fef85942bfccf58890590a82aacf4aee57b75681c4a529d6aa5633",
+				"DiscoKey":   "discokey:bf38a17b29854a48515c05ba77a914f8159771b2aec33b2536b353a0c00f5170",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60740",
+					"10.65.0.27:60740",
+					"172.17.0.1:60740",
+					"172.19.0.1:60740",
+					"172.20.0.1:60740"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:36:42.478410842Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6219602308049180,
+				"StableID":   "n5dDwYQsZq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aefa52e419d267ef6b41522c3837b21964e004dc33cb63cba387eeb663bd3a43",
+				"DiscoKey":   "discokey:5c849ebeeab05b5673d956ec5d2be343b753849f2f73821369cf2dfc6402fa66",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43640",
+					"10.65.0.27:43640",
+					"172.17.0.1:43640",
+					"172.19.0.1:43640",
+					"172.20.0.1:43640"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:36:43.546884161Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5619277868006469,
+				"StableID":   "nLLCtFuysk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c2bc6893b12c60a8b4117112c48e1d0d5cd152a44fbb93bc56cdcb67361ab369",
+				"DiscoKey":   "discokey:71453ce0487ae899966e7600480dcfd921c6062aa0cdb99329acc4445a21013f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37603",
+					"10.65.0.27:37603",
+					"172.17.0.1:37603",
+					"172.19.0.1:37603",
+					"172.20.0.1:37603"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:36:44.102860155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1949930473611386,
+				"StableID":   "nF9LjHN8EG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0520a05867071797620eac590ce4721758498e15f7a5544adced085dc694c1f",
+				"DiscoKey":   "discokey:bbc4595df07fc1cd97ea97fc2139aa31d71e0517edb4b2ce22d8cb19d6be220c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45998",
+					"10.65.0.27:45998",
+					"172.17.0.1:45998",
+					"172.19.0.1:45998",
+					"172.20.0.1:45998"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:36:44.641057149Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3922831435313901,
+				"StableID":   "nQzLqX8fdX11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba7ec5111e527ac491757f4711444d81ce4324c47ab1fb152e741cf70649e662",
+				"DiscoKey":   "discokey:bfbe8d5fee913745b5adb2029691c33c8e7c893b59f07ac6b025dec9b2aaa904",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33462",
+					"10.65.0.27:33462",
+					"172.17.0.1:33462",
+					"172.19.0.1:33462",
+					"172.20.0.1:33462"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:36:45.183706915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3188966479592688,
+				"StableID":   "nZBYh2kHuR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:598fb6b7d6644fa86fa4f87f4233a8d7acf65193e8e6fa83ab4f63c1d28f8325",
+				"DiscoKey":   "discokey:2684699793fae45a134263e88c970c4fe7a21a04e14eb597ffd580e3681f4166",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38560",
+					"10.65.0.27:38560",
+					"172.17.0.1:38560",
+					"172.19.0.1:38560",
+					"172.20.0.1:38560"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:36:45.722400629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4388674661218757,
+				"StableID":   "ngE6WQ3eGb11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4f91d56dd1ea841cbe7ffab1472ff82ece2bace77f4a3f009caab96e7697f06",
+				"DiscoKey":   "discokey:30aa89a55718cecce47efd15ade388e441c99b5e331bcf624cecf6e0d0c33760",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52079",
+					"10.65.0.27:52079",
+					"172.17.0.1:52079",
+					"172.19.0.1:52079",
+					"172.20.0.1:52079"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:36:47.098952687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8001103941033343,
+				"StableID":   "nkyzm7SiU521CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:83b4ecf2b957218ecac739aa9b2092c8a95bc0c7e3b4326994f34b42bc0d8924",
+				"KeyExpiry":  "2026-11-08T18:36:47Z",
+				"DiscoKey":   "discokey:74d75c9bbc4beb1e985ae5c44643b5e270507e6d9ff4f827a16d932bc22a1004",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40677",
+					"10.65.0.27:40677",
+					"172.17.0.1:40677",
+					"172.19.0.1:40677",
+					"172.20.0.1:40677"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:36:47.637656119Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         922686301093192,
+				"StableID":   "nm1YqTQtC811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5fa74c00673f32839e190fe41a8a0335020af612f9536858c0d5b52f4efa9b1d",
+				"KeyExpiry":  "2026-11-08T18:36:48Z",
+				"DiscoKey":   "discokey:0a28137ce9a22ed8cced08245ddcbabbc27b6fdd0a4d8de898700d970e18c33c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38847",
+					"10.65.0.27:38847",
+					"172.17.0.1:38847",
+					"172.19.0.1:38847",
+					"172.20.0.1:38847"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:36:48.158330475Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3336477534055655,
+				"StableID":   "nW4LTDc64T11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e8a9782344aed454b2a7ed9c81a181016b8ed378c27070eb5ee653568aa22550",
+				"KeyExpiry":  "2026-11-08T18:36:48Z",
+				"DiscoKey":   "discokey:9ef60a59270caa12a3a7f1da9b29db3a6fe1d5295994ff7249bd586c30c23f21",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:48138",
+					"10.65.0.27:48138",
+					"172.17.0.1:48138",
+					"172.19.0.1:48138",
+					"172.20.0.1:48138"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:36:48.702894407Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7177155754033765": {
+				"ID":          7177155754033765,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3336477534055655,
+				"StableID":   "nW4LTDc64T11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e8a9782344aed454b2a7ed9c81a181016b8ed378c27070eb5ee653568aa22550",
+				"KeyExpiry":  "2026-11-08T18:36:48Z",
+				"DiscoKey":   "discokey:9ef60a59270caa12a3a7f1da9b29db3a6fe1d5295994ff7249bd586c30c23f21",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:48138",
+					"10.65.0.27:48138",
+					"172.17.0.1:48138",
+					"172.19.0.1:48138",
+					"172.20.0.1:48138"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:36:48.702894407Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e8a9782344aed454b2a7ed9c81a181016b8ed378c27070eb5ee653568aa22550",
+			"MachineKey": "mkey:287f012741951287ab5305a76ebe788ad27a570362f804e29f8c0a000b4e9352",
+			"Peers": [{
+				"ID":         3168131240925008,
+				"StableID":   "nX6H1GSrjR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c886f1599393bfd6442fc5cd5676fc43a7a4ffb41ca8a85caa7f26b3a08055",
+				"DiscoKey":   "discokey:0eb3a1c280df196d700bb107a6721d2223c5b3991ad4bf94988024e951eecc1e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58730",
+					"10.65.0.27:58730",
+					"172.17.0.1:58730",
+					"172.19.0.1:58730",
+					"172.20.0.1:58730"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:36:40.37788928Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6245672826688978,
+				"StableID":   "nF1nPbEgmq11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a57c23204adb8aa23ed526c6ba90ae0997cd587bb7eddd7873be6fc39a140d1f",
+				"DiscoKey":   "discokey:b43c70046a13eaceea25456c33ac35fd31108f81eb652db612e306ce9d91db5d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43912",
+					"10.65.0.27:43912",
+					"172.17.0.1:43912",
+					"172.19.0.1:43912",
+					"172.20.0.1:43912"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:36:40.86868446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3983758180432024,
+				"StableID":   "nfgcfBaF7Y11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:506bf2a42965905de3fd322f0688ef00e428fba6ae84ebf09257c4e394fccf6f",
+				"DiscoKey":   "discokey:12017fb6117fe12c02bbab3bad9e428585fe81fc210e6fa8fb45624fceaaa04f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35907",
+					"10.65.0.27:35907",
+					"172.17.0.1:35907",
+					"172.19.0.1:35907",
+					"172.20.0.1:35907"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:36:41.398072621Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2791095926211361,
+				"StableID":   "nJqjLiM6oN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6729631809256061f766a87280f0b1f460bba3b8f0e97acec4ad87b04234a68",
+				"DiscoKey":   "discokey:4db96d9f99c69c4b67da309c42fd815cd2e4cae025e59358ade6321a71944601",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:41108",
+					"10.65.0.27:41108",
+					"172.17.0.1:41108",
+					"172.19.0.1:41108",
+					"172.20.0.1:41108"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:36:41.931695818Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1110201268129711,
+				"StableID":   "nCdpM57pf911CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aedbcb2d15fef85942bfccf58890590a82aacf4aee57b75681c4a529d6aa5633",
+				"DiscoKey":   "discokey:bf38a17b29854a48515c05ba77a914f8159771b2aec33b2536b353a0c00f5170",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60740",
+					"10.65.0.27:60740",
+					"172.17.0.1:60740",
+					"172.19.0.1:60740",
+					"172.20.0.1:60740"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:36:42.478410842Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7177155754033765,
+				"StableID":   "n6mByFiY3y11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea05e22aad7d12ca56e4c34f1078d44308e4199a52c1c3aaba8e63a1f0f0f239",
+				"DiscoKey":   "discokey:77c9346d6a199d7c1ead5e5bc2b3d5ec92cc860fbf5aa92594fec79e4d489708",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42457",
+					"10.65.0.27:42457",
+					"172.17.0.1:42457",
+					"172.19.0.1:42457",
+					"172.20.0.1:42457"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:36:43.025686311Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6219602308049180,
+				"StableID":   "n5dDwYQsZq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aefa52e419d267ef6b41522c3837b21964e004dc33cb63cba387eeb663bd3a43",
+				"DiscoKey":   "discokey:5c849ebeeab05b5673d956ec5d2be343b753849f2f73821369cf2dfc6402fa66",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43640",
+					"10.65.0.27:43640",
+					"172.17.0.1:43640",
+					"172.19.0.1:43640",
+					"172.20.0.1:43640"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:36:43.546884161Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5619277868006469,
+				"StableID":   "nLLCtFuysk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c2bc6893b12c60a8b4117112c48e1d0d5cd152a44fbb93bc56cdcb67361ab369",
+				"DiscoKey":   "discokey:71453ce0487ae899966e7600480dcfd921c6062aa0cdb99329acc4445a21013f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37603",
+					"10.65.0.27:37603",
+					"172.17.0.1:37603",
+					"172.19.0.1:37603",
+					"172.20.0.1:37603"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:36:44.102860155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1949930473611386,
+				"StableID":   "nF9LjHN8EG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0520a05867071797620eac590ce4721758498e15f7a5544adced085dc694c1f",
+				"DiscoKey":   "discokey:bbc4595df07fc1cd97ea97fc2139aa31d71e0517edb4b2ce22d8cb19d6be220c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45998",
+					"10.65.0.27:45998",
+					"172.17.0.1:45998",
+					"172.19.0.1:45998",
+					"172.20.0.1:45998"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:36:44.641057149Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3922831435313901,
+				"StableID":   "nQzLqX8fdX11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba7ec5111e527ac491757f4711444d81ce4324c47ab1fb152e741cf70649e662",
+				"DiscoKey":   "discokey:bfbe8d5fee913745b5adb2029691c33c8e7c893b59f07ac6b025dec9b2aaa904",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33462",
+					"10.65.0.27:33462",
+					"172.17.0.1:33462",
+					"172.19.0.1:33462",
+					"172.20.0.1:33462"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:36:45.183706915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3188966479592688,
+				"StableID":   "nZBYh2kHuR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:598fb6b7d6644fa86fa4f87f4233a8d7acf65193e8e6fa83ab4f63c1d28f8325",
+				"DiscoKey":   "discokey:2684699793fae45a134263e88c970c4fe7a21a04e14eb597ffd580e3681f4166",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38560",
+					"10.65.0.27:38560",
+					"172.17.0.1:38560",
+					"172.19.0.1:38560",
+					"172.20.0.1:38560"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:36:45.722400629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4388674661218757,
+				"StableID":   "ngE6WQ3eGb11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4f91d56dd1ea841cbe7ffab1472ff82ece2bace77f4a3f009caab96e7697f06",
+				"DiscoKey":   "discokey:30aa89a55718cecce47efd15ade388e441c99b5e331bcf624cecf6e0d0c33760",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52079",
+					"10.65.0.27:52079",
+					"172.17.0.1:52079",
+					"172.19.0.1:52079",
+					"172.20.0.1:52079"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:36:47.098952687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8001103941033343,
+				"StableID":   "nkyzm7SiU521CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:83b4ecf2b957218ecac739aa9b2092c8a95bc0c7e3b4326994f34b42bc0d8924",
+				"KeyExpiry":  "2026-11-08T18:36:47Z",
+				"DiscoKey":   "discokey:74d75c9bbc4beb1e985ae5c44643b5e270507e6d9ff4f827a16d932bc22a1004",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40677",
+					"10.65.0.27:40677",
+					"172.17.0.1:40677",
+					"172.19.0.1:40677",
+					"172.20.0.1:40677"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:36:47.637656119Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         922686301093192,
+				"StableID":   "nm1YqTQtC811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5fa74c00673f32839e190fe41a8a0335020af612f9536858c0d5b52f4efa9b1d",
+				"KeyExpiry":  "2026-11-08T18:36:48Z",
+				"DiscoKey":   "discokey:0a28137ce9a22ed8cced08245ddcbabbc27b6fdd0a4d8de898700d970e18c33c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38847",
+					"10.65.0.27:38847",
+					"172.17.0.1:38847",
+					"172.19.0.1:38847",
+					"172.20.0.1:38847"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:36:48.158330475Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3983758180432024,
+				"StableID":   "nfgcfBaF7Y11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       3983758180432024,
+				"Key":        "nodekey:506bf2a42965905de3fd322f0688ef00e428fba6ae84ebf09257c4e394fccf6f",
+				"DiscoKey":   "discokey:12017fb6117fe12c02bbab3bad9e428585fe81fc210e6fa8fb45624fceaaa04f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35907",
+					"10.65.0.27:35907",
+					"172.17.0.1:35907",
+					"172.19.0.1:35907",
+					"172.20.0.1:35907"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:36:41.398072621Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:506bf2a42965905de3fd322f0688ef00e428fba6ae84ebf09257c4e394fccf6f",
+			"MachineKey": "mkey:af50f73f5d16dbc6e12ed56931f5f35c95569b583b65f59c082f65ca2de77572",
+			"Peers": [{
+				"ID":         3168131240925008,
+				"StableID":   "nX6H1GSrjR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c886f1599393bfd6442fc5cd5676fc43a7a4ffb41ca8a85caa7f26b3a08055",
+				"DiscoKey":   "discokey:0eb3a1c280df196d700bb107a6721d2223c5b3991ad4bf94988024e951eecc1e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58730",
+					"10.65.0.27:58730",
+					"172.17.0.1:58730",
+					"172.19.0.1:58730",
+					"172.20.0.1:58730"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:36:40.37788928Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6245672826688978,
+				"StableID":   "nF1nPbEgmq11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a57c23204adb8aa23ed526c6ba90ae0997cd587bb7eddd7873be6fc39a140d1f",
+				"DiscoKey":   "discokey:b43c70046a13eaceea25456c33ac35fd31108f81eb652db612e306ce9d91db5d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43912",
+					"10.65.0.27:43912",
+					"172.17.0.1:43912",
+					"172.19.0.1:43912",
+					"172.20.0.1:43912"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:36:40.86868446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2791095926211361,
+				"StableID":   "nJqjLiM6oN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6729631809256061f766a87280f0b1f460bba3b8f0e97acec4ad87b04234a68",
+				"DiscoKey":   "discokey:4db96d9f99c69c4b67da309c42fd815cd2e4cae025e59358ade6321a71944601",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:41108",
+					"10.65.0.27:41108",
+					"172.17.0.1:41108",
+					"172.19.0.1:41108",
+					"172.20.0.1:41108"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:36:41.931695818Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1110201268129711,
+				"StableID":   "nCdpM57pf911CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aedbcb2d15fef85942bfccf58890590a82aacf4aee57b75681c4a529d6aa5633",
+				"DiscoKey":   "discokey:bf38a17b29854a48515c05ba77a914f8159771b2aec33b2536b353a0c00f5170",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60740",
+					"10.65.0.27:60740",
+					"172.17.0.1:60740",
+					"172.19.0.1:60740",
+					"172.20.0.1:60740"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:36:42.478410842Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7177155754033765,
+				"StableID":   "n6mByFiY3y11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea05e22aad7d12ca56e4c34f1078d44308e4199a52c1c3aaba8e63a1f0f0f239",
+				"DiscoKey":   "discokey:77c9346d6a199d7c1ead5e5bc2b3d5ec92cc860fbf5aa92594fec79e4d489708",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42457",
+					"10.65.0.27:42457",
+					"172.17.0.1:42457",
+					"172.19.0.1:42457",
+					"172.20.0.1:42457"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:36:43.025686311Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6219602308049180,
+				"StableID":   "n5dDwYQsZq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aefa52e419d267ef6b41522c3837b21964e004dc33cb63cba387eeb663bd3a43",
+				"DiscoKey":   "discokey:5c849ebeeab05b5673d956ec5d2be343b753849f2f73821369cf2dfc6402fa66",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43640",
+					"10.65.0.27:43640",
+					"172.17.0.1:43640",
+					"172.19.0.1:43640",
+					"172.20.0.1:43640"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:36:43.546884161Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5619277868006469,
+				"StableID":   "nLLCtFuysk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c2bc6893b12c60a8b4117112c48e1d0d5cd152a44fbb93bc56cdcb67361ab369",
+				"DiscoKey":   "discokey:71453ce0487ae899966e7600480dcfd921c6062aa0cdb99329acc4445a21013f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37603",
+					"10.65.0.27:37603",
+					"172.17.0.1:37603",
+					"172.19.0.1:37603",
+					"172.20.0.1:37603"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:36:44.102860155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1949930473611386,
+				"StableID":   "nF9LjHN8EG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0520a05867071797620eac590ce4721758498e15f7a5544adced085dc694c1f",
+				"DiscoKey":   "discokey:bbc4595df07fc1cd97ea97fc2139aa31d71e0517edb4b2ce22d8cb19d6be220c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45998",
+					"10.65.0.27:45998",
+					"172.17.0.1:45998",
+					"172.19.0.1:45998",
+					"172.20.0.1:45998"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:36:44.641057149Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3922831435313901,
+				"StableID":   "nQzLqX8fdX11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba7ec5111e527ac491757f4711444d81ce4324c47ab1fb152e741cf70649e662",
+				"DiscoKey":   "discokey:bfbe8d5fee913745b5adb2029691c33c8e7c893b59f07ac6b025dec9b2aaa904",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33462",
+					"10.65.0.27:33462",
+					"172.17.0.1:33462",
+					"172.19.0.1:33462",
+					"172.20.0.1:33462"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:36:45.183706915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3188966479592688,
+				"StableID":   "nZBYh2kHuR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:598fb6b7d6644fa86fa4f87f4233a8d7acf65193e8e6fa83ab4f63c1d28f8325",
+				"DiscoKey":   "discokey:2684699793fae45a134263e88c970c4fe7a21a04e14eb597ffd580e3681f4166",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38560",
+					"10.65.0.27:38560",
+					"172.17.0.1:38560",
+					"172.19.0.1:38560",
+					"172.20.0.1:38560"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:36:45.722400629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4388674661218757,
+				"StableID":   "ngE6WQ3eGb11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4f91d56dd1ea841cbe7ffab1472ff82ece2bace77f4a3f009caab96e7697f06",
+				"DiscoKey":   "discokey:30aa89a55718cecce47efd15ade388e441c99b5e331bcf624cecf6e0d0c33760",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52079",
+					"10.65.0.27:52079",
+					"172.17.0.1:52079",
+					"172.19.0.1:52079",
+					"172.20.0.1:52079"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:36:47.098952687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8001103941033343,
+				"StableID":   "nkyzm7SiU521CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:83b4ecf2b957218ecac739aa9b2092c8a95bc0c7e3b4326994f34b42bc0d8924",
+				"KeyExpiry":  "2026-11-08T18:36:47Z",
+				"DiscoKey":   "discokey:74d75c9bbc4beb1e985ae5c44643b5e270507e6d9ff4f827a16d932bc22a1004",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40677",
+					"10.65.0.27:40677",
+					"172.17.0.1:40677",
+					"172.19.0.1:40677",
+					"172.20.0.1:40677"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:36:47.637656119Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         922686301093192,
+				"StableID":   "nm1YqTQtC811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5fa74c00673f32839e190fe41a8a0335020af612f9536858c0d5b52f4efa9b1d",
+				"KeyExpiry":  "2026-11-08T18:36:48Z",
+				"DiscoKey":   "discokey:0a28137ce9a22ed8cced08245ddcbabbc27b6fdd0a4d8de898700d970e18c33c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38847",
+					"10.65.0.27:38847",
+					"172.17.0.1:38847",
+					"172.19.0.1:38847",
+					"172.20.0.1:38847"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:36:48.158330475Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3336477534055655,
+				"StableID":   "nW4LTDc64T11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e8a9782344aed454b2a7ed9c81a181016b8ed378c27070eb5ee653568aa22550",
+				"KeyExpiry":  "2026-11-08T18:36:48Z",
+				"DiscoKey":   "discokey:9ef60a59270caa12a3a7f1da9b29db3a6fe1d5295994ff7249bd586c30c23f21",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:48138",
+					"10.65.0.27:48138",
+					"172.17.0.1:48138",
+					"172.19.0.1:48138",
+					"172.20.0.1:48138"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:36:48.702894407Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "3983758180432024": {
+				"ID":          3983758180432024,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5619277868006469,
+				"StableID":   "nLLCtFuysk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       5619277868006469,
+				"Key":        "nodekey:c2bc6893b12c60a8b4117112c48e1d0d5cd152a44fbb93bc56cdcb67361ab369",
+				"DiscoKey":   "discokey:71453ce0487ae899966e7600480dcfd921c6062aa0cdb99329acc4445a21013f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37603",
+					"10.65.0.27:37603",
+					"172.17.0.1:37603",
+					"172.19.0.1:37603",
+					"172.20.0.1:37603"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:36:44.102860155Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c2bc6893b12c60a8b4117112c48e1d0d5cd152a44fbb93bc56cdcb67361ab369",
+			"MachineKey": "mkey:5bd47c1f3aa2da627a5f53b14c724102f2a4f472e31e4003808774d7b41c7f1f",
+			"Peers": [{
+				"ID":         3168131240925008,
+				"StableID":   "nX6H1GSrjR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c886f1599393bfd6442fc5cd5676fc43a7a4ffb41ca8a85caa7f26b3a08055",
+				"DiscoKey":   "discokey:0eb3a1c280df196d700bb107a6721d2223c5b3991ad4bf94988024e951eecc1e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58730",
+					"10.65.0.27:58730",
+					"172.17.0.1:58730",
+					"172.19.0.1:58730",
+					"172.20.0.1:58730"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:36:40.37788928Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6245672826688978,
+				"StableID":   "nF1nPbEgmq11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a57c23204adb8aa23ed526c6ba90ae0997cd587bb7eddd7873be6fc39a140d1f",
+				"DiscoKey":   "discokey:b43c70046a13eaceea25456c33ac35fd31108f81eb652db612e306ce9d91db5d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43912",
+					"10.65.0.27:43912",
+					"172.17.0.1:43912",
+					"172.19.0.1:43912",
+					"172.20.0.1:43912"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:36:40.86868446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3983758180432024,
+				"StableID":   "nfgcfBaF7Y11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:506bf2a42965905de3fd322f0688ef00e428fba6ae84ebf09257c4e394fccf6f",
+				"DiscoKey":   "discokey:12017fb6117fe12c02bbab3bad9e428585fe81fc210e6fa8fb45624fceaaa04f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35907",
+					"10.65.0.27:35907",
+					"172.17.0.1:35907",
+					"172.19.0.1:35907",
+					"172.20.0.1:35907"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:36:41.398072621Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2791095926211361,
+				"StableID":   "nJqjLiM6oN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6729631809256061f766a87280f0b1f460bba3b8f0e97acec4ad87b04234a68",
+				"DiscoKey":   "discokey:4db96d9f99c69c4b67da309c42fd815cd2e4cae025e59358ade6321a71944601",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:41108",
+					"10.65.0.27:41108",
+					"172.17.0.1:41108",
+					"172.19.0.1:41108",
+					"172.20.0.1:41108"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:36:41.931695818Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1110201268129711,
+				"StableID":   "nCdpM57pf911CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aedbcb2d15fef85942bfccf58890590a82aacf4aee57b75681c4a529d6aa5633",
+				"DiscoKey":   "discokey:bf38a17b29854a48515c05ba77a914f8159771b2aec33b2536b353a0c00f5170",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60740",
+					"10.65.0.27:60740",
+					"172.17.0.1:60740",
+					"172.19.0.1:60740",
+					"172.20.0.1:60740"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:36:42.478410842Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7177155754033765,
+				"StableID":   "n6mByFiY3y11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea05e22aad7d12ca56e4c34f1078d44308e4199a52c1c3aaba8e63a1f0f0f239",
+				"DiscoKey":   "discokey:77c9346d6a199d7c1ead5e5bc2b3d5ec92cc860fbf5aa92594fec79e4d489708",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42457",
+					"10.65.0.27:42457",
+					"172.17.0.1:42457",
+					"172.19.0.1:42457",
+					"172.20.0.1:42457"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:36:43.025686311Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6219602308049180,
+				"StableID":   "n5dDwYQsZq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aefa52e419d267ef6b41522c3837b21964e004dc33cb63cba387eeb663bd3a43",
+				"DiscoKey":   "discokey:5c849ebeeab05b5673d956ec5d2be343b753849f2f73821369cf2dfc6402fa66",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43640",
+					"10.65.0.27:43640",
+					"172.17.0.1:43640",
+					"172.19.0.1:43640",
+					"172.20.0.1:43640"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:36:43.546884161Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1949930473611386,
+				"StableID":   "nF9LjHN8EG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0520a05867071797620eac590ce4721758498e15f7a5544adced085dc694c1f",
+				"DiscoKey":   "discokey:bbc4595df07fc1cd97ea97fc2139aa31d71e0517edb4b2ce22d8cb19d6be220c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45998",
+					"10.65.0.27:45998",
+					"172.17.0.1:45998",
+					"172.19.0.1:45998",
+					"172.20.0.1:45998"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:36:44.641057149Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3922831435313901,
+				"StableID":   "nQzLqX8fdX11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba7ec5111e527ac491757f4711444d81ce4324c47ab1fb152e741cf70649e662",
+				"DiscoKey":   "discokey:bfbe8d5fee913745b5adb2029691c33c8e7c893b59f07ac6b025dec9b2aaa904",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33462",
+					"10.65.0.27:33462",
+					"172.17.0.1:33462",
+					"172.19.0.1:33462",
+					"172.20.0.1:33462"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:36:45.183706915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3188966479592688,
+				"StableID":   "nZBYh2kHuR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:598fb6b7d6644fa86fa4f87f4233a8d7acf65193e8e6fa83ab4f63c1d28f8325",
+				"DiscoKey":   "discokey:2684699793fae45a134263e88c970c4fe7a21a04e14eb597ffd580e3681f4166",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38560",
+					"10.65.0.27:38560",
+					"172.17.0.1:38560",
+					"172.19.0.1:38560",
+					"172.20.0.1:38560"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:36:45.722400629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4388674661218757,
+				"StableID":   "ngE6WQ3eGb11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4f91d56dd1ea841cbe7ffab1472ff82ece2bace77f4a3f009caab96e7697f06",
+				"DiscoKey":   "discokey:30aa89a55718cecce47efd15ade388e441c99b5e331bcf624cecf6e0d0c33760",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52079",
+					"10.65.0.27:52079",
+					"172.17.0.1:52079",
+					"172.19.0.1:52079",
+					"172.20.0.1:52079"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:36:47.098952687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8001103941033343,
+				"StableID":   "nkyzm7SiU521CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:83b4ecf2b957218ecac739aa9b2092c8a95bc0c7e3b4326994f34b42bc0d8924",
+				"KeyExpiry":  "2026-11-08T18:36:47Z",
+				"DiscoKey":   "discokey:74d75c9bbc4beb1e985ae5c44643b5e270507e6d9ff4f827a16d932bc22a1004",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40677",
+					"10.65.0.27:40677",
+					"172.17.0.1:40677",
+					"172.19.0.1:40677",
+					"172.20.0.1:40677"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:36:47.637656119Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         922686301093192,
+				"StableID":   "nm1YqTQtC811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5fa74c00673f32839e190fe41a8a0335020af612f9536858c0d5b52f4efa9b1d",
+				"KeyExpiry":  "2026-11-08T18:36:48Z",
+				"DiscoKey":   "discokey:0a28137ce9a22ed8cced08245ddcbabbc27b6fdd0a4d8de898700d970e18c33c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38847",
+					"10.65.0.27:38847",
+					"172.17.0.1:38847",
+					"172.19.0.1:38847",
+					"172.20.0.1:38847"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:36:48.158330475Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3336477534055655,
+				"StableID":   "nW4LTDc64T11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e8a9782344aed454b2a7ed9c81a181016b8ed378c27070eb5ee653568aa22550",
+				"KeyExpiry":  "2026-11-08T18:36:48Z",
+				"DiscoKey":   "discokey:9ef60a59270caa12a3a7f1da9b29db3a6fe1d5295994ff7249bd586c30c23f21",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:48138",
+					"10.65.0.27:48138",
+					"172.17.0.1:48138",
+					"172.19.0.1:48138",
+					"172.20.0.1:48138"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:36:48.702894407Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5619277868006469": {
+				"ID":          5619277868006469,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8001103941033343,
+				"StableID":   "nkyzm7SiU521CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:83b4ecf2b957218ecac739aa9b2092c8a95bc0c7e3b4326994f34b42bc0d8924",
+				"KeyExpiry":  "2026-11-08T18:36:47Z",
+				"DiscoKey":   "discokey:74d75c9bbc4beb1e985ae5c44643b5e270507e6d9ff4f827a16d932bc22a1004",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40677",
+					"10.65.0.27:40677",
+					"172.17.0.1:40677",
+					"172.19.0.1:40677",
+					"172.20.0.1:40677"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:36:47.637656119Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:83b4ecf2b957218ecac739aa9b2092c8a95bc0c7e3b4326994f34b42bc0d8924",
+			"MachineKey": "mkey:ad9ee2a4f519ef332a61a8a9080db10fde035e6899af81996280282a288b7552",
+			"Peers": [{
+				"ID":         3168131240925008,
+				"StableID":   "nX6H1GSrjR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c886f1599393bfd6442fc5cd5676fc43a7a4ffb41ca8a85caa7f26b3a08055",
+				"DiscoKey":   "discokey:0eb3a1c280df196d700bb107a6721d2223c5b3991ad4bf94988024e951eecc1e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58730",
+					"10.65.0.27:58730",
+					"172.17.0.1:58730",
+					"172.19.0.1:58730",
+					"172.20.0.1:58730"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:36:40.37788928Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6245672826688978,
+				"StableID":   "nF1nPbEgmq11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a57c23204adb8aa23ed526c6ba90ae0997cd587bb7eddd7873be6fc39a140d1f",
+				"DiscoKey":   "discokey:b43c70046a13eaceea25456c33ac35fd31108f81eb652db612e306ce9d91db5d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43912",
+					"10.65.0.27:43912",
+					"172.17.0.1:43912",
+					"172.19.0.1:43912",
+					"172.20.0.1:43912"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:36:40.86868446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3983758180432024,
+				"StableID":   "nfgcfBaF7Y11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:506bf2a42965905de3fd322f0688ef00e428fba6ae84ebf09257c4e394fccf6f",
+				"DiscoKey":   "discokey:12017fb6117fe12c02bbab3bad9e428585fe81fc210e6fa8fb45624fceaaa04f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35907",
+					"10.65.0.27:35907",
+					"172.17.0.1:35907",
+					"172.19.0.1:35907",
+					"172.20.0.1:35907"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:36:41.398072621Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2791095926211361,
+				"StableID":   "nJqjLiM6oN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6729631809256061f766a87280f0b1f460bba3b8f0e97acec4ad87b04234a68",
+				"DiscoKey":   "discokey:4db96d9f99c69c4b67da309c42fd815cd2e4cae025e59358ade6321a71944601",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:41108",
+					"10.65.0.27:41108",
+					"172.17.0.1:41108",
+					"172.19.0.1:41108",
+					"172.20.0.1:41108"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:36:41.931695818Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1110201268129711,
+				"StableID":   "nCdpM57pf911CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aedbcb2d15fef85942bfccf58890590a82aacf4aee57b75681c4a529d6aa5633",
+				"DiscoKey":   "discokey:bf38a17b29854a48515c05ba77a914f8159771b2aec33b2536b353a0c00f5170",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60740",
+					"10.65.0.27:60740",
+					"172.17.0.1:60740",
+					"172.19.0.1:60740",
+					"172.20.0.1:60740"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:36:42.478410842Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7177155754033765,
+				"StableID":   "n6mByFiY3y11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea05e22aad7d12ca56e4c34f1078d44308e4199a52c1c3aaba8e63a1f0f0f239",
+				"DiscoKey":   "discokey:77c9346d6a199d7c1ead5e5bc2b3d5ec92cc860fbf5aa92594fec79e4d489708",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42457",
+					"10.65.0.27:42457",
+					"172.17.0.1:42457",
+					"172.19.0.1:42457",
+					"172.20.0.1:42457"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:36:43.025686311Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6219602308049180,
+				"StableID":   "n5dDwYQsZq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aefa52e419d267ef6b41522c3837b21964e004dc33cb63cba387eeb663bd3a43",
+				"DiscoKey":   "discokey:5c849ebeeab05b5673d956ec5d2be343b753849f2f73821369cf2dfc6402fa66",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43640",
+					"10.65.0.27:43640",
+					"172.17.0.1:43640",
+					"172.19.0.1:43640",
+					"172.20.0.1:43640"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:36:43.546884161Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5619277868006469,
+				"StableID":   "nLLCtFuysk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c2bc6893b12c60a8b4117112c48e1d0d5cd152a44fbb93bc56cdcb67361ab369",
+				"DiscoKey":   "discokey:71453ce0487ae899966e7600480dcfd921c6062aa0cdb99329acc4445a21013f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37603",
+					"10.65.0.27:37603",
+					"172.17.0.1:37603",
+					"172.19.0.1:37603",
+					"172.20.0.1:37603"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:36:44.102860155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1949930473611386,
+				"StableID":   "nF9LjHN8EG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0520a05867071797620eac590ce4721758498e15f7a5544adced085dc694c1f",
+				"DiscoKey":   "discokey:bbc4595df07fc1cd97ea97fc2139aa31d71e0517edb4b2ce22d8cb19d6be220c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45998",
+					"10.65.0.27:45998",
+					"172.17.0.1:45998",
+					"172.19.0.1:45998",
+					"172.20.0.1:45998"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:36:44.641057149Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3922831435313901,
+				"StableID":   "nQzLqX8fdX11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba7ec5111e527ac491757f4711444d81ce4324c47ab1fb152e741cf70649e662",
+				"DiscoKey":   "discokey:bfbe8d5fee913745b5adb2029691c33c8e7c893b59f07ac6b025dec9b2aaa904",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33462",
+					"10.65.0.27:33462",
+					"172.17.0.1:33462",
+					"172.19.0.1:33462",
+					"172.20.0.1:33462"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:36:45.183706915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3188966479592688,
+				"StableID":   "nZBYh2kHuR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:598fb6b7d6644fa86fa4f87f4233a8d7acf65193e8e6fa83ab4f63c1d28f8325",
+				"DiscoKey":   "discokey:2684699793fae45a134263e88c970c4fe7a21a04e14eb597ffd580e3681f4166",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38560",
+					"10.65.0.27:38560",
+					"172.17.0.1:38560",
+					"172.19.0.1:38560",
+					"172.20.0.1:38560"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:36:45.722400629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4388674661218757,
+				"StableID":   "ngE6WQ3eGb11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4f91d56dd1ea841cbe7ffab1472ff82ece2bace77f4a3f009caab96e7697f06",
+				"DiscoKey":   "discokey:30aa89a55718cecce47efd15ade388e441c99b5e331bcf624cecf6e0d0c33760",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52079",
+					"10.65.0.27:52079",
+					"172.17.0.1:52079",
+					"172.19.0.1:52079",
+					"172.20.0.1:52079"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:36:47.098952687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         922686301093192,
+				"StableID":   "nm1YqTQtC811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5fa74c00673f32839e190fe41a8a0335020af612f9536858c0d5b52f4efa9b1d",
+				"KeyExpiry":  "2026-11-08T18:36:48Z",
+				"DiscoKey":   "discokey:0a28137ce9a22ed8cced08245ddcbabbc27b6fdd0a4d8de898700d970e18c33c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38847",
+					"10.65.0.27:38847",
+					"172.17.0.1:38847",
+					"172.19.0.1:38847",
+					"172.20.0.1:38847"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:36:48.158330475Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3336477534055655,
+				"StableID":   "nW4LTDc64T11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e8a9782344aed454b2a7ed9c81a181016b8ed378c27070eb5ee653568aa22550",
+				"KeyExpiry":  "2026-11-08T18:36:48Z",
+				"DiscoKey":   "discokey:9ef60a59270caa12a3a7f1da9b29db3a6fe1d5295994ff7249bd586c30c23f21",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:48138",
+					"10.65.0.27:48138",
+					"172.17.0.1:48138",
+					"172.19.0.1:48138",
+					"172.20.0.1:48138"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:36:48.702894407Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3188966479592688,
+				"StableID":   "nZBYh2kHuR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       3188966479592688,
+				"Key":        "nodekey:598fb6b7d6644fa86fa4f87f4233a8d7acf65193e8e6fa83ab4f63c1d28f8325",
+				"DiscoKey":   "discokey:2684699793fae45a134263e88c970c4fe7a21a04e14eb597ffd580e3681f4166",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38560",
+					"10.65.0.27:38560",
+					"172.17.0.1:38560",
+					"172.19.0.1:38560",
+					"172.20.0.1:38560"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:36:45.722400629Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:598fb6b7d6644fa86fa4f87f4233a8d7acf65193e8e6fa83ab4f63c1d28f8325",
+			"MachineKey": "mkey:7cc7beb5fe5bcb35d109d568a3b269117f72553ded0997505c61670132ceb676",
+			"Peers": [{
+				"ID":         3168131240925008,
+				"StableID":   "nX6H1GSrjR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c886f1599393bfd6442fc5cd5676fc43a7a4ffb41ca8a85caa7f26b3a08055",
+				"DiscoKey":   "discokey:0eb3a1c280df196d700bb107a6721d2223c5b3991ad4bf94988024e951eecc1e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58730",
+					"10.65.0.27:58730",
+					"172.17.0.1:58730",
+					"172.19.0.1:58730",
+					"172.20.0.1:58730"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:36:40.37788928Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6245672826688978,
+				"StableID":   "nF1nPbEgmq11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a57c23204adb8aa23ed526c6ba90ae0997cd587bb7eddd7873be6fc39a140d1f",
+				"DiscoKey":   "discokey:b43c70046a13eaceea25456c33ac35fd31108f81eb652db612e306ce9d91db5d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43912",
+					"10.65.0.27:43912",
+					"172.17.0.1:43912",
+					"172.19.0.1:43912",
+					"172.20.0.1:43912"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:36:40.86868446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3983758180432024,
+				"StableID":   "nfgcfBaF7Y11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:506bf2a42965905de3fd322f0688ef00e428fba6ae84ebf09257c4e394fccf6f",
+				"DiscoKey":   "discokey:12017fb6117fe12c02bbab3bad9e428585fe81fc210e6fa8fb45624fceaaa04f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35907",
+					"10.65.0.27:35907",
+					"172.17.0.1:35907",
+					"172.19.0.1:35907",
+					"172.20.0.1:35907"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:36:41.398072621Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2791095926211361,
+				"StableID":   "nJqjLiM6oN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6729631809256061f766a87280f0b1f460bba3b8f0e97acec4ad87b04234a68",
+				"DiscoKey":   "discokey:4db96d9f99c69c4b67da309c42fd815cd2e4cae025e59358ade6321a71944601",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:41108",
+					"10.65.0.27:41108",
+					"172.17.0.1:41108",
+					"172.19.0.1:41108",
+					"172.20.0.1:41108"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:36:41.931695818Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1110201268129711,
+				"StableID":   "nCdpM57pf911CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aedbcb2d15fef85942bfccf58890590a82aacf4aee57b75681c4a529d6aa5633",
+				"DiscoKey":   "discokey:bf38a17b29854a48515c05ba77a914f8159771b2aec33b2536b353a0c00f5170",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60740",
+					"10.65.0.27:60740",
+					"172.17.0.1:60740",
+					"172.19.0.1:60740",
+					"172.20.0.1:60740"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:36:42.478410842Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7177155754033765,
+				"StableID":   "n6mByFiY3y11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea05e22aad7d12ca56e4c34f1078d44308e4199a52c1c3aaba8e63a1f0f0f239",
+				"DiscoKey":   "discokey:77c9346d6a199d7c1ead5e5bc2b3d5ec92cc860fbf5aa92594fec79e4d489708",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42457",
+					"10.65.0.27:42457",
+					"172.17.0.1:42457",
+					"172.19.0.1:42457",
+					"172.20.0.1:42457"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:36:43.025686311Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6219602308049180,
+				"StableID":   "n5dDwYQsZq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aefa52e419d267ef6b41522c3837b21964e004dc33cb63cba387eeb663bd3a43",
+				"DiscoKey":   "discokey:5c849ebeeab05b5673d956ec5d2be343b753849f2f73821369cf2dfc6402fa66",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43640",
+					"10.65.0.27:43640",
+					"172.17.0.1:43640",
+					"172.19.0.1:43640",
+					"172.20.0.1:43640"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:36:43.546884161Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5619277868006469,
+				"StableID":   "nLLCtFuysk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c2bc6893b12c60a8b4117112c48e1d0d5cd152a44fbb93bc56cdcb67361ab369",
+				"DiscoKey":   "discokey:71453ce0487ae899966e7600480dcfd921c6062aa0cdb99329acc4445a21013f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37603",
+					"10.65.0.27:37603",
+					"172.17.0.1:37603",
+					"172.19.0.1:37603",
+					"172.20.0.1:37603"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:36:44.102860155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1949930473611386,
+				"StableID":   "nF9LjHN8EG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0520a05867071797620eac590ce4721758498e15f7a5544adced085dc694c1f",
+				"DiscoKey":   "discokey:bbc4595df07fc1cd97ea97fc2139aa31d71e0517edb4b2ce22d8cb19d6be220c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45998",
+					"10.65.0.27:45998",
+					"172.17.0.1:45998",
+					"172.19.0.1:45998",
+					"172.20.0.1:45998"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:36:44.641057149Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3922831435313901,
+				"StableID":   "nQzLqX8fdX11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba7ec5111e527ac491757f4711444d81ce4324c47ab1fb152e741cf70649e662",
+				"DiscoKey":   "discokey:bfbe8d5fee913745b5adb2029691c33c8e7c893b59f07ac6b025dec9b2aaa904",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33462",
+					"10.65.0.27:33462",
+					"172.17.0.1:33462",
+					"172.19.0.1:33462",
+					"172.20.0.1:33462"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:36:45.183706915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4388674661218757,
+				"StableID":   "ngE6WQ3eGb11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4f91d56dd1ea841cbe7ffab1472ff82ece2bace77f4a3f009caab96e7697f06",
+				"DiscoKey":   "discokey:30aa89a55718cecce47efd15ade388e441c99b5e331bcf624cecf6e0d0c33760",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52079",
+					"10.65.0.27:52079",
+					"172.17.0.1:52079",
+					"172.19.0.1:52079",
+					"172.20.0.1:52079"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:36:47.098952687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8001103941033343,
+				"StableID":   "nkyzm7SiU521CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:83b4ecf2b957218ecac739aa9b2092c8a95bc0c7e3b4326994f34b42bc0d8924",
+				"KeyExpiry":  "2026-11-08T18:36:47Z",
+				"DiscoKey":   "discokey:74d75c9bbc4beb1e985ae5c44643b5e270507e6d9ff4f827a16d932bc22a1004",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40677",
+					"10.65.0.27:40677",
+					"172.17.0.1:40677",
+					"172.19.0.1:40677",
+					"172.20.0.1:40677"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:36:47.637656119Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         922686301093192,
+				"StableID":   "nm1YqTQtC811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5fa74c00673f32839e190fe41a8a0335020af612f9536858c0d5b52f4efa9b1d",
+				"KeyExpiry":  "2026-11-08T18:36:48Z",
+				"DiscoKey":   "discokey:0a28137ce9a22ed8cced08245ddcbabbc27b6fdd0a4d8de898700d970e18c33c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38847",
+					"10.65.0.27:38847",
+					"172.17.0.1:38847",
+					"172.19.0.1:38847",
+					"172.20.0.1:38847"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:36:48.158330475Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3336477534055655,
+				"StableID":   "nW4LTDc64T11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e8a9782344aed454b2a7ed9c81a181016b8ed378c27070eb5ee653568aa22550",
+				"KeyExpiry":  "2026-11-08T18:36:48Z",
+				"DiscoKey":   "discokey:9ef60a59270caa12a3a7f1da9b29db3a6fe1d5295994ff7249bd586c30c23f21",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:48138",
+					"10.65.0.27:48138",
+					"172.17.0.1:48138",
+					"172.19.0.1:48138",
+					"172.20.0.1:48138"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:36:48.702894407Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3188966479592688": {
+				"ID":          3188966479592688,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6245672826688978,
+				"StableID":   "nF1nPbEgmq11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       6245672826688978,
+				"Key":        "nodekey:a57c23204adb8aa23ed526c6ba90ae0997cd587bb7eddd7873be6fc39a140d1f",
+				"DiscoKey":   "discokey:b43c70046a13eaceea25456c33ac35fd31108f81eb652db612e306ce9d91db5d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43912",
+					"10.65.0.27:43912",
+					"172.17.0.1:43912",
+					"172.19.0.1:43912",
+					"172.20.0.1:43912"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:36:40.86868446Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a57c23204adb8aa23ed526c6ba90ae0997cd587bb7eddd7873be6fc39a140d1f",
+			"MachineKey": "mkey:2eb39f603aeb5d646e6ebb036bed816f107e06ee2204fa2d6fd77f1af5c2bd06",
+			"Peers": [{
+				"ID":         3168131240925008,
+				"StableID":   "nX6H1GSrjR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c886f1599393bfd6442fc5cd5676fc43a7a4ffb41ca8a85caa7f26b3a08055",
+				"DiscoKey":   "discokey:0eb3a1c280df196d700bb107a6721d2223c5b3991ad4bf94988024e951eecc1e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58730",
+					"10.65.0.27:58730",
+					"172.17.0.1:58730",
+					"172.19.0.1:58730",
+					"172.20.0.1:58730"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:36:40.37788928Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3983758180432024,
+				"StableID":   "nfgcfBaF7Y11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:506bf2a42965905de3fd322f0688ef00e428fba6ae84ebf09257c4e394fccf6f",
+				"DiscoKey":   "discokey:12017fb6117fe12c02bbab3bad9e428585fe81fc210e6fa8fb45624fceaaa04f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35907",
+					"10.65.0.27:35907",
+					"172.17.0.1:35907",
+					"172.19.0.1:35907",
+					"172.20.0.1:35907"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:36:41.398072621Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2791095926211361,
+				"StableID":   "nJqjLiM6oN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6729631809256061f766a87280f0b1f460bba3b8f0e97acec4ad87b04234a68",
+				"DiscoKey":   "discokey:4db96d9f99c69c4b67da309c42fd815cd2e4cae025e59358ade6321a71944601",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:41108",
+					"10.65.0.27:41108",
+					"172.17.0.1:41108",
+					"172.19.0.1:41108",
+					"172.20.0.1:41108"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:36:41.931695818Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1110201268129711,
+				"StableID":   "nCdpM57pf911CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aedbcb2d15fef85942bfccf58890590a82aacf4aee57b75681c4a529d6aa5633",
+				"DiscoKey":   "discokey:bf38a17b29854a48515c05ba77a914f8159771b2aec33b2536b353a0c00f5170",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60740",
+					"10.65.0.27:60740",
+					"172.17.0.1:60740",
+					"172.19.0.1:60740",
+					"172.20.0.1:60740"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:36:42.478410842Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7177155754033765,
+				"StableID":   "n6mByFiY3y11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea05e22aad7d12ca56e4c34f1078d44308e4199a52c1c3aaba8e63a1f0f0f239",
+				"DiscoKey":   "discokey:77c9346d6a199d7c1ead5e5bc2b3d5ec92cc860fbf5aa92594fec79e4d489708",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42457",
+					"10.65.0.27:42457",
+					"172.17.0.1:42457",
+					"172.19.0.1:42457",
+					"172.20.0.1:42457"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:36:43.025686311Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6219602308049180,
+				"StableID":   "n5dDwYQsZq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aefa52e419d267ef6b41522c3837b21964e004dc33cb63cba387eeb663bd3a43",
+				"DiscoKey":   "discokey:5c849ebeeab05b5673d956ec5d2be343b753849f2f73821369cf2dfc6402fa66",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43640",
+					"10.65.0.27:43640",
+					"172.17.0.1:43640",
+					"172.19.0.1:43640",
+					"172.20.0.1:43640"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:36:43.546884161Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5619277868006469,
+				"StableID":   "nLLCtFuysk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c2bc6893b12c60a8b4117112c48e1d0d5cd152a44fbb93bc56cdcb67361ab369",
+				"DiscoKey":   "discokey:71453ce0487ae899966e7600480dcfd921c6062aa0cdb99329acc4445a21013f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37603",
+					"10.65.0.27:37603",
+					"172.17.0.1:37603",
+					"172.19.0.1:37603",
+					"172.20.0.1:37603"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:36:44.102860155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1949930473611386,
+				"StableID":   "nF9LjHN8EG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0520a05867071797620eac590ce4721758498e15f7a5544adced085dc694c1f",
+				"DiscoKey":   "discokey:bbc4595df07fc1cd97ea97fc2139aa31d71e0517edb4b2ce22d8cb19d6be220c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45998",
+					"10.65.0.27:45998",
+					"172.17.0.1:45998",
+					"172.19.0.1:45998",
+					"172.20.0.1:45998"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:36:44.641057149Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3922831435313901,
+				"StableID":   "nQzLqX8fdX11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba7ec5111e527ac491757f4711444d81ce4324c47ab1fb152e741cf70649e662",
+				"DiscoKey":   "discokey:bfbe8d5fee913745b5adb2029691c33c8e7c893b59f07ac6b025dec9b2aaa904",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33462",
+					"10.65.0.27:33462",
+					"172.17.0.1:33462",
+					"172.19.0.1:33462",
+					"172.20.0.1:33462"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:36:45.183706915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3188966479592688,
+				"StableID":   "nZBYh2kHuR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:598fb6b7d6644fa86fa4f87f4233a8d7acf65193e8e6fa83ab4f63c1d28f8325",
+				"DiscoKey":   "discokey:2684699793fae45a134263e88c970c4fe7a21a04e14eb597ffd580e3681f4166",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38560",
+					"10.65.0.27:38560",
+					"172.17.0.1:38560",
+					"172.19.0.1:38560",
+					"172.20.0.1:38560"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:36:45.722400629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4388674661218757,
+				"StableID":   "ngE6WQ3eGb11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4f91d56dd1ea841cbe7ffab1472ff82ece2bace77f4a3f009caab96e7697f06",
+				"DiscoKey":   "discokey:30aa89a55718cecce47efd15ade388e441c99b5e331bcf624cecf6e0d0c33760",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52079",
+					"10.65.0.27:52079",
+					"172.17.0.1:52079",
+					"172.19.0.1:52079",
+					"172.20.0.1:52079"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:36:47.098952687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8001103941033343,
+				"StableID":   "nkyzm7SiU521CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:83b4ecf2b957218ecac739aa9b2092c8a95bc0c7e3b4326994f34b42bc0d8924",
+				"KeyExpiry":  "2026-11-08T18:36:47Z",
+				"DiscoKey":   "discokey:74d75c9bbc4beb1e985ae5c44643b5e270507e6d9ff4f827a16d932bc22a1004",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40677",
+					"10.65.0.27:40677",
+					"172.17.0.1:40677",
+					"172.19.0.1:40677",
+					"172.20.0.1:40677"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:36:47.637656119Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         922686301093192,
+				"StableID":   "nm1YqTQtC811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5fa74c00673f32839e190fe41a8a0335020af612f9536858c0d5b52f4efa9b1d",
+				"KeyExpiry":  "2026-11-08T18:36:48Z",
+				"DiscoKey":   "discokey:0a28137ce9a22ed8cced08245ddcbabbc27b6fdd0a4d8de898700d970e18c33c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38847",
+					"10.65.0.27:38847",
+					"172.17.0.1:38847",
+					"172.19.0.1:38847",
+					"172.20.0.1:38847"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:36:48.158330475Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3336477534055655,
+				"StableID":   "nW4LTDc64T11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e8a9782344aed454b2a7ed9c81a181016b8ed378c27070eb5ee653568aa22550",
+				"KeyExpiry":  "2026-11-08T18:36:48Z",
+				"DiscoKey":   "discokey:9ef60a59270caa12a3a7f1da9b29db3a6fe1d5295994ff7249bd586c30c23f21",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:48138",
+					"10.65.0.27:48138",
+					"172.17.0.1:48138",
+					"172.19.0.1:48138",
+					"172.20.0.1:48138"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:36:48.702894407Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6245672826688978": {
+				"ID":          6245672826688978,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3168131240925008,
+				"StableID":   "nX6H1GSrjR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       3168131240925008,
+				"Key":        "nodekey:07c886f1599393bfd6442fc5cd5676fc43a7a4ffb41ca8a85caa7f26b3a08055",
+				"DiscoKey":   "discokey:0eb3a1c280df196d700bb107a6721d2223c5b3991ad4bf94988024e951eecc1e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58730",
+					"10.65.0.27:58730",
+					"172.17.0.1:58730",
+					"172.19.0.1:58730",
+					"172.20.0.1:58730"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:36:40.37788928Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:07c886f1599393bfd6442fc5cd5676fc43a7a4ffb41ca8a85caa7f26b3a08055",
+			"MachineKey": "mkey:334debb0db4e201d4717240772023205a16a67fea1e54c642c5a46e7e8922349",
+			"Peers": [{
+				"ID":         6245672826688978,
+				"StableID":   "nF1nPbEgmq11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a57c23204adb8aa23ed526c6ba90ae0997cd587bb7eddd7873be6fc39a140d1f",
+				"DiscoKey":   "discokey:b43c70046a13eaceea25456c33ac35fd31108f81eb652db612e306ce9d91db5d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43912",
+					"10.65.0.27:43912",
+					"172.17.0.1:43912",
+					"172.19.0.1:43912",
+					"172.20.0.1:43912"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:36:40.86868446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3983758180432024,
+				"StableID":   "nfgcfBaF7Y11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:506bf2a42965905de3fd322f0688ef00e428fba6ae84ebf09257c4e394fccf6f",
+				"DiscoKey":   "discokey:12017fb6117fe12c02bbab3bad9e428585fe81fc210e6fa8fb45624fceaaa04f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35907",
+					"10.65.0.27:35907",
+					"172.17.0.1:35907",
+					"172.19.0.1:35907",
+					"172.20.0.1:35907"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:36:41.398072621Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2791095926211361,
+				"StableID":   "nJqjLiM6oN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6729631809256061f766a87280f0b1f460bba3b8f0e97acec4ad87b04234a68",
+				"DiscoKey":   "discokey:4db96d9f99c69c4b67da309c42fd815cd2e4cae025e59358ade6321a71944601",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:41108",
+					"10.65.0.27:41108",
+					"172.17.0.1:41108",
+					"172.19.0.1:41108",
+					"172.20.0.1:41108"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:36:41.931695818Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1110201268129711,
+				"StableID":   "nCdpM57pf911CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aedbcb2d15fef85942bfccf58890590a82aacf4aee57b75681c4a529d6aa5633",
+				"DiscoKey":   "discokey:bf38a17b29854a48515c05ba77a914f8159771b2aec33b2536b353a0c00f5170",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60740",
+					"10.65.0.27:60740",
+					"172.17.0.1:60740",
+					"172.19.0.1:60740",
+					"172.20.0.1:60740"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:36:42.478410842Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7177155754033765,
+				"StableID":   "n6mByFiY3y11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea05e22aad7d12ca56e4c34f1078d44308e4199a52c1c3aaba8e63a1f0f0f239",
+				"DiscoKey":   "discokey:77c9346d6a199d7c1ead5e5bc2b3d5ec92cc860fbf5aa92594fec79e4d489708",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42457",
+					"10.65.0.27:42457",
+					"172.17.0.1:42457",
+					"172.19.0.1:42457",
+					"172.20.0.1:42457"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:36:43.025686311Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6219602308049180,
+				"StableID":   "n5dDwYQsZq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aefa52e419d267ef6b41522c3837b21964e004dc33cb63cba387eeb663bd3a43",
+				"DiscoKey":   "discokey:5c849ebeeab05b5673d956ec5d2be343b753849f2f73821369cf2dfc6402fa66",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43640",
+					"10.65.0.27:43640",
+					"172.17.0.1:43640",
+					"172.19.0.1:43640",
+					"172.20.0.1:43640"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:36:43.546884161Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5619277868006469,
+				"StableID":   "nLLCtFuysk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c2bc6893b12c60a8b4117112c48e1d0d5cd152a44fbb93bc56cdcb67361ab369",
+				"DiscoKey":   "discokey:71453ce0487ae899966e7600480dcfd921c6062aa0cdb99329acc4445a21013f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37603",
+					"10.65.0.27:37603",
+					"172.17.0.1:37603",
+					"172.19.0.1:37603",
+					"172.20.0.1:37603"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:36:44.102860155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1949930473611386,
+				"StableID":   "nF9LjHN8EG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0520a05867071797620eac590ce4721758498e15f7a5544adced085dc694c1f",
+				"DiscoKey":   "discokey:bbc4595df07fc1cd97ea97fc2139aa31d71e0517edb4b2ce22d8cb19d6be220c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45998",
+					"10.65.0.27:45998",
+					"172.17.0.1:45998",
+					"172.19.0.1:45998",
+					"172.20.0.1:45998"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:36:44.641057149Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3922831435313901,
+				"StableID":   "nQzLqX8fdX11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba7ec5111e527ac491757f4711444d81ce4324c47ab1fb152e741cf70649e662",
+				"DiscoKey":   "discokey:bfbe8d5fee913745b5adb2029691c33c8e7c893b59f07ac6b025dec9b2aaa904",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33462",
+					"10.65.0.27:33462",
+					"172.17.0.1:33462",
+					"172.19.0.1:33462",
+					"172.20.0.1:33462"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:36:45.183706915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3188966479592688,
+				"StableID":   "nZBYh2kHuR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:598fb6b7d6644fa86fa4f87f4233a8d7acf65193e8e6fa83ab4f63c1d28f8325",
+				"DiscoKey":   "discokey:2684699793fae45a134263e88c970c4fe7a21a04e14eb597ffd580e3681f4166",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38560",
+					"10.65.0.27:38560",
+					"172.17.0.1:38560",
+					"172.19.0.1:38560",
+					"172.20.0.1:38560"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:36:45.722400629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4388674661218757,
+				"StableID":   "ngE6WQ3eGb11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4f91d56dd1ea841cbe7ffab1472ff82ece2bace77f4a3f009caab96e7697f06",
+				"DiscoKey":   "discokey:30aa89a55718cecce47efd15ade388e441c99b5e331bcf624cecf6e0d0c33760",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52079",
+					"10.65.0.27:52079",
+					"172.17.0.1:52079",
+					"172.19.0.1:52079",
+					"172.20.0.1:52079"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:36:47.098952687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8001103941033343,
+				"StableID":   "nkyzm7SiU521CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:83b4ecf2b957218ecac739aa9b2092c8a95bc0c7e3b4326994f34b42bc0d8924",
+				"KeyExpiry":  "2026-11-08T18:36:47Z",
+				"DiscoKey":   "discokey:74d75c9bbc4beb1e985ae5c44643b5e270507e6d9ff4f827a16d932bc22a1004",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40677",
+					"10.65.0.27:40677",
+					"172.17.0.1:40677",
+					"172.19.0.1:40677",
+					"172.20.0.1:40677"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:36:47.637656119Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         922686301093192,
+				"StableID":   "nm1YqTQtC811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5fa74c00673f32839e190fe41a8a0335020af612f9536858c0d5b52f4efa9b1d",
+				"KeyExpiry":  "2026-11-08T18:36:48Z",
+				"DiscoKey":   "discokey:0a28137ce9a22ed8cced08245ddcbabbc27b6fdd0a4d8de898700d970e18c33c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38847",
+					"10.65.0.27:38847",
+					"172.17.0.1:38847",
+					"172.19.0.1:38847",
+					"172.20.0.1:38847"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:36:48.158330475Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3336477534055655,
+				"StableID":   "nW4LTDc64T11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e8a9782344aed454b2a7ed9c81a181016b8ed378c27070eb5ee653568aa22550",
+				"KeyExpiry":  "2026-11-08T18:36:48Z",
+				"DiscoKey":   "discokey:9ef60a59270caa12a3a7f1da9b29db3a6fe1d5295994ff7249bd586c30c23f21",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:48138",
+					"10.65.0.27:48138",
+					"172.17.0.1:48138",
+					"172.19.0.1:48138",
+					"172.20.0.1:48138"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:36:48.702894407Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3168131240925008": {
+				"ID":          3168131240925008,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1110201268129711,
+				"StableID":   "nCdpM57pf911CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1110201268129711,
+				"Key":        "nodekey:aedbcb2d15fef85942bfccf58890590a82aacf4aee57b75681c4a529d6aa5633",
+				"DiscoKey":   "discokey:bf38a17b29854a48515c05ba77a914f8159771b2aec33b2536b353a0c00f5170",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60740",
+					"10.65.0.27:60740",
+					"172.17.0.1:60740",
+					"172.19.0.1:60740",
+					"172.20.0.1:60740"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:36:42.478410842Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:aedbcb2d15fef85942bfccf58890590a82aacf4aee57b75681c4a529d6aa5633",
+			"MachineKey": "mkey:e99b355069cdab1151238247bd5f6ac4d74b805f6f86107f40b92e20d226895a",
+			"Peers": [{
+				"ID":         3168131240925008,
+				"StableID":   "nX6H1GSrjR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c886f1599393bfd6442fc5cd5676fc43a7a4ffb41ca8a85caa7f26b3a08055",
+				"DiscoKey":   "discokey:0eb3a1c280df196d700bb107a6721d2223c5b3991ad4bf94988024e951eecc1e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58730",
+					"10.65.0.27:58730",
+					"172.17.0.1:58730",
+					"172.19.0.1:58730",
+					"172.20.0.1:58730"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:36:40.37788928Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6245672826688978,
+				"StableID":   "nF1nPbEgmq11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a57c23204adb8aa23ed526c6ba90ae0997cd587bb7eddd7873be6fc39a140d1f",
+				"DiscoKey":   "discokey:b43c70046a13eaceea25456c33ac35fd31108f81eb652db612e306ce9d91db5d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43912",
+					"10.65.0.27:43912",
+					"172.17.0.1:43912",
+					"172.19.0.1:43912",
+					"172.20.0.1:43912"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:36:40.86868446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3983758180432024,
+				"StableID":   "nfgcfBaF7Y11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:506bf2a42965905de3fd322f0688ef00e428fba6ae84ebf09257c4e394fccf6f",
+				"DiscoKey":   "discokey:12017fb6117fe12c02bbab3bad9e428585fe81fc210e6fa8fb45624fceaaa04f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35907",
+					"10.65.0.27:35907",
+					"172.17.0.1:35907",
+					"172.19.0.1:35907",
+					"172.20.0.1:35907"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:36:41.398072621Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2791095926211361,
+				"StableID":   "nJqjLiM6oN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6729631809256061f766a87280f0b1f460bba3b8f0e97acec4ad87b04234a68",
+				"DiscoKey":   "discokey:4db96d9f99c69c4b67da309c42fd815cd2e4cae025e59358ade6321a71944601",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:41108",
+					"10.65.0.27:41108",
+					"172.17.0.1:41108",
+					"172.19.0.1:41108",
+					"172.20.0.1:41108"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:36:41.931695818Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7177155754033765,
+				"StableID":   "n6mByFiY3y11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea05e22aad7d12ca56e4c34f1078d44308e4199a52c1c3aaba8e63a1f0f0f239",
+				"DiscoKey":   "discokey:77c9346d6a199d7c1ead5e5bc2b3d5ec92cc860fbf5aa92594fec79e4d489708",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42457",
+					"10.65.0.27:42457",
+					"172.17.0.1:42457",
+					"172.19.0.1:42457",
+					"172.20.0.1:42457"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:36:43.025686311Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6219602308049180,
+				"StableID":   "n5dDwYQsZq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aefa52e419d267ef6b41522c3837b21964e004dc33cb63cba387eeb663bd3a43",
+				"DiscoKey":   "discokey:5c849ebeeab05b5673d956ec5d2be343b753849f2f73821369cf2dfc6402fa66",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43640",
+					"10.65.0.27:43640",
+					"172.17.0.1:43640",
+					"172.19.0.1:43640",
+					"172.20.0.1:43640"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:36:43.546884161Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5619277868006469,
+				"StableID":   "nLLCtFuysk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c2bc6893b12c60a8b4117112c48e1d0d5cd152a44fbb93bc56cdcb67361ab369",
+				"DiscoKey":   "discokey:71453ce0487ae899966e7600480dcfd921c6062aa0cdb99329acc4445a21013f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37603",
+					"10.65.0.27:37603",
+					"172.17.0.1:37603",
+					"172.19.0.1:37603",
+					"172.20.0.1:37603"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:36:44.102860155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1949930473611386,
+				"StableID":   "nF9LjHN8EG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0520a05867071797620eac590ce4721758498e15f7a5544adced085dc694c1f",
+				"DiscoKey":   "discokey:bbc4595df07fc1cd97ea97fc2139aa31d71e0517edb4b2ce22d8cb19d6be220c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45998",
+					"10.65.0.27:45998",
+					"172.17.0.1:45998",
+					"172.19.0.1:45998",
+					"172.20.0.1:45998"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:36:44.641057149Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3922831435313901,
+				"StableID":   "nQzLqX8fdX11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba7ec5111e527ac491757f4711444d81ce4324c47ab1fb152e741cf70649e662",
+				"DiscoKey":   "discokey:bfbe8d5fee913745b5adb2029691c33c8e7c893b59f07ac6b025dec9b2aaa904",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33462",
+					"10.65.0.27:33462",
+					"172.17.0.1:33462",
+					"172.19.0.1:33462",
+					"172.20.0.1:33462"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:36:45.183706915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3188966479592688,
+				"StableID":   "nZBYh2kHuR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:598fb6b7d6644fa86fa4f87f4233a8d7acf65193e8e6fa83ab4f63c1d28f8325",
+				"DiscoKey":   "discokey:2684699793fae45a134263e88c970c4fe7a21a04e14eb597ffd580e3681f4166",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38560",
+					"10.65.0.27:38560",
+					"172.17.0.1:38560",
+					"172.19.0.1:38560",
+					"172.20.0.1:38560"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:36:45.722400629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4388674661218757,
+				"StableID":   "ngE6WQ3eGb11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4f91d56dd1ea841cbe7ffab1472ff82ece2bace77f4a3f009caab96e7697f06",
+				"DiscoKey":   "discokey:30aa89a55718cecce47efd15ade388e441c99b5e331bcf624cecf6e0d0c33760",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52079",
+					"10.65.0.27:52079",
+					"172.17.0.1:52079",
+					"172.19.0.1:52079",
+					"172.20.0.1:52079"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:36:47.098952687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8001103941033343,
+				"StableID":   "nkyzm7SiU521CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:83b4ecf2b957218ecac739aa9b2092c8a95bc0c7e3b4326994f34b42bc0d8924",
+				"KeyExpiry":  "2026-11-08T18:36:47Z",
+				"DiscoKey":   "discokey:74d75c9bbc4beb1e985ae5c44643b5e270507e6d9ff4f827a16d932bc22a1004",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40677",
+					"10.65.0.27:40677",
+					"172.17.0.1:40677",
+					"172.19.0.1:40677",
+					"172.20.0.1:40677"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:36:47.637656119Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         922686301093192,
+				"StableID":   "nm1YqTQtC811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5fa74c00673f32839e190fe41a8a0335020af612f9536858c0d5b52f4efa9b1d",
+				"KeyExpiry":  "2026-11-08T18:36:48Z",
+				"DiscoKey":   "discokey:0a28137ce9a22ed8cced08245ddcbabbc27b6fdd0a4d8de898700d970e18c33c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38847",
+					"10.65.0.27:38847",
+					"172.17.0.1:38847",
+					"172.19.0.1:38847",
+					"172.20.0.1:38847"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:36:48.158330475Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3336477534055655,
+				"StableID":   "nW4LTDc64T11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e8a9782344aed454b2a7ed9c81a181016b8ed378c27070eb5ee653568aa22550",
+				"KeyExpiry":  "2026-11-08T18:36:48Z",
+				"DiscoKey":   "discokey:9ef60a59270caa12a3a7f1da9b29db3a6fe1d5295994ff7249bd586c30c23f21",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:48138",
+					"10.65.0.27:48138",
+					"172.17.0.1:48138",
+					"172.19.0.1:48138",
+					"172.20.0.1:48138"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:36:48.702894407Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1110201268129711": {
+				"ID":          1110201268129711,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}, "1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2791095926211361,
+				"StableID":   "nJqjLiM6oN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       2791095926211361,
+				"Key":        "nodekey:d6729631809256061f766a87280f0b1f460bba3b8f0e97acec4ad87b04234a68",
+				"DiscoKey":   "discokey:4db96d9f99c69c4b67da309c42fd815cd2e4cae025e59358ade6321a71944601",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:41108",
+					"10.65.0.27:41108",
+					"172.17.0.1:41108",
+					"172.19.0.1:41108",
+					"172.20.0.1:41108"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:36:41.931695818Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d6729631809256061f766a87280f0b1f460bba3b8f0e97acec4ad87b04234a68",
+			"MachineKey": "mkey:c55053dc81c1b9d743c8ea8ca50eb02ac87352aa645e9acfd8beacd4bcb87f00",
+			"Peers": [{
+				"ID":         3168131240925008,
+				"StableID":   "nX6H1GSrjR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c886f1599393bfd6442fc5cd5676fc43a7a4ffb41ca8a85caa7f26b3a08055",
+				"DiscoKey":   "discokey:0eb3a1c280df196d700bb107a6721d2223c5b3991ad4bf94988024e951eecc1e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58730",
+					"10.65.0.27:58730",
+					"172.17.0.1:58730",
+					"172.19.0.1:58730",
+					"172.20.0.1:58730"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:36:40.37788928Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6245672826688978,
+				"StableID":   "nF1nPbEgmq11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a57c23204adb8aa23ed526c6ba90ae0997cd587bb7eddd7873be6fc39a140d1f",
+				"DiscoKey":   "discokey:b43c70046a13eaceea25456c33ac35fd31108f81eb652db612e306ce9d91db5d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43912",
+					"10.65.0.27:43912",
+					"172.17.0.1:43912",
+					"172.19.0.1:43912",
+					"172.20.0.1:43912"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:36:40.86868446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3983758180432024,
+				"StableID":   "nfgcfBaF7Y11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:506bf2a42965905de3fd322f0688ef00e428fba6ae84ebf09257c4e394fccf6f",
+				"DiscoKey":   "discokey:12017fb6117fe12c02bbab3bad9e428585fe81fc210e6fa8fb45624fceaaa04f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35907",
+					"10.65.0.27:35907",
+					"172.17.0.1:35907",
+					"172.19.0.1:35907",
+					"172.20.0.1:35907"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:36:41.398072621Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1110201268129711,
+				"StableID":   "nCdpM57pf911CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aedbcb2d15fef85942bfccf58890590a82aacf4aee57b75681c4a529d6aa5633",
+				"DiscoKey":   "discokey:bf38a17b29854a48515c05ba77a914f8159771b2aec33b2536b353a0c00f5170",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60740",
+					"10.65.0.27:60740",
+					"172.17.0.1:60740",
+					"172.19.0.1:60740",
+					"172.20.0.1:60740"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:36:42.478410842Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7177155754033765,
+				"StableID":   "n6mByFiY3y11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea05e22aad7d12ca56e4c34f1078d44308e4199a52c1c3aaba8e63a1f0f0f239",
+				"DiscoKey":   "discokey:77c9346d6a199d7c1ead5e5bc2b3d5ec92cc860fbf5aa92594fec79e4d489708",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42457",
+					"10.65.0.27:42457",
+					"172.17.0.1:42457",
+					"172.19.0.1:42457",
+					"172.20.0.1:42457"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:36:43.025686311Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6219602308049180,
+				"StableID":   "n5dDwYQsZq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aefa52e419d267ef6b41522c3837b21964e004dc33cb63cba387eeb663bd3a43",
+				"DiscoKey":   "discokey:5c849ebeeab05b5673d956ec5d2be343b753849f2f73821369cf2dfc6402fa66",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43640",
+					"10.65.0.27:43640",
+					"172.17.0.1:43640",
+					"172.19.0.1:43640",
+					"172.20.0.1:43640"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:36:43.546884161Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5619277868006469,
+				"StableID":   "nLLCtFuysk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c2bc6893b12c60a8b4117112c48e1d0d5cd152a44fbb93bc56cdcb67361ab369",
+				"DiscoKey":   "discokey:71453ce0487ae899966e7600480dcfd921c6062aa0cdb99329acc4445a21013f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37603",
+					"10.65.0.27:37603",
+					"172.17.0.1:37603",
+					"172.19.0.1:37603",
+					"172.20.0.1:37603"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:36:44.102860155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1949930473611386,
+				"StableID":   "nF9LjHN8EG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0520a05867071797620eac590ce4721758498e15f7a5544adced085dc694c1f",
+				"DiscoKey":   "discokey:bbc4595df07fc1cd97ea97fc2139aa31d71e0517edb4b2ce22d8cb19d6be220c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45998",
+					"10.65.0.27:45998",
+					"172.17.0.1:45998",
+					"172.19.0.1:45998",
+					"172.20.0.1:45998"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:36:44.641057149Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3922831435313901,
+				"StableID":   "nQzLqX8fdX11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba7ec5111e527ac491757f4711444d81ce4324c47ab1fb152e741cf70649e662",
+				"DiscoKey":   "discokey:bfbe8d5fee913745b5adb2029691c33c8e7c893b59f07ac6b025dec9b2aaa904",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33462",
+					"10.65.0.27:33462",
+					"172.17.0.1:33462",
+					"172.19.0.1:33462",
+					"172.20.0.1:33462"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:36:45.183706915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3188966479592688,
+				"StableID":   "nZBYh2kHuR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:598fb6b7d6644fa86fa4f87f4233a8d7acf65193e8e6fa83ab4f63c1d28f8325",
+				"DiscoKey":   "discokey:2684699793fae45a134263e88c970c4fe7a21a04e14eb597ffd580e3681f4166",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38560",
+					"10.65.0.27:38560",
+					"172.17.0.1:38560",
+					"172.19.0.1:38560",
+					"172.20.0.1:38560"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:36:45.722400629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4388674661218757,
+				"StableID":   "ngE6WQ3eGb11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4f91d56dd1ea841cbe7ffab1472ff82ece2bace77f4a3f009caab96e7697f06",
+				"DiscoKey":   "discokey:30aa89a55718cecce47efd15ade388e441c99b5e331bcf624cecf6e0d0c33760",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52079",
+					"10.65.0.27:52079",
+					"172.17.0.1:52079",
+					"172.19.0.1:52079",
+					"172.20.0.1:52079"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:36:47.098952687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8001103941033343,
+				"StableID":   "nkyzm7SiU521CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:83b4ecf2b957218ecac739aa9b2092c8a95bc0c7e3b4326994f34b42bc0d8924",
+				"KeyExpiry":  "2026-11-08T18:36:47Z",
+				"DiscoKey":   "discokey:74d75c9bbc4beb1e985ae5c44643b5e270507e6d9ff4f827a16d932bc22a1004",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40677",
+					"10.65.0.27:40677",
+					"172.17.0.1:40677",
+					"172.19.0.1:40677",
+					"172.20.0.1:40677"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:36:47.637656119Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         922686301093192,
+				"StableID":   "nm1YqTQtC811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5fa74c00673f32839e190fe41a8a0335020af612f9536858c0d5b52f4efa9b1d",
+				"KeyExpiry":  "2026-11-08T18:36:48Z",
+				"DiscoKey":   "discokey:0a28137ce9a22ed8cced08245ddcbabbc27b6fdd0a4d8de898700d970e18c33c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38847",
+					"10.65.0.27:38847",
+					"172.17.0.1:38847",
+					"172.19.0.1:38847",
+					"172.20.0.1:38847"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:36:48.158330475Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3336477534055655,
+				"StableID":   "nW4LTDc64T11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e8a9782344aed454b2a7ed9c81a181016b8ed378c27070eb5ee653568aa22550",
+				"KeyExpiry":  "2026-11-08T18:36:48Z",
+				"DiscoKey":   "discokey:9ef60a59270caa12a3a7f1da9b29db3a6fe1d5295994ff7249bd586c30c23f21",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:48138",
+					"10.65.0.27:48138",
+					"172.17.0.1:48138",
+					"172.19.0.1:48138",
+					"172.20.0.1:48138"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:36:48.702894407Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2791095926211361": {
+				"ID":          2791095926211361,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6219602308049180,
+				"StableID":   "n5dDwYQsZq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       6219602308049180,
+				"Key":        "nodekey:aefa52e419d267ef6b41522c3837b21964e004dc33cb63cba387eeb663bd3a43",
+				"DiscoKey":   "discokey:5c849ebeeab05b5673d956ec5d2be343b753849f2f73821369cf2dfc6402fa66",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43640",
+					"10.65.0.27:43640",
+					"172.17.0.1:43640",
+					"172.19.0.1:43640",
+					"172.20.0.1:43640"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:36:43.546884161Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:aefa52e419d267ef6b41522c3837b21964e004dc33cb63cba387eeb663bd3a43",
+			"MachineKey": "mkey:b12c036fefd51c0da3ef2a7ae704dc4ab2496367400dde7da8156669b6a93212",
+			"Peers": [{
+				"ID":         3168131240925008,
+				"StableID":   "nX6H1GSrjR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c886f1599393bfd6442fc5cd5676fc43a7a4ffb41ca8a85caa7f26b3a08055",
+				"DiscoKey":   "discokey:0eb3a1c280df196d700bb107a6721d2223c5b3991ad4bf94988024e951eecc1e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58730",
+					"10.65.0.27:58730",
+					"172.17.0.1:58730",
+					"172.19.0.1:58730",
+					"172.20.0.1:58730"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:36:40.37788928Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6245672826688978,
+				"StableID":   "nF1nPbEgmq11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a57c23204adb8aa23ed526c6ba90ae0997cd587bb7eddd7873be6fc39a140d1f",
+				"DiscoKey":   "discokey:b43c70046a13eaceea25456c33ac35fd31108f81eb652db612e306ce9d91db5d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43912",
+					"10.65.0.27:43912",
+					"172.17.0.1:43912",
+					"172.19.0.1:43912",
+					"172.20.0.1:43912"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:36:40.86868446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3983758180432024,
+				"StableID":   "nfgcfBaF7Y11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:506bf2a42965905de3fd322f0688ef00e428fba6ae84ebf09257c4e394fccf6f",
+				"DiscoKey":   "discokey:12017fb6117fe12c02bbab3bad9e428585fe81fc210e6fa8fb45624fceaaa04f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35907",
+					"10.65.0.27:35907",
+					"172.17.0.1:35907",
+					"172.19.0.1:35907",
+					"172.20.0.1:35907"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:36:41.398072621Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2791095926211361,
+				"StableID":   "nJqjLiM6oN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6729631809256061f766a87280f0b1f460bba3b8f0e97acec4ad87b04234a68",
+				"DiscoKey":   "discokey:4db96d9f99c69c4b67da309c42fd815cd2e4cae025e59358ade6321a71944601",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:41108",
+					"10.65.0.27:41108",
+					"172.17.0.1:41108",
+					"172.19.0.1:41108",
+					"172.20.0.1:41108"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:36:41.931695818Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1110201268129711,
+				"StableID":   "nCdpM57pf911CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aedbcb2d15fef85942bfccf58890590a82aacf4aee57b75681c4a529d6aa5633",
+				"DiscoKey":   "discokey:bf38a17b29854a48515c05ba77a914f8159771b2aec33b2536b353a0c00f5170",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60740",
+					"10.65.0.27:60740",
+					"172.17.0.1:60740",
+					"172.19.0.1:60740",
+					"172.20.0.1:60740"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:36:42.478410842Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7177155754033765,
+				"StableID":   "n6mByFiY3y11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea05e22aad7d12ca56e4c34f1078d44308e4199a52c1c3aaba8e63a1f0f0f239",
+				"DiscoKey":   "discokey:77c9346d6a199d7c1ead5e5bc2b3d5ec92cc860fbf5aa92594fec79e4d489708",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42457",
+					"10.65.0.27:42457",
+					"172.17.0.1:42457",
+					"172.19.0.1:42457",
+					"172.20.0.1:42457"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:36:43.025686311Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5619277868006469,
+				"StableID":   "nLLCtFuysk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c2bc6893b12c60a8b4117112c48e1d0d5cd152a44fbb93bc56cdcb67361ab369",
+				"DiscoKey":   "discokey:71453ce0487ae899966e7600480dcfd921c6062aa0cdb99329acc4445a21013f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37603",
+					"10.65.0.27:37603",
+					"172.17.0.1:37603",
+					"172.19.0.1:37603",
+					"172.20.0.1:37603"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:36:44.102860155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1949930473611386,
+				"StableID":   "nF9LjHN8EG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0520a05867071797620eac590ce4721758498e15f7a5544adced085dc694c1f",
+				"DiscoKey":   "discokey:bbc4595df07fc1cd97ea97fc2139aa31d71e0517edb4b2ce22d8cb19d6be220c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45998",
+					"10.65.0.27:45998",
+					"172.17.0.1:45998",
+					"172.19.0.1:45998",
+					"172.20.0.1:45998"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:36:44.641057149Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3922831435313901,
+				"StableID":   "nQzLqX8fdX11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba7ec5111e527ac491757f4711444d81ce4324c47ab1fb152e741cf70649e662",
+				"DiscoKey":   "discokey:bfbe8d5fee913745b5adb2029691c33c8e7c893b59f07ac6b025dec9b2aaa904",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33462",
+					"10.65.0.27:33462",
+					"172.17.0.1:33462",
+					"172.19.0.1:33462",
+					"172.20.0.1:33462"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:36:45.183706915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3188966479592688,
+				"StableID":   "nZBYh2kHuR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:598fb6b7d6644fa86fa4f87f4233a8d7acf65193e8e6fa83ab4f63c1d28f8325",
+				"DiscoKey":   "discokey:2684699793fae45a134263e88c970c4fe7a21a04e14eb597ffd580e3681f4166",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38560",
+					"10.65.0.27:38560",
+					"172.17.0.1:38560",
+					"172.19.0.1:38560",
+					"172.20.0.1:38560"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:36:45.722400629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4388674661218757,
+				"StableID":   "ngE6WQ3eGb11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4f91d56dd1ea841cbe7ffab1472ff82ece2bace77f4a3f009caab96e7697f06",
+				"DiscoKey":   "discokey:30aa89a55718cecce47efd15ade388e441c99b5e331bcf624cecf6e0d0c33760",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52079",
+					"10.65.0.27:52079",
+					"172.17.0.1:52079",
+					"172.19.0.1:52079",
+					"172.20.0.1:52079"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:36:47.098952687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8001103941033343,
+				"StableID":   "nkyzm7SiU521CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:83b4ecf2b957218ecac739aa9b2092c8a95bc0c7e3b4326994f34b42bc0d8924",
+				"KeyExpiry":  "2026-11-08T18:36:47Z",
+				"DiscoKey":   "discokey:74d75c9bbc4beb1e985ae5c44643b5e270507e6d9ff4f827a16d932bc22a1004",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40677",
+					"10.65.0.27:40677",
+					"172.17.0.1:40677",
+					"172.19.0.1:40677",
+					"172.20.0.1:40677"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:36:47.637656119Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         922686301093192,
+				"StableID":   "nm1YqTQtC811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5fa74c00673f32839e190fe41a8a0335020af612f9536858c0d5b52f4efa9b1d",
+				"KeyExpiry":  "2026-11-08T18:36:48Z",
+				"DiscoKey":   "discokey:0a28137ce9a22ed8cced08245ddcbabbc27b6fdd0a4d8de898700d970e18c33c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38847",
+					"10.65.0.27:38847",
+					"172.17.0.1:38847",
+					"172.19.0.1:38847",
+					"172.20.0.1:38847"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:36:48.158330475Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3336477534055655,
+				"StableID":   "nW4LTDc64T11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e8a9782344aed454b2a7ed9c81a181016b8ed378c27070eb5ee653568aa22550",
+				"KeyExpiry":  "2026-11-08T18:36:48Z",
+				"DiscoKey":   "discokey:9ef60a59270caa12a3a7f1da9b29db3a6fe1d5295994ff7249bd586c30c23f21",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:48138",
+					"10.65.0.27:48138",
+					"172.17.0.1:48138",
+					"172.19.0.1:48138",
+					"172.20.0.1:48138"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:36:48.702894407Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6219602308049180": {
+				"ID":          6219602308049180,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1949930473611386,
+				"StableID":   "nF9LjHN8EG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1949930473611386,
+				"Key":        "nodekey:b0520a05867071797620eac590ce4721758498e15f7a5544adced085dc694c1f",
+				"DiscoKey":   "discokey:bbc4595df07fc1cd97ea97fc2139aa31d71e0517edb4b2ce22d8cb19d6be220c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45998",
+					"10.65.0.27:45998",
+					"172.17.0.1:45998",
+					"172.19.0.1:45998",
+					"172.20.0.1:45998"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:36:44.641057149Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b0520a05867071797620eac590ce4721758498e15f7a5544adced085dc694c1f",
+			"MachineKey": "mkey:c6a1f224253ea00b4207e4c9df6c2a40cfcbd6ba2408b2a28efee330a7742c21",
+			"Peers": [{
+				"ID":         3168131240925008,
+				"StableID":   "nX6H1GSrjR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c886f1599393bfd6442fc5cd5676fc43a7a4ffb41ca8a85caa7f26b3a08055",
+				"DiscoKey":   "discokey:0eb3a1c280df196d700bb107a6721d2223c5b3991ad4bf94988024e951eecc1e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58730",
+					"10.65.0.27:58730",
+					"172.17.0.1:58730",
+					"172.19.0.1:58730",
+					"172.20.0.1:58730"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:36:40.37788928Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6245672826688978,
+				"StableID":   "nF1nPbEgmq11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a57c23204adb8aa23ed526c6ba90ae0997cd587bb7eddd7873be6fc39a140d1f",
+				"DiscoKey":   "discokey:b43c70046a13eaceea25456c33ac35fd31108f81eb652db612e306ce9d91db5d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43912",
+					"10.65.0.27:43912",
+					"172.17.0.1:43912",
+					"172.19.0.1:43912",
+					"172.20.0.1:43912"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:36:40.86868446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3983758180432024,
+				"StableID":   "nfgcfBaF7Y11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:506bf2a42965905de3fd322f0688ef00e428fba6ae84ebf09257c4e394fccf6f",
+				"DiscoKey":   "discokey:12017fb6117fe12c02bbab3bad9e428585fe81fc210e6fa8fb45624fceaaa04f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35907",
+					"10.65.0.27:35907",
+					"172.17.0.1:35907",
+					"172.19.0.1:35907",
+					"172.20.0.1:35907"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:36:41.398072621Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2791095926211361,
+				"StableID":   "nJqjLiM6oN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6729631809256061f766a87280f0b1f460bba3b8f0e97acec4ad87b04234a68",
+				"DiscoKey":   "discokey:4db96d9f99c69c4b67da309c42fd815cd2e4cae025e59358ade6321a71944601",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:41108",
+					"10.65.0.27:41108",
+					"172.17.0.1:41108",
+					"172.19.0.1:41108",
+					"172.20.0.1:41108"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:36:41.931695818Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1110201268129711,
+				"StableID":   "nCdpM57pf911CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aedbcb2d15fef85942bfccf58890590a82aacf4aee57b75681c4a529d6aa5633",
+				"DiscoKey":   "discokey:bf38a17b29854a48515c05ba77a914f8159771b2aec33b2536b353a0c00f5170",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60740",
+					"10.65.0.27:60740",
+					"172.17.0.1:60740",
+					"172.19.0.1:60740",
+					"172.20.0.1:60740"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:36:42.478410842Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7177155754033765,
+				"StableID":   "n6mByFiY3y11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea05e22aad7d12ca56e4c34f1078d44308e4199a52c1c3aaba8e63a1f0f0f239",
+				"DiscoKey":   "discokey:77c9346d6a199d7c1ead5e5bc2b3d5ec92cc860fbf5aa92594fec79e4d489708",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42457",
+					"10.65.0.27:42457",
+					"172.17.0.1:42457",
+					"172.19.0.1:42457",
+					"172.20.0.1:42457"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:36:43.025686311Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6219602308049180,
+				"StableID":   "n5dDwYQsZq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aefa52e419d267ef6b41522c3837b21964e004dc33cb63cba387eeb663bd3a43",
+				"DiscoKey":   "discokey:5c849ebeeab05b5673d956ec5d2be343b753849f2f73821369cf2dfc6402fa66",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43640",
+					"10.65.0.27:43640",
+					"172.17.0.1:43640",
+					"172.19.0.1:43640",
+					"172.20.0.1:43640"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:36:43.546884161Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5619277868006469,
+				"StableID":   "nLLCtFuysk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c2bc6893b12c60a8b4117112c48e1d0d5cd152a44fbb93bc56cdcb67361ab369",
+				"DiscoKey":   "discokey:71453ce0487ae899966e7600480dcfd921c6062aa0cdb99329acc4445a21013f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37603",
+					"10.65.0.27:37603",
+					"172.17.0.1:37603",
+					"172.19.0.1:37603",
+					"172.20.0.1:37603"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:36:44.102860155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3922831435313901,
+				"StableID":   "nQzLqX8fdX11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba7ec5111e527ac491757f4711444d81ce4324c47ab1fb152e741cf70649e662",
+				"DiscoKey":   "discokey:bfbe8d5fee913745b5adb2029691c33c8e7c893b59f07ac6b025dec9b2aaa904",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33462",
+					"10.65.0.27:33462",
+					"172.17.0.1:33462",
+					"172.19.0.1:33462",
+					"172.20.0.1:33462"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:36:45.183706915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3188966479592688,
+				"StableID":   "nZBYh2kHuR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:598fb6b7d6644fa86fa4f87f4233a8d7acf65193e8e6fa83ab4f63c1d28f8325",
+				"DiscoKey":   "discokey:2684699793fae45a134263e88c970c4fe7a21a04e14eb597ffd580e3681f4166",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38560",
+					"10.65.0.27:38560",
+					"172.17.0.1:38560",
+					"172.19.0.1:38560",
+					"172.20.0.1:38560"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:36:45.722400629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4388674661218757,
+				"StableID":   "ngE6WQ3eGb11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4f91d56dd1ea841cbe7ffab1472ff82ece2bace77f4a3f009caab96e7697f06",
+				"DiscoKey":   "discokey:30aa89a55718cecce47efd15ade388e441c99b5e331bcf624cecf6e0d0c33760",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52079",
+					"10.65.0.27:52079",
+					"172.17.0.1:52079",
+					"172.19.0.1:52079",
+					"172.20.0.1:52079"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:36:47.098952687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8001103941033343,
+				"StableID":   "nkyzm7SiU521CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:83b4ecf2b957218ecac739aa9b2092c8a95bc0c7e3b4326994f34b42bc0d8924",
+				"KeyExpiry":  "2026-11-08T18:36:47Z",
+				"DiscoKey":   "discokey:74d75c9bbc4beb1e985ae5c44643b5e270507e6d9ff4f827a16d932bc22a1004",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40677",
+					"10.65.0.27:40677",
+					"172.17.0.1:40677",
+					"172.19.0.1:40677",
+					"172.20.0.1:40677"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:36:47.637656119Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         922686301093192,
+				"StableID":   "nm1YqTQtC811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5fa74c00673f32839e190fe41a8a0335020af612f9536858c0d5b52f4efa9b1d",
+				"KeyExpiry":  "2026-11-08T18:36:48Z",
+				"DiscoKey":   "discokey:0a28137ce9a22ed8cced08245ddcbabbc27b6fdd0a4d8de898700d970e18c33c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38847",
+					"10.65.0.27:38847",
+					"172.17.0.1:38847",
+					"172.19.0.1:38847",
+					"172.20.0.1:38847"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:36:48.158330475Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3336477534055655,
+				"StableID":   "nW4LTDc64T11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e8a9782344aed454b2a7ed9c81a181016b8ed378c27070eb5ee653568aa22550",
+				"KeyExpiry":  "2026-11-08T18:36:48Z",
+				"DiscoKey":   "discokey:9ef60a59270caa12a3a7f1da9b29db3a6fe1d5295994ff7249bd586c30c23f21",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:48138",
+					"10.65.0.27:48138",
+					"172.17.0.1:48138",
+					"172.19.0.1:48138",
+					"172.20.0.1:48138"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:36:48.702894407Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1949930473611386": {
+				"ID":          1949930473611386,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         922686301093192,
+				"StableID":   "nm1YqTQtC811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5fa74c00673f32839e190fe41a8a0335020af612f9536858c0d5b52f4efa9b1d",
+				"KeyExpiry":  "2026-11-08T18:36:48Z",
+				"DiscoKey":   "discokey:0a28137ce9a22ed8cced08245ddcbabbc27b6fdd0a4d8de898700d970e18c33c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38847",
+					"10.65.0.27:38847",
+					"172.17.0.1:38847",
+					"172.19.0.1:38847",
+					"172.20.0.1:38847"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:36:48.158330475Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5fa74c00673f32839e190fe41a8a0335020af612f9536858c0d5b52f4efa9b1d",
+			"MachineKey": "mkey:150480524dfbb6aefdb64836db6fa7b53d30e9c93ff9eb4489de9c35e98f5a2e",
+			"Peers": [{
+				"ID":         3168131240925008,
+				"StableID":   "nX6H1GSrjR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c886f1599393bfd6442fc5cd5676fc43a7a4ffb41ca8a85caa7f26b3a08055",
+				"DiscoKey":   "discokey:0eb3a1c280df196d700bb107a6721d2223c5b3991ad4bf94988024e951eecc1e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58730",
+					"10.65.0.27:58730",
+					"172.17.0.1:58730",
+					"172.19.0.1:58730",
+					"172.20.0.1:58730"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:36:40.37788928Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6245672826688978,
+				"StableID":   "nF1nPbEgmq11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a57c23204adb8aa23ed526c6ba90ae0997cd587bb7eddd7873be6fc39a140d1f",
+				"DiscoKey":   "discokey:b43c70046a13eaceea25456c33ac35fd31108f81eb652db612e306ce9d91db5d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43912",
+					"10.65.0.27:43912",
+					"172.17.0.1:43912",
+					"172.19.0.1:43912",
+					"172.20.0.1:43912"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:36:40.86868446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3983758180432024,
+				"StableID":   "nfgcfBaF7Y11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:506bf2a42965905de3fd322f0688ef00e428fba6ae84ebf09257c4e394fccf6f",
+				"DiscoKey":   "discokey:12017fb6117fe12c02bbab3bad9e428585fe81fc210e6fa8fb45624fceaaa04f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35907",
+					"10.65.0.27:35907",
+					"172.17.0.1:35907",
+					"172.19.0.1:35907",
+					"172.20.0.1:35907"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:36:41.398072621Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2791095926211361,
+				"StableID":   "nJqjLiM6oN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6729631809256061f766a87280f0b1f460bba3b8f0e97acec4ad87b04234a68",
+				"DiscoKey":   "discokey:4db96d9f99c69c4b67da309c42fd815cd2e4cae025e59358ade6321a71944601",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:41108",
+					"10.65.0.27:41108",
+					"172.17.0.1:41108",
+					"172.19.0.1:41108",
+					"172.20.0.1:41108"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:36:41.931695818Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1110201268129711,
+				"StableID":   "nCdpM57pf911CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aedbcb2d15fef85942bfccf58890590a82aacf4aee57b75681c4a529d6aa5633",
+				"DiscoKey":   "discokey:bf38a17b29854a48515c05ba77a914f8159771b2aec33b2536b353a0c00f5170",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60740",
+					"10.65.0.27:60740",
+					"172.17.0.1:60740",
+					"172.19.0.1:60740",
+					"172.20.0.1:60740"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:36:42.478410842Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7177155754033765,
+				"StableID":   "n6mByFiY3y11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea05e22aad7d12ca56e4c34f1078d44308e4199a52c1c3aaba8e63a1f0f0f239",
+				"DiscoKey":   "discokey:77c9346d6a199d7c1ead5e5bc2b3d5ec92cc860fbf5aa92594fec79e4d489708",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42457",
+					"10.65.0.27:42457",
+					"172.17.0.1:42457",
+					"172.19.0.1:42457",
+					"172.20.0.1:42457"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:36:43.025686311Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6219602308049180,
+				"StableID":   "n5dDwYQsZq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aefa52e419d267ef6b41522c3837b21964e004dc33cb63cba387eeb663bd3a43",
+				"DiscoKey":   "discokey:5c849ebeeab05b5673d956ec5d2be343b753849f2f73821369cf2dfc6402fa66",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43640",
+					"10.65.0.27:43640",
+					"172.17.0.1:43640",
+					"172.19.0.1:43640",
+					"172.20.0.1:43640"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:36:43.546884161Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5619277868006469,
+				"StableID":   "nLLCtFuysk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c2bc6893b12c60a8b4117112c48e1d0d5cd152a44fbb93bc56cdcb67361ab369",
+				"DiscoKey":   "discokey:71453ce0487ae899966e7600480dcfd921c6062aa0cdb99329acc4445a21013f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37603",
+					"10.65.0.27:37603",
+					"172.17.0.1:37603",
+					"172.19.0.1:37603",
+					"172.20.0.1:37603"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:36:44.102860155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1949930473611386,
+				"StableID":   "nF9LjHN8EG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0520a05867071797620eac590ce4721758498e15f7a5544adced085dc694c1f",
+				"DiscoKey":   "discokey:bbc4595df07fc1cd97ea97fc2139aa31d71e0517edb4b2ce22d8cb19d6be220c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45998",
+					"10.65.0.27:45998",
+					"172.17.0.1:45998",
+					"172.19.0.1:45998",
+					"172.20.0.1:45998"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:36:44.641057149Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3922831435313901,
+				"StableID":   "nQzLqX8fdX11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba7ec5111e527ac491757f4711444d81ce4324c47ab1fb152e741cf70649e662",
+				"DiscoKey":   "discokey:bfbe8d5fee913745b5adb2029691c33c8e7c893b59f07ac6b025dec9b2aaa904",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33462",
+					"10.65.0.27:33462",
+					"172.17.0.1:33462",
+					"172.19.0.1:33462",
+					"172.20.0.1:33462"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:36:45.183706915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3188966479592688,
+				"StableID":   "nZBYh2kHuR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:598fb6b7d6644fa86fa4f87f4233a8d7acf65193e8e6fa83ab4f63c1d28f8325",
+				"DiscoKey":   "discokey:2684699793fae45a134263e88c970c4fe7a21a04e14eb597ffd580e3681f4166",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38560",
+					"10.65.0.27:38560",
+					"172.17.0.1:38560",
+					"172.19.0.1:38560",
+					"172.20.0.1:38560"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:36:45.722400629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4388674661218757,
+				"StableID":   "ngE6WQ3eGb11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4f91d56dd1ea841cbe7ffab1472ff82ece2bace77f4a3f009caab96e7697f06",
+				"DiscoKey":   "discokey:30aa89a55718cecce47efd15ade388e441c99b5e331bcf624cecf6e0d0c33760",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52079",
+					"10.65.0.27:52079",
+					"172.17.0.1:52079",
+					"172.19.0.1:52079",
+					"172.20.0.1:52079"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:36:47.098952687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8001103941033343,
+				"StableID":   "nkyzm7SiU521CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:83b4ecf2b957218ecac739aa9b2092c8a95bc0c7e3b4326994f34b42bc0d8924",
+				"KeyExpiry":  "2026-11-08T18:36:47Z",
+				"DiscoKey":   "discokey:74d75c9bbc4beb1e985ae5c44643b5e270507e6d9ff4f827a16d932bc22a1004",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40677",
+					"10.65.0.27:40677",
+					"172.17.0.1:40677",
+					"172.19.0.1:40677",
+					"172.20.0.1:40677"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:36:47.637656119Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3336477534055655,
+				"StableID":   "nW4LTDc64T11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e8a9782344aed454b2a7ed9c81a181016b8ed378c27070eb5ee653568aa22550",
+				"KeyExpiry":  "2026-11-08T18:36:48Z",
+				"DiscoKey":   "discokey:9ef60a59270caa12a3a7f1da9b29db3a6fe1d5295994ff7249bd586c30c23f21",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:48138",
+					"10.65.0.27:48138",
+					"172.17.0.1:48138",
+					"172.19.0.1:48138",
+					"172.20.0.1:48138"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:36:48.702894407Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3922831435313901,
+				"StableID":   "nQzLqX8fdX11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       3922831435313901,
+				"Key":        "nodekey:ba7ec5111e527ac491757f4711444d81ce4324c47ab1fb152e741cf70649e662",
+				"DiscoKey":   "discokey:bfbe8d5fee913745b5adb2029691c33c8e7c893b59f07ac6b025dec9b2aaa904",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33462",
+					"10.65.0.27:33462",
+					"172.17.0.1:33462",
+					"172.19.0.1:33462",
+					"172.20.0.1:33462"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:36:45.183706915Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ba7ec5111e527ac491757f4711444d81ce4324c47ab1fb152e741cf70649e662",
+			"MachineKey": "mkey:b3ee90d1e41f20f9eeb7d05cee88bc777d62574af687b6fc7e234c71d9685e5a",
+			"Peers": [{
+				"ID":         3168131240925008,
+				"StableID":   "nX6H1GSrjR11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07c886f1599393bfd6442fc5cd5676fc43a7a4ffb41ca8a85caa7f26b3a08055",
+				"DiscoKey":   "discokey:0eb3a1c280df196d700bb107a6721d2223c5b3991ad4bf94988024e951eecc1e",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:58730",
+					"10.65.0.27:58730",
+					"172.17.0.1:58730",
+					"172.19.0.1:58730",
+					"172.20.0.1:58730"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:36:40.37788928Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6245672826688978,
+				"StableID":   "nF1nPbEgmq11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a57c23204adb8aa23ed526c6ba90ae0997cd587bb7eddd7873be6fc39a140d1f",
+				"DiscoKey":   "discokey:b43c70046a13eaceea25456c33ac35fd31108f81eb652db612e306ce9d91db5d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43912",
+					"10.65.0.27:43912",
+					"172.17.0.1:43912",
+					"172.19.0.1:43912",
+					"172.20.0.1:43912"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:36:40.86868446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3983758180432024,
+				"StableID":   "nfgcfBaF7Y11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:506bf2a42965905de3fd322f0688ef00e428fba6ae84ebf09257c4e394fccf6f",
+				"DiscoKey":   "discokey:12017fb6117fe12c02bbab3bad9e428585fe81fc210e6fa8fb45624fceaaa04f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:35907",
+					"10.65.0.27:35907",
+					"172.17.0.1:35907",
+					"172.19.0.1:35907",
+					"172.20.0.1:35907"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:36:41.398072621Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2791095926211361,
+				"StableID":   "nJqjLiM6oN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6729631809256061f766a87280f0b1f460bba3b8f0e97acec4ad87b04234a68",
+				"DiscoKey":   "discokey:4db96d9f99c69c4b67da309c42fd815cd2e4cae025e59358ade6321a71944601",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:41108",
+					"10.65.0.27:41108",
+					"172.17.0.1:41108",
+					"172.19.0.1:41108",
+					"172.20.0.1:41108"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:36:41.931695818Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1110201268129711,
+				"StableID":   "nCdpM57pf911CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aedbcb2d15fef85942bfccf58890590a82aacf4aee57b75681c4a529d6aa5633",
+				"DiscoKey":   "discokey:bf38a17b29854a48515c05ba77a914f8159771b2aec33b2536b353a0c00f5170",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:60740",
+					"10.65.0.27:60740",
+					"172.17.0.1:60740",
+					"172.19.0.1:60740",
+					"172.20.0.1:60740"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:36:42.478410842Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7177155754033765,
+				"StableID":   "n6mByFiY3y11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea05e22aad7d12ca56e4c34f1078d44308e4199a52c1c3aaba8e63a1f0f0f239",
+				"DiscoKey":   "discokey:77c9346d6a199d7c1ead5e5bc2b3d5ec92cc860fbf5aa92594fec79e4d489708",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:42457",
+					"10.65.0.27:42457",
+					"172.17.0.1:42457",
+					"172.19.0.1:42457",
+					"172.20.0.1:42457"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:36:43.025686311Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6219602308049180,
+				"StableID":   "n5dDwYQsZq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aefa52e419d267ef6b41522c3837b21964e004dc33cb63cba387eeb663bd3a43",
+				"DiscoKey":   "discokey:5c849ebeeab05b5673d956ec5d2be343b753849f2f73821369cf2dfc6402fa66",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43640",
+					"10.65.0.27:43640",
+					"172.17.0.1:43640",
+					"172.19.0.1:43640",
+					"172.20.0.1:43640"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:36:43.546884161Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5619277868006469,
+				"StableID":   "nLLCtFuysk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c2bc6893b12c60a8b4117112c48e1d0d5cd152a44fbb93bc56cdcb67361ab369",
+				"DiscoKey":   "discokey:71453ce0487ae899966e7600480dcfd921c6062aa0cdb99329acc4445a21013f",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37603",
+					"10.65.0.27:37603",
+					"172.17.0.1:37603",
+					"172.19.0.1:37603",
+					"172.20.0.1:37603"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:36:44.102860155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1949930473611386,
+				"StableID":   "nF9LjHN8EG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0520a05867071797620eac590ce4721758498e15f7a5544adced085dc694c1f",
+				"DiscoKey":   "discokey:bbc4595df07fc1cd97ea97fc2139aa31d71e0517edb4b2ce22d8cb19d6be220c",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:45998",
+					"10.65.0.27:45998",
+					"172.17.0.1:45998",
+					"172.19.0.1:45998",
+					"172.20.0.1:45998"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:36:44.641057149Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3188966479592688,
+				"StableID":   "nZBYh2kHuR11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:598fb6b7d6644fa86fa4f87f4233a8d7acf65193e8e6fa83ab4f63c1d28f8325",
+				"DiscoKey":   "discokey:2684699793fae45a134263e88c970c4fe7a21a04e14eb597ffd580e3681f4166",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:38560",
+					"10.65.0.27:38560",
+					"172.17.0.1:38560",
+					"172.19.0.1:38560",
+					"172.20.0.1:38560"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:36:45.722400629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4388674661218757,
+				"StableID":   "ngE6WQ3eGb11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4f91d56dd1ea841cbe7ffab1472ff82ece2bace77f4a3f009caab96e7697f06",
+				"DiscoKey":   "discokey:30aa89a55718cecce47efd15ade388e441c99b5e331bcf624cecf6e0d0c33760",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52079",
+					"10.65.0.27:52079",
+					"172.17.0.1:52079",
+					"172.19.0.1:52079",
+					"172.20.0.1:52079"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:36:47.098952687Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8001103941033343,
+				"StableID":   "nkyzm7SiU521CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:83b4ecf2b957218ecac739aa9b2092c8a95bc0c7e3b4326994f34b42bc0d8924",
+				"KeyExpiry":  "2026-11-08T18:36:47Z",
+				"DiscoKey":   "discokey:74d75c9bbc4beb1e985ae5c44643b5e270507e6d9ff4f827a16d932bc22a1004",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:40677",
+					"10.65.0.27:40677",
+					"172.17.0.1:40677",
+					"172.19.0.1:40677",
+					"172.20.0.1:40677"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:36:47.637656119Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         922686301093192,
+				"StableID":   "nm1YqTQtC811CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:5fa74c00673f32839e190fe41a8a0335020af612f9536858c0d5b52f4efa9b1d",
+				"KeyExpiry":  "2026-11-08T18:36:48Z",
+				"DiscoKey":   "discokey:0a28137ce9a22ed8cced08245ddcbabbc27b6fdd0a4d8de898700d970e18c33c",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:38847",
+					"10.65.0.27:38847",
+					"172.17.0.1:38847",
+					"172.19.0.1:38847",
+					"172.20.0.1:38847"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:36:48.158330475Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3336477534055655,
+				"StableID":   "nW4LTDc64T11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e8a9782344aed454b2a7ed9c81a181016b8ed378c27070eb5ee653568aa22550",
+				"KeyExpiry":  "2026-11-08T18:36:48Z",
+				"DiscoKey":   "discokey:9ef60a59270caa12a3a7f1da9b29db3a6fe1d5295994ff7249bd586c30c23f21",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:48138",
+					"10.65.0.27:48138",
+					"172.17.0.1:48138",
+					"172.19.0.1:48138",
+					"172.20.0.1:48138"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:36:48.702894407Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3922831435313901": {
+				"ID":          3922831435313901,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/sshtest_results/sshtest-deny-fail-policy-allows.hujson
+++ b/hscontrol/policy/v2/testdata/sshtest_results/sshtest-deny-fail-policy-allows.hujson
@@ -1,0 +1,20082 @@
+// sshtest-deny-fail-policy-allows
+//
+// deny asserted but policy allows, must fail
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T18:37:33Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "sshtest-deny-fail-policy-allows",
+	"description":    "deny asserted but policy allows, must fail",
+	"category":       "sshtest",
+	"captured_at":    "2026-05-12T18:37:33.995122251Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                  \n  \n                                                                        \n                                                                 \n{\n\t\"category\":    \"sshtest\",\n\t\"description\": \"deny asserted but policy allows, must fail\",\n\t\"id\":          \"sshtest-deny-fail-policy-allows\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"thor@example.org\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"sshTests\": [{\n\t\t\"deny\": [\"root\"],\n\t\t\"dst\":  [\"tag:server\"],\n\t\t\"src\":  \"thor@example.org\"\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/sshtest/sshtest-deny-fail-policy-allows.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["thor@example.org"],
+				"users":  ["root"]
+			}],
+			"sshTests":  [{"deny": ["root"], "dst": ["tag:server"], "src": "thor@example.org"}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8141071774583320,
+				"StableID":   "n7Juvj97a621CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       8141071774583320,
+				"Key":        "nodekey:e74dd76a4e22d83bf4261a2b588e875b56fe5b6dbaca2f68ea46fd0b84e1ae4a",
+				"DiscoKey":   "discokey:7e855e1e38be6802169f86756732a4e634c8428c6278d8e2706a1cfd1f7b5519",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59005",
+					"10.65.0.27:59005",
+					"172.17.0.1:59005",
+					"172.19.0.1:59005",
+					"172.20.0.1:59005"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:37:42.474600685Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e74dd76a4e22d83bf4261a2b588e875b56fe5b6dbaca2f68ea46fd0b84e1ae4a",
+			"MachineKey": "mkey:fbcca250c27a677d81c6e8609f821b84f7af8a7c6ae1ff44e87164cec12cdc10",
+			"Peers": [{
+				"ID":         3032338836974926,
+				"StableID":   "nb3VGAQMgQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:415dfc49c2cdd22b4ee5c9444b40b9d173f13320a1bbdf47b88bac930a76011f",
+				"DiscoKey":   "discokey:d3fd9dc986c22532577a697618dc297abf55d21579ac5d887e34b39d5b64a712",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50934",
+					"10.65.0.27:50934",
+					"172.17.0.1:50934",
+					"172.19.0.1:50934",
+					"172.20.0.1:50934"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:37:36.527847188Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         483420215403172,
+				"StableID":   "nhyL3Wdwm411CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4f1fcefdb43d82fdeddf5503e061dffd4122d55cd3eec6ca317941724f52c70",
+				"DiscoKey":   "discokey:38addf17508e4861f9d415b70ebc74a3c49f8c1746f81c4b1a416ace2e5ef90d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48914",
+					"10.65.0.27:48914",
+					"172.17.0.1:48914",
+					"172.19.0.1:48914",
+					"172.20.0.1:48914"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:37:37.06700217Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8575151217514602,
+				"StableID":   "nX5EsXghx921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e3b2a07ed6475d0b70733fb407a0c8ec2d8af0a1d8a23de1896f461f2811768",
+				"DiscoKey":   "discokey:305e6eb0226dbba6910267248e3a87b86462f9b8ee25296394f9b5291fc91c43",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:55965",
+					"10.65.0.27:55965",
+					"172.17.0.1:55965",
+					"172.19.0.1:55965",
+					"172.20.0.1:55965"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:37:37.615376734Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3578705368049755,
+				"StableID":   "n2W5gFXowU11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:660dab33bf89014cf23c67b239aa0e68cd5aa89c66e483c9361cdc51ade7a701",
+				"DiscoKey":   "discokey:f52bf7decac9f3ab3223cd859d8664392a01af30e317df3b2537741f1cc9f016",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59630",
+					"10.65.0.27:59630",
+					"172.17.0.1:59630",
+					"172.19.0.1:59630",
+					"172.20.0.1:59630"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:37:38.177923205Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3158116736132111,
+				"StableID":   "nvGYWYNKfR11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c089d30fb931d7e0580346a34861ae49c36886330a75690b2899bd1bcf26a5d",
+				"DiscoKey":   "discokey:d0f943290fc69ee802e188615a45abe22c20c704f335515796c50c6bc8ad3660",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34185",
+					"10.65.0.27:34185",
+					"172.17.0.1:34185",
+					"172.19.0.1:34185",
+					"172.20.0.1:34185"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:37:38.742389702Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8847665348978334,
+				"StableID":   "nuUzUcA86C21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d9b139b700df726eac3f6d6b4f42b088ad283e5c407f8fe88837a9f0eb12642",
+				"DiscoKey":   "discokey:5ebed62f2c96b50b9352f877d3760de2e360c7b3a201aa51df46a2d81707f76e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37961",
+					"10.65.0.27:37961",
+					"172.17.0.1:37961",
+					"172.19.0.1:37961",
+					"172.20.0.1:37961"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:37:39.236293154Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8562652946575123,
+				"StableID":   "nWzkTeN3s921CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b2a1f0a1408ca116aa151dff4cfa996a9247463bccef46b2bb532ef025e9043",
+				"DiscoKey":   "discokey:06e142bebb2432b73209b00868463b8752ca52f96c2e4f64bed9057474079406",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51168",
+					"10.65.0.27:51168",
+					"172.17.0.1:51168",
+					"172.19.0.1:51168",
+					"172.20.0.1:51168"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:37:39.758894372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         607415585710634,
+				"StableID":   "nKZ7K6n6k511CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:036e558a08c07f847e31b8198be0f8abae0a7346a0614a4ab101c146c7234d5d",
+				"DiscoKey":   "discokey:f632a9f5c307d515f77750e3e531bab317f6256dd82a19d82c67138f94e3ea08",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54833",
+					"10.65.0.27:54833",
+					"172.17.0.1:54833",
+					"172.19.0.1:54833",
+					"172.20.0.1:54833"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:37:40.304509818Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6530190670267758,
+				"StableID":   "nMAmw43Yzs11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:52439a2bbdb733188c897535b8166b599f411b9c2bec6ca78d39927fbab1af78",
+				"DiscoKey":   "discokey:4a301a93ff07289e15db3f29ed011930d10919f24543d77f7e14728f9ed76c42",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52354",
+					"10.65.0.27:52354",
+					"172.17.0.1:52354",
+					"172.19.0.1:52354",
+					"172.20.0.1:52354"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:37:40.849942447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6548654885639027,
+				"StableID":   "nJSsRS4u8t11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08de7a4d3b30589a7e43615c59dcfcc246504897a3393507b19ebd6e8249b255",
+				"DiscoKey":   "discokey:23781cdacfb92c0606733c03a30cfeb7b520a229b8d16f06fae1afde9392ef06",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54610",
+					"10.65.0.27:54610",
+					"172.17.0.1:54610",
+					"172.19.0.1:54610",
+					"172.20.0.1:54610"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:37:41.390120527Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8827036839117342,
+				"StableID":   "nMJuhoHnvB21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39797e802b7386b1d31a3e41868cb839253bf42e890780fcbeb0b49dd173b71b",
+				"DiscoKey":   "discokey:edd5ad5b621524ca14daf6d747f5cf642a0251bab9350616fae7d4b2bef8e05d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60247",
+					"10.65.0.27:60247",
+					"172.17.0.1:60247",
+					"172.19.0.1:60247",
+					"172.20.0.1:60247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:37:41.942163092Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5304552881871009,
+				"StableID":   "nr7paLcSRi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d07705deb92539fa65d6491efd8403079d3b4d5cc3e566c60ee63041c6694c56",
+				"KeyExpiry":  "2026-11-08T18:37:43Z",
+				"DiscoKey":   "discokey:c7bdd1f4bd27742d655d84885ebca45fae1699a27c62854d52a51b886bcd0809",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52750",
+					"10.65.0.27:52750",
+					"172.17.0.1:52750",
+					"172.19.0.1:52750",
+					"172.20.0.1:52750"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:37:43.035658911Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         836729174456001,
+				"StableID":   "nc6LuUTxX711CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:693b108a5e9eeb52115428e562f7f74c37493593b94c728acce685dcde8a4d1f",
+				"KeyExpiry":  "2026-11-08T18:37:43Z",
+				"DiscoKey":   "discokey:122df4cae32fd9051e1cb82d12fa0b5976d6fc08bca7a9578039f6a8f17d4473",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41543",
+					"10.65.0.27:41543",
+					"172.17.0.1:41543",
+					"172.19.0.1:41543",
+					"172.20.0.1:41543"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:37:43.545425462Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5637802766590294,
+				"StableID":   "njXdj5XN2m11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:0f0ea4cd2f2d165a8d5a53d0afc97a72aedd40f3860dfe3afb97b2824e7c346c",
+				"KeyExpiry":  "2026-11-08T18:37:44Z",
+				"DiscoKey":   "discokey:47ba49b59a4773afc63f967e8366189646cbb514c7f78c4082e689c808f25c1c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36835",
+					"10.65.0.27:36835",
+					"172.17.0.1:36835",
+					"172.19.0.1:36835",
+					"172.20.0.1:36835"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:37:44.098696814Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8141071774583320": {
+				"ID":          8141071774583320,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8847665348978334,
+				"StableID":   "nuUzUcA86C21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       8847665348978334,
+				"Key":        "nodekey:3d9b139b700df726eac3f6d6b4f42b088ad283e5c407f8fe88837a9f0eb12642",
+				"DiscoKey":   "discokey:5ebed62f2c96b50b9352f877d3760de2e360c7b3a201aa51df46a2d81707f76e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37961",
+					"10.65.0.27:37961",
+					"172.17.0.1:37961",
+					"172.19.0.1:37961",
+					"172.20.0.1:37961"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:37:39.236293154Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3d9b139b700df726eac3f6d6b4f42b088ad283e5c407f8fe88837a9f0eb12642",
+			"MachineKey": "mkey:b52353c8ffc6552fed88cc86e06b88b1f4d6d24b2f814f94749dd7107cb5ca7b",
+			"Peers": [{
+				"ID":         3032338836974926,
+				"StableID":   "nb3VGAQMgQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:415dfc49c2cdd22b4ee5c9444b40b9d173f13320a1bbdf47b88bac930a76011f",
+				"DiscoKey":   "discokey:d3fd9dc986c22532577a697618dc297abf55d21579ac5d887e34b39d5b64a712",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50934",
+					"10.65.0.27:50934",
+					"172.17.0.1:50934",
+					"172.19.0.1:50934",
+					"172.20.0.1:50934"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:37:36.527847188Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         483420215403172,
+				"StableID":   "nhyL3Wdwm411CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4f1fcefdb43d82fdeddf5503e061dffd4122d55cd3eec6ca317941724f52c70",
+				"DiscoKey":   "discokey:38addf17508e4861f9d415b70ebc74a3c49f8c1746f81c4b1a416ace2e5ef90d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48914",
+					"10.65.0.27:48914",
+					"172.17.0.1:48914",
+					"172.19.0.1:48914",
+					"172.20.0.1:48914"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:37:37.06700217Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8575151217514602,
+				"StableID":   "nX5EsXghx921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e3b2a07ed6475d0b70733fb407a0c8ec2d8af0a1d8a23de1896f461f2811768",
+				"DiscoKey":   "discokey:305e6eb0226dbba6910267248e3a87b86462f9b8ee25296394f9b5291fc91c43",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:55965",
+					"10.65.0.27:55965",
+					"172.17.0.1:55965",
+					"172.19.0.1:55965",
+					"172.20.0.1:55965"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:37:37.615376734Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3578705368049755,
+				"StableID":   "n2W5gFXowU11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:660dab33bf89014cf23c67b239aa0e68cd5aa89c66e483c9361cdc51ade7a701",
+				"DiscoKey":   "discokey:f52bf7decac9f3ab3223cd859d8664392a01af30e317df3b2537741f1cc9f016",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59630",
+					"10.65.0.27:59630",
+					"172.17.0.1:59630",
+					"172.19.0.1:59630",
+					"172.20.0.1:59630"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:37:38.177923205Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3158116736132111,
+				"StableID":   "nvGYWYNKfR11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c089d30fb931d7e0580346a34861ae49c36886330a75690b2899bd1bcf26a5d",
+				"DiscoKey":   "discokey:d0f943290fc69ee802e188615a45abe22c20c704f335515796c50c6bc8ad3660",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34185",
+					"10.65.0.27:34185",
+					"172.17.0.1:34185",
+					"172.19.0.1:34185",
+					"172.20.0.1:34185"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:37:38.742389702Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8562652946575123,
+				"StableID":   "nWzkTeN3s921CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b2a1f0a1408ca116aa151dff4cfa996a9247463bccef46b2bb532ef025e9043",
+				"DiscoKey":   "discokey:06e142bebb2432b73209b00868463b8752ca52f96c2e4f64bed9057474079406",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51168",
+					"10.65.0.27:51168",
+					"172.17.0.1:51168",
+					"172.19.0.1:51168",
+					"172.20.0.1:51168"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:37:39.758894372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         607415585710634,
+				"StableID":   "nKZ7K6n6k511CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:036e558a08c07f847e31b8198be0f8abae0a7346a0614a4ab101c146c7234d5d",
+				"DiscoKey":   "discokey:f632a9f5c307d515f77750e3e531bab317f6256dd82a19d82c67138f94e3ea08",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54833",
+					"10.65.0.27:54833",
+					"172.17.0.1:54833",
+					"172.19.0.1:54833",
+					"172.20.0.1:54833"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:37:40.304509818Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6530190670267758,
+				"StableID":   "nMAmw43Yzs11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:52439a2bbdb733188c897535b8166b599f411b9c2bec6ca78d39927fbab1af78",
+				"DiscoKey":   "discokey:4a301a93ff07289e15db3f29ed011930d10919f24543d77f7e14728f9ed76c42",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52354",
+					"10.65.0.27:52354",
+					"172.17.0.1:52354",
+					"172.19.0.1:52354",
+					"172.20.0.1:52354"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:37:40.849942447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6548654885639027,
+				"StableID":   "nJSsRS4u8t11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08de7a4d3b30589a7e43615c59dcfcc246504897a3393507b19ebd6e8249b255",
+				"DiscoKey":   "discokey:23781cdacfb92c0606733c03a30cfeb7b520a229b8d16f06fae1afde9392ef06",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54610",
+					"10.65.0.27:54610",
+					"172.17.0.1:54610",
+					"172.19.0.1:54610",
+					"172.20.0.1:54610"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:37:41.390120527Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8827036839117342,
+				"StableID":   "nMJuhoHnvB21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39797e802b7386b1d31a3e41868cb839253bf42e890780fcbeb0b49dd173b71b",
+				"DiscoKey":   "discokey:edd5ad5b621524ca14daf6d747f5cf642a0251bab9350616fae7d4b2bef8e05d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60247",
+					"10.65.0.27:60247",
+					"172.17.0.1:60247",
+					"172.19.0.1:60247",
+					"172.20.0.1:60247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:37:41.942163092Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8141071774583320,
+				"StableID":   "n7Juvj97a621CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e74dd76a4e22d83bf4261a2b588e875b56fe5b6dbaca2f68ea46fd0b84e1ae4a",
+				"DiscoKey":   "discokey:7e855e1e38be6802169f86756732a4e634c8428c6278d8e2706a1cfd1f7b5519",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59005",
+					"10.65.0.27:59005",
+					"172.17.0.1:59005",
+					"172.19.0.1:59005",
+					"172.20.0.1:59005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:37:42.474600685Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5304552881871009,
+				"StableID":   "nr7paLcSRi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d07705deb92539fa65d6491efd8403079d3b4d5cc3e566c60ee63041c6694c56",
+				"KeyExpiry":  "2026-11-08T18:37:43Z",
+				"DiscoKey":   "discokey:c7bdd1f4bd27742d655d84885ebca45fae1699a27c62854d52a51b886bcd0809",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52750",
+					"10.65.0.27:52750",
+					"172.17.0.1:52750",
+					"172.19.0.1:52750",
+					"172.20.0.1:52750"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:37:43.035658911Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         836729174456001,
+				"StableID":   "nc6LuUTxX711CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:693b108a5e9eeb52115428e562f7f74c37493593b94c728acce685dcde8a4d1f",
+				"KeyExpiry":  "2026-11-08T18:37:43Z",
+				"DiscoKey":   "discokey:122df4cae32fd9051e1cb82d12fa0b5976d6fc08bca7a9578039f6a8f17d4473",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41543",
+					"10.65.0.27:41543",
+					"172.17.0.1:41543",
+					"172.19.0.1:41543",
+					"172.20.0.1:41543"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:37:43.545425462Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5637802766590294,
+				"StableID":   "njXdj5XN2m11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:0f0ea4cd2f2d165a8d5a53d0afc97a72aedd40f3860dfe3afb97b2824e7c346c",
+				"KeyExpiry":  "2026-11-08T18:37:44Z",
+				"DiscoKey":   "discokey:47ba49b59a4773afc63f967e8366189646cbb514c7f78c4082e689c808f25c1c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36835",
+					"10.65.0.27:36835",
+					"172.17.0.1:36835",
+					"172.19.0.1:36835",
+					"172.20.0.1:36835"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:37:44.098696814Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8847665348978334": {
+				"ID":          8847665348978334,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5637802766590294,
+				"StableID":   "njXdj5XN2m11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:0f0ea4cd2f2d165a8d5a53d0afc97a72aedd40f3860dfe3afb97b2824e7c346c",
+				"KeyExpiry":  "2026-11-08T18:37:44Z",
+				"DiscoKey":   "discokey:47ba49b59a4773afc63f967e8366189646cbb514c7f78c4082e689c808f25c1c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36835",
+					"10.65.0.27:36835",
+					"172.17.0.1:36835",
+					"172.19.0.1:36835",
+					"172.20.0.1:36835"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:37:44.098696814Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0f0ea4cd2f2d165a8d5a53d0afc97a72aedd40f3860dfe3afb97b2824e7c346c",
+			"MachineKey": "mkey:3f9a7eb3fdce1bce43a17d1fa2be7c5e881609d93677aedf3e67f38a0223350d",
+			"Peers": [{
+				"ID":         3032338836974926,
+				"StableID":   "nb3VGAQMgQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:415dfc49c2cdd22b4ee5c9444b40b9d173f13320a1bbdf47b88bac930a76011f",
+				"DiscoKey":   "discokey:d3fd9dc986c22532577a697618dc297abf55d21579ac5d887e34b39d5b64a712",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50934",
+					"10.65.0.27:50934",
+					"172.17.0.1:50934",
+					"172.19.0.1:50934",
+					"172.20.0.1:50934"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:37:36.527847188Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         483420215403172,
+				"StableID":   "nhyL3Wdwm411CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4f1fcefdb43d82fdeddf5503e061dffd4122d55cd3eec6ca317941724f52c70",
+				"DiscoKey":   "discokey:38addf17508e4861f9d415b70ebc74a3c49f8c1746f81c4b1a416ace2e5ef90d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48914",
+					"10.65.0.27:48914",
+					"172.17.0.1:48914",
+					"172.19.0.1:48914",
+					"172.20.0.1:48914"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:37:37.06700217Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8575151217514602,
+				"StableID":   "nX5EsXghx921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e3b2a07ed6475d0b70733fb407a0c8ec2d8af0a1d8a23de1896f461f2811768",
+				"DiscoKey":   "discokey:305e6eb0226dbba6910267248e3a87b86462f9b8ee25296394f9b5291fc91c43",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:55965",
+					"10.65.0.27:55965",
+					"172.17.0.1:55965",
+					"172.19.0.1:55965",
+					"172.20.0.1:55965"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:37:37.615376734Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3578705368049755,
+				"StableID":   "n2W5gFXowU11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:660dab33bf89014cf23c67b239aa0e68cd5aa89c66e483c9361cdc51ade7a701",
+				"DiscoKey":   "discokey:f52bf7decac9f3ab3223cd859d8664392a01af30e317df3b2537741f1cc9f016",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59630",
+					"10.65.0.27:59630",
+					"172.17.0.1:59630",
+					"172.19.0.1:59630",
+					"172.20.0.1:59630"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:37:38.177923205Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3158116736132111,
+				"StableID":   "nvGYWYNKfR11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c089d30fb931d7e0580346a34861ae49c36886330a75690b2899bd1bcf26a5d",
+				"DiscoKey":   "discokey:d0f943290fc69ee802e188615a45abe22c20c704f335515796c50c6bc8ad3660",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34185",
+					"10.65.0.27:34185",
+					"172.17.0.1:34185",
+					"172.19.0.1:34185",
+					"172.20.0.1:34185"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:37:38.742389702Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8847665348978334,
+				"StableID":   "nuUzUcA86C21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d9b139b700df726eac3f6d6b4f42b088ad283e5c407f8fe88837a9f0eb12642",
+				"DiscoKey":   "discokey:5ebed62f2c96b50b9352f877d3760de2e360c7b3a201aa51df46a2d81707f76e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37961",
+					"10.65.0.27:37961",
+					"172.17.0.1:37961",
+					"172.19.0.1:37961",
+					"172.20.0.1:37961"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:37:39.236293154Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8562652946575123,
+				"StableID":   "nWzkTeN3s921CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b2a1f0a1408ca116aa151dff4cfa996a9247463bccef46b2bb532ef025e9043",
+				"DiscoKey":   "discokey:06e142bebb2432b73209b00868463b8752ca52f96c2e4f64bed9057474079406",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51168",
+					"10.65.0.27:51168",
+					"172.17.0.1:51168",
+					"172.19.0.1:51168",
+					"172.20.0.1:51168"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:37:39.758894372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         607415585710634,
+				"StableID":   "nKZ7K6n6k511CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:036e558a08c07f847e31b8198be0f8abae0a7346a0614a4ab101c146c7234d5d",
+				"DiscoKey":   "discokey:f632a9f5c307d515f77750e3e531bab317f6256dd82a19d82c67138f94e3ea08",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54833",
+					"10.65.0.27:54833",
+					"172.17.0.1:54833",
+					"172.19.0.1:54833",
+					"172.20.0.1:54833"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:37:40.304509818Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6530190670267758,
+				"StableID":   "nMAmw43Yzs11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:52439a2bbdb733188c897535b8166b599f411b9c2bec6ca78d39927fbab1af78",
+				"DiscoKey":   "discokey:4a301a93ff07289e15db3f29ed011930d10919f24543d77f7e14728f9ed76c42",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52354",
+					"10.65.0.27:52354",
+					"172.17.0.1:52354",
+					"172.19.0.1:52354",
+					"172.20.0.1:52354"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:37:40.849942447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6548654885639027,
+				"StableID":   "nJSsRS4u8t11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08de7a4d3b30589a7e43615c59dcfcc246504897a3393507b19ebd6e8249b255",
+				"DiscoKey":   "discokey:23781cdacfb92c0606733c03a30cfeb7b520a229b8d16f06fae1afde9392ef06",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54610",
+					"10.65.0.27:54610",
+					"172.17.0.1:54610",
+					"172.19.0.1:54610",
+					"172.20.0.1:54610"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:37:41.390120527Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8827036839117342,
+				"StableID":   "nMJuhoHnvB21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39797e802b7386b1d31a3e41868cb839253bf42e890780fcbeb0b49dd173b71b",
+				"DiscoKey":   "discokey:edd5ad5b621524ca14daf6d747f5cf642a0251bab9350616fae7d4b2bef8e05d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60247",
+					"10.65.0.27:60247",
+					"172.17.0.1:60247",
+					"172.19.0.1:60247",
+					"172.20.0.1:60247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:37:41.942163092Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8141071774583320,
+				"StableID":   "n7Juvj97a621CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e74dd76a4e22d83bf4261a2b588e875b56fe5b6dbaca2f68ea46fd0b84e1ae4a",
+				"DiscoKey":   "discokey:7e855e1e38be6802169f86756732a4e634c8428c6278d8e2706a1cfd1f7b5519",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59005",
+					"10.65.0.27:59005",
+					"172.17.0.1:59005",
+					"172.19.0.1:59005",
+					"172.20.0.1:59005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:37:42.474600685Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5304552881871009,
+				"StableID":   "nr7paLcSRi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d07705deb92539fa65d6491efd8403079d3b4d5cc3e566c60ee63041c6694c56",
+				"KeyExpiry":  "2026-11-08T18:37:43Z",
+				"DiscoKey":   "discokey:c7bdd1f4bd27742d655d84885ebca45fae1699a27c62854d52a51b886bcd0809",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52750",
+					"10.65.0.27:52750",
+					"172.17.0.1:52750",
+					"172.19.0.1:52750",
+					"172.20.0.1:52750"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:37:43.035658911Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         836729174456001,
+				"StableID":   "nc6LuUTxX711CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:693b108a5e9eeb52115428e562f7f74c37493593b94c728acce685dcde8a4d1f",
+				"KeyExpiry":  "2026-11-08T18:37:43Z",
+				"DiscoKey":   "discokey:122df4cae32fd9051e1cb82d12fa0b5976d6fc08bca7a9578039f6a8f17d4473",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41543",
+					"10.65.0.27:41543",
+					"172.17.0.1:41543",
+					"172.19.0.1:41543",
+					"172.20.0.1:41543"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:37:43.545425462Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8575151217514602,
+				"StableID":   "nX5EsXghx921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       8575151217514602,
+				"Key":        "nodekey:4e3b2a07ed6475d0b70733fb407a0c8ec2d8af0a1d8a23de1896f461f2811768",
+				"DiscoKey":   "discokey:305e6eb0226dbba6910267248e3a87b86462f9b8ee25296394f9b5291fc91c43",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:55965",
+					"10.65.0.27:55965",
+					"172.17.0.1:55965",
+					"172.19.0.1:55965",
+					"172.20.0.1:55965"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:37:37.615376734Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4e3b2a07ed6475d0b70733fb407a0c8ec2d8af0a1d8a23de1896f461f2811768",
+			"MachineKey": "mkey:5e1394e54136b269b431ada4eb3ce05c3c87d9bebc5a0b180a360b5838086b3d",
+			"Peers": [{
+				"ID":         3032338836974926,
+				"StableID":   "nb3VGAQMgQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:415dfc49c2cdd22b4ee5c9444b40b9d173f13320a1bbdf47b88bac930a76011f",
+				"DiscoKey":   "discokey:d3fd9dc986c22532577a697618dc297abf55d21579ac5d887e34b39d5b64a712",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50934",
+					"10.65.0.27:50934",
+					"172.17.0.1:50934",
+					"172.19.0.1:50934",
+					"172.20.0.1:50934"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:37:36.527847188Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         483420215403172,
+				"StableID":   "nhyL3Wdwm411CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4f1fcefdb43d82fdeddf5503e061dffd4122d55cd3eec6ca317941724f52c70",
+				"DiscoKey":   "discokey:38addf17508e4861f9d415b70ebc74a3c49f8c1746f81c4b1a416ace2e5ef90d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48914",
+					"10.65.0.27:48914",
+					"172.17.0.1:48914",
+					"172.19.0.1:48914",
+					"172.20.0.1:48914"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:37:37.06700217Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3578705368049755,
+				"StableID":   "n2W5gFXowU11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:660dab33bf89014cf23c67b239aa0e68cd5aa89c66e483c9361cdc51ade7a701",
+				"DiscoKey":   "discokey:f52bf7decac9f3ab3223cd859d8664392a01af30e317df3b2537741f1cc9f016",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59630",
+					"10.65.0.27:59630",
+					"172.17.0.1:59630",
+					"172.19.0.1:59630",
+					"172.20.0.1:59630"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:37:38.177923205Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3158116736132111,
+				"StableID":   "nvGYWYNKfR11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c089d30fb931d7e0580346a34861ae49c36886330a75690b2899bd1bcf26a5d",
+				"DiscoKey":   "discokey:d0f943290fc69ee802e188615a45abe22c20c704f335515796c50c6bc8ad3660",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34185",
+					"10.65.0.27:34185",
+					"172.17.0.1:34185",
+					"172.19.0.1:34185",
+					"172.20.0.1:34185"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:37:38.742389702Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8847665348978334,
+				"StableID":   "nuUzUcA86C21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d9b139b700df726eac3f6d6b4f42b088ad283e5c407f8fe88837a9f0eb12642",
+				"DiscoKey":   "discokey:5ebed62f2c96b50b9352f877d3760de2e360c7b3a201aa51df46a2d81707f76e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37961",
+					"10.65.0.27:37961",
+					"172.17.0.1:37961",
+					"172.19.0.1:37961",
+					"172.20.0.1:37961"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:37:39.236293154Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8562652946575123,
+				"StableID":   "nWzkTeN3s921CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b2a1f0a1408ca116aa151dff4cfa996a9247463bccef46b2bb532ef025e9043",
+				"DiscoKey":   "discokey:06e142bebb2432b73209b00868463b8752ca52f96c2e4f64bed9057474079406",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51168",
+					"10.65.0.27:51168",
+					"172.17.0.1:51168",
+					"172.19.0.1:51168",
+					"172.20.0.1:51168"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:37:39.758894372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         607415585710634,
+				"StableID":   "nKZ7K6n6k511CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:036e558a08c07f847e31b8198be0f8abae0a7346a0614a4ab101c146c7234d5d",
+				"DiscoKey":   "discokey:f632a9f5c307d515f77750e3e531bab317f6256dd82a19d82c67138f94e3ea08",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54833",
+					"10.65.0.27:54833",
+					"172.17.0.1:54833",
+					"172.19.0.1:54833",
+					"172.20.0.1:54833"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:37:40.304509818Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6530190670267758,
+				"StableID":   "nMAmw43Yzs11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:52439a2bbdb733188c897535b8166b599f411b9c2bec6ca78d39927fbab1af78",
+				"DiscoKey":   "discokey:4a301a93ff07289e15db3f29ed011930d10919f24543d77f7e14728f9ed76c42",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52354",
+					"10.65.0.27:52354",
+					"172.17.0.1:52354",
+					"172.19.0.1:52354",
+					"172.20.0.1:52354"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:37:40.849942447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6548654885639027,
+				"StableID":   "nJSsRS4u8t11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08de7a4d3b30589a7e43615c59dcfcc246504897a3393507b19ebd6e8249b255",
+				"DiscoKey":   "discokey:23781cdacfb92c0606733c03a30cfeb7b520a229b8d16f06fae1afde9392ef06",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54610",
+					"10.65.0.27:54610",
+					"172.17.0.1:54610",
+					"172.19.0.1:54610",
+					"172.20.0.1:54610"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:37:41.390120527Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8827036839117342,
+				"StableID":   "nMJuhoHnvB21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39797e802b7386b1d31a3e41868cb839253bf42e890780fcbeb0b49dd173b71b",
+				"DiscoKey":   "discokey:edd5ad5b621524ca14daf6d747f5cf642a0251bab9350616fae7d4b2bef8e05d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60247",
+					"10.65.0.27:60247",
+					"172.17.0.1:60247",
+					"172.19.0.1:60247",
+					"172.20.0.1:60247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:37:41.942163092Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8141071774583320,
+				"StableID":   "n7Juvj97a621CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e74dd76a4e22d83bf4261a2b588e875b56fe5b6dbaca2f68ea46fd0b84e1ae4a",
+				"DiscoKey":   "discokey:7e855e1e38be6802169f86756732a4e634c8428c6278d8e2706a1cfd1f7b5519",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59005",
+					"10.65.0.27:59005",
+					"172.17.0.1:59005",
+					"172.19.0.1:59005",
+					"172.20.0.1:59005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:37:42.474600685Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5304552881871009,
+				"StableID":   "nr7paLcSRi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d07705deb92539fa65d6491efd8403079d3b4d5cc3e566c60ee63041c6694c56",
+				"KeyExpiry":  "2026-11-08T18:37:43Z",
+				"DiscoKey":   "discokey:c7bdd1f4bd27742d655d84885ebca45fae1699a27c62854d52a51b886bcd0809",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52750",
+					"10.65.0.27:52750",
+					"172.17.0.1:52750",
+					"172.19.0.1:52750",
+					"172.20.0.1:52750"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:37:43.035658911Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         836729174456001,
+				"StableID":   "nc6LuUTxX711CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:693b108a5e9eeb52115428e562f7f74c37493593b94c728acce685dcde8a4d1f",
+				"KeyExpiry":  "2026-11-08T18:37:43Z",
+				"DiscoKey":   "discokey:122df4cae32fd9051e1cb82d12fa0b5976d6fc08bca7a9578039f6a8f17d4473",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41543",
+					"10.65.0.27:41543",
+					"172.17.0.1:41543",
+					"172.19.0.1:41543",
+					"172.20.0.1:41543"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:37:43.545425462Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5637802766590294,
+				"StableID":   "njXdj5XN2m11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:0f0ea4cd2f2d165a8d5a53d0afc97a72aedd40f3860dfe3afb97b2824e7c346c",
+				"KeyExpiry":  "2026-11-08T18:37:44Z",
+				"DiscoKey":   "discokey:47ba49b59a4773afc63f967e8366189646cbb514c7f78c4082e689c808f25c1c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36835",
+					"10.65.0.27:36835",
+					"172.17.0.1:36835",
+					"172.19.0.1:36835",
+					"172.20.0.1:36835"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:37:44.098696814Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8575151217514602": {
+				"ID":          8575151217514602,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         607415585710634,
+				"StableID":   "nKZ7K6n6k511CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       607415585710634,
+				"Key":        "nodekey:036e558a08c07f847e31b8198be0f8abae0a7346a0614a4ab101c146c7234d5d",
+				"DiscoKey":   "discokey:f632a9f5c307d515f77750e3e531bab317f6256dd82a19d82c67138f94e3ea08",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54833",
+					"10.65.0.27:54833",
+					"172.17.0.1:54833",
+					"172.19.0.1:54833",
+					"172.20.0.1:54833"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:37:40.304509818Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:036e558a08c07f847e31b8198be0f8abae0a7346a0614a4ab101c146c7234d5d",
+			"MachineKey": "mkey:dd0e9129ec3e8b47f121987c0aaf449a843a1f643aeec13514acbc0a9aca135c",
+			"Peers": [{
+				"ID":         3032338836974926,
+				"StableID":   "nb3VGAQMgQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:415dfc49c2cdd22b4ee5c9444b40b9d173f13320a1bbdf47b88bac930a76011f",
+				"DiscoKey":   "discokey:d3fd9dc986c22532577a697618dc297abf55d21579ac5d887e34b39d5b64a712",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50934",
+					"10.65.0.27:50934",
+					"172.17.0.1:50934",
+					"172.19.0.1:50934",
+					"172.20.0.1:50934"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:37:36.527847188Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         483420215403172,
+				"StableID":   "nhyL3Wdwm411CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4f1fcefdb43d82fdeddf5503e061dffd4122d55cd3eec6ca317941724f52c70",
+				"DiscoKey":   "discokey:38addf17508e4861f9d415b70ebc74a3c49f8c1746f81c4b1a416ace2e5ef90d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48914",
+					"10.65.0.27:48914",
+					"172.17.0.1:48914",
+					"172.19.0.1:48914",
+					"172.20.0.1:48914"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:37:37.06700217Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8575151217514602,
+				"StableID":   "nX5EsXghx921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e3b2a07ed6475d0b70733fb407a0c8ec2d8af0a1d8a23de1896f461f2811768",
+				"DiscoKey":   "discokey:305e6eb0226dbba6910267248e3a87b86462f9b8ee25296394f9b5291fc91c43",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:55965",
+					"10.65.0.27:55965",
+					"172.17.0.1:55965",
+					"172.19.0.1:55965",
+					"172.20.0.1:55965"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:37:37.615376734Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3578705368049755,
+				"StableID":   "n2W5gFXowU11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:660dab33bf89014cf23c67b239aa0e68cd5aa89c66e483c9361cdc51ade7a701",
+				"DiscoKey":   "discokey:f52bf7decac9f3ab3223cd859d8664392a01af30e317df3b2537741f1cc9f016",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59630",
+					"10.65.0.27:59630",
+					"172.17.0.1:59630",
+					"172.19.0.1:59630",
+					"172.20.0.1:59630"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:37:38.177923205Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3158116736132111,
+				"StableID":   "nvGYWYNKfR11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c089d30fb931d7e0580346a34861ae49c36886330a75690b2899bd1bcf26a5d",
+				"DiscoKey":   "discokey:d0f943290fc69ee802e188615a45abe22c20c704f335515796c50c6bc8ad3660",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34185",
+					"10.65.0.27:34185",
+					"172.17.0.1:34185",
+					"172.19.0.1:34185",
+					"172.20.0.1:34185"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:37:38.742389702Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8847665348978334,
+				"StableID":   "nuUzUcA86C21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d9b139b700df726eac3f6d6b4f42b088ad283e5c407f8fe88837a9f0eb12642",
+				"DiscoKey":   "discokey:5ebed62f2c96b50b9352f877d3760de2e360c7b3a201aa51df46a2d81707f76e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37961",
+					"10.65.0.27:37961",
+					"172.17.0.1:37961",
+					"172.19.0.1:37961",
+					"172.20.0.1:37961"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:37:39.236293154Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8562652946575123,
+				"StableID":   "nWzkTeN3s921CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b2a1f0a1408ca116aa151dff4cfa996a9247463bccef46b2bb532ef025e9043",
+				"DiscoKey":   "discokey:06e142bebb2432b73209b00868463b8752ca52f96c2e4f64bed9057474079406",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51168",
+					"10.65.0.27:51168",
+					"172.17.0.1:51168",
+					"172.19.0.1:51168",
+					"172.20.0.1:51168"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:37:39.758894372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6530190670267758,
+				"StableID":   "nMAmw43Yzs11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:52439a2bbdb733188c897535b8166b599f411b9c2bec6ca78d39927fbab1af78",
+				"DiscoKey":   "discokey:4a301a93ff07289e15db3f29ed011930d10919f24543d77f7e14728f9ed76c42",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52354",
+					"10.65.0.27:52354",
+					"172.17.0.1:52354",
+					"172.19.0.1:52354",
+					"172.20.0.1:52354"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:37:40.849942447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6548654885639027,
+				"StableID":   "nJSsRS4u8t11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08de7a4d3b30589a7e43615c59dcfcc246504897a3393507b19ebd6e8249b255",
+				"DiscoKey":   "discokey:23781cdacfb92c0606733c03a30cfeb7b520a229b8d16f06fae1afde9392ef06",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54610",
+					"10.65.0.27:54610",
+					"172.17.0.1:54610",
+					"172.19.0.1:54610",
+					"172.20.0.1:54610"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:37:41.390120527Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8827036839117342,
+				"StableID":   "nMJuhoHnvB21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39797e802b7386b1d31a3e41868cb839253bf42e890780fcbeb0b49dd173b71b",
+				"DiscoKey":   "discokey:edd5ad5b621524ca14daf6d747f5cf642a0251bab9350616fae7d4b2bef8e05d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60247",
+					"10.65.0.27:60247",
+					"172.17.0.1:60247",
+					"172.19.0.1:60247",
+					"172.20.0.1:60247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:37:41.942163092Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8141071774583320,
+				"StableID":   "n7Juvj97a621CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e74dd76a4e22d83bf4261a2b588e875b56fe5b6dbaca2f68ea46fd0b84e1ae4a",
+				"DiscoKey":   "discokey:7e855e1e38be6802169f86756732a4e634c8428c6278d8e2706a1cfd1f7b5519",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59005",
+					"10.65.0.27:59005",
+					"172.17.0.1:59005",
+					"172.19.0.1:59005",
+					"172.20.0.1:59005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:37:42.474600685Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5304552881871009,
+				"StableID":   "nr7paLcSRi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d07705deb92539fa65d6491efd8403079d3b4d5cc3e566c60ee63041c6694c56",
+				"KeyExpiry":  "2026-11-08T18:37:43Z",
+				"DiscoKey":   "discokey:c7bdd1f4bd27742d655d84885ebca45fae1699a27c62854d52a51b886bcd0809",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52750",
+					"10.65.0.27:52750",
+					"172.17.0.1:52750",
+					"172.19.0.1:52750",
+					"172.20.0.1:52750"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:37:43.035658911Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         836729174456001,
+				"StableID":   "nc6LuUTxX711CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:693b108a5e9eeb52115428e562f7f74c37493593b94c728acce685dcde8a4d1f",
+				"KeyExpiry":  "2026-11-08T18:37:43Z",
+				"DiscoKey":   "discokey:122df4cae32fd9051e1cb82d12fa0b5976d6fc08bca7a9578039f6a8f17d4473",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41543",
+					"10.65.0.27:41543",
+					"172.17.0.1:41543",
+					"172.19.0.1:41543",
+					"172.20.0.1:41543"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:37:43.545425462Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5637802766590294,
+				"StableID":   "njXdj5XN2m11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:0f0ea4cd2f2d165a8d5a53d0afc97a72aedd40f3860dfe3afb97b2824e7c346c",
+				"KeyExpiry":  "2026-11-08T18:37:44Z",
+				"DiscoKey":   "discokey:47ba49b59a4773afc63f967e8366189646cbb514c7f78c4082e689c808f25c1c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36835",
+					"10.65.0.27:36835",
+					"172.17.0.1:36835",
+					"172.19.0.1:36835",
+					"172.20.0.1:36835"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:37:44.098696814Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "607415585710634": {
+				"ID":          607415585710634,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5304552881871009,
+				"StableID":   "nr7paLcSRi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d07705deb92539fa65d6491efd8403079d3b4d5cc3e566c60ee63041c6694c56",
+				"KeyExpiry":  "2026-11-08T18:37:43Z",
+				"DiscoKey":   "discokey:c7bdd1f4bd27742d655d84885ebca45fae1699a27c62854d52a51b886bcd0809",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52750",
+					"10.65.0.27:52750",
+					"172.17.0.1:52750",
+					"172.19.0.1:52750",
+					"172.20.0.1:52750"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:37:43.035658911Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d07705deb92539fa65d6491efd8403079d3b4d5cc3e566c60ee63041c6694c56",
+			"MachineKey": "mkey:ed4016bf655caab912d3b1196a3530dec0c8a61a30e072b92d0b6d20f054bc1d",
+			"Peers": [{
+				"ID":         3032338836974926,
+				"StableID":   "nb3VGAQMgQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:415dfc49c2cdd22b4ee5c9444b40b9d173f13320a1bbdf47b88bac930a76011f",
+				"DiscoKey":   "discokey:d3fd9dc986c22532577a697618dc297abf55d21579ac5d887e34b39d5b64a712",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50934",
+					"10.65.0.27:50934",
+					"172.17.0.1:50934",
+					"172.19.0.1:50934",
+					"172.20.0.1:50934"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:37:36.527847188Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         483420215403172,
+				"StableID":   "nhyL3Wdwm411CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4f1fcefdb43d82fdeddf5503e061dffd4122d55cd3eec6ca317941724f52c70",
+				"DiscoKey":   "discokey:38addf17508e4861f9d415b70ebc74a3c49f8c1746f81c4b1a416ace2e5ef90d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48914",
+					"10.65.0.27:48914",
+					"172.17.0.1:48914",
+					"172.19.0.1:48914",
+					"172.20.0.1:48914"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:37:37.06700217Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8575151217514602,
+				"StableID":   "nX5EsXghx921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e3b2a07ed6475d0b70733fb407a0c8ec2d8af0a1d8a23de1896f461f2811768",
+				"DiscoKey":   "discokey:305e6eb0226dbba6910267248e3a87b86462f9b8ee25296394f9b5291fc91c43",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:55965",
+					"10.65.0.27:55965",
+					"172.17.0.1:55965",
+					"172.19.0.1:55965",
+					"172.20.0.1:55965"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:37:37.615376734Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3578705368049755,
+				"StableID":   "n2W5gFXowU11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:660dab33bf89014cf23c67b239aa0e68cd5aa89c66e483c9361cdc51ade7a701",
+				"DiscoKey":   "discokey:f52bf7decac9f3ab3223cd859d8664392a01af30e317df3b2537741f1cc9f016",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59630",
+					"10.65.0.27:59630",
+					"172.17.0.1:59630",
+					"172.19.0.1:59630",
+					"172.20.0.1:59630"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:37:38.177923205Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3158116736132111,
+				"StableID":   "nvGYWYNKfR11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c089d30fb931d7e0580346a34861ae49c36886330a75690b2899bd1bcf26a5d",
+				"DiscoKey":   "discokey:d0f943290fc69ee802e188615a45abe22c20c704f335515796c50c6bc8ad3660",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34185",
+					"10.65.0.27:34185",
+					"172.17.0.1:34185",
+					"172.19.0.1:34185",
+					"172.20.0.1:34185"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:37:38.742389702Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8847665348978334,
+				"StableID":   "nuUzUcA86C21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d9b139b700df726eac3f6d6b4f42b088ad283e5c407f8fe88837a9f0eb12642",
+				"DiscoKey":   "discokey:5ebed62f2c96b50b9352f877d3760de2e360c7b3a201aa51df46a2d81707f76e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37961",
+					"10.65.0.27:37961",
+					"172.17.0.1:37961",
+					"172.19.0.1:37961",
+					"172.20.0.1:37961"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:37:39.236293154Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8562652946575123,
+				"StableID":   "nWzkTeN3s921CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b2a1f0a1408ca116aa151dff4cfa996a9247463bccef46b2bb532ef025e9043",
+				"DiscoKey":   "discokey:06e142bebb2432b73209b00868463b8752ca52f96c2e4f64bed9057474079406",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51168",
+					"10.65.0.27:51168",
+					"172.17.0.1:51168",
+					"172.19.0.1:51168",
+					"172.20.0.1:51168"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:37:39.758894372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         607415585710634,
+				"StableID":   "nKZ7K6n6k511CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:036e558a08c07f847e31b8198be0f8abae0a7346a0614a4ab101c146c7234d5d",
+				"DiscoKey":   "discokey:f632a9f5c307d515f77750e3e531bab317f6256dd82a19d82c67138f94e3ea08",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54833",
+					"10.65.0.27:54833",
+					"172.17.0.1:54833",
+					"172.19.0.1:54833",
+					"172.20.0.1:54833"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:37:40.304509818Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6530190670267758,
+				"StableID":   "nMAmw43Yzs11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:52439a2bbdb733188c897535b8166b599f411b9c2bec6ca78d39927fbab1af78",
+				"DiscoKey":   "discokey:4a301a93ff07289e15db3f29ed011930d10919f24543d77f7e14728f9ed76c42",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52354",
+					"10.65.0.27:52354",
+					"172.17.0.1:52354",
+					"172.19.0.1:52354",
+					"172.20.0.1:52354"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:37:40.849942447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6548654885639027,
+				"StableID":   "nJSsRS4u8t11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08de7a4d3b30589a7e43615c59dcfcc246504897a3393507b19ebd6e8249b255",
+				"DiscoKey":   "discokey:23781cdacfb92c0606733c03a30cfeb7b520a229b8d16f06fae1afde9392ef06",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54610",
+					"10.65.0.27:54610",
+					"172.17.0.1:54610",
+					"172.19.0.1:54610",
+					"172.20.0.1:54610"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:37:41.390120527Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8827036839117342,
+				"StableID":   "nMJuhoHnvB21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39797e802b7386b1d31a3e41868cb839253bf42e890780fcbeb0b49dd173b71b",
+				"DiscoKey":   "discokey:edd5ad5b621524ca14daf6d747f5cf642a0251bab9350616fae7d4b2bef8e05d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60247",
+					"10.65.0.27:60247",
+					"172.17.0.1:60247",
+					"172.19.0.1:60247",
+					"172.20.0.1:60247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:37:41.942163092Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8141071774583320,
+				"StableID":   "n7Juvj97a621CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e74dd76a4e22d83bf4261a2b588e875b56fe5b6dbaca2f68ea46fd0b84e1ae4a",
+				"DiscoKey":   "discokey:7e855e1e38be6802169f86756732a4e634c8428c6278d8e2706a1cfd1f7b5519",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59005",
+					"10.65.0.27:59005",
+					"172.17.0.1:59005",
+					"172.19.0.1:59005",
+					"172.20.0.1:59005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:37:42.474600685Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         836729174456001,
+				"StableID":   "nc6LuUTxX711CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:693b108a5e9eeb52115428e562f7f74c37493593b94c728acce685dcde8a4d1f",
+				"KeyExpiry":  "2026-11-08T18:37:43Z",
+				"DiscoKey":   "discokey:122df4cae32fd9051e1cb82d12fa0b5976d6fc08bca7a9578039f6a8f17d4473",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41543",
+					"10.65.0.27:41543",
+					"172.17.0.1:41543",
+					"172.19.0.1:41543",
+					"172.20.0.1:41543"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:37:43.545425462Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5637802766590294,
+				"StableID":   "njXdj5XN2m11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:0f0ea4cd2f2d165a8d5a53d0afc97a72aedd40f3860dfe3afb97b2824e7c346c",
+				"KeyExpiry":  "2026-11-08T18:37:44Z",
+				"DiscoKey":   "discokey:47ba49b59a4773afc63f967e8366189646cbb514c7f78c4082e689c808f25c1c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36835",
+					"10.65.0.27:36835",
+					"172.17.0.1:36835",
+					"172.19.0.1:36835",
+					"172.20.0.1:36835"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:37:44.098696814Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8827036839117342,
+				"StableID":   "nMJuhoHnvB21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       8827036839117342,
+				"Key":        "nodekey:39797e802b7386b1d31a3e41868cb839253bf42e890780fcbeb0b49dd173b71b",
+				"DiscoKey":   "discokey:edd5ad5b621524ca14daf6d747f5cf642a0251bab9350616fae7d4b2bef8e05d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60247",
+					"10.65.0.27:60247",
+					"172.17.0.1:60247",
+					"172.19.0.1:60247",
+					"172.20.0.1:60247"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:37:41.942163092Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:39797e802b7386b1d31a3e41868cb839253bf42e890780fcbeb0b49dd173b71b",
+			"MachineKey": "mkey:c3003905cb4ad7e2a75aa07c4ca9de24babe6b409dfce0a23f291b51a51cd741",
+			"Peers": [{
+				"ID":         3032338836974926,
+				"StableID":   "nb3VGAQMgQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:415dfc49c2cdd22b4ee5c9444b40b9d173f13320a1bbdf47b88bac930a76011f",
+				"DiscoKey":   "discokey:d3fd9dc986c22532577a697618dc297abf55d21579ac5d887e34b39d5b64a712",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50934",
+					"10.65.0.27:50934",
+					"172.17.0.1:50934",
+					"172.19.0.1:50934",
+					"172.20.0.1:50934"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:37:36.527847188Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         483420215403172,
+				"StableID":   "nhyL3Wdwm411CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4f1fcefdb43d82fdeddf5503e061dffd4122d55cd3eec6ca317941724f52c70",
+				"DiscoKey":   "discokey:38addf17508e4861f9d415b70ebc74a3c49f8c1746f81c4b1a416ace2e5ef90d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48914",
+					"10.65.0.27:48914",
+					"172.17.0.1:48914",
+					"172.19.0.1:48914",
+					"172.20.0.1:48914"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:37:37.06700217Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8575151217514602,
+				"StableID":   "nX5EsXghx921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e3b2a07ed6475d0b70733fb407a0c8ec2d8af0a1d8a23de1896f461f2811768",
+				"DiscoKey":   "discokey:305e6eb0226dbba6910267248e3a87b86462f9b8ee25296394f9b5291fc91c43",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:55965",
+					"10.65.0.27:55965",
+					"172.17.0.1:55965",
+					"172.19.0.1:55965",
+					"172.20.0.1:55965"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:37:37.615376734Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3578705368049755,
+				"StableID":   "n2W5gFXowU11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:660dab33bf89014cf23c67b239aa0e68cd5aa89c66e483c9361cdc51ade7a701",
+				"DiscoKey":   "discokey:f52bf7decac9f3ab3223cd859d8664392a01af30e317df3b2537741f1cc9f016",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59630",
+					"10.65.0.27:59630",
+					"172.17.0.1:59630",
+					"172.19.0.1:59630",
+					"172.20.0.1:59630"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:37:38.177923205Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3158116736132111,
+				"StableID":   "nvGYWYNKfR11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c089d30fb931d7e0580346a34861ae49c36886330a75690b2899bd1bcf26a5d",
+				"DiscoKey":   "discokey:d0f943290fc69ee802e188615a45abe22c20c704f335515796c50c6bc8ad3660",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34185",
+					"10.65.0.27:34185",
+					"172.17.0.1:34185",
+					"172.19.0.1:34185",
+					"172.20.0.1:34185"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:37:38.742389702Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8847665348978334,
+				"StableID":   "nuUzUcA86C21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d9b139b700df726eac3f6d6b4f42b088ad283e5c407f8fe88837a9f0eb12642",
+				"DiscoKey":   "discokey:5ebed62f2c96b50b9352f877d3760de2e360c7b3a201aa51df46a2d81707f76e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37961",
+					"10.65.0.27:37961",
+					"172.17.0.1:37961",
+					"172.19.0.1:37961",
+					"172.20.0.1:37961"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:37:39.236293154Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8562652946575123,
+				"StableID":   "nWzkTeN3s921CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b2a1f0a1408ca116aa151dff4cfa996a9247463bccef46b2bb532ef025e9043",
+				"DiscoKey":   "discokey:06e142bebb2432b73209b00868463b8752ca52f96c2e4f64bed9057474079406",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51168",
+					"10.65.0.27:51168",
+					"172.17.0.1:51168",
+					"172.19.0.1:51168",
+					"172.20.0.1:51168"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:37:39.758894372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         607415585710634,
+				"StableID":   "nKZ7K6n6k511CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:036e558a08c07f847e31b8198be0f8abae0a7346a0614a4ab101c146c7234d5d",
+				"DiscoKey":   "discokey:f632a9f5c307d515f77750e3e531bab317f6256dd82a19d82c67138f94e3ea08",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54833",
+					"10.65.0.27:54833",
+					"172.17.0.1:54833",
+					"172.19.0.1:54833",
+					"172.20.0.1:54833"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:37:40.304509818Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6530190670267758,
+				"StableID":   "nMAmw43Yzs11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:52439a2bbdb733188c897535b8166b599f411b9c2bec6ca78d39927fbab1af78",
+				"DiscoKey":   "discokey:4a301a93ff07289e15db3f29ed011930d10919f24543d77f7e14728f9ed76c42",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52354",
+					"10.65.0.27:52354",
+					"172.17.0.1:52354",
+					"172.19.0.1:52354",
+					"172.20.0.1:52354"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:37:40.849942447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6548654885639027,
+				"StableID":   "nJSsRS4u8t11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08de7a4d3b30589a7e43615c59dcfcc246504897a3393507b19ebd6e8249b255",
+				"DiscoKey":   "discokey:23781cdacfb92c0606733c03a30cfeb7b520a229b8d16f06fae1afde9392ef06",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54610",
+					"10.65.0.27:54610",
+					"172.17.0.1:54610",
+					"172.19.0.1:54610",
+					"172.20.0.1:54610"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:37:41.390120527Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8141071774583320,
+				"StableID":   "n7Juvj97a621CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e74dd76a4e22d83bf4261a2b588e875b56fe5b6dbaca2f68ea46fd0b84e1ae4a",
+				"DiscoKey":   "discokey:7e855e1e38be6802169f86756732a4e634c8428c6278d8e2706a1cfd1f7b5519",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59005",
+					"10.65.0.27:59005",
+					"172.17.0.1:59005",
+					"172.19.0.1:59005",
+					"172.20.0.1:59005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:37:42.474600685Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5304552881871009,
+				"StableID":   "nr7paLcSRi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d07705deb92539fa65d6491efd8403079d3b4d5cc3e566c60ee63041c6694c56",
+				"KeyExpiry":  "2026-11-08T18:37:43Z",
+				"DiscoKey":   "discokey:c7bdd1f4bd27742d655d84885ebca45fae1699a27c62854d52a51b886bcd0809",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52750",
+					"10.65.0.27:52750",
+					"172.17.0.1:52750",
+					"172.19.0.1:52750",
+					"172.20.0.1:52750"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:37:43.035658911Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         836729174456001,
+				"StableID":   "nc6LuUTxX711CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:693b108a5e9eeb52115428e562f7f74c37493593b94c728acce685dcde8a4d1f",
+				"KeyExpiry":  "2026-11-08T18:37:43Z",
+				"DiscoKey":   "discokey:122df4cae32fd9051e1cb82d12fa0b5976d6fc08bca7a9578039f6a8f17d4473",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41543",
+					"10.65.0.27:41543",
+					"172.17.0.1:41543",
+					"172.19.0.1:41543",
+					"172.20.0.1:41543"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:37:43.545425462Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5637802766590294,
+				"StableID":   "njXdj5XN2m11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:0f0ea4cd2f2d165a8d5a53d0afc97a72aedd40f3860dfe3afb97b2824e7c346c",
+				"KeyExpiry":  "2026-11-08T18:37:44Z",
+				"DiscoKey":   "discokey:47ba49b59a4773afc63f967e8366189646cbb514c7f78c4082e689c808f25c1c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36835",
+					"10.65.0.27:36835",
+					"172.17.0.1:36835",
+					"172.19.0.1:36835",
+					"172.20.0.1:36835"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:37:44.098696814Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8827036839117342": {
+				"ID":          8827036839117342,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         483420215403172,
+				"StableID":   "nhyL3Wdwm411CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       483420215403172,
+				"Key":        "nodekey:b4f1fcefdb43d82fdeddf5503e061dffd4122d55cd3eec6ca317941724f52c70",
+				"DiscoKey":   "discokey:38addf17508e4861f9d415b70ebc74a3c49f8c1746f81c4b1a416ace2e5ef90d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48914",
+					"10.65.0.27:48914",
+					"172.17.0.1:48914",
+					"172.19.0.1:48914",
+					"172.20.0.1:48914"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:37:37.06700217Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b4f1fcefdb43d82fdeddf5503e061dffd4122d55cd3eec6ca317941724f52c70",
+			"MachineKey": "mkey:f4603f42a3c23263a65edba9b839266f5988801e43b81f1d338c54ebef329645",
+			"Peers": [{
+				"ID":         3032338836974926,
+				"StableID":   "nb3VGAQMgQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:415dfc49c2cdd22b4ee5c9444b40b9d173f13320a1bbdf47b88bac930a76011f",
+				"DiscoKey":   "discokey:d3fd9dc986c22532577a697618dc297abf55d21579ac5d887e34b39d5b64a712",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50934",
+					"10.65.0.27:50934",
+					"172.17.0.1:50934",
+					"172.19.0.1:50934",
+					"172.20.0.1:50934"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:37:36.527847188Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8575151217514602,
+				"StableID":   "nX5EsXghx921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e3b2a07ed6475d0b70733fb407a0c8ec2d8af0a1d8a23de1896f461f2811768",
+				"DiscoKey":   "discokey:305e6eb0226dbba6910267248e3a87b86462f9b8ee25296394f9b5291fc91c43",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:55965",
+					"10.65.0.27:55965",
+					"172.17.0.1:55965",
+					"172.19.0.1:55965",
+					"172.20.0.1:55965"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:37:37.615376734Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3578705368049755,
+				"StableID":   "n2W5gFXowU11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:660dab33bf89014cf23c67b239aa0e68cd5aa89c66e483c9361cdc51ade7a701",
+				"DiscoKey":   "discokey:f52bf7decac9f3ab3223cd859d8664392a01af30e317df3b2537741f1cc9f016",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59630",
+					"10.65.0.27:59630",
+					"172.17.0.1:59630",
+					"172.19.0.1:59630",
+					"172.20.0.1:59630"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:37:38.177923205Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3158116736132111,
+				"StableID":   "nvGYWYNKfR11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c089d30fb931d7e0580346a34861ae49c36886330a75690b2899bd1bcf26a5d",
+				"DiscoKey":   "discokey:d0f943290fc69ee802e188615a45abe22c20c704f335515796c50c6bc8ad3660",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34185",
+					"10.65.0.27:34185",
+					"172.17.0.1:34185",
+					"172.19.0.1:34185",
+					"172.20.0.1:34185"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:37:38.742389702Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8847665348978334,
+				"StableID":   "nuUzUcA86C21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d9b139b700df726eac3f6d6b4f42b088ad283e5c407f8fe88837a9f0eb12642",
+				"DiscoKey":   "discokey:5ebed62f2c96b50b9352f877d3760de2e360c7b3a201aa51df46a2d81707f76e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37961",
+					"10.65.0.27:37961",
+					"172.17.0.1:37961",
+					"172.19.0.1:37961",
+					"172.20.0.1:37961"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:37:39.236293154Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8562652946575123,
+				"StableID":   "nWzkTeN3s921CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b2a1f0a1408ca116aa151dff4cfa996a9247463bccef46b2bb532ef025e9043",
+				"DiscoKey":   "discokey:06e142bebb2432b73209b00868463b8752ca52f96c2e4f64bed9057474079406",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51168",
+					"10.65.0.27:51168",
+					"172.17.0.1:51168",
+					"172.19.0.1:51168",
+					"172.20.0.1:51168"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:37:39.758894372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         607415585710634,
+				"StableID":   "nKZ7K6n6k511CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:036e558a08c07f847e31b8198be0f8abae0a7346a0614a4ab101c146c7234d5d",
+				"DiscoKey":   "discokey:f632a9f5c307d515f77750e3e531bab317f6256dd82a19d82c67138f94e3ea08",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54833",
+					"10.65.0.27:54833",
+					"172.17.0.1:54833",
+					"172.19.0.1:54833",
+					"172.20.0.1:54833"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:37:40.304509818Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6530190670267758,
+				"StableID":   "nMAmw43Yzs11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:52439a2bbdb733188c897535b8166b599f411b9c2bec6ca78d39927fbab1af78",
+				"DiscoKey":   "discokey:4a301a93ff07289e15db3f29ed011930d10919f24543d77f7e14728f9ed76c42",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52354",
+					"10.65.0.27:52354",
+					"172.17.0.1:52354",
+					"172.19.0.1:52354",
+					"172.20.0.1:52354"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:37:40.849942447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6548654885639027,
+				"StableID":   "nJSsRS4u8t11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08de7a4d3b30589a7e43615c59dcfcc246504897a3393507b19ebd6e8249b255",
+				"DiscoKey":   "discokey:23781cdacfb92c0606733c03a30cfeb7b520a229b8d16f06fae1afde9392ef06",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54610",
+					"10.65.0.27:54610",
+					"172.17.0.1:54610",
+					"172.19.0.1:54610",
+					"172.20.0.1:54610"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:37:41.390120527Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8827036839117342,
+				"StableID":   "nMJuhoHnvB21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39797e802b7386b1d31a3e41868cb839253bf42e890780fcbeb0b49dd173b71b",
+				"DiscoKey":   "discokey:edd5ad5b621524ca14daf6d747f5cf642a0251bab9350616fae7d4b2bef8e05d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60247",
+					"10.65.0.27:60247",
+					"172.17.0.1:60247",
+					"172.19.0.1:60247",
+					"172.20.0.1:60247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:37:41.942163092Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8141071774583320,
+				"StableID":   "n7Juvj97a621CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e74dd76a4e22d83bf4261a2b588e875b56fe5b6dbaca2f68ea46fd0b84e1ae4a",
+				"DiscoKey":   "discokey:7e855e1e38be6802169f86756732a4e634c8428c6278d8e2706a1cfd1f7b5519",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59005",
+					"10.65.0.27:59005",
+					"172.17.0.1:59005",
+					"172.19.0.1:59005",
+					"172.20.0.1:59005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:37:42.474600685Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5304552881871009,
+				"StableID":   "nr7paLcSRi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d07705deb92539fa65d6491efd8403079d3b4d5cc3e566c60ee63041c6694c56",
+				"KeyExpiry":  "2026-11-08T18:37:43Z",
+				"DiscoKey":   "discokey:c7bdd1f4bd27742d655d84885ebca45fae1699a27c62854d52a51b886bcd0809",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52750",
+					"10.65.0.27:52750",
+					"172.17.0.1:52750",
+					"172.19.0.1:52750",
+					"172.20.0.1:52750"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:37:43.035658911Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         836729174456001,
+				"StableID":   "nc6LuUTxX711CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:693b108a5e9eeb52115428e562f7f74c37493593b94c728acce685dcde8a4d1f",
+				"KeyExpiry":  "2026-11-08T18:37:43Z",
+				"DiscoKey":   "discokey:122df4cae32fd9051e1cb82d12fa0b5976d6fc08bca7a9578039f6a8f17d4473",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41543",
+					"10.65.0.27:41543",
+					"172.17.0.1:41543",
+					"172.19.0.1:41543",
+					"172.20.0.1:41543"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:37:43.545425462Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5637802766590294,
+				"StableID":   "njXdj5XN2m11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:0f0ea4cd2f2d165a8d5a53d0afc97a72aedd40f3860dfe3afb97b2824e7c346c",
+				"KeyExpiry":  "2026-11-08T18:37:44Z",
+				"DiscoKey":   "discokey:47ba49b59a4773afc63f967e8366189646cbb514c7f78c4082e689c808f25c1c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36835",
+					"10.65.0.27:36835",
+					"172.17.0.1:36835",
+					"172.19.0.1:36835",
+					"172.20.0.1:36835"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:37:44.098696814Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "483420215403172": {
+				"ID":          483420215403172,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3032338836974926,
+				"StableID":   "nb3VGAQMgQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       3032338836974926,
+				"Key":        "nodekey:415dfc49c2cdd22b4ee5c9444b40b9d173f13320a1bbdf47b88bac930a76011f",
+				"DiscoKey":   "discokey:d3fd9dc986c22532577a697618dc297abf55d21579ac5d887e34b39d5b64a712",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50934",
+					"10.65.0.27:50934",
+					"172.17.0.1:50934",
+					"172.19.0.1:50934",
+					"172.20.0.1:50934"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:37:36.527847188Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:415dfc49c2cdd22b4ee5c9444b40b9d173f13320a1bbdf47b88bac930a76011f",
+			"MachineKey": "mkey:bfbda5f9237c64031feaff4d61ec94587a27dfbe501371a4473aef705c70ca20",
+			"Peers": [{
+				"ID":         483420215403172,
+				"StableID":   "nhyL3Wdwm411CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4f1fcefdb43d82fdeddf5503e061dffd4122d55cd3eec6ca317941724f52c70",
+				"DiscoKey":   "discokey:38addf17508e4861f9d415b70ebc74a3c49f8c1746f81c4b1a416ace2e5ef90d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48914",
+					"10.65.0.27:48914",
+					"172.17.0.1:48914",
+					"172.19.0.1:48914",
+					"172.20.0.1:48914"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:37:37.06700217Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8575151217514602,
+				"StableID":   "nX5EsXghx921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e3b2a07ed6475d0b70733fb407a0c8ec2d8af0a1d8a23de1896f461f2811768",
+				"DiscoKey":   "discokey:305e6eb0226dbba6910267248e3a87b86462f9b8ee25296394f9b5291fc91c43",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:55965",
+					"10.65.0.27:55965",
+					"172.17.0.1:55965",
+					"172.19.0.1:55965",
+					"172.20.0.1:55965"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:37:37.615376734Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3578705368049755,
+				"StableID":   "n2W5gFXowU11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:660dab33bf89014cf23c67b239aa0e68cd5aa89c66e483c9361cdc51ade7a701",
+				"DiscoKey":   "discokey:f52bf7decac9f3ab3223cd859d8664392a01af30e317df3b2537741f1cc9f016",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59630",
+					"10.65.0.27:59630",
+					"172.17.0.1:59630",
+					"172.19.0.1:59630",
+					"172.20.0.1:59630"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:37:38.177923205Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3158116736132111,
+				"StableID":   "nvGYWYNKfR11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c089d30fb931d7e0580346a34861ae49c36886330a75690b2899bd1bcf26a5d",
+				"DiscoKey":   "discokey:d0f943290fc69ee802e188615a45abe22c20c704f335515796c50c6bc8ad3660",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34185",
+					"10.65.0.27:34185",
+					"172.17.0.1:34185",
+					"172.19.0.1:34185",
+					"172.20.0.1:34185"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:37:38.742389702Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8847665348978334,
+				"StableID":   "nuUzUcA86C21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d9b139b700df726eac3f6d6b4f42b088ad283e5c407f8fe88837a9f0eb12642",
+				"DiscoKey":   "discokey:5ebed62f2c96b50b9352f877d3760de2e360c7b3a201aa51df46a2d81707f76e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37961",
+					"10.65.0.27:37961",
+					"172.17.0.1:37961",
+					"172.19.0.1:37961",
+					"172.20.0.1:37961"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:37:39.236293154Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8562652946575123,
+				"StableID":   "nWzkTeN3s921CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b2a1f0a1408ca116aa151dff4cfa996a9247463bccef46b2bb532ef025e9043",
+				"DiscoKey":   "discokey:06e142bebb2432b73209b00868463b8752ca52f96c2e4f64bed9057474079406",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51168",
+					"10.65.0.27:51168",
+					"172.17.0.1:51168",
+					"172.19.0.1:51168",
+					"172.20.0.1:51168"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:37:39.758894372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         607415585710634,
+				"StableID":   "nKZ7K6n6k511CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:036e558a08c07f847e31b8198be0f8abae0a7346a0614a4ab101c146c7234d5d",
+				"DiscoKey":   "discokey:f632a9f5c307d515f77750e3e531bab317f6256dd82a19d82c67138f94e3ea08",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54833",
+					"10.65.0.27:54833",
+					"172.17.0.1:54833",
+					"172.19.0.1:54833",
+					"172.20.0.1:54833"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:37:40.304509818Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6530190670267758,
+				"StableID":   "nMAmw43Yzs11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:52439a2bbdb733188c897535b8166b599f411b9c2bec6ca78d39927fbab1af78",
+				"DiscoKey":   "discokey:4a301a93ff07289e15db3f29ed011930d10919f24543d77f7e14728f9ed76c42",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52354",
+					"10.65.0.27:52354",
+					"172.17.0.1:52354",
+					"172.19.0.1:52354",
+					"172.20.0.1:52354"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:37:40.849942447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6548654885639027,
+				"StableID":   "nJSsRS4u8t11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08de7a4d3b30589a7e43615c59dcfcc246504897a3393507b19ebd6e8249b255",
+				"DiscoKey":   "discokey:23781cdacfb92c0606733c03a30cfeb7b520a229b8d16f06fae1afde9392ef06",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54610",
+					"10.65.0.27:54610",
+					"172.17.0.1:54610",
+					"172.19.0.1:54610",
+					"172.20.0.1:54610"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:37:41.390120527Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8827036839117342,
+				"StableID":   "nMJuhoHnvB21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39797e802b7386b1d31a3e41868cb839253bf42e890780fcbeb0b49dd173b71b",
+				"DiscoKey":   "discokey:edd5ad5b621524ca14daf6d747f5cf642a0251bab9350616fae7d4b2bef8e05d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60247",
+					"10.65.0.27:60247",
+					"172.17.0.1:60247",
+					"172.19.0.1:60247",
+					"172.20.0.1:60247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:37:41.942163092Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8141071774583320,
+				"StableID":   "n7Juvj97a621CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e74dd76a4e22d83bf4261a2b588e875b56fe5b6dbaca2f68ea46fd0b84e1ae4a",
+				"DiscoKey":   "discokey:7e855e1e38be6802169f86756732a4e634c8428c6278d8e2706a1cfd1f7b5519",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59005",
+					"10.65.0.27:59005",
+					"172.17.0.1:59005",
+					"172.19.0.1:59005",
+					"172.20.0.1:59005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:37:42.474600685Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5304552881871009,
+				"StableID":   "nr7paLcSRi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d07705deb92539fa65d6491efd8403079d3b4d5cc3e566c60ee63041c6694c56",
+				"KeyExpiry":  "2026-11-08T18:37:43Z",
+				"DiscoKey":   "discokey:c7bdd1f4bd27742d655d84885ebca45fae1699a27c62854d52a51b886bcd0809",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52750",
+					"10.65.0.27:52750",
+					"172.17.0.1:52750",
+					"172.19.0.1:52750",
+					"172.20.0.1:52750"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:37:43.035658911Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         836729174456001,
+				"StableID":   "nc6LuUTxX711CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:693b108a5e9eeb52115428e562f7f74c37493593b94c728acce685dcde8a4d1f",
+				"KeyExpiry":  "2026-11-08T18:37:43Z",
+				"DiscoKey":   "discokey:122df4cae32fd9051e1cb82d12fa0b5976d6fc08bca7a9578039f6a8f17d4473",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41543",
+					"10.65.0.27:41543",
+					"172.17.0.1:41543",
+					"172.19.0.1:41543",
+					"172.20.0.1:41543"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:37:43.545425462Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5637802766590294,
+				"StableID":   "njXdj5XN2m11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:0f0ea4cd2f2d165a8d5a53d0afc97a72aedd40f3860dfe3afb97b2824e7c346c",
+				"KeyExpiry":  "2026-11-08T18:37:44Z",
+				"DiscoKey":   "discokey:47ba49b59a4773afc63f967e8366189646cbb514c7f78c4082e689c808f25c1c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36835",
+					"10.65.0.27:36835",
+					"172.17.0.1:36835",
+					"172.19.0.1:36835",
+					"172.20.0.1:36835"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:37:44.098696814Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3032338836974926": {
+				"ID":          3032338836974926,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3158116736132111,
+				"StableID":   "nvGYWYNKfR11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       3158116736132111,
+				"Key":        "nodekey:1c089d30fb931d7e0580346a34861ae49c36886330a75690b2899bd1bcf26a5d",
+				"DiscoKey":   "discokey:d0f943290fc69ee802e188615a45abe22c20c704f335515796c50c6bc8ad3660",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34185",
+					"10.65.0.27:34185",
+					"172.17.0.1:34185",
+					"172.19.0.1:34185",
+					"172.20.0.1:34185"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:37:38.742389702Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1c089d30fb931d7e0580346a34861ae49c36886330a75690b2899bd1bcf26a5d",
+			"MachineKey": "mkey:2279fd5d917b0eaa3d920cff8c5ae800566106f9029b73499254329c72992c68",
+			"Peers": [{
+				"ID":         3032338836974926,
+				"StableID":   "nb3VGAQMgQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:415dfc49c2cdd22b4ee5c9444b40b9d173f13320a1bbdf47b88bac930a76011f",
+				"DiscoKey":   "discokey:d3fd9dc986c22532577a697618dc297abf55d21579ac5d887e34b39d5b64a712",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50934",
+					"10.65.0.27:50934",
+					"172.17.0.1:50934",
+					"172.19.0.1:50934",
+					"172.20.0.1:50934"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:37:36.527847188Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         483420215403172,
+				"StableID":   "nhyL3Wdwm411CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4f1fcefdb43d82fdeddf5503e061dffd4122d55cd3eec6ca317941724f52c70",
+				"DiscoKey":   "discokey:38addf17508e4861f9d415b70ebc74a3c49f8c1746f81c4b1a416ace2e5ef90d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48914",
+					"10.65.0.27:48914",
+					"172.17.0.1:48914",
+					"172.19.0.1:48914",
+					"172.20.0.1:48914"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:37:37.06700217Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8575151217514602,
+				"StableID":   "nX5EsXghx921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e3b2a07ed6475d0b70733fb407a0c8ec2d8af0a1d8a23de1896f461f2811768",
+				"DiscoKey":   "discokey:305e6eb0226dbba6910267248e3a87b86462f9b8ee25296394f9b5291fc91c43",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:55965",
+					"10.65.0.27:55965",
+					"172.17.0.1:55965",
+					"172.19.0.1:55965",
+					"172.20.0.1:55965"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:37:37.615376734Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3578705368049755,
+				"StableID":   "n2W5gFXowU11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:660dab33bf89014cf23c67b239aa0e68cd5aa89c66e483c9361cdc51ade7a701",
+				"DiscoKey":   "discokey:f52bf7decac9f3ab3223cd859d8664392a01af30e317df3b2537741f1cc9f016",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59630",
+					"10.65.0.27:59630",
+					"172.17.0.1:59630",
+					"172.19.0.1:59630",
+					"172.20.0.1:59630"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:37:38.177923205Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8847665348978334,
+				"StableID":   "nuUzUcA86C21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d9b139b700df726eac3f6d6b4f42b088ad283e5c407f8fe88837a9f0eb12642",
+				"DiscoKey":   "discokey:5ebed62f2c96b50b9352f877d3760de2e360c7b3a201aa51df46a2d81707f76e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37961",
+					"10.65.0.27:37961",
+					"172.17.0.1:37961",
+					"172.19.0.1:37961",
+					"172.20.0.1:37961"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:37:39.236293154Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8562652946575123,
+				"StableID":   "nWzkTeN3s921CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b2a1f0a1408ca116aa151dff4cfa996a9247463bccef46b2bb532ef025e9043",
+				"DiscoKey":   "discokey:06e142bebb2432b73209b00868463b8752ca52f96c2e4f64bed9057474079406",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51168",
+					"10.65.0.27:51168",
+					"172.17.0.1:51168",
+					"172.19.0.1:51168",
+					"172.20.0.1:51168"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:37:39.758894372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         607415585710634,
+				"StableID":   "nKZ7K6n6k511CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:036e558a08c07f847e31b8198be0f8abae0a7346a0614a4ab101c146c7234d5d",
+				"DiscoKey":   "discokey:f632a9f5c307d515f77750e3e531bab317f6256dd82a19d82c67138f94e3ea08",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54833",
+					"10.65.0.27:54833",
+					"172.17.0.1:54833",
+					"172.19.0.1:54833",
+					"172.20.0.1:54833"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:37:40.304509818Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6530190670267758,
+				"StableID":   "nMAmw43Yzs11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:52439a2bbdb733188c897535b8166b599f411b9c2bec6ca78d39927fbab1af78",
+				"DiscoKey":   "discokey:4a301a93ff07289e15db3f29ed011930d10919f24543d77f7e14728f9ed76c42",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52354",
+					"10.65.0.27:52354",
+					"172.17.0.1:52354",
+					"172.19.0.1:52354",
+					"172.20.0.1:52354"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:37:40.849942447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6548654885639027,
+				"StableID":   "nJSsRS4u8t11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08de7a4d3b30589a7e43615c59dcfcc246504897a3393507b19ebd6e8249b255",
+				"DiscoKey":   "discokey:23781cdacfb92c0606733c03a30cfeb7b520a229b8d16f06fae1afde9392ef06",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54610",
+					"10.65.0.27:54610",
+					"172.17.0.1:54610",
+					"172.19.0.1:54610",
+					"172.20.0.1:54610"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:37:41.390120527Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8827036839117342,
+				"StableID":   "nMJuhoHnvB21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39797e802b7386b1d31a3e41868cb839253bf42e890780fcbeb0b49dd173b71b",
+				"DiscoKey":   "discokey:edd5ad5b621524ca14daf6d747f5cf642a0251bab9350616fae7d4b2bef8e05d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60247",
+					"10.65.0.27:60247",
+					"172.17.0.1:60247",
+					"172.19.0.1:60247",
+					"172.20.0.1:60247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:37:41.942163092Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8141071774583320,
+				"StableID":   "n7Juvj97a621CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e74dd76a4e22d83bf4261a2b588e875b56fe5b6dbaca2f68ea46fd0b84e1ae4a",
+				"DiscoKey":   "discokey:7e855e1e38be6802169f86756732a4e634c8428c6278d8e2706a1cfd1f7b5519",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59005",
+					"10.65.0.27:59005",
+					"172.17.0.1:59005",
+					"172.19.0.1:59005",
+					"172.20.0.1:59005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:37:42.474600685Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5304552881871009,
+				"StableID":   "nr7paLcSRi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d07705deb92539fa65d6491efd8403079d3b4d5cc3e566c60ee63041c6694c56",
+				"KeyExpiry":  "2026-11-08T18:37:43Z",
+				"DiscoKey":   "discokey:c7bdd1f4bd27742d655d84885ebca45fae1699a27c62854d52a51b886bcd0809",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52750",
+					"10.65.0.27:52750",
+					"172.17.0.1:52750",
+					"172.19.0.1:52750",
+					"172.20.0.1:52750"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:37:43.035658911Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         836729174456001,
+				"StableID":   "nc6LuUTxX711CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:693b108a5e9eeb52115428e562f7f74c37493593b94c728acce685dcde8a4d1f",
+				"KeyExpiry":  "2026-11-08T18:37:43Z",
+				"DiscoKey":   "discokey:122df4cae32fd9051e1cb82d12fa0b5976d6fc08bca7a9578039f6a8f17d4473",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41543",
+					"10.65.0.27:41543",
+					"172.17.0.1:41543",
+					"172.19.0.1:41543",
+					"172.20.0.1:41543"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:37:43.545425462Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5637802766590294,
+				"StableID":   "njXdj5XN2m11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:0f0ea4cd2f2d165a8d5a53d0afc97a72aedd40f3860dfe3afb97b2824e7c346c",
+				"KeyExpiry":  "2026-11-08T18:37:44Z",
+				"DiscoKey":   "discokey:47ba49b59a4773afc63f967e8366189646cbb514c7f78c4082e689c808f25c1c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36835",
+					"10.65.0.27:36835",
+					"172.17.0.1:36835",
+					"172.19.0.1:36835",
+					"172.20.0.1:36835"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:37:44.098696814Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3158116736132111": {
+				"ID":          3158116736132111,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3578705368049755,
+				"StableID":   "n2W5gFXowU11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       3578705368049755,
+				"Key":        "nodekey:660dab33bf89014cf23c67b239aa0e68cd5aa89c66e483c9361cdc51ade7a701",
+				"DiscoKey":   "discokey:f52bf7decac9f3ab3223cd859d8664392a01af30e317df3b2537741f1cc9f016",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59630",
+					"10.65.0.27:59630",
+					"172.17.0.1:59630",
+					"172.19.0.1:59630",
+					"172.20.0.1:59630"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:37:38.177923205Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:660dab33bf89014cf23c67b239aa0e68cd5aa89c66e483c9361cdc51ade7a701",
+			"MachineKey": "mkey:3d5c47397daa5f7a3532b82d82fcd0d063ff35dd2e9dff2bee57377b9b14290f",
+			"Peers": [{
+				"ID":         3032338836974926,
+				"StableID":   "nb3VGAQMgQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:415dfc49c2cdd22b4ee5c9444b40b9d173f13320a1bbdf47b88bac930a76011f",
+				"DiscoKey":   "discokey:d3fd9dc986c22532577a697618dc297abf55d21579ac5d887e34b39d5b64a712",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50934",
+					"10.65.0.27:50934",
+					"172.17.0.1:50934",
+					"172.19.0.1:50934",
+					"172.20.0.1:50934"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:37:36.527847188Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         483420215403172,
+				"StableID":   "nhyL3Wdwm411CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4f1fcefdb43d82fdeddf5503e061dffd4122d55cd3eec6ca317941724f52c70",
+				"DiscoKey":   "discokey:38addf17508e4861f9d415b70ebc74a3c49f8c1746f81c4b1a416ace2e5ef90d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48914",
+					"10.65.0.27:48914",
+					"172.17.0.1:48914",
+					"172.19.0.1:48914",
+					"172.20.0.1:48914"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:37:37.06700217Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8575151217514602,
+				"StableID":   "nX5EsXghx921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e3b2a07ed6475d0b70733fb407a0c8ec2d8af0a1d8a23de1896f461f2811768",
+				"DiscoKey":   "discokey:305e6eb0226dbba6910267248e3a87b86462f9b8ee25296394f9b5291fc91c43",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:55965",
+					"10.65.0.27:55965",
+					"172.17.0.1:55965",
+					"172.19.0.1:55965",
+					"172.20.0.1:55965"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:37:37.615376734Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3158116736132111,
+				"StableID":   "nvGYWYNKfR11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c089d30fb931d7e0580346a34861ae49c36886330a75690b2899bd1bcf26a5d",
+				"DiscoKey":   "discokey:d0f943290fc69ee802e188615a45abe22c20c704f335515796c50c6bc8ad3660",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34185",
+					"10.65.0.27:34185",
+					"172.17.0.1:34185",
+					"172.19.0.1:34185",
+					"172.20.0.1:34185"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:37:38.742389702Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8847665348978334,
+				"StableID":   "nuUzUcA86C21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d9b139b700df726eac3f6d6b4f42b088ad283e5c407f8fe88837a9f0eb12642",
+				"DiscoKey":   "discokey:5ebed62f2c96b50b9352f877d3760de2e360c7b3a201aa51df46a2d81707f76e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37961",
+					"10.65.0.27:37961",
+					"172.17.0.1:37961",
+					"172.19.0.1:37961",
+					"172.20.0.1:37961"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:37:39.236293154Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8562652946575123,
+				"StableID":   "nWzkTeN3s921CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b2a1f0a1408ca116aa151dff4cfa996a9247463bccef46b2bb532ef025e9043",
+				"DiscoKey":   "discokey:06e142bebb2432b73209b00868463b8752ca52f96c2e4f64bed9057474079406",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51168",
+					"10.65.0.27:51168",
+					"172.17.0.1:51168",
+					"172.19.0.1:51168",
+					"172.20.0.1:51168"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:37:39.758894372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         607415585710634,
+				"StableID":   "nKZ7K6n6k511CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:036e558a08c07f847e31b8198be0f8abae0a7346a0614a4ab101c146c7234d5d",
+				"DiscoKey":   "discokey:f632a9f5c307d515f77750e3e531bab317f6256dd82a19d82c67138f94e3ea08",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54833",
+					"10.65.0.27:54833",
+					"172.17.0.1:54833",
+					"172.19.0.1:54833",
+					"172.20.0.1:54833"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:37:40.304509818Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6530190670267758,
+				"StableID":   "nMAmw43Yzs11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:52439a2bbdb733188c897535b8166b599f411b9c2bec6ca78d39927fbab1af78",
+				"DiscoKey":   "discokey:4a301a93ff07289e15db3f29ed011930d10919f24543d77f7e14728f9ed76c42",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52354",
+					"10.65.0.27:52354",
+					"172.17.0.1:52354",
+					"172.19.0.1:52354",
+					"172.20.0.1:52354"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:37:40.849942447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6548654885639027,
+				"StableID":   "nJSsRS4u8t11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08de7a4d3b30589a7e43615c59dcfcc246504897a3393507b19ebd6e8249b255",
+				"DiscoKey":   "discokey:23781cdacfb92c0606733c03a30cfeb7b520a229b8d16f06fae1afde9392ef06",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54610",
+					"10.65.0.27:54610",
+					"172.17.0.1:54610",
+					"172.19.0.1:54610",
+					"172.20.0.1:54610"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:37:41.390120527Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8827036839117342,
+				"StableID":   "nMJuhoHnvB21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39797e802b7386b1d31a3e41868cb839253bf42e890780fcbeb0b49dd173b71b",
+				"DiscoKey":   "discokey:edd5ad5b621524ca14daf6d747f5cf642a0251bab9350616fae7d4b2bef8e05d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60247",
+					"10.65.0.27:60247",
+					"172.17.0.1:60247",
+					"172.19.0.1:60247",
+					"172.20.0.1:60247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:37:41.942163092Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8141071774583320,
+				"StableID":   "n7Juvj97a621CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e74dd76a4e22d83bf4261a2b588e875b56fe5b6dbaca2f68ea46fd0b84e1ae4a",
+				"DiscoKey":   "discokey:7e855e1e38be6802169f86756732a4e634c8428c6278d8e2706a1cfd1f7b5519",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59005",
+					"10.65.0.27:59005",
+					"172.17.0.1:59005",
+					"172.19.0.1:59005",
+					"172.20.0.1:59005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:37:42.474600685Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5304552881871009,
+				"StableID":   "nr7paLcSRi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d07705deb92539fa65d6491efd8403079d3b4d5cc3e566c60ee63041c6694c56",
+				"KeyExpiry":  "2026-11-08T18:37:43Z",
+				"DiscoKey":   "discokey:c7bdd1f4bd27742d655d84885ebca45fae1699a27c62854d52a51b886bcd0809",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52750",
+					"10.65.0.27:52750",
+					"172.17.0.1:52750",
+					"172.19.0.1:52750",
+					"172.20.0.1:52750"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:37:43.035658911Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         836729174456001,
+				"StableID":   "nc6LuUTxX711CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:693b108a5e9eeb52115428e562f7f74c37493593b94c728acce685dcde8a4d1f",
+				"KeyExpiry":  "2026-11-08T18:37:43Z",
+				"DiscoKey":   "discokey:122df4cae32fd9051e1cb82d12fa0b5976d6fc08bca7a9578039f6a8f17d4473",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41543",
+					"10.65.0.27:41543",
+					"172.17.0.1:41543",
+					"172.19.0.1:41543",
+					"172.20.0.1:41543"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:37:43.545425462Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5637802766590294,
+				"StableID":   "njXdj5XN2m11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:0f0ea4cd2f2d165a8d5a53d0afc97a72aedd40f3860dfe3afb97b2824e7c346c",
+				"KeyExpiry":  "2026-11-08T18:37:44Z",
+				"DiscoKey":   "discokey:47ba49b59a4773afc63f967e8366189646cbb514c7f78c4082e689c808f25c1c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36835",
+					"10.65.0.27:36835",
+					"172.17.0.1:36835",
+					"172.19.0.1:36835",
+					"172.20.0.1:36835"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:37:44.098696814Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3578705368049755": {
+				"ID":          3578705368049755,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8562652946575123,
+				"StableID":   "nWzkTeN3s921CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       8562652946575123,
+				"Key":        "nodekey:0b2a1f0a1408ca116aa151dff4cfa996a9247463bccef46b2bb532ef025e9043",
+				"DiscoKey":   "discokey:06e142bebb2432b73209b00868463b8752ca52f96c2e4f64bed9057474079406",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51168",
+					"10.65.0.27:51168",
+					"172.17.0.1:51168",
+					"172.19.0.1:51168",
+					"172.20.0.1:51168"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:37:39.758894372Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0b2a1f0a1408ca116aa151dff4cfa996a9247463bccef46b2bb532ef025e9043",
+			"MachineKey": "mkey:8d834058e90eb1116b6851dbb16962e97f911a08b96ee44167b78ba3ade5ba40",
+			"Peers": [{
+				"ID":         3032338836974926,
+				"StableID":   "nb3VGAQMgQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:415dfc49c2cdd22b4ee5c9444b40b9d173f13320a1bbdf47b88bac930a76011f",
+				"DiscoKey":   "discokey:d3fd9dc986c22532577a697618dc297abf55d21579ac5d887e34b39d5b64a712",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50934",
+					"10.65.0.27:50934",
+					"172.17.0.1:50934",
+					"172.19.0.1:50934",
+					"172.20.0.1:50934"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:37:36.527847188Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         483420215403172,
+				"StableID":   "nhyL3Wdwm411CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4f1fcefdb43d82fdeddf5503e061dffd4122d55cd3eec6ca317941724f52c70",
+				"DiscoKey":   "discokey:38addf17508e4861f9d415b70ebc74a3c49f8c1746f81c4b1a416ace2e5ef90d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48914",
+					"10.65.0.27:48914",
+					"172.17.0.1:48914",
+					"172.19.0.1:48914",
+					"172.20.0.1:48914"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:37:37.06700217Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8575151217514602,
+				"StableID":   "nX5EsXghx921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e3b2a07ed6475d0b70733fb407a0c8ec2d8af0a1d8a23de1896f461f2811768",
+				"DiscoKey":   "discokey:305e6eb0226dbba6910267248e3a87b86462f9b8ee25296394f9b5291fc91c43",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:55965",
+					"10.65.0.27:55965",
+					"172.17.0.1:55965",
+					"172.19.0.1:55965",
+					"172.20.0.1:55965"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:37:37.615376734Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3578705368049755,
+				"StableID":   "n2W5gFXowU11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:660dab33bf89014cf23c67b239aa0e68cd5aa89c66e483c9361cdc51ade7a701",
+				"DiscoKey":   "discokey:f52bf7decac9f3ab3223cd859d8664392a01af30e317df3b2537741f1cc9f016",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59630",
+					"10.65.0.27:59630",
+					"172.17.0.1:59630",
+					"172.19.0.1:59630",
+					"172.20.0.1:59630"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:37:38.177923205Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3158116736132111,
+				"StableID":   "nvGYWYNKfR11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c089d30fb931d7e0580346a34861ae49c36886330a75690b2899bd1bcf26a5d",
+				"DiscoKey":   "discokey:d0f943290fc69ee802e188615a45abe22c20c704f335515796c50c6bc8ad3660",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34185",
+					"10.65.0.27:34185",
+					"172.17.0.1:34185",
+					"172.19.0.1:34185",
+					"172.20.0.1:34185"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:37:38.742389702Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8847665348978334,
+				"StableID":   "nuUzUcA86C21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d9b139b700df726eac3f6d6b4f42b088ad283e5c407f8fe88837a9f0eb12642",
+				"DiscoKey":   "discokey:5ebed62f2c96b50b9352f877d3760de2e360c7b3a201aa51df46a2d81707f76e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37961",
+					"10.65.0.27:37961",
+					"172.17.0.1:37961",
+					"172.19.0.1:37961",
+					"172.20.0.1:37961"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:37:39.236293154Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         607415585710634,
+				"StableID":   "nKZ7K6n6k511CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:036e558a08c07f847e31b8198be0f8abae0a7346a0614a4ab101c146c7234d5d",
+				"DiscoKey":   "discokey:f632a9f5c307d515f77750e3e531bab317f6256dd82a19d82c67138f94e3ea08",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54833",
+					"10.65.0.27:54833",
+					"172.17.0.1:54833",
+					"172.19.0.1:54833",
+					"172.20.0.1:54833"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:37:40.304509818Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6530190670267758,
+				"StableID":   "nMAmw43Yzs11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:52439a2bbdb733188c897535b8166b599f411b9c2bec6ca78d39927fbab1af78",
+				"DiscoKey":   "discokey:4a301a93ff07289e15db3f29ed011930d10919f24543d77f7e14728f9ed76c42",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52354",
+					"10.65.0.27:52354",
+					"172.17.0.1:52354",
+					"172.19.0.1:52354",
+					"172.20.0.1:52354"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:37:40.849942447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6548654885639027,
+				"StableID":   "nJSsRS4u8t11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08de7a4d3b30589a7e43615c59dcfcc246504897a3393507b19ebd6e8249b255",
+				"DiscoKey":   "discokey:23781cdacfb92c0606733c03a30cfeb7b520a229b8d16f06fae1afde9392ef06",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54610",
+					"10.65.0.27:54610",
+					"172.17.0.1:54610",
+					"172.19.0.1:54610",
+					"172.20.0.1:54610"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:37:41.390120527Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8827036839117342,
+				"StableID":   "nMJuhoHnvB21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39797e802b7386b1d31a3e41868cb839253bf42e890780fcbeb0b49dd173b71b",
+				"DiscoKey":   "discokey:edd5ad5b621524ca14daf6d747f5cf642a0251bab9350616fae7d4b2bef8e05d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60247",
+					"10.65.0.27:60247",
+					"172.17.0.1:60247",
+					"172.19.0.1:60247",
+					"172.20.0.1:60247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:37:41.942163092Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8141071774583320,
+				"StableID":   "n7Juvj97a621CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e74dd76a4e22d83bf4261a2b588e875b56fe5b6dbaca2f68ea46fd0b84e1ae4a",
+				"DiscoKey":   "discokey:7e855e1e38be6802169f86756732a4e634c8428c6278d8e2706a1cfd1f7b5519",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59005",
+					"10.65.0.27:59005",
+					"172.17.0.1:59005",
+					"172.19.0.1:59005",
+					"172.20.0.1:59005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:37:42.474600685Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5304552881871009,
+				"StableID":   "nr7paLcSRi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d07705deb92539fa65d6491efd8403079d3b4d5cc3e566c60ee63041c6694c56",
+				"KeyExpiry":  "2026-11-08T18:37:43Z",
+				"DiscoKey":   "discokey:c7bdd1f4bd27742d655d84885ebca45fae1699a27c62854d52a51b886bcd0809",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52750",
+					"10.65.0.27:52750",
+					"172.17.0.1:52750",
+					"172.19.0.1:52750",
+					"172.20.0.1:52750"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:37:43.035658911Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         836729174456001,
+				"StableID":   "nc6LuUTxX711CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:693b108a5e9eeb52115428e562f7f74c37493593b94c728acce685dcde8a4d1f",
+				"KeyExpiry":  "2026-11-08T18:37:43Z",
+				"DiscoKey":   "discokey:122df4cae32fd9051e1cb82d12fa0b5976d6fc08bca7a9578039f6a8f17d4473",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41543",
+					"10.65.0.27:41543",
+					"172.17.0.1:41543",
+					"172.19.0.1:41543",
+					"172.20.0.1:41543"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:37:43.545425462Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5637802766590294,
+				"StableID":   "njXdj5XN2m11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:0f0ea4cd2f2d165a8d5a53d0afc97a72aedd40f3860dfe3afb97b2824e7c346c",
+				"KeyExpiry":  "2026-11-08T18:37:44Z",
+				"DiscoKey":   "discokey:47ba49b59a4773afc63f967e8366189646cbb514c7f78c4082e689c808f25c1c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36835",
+					"10.65.0.27:36835",
+					"172.17.0.1:36835",
+					"172.19.0.1:36835",
+					"172.20.0.1:36835"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:37:44.098696814Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8562652946575123": {
+				"ID":          8562652946575123,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6530190670267758,
+				"StableID":   "nMAmw43Yzs11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       6530190670267758,
+				"Key":        "nodekey:52439a2bbdb733188c897535b8166b599f411b9c2bec6ca78d39927fbab1af78",
+				"DiscoKey":   "discokey:4a301a93ff07289e15db3f29ed011930d10919f24543d77f7e14728f9ed76c42",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52354",
+					"10.65.0.27:52354",
+					"172.17.0.1:52354",
+					"172.19.0.1:52354",
+					"172.20.0.1:52354"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:37:40.849942447Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:52439a2bbdb733188c897535b8166b599f411b9c2bec6ca78d39927fbab1af78",
+			"MachineKey": "mkey:5fb6de3a0eecc6e0237fa290f46018473f286827721207181a93ff4ca0a7825d",
+			"Peers": [{
+				"ID":         3032338836974926,
+				"StableID":   "nb3VGAQMgQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:415dfc49c2cdd22b4ee5c9444b40b9d173f13320a1bbdf47b88bac930a76011f",
+				"DiscoKey":   "discokey:d3fd9dc986c22532577a697618dc297abf55d21579ac5d887e34b39d5b64a712",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50934",
+					"10.65.0.27:50934",
+					"172.17.0.1:50934",
+					"172.19.0.1:50934",
+					"172.20.0.1:50934"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:37:36.527847188Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         483420215403172,
+				"StableID":   "nhyL3Wdwm411CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4f1fcefdb43d82fdeddf5503e061dffd4122d55cd3eec6ca317941724f52c70",
+				"DiscoKey":   "discokey:38addf17508e4861f9d415b70ebc74a3c49f8c1746f81c4b1a416ace2e5ef90d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48914",
+					"10.65.0.27:48914",
+					"172.17.0.1:48914",
+					"172.19.0.1:48914",
+					"172.20.0.1:48914"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:37:37.06700217Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8575151217514602,
+				"StableID":   "nX5EsXghx921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e3b2a07ed6475d0b70733fb407a0c8ec2d8af0a1d8a23de1896f461f2811768",
+				"DiscoKey":   "discokey:305e6eb0226dbba6910267248e3a87b86462f9b8ee25296394f9b5291fc91c43",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:55965",
+					"10.65.0.27:55965",
+					"172.17.0.1:55965",
+					"172.19.0.1:55965",
+					"172.20.0.1:55965"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:37:37.615376734Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3578705368049755,
+				"StableID":   "n2W5gFXowU11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:660dab33bf89014cf23c67b239aa0e68cd5aa89c66e483c9361cdc51ade7a701",
+				"DiscoKey":   "discokey:f52bf7decac9f3ab3223cd859d8664392a01af30e317df3b2537741f1cc9f016",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59630",
+					"10.65.0.27:59630",
+					"172.17.0.1:59630",
+					"172.19.0.1:59630",
+					"172.20.0.1:59630"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:37:38.177923205Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3158116736132111,
+				"StableID":   "nvGYWYNKfR11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c089d30fb931d7e0580346a34861ae49c36886330a75690b2899bd1bcf26a5d",
+				"DiscoKey":   "discokey:d0f943290fc69ee802e188615a45abe22c20c704f335515796c50c6bc8ad3660",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34185",
+					"10.65.0.27:34185",
+					"172.17.0.1:34185",
+					"172.19.0.1:34185",
+					"172.20.0.1:34185"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:37:38.742389702Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8847665348978334,
+				"StableID":   "nuUzUcA86C21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d9b139b700df726eac3f6d6b4f42b088ad283e5c407f8fe88837a9f0eb12642",
+				"DiscoKey":   "discokey:5ebed62f2c96b50b9352f877d3760de2e360c7b3a201aa51df46a2d81707f76e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37961",
+					"10.65.0.27:37961",
+					"172.17.0.1:37961",
+					"172.19.0.1:37961",
+					"172.20.0.1:37961"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:37:39.236293154Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8562652946575123,
+				"StableID":   "nWzkTeN3s921CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b2a1f0a1408ca116aa151dff4cfa996a9247463bccef46b2bb532ef025e9043",
+				"DiscoKey":   "discokey:06e142bebb2432b73209b00868463b8752ca52f96c2e4f64bed9057474079406",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51168",
+					"10.65.0.27:51168",
+					"172.17.0.1:51168",
+					"172.19.0.1:51168",
+					"172.20.0.1:51168"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:37:39.758894372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         607415585710634,
+				"StableID":   "nKZ7K6n6k511CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:036e558a08c07f847e31b8198be0f8abae0a7346a0614a4ab101c146c7234d5d",
+				"DiscoKey":   "discokey:f632a9f5c307d515f77750e3e531bab317f6256dd82a19d82c67138f94e3ea08",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54833",
+					"10.65.0.27:54833",
+					"172.17.0.1:54833",
+					"172.19.0.1:54833",
+					"172.20.0.1:54833"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:37:40.304509818Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6548654885639027,
+				"StableID":   "nJSsRS4u8t11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08de7a4d3b30589a7e43615c59dcfcc246504897a3393507b19ebd6e8249b255",
+				"DiscoKey":   "discokey:23781cdacfb92c0606733c03a30cfeb7b520a229b8d16f06fae1afde9392ef06",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54610",
+					"10.65.0.27:54610",
+					"172.17.0.1:54610",
+					"172.19.0.1:54610",
+					"172.20.0.1:54610"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:37:41.390120527Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8827036839117342,
+				"StableID":   "nMJuhoHnvB21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39797e802b7386b1d31a3e41868cb839253bf42e890780fcbeb0b49dd173b71b",
+				"DiscoKey":   "discokey:edd5ad5b621524ca14daf6d747f5cf642a0251bab9350616fae7d4b2bef8e05d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60247",
+					"10.65.0.27:60247",
+					"172.17.0.1:60247",
+					"172.19.0.1:60247",
+					"172.20.0.1:60247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:37:41.942163092Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8141071774583320,
+				"StableID":   "n7Juvj97a621CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e74dd76a4e22d83bf4261a2b588e875b56fe5b6dbaca2f68ea46fd0b84e1ae4a",
+				"DiscoKey":   "discokey:7e855e1e38be6802169f86756732a4e634c8428c6278d8e2706a1cfd1f7b5519",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59005",
+					"10.65.0.27:59005",
+					"172.17.0.1:59005",
+					"172.19.0.1:59005",
+					"172.20.0.1:59005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:37:42.474600685Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5304552881871009,
+				"StableID":   "nr7paLcSRi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d07705deb92539fa65d6491efd8403079d3b4d5cc3e566c60ee63041c6694c56",
+				"KeyExpiry":  "2026-11-08T18:37:43Z",
+				"DiscoKey":   "discokey:c7bdd1f4bd27742d655d84885ebca45fae1699a27c62854d52a51b886bcd0809",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52750",
+					"10.65.0.27:52750",
+					"172.17.0.1:52750",
+					"172.19.0.1:52750",
+					"172.20.0.1:52750"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:37:43.035658911Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         836729174456001,
+				"StableID":   "nc6LuUTxX711CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:693b108a5e9eeb52115428e562f7f74c37493593b94c728acce685dcde8a4d1f",
+				"KeyExpiry":  "2026-11-08T18:37:43Z",
+				"DiscoKey":   "discokey:122df4cae32fd9051e1cb82d12fa0b5976d6fc08bca7a9578039f6a8f17d4473",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41543",
+					"10.65.0.27:41543",
+					"172.17.0.1:41543",
+					"172.19.0.1:41543",
+					"172.20.0.1:41543"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:37:43.545425462Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5637802766590294,
+				"StableID":   "njXdj5XN2m11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:0f0ea4cd2f2d165a8d5a53d0afc97a72aedd40f3860dfe3afb97b2824e7c346c",
+				"KeyExpiry":  "2026-11-08T18:37:44Z",
+				"DiscoKey":   "discokey:47ba49b59a4773afc63f967e8366189646cbb514c7f78c4082e689c808f25c1c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36835",
+					"10.65.0.27:36835",
+					"172.17.0.1:36835",
+					"172.19.0.1:36835",
+					"172.20.0.1:36835"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:37:44.098696814Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6530190670267758": {
+				"ID":          6530190670267758,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         836729174456001,
+				"StableID":   "nc6LuUTxX711CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:693b108a5e9eeb52115428e562f7f74c37493593b94c728acce685dcde8a4d1f",
+				"KeyExpiry":  "2026-11-08T18:37:43Z",
+				"DiscoKey":   "discokey:122df4cae32fd9051e1cb82d12fa0b5976d6fc08bca7a9578039f6a8f17d4473",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41543",
+					"10.65.0.27:41543",
+					"172.17.0.1:41543",
+					"172.19.0.1:41543",
+					"172.20.0.1:41543"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:37:43.545425462Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:693b108a5e9eeb52115428e562f7f74c37493593b94c728acce685dcde8a4d1f",
+			"MachineKey": "mkey:67edc5e25cbd812d68a755b83a40f48c0724e9501b47e35d82a387b1cbebc46b",
+			"Peers": [{
+				"ID":         3032338836974926,
+				"StableID":   "nb3VGAQMgQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:415dfc49c2cdd22b4ee5c9444b40b9d173f13320a1bbdf47b88bac930a76011f",
+				"DiscoKey":   "discokey:d3fd9dc986c22532577a697618dc297abf55d21579ac5d887e34b39d5b64a712",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50934",
+					"10.65.0.27:50934",
+					"172.17.0.1:50934",
+					"172.19.0.1:50934",
+					"172.20.0.1:50934"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:37:36.527847188Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         483420215403172,
+				"StableID":   "nhyL3Wdwm411CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4f1fcefdb43d82fdeddf5503e061dffd4122d55cd3eec6ca317941724f52c70",
+				"DiscoKey":   "discokey:38addf17508e4861f9d415b70ebc74a3c49f8c1746f81c4b1a416ace2e5ef90d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48914",
+					"10.65.0.27:48914",
+					"172.17.0.1:48914",
+					"172.19.0.1:48914",
+					"172.20.0.1:48914"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:37:37.06700217Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8575151217514602,
+				"StableID":   "nX5EsXghx921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e3b2a07ed6475d0b70733fb407a0c8ec2d8af0a1d8a23de1896f461f2811768",
+				"DiscoKey":   "discokey:305e6eb0226dbba6910267248e3a87b86462f9b8ee25296394f9b5291fc91c43",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:55965",
+					"10.65.0.27:55965",
+					"172.17.0.1:55965",
+					"172.19.0.1:55965",
+					"172.20.0.1:55965"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:37:37.615376734Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3578705368049755,
+				"StableID":   "n2W5gFXowU11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:660dab33bf89014cf23c67b239aa0e68cd5aa89c66e483c9361cdc51ade7a701",
+				"DiscoKey":   "discokey:f52bf7decac9f3ab3223cd859d8664392a01af30e317df3b2537741f1cc9f016",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59630",
+					"10.65.0.27:59630",
+					"172.17.0.1:59630",
+					"172.19.0.1:59630",
+					"172.20.0.1:59630"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:37:38.177923205Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3158116736132111,
+				"StableID":   "nvGYWYNKfR11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c089d30fb931d7e0580346a34861ae49c36886330a75690b2899bd1bcf26a5d",
+				"DiscoKey":   "discokey:d0f943290fc69ee802e188615a45abe22c20c704f335515796c50c6bc8ad3660",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34185",
+					"10.65.0.27:34185",
+					"172.17.0.1:34185",
+					"172.19.0.1:34185",
+					"172.20.0.1:34185"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:37:38.742389702Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8847665348978334,
+				"StableID":   "nuUzUcA86C21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d9b139b700df726eac3f6d6b4f42b088ad283e5c407f8fe88837a9f0eb12642",
+				"DiscoKey":   "discokey:5ebed62f2c96b50b9352f877d3760de2e360c7b3a201aa51df46a2d81707f76e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37961",
+					"10.65.0.27:37961",
+					"172.17.0.1:37961",
+					"172.19.0.1:37961",
+					"172.20.0.1:37961"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:37:39.236293154Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8562652946575123,
+				"StableID":   "nWzkTeN3s921CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b2a1f0a1408ca116aa151dff4cfa996a9247463bccef46b2bb532ef025e9043",
+				"DiscoKey":   "discokey:06e142bebb2432b73209b00868463b8752ca52f96c2e4f64bed9057474079406",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51168",
+					"10.65.0.27:51168",
+					"172.17.0.1:51168",
+					"172.19.0.1:51168",
+					"172.20.0.1:51168"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:37:39.758894372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         607415585710634,
+				"StableID":   "nKZ7K6n6k511CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:036e558a08c07f847e31b8198be0f8abae0a7346a0614a4ab101c146c7234d5d",
+				"DiscoKey":   "discokey:f632a9f5c307d515f77750e3e531bab317f6256dd82a19d82c67138f94e3ea08",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54833",
+					"10.65.0.27:54833",
+					"172.17.0.1:54833",
+					"172.19.0.1:54833",
+					"172.20.0.1:54833"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:37:40.304509818Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6530190670267758,
+				"StableID":   "nMAmw43Yzs11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:52439a2bbdb733188c897535b8166b599f411b9c2bec6ca78d39927fbab1af78",
+				"DiscoKey":   "discokey:4a301a93ff07289e15db3f29ed011930d10919f24543d77f7e14728f9ed76c42",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52354",
+					"10.65.0.27:52354",
+					"172.17.0.1:52354",
+					"172.19.0.1:52354",
+					"172.20.0.1:52354"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:37:40.849942447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6548654885639027,
+				"StableID":   "nJSsRS4u8t11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08de7a4d3b30589a7e43615c59dcfcc246504897a3393507b19ebd6e8249b255",
+				"DiscoKey":   "discokey:23781cdacfb92c0606733c03a30cfeb7b520a229b8d16f06fae1afde9392ef06",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54610",
+					"10.65.0.27:54610",
+					"172.17.0.1:54610",
+					"172.19.0.1:54610",
+					"172.20.0.1:54610"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:37:41.390120527Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8827036839117342,
+				"StableID":   "nMJuhoHnvB21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39797e802b7386b1d31a3e41868cb839253bf42e890780fcbeb0b49dd173b71b",
+				"DiscoKey":   "discokey:edd5ad5b621524ca14daf6d747f5cf642a0251bab9350616fae7d4b2bef8e05d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60247",
+					"10.65.0.27:60247",
+					"172.17.0.1:60247",
+					"172.19.0.1:60247",
+					"172.20.0.1:60247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:37:41.942163092Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8141071774583320,
+				"StableID":   "n7Juvj97a621CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e74dd76a4e22d83bf4261a2b588e875b56fe5b6dbaca2f68ea46fd0b84e1ae4a",
+				"DiscoKey":   "discokey:7e855e1e38be6802169f86756732a4e634c8428c6278d8e2706a1cfd1f7b5519",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59005",
+					"10.65.0.27:59005",
+					"172.17.0.1:59005",
+					"172.19.0.1:59005",
+					"172.20.0.1:59005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:37:42.474600685Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5304552881871009,
+				"StableID":   "nr7paLcSRi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d07705deb92539fa65d6491efd8403079d3b4d5cc3e566c60ee63041c6694c56",
+				"KeyExpiry":  "2026-11-08T18:37:43Z",
+				"DiscoKey":   "discokey:c7bdd1f4bd27742d655d84885ebca45fae1699a27c62854d52a51b886bcd0809",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52750",
+					"10.65.0.27:52750",
+					"172.17.0.1:52750",
+					"172.19.0.1:52750",
+					"172.20.0.1:52750"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:37:43.035658911Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5637802766590294,
+				"StableID":   "njXdj5XN2m11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:0f0ea4cd2f2d165a8d5a53d0afc97a72aedd40f3860dfe3afb97b2824e7c346c",
+				"KeyExpiry":  "2026-11-08T18:37:44Z",
+				"DiscoKey":   "discokey:47ba49b59a4773afc63f967e8366189646cbb514c7f78c4082e689c808f25c1c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36835",
+					"10.65.0.27:36835",
+					"172.17.0.1:36835",
+					"172.19.0.1:36835",
+					"172.20.0.1:36835"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:37:44.098696814Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6548654885639027,
+				"StableID":   "nJSsRS4u8t11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       6548654885639027,
+				"Key":        "nodekey:08de7a4d3b30589a7e43615c59dcfcc246504897a3393507b19ebd6e8249b255",
+				"DiscoKey":   "discokey:23781cdacfb92c0606733c03a30cfeb7b520a229b8d16f06fae1afde9392ef06",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:54610",
+					"10.65.0.27:54610",
+					"172.17.0.1:54610",
+					"172.19.0.1:54610",
+					"172.20.0.1:54610"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:37:41.390120527Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:08de7a4d3b30589a7e43615c59dcfcc246504897a3393507b19ebd6e8249b255",
+			"MachineKey": "mkey:92a62547dc4845e44ad1de91ecaa26f67726c12a63ed88c7a81b97f7de069d79",
+			"Peers": [{
+				"ID":         3032338836974926,
+				"StableID":   "nb3VGAQMgQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:415dfc49c2cdd22b4ee5c9444b40b9d173f13320a1bbdf47b88bac930a76011f",
+				"DiscoKey":   "discokey:d3fd9dc986c22532577a697618dc297abf55d21579ac5d887e34b39d5b64a712",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:50934",
+					"10.65.0.27:50934",
+					"172.17.0.1:50934",
+					"172.19.0.1:50934",
+					"172.20.0.1:50934"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:37:36.527847188Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         483420215403172,
+				"StableID":   "nhyL3Wdwm411CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b4f1fcefdb43d82fdeddf5503e061dffd4122d55cd3eec6ca317941724f52c70",
+				"DiscoKey":   "discokey:38addf17508e4861f9d415b70ebc74a3c49f8c1746f81c4b1a416ace2e5ef90d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48914",
+					"10.65.0.27:48914",
+					"172.17.0.1:48914",
+					"172.19.0.1:48914",
+					"172.20.0.1:48914"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:37:37.06700217Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8575151217514602,
+				"StableID":   "nX5EsXghx921CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4e3b2a07ed6475d0b70733fb407a0c8ec2d8af0a1d8a23de1896f461f2811768",
+				"DiscoKey":   "discokey:305e6eb0226dbba6910267248e3a87b86462f9b8ee25296394f9b5291fc91c43",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:55965",
+					"10.65.0.27:55965",
+					"172.17.0.1:55965",
+					"172.19.0.1:55965",
+					"172.20.0.1:55965"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:37:37.615376734Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3578705368049755,
+				"StableID":   "n2W5gFXowU11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:660dab33bf89014cf23c67b239aa0e68cd5aa89c66e483c9361cdc51ade7a701",
+				"DiscoKey":   "discokey:f52bf7decac9f3ab3223cd859d8664392a01af30e317df3b2537741f1cc9f016",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:59630",
+					"10.65.0.27:59630",
+					"172.17.0.1:59630",
+					"172.19.0.1:59630",
+					"172.20.0.1:59630"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:37:38.177923205Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3158116736132111,
+				"StableID":   "nvGYWYNKfR11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c089d30fb931d7e0580346a34861ae49c36886330a75690b2899bd1bcf26a5d",
+				"DiscoKey":   "discokey:d0f943290fc69ee802e188615a45abe22c20c704f335515796c50c6bc8ad3660",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34185",
+					"10.65.0.27:34185",
+					"172.17.0.1:34185",
+					"172.19.0.1:34185",
+					"172.20.0.1:34185"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:37:38.742389702Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8847665348978334,
+				"StableID":   "nuUzUcA86C21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3d9b139b700df726eac3f6d6b4f42b088ad283e5c407f8fe88837a9f0eb12642",
+				"DiscoKey":   "discokey:5ebed62f2c96b50b9352f877d3760de2e360c7b3a201aa51df46a2d81707f76e",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:37961",
+					"10.65.0.27:37961",
+					"172.17.0.1:37961",
+					"172.19.0.1:37961",
+					"172.20.0.1:37961"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:37:39.236293154Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8562652946575123,
+				"StableID":   "nWzkTeN3s921CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0b2a1f0a1408ca116aa151dff4cfa996a9247463bccef46b2bb532ef025e9043",
+				"DiscoKey":   "discokey:06e142bebb2432b73209b00868463b8752ca52f96c2e4f64bed9057474079406",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51168",
+					"10.65.0.27:51168",
+					"172.17.0.1:51168",
+					"172.19.0.1:51168",
+					"172.20.0.1:51168"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:37:39.758894372Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         607415585710634,
+				"StableID":   "nKZ7K6n6k511CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:036e558a08c07f847e31b8198be0f8abae0a7346a0614a4ab101c146c7234d5d",
+				"DiscoKey":   "discokey:f632a9f5c307d515f77750e3e531bab317f6256dd82a19d82c67138f94e3ea08",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:54833",
+					"10.65.0.27:54833",
+					"172.17.0.1:54833",
+					"172.19.0.1:54833",
+					"172.20.0.1:54833"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:37:40.304509818Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6530190670267758,
+				"StableID":   "nMAmw43Yzs11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:52439a2bbdb733188c897535b8166b599f411b9c2bec6ca78d39927fbab1af78",
+				"DiscoKey":   "discokey:4a301a93ff07289e15db3f29ed011930d10919f24543d77f7e14728f9ed76c42",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:52354",
+					"10.65.0.27:52354",
+					"172.17.0.1:52354",
+					"172.19.0.1:52354",
+					"172.20.0.1:52354"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:37:40.849942447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8827036839117342,
+				"StableID":   "nMJuhoHnvB21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:39797e802b7386b1d31a3e41868cb839253bf42e890780fcbeb0b49dd173b71b",
+				"DiscoKey":   "discokey:edd5ad5b621524ca14daf6d747f5cf642a0251bab9350616fae7d4b2bef8e05d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60247",
+					"10.65.0.27:60247",
+					"172.17.0.1:60247",
+					"172.19.0.1:60247",
+					"172.20.0.1:60247"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:37:41.942163092Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8141071774583320,
+				"StableID":   "n7Juvj97a621CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e74dd76a4e22d83bf4261a2b588e875b56fe5b6dbaca2f68ea46fd0b84e1ae4a",
+				"DiscoKey":   "discokey:7e855e1e38be6802169f86756732a4e634c8428c6278d8e2706a1cfd1f7b5519",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59005",
+					"10.65.0.27:59005",
+					"172.17.0.1:59005",
+					"172.19.0.1:59005",
+					"172.20.0.1:59005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:37:42.474600685Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5304552881871009,
+				"StableID":   "nr7paLcSRi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d07705deb92539fa65d6491efd8403079d3b4d5cc3e566c60ee63041c6694c56",
+				"KeyExpiry":  "2026-11-08T18:37:43Z",
+				"DiscoKey":   "discokey:c7bdd1f4bd27742d655d84885ebca45fae1699a27c62854d52a51b886bcd0809",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52750",
+					"10.65.0.27:52750",
+					"172.17.0.1:52750",
+					"172.19.0.1:52750",
+					"172.20.0.1:52750"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:37:43.035658911Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         836729174456001,
+				"StableID":   "nc6LuUTxX711CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:693b108a5e9eeb52115428e562f7f74c37493593b94c728acce685dcde8a4d1f",
+				"KeyExpiry":  "2026-11-08T18:37:43Z",
+				"DiscoKey":   "discokey:122df4cae32fd9051e1cb82d12fa0b5976d6fc08bca7a9578039f6a8f17d4473",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:41543",
+					"10.65.0.27:41543",
+					"172.17.0.1:41543",
+					"172.19.0.1:41543",
+					"172.20.0.1:41543"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:37:43.545425462Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5637802766590294,
+				"StableID":   "njXdj5XN2m11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:0f0ea4cd2f2d165a8d5a53d0afc97a72aedd40f3860dfe3afb97b2824e7c346c",
+				"KeyExpiry":  "2026-11-08T18:37:44Z",
+				"DiscoKey":   "discokey:47ba49b59a4773afc63f967e8366189646cbb514c7f78c4082e689c808f25c1c",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:36835",
+					"10.65.0.27:36835",
+					"172.17.0.1:36835",
+					"172.19.0.1:36835",
+					"172.20.0.1:36835"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:37:44.098696814Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6548654885639027": {
+				"ID":          6548654885639027,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/sshtest_results/sshtest-deny-pass-cross-user-blocked.hujson
+++ b/hscontrol/policy/v2/testdata/sshtest_results/sshtest-deny-pass-cross-user-blocked.hujson
@@ -1,0 +1,20139 @@
+// sshtest-deny-pass-cross-user-blocked
+//
+// autogroup:self cross-user deny passes
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T18:38:20Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "sshtest-deny-pass-cross-user-blocked",
+	"description":    "autogroup:self cross-user deny passes",
+	"category":       "sshtest",
+	"captured_at":    "2026-05-12T18:38:20.137993298Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                       \n  \n                                                                      \n                                                         \n{\n\t\"category\":    \"sshtest\",\n\t\"description\": \"autogroup:self cross-user deny passes\",\n\t\"id\":          \"sshtest-deny-pass-cross-user-blocked\",\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"autogroup:self\"],\n\t\t\"src\":    [\"autogroup:member\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"sshTests\": [{\n\t\t\"deny\": [\"root\"],\n\t\t\"dst\":  [\"odin@example.com\"],\n\t\t\"src\":  \"thor@example.org\"\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/sshtest/sshtest-deny-pass-cross-user-blocked.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["autogroup:self"],
+				"src":    ["autogroup:member"],
+				"users":  ["root"]
+			}],
+			"sshTests": [
+				{"deny": ["root"], "dst": ["odin@example.com"], "src": "thor@example.org"}
+			],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4539888849874230,
+				"StableID":   "njHaYYB8Tc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       4539888849874230,
+				"Key":        "nodekey:4a9b3ad62b20b77e0840c940e7cec4a6905dacd55d78faa23a3b64172ced263e",
+				"DiscoKey":   "discokey:9772452910d1046b8cc0e5ad123daf900cd6c7cbe7531d7305602706cb7c3f3d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56111",
+					"10.65.0.27:56111",
+					"172.17.0.1:56111",
+					"172.19.0.1:56111",
+					"172.20.0.1:56111"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:38:28.592184887Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4a9b3ad62b20b77e0840c940e7cec4a6905dacd55d78faa23a3b64172ced263e",
+			"MachineKey": "mkey:b1e8971e3afdbc065236b47db3d7c4fe09cd3ac531a76c80cbf5b83b145d8f5d",
+			"Peers": [{
+				"ID":         3531838953319780,
+				"StableID":   "nbeF6PRaaU11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:839701f9cd3247681b0303c5da67af28bc8d138bb0517dd71ec99b824b40257e",
+				"DiscoKey":   "discokey:25d482e1d98ae5d10740fccdbd59cb83e8d6dace6a130c4066dfff84114d3e13",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33873",
+					"10.65.0.27:33873",
+					"172.17.0.1:33873",
+					"172.19.0.1:33873",
+					"172.20.0.1:33873"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:38:22.658992188Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1908933400158695,
+				"StableID":   "nLFjjiSZuF11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:899de6931e39c003ed29262115fde54de324f35803dde67e3dd5e8fb86f36a47",
+				"DiscoKey":   "discokey:d65a2b4a6e61456d81ce7d2a62aa04a1d4eba6203faa21d5adda4027808eeb31",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:58044",
+					"10.65.0.27:58044",
+					"172.17.0.1:58044",
+					"172.19.0.1:58044",
+					"172.20.0.1:58044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:38:23.208502176Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8182581777919834,
+				"StableID":   "ndSEnnYut621CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f93cbf9f2d6cf7a63ded046ec3725b3a28324637162502f5e3f8ffd5e1c3c71d",
+				"DiscoKey":   "discokey:c5d22a78d96fbe393e65568b8d2b6565210e85f0702a6b65be58e239866e4673",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39323",
+					"10.65.0.27:39323",
+					"172.17.0.1:39323",
+					"172.19.0.1:39323",
+					"172.20.0.1:39323"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:38:23.740448591Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2375238083408566,
+				"StableID":   "nZEzoeUkYK11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83a2a57faa49f36d5100ccd0fb2c7474e5fbe21cec6c339a67596e76a18dbc29",
+				"DiscoKey":   "discokey:9a7347c1deffcf59d83629d9dc9fc1deeefc6fa3414f734ca3e452511316015f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:46426",
+					"10.65.0.27:46426",
+					"172.17.0.1:46426",
+					"172.19.0.1:46426",
+					"172.20.0.1:46426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:38:24.27989739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         417201869267411,
+				"StableID":   "nLMhYmBxF411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:52b22d57e836f5520622f0c7d6529fe3b450b03bfda8675323fc6cd4d4a7183a",
+				"DiscoKey":   "discokey:6ebef548f26b3e67d8c86d46ab0e6eb13e7db75e89cd652b411c8be43579d360",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41204",
+					"10.65.0.27:41204",
+					"172.17.0.1:41204",
+					"172.19.0.1:41204",
+					"172.20.0.1:41204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:38:24.814203311Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8349808007303302,
+				"StableID":   "njoo2GJeC821CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8125b0a7b4c19db0b678e9e19a269ea24aa9b67d2d11dc01981d68c0d2353b61",
+				"DiscoKey":   "discokey:5b12bd0175100898141f600dea5758faecd706183565fa2d985661895c1f7957",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39960",
+					"10.65.0.27:39960",
+					"172.17.0.1:39960",
+					"172.19.0.1:39960",
+					"172.20.0.1:39960"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:38:25.349121596Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1377968672203558,
+				"StableID":   "nmWyvDu5mB11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28f8f943646e5b894bd4951eff6b08633cd44d1ede7858fe1c25d6d884ffb729",
+				"DiscoKey":   "discokey:8092c7e21c4a486f8a6df94e863991fe1e786889cc31299b32fa10d7e8437424",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54707",
+					"10.65.0.27:54707",
+					"172.17.0.1:54707",
+					"172.19.0.1:54707",
+					"172.20.0.1:54707"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:38:25.89289962Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7135187296562774,
+				"StableID":   "nfja6jGYix11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6aba16362dd906263f5d28175ba80cc8a8abce7e2b9eb1c1e60686b766b18235",
+				"DiscoKey":   "discokey:a13c4fb73e162684a81d8dcb3b6e4d08a5ac4e58c70e24d2f3a97f0ea7b4f775",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37303",
+					"10.65.0.27:37303",
+					"172.17.0.1:37303",
+					"172.19.0.1:37303",
+					"172.20.0.1:37303"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:38:26.438228041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         233618072356079,
+				"StableID":   "nk3s4Ykop211CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4d37148e61ce4b213c519cc8cb54524d0a4edfcdfc8c11e2b5257057eb6405f",
+				"DiscoKey":   "discokey:0bbcbf4391cf4fd8bf64855b0cbda4657d58b31af5dc659475707a4bdf359f41",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:40005",
+					"10.65.0.27:40005",
+					"172.17.0.1:40005",
+					"172.19.0.1:40005",
+					"172.20.0.1:40005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:38:26.972061446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1576612755086865,
+				"StableID":   "nSozJjw3KD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b6eb1764e5cfce267b4261d66aa8bf3a934a6e889203085a16dd950191d0509",
+				"DiscoKey":   "discokey:b65b3ef63ddbdbdc68caf418110b14243fbfdeb0a7a1d1bc8b66c0a052237862",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52919",
+					"10.65.0.27:52919",
+					"172.17.0.1:52919",
+					"172.19.0.1:52919",
+					"172.20.0.1:52919"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:38:27.515060229Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7598876428598967,
+				"StableID":   "nELCshbYL221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b3d83dd4d1f9c680e8dc1cda01e70b0237ad571e6c14299bfddeeee7f1d8414",
+				"DiscoKey":   "discokey:dc231c0bf1d67abb7ecd369f8ddee8dceb8213c0eac65c0deee822544e633176",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55155",
+					"10.65.0.27:55155",
+					"172.17.0.1:55155",
+					"172.19.0.1:55155",
+					"172.20.0.1:55155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:38:28.04751184Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6680210421805012,
+				"StableID":   "nqXofQoUAu11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5ca43ba42cb01fe91cc4d882f9b2261b2dd2422f99f2da9be2141fa6d5c91462",
+				"KeyExpiry":  "2026-11-08T18:38:29Z",
+				"DiscoKey":   "discokey:bb8916bd7b1dfe5a8a6eeea855040e60e178567e44e16eb51148c64ee9824965",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:55836",
+					"10.65.0.27:55836",
+					"172.17.0.1:55836",
+					"172.19.0.1:55836",
+					"172.20.0.1:55836"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:38:29.144768226Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         372969410384347,
+				"StableID":   "nC95dtGvu311CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8a6b1c11646bd03145c70624a2a770021fcea7c2d90ee42c577d077f780d3a6f",
+				"KeyExpiry":  "2026-11-08T18:38:29Z",
+				"DiscoKey":   "discokey:92f4c6d740c4a633a89c09db46bc27c82b785716c9c2bd966332e150629f4e15",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39270",
+					"10.65.0.27:39270",
+					"172.17.0.1:39270",
+					"172.19.0.1:39270",
+					"172.20.0.1:39270"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:38:29.678817243Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7861257255743688,
+				"StableID":   "nPib55uNP421CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:46d12c9975815bc286cf210b9bedf283f27e8cfbca68a902089ab3c85f447022",
+				"KeyExpiry":  "2026-11-08T18:38:30Z",
+				"DiscoKey":   "discokey:214a39694d62c83e8b5faed9ef30f75cde5ee7d41463d53ef9625c287b75dd13",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44331",
+					"10.65.0.27:44331",
+					"172.17.0.1:44331",
+					"172.19.0.1:44331",
+					"172.20.0.1:44331"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:38:30.225429861Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4539888849874230": {
+				"ID":          4539888849874230,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8349808007303302,
+				"StableID":   "njoo2GJeC821CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       8349808007303302,
+				"Key":        "nodekey:8125b0a7b4c19db0b678e9e19a269ea24aa9b67d2d11dc01981d68c0d2353b61",
+				"DiscoKey":   "discokey:5b12bd0175100898141f600dea5758faecd706183565fa2d985661895c1f7957",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39960",
+					"10.65.0.27:39960",
+					"172.17.0.1:39960",
+					"172.19.0.1:39960",
+					"172.20.0.1:39960"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:38:25.349121596Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8125b0a7b4c19db0b678e9e19a269ea24aa9b67d2d11dc01981d68c0d2353b61",
+			"MachineKey": "mkey:73ab18c4d1f31e46a0799f160769a1887a773827dfc53e944f09c2f6eeab4619",
+			"Peers": [{
+				"ID":         3531838953319780,
+				"StableID":   "nbeF6PRaaU11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:839701f9cd3247681b0303c5da67af28bc8d138bb0517dd71ec99b824b40257e",
+				"DiscoKey":   "discokey:25d482e1d98ae5d10740fccdbd59cb83e8d6dace6a130c4066dfff84114d3e13",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33873",
+					"10.65.0.27:33873",
+					"172.17.0.1:33873",
+					"172.19.0.1:33873",
+					"172.20.0.1:33873"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:38:22.658992188Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1908933400158695,
+				"StableID":   "nLFjjiSZuF11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:899de6931e39c003ed29262115fde54de324f35803dde67e3dd5e8fb86f36a47",
+				"DiscoKey":   "discokey:d65a2b4a6e61456d81ce7d2a62aa04a1d4eba6203faa21d5adda4027808eeb31",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:58044",
+					"10.65.0.27:58044",
+					"172.17.0.1:58044",
+					"172.19.0.1:58044",
+					"172.20.0.1:58044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:38:23.208502176Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8182581777919834,
+				"StableID":   "ndSEnnYut621CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f93cbf9f2d6cf7a63ded046ec3725b3a28324637162502f5e3f8ffd5e1c3c71d",
+				"DiscoKey":   "discokey:c5d22a78d96fbe393e65568b8d2b6565210e85f0702a6b65be58e239866e4673",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39323",
+					"10.65.0.27:39323",
+					"172.17.0.1:39323",
+					"172.19.0.1:39323",
+					"172.20.0.1:39323"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:38:23.740448591Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2375238083408566,
+				"StableID":   "nZEzoeUkYK11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83a2a57faa49f36d5100ccd0fb2c7474e5fbe21cec6c339a67596e76a18dbc29",
+				"DiscoKey":   "discokey:9a7347c1deffcf59d83629d9dc9fc1deeefc6fa3414f734ca3e452511316015f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:46426",
+					"10.65.0.27:46426",
+					"172.17.0.1:46426",
+					"172.19.0.1:46426",
+					"172.20.0.1:46426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:38:24.27989739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         417201869267411,
+				"StableID":   "nLMhYmBxF411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:52b22d57e836f5520622f0c7d6529fe3b450b03bfda8675323fc6cd4d4a7183a",
+				"DiscoKey":   "discokey:6ebef548f26b3e67d8c86d46ab0e6eb13e7db75e89cd652b411c8be43579d360",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41204",
+					"10.65.0.27:41204",
+					"172.17.0.1:41204",
+					"172.19.0.1:41204",
+					"172.20.0.1:41204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:38:24.814203311Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1377968672203558,
+				"StableID":   "nmWyvDu5mB11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28f8f943646e5b894bd4951eff6b08633cd44d1ede7858fe1c25d6d884ffb729",
+				"DiscoKey":   "discokey:8092c7e21c4a486f8a6df94e863991fe1e786889cc31299b32fa10d7e8437424",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54707",
+					"10.65.0.27:54707",
+					"172.17.0.1:54707",
+					"172.19.0.1:54707",
+					"172.20.0.1:54707"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:38:25.89289962Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7135187296562774,
+				"StableID":   "nfja6jGYix11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6aba16362dd906263f5d28175ba80cc8a8abce7e2b9eb1c1e60686b766b18235",
+				"DiscoKey":   "discokey:a13c4fb73e162684a81d8dcb3b6e4d08a5ac4e58c70e24d2f3a97f0ea7b4f775",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37303",
+					"10.65.0.27:37303",
+					"172.17.0.1:37303",
+					"172.19.0.1:37303",
+					"172.20.0.1:37303"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:38:26.438228041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         233618072356079,
+				"StableID":   "nk3s4Ykop211CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4d37148e61ce4b213c519cc8cb54524d0a4edfcdfc8c11e2b5257057eb6405f",
+				"DiscoKey":   "discokey:0bbcbf4391cf4fd8bf64855b0cbda4657d58b31af5dc659475707a4bdf359f41",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:40005",
+					"10.65.0.27:40005",
+					"172.17.0.1:40005",
+					"172.19.0.1:40005",
+					"172.20.0.1:40005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:38:26.972061446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1576612755086865,
+				"StableID":   "nSozJjw3KD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b6eb1764e5cfce267b4261d66aa8bf3a934a6e889203085a16dd950191d0509",
+				"DiscoKey":   "discokey:b65b3ef63ddbdbdc68caf418110b14243fbfdeb0a7a1d1bc8b66c0a052237862",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52919",
+					"10.65.0.27:52919",
+					"172.17.0.1:52919",
+					"172.19.0.1:52919",
+					"172.20.0.1:52919"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:38:27.515060229Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7598876428598967,
+				"StableID":   "nELCshbYL221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b3d83dd4d1f9c680e8dc1cda01e70b0237ad571e6c14299bfddeeee7f1d8414",
+				"DiscoKey":   "discokey:dc231c0bf1d67abb7ecd369f8ddee8dceb8213c0eac65c0deee822544e633176",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55155",
+					"10.65.0.27:55155",
+					"172.17.0.1:55155",
+					"172.19.0.1:55155",
+					"172.20.0.1:55155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:38:28.04751184Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4539888849874230,
+				"StableID":   "njHaYYB8Tc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4a9b3ad62b20b77e0840c940e7cec4a6905dacd55d78faa23a3b64172ced263e",
+				"DiscoKey":   "discokey:9772452910d1046b8cc0e5ad123daf900cd6c7cbe7531d7305602706cb7c3f3d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56111",
+					"10.65.0.27:56111",
+					"172.17.0.1:56111",
+					"172.19.0.1:56111",
+					"172.20.0.1:56111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:38:28.592184887Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6680210421805012,
+				"StableID":   "nqXofQoUAu11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5ca43ba42cb01fe91cc4d882f9b2261b2dd2422f99f2da9be2141fa6d5c91462",
+				"KeyExpiry":  "2026-11-08T18:38:29Z",
+				"DiscoKey":   "discokey:bb8916bd7b1dfe5a8a6eeea855040e60e178567e44e16eb51148c64ee9824965",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:55836",
+					"10.65.0.27:55836",
+					"172.17.0.1:55836",
+					"172.19.0.1:55836",
+					"172.20.0.1:55836"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:38:29.144768226Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         372969410384347,
+				"StableID":   "nC95dtGvu311CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8a6b1c11646bd03145c70624a2a770021fcea7c2d90ee42c577d077f780d3a6f",
+				"KeyExpiry":  "2026-11-08T18:38:29Z",
+				"DiscoKey":   "discokey:92f4c6d740c4a633a89c09db46bc27c82b785716c9c2bd966332e150629f4e15",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39270",
+					"10.65.0.27:39270",
+					"172.17.0.1:39270",
+					"172.19.0.1:39270",
+					"172.20.0.1:39270"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:38:29.678817243Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7861257255743688,
+				"StableID":   "nPib55uNP421CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:46d12c9975815bc286cf210b9bedf283f27e8cfbca68a902089ab3c85f447022",
+				"KeyExpiry":  "2026-11-08T18:38:30Z",
+				"DiscoKey":   "discokey:214a39694d62c83e8b5faed9ef30f75cde5ee7d41463d53ef9625c287b75dd13",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44331",
+					"10.65.0.27:44331",
+					"172.17.0.1:44331",
+					"172.19.0.1:44331",
+					"172.20.0.1:44331"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:38:30.225429861Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8349808007303302": {
+				"ID":          8349808007303302,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7861257255743688,
+				"StableID":   "nPib55uNP421CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:46d12c9975815bc286cf210b9bedf283f27e8cfbca68a902089ab3c85f447022",
+				"KeyExpiry":  "2026-11-08T18:38:30Z",
+				"DiscoKey":   "discokey:214a39694d62c83e8b5faed9ef30f75cde5ee7d41463d53ef9625c287b75dd13",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44331",
+					"10.65.0.27:44331",
+					"172.17.0.1:44331",
+					"172.19.0.1:44331",
+					"172.20.0.1:44331"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:38:30.225429861Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:46d12c9975815bc286cf210b9bedf283f27e8cfbca68a902089ab3c85f447022",
+			"MachineKey": "mkey:6b6038e0202de33d96da9e80c5002d3844bb4dc4fad0668da4eec595aaab2a54",
+			"Peers": [{
+				"ID":         3531838953319780,
+				"StableID":   "nbeF6PRaaU11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:839701f9cd3247681b0303c5da67af28bc8d138bb0517dd71ec99b824b40257e",
+				"DiscoKey":   "discokey:25d482e1d98ae5d10740fccdbd59cb83e8d6dace6a130c4066dfff84114d3e13",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33873",
+					"10.65.0.27:33873",
+					"172.17.0.1:33873",
+					"172.19.0.1:33873",
+					"172.20.0.1:33873"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:38:22.658992188Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1908933400158695,
+				"StableID":   "nLFjjiSZuF11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:899de6931e39c003ed29262115fde54de324f35803dde67e3dd5e8fb86f36a47",
+				"DiscoKey":   "discokey:d65a2b4a6e61456d81ce7d2a62aa04a1d4eba6203faa21d5adda4027808eeb31",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:58044",
+					"10.65.0.27:58044",
+					"172.17.0.1:58044",
+					"172.19.0.1:58044",
+					"172.20.0.1:58044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:38:23.208502176Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8182581777919834,
+				"StableID":   "ndSEnnYut621CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f93cbf9f2d6cf7a63ded046ec3725b3a28324637162502f5e3f8ffd5e1c3c71d",
+				"DiscoKey":   "discokey:c5d22a78d96fbe393e65568b8d2b6565210e85f0702a6b65be58e239866e4673",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39323",
+					"10.65.0.27:39323",
+					"172.17.0.1:39323",
+					"172.19.0.1:39323",
+					"172.20.0.1:39323"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:38:23.740448591Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2375238083408566,
+				"StableID":   "nZEzoeUkYK11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83a2a57faa49f36d5100ccd0fb2c7474e5fbe21cec6c339a67596e76a18dbc29",
+				"DiscoKey":   "discokey:9a7347c1deffcf59d83629d9dc9fc1deeefc6fa3414f734ca3e452511316015f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:46426",
+					"10.65.0.27:46426",
+					"172.17.0.1:46426",
+					"172.19.0.1:46426",
+					"172.20.0.1:46426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:38:24.27989739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         417201869267411,
+				"StableID":   "nLMhYmBxF411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:52b22d57e836f5520622f0c7d6529fe3b450b03bfda8675323fc6cd4d4a7183a",
+				"DiscoKey":   "discokey:6ebef548f26b3e67d8c86d46ab0e6eb13e7db75e89cd652b411c8be43579d360",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41204",
+					"10.65.0.27:41204",
+					"172.17.0.1:41204",
+					"172.19.0.1:41204",
+					"172.20.0.1:41204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:38:24.814203311Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8349808007303302,
+				"StableID":   "njoo2GJeC821CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8125b0a7b4c19db0b678e9e19a269ea24aa9b67d2d11dc01981d68c0d2353b61",
+				"DiscoKey":   "discokey:5b12bd0175100898141f600dea5758faecd706183565fa2d985661895c1f7957",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39960",
+					"10.65.0.27:39960",
+					"172.17.0.1:39960",
+					"172.19.0.1:39960",
+					"172.20.0.1:39960"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:38:25.349121596Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1377968672203558,
+				"StableID":   "nmWyvDu5mB11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28f8f943646e5b894bd4951eff6b08633cd44d1ede7858fe1c25d6d884ffb729",
+				"DiscoKey":   "discokey:8092c7e21c4a486f8a6df94e863991fe1e786889cc31299b32fa10d7e8437424",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54707",
+					"10.65.0.27:54707",
+					"172.17.0.1:54707",
+					"172.19.0.1:54707",
+					"172.20.0.1:54707"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:38:25.89289962Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7135187296562774,
+				"StableID":   "nfja6jGYix11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6aba16362dd906263f5d28175ba80cc8a8abce7e2b9eb1c1e60686b766b18235",
+				"DiscoKey":   "discokey:a13c4fb73e162684a81d8dcb3b6e4d08a5ac4e58c70e24d2f3a97f0ea7b4f775",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37303",
+					"10.65.0.27:37303",
+					"172.17.0.1:37303",
+					"172.19.0.1:37303",
+					"172.20.0.1:37303"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:38:26.438228041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         233618072356079,
+				"StableID":   "nk3s4Ykop211CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4d37148e61ce4b213c519cc8cb54524d0a4edfcdfc8c11e2b5257057eb6405f",
+				"DiscoKey":   "discokey:0bbcbf4391cf4fd8bf64855b0cbda4657d58b31af5dc659475707a4bdf359f41",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:40005",
+					"10.65.0.27:40005",
+					"172.17.0.1:40005",
+					"172.19.0.1:40005",
+					"172.20.0.1:40005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:38:26.972061446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1576612755086865,
+				"StableID":   "nSozJjw3KD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b6eb1764e5cfce267b4261d66aa8bf3a934a6e889203085a16dd950191d0509",
+				"DiscoKey":   "discokey:b65b3ef63ddbdbdc68caf418110b14243fbfdeb0a7a1d1bc8b66c0a052237862",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52919",
+					"10.65.0.27:52919",
+					"172.17.0.1:52919",
+					"172.19.0.1:52919",
+					"172.20.0.1:52919"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:38:27.515060229Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7598876428598967,
+				"StableID":   "nELCshbYL221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b3d83dd4d1f9c680e8dc1cda01e70b0237ad571e6c14299bfddeeee7f1d8414",
+				"DiscoKey":   "discokey:dc231c0bf1d67abb7ecd369f8ddee8dceb8213c0eac65c0deee822544e633176",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55155",
+					"10.65.0.27:55155",
+					"172.17.0.1:55155",
+					"172.19.0.1:55155",
+					"172.20.0.1:55155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:38:28.04751184Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4539888849874230,
+				"StableID":   "njHaYYB8Tc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4a9b3ad62b20b77e0840c940e7cec4a6905dacd55d78faa23a3b64172ced263e",
+				"DiscoKey":   "discokey:9772452910d1046b8cc0e5ad123daf900cd6c7cbe7531d7305602706cb7c3f3d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56111",
+					"10.65.0.27:56111",
+					"172.17.0.1:56111",
+					"172.19.0.1:56111",
+					"172.20.0.1:56111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:38:28.592184887Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6680210421805012,
+				"StableID":   "nqXofQoUAu11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5ca43ba42cb01fe91cc4d882f9b2261b2dd2422f99f2da9be2141fa6d5c91462",
+				"KeyExpiry":  "2026-11-08T18:38:29Z",
+				"DiscoKey":   "discokey:bb8916bd7b1dfe5a8a6eeea855040e60e178567e44e16eb51148c64ee9824965",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:55836",
+					"10.65.0.27:55836",
+					"172.17.0.1:55836",
+					"172.19.0.1:55836",
+					"172.20.0.1:55836"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:38:29.144768226Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         372969410384347,
+				"StableID":   "nC95dtGvu311CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8a6b1c11646bd03145c70624a2a770021fcea7c2d90ee42c577d077f780d3a6f",
+				"KeyExpiry":  "2026-11-08T18:38:29Z",
+				"DiscoKey":   "discokey:92f4c6d740c4a633a89c09db46bc27c82b785716c9c2bd966332e150629f4e15",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39270",
+					"10.65.0.27:39270",
+					"172.17.0.1:39270",
+					"172.19.0.1:39270",
+					"172.20.0.1:39270"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:38:29.678817243Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{
+				"principals": [{"nodeIP": "100.64.0.19"}, {"nodeIP": "fd7a:115c:a1e0::13"}],
+				"sshUsers":   {"root": "root"},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				}
+			}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		},
+		"ssh_rules": [{
+			"principals": [{"nodeIP": "100.64.0.19"}, {"nodeIP": "fd7a:115c:a1e0::13"}],
+			"sshUsers":   {"root": "root"},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}
+		}]
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8182581777919834,
+				"StableID":   "ndSEnnYut621CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       8182581777919834,
+				"Key":        "nodekey:f93cbf9f2d6cf7a63ded046ec3725b3a28324637162502f5e3f8ffd5e1c3c71d",
+				"DiscoKey":   "discokey:c5d22a78d96fbe393e65568b8d2b6565210e85f0702a6b65be58e239866e4673",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39323",
+					"10.65.0.27:39323",
+					"172.17.0.1:39323",
+					"172.19.0.1:39323",
+					"172.20.0.1:39323"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:38:23.740448591Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f93cbf9f2d6cf7a63ded046ec3725b3a28324637162502f5e3f8ffd5e1c3c71d",
+			"MachineKey": "mkey:eeeab93212644578e463e494c7c6e098d2ee539118fa5cb7aad1bb3dd98c945c",
+			"Peers": [{
+				"ID":         3531838953319780,
+				"StableID":   "nbeF6PRaaU11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:839701f9cd3247681b0303c5da67af28bc8d138bb0517dd71ec99b824b40257e",
+				"DiscoKey":   "discokey:25d482e1d98ae5d10740fccdbd59cb83e8d6dace6a130c4066dfff84114d3e13",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33873",
+					"10.65.0.27:33873",
+					"172.17.0.1:33873",
+					"172.19.0.1:33873",
+					"172.20.0.1:33873"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:38:22.658992188Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1908933400158695,
+				"StableID":   "nLFjjiSZuF11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:899de6931e39c003ed29262115fde54de324f35803dde67e3dd5e8fb86f36a47",
+				"DiscoKey":   "discokey:d65a2b4a6e61456d81ce7d2a62aa04a1d4eba6203faa21d5adda4027808eeb31",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:58044",
+					"10.65.0.27:58044",
+					"172.17.0.1:58044",
+					"172.19.0.1:58044",
+					"172.20.0.1:58044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:38:23.208502176Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2375238083408566,
+				"StableID":   "nZEzoeUkYK11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83a2a57faa49f36d5100ccd0fb2c7474e5fbe21cec6c339a67596e76a18dbc29",
+				"DiscoKey":   "discokey:9a7347c1deffcf59d83629d9dc9fc1deeefc6fa3414f734ca3e452511316015f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:46426",
+					"10.65.0.27:46426",
+					"172.17.0.1:46426",
+					"172.19.0.1:46426",
+					"172.20.0.1:46426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:38:24.27989739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         417201869267411,
+				"StableID":   "nLMhYmBxF411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:52b22d57e836f5520622f0c7d6529fe3b450b03bfda8675323fc6cd4d4a7183a",
+				"DiscoKey":   "discokey:6ebef548f26b3e67d8c86d46ab0e6eb13e7db75e89cd652b411c8be43579d360",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41204",
+					"10.65.0.27:41204",
+					"172.17.0.1:41204",
+					"172.19.0.1:41204",
+					"172.20.0.1:41204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:38:24.814203311Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8349808007303302,
+				"StableID":   "njoo2GJeC821CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8125b0a7b4c19db0b678e9e19a269ea24aa9b67d2d11dc01981d68c0d2353b61",
+				"DiscoKey":   "discokey:5b12bd0175100898141f600dea5758faecd706183565fa2d985661895c1f7957",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39960",
+					"10.65.0.27:39960",
+					"172.17.0.1:39960",
+					"172.19.0.1:39960",
+					"172.20.0.1:39960"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:38:25.349121596Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1377968672203558,
+				"StableID":   "nmWyvDu5mB11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28f8f943646e5b894bd4951eff6b08633cd44d1ede7858fe1c25d6d884ffb729",
+				"DiscoKey":   "discokey:8092c7e21c4a486f8a6df94e863991fe1e786889cc31299b32fa10d7e8437424",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54707",
+					"10.65.0.27:54707",
+					"172.17.0.1:54707",
+					"172.19.0.1:54707",
+					"172.20.0.1:54707"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:38:25.89289962Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7135187296562774,
+				"StableID":   "nfja6jGYix11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6aba16362dd906263f5d28175ba80cc8a8abce7e2b9eb1c1e60686b766b18235",
+				"DiscoKey":   "discokey:a13c4fb73e162684a81d8dcb3b6e4d08a5ac4e58c70e24d2f3a97f0ea7b4f775",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37303",
+					"10.65.0.27:37303",
+					"172.17.0.1:37303",
+					"172.19.0.1:37303",
+					"172.20.0.1:37303"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:38:26.438228041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         233618072356079,
+				"StableID":   "nk3s4Ykop211CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4d37148e61ce4b213c519cc8cb54524d0a4edfcdfc8c11e2b5257057eb6405f",
+				"DiscoKey":   "discokey:0bbcbf4391cf4fd8bf64855b0cbda4657d58b31af5dc659475707a4bdf359f41",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:40005",
+					"10.65.0.27:40005",
+					"172.17.0.1:40005",
+					"172.19.0.1:40005",
+					"172.20.0.1:40005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:38:26.972061446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1576612755086865,
+				"StableID":   "nSozJjw3KD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b6eb1764e5cfce267b4261d66aa8bf3a934a6e889203085a16dd950191d0509",
+				"DiscoKey":   "discokey:b65b3ef63ddbdbdc68caf418110b14243fbfdeb0a7a1d1bc8b66c0a052237862",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52919",
+					"10.65.0.27:52919",
+					"172.17.0.1:52919",
+					"172.19.0.1:52919",
+					"172.20.0.1:52919"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:38:27.515060229Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7598876428598967,
+				"StableID":   "nELCshbYL221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b3d83dd4d1f9c680e8dc1cda01e70b0237ad571e6c14299bfddeeee7f1d8414",
+				"DiscoKey":   "discokey:dc231c0bf1d67abb7ecd369f8ddee8dceb8213c0eac65c0deee822544e633176",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55155",
+					"10.65.0.27:55155",
+					"172.17.0.1:55155",
+					"172.19.0.1:55155",
+					"172.20.0.1:55155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:38:28.04751184Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4539888849874230,
+				"StableID":   "njHaYYB8Tc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4a9b3ad62b20b77e0840c940e7cec4a6905dacd55d78faa23a3b64172ced263e",
+				"DiscoKey":   "discokey:9772452910d1046b8cc0e5ad123daf900cd6c7cbe7531d7305602706cb7c3f3d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56111",
+					"10.65.0.27:56111",
+					"172.17.0.1:56111",
+					"172.19.0.1:56111",
+					"172.20.0.1:56111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:38:28.592184887Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6680210421805012,
+				"StableID":   "nqXofQoUAu11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5ca43ba42cb01fe91cc4d882f9b2261b2dd2422f99f2da9be2141fa6d5c91462",
+				"KeyExpiry":  "2026-11-08T18:38:29Z",
+				"DiscoKey":   "discokey:bb8916bd7b1dfe5a8a6eeea855040e60e178567e44e16eb51148c64ee9824965",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:55836",
+					"10.65.0.27:55836",
+					"172.17.0.1:55836",
+					"172.19.0.1:55836",
+					"172.20.0.1:55836"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:38:29.144768226Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         372969410384347,
+				"StableID":   "nC95dtGvu311CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8a6b1c11646bd03145c70624a2a770021fcea7c2d90ee42c577d077f780d3a6f",
+				"KeyExpiry":  "2026-11-08T18:38:29Z",
+				"DiscoKey":   "discokey:92f4c6d740c4a633a89c09db46bc27c82b785716c9c2bd966332e150629f4e15",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39270",
+					"10.65.0.27:39270",
+					"172.17.0.1:39270",
+					"172.19.0.1:39270",
+					"172.20.0.1:39270"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:38:29.678817243Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7861257255743688,
+				"StableID":   "nPib55uNP421CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:46d12c9975815bc286cf210b9bedf283f27e8cfbca68a902089ab3c85f447022",
+				"KeyExpiry":  "2026-11-08T18:38:30Z",
+				"DiscoKey":   "discokey:214a39694d62c83e8b5faed9ef30f75cde5ee7d41463d53ef9625c287b75dd13",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44331",
+					"10.65.0.27:44331",
+					"172.17.0.1:44331",
+					"172.19.0.1:44331",
+					"172.20.0.1:44331"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:38:30.225429861Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8182581777919834": {
+				"ID":          8182581777919834,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7135187296562774,
+				"StableID":   "nfja6jGYix11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       7135187296562774,
+				"Key":        "nodekey:6aba16362dd906263f5d28175ba80cc8a8abce7e2b9eb1c1e60686b766b18235",
+				"DiscoKey":   "discokey:a13c4fb73e162684a81d8dcb3b6e4d08a5ac4e58c70e24d2f3a97f0ea7b4f775",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37303",
+					"10.65.0.27:37303",
+					"172.17.0.1:37303",
+					"172.19.0.1:37303",
+					"172.20.0.1:37303"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:38:26.438228041Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6aba16362dd906263f5d28175ba80cc8a8abce7e2b9eb1c1e60686b766b18235",
+			"MachineKey": "mkey:d6b1dcbf59556c3c9dfc7e081ae429fa46fac1a9f245861ec971bc66913dc07c",
+			"Peers": [{
+				"ID":         3531838953319780,
+				"StableID":   "nbeF6PRaaU11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:839701f9cd3247681b0303c5da67af28bc8d138bb0517dd71ec99b824b40257e",
+				"DiscoKey":   "discokey:25d482e1d98ae5d10740fccdbd59cb83e8d6dace6a130c4066dfff84114d3e13",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33873",
+					"10.65.0.27:33873",
+					"172.17.0.1:33873",
+					"172.19.0.1:33873",
+					"172.20.0.1:33873"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:38:22.658992188Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1908933400158695,
+				"StableID":   "nLFjjiSZuF11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:899de6931e39c003ed29262115fde54de324f35803dde67e3dd5e8fb86f36a47",
+				"DiscoKey":   "discokey:d65a2b4a6e61456d81ce7d2a62aa04a1d4eba6203faa21d5adda4027808eeb31",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:58044",
+					"10.65.0.27:58044",
+					"172.17.0.1:58044",
+					"172.19.0.1:58044",
+					"172.20.0.1:58044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:38:23.208502176Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8182581777919834,
+				"StableID":   "ndSEnnYut621CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f93cbf9f2d6cf7a63ded046ec3725b3a28324637162502f5e3f8ffd5e1c3c71d",
+				"DiscoKey":   "discokey:c5d22a78d96fbe393e65568b8d2b6565210e85f0702a6b65be58e239866e4673",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39323",
+					"10.65.0.27:39323",
+					"172.17.0.1:39323",
+					"172.19.0.1:39323",
+					"172.20.0.1:39323"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:38:23.740448591Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2375238083408566,
+				"StableID":   "nZEzoeUkYK11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83a2a57faa49f36d5100ccd0fb2c7474e5fbe21cec6c339a67596e76a18dbc29",
+				"DiscoKey":   "discokey:9a7347c1deffcf59d83629d9dc9fc1deeefc6fa3414f734ca3e452511316015f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:46426",
+					"10.65.0.27:46426",
+					"172.17.0.1:46426",
+					"172.19.0.1:46426",
+					"172.20.0.1:46426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:38:24.27989739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         417201869267411,
+				"StableID":   "nLMhYmBxF411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:52b22d57e836f5520622f0c7d6529fe3b450b03bfda8675323fc6cd4d4a7183a",
+				"DiscoKey":   "discokey:6ebef548f26b3e67d8c86d46ab0e6eb13e7db75e89cd652b411c8be43579d360",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41204",
+					"10.65.0.27:41204",
+					"172.17.0.1:41204",
+					"172.19.0.1:41204",
+					"172.20.0.1:41204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:38:24.814203311Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8349808007303302,
+				"StableID":   "njoo2GJeC821CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8125b0a7b4c19db0b678e9e19a269ea24aa9b67d2d11dc01981d68c0d2353b61",
+				"DiscoKey":   "discokey:5b12bd0175100898141f600dea5758faecd706183565fa2d985661895c1f7957",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39960",
+					"10.65.0.27:39960",
+					"172.17.0.1:39960",
+					"172.19.0.1:39960",
+					"172.20.0.1:39960"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:38:25.349121596Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1377968672203558,
+				"StableID":   "nmWyvDu5mB11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28f8f943646e5b894bd4951eff6b08633cd44d1ede7858fe1c25d6d884ffb729",
+				"DiscoKey":   "discokey:8092c7e21c4a486f8a6df94e863991fe1e786889cc31299b32fa10d7e8437424",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54707",
+					"10.65.0.27:54707",
+					"172.17.0.1:54707",
+					"172.19.0.1:54707",
+					"172.20.0.1:54707"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:38:25.89289962Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         233618072356079,
+				"StableID":   "nk3s4Ykop211CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4d37148e61ce4b213c519cc8cb54524d0a4edfcdfc8c11e2b5257057eb6405f",
+				"DiscoKey":   "discokey:0bbcbf4391cf4fd8bf64855b0cbda4657d58b31af5dc659475707a4bdf359f41",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:40005",
+					"10.65.0.27:40005",
+					"172.17.0.1:40005",
+					"172.19.0.1:40005",
+					"172.20.0.1:40005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:38:26.972061446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1576612755086865,
+				"StableID":   "nSozJjw3KD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b6eb1764e5cfce267b4261d66aa8bf3a934a6e889203085a16dd950191d0509",
+				"DiscoKey":   "discokey:b65b3ef63ddbdbdc68caf418110b14243fbfdeb0a7a1d1bc8b66c0a052237862",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52919",
+					"10.65.0.27:52919",
+					"172.17.0.1:52919",
+					"172.19.0.1:52919",
+					"172.20.0.1:52919"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:38:27.515060229Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7598876428598967,
+				"StableID":   "nELCshbYL221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b3d83dd4d1f9c680e8dc1cda01e70b0237ad571e6c14299bfddeeee7f1d8414",
+				"DiscoKey":   "discokey:dc231c0bf1d67abb7ecd369f8ddee8dceb8213c0eac65c0deee822544e633176",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55155",
+					"10.65.0.27:55155",
+					"172.17.0.1:55155",
+					"172.19.0.1:55155",
+					"172.20.0.1:55155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:38:28.04751184Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4539888849874230,
+				"StableID":   "njHaYYB8Tc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4a9b3ad62b20b77e0840c940e7cec4a6905dacd55d78faa23a3b64172ced263e",
+				"DiscoKey":   "discokey:9772452910d1046b8cc0e5ad123daf900cd6c7cbe7531d7305602706cb7c3f3d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56111",
+					"10.65.0.27:56111",
+					"172.17.0.1:56111",
+					"172.19.0.1:56111",
+					"172.20.0.1:56111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:38:28.592184887Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6680210421805012,
+				"StableID":   "nqXofQoUAu11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5ca43ba42cb01fe91cc4d882f9b2261b2dd2422f99f2da9be2141fa6d5c91462",
+				"KeyExpiry":  "2026-11-08T18:38:29Z",
+				"DiscoKey":   "discokey:bb8916bd7b1dfe5a8a6eeea855040e60e178567e44e16eb51148c64ee9824965",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:55836",
+					"10.65.0.27:55836",
+					"172.17.0.1:55836",
+					"172.19.0.1:55836",
+					"172.20.0.1:55836"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:38:29.144768226Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         372969410384347,
+				"StableID":   "nC95dtGvu311CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8a6b1c11646bd03145c70624a2a770021fcea7c2d90ee42c577d077f780d3a6f",
+				"KeyExpiry":  "2026-11-08T18:38:29Z",
+				"DiscoKey":   "discokey:92f4c6d740c4a633a89c09db46bc27c82b785716c9c2bd966332e150629f4e15",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39270",
+					"10.65.0.27:39270",
+					"172.17.0.1:39270",
+					"172.19.0.1:39270",
+					"172.20.0.1:39270"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:38:29.678817243Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7861257255743688,
+				"StableID":   "nPib55uNP421CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:46d12c9975815bc286cf210b9bedf283f27e8cfbca68a902089ab3c85f447022",
+				"KeyExpiry":  "2026-11-08T18:38:30Z",
+				"DiscoKey":   "discokey:214a39694d62c83e8b5faed9ef30f75cde5ee7d41463d53ef9625c287b75dd13",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44331",
+					"10.65.0.27:44331",
+					"172.17.0.1:44331",
+					"172.19.0.1:44331",
+					"172.20.0.1:44331"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:38:30.225429861Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7135187296562774": {
+				"ID":          7135187296562774,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6680210421805012,
+				"StableID":   "nqXofQoUAu11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5ca43ba42cb01fe91cc4d882f9b2261b2dd2422f99f2da9be2141fa6d5c91462",
+				"KeyExpiry":  "2026-11-08T18:38:29Z",
+				"DiscoKey":   "discokey:bb8916bd7b1dfe5a8a6eeea855040e60e178567e44e16eb51148c64ee9824965",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:55836",
+					"10.65.0.27:55836",
+					"172.17.0.1:55836",
+					"172.19.0.1:55836",
+					"172.20.0.1:55836"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:38:29.144768226Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5ca43ba42cb01fe91cc4d882f9b2261b2dd2422f99f2da9be2141fa6d5c91462",
+			"MachineKey": "mkey:073d84fc2353fd1a0334ab70995a3e669bae4dc74bd97550a75c3448fb322b40",
+			"Peers": [{
+				"ID":         3531838953319780,
+				"StableID":   "nbeF6PRaaU11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:839701f9cd3247681b0303c5da67af28bc8d138bb0517dd71ec99b824b40257e",
+				"DiscoKey":   "discokey:25d482e1d98ae5d10740fccdbd59cb83e8d6dace6a130c4066dfff84114d3e13",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33873",
+					"10.65.0.27:33873",
+					"172.17.0.1:33873",
+					"172.19.0.1:33873",
+					"172.20.0.1:33873"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:38:22.658992188Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1908933400158695,
+				"StableID":   "nLFjjiSZuF11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:899de6931e39c003ed29262115fde54de324f35803dde67e3dd5e8fb86f36a47",
+				"DiscoKey":   "discokey:d65a2b4a6e61456d81ce7d2a62aa04a1d4eba6203faa21d5adda4027808eeb31",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:58044",
+					"10.65.0.27:58044",
+					"172.17.0.1:58044",
+					"172.19.0.1:58044",
+					"172.20.0.1:58044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:38:23.208502176Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8182581777919834,
+				"StableID":   "ndSEnnYut621CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f93cbf9f2d6cf7a63ded046ec3725b3a28324637162502f5e3f8ffd5e1c3c71d",
+				"DiscoKey":   "discokey:c5d22a78d96fbe393e65568b8d2b6565210e85f0702a6b65be58e239866e4673",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39323",
+					"10.65.0.27:39323",
+					"172.17.0.1:39323",
+					"172.19.0.1:39323",
+					"172.20.0.1:39323"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:38:23.740448591Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2375238083408566,
+				"StableID":   "nZEzoeUkYK11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83a2a57faa49f36d5100ccd0fb2c7474e5fbe21cec6c339a67596e76a18dbc29",
+				"DiscoKey":   "discokey:9a7347c1deffcf59d83629d9dc9fc1deeefc6fa3414f734ca3e452511316015f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:46426",
+					"10.65.0.27:46426",
+					"172.17.0.1:46426",
+					"172.19.0.1:46426",
+					"172.20.0.1:46426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:38:24.27989739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         417201869267411,
+				"StableID":   "nLMhYmBxF411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:52b22d57e836f5520622f0c7d6529fe3b450b03bfda8675323fc6cd4d4a7183a",
+				"DiscoKey":   "discokey:6ebef548f26b3e67d8c86d46ab0e6eb13e7db75e89cd652b411c8be43579d360",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41204",
+					"10.65.0.27:41204",
+					"172.17.0.1:41204",
+					"172.19.0.1:41204",
+					"172.20.0.1:41204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:38:24.814203311Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8349808007303302,
+				"StableID":   "njoo2GJeC821CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8125b0a7b4c19db0b678e9e19a269ea24aa9b67d2d11dc01981d68c0d2353b61",
+				"DiscoKey":   "discokey:5b12bd0175100898141f600dea5758faecd706183565fa2d985661895c1f7957",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39960",
+					"10.65.0.27:39960",
+					"172.17.0.1:39960",
+					"172.19.0.1:39960",
+					"172.20.0.1:39960"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:38:25.349121596Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1377968672203558,
+				"StableID":   "nmWyvDu5mB11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28f8f943646e5b894bd4951eff6b08633cd44d1ede7858fe1c25d6d884ffb729",
+				"DiscoKey":   "discokey:8092c7e21c4a486f8a6df94e863991fe1e786889cc31299b32fa10d7e8437424",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54707",
+					"10.65.0.27:54707",
+					"172.17.0.1:54707",
+					"172.19.0.1:54707",
+					"172.20.0.1:54707"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:38:25.89289962Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7135187296562774,
+				"StableID":   "nfja6jGYix11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6aba16362dd906263f5d28175ba80cc8a8abce7e2b9eb1c1e60686b766b18235",
+				"DiscoKey":   "discokey:a13c4fb73e162684a81d8dcb3b6e4d08a5ac4e58c70e24d2f3a97f0ea7b4f775",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37303",
+					"10.65.0.27:37303",
+					"172.17.0.1:37303",
+					"172.19.0.1:37303",
+					"172.20.0.1:37303"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:38:26.438228041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         233618072356079,
+				"StableID":   "nk3s4Ykop211CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4d37148e61ce4b213c519cc8cb54524d0a4edfcdfc8c11e2b5257057eb6405f",
+				"DiscoKey":   "discokey:0bbcbf4391cf4fd8bf64855b0cbda4657d58b31af5dc659475707a4bdf359f41",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:40005",
+					"10.65.0.27:40005",
+					"172.17.0.1:40005",
+					"172.19.0.1:40005",
+					"172.20.0.1:40005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:38:26.972061446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1576612755086865,
+				"StableID":   "nSozJjw3KD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b6eb1764e5cfce267b4261d66aa8bf3a934a6e889203085a16dd950191d0509",
+				"DiscoKey":   "discokey:b65b3ef63ddbdbdc68caf418110b14243fbfdeb0a7a1d1bc8b66c0a052237862",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52919",
+					"10.65.0.27:52919",
+					"172.17.0.1:52919",
+					"172.19.0.1:52919",
+					"172.20.0.1:52919"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:38:27.515060229Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7598876428598967,
+				"StableID":   "nELCshbYL221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b3d83dd4d1f9c680e8dc1cda01e70b0237ad571e6c14299bfddeeee7f1d8414",
+				"DiscoKey":   "discokey:dc231c0bf1d67abb7ecd369f8ddee8dceb8213c0eac65c0deee822544e633176",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55155",
+					"10.65.0.27:55155",
+					"172.17.0.1:55155",
+					"172.19.0.1:55155",
+					"172.20.0.1:55155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:38:28.04751184Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4539888849874230,
+				"StableID":   "njHaYYB8Tc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4a9b3ad62b20b77e0840c940e7cec4a6905dacd55d78faa23a3b64172ced263e",
+				"DiscoKey":   "discokey:9772452910d1046b8cc0e5ad123daf900cd6c7cbe7531d7305602706cb7c3f3d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56111",
+					"10.65.0.27:56111",
+					"172.17.0.1:56111",
+					"172.19.0.1:56111",
+					"172.20.0.1:56111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:38:28.592184887Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         372969410384347,
+				"StableID":   "nC95dtGvu311CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8a6b1c11646bd03145c70624a2a770021fcea7c2d90ee42c577d077f780d3a6f",
+				"KeyExpiry":  "2026-11-08T18:38:29Z",
+				"DiscoKey":   "discokey:92f4c6d740c4a633a89c09db46bc27c82b785716c9c2bd966332e150629f4e15",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39270",
+					"10.65.0.27:39270",
+					"172.17.0.1:39270",
+					"172.19.0.1:39270",
+					"172.20.0.1:39270"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:38:29.678817243Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7861257255743688,
+				"StableID":   "nPib55uNP421CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:46d12c9975815bc286cf210b9bedf283f27e8cfbca68a902089ab3c85f447022",
+				"KeyExpiry":  "2026-11-08T18:38:30Z",
+				"DiscoKey":   "discokey:214a39694d62c83e8b5faed9ef30f75cde5ee7d41463d53ef9625c287b75dd13",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44331",
+					"10.65.0.27:44331",
+					"172.17.0.1:44331",
+					"172.19.0.1:44331",
+					"172.20.0.1:44331"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:38:30.225429861Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{
+				"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+				"sshUsers":   {"root": "root"},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				}
+			}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		},
+		"ssh_rules": [{
+			"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+			"sshUsers":   {"root": "root"},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}
+		}]
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7598876428598967,
+				"StableID":   "nELCshbYL221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       7598876428598967,
+				"Key":        "nodekey:3b3d83dd4d1f9c680e8dc1cda01e70b0237ad571e6c14299bfddeeee7f1d8414",
+				"DiscoKey":   "discokey:dc231c0bf1d67abb7ecd369f8ddee8dceb8213c0eac65c0deee822544e633176",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55155",
+					"10.65.0.27:55155",
+					"172.17.0.1:55155",
+					"172.19.0.1:55155",
+					"172.20.0.1:55155"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:38:28.04751184Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3b3d83dd4d1f9c680e8dc1cda01e70b0237ad571e6c14299bfddeeee7f1d8414",
+			"MachineKey": "mkey:631f8637d7614f2e503ffd65216ed882761c65bfc334280f5e5fc8395e510c50",
+			"Peers": [{
+				"ID":         3531838953319780,
+				"StableID":   "nbeF6PRaaU11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:839701f9cd3247681b0303c5da67af28bc8d138bb0517dd71ec99b824b40257e",
+				"DiscoKey":   "discokey:25d482e1d98ae5d10740fccdbd59cb83e8d6dace6a130c4066dfff84114d3e13",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33873",
+					"10.65.0.27:33873",
+					"172.17.0.1:33873",
+					"172.19.0.1:33873",
+					"172.20.0.1:33873"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:38:22.658992188Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1908933400158695,
+				"StableID":   "nLFjjiSZuF11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:899de6931e39c003ed29262115fde54de324f35803dde67e3dd5e8fb86f36a47",
+				"DiscoKey":   "discokey:d65a2b4a6e61456d81ce7d2a62aa04a1d4eba6203faa21d5adda4027808eeb31",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:58044",
+					"10.65.0.27:58044",
+					"172.17.0.1:58044",
+					"172.19.0.1:58044",
+					"172.20.0.1:58044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:38:23.208502176Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8182581777919834,
+				"StableID":   "ndSEnnYut621CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f93cbf9f2d6cf7a63ded046ec3725b3a28324637162502f5e3f8ffd5e1c3c71d",
+				"DiscoKey":   "discokey:c5d22a78d96fbe393e65568b8d2b6565210e85f0702a6b65be58e239866e4673",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39323",
+					"10.65.0.27:39323",
+					"172.17.0.1:39323",
+					"172.19.0.1:39323",
+					"172.20.0.1:39323"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:38:23.740448591Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2375238083408566,
+				"StableID":   "nZEzoeUkYK11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83a2a57faa49f36d5100ccd0fb2c7474e5fbe21cec6c339a67596e76a18dbc29",
+				"DiscoKey":   "discokey:9a7347c1deffcf59d83629d9dc9fc1deeefc6fa3414f734ca3e452511316015f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:46426",
+					"10.65.0.27:46426",
+					"172.17.0.1:46426",
+					"172.19.0.1:46426",
+					"172.20.0.1:46426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:38:24.27989739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         417201869267411,
+				"StableID":   "nLMhYmBxF411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:52b22d57e836f5520622f0c7d6529fe3b450b03bfda8675323fc6cd4d4a7183a",
+				"DiscoKey":   "discokey:6ebef548f26b3e67d8c86d46ab0e6eb13e7db75e89cd652b411c8be43579d360",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41204",
+					"10.65.0.27:41204",
+					"172.17.0.1:41204",
+					"172.19.0.1:41204",
+					"172.20.0.1:41204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:38:24.814203311Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8349808007303302,
+				"StableID":   "njoo2GJeC821CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8125b0a7b4c19db0b678e9e19a269ea24aa9b67d2d11dc01981d68c0d2353b61",
+				"DiscoKey":   "discokey:5b12bd0175100898141f600dea5758faecd706183565fa2d985661895c1f7957",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39960",
+					"10.65.0.27:39960",
+					"172.17.0.1:39960",
+					"172.19.0.1:39960",
+					"172.20.0.1:39960"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:38:25.349121596Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1377968672203558,
+				"StableID":   "nmWyvDu5mB11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28f8f943646e5b894bd4951eff6b08633cd44d1ede7858fe1c25d6d884ffb729",
+				"DiscoKey":   "discokey:8092c7e21c4a486f8a6df94e863991fe1e786889cc31299b32fa10d7e8437424",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54707",
+					"10.65.0.27:54707",
+					"172.17.0.1:54707",
+					"172.19.0.1:54707",
+					"172.20.0.1:54707"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:38:25.89289962Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7135187296562774,
+				"StableID":   "nfja6jGYix11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6aba16362dd906263f5d28175ba80cc8a8abce7e2b9eb1c1e60686b766b18235",
+				"DiscoKey":   "discokey:a13c4fb73e162684a81d8dcb3b6e4d08a5ac4e58c70e24d2f3a97f0ea7b4f775",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37303",
+					"10.65.0.27:37303",
+					"172.17.0.1:37303",
+					"172.19.0.1:37303",
+					"172.20.0.1:37303"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:38:26.438228041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         233618072356079,
+				"StableID":   "nk3s4Ykop211CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4d37148e61ce4b213c519cc8cb54524d0a4edfcdfc8c11e2b5257057eb6405f",
+				"DiscoKey":   "discokey:0bbcbf4391cf4fd8bf64855b0cbda4657d58b31af5dc659475707a4bdf359f41",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:40005",
+					"10.65.0.27:40005",
+					"172.17.0.1:40005",
+					"172.19.0.1:40005",
+					"172.20.0.1:40005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:38:26.972061446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1576612755086865,
+				"StableID":   "nSozJjw3KD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b6eb1764e5cfce267b4261d66aa8bf3a934a6e889203085a16dd950191d0509",
+				"DiscoKey":   "discokey:b65b3ef63ddbdbdc68caf418110b14243fbfdeb0a7a1d1bc8b66c0a052237862",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52919",
+					"10.65.0.27:52919",
+					"172.17.0.1:52919",
+					"172.19.0.1:52919",
+					"172.20.0.1:52919"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:38:27.515060229Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4539888849874230,
+				"StableID":   "njHaYYB8Tc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4a9b3ad62b20b77e0840c940e7cec4a6905dacd55d78faa23a3b64172ced263e",
+				"DiscoKey":   "discokey:9772452910d1046b8cc0e5ad123daf900cd6c7cbe7531d7305602706cb7c3f3d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56111",
+					"10.65.0.27:56111",
+					"172.17.0.1:56111",
+					"172.19.0.1:56111",
+					"172.20.0.1:56111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:38:28.592184887Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6680210421805012,
+				"StableID":   "nqXofQoUAu11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5ca43ba42cb01fe91cc4d882f9b2261b2dd2422f99f2da9be2141fa6d5c91462",
+				"KeyExpiry":  "2026-11-08T18:38:29Z",
+				"DiscoKey":   "discokey:bb8916bd7b1dfe5a8a6eeea855040e60e178567e44e16eb51148c64ee9824965",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:55836",
+					"10.65.0.27:55836",
+					"172.17.0.1:55836",
+					"172.19.0.1:55836",
+					"172.20.0.1:55836"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:38:29.144768226Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         372969410384347,
+				"StableID":   "nC95dtGvu311CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8a6b1c11646bd03145c70624a2a770021fcea7c2d90ee42c577d077f780d3a6f",
+				"KeyExpiry":  "2026-11-08T18:38:29Z",
+				"DiscoKey":   "discokey:92f4c6d740c4a633a89c09db46bc27c82b785716c9c2bd966332e150629f4e15",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39270",
+					"10.65.0.27:39270",
+					"172.17.0.1:39270",
+					"172.19.0.1:39270",
+					"172.20.0.1:39270"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:38:29.678817243Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7861257255743688,
+				"StableID":   "nPib55uNP421CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:46d12c9975815bc286cf210b9bedf283f27e8cfbca68a902089ab3c85f447022",
+				"KeyExpiry":  "2026-11-08T18:38:30Z",
+				"DiscoKey":   "discokey:214a39694d62c83e8b5faed9ef30f75cde5ee7d41463d53ef9625c287b75dd13",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44331",
+					"10.65.0.27:44331",
+					"172.17.0.1:44331",
+					"172.19.0.1:44331",
+					"172.20.0.1:44331"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:38:30.225429861Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7598876428598967": {
+				"ID":          7598876428598967,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1908933400158695,
+				"StableID":   "nLFjjiSZuF11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1908933400158695,
+				"Key":        "nodekey:899de6931e39c003ed29262115fde54de324f35803dde67e3dd5e8fb86f36a47",
+				"DiscoKey":   "discokey:d65a2b4a6e61456d81ce7d2a62aa04a1d4eba6203faa21d5adda4027808eeb31",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:58044",
+					"10.65.0.27:58044",
+					"172.17.0.1:58044",
+					"172.19.0.1:58044",
+					"172.20.0.1:58044"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:38:23.208502176Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:899de6931e39c003ed29262115fde54de324f35803dde67e3dd5e8fb86f36a47",
+			"MachineKey": "mkey:dd19e7357a8d4bc1d195b94096bebabd9d35596db959122e3786e841e63b283a",
+			"Peers": [{
+				"ID":         3531838953319780,
+				"StableID":   "nbeF6PRaaU11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:839701f9cd3247681b0303c5da67af28bc8d138bb0517dd71ec99b824b40257e",
+				"DiscoKey":   "discokey:25d482e1d98ae5d10740fccdbd59cb83e8d6dace6a130c4066dfff84114d3e13",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33873",
+					"10.65.0.27:33873",
+					"172.17.0.1:33873",
+					"172.19.0.1:33873",
+					"172.20.0.1:33873"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:38:22.658992188Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8182581777919834,
+				"StableID":   "ndSEnnYut621CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f93cbf9f2d6cf7a63ded046ec3725b3a28324637162502f5e3f8ffd5e1c3c71d",
+				"DiscoKey":   "discokey:c5d22a78d96fbe393e65568b8d2b6565210e85f0702a6b65be58e239866e4673",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39323",
+					"10.65.0.27:39323",
+					"172.17.0.1:39323",
+					"172.19.0.1:39323",
+					"172.20.0.1:39323"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:38:23.740448591Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2375238083408566,
+				"StableID":   "nZEzoeUkYK11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83a2a57faa49f36d5100ccd0fb2c7474e5fbe21cec6c339a67596e76a18dbc29",
+				"DiscoKey":   "discokey:9a7347c1deffcf59d83629d9dc9fc1deeefc6fa3414f734ca3e452511316015f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:46426",
+					"10.65.0.27:46426",
+					"172.17.0.1:46426",
+					"172.19.0.1:46426",
+					"172.20.0.1:46426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:38:24.27989739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         417201869267411,
+				"StableID":   "nLMhYmBxF411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:52b22d57e836f5520622f0c7d6529fe3b450b03bfda8675323fc6cd4d4a7183a",
+				"DiscoKey":   "discokey:6ebef548f26b3e67d8c86d46ab0e6eb13e7db75e89cd652b411c8be43579d360",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41204",
+					"10.65.0.27:41204",
+					"172.17.0.1:41204",
+					"172.19.0.1:41204",
+					"172.20.0.1:41204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:38:24.814203311Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8349808007303302,
+				"StableID":   "njoo2GJeC821CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8125b0a7b4c19db0b678e9e19a269ea24aa9b67d2d11dc01981d68c0d2353b61",
+				"DiscoKey":   "discokey:5b12bd0175100898141f600dea5758faecd706183565fa2d985661895c1f7957",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39960",
+					"10.65.0.27:39960",
+					"172.17.0.1:39960",
+					"172.19.0.1:39960",
+					"172.20.0.1:39960"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:38:25.349121596Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1377968672203558,
+				"StableID":   "nmWyvDu5mB11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28f8f943646e5b894bd4951eff6b08633cd44d1ede7858fe1c25d6d884ffb729",
+				"DiscoKey":   "discokey:8092c7e21c4a486f8a6df94e863991fe1e786889cc31299b32fa10d7e8437424",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54707",
+					"10.65.0.27:54707",
+					"172.17.0.1:54707",
+					"172.19.0.1:54707",
+					"172.20.0.1:54707"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:38:25.89289962Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7135187296562774,
+				"StableID":   "nfja6jGYix11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6aba16362dd906263f5d28175ba80cc8a8abce7e2b9eb1c1e60686b766b18235",
+				"DiscoKey":   "discokey:a13c4fb73e162684a81d8dcb3b6e4d08a5ac4e58c70e24d2f3a97f0ea7b4f775",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37303",
+					"10.65.0.27:37303",
+					"172.17.0.1:37303",
+					"172.19.0.1:37303",
+					"172.20.0.1:37303"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:38:26.438228041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         233618072356079,
+				"StableID":   "nk3s4Ykop211CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4d37148e61ce4b213c519cc8cb54524d0a4edfcdfc8c11e2b5257057eb6405f",
+				"DiscoKey":   "discokey:0bbcbf4391cf4fd8bf64855b0cbda4657d58b31af5dc659475707a4bdf359f41",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:40005",
+					"10.65.0.27:40005",
+					"172.17.0.1:40005",
+					"172.19.0.1:40005",
+					"172.20.0.1:40005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:38:26.972061446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1576612755086865,
+				"StableID":   "nSozJjw3KD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b6eb1764e5cfce267b4261d66aa8bf3a934a6e889203085a16dd950191d0509",
+				"DiscoKey":   "discokey:b65b3ef63ddbdbdc68caf418110b14243fbfdeb0a7a1d1bc8b66c0a052237862",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52919",
+					"10.65.0.27:52919",
+					"172.17.0.1:52919",
+					"172.19.0.1:52919",
+					"172.20.0.1:52919"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:38:27.515060229Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7598876428598967,
+				"StableID":   "nELCshbYL221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b3d83dd4d1f9c680e8dc1cda01e70b0237ad571e6c14299bfddeeee7f1d8414",
+				"DiscoKey":   "discokey:dc231c0bf1d67abb7ecd369f8ddee8dceb8213c0eac65c0deee822544e633176",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55155",
+					"10.65.0.27:55155",
+					"172.17.0.1:55155",
+					"172.19.0.1:55155",
+					"172.20.0.1:55155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:38:28.04751184Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4539888849874230,
+				"StableID":   "njHaYYB8Tc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4a9b3ad62b20b77e0840c940e7cec4a6905dacd55d78faa23a3b64172ced263e",
+				"DiscoKey":   "discokey:9772452910d1046b8cc0e5ad123daf900cd6c7cbe7531d7305602706cb7c3f3d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56111",
+					"10.65.0.27:56111",
+					"172.17.0.1:56111",
+					"172.19.0.1:56111",
+					"172.20.0.1:56111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:38:28.592184887Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6680210421805012,
+				"StableID":   "nqXofQoUAu11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5ca43ba42cb01fe91cc4d882f9b2261b2dd2422f99f2da9be2141fa6d5c91462",
+				"KeyExpiry":  "2026-11-08T18:38:29Z",
+				"DiscoKey":   "discokey:bb8916bd7b1dfe5a8a6eeea855040e60e178567e44e16eb51148c64ee9824965",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:55836",
+					"10.65.0.27:55836",
+					"172.17.0.1:55836",
+					"172.19.0.1:55836",
+					"172.20.0.1:55836"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:38:29.144768226Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         372969410384347,
+				"StableID":   "nC95dtGvu311CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8a6b1c11646bd03145c70624a2a770021fcea7c2d90ee42c577d077f780d3a6f",
+				"KeyExpiry":  "2026-11-08T18:38:29Z",
+				"DiscoKey":   "discokey:92f4c6d740c4a633a89c09db46bc27c82b785716c9c2bd966332e150629f4e15",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39270",
+					"10.65.0.27:39270",
+					"172.17.0.1:39270",
+					"172.19.0.1:39270",
+					"172.20.0.1:39270"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:38:29.678817243Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7861257255743688,
+				"StableID":   "nPib55uNP421CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:46d12c9975815bc286cf210b9bedf283f27e8cfbca68a902089ab3c85f447022",
+				"KeyExpiry":  "2026-11-08T18:38:30Z",
+				"DiscoKey":   "discokey:214a39694d62c83e8b5faed9ef30f75cde5ee7d41463d53ef9625c287b75dd13",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44331",
+					"10.65.0.27:44331",
+					"172.17.0.1:44331",
+					"172.19.0.1:44331",
+					"172.20.0.1:44331"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:38:30.225429861Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1908933400158695": {
+				"ID":          1908933400158695,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3531838953319780,
+				"StableID":   "nbeF6PRaaU11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       3531838953319780,
+				"Key":        "nodekey:839701f9cd3247681b0303c5da67af28bc8d138bb0517dd71ec99b824b40257e",
+				"DiscoKey":   "discokey:25d482e1d98ae5d10740fccdbd59cb83e8d6dace6a130c4066dfff84114d3e13",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33873",
+					"10.65.0.27:33873",
+					"172.17.0.1:33873",
+					"172.19.0.1:33873",
+					"172.20.0.1:33873"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:38:22.658992188Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:839701f9cd3247681b0303c5da67af28bc8d138bb0517dd71ec99b824b40257e",
+			"MachineKey": "mkey:8dad06872992f9b5693917b393616c9850c805e93d165c7424ed4b020e15917a",
+			"Peers": [{
+				"ID":         1908933400158695,
+				"StableID":   "nLFjjiSZuF11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:899de6931e39c003ed29262115fde54de324f35803dde67e3dd5e8fb86f36a47",
+				"DiscoKey":   "discokey:d65a2b4a6e61456d81ce7d2a62aa04a1d4eba6203faa21d5adda4027808eeb31",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:58044",
+					"10.65.0.27:58044",
+					"172.17.0.1:58044",
+					"172.19.0.1:58044",
+					"172.20.0.1:58044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:38:23.208502176Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8182581777919834,
+				"StableID":   "ndSEnnYut621CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f93cbf9f2d6cf7a63ded046ec3725b3a28324637162502f5e3f8ffd5e1c3c71d",
+				"DiscoKey":   "discokey:c5d22a78d96fbe393e65568b8d2b6565210e85f0702a6b65be58e239866e4673",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39323",
+					"10.65.0.27:39323",
+					"172.17.0.1:39323",
+					"172.19.0.1:39323",
+					"172.20.0.1:39323"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:38:23.740448591Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2375238083408566,
+				"StableID":   "nZEzoeUkYK11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83a2a57faa49f36d5100ccd0fb2c7474e5fbe21cec6c339a67596e76a18dbc29",
+				"DiscoKey":   "discokey:9a7347c1deffcf59d83629d9dc9fc1deeefc6fa3414f734ca3e452511316015f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:46426",
+					"10.65.0.27:46426",
+					"172.17.0.1:46426",
+					"172.19.0.1:46426",
+					"172.20.0.1:46426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:38:24.27989739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         417201869267411,
+				"StableID":   "nLMhYmBxF411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:52b22d57e836f5520622f0c7d6529fe3b450b03bfda8675323fc6cd4d4a7183a",
+				"DiscoKey":   "discokey:6ebef548f26b3e67d8c86d46ab0e6eb13e7db75e89cd652b411c8be43579d360",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41204",
+					"10.65.0.27:41204",
+					"172.17.0.1:41204",
+					"172.19.0.1:41204",
+					"172.20.0.1:41204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:38:24.814203311Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8349808007303302,
+				"StableID":   "njoo2GJeC821CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8125b0a7b4c19db0b678e9e19a269ea24aa9b67d2d11dc01981d68c0d2353b61",
+				"DiscoKey":   "discokey:5b12bd0175100898141f600dea5758faecd706183565fa2d985661895c1f7957",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39960",
+					"10.65.0.27:39960",
+					"172.17.0.1:39960",
+					"172.19.0.1:39960",
+					"172.20.0.1:39960"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:38:25.349121596Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1377968672203558,
+				"StableID":   "nmWyvDu5mB11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28f8f943646e5b894bd4951eff6b08633cd44d1ede7858fe1c25d6d884ffb729",
+				"DiscoKey":   "discokey:8092c7e21c4a486f8a6df94e863991fe1e786889cc31299b32fa10d7e8437424",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54707",
+					"10.65.0.27:54707",
+					"172.17.0.1:54707",
+					"172.19.0.1:54707",
+					"172.20.0.1:54707"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:38:25.89289962Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7135187296562774,
+				"StableID":   "nfja6jGYix11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6aba16362dd906263f5d28175ba80cc8a8abce7e2b9eb1c1e60686b766b18235",
+				"DiscoKey":   "discokey:a13c4fb73e162684a81d8dcb3b6e4d08a5ac4e58c70e24d2f3a97f0ea7b4f775",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37303",
+					"10.65.0.27:37303",
+					"172.17.0.1:37303",
+					"172.19.0.1:37303",
+					"172.20.0.1:37303"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:38:26.438228041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         233618072356079,
+				"StableID":   "nk3s4Ykop211CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4d37148e61ce4b213c519cc8cb54524d0a4edfcdfc8c11e2b5257057eb6405f",
+				"DiscoKey":   "discokey:0bbcbf4391cf4fd8bf64855b0cbda4657d58b31af5dc659475707a4bdf359f41",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:40005",
+					"10.65.0.27:40005",
+					"172.17.0.1:40005",
+					"172.19.0.1:40005",
+					"172.20.0.1:40005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:38:26.972061446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1576612755086865,
+				"StableID":   "nSozJjw3KD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b6eb1764e5cfce267b4261d66aa8bf3a934a6e889203085a16dd950191d0509",
+				"DiscoKey":   "discokey:b65b3ef63ddbdbdc68caf418110b14243fbfdeb0a7a1d1bc8b66c0a052237862",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52919",
+					"10.65.0.27:52919",
+					"172.17.0.1:52919",
+					"172.19.0.1:52919",
+					"172.20.0.1:52919"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:38:27.515060229Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7598876428598967,
+				"StableID":   "nELCshbYL221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b3d83dd4d1f9c680e8dc1cda01e70b0237ad571e6c14299bfddeeee7f1d8414",
+				"DiscoKey":   "discokey:dc231c0bf1d67abb7ecd369f8ddee8dceb8213c0eac65c0deee822544e633176",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55155",
+					"10.65.0.27:55155",
+					"172.17.0.1:55155",
+					"172.19.0.1:55155",
+					"172.20.0.1:55155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:38:28.04751184Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4539888849874230,
+				"StableID":   "njHaYYB8Tc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4a9b3ad62b20b77e0840c940e7cec4a6905dacd55d78faa23a3b64172ced263e",
+				"DiscoKey":   "discokey:9772452910d1046b8cc0e5ad123daf900cd6c7cbe7531d7305602706cb7c3f3d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56111",
+					"10.65.0.27:56111",
+					"172.17.0.1:56111",
+					"172.19.0.1:56111",
+					"172.20.0.1:56111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:38:28.592184887Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6680210421805012,
+				"StableID":   "nqXofQoUAu11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5ca43ba42cb01fe91cc4d882f9b2261b2dd2422f99f2da9be2141fa6d5c91462",
+				"KeyExpiry":  "2026-11-08T18:38:29Z",
+				"DiscoKey":   "discokey:bb8916bd7b1dfe5a8a6eeea855040e60e178567e44e16eb51148c64ee9824965",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:55836",
+					"10.65.0.27:55836",
+					"172.17.0.1:55836",
+					"172.19.0.1:55836",
+					"172.20.0.1:55836"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:38:29.144768226Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         372969410384347,
+				"StableID":   "nC95dtGvu311CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8a6b1c11646bd03145c70624a2a770021fcea7c2d90ee42c577d077f780d3a6f",
+				"KeyExpiry":  "2026-11-08T18:38:29Z",
+				"DiscoKey":   "discokey:92f4c6d740c4a633a89c09db46bc27c82b785716c9c2bd966332e150629f4e15",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39270",
+					"10.65.0.27:39270",
+					"172.17.0.1:39270",
+					"172.19.0.1:39270",
+					"172.20.0.1:39270"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:38:29.678817243Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7861257255743688,
+				"StableID":   "nPib55uNP421CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:46d12c9975815bc286cf210b9bedf283f27e8cfbca68a902089ab3c85f447022",
+				"KeyExpiry":  "2026-11-08T18:38:30Z",
+				"DiscoKey":   "discokey:214a39694d62c83e8b5faed9ef30f75cde5ee7d41463d53ef9625c287b75dd13",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44331",
+					"10.65.0.27:44331",
+					"172.17.0.1:44331",
+					"172.19.0.1:44331",
+					"172.20.0.1:44331"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:38:30.225429861Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3531838953319780": {
+				"ID":          3531838953319780,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         417201869267411,
+				"StableID":   "nLMhYmBxF411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       417201869267411,
+				"Key":        "nodekey:52b22d57e836f5520622f0c7d6529fe3b450b03bfda8675323fc6cd4d4a7183a",
+				"DiscoKey":   "discokey:6ebef548f26b3e67d8c86d46ab0e6eb13e7db75e89cd652b411c8be43579d360",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41204",
+					"10.65.0.27:41204",
+					"172.17.0.1:41204",
+					"172.19.0.1:41204",
+					"172.20.0.1:41204"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:38:24.814203311Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:52b22d57e836f5520622f0c7d6529fe3b450b03bfda8675323fc6cd4d4a7183a",
+			"MachineKey": "mkey:1d90baf84a6651084f1f309a0235ffd45e01f9df0ff73437dd5f5c345582775c",
+			"Peers": [{
+				"ID":         3531838953319780,
+				"StableID":   "nbeF6PRaaU11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:839701f9cd3247681b0303c5da67af28bc8d138bb0517dd71ec99b824b40257e",
+				"DiscoKey":   "discokey:25d482e1d98ae5d10740fccdbd59cb83e8d6dace6a130c4066dfff84114d3e13",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33873",
+					"10.65.0.27:33873",
+					"172.17.0.1:33873",
+					"172.19.0.1:33873",
+					"172.20.0.1:33873"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:38:22.658992188Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1908933400158695,
+				"StableID":   "nLFjjiSZuF11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:899de6931e39c003ed29262115fde54de324f35803dde67e3dd5e8fb86f36a47",
+				"DiscoKey":   "discokey:d65a2b4a6e61456d81ce7d2a62aa04a1d4eba6203faa21d5adda4027808eeb31",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:58044",
+					"10.65.0.27:58044",
+					"172.17.0.1:58044",
+					"172.19.0.1:58044",
+					"172.20.0.1:58044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:38:23.208502176Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8182581777919834,
+				"StableID":   "ndSEnnYut621CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f93cbf9f2d6cf7a63ded046ec3725b3a28324637162502f5e3f8ffd5e1c3c71d",
+				"DiscoKey":   "discokey:c5d22a78d96fbe393e65568b8d2b6565210e85f0702a6b65be58e239866e4673",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39323",
+					"10.65.0.27:39323",
+					"172.17.0.1:39323",
+					"172.19.0.1:39323",
+					"172.20.0.1:39323"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:38:23.740448591Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2375238083408566,
+				"StableID":   "nZEzoeUkYK11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83a2a57faa49f36d5100ccd0fb2c7474e5fbe21cec6c339a67596e76a18dbc29",
+				"DiscoKey":   "discokey:9a7347c1deffcf59d83629d9dc9fc1deeefc6fa3414f734ca3e452511316015f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:46426",
+					"10.65.0.27:46426",
+					"172.17.0.1:46426",
+					"172.19.0.1:46426",
+					"172.20.0.1:46426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:38:24.27989739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8349808007303302,
+				"StableID":   "njoo2GJeC821CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8125b0a7b4c19db0b678e9e19a269ea24aa9b67d2d11dc01981d68c0d2353b61",
+				"DiscoKey":   "discokey:5b12bd0175100898141f600dea5758faecd706183565fa2d985661895c1f7957",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39960",
+					"10.65.0.27:39960",
+					"172.17.0.1:39960",
+					"172.19.0.1:39960",
+					"172.20.0.1:39960"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:38:25.349121596Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1377968672203558,
+				"StableID":   "nmWyvDu5mB11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28f8f943646e5b894bd4951eff6b08633cd44d1ede7858fe1c25d6d884ffb729",
+				"DiscoKey":   "discokey:8092c7e21c4a486f8a6df94e863991fe1e786889cc31299b32fa10d7e8437424",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54707",
+					"10.65.0.27:54707",
+					"172.17.0.1:54707",
+					"172.19.0.1:54707",
+					"172.20.0.1:54707"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:38:25.89289962Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7135187296562774,
+				"StableID":   "nfja6jGYix11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6aba16362dd906263f5d28175ba80cc8a8abce7e2b9eb1c1e60686b766b18235",
+				"DiscoKey":   "discokey:a13c4fb73e162684a81d8dcb3b6e4d08a5ac4e58c70e24d2f3a97f0ea7b4f775",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37303",
+					"10.65.0.27:37303",
+					"172.17.0.1:37303",
+					"172.19.0.1:37303",
+					"172.20.0.1:37303"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:38:26.438228041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         233618072356079,
+				"StableID":   "nk3s4Ykop211CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4d37148e61ce4b213c519cc8cb54524d0a4edfcdfc8c11e2b5257057eb6405f",
+				"DiscoKey":   "discokey:0bbcbf4391cf4fd8bf64855b0cbda4657d58b31af5dc659475707a4bdf359f41",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:40005",
+					"10.65.0.27:40005",
+					"172.17.0.1:40005",
+					"172.19.0.1:40005",
+					"172.20.0.1:40005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:38:26.972061446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1576612755086865,
+				"StableID":   "nSozJjw3KD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b6eb1764e5cfce267b4261d66aa8bf3a934a6e889203085a16dd950191d0509",
+				"DiscoKey":   "discokey:b65b3ef63ddbdbdc68caf418110b14243fbfdeb0a7a1d1bc8b66c0a052237862",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52919",
+					"10.65.0.27:52919",
+					"172.17.0.1:52919",
+					"172.19.0.1:52919",
+					"172.20.0.1:52919"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:38:27.515060229Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7598876428598967,
+				"StableID":   "nELCshbYL221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b3d83dd4d1f9c680e8dc1cda01e70b0237ad571e6c14299bfddeeee7f1d8414",
+				"DiscoKey":   "discokey:dc231c0bf1d67abb7ecd369f8ddee8dceb8213c0eac65c0deee822544e633176",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55155",
+					"10.65.0.27:55155",
+					"172.17.0.1:55155",
+					"172.19.0.1:55155",
+					"172.20.0.1:55155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:38:28.04751184Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4539888849874230,
+				"StableID":   "njHaYYB8Tc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4a9b3ad62b20b77e0840c940e7cec4a6905dacd55d78faa23a3b64172ced263e",
+				"DiscoKey":   "discokey:9772452910d1046b8cc0e5ad123daf900cd6c7cbe7531d7305602706cb7c3f3d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56111",
+					"10.65.0.27:56111",
+					"172.17.0.1:56111",
+					"172.19.0.1:56111",
+					"172.20.0.1:56111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:38:28.592184887Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6680210421805012,
+				"StableID":   "nqXofQoUAu11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5ca43ba42cb01fe91cc4d882f9b2261b2dd2422f99f2da9be2141fa6d5c91462",
+				"KeyExpiry":  "2026-11-08T18:38:29Z",
+				"DiscoKey":   "discokey:bb8916bd7b1dfe5a8a6eeea855040e60e178567e44e16eb51148c64ee9824965",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:55836",
+					"10.65.0.27:55836",
+					"172.17.0.1:55836",
+					"172.19.0.1:55836",
+					"172.20.0.1:55836"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:38:29.144768226Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         372969410384347,
+				"StableID":   "nC95dtGvu311CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8a6b1c11646bd03145c70624a2a770021fcea7c2d90ee42c577d077f780d3a6f",
+				"KeyExpiry":  "2026-11-08T18:38:29Z",
+				"DiscoKey":   "discokey:92f4c6d740c4a633a89c09db46bc27c82b785716c9c2bd966332e150629f4e15",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39270",
+					"10.65.0.27:39270",
+					"172.17.0.1:39270",
+					"172.19.0.1:39270",
+					"172.20.0.1:39270"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:38:29.678817243Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7861257255743688,
+				"StableID":   "nPib55uNP421CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:46d12c9975815bc286cf210b9bedf283f27e8cfbca68a902089ab3c85f447022",
+				"KeyExpiry":  "2026-11-08T18:38:30Z",
+				"DiscoKey":   "discokey:214a39694d62c83e8b5faed9ef30f75cde5ee7d41463d53ef9625c287b75dd13",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44331",
+					"10.65.0.27:44331",
+					"172.17.0.1:44331",
+					"172.19.0.1:44331",
+					"172.20.0.1:44331"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:38:30.225429861Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "417201869267411": {
+				"ID":          417201869267411,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2375238083408566,
+				"StableID":   "nZEzoeUkYK11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       2375238083408566,
+				"Key":        "nodekey:83a2a57faa49f36d5100ccd0fb2c7474e5fbe21cec6c339a67596e76a18dbc29",
+				"DiscoKey":   "discokey:9a7347c1deffcf59d83629d9dc9fc1deeefc6fa3414f734ca3e452511316015f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:46426",
+					"10.65.0.27:46426",
+					"172.17.0.1:46426",
+					"172.19.0.1:46426",
+					"172.20.0.1:46426"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:38:24.27989739Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:83a2a57faa49f36d5100ccd0fb2c7474e5fbe21cec6c339a67596e76a18dbc29",
+			"MachineKey": "mkey:f6de10d1cf1ffc47cdf4683c50243ec009606e06995a61ebd6d8ad628b602305",
+			"Peers": [{
+				"ID":         3531838953319780,
+				"StableID":   "nbeF6PRaaU11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:839701f9cd3247681b0303c5da67af28bc8d138bb0517dd71ec99b824b40257e",
+				"DiscoKey":   "discokey:25d482e1d98ae5d10740fccdbd59cb83e8d6dace6a130c4066dfff84114d3e13",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33873",
+					"10.65.0.27:33873",
+					"172.17.0.1:33873",
+					"172.19.0.1:33873",
+					"172.20.0.1:33873"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:38:22.658992188Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1908933400158695,
+				"StableID":   "nLFjjiSZuF11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:899de6931e39c003ed29262115fde54de324f35803dde67e3dd5e8fb86f36a47",
+				"DiscoKey":   "discokey:d65a2b4a6e61456d81ce7d2a62aa04a1d4eba6203faa21d5adda4027808eeb31",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:58044",
+					"10.65.0.27:58044",
+					"172.17.0.1:58044",
+					"172.19.0.1:58044",
+					"172.20.0.1:58044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:38:23.208502176Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8182581777919834,
+				"StableID":   "ndSEnnYut621CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f93cbf9f2d6cf7a63ded046ec3725b3a28324637162502f5e3f8ffd5e1c3c71d",
+				"DiscoKey":   "discokey:c5d22a78d96fbe393e65568b8d2b6565210e85f0702a6b65be58e239866e4673",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39323",
+					"10.65.0.27:39323",
+					"172.17.0.1:39323",
+					"172.19.0.1:39323",
+					"172.20.0.1:39323"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:38:23.740448591Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         417201869267411,
+				"StableID":   "nLMhYmBxF411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:52b22d57e836f5520622f0c7d6529fe3b450b03bfda8675323fc6cd4d4a7183a",
+				"DiscoKey":   "discokey:6ebef548f26b3e67d8c86d46ab0e6eb13e7db75e89cd652b411c8be43579d360",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41204",
+					"10.65.0.27:41204",
+					"172.17.0.1:41204",
+					"172.19.0.1:41204",
+					"172.20.0.1:41204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:38:24.814203311Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8349808007303302,
+				"StableID":   "njoo2GJeC821CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8125b0a7b4c19db0b678e9e19a269ea24aa9b67d2d11dc01981d68c0d2353b61",
+				"DiscoKey":   "discokey:5b12bd0175100898141f600dea5758faecd706183565fa2d985661895c1f7957",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39960",
+					"10.65.0.27:39960",
+					"172.17.0.1:39960",
+					"172.19.0.1:39960",
+					"172.20.0.1:39960"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:38:25.349121596Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1377968672203558,
+				"StableID":   "nmWyvDu5mB11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28f8f943646e5b894bd4951eff6b08633cd44d1ede7858fe1c25d6d884ffb729",
+				"DiscoKey":   "discokey:8092c7e21c4a486f8a6df94e863991fe1e786889cc31299b32fa10d7e8437424",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54707",
+					"10.65.0.27:54707",
+					"172.17.0.1:54707",
+					"172.19.0.1:54707",
+					"172.20.0.1:54707"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:38:25.89289962Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7135187296562774,
+				"StableID":   "nfja6jGYix11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6aba16362dd906263f5d28175ba80cc8a8abce7e2b9eb1c1e60686b766b18235",
+				"DiscoKey":   "discokey:a13c4fb73e162684a81d8dcb3b6e4d08a5ac4e58c70e24d2f3a97f0ea7b4f775",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37303",
+					"10.65.0.27:37303",
+					"172.17.0.1:37303",
+					"172.19.0.1:37303",
+					"172.20.0.1:37303"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:38:26.438228041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         233618072356079,
+				"StableID":   "nk3s4Ykop211CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4d37148e61ce4b213c519cc8cb54524d0a4edfcdfc8c11e2b5257057eb6405f",
+				"DiscoKey":   "discokey:0bbcbf4391cf4fd8bf64855b0cbda4657d58b31af5dc659475707a4bdf359f41",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:40005",
+					"10.65.0.27:40005",
+					"172.17.0.1:40005",
+					"172.19.0.1:40005",
+					"172.20.0.1:40005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:38:26.972061446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1576612755086865,
+				"StableID":   "nSozJjw3KD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b6eb1764e5cfce267b4261d66aa8bf3a934a6e889203085a16dd950191d0509",
+				"DiscoKey":   "discokey:b65b3ef63ddbdbdc68caf418110b14243fbfdeb0a7a1d1bc8b66c0a052237862",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52919",
+					"10.65.0.27:52919",
+					"172.17.0.1:52919",
+					"172.19.0.1:52919",
+					"172.20.0.1:52919"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:38:27.515060229Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7598876428598967,
+				"StableID":   "nELCshbYL221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b3d83dd4d1f9c680e8dc1cda01e70b0237ad571e6c14299bfddeeee7f1d8414",
+				"DiscoKey":   "discokey:dc231c0bf1d67abb7ecd369f8ddee8dceb8213c0eac65c0deee822544e633176",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55155",
+					"10.65.0.27:55155",
+					"172.17.0.1:55155",
+					"172.19.0.1:55155",
+					"172.20.0.1:55155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:38:28.04751184Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4539888849874230,
+				"StableID":   "njHaYYB8Tc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4a9b3ad62b20b77e0840c940e7cec4a6905dacd55d78faa23a3b64172ced263e",
+				"DiscoKey":   "discokey:9772452910d1046b8cc0e5ad123daf900cd6c7cbe7531d7305602706cb7c3f3d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56111",
+					"10.65.0.27:56111",
+					"172.17.0.1:56111",
+					"172.19.0.1:56111",
+					"172.20.0.1:56111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:38:28.592184887Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6680210421805012,
+				"StableID":   "nqXofQoUAu11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5ca43ba42cb01fe91cc4d882f9b2261b2dd2422f99f2da9be2141fa6d5c91462",
+				"KeyExpiry":  "2026-11-08T18:38:29Z",
+				"DiscoKey":   "discokey:bb8916bd7b1dfe5a8a6eeea855040e60e178567e44e16eb51148c64ee9824965",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:55836",
+					"10.65.0.27:55836",
+					"172.17.0.1:55836",
+					"172.19.0.1:55836",
+					"172.20.0.1:55836"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:38:29.144768226Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         372969410384347,
+				"StableID":   "nC95dtGvu311CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8a6b1c11646bd03145c70624a2a770021fcea7c2d90ee42c577d077f780d3a6f",
+				"KeyExpiry":  "2026-11-08T18:38:29Z",
+				"DiscoKey":   "discokey:92f4c6d740c4a633a89c09db46bc27c82b785716c9c2bd966332e150629f4e15",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39270",
+					"10.65.0.27:39270",
+					"172.17.0.1:39270",
+					"172.19.0.1:39270",
+					"172.20.0.1:39270"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:38:29.678817243Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7861257255743688,
+				"StableID":   "nPib55uNP421CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:46d12c9975815bc286cf210b9bedf283f27e8cfbca68a902089ab3c85f447022",
+				"KeyExpiry":  "2026-11-08T18:38:30Z",
+				"DiscoKey":   "discokey:214a39694d62c83e8b5faed9ef30f75cde5ee7d41463d53ef9625c287b75dd13",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44331",
+					"10.65.0.27:44331",
+					"172.17.0.1:44331",
+					"172.19.0.1:44331",
+					"172.20.0.1:44331"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:38:30.225429861Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2375238083408566": {
+				"ID":          2375238083408566,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1377968672203558,
+				"StableID":   "nmWyvDu5mB11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1377968672203558,
+				"Key":        "nodekey:28f8f943646e5b894bd4951eff6b08633cd44d1ede7858fe1c25d6d884ffb729",
+				"DiscoKey":   "discokey:8092c7e21c4a486f8a6df94e863991fe1e786889cc31299b32fa10d7e8437424",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54707",
+					"10.65.0.27:54707",
+					"172.17.0.1:54707",
+					"172.19.0.1:54707",
+					"172.20.0.1:54707"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:38:25.89289962Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:28f8f943646e5b894bd4951eff6b08633cd44d1ede7858fe1c25d6d884ffb729",
+			"MachineKey": "mkey:a685c871d61d4918e26c05eefa2bfd087f381bc4a96fc0bbfc5eced7001c601c",
+			"Peers": [{
+				"ID":         3531838953319780,
+				"StableID":   "nbeF6PRaaU11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:839701f9cd3247681b0303c5da67af28bc8d138bb0517dd71ec99b824b40257e",
+				"DiscoKey":   "discokey:25d482e1d98ae5d10740fccdbd59cb83e8d6dace6a130c4066dfff84114d3e13",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33873",
+					"10.65.0.27:33873",
+					"172.17.0.1:33873",
+					"172.19.0.1:33873",
+					"172.20.0.1:33873"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:38:22.658992188Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1908933400158695,
+				"StableID":   "nLFjjiSZuF11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:899de6931e39c003ed29262115fde54de324f35803dde67e3dd5e8fb86f36a47",
+				"DiscoKey":   "discokey:d65a2b4a6e61456d81ce7d2a62aa04a1d4eba6203faa21d5adda4027808eeb31",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:58044",
+					"10.65.0.27:58044",
+					"172.17.0.1:58044",
+					"172.19.0.1:58044",
+					"172.20.0.1:58044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:38:23.208502176Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8182581777919834,
+				"StableID":   "ndSEnnYut621CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f93cbf9f2d6cf7a63ded046ec3725b3a28324637162502f5e3f8ffd5e1c3c71d",
+				"DiscoKey":   "discokey:c5d22a78d96fbe393e65568b8d2b6565210e85f0702a6b65be58e239866e4673",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39323",
+					"10.65.0.27:39323",
+					"172.17.0.1:39323",
+					"172.19.0.1:39323",
+					"172.20.0.1:39323"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:38:23.740448591Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2375238083408566,
+				"StableID":   "nZEzoeUkYK11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83a2a57faa49f36d5100ccd0fb2c7474e5fbe21cec6c339a67596e76a18dbc29",
+				"DiscoKey":   "discokey:9a7347c1deffcf59d83629d9dc9fc1deeefc6fa3414f734ca3e452511316015f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:46426",
+					"10.65.0.27:46426",
+					"172.17.0.1:46426",
+					"172.19.0.1:46426",
+					"172.20.0.1:46426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:38:24.27989739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         417201869267411,
+				"StableID":   "nLMhYmBxF411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:52b22d57e836f5520622f0c7d6529fe3b450b03bfda8675323fc6cd4d4a7183a",
+				"DiscoKey":   "discokey:6ebef548f26b3e67d8c86d46ab0e6eb13e7db75e89cd652b411c8be43579d360",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41204",
+					"10.65.0.27:41204",
+					"172.17.0.1:41204",
+					"172.19.0.1:41204",
+					"172.20.0.1:41204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:38:24.814203311Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8349808007303302,
+				"StableID":   "njoo2GJeC821CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8125b0a7b4c19db0b678e9e19a269ea24aa9b67d2d11dc01981d68c0d2353b61",
+				"DiscoKey":   "discokey:5b12bd0175100898141f600dea5758faecd706183565fa2d985661895c1f7957",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39960",
+					"10.65.0.27:39960",
+					"172.17.0.1:39960",
+					"172.19.0.1:39960",
+					"172.20.0.1:39960"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:38:25.349121596Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7135187296562774,
+				"StableID":   "nfja6jGYix11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6aba16362dd906263f5d28175ba80cc8a8abce7e2b9eb1c1e60686b766b18235",
+				"DiscoKey":   "discokey:a13c4fb73e162684a81d8dcb3b6e4d08a5ac4e58c70e24d2f3a97f0ea7b4f775",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37303",
+					"10.65.0.27:37303",
+					"172.17.0.1:37303",
+					"172.19.0.1:37303",
+					"172.20.0.1:37303"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:38:26.438228041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         233618072356079,
+				"StableID":   "nk3s4Ykop211CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4d37148e61ce4b213c519cc8cb54524d0a4edfcdfc8c11e2b5257057eb6405f",
+				"DiscoKey":   "discokey:0bbcbf4391cf4fd8bf64855b0cbda4657d58b31af5dc659475707a4bdf359f41",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:40005",
+					"10.65.0.27:40005",
+					"172.17.0.1:40005",
+					"172.19.0.1:40005",
+					"172.20.0.1:40005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:38:26.972061446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1576612755086865,
+				"StableID":   "nSozJjw3KD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b6eb1764e5cfce267b4261d66aa8bf3a934a6e889203085a16dd950191d0509",
+				"DiscoKey":   "discokey:b65b3ef63ddbdbdc68caf418110b14243fbfdeb0a7a1d1bc8b66c0a052237862",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52919",
+					"10.65.0.27:52919",
+					"172.17.0.1:52919",
+					"172.19.0.1:52919",
+					"172.20.0.1:52919"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:38:27.515060229Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7598876428598967,
+				"StableID":   "nELCshbYL221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b3d83dd4d1f9c680e8dc1cda01e70b0237ad571e6c14299bfddeeee7f1d8414",
+				"DiscoKey":   "discokey:dc231c0bf1d67abb7ecd369f8ddee8dceb8213c0eac65c0deee822544e633176",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55155",
+					"10.65.0.27:55155",
+					"172.17.0.1:55155",
+					"172.19.0.1:55155",
+					"172.20.0.1:55155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:38:28.04751184Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4539888849874230,
+				"StableID":   "njHaYYB8Tc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4a9b3ad62b20b77e0840c940e7cec4a6905dacd55d78faa23a3b64172ced263e",
+				"DiscoKey":   "discokey:9772452910d1046b8cc0e5ad123daf900cd6c7cbe7531d7305602706cb7c3f3d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56111",
+					"10.65.0.27:56111",
+					"172.17.0.1:56111",
+					"172.19.0.1:56111",
+					"172.20.0.1:56111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:38:28.592184887Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6680210421805012,
+				"StableID":   "nqXofQoUAu11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5ca43ba42cb01fe91cc4d882f9b2261b2dd2422f99f2da9be2141fa6d5c91462",
+				"KeyExpiry":  "2026-11-08T18:38:29Z",
+				"DiscoKey":   "discokey:bb8916bd7b1dfe5a8a6eeea855040e60e178567e44e16eb51148c64ee9824965",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:55836",
+					"10.65.0.27:55836",
+					"172.17.0.1:55836",
+					"172.19.0.1:55836",
+					"172.20.0.1:55836"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:38:29.144768226Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         372969410384347,
+				"StableID":   "nC95dtGvu311CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8a6b1c11646bd03145c70624a2a770021fcea7c2d90ee42c577d077f780d3a6f",
+				"KeyExpiry":  "2026-11-08T18:38:29Z",
+				"DiscoKey":   "discokey:92f4c6d740c4a633a89c09db46bc27c82b785716c9c2bd966332e150629f4e15",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39270",
+					"10.65.0.27:39270",
+					"172.17.0.1:39270",
+					"172.19.0.1:39270",
+					"172.20.0.1:39270"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:38:29.678817243Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7861257255743688,
+				"StableID":   "nPib55uNP421CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:46d12c9975815bc286cf210b9bedf283f27e8cfbca68a902089ab3c85f447022",
+				"KeyExpiry":  "2026-11-08T18:38:30Z",
+				"DiscoKey":   "discokey:214a39694d62c83e8b5faed9ef30f75cde5ee7d41463d53ef9625c287b75dd13",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44331",
+					"10.65.0.27:44331",
+					"172.17.0.1:44331",
+					"172.19.0.1:44331",
+					"172.20.0.1:44331"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:38:30.225429861Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1377968672203558": {
+				"ID":          1377968672203558,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         233618072356079,
+				"StableID":   "nk3s4Ykop211CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       233618072356079,
+				"Key":        "nodekey:e4d37148e61ce4b213c519cc8cb54524d0a4edfcdfc8c11e2b5257057eb6405f",
+				"DiscoKey":   "discokey:0bbcbf4391cf4fd8bf64855b0cbda4657d58b31af5dc659475707a4bdf359f41",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:40005",
+					"10.65.0.27:40005",
+					"172.17.0.1:40005",
+					"172.19.0.1:40005",
+					"172.20.0.1:40005"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:38:26.972061446Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e4d37148e61ce4b213c519cc8cb54524d0a4edfcdfc8c11e2b5257057eb6405f",
+			"MachineKey": "mkey:29385b4e50ce4697e1066d5e57206710c8adfa6729e7ab5a21bf2f5c042fb436",
+			"Peers": [{
+				"ID":         3531838953319780,
+				"StableID":   "nbeF6PRaaU11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:839701f9cd3247681b0303c5da67af28bc8d138bb0517dd71ec99b824b40257e",
+				"DiscoKey":   "discokey:25d482e1d98ae5d10740fccdbd59cb83e8d6dace6a130c4066dfff84114d3e13",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33873",
+					"10.65.0.27:33873",
+					"172.17.0.1:33873",
+					"172.19.0.1:33873",
+					"172.20.0.1:33873"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:38:22.658992188Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1908933400158695,
+				"StableID":   "nLFjjiSZuF11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:899de6931e39c003ed29262115fde54de324f35803dde67e3dd5e8fb86f36a47",
+				"DiscoKey":   "discokey:d65a2b4a6e61456d81ce7d2a62aa04a1d4eba6203faa21d5adda4027808eeb31",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:58044",
+					"10.65.0.27:58044",
+					"172.17.0.1:58044",
+					"172.19.0.1:58044",
+					"172.20.0.1:58044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:38:23.208502176Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8182581777919834,
+				"StableID":   "ndSEnnYut621CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f93cbf9f2d6cf7a63ded046ec3725b3a28324637162502f5e3f8ffd5e1c3c71d",
+				"DiscoKey":   "discokey:c5d22a78d96fbe393e65568b8d2b6565210e85f0702a6b65be58e239866e4673",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39323",
+					"10.65.0.27:39323",
+					"172.17.0.1:39323",
+					"172.19.0.1:39323",
+					"172.20.0.1:39323"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:38:23.740448591Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2375238083408566,
+				"StableID":   "nZEzoeUkYK11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83a2a57faa49f36d5100ccd0fb2c7474e5fbe21cec6c339a67596e76a18dbc29",
+				"DiscoKey":   "discokey:9a7347c1deffcf59d83629d9dc9fc1deeefc6fa3414f734ca3e452511316015f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:46426",
+					"10.65.0.27:46426",
+					"172.17.0.1:46426",
+					"172.19.0.1:46426",
+					"172.20.0.1:46426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:38:24.27989739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         417201869267411,
+				"StableID":   "nLMhYmBxF411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:52b22d57e836f5520622f0c7d6529fe3b450b03bfda8675323fc6cd4d4a7183a",
+				"DiscoKey":   "discokey:6ebef548f26b3e67d8c86d46ab0e6eb13e7db75e89cd652b411c8be43579d360",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41204",
+					"10.65.0.27:41204",
+					"172.17.0.1:41204",
+					"172.19.0.1:41204",
+					"172.20.0.1:41204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:38:24.814203311Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8349808007303302,
+				"StableID":   "njoo2GJeC821CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8125b0a7b4c19db0b678e9e19a269ea24aa9b67d2d11dc01981d68c0d2353b61",
+				"DiscoKey":   "discokey:5b12bd0175100898141f600dea5758faecd706183565fa2d985661895c1f7957",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39960",
+					"10.65.0.27:39960",
+					"172.17.0.1:39960",
+					"172.19.0.1:39960",
+					"172.20.0.1:39960"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:38:25.349121596Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1377968672203558,
+				"StableID":   "nmWyvDu5mB11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28f8f943646e5b894bd4951eff6b08633cd44d1ede7858fe1c25d6d884ffb729",
+				"DiscoKey":   "discokey:8092c7e21c4a486f8a6df94e863991fe1e786889cc31299b32fa10d7e8437424",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54707",
+					"10.65.0.27:54707",
+					"172.17.0.1:54707",
+					"172.19.0.1:54707",
+					"172.20.0.1:54707"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:38:25.89289962Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7135187296562774,
+				"StableID":   "nfja6jGYix11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6aba16362dd906263f5d28175ba80cc8a8abce7e2b9eb1c1e60686b766b18235",
+				"DiscoKey":   "discokey:a13c4fb73e162684a81d8dcb3b6e4d08a5ac4e58c70e24d2f3a97f0ea7b4f775",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37303",
+					"10.65.0.27:37303",
+					"172.17.0.1:37303",
+					"172.19.0.1:37303",
+					"172.20.0.1:37303"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:38:26.438228041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1576612755086865,
+				"StableID":   "nSozJjw3KD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b6eb1764e5cfce267b4261d66aa8bf3a934a6e889203085a16dd950191d0509",
+				"DiscoKey":   "discokey:b65b3ef63ddbdbdc68caf418110b14243fbfdeb0a7a1d1bc8b66c0a052237862",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52919",
+					"10.65.0.27:52919",
+					"172.17.0.1:52919",
+					"172.19.0.1:52919",
+					"172.20.0.1:52919"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:38:27.515060229Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7598876428598967,
+				"StableID":   "nELCshbYL221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b3d83dd4d1f9c680e8dc1cda01e70b0237ad571e6c14299bfddeeee7f1d8414",
+				"DiscoKey":   "discokey:dc231c0bf1d67abb7ecd369f8ddee8dceb8213c0eac65c0deee822544e633176",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55155",
+					"10.65.0.27:55155",
+					"172.17.0.1:55155",
+					"172.19.0.1:55155",
+					"172.20.0.1:55155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:38:28.04751184Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4539888849874230,
+				"StableID":   "njHaYYB8Tc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4a9b3ad62b20b77e0840c940e7cec4a6905dacd55d78faa23a3b64172ced263e",
+				"DiscoKey":   "discokey:9772452910d1046b8cc0e5ad123daf900cd6c7cbe7531d7305602706cb7c3f3d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56111",
+					"10.65.0.27:56111",
+					"172.17.0.1:56111",
+					"172.19.0.1:56111",
+					"172.20.0.1:56111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:38:28.592184887Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6680210421805012,
+				"StableID":   "nqXofQoUAu11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5ca43ba42cb01fe91cc4d882f9b2261b2dd2422f99f2da9be2141fa6d5c91462",
+				"KeyExpiry":  "2026-11-08T18:38:29Z",
+				"DiscoKey":   "discokey:bb8916bd7b1dfe5a8a6eeea855040e60e178567e44e16eb51148c64ee9824965",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:55836",
+					"10.65.0.27:55836",
+					"172.17.0.1:55836",
+					"172.19.0.1:55836",
+					"172.20.0.1:55836"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:38:29.144768226Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         372969410384347,
+				"StableID":   "nC95dtGvu311CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8a6b1c11646bd03145c70624a2a770021fcea7c2d90ee42c577d077f780d3a6f",
+				"KeyExpiry":  "2026-11-08T18:38:29Z",
+				"DiscoKey":   "discokey:92f4c6d740c4a633a89c09db46bc27c82b785716c9c2bd966332e150629f4e15",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39270",
+					"10.65.0.27:39270",
+					"172.17.0.1:39270",
+					"172.19.0.1:39270",
+					"172.20.0.1:39270"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:38:29.678817243Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7861257255743688,
+				"StableID":   "nPib55uNP421CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:46d12c9975815bc286cf210b9bedf283f27e8cfbca68a902089ab3c85f447022",
+				"KeyExpiry":  "2026-11-08T18:38:30Z",
+				"DiscoKey":   "discokey:214a39694d62c83e8b5faed9ef30f75cde5ee7d41463d53ef9625c287b75dd13",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44331",
+					"10.65.0.27:44331",
+					"172.17.0.1:44331",
+					"172.19.0.1:44331",
+					"172.20.0.1:44331"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:38:30.225429861Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "233618072356079": {
+				"ID":          233618072356079,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         372969410384347,
+				"StableID":   "nC95dtGvu311CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8a6b1c11646bd03145c70624a2a770021fcea7c2d90ee42c577d077f780d3a6f",
+				"KeyExpiry":  "2026-11-08T18:38:29Z",
+				"DiscoKey":   "discokey:92f4c6d740c4a633a89c09db46bc27c82b785716c9c2bd966332e150629f4e15",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39270",
+					"10.65.0.27:39270",
+					"172.17.0.1:39270",
+					"172.19.0.1:39270",
+					"172.20.0.1:39270"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:38:29.678817243Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8a6b1c11646bd03145c70624a2a770021fcea7c2d90ee42c577d077f780d3a6f",
+			"MachineKey": "mkey:7f48918102117cbe039cab4f33fd8059bd23cf26cf2e9187c5cdff2667523429",
+			"Peers": [{
+				"ID":         3531838953319780,
+				"StableID":   "nbeF6PRaaU11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:839701f9cd3247681b0303c5da67af28bc8d138bb0517dd71ec99b824b40257e",
+				"DiscoKey":   "discokey:25d482e1d98ae5d10740fccdbd59cb83e8d6dace6a130c4066dfff84114d3e13",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33873",
+					"10.65.0.27:33873",
+					"172.17.0.1:33873",
+					"172.19.0.1:33873",
+					"172.20.0.1:33873"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:38:22.658992188Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1908933400158695,
+				"StableID":   "nLFjjiSZuF11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:899de6931e39c003ed29262115fde54de324f35803dde67e3dd5e8fb86f36a47",
+				"DiscoKey":   "discokey:d65a2b4a6e61456d81ce7d2a62aa04a1d4eba6203faa21d5adda4027808eeb31",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:58044",
+					"10.65.0.27:58044",
+					"172.17.0.1:58044",
+					"172.19.0.1:58044",
+					"172.20.0.1:58044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:38:23.208502176Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8182581777919834,
+				"StableID":   "ndSEnnYut621CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f93cbf9f2d6cf7a63ded046ec3725b3a28324637162502f5e3f8ffd5e1c3c71d",
+				"DiscoKey":   "discokey:c5d22a78d96fbe393e65568b8d2b6565210e85f0702a6b65be58e239866e4673",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39323",
+					"10.65.0.27:39323",
+					"172.17.0.1:39323",
+					"172.19.0.1:39323",
+					"172.20.0.1:39323"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:38:23.740448591Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2375238083408566,
+				"StableID":   "nZEzoeUkYK11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83a2a57faa49f36d5100ccd0fb2c7474e5fbe21cec6c339a67596e76a18dbc29",
+				"DiscoKey":   "discokey:9a7347c1deffcf59d83629d9dc9fc1deeefc6fa3414f734ca3e452511316015f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:46426",
+					"10.65.0.27:46426",
+					"172.17.0.1:46426",
+					"172.19.0.1:46426",
+					"172.20.0.1:46426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:38:24.27989739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         417201869267411,
+				"StableID":   "nLMhYmBxF411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:52b22d57e836f5520622f0c7d6529fe3b450b03bfda8675323fc6cd4d4a7183a",
+				"DiscoKey":   "discokey:6ebef548f26b3e67d8c86d46ab0e6eb13e7db75e89cd652b411c8be43579d360",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41204",
+					"10.65.0.27:41204",
+					"172.17.0.1:41204",
+					"172.19.0.1:41204",
+					"172.20.0.1:41204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:38:24.814203311Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8349808007303302,
+				"StableID":   "njoo2GJeC821CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8125b0a7b4c19db0b678e9e19a269ea24aa9b67d2d11dc01981d68c0d2353b61",
+				"DiscoKey":   "discokey:5b12bd0175100898141f600dea5758faecd706183565fa2d985661895c1f7957",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39960",
+					"10.65.0.27:39960",
+					"172.17.0.1:39960",
+					"172.19.0.1:39960",
+					"172.20.0.1:39960"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:38:25.349121596Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1377968672203558,
+				"StableID":   "nmWyvDu5mB11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28f8f943646e5b894bd4951eff6b08633cd44d1ede7858fe1c25d6d884ffb729",
+				"DiscoKey":   "discokey:8092c7e21c4a486f8a6df94e863991fe1e786889cc31299b32fa10d7e8437424",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54707",
+					"10.65.0.27:54707",
+					"172.17.0.1:54707",
+					"172.19.0.1:54707",
+					"172.20.0.1:54707"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:38:25.89289962Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7135187296562774,
+				"StableID":   "nfja6jGYix11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6aba16362dd906263f5d28175ba80cc8a8abce7e2b9eb1c1e60686b766b18235",
+				"DiscoKey":   "discokey:a13c4fb73e162684a81d8dcb3b6e4d08a5ac4e58c70e24d2f3a97f0ea7b4f775",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37303",
+					"10.65.0.27:37303",
+					"172.17.0.1:37303",
+					"172.19.0.1:37303",
+					"172.20.0.1:37303"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:38:26.438228041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         233618072356079,
+				"StableID":   "nk3s4Ykop211CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4d37148e61ce4b213c519cc8cb54524d0a4edfcdfc8c11e2b5257057eb6405f",
+				"DiscoKey":   "discokey:0bbcbf4391cf4fd8bf64855b0cbda4657d58b31af5dc659475707a4bdf359f41",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:40005",
+					"10.65.0.27:40005",
+					"172.17.0.1:40005",
+					"172.19.0.1:40005",
+					"172.20.0.1:40005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:38:26.972061446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1576612755086865,
+				"StableID":   "nSozJjw3KD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b6eb1764e5cfce267b4261d66aa8bf3a934a6e889203085a16dd950191d0509",
+				"DiscoKey":   "discokey:b65b3ef63ddbdbdc68caf418110b14243fbfdeb0a7a1d1bc8b66c0a052237862",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52919",
+					"10.65.0.27:52919",
+					"172.17.0.1:52919",
+					"172.19.0.1:52919",
+					"172.20.0.1:52919"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:38:27.515060229Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7598876428598967,
+				"StableID":   "nELCshbYL221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b3d83dd4d1f9c680e8dc1cda01e70b0237ad571e6c14299bfddeeee7f1d8414",
+				"DiscoKey":   "discokey:dc231c0bf1d67abb7ecd369f8ddee8dceb8213c0eac65c0deee822544e633176",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55155",
+					"10.65.0.27:55155",
+					"172.17.0.1:55155",
+					"172.19.0.1:55155",
+					"172.20.0.1:55155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:38:28.04751184Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4539888849874230,
+				"StableID":   "njHaYYB8Tc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4a9b3ad62b20b77e0840c940e7cec4a6905dacd55d78faa23a3b64172ced263e",
+				"DiscoKey":   "discokey:9772452910d1046b8cc0e5ad123daf900cd6c7cbe7531d7305602706cb7c3f3d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56111",
+					"10.65.0.27:56111",
+					"172.17.0.1:56111",
+					"172.19.0.1:56111",
+					"172.20.0.1:56111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:38:28.592184887Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6680210421805012,
+				"StableID":   "nqXofQoUAu11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5ca43ba42cb01fe91cc4d882f9b2261b2dd2422f99f2da9be2141fa6d5c91462",
+				"KeyExpiry":  "2026-11-08T18:38:29Z",
+				"DiscoKey":   "discokey:bb8916bd7b1dfe5a8a6eeea855040e60e178567e44e16eb51148c64ee9824965",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:55836",
+					"10.65.0.27:55836",
+					"172.17.0.1:55836",
+					"172.19.0.1:55836",
+					"172.20.0.1:55836"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:38:29.144768226Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7861257255743688,
+				"StableID":   "nPib55uNP421CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:46d12c9975815bc286cf210b9bedf283f27e8cfbca68a902089ab3c85f447022",
+				"KeyExpiry":  "2026-11-08T18:38:30Z",
+				"DiscoKey":   "discokey:214a39694d62c83e8b5faed9ef30f75cde5ee7d41463d53ef9625c287b75dd13",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44331",
+					"10.65.0.27:44331",
+					"172.17.0.1:44331",
+					"172.19.0.1:44331",
+					"172.20.0.1:44331"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:38:30.225429861Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{
+				"principals": [{"nodeIP": "100.64.0.18"}, {"nodeIP": "fd7a:115c:a1e0::12"}],
+				"sshUsers":   {"root": "root"},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				}
+			}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		},
+		"ssh_rules": [{
+			"principals": [{"nodeIP": "100.64.0.18"}, {"nodeIP": "fd7a:115c:a1e0::12"}],
+			"sshUsers":   {"root": "root"},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}
+		}]
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1576612755086865,
+				"StableID":   "nSozJjw3KD11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1576612755086865,
+				"Key":        "nodekey:4b6eb1764e5cfce267b4261d66aa8bf3a934a6e889203085a16dd950191d0509",
+				"DiscoKey":   "discokey:b65b3ef63ddbdbdc68caf418110b14243fbfdeb0a7a1d1bc8b66c0a052237862",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:52919",
+					"10.65.0.27:52919",
+					"172.17.0.1:52919",
+					"172.19.0.1:52919",
+					"172.20.0.1:52919"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:38:27.515060229Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4b6eb1764e5cfce267b4261d66aa8bf3a934a6e889203085a16dd950191d0509",
+			"MachineKey": "mkey:f98853bf2076aa8143cc8d92c4e1c9fc9bed37da982f20ddeade5b654d2d376f",
+			"Peers": [{
+				"ID":         3531838953319780,
+				"StableID":   "nbeF6PRaaU11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:839701f9cd3247681b0303c5da67af28bc8d138bb0517dd71ec99b824b40257e",
+				"DiscoKey":   "discokey:25d482e1d98ae5d10740fccdbd59cb83e8d6dace6a130c4066dfff84114d3e13",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33873",
+					"10.65.0.27:33873",
+					"172.17.0.1:33873",
+					"172.19.0.1:33873",
+					"172.20.0.1:33873"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:38:22.658992188Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1908933400158695,
+				"StableID":   "nLFjjiSZuF11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:899de6931e39c003ed29262115fde54de324f35803dde67e3dd5e8fb86f36a47",
+				"DiscoKey":   "discokey:d65a2b4a6e61456d81ce7d2a62aa04a1d4eba6203faa21d5adda4027808eeb31",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:58044",
+					"10.65.0.27:58044",
+					"172.17.0.1:58044",
+					"172.19.0.1:58044",
+					"172.20.0.1:58044"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:38:23.208502176Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8182581777919834,
+				"StableID":   "ndSEnnYut621CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f93cbf9f2d6cf7a63ded046ec3725b3a28324637162502f5e3f8ffd5e1c3c71d",
+				"DiscoKey":   "discokey:c5d22a78d96fbe393e65568b8d2b6565210e85f0702a6b65be58e239866e4673",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:39323",
+					"10.65.0.27:39323",
+					"172.17.0.1:39323",
+					"172.19.0.1:39323",
+					"172.20.0.1:39323"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:38:23.740448591Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2375238083408566,
+				"StableID":   "nZEzoeUkYK11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83a2a57faa49f36d5100ccd0fb2c7474e5fbe21cec6c339a67596e76a18dbc29",
+				"DiscoKey":   "discokey:9a7347c1deffcf59d83629d9dc9fc1deeefc6fa3414f734ca3e452511316015f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:46426",
+					"10.65.0.27:46426",
+					"172.17.0.1:46426",
+					"172.19.0.1:46426",
+					"172.20.0.1:46426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:38:24.27989739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         417201869267411,
+				"StableID":   "nLMhYmBxF411CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:52b22d57e836f5520622f0c7d6529fe3b450b03bfda8675323fc6cd4d4a7183a",
+				"DiscoKey":   "discokey:6ebef548f26b3e67d8c86d46ab0e6eb13e7db75e89cd652b411c8be43579d360",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:41204",
+					"10.65.0.27:41204",
+					"172.17.0.1:41204",
+					"172.19.0.1:41204",
+					"172.20.0.1:41204"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:38:24.814203311Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8349808007303302,
+				"StableID":   "njoo2GJeC821CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8125b0a7b4c19db0b678e9e19a269ea24aa9b67d2d11dc01981d68c0d2353b61",
+				"DiscoKey":   "discokey:5b12bd0175100898141f600dea5758faecd706183565fa2d985661895c1f7957",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39960",
+					"10.65.0.27:39960",
+					"172.17.0.1:39960",
+					"172.19.0.1:39960",
+					"172.20.0.1:39960"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:38:25.349121596Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1377968672203558,
+				"StableID":   "nmWyvDu5mB11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28f8f943646e5b894bd4951eff6b08633cd44d1ede7858fe1c25d6d884ffb729",
+				"DiscoKey":   "discokey:8092c7e21c4a486f8a6df94e863991fe1e786889cc31299b32fa10d7e8437424",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:54707",
+					"10.65.0.27:54707",
+					"172.17.0.1:54707",
+					"172.19.0.1:54707",
+					"172.20.0.1:54707"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:38:25.89289962Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7135187296562774,
+				"StableID":   "nfja6jGYix11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6aba16362dd906263f5d28175ba80cc8a8abce7e2b9eb1c1e60686b766b18235",
+				"DiscoKey":   "discokey:a13c4fb73e162684a81d8dcb3b6e4d08a5ac4e58c70e24d2f3a97f0ea7b4f775",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37303",
+					"10.65.0.27:37303",
+					"172.17.0.1:37303",
+					"172.19.0.1:37303",
+					"172.20.0.1:37303"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:38:26.438228041Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         233618072356079,
+				"StableID":   "nk3s4Ykop211CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4d37148e61ce4b213c519cc8cb54524d0a4edfcdfc8c11e2b5257057eb6405f",
+				"DiscoKey":   "discokey:0bbcbf4391cf4fd8bf64855b0cbda4657d58b31af5dc659475707a4bdf359f41",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:40005",
+					"10.65.0.27:40005",
+					"172.17.0.1:40005",
+					"172.19.0.1:40005",
+					"172.20.0.1:40005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:38:26.972061446Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7598876428598967,
+				"StableID":   "nELCshbYL221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b3d83dd4d1f9c680e8dc1cda01e70b0237ad571e6c14299bfddeeee7f1d8414",
+				"DiscoKey":   "discokey:dc231c0bf1d67abb7ecd369f8ddee8dceb8213c0eac65c0deee822544e633176",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:55155",
+					"10.65.0.27:55155",
+					"172.17.0.1:55155",
+					"172.19.0.1:55155",
+					"172.20.0.1:55155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:38:28.04751184Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4539888849874230,
+				"StableID":   "njHaYYB8Tc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4a9b3ad62b20b77e0840c940e7cec4a6905dacd55d78faa23a3b64172ced263e",
+				"DiscoKey":   "discokey:9772452910d1046b8cc0e5ad123daf900cd6c7cbe7531d7305602706cb7c3f3d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56111",
+					"10.65.0.27:56111",
+					"172.17.0.1:56111",
+					"172.19.0.1:56111",
+					"172.20.0.1:56111"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:38:28.592184887Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6680210421805012,
+				"StableID":   "nqXofQoUAu11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5ca43ba42cb01fe91cc4d882f9b2261b2dd2422f99f2da9be2141fa6d5c91462",
+				"KeyExpiry":  "2026-11-08T18:38:29Z",
+				"DiscoKey":   "discokey:bb8916bd7b1dfe5a8a6eeea855040e60e178567e44e16eb51148c64ee9824965",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:55836",
+					"10.65.0.27:55836",
+					"172.17.0.1:55836",
+					"172.19.0.1:55836",
+					"172.20.0.1:55836"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:38:29.144768226Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         372969410384347,
+				"StableID":   "nC95dtGvu311CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:8a6b1c11646bd03145c70624a2a770021fcea7c2d90ee42c577d077f780d3a6f",
+				"KeyExpiry":  "2026-11-08T18:38:29Z",
+				"DiscoKey":   "discokey:92f4c6d740c4a633a89c09db46bc27c82b785716c9c2bd966332e150629f4e15",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:39270",
+					"10.65.0.27:39270",
+					"172.17.0.1:39270",
+					"172.19.0.1:39270",
+					"172.20.0.1:39270"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:38:29.678817243Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7861257255743688,
+				"StableID":   "nPib55uNP421CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:46d12c9975815bc286cf210b9bedf283f27e8cfbca68a902089ab3c85f447022",
+				"KeyExpiry":  "2026-11-08T18:38:30Z",
+				"DiscoKey":   "discokey:214a39694d62c83e8b5faed9ef30f75cde5ee7d41463d53ef9625c287b75dd13",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44331",
+					"10.65.0.27:44331",
+					"172.17.0.1:44331",
+					"172.19.0.1:44331",
+					"172.20.0.1:44331"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:38:30.225429861Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1576612755086865": {
+				"ID":          1576612755086865,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/sshtest_results/sshtest-deny-pass-no-rule.hujson
+++ b/hscontrol/policy/v2/testdata/sshtest_results/sshtest-deny-pass-no-rule.hujson
@@ -1,0 +1,20099 @@
+// sshtest-deny-pass-no-rule
+//
+// deny asserted, no ssh rule, must pass
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T18:39:15Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "sshtest-deny-pass-no-rule",
+	"description":    "deny asserted, no ssh rule, must pass",
+	"category":       "sshtest",
+	"captured_at":    "2026-05-12T18:39:15.531493968Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                            \n  \n                                                                         \n                                                                        \n                  \n{\n\t\"category\":    \"sshtest\",\n\t\"description\": \"deny asserted, no ssh rule, must pass\",\n\t\"id\":          \"sshtest-deny-pass-no-rule\",\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:prod\"],\n\t\t\"src\":    [\"thor@example.org\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"sshTests\": [{\n\t\t\"deny\": [\"root\"],\n\t\t\"dst\":  [\"tag:server\"],\n\t\t\"src\":  \"thor@example.org\"\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/sshtest/sshtest-deny-pass-no-rule.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:prod"],
+				"src":    ["thor@example.org"],
+				"users":  ["root"]
+			}],
+			"sshTests":  [{"deny": ["root"], "dst": ["tag:server"], "src": "thor@example.org"}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5661569203018776,
+				"StableID":   "nPWbLip8Dm11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       5661569203018776,
+				"Key":        "nodekey:3b8933288a1d26f216a169901d63905e4d0b95070fe4a6647d83a203ab0df036",
+				"DiscoKey":   "discokey:bbfc76af9546cde6bdfad6c0edefceb948a5dafeb93b66897dea5b88a9d2f840",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47001",
+					"10.65.0.27:47001",
+					"172.17.0.1:47001",
+					"172.19.0.1:47001",
+					"172.20.0.1:47001"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:39:23.995807116Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3b8933288a1d26f216a169901d63905e4d0b95070fe4a6647d83a203ab0df036",
+			"MachineKey": "mkey:23067ba9265801ab296914031b09ddc1ad1f8331a6bee83c7618108ee59bb916",
+			"Peers": [{
+				"ID":         8474206718605856,
+				"StableID":   "n93cAN3zA921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:99ef3d41f4546c1a123d34973ca207b5e40a30eed61b3febdc38ee8f31310b69",
+				"DiscoKey":   "discokey:c639cfb07029f7cf2523a7a8c4a13a4b5755e1a91f6e90b89ab4e148fe480001",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44891",
+					"10.65.0.27:44891",
+					"172.17.0.1:44891",
+					"172.19.0.1:44891",
+					"172.20.0.1:44891"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 57289},
+					{"Proto": "peerapi6", "Port": 57289}
+				]},
+				"Created":              "2026-05-12T18:39:18.091889449Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3846456934384807,
+				"StableID":   "ncRgiGu43X11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:203e4dfb1d80d7c1fea8e138bba18fc4dbcd2820b283443f401ba2522b20f810",
+				"DiscoKey":   "discokey:6c0f074d583b981c851c07291dcac5c5975bccf03f79a6078329fb68cb269265",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39175",
+					"10.65.0.27:39175",
+					"172.17.0.1:39175",
+					"172.19.0.1:39175",
+					"172.20.0.1:39175"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:39:18.612037811Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4007060793922626,
+				"StableID":   "nVanp9hoHY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab3924ba47307b31a05c4f1b307f7a560025a8db2a0e2c61bd4391be364cf758",
+				"DiscoKey":   "discokey:681f5ef66139d20b2e862189cfbf8dff48f5bab946b8f89bcafd8a5dddd11c56",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:37844",
+					"10.65.0.27:37844",
+					"172.17.0.1:37844",
+					"172.19.0.1:37844",
+					"172.20.0.1:37844"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:39:19.133599214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6428516144351188,
+				"StableID":   "nHTuFfDVCs11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d32f31e1600d147b39c93bd3dc9db26416fa32aaac1703ffb1a2aa565f253a18",
+				"DiscoKey":   "discokey:1af4901e85a40c50fa7702876f1e9af65e6322b1a5f5ab3ca3aa1d4d7a383738",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58493",
+					"10.65.0.27:58493",
+					"172.17.0.1:58493",
+					"172.19.0.1:58493",
+					"172.20.0.1:58493"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:39:19.688477678Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7419866486659642,
+				"StableID":   "nXVeH2KUwz11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:01603471a77d30f507330843f42cb9cbf098bd40a6e6a247c3397b6b2a4e3560",
+				"DiscoKey":   "discokey:75b5c9fb7d747681baa0ca1f00f119a3281a88d53c566971e923a9021f8c9f20",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34831",
+					"10.65.0.27:34831",
+					"172.17.0.1:34831",
+					"172.19.0.1:34831",
+					"172.20.0.1:34831"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:39:20.191642896Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2823769285968430,
+				"StableID":   "nHrvFbdt3P11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bcc3352de2a036e53cee93bf3460933af9a098ca0793ba104570c38704e07b23",
+				"DiscoKey":   "discokey:3cd1b81dc872c7be51d6b693d16a101484460b9f5cd674866bbf135f1aa85d13",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:36817",
+					"10.65.0.27:36817",
+					"172.17.0.1:36817",
+					"172.19.0.1:36817",
+					"172.20.0.1:36817"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:39:20.753180617Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         441195553087581,
+				"StableID":   "nNhwDdTpS411CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1813ed29c1b10b1fe8554cbdefcafc1e62646cc708397fd20a8bf6105050b87c",
+				"DiscoKey":   "discokey:fa2ee33348c2a8b951aa4bba00fe1a42ed41a676361eea9baf94e0f29d1aa677",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47352",
+					"10.65.0.27:47352",
+					"172.17.0.1:47352",
+					"172.19.0.1:47352",
+					"172.20.0.1:47352"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:39:21.281210138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         644359334111538,
+				"StableID":   "nFHLrAEq2611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03e88b364fbd215a0d22bcdc35981bc2fe1e32ef7c43079cfd3568f25eefaa09",
+				"DiscoKey":   "discokey:40c1dfd75f92b67e83eb95d175d727bfb83f9caf3e1ef53385020efba7d37a55",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52956",
+					"10.65.0.27:52956",
+					"172.17.0.1:52956",
+					"172.19.0.1:52956",
+					"172.20.0.1:52956"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:39:21.832221727Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6508397502878691,
+				"StableID":   "ncwQNqZfps11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5ccbab58e2b2c4016bda0447a6cc2f94de15ff19c97ba21af7c103e5b406995d",
+				"DiscoKey":   "discokey:6229cdd8d8b1f3ef4028ad47a1c64f19ea1c09577d605579b992788d129e6638",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39928",
+					"10.65.0.27:39928",
+					"172.17.0.1:39928",
+					"172.19.0.1:39928",
+					"172.20.0.1:39928"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:39:22.355862072Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7785433198467645,
+				"StableID":   "np2YnS83o321CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:da443a4fa8a2fcfe70e50b383e9122fd3cf56580106adcb0ccd37f8968b25015",
+				"DiscoKey":   "discokey:be85de1b91cb0779bf0576561048a5cfc9f10dc91cea21a447742a31c25fdb30",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55637",
+					"10.65.0.27:55637",
+					"172.17.0.1:55637",
+					"172.19.0.1:55637",
+					"172.20.0.1:55637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:39:22.915650328Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8844789465698398,
+				"StableID":   "nFdTX2dp4C21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c47353e8cee1f9c282361d960eb2d24ab0eb488102fa1afd73e7661f7b3cfb6f",
+				"DiscoKey":   "discokey:b4809e1e9474594ecec896a8bd2ca17fac190710383e6d20a5b82e357812ab2a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50732",
+					"10.65.0.27:50732",
+					"172.17.0.1:50732",
+					"172.19.0.1:50732",
+					"172.20.0.1:50732"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:39:23.45158968Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2656439323035545,
+				"StableID":   "nUGoR5A7kM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:97ab98ca073effb2fc797fe936f96b30a387063e9224eee679e7481013766931",
+				"KeyExpiry":  "2026-11-08T18:39:24Z",
+				"DiscoKey":   "discokey:f999c8d92a4f40c9da81625e61c85d78a831b95fccbf917593f8f73b75196b53",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46452",
+					"10.65.0.27:46452",
+					"172.17.0.1:46452",
+					"172.19.0.1:46452",
+					"172.20.0.1:46452"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:39:24.544473863Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6002608916871740,
+				"StableID":   "nont1kMbso11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c1cd0841824d93802c40af940852af23822f4455fb32cfbc552ae9cfae2fc302",
+				"KeyExpiry":  "2026-11-08T18:39:25Z",
+				"DiscoKey":   "discokey:47bb2e6f428a1410b5cdaccf61c958dd4a73c227c280599a10aad0ad1f8a3c54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55424",
+					"10.65.0.27:55424",
+					"172.17.0.1:55424",
+					"172.19.0.1:55424",
+					"172.20.0.1:55424"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:39:25.081539782Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6766183268744481,
+				"StableID":   "nSdfkLARqu11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:674a351cd6fb70d97e65ffee7d83d2d87c59c288784421d3932a852c07344109",
+				"KeyExpiry":  "2026-11-08T18:39:25Z",
+				"DiscoKey":   "discokey:d73088a9b4a16ef15651662edb53eab500dbc237151e3d2f527cad4c164d8d65",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39832",
+					"10.65.0.27:39832",
+					"172.17.0.1:39832",
+					"172.19.0.1:39832",
+					"172.20.0.1:39832"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:39:25.617645901Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5661569203018776": {
+				"ID":          5661569203018776,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2823769285968430,
+				"StableID":   "nHrvFbdt3P11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       2823769285968430,
+				"Key":        "nodekey:bcc3352de2a036e53cee93bf3460933af9a098ca0793ba104570c38704e07b23",
+				"DiscoKey":   "discokey:3cd1b81dc872c7be51d6b693d16a101484460b9f5cd674866bbf135f1aa85d13",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:36817",
+					"10.65.0.27:36817",
+					"172.17.0.1:36817",
+					"172.19.0.1:36817",
+					"172.20.0.1:36817"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:39:20.753180617Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:bcc3352de2a036e53cee93bf3460933af9a098ca0793ba104570c38704e07b23",
+			"MachineKey": "mkey:50049ba7b9aede169327719d256ff8cbee68fd0d632907983933150c271ed513",
+			"Peers": [{
+				"ID":         8474206718605856,
+				"StableID":   "n93cAN3zA921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:99ef3d41f4546c1a123d34973ca207b5e40a30eed61b3febdc38ee8f31310b69",
+				"DiscoKey":   "discokey:c639cfb07029f7cf2523a7a8c4a13a4b5755e1a91f6e90b89ab4e148fe480001",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44891",
+					"10.65.0.27:44891",
+					"172.17.0.1:44891",
+					"172.19.0.1:44891",
+					"172.20.0.1:44891"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 57289},
+					{"Proto": "peerapi6", "Port": 57289}
+				]},
+				"Created":              "2026-05-12T18:39:18.091889449Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3846456934384807,
+				"StableID":   "ncRgiGu43X11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:203e4dfb1d80d7c1fea8e138bba18fc4dbcd2820b283443f401ba2522b20f810",
+				"DiscoKey":   "discokey:6c0f074d583b981c851c07291dcac5c5975bccf03f79a6078329fb68cb269265",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39175",
+					"10.65.0.27:39175",
+					"172.17.0.1:39175",
+					"172.19.0.1:39175",
+					"172.20.0.1:39175"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:39:18.612037811Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4007060793922626,
+				"StableID":   "nVanp9hoHY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab3924ba47307b31a05c4f1b307f7a560025a8db2a0e2c61bd4391be364cf758",
+				"DiscoKey":   "discokey:681f5ef66139d20b2e862189cfbf8dff48f5bab946b8f89bcafd8a5dddd11c56",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:37844",
+					"10.65.0.27:37844",
+					"172.17.0.1:37844",
+					"172.19.0.1:37844",
+					"172.20.0.1:37844"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:39:19.133599214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6428516144351188,
+				"StableID":   "nHTuFfDVCs11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d32f31e1600d147b39c93bd3dc9db26416fa32aaac1703ffb1a2aa565f253a18",
+				"DiscoKey":   "discokey:1af4901e85a40c50fa7702876f1e9af65e6322b1a5f5ab3ca3aa1d4d7a383738",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58493",
+					"10.65.0.27:58493",
+					"172.17.0.1:58493",
+					"172.19.0.1:58493",
+					"172.20.0.1:58493"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:39:19.688477678Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7419866486659642,
+				"StableID":   "nXVeH2KUwz11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:01603471a77d30f507330843f42cb9cbf098bd40a6e6a247c3397b6b2a4e3560",
+				"DiscoKey":   "discokey:75b5c9fb7d747681baa0ca1f00f119a3281a88d53c566971e923a9021f8c9f20",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34831",
+					"10.65.0.27:34831",
+					"172.17.0.1:34831",
+					"172.19.0.1:34831",
+					"172.20.0.1:34831"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:39:20.191642896Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         441195553087581,
+				"StableID":   "nNhwDdTpS411CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1813ed29c1b10b1fe8554cbdefcafc1e62646cc708397fd20a8bf6105050b87c",
+				"DiscoKey":   "discokey:fa2ee33348c2a8b951aa4bba00fe1a42ed41a676361eea9baf94e0f29d1aa677",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47352",
+					"10.65.0.27:47352",
+					"172.17.0.1:47352",
+					"172.19.0.1:47352",
+					"172.20.0.1:47352"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:39:21.281210138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         644359334111538,
+				"StableID":   "nFHLrAEq2611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03e88b364fbd215a0d22bcdc35981bc2fe1e32ef7c43079cfd3568f25eefaa09",
+				"DiscoKey":   "discokey:40c1dfd75f92b67e83eb95d175d727bfb83f9caf3e1ef53385020efba7d37a55",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52956",
+					"10.65.0.27:52956",
+					"172.17.0.1:52956",
+					"172.19.0.1:52956",
+					"172.20.0.1:52956"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:39:21.832221727Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6508397502878691,
+				"StableID":   "ncwQNqZfps11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5ccbab58e2b2c4016bda0447a6cc2f94de15ff19c97ba21af7c103e5b406995d",
+				"DiscoKey":   "discokey:6229cdd8d8b1f3ef4028ad47a1c64f19ea1c09577d605579b992788d129e6638",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39928",
+					"10.65.0.27:39928",
+					"172.17.0.1:39928",
+					"172.19.0.1:39928",
+					"172.20.0.1:39928"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:39:22.355862072Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7785433198467645,
+				"StableID":   "np2YnS83o321CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:da443a4fa8a2fcfe70e50b383e9122fd3cf56580106adcb0ccd37f8968b25015",
+				"DiscoKey":   "discokey:be85de1b91cb0779bf0576561048a5cfc9f10dc91cea21a447742a31c25fdb30",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55637",
+					"10.65.0.27:55637",
+					"172.17.0.1:55637",
+					"172.19.0.1:55637",
+					"172.20.0.1:55637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:39:22.915650328Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8844789465698398,
+				"StableID":   "nFdTX2dp4C21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c47353e8cee1f9c282361d960eb2d24ab0eb488102fa1afd73e7661f7b3cfb6f",
+				"DiscoKey":   "discokey:b4809e1e9474594ecec896a8bd2ca17fac190710383e6d20a5b82e357812ab2a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50732",
+					"10.65.0.27:50732",
+					"172.17.0.1:50732",
+					"172.19.0.1:50732",
+					"172.20.0.1:50732"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:39:23.45158968Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5661569203018776,
+				"StableID":   "nPWbLip8Dm11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b8933288a1d26f216a169901d63905e4d0b95070fe4a6647d83a203ab0df036",
+				"DiscoKey":   "discokey:bbfc76af9546cde6bdfad6c0edefceb948a5dafeb93b66897dea5b88a9d2f840",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47001",
+					"10.65.0.27:47001",
+					"172.17.0.1:47001",
+					"172.19.0.1:47001",
+					"172.20.0.1:47001"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:39:23.995807116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2656439323035545,
+				"StableID":   "nUGoR5A7kM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:97ab98ca073effb2fc797fe936f96b30a387063e9224eee679e7481013766931",
+				"KeyExpiry":  "2026-11-08T18:39:24Z",
+				"DiscoKey":   "discokey:f999c8d92a4f40c9da81625e61c85d78a831b95fccbf917593f8f73b75196b53",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46452",
+					"10.65.0.27:46452",
+					"172.17.0.1:46452",
+					"172.19.0.1:46452",
+					"172.20.0.1:46452"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:39:24.544473863Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6002608916871740,
+				"StableID":   "nont1kMbso11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c1cd0841824d93802c40af940852af23822f4455fb32cfbc552ae9cfae2fc302",
+				"KeyExpiry":  "2026-11-08T18:39:25Z",
+				"DiscoKey":   "discokey:47bb2e6f428a1410b5cdaccf61c958dd4a73c227c280599a10aad0ad1f8a3c54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55424",
+					"10.65.0.27:55424",
+					"172.17.0.1:55424",
+					"172.19.0.1:55424",
+					"172.20.0.1:55424"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:39:25.081539782Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6766183268744481,
+				"StableID":   "nSdfkLARqu11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:674a351cd6fb70d97e65ffee7d83d2d87c59c288784421d3932a852c07344109",
+				"KeyExpiry":  "2026-11-08T18:39:25Z",
+				"DiscoKey":   "discokey:d73088a9b4a16ef15651662edb53eab500dbc237151e3d2f527cad4c164d8d65",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39832",
+					"10.65.0.27:39832",
+					"172.17.0.1:39832",
+					"172.19.0.1:39832",
+					"172.20.0.1:39832"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:39:25.617645901Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2823769285968430": {
+				"ID":          2823769285968430,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6766183268744481,
+				"StableID":   "nSdfkLARqu11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:674a351cd6fb70d97e65ffee7d83d2d87c59c288784421d3932a852c07344109",
+				"KeyExpiry":  "2026-11-08T18:39:25Z",
+				"DiscoKey":   "discokey:d73088a9b4a16ef15651662edb53eab500dbc237151e3d2f527cad4c164d8d65",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39832",
+					"10.65.0.27:39832",
+					"172.17.0.1:39832",
+					"172.19.0.1:39832",
+					"172.20.0.1:39832"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:39:25.617645901Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:674a351cd6fb70d97e65ffee7d83d2d87c59c288784421d3932a852c07344109",
+			"MachineKey": "mkey:34419c12b88f6e2ab99d8e5aa99e26ced26bae53b556e8b3b8ac70aa0ba4e263",
+			"Peers": [{
+				"ID":         8474206718605856,
+				"StableID":   "n93cAN3zA921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:99ef3d41f4546c1a123d34973ca207b5e40a30eed61b3febdc38ee8f31310b69",
+				"DiscoKey":   "discokey:c639cfb07029f7cf2523a7a8c4a13a4b5755e1a91f6e90b89ab4e148fe480001",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44891",
+					"10.65.0.27:44891",
+					"172.17.0.1:44891",
+					"172.19.0.1:44891",
+					"172.20.0.1:44891"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 57289},
+					{"Proto": "peerapi6", "Port": 57289}
+				]},
+				"Created":              "2026-05-12T18:39:18.091889449Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3846456934384807,
+				"StableID":   "ncRgiGu43X11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:203e4dfb1d80d7c1fea8e138bba18fc4dbcd2820b283443f401ba2522b20f810",
+				"DiscoKey":   "discokey:6c0f074d583b981c851c07291dcac5c5975bccf03f79a6078329fb68cb269265",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39175",
+					"10.65.0.27:39175",
+					"172.17.0.1:39175",
+					"172.19.0.1:39175",
+					"172.20.0.1:39175"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:39:18.612037811Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4007060793922626,
+				"StableID":   "nVanp9hoHY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab3924ba47307b31a05c4f1b307f7a560025a8db2a0e2c61bd4391be364cf758",
+				"DiscoKey":   "discokey:681f5ef66139d20b2e862189cfbf8dff48f5bab946b8f89bcafd8a5dddd11c56",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:37844",
+					"10.65.0.27:37844",
+					"172.17.0.1:37844",
+					"172.19.0.1:37844",
+					"172.20.0.1:37844"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:39:19.133599214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6428516144351188,
+				"StableID":   "nHTuFfDVCs11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d32f31e1600d147b39c93bd3dc9db26416fa32aaac1703ffb1a2aa565f253a18",
+				"DiscoKey":   "discokey:1af4901e85a40c50fa7702876f1e9af65e6322b1a5f5ab3ca3aa1d4d7a383738",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58493",
+					"10.65.0.27:58493",
+					"172.17.0.1:58493",
+					"172.19.0.1:58493",
+					"172.20.0.1:58493"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:39:19.688477678Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7419866486659642,
+				"StableID":   "nXVeH2KUwz11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:01603471a77d30f507330843f42cb9cbf098bd40a6e6a247c3397b6b2a4e3560",
+				"DiscoKey":   "discokey:75b5c9fb7d747681baa0ca1f00f119a3281a88d53c566971e923a9021f8c9f20",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34831",
+					"10.65.0.27:34831",
+					"172.17.0.1:34831",
+					"172.19.0.1:34831",
+					"172.20.0.1:34831"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:39:20.191642896Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2823769285968430,
+				"StableID":   "nHrvFbdt3P11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bcc3352de2a036e53cee93bf3460933af9a098ca0793ba104570c38704e07b23",
+				"DiscoKey":   "discokey:3cd1b81dc872c7be51d6b693d16a101484460b9f5cd674866bbf135f1aa85d13",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:36817",
+					"10.65.0.27:36817",
+					"172.17.0.1:36817",
+					"172.19.0.1:36817",
+					"172.20.0.1:36817"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:39:20.753180617Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         441195553087581,
+				"StableID":   "nNhwDdTpS411CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1813ed29c1b10b1fe8554cbdefcafc1e62646cc708397fd20a8bf6105050b87c",
+				"DiscoKey":   "discokey:fa2ee33348c2a8b951aa4bba00fe1a42ed41a676361eea9baf94e0f29d1aa677",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47352",
+					"10.65.0.27:47352",
+					"172.17.0.1:47352",
+					"172.19.0.1:47352",
+					"172.20.0.1:47352"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:39:21.281210138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         644359334111538,
+				"StableID":   "nFHLrAEq2611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03e88b364fbd215a0d22bcdc35981bc2fe1e32ef7c43079cfd3568f25eefaa09",
+				"DiscoKey":   "discokey:40c1dfd75f92b67e83eb95d175d727bfb83f9caf3e1ef53385020efba7d37a55",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52956",
+					"10.65.0.27:52956",
+					"172.17.0.1:52956",
+					"172.19.0.1:52956",
+					"172.20.0.1:52956"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:39:21.832221727Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6508397502878691,
+				"StableID":   "ncwQNqZfps11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5ccbab58e2b2c4016bda0447a6cc2f94de15ff19c97ba21af7c103e5b406995d",
+				"DiscoKey":   "discokey:6229cdd8d8b1f3ef4028ad47a1c64f19ea1c09577d605579b992788d129e6638",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39928",
+					"10.65.0.27:39928",
+					"172.17.0.1:39928",
+					"172.19.0.1:39928",
+					"172.20.0.1:39928"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:39:22.355862072Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7785433198467645,
+				"StableID":   "np2YnS83o321CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:da443a4fa8a2fcfe70e50b383e9122fd3cf56580106adcb0ccd37f8968b25015",
+				"DiscoKey":   "discokey:be85de1b91cb0779bf0576561048a5cfc9f10dc91cea21a447742a31c25fdb30",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55637",
+					"10.65.0.27:55637",
+					"172.17.0.1:55637",
+					"172.19.0.1:55637",
+					"172.20.0.1:55637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:39:22.915650328Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8844789465698398,
+				"StableID":   "nFdTX2dp4C21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c47353e8cee1f9c282361d960eb2d24ab0eb488102fa1afd73e7661f7b3cfb6f",
+				"DiscoKey":   "discokey:b4809e1e9474594ecec896a8bd2ca17fac190710383e6d20a5b82e357812ab2a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50732",
+					"10.65.0.27:50732",
+					"172.17.0.1:50732",
+					"172.19.0.1:50732",
+					"172.20.0.1:50732"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:39:23.45158968Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5661569203018776,
+				"StableID":   "nPWbLip8Dm11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b8933288a1d26f216a169901d63905e4d0b95070fe4a6647d83a203ab0df036",
+				"DiscoKey":   "discokey:bbfc76af9546cde6bdfad6c0edefceb948a5dafeb93b66897dea5b88a9d2f840",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47001",
+					"10.65.0.27:47001",
+					"172.17.0.1:47001",
+					"172.19.0.1:47001",
+					"172.20.0.1:47001"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:39:23.995807116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2656439323035545,
+				"StableID":   "nUGoR5A7kM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:97ab98ca073effb2fc797fe936f96b30a387063e9224eee679e7481013766931",
+				"KeyExpiry":  "2026-11-08T18:39:24Z",
+				"DiscoKey":   "discokey:f999c8d92a4f40c9da81625e61c85d78a831b95fccbf917593f8f73b75196b53",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46452",
+					"10.65.0.27:46452",
+					"172.17.0.1:46452",
+					"172.19.0.1:46452",
+					"172.20.0.1:46452"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:39:24.544473863Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6002608916871740,
+				"StableID":   "nont1kMbso11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c1cd0841824d93802c40af940852af23822f4455fb32cfbc552ae9cfae2fc302",
+				"KeyExpiry":  "2026-11-08T18:39:25Z",
+				"DiscoKey":   "discokey:47bb2e6f428a1410b5cdaccf61c958dd4a73c227c280599a10aad0ad1f8a3c54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55424",
+					"10.65.0.27:55424",
+					"172.17.0.1:55424",
+					"172.19.0.1:55424",
+					"172.20.0.1:55424"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:39:25.081539782Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4007060793922626,
+				"StableID":   "nVanp9hoHY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       4007060793922626,
+				"Key":        "nodekey:ab3924ba47307b31a05c4f1b307f7a560025a8db2a0e2c61bd4391be364cf758",
+				"DiscoKey":   "discokey:681f5ef66139d20b2e862189cfbf8dff48f5bab946b8f89bcafd8a5dddd11c56",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:37844",
+					"10.65.0.27:37844",
+					"172.17.0.1:37844",
+					"172.19.0.1:37844",
+					"172.20.0.1:37844"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:39:19.133599214Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ab3924ba47307b31a05c4f1b307f7a560025a8db2a0e2c61bd4391be364cf758",
+			"MachineKey": "mkey:9328c6277c160c87a1c1034d327fa40a9476aa120ed747815b6d0005876ee93a",
+			"Peers": [{
+				"ID":         8474206718605856,
+				"StableID":   "n93cAN3zA921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:99ef3d41f4546c1a123d34973ca207b5e40a30eed61b3febdc38ee8f31310b69",
+				"DiscoKey":   "discokey:c639cfb07029f7cf2523a7a8c4a13a4b5755e1a91f6e90b89ab4e148fe480001",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44891",
+					"10.65.0.27:44891",
+					"172.17.0.1:44891",
+					"172.19.0.1:44891",
+					"172.20.0.1:44891"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 57289},
+					{"Proto": "peerapi6", "Port": 57289}
+				]},
+				"Created":              "2026-05-12T18:39:18.091889449Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3846456934384807,
+				"StableID":   "ncRgiGu43X11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:203e4dfb1d80d7c1fea8e138bba18fc4dbcd2820b283443f401ba2522b20f810",
+				"DiscoKey":   "discokey:6c0f074d583b981c851c07291dcac5c5975bccf03f79a6078329fb68cb269265",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39175",
+					"10.65.0.27:39175",
+					"172.17.0.1:39175",
+					"172.19.0.1:39175",
+					"172.20.0.1:39175"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:39:18.612037811Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6428516144351188,
+				"StableID":   "nHTuFfDVCs11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d32f31e1600d147b39c93bd3dc9db26416fa32aaac1703ffb1a2aa565f253a18",
+				"DiscoKey":   "discokey:1af4901e85a40c50fa7702876f1e9af65e6322b1a5f5ab3ca3aa1d4d7a383738",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58493",
+					"10.65.0.27:58493",
+					"172.17.0.1:58493",
+					"172.19.0.1:58493",
+					"172.20.0.1:58493"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:39:19.688477678Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7419866486659642,
+				"StableID":   "nXVeH2KUwz11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:01603471a77d30f507330843f42cb9cbf098bd40a6e6a247c3397b6b2a4e3560",
+				"DiscoKey":   "discokey:75b5c9fb7d747681baa0ca1f00f119a3281a88d53c566971e923a9021f8c9f20",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34831",
+					"10.65.0.27:34831",
+					"172.17.0.1:34831",
+					"172.19.0.1:34831",
+					"172.20.0.1:34831"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:39:20.191642896Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2823769285968430,
+				"StableID":   "nHrvFbdt3P11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bcc3352de2a036e53cee93bf3460933af9a098ca0793ba104570c38704e07b23",
+				"DiscoKey":   "discokey:3cd1b81dc872c7be51d6b693d16a101484460b9f5cd674866bbf135f1aa85d13",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:36817",
+					"10.65.0.27:36817",
+					"172.17.0.1:36817",
+					"172.19.0.1:36817",
+					"172.20.0.1:36817"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:39:20.753180617Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         441195553087581,
+				"StableID":   "nNhwDdTpS411CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1813ed29c1b10b1fe8554cbdefcafc1e62646cc708397fd20a8bf6105050b87c",
+				"DiscoKey":   "discokey:fa2ee33348c2a8b951aa4bba00fe1a42ed41a676361eea9baf94e0f29d1aa677",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47352",
+					"10.65.0.27:47352",
+					"172.17.0.1:47352",
+					"172.19.0.1:47352",
+					"172.20.0.1:47352"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:39:21.281210138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         644359334111538,
+				"StableID":   "nFHLrAEq2611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03e88b364fbd215a0d22bcdc35981bc2fe1e32ef7c43079cfd3568f25eefaa09",
+				"DiscoKey":   "discokey:40c1dfd75f92b67e83eb95d175d727bfb83f9caf3e1ef53385020efba7d37a55",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52956",
+					"10.65.0.27:52956",
+					"172.17.0.1:52956",
+					"172.19.0.1:52956",
+					"172.20.0.1:52956"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:39:21.832221727Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6508397502878691,
+				"StableID":   "ncwQNqZfps11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5ccbab58e2b2c4016bda0447a6cc2f94de15ff19c97ba21af7c103e5b406995d",
+				"DiscoKey":   "discokey:6229cdd8d8b1f3ef4028ad47a1c64f19ea1c09577d605579b992788d129e6638",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39928",
+					"10.65.0.27:39928",
+					"172.17.0.1:39928",
+					"172.19.0.1:39928",
+					"172.20.0.1:39928"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:39:22.355862072Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7785433198467645,
+				"StableID":   "np2YnS83o321CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:da443a4fa8a2fcfe70e50b383e9122fd3cf56580106adcb0ccd37f8968b25015",
+				"DiscoKey":   "discokey:be85de1b91cb0779bf0576561048a5cfc9f10dc91cea21a447742a31c25fdb30",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55637",
+					"10.65.0.27:55637",
+					"172.17.0.1:55637",
+					"172.19.0.1:55637",
+					"172.20.0.1:55637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:39:22.915650328Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8844789465698398,
+				"StableID":   "nFdTX2dp4C21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c47353e8cee1f9c282361d960eb2d24ab0eb488102fa1afd73e7661f7b3cfb6f",
+				"DiscoKey":   "discokey:b4809e1e9474594ecec896a8bd2ca17fac190710383e6d20a5b82e357812ab2a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50732",
+					"10.65.0.27:50732",
+					"172.17.0.1:50732",
+					"172.19.0.1:50732",
+					"172.20.0.1:50732"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:39:23.45158968Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5661569203018776,
+				"StableID":   "nPWbLip8Dm11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b8933288a1d26f216a169901d63905e4d0b95070fe4a6647d83a203ab0df036",
+				"DiscoKey":   "discokey:bbfc76af9546cde6bdfad6c0edefceb948a5dafeb93b66897dea5b88a9d2f840",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47001",
+					"10.65.0.27:47001",
+					"172.17.0.1:47001",
+					"172.19.0.1:47001",
+					"172.20.0.1:47001"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:39:23.995807116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2656439323035545,
+				"StableID":   "nUGoR5A7kM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:97ab98ca073effb2fc797fe936f96b30a387063e9224eee679e7481013766931",
+				"KeyExpiry":  "2026-11-08T18:39:24Z",
+				"DiscoKey":   "discokey:f999c8d92a4f40c9da81625e61c85d78a831b95fccbf917593f8f73b75196b53",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46452",
+					"10.65.0.27:46452",
+					"172.17.0.1:46452",
+					"172.19.0.1:46452",
+					"172.20.0.1:46452"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:39:24.544473863Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6002608916871740,
+				"StableID":   "nont1kMbso11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c1cd0841824d93802c40af940852af23822f4455fb32cfbc552ae9cfae2fc302",
+				"KeyExpiry":  "2026-11-08T18:39:25Z",
+				"DiscoKey":   "discokey:47bb2e6f428a1410b5cdaccf61c958dd4a73c227c280599a10aad0ad1f8a3c54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55424",
+					"10.65.0.27:55424",
+					"172.17.0.1:55424",
+					"172.19.0.1:55424",
+					"172.20.0.1:55424"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:39:25.081539782Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6766183268744481,
+				"StableID":   "nSdfkLARqu11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:674a351cd6fb70d97e65ffee7d83d2d87c59c288784421d3932a852c07344109",
+				"KeyExpiry":  "2026-11-08T18:39:25Z",
+				"DiscoKey":   "discokey:d73088a9b4a16ef15651662edb53eab500dbc237151e3d2f527cad4c164d8d65",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39832",
+					"10.65.0.27:39832",
+					"172.17.0.1:39832",
+					"172.19.0.1:39832",
+					"172.20.0.1:39832"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:39:25.617645901Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4007060793922626": {
+				"ID":          4007060793922626,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         644359334111538,
+				"StableID":   "nFHLrAEq2611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       644359334111538,
+				"Key":        "nodekey:03e88b364fbd215a0d22bcdc35981bc2fe1e32ef7c43079cfd3568f25eefaa09",
+				"DiscoKey":   "discokey:40c1dfd75f92b67e83eb95d175d727bfb83f9caf3e1ef53385020efba7d37a55",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52956",
+					"10.65.0.27:52956",
+					"172.17.0.1:52956",
+					"172.19.0.1:52956",
+					"172.20.0.1:52956"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:39:21.832221727Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:03e88b364fbd215a0d22bcdc35981bc2fe1e32ef7c43079cfd3568f25eefaa09",
+			"MachineKey": "mkey:fce10faa587370ccc91e64d5f2274ae04dfe9430ad415d2fe019f0aacceeff32",
+			"Peers": [{
+				"ID":         8474206718605856,
+				"StableID":   "n93cAN3zA921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:99ef3d41f4546c1a123d34973ca207b5e40a30eed61b3febdc38ee8f31310b69",
+				"DiscoKey":   "discokey:c639cfb07029f7cf2523a7a8c4a13a4b5755e1a91f6e90b89ab4e148fe480001",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44891",
+					"10.65.0.27:44891",
+					"172.17.0.1:44891",
+					"172.19.0.1:44891",
+					"172.20.0.1:44891"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 57289},
+					{"Proto": "peerapi6", "Port": 57289}
+				]},
+				"Created":              "2026-05-12T18:39:18.091889449Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3846456934384807,
+				"StableID":   "ncRgiGu43X11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:203e4dfb1d80d7c1fea8e138bba18fc4dbcd2820b283443f401ba2522b20f810",
+				"DiscoKey":   "discokey:6c0f074d583b981c851c07291dcac5c5975bccf03f79a6078329fb68cb269265",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39175",
+					"10.65.0.27:39175",
+					"172.17.0.1:39175",
+					"172.19.0.1:39175",
+					"172.20.0.1:39175"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:39:18.612037811Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4007060793922626,
+				"StableID":   "nVanp9hoHY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab3924ba47307b31a05c4f1b307f7a560025a8db2a0e2c61bd4391be364cf758",
+				"DiscoKey":   "discokey:681f5ef66139d20b2e862189cfbf8dff48f5bab946b8f89bcafd8a5dddd11c56",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:37844",
+					"10.65.0.27:37844",
+					"172.17.0.1:37844",
+					"172.19.0.1:37844",
+					"172.20.0.1:37844"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:39:19.133599214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6428516144351188,
+				"StableID":   "nHTuFfDVCs11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d32f31e1600d147b39c93bd3dc9db26416fa32aaac1703ffb1a2aa565f253a18",
+				"DiscoKey":   "discokey:1af4901e85a40c50fa7702876f1e9af65e6322b1a5f5ab3ca3aa1d4d7a383738",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58493",
+					"10.65.0.27:58493",
+					"172.17.0.1:58493",
+					"172.19.0.1:58493",
+					"172.20.0.1:58493"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:39:19.688477678Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7419866486659642,
+				"StableID":   "nXVeH2KUwz11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:01603471a77d30f507330843f42cb9cbf098bd40a6e6a247c3397b6b2a4e3560",
+				"DiscoKey":   "discokey:75b5c9fb7d747681baa0ca1f00f119a3281a88d53c566971e923a9021f8c9f20",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34831",
+					"10.65.0.27:34831",
+					"172.17.0.1:34831",
+					"172.19.0.1:34831",
+					"172.20.0.1:34831"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:39:20.191642896Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2823769285968430,
+				"StableID":   "nHrvFbdt3P11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bcc3352de2a036e53cee93bf3460933af9a098ca0793ba104570c38704e07b23",
+				"DiscoKey":   "discokey:3cd1b81dc872c7be51d6b693d16a101484460b9f5cd674866bbf135f1aa85d13",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:36817",
+					"10.65.0.27:36817",
+					"172.17.0.1:36817",
+					"172.19.0.1:36817",
+					"172.20.0.1:36817"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:39:20.753180617Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         441195553087581,
+				"StableID":   "nNhwDdTpS411CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1813ed29c1b10b1fe8554cbdefcafc1e62646cc708397fd20a8bf6105050b87c",
+				"DiscoKey":   "discokey:fa2ee33348c2a8b951aa4bba00fe1a42ed41a676361eea9baf94e0f29d1aa677",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47352",
+					"10.65.0.27:47352",
+					"172.17.0.1:47352",
+					"172.19.0.1:47352",
+					"172.20.0.1:47352"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:39:21.281210138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6508397502878691,
+				"StableID":   "ncwQNqZfps11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5ccbab58e2b2c4016bda0447a6cc2f94de15ff19c97ba21af7c103e5b406995d",
+				"DiscoKey":   "discokey:6229cdd8d8b1f3ef4028ad47a1c64f19ea1c09577d605579b992788d129e6638",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39928",
+					"10.65.0.27:39928",
+					"172.17.0.1:39928",
+					"172.19.0.1:39928",
+					"172.20.0.1:39928"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:39:22.355862072Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7785433198467645,
+				"StableID":   "np2YnS83o321CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:da443a4fa8a2fcfe70e50b383e9122fd3cf56580106adcb0ccd37f8968b25015",
+				"DiscoKey":   "discokey:be85de1b91cb0779bf0576561048a5cfc9f10dc91cea21a447742a31c25fdb30",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55637",
+					"10.65.0.27:55637",
+					"172.17.0.1:55637",
+					"172.19.0.1:55637",
+					"172.20.0.1:55637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:39:22.915650328Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8844789465698398,
+				"StableID":   "nFdTX2dp4C21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c47353e8cee1f9c282361d960eb2d24ab0eb488102fa1afd73e7661f7b3cfb6f",
+				"DiscoKey":   "discokey:b4809e1e9474594ecec896a8bd2ca17fac190710383e6d20a5b82e357812ab2a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50732",
+					"10.65.0.27:50732",
+					"172.17.0.1:50732",
+					"172.19.0.1:50732",
+					"172.20.0.1:50732"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:39:23.45158968Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5661569203018776,
+				"StableID":   "nPWbLip8Dm11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b8933288a1d26f216a169901d63905e4d0b95070fe4a6647d83a203ab0df036",
+				"DiscoKey":   "discokey:bbfc76af9546cde6bdfad6c0edefceb948a5dafeb93b66897dea5b88a9d2f840",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47001",
+					"10.65.0.27:47001",
+					"172.17.0.1:47001",
+					"172.19.0.1:47001",
+					"172.20.0.1:47001"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:39:23.995807116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2656439323035545,
+				"StableID":   "nUGoR5A7kM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:97ab98ca073effb2fc797fe936f96b30a387063e9224eee679e7481013766931",
+				"KeyExpiry":  "2026-11-08T18:39:24Z",
+				"DiscoKey":   "discokey:f999c8d92a4f40c9da81625e61c85d78a831b95fccbf917593f8f73b75196b53",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46452",
+					"10.65.0.27:46452",
+					"172.17.0.1:46452",
+					"172.19.0.1:46452",
+					"172.20.0.1:46452"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:39:24.544473863Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6002608916871740,
+				"StableID":   "nont1kMbso11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c1cd0841824d93802c40af940852af23822f4455fb32cfbc552ae9cfae2fc302",
+				"KeyExpiry":  "2026-11-08T18:39:25Z",
+				"DiscoKey":   "discokey:47bb2e6f428a1410b5cdaccf61c958dd4a73c227c280599a10aad0ad1f8a3c54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55424",
+					"10.65.0.27:55424",
+					"172.17.0.1:55424",
+					"172.19.0.1:55424",
+					"172.20.0.1:55424"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:39:25.081539782Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6766183268744481,
+				"StableID":   "nSdfkLARqu11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:674a351cd6fb70d97e65ffee7d83d2d87c59c288784421d3932a852c07344109",
+				"KeyExpiry":  "2026-11-08T18:39:25Z",
+				"DiscoKey":   "discokey:d73088a9b4a16ef15651662edb53eab500dbc237151e3d2f527cad4c164d8d65",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39832",
+					"10.65.0.27:39832",
+					"172.17.0.1:39832",
+					"172.19.0.1:39832",
+					"172.20.0.1:39832"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:39:25.617645901Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "644359334111538": {
+				"ID":          644359334111538,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2656439323035545,
+				"StableID":   "nUGoR5A7kM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:97ab98ca073effb2fc797fe936f96b30a387063e9224eee679e7481013766931",
+				"KeyExpiry":  "2026-11-08T18:39:24Z",
+				"DiscoKey":   "discokey:f999c8d92a4f40c9da81625e61c85d78a831b95fccbf917593f8f73b75196b53",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46452",
+					"10.65.0.27:46452",
+					"172.17.0.1:46452",
+					"172.19.0.1:46452",
+					"172.20.0.1:46452"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:39:24.544473863Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:97ab98ca073effb2fc797fe936f96b30a387063e9224eee679e7481013766931",
+			"MachineKey": "mkey:5f26c6842c0701ecac5b0d492cb0df937bd9ede9ec345d7a3aca5d0665b4f953",
+			"Peers": [{
+				"ID":         8474206718605856,
+				"StableID":   "n93cAN3zA921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:99ef3d41f4546c1a123d34973ca207b5e40a30eed61b3febdc38ee8f31310b69",
+				"DiscoKey":   "discokey:c639cfb07029f7cf2523a7a8c4a13a4b5755e1a91f6e90b89ab4e148fe480001",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44891",
+					"10.65.0.27:44891",
+					"172.17.0.1:44891",
+					"172.19.0.1:44891",
+					"172.20.0.1:44891"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 57289},
+					{"Proto": "peerapi6", "Port": 57289}
+				]},
+				"Created":              "2026-05-12T18:39:18.091889449Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3846456934384807,
+				"StableID":   "ncRgiGu43X11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:203e4dfb1d80d7c1fea8e138bba18fc4dbcd2820b283443f401ba2522b20f810",
+				"DiscoKey":   "discokey:6c0f074d583b981c851c07291dcac5c5975bccf03f79a6078329fb68cb269265",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39175",
+					"10.65.0.27:39175",
+					"172.17.0.1:39175",
+					"172.19.0.1:39175",
+					"172.20.0.1:39175"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:39:18.612037811Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4007060793922626,
+				"StableID":   "nVanp9hoHY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab3924ba47307b31a05c4f1b307f7a560025a8db2a0e2c61bd4391be364cf758",
+				"DiscoKey":   "discokey:681f5ef66139d20b2e862189cfbf8dff48f5bab946b8f89bcafd8a5dddd11c56",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:37844",
+					"10.65.0.27:37844",
+					"172.17.0.1:37844",
+					"172.19.0.1:37844",
+					"172.20.0.1:37844"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:39:19.133599214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6428516144351188,
+				"StableID":   "nHTuFfDVCs11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d32f31e1600d147b39c93bd3dc9db26416fa32aaac1703ffb1a2aa565f253a18",
+				"DiscoKey":   "discokey:1af4901e85a40c50fa7702876f1e9af65e6322b1a5f5ab3ca3aa1d4d7a383738",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58493",
+					"10.65.0.27:58493",
+					"172.17.0.1:58493",
+					"172.19.0.1:58493",
+					"172.20.0.1:58493"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:39:19.688477678Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7419866486659642,
+				"StableID":   "nXVeH2KUwz11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:01603471a77d30f507330843f42cb9cbf098bd40a6e6a247c3397b6b2a4e3560",
+				"DiscoKey":   "discokey:75b5c9fb7d747681baa0ca1f00f119a3281a88d53c566971e923a9021f8c9f20",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34831",
+					"10.65.0.27:34831",
+					"172.17.0.1:34831",
+					"172.19.0.1:34831",
+					"172.20.0.1:34831"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:39:20.191642896Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2823769285968430,
+				"StableID":   "nHrvFbdt3P11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bcc3352de2a036e53cee93bf3460933af9a098ca0793ba104570c38704e07b23",
+				"DiscoKey":   "discokey:3cd1b81dc872c7be51d6b693d16a101484460b9f5cd674866bbf135f1aa85d13",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:36817",
+					"10.65.0.27:36817",
+					"172.17.0.1:36817",
+					"172.19.0.1:36817",
+					"172.20.0.1:36817"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:39:20.753180617Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         441195553087581,
+				"StableID":   "nNhwDdTpS411CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1813ed29c1b10b1fe8554cbdefcafc1e62646cc708397fd20a8bf6105050b87c",
+				"DiscoKey":   "discokey:fa2ee33348c2a8b951aa4bba00fe1a42ed41a676361eea9baf94e0f29d1aa677",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47352",
+					"10.65.0.27:47352",
+					"172.17.0.1:47352",
+					"172.19.0.1:47352",
+					"172.20.0.1:47352"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:39:21.281210138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         644359334111538,
+				"StableID":   "nFHLrAEq2611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03e88b364fbd215a0d22bcdc35981bc2fe1e32ef7c43079cfd3568f25eefaa09",
+				"DiscoKey":   "discokey:40c1dfd75f92b67e83eb95d175d727bfb83f9caf3e1ef53385020efba7d37a55",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52956",
+					"10.65.0.27:52956",
+					"172.17.0.1:52956",
+					"172.19.0.1:52956",
+					"172.20.0.1:52956"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:39:21.832221727Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6508397502878691,
+				"StableID":   "ncwQNqZfps11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5ccbab58e2b2c4016bda0447a6cc2f94de15ff19c97ba21af7c103e5b406995d",
+				"DiscoKey":   "discokey:6229cdd8d8b1f3ef4028ad47a1c64f19ea1c09577d605579b992788d129e6638",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39928",
+					"10.65.0.27:39928",
+					"172.17.0.1:39928",
+					"172.19.0.1:39928",
+					"172.20.0.1:39928"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:39:22.355862072Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7785433198467645,
+				"StableID":   "np2YnS83o321CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:da443a4fa8a2fcfe70e50b383e9122fd3cf56580106adcb0ccd37f8968b25015",
+				"DiscoKey":   "discokey:be85de1b91cb0779bf0576561048a5cfc9f10dc91cea21a447742a31c25fdb30",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55637",
+					"10.65.0.27:55637",
+					"172.17.0.1:55637",
+					"172.19.0.1:55637",
+					"172.20.0.1:55637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:39:22.915650328Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8844789465698398,
+				"StableID":   "nFdTX2dp4C21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c47353e8cee1f9c282361d960eb2d24ab0eb488102fa1afd73e7661f7b3cfb6f",
+				"DiscoKey":   "discokey:b4809e1e9474594ecec896a8bd2ca17fac190710383e6d20a5b82e357812ab2a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50732",
+					"10.65.0.27:50732",
+					"172.17.0.1:50732",
+					"172.19.0.1:50732",
+					"172.20.0.1:50732"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:39:23.45158968Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5661569203018776,
+				"StableID":   "nPWbLip8Dm11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b8933288a1d26f216a169901d63905e4d0b95070fe4a6647d83a203ab0df036",
+				"DiscoKey":   "discokey:bbfc76af9546cde6bdfad6c0edefceb948a5dafeb93b66897dea5b88a9d2f840",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47001",
+					"10.65.0.27:47001",
+					"172.17.0.1:47001",
+					"172.19.0.1:47001",
+					"172.20.0.1:47001"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:39:23.995807116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6002608916871740,
+				"StableID":   "nont1kMbso11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c1cd0841824d93802c40af940852af23822f4455fb32cfbc552ae9cfae2fc302",
+				"KeyExpiry":  "2026-11-08T18:39:25Z",
+				"DiscoKey":   "discokey:47bb2e6f428a1410b5cdaccf61c958dd4a73c227c280599a10aad0ad1f8a3c54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55424",
+					"10.65.0.27:55424",
+					"172.17.0.1:55424",
+					"172.19.0.1:55424",
+					"172.20.0.1:55424"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:39:25.081539782Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6766183268744481,
+				"StableID":   "nSdfkLARqu11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:674a351cd6fb70d97e65ffee7d83d2d87c59c288784421d3932a852c07344109",
+				"KeyExpiry":  "2026-11-08T18:39:25Z",
+				"DiscoKey":   "discokey:d73088a9b4a16ef15651662edb53eab500dbc237151e3d2f527cad4c164d8d65",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39832",
+					"10.65.0.27:39832",
+					"172.17.0.1:39832",
+					"172.19.0.1:39832",
+					"172.20.0.1:39832"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:39:25.617645901Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8844789465698398,
+				"StableID":   "nFdTX2dp4C21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       8844789465698398,
+				"Key":        "nodekey:c47353e8cee1f9c282361d960eb2d24ab0eb488102fa1afd73e7661f7b3cfb6f",
+				"DiscoKey":   "discokey:b4809e1e9474594ecec896a8bd2ca17fac190710383e6d20a5b82e357812ab2a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50732",
+					"10.65.0.27:50732",
+					"172.17.0.1:50732",
+					"172.19.0.1:50732",
+					"172.20.0.1:50732"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:39:23.45158968Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c47353e8cee1f9c282361d960eb2d24ab0eb488102fa1afd73e7661f7b3cfb6f",
+			"MachineKey": "mkey:0ed8a21fa6a80f644ed0489bf389382d74efe83a55b3e4d79b6cde25aeb2a77f",
+			"Peers": [{
+				"ID":         8474206718605856,
+				"StableID":   "n93cAN3zA921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:99ef3d41f4546c1a123d34973ca207b5e40a30eed61b3febdc38ee8f31310b69",
+				"DiscoKey":   "discokey:c639cfb07029f7cf2523a7a8c4a13a4b5755e1a91f6e90b89ab4e148fe480001",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44891",
+					"10.65.0.27:44891",
+					"172.17.0.1:44891",
+					"172.19.0.1:44891",
+					"172.20.0.1:44891"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 57289},
+					{"Proto": "peerapi6", "Port": 57289}
+				]},
+				"Created":              "2026-05-12T18:39:18.091889449Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3846456934384807,
+				"StableID":   "ncRgiGu43X11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:203e4dfb1d80d7c1fea8e138bba18fc4dbcd2820b283443f401ba2522b20f810",
+				"DiscoKey":   "discokey:6c0f074d583b981c851c07291dcac5c5975bccf03f79a6078329fb68cb269265",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39175",
+					"10.65.0.27:39175",
+					"172.17.0.1:39175",
+					"172.19.0.1:39175",
+					"172.20.0.1:39175"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:39:18.612037811Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4007060793922626,
+				"StableID":   "nVanp9hoHY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab3924ba47307b31a05c4f1b307f7a560025a8db2a0e2c61bd4391be364cf758",
+				"DiscoKey":   "discokey:681f5ef66139d20b2e862189cfbf8dff48f5bab946b8f89bcafd8a5dddd11c56",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:37844",
+					"10.65.0.27:37844",
+					"172.17.0.1:37844",
+					"172.19.0.1:37844",
+					"172.20.0.1:37844"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:39:19.133599214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6428516144351188,
+				"StableID":   "nHTuFfDVCs11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d32f31e1600d147b39c93bd3dc9db26416fa32aaac1703ffb1a2aa565f253a18",
+				"DiscoKey":   "discokey:1af4901e85a40c50fa7702876f1e9af65e6322b1a5f5ab3ca3aa1d4d7a383738",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58493",
+					"10.65.0.27:58493",
+					"172.17.0.1:58493",
+					"172.19.0.1:58493",
+					"172.20.0.1:58493"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:39:19.688477678Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7419866486659642,
+				"StableID":   "nXVeH2KUwz11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:01603471a77d30f507330843f42cb9cbf098bd40a6e6a247c3397b6b2a4e3560",
+				"DiscoKey":   "discokey:75b5c9fb7d747681baa0ca1f00f119a3281a88d53c566971e923a9021f8c9f20",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34831",
+					"10.65.0.27:34831",
+					"172.17.0.1:34831",
+					"172.19.0.1:34831",
+					"172.20.0.1:34831"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:39:20.191642896Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2823769285968430,
+				"StableID":   "nHrvFbdt3P11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bcc3352de2a036e53cee93bf3460933af9a098ca0793ba104570c38704e07b23",
+				"DiscoKey":   "discokey:3cd1b81dc872c7be51d6b693d16a101484460b9f5cd674866bbf135f1aa85d13",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:36817",
+					"10.65.0.27:36817",
+					"172.17.0.1:36817",
+					"172.19.0.1:36817",
+					"172.20.0.1:36817"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:39:20.753180617Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         441195553087581,
+				"StableID":   "nNhwDdTpS411CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1813ed29c1b10b1fe8554cbdefcafc1e62646cc708397fd20a8bf6105050b87c",
+				"DiscoKey":   "discokey:fa2ee33348c2a8b951aa4bba00fe1a42ed41a676361eea9baf94e0f29d1aa677",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47352",
+					"10.65.0.27:47352",
+					"172.17.0.1:47352",
+					"172.19.0.1:47352",
+					"172.20.0.1:47352"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:39:21.281210138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         644359334111538,
+				"StableID":   "nFHLrAEq2611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03e88b364fbd215a0d22bcdc35981bc2fe1e32ef7c43079cfd3568f25eefaa09",
+				"DiscoKey":   "discokey:40c1dfd75f92b67e83eb95d175d727bfb83f9caf3e1ef53385020efba7d37a55",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52956",
+					"10.65.0.27:52956",
+					"172.17.0.1:52956",
+					"172.19.0.1:52956",
+					"172.20.0.1:52956"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:39:21.832221727Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6508397502878691,
+				"StableID":   "ncwQNqZfps11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5ccbab58e2b2c4016bda0447a6cc2f94de15ff19c97ba21af7c103e5b406995d",
+				"DiscoKey":   "discokey:6229cdd8d8b1f3ef4028ad47a1c64f19ea1c09577d605579b992788d129e6638",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39928",
+					"10.65.0.27:39928",
+					"172.17.0.1:39928",
+					"172.19.0.1:39928",
+					"172.20.0.1:39928"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:39:22.355862072Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7785433198467645,
+				"StableID":   "np2YnS83o321CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:da443a4fa8a2fcfe70e50b383e9122fd3cf56580106adcb0ccd37f8968b25015",
+				"DiscoKey":   "discokey:be85de1b91cb0779bf0576561048a5cfc9f10dc91cea21a447742a31c25fdb30",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55637",
+					"10.65.0.27:55637",
+					"172.17.0.1:55637",
+					"172.19.0.1:55637",
+					"172.20.0.1:55637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:39:22.915650328Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5661569203018776,
+				"StableID":   "nPWbLip8Dm11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b8933288a1d26f216a169901d63905e4d0b95070fe4a6647d83a203ab0df036",
+				"DiscoKey":   "discokey:bbfc76af9546cde6bdfad6c0edefceb948a5dafeb93b66897dea5b88a9d2f840",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47001",
+					"10.65.0.27:47001",
+					"172.17.0.1:47001",
+					"172.19.0.1:47001",
+					"172.20.0.1:47001"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:39:23.995807116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2656439323035545,
+				"StableID":   "nUGoR5A7kM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:97ab98ca073effb2fc797fe936f96b30a387063e9224eee679e7481013766931",
+				"KeyExpiry":  "2026-11-08T18:39:24Z",
+				"DiscoKey":   "discokey:f999c8d92a4f40c9da81625e61c85d78a831b95fccbf917593f8f73b75196b53",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46452",
+					"10.65.0.27:46452",
+					"172.17.0.1:46452",
+					"172.19.0.1:46452",
+					"172.20.0.1:46452"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:39:24.544473863Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6002608916871740,
+				"StableID":   "nont1kMbso11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c1cd0841824d93802c40af940852af23822f4455fb32cfbc552ae9cfae2fc302",
+				"KeyExpiry":  "2026-11-08T18:39:25Z",
+				"DiscoKey":   "discokey:47bb2e6f428a1410b5cdaccf61c958dd4a73c227c280599a10aad0ad1f8a3c54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55424",
+					"10.65.0.27:55424",
+					"172.17.0.1:55424",
+					"172.19.0.1:55424",
+					"172.20.0.1:55424"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:39:25.081539782Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6766183268744481,
+				"StableID":   "nSdfkLARqu11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:674a351cd6fb70d97e65ffee7d83d2d87c59c288784421d3932a852c07344109",
+				"KeyExpiry":  "2026-11-08T18:39:25Z",
+				"DiscoKey":   "discokey:d73088a9b4a16ef15651662edb53eab500dbc237151e3d2f527cad4c164d8d65",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39832",
+					"10.65.0.27:39832",
+					"172.17.0.1:39832",
+					"172.19.0.1:39832",
+					"172.20.0.1:39832"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:39:25.617645901Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{
+				"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+				"sshUsers":   {"root": "root"},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				}
+			}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8844789465698398": {
+				"ID":          8844789465698398,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		},
+		"ssh_rules": [{
+			"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+			"sshUsers":   {"root": "root"},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}
+		}]
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3846456934384807,
+				"StableID":   "ncRgiGu43X11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       3846456934384807,
+				"Key":        "nodekey:203e4dfb1d80d7c1fea8e138bba18fc4dbcd2820b283443f401ba2522b20f810",
+				"DiscoKey":   "discokey:6c0f074d583b981c851c07291dcac5c5975bccf03f79a6078329fb68cb269265",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39175",
+					"10.65.0.27:39175",
+					"172.17.0.1:39175",
+					"172.19.0.1:39175",
+					"172.20.0.1:39175"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:39:18.612037811Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:203e4dfb1d80d7c1fea8e138bba18fc4dbcd2820b283443f401ba2522b20f810",
+			"MachineKey": "mkey:0d25583c5886a472324c08e0fd5239fcbe8833ae2a86ec7da67f9a31da238271",
+			"Peers": [{
+				"ID":         8474206718605856,
+				"StableID":   "n93cAN3zA921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:99ef3d41f4546c1a123d34973ca207b5e40a30eed61b3febdc38ee8f31310b69",
+				"DiscoKey":   "discokey:c639cfb07029f7cf2523a7a8c4a13a4b5755e1a91f6e90b89ab4e148fe480001",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44891",
+					"10.65.0.27:44891",
+					"172.17.0.1:44891",
+					"172.19.0.1:44891",
+					"172.20.0.1:44891"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 57289},
+					{"Proto": "peerapi6", "Port": 57289}
+				]},
+				"Created":              "2026-05-12T18:39:18.091889449Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4007060793922626,
+				"StableID":   "nVanp9hoHY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab3924ba47307b31a05c4f1b307f7a560025a8db2a0e2c61bd4391be364cf758",
+				"DiscoKey":   "discokey:681f5ef66139d20b2e862189cfbf8dff48f5bab946b8f89bcafd8a5dddd11c56",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:37844",
+					"10.65.0.27:37844",
+					"172.17.0.1:37844",
+					"172.19.0.1:37844",
+					"172.20.0.1:37844"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:39:19.133599214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6428516144351188,
+				"StableID":   "nHTuFfDVCs11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d32f31e1600d147b39c93bd3dc9db26416fa32aaac1703ffb1a2aa565f253a18",
+				"DiscoKey":   "discokey:1af4901e85a40c50fa7702876f1e9af65e6322b1a5f5ab3ca3aa1d4d7a383738",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58493",
+					"10.65.0.27:58493",
+					"172.17.0.1:58493",
+					"172.19.0.1:58493",
+					"172.20.0.1:58493"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:39:19.688477678Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7419866486659642,
+				"StableID":   "nXVeH2KUwz11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:01603471a77d30f507330843f42cb9cbf098bd40a6e6a247c3397b6b2a4e3560",
+				"DiscoKey":   "discokey:75b5c9fb7d747681baa0ca1f00f119a3281a88d53c566971e923a9021f8c9f20",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34831",
+					"10.65.0.27:34831",
+					"172.17.0.1:34831",
+					"172.19.0.1:34831",
+					"172.20.0.1:34831"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:39:20.191642896Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2823769285968430,
+				"StableID":   "nHrvFbdt3P11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bcc3352de2a036e53cee93bf3460933af9a098ca0793ba104570c38704e07b23",
+				"DiscoKey":   "discokey:3cd1b81dc872c7be51d6b693d16a101484460b9f5cd674866bbf135f1aa85d13",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:36817",
+					"10.65.0.27:36817",
+					"172.17.0.1:36817",
+					"172.19.0.1:36817",
+					"172.20.0.1:36817"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:39:20.753180617Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         441195553087581,
+				"StableID":   "nNhwDdTpS411CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1813ed29c1b10b1fe8554cbdefcafc1e62646cc708397fd20a8bf6105050b87c",
+				"DiscoKey":   "discokey:fa2ee33348c2a8b951aa4bba00fe1a42ed41a676361eea9baf94e0f29d1aa677",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47352",
+					"10.65.0.27:47352",
+					"172.17.0.1:47352",
+					"172.19.0.1:47352",
+					"172.20.0.1:47352"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:39:21.281210138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         644359334111538,
+				"StableID":   "nFHLrAEq2611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03e88b364fbd215a0d22bcdc35981bc2fe1e32ef7c43079cfd3568f25eefaa09",
+				"DiscoKey":   "discokey:40c1dfd75f92b67e83eb95d175d727bfb83f9caf3e1ef53385020efba7d37a55",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52956",
+					"10.65.0.27:52956",
+					"172.17.0.1:52956",
+					"172.19.0.1:52956",
+					"172.20.0.1:52956"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:39:21.832221727Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6508397502878691,
+				"StableID":   "ncwQNqZfps11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5ccbab58e2b2c4016bda0447a6cc2f94de15ff19c97ba21af7c103e5b406995d",
+				"DiscoKey":   "discokey:6229cdd8d8b1f3ef4028ad47a1c64f19ea1c09577d605579b992788d129e6638",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39928",
+					"10.65.0.27:39928",
+					"172.17.0.1:39928",
+					"172.19.0.1:39928",
+					"172.20.0.1:39928"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:39:22.355862072Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7785433198467645,
+				"StableID":   "np2YnS83o321CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:da443a4fa8a2fcfe70e50b383e9122fd3cf56580106adcb0ccd37f8968b25015",
+				"DiscoKey":   "discokey:be85de1b91cb0779bf0576561048a5cfc9f10dc91cea21a447742a31c25fdb30",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55637",
+					"10.65.0.27:55637",
+					"172.17.0.1:55637",
+					"172.19.0.1:55637",
+					"172.20.0.1:55637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:39:22.915650328Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8844789465698398,
+				"StableID":   "nFdTX2dp4C21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c47353e8cee1f9c282361d960eb2d24ab0eb488102fa1afd73e7661f7b3cfb6f",
+				"DiscoKey":   "discokey:b4809e1e9474594ecec896a8bd2ca17fac190710383e6d20a5b82e357812ab2a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50732",
+					"10.65.0.27:50732",
+					"172.17.0.1:50732",
+					"172.19.0.1:50732",
+					"172.20.0.1:50732"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:39:23.45158968Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5661569203018776,
+				"StableID":   "nPWbLip8Dm11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b8933288a1d26f216a169901d63905e4d0b95070fe4a6647d83a203ab0df036",
+				"DiscoKey":   "discokey:bbfc76af9546cde6bdfad6c0edefceb948a5dafeb93b66897dea5b88a9d2f840",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47001",
+					"10.65.0.27:47001",
+					"172.17.0.1:47001",
+					"172.19.0.1:47001",
+					"172.20.0.1:47001"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:39:23.995807116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2656439323035545,
+				"StableID":   "nUGoR5A7kM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:97ab98ca073effb2fc797fe936f96b30a387063e9224eee679e7481013766931",
+				"KeyExpiry":  "2026-11-08T18:39:24Z",
+				"DiscoKey":   "discokey:f999c8d92a4f40c9da81625e61c85d78a831b95fccbf917593f8f73b75196b53",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46452",
+					"10.65.0.27:46452",
+					"172.17.0.1:46452",
+					"172.19.0.1:46452",
+					"172.20.0.1:46452"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:39:24.544473863Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6002608916871740,
+				"StableID":   "nont1kMbso11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c1cd0841824d93802c40af940852af23822f4455fb32cfbc552ae9cfae2fc302",
+				"KeyExpiry":  "2026-11-08T18:39:25Z",
+				"DiscoKey":   "discokey:47bb2e6f428a1410b5cdaccf61c958dd4a73c227c280599a10aad0ad1f8a3c54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55424",
+					"10.65.0.27:55424",
+					"172.17.0.1:55424",
+					"172.19.0.1:55424",
+					"172.20.0.1:55424"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:39:25.081539782Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6766183268744481,
+				"StableID":   "nSdfkLARqu11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:674a351cd6fb70d97e65ffee7d83d2d87c59c288784421d3932a852c07344109",
+				"KeyExpiry":  "2026-11-08T18:39:25Z",
+				"DiscoKey":   "discokey:d73088a9b4a16ef15651662edb53eab500dbc237151e3d2f527cad4c164d8d65",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39832",
+					"10.65.0.27:39832",
+					"172.17.0.1:39832",
+					"172.19.0.1:39832",
+					"172.20.0.1:39832"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:39:25.617645901Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3846456934384807": {
+				"ID":          3846456934384807,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8474206718605856,
+				"StableID":   "n93cAN3zA921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       8474206718605856,
+				"Key":        "nodekey:99ef3d41f4546c1a123d34973ca207b5e40a30eed61b3febdc38ee8f31310b69",
+				"DiscoKey":   "discokey:c639cfb07029f7cf2523a7a8c4a13a4b5755e1a91f6e90b89ab4e148fe480001",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44891",
+					"10.65.0.27:44891",
+					"172.17.0.1:44891",
+					"172.19.0.1:44891",
+					"172.20.0.1:44891"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 57289},
+						{"Proto": "peerapi6", "Port": 57289},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:39:18.091889449Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:99ef3d41f4546c1a123d34973ca207b5e40a30eed61b3febdc38ee8f31310b69",
+			"MachineKey": "mkey:7983e9660507f9784676f1bb4cbed08a3be41a2d15e568caba36e6353c18d253",
+			"Peers": [{
+				"ID":         3846456934384807,
+				"StableID":   "ncRgiGu43X11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:203e4dfb1d80d7c1fea8e138bba18fc4dbcd2820b283443f401ba2522b20f810",
+				"DiscoKey":   "discokey:6c0f074d583b981c851c07291dcac5c5975bccf03f79a6078329fb68cb269265",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39175",
+					"10.65.0.27:39175",
+					"172.17.0.1:39175",
+					"172.19.0.1:39175",
+					"172.20.0.1:39175"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:39:18.612037811Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4007060793922626,
+				"StableID":   "nVanp9hoHY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab3924ba47307b31a05c4f1b307f7a560025a8db2a0e2c61bd4391be364cf758",
+				"DiscoKey":   "discokey:681f5ef66139d20b2e862189cfbf8dff48f5bab946b8f89bcafd8a5dddd11c56",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:37844",
+					"10.65.0.27:37844",
+					"172.17.0.1:37844",
+					"172.19.0.1:37844",
+					"172.20.0.1:37844"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:39:19.133599214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6428516144351188,
+				"StableID":   "nHTuFfDVCs11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d32f31e1600d147b39c93bd3dc9db26416fa32aaac1703ffb1a2aa565f253a18",
+				"DiscoKey":   "discokey:1af4901e85a40c50fa7702876f1e9af65e6322b1a5f5ab3ca3aa1d4d7a383738",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58493",
+					"10.65.0.27:58493",
+					"172.17.0.1:58493",
+					"172.19.0.1:58493",
+					"172.20.0.1:58493"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:39:19.688477678Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7419866486659642,
+				"StableID":   "nXVeH2KUwz11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:01603471a77d30f507330843f42cb9cbf098bd40a6e6a247c3397b6b2a4e3560",
+				"DiscoKey":   "discokey:75b5c9fb7d747681baa0ca1f00f119a3281a88d53c566971e923a9021f8c9f20",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34831",
+					"10.65.0.27:34831",
+					"172.17.0.1:34831",
+					"172.19.0.1:34831",
+					"172.20.0.1:34831"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:39:20.191642896Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2823769285968430,
+				"StableID":   "nHrvFbdt3P11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bcc3352de2a036e53cee93bf3460933af9a098ca0793ba104570c38704e07b23",
+				"DiscoKey":   "discokey:3cd1b81dc872c7be51d6b693d16a101484460b9f5cd674866bbf135f1aa85d13",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:36817",
+					"10.65.0.27:36817",
+					"172.17.0.1:36817",
+					"172.19.0.1:36817",
+					"172.20.0.1:36817"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:39:20.753180617Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         441195553087581,
+				"StableID":   "nNhwDdTpS411CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1813ed29c1b10b1fe8554cbdefcafc1e62646cc708397fd20a8bf6105050b87c",
+				"DiscoKey":   "discokey:fa2ee33348c2a8b951aa4bba00fe1a42ed41a676361eea9baf94e0f29d1aa677",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47352",
+					"10.65.0.27:47352",
+					"172.17.0.1:47352",
+					"172.19.0.1:47352",
+					"172.20.0.1:47352"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:39:21.281210138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         644359334111538,
+				"StableID":   "nFHLrAEq2611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03e88b364fbd215a0d22bcdc35981bc2fe1e32ef7c43079cfd3568f25eefaa09",
+				"DiscoKey":   "discokey:40c1dfd75f92b67e83eb95d175d727bfb83f9caf3e1ef53385020efba7d37a55",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52956",
+					"10.65.0.27:52956",
+					"172.17.0.1:52956",
+					"172.19.0.1:52956",
+					"172.20.0.1:52956"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:39:21.832221727Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6508397502878691,
+				"StableID":   "ncwQNqZfps11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5ccbab58e2b2c4016bda0447a6cc2f94de15ff19c97ba21af7c103e5b406995d",
+				"DiscoKey":   "discokey:6229cdd8d8b1f3ef4028ad47a1c64f19ea1c09577d605579b992788d129e6638",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39928",
+					"10.65.0.27:39928",
+					"172.17.0.1:39928",
+					"172.19.0.1:39928",
+					"172.20.0.1:39928"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:39:22.355862072Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7785433198467645,
+				"StableID":   "np2YnS83o321CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:da443a4fa8a2fcfe70e50b383e9122fd3cf56580106adcb0ccd37f8968b25015",
+				"DiscoKey":   "discokey:be85de1b91cb0779bf0576561048a5cfc9f10dc91cea21a447742a31c25fdb30",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55637",
+					"10.65.0.27:55637",
+					"172.17.0.1:55637",
+					"172.19.0.1:55637",
+					"172.20.0.1:55637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:39:22.915650328Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8844789465698398,
+				"StableID":   "nFdTX2dp4C21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c47353e8cee1f9c282361d960eb2d24ab0eb488102fa1afd73e7661f7b3cfb6f",
+				"DiscoKey":   "discokey:b4809e1e9474594ecec896a8bd2ca17fac190710383e6d20a5b82e357812ab2a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50732",
+					"10.65.0.27:50732",
+					"172.17.0.1:50732",
+					"172.19.0.1:50732",
+					"172.20.0.1:50732"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:39:23.45158968Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5661569203018776,
+				"StableID":   "nPWbLip8Dm11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b8933288a1d26f216a169901d63905e4d0b95070fe4a6647d83a203ab0df036",
+				"DiscoKey":   "discokey:bbfc76af9546cde6bdfad6c0edefceb948a5dafeb93b66897dea5b88a9d2f840",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47001",
+					"10.65.0.27:47001",
+					"172.17.0.1:47001",
+					"172.19.0.1:47001",
+					"172.20.0.1:47001"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:39:23.995807116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2656439323035545,
+				"StableID":   "nUGoR5A7kM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:97ab98ca073effb2fc797fe936f96b30a387063e9224eee679e7481013766931",
+				"KeyExpiry":  "2026-11-08T18:39:24Z",
+				"DiscoKey":   "discokey:f999c8d92a4f40c9da81625e61c85d78a831b95fccbf917593f8f73b75196b53",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46452",
+					"10.65.0.27:46452",
+					"172.17.0.1:46452",
+					"172.19.0.1:46452",
+					"172.20.0.1:46452"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:39:24.544473863Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6002608916871740,
+				"StableID":   "nont1kMbso11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c1cd0841824d93802c40af940852af23822f4455fb32cfbc552ae9cfae2fc302",
+				"KeyExpiry":  "2026-11-08T18:39:25Z",
+				"DiscoKey":   "discokey:47bb2e6f428a1410b5cdaccf61c958dd4a73c227c280599a10aad0ad1f8a3c54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55424",
+					"10.65.0.27:55424",
+					"172.17.0.1:55424",
+					"172.19.0.1:55424",
+					"172.20.0.1:55424"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:39:25.081539782Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6766183268744481,
+				"StableID":   "nSdfkLARqu11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:674a351cd6fb70d97e65ffee7d83d2d87c59c288784421d3932a852c07344109",
+				"KeyExpiry":  "2026-11-08T18:39:25Z",
+				"DiscoKey":   "discokey:d73088a9b4a16ef15651662edb53eab500dbc237151e3d2f527cad4c164d8d65",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39832",
+					"10.65.0.27:39832",
+					"172.17.0.1:39832",
+					"172.19.0.1:39832",
+					"172.20.0.1:39832"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:39:25.617645901Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8474206718605856": {
+				"ID":          8474206718605856,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7419866486659642,
+				"StableID":   "nXVeH2KUwz11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       7419866486659642,
+				"Key":        "nodekey:01603471a77d30f507330843f42cb9cbf098bd40a6e6a247c3397b6b2a4e3560",
+				"DiscoKey":   "discokey:75b5c9fb7d747681baa0ca1f00f119a3281a88d53c566971e923a9021f8c9f20",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34831",
+					"10.65.0.27:34831",
+					"172.17.0.1:34831",
+					"172.19.0.1:34831",
+					"172.20.0.1:34831"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:39:20.191642896Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:01603471a77d30f507330843f42cb9cbf098bd40a6e6a247c3397b6b2a4e3560",
+			"MachineKey": "mkey:744e507defb7737198c9cc1946f9f68dc26faf34e9b06eff8c0f341fa4872f42",
+			"Peers": [{
+				"ID":         8474206718605856,
+				"StableID":   "n93cAN3zA921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:99ef3d41f4546c1a123d34973ca207b5e40a30eed61b3febdc38ee8f31310b69",
+				"DiscoKey":   "discokey:c639cfb07029f7cf2523a7a8c4a13a4b5755e1a91f6e90b89ab4e148fe480001",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44891",
+					"10.65.0.27:44891",
+					"172.17.0.1:44891",
+					"172.19.0.1:44891",
+					"172.20.0.1:44891"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 57289},
+					{"Proto": "peerapi6", "Port": 57289}
+				]},
+				"Created":              "2026-05-12T18:39:18.091889449Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3846456934384807,
+				"StableID":   "ncRgiGu43X11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:203e4dfb1d80d7c1fea8e138bba18fc4dbcd2820b283443f401ba2522b20f810",
+				"DiscoKey":   "discokey:6c0f074d583b981c851c07291dcac5c5975bccf03f79a6078329fb68cb269265",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39175",
+					"10.65.0.27:39175",
+					"172.17.0.1:39175",
+					"172.19.0.1:39175",
+					"172.20.0.1:39175"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:39:18.612037811Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4007060793922626,
+				"StableID":   "nVanp9hoHY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab3924ba47307b31a05c4f1b307f7a560025a8db2a0e2c61bd4391be364cf758",
+				"DiscoKey":   "discokey:681f5ef66139d20b2e862189cfbf8dff48f5bab946b8f89bcafd8a5dddd11c56",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:37844",
+					"10.65.0.27:37844",
+					"172.17.0.1:37844",
+					"172.19.0.1:37844",
+					"172.20.0.1:37844"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:39:19.133599214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6428516144351188,
+				"StableID":   "nHTuFfDVCs11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d32f31e1600d147b39c93bd3dc9db26416fa32aaac1703ffb1a2aa565f253a18",
+				"DiscoKey":   "discokey:1af4901e85a40c50fa7702876f1e9af65e6322b1a5f5ab3ca3aa1d4d7a383738",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58493",
+					"10.65.0.27:58493",
+					"172.17.0.1:58493",
+					"172.19.0.1:58493",
+					"172.20.0.1:58493"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:39:19.688477678Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2823769285968430,
+				"StableID":   "nHrvFbdt3P11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bcc3352de2a036e53cee93bf3460933af9a098ca0793ba104570c38704e07b23",
+				"DiscoKey":   "discokey:3cd1b81dc872c7be51d6b693d16a101484460b9f5cd674866bbf135f1aa85d13",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:36817",
+					"10.65.0.27:36817",
+					"172.17.0.1:36817",
+					"172.19.0.1:36817",
+					"172.20.0.1:36817"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:39:20.753180617Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         441195553087581,
+				"StableID":   "nNhwDdTpS411CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1813ed29c1b10b1fe8554cbdefcafc1e62646cc708397fd20a8bf6105050b87c",
+				"DiscoKey":   "discokey:fa2ee33348c2a8b951aa4bba00fe1a42ed41a676361eea9baf94e0f29d1aa677",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47352",
+					"10.65.0.27:47352",
+					"172.17.0.1:47352",
+					"172.19.0.1:47352",
+					"172.20.0.1:47352"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:39:21.281210138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         644359334111538,
+				"StableID":   "nFHLrAEq2611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03e88b364fbd215a0d22bcdc35981bc2fe1e32ef7c43079cfd3568f25eefaa09",
+				"DiscoKey":   "discokey:40c1dfd75f92b67e83eb95d175d727bfb83f9caf3e1ef53385020efba7d37a55",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52956",
+					"10.65.0.27:52956",
+					"172.17.0.1:52956",
+					"172.19.0.1:52956",
+					"172.20.0.1:52956"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:39:21.832221727Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6508397502878691,
+				"StableID":   "ncwQNqZfps11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5ccbab58e2b2c4016bda0447a6cc2f94de15ff19c97ba21af7c103e5b406995d",
+				"DiscoKey":   "discokey:6229cdd8d8b1f3ef4028ad47a1c64f19ea1c09577d605579b992788d129e6638",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39928",
+					"10.65.0.27:39928",
+					"172.17.0.1:39928",
+					"172.19.0.1:39928",
+					"172.20.0.1:39928"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:39:22.355862072Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7785433198467645,
+				"StableID":   "np2YnS83o321CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:da443a4fa8a2fcfe70e50b383e9122fd3cf56580106adcb0ccd37f8968b25015",
+				"DiscoKey":   "discokey:be85de1b91cb0779bf0576561048a5cfc9f10dc91cea21a447742a31c25fdb30",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55637",
+					"10.65.0.27:55637",
+					"172.17.0.1:55637",
+					"172.19.0.1:55637",
+					"172.20.0.1:55637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:39:22.915650328Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8844789465698398,
+				"StableID":   "nFdTX2dp4C21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c47353e8cee1f9c282361d960eb2d24ab0eb488102fa1afd73e7661f7b3cfb6f",
+				"DiscoKey":   "discokey:b4809e1e9474594ecec896a8bd2ca17fac190710383e6d20a5b82e357812ab2a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50732",
+					"10.65.0.27:50732",
+					"172.17.0.1:50732",
+					"172.19.0.1:50732",
+					"172.20.0.1:50732"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:39:23.45158968Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5661569203018776,
+				"StableID":   "nPWbLip8Dm11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b8933288a1d26f216a169901d63905e4d0b95070fe4a6647d83a203ab0df036",
+				"DiscoKey":   "discokey:bbfc76af9546cde6bdfad6c0edefceb948a5dafeb93b66897dea5b88a9d2f840",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47001",
+					"10.65.0.27:47001",
+					"172.17.0.1:47001",
+					"172.19.0.1:47001",
+					"172.20.0.1:47001"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:39:23.995807116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2656439323035545,
+				"StableID":   "nUGoR5A7kM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:97ab98ca073effb2fc797fe936f96b30a387063e9224eee679e7481013766931",
+				"KeyExpiry":  "2026-11-08T18:39:24Z",
+				"DiscoKey":   "discokey:f999c8d92a4f40c9da81625e61c85d78a831b95fccbf917593f8f73b75196b53",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46452",
+					"10.65.0.27:46452",
+					"172.17.0.1:46452",
+					"172.19.0.1:46452",
+					"172.20.0.1:46452"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:39:24.544473863Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6002608916871740,
+				"StableID":   "nont1kMbso11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c1cd0841824d93802c40af940852af23822f4455fb32cfbc552ae9cfae2fc302",
+				"KeyExpiry":  "2026-11-08T18:39:25Z",
+				"DiscoKey":   "discokey:47bb2e6f428a1410b5cdaccf61c958dd4a73c227c280599a10aad0ad1f8a3c54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55424",
+					"10.65.0.27:55424",
+					"172.17.0.1:55424",
+					"172.19.0.1:55424",
+					"172.20.0.1:55424"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:39:25.081539782Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6766183268744481,
+				"StableID":   "nSdfkLARqu11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:674a351cd6fb70d97e65ffee7d83d2d87c59c288784421d3932a852c07344109",
+				"KeyExpiry":  "2026-11-08T18:39:25Z",
+				"DiscoKey":   "discokey:d73088a9b4a16ef15651662edb53eab500dbc237151e3d2f527cad4c164d8d65",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39832",
+					"10.65.0.27:39832",
+					"172.17.0.1:39832",
+					"172.19.0.1:39832",
+					"172.20.0.1:39832"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:39:25.617645901Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7419866486659642": {
+				"ID":          7419866486659642,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6428516144351188,
+				"StableID":   "nHTuFfDVCs11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       6428516144351188,
+				"Key":        "nodekey:d32f31e1600d147b39c93bd3dc9db26416fa32aaac1703ffb1a2aa565f253a18",
+				"DiscoKey":   "discokey:1af4901e85a40c50fa7702876f1e9af65e6322b1a5f5ab3ca3aa1d4d7a383738",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58493",
+					"10.65.0.27:58493",
+					"172.17.0.1:58493",
+					"172.19.0.1:58493",
+					"172.20.0.1:58493"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:39:19.688477678Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d32f31e1600d147b39c93bd3dc9db26416fa32aaac1703ffb1a2aa565f253a18",
+			"MachineKey": "mkey:7f5cf112851c1c240519c4e81c72c50f334851061abc615ff3a898b63a69d96c",
+			"Peers": [{
+				"ID":         8474206718605856,
+				"StableID":   "n93cAN3zA921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:99ef3d41f4546c1a123d34973ca207b5e40a30eed61b3febdc38ee8f31310b69",
+				"DiscoKey":   "discokey:c639cfb07029f7cf2523a7a8c4a13a4b5755e1a91f6e90b89ab4e148fe480001",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44891",
+					"10.65.0.27:44891",
+					"172.17.0.1:44891",
+					"172.19.0.1:44891",
+					"172.20.0.1:44891"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 57289},
+					{"Proto": "peerapi6", "Port": 57289}
+				]},
+				"Created":              "2026-05-12T18:39:18.091889449Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3846456934384807,
+				"StableID":   "ncRgiGu43X11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:203e4dfb1d80d7c1fea8e138bba18fc4dbcd2820b283443f401ba2522b20f810",
+				"DiscoKey":   "discokey:6c0f074d583b981c851c07291dcac5c5975bccf03f79a6078329fb68cb269265",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39175",
+					"10.65.0.27:39175",
+					"172.17.0.1:39175",
+					"172.19.0.1:39175",
+					"172.20.0.1:39175"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:39:18.612037811Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4007060793922626,
+				"StableID":   "nVanp9hoHY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab3924ba47307b31a05c4f1b307f7a560025a8db2a0e2c61bd4391be364cf758",
+				"DiscoKey":   "discokey:681f5ef66139d20b2e862189cfbf8dff48f5bab946b8f89bcafd8a5dddd11c56",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:37844",
+					"10.65.0.27:37844",
+					"172.17.0.1:37844",
+					"172.19.0.1:37844",
+					"172.20.0.1:37844"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:39:19.133599214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7419866486659642,
+				"StableID":   "nXVeH2KUwz11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:01603471a77d30f507330843f42cb9cbf098bd40a6e6a247c3397b6b2a4e3560",
+				"DiscoKey":   "discokey:75b5c9fb7d747681baa0ca1f00f119a3281a88d53c566971e923a9021f8c9f20",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34831",
+					"10.65.0.27:34831",
+					"172.17.0.1:34831",
+					"172.19.0.1:34831",
+					"172.20.0.1:34831"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:39:20.191642896Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2823769285968430,
+				"StableID":   "nHrvFbdt3P11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bcc3352de2a036e53cee93bf3460933af9a098ca0793ba104570c38704e07b23",
+				"DiscoKey":   "discokey:3cd1b81dc872c7be51d6b693d16a101484460b9f5cd674866bbf135f1aa85d13",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:36817",
+					"10.65.0.27:36817",
+					"172.17.0.1:36817",
+					"172.19.0.1:36817",
+					"172.20.0.1:36817"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:39:20.753180617Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         441195553087581,
+				"StableID":   "nNhwDdTpS411CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1813ed29c1b10b1fe8554cbdefcafc1e62646cc708397fd20a8bf6105050b87c",
+				"DiscoKey":   "discokey:fa2ee33348c2a8b951aa4bba00fe1a42ed41a676361eea9baf94e0f29d1aa677",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47352",
+					"10.65.0.27:47352",
+					"172.17.0.1:47352",
+					"172.19.0.1:47352",
+					"172.20.0.1:47352"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:39:21.281210138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         644359334111538,
+				"StableID":   "nFHLrAEq2611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03e88b364fbd215a0d22bcdc35981bc2fe1e32ef7c43079cfd3568f25eefaa09",
+				"DiscoKey":   "discokey:40c1dfd75f92b67e83eb95d175d727bfb83f9caf3e1ef53385020efba7d37a55",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52956",
+					"10.65.0.27:52956",
+					"172.17.0.1:52956",
+					"172.19.0.1:52956",
+					"172.20.0.1:52956"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:39:21.832221727Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6508397502878691,
+				"StableID":   "ncwQNqZfps11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5ccbab58e2b2c4016bda0447a6cc2f94de15ff19c97ba21af7c103e5b406995d",
+				"DiscoKey":   "discokey:6229cdd8d8b1f3ef4028ad47a1c64f19ea1c09577d605579b992788d129e6638",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39928",
+					"10.65.0.27:39928",
+					"172.17.0.1:39928",
+					"172.19.0.1:39928",
+					"172.20.0.1:39928"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:39:22.355862072Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7785433198467645,
+				"StableID":   "np2YnS83o321CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:da443a4fa8a2fcfe70e50b383e9122fd3cf56580106adcb0ccd37f8968b25015",
+				"DiscoKey":   "discokey:be85de1b91cb0779bf0576561048a5cfc9f10dc91cea21a447742a31c25fdb30",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55637",
+					"10.65.0.27:55637",
+					"172.17.0.1:55637",
+					"172.19.0.1:55637",
+					"172.20.0.1:55637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:39:22.915650328Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8844789465698398,
+				"StableID":   "nFdTX2dp4C21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c47353e8cee1f9c282361d960eb2d24ab0eb488102fa1afd73e7661f7b3cfb6f",
+				"DiscoKey":   "discokey:b4809e1e9474594ecec896a8bd2ca17fac190710383e6d20a5b82e357812ab2a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50732",
+					"10.65.0.27:50732",
+					"172.17.0.1:50732",
+					"172.19.0.1:50732",
+					"172.20.0.1:50732"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:39:23.45158968Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5661569203018776,
+				"StableID":   "nPWbLip8Dm11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b8933288a1d26f216a169901d63905e4d0b95070fe4a6647d83a203ab0df036",
+				"DiscoKey":   "discokey:bbfc76af9546cde6bdfad6c0edefceb948a5dafeb93b66897dea5b88a9d2f840",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47001",
+					"10.65.0.27:47001",
+					"172.17.0.1:47001",
+					"172.19.0.1:47001",
+					"172.20.0.1:47001"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:39:23.995807116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2656439323035545,
+				"StableID":   "nUGoR5A7kM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:97ab98ca073effb2fc797fe936f96b30a387063e9224eee679e7481013766931",
+				"KeyExpiry":  "2026-11-08T18:39:24Z",
+				"DiscoKey":   "discokey:f999c8d92a4f40c9da81625e61c85d78a831b95fccbf917593f8f73b75196b53",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46452",
+					"10.65.0.27:46452",
+					"172.17.0.1:46452",
+					"172.19.0.1:46452",
+					"172.20.0.1:46452"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:39:24.544473863Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6002608916871740,
+				"StableID":   "nont1kMbso11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c1cd0841824d93802c40af940852af23822f4455fb32cfbc552ae9cfae2fc302",
+				"KeyExpiry":  "2026-11-08T18:39:25Z",
+				"DiscoKey":   "discokey:47bb2e6f428a1410b5cdaccf61c958dd4a73c227c280599a10aad0ad1f8a3c54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55424",
+					"10.65.0.27:55424",
+					"172.17.0.1:55424",
+					"172.19.0.1:55424",
+					"172.20.0.1:55424"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:39:25.081539782Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6766183268744481,
+				"StableID":   "nSdfkLARqu11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:674a351cd6fb70d97e65ffee7d83d2d87c59c288784421d3932a852c07344109",
+				"KeyExpiry":  "2026-11-08T18:39:25Z",
+				"DiscoKey":   "discokey:d73088a9b4a16ef15651662edb53eab500dbc237151e3d2f527cad4c164d8d65",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39832",
+					"10.65.0.27:39832",
+					"172.17.0.1:39832",
+					"172.19.0.1:39832",
+					"172.20.0.1:39832"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:39:25.617645901Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6428516144351188": {
+				"ID":          6428516144351188,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         441195553087581,
+				"StableID":   "nNhwDdTpS411CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       441195553087581,
+				"Key":        "nodekey:1813ed29c1b10b1fe8554cbdefcafc1e62646cc708397fd20a8bf6105050b87c",
+				"DiscoKey":   "discokey:fa2ee33348c2a8b951aa4bba00fe1a42ed41a676361eea9baf94e0f29d1aa677",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47352",
+					"10.65.0.27:47352",
+					"172.17.0.1:47352",
+					"172.19.0.1:47352",
+					"172.20.0.1:47352"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:39:21.281210138Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1813ed29c1b10b1fe8554cbdefcafc1e62646cc708397fd20a8bf6105050b87c",
+			"MachineKey": "mkey:ecd747a7e2113e7647328db394fe88a9c2b58f5c494e2586e9b4dc7234646029",
+			"Peers": [{
+				"ID":         8474206718605856,
+				"StableID":   "n93cAN3zA921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:99ef3d41f4546c1a123d34973ca207b5e40a30eed61b3febdc38ee8f31310b69",
+				"DiscoKey":   "discokey:c639cfb07029f7cf2523a7a8c4a13a4b5755e1a91f6e90b89ab4e148fe480001",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44891",
+					"10.65.0.27:44891",
+					"172.17.0.1:44891",
+					"172.19.0.1:44891",
+					"172.20.0.1:44891"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 57289},
+					{"Proto": "peerapi6", "Port": 57289}
+				]},
+				"Created":              "2026-05-12T18:39:18.091889449Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3846456934384807,
+				"StableID":   "ncRgiGu43X11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:203e4dfb1d80d7c1fea8e138bba18fc4dbcd2820b283443f401ba2522b20f810",
+				"DiscoKey":   "discokey:6c0f074d583b981c851c07291dcac5c5975bccf03f79a6078329fb68cb269265",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39175",
+					"10.65.0.27:39175",
+					"172.17.0.1:39175",
+					"172.19.0.1:39175",
+					"172.20.0.1:39175"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:39:18.612037811Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4007060793922626,
+				"StableID":   "nVanp9hoHY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab3924ba47307b31a05c4f1b307f7a560025a8db2a0e2c61bd4391be364cf758",
+				"DiscoKey":   "discokey:681f5ef66139d20b2e862189cfbf8dff48f5bab946b8f89bcafd8a5dddd11c56",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:37844",
+					"10.65.0.27:37844",
+					"172.17.0.1:37844",
+					"172.19.0.1:37844",
+					"172.20.0.1:37844"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:39:19.133599214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6428516144351188,
+				"StableID":   "nHTuFfDVCs11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d32f31e1600d147b39c93bd3dc9db26416fa32aaac1703ffb1a2aa565f253a18",
+				"DiscoKey":   "discokey:1af4901e85a40c50fa7702876f1e9af65e6322b1a5f5ab3ca3aa1d4d7a383738",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58493",
+					"10.65.0.27:58493",
+					"172.17.0.1:58493",
+					"172.19.0.1:58493",
+					"172.20.0.1:58493"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:39:19.688477678Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7419866486659642,
+				"StableID":   "nXVeH2KUwz11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:01603471a77d30f507330843f42cb9cbf098bd40a6e6a247c3397b6b2a4e3560",
+				"DiscoKey":   "discokey:75b5c9fb7d747681baa0ca1f00f119a3281a88d53c566971e923a9021f8c9f20",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34831",
+					"10.65.0.27:34831",
+					"172.17.0.1:34831",
+					"172.19.0.1:34831",
+					"172.20.0.1:34831"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:39:20.191642896Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2823769285968430,
+				"StableID":   "nHrvFbdt3P11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bcc3352de2a036e53cee93bf3460933af9a098ca0793ba104570c38704e07b23",
+				"DiscoKey":   "discokey:3cd1b81dc872c7be51d6b693d16a101484460b9f5cd674866bbf135f1aa85d13",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:36817",
+					"10.65.0.27:36817",
+					"172.17.0.1:36817",
+					"172.19.0.1:36817",
+					"172.20.0.1:36817"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:39:20.753180617Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         644359334111538,
+				"StableID":   "nFHLrAEq2611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03e88b364fbd215a0d22bcdc35981bc2fe1e32ef7c43079cfd3568f25eefaa09",
+				"DiscoKey":   "discokey:40c1dfd75f92b67e83eb95d175d727bfb83f9caf3e1ef53385020efba7d37a55",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52956",
+					"10.65.0.27:52956",
+					"172.17.0.1:52956",
+					"172.19.0.1:52956",
+					"172.20.0.1:52956"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:39:21.832221727Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6508397502878691,
+				"StableID":   "ncwQNqZfps11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5ccbab58e2b2c4016bda0447a6cc2f94de15ff19c97ba21af7c103e5b406995d",
+				"DiscoKey":   "discokey:6229cdd8d8b1f3ef4028ad47a1c64f19ea1c09577d605579b992788d129e6638",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39928",
+					"10.65.0.27:39928",
+					"172.17.0.1:39928",
+					"172.19.0.1:39928",
+					"172.20.0.1:39928"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:39:22.355862072Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7785433198467645,
+				"StableID":   "np2YnS83o321CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:da443a4fa8a2fcfe70e50b383e9122fd3cf56580106adcb0ccd37f8968b25015",
+				"DiscoKey":   "discokey:be85de1b91cb0779bf0576561048a5cfc9f10dc91cea21a447742a31c25fdb30",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55637",
+					"10.65.0.27:55637",
+					"172.17.0.1:55637",
+					"172.19.0.1:55637",
+					"172.20.0.1:55637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:39:22.915650328Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8844789465698398,
+				"StableID":   "nFdTX2dp4C21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c47353e8cee1f9c282361d960eb2d24ab0eb488102fa1afd73e7661f7b3cfb6f",
+				"DiscoKey":   "discokey:b4809e1e9474594ecec896a8bd2ca17fac190710383e6d20a5b82e357812ab2a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50732",
+					"10.65.0.27:50732",
+					"172.17.0.1:50732",
+					"172.19.0.1:50732",
+					"172.20.0.1:50732"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:39:23.45158968Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5661569203018776,
+				"StableID":   "nPWbLip8Dm11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b8933288a1d26f216a169901d63905e4d0b95070fe4a6647d83a203ab0df036",
+				"DiscoKey":   "discokey:bbfc76af9546cde6bdfad6c0edefceb948a5dafeb93b66897dea5b88a9d2f840",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47001",
+					"10.65.0.27:47001",
+					"172.17.0.1:47001",
+					"172.19.0.1:47001",
+					"172.20.0.1:47001"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:39:23.995807116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2656439323035545,
+				"StableID":   "nUGoR5A7kM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:97ab98ca073effb2fc797fe936f96b30a387063e9224eee679e7481013766931",
+				"KeyExpiry":  "2026-11-08T18:39:24Z",
+				"DiscoKey":   "discokey:f999c8d92a4f40c9da81625e61c85d78a831b95fccbf917593f8f73b75196b53",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46452",
+					"10.65.0.27:46452",
+					"172.17.0.1:46452",
+					"172.19.0.1:46452",
+					"172.20.0.1:46452"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:39:24.544473863Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6002608916871740,
+				"StableID":   "nont1kMbso11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c1cd0841824d93802c40af940852af23822f4455fb32cfbc552ae9cfae2fc302",
+				"KeyExpiry":  "2026-11-08T18:39:25Z",
+				"DiscoKey":   "discokey:47bb2e6f428a1410b5cdaccf61c958dd4a73c227c280599a10aad0ad1f8a3c54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55424",
+					"10.65.0.27:55424",
+					"172.17.0.1:55424",
+					"172.19.0.1:55424",
+					"172.20.0.1:55424"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:39:25.081539782Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6766183268744481,
+				"StableID":   "nSdfkLARqu11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:674a351cd6fb70d97e65ffee7d83d2d87c59c288784421d3932a852c07344109",
+				"KeyExpiry":  "2026-11-08T18:39:25Z",
+				"DiscoKey":   "discokey:d73088a9b4a16ef15651662edb53eab500dbc237151e3d2f527cad4c164d8d65",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39832",
+					"10.65.0.27:39832",
+					"172.17.0.1:39832",
+					"172.19.0.1:39832",
+					"172.20.0.1:39832"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:39:25.617645901Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "441195553087581": {
+				"ID":          441195553087581,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6508397502878691,
+				"StableID":   "ncwQNqZfps11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       6508397502878691,
+				"Key":        "nodekey:5ccbab58e2b2c4016bda0447a6cc2f94de15ff19c97ba21af7c103e5b406995d",
+				"DiscoKey":   "discokey:6229cdd8d8b1f3ef4028ad47a1c64f19ea1c09577d605579b992788d129e6638",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39928",
+					"10.65.0.27:39928",
+					"172.17.0.1:39928",
+					"172.19.0.1:39928",
+					"172.20.0.1:39928"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:39:22.355862072Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5ccbab58e2b2c4016bda0447a6cc2f94de15ff19c97ba21af7c103e5b406995d",
+			"MachineKey": "mkey:3fde14573d65dda86392673503a60d06d35431a9d7374b8420af6af761721960",
+			"Peers": [{
+				"ID":         8474206718605856,
+				"StableID":   "n93cAN3zA921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:99ef3d41f4546c1a123d34973ca207b5e40a30eed61b3febdc38ee8f31310b69",
+				"DiscoKey":   "discokey:c639cfb07029f7cf2523a7a8c4a13a4b5755e1a91f6e90b89ab4e148fe480001",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44891",
+					"10.65.0.27:44891",
+					"172.17.0.1:44891",
+					"172.19.0.1:44891",
+					"172.20.0.1:44891"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 57289},
+					{"Proto": "peerapi6", "Port": 57289}
+				]},
+				"Created":              "2026-05-12T18:39:18.091889449Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3846456934384807,
+				"StableID":   "ncRgiGu43X11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:203e4dfb1d80d7c1fea8e138bba18fc4dbcd2820b283443f401ba2522b20f810",
+				"DiscoKey":   "discokey:6c0f074d583b981c851c07291dcac5c5975bccf03f79a6078329fb68cb269265",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39175",
+					"10.65.0.27:39175",
+					"172.17.0.1:39175",
+					"172.19.0.1:39175",
+					"172.20.0.1:39175"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:39:18.612037811Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4007060793922626,
+				"StableID":   "nVanp9hoHY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab3924ba47307b31a05c4f1b307f7a560025a8db2a0e2c61bd4391be364cf758",
+				"DiscoKey":   "discokey:681f5ef66139d20b2e862189cfbf8dff48f5bab946b8f89bcafd8a5dddd11c56",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:37844",
+					"10.65.0.27:37844",
+					"172.17.0.1:37844",
+					"172.19.0.1:37844",
+					"172.20.0.1:37844"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:39:19.133599214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6428516144351188,
+				"StableID":   "nHTuFfDVCs11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d32f31e1600d147b39c93bd3dc9db26416fa32aaac1703ffb1a2aa565f253a18",
+				"DiscoKey":   "discokey:1af4901e85a40c50fa7702876f1e9af65e6322b1a5f5ab3ca3aa1d4d7a383738",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58493",
+					"10.65.0.27:58493",
+					"172.17.0.1:58493",
+					"172.19.0.1:58493",
+					"172.20.0.1:58493"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:39:19.688477678Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7419866486659642,
+				"StableID":   "nXVeH2KUwz11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:01603471a77d30f507330843f42cb9cbf098bd40a6e6a247c3397b6b2a4e3560",
+				"DiscoKey":   "discokey:75b5c9fb7d747681baa0ca1f00f119a3281a88d53c566971e923a9021f8c9f20",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34831",
+					"10.65.0.27:34831",
+					"172.17.0.1:34831",
+					"172.19.0.1:34831",
+					"172.20.0.1:34831"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:39:20.191642896Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2823769285968430,
+				"StableID":   "nHrvFbdt3P11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bcc3352de2a036e53cee93bf3460933af9a098ca0793ba104570c38704e07b23",
+				"DiscoKey":   "discokey:3cd1b81dc872c7be51d6b693d16a101484460b9f5cd674866bbf135f1aa85d13",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:36817",
+					"10.65.0.27:36817",
+					"172.17.0.1:36817",
+					"172.19.0.1:36817",
+					"172.20.0.1:36817"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:39:20.753180617Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         441195553087581,
+				"StableID":   "nNhwDdTpS411CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1813ed29c1b10b1fe8554cbdefcafc1e62646cc708397fd20a8bf6105050b87c",
+				"DiscoKey":   "discokey:fa2ee33348c2a8b951aa4bba00fe1a42ed41a676361eea9baf94e0f29d1aa677",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47352",
+					"10.65.0.27:47352",
+					"172.17.0.1:47352",
+					"172.19.0.1:47352",
+					"172.20.0.1:47352"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:39:21.281210138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         644359334111538,
+				"StableID":   "nFHLrAEq2611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03e88b364fbd215a0d22bcdc35981bc2fe1e32ef7c43079cfd3568f25eefaa09",
+				"DiscoKey":   "discokey:40c1dfd75f92b67e83eb95d175d727bfb83f9caf3e1ef53385020efba7d37a55",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52956",
+					"10.65.0.27:52956",
+					"172.17.0.1:52956",
+					"172.19.0.1:52956",
+					"172.20.0.1:52956"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:39:21.832221727Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7785433198467645,
+				"StableID":   "np2YnS83o321CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:da443a4fa8a2fcfe70e50b383e9122fd3cf56580106adcb0ccd37f8968b25015",
+				"DiscoKey":   "discokey:be85de1b91cb0779bf0576561048a5cfc9f10dc91cea21a447742a31c25fdb30",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55637",
+					"10.65.0.27:55637",
+					"172.17.0.1:55637",
+					"172.19.0.1:55637",
+					"172.20.0.1:55637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:39:22.915650328Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8844789465698398,
+				"StableID":   "nFdTX2dp4C21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c47353e8cee1f9c282361d960eb2d24ab0eb488102fa1afd73e7661f7b3cfb6f",
+				"DiscoKey":   "discokey:b4809e1e9474594ecec896a8bd2ca17fac190710383e6d20a5b82e357812ab2a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50732",
+					"10.65.0.27:50732",
+					"172.17.0.1:50732",
+					"172.19.0.1:50732",
+					"172.20.0.1:50732"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:39:23.45158968Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5661569203018776,
+				"StableID":   "nPWbLip8Dm11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b8933288a1d26f216a169901d63905e4d0b95070fe4a6647d83a203ab0df036",
+				"DiscoKey":   "discokey:bbfc76af9546cde6bdfad6c0edefceb948a5dafeb93b66897dea5b88a9d2f840",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47001",
+					"10.65.0.27:47001",
+					"172.17.0.1:47001",
+					"172.19.0.1:47001",
+					"172.20.0.1:47001"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:39:23.995807116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2656439323035545,
+				"StableID":   "nUGoR5A7kM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:97ab98ca073effb2fc797fe936f96b30a387063e9224eee679e7481013766931",
+				"KeyExpiry":  "2026-11-08T18:39:24Z",
+				"DiscoKey":   "discokey:f999c8d92a4f40c9da81625e61c85d78a831b95fccbf917593f8f73b75196b53",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46452",
+					"10.65.0.27:46452",
+					"172.17.0.1:46452",
+					"172.19.0.1:46452",
+					"172.20.0.1:46452"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:39:24.544473863Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6002608916871740,
+				"StableID":   "nont1kMbso11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c1cd0841824d93802c40af940852af23822f4455fb32cfbc552ae9cfae2fc302",
+				"KeyExpiry":  "2026-11-08T18:39:25Z",
+				"DiscoKey":   "discokey:47bb2e6f428a1410b5cdaccf61c958dd4a73c227c280599a10aad0ad1f8a3c54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55424",
+					"10.65.0.27:55424",
+					"172.17.0.1:55424",
+					"172.19.0.1:55424",
+					"172.20.0.1:55424"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:39:25.081539782Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6766183268744481,
+				"StableID":   "nSdfkLARqu11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:674a351cd6fb70d97e65ffee7d83d2d87c59c288784421d3932a852c07344109",
+				"KeyExpiry":  "2026-11-08T18:39:25Z",
+				"DiscoKey":   "discokey:d73088a9b4a16ef15651662edb53eab500dbc237151e3d2f527cad4c164d8d65",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39832",
+					"10.65.0.27:39832",
+					"172.17.0.1:39832",
+					"172.19.0.1:39832",
+					"172.20.0.1:39832"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:39:25.617645901Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6508397502878691": {
+				"ID":          6508397502878691,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6002608916871740,
+				"StableID":   "nont1kMbso11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c1cd0841824d93802c40af940852af23822f4455fb32cfbc552ae9cfae2fc302",
+				"KeyExpiry":  "2026-11-08T18:39:25Z",
+				"DiscoKey":   "discokey:47bb2e6f428a1410b5cdaccf61c958dd4a73c227c280599a10aad0ad1f8a3c54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55424",
+					"10.65.0.27:55424",
+					"172.17.0.1:55424",
+					"172.19.0.1:55424",
+					"172.20.0.1:55424"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:39:25.081539782Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c1cd0841824d93802c40af940852af23822f4455fb32cfbc552ae9cfae2fc302",
+			"MachineKey": "mkey:b0e9719f42ec817344b5c6f7f13ce73adfd7fc08591a71fcc92942b860269c6e",
+			"Peers": [{
+				"ID":         8474206718605856,
+				"StableID":   "n93cAN3zA921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:99ef3d41f4546c1a123d34973ca207b5e40a30eed61b3febdc38ee8f31310b69",
+				"DiscoKey":   "discokey:c639cfb07029f7cf2523a7a8c4a13a4b5755e1a91f6e90b89ab4e148fe480001",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44891",
+					"10.65.0.27:44891",
+					"172.17.0.1:44891",
+					"172.19.0.1:44891",
+					"172.20.0.1:44891"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 57289},
+					{"Proto": "peerapi6", "Port": 57289}
+				]},
+				"Created":              "2026-05-12T18:39:18.091889449Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3846456934384807,
+				"StableID":   "ncRgiGu43X11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:203e4dfb1d80d7c1fea8e138bba18fc4dbcd2820b283443f401ba2522b20f810",
+				"DiscoKey":   "discokey:6c0f074d583b981c851c07291dcac5c5975bccf03f79a6078329fb68cb269265",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39175",
+					"10.65.0.27:39175",
+					"172.17.0.1:39175",
+					"172.19.0.1:39175",
+					"172.20.0.1:39175"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:39:18.612037811Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4007060793922626,
+				"StableID":   "nVanp9hoHY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab3924ba47307b31a05c4f1b307f7a560025a8db2a0e2c61bd4391be364cf758",
+				"DiscoKey":   "discokey:681f5ef66139d20b2e862189cfbf8dff48f5bab946b8f89bcafd8a5dddd11c56",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:37844",
+					"10.65.0.27:37844",
+					"172.17.0.1:37844",
+					"172.19.0.1:37844",
+					"172.20.0.1:37844"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:39:19.133599214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6428516144351188,
+				"StableID":   "nHTuFfDVCs11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d32f31e1600d147b39c93bd3dc9db26416fa32aaac1703ffb1a2aa565f253a18",
+				"DiscoKey":   "discokey:1af4901e85a40c50fa7702876f1e9af65e6322b1a5f5ab3ca3aa1d4d7a383738",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58493",
+					"10.65.0.27:58493",
+					"172.17.0.1:58493",
+					"172.19.0.1:58493",
+					"172.20.0.1:58493"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:39:19.688477678Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7419866486659642,
+				"StableID":   "nXVeH2KUwz11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:01603471a77d30f507330843f42cb9cbf098bd40a6e6a247c3397b6b2a4e3560",
+				"DiscoKey":   "discokey:75b5c9fb7d747681baa0ca1f00f119a3281a88d53c566971e923a9021f8c9f20",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34831",
+					"10.65.0.27:34831",
+					"172.17.0.1:34831",
+					"172.19.0.1:34831",
+					"172.20.0.1:34831"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:39:20.191642896Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2823769285968430,
+				"StableID":   "nHrvFbdt3P11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bcc3352de2a036e53cee93bf3460933af9a098ca0793ba104570c38704e07b23",
+				"DiscoKey":   "discokey:3cd1b81dc872c7be51d6b693d16a101484460b9f5cd674866bbf135f1aa85d13",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:36817",
+					"10.65.0.27:36817",
+					"172.17.0.1:36817",
+					"172.19.0.1:36817",
+					"172.20.0.1:36817"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:39:20.753180617Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         441195553087581,
+				"StableID":   "nNhwDdTpS411CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1813ed29c1b10b1fe8554cbdefcafc1e62646cc708397fd20a8bf6105050b87c",
+				"DiscoKey":   "discokey:fa2ee33348c2a8b951aa4bba00fe1a42ed41a676361eea9baf94e0f29d1aa677",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47352",
+					"10.65.0.27:47352",
+					"172.17.0.1:47352",
+					"172.19.0.1:47352",
+					"172.20.0.1:47352"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:39:21.281210138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         644359334111538,
+				"StableID":   "nFHLrAEq2611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03e88b364fbd215a0d22bcdc35981bc2fe1e32ef7c43079cfd3568f25eefaa09",
+				"DiscoKey":   "discokey:40c1dfd75f92b67e83eb95d175d727bfb83f9caf3e1ef53385020efba7d37a55",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52956",
+					"10.65.0.27:52956",
+					"172.17.0.1:52956",
+					"172.19.0.1:52956",
+					"172.20.0.1:52956"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:39:21.832221727Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6508397502878691,
+				"StableID":   "ncwQNqZfps11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5ccbab58e2b2c4016bda0447a6cc2f94de15ff19c97ba21af7c103e5b406995d",
+				"DiscoKey":   "discokey:6229cdd8d8b1f3ef4028ad47a1c64f19ea1c09577d605579b992788d129e6638",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39928",
+					"10.65.0.27:39928",
+					"172.17.0.1:39928",
+					"172.19.0.1:39928",
+					"172.20.0.1:39928"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:39:22.355862072Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7785433198467645,
+				"StableID":   "np2YnS83o321CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:da443a4fa8a2fcfe70e50b383e9122fd3cf56580106adcb0ccd37f8968b25015",
+				"DiscoKey":   "discokey:be85de1b91cb0779bf0576561048a5cfc9f10dc91cea21a447742a31c25fdb30",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55637",
+					"10.65.0.27:55637",
+					"172.17.0.1:55637",
+					"172.19.0.1:55637",
+					"172.20.0.1:55637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:39:22.915650328Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8844789465698398,
+				"StableID":   "nFdTX2dp4C21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c47353e8cee1f9c282361d960eb2d24ab0eb488102fa1afd73e7661f7b3cfb6f",
+				"DiscoKey":   "discokey:b4809e1e9474594ecec896a8bd2ca17fac190710383e6d20a5b82e357812ab2a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50732",
+					"10.65.0.27:50732",
+					"172.17.0.1:50732",
+					"172.19.0.1:50732",
+					"172.20.0.1:50732"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:39:23.45158968Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5661569203018776,
+				"StableID":   "nPWbLip8Dm11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b8933288a1d26f216a169901d63905e4d0b95070fe4a6647d83a203ab0df036",
+				"DiscoKey":   "discokey:bbfc76af9546cde6bdfad6c0edefceb948a5dafeb93b66897dea5b88a9d2f840",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47001",
+					"10.65.0.27:47001",
+					"172.17.0.1:47001",
+					"172.19.0.1:47001",
+					"172.20.0.1:47001"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:39:23.995807116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2656439323035545,
+				"StableID":   "nUGoR5A7kM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:97ab98ca073effb2fc797fe936f96b30a387063e9224eee679e7481013766931",
+				"KeyExpiry":  "2026-11-08T18:39:24Z",
+				"DiscoKey":   "discokey:f999c8d92a4f40c9da81625e61c85d78a831b95fccbf917593f8f73b75196b53",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46452",
+					"10.65.0.27:46452",
+					"172.17.0.1:46452",
+					"172.19.0.1:46452",
+					"172.20.0.1:46452"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:39:24.544473863Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6766183268744481,
+				"StableID":   "nSdfkLARqu11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:674a351cd6fb70d97e65ffee7d83d2d87c59c288784421d3932a852c07344109",
+				"KeyExpiry":  "2026-11-08T18:39:25Z",
+				"DiscoKey":   "discokey:d73088a9b4a16ef15651662edb53eab500dbc237151e3d2f527cad4c164d8d65",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39832",
+					"10.65.0.27:39832",
+					"172.17.0.1:39832",
+					"172.19.0.1:39832",
+					"172.20.0.1:39832"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:39:25.617645901Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7785433198467645,
+				"StableID":   "np2YnS83o321CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       7785433198467645,
+				"Key":        "nodekey:da443a4fa8a2fcfe70e50b383e9122fd3cf56580106adcb0ccd37f8968b25015",
+				"DiscoKey":   "discokey:be85de1b91cb0779bf0576561048a5cfc9f10dc91cea21a447742a31c25fdb30",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:55637",
+					"10.65.0.27:55637",
+					"172.17.0.1:55637",
+					"172.19.0.1:55637",
+					"172.20.0.1:55637"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:39:22.915650328Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:da443a4fa8a2fcfe70e50b383e9122fd3cf56580106adcb0ccd37f8968b25015",
+			"MachineKey": "mkey:e1ee01c39bc2cb61eec8cce6ecd949166bf4d09b7fa43a6a9eb376188a7aba57",
+			"Peers": [{
+				"ID":         8474206718605856,
+				"StableID":   "n93cAN3zA921CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:99ef3d41f4546c1a123d34973ca207b5e40a30eed61b3febdc38ee8f31310b69",
+				"DiscoKey":   "discokey:c639cfb07029f7cf2523a7a8c4a13a4b5755e1a91f6e90b89ab4e148fe480001",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44891",
+					"10.65.0.27:44891",
+					"172.17.0.1:44891",
+					"172.19.0.1:44891",
+					"172.20.0.1:44891"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 57289},
+					{"Proto": "peerapi6", "Port": 57289}
+				]},
+				"Created":              "2026-05-12T18:39:18.091889449Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3846456934384807,
+				"StableID":   "ncRgiGu43X11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:203e4dfb1d80d7c1fea8e138bba18fc4dbcd2820b283443f401ba2522b20f810",
+				"DiscoKey":   "discokey:6c0f074d583b981c851c07291dcac5c5975bccf03f79a6078329fb68cb269265",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:39175",
+					"10.65.0.27:39175",
+					"172.17.0.1:39175",
+					"172.19.0.1:39175",
+					"172.20.0.1:39175"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:39:18.612037811Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4007060793922626,
+				"StableID":   "nVanp9hoHY11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ab3924ba47307b31a05c4f1b307f7a560025a8db2a0e2c61bd4391be364cf758",
+				"DiscoKey":   "discokey:681f5ef66139d20b2e862189cfbf8dff48f5bab946b8f89bcafd8a5dddd11c56",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:37844",
+					"10.65.0.27:37844",
+					"172.17.0.1:37844",
+					"172.19.0.1:37844",
+					"172.20.0.1:37844"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:39:19.133599214Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6428516144351188,
+				"StableID":   "nHTuFfDVCs11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d32f31e1600d147b39c93bd3dc9db26416fa32aaac1703ffb1a2aa565f253a18",
+				"DiscoKey":   "discokey:1af4901e85a40c50fa7702876f1e9af65e6322b1a5f5ab3ca3aa1d4d7a383738",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:58493",
+					"10.65.0.27:58493",
+					"172.17.0.1:58493",
+					"172.19.0.1:58493",
+					"172.20.0.1:58493"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:39:19.688477678Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7419866486659642,
+				"StableID":   "nXVeH2KUwz11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:01603471a77d30f507330843f42cb9cbf098bd40a6e6a247c3397b6b2a4e3560",
+				"DiscoKey":   "discokey:75b5c9fb7d747681baa0ca1f00f119a3281a88d53c566971e923a9021f8c9f20",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:34831",
+					"10.65.0.27:34831",
+					"172.17.0.1:34831",
+					"172.19.0.1:34831",
+					"172.20.0.1:34831"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:39:20.191642896Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2823769285968430,
+				"StableID":   "nHrvFbdt3P11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bcc3352de2a036e53cee93bf3460933af9a098ca0793ba104570c38704e07b23",
+				"DiscoKey":   "discokey:3cd1b81dc872c7be51d6b693d16a101484460b9f5cd674866bbf135f1aa85d13",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:36817",
+					"10.65.0.27:36817",
+					"172.17.0.1:36817",
+					"172.19.0.1:36817",
+					"172.20.0.1:36817"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:39:20.753180617Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         441195553087581,
+				"StableID":   "nNhwDdTpS411CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1813ed29c1b10b1fe8554cbdefcafc1e62646cc708397fd20a8bf6105050b87c",
+				"DiscoKey":   "discokey:fa2ee33348c2a8b951aa4bba00fe1a42ed41a676361eea9baf94e0f29d1aa677",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:47352",
+					"10.65.0.27:47352",
+					"172.17.0.1:47352",
+					"172.19.0.1:47352",
+					"172.20.0.1:47352"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:39:21.281210138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         644359334111538,
+				"StableID":   "nFHLrAEq2611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03e88b364fbd215a0d22bcdc35981bc2fe1e32ef7c43079cfd3568f25eefaa09",
+				"DiscoKey":   "discokey:40c1dfd75f92b67e83eb95d175d727bfb83f9caf3e1ef53385020efba7d37a55",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:52956",
+					"10.65.0.27:52956",
+					"172.17.0.1:52956",
+					"172.19.0.1:52956",
+					"172.20.0.1:52956"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:39:21.832221727Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6508397502878691,
+				"StableID":   "ncwQNqZfps11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5ccbab58e2b2c4016bda0447a6cc2f94de15ff19c97ba21af7c103e5b406995d",
+				"DiscoKey":   "discokey:6229cdd8d8b1f3ef4028ad47a1c64f19ea1c09577d605579b992788d129e6638",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:39928",
+					"10.65.0.27:39928",
+					"172.17.0.1:39928",
+					"172.19.0.1:39928",
+					"172.20.0.1:39928"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:39:22.355862072Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8844789465698398,
+				"StableID":   "nFdTX2dp4C21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c47353e8cee1f9c282361d960eb2d24ab0eb488102fa1afd73e7661f7b3cfb6f",
+				"DiscoKey":   "discokey:b4809e1e9474594ecec896a8bd2ca17fac190710383e6d20a5b82e357812ab2a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50732",
+					"10.65.0.27:50732",
+					"172.17.0.1:50732",
+					"172.19.0.1:50732",
+					"172.20.0.1:50732"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:39:23.45158968Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5661569203018776,
+				"StableID":   "nPWbLip8Dm11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3b8933288a1d26f216a169901d63905e4d0b95070fe4a6647d83a203ab0df036",
+				"DiscoKey":   "discokey:bbfc76af9546cde6bdfad6c0edefceb948a5dafeb93b66897dea5b88a9d2f840",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47001",
+					"10.65.0.27:47001",
+					"172.17.0.1:47001",
+					"172.19.0.1:47001",
+					"172.20.0.1:47001"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:39:23.995807116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2656439323035545,
+				"StableID":   "nUGoR5A7kM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:97ab98ca073effb2fc797fe936f96b30a387063e9224eee679e7481013766931",
+				"KeyExpiry":  "2026-11-08T18:39:24Z",
+				"DiscoKey":   "discokey:f999c8d92a4f40c9da81625e61c85d78a831b95fccbf917593f8f73b75196b53",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:46452",
+					"10.65.0.27:46452",
+					"172.17.0.1:46452",
+					"172.19.0.1:46452",
+					"172.20.0.1:46452"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:39:24.544473863Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6002608916871740,
+				"StableID":   "nont1kMbso11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:c1cd0841824d93802c40af940852af23822f4455fb32cfbc552ae9cfae2fc302",
+				"KeyExpiry":  "2026-11-08T18:39:25Z",
+				"DiscoKey":   "discokey:47bb2e6f428a1410b5cdaccf61c958dd4a73c227c280599a10aad0ad1f8a3c54",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:55424",
+					"10.65.0.27:55424",
+					"172.17.0.1:55424",
+					"172.19.0.1:55424",
+					"172.20.0.1:55424"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:39:25.081539782Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         6766183268744481,
+				"StableID":   "nSdfkLARqu11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:674a351cd6fb70d97e65ffee7d83d2d87c59c288784421d3932a852c07344109",
+				"KeyExpiry":  "2026-11-08T18:39:25Z",
+				"DiscoKey":   "discokey:d73088a9b4a16ef15651662edb53eab500dbc237151e3d2f527cad4c164d8d65",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:39832",
+					"10.65.0.27:39832",
+					"172.17.0.1:39832",
+					"172.19.0.1:39832",
+					"172.20.0.1:39832"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:39:25.617645901Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7785433198467645": {
+				"ID":          7785433198467645,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/sshtest_results/sshtest-dst-duplicate-tags.hujson
+++ b/hscontrol/policy/v2/testdata/sshtest_results/sshtest-dst-duplicate-tags.hujson
@@ -1,0 +1,21903 @@
+// sshtest-dst-duplicate-tags
+//
+// sshTests dst contains duplicate tag
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-13T09:30:16Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "sshtest-dst-duplicate-tags",
+	"description":    "sshTests dst contains duplicate tag",
+	"category":       "sshtest",
+	"captured_at":    "2026-05-13T09:30:16.848261709Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                             \n  \n                                                                    \n                                            \n{\n\t\"category\":    \"sshtest\",\n\t\"description\": \"sshTests dst contains duplicate tag\",\n\t\"id\":          \"sshtest-dst-duplicate-tags\",\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"thor@example.org\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"sshTests\": [{\n\t\t\"accept\": [\"root\"],\n\t\t\"dst\":    [\"tag:server\", \"tag:server\"],\n\t\t\"src\":    \"thor@example.org\"\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-edges/sshtest-dst-duplicate-tags.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["thor@example.org"],
+				"users":  ["root"]
+			}],
+			"sshTests": [{
+				"accept": ["root"],
+				"dst":    ["tag:server", "tag:server"],
+				"src":    "thor@example.org"
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6635437266779190,
+				"StableID":   "nme7HkgCpt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       6635437266779190,
+				"Key":        "nodekey:cbf7c7ea6bd03996c13db4de2b558efbbd5cf8536f41cc76424b15a8cce8ed6b",
+				"DiscoKey":   "discokey:b83c63aafa2ac23ca7968015176fdf00a90a94ddc1cc8402ef0b72afc8a78706",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45684",
+					"10.65.0.27:45684",
+					"172.17.0.1:45684",
+					"172.18.0.1:45684",
+					"172.19.0.1:45684",
+					"172.20.0.1:45684",
+					"172.21.0.1:45684",
+					"172.22.0.1:45684",
+					"172.23.0.1:45684",
+					"172.24.0.1:45684",
+					"172.25.0.1:45684",
+					"172.26.0.1:45684",
+					"172.27.0.1:45684"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:30:26.20463116Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:cbf7c7ea6bd03996c13db4de2b558efbbd5cf8536f41cc76424b15a8cce8ed6b",
+			"MachineKey": "mkey:edb0fca405f47ebe38ca05c073534e3ca50b655031fe9ea0d9f932c152dda818",
+			"Peers": [{
+				"ID":         3628307374917488,
+				"StableID":   "nwJfAyUGLV11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8587a6f7374ca011a9ac6468627b921cfa75948a6fb3f0b04df5ffc7e4822b5b",
+				"DiscoKey":   "discokey:5291592b301d037d3573ecb86b8ffafda3907780e8ffc5edb50e85035ed66a74",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:60776",
+					"10.65.0.27:60776",
+					"172.17.0.1:60776",
+					"172.18.0.1:60776",
+					"172.19.0.1:60776",
+					"172.20.0.1:60776",
+					"172.21.0.1:60776",
+					"172.22.0.1:60776",
+					"172.23.0.1:60776",
+					"172.24.0.1:60776",
+					"172.25.0.1:60776",
+					"172.26.0.1:60776",
+					"172.27.0.1:60776"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:30:19.604495837Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1493384375532153,
+				"StableID":   "nJPrQAgMfC11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb5bb1cdb0ff33b7e7bee6ec6b139f6fafb9f188c6bab4243677c47cc5a70831",
+				"DiscoKey":   "discokey:13886cbf8a432412327a73ba106d682f72fbde38b2771ab03c66baabdfaee42f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:52709",
+					"10.65.0.27:52709",
+					"172.17.0.1:52709",
+					"172.18.0.1:52709",
+					"172.19.0.1:52709",
+					"172.20.0.1:52709",
+					"172.21.0.1:52709",
+					"172.22.0.1:52709",
+					"172.23.0.1:52709",
+					"172.24.0.1:52709",
+					"172.25.0.1:52709",
+					"172.26.0.1:52709",
+					"172.27.0.1:52709"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:30:20.319592339Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1099277371122160,
+				"StableID":   "ns8Hzq9sa911CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6ead0b971a84bb0155d90e0ebd3eb6e7d7353739feb2acb825c5deb763631d53",
+				"DiscoKey":   "discokey:a4ae1f8f20ee5f9b386feb4b92b080b07ae8d53d1cc019fa7c7761bdb2a7df70",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43004",
+					"10.65.0.27:43004",
+					"172.17.0.1:43004",
+					"172.18.0.1:43004",
+					"172.19.0.1:43004",
+					"172.20.0.1:43004",
+					"172.21.0.1:43004",
+					"172.22.0.1:43004",
+					"172.23.0.1:43004",
+					"172.24.0.1:43004",
+					"172.25.0.1:43004",
+					"172.26.0.1:43004",
+					"172.27.0.1:43004"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:30:20.856238896Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2691709711896678,
+				"StableID":   "ndnyuge52N11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2f0f9aa40c11d6caefbf393a5ae8eeb99f47053abac6b79681f8aa1b67e98769",
+				"DiscoKey":   "discokey:29ee71a95c71f6ed791da21b42c0c819f0b95368406800121696acf5ffca1745",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45143",
+					"10.65.0.27:45143",
+					"172.17.0.1:45143",
+					"172.18.0.1:45143",
+					"172.19.0.1:45143",
+					"172.20.0.1:45143",
+					"172.21.0.1:45143",
+					"172.22.0.1:45143",
+					"172.23.0.1:45143",
+					"172.24.0.1:45143",
+					"172.25.0.1:45143",
+					"172.26.0.1:45143",
+					"172.27.0.1:45143"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:30:21.393986895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         12685843844750,
+				"StableID":   "n9tdafEk6111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e9317595a76d9da92f070ba866cbbfd950bebd0bb2a22da60dd5f548d9e7739",
+				"DiscoKey":   "discokey:20045d9d345983c979fadb65dd0db6620eb191751458cac1582766f33d25be41",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58390",
+					"10.65.0.27:58390",
+					"172.17.0.1:58390",
+					"172.18.0.1:58390",
+					"172.19.0.1:58390",
+					"172.20.0.1:58390",
+					"172.21.0.1:58390",
+					"172.22.0.1:58390",
+					"172.23.0.1:58390",
+					"172.24.0.1:58390",
+					"172.25.0.1:58390",
+					"172.26.0.1:58390",
+					"172.27.0.1:58390"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:30:21.965086659Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         220059800127697,
+				"StableID":   "nJfiyfbfi211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f82d10ad4a8afe9aeee81c4c1dcf49cda2f43da67e83bb43dd02f4616d907911",
+				"DiscoKey":   "discokey:9c598e24bacf2aa5dbcdfa20934c7082c2d423abf9aa422d163284b41be6ee49",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41839",
+					"10.65.0.27:41839",
+					"172.17.0.1:41839",
+					"172.18.0.1:41839",
+					"172.19.0.1:41839",
+					"172.20.0.1:41839",
+					"172.21.0.1:41839",
+					"172.22.0.1:41839",
+					"172.23.0.1:41839",
+					"172.24.0.1:41839",
+					"172.25.0.1:41839",
+					"172.26.0.1:41839",
+					"172.27.0.1:41839"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:30:22.487425695Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7367908405015496,
+				"StableID":   "nw4zXgTwXz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b5171dd8248b6600e124ab8a373ad2474d1422ebf0a43a7f93e526e1e45ae774",
+				"DiscoKey":   "discokey:32447222761bd26fc98eb5000a8954e03b20b5456e2f40230debc4e3bd71dc5f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44778",
+					"10.65.0.27:44778",
+					"172.17.0.1:44778",
+					"172.18.0.1:44778",
+					"172.19.0.1:44778",
+					"172.20.0.1:44778",
+					"172.21.0.1:44778",
+					"172.22.0.1:44778",
+					"172.23.0.1:44778",
+					"172.24.0.1:44778",
+					"172.25.0.1:44778",
+					"172.26.0.1:44778",
+					"172.27.0.1:44778"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:30:23.04063128Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5602755481149455,
+				"StableID":   "nJ4o8PtVkk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d8d2db2cb821338ea64e3375fc8e1048d0b9fc371c24e4d176cd629ef522065",
+				"DiscoKey":   "discokey:400d522c5a33d5f017772b6608482cf826411a0f597b22b01e50664e6835e35a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37413",
+					"10.65.0.27:37413",
+					"172.17.0.1:37413",
+					"172.18.0.1:37413",
+					"172.19.0.1:37413",
+					"172.20.0.1:37413",
+					"172.21.0.1:37413",
+					"172.22.0.1:37413",
+					"172.23.0.1:37413",
+					"172.24.0.1:37413",
+					"172.25.0.1:37413",
+					"172.26.0.1:37413",
+					"172.27.0.1:37413"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:30:23.630307934Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7395883338911835,
+				"StableID":   "nYPXeDKckz11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c89610742a89888e4ceac7e52b6aa315db690c98ada622f726b3a4242e9b8d3f",
+				"DiscoKey":   "discokey:00b9780e7c8d9deeaf1a27ce309babca928035af7dd7fa200c57271a67bf820a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35503",
+					"10.65.0.27:35503",
+					"172.17.0.1:35503",
+					"172.18.0.1:35503",
+					"172.19.0.1:35503",
+					"172.20.0.1:35503",
+					"172.21.0.1:35503",
+					"172.22.0.1:35503",
+					"172.23.0.1:35503",
+					"172.24.0.1:35503",
+					"172.25.0.1:35503",
+					"172.26.0.1:35503",
+					"172.27.0.1:35503"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:30:24.35024234Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         156123256026230,
+				"StableID":   "nK3wWQ6iD211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35bbd44adc1e0017f0f3cb5dc15c25172e8e0873f8475470e8716c906e85701c",
+				"DiscoKey":   "discokey:e315d2aa2650c181b0e7e8abe62aed80b5f6a8b39b3f5f590a3a6e81d7994a4e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59133",
+					"10.65.0.27:59133",
+					"172.17.0.1:59133",
+					"172.18.0.1:59133",
+					"172.19.0.1:59133",
+					"172.20.0.1:59133",
+					"172.21.0.1:59133",
+					"172.22.0.1:59133",
+					"172.23.0.1:59133",
+					"172.24.0.1:59133",
+					"172.25.0.1:59133",
+					"172.26.0.1:59133",
+					"172.27.0.1:59133"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:30:24.961232221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8431358078059330,
+				"StableID":   "nsmfXpUaq821CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:63133f6c88593acd3b63105c7176719ce717f2e66b9b7657c0aa3acc4557316d",
+				"DiscoKey":   "discokey:d204d313a545b75f35dbf27c5fd8924b694c32b6d1d7622f8c665bae2c052373",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50334",
+					"10.65.0.27:50334",
+					"172.17.0.1:50334",
+					"172.18.0.1:50334",
+					"172.19.0.1:50334",
+					"172.20.0.1:50334",
+					"172.21.0.1:50334",
+					"172.22.0.1:50334",
+					"172.23.0.1:50334",
+					"172.24.0.1:50334",
+					"172.25.0.1:50334",
+					"172.26.0.1:50334",
+					"172.27.0.1:50334"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:30:25.669266846Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6048256030654495,
+				"StableID":   "nkqe9wRGEp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a2661c0992e6f6f36c961226b6c951c0324de2a6d2279d7e43c3a6fed43f9652",
+				"KeyExpiry":  "2026-11-09T09:30:26Z",
+				"DiscoKey":   "discokey:3ebad77570ee23f4a75003d66ebe44faa51879ec277d967f1df088231e820c28",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45887",
+					"10.65.0.27:45887",
+					"172.17.0.1:45887",
+					"172.18.0.1:45887",
+					"172.19.0.1:45887",
+					"172.20.0.1:45887",
+					"172.21.0.1:45887",
+					"172.22.0.1:45887",
+					"172.23.0.1:45887",
+					"172.24.0.1:45887",
+					"172.25.0.1:45887",
+					"172.26.0.1:45887",
+					"172.27.0.1:45887"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:30:26.725360455Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8234239497029749,
+				"StableID":   "nvuPXWWJJ721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:180fb2b409872a185fa9447ecfbb845e0154f6c7f143eb6ca09e3d2bd6ddbb17",
+				"KeyExpiry":  "2026-11-09T09:30:27Z",
+				"DiscoKey":   "discokey:7e5bb9a482709932c2f64cb02779a5a9c71b33777a842c47041a0fc713b9587a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50553",
+					"10.65.0.27:50553",
+					"172.17.0.1:50553",
+					"172.18.0.1:50553",
+					"172.19.0.1:50553",
+					"172.20.0.1:50553",
+					"172.21.0.1:50553",
+					"172.22.0.1:50553",
+					"172.23.0.1:50553",
+					"172.24.0.1:50553",
+					"172.25.0.1:50553",
+					"172.26.0.1:50553",
+					"172.27.0.1:50553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:30:27.260403572Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3225617935357335,
+				"StableID":   "nAUbLnWtBS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:05fb5c7def2bd52a36b410573911e9e7309ce75d545fb99011ceb2ed571d5d5d",
+				"KeyExpiry":  "2026-11-09T09:30:27Z",
+				"DiscoKey":   "discokey:0dde8e43d786368333282af84458203134ee89de681daae268aea547302eaa39",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57338",
+					"10.65.0.27:57338",
+					"172.17.0.1:57338",
+					"172.18.0.1:57338",
+					"172.19.0.1:57338",
+					"172.20.0.1:57338",
+					"172.21.0.1:57338",
+					"172.22.0.1:57338",
+					"172.23.0.1:57338",
+					"172.24.0.1:57338",
+					"172.25.0.1:57338",
+					"172.26.0.1:57338",
+					"172.27.0.1:57338"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:30:27.807949242Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{
+				"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+				"sshUsers":   {"root": "root"},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				}
+			}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6635437266779190": {
+				"ID":          6635437266779190,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		},
+		"ssh_rules": [{
+			"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+			"sshUsers":   {"root": "root"},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}
+		}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         220059800127697,
+				"StableID":   "nJfiyfbfi211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       220059800127697,
+				"Key":        "nodekey:f82d10ad4a8afe9aeee81c4c1dcf49cda2f43da67e83bb43dd02f4616d907911",
+				"DiscoKey":   "discokey:9c598e24bacf2aa5dbcdfa20934c7082c2d423abf9aa422d163284b41be6ee49",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41839",
+					"10.65.0.27:41839",
+					"172.17.0.1:41839",
+					"172.18.0.1:41839",
+					"172.19.0.1:41839",
+					"172.20.0.1:41839",
+					"172.21.0.1:41839",
+					"172.22.0.1:41839",
+					"172.23.0.1:41839",
+					"172.24.0.1:41839",
+					"172.25.0.1:41839",
+					"172.26.0.1:41839",
+					"172.27.0.1:41839"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:30:22.487425695Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f82d10ad4a8afe9aeee81c4c1dcf49cda2f43da67e83bb43dd02f4616d907911",
+			"MachineKey": "mkey:90d79ada9ae5e6f735ec96d6551ba3fdee4d715dbef6c12892b07042b7237330",
+			"Peers": [{
+				"ID":         3628307374917488,
+				"StableID":   "nwJfAyUGLV11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8587a6f7374ca011a9ac6468627b921cfa75948a6fb3f0b04df5ffc7e4822b5b",
+				"DiscoKey":   "discokey:5291592b301d037d3573ecb86b8ffafda3907780e8ffc5edb50e85035ed66a74",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:60776",
+					"10.65.0.27:60776",
+					"172.17.0.1:60776",
+					"172.18.0.1:60776",
+					"172.19.0.1:60776",
+					"172.20.0.1:60776",
+					"172.21.0.1:60776",
+					"172.22.0.1:60776",
+					"172.23.0.1:60776",
+					"172.24.0.1:60776",
+					"172.25.0.1:60776",
+					"172.26.0.1:60776",
+					"172.27.0.1:60776"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:30:19.604495837Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1493384375532153,
+				"StableID":   "nJPrQAgMfC11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb5bb1cdb0ff33b7e7bee6ec6b139f6fafb9f188c6bab4243677c47cc5a70831",
+				"DiscoKey":   "discokey:13886cbf8a432412327a73ba106d682f72fbde38b2771ab03c66baabdfaee42f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:52709",
+					"10.65.0.27:52709",
+					"172.17.0.1:52709",
+					"172.18.0.1:52709",
+					"172.19.0.1:52709",
+					"172.20.0.1:52709",
+					"172.21.0.1:52709",
+					"172.22.0.1:52709",
+					"172.23.0.1:52709",
+					"172.24.0.1:52709",
+					"172.25.0.1:52709",
+					"172.26.0.1:52709",
+					"172.27.0.1:52709"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:30:20.319592339Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1099277371122160,
+				"StableID":   "ns8Hzq9sa911CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6ead0b971a84bb0155d90e0ebd3eb6e7d7353739feb2acb825c5deb763631d53",
+				"DiscoKey":   "discokey:a4ae1f8f20ee5f9b386feb4b92b080b07ae8d53d1cc019fa7c7761bdb2a7df70",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43004",
+					"10.65.0.27:43004",
+					"172.17.0.1:43004",
+					"172.18.0.1:43004",
+					"172.19.0.1:43004",
+					"172.20.0.1:43004",
+					"172.21.0.1:43004",
+					"172.22.0.1:43004",
+					"172.23.0.1:43004",
+					"172.24.0.1:43004",
+					"172.25.0.1:43004",
+					"172.26.0.1:43004",
+					"172.27.0.1:43004"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:30:20.856238896Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2691709711896678,
+				"StableID":   "ndnyuge52N11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2f0f9aa40c11d6caefbf393a5ae8eeb99f47053abac6b79681f8aa1b67e98769",
+				"DiscoKey":   "discokey:29ee71a95c71f6ed791da21b42c0c819f0b95368406800121696acf5ffca1745",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45143",
+					"10.65.0.27:45143",
+					"172.17.0.1:45143",
+					"172.18.0.1:45143",
+					"172.19.0.1:45143",
+					"172.20.0.1:45143",
+					"172.21.0.1:45143",
+					"172.22.0.1:45143",
+					"172.23.0.1:45143",
+					"172.24.0.1:45143",
+					"172.25.0.1:45143",
+					"172.26.0.1:45143",
+					"172.27.0.1:45143"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:30:21.393986895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         12685843844750,
+				"StableID":   "n9tdafEk6111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e9317595a76d9da92f070ba866cbbfd950bebd0bb2a22da60dd5f548d9e7739",
+				"DiscoKey":   "discokey:20045d9d345983c979fadb65dd0db6620eb191751458cac1582766f33d25be41",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58390",
+					"10.65.0.27:58390",
+					"172.17.0.1:58390",
+					"172.18.0.1:58390",
+					"172.19.0.1:58390",
+					"172.20.0.1:58390",
+					"172.21.0.1:58390",
+					"172.22.0.1:58390",
+					"172.23.0.1:58390",
+					"172.24.0.1:58390",
+					"172.25.0.1:58390",
+					"172.26.0.1:58390",
+					"172.27.0.1:58390"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:30:21.965086659Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7367908405015496,
+				"StableID":   "nw4zXgTwXz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b5171dd8248b6600e124ab8a373ad2474d1422ebf0a43a7f93e526e1e45ae774",
+				"DiscoKey":   "discokey:32447222761bd26fc98eb5000a8954e03b20b5456e2f40230debc4e3bd71dc5f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44778",
+					"10.65.0.27:44778",
+					"172.17.0.1:44778",
+					"172.18.0.1:44778",
+					"172.19.0.1:44778",
+					"172.20.0.1:44778",
+					"172.21.0.1:44778",
+					"172.22.0.1:44778",
+					"172.23.0.1:44778",
+					"172.24.0.1:44778",
+					"172.25.0.1:44778",
+					"172.26.0.1:44778",
+					"172.27.0.1:44778"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:30:23.04063128Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5602755481149455,
+				"StableID":   "nJ4o8PtVkk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d8d2db2cb821338ea64e3375fc8e1048d0b9fc371c24e4d176cd629ef522065",
+				"DiscoKey":   "discokey:400d522c5a33d5f017772b6608482cf826411a0f597b22b01e50664e6835e35a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37413",
+					"10.65.0.27:37413",
+					"172.17.0.1:37413",
+					"172.18.0.1:37413",
+					"172.19.0.1:37413",
+					"172.20.0.1:37413",
+					"172.21.0.1:37413",
+					"172.22.0.1:37413",
+					"172.23.0.1:37413",
+					"172.24.0.1:37413",
+					"172.25.0.1:37413",
+					"172.26.0.1:37413",
+					"172.27.0.1:37413"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:30:23.630307934Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7395883338911835,
+				"StableID":   "nYPXeDKckz11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c89610742a89888e4ceac7e52b6aa315db690c98ada622f726b3a4242e9b8d3f",
+				"DiscoKey":   "discokey:00b9780e7c8d9deeaf1a27ce309babca928035af7dd7fa200c57271a67bf820a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35503",
+					"10.65.0.27:35503",
+					"172.17.0.1:35503",
+					"172.18.0.1:35503",
+					"172.19.0.1:35503",
+					"172.20.0.1:35503",
+					"172.21.0.1:35503",
+					"172.22.0.1:35503",
+					"172.23.0.1:35503",
+					"172.24.0.1:35503",
+					"172.25.0.1:35503",
+					"172.26.0.1:35503",
+					"172.27.0.1:35503"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:30:24.35024234Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         156123256026230,
+				"StableID":   "nK3wWQ6iD211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35bbd44adc1e0017f0f3cb5dc15c25172e8e0873f8475470e8716c906e85701c",
+				"DiscoKey":   "discokey:e315d2aa2650c181b0e7e8abe62aed80b5f6a8b39b3f5f590a3a6e81d7994a4e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59133",
+					"10.65.0.27:59133",
+					"172.17.0.1:59133",
+					"172.18.0.1:59133",
+					"172.19.0.1:59133",
+					"172.20.0.1:59133",
+					"172.21.0.1:59133",
+					"172.22.0.1:59133",
+					"172.23.0.1:59133",
+					"172.24.0.1:59133",
+					"172.25.0.1:59133",
+					"172.26.0.1:59133",
+					"172.27.0.1:59133"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:30:24.961232221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8431358078059330,
+				"StableID":   "nsmfXpUaq821CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:63133f6c88593acd3b63105c7176719ce717f2e66b9b7657c0aa3acc4557316d",
+				"DiscoKey":   "discokey:d204d313a545b75f35dbf27c5fd8924b694c32b6d1d7622f8c665bae2c052373",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50334",
+					"10.65.0.27:50334",
+					"172.17.0.1:50334",
+					"172.18.0.1:50334",
+					"172.19.0.1:50334",
+					"172.20.0.1:50334",
+					"172.21.0.1:50334",
+					"172.22.0.1:50334",
+					"172.23.0.1:50334",
+					"172.24.0.1:50334",
+					"172.25.0.1:50334",
+					"172.26.0.1:50334",
+					"172.27.0.1:50334"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:30:25.669266846Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6635437266779190,
+				"StableID":   "nme7HkgCpt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cbf7c7ea6bd03996c13db4de2b558efbbd5cf8536f41cc76424b15a8cce8ed6b",
+				"DiscoKey":   "discokey:b83c63aafa2ac23ca7968015176fdf00a90a94ddc1cc8402ef0b72afc8a78706",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45684",
+					"10.65.0.27:45684",
+					"172.17.0.1:45684",
+					"172.18.0.1:45684",
+					"172.19.0.1:45684",
+					"172.20.0.1:45684",
+					"172.21.0.1:45684",
+					"172.22.0.1:45684",
+					"172.23.0.1:45684",
+					"172.24.0.1:45684",
+					"172.25.0.1:45684",
+					"172.26.0.1:45684",
+					"172.27.0.1:45684"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:30:26.20463116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6048256030654495,
+				"StableID":   "nkqe9wRGEp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a2661c0992e6f6f36c961226b6c951c0324de2a6d2279d7e43c3a6fed43f9652",
+				"KeyExpiry":  "2026-11-09T09:30:26Z",
+				"DiscoKey":   "discokey:3ebad77570ee23f4a75003d66ebe44faa51879ec277d967f1df088231e820c28",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45887",
+					"10.65.0.27:45887",
+					"172.17.0.1:45887",
+					"172.18.0.1:45887",
+					"172.19.0.1:45887",
+					"172.20.0.1:45887",
+					"172.21.0.1:45887",
+					"172.22.0.1:45887",
+					"172.23.0.1:45887",
+					"172.24.0.1:45887",
+					"172.25.0.1:45887",
+					"172.26.0.1:45887",
+					"172.27.0.1:45887"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:30:26.725360455Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8234239497029749,
+				"StableID":   "nvuPXWWJJ721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:180fb2b409872a185fa9447ecfbb845e0154f6c7f143eb6ca09e3d2bd6ddbb17",
+				"KeyExpiry":  "2026-11-09T09:30:27Z",
+				"DiscoKey":   "discokey:7e5bb9a482709932c2f64cb02779a5a9c71b33777a842c47041a0fc713b9587a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50553",
+					"10.65.0.27:50553",
+					"172.17.0.1:50553",
+					"172.18.0.1:50553",
+					"172.19.0.1:50553",
+					"172.20.0.1:50553",
+					"172.21.0.1:50553",
+					"172.22.0.1:50553",
+					"172.23.0.1:50553",
+					"172.24.0.1:50553",
+					"172.25.0.1:50553",
+					"172.26.0.1:50553",
+					"172.27.0.1:50553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:30:27.260403572Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3225617935357335,
+				"StableID":   "nAUbLnWtBS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:05fb5c7def2bd52a36b410573911e9e7309ce75d545fb99011ceb2ed571d5d5d",
+				"KeyExpiry":  "2026-11-09T09:30:27Z",
+				"DiscoKey":   "discokey:0dde8e43d786368333282af84458203134ee89de681daae268aea547302eaa39",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57338",
+					"10.65.0.27:57338",
+					"172.17.0.1:57338",
+					"172.18.0.1:57338",
+					"172.19.0.1:57338",
+					"172.20.0.1:57338",
+					"172.21.0.1:57338",
+					"172.22.0.1:57338",
+					"172.23.0.1:57338",
+					"172.24.0.1:57338",
+					"172.25.0.1:57338",
+					"172.26.0.1:57338",
+					"172.27.0.1:57338"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:30:27.807949242Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "220059800127697": {
+				"ID":          220059800127697,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3225617935357335,
+				"StableID":   "nAUbLnWtBS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:05fb5c7def2bd52a36b410573911e9e7309ce75d545fb99011ceb2ed571d5d5d",
+				"KeyExpiry":  "2026-11-09T09:30:27Z",
+				"DiscoKey":   "discokey:0dde8e43d786368333282af84458203134ee89de681daae268aea547302eaa39",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57338",
+					"10.65.0.27:57338",
+					"172.17.0.1:57338",
+					"172.18.0.1:57338",
+					"172.19.0.1:57338",
+					"172.20.0.1:57338",
+					"172.21.0.1:57338",
+					"172.22.0.1:57338",
+					"172.23.0.1:57338",
+					"172.24.0.1:57338",
+					"172.25.0.1:57338",
+					"172.26.0.1:57338",
+					"172.27.0.1:57338"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:30:27.807949242Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:05fb5c7def2bd52a36b410573911e9e7309ce75d545fb99011ceb2ed571d5d5d",
+			"MachineKey": "mkey:5c5ba093e480d67dce27283e6649b1c1b16139393ece212c33c79620d8f62872",
+			"Peers": [{
+				"ID":         3628307374917488,
+				"StableID":   "nwJfAyUGLV11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8587a6f7374ca011a9ac6468627b921cfa75948a6fb3f0b04df5ffc7e4822b5b",
+				"DiscoKey":   "discokey:5291592b301d037d3573ecb86b8ffafda3907780e8ffc5edb50e85035ed66a74",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:60776",
+					"10.65.0.27:60776",
+					"172.17.0.1:60776",
+					"172.18.0.1:60776",
+					"172.19.0.1:60776",
+					"172.20.0.1:60776",
+					"172.21.0.1:60776",
+					"172.22.0.1:60776",
+					"172.23.0.1:60776",
+					"172.24.0.1:60776",
+					"172.25.0.1:60776",
+					"172.26.0.1:60776",
+					"172.27.0.1:60776"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:30:19.604495837Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1493384375532153,
+				"StableID":   "nJPrQAgMfC11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb5bb1cdb0ff33b7e7bee6ec6b139f6fafb9f188c6bab4243677c47cc5a70831",
+				"DiscoKey":   "discokey:13886cbf8a432412327a73ba106d682f72fbde38b2771ab03c66baabdfaee42f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:52709",
+					"10.65.0.27:52709",
+					"172.17.0.1:52709",
+					"172.18.0.1:52709",
+					"172.19.0.1:52709",
+					"172.20.0.1:52709",
+					"172.21.0.1:52709",
+					"172.22.0.1:52709",
+					"172.23.0.1:52709",
+					"172.24.0.1:52709",
+					"172.25.0.1:52709",
+					"172.26.0.1:52709",
+					"172.27.0.1:52709"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:30:20.319592339Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1099277371122160,
+				"StableID":   "ns8Hzq9sa911CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6ead0b971a84bb0155d90e0ebd3eb6e7d7353739feb2acb825c5deb763631d53",
+				"DiscoKey":   "discokey:a4ae1f8f20ee5f9b386feb4b92b080b07ae8d53d1cc019fa7c7761bdb2a7df70",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43004",
+					"10.65.0.27:43004",
+					"172.17.0.1:43004",
+					"172.18.0.1:43004",
+					"172.19.0.1:43004",
+					"172.20.0.1:43004",
+					"172.21.0.1:43004",
+					"172.22.0.1:43004",
+					"172.23.0.1:43004",
+					"172.24.0.1:43004",
+					"172.25.0.1:43004",
+					"172.26.0.1:43004",
+					"172.27.0.1:43004"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:30:20.856238896Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2691709711896678,
+				"StableID":   "ndnyuge52N11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2f0f9aa40c11d6caefbf393a5ae8eeb99f47053abac6b79681f8aa1b67e98769",
+				"DiscoKey":   "discokey:29ee71a95c71f6ed791da21b42c0c819f0b95368406800121696acf5ffca1745",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45143",
+					"10.65.0.27:45143",
+					"172.17.0.1:45143",
+					"172.18.0.1:45143",
+					"172.19.0.1:45143",
+					"172.20.0.1:45143",
+					"172.21.0.1:45143",
+					"172.22.0.1:45143",
+					"172.23.0.1:45143",
+					"172.24.0.1:45143",
+					"172.25.0.1:45143",
+					"172.26.0.1:45143",
+					"172.27.0.1:45143"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:30:21.393986895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         12685843844750,
+				"StableID":   "n9tdafEk6111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e9317595a76d9da92f070ba866cbbfd950bebd0bb2a22da60dd5f548d9e7739",
+				"DiscoKey":   "discokey:20045d9d345983c979fadb65dd0db6620eb191751458cac1582766f33d25be41",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58390",
+					"10.65.0.27:58390",
+					"172.17.0.1:58390",
+					"172.18.0.1:58390",
+					"172.19.0.1:58390",
+					"172.20.0.1:58390",
+					"172.21.0.1:58390",
+					"172.22.0.1:58390",
+					"172.23.0.1:58390",
+					"172.24.0.1:58390",
+					"172.25.0.1:58390",
+					"172.26.0.1:58390",
+					"172.27.0.1:58390"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:30:21.965086659Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         220059800127697,
+				"StableID":   "nJfiyfbfi211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f82d10ad4a8afe9aeee81c4c1dcf49cda2f43da67e83bb43dd02f4616d907911",
+				"DiscoKey":   "discokey:9c598e24bacf2aa5dbcdfa20934c7082c2d423abf9aa422d163284b41be6ee49",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41839",
+					"10.65.0.27:41839",
+					"172.17.0.1:41839",
+					"172.18.0.1:41839",
+					"172.19.0.1:41839",
+					"172.20.0.1:41839",
+					"172.21.0.1:41839",
+					"172.22.0.1:41839",
+					"172.23.0.1:41839",
+					"172.24.0.1:41839",
+					"172.25.0.1:41839",
+					"172.26.0.1:41839",
+					"172.27.0.1:41839"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:30:22.487425695Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7367908405015496,
+				"StableID":   "nw4zXgTwXz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b5171dd8248b6600e124ab8a373ad2474d1422ebf0a43a7f93e526e1e45ae774",
+				"DiscoKey":   "discokey:32447222761bd26fc98eb5000a8954e03b20b5456e2f40230debc4e3bd71dc5f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44778",
+					"10.65.0.27:44778",
+					"172.17.0.1:44778",
+					"172.18.0.1:44778",
+					"172.19.0.1:44778",
+					"172.20.0.1:44778",
+					"172.21.0.1:44778",
+					"172.22.0.1:44778",
+					"172.23.0.1:44778",
+					"172.24.0.1:44778",
+					"172.25.0.1:44778",
+					"172.26.0.1:44778",
+					"172.27.0.1:44778"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:30:23.04063128Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5602755481149455,
+				"StableID":   "nJ4o8PtVkk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d8d2db2cb821338ea64e3375fc8e1048d0b9fc371c24e4d176cd629ef522065",
+				"DiscoKey":   "discokey:400d522c5a33d5f017772b6608482cf826411a0f597b22b01e50664e6835e35a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37413",
+					"10.65.0.27:37413",
+					"172.17.0.1:37413",
+					"172.18.0.1:37413",
+					"172.19.0.1:37413",
+					"172.20.0.1:37413",
+					"172.21.0.1:37413",
+					"172.22.0.1:37413",
+					"172.23.0.1:37413",
+					"172.24.0.1:37413",
+					"172.25.0.1:37413",
+					"172.26.0.1:37413",
+					"172.27.0.1:37413"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:30:23.630307934Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7395883338911835,
+				"StableID":   "nYPXeDKckz11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c89610742a89888e4ceac7e52b6aa315db690c98ada622f726b3a4242e9b8d3f",
+				"DiscoKey":   "discokey:00b9780e7c8d9deeaf1a27ce309babca928035af7dd7fa200c57271a67bf820a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35503",
+					"10.65.0.27:35503",
+					"172.17.0.1:35503",
+					"172.18.0.1:35503",
+					"172.19.0.1:35503",
+					"172.20.0.1:35503",
+					"172.21.0.1:35503",
+					"172.22.0.1:35503",
+					"172.23.0.1:35503",
+					"172.24.0.1:35503",
+					"172.25.0.1:35503",
+					"172.26.0.1:35503",
+					"172.27.0.1:35503"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:30:24.35024234Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         156123256026230,
+				"StableID":   "nK3wWQ6iD211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35bbd44adc1e0017f0f3cb5dc15c25172e8e0873f8475470e8716c906e85701c",
+				"DiscoKey":   "discokey:e315d2aa2650c181b0e7e8abe62aed80b5f6a8b39b3f5f590a3a6e81d7994a4e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59133",
+					"10.65.0.27:59133",
+					"172.17.0.1:59133",
+					"172.18.0.1:59133",
+					"172.19.0.1:59133",
+					"172.20.0.1:59133",
+					"172.21.0.1:59133",
+					"172.22.0.1:59133",
+					"172.23.0.1:59133",
+					"172.24.0.1:59133",
+					"172.25.0.1:59133",
+					"172.26.0.1:59133",
+					"172.27.0.1:59133"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:30:24.961232221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8431358078059330,
+				"StableID":   "nsmfXpUaq821CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:63133f6c88593acd3b63105c7176719ce717f2e66b9b7657c0aa3acc4557316d",
+				"DiscoKey":   "discokey:d204d313a545b75f35dbf27c5fd8924b694c32b6d1d7622f8c665bae2c052373",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50334",
+					"10.65.0.27:50334",
+					"172.17.0.1:50334",
+					"172.18.0.1:50334",
+					"172.19.0.1:50334",
+					"172.20.0.1:50334",
+					"172.21.0.1:50334",
+					"172.22.0.1:50334",
+					"172.23.0.1:50334",
+					"172.24.0.1:50334",
+					"172.25.0.1:50334",
+					"172.26.0.1:50334",
+					"172.27.0.1:50334"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:30:25.669266846Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6635437266779190,
+				"StableID":   "nme7HkgCpt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cbf7c7ea6bd03996c13db4de2b558efbbd5cf8536f41cc76424b15a8cce8ed6b",
+				"DiscoKey":   "discokey:b83c63aafa2ac23ca7968015176fdf00a90a94ddc1cc8402ef0b72afc8a78706",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45684",
+					"10.65.0.27:45684",
+					"172.17.0.1:45684",
+					"172.18.0.1:45684",
+					"172.19.0.1:45684",
+					"172.20.0.1:45684",
+					"172.21.0.1:45684",
+					"172.22.0.1:45684",
+					"172.23.0.1:45684",
+					"172.24.0.1:45684",
+					"172.25.0.1:45684",
+					"172.26.0.1:45684",
+					"172.27.0.1:45684"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:30:26.20463116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6048256030654495,
+				"StableID":   "nkqe9wRGEp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a2661c0992e6f6f36c961226b6c951c0324de2a6d2279d7e43c3a6fed43f9652",
+				"KeyExpiry":  "2026-11-09T09:30:26Z",
+				"DiscoKey":   "discokey:3ebad77570ee23f4a75003d66ebe44faa51879ec277d967f1df088231e820c28",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45887",
+					"10.65.0.27:45887",
+					"172.17.0.1:45887",
+					"172.18.0.1:45887",
+					"172.19.0.1:45887",
+					"172.20.0.1:45887",
+					"172.21.0.1:45887",
+					"172.22.0.1:45887",
+					"172.23.0.1:45887",
+					"172.24.0.1:45887",
+					"172.25.0.1:45887",
+					"172.26.0.1:45887",
+					"172.27.0.1:45887"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:30:26.725360455Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8234239497029749,
+				"StableID":   "nvuPXWWJJ721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:180fb2b409872a185fa9447ecfbb845e0154f6c7f143eb6ca09e3d2bd6ddbb17",
+				"KeyExpiry":  "2026-11-09T09:30:27Z",
+				"DiscoKey":   "discokey:7e5bb9a482709932c2f64cb02779a5a9c71b33777a842c47041a0fc713b9587a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50553",
+					"10.65.0.27:50553",
+					"172.17.0.1:50553",
+					"172.18.0.1:50553",
+					"172.19.0.1:50553",
+					"172.20.0.1:50553",
+					"172.21.0.1:50553",
+					"172.22.0.1:50553",
+					"172.23.0.1:50553",
+					"172.24.0.1:50553",
+					"172.25.0.1:50553",
+					"172.26.0.1:50553",
+					"172.27.0.1:50553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:30:27.260403572Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1099277371122160,
+				"StableID":   "ns8Hzq9sa911CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1099277371122160,
+				"Key":        "nodekey:6ead0b971a84bb0155d90e0ebd3eb6e7d7353739feb2acb825c5deb763631d53",
+				"DiscoKey":   "discokey:a4ae1f8f20ee5f9b386feb4b92b080b07ae8d53d1cc019fa7c7761bdb2a7df70",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43004",
+					"10.65.0.27:43004",
+					"172.17.0.1:43004",
+					"172.18.0.1:43004",
+					"172.19.0.1:43004",
+					"172.20.0.1:43004",
+					"172.21.0.1:43004",
+					"172.22.0.1:43004",
+					"172.23.0.1:43004",
+					"172.24.0.1:43004",
+					"172.25.0.1:43004",
+					"172.26.0.1:43004",
+					"172.27.0.1:43004"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:30:20.856238896Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6ead0b971a84bb0155d90e0ebd3eb6e7d7353739feb2acb825c5deb763631d53",
+			"MachineKey": "mkey:0279ea735236deb1a45dad38dc01e20fc68b67c0c95c95cafe26d3023a8bfe44",
+			"Peers": [{
+				"ID":         3628307374917488,
+				"StableID":   "nwJfAyUGLV11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8587a6f7374ca011a9ac6468627b921cfa75948a6fb3f0b04df5ffc7e4822b5b",
+				"DiscoKey":   "discokey:5291592b301d037d3573ecb86b8ffafda3907780e8ffc5edb50e85035ed66a74",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:60776",
+					"10.65.0.27:60776",
+					"172.17.0.1:60776",
+					"172.18.0.1:60776",
+					"172.19.0.1:60776",
+					"172.20.0.1:60776",
+					"172.21.0.1:60776",
+					"172.22.0.1:60776",
+					"172.23.0.1:60776",
+					"172.24.0.1:60776",
+					"172.25.0.1:60776",
+					"172.26.0.1:60776",
+					"172.27.0.1:60776"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:30:19.604495837Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1493384375532153,
+				"StableID":   "nJPrQAgMfC11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb5bb1cdb0ff33b7e7bee6ec6b139f6fafb9f188c6bab4243677c47cc5a70831",
+				"DiscoKey":   "discokey:13886cbf8a432412327a73ba106d682f72fbde38b2771ab03c66baabdfaee42f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:52709",
+					"10.65.0.27:52709",
+					"172.17.0.1:52709",
+					"172.18.0.1:52709",
+					"172.19.0.1:52709",
+					"172.20.0.1:52709",
+					"172.21.0.1:52709",
+					"172.22.0.1:52709",
+					"172.23.0.1:52709",
+					"172.24.0.1:52709",
+					"172.25.0.1:52709",
+					"172.26.0.1:52709",
+					"172.27.0.1:52709"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:30:20.319592339Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2691709711896678,
+				"StableID":   "ndnyuge52N11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2f0f9aa40c11d6caefbf393a5ae8eeb99f47053abac6b79681f8aa1b67e98769",
+				"DiscoKey":   "discokey:29ee71a95c71f6ed791da21b42c0c819f0b95368406800121696acf5ffca1745",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45143",
+					"10.65.0.27:45143",
+					"172.17.0.1:45143",
+					"172.18.0.1:45143",
+					"172.19.0.1:45143",
+					"172.20.0.1:45143",
+					"172.21.0.1:45143",
+					"172.22.0.1:45143",
+					"172.23.0.1:45143",
+					"172.24.0.1:45143",
+					"172.25.0.1:45143",
+					"172.26.0.1:45143",
+					"172.27.0.1:45143"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:30:21.393986895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         12685843844750,
+				"StableID":   "n9tdafEk6111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e9317595a76d9da92f070ba866cbbfd950bebd0bb2a22da60dd5f548d9e7739",
+				"DiscoKey":   "discokey:20045d9d345983c979fadb65dd0db6620eb191751458cac1582766f33d25be41",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58390",
+					"10.65.0.27:58390",
+					"172.17.0.1:58390",
+					"172.18.0.1:58390",
+					"172.19.0.1:58390",
+					"172.20.0.1:58390",
+					"172.21.0.1:58390",
+					"172.22.0.1:58390",
+					"172.23.0.1:58390",
+					"172.24.0.1:58390",
+					"172.25.0.1:58390",
+					"172.26.0.1:58390",
+					"172.27.0.1:58390"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:30:21.965086659Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         220059800127697,
+				"StableID":   "nJfiyfbfi211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f82d10ad4a8afe9aeee81c4c1dcf49cda2f43da67e83bb43dd02f4616d907911",
+				"DiscoKey":   "discokey:9c598e24bacf2aa5dbcdfa20934c7082c2d423abf9aa422d163284b41be6ee49",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41839",
+					"10.65.0.27:41839",
+					"172.17.0.1:41839",
+					"172.18.0.1:41839",
+					"172.19.0.1:41839",
+					"172.20.0.1:41839",
+					"172.21.0.1:41839",
+					"172.22.0.1:41839",
+					"172.23.0.1:41839",
+					"172.24.0.1:41839",
+					"172.25.0.1:41839",
+					"172.26.0.1:41839",
+					"172.27.0.1:41839"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:30:22.487425695Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7367908405015496,
+				"StableID":   "nw4zXgTwXz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b5171dd8248b6600e124ab8a373ad2474d1422ebf0a43a7f93e526e1e45ae774",
+				"DiscoKey":   "discokey:32447222761bd26fc98eb5000a8954e03b20b5456e2f40230debc4e3bd71dc5f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44778",
+					"10.65.0.27:44778",
+					"172.17.0.1:44778",
+					"172.18.0.1:44778",
+					"172.19.0.1:44778",
+					"172.20.0.1:44778",
+					"172.21.0.1:44778",
+					"172.22.0.1:44778",
+					"172.23.0.1:44778",
+					"172.24.0.1:44778",
+					"172.25.0.1:44778",
+					"172.26.0.1:44778",
+					"172.27.0.1:44778"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:30:23.04063128Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5602755481149455,
+				"StableID":   "nJ4o8PtVkk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d8d2db2cb821338ea64e3375fc8e1048d0b9fc371c24e4d176cd629ef522065",
+				"DiscoKey":   "discokey:400d522c5a33d5f017772b6608482cf826411a0f597b22b01e50664e6835e35a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37413",
+					"10.65.0.27:37413",
+					"172.17.0.1:37413",
+					"172.18.0.1:37413",
+					"172.19.0.1:37413",
+					"172.20.0.1:37413",
+					"172.21.0.1:37413",
+					"172.22.0.1:37413",
+					"172.23.0.1:37413",
+					"172.24.0.1:37413",
+					"172.25.0.1:37413",
+					"172.26.0.1:37413",
+					"172.27.0.1:37413"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:30:23.630307934Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7395883338911835,
+				"StableID":   "nYPXeDKckz11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c89610742a89888e4ceac7e52b6aa315db690c98ada622f726b3a4242e9b8d3f",
+				"DiscoKey":   "discokey:00b9780e7c8d9deeaf1a27ce309babca928035af7dd7fa200c57271a67bf820a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35503",
+					"10.65.0.27:35503",
+					"172.17.0.1:35503",
+					"172.18.0.1:35503",
+					"172.19.0.1:35503",
+					"172.20.0.1:35503",
+					"172.21.0.1:35503",
+					"172.22.0.1:35503",
+					"172.23.0.1:35503",
+					"172.24.0.1:35503",
+					"172.25.0.1:35503",
+					"172.26.0.1:35503",
+					"172.27.0.1:35503"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:30:24.35024234Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         156123256026230,
+				"StableID":   "nK3wWQ6iD211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35bbd44adc1e0017f0f3cb5dc15c25172e8e0873f8475470e8716c906e85701c",
+				"DiscoKey":   "discokey:e315d2aa2650c181b0e7e8abe62aed80b5f6a8b39b3f5f590a3a6e81d7994a4e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59133",
+					"10.65.0.27:59133",
+					"172.17.0.1:59133",
+					"172.18.0.1:59133",
+					"172.19.0.1:59133",
+					"172.20.0.1:59133",
+					"172.21.0.1:59133",
+					"172.22.0.1:59133",
+					"172.23.0.1:59133",
+					"172.24.0.1:59133",
+					"172.25.0.1:59133",
+					"172.26.0.1:59133",
+					"172.27.0.1:59133"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:30:24.961232221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8431358078059330,
+				"StableID":   "nsmfXpUaq821CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:63133f6c88593acd3b63105c7176719ce717f2e66b9b7657c0aa3acc4557316d",
+				"DiscoKey":   "discokey:d204d313a545b75f35dbf27c5fd8924b694c32b6d1d7622f8c665bae2c052373",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50334",
+					"10.65.0.27:50334",
+					"172.17.0.1:50334",
+					"172.18.0.1:50334",
+					"172.19.0.1:50334",
+					"172.20.0.1:50334",
+					"172.21.0.1:50334",
+					"172.22.0.1:50334",
+					"172.23.0.1:50334",
+					"172.24.0.1:50334",
+					"172.25.0.1:50334",
+					"172.26.0.1:50334",
+					"172.27.0.1:50334"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:30:25.669266846Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6635437266779190,
+				"StableID":   "nme7HkgCpt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cbf7c7ea6bd03996c13db4de2b558efbbd5cf8536f41cc76424b15a8cce8ed6b",
+				"DiscoKey":   "discokey:b83c63aafa2ac23ca7968015176fdf00a90a94ddc1cc8402ef0b72afc8a78706",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45684",
+					"10.65.0.27:45684",
+					"172.17.0.1:45684",
+					"172.18.0.1:45684",
+					"172.19.0.1:45684",
+					"172.20.0.1:45684",
+					"172.21.0.1:45684",
+					"172.22.0.1:45684",
+					"172.23.0.1:45684",
+					"172.24.0.1:45684",
+					"172.25.0.1:45684",
+					"172.26.0.1:45684",
+					"172.27.0.1:45684"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:30:26.20463116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6048256030654495,
+				"StableID":   "nkqe9wRGEp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a2661c0992e6f6f36c961226b6c951c0324de2a6d2279d7e43c3a6fed43f9652",
+				"KeyExpiry":  "2026-11-09T09:30:26Z",
+				"DiscoKey":   "discokey:3ebad77570ee23f4a75003d66ebe44faa51879ec277d967f1df088231e820c28",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45887",
+					"10.65.0.27:45887",
+					"172.17.0.1:45887",
+					"172.18.0.1:45887",
+					"172.19.0.1:45887",
+					"172.20.0.1:45887",
+					"172.21.0.1:45887",
+					"172.22.0.1:45887",
+					"172.23.0.1:45887",
+					"172.24.0.1:45887",
+					"172.25.0.1:45887",
+					"172.26.0.1:45887",
+					"172.27.0.1:45887"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:30:26.725360455Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8234239497029749,
+				"StableID":   "nvuPXWWJJ721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:180fb2b409872a185fa9447ecfbb845e0154f6c7f143eb6ca09e3d2bd6ddbb17",
+				"KeyExpiry":  "2026-11-09T09:30:27Z",
+				"DiscoKey":   "discokey:7e5bb9a482709932c2f64cb02779a5a9c71b33777a842c47041a0fc713b9587a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50553",
+					"10.65.0.27:50553",
+					"172.17.0.1:50553",
+					"172.18.0.1:50553",
+					"172.19.0.1:50553",
+					"172.20.0.1:50553",
+					"172.21.0.1:50553",
+					"172.22.0.1:50553",
+					"172.23.0.1:50553",
+					"172.24.0.1:50553",
+					"172.25.0.1:50553",
+					"172.26.0.1:50553",
+					"172.27.0.1:50553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:30:27.260403572Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3225617935357335,
+				"StableID":   "nAUbLnWtBS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:05fb5c7def2bd52a36b410573911e9e7309ce75d545fb99011ceb2ed571d5d5d",
+				"KeyExpiry":  "2026-11-09T09:30:27Z",
+				"DiscoKey":   "discokey:0dde8e43d786368333282af84458203134ee89de681daae268aea547302eaa39",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57338",
+					"10.65.0.27:57338",
+					"172.17.0.1:57338",
+					"172.18.0.1:57338",
+					"172.19.0.1:57338",
+					"172.20.0.1:57338",
+					"172.21.0.1:57338",
+					"172.22.0.1:57338",
+					"172.23.0.1:57338",
+					"172.24.0.1:57338",
+					"172.25.0.1:57338",
+					"172.26.0.1:57338",
+					"172.27.0.1:57338"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:30:27.807949242Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1099277371122160": {
+				"ID":          1099277371122160,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5602755481149455,
+				"StableID":   "nJ4o8PtVkk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       5602755481149455,
+				"Key":        "nodekey:4d8d2db2cb821338ea64e3375fc8e1048d0b9fc371c24e4d176cd629ef522065",
+				"DiscoKey":   "discokey:400d522c5a33d5f017772b6608482cf826411a0f597b22b01e50664e6835e35a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37413",
+					"10.65.0.27:37413",
+					"172.17.0.1:37413",
+					"172.18.0.1:37413",
+					"172.19.0.1:37413",
+					"172.20.0.1:37413",
+					"172.21.0.1:37413",
+					"172.22.0.1:37413",
+					"172.23.0.1:37413",
+					"172.24.0.1:37413",
+					"172.25.0.1:37413",
+					"172.26.0.1:37413",
+					"172.27.0.1:37413"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:30:23.630307934Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4d8d2db2cb821338ea64e3375fc8e1048d0b9fc371c24e4d176cd629ef522065",
+			"MachineKey": "mkey:d1154bde5c178198e6e8505962ee21804e3d766d1651ad980ea677528bc5b93c",
+			"Peers": [{
+				"ID":         3628307374917488,
+				"StableID":   "nwJfAyUGLV11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8587a6f7374ca011a9ac6468627b921cfa75948a6fb3f0b04df5ffc7e4822b5b",
+				"DiscoKey":   "discokey:5291592b301d037d3573ecb86b8ffafda3907780e8ffc5edb50e85035ed66a74",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:60776",
+					"10.65.0.27:60776",
+					"172.17.0.1:60776",
+					"172.18.0.1:60776",
+					"172.19.0.1:60776",
+					"172.20.0.1:60776",
+					"172.21.0.1:60776",
+					"172.22.0.1:60776",
+					"172.23.0.1:60776",
+					"172.24.0.1:60776",
+					"172.25.0.1:60776",
+					"172.26.0.1:60776",
+					"172.27.0.1:60776"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:30:19.604495837Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1493384375532153,
+				"StableID":   "nJPrQAgMfC11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb5bb1cdb0ff33b7e7bee6ec6b139f6fafb9f188c6bab4243677c47cc5a70831",
+				"DiscoKey":   "discokey:13886cbf8a432412327a73ba106d682f72fbde38b2771ab03c66baabdfaee42f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:52709",
+					"10.65.0.27:52709",
+					"172.17.0.1:52709",
+					"172.18.0.1:52709",
+					"172.19.0.1:52709",
+					"172.20.0.1:52709",
+					"172.21.0.1:52709",
+					"172.22.0.1:52709",
+					"172.23.0.1:52709",
+					"172.24.0.1:52709",
+					"172.25.0.1:52709",
+					"172.26.0.1:52709",
+					"172.27.0.1:52709"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:30:20.319592339Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1099277371122160,
+				"StableID":   "ns8Hzq9sa911CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6ead0b971a84bb0155d90e0ebd3eb6e7d7353739feb2acb825c5deb763631d53",
+				"DiscoKey":   "discokey:a4ae1f8f20ee5f9b386feb4b92b080b07ae8d53d1cc019fa7c7761bdb2a7df70",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43004",
+					"10.65.0.27:43004",
+					"172.17.0.1:43004",
+					"172.18.0.1:43004",
+					"172.19.0.1:43004",
+					"172.20.0.1:43004",
+					"172.21.0.1:43004",
+					"172.22.0.1:43004",
+					"172.23.0.1:43004",
+					"172.24.0.1:43004",
+					"172.25.0.1:43004",
+					"172.26.0.1:43004",
+					"172.27.0.1:43004"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:30:20.856238896Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2691709711896678,
+				"StableID":   "ndnyuge52N11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2f0f9aa40c11d6caefbf393a5ae8eeb99f47053abac6b79681f8aa1b67e98769",
+				"DiscoKey":   "discokey:29ee71a95c71f6ed791da21b42c0c819f0b95368406800121696acf5ffca1745",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45143",
+					"10.65.0.27:45143",
+					"172.17.0.1:45143",
+					"172.18.0.1:45143",
+					"172.19.0.1:45143",
+					"172.20.0.1:45143",
+					"172.21.0.1:45143",
+					"172.22.0.1:45143",
+					"172.23.0.1:45143",
+					"172.24.0.1:45143",
+					"172.25.0.1:45143",
+					"172.26.0.1:45143",
+					"172.27.0.1:45143"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:30:21.393986895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         12685843844750,
+				"StableID":   "n9tdafEk6111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e9317595a76d9da92f070ba866cbbfd950bebd0bb2a22da60dd5f548d9e7739",
+				"DiscoKey":   "discokey:20045d9d345983c979fadb65dd0db6620eb191751458cac1582766f33d25be41",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58390",
+					"10.65.0.27:58390",
+					"172.17.0.1:58390",
+					"172.18.0.1:58390",
+					"172.19.0.1:58390",
+					"172.20.0.1:58390",
+					"172.21.0.1:58390",
+					"172.22.0.1:58390",
+					"172.23.0.1:58390",
+					"172.24.0.1:58390",
+					"172.25.0.1:58390",
+					"172.26.0.1:58390",
+					"172.27.0.1:58390"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:30:21.965086659Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         220059800127697,
+				"StableID":   "nJfiyfbfi211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f82d10ad4a8afe9aeee81c4c1dcf49cda2f43da67e83bb43dd02f4616d907911",
+				"DiscoKey":   "discokey:9c598e24bacf2aa5dbcdfa20934c7082c2d423abf9aa422d163284b41be6ee49",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41839",
+					"10.65.0.27:41839",
+					"172.17.0.1:41839",
+					"172.18.0.1:41839",
+					"172.19.0.1:41839",
+					"172.20.0.1:41839",
+					"172.21.0.1:41839",
+					"172.22.0.1:41839",
+					"172.23.0.1:41839",
+					"172.24.0.1:41839",
+					"172.25.0.1:41839",
+					"172.26.0.1:41839",
+					"172.27.0.1:41839"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:30:22.487425695Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7367908405015496,
+				"StableID":   "nw4zXgTwXz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b5171dd8248b6600e124ab8a373ad2474d1422ebf0a43a7f93e526e1e45ae774",
+				"DiscoKey":   "discokey:32447222761bd26fc98eb5000a8954e03b20b5456e2f40230debc4e3bd71dc5f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44778",
+					"10.65.0.27:44778",
+					"172.17.0.1:44778",
+					"172.18.0.1:44778",
+					"172.19.0.1:44778",
+					"172.20.0.1:44778",
+					"172.21.0.1:44778",
+					"172.22.0.1:44778",
+					"172.23.0.1:44778",
+					"172.24.0.1:44778",
+					"172.25.0.1:44778",
+					"172.26.0.1:44778",
+					"172.27.0.1:44778"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:30:23.04063128Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7395883338911835,
+				"StableID":   "nYPXeDKckz11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c89610742a89888e4ceac7e52b6aa315db690c98ada622f726b3a4242e9b8d3f",
+				"DiscoKey":   "discokey:00b9780e7c8d9deeaf1a27ce309babca928035af7dd7fa200c57271a67bf820a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35503",
+					"10.65.0.27:35503",
+					"172.17.0.1:35503",
+					"172.18.0.1:35503",
+					"172.19.0.1:35503",
+					"172.20.0.1:35503",
+					"172.21.0.1:35503",
+					"172.22.0.1:35503",
+					"172.23.0.1:35503",
+					"172.24.0.1:35503",
+					"172.25.0.1:35503",
+					"172.26.0.1:35503",
+					"172.27.0.1:35503"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:30:24.35024234Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         156123256026230,
+				"StableID":   "nK3wWQ6iD211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35bbd44adc1e0017f0f3cb5dc15c25172e8e0873f8475470e8716c906e85701c",
+				"DiscoKey":   "discokey:e315d2aa2650c181b0e7e8abe62aed80b5f6a8b39b3f5f590a3a6e81d7994a4e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59133",
+					"10.65.0.27:59133",
+					"172.17.0.1:59133",
+					"172.18.0.1:59133",
+					"172.19.0.1:59133",
+					"172.20.0.1:59133",
+					"172.21.0.1:59133",
+					"172.22.0.1:59133",
+					"172.23.0.1:59133",
+					"172.24.0.1:59133",
+					"172.25.0.1:59133",
+					"172.26.0.1:59133",
+					"172.27.0.1:59133"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:30:24.961232221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8431358078059330,
+				"StableID":   "nsmfXpUaq821CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:63133f6c88593acd3b63105c7176719ce717f2e66b9b7657c0aa3acc4557316d",
+				"DiscoKey":   "discokey:d204d313a545b75f35dbf27c5fd8924b694c32b6d1d7622f8c665bae2c052373",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50334",
+					"10.65.0.27:50334",
+					"172.17.0.1:50334",
+					"172.18.0.1:50334",
+					"172.19.0.1:50334",
+					"172.20.0.1:50334",
+					"172.21.0.1:50334",
+					"172.22.0.1:50334",
+					"172.23.0.1:50334",
+					"172.24.0.1:50334",
+					"172.25.0.1:50334",
+					"172.26.0.1:50334",
+					"172.27.0.1:50334"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:30:25.669266846Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6635437266779190,
+				"StableID":   "nme7HkgCpt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cbf7c7ea6bd03996c13db4de2b558efbbd5cf8536f41cc76424b15a8cce8ed6b",
+				"DiscoKey":   "discokey:b83c63aafa2ac23ca7968015176fdf00a90a94ddc1cc8402ef0b72afc8a78706",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45684",
+					"10.65.0.27:45684",
+					"172.17.0.1:45684",
+					"172.18.0.1:45684",
+					"172.19.0.1:45684",
+					"172.20.0.1:45684",
+					"172.21.0.1:45684",
+					"172.22.0.1:45684",
+					"172.23.0.1:45684",
+					"172.24.0.1:45684",
+					"172.25.0.1:45684",
+					"172.26.0.1:45684",
+					"172.27.0.1:45684"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:30:26.20463116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6048256030654495,
+				"StableID":   "nkqe9wRGEp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a2661c0992e6f6f36c961226b6c951c0324de2a6d2279d7e43c3a6fed43f9652",
+				"KeyExpiry":  "2026-11-09T09:30:26Z",
+				"DiscoKey":   "discokey:3ebad77570ee23f4a75003d66ebe44faa51879ec277d967f1df088231e820c28",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45887",
+					"10.65.0.27:45887",
+					"172.17.0.1:45887",
+					"172.18.0.1:45887",
+					"172.19.0.1:45887",
+					"172.20.0.1:45887",
+					"172.21.0.1:45887",
+					"172.22.0.1:45887",
+					"172.23.0.1:45887",
+					"172.24.0.1:45887",
+					"172.25.0.1:45887",
+					"172.26.0.1:45887",
+					"172.27.0.1:45887"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:30:26.725360455Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8234239497029749,
+				"StableID":   "nvuPXWWJJ721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:180fb2b409872a185fa9447ecfbb845e0154f6c7f143eb6ca09e3d2bd6ddbb17",
+				"KeyExpiry":  "2026-11-09T09:30:27Z",
+				"DiscoKey":   "discokey:7e5bb9a482709932c2f64cb02779a5a9c71b33777a842c47041a0fc713b9587a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50553",
+					"10.65.0.27:50553",
+					"172.17.0.1:50553",
+					"172.18.0.1:50553",
+					"172.19.0.1:50553",
+					"172.20.0.1:50553",
+					"172.21.0.1:50553",
+					"172.22.0.1:50553",
+					"172.23.0.1:50553",
+					"172.24.0.1:50553",
+					"172.25.0.1:50553",
+					"172.26.0.1:50553",
+					"172.27.0.1:50553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:30:27.260403572Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3225617935357335,
+				"StableID":   "nAUbLnWtBS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:05fb5c7def2bd52a36b410573911e9e7309ce75d545fb99011ceb2ed571d5d5d",
+				"KeyExpiry":  "2026-11-09T09:30:27Z",
+				"DiscoKey":   "discokey:0dde8e43d786368333282af84458203134ee89de681daae268aea547302eaa39",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57338",
+					"10.65.0.27:57338",
+					"172.17.0.1:57338",
+					"172.18.0.1:57338",
+					"172.19.0.1:57338",
+					"172.20.0.1:57338",
+					"172.21.0.1:57338",
+					"172.22.0.1:57338",
+					"172.23.0.1:57338",
+					"172.24.0.1:57338",
+					"172.25.0.1:57338",
+					"172.26.0.1:57338",
+					"172.27.0.1:57338"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:30:27.807949242Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5602755481149455": {
+				"ID":          5602755481149455,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6048256030654495,
+				"StableID":   "nkqe9wRGEp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a2661c0992e6f6f36c961226b6c951c0324de2a6d2279d7e43c3a6fed43f9652",
+				"KeyExpiry":  "2026-11-09T09:30:26Z",
+				"DiscoKey":   "discokey:3ebad77570ee23f4a75003d66ebe44faa51879ec277d967f1df088231e820c28",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45887",
+					"10.65.0.27:45887",
+					"172.17.0.1:45887",
+					"172.18.0.1:45887",
+					"172.19.0.1:45887",
+					"172.20.0.1:45887",
+					"172.21.0.1:45887",
+					"172.22.0.1:45887",
+					"172.23.0.1:45887",
+					"172.24.0.1:45887",
+					"172.25.0.1:45887",
+					"172.26.0.1:45887",
+					"172.27.0.1:45887"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:30:26.725360455Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a2661c0992e6f6f36c961226b6c951c0324de2a6d2279d7e43c3a6fed43f9652",
+			"MachineKey": "mkey:c34158ddf9728cc7be60f62e351a9342738ceb57ba20058da89350d1fb9ed159",
+			"Peers": [{
+				"ID":         3628307374917488,
+				"StableID":   "nwJfAyUGLV11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8587a6f7374ca011a9ac6468627b921cfa75948a6fb3f0b04df5ffc7e4822b5b",
+				"DiscoKey":   "discokey:5291592b301d037d3573ecb86b8ffafda3907780e8ffc5edb50e85035ed66a74",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:60776",
+					"10.65.0.27:60776",
+					"172.17.0.1:60776",
+					"172.18.0.1:60776",
+					"172.19.0.1:60776",
+					"172.20.0.1:60776",
+					"172.21.0.1:60776",
+					"172.22.0.1:60776",
+					"172.23.0.1:60776",
+					"172.24.0.1:60776",
+					"172.25.0.1:60776",
+					"172.26.0.1:60776",
+					"172.27.0.1:60776"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:30:19.604495837Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1493384375532153,
+				"StableID":   "nJPrQAgMfC11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb5bb1cdb0ff33b7e7bee6ec6b139f6fafb9f188c6bab4243677c47cc5a70831",
+				"DiscoKey":   "discokey:13886cbf8a432412327a73ba106d682f72fbde38b2771ab03c66baabdfaee42f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:52709",
+					"10.65.0.27:52709",
+					"172.17.0.1:52709",
+					"172.18.0.1:52709",
+					"172.19.0.1:52709",
+					"172.20.0.1:52709",
+					"172.21.0.1:52709",
+					"172.22.0.1:52709",
+					"172.23.0.1:52709",
+					"172.24.0.1:52709",
+					"172.25.0.1:52709",
+					"172.26.0.1:52709",
+					"172.27.0.1:52709"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:30:20.319592339Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1099277371122160,
+				"StableID":   "ns8Hzq9sa911CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6ead0b971a84bb0155d90e0ebd3eb6e7d7353739feb2acb825c5deb763631d53",
+				"DiscoKey":   "discokey:a4ae1f8f20ee5f9b386feb4b92b080b07ae8d53d1cc019fa7c7761bdb2a7df70",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43004",
+					"10.65.0.27:43004",
+					"172.17.0.1:43004",
+					"172.18.0.1:43004",
+					"172.19.0.1:43004",
+					"172.20.0.1:43004",
+					"172.21.0.1:43004",
+					"172.22.0.1:43004",
+					"172.23.0.1:43004",
+					"172.24.0.1:43004",
+					"172.25.0.1:43004",
+					"172.26.0.1:43004",
+					"172.27.0.1:43004"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:30:20.856238896Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2691709711896678,
+				"StableID":   "ndnyuge52N11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2f0f9aa40c11d6caefbf393a5ae8eeb99f47053abac6b79681f8aa1b67e98769",
+				"DiscoKey":   "discokey:29ee71a95c71f6ed791da21b42c0c819f0b95368406800121696acf5ffca1745",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45143",
+					"10.65.0.27:45143",
+					"172.17.0.1:45143",
+					"172.18.0.1:45143",
+					"172.19.0.1:45143",
+					"172.20.0.1:45143",
+					"172.21.0.1:45143",
+					"172.22.0.1:45143",
+					"172.23.0.1:45143",
+					"172.24.0.1:45143",
+					"172.25.0.1:45143",
+					"172.26.0.1:45143",
+					"172.27.0.1:45143"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:30:21.393986895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         12685843844750,
+				"StableID":   "n9tdafEk6111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e9317595a76d9da92f070ba866cbbfd950bebd0bb2a22da60dd5f548d9e7739",
+				"DiscoKey":   "discokey:20045d9d345983c979fadb65dd0db6620eb191751458cac1582766f33d25be41",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58390",
+					"10.65.0.27:58390",
+					"172.17.0.1:58390",
+					"172.18.0.1:58390",
+					"172.19.0.1:58390",
+					"172.20.0.1:58390",
+					"172.21.0.1:58390",
+					"172.22.0.1:58390",
+					"172.23.0.1:58390",
+					"172.24.0.1:58390",
+					"172.25.0.1:58390",
+					"172.26.0.1:58390",
+					"172.27.0.1:58390"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:30:21.965086659Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         220059800127697,
+				"StableID":   "nJfiyfbfi211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f82d10ad4a8afe9aeee81c4c1dcf49cda2f43da67e83bb43dd02f4616d907911",
+				"DiscoKey":   "discokey:9c598e24bacf2aa5dbcdfa20934c7082c2d423abf9aa422d163284b41be6ee49",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41839",
+					"10.65.0.27:41839",
+					"172.17.0.1:41839",
+					"172.18.0.1:41839",
+					"172.19.0.1:41839",
+					"172.20.0.1:41839",
+					"172.21.0.1:41839",
+					"172.22.0.1:41839",
+					"172.23.0.1:41839",
+					"172.24.0.1:41839",
+					"172.25.0.1:41839",
+					"172.26.0.1:41839",
+					"172.27.0.1:41839"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:30:22.487425695Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7367908405015496,
+				"StableID":   "nw4zXgTwXz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b5171dd8248b6600e124ab8a373ad2474d1422ebf0a43a7f93e526e1e45ae774",
+				"DiscoKey":   "discokey:32447222761bd26fc98eb5000a8954e03b20b5456e2f40230debc4e3bd71dc5f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44778",
+					"10.65.0.27:44778",
+					"172.17.0.1:44778",
+					"172.18.0.1:44778",
+					"172.19.0.1:44778",
+					"172.20.0.1:44778",
+					"172.21.0.1:44778",
+					"172.22.0.1:44778",
+					"172.23.0.1:44778",
+					"172.24.0.1:44778",
+					"172.25.0.1:44778",
+					"172.26.0.1:44778",
+					"172.27.0.1:44778"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:30:23.04063128Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5602755481149455,
+				"StableID":   "nJ4o8PtVkk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d8d2db2cb821338ea64e3375fc8e1048d0b9fc371c24e4d176cd629ef522065",
+				"DiscoKey":   "discokey:400d522c5a33d5f017772b6608482cf826411a0f597b22b01e50664e6835e35a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37413",
+					"10.65.0.27:37413",
+					"172.17.0.1:37413",
+					"172.18.0.1:37413",
+					"172.19.0.1:37413",
+					"172.20.0.1:37413",
+					"172.21.0.1:37413",
+					"172.22.0.1:37413",
+					"172.23.0.1:37413",
+					"172.24.0.1:37413",
+					"172.25.0.1:37413",
+					"172.26.0.1:37413",
+					"172.27.0.1:37413"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:30:23.630307934Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7395883338911835,
+				"StableID":   "nYPXeDKckz11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c89610742a89888e4ceac7e52b6aa315db690c98ada622f726b3a4242e9b8d3f",
+				"DiscoKey":   "discokey:00b9780e7c8d9deeaf1a27ce309babca928035af7dd7fa200c57271a67bf820a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35503",
+					"10.65.0.27:35503",
+					"172.17.0.1:35503",
+					"172.18.0.1:35503",
+					"172.19.0.1:35503",
+					"172.20.0.1:35503",
+					"172.21.0.1:35503",
+					"172.22.0.1:35503",
+					"172.23.0.1:35503",
+					"172.24.0.1:35503",
+					"172.25.0.1:35503",
+					"172.26.0.1:35503",
+					"172.27.0.1:35503"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:30:24.35024234Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         156123256026230,
+				"StableID":   "nK3wWQ6iD211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35bbd44adc1e0017f0f3cb5dc15c25172e8e0873f8475470e8716c906e85701c",
+				"DiscoKey":   "discokey:e315d2aa2650c181b0e7e8abe62aed80b5f6a8b39b3f5f590a3a6e81d7994a4e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59133",
+					"10.65.0.27:59133",
+					"172.17.0.1:59133",
+					"172.18.0.1:59133",
+					"172.19.0.1:59133",
+					"172.20.0.1:59133",
+					"172.21.0.1:59133",
+					"172.22.0.1:59133",
+					"172.23.0.1:59133",
+					"172.24.0.1:59133",
+					"172.25.0.1:59133",
+					"172.26.0.1:59133",
+					"172.27.0.1:59133"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:30:24.961232221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8431358078059330,
+				"StableID":   "nsmfXpUaq821CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:63133f6c88593acd3b63105c7176719ce717f2e66b9b7657c0aa3acc4557316d",
+				"DiscoKey":   "discokey:d204d313a545b75f35dbf27c5fd8924b694c32b6d1d7622f8c665bae2c052373",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50334",
+					"10.65.0.27:50334",
+					"172.17.0.1:50334",
+					"172.18.0.1:50334",
+					"172.19.0.1:50334",
+					"172.20.0.1:50334",
+					"172.21.0.1:50334",
+					"172.22.0.1:50334",
+					"172.23.0.1:50334",
+					"172.24.0.1:50334",
+					"172.25.0.1:50334",
+					"172.26.0.1:50334",
+					"172.27.0.1:50334"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:30:25.669266846Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6635437266779190,
+				"StableID":   "nme7HkgCpt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cbf7c7ea6bd03996c13db4de2b558efbbd5cf8536f41cc76424b15a8cce8ed6b",
+				"DiscoKey":   "discokey:b83c63aafa2ac23ca7968015176fdf00a90a94ddc1cc8402ef0b72afc8a78706",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45684",
+					"10.65.0.27:45684",
+					"172.17.0.1:45684",
+					"172.18.0.1:45684",
+					"172.19.0.1:45684",
+					"172.20.0.1:45684",
+					"172.21.0.1:45684",
+					"172.22.0.1:45684",
+					"172.23.0.1:45684",
+					"172.24.0.1:45684",
+					"172.25.0.1:45684",
+					"172.26.0.1:45684",
+					"172.27.0.1:45684"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:30:26.20463116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8234239497029749,
+				"StableID":   "nvuPXWWJJ721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:180fb2b409872a185fa9447ecfbb845e0154f6c7f143eb6ca09e3d2bd6ddbb17",
+				"KeyExpiry":  "2026-11-09T09:30:27Z",
+				"DiscoKey":   "discokey:7e5bb9a482709932c2f64cb02779a5a9c71b33777a842c47041a0fc713b9587a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50553",
+					"10.65.0.27:50553",
+					"172.17.0.1:50553",
+					"172.18.0.1:50553",
+					"172.19.0.1:50553",
+					"172.20.0.1:50553",
+					"172.21.0.1:50553",
+					"172.22.0.1:50553",
+					"172.23.0.1:50553",
+					"172.24.0.1:50553",
+					"172.25.0.1:50553",
+					"172.26.0.1:50553",
+					"172.27.0.1:50553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:30:27.260403572Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3225617935357335,
+				"StableID":   "nAUbLnWtBS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:05fb5c7def2bd52a36b410573911e9e7309ce75d545fb99011ceb2ed571d5d5d",
+				"KeyExpiry":  "2026-11-09T09:30:27Z",
+				"DiscoKey":   "discokey:0dde8e43d786368333282af84458203134ee89de681daae268aea547302eaa39",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57338",
+					"10.65.0.27:57338",
+					"172.17.0.1:57338",
+					"172.18.0.1:57338",
+					"172.19.0.1:57338",
+					"172.20.0.1:57338",
+					"172.21.0.1:57338",
+					"172.22.0.1:57338",
+					"172.23.0.1:57338",
+					"172.24.0.1:57338",
+					"172.25.0.1:57338",
+					"172.26.0.1:57338",
+					"172.27.0.1:57338"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:30:27.807949242Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8431358078059330,
+				"StableID":   "nsmfXpUaq821CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       8431358078059330,
+				"Key":        "nodekey:63133f6c88593acd3b63105c7176719ce717f2e66b9b7657c0aa3acc4557316d",
+				"DiscoKey":   "discokey:d204d313a545b75f35dbf27c5fd8924b694c32b6d1d7622f8c665bae2c052373",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50334",
+					"10.65.0.27:50334",
+					"172.17.0.1:50334",
+					"172.18.0.1:50334",
+					"172.19.0.1:50334",
+					"172.20.0.1:50334",
+					"172.21.0.1:50334",
+					"172.22.0.1:50334",
+					"172.23.0.1:50334",
+					"172.24.0.1:50334",
+					"172.25.0.1:50334",
+					"172.26.0.1:50334",
+					"172.27.0.1:50334"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:30:25.669266846Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:63133f6c88593acd3b63105c7176719ce717f2e66b9b7657c0aa3acc4557316d",
+			"MachineKey": "mkey:4fb42d47ba8b660f06c81ca25e11233366908ac121525cc6c3667d29b1195814",
+			"Peers": [{
+				"ID":         3628307374917488,
+				"StableID":   "nwJfAyUGLV11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8587a6f7374ca011a9ac6468627b921cfa75948a6fb3f0b04df5ffc7e4822b5b",
+				"DiscoKey":   "discokey:5291592b301d037d3573ecb86b8ffafda3907780e8ffc5edb50e85035ed66a74",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:60776",
+					"10.65.0.27:60776",
+					"172.17.0.1:60776",
+					"172.18.0.1:60776",
+					"172.19.0.1:60776",
+					"172.20.0.1:60776",
+					"172.21.0.1:60776",
+					"172.22.0.1:60776",
+					"172.23.0.1:60776",
+					"172.24.0.1:60776",
+					"172.25.0.1:60776",
+					"172.26.0.1:60776",
+					"172.27.0.1:60776"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:30:19.604495837Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1493384375532153,
+				"StableID":   "nJPrQAgMfC11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb5bb1cdb0ff33b7e7bee6ec6b139f6fafb9f188c6bab4243677c47cc5a70831",
+				"DiscoKey":   "discokey:13886cbf8a432412327a73ba106d682f72fbde38b2771ab03c66baabdfaee42f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:52709",
+					"10.65.0.27:52709",
+					"172.17.0.1:52709",
+					"172.18.0.1:52709",
+					"172.19.0.1:52709",
+					"172.20.0.1:52709",
+					"172.21.0.1:52709",
+					"172.22.0.1:52709",
+					"172.23.0.1:52709",
+					"172.24.0.1:52709",
+					"172.25.0.1:52709",
+					"172.26.0.1:52709",
+					"172.27.0.1:52709"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:30:20.319592339Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1099277371122160,
+				"StableID":   "ns8Hzq9sa911CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6ead0b971a84bb0155d90e0ebd3eb6e7d7353739feb2acb825c5deb763631d53",
+				"DiscoKey":   "discokey:a4ae1f8f20ee5f9b386feb4b92b080b07ae8d53d1cc019fa7c7761bdb2a7df70",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43004",
+					"10.65.0.27:43004",
+					"172.17.0.1:43004",
+					"172.18.0.1:43004",
+					"172.19.0.1:43004",
+					"172.20.0.1:43004",
+					"172.21.0.1:43004",
+					"172.22.0.1:43004",
+					"172.23.0.1:43004",
+					"172.24.0.1:43004",
+					"172.25.0.1:43004",
+					"172.26.0.1:43004",
+					"172.27.0.1:43004"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:30:20.856238896Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2691709711896678,
+				"StableID":   "ndnyuge52N11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2f0f9aa40c11d6caefbf393a5ae8eeb99f47053abac6b79681f8aa1b67e98769",
+				"DiscoKey":   "discokey:29ee71a95c71f6ed791da21b42c0c819f0b95368406800121696acf5ffca1745",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45143",
+					"10.65.0.27:45143",
+					"172.17.0.1:45143",
+					"172.18.0.1:45143",
+					"172.19.0.1:45143",
+					"172.20.0.1:45143",
+					"172.21.0.1:45143",
+					"172.22.0.1:45143",
+					"172.23.0.1:45143",
+					"172.24.0.1:45143",
+					"172.25.0.1:45143",
+					"172.26.0.1:45143",
+					"172.27.0.1:45143"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:30:21.393986895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         12685843844750,
+				"StableID":   "n9tdafEk6111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e9317595a76d9da92f070ba866cbbfd950bebd0bb2a22da60dd5f548d9e7739",
+				"DiscoKey":   "discokey:20045d9d345983c979fadb65dd0db6620eb191751458cac1582766f33d25be41",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58390",
+					"10.65.0.27:58390",
+					"172.17.0.1:58390",
+					"172.18.0.1:58390",
+					"172.19.0.1:58390",
+					"172.20.0.1:58390",
+					"172.21.0.1:58390",
+					"172.22.0.1:58390",
+					"172.23.0.1:58390",
+					"172.24.0.1:58390",
+					"172.25.0.1:58390",
+					"172.26.0.1:58390",
+					"172.27.0.1:58390"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:30:21.965086659Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         220059800127697,
+				"StableID":   "nJfiyfbfi211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f82d10ad4a8afe9aeee81c4c1dcf49cda2f43da67e83bb43dd02f4616d907911",
+				"DiscoKey":   "discokey:9c598e24bacf2aa5dbcdfa20934c7082c2d423abf9aa422d163284b41be6ee49",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41839",
+					"10.65.0.27:41839",
+					"172.17.0.1:41839",
+					"172.18.0.1:41839",
+					"172.19.0.1:41839",
+					"172.20.0.1:41839",
+					"172.21.0.1:41839",
+					"172.22.0.1:41839",
+					"172.23.0.1:41839",
+					"172.24.0.1:41839",
+					"172.25.0.1:41839",
+					"172.26.0.1:41839",
+					"172.27.0.1:41839"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:30:22.487425695Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7367908405015496,
+				"StableID":   "nw4zXgTwXz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b5171dd8248b6600e124ab8a373ad2474d1422ebf0a43a7f93e526e1e45ae774",
+				"DiscoKey":   "discokey:32447222761bd26fc98eb5000a8954e03b20b5456e2f40230debc4e3bd71dc5f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44778",
+					"10.65.0.27:44778",
+					"172.17.0.1:44778",
+					"172.18.0.1:44778",
+					"172.19.0.1:44778",
+					"172.20.0.1:44778",
+					"172.21.0.1:44778",
+					"172.22.0.1:44778",
+					"172.23.0.1:44778",
+					"172.24.0.1:44778",
+					"172.25.0.1:44778",
+					"172.26.0.1:44778",
+					"172.27.0.1:44778"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:30:23.04063128Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5602755481149455,
+				"StableID":   "nJ4o8PtVkk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d8d2db2cb821338ea64e3375fc8e1048d0b9fc371c24e4d176cd629ef522065",
+				"DiscoKey":   "discokey:400d522c5a33d5f017772b6608482cf826411a0f597b22b01e50664e6835e35a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37413",
+					"10.65.0.27:37413",
+					"172.17.0.1:37413",
+					"172.18.0.1:37413",
+					"172.19.0.1:37413",
+					"172.20.0.1:37413",
+					"172.21.0.1:37413",
+					"172.22.0.1:37413",
+					"172.23.0.1:37413",
+					"172.24.0.1:37413",
+					"172.25.0.1:37413",
+					"172.26.0.1:37413",
+					"172.27.0.1:37413"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:30:23.630307934Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7395883338911835,
+				"StableID":   "nYPXeDKckz11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c89610742a89888e4ceac7e52b6aa315db690c98ada622f726b3a4242e9b8d3f",
+				"DiscoKey":   "discokey:00b9780e7c8d9deeaf1a27ce309babca928035af7dd7fa200c57271a67bf820a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35503",
+					"10.65.0.27:35503",
+					"172.17.0.1:35503",
+					"172.18.0.1:35503",
+					"172.19.0.1:35503",
+					"172.20.0.1:35503",
+					"172.21.0.1:35503",
+					"172.22.0.1:35503",
+					"172.23.0.1:35503",
+					"172.24.0.1:35503",
+					"172.25.0.1:35503",
+					"172.26.0.1:35503",
+					"172.27.0.1:35503"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:30:24.35024234Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         156123256026230,
+				"StableID":   "nK3wWQ6iD211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35bbd44adc1e0017f0f3cb5dc15c25172e8e0873f8475470e8716c906e85701c",
+				"DiscoKey":   "discokey:e315d2aa2650c181b0e7e8abe62aed80b5f6a8b39b3f5f590a3a6e81d7994a4e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59133",
+					"10.65.0.27:59133",
+					"172.17.0.1:59133",
+					"172.18.0.1:59133",
+					"172.19.0.1:59133",
+					"172.20.0.1:59133",
+					"172.21.0.1:59133",
+					"172.22.0.1:59133",
+					"172.23.0.1:59133",
+					"172.24.0.1:59133",
+					"172.25.0.1:59133",
+					"172.26.0.1:59133",
+					"172.27.0.1:59133"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:30:24.961232221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6635437266779190,
+				"StableID":   "nme7HkgCpt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cbf7c7ea6bd03996c13db4de2b558efbbd5cf8536f41cc76424b15a8cce8ed6b",
+				"DiscoKey":   "discokey:b83c63aafa2ac23ca7968015176fdf00a90a94ddc1cc8402ef0b72afc8a78706",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45684",
+					"10.65.0.27:45684",
+					"172.17.0.1:45684",
+					"172.18.0.1:45684",
+					"172.19.0.1:45684",
+					"172.20.0.1:45684",
+					"172.21.0.1:45684",
+					"172.22.0.1:45684",
+					"172.23.0.1:45684",
+					"172.24.0.1:45684",
+					"172.25.0.1:45684",
+					"172.26.0.1:45684",
+					"172.27.0.1:45684"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:30:26.20463116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6048256030654495,
+				"StableID":   "nkqe9wRGEp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a2661c0992e6f6f36c961226b6c951c0324de2a6d2279d7e43c3a6fed43f9652",
+				"KeyExpiry":  "2026-11-09T09:30:26Z",
+				"DiscoKey":   "discokey:3ebad77570ee23f4a75003d66ebe44faa51879ec277d967f1df088231e820c28",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45887",
+					"10.65.0.27:45887",
+					"172.17.0.1:45887",
+					"172.18.0.1:45887",
+					"172.19.0.1:45887",
+					"172.20.0.1:45887",
+					"172.21.0.1:45887",
+					"172.22.0.1:45887",
+					"172.23.0.1:45887",
+					"172.24.0.1:45887",
+					"172.25.0.1:45887",
+					"172.26.0.1:45887",
+					"172.27.0.1:45887"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:30:26.725360455Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8234239497029749,
+				"StableID":   "nvuPXWWJJ721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:180fb2b409872a185fa9447ecfbb845e0154f6c7f143eb6ca09e3d2bd6ddbb17",
+				"KeyExpiry":  "2026-11-09T09:30:27Z",
+				"DiscoKey":   "discokey:7e5bb9a482709932c2f64cb02779a5a9c71b33777a842c47041a0fc713b9587a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50553",
+					"10.65.0.27:50553",
+					"172.17.0.1:50553",
+					"172.18.0.1:50553",
+					"172.19.0.1:50553",
+					"172.20.0.1:50553",
+					"172.21.0.1:50553",
+					"172.22.0.1:50553",
+					"172.23.0.1:50553",
+					"172.24.0.1:50553",
+					"172.25.0.1:50553",
+					"172.26.0.1:50553",
+					"172.27.0.1:50553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:30:27.260403572Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3225617935357335,
+				"StableID":   "nAUbLnWtBS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:05fb5c7def2bd52a36b410573911e9e7309ce75d545fb99011ceb2ed571d5d5d",
+				"KeyExpiry":  "2026-11-09T09:30:27Z",
+				"DiscoKey":   "discokey:0dde8e43d786368333282af84458203134ee89de681daae268aea547302eaa39",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57338",
+					"10.65.0.27:57338",
+					"172.17.0.1:57338",
+					"172.18.0.1:57338",
+					"172.19.0.1:57338",
+					"172.20.0.1:57338",
+					"172.21.0.1:57338",
+					"172.22.0.1:57338",
+					"172.23.0.1:57338",
+					"172.24.0.1:57338",
+					"172.25.0.1:57338",
+					"172.26.0.1:57338",
+					"172.27.0.1:57338"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:30:27.807949242Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8431358078059330": {
+				"ID":          8431358078059330,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1493384375532153,
+				"StableID":   "nJPrQAgMfC11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1493384375532153,
+				"Key":        "nodekey:cb5bb1cdb0ff33b7e7bee6ec6b139f6fafb9f188c6bab4243677c47cc5a70831",
+				"DiscoKey":   "discokey:13886cbf8a432412327a73ba106d682f72fbde38b2771ab03c66baabdfaee42f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:52709",
+					"10.65.0.27:52709",
+					"172.17.0.1:52709",
+					"172.18.0.1:52709",
+					"172.19.0.1:52709",
+					"172.20.0.1:52709",
+					"172.21.0.1:52709",
+					"172.22.0.1:52709",
+					"172.23.0.1:52709",
+					"172.24.0.1:52709",
+					"172.25.0.1:52709",
+					"172.26.0.1:52709",
+					"172.27.0.1:52709"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:30:20.319592339Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:cb5bb1cdb0ff33b7e7bee6ec6b139f6fafb9f188c6bab4243677c47cc5a70831",
+			"MachineKey": "mkey:60ad84a05ed643666b7b0c6bc44585400fa80e517e00adcd8f95403e30346111",
+			"Peers": [{
+				"ID":         3628307374917488,
+				"StableID":   "nwJfAyUGLV11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8587a6f7374ca011a9ac6468627b921cfa75948a6fb3f0b04df5ffc7e4822b5b",
+				"DiscoKey":   "discokey:5291592b301d037d3573ecb86b8ffafda3907780e8ffc5edb50e85035ed66a74",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:60776",
+					"10.65.0.27:60776",
+					"172.17.0.1:60776",
+					"172.18.0.1:60776",
+					"172.19.0.1:60776",
+					"172.20.0.1:60776",
+					"172.21.0.1:60776",
+					"172.22.0.1:60776",
+					"172.23.0.1:60776",
+					"172.24.0.1:60776",
+					"172.25.0.1:60776",
+					"172.26.0.1:60776",
+					"172.27.0.1:60776"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:30:19.604495837Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1099277371122160,
+				"StableID":   "ns8Hzq9sa911CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6ead0b971a84bb0155d90e0ebd3eb6e7d7353739feb2acb825c5deb763631d53",
+				"DiscoKey":   "discokey:a4ae1f8f20ee5f9b386feb4b92b080b07ae8d53d1cc019fa7c7761bdb2a7df70",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43004",
+					"10.65.0.27:43004",
+					"172.17.0.1:43004",
+					"172.18.0.1:43004",
+					"172.19.0.1:43004",
+					"172.20.0.1:43004",
+					"172.21.0.1:43004",
+					"172.22.0.1:43004",
+					"172.23.0.1:43004",
+					"172.24.0.1:43004",
+					"172.25.0.1:43004",
+					"172.26.0.1:43004",
+					"172.27.0.1:43004"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:30:20.856238896Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2691709711896678,
+				"StableID":   "ndnyuge52N11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2f0f9aa40c11d6caefbf393a5ae8eeb99f47053abac6b79681f8aa1b67e98769",
+				"DiscoKey":   "discokey:29ee71a95c71f6ed791da21b42c0c819f0b95368406800121696acf5ffca1745",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45143",
+					"10.65.0.27:45143",
+					"172.17.0.1:45143",
+					"172.18.0.1:45143",
+					"172.19.0.1:45143",
+					"172.20.0.1:45143",
+					"172.21.0.1:45143",
+					"172.22.0.1:45143",
+					"172.23.0.1:45143",
+					"172.24.0.1:45143",
+					"172.25.0.1:45143",
+					"172.26.0.1:45143",
+					"172.27.0.1:45143"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:30:21.393986895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         12685843844750,
+				"StableID":   "n9tdafEk6111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e9317595a76d9da92f070ba866cbbfd950bebd0bb2a22da60dd5f548d9e7739",
+				"DiscoKey":   "discokey:20045d9d345983c979fadb65dd0db6620eb191751458cac1582766f33d25be41",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58390",
+					"10.65.0.27:58390",
+					"172.17.0.1:58390",
+					"172.18.0.1:58390",
+					"172.19.0.1:58390",
+					"172.20.0.1:58390",
+					"172.21.0.1:58390",
+					"172.22.0.1:58390",
+					"172.23.0.1:58390",
+					"172.24.0.1:58390",
+					"172.25.0.1:58390",
+					"172.26.0.1:58390",
+					"172.27.0.1:58390"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:30:21.965086659Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         220059800127697,
+				"StableID":   "nJfiyfbfi211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f82d10ad4a8afe9aeee81c4c1dcf49cda2f43da67e83bb43dd02f4616d907911",
+				"DiscoKey":   "discokey:9c598e24bacf2aa5dbcdfa20934c7082c2d423abf9aa422d163284b41be6ee49",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41839",
+					"10.65.0.27:41839",
+					"172.17.0.1:41839",
+					"172.18.0.1:41839",
+					"172.19.0.1:41839",
+					"172.20.0.1:41839",
+					"172.21.0.1:41839",
+					"172.22.0.1:41839",
+					"172.23.0.1:41839",
+					"172.24.0.1:41839",
+					"172.25.0.1:41839",
+					"172.26.0.1:41839",
+					"172.27.0.1:41839"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:30:22.487425695Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7367908405015496,
+				"StableID":   "nw4zXgTwXz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b5171dd8248b6600e124ab8a373ad2474d1422ebf0a43a7f93e526e1e45ae774",
+				"DiscoKey":   "discokey:32447222761bd26fc98eb5000a8954e03b20b5456e2f40230debc4e3bd71dc5f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44778",
+					"10.65.0.27:44778",
+					"172.17.0.1:44778",
+					"172.18.0.1:44778",
+					"172.19.0.1:44778",
+					"172.20.0.1:44778",
+					"172.21.0.1:44778",
+					"172.22.0.1:44778",
+					"172.23.0.1:44778",
+					"172.24.0.1:44778",
+					"172.25.0.1:44778",
+					"172.26.0.1:44778",
+					"172.27.0.1:44778"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:30:23.04063128Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5602755481149455,
+				"StableID":   "nJ4o8PtVkk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d8d2db2cb821338ea64e3375fc8e1048d0b9fc371c24e4d176cd629ef522065",
+				"DiscoKey":   "discokey:400d522c5a33d5f017772b6608482cf826411a0f597b22b01e50664e6835e35a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37413",
+					"10.65.0.27:37413",
+					"172.17.0.1:37413",
+					"172.18.0.1:37413",
+					"172.19.0.1:37413",
+					"172.20.0.1:37413",
+					"172.21.0.1:37413",
+					"172.22.0.1:37413",
+					"172.23.0.1:37413",
+					"172.24.0.1:37413",
+					"172.25.0.1:37413",
+					"172.26.0.1:37413",
+					"172.27.0.1:37413"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:30:23.630307934Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7395883338911835,
+				"StableID":   "nYPXeDKckz11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c89610742a89888e4ceac7e52b6aa315db690c98ada622f726b3a4242e9b8d3f",
+				"DiscoKey":   "discokey:00b9780e7c8d9deeaf1a27ce309babca928035af7dd7fa200c57271a67bf820a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35503",
+					"10.65.0.27:35503",
+					"172.17.0.1:35503",
+					"172.18.0.1:35503",
+					"172.19.0.1:35503",
+					"172.20.0.1:35503",
+					"172.21.0.1:35503",
+					"172.22.0.1:35503",
+					"172.23.0.1:35503",
+					"172.24.0.1:35503",
+					"172.25.0.1:35503",
+					"172.26.0.1:35503",
+					"172.27.0.1:35503"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:30:24.35024234Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         156123256026230,
+				"StableID":   "nK3wWQ6iD211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35bbd44adc1e0017f0f3cb5dc15c25172e8e0873f8475470e8716c906e85701c",
+				"DiscoKey":   "discokey:e315d2aa2650c181b0e7e8abe62aed80b5f6a8b39b3f5f590a3a6e81d7994a4e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59133",
+					"10.65.0.27:59133",
+					"172.17.0.1:59133",
+					"172.18.0.1:59133",
+					"172.19.0.1:59133",
+					"172.20.0.1:59133",
+					"172.21.0.1:59133",
+					"172.22.0.1:59133",
+					"172.23.0.1:59133",
+					"172.24.0.1:59133",
+					"172.25.0.1:59133",
+					"172.26.0.1:59133",
+					"172.27.0.1:59133"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:30:24.961232221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8431358078059330,
+				"StableID":   "nsmfXpUaq821CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:63133f6c88593acd3b63105c7176719ce717f2e66b9b7657c0aa3acc4557316d",
+				"DiscoKey":   "discokey:d204d313a545b75f35dbf27c5fd8924b694c32b6d1d7622f8c665bae2c052373",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50334",
+					"10.65.0.27:50334",
+					"172.17.0.1:50334",
+					"172.18.0.1:50334",
+					"172.19.0.1:50334",
+					"172.20.0.1:50334",
+					"172.21.0.1:50334",
+					"172.22.0.1:50334",
+					"172.23.0.1:50334",
+					"172.24.0.1:50334",
+					"172.25.0.1:50334",
+					"172.26.0.1:50334",
+					"172.27.0.1:50334"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:30:25.669266846Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6635437266779190,
+				"StableID":   "nme7HkgCpt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cbf7c7ea6bd03996c13db4de2b558efbbd5cf8536f41cc76424b15a8cce8ed6b",
+				"DiscoKey":   "discokey:b83c63aafa2ac23ca7968015176fdf00a90a94ddc1cc8402ef0b72afc8a78706",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45684",
+					"10.65.0.27:45684",
+					"172.17.0.1:45684",
+					"172.18.0.1:45684",
+					"172.19.0.1:45684",
+					"172.20.0.1:45684",
+					"172.21.0.1:45684",
+					"172.22.0.1:45684",
+					"172.23.0.1:45684",
+					"172.24.0.1:45684",
+					"172.25.0.1:45684",
+					"172.26.0.1:45684",
+					"172.27.0.1:45684"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:30:26.20463116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6048256030654495,
+				"StableID":   "nkqe9wRGEp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a2661c0992e6f6f36c961226b6c951c0324de2a6d2279d7e43c3a6fed43f9652",
+				"KeyExpiry":  "2026-11-09T09:30:26Z",
+				"DiscoKey":   "discokey:3ebad77570ee23f4a75003d66ebe44faa51879ec277d967f1df088231e820c28",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45887",
+					"10.65.0.27:45887",
+					"172.17.0.1:45887",
+					"172.18.0.1:45887",
+					"172.19.0.1:45887",
+					"172.20.0.1:45887",
+					"172.21.0.1:45887",
+					"172.22.0.1:45887",
+					"172.23.0.1:45887",
+					"172.24.0.1:45887",
+					"172.25.0.1:45887",
+					"172.26.0.1:45887",
+					"172.27.0.1:45887"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:30:26.725360455Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8234239497029749,
+				"StableID":   "nvuPXWWJJ721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:180fb2b409872a185fa9447ecfbb845e0154f6c7f143eb6ca09e3d2bd6ddbb17",
+				"KeyExpiry":  "2026-11-09T09:30:27Z",
+				"DiscoKey":   "discokey:7e5bb9a482709932c2f64cb02779a5a9c71b33777a842c47041a0fc713b9587a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50553",
+					"10.65.0.27:50553",
+					"172.17.0.1:50553",
+					"172.18.0.1:50553",
+					"172.19.0.1:50553",
+					"172.20.0.1:50553",
+					"172.21.0.1:50553",
+					"172.22.0.1:50553",
+					"172.23.0.1:50553",
+					"172.24.0.1:50553",
+					"172.25.0.1:50553",
+					"172.26.0.1:50553",
+					"172.27.0.1:50553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:30:27.260403572Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3225617935357335,
+				"StableID":   "nAUbLnWtBS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:05fb5c7def2bd52a36b410573911e9e7309ce75d545fb99011ceb2ed571d5d5d",
+				"KeyExpiry":  "2026-11-09T09:30:27Z",
+				"DiscoKey":   "discokey:0dde8e43d786368333282af84458203134ee89de681daae268aea547302eaa39",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57338",
+					"10.65.0.27:57338",
+					"172.17.0.1:57338",
+					"172.18.0.1:57338",
+					"172.19.0.1:57338",
+					"172.20.0.1:57338",
+					"172.21.0.1:57338",
+					"172.22.0.1:57338",
+					"172.23.0.1:57338",
+					"172.24.0.1:57338",
+					"172.25.0.1:57338",
+					"172.26.0.1:57338",
+					"172.27.0.1:57338"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:30:27.807949242Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1493384375532153": {
+				"ID":          1493384375532153,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3628307374917488,
+				"StableID":   "nwJfAyUGLV11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       3628307374917488,
+				"Key":        "nodekey:8587a6f7374ca011a9ac6468627b921cfa75948a6fb3f0b04df5ffc7e4822b5b",
+				"DiscoKey":   "discokey:5291592b301d037d3573ecb86b8ffafda3907780e8ffc5edb50e85035ed66a74",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:60776",
+					"10.65.0.27:60776",
+					"172.17.0.1:60776",
+					"172.18.0.1:60776",
+					"172.19.0.1:60776",
+					"172.20.0.1:60776",
+					"172.21.0.1:60776",
+					"172.22.0.1:60776",
+					"172.23.0.1:60776",
+					"172.24.0.1:60776",
+					"172.25.0.1:60776",
+					"172.26.0.1:60776",
+					"172.27.0.1:60776"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:30:19.604495837Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8587a6f7374ca011a9ac6468627b921cfa75948a6fb3f0b04df5ffc7e4822b5b",
+			"MachineKey": "mkey:d22c37231a8232179fe85efb2da54f8a9d4d20fa9d384d721387eb439461fc3f",
+			"Peers": [{
+				"ID":         1493384375532153,
+				"StableID":   "nJPrQAgMfC11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb5bb1cdb0ff33b7e7bee6ec6b139f6fafb9f188c6bab4243677c47cc5a70831",
+				"DiscoKey":   "discokey:13886cbf8a432412327a73ba106d682f72fbde38b2771ab03c66baabdfaee42f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:52709",
+					"10.65.0.27:52709",
+					"172.17.0.1:52709",
+					"172.18.0.1:52709",
+					"172.19.0.1:52709",
+					"172.20.0.1:52709",
+					"172.21.0.1:52709",
+					"172.22.0.1:52709",
+					"172.23.0.1:52709",
+					"172.24.0.1:52709",
+					"172.25.0.1:52709",
+					"172.26.0.1:52709",
+					"172.27.0.1:52709"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:30:20.319592339Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1099277371122160,
+				"StableID":   "ns8Hzq9sa911CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6ead0b971a84bb0155d90e0ebd3eb6e7d7353739feb2acb825c5deb763631d53",
+				"DiscoKey":   "discokey:a4ae1f8f20ee5f9b386feb4b92b080b07ae8d53d1cc019fa7c7761bdb2a7df70",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43004",
+					"10.65.0.27:43004",
+					"172.17.0.1:43004",
+					"172.18.0.1:43004",
+					"172.19.0.1:43004",
+					"172.20.0.1:43004",
+					"172.21.0.1:43004",
+					"172.22.0.1:43004",
+					"172.23.0.1:43004",
+					"172.24.0.1:43004",
+					"172.25.0.1:43004",
+					"172.26.0.1:43004",
+					"172.27.0.1:43004"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:30:20.856238896Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2691709711896678,
+				"StableID":   "ndnyuge52N11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2f0f9aa40c11d6caefbf393a5ae8eeb99f47053abac6b79681f8aa1b67e98769",
+				"DiscoKey":   "discokey:29ee71a95c71f6ed791da21b42c0c819f0b95368406800121696acf5ffca1745",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45143",
+					"10.65.0.27:45143",
+					"172.17.0.1:45143",
+					"172.18.0.1:45143",
+					"172.19.0.1:45143",
+					"172.20.0.1:45143",
+					"172.21.0.1:45143",
+					"172.22.0.1:45143",
+					"172.23.0.1:45143",
+					"172.24.0.1:45143",
+					"172.25.0.1:45143",
+					"172.26.0.1:45143",
+					"172.27.0.1:45143"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:30:21.393986895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         12685843844750,
+				"StableID":   "n9tdafEk6111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e9317595a76d9da92f070ba866cbbfd950bebd0bb2a22da60dd5f548d9e7739",
+				"DiscoKey":   "discokey:20045d9d345983c979fadb65dd0db6620eb191751458cac1582766f33d25be41",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58390",
+					"10.65.0.27:58390",
+					"172.17.0.1:58390",
+					"172.18.0.1:58390",
+					"172.19.0.1:58390",
+					"172.20.0.1:58390",
+					"172.21.0.1:58390",
+					"172.22.0.1:58390",
+					"172.23.0.1:58390",
+					"172.24.0.1:58390",
+					"172.25.0.1:58390",
+					"172.26.0.1:58390",
+					"172.27.0.1:58390"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:30:21.965086659Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         220059800127697,
+				"StableID":   "nJfiyfbfi211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f82d10ad4a8afe9aeee81c4c1dcf49cda2f43da67e83bb43dd02f4616d907911",
+				"DiscoKey":   "discokey:9c598e24bacf2aa5dbcdfa20934c7082c2d423abf9aa422d163284b41be6ee49",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41839",
+					"10.65.0.27:41839",
+					"172.17.0.1:41839",
+					"172.18.0.1:41839",
+					"172.19.0.1:41839",
+					"172.20.0.1:41839",
+					"172.21.0.1:41839",
+					"172.22.0.1:41839",
+					"172.23.0.1:41839",
+					"172.24.0.1:41839",
+					"172.25.0.1:41839",
+					"172.26.0.1:41839",
+					"172.27.0.1:41839"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:30:22.487425695Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7367908405015496,
+				"StableID":   "nw4zXgTwXz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b5171dd8248b6600e124ab8a373ad2474d1422ebf0a43a7f93e526e1e45ae774",
+				"DiscoKey":   "discokey:32447222761bd26fc98eb5000a8954e03b20b5456e2f40230debc4e3bd71dc5f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44778",
+					"10.65.0.27:44778",
+					"172.17.0.1:44778",
+					"172.18.0.1:44778",
+					"172.19.0.1:44778",
+					"172.20.0.1:44778",
+					"172.21.0.1:44778",
+					"172.22.0.1:44778",
+					"172.23.0.1:44778",
+					"172.24.0.1:44778",
+					"172.25.0.1:44778",
+					"172.26.0.1:44778",
+					"172.27.0.1:44778"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:30:23.04063128Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5602755481149455,
+				"StableID":   "nJ4o8PtVkk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d8d2db2cb821338ea64e3375fc8e1048d0b9fc371c24e4d176cd629ef522065",
+				"DiscoKey":   "discokey:400d522c5a33d5f017772b6608482cf826411a0f597b22b01e50664e6835e35a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37413",
+					"10.65.0.27:37413",
+					"172.17.0.1:37413",
+					"172.18.0.1:37413",
+					"172.19.0.1:37413",
+					"172.20.0.1:37413",
+					"172.21.0.1:37413",
+					"172.22.0.1:37413",
+					"172.23.0.1:37413",
+					"172.24.0.1:37413",
+					"172.25.0.1:37413",
+					"172.26.0.1:37413",
+					"172.27.0.1:37413"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:30:23.630307934Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7395883338911835,
+				"StableID":   "nYPXeDKckz11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c89610742a89888e4ceac7e52b6aa315db690c98ada622f726b3a4242e9b8d3f",
+				"DiscoKey":   "discokey:00b9780e7c8d9deeaf1a27ce309babca928035af7dd7fa200c57271a67bf820a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35503",
+					"10.65.0.27:35503",
+					"172.17.0.1:35503",
+					"172.18.0.1:35503",
+					"172.19.0.1:35503",
+					"172.20.0.1:35503",
+					"172.21.0.1:35503",
+					"172.22.0.1:35503",
+					"172.23.0.1:35503",
+					"172.24.0.1:35503",
+					"172.25.0.1:35503",
+					"172.26.0.1:35503",
+					"172.27.0.1:35503"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:30:24.35024234Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         156123256026230,
+				"StableID":   "nK3wWQ6iD211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35bbd44adc1e0017f0f3cb5dc15c25172e8e0873f8475470e8716c906e85701c",
+				"DiscoKey":   "discokey:e315d2aa2650c181b0e7e8abe62aed80b5f6a8b39b3f5f590a3a6e81d7994a4e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59133",
+					"10.65.0.27:59133",
+					"172.17.0.1:59133",
+					"172.18.0.1:59133",
+					"172.19.0.1:59133",
+					"172.20.0.1:59133",
+					"172.21.0.1:59133",
+					"172.22.0.1:59133",
+					"172.23.0.1:59133",
+					"172.24.0.1:59133",
+					"172.25.0.1:59133",
+					"172.26.0.1:59133",
+					"172.27.0.1:59133"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:30:24.961232221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8431358078059330,
+				"StableID":   "nsmfXpUaq821CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:63133f6c88593acd3b63105c7176719ce717f2e66b9b7657c0aa3acc4557316d",
+				"DiscoKey":   "discokey:d204d313a545b75f35dbf27c5fd8924b694c32b6d1d7622f8c665bae2c052373",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50334",
+					"10.65.0.27:50334",
+					"172.17.0.1:50334",
+					"172.18.0.1:50334",
+					"172.19.0.1:50334",
+					"172.20.0.1:50334",
+					"172.21.0.1:50334",
+					"172.22.0.1:50334",
+					"172.23.0.1:50334",
+					"172.24.0.1:50334",
+					"172.25.0.1:50334",
+					"172.26.0.1:50334",
+					"172.27.0.1:50334"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:30:25.669266846Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6635437266779190,
+				"StableID":   "nme7HkgCpt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cbf7c7ea6bd03996c13db4de2b558efbbd5cf8536f41cc76424b15a8cce8ed6b",
+				"DiscoKey":   "discokey:b83c63aafa2ac23ca7968015176fdf00a90a94ddc1cc8402ef0b72afc8a78706",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45684",
+					"10.65.0.27:45684",
+					"172.17.0.1:45684",
+					"172.18.0.1:45684",
+					"172.19.0.1:45684",
+					"172.20.0.1:45684",
+					"172.21.0.1:45684",
+					"172.22.0.1:45684",
+					"172.23.0.1:45684",
+					"172.24.0.1:45684",
+					"172.25.0.1:45684",
+					"172.26.0.1:45684",
+					"172.27.0.1:45684"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:30:26.20463116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6048256030654495,
+				"StableID":   "nkqe9wRGEp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a2661c0992e6f6f36c961226b6c951c0324de2a6d2279d7e43c3a6fed43f9652",
+				"KeyExpiry":  "2026-11-09T09:30:26Z",
+				"DiscoKey":   "discokey:3ebad77570ee23f4a75003d66ebe44faa51879ec277d967f1df088231e820c28",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45887",
+					"10.65.0.27:45887",
+					"172.17.0.1:45887",
+					"172.18.0.1:45887",
+					"172.19.0.1:45887",
+					"172.20.0.1:45887",
+					"172.21.0.1:45887",
+					"172.22.0.1:45887",
+					"172.23.0.1:45887",
+					"172.24.0.1:45887",
+					"172.25.0.1:45887",
+					"172.26.0.1:45887",
+					"172.27.0.1:45887"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:30:26.725360455Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8234239497029749,
+				"StableID":   "nvuPXWWJJ721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:180fb2b409872a185fa9447ecfbb845e0154f6c7f143eb6ca09e3d2bd6ddbb17",
+				"KeyExpiry":  "2026-11-09T09:30:27Z",
+				"DiscoKey":   "discokey:7e5bb9a482709932c2f64cb02779a5a9c71b33777a842c47041a0fc713b9587a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50553",
+					"10.65.0.27:50553",
+					"172.17.0.1:50553",
+					"172.18.0.1:50553",
+					"172.19.0.1:50553",
+					"172.20.0.1:50553",
+					"172.21.0.1:50553",
+					"172.22.0.1:50553",
+					"172.23.0.1:50553",
+					"172.24.0.1:50553",
+					"172.25.0.1:50553",
+					"172.26.0.1:50553",
+					"172.27.0.1:50553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:30:27.260403572Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3225617935357335,
+				"StableID":   "nAUbLnWtBS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:05fb5c7def2bd52a36b410573911e9e7309ce75d545fb99011ceb2ed571d5d5d",
+				"KeyExpiry":  "2026-11-09T09:30:27Z",
+				"DiscoKey":   "discokey:0dde8e43d786368333282af84458203134ee89de681daae268aea547302eaa39",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57338",
+					"10.65.0.27:57338",
+					"172.17.0.1:57338",
+					"172.18.0.1:57338",
+					"172.19.0.1:57338",
+					"172.20.0.1:57338",
+					"172.21.0.1:57338",
+					"172.22.0.1:57338",
+					"172.23.0.1:57338",
+					"172.24.0.1:57338",
+					"172.25.0.1:57338",
+					"172.26.0.1:57338",
+					"172.27.0.1:57338"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:30:27.807949242Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3628307374917488": {
+				"ID":          3628307374917488,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         12685843844750,
+				"StableID":   "n9tdafEk6111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       12685843844750,
+				"Key":        "nodekey:8e9317595a76d9da92f070ba866cbbfd950bebd0bb2a22da60dd5f548d9e7739",
+				"DiscoKey":   "discokey:20045d9d345983c979fadb65dd0db6620eb191751458cac1582766f33d25be41",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58390",
+					"10.65.0.27:58390",
+					"172.17.0.1:58390",
+					"172.18.0.1:58390",
+					"172.19.0.1:58390",
+					"172.20.0.1:58390",
+					"172.21.0.1:58390",
+					"172.22.0.1:58390",
+					"172.23.0.1:58390",
+					"172.24.0.1:58390",
+					"172.25.0.1:58390",
+					"172.26.0.1:58390",
+					"172.27.0.1:58390"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:30:21.965086659Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8e9317595a76d9da92f070ba866cbbfd950bebd0bb2a22da60dd5f548d9e7739",
+			"MachineKey": "mkey:a320d24b66814ccc76bdc3cddf6b95f9f4a467e166fb9c75b294635c456c384c",
+			"Peers": [{
+				"ID":         3628307374917488,
+				"StableID":   "nwJfAyUGLV11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8587a6f7374ca011a9ac6468627b921cfa75948a6fb3f0b04df5ffc7e4822b5b",
+				"DiscoKey":   "discokey:5291592b301d037d3573ecb86b8ffafda3907780e8ffc5edb50e85035ed66a74",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:60776",
+					"10.65.0.27:60776",
+					"172.17.0.1:60776",
+					"172.18.0.1:60776",
+					"172.19.0.1:60776",
+					"172.20.0.1:60776",
+					"172.21.0.1:60776",
+					"172.22.0.1:60776",
+					"172.23.0.1:60776",
+					"172.24.0.1:60776",
+					"172.25.0.1:60776",
+					"172.26.0.1:60776",
+					"172.27.0.1:60776"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:30:19.604495837Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1493384375532153,
+				"StableID":   "nJPrQAgMfC11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb5bb1cdb0ff33b7e7bee6ec6b139f6fafb9f188c6bab4243677c47cc5a70831",
+				"DiscoKey":   "discokey:13886cbf8a432412327a73ba106d682f72fbde38b2771ab03c66baabdfaee42f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:52709",
+					"10.65.0.27:52709",
+					"172.17.0.1:52709",
+					"172.18.0.1:52709",
+					"172.19.0.1:52709",
+					"172.20.0.1:52709",
+					"172.21.0.1:52709",
+					"172.22.0.1:52709",
+					"172.23.0.1:52709",
+					"172.24.0.1:52709",
+					"172.25.0.1:52709",
+					"172.26.0.1:52709",
+					"172.27.0.1:52709"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:30:20.319592339Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1099277371122160,
+				"StableID":   "ns8Hzq9sa911CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6ead0b971a84bb0155d90e0ebd3eb6e7d7353739feb2acb825c5deb763631d53",
+				"DiscoKey":   "discokey:a4ae1f8f20ee5f9b386feb4b92b080b07ae8d53d1cc019fa7c7761bdb2a7df70",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43004",
+					"10.65.0.27:43004",
+					"172.17.0.1:43004",
+					"172.18.0.1:43004",
+					"172.19.0.1:43004",
+					"172.20.0.1:43004",
+					"172.21.0.1:43004",
+					"172.22.0.1:43004",
+					"172.23.0.1:43004",
+					"172.24.0.1:43004",
+					"172.25.0.1:43004",
+					"172.26.0.1:43004",
+					"172.27.0.1:43004"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:30:20.856238896Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2691709711896678,
+				"StableID":   "ndnyuge52N11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2f0f9aa40c11d6caefbf393a5ae8eeb99f47053abac6b79681f8aa1b67e98769",
+				"DiscoKey":   "discokey:29ee71a95c71f6ed791da21b42c0c819f0b95368406800121696acf5ffca1745",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45143",
+					"10.65.0.27:45143",
+					"172.17.0.1:45143",
+					"172.18.0.1:45143",
+					"172.19.0.1:45143",
+					"172.20.0.1:45143",
+					"172.21.0.1:45143",
+					"172.22.0.1:45143",
+					"172.23.0.1:45143",
+					"172.24.0.1:45143",
+					"172.25.0.1:45143",
+					"172.26.0.1:45143",
+					"172.27.0.1:45143"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:30:21.393986895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         220059800127697,
+				"StableID":   "nJfiyfbfi211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f82d10ad4a8afe9aeee81c4c1dcf49cda2f43da67e83bb43dd02f4616d907911",
+				"DiscoKey":   "discokey:9c598e24bacf2aa5dbcdfa20934c7082c2d423abf9aa422d163284b41be6ee49",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41839",
+					"10.65.0.27:41839",
+					"172.17.0.1:41839",
+					"172.18.0.1:41839",
+					"172.19.0.1:41839",
+					"172.20.0.1:41839",
+					"172.21.0.1:41839",
+					"172.22.0.1:41839",
+					"172.23.0.1:41839",
+					"172.24.0.1:41839",
+					"172.25.0.1:41839",
+					"172.26.0.1:41839",
+					"172.27.0.1:41839"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:30:22.487425695Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7367908405015496,
+				"StableID":   "nw4zXgTwXz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b5171dd8248b6600e124ab8a373ad2474d1422ebf0a43a7f93e526e1e45ae774",
+				"DiscoKey":   "discokey:32447222761bd26fc98eb5000a8954e03b20b5456e2f40230debc4e3bd71dc5f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44778",
+					"10.65.0.27:44778",
+					"172.17.0.1:44778",
+					"172.18.0.1:44778",
+					"172.19.0.1:44778",
+					"172.20.0.1:44778",
+					"172.21.0.1:44778",
+					"172.22.0.1:44778",
+					"172.23.0.1:44778",
+					"172.24.0.1:44778",
+					"172.25.0.1:44778",
+					"172.26.0.1:44778",
+					"172.27.0.1:44778"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:30:23.04063128Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5602755481149455,
+				"StableID":   "nJ4o8PtVkk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d8d2db2cb821338ea64e3375fc8e1048d0b9fc371c24e4d176cd629ef522065",
+				"DiscoKey":   "discokey:400d522c5a33d5f017772b6608482cf826411a0f597b22b01e50664e6835e35a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37413",
+					"10.65.0.27:37413",
+					"172.17.0.1:37413",
+					"172.18.0.1:37413",
+					"172.19.0.1:37413",
+					"172.20.0.1:37413",
+					"172.21.0.1:37413",
+					"172.22.0.1:37413",
+					"172.23.0.1:37413",
+					"172.24.0.1:37413",
+					"172.25.0.1:37413",
+					"172.26.0.1:37413",
+					"172.27.0.1:37413"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:30:23.630307934Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7395883338911835,
+				"StableID":   "nYPXeDKckz11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c89610742a89888e4ceac7e52b6aa315db690c98ada622f726b3a4242e9b8d3f",
+				"DiscoKey":   "discokey:00b9780e7c8d9deeaf1a27ce309babca928035af7dd7fa200c57271a67bf820a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35503",
+					"10.65.0.27:35503",
+					"172.17.0.1:35503",
+					"172.18.0.1:35503",
+					"172.19.0.1:35503",
+					"172.20.0.1:35503",
+					"172.21.0.1:35503",
+					"172.22.0.1:35503",
+					"172.23.0.1:35503",
+					"172.24.0.1:35503",
+					"172.25.0.1:35503",
+					"172.26.0.1:35503",
+					"172.27.0.1:35503"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:30:24.35024234Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         156123256026230,
+				"StableID":   "nK3wWQ6iD211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35bbd44adc1e0017f0f3cb5dc15c25172e8e0873f8475470e8716c906e85701c",
+				"DiscoKey":   "discokey:e315d2aa2650c181b0e7e8abe62aed80b5f6a8b39b3f5f590a3a6e81d7994a4e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59133",
+					"10.65.0.27:59133",
+					"172.17.0.1:59133",
+					"172.18.0.1:59133",
+					"172.19.0.1:59133",
+					"172.20.0.1:59133",
+					"172.21.0.1:59133",
+					"172.22.0.1:59133",
+					"172.23.0.1:59133",
+					"172.24.0.1:59133",
+					"172.25.0.1:59133",
+					"172.26.0.1:59133",
+					"172.27.0.1:59133"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:30:24.961232221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8431358078059330,
+				"StableID":   "nsmfXpUaq821CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:63133f6c88593acd3b63105c7176719ce717f2e66b9b7657c0aa3acc4557316d",
+				"DiscoKey":   "discokey:d204d313a545b75f35dbf27c5fd8924b694c32b6d1d7622f8c665bae2c052373",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50334",
+					"10.65.0.27:50334",
+					"172.17.0.1:50334",
+					"172.18.0.1:50334",
+					"172.19.0.1:50334",
+					"172.20.0.1:50334",
+					"172.21.0.1:50334",
+					"172.22.0.1:50334",
+					"172.23.0.1:50334",
+					"172.24.0.1:50334",
+					"172.25.0.1:50334",
+					"172.26.0.1:50334",
+					"172.27.0.1:50334"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:30:25.669266846Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6635437266779190,
+				"StableID":   "nme7HkgCpt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cbf7c7ea6bd03996c13db4de2b558efbbd5cf8536f41cc76424b15a8cce8ed6b",
+				"DiscoKey":   "discokey:b83c63aafa2ac23ca7968015176fdf00a90a94ddc1cc8402ef0b72afc8a78706",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45684",
+					"10.65.0.27:45684",
+					"172.17.0.1:45684",
+					"172.18.0.1:45684",
+					"172.19.0.1:45684",
+					"172.20.0.1:45684",
+					"172.21.0.1:45684",
+					"172.22.0.1:45684",
+					"172.23.0.1:45684",
+					"172.24.0.1:45684",
+					"172.25.0.1:45684",
+					"172.26.0.1:45684",
+					"172.27.0.1:45684"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:30:26.20463116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6048256030654495,
+				"StableID":   "nkqe9wRGEp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a2661c0992e6f6f36c961226b6c951c0324de2a6d2279d7e43c3a6fed43f9652",
+				"KeyExpiry":  "2026-11-09T09:30:26Z",
+				"DiscoKey":   "discokey:3ebad77570ee23f4a75003d66ebe44faa51879ec277d967f1df088231e820c28",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45887",
+					"10.65.0.27:45887",
+					"172.17.0.1:45887",
+					"172.18.0.1:45887",
+					"172.19.0.1:45887",
+					"172.20.0.1:45887",
+					"172.21.0.1:45887",
+					"172.22.0.1:45887",
+					"172.23.0.1:45887",
+					"172.24.0.1:45887",
+					"172.25.0.1:45887",
+					"172.26.0.1:45887",
+					"172.27.0.1:45887"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:30:26.725360455Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8234239497029749,
+				"StableID":   "nvuPXWWJJ721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:180fb2b409872a185fa9447ecfbb845e0154f6c7f143eb6ca09e3d2bd6ddbb17",
+				"KeyExpiry":  "2026-11-09T09:30:27Z",
+				"DiscoKey":   "discokey:7e5bb9a482709932c2f64cb02779a5a9c71b33777a842c47041a0fc713b9587a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50553",
+					"10.65.0.27:50553",
+					"172.17.0.1:50553",
+					"172.18.0.1:50553",
+					"172.19.0.1:50553",
+					"172.20.0.1:50553",
+					"172.21.0.1:50553",
+					"172.22.0.1:50553",
+					"172.23.0.1:50553",
+					"172.24.0.1:50553",
+					"172.25.0.1:50553",
+					"172.26.0.1:50553",
+					"172.27.0.1:50553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:30:27.260403572Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3225617935357335,
+				"StableID":   "nAUbLnWtBS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:05fb5c7def2bd52a36b410573911e9e7309ce75d545fb99011ceb2ed571d5d5d",
+				"KeyExpiry":  "2026-11-09T09:30:27Z",
+				"DiscoKey":   "discokey:0dde8e43d786368333282af84458203134ee89de681daae268aea547302eaa39",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57338",
+					"10.65.0.27:57338",
+					"172.17.0.1:57338",
+					"172.18.0.1:57338",
+					"172.19.0.1:57338",
+					"172.20.0.1:57338",
+					"172.21.0.1:57338",
+					"172.22.0.1:57338",
+					"172.23.0.1:57338",
+					"172.24.0.1:57338",
+					"172.25.0.1:57338",
+					"172.26.0.1:57338",
+					"172.27.0.1:57338"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:30:27.807949242Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "12685843844750": {
+				"ID":          12685843844750,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2691709711896678,
+				"StableID":   "ndnyuge52N11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       2691709711896678,
+				"Key":        "nodekey:2f0f9aa40c11d6caefbf393a5ae8eeb99f47053abac6b79681f8aa1b67e98769",
+				"DiscoKey":   "discokey:29ee71a95c71f6ed791da21b42c0c819f0b95368406800121696acf5ffca1745",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45143",
+					"10.65.0.27:45143",
+					"172.17.0.1:45143",
+					"172.18.0.1:45143",
+					"172.19.0.1:45143",
+					"172.20.0.1:45143",
+					"172.21.0.1:45143",
+					"172.22.0.1:45143",
+					"172.23.0.1:45143",
+					"172.24.0.1:45143",
+					"172.25.0.1:45143",
+					"172.26.0.1:45143",
+					"172.27.0.1:45143"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:30:21.393986895Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2f0f9aa40c11d6caefbf393a5ae8eeb99f47053abac6b79681f8aa1b67e98769",
+			"MachineKey": "mkey:98b3f0cecb218d4216107264c62e406d7341383c2bc23bdd2c7d44aa3678637e",
+			"Peers": [{
+				"ID":         3628307374917488,
+				"StableID":   "nwJfAyUGLV11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8587a6f7374ca011a9ac6468627b921cfa75948a6fb3f0b04df5ffc7e4822b5b",
+				"DiscoKey":   "discokey:5291592b301d037d3573ecb86b8ffafda3907780e8ffc5edb50e85035ed66a74",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:60776",
+					"10.65.0.27:60776",
+					"172.17.0.1:60776",
+					"172.18.0.1:60776",
+					"172.19.0.1:60776",
+					"172.20.0.1:60776",
+					"172.21.0.1:60776",
+					"172.22.0.1:60776",
+					"172.23.0.1:60776",
+					"172.24.0.1:60776",
+					"172.25.0.1:60776",
+					"172.26.0.1:60776",
+					"172.27.0.1:60776"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:30:19.604495837Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1493384375532153,
+				"StableID":   "nJPrQAgMfC11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb5bb1cdb0ff33b7e7bee6ec6b139f6fafb9f188c6bab4243677c47cc5a70831",
+				"DiscoKey":   "discokey:13886cbf8a432412327a73ba106d682f72fbde38b2771ab03c66baabdfaee42f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:52709",
+					"10.65.0.27:52709",
+					"172.17.0.1:52709",
+					"172.18.0.1:52709",
+					"172.19.0.1:52709",
+					"172.20.0.1:52709",
+					"172.21.0.1:52709",
+					"172.22.0.1:52709",
+					"172.23.0.1:52709",
+					"172.24.0.1:52709",
+					"172.25.0.1:52709",
+					"172.26.0.1:52709",
+					"172.27.0.1:52709"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:30:20.319592339Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1099277371122160,
+				"StableID":   "ns8Hzq9sa911CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6ead0b971a84bb0155d90e0ebd3eb6e7d7353739feb2acb825c5deb763631d53",
+				"DiscoKey":   "discokey:a4ae1f8f20ee5f9b386feb4b92b080b07ae8d53d1cc019fa7c7761bdb2a7df70",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43004",
+					"10.65.0.27:43004",
+					"172.17.0.1:43004",
+					"172.18.0.1:43004",
+					"172.19.0.1:43004",
+					"172.20.0.1:43004",
+					"172.21.0.1:43004",
+					"172.22.0.1:43004",
+					"172.23.0.1:43004",
+					"172.24.0.1:43004",
+					"172.25.0.1:43004",
+					"172.26.0.1:43004",
+					"172.27.0.1:43004"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:30:20.856238896Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         12685843844750,
+				"StableID":   "n9tdafEk6111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e9317595a76d9da92f070ba866cbbfd950bebd0bb2a22da60dd5f548d9e7739",
+				"DiscoKey":   "discokey:20045d9d345983c979fadb65dd0db6620eb191751458cac1582766f33d25be41",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58390",
+					"10.65.0.27:58390",
+					"172.17.0.1:58390",
+					"172.18.0.1:58390",
+					"172.19.0.1:58390",
+					"172.20.0.1:58390",
+					"172.21.0.1:58390",
+					"172.22.0.1:58390",
+					"172.23.0.1:58390",
+					"172.24.0.1:58390",
+					"172.25.0.1:58390",
+					"172.26.0.1:58390",
+					"172.27.0.1:58390"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:30:21.965086659Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         220059800127697,
+				"StableID":   "nJfiyfbfi211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f82d10ad4a8afe9aeee81c4c1dcf49cda2f43da67e83bb43dd02f4616d907911",
+				"DiscoKey":   "discokey:9c598e24bacf2aa5dbcdfa20934c7082c2d423abf9aa422d163284b41be6ee49",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41839",
+					"10.65.0.27:41839",
+					"172.17.0.1:41839",
+					"172.18.0.1:41839",
+					"172.19.0.1:41839",
+					"172.20.0.1:41839",
+					"172.21.0.1:41839",
+					"172.22.0.1:41839",
+					"172.23.0.1:41839",
+					"172.24.0.1:41839",
+					"172.25.0.1:41839",
+					"172.26.0.1:41839",
+					"172.27.0.1:41839"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:30:22.487425695Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7367908405015496,
+				"StableID":   "nw4zXgTwXz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b5171dd8248b6600e124ab8a373ad2474d1422ebf0a43a7f93e526e1e45ae774",
+				"DiscoKey":   "discokey:32447222761bd26fc98eb5000a8954e03b20b5456e2f40230debc4e3bd71dc5f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44778",
+					"10.65.0.27:44778",
+					"172.17.0.1:44778",
+					"172.18.0.1:44778",
+					"172.19.0.1:44778",
+					"172.20.0.1:44778",
+					"172.21.0.1:44778",
+					"172.22.0.1:44778",
+					"172.23.0.1:44778",
+					"172.24.0.1:44778",
+					"172.25.0.1:44778",
+					"172.26.0.1:44778",
+					"172.27.0.1:44778"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:30:23.04063128Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5602755481149455,
+				"StableID":   "nJ4o8PtVkk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d8d2db2cb821338ea64e3375fc8e1048d0b9fc371c24e4d176cd629ef522065",
+				"DiscoKey":   "discokey:400d522c5a33d5f017772b6608482cf826411a0f597b22b01e50664e6835e35a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37413",
+					"10.65.0.27:37413",
+					"172.17.0.1:37413",
+					"172.18.0.1:37413",
+					"172.19.0.1:37413",
+					"172.20.0.1:37413",
+					"172.21.0.1:37413",
+					"172.22.0.1:37413",
+					"172.23.0.1:37413",
+					"172.24.0.1:37413",
+					"172.25.0.1:37413",
+					"172.26.0.1:37413",
+					"172.27.0.1:37413"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:30:23.630307934Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7395883338911835,
+				"StableID":   "nYPXeDKckz11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c89610742a89888e4ceac7e52b6aa315db690c98ada622f726b3a4242e9b8d3f",
+				"DiscoKey":   "discokey:00b9780e7c8d9deeaf1a27ce309babca928035af7dd7fa200c57271a67bf820a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35503",
+					"10.65.0.27:35503",
+					"172.17.0.1:35503",
+					"172.18.0.1:35503",
+					"172.19.0.1:35503",
+					"172.20.0.1:35503",
+					"172.21.0.1:35503",
+					"172.22.0.1:35503",
+					"172.23.0.1:35503",
+					"172.24.0.1:35503",
+					"172.25.0.1:35503",
+					"172.26.0.1:35503",
+					"172.27.0.1:35503"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:30:24.35024234Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         156123256026230,
+				"StableID":   "nK3wWQ6iD211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35bbd44adc1e0017f0f3cb5dc15c25172e8e0873f8475470e8716c906e85701c",
+				"DiscoKey":   "discokey:e315d2aa2650c181b0e7e8abe62aed80b5f6a8b39b3f5f590a3a6e81d7994a4e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59133",
+					"10.65.0.27:59133",
+					"172.17.0.1:59133",
+					"172.18.0.1:59133",
+					"172.19.0.1:59133",
+					"172.20.0.1:59133",
+					"172.21.0.1:59133",
+					"172.22.0.1:59133",
+					"172.23.0.1:59133",
+					"172.24.0.1:59133",
+					"172.25.0.1:59133",
+					"172.26.0.1:59133",
+					"172.27.0.1:59133"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:30:24.961232221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8431358078059330,
+				"StableID":   "nsmfXpUaq821CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:63133f6c88593acd3b63105c7176719ce717f2e66b9b7657c0aa3acc4557316d",
+				"DiscoKey":   "discokey:d204d313a545b75f35dbf27c5fd8924b694c32b6d1d7622f8c665bae2c052373",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50334",
+					"10.65.0.27:50334",
+					"172.17.0.1:50334",
+					"172.18.0.1:50334",
+					"172.19.0.1:50334",
+					"172.20.0.1:50334",
+					"172.21.0.1:50334",
+					"172.22.0.1:50334",
+					"172.23.0.1:50334",
+					"172.24.0.1:50334",
+					"172.25.0.1:50334",
+					"172.26.0.1:50334",
+					"172.27.0.1:50334"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:30:25.669266846Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6635437266779190,
+				"StableID":   "nme7HkgCpt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cbf7c7ea6bd03996c13db4de2b558efbbd5cf8536f41cc76424b15a8cce8ed6b",
+				"DiscoKey":   "discokey:b83c63aafa2ac23ca7968015176fdf00a90a94ddc1cc8402ef0b72afc8a78706",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45684",
+					"10.65.0.27:45684",
+					"172.17.0.1:45684",
+					"172.18.0.1:45684",
+					"172.19.0.1:45684",
+					"172.20.0.1:45684",
+					"172.21.0.1:45684",
+					"172.22.0.1:45684",
+					"172.23.0.1:45684",
+					"172.24.0.1:45684",
+					"172.25.0.1:45684",
+					"172.26.0.1:45684",
+					"172.27.0.1:45684"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:30:26.20463116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6048256030654495,
+				"StableID":   "nkqe9wRGEp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a2661c0992e6f6f36c961226b6c951c0324de2a6d2279d7e43c3a6fed43f9652",
+				"KeyExpiry":  "2026-11-09T09:30:26Z",
+				"DiscoKey":   "discokey:3ebad77570ee23f4a75003d66ebe44faa51879ec277d967f1df088231e820c28",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45887",
+					"10.65.0.27:45887",
+					"172.17.0.1:45887",
+					"172.18.0.1:45887",
+					"172.19.0.1:45887",
+					"172.20.0.1:45887",
+					"172.21.0.1:45887",
+					"172.22.0.1:45887",
+					"172.23.0.1:45887",
+					"172.24.0.1:45887",
+					"172.25.0.1:45887",
+					"172.26.0.1:45887",
+					"172.27.0.1:45887"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:30:26.725360455Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8234239497029749,
+				"StableID":   "nvuPXWWJJ721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:180fb2b409872a185fa9447ecfbb845e0154f6c7f143eb6ca09e3d2bd6ddbb17",
+				"KeyExpiry":  "2026-11-09T09:30:27Z",
+				"DiscoKey":   "discokey:7e5bb9a482709932c2f64cb02779a5a9c71b33777a842c47041a0fc713b9587a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50553",
+					"10.65.0.27:50553",
+					"172.17.0.1:50553",
+					"172.18.0.1:50553",
+					"172.19.0.1:50553",
+					"172.20.0.1:50553",
+					"172.21.0.1:50553",
+					"172.22.0.1:50553",
+					"172.23.0.1:50553",
+					"172.24.0.1:50553",
+					"172.25.0.1:50553",
+					"172.26.0.1:50553",
+					"172.27.0.1:50553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:30:27.260403572Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3225617935357335,
+				"StableID":   "nAUbLnWtBS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:05fb5c7def2bd52a36b410573911e9e7309ce75d545fb99011ceb2ed571d5d5d",
+				"KeyExpiry":  "2026-11-09T09:30:27Z",
+				"DiscoKey":   "discokey:0dde8e43d786368333282af84458203134ee89de681daae268aea547302eaa39",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57338",
+					"10.65.0.27:57338",
+					"172.17.0.1:57338",
+					"172.18.0.1:57338",
+					"172.19.0.1:57338",
+					"172.20.0.1:57338",
+					"172.21.0.1:57338",
+					"172.22.0.1:57338",
+					"172.23.0.1:57338",
+					"172.24.0.1:57338",
+					"172.25.0.1:57338",
+					"172.26.0.1:57338",
+					"172.27.0.1:57338"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:30:27.807949242Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2691709711896678": {
+				"ID":          2691709711896678,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7367908405015496,
+				"StableID":   "nw4zXgTwXz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       7367908405015496,
+				"Key":        "nodekey:b5171dd8248b6600e124ab8a373ad2474d1422ebf0a43a7f93e526e1e45ae774",
+				"DiscoKey":   "discokey:32447222761bd26fc98eb5000a8954e03b20b5456e2f40230debc4e3bd71dc5f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44778",
+					"10.65.0.27:44778",
+					"172.17.0.1:44778",
+					"172.18.0.1:44778",
+					"172.19.0.1:44778",
+					"172.20.0.1:44778",
+					"172.21.0.1:44778",
+					"172.22.0.1:44778",
+					"172.23.0.1:44778",
+					"172.24.0.1:44778",
+					"172.25.0.1:44778",
+					"172.26.0.1:44778",
+					"172.27.0.1:44778"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:30:23.04063128Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b5171dd8248b6600e124ab8a373ad2474d1422ebf0a43a7f93e526e1e45ae774",
+			"MachineKey": "mkey:75757ab6de2cb3f822350faa42655f580e6cb6181fc71e81167d064706a89772",
+			"Peers": [{
+				"ID":         3628307374917488,
+				"StableID":   "nwJfAyUGLV11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8587a6f7374ca011a9ac6468627b921cfa75948a6fb3f0b04df5ffc7e4822b5b",
+				"DiscoKey":   "discokey:5291592b301d037d3573ecb86b8ffafda3907780e8ffc5edb50e85035ed66a74",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:60776",
+					"10.65.0.27:60776",
+					"172.17.0.1:60776",
+					"172.18.0.1:60776",
+					"172.19.0.1:60776",
+					"172.20.0.1:60776",
+					"172.21.0.1:60776",
+					"172.22.0.1:60776",
+					"172.23.0.1:60776",
+					"172.24.0.1:60776",
+					"172.25.0.1:60776",
+					"172.26.0.1:60776",
+					"172.27.0.1:60776"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:30:19.604495837Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1493384375532153,
+				"StableID":   "nJPrQAgMfC11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb5bb1cdb0ff33b7e7bee6ec6b139f6fafb9f188c6bab4243677c47cc5a70831",
+				"DiscoKey":   "discokey:13886cbf8a432412327a73ba106d682f72fbde38b2771ab03c66baabdfaee42f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:52709",
+					"10.65.0.27:52709",
+					"172.17.0.1:52709",
+					"172.18.0.1:52709",
+					"172.19.0.1:52709",
+					"172.20.0.1:52709",
+					"172.21.0.1:52709",
+					"172.22.0.1:52709",
+					"172.23.0.1:52709",
+					"172.24.0.1:52709",
+					"172.25.0.1:52709",
+					"172.26.0.1:52709",
+					"172.27.0.1:52709"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:30:20.319592339Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1099277371122160,
+				"StableID":   "ns8Hzq9sa911CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6ead0b971a84bb0155d90e0ebd3eb6e7d7353739feb2acb825c5deb763631d53",
+				"DiscoKey":   "discokey:a4ae1f8f20ee5f9b386feb4b92b080b07ae8d53d1cc019fa7c7761bdb2a7df70",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43004",
+					"10.65.0.27:43004",
+					"172.17.0.1:43004",
+					"172.18.0.1:43004",
+					"172.19.0.1:43004",
+					"172.20.0.1:43004",
+					"172.21.0.1:43004",
+					"172.22.0.1:43004",
+					"172.23.0.1:43004",
+					"172.24.0.1:43004",
+					"172.25.0.1:43004",
+					"172.26.0.1:43004",
+					"172.27.0.1:43004"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:30:20.856238896Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2691709711896678,
+				"StableID":   "ndnyuge52N11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2f0f9aa40c11d6caefbf393a5ae8eeb99f47053abac6b79681f8aa1b67e98769",
+				"DiscoKey":   "discokey:29ee71a95c71f6ed791da21b42c0c819f0b95368406800121696acf5ffca1745",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45143",
+					"10.65.0.27:45143",
+					"172.17.0.1:45143",
+					"172.18.0.1:45143",
+					"172.19.0.1:45143",
+					"172.20.0.1:45143",
+					"172.21.0.1:45143",
+					"172.22.0.1:45143",
+					"172.23.0.1:45143",
+					"172.24.0.1:45143",
+					"172.25.0.1:45143",
+					"172.26.0.1:45143",
+					"172.27.0.1:45143"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:30:21.393986895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         12685843844750,
+				"StableID":   "n9tdafEk6111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e9317595a76d9da92f070ba866cbbfd950bebd0bb2a22da60dd5f548d9e7739",
+				"DiscoKey":   "discokey:20045d9d345983c979fadb65dd0db6620eb191751458cac1582766f33d25be41",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58390",
+					"10.65.0.27:58390",
+					"172.17.0.1:58390",
+					"172.18.0.1:58390",
+					"172.19.0.1:58390",
+					"172.20.0.1:58390",
+					"172.21.0.1:58390",
+					"172.22.0.1:58390",
+					"172.23.0.1:58390",
+					"172.24.0.1:58390",
+					"172.25.0.1:58390",
+					"172.26.0.1:58390",
+					"172.27.0.1:58390"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:30:21.965086659Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         220059800127697,
+				"StableID":   "nJfiyfbfi211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f82d10ad4a8afe9aeee81c4c1dcf49cda2f43da67e83bb43dd02f4616d907911",
+				"DiscoKey":   "discokey:9c598e24bacf2aa5dbcdfa20934c7082c2d423abf9aa422d163284b41be6ee49",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41839",
+					"10.65.0.27:41839",
+					"172.17.0.1:41839",
+					"172.18.0.1:41839",
+					"172.19.0.1:41839",
+					"172.20.0.1:41839",
+					"172.21.0.1:41839",
+					"172.22.0.1:41839",
+					"172.23.0.1:41839",
+					"172.24.0.1:41839",
+					"172.25.0.1:41839",
+					"172.26.0.1:41839",
+					"172.27.0.1:41839"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:30:22.487425695Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5602755481149455,
+				"StableID":   "nJ4o8PtVkk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d8d2db2cb821338ea64e3375fc8e1048d0b9fc371c24e4d176cd629ef522065",
+				"DiscoKey":   "discokey:400d522c5a33d5f017772b6608482cf826411a0f597b22b01e50664e6835e35a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37413",
+					"10.65.0.27:37413",
+					"172.17.0.1:37413",
+					"172.18.0.1:37413",
+					"172.19.0.1:37413",
+					"172.20.0.1:37413",
+					"172.21.0.1:37413",
+					"172.22.0.1:37413",
+					"172.23.0.1:37413",
+					"172.24.0.1:37413",
+					"172.25.0.1:37413",
+					"172.26.0.1:37413",
+					"172.27.0.1:37413"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:30:23.630307934Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7395883338911835,
+				"StableID":   "nYPXeDKckz11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c89610742a89888e4ceac7e52b6aa315db690c98ada622f726b3a4242e9b8d3f",
+				"DiscoKey":   "discokey:00b9780e7c8d9deeaf1a27ce309babca928035af7dd7fa200c57271a67bf820a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35503",
+					"10.65.0.27:35503",
+					"172.17.0.1:35503",
+					"172.18.0.1:35503",
+					"172.19.0.1:35503",
+					"172.20.0.1:35503",
+					"172.21.0.1:35503",
+					"172.22.0.1:35503",
+					"172.23.0.1:35503",
+					"172.24.0.1:35503",
+					"172.25.0.1:35503",
+					"172.26.0.1:35503",
+					"172.27.0.1:35503"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:30:24.35024234Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         156123256026230,
+				"StableID":   "nK3wWQ6iD211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35bbd44adc1e0017f0f3cb5dc15c25172e8e0873f8475470e8716c906e85701c",
+				"DiscoKey":   "discokey:e315d2aa2650c181b0e7e8abe62aed80b5f6a8b39b3f5f590a3a6e81d7994a4e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59133",
+					"10.65.0.27:59133",
+					"172.17.0.1:59133",
+					"172.18.0.1:59133",
+					"172.19.0.1:59133",
+					"172.20.0.1:59133",
+					"172.21.0.1:59133",
+					"172.22.0.1:59133",
+					"172.23.0.1:59133",
+					"172.24.0.1:59133",
+					"172.25.0.1:59133",
+					"172.26.0.1:59133",
+					"172.27.0.1:59133"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:30:24.961232221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8431358078059330,
+				"StableID":   "nsmfXpUaq821CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:63133f6c88593acd3b63105c7176719ce717f2e66b9b7657c0aa3acc4557316d",
+				"DiscoKey":   "discokey:d204d313a545b75f35dbf27c5fd8924b694c32b6d1d7622f8c665bae2c052373",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50334",
+					"10.65.0.27:50334",
+					"172.17.0.1:50334",
+					"172.18.0.1:50334",
+					"172.19.0.1:50334",
+					"172.20.0.1:50334",
+					"172.21.0.1:50334",
+					"172.22.0.1:50334",
+					"172.23.0.1:50334",
+					"172.24.0.1:50334",
+					"172.25.0.1:50334",
+					"172.26.0.1:50334",
+					"172.27.0.1:50334"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:30:25.669266846Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6635437266779190,
+				"StableID":   "nme7HkgCpt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cbf7c7ea6bd03996c13db4de2b558efbbd5cf8536f41cc76424b15a8cce8ed6b",
+				"DiscoKey":   "discokey:b83c63aafa2ac23ca7968015176fdf00a90a94ddc1cc8402ef0b72afc8a78706",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45684",
+					"10.65.0.27:45684",
+					"172.17.0.1:45684",
+					"172.18.0.1:45684",
+					"172.19.0.1:45684",
+					"172.20.0.1:45684",
+					"172.21.0.1:45684",
+					"172.22.0.1:45684",
+					"172.23.0.1:45684",
+					"172.24.0.1:45684",
+					"172.25.0.1:45684",
+					"172.26.0.1:45684",
+					"172.27.0.1:45684"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:30:26.20463116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6048256030654495,
+				"StableID":   "nkqe9wRGEp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a2661c0992e6f6f36c961226b6c951c0324de2a6d2279d7e43c3a6fed43f9652",
+				"KeyExpiry":  "2026-11-09T09:30:26Z",
+				"DiscoKey":   "discokey:3ebad77570ee23f4a75003d66ebe44faa51879ec277d967f1df088231e820c28",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45887",
+					"10.65.0.27:45887",
+					"172.17.0.1:45887",
+					"172.18.0.1:45887",
+					"172.19.0.1:45887",
+					"172.20.0.1:45887",
+					"172.21.0.1:45887",
+					"172.22.0.1:45887",
+					"172.23.0.1:45887",
+					"172.24.0.1:45887",
+					"172.25.0.1:45887",
+					"172.26.0.1:45887",
+					"172.27.0.1:45887"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:30:26.725360455Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8234239497029749,
+				"StableID":   "nvuPXWWJJ721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:180fb2b409872a185fa9447ecfbb845e0154f6c7f143eb6ca09e3d2bd6ddbb17",
+				"KeyExpiry":  "2026-11-09T09:30:27Z",
+				"DiscoKey":   "discokey:7e5bb9a482709932c2f64cb02779a5a9c71b33777a842c47041a0fc713b9587a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50553",
+					"10.65.0.27:50553",
+					"172.17.0.1:50553",
+					"172.18.0.1:50553",
+					"172.19.0.1:50553",
+					"172.20.0.1:50553",
+					"172.21.0.1:50553",
+					"172.22.0.1:50553",
+					"172.23.0.1:50553",
+					"172.24.0.1:50553",
+					"172.25.0.1:50553",
+					"172.26.0.1:50553",
+					"172.27.0.1:50553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:30:27.260403572Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3225617935357335,
+				"StableID":   "nAUbLnWtBS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:05fb5c7def2bd52a36b410573911e9e7309ce75d545fb99011ceb2ed571d5d5d",
+				"KeyExpiry":  "2026-11-09T09:30:27Z",
+				"DiscoKey":   "discokey:0dde8e43d786368333282af84458203134ee89de681daae268aea547302eaa39",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57338",
+					"10.65.0.27:57338",
+					"172.17.0.1:57338",
+					"172.18.0.1:57338",
+					"172.19.0.1:57338",
+					"172.20.0.1:57338",
+					"172.21.0.1:57338",
+					"172.22.0.1:57338",
+					"172.23.0.1:57338",
+					"172.24.0.1:57338",
+					"172.25.0.1:57338",
+					"172.26.0.1:57338",
+					"172.27.0.1:57338"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:30:27.807949242Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7367908405015496": {
+				"ID":          7367908405015496,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7395883338911835,
+				"StableID":   "nYPXeDKckz11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       7395883338911835,
+				"Key":        "nodekey:c89610742a89888e4ceac7e52b6aa315db690c98ada622f726b3a4242e9b8d3f",
+				"DiscoKey":   "discokey:00b9780e7c8d9deeaf1a27ce309babca928035af7dd7fa200c57271a67bf820a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35503",
+					"10.65.0.27:35503",
+					"172.17.0.1:35503",
+					"172.18.0.1:35503",
+					"172.19.0.1:35503",
+					"172.20.0.1:35503",
+					"172.21.0.1:35503",
+					"172.22.0.1:35503",
+					"172.23.0.1:35503",
+					"172.24.0.1:35503",
+					"172.25.0.1:35503",
+					"172.26.0.1:35503",
+					"172.27.0.1:35503"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:30:24.35024234Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c89610742a89888e4ceac7e52b6aa315db690c98ada622f726b3a4242e9b8d3f",
+			"MachineKey": "mkey:3ba5f17cf7f47c9df0932134e81b4967449de6e683bd0fc647bf725ff1a9bc33",
+			"Peers": [{
+				"ID":         3628307374917488,
+				"StableID":   "nwJfAyUGLV11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8587a6f7374ca011a9ac6468627b921cfa75948a6fb3f0b04df5ffc7e4822b5b",
+				"DiscoKey":   "discokey:5291592b301d037d3573ecb86b8ffafda3907780e8ffc5edb50e85035ed66a74",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:60776",
+					"10.65.0.27:60776",
+					"172.17.0.1:60776",
+					"172.18.0.1:60776",
+					"172.19.0.1:60776",
+					"172.20.0.1:60776",
+					"172.21.0.1:60776",
+					"172.22.0.1:60776",
+					"172.23.0.1:60776",
+					"172.24.0.1:60776",
+					"172.25.0.1:60776",
+					"172.26.0.1:60776",
+					"172.27.0.1:60776"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:30:19.604495837Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1493384375532153,
+				"StableID":   "nJPrQAgMfC11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb5bb1cdb0ff33b7e7bee6ec6b139f6fafb9f188c6bab4243677c47cc5a70831",
+				"DiscoKey":   "discokey:13886cbf8a432412327a73ba106d682f72fbde38b2771ab03c66baabdfaee42f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:52709",
+					"10.65.0.27:52709",
+					"172.17.0.1:52709",
+					"172.18.0.1:52709",
+					"172.19.0.1:52709",
+					"172.20.0.1:52709",
+					"172.21.0.1:52709",
+					"172.22.0.1:52709",
+					"172.23.0.1:52709",
+					"172.24.0.1:52709",
+					"172.25.0.1:52709",
+					"172.26.0.1:52709",
+					"172.27.0.1:52709"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:30:20.319592339Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1099277371122160,
+				"StableID":   "ns8Hzq9sa911CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6ead0b971a84bb0155d90e0ebd3eb6e7d7353739feb2acb825c5deb763631d53",
+				"DiscoKey":   "discokey:a4ae1f8f20ee5f9b386feb4b92b080b07ae8d53d1cc019fa7c7761bdb2a7df70",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43004",
+					"10.65.0.27:43004",
+					"172.17.0.1:43004",
+					"172.18.0.1:43004",
+					"172.19.0.1:43004",
+					"172.20.0.1:43004",
+					"172.21.0.1:43004",
+					"172.22.0.1:43004",
+					"172.23.0.1:43004",
+					"172.24.0.1:43004",
+					"172.25.0.1:43004",
+					"172.26.0.1:43004",
+					"172.27.0.1:43004"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:30:20.856238896Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2691709711896678,
+				"StableID":   "ndnyuge52N11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2f0f9aa40c11d6caefbf393a5ae8eeb99f47053abac6b79681f8aa1b67e98769",
+				"DiscoKey":   "discokey:29ee71a95c71f6ed791da21b42c0c819f0b95368406800121696acf5ffca1745",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45143",
+					"10.65.0.27:45143",
+					"172.17.0.1:45143",
+					"172.18.0.1:45143",
+					"172.19.0.1:45143",
+					"172.20.0.1:45143",
+					"172.21.0.1:45143",
+					"172.22.0.1:45143",
+					"172.23.0.1:45143",
+					"172.24.0.1:45143",
+					"172.25.0.1:45143",
+					"172.26.0.1:45143",
+					"172.27.0.1:45143"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:30:21.393986895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         12685843844750,
+				"StableID":   "n9tdafEk6111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e9317595a76d9da92f070ba866cbbfd950bebd0bb2a22da60dd5f548d9e7739",
+				"DiscoKey":   "discokey:20045d9d345983c979fadb65dd0db6620eb191751458cac1582766f33d25be41",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58390",
+					"10.65.0.27:58390",
+					"172.17.0.1:58390",
+					"172.18.0.1:58390",
+					"172.19.0.1:58390",
+					"172.20.0.1:58390",
+					"172.21.0.1:58390",
+					"172.22.0.1:58390",
+					"172.23.0.1:58390",
+					"172.24.0.1:58390",
+					"172.25.0.1:58390",
+					"172.26.0.1:58390",
+					"172.27.0.1:58390"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:30:21.965086659Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         220059800127697,
+				"StableID":   "nJfiyfbfi211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f82d10ad4a8afe9aeee81c4c1dcf49cda2f43da67e83bb43dd02f4616d907911",
+				"DiscoKey":   "discokey:9c598e24bacf2aa5dbcdfa20934c7082c2d423abf9aa422d163284b41be6ee49",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41839",
+					"10.65.0.27:41839",
+					"172.17.0.1:41839",
+					"172.18.0.1:41839",
+					"172.19.0.1:41839",
+					"172.20.0.1:41839",
+					"172.21.0.1:41839",
+					"172.22.0.1:41839",
+					"172.23.0.1:41839",
+					"172.24.0.1:41839",
+					"172.25.0.1:41839",
+					"172.26.0.1:41839",
+					"172.27.0.1:41839"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:30:22.487425695Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7367908405015496,
+				"StableID":   "nw4zXgTwXz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b5171dd8248b6600e124ab8a373ad2474d1422ebf0a43a7f93e526e1e45ae774",
+				"DiscoKey":   "discokey:32447222761bd26fc98eb5000a8954e03b20b5456e2f40230debc4e3bd71dc5f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44778",
+					"10.65.0.27:44778",
+					"172.17.0.1:44778",
+					"172.18.0.1:44778",
+					"172.19.0.1:44778",
+					"172.20.0.1:44778",
+					"172.21.0.1:44778",
+					"172.22.0.1:44778",
+					"172.23.0.1:44778",
+					"172.24.0.1:44778",
+					"172.25.0.1:44778",
+					"172.26.0.1:44778",
+					"172.27.0.1:44778"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:30:23.04063128Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5602755481149455,
+				"StableID":   "nJ4o8PtVkk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d8d2db2cb821338ea64e3375fc8e1048d0b9fc371c24e4d176cd629ef522065",
+				"DiscoKey":   "discokey:400d522c5a33d5f017772b6608482cf826411a0f597b22b01e50664e6835e35a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37413",
+					"10.65.0.27:37413",
+					"172.17.0.1:37413",
+					"172.18.0.1:37413",
+					"172.19.0.1:37413",
+					"172.20.0.1:37413",
+					"172.21.0.1:37413",
+					"172.22.0.1:37413",
+					"172.23.0.1:37413",
+					"172.24.0.1:37413",
+					"172.25.0.1:37413",
+					"172.26.0.1:37413",
+					"172.27.0.1:37413"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:30:23.630307934Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         156123256026230,
+				"StableID":   "nK3wWQ6iD211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35bbd44adc1e0017f0f3cb5dc15c25172e8e0873f8475470e8716c906e85701c",
+				"DiscoKey":   "discokey:e315d2aa2650c181b0e7e8abe62aed80b5f6a8b39b3f5f590a3a6e81d7994a4e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59133",
+					"10.65.0.27:59133",
+					"172.17.0.1:59133",
+					"172.18.0.1:59133",
+					"172.19.0.1:59133",
+					"172.20.0.1:59133",
+					"172.21.0.1:59133",
+					"172.22.0.1:59133",
+					"172.23.0.1:59133",
+					"172.24.0.1:59133",
+					"172.25.0.1:59133",
+					"172.26.0.1:59133",
+					"172.27.0.1:59133"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:30:24.961232221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8431358078059330,
+				"StableID":   "nsmfXpUaq821CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:63133f6c88593acd3b63105c7176719ce717f2e66b9b7657c0aa3acc4557316d",
+				"DiscoKey":   "discokey:d204d313a545b75f35dbf27c5fd8924b694c32b6d1d7622f8c665bae2c052373",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50334",
+					"10.65.0.27:50334",
+					"172.17.0.1:50334",
+					"172.18.0.1:50334",
+					"172.19.0.1:50334",
+					"172.20.0.1:50334",
+					"172.21.0.1:50334",
+					"172.22.0.1:50334",
+					"172.23.0.1:50334",
+					"172.24.0.1:50334",
+					"172.25.0.1:50334",
+					"172.26.0.1:50334",
+					"172.27.0.1:50334"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:30:25.669266846Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6635437266779190,
+				"StableID":   "nme7HkgCpt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cbf7c7ea6bd03996c13db4de2b558efbbd5cf8536f41cc76424b15a8cce8ed6b",
+				"DiscoKey":   "discokey:b83c63aafa2ac23ca7968015176fdf00a90a94ddc1cc8402ef0b72afc8a78706",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45684",
+					"10.65.0.27:45684",
+					"172.17.0.1:45684",
+					"172.18.0.1:45684",
+					"172.19.0.1:45684",
+					"172.20.0.1:45684",
+					"172.21.0.1:45684",
+					"172.22.0.1:45684",
+					"172.23.0.1:45684",
+					"172.24.0.1:45684",
+					"172.25.0.1:45684",
+					"172.26.0.1:45684",
+					"172.27.0.1:45684"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:30:26.20463116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6048256030654495,
+				"StableID":   "nkqe9wRGEp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a2661c0992e6f6f36c961226b6c951c0324de2a6d2279d7e43c3a6fed43f9652",
+				"KeyExpiry":  "2026-11-09T09:30:26Z",
+				"DiscoKey":   "discokey:3ebad77570ee23f4a75003d66ebe44faa51879ec277d967f1df088231e820c28",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45887",
+					"10.65.0.27:45887",
+					"172.17.0.1:45887",
+					"172.18.0.1:45887",
+					"172.19.0.1:45887",
+					"172.20.0.1:45887",
+					"172.21.0.1:45887",
+					"172.22.0.1:45887",
+					"172.23.0.1:45887",
+					"172.24.0.1:45887",
+					"172.25.0.1:45887",
+					"172.26.0.1:45887",
+					"172.27.0.1:45887"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:30:26.725360455Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8234239497029749,
+				"StableID":   "nvuPXWWJJ721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:180fb2b409872a185fa9447ecfbb845e0154f6c7f143eb6ca09e3d2bd6ddbb17",
+				"KeyExpiry":  "2026-11-09T09:30:27Z",
+				"DiscoKey":   "discokey:7e5bb9a482709932c2f64cb02779a5a9c71b33777a842c47041a0fc713b9587a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50553",
+					"10.65.0.27:50553",
+					"172.17.0.1:50553",
+					"172.18.0.1:50553",
+					"172.19.0.1:50553",
+					"172.20.0.1:50553",
+					"172.21.0.1:50553",
+					"172.22.0.1:50553",
+					"172.23.0.1:50553",
+					"172.24.0.1:50553",
+					"172.25.0.1:50553",
+					"172.26.0.1:50553",
+					"172.27.0.1:50553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:30:27.260403572Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3225617935357335,
+				"StableID":   "nAUbLnWtBS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:05fb5c7def2bd52a36b410573911e9e7309ce75d545fb99011ceb2ed571d5d5d",
+				"KeyExpiry":  "2026-11-09T09:30:27Z",
+				"DiscoKey":   "discokey:0dde8e43d786368333282af84458203134ee89de681daae268aea547302eaa39",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57338",
+					"10.65.0.27:57338",
+					"172.17.0.1:57338",
+					"172.18.0.1:57338",
+					"172.19.0.1:57338",
+					"172.20.0.1:57338",
+					"172.21.0.1:57338",
+					"172.22.0.1:57338",
+					"172.23.0.1:57338",
+					"172.24.0.1:57338",
+					"172.25.0.1:57338",
+					"172.26.0.1:57338",
+					"172.27.0.1:57338"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:30:27.807949242Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7395883338911835": {
+				"ID":          7395883338911835,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8234239497029749,
+				"StableID":   "nvuPXWWJJ721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:180fb2b409872a185fa9447ecfbb845e0154f6c7f143eb6ca09e3d2bd6ddbb17",
+				"KeyExpiry":  "2026-11-09T09:30:27Z",
+				"DiscoKey":   "discokey:7e5bb9a482709932c2f64cb02779a5a9c71b33777a842c47041a0fc713b9587a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50553",
+					"10.65.0.27:50553",
+					"172.17.0.1:50553",
+					"172.18.0.1:50553",
+					"172.19.0.1:50553",
+					"172.20.0.1:50553",
+					"172.21.0.1:50553",
+					"172.22.0.1:50553",
+					"172.23.0.1:50553",
+					"172.24.0.1:50553",
+					"172.25.0.1:50553",
+					"172.26.0.1:50553",
+					"172.27.0.1:50553"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:30:27.260403572Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:180fb2b409872a185fa9447ecfbb845e0154f6c7f143eb6ca09e3d2bd6ddbb17",
+			"MachineKey": "mkey:bd48e5981fcc8a3224972d235adf5c0fc50567fa491291d3d0dd8abd050c3e08",
+			"Peers": [{
+				"ID":         3628307374917488,
+				"StableID":   "nwJfAyUGLV11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8587a6f7374ca011a9ac6468627b921cfa75948a6fb3f0b04df5ffc7e4822b5b",
+				"DiscoKey":   "discokey:5291592b301d037d3573ecb86b8ffafda3907780e8ffc5edb50e85035ed66a74",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:60776",
+					"10.65.0.27:60776",
+					"172.17.0.1:60776",
+					"172.18.0.1:60776",
+					"172.19.0.1:60776",
+					"172.20.0.1:60776",
+					"172.21.0.1:60776",
+					"172.22.0.1:60776",
+					"172.23.0.1:60776",
+					"172.24.0.1:60776",
+					"172.25.0.1:60776",
+					"172.26.0.1:60776",
+					"172.27.0.1:60776"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:30:19.604495837Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1493384375532153,
+				"StableID":   "nJPrQAgMfC11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb5bb1cdb0ff33b7e7bee6ec6b139f6fafb9f188c6bab4243677c47cc5a70831",
+				"DiscoKey":   "discokey:13886cbf8a432412327a73ba106d682f72fbde38b2771ab03c66baabdfaee42f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:52709",
+					"10.65.0.27:52709",
+					"172.17.0.1:52709",
+					"172.18.0.1:52709",
+					"172.19.0.1:52709",
+					"172.20.0.1:52709",
+					"172.21.0.1:52709",
+					"172.22.0.1:52709",
+					"172.23.0.1:52709",
+					"172.24.0.1:52709",
+					"172.25.0.1:52709",
+					"172.26.0.1:52709",
+					"172.27.0.1:52709"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:30:20.319592339Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1099277371122160,
+				"StableID":   "ns8Hzq9sa911CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6ead0b971a84bb0155d90e0ebd3eb6e7d7353739feb2acb825c5deb763631d53",
+				"DiscoKey":   "discokey:a4ae1f8f20ee5f9b386feb4b92b080b07ae8d53d1cc019fa7c7761bdb2a7df70",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43004",
+					"10.65.0.27:43004",
+					"172.17.0.1:43004",
+					"172.18.0.1:43004",
+					"172.19.0.1:43004",
+					"172.20.0.1:43004",
+					"172.21.0.1:43004",
+					"172.22.0.1:43004",
+					"172.23.0.1:43004",
+					"172.24.0.1:43004",
+					"172.25.0.1:43004",
+					"172.26.0.1:43004",
+					"172.27.0.1:43004"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:30:20.856238896Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2691709711896678,
+				"StableID":   "ndnyuge52N11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2f0f9aa40c11d6caefbf393a5ae8eeb99f47053abac6b79681f8aa1b67e98769",
+				"DiscoKey":   "discokey:29ee71a95c71f6ed791da21b42c0c819f0b95368406800121696acf5ffca1745",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45143",
+					"10.65.0.27:45143",
+					"172.17.0.1:45143",
+					"172.18.0.1:45143",
+					"172.19.0.1:45143",
+					"172.20.0.1:45143",
+					"172.21.0.1:45143",
+					"172.22.0.1:45143",
+					"172.23.0.1:45143",
+					"172.24.0.1:45143",
+					"172.25.0.1:45143",
+					"172.26.0.1:45143",
+					"172.27.0.1:45143"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:30:21.393986895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         12685843844750,
+				"StableID":   "n9tdafEk6111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e9317595a76d9da92f070ba866cbbfd950bebd0bb2a22da60dd5f548d9e7739",
+				"DiscoKey":   "discokey:20045d9d345983c979fadb65dd0db6620eb191751458cac1582766f33d25be41",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58390",
+					"10.65.0.27:58390",
+					"172.17.0.1:58390",
+					"172.18.0.1:58390",
+					"172.19.0.1:58390",
+					"172.20.0.1:58390",
+					"172.21.0.1:58390",
+					"172.22.0.1:58390",
+					"172.23.0.1:58390",
+					"172.24.0.1:58390",
+					"172.25.0.1:58390",
+					"172.26.0.1:58390",
+					"172.27.0.1:58390"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:30:21.965086659Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         220059800127697,
+				"StableID":   "nJfiyfbfi211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f82d10ad4a8afe9aeee81c4c1dcf49cda2f43da67e83bb43dd02f4616d907911",
+				"DiscoKey":   "discokey:9c598e24bacf2aa5dbcdfa20934c7082c2d423abf9aa422d163284b41be6ee49",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41839",
+					"10.65.0.27:41839",
+					"172.17.0.1:41839",
+					"172.18.0.1:41839",
+					"172.19.0.1:41839",
+					"172.20.0.1:41839",
+					"172.21.0.1:41839",
+					"172.22.0.1:41839",
+					"172.23.0.1:41839",
+					"172.24.0.1:41839",
+					"172.25.0.1:41839",
+					"172.26.0.1:41839",
+					"172.27.0.1:41839"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:30:22.487425695Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7367908405015496,
+				"StableID":   "nw4zXgTwXz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b5171dd8248b6600e124ab8a373ad2474d1422ebf0a43a7f93e526e1e45ae774",
+				"DiscoKey":   "discokey:32447222761bd26fc98eb5000a8954e03b20b5456e2f40230debc4e3bd71dc5f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44778",
+					"10.65.0.27:44778",
+					"172.17.0.1:44778",
+					"172.18.0.1:44778",
+					"172.19.0.1:44778",
+					"172.20.0.1:44778",
+					"172.21.0.1:44778",
+					"172.22.0.1:44778",
+					"172.23.0.1:44778",
+					"172.24.0.1:44778",
+					"172.25.0.1:44778",
+					"172.26.0.1:44778",
+					"172.27.0.1:44778"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:30:23.04063128Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5602755481149455,
+				"StableID":   "nJ4o8PtVkk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d8d2db2cb821338ea64e3375fc8e1048d0b9fc371c24e4d176cd629ef522065",
+				"DiscoKey":   "discokey:400d522c5a33d5f017772b6608482cf826411a0f597b22b01e50664e6835e35a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37413",
+					"10.65.0.27:37413",
+					"172.17.0.1:37413",
+					"172.18.0.1:37413",
+					"172.19.0.1:37413",
+					"172.20.0.1:37413",
+					"172.21.0.1:37413",
+					"172.22.0.1:37413",
+					"172.23.0.1:37413",
+					"172.24.0.1:37413",
+					"172.25.0.1:37413",
+					"172.26.0.1:37413",
+					"172.27.0.1:37413"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:30:23.630307934Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7395883338911835,
+				"StableID":   "nYPXeDKckz11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c89610742a89888e4ceac7e52b6aa315db690c98ada622f726b3a4242e9b8d3f",
+				"DiscoKey":   "discokey:00b9780e7c8d9deeaf1a27ce309babca928035af7dd7fa200c57271a67bf820a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35503",
+					"10.65.0.27:35503",
+					"172.17.0.1:35503",
+					"172.18.0.1:35503",
+					"172.19.0.1:35503",
+					"172.20.0.1:35503",
+					"172.21.0.1:35503",
+					"172.22.0.1:35503",
+					"172.23.0.1:35503",
+					"172.24.0.1:35503",
+					"172.25.0.1:35503",
+					"172.26.0.1:35503",
+					"172.27.0.1:35503"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:30:24.35024234Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         156123256026230,
+				"StableID":   "nK3wWQ6iD211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35bbd44adc1e0017f0f3cb5dc15c25172e8e0873f8475470e8716c906e85701c",
+				"DiscoKey":   "discokey:e315d2aa2650c181b0e7e8abe62aed80b5f6a8b39b3f5f590a3a6e81d7994a4e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59133",
+					"10.65.0.27:59133",
+					"172.17.0.1:59133",
+					"172.18.0.1:59133",
+					"172.19.0.1:59133",
+					"172.20.0.1:59133",
+					"172.21.0.1:59133",
+					"172.22.0.1:59133",
+					"172.23.0.1:59133",
+					"172.24.0.1:59133",
+					"172.25.0.1:59133",
+					"172.26.0.1:59133",
+					"172.27.0.1:59133"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:30:24.961232221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8431358078059330,
+				"StableID":   "nsmfXpUaq821CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:63133f6c88593acd3b63105c7176719ce717f2e66b9b7657c0aa3acc4557316d",
+				"DiscoKey":   "discokey:d204d313a545b75f35dbf27c5fd8924b694c32b6d1d7622f8c665bae2c052373",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50334",
+					"10.65.0.27:50334",
+					"172.17.0.1:50334",
+					"172.18.0.1:50334",
+					"172.19.0.1:50334",
+					"172.20.0.1:50334",
+					"172.21.0.1:50334",
+					"172.22.0.1:50334",
+					"172.23.0.1:50334",
+					"172.24.0.1:50334",
+					"172.25.0.1:50334",
+					"172.26.0.1:50334",
+					"172.27.0.1:50334"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:30:25.669266846Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6635437266779190,
+				"StableID":   "nme7HkgCpt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cbf7c7ea6bd03996c13db4de2b558efbbd5cf8536f41cc76424b15a8cce8ed6b",
+				"DiscoKey":   "discokey:b83c63aafa2ac23ca7968015176fdf00a90a94ddc1cc8402ef0b72afc8a78706",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45684",
+					"10.65.0.27:45684",
+					"172.17.0.1:45684",
+					"172.18.0.1:45684",
+					"172.19.0.1:45684",
+					"172.20.0.1:45684",
+					"172.21.0.1:45684",
+					"172.22.0.1:45684",
+					"172.23.0.1:45684",
+					"172.24.0.1:45684",
+					"172.25.0.1:45684",
+					"172.26.0.1:45684",
+					"172.27.0.1:45684"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:30:26.20463116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6048256030654495,
+				"StableID":   "nkqe9wRGEp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a2661c0992e6f6f36c961226b6c951c0324de2a6d2279d7e43c3a6fed43f9652",
+				"KeyExpiry":  "2026-11-09T09:30:26Z",
+				"DiscoKey":   "discokey:3ebad77570ee23f4a75003d66ebe44faa51879ec277d967f1df088231e820c28",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45887",
+					"10.65.0.27:45887",
+					"172.17.0.1:45887",
+					"172.18.0.1:45887",
+					"172.19.0.1:45887",
+					"172.20.0.1:45887",
+					"172.21.0.1:45887",
+					"172.22.0.1:45887",
+					"172.23.0.1:45887",
+					"172.24.0.1:45887",
+					"172.25.0.1:45887",
+					"172.26.0.1:45887",
+					"172.27.0.1:45887"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:30:26.725360455Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3225617935357335,
+				"StableID":   "nAUbLnWtBS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:05fb5c7def2bd52a36b410573911e9e7309ce75d545fb99011ceb2ed571d5d5d",
+				"KeyExpiry":  "2026-11-09T09:30:27Z",
+				"DiscoKey":   "discokey:0dde8e43d786368333282af84458203134ee89de681daae268aea547302eaa39",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57338",
+					"10.65.0.27:57338",
+					"172.17.0.1:57338",
+					"172.18.0.1:57338",
+					"172.19.0.1:57338",
+					"172.20.0.1:57338",
+					"172.21.0.1:57338",
+					"172.22.0.1:57338",
+					"172.23.0.1:57338",
+					"172.24.0.1:57338",
+					"172.25.0.1:57338",
+					"172.26.0.1:57338",
+					"172.27.0.1:57338"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:30:27.807949242Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         156123256026230,
+				"StableID":   "nK3wWQ6iD211CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       156123256026230,
+				"Key":        "nodekey:35bbd44adc1e0017f0f3cb5dc15c25172e8e0873f8475470e8716c906e85701c",
+				"DiscoKey":   "discokey:e315d2aa2650c181b0e7e8abe62aed80b5f6a8b39b3f5f590a3a6e81d7994a4e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:59133",
+					"10.65.0.27:59133",
+					"172.17.0.1:59133",
+					"172.18.0.1:59133",
+					"172.19.0.1:59133",
+					"172.20.0.1:59133",
+					"172.21.0.1:59133",
+					"172.22.0.1:59133",
+					"172.23.0.1:59133",
+					"172.24.0.1:59133",
+					"172.25.0.1:59133",
+					"172.26.0.1:59133",
+					"172.27.0.1:59133"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:30:24.961232221Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:35bbd44adc1e0017f0f3cb5dc15c25172e8e0873f8475470e8716c906e85701c",
+			"MachineKey": "mkey:65e9067aa197f79f8903cd68b0d43a899472813b219cc5697e6a026b67b1475a",
+			"Peers": [{
+				"ID":         3628307374917488,
+				"StableID":   "nwJfAyUGLV11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8587a6f7374ca011a9ac6468627b921cfa75948a6fb3f0b04df5ffc7e4822b5b",
+				"DiscoKey":   "discokey:5291592b301d037d3573ecb86b8ffafda3907780e8ffc5edb50e85035ed66a74",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:60776",
+					"10.65.0.27:60776",
+					"172.17.0.1:60776",
+					"172.18.0.1:60776",
+					"172.19.0.1:60776",
+					"172.20.0.1:60776",
+					"172.21.0.1:60776",
+					"172.22.0.1:60776",
+					"172.23.0.1:60776",
+					"172.24.0.1:60776",
+					"172.25.0.1:60776",
+					"172.26.0.1:60776",
+					"172.27.0.1:60776"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:30:19.604495837Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1493384375532153,
+				"StableID":   "nJPrQAgMfC11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb5bb1cdb0ff33b7e7bee6ec6b139f6fafb9f188c6bab4243677c47cc5a70831",
+				"DiscoKey":   "discokey:13886cbf8a432412327a73ba106d682f72fbde38b2771ab03c66baabdfaee42f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:52709",
+					"10.65.0.27:52709",
+					"172.17.0.1:52709",
+					"172.18.0.1:52709",
+					"172.19.0.1:52709",
+					"172.20.0.1:52709",
+					"172.21.0.1:52709",
+					"172.22.0.1:52709",
+					"172.23.0.1:52709",
+					"172.24.0.1:52709",
+					"172.25.0.1:52709",
+					"172.26.0.1:52709",
+					"172.27.0.1:52709"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:30:20.319592339Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1099277371122160,
+				"StableID":   "ns8Hzq9sa911CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6ead0b971a84bb0155d90e0ebd3eb6e7d7353739feb2acb825c5deb763631d53",
+				"DiscoKey":   "discokey:a4ae1f8f20ee5f9b386feb4b92b080b07ae8d53d1cc019fa7c7761bdb2a7df70",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:43004",
+					"10.65.0.27:43004",
+					"172.17.0.1:43004",
+					"172.18.0.1:43004",
+					"172.19.0.1:43004",
+					"172.20.0.1:43004",
+					"172.21.0.1:43004",
+					"172.22.0.1:43004",
+					"172.23.0.1:43004",
+					"172.24.0.1:43004",
+					"172.25.0.1:43004",
+					"172.26.0.1:43004",
+					"172.27.0.1:43004"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:30:20.856238896Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2691709711896678,
+				"StableID":   "ndnyuge52N11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2f0f9aa40c11d6caefbf393a5ae8eeb99f47053abac6b79681f8aa1b67e98769",
+				"DiscoKey":   "discokey:29ee71a95c71f6ed791da21b42c0c819f0b95368406800121696acf5ffca1745",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:45143",
+					"10.65.0.27:45143",
+					"172.17.0.1:45143",
+					"172.18.0.1:45143",
+					"172.19.0.1:45143",
+					"172.20.0.1:45143",
+					"172.21.0.1:45143",
+					"172.22.0.1:45143",
+					"172.23.0.1:45143",
+					"172.24.0.1:45143",
+					"172.25.0.1:45143",
+					"172.26.0.1:45143",
+					"172.27.0.1:45143"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:30:21.393986895Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         12685843844750,
+				"StableID":   "n9tdafEk6111CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e9317595a76d9da92f070ba866cbbfd950bebd0bb2a22da60dd5f548d9e7739",
+				"DiscoKey":   "discokey:20045d9d345983c979fadb65dd0db6620eb191751458cac1582766f33d25be41",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:58390",
+					"10.65.0.27:58390",
+					"172.17.0.1:58390",
+					"172.18.0.1:58390",
+					"172.19.0.1:58390",
+					"172.20.0.1:58390",
+					"172.21.0.1:58390",
+					"172.22.0.1:58390",
+					"172.23.0.1:58390",
+					"172.24.0.1:58390",
+					"172.25.0.1:58390",
+					"172.26.0.1:58390",
+					"172.27.0.1:58390"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:30:21.965086659Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         220059800127697,
+				"StableID":   "nJfiyfbfi211CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f82d10ad4a8afe9aeee81c4c1dcf49cda2f43da67e83bb43dd02f4616d907911",
+				"DiscoKey":   "discokey:9c598e24bacf2aa5dbcdfa20934c7082c2d423abf9aa422d163284b41be6ee49",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:41839",
+					"10.65.0.27:41839",
+					"172.17.0.1:41839",
+					"172.18.0.1:41839",
+					"172.19.0.1:41839",
+					"172.20.0.1:41839",
+					"172.21.0.1:41839",
+					"172.22.0.1:41839",
+					"172.23.0.1:41839",
+					"172.24.0.1:41839",
+					"172.25.0.1:41839",
+					"172.26.0.1:41839",
+					"172.27.0.1:41839"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:30:22.487425695Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7367908405015496,
+				"StableID":   "nw4zXgTwXz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b5171dd8248b6600e124ab8a373ad2474d1422ebf0a43a7f93e526e1e45ae774",
+				"DiscoKey":   "discokey:32447222761bd26fc98eb5000a8954e03b20b5456e2f40230debc4e3bd71dc5f",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44778",
+					"10.65.0.27:44778",
+					"172.17.0.1:44778",
+					"172.18.0.1:44778",
+					"172.19.0.1:44778",
+					"172.20.0.1:44778",
+					"172.21.0.1:44778",
+					"172.22.0.1:44778",
+					"172.23.0.1:44778",
+					"172.24.0.1:44778",
+					"172.25.0.1:44778",
+					"172.26.0.1:44778",
+					"172.27.0.1:44778"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:30:23.04063128Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5602755481149455,
+				"StableID":   "nJ4o8PtVkk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4d8d2db2cb821338ea64e3375fc8e1048d0b9fc371c24e4d176cd629ef522065",
+				"DiscoKey":   "discokey:400d522c5a33d5f017772b6608482cf826411a0f597b22b01e50664e6835e35a",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37413",
+					"10.65.0.27:37413",
+					"172.17.0.1:37413",
+					"172.18.0.1:37413",
+					"172.19.0.1:37413",
+					"172.20.0.1:37413",
+					"172.21.0.1:37413",
+					"172.22.0.1:37413",
+					"172.23.0.1:37413",
+					"172.24.0.1:37413",
+					"172.25.0.1:37413",
+					"172.26.0.1:37413",
+					"172.27.0.1:37413"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:30:23.630307934Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7395883338911835,
+				"StableID":   "nYPXeDKckz11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c89610742a89888e4ceac7e52b6aa315db690c98ada622f726b3a4242e9b8d3f",
+				"DiscoKey":   "discokey:00b9780e7c8d9deeaf1a27ce309babca928035af7dd7fa200c57271a67bf820a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35503",
+					"10.65.0.27:35503",
+					"172.17.0.1:35503",
+					"172.18.0.1:35503",
+					"172.19.0.1:35503",
+					"172.20.0.1:35503",
+					"172.21.0.1:35503",
+					"172.22.0.1:35503",
+					"172.23.0.1:35503",
+					"172.24.0.1:35503",
+					"172.25.0.1:35503",
+					"172.26.0.1:35503",
+					"172.27.0.1:35503"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:30:24.35024234Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8431358078059330,
+				"StableID":   "nsmfXpUaq821CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:63133f6c88593acd3b63105c7176719ce717f2e66b9b7657c0aa3acc4557316d",
+				"DiscoKey":   "discokey:d204d313a545b75f35dbf27c5fd8924b694c32b6d1d7622f8c665bae2c052373",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50334",
+					"10.65.0.27:50334",
+					"172.17.0.1:50334",
+					"172.18.0.1:50334",
+					"172.19.0.1:50334",
+					"172.20.0.1:50334",
+					"172.21.0.1:50334",
+					"172.22.0.1:50334",
+					"172.23.0.1:50334",
+					"172.24.0.1:50334",
+					"172.25.0.1:50334",
+					"172.26.0.1:50334",
+					"172.27.0.1:50334"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:30:25.669266846Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6635437266779190,
+				"StableID":   "nme7HkgCpt11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cbf7c7ea6bd03996c13db4de2b558efbbd5cf8536f41cc76424b15a8cce8ed6b",
+				"DiscoKey":   "discokey:b83c63aafa2ac23ca7968015176fdf00a90a94ddc1cc8402ef0b72afc8a78706",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45684",
+					"10.65.0.27:45684",
+					"172.17.0.1:45684",
+					"172.18.0.1:45684",
+					"172.19.0.1:45684",
+					"172.20.0.1:45684",
+					"172.21.0.1:45684",
+					"172.22.0.1:45684",
+					"172.23.0.1:45684",
+					"172.24.0.1:45684",
+					"172.25.0.1:45684",
+					"172.26.0.1:45684",
+					"172.27.0.1:45684"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:30:26.20463116Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6048256030654495,
+				"StableID":   "nkqe9wRGEp11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:a2661c0992e6f6f36c961226b6c951c0324de2a6d2279d7e43c3a6fed43f9652",
+				"KeyExpiry":  "2026-11-09T09:30:26Z",
+				"DiscoKey":   "discokey:3ebad77570ee23f4a75003d66ebe44faa51879ec277d967f1df088231e820c28",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:45887",
+					"10.65.0.27:45887",
+					"172.17.0.1:45887",
+					"172.18.0.1:45887",
+					"172.19.0.1:45887",
+					"172.20.0.1:45887",
+					"172.21.0.1:45887",
+					"172.22.0.1:45887",
+					"172.23.0.1:45887",
+					"172.24.0.1:45887",
+					"172.25.0.1:45887",
+					"172.26.0.1:45887",
+					"172.27.0.1:45887"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:30:26.725360455Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8234239497029749,
+				"StableID":   "nvuPXWWJJ721CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:180fb2b409872a185fa9447ecfbb845e0154f6c7f143eb6ca09e3d2bd6ddbb17",
+				"KeyExpiry":  "2026-11-09T09:30:27Z",
+				"DiscoKey":   "discokey:7e5bb9a482709932c2f64cb02779a5a9c71b33777a842c47041a0fc713b9587a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:50553",
+					"10.65.0.27:50553",
+					"172.17.0.1:50553",
+					"172.18.0.1:50553",
+					"172.19.0.1:50553",
+					"172.20.0.1:50553",
+					"172.21.0.1:50553",
+					"172.22.0.1:50553",
+					"172.23.0.1:50553",
+					"172.24.0.1:50553",
+					"172.25.0.1:50553",
+					"172.26.0.1:50553",
+					"172.27.0.1:50553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:30:27.260403572Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3225617935357335,
+				"StableID":   "nAUbLnWtBS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:05fb5c7def2bd52a36b410573911e9e7309ce75d545fb99011ceb2ed571d5d5d",
+				"KeyExpiry":  "2026-11-09T09:30:27Z",
+				"DiscoKey":   "discokey:0dde8e43d786368333282af84458203134ee89de681daae268aea547302eaa39",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57338",
+					"10.65.0.27:57338",
+					"172.17.0.1:57338",
+					"172.18.0.1:57338",
+					"172.19.0.1:57338",
+					"172.20.0.1:57338",
+					"172.21.0.1:57338",
+					"172.22.0.1:57338",
+					"172.23.0.1:57338",
+					"172.24.0.1:57338",
+					"172.25.0.1:57338",
+					"172.26.0.1:57338",
+					"172.27.0.1:57338"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:30:27.807949242Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "156123256026230": {
+				"ID":          156123256026230,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/sshtest_results/sshtest-group-as-src.hujson
+++ b/hscontrol/policy/v2/testdata/sshtest_results/sshtest-group-as-src.hujson
@@ -1,0 +1,20105 @@
+// sshtest-group-as-src
+//
+// group as ssh src, member as sshTests src
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T18:40:10Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "sshtest-group-as-src",
+	"description":    "group as ssh src, member as sshTests src",
+	"category":       "sshtest",
+	"captured_at":    "2026-05-12T18:40:10.876022886Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                       \n  \n                                                                   \n{\n\t\"category\":    \"sshtest\",\n\t\"description\": \"group as ssh src, member as sshTests src\",\n\t\"id\":          \"sshtest-group-as-src\",\n\t\"policy\": {\"groups\": {\n\t\t\"group:admins\":     [\"odin@example.com\"],\n\t\t\"group:developers\": [\"thor@example.org\", \"odin@example.com\"]\n\t}, \"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"group:developers\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"sshTests\": [{\n\t\t\"accept\": [\"root\"],\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    \"thor@example.org\"\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/sshtest/sshtest-group-as-src.hujson",
+		"full_policy": {
+			"groups": {
+				"group:admins":     ["odin@example.com"],
+				"group:developers": ["thor@example.org", "odin@example.com"]
+			},
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["group:developers"],
+				"users":  ["root"]
+			}],
+			"sshTests":  [{"accept": ["root"], "dst": ["tag:server"], "src": "thor@example.org"}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4603542815329677,
+				"StableID":   "ngLwVHGxwc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       4603542815329677,
+				"Key":        "nodekey:b6772d3f4f8c0277eb067251a7a11c1ca48be9383ab8f9feeb2159dfd1340133",
+				"DiscoKey":   "discokey:eafa42a5e1acc4a572d7bded1f741a136106973ddcad2512450c65aed5856632",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46841",
+					"10.65.0.27:46841",
+					"172.17.0.1:46841",
+					"172.19.0.1:46841",
+					"172.20.0.1:46841"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:40:19.767892007Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b6772d3f4f8c0277eb067251a7a11c1ca48be9383ab8f9feeb2159dfd1340133",
+			"MachineKey": "mkey:58cd716f6cc3d03d2a2640beed3f2c40de4cab6b3e3e0fb24affb5ed76d06841",
+			"Peers": [{
+				"ID":         5809610132252533,
+				"StableID":   "nWB6KCcBNn11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:44695cde7e73508dba2bd8befe90c656980ff2212991b1934e7072331683fb6b",
+				"DiscoKey":   "discokey:0d4573f14e3c344fbc90eb10958d36edd9955ae3047039d02191874cbdab916c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54897",
+					"10.65.0.27:54897",
+					"172.17.0.1:54897",
+					"172.19.0.1:54897",
+					"172.20.0.1:54897"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:40:13.638267875Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1181865146313478,
+				"StableID":   "nsdcsQbGEA11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e65ba3ec30ccbae668ef978abbf8cc44875e8b5e68ab460515545879e1a5a56b",
+				"DiscoKey":   "discokey:3d081a32ff54c3488064f9e7bead5817b1904419e350dbceaa5225d3bf0d166f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35550",
+					"10.65.0.27:35550",
+					"172.17.0.1:35550",
+					"172.19.0.1:35550",
+					"172.20.0.1:35550"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:40:14.370485639Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8765044338174851,
+				"StableID":   "nxPTgQrhSB21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07f88ef1a6ee16139d70776f6c79c43d3c0f159d0acc375ccf84890f6968fc6c",
+				"DiscoKey":   "discokey:0761a417033fdab0b74c4a98efb5634889f555dd4be46886560757101db1510a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46604",
+					"10.65.0.27:46604",
+					"172.17.0.1:46604",
+					"172.19.0.1:46604",
+					"172.20.0.1:46604"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:40:14.915495854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7221292549266636,
+				"StableID":   "n3ebRP7YPy11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:807d4656cf5f0de044b8fffc549d13f641cb5964f6be862be6d02d60acf22044",
+				"DiscoKey":   "discokey:2233bb766602a51ab4b19e2e0fcb088137c70a74a05a0c9ae199f04a630f461d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56553",
+					"10.65.0.27:56553",
+					"172.17.0.1:56553",
+					"172.19.0.1:56553",
+					"172.20.0.1:56553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:40:15.458217934Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6902047361726117,
+				"StableID":   "nn9VQf5xtv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e13f79fa76b39e38e728cf4361adb106ef81443c278963f725dd4b62aa30726",
+				"DiscoKey":   "discokey:4123e2e1b33bf53671b9a9658556761435158c547f58ac0763032242f737ac74",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53925",
+					"10.65.0.27:53925",
+					"172.17.0.1:53925",
+					"172.19.0.1:53925",
+					"172.20.0.1:53925"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:40:16.023521426Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3721486791053520,
+				"StableID":   "njSN6Z9U4W11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd11a17ab1d3191b175630bd3c34ae8d978a177bd6491fed944c2f9c78470d3c",
+				"DiscoKey":   "discokey:64bfbe357754820ce98e041d10af1b50fe556838b9dfdcf6225025893137dc3b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33268",
+					"10.65.0.27:33268",
+					"172.17.0.1:33268",
+					"172.19.0.1:33268",
+					"172.20.0.1:33268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:40:16.538744124Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6021417669190818,
+				"StableID":   "nMAv33S72p11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:59bf9e80cb4344b001641d3b749fabd176d151635d7c223f75c231f9d261f609",
+				"DiscoKey":   "discokey:a0667d872c772650af20b18bca3412d6d5ba910282a7c64cf8ec1c3e1d9b6258",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44934",
+					"10.65.0.27:44934",
+					"172.17.0.1:44934",
+					"172.19.0.1:44934",
+					"172.20.0.1:44934"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:40:17.080857195Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1412060730063056,
+				"StableID":   "nbgmLaSX2C11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:259ab860832152671856b7872467106d20929910142f1fa8a65ae7600e98c775",
+				"DiscoKey":   "discokey:b0bb816e222f653ea8e7b163bbf764e9d55ec56dd1ed4598e42c83a7050e1b6e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:32970",
+					"10.65.0.27:32970",
+					"172.17.0.1:32970",
+					"172.19.0.1:32970",
+					"172.20.0.1:32970"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:40:17.619990081Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4407851505619092,
+				"StableID":   "nKEFaWnKRb11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5773e1674f6b2e54984c6b8ced707ed0852017f8a14c7c01629398a7d6df3801",
+				"DiscoKey":   "discokey:9f408b0536ae1d44dfaae1cbb4e9cffa9653e973d26fc30f0cb8b34c4b3dac52",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:54117",
+					"10.65.0.27:54117",
+					"172.17.0.1:54117",
+					"172.19.0.1:54117",
+					"172.20.0.1:54117"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:40:18.174260601Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3423678238263718,
+				"StableID":   "nuCe5sDbjT11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7fb5861c7b87af318b08e7fd2fdcbc8cf68c9f3e9c075139f0ed6facf0e5d0f",
+				"DiscoKey":   "discokey:c6b73bc68432bbc3725ac49e95241f04619d9ad9c8c8fbe5e7631eb76b4f470e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60525",
+					"10.65.0.27:60525",
+					"172.17.0.1:60525",
+					"172.19.0.1:60525",
+					"172.20.0.1:60525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:40:18.679974271Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1198495343544994,
+				"StableID":   "nHCNTYSoMA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3cc1eafed253c7985ff23a31f91c84fef02a5b5c2db2aba6c030807ff9397322",
+				"DiscoKey":   "discokey:ee50d9165332537843efb62f32aa634aadeebc2e77343ca79925385bfec0b67c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:52213",
+					"10.65.0.27:52213",
+					"172.17.0.1:52213",
+					"172.19.0.1:52213",
+					"172.20.0.1:52213"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:40:19.251637105Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8606217454180840,
+				"StableID":   "n5XVprjmCA21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:26e24b58894b54af76d52c1cf10f71a67e70454e0d74ddef424636494e3f8768",
+				"KeyExpiry":  "2026-11-08T18:40:20Z",
+				"DiscoKey":   "discokey:1fcf8cb6f2f03c92d7cc80cfaa1999d28386b56d62372e5f9d6e1743e1eebe4b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:39624",
+					"10.65.0.27:39624",
+					"172.17.0.1:39624",
+					"172.19.0.1:39624",
+					"172.20.0.1:39624"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:40:20.30664337Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1481034582966440,
+				"StableID":   "nmurXVGmZC11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ce5cafb20e8f464fd7309cae65831e887be244036dc4e8219bebd1c7dc384f00",
+				"KeyExpiry":  "2026-11-08T18:40:20Z",
+				"DiscoKey":   "discokey:c752cbc612b4813b932ca90b1ac2fcfdafe3488a98f6c0140f000e4a87192c3a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59063",
+					"10.65.0.27:59063",
+					"172.17.0.1:59063",
+					"172.19.0.1:59063",
+					"172.20.0.1:59063"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:40:20.848044346Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3239946332099071,
+				"StableID":   "nYwAhytNJS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fe01efeba5571b10bba7fc07d7bed59a693a9381a66233430b70eacf068a513b",
+				"KeyExpiry":  "2026-11-08T18:40:21Z",
+				"DiscoKey":   "discokey:a08f2c4c494ca9deb14be10a7ee716e89cf4fb18a9342be3075960b3d1992a5e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57350",
+					"10.65.0.27:57350",
+					"172.17.0.1:57350",
+					"172.19.0.1:57350",
+					"172.20.0.1:57350"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:40:21.392723113Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{"principals": [
+				{"nodeIP": "100.64.0.17"},
+				{"nodeIP": "100.64.0.19"},
+				{"nodeIP": "fd7a:115c:a1e0::11"},
+				{"nodeIP": "fd7a:115c:a1e0::13"}
+			], "sshUsers": {"root": "root"}, "action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4603542815329677": {
+				"ID":          4603542815329677,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		},
+		"ssh_rules": [{"principals": [
+			{"nodeIP": "100.64.0.17"},
+			{"nodeIP": "100.64.0.19"},
+			{"nodeIP": "fd7a:115c:a1e0::11"},
+			{"nodeIP": "fd7a:115c:a1e0::13"}
+		], "sshUsers": {"root": "root"}, "action": {
+			"accept":                    true,
+			"allowAgentForwarding":      true,
+			"allowLocalPortForwarding":  true,
+			"allowRemotePortForwarding": true
+		}}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3721486791053520,
+				"StableID":   "njSN6Z9U4W11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       3721486791053520,
+				"Key":        "nodekey:cd11a17ab1d3191b175630bd3c34ae8d978a177bd6491fed944c2f9c78470d3c",
+				"DiscoKey":   "discokey:64bfbe357754820ce98e041d10af1b50fe556838b9dfdcf6225025893137dc3b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33268",
+					"10.65.0.27:33268",
+					"172.17.0.1:33268",
+					"172.19.0.1:33268",
+					"172.20.0.1:33268"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:40:16.538744124Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:cd11a17ab1d3191b175630bd3c34ae8d978a177bd6491fed944c2f9c78470d3c",
+			"MachineKey": "mkey:648d3593613fd5bda6d0f067615474a289b143a1ba6d47e752167c2c22d6b717",
+			"Peers": [{
+				"ID":         5809610132252533,
+				"StableID":   "nWB6KCcBNn11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:44695cde7e73508dba2bd8befe90c656980ff2212991b1934e7072331683fb6b",
+				"DiscoKey":   "discokey:0d4573f14e3c344fbc90eb10958d36edd9955ae3047039d02191874cbdab916c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54897",
+					"10.65.0.27:54897",
+					"172.17.0.1:54897",
+					"172.19.0.1:54897",
+					"172.20.0.1:54897"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:40:13.638267875Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1181865146313478,
+				"StableID":   "nsdcsQbGEA11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e65ba3ec30ccbae668ef978abbf8cc44875e8b5e68ab460515545879e1a5a56b",
+				"DiscoKey":   "discokey:3d081a32ff54c3488064f9e7bead5817b1904419e350dbceaa5225d3bf0d166f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35550",
+					"10.65.0.27:35550",
+					"172.17.0.1:35550",
+					"172.19.0.1:35550",
+					"172.20.0.1:35550"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:40:14.370485639Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8765044338174851,
+				"StableID":   "nxPTgQrhSB21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07f88ef1a6ee16139d70776f6c79c43d3c0f159d0acc375ccf84890f6968fc6c",
+				"DiscoKey":   "discokey:0761a417033fdab0b74c4a98efb5634889f555dd4be46886560757101db1510a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46604",
+					"10.65.0.27:46604",
+					"172.17.0.1:46604",
+					"172.19.0.1:46604",
+					"172.20.0.1:46604"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:40:14.915495854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7221292549266636,
+				"StableID":   "n3ebRP7YPy11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:807d4656cf5f0de044b8fffc549d13f641cb5964f6be862be6d02d60acf22044",
+				"DiscoKey":   "discokey:2233bb766602a51ab4b19e2e0fcb088137c70a74a05a0c9ae199f04a630f461d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56553",
+					"10.65.0.27:56553",
+					"172.17.0.1:56553",
+					"172.19.0.1:56553",
+					"172.20.0.1:56553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:40:15.458217934Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6902047361726117,
+				"StableID":   "nn9VQf5xtv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e13f79fa76b39e38e728cf4361adb106ef81443c278963f725dd4b62aa30726",
+				"DiscoKey":   "discokey:4123e2e1b33bf53671b9a9658556761435158c547f58ac0763032242f737ac74",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53925",
+					"10.65.0.27:53925",
+					"172.17.0.1:53925",
+					"172.19.0.1:53925",
+					"172.20.0.1:53925"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:40:16.023521426Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6021417669190818,
+				"StableID":   "nMAv33S72p11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:59bf9e80cb4344b001641d3b749fabd176d151635d7c223f75c231f9d261f609",
+				"DiscoKey":   "discokey:a0667d872c772650af20b18bca3412d6d5ba910282a7c64cf8ec1c3e1d9b6258",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44934",
+					"10.65.0.27:44934",
+					"172.17.0.1:44934",
+					"172.19.0.1:44934",
+					"172.20.0.1:44934"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:40:17.080857195Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1412060730063056,
+				"StableID":   "nbgmLaSX2C11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:259ab860832152671856b7872467106d20929910142f1fa8a65ae7600e98c775",
+				"DiscoKey":   "discokey:b0bb816e222f653ea8e7b163bbf764e9d55ec56dd1ed4598e42c83a7050e1b6e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:32970",
+					"10.65.0.27:32970",
+					"172.17.0.1:32970",
+					"172.19.0.1:32970",
+					"172.20.0.1:32970"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:40:17.619990081Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4407851505619092,
+				"StableID":   "nKEFaWnKRb11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5773e1674f6b2e54984c6b8ced707ed0852017f8a14c7c01629398a7d6df3801",
+				"DiscoKey":   "discokey:9f408b0536ae1d44dfaae1cbb4e9cffa9653e973d26fc30f0cb8b34c4b3dac52",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:54117",
+					"10.65.0.27:54117",
+					"172.17.0.1:54117",
+					"172.19.0.1:54117",
+					"172.20.0.1:54117"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:40:18.174260601Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3423678238263718,
+				"StableID":   "nuCe5sDbjT11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7fb5861c7b87af318b08e7fd2fdcbc8cf68c9f3e9c075139f0ed6facf0e5d0f",
+				"DiscoKey":   "discokey:c6b73bc68432bbc3725ac49e95241f04619d9ad9c8c8fbe5e7631eb76b4f470e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60525",
+					"10.65.0.27:60525",
+					"172.17.0.1:60525",
+					"172.19.0.1:60525",
+					"172.20.0.1:60525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:40:18.679974271Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1198495343544994,
+				"StableID":   "nHCNTYSoMA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3cc1eafed253c7985ff23a31f91c84fef02a5b5c2db2aba6c030807ff9397322",
+				"DiscoKey":   "discokey:ee50d9165332537843efb62f32aa634aadeebc2e77343ca79925385bfec0b67c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:52213",
+					"10.65.0.27:52213",
+					"172.17.0.1:52213",
+					"172.19.0.1:52213",
+					"172.20.0.1:52213"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:40:19.251637105Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4603542815329677,
+				"StableID":   "ngLwVHGxwc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6772d3f4f8c0277eb067251a7a11c1ca48be9383ab8f9feeb2159dfd1340133",
+				"DiscoKey":   "discokey:eafa42a5e1acc4a572d7bded1f741a136106973ddcad2512450c65aed5856632",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46841",
+					"10.65.0.27:46841",
+					"172.17.0.1:46841",
+					"172.19.0.1:46841",
+					"172.20.0.1:46841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:40:19.767892007Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8606217454180840,
+				"StableID":   "n5XVprjmCA21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:26e24b58894b54af76d52c1cf10f71a67e70454e0d74ddef424636494e3f8768",
+				"KeyExpiry":  "2026-11-08T18:40:20Z",
+				"DiscoKey":   "discokey:1fcf8cb6f2f03c92d7cc80cfaa1999d28386b56d62372e5f9d6e1743e1eebe4b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:39624",
+					"10.65.0.27:39624",
+					"172.17.0.1:39624",
+					"172.19.0.1:39624",
+					"172.20.0.1:39624"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:40:20.30664337Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1481034582966440,
+				"StableID":   "nmurXVGmZC11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ce5cafb20e8f464fd7309cae65831e887be244036dc4e8219bebd1c7dc384f00",
+				"KeyExpiry":  "2026-11-08T18:40:20Z",
+				"DiscoKey":   "discokey:c752cbc612b4813b932ca90b1ac2fcfdafe3488a98f6c0140f000e4a87192c3a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59063",
+					"10.65.0.27:59063",
+					"172.17.0.1:59063",
+					"172.19.0.1:59063",
+					"172.20.0.1:59063"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:40:20.848044346Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3239946332099071,
+				"StableID":   "nYwAhytNJS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fe01efeba5571b10bba7fc07d7bed59a693a9381a66233430b70eacf068a513b",
+				"KeyExpiry":  "2026-11-08T18:40:21Z",
+				"DiscoKey":   "discokey:a08f2c4c494ca9deb14be10a7ee716e89cf4fb18a9342be3075960b3d1992a5e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57350",
+					"10.65.0.27:57350",
+					"172.17.0.1:57350",
+					"172.19.0.1:57350",
+					"172.20.0.1:57350"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:40:21.392723113Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3721486791053520": {
+				"ID":          3721486791053520,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3239946332099071,
+				"StableID":   "nYwAhytNJS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fe01efeba5571b10bba7fc07d7bed59a693a9381a66233430b70eacf068a513b",
+				"KeyExpiry":  "2026-11-08T18:40:21Z",
+				"DiscoKey":   "discokey:a08f2c4c494ca9deb14be10a7ee716e89cf4fb18a9342be3075960b3d1992a5e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57350",
+					"10.65.0.27:57350",
+					"172.17.0.1:57350",
+					"172.19.0.1:57350",
+					"172.20.0.1:57350"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:40:21.392723113Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:fe01efeba5571b10bba7fc07d7bed59a693a9381a66233430b70eacf068a513b",
+			"MachineKey": "mkey:2d572d6b062bfb1ea000d38a3319ebacc18373809476d2b0ad38fd90306d6e6e",
+			"Peers": [{
+				"ID":         5809610132252533,
+				"StableID":   "nWB6KCcBNn11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:44695cde7e73508dba2bd8befe90c656980ff2212991b1934e7072331683fb6b",
+				"DiscoKey":   "discokey:0d4573f14e3c344fbc90eb10958d36edd9955ae3047039d02191874cbdab916c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54897",
+					"10.65.0.27:54897",
+					"172.17.0.1:54897",
+					"172.19.0.1:54897",
+					"172.20.0.1:54897"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:40:13.638267875Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1181865146313478,
+				"StableID":   "nsdcsQbGEA11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e65ba3ec30ccbae668ef978abbf8cc44875e8b5e68ab460515545879e1a5a56b",
+				"DiscoKey":   "discokey:3d081a32ff54c3488064f9e7bead5817b1904419e350dbceaa5225d3bf0d166f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35550",
+					"10.65.0.27:35550",
+					"172.17.0.1:35550",
+					"172.19.0.1:35550",
+					"172.20.0.1:35550"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:40:14.370485639Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8765044338174851,
+				"StableID":   "nxPTgQrhSB21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07f88ef1a6ee16139d70776f6c79c43d3c0f159d0acc375ccf84890f6968fc6c",
+				"DiscoKey":   "discokey:0761a417033fdab0b74c4a98efb5634889f555dd4be46886560757101db1510a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46604",
+					"10.65.0.27:46604",
+					"172.17.0.1:46604",
+					"172.19.0.1:46604",
+					"172.20.0.1:46604"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:40:14.915495854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7221292549266636,
+				"StableID":   "n3ebRP7YPy11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:807d4656cf5f0de044b8fffc549d13f641cb5964f6be862be6d02d60acf22044",
+				"DiscoKey":   "discokey:2233bb766602a51ab4b19e2e0fcb088137c70a74a05a0c9ae199f04a630f461d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56553",
+					"10.65.0.27:56553",
+					"172.17.0.1:56553",
+					"172.19.0.1:56553",
+					"172.20.0.1:56553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:40:15.458217934Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6902047361726117,
+				"StableID":   "nn9VQf5xtv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e13f79fa76b39e38e728cf4361adb106ef81443c278963f725dd4b62aa30726",
+				"DiscoKey":   "discokey:4123e2e1b33bf53671b9a9658556761435158c547f58ac0763032242f737ac74",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53925",
+					"10.65.0.27:53925",
+					"172.17.0.1:53925",
+					"172.19.0.1:53925",
+					"172.20.0.1:53925"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:40:16.023521426Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3721486791053520,
+				"StableID":   "njSN6Z9U4W11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd11a17ab1d3191b175630bd3c34ae8d978a177bd6491fed944c2f9c78470d3c",
+				"DiscoKey":   "discokey:64bfbe357754820ce98e041d10af1b50fe556838b9dfdcf6225025893137dc3b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33268",
+					"10.65.0.27:33268",
+					"172.17.0.1:33268",
+					"172.19.0.1:33268",
+					"172.20.0.1:33268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:40:16.538744124Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6021417669190818,
+				"StableID":   "nMAv33S72p11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:59bf9e80cb4344b001641d3b749fabd176d151635d7c223f75c231f9d261f609",
+				"DiscoKey":   "discokey:a0667d872c772650af20b18bca3412d6d5ba910282a7c64cf8ec1c3e1d9b6258",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44934",
+					"10.65.0.27:44934",
+					"172.17.0.1:44934",
+					"172.19.0.1:44934",
+					"172.20.0.1:44934"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:40:17.080857195Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1412060730063056,
+				"StableID":   "nbgmLaSX2C11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:259ab860832152671856b7872467106d20929910142f1fa8a65ae7600e98c775",
+				"DiscoKey":   "discokey:b0bb816e222f653ea8e7b163bbf764e9d55ec56dd1ed4598e42c83a7050e1b6e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:32970",
+					"10.65.0.27:32970",
+					"172.17.0.1:32970",
+					"172.19.0.1:32970",
+					"172.20.0.1:32970"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:40:17.619990081Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4407851505619092,
+				"StableID":   "nKEFaWnKRb11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5773e1674f6b2e54984c6b8ced707ed0852017f8a14c7c01629398a7d6df3801",
+				"DiscoKey":   "discokey:9f408b0536ae1d44dfaae1cbb4e9cffa9653e973d26fc30f0cb8b34c4b3dac52",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:54117",
+					"10.65.0.27:54117",
+					"172.17.0.1:54117",
+					"172.19.0.1:54117",
+					"172.20.0.1:54117"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:40:18.174260601Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3423678238263718,
+				"StableID":   "nuCe5sDbjT11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7fb5861c7b87af318b08e7fd2fdcbc8cf68c9f3e9c075139f0ed6facf0e5d0f",
+				"DiscoKey":   "discokey:c6b73bc68432bbc3725ac49e95241f04619d9ad9c8c8fbe5e7631eb76b4f470e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60525",
+					"10.65.0.27:60525",
+					"172.17.0.1:60525",
+					"172.19.0.1:60525",
+					"172.20.0.1:60525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:40:18.679974271Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1198495343544994,
+				"StableID":   "nHCNTYSoMA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3cc1eafed253c7985ff23a31f91c84fef02a5b5c2db2aba6c030807ff9397322",
+				"DiscoKey":   "discokey:ee50d9165332537843efb62f32aa634aadeebc2e77343ca79925385bfec0b67c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:52213",
+					"10.65.0.27:52213",
+					"172.17.0.1:52213",
+					"172.19.0.1:52213",
+					"172.20.0.1:52213"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:40:19.251637105Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4603542815329677,
+				"StableID":   "ngLwVHGxwc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6772d3f4f8c0277eb067251a7a11c1ca48be9383ab8f9feeb2159dfd1340133",
+				"DiscoKey":   "discokey:eafa42a5e1acc4a572d7bded1f741a136106973ddcad2512450c65aed5856632",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46841",
+					"10.65.0.27:46841",
+					"172.17.0.1:46841",
+					"172.19.0.1:46841",
+					"172.20.0.1:46841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:40:19.767892007Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8606217454180840,
+				"StableID":   "n5XVprjmCA21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:26e24b58894b54af76d52c1cf10f71a67e70454e0d74ddef424636494e3f8768",
+				"KeyExpiry":  "2026-11-08T18:40:20Z",
+				"DiscoKey":   "discokey:1fcf8cb6f2f03c92d7cc80cfaa1999d28386b56d62372e5f9d6e1743e1eebe4b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:39624",
+					"10.65.0.27:39624",
+					"172.17.0.1:39624",
+					"172.19.0.1:39624",
+					"172.20.0.1:39624"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:40:20.30664337Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1481034582966440,
+				"StableID":   "nmurXVGmZC11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ce5cafb20e8f464fd7309cae65831e887be244036dc4e8219bebd1c7dc384f00",
+				"KeyExpiry":  "2026-11-08T18:40:20Z",
+				"DiscoKey":   "discokey:c752cbc612b4813b932ca90b1ac2fcfdafe3488a98f6c0140f000e4a87192c3a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59063",
+					"10.65.0.27:59063",
+					"172.17.0.1:59063",
+					"172.19.0.1:59063",
+					"172.20.0.1:59063"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:40:20.848044346Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8765044338174851,
+				"StableID":   "nxPTgQrhSB21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       8765044338174851,
+				"Key":        "nodekey:07f88ef1a6ee16139d70776f6c79c43d3c0f159d0acc375ccf84890f6968fc6c",
+				"DiscoKey":   "discokey:0761a417033fdab0b74c4a98efb5634889f555dd4be46886560757101db1510a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46604",
+					"10.65.0.27:46604",
+					"172.17.0.1:46604",
+					"172.19.0.1:46604",
+					"172.20.0.1:46604"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:40:14.915495854Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:07f88ef1a6ee16139d70776f6c79c43d3c0f159d0acc375ccf84890f6968fc6c",
+			"MachineKey": "mkey:17fc380482e5e6bb572866128ecddeb84102329c27a017b21d149d7deff00533",
+			"Peers": [{
+				"ID":         5809610132252533,
+				"StableID":   "nWB6KCcBNn11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:44695cde7e73508dba2bd8befe90c656980ff2212991b1934e7072331683fb6b",
+				"DiscoKey":   "discokey:0d4573f14e3c344fbc90eb10958d36edd9955ae3047039d02191874cbdab916c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54897",
+					"10.65.0.27:54897",
+					"172.17.0.1:54897",
+					"172.19.0.1:54897",
+					"172.20.0.1:54897"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:40:13.638267875Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1181865146313478,
+				"StableID":   "nsdcsQbGEA11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e65ba3ec30ccbae668ef978abbf8cc44875e8b5e68ab460515545879e1a5a56b",
+				"DiscoKey":   "discokey:3d081a32ff54c3488064f9e7bead5817b1904419e350dbceaa5225d3bf0d166f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35550",
+					"10.65.0.27:35550",
+					"172.17.0.1:35550",
+					"172.19.0.1:35550",
+					"172.20.0.1:35550"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:40:14.370485639Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7221292549266636,
+				"StableID":   "n3ebRP7YPy11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:807d4656cf5f0de044b8fffc549d13f641cb5964f6be862be6d02d60acf22044",
+				"DiscoKey":   "discokey:2233bb766602a51ab4b19e2e0fcb088137c70a74a05a0c9ae199f04a630f461d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56553",
+					"10.65.0.27:56553",
+					"172.17.0.1:56553",
+					"172.19.0.1:56553",
+					"172.20.0.1:56553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:40:15.458217934Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6902047361726117,
+				"StableID":   "nn9VQf5xtv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e13f79fa76b39e38e728cf4361adb106ef81443c278963f725dd4b62aa30726",
+				"DiscoKey":   "discokey:4123e2e1b33bf53671b9a9658556761435158c547f58ac0763032242f737ac74",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53925",
+					"10.65.0.27:53925",
+					"172.17.0.1:53925",
+					"172.19.0.1:53925",
+					"172.20.0.1:53925"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:40:16.023521426Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3721486791053520,
+				"StableID":   "njSN6Z9U4W11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd11a17ab1d3191b175630bd3c34ae8d978a177bd6491fed944c2f9c78470d3c",
+				"DiscoKey":   "discokey:64bfbe357754820ce98e041d10af1b50fe556838b9dfdcf6225025893137dc3b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33268",
+					"10.65.0.27:33268",
+					"172.17.0.1:33268",
+					"172.19.0.1:33268",
+					"172.20.0.1:33268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:40:16.538744124Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6021417669190818,
+				"StableID":   "nMAv33S72p11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:59bf9e80cb4344b001641d3b749fabd176d151635d7c223f75c231f9d261f609",
+				"DiscoKey":   "discokey:a0667d872c772650af20b18bca3412d6d5ba910282a7c64cf8ec1c3e1d9b6258",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44934",
+					"10.65.0.27:44934",
+					"172.17.0.1:44934",
+					"172.19.0.1:44934",
+					"172.20.0.1:44934"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:40:17.080857195Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1412060730063056,
+				"StableID":   "nbgmLaSX2C11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:259ab860832152671856b7872467106d20929910142f1fa8a65ae7600e98c775",
+				"DiscoKey":   "discokey:b0bb816e222f653ea8e7b163bbf764e9d55ec56dd1ed4598e42c83a7050e1b6e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:32970",
+					"10.65.0.27:32970",
+					"172.17.0.1:32970",
+					"172.19.0.1:32970",
+					"172.20.0.1:32970"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:40:17.619990081Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4407851505619092,
+				"StableID":   "nKEFaWnKRb11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5773e1674f6b2e54984c6b8ced707ed0852017f8a14c7c01629398a7d6df3801",
+				"DiscoKey":   "discokey:9f408b0536ae1d44dfaae1cbb4e9cffa9653e973d26fc30f0cb8b34c4b3dac52",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:54117",
+					"10.65.0.27:54117",
+					"172.17.0.1:54117",
+					"172.19.0.1:54117",
+					"172.20.0.1:54117"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:40:18.174260601Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3423678238263718,
+				"StableID":   "nuCe5sDbjT11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7fb5861c7b87af318b08e7fd2fdcbc8cf68c9f3e9c075139f0ed6facf0e5d0f",
+				"DiscoKey":   "discokey:c6b73bc68432bbc3725ac49e95241f04619d9ad9c8c8fbe5e7631eb76b4f470e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60525",
+					"10.65.0.27:60525",
+					"172.17.0.1:60525",
+					"172.19.0.1:60525",
+					"172.20.0.1:60525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:40:18.679974271Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1198495343544994,
+				"StableID":   "nHCNTYSoMA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3cc1eafed253c7985ff23a31f91c84fef02a5b5c2db2aba6c030807ff9397322",
+				"DiscoKey":   "discokey:ee50d9165332537843efb62f32aa634aadeebc2e77343ca79925385bfec0b67c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:52213",
+					"10.65.0.27:52213",
+					"172.17.0.1:52213",
+					"172.19.0.1:52213",
+					"172.20.0.1:52213"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:40:19.251637105Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4603542815329677,
+				"StableID":   "ngLwVHGxwc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6772d3f4f8c0277eb067251a7a11c1ca48be9383ab8f9feeb2159dfd1340133",
+				"DiscoKey":   "discokey:eafa42a5e1acc4a572d7bded1f741a136106973ddcad2512450c65aed5856632",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46841",
+					"10.65.0.27:46841",
+					"172.17.0.1:46841",
+					"172.19.0.1:46841",
+					"172.20.0.1:46841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:40:19.767892007Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8606217454180840,
+				"StableID":   "n5XVprjmCA21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:26e24b58894b54af76d52c1cf10f71a67e70454e0d74ddef424636494e3f8768",
+				"KeyExpiry":  "2026-11-08T18:40:20Z",
+				"DiscoKey":   "discokey:1fcf8cb6f2f03c92d7cc80cfaa1999d28386b56d62372e5f9d6e1743e1eebe4b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:39624",
+					"10.65.0.27:39624",
+					"172.17.0.1:39624",
+					"172.19.0.1:39624",
+					"172.20.0.1:39624"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:40:20.30664337Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1481034582966440,
+				"StableID":   "nmurXVGmZC11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ce5cafb20e8f464fd7309cae65831e887be244036dc4e8219bebd1c7dc384f00",
+				"KeyExpiry":  "2026-11-08T18:40:20Z",
+				"DiscoKey":   "discokey:c752cbc612b4813b932ca90b1ac2fcfdafe3488a98f6c0140f000e4a87192c3a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59063",
+					"10.65.0.27:59063",
+					"172.17.0.1:59063",
+					"172.19.0.1:59063",
+					"172.20.0.1:59063"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:40:20.848044346Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3239946332099071,
+				"StableID":   "nYwAhytNJS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fe01efeba5571b10bba7fc07d7bed59a693a9381a66233430b70eacf068a513b",
+				"KeyExpiry":  "2026-11-08T18:40:21Z",
+				"DiscoKey":   "discokey:a08f2c4c494ca9deb14be10a7ee716e89cf4fb18a9342be3075960b3d1992a5e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57350",
+					"10.65.0.27:57350",
+					"172.17.0.1:57350",
+					"172.19.0.1:57350",
+					"172.20.0.1:57350"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:40:21.392723113Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8765044338174851": {
+				"ID":          8765044338174851,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1412060730063056,
+				"StableID":   "nbgmLaSX2C11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1412060730063056,
+				"Key":        "nodekey:259ab860832152671856b7872467106d20929910142f1fa8a65ae7600e98c775",
+				"DiscoKey":   "discokey:b0bb816e222f653ea8e7b163bbf764e9d55ec56dd1ed4598e42c83a7050e1b6e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:32970",
+					"10.65.0.27:32970",
+					"172.17.0.1:32970",
+					"172.19.0.1:32970",
+					"172.20.0.1:32970"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:40:17.619990081Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:259ab860832152671856b7872467106d20929910142f1fa8a65ae7600e98c775",
+			"MachineKey": "mkey:c786ab0266fbbe92df8be4479cef67af2dca27e4eaeab874c7111086a527270e",
+			"Peers": [{
+				"ID":         5809610132252533,
+				"StableID":   "nWB6KCcBNn11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:44695cde7e73508dba2bd8befe90c656980ff2212991b1934e7072331683fb6b",
+				"DiscoKey":   "discokey:0d4573f14e3c344fbc90eb10958d36edd9955ae3047039d02191874cbdab916c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54897",
+					"10.65.0.27:54897",
+					"172.17.0.1:54897",
+					"172.19.0.1:54897",
+					"172.20.0.1:54897"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:40:13.638267875Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1181865146313478,
+				"StableID":   "nsdcsQbGEA11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e65ba3ec30ccbae668ef978abbf8cc44875e8b5e68ab460515545879e1a5a56b",
+				"DiscoKey":   "discokey:3d081a32ff54c3488064f9e7bead5817b1904419e350dbceaa5225d3bf0d166f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35550",
+					"10.65.0.27:35550",
+					"172.17.0.1:35550",
+					"172.19.0.1:35550",
+					"172.20.0.1:35550"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:40:14.370485639Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8765044338174851,
+				"StableID":   "nxPTgQrhSB21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07f88ef1a6ee16139d70776f6c79c43d3c0f159d0acc375ccf84890f6968fc6c",
+				"DiscoKey":   "discokey:0761a417033fdab0b74c4a98efb5634889f555dd4be46886560757101db1510a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46604",
+					"10.65.0.27:46604",
+					"172.17.0.1:46604",
+					"172.19.0.1:46604",
+					"172.20.0.1:46604"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:40:14.915495854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7221292549266636,
+				"StableID":   "n3ebRP7YPy11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:807d4656cf5f0de044b8fffc549d13f641cb5964f6be862be6d02d60acf22044",
+				"DiscoKey":   "discokey:2233bb766602a51ab4b19e2e0fcb088137c70a74a05a0c9ae199f04a630f461d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56553",
+					"10.65.0.27:56553",
+					"172.17.0.1:56553",
+					"172.19.0.1:56553",
+					"172.20.0.1:56553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:40:15.458217934Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6902047361726117,
+				"StableID":   "nn9VQf5xtv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e13f79fa76b39e38e728cf4361adb106ef81443c278963f725dd4b62aa30726",
+				"DiscoKey":   "discokey:4123e2e1b33bf53671b9a9658556761435158c547f58ac0763032242f737ac74",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53925",
+					"10.65.0.27:53925",
+					"172.17.0.1:53925",
+					"172.19.0.1:53925",
+					"172.20.0.1:53925"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:40:16.023521426Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3721486791053520,
+				"StableID":   "njSN6Z9U4W11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd11a17ab1d3191b175630bd3c34ae8d978a177bd6491fed944c2f9c78470d3c",
+				"DiscoKey":   "discokey:64bfbe357754820ce98e041d10af1b50fe556838b9dfdcf6225025893137dc3b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33268",
+					"10.65.0.27:33268",
+					"172.17.0.1:33268",
+					"172.19.0.1:33268",
+					"172.20.0.1:33268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:40:16.538744124Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6021417669190818,
+				"StableID":   "nMAv33S72p11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:59bf9e80cb4344b001641d3b749fabd176d151635d7c223f75c231f9d261f609",
+				"DiscoKey":   "discokey:a0667d872c772650af20b18bca3412d6d5ba910282a7c64cf8ec1c3e1d9b6258",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44934",
+					"10.65.0.27:44934",
+					"172.17.0.1:44934",
+					"172.19.0.1:44934",
+					"172.20.0.1:44934"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:40:17.080857195Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4407851505619092,
+				"StableID":   "nKEFaWnKRb11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5773e1674f6b2e54984c6b8ced707ed0852017f8a14c7c01629398a7d6df3801",
+				"DiscoKey":   "discokey:9f408b0536ae1d44dfaae1cbb4e9cffa9653e973d26fc30f0cb8b34c4b3dac52",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:54117",
+					"10.65.0.27:54117",
+					"172.17.0.1:54117",
+					"172.19.0.1:54117",
+					"172.20.0.1:54117"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:40:18.174260601Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3423678238263718,
+				"StableID":   "nuCe5sDbjT11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7fb5861c7b87af318b08e7fd2fdcbc8cf68c9f3e9c075139f0ed6facf0e5d0f",
+				"DiscoKey":   "discokey:c6b73bc68432bbc3725ac49e95241f04619d9ad9c8c8fbe5e7631eb76b4f470e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60525",
+					"10.65.0.27:60525",
+					"172.17.0.1:60525",
+					"172.19.0.1:60525",
+					"172.20.0.1:60525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:40:18.679974271Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1198495343544994,
+				"StableID":   "nHCNTYSoMA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3cc1eafed253c7985ff23a31f91c84fef02a5b5c2db2aba6c030807ff9397322",
+				"DiscoKey":   "discokey:ee50d9165332537843efb62f32aa634aadeebc2e77343ca79925385bfec0b67c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:52213",
+					"10.65.0.27:52213",
+					"172.17.0.1:52213",
+					"172.19.0.1:52213",
+					"172.20.0.1:52213"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:40:19.251637105Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4603542815329677,
+				"StableID":   "ngLwVHGxwc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6772d3f4f8c0277eb067251a7a11c1ca48be9383ab8f9feeb2159dfd1340133",
+				"DiscoKey":   "discokey:eafa42a5e1acc4a572d7bded1f741a136106973ddcad2512450c65aed5856632",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46841",
+					"10.65.0.27:46841",
+					"172.17.0.1:46841",
+					"172.19.0.1:46841",
+					"172.20.0.1:46841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:40:19.767892007Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8606217454180840,
+				"StableID":   "n5XVprjmCA21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:26e24b58894b54af76d52c1cf10f71a67e70454e0d74ddef424636494e3f8768",
+				"KeyExpiry":  "2026-11-08T18:40:20Z",
+				"DiscoKey":   "discokey:1fcf8cb6f2f03c92d7cc80cfaa1999d28386b56d62372e5f9d6e1743e1eebe4b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:39624",
+					"10.65.0.27:39624",
+					"172.17.0.1:39624",
+					"172.19.0.1:39624",
+					"172.20.0.1:39624"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:40:20.30664337Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1481034582966440,
+				"StableID":   "nmurXVGmZC11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ce5cafb20e8f464fd7309cae65831e887be244036dc4e8219bebd1c7dc384f00",
+				"KeyExpiry":  "2026-11-08T18:40:20Z",
+				"DiscoKey":   "discokey:c752cbc612b4813b932ca90b1ac2fcfdafe3488a98f6c0140f000e4a87192c3a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59063",
+					"10.65.0.27:59063",
+					"172.17.0.1:59063",
+					"172.19.0.1:59063",
+					"172.20.0.1:59063"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:40:20.848044346Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3239946332099071,
+				"StableID":   "nYwAhytNJS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fe01efeba5571b10bba7fc07d7bed59a693a9381a66233430b70eacf068a513b",
+				"KeyExpiry":  "2026-11-08T18:40:21Z",
+				"DiscoKey":   "discokey:a08f2c4c494ca9deb14be10a7ee716e89cf4fb18a9342be3075960b3d1992a5e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57350",
+					"10.65.0.27:57350",
+					"172.17.0.1:57350",
+					"172.19.0.1:57350",
+					"172.20.0.1:57350"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:40:21.392723113Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1412060730063056": {
+				"ID":          1412060730063056,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8606217454180840,
+				"StableID":   "n5XVprjmCA21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:26e24b58894b54af76d52c1cf10f71a67e70454e0d74ddef424636494e3f8768",
+				"KeyExpiry":  "2026-11-08T18:40:20Z",
+				"DiscoKey":   "discokey:1fcf8cb6f2f03c92d7cc80cfaa1999d28386b56d62372e5f9d6e1743e1eebe4b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:39624",
+					"10.65.0.27:39624",
+					"172.17.0.1:39624",
+					"172.19.0.1:39624",
+					"172.20.0.1:39624"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:40:20.30664337Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:26e24b58894b54af76d52c1cf10f71a67e70454e0d74ddef424636494e3f8768",
+			"MachineKey": "mkey:8e3ba0af9ab3572adcf3e6e2ee597f2235a20829c8bd81eb9a8ec6e1aa791d6b",
+			"Peers": [{
+				"ID":         5809610132252533,
+				"StableID":   "nWB6KCcBNn11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:44695cde7e73508dba2bd8befe90c656980ff2212991b1934e7072331683fb6b",
+				"DiscoKey":   "discokey:0d4573f14e3c344fbc90eb10958d36edd9955ae3047039d02191874cbdab916c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54897",
+					"10.65.0.27:54897",
+					"172.17.0.1:54897",
+					"172.19.0.1:54897",
+					"172.20.0.1:54897"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:40:13.638267875Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1181865146313478,
+				"StableID":   "nsdcsQbGEA11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e65ba3ec30ccbae668ef978abbf8cc44875e8b5e68ab460515545879e1a5a56b",
+				"DiscoKey":   "discokey:3d081a32ff54c3488064f9e7bead5817b1904419e350dbceaa5225d3bf0d166f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35550",
+					"10.65.0.27:35550",
+					"172.17.0.1:35550",
+					"172.19.0.1:35550",
+					"172.20.0.1:35550"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:40:14.370485639Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8765044338174851,
+				"StableID":   "nxPTgQrhSB21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07f88ef1a6ee16139d70776f6c79c43d3c0f159d0acc375ccf84890f6968fc6c",
+				"DiscoKey":   "discokey:0761a417033fdab0b74c4a98efb5634889f555dd4be46886560757101db1510a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46604",
+					"10.65.0.27:46604",
+					"172.17.0.1:46604",
+					"172.19.0.1:46604",
+					"172.20.0.1:46604"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:40:14.915495854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7221292549266636,
+				"StableID":   "n3ebRP7YPy11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:807d4656cf5f0de044b8fffc549d13f641cb5964f6be862be6d02d60acf22044",
+				"DiscoKey":   "discokey:2233bb766602a51ab4b19e2e0fcb088137c70a74a05a0c9ae199f04a630f461d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56553",
+					"10.65.0.27:56553",
+					"172.17.0.1:56553",
+					"172.19.0.1:56553",
+					"172.20.0.1:56553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:40:15.458217934Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6902047361726117,
+				"StableID":   "nn9VQf5xtv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e13f79fa76b39e38e728cf4361adb106ef81443c278963f725dd4b62aa30726",
+				"DiscoKey":   "discokey:4123e2e1b33bf53671b9a9658556761435158c547f58ac0763032242f737ac74",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53925",
+					"10.65.0.27:53925",
+					"172.17.0.1:53925",
+					"172.19.0.1:53925",
+					"172.20.0.1:53925"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:40:16.023521426Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3721486791053520,
+				"StableID":   "njSN6Z9U4W11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd11a17ab1d3191b175630bd3c34ae8d978a177bd6491fed944c2f9c78470d3c",
+				"DiscoKey":   "discokey:64bfbe357754820ce98e041d10af1b50fe556838b9dfdcf6225025893137dc3b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33268",
+					"10.65.0.27:33268",
+					"172.17.0.1:33268",
+					"172.19.0.1:33268",
+					"172.20.0.1:33268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:40:16.538744124Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6021417669190818,
+				"StableID":   "nMAv33S72p11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:59bf9e80cb4344b001641d3b749fabd176d151635d7c223f75c231f9d261f609",
+				"DiscoKey":   "discokey:a0667d872c772650af20b18bca3412d6d5ba910282a7c64cf8ec1c3e1d9b6258",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44934",
+					"10.65.0.27:44934",
+					"172.17.0.1:44934",
+					"172.19.0.1:44934",
+					"172.20.0.1:44934"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:40:17.080857195Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1412060730063056,
+				"StableID":   "nbgmLaSX2C11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:259ab860832152671856b7872467106d20929910142f1fa8a65ae7600e98c775",
+				"DiscoKey":   "discokey:b0bb816e222f653ea8e7b163bbf764e9d55ec56dd1ed4598e42c83a7050e1b6e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:32970",
+					"10.65.0.27:32970",
+					"172.17.0.1:32970",
+					"172.19.0.1:32970",
+					"172.20.0.1:32970"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:40:17.619990081Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4407851505619092,
+				"StableID":   "nKEFaWnKRb11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5773e1674f6b2e54984c6b8ced707ed0852017f8a14c7c01629398a7d6df3801",
+				"DiscoKey":   "discokey:9f408b0536ae1d44dfaae1cbb4e9cffa9653e973d26fc30f0cb8b34c4b3dac52",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:54117",
+					"10.65.0.27:54117",
+					"172.17.0.1:54117",
+					"172.19.0.1:54117",
+					"172.20.0.1:54117"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:40:18.174260601Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3423678238263718,
+				"StableID":   "nuCe5sDbjT11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7fb5861c7b87af318b08e7fd2fdcbc8cf68c9f3e9c075139f0ed6facf0e5d0f",
+				"DiscoKey":   "discokey:c6b73bc68432bbc3725ac49e95241f04619d9ad9c8c8fbe5e7631eb76b4f470e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60525",
+					"10.65.0.27:60525",
+					"172.17.0.1:60525",
+					"172.19.0.1:60525",
+					"172.20.0.1:60525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:40:18.679974271Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1198495343544994,
+				"StableID":   "nHCNTYSoMA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3cc1eafed253c7985ff23a31f91c84fef02a5b5c2db2aba6c030807ff9397322",
+				"DiscoKey":   "discokey:ee50d9165332537843efb62f32aa634aadeebc2e77343ca79925385bfec0b67c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:52213",
+					"10.65.0.27:52213",
+					"172.17.0.1:52213",
+					"172.19.0.1:52213",
+					"172.20.0.1:52213"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:40:19.251637105Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4603542815329677,
+				"StableID":   "ngLwVHGxwc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6772d3f4f8c0277eb067251a7a11c1ca48be9383ab8f9feeb2159dfd1340133",
+				"DiscoKey":   "discokey:eafa42a5e1acc4a572d7bded1f741a136106973ddcad2512450c65aed5856632",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46841",
+					"10.65.0.27:46841",
+					"172.17.0.1:46841",
+					"172.19.0.1:46841",
+					"172.20.0.1:46841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:40:19.767892007Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1481034582966440,
+				"StableID":   "nmurXVGmZC11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ce5cafb20e8f464fd7309cae65831e887be244036dc4e8219bebd1c7dc384f00",
+				"KeyExpiry":  "2026-11-08T18:40:20Z",
+				"DiscoKey":   "discokey:c752cbc612b4813b932ca90b1ac2fcfdafe3488a98f6c0140f000e4a87192c3a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59063",
+					"10.65.0.27:59063",
+					"172.17.0.1:59063",
+					"172.19.0.1:59063",
+					"172.20.0.1:59063"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:40:20.848044346Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3239946332099071,
+				"StableID":   "nYwAhytNJS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fe01efeba5571b10bba7fc07d7bed59a693a9381a66233430b70eacf068a513b",
+				"KeyExpiry":  "2026-11-08T18:40:21Z",
+				"DiscoKey":   "discokey:a08f2c4c494ca9deb14be10a7ee716e89cf4fb18a9342be3075960b3d1992a5e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57350",
+					"10.65.0.27:57350",
+					"172.17.0.1:57350",
+					"172.19.0.1:57350",
+					"172.20.0.1:57350"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:40:21.392723113Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1198495343544994,
+				"StableID":   "nHCNTYSoMA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1198495343544994,
+				"Key":        "nodekey:3cc1eafed253c7985ff23a31f91c84fef02a5b5c2db2aba6c030807ff9397322",
+				"DiscoKey":   "discokey:ee50d9165332537843efb62f32aa634aadeebc2e77343ca79925385bfec0b67c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:52213",
+					"10.65.0.27:52213",
+					"172.17.0.1:52213",
+					"172.19.0.1:52213",
+					"172.20.0.1:52213"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:40:19.251637105Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3cc1eafed253c7985ff23a31f91c84fef02a5b5c2db2aba6c030807ff9397322",
+			"MachineKey": "mkey:4dd489c84a9eb4ec50bce55e56155b7bd5116fde510934067b00bda45f8f8f4d",
+			"Peers": [{
+				"ID":         5809610132252533,
+				"StableID":   "nWB6KCcBNn11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:44695cde7e73508dba2bd8befe90c656980ff2212991b1934e7072331683fb6b",
+				"DiscoKey":   "discokey:0d4573f14e3c344fbc90eb10958d36edd9955ae3047039d02191874cbdab916c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54897",
+					"10.65.0.27:54897",
+					"172.17.0.1:54897",
+					"172.19.0.1:54897",
+					"172.20.0.1:54897"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:40:13.638267875Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1181865146313478,
+				"StableID":   "nsdcsQbGEA11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e65ba3ec30ccbae668ef978abbf8cc44875e8b5e68ab460515545879e1a5a56b",
+				"DiscoKey":   "discokey:3d081a32ff54c3488064f9e7bead5817b1904419e350dbceaa5225d3bf0d166f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35550",
+					"10.65.0.27:35550",
+					"172.17.0.1:35550",
+					"172.19.0.1:35550",
+					"172.20.0.1:35550"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:40:14.370485639Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8765044338174851,
+				"StableID":   "nxPTgQrhSB21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07f88ef1a6ee16139d70776f6c79c43d3c0f159d0acc375ccf84890f6968fc6c",
+				"DiscoKey":   "discokey:0761a417033fdab0b74c4a98efb5634889f555dd4be46886560757101db1510a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46604",
+					"10.65.0.27:46604",
+					"172.17.0.1:46604",
+					"172.19.0.1:46604",
+					"172.20.0.1:46604"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:40:14.915495854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7221292549266636,
+				"StableID":   "n3ebRP7YPy11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:807d4656cf5f0de044b8fffc549d13f641cb5964f6be862be6d02d60acf22044",
+				"DiscoKey":   "discokey:2233bb766602a51ab4b19e2e0fcb088137c70a74a05a0c9ae199f04a630f461d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56553",
+					"10.65.0.27:56553",
+					"172.17.0.1:56553",
+					"172.19.0.1:56553",
+					"172.20.0.1:56553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:40:15.458217934Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6902047361726117,
+				"StableID":   "nn9VQf5xtv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e13f79fa76b39e38e728cf4361adb106ef81443c278963f725dd4b62aa30726",
+				"DiscoKey":   "discokey:4123e2e1b33bf53671b9a9658556761435158c547f58ac0763032242f737ac74",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53925",
+					"10.65.0.27:53925",
+					"172.17.0.1:53925",
+					"172.19.0.1:53925",
+					"172.20.0.1:53925"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:40:16.023521426Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3721486791053520,
+				"StableID":   "njSN6Z9U4W11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd11a17ab1d3191b175630bd3c34ae8d978a177bd6491fed944c2f9c78470d3c",
+				"DiscoKey":   "discokey:64bfbe357754820ce98e041d10af1b50fe556838b9dfdcf6225025893137dc3b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33268",
+					"10.65.0.27:33268",
+					"172.17.0.1:33268",
+					"172.19.0.1:33268",
+					"172.20.0.1:33268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:40:16.538744124Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6021417669190818,
+				"StableID":   "nMAv33S72p11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:59bf9e80cb4344b001641d3b749fabd176d151635d7c223f75c231f9d261f609",
+				"DiscoKey":   "discokey:a0667d872c772650af20b18bca3412d6d5ba910282a7c64cf8ec1c3e1d9b6258",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44934",
+					"10.65.0.27:44934",
+					"172.17.0.1:44934",
+					"172.19.0.1:44934",
+					"172.20.0.1:44934"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:40:17.080857195Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1412060730063056,
+				"StableID":   "nbgmLaSX2C11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:259ab860832152671856b7872467106d20929910142f1fa8a65ae7600e98c775",
+				"DiscoKey":   "discokey:b0bb816e222f653ea8e7b163bbf764e9d55ec56dd1ed4598e42c83a7050e1b6e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:32970",
+					"10.65.0.27:32970",
+					"172.17.0.1:32970",
+					"172.19.0.1:32970",
+					"172.20.0.1:32970"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:40:17.619990081Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4407851505619092,
+				"StableID":   "nKEFaWnKRb11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5773e1674f6b2e54984c6b8ced707ed0852017f8a14c7c01629398a7d6df3801",
+				"DiscoKey":   "discokey:9f408b0536ae1d44dfaae1cbb4e9cffa9653e973d26fc30f0cb8b34c4b3dac52",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:54117",
+					"10.65.0.27:54117",
+					"172.17.0.1:54117",
+					"172.19.0.1:54117",
+					"172.20.0.1:54117"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:40:18.174260601Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3423678238263718,
+				"StableID":   "nuCe5sDbjT11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7fb5861c7b87af318b08e7fd2fdcbc8cf68c9f3e9c075139f0ed6facf0e5d0f",
+				"DiscoKey":   "discokey:c6b73bc68432bbc3725ac49e95241f04619d9ad9c8c8fbe5e7631eb76b4f470e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60525",
+					"10.65.0.27:60525",
+					"172.17.0.1:60525",
+					"172.19.0.1:60525",
+					"172.20.0.1:60525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:40:18.679974271Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4603542815329677,
+				"StableID":   "ngLwVHGxwc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6772d3f4f8c0277eb067251a7a11c1ca48be9383ab8f9feeb2159dfd1340133",
+				"DiscoKey":   "discokey:eafa42a5e1acc4a572d7bded1f741a136106973ddcad2512450c65aed5856632",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46841",
+					"10.65.0.27:46841",
+					"172.17.0.1:46841",
+					"172.19.0.1:46841",
+					"172.20.0.1:46841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:40:19.767892007Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8606217454180840,
+				"StableID":   "n5XVprjmCA21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:26e24b58894b54af76d52c1cf10f71a67e70454e0d74ddef424636494e3f8768",
+				"KeyExpiry":  "2026-11-08T18:40:20Z",
+				"DiscoKey":   "discokey:1fcf8cb6f2f03c92d7cc80cfaa1999d28386b56d62372e5f9d6e1743e1eebe4b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:39624",
+					"10.65.0.27:39624",
+					"172.17.0.1:39624",
+					"172.19.0.1:39624",
+					"172.20.0.1:39624"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:40:20.30664337Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1481034582966440,
+				"StableID":   "nmurXVGmZC11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ce5cafb20e8f464fd7309cae65831e887be244036dc4e8219bebd1c7dc384f00",
+				"KeyExpiry":  "2026-11-08T18:40:20Z",
+				"DiscoKey":   "discokey:c752cbc612b4813b932ca90b1ac2fcfdafe3488a98f6c0140f000e4a87192c3a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59063",
+					"10.65.0.27:59063",
+					"172.17.0.1:59063",
+					"172.19.0.1:59063",
+					"172.20.0.1:59063"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:40:20.848044346Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3239946332099071,
+				"StableID":   "nYwAhytNJS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fe01efeba5571b10bba7fc07d7bed59a693a9381a66233430b70eacf068a513b",
+				"KeyExpiry":  "2026-11-08T18:40:21Z",
+				"DiscoKey":   "discokey:a08f2c4c494ca9deb14be10a7ee716e89cf4fb18a9342be3075960b3d1992a5e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57350",
+					"10.65.0.27:57350",
+					"172.17.0.1:57350",
+					"172.19.0.1:57350",
+					"172.20.0.1:57350"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:40:21.392723113Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1198495343544994": {
+				"ID":          1198495343544994,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1181865146313478,
+				"StableID":   "nsdcsQbGEA11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1181865146313478,
+				"Key":        "nodekey:e65ba3ec30ccbae668ef978abbf8cc44875e8b5e68ab460515545879e1a5a56b",
+				"DiscoKey":   "discokey:3d081a32ff54c3488064f9e7bead5817b1904419e350dbceaa5225d3bf0d166f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35550",
+					"10.65.0.27:35550",
+					"172.17.0.1:35550",
+					"172.19.0.1:35550",
+					"172.20.0.1:35550"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:40:14.370485639Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e65ba3ec30ccbae668ef978abbf8cc44875e8b5e68ab460515545879e1a5a56b",
+			"MachineKey": "mkey:150081b6fb9d32073af69fc781339d707dd6f56297db7b593af5e061b10a5f23",
+			"Peers": [{
+				"ID":         5809610132252533,
+				"StableID":   "nWB6KCcBNn11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:44695cde7e73508dba2bd8befe90c656980ff2212991b1934e7072331683fb6b",
+				"DiscoKey":   "discokey:0d4573f14e3c344fbc90eb10958d36edd9955ae3047039d02191874cbdab916c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54897",
+					"10.65.0.27:54897",
+					"172.17.0.1:54897",
+					"172.19.0.1:54897",
+					"172.20.0.1:54897"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:40:13.638267875Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8765044338174851,
+				"StableID":   "nxPTgQrhSB21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07f88ef1a6ee16139d70776f6c79c43d3c0f159d0acc375ccf84890f6968fc6c",
+				"DiscoKey":   "discokey:0761a417033fdab0b74c4a98efb5634889f555dd4be46886560757101db1510a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46604",
+					"10.65.0.27:46604",
+					"172.17.0.1:46604",
+					"172.19.0.1:46604",
+					"172.20.0.1:46604"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:40:14.915495854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7221292549266636,
+				"StableID":   "n3ebRP7YPy11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:807d4656cf5f0de044b8fffc549d13f641cb5964f6be862be6d02d60acf22044",
+				"DiscoKey":   "discokey:2233bb766602a51ab4b19e2e0fcb088137c70a74a05a0c9ae199f04a630f461d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56553",
+					"10.65.0.27:56553",
+					"172.17.0.1:56553",
+					"172.19.0.1:56553",
+					"172.20.0.1:56553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:40:15.458217934Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6902047361726117,
+				"StableID":   "nn9VQf5xtv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e13f79fa76b39e38e728cf4361adb106ef81443c278963f725dd4b62aa30726",
+				"DiscoKey":   "discokey:4123e2e1b33bf53671b9a9658556761435158c547f58ac0763032242f737ac74",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53925",
+					"10.65.0.27:53925",
+					"172.17.0.1:53925",
+					"172.19.0.1:53925",
+					"172.20.0.1:53925"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:40:16.023521426Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3721486791053520,
+				"StableID":   "njSN6Z9U4W11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd11a17ab1d3191b175630bd3c34ae8d978a177bd6491fed944c2f9c78470d3c",
+				"DiscoKey":   "discokey:64bfbe357754820ce98e041d10af1b50fe556838b9dfdcf6225025893137dc3b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33268",
+					"10.65.0.27:33268",
+					"172.17.0.1:33268",
+					"172.19.0.1:33268",
+					"172.20.0.1:33268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:40:16.538744124Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6021417669190818,
+				"StableID":   "nMAv33S72p11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:59bf9e80cb4344b001641d3b749fabd176d151635d7c223f75c231f9d261f609",
+				"DiscoKey":   "discokey:a0667d872c772650af20b18bca3412d6d5ba910282a7c64cf8ec1c3e1d9b6258",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44934",
+					"10.65.0.27:44934",
+					"172.17.0.1:44934",
+					"172.19.0.1:44934",
+					"172.20.0.1:44934"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:40:17.080857195Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1412060730063056,
+				"StableID":   "nbgmLaSX2C11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:259ab860832152671856b7872467106d20929910142f1fa8a65ae7600e98c775",
+				"DiscoKey":   "discokey:b0bb816e222f653ea8e7b163bbf764e9d55ec56dd1ed4598e42c83a7050e1b6e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:32970",
+					"10.65.0.27:32970",
+					"172.17.0.1:32970",
+					"172.19.0.1:32970",
+					"172.20.0.1:32970"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:40:17.619990081Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4407851505619092,
+				"StableID":   "nKEFaWnKRb11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5773e1674f6b2e54984c6b8ced707ed0852017f8a14c7c01629398a7d6df3801",
+				"DiscoKey":   "discokey:9f408b0536ae1d44dfaae1cbb4e9cffa9653e973d26fc30f0cb8b34c4b3dac52",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:54117",
+					"10.65.0.27:54117",
+					"172.17.0.1:54117",
+					"172.19.0.1:54117",
+					"172.20.0.1:54117"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:40:18.174260601Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3423678238263718,
+				"StableID":   "nuCe5sDbjT11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7fb5861c7b87af318b08e7fd2fdcbc8cf68c9f3e9c075139f0ed6facf0e5d0f",
+				"DiscoKey":   "discokey:c6b73bc68432bbc3725ac49e95241f04619d9ad9c8c8fbe5e7631eb76b4f470e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60525",
+					"10.65.0.27:60525",
+					"172.17.0.1:60525",
+					"172.19.0.1:60525",
+					"172.20.0.1:60525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:40:18.679974271Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1198495343544994,
+				"StableID":   "nHCNTYSoMA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3cc1eafed253c7985ff23a31f91c84fef02a5b5c2db2aba6c030807ff9397322",
+				"DiscoKey":   "discokey:ee50d9165332537843efb62f32aa634aadeebc2e77343ca79925385bfec0b67c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:52213",
+					"10.65.0.27:52213",
+					"172.17.0.1:52213",
+					"172.19.0.1:52213",
+					"172.20.0.1:52213"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:40:19.251637105Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4603542815329677,
+				"StableID":   "ngLwVHGxwc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6772d3f4f8c0277eb067251a7a11c1ca48be9383ab8f9feeb2159dfd1340133",
+				"DiscoKey":   "discokey:eafa42a5e1acc4a572d7bded1f741a136106973ddcad2512450c65aed5856632",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46841",
+					"10.65.0.27:46841",
+					"172.17.0.1:46841",
+					"172.19.0.1:46841",
+					"172.20.0.1:46841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:40:19.767892007Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8606217454180840,
+				"StableID":   "n5XVprjmCA21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:26e24b58894b54af76d52c1cf10f71a67e70454e0d74ddef424636494e3f8768",
+				"KeyExpiry":  "2026-11-08T18:40:20Z",
+				"DiscoKey":   "discokey:1fcf8cb6f2f03c92d7cc80cfaa1999d28386b56d62372e5f9d6e1743e1eebe4b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:39624",
+					"10.65.0.27:39624",
+					"172.17.0.1:39624",
+					"172.19.0.1:39624",
+					"172.20.0.1:39624"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:40:20.30664337Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1481034582966440,
+				"StableID":   "nmurXVGmZC11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ce5cafb20e8f464fd7309cae65831e887be244036dc4e8219bebd1c7dc384f00",
+				"KeyExpiry":  "2026-11-08T18:40:20Z",
+				"DiscoKey":   "discokey:c752cbc612b4813b932ca90b1ac2fcfdafe3488a98f6c0140f000e4a87192c3a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59063",
+					"10.65.0.27:59063",
+					"172.17.0.1:59063",
+					"172.19.0.1:59063",
+					"172.20.0.1:59063"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:40:20.848044346Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3239946332099071,
+				"StableID":   "nYwAhytNJS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fe01efeba5571b10bba7fc07d7bed59a693a9381a66233430b70eacf068a513b",
+				"KeyExpiry":  "2026-11-08T18:40:21Z",
+				"DiscoKey":   "discokey:a08f2c4c494ca9deb14be10a7ee716e89cf4fb18a9342be3075960b3d1992a5e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57350",
+					"10.65.0.27:57350",
+					"172.17.0.1:57350",
+					"172.19.0.1:57350",
+					"172.20.0.1:57350"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:40:21.392723113Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1181865146313478": {
+				"ID":          1181865146313478,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5809610132252533,
+				"StableID":   "nWB6KCcBNn11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       5809610132252533,
+				"Key":        "nodekey:44695cde7e73508dba2bd8befe90c656980ff2212991b1934e7072331683fb6b",
+				"DiscoKey":   "discokey:0d4573f14e3c344fbc90eb10958d36edd9955ae3047039d02191874cbdab916c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54897",
+					"10.65.0.27:54897",
+					"172.17.0.1:54897",
+					"172.19.0.1:54897",
+					"172.20.0.1:54897"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:40:13.638267875Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:44695cde7e73508dba2bd8befe90c656980ff2212991b1934e7072331683fb6b",
+			"MachineKey": "mkey:23da34bc1874bf0663d7e1103fb8d6de72bac7eb2ca14e7785ded59304152f4a",
+			"Peers": [{
+				"ID":         1181865146313478,
+				"StableID":   "nsdcsQbGEA11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e65ba3ec30ccbae668ef978abbf8cc44875e8b5e68ab460515545879e1a5a56b",
+				"DiscoKey":   "discokey:3d081a32ff54c3488064f9e7bead5817b1904419e350dbceaa5225d3bf0d166f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35550",
+					"10.65.0.27:35550",
+					"172.17.0.1:35550",
+					"172.19.0.1:35550",
+					"172.20.0.1:35550"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:40:14.370485639Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8765044338174851,
+				"StableID":   "nxPTgQrhSB21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07f88ef1a6ee16139d70776f6c79c43d3c0f159d0acc375ccf84890f6968fc6c",
+				"DiscoKey":   "discokey:0761a417033fdab0b74c4a98efb5634889f555dd4be46886560757101db1510a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46604",
+					"10.65.0.27:46604",
+					"172.17.0.1:46604",
+					"172.19.0.1:46604",
+					"172.20.0.1:46604"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:40:14.915495854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7221292549266636,
+				"StableID":   "n3ebRP7YPy11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:807d4656cf5f0de044b8fffc549d13f641cb5964f6be862be6d02d60acf22044",
+				"DiscoKey":   "discokey:2233bb766602a51ab4b19e2e0fcb088137c70a74a05a0c9ae199f04a630f461d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56553",
+					"10.65.0.27:56553",
+					"172.17.0.1:56553",
+					"172.19.0.1:56553",
+					"172.20.0.1:56553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:40:15.458217934Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6902047361726117,
+				"StableID":   "nn9VQf5xtv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e13f79fa76b39e38e728cf4361adb106ef81443c278963f725dd4b62aa30726",
+				"DiscoKey":   "discokey:4123e2e1b33bf53671b9a9658556761435158c547f58ac0763032242f737ac74",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53925",
+					"10.65.0.27:53925",
+					"172.17.0.1:53925",
+					"172.19.0.1:53925",
+					"172.20.0.1:53925"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:40:16.023521426Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3721486791053520,
+				"StableID":   "njSN6Z9U4W11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd11a17ab1d3191b175630bd3c34ae8d978a177bd6491fed944c2f9c78470d3c",
+				"DiscoKey":   "discokey:64bfbe357754820ce98e041d10af1b50fe556838b9dfdcf6225025893137dc3b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33268",
+					"10.65.0.27:33268",
+					"172.17.0.1:33268",
+					"172.19.0.1:33268",
+					"172.20.0.1:33268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:40:16.538744124Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6021417669190818,
+				"StableID":   "nMAv33S72p11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:59bf9e80cb4344b001641d3b749fabd176d151635d7c223f75c231f9d261f609",
+				"DiscoKey":   "discokey:a0667d872c772650af20b18bca3412d6d5ba910282a7c64cf8ec1c3e1d9b6258",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44934",
+					"10.65.0.27:44934",
+					"172.17.0.1:44934",
+					"172.19.0.1:44934",
+					"172.20.0.1:44934"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:40:17.080857195Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1412060730063056,
+				"StableID":   "nbgmLaSX2C11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:259ab860832152671856b7872467106d20929910142f1fa8a65ae7600e98c775",
+				"DiscoKey":   "discokey:b0bb816e222f653ea8e7b163bbf764e9d55ec56dd1ed4598e42c83a7050e1b6e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:32970",
+					"10.65.0.27:32970",
+					"172.17.0.1:32970",
+					"172.19.0.1:32970",
+					"172.20.0.1:32970"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:40:17.619990081Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4407851505619092,
+				"StableID":   "nKEFaWnKRb11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5773e1674f6b2e54984c6b8ced707ed0852017f8a14c7c01629398a7d6df3801",
+				"DiscoKey":   "discokey:9f408b0536ae1d44dfaae1cbb4e9cffa9653e973d26fc30f0cb8b34c4b3dac52",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:54117",
+					"10.65.0.27:54117",
+					"172.17.0.1:54117",
+					"172.19.0.1:54117",
+					"172.20.0.1:54117"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:40:18.174260601Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3423678238263718,
+				"StableID":   "nuCe5sDbjT11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7fb5861c7b87af318b08e7fd2fdcbc8cf68c9f3e9c075139f0ed6facf0e5d0f",
+				"DiscoKey":   "discokey:c6b73bc68432bbc3725ac49e95241f04619d9ad9c8c8fbe5e7631eb76b4f470e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60525",
+					"10.65.0.27:60525",
+					"172.17.0.1:60525",
+					"172.19.0.1:60525",
+					"172.20.0.1:60525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:40:18.679974271Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1198495343544994,
+				"StableID":   "nHCNTYSoMA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3cc1eafed253c7985ff23a31f91c84fef02a5b5c2db2aba6c030807ff9397322",
+				"DiscoKey":   "discokey:ee50d9165332537843efb62f32aa634aadeebc2e77343ca79925385bfec0b67c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:52213",
+					"10.65.0.27:52213",
+					"172.17.0.1:52213",
+					"172.19.0.1:52213",
+					"172.20.0.1:52213"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:40:19.251637105Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4603542815329677,
+				"StableID":   "ngLwVHGxwc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6772d3f4f8c0277eb067251a7a11c1ca48be9383ab8f9feeb2159dfd1340133",
+				"DiscoKey":   "discokey:eafa42a5e1acc4a572d7bded1f741a136106973ddcad2512450c65aed5856632",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46841",
+					"10.65.0.27:46841",
+					"172.17.0.1:46841",
+					"172.19.0.1:46841",
+					"172.20.0.1:46841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:40:19.767892007Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8606217454180840,
+				"StableID":   "n5XVprjmCA21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:26e24b58894b54af76d52c1cf10f71a67e70454e0d74ddef424636494e3f8768",
+				"KeyExpiry":  "2026-11-08T18:40:20Z",
+				"DiscoKey":   "discokey:1fcf8cb6f2f03c92d7cc80cfaa1999d28386b56d62372e5f9d6e1743e1eebe4b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:39624",
+					"10.65.0.27:39624",
+					"172.17.0.1:39624",
+					"172.19.0.1:39624",
+					"172.20.0.1:39624"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:40:20.30664337Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1481034582966440,
+				"StableID":   "nmurXVGmZC11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ce5cafb20e8f464fd7309cae65831e887be244036dc4e8219bebd1c7dc384f00",
+				"KeyExpiry":  "2026-11-08T18:40:20Z",
+				"DiscoKey":   "discokey:c752cbc612b4813b932ca90b1ac2fcfdafe3488a98f6c0140f000e4a87192c3a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59063",
+					"10.65.0.27:59063",
+					"172.17.0.1:59063",
+					"172.19.0.1:59063",
+					"172.20.0.1:59063"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:40:20.848044346Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3239946332099071,
+				"StableID":   "nYwAhytNJS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fe01efeba5571b10bba7fc07d7bed59a693a9381a66233430b70eacf068a513b",
+				"KeyExpiry":  "2026-11-08T18:40:21Z",
+				"DiscoKey":   "discokey:a08f2c4c494ca9deb14be10a7ee716e89cf4fb18a9342be3075960b3d1992a5e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57350",
+					"10.65.0.27:57350",
+					"172.17.0.1:57350",
+					"172.19.0.1:57350",
+					"172.20.0.1:57350"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:40:21.392723113Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5809610132252533": {
+				"ID":          5809610132252533,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6902047361726117,
+				"StableID":   "nn9VQf5xtv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       6902047361726117,
+				"Key":        "nodekey:0e13f79fa76b39e38e728cf4361adb106ef81443c278963f725dd4b62aa30726",
+				"DiscoKey":   "discokey:4123e2e1b33bf53671b9a9658556761435158c547f58ac0763032242f737ac74",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53925",
+					"10.65.0.27:53925",
+					"172.17.0.1:53925",
+					"172.19.0.1:53925",
+					"172.20.0.1:53925"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:40:16.023521426Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0e13f79fa76b39e38e728cf4361adb106ef81443c278963f725dd4b62aa30726",
+			"MachineKey": "mkey:ddd349df5f457a7d142d5e50827f72eaa8364cedda8bf02a7254ba0a9582fd78",
+			"Peers": [{
+				"ID":         5809610132252533,
+				"StableID":   "nWB6KCcBNn11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:44695cde7e73508dba2bd8befe90c656980ff2212991b1934e7072331683fb6b",
+				"DiscoKey":   "discokey:0d4573f14e3c344fbc90eb10958d36edd9955ae3047039d02191874cbdab916c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54897",
+					"10.65.0.27:54897",
+					"172.17.0.1:54897",
+					"172.19.0.1:54897",
+					"172.20.0.1:54897"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:40:13.638267875Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1181865146313478,
+				"StableID":   "nsdcsQbGEA11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e65ba3ec30ccbae668ef978abbf8cc44875e8b5e68ab460515545879e1a5a56b",
+				"DiscoKey":   "discokey:3d081a32ff54c3488064f9e7bead5817b1904419e350dbceaa5225d3bf0d166f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35550",
+					"10.65.0.27:35550",
+					"172.17.0.1:35550",
+					"172.19.0.1:35550",
+					"172.20.0.1:35550"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:40:14.370485639Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8765044338174851,
+				"StableID":   "nxPTgQrhSB21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07f88ef1a6ee16139d70776f6c79c43d3c0f159d0acc375ccf84890f6968fc6c",
+				"DiscoKey":   "discokey:0761a417033fdab0b74c4a98efb5634889f555dd4be46886560757101db1510a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46604",
+					"10.65.0.27:46604",
+					"172.17.0.1:46604",
+					"172.19.0.1:46604",
+					"172.20.0.1:46604"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:40:14.915495854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7221292549266636,
+				"StableID":   "n3ebRP7YPy11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:807d4656cf5f0de044b8fffc549d13f641cb5964f6be862be6d02d60acf22044",
+				"DiscoKey":   "discokey:2233bb766602a51ab4b19e2e0fcb088137c70a74a05a0c9ae199f04a630f461d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56553",
+					"10.65.0.27:56553",
+					"172.17.0.1:56553",
+					"172.19.0.1:56553",
+					"172.20.0.1:56553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:40:15.458217934Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3721486791053520,
+				"StableID":   "njSN6Z9U4W11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd11a17ab1d3191b175630bd3c34ae8d978a177bd6491fed944c2f9c78470d3c",
+				"DiscoKey":   "discokey:64bfbe357754820ce98e041d10af1b50fe556838b9dfdcf6225025893137dc3b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33268",
+					"10.65.0.27:33268",
+					"172.17.0.1:33268",
+					"172.19.0.1:33268",
+					"172.20.0.1:33268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:40:16.538744124Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6021417669190818,
+				"StableID":   "nMAv33S72p11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:59bf9e80cb4344b001641d3b749fabd176d151635d7c223f75c231f9d261f609",
+				"DiscoKey":   "discokey:a0667d872c772650af20b18bca3412d6d5ba910282a7c64cf8ec1c3e1d9b6258",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44934",
+					"10.65.0.27:44934",
+					"172.17.0.1:44934",
+					"172.19.0.1:44934",
+					"172.20.0.1:44934"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:40:17.080857195Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1412060730063056,
+				"StableID":   "nbgmLaSX2C11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:259ab860832152671856b7872467106d20929910142f1fa8a65ae7600e98c775",
+				"DiscoKey":   "discokey:b0bb816e222f653ea8e7b163bbf764e9d55ec56dd1ed4598e42c83a7050e1b6e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:32970",
+					"10.65.0.27:32970",
+					"172.17.0.1:32970",
+					"172.19.0.1:32970",
+					"172.20.0.1:32970"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:40:17.619990081Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4407851505619092,
+				"StableID":   "nKEFaWnKRb11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5773e1674f6b2e54984c6b8ced707ed0852017f8a14c7c01629398a7d6df3801",
+				"DiscoKey":   "discokey:9f408b0536ae1d44dfaae1cbb4e9cffa9653e973d26fc30f0cb8b34c4b3dac52",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:54117",
+					"10.65.0.27:54117",
+					"172.17.0.1:54117",
+					"172.19.0.1:54117",
+					"172.20.0.1:54117"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:40:18.174260601Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3423678238263718,
+				"StableID":   "nuCe5sDbjT11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7fb5861c7b87af318b08e7fd2fdcbc8cf68c9f3e9c075139f0ed6facf0e5d0f",
+				"DiscoKey":   "discokey:c6b73bc68432bbc3725ac49e95241f04619d9ad9c8c8fbe5e7631eb76b4f470e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60525",
+					"10.65.0.27:60525",
+					"172.17.0.1:60525",
+					"172.19.0.1:60525",
+					"172.20.0.1:60525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:40:18.679974271Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1198495343544994,
+				"StableID":   "nHCNTYSoMA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3cc1eafed253c7985ff23a31f91c84fef02a5b5c2db2aba6c030807ff9397322",
+				"DiscoKey":   "discokey:ee50d9165332537843efb62f32aa634aadeebc2e77343ca79925385bfec0b67c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:52213",
+					"10.65.0.27:52213",
+					"172.17.0.1:52213",
+					"172.19.0.1:52213",
+					"172.20.0.1:52213"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:40:19.251637105Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4603542815329677,
+				"StableID":   "ngLwVHGxwc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6772d3f4f8c0277eb067251a7a11c1ca48be9383ab8f9feeb2159dfd1340133",
+				"DiscoKey":   "discokey:eafa42a5e1acc4a572d7bded1f741a136106973ddcad2512450c65aed5856632",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46841",
+					"10.65.0.27:46841",
+					"172.17.0.1:46841",
+					"172.19.0.1:46841",
+					"172.20.0.1:46841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:40:19.767892007Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8606217454180840,
+				"StableID":   "n5XVprjmCA21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:26e24b58894b54af76d52c1cf10f71a67e70454e0d74ddef424636494e3f8768",
+				"KeyExpiry":  "2026-11-08T18:40:20Z",
+				"DiscoKey":   "discokey:1fcf8cb6f2f03c92d7cc80cfaa1999d28386b56d62372e5f9d6e1743e1eebe4b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:39624",
+					"10.65.0.27:39624",
+					"172.17.0.1:39624",
+					"172.19.0.1:39624",
+					"172.20.0.1:39624"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:40:20.30664337Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1481034582966440,
+				"StableID":   "nmurXVGmZC11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ce5cafb20e8f464fd7309cae65831e887be244036dc4e8219bebd1c7dc384f00",
+				"KeyExpiry":  "2026-11-08T18:40:20Z",
+				"DiscoKey":   "discokey:c752cbc612b4813b932ca90b1ac2fcfdafe3488a98f6c0140f000e4a87192c3a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59063",
+					"10.65.0.27:59063",
+					"172.17.0.1:59063",
+					"172.19.0.1:59063",
+					"172.20.0.1:59063"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:40:20.848044346Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3239946332099071,
+				"StableID":   "nYwAhytNJS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fe01efeba5571b10bba7fc07d7bed59a693a9381a66233430b70eacf068a513b",
+				"KeyExpiry":  "2026-11-08T18:40:21Z",
+				"DiscoKey":   "discokey:a08f2c4c494ca9deb14be10a7ee716e89cf4fb18a9342be3075960b3d1992a5e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57350",
+					"10.65.0.27:57350",
+					"172.17.0.1:57350",
+					"172.19.0.1:57350",
+					"172.20.0.1:57350"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:40:21.392723113Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6902047361726117": {
+				"ID":          6902047361726117,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7221292549266636,
+				"StableID":   "n3ebRP7YPy11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       7221292549266636,
+				"Key":        "nodekey:807d4656cf5f0de044b8fffc549d13f641cb5964f6be862be6d02d60acf22044",
+				"DiscoKey":   "discokey:2233bb766602a51ab4b19e2e0fcb088137c70a74a05a0c9ae199f04a630f461d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56553",
+					"10.65.0.27:56553",
+					"172.17.0.1:56553",
+					"172.19.0.1:56553",
+					"172.20.0.1:56553"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:40:15.458217934Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:807d4656cf5f0de044b8fffc549d13f641cb5964f6be862be6d02d60acf22044",
+			"MachineKey": "mkey:003d1795782c8ada6246fd46ebb826c552aae3e57bbadf582b6d071818f58b0b",
+			"Peers": [{
+				"ID":         5809610132252533,
+				"StableID":   "nWB6KCcBNn11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:44695cde7e73508dba2bd8befe90c656980ff2212991b1934e7072331683fb6b",
+				"DiscoKey":   "discokey:0d4573f14e3c344fbc90eb10958d36edd9955ae3047039d02191874cbdab916c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54897",
+					"10.65.0.27:54897",
+					"172.17.0.1:54897",
+					"172.19.0.1:54897",
+					"172.20.0.1:54897"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:40:13.638267875Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1181865146313478,
+				"StableID":   "nsdcsQbGEA11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e65ba3ec30ccbae668ef978abbf8cc44875e8b5e68ab460515545879e1a5a56b",
+				"DiscoKey":   "discokey:3d081a32ff54c3488064f9e7bead5817b1904419e350dbceaa5225d3bf0d166f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35550",
+					"10.65.0.27:35550",
+					"172.17.0.1:35550",
+					"172.19.0.1:35550",
+					"172.20.0.1:35550"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:40:14.370485639Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8765044338174851,
+				"StableID":   "nxPTgQrhSB21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07f88ef1a6ee16139d70776f6c79c43d3c0f159d0acc375ccf84890f6968fc6c",
+				"DiscoKey":   "discokey:0761a417033fdab0b74c4a98efb5634889f555dd4be46886560757101db1510a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46604",
+					"10.65.0.27:46604",
+					"172.17.0.1:46604",
+					"172.19.0.1:46604",
+					"172.20.0.1:46604"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:40:14.915495854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6902047361726117,
+				"StableID":   "nn9VQf5xtv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e13f79fa76b39e38e728cf4361adb106ef81443c278963f725dd4b62aa30726",
+				"DiscoKey":   "discokey:4123e2e1b33bf53671b9a9658556761435158c547f58ac0763032242f737ac74",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53925",
+					"10.65.0.27:53925",
+					"172.17.0.1:53925",
+					"172.19.0.1:53925",
+					"172.20.0.1:53925"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:40:16.023521426Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3721486791053520,
+				"StableID":   "njSN6Z9U4W11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd11a17ab1d3191b175630bd3c34ae8d978a177bd6491fed944c2f9c78470d3c",
+				"DiscoKey":   "discokey:64bfbe357754820ce98e041d10af1b50fe556838b9dfdcf6225025893137dc3b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33268",
+					"10.65.0.27:33268",
+					"172.17.0.1:33268",
+					"172.19.0.1:33268",
+					"172.20.0.1:33268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:40:16.538744124Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6021417669190818,
+				"StableID":   "nMAv33S72p11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:59bf9e80cb4344b001641d3b749fabd176d151635d7c223f75c231f9d261f609",
+				"DiscoKey":   "discokey:a0667d872c772650af20b18bca3412d6d5ba910282a7c64cf8ec1c3e1d9b6258",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44934",
+					"10.65.0.27:44934",
+					"172.17.0.1:44934",
+					"172.19.0.1:44934",
+					"172.20.0.1:44934"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:40:17.080857195Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1412060730063056,
+				"StableID":   "nbgmLaSX2C11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:259ab860832152671856b7872467106d20929910142f1fa8a65ae7600e98c775",
+				"DiscoKey":   "discokey:b0bb816e222f653ea8e7b163bbf764e9d55ec56dd1ed4598e42c83a7050e1b6e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:32970",
+					"10.65.0.27:32970",
+					"172.17.0.1:32970",
+					"172.19.0.1:32970",
+					"172.20.0.1:32970"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:40:17.619990081Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4407851505619092,
+				"StableID":   "nKEFaWnKRb11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5773e1674f6b2e54984c6b8ced707ed0852017f8a14c7c01629398a7d6df3801",
+				"DiscoKey":   "discokey:9f408b0536ae1d44dfaae1cbb4e9cffa9653e973d26fc30f0cb8b34c4b3dac52",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:54117",
+					"10.65.0.27:54117",
+					"172.17.0.1:54117",
+					"172.19.0.1:54117",
+					"172.20.0.1:54117"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:40:18.174260601Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3423678238263718,
+				"StableID":   "nuCe5sDbjT11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7fb5861c7b87af318b08e7fd2fdcbc8cf68c9f3e9c075139f0ed6facf0e5d0f",
+				"DiscoKey":   "discokey:c6b73bc68432bbc3725ac49e95241f04619d9ad9c8c8fbe5e7631eb76b4f470e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60525",
+					"10.65.0.27:60525",
+					"172.17.0.1:60525",
+					"172.19.0.1:60525",
+					"172.20.0.1:60525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:40:18.679974271Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1198495343544994,
+				"StableID":   "nHCNTYSoMA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3cc1eafed253c7985ff23a31f91c84fef02a5b5c2db2aba6c030807ff9397322",
+				"DiscoKey":   "discokey:ee50d9165332537843efb62f32aa634aadeebc2e77343ca79925385bfec0b67c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:52213",
+					"10.65.0.27:52213",
+					"172.17.0.1:52213",
+					"172.19.0.1:52213",
+					"172.20.0.1:52213"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:40:19.251637105Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4603542815329677,
+				"StableID":   "ngLwVHGxwc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6772d3f4f8c0277eb067251a7a11c1ca48be9383ab8f9feeb2159dfd1340133",
+				"DiscoKey":   "discokey:eafa42a5e1acc4a572d7bded1f741a136106973ddcad2512450c65aed5856632",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46841",
+					"10.65.0.27:46841",
+					"172.17.0.1:46841",
+					"172.19.0.1:46841",
+					"172.20.0.1:46841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:40:19.767892007Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8606217454180840,
+				"StableID":   "n5XVprjmCA21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:26e24b58894b54af76d52c1cf10f71a67e70454e0d74ddef424636494e3f8768",
+				"KeyExpiry":  "2026-11-08T18:40:20Z",
+				"DiscoKey":   "discokey:1fcf8cb6f2f03c92d7cc80cfaa1999d28386b56d62372e5f9d6e1743e1eebe4b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:39624",
+					"10.65.0.27:39624",
+					"172.17.0.1:39624",
+					"172.19.0.1:39624",
+					"172.20.0.1:39624"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:40:20.30664337Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1481034582966440,
+				"StableID":   "nmurXVGmZC11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ce5cafb20e8f464fd7309cae65831e887be244036dc4e8219bebd1c7dc384f00",
+				"KeyExpiry":  "2026-11-08T18:40:20Z",
+				"DiscoKey":   "discokey:c752cbc612b4813b932ca90b1ac2fcfdafe3488a98f6c0140f000e4a87192c3a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59063",
+					"10.65.0.27:59063",
+					"172.17.0.1:59063",
+					"172.19.0.1:59063",
+					"172.20.0.1:59063"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:40:20.848044346Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3239946332099071,
+				"StableID":   "nYwAhytNJS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fe01efeba5571b10bba7fc07d7bed59a693a9381a66233430b70eacf068a513b",
+				"KeyExpiry":  "2026-11-08T18:40:21Z",
+				"DiscoKey":   "discokey:a08f2c4c494ca9deb14be10a7ee716e89cf4fb18a9342be3075960b3d1992a5e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57350",
+					"10.65.0.27:57350",
+					"172.17.0.1:57350",
+					"172.19.0.1:57350",
+					"172.20.0.1:57350"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:40:21.392723113Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7221292549266636": {
+				"ID":          7221292549266636,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6021417669190818,
+				"StableID":   "nMAv33S72p11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       6021417669190818,
+				"Key":        "nodekey:59bf9e80cb4344b001641d3b749fabd176d151635d7c223f75c231f9d261f609",
+				"DiscoKey":   "discokey:a0667d872c772650af20b18bca3412d6d5ba910282a7c64cf8ec1c3e1d9b6258",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44934",
+					"10.65.0.27:44934",
+					"172.17.0.1:44934",
+					"172.19.0.1:44934",
+					"172.20.0.1:44934"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:40:17.080857195Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:59bf9e80cb4344b001641d3b749fabd176d151635d7c223f75c231f9d261f609",
+			"MachineKey": "mkey:7da4300ce69f0a5776674b2146330ec4a54de0a29a893d43eda38b0113a2d465",
+			"Peers": [{
+				"ID":         5809610132252533,
+				"StableID":   "nWB6KCcBNn11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:44695cde7e73508dba2bd8befe90c656980ff2212991b1934e7072331683fb6b",
+				"DiscoKey":   "discokey:0d4573f14e3c344fbc90eb10958d36edd9955ae3047039d02191874cbdab916c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54897",
+					"10.65.0.27:54897",
+					"172.17.0.1:54897",
+					"172.19.0.1:54897",
+					"172.20.0.1:54897"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:40:13.638267875Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1181865146313478,
+				"StableID":   "nsdcsQbGEA11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e65ba3ec30ccbae668ef978abbf8cc44875e8b5e68ab460515545879e1a5a56b",
+				"DiscoKey":   "discokey:3d081a32ff54c3488064f9e7bead5817b1904419e350dbceaa5225d3bf0d166f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35550",
+					"10.65.0.27:35550",
+					"172.17.0.1:35550",
+					"172.19.0.1:35550",
+					"172.20.0.1:35550"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:40:14.370485639Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8765044338174851,
+				"StableID":   "nxPTgQrhSB21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07f88ef1a6ee16139d70776f6c79c43d3c0f159d0acc375ccf84890f6968fc6c",
+				"DiscoKey":   "discokey:0761a417033fdab0b74c4a98efb5634889f555dd4be46886560757101db1510a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46604",
+					"10.65.0.27:46604",
+					"172.17.0.1:46604",
+					"172.19.0.1:46604",
+					"172.20.0.1:46604"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:40:14.915495854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7221292549266636,
+				"StableID":   "n3ebRP7YPy11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:807d4656cf5f0de044b8fffc549d13f641cb5964f6be862be6d02d60acf22044",
+				"DiscoKey":   "discokey:2233bb766602a51ab4b19e2e0fcb088137c70a74a05a0c9ae199f04a630f461d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56553",
+					"10.65.0.27:56553",
+					"172.17.0.1:56553",
+					"172.19.0.1:56553",
+					"172.20.0.1:56553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:40:15.458217934Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6902047361726117,
+				"StableID":   "nn9VQf5xtv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e13f79fa76b39e38e728cf4361adb106ef81443c278963f725dd4b62aa30726",
+				"DiscoKey":   "discokey:4123e2e1b33bf53671b9a9658556761435158c547f58ac0763032242f737ac74",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53925",
+					"10.65.0.27:53925",
+					"172.17.0.1:53925",
+					"172.19.0.1:53925",
+					"172.20.0.1:53925"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:40:16.023521426Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3721486791053520,
+				"StableID":   "njSN6Z9U4W11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd11a17ab1d3191b175630bd3c34ae8d978a177bd6491fed944c2f9c78470d3c",
+				"DiscoKey":   "discokey:64bfbe357754820ce98e041d10af1b50fe556838b9dfdcf6225025893137dc3b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33268",
+					"10.65.0.27:33268",
+					"172.17.0.1:33268",
+					"172.19.0.1:33268",
+					"172.20.0.1:33268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:40:16.538744124Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1412060730063056,
+				"StableID":   "nbgmLaSX2C11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:259ab860832152671856b7872467106d20929910142f1fa8a65ae7600e98c775",
+				"DiscoKey":   "discokey:b0bb816e222f653ea8e7b163bbf764e9d55ec56dd1ed4598e42c83a7050e1b6e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:32970",
+					"10.65.0.27:32970",
+					"172.17.0.1:32970",
+					"172.19.0.1:32970",
+					"172.20.0.1:32970"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:40:17.619990081Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4407851505619092,
+				"StableID":   "nKEFaWnKRb11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5773e1674f6b2e54984c6b8ced707ed0852017f8a14c7c01629398a7d6df3801",
+				"DiscoKey":   "discokey:9f408b0536ae1d44dfaae1cbb4e9cffa9653e973d26fc30f0cb8b34c4b3dac52",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:54117",
+					"10.65.0.27:54117",
+					"172.17.0.1:54117",
+					"172.19.0.1:54117",
+					"172.20.0.1:54117"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:40:18.174260601Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3423678238263718,
+				"StableID":   "nuCe5sDbjT11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7fb5861c7b87af318b08e7fd2fdcbc8cf68c9f3e9c075139f0ed6facf0e5d0f",
+				"DiscoKey":   "discokey:c6b73bc68432bbc3725ac49e95241f04619d9ad9c8c8fbe5e7631eb76b4f470e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60525",
+					"10.65.0.27:60525",
+					"172.17.0.1:60525",
+					"172.19.0.1:60525",
+					"172.20.0.1:60525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:40:18.679974271Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1198495343544994,
+				"StableID":   "nHCNTYSoMA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3cc1eafed253c7985ff23a31f91c84fef02a5b5c2db2aba6c030807ff9397322",
+				"DiscoKey":   "discokey:ee50d9165332537843efb62f32aa634aadeebc2e77343ca79925385bfec0b67c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:52213",
+					"10.65.0.27:52213",
+					"172.17.0.1:52213",
+					"172.19.0.1:52213",
+					"172.20.0.1:52213"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:40:19.251637105Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4603542815329677,
+				"StableID":   "ngLwVHGxwc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6772d3f4f8c0277eb067251a7a11c1ca48be9383ab8f9feeb2159dfd1340133",
+				"DiscoKey":   "discokey:eafa42a5e1acc4a572d7bded1f741a136106973ddcad2512450c65aed5856632",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46841",
+					"10.65.0.27:46841",
+					"172.17.0.1:46841",
+					"172.19.0.1:46841",
+					"172.20.0.1:46841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:40:19.767892007Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8606217454180840,
+				"StableID":   "n5XVprjmCA21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:26e24b58894b54af76d52c1cf10f71a67e70454e0d74ddef424636494e3f8768",
+				"KeyExpiry":  "2026-11-08T18:40:20Z",
+				"DiscoKey":   "discokey:1fcf8cb6f2f03c92d7cc80cfaa1999d28386b56d62372e5f9d6e1743e1eebe4b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:39624",
+					"10.65.0.27:39624",
+					"172.17.0.1:39624",
+					"172.19.0.1:39624",
+					"172.20.0.1:39624"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:40:20.30664337Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1481034582966440,
+				"StableID":   "nmurXVGmZC11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ce5cafb20e8f464fd7309cae65831e887be244036dc4e8219bebd1c7dc384f00",
+				"KeyExpiry":  "2026-11-08T18:40:20Z",
+				"DiscoKey":   "discokey:c752cbc612b4813b932ca90b1ac2fcfdafe3488a98f6c0140f000e4a87192c3a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59063",
+					"10.65.0.27:59063",
+					"172.17.0.1:59063",
+					"172.19.0.1:59063",
+					"172.20.0.1:59063"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:40:20.848044346Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3239946332099071,
+				"StableID":   "nYwAhytNJS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fe01efeba5571b10bba7fc07d7bed59a693a9381a66233430b70eacf068a513b",
+				"KeyExpiry":  "2026-11-08T18:40:21Z",
+				"DiscoKey":   "discokey:a08f2c4c494ca9deb14be10a7ee716e89cf4fb18a9342be3075960b3d1992a5e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57350",
+					"10.65.0.27:57350",
+					"172.17.0.1:57350",
+					"172.19.0.1:57350",
+					"172.20.0.1:57350"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:40:21.392723113Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6021417669190818": {
+				"ID":          6021417669190818,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4407851505619092,
+				"StableID":   "nKEFaWnKRb11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       4407851505619092,
+				"Key":        "nodekey:5773e1674f6b2e54984c6b8ced707ed0852017f8a14c7c01629398a7d6df3801",
+				"DiscoKey":   "discokey:9f408b0536ae1d44dfaae1cbb4e9cffa9653e973d26fc30f0cb8b34c4b3dac52",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:54117",
+					"10.65.0.27:54117",
+					"172.17.0.1:54117",
+					"172.19.0.1:54117",
+					"172.20.0.1:54117"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:40:18.174260601Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5773e1674f6b2e54984c6b8ced707ed0852017f8a14c7c01629398a7d6df3801",
+			"MachineKey": "mkey:a1a1a1d7a5aa2a7cf7ffd3535d63e1339b7e574e1059f0aefe3efbc91f675405",
+			"Peers": [{
+				"ID":         5809610132252533,
+				"StableID":   "nWB6KCcBNn11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:44695cde7e73508dba2bd8befe90c656980ff2212991b1934e7072331683fb6b",
+				"DiscoKey":   "discokey:0d4573f14e3c344fbc90eb10958d36edd9955ae3047039d02191874cbdab916c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54897",
+					"10.65.0.27:54897",
+					"172.17.0.1:54897",
+					"172.19.0.1:54897",
+					"172.20.0.1:54897"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:40:13.638267875Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1181865146313478,
+				"StableID":   "nsdcsQbGEA11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e65ba3ec30ccbae668ef978abbf8cc44875e8b5e68ab460515545879e1a5a56b",
+				"DiscoKey":   "discokey:3d081a32ff54c3488064f9e7bead5817b1904419e350dbceaa5225d3bf0d166f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35550",
+					"10.65.0.27:35550",
+					"172.17.0.1:35550",
+					"172.19.0.1:35550",
+					"172.20.0.1:35550"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:40:14.370485639Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8765044338174851,
+				"StableID":   "nxPTgQrhSB21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07f88ef1a6ee16139d70776f6c79c43d3c0f159d0acc375ccf84890f6968fc6c",
+				"DiscoKey":   "discokey:0761a417033fdab0b74c4a98efb5634889f555dd4be46886560757101db1510a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46604",
+					"10.65.0.27:46604",
+					"172.17.0.1:46604",
+					"172.19.0.1:46604",
+					"172.20.0.1:46604"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:40:14.915495854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7221292549266636,
+				"StableID":   "n3ebRP7YPy11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:807d4656cf5f0de044b8fffc549d13f641cb5964f6be862be6d02d60acf22044",
+				"DiscoKey":   "discokey:2233bb766602a51ab4b19e2e0fcb088137c70a74a05a0c9ae199f04a630f461d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56553",
+					"10.65.0.27:56553",
+					"172.17.0.1:56553",
+					"172.19.0.1:56553",
+					"172.20.0.1:56553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:40:15.458217934Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6902047361726117,
+				"StableID":   "nn9VQf5xtv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e13f79fa76b39e38e728cf4361adb106ef81443c278963f725dd4b62aa30726",
+				"DiscoKey":   "discokey:4123e2e1b33bf53671b9a9658556761435158c547f58ac0763032242f737ac74",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53925",
+					"10.65.0.27:53925",
+					"172.17.0.1:53925",
+					"172.19.0.1:53925",
+					"172.20.0.1:53925"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:40:16.023521426Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3721486791053520,
+				"StableID":   "njSN6Z9U4W11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd11a17ab1d3191b175630bd3c34ae8d978a177bd6491fed944c2f9c78470d3c",
+				"DiscoKey":   "discokey:64bfbe357754820ce98e041d10af1b50fe556838b9dfdcf6225025893137dc3b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33268",
+					"10.65.0.27:33268",
+					"172.17.0.1:33268",
+					"172.19.0.1:33268",
+					"172.20.0.1:33268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:40:16.538744124Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6021417669190818,
+				"StableID":   "nMAv33S72p11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:59bf9e80cb4344b001641d3b749fabd176d151635d7c223f75c231f9d261f609",
+				"DiscoKey":   "discokey:a0667d872c772650af20b18bca3412d6d5ba910282a7c64cf8ec1c3e1d9b6258",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44934",
+					"10.65.0.27:44934",
+					"172.17.0.1:44934",
+					"172.19.0.1:44934",
+					"172.20.0.1:44934"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:40:17.080857195Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1412060730063056,
+				"StableID":   "nbgmLaSX2C11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:259ab860832152671856b7872467106d20929910142f1fa8a65ae7600e98c775",
+				"DiscoKey":   "discokey:b0bb816e222f653ea8e7b163bbf764e9d55ec56dd1ed4598e42c83a7050e1b6e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:32970",
+					"10.65.0.27:32970",
+					"172.17.0.1:32970",
+					"172.19.0.1:32970",
+					"172.20.0.1:32970"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:40:17.619990081Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3423678238263718,
+				"StableID":   "nuCe5sDbjT11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7fb5861c7b87af318b08e7fd2fdcbc8cf68c9f3e9c075139f0ed6facf0e5d0f",
+				"DiscoKey":   "discokey:c6b73bc68432bbc3725ac49e95241f04619d9ad9c8c8fbe5e7631eb76b4f470e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60525",
+					"10.65.0.27:60525",
+					"172.17.0.1:60525",
+					"172.19.0.1:60525",
+					"172.20.0.1:60525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:40:18.679974271Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1198495343544994,
+				"StableID":   "nHCNTYSoMA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3cc1eafed253c7985ff23a31f91c84fef02a5b5c2db2aba6c030807ff9397322",
+				"DiscoKey":   "discokey:ee50d9165332537843efb62f32aa634aadeebc2e77343ca79925385bfec0b67c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:52213",
+					"10.65.0.27:52213",
+					"172.17.0.1:52213",
+					"172.19.0.1:52213",
+					"172.20.0.1:52213"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:40:19.251637105Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4603542815329677,
+				"StableID":   "ngLwVHGxwc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6772d3f4f8c0277eb067251a7a11c1ca48be9383ab8f9feeb2159dfd1340133",
+				"DiscoKey":   "discokey:eafa42a5e1acc4a572d7bded1f741a136106973ddcad2512450c65aed5856632",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46841",
+					"10.65.0.27:46841",
+					"172.17.0.1:46841",
+					"172.19.0.1:46841",
+					"172.20.0.1:46841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:40:19.767892007Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8606217454180840,
+				"StableID":   "n5XVprjmCA21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:26e24b58894b54af76d52c1cf10f71a67e70454e0d74ddef424636494e3f8768",
+				"KeyExpiry":  "2026-11-08T18:40:20Z",
+				"DiscoKey":   "discokey:1fcf8cb6f2f03c92d7cc80cfaa1999d28386b56d62372e5f9d6e1743e1eebe4b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:39624",
+					"10.65.0.27:39624",
+					"172.17.0.1:39624",
+					"172.19.0.1:39624",
+					"172.20.0.1:39624"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:40:20.30664337Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1481034582966440,
+				"StableID":   "nmurXVGmZC11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ce5cafb20e8f464fd7309cae65831e887be244036dc4e8219bebd1c7dc384f00",
+				"KeyExpiry":  "2026-11-08T18:40:20Z",
+				"DiscoKey":   "discokey:c752cbc612b4813b932ca90b1ac2fcfdafe3488a98f6c0140f000e4a87192c3a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59063",
+					"10.65.0.27:59063",
+					"172.17.0.1:59063",
+					"172.19.0.1:59063",
+					"172.20.0.1:59063"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:40:20.848044346Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3239946332099071,
+				"StableID":   "nYwAhytNJS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fe01efeba5571b10bba7fc07d7bed59a693a9381a66233430b70eacf068a513b",
+				"KeyExpiry":  "2026-11-08T18:40:21Z",
+				"DiscoKey":   "discokey:a08f2c4c494ca9deb14be10a7ee716e89cf4fb18a9342be3075960b3d1992a5e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57350",
+					"10.65.0.27:57350",
+					"172.17.0.1:57350",
+					"172.19.0.1:57350",
+					"172.20.0.1:57350"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:40:21.392723113Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4407851505619092": {
+				"ID":          4407851505619092,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1481034582966440,
+				"StableID":   "nmurXVGmZC11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ce5cafb20e8f464fd7309cae65831e887be244036dc4e8219bebd1c7dc384f00",
+				"KeyExpiry":  "2026-11-08T18:40:20Z",
+				"DiscoKey":   "discokey:c752cbc612b4813b932ca90b1ac2fcfdafe3488a98f6c0140f000e4a87192c3a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59063",
+					"10.65.0.27:59063",
+					"172.17.0.1:59063",
+					"172.19.0.1:59063",
+					"172.20.0.1:59063"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:40:20.848044346Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ce5cafb20e8f464fd7309cae65831e887be244036dc4e8219bebd1c7dc384f00",
+			"MachineKey": "mkey:f8310df581d4c30e19e06803d93e64424201ba5674aacc29bbc143272ed2311e",
+			"Peers": [{
+				"ID":         5809610132252533,
+				"StableID":   "nWB6KCcBNn11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:44695cde7e73508dba2bd8befe90c656980ff2212991b1934e7072331683fb6b",
+				"DiscoKey":   "discokey:0d4573f14e3c344fbc90eb10958d36edd9955ae3047039d02191874cbdab916c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54897",
+					"10.65.0.27:54897",
+					"172.17.0.1:54897",
+					"172.19.0.1:54897",
+					"172.20.0.1:54897"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:40:13.638267875Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1181865146313478,
+				"StableID":   "nsdcsQbGEA11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e65ba3ec30ccbae668ef978abbf8cc44875e8b5e68ab460515545879e1a5a56b",
+				"DiscoKey":   "discokey:3d081a32ff54c3488064f9e7bead5817b1904419e350dbceaa5225d3bf0d166f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35550",
+					"10.65.0.27:35550",
+					"172.17.0.1:35550",
+					"172.19.0.1:35550",
+					"172.20.0.1:35550"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:40:14.370485639Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8765044338174851,
+				"StableID":   "nxPTgQrhSB21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07f88ef1a6ee16139d70776f6c79c43d3c0f159d0acc375ccf84890f6968fc6c",
+				"DiscoKey":   "discokey:0761a417033fdab0b74c4a98efb5634889f555dd4be46886560757101db1510a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46604",
+					"10.65.0.27:46604",
+					"172.17.0.1:46604",
+					"172.19.0.1:46604",
+					"172.20.0.1:46604"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:40:14.915495854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7221292549266636,
+				"StableID":   "n3ebRP7YPy11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:807d4656cf5f0de044b8fffc549d13f641cb5964f6be862be6d02d60acf22044",
+				"DiscoKey":   "discokey:2233bb766602a51ab4b19e2e0fcb088137c70a74a05a0c9ae199f04a630f461d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56553",
+					"10.65.0.27:56553",
+					"172.17.0.1:56553",
+					"172.19.0.1:56553",
+					"172.20.0.1:56553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:40:15.458217934Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6902047361726117,
+				"StableID":   "nn9VQf5xtv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e13f79fa76b39e38e728cf4361adb106ef81443c278963f725dd4b62aa30726",
+				"DiscoKey":   "discokey:4123e2e1b33bf53671b9a9658556761435158c547f58ac0763032242f737ac74",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53925",
+					"10.65.0.27:53925",
+					"172.17.0.1:53925",
+					"172.19.0.1:53925",
+					"172.20.0.1:53925"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:40:16.023521426Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3721486791053520,
+				"StableID":   "njSN6Z9U4W11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd11a17ab1d3191b175630bd3c34ae8d978a177bd6491fed944c2f9c78470d3c",
+				"DiscoKey":   "discokey:64bfbe357754820ce98e041d10af1b50fe556838b9dfdcf6225025893137dc3b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33268",
+					"10.65.0.27:33268",
+					"172.17.0.1:33268",
+					"172.19.0.1:33268",
+					"172.20.0.1:33268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:40:16.538744124Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6021417669190818,
+				"StableID":   "nMAv33S72p11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:59bf9e80cb4344b001641d3b749fabd176d151635d7c223f75c231f9d261f609",
+				"DiscoKey":   "discokey:a0667d872c772650af20b18bca3412d6d5ba910282a7c64cf8ec1c3e1d9b6258",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44934",
+					"10.65.0.27:44934",
+					"172.17.0.1:44934",
+					"172.19.0.1:44934",
+					"172.20.0.1:44934"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:40:17.080857195Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1412060730063056,
+				"StableID":   "nbgmLaSX2C11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:259ab860832152671856b7872467106d20929910142f1fa8a65ae7600e98c775",
+				"DiscoKey":   "discokey:b0bb816e222f653ea8e7b163bbf764e9d55ec56dd1ed4598e42c83a7050e1b6e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:32970",
+					"10.65.0.27:32970",
+					"172.17.0.1:32970",
+					"172.19.0.1:32970",
+					"172.20.0.1:32970"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:40:17.619990081Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4407851505619092,
+				"StableID":   "nKEFaWnKRb11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5773e1674f6b2e54984c6b8ced707ed0852017f8a14c7c01629398a7d6df3801",
+				"DiscoKey":   "discokey:9f408b0536ae1d44dfaae1cbb4e9cffa9653e973d26fc30f0cb8b34c4b3dac52",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:54117",
+					"10.65.0.27:54117",
+					"172.17.0.1:54117",
+					"172.19.0.1:54117",
+					"172.20.0.1:54117"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:40:18.174260601Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3423678238263718,
+				"StableID":   "nuCe5sDbjT11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e7fb5861c7b87af318b08e7fd2fdcbc8cf68c9f3e9c075139f0ed6facf0e5d0f",
+				"DiscoKey":   "discokey:c6b73bc68432bbc3725ac49e95241f04619d9ad9c8c8fbe5e7631eb76b4f470e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60525",
+					"10.65.0.27:60525",
+					"172.17.0.1:60525",
+					"172.19.0.1:60525",
+					"172.20.0.1:60525"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:40:18.679974271Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1198495343544994,
+				"StableID":   "nHCNTYSoMA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3cc1eafed253c7985ff23a31f91c84fef02a5b5c2db2aba6c030807ff9397322",
+				"DiscoKey":   "discokey:ee50d9165332537843efb62f32aa634aadeebc2e77343ca79925385bfec0b67c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:52213",
+					"10.65.0.27:52213",
+					"172.17.0.1:52213",
+					"172.19.0.1:52213",
+					"172.20.0.1:52213"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:40:19.251637105Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4603542815329677,
+				"StableID":   "ngLwVHGxwc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6772d3f4f8c0277eb067251a7a11c1ca48be9383ab8f9feeb2159dfd1340133",
+				"DiscoKey":   "discokey:eafa42a5e1acc4a572d7bded1f741a136106973ddcad2512450c65aed5856632",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46841",
+					"10.65.0.27:46841",
+					"172.17.0.1:46841",
+					"172.19.0.1:46841",
+					"172.20.0.1:46841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:40:19.767892007Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8606217454180840,
+				"StableID":   "n5XVprjmCA21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:26e24b58894b54af76d52c1cf10f71a67e70454e0d74ddef424636494e3f8768",
+				"KeyExpiry":  "2026-11-08T18:40:20Z",
+				"DiscoKey":   "discokey:1fcf8cb6f2f03c92d7cc80cfaa1999d28386b56d62372e5f9d6e1743e1eebe4b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:39624",
+					"10.65.0.27:39624",
+					"172.17.0.1:39624",
+					"172.19.0.1:39624",
+					"172.20.0.1:39624"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:40:20.30664337Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3239946332099071,
+				"StableID":   "nYwAhytNJS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fe01efeba5571b10bba7fc07d7bed59a693a9381a66233430b70eacf068a513b",
+				"KeyExpiry":  "2026-11-08T18:40:21Z",
+				"DiscoKey":   "discokey:a08f2c4c494ca9deb14be10a7ee716e89cf4fb18a9342be3075960b3d1992a5e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57350",
+					"10.65.0.27:57350",
+					"172.17.0.1:57350",
+					"172.19.0.1:57350",
+					"172.20.0.1:57350"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:40:21.392723113Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3423678238263718,
+				"StableID":   "nuCe5sDbjT11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       3423678238263718,
+				"Key":        "nodekey:e7fb5861c7b87af318b08e7fd2fdcbc8cf68c9f3e9c075139f0ed6facf0e5d0f",
+				"DiscoKey":   "discokey:c6b73bc68432bbc3725ac49e95241f04619d9ad9c8c8fbe5e7631eb76b4f470e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:60525",
+					"10.65.0.27:60525",
+					"172.17.0.1:60525",
+					"172.19.0.1:60525",
+					"172.20.0.1:60525"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:40:18.679974271Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e7fb5861c7b87af318b08e7fd2fdcbc8cf68c9f3e9c075139f0ed6facf0e5d0f",
+			"MachineKey": "mkey:54c265c029d80447ab69cad758dbf3e9631d546b3e8fa882fdc841268178d147",
+			"Peers": [{
+				"ID":         5809610132252533,
+				"StableID":   "nWB6KCcBNn11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:44695cde7e73508dba2bd8befe90c656980ff2212991b1934e7072331683fb6b",
+				"DiscoKey":   "discokey:0d4573f14e3c344fbc90eb10958d36edd9955ae3047039d02191874cbdab916c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:54897",
+					"10.65.0.27:54897",
+					"172.17.0.1:54897",
+					"172.19.0.1:54897",
+					"172.20.0.1:54897"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:40:13.638267875Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1181865146313478,
+				"StableID":   "nsdcsQbGEA11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e65ba3ec30ccbae668ef978abbf8cc44875e8b5e68ab460515545879e1a5a56b",
+				"DiscoKey":   "discokey:3d081a32ff54c3488064f9e7bead5817b1904419e350dbceaa5225d3bf0d166f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:35550",
+					"10.65.0.27:35550",
+					"172.17.0.1:35550",
+					"172.19.0.1:35550",
+					"172.20.0.1:35550"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:40:14.370485639Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8765044338174851,
+				"StableID":   "nxPTgQrhSB21CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:07f88ef1a6ee16139d70776f6c79c43d3c0f159d0acc375ccf84890f6968fc6c",
+				"DiscoKey":   "discokey:0761a417033fdab0b74c4a98efb5634889f555dd4be46886560757101db1510a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:46604",
+					"10.65.0.27:46604",
+					"172.17.0.1:46604",
+					"172.19.0.1:46604",
+					"172.20.0.1:46604"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:40:14.915495854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7221292549266636,
+				"StableID":   "n3ebRP7YPy11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:807d4656cf5f0de044b8fffc549d13f641cb5964f6be862be6d02d60acf22044",
+				"DiscoKey":   "discokey:2233bb766602a51ab4b19e2e0fcb088137c70a74a05a0c9ae199f04a630f461d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56553",
+					"10.65.0.27:56553",
+					"172.17.0.1:56553",
+					"172.19.0.1:56553",
+					"172.20.0.1:56553"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:40:15.458217934Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6902047361726117,
+				"StableID":   "nn9VQf5xtv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e13f79fa76b39e38e728cf4361adb106ef81443c278963f725dd4b62aa30726",
+				"DiscoKey":   "discokey:4123e2e1b33bf53671b9a9658556761435158c547f58ac0763032242f737ac74",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53925",
+					"10.65.0.27:53925",
+					"172.17.0.1:53925",
+					"172.19.0.1:53925",
+					"172.20.0.1:53925"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:40:16.023521426Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3721486791053520,
+				"StableID":   "njSN6Z9U4W11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd11a17ab1d3191b175630bd3c34ae8d978a177bd6491fed944c2f9c78470d3c",
+				"DiscoKey":   "discokey:64bfbe357754820ce98e041d10af1b50fe556838b9dfdcf6225025893137dc3b",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:33268",
+					"10.65.0.27:33268",
+					"172.17.0.1:33268",
+					"172.19.0.1:33268",
+					"172.20.0.1:33268"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:40:16.538744124Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6021417669190818,
+				"StableID":   "nMAv33S72p11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:59bf9e80cb4344b001641d3b749fabd176d151635d7c223f75c231f9d261f609",
+				"DiscoKey":   "discokey:a0667d872c772650af20b18bca3412d6d5ba910282a7c64cf8ec1c3e1d9b6258",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:44934",
+					"10.65.0.27:44934",
+					"172.17.0.1:44934",
+					"172.19.0.1:44934",
+					"172.20.0.1:44934"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:40:17.080857195Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1412060730063056,
+				"StableID":   "nbgmLaSX2C11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:259ab860832152671856b7872467106d20929910142f1fa8a65ae7600e98c775",
+				"DiscoKey":   "discokey:b0bb816e222f653ea8e7b163bbf764e9d55ec56dd1ed4598e42c83a7050e1b6e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:32970",
+					"10.65.0.27:32970",
+					"172.17.0.1:32970",
+					"172.19.0.1:32970",
+					"172.20.0.1:32970"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:40:17.619990081Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4407851505619092,
+				"StableID":   "nKEFaWnKRb11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5773e1674f6b2e54984c6b8ced707ed0852017f8a14c7c01629398a7d6df3801",
+				"DiscoKey":   "discokey:9f408b0536ae1d44dfaae1cbb4e9cffa9653e973d26fc30f0cb8b34c4b3dac52",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:54117",
+					"10.65.0.27:54117",
+					"172.17.0.1:54117",
+					"172.19.0.1:54117",
+					"172.20.0.1:54117"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:40:18.174260601Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1198495343544994,
+				"StableID":   "nHCNTYSoMA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3cc1eafed253c7985ff23a31f91c84fef02a5b5c2db2aba6c030807ff9397322",
+				"DiscoKey":   "discokey:ee50d9165332537843efb62f32aa634aadeebc2e77343ca79925385bfec0b67c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:52213",
+					"10.65.0.27:52213",
+					"172.17.0.1:52213",
+					"172.19.0.1:52213",
+					"172.20.0.1:52213"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:40:19.251637105Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4603542815329677,
+				"StableID":   "ngLwVHGxwc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6772d3f4f8c0277eb067251a7a11c1ca48be9383ab8f9feeb2159dfd1340133",
+				"DiscoKey":   "discokey:eafa42a5e1acc4a572d7bded1f741a136106973ddcad2512450c65aed5856632",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:46841",
+					"10.65.0.27:46841",
+					"172.17.0.1:46841",
+					"172.19.0.1:46841",
+					"172.20.0.1:46841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:40:19.767892007Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8606217454180840,
+				"StableID":   "n5XVprjmCA21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:26e24b58894b54af76d52c1cf10f71a67e70454e0d74ddef424636494e3f8768",
+				"KeyExpiry":  "2026-11-08T18:40:20Z",
+				"DiscoKey":   "discokey:1fcf8cb6f2f03c92d7cc80cfaa1999d28386b56d62372e5f9d6e1743e1eebe4b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:39624",
+					"10.65.0.27:39624",
+					"172.17.0.1:39624",
+					"172.19.0.1:39624",
+					"172.20.0.1:39624"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:40:20.30664337Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1481034582966440,
+				"StableID":   "nmurXVGmZC11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ce5cafb20e8f464fd7309cae65831e887be244036dc4e8219bebd1c7dc384f00",
+				"KeyExpiry":  "2026-11-08T18:40:20Z",
+				"DiscoKey":   "discokey:c752cbc612b4813b932ca90b1ac2fcfdafe3488a98f6c0140f000e4a87192c3a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:59063",
+					"10.65.0.27:59063",
+					"172.17.0.1:59063",
+					"172.19.0.1:59063",
+					"172.20.0.1:59063"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:40:20.848044346Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3239946332099071,
+				"StableID":   "nYwAhytNJS11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fe01efeba5571b10bba7fc07d7bed59a693a9381a66233430b70eacf068a513b",
+				"KeyExpiry":  "2026-11-08T18:40:21Z",
+				"DiscoKey":   "discokey:a08f2c4c494ca9deb14be10a7ee716e89cf4fb18a9342be3075960b3d1992a5e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:57350",
+					"10.65.0.27:57350",
+					"172.17.0.1:57350",
+					"172.19.0.1:57350",
+					"172.20.0.1:57350"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:40:21.392723113Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3423678238263718": {
+				"ID":          3423678238263718,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/sshtest_results/sshtest-host-alias-as-dst.hujson
+++ b/hscontrol/policy/v2/testdata/sshtest_results/sshtest-host-alias-as-dst.hujson
@@ -1,0 +1,20100 @@
+// sshtest-host-alias-as-dst
+//
+// host alias as sshTests dst
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T18:41:06Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "sshtest-host-alias-as-dst",
+	"description":    "host alias as sshTests dst",
+	"category":       "sshtest",
+	"captured_at":    "2026-05-12T18:41:06.665078067Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                            \n  \n                                                                        \n              \n{\n\t\"category\":    \"sshtest\",\n\t\"description\": \"host alias as sshTests dst\",\n\t\"id\":          \"sshtest-host-alias-as-dst\",\n\t\"policy\": {\"hosts\": {\"srv\": \"100.64.0.16\"}, \"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"thor@example.org\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"sshTests\": [{\n\t\t\"accept\": [\"root\"],\n\t\t\"dst\":    [\"srv\"],\n\t\t\"src\":    \"thor@example.org\"\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/sshtest/sshtest-host-alias-as-dst.hujson",
+		"full_policy": {
+			"hosts": {"srv": "100.64.0.16"},
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["thor@example.org"],
+				"users":  ["root"]
+			}],
+			"sshTests":  [{"accept": ["root"], "dst": ["srv"], "src": "thor@example.org"}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1491238603175504,
+				"StableID":   "nfLerwJPeC11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1491238603175504,
+				"Key":        "nodekey:ba328d303410383602534db8fb5ba72f5596fa90aa5c14f0d365eebc26935e48",
+				"DiscoKey":   "discokey:233b3e5784db6d954d55f681ad0a0d4b5b31b9c7a8924439f292568fad75737f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:60838",
+					"10.65.0.27:60838",
+					"172.17.0.1:60838",
+					"172.19.0.1:60838",
+					"172.20.0.1:60838"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:41:15.371303125Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ba328d303410383602534db8fb5ba72f5596fa90aa5c14f0d365eebc26935e48",
+			"MachineKey": "mkey:24fa6d55b02c2843636612c96f2377b446297dc11abde2e7b242763bbc473b39",
+			"Peers": [{
+				"ID":         240498609966026,
+				"StableID":   "nw9ccTVvs211CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08a50463cd2a8618c86fa9743cb481386625ccf5ad63800379d75f85ad7ccd45",
+				"DiscoKey":   "discokey:c4a4aaf76382f91aedf4eb0b4c7d983862afd0bdbace8aaf248f95f126cd8f79",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:37471",
+					"10.65.0.27:37471",
+					"172.17.0.1:37471",
+					"172.19.0.1:37471",
+					"172.20.0.1:37471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:41:09.221291803Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         341571337179728,
+				"StableID":   "nProQzVhf311CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0565706dd68331ca77ebb52c24e15c825d12ce6d56273a22a575c02cfbb47d03",
+				"DiscoKey":   "discokey:d6559c7b43fe9bda4559ffe8bb0cc4fb9882bcfefc42c046278926020ba5e029",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:52393",
+					"10.65.0.27:52393",
+					"172.17.0.1:52393",
+					"172.19.0.1:52393",
+					"172.20.0.1:52393"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:41:09.712537259Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3510987038080586,
+				"StableID":   "nVrCkCg8RU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89626677e197c4c4ab4063e24e4d0b851e9e31f30a0bf7b0d94a607fccf9d435",
+				"DiscoKey":   "discokey:bf6edaacd9c2e2437536de63475583a735385d7c27ae61683f398571216e970f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57038",
+					"10.65.0.27:57038",
+					"172.17.0.1:57038",
+					"172.19.0.1:57038",
+					"172.20.0.1:57038"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:41:10.258023255Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6210871730105602,
+				"StableID":   "nKmBfy4vVq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af22824f1f4eb5fddd48c970a55fbb3de7241d957bed6a647843b57dad582916",
+				"DiscoKey":   "discokey:d6a41658e27d52234b9966361ffb1f730de2f7640880b3f681e44074e5c29556",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43533",
+					"10.65.0.27:43533",
+					"172.17.0.1:43533",
+					"172.19.0.1:43533",
+					"172.20.0.1:43533"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:41:10.794537399Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8895713735327768,
+				"StableID":   "nVXKrHKtTC21CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b067afeeaddc05dd8d2d6a4175d13f8ed7ad881deef69568261294e0a2b6902f",
+				"DiscoKey":   "discokey:95c211f7d6db0ce545f9fdb2db475199f9705b8a44d71571fd118c6f31444239",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52118",
+					"10.65.0.27:52118",
+					"172.17.0.1:52118",
+					"172.19.0.1:52118",
+					"172.20.0.1:52118"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:41:11.33520277Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6036672185069575,
+				"StableID":   "ngZ9PE929p11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c78295bd39eae7cf0e339da9da6afec8d17333563273f14e1d506925bd1d5a38",
+				"DiscoKey":   "discokey:85276bf5805fd1433d589c0d1a40d1fda06fc604813b7aa351b4a1c090555c15",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40897",
+					"10.65.0.27:40897",
+					"172.17.0.1:40897",
+					"172.19.0.1:40897",
+					"172.20.0.1:40897"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:41:11.899719454Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7599225092640387,
+				"StableID":   "nEaY7vkhL221CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f283efe5dd48f342c58094239f5f650c4aaee320863de0341c3f7afe1202df44",
+				"DiscoKey":   "discokey:d3f29c6a647567f424be839fd6e3a0db91b22ad0b1c880371c45ee1d425ec704",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43890",
+					"10.65.0.27:43890",
+					"172.17.0.1:43890",
+					"172.19.0.1:43890",
+					"172.20.0.1:43890"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:41:12.423400737Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1156665432318304,
+				"StableID":   "nsiUS6er2A11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e2ee16b751e1367569f4bca507e2fa8d7c39f276e6bd8045888d08e57507b26",
+				"DiscoKey":   "discokey:70271273bdef94681a9a3d2c71256197185c20aa6939ed8d3622d19abd6a2a19",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:32865",
+					"10.65.0.27:32865",
+					"172.17.0.1:32865",
+					"172.19.0.1:32865",
+					"172.20.0.1:32865"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:41:12.96415126Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7118969969782211,
+				"StableID":   "nA4pTdGCbx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0051b5c6157b41a2c1c8e17fcd6096ada3c6ea149d502c9266cdade174c3f107",
+				"DiscoKey":   "discokey:4c62525bdb5cddf6b8a07f8e33ceb1e9ec92616276654615f4d6f8f409dfbd7b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37240",
+					"10.65.0.27:37240",
+					"172.17.0.1:37240",
+					"172.19.0.1:37240",
+					"172.20.0.1:37240"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:41:13.503847073Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8714220496961158,
+				"StableID":   "nwbUs9og3B21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a9f329975df1ad90f87b4d9a5b3f8f3089944ba40aa27375219c973988334951",
+				"DiscoKey":   "discokey:bb9dac3bdf9553866636640c4e8c09d0a9e1cdc0d39b904a232d1eb28e64de4d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50155",
+					"10.65.0.27:50155",
+					"172.17.0.1:50155",
+					"172.19.0.1:50155",
+					"172.20.0.1:50155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:41:14.294560245Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3749613256813633,
+				"StableID":   "nGaKZxyCHW11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90fbc29d18637b89c100d4fe7db24ad225e54f823f03f395527f08f4910ea52c",
+				"DiscoKey":   "discokey:60093ed47698d591358247326e00939a53012482a0c973525fd058ab56ce580c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58799",
+					"10.65.0.27:58799",
+					"172.17.0.1:58799",
+					"172.19.0.1:58799",
+					"172.20.0.1:58799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:41:14.828130908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4503593138210239,
+				"StableID":   "nxB2onkgAc11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:61a418955218509ba7a58707b775298eeb7970dc44c6177feb921d74569b2148",
+				"KeyExpiry":  "2026-11-08T18:41:15Z",
+				"DiscoKey":   "discokey:f455e93b2306a4568e896e309cc4f19bb5d76cfabc08eb4dae1f2f7103149c38",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53550",
+					"10.65.0.27:53550",
+					"172.17.0.1:53550",
+					"172.19.0.1:53550",
+					"172.20.0.1:53550"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:41:15.91852783Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5565423625422992,
+				"StableID":   "nHu5tzEbTk11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:08ae16170f4d7633588f2ab6c5d75f16e8e93f2e6d1d33147602f9476e7b0d29",
+				"KeyExpiry":  "2026-11-08T18:41:16Z",
+				"DiscoKey":   "discokey:b02d1adf6327312a287e2573c334eb7611a3673ab7b74df4c0bdb2a490abde78",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47365",
+					"10.65.0.27:47365",
+					"172.17.0.1:47365",
+					"172.19.0.1:47365",
+					"172.20.0.1:47365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:41:16.460447379Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4102605109684321,
+				"StableID":   "nEZEqoU53Z11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3baf2a6ce0936e23578b1314280906653476724fe82c56c82d44a2688e94396c",
+				"KeyExpiry":  "2026-11-08T18:41:16Z",
+				"DiscoKey":   "discokey:6e48d70ecb1b911c363d17e4b37aeb98cc43163d2b3ef8952686c439e664aa23",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44089",
+					"10.65.0.27:44089",
+					"172.17.0.1:44089",
+					"172.19.0.1:44089",
+					"172.20.0.1:44089"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:41:16.996929073Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{
+				"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+				"sshUsers":   {"root": "root"},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				}
+			}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1491238603175504": {
+				"ID":          1491238603175504,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		},
+		"ssh_rules": [{
+			"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+			"sshUsers":   {"root": "root"},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}
+		}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6036672185069575,
+				"StableID":   "ngZ9PE929p11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       6036672185069575,
+				"Key":        "nodekey:c78295bd39eae7cf0e339da9da6afec8d17333563273f14e1d506925bd1d5a38",
+				"DiscoKey":   "discokey:85276bf5805fd1433d589c0d1a40d1fda06fc604813b7aa351b4a1c090555c15",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40897",
+					"10.65.0.27:40897",
+					"172.17.0.1:40897",
+					"172.19.0.1:40897",
+					"172.20.0.1:40897"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:41:11.899719454Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c78295bd39eae7cf0e339da9da6afec8d17333563273f14e1d506925bd1d5a38",
+			"MachineKey": "mkey:38e4ec7eca18612420911a2e6663e70d2362c3a0dbb940b6fe1516be94826c32",
+			"Peers": [{
+				"ID":         240498609966026,
+				"StableID":   "nw9ccTVvs211CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08a50463cd2a8618c86fa9743cb481386625ccf5ad63800379d75f85ad7ccd45",
+				"DiscoKey":   "discokey:c4a4aaf76382f91aedf4eb0b4c7d983862afd0bdbace8aaf248f95f126cd8f79",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:37471",
+					"10.65.0.27:37471",
+					"172.17.0.1:37471",
+					"172.19.0.1:37471",
+					"172.20.0.1:37471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:41:09.221291803Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         341571337179728,
+				"StableID":   "nProQzVhf311CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0565706dd68331ca77ebb52c24e15c825d12ce6d56273a22a575c02cfbb47d03",
+				"DiscoKey":   "discokey:d6559c7b43fe9bda4559ffe8bb0cc4fb9882bcfefc42c046278926020ba5e029",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:52393",
+					"10.65.0.27:52393",
+					"172.17.0.1:52393",
+					"172.19.0.1:52393",
+					"172.20.0.1:52393"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:41:09.712537259Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3510987038080586,
+				"StableID":   "nVrCkCg8RU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89626677e197c4c4ab4063e24e4d0b851e9e31f30a0bf7b0d94a607fccf9d435",
+				"DiscoKey":   "discokey:bf6edaacd9c2e2437536de63475583a735385d7c27ae61683f398571216e970f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57038",
+					"10.65.0.27:57038",
+					"172.17.0.1:57038",
+					"172.19.0.1:57038",
+					"172.20.0.1:57038"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:41:10.258023255Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6210871730105602,
+				"StableID":   "nKmBfy4vVq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af22824f1f4eb5fddd48c970a55fbb3de7241d957bed6a647843b57dad582916",
+				"DiscoKey":   "discokey:d6a41658e27d52234b9966361ffb1f730de2f7640880b3f681e44074e5c29556",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43533",
+					"10.65.0.27:43533",
+					"172.17.0.1:43533",
+					"172.19.0.1:43533",
+					"172.20.0.1:43533"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:41:10.794537399Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8895713735327768,
+				"StableID":   "nVXKrHKtTC21CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b067afeeaddc05dd8d2d6a4175d13f8ed7ad881deef69568261294e0a2b6902f",
+				"DiscoKey":   "discokey:95c211f7d6db0ce545f9fdb2db475199f9705b8a44d71571fd118c6f31444239",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52118",
+					"10.65.0.27:52118",
+					"172.17.0.1:52118",
+					"172.19.0.1:52118",
+					"172.20.0.1:52118"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:41:11.33520277Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7599225092640387,
+				"StableID":   "nEaY7vkhL221CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f283efe5dd48f342c58094239f5f650c4aaee320863de0341c3f7afe1202df44",
+				"DiscoKey":   "discokey:d3f29c6a647567f424be839fd6e3a0db91b22ad0b1c880371c45ee1d425ec704",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43890",
+					"10.65.0.27:43890",
+					"172.17.0.1:43890",
+					"172.19.0.1:43890",
+					"172.20.0.1:43890"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:41:12.423400737Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1156665432318304,
+				"StableID":   "nsiUS6er2A11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e2ee16b751e1367569f4bca507e2fa8d7c39f276e6bd8045888d08e57507b26",
+				"DiscoKey":   "discokey:70271273bdef94681a9a3d2c71256197185c20aa6939ed8d3622d19abd6a2a19",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:32865",
+					"10.65.0.27:32865",
+					"172.17.0.1:32865",
+					"172.19.0.1:32865",
+					"172.20.0.1:32865"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:41:12.96415126Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7118969969782211,
+				"StableID":   "nA4pTdGCbx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0051b5c6157b41a2c1c8e17fcd6096ada3c6ea149d502c9266cdade174c3f107",
+				"DiscoKey":   "discokey:4c62525bdb5cddf6b8a07f8e33ceb1e9ec92616276654615f4d6f8f409dfbd7b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37240",
+					"10.65.0.27:37240",
+					"172.17.0.1:37240",
+					"172.19.0.1:37240",
+					"172.20.0.1:37240"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:41:13.503847073Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8714220496961158,
+				"StableID":   "nwbUs9og3B21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a9f329975df1ad90f87b4d9a5b3f8f3089944ba40aa27375219c973988334951",
+				"DiscoKey":   "discokey:bb9dac3bdf9553866636640c4e8c09d0a9e1cdc0d39b904a232d1eb28e64de4d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50155",
+					"10.65.0.27:50155",
+					"172.17.0.1:50155",
+					"172.19.0.1:50155",
+					"172.20.0.1:50155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:41:14.294560245Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3749613256813633,
+				"StableID":   "nGaKZxyCHW11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90fbc29d18637b89c100d4fe7db24ad225e54f823f03f395527f08f4910ea52c",
+				"DiscoKey":   "discokey:60093ed47698d591358247326e00939a53012482a0c973525fd058ab56ce580c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58799",
+					"10.65.0.27:58799",
+					"172.17.0.1:58799",
+					"172.19.0.1:58799",
+					"172.20.0.1:58799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:41:14.828130908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1491238603175504,
+				"StableID":   "nfLerwJPeC11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba328d303410383602534db8fb5ba72f5596fa90aa5c14f0d365eebc26935e48",
+				"DiscoKey":   "discokey:233b3e5784db6d954d55f681ad0a0d4b5b31b9c7a8924439f292568fad75737f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:60838",
+					"10.65.0.27:60838",
+					"172.17.0.1:60838",
+					"172.19.0.1:60838",
+					"172.20.0.1:60838"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:41:15.371303125Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4503593138210239,
+				"StableID":   "nxB2onkgAc11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:61a418955218509ba7a58707b775298eeb7970dc44c6177feb921d74569b2148",
+				"KeyExpiry":  "2026-11-08T18:41:15Z",
+				"DiscoKey":   "discokey:f455e93b2306a4568e896e309cc4f19bb5d76cfabc08eb4dae1f2f7103149c38",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53550",
+					"10.65.0.27:53550",
+					"172.17.0.1:53550",
+					"172.19.0.1:53550",
+					"172.20.0.1:53550"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:41:15.91852783Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5565423625422992,
+				"StableID":   "nHu5tzEbTk11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:08ae16170f4d7633588f2ab6c5d75f16e8e93f2e6d1d33147602f9476e7b0d29",
+				"KeyExpiry":  "2026-11-08T18:41:16Z",
+				"DiscoKey":   "discokey:b02d1adf6327312a287e2573c334eb7611a3673ab7b74df4c0bdb2a490abde78",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47365",
+					"10.65.0.27:47365",
+					"172.17.0.1:47365",
+					"172.19.0.1:47365",
+					"172.20.0.1:47365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:41:16.460447379Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4102605109684321,
+				"StableID":   "nEZEqoU53Z11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3baf2a6ce0936e23578b1314280906653476724fe82c56c82d44a2688e94396c",
+				"KeyExpiry":  "2026-11-08T18:41:16Z",
+				"DiscoKey":   "discokey:6e48d70ecb1b911c363d17e4b37aeb98cc43163d2b3ef8952686c439e664aa23",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44089",
+					"10.65.0.27:44089",
+					"172.17.0.1:44089",
+					"172.19.0.1:44089",
+					"172.20.0.1:44089"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:41:16.996929073Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6036672185069575": {
+				"ID":          6036672185069575,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4102605109684321,
+				"StableID":   "nEZEqoU53Z11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3baf2a6ce0936e23578b1314280906653476724fe82c56c82d44a2688e94396c",
+				"KeyExpiry":  "2026-11-08T18:41:16Z",
+				"DiscoKey":   "discokey:6e48d70ecb1b911c363d17e4b37aeb98cc43163d2b3ef8952686c439e664aa23",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44089",
+					"10.65.0.27:44089",
+					"172.17.0.1:44089",
+					"172.19.0.1:44089",
+					"172.20.0.1:44089"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:41:16.996929073Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3baf2a6ce0936e23578b1314280906653476724fe82c56c82d44a2688e94396c",
+			"MachineKey": "mkey:d002a6e03b199444f16bcdc3040967fe5a0a37c2c9d033886393bcc87247d034",
+			"Peers": [{
+				"ID":         240498609966026,
+				"StableID":   "nw9ccTVvs211CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08a50463cd2a8618c86fa9743cb481386625ccf5ad63800379d75f85ad7ccd45",
+				"DiscoKey":   "discokey:c4a4aaf76382f91aedf4eb0b4c7d983862afd0bdbace8aaf248f95f126cd8f79",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:37471",
+					"10.65.0.27:37471",
+					"172.17.0.1:37471",
+					"172.19.0.1:37471",
+					"172.20.0.1:37471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:41:09.221291803Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         341571337179728,
+				"StableID":   "nProQzVhf311CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0565706dd68331ca77ebb52c24e15c825d12ce6d56273a22a575c02cfbb47d03",
+				"DiscoKey":   "discokey:d6559c7b43fe9bda4559ffe8bb0cc4fb9882bcfefc42c046278926020ba5e029",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:52393",
+					"10.65.0.27:52393",
+					"172.17.0.1:52393",
+					"172.19.0.1:52393",
+					"172.20.0.1:52393"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:41:09.712537259Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3510987038080586,
+				"StableID":   "nVrCkCg8RU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89626677e197c4c4ab4063e24e4d0b851e9e31f30a0bf7b0d94a607fccf9d435",
+				"DiscoKey":   "discokey:bf6edaacd9c2e2437536de63475583a735385d7c27ae61683f398571216e970f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57038",
+					"10.65.0.27:57038",
+					"172.17.0.1:57038",
+					"172.19.0.1:57038",
+					"172.20.0.1:57038"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:41:10.258023255Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6210871730105602,
+				"StableID":   "nKmBfy4vVq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af22824f1f4eb5fddd48c970a55fbb3de7241d957bed6a647843b57dad582916",
+				"DiscoKey":   "discokey:d6a41658e27d52234b9966361ffb1f730de2f7640880b3f681e44074e5c29556",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43533",
+					"10.65.0.27:43533",
+					"172.17.0.1:43533",
+					"172.19.0.1:43533",
+					"172.20.0.1:43533"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:41:10.794537399Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8895713735327768,
+				"StableID":   "nVXKrHKtTC21CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b067afeeaddc05dd8d2d6a4175d13f8ed7ad881deef69568261294e0a2b6902f",
+				"DiscoKey":   "discokey:95c211f7d6db0ce545f9fdb2db475199f9705b8a44d71571fd118c6f31444239",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52118",
+					"10.65.0.27:52118",
+					"172.17.0.1:52118",
+					"172.19.0.1:52118",
+					"172.20.0.1:52118"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:41:11.33520277Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6036672185069575,
+				"StableID":   "ngZ9PE929p11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c78295bd39eae7cf0e339da9da6afec8d17333563273f14e1d506925bd1d5a38",
+				"DiscoKey":   "discokey:85276bf5805fd1433d589c0d1a40d1fda06fc604813b7aa351b4a1c090555c15",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40897",
+					"10.65.0.27:40897",
+					"172.17.0.1:40897",
+					"172.19.0.1:40897",
+					"172.20.0.1:40897"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:41:11.899719454Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7599225092640387,
+				"StableID":   "nEaY7vkhL221CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f283efe5dd48f342c58094239f5f650c4aaee320863de0341c3f7afe1202df44",
+				"DiscoKey":   "discokey:d3f29c6a647567f424be839fd6e3a0db91b22ad0b1c880371c45ee1d425ec704",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43890",
+					"10.65.0.27:43890",
+					"172.17.0.1:43890",
+					"172.19.0.1:43890",
+					"172.20.0.1:43890"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:41:12.423400737Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1156665432318304,
+				"StableID":   "nsiUS6er2A11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e2ee16b751e1367569f4bca507e2fa8d7c39f276e6bd8045888d08e57507b26",
+				"DiscoKey":   "discokey:70271273bdef94681a9a3d2c71256197185c20aa6939ed8d3622d19abd6a2a19",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:32865",
+					"10.65.0.27:32865",
+					"172.17.0.1:32865",
+					"172.19.0.1:32865",
+					"172.20.0.1:32865"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:41:12.96415126Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7118969969782211,
+				"StableID":   "nA4pTdGCbx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0051b5c6157b41a2c1c8e17fcd6096ada3c6ea149d502c9266cdade174c3f107",
+				"DiscoKey":   "discokey:4c62525bdb5cddf6b8a07f8e33ceb1e9ec92616276654615f4d6f8f409dfbd7b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37240",
+					"10.65.0.27:37240",
+					"172.17.0.1:37240",
+					"172.19.0.1:37240",
+					"172.20.0.1:37240"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:41:13.503847073Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8714220496961158,
+				"StableID":   "nwbUs9og3B21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a9f329975df1ad90f87b4d9a5b3f8f3089944ba40aa27375219c973988334951",
+				"DiscoKey":   "discokey:bb9dac3bdf9553866636640c4e8c09d0a9e1cdc0d39b904a232d1eb28e64de4d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50155",
+					"10.65.0.27:50155",
+					"172.17.0.1:50155",
+					"172.19.0.1:50155",
+					"172.20.0.1:50155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:41:14.294560245Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3749613256813633,
+				"StableID":   "nGaKZxyCHW11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90fbc29d18637b89c100d4fe7db24ad225e54f823f03f395527f08f4910ea52c",
+				"DiscoKey":   "discokey:60093ed47698d591358247326e00939a53012482a0c973525fd058ab56ce580c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58799",
+					"10.65.0.27:58799",
+					"172.17.0.1:58799",
+					"172.19.0.1:58799",
+					"172.20.0.1:58799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:41:14.828130908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1491238603175504,
+				"StableID":   "nfLerwJPeC11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba328d303410383602534db8fb5ba72f5596fa90aa5c14f0d365eebc26935e48",
+				"DiscoKey":   "discokey:233b3e5784db6d954d55f681ad0a0d4b5b31b9c7a8924439f292568fad75737f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:60838",
+					"10.65.0.27:60838",
+					"172.17.0.1:60838",
+					"172.19.0.1:60838",
+					"172.20.0.1:60838"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:41:15.371303125Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4503593138210239,
+				"StableID":   "nxB2onkgAc11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:61a418955218509ba7a58707b775298eeb7970dc44c6177feb921d74569b2148",
+				"KeyExpiry":  "2026-11-08T18:41:15Z",
+				"DiscoKey":   "discokey:f455e93b2306a4568e896e309cc4f19bb5d76cfabc08eb4dae1f2f7103149c38",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53550",
+					"10.65.0.27:53550",
+					"172.17.0.1:53550",
+					"172.19.0.1:53550",
+					"172.20.0.1:53550"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:41:15.91852783Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5565423625422992,
+				"StableID":   "nHu5tzEbTk11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:08ae16170f4d7633588f2ab6c5d75f16e8e93f2e6d1d33147602f9476e7b0d29",
+				"KeyExpiry":  "2026-11-08T18:41:16Z",
+				"DiscoKey":   "discokey:b02d1adf6327312a287e2573c334eb7611a3673ab7b74df4c0bdb2a490abde78",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47365",
+					"10.65.0.27:47365",
+					"172.17.0.1:47365",
+					"172.19.0.1:47365",
+					"172.20.0.1:47365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:41:16.460447379Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3510987038080586,
+				"StableID":   "nVrCkCg8RU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       3510987038080586,
+				"Key":        "nodekey:89626677e197c4c4ab4063e24e4d0b851e9e31f30a0bf7b0d94a607fccf9d435",
+				"DiscoKey":   "discokey:bf6edaacd9c2e2437536de63475583a735385d7c27ae61683f398571216e970f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57038",
+					"10.65.0.27:57038",
+					"172.17.0.1:57038",
+					"172.19.0.1:57038",
+					"172.20.0.1:57038"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:41:10.258023255Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:89626677e197c4c4ab4063e24e4d0b851e9e31f30a0bf7b0d94a607fccf9d435",
+			"MachineKey": "mkey:ddedfae0efcf3d12936174ece2888032f03c935f1f597b147b89f6b2c0fd4115",
+			"Peers": [{
+				"ID":         240498609966026,
+				"StableID":   "nw9ccTVvs211CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08a50463cd2a8618c86fa9743cb481386625ccf5ad63800379d75f85ad7ccd45",
+				"DiscoKey":   "discokey:c4a4aaf76382f91aedf4eb0b4c7d983862afd0bdbace8aaf248f95f126cd8f79",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:37471",
+					"10.65.0.27:37471",
+					"172.17.0.1:37471",
+					"172.19.0.1:37471",
+					"172.20.0.1:37471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:41:09.221291803Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         341571337179728,
+				"StableID":   "nProQzVhf311CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0565706dd68331ca77ebb52c24e15c825d12ce6d56273a22a575c02cfbb47d03",
+				"DiscoKey":   "discokey:d6559c7b43fe9bda4559ffe8bb0cc4fb9882bcfefc42c046278926020ba5e029",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:52393",
+					"10.65.0.27:52393",
+					"172.17.0.1:52393",
+					"172.19.0.1:52393",
+					"172.20.0.1:52393"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:41:09.712537259Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6210871730105602,
+				"StableID":   "nKmBfy4vVq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af22824f1f4eb5fddd48c970a55fbb3de7241d957bed6a647843b57dad582916",
+				"DiscoKey":   "discokey:d6a41658e27d52234b9966361ffb1f730de2f7640880b3f681e44074e5c29556",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43533",
+					"10.65.0.27:43533",
+					"172.17.0.1:43533",
+					"172.19.0.1:43533",
+					"172.20.0.1:43533"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:41:10.794537399Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8895713735327768,
+				"StableID":   "nVXKrHKtTC21CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b067afeeaddc05dd8d2d6a4175d13f8ed7ad881deef69568261294e0a2b6902f",
+				"DiscoKey":   "discokey:95c211f7d6db0ce545f9fdb2db475199f9705b8a44d71571fd118c6f31444239",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52118",
+					"10.65.0.27:52118",
+					"172.17.0.1:52118",
+					"172.19.0.1:52118",
+					"172.20.0.1:52118"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:41:11.33520277Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6036672185069575,
+				"StableID":   "ngZ9PE929p11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c78295bd39eae7cf0e339da9da6afec8d17333563273f14e1d506925bd1d5a38",
+				"DiscoKey":   "discokey:85276bf5805fd1433d589c0d1a40d1fda06fc604813b7aa351b4a1c090555c15",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40897",
+					"10.65.0.27:40897",
+					"172.17.0.1:40897",
+					"172.19.0.1:40897",
+					"172.20.0.1:40897"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:41:11.899719454Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7599225092640387,
+				"StableID":   "nEaY7vkhL221CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f283efe5dd48f342c58094239f5f650c4aaee320863de0341c3f7afe1202df44",
+				"DiscoKey":   "discokey:d3f29c6a647567f424be839fd6e3a0db91b22ad0b1c880371c45ee1d425ec704",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43890",
+					"10.65.0.27:43890",
+					"172.17.0.1:43890",
+					"172.19.0.1:43890",
+					"172.20.0.1:43890"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:41:12.423400737Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1156665432318304,
+				"StableID":   "nsiUS6er2A11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e2ee16b751e1367569f4bca507e2fa8d7c39f276e6bd8045888d08e57507b26",
+				"DiscoKey":   "discokey:70271273bdef94681a9a3d2c71256197185c20aa6939ed8d3622d19abd6a2a19",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:32865",
+					"10.65.0.27:32865",
+					"172.17.0.1:32865",
+					"172.19.0.1:32865",
+					"172.20.0.1:32865"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:41:12.96415126Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7118969969782211,
+				"StableID":   "nA4pTdGCbx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0051b5c6157b41a2c1c8e17fcd6096ada3c6ea149d502c9266cdade174c3f107",
+				"DiscoKey":   "discokey:4c62525bdb5cddf6b8a07f8e33ceb1e9ec92616276654615f4d6f8f409dfbd7b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37240",
+					"10.65.0.27:37240",
+					"172.17.0.1:37240",
+					"172.19.0.1:37240",
+					"172.20.0.1:37240"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:41:13.503847073Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8714220496961158,
+				"StableID":   "nwbUs9og3B21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a9f329975df1ad90f87b4d9a5b3f8f3089944ba40aa27375219c973988334951",
+				"DiscoKey":   "discokey:bb9dac3bdf9553866636640c4e8c09d0a9e1cdc0d39b904a232d1eb28e64de4d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50155",
+					"10.65.0.27:50155",
+					"172.17.0.1:50155",
+					"172.19.0.1:50155",
+					"172.20.0.1:50155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:41:14.294560245Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3749613256813633,
+				"StableID":   "nGaKZxyCHW11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90fbc29d18637b89c100d4fe7db24ad225e54f823f03f395527f08f4910ea52c",
+				"DiscoKey":   "discokey:60093ed47698d591358247326e00939a53012482a0c973525fd058ab56ce580c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58799",
+					"10.65.0.27:58799",
+					"172.17.0.1:58799",
+					"172.19.0.1:58799",
+					"172.20.0.1:58799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:41:14.828130908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1491238603175504,
+				"StableID":   "nfLerwJPeC11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba328d303410383602534db8fb5ba72f5596fa90aa5c14f0d365eebc26935e48",
+				"DiscoKey":   "discokey:233b3e5784db6d954d55f681ad0a0d4b5b31b9c7a8924439f292568fad75737f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:60838",
+					"10.65.0.27:60838",
+					"172.17.0.1:60838",
+					"172.19.0.1:60838",
+					"172.20.0.1:60838"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:41:15.371303125Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4503593138210239,
+				"StableID":   "nxB2onkgAc11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:61a418955218509ba7a58707b775298eeb7970dc44c6177feb921d74569b2148",
+				"KeyExpiry":  "2026-11-08T18:41:15Z",
+				"DiscoKey":   "discokey:f455e93b2306a4568e896e309cc4f19bb5d76cfabc08eb4dae1f2f7103149c38",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53550",
+					"10.65.0.27:53550",
+					"172.17.0.1:53550",
+					"172.19.0.1:53550",
+					"172.20.0.1:53550"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:41:15.91852783Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5565423625422992,
+				"StableID":   "nHu5tzEbTk11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:08ae16170f4d7633588f2ab6c5d75f16e8e93f2e6d1d33147602f9476e7b0d29",
+				"KeyExpiry":  "2026-11-08T18:41:16Z",
+				"DiscoKey":   "discokey:b02d1adf6327312a287e2573c334eb7611a3673ab7b74df4c0bdb2a490abde78",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47365",
+					"10.65.0.27:47365",
+					"172.17.0.1:47365",
+					"172.19.0.1:47365",
+					"172.20.0.1:47365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:41:16.460447379Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4102605109684321,
+				"StableID":   "nEZEqoU53Z11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3baf2a6ce0936e23578b1314280906653476724fe82c56c82d44a2688e94396c",
+				"KeyExpiry":  "2026-11-08T18:41:16Z",
+				"DiscoKey":   "discokey:6e48d70ecb1b911c363d17e4b37aeb98cc43163d2b3ef8952686c439e664aa23",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44089",
+					"10.65.0.27:44089",
+					"172.17.0.1:44089",
+					"172.19.0.1:44089",
+					"172.20.0.1:44089"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:41:16.996929073Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3510987038080586": {
+				"ID":          3510987038080586,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1156665432318304,
+				"StableID":   "nsiUS6er2A11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1156665432318304,
+				"Key":        "nodekey:0e2ee16b751e1367569f4bca507e2fa8d7c39f276e6bd8045888d08e57507b26",
+				"DiscoKey":   "discokey:70271273bdef94681a9a3d2c71256197185c20aa6939ed8d3622d19abd6a2a19",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:32865",
+					"10.65.0.27:32865",
+					"172.17.0.1:32865",
+					"172.19.0.1:32865",
+					"172.20.0.1:32865"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:41:12.96415126Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0e2ee16b751e1367569f4bca507e2fa8d7c39f276e6bd8045888d08e57507b26",
+			"MachineKey": "mkey:653e8d65010ddeaefca51cb7f8fcbe4e4066e8cb738712462b858e650141e723",
+			"Peers": [{
+				"ID":         240498609966026,
+				"StableID":   "nw9ccTVvs211CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08a50463cd2a8618c86fa9743cb481386625ccf5ad63800379d75f85ad7ccd45",
+				"DiscoKey":   "discokey:c4a4aaf76382f91aedf4eb0b4c7d983862afd0bdbace8aaf248f95f126cd8f79",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:37471",
+					"10.65.0.27:37471",
+					"172.17.0.1:37471",
+					"172.19.0.1:37471",
+					"172.20.0.1:37471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:41:09.221291803Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         341571337179728,
+				"StableID":   "nProQzVhf311CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0565706dd68331ca77ebb52c24e15c825d12ce6d56273a22a575c02cfbb47d03",
+				"DiscoKey":   "discokey:d6559c7b43fe9bda4559ffe8bb0cc4fb9882bcfefc42c046278926020ba5e029",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:52393",
+					"10.65.0.27:52393",
+					"172.17.0.1:52393",
+					"172.19.0.1:52393",
+					"172.20.0.1:52393"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:41:09.712537259Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3510987038080586,
+				"StableID":   "nVrCkCg8RU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89626677e197c4c4ab4063e24e4d0b851e9e31f30a0bf7b0d94a607fccf9d435",
+				"DiscoKey":   "discokey:bf6edaacd9c2e2437536de63475583a735385d7c27ae61683f398571216e970f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57038",
+					"10.65.0.27:57038",
+					"172.17.0.1:57038",
+					"172.19.0.1:57038",
+					"172.20.0.1:57038"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:41:10.258023255Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6210871730105602,
+				"StableID":   "nKmBfy4vVq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af22824f1f4eb5fddd48c970a55fbb3de7241d957bed6a647843b57dad582916",
+				"DiscoKey":   "discokey:d6a41658e27d52234b9966361ffb1f730de2f7640880b3f681e44074e5c29556",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43533",
+					"10.65.0.27:43533",
+					"172.17.0.1:43533",
+					"172.19.0.1:43533",
+					"172.20.0.1:43533"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:41:10.794537399Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8895713735327768,
+				"StableID":   "nVXKrHKtTC21CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b067afeeaddc05dd8d2d6a4175d13f8ed7ad881deef69568261294e0a2b6902f",
+				"DiscoKey":   "discokey:95c211f7d6db0ce545f9fdb2db475199f9705b8a44d71571fd118c6f31444239",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52118",
+					"10.65.0.27:52118",
+					"172.17.0.1:52118",
+					"172.19.0.1:52118",
+					"172.20.0.1:52118"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:41:11.33520277Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6036672185069575,
+				"StableID":   "ngZ9PE929p11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c78295bd39eae7cf0e339da9da6afec8d17333563273f14e1d506925bd1d5a38",
+				"DiscoKey":   "discokey:85276bf5805fd1433d589c0d1a40d1fda06fc604813b7aa351b4a1c090555c15",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40897",
+					"10.65.0.27:40897",
+					"172.17.0.1:40897",
+					"172.19.0.1:40897",
+					"172.20.0.1:40897"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:41:11.899719454Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7599225092640387,
+				"StableID":   "nEaY7vkhL221CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f283efe5dd48f342c58094239f5f650c4aaee320863de0341c3f7afe1202df44",
+				"DiscoKey":   "discokey:d3f29c6a647567f424be839fd6e3a0db91b22ad0b1c880371c45ee1d425ec704",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43890",
+					"10.65.0.27:43890",
+					"172.17.0.1:43890",
+					"172.19.0.1:43890",
+					"172.20.0.1:43890"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:41:12.423400737Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7118969969782211,
+				"StableID":   "nA4pTdGCbx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0051b5c6157b41a2c1c8e17fcd6096ada3c6ea149d502c9266cdade174c3f107",
+				"DiscoKey":   "discokey:4c62525bdb5cddf6b8a07f8e33ceb1e9ec92616276654615f4d6f8f409dfbd7b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37240",
+					"10.65.0.27:37240",
+					"172.17.0.1:37240",
+					"172.19.0.1:37240",
+					"172.20.0.1:37240"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:41:13.503847073Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8714220496961158,
+				"StableID":   "nwbUs9og3B21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a9f329975df1ad90f87b4d9a5b3f8f3089944ba40aa27375219c973988334951",
+				"DiscoKey":   "discokey:bb9dac3bdf9553866636640c4e8c09d0a9e1cdc0d39b904a232d1eb28e64de4d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50155",
+					"10.65.0.27:50155",
+					"172.17.0.1:50155",
+					"172.19.0.1:50155",
+					"172.20.0.1:50155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:41:14.294560245Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3749613256813633,
+				"StableID":   "nGaKZxyCHW11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90fbc29d18637b89c100d4fe7db24ad225e54f823f03f395527f08f4910ea52c",
+				"DiscoKey":   "discokey:60093ed47698d591358247326e00939a53012482a0c973525fd058ab56ce580c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58799",
+					"10.65.0.27:58799",
+					"172.17.0.1:58799",
+					"172.19.0.1:58799",
+					"172.20.0.1:58799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:41:14.828130908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1491238603175504,
+				"StableID":   "nfLerwJPeC11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba328d303410383602534db8fb5ba72f5596fa90aa5c14f0d365eebc26935e48",
+				"DiscoKey":   "discokey:233b3e5784db6d954d55f681ad0a0d4b5b31b9c7a8924439f292568fad75737f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:60838",
+					"10.65.0.27:60838",
+					"172.17.0.1:60838",
+					"172.19.0.1:60838",
+					"172.20.0.1:60838"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:41:15.371303125Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4503593138210239,
+				"StableID":   "nxB2onkgAc11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:61a418955218509ba7a58707b775298eeb7970dc44c6177feb921d74569b2148",
+				"KeyExpiry":  "2026-11-08T18:41:15Z",
+				"DiscoKey":   "discokey:f455e93b2306a4568e896e309cc4f19bb5d76cfabc08eb4dae1f2f7103149c38",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53550",
+					"10.65.0.27:53550",
+					"172.17.0.1:53550",
+					"172.19.0.1:53550",
+					"172.20.0.1:53550"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:41:15.91852783Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5565423625422992,
+				"StableID":   "nHu5tzEbTk11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:08ae16170f4d7633588f2ab6c5d75f16e8e93f2e6d1d33147602f9476e7b0d29",
+				"KeyExpiry":  "2026-11-08T18:41:16Z",
+				"DiscoKey":   "discokey:b02d1adf6327312a287e2573c334eb7611a3673ab7b74df4c0bdb2a490abde78",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47365",
+					"10.65.0.27:47365",
+					"172.17.0.1:47365",
+					"172.19.0.1:47365",
+					"172.20.0.1:47365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:41:16.460447379Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4102605109684321,
+				"StableID":   "nEZEqoU53Z11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3baf2a6ce0936e23578b1314280906653476724fe82c56c82d44a2688e94396c",
+				"KeyExpiry":  "2026-11-08T18:41:16Z",
+				"DiscoKey":   "discokey:6e48d70ecb1b911c363d17e4b37aeb98cc43163d2b3ef8952686c439e664aa23",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44089",
+					"10.65.0.27:44089",
+					"172.17.0.1:44089",
+					"172.19.0.1:44089",
+					"172.20.0.1:44089"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:41:16.996929073Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1156665432318304": {
+				"ID":          1156665432318304,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4503593138210239,
+				"StableID":   "nxB2onkgAc11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:61a418955218509ba7a58707b775298eeb7970dc44c6177feb921d74569b2148",
+				"KeyExpiry":  "2026-11-08T18:41:15Z",
+				"DiscoKey":   "discokey:f455e93b2306a4568e896e309cc4f19bb5d76cfabc08eb4dae1f2f7103149c38",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53550",
+					"10.65.0.27:53550",
+					"172.17.0.1:53550",
+					"172.19.0.1:53550",
+					"172.20.0.1:53550"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:41:15.91852783Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:61a418955218509ba7a58707b775298eeb7970dc44c6177feb921d74569b2148",
+			"MachineKey": "mkey:4f2bb1af31c652cd3b82663406b4656df812c22fa7bcd150cf44cfffa952435d",
+			"Peers": [{
+				"ID":         240498609966026,
+				"StableID":   "nw9ccTVvs211CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08a50463cd2a8618c86fa9743cb481386625ccf5ad63800379d75f85ad7ccd45",
+				"DiscoKey":   "discokey:c4a4aaf76382f91aedf4eb0b4c7d983862afd0bdbace8aaf248f95f126cd8f79",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:37471",
+					"10.65.0.27:37471",
+					"172.17.0.1:37471",
+					"172.19.0.1:37471",
+					"172.20.0.1:37471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:41:09.221291803Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         341571337179728,
+				"StableID":   "nProQzVhf311CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0565706dd68331ca77ebb52c24e15c825d12ce6d56273a22a575c02cfbb47d03",
+				"DiscoKey":   "discokey:d6559c7b43fe9bda4559ffe8bb0cc4fb9882bcfefc42c046278926020ba5e029",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:52393",
+					"10.65.0.27:52393",
+					"172.17.0.1:52393",
+					"172.19.0.1:52393",
+					"172.20.0.1:52393"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:41:09.712537259Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3510987038080586,
+				"StableID":   "nVrCkCg8RU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89626677e197c4c4ab4063e24e4d0b851e9e31f30a0bf7b0d94a607fccf9d435",
+				"DiscoKey":   "discokey:bf6edaacd9c2e2437536de63475583a735385d7c27ae61683f398571216e970f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57038",
+					"10.65.0.27:57038",
+					"172.17.0.1:57038",
+					"172.19.0.1:57038",
+					"172.20.0.1:57038"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:41:10.258023255Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6210871730105602,
+				"StableID":   "nKmBfy4vVq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af22824f1f4eb5fddd48c970a55fbb3de7241d957bed6a647843b57dad582916",
+				"DiscoKey":   "discokey:d6a41658e27d52234b9966361ffb1f730de2f7640880b3f681e44074e5c29556",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43533",
+					"10.65.0.27:43533",
+					"172.17.0.1:43533",
+					"172.19.0.1:43533",
+					"172.20.0.1:43533"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:41:10.794537399Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8895713735327768,
+				"StableID":   "nVXKrHKtTC21CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b067afeeaddc05dd8d2d6a4175d13f8ed7ad881deef69568261294e0a2b6902f",
+				"DiscoKey":   "discokey:95c211f7d6db0ce545f9fdb2db475199f9705b8a44d71571fd118c6f31444239",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52118",
+					"10.65.0.27:52118",
+					"172.17.0.1:52118",
+					"172.19.0.1:52118",
+					"172.20.0.1:52118"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:41:11.33520277Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6036672185069575,
+				"StableID":   "ngZ9PE929p11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c78295bd39eae7cf0e339da9da6afec8d17333563273f14e1d506925bd1d5a38",
+				"DiscoKey":   "discokey:85276bf5805fd1433d589c0d1a40d1fda06fc604813b7aa351b4a1c090555c15",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40897",
+					"10.65.0.27:40897",
+					"172.17.0.1:40897",
+					"172.19.0.1:40897",
+					"172.20.0.1:40897"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:41:11.899719454Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7599225092640387,
+				"StableID":   "nEaY7vkhL221CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f283efe5dd48f342c58094239f5f650c4aaee320863de0341c3f7afe1202df44",
+				"DiscoKey":   "discokey:d3f29c6a647567f424be839fd6e3a0db91b22ad0b1c880371c45ee1d425ec704",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43890",
+					"10.65.0.27:43890",
+					"172.17.0.1:43890",
+					"172.19.0.1:43890",
+					"172.20.0.1:43890"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:41:12.423400737Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1156665432318304,
+				"StableID":   "nsiUS6er2A11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e2ee16b751e1367569f4bca507e2fa8d7c39f276e6bd8045888d08e57507b26",
+				"DiscoKey":   "discokey:70271273bdef94681a9a3d2c71256197185c20aa6939ed8d3622d19abd6a2a19",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:32865",
+					"10.65.0.27:32865",
+					"172.17.0.1:32865",
+					"172.19.0.1:32865",
+					"172.20.0.1:32865"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:41:12.96415126Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7118969969782211,
+				"StableID":   "nA4pTdGCbx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0051b5c6157b41a2c1c8e17fcd6096ada3c6ea149d502c9266cdade174c3f107",
+				"DiscoKey":   "discokey:4c62525bdb5cddf6b8a07f8e33ceb1e9ec92616276654615f4d6f8f409dfbd7b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37240",
+					"10.65.0.27:37240",
+					"172.17.0.1:37240",
+					"172.19.0.1:37240",
+					"172.20.0.1:37240"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:41:13.503847073Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8714220496961158,
+				"StableID":   "nwbUs9og3B21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a9f329975df1ad90f87b4d9a5b3f8f3089944ba40aa27375219c973988334951",
+				"DiscoKey":   "discokey:bb9dac3bdf9553866636640c4e8c09d0a9e1cdc0d39b904a232d1eb28e64de4d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50155",
+					"10.65.0.27:50155",
+					"172.17.0.1:50155",
+					"172.19.0.1:50155",
+					"172.20.0.1:50155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:41:14.294560245Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3749613256813633,
+				"StableID":   "nGaKZxyCHW11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90fbc29d18637b89c100d4fe7db24ad225e54f823f03f395527f08f4910ea52c",
+				"DiscoKey":   "discokey:60093ed47698d591358247326e00939a53012482a0c973525fd058ab56ce580c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58799",
+					"10.65.0.27:58799",
+					"172.17.0.1:58799",
+					"172.19.0.1:58799",
+					"172.20.0.1:58799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:41:14.828130908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1491238603175504,
+				"StableID":   "nfLerwJPeC11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba328d303410383602534db8fb5ba72f5596fa90aa5c14f0d365eebc26935e48",
+				"DiscoKey":   "discokey:233b3e5784db6d954d55f681ad0a0d4b5b31b9c7a8924439f292568fad75737f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:60838",
+					"10.65.0.27:60838",
+					"172.17.0.1:60838",
+					"172.19.0.1:60838",
+					"172.20.0.1:60838"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:41:15.371303125Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5565423625422992,
+				"StableID":   "nHu5tzEbTk11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:08ae16170f4d7633588f2ab6c5d75f16e8e93f2e6d1d33147602f9476e7b0d29",
+				"KeyExpiry":  "2026-11-08T18:41:16Z",
+				"DiscoKey":   "discokey:b02d1adf6327312a287e2573c334eb7611a3673ab7b74df4c0bdb2a490abde78",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47365",
+					"10.65.0.27:47365",
+					"172.17.0.1:47365",
+					"172.19.0.1:47365",
+					"172.20.0.1:47365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:41:16.460447379Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4102605109684321,
+				"StableID":   "nEZEqoU53Z11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3baf2a6ce0936e23578b1314280906653476724fe82c56c82d44a2688e94396c",
+				"KeyExpiry":  "2026-11-08T18:41:16Z",
+				"DiscoKey":   "discokey:6e48d70ecb1b911c363d17e4b37aeb98cc43163d2b3ef8952686c439e664aa23",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44089",
+					"10.65.0.27:44089",
+					"172.17.0.1:44089",
+					"172.19.0.1:44089",
+					"172.20.0.1:44089"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:41:16.996929073Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3749613256813633,
+				"StableID":   "nGaKZxyCHW11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       3749613256813633,
+				"Key":        "nodekey:90fbc29d18637b89c100d4fe7db24ad225e54f823f03f395527f08f4910ea52c",
+				"DiscoKey":   "discokey:60093ed47698d591358247326e00939a53012482a0c973525fd058ab56ce580c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58799",
+					"10.65.0.27:58799",
+					"172.17.0.1:58799",
+					"172.19.0.1:58799",
+					"172.20.0.1:58799"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:41:14.828130908Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:90fbc29d18637b89c100d4fe7db24ad225e54f823f03f395527f08f4910ea52c",
+			"MachineKey": "mkey:4f59cdf8535bc851cd9831628ac14eed8f8e35730d7d8b087b57af6f7f330971",
+			"Peers": [{
+				"ID":         240498609966026,
+				"StableID":   "nw9ccTVvs211CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08a50463cd2a8618c86fa9743cb481386625ccf5ad63800379d75f85ad7ccd45",
+				"DiscoKey":   "discokey:c4a4aaf76382f91aedf4eb0b4c7d983862afd0bdbace8aaf248f95f126cd8f79",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:37471",
+					"10.65.0.27:37471",
+					"172.17.0.1:37471",
+					"172.19.0.1:37471",
+					"172.20.0.1:37471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:41:09.221291803Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         341571337179728,
+				"StableID":   "nProQzVhf311CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0565706dd68331ca77ebb52c24e15c825d12ce6d56273a22a575c02cfbb47d03",
+				"DiscoKey":   "discokey:d6559c7b43fe9bda4559ffe8bb0cc4fb9882bcfefc42c046278926020ba5e029",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:52393",
+					"10.65.0.27:52393",
+					"172.17.0.1:52393",
+					"172.19.0.1:52393",
+					"172.20.0.1:52393"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:41:09.712537259Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3510987038080586,
+				"StableID":   "nVrCkCg8RU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89626677e197c4c4ab4063e24e4d0b851e9e31f30a0bf7b0d94a607fccf9d435",
+				"DiscoKey":   "discokey:bf6edaacd9c2e2437536de63475583a735385d7c27ae61683f398571216e970f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57038",
+					"10.65.0.27:57038",
+					"172.17.0.1:57038",
+					"172.19.0.1:57038",
+					"172.20.0.1:57038"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:41:10.258023255Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6210871730105602,
+				"StableID":   "nKmBfy4vVq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af22824f1f4eb5fddd48c970a55fbb3de7241d957bed6a647843b57dad582916",
+				"DiscoKey":   "discokey:d6a41658e27d52234b9966361ffb1f730de2f7640880b3f681e44074e5c29556",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43533",
+					"10.65.0.27:43533",
+					"172.17.0.1:43533",
+					"172.19.0.1:43533",
+					"172.20.0.1:43533"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:41:10.794537399Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8895713735327768,
+				"StableID":   "nVXKrHKtTC21CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b067afeeaddc05dd8d2d6a4175d13f8ed7ad881deef69568261294e0a2b6902f",
+				"DiscoKey":   "discokey:95c211f7d6db0ce545f9fdb2db475199f9705b8a44d71571fd118c6f31444239",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52118",
+					"10.65.0.27:52118",
+					"172.17.0.1:52118",
+					"172.19.0.1:52118",
+					"172.20.0.1:52118"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:41:11.33520277Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6036672185069575,
+				"StableID":   "ngZ9PE929p11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c78295bd39eae7cf0e339da9da6afec8d17333563273f14e1d506925bd1d5a38",
+				"DiscoKey":   "discokey:85276bf5805fd1433d589c0d1a40d1fda06fc604813b7aa351b4a1c090555c15",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40897",
+					"10.65.0.27:40897",
+					"172.17.0.1:40897",
+					"172.19.0.1:40897",
+					"172.20.0.1:40897"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:41:11.899719454Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7599225092640387,
+				"StableID":   "nEaY7vkhL221CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f283efe5dd48f342c58094239f5f650c4aaee320863de0341c3f7afe1202df44",
+				"DiscoKey":   "discokey:d3f29c6a647567f424be839fd6e3a0db91b22ad0b1c880371c45ee1d425ec704",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43890",
+					"10.65.0.27:43890",
+					"172.17.0.1:43890",
+					"172.19.0.1:43890",
+					"172.20.0.1:43890"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:41:12.423400737Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1156665432318304,
+				"StableID":   "nsiUS6er2A11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e2ee16b751e1367569f4bca507e2fa8d7c39f276e6bd8045888d08e57507b26",
+				"DiscoKey":   "discokey:70271273bdef94681a9a3d2c71256197185c20aa6939ed8d3622d19abd6a2a19",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:32865",
+					"10.65.0.27:32865",
+					"172.17.0.1:32865",
+					"172.19.0.1:32865",
+					"172.20.0.1:32865"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:41:12.96415126Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7118969969782211,
+				"StableID":   "nA4pTdGCbx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0051b5c6157b41a2c1c8e17fcd6096ada3c6ea149d502c9266cdade174c3f107",
+				"DiscoKey":   "discokey:4c62525bdb5cddf6b8a07f8e33ceb1e9ec92616276654615f4d6f8f409dfbd7b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37240",
+					"10.65.0.27:37240",
+					"172.17.0.1:37240",
+					"172.19.0.1:37240",
+					"172.20.0.1:37240"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:41:13.503847073Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8714220496961158,
+				"StableID":   "nwbUs9og3B21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a9f329975df1ad90f87b4d9a5b3f8f3089944ba40aa27375219c973988334951",
+				"DiscoKey":   "discokey:bb9dac3bdf9553866636640c4e8c09d0a9e1cdc0d39b904a232d1eb28e64de4d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50155",
+					"10.65.0.27:50155",
+					"172.17.0.1:50155",
+					"172.19.0.1:50155",
+					"172.20.0.1:50155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:41:14.294560245Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1491238603175504,
+				"StableID":   "nfLerwJPeC11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba328d303410383602534db8fb5ba72f5596fa90aa5c14f0d365eebc26935e48",
+				"DiscoKey":   "discokey:233b3e5784db6d954d55f681ad0a0d4b5b31b9c7a8924439f292568fad75737f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:60838",
+					"10.65.0.27:60838",
+					"172.17.0.1:60838",
+					"172.19.0.1:60838",
+					"172.20.0.1:60838"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:41:15.371303125Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4503593138210239,
+				"StableID":   "nxB2onkgAc11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:61a418955218509ba7a58707b775298eeb7970dc44c6177feb921d74569b2148",
+				"KeyExpiry":  "2026-11-08T18:41:15Z",
+				"DiscoKey":   "discokey:f455e93b2306a4568e896e309cc4f19bb5d76cfabc08eb4dae1f2f7103149c38",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53550",
+					"10.65.0.27:53550",
+					"172.17.0.1:53550",
+					"172.19.0.1:53550",
+					"172.20.0.1:53550"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:41:15.91852783Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5565423625422992,
+				"StableID":   "nHu5tzEbTk11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:08ae16170f4d7633588f2ab6c5d75f16e8e93f2e6d1d33147602f9476e7b0d29",
+				"KeyExpiry":  "2026-11-08T18:41:16Z",
+				"DiscoKey":   "discokey:b02d1adf6327312a287e2573c334eb7611a3673ab7b74df4c0bdb2a490abde78",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47365",
+					"10.65.0.27:47365",
+					"172.17.0.1:47365",
+					"172.19.0.1:47365",
+					"172.20.0.1:47365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:41:16.460447379Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4102605109684321,
+				"StableID":   "nEZEqoU53Z11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3baf2a6ce0936e23578b1314280906653476724fe82c56c82d44a2688e94396c",
+				"KeyExpiry":  "2026-11-08T18:41:16Z",
+				"DiscoKey":   "discokey:6e48d70ecb1b911c363d17e4b37aeb98cc43163d2b3ef8952686c439e664aa23",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44089",
+					"10.65.0.27:44089",
+					"172.17.0.1:44089",
+					"172.19.0.1:44089",
+					"172.20.0.1:44089"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:41:16.996929073Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3749613256813633": {
+				"ID":          3749613256813633,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         341571337179728,
+				"StableID":   "nProQzVhf311CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       341571337179728,
+				"Key":        "nodekey:0565706dd68331ca77ebb52c24e15c825d12ce6d56273a22a575c02cfbb47d03",
+				"DiscoKey":   "discokey:d6559c7b43fe9bda4559ffe8bb0cc4fb9882bcfefc42c046278926020ba5e029",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:52393",
+					"10.65.0.27:52393",
+					"172.17.0.1:52393",
+					"172.19.0.1:52393",
+					"172.20.0.1:52393"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:41:09.712537259Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0565706dd68331ca77ebb52c24e15c825d12ce6d56273a22a575c02cfbb47d03",
+			"MachineKey": "mkey:e5264524fdb0592c12c1eb49201ac1e77cc33a46278819537d7a86b36b537d7b",
+			"Peers": [{
+				"ID":         240498609966026,
+				"StableID":   "nw9ccTVvs211CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08a50463cd2a8618c86fa9743cb481386625ccf5ad63800379d75f85ad7ccd45",
+				"DiscoKey":   "discokey:c4a4aaf76382f91aedf4eb0b4c7d983862afd0bdbace8aaf248f95f126cd8f79",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:37471",
+					"10.65.0.27:37471",
+					"172.17.0.1:37471",
+					"172.19.0.1:37471",
+					"172.20.0.1:37471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:41:09.221291803Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3510987038080586,
+				"StableID":   "nVrCkCg8RU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89626677e197c4c4ab4063e24e4d0b851e9e31f30a0bf7b0d94a607fccf9d435",
+				"DiscoKey":   "discokey:bf6edaacd9c2e2437536de63475583a735385d7c27ae61683f398571216e970f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57038",
+					"10.65.0.27:57038",
+					"172.17.0.1:57038",
+					"172.19.0.1:57038",
+					"172.20.0.1:57038"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:41:10.258023255Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6210871730105602,
+				"StableID":   "nKmBfy4vVq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af22824f1f4eb5fddd48c970a55fbb3de7241d957bed6a647843b57dad582916",
+				"DiscoKey":   "discokey:d6a41658e27d52234b9966361ffb1f730de2f7640880b3f681e44074e5c29556",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43533",
+					"10.65.0.27:43533",
+					"172.17.0.1:43533",
+					"172.19.0.1:43533",
+					"172.20.0.1:43533"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:41:10.794537399Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8895713735327768,
+				"StableID":   "nVXKrHKtTC21CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b067afeeaddc05dd8d2d6a4175d13f8ed7ad881deef69568261294e0a2b6902f",
+				"DiscoKey":   "discokey:95c211f7d6db0ce545f9fdb2db475199f9705b8a44d71571fd118c6f31444239",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52118",
+					"10.65.0.27:52118",
+					"172.17.0.1:52118",
+					"172.19.0.1:52118",
+					"172.20.0.1:52118"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:41:11.33520277Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6036672185069575,
+				"StableID":   "ngZ9PE929p11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c78295bd39eae7cf0e339da9da6afec8d17333563273f14e1d506925bd1d5a38",
+				"DiscoKey":   "discokey:85276bf5805fd1433d589c0d1a40d1fda06fc604813b7aa351b4a1c090555c15",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40897",
+					"10.65.0.27:40897",
+					"172.17.0.1:40897",
+					"172.19.0.1:40897",
+					"172.20.0.1:40897"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:41:11.899719454Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7599225092640387,
+				"StableID":   "nEaY7vkhL221CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f283efe5dd48f342c58094239f5f650c4aaee320863de0341c3f7afe1202df44",
+				"DiscoKey":   "discokey:d3f29c6a647567f424be839fd6e3a0db91b22ad0b1c880371c45ee1d425ec704",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43890",
+					"10.65.0.27:43890",
+					"172.17.0.1:43890",
+					"172.19.0.1:43890",
+					"172.20.0.1:43890"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:41:12.423400737Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1156665432318304,
+				"StableID":   "nsiUS6er2A11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e2ee16b751e1367569f4bca507e2fa8d7c39f276e6bd8045888d08e57507b26",
+				"DiscoKey":   "discokey:70271273bdef94681a9a3d2c71256197185c20aa6939ed8d3622d19abd6a2a19",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:32865",
+					"10.65.0.27:32865",
+					"172.17.0.1:32865",
+					"172.19.0.1:32865",
+					"172.20.0.1:32865"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:41:12.96415126Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7118969969782211,
+				"StableID":   "nA4pTdGCbx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0051b5c6157b41a2c1c8e17fcd6096ada3c6ea149d502c9266cdade174c3f107",
+				"DiscoKey":   "discokey:4c62525bdb5cddf6b8a07f8e33ceb1e9ec92616276654615f4d6f8f409dfbd7b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37240",
+					"10.65.0.27:37240",
+					"172.17.0.1:37240",
+					"172.19.0.1:37240",
+					"172.20.0.1:37240"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:41:13.503847073Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8714220496961158,
+				"StableID":   "nwbUs9og3B21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a9f329975df1ad90f87b4d9a5b3f8f3089944ba40aa27375219c973988334951",
+				"DiscoKey":   "discokey:bb9dac3bdf9553866636640c4e8c09d0a9e1cdc0d39b904a232d1eb28e64de4d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50155",
+					"10.65.0.27:50155",
+					"172.17.0.1:50155",
+					"172.19.0.1:50155",
+					"172.20.0.1:50155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:41:14.294560245Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3749613256813633,
+				"StableID":   "nGaKZxyCHW11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90fbc29d18637b89c100d4fe7db24ad225e54f823f03f395527f08f4910ea52c",
+				"DiscoKey":   "discokey:60093ed47698d591358247326e00939a53012482a0c973525fd058ab56ce580c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58799",
+					"10.65.0.27:58799",
+					"172.17.0.1:58799",
+					"172.19.0.1:58799",
+					"172.20.0.1:58799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:41:14.828130908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1491238603175504,
+				"StableID":   "nfLerwJPeC11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba328d303410383602534db8fb5ba72f5596fa90aa5c14f0d365eebc26935e48",
+				"DiscoKey":   "discokey:233b3e5784db6d954d55f681ad0a0d4b5b31b9c7a8924439f292568fad75737f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:60838",
+					"10.65.0.27:60838",
+					"172.17.0.1:60838",
+					"172.19.0.1:60838",
+					"172.20.0.1:60838"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:41:15.371303125Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4503593138210239,
+				"StableID":   "nxB2onkgAc11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:61a418955218509ba7a58707b775298eeb7970dc44c6177feb921d74569b2148",
+				"KeyExpiry":  "2026-11-08T18:41:15Z",
+				"DiscoKey":   "discokey:f455e93b2306a4568e896e309cc4f19bb5d76cfabc08eb4dae1f2f7103149c38",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53550",
+					"10.65.0.27:53550",
+					"172.17.0.1:53550",
+					"172.19.0.1:53550",
+					"172.20.0.1:53550"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:41:15.91852783Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5565423625422992,
+				"StableID":   "nHu5tzEbTk11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:08ae16170f4d7633588f2ab6c5d75f16e8e93f2e6d1d33147602f9476e7b0d29",
+				"KeyExpiry":  "2026-11-08T18:41:16Z",
+				"DiscoKey":   "discokey:b02d1adf6327312a287e2573c334eb7611a3673ab7b74df4c0bdb2a490abde78",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47365",
+					"10.65.0.27:47365",
+					"172.17.0.1:47365",
+					"172.19.0.1:47365",
+					"172.20.0.1:47365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:41:16.460447379Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4102605109684321,
+				"StableID":   "nEZEqoU53Z11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3baf2a6ce0936e23578b1314280906653476724fe82c56c82d44a2688e94396c",
+				"KeyExpiry":  "2026-11-08T18:41:16Z",
+				"DiscoKey":   "discokey:6e48d70ecb1b911c363d17e4b37aeb98cc43163d2b3ef8952686c439e664aa23",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44089",
+					"10.65.0.27:44089",
+					"172.17.0.1:44089",
+					"172.19.0.1:44089",
+					"172.20.0.1:44089"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:41:16.996929073Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "341571337179728": {
+				"ID":          341571337179728,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         240498609966026,
+				"StableID":   "nw9ccTVvs211CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       240498609966026,
+				"Key":        "nodekey:08a50463cd2a8618c86fa9743cb481386625ccf5ad63800379d75f85ad7ccd45",
+				"DiscoKey":   "discokey:c4a4aaf76382f91aedf4eb0b4c7d983862afd0bdbace8aaf248f95f126cd8f79",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:37471",
+					"10.65.0.27:37471",
+					"172.17.0.1:37471",
+					"172.19.0.1:37471",
+					"172.20.0.1:37471"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:41:09.221291803Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:08a50463cd2a8618c86fa9743cb481386625ccf5ad63800379d75f85ad7ccd45",
+			"MachineKey": "mkey:bccb0f23045648dbe71db29bf627fc5b5670158ae673b0c4e11ad56ce53a4a5c",
+			"Peers": [{
+				"ID":         341571337179728,
+				"StableID":   "nProQzVhf311CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0565706dd68331ca77ebb52c24e15c825d12ce6d56273a22a575c02cfbb47d03",
+				"DiscoKey":   "discokey:d6559c7b43fe9bda4559ffe8bb0cc4fb9882bcfefc42c046278926020ba5e029",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:52393",
+					"10.65.0.27:52393",
+					"172.17.0.1:52393",
+					"172.19.0.1:52393",
+					"172.20.0.1:52393"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:41:09.712537259Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3510987038080586,
+				"StableID":   "nVrCkCg8RU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89626677e197c4c4ab4063e24e4d0b851e9e31f30a0bf7b0d94a607fccf9d435",
+				"DiscoKey":   "discokey:bf6edaacd9c2e2437536de63475583a735385d7c27ae61683f398571216e970f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57038",
+					"10.65.0.27:57038",
+					"172.17.0.1:57038",
+					"172.19.0.1:57038",
+					"172.20.0.1:57038"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:41:10.258023255Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6210871730105602,
+				"StableID":   "nKmBfy4vVq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af22824f1f4eb5fddd48c970a55fbb3de7241d957bed6a647843b57dad582916",
+				"DiscoKey":   "discokey:d6a41658e27d52234b9966361ffb1f730de2f7640880b3f681e44074e5c29556",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43533",
+					"10.65.0.27:43533",
+					"172.17.0.1:43533",
+					"172.19.0.1:43533",
+					"172.20.0.1:43533"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:41:10.794537399Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8895713735327768,
+				"StableID":   "nVXKrHKtTC21CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b067afeeaddc05dd8d2d6a4175d13f8ed7ad881deef69568261294e0a2b6902f",
+				"DiscoKey":   "discokey:95c211f7d6db0ce545f9fdb2db475199f9705b8a44d71571fd118c6f31444239",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52118",
+					"10.65.0.27:52118",
+					"172.17.0.1:52118",
+					"172.19.0.1:52118",
+					"172.20.0.1:52118"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:41:11.33520277Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6036672185069575,
+				"StableID":   "ngZ9PE929p11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c78295bd39eae7cf0e339da9da6afec8d17333563273f14e1d506925bd1d5a38",
+				"DiscoKey":   "discokey:85276bf5805fd1433d589c0d1a40d1fda06fc604813b7aa351b4a1c090555c15",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40897",
+					"10.65.0.27:40897",
+					"172.17.0.1:40897",
+					"172.19.0.1:40897",
+					"172.20.0.1:40897"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:41:11.899719454Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7599225092640387,
+				"StableID":   "nEaY7vkhL221CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f283efe5dd48f342c58094239f5f650c4aaee320863de0341c3f7afe1202df44",
+				"DiscoKey":   "discokey:d3f29c6a647567f424be839fd6e3a0db91b22ad0b1c880371c45ee1d425ec704",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43890",
+					"10.65.0.27:43890",
+					"172.17.0.1:43890",
+					"172.19.0.1:43890",
+					"172.20.0.1:43890"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:41:12.423400737Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1156665432318304,
+				"StableID":   "nsiUS6er2A11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e2ee16b751e1367569f4bca507e2fa8d7c39f276e6bd8045888d08e57507b26",
+				"DiscoKey":   "discokey:70271273bdef94681a9a3d2c71256197185c20aa6939ed8d3622d19abd6a2a19",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:32865",
+					"10.65.0.27:32865",
+					"172.17.0.1:32865",
+					"172.19.0.1:32865",
+					"172.20.0.1:32865"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:41:12.96415126Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7118969969782211,
+				"StableID":   "nA4pTdGCbx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0051b5c6157b41a2c1c8e17fcd6096ada3c6ea149d502c9266cdade174c3f107",
+				"DiscoKey":   "discokey:4c62525bdb5cddf6b8a07f8e33ceb1e9ec92616276654615f4d6f8f409dfbd7b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37240",
+					"10.65.0.27:37240",
+					"172.17.0.1:37240",
+					"172.19.0.1:37240",
+					"172.20.0.1:37240"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:41:13.503847073Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8714220496961158,
+				"StableID":   "nwbUs9og3B21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a9f329975df1ad90f87b4d9a5b3f8f3089944ba40aa27375219c973988334951",
+				"DiscoKey":   "discokey:bb9dac3bdf9553866636640c4e8c09d0a9e1cdc0d39b904a232d1eb28e64de4d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50155",
+					"10.65.0.27:50155",
+					"172.17.0.1:50155",
+					"172.19.0.1:50155",
+					"172.20.0.1:50155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:41:14.294560245Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3749613256813633,
+				"StableID":   "nGaKZxyCHW11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90fbc29d18637b89c100d4fe7db24ad225e54f823f03f395527f08f4910ea52c",
+				"DiscoKey":   "discokey:60093ed47698d591358247326e00939a53012482a0c973525fd058ab56ce580c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58799",
+					"10.65.0.27:58799",
+					"172.17.0.1:58799",
+					"172.19.0.1:58799",
+					"172.20.0.1:58799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:41:14.828130908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1491238603175504,
+				"StableID":   "nfLerwJPeC11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba328d303410383602534db8fb5ba72f5596fa90aa5c14f0d365eebc26935e48",
+				"DiscoKey":   "discokey:233b3e5784db6d954d55f681ad0a0d4b5b31b9c7a8924439f292568fad75737f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:60838",
+					"10.65.0.27:60838",
+					"172.17.0.1:60838",
+					"172.19.0.1:60838",
+					"172.20.0.1:60838"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:41:15.371303125Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4503593138210239,
+				"StableID":   "nxB2onkgAc11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:61a418955218509ba7a58707b775298eeb7970dc44c6177feb921d74569b2148",
+				"KeyExpiry":  "2026-11-08T18:41:15Z",
+				"DiscoKey":   "discokey:f455e93b2306a4568e896e309cc4f19bb5d76cfabc08eb4dae1f2f7103149c38",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53550",
+					"10.65.0.27:53550",
+					"172.17.0.1:53550",
+					"172.19.0.1:53550",
+					"172.20.0.1:53550"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:41:15.91852783Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5565423625422992,
+				"StableID":   "nHu5tzEbTk11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:08ae16170f4d7633588f2ab6c5d75f16e8e93f2e6d1d33147602f9476e7b0d29",
+				"KeyExpiry":  "2026-11-08T18:41:16Z",
+				"DiscoKey":   "discokey:b02d1adf6327312a287e2573c334eb7611a3673ab7b74df4c0bdb2a490abde78",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47365",
+					"10.65.0.27:47365",
+					"172.17.0.1:47365",
+					"172.19.0.1:47365",
+					"172.20.0.1:47365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:41:16.460447379Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4102605109684321,
+				"StableID":   "nEZEqoU53Z11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3baf2a6ce0936e23578b1314280906653476724fe82c56c82d44a2688e94396c",
+				"KeyExpiry":  "2026-11-08T18:41:16Z",
+				"DiscoKey":   "discokey:6e48d70ecb1b911c363d17e4b37aeb98cc43163d2b3ef8952686c439e664aa23",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44089",
+					"10.65.0.27:44089",
+					"172.17.0.1:44089",
+					"172.19.0.1:44089",
+					"172.20.0.1:44089"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:41:16.996929073Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "240498609966026": {
+				"ID":          240498609966026,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8895713735327768,
+				"StableID":   "nVXKrHKtTC21CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       8895713735327768,
+				"Key":        "nodekey:b067afeeaddc05dd8d2d6a4175d13f8ed7ad881deef69568261294e0a2b6902f",
+				"DiscoKey":   "discokey:95c211f7d6db0ce545f9fdb2db475199f9705b8a44d71571fd118c6f31444239",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52118",
+					"10.65.0.27:52118",
+					"172.17.0.1:52118",
+					"172.19.0.1:52118",
+					"172.20.0.1:52118"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:41:11.33520277Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b067afeeaddc05dd8d2d6a4175d13f8ed7ad881deef69568261294e0a2b6902f",
+			"MachineKey": "mkey:9ac0a587a9f0c688d3bcaa1c4c65c865858fa406e75881503bb50b53791f8539",
+			"Peers": [{
+				"ID":         240498609966026,
+				"StableID":   "nw9ccTVvs211CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08a50463cd2a8618c86fa9743cb481386625ccf5ad63800379d75f85ad7ccd45",
+				"DiscoKey":   "discokey:c4a4aaf76382f91aedf4eb0b4c7d983862afd0bdbace8aaf248f95f126cd8f79",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:37471",
+					"10.65.0.27:37471",
+					"172.17.0.1:37471",
+					"172.19.0.1:37471",
+					"172.20.0.1:37471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:41:09.221291803Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         341571337179728,
+				"StableID":   "nProQzVhf311CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0565706dd68331ca77ebb52c24e15c825d12ce6d56273a22a575c02cfbb47d03",
+				"DiscoKey":   "discokey:d6559c7b43fe9bda4559ffe8bb0cc4fb9882bcfefc42c046278926020ba5e029",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:52393",
+					"10.65.0.27:52393",
+					"172.17.0.1:52393",
+					"172.19.0.1:52393",
+					"172.20.0.1:52393"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:41:09.712537259Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3510987038080586,
+				"StableID":   "nVrCkCg8RU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89626677e197c4c4ab4063e24e4d0b851e9e31f30a0bf7b0d94a607fccf9d435",
+				"DiscoKey":   "discokey:bf6edaacd9c2e2437536de63475583a735385d7c27ae61683f398571216e970f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57038",
+					"10.65.0.27:57038",
+					"172.17.0.1:57038",
+					"172.19.0.1:57038",
+					"172.20.0.1:57038"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:41:10.258023255Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6210871730105602,
+				"StableID":   "nKmBfy4vVq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af22824f1f4eb5fddd48c970a55fbb3de7241d957bed6a647843b57dad582916",
+				"DiscoKey":   "discokey:d6a41658e27d52234b9966361ffb1f730de2f7640880b3f681e44074e5c29556",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43533",
+					"10.65.0.27:43533",
+					"172.17.0.1:43533",
+					"172.19.0.1:43533",
+					"172.20.0.1:43533"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:41:10.794537399Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6036672185069575,
+				"StableID":   "ngZ9PE929p11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c78295bd39eae7cf0e339da9da6afec8d17333563273f14e1d506925bd1d5a38",
+				"DiscoKey":   "discokey:85276bf5805fd1433d589c0d1a40d1fda06fc604813b7aa351b4a1c090555c15",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40897",
+					"10.65.0.27:40897",
+					"172.17.0.1:40897",
+					"172.19.0.1:40897",
+					"172.20.0.1:40897"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:41:11.899719454Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7599225092640387,
+				"StableID":   "nEaY7vkhL221CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f283efe5dd48f342c58094239f5f650c4aaee320863de0341c3f7afe1202df44",
+				"DiscoKey":   "discokey:d3f29c6a647567f424be839fd6e3a0db91b22ad0b1c880371c45ee1d425ec704",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43890",
+					"10.65.0.27:43890",
+					"172.17.0.1:43890",
+					"172.19.0.1:43890",
+					"172.20.0.1:43890"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:41:12.423400737Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1156665432318304,
+				"StableID":   "nsiUS6er2A11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e2ee16b751e1367569f4bca507e2fa8d7c39f276e6bd8045888d08e57507b26",
+				"DiscoKey":   "discokey:70271273bdef94681a9a3d2c71256197185c20aa6939ed8d3622d19abd6a2a19",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:32865",
+					"10.65.0.27:32865",
+					"172.17.0.1:32865",
+					"172.19.0.1:32865",
+					"172.20.0.1:32865"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:41:12.96415126Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7118969969782211,
+				"StableID":   "nA4pTdGCbx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0051b5c6157b41a2c1c8e17fcd6096ada3c6ea149d502c9266cdade174c3f107",
+				"DiscoKey":   "discokey:4c62525bdb5cddf6b8a07f8e33ceb1e9ec92616276654615f4d6f8f409dfbd7b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37240",
+					"10.65.0.27:37240",
+					"172.17.0.1:37240",
+					"172.19.0.1:37240",
+					"172.20.0.1:37240"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:41:13.503847073Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8714220496961158,
+				"StableID":   "nwbUs9og3B21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a9f329975df1ad90f87b4d9a5b3f8f3089944ba40aa27375219c973988334951",
+				"DiscoKey":   "discokey:bb9dac3bdf9553866636640c4e8c09d0a9e1cdc0d39b904a232d1eb28e64de4d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50155",
+					"10.65.0.27:50155",
+					"172.17.0.1:50155",
+					"172.19.0.1:50155",
+					"172.20.0.1:50155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:41:14.294560245Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3749613256813633,
+				"StableID":   "nGaKZxyCHW11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90fbc29d18637b89c100d4fe7db24ad225e54f823f03f395527f08f4910ea52c",
+				"DiscoKey":   "discokey:60093ed47698d591358247326e00939a53012482a0c973525fd058ab56ce580c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58799",
+					"10.65.0.27:58799",
+					"172.17.0.1:58799",
+					"172.19.0.1:58799",
+					"172.20.0.1:58799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:41:14.828130908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1491238603175504,
+				"StableID":   "nfLerwJPeC11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba328d303410383602534db8fb5ba72f5596fa90aa5c14f0d365eebc26935e48",
+				"DiscoKey":   "discokey:233b3e5784db6d954d55f681ad0a0d4b5b31b9c7a8924439f292568fad75737f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:60838",
+					"10.65.0.27:60838",
+					"172.17.0.1:60838",
+					"172.19.0.1:60838",
+					"172.20.0.1:60838"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:41:15.371303125Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4503593138210239,
+				"StableID":   "nxB2onkgAc11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:61a418955218509ba7a58707b775298eeb7970dc44c6177feb921d74569b2148",
+				"KeyExpiry":  "2026-11-08T18:41:15Z",
+				"DiscoKey":   "discokey:f455e93b2306a4568e896e309cc4f19bb5d76cfabc08eb4dae1f2f7103149c38",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53550",
+					"10.65.0.27:53550",
+					"172.17.0.1:53550",
+					"172.19.0.1:53550",
+					"172.20.0.1:53550"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:41:15.91852783Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5565423625422992,
+				"StableID":   "nHu5tzEbTk11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:08ae16170f4d7633588f2ab6c5d75f16e8e93f2e6d1d33147602f9476e7b0d29",
+				"KeyExpiry":  "2026-11-08T18:41:16Z",
+				"DiscoKey":   "discokey:b02d1adf6327312a287e2573c334eb7611a3673ab7b74df4c0bdb2a490abde78",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47365",
+					"10.65.0.27:47365",
+					"172.17.0.1:47365",
+					"172.19.0.1:47365",
+					"172.20.0.1:47365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:41:16.460447379Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4102605109684321,
+				"StableID":   "nEZEqoU53Z11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3baf2a6ce0936e23578b1314280906653476724fe82c56c82d44a2688e94396c",
+				"KeyExpiry":  "2026-11-08T18:41:16Z",
+				"DiscoKey":   "discokey:6e48d70ecb1b911c363d17e4b37aeb98cc43163d2b3ef8952686c439e664aa23",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44089",
+					"10.65.0.27:44089",
+					"172.17.0.1:44089",
+					"172.19.0.1:44089",
+					"172.20.0.1:44089"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:41:16.996929073Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8895713735327768": {
+				"ID":          8895713735327768,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6210871730105602,
+				"StableID":   "nKmBfy4vVq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       6210871730105602,
+				"Key":        "nodekey:af22824f1f4eb5fddd48c970a55fbb3de7241d957bed6a647843b57dad582916",
+				"DiscoKey":   "discokey:d6a41658e27d52234b9966361ffb1f730de2f7640880b3f681e44074e5c29556",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43533",
+					"10.65.0.27:43533",
+					"172.17.0.1:43533",
+					"172.19.0.1:43533",
+					"172.20.0.1:43533"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:41:10.794537399Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:af22824f1f4eb5fddd48c970a55fbb3de7241d957bed6a647843b57dad582916",
+			"MachineKey": "mkey:e2fb8814cc97d4654033550dafaed8fe431d7c528eacd826581e019421a14d76",
+			"Peers": [{
+				"ID":         240498609966026,
+				"StableID":   "nw9ccTVvs211CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08a50463cd2a8618c86fa9743cb481386625ccf5ad63800379d75f85ad7ccd45",
+				"DiscoKey":   "discokey:c4a4aaf76382f91aedf4eb0b4c7d983862afd0bdbace8aaf248f95f126cd8f79",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:37471",
+					"10.65.0.27:37471",
+					"172.17.0.1:37471",
+					"172.19.0.1:37471",
+					"172.20.0.1:37471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:41:09.221291803Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         341571337179728,
+				"StableID":   "nProQzVhf311CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0565706dd68331ca77ebb52c24e15c825d12ce6d56273a22a575c02cfbb47d03",
+				"DiscoKey":   "discokey:d6559c7b43fe9bda4559ffe8bb0cc4fb9882bcfefc42c046278926020ba5e029",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:52393",
+					"10.65.0.27:52393",
+					"172.17.0.1:52393",
+					"172.19.0.1:52393",
+					"172.20.0.1:52393"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:41:09.712537259Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3510987038080586,
+				"StableID":   "nVrCkCg8RU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89626677e197c4c4ab4063e24e4d0b851e9e31f30a0bf7b0d94a607fccf9d435",
+				"DiscoKey":   "discokey:bf6edaacd9c2e2437536de63475583a735385d7c27ae61683f398571216e970f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57038",
+					"10.65.0.27:57038",
+					"172.17.0.1:57038",
+					"172.19.0.1:57038",
+					"172.20.0.1:57038"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:41:10.258023255Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8895713735327768,
+				"StableID":   "nVXKrHKtTC21CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b067afeeaddc05dd8d2d6a4175d13f8ed7ad881deef69568261294e0a2b6902f",
+				"DiscoKey":   "discokey:95c211f7d6db0ce545f9fdb2db475199f9705b8a44d71571fd118c6f31444239",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52118",
+					"10.65.0.27:52118",
+					"172.17.0.1:52118",
+					"172.19.0.1:52118",
+					"172.20.0.1:52118"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:41:11.33520277Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6036672185069575,
+				"StableID":   "ngZ9PE929p11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c78295bd39eae7cf0e339da9da6afec8d17333563273f14e1d506925bd1d5a38",
+				"DiscoKey":   "discokey:85276bf5805fd1433d589c0d1a40d1fda06fc604813b7aa351b4a1c090555c15",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40897",
+					"10.65.0.27:40897",
+					"172.17.0.1:40897",
+					"172.19.0.1:40897",
+					"172.20.0.1:40897"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:41:11.899719454Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7599225092640387,
+				"StableID":   "nEaY7vkhL221CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f283efe5dd48f342c58094239f5f650c4aaee320863de0341c3f7afe1202df44",
+				"DiscoKey":   "discokey:d3f29c6a647567f424be839fd6e3a0db91b22ad0b1c880371c45ee1d425ec704",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43890",
+					"10.65.0.27:43890",
+					"172.17.0.1:43890",
+					"172.19.0.1:43890",
+					"172.20.0.1:43890"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:41:12.423400737Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1156665432318304,
+				"StableID":   "nsiUS6er2A11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e2ee16b751e1367569f4bca507e2fa8d7c39f276e6bd8045888d08e57507b26",
+				"DiscoKey":   "discokey:70271273bdef94681a9a3d2c71256197185c20aa6939ed8d3622d19abd6a2a19",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:32865",
+					"10.65.0.27:32865",
+					"172.17.0.1:32865",
+					"172.19.0.1:32865",
+					"172.20.0.1:32865"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:41:12.96415126Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7118969969782211,
+				"StableID":   "nA4pTdGCbx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0051b5c6157b41a2c1c8e17fcd6096ada3c6ea149d502c9266cdade174c3f107",
+				"DiscoKey":   "discokey:4c62525bdb5cddf6b8a07f8e33ceb1e9ec92616276654615f4d6f8f409dfbd7b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37240",
+					"10.65.0.27:37240",
+					"172.17.0.1:37240",
+					"172.19.0.1:37240",
+					"172.20.0.1:37240"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:41:13.503847073Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8714220496961158,
+				"StableID":   "nwbUs9og3B21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a9f329975df1ad90f87b4d9a5b3f8f3089944ba40aa27375219c973988334951",
+				"DiscoKey":   "discokey:bb9dac3bdf9553866636640c4e8c09d0a9e1cdc0d39b904a232d1eb28e64de4d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50155",
+					"10.65.0.27:50155",
+					"172.17.0.1:50155",
+					"172.19.0.1:50155",
+					"172.20.0.1:50155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:41:14.294560245Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3749613256813633,
+				"StableID":   "nGaKZxyCHW11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90fbc29d18637b89c100d4fe7db24ad225e54f823f03f395527f08f4910ea52c",
+				"DiscoKey":   "discokey:60093ed47698d591358247326e00939a53012482a0c973525fd058ab56ce580c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58799",
+					"10.65.0.27:58799",
+					"172.17.0.1:58799",
+					"172.19.0.1:58799",
+					"172.20.0.1:58799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:41:14.828130908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1491238603175504,
+				"StableID":   "nfLerwJPeC11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba328d303410383602534db8fb5ba72f5596fa90aa5c14f0d365eebc26935e48",
+				"DiscoKey":   "discokey:233b3e5784db6d954d55f681ad0a0d4b5b31b9c7a8924439f292568fad75737f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:60838",
+					"10.65.0.27:60838",
+					"172.17.0.1:60838",
+					"172.19.0.1:60838",
+					"172.20.0.1:60838"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:41:15.371303125Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4503593138210239,
+				"StableID":   "nxB2onkgAc11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:61a418955218509ba7a58707b775298eeb7970dc44c6177feb921d74569b2148",
+				"KeyExpiry":  "2026-11-08T18:41:15Z",
+				"DiscoKey":   "discokey:f455e93b2306a4568e896e309cc4f19bb5d76cfabc08eb4dae1f2f7103149c38",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53550",
+					"10.65.0.27:53550",
+					"172.17.0.1:53550",
+					"172.19.0.1:53550",
+					"172.20.0.1:53550"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:41:15.91852783Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5565423625422992,
+				"StableID":   "nHu5tzEbTk11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:08ae16170f4d7633588f2ab6c5d75f16e8e93f2e6d1d33147602f9476e7b0d29",
+				"KeyExpiry":  "2026-11-08T18:41:16Z",
+				"DiscoKey":   "discokey:b02d1adf6327312a287e2573c334eb7611a3673ab7b74df4c0bdb2a490abde78",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47365",
+					"10.65.0.27:47365",
+					"172.17.0.1:47365",
+					"172.19.0.1:47365",
+					"172.20.0.1:47365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:41:16.460447379Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4102605109684321,
+				"StableID":   "nEZEqoU53Z11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3baf2a6ce0936e23578b1314280906653476724fe82c56c82d44a2688e94396c",
+				"KeyExpiry":  "2026-11-08T18:41:16Z",
+				"DiscoKey":   "discokey:6e48d70ecb1b911c363d17e4b37aeb98cc43163d2b3ef8952686c439e664aa23",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44089",
+					"10.65.0.27:44089",
+					"172.17.0.1:44089",
+					"172.19.0.1:44089",
+					"172.20.0.1:44089"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:41:16.996929073Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6210871730105602": {
+				"ID":          6210871730105602,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7599225092640387,
+				"StableID":   "nEaY7vkhL221CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       7599225092640387,
+				"Key":        "nodekey:f283efe5dd48f342c58094239f5f650c4aaee320863de0341c3f7afe1202df44",
+				"DiscoKey":   "discokey:d3f29c6a647567f424be839fd6e3a0db91b22ad0b1c880371c45ee1d425ec704",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43890",
+					"10.65.0.27:43890",
+					"172.17.0.1:43890",
+					"172.19.0.1:43890",
+					"172.20.0.1:43890"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:41:12.423400737Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f283efe5dd48f342c58094239f5f650c4aaee320863de0341c3f7afe1202df44",
+			"MachineKey": "mkey:a018b6468f4975c15327d1d5b5f9ebd82e04fe81137386549d3e64eae7399e1f",
+			"Peers": [{
+				"ID":         240498609966026,
+				"StableID":   "nw9ccTVvs211CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08a50463cd2a8618c86fa9743cb481386625ccf5ad63800379d75f85ad7ccd45",
+				"DiscoKey":   "discokey:c4a4aaf76382f91aedf4eb0b4c7d983862afd0bdbace8aaf248f95f126cd8f79",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:37471",
+					"10.65.0.27:37471",
+					"172.17.0.1:37471",
+					"172.19.0.1:37471",
+					"172.20.0.1:37471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:41:09.221291803Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         341571337179728,
+				"StableID":   "nProQzVhf311CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0565706dd68331ca77ebb52c24e15c825d12ce6d56273a22a575c02cfbb47d03",
+				"DiscoKey":   "discokey:d6559c7b43fe9bda4559ffe8bb0cc4fb9882bcfefc42c046278926020ba5e029",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:52393",
+					"10.65.0.27:52393",
+					"172.17.0.1:52393",
+					"172.19.0.1:52393",
+					"172.20.0.1:52393"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:41:09.712537259Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3510987038080586,
+				"StableID":   "nVrCkCg8RU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89626677e197c4c4ab4063e24e4d0b851e9e31f30a0bf7b0d94a607fccf9d435",
+				"DiscoKey":   "discokey:bf6edaacd9c2e2437536de63475583a735385d7c27ae61683f398571216e970f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57038",
+					"10.65.0.27:57038",
+					"172.17.0.1:57038",
+					"172.19.0.1:57038",
+					"172.20.0.1:57038"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:41:10.258023255Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6210871730105602,
+				"StableID":   "nKmBfy4vVq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af22824f1f4eb5fddd48c970a55fbb3de7241d957bed6a647843b57dad582916",
+				"DiscoKey":   "discokey:d6a41658e27d52234b9966361ffb1f730de2f7640880b3f681e44074e5c29556",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43533",
+					"10.65.0.27:43533",
+					"172.17.0.1:43533",
+					"172.19.0.1:43533",
+					"172.20.0.1:43533"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:41:10.794537399Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8895713735327768,
+				"StableID":   "nVXKrHKtTC21CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b067afeeaddc05dd8d2d6a4175d13f8ed7ad881deef69568261294e0a2b6902f",
+				"DiscoKey":   "discokey:95c211f7d6db0ce545f9fdb2db475199f9705b8a44d71571fd118c6f31444239",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52118",
+					"10.65.0.27:52118",
+					"172.17.0.1:52118",
+					"172.19.0.1:52118",
+					"172.20.0.1:52118"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:41:11.33520277Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6036672185069575,
+				"StableID":   "ngZ9PE929p11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c78295bd39eae7cf0e339da9da6afec8d17333563273f14e1d506925bd1d5a38",
+				"DiscoKey":   "discokey:85276bf5805fd1433d589c0d1a40d1fda06fc604813b7aa351b4a1c090555c15",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40897",
+					"10.65.0.27:40897",
+					"172.17.0.1:40897",
+					"172.19.0.1:40897",
+					"172.20.0.1:40897"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:41:11.899719454Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1156665432318304,
+				"StableID":   "nsiUS6er2A11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e2ee16b751e1367569f4bca507e2fa8d7c39f276e6bd8045888d08e57507b26",
+				"DiscoKey":   "discokey:70271273bdef94681a9a3d2c71256197185c20aa6939ed8d3622d19abd6a2a19",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:32865",
+					"10.65.0.27:32865",
+					"172.17.0.1:32865",
+					"172.19.0.1:32865",
+					"172.20.0.1:32865"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:41:12.96415126Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7118969969782211,
+				"StableID":   "nA4pTdGCbx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0051b5c6157b41a2c1c8e17fcd6096ada3c6ea149d502c9266cdade174c3f107",
+				"DiscoKey":   "discokey:4c62525bdb5cddf6b8a07f8e33ceb1e9ec92616276654615f4d6f8f409dfbd7b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37240",
+					"10.65.0.27:37240",
+					"172.17.0.1:37240",
+					"172.19.0.1:37240",
+					"172.20.0.1:37240"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:41:13.503847073Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8714220496961158,
+				"StableID":   "nwbUs9og3B21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a9f329975df1ad90f87b4d9a5b3f8f3089944ba40aa27375219c973988334951",
+				"DiscoKey":   "discokey:bb9dac3bdf9553866636640c4e8c09d0a9e1cdc0d39b904a232d1eb28e64de4d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50155",
+					"10.65.0.27:50155",
+					"172.17.0.1:50155",
+					"172.19.0.1:50155",
+					"172.20.0.1:50155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:41:14.294560245Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3749613256813633,
+				"StableID":   "nGaKZxyCHW11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90fbc29d18637b89c100d4fe7db24ad225e54f823f03f395527f08f4910ea52c",
+				"DiscoKey":   "discokey:60093ed47698d591358247326e00939a53012482a0c973525fd058ab56ce580c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58799",
+					"10.65.0.27:58799",
+					"172.17.0.1:58799",
+					"172.19.0.1:58799",
+					"172.20.0.1:58799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:41:14.828130908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1491238603175504,
+				"StableID":   "nfLerwJPeC11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba328d303410383602534db8fb5ba72f5596fa90aa5c14f0d365eebc26935e48",
+				"DiscoKey":   "discokey:233b3e5784db6d954d55f681ad0a0d4b5b31b9c7a8924439f292568fad75737f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:60838",
+					"10.65.0.27:60838",
+					"172.17.0.1:60838",
+					"172.19.0.1:60838",
+					"172.20.0.1:60838"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:41:15.371303125Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4503593138210239,
+				"StableID":   "nxB2onkgAc11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:61a418955218509ba7a58707b775298eeb7970dc44c6177feb921d74569b2148",
+				"KeyExpiry":  "2026-11-08T18:41:15Z",
+				"DiscoKey":   "discokey:f455e93b2306a4568e896e309cc4f19bb5d76cfabc08eb4dae1f2f7103149c38",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53550",
+					"10.65.0.27:53550",
+					"172.17.0.1:53550",
+					"172.19.0.1:53550",
+					"172.20.0.1:53550"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:41:15.91852783Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5565423625422992,
+				"StableID":   "nHu5tzEbTk11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:08ae16170f4d7633588f2ab6c5d75f16e8e93f2e6d1d33147602f9476e7b0d29",
+				"KeyExpiry":  "2026-11-08T18:41:16Z",
+				"DiscoKey":   "discokey:b02d1adf6327312a287e2573c334eb7611a3673ab7b74df4c0bdb2a490abde78",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47365",
+					"10.65.0.27:47365",
+					"172.17.0.1:47365",
+					"172.19.0.1:47365",
+					"172.20.0.1:47365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:41:16.460447379Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4102605109684321,
+				"StableID":   "nEZEqoU53Z11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3baf2a6ce0936e23578b1314280906653476724fe82c56c82d44a2688e94396c",
+				"KeyExpiry":  "2026-11-08T18:41:16Z",
+				"DiscoKey":   "discokey:6e48d70ecb1b911c363d17e4b37aeb98cc43163d2b3ef8952686c439e664aa23",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44089",
+					"10.65.0.27:44089",
+					"172.17.0.1:44089",
+					"172.19.0.1:44089",
+					"172.20.0.1:44089"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:41:16.996929073Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7599225092640387": {
+				"ID":          7599225092640387,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7118969969782211,
+				"StableID":   "nA4pTdGCbx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       7118969969782211,
+				"Key":        "nodekey:0051b5c6157b41a2c1c8e17fcd6096ada3c6ea149d502c9266cdade174c3f107",
+				"DiscoKey":   "discokey:4c62525bdb5cddf6b8a07f8e33ceb1e9ec92616276654615f4d6f8f409dfbd7b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37240",
+					"10.65.0.27:37240",
+					"172.17.0.1:37240",
+					"172.19.0.1:37240",
+					"172.20.0.1:37240"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:41:13.503847073Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0051b5c6157b41a2c1c8e17fcd6096ada3c6ea149d502c9266cdade174c3f107",
+			"MachineKey": "mkey:84635f3a9e2d68e57ee17a480d1463eb37b0bf82591ff91cdff2623101d74a34",
+			"Peers": [{
+				"ID":         240498609966026,
+				"StableID":   "nw9ccTVvs211CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08a50463cd2a8618c86fa9743cb481386625ccf5ad63800379d75f85ad7ccd45",
+				"DiscoKey":   "discokey:c4a4aaf76382f91aedf4eb0b4c7d983862afd0bdbace8aaf248f95f126cd8f79",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:37471",
+					"10.65.0.27:37471",
+					"172.17.0.1:37471",
+					"172.19.0.1:37471",
+					"172.20.0.1:37471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:41:09.221291803Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         341571337179728,
+				"StableID":   "nProQzVhf311CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0565706dd68331ca77ebb52c24e15c825d12ce6d56273a22a575c02cfbb47d03",
+				"DiscoKey":   "discokey:d6559c7b43fe9bda4559ffe8bb0cc4fb9882bcfefc42c046278926020ba5e029",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:52393",
+					"10.65.0.27:52393",
+					"172.17.0.1:52393",
+					"172.19.0.1:52393",
+					"172.20.0.1:52393"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:41:09.712537259Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3510987038080586,
+				"StableID":   "nVrCkCg8RU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89626677e197c4c4ab4063e24e4d0b851e9e31f30a0bf7b0d94a607fccf9d435",
+				"DiscoKey":   "discokey:bf6edaacd9c2e2437536de63475583a735385d7c27ae61683f398571216e970f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57038",
+					"10.65.0.27:57038",
+					"172.17.0.1:57038",
+					"172.19.0.1:57038",
+					"172.20.0.1:57038"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:41:10.258023255Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6210871730105602,
+				"StableID":   "nKmBfy4vVq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af22824f1f4eb5fddd48c970a55fbb3de7241d957bed6a647843b57dad582916",
+				"DiscoKey":   "discokey:d6a41658e27d52234b9966361ffb1f730de2f7640880b3f681e44074e5c29556",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43533",
+					"10.65.0.27:43533",
+					"172.17.0.1:43533",
+					"172.19.0.1:43533",
+					"172.20.0.1:43533"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:41:10.794537399Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8895713735327768,
+				"StableID":   "nVXKrHKtTC21CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b067afeeaddc05dd8d2d6a4175d13f8ed7ad881deef69568261294e0a2b6902f",
+				"DiscoKey":   "discokey:95c211f7d6db0ce545f9fdb2db475199f9705b8a44d71571fd118c6f31444239",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52118",
+					"10.65.0.27:52118",
+					"172.17.0.1:52118",
+					"172.19.0.1:52118",
+					"172.20.0.1:52118"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:41:11.33520277Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6036672185069575,
+				"StableID":   "ngZ9PE929p11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c78295bd39eae7cf0e339da9da6afec8d17333563273f14e1d506925bd1d5a38",
+				"DiscoKey":   "discokey:85276bf5805fd1433d589c0d1a40d1fda06fc604813b7aa351b4a1c090555c15",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40897",
+					"10.65.0.27:40897",
+					"172.17.0.1:40897",
+					"172.19.0.1:40897",
+					"172.20.0.1:40897"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:41:11.899719454Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7599225092640387,
+				"StableID":   "nEaY7vkhL221CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f283efe5dd48f342c58094239f5f650c4aaee320863de0341c3f7afe1202df44",
+				"DiscoKey":   "discokey:d3f29c6a647567f424be839fd6e3a0db91b22ad0b1c880371c45ee1d425ec704",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43890",
+					"10.65.0.27:43890",
+					"172.17.0.1:43890",
+					"172.19.0.1:43890",
+					"172.20.0.1:43890"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:41:12.423400737Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1156665432318304,
+				"StableID":   "nsiUS6er2A11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e2ee16b751e1367569f4bca507e2fa8d7c39f276e6bd8045888d08e57507b26",
+				"DiscoKey":   "discokey:70271273bdef94681a9a3d2c71256197185c20aa6939ed8d3622d19abd6a2a19",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:32865",
+					"10.65.0.27:32865",
+					"172.17.0.1:32865",
+					"172.19.0.1:32865",
+					"172.20.0.1:32865"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:41:12.96415126Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8714220496961158,
+				"StableID":   "nwbUs9og3B21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a9f329975df1ad90f87b4d9a5b3f8f3089944ba40aa27375219c973988334951",
+				"DiscoKey":   "discokey:bb9dac3bdf9553866636640c4e8c09d0a9e1cdc0d39b904a232d1eb28e64de4d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50155",
+					"10.65.0.27:50155",
+					"172.17.0.1:50155",
+					"172.19.0.1:50155",
+					"172.20.0.1:50155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:41:14.294560245Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3749613256813633,
+				"StableID":   "nGaKZxyCHW11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90fbc29d18637b89c100d4fe7db24ad225e54f823f03f395527f08f4910ea52c",
+				"DiscoKey":   "discokey:60093ed47698d591358247326e00939a53012482a0c973525fd058ab56ce580c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58799",
+					"10.65.0.27:58799",
+					"172.17.0.1:58799",
+					"172.19.0.1:58799",
+					"172.20.0.1:58799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:41:14.828130908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1491238603175504,
+				"StableID":   "nfLerwJPeC11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba328d303410383602534db8fb5ba72f5596fa90aa5c14f0d365eebc26935e48",
+				"DiscoKey":   "discokey:233b3e5784db6d954d55f681ad0a0d4b5b31b9c7a8924439f292568fad75737f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:60838",
+					"10.65.0.27:60838",
+					"172.17.0.1:60838",
+					"172.19.0.1:60838",
+					"172.20.0.1:60838"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:41:15.371303125Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4503593138210239,
+				"StableID":   "nxB2onkgAc11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:61a418955218509ba7a58707b775298eeb7970dc44c6177feb921d74569b2148",
+				"KeyExpiry":  "2026-11-08T18:41:15Z",
+				"DiscoKey":   "discokey:f455e93b2306a4568e896e309cc4f19bb5d76cfabc08eb4dae1f2f7103149c38",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53550",
+					"10.65.0.27:53550",
+					"172.17.0.1:53550",
+					"172.19.0.1:53550",
+					"172.20.0.1:53550"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:41:15.91852783Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5565423625422992,
+				"StableID":   "nHu5tzEbTk11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:08ae16170f4d7633588f2ab6c5d75f16e8e93f2e6d1d33147602f9476e7b0d29",
+				"KeyExpiry":  "2026-11-08T18:41:16Z",
+				"DiscoKey":   "discokey:b02d1adf6327312a287e2573c334eb7611a3673ab7b74df4c0bdb2a490abde78",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47365",
+					"10.65.0.27:47365",
+					"172.17.0.1:47365",
+					"172.19.0.1:47365",
+					"172.20.0.1:47365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:41:16.460447379Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4102605109684321,
+				"StableID":   "nEZEqoU53Z11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3baf2a6ce0936e23578b1314280906653476724fe82c56c82d44a2688e94396c",
+				"KeyExpiry":  "2026-11-08T18:41:16Z",
+				"DiscoKey":   "discokey:6e48d70ecb1b911c363d17e4b37aeb98cc43163d2b3ef8952686c439e664aa23",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44089",
+					"10.65.0.27:44089",
+					"172.17.0.1:44089",
+					"172.19.0.1:44089",
+					"172.20.0.1:44089"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:41:16.996929073Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7118969969782211": {
+				"ID":          7118969969782211,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5565423625422992,
+				"StableID":   "nHu5tzEbTk11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:08ae16170f4d7633588f2ab6c5d75f16e8e93f2e6d1d33147602f9476e7b0d29",
+				"KeyExpiry":  "2026-11-08T18:41:16Z",
+				"DiscoKey":   "discokey:b02d1adf6327312a287e2573c334eb7611a3673ab7b74df4c0bdb2a490abde78",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47365",
+					"10.65.0.27:47365",
+					"172.17.0.1:47365",
+					"172.19.0.1:47365",
+					"172.20.0.1:47365"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:41:16.460447379Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:08ae16170f4d7633588f2ab6c5d75f16e8e93f2e6d1d33147602f9476e7b0d29",
+			"MachineKey": "mkey:d53615fc0c6d8567d6c7560056bd20a5c257819a420cd24d713e79eb405b1170",
+			"Peers": [{
+				"ID":         240498609966026,
+				"StableID":   "nw9ccTVvs211CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08a50463cd2a8618c86fa9743cb481386625ccf5ad63800379d75f85ad7ccd45",
+				"DiscoKey":   "discokey:c4a4aaf76382f91aedf4eb0b4c7d983862afd0bdbace8aaf248f95f126cd8f79",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:37471",
+					"10.65.0.27:37471",
+					"172.17.0.1:37471",
+					"172.19.0.1:37471",
+					"172.20.0.1:37471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:41:09.221291803Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         341571337179728,
+				"StableID":   "nProQzVhf311CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0565706dd68331ca77ebb52c24e15c825d12ce6d56273a22a575c02cfbb47d03",
+				"DiscoKey":   "discokey:d6559c7b43fe9bda4559ffe8bb0cc4fb9882bcfefc42c046278926020ba5e029",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:52393",
+					"10.65.0.27:52393",
+					"172.17.0.1:52393",
+					"172.19.0.1:52393",
+					"172.20.0.1:52393"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:41:09.712537259Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3510987038080586,
+				"StableID":   "nVrCkCg8RU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89626677e197c4c4ab4063e24e4d0b851e9e31f30a0bf7b0d94a607fccf9d435",
+				"DiscoKey":   "discokey:bf6edaacd9c2e2437536de63475583a735385d7c27ae61683f398571216e970f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57038",
+					"10.65.0.27:57038",
+					"172.17.0.1:57038",
+					"172.19.0.1:57038",
+					"172.20.0.1:57038"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:41:10.258023255Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6210871730105602,
+				"StableID":   "nKmBfy4vVq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af22824f1f4eb5fddd48c970a55fbb3de7241d957bed6a647843b57dad582916",
+				"DiscoKey":   "discokey:d6a41658e27d52234b9966361ffb1f730de2f7640880b3f681e44074e5c29556",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43533",
+					"10.65.0.27:43533",
+					"172.17.0.1:43533",
+					"172.19.0.1:43533",
+					"172.20.0.1:43533"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:41:10.794537399Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8895713735327768,
+				"StableID":   "nVXKrHKtTC21CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b067afeeaddc05dd8d2d6a4175d13f8ed7ad881deef69568261294e0a2b6902f",
+				"DiscoKey":   "discokey:95c211f7d6db0ce545f9fdb2db475199f9705b8a44d71571fd118c6f31444239",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52118",
+					"10.65.0.27:52118",
+					"172.17.0.1:52118",
+					"172.19.0.1:52118",
+					"172.20.0.1:52118"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:41:11.33520277Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6036672185069575,
+				"StableID":   "ngZ9PE929p11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c78295bd39eae7cf0e339da9da6afec8d17333563273f14e1d506925bd1d5a38",
+				"DiscoKey":   "discokey:85276bf5805fd1433d589c0d1a40d1fda06fc604813b7aa351b4a1c090555c15",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40897",
+					"10.65.0.27:40897",
+					"172.17.0.1:40897",
+					"172.19.0.1:40897",
+					"172.20.0.1:40897"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:41:11.899719454Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7599225092640387,
+				"StableID":   "nEaY7vkhL221CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f283efe5dd48f342c58094239f5f650c4aaee320863de0341c3f7afe1202df44",
+				"DiscoKey":   "discokey:d3f29c6a647567f424be839fd6e3a0db91b22ad0b1c880371c45ee1d425ec704",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43890",
+					"10.65.0.27:43890",
+					"172.17.0.1:43890",
+					"172.19.0.1:43890",
+					"172.20.0.1:43890"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:41:12.423400737Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1156665432318304,
+				"StableID":   "nsiUS6er2A11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e2ee16b751e1367569f4bca507e2fa8d7c39f276e6bd8045888d08e57507b26",
+				"DiscoKey":   "discokey:70271273bdef94681a9a3d2c71256197185c20aa6939ed8d3622d19abd6a2a19",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:32865",
+					"10.65.0.27:32865",
+					"172.17.0.1:32865",
+					"172.19.0.1:32865",
+					"172.20.0.1:32865"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:41:12.96415126Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7118969969782211,
+				"StableID":   "nA4pTdGCbx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0051b5c6157b41a2c1c8e17fcd6096ada3c6ea149d502c9266cdade174c3f107",
+				"DiscoKey":   "discokey:4c62525bdb5cddf6b8a07f8e33ceb1e9ec92616276654615f4d6f8f409dfbd7b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37240",
+					"10.65.0.27:37240",
+					"172.17.0.1:37240",
+					"172.19.0.1:37240",
+					"172.20.0.1:37240"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:41:13.503847073Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8714220496961158,
+				"StableID":   "nwbUs9og3B21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a9f329975df1ad90f87b4d9a5b3f8f3089944ba40aa27375219c973988334951",
+				"DiscoKey":   "discokey:bb9dac3bdf9553866636640c4e8c09d0a9e1cdc0d39b904a232d1eb28e64de4d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50155",
+					"10.65.0.27:50155",
+					"172.17.0.1:50155",
+					"172.19.0.1:50155",
+					"172.20.0.1:50155"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:41:14.294560245Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3749613256813633,
+				"StableID":   "nGaKZxyCHW11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90fbc29d18637b89c100d4fe7db24ad225e54f823f03f395527f08f4910ea52c",
+				"DiscoKey":   "discokey:60093ed47698d591358247326e00939a53012482a0c973525fd058ab56ce580c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58799",
+					"10.65.0.27:58799",
+					"172.17.0.1:58799",
+					"172.19.0.1:58799",
+					"172.20.0.1:58799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:41:14.828130908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1491238603175504,
+				"StableID":   "nfLerwJPeC11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba328d303410383602534db8fb5ba72f5596fa90aa5c14f0d365eebc26935e48",
+				"DiscoKey":   "discokey:233b3e5784db6d954d55f681ad0a0d4b5b31b9c7a8924439f292568fad75737f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:60838",
+					"10.65.0.27:60838",
+					"172.17.0.1:60838",
+					"172.19.0.1:60838",
+					"172.20.0.1:60838"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:41:15.371303125Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4503593138210239,
+				"StableID":   "nxB2onkgAc11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:61a418955218509ba7a58707b775298eeb7970dc44c6177feb921d74569b2148",
+				"KeyExpiry":  "2026-11-08T18:41:15Z",
+				"DiscoKey":   "discokey:f455e93b2306a4568e896e309cc4f19bb5d76cfabc08eb4dae1f2f7103149c38",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53550",
+					"10.65.0.27:53550",
+					"172.17.0.1:53550",
+					"172.19.0.1:53550",
+					"172.20.0.1:53550"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:41:15.91852783Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4102605109684321,
+				"StableID":   "nEZEqoU53Z11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3baf2a6ce0936e23578b1314280906653476724fe82c56c82d44a2688e94396c",
+				"KeyExpiry":  "2026-11-08T18:41:16Z",
+				"DiscoKey":   "discokey:6e48d70ecb1b911c363d17e4b37aeb98cc43163d2b3ef8952686c439e664aa23",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44089",
+					"10.65.0.27:44089",
+					"172.17.0.1:44089",
+					"172.19.0.1:44089",
+					"172.20.0.1:44089"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:41:16.996929073Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8714220496961158,
+				"StableID":   "nwbUs9og3B21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       8714220496961158,
+				"Key":        "nodekey:a9f329975df1ad90f87b4d9a5b3f8f3089944ba40aa27375219c973988334951",
+				"DiscoKey":   "discokey:bb9dac3bdf9553866636640c4e8c09d0a9e1cdc0d39b904a232d1eb28e64de4d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:50155",
+					"10.65.0.27:50155",
+					"172.17.0.1:50155",
+					"172.19.0.1:50155",
+					"172.20.0.1:50155"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:41:14.294560245Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a9f329975df1ad90f87b4d9a5b3f8f3089944ba40aa27375219c973988334951",
+			"MachineKey": "mkey:a81c311aa2655226888292e78898ec2c4e2e8058332b729118458c4af0dc531a",
+			"Peers": [{
+				"ID":         240498609966026,
+				"StableID":   "nw9ccTVvs211CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:08a50463cd2a8618c86fa9743cb481386625ccf5ad63800379d75f85ad7ccd45",
+				"DiscoKey":   "discokey:c4a4aaf76382f91aedf4eb0b4c7d983862afd0bdbace8aaf248f95f126cd8f79",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:37471",
+					"10.65.0.27:37471",
+					"172.17.0.1:37471",
+					"172.19.0.1:37471",
+					"172.20.0.1:37471"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:41:09.221291803Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         341571337179728,
+				"StableID":   "nProQzVhf311CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0565706dd68331ca77ebb52c24e15c825d12ce6d56273a22a575c02cfbb47d03",
+				"DiscoKey":   "discokey:d6559c7b43fe9bda4559ffe8bb0cc4fb9882bcfefc42c046278926020ba5e029",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:52393",
+					"10.65.0.27:52393",
+					"172.17.0.1:52393",
+					"172.19.0.1:52393",
+					"172.20.0.1:52393"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:41:09.712537259Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3510987038080586,
+				"StableID":   "nVrCkCg8RU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:89626677e197c4c4ab4063e24e4d0b851e9e31f30a0bf7b0d94a607fccf9d435",
+				"DiscoKey":   "discokey:bf6edaacd9c2e2437536de63475583a735385d7c27ae61683f398571216e970f",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:57038",
+					"10.65.0.27:57038",
+					"172.17.0.1:57038",
+					"172.19.0.1:57038",
+					"172.20.0.1:57038"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:41:10.258023255Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6210871730105602,
+				"StableID":   "nKmBfy4vVq11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af22824f1f4eb5fddd48c970a55fbb3de7241d957bed6a647843b57dad582916",
+				"DiscoKey":   "discokey:d6a41658e27d52234b9966361ffb1f730de2f7640880b3f681e44074e5c29556",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:43533",
+					"10.65.0.27:43533",
+					"172.17.0.1:43533",
+					"172.19.0.1:43533",
+					"172.20.0.1:43533"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:41:10.794537399Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8895713735327768,
+				"StableID":   "nVXKrHKtTC21CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b067afeeaddc05dd8d2d6a4175d13f8ed7ad881deef69568261294e0a2b6902f",
+				"DiscoKey":   "discokey:95c211f7d6db0ce545f9fdb2db475199f9705b8a44d71571fd118c6f31444239",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:52118",
+					"10.65.0.27:52118",
+					"172.17.0.1:52118",
+					"172.19.0.1:52118",
+					"172.20.0.1:52118"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:41:11.33520277Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6036672185069575,
+				"StableID":   "ngZ9PE929p11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c78295bd39eae7cf0e339da9da6afec8d17333563273f14e1d506925bd1d5a38",
+				"DiscoKey":   "discokey:85276bf5805fd1433d589c0d1a40d1fda06fc604813b7aa351b4a1c090555c15",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:40897",
+					"10.65.0.27:40897",
+					"172.17.0.1:40897",
+					"172.19.0.1:40897",
+					"172.20.0.1:40897"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:41:11.899719454Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7599225092640387,
+				"StableID":   "nEaY7vkhL221CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f283efe5dd48f342c58094239f5f650c4aaee320863de0341c3f7afe1202df44",
+				"DiscoKey":   "discokey:d3f29c6a647567f424be839fd6e3a0db91b22ad0b1c880371c45ee1d425ec704",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:43890",
+					"10.65.0.27:43890",
+					"172.17.0.1:43890",
+					"172.19.0.1:43890",
+					"172.20.0.1:43890"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:41:12.423400737Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1156665432318304,
+				"StableID":   "nsiUS6er2A11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0e2ee16b751e1367569f4bca507e2fa8d7c39f276e6bd8045888d08e57507b26",
+				"DiscoKey":   "discokey:70271273bdef94681a9a3d2c71256197185c20aa6939ed8d3622d19abd6a2a19",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:32865",
+					"10.65.0.27:32865",
+					"172.17.0.1:32865",
+					"172.19.0.1:32865",
+					"172.20.0.1:32865"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:41:12.96415126Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7118969969782211,
+				"StableID":   "nA4pTdGCbx11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0051b5c6157b41a2c1c8e17fcd6096ada3c6ea149d502c9266cdade174c3f107",
+				"DiscoKey":   "discokey:4c62525bdb5cddf6b8a07f8e33ceb1e9ec92616276654615f4d6f8f409dfbd7b",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:37240",
+					"10.65.0.27:37240",
+					"172.17.0.1:37240",
+					"172.19.0.1:37240",
+					"172.20.0.1:37240"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:41:13.503847073Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3749613256813633,
+				"StableID":   "nGaKZxyCHW11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:90fbc29d18637b89c100d4fe7db24ad225e54f823f03f395527f08f4910ea52c",
+				"DiscoKey":   "discokey:60093ed47698d591358247326e00939a53012482a0c973525fd058ab56ce580c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:58799",
+					"10.65.0.27:58799",
+					"172.17.0.1:58799",
+					"172.19.0.1:58799",
+					"172.20.0.1:58799"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:41:14.828130908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1491238603175504,
+				"StableID":   "nfLerwJPeC11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba328d303410383602534db8fb5ba72f5596fa90aa5c14f0d365eebc26935e48",
+				"DiscoKey":   "discokey:233b3e5784db6d954d55f681ad0a0d4b5b31b9c7a8924439f292568fad75737f",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:60838",
+					"10.65.0.27:60838",
+					"172.17.0.1:60838",
+					"172.19.0.1:60838",
+					"172.20.0.1:60838"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:41:15.371303125Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4503593138210239,
+				"StableID":   "nxB2onkgAc11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:61a418955218509ba7a58707b775298eeb7970dc44c6177feb921d74569b2148",
+				"KeyExpiry":  "2026-11-08T18:41:15Z",
+				"DiscoKey":   "discokey:f455e93b2306a4568e896e309cc4f19bb5d76cfabc08eb4dae1f2f7103149c38",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:53550",
+					"10.65.0.27:53550",
+					"172.17.0.1:53550",
+					"172.19.0.1:53550",
+					"172.20.0.1:53550"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:41:15.91852783Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5565423625422992,
+				"StableID":   "nHu5tzEbTk11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:08ae16170f4d7633588f2ab6c5d75f16e8e93f2e6d1d33147602f9476e7b0d29",
+				"KeyExpiry":  "2026-11-08T18:41:16Z",
+				"DiscoKey":   "discokey:b02d1adf6327312a287e2573c334eb7611a3673ab7b74df4c0bdb2a490abde78",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:47365",
+					"10.65.0.27:47365",
+					"172.17.0.1:47365",
+					"172.19.0.1:47365",
+					"172.20.0.1:47365"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:41:16.460447379Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4102605109684321,
+				"StableID":   "nEZEqoU53Z11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3baf2a6ce0936e23578b1314280906653476724fe82c56c82d44a2688e94396c",
+				"KeyExpiry":  "2026-11-08T18:41:16Z",
+				"DiscoKey":   "discokey:6e48d70ecb1b911c363d17e4b37aeb98cc43163d2b3ef8952686c439e664aa23",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44089",
+					"10.65.0.27:44089",
+					"172.17.0.1:44089",
+					"172.19.0.1:44089",
+					"172.20.0.1:44089"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:41:16.996929073Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8714220496961158": {
+				"ID":          8714220496961158,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/sshtest_results/sshtest-ip-literal-src.hujson
+++ b/hscontrol/policy/v2/testdata/sshtest_results/sshtest-ip-literal-src.hujson
@@ -1,0 +1,20099 @@
+// sshtest-ip-literal-src
+//
+// sshTests src as IP literal
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T18:42:02Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "sshtest-ip-literal-src",
+	"description":    "sshTests src as IP literal",
+	"category":       "sshtest",
+	"captured_at":    "2026-05-12T18:42:02.258609574Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                         \n  \n                                                          \n{\n\t\"category\":    \"sshtest\",\n\t\"description\": \"sshTests src as IP literal\",\n\t\"id\":          \"sshtest-ip-literal-src\",\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"thor@example.org\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"sshTests\": [{\n\t\t\"accept\": [\"root\"],\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    \"100.64.0.17\"\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/sshtest/sshtest-ip-literal-src.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["thor@example.org"],
+				"users":  ["root"]
+			}],
+			"sshTests":  [{"accept": ["root"], "dst": ["tag:server"], "src": "100.64.0.17"}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8853228925457753,
+				"StableID":   "ngihg4Ke8C21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       8853228925457753,
+				"Key":        "nodekey:ea8eaced1cfef237fc874e043f9ee4bb2bb25962d87a84a61b54fc34e6426a2d",
+				"DiscoKey":   "discokey:cc1adca9f1dd4302c6deb3f12582ff360109a71a014d6d1a5eb3b07217e6b868",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56826",
+					"10.65.0.27:56826",
+					"172.17.0.1:56826",
+					"172.19.0.1:56826",
+					"172.20.0.1:56826"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:42:13.046497681Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ea8eaced1cfef237fc874e043f9ee4bb2bb25962d87a84a61b54fc34e6426a2d",
+			"MachineKey": "mkey:879112bf7e50823ce339a634b6a391f377457794e125181ef88e815055ac6d70",
+			"Peers": [{
+				"ID":         2107794865515843,
+				"StableID":   "nvWkTRCdTH11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf500e8e8d399ec7a80a04cd91ba87bb5e7d807a04c02ddfde5ed03c5ac7621a",
+				"DiscoKey":   "discokey:a810cd5d5deefdf927015e5aeefb1df748e3a36a50228939a212905250a79c4d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46426",
+					"10.65.0.27:46426",
+					"172.17.0.1:46426",
+					"172.19.0.1:46426",
+					"172.20.0.1:46426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:42:07.17026767Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3271489561762550,
+				"StableID":   "nuGEt2VfYS11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f87cd8de6d8802c5689ad796dd9b9e178562554000c9588fcee4efd4b7959871",
+				"DiscoKey":   "discokey:59788ee09e4842b712929a33b31587544e9251fa79733f708fb210e4ef80df51",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:46590",
+					"10.65.0.27:46590",
+					"172.17.0.1:46590",
+					"172.19.0.1:46590",
+					"172.20.0.1:46590"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:42:07.654822046Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5750505107573070,
+				"StableID":   "nb7Fg32Rum11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8467b29855e1cd9b977af1ecd74cfc2fdc0ef2c4d25f10f10e1e2383cc07f21d",
+				"DiscoKey":   "discokey:06fe18a20509b7424041576a76adafb50be1b46d64eaf73fc5560b4f5beeeb50",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59964",
+					"10.65.0.27:59964",
+					"172.17.0.1:59964",
+					"172.19.0.1:59964",
+					"172.20.0.1:59964"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:42:08.1985255Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6958286858885,
+				"StableID":   "nE5yyNn94111CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdb16b0fc71019137f6d0317d1773d0938389fb29b72e52020ba0c596cfadd4d",
+				"DiscoKey":   "discokey:a571eb7e453d8d802187e4d50a4ac5a9fe18021565cd761cb78d7d2779054e74",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39497",
+					"10.65.0.27:39497",
+					"172.17.0.1:39497",
+					"172.19.0.1:39497",
+					"172.20.0.1:39497"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:42:08.73515415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7765976342319786,
+				"StableID":   "nmxy2j2Ee321CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:862f769e7eeadbf0543a1079a3fc8820d5b2eb6dedd3a2df955cce46b349ee5b",
+				"DiscoKey":   "discokey:908e6ff2c41af8396e12ae4be9d9a4a0237073416ebcb170785e5ac226fdbe7c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57346",
+					"10.65.0.27:57346",
+					"172.17.0.1:57346",
+					"172.19.0.1:57346",
+					"172.20.0.1:57346"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:42:09.280550815Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6506773082495447,
+				"StableID":   "nexLuvtvos11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:56209ad55cab2294595a7956e8c13820c1822743eb2e07a20ec005a05ae96743",
+				"DiscoKey":   "discokey:3714768eab0f957b8019abdd426c02fb2354fc0aeefbcb74d817eca337186301",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:43177",
+					"10.65.0.27:43177",
+					"172.17.0.1:43177",
+					"172.19.0.1:43177",
+					"172.20.0.1:43177"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:42:09.839963905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4795657944005432,
+				"StableID":   "n554ZXoxSe11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:160d7bd196d93fcb90fecf5a7d355bd70171482742a85bcf580c3449c887816c",
+				"DiscoKey":   "discokey:7e0ac3f8aa7a69fb80d06c277b30877ea8657027525b1a5d4bf818df42f0a575",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38750",
+					"10.65.0.27:38750",
+					"172.17.0.1:38750",
+					"172.19.0.1:38750",
+					"172.20.0.1:38750"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:42:10.367105213Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         737133093972331,
+				"StableID":   "n2ebKiErk611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7a3804bacb24ea6a0bb127400097e08529824fc8adbb04addd7fe035dc819a2b",
+				"DiscoKey":   "discokey:98b9f18c6425e92da333e4db7d5826f34b39df0312701fea1e4b5b8171820811",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37863",
+					"10.65.0.27:37863",
+					"172.17.0.1:37863",
+					"172.19.0.1:37863",
+					"172.20.0.1:37863"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:42:10.92223257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2765680423692704,
+				"StableID":   "n7r1RdjabN11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2811cb575850b23f8299a4b259850c98edeae8950ea77bd9f5918bb8f368fb66",
+				"DiscoKey":   "discokey:057e4cd16ea2e34268069aa323243aa8c476f9eea1eec4a5d30ef55bb7f94533",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38368",
+					"10.65.0.27:38368",
+					"172.17.0.1:38368",
+					"172.19.0.1:38368",
+					"172.20.0.1:38368"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:42:11.470756103Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2675001517369833,
+				"StableID":   "nGihyikWtM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6d3a926a7a50964b2b01e1004b3a36e8359e6c0c13be90fcf1645c0c61a35a10",
+				"DiscoKey":   "discokey:78e4438942419188b8cd767f064dd3e5a24a6dedd652e992ab10a94f610c3953",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44440",
+					"10.65.0.27:44440",
+					"172.17.0.1:44440",
+					"172.19.0.1:44440",
+					"172.20.0.1:44440"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:42:11.964549675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2605669856774919,
+				"StableID":   "nGdfYfX7MM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d820bcf4ba5a242b49d2b64b05c1012406aad212ce148d83e7ddfc848a00c0a",
+				"DiscoKey":   "discokey:d633cfd71b59b6122da8369ecc5c46982b0b5611b80bd47d225ec7df43c28a45",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43304",
+					"10.65.0.27:43304",
+					"172.17.0.1:43304",
+					"172.19.0.1:43304",
+					"172.20.0.1:43304"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:42:12.512864003Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7879449713780322,
+				"StableID":   "nXHLJQncX421CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e02d27592c0afc2627238fb7a9814f8b101b6ef087c473ac7b9ea468b87ade4a",
+				"KeyExpiry":  "2026-11-08T18:42:13Z",
+				"DiscoKey":   "discokey:d080c365550cfaa8e60544ca49deeeaa745c60ab9d904948e77d42f6fd70653c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34510",
+					"10.65.0.27:34510",
+					"172.17.0.1:34510",
+					"172.19.0.1:34510",
+					"172.20.0.1:34510"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:42:13.591035372Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1623421204509298,
+				"StableID":   "nhCUhHXFgD11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3366437d728ea6c21dd6ae2e1cbfc10fcda27c000fa1c58cf7b80021b7a5cb31",
+				"KeyExpiry":  "2026-11-08T18:42:14Z",
+				"DiscoKey":   "discokey:83f62475a7bdcae0681ce2a3d8b8f77d10080e41e5d0b14730921ce5449e1d2b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51904",
+					"10.65.0.27:51904",
+					"172.17.0.1:51904",
+					"172.19.0.1:51904",
+					"172.20.0.1:51904"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:42:14.146489745Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1681457587646704,
+				"StableID":   "nDj59J3Y8E11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:354044a49a47914e16be1473e39069c698caf4962ecf5e03906382cbe51cf71f",
+				"KeyExpiry":  "2026-11-08T18:42:14Z",
+				"DiscoKey":   "discokey:4863a1de33e9caf6aed67d6e11cee190a96ebad8a95a73ea65a42ed25ab2ea75",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:52679",
+					"10.65.0.27:52679",
+					"172.17.0.1:52679",
+					"172.19.0.1:52679",
+					"172.20.0.1:52679"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:42:14.680627967Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{
+				"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+				"sshUsers":   {"root": "root"},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				}
+			}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8853228925457753": {
+				"ID":          8853228925457753,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		},
+		"ssh_rules": [{
+			"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+			"sshUsers":   {"root": "root"},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}
+		}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6506773082495447,
+				"StableID":   "nexLuvtvos11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       6506773082495447,
+				"Key":        "nodekey:56209ad55cab2294595a7956e8c13820c1822743eb2e07a20ec005a05ae96743",
+				"DiscoKey":   "discokey:3714768eab0f957b8019abdd426c02fb2354fc0aeefbcb74d817eca337186301",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:43177",
+					"10.65.0.27:43177",
+					"172.17.0.1:43177",
+					"172.19.0.1:43177",
+					"172.20.0.1:43177"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:42:09.839963905Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:56209ad55cab2294595a7956e8c13820c1822743eb2e07a20ec005a05ae96743",
+			"MachineKey": "mkey:d37aad5c732e40d5b962fa64ff178b55da9be69c5fef0e0cb743e2ca40c8064d",
+			"Peers": [{
+				"ID":         2107794865515843,
+				"StableID":   "nvWkTRCdTH11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf500e8e8d399ec7a80a04cd91ba87bb5e7d807a04c02ddfde5ed03c5ac7621a",
+				"DiscoKey":   "discokey:a810cd5d5deefdf927015e5aeefb1df748e3a36a50228939a212905250a79c4d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46426",
+					"10.65.0.27:46426",
+					"172.17.0.1:46426",
+					"172.19.0.1:46426",
+					"172.20.0.1:46426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:42:07.17026767Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3271489561762550,
+				"StableID":   "nuGEt2VfYS11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f87cd8de6d8802c5689ad796dd9b9e178562554000c9588fcee4efd4b7959871",
+				"DiscoKey":   "discokey:59788ee09e4842b712929a33b31587544e9251fa79733f708fb210e4ef80df51",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:46590",
+					"10.65.0.27:46590",
+					"172.17.0.1:46590",
+					"172.19.0.1:46590",
+					"172.20.0.1:46590"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:42:07.654822046Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5750505107573070,
+				"StableID":   "nb7Fg32Rum11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8467b29855e1cd9b977af1ecd74cfc2fdc0ef2c4d25f10f10e1e2383cc07f21d",
+				"DiscoKey":   "discokey:06fe18a20509b7424041576a76adafb50be1b46d64eaf73fc5560b4f5beeeb50",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59964",
+					"10.65.0.27:59964",
+					"172.17.0.1:59964",
+					"172.19.0.1:59964",
+					"172.20.0.1:59964"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:42:08.1985255Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6958286858885,
+				"StableID":   "nE5yyNn94111CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdb16b0fc71019137f6d0317d1773d0938389fb29b72e52020ba0c596cfadd4d",
+				"DiscoKey":   "discokey:a571eb7e453d8d802187e4d50a4ac5a9fe18021565cd761cb78d7d2779054e74",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39497",
+					"10.65.0.27:39497",
+					"172.17.0.1:39497",
+					"172.19.0.1:39497",
+					"172.20.0.1:39497"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:42:08.73515415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7765976342319786,
+				"StableID":   "nmxy2j2Ee321CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:862f769e7eeadbf0543a1079a3fc8820d5b2eb6dedd3a2df955cce46b349ee5b",
+				"DiscoKey":   "discokey:908e6ff2c41af8396e12ae4be9d9a4a0237073416ebcb170785e5ac226fdbe7c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57346",
+					"10.65.0.27:57346",
+					"172.17.0.1:57346",
+					"172.19.0.1:57346",
+					"172.20.0.1:57346"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:42:09.280550815Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4795657944005432,
+				"StableID":   "n554ZXoxSe11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:160d7bd196d93fcb90fecf5a7d355bd70171482742a85bcf580c3449c887816c",
+				"DiscoKey":   "discokey:7e0ac3f8aa7a69fb80d06c277b30877ea8657027525b1a5d4bf818df42f0a575",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38750",
+					"10.65.0.27:38750",
+					"172.17.0.1:38750",
+					"172.19.0.1:38750",
+					"172.20.0.1:38750"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:42:10.367105213Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         737133093972331,
+				"StableID":   "n2ebKiErk611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7a3804bacb24ea6a0bb127400097e08529824fc8adbb04addd7fe035dc819a2b",
+				"DiscoKey":   "discokey:98b9f18c6425e92da333e4db7d5826f34b39df0312701fea1e4b5b8171820811",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37863",
+					"10.65.0.27:37863",
+					"172.17.0.1:37863",
+					"172.19.0.1:37863",
+					"172.20.0.1:37863"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:42:10.92223257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2765680423692704,
+				"StableID":   "n7r1RdjabN11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2811cb575850b23f8299a4b259850c98edeae8950ea77bd9f5918bb8f368fb66",
+				"DiscoKey":   "discokey:057e4cd16ea2e34268069aa323243aa8c476f9eea1eec4a5d30ef55bb7f94533",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38368",
+					"10.65.0.27:38368",
+					"172.17.0.1:38368",
+					"172.19.0.1:38368",
+					"172.20.0.1:38368"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:42:11.470756103Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2675001517369833,
+				"StableID":   "nGihyikWtM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6d3a926a7a50964b2b01e1004b3a36e8359e6c0c13be90fcf1645c0c61a35a10",
+				"DiscoKey":   "discokey:78e4438942419188b8cd767f064dd3e5a24a6dedd652e992ab10a94f610c3953",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44440",
+					"10.65.0.27:44440",
+					"172.17.0.1:44440",
+					"172.19.0.1:44440",
+					"172.20.0.1:44440"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:42:11.964549675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2605669856774919,
+				"StableID":   "nGdfYfX7MM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d820bcf4ba5a242b49d2b64b05c1012406aad212ce148d83e7ddfc848a00c0a",
+				"DiscoKey":   "discokey:d633cfd71b59b6122da8369ecc5c46982b0b5611b80bd47d225ec7df43c28a45",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43304",
+					"10.65.0.27:43304",
+					"172.17.0.1:43304",
+					"172.19.0.1:43304",
+					"172.20.0.1:43304"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:42:12.512864003Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8853228925457753,
+				"StableID":   "ngihg4Ke8C21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea8eaced1cfef237fc874e043f9ee4bb2bb25962d87a84a61b54fc34e6426a2d",
+				"DiscoKey":   "discokey:cc1adca9f1dd4302c6deb3f12582ff360109a71a014d6d1a5eb3b07217e6b868",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56826",
+					"10.65.0.27:56826",
+					"172.17.0.1:56826",
+					"172.19.0.1:56826",
+					"172.20.0.1:56826"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:42:13.046497681Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7879449713780322,
+				"StableID":   "nXHLJQncX421CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e02d27592c0afc2627238fb7a9814f8b101b6ef087c473ac7b9ea468b87ade4a",
+				"KeyExpiry":  "2026-11-08T18:42:13Z",
+				"DiscoKey":   "discokey:d080c365550cfaa8e60544ca49deeeaa745c60ab9d904948e77d42f6fd70653c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34510",
+					"10.65.0.27:34510",
+					"172.17.0.1:34510",
+					"172.19.0.1:34510",
+					"172.20.0.1:34510"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:42:13.591035372Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1623421204509298,
+				"StableID":   "nhCUhHXFgD11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3366437d728ea6c21dd6ae2e1cbfc10fcda27c000fa1c58cf7b80021b7a5cb31",
+				"KeyExpiry":  "2026-11-08T18:42:14Z",
+				"DiscoKey":   "discokey:83f62475a7bdcae0681ce2a3d8b8f77d10080e41e5d0b14730921ce5449e1d2b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51904",
+					"10.65.0.27:51904",
+					"172.17.0.1:51904",
+					"172.19.0.1:51904",
+					"172.20.0.1:51904"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:42:14.146489745Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1681457587646704,
+				"StableID":   "nDj59J3Y8E11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:354044a49a47914e16be1473e39069c698caf4962ecf5e03906382cbe51cf71f",
+				"KeyExpiry":  "2026-11-08T18:42:14Z",
+				"DiscoKey":   "discokey:4863a1de33e9caf6aed67d6e11cee190a96ebad8a95a73ea65a42ed25ab2ea75",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:52679",
+					"10.65.0.27:52679",
+					"172.17.0.1:52679",
+					"172.19.0.1:52679",
+					"172.20.0.1:52679"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:42:14.680627967Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6506773082495447": {
+				"ID":          6506773082495447,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1681457587646704,
+				"StableID":   "nDj59J3Y8E11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:354044a49a47914e16be1473e39069c698caf4962ecf5e03906382cbe51cf71f",
+				"KeyExpiry":  "2026-11-08T18:42:14Z",
+				"DiscoKey":   "discokey:4863a1de33e9caf6aed67d6e11cee190a96ebad8a95a73ea65a42ed25ab2ea75",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:52679",
+					"10.65.0.27:52679",
+					"172.17.0.1:52679",
+					"172.19.0.1:52679",
+					"172.20.0.1:52679"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:42:14.680627967Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:354044a49a47914e16be1473e39069c698caf4962ecf5e03906382cbe51cf71f",
+			"MachineKey": "mkey:fea31482b928f952a1f74f4fbd73840269154e1ed4814fce785c4f30cd956f3e",
+			"Peers": [{
+				"ID":         2107794865515843,
+				"StableID":   "nvWkTRCdTH11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf500e8e8d399ec7a80a04cd91ba87bb5e7d807a04c02ddfde5ed03c5ac7621a",
+				"DiscoKey":   "discokey:a810cd5d5deefdf927015e5aeefb1df748e3a36a50228939a212905250a79c4d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46426",
+					"10.65.0.27:46426",
+					"172.17.0.1:46426",
+					"172.19.0.1:46426",
+					"172.20.0.1:46426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:42:07.17026767Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3271489561762550,
+				"StableID":   "nuGEt2VfYS11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f87cd8de6d8802c5689ad796dd9b9e178562554000c9588fcee4efd4b7959871",
+				"DiscoKey":   "discokey:59788ee09e4842b712929a33b31587544e9251fa79733f708fb210e4ef80df51",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:46590",
+					"10.65.0.27:46590",
+					"172.17.0.1:46590",
+					"172.19.0.1:46590",
+					"172.20.0.1:46590"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:42:07.654822046Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5750505107573070,
+				"StableID":   "nb7Fg32Rum11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8467b29855e1cd9b977af1ecd74cfc2fdc0ef2c4d25f10f10e1e2383cc07f21d",
+				"DiscoKey":   "discokey:06fe18a20509b7424041576a76adafb50be1b46d64eaf73fc5560b4f5beeeb50",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59964",
+					"10.65.0.27:59964",
+					"172.17.0.1:59964",
+					"172.19.0.1:59964",
+					"172.20.0.1:59964"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:42:08.1985255Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6958286858885,
+				"StableID":   "nE5yyNn94111CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdb16b0fc71019137f6d0317d1773d0938389fb29b72e52020ba0c596cfadd4d",
+				"DiscoKey":   "discokey:a571eb7e453d8d802187e4d50a4ac5a9fe18021565cd761cb78d7d2779054e74",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39497",
+					"10.65.0.27:39497",
+					"172.17.0.1:39497",
+					"172.19.0.1:39497",
+					"172.20.0.1:39497"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:42:08.73515415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7765976342319786,
+				"StableID":   "nmxy2j2Ee321CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:862f769e7eeadbf0543a1079a3fc8820d5b2eb6dedd3a2df955cce46b349ee5b",
+				"DiscoKey":   "discokey:908e6ff2c41af8396e12ae4be9d9a4a0237073416ebcb170785e5ac226fdbe7c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57346",
+					"10.65.0.27:57346",
+					"172.17.0.1:57346",
+					"172.19.0.1:57346",
+					"172.20.0.1:57346"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:42:09.280550815Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6506773082495447,
+				"StableID":   "nexLuvtvos11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:56209ad55cab2294595a7956e8c13820c1822743eb2e07a20ec005a05ae96743",
+				"DiscoKey":   "discokey:3714768eab0f957b8019abdd426c02fb2354fc0aeefbcb74d817eca337186301",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:43177",
+					"10.65.0.27:43177",
+					"172.17.0.1:43177",
+					"172.19.0.1:43177",
+					"172.20.0.1:43177"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:42:09.839963905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4795657944005432,
+				"StableID":   "n554ZXoxSe11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:160d7bd196d93fcb90fecf5a7d355bd70171482742a85bcf580c3449c887816c",
+				"DiscoKey":   "discokey:7e0ac3f8aa7a69fb80d06c277b30877ea8657027525b1a5d4bf818df42f0a575",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38750",
+					"10.65.0.27:38750",
+					"172.17.0.1:38750",
+					"172.19.0.1:38750",
+					"172.20.0.1:38750"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:42:10.367105213Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         737133093972331,
+				"StableID":   "n2ebKiErk611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7a3804bacb24ea6a0bb127400097e08529824fc8adbb04addd7fe035dc819a2b",
+				"DiscoKey":   "discokey:98b9f18c6425e92da333e4db7d5826f34b39df0312701fea1e4b5b8171820811",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37863",
+					"10.65.0.27:37863",
+					"172.17.0.1:37863",
+					"172.19.0.1:37863",
+					"172.20.0.1:37863"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:42:10.92223257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2765680423692704,
+				"StableID":   "n7r1RdjabN11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2811cb575850b23f8299a4b259850c98edeae8950ea77bd9f5918bb8f368fb66",
+				"DiscoKey":   "discokey:057e4cd16ea2e34268069aa323243aa8c476f9eea1eec4a5d30ef55bb7f94533",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38368",
+					"10.65.0.27:38368",
+					"172.17.0.1:38368",
+					"172.19.0.1:38368",
+					"172.20.0.1:38368"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:42:11.470756103Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2675001517369833,
+				"StableID":   "nGihyikWtM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6d3a926a7a50964b2b01e1004b3a36e8359e6c0c13be90fcf1645c0c61a35a10",
+				"DiscoKey":   "discokey:78e4438942419188b8cd767f064dd3e5a24a6dedd652e992ab10a94f610c3953",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44440",
+					"10.65.0.27:44440",
+					"172.17.0.1:44440",
+					"172.19.0.1:44440",
+					"172.20.0.1:44440"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:42:11.964549675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2605669856774919,
+				"StableID":   "nGdfYfX7MM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d820bcf4ba5a242b49d2b64b05c1012406aad212ce148d83e7ddfc848a00c0a",
+				"DiscoKey":   "discokey:d633cfd71b59b6122da8369ecc5c46982b0b5611b80bd47d225ec7df43c28a45",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43304",
+					"10.65.0.27:43304",
+					"172.17.0.1:43304",
+					"172.19.0.1:43304",
+					"172.20.0.1:43304"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:42:12.512864003Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8853228925457753,
+				"StableID":   "ngihg4Ke8C21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea8eaced1cfef237fc874e043f9ee4bb2bb25962d87a84a61b54fc34e6426a2d",
+				"DiscoKey":   "discokey:cc1adca9f1dd4302c6deb3f12582ff360109a71a014d6d1a5eb3b07217e6b868",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56826",
+					"10.65.0.27:56826",
+					"172.17.0.1:56826",
+					"172.19.0.1:56826",
+					"172.20.0.1:56826"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:42:13.046497681Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7879449713780322,
+				"StableID":   "nXHLJQncX421CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e02d27592c0afc2627238fb7a9814f8b101b6ef087c473ac7b9ea468b87ade4a",
+				"KeyExpiry":  "2026-11-08T18:42:13Z",
+				"DiscoKey":   "discokey:d080c365550cfaa8e60544ca49deeeaa745c60ab9d904948e77d42f6fd70653c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34510",
+					"10.65.0.27:34510",
+					"172.17.0.1:34510",
+					"172.19.0.1:34510",
+					"172.20.0.1:34510"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:42:13.591035372Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1623421204509298,
+				"StableID":   "nhCUhHXFgD11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3366437d728ea6c21dd6ae2e1cbfc10fcda27c000fa1c58cf7b80021b7a5cb31",
+				"KeyExpiry":  "2026-11-08T18:42:14Z",
+				"DiscoKey":   "discokey:83f62475a7bdcae0681ce2a3d8b8f77d10080e41e5d0b14730921ce5449e1d2b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51904",
+					"10.65.0.27:51904",
+					"172.17.0.1:51904",
+					"172.19.0.1:51904",
+					"172.20.0.1:51904"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:42:14.146489745Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5750505107573070,
+				"StableID":   "nb7Fg32Rum11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       5750505107573070,
+				"Key":        "nodekey:8467b29855e1cd9b977af1ecd74cfc2fdc0ef2c4d25f10f10e1e2383cc07f21d",
+				"DiscoKey":   "discokey:06fe18a20509b7424041576a76adafb50be1b46d64eaf73fc5560b4f5beeeb50",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59964",
+					"10.65.0.27:59964",
+					"172.17.0.1:59964",
+					"172.19.0.1:59964",
+					"172.20.0.1:59964"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:42:08.1985255Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8467b29855e1cd9b977af1ecd74cfc2fdc0ef2c4d25f10f10e1e2383cc07f21d",
+			"MachineKey": "mkey:193e24e84a00611edce8f414958f5cf03ffa19c63378ea8c2cd30c384cb8d93f",
+			"Peers": [{
+				"ID":         2107794865515843,
+				"StableID":   "nvWkTRCdTH11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf500e8e8d399ec7a80a04cd91ba87bb5e7d807a04c02ddfde5ed03c5ac7621a",
+				"DiscoKey":   "discokey:a810cd5d5deefdf927015e5aeefb1df748e3a36a50228939a212905250a79c4d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46426",
+					"10.65.0.27:46426",
+					"172.17.0.1:46426",
+					"172.19.0.1:46426",
+					"172.20.0.1:46426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:42:07.17026767Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3271489561762550,
+				"StableID":   "nuGEt2VfYS11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f87cd8de6d8802c5689ad796dd9b9e178562554000c9588fcee4efd4b7959871",
+				"DiscoKey":   "discokey:59788ee09e4842b712929a33b31587544e9251fa79733f708fb210e4ef80df51",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:46590",
+					"10.65.0.27:46590",
+					"172.17.0.1:46590",
+					"172.19.0.1:46590",
+					"172.20.0.1:46590"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:42:07.654822046Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6958286858885,
+				"StableID":   "nE5yyNn94111CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdb16b0fc71019137f6d0317d1773d0938389fb29b72e52020ba0c596cfadd4d",
+				"DiscoKey":   "discokey:a571eb7e453d8d802187e4d50a4ac5a9fe18021565cd761cb78d7d2779054e74",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39497",
+					"10.65.0.27:39497",
+					"172.17.0.1:39497",
+					"172.19.0.1:39497",
+					"172.20.0.1:39497"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:42:08.73515415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7765976342319786,
+				"StableID":   "nmxy2j2Ee321CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:862f769e7eeadbf0543a1079a3fc8820d5b2eb6dedd3a2df955cce46b349ee5b",
+				"DiscoKey":   "discokey:908e6ff2c41af8396e12ae4be9d9a4a0237073416ebcb170785e5ac226fdbe7c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57346",
+					"10.65.0.27:57346",
+					"172.17.0.1:57346",
+					"172.19.0.1:57346",
+					"172.20.0.1:57346"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:42:09.280550815Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6506773082495447,
+				"StableID":   "nexLuvtvos11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:56209ad55cab2294595a7956e8c13820c1822743eb2e07a20ec005a05ae96743",
+				"DiscoKey":   "discokey:3714768eab0f957b8019abdd426c02fb2354fc0aeefbcb74d817eca337186301",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:43177",
+					"10.65.0.27:43177",
+					"172.17.0.1:43177",
+					"172.19.0.1:43177",
+					"172.20.0.1:43177"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:42:09.839963905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4795657944005432,
+				"StableID":   "n554ZXoxSe11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:160d7bd196d93fcb90fecf5a7d355bd70171482742a85bcf580c3449c887816c",
+				"DiscoKey":   "discokey:7e0ac3f8aa7a69fb80d06c277b30877ea8657027525b1a5d4bf818df42f0a575",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38750",
+					"10.65.0.27:38750",
+					"172.17.0.1:38750",
+					"172.19.0.1:38750",
+					"172.20.0.1:38750"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:42:10.367105213Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         737133093972331,
+				"StableID":   "n2ebKiErk611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7a3804bacb24ea6a0bb127400097e08529824fc8adbb04addd7fe035dc819a2b",
+				"DiscoKey":   "discokey:98b9f18c6425e92da333e4db7d5826f34b39df0312701fea1e4b5b8171820811",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37863",
+					"10.65.0.27:37863",
+					"172.17.0.1:37863",
+					"172.19.0.1:37863",
+					"172.20.0.1:37863"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:42:10.92223257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2765680423692704,
+				"StableID":   "n7r1RdjabN11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2811cb575850b23f8299a4b259850c98edeae8950ea77bd9f5918bb8f368fb66",
+				"DiscoKey":   "discokey:057e4cd16ea2e34268069aa323243aa8c476f9eea1eec4a5d30ef55bb7f94533",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38368",
+					"10.65.0.27:38368",
+					"172.17.0.1:38368",
+					"172.19.0.1:38368",
+					"172.20.0.1:38368"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:42:11.470756103Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2675001517369833,
+				"StableID":   "nGihyikWtM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6d3a926a7a50964b2b01e1004b3a36e8359e6c0c13be90fcf1645c0c61a35a10",
+				"DiscoKey":   "discokey:78e4438942419188b8cd767f064dd3e5a24a6dedd652e992ab10a94f610c3953",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44440",
+					"10.65.0.27:44440",
+					"172.17.0.1:44440",
+					"172.19.0.1:44440",
+					"172.20.0.1:44440"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:42:11.964549675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2605669856774919,
+				"StableID":   "nGdfYfX7MM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d820bcf4ba5a242b49d2b64b05c1012406aad212ce148d83e7ddfc848a00c0a",
+				"DiscoKey":   "discokey:d633cfd71b59b6122da8369ecc5c46982b0b5611b80bd47d225ec7df43c28a45",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43304",
+					"10.65.0.27:43304",
+					"172.17.0.1:43304",
+					"172.19.0.1:43304",
+					"172.20.0.1:43304"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:42:12.512864003Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8853228925457753,
+				"StableID":   "ngihg4Ke8C21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea8eaced1cfef237fc874e043f9ee4bb2bb25962d87a84a61b54fc34e6426a2d",
+				"DiscoKey":   "discokey:cc1adca9f1dd4302c6deb3f12582ff360109a71a014d6d1a5eb3b07217e6b868",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56826",
+					"10.65.0.27:56826",
+					"172.17.0.1:56826",
+					"172.19.0.1:56826",
+					"172.20.0.1:56826"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:42:13.046497681Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7879449713780322,
+				"StableID":   "nXHLJQncX421CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e02d27592c0afc2627238fb7a9814f8b101b6ef087c473ac7b9ea468b87ade4a",
+				"KeyExpiry":  "2026-11-08T18:42:13Z",
+				"DiscoKey":   "discokey:d080c365550cfaa8e60544ca49deeeaa745c60ab9d904948e77d42f6fd70653c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34510",
+					"10.65.0.27:34510",
+					"172.17.0.1:34510",
+					"172.19.0.1:34510",
+					"172.20.0.1:34510"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:42:13.591035372Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1623421204509298,
+				"StableID":   "nhCUhHXFgD11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3366437d728ea6c21dd6ae2e1cbfc10fcda27c000fa1c58cf7b80021b7a5cb31",
+				"KeyExpiry":  "2026-11-08T18:42:14Z",
+				"DiscoKey":   "discokey:83f62475a7bdcae0681ce2a3d8b8f77d10080e41e5d0b14730921ce5449e1d2b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51904",
+					"10.65.0.27:51904",
+					"172.17.0.1:51904",
+					"172.19.0.1:51904",
+					"172.20.0.1:51904"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:42:14.146489745Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1681457587646704,
+				"StableID":   "nDj59J3Y8E11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:354044a49a47914e16be1473e39069c698caf4962ecf5e03906382cbe51cf71f",
+				"KeyExpiry":  "2026-11-08T18:42:14Z",
+				"DiscoKey":   "discokey:4863a1de33e9caf6aed67d6e11cee190a96ebad8a95a73ea65a42ed25ab2ea75",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:52679",
+					"10.65.0.27:52679",
+					"172.17.0.1:52679",
+					"172.19.0.1:52679",
+					"172.20.0.1:52679"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:42:14.680627967Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5750505107573070": {
+				"ID":          5750505107573070,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         737133093972331,
+				"StableID":   "n2ebKiErk611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       737133093972331,
+				"Key":        "nodekey:7a3804bacb24ea6a0bb127400097e08529824fc8adbb04addd7fe035dc819a2b",
+				"DiscoKey":   "discokey:98b9f18c6425e92da333e4db7d5826f34b39df0312701fea1e4b5b8171820811",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37863",
+					"10.65.0.27:37863",
+					"172.17.0.1:37863",
+					"172.19.0.1:37863",
+					"172.20.0.1:37863"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:42:10.92223257Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7a3804bacb24ea6a0bb127400097e08529824fc8adbb04addd7fe035dc819a2b",
+			"MachineKey": "mkey:9c2f8d8cb860ed487713bd4766a8e8be58834a709625dbf780f7f3cd1b456170",
+			"Peers": [{
+				"ID":         2107794865515843,
+				"StableID":   "nvWkTRCdTH11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf500e8e8d399ec7a80a04cd91ba87bb5e7d807a04c02ddfde5ed03c5ac7621a",
+				"DiscoKey":   "discokey:a810cd5d5deefdf927015e5aeefb1df748e3a36a50228939a212905250a79c4d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46426",
+					"10.65.0.27:46426",
+					"172.17.0.1:46426",
+					"172.19.0.1:46426",
+					"172.20.0.1:46426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:42:07.17026767Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3271489561762550,
+				"StableID":   "nuGEt2VfYS11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f87cd8de6d8802c5689ad796dd9b9e178562554000c9588fcee4efd4b7959871",
+				"DiscoKey":   "discokey:59788ee09e4842b712929a33b31587544e9251fa79733f708fb210e4ef80df51",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:46590",
+					"10.65.0.27:46590",
+					"172.17.0.1:46590",
+					"172.19.0.1:46590",
+					"172.20.0.1:46590"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:42:07.654822046Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5750505107573070,
+				"StableID":   "nb7Fg32Rum11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8467b29855e1cd9b977af1ecd74cfc2fdc0ef2c4d25f10f10e1e2383cc07f21d",
+				"DiscoKey":   "discokey:06fe18a20509b7424041576a76adafb50be1b46d64eaf73fc5560b4f5beeeb50",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59964",
+					"10.65.0.27:59964",
+					"172.17.0.1:59964",
+					"172.19.0.1:59964",
+					"172.20.0.1:59964"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:42:08.1985255Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6958286858885,
+				"StableID":   "nE5yyNn94111CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdb16b0fc71019137f6d0317d1773d0938389fb29b72e52020ba0c596cfadd4d",
+				"DiscoKey":   "discokey:a571eb7e453d8d802187e4d50a4ac5a9fe18021565cd761cb78d7d2779054e74",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39497",
+					"10.65.0.27:39497",
+					"172.17.0.1:39497",
+					"172.19.0.1:39497",
+					"172.20.0.1:39497"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:42:08.73515415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7765976342319786,
+				"StableID":   "nmxy2j2Ee321CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:862f769e7eeadbf0543a1079a3fc8820d5b2eb6dedd3a2df955cce46b349ee5b",
+				"DiscoKey":   "discokey:908e6ff2c41af8396e12ae4be9d9a4a0237073416ebcb170785e5ac226fdbe7c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57346",
+					"10.65.0.27:57346",
+					"172.17.0.1:57346",
+					"172.19.0.1:57346",
+					"172.20.0.1:57346"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:42:09.280550815Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6506773082495447,
+				"StableID":   "nexLuvtvos11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:56209ad55cab2294595a7956e8c13820c1822743eb2e07a20ec005a05ae96743",
+				"DiscoKey":   "discokey:3714768eab0f957b8019abdd426c02fb2354fc0aeefbcb74d817eca337186301",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:43177",
+					"10.65.0.27:43177",
+					"172.17.0.1:43177",
+					"172.19.0.1:43177",
+					"172.20.0.1:43177"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:42:09.839963905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4795657944005432,
+				"StableID":   "n554ZXoxSe11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:160d7bd196d93fcb90fecf5a7d355bd70171482742a85bcf580c3449c887816c",
+				"DiscoKey":   "discokey:7e0ac3f8aa7a69fb80d06c277b30877ea8657027525b1a5d4bf818df42f0a575",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38750",
+					"10.65.0.27:38750",
+					"172.17.0.1:38750",
+					"172.19.0.1:38750",
+					"172.20.0.1:38750"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:42:10.367105213Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2765680423692704,
+				"StableID":   "n7r1RdjabN11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2811cb575850b23f8299a4b259850c98edeae8950ea77bd9f5918bb8f368fb66",
+				"DiscoKey":   "discokey:057e4cd16ea2e34268069aa323243aa8c476f9eea1eec4a5d30ef55bb7f94533",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38368",
+					"10.65.0.27:38368",
+					"172.17.0.1:38368",
+					"172.19.0.1:38368",
+					"172.20.0.1:38368"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:42:11.470756103Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2675001517369833,
+				"StableID":   "nGihyikWtM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6d3a926a7a50964b2b01e1004b3a36e8359e6c0c13be90fcf1645c0c61a35a10",
+				"DiscoKey":   "discokey:78e4438942419188b8cd767f064dd3e5a24a6dedd652e992ab10a94f610c3953",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44440",
+					"10.65.0.27:44440",
+					"172.17.0.1:44440",
+					"172.19.0.1:44440",
+					"172.20.0.1:44440"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:42:11.964549675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2605669856774919,
+				"StableID":   "nGdfYfX7MM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d820bcf4ba5a242b49d2b64b05c1012406aad212ce148d83e7ddfc848a00c0a",
+				"DiscoKey":   "discokey:d633cfd71b59b6122da8369ecc5c46982b0b5611b80bd47d225ec7df43c28a45",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43304",
+					"10.65.0.27:43304",
+					"172.17.0.1:43304",
+					"172.19.0.1:43304",
+					"172.20.0.1:43304"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:42:12.512864003Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8853228925457753,
+				"StableID":   "ngihg4Ke8C21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea8eaced1cfef237fc874e043f9ee4bb2bb25962d87a84a61b54fc34e6426a2d",
+				"DiscoKey":   "discokey:cc1adca9f1dd4302c6deb3f12582ff360109a71a014d6d1a5eb3b07217e6b868",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56826",
+					"10.65.0.27:56826",
+					"172.17.0.1:56826",
+					"172.19.0.1:56826",
+					"172.20.0.1:56826"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:42:13.046497681Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7879449713780322,
+				"StableID":   "nXHLJQncX421CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e02d27592c0afc2627238fb7a9814f8b101b6ef087c473ac7b9ea468b87ade4a",
+				"KeyExpiry":  "2026-11-08T18:42:13Z",
+				"DiscoKey":   "discokey:d080c365550cfaa8e60544ca49deeeaa745c60ab9d904948e77d42f6fd70653c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34510",
+					"10.65.0.27:34510",
+					"172.17.0.1:34510",
+					"172.19.0.1:34510",
+					"172.20.0.1:34510"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:42:13.591035372Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1623421204509298,
+				"StableID":   "nhCUhHXFgD11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3366437d728ea6c21dd6ae2e1cbfc10fcda27c000fa1c58cf7b80021b7a5cb31",
+				"KeyExpiry":  "2026-11-08T18:42:14Z",
+				"DiscoKey":   "discokey:83f62475a7bdcae0681ce2a3d8b8f77d10080e41e5d0b14730921ce5449e1d2b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51904",
+					"10.65.0.27:51904",
+					"172.17.0.1:51904",
+					"172.19.0.1:51904",
+					"172.20.0.1:51904"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:42:14.146489745Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1681457587646704,
+				"StableID":   "nDj59J3Y8E11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:354044a49a47914e16be1473e39069c698caf4962ecf5e03906382cbe51cf71f",
+				"KeyExpiry":  "2026-11-08T18:42:14Z",
+				"DiscoKey":   "discokey:4863a1de33e9caf6aed67d6e11cee190a96ebad8a95a73ea65a42ed25ab2ea75",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:52679",
+					"10.65.0.27:52679",
+					"172.17.0.1:52679",
+					"172.19.0.1:52679",
+					"172.20.0.1:52679"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:42:14.680627967Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "737133093972331": {
+				"ID":          737133093972331,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7879449713780322,
+				"StableID":   "nXHLJQncX421CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e02d27592c0afc2627238fb7a9814f8b101b6ef087c473ac7b9ea468b87ade4a",
+				"KeyExpiry":  "2026-11-08T18:42:13Z",
+				"DiscoKey":   "discokey:d080c365550cfaa8e60544ca49deeeaa745c60ab9d904948e77d42f6fd70653c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34510",
+					"10.65.0.27:34510",
+					"172.17.0.1:34510",
+					"172.19.0.1:34510",
+					"172.20.0.1:34510"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:42:13.591035372Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e02d27592c0afc2627238fb7a9814f8b101b6ef087c473ac7b9ea468b87ade4a",
+			"MachineKey": "mkey:db439876433720666a7b95150368b0354423e563ada1701e9ca8ede1eb57c27c",
+			"Peers": [{
+				"ID":         2107794865515843,
+				"StableID":   "nvWkTRCdTH11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf500e8e8d399ec7a80a04cd91ba87bb5e7d807a04c02ddfde5ed03c5ac7621a",
+				"DiscoKey":   "discokey:a810cd5d5deefdf927015e5aeefb1df748e3a36a50228939a212905250a79c4d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46426",
+					"10.65.0.27:46426",
+					"172.17.0.1:46426",
+					"172.19.0.1:46426",
+					"172.20.0.1:46426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:42:07.17026767Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3271489561762550,
+				"StableID":   "nuGEt2VfYS11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f87cd8de6d8802c5689ad796dd9b9e178562554000c9588fcee4efd4b7959871",
+				"DiscoKey":   "discokey:59788ee09e4842b712929a33b31587544e9251fa79733f708fb210e4ef80df51",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:46590",
+					"10.65.0.27:46590",
+					"172.17.0.1:46590",
+					"172.19.0.1:46590",
+					"172.20.0.1:46590"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:42:07.654822046Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5750505107573070,
+				"StableID":   "nb7Fg32Rum11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8467b29855e1cd9b977af1ecd74cfc2fdc0ef2c4d25f10f10e1e2383cc07f21d",
+				"DiscoKey":   "discokey:06fe18a20509b7424041576a76adafb50be1b46d64eaf73fc5560b4f5beeeb50",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59964",
+					"10.65.0.27:59964",
+					"172.17.0.1:59964",
+					"172.19.0.1:59964",
+					"172.20.0.1:59964"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:42:08.1985255Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6958286858885,
+				"StableID":   "nE5yyNn94111CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdb16b0fc71019137f6d0317d1773d0938389fb29b72e52020ba0c596cfadd4d",
+				"DiscoKey":   "discokey:a571eb7e453d8d802187e4d50a4ac5a9fe18021565cd761cb78d7d2779054e74",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39497",
+					"10.65.0.27:39497",
+					"172.17.0.1:39497",
+					"172.19.0.1:39497",
+					"172.20.0.1:39497"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:42:08.73515415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7765976342319786,
+				"StableID":   "nmxy2j2Ee321CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:862f769e7eeadbf0543a1079a3fc8820d5b2eb6dedd3a2df955cce46b349ee5b",
+				"DiscoKey":   "discokey:908e6ff2c41af8396e12ae4be9d9a4a0237073416ebcb170785e5ac226fdbe7c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57346",
+					"10.65.0.27:57346",
+					"172.17.0.1:57346",
+					"172.19.0.1:57346",
+					"172.20.0.1:57346"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:42:09.280550815Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6506773082495447,
+				"StableID":   "nexLuvtvos11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:56209ad55cab2294595a7956e8c13820c1822743eb2e07a20ec005a05ae96743",
+				"DiscoKey":   "discokey:3714768eab0f957b8019abdd426c02fb2354fc0aeefbcb74d817eca337186301",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:43177",
+					"10.65.0.27:43177",
+					"172.17.0.1:43177",
+					"172.19.0.1:43177",
+					"172.20.0.1:43177"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:42:09.839963905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4795657944005432,
+				"StableID":   "n554ZXoxSe11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:160d7bd196d93fcb90fecf5a7d355bd70171482742a85bcf580c3449c887816c",
+				"DiscoKey":   "discokey:7e0ac3f8aa7a69fb80d06c277b30877ea8657027525b1a5d4bf818df42f0a575",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38750",
+					"10.65.0.27:38750",
+					"172.17.0.1:38750",
+					"172.19.0.1:38750",
+					"172.20.0.1:38750"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:42:10.367105213Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         737133093972331,
+				"StableID":   "n2ebKiErk611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7a3804bacb24ea6a0bb127400097e08529824fc8adbb04addd7fe035dc819a2b",
+				"DiscoKey":   "discokey:98b9f18c6425e92da333e4db7d5826f34b39df0312701fea1e4b5b8171820811",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37863",
+					"10.65.0.27:37863",
+					"172.17.0.1:37863",
+					"172.19.0.1:37863",
+					"172.20.0.1:37863"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:42:10.92223257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2765680423692704,
+				"StableID":   "n7r1RdjabN11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2811cb575850b23f8299a4b259850c98edeae8950ea77bd9f5918bb8f368fb66",
+				"DiscoKey":   "discokey:057e4cd16ea2e34268069aa323243aa8c476f9eea1eec4a5d30ef55bb7f94533",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38368",
+					"10.65.0.27:38368",
+					"172.17.0.1:38368",
+					"172.19.0.1:38368",
+					"172.20.0.1:38368"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:42:11.470756103Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2675001517369833,
+				"StableID":   "nGihyikWtM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6d3a926a7a50964b2b01e1004b3a36e8359e6c0c13be90fcf1645c0c61a35a10",
+				"DiscoKey":   "discokey:78e4438942419188b8cd767f064dd3e5a24a6dedd652e992ab10a94f610c3953",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44440",
+					"10.65.0.27:44440",
+					"172.17.0.1:44440",
+					"172.19.0.1:44440",
+					"172.20.0.1:44440"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:42:11.964549675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2605669856774919,
+				"StableID":   "nGdfYfX7MM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d820bcf4ba5a242b49d2b64b05c1012406aad212ce148d83e7ddfc848a00c0a",
+				"DiscoKey":   "discokey:d633cfd71b59b6122da8369ecc5c46982b0b5611b80bd47d225ec7df43c28a45",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43304",
+					"10.65.0.27:43304",
+					"172.17.0.1:43304",
+					"172.19.0.1:43304",
+					"172.20.0.1:43304"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:42:12.512864003Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8853228925457753,
+				"StableID":   "ngihg4Ke8C21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea8eaced1cfef237fc874e043f9ee4bb2bb25962d87a84a61b54fc34e6426a2d",
+				"DiscoKey":   "discokey:cc1adca9f1dd4302c6deb3f12582ff360109a71a014d6d1a5eb3b07217e6b868",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56826",
+					"10.65.0.27:56826",
+					"172.17.0.1:56826",
+					"172.19.0.1:56826",
+					"172.20.0.1:56826"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:42:13.046497681Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1623421204509298,
+				"StableID":   "nhCUhHXFgD11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3366437d728ea6c21dd6ae2e1cbfc10fcda27c000fa1c58cf7b80021b7a5cb31",
+				"KeyExpiry":  "2026-11-08T18:42:14Z",
+				"DiscoKey":   "discokey:83f62475a7bdcae0681ce2a3d8b8f77d10080e41e5d0b14730921ce5449e1d2b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51904",
+					"10.65.0.27:51904",
+					"172.17.0.1:51904",
+					"172.19.0.1:51904",
+					"172.20.0.1:51904"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:42:14.146489745Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1681457587646704,
+				"StableID":   "nDj59J3Y8E11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:354044a49a47914e16be1473e39069c698caf4962ecf5e03906382cbe51cf71f",
+				"KeyExpiry":  "2026-11-08T18:42:14Z",
+				"DiscoKey":   "discokey:4863a1de33e9caf6aed67d6e11cee190a96ebad8a95a73ea65a42ed25ab2ea75",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:52679",
+					"10.65.0.27:52679",
+					"172.17.0.1:52679",
+					"172.19.0.1:52679",
+					"172.20.0.1:52679"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:42:14.680627967Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2605669856774919,
+				"StableID":   "nGdfYfX7MM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       2605669856774919,
+				"Key":        "nodekey:9d820bcf4ba5a242b49d2b64b05c1012406aad212ce148d83e7ddfc848a00c0a",
+				"DiscoKey":   "discokey:d633cfd71b59b6122da8369ecc5c46982b0b5611b80bd47d225ec7df43c28a45",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43304",
+					"10.65.0.27:43304",
+					"172.17.0.1:43304",
+					"172.19.0.1:43304",
+					"172.20.0.1:43304"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:42:12.512864003Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9d820bcf4ba5a242b49d2b64b05c1012406aad212ce148d83e7ddfc848a00c0a",
+			"MachineKey": "mkey:c555aa783a85dcfb276919db8ea560885eb96821f5822beee526081a13908054",
+			"Peers": [{
+				"ID":         2107794865515843,
+				"StableID":   "nvWkTRCdTH11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf500e8e8d399ec7a80a04cd91ba87bb5e7d807a04c02ddfde5ed03c5ac7621a",
+				"DiscoKey":   "discokey:a810cd5d5deefdf927015e5aeefb1df748e3a36a50228939a212905250a79c4d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46426",
+					"10.65.0.27:46426",
+					"172.17.0.1:46426",
+					"172.19.0.1:46426",
+					"172.20.0.1:46426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:42:07.17026767Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3271489561762550,
+				"StableID":   "nuGEt2VfYS11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f87cd8de6d8802c5689ad796dd9b9e178562554000c9588fcee4efd4b7959871",
+				"DiscoKey":   "discokey:59788ee09e4842b712929a33b31587544e9251fa79733f708fb210e4ef80df51",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:46590",
+					"10.65.0.27:46590",
+					"172.17.0.1:46590",
+					"172.19.0.1:46590",
+					"172.20.0.1:46590"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:42:07.654822046Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5750505107573070,
+				"StableID":   "nb7Fg32Rum11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8467b29855e1cd9b977af1ecd74cfc2fdc0ef2c4d25f10f10e1e2383cc07f21d",
+				"DiscoKey":   "discokey:06fe18a20509b7424041576a76adafb50be1b46d64eaf73fc5560b4f5beeeb50",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59964",
+					"10.65.0.27:59964",
+					"172.17.0.1:59964",
+					"172.19.0.1:59964",
+					"172.20.0.1:59964"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:42:08.1985255Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6958286858885,
+				"StableID":   "nE5yyNn94111CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdb16b0fc71019137f6d0317d1773d0938389fb29b72e52020ba0c596cfadd4d",
+				"DiscoKey":   "discokey:a571eb7e453d8d802187e4d50a4ac5a9fe18021565cd761cb78d7d2779054e74",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39497",
+					"10.65.0.27:39497",
+					"172.17.0.1:39497",
+					"172.19.0.1:39497",
+					"172.20.0.1:39497"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:42:08.73515415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7765976342319786,
+				"StableID":   "nmxy2j2Ee321CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:862f769e7eeadbf0543a1079a3fc8820d5b2eb6dedd3a2df955cce46b349ee5b",
+				"DiscoKey":   "discokey:908e6ff2c41af8396e12ae4be9d9a4a0237073416ebcb170785e5ac226fdbe7c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57346",
+					"10.65.0.27:57346",
+					"172.17.0.1:57346",
+					"172.19.0.1:57346",
+					"172.20.0.1:57346"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:42:09.280550815Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6506773082495447,
+				"StableID":   "nexLuvtvos11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:56209ad55cab2294595a7956e8c13820c1822743eb2e07a20ec005a05ae96743",
+				"DiscoKey":   "discokey:3714768eab0f957b8019abdd426c02fb2354fc0aeefbcb74d817eca337186301",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:43177",
+					"10.65.0.27:43177",
+					"172.17.0.1:43177",
+					"172.19.0.1:43177",
+					"172.20.0.1:43177"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:42:09.839963905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4795657944005432,
+				"StableID":   "n554ZXoxSe11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:160d7bd196d93fcb90fecf5a7d355bd70171482742a85bcf580c3449c887816c",
+				"DiscoKey":   "discokey:7e0ac3f8aa7a69fb80d06c277b30877ea8657027525b1a5d4bf818df42f0a575",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38750",
+					"10.65.0.27:38750",
+					"172.17.0.1:38750",
+					"172.19.0.1:38750",
+					"172.20.0.1:38750"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:42:10.367105213Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         737133093972331,
+				"StableID":   "n2ebKiErk611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7a3804bacb24ea6a0bb127400097e08529824fc8adbb04addd7fe035dc819a2b",
+				"DiscoKey":   "discokey:98b9f18c6425e92da333e4db7d5826f34b39df0312701fea1e4b5b8171820811",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37863",
+					"10.65.0.27:37863",
+					"172.17.0.1:37863",
+					"172.19.0.1:37863",
+					"172.20.0.1:37863"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:42:10.92223257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2765680423692704,
+				"StableID":   "n7r1RdjabN11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2811cb575850b23f8299a4b259850c98edeae8950ea77bd9f5918bb8f368fb66",
+				"DiscoKey":   "discokey:057e4cd16ea2e34268069aa323243aa8c476f9eea1eec4a5d30ef55bb7f94533",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38368",
+					"10.65.0.27:38368",
+					"172.17.0.1:38368",
+					"172.19.0.1:38368",
+					"172.20.0.1:38368"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:42:11.470756103Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2675001517369833,
+				"StableID":   "nGihyikWtM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6d3a926a7a50964b2b01e1004b3a36e8359e6c0c13be90fcf1645c0c61a35a10",
+				"DiscoKey":   "discokey:78e4438942419188b8cd767f064dd3e5a24a6dedd652e992ab10a94f610c3953",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44440",
+					"10.65.0.27:44440",
+					"172.17.0.1:44440",
+					"172.19.0.1:44440",
+					"172.20.0.1:44440"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:42:11.964549675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8853228925457753,
+				"StableID":   "ngihg4Ke8C21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea8eaced1cfef237fc874e043f9ee4bb2bb25962d87a84a61b54fc34e6426a2d",
+				"DiscoKey":   "discokey:cc1adca9f1dd4302c6deb3f12582ff360109a71a014d6d1a5eb3b07217e6b868",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56826",
+					"10.65.0.27:56826",
+					"172.17.0.1:56826",
+					"172.19.0.1:56826",
+					"172.20.0.1:56826"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:42:13.046497681Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7879449713780322,
+				"StableID":   "nXHLJQncX421CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e02d27592c0afc2627238fb7a9814f8b101b6ef087c473ac7b9ea468b87ade4a",
+				"KeyExpiry":  "2026-11-08T18:42:13Z",
+				"DiscoKey":   "discokey:d080c365550cfaa8e60544ca49deeeaa745c60ab9d904948e77d42f6fd70653c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34510",
+					"10.65.0.27:34510",
+					"172.17.0.1:34510",
+					"172.19.0.1:34510",
+					"172.20.0.1:34510"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:42:13.591035372Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1623421204509298,
+				"StableID":   "nhCUhHXFgD11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3366437d728ea6c21dd6ae2e1cbfc10fcda27c000fa1c58cf7b80021b7a5cb31",
+				"KeyExpiry":  "2026-11-08T18:42:14Z",
+				"DiscoKey":   "discokey:83f62475a7bdcae0681ce2a3d8b8f77d10080e41e5d0b14730921ce5449e1d2b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51904",
+					"10.65.0.27:51904",
+					"172.17.0.1:51904",
+					"172.19.0.1:51904",
+					"172.20.0.1:51904"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:42:14.146489745Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1681457587646704,
+				"StableID":   "nDj59J3Y8E11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:354044a49a47914e16be1473e39069c698caf4962ecf5e03906382cbe51cf71f",
+				"KeyExpiry":  "2026-11-08T18:42:14Z",
+				"DiscoKey":   "discokey:4863a1de33e9caf6aed67d6e11cee190a96ebad8a95a73ea65a42ed25ab2ea75",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:52679",
+					"10.65.0.27:52679",
+					"172.17.0.1:52679",
+					"172.19.0.1:52679",
+					"172.20.0.1:52679"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:42:14.680627967Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2605669856774919": {
+				"ID":          2605669856774919,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3271489561762550,
+				"StableID":   "nuGEt2VfYS11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       3271489561762550,
+				"Key":        "nodekey:f87cd8de6d8802c5689ad796dd9b9e178562554000c9588fcee4efd4b7959871",
+				"DiscoKey":   "discokey:59788ee09e4842b712929a33b31587544e9251fa79733f708fb210e4ef80df51",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:46590",
+					"10.65.0.27:46590",
+					"172.17.0.1:46590",
+					"172.19.0.1:46590",
+					"172.20.0.1:46590"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:42:07.654822046Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f87cd8de6d8802c5689ad796dd9b9e178562554000c9588fcee4efd4b7959871",
+			"MachineKey": "mkey:463620ee982d002f72eb6ac380288ee39ee96dc289f6861479bdc2540a7c1c27",
+			"Peers": [{
+				"ID":         2107794865515843,
+				"StableID":   "nvWkTRCdTH11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf500e8e8d399ec7a80a04cd91ba87bb5e7d807a04c02ddfde5ed03c5ac7621a",
+				"DiscoKey":   "discokey:a810cd5d5deefdf927015e5aeefb1df748e3a36a50228939a212905250a79c4d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46426",
+					"10.65.0.27:46426",
+					"172.17.0.1:46426",
+					"172.19.0.1:46426",
+					"172.20.0.1:46426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:42:07.17026767Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5750505107573070,
+				"StableID":   "nb7Fg32Rum11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8467b29855e1cd9b977af1ecd74cfc2fdc0ef2c4d25f10f10e1e2383cc07f21d",
+				"DiscoKey":   "discokey:06fe18a20509b7424041576a76adafb50be1b46d64eaf73fc5560b4f5beeeb50",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59964",
+					"10.65.0.27:59964",
+					"172.17.0.1:59964",
+					"172.19.0.1:59964",
+					"172.20.0.1:59964"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:42:08.1985255Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6958286858885,
+				"StableID":   "nE5yyNn94111CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdb16b0fc71019137f6d0317d1773d0938389fb29b72e52020ba0c596cfadd4d",
+				"DiscoKey":   "discokey:a571eb7e453d8d802187e4d50a4ac5a9fe18021565cd761cb78d7d2779054e74",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39497",
+					"10.65.0.27:39497",
+					"172.17.0.1:39497",
+					"172.19.0.1:39497",
+					"172.20.0.1:39497"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:42:08.73515415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7765976342319786,
+				"StableID":   "nmxy2j2Ee321CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:862f769e7eeadbf0543a1079a3fc8820d5b2eb6dedd3a2df955cce46b349ee5b",
+				"DiscoKey":   "discokey:908e6ff2c41af8396e12ae4be9d9a4a0237073416ebcb170785e5ac226fdbe7c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57346",
+					"10.65.0.27:57346",
+					"172.17.0.1:57346",
+					"172.19.0.1:57346",
+					"172.20.0.1:57346"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:42:09.280550815Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6506773082495447,
+				"StableID":   "nexLuvtvos11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:56209ad55cab2294595a7956e8c13820c1822743eb2e07a20ec005a05ae96743",
+				"DiscoKey":   "discokey:3714768eab0f957b8019abdd426c02fb2354fc0aeefbcb74d817eca337186301",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:43177",
+					"10.65.0.27:43177",
+					"172.17.0.1:43177",
+					"172.19.0.1:43177",
+					"172.20.0.1:43177"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:42:09.839963905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4795657944005432,
+				"StableID":   "n554ZXoxSe11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:160d7bd196d93fcb90fecf5a7d355bd70171482742a85bcf580c3449c887816c",
+				"DiscoKey":   "discokey:7e0ac3f8aa7a69fb80d06c277b30877ea8657027525b1a5d4bf818df42f0a575",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38750",
+					"10.65.0.27:38750",
+					"172.17.0.1:38750",
+					"172.19.0.1:38750",
+					"172.20.0.1:38750"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:42:10.367105213Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         737133093972331,
+				"StableID":   "n2ebKiErk611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7a3804bacb24ea6a0bb127400097e08529824fc8adbb04addd7fe035dc819a2b",
+				"DiscoKey":   "discokey:98b9f18c6425e92da333e4db7d5826f34b39df0312701fea1e4b5b8171820811",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37863",
+					"10.65.0.27:37863",
+					"172.17.0.1:37863",
+					"172.19.0.1:37863",
+					"172.20.0.1:37863"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:42:10.92223257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2765680423692704,
+				"StableID":   "n7r1RdjabN11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2811cb575850b23f8299a4b259850c98edeae8950ea77bd9f5918bb8f368fb66",
+				"DiscoKey":   "discokey:057e4cd16ea2e34268069aa323243aa8c476f9eea1eec4a5d30ef55bb7f94533",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38368",
+					"10.65.0.27:38368",
+					"172.17.0.1:38368",
+					"172.19.0.1:38368",
+					"172.20.0.1:38368"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:42:11.470756103Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2675001517369833,
+				"StableID":   "nGihyikWtM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6d3a926a7a50964b2b01e1004b3a36e8359e6c0c13be90fcf1645c0c61a35a10",
+				"DiscoKey":   "discokey:78e4438942419188b8cd767f064dd3e5a24a6dedd652e992ab10a94f610c3953",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44440",
+					"10.65.0.27:44440",
+					"172.17.0.1:44440",
+					"172.19.0.1:44440",
+					"172.20.0.1:44440"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:42:11.964549675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2605669856774919,
+				"StableID":   "nGdfYfX7MM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d820bcf4ba5a242b49d2b64b05c1012406aad212ce148d83e7ddfc848a00c0a",
+				"DiscoKey":   "discokey:d633cfd71b59b6122da8369ecc5c46982b0b5611b80bd47d225ec7df43c28a45",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43304",
+					"10.65.0.27:43304",
+					"172.17.0.1:43304",
+					"172.19.0.1:43304",
+					"172.20.0.1:43304"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:42:12.512864003Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8853228925457753,
+				"StableID":   "ngihg4Ke8C21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea8eaced1cfef237fc874e043f9ee4bb2bb25962d87a84a61b54fc34e6426a2d",
+				"DiscoKey":   "discokey:cc1adca9f1dd4302c6deb3f12582ff360109a71a014d6d1a5eb3b07217e6b868",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56826",
+					"10.65.0.27:56826",
+					"172.17.0.1:56826",
+					"172.19.0.1:56826",
+					"172.20.0.1:56826"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:42:13.046497681Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7879449713780322,
+				"StableID":   "nXHLJQncX421CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e02d27592c0afc2627238fb7a9814f8b101b6ef087c473ac7b9ea468b87ade4a",
+				"KeyExpiry":  "2026-11-08T18:42:13Z",
+				"DiscoKey":   "discokey:d080c365550cfaa8e60544ca49deeeaa745c60ab9d904948e77d42f6fd70653c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34510",
+					"10.65.0.27:34510",
+					"172.17.0.1:34510",
+					"172.19.0.1:34510",
+					"172.20.0.1:34510"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:42:13.591035372Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1623421204509298,
+				"StableID":   "nhCUhHXFgD11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3366437d728ea6c21dd6ae2e1cbfc10fcda27c000fa1c58cf7b80021b7a5cb31",
+				"KeyExpiry":  "2026-11-08T18:42:14Z",
+				"DiscoKey":   "discokey:83f62475a7bdcae0681ce2a3d8b8f77d10080e41e5d0b14730921ce5449e1d2b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51904",
+					"10.65.0.27:51904",
+					"172.17.0.1:51904",
+					"172.19.0.1:51904",
+					"172.20.0.1:51904"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:42:14.146489745Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1681457587646704,
+				"StableID":   "nDj59J3Y8E11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:354044a49a47914e16be1473e39069c698caf4962ecf5e03906382cbe51cf71f",
+				"KeyExpiry":  "2026-11-08T18:42:14Z",
+				"DiscoKey":   "discokey:4863a1de33e9caf6aed67d6e11cee190a96ebad8a95a73ea65a42ed25ab2ea75",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:52679",
+					"10.65.0.27:52679",
+					"172.17.0.1:52679",
+					"172.19.0.1:52679",
+					"172.20.0.1:52679"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:42:14.680627967Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3271489561762550": {
+				"ID":          3271489561762550,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2107794865515843,
+				"StableID":   "nvWkTRCdTH11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       2107794865515843,
+				"Key":        "nodekey:bf500e8e8d399ec7a80a04cd91ba87bb5e7d807a04c02ddfde5ed03c5ac7621a",
+				"DiscoKey":   "discokey:a810cd5d5deefdf927015e5aeefb1df748e3a36a50228939a212905250a79c4d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46426",
+					"10.65.0.27:46426",
+					"172.17.0.1:46426",
+					"172.19.0.1:46426",
+					"172.20.0.1:46426"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:42:07.17026767Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:bf500e8e8d399ec7a80a04cd91ba87bb5e7d807a04c02ddfde5ed03c5ac7621a",
+			"MachineKey": "mkey:377fbe38bc5a06e51fe677c69174f0dfd8e266c48bf68625b6e3b4f2f458be68",
+			"Peers": [{
+				"ID":         3271489561762550,
+				"StableID":   "nuGEt2VfYS11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f87cd8de6d8802c5689ad796dd9b9e178562554000c9588fcee4efd4b7959871",
+				"DiscoKey":   "discokey:59788ee09e4842b712929a33b31587544e9251fa79733f708fb210e4ef80df51",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:46590",
+					"10.65.0.27:46590",
+					"172.17.0.1:46590",
+					"172.19.0.1:46590",
+					"172.20.0.1:46590"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:42:07.654822046Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5750505107573070,
+				"StableID":   "nb7Fg32Rum11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8467b29855e1cd9b977af1ecd74cfc2fdc0ef2c4d25f10f10e1e2383cc07f21d",
+				"DiscoKey":   "discokey:06fe18a20509b7424041576a76adafb50be1b46d64eaf73fc5560b4f5beeeb50",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59964",
+					"10.65.0.27:59964",
+					"172.17.0.1:59964",
+					"172.19.0.1:59964",
+					"172.20.0.1:59964"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:42:08.1985255Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6958286858885,
+				"StableID":   "nE5yyNn94111CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdb16b0fc71019137f6d0317d1773d0938389fb29b72e52020ba0c596cfadd4d",
+				"DiscoKey":   "discokey:a571eb7e453d8d802187e4d50a4ac5a9fe18021565cd761cb78d7d2779054e74",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39497",
+					"10.65.0.27:39497",
+					"172.17.0.1:39497",
+					"172.19.0.1:39497",
+					"172.20.0.1:39497"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:42:08.73515415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7765976342319786,
+				"StableID":   "nmxy2j2Ee321CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:862f769e7eeadbf0543a1079a3fc8820d5b2eb6dedd3a2df955cce46b349ee5b",
+				"DiscoKey":   "discokey:908e6ff2c41af8396e12ae4be9d9a4a0237073416ebcb170785e5ac226fdbe7c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57346",
+					"10.65.0.27:57346",
+					"172.17.0.1:57346",
+					"172.19.0.1:57346",
+					"172.20.0.1:57346"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:42:09.280550815Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6506773082495447,
+				"StableID":   "nexLuvtvos11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:56209ad55cab2294595a7956e8c13820c1822743eb2e07a20ec005a05ae96743",
+				"DiscoKey":   "discokey:3714768eab0f957b8019abdd426c02fb2354fc0aeefbcb74d817eca337186301",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:43177",
+					"10.65.0.27:43177",
+					"172.17.0.1:43177",
+					"172.19.0.1:43177",
+					"172.20.0.1:43177"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:42:09.839963905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4795657944005432,
+				"StableID":   "n554ZXoxSe11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:160d7bd196d93fcb90fecf5a7d355bd70171482742a85bcf580c3449c887816c",
+				"DiscoKey":   "discokey:7e0ac3f8aa7a69fb80d06c277b30877ea8657027525b1a5d4bf818df42f0a575",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38750",
+					"10.65.0.27:38750",
+					"172.17.0.1:38750",
+					"172.19.0.1:38750",
+					"172.20.0.1:38750"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:42:10.367105213Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         737133093972331,
+				"StableID":   "n2ebKiErk611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7a3804bacb24ea6a0bb127400097e08529824fc8adbb04addd7fe035dc819a2b",
+				"DiscoKey":   "discokey:98b9f18c6425e92da333e4db7d5826f34b39df0312701fea1e4b5b8171820811",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37863",
+					"10.65.0.27:37863",
+					"172.17.0.1:37863",
+					"172.19.0.1:37863",
+					"172.20.0.1:37863"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:42:10.92223257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2765680423692704,
+				"StableID":   "n7r1RdjabN11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2811cb575850b23f8299a4b259850c98edeae8950ea77bd9f5918bb8f368fb66",
+				"DiscoKey":   "discokey:057e4cd16ea2e34268069aa323243aa8c476f9eea1eec4a5d30ef55bb7f94533",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38368",
+					"10.65.0.27:38368",
+					"172.17.0.1:38368",
+					"172.19.0.1:38368",
+					"172.20.0.1:38368"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:42:11.470756103Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2675001517369833,
+				"StableID":   "nGihyikWtM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6d3a926a7a50964b2b01e1004b3a36e8359e6c0c13be90fcf1645c0c61a35a10",
+				"DiscoKey":   "discokey:78e4438942419188b8cd767f064dd3e5a24a6dedd652e992ab10a94f610c3953",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44440",
+					"10.65.0.27:44440",
+					"172.17.0.1:44440",
+					"172.19.0.1:44440",
+					"172.20.0.1:44440"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:42:11.964549675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2605669856774919,
+				"StableID":   "nGdfYfX7MM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d820bcf4ba5a242b49d2b64b05c1012406aad212ce148d83e7ddfc848a00c0a",
+				"DiscoKey":   "discokey:d633cfd71b59b6122da8369ecc5c46982b0b5611b80bd47d225ec7df43c28a45",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43304",
+					"10.65.0.27:43304",
+					"172.17.0.1:43304",
+					"172.19.0.1:43304",
+					"172.20.0.1:43304"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:42:12.512864003Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8853228925457753,
+				"StableID":   "ngihg4Ke8C21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea8eaced1cfef237fc874e043f9ee4bb2bb25962d87a84a61b54fc34e6426a2d",
+				"DiscoKey":   "discokey:cc1adca9f1dd4302c6deb3f12582ff360109a71a014d6d1a5eb3b07217e6b868",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56826",
+					"10.65.0.27:56826",
+					"172.17.0.1:56826",
+					"172.19.0.1:56826",
+					"172.20.0.1:56826"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:42:13.046497681Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7879449713780322,
+				"StableID":   "nXHLJQncX421CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e02d27592c0afc2627238fb7a9814f8b101b6ef087c473ac7b9ea468b87ade4a",
+				"KeyExpiry":  "2026-11-08T18:42:13Z",
+				"DiscoKey":   "discokey:d080c365550cfaa8e60544ca49deeeaa745c60ab9d904948e77d42f6fd70653c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34510",
+					"10.65.0.27:34510",
+					"172.17.0.1:34510",
+					"172.19.0.1:34510",
+					"172.20.0.1:34510"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:42:13.591035372Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1623421204509298,
+				"StableID":   "nhCUhHXFgD11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3366437d728ea6c21dd6ae2e1cbfc10fcda27c000fa1c58cf7b80021b7a5cb31",
+				"KeyExpiry":  "2026-11-08T18:42:14Z",
+				"DiscoKey":   "discokey:83f62475a7bdcae0681ce2a3d8b8f77d10080e41e5d0b14730921ce5449e1d2b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51904",
+					"10.65.0.27:51904",
+					"172.17.0.1:51904",
+					"172.19.0.1:51904",
+					"172.20.0.1:51904"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:42:14.146489745Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1681457587646704,
+				"StableID":   "nDj59J3Y8E11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:354044a49a47914e16be1473e39069c698caf4962ecf5e03906382cbe51cf71f",
+				"KeyExpiry":  "2026-11-08T18:42:14Z",
+				"DiscoKey":   "discokey:4863a1de33e9caf6aed67d6e11cee190a96ebad8a95a73ea65a42ed25ab2ea75",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:52679",
+					"10.65.0.27:52679",
+					"172.17.0.1:52679",
+					"172.19.0.1:52679",
+					"172.20.0.1:52679"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:42:14.680627967Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2107794865515843": {
+				"ID":          2107794865515843,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7765976342319786,
+				"StableID":   "nmxy2j2Ee321CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       7765976342319786,
+				"Key":        "nodekey:862f769e7eeadbf0543a1079a3fc8820d5b2eb6dedd3a2df955cce46b349ee5b",
+				"DiscoKey":   "discokey:908e6ff2c41af8396e12ae4be9d9a4a0237073416ebcb170785e5ac226fdbe7c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57346",
+					"10.65.0.27:57346",
+					"172.17.0.1:57346",
+					"172.19.0.1:57346",
+					"172.20.0.1:57346"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:42:09.280550815Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:862f769e7eeadbf0543a1079a3fc8820d5b2eb6dedd3a2df955cce46b349ee5b",
+			"MachineKey": "mkey:189797a8b89dc14a9a064ada8adc48bdd10f388969f4a68a3d294f7a3adb311f",
+			"Peers": [{
+				"ID":         2107794865515843,
+				"StableID":   "nvWkTRCdTH11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf500e8e8d399ec7a80a04cd91ba87bb5e7d807a04c02ddfde5ed03c5ac7621a",
+				"DiscoKey":   "discokey:a810cd5d5deefdf927015e5aeefb1df748e3a36a50228939a212905250a79c4d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46426",
+					"10.65.0.27:46426",
+					"172.17.0.1:46426",
+					"172.19.0.1:46426",
+					"172.20.0.1:46426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:42:07.17026767Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3271489561762550,
+				"StableID":   "nuGEt2VfYS11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f87cd8de6d8802c5689ad796dd9b9e178562554000c9588fcee4efd4b7959871",
+				"DiscoKey":   "discokey:59788ee09e4842b712929a33b31587544e9251fa79733f708fb210e4ef80df51",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:46590",
+					"10.65.0.27:46590",
+					"172.17.0.1:46590",
+					"172.19.0.1:46590",
+					"172.20.0.1:46590"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:42:07.654822046Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5750505107573070,
+				"StableID":   "nb7Fg32Rum11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8467b29855e1cd9b977af1ecd74cfc2fdc0ef2c4d25f10f10e1e2383cc07f21d",
+				"DiscoKey":   "discokey:06fe18a20509b7424041576a76adafb50be1b46d64eaf73fc5560b4f5beeeb50",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59964",
+					"10.65.0.27:59964",
+					"172.17.0.1:59964",
+					"172.19.0.1:59964",
+					"172.20.0.1:59964"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:42:08.1985255Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6958286858885,
+				"StableID":   "nE5yyNn94111CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdb16b0fc71019137f6d0317d1773d0938389fb29b72e52020ba0c596cfadd4d",
+				"DiscoKey":   "discokey:a571eb7e453d8d802187e4d50a4ac5a9fe18021565cd761cb78d7d2779054e74",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39497",
+					"10.65.0.27:39497",
+					"172.17.0.1:39497",
+					"172.19.0.1:39497",
+					"172.20.0.1:39497"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:42:08.73515415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6506773082495447,
+				"StableID":   "nexLuvtvos11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:56209ad55cab2294595a7956e8c13820c1822743eb2e07a20ec005a05ae96743",
+				"DiscoKey":   "discokey:3714768eab0f957b8019abdd426c02fb2354fc0aeefbcb74d817eca337186301",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:43177",
+					"10.65.0.27:43177",
+					"172.17.0.1:43177",
+					"172.19.0.1:43177",
+					"172.20.0.1:43177"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:42:09.839963905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4795657944005432,
+				"StableID":   "n554ZXoxSe11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:160d7bd196d93fcb90fecf5a7d355bd70171482742a85bcf580c3449c887816c",
+				"DiscoKey":   "discokey:7e0ac3f8aa7a69fb80d06c277b30877ea8657027525b1a5d4bf818df42f0a575",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38750",
+					"10.65.0.27:38750",
+					"172.17.0.1:38750",
+					"172.19.0.1:38750",
+					"172.20.0.1:38750"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:42:10.367105213Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         737133093972331,
+				"StableID":   "n2ebKiErk611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7a3804bacb24ea6a0bb127400097e08529824fc8adbb04addd7fe035dc819a2b",
+				"DiscoKey":   "discokey:98b9f18c6425e92da333e4db7d5826f34b39df0312701fea1e4b5b8171820811",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37863",
+					"10.65.0.27:37863",
+					"172.17.0.1:37863",
+					"172.19.0.1:37863",
+					"172.20.0.1:37863"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:42:10.92223257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2765680423692704,
+				"StableID":   "n7r1RdjabN11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2811cb575850b23f8299a4b259850c98edeae8950ea77bd9f5918bb8f368fb66",
+				"DiscoKey":   "discokey:057e4cd16ea2e34268069aa323243aa8c476f9eea1eec4a5d30ef55bb7f94533",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38368",
+					"10.65.0.27:38368",
+					"172.17.0.1:38368",
+					"172.19.0.1:38368",
+					"172.20.0.1:38368"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:42:11.470756103Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2675001517369833,
+				"StableID":   "nGihyikWtM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6d3a926a7a50964b2b01e1004b3a36e8359e6c0c13be90fcf1645c0c61a35a10",
+				"DiscoKey":   "discokey:78e4438942419188b8cd767f064dd3e5a24a6dedd652e992ab10a94f610c3953",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44440",
+					"10.65.0.27:44440",
+					"172.17.0.1:44440",
+					"172.19.0.1:44440",
+					"172.20.0.1:44440"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:42:11.964549675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2605669856774919,
+				"StableID":   "nGdfYfX7MM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d820bcf4ba5a242b49d2b64b05c1012406aad212ce148d83e7ddfc848a00c0a",
+				"DiscoKey":   "discokey:d633cfd71b59b6122da8369ecc5c46982b0b5611b80bd47d225ec7df43c28a45",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43304",
+					"10.65.0.27:43304",
+					"172.17.0.1:43304",
+					"172.19.0.1:43304",
+					"172.20.0.1:43304"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:42:12.512864003Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8853228925457753,
+				"StableID":   "ngihg4Ke8C21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea8eaced1cfef237fc874e043f9ee4bb2bb25962d87a84a61b54fc34e6426a2d",
+				"DiscoKey":   "discokey:cc1adca9f1dd4302c6deb3f12582ff360109a71a014d6d1a5eb3b07217e6b868",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56826",
+					"10.65.0.27:56826",
+					"172.17.0.1:56826",
+					"172.19.0.1:56826",
+					"172.20.0.1:56826"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:42:13.046497681Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7879449713780322,
+				"StableID":   "nXHLJQncX421CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e02d27592c0afc2627238fb7a9814f8b101b6ef087c473ac7b9ea468b87ade4a",
+				"KeyExpiry":  "2026-11-08T18:42:13Z",
+				"DiscoKey":   "discokey:d080c365550cfaa8e60544ca49deeeaa745c60ab9d904948e77d42f6fd70653c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34510",
+					"10.65.0.27:34510",
+					"172.17.0.1:34510",
+					"172.19.0.1:34510",
+					"172.20.0.1:34510"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:42:13.591035372Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1623421204509298,
+				"StableID":   "nhCUhHXFgD11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3366437d728ea6c21dd6ae2e1cbfc10fcda27c000fa1c58cf7b80021b7a5cb31",
+				"KeyExpiry":  "2026-11-08T18:42:14Z",
+				"DiscoKey":   "discokey:83f62475a7bdcae0681ce2a3d8b8f77d10080e41e5d0b14730921ce5449e1d2b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51904",
+					"10.65.0.27:51904",
+					"172.17.0.1:51904",
+					"172.19.0.1:51904",
+					"172.20.0.1:51904"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:42:14.146489745Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1681457587646704,
+				"StableID":   "nDj59J3Y8E11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:354044a49a47914e16be1473e39069c698caf4962ecf5e03906382cbe51cf71f",
+				"KeyExpiry":  "2026-11-08T18:42:14Z",
+				"DiscoKey":   "discokey:4863a1de33e9caf6aed67d6e11cee190a96ebad8a95a73ea65a42ed25ab2ea75",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:52679",
+					"10.65.0.27:52679",
+					"172.17.0.1:52679",
+					"172.19.0.1:52679",
+					"172.20.0.1:52679"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:42:14.680627967Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7765976342319786": {
+				"ID":          7765976342319786,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6958286858885,
+				"StableID":   "nE5yyNn94111CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       6958286858885,
+				"Key":        "nodekey:cdb16b0fc71019137f6d0317d1773d0938389fb29b72e52020ba0c596cfadd4d",
+				"DiscoKey":   "discokey:a571eb7e453d8d802187e4d50a4ac5a9fe18021565cd761cb78d7d2779054e74",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39497",
+					"10.65.0.27:39497",
+					"172.17.0.1:39497",
+					"172.19.0.1:39497",
+					"172.20.0.1:39497"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:42:08.73515415Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:cdb16b0fc71019137f6d0317d1773d0938389fb29b72e52020ba0c596cfadd4d",
+			"MachineKey": "mkey:a6c3b72d4809d7ef6b91acce167a55383d9f9ceca3a8439640cc3404dd38ef67",
+			"Peers": [{
+				"ID":         2107794865515843,
+				"StableID":   "nvWkTRCdTH11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf500e8e8d399ec7a80a04cd91ba87bb5e7d807a04c02ddfde5ed03c5ac7621a",
+				"DiscoKey":   "discokey:a810cd5d5deefdf927015e5aeefb1df748e3a36a50228939a212905250a79c4d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46426",
+					"10.65.0.27:46426",
+					"172.17.0.1:46426",
+					"172.19.0.1:46426",
+					"172.20.0.1:46426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:42:07.17026767Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3271489561762550,
+				"StableID":   "nuGEt2VfYS11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f87cd8de6d8802c5689ad796dd9b9e178562554000c9588fcee4efd4b7959871",
+				"DiscoKey":   "discokey:59788ee09e4842b712929a33b31587544e9251fa79733f708fb210e4ef80df51",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:46590",
+					"10.65.0.27:46590",
+					"172.17.0.1:46590",
+					"172.19.0.1:46590",
+					"172.20.0.1:46590"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:42:07.654822046Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5750505107573070,
+				"StableID":   "nb7Fg32Rum11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8467b29855e1cd9b977af1ecd74cfc2fdc0ef2c4d25f10f10e1e2383cc07f21d",
+				"DiscoKey":   "discokey:06fe18a20509b7424041576a76adafb50be1b46d64eaf73fc5560b4f5beeeb50",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59964",
+					"10.65.0.27:59964",
+					"172.17.0.1:59964",
+					"172.19.0.1:59964",
+					"172.20.0.1:59964"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:42:08.1985255Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7765976342319786,
+				"StableID":   "nmxy2j2Ee321CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:862f769e7eeadbf0543a1079a3fc8820d5b2eb6dedd3a2df955cce46b349ee5b",
+				"DiscoKey":   "discokey:908e6ff2c41af8396e12ae4be9d9a4a0237073416ebcb170785e5ac226fdbe7c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57346",
+					"10.65.0.27:57346",
+					"172.17.0.1:57346",
+					"172.19.0.1:57346",
+					"172.20.0.1:57346"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:42:09.280550815Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6506773082495447,
+				"StableID":   "nexLuvtvos11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:56209ad55cab2294595a7956e8c13820c1822743eb2e07a20ec005a05ae96743",
+				"DiscoKey":   "discokey:3714768eab0f957b8019abdd426c02fb2354fc0aeefbcb74d817eca337186301",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:43177",
+					"10.65.0.27:43177",
+					"172.17.0.1:43177",
+					"172.19.0.1:43177",
+					"172.20.0.1:43177"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:42:09.839963905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4795657944005432,
+				"StableID":   "n554ZXoxSe11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:160d7bd196d93fcb90fecf5a7d355bd70171482742a85bcf580c3449c887816c",
+				"DiscoKey":   "discokey:7e0ac3f8aa7a69fb80d06c277b30877ea8657027525b1a5d4bf818df42f0a575",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38750",
+					"10.65.0.27:38750",
+					"172.17.0.1:38750",
+					"172.19.0.1:38750",
+					"172.20.0.1:38750"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:42:10.367105213Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         737133093972331,
+				"StableID":   "n2ebKiErk611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7a3804bacb24ea6a0bb127400097e08529824fc8adbb04addd7fe035dc819a2b",
+				"DiscoKey":   "discokey:98b9f18c6425e92da333e4db7d5826f34b39df0312701fea1e4b5b8171820811",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37863",
+					"10.65.0.27:37863",
+					"172.17.0.1:37863",
+					"172.19.0.1:37863",
+					"172.20.0.1:37863"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:42:10.92223257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2765680423692704,
+				"StableID":   "n7r1RdjabN11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2811cb575850b23f8299a4b259850c98edeae8950ea77bd9f5918bb8f368fb66",
+				"DiscoKey":   "discokey:057e4cd16ea2e34268069aa323243aa8c476f9eea1eec4a5d30ef55bb7f94533",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38368",
+					"10.65.0.27:38368",
+					"172.17.0.1:38368",
+					"172.19.0.1:38368",
+					"172.20.0.1:38368"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:42:11.470756103Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2675001517369833,
+				"StableID":   "nGihyikWtM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6d3a926a7a50964b2b01e1004b3a36e8359e6c0c13be90fcf1645c0c61a35a10",
+				"DiscoKey":   "discokey:78e4438942419188b8cd767f064dd3e5a24a6dedd652e992ab10a94f610c3953",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44440",
+					"10.65.0.27:44440",
+					"172.17.0.1:44440",
+					"172.19.0.1:44440",
+					"172.20.0.1:44440"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:42:11.964549675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2605669856774919,
+				"StableID":   "nGdfYfX7MM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d820bcf4ba5a242b49d2b64b05c1012406aad212ce148d83e7ddfc848a00c0a",
+				"DiscoKey":   "discokey:d633cfd71b59b6122da8369ecc5c46982b0b5611b80bd47d225ec7df43c28a45",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43304",
+					"10.65.0.27:43304",
+					"172.17.0.1:43304",
+					"172.19.0.1:43304",
+					"172.20.0.1:43304"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:42:12.512864003Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8853228925457753,
+				"StableID":   "ngihg4Ke8C21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea8eaced1cfef237fc874e043f9ee4bb2bb25962d87a84a61b54fc34e6426a2d",
+				"DiscoKey":   "discokey:cc1adca9f1dd4302c6deb3f12582ff360109a71a014d6d1a5eb3b07217e6b868",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56826",
+					"10.65.0.27:56826",
+					"172.17.0.1:56826",
+					"172.19.0.1:56826",
+					"172.20.0.1:56826"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:42:13.046497681Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7879449713780322,
+				"StableID":   "nXHLJQncX421CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e02d27592c0afc2627238fb7a9814f8b101b6ef087c473ac7b9ea468b87ade4a",
+				"KeyExpiry":  "2026-11-08T18:42:13Z",
+				"DiscoKey":   "discokey:d080c365550cfaa8e60544ca49deeeaa745c60ab9d904948e77d42f6fd70653c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34510",
+					"10.65.0.27:34510",
+					"172.17.0.1:34510",
+					"172.19.0.1:34510",
+					"172.20.0.1:34510"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:42:13.591035372Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1623421204509298,
+				"StableID":   "nhCUhHXFgD11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3366437d728ea6c21dd6ae2e1cbfc10fcda27c000fa1c58cf7b80021b7a5cb31",
+				"KeyExpiry":  "2026-11-08T18:42:14Z",
+				"DiscoKey":   "discokey:83f62475a7bdcae0681ce2a3d8b8f77d10080e41e5d0b14730921ce5449e1d2b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51904",
+					"10.65.0.27:51904",
+					"172.17.0.1:51904",
+					"172.19.0.1:51904",
+					"172.20.0.1:51904"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:42:14.146489745Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1681457587646704,
+				"StableID":   "nDj59J3Y8E11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:354044a49a47914e16be1473e39069c698caf4962ecf5e03906382cbe51cf71f",
+				"KeyExpiry":  "2026-11-08T18:42:14Z",
+				"DiscoKey":   "discokey:4863a1de33e9caf6aed67d6e11cee190a96ebad8a95a73ea65a42ed25ab2ea75",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:52679",
+					"10.65.0.27:52679",
+					"172.17.0.1:52679",
+					"172.19.0.1:52679",
+					"172.20.0.1:52679"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:42:14.680627967Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6958286858885": {
+				"ID":          6958286858885,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4795657944005432,
+				"StableID":   "n554ZXoxSe11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       4795657944005432,
+				"Key":        "nodekey:160d7bd196d93fcb90fecf5a7d355bd70171482742a85bcf580c3449c887816c",
+				"DiscoKey":   "discokey:7e0ac3f8aa7a69fb80d06c277b30877ea8657027525b1a5d4bf818df42f0a575",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38750",
+					"10.65.0.27:38750",
+					"172.17.0.1:38750",
+					"172.19.0.1:38750",
+					"172.20.0.1:38750"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:42:10.367105213Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:160d7bd196d93fcb90fecf5a7d355bd70171482742a85bcf580c3449c887816c",
+			"MachineKey": "mkey:81db5b4b287aa4a98edf0827f2323d6459994162eda9a54236dcbbbaa4c0a11d",
+			"Peers": [{
+				"ID":         2107794865515843,
+				"StableID":   "nvWkTRCdTH11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf500e8e8d399ec7a80a04cd91ba87bb5e7d807a04c02ddfde5ed03c5ac7621a",
+				"DiscoKey":   "discokey:a810cd5d5deefdf927015e5aeefb1df748e3a36a50228939a212905250a79c4d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46426",
+					"10.65.0.27:46426",
+					"172.17.0.1:46426",
+					"172.19.0.1:46426",
+					"172.20.0.1:46426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:42:07.17026767Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3271489561762550,
+				"StableID":   "nuGEt2VfYS11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f87cd8de6d8802c5689ad796dd9b9e178562554000c9588fcee4efd4b7959871",
+				"DiscoKey":   "discokey:59788ee09e4842b712929a33b31587544e9251fa79733f708fb210e4ef80df51",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:46590",
+					"10.65.0.27:46590",
+					"172.17.0.1:46590",
+					"172.19.0.1:46590",
+					"172.20.0.1:46590"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:42:07.654822046Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5750505107573070,
+				"StableID":   "nb7Fg32Rum11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8467b29855e1cd9b977af1ecd74cfc2fdc0ef2c4d25f10f10e1e2383cc07f21d",
+				"DiscoKey":   "discokey:06fe18a20509b7424041576a76adafb50be1b46d64eaf73fc5560b4f5beeeb50",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59964",
+					"10.65.0.27:59964",
+					"172.17.0.1:59964",
+					"172.19.0.1:59964",
+					"172.20.0.1:59964"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:42:08.1985255Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6958286858885,
+				"StableID":   "nE5yyNn94111CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdb16b0fc71019137f6d0317d1773d0938389fb29b72e52020ba0c596cfadd4d",
+				"DiscoKey":   "discokey:a571eb7e453d8d802187e4d50a4ac5a9fe18021565cd761cb78d7d2779054e74",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39497",
+					"10.65.0.27:39497",
+					"172.17.0.1:39497",
+					"172.19.0.1:39497",
+					"172.20.0.1:39497"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:42:08.73515415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7765976342319786,
+				"StableID":   "nmxy2j2Ee321CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:862f769e7eeadbf0543a1079a3fc8820d5b2eb6dedd3a2df955cce46b349ee5b",
+				"DiscoKey":   "discokey:908e6ff2c41af8396e12ae4be9d9a4a0237073416ebcb170785e5ac226fdbe7c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57346",
+					"10.65.0.27:57346",
+					"172.17.0.1:57346",
+					"172.19.0.1:57346",
+					"172.20.0.1:57346"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:42:09.280550815Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6506773082495447,
+				"StableID":   "nexLuvtvos11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:56209ad55cab2294595a7956e8c13820c1822743eb2e07a20ec005a05ae96743",
+				"DiscoKey":   "discokey:3714768eab0f957b8019abdd426c02fb2354fc0aeefbcb74d817eca337186301",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:43177",
+					"10.65.0.27:43177",
+					"172.17.0.1:43177",
+					"172.19.0.1:43177",
+					"172.20.0.1:43177"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:42:09.839963905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         737133093972331,
+				"StableID":   "n2ebKiErk611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7a3804bacb24ea6a0bb127400097e08529824fc8adbb04addd7fe035dc819a2b",
+				"DiscoKey":   "discokey:98b9f18c6425e92da333e4db7d5826f34b39df0312701fea1e4b5b8171820811",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37863",
+					"10.65.0.27:37863",
+					"172.17.0.1:37863",
+					"172.19.0.1:37863",
+					"172.20.0.1:37863"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:42:10.92223257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2765680423692704,
+				"StableID":   "n7r1RdjabN11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2811cb575850b23f8299a4b259850c98edeae8950ea77bd9f5918bb8f368fb66",
+				"DiscoKey":   "discokey:057e4cd16ea2e34268069aa323243aa8c476f9eea1eec4a5d30ef55bb7f94533",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38368",
+					"10.65.0.27:38368",
+					"172.17.0.1:38368",
+					"172.19.0.1:38368",
+					"172.20.0.1:38368"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:42:11.470756103Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2675001517369833,
+				"StableID":   "nGihyikWtM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6d3a926a7a50964b2b01e1004b3a36e8359e6c0c13be90fcf1645c0c61a35a10",
+				"DiscoKey":   "discokey:78e4438942419188b8cd767f064dd3e5a24a6dedd652e992ab10a94f610c3953",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44440",
+					"10.65.0.27:44440",
+					"172.17.0.1:44440",
+					"172.19.0.1:44440",
+					"172.20.0.1:44440"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:42:11.964549675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2605669856774919,
+				"StableID":   "nGdfYfX7MM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d820bcf4ba5a242b49d2b64b05c1012406aad212ce148d83e7ddfc848a00c0a",
+				"DiscoKey":   "discokey:d633cfd71b59b6122da8369ecc5c46982b0b5611b80bd47d225ec7df43c28a45",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43304",
+					"10.65.0.27:43304",
+					"172.17.0.1:43304",
+					"172.19.0.1:43304",
+					"172.20.0.1:43304"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:42:12.512864003Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8853228925457753,
+				"StableID":   "ngihg4Ke8C21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea8eaced1cfef237fc874e043f9ee4bb2bb25962d87a84a61b54fc34e6426a2d",
+				"DiscoKey":   "discokey:cc1adca9f1dd4302c6deb3f12582ff360109a71a014d6d1a5eb3b07217e6b868",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56826",
+					"10.65.0.27:56826",
+					"172.17.0.1:56826",
+					"172.19.0.1:56826",
+					"172.20.0.1:56826"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:42:13.046497681Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7879449713780322,
+				"StableID":   "nXHLJQncX421CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e02d27592c0afc2627238fb7a9814f8b101b6ef087c473ac7b9ea468b87ade4a",
+				"KeyExpiry":  "2026-11-08T18:42:13Z",
+				"DiscoKey":   "discokey:d080c365550cfaa8e60544ca49deeeaa745c60ab9d904948e77d42f6fd70653c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34510",
+					"10.65.0.27:34510",
+					"172.17.0.1:34510",
+					"172.19.0.1:34510",
+					"172.20.0.1:34510"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:42:13.591035372Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1623421204509298,
+				"StableID":   "nhCUhHXFgD11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3366437d728ea6c21dd6ae2e1cbfc10fcda27c000fa1c58cf7b80021b7a5cb31",
+				"KeyExpiry":  "2026-11-08T18:42:14Z",
+				"DiscoKey":   "discokey:83f62475a7bdcae0681ce2a3d8b8f77d10080e41e5d0b14730921ce5449e1d2b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51904",
+					"10.65.0.27:51904",
+					"172.17.0.1:51904",
+					"172.19.0.1:51904",
+					"172.20.0.1:51904"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:42:14.146489745Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1681457587646704,
+				"StableID":   "nDj59J3Y8E11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:354044a49a47914e16be1473e39069c698caf4962ecf5e03906382cbe51cf71f",
+				"KeyExpiry":  "2026-11-08T18:42:14Z",
+				"DiscoKey":   "discokey:4863a1de33e9caf6aed67d6e11cee190a96ebad8a95a73ea65a42ed25ab2ea75",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:52679",
+					"10.65.0.27:52679",
+					"172.17.0.1:52679",
+					"172.19.0.1:52679",
+					"172.20.0.1:52679"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:42:14.680627967Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4795657944005432": {
+				"ID":          4795657944005432,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2765680423692704,
+				"StableID":   "n7r1RdjabN11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       2765680423692704,
+				"Key":        "nodekey:2811cb575850b23f8299a4b259850c98edeae8950ea77bd9f5918bb8f368fb66",
+				"DiscoKey":   "discokey:057e4cd16ea2e34268069aa323243aa8c476f9eea1eec4a5d30ef55bb7f94533",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38368",
+					"10.65.0.27:38368",
+					"172.17.0.1:38368",
+					"172.19.0.1:38368",
+					"172.20.0.1:38368"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:42:11.470756103Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2811cb575850b23f8299a4b259850c98edeae8950ea77bd9f5918bb8f368fb66",
+			"MachineKey": "mkey:423e4f870c7008be7e25ea33a75182341fa82efd1bd498de044c011c47c5df20",
+			"Peers": [{
+				"ID":         2107794865515843,
+				"StableID":   "nvWkTRCdTH11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf500e8e8d399ec7a80a04cd91ba87bb5e7d807a04c02ddfde5ed03c5ac7621a",
+				"DiscoKey":   "discokey:a810cd5d5deefdf927015e5aeefb1df748e3a36a50228939a212905250a79c4d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46426",
+					"10.65.0.27:46426",
+					"172.17.0.1:46426",
+					"172.19.0.1:46426",
+					"172.20.0.1:46426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:42:07.17026767Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3271489561762550,
+				"StableID":   "nuGEt2VfYS11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f87cd8de6d8802c5689ad796dd9b9e178562554000c9588fcee4efd4b7959871",
+				"DiscoKey":   "discokey:59788ee09e4842b712929a33b31587544e9251fa79733f708fb210e4ef80df51",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:46590",
+					"10.65.0.27:46590",
+					"172.17.0.1:46590",
+					"172.19.0.1:46590",
+					"172.20.0.1:46590"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:42:07.654822046Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5750505107573070,
+				"StableID":   "nb7Fg32Rum11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8467b29855e1cd9b977af1ecd74cfc2fdc0ef2c4d25f10f10e1e2383cc07f21d",
+				"DiscoKey":   "discokey:06fe18a20509b7424041576a76adafb50be1b46d64eaf73fc5560b4f5beeeb50",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59964",
+					"10.65.0.27:59964",
+					"172.17.0.1:59964",
+					"172.19.0.1:59964",
+					"172.20.0.1:59964"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:42:08.1985255Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6958286858885,
+				"StableID":   "nE5yyNn94111CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdb16b0fc71019137f6d0317d1773d0938389fb29b72e52020ba0c596cfadd4d",
+				"DiscoKey":   "discokey:a571eb7e453d8d802187e4d50a4ac5a9fe18021565cd761cb78d7d2779054e74",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39497",
+					"10.65.0.27:39497",
+					"172.17.0.1:39497",
+					"172.19.0.1:39497",
+					"172.20.0.1:39497"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:42:08.73515415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7765976342319786,
+				"StableID":   "nmxy2j2Ee321CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:862f769e7eeadbf0543a1079a3fc8820d5b2eb6dedd3a2df955cce46b349ee5b",
+				"DiscoKey":   "discokey:908e6ff2c41af8396e12ae4be9d9a4a0237073416ebcb170785e5ac226fdbe7c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57346",
+					"10.65.0.27:57346",
+					"172.17.0.1:57346",
+					"172.19.0.1:57346",
+					"172.20.0.1:57346"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:42:09.280550815Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6506773082495447,
+				"StableID":   "nexLuvtvos11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:56209ad55cab2294595a7956e8c13820c1822743eb2e07a20ec005a05ae96743",
+				"DiscoKey":   "discokey:3714768eab0f957b8019abdd426c02fb2354fc0aeefbcb74d817eca337186301",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:43177",
+					"10.65.0.27:43177",
+					"172.17.0.1:43177",
+					"172.19.0.1:43177",
+					"172.20.0.1:43177"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:42:09.839963905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4795657944005432,
+				"StableID":   "n554ZXoxSe11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:160d7bd196d93fcb90fecf5a7d355bd70171482742a85bcf580c3449c887816c",
+				"DiscoKey":   "discokey:7e0ac3f8aa7a69fb80d06c277b30877ea8657027525b1a5d4bf818df42f0a575",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38750",
+					"10.65.0.27:38750",
+					"172.17.0.1:38750",
+					"172.19.0.1:38750",
+					"172.20.0.1:38750"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:42:10.367105213Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         737133093972331,
+				"StableID":   "n2ebKiErk611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7a3804bacb24ea6a0bb127400097e08529824fc8adbb04addd7fe035dc819a2b",
+				"DiscoKey":   "discokey:98b9f18c6425e92da333e4db7d5826f34b39df0312701fea1e4b5b8171820811",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37863",
+					"10.65.0.27:37863",
+					"172.17.0.1:37863",
+					"172.19.0.1:37863",
+					"172.20.0.1:37863"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:42:10.92223257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2675001517369833,
+				"StableID":   "nGihyikWtM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6d3a926a7a50964b2b01e1004b3a36e8359e6c0c13be90fcf1645c0c61a35a10",
+				"DiscoKey":   "discokey:78e4438942419188b8cd767f064dd3e5a24a6dedd652e992ab10a94f610c3953",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44440",
+					"10.65.0.27:44440",
+					"172.17.0.1:44440",
+					"172.19.0.1:44440",
+					"172.20.0.1:44440"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:42:11.964549675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2605669856774919,
+				"StableID":   "nGdfYfX7MM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d820bcf4ba5a242b49d2b64b05c1012406aad212ce148d83e7ddfc848a00c0a",
+				"DiscoKey":   "discokey:d633cfd71b59b6122da8369ecc5c46982b0b5611b80bd47d225ec7df43c28a45",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43304",
+					"10.65.0.27:43304",
+					"172.17.0.1:43304",
+					"172.19.0.1:43304",
+					"172.20.0.1:43304"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:42:12.512864003Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8853228925457753,
+				"StableID":   "ngihg4Ke8C21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea8eaced1cfef237fc874e043f9ee4bb2bb25962d87a84a61b54fc34e6426a2d",
+				"DiscoKey":   "discokey:cc1adca9f1dd4302c6deb3f12582ff360109a71a014d6d1a5eb3b07217e6b868",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56826",
+					"10.65.0.27:56826",
+					"172.17.0.1:56826",
+					"172.19.0.1:56826",
+					"172.20.0.1:56826"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:42:13.046497681Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7879449713780322,
+				"StableID":   "nXHLJQncX421CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e02d27592c0afc2627238fb7a9814f8b101b6ef087c473ac7b9ea468b87ade4a",
+				"KeyExpiry":  "2026-11-08T18:42:13Z",
+				"DiscoKey":   "discokey:d080c365550cfaa8e60544ca49deeeaa745c60ab9d904948e77d42f6fd70653c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34510",
+					"10.65.0.27:34510",
+					"172.17.0.1:34510",
+					"172.19.0.1:34510",
+					"172.20.0.1:34510"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:42:13.591035372Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1623421204509298,
+				"StableID":   "nhCUhHXFgD11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3366437d728ea6c21dd6ae2e1cbfc10fcda27c000fa1c58cf7b80021b7a5cb31",
+				"KeyExpiry":  "2026-11-08T18:42:14Z",
+				"DiscoKey":   "discokey:83f62475a7bdcae0681ce2a3d8b8f77d10080e41e5d0b14730921ce5449e1d2b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51904",
+					"10.65.0.27:51904",
+					"172.17.0.1:51904",
+					"172.19.0.1:51904",
+					"172.20.0.1:51904"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:42:14.146489745Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1681457587646704,
+				"StableID":   "nDj59J3Y8E11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:354044a49a47914e16be1473e39069c698caf4962ecf5e03906382cbe51cf71f",
+				"KeyExpiry":  "2026-11-08T18:42:14Z",
+				"DiscoKey":   "discokey:4863a1de33e9caf6aed67d6e11cee190a96ebad8a95a73ea65a42ed25ab2ea75",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:52679",
+					"10.65.0.27:52679",
+					"172.17.0.1:52679",
+					"172.19.0.1:52679",
+					"172.20.0.1:52679"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:42:14.680627967Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2765680423692704": {
+				"ID":          2765680423692704,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1623421204509298,
+				"StableID":   "nhCUhHXFgD11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3366437d728ea6c21dd6ae2e1cbfc10fcda27c000fa1c58cf7b80021b7a5cb31",
+				"KeyExpiry":  "2026-11-08T18:42:14Z",
+				"DiscoKey":   "discokey:83f62475a7bdcae0681ce2a3d8b8f77d10080e41e5d0b14730921ce5449e1d2b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51904",
+					"10.65.0.27:51904",
+					"172.17.0.1:51904",
+					"172.19.0.1:51904",
+					"172.20.0.1:51904"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:42:14.146489745Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3366437d728ea6c21dd6ae2e1cbfc10fcda27c000fa1c58cf7b80021b7a5cb31",
+			"MachineKey": "mkey:3c937ee29b7ad80c50df4a3d0837df93b3aedc37e1fa6112b131bd72a6351511",
+			"Peers": [{
+				"ID":         2107794865515843,
+				"StableID":   "nvWkTRCdTH11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf500e8e8d399ec7a80a04cd91ba87bb5e7d807a04c02ddfde5ed03c5ac7621a",
+				"DiscoKey":   "discokey:a810cd5d5deefdf927015e5aeefb1df748e3a36a50228939a212905250a79c4d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46426",
+					"10.65.0.27:46426",
+					"172.17.0.1:46426",
+					"172.19.0.1:46426",
+					"172.20.0.1:46426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:42:07.17026767Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3271489561762550,
+				"StableID":   "nuGEt2VfYS11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f87cd8de6d8802c5689ad796dd9b9e178562554000c9588fcee4efd4b7959871",
+				"DiscoKey":   "discokey:59788ee09e4842b712929a33b31587544e9251fa79733f708fb210e4ef80df51",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:46590",
+					"10.65.0.27:46590",
+					"172.17.0.1:46590",
+					"172.19.0.1:46590",
+					"172.20.0.1:46590"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:42:07.654822046Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5750505107573070,
+				"StableID":   "nb7Fg32Rum11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8467b29855e1cd9b977af1ecd74cfc2fdc0ef2c4d25f10f10e1e2383cc07f21d",
+				"DiscoKey":   "discokey:06fe18a20509b7424041576a76adafb50be1b46d64eaf73fc5560b4f5beeeb50",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59964",
+					"10.65.0.27:59964",
+					"172.17.0.1:59964",
+					"172.19.0.1:59964",
+					"172.20.0.1:59964"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:42:08.1985255Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6958286858885,
+				"StableID":   "nE5yyNn94111CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdb16b0fc71019137f6d0317d1773d0938389fb29b72e52020ba0c596cfadd4d",
+				"DiscoKey":   "discokey:a571eb7e453d8d802187e4d50a4ac5a9fe18021565cd761cb78d7d2779054e74",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39497",
+					"10.65.0.27:39497",
+					"172.17.0.1:39497",
+					"172.19.0.1:39497",
+					"172.20.0.1:39497"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:42:08.73515415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7765976342319786,
+				"StableID":   "nmxy2j2Ee321CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:862f769e7eeadbf0543a1079a3fc8820d5b2eb6dedd3a2df955cce46b349ee5b",
+				"DiscoKey":   "discokey:908e6ff2c41af8396e12ae4be9d9a4a0237073416ebcb170785e5ac226fdbe7c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57346",
+					"10.65.0.27:57346",
+					"172.17.0.1:57346",
+					"172.19.0.1:57346",
+					"172.20.0.1:57346"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:42:09.280550815Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6506773082495447,
+				"StableID":   "nexLuvtvos11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:56209ad55cab2294595a7956e8c13820c1822743eb2e07a20ec005a05ae96743",
+				"DiscoKey":   "discokey:3714768eab0f957b8019abdd426c02fb2354fc0aeefbcb74d817eca337186301",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:43177",
+					"10.65.0.27:43177",
+					"172.17.0.1:43177",
+					"172.19.0.1:43177",
+					"172.20.0.1:43177"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:42:09.839963905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4795657944005432,
+				"StableID":   "n554ZXoxSe11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:160d7bd196d93fcb90fecf5a7d355bd70171482742a85bcf580c3449c887816c",
+				"DiscoKey":   "discokey:7e0ac3f8aa7a69fb80d06c277b30877ea8657027525b1a5d4bf818df42f0a575",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38750",
+					"10.65.0.27:38750",
+					"172.17.0.1:38750",
+					"172.19.0.1:38750",
+					"172.20.0.1:38750"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:42:10.367105213Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         737133093972331,
+				"StableID":   "n2ebKiErk611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7a3804bacb24ea6a0bb127400097e08529824fc8adbb04addd7fe035dc819a2b",
+				"DiscoKey":   "discokey:98b9f18c6425e92da333e4db7d5826f34b39df0312701fea1e4b5b8171820811",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37863",
+					"10.65.0.27:37863",
+					"172.17.0.1:37863",
+					"172.19.0.1:37863",
+					"172.20.0.1:37863"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:42:10.92223257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2765680423692704,
+				"StableID":   "n7r1RdjabN11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2811cb575850b23f8299a4b259850c98edeae8950ea77bd9f5918bb8f368fb66",
+				"DiscoKey":   "discokey:057e4cd16ea2e34268069aa323243aa8c476f9eea1eec4a5d30ef55bb7f94533",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38368",
+					"10.65.0.27:38368",
+					"172.17.0.1:38368",
+					"172.19.0.1:38368",
+					"172.20.0.1:38368"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:42:11.470756103Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2675001517369833,
+				"StableID":   "nGihyikWtM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6d3a926a7a50964b2b01e1004b3a36e8359e6c0c13be90fcf1645c0c61a35a10",
+				"DiscoKey":   "discokey:78e4438942419188b8cd767f064dd3e5a24a6dedd652e992ab10a94f610c3953",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44440",
+					"10.65.0.27:44440",
+					"172.17.0.1:44440",
+					"172.19.0.1:44440",
+					"172.20.0.1:44440"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:42:11.964549675Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2605669856774919,
+				"StableID":   "nGdfYfX7MM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d820bcf4ba5a242b49d2b64b05c1012406aad212ce148d83e7ddfc848a00c0a",
+				"DiscoKey":   "discokey:d633cfd71b59b6122da8369ecc5c46982b0b5611b80bd47d225ec7df43c28a45",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43304",
+					"10.65.0.27:43304",
+					"172.17.0.1:43304",
+					"172.19.0.1:43304",
+					"172.20.0.1:43304"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:42:12.512864003Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8853228925457753,
+				"StableID":   "ngihg4Ke8C21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea8eaced1cfef237fc874e043f9ee4bb2bb25962d87a84a61b54fc34e6426a2d",
+				"DiscoKey":   "discokey:cc1adca9f1dd4302c6deb3f12582ff360109a71a014d6d1a5eb3b07217e6b868",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56826",
+					"10.65.0.27:56826",
+					"172.17.0.1:56826",
+					"172.19.0.1:56826",
+					"172.20.0.1:56826"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:42:13.046497681Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7879449713780322,
+				"StableID":   "nXHLJQncX421CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e02d27592c0afc2627238fb7a9814f8b101b6ef087c473ac7b9ea468b87ade4a",
+				"KeyExpiry":  "2026-11-08T18:42:13Z",
+				"DiscoKey":   "discokey:d080c365550cfaa8e60544ca49deeeaa745c60ab9d904948e77d42f6fd70653c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34510",
+					"10.65.0.27:34510",
+					"172.17.0.1:34510",
+					"172.19.0.1:34510",
+					"172.20.0.1:34510"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:42:13.591035372Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1681457587646704,
+				"StableID":   "nDj59J3Y8E11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:354044a49a47914e16be1473e39069c698caf4962ecf5e03906382cbe51cf71f",
+				"KeyExpiry":  "2026-11-08T18:42:14Z",
+				"DiscoKey":   "discokey:4863a1de33e9caf6aed67d6e11cee190a96ebad8a95a73ea65a42ed25ab2ea75",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:52679",
+					"10.65.0.27:52679",
+					"172.17.0.1:52679",
+					"172.19.0.1:52679",
+					"172.20.0.1:52679"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:42:14.680627967Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2675001517369833,
+				"StableID":   "nGihyikWtM11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       2675001517369833,
+				"Key":        "nodekey:6d3a926a7a50964b2b01e1004b3a36e8359e6c0c13be90fcf1645c0c61a35a10",
+				"DiscoKey":   "discokey:78e4438942419188b8cd767f064dd3e5a24a6dedd652e992ab10a94f610c3953",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:44440",
+					"10.65.0.27:44440",
+					"172.17.0.1:44440",
+					"172.19.0.1:44440",
+					"172.20.0.1:44440"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:42:11.964549675Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6d3a926a7a50964b2b01e1004b3a36e8359e6c0c13be90fcf1645c0c61a35a10",
+			"MachineKey": "mkey:aeb8eeeea56506627dd42ceb08ffa07b18918b0d332dbfa6281b1b20d37c0445",
+			"Peers": [{
+				"ID":         2107794865515843,
+				"StableID":   "nvWkTRCdTH11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bf500e8e8d399ec7a80a04cd91ba87bb5e7d807a04c02ddfde5ed03c5ac7621a",
+				"DiscoKey":   "discokey:a810cd5d5deefdf927015e5aeefb1df748e3a36a50228939a212905250a79c4d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46426",
+					"10.65.0.27:46426",
+					"172.17.0.1:46426",
+					"172.19.0.1:46426",
+					"172.20.0.1:46426"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:42:07.17026767Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3271489561762550,
+				"StableID":   "nuGEt2VfYS11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f87cd8de6d8802c5689ad796dd9b9e178562554000c9588fcee4efd4b7959871",
+				"DiscoKey":   "discokey:59788ee09e4842b712929a33b31587544e9251fa79733f708fb210e4ef80df51",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:46590",
+					"10.65.0.27:46590",
+					"172.17.0.1:46590",
+					"172.19.0.1:46590",
+					"172.20.0.1:46590"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:42:07.654822046Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5750505107573070,
+				"StableID":   "nb7Fg32Rum11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8467b29855e1cd9b977af1ecd74cfc2fdc0ef2c4d25f10f10e1e2383cc07f21d",
+				"DiscoKey":   "discokey:06fe18a20509b7424041576a76adafb50be1b46d64eaf73fc5560b4f5beeeb50",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:59964",
+					"10.65.0.27:59964",
+					"172.17.0.1:59964",
+					"172.19.0.1:59964",
+					"172.20.0.1:59964"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:42:08.1985255Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6958286858885,
+				"StableID":   "nE5yyNn94111CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdb16b0fc71019137f6d0317d1773d0938389fb29b72e52020ba0c596cfadd4d",
+				"DiscoKey":   "discokey:a571eb7e453d8d802187e4d50a4ac5a9fe18021565cd761cb78d7d2779054e74",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:39497",
+					"10.65.0.27:39497",
+					"172.17.0.1:39497",
+					"172.19.0.1:39497",
+					"172.20.0.1:39497"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:42:08.73515415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7765976342319786,
+				"StableID":   "nmxy2j2Ee321CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:862f769e7eeadbf0543a1079a3fc8820d5b2eb6dedd3a2df955cce46b349ee5b",
+				"DiscoKey":   "discokey:908e6ff2c41af8396e12ae4be9d9a4a0237073416ebcb170785e5ac226fdbe7c",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57346",
+					"10.65.0.27:57346",
+					"172.17.0.1:57346",
+					"172.19.0.1:57346",
+					"172.20.0.1:57346"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:42:09.280550815Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6506773082495447,
+				"StableID":   "nexLuvtvos11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:56209ad55cab2294595a7956e8c13820c1822743eb2e07a20ec005a05ae96743",
+				"DiscoKey":   "discokey:3714768eab0f957b8019abdd426c02fb2354fc0aeefbcb74d817eca337186301",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:43177",
+					"10.65.0.27:43177",
+					"172.17.0.1:43177",
+					"172.19.0.1:43177",
+					"172.20.0.1:43177"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:42:09.839963905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4795657944005432,
+				"StableID":   "n554ZXoxSe11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:160d7bd196d93fcb90fecf5a7d355bd70171482742a85bcf580c3449c887816c",
+				"DiscoKey":   "discokey:7e0ac3f8aa7a69fb80d06c277b30877ea8657027525b1a5d4bf818df42f0a575",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:38750",
+					"10.65.0.27:38750",
+					"172.17.0.1:38750",
+					"172.19.0.1:38750",
+					"172.20.0.1:38750"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:42:10.367105213Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         737133093972331,
+				"StableID":   "n2ebKiErk611CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7a3804bacb24ea6a0bb127400097e08529824fc8adbb04addd7fe035dc819a2b",
+				"DiscoKey":   "discokey:98b9f18c6425e92da333e4db7d5826f34b39df0312701fea1e4b5b8171820811",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:37863",
+					"10.65.0.27:37863",
+					"172.17.0.1:37863",
+					"172.19.0.1:37863",
+					"172.20.0.1:37863"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:42:10.92223257Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2765680423692704,
+				"StableID":   "n7r1RdjabN11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2811cb575850b23f8299a4b259850c98edeae8950ea77bd9f5918bb8f368fb66",
+				"DiscoKey":   "discokey:057e4cd16ea2e34268069aa323243aa8c476f9eea1eec4a5d30ef55bb7f94533",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:38368",
+					"10.65.0.27:38368",
+					"172.17.0.1:38368",
+					"172.19.0.1:38368",
+					"172.20.0.1:38368"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:42:11.470756103Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2605669856774919,
+				"StableID":   "nGdfYfX7MM11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9d820bcf4ba5a242b49d2b64b05c1012406aad212ce148d83e7ddfc848a00c0a",
+				"DiscoKey":   "discokey:d633cfd71b59b6122da8369ecc5c46982b0b5611b80bd47d225ec7df43c28a45",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:43304",
+					"10.65.0.27:43304",
+					"172.17.0.1:43304",
+					"172.19.0.1:43304",
+					"172.20.0.1:43304"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:42:12.512864003Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8853228925457753,
+				"StableID":   "ngihg4Ke8C21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ea8eaced1cfef237fc874e043f9ee4bb2bb25962d87a84a61b54fc34e6426a2d",
+				"DiscoKey":   "discokey:cc1adca9f1dd4302c6deb3f12582ff360109a71a014d6d1a5eb3b07217e6b868",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:56826",
+					"10.65.0.27:56826",
+					"172.17.0.1:56826",
+					"172.19.0.1:56826",
+					"172.20.0.1:56826"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:42:13.046497681Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7879449713780322,
+				"StableID":   "nXHLJQncX421CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:e02d27592c0afc2627238fb7a9814f8b101b6ef087c473ac7b9ea468b87ade4a",
+				"KeyExpiry":  "2026-11-08T18:42:13Z",
+				"DiscoKey":   "discokey:d080c365550cfaa8e60544ca49deeeaa745c60ab9d904948e77d42f6fd70653c",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34510",
+					"10.65.0.27:34510",
+					"172.17.0.1:34510",
+					"172.19.0.1:34510",
+					"172.20.0.1:34510"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:42:13.591035372Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1623421204509298,
+				"StableID":   "nhCUhHXFgD11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3366437d728ea6c21dd6ae2e1cbfc10fcda27c000fa1c58cf7b80021b7a5cb31",
+				"KeyExpiry":  "2026-11-08T18:42:14Z",
+				"DiscoKey":   "discokey:83f62475a7bdcae0681ce2a3d8b8f77d10080e41e5d0b14730921ce5449e1d2b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:51904",
+					"10.65.0.27:51904",
+					"172.17.0.1:51904",
+					"172.19.0.1:51904",
+					"172.20.0.1:51904"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:42:14.146489745Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1681457587646704,
+				"StableID":   "nDj59J3Y8E11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:354044a49a47914e16be1473e39069c698caf4962ecf5e03906382cbe51cf71f",
+				"KeyExpiry":  "2026-11-08T18:42:14Z",
+				"DiscoKey":   "discokey:4863a1de33e9caf6aed67d6e11cee190a96ebad8a95a73ea65a42ed25ab2ea75",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:52679",
+					"10.65.0.27:52679",
+					"172.17.0.1:52679",
+					"172.19.0.1:52679",
+					"172.20.0.1:52679"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:42:14.680627967Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2675001517369833": {
+				"ID":          2675001517369833,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/sshtest_results/sshtest-malformed-dst-autogroup-internet.hujson
+++ b/hscontrol/policy/v2/testdata/sshtest_results/sshtest-malformed-dst-autogroup-internet.hujson
@@ -1,0 +1,20088 @@
+// sshtest-malformed-dst-autogroup-internet
+//
+// sshTests dst autogroup:internet must be rejected
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T18:42:59Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "sshtest-malformed-dst-autogroup-internet",
+	"description":    "sshTests dst autogroup:internet must be rejected",
+	"category":       "sshtest",
+	"captured_at":    "2026-05-12T18:42:59.943212941Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {
+			"message": "SSH tests dst contains disallowed element \"autogroup:internet\""
+		},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                           \n  \n                                                                      \n                                                               \n{\n\t\"category\":    \"sshtest\",\n\t\"description\": \"sshTests dst autogroup:internet must be rejected\",\n\t\"id\":          \"sshtest-malformed-dst-autogroup-internet\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"thor@example.org\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"sshTests\": [{\n\t\t\"accept\": [\"root\"],\n\t\t\"dst\":    [\"autogroup:internet\"],\n\t\t\"src\":    \"thor@example.org\"\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/sshtest/sshtest-malformed-dst-autogroup-internet.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["thor@example.org"],
+				"users":  ["root"]
+			}],
+			"sshTests": [{
+				"accept": ["root"],
+				"dst":    ["autogroup:internet"],
+				"src":    "thor@example.org"
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1778563694427652,
+				"StableID":   "nPkjGSrWtE11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1778563694427652,
+				"Key":        "nodekey:c6247aaf6ec419e6a20e3b14b8e214e14ea0229ba5243fc2cb5178169794d219",
+				"DiscoKey":   "discokey:9729bf0df16ed58b29fe665ef75bdcdbc62bf5c1f5f1fa8899d51da1b69ecc7a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44311",
+					"10.65.0.27:44311",
+					"172.17.0.1:44311",
+					"172.19.0.1:44311",
+					"172.20.0.1:44311"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:43:08.424953265Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c6247aaf6ec419e6a20e3b14b8e214e14ea0229ba5243fc2cb5178169794d219",
+			"MachineKey": "mkey:3a66ada6d5f8eba305169bd3f9b7bb56d2a47733edbf37981437c345bd677c15",
+			"Peers": [{
+				"ID":         6705409733160145,
+				"StableID":   "nAbJX7ktMu11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fde66e749b7c9998d7edb8b7229c20448ad4097677d60b91bdd6990ef4e4d463",
+				"DiscoKey":   "discokey:304fed7316a159e19434f07300fc22ba4cd5ded13311d388100aaf941e8bf364",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35297",
+					"10.65.0.27:35297",
+					"172.17.0.1:35297",
+					"172.19.0.1:35297",
+					"172.20.0.1:35297"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:43:02.530048154Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5287052114870279,
+				"StableID":   "nJNSjqtWHi11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:baec9a448c38cd7ab8d1493fe668aaf040a2a8de057f85d83d7f32ea79e3b47d",
+				"DiscoKey":   "discokey:017dae7f7949d565b61236b087188e8250aa2d215831e42c32fbf994e0340a72",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48714",
+					"10.65.0.27:48714",
+					"172.17.0.1:48714",
+					"172.19.0.1:48714",
+					"172.20.0.1:48714"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:43:03.012273454Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         79816518206558,
+				"StableID":   "nK5vPPe9d111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2381afede94000929e55d4334927003e638f36610a056769ab1ce8c30ab8bb1b",
+				"DiscoKey":   "discokey:526d726141ed3ac418866cc0c2a36c4e6e34f3a8cf8f382b9b9394a129f3d312",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34957",
+					"10.65.0.27:34957",
+					"172.17.0.1:34957",
+					"172.19.0.1:34957",
+					"172.20.0.1:34957"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:43:03.559851036Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5712732665356895,
+				"StableID":   "nSNcJQoJcm11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c0508573148420952dc4aa9c8523397179a6b37deb4fabe74e4882c14d804270",
+				"DiscoKey":   "discokey:524a0294c94f761fc0b773f8295bd19f215ca9b43ff9b8e56e9075740a84d16e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56091",
+					"10.65.0.27:56091",
+					"172.17.0.1:56091",
+					"172.19.0.1:56091",
+					"172.20.0.1:56091"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:43:04.108159952Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6690571426423582,
+				"StableID":   "nqeiA3yAFu11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:45534397287c4f9a5e2ce320cbfb510cacac2acda074102b1680d710f44c636a",
+				"DiscoKey":   "discokey:700b2fb1da26d8d2c11bfaa12a798542d63ba3e22cf7bc41a2dfe5f3e85a9e7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:59278",
+					"10.65.0.27:59278",
+					"172.17.0.1:59278",
+					"172.19.0.1:59278",
+					"172.20.0.1:59278"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:43:04.640112917Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6756386465092508,
+				"StableID":   "noQBmJpyku11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:907ba4b6193a07ca1a438e8b5232e3e632654aa3cb7be512336eee05fabd9f59",
+				"DiscoKey":   "discokey:c8b37108d84c450de094db28ac9a61b2011a0704bbe8df855e8fd7b33b1a1062",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53630",
+					"10.65.0.27:53630",
+					"172.17.0.1:53630",
+					"172.19.0.1:53630",
+					"172.20.0.1:53630"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:43:05.198137654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1019520298251466,
+				"StableID":   "nRNFa25kx811CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3278f2afea4315d278ef2bb5c47bb5ab779ab26bea75e2b3f48a1a8221e8454a",
+				"DiscoKey":   "discokey:c1ea4049bc5c08266c6fd2d8b5c1070814a727f409f0542e99362116fd677b1c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40735",
+					"10.65.0.27:40735",
+					"172.17.0.1:40735",
+					"172.19.0.1:40735",
+					"172.20.0.1:40735"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:43:05.753721108Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6903507164049026,
+				"StableID":   "nB1y8mRcuv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:840896b2fa09524a1b1f39617bfa49c58d4704f6bc6750cc36655e3aba9db113",
+				"DiscoKey":   "discokey:cf362e1457f1c567869297231db070f8c85c21c36a7289e80295bbaea088980e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46595",
+					"10.65.0.27:46595",
+					"172.17.0.1:46595",
+					"172.19.0.1:46595",
+					"172.20.0.1:46595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:43:06.258894294Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6565375780553687,
+				"StableID":   "nNLxekHUGt11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6b7a30b3ab7a8cc19add7e6179b84696df44443c5b1bf0b061150b8165c8903a",
+				"DiscoKey":   "discokey:07f6b591ba2a1d71ea81cf488aabc0266f9e765700e5c8338fea3c1c3e201412",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44689",
+					"10.65.0.27:44689",
+					"172.17.0.1:44689",
+					"172.19.0.1:44689",
+					"172.20.0.1:44689"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:43:06.78817179Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2332046482957184,
+				"StableID":   "nRotyauBDK11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9eb470f6cc3ba0293380a716ed8c876a3f4200a12264e01e06a1c58e12db7b44",
+				"DiscoKey":   "discokey:1156ff43993479cdc3d22e187ad2d37948e7dbca1899730f122963083c669e4a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53835",
+					"10.65.0.27:53835",
+					"172.17.0.1:53835",
+					"172.19.0.1:53835",
+					"172.20.0.1:53835"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:43:07.339293656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7669499834085359,
+				"StableID":   "nQwSNpkXt221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:894dcc7ae88f88b5a0a633ae4b61b0c879d22c947571ce024235a78e22fa692a",
+				"DiscoKey":   "discokey:55a28e63f72717d92e76ef381e5e852c8d8a935bcd9cf6f4a688553fb9d8ef62",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35663",
+					"10.65.0.27:35663",
+					"172.17.0.1:35663",
+					"172.19.0.1:35663",
+					"172.20.0.1:35663"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:43:07.877874763Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3450710695312138,
+				"StableID":   "nK3zjUKqwT11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1e7dcf085f1d9659bc769a9063d1cce6f263621852e94d60c09a8c35265da76c",
+				"KeyExpiry":  "2026-11-08T18:43:08Z",
+				"DiscoKey":   "discokey:c3e9c6d8874bcbd8241484e4e2b517c58b4c8850b4df1acb84f17e1a2324d224",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34174",
+					"10.65.0.27:34174",
+					"172.17.0.1:34174",
+					"172.19.0.1:34174",
+					"172.20.0.1:34174"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:43:08.964481601Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7188264267484786,
+				"StableID":   "nDxFGmWa8y11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a57c4a640749272e957cab5d7c3e8ae76159f4a13aa75184629e872192a78118",
+				"KeyExpiry":  "2026-11-08T18:43:09Z",
+				"DiscoKey":   "discokey:26b8dd4873a42f4c6f7844094e2bf45914c6931c333a9485123fe48f9ac96671",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:56939",
+					"10.65.0.27:56939",
+					"172.17.0.1:56939",
+					"172.19.0.1:56939",
+					"172.20.0.1:56939"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:43:09.506238145Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7701579901160944,
+				"StableID":   "nskZ3nS49321CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:db8ccc084baa7b619714f5f7f372dd6d25bb61a0cc556613fa9df7b9a1b3506e",
+				"KeyExpiry":  "2026-11-08T18:43:10Z",
+				"DiscoKey":   "discokey:8c82f1b37ce845db036cb145bba82479e8d342822d8f8293944c9ae6fbb30218",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:43733",
+					"10.65.0.27:43733",
+					"172.17.0.1:43733",
+					"172.19.0.1:43733",
+					"172.20.0.1:43733"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:43:10.061206821Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1778563694427652": {
+				"ID":          1778563694427652,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6756386465092508,
+				"StableID":   "noQBmJpyku11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       6756386465092508,
+				"Key":        "nodekey:907ba4b6193a07ca1a438e8b5232e3e632654aa3cb7be512336eee05fabd9f59",
+				"DiscoKey":   "discokey:c8b37108d84c450de094db28ac9a61b2011a0704bbe8df855e8fd7b33b1a1062",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53630",
+					"10.65.0.27:53630",
+					"172.17.0.1:53630",
+					"172.19.0.1:53630",
+					"172.20.0.1:53630"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:43:05.198137654Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:907ba4b6193a07ca1a438e8b5232e3e632654aa3cb7be512336eee05fabd9f59",
+			"MachineKey": "mkey:10b1969743bfbc8a3ebbe2d39cb0eca6d3efdecabfa1466b9192deb7331aab1e",
+			"Peers": [{
+				"ID":         6705409733160145,
+				"StableID":   "nAbJX7ktMu11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fde66e749b7c9998d7edb8b7229c20448ad4097677d60b91bdd6990ef4e4d463",
+				"DiscoKey":   "discokey:304fed7316a159e19434f07300fc22ba4cd5ded13311d388100aaf941e8bf364",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35297",
+					"10.65.0.27:35297",
+					"172.17.0.1:35297",
+					"172.19.0.1:35297",
+					"172.20.0.1:35297"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:43:02.530048154Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5287052114870279,
+				"StableID":   "nJNSjqtWHi11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:baec9a448c38cd7ab8d1493fe668aaf040a2a8de057f85d83d7f32ea79e3b47d",
+				"DiscoKey":   "discokey:017dae7f7949d565b61236b087188e8250aa2d215831e42c32fbf994e0340a72",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48714",
+					"10.65.0.27:48714",
+					"172.17.0.1:48714",
+					"172.19.0.1:48714",
+					"172.20.0.1:48714"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:43:03.012273454Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         79816518206558,
+				"StableID":   "nK5vPPe9d111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2381afede94000929e55d4334927003e638f36610a056769ab1ce8c30ab8bb1b",
+				"DiscoKey":   "discokey:526d726141ed3ac418866cc0c2a36c4e6e34f3a8cf8f382b9b9394a129f3d312",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34957",
+					"10.65.0.27:34957",
+					"172.17.0.1:34957",
+					"172.19.0.1:34957",
+					"172.20.0.1:34957"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:43:03.559851036Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5712732665356895,
+				"StableID":   "nSNcJQoJcm11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c0508573148420952dc4aa9c8523397179a6b37deb4fabe74e4882c14d804270",
+				"DiscoKey":   "discokey:524a0294c94f761fc0b773f8295bd19f215ca9b43ff9b8e56e9075740a84d16e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56091",
+					"10.65.0.27:56091",
+					"172.17.0.1:56091",
+					"172.19.0.1:56091",
+					"172.20.0.1:56091"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:43:04.108159952Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6690571426423582,
+				"StableID":   "nqeiA3yAFu11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:45534397287c4f9a5e2ce320cbfb510cacac2acda074102b1680d710f44c636a",
+				"DiscoKey":   "discokey:700b2fb1da26d8d2c11bfaa12a798542d63ba3e22cf7bc41a2dfe5f3e85a9e7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:59278",
+					"10.65.0.27:59278",
+					"172.17.0.1:59278",
+					"172.19.0.1:59278",
+					"172.20.0.1:59278"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:43:04.640112917Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1019520298251466,
+				"StableID":   "nRNFa25kx811CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3278f2afea4315d278ef2bb5c47bb5ab779ab26bea75e2b3f48a1a8221e8454a",
+				"DiscoKey":   "discokey:c1ea4049bc5c08266c6fd2d8b5c1070814a727f409f0542e99362116fd677b1c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40735",
+					"10.65.0.27:40735",
+					"172.17.0.1:40735",
+					"172.19.0.1:40735",
+					"172.20.0.1:40735"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:43:05.753721108Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6903507164049026,
+				"StableID":   "nB1y8mRcuv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:840896b2fa09524a1b1f39617bfa49c58d4704f6bc6750cc36655e3aba9db113",
+				"DiscoKey":   "discokey:cf362e1457f1c567869297231db070f8c85c21c36a7289e80295bbaea088980e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46595",
+					"10.65.0.27:46595",
+					"172.17.0.1:46595",
+					"172.19.0.1:46595",
+					"172.20.0.1:46595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:43:06.258894294Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6565375780553687,
+				"StableID":   "nNLxekHUGt11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6b7a30b3ab7a8cc19add7e6179b84696df44443c5b1bf0b061150b8165c8903a",
+				"DiscoKey":   "discokey:07f6b591ba2a1d71ea81cf488aabc0266f9e765700e5c8338fea3c1c3e201412",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44689",
+					"10.65.0.27:44689",
+					"172.17.0.1:44689",
+					"172.19.0.1:44689",
+					"172.20.0.1:44689"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:43:06.78817179Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2332046482957184,
+				"StableID":   "nRotyauBDK11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9eb470f6cc3ba0293380a716ed8c876a3f4200a12264e01e06a1c58e12db7b44",
+				"DiscoKey":   "discokey:1156ff43993479cdc3d22e187ad2d37948e7dbca1899730f122963083c669e4a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53835",
+					"10.65.0.27:53835",
+					"172.17.0.1:53835",
+					"172.19.0.1:53835",
+					"172.20.0.1:53835"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:43:07.339293656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7669499834085359,
+				"StableID":   "nQwSNpkXt221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:894dcc7ae88f88b5a0a633ae4b61b0c879d22c947571ce024235a78e22fa692a",
+				"DiscoKey":   "discokey:55a28e63f72717d92e76ef381e5e852c8d8a935bcd9cf6f4a688553fb9d8ef62",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35663",
+					"10.65.0.27:35663",
+					"172.17.0.1:35663",
+					"172.19.0.1:35663",
+					"172.20.0.1:35663"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:43:07.877874763Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1778563694427652,
+				"StableID":   "nPkjGSrWtE11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c6247aaf6ec419e6a20e3b14b8e214e14ea0229ba5243fc2cb5178169794d219",
+				"DiscoKey":   "discokey:9729bf0df16ed58b29fe665ef75bdcdbc62bf5c1f5f1fa8899d51da1b69ecc7a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44311",
+					"10.65.0.27:44311",
+					"172.17.0.1:44311",
+					"172.19.0.1:44311",
+					"172.20.0.1:44311"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:43:08.424953265Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3450710695312138,
+				"StableID":   "nK3zjUKqwT11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1e7dcf085f1d9659bc769a9063d1cce6f263621852e94d60c09a8c35265da76c",
+				"KeyExpiry":  "2026-11-08T18:43:08Z",
+				"DiscoKey":   "discokey:c3e9c6d8874bcbd8241484e4e2b517c58b4c8850b4df1acb84f17e1a2324d224",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34174",
+					"10.65.0.27:34174",
+					"172.17.0.1:34174",
+					"172.19.0.1:34174",
+					"172.20.0.1:34174"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:43:08.964481601Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7188264267484786,
+				"StableID":   "nDxFGmWa8y11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a57c4a640749272e957cab5d7c3e8ae76159f4a13aa75184629e872192a78118",
+				"KeyExpiry":  "2026-11-08T18:43:09Z",
+				"DiscoKey":   "discokey:26b8dd4873a42f4c6f7844094e2bf45914c6931c333a9485123fe48f9ac96671",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:56939",
+					"10.65.0.27:56939",
+					"172.17.0.1:56939",
+					"172.19.0.1:56939",
+					"172.20.0.1:56939"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:43:09.506238145Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7701579901160944,
+				"StableID":   "nskZ3nS49321CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:db8ccc084baa7b619714f5f7f372dd6d25bb61a0cc556613fa9df7b9a1b3506e",
+				"KeyExpiry":  "2026-11-08T18:43:10Z",
+				"DiscoKey":   "discokey:8c82f1b37ce845db036cb145bba82479e8d342822d8f8293944c9ae6fbb30218",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:43733",
+					"10.65.0.27:43733",
+					"172.17.0.1:43733",
+					"172.19.0.1:43733",
+					"172.20.0.1:43733"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:43:10.061206821Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6756386465092508": {
+				"ID":          6756386465092508,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7701579901160944,
+				"StableID":   "nskZ3nS49321CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:db8ccc084baa7b619714f5f7f372dd6d25bb61a0cc556613fa9df7b9a1b3506e",
+				"KeyExpiry":  "2026-11-08T18:43:10Z",
+				"DiscoKey":   "discokey:8c82f1b37ce845db036cb145bba82479e8d342822d8f8293944c9ae6fbb30218",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:43733",
+					"10.65.0.27:43733",
+					"172.17.0.1:43733",
+					"172.19.0.1:43733",
+					"172.20.0.1:43733"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:43:10.061206821Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:db8ccc084baa7b619714f5f7f372dd6d25bb61a0cc556613fa9df7b9a1b3506e",
+			"MachineKey": "mkey:e5428a84f8060f6195c3f2bd47238a33b5bff33f61db9affd8d0a8c5c358647b",
+			"Peers": [{
+				"ID":         6705409733160145,
+				"StableID":   "nAbJX7ktMu11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fde66e749b7c9998d7edb8b7229c20448ad4097677d60b91bdd6990ef4e4d463",
+				"DiscoKey":   "discokey:304fed7316a159e19434f07300fc22ba4cd5ded13311d388100aaf941e8bf364",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35297",
+					"10.65.0.27:35297",
+					"172.17.0.1:35297",
+					"172.19.0.1:35297",
+					"172.20.0.1:35297"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:43:02.530048154Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5287052114870279,
+				"StableID":   "nJNSjqtWHi11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:baec9a448c38cd7ab8d1493fe668aaf040a2a8de057f85d83d7f32ea79e3b47d",
+				"DiscoKey":   "discokey:017dae7f7949d565b61236b087188e8250aa2d215831e42c32fbf994e0340a72",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48714",
+					"10.65.0.27:48714",
+					"172.17.0.1:48714",
+					"172.19.0.1:48714",
+					"172.20.0.1:48714"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:43:03.012273454Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         79816518206558,
+				"StableID":   "nK5vPPe9d111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2381afede94000929e55d4334927003e638f36610a056769ab1ce8c30ab8bb1b",
+				"DiscoKey":   "discokey:526d726141ed3ac418866cc0c2a36c4e6e34f3a8cf8f382b9b9394a129f3d312",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34957",
+					"10.65.0.27:34957",
+					"172.17.0.1:34957",
+					"172.19.0.1:34957",
+					"172.20.0.1:34957"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:43:03.559851036Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5712732665356895,
+				"StableID":   "nSNcJQoJcm11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c0508573148420952dc4aa9c8523397179a6b37deb4fabe74e4882c14d804270",
+				"DiscoKey":   "discokey:524a0294c94f761fc0b773f8295bd19f215ca9b43ff9b8e56e9075740a84d16e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56091",
+					"10.65.0.27:56091",
+					"172.17.0.1:56091",
+					"172.19.0.1:56091",
+					"172.20.0.1:56091"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:43:04.108159952Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6690571426423582,
+				"StableID":   "nqeiA3yAFu11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:45534397287c4f9a5e2ce320cbfb510cacac2acda074102b1680d710f44c636a",
+				"DiscoKey":   "discokey:700b2fb1da26d8d2c11bfaa12a798542d63ba3e22cf7bc41a2dfe5f3e85a9e7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:59278",
+					"10.65.0.27:59278",
+					"172.17.0.1:59278",
+					"172.19.0.1:59278",
+					"172.20.0.1:59278"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:43:04.640112917Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6756386465092508,
+				"StableID":   "noQBmJpyku11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:907ba4b6193a07ca1a438e8b5232e3e632654aa3cb7be512336eee05fabd9f59",
+				"DiscoKey":   "discokey:c8b37108d84c450de094db28ac9a61b2011a0704bbe8df855e8fd7b33b1a1062",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53630",
+					"10.65.0.27:53630",
+					"172.17.0.1:53630",
+					"172.19.0.1:53630",
+					"172.20.0.1:53630"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:43:05.198137654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1019520298251466,
+				"StableID":   "nRNFa25kx811CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3278f2afea4315d278ef2bb5c47bb5ab779ab26bea75e2b3f48a1a8221e8454a",
+				"DiscoKey":   "discokey:c1ea4049bc5c08266c6fd2d8b5c1070814a727f409f0542e99362116fd677b1c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40735",
+					"10.65.0.27:40735",
+					"172.17.0.1:40735",
+					"172.19.0.1:40735",
+					"172.20.0.1:40735"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:43:05.753721108Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6903507164049026,
+				"StableID":   "nB1y8mRcuv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:840896b2fa09524a1b1f39617bfa49c58d4704f6bc6750cc36655e3aba9db113",
+				"DiscoKey":   "discokey:cf362e1457f1c567869297231db070f8c85c21c36a7289e80295bbaea088980e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46595",
+					"10.65.0.27:46595",
+					"172.17.0.1:46595",
+					"172.19.0.1:46595",
+					"172.20.0.1:46595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:43:06.258894294Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6565375780553687,
+				"StableID":   "nNLxekHUGt11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6b7a30b3ab7a8cc19add7e6179b84696df44443c5b1bf0b061150b8165c8903a",
+				"DiscoKey":   "discokey:07f6b591ba2a1d71ea81cf488aabc0266f9e765700e5c8338fea3c1c3e201412",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44689",
+					"10.65.0.27:44689",
+					"172.17.0.1:44689",
+					"172.19.0.1:44689",
+					"172.20.0.1:44689"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:43:06.78817179Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2332046482957184,
+				"StableID":   "nRotyauBDK11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9eb470f6cc3ba0293380a716ed8c876a3f4200a12264e01e06a1c58e12db7b44",
+				"DiscoKey":   "discokey:1156ff43993479cdc3d22e187ad2d37948e7dbca1899730f122963083c669e4a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53835",
+					"10.65.0.27:53835",
+					"172.17.0.1:53835",
+					"172.19.0.1:53835",
+					"172.20.0.1:53835"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:43:07.339293656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7669499834085359,
+				"StableID":   "nQwSNpkXt221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:894dcc7ae88f88b5a0a633ae4b61b0c879d22c947571ce024235a78e22fa692a",
+				"DiscoKey":   "discokey:55a28e63f72717d92e76ef381e5e852c8d8a935bcd9cf6f4a688553fb9d8ef62",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35663",
+					"10.65.0.27:35663",
+					"172.17.0.1:35663",
+					"172.19.0.1:35663",
+					"172.20.0.1:35663"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:43:07.877874763Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1778563694427652,
+				"StableID":   "nPkjGSrWtE11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c6247aaf6ec419e6a20e3b14b8e214e14ea0229ba5243fc2cb5178169794d219",
+				"DiscoKey":   "discokey:9729bf0df16ed58b29fe665ef75bdcdbc62bf5c1f5f1fa8899d51da1b69ecc7a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44311",
+					"10.65.0.27:44311",
+					"172.17.0.1:44311",
+					"172.19.0.1:44311",
+					"172.20.0.1:44311"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:43:08.424953265Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3450710695312138,
+				"StableID":   "nK3zjUKqwT11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1e7dcf085f1d9659bc769a9063d1cce6f263621852e94d60c09a8c35265da76c",
+				"KeyExpiry":  "2026-11-08T18:43:08Z",
+				"DiscoKey":   "discokey:c3e9c6d8874bcbd8241484e4e2b517c58b4c8850b4df1acb84f17e1a2324d224",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34174",
+					"10.65.0.27:34174",
+					"172.17.0.1:34174",
+					"172.19.0.1:34174",
+					"172.20.0.1:34174"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:43:08.964481601Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7188264267484786,
+				"StableID":   "nDxFGmWa8y11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a57c4a640749272e957cab5d7c3e8ae76159f4a13aa75184629e872192a78118",
+				"KeyExpiry":  "2026-11-08T18:43:09Z",
+				"DiscoKey":   "discokey:26b8dd4873a42f4c6f7844094e2bf45914c6931c333a9485123fe48f9ac96671",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:56939",
+					"10.65.0.27:56939",
+					"172.17.0.1:56939",
+					"172.19.0.1:56939",
+					"172.20.0.1:56939"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:43:09.506238145Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         79816518206558,
+				"StableID":   "nK5vPPe9d111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       79816518206558,
+				"Key":        "nodekey:2381afede94000929e55d4334927003e638f36610a056769ab1ce8c30ab8bb1b",
+				"DiscoKey":   "discokey:526d726141ed3ac418866cc0c2a36c4e6e34f3a8cf8f382b9b9394a129f3d312",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34957",
+					"10.65.0.27:34957",
+					"172.17.0.1:34957",
+					"172.19.0.1:34957",
+					"172.20.0.1:34957"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:43:03.559851036Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2381afede94000929e55d4334927003e638f36610a056769ab1ce8c30ab8bb1b",
+			"MachineKey": "mkey:723d098962c75de50caa38522fe4d64e5e95f387ea9ee2e3d77dee0bea3ab40a",
+			"Peers": [{
+				"ID":         6705409733160145,
+				"StableID":   "nAbJX7ktMu11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fde66e749b7c9998d7edb8b7229c20448ad4097677d60b91bdd6990ef4e4d463",
+				"DiscoKey":   "discokey:304fed7316a159e19434f07300fc22ba4cd5ded13311d388100aaf941e8bf364",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35297",
+					"10.65.0.27:35297",
+					"172.17.0.1:35297",
+					"172.19.0.1:35297",
+					"172.20.0.1:35297"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:43:02.530048154Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5287052114870279,
+				"StableID":   "nJNSjqtWHi11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:baec9a448c38cd7ab8d1493fe668aaf040a2a8de057f85d83d7f32ea79e3b47d",
+				"DiscoKey":   "discokey:017dae7f7949d565b61236b087188e8250aa2d215831e42c32fbf994e0340a72",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48714",
+					"10.65.0.27:48714",
+					"172.17.0.1:48714",
+					"172.19.0.1:48714",
+					"172.20.0.1:48714"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:43:03.012273454Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5712732665356895,
+				"StableID":   "nSNcJQoJcm11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c0508573148420952dc4aa9c8523397179a6b37deb4fabe74e4882c14d804270",
+				"DiscoKey":   "discokey:524a0294c94f761fc0b773f8295bd19f215ca9b43ff9b8e56e9075740a84d16e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56091",
+					"10.65.0.27:56091",
+					"172.17.0.1:56091",
+					"172.19.0.1:56091",
+					"172.20.0.1:56091"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:43:04.108159952Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6690571426423582,
+				"StableID":   "nqeiA3yAFu11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:45534397287c4f9a5e2ce320cbfb510cacac2acda074102b1680d710f44c636a",
+				"DiscoKey":   "discokey:700b2fb1da26d8d2c11bfaa12a798542d63ba3e22cf7bc41a2dfe5f3e85a9e7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:59278",
+					"10.65.0.27:59278",
+					"172.17.0.1:59278",
+					"172.19.0.1:59278",
+					"172.20.0.1:59278"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:43:04.640112917Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6756386465092508,
+				"StableID":   "noQBmJpyku11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:907ba4b6193a07ca1a438e8b5232e3e632654aa3cb7be512336eee05fabd9f59",
+				"DiscoKey":   "discokey:c8b37108d84c450de094db28ac9a61b2011a0704bbe8df855e8fd7b33b1a1062",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53630",
+					"10.65.0.27:53630",
+					"172.17.0.1:53630",
+					"172.19.0.1:53630",
+					"172.20.0.1:53630"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:43:05.198137654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1019520298251466,
+				"StableID":   "nRNFa25kx811CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3278f2afea4315d278ef2bb5c47bb5ab779ab26bea75e2b3f48a1a8221e8454a",
+				"DiscoKey":   "discokey:c1ea4049bc5c08266c6fd2d8b5c1070814a727f409f0542e99362116fd677b1c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40735",
+					"10.65.0.27:40735",
+					"172.17.0.1:40735",
+					"172.19.0.1:40735",
+					"172.20.0.1:40735"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:43:05.753721108Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6903507164049026,
+				"StableID":   "nB1y8mRcuv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:840896b2fa09524a1b1f39617bfa49c58d4704f6bc6750cc36655e3aba9db113",
+				"DiscoKey":   "discokey:cf362e1457f1c567869297231db070f8c85c21c36a7289e80295bbaea088980e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46595",
+					"10.65.0.27:46595",
+					"172.17.0.1:46595",
+					"172.19.0.1:46595",
+					"172.20.0.1:46595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:43:06.258894294Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6565375780553687,
+				"StableID":   "nNLxekHUGt11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6b7a30b3ab7a8cc19add7e6179b84696df44443c5b1bf0b061150b8165c8903a",
+				"DiscoKey":   "discokey:07f6b591ba2a1d71ea81cf488aabc0266f9e765700e5c8338fea3c1c3e201412",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44689",
+					"10.65.0.27:44689",
+					"172.17.0.1:44689",
+					"172.19.0.1:44689",
+					"172.20.0.1:44689"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:43:06.78817179Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2332046482957184,
+				"StableID":   "nRotyauBDK11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9eb470f6cc3ba0293380a716ed8c876a3f4200a12264e01e06a1c58e12db7b44",
+				"DiscoKey":   "discokey:1156ff43993479cdc3d22e187ad2d37948e7dbca1899730f122963083c669e4a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53835",
+					"10.65.0.27:53835",
+					"172.17.0.1:53835",
+					"172.19.0.1:53835",
+					"172.20.0.1:53835"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:43:07.339293656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7669499834085359,
+				"StableID":   "nQwSNpkXt221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:894dcc7ae88f88b5a0a633ae4b61b0c879d22c947571ce024235a78e22fa692a",
+				"DiscoKey":   "discokey:55a28e63f72717d92e76ef381e5e852c8d8a935bcd9cf6f4a688553fb9d8ef62",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35663",
+					"10.65.0.27:35663",
+					"172.17.0.1:35663",
+					"172.19.0.1:35663",
+					"172.20.0.1:35663"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:43:07.877874763Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1778563694427652,
+				"StableID":   "nPkjGSrWtE11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c6247aaf6ec419e6a20e3b14b8e214e14ea0229ba5243fc2cb5178169794d219",
+				"DiscoKey":   "discokey:9729bf0df16ed58b29fe665ef75bdcdbc62bf5c1f5f1fa8899d51da1b69ecc7a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44311",
+					"10.65.0.27:44311",
+					"172.17.0.1:44311",
+					"172.19.0.1:44311",
+					"172.20.0.1:44311"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:43:08.424953265Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3450710695312138,
+				"StableID":   "nK3zjUKqwT11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1e7dcf085f1d9659bc769a9063d1cce6f263621852e94d60c09a8c35265da76c",
+				"KeyExpiry":  "2026-11-08T18:43:08Z",
+				"DiscoKey":   "discokey:c3e9c6d8874bcbd8241484e4e2b517c58b4c8850b4df1acb84f17e1a2324d224",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34174",
+					"10.65.0.27:34174",
+					"172.17.0.1:34174",
+					"172.19.0.1:34174",
+					"172.20.0.1:34174"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:43:08.964481601Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7188264267484786,
+				"StableID":   "nDxFGmWa8y11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a57c4a640749272e957cab5d7c3e8ae76159f4a13aa75184629e872192a78118",
+				"KeyExpiry":  "2026-11-08T18:43:09Z",
+				"DiscoKey":   "discokey:26b8dd4873a42f4c6f7844094e2bf45914c6931c333a9485123fe48f9ac96671",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:56939",
+					"10.65.0.27:56939",
+					"172.17.0.1:56939",
+					"172.19.0.1:56939",
+					"172.20.0.1:56939"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:43:09.506238145Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7701579901160944,
+				"StableID":   "nskZ3nS49321CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:db8ccc084baa7b619714f5f7f372dd6d25bb61a0cc556613fa9df7b9a1b3506e",
+				"KeyExpiry":  "2026-11-08T18:43:10Z",
+				"DiscoKey":   "discokey:8c82f1b37ce845db036cb145bba82479e8d342822d8f8293944c9ae6fbb30218",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:43733",
+					"10.65.0.27:43733",
+					"172.17.0.1:43733",
+					"172.19.0.1:43733",
+					"172.20.0.1:43733"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:43:10.061206821Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "79816518206558": {
+				"ID":          79816518206558,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6903507164049026,
+				"StableID":   "nB1y8mRcuv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       6903507164049026,
+				"Key":        "nodekey:840896b2fa09524a1b1f39617bfa49c58d4704f6bc6750cc36655e3aba9db113",
+				"DiscoKey":   "discokey:cf362e1457f1c567869297231db070f8c85c21c36a7289e80295bbaea088980e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46595",
+					"10.65.0.27:46595",
+					"172.17.0.1:46595",
+					"172.19.0.1:46595",
+					"172.20.0.1:46595"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:43:06.258894294Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:840896b2fa09524a1b1f39617bfa49c58d4704f6bc6750cc36655e3aba9db113",
+			"MachineKey": "mkey:00ce8e0cb39f3ac5b83d87847a791a81ee451e8900246ba90b870c7102634a6d",
+			"Peers": [{
+				"ID":         6705409733160145,
+				"StableID":   "nAbJX7ktMu11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fde66e749b7c9998d7edb8b7229c20448ad4097677d60b91bdd6990ef4e4d463",
+				"DiscoKey":   "discokey:304fed7316a159e19434f07300fc22ba4cd5ded13311d388100aaf941e8bf364",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35297",
+					"10.65.0.27:35297",
+					"172.17.0.1:35297",
+					"172.19.0.1:35297",
+					"172.20.0.1:35297"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:43:02.530048154Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5287052114870279,
+				"StableID":   "nJNSjqtWHi11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:baec9a448c38cd7ab8d1493fe668aaf040a2a8de057f85d83d7f32ea79e3b47d",
+				"DiscoKey":   "discokey:017dae7f7949d565b61236b087188e8250aa2d215831e42c32fbf994e0340a72",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48714",
+					"10.65.0.27:48714",
+					"172.17.0.1:48714",
+					"172.19.0.1:48714",
+					"172.20.0.1:48714"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:43:03.012273454Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         79816518206558,
+				"StableID":   "nK5vPPe9d111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2381afede94000929e55d4334927003e638f36610a056769ab1ce8c30ab8bb1b",
+				"DiscoKey":   "discokey:526d726141ed3ac418866cc0c2a36c4e6e34f3a8cf8f382b9b9394a129f3d312",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34957",
+					"10.65.0.27:34957",
+					"172.17.0.1:34957",
+					"172.19.0.1:34957",
+					"172.20.0.1:34957"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:43:03.559851036Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5712732665356895,
+				"StableID":   "nSNcJQoJcm11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c0508573148420952dc4aa9c8523397179a6b37deb4fabe74e4882c14d804270",
+				"DiscoKey":   "discokey:524a0294c94f761fc0b773f8295bd19f215ca9b43ff9b8e56e9075740a84d16e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56091",
+					"10.65.0.27:56091",
+					"172.17.0.1:56091",
+					"172.19.0.1:56091",
+					"172.20.0.1:56091"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:43:04.108159952Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6690571426423582,
+				"StableID":   "nqeiA3yAFu11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:45534397287c4f9a5e2ce320cbfb510cacac2acda074102b1680d710f44c636a",
+				"DiscoKey":   "discokey:700b2fb1da26d8d2c11bfaa12a798542d63ba3e22cf7bc41a2dfe5f3e85a9e7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:59278",
+					"10.65.0.27:59278",
+					"172.17.0.1:59278",
+					"172.19.0.1:59278",
+					"172.20.0.1:59278"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:43:04.640112917Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6756386465092508,
+				"StableID":   "noQBmJpyku11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:907ba4b6193a07ca1a438e8b5232e3e632654aa3cb7be512336eee05fabd9f59",
+				"DiscoKey":   "discokey:c8b37108d84c450de094db28ac9a61b2011a0704bbe8df855e8fd7b33b1a1062",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53630",
+					"10.65.0.27:53630",
+					"172.17.0.1:53630",
+					"172.19.0.1:53630",
+					"172.20.0.1:53630"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:43:05.198137654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1019520298251466,
+				"StableID":   "nRNFa25kx811CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3278f2afea4315d278ef2bb5c47bb5ab779ab26bea75e2b3f48a1a8221e8454a",
+				"DiscoKey":   "discokey:c1ea4049bc5c08266c6fd2d8b5c1070814a727f409f0542e99362116fd677b1c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40735",
+					"10.65.0.27:40735",
+					"172.17.0.1:40735",
+					"172.19.0.1:40735",
+					"172.20.0.1:40735"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:43:05.753721108Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6565375780553687,
+				"StableID":   "nNLxekHUGt11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6b7a30b3ab7a8cc19add7e6179b84696df44443c5b1bf0b061150b8165c8903a",
+				"DiscoKey":   "discokey:07f6b591ba2a1d71ea81cf488aabc0266f9e765700e5c8338fea3c1c3e201412",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44689",
+					"10.65.0.27:44689",
+					"172.17.0.1:44689",
+					"172.19.0.1:44689",
+					"172.20.0.1:44689"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:43:06.78817179Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2332046482957184,
+				"StableID":   "nRotyauBDK11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9eb470f6cc3ba0293380a716ed8c876a3f4200a12264e01e06a1c58e12db7b44",
+				"DiscoKey":   "discokey:1156ff43993479cdc3d22e187ad2d37948e7dbca1899730f122963083c669e4a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53835",
+					"10.65.0.27:53835",
+					"172.17.0.1:53835",
+					"172.19.0.1:53835",
+					"172.20.0.1:53835"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:43:07.339293656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7669499834085359,
+				"StableID":   "nQwSNpkXt221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:894dcc7ae88f88b5a0a633ae4b61b0c879d22c947571ce024235a78e22fa692a",
+				"DiscoKey":   "discokey:55a28e63f72717d92e76ef381e5e852c8d8a935bcd9cf6f4a688553fb9d8ef62",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35663",
+					"10.65.0.27:35663",
+					"172.17.0.1:35663",
+					"172.19.0.1:35663",
+					"172.20.0.1:35663"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:43:07.877874763Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1778563694427652,
+				"StableID":   "nPkjGSrWtE11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c6247aaf6ec419e6a20e3b14b8e214e14ea0229ba5243fc2cb5178169794d219",
+				"DiscoKey":   "discokey:9729bf0df16ed58b29fe665ef75bdcdbc62bf5c1f5f1fa8899d51da1b69ecc7a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44311",
+					"10.65.0.27:44311",
+					"172.17.0.1:44311",
+					"172.19.0.1:44311",
+					"172.20.0.1:44311"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:43:08.424953265Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3450710695312138,
+				"StableID":   "nK3zjUKqwT11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1e7dcf085f1d9659bc769a9063d1cce6f263621852e94d60c09a8c35265da76c",
+				"KeyExpiry":  "2026-11-08T18:43:08Z",
+				"DiscoKey":   "discokey:c3e9c6d8874bcbd8241484e4e2b517c58b4c8850b4df1acb84f17e1a2324d224",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34174",
+					"10.65.0.27:34174",
+					"172.17.0.1:34174",
+					"172.19.0.1:34174",
+					"172.20.0.1:34174"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:43:08.964481601Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7188264267484786,
+				"StableID":   "nDxFGmWa8y11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a57c4a640749272e957cab5d7c3e8ae76159f4a13aa75184629e872192a78118",
+				"KeyExpiry":  "2026-11-08T18:43:09Z",
+				"DiscoKey":   "discokey:26b8dd4873a42f4c6f7844094e2bf45914c6931c333a9485123fe48f9ac96671",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:56939",
+					"10.65.0.27:56939",
+					"172.17.0.1:56939",
+					"172.19.0.1:56939",
+					"172.20.0.1:56939"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:43:09.506238145Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7701579901160944,
+				"StableID":   "nskZ3nS49321CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:db8ccc084baa7b619714f5f7f372dd6d25bb61a0cc556613fa9df7b9a1b3506e",
+				"KeyExpiry":  "2026-11-08T18:43:10Z",
+				"DiscoKey":   "discokey:8c82f1b37ce845db036cb145bba82479e8d342822d8f8293944c9ae6fbb30218",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:43733",
+					"10.65.0.27:43733",
+					"172.17.0.1:43733",
+					"172.19.0.1:43733",
+					"172.20.0.1:43733"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:43:10.061206821Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6903507164049026": {
+				"ID":          6903507164049026,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3450710695312138,
+				"StableID":   "nK3zjUKqwT11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1e7dcf085f1d9659bc769a9063d1cce6f263621852e94d60c09a8c35265da76c",
+				"KeyExpiry":  "2026-11-08T18:43:08Z",
+				"DiscoKey":   "discokey:c3e9c6d8874bcbd8241484e4e2b517c58b4c8850b4df1acb84f17e1a2324d224",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34174",
+					"10.65.0.27:34174",
+					"172.17.0.1:34174",
+					"172.19.0.1:34174",
+					"172.20.0.1:34174"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:43:08.964481601Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1e7dcf085f1d9659bc769a9063d1cce6f263621852e94d60c09a8c35265da76c",
+			"MachineKey": "mkey:d0f7482c5bc8b1b11568a1a5edddb4c9f3f39d801488fc1efa7154fa7e4a5936",
+			"Peers": [{
+				"ID":         6705409733160145,
+				"StableID":   "nAbJX7ktMu11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fde66e749b7c9998d7edb8b7229c20448ad4097677d60b91bdd6990ef4e4d463",
+				"DiscoKey":   "discokey:304fed7316a159e19434f07300fc22ba4cd5ded13311d388100aaf941e8bf364",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35297",
+					"10.65.0.27:35297",
+					"172.17.0.1:35297",
+					"172.19.0.1:35297",
+					"172.20.0.1:35297"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:43:02.530048154Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5287052114870279,
+				"StableID":   "nJNSjqtWHi11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:baec9a448c38cd7ab8d1493fe668aaf040a2a8de057f85d83d7f32ea79e3b47d",
+				"DiscoKey":   "discokey:017dae7f7949d565b61236b087188e8250aa2d215831e42c32fbf994e0340a72",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48714",
+					"10.65.0.27:48714",
+					"172.17.0.1:48714",
+					"172.19.0.1:48714",
+					"172.20.0.1:48714"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:43:03.012273454Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         79816518206558,
+				"StableID":   "nK5vPPe9d111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2381afede94000929e55d4334927003e638f36610a056769ab1ce8c30ab8bb1b",
+				"DiscoKey":   "discokey:526d726141ed3ac418866cc0c2a36c4e6e34f3a8cf8f382b9b9394a129f3d312",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34957",
+					"10.65.0.27:34957",
+					"172.17.0.1:34957",
+					"172.19.0.1:34957",
+					"172.20.0.1:34957"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:43:03.559851036Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5712732665356895,
+				"StableID":   "nSNcJQoJcm11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c0508573148420952dc4aa9c8523397179a6b37deb4fabe74e4882c14d804270",
+				"DiscoKey":   "discokey:524a0294c94f761fc0b773f8295bd19f215ca9b43ff9b8e56e9075740a84d16e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56091",
+					"10.65.0.27:56091",
+					"172.17.0.1:56091",
+					"172.19.0.1:56091",
+					"172.20.0.1:56091"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:43:04.108159952Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6690571426423582,
+				"StableID":   "nqeiA3yAFu11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:45534397287c4f9a5e2ce320cbfb510cacac2acda074102b1680d710f44c636a",
+				"DiscoKey":   "discokey:700b2fb1da26d8d2c11bfaa12a798542d63ba3e22cf7bc41a2dfe5f3e85a9e7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:59278",
+					"10.65.0.27:59278",
+					"172.17.0.1:59278",
+					"172.19.0.1:59278",
+					"172.20.0.1:59278"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:43:04.640112917Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6756386465092508,
+				"StableID":   "noQBmJpyku11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:907ba4b6193a07ca1a438e8b5232e3e632654aa3cb7be512336eee05fabd9f59",
+				"DiscoKey":   "discokey:c8b37108d84c450de094db28ac9a61b2011a0704bbe8df855e8fd7b33b1a1062",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53630",
+					"10.65.0.27:53630",
+					"172.17.0.1:53630",
+					"172.19.0.1:53630",
+					"172.20.0.1:53630"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:43:05.198137654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1019520298251466,
+				"StableID":   "nRNFa25kx811CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3278f2afea4315d278ef2bb5c47bb5ab779ab26bea75e2b3f48a1a8221e8454a",
+				"DiscoKey":   "discokey:c1ea4049bc5c08266c6fd2d8b5c1070814a727f409f0542e99362116fd677b1c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40735",
+					"10.65.0.27:40735",
+					"172.17.0.1:40735",
+					"172.19.0.1:40735",
+					"172.20.0.1:40735"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:43:05.753721108Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6903507164049026,
+				"StableID":   "nB1y8mRcuv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:840896b2fa09524a1b1f39617bfa49c58d4704f6bc6750cc36655e3aba9db113",
+				"DiscoKey":   "discokey:cf362e1457f1c567869297231db070f8c85c21c36a7289e80295bbaea088980e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46595",
+					"10.65.0.27:46595",
+					"172.17.0.1:46595",
+					"172.19.0.1:46595",
+					"172.20.0.1:46595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:43:06.258894294Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6565375780553687,
+				"StableID":   "nNLxekHUGt11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6b7a30b3ab7a8cc19add7e6179b84696df44443c5b1bf0b061150b8165c8903a",
+				"DiscoKey":   "discokey:07f6b591ba2a1d71ea81cf488aabc0266f9e765700e5c8338fea3c1c3e201412",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44689",
+					"10.65.0.27:44689",
+					"172.17.0.1:44689",
+					"172.19.0.1:44689",
+					"172.20.0.1:44689"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:43:06.78817179Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2332046482957184,
+				"StableID":   "nRotyauBDK11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9eb470f6cc3ba0293380a716ed8c876a3f4200a12264e01e06a1c58e12db7b44",
+				"DiscoKey":   "discokey:1156ff43993479cdc3d22e187ad2d37948e7dbca1899730f122963083c669e4a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53835",
+					"10.65.0.27:53835",
+					"172.17.0.1:53835",
+					"172.19.0.1:53835",
+					"172.20.0.1:53835"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:43:07.339293656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7669499834085359,
+				"StableID":   "nQwSNpkXt221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:894dcc7ae88f88b5a0a633ae4b61b0c879d22c947571ce024235a78e22fa692a",
+				"DiscoKey":   "discokey:55a28e63f72717d92e76ef381e5e852c8d8a935bcd9cf6f4a688553fb9d8ef62",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35663",
+					"10.65.0.27:35663",
+					"172.17.0.1:35663",
+					"172.19.0.1:35663",
+					"172.20.0.1:35663"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:43:07.877874763Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1778563694427652,
+				"StableID":   "nPkjGSrWtE11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c6247aaf6ec419e6a20e3b14b8e214e14ea0229ba5243fc2cb5178169794d219",
+				"DiscoKey":   "discokey:9729bf0df16ed58b29fe665ef75bdcdbc62bf5c1f5f1fa8899d51da1b69ecc7a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44311",
+					"10.65.0.27:44311",
+					"172.17.0.1:44311",
+					"172.19.0.1:44311",
+					"172.20.0.1:44311"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:43:08.424953265Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7188264267484786,
+				"StableID":   "nDxFGmWa8y11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a57c4a640749272e957cab5d7c3e8ae76159f4a13aa75184629e872192a78118",
+				"KeyExpiry":  "2026-11-08T18:43:09Z",
+				"DiscoKey":   "discokey:26b8dd4873a42f4c6f7844094e2bf45914c6931c333a9485123fe48f9ac96671",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:56939",
+					"10.65.0.27:56939",
+					"172.17.0.1:56939",
+					"172.19.0.1:56939",
+					"172.20.0.1:56939"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:43:09.506238145Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7701579901160944,
+				"StableID":   "nskZ3nS49321CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:db8ccc084baa7b619714f5f7f372dd6d25bb61a0cc556613fa9df7b9a1b3506e",
+				"KeyExpiry":  "2026-11-08T18:43:10Z",
+				"DiscoKey":   "discokey:8c82f1b37ce845db036cb145bba82479e8d342822d8f8293944c9ae6fbb30218",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:43733",
+					"10.65.0.27:43733",
+					"172.17.0.1:43733",
+					"172.19.0.1:43733",
+					"172.20.0.1:43733"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:43:10.061206821Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7669499834085359,
+				"StableID":   "nQwSNpkXt221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       7669499834085359,
+				"Key":        "nodekey:894dcc7ae88f88b5a0a633ae4b61b0c879d22c947571ce024235a78e22fa692a",
+				"DiscoKey":   "discokey:55a28e63f72717d92e76ef381e5e852c8d8a935bcd9cf6f4a688553fb9d8ef62",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35663",
+					"10.65.0.27:35663",
+					"172.17.0.1:35663",
+					"172.19.0.1:35663",
+					"172.20.0.1:35663"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:43:07.877874763Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:894dcc7ae88f88b5a0a633ae4b61b0c879d22c947571ce024235a78e22fa692a",
+			"MachineKey": "mkey:8fc8f873fab89c181cc4f2e51931533a4f6ac5340ef1daf5f65d88e14214cc53",
+			"Peers": [{
+				"ID":         6705409733160145,
+				"StableID":   "nAbJX7ktMu11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fde66e749b7c9998d7edb8b7229c20448ad4097677d60b91bdd6990ef4e4d463",
+				"DiscoKey":   "discokey:304fed7316a159e19434f07300fc22ba4cd5ded13311d388100aaf941e8bf364",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35297",
+					"10.65.0.27:35297",
+					"172.17.0.1:35297",
+					"172.19.0.1:35297",
+					"172.20.0.1:35297"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:43:02.530048154Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5287052114870279,
+				"StableID":   "nJNSjqtWHi11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:baec9a448c38cd7ab8d1493fe668aaf040a2a8de057f85d83d7f32ea79e3b47d",
+				"DiscoKey":   "discokey:017dae7f7949d565b61236b087188e8250aa2d215831e42c32fbf994e0340a72",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48714",
+					"10.65.0.27:48714",
+					"172.17.0.1:48714",
+					"172.19.0.1:48714",
+					"172.20.0.1:48714"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:43:03.012273454Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         79816518206558,
+				"StableID":   "nK5vPPe9d111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2381afede94000929e55d4334927003e638f36610a056769ab1ce8c30ab8bb1b",
+				"DiscoKey":   "discokey:526d726141ed3ac418866cc0c2a36c4e6e34f3a8cf8f382b9b9394a129f3d312",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34957",
+					"10.65.0.27:34957",
+					"172.17.0.1:34957",
+					"172.19.0.1:34957",
+					"172.20.0.1:34957"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:43:03.559851036Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5712732665356895,
+				"StableID":   "nSNcJQoJcm11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c0508573148420952dc4aa9c8523397179a6b37deb4fabe74e4882c14d804270",
+				"DiscoKey":   "discokey:524a0294c94f761fc0b773f8295bd19f215ca9b43ff9b8e56e9075740a84d16e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56091",
+					"10.65.0.27:56091",
+					"172.17.0.1:56091",
+					"172.19.0.1:56091",
+					"172.20.0.1:56091"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:43:04.108159952Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6690571426423582,
+				"StableID":   "nqeiA3yAFu11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:45534397287c4f9a5e2ce320cbfb510cacac2acda074102b1680d710f44c636a",
+				"DiscoKey":   "discokey:700b2fb1da26d8d2c11bfaa12a798542d63ba3e22cf7bc41a2dfe5f3e85a9e7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:59278",
+					"10.65.0.27:59278",
+					"172.17.0.1:59278",
+					"172.19.0.1:59278",
+					"172.20.0.1:59278"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:43:04.640112917Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6756386465092508,
+				"StableID":   "noQBmJpyku11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:907ba4b6193a07ca1a438e8b5232e3e632654aa3cb7be512336eee05fabd9f59",
+				"DiscoKey":   "discokey:c8b37108d84c450de094db28ac9a61b2011a0704bbe8df855e8fd7b33b1a1062",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53630",
+					"10.65.0.27:53630",
+					"172.17.0.1:53630",
+					"172.19.0.1:53630",
+					"172.20.0.1:53630"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:43:05.198137654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1019520298251466,
+				"StableID":   "nRNFa25kx811CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3278f2afea4315d278ef2bb5c47bb5ab779ab26bea75e2b3f48a1a8221e8454a",
+				"DiscoKey":   "discokey:c1ea4049bc5c08266c6fd2d8b5c1070814a727f409f0542e99362116fd677b1c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40735",
+					"10.65.0.27:40735",
+					"172.17.0.1:40735",
+					"172.19.0.1:40735",
+					"172.20.0.1:40735"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:43:05.753721108Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6903507164049026,
+				"StableID":   "nB1y8mRcuv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:840896b2fa09524a1b1f39617bfa49c58d4704f6bc6750cc36655e3aba9db113",
+				"DiscoKey":   "discokey:cf362e1457f1c567869297231db070f8c85c21c36a7289e80295bbaea088980e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46595",
+					"10.65.0.27:46595",
+					"172.17.0.1:46595",
+					"172.19.0.1:46595",
+					"172.20.0.1:46595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:43:06.258894294Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6565375780553687,
+				"StableID":   "nNLxekHUGt11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6b7a30b3ab7a8cc19add7e6179b84696df44443c5b1bf0b061150b8165c8903a",
+				"DiscoKey":   "discokey:07f6b591ba2a1d71ea81cf488aabc0266f9e765700e5c8338fea3c1c3e201412",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44689",
+					"10.65.0.27:44689",
+					"172.17.0.1:44689",
+					"172.19.0.1:44689",
+					"172.20.0.1:44689"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:43:06.78817179Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2332046482957184,
+				"StableID":   "nRotyauBDK11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9eb470f6cc3ba0293380a716ed8c876a3f4200a12264e01e06a1c58e12db7b44",
+				"DiscoKey":   "discokey:1156ff43993479cdc3d22e187ad2d37948e7dbca1899730f122963083c669e4a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53835",
+					"10.65.0.27:53835",
+					"172.17.0.1:53835",
+					"172.19.0.1:53835",
+					"172.20.0.1:53835"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:43:07.339293656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1778563694427652,
+				"StableID":   "nPkjGSrWtE11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c6247aaf6ec419e6a20e3b14b8e214e14ea0229ba5243fc2cb5178169794d219",
+				"DiscoKey":   "discokey:9729bf0df16ed58b29fe665ef75bdcdbc62bf5c1f5f1fa8899d51da1b69ecc7a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44311",
+					"10.65.0.27:44311",
+					"172.17.0.1:44311",
+					"172.19.0.1:44311",
+					"172.20.0.1:44311"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:43:08.424953265Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3450710695312138,
+				"StableID":   "nK3zjUKqwT11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1e7dcf085f1d9659bc769a9063d1cce6f263621852e94d60c09a8c35265da76c",
+				"KeyExpiry":  "2026-11-08T18:43:08Z",
+				"DiscoKey":   "discokey:c3e9c6d8874bcbd8241484e4e2b517c58b4c8850b4df1acb84f17e1a2324d224",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34174",
+					"10.65.0.27:34174",
+					"172.17.0.1:34174",
+					"172.19.0.1:34174",
+					"172.20.0.1:34174"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:43:08.964481601Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7188264267484786,
+				"StableID":   "nDxFGmWa8y11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a57c4a640749272e957cab5d7c3e8ae76159f4a13aa75184629e872192a78118",
+				"KeyExpiry":  "2026-11-08T18:43:09Z",
+				"DiscoKey":   "discokey:26b8dd4873a42f4c6f7844094e2bf45914c6931c333a9485123fe48f9ac96671",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:56939",
+					"10.65.0.27:56939",
+					"172.17.0.1:56939",
+					"172.19.0.1:56939",
+					"172.20.0.1:56939"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:43:09.506238145Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7701579901160944,
+				"StableID":   "nskZ3nS49321CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:db8ccc084baa7b619714f5f7f372dd6d25bb61a0cc556613fa9df7b9a1b3506e",
+				"KeyExpiry":  "2026-11-08T18:43:10Z",
+				"DiscoKey":   "discokey:8c82f1b37ce845db036cb145bba82479e8d342822d8f8293944c9ae6fbb30218",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:43733",
+					"10.65.0.27:43733",
+					"172.17.0.1:43733",
+					"172.19.0.1:43733",
+					"172.20.0.1:43733"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:43:10.061206821Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7669499834085359": {
+				"ID":          7669499834085359,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5287052114870279,
+				"StableID":   "nJNSjqtWHi11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       5287052114870279,
+				"Key":        "nodekey:baec9a448c38cd7ab8d1493fe668aaf040a2a8de057f85d83d7f32ea79e3b47d",
+				"DiscoKey":   "discokey:017dae7f7949d565b61236b087188e8250aa2d215831e42c32fbf994e0340a72",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48714",
+					"10.65.0.27:48714",
+					"172.17.0.1:48714",
+					"172.19.0.1:48714",
+					"172.20.0.1:48714"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:43:03.012273454Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:baec9a448c38cd7ab8d1493fe668aaf040a2a8de057f85d83d7f32ea79e3b47d",
+			"MachineKey": "mkey:d144445c265ca6a3aa4588d2637b9c828a23a4fe2846ad97ccef944f28c5181b",
+			"Peers": [{
+				"ID":         6705409733160145,
+				"StableID":   "nAbJX7ktMu11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fde66e749b7c9998d7edb8b7229c20448ad4097677d60b91bdd6990ef4e4d463",
+				"DiscoKey":   "discokey:304fed7316a159e19434f07300fc22ba4cd5ded13311d388100aaf941e8bf364",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35297",
+					"10.65.0.27:35297",
+					"172.17.0.1:35297",
+					"172.19.0.1:35297",
+					"172.20.0.1:35297"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:43:02.530048154Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         79816518206558,
+				"StableID":   "nK5vPPe9d111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2381afede94000929e55d4334927003e638f36610a056769ab1ce8c30ab8bb1b",
+				"DiscoKey":   "discokey:526d726141ed3ac418866cc0c2a36c4e6e34f3a8cf8f382b9b9394a129f3d312",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34957",
+					"10.65.0.27:34957",
+					"172.17.0.1:34957",
+					"172.19.0.1:34957",
+					"172.20.0.1:34957"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:43:03.559851036Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5712732665356895,
+				"StableID":   "nSNcJQoJcm11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c0508573148420952dc4aa9c8523397179a6b37deb4fabe74e4882c14d804270",
+				"DiscoKey":   "discokey:524a0294c94f761fc0b773f8295bd19f215ca9b43ff9b8e56e9075740a84d16e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56091",
+					"10.65.0.27:56091",
+					"172.17.0.1:56091",
+					"172.19.0.1:56091",
+					"172.20.0.1:56091"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:43:04.108159952Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6690571426423582,
+				"StableID":   "nqeiA3yAFu11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:45534397287c4f9a5e2ce320cbfb510cacac2acda074102b1680d710f44c636a",
+				"DiscoKey":   "discokey:700b2fb1da26d8d2c11bfaa12a798542d63ba3e22cf7bc41a2dfe5f3e85a9e7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:59278",
+					"10.65.0.27:59278",
+					"172.17.0.1:59278",
+					"172.19.0.1:59278",
+					"172.20.0.1:59278"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:43:04.640112917Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6756386465092508,
+				"StableID":   "noQBmJpyku11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:907ba4b6193a07ca1a438e8b5232e3e632654aa3cb7be512336eee05fabd9f59",
+				"DiscoKey":   "discokey:c8b37108d84c450de094db28ac9a61b2011a0704bbe8df855e8fd7b33b1a1062",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53630",
+					"10.65.0.27:53630",
+					"172.17.0.1:53630",
+					"172.19.0.1:53630",
+					"172.20.0.1:53630"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:43:05.198137654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1019520298251466,
+				"StableID":   "nRNFa25kx811CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3278f2afea4315d278ef2bb5c47bb5ab779ab26bea75e2b3f48a1a8221e8454a",
+				"DiscoKey":   "discokey:c1ea4049bc5c08266c6fd2d8b5c1070814a727f409f0542e99362116fd677b1c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40735",
+					"10.65.0.27:40735",
+					"172.17.0.1:40735",
+					"172.19.0.1:40735",
+					"172.20.0.1:40735"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:43:05.753721108Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6903507164049026,
+				"StableID":   "nB1y8mRcuv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:840896b2fa09524a1b1f39617bfa49c58d4704f6bc6750cc36655e3aba9db113",
+				"DiscoKey":   "discokey:cf362e1457f1c567869297231db070f8c85c21c36a7289e80295bbaea088980e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46595",
+					"10.65.0.27:46595",
+					"172.17.0.1:46595",
+					"172.19.0.1:46595",
+					"172.20.0.1:46595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:43:06.258894294Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6565375780553687,
+				"StableID":   "nNLxekHUGt11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6b7a30b3ab7a8cc19add7e6179b84696df44443c5b1bf0b061150b8165c8903a",
+				"DiscoKey":   "discokey:07f6b591ba2a1d71ea81cf488aabc0266f9e765700e5c8338fea3c1c3e201412",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44689",
+					"10.65.0.27:44689",
+					"172.17.0.1:44689",
+					"172.19.0.1:44689",
+					"172.20.0.1:44689"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:43:06.78817179Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2332046482957184,
+				"StableID":   "nRotyauBDK11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9eb470f6cc3ba0293380a716ed8c876a3f4200a12264e01e06a1c58e12db7b44",
+				"DiscoKey":   "discokey:1156ff43993479cdc3d22e187ad2d37948e7dbca1899730f122963083c669e4a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53835",
+					"10.65.0.27:53835",
+					"172.17.0.1:53835",
+					"172.19.0.1:53835",
+					"172.20.0.1:53835"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:43:07.339293656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7669499834085359,
+				"StableID":   "nQwSNpkXt221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:894dcc7ae88f88b5a0a633ae4b61b0c879d22c947571ce024235a78e22fa692a",
+				"DiscoKey":   "discokey:55a28e63f72717d92e76ef381e5e852c8d8a935bcd9cf6f4a688553fb9d8ef62",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35663",
+					"10.65.0.27:35663",
+					"172.17.0.1:35663",
+					"172.19.0.1:35663",
+					"172.20.0.1:35663"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:43:07.877874763Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1778563694427652,
+				"StableID":   "nPkjGSrWtE11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c6247aaf6ec419e6a20e3b14b8e214e14ea0229ba5243fc2cb5178169794d219",
+				"DiscoKey":   "discokey:9729bf0df16ed58b29fe665ef75bdcdbc62bf5c1f5f1fa8899d51da1b69ecc7a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44311",
+					"10.65.0.27:44311",
+					"172.17.0.1:44311",
+					"172.19.0.1:44311",
+					"172.20.0.1:44311"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:43:08.424953265Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3450710695312138,
+				"StableID":   "nK3zjUKqwT11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1e7dcf085f1d9659bc769a9063d1cce6f263621852e94d60c09a8c35265da76c",
+				"KeyExpiry":  "2026-11-08T18:43:08Z",
+				"DiscoKey":   "discokey:c3e9c6d8874bcbd8241484e4e2b517c58b4c8850b4df1acb84f17e1a2324d224",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34174",
+					"10.65.0.27:34174",
+					"172.17.0.1:34174",
+					"172.19.0.1:34174",
+					"172.20.0.1:34174"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:43:08.964481601Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7188264267484786,
+				"StableID":   "nDxFGmWa8y11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a57c4a640749272e957cab5d7c3e8ae76159f4a13aa75184629e872192a78118",
+				"KeyExpiry":  "2026-11-08T18:43:09Z",
+				"DiscoKey":   "discokey:26b8dd4873a42f4c6f7844094e2bf45914c6931c333a9485123fe48f9ac96671",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:56939",
+					"10.65.0.27:56939",
+					"172.17.0.1:56939",
+					"172.19.0.1:56939",
+					"172.20.0.1:56939"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:43:09.506238145Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7701579901160944,
+				"StableID":   "nskZ3nS49321CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:db8ccc084baa7b619714f5f7f372dd6d25bb61a0cc556613fa9df7b9a1b3506e",
+				"KeyExpiry":  "2026-11-08T18:43:10Z",
+				"DiscoKey":   "discokey:8c82f1b37ce845db036cb145bba82479e8d342822d8f8293944c9ae6fbb30218",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:43733",
+					"10.65.0.27:43733",
+					"172.17.0.1:43733",
+					"172.19.0.1:43733",
+					"172.20.0.1:43733"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:43:10.061206821Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5287052114870279": {
+				"ID":          5287052114870279,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6705409733160145,
+				"StableID":   "nAbJX7ktMu11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       6705409733160145,
+				"Key":        "nodekey:fde66e749b7c9998d7edb8b7229c20448ad4097677d60b91bdd6990ef4e4d463",
+				"DiscoKey":   "discokey:304fed7316a159e19434f07300fc22ba4cd5ded13311d388100aaf941e8bf364",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35297",
+					"10.65.0.27:35297",
+					"172.17.0.1:35297",
+					"172.19.0.1:35297",
+					"172.20.0.1:35297"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:43:02.530048154Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:fde66e749b7c9998d7edb8b7229c20448ad4097677d60b91bdd6990ef4e4d463",
+			"MachineKey": "mkey:f122b7bbe606ae5917f4a8db309ef9db241a0a6d9c490adcef5569b6d858e03a",
+			"Peers": [{
+				"ID":         5287052114870279,
+				"StableID":   "nJNSjqtWHi11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:baec9a448c38cd7ab8d1493fe668aaf040a2a8de057f85d83d7f32ea79e3b47d",
+				"DiscoKey":   "discokey:017dae7f7949d565b61236b087188e8250aa2d215831e42c32fbf994e0340a72",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48714",
+					"10.65.0.27:48714",
+					"172.17.0.1:48714",
+					"172.19.0.1:48714",
+					"172.20.0.1:48714"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:43:03.012273454Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         79816518206558,
+				"StableID":   "nK5vPPe9d111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2381afede94000929e55d4334927003e638f36610a056769ab1ce8c30ab8bb1b",
+				"DiscoKey":   "discokey:526d726141ed3ac418866cc0c2a36c4e6e34f3a8cf8f382b9b9394a129f3d312",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34957",
+					"10.65.0.27:34957",
+					"172.17.0.1:34957",
+					"172.19.0.1:34957",
+					"172.20.0.1:34957"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:43:03.559851036Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5712732665356895,
+				"StableID":   "nSNcJQoJcm11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c0508573148420952dc4aa9c8523397179a6b37deb4fabe74e4882c14d804270",
+				"DiscoKey":   "discokey:524a0294c94f761fc0b773f8295bd19f215ca9b43ff9b8e56e9075740a84d16e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56091",
+					"10.65.0.27:56091",
+					"172.17.0.1:56091",
+					"172.19.0.1:56091",
+					"172.20.0.1:56091"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:43:04.108159952Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6690571426423582,
+				"StableID":   "nqeiA3yAFu11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:45534397287c4f9a5e2ce320cbfb510cacac2acda074102b1680d710f44c636a",
+				"DiscoKey":   "discokey:700b2fb1da26d8d2c11bfaa12a798542d63ba3e22cf7bc41a2dfe5f3e85a9e7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:59278",
+					"10.65.0.27:59278",
+					"172.17.0.1:59278",
+					"172.19.0.1:59278",
+					"172.20.0.1:59278"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:43:04.640112917Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6756386465092508,
+				"StableID":   "noQBmJpyku11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:907ba4b6193a07ca1a438e8b5232e3e632654aa3cb7be512336eee05fabd9f59",
+				"DiscoKey":   "discokey:c8b37108d84c450de094db28ac9a61b2011a0704bbe8df855e8fd7b33b1a1062",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53630",
+					"10.65.0.27:53630",
+					"172.17.0.1:53630",
+					"172.19.0.1:53630",
+					"172.20.0.1:53630"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:43:05.198137654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1019520298251466,
+				"StableID":   "nRNFa25kx811CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3278f2afea4315d278ef2bb5c47bb5ab779ab26bea75e2b3f48a1a8221e8454a",
+				"DiscoKey":   "discokey:c1ea4049bc5c08266c6fd2d8b5c1070814a727f409f0542e99362116fd677b1c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40735",
+					"10.65.0.27:40735",
+					"172.17.0.1:40735",
+					"172.19.0.1:40735",
+					"172.20.0.1:40735"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:43:05.753721108Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6903507164049026,
+				"StableID":   "nB1y8mRcuv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:840896b2fa09524a1b1f39617bfa49c58d4704f6bc6750cc36655e3aba9db113",
+				"DiscoKey":   "discokey:cf362e1457f1c567869297231db070f8c85c21c36a7289e80295bbaea088980e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46595",
+					"10.65.0.27:46595",
+					"172.17.0.1:46595",
+					"172.19.0.1:46595",
+					"172.20.0.1:46595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:43:06.258894294Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6565375780553687,
+				"StableID":   "nNLxekHUGt11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6b7a30b3ab7a8cc19add7e6179b84696df44443c5b1bf0b061150b8165c8903a",
+				"DiscoKey":   "discokey:07f6b591ba2a1d71ea81cf488aabc0266f9e765700e5c8338fea3c1c3e201412",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44689",
+					"10.65.0.27:44689",
+					"172.17.0.1:44689",
+					"172.19.0.1:44689",
+					"172.20.0.1:44689"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:43:06.78817179Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2332046482957184,
+				"StableID":   "nRotyauBDK11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9eb470f6cc3ba0293380a716ed8c876a3f4200a12264e01e06a1c58e12db7b44",
+				"DiscoKey":   "discokey:1156ff43993479cdc3d22e187ad2d37948e7dbca1899730f122963083c669e4a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53835",
+					"10.65.0.27:53835",
+					"172.17.0.1:53835",
+					"172.19.0.1:53835",
+					"172.20.0.1:53835"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:43:07.339293656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7669499834085359,
+				"StableID":   "nQwSNpkXt221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:894dcc7ae88f88b5a0a633ae4b61b0c879d22c947571ce024235a78e22fa692a",
+				"DiscoKey":   "discokey:55a28e63f72717d92e76ef381e5e852c8d8a935bcd9cf6f4a688553fb9d8ef62",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35663",
+					"10.65.0.27:35663",
+					"172.17.0.1:35663",
+					"172.19.0.1:35663",
+					"172.20.0.1:35663"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:43:07.877874763Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1778563694427652,
+				"StableID":   "nPkjGSrWtE11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c6247aaf6ec419e6a20e3b14b8e214e14ea0229ba5243fc2cb5178169794d219",
+				"DiscoKey":   "discokey:9729bf0df16ed58b29fe665ef75bdcdbc62bf5c1f5f1fa8899d51da1b69ecc7a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44311",
+					"10.65.0.27:44311",
+					"172.17.0.1:44311",
+					"172.19.0.1:44311",
+					"172.20.0.1:44311"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:43:08.424953265Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3450710695312138,
+				"StableID":   "nK3zjUKqwT11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1e7dcf085f1d9659bc769a9063d1cce6f263621852e94d60c09a8c35265da76c",
+				"KeyExpiry":  "2026-11-08T18:43:08Z",
+				"DiscoKey":   "discokey:c3e9c6d8874bcbd8241484e4e2b517c58b4c8850b4df1acb84f17e1a2324d224",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34174",
+					"10.65.0.27:34174",
+					"172.17.0.1:34174",
+					"172.19.0.1:34174",
+					"172.20.0.1:34174"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:43:08.964481601Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7188264267484786,
+				"StableID":   "nDxFGmWa8y11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a57c4a640749272e957cab5d7c3e8ae76159f4a13aa75184629e872192a78118",
+				"KeyExpiry":  "2026-11-08T18:43:09Z",
+				"DiscoKey":   "discokey:26b8dd4873a42f4c6f7844094e2bf45914c6931c333a9485123fe48f9ac96671",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:56939",
+					"10.65.0.27:56939",
+					"172.17.0.1:56939",
+					"172.19.0.1:56939",
+					"172.20.0.1:56939"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:43:09.506238145Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7701579901160944,
+				"StableID":   "nskZ3nS49321CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:db8ccc084baa7b619714f5f7f372dd6d25bb61a0cc556613fa9df7b9a1b3506e",
+				"KeyExpiry":  "2026-11-08T18:43:10Z",
+				"DiscoKey":   "discokey:8c82f1b37ce845db036cb145bba82479e8d342822d8f8293944c9ae6fbb30218",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:43733",
+					"10.65.0.27:43733",
+					"172.17.0.1:43733",
+					"172.19.0.1:43733",
+					"172.20.0.1:43733"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:43:10.061206821Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6705409733160145": {
+				"ID":          6705409733160145,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6690571426423582,
+				"StableID":   "nqeiA3yAFu11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       6690571426423582,
+				"Key":        "nodekey:45534397287c4f9a5e2ce320cbfb510cacac2acda074102b1680d710f44c636a",
+				"DiscoKey":   "discokey:700b2fb1da26d8d2c11bfaa12a798542d63ba3e22cf7bc41a2dfe5f3e85a9e7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:59278",
+					"10.65.0.27:59278",
+					"172.17.0.1:59278",
+					"172.19.0.1:59278",
+					"172.20.0.1:59278"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:43:04.640112917Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:45534397287c4f9a5e2ce320cbfb510cacac2acda074102b1680d710f44c636a",
+			"MachineKey": "mkey:2a9ddff394dda2309c8f564c19d2ffd2701c2db2aa68ec21ffdba8057600763c",
+			"Peers": [{
+				"ID":         6705409733160145,
+				"StableID":   "nAbJX7ktMu11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fde66e749b7c9998d7edb8b7229c20448ad4097677d60b91bdd6990ef4e4d463",
+				"DiscoKey":   "discokey:304fed7316a159e19434f07300fc22ba4cd5ded13311d388100aaf941e8bf364",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35297",
+					"10.65.0.27:35297",
+					"172.17.0.1:35297",
+					"172.19.0.1:35297",
+					"172.20.0.1:35297"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:43:02.530048154Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5287052114870279,
+				"StableID":   "nJNSjqtWHi11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:baec9a448c38cd7ab8d1493fe668aaf040a2a8de057f85d83d7f32ea79e3b47d",
+				"DiscoKey":   "discokey:017dae7f7949d565b61236b087188e8250aa2d215831e42c32fbf994e0340a72",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48714",
+					"10.65.0.27:48714",
+					"172.17.0.1:48714",
+					"172.19.0.1:48714",
+					"172.20.0.1:48714"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:43:03.012273454Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         79816518206558,
+				"StableID":   "nK5vPPe9d111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2381afede94000929e55d4334927003e638f36610a056769ab1ce8c30ab8bb1b",
+				"DiscoKey":   "discokey:526d726141ed3ac418866cc0c2a36c4e6e34f3a8cf8f382b9b9394a129f3d312",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34957",
+					"10.65.0.27:34957",
+					"172.17.0.1:34957",
+					"172.19.0.1:34957",
+					"172.20.0.1:34957"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:43:03.559851036Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5712732665356895,
+				"StableID":   "nSNcJQoJcm11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c0508573148420952dc4aa9c8523397179a6b37deb4fabe74e4882c14d804270",
+				"DiscoKey":   "discokey:524a0294c94f761fc0b773f8295bd19f215ca9b43ff9b8e56e9075740a84d16e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56091",
+					"10.65.0.27:56091",
+					"172.17.0.1:56091",
+					"172.19.0.1:56091",
+					"172.20.0.1:56091"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:43:04.108159952Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6756386465092508,
+				"StableID":   "noQBmJpyku11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:907ba4b6193a07ca1a438e8b5232e3e632654aa3cb7be512336eee05fabd9f59",
+				"DiscoKey":   "discokey:c8b37108d84c450de094db28ac9a61b2011a0704bbe8df855e8fd7b33b1a1062",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53630",
+					"10.65.0.27:53630",
+					"172.17.0.1:53630",
+					"172.19.0.1:53630",
+					"172.20.0.1:53630"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:43:05.198137654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1019520298251466,
+				"StableID":   "nRNFa25kx811CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3278f2afea4315d278ef2bb5c47bb5ab779ab26bea75e2b3f48a1a8221e8454a",
+				"DiscoKey":   "discokey:c1ea4049bc5c08266c6fd2d8b5c1070814a727f409f0542e99362116fd677b1c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40735",
+					"10.65.0.27:40735",
+					"172.17.0.1:40735",
+					"172.19.0.1:40735",
+					"172.20.0.1:40735"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:43:05.753721108Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6903507164049026,
+				"StableID":   "nB1y8mRcuv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:840896b2fa09524a1b1f39617bfa49c58d4704f6bc6750cc36655e3aba9db113",
+				"DiscoKey":   "discokey:cf362e1457f1c567869297231db070f8c85c21c36a7289e80295bbaea088980e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46595",
+					"10.65.0.27:46595",
+					"172.17.0.1:46595",
+					"172.19.0.1:46595",
+					"172.20.0.1:46595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:43:06.258894294Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6565375780553687,
+				"StableID":   "nNLxekHUGt11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6b7a30b3ab7a8cc19add7e6179b84696df44443c5b1bf0b061150b8165c8903a",
+				"DiscoKey":   "discokey:07f6b591ba2a1d71ea81cf488aabc0266f9e765700e5c8338fea3c1c3e201412",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44689",
+					"10.65.0.27:44689",
+					"172.17.0.1:44689",
+					"172.19.0.1:44689",
+					"172.20.0.1:44689"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:43:06.78817179Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2332046482957184,
+				"StableID":   "nRotyauBDK11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9eb470f6cc3ba0293380a716ed8c876a3f4200a12264e01e06a1c58e12db7b44",
+				"DiscoKey":   "discokey:1156ff43993479cdc3d22e187ad2d37948e7dbca1899730f122963083c669e4a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53835",
+					"10.65.0.27:53835",
+					"172.17.0.1:53835",
+					"172.19.0.1:53835",
+					"172.20.0.1:53835"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:43:07.339293656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7669499834085359,
+				"StableID":   "nQwSNpkXt221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:894dcc7ae88f88b5a0a633ae4b61b0c879d22c947571ce024235a78e22fa692a",
+				"DiscoKey":   "discokey:55a28e63f72717d92e76ef381e5e852c8d8a935bcd9cf6f4a688553fb9d8ef62",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35663",
+					"10.65.0.27:35663",
+					"172.17.0.1:35663",
+					"172.19.0.1:35663",
+					"172.20.0.1:35663"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:43:07.877874763Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1778563694427652,
+				"StableID":   "nPkjGSrWtE11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c6247aaf6ec419e6a20e3b14b8e214e14ea0229ba5243fc2cb5178169794d219",
+				"DiscoKey":   "discokey:9729bf0df16ed58b29fe665ef75bdcdbc62bf5c1f5f1fa8899d51da1b69ecc7a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44311",
+					"10.65.0.27:44311",
+					"172.17.0.1:44311",
+					"172.19.0.1:44311",
+					"172.20.0.1:44311"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:43:08.424953265Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3450710695312138,
+				"StableID":   "nK3zjUKqwT11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1e7dcf085f1d9659bc769a9063d1cce6f263621852e94d60c09a8c35265da76c",
+				"KeyExpiry":  "2026-11-08T18:43:08Z",
+				"DiscoKey":   "discokey:c3e9c6d8874bcbd8241484e4e2b517c58b4c8850b4df1acb84f17e1a2324d224",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34174",
+					"10.65.0.27:34174",
+					"172.17.0.1:34174",
+					"172.19.0.1:34174",
+					"172.20.0.1:34174"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:43:08.964481601Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7188264267484786,
+				"StableID":   "nDxFGmWa8y11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a57c4a640749272e957cab5d7c3e8ae76159f4a13aa75184629e872192a78118",
+				"KeyExpiry":  "2026-11-08T18:43:09Z",
+				"DiscoKey":   "discokey:26b8dd4873a42f4c6f7844094e2bf45914c6931c333a9485123fe48f9ac96671",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:56939",
+					"10.65.0.27:56939",
+					"172.17.0.1:56939",
+					"172.19.0.1:56939",
+					"172.20.0.1:56939"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:43:09.506238145Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7701579901160944,
+				"StableID":   "nskZ3nS49321CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:db8ccc084baa7b619714f5f7f372dd6d25bb61a0cc556613fa9df7b9a1b3506e",
+				"KeyExpiry":  "2026-11-08T18:43:10Z",
+				"DiscoKey":   "discokey:8c82f1b37ce845db036cb145bba82479e8d342822d8f8293944c9ae6fbb30218",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:43733",
+					"10.65.0.27:43733",
+					"172.17.0.1:43733",
+					"172.19.0.1:43733",
+					"172.20.0.1:43733"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:43:10.061206821Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6690571426423582": {
+				"ID":          6690571426423582,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5712732665356895,
+				"StableID":   "nSNcJQoJcm11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       5712732665356895,
+				"Key":        "nodekey:c0508573148420952dc4aa9c8523397179a6b37deb4fabe74e4882c14d804270",
+				"DiscoKey":   "discokey:524a0294c94f761fc0b773f8295bd19f215ca9b43ff9b8e56e9075740a84d16e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56091",
+					"10.65.0.27:56091",
+					"172.17.0.1:56091",
+					"172.19.0.1:56091",
+					"172.20.0.1:56091"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:43:04.108159952Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c0508573148420952dc4aa9c8523397179a6b37deb4fabe74e4882c14d804270",
+			"MachineKey": "mkey:84dc1285c92132eb1a33d38fce62709d66e04a7d09ecdc616b12da990c093547",
+			"Peers": [{
+				"ID":         6705409733160145,
+				"StableID":   "nAbJX7ktMu11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fde66e749b7c9998d7edb8b7229c20448ad4097677d60b91bdd6990ef4e4d463",
+				"DiscoKey":   "discokey:304fed7316a159e19434f07300fc22ba4cd5ded13311d388100aaf941e8bf364",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35297",
+					"10.65.0.27:35297",
+					"172.17.0.1:35297",
+					"172.19.0.1:35297",
+					"172.20.0.1:35297"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:43:02.530048154Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5287052114870279,
+				"StableID":   "nJNSjqtWHi11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:baec9a448c38cd7ab8d1493fe668aaf040a2a8de057f85d83d7f32ea79e3b47d",
+				"DiscoKey":   "discokey:017dae7f7949d565b61236b087188e8250aa2d215831e42c32fbf994e0340a72",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48714",
+					"10.65.0.27:48714",
+					"172.17.0.1:48714",
+					"172.19.0.1:48714",
+					"172.20.0.1:48714"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:43:03.012273454Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         79816518206558,
+				"StableID":   "nK5vPPe9d111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2381afede94000929e55d4334927003e638f36610a056769ab1ce8c30ab8bb1b",
+				"DiscoKey":   "discokey:526d726141ed3ac418866cc0c2a36c4e6e34f3a8cf8f382b9b9394a129f3d312",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34957",
+					"10.65.0.27:34957",
+					"172.17.0.1:34957",
+					"172.19.0.1:34957",
+					"172.20.0.1:34957"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:43:03.559851036Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6690571426423582,
+				"StableID":   "nqeiA3yAFu11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:45534397287c4f9a5e2ce320cbfb510cacac2acda074102b1680d710f44c636a",
+				"DiscoKey":   "discokey:700b2fb1da26d8d2c11bfaa12a798542d63ba3e22cf7bc41a2dfe5f3e85a9e7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:59278",
+					"10.65.0.27:59278",
+					"172.17.0.1:59278",
+					"172.19.0.1:59278",
+					"172.20.0.1:59278"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:43:04.640112917Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6756386465092508,
+				"StableID":   "noQBmJpyku11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:907ba4b6193a07ca1a438e8b5232e3e632654aa3cb7be512336eee05fabd9f59",
+				"DiscoKey":   "discokey:c8b37108d84c450de094db28ac9a61b2011a0704bbe8df855e8fd7b33b1a1062",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53630",
+					"10.65.0.27:53630",
+					"172.17.0.1:53630",
+					"172.19.0.1:53630",
+					"172.20.0.1:53630"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:43:05.198137654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1019520298251466,
+				"StableID":   "nRNFa25kx811CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3278f2afea4315d278ef2bb5c47bb5ab779ab26bea75e2b3f48a1a8221e8454a",
+				"DiscoKey":   "discokey:c1ea4049bc5c08266c6fd2d8b5c1070814a727f409f0542e99362116fd677b1c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40735",
+					"10.65.0.27:40735",
+					"172.17.0.1:40735",
+					"172.19.0.1:40735",
+					"172.20.0.1:40735"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:43:05.753721108Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6903507164049026,
+				"StableID":   "nB1y8mRcuv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:840896b2fa09524a1b1f39617bfa49c58d4704f6bc6750cc36655e3aba9db113",
+				"DiscoKey":   "discokey:cf362e1457f1c567869297231db070f8c85c21c36a7289e80295bbaea088980e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46595",
+					"10.65.0.27:46595",
+					"172.17.0.1:46595",
+					"172.19.0.1:46595",
+					"172.20.0.1:46595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:43:06.258894294Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6565375780553687,
+				"StableID":   "nNLxekHUGt11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6b7a30b3ab7a8cc19add7e6179b84696df44443c5b1bf0b061150b8165c8903a",
+				"DiscoKey":   "discokey:07f6b591ba2a1d71ea81cf488aabc0266f9e765700e5c8338fea3c1c3e201412",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44689",
+					"10.65.0.27:44689",
+					"172.17.0.1:44689",
+					"172.19.0.1:44689",
+					"172.20.0.1:44689"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:43:06.78817179Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2332046482957184,
+				"StableID":   "nRotyauBDK11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9eb470f6cc3ba0293380a716ed8c876a3f4200a12264e01e06a1c58e12db7b44",
+				"DiscoKey":   "discokey:1156ff43993479cdc3d22e187ad2d37948e7dbca1899730f122963083c669e4a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53835",
+					"10.65.0.27:53835",
+					"172.17.0.1:53835",
+					"172.19.0.1:53835",
+					"172.20.0.1:53835"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:43:07.339293656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7669499834085359,
+				"StableID":   "nQwSNpkXt221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:894dcc7ae88f88b5a0a633ae4b61b0c879d22c947571ce024235a78e22fa692a",
+				"DiscoKey":   "discokey:55a28e63f72717d92e76ef381e5e852c8d8a935bcd9cf6f4a688553fb9d8ef62",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35663",
+					"10.65.0.27:35663",
+					"172.17.0.1:35663",
+					"172.19.0.1:35663",
+					"172.20.0.1:35663"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:43:07.877874763Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1778563694427652,
+				"StableID":   "nPkjGSrWtE11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c6247aaf6ec419e6a20e3b14b8e214e14ea0229ba5243fc2cb5178169794d219",
+				"DiscoKey":   "discokey:9729bf0df16ed58b29fe665ef75bdcdbc62bf5c1f5f1fa8899d51da1b69ecc7a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44311",
+					"10.65.0.27:44311",
+					"172.17.0.1:44311",
+					"172.19.0.1:44311",
+					"172.20.0.1:44311"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:43:08.424953265Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3450710695312138,
+				"StableID":   "nK3zjUKqwT11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1e7dcf085f1d9659bc769a9063d1cce6f263621852e94d60c09a8c35265da76c",
+				"KeyExpiry":  "2026-11-08T18:43:08Z",
+				"DiscoKey":   "discokey:c3e9c6d8874bcbd8241484e4e2b517c58b4c8850b4df1acb84f17e1a2324d224",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34174",
+					"10.65.0.27:34174",
+					"172.17.0.1:34174",
+					"172.19.0.1:34174",
+					"172.20.0.1:34174"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:43:08.964481601Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7188264267484786,
+				"StableID":   "nDxFGmWa8y11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a57c4a640749272e957cab5d7c3e8ae76159f4a13aa75184629e872192a78118",
+				"KeyExpiry":  "2026-11-08T18:43:09Z",
+				"DiscoKey":   "discokey:26b8dd4873a42f4c6f7844094e2bf45914c6931c333a9485123fe48f9ac96671",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:56939",
+					"10.65.0.27:56939",
+					"172.17.0.1:56939",
+					"172.19.0.1:56939",
+					"172.20.0.1:56939"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:43:09.506238145Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7701579901160944,
+				"StableID":   "nskZ3nS49321CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:db8ccc084baa7b619714f5f7f372dd6d25bb61a0cc556613fa9df7b9a1b3506e",
+				"KeyExpiry":  "2026-11-08T18:43:10Z",
+				"DiscoKey":   "discokey:8c82f1b37ce845db036cb145bba82479e8d342822d8f8293944c9ae6fbb30218",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:43733",
+					"10.65.0.27:43733",
+					"172.17.0.1:43733",
+					"172.19.0.1:43733",
+					"172.20.0.1:43733"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:43:10.061206821Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5712732665356895": {
+				"ID":          5712732665356895,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1019520298251466,
+				"StableID":   "nRNFa25kx811CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1019520298251466,
+				"Key":        "nodekey:3278f2afea4315d278ef2bb5c47bb5ab779ab26bea75e2b3f48a1a8221e8454a",
+				"DiscoKey":   "discokey:c1ea4049bc5c08266c6fd2d8b5c1070814a727f409f0542e99362116fd677b1c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40735",
+					"10.65.0.27:40735",
+					"172.17.0.1:40735",
+					"172.19.0.1:40735",
+					"172.20.0.1:40735"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:43:05.753721108Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3278f2afea4315d278ef2bb5c47bb5ab779ab26bea75e2b3f48a1a8221e8454a",
+			"MachineKey": "mkey:e7e244ef1484aaaea4749c711085900ee0427eee4cb284732c950451ebfb764a",
+			"Peers": [{
+				"ID":         6705409733160145,
+				"StableID":   "nAbJX7ktMu11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fde66e749b7c9998d7edb8b7229c20448ad4097677d60b91bdd6990ef4e4d463",
+				"DiscoKey":   "discokey:304fed7316a159e19434f07300fc22ba4cd5ded13311d388100aaf941e8bf364",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35297",
+					"10.65.0.27:35297",
+					"172.17.0.1:35297",
+					"172.19.0.1:35297",
+					"172.20.0.1:35297"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:43:02.530048154Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5287052114870279,
+				"StableID":   "nJNSjqtWHi11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:baec9a448c38cd7ab8d1493fe668aaf040a2a8de057f85d83d7f32ea79e3b47d",
+				"DiscoKey":   "discokey:017dae7f7949d565b61236b087188e8250aa2d215831e42c32fbf994e0340a72",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48714",
+					"10.65.0.27:48714",
+					"172.17.0.1:48714",
+					"172.19.0.1:48714",
+					"172.20.0.1:48714"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:43:03.012273454Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         79816518206558,
+				"StableID":   "nK5vPPe9d111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2381afede94000929e55d4334927003e638f36610a056769ab1ce8c30ab8bb1b",
+				"DiscoKey":   "discokey:526d726141ed3ac418866cc0c2a36c4e6e34f3a8cf8f382b9b9394a129f3d312",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34957",
+					"10.65.0.27:34957",
+					"172.17.0.1:34957",
+					"172.19.0.1:34957",
+					"172.20.0.1:34957"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:43:03.559851036Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5712732665356895,
+				"StableID":   "nSNcJQoJcm11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c0508573148420952dc4aa9c8523397179a6b37deb4fabe74e4882c14d804270",
+				"DiscoKey":   "discokey:524a0294c94f761fc0b773f8295bd19f215ca9b43ff9b8e56e9075740a84d16e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56091",
+					"10.65.0.27:56091",
+					"172.17.0.1:56091",
+					"172.19.0.1:56091",
+					"172.20.0.1:56091"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:43:04.108159952Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6690571426423582,
+				"StableID":   "nqeiA3yAFu11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:45534397287c4f9a5e2ce320cbfb510cacac2acda074102b1680d710f44c636a",
+				"DiscoKey":   "discokey:700b2fb1da26d8d2c11bfaa12a798542d63ba3e22cf7bc41a2dfe5f3e85a9e7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:59278",
+					"10.65.0.27:59278",
+					"172.17.0.1:59278",
+					"172.19.0.1:59278",
+					"172.20.0.1:59278"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:43:04.640112917Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6756386465092508,
+				"StableID":   "noQBmJpyku11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:907ba4b6193a07ca1a438e8b5232e3e632654aa3cb7be512336eee05fabd9f59",
+				"DiscoKey":   "discokey:c8b37108d84c450de094db28ac9a61b2011a0704bbe8df855e8fd7b33b1a1062",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53630",
+					"10.65.0.27:53630",
+					"172.17.0.1:53630",
+					"172.19.0.1:53630",
+					"172.20.0.1:53630"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:43:05.198137654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6903507164049026,
+				"StableID":   "nB1y8mRcuv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:840896b2fa09524a1b1f39617bfa49c58d4704f6bc6750cc36655e3aba9db113",
+				"DiscoKey":   "discokey:cf362e1457f1c567869297231db070f8c85c21c36a7289e80295bbaea088980e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46595",
+					"10.65.0.27:46595",
+					"172.17.0.1:46595",
+					"172.19.0.1:46595",
+					"172.20.0.1:46595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:43:06.258894294Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6565375780553687,
+				"StableID":   "nNLxekHUGt11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6b7a30b3ab7a8cc19add7e6179b84696df44443c5b1bf0b061150b8165c8903a",
+				"DiscoKey":   "discokey:07f6b591ba2a1d71ea81cf488aabc0266f9e765700e5c8338fea3c1c3e201412",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44689",
+					"10.65.0.27:44689",
+					"172.17.0.1:44689",
+					"172.19.0.1:44689",
+					"172.20.0.1:44689"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:43:06.78817179Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2332046482957184,
+				"StableID":   "nRotyauBDK11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9eb470f6cc3ba0293380a716ed8c876a3f4200a12264e01e06a1c58e12db7b44",
+				"DiscoKey":   "discokey:1156ff43993479cdc3d22e187ad2d37948e7dbca1899730f122963083c669e4a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53835",
+					"10.65.0.27:53835",
+					"172.17.0.1:53835",
+					"172.19.0.1:53835",
+					"172.20.0.1:53835"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:43:07.339293656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7669499834085359,
+				"StableID":   "nQwSNpkXt221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:894dcc7ae88f88b5a0a633ae4b61b0c879d22c947571ce024235a78e22fa692a",
+				"DiscoKey":   "discokey:55a28e63f72717d92e76ef381e5e852c8d8a935bcd9cf6f4a688553fb9d8ef62",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35663",
+					"10.65.0.27:35663",
+					"172.17.0.1:35663",
+					"172.19.0.1:35663",
+					"172.20.0.1:35663"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:43:07.877874763Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1778563694427652,
+				"StableID":   "nPkjGSrWtE11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c6247aaf6ec419e6a20e3b14b8e214e14ea0229ba5243fc2cb5178169794d219",
+				"DiscoKey":   "discokey:9729bf0df16ed58b29fe665ef75bdcdbc62bf5c1f5f1fa8899d51da1b69ecc7a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44311",
+					"10.65.0.27:44311",
+					"172.17.0.1:44311",
+					"172.19.0.1:44311",
+					"172.20.0.1:44311"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:43:08.424953265Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3450710695312138,
+				"StableID":   "nK3zjUKqwT11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1e7dcf085f1d9659bc769a9063d1cce6f263621852e94d60c09a8c35265da76c",
+				"KeyExpiry":  "2026-11-08T18:43:08Z",
+				"DiscoKey":   "discokey:c3e9c6d8874bcbd8241484e4e2b517c58b4c8850b4df1acb84f17e1a2324d224",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34174",
+					"10.65.0.27:34174",
+					"172.17.0.1:34174",
+					"172.19.0.1:34174",
+					"172.20.0.1:34174"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:43:08.964481601Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7188264267484786,
+				"StableID":   "nDxFGmWa8y11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a57c4a640749272e957cab5d7c3e8ae76159f4a13aa75184629e872192a78118",
+				"KeyExpiry":  "2026-11-08T18:43:09Z",
+				"DiscoKey":   "discokey:26b8dd4873a42f4c6f7844094e2bf45914c6931c333a9485123fe48f9ac96671",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:56939",
+					"10.65.0.27:56939",
+					"172.17.0.1:56939",
+					"172.19.0.1:56939",
+					"172.20.0.1:56939"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:43:09.506238145Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7701579901160944,
+				"StableID":   "nskZ3nS49321CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:db8ccc084baa7b619714f5f7f372dd6d25bb61a0cc556613fa9df7b9a1b3506e",
+				"KeyExpiry":  "2026-11-08T18:43:10Z",
+				"DiscoKey":   "discokey:8c82f1b37ce845db036cb145bba82479e8d342822d8f8293944c9ae6fbb30218",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:43733",
+					"10.65.0.27:43733",
+					"172.17.0.1:43733",
+					"172.19.0.1:43733",
+					"172.20.0.1:43733"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:43:10.061206821Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1019520298251466": {
+				"ID":          1019520298251466,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}, "1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6565375780553687,
+				"StableID":   "nNLxekHUGt11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       6565375780553687,
+				"Key":        "nodekey:6b7a30b3ab7a8cc19add7e6179b84696df44443c5b1bf0b061150b8165c8903a",
+				"DiscoKey":   "discokey:07f6b591ba2a1d71ea81cf488aabc0266f9e765700e5c8338fea3c1c3e201412",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44689",
+					"10.65.0.27:44689",
+					"172.17.0.1:44689",
+					"172.19.0.1:44689",
+					"172.20.0.1:44689"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:43:06.78817179Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6b7a30b3ab7a8cc19add7e6179b84696df44443c5b1bf0b061150b8165c8903a",
+			"MachineKey": "mkey:c26e7779a143f999810cf5db83ab3468ebe2398bbc3bf25893e0b908d7d5f17f",
+			"Peers": [{
+				"ID":         6705409733160145,
+				"StableID":   "nAbJX7ktMu11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fde66e749b7c9998d7edb8b7229c20448ad4097677d60b91bdd6990ef4e4d463",
+				"DiscoKey":   "discokey:304fed7316a159e19434f07300fc22ba4cd5ded13311d388100aaf941e8bf364",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35297",
+					"10.65.0.27:35297",
+					"172.17.0.1:35297",
+					"172.19.0.1:35297",
+					"172.20.0.1:35297"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:43:02.530048154Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5287052114870279,
+				"StableID":   "nJNSjqtWHi11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:baec9a448c38cd7ab8d1493fe668aaf040a2a8de057f85d83d7f32ea79e3b47d",
+				"DiscoKey":   "discokey:017dae7f7949d565b61236b087188e8250aa2d215831e42c32fbf994e0340a72",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48714",
+					"10.65.0.27:48714",
+					"172.17.0.1:48714",
+					"172.19.0.1:48714",
+					"172.20.0.1:48714"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:43:03.012273454Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         79816518206558,
+				"StableID":   "nK5vPPe9d111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2381afede94000929e55d4334927003e638f36610a056769ab1ce8c30ab8bb1b",
+				"DiscoKey":   "discokey:526d726141ed3ac418866cc0c2a36c4e6e34f3a8cf8f382b9b9394a129f3d312",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34957",
+					"10.65.0.27:34957",
+					"172.17.0.1:34957",
+					"172.19.0.1:34957",
+					"172.20.0.1:34957"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:43:03.559851036Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5712732665356895,
+				"StableID":   "nSNcJQoJcm11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c0508573148420952dc4aa9c8523397179a6b37deb4fabe74e4882c14d804270",
+				"DiscoKey":   "discokey:524a0294c94f761fc0b773f8295bd19f215ca9b43ff9b8e56e9075740a84d16e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56091",
+					"10.65.0.27:56091",
+					"172.17.0.1:56091",
+					"172.19.0.1:56091",
+					"172.20.0.1:56091"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:43:04.108159952Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6690571426423582,
+				"StableID":   "nqeiA3yAFu11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:45534397287c4f9a5e2ce320cbfb510cacac2acda074102b1680d710f44c636a",
+				"DiscoKey":   "discokey:700b2fb1da26d8d2c11bfaa12a798542d63ba3e22cf7bc41a2dfe5f3e85a9e7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:59278",
+					"10.65.0.27:59278",
+					"172.17.0.1:59278",
+					"172.19.0.1:59278",
+					"172.20.0.1:59278"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:43:04.640112917Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6756386465092508,
+				"StableID":   "noQBmJpyku11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:907ba4b6193a07ca1a438e8b5232e3e632654aa3cb7be512336eee05fabd9f59",
+				"DiscoKey":   "discokey:c8b37108d84c450de094db28ac9a61b2011a0704bbe8df855e8fd7b33b1a1062",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53630",
+					"10.65.0.27:53630",
+					"172.17.0.1:53630",
+					"172.19.0.1:53630",
+					"172.20.0.1:53630"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:43:05.198137654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1019520298251466,
+				"StableID":   "nRNFa25kx811CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3278f2afea4315d278ef2bb5c47bb5ab779ab26bea75e2b3f48a1a8221e8454a",
+				"DiscoKey":   "discokey:c1ea4049bc5c08266c6fd2d8b5c1070814a727f409f0542e99362116fd677b1c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40735",
+					"10.65.0.27:40735",
+					"172.17.0.1:40735",
+					"172.19.0.1:40735",
+					"172.20.0.1:40735"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:43:05.753721108Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6903507164049026,
+				"StableID":   "nB1y8mRcuv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:840896b2fa09524a1b1f39617bfa49c58d4704f6bc6750cc36655e3aba9db113",
+				"DiscoKey":   "discokey:cf362e1457f1c567869297231db070f8c85c21c36a7289e80295bbaea088980e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46595",
+					"10.65.0.27:46595",
+					"172.17.0.1:46595",
+					"172.19.0.1:46595",
+					"172.20.0.1:46595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:43:06.258894294Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2332046482957184,
+				"StableID":   "nRotyauBDK11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9eb470f6cc3ba0293380a716ed8c876a3f4200a12264e01e06a1c58e12db7b44",
+				"DiscoKey":   "discokey:1156ff43993479cdc3d22e187ad2d37948e7dbca1899730f122963083c669e4a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53835",
+					"10.65.0.27:53835",
+					"172.17.0.1:53835",
+					"172.19.0.1:53835",
+					"172.20.0.1:53835"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:43:07.339293656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7669499834085359,
+				"StableID":   "nQwSNpkXt221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:894dcc7ae88f88b5a0a633ae4b61b0c879d22c947571ce024235a78e22fa692a",
+				"DiscoKey":   "discokey:55a28e63f72717d92e76ef381e5e852c8d8a935bcd9cf6f4a688553fb9d8ef62",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35663",
+					"10.65.0.27:35663",
+					"172.17.0.1:35663",
+					"172.19.0.1:35663",
+					"172.20.0.1:35663"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:43:07.877874763Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1778563694427652,
+				"StableID":   "nPkjGSrWtE11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c6247aaf6ec419e6a20e3b14b8e214e14ea0229ba5243fc2cb5178169794d219",
+				"DiscoKey":   "discokey:9729bf0df16ed58b29fe665ef75bdcdbc62bf5c1f5f1fa8899d51da1b69ecc7a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44311",
+					"10.65.0.27:44311",
+					"172.17.0.1:44311",
+					"172.19.0.1:44311",
+					"172.20.0.1:44311"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:43:08.424953265Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3450710695312138,
+				"StableID":   "nK3zjUKqwT11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1e7dcf085f1d9659bc769a9063d1cce6f263621852e94d60c09a8c35265da76c",
+				"KeyExpiry":  "2026-11-08T18:43:08Z",
+				"DiscoKey":   "discokey:c3e9c6d8874bcbd8241484e4e2b517c58b4c8850b4df1acb84f17e1a2324d224",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34174",
+					"10.65.0.27:34174",
+					"172.17.0.1:34174",
+					"172.19.0.1:34174",
+					"172.20.0.1:34174"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:43:08.964481601Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7188264267484786,
+				"StableID":   "nDxFGmWa8y11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a57c4a640749272e957cab5d7c3e8ae76159f4a13aa75184629e872192a78118",
+				"KeyExpiry":  "2026-11-08T18:43:09Z",
+				"DiscoKey":   "discokey:26b8dd4873a42f4c6f7844094e2bf45914c6931c333a9485123fe48f9ac96671",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:56939",
+					"10.65.0.27:56939",
+					"172.17.0.1:56939",
+					"172.19.0.1:56939",
+					"172.20.0.1:56939"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:43:09.506238145Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7701579901160944,
+				"StableID":   "nskZ3nS49321CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:db8ccc084baa7b619714f5f7f372dd6d25bb61a0cc556613fa9df7b9a1b3506e",
+				"KeyExpiry":  "2026-11-08T18:43:10Z",
+				"DiscoKey":   "discokey:8c82f1b37ce845db036cb145bba82479e8d342822d8f8293944c9ae6fbb30218",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:43733",
+					"10.65.0.27:43733",
+					"172.17.0.1:43733",
+					"172.19.0.1:43733",
+					"172.20.0.1:43733"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:43:10.061206821Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6565375780553687": {
+				"ID":          6565375780553687,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7188264267484786,
+				"StableID":   "nDxFGmWa8y11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a57c4a640749272e957cab5d7c3e8ae76159f4a13aa75184629e872192a78118",
+				"KeyExpiry":  "2026-11-08T18:43:09Z",
+				"DiscoKey":   "discokey:26b8dd4873a42f4c6f7844094e2bf45914c6931c333a9485123fe48f9ac96671",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:56939",
+					"10.65.0.27:56939",
+					"172.17.0.1:56939",
+					"172.19.0.1:56939",
+					"172.20.0.1:56939"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:43:09.506238145Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a57c4a640749272e957cab5d7c3e8ae76159f4a13aa75184629e872192a78118",
+			"MachineKey": "mkey:32155ebd35c1486682c6cd49df76a8d94ae8bf9d6b9ff545dbb0ae110d4d417b",
+			"Peers": [{
+				"ID":         6705409733160145,
+				"StableID":   "nAbJX7ktMu11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fde66e749b7c9998d7edb8b7229c20448ad4097677d60b91bdd6990ef4e4d463",
+				"DiscoKey":   "discokey:304fed7316a159e19434f07300fc22ba4cd5ded13311d388100aaf941e8bf364",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35297",
+					"10.65.0.27:35297",
+					"172.17.0.1:35297",
+					"172.19.0.1:35297",
+					"172.20.0.1:35297"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:43:02.530048154Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5287052114870279,
+				"StableID":   "nJNSjqtWHi11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:baec9a448c38cd7ab8d1493fe668aaf040a2a8de057f85d83d7f32ea79e3b47d",
+				"DiscoKey":   "discokey:017dae7f7949d565b61236b087188e8250aa2d215831e42c32fbf994e0340a72",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48714",
+					"10.65.0.27:48714",
+					"172.17.0.1:48714",
+					"172.19.0.1:48714",
+					"172.20.0.1:48714"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:43:03.012273454Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         79816518206558,
+				"StableID":   "nK5vPPe9d111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2381afede94000929e55d4334927003e638f36610a056769ab1ce8c30ab8bb1b",
+				"DiscoKey":   "discokey:526d726141ed3ac418866cc0c2a36c4e6e34f3a8cf8f382b9b9394a129f3d312",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34957",
+					"10.65.0.27:34957",
+					"172.17.0.1:34957",
+					"172.19.0.1:34957",
+					"172.20.0.1:34957"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:43:03.559851036Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5712732665356895,
+				"StableID":   "nSNcJQoJcm11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c0508573148420952dc4aa9c8523397179a6b37deb4fabe74e4882c14d804270",
+				"DiscoKey":   "discokey:524a0294c94f761fc0b773f8295bd19f215ca9b43ff9b8e56e9075740a84d16e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56091",
+					"10.65.0.27:56091",
+					"172.17.0.1:56091",
+					"172.19.0.1:56091",
+					"172.20.0.1:56091"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:43:04.108159952Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6690571426423582,
+				"StableID":   "nqeiA3yAFu11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:45534397287c4f9a5e2ce320cbfb510cacac2acda074102b1680d710f44c636a",
+				"DiscoKey":   "discokey:700b2fb1da26d8d2c11bfaa12a798542d63ba3e22cf7bc41a2dfe5f3e85a9e7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:59278",
+					"10.65.0.27:59278",
+					"172.17.0.1:59278",
+					"172.19.0.1:59278",
+					"172.20.0.1:59278"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:43:04.640112917Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6756386465092508,
+				"StableID":   "noQBmJpyku11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:907ba4b6193a07ca1a438e8b5232e3e632654aa3cb7be512336eee05fabd9f59",
+				"DiscoKey":   "discokey:c8b37108d84c450de094db28ac9a61b2011a0704bbe8df855e8fd7b33b1a1062",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53630",
+					"10.65.0.27:53630",
+					"172.17.0.1:53630",
+					"172.19.0.1:53630",
+					"172.20.0.1:53630"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:43:05.198137654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1019520298251466,
+				"StableID":   "nRNFa25kx811CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3278f2afea4315d278ef2bb5c47bb5ab779ab26bea75e2b3f48a1a8221e8454a",
+				"DiscoKey":   "discokey:c1ea4049bc5c08266c6fd2d8b5c1070814a727f409f0542e99362116fd677b1c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40735",
+					"10.65.0.27:40735",
+					"172.17.0.1:40735",
+					"172.19.0.1:40735",
+					"172.20.0.1:40735"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:43:05.753721108Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6903507164049026,
+				"StableID":   "nB1y8mRcuv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:840896b2fa09524a1b1f39617bfa49c58d4704f6bc6750cc36655e3aba9db113",
+				"DiscoKey":   "discokey:cf362e1457f1c567869297231db070f8c85c21c36a7289e80295bbaea088980e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46595",
+					"10.65.0.27:46595",
+					"172.17.0.1:46595",
+					"172.19.0.1:46595",
+					"172.20.0.1:46595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:43:06.258894294Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6565375780553687,
+				"StableID":   "nNLxekHUGt11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6b7a30b3ab7a8cc19add7e6179b84696df44443c5b1bf0b061150b8165c8903a",
+				"DiscoKey":   "discokey:07f6b591ba2a1d71ea81cf488aabc0266f9e765700e5c8338fea3c1c3e201412",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44689",
+					"10.65.0.27:44689",
+					"172.17.0.1:44689",
+					"172.19.0.1:44689",
+					"172.20.0.1:44689"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:43:06.78817179Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2332046482957184,
+				"StableID":   "nRotyauBDK11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9eb470f6cc3ba0293380a716ed8c876a3f4200a12264e01e06a1c58e12db7b44",
+				"DiscoKey":   "discokey:1156ff43993479cdc3d22e187ad2d37948e7dbca1899730f122963083c669e4a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53835",
+					"10.65.0.27:53835",
+					"172.17.0.1:53835",
+					"172.19.0.1:53835",
+					"172.20.0.1:53835"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:43:07.339293656Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7669499834085359,
+				"StableID":   "nQwSNpkXt221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:894dcc7ae88f88b5a0a633ae4b61b0c879d22c947571ce024235a78e22fa692a",
+				"DiscoKey":   "discokey:55a28e63f72717d92e76ef381e5e852c8d8a935bcd9cf6f4a688553fb9d8ef62",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35663",
+					"10.65.0.27:35663",
+					"172.17.0.1:35663",
+					"172.19.0.1:35663",
+					"172.20.0.1:35663"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:43:07.877874763Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1778563694427652,
+				"StableID":   "nPkjGSrWtE11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c6247aaf6ec419e6a20e3b14b8e214e14ea0229ba5243fc2cb5178169794d219",
+				"DiscoKey":   "discokey:9729bf0df16ed58b29fe665ef75bdcdbc62bf5c1f5f1fa8899d51da1b69ecc7a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44311",
+					"10.65.0.27:44311",
+					"172.17.0.1:44311",
+					"172.19.0.1:44311",
+					"172.20.0.1:44311"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:43:08.424953265Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3450710695312138,
+				"StableID":   "nK3zjUKqwT11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1e7dcf085f1d9659bc769a9063d1cce6f263621852e94d60c09a8c35265da76c",
+				"KeyExpiry":  "2026-11-08T18:43:08Z",
+				"DiscoKey":   "discokey:c3e9c6d8874bcbd8241484e4e2b517c58b4c8850b4df1acb84f17e1a2324d224",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34174",
+					"10.65.0.27:34174",
+					"172.17.0.1:34174",
+					"172.19.0.1:34174",
+					"172.20.0.1:34174"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:43:08.964481601Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7701579901160944,
+				"StableID":   "nskZ3nS49321CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:db8ccc084baa7b619714f5f7f372dd6d25bb61a0cc556613fa9df7b9a1b3506e",
+				"KeyExpiry":  "2026-11-08T18:43:10Z",
+				"DiscoKey":   "discokey:8c82f1b37ce845db036cb145bba82479e8d342822d8f8293944c9ae6fbb30218",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:43733",
+					"10.65.0.27:43733",
+					"172.17.0.1:43733",
+					"172.19.0.1:43733",
+					"172.20.0.1:43733"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:43:10.061206821Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2332046482957184,
+				"StableID":   "nRotyauBDK11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       2332046482957184,
+				"Key":        "nodekey:9eb470f6cc3ba0293380a716ed8c876a3f4200a12264e01e06a1c58e12db7b44",
+				"DiscoKey":   "discokey:1156ff43993479cdc3d22e187ad2d37948e7dbca1899730f122963083c669e4a",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:53835",
+					"10.65.0.27:53835",
+					"172.17.0.1:53835",
+					"172.19.0.1:53835",
+					"172.20.0.1:53835"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:43:07.339293656Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9eb470f6cc3ba0293380a716ed8c876a3f4200a12264e01e06a1c58e12db7b44",
+			"MachineKey": "mkey:925c18e38035c13edceb5399c58bc685ed114186bc6620cc18d77fa455b34e16",
+			"Peers": [{
+				"ID":         6705409733160145,
+				"StableID":   "nAbJX7ktMu11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fde66e749b7c9998d7edb8b7229c20448ad4097677d60b91bdd6990ef4e4d463",
+				"DiscoKey":   "discokey:304fed7316a159e19434f07300fc22ba4cd5ded13311d388100aaf941e8bf364",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:35297",
+					"10.65.0.27:35297",
+					"172.17.0.1:35297",
+					"172.19.0.1:35297",
+					"172.20.0.1:35297"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:43:02.530048154Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5287052114870279,
+				"StableID":   "nJNSjqtWHi11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:baec9a448c38cd7ab8d1493fe668aaf040a2a8de057f85d83d7f32ea79e3b47d",
+				"DiscoKey":   "discokey:017dae7f7949d565b61236b087188e8250aa2d215831e42c32fbf994e0340a72",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:48714",
+					"10.65.0.27:48714",
+					"172.17.0.1:48714",
+					"172.19.0.1:48714",
+					"172.20.0.1:48714"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:43:03.012273454Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         79816518206558,
+				"StableID":   "nK5vPPe9d111CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2381afede94000929e55d4334927003e638f36610a056769ab1ce8c30ab8bb1b",
+				"DiscoKey":   "discokey:526d726141ed3ac418866cc0c2a36c4e6e34f3a8cf8f382b9b9394a129f3d312",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34957",
+					"10.65.0.27:34957",
+					"172.17.0.1:34957",
+					"172.19.0.1:34957",
+					"172.20.0.1:34957"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:43:03.559851036Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5712732665356895,
+				"StableID":   "nSNcJQoJcm11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c0508573148420952dc4aa9c8523397179a6b37deb4fabe74e4882c14d804270",
+				"DiscoKey":   "discokey:524a0294c94f761fc0b773f8295bd19f215ca9b43ff9b8e56e9075740a84d16e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:56091",
+					"10.65.0.27:56091",
+					"172.17.0.1:56091",
+					"172.19.0.1:56091",
+					"172.20.0.1:56091"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:43:04.108159952Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6690571426423582,
+				"StableID":   "nqeiA3yAFu11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:45534397287c4f9a5e2ce320cbfb510cacac2acda074102b1680d710f44c636a",
+				"DiscoKey":   "discokey:700b2fb1da26d8d2c11bfaa12a798542d63ba3e22cf7bc41a2dfe5f3e85a9e7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:59278",
+					"10.65.0.27:59278",
+					"172.17.0.1:59278",
+					"172.19.0.1:59278",
+					"172.20.0.1:59278"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:43:04.640112917Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6756386465092508,
+				"StableID":   "noQBmJpyku11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:907ba4b6193a07ca1a438e8b5232e3e632654aa3cb7be512336eee05fabd9f59",
+				"DiscoKey":   "discokey:c8b37108d84c450de094db28ac9a61b2011a0704bbe8df855e8fd7b33b1a1062",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53630",
+					"10.65.0.27:53630",
+					"172.17.0.1:53630",
+					"172.19.0.1:53630",
+					"172.20.0.1:53630"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:43:05.198137654Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1019520298251466,
+				"StableID":   "nRNFa25kx811CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3278f2afea4315d278ef2bb5c47bb5ab779ab26bea75e2b3f48a1a8221e8454a",
+				"DiscoKey":   "discokey:c1ea4049bc5c08266c6fd2d8b5c1070814a727f409f0542e99362116fd677b1c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40735",
+					"10.65.0.27:40735",
+					"172.17.0.1:40735",
+					"172.19.0.1:40735",
+					"172.20.0.1:40735"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:43:05.753721108Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6903507164049026,
+				"StableID":   "nB1y8mRcuv11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:840896b2fa09524a1b1f39617bfa49c58d4704f6bc6750cc36655e3aba9db113",
+				"DiscoKey":   "discokey:cf362e1457f1c567869297231db070f8c85c21c36a7289e80295bbaea088980e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:46595",
+					"10.65.0.27:46595",
+					"172.17.0.1:46595",
+					"172.19.0.1:46595",
+					"172.20.0.1:46595"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:43:06.258894294Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6565375780553687,
+				"StableID":   "nNLxekHUGt11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6b7a30b3ab7a8cc19add7e6179b84696df44443c5b1bf0b061150b8165c8903a",
+				"DiscoKey":   "discokey:07f6b591ba2a1d71ea81cf488aabc0266f9e765700e5c8338fea3c1c3e201412",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:44689",
+					"10.65.0.27:44689",
+					"172.17.0.1:44689",
+					"172.19.0.1:44689",
+					"172.20.0.1:44689"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:43:06.78817179Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7669499834085359,
+				"StableID":   "nQwSNpkXt221CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:894dcc7ae88f88b5a0a633ae4b61b0c879d22c947571ce024235a78e22fa692a",
+				"DiscoKey":   "discokey:55a28e63f72717d92e76ef381e5e852c8d8a935bcd9cf6f4a688553fb9d8ef62",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:35663",
+					"10.65.0.27:35663",
+					"172.17.0.1:35663",
+					"172.19.0.1:35663",
+					"172.20.0.1:35663"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:43:07.877874763Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1778563694427652,
+				"StableID":   "nPkjGSrWtE11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c6247aaf6ec419e6a20e3b14b8e214e14ea0229ba5243fc2cb5178169794d219",
+				"DiscoKey":   "discokey:9729bf0df16ed58b29fe665ef75bdcdbc62bf5c1f5f1fa8899d51da1b69ecc7a",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:44311",
+					"10.65.0.27:44311",
+					"172.17.0.1:44311",
+					"172.19.0.1:44311",
+					"172.20.0.1:44311"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:43:08.424953265Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3450710695312138,
+				"StableID":   "nK3zjUKqwT11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:1e7dcf085f1d9659bc769a9063d1cce6f263621852e94d60c09a8c35265da76c",
+				"KeyExpiry":  "2026-11-08T18:43:08Z",
+				"DiscoKey":   "discokey:c3e9c6d8874bcbd8241484e4e2b517c58b4c8850b4df1acb84f17e1a2324d224",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:34174",
+					"10.65.0.27:34174",
+					"172.17.0.1:34174",
+					"172.19.0.1:34174",
+					"172.20.0.1:34174"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:43:08.964481601Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7188264267484786,
+				"StableID":   "nDxFGmWa8y11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a57c4a640749272e957cab5d7c3e8ae76159f4a13aa75184629e872192a78118",
+				"KeyExpiry":  "2026-11-08T18:43:09Z",
+				"DiscoKey":   "discokey:26b8dd4873a42f4c6f7844094e2bf45914c6931c333a9485123fe48f9ac96671",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:56939",
+					"10.65.0.27:56939",
+					"172.17.0.1:56939",
+					"172.19.0.1:56939",
+					"172.20.0.1:56939"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:43:09.506238145Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7701579901160944,
+				"StableID":   "nskZ3nS49321CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:db8ccc084baa7b619714f5f7f372dd6d25bb61a0cc556613fa9df7b9a1b3506e",
+				"KeyExpiry":  "2026-11-08T18:43:10Z",
+				"DiscoKey":   "discokey:8c82f1b37ce845db036cb145bba82479e8d342822d8f8293944c9ae6fbb30218",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:43733",
+					"10.65.0.27:43733",
+					"172.17.0.1:43733",
+					"172.19.0.1:43733",
+					"172.20.0.1:43733"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:43:10.061206821Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2332046482957184": {
+				"ID":          2332046482957184,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/sshtest_results/sshtest-malformed-dst-bare-ipv4.hujson
+++ b/hscontrol/policy/v2/testdata/sshtest_results/sshtest-malformed-dst-bare-ipv4.hujson
@@ -1,0 +1,18758 @@
+// sshtest-malformed-dst-bare-ipv4
+//
+// sshTests dst with bare IPv4 literal
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-13T10:48:43Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "sshtest-malformed-dst-bare-ipv4",
+	"description":    "sshTests dst with bare IPv4 literal",
+	"category":       "sshtest",
+	"captured_at":    "2026-05-13T10:48:43.837501769Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                  \n  \n                                                                       \n                                            \n{\n\t\"category\":    \"sshtest\",\n\t\"description\": \"sshTests dst with bare IPv4 literal\",\n\t\"id\":          \"sshtest-malformed-dst-bare-ipv4\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"grants\": [{\"dst\": [\"*\"], \"ip\": [\"*\"], \"src\": [\"*\"]}], \"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"autogroup:member\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"sshTests\": [{\n\t\t\"accept\": [\"root\"],\n\t\t\"dst\":    [\"100.64.0.16\"],\n\t\t\"src\":    \"odin@example.com\"\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/sshtest-edges-baremip/sshtest-malformed-dst-bare-ipv4.hujson",
+		"full_policy": {
+			"grants": [{"dst": ["*"], "ip": ["*"], "src": ["*"]}],
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["autogroup:member"],
+				"users":  ["root"]
+			}],
+			"sshTests": [
+				{"accept": ["root"], "dst": ["100.64.0.16"], "src": "odin@example.com"}
+			],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8722759479154595,
+				"StableID":   "nG3DVp6Z7B21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       8722759479154595,
+				"Key":        "nodekey:ce0976880a1f7f6dc7475d9cfbc62750f45c14025cea8ac3cbf9c24afba8ba23",
+				"DiscoKey":   "discokey:e0112828e95db0bb1c0982dca3ef7ce2e574c0d18c0462ed202244eac928fc71",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:40653", "10.65.0.27:40653", "172.17.0.1:40653"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T10:48:56.276059496Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ce0976880a1f7f6dc7475d9cfbc62750f45c14025cea8ac3cbf9c24afba8ba23",
+			"MachineKey": "mkey:306c55ab2ca3b6e3418717b16619e21926dcffa2611d5965ed5dbce0b19b3863",
+			"Peers": [{
+				"ID":         6200298225266045,
+				"StableID":   "nkL6FbK8Rq11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:caa25e6f3964747f2819e3fda3f7c706295b6a49c664b8e2ea89c3969bdbda2b",
+				"DiscoKey":   "discokey:77ec9f8fce0ede08d9d1a5b029f8a0cae296110933405e7519506e79e073333d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:48042", "10.65.0.27:48042", "172.17.0.1:48042"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T10:48:50.362795491Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         772085588111436,
+				"StableID":   "nwaEYzNg2711CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c2079dc508afa576b94809475a2ac47d3a36c6e3f735ef1b55c27ffcec1a373",
+				"DiscoKey":   "discokey:8cb4612d5f0e3c5749ae5ed0fbbbe1785c2932e55ba34fec31e0be6d96f2607a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:55637", "10.65.0.27:55637", "172.17.0.1:55637"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T10:48:50.891907715Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1638953534304319,
+				"StableID":   "n22eVkXHoD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1462e2a6dc4d8abe004dff315631a69b43887f020c6f19139bda5e98be5f75c",
+				"DiscoKey":   "discokey:140fac845fae8282c5c0766d4640b23d93aa54c0b9fa01194f57b1a38629c901",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:44209", "10.65.0.27:44209", "172.17.0.1:44209"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T10:48:51.424310318Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3765147146864741,
+				"StableID":   "ncADEo2FQW11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38fe0b9e71caeb8135dac0fbe880b7e748009c26f0abb43b3527cb72212b175b",
+				"DiscoKey":   "discokey:198022f74d83de950d9085d4fc72fd3fbc42e6f9db4452df75e4ee3820310271",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:49338", "10.65.0.27:49338", "172.17.0.1:49338"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T10:48:51.967866113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3519823077666716,
+				"StableID":   "nBpiJTn8VU11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0d87ab5fbdc9d4e34413f797214d6ac38849e6dc6374e12d90612cba7f8a069",
+				"DiscoKey":   "discokey:0a60fc1cddb12dbd09d89e6b51a4ce9a2411d5e9c839caf89eb396dd0df44851",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:38235", "10.65.0.27:38235", "172.17.0.1:38235"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T10:48:52.512631024Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1986105523559038,
+				"StableID":   "nPm32DdWWG11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5102f677c7b7bb670223630e40cbaea4e932d7d0a62f334e3d39dda92d3fdb77",
+				"DiscoKey":   "discokey:ce969702ba57154bad7015018753d95c981ffd8a8be1de79cea3e61e0bc0297a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:49208", "10.65.0.27:49208", "172.17.0.1:49208"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T10:48:53.034821277Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5130804425872062,
+				"StableID":   "nFwzVrXk4h11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:908f9f71cf33139bd9e32b7628bef012d466eb003ded2d8d99417a85cb294047",
+				"DiscoKey":   "discokey:ceb56c41917fe22122cde49a826c033fede711c180bbe5331d982702739fbc2b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:55194", "10.65.0.27:55194", "172.17.0.1:55194"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T10:48:53.586230203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2159651897938158,
+				"StableID":   "nunjqoP7sH11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e9c626ba7ebfdb3c7dde942b025e7c1e785e5346f6406556926a73daeeb1c816",
+				"DiscoKey":   "discokey:cbcb42ec1c6942dc1516dbd7fa3ccbc14b63f19487e6bdce2f989034bcf02962",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:43026", "10.65.0.27:43026", "172.17.0.1:43026"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T10:48:54.126510557Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1349337447109109,
+				"StableID":   "nWqVcno7YB11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:53b27d1f1c5b6ac9e0ee6390391b0a3635092481c5727fc7ea696388d123a02f",
+				"DiscoKey":   "discokey:081d07001df2cca09159b3071e5ffcd20ce392e9fa11610354247a31d4f09f59",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54340", "10.65.0.27:54340", "172.17.0.1:54340"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T10:48:54.655381755Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5882431403440684,
+				"StableID":   "nuRZgtVAwn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a398e17e1c282f84c5f6b7cfb7446ecaccec8951981b1fd55c1d8e6368d9fa42",
+				"DiscoKey":   "discokey:f8fa287f5363f5bdf521d0b8e84f40c36e1bf3c5465949d12433d213e7e4f718",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:40111", "10.65.0.27:40111", "172.17.0.1:40111"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T10:48:55.202876425Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2367360492594434,
+				"StableID":   "nRLx5fYBVK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:191d2ceeca75f0e2829f5296e0321d7af0b1a9b19888776491e988a1ede7311a",
+				"DiscoKey":   "discokey:fb30d96a84b67697b2c5ba4a27262251e2245a56a402f546b9b2bb8f84f9291d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:40035", "10.65.0.27:40035", "172.17.0.1:40035"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T10:48:55.738626975Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8789958571042068,
+				"StableID":   "nuyB8nJzdB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d5f6fca3ad79e6e1c4176b9916873989f27d90b04f1b821734ddac3ea33db221",
+				"KeyExpiry":  "2026-11-09T10:48:56Z",
+				"DiscoKey":   "discokey:29333efc1ed524edb99c6286282bb51a73104d7f9fe6c8e43aa5f607c9efce78",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:50705", "10.65.0.27:50705", "172.17.0.1:50705"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T10:48:56.81026368Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4397469093301501,
+				"StableID":   "nL2HMG4dLb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b3cb7fa4c23188ce2a8ad836a8b252fa1526358fba756bd509adbb33ab240f5c",
+				"KeyExpiry":  "2026-11-09T10:48:57Z",
+				"DiscoKey":   "discokey:73765b4c398fc506d93c97edceb5bd28515a96c711012398c1d91fcf33592012",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:45003", "10.65.0.27:45003", "172.17.0.1:45003"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T10:48:57.352517284Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7822324820044157,
+				"StableID":   "nAw947Dk5421CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bbb1fc9a6f7e90fb22a04203694abe55b821617df286d129da214c42b98ea319",
+				"KeyExpiry":  "2026-11-09T10:48:57Z",
+				"DiscoKey":   "discokey:a733427a6a060e36d67831e7b58bc300b184092bf1598e0d517c4a413de3ee58",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:53974", "10.65.0.27:53974", "172.17.0.1:53974"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T10:48:57.903377063Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{"principals": [
+				{"nodeIP": "100.64.0.17"},
+				{"nodeIP": "100.64.0.18"},
+				{"nodeIP": "100.64.0.19"},
+				{"nodeIP": "fd7a:115c:a1e0::11"},
+				{"nodeIP": "fd7a:115c:a1e0::12"},
+				{"nodeIP": "fd7a:115c:a1e0::13"}
+			], "sshUsers": {"root": "root"}, "action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8722759479154595": {
+				"ID":          8722759479154595,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		},
+		"ssh_rules": [{"principals": [
+			{"nodeIP": "100.64.0.17"},
+			{"nodeIP": "100.64.0.18"},
+			{"nodeIP": "100.64.0.19"},
+			{"nodeIP": "fd7a:115c:a1e0::11"},
+			{"nodeIP": "fd7a:115c:a1e0::12"},
+			{"nodeIP": "fd7a:115c:a1e0::13"}
+		], "sshUsers": {"root": "root"}, "action": {
+			"accept":                    true,
+			"allowAgentForwarding":      true,
+			"allowLocalPortForwarding":  true,
+			"allowRemotePortForwarding": true
+		}}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1986105523559038,
+				"StableID":   "nPm32DdWWG11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1986105523559038,
+				"Key":        "nodekey:5102f677c7b7bb670223630e40cbaea4e932d7d0a62f334e3d39dda92d3fdb77",
+				"DiscoKey":   "discokey:ce969702ba57154bad7015018753d95c981ffd8a8be1de79cea3e61e0bc0297a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:49208", "10.65.0.27:49208", "172.17.0.1:49208"],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T10:48:53.034821277Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5102f677c7b7bb670223630e40cbaea4e932d7d0a62f334e3d39dda92d3fdb77",
+			"MachineKey": "mkey:5f243ec1cddf2ef9bb90da7ddd78cdd56babe27b3131272afdb505a21f55d86b",
+			"Peers": [{
+				"ID":         6200298225266045,
+				"StableID":   "nkL6FbK8Rq11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:caa25e6f3964747f2819e3fda3f7c706295b6a49c664b8e2ea89c3969bdbda2b",
+				"DiscoKey":   "discokey:77ec9f8fce0ede08d9d1a5b029f8a0cae296110933405e7519506e79e073333d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:48042", "10.65.0.27:48042", "172.17.0.1:48042"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T10:48:50.362795491Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         772085588111436,
+				"StableID":   "nwaEYzNg2711CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c2079dc508afa576b94809475a2ac47d3a36c6e3f735ef1b55c27ffcec1a373",
+				"DiscoKey":   "discokey:8cb4612d5f0e3c5749ae5ed0fbbbe1785c2932e55ba34fec31e0be6d96f2607a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:55637", "10.65.0.27:55637", "172.17.0.1:55637"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T10:48:50.891907715Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1638953534304319,
+				"StableID":   "n22eVkXHoD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1462e2a6dc4d8abe004dff315631a69b43887f020c6f19139bda5e98be5f75c",
+				"DiscoKey":   "discokey:140fac845fae8282c5c0766d4640b23d93aa54c0b9fa01194f57b1a38629c901",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:44209", "10.65.0.27:44209", "172.17.0.1:44209"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T10:48:51.424310318Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3765147146864741,
+				"StableID":   "ncADEo2FQW11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38fe0b9e71caeb8135dac0fbe880b7e748009c26f0abb43b3527cb72212b175b",
+				"DiscoKey":   "discokey:198022f74d83de950d9085d4fc72fd3fbc42e6f9db4452df75e4ee3820310271",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:49338", "10.65.0.27:49338", "172.17.0.1:49338"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T10:48:51.967866113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3519823077666716,
+				"StableID":   "nBpiJTn8VU11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0d87ab5fbdc9d4e34413f797214d6ac38849e6dc6374e12d90612cba7f8a069",
+				"DiscoKey":   "discokey:0a60fc1cddb12dbd09d89e6b51a4ce9a2411d5e9c839caf89eb396dd0df44851",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:38235", "10.65.0.27:38235", "172.17.0.1:38235"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T10:48:52.512631024Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5130804425872062,
+				"StableID":   "nFwzVrXk4h11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:908f9f71cf33139bd9e32b7628bef012d466eb003ded2d8d99417a85cb294047",
+				"DiscoKey":   "discokey:ceb56c41917fe22122cde49a826c033fede711c180bbe5331d982702739fbc2b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:55194", "10.65.0.27:55194", "172.17.0.1:55194"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T10:48:53.586230203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2159651897938158,
+				"StableID":   "nunjqoP7sH11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e9c626ba7ebfdb3c7dde942b025e7c1e785e5346f6406556926a73daeeb1c816",
+				"DiscoKey":   "discokey:cbcb42ec1c6942dc1516dbd7fa3ccbc14b63f19487e6bdce2f989034bcf02962",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:43026", "10.65.0.27:43026", "172.17.0.1:43026"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T10:48:54.126510557Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1349337447109109,
+				"StableID":   "nWqVcno7YB11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:53b27d1f1c5b6ac9e0ee6390391b0a3635092481c5727fc7ea696388d123a02f",
+				"DiscoKey":   "discokey:081d07001df2cca09159b3071e5ffcd20ce392e9fa11610354247a31d4f09f59",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54340", "10.65.0.27:54340", "172.17.0.1:54340"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T10:48:54.655381755Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5882431403440684,
+				"StableID":   "nuRZgtVAwn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a398e17e1c282f84c5f6b7cfb7446ecaccec8951981b1fd55c1d8e6368d9fa42",
+				"DiscoKey":   "discokey:f8fa287f5363f5bdf521d0b8e84f40c36e1bf3c5465949d12433d213e7e4f718",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:40111", "10.65.0.27:40111", "172.17.0.1:40111"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T10:48:55.202876425Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2367360492594434,
+				"StableID":   "nRLx5fYBVK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:191d2ceeca75f0e2829f5296e0321d7af0b1a9b19888776491e988a1ede7311a",
+				"DiscoKey":   "discokey:fb30d96a84b67697b2c5ba4a27262251e2245a56a402f546b9b2bb8f84f9291d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:40035", "10.65.0.27:40035", "172.17.0.1:40035"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T10:48:55.738626975Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8722759479154595,
+				"StableID":   "nG3DVp6Z7B21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ce0976880a1f7f6dc7475d9cfbc62750f45c14025cea8ac3cbf9c24afba8ba23",
+				"DiscoKey":   "discokey:e0112828e95db0bb1c0982dca3ef7ce2e574c0d18c0462ed202244eac928fc71",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:40653", "10.65.0.27:40653", "172.17.0.1:40653"],
+				"HomeDERP":   26,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T10:48:56.276059496Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8789958571042068,
+				"StableID":   "nuyB8nJzdB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d5f6fca3ad79e6e1c4176b9916873989f27d90b04f1b821734ddac3ea33db221",
+				"KeyExpiry":  "2026-11-09T10:48:56Z",
+				"DiscoKey":   "discokey:29333efc1ed524edb99c6286282bb51a73104d7f9fe6c8e43aa5f607c9efce78",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:50705", "10.65.0.27:50705", "172.17.0.1:50705"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T10:48:56.81026368Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4397469093301501,
+				"StableID":   "nL2HMG4dLb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b3cb7fa4c23188ce2a8ad836a8b252fa1526358fba756bd509adbb33ab240f5c",
+				"KeyExpiry":  "2026-11-09T10:48:57Z",
+				"DiscoKey":   "discokey:73765b4c398fc506d93c97edceb5bd28515a96c711012398c1d91fcf33592012",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:45003", "10.65.0.27:45003", "172.17.0.1:45003"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T10:48:57.352517284Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7822324820044157,
+				"StableID":   "nAw947Dk5421CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bbb1fc9a6f7e90fb22a04203694abe55b821617df286d129da214c42b98ea319",
+				"KeyExpiry":  "2026-11-09T10:48:57Z",
+				"DiscoKey":   "discokey:a733427a6a060e36d67831e7b58bc300b184092bf1598e0d517c4a413de3ee58",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:53974", "10.65.0.27:53974", "172.17.0.1:53974"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T10:48:57.903377063Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1986105523559038": {
+				"ID":          1986105523559038,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7822324820044157,
+				"StableID":   "nAw947Dk5421CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bbb1fc9a6f7e90fb22a04203694abe55b821617df286d129da214c42b98ea319",
+				"KeyExpiry":  "2026-11-09T10:48:57Z",
+				"DiscoKey":   "discokey:a733427a6a060e36d67831e7b58bc300b184092bf1598e0d517c4a413de3ee58",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:53974", "10.65.0.27:53974", "172.17.0.1:53974"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T10:48:57.903377063Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:bbb1fc9a6f7e90fb22a04203694abe55b821617df286d129da214c42b98ea319",
+			"MachineKey": "mkey:fe88c3803b82174e5c5e0263b6aa2575c667b97bca69cb569c22b32120869f31",
+			"Peers": [{
+				"ID":         6200298225266045,
+				"StableID":   "nkL6FbK8Rq11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:caa25e6f3964747f2819e3fda3f7c706295b6a49c664b8e2ea89c3969bdbda2b",
+				"DiscoKey":   "discokey:77ec9f8fce0ede08d9d1a5b029f8a0cae296110933405e7519506e79e073333d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:48042", "10.65.0.27:48042", "172.17.0.1:48042"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T10:48:50.362795491Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         772085588111436,
+				"StableID":   "nwaEYzNg2711CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c2079dc508afa576b94809475a2ac47d3a36c6e3f735ef1b55c27ffcec1a373",
+				"DiscoKey":   "discokey:8cb4612d5f0e3c5749ae5ed0fbbbe1785c2932e55ba34fec31e0be6d96f2607a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:55637", "10.65.0.27:55637", "172.17.0.1:55637"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T10:48:50.891907715Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1638953534304319,
+				"StableID":   "n22eVkXHoD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1462e2a6dc4d8abe004dff315631a69b43887f020c6f19139bda5e98be5f75c",
+				"DiscoKey":   "discokey:140fac845fae8282c5c0766d4640b23d93aa54c0b9fa01194f57b1a38629c901",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:44209", "10.65.0.27:44209", "172.17.0.1:44209"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T10:48:51.424310318Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3765147146864741,
+				"StableID":   "ncADEo2FQW11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38fe0b9e71caeb8135dac0fbe880b7e748009c26f0abb43b3527cb72212b175b",
+				"DiscoKey":   "discokey:198022f74d83de950d9085d4fc72fd3fbc42e6f9db4452df75e4ee3820310271",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:49338", "10.65.0.27:49338", "172.17.0.1:49338"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T10:48:51.967866113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3519823077666716,
+				"StableID":   "nBpiJTn8VU11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0d87ab5fbdc9d4e34413f797214d6ac38849e6dc6374e12d90612cba7f8a069",
+				"DiscoKey":   "discokey:0a60fc1cddb12dbd09d89e6b51a4ce9a2411d5e9c839caf89eb396dd0df44851",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:38235", "10.65.0.27:38235", "172.17.0.1:38235"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T10:48:52.512631024Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1986105523559038,
+				"StableID":   "nPm32DdWWG11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5102f677c7b7bb670223630e40cbaea4e932d7d0a62f334e3d39dda92d3fdb77",
+				"DiscoKey":   "discokey:ce969702ba57154bad7015018753d95c981ffd8a8be1de79cea3e61e0bc0297a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:49208", "10.65.0.27:49208", "172.17.0.1:49208"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T10:48:53.034821277Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5130804425872062,
+				"StableID":   "nFwzVrXk4h11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:908f9f71cf33139bd9e32b7628bef012d466eb003ded2d8d99417a85cb294047",
+				"DiscoKey":   "discokey:ceb56c41917fe22122cde49a826c033fede711c180bbe5331d982702739fbc2b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:55194", "10.65.0.27:55194", "172.17.0.1:55194"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T10:48:53.586230203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2159651897938158,
+				"StableID":   "nunjqoP7sH11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e9c626ba7ebfdb3c7dde942b025e7c1e785e5346f6406556926a73daeeb1c816",
+				"DiscoKey":   "discokey:cbcb42ec1c6942dc1516dbd7fa3ccbc14b63f19487e6bdce2f989034bcf02962",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:43026", "10.65.0.27:43026", "172.17.0.1:43026"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T10:48:54.126510557Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1349337447109109,
+				"StableID":   "nWqVcno7YB11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:53b27d1f1c5b6ac9e0ee6390391b0a3635092481c5727fc7ea696388d123a02f",
+				"DiscoKey":   "discokey:081d07001df2cca09159b3071e5ffcd20ce392e9fa11610354247a31d4f09f59",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54340", "10.65.0.27:54340", "172.17.0.1:54340"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T10:48:54.655381755Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5882431403440684,
+				"StableID":   "nuRZgtVAwn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a398e17e1c282f84c5f6b7cfb7446ecaccec8951981b1fd55c1d8e6368d9fa42",
+				"DiscoKey":   "discokey:f8fa287f5363f5bdf521d0b8e84f40c36e1bf3c5465949d12433d213e7e4f718",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:40111", "10.65.0.27:40111", "172.17.0.1:40111"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T10:48:55.202876425Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2367360492594434,
+				"StableID":   "nRLx5fYBVK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:191d2ceeca75f0e2829f5296e0321d7af0b1a9b19888776491e988a1ede7311a",
+				"DiscoKey":   "discokey:fb30d96a84b67697b2c5ba4a27262251e2245a56a402f546b9b2bb8f84f9291d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:40035", "10.65.0.27:40035", "172.17.0.1:40035"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T10:48:55.738626975Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8722759479154595,
+				"StableID":   "nG3DVp6Z7B21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ce0976880a1f7f6dc7475d9cfbc62750f45c14025cea8ac3cbf9c24afba8ba23",
+				"DiscoKey":   "discokey:e0112828e95db0bb1c0982dca3ef7ce2e574c0d18c0462ed202244eac928fc71",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:40653", "10.65.0.27:40653", "172.17.0.1:40653"],
+				"HomeDERP":   26,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T10:48:56.276059496Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8789958571042068,
+				"StableID":   "nuyB8nJzdB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d5f6fca3ad79e6e1c4176b9916873989f27d90b04f1b821734ddac3ea33db221",
+				"KeyExpiry":  "2026-11-09T10:48:56Z",
+				"DiscoKey":   "discokey:29333efc1ed524edb99c6286282bb51a73104d7f9fe6c8e43aa5f607c9efce78",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:50705", "10.65.0.27:50705", "172.17.0.1:50705"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T10:48:56.81026368Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4397469093301501,
+				"StableID":   "nL2HMG4dLb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b3cb7fa4c23188ce2a8ad836a8b252fa1526358fba756bd509adbb33ab240f5c",
+				"KeyExpiry":  "2026-11-09T10:48:57Z",
+				"DiscoKey":   "discokey:73765b4c398fc506d93c97edceb5bd28515a96c711012398c1d91fcf33592012",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:45003", "10.65.0.27:45003", "172.17.0.1:45003"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T10:48:57.352517284Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1638953534304319,
+				"StableID":   "n22eVkXHoD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1638953534304319,
+				"Key":        "nodekey:c1462e2a6dc4d8abe004dff315631a69b43887f020c6f19139bda5e98be5f75c",
+				"DiscoKey":   "discokey:140fac845fae8282c5c0766d4640b23d93aa54c0b9fa01194f57b1a38629c901",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:44209", "10.65.0.27:44209", "172.17.0.1:44209"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T10:48:51.424310318Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c1462e2a6dc4d8abe004dff315631a69b43887f020c6f19139bda5e98be5f75c",
+			"MachineKey": "mkey:88de3e7777edb60bb959f3ec791c9e79ae3463e549c37cdd7c2fad97b6cd0615",
+			"Peers": [{
+				"ID":         6200298225266045,
+				"StableID":   "nkL6FbK8Rq11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:caa25e6f3964747f2819e3fda3f7c706295b6a49c664b8e2ea89c3969bdbda2b",
+				"DiscoKey":   "discokey:77ec9f8fce0ede08d9d1a5b029f8a0cae296110933405e7519506e79e073333d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:48042", "10.65.0.27:48042", "172.17.0.1:48042"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T10:48:50.362795491Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         772085588111436,
+				"StableID":   "nwaEYzNg2711CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c2079dc508afa576b94809475a2ac47d3a36c6e3f735ef1b55c27ffcec1a373",
+				"DiscoKey":   "discokey:8cb4612d5f0e3c5749ae5ed0fbbbe1785c2932e55ba34fec31e0be6d96f2607a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:55637", "10.65.0.27:55637", "172.17.0.1:55637"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T10:48:50.891907715Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3765147146864741,
+				"StableID":   "ncADEo2FQW11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38fe0b9e71caeb8135dac0fbe880b7e748009c26f0abb43b3527cb72212b175b",
+				"DiscoKey":   "discokey:198022f74d83de950d9085d4fc72fd3fbc42e6f9db4452df75e4ee3820310271",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:49338", "10.65.0.27:49338", "172.17.0.1:49338"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T10:48:51.967866113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3519823077666716,
+				"StableID":   "nBpiJTn8VU11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0d87ab5fbdc9d4e34413f797214d6ac38849e6dc6374e12d90612cba7f8a069",
+				"DiscoKey":   "discokey:0a60fc1cddb12dbd09d89e6b51a4ce9a2411d5e9c839caf89eb396dd0df44851",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:38235", "10.65.0.27:38235", "172.17.0.1:38235"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T10:48:52.512631024Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1986105523559038,
+				"StableID":   "nPm32DdWWG11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5102f677c7b7bb670223630e40cbaea4e932d7d0a62f334e3d39dda92d3fdb77",
+				"DiscoKey":   "discokey:ce969702ba57154bad7015018753d95c981ffd8a8be1de79cea3e61e0bc0297a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:49208", "10.65.0.27:49208", "172.17.0.1:49208"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T10:48:53.034821277Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5130804425872062,
+				"StableID":   "nFwzVrXk4h11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:908f9f71cf33139bd9e32b7628bef012d466eb003ded2d8d99417a85cb294047",
+				"DiscoKey":   "discokey:ceb56c41917fe22122cde49a826c033fede711c180bbe5331d982702739fbc2b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:55194", "10.65.0.27:55194", "172.17.0.1:55194"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T10:48:53.586230203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2159651897938158,
+				"StableID":   "nunjqoP7sH11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e9c626ba7ebfdb3c7dde942b025e7c1e785e5346f6406556926a73daeeb1c816",
+				"DiscoKey":   "discokey:cbcb42ec1c6942dc1516dbd7fa3ccbc14b63f19487e6bdce2f989034bcf02962",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:43026", "10.65.0.27:43026", "172.17.0.1:43026"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T10:48:54.126510557Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1349337447109109,
+				"StableID":   "nWqVcno7YB11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:53b27d1f1c5b6ac9e0ee6390391b0a3635092481c5727fc7ea696388d123a02f",
+				"DiscoKey":   "discokey:081d07001df2cca09159b3071e5ffcd20ce392e9fa11610354247a31d4f09f59",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54340", "10.65.0.27:54340", "172.17.0.1:54340"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T10:48:54.655381755Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5882431403440684,
+				"StableID":   "nuRZgtVAwn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a398e17e1c282f84c5f6b7cfb7446ecaccec8951981b1fd55c1d8e6368d9fa42",
+				"DiscoKey":   "discokey:f8fa287f5363f5bdf521d0b8e84f40c36e1bf3c5465949d12433d213e7e4f718",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:40111", "10.65.0.27:40111", "172.17.0.1:40111"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T10:48:55.202876425Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2367360492594434,
+				"StableID":   "nRLx5fYBVK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:191d2ceeca75f0e2829f5296e0321d7af0b1a9b19888776491e988a1ede7311a",
+				"DiscoKey":   "discokey:fb30d96a84b67697b2c5ba4a27262251e2245a56a402f546b9b2bb8f84f9291d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:40035", "10.65.0.27:40035", "172.17.0.1:40035"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T10:48:55.738626975Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8722759479154595,
+				"StableID":   "nG3DVp6Z7B21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ce0976880a1f7f6dc7475d9cfbc62750f45c14025cea8ac3cbf9c24afba8ba23",
+				"DiscoKey":   "discokey:e0112828e95db0bb1c0982dca3ef7ce2e574c0d18c0462ed202244eac928fc71",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:40653", "10.65.0.27:40653", "172.17.0.1:40653"],
+				"HomeDERP":   26,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T10:48:56.276059496Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8789958571042068,
+				"StableID":   "nuyB8nJzdB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d5f6fca3ad79e6e1c4176b9916873989f27d90b04f1b821734ddac3ea33db221",
+				"KeyExpiry":  "2026-11-09T10:48:56Z",
+				"DiscoKey":   "discokey:29333efc1ed524edb99c6286282bb51a73104d7f9fe6c8e43aa5f607c9efce78",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:50705", "10.65.0.27:50705", "172.17.0.1:50705"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T10:48:56.81026368Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4397469093301501,
+				"StableID":   "nL2HMG4dLb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b3cb7fa4c23188ce2a8ad836a8b252fa1526358fba756bd509adbb33ab240f5c",
+				"KeyExpiry":  "2026-11-09T10:48:57Z",
+				"DiscoKey":   "discokey:73765b4c398fc506d93c97edceb5bd28515a96c711012398c1d91fcf33592012",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:45003", "10.65.0.27:45003", "172.17.0.1:45003"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T10:48:57.352517284Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7822324820044157,
+				"StableID":   "nAw947Dk5421CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bbb1fc9a6f7e90fb22a04203694abe55b821617df286d129da214c42b98ea319",
+				"KeyExpiry":  "2026-11-09T10:48:57Z",
+				"DiscoKey":   "discokey:a733427a6a060e36d67831e7b58bc300b184092bf1598e0d517c4a413de3ee58",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:53974", "10.65.0.27:53974", "172.17.0.1:53974"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T10:48:57.903377063Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1638953534304319": {
+				"ID":          1638953534304319,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2159651897938158,
+				"StableID":   "nunjqoP7sH11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       2159651897938158,
+				"Key":        "nodekey:e9c626ba7ebfdb3c7dde942b025e7c1e785e5346f6406556926a73daeeb1c816",
+				"DiscoKey":   "discokey:cbcb42ec1c6942dc1516dbd7fa3ccbc14b63f19487e6bdce2f989034bcf02962",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:43026", "10.65.0.27:43026", "172.17.0.1:43026"],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T10:48:54.126510557Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e9c626ba7ebfdb3c7dde942b025e7c1e785e5346f6406556926a73daeeb1c816",
+			"MachineKey": "mkey:9dbdb62aca089eed843210244b22603cbd48c2b138dfd3851db6996b33a6f376",
+			"Peers": [{
+				"ID":         6200298225266045,
+				"StableID":   "nkL6FbK8Rq11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:caa25e6f3964747f2819e3fda3f7c706295b6a49c664b8e2ea89c3969bdbda2b",
+				"DiscoKey":   "discokey:77ec9f8fce0ede08d9d1a5b029f8a0cae296110933405e7519506e79e073333d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:48042", "10.65.0.27:48042", "172.17.0.1:48042"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T10:48:50.362795491Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         772085588111436,
+				"StableID":   "nwaEYzNg2711CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c2079dc508afa576b94809475a2ac47d3a36c6e3f735ef1b55c27ffcec1a373",
+				"DiscoKey":   "discokey:8cb4612d5f0e3c5749ae5ed0fbbbe1785c2932e55ba34fec31e0be6d96f2607a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:55637", "10.65.0.27:55637", "172.17.0.1:55637"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T10:48:50.891907715Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1638953534304319,
+				"StableID":   "n22eVkXHoD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1462e2a6dc4d8abe004dff315631a69b43887f020c6f19139bda5e98be5f75c",
+				"DiscoKey":   "discokey:140fac845fae8282c5c0766d4640b23d93aa54c0b9fa01194f57b1a38629c901",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:44209", "10.65.0.27:44209", "172.17.0.1:44209"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T10:48:51.424310318Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3765147146864741,
+				"StableID":   "ncADEo2FQW11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38fe0b9e71caeb8135dac0fbe880b7e748009c26f0abb43b3527cb72212b175b",
+				"DiscoKey":   "discokey:198022f74d83de950d9085d4fc72fd3fbc42e6f9db4452df75e4ee3820310271",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:49338", "10.65.0.27:49338", "172.17.0.1:49338"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T10:48:51.967866113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3519823077666716,
+				"StableID":   "nBpiJTn8VU11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0d87ab5fbdc9d4e34413f797214d6ac38849e6dc6374e12d90612cba7f8a069",
+				"DiscoKey":   "discokey:0a60fc1cddb12dbd09d89e6b51a4ce9a2411d5e9c839caf89eb396dd0df44851",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:38235", "10.65.0.27:38235", "172.17.0.1:38235"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T10:48:52.512631024Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1986105523559038,
+				"StableID":   "nPm32DdWWG11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5102f677c7b7bb670223630e40cbaea4e932d7d0a62f334e3d39dda92d3fdb77",
+				"DiscoKey":   "discokey:ce969702ba57154bad7015018753d95c981ffd8a8be1de79cea3e61e0bc0297a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:49208", "10.65.0.27:49208", "172.17.0.1:49208"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T10:48:53.034821277Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5130804425872062,
+				"StableID":   "nFwzVrXk4h11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:908f9f71cf33139bd9e32b7628bef012d466eb003ded2d8d99417a85cb294047",
+				"DiscoKey":   "discokey:ceb56c41917fe22122cde49a826c033fede711c180bbe5331d982702739fbc2b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:55194", "10.65.0.27:55194", "172.17.0.1:55194"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T10:48:53.586230203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1349337447109109,
+				"StableID":   "nWqVcno7YB11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:53b27d1f1c5b6ac9e0ee6390391b0a3635092481c5727fc7ea696388d123a02f",
+				"DiscoKey":   "discokey:081d07001df2cca09159b3071e5ffcd20ce392e9fa11610354247a31d4f09f59",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54340", "10.65.0.27:54340", "172.17.0.1:54340"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T10:48:54.655381755Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5882431403440684,
+				"StableID":   "nuRZgtVAwn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a398e17e1c282f84c5f6b7cfb7446ecaccec8951981b1fd55c1d8e6368d9fa42",
+				"DiscoKey":   "discokey:f8fa287f5363f5bdf521d0b8e84f40c36e1bf3c5465949d12433d213e7e4f718",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:40111", "10.65.0.27:40111", "172.17.0.1:40111"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T10:48:55.202876425Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2367360492594434,
+				"StableID":   "nRLx5fYBVK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:191d2ceeca75f0e2829f5296e0321d7af0b1a9b19888776491e988a1ede7311a",
+				"DiscoKey":   "discokey:fb30d96a84b67697b2c5ba4a27262251e2245a56a402f546b9b2bb8f84f9291d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:40035", "10.65.0.27:40035", "172.17.0.1:40035"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T10:48:55.738626975Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8722759479154595,
+				"StableID":   "nG3DVp6Z7B21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ce0976880a1f7f6dc7475d9cfbc62750f45c14025cea8ac3cbf9c24afba8ba23",
+				"DiscoKey":   "discokey:e0112828e95db0bb1c0982dca3ef7ce2e574c0d18c0462ed202244eac928fc71",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:40653", "10.65.0.27:40653", "172.17.0.1:40653"],
+				"HomeDERP":   26,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T10:48:56.276059496Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8789958571042068,
+				"StableID":   "nuyB8nJzdB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d5f6fca3ad79e6e1c4176b9916873989f27d90b04f1b821734ddac3ea33db221",
+				"KeyExpiry":  "2026-11-09T10:48:56Z",
+				"DiscoKey":   "discokey:29333efc1ed524edb99c6286282bb51a73104d7f9fe6c8e43aa5f607c9efce78",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:50705", "10.65.0.27:50705", "172.17.0.1:50705"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T10:48:56.81026368Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4397469093301501,
+				"StableID":   "nL2HMG4dLb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b3cb7fa4c23188ce2a8ad836a8b252fa1526358fba756bd509adbb33ab240f5c",
+				"KeyExpiry":  "2026-11-09T10:48:57Z",
+				"DiscoKey":   "discokey:73765b4c398fc506d93c97edceb5bd28515a96c711012398c1d91fcf33592012",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:45003", "10.65.0.27:45003", "172.17.0.1:45003"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T10:48:57.352517284Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7822324820044157,
+				"StableID":   "nAw947Dk5421CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bbb1fc9a6f7e90fb22a04203694abe55b821617df286d129da214c42b98ea319",
+				"KeyExpiry":  "2026-11-09T10:48:57Z",
+				"DiscoKey":   "discokey:a733427a6a060e36d67831e7b58bc300b184092bf1598e0d517c4a413de3ee58",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:53974", "10.65.0.27:53974", "172.17.0.1:53974"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T10:48:57.903377063Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2159651897938158": {
+				"ID":          2159651897938158,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8789958571042068,
+				"StableID":   "nuyB8nJzdB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d5f6fca3ad79e6e1c4176b9916873989f27d90b04f1b821734ddac3ea33db221",
+				"KeyExpiry":  "2026-11-09T10:48:56Z",
+				"DiscoKey":   "discokey:29333efc1ed524edb99c6286282bb51a73104d7f9fe6c8e43aa5f607c9efce78",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:50705", "10.65.0.27:50705", "172.17.0.1:50705"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T10:48:56.81026368Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d5f6fca3ad79e6e1c4176b9916873989f27d90b04f1b821734ddac3ea33db221",
+			"MachineKey": "mkey:db813f7e596172e9b632fbe69cdf33d69014075a5c6ee5175e39acaa4dab8701",
+			"Peers": [{
+				"ID":         6200298225266045,
+				"StableID":   "nkL6FbK8Rq11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:caa25e6f3964747f2819e3fda3f7c706295b6a49c664b8e2ea89c3969bdbda2b",
+				"DiscoKey":   "discokey:77ec9f8fce0ede08d9d1a5b029f8a0cae296110933405e7519506e79e073333d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:48042", "10.65.0.27:48042", "172.17.0.1:48042"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T10:48:50.362795491Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         772085588111436,
+				"StableID":   "nwaEYzNg2711CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c2079dc508afa576b94809475a2ac47d3a36c6e3f735ef1b55c27ffcec1a373",
+				"DiscoKey":   "discokey:8cb4612d5f0e3c5749ae5ed0fbbbe1785c2932e55ba34fec31e0be6d96f2607a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:55637", "10.65.0.27:55637", "172.17.0.1:55637"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T10:48:50.891907715Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1638953534304319,
+				"StableID":   "n22eVkXHoD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1462e2a6dc4d8abe004dff315631a69b43887f020c6f19139bda5e98be5f75c",
+				"DiscoKey":   "discokey:140fac845fae8282c5c0766d4640b23d93aa54c0b9fa01194f57b1a38629c901",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:44209", "10.65.0.27:44209", "172.17.0.1:44209"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T10:48:51.424310318Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3765147146864741,
+				"StableID":   "ncADEo2FQW11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38fe0b9e71caeb8135dac0fbe880b7e748009c26f0abb43b3527cb72212b175b",
+				"DiscoKey":   "discokey:198022f74d83de950d9085d4fc72fd3fbc42e6f9db4452df75e4ee3820310271",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:49338", "10.65.0.27:49338", "172.17.0.1:49338"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T10:48:51.967866113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3519823077666716,
+				"StableID":   "nBpiJTn8VU11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0d87ab5fbdc9d4e34413f797214d6ac38849e6dc6374e12d90612cba7f8a069",
+				"DiscoKey":   "discokey:0a60fc1cddb12dbd09d89e6b51a4ce9a2411d5e9c839caf89eb396dd0df44851",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:38235", "10.65.0.27:38235", "172.17.0.1:38235"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T10:48:52.512631024Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1986105523559038,
+				"StableID":   "nPm32DdWWG11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5102f677c7b7bb670223630e40cbaea4e932d7d0a62f334e3d39dda92d3fdb77",
+				"DiscoKey":   "discokey:ce969702ba57154bad7015018753d95c981ffd8a8be1de79cea3e61e0bc0297a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:49208", "10.65.0.27:49208", "172.17.0.1:49208"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T10:48:53.034821277Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5130804425872062,
+				"StableID":   "nFwzVrXk4h11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:908f9f71cf33139bd9e32b7628bef012d466eb003ded2d8d99417a85cb294047",
+				"DiscoKey":   "discokey:ceb56c41917fe22122cde49a826c033fede711c180bbe5331d982702739fbc2b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:55194", "10.65.0.27:55194", "172.17.0.1:55194"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T10:48:53.586230203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2159651897938158,
+				"StableID":   "nunjqoP7sH11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e9c626ba7ebfdb3c7dde942b025e7c1e785e5346f6406556926a73daeeb1c816",
+				"DiscoKey":   "discokey:cbcb42ec1c6942dc1516dbd7fa3ccbc14b63f19487e6bdce2f989034bcf02962",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:43026", "10.65.0.27:43026", "172.17.0.1:43026"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T10:48:54.126510557Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1349337447109109,
+				"StableID":   "nWqVcno7YB11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:53b27d1f1c5b6ac9e0ee6390391b0a3635092481c5727fc7ea696388d123a02f",
+				"DiscoKey":   "discokey:081d07001df2cca09159b3071e5ffcd20ce392e9fa11610354247a31d4f09f59",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54340", "10.65.0.27:54340", "172.17.0.1:54340"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T10:48:54.655381755Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5882431403440684,
+				"StableID":   "nuRZgtVAwn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a398e17e1c282f84c5f6b7cfb7446ecaccec8951981b1fd55c1d8e6368d9fa42",
+				"DiscoKey":   "discokey:f8fa287f5363f5bdf521d0b8e84f40c36e1bf3c5465949d12433d213e7e4f718",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:40111", "10.65.0.27:40111", "172.17.0.1:40111"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T10:48:55.202876425Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2367360492594434,
+				"StableID":   "nRLx5fYBVK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:191d2ceeca75f0e2829f5296e0321d7af0b1a9b19888776491e988a1ede7311a",
+				"DiscoKey":   "discokey:fb30d96a84b67697b2c5ba4a27262251e2245a56a402f546b9b2bb8f84f9291d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:40035", "10.65.0.27:40035", "172.17.0.1:40035"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T10:48:55.738626975Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8722759479154595,
+				"StableID":   "nG3DVp6Z7B21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ce0976880a1f7f6dc7475d9cfbc62750f45c14025cea8ac3cbf9c24afba8ba23",
+				"DiscoKey":   "discokey:e0112828e95db0bb1c0982dca3ef7ce2e574c0d18c0462ed202244eac928fc71",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:40653", "10.65.0.27:40653", "172.17.0.1:40653"],
+				"HomeDERP":   26,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T10:48:56.276059496Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4397469093301501,
+				"StableID":   "nL2HMG4dLb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b3cb7fa4c23188ce2a8ad836a8b252fa1526358fba756bd509adbb33ab240f5c",
+				"KeyExpiry":  "2026-11-09T10:48:57Z",
+				"DiscoKey":   "discokey:73765b4c398fc506d93c97edceb5bd28515a96c711012398c1d91fcf33592012",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:45003", "10.65.0.27:45003", "172.17.0.1:45003"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T10:48:57.352517284Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7822324820044157,
+				"StableID":   "nAw947Dk5421CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bbb1fc9a6f7e90fb22a04203694abe55b821617df286d129da214c42b98ea319",
+				"KeyExpiry":  "2026-11-09T10:48:57Z",
+				"DiscoKey":   "discokey:a733427a6a060e36d67831e7b58bc300b184092bf1598e0d517c4a413de3ee58",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:53974", "10.65.0.27:53974", "172.17.0.1:53974"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T10:48:57.903377063Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2367360492594434,
+				"StableID":   "nRLx5fYBVK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       2367360492594434,
+				"Key":        "nodekey:191d2ceeca75f0e2829f5296e0321d7af0b1a9b19888776491e988a1ede7311a",
+				"DiscoKey":   "discokey:fb30d96a84b67697b2c5ba4a27262251e2245a56a402f546b9b2bb8f84f9291d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:40035", "10.65.0.27:40035", "172.17.0.1:40035"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T10:48:55.738626975Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:191d2ceeca75f0e2829f5296e0321d7af0b1a9b19888776491e988a1ede7311a",
+			"MachineKey": "mkey:25338232ba5bc2801a583c4a8f0942f0d4094faefeb5fe7d21caa92ed676311e",
+			"Peers": [{
+				"ID":         6200298225266045,
+				"StableID":   "nkL6FbK8Rq11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:caa25e6f3964747f2819e3fda3f7c706295b6a49c664b8e2ea89c3969bdbda2b",
+				"DiscoKey":   "discokey:77ec9f8fce0ede08d9d1a5b029f8a0cae296110933405e7519506e79e073333d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:48042", "10.65.0.27:48042", "172.17.0.1:48042"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T10:48:50.362795491Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         772085588111436,
+				"StableID":   "nwaEYzNg2711CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c2079dc508afa576b94809475a2ac47d3a36c6e3f735ef1b55c27ffcec1a373",
+				"DiscoKey":   "discokey:8cb4612d5f0e3c5749ae5ed0fbbbe1785c2932e55ba34fec31e0be6d96f2607a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:55637", "10.65.0.27:55637", "172.17.0.1:55637"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T10:48:50.891907715Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1638953534304319,
+				"StableID":   "n22eVkXHoD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1462e2a6dc4d8abe004dff315631a69b43887f020c6f19139bda5e98be5f75c",
+				"DiscoKey":   "discokey:140fac845fae8282c5c0766d4640b23d93aa54c0b9fa01194f57b1a38629c901",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:44209", "10.65.0.27:44209", "172.17.0.1:44209"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T10:48:51.424310318Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3765147146864741,
+				"StableID":   "ncADEo2FQW11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38fe0b9e71caeb8135dac0fbe880b7e748009c26f0abb43b3527cb72212b175b",
+				"DiscoKey":   "discokey:198022f74d83de950d9085d4fc72fd3fbc42e6f9db4452df75e4ee3820310271",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:49338", "10.65.0.27:49338", "172.17.0.1:49338"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T10:48:51.967866113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3519823077666716,
+				"StableID":   "nBpiJTn8VU11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0d87ab5fbdc9d4e34413f797214d6ac38849e6dc6374e12d90612cba7f8a069",
+				"DiscoKey":   "discokey:0a60fc1cddb12dbd09d89e6b51a4ce9a2411d5e9c839caf89eb396dd0df44851",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:38235", "10.65.0.27:38235", "172.17.0.1:38235"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T10:48:52.512631024Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1986105523559038,
+				"StableID":   "nPm32DdWWG11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5102f677c7b7bb670223630e40cbaea4e932d7d0a62f334e3d39dda92d3fdb77",
+				"DiscoKey":   "discokey:ce969702ba57154bad7015018753d95c981ffd8a8be1de79cea3e61e0bc0297a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:49208", "10.65.0.27:49208", "172.17.0.1:49208"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T10:48:53.034821277Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5130804425872062,
+				"StableID":   "nFwzVrXk4h11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:908f9f71cf33139bd9e32b7628bef012d466eb003ded2d8d99417a85cb294047",
+				"DiscoKey":   "discokey:ceb56c41917fe22122cde49a826c033fede711c180bbe5331d982702739fbc2b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:55194", "10.65.0.27:55194", "172.17.0.1:55194"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T10:48:53.586230203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2159651897938158,
+				"StableID":   "nunjqoP7sH11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e9c626ba7ebfdb3c7dde942b025e7c1e785e5346f6406556926a73daeeb1c816",
+				"DiscoKey":   "discokey:cbcb42ec1c6942dc1516dbd7fa3ccbc14b63f19487e6bdce2f989034bcf02962",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:43026", "10.65.0.27:43026", "172.17.0.1:43026"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T10:48:54.126510557Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1349337447109109,
+				"StableID":   "nWqVcno7YB11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:53b27d1f1c5b6ac9e0ee6390391b0a3635092481c5727fc7ea696388d123a02f",
+				"DiscoKey":   "discokey:081d07001df2cca09159b3071e5ffcd20ce392e9fa11610354247a31d4f09f59",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54340", "10.65.0.27:54340", "172.17.0.1:54340"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T10:48:54.655381755Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5882431403440684,
+				"StableID":   "nuRZgtVAwn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a398e17e1c282f84c5f6b7cfb7446ecaccec8951981b1fd55c1d8e6368d9fa42",
+				"DiscoKey":   "discokey:f8fa287f5363f5bdf521d0b8e84f40c36e1bf3c5465949d12433d213e7e4f718",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:40111", "10.65.0.27:40111", "172.17.0.1:40111"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T10:48:55.202876425Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8722759479154595,
+				"StableID":   "nG3DVp6Z7B21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ce0976880a1f7f6dc7475d9cfbc62750f45c14025cea8ac3cbf9c24afba8ba23",
+				"DiscoKey":   "discokey:e0112828e95db0bb1c0982dca3ef7ce2e574c0d18c0462ed202244eac928fc71",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:40653", "10.65.0.27:40653", "172.17.0.1:40653"],
+				"HomeDERP":   26,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T10:48:56.276059496Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8789958571042068,
+				"StableID":   "nuyB8nJzdB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d5f6fca3ad79e6e1c4176b9916873989f27d90b04f1b821734ddac3ea33db221",
+				"KeyExpiry":  "2026-11-09T10:48:56Z",
+				"DiscoKey":   "discokey:29333efc1ed524edb99c6286282bb51a73104d7f9fe6c8e43aa5f607c9efce78",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:50705", "10.65.0.27:50705", "172.17.0.1:50705"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T10:48:56.81026368Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4397469093301501,
+				"StableID":   "nL2HMG4dLb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b3cb7fa4c23188ce2a8ad836a8b252fa1526358fba756bd509adbb33ab240f5c",
+				"KeyExpiry":  "2026-11-09T10:48:57Z",
+				"DiscoKey":   "discokey:73765b4c398fc506d93c97edceb5bd28515a96c711012398c1d91fcf33592012",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:45003", "10.65.0.27:45003", "172.17.0.1:45003"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T10:48:57.352517284Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7822324820044157,
+				"StableID":   "nAw947Dk5421CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bbb1fc9a6f7e90fb22a04203694abe55b821617df286d129da214c42b98ea319",
+				"KeyExpiry":  "2026-11-09T10:48:57Z",
+				"DiscoKey":   "discokey:a733427a6a060e36d67831e7b58bc300b184092bf1598e0d517c4a413de3ee58",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:53974", "10.65.0.27:53974", "172.17.0.1:53974"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T10:48:57.903377063Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2367360492594434": {
+				"ID":          2367360492594434,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         772085588111436,
+				"StableID":   "nwaEYzNg2711CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       772085588111436,
+				"Key":        "nodekey:1c2079dc508afa576b94809475a2ac47d3a36c6e3f735ef1b55c27ffcec1a373",
+				"DiscoKey":   "discokey:8cb4612d5f0e3c5749ae5ed0fbbbe1785c2932e55ba34fec31e0be6d96f2607a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:55637", "10.65.0.27:55637", "172.17.0.1:55637"],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T10:48:50.891907715Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1c2079dc508afa576b94809475a2ac47d3a36c6e3f735ef1b55c27ffcec1a373",
+			"MachineKey": "mkey:2dd462b76957c5cd6d3354f5b9b0a6f8517b040d2788e8ec3625bd8853be451b",
+			"Peers": [{
+				"ID":         6200298225266045,
+				"StableID":   "nkL6FbK8Rq11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:caa25e6f3964747f2819e3fda3f7c706295b6a49c664b8e2ea89c3969bdbda2b",
+				"DiscoKey":   "discokey:77ec9f8fce0ede08d9d1a5b029f8a0cae296110933405e7519506e79e073333d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:48042", "10.65.0.27:48042", "172.17.0.1:48042"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T10:48:50.362795491Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1638953534304319,
+				"StableID":   "n22eVkXHoD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1462e2a6dc4d8abe004dff315631a69b43887f020c6f19139bda5e98be5f75c",
+				"DiscoKey":   "discokey:140fac845fae8282c5c0766d4640b23d93aa54c0b9fa01194f57b1a38629c901",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:44209", "10.65.0.27:44209", "172.17.0.1:44209"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T10:48:51.424310318Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3765147146864741,
+				"StableID":   "ncADEo2FQW11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38fe0b9e71caeb8135dac0fbe880b7e748009c26f0abb43b3527cb72212b175b",
+				"DiscoKey":   "discokey:198022f74d83de950d9085d4fc72fd3fbc42e6f9db4452df75e4ee3820310271",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:49338", "10.65.0.27:49338", "172.17.0.1:49338"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T10:48:51.967866113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3519823077666716,
+				"StableID":   "nBpiJTn8VU11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0d87ab5fbdc9d4e34413f797214d6ac38849e6dc6374e12d90612cba7f8a069",
+				"DiscoKey":   "discokey:0a60fc1cddb12dbd09d89e6b51a4ce9a2411d5e9c839caf89eb396dd0df44851",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:38235", "10.65.0.27:38235", "172.17.0.1:38235"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T10:48:52.512631024Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1986105523559038,
+				"StableID":   "nPm32DdWWG11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5102f677c7b7bb670223630e40cbaea4e932d7d0a62f334e3d39dda92d3fdb77",
+				"DiscoKey":   "discokey:ce969702ba57154bad7015018753d95c981ffd8a8be1de79cea3e61e0bc0297a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:49208", "10.65.0.27:49208", "172.17.0.1:49208"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T10:48:53.034821277Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5130804425872062,
+				"StableID":   "nFwzVrXk4h11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:908f9f71cf33139bd9e32b7628bef012d466eb003ded2d8d99417a85cb294047",
+				"DiscoKey":   "discokey:ceb56c41917fe22122cde49a826c033fede711c180bbe5331d982702739fbc2b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:55194", "10.65.0.27:55194", "172.17.0.1:55194"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T10:48:53.586230203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2159651897938158,
+				"StableID":   "nunjqoP7sH11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e9c626ba7ebfdb3c7dde942b025e7c1e785e5346f6406556926a73daeeb1c816",
+				"DiscoKey":   "discokey:cbcb42ec1c6942dc1516dbd7fa3ccbc14b63f19487e6bdce2f989034bcf02962",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:43026", "10.65.0.27:43026", "172.17.0.1:43026"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T10:48:54.126510557Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1349337447109109,
+				"StableID":   "nWqVcno7YB11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:53b27d1f1c5b6ac9e0ee6390391b0a3635092481c5727fc7ea696388d123a02f",
+				"DiscoKey":   "discokey:081d07001df2cca09159b3071e5ffcd20ce392e9fa11610354247a31d4f09f59",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54340", "10.65.0.27:54340", "172.17.0.1:54340"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T10:48:54.655381755Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5882431403440684,
+				"StableID":   "nuRZgtVAwn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a398e17e1c282f84c5f6b7cfb7446ecaccec8951981b1fd55c1d8e6368d9fa42",
+				"DiscoKey":   "discokey:f8fa287f5363f5bdf521d0b8e84f40c36e1bf3c5465949d12433d213e7e4f718",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:40111", "10.65.0.27:40111", "172.17.0.1:40111"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T10:48:55.202876425Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2367360492594434,
+				"StableID":   "nRLx5fYBVK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:191d2ceeca75f0e2829f5296e0321d7af0b1a9b19888776491e988a1ede7311a",
+				"DiscoKey":   "discokey:fb30d96a84b67697b2c5ba4a27262251e2245a56a402f546b9b2bb8f84f9291d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:40035", "10.65.0.27:40035", "172.17.0.1:40035"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T10:48:55.738626975Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8722759479154595,
+				"StableID":   "nG3DVp6Z7B21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ce0976880a1f7f6dc7475d9cfbc62750f45c14025cea8ac3cbf9c24afba8ba23",
+				"DiscoKey":   "discokey:e0112828e95db0bb1c0982dca3ef7ce2e574c0d18c0462ed202244eac928fc71",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:40653", "10.65.0.27:40653", "172.17.0.1:40653"],
+				"HomeDERP":   26,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T10:48:56.276059496Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8789958571042068,
+				"StableID":   "nuyB8nJzdB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d5f6fca3ad79e6e1c4176b9916873989f27d90b04f1b821734ddac3ea33db221",
+				"KeyExpiry":  "2026-11-09T10:48:56Z",
+				"DiscoKey":   "discokey:29333efc1ed524edb99c6286282bb51a73104d7f9fe6c8e43aa5f607c9efce78",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:50705", "10.65.0.27:50705", "172.17.0.1:50705"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T10:48:56.81026368Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4397469093301501,
+				"StableID":   "nL2HMG4dLb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b3cb7fa4c23188ce2a8ad836a8b252fa1526358fba756bd509adbb33ab240f5c",
+				"KeyExpiry":  "2026-11-09T10:48:57Z",
+				"DiscoKey":   "discokey:73765b4c398fc506d93c97edceb5bd28515a96c711012398c1d91fcf33592012",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:45003", "10.65.0.27:45003", "172.17.0.1:45003"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T10:48:57.352517284Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7822324820044157,
+				"StableID":   "nAw947Dk5421CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bbb1fc9a6f7e90fb22a04203694abe55b821617df286d129da214c42b98ea319",
+				"KeyExpiry":  "2026-11-09T10:48:57Z",
+				"DiscoKey":   "discokey:a733427a6a060e36d67831e7b58bc300b184092bf1598e0d517c4a413de3ee58",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:53974", "10.65.0.27:53974", "172.17.0.1:53974"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T10:48:57.903377063Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "772085588111436": {
+				"ID":          772085588111436,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6200298225266045,
+				"StableID":   "nkL6FbK8Rq11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       6200298225266045,
+				"Key":        "nodekey:caa25e6f3964747f2819e3fda3f7c706295b6a49c664b8e2ea89c3969bdbda2b",
+				"DiscoKey":   "discokey:77ec9f8fce0ede08d9d1a5b029f8a0cae296110933405e7519506e79e073333d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:48042", "10.65.0.27:48042", "172.17.0.1:48042"],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T10:48:50.362795491Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:caa25e6f3964747f2819e3fda3f7c706295b6a49c664b8e2ea89c3969bdbda2b",
+			"MachineKey": "mkey:83aa5bc784977d87ee4ca20a505b454b1acd4d74244beb4cb465b2e804e12905",
+			"Peers": [{
+				"ID":         772085588111436,
+				"StableID":   "nwaEYzNg2711CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c2079dc508afa576b94809475a2ac47d3a36c6e3f735ef1b55c27ffcec1a373",
+				"DiscoKey":   "discokey:8cb4612d5f0e3c5749ae5ed0fbbbe1785c2932e55ba34fec31e0be6d96f2607a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:55637", "10.65.0.27:55637", "172.17.0.1:55637"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T10:48:50.891907715Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1638953534304319,
+				"StableID":   "n22eVkXHoD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1462e2a6dc4d8abe004dff315631a69b43887f020c6f19139bda5e98be5f75c",
+				"DiscoKey":   "discokey:140fac845fae8282c5c0766d4640b23d93aa54c0b9fa01194f57b1a38629c901",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:44209", "10.65.0.27:44209", "172.17.0.1:44209"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T10:48:51.424310318Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3765147146864741,
+				"StableID":   "ncADEo2FQW11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38fe0b9e71caeb8135dac0fbe880b7e748009c26f0abb43b3527cb72212b175b",
+				"DiscoKey":   "discokey:198022f74d83de950d9085d4fc72fd3fbc42e6f9db4452df75e4ee3820310271",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:49338", "10.65.0.27:49338", "172.17.0.1:49338"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T10:48:51.967866113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3519823077666716,
+				"StableID":   "nBpiJTn8VU11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0d87ab5fbdc9d4e34413f797214d6ac38849e6dc6374e12d90612cba7f8a069",
+				"DiscoKey":   "discokey:0a60fc1cddb12dbd09d89e6b51a4ce9a2411d5e9c839caf89eb396dd0df44851",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:38235", "10.65.0.27:38235", "172.17.0.1:38235"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T10:48:52.512631024Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1986105523559038,
+				"StableID":   "nPm32DdWWG11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5102f677c7b7bb670223630e40cbaea4e932d7d0a62f334e3d39dda92d3fdb77",
+				"DiscoKey":   "discokey:ce969702ba57154bad7015018753d95c981ffd8a8be1de79cea3e61e0bc0297a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:49208", "10.65.0.27:49208", "172.17.0.1:49208"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T10:48:53.034821277Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5130804425872062,
+				"StableID":   "nFwzVrXk4h11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:908f9f71cf33139bd9e32b7628bef012d466eb003ded2d8d99417a85cb294047",
+				"DiscoKey":   "discokey:ceb56c41917fe22122cde49a826c033fede711c180bbe5331d982702739fbc2b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:55194", "10.65.0.27:55194", "172.17.0.1:55194"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T10:48:53.586230203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2159651897938158,
+				"StableID":   "nunjqoP7sH11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e9c626ba7ebfdb3c7dde942b025e7c1e785e5346f6406556926a73daeeb1c816",
+				"DiscoKey":   "discokey:cbcb42ec1c6942dc1516dbd7fa3ccbc14b63f19487e6bdce2f989034bcf02962",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:43026", "10.65.0.27:43026", "172.17.0.1:43026"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T10:48:54.126510557Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1349337447109109,
+				"StableID":   "nWqVcno7YB11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:53b27d1f1c5b6ac9e0ee6390391b0a3635092481c5727fc7ea696388d123a02f",
+				"DiscoKey":   "discokey:081d07001df2cca09159b3071e5ffcd20ce392e9fa11610354247a31d4f09f59",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54340", "10.65.0.27:54340", "172.17.0.1:54340"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T10:48:54.655381755Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5882431403440684,
+				"StableID":   "nuRZgtVAwn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a398e17e1c282f84c5f6b7cfb7446ecaccec8951981b1fd55c1d8e6368d9fa42",
+				"DiscoKey":   "discokey:f8fa287f5363f5bdf521d0b8e84f40c36e1bf3c5465949d12433d213e7e4f718",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:40111", "10.65.0.27:40111", "172.17.0.1:40111"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T10:48:55.202876425Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2367360492594434,
+				"StableID":   "nRLx5fYBVK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:191d2ceeca75f0e2829f5296e0321d7af0b1a9b19888776491e988a1ede7311a",
+				"DiscoKey":   "discokey:fb30d96a84b67697b2c5ba4a27262251e2245a56a402f546b9b2bb8f84f9291d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:40035", "10.65.0.27:40035", "172.17.0.1:40035"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T10:48:55.738626975Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8722759479154595,
+				"StableID":   "nG3DVp6Z7B21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ce0976880a1f7f6dc7475d9cfbc62750f45c14025cea8ac3cbf9c24afba8ba23",
+				"DiscoKey":   "discokey:e0112828e95db0bb1c0982dca3ef7ce2e574c0d18c0462ed202244eac928fc71",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:40653", "10.65.0.27:40653", "172.17.0.1:40653"],
+				"HomeDERP":   26,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T10:48:56.276059496Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8789958571042068,
+				"StableID":   "nuyB8nJzdB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d5f6fca3ad79e6e1c4176b9916873989f27d90b04f1b821734ddac3ea33db221",
+				"KeyExpiry":  "2026-11-09T10:48:56Z",
+				"DiscoKey":   "discokey:29333efc1ed524edb99c6286282bb51a73104d7f9fe6c8e43aa5f607c9efce78",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:50705", "10.65.0.27:50705", "172.17.0.1:50705"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T10:48:56.81026368Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4397469093301501,
+				"StableID":   "nL2HMG4dLb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b3cb7fa4c23188ce2a8ad836a8b252fa1526358fba756bd509adbb33ab240f5c",
+				"KeyExpiry":  "2026-11-09T10:48:57Z",
+				"DiscoKey":   "discokey:73765b4c398fc506d93c97edceb5bd28515a96c711012398c1d91fcf33592012",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:45003", "10.65.0.27:45003", "172.17.0.1:45003"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T10:48:57.352517284Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7822324820044157,
+				"StableID":   "nAw947Dk5421CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bbb1fc9a6f7e90fb22a04203694abe55b821617df286d129da214c42b98ea319",
+				"KeyExpiry":  "2026-11-09T10:48:57Z",
+				"DiscoKey":   "discokey:a733427a6a060e36d67831e7b58bc300b184092bf1598e0d517c4a413de3ee58",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:53974", "10.65.0.27:53974", "172.17.0.1:53974"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T10:48:57.903377063Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6200298225266045": {
+				"ID":          6200298225266045,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3519823077666716,
+				"StableID":   "nBpiJTn8VU11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       3519823077666716,
+				"Key":        "nodekey:e0d87ab5fbdc9d4e34413f797214d6ac38849e6dc6374e12d90612cba7f8a069",
+				"DiscoKey":   "discokey:0a60fc1cddb12dbd09d89e6b51a4ce9a2411d5e9c839caf89eb396dd0df44851",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:38235", "10.65.0.27:38235", "172.17.0.1:38235"],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T10:48:52.512631024Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e0d87ab5fbdc9d4e34413f797214d6ac38849e6dc6374e12d90612cba7f8a069",
+			"MachineKey": "mkey:c8d911aa0beb92048817b9af5f30ddcb31492ef289ce7a3e533dcf5a29d4c446",
+			"Peers": [{
+				"ID":         6200298225266045,
+				"StableID":   "nkL6FbK8Rq11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:caa25e6f3964747f2819e3fda3f7c706295b6a49c664b8e2ea89c3969bdbda2b",
+				"DiscoKey":   "discokey:77ec9f8fce0ede08d9d1a5b029f8a0cae296110933405e7519506e79e073333d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:48042", "10.65.0.27:48042", "172.17.0.1:48042"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T10:48:50.362795491Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         772085588111436,
+				"StableID":   "nwaEYzNg2711CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c2079dc508afa576b94809475a2ac47d3a36c6e3f735ef1b55c27ffcec1a373",
+				"DiscoKey":   "discokey:8cb4612d5f0e3c5749ae5ed0fbbbe1785c2932e55ba34fec31e0be6d96f2607a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:55637", "10.65.0.27:55637", "172.17.0.1:55637"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T10:48:50.891907715Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1638953534304319,
+				"StableID":   "n22eVkXHoD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1462e2a6dc4d8abe004dff315631a69b43887f020c6f19139bda5e98be5f75c",
+				"DiscoKey":   "discokey:140fac845fae8282c5c0766d4640b23d93aa54c0b9fa01194f57b1a38629c901",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:44209", "10.65.0.27:44209", "172.17.0.1:44209"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T10:48:51.424310318Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3765147146864741,
+				"StableID":   "ncADEo2FQW11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38fe0b9e71caeb8135dac0fbe880b7e748009c26f0abb43b3527cb72212b175b",
+				"DiscoKey":   "discokey:198022f74d83de950d9085d4fc72fd3fbc42e6f9db4452df75e4ee3820310271",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:49338", "10.65.0.27:49338", "172.17.0.1:49338"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T10:48:51.967866113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1986105523559038,
+				"StableID":   "nPm32DdWWG11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5102f677c7b7bb670223630e40cbaea4e932d7d0a62f334e3d39dda92d3fdb77",
+				"DiscoKey":   "discokey:ce969702ba57154bad7015018753d95c981ffd8a8be1de79cea3e61e0bc0297a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:49208", "10.65.0.27:49208", "172.17.0.1:49208"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T10:48:53.034821277Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5130804425872062,
+				"StableID":   "nFwzVrXk4h11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:908f9f71cf33139bd9e32b7628bef012d466eb003ded2d8d99417a85cb294047",
+				"DiscoKey":   "discokey:ceb56c41917fe22122cde49a826c033fede711c180bbe5331d982702739fbc2b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:55194", "10.65.0.27:55194", "172.17.0.1:55194"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T10:48:53.586230203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2159651897938158,
+				"StableID":   "nunjqoP7sH11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e9c626ba7ebfdb3c7dde942b025e7c1e785e5346f6406556926a73daeeb1c816",
+				"DiscoKey":   "discokey:cbcb42ec1c6942dc1516dbd7fa3ccbc14b63f19487e6bdce2f989034bcf02962",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:43026", "10.65.0.27:43026", "172.17.0.1:43026"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T10:48:54.126510557Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1349337447109109,
+				"StableID":   "nWqVcno7YB11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:53b27d1f1c5b6ac9e0ee6390391b0a3635092481c5727fc7ea696388d123a02f",
+				"DiscoKey":   "discokey:081d07001df2cca09159b3071e5ffcd20ce392e9fa11610354247a31d4f09f59",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54340", "10.65.0.27:54340", "172.17.0.1:54340"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T10:48:54.655381755Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5882431403440684,
+				"StableID":   "nuRZgtVAwn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a398e17e1c282f84c5f6b7cfb7446ecaccec8951981b1fd55c1d8e6368d9fa42",
+				"DiscoKey":   "discokey:f8fa287f5363f5bdf521d0b8e84f40c36e1bf3c5465949d12433d213e7e4f718",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:40111", "10.65.0.27:40111", "172.17.0.1:40111"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T10:48:55.202876425Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2367360492594434,
+				"StableID":   "nRLx5fYBVK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:191d2ceeca75f0e2829f5296e0321d7af0b1a9b19888776491e988a1ede7311a",
+				"DiscoKey":   "discokey:fb30d96a84b67697b2c5ba4a27262251e2245a56a402f546b9b2bb8f84f9291d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:40035", "10.65.0.27:40035", "172.17.0.1:40035"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T10:48:55.738626975Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8722759479154595,
+				"StableID":   "nG3DVp6Z7B21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ce0976880a1f7f6dc7475d9cfbc62750f45c14025cea8ac3cbf9c24afba8ba23",
+				"DiscoKey":   "discokey:e0112828e95db0bb1c0982dca3ef7ce2e574c0d18c0462ed202244eac928fc71",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:40653", "10.65.0.27:40653", "172.17.0.1:40653"],
+				"HomeDERP":   26,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T10:48:56.276059496Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8789958571042068,
+				"StableID":   "nuyB8nJzdB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d5f6fca3ad79e6e1c4176b9916873989f27d90b04f1b821734ddac3ea33db221",
+				"KeyExpiry":  "2026-11-09T10:48:56Z",
+				"DiscoKey":   "discokey:29333efc1ed524edb99c6286282bb51a73104d7f9fe6c8e43aa5f607c9efce78",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:50705", "10.65.0.27:50705", "172.17.0.1:50705"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T10:48:56.81026368Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4397469093301501,
+				"StableID":   "nL2HMG4dLb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b3cb7fa4c23188ce2a8ad836a8b252fa1526358fba756bd509adbb33ab240f5c",
+				"KeyExpiry":  "2026-11-09T10:48:57Z",
+				"DiscoKey":   "discokey:73765b4c398fc506d93c97edceb5bd28515a96c711012398c1d91fcf33592012",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:45003", "10.65.0.27:45003", "172.17.0.1:45003"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T10:48:57.352517284Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7822324820044157,
+				"StableID":   "nAw947Dk5421CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bbb1fc9a6f7e90fb22a04203694abe55b821617df286d129da214c42b98ea319",
+				"KeyExpiry":  "2026-11-09T10:48:57Z",
+				"DiscoKey":   "discokey:a733427a6a060e36d67831e7b58bc300b184092bf1598e0d517c4a413de3ee58",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:53974", "10.65.0.27:53974", "172.17.0.1:53974"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T10:48:57.903377063Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3519823077666716": {
+				"ID":          3519823077666716,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3765147146864741,
+				"StableID":   "ncADEo2FQW11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       3765147146864741,
+				"Key":        "nodekey:38fe0b9e71caeb8135dac0fbe880b7e748009c26f0abb43b3527cb72212b175b",
+				"DiscoKey":   "discokey:198022f74d83de950d9085d4fc72fd3fbc42e6f9db4452df75e4ee3820310271",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:49338", "10.65.0.27:49338", "172.17.0.1:49338"],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T10:48:51.967866113Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:38fe0b9e71caeb8135dac0fbe880b7e748009c26f0abb43b3527cb72212b175b",
+			"MachineKey": "mkey:5626ffd550807dc51983e6d38c8bdb3a085434430d65d5bb7a33f036462e527a",
+			"Peers": [{
+				"ID":         6200298225266045,
+				"StableID":   "nkL6FbK8Rq11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:caa25e6f3964747f2819e3fda3f7c706295b6a49c664b8e2ea89c3969bdbda2b",
+				"DiscoKey":   "discokey:77ec9f8fce0ede08d9d1a5b029f8a0cae296110933405e7519506e79e073333d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:48042", "10.65.0.27:48042", "172.17.0.1:48042"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T10:48:50.362795491Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         772085588111436,
+				"StableID":   "nwaEYzNg2711CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c2079dc508afa576b94809475a2ac47d3a36c6e3f735ef1b55c27ffcec1a373",
+				"DiscoKey":   "discokey:8cb4612d5f0e3c5749ae5ed0fbbbe1785c2932e55ba34fec31e0be6d96f2607a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:55637", "10.65.0.27:55637", "172.17.0.1:55637"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T10:48:50.891907715Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1638953534304319,
+				"StableID":   "n22eVkXHoD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1462e2a6dc4d8abe004dff315631a69b43887f020c6f19139bda5e98be5f75c",
+				"DiscoKey":   "discokey:140fac845fae8282c5c0766d4640b23d93aa54c0b9fa01194f57b1a38629c901",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:44209", "10.65.0.27:44209", "172.17.0.1:44209"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T10:48:51.424310318Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3519823077666716,
+				"StableID":   "nBpiJTn8VU11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0d87ab5fbdc9d4e34413f797214d6ac38849e6dc6374e12d90612cba7f8a069",
+				"DiscoKey":   "discokey:0a60fc1cddb12dbd09d89e6b51a4ce9a2411d5e9c839caf89eb396dd0df44851",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:38235", "10.65.0.27:38235", "172.17.0.1:38235"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T10:48:52.512631024Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1986105523559038,
+				"StableID":   "nPm32DdWWG11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5102f677c7b7bb670223630e40cbaea4e932d7d0a62f334e3d39dda92d3fdb77",
+				"DiscoKey":   "discokey:ce969702ba57154bad7015018753d95c981ffd8a8be1de79cea3e61e0bc0297a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:49208", "10.65.0.27:49208", "172.17.0.1:49208"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T10:48:53.034821277Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5130804425872062,
+				"StableID":   "nFwzVrXk4h11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:908f9f71cf33139bd9e32b7628bef012d466eb003ded2d8d99417a85cb294047",
+				"DiscoKey":   "discokey:ceb56c41917fe22122cde49a826c033fede711c180bbe5331d982702739fbc2b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:55194", "10.65.0.27:55194", "172.17.0.1:55194"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T10:48:53.586230203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2159651897938158,
+				"StableID":   "nunjqoP7sH11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e9c626ba7ebfdb3c7dde942b025e7c1e785e5346f6406556926a73daeeb1c816",
+				"DiscoKey":   "discokey:cbcb42ec1c6942dc1516dbd7fa3ccbc14b63f19487e6bdce2f989034bcf02962",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:43026", "10.65.0.27:43026", "172.17.0.1:43026"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T10:48:54.126510557Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1349337447109109,
+				"StableID":   "nWqVcno7YB11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:53b27d1f1c5b6ac9e0ee6390391b0a3635092481c5727fc7ea696388d123a02f",
+				"DiscoKey":   "discokey:081d07001df2cca09159b3071e5ffcd20ce392e9fa11610354247a31d4f09f59",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54340", "10.65.0.27:54340", "172.17.0.1:54340"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T10:48:54.655381755Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5882431403440684,
+				"StableID":   "nuRZgtVAwn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a398e17e1c282f84c5f6b7cfb7446ecaccec8951981b1fd55c1d8e6368d9fa42",
+				"DiscoKey":   "discokey:f8fa287f5363f5bdf521d0b8e84f40c36e1bf3c5465949d12433d213e7e4f718",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:40111", "10.65.0.27:40111", "172.17.0.1:40111"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T10:48:55.202876425Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2367360492594434,
+				"StableID":   "nRLx5fYBVK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:191d2ceeca75f0e2829f5296e0321d7af0b1a9b19888776491e988a1ede7311a",
+				"DiscoKey":   "discokey:fb30d96a84b67697b2c5ba4a27262251e2245a56a402f546b9b2bb8f84f9291d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:40035", "10.65.0.27:40035", "172.17.0.1:40035"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T10:48:55.738626975Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8722759479154595,
+				"StableID":   "nG3DVp6Z7B21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ce0976880a1f7f6dc7475d9cfbc62750f45c14025cea8ac3cbf9c24afba8ba23",
+				"DiscoKey":   "discokey:e0112828e95db0bb1c0982dca3ef7ce2e574c0d18c0462ed202244eac928fc71",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:40653", "10.65.0.27:40653", "172.17.0.1:40653"],
+				"HomeDERP":   26,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T10:48:56.276059496Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8789958571042068,
+				"StableID":   "nuyB8nJzdB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d5f6fca3ad79e6e1c4176b9916873989f27d90b04f1b821734ddac3ea33db221",
+				"KeyExpiry":  "2026-11-09T10:48:56Z",
+				"DiscoKey":   "discokey:29333efc1ed524edb99c6286282bb51a73104d7f9fe6c8e43aa5f607c9efce78",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:50705", "10.65.0.27:50705", "172.17.0.1:50705"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T10:48:56.81026368Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4397469093301501,
+				"StableID":   "nL2HMG4dLb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b3cb7fa4c23188ce2a8ad836a8b252fa1526358fba756bd509adbb33ab240f5c",
+				"KeyExpiry":  "2026-11-09T10:48:57Z",
+				"DiscoKey":   "discokey:73765b4c398fc506d93c97edceb5bd28515a96c711012398c1d91fcf33592012",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:45003", "10.65.0.27:45003", "172.17.0.1:45003"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T10:48:57.352517284Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7822324820044157,
+				"StableID":   "nAw947Dk5421CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bbb1fc9a6f7e90fb22a04203694abe55b821617df286d129da214c42b98ea319",
+				"KeyExpiry":  "2026-11-09T10:48:57Z",
+				"DiscoKey":   "discokey:a733427a6a060e36d67831e7b58bc300b184092bf1598e0d517c4a413de3ee58",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:53974", "10.65.0.27:53974", "172.17.0.1:53974"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T10:48:57.903377063Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3765147146864741": {
+				"ID":          3765147146864741,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5130804425872062,
+				"StableID":   "nFwzVrXk4h11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       5130804425872062,
+				"Key":        "nodekey:908f9f71cf33139bd9e32b7628bef012d466eb003ded2d8d99417a85cb294047",
+				"DiscoKey":   "discokey:ceb56c41917fe22122cde49a826c033fede711c180bbe5331d982702739fbc2b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:55194", "10.65.0.27:55194", "172.17.0.1:55194"],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T10:48:53.586230203Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:908f9f71cf33139bd9e32b7628bef012d466eb003ded2d8d99417a85cb294047",
+			"MachineKey": "mkey:ad41105a1ab99f000c660872c887ae19ef828614b52fd434589a50456776524f",
+			"Peers": [{
+				"ID":         6200298225266045,
+				"StableID":   "nkL6FbK8Rq11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:caa25e6f3964747f2819e3fda3f7c706295b6a49c664b8e2ea89c3969bdbda2b",
+				"DiscoKey":   "discokey:77ec9f8fce0ede08d9d1a5b029f8a0cae296110933405e7519506e79e073333d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:48042", "10.65.0.27:48042", "172.17.0.1:48042"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T10:48:50.362795491Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         772085588111436,
+				"StableID":   "nwaEYzNg2711CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c2079dc508afa576b94809475a2ac47d3a36c6e3f735ef1b55c27ffcec1a373",
+				"DiscoKey":   "discokey:8cb4612d5f0e3c5749ae5ed0fbbbe1785c2932e55ba34fec31e0be6d96f2607a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:55637", "10.65.0.27:55637", "172.17.0.1:55637"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T10:48:50.891907715Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1638953534304319,
+				"StableID":   "n22eVkXHoD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1462e2a6dc4d8abe004dff315631a69b43887f020c6f19139bda5e98be5f75c",
+				"DiscoKey":   "discokey:140fac845fae8282c5c0766d4640b23d93aa54c0b9fa01194f57b1a38629c901",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:44209", "10.65.0.27:44209", "172.17.0.1:44209"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T10:48:51.424310318Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3765147146864741,
+				"StableID":   "ncADEo2FQW11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38fe0b9e71caeb8135dac0fbe880b7e748009c26f0abb43b3527cb72212b175b",
+				"DiscoKey":   "discokey:198022f74d83de950d9085d4fc72fd3fbc42e6f9db4452df75e4ee3820310271",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:49338", "10.65.0.27:49338", "172.17.0.1:49338"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T10:48:51.967866113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3519823077666716,
+				"StableID":   "nBpiJTn8VU11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0d87ab5fbdc9d4e34413f797214d6ac38849e6dc6374e12d90612cba7f8a069",
+				"DiscoKey":   "discokey:0a60fc1cddb12dbd09d89e6b51a4ce9a2411d5e9c839caf89eb396dd0df44851",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:38235", "10.65.0.27:38235", "172.17.0.1:38235"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T10:48:52.512631024Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1986105523559038,
+				"StableID":   "nPm32DdWWG11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5102f677c7b7bb670223630e40cbaea4e932d7d0a62f334e3d39dda92d3fdb77",
+				"DiscoKey":   "discokey:ce969702ba57154bad7015018753d95c981ffd8a8be1de79cea3e61e0bc0297a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:49208", "10.65.0.27:49208", "172.17.0.1:49208"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T10:48:53.034821277Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2159651897938158,
+				"StableID":   "nunjqoP7sH11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e9c626ba7ebfdb3c7dde942b025e7c1e785e5346f6406556926a73daeeb1c816",
+				"DiscoKey":   "discokey:cbcb42ec1c6942dc1516dbd7fa3ccbc14b63f19487e6bdce2f989034bcf02962",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:43026", "10.65.0.27:43026", "172.17.0.1:43026"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T10:48:54.126510557Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1349337447109109,
+				"StableID":   "nWqVcno7YB11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:53b27d1f1c5b6ac9e0ee6390391b0a3635092481c5727fc7ea696388d123a02f",
+				"DiscoKey":   "discokey:081d07001df2cca09159b3071e5ffcd20ce392e9fa11610354247a31d4f09f59",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54340", "10.65.0.27:54340", "172.17.0.1:54340"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T10:48:54.655381755Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5882431403440684,
+				"StableID":   "nuRZgtVAwn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a398e17e1c282f84c5f6b7cfb7446ecaccec8951981b1fd55c1d8e6368d9fa42",
+				"DiscoKey":   "discokey:f8fa287f5363f5bdf521d0b8e84f40c36e1bf3c5465949d12433d213e7e4f718",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:40111", "10.65.0.27:40111", "172.17.0.1:40111"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T10:48:55.202876425Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2367360492594434,
+				"StableID":   "nRLx5fYBVK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:191d2ceeca75f0e2829f5296e0321d7af0b1a9b19888776491e988a1ede7311a",
+				"DiscoKey":   "discokey:fb30d96a84b67697b2c5ba4a27262251e2245a56a402f546b9b2bb8f84f9291d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:40035", "10.65.0.27:40035", "172.17.0.1:40035"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T10:48:55.738626975Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8722759479154595,
+				"StableID":   "nG3DVp6Z7B21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ce0976880a1f7f6dc7475d9cfbc62750f45c14025cea8ac3cbf9c24afba8ba23",
+				"DiscoKey":   "discokey:e0112828e95db0bb1c0982dca3ef7ce2e574c0d18c0462ed202244eac928fc71",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:40653", "10.65.0.27:40653", "172.17.0.1:40653"],
+				"HomeDERP":   26,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T10:48:56.276059496Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8789958571042068,
+				"StableID":   "nuyB8nJzdB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d5f6fca3ad79e6e1c4176b9916873989f27d90b04f1b821734ddac3ea33db221",
+				"KeyExpiry":  "2026-11-09T10:48:56Z",
+				"DiscoKey":   "discokey:29333efc1ed524edb99c6286282bb51a73104d7f9fe6c8e43aa5f607c9efce78",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:50705", "10.65.0.27:50705", "172.17.0.1:50705"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T10:48:56.81026368Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4397469093301501,
+				"StableID":   "nL2HMG4dLb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b3cb7fa4c23188ce2a8ad836a8b252fa1526358fba756bd509adbb33ab240f5c",
+				"KeyExpiry":  "2026-11-09T10:48:57Z",
+				"DiscoKey":   "discokey:73765b4c398fc506d93c97edceb5bd28515a96c711012398c1d91fcf33592012",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:45003", "10.65.0.27:45003", "172.17.0.1:45003"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T10:48:57.352517284Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7822324820044157,
+				"StableID":   "nAw947Dk5421CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bbb1fc9a6f7e90fb22a04203694abe55b821617df286d129da214c42b98ea319",
+				"KeyExpiry":  "2026-11-09T10:48:57Z",
+				"DiscoKey":   "discokey:a733427a6a060e36d67831e7b58bc300b184092bf1598e0d517c4a413de3ee58",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:53974", "10.65.0.27:53974", "172.17.0.1:53974"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T10:48:57.903377063Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5130804425872062": {
+				"ID":          5130804425872062,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1349337447109109,
+				"StableID":   "nWqVcno7YB11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1349337447109109,
+				"Key":        "nodekey:53b27d1f1c5b6ac9e0ee6390391b0a3635092481c5727fc7ea696388d123a02f",
+				"DiscoKey":   "discokey:081d07001df2cca09159b3071e5ffcd20ce392e9fa11610354247a31d4f09f59",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54340", "10.65.0.27:54340", "172.17.0.1:54340"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T10:48:54.655381755Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:53b27d1f1c5b6ac9e0ee6390391b0a3635092481c5727fc7ea696388d123a02f",
+			"MachineKey": "mkey:c0a3bf6535f0d30922c2ddccd6fe4e4468d1df2dcbc4748e01fda852e632b230",
+			"Peers": [{
+				"ID":         6200298225266045,
+				"StableID":   "nkL6FbK8Rq11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:caa25e6f3964747f2819e3fda3f7c706295b6a49c664b8e2ea89c3969bdbda2b",
+				"DiscoKey":   "discokey:77ec9f8fce0ede08d9d1a5b029f8a0cae296110933405e7519506e79e073333d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:48042", "10.65.0.27:48042", "172.17.0.1:48042"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T10:48:50.362795491Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         772085588111436,
+				"StableID":   "nwaEYzNg2711CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c2079dc508afa576b94809475a2ac47d3a36c6e3f735ef1b55c27ffcec1a373",
+				"DiscoKey":   "discokey:8cb4612d5f0e3c5749ae5ed0fbbbe1785c2932e55ba34fec31e0be6d96f2607a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:55637", "10.65.0.27:55637", "172.17.0.1:55637"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T10:48:50.891907715Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1638953534304319,
+				"StableID":   "n22eVkXHoD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1462e2a6dc4d8abe004dff315631a69b43887f020c6f19139bda5e98be5f75c",
+				"DiscoKey":   "discokey:140fac845fae8282c5c0766d4640b23d93aa54c0b9fa01194f57b1a38629c901",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:44209", "10.65.0.27:44209", "172.17.0.1:44209"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T10:48:51.424310318Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3765147146864741,
+				"StableID":   "ncADEo2FQW11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38fe0b9e71caeb8135dac0fbe880b7e748009c26f0abb43b3527cb72212b175b",
+				"DiscoKey":   "discokey:198022f74d83de950d9085d4fc72fd3fbc42e6f9db4452df75e4ee3820310271",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:49338", "10.65.0.27:49338", "172.17.0.1:49338"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T10:48:51.967866113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3519823077666716,
+				"StableID":   "nBpiJTn8VU11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0d87ab5fbdc9d4e34413f797214d6ac38849e6dc6374e12d90612cba7f8a069",
+				"DiscoKey":   "discokey:0a60fc1cddb12dbd09d89e6b51a4ce9a2411d5e9c839caf89eb396dd0df44851",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:38235", "10.65.0.27:38235", "172.17.0.1:38235"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T10:48:52.512631024Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1986105523559038,
+				"StableID":   "nPm32DdWWG11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5102f677c7b7bb670223630e40cbaea4e932d7d0a62f334e3d39dda92d3fdb77",
+				"DiscoKey":   "discokey:ce969702ba57154bad7015018753d95c981ffd8a8be1de79cea3e61e0bc0297a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:49208", "10.65.0.27:49208", "172.17.0.1:49208"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T10:48:53.034821277Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5130804425872062,
+				"StableID":   "nFwzVrXk4h11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:908f9f71cf33139bd9e32b7628bef012d466eb003ded2d8d99417a85cb294047",
+				"DiscoKey":   "discokey:ceb56c41917fe22122cde49a826c033fede711c180bbe5331d982702739fbc2b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:55194", "10.65.0.27:55194", "172.17.0.1:55194"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T10:48:53.586230203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2159651897938158,
+				"StableID":   "nunjqoP7sH11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e9c626ba7ebfdb3c7dde942b025e7c1e785e5346f6406556926a73daeeb1c816",
+				"DiscoKey":   "discokey:cbcb42ec1c6942dc1516dbd7fa3ccbc14b63f19487e6bdce2f989034bcf02962",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:43026", "10.65.0.27:43026", "172.17.0.1:43026"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T10:48:54.126510557Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5882431403440684,
+				"StableID":   "nuRZgtVAwn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a398e17e1c282f84c5f6b7cfb7446ecaccec8951981b1fd55c1d8e6368d9fa42",
+				"DiscoKey":   "discokey:f8fa287f5363f5bdf521d0b8e84f40c36e1bf3c5465949d12433d213e7e4f718",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:40111", "10.65.0.27:40111", "172.17.0.1:40111"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T10:48:55.202876425Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2367360492594434,
+				"StableID":   "nRLx5fYBVK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:191d2ceeca75f0e2829f5296e0321d7af0b1a9b19888776491e988a1ede7311a",
+				"DiscoKey":   "discokey:fb30d96a84b67697b2c5ba4a27262251e2245a56a402f546b9b2bb8f84f9291d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:40035", "10.65.0.27:40035", "172.17.0.1:40035"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T10:48:55.738626975Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8722759479154595,
+				"StableID":   "nG3DVp6Z7B21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ce0976880a1f7f6dc7475d9cfbc62750f45c14025cea8ac3cbf9c24afba8ba23",
+				"DiscoKey":   "discokey:e0112828e95db0bb1c0982dca3ef7ce2e574c0d18c0462ed202244eac928fc71",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:40653", "10.65.0.27:40653", "172.17.0.1:40653"],
+				"HomeDERP":   26,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T10:48:56.276059496Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8789958571042068,
+				"StableID":   "nuyB8nJzdB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d5f6fca3ad79e6e1c4176b9916873989f27d90b04f1b821734ddac3ea33db221",
+				"KeyExpiry":  "2026-11-09T10:48:56Z",
+				"DiscoKey":   "discokey:29333efc1ed524edb99c6286282bb51a73104d7f9fe6c8e43aa5f607c9efce78",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:50705", "10.65.0.27:50705", "172.17.0.1:50705"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T10:48:56.81026368Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4397469093301501,
+				"StableID":   "nL2HMG4dLb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b3cb7fa4c23188ce2a8ad836a8b252fa1526358fba756bd509adbb33ab240f5c",
+				"KeyExpiry":  "2026-11-09T10:48:57Z",
+				"DiscoKey":   "discokey:73765b4c398fc506d93c97edceb5bd28515a96c711012398c1d91fcf33592012",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:45003", "10.65.0.27:45003", "172.17.0.1:45003"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T10:48:57.352517284Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7822324820044157,
+				"StableID":   "nAw947Dk5421CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bbb1fc9a6f7e90fb22a04203694abe55b821617df286d129da214c42b98ea319",
+				"KeyExpiry":  "2026-11-09T10:48:57Z",
+				"DiscoKey":   "discokey:a733427a6a060e36d67831e7b58bc300b184092bf1598e0d517c4a413de3ee58",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:53974", "10.65.0.27:53974", "172.17.0.1:53974"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T10:48:57.903377063Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1349337447109109": {
+				"ID":          1349337447109109,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4397469093301501,
+				"StableID":   "nL2HMG4dLb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b3cb7fa4c23188ce2a8ad836a8b252fa1526358fba756bd509adbb33ab240f5c",
+				"KeyExpiry":  "2026-11-09T10:48:57Z",
+				"DiscoKey":   "discokey:73765b4c398fc506d93c97edceb5bd28515a96c711012398c1d91fcf33592012",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:45003", "10.65.0.27:45003", "172.17.0.1:45003"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T10:48:57.352517284Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b3cb7fa4c23188ce2a8ad836a8b252fa1526358fba756bd509adbb33ab240f5c",
+			"MachineKey": "mkey:e7d0a43386db8802a3d53edb64e4d914ea8ce9433ee8eecde0904afbfd077217",
+			"Peers": [{
+				"ID":         6200298225266045,
+				"StableID":   "nkL6FbK8Rq11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:caa25e6f3964747f2819e3fda3f7c706295b6a49c664b8e2ea89c3969bdbda2b",
+				"DiscoKey":   "discokey:77ec9f8fce0ede08d9d1a5b029f8a0cae296110933405e7519506e79e073333d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:48042", "10.65.0.27:48042", "172.17.0.1:48042"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T10:48:50.362795491Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         772085588111436,
+				"StableID":   "nwaEYzNg2711CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c2079dc508afa576b94809475a2ac47d3a36c6e3f735ef1b55c27ffcec1a373",
+				"DiscoKey":   "discokey:8cb4612d5f0e3c5749ae5ed0fbbbe1785c2932e55ba34fec31e0be6d96f2607a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:55637", "10.65.0.27:55637", "172.17.0.1:55637"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T10:48:50.891907715Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1638953534304319,
+				"StableID":   "n22eVkXHoD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1462e2a6dc4d8abe004dff315631a69b43887f020c6f19139bda5e98be5f75c",
+				"DiscoKey":   "discokey:140fac845fae8282c5c0766d4640b23d93aa54c0b9fa01194f57b1a38629c901",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:44209", "10.65.0.27:44209", "172.17.0.1:44209"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T10:48:51.424310318Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3765147146864741,
+				"StableID":   "ncADEo2FQW11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38fe0b9e71caeb8135dac0fbe880b7e748009c26f0abb43b3527cb72212b175b",
+				"DiscoKey":   "discokey:198022f74d83de950d9085d4fc72fd3fbc42e6f9db4452df75e4ee3820310271",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:49338", "10.65.0.27:49338", "172.17.0.1:49338"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T10:48:51.967866113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3519823077666716,
+				"StableID":   "nBpiJTn8VU11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0d87ab5fbdc9d4e34413f797214d6ac38849e6dc6374e12d90612cba7f8a069",
+				"DiscoKey":   "discokey:0a60fc1cddb12dbd09d89e6b51a4ce9a2411d5e9c839caf89eb396dd0df44851",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:38235", "10.65.0.27:38235", "172.17.0.1:38235"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T10:48:52.512631024Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1986105523559038,
+				"StableID":   "nPm32DdWWG11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5102f677c7b7bb670223630e40cbaea4e932d7d0a62f334e3d39dda92d3fdb77",
+				"DiscoKey":   "discokey:ce969702ba57154bad7015018753d95c981ffd8a8be1de79cea3e61e0bc0297a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:49208", "10.65.0.27:49208", "172.17.0.1:49208"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T10:48:53.034821277Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5130804425872062,
+				"StableID":   "nFwzVrXk4h11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:908f9f71cf33139bd9e32b7628bef012d466eb003ded2d8d99417a85cb294047",
+				"DiscoKey":   "discokey:ceb56c41917fe22122cde49a826c033fede711c180bbe5331d982702739fbc2b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:55194", "10.65.0.27:55194", "172.17.0.1:55194"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T10:48:53.586230203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2159651897938158,
+				"StableID":   "nunjqoP7sH11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e9c626ba7ebfdb3c7dde942b025e7c1e785e5346f6406556926a73daeeb1c816",
+				"DiscoKey":   "discokey:cbcb42ec1c6942dc1516dbd7fa3ccbc14b63f19487e6bdce2f989034bcf02962",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:43026", "10.65.0.27:43026", "172.17.0.1:43026"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T10:48:54.126510557Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1349337447109109,
+				"StableID":   "nWqVcno7YB11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:53b27d1f1c5b6ac9e0ee6390391b0a3635092481c5727fc7ea696388d123a02f",
+				"DiscoKey":   "discokey:081d07001df2cca09159b3071e5ffcd20ce392e9fa11610354247a31d4f09f59",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54340", "10.65.0.27:54340", "172.17.0.1:54340"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T10:48:54.655381755Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5882431403440684,
+				"StableID":   "nuRZgtVAwn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a398e17e1c282f84c5f6b7cfb7446ecaccec8951981b1fd55c1d8e6368d9fa42",
+				"DiscoKey":   "discokey:f8fa287f5363f5bdf521d0b8e84f40c36e1bf3c5465949d12433d213e7e4f718",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:40111", "10.65.0.27:40111", "172.17.0.1:40111"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T10:48:55.202876425Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2367360492594434,
+				"StableID":   "nRLx5fYBVK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:191d2ceeca75f0e2829f5296e0321d7af0b1a9b19888776491e988a1ede7311a",
+				"DiscoKey":   "discokey:fb30d96a84b67697b2c5ba4a27262251e2245a56a402f546b9b2bb8f84f9291d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:40035", "10.65.0.27:40035", "172.17.0.1:40035"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T10:48:55.738626975Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8722759479154595,
+				"StableID":   "nG3DVp6Z7B21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ce0976880a1f7f6dc7475d9cfbc62750f45c14025cea8ac3cbf9c24afba8ba23",
+				"DiscoKey":   "discokey:e0112828e95db0bb1c0982dca3ef7ce2e574c0d18c0462ed202244eac928fc71",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:40653", "10.65.0.27:40653", "172.17.0.1:40653"],
+				"HomeDERP":   26,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T10:48:56.276059496Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8789958571042068,
+				"StableID":   "nuyB8nJzdB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d5f6fca3ad79e6e1c4176b9916873989f27d90b04f1b821734ddac3ea33db221",
+				"KeyExpiry":  "2026-11-09T10:48:56Z",
+				"DiscoKey":   "discokey:29333efc1ed524edb99c6286282bb51a73104d7f9fe6c8e43aa5f607c9efce78",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:50705", "10.65.0.27:50705", "172.17.0.1:50705"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T10:48:56.81026368Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7822324820044157,
+				"StableID":   "nAw947Dk5421CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bbb1fc9a6f7e90fb22a04203694abe55b821617df286d129da214c42b98ea319",
+				"KeyExpiry":  "2026-11-09T10:48:57Z",
+				"DiscoKey":   "discokey:a733427a6a060e36d67831e7b58bc300b184092bf1598e0d517c4a413de3ee58",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:53974", "10.65.0.27:53974", "172.17.0.1:53974"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T10:48:57.903377063Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5882431403440684,
+				"StableID":   "nuRZgtVAwn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       5882431403440684,
+				"Key":        "nodekey:a398e17e1c282f84c5f6b7cfb7446ecaccec8951981b1fd55c1d8e6368d9fa42",
+				"DiscoKey":   "discokey:f8fa287f5363f5bdf521d0b8e84f40c36e1bf3c5465949d12433d213e7e4f718",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:40111", "10.65.0.27:40111", "172.17.0.1:40111"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T10:48:55.202876425Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a398e17e1c282f84c5f6b7cfb7446ecaccec8951981b1fd55c1d8e6368d9fa42",
+			"MachineKey": "mkey:4705e9c98098b3df65701651d41e77c42fdfc943b546f111113041ad3e250f2f",
+			"Peers": [{
+				"ID":         6200298225266045,
+				"StableID":   "nkL6FbK8Rq11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:caa25e6f3964747f2819e3fda3f7c706295b6a49c664b8e2ea89c3969bdbda2b",
+				"DiscoKey":   "discokey:77ec9f8fce0ede08d9d1a5b029f8a0cae296110933405e7519506e79e073333d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:48042", "10.65.0.27:48042", "172.17.0.1:48042"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T10:48:50.362795491Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         772085588111436,
+				"StableID":   "nwaEYzNg2711CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1c2079dc508afa576b94809475a2ac47d3a36c6e3f735ef1b55c27ffcec1a373",
+				"DiscoKey":   "discokey:8cb4612d5f0e3c5749ae5ed0fbbbe1785c2932e55ba34fec31e0be6d96f2607a",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:55637", "10.65.0.27:55637", "172.17.0.1:55637"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T10:48:50.891907715Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1638953534304319,
+				"StableID":   "n22eVkXHoD11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c1462e2a6dc4d8abe004dff315631a69b43887f020c6f19139bda5e98be5f75c",
+				"DiscoKey":   "discokey:140fac845fae8282c5c0766d4640b23d93aa54c0b9fa01194f57b1a38629c901",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:44209", "10.65.0.27:44209", "172.17.0.1:44209"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T10:48:51.424310318Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3765147146864741,
+				"StableID":   "ncADEo2FQW11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38fe0b9e71caeb8135dac0fbe880b7e748009c26f0abb43b3527cb72212b175b",
+				"DiscoKey":   "discokey:198022f74d83de950d9085d4fc72fd3fbc42e6f9db4452df75e4ee3820310271",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:49338", "10.65.0.27:49338", "172.17.0.1:49338"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T10:48:51.967866113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3519823077666716,
+				"StableID":   "nBpiJTn8VU11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0d87ab5fbdc9d4e34413f797214d6ac38849e6dc6374e12d90612cba7f8a069",
+				"DiscoKey":   "discokey:0a60fc1cddb12dbd09d89e6b51a4ce9a2411d5e9c839caf89eb396dd0df44851",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:38235", "10.65.0.27:38235", "172.17.0.1:38235"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T10:48:52.512631024Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         1986105523559038,
+				"StableID":   "nPm32DdWWG11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5102f677c7b7bb670223630e40cbaea4e932d7d0a62f334e3d39dda92d3fdb77",
+				"DiscoKey":   "discokey:ce969702ba57154bad7015018753d95c981ffd8a8be1de79cea3e61e0bc0297a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:49208", "10.65.0.27:49208", "172.17.0.1:49208"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T10:48:53.034821277Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5130804425872062,
+				"StableID":   "nFwzVrXk4h11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:908f9f71cf33139bd9e32b7628bef012d466eb003ded2d8d99417a85cb294047",
+				"DiscoKey":   "discokey:ceb56c41917fe22122cde49a826c033fede711c180bbe5331d982702739fbc2b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:55194", "10.65.0.27:55194", "172.17.0.1:55194"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T10:48:53.586230203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2159651897938158,
+				"StableID":   "nunjqoP7sH11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e9c626ba7ebfdb3c7dde942b025e7c1e785e5346f6406556926a73daeeb1c816",
+				"DiscoKey":   "discokey:cbcb42ec1c6942dc1516dbd7fa3ccbc14b63f19487e6bdce2f989034bcf02962",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:43026", "10.65.0.27:43026", "172.17.0.1:43026"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T10:48:54.126510557Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1349337447109109,
+				"StableID":   "nWqVcno7YB11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:53b27d1f1c5b6ac9e0ee6390391b0a3635092481c5727fc7ea696388d123a02f",
+				"DiscoKey":   "discokey:081d07001df2cca09159b3071e5ffcd20ce392e9fa11610354247a31d4f09f59",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:54340", "10.65.0.27:54340", "172.17.0.1:54340"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T10:48:54.655381755Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2367360492594434,
+				"StableID":   "nRLx5fYBVK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:191d2ceeca75f0e2829f5296e0321d7af0b1a9b19888776491e988a1ede7311a",
+				"DiscoKey":   "discokey:fb30d96a84b67697b2c5ba4a27262251e2245a56a402f546b9b2bb8f84f9291d",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:40035", "10.65.0.27:40035", "172.17.0.1:40035"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T10:48:55.738626975Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8722759479154595,
+				"StableID":   "nG3DVp6Z7B21CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ce0976880a1f7f6dc7475d9cfbc62750f45c14025cea8ac3cbf9c24afba8ba23",
+				"DiscoKey":   "discokey:e0112828e95db0bb1c0982dca3ef7ce2e574c0d18c0462ed202244eac928fc71",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:40653", "10.65.0.27:40653", "172.17.0.1:40653"],
+				"HomeDERP":   26,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T10:48:56.276059496Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8789958571042068,
+				"StableID":   "nuyB8nJzdB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d5f6fca3ad79e6e1c4176b9916873989f27d90b04f1b821734ddac3ea33db221",
+				"KeyExpiry":  "2026-11-09T10:48:56Z",
+				"DiscoKey":   "discokey:29333efc1ed524edb99c6286282bb51a73104d7f9fe6c8e43aa5f607c9efce78",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:50705", "10.65.0.27:50705", "172.17.0.1:50705"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T10:48:56.81026368Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4397469093301501,
+				"StableID":   "nL2HMG4dLb11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:b3cb7fa4c23188ce2a8ad836a8b252fa1526358fba756bd509adbb33ab240f5c",
+				"KeyExpiry":  "2026-11-09T10:48:57Z",
+				"DiscoKey":   "discokey:73765b4c398fc506d93c97edceb5bd28515a96c711012398c1d91fcf33592012",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:45003", "10.65.0.27:45003", "172.17.0.1:45003"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T10:48:57.352517284Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7822324820044157,
+				"StableID":   "nAw947Dk5421CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:bbb1fc9a6f7e90fb22a04203694abe55b821617df286d129da214c42b98ea319",
+				"KeyExpiry":  "2026-11-09T10:48:57Z",
+				"DiscoKey":   "discokey:a733427a6a060e36d67831e7b58bc300b184092bf1598e0d517c4a413de3ee58",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:53974", "10.65.0.27:53974", "172.17.0.1:53974"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T10:48:57.903377063Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5882431403440684": {
+				"ID":          5882431403440684,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/sshtest_results/sshtest-malformed-dst-bare-ipv6.hujson
+++ b/hscontrol/policy/v2/testdata/sshtest_results/sshtest-malformed-dst-bare-ipv6.hujson
@@ -1,0 +1,18737 @@
+// sshtest-malformed-dst-bare-ipv6
+//
+// sshTests dst with bare IPv6 literal
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-13T10:49:43Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "sshtest-malformed-dst-bare-ipv6",
+	"description":    "sshTests dst with bare IPv6 literal",
+	"category":       "sshtest",
+	"captured_at":    "2026-05-13T10:49:43.202748457Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                  \n  \n                                                                   \n           \n{\n\t\"category\":    \"sshtest\",\n\t\"description\": \"sshTests dst with bare IPv6 literal\",\n\t\"id\":          \"sshtest-malformed-dst-bare-ipv6\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"grants\": [{\"dst\": [\"*\"], \"ip\": [\"*\"], \"src\": [\"*\"]}], \"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"autogroup:member\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"sshTests\": [{\n\t\t\"accept\": [\"root\"],\n\t\t\"dst\":    [\"fd7a:115c:a1e0::10\"],\n\t\t\"src\":    \"odin@example.com\"\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/sshtest-edges-baremip/sshtest-malformed-dst-bare-ipv6.hujson",
+		"full_policy": {
+			"grants": [{"dst": ["*"], "ip": ["*"], "src": ["*"]}],
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["autogroup:member"],
+				"users":  ["root"]
+			}],
+			"sshTests": [{
+				"accept": ["root"],
+				"dst":    ["fd7a:115c:a1e0::10"],
+				"src":    "odin@example.com"
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         334927240877647,
+				"StableID":   "nk5aNJygc311CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       334927240877647,
+				"Key":        "nodekey:dc734d58cca95b35554d568625022525f4805fd9661485b56dd62c478b903961",
+				"DiscoKey":   "discokey:08860ffc9ad49254248fc284273dc3f1e6cd4500003b3b4180836ac7b297e55c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53569", "10.65.0.27:53569", "172.17.0.1:53569"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T10:49:51.696657826Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:dc734d58cca95b35554d568625022525f4805fd9661485b56dd62c478b903961",
+			"MachineKey": "mkey:a30c70c9ed64003a2cccda14180de7a17d10f0a3abca514727971b3ea7964073",
+			"Peers": [{
+				"ID":         859261059412166,
+				"StableID":   "nuUJRCLAi711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a7e877e42095005a66e6c1aab51ed3285f7d7cc62ccc078ad1d5217f9766a755",
+				"DiscoKey":   "discokey:bf7ca0736125ef38e6f6b59d7c13ec464d326a7f9eaf2755b2c0e786a87d9e5b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:56022", "10.65.0.27:56022", "172.17.0.1:56022"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T10:49:45.772657121Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4038382799288908,
+				"StableID":   "nDhVBAUzXY11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2d6413a67f6cfa2f0811ea5173d77cb82eea52a994848e24959d79f17685b976",
+				"DiscoKey":   "discokey:de3507d6af75b68423e1c5dc49aecff2ad9aa9960b7adf5b8f08cda91fa33a44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:47955", "10.65.0.27:47955", "172.17.0.1:47955"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T10:49:46.301030305Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3017773562694856,
+				"StableID":   "nh7cr4okZQ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ed22425f9400edd4fd7f9b6230fada69809c3f67c5d6e205ac0eb9003874076",
+				"DiscoKey":   "discokey:cecc4ba5b5bec6c80fdbe0cb7284423408923db0827f81de7ba9d756d26b934a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:34716", "10.65.0.27:34716", "172.17.0.1:34716"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T10:49:46.825444131Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         841031876026915,
+				"StableID":   "nxFZuuUuZ711CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:40c5193c938376c182253108a8393e39db387193b50b5a03a504640b92525415",
+				"DiscoKey":   "discokey:e7c83de9c4cc48f6392ec088db09d6967e1ccae6eb202ed929bc594b5a661200",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:37212", "10.65.0.27:37212", "172.17.0.1:37212"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T10:49:47.356999827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5408923338656444,
+				"StableID":   "nVK4TAFiEj11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f270ee1ed3fdaa747b96e3392a25be3014c3b1d705dc821b832d712fc6ec1123",
+				"DiscoKey":   "discokey:27ca093c2966725423323b41a97e26a816094c51fc6e814998cd6c02d004d26f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:33332", "10.65.0.27:33332", "172.17.0.1:33332"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T10:49:47.918004223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3719379002270468,
+				"StableID":   "n3Wu1DnW3W11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4be2686873fed2b904d2b62fb3dcaa61b053ca2e8b2bb7be71974cdce4306870",
+				"DiscoKey":   "discokey:8e144a7a9659a77eef738e00b4ff3752d5dce14b11b8bffefda1135826276c7c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:57272", "10.65.0.27:57272", "172.17.0.1:57272"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T10:49:48.451607497Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4938745266024003,
+				"StableID":   "nikkDtTmZf11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bff1dab85d012316bf0f494449937f3a626217a3f81f560d9771dca2b18ce028",
+				"DiscoKey":   "discokey:7b76eb268d98f6279a6c473c43610738414da4d9972308ee11079fcb1505bc39",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:55316", "10.65.0.27:55316", "172.17.0.1:55316"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T10:49:48.99059142Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5717007869107976,
+				"StableID":   "nqhKRw6Fem11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:778958671603dd7ab7e6329ca20c7f129326c2b53b666e9a1ad110fb07ec4200",
+				"DiscoKey":   "discokey:62ba0795a1a73a0e59aca58921ef4bf02dc562a67d72dcb09c763dbf9878441e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:41514", "10.65.0.27:41514", "172.17.0.1:41514"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T10:49:49.539044425Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2681791575458757,
+				"StableID":   "ngUFAo7bwM11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b3998f59a28c54d599dab7f93dca41491b68bf149bd4cdb7bfc6c2a12e43467e",
+				"DiscoKey":   "discokey:2b408dcfd99442c220534cfe6cf009234106918bfa35cd155c4bc373110a2610",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57338", "10.65.0.27:57338", "172.17.0.1:57338"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T10:49:50.077242292Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6843923602848287,
+				"StableID":   "n68NsXGdSv11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35a55ec66e4cda8326413883a0811dfd80ac59d0d3914758bd050f7dbcc7407f",
+				"DiscoKey":   "discokey:e9aca9a712d8b23b1eb95b03b046456a2e75c67dca65a58baa026b9c88267831",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:49062", "10.65.0.27:49062", "172.17.0.1:49062"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T10:49:50.611547224Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5639247385574474,
+				"StableID":   "nukXm3U23m11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f94eea7d87a9966dc52c708dd1d9b2358ba3967e333eab363b20056afeccc32f",
+				"DiscoKey":   "discokey:8b3aa50839dbf30da90c85f2028cb66b27d0b99642ea15a012fcda7b8fb5146c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:56076", "10.65.0.27:56076", "172.17.0.1:56076"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T10:49:51.149343502Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6999320821172825,
+				"StableID":   "nvDJvmH1fw11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5d1f86245681cd179cba56fc189351670f3f4614e12b161fb2b9dadad1795447",
+				"KeyExpiry":  "2026-11-09T10:49:52Z",
+				"DiscoKey":   "discokey:c6c54d8ca1c7739b766b9e220290d53920c0598ba35753f259b5493a7dcfb017",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:41270", "10.65.0.27:41270", "172.17.0.1:41270"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T10:49:52.231996754Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3911180766115955,
+				"StableID":   "nGfM626PYX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2ebeea6ee130392da77f4dc5e1166a0f819ac768b8d773808e8d454cd3a46169",
+				"KeyExpiry":  "2026-11-09T10:49:52Z",
+				"DiscoKey":   "discokey:5ffa1f5176b04a6e9c1b22114c7594f9557df41aae4c3c439444f29cbab27f62",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:33581", "10.65.0.27:33581", "172.17.0.1:33581"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T10:49:52.769240823Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7952933030713537,
+				"StableID":   "nNDJPm4u6521CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e1d5f353569caba6c02adf8f7d450836332b84718111e65686b3d1e1af02cb6d",
+				"KeyExpiry":  "2026-11-09T10:49:53Z",
+				"DiscoKey":   "discokey:cbb9f7d452557afe0040be4401b3886943ad7a102a1117f1170aa343e6ae6a4b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:58443", "10.65.0.27:58443", "172.17.0.1:58443"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T10:49:53.299344535Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "334927240877647": {
+				"ID":          334927240877647,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3719379002270468,
+				"StableID":   "n3Wu1DnW3W11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       3719379002270468,
+				"Key":        "nodekey:4be2686873fed2b904d2b62fb3dcaa61b053ca2e8b2bb7be71974cdce4306870",
+				"DiscoKey":   "discokey:8e144a7a9659a77eef738e00b4ff3752d5dce14b11b8bffefda1135826276c7c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:57272", "10.65.0.27:57272", "172.17.0.1:57272"],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T10:49:48.451607497Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4be2686873fed2b904d2b62fb3dcaa61b053ca2e8b2bb7be71974cdce4306870",
+			"MachineKey": "mkey:d58d4f7bcf3b7fd17add9d81732861fbfab0a8fcf0feca16489265da8127c549",
+			"Peers": [{
+				"ID":         859261059412166,
+				"StableID":   "nuUJRCLAi711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a7e877e42095005a66e6c1aab51ed3285f7d7cc62ccc078ad1d5217f9766a755",
+				"DiscoKey":   "discokey:bf7ca0736125ef38e6f6b59d7c13ec464d326a7f9eaf2755b2c0e786a87d9e5b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:56022", "10.65.0.27:56022", "172.17.0.1:56022"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T10:49:45.772657121Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4038382799288908,
+				"StableID":   "nDhVBAUzXY11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2d6413a67f6cfa2f0811ea5173d77cb82eea52a994848e24959d79f17685b976",
+				"DiscoKey":   "discokey:de3507d6af75b68423e1c5dc49aecff2ad9aa9960b7adf5b8f08cda91fa33a44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:47955", "10.65.0.27:47955", "172.17.0.1:47955"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T10:49:46.301030305Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3017773562694856,
+				"StableID":   "nh7cr4okZQ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ed22425f9400edd4fd7f9b6230fada69809c3f67c5d6e205ac0eb9003874076",
+				"DiscoKey":   "discokey:cecc4ba5b5bec6c80fdbe0cb7284423408923db0827f81de7ba9d756d26b934a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:34716", "10.65.0.27:34716", "172.17.0.1:34716"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T10:49:46.825444131Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         841031876026915,
+				"StableID":   "nxFZuuUuZ711CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:40c5193c938376c182253108a8393e39db387193b50b5a03a504640b92525415",
+				"DiscoKey":   "discokey:e7c83de9c4cc48f6392ec088db09d6967e1ccae6eb202ed929bc594b5a661200",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:37212", "10.65.0.27:37212", "172.17.0.1:37212"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T10:49:47.356999827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5408923338656444,
+				"StableID":   "nVK4TAFiEj11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f270ee1ed3fdaa747b96e3392a25be3014c3b1d705dc821b832d712fc6ec1123",
+				"DiscoKey":   "discokey:27ca093c2966725423323b41a97e26a816094c51fc6e814998cd6c02d004d26f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:33332", "10.65.0.27:33332", "172.17.0.1:33332"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T10:49:47.918004223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4938745266024003,
+				"StableID":   "nikkDtTmZf11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bff1dab85d012316bf0f494449937f3a626217a3f81f560d9771dca2b18ce028",
+				"DiscoKey":   "discokey:7b76eb268d98f6279a6c473c43610738414da4d9972308ee11079fcb1505bc39",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:55316", "10.65.0.27:55316", "172.17.0.1:55316"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T10:49:48.99059142Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5717007869107976,
+				"StableID":   "nqhKRw6Fem11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:778958671603dd7ab7e6329ca20c7f129326c2b53b666e9a1ad110fb07ec4200",
+				"DiscoKey":   "discokey:62ba0795a1a73a0e59aca58921ef4bf02dc562a67d72dcb09c763dbf9878441e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:41514", "10.65.0.27:41514", "172.17.0.1:41514"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T10:49:49.539044425Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2681791575458757,
+				"StableID":   "ngUFAo7bwM11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b3998f59a28c54d599dab7f93dca41491b68bf149bd4cdb7bfc6c2a12e43467e",
+				"DiscoKey":   "discokey:2b408dcfd99442c220534cfe6cf009234106918bfa35cd155c4bc373110a2610",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57338", "10.65.0.27:57338", "172.17.0.1:57338"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T10:49:50.077242292Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6843923602848287,
+				"StableID":   "n68NsXGdSv11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35a55ec66e4cda8326413883a0811dfd80ac59d0d3914758bd050f7dbcc7407f",
+				"DiscoKey":   "discokey:e9aca9a712d8b23b1eb95b03b046456a2e75c67dca65a58baa026b9c88267831",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:49062", "10.65.0.27:49062", "172.17.0.1:49062"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T10:49:50.611547224Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5639247385574474,
+				"StableID":   "nukXm3U23m11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f94eea7d87a9966dc52c708dd1d9b2358ba3967e333eab363b20056afeccc32f",
+				"DiscoKey":   "discokey:8b3aa50839dbf30da90c85f2028cb66b27d0b99642ea15a012fcda7b8fb5146c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:56076", "10.65.0.27:56076", "172.17.0.1:56076"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T10:49:51.149343502Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         334927240877647,
+				"StableID":   "nk5aNJygc311CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc734d58cca95b35554d568625022525f4805fd9661485b56dd62c478b903961",
+				"DiscoKey":   "discokey:08860ffc9ad49254248fc284273dc3f1e6cd4500003b3b4180836ac7b297e55c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53569", "10.65.0.27:53569", "172.17.0.1:53569"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T10:49:51.696657826Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6999320821172825,
+				"StableID":   "nvDJvmH1fw11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5d1f86245681cd179cba56fc189351670f3f4614e12b161fb2b9dadad1795447",
+				"KeyExpiry":  "2026-11-09T10:49:52Z",
+				"DiscoKey":   "discokey:c6c54d8ca1c7739b766b9e220290d53920c0598ba35753f259b5493a7dcfb017",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:41270", "10.65.0.27:41270", "172.17.0.1:41270"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T10:49:52.231996754Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3911180766115955,
+				"StableID":   "nGfM626PYX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2ebeea6ee130392da77f4dc5e1166a0f819ac768b8d773808e8d454cd3a46169",
+				"KeyExpiry":  "2026-11-09T10:49:52Z",
+				"DiscoKey":   "discokey:5ffa1f5176b04a6e9c1b22114c7594f9557df41aae4c3c439444f29cbab27f62",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:33581", "10.65.0.27:33581", "172.17.0.1:33581"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T10:49:52.769240823Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7952933030713537,
+				"StableID":   "nNDJPm4u6521CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e1d5f353569caba6c02adf8f7d450836332b84718111e65686b3d1e1af02cb6d",
+				"KeyExpiry":  "2026-11-09T10:49:53Z",
+				"DiscoKey":   "discokey:cbb9f7d452557afe0040be4401b3886943ad7a102a1117f1170aa343e6ae6a4b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:58443", "10.65.0.27:58443", "172.17.0.1:58443"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T10:49:53.299344535Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3719379002270468": {
+				"ID":          3719379002270468,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7952933030713537,
+				"StableID":   "nNDJPm4u6521CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e1d5f353569caba6c02adf8f7d450836332b84718111e65686b3d1e1af02cb6d",
+				"KeyExpiry":  "2026-11-09T10:49:53Z",
+				"DiscoKey":   "discokey:cbb9f7d452557afe0040be4401b3886943ad7a102a1117f1170aa343e6ae6a4b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:58443", "10.65.0.27:58443", "172.17.0.1:58443"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T10:49:53.299344535Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e1d5f353569caba6c02adf8f7d450836332b84718111e65686b3d1e1af02cb6d",
+			"MachineKey": "mkey:58c354c8cbb19788094e5a4e666e159bb45f81a41d04403b3d4be56869735d34",
+			"Peers": [{
+				"ID":         859261059412166,
+				"StableID":   "nuUJRCLAi711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a7e877e42095005a66e6c1aab51ed3285f7d7cc62ccc078ad1d5217f9766a755",
+				"DiscoKey":   "discokey:bf7ca0736125ef38e6f6b59d7c13ec464d326a7f9eaf2755b2c0e786a87d9e5b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:56022", "10.65.0.27:56022", "172.17.0.1:56022"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T10:49:45.772657121Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4038382799288908,
+				"StableID":   "nDhVBAUzXY11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2d6413a67f6cfa2f0811ea5173d77cb82eea52a994848e24959d79f17685b976",
+				"DiscoKey":   "discokey:de3507d6af75b68423e1c5dc49aecff2ad9aa9960b7adf5b8f08cda91fa33a44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:47955", "10.65.0.27:47955", "172.17.0.1:47955"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T10:49:46.301030305Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3017773562694856,
+				"StableID":   "nh7cr4okZQ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ed22425f9400edd4fd7f9b6230fada69809c3f67c5d6e205ac0eb9003874076",
+				"DiscoKey":   "discokey:cecc4ba5b5bec6c80fdbe0cb7284423408923db0827f81de7ba9d756d26b934a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:34716", "10.65.0.27:34716", "172.17.0.1:34716"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T10:49:46.825444131Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         841031876026915,
+				"StableID":   "nxFZuuUuZ711CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:40c5193c938376c182253108a8393e39db387193b50b5a03a504640b92525415",
+				"DiscoKey":   "discokey:e7c83de9c4cc48f6392ec088db09d6967e1ccae6eb202ed929bc594b5a661200",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:37212", "10.65.0.27:37212", "172.17.0.1:37212"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T10:49:47.356999827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5408923338656444,
+				"StableID":   "nVK4TAFiEj11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f270ee1ed3fdaa747b96e3392a25be3014c3b1d705dc821b832d712fc6ec1123",
+				"DiscoKey":   "discokey:27ca093c2966725423323b41a97e26a816094c51fc6e814998cd6c02d004d26f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:33332", "10.65.0.27:33332", "172.17.0.1:33332"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T10:49:47.918004223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3719379002270468,
+				"StableID":   "n3Wu1DnW3W11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4be2686873fed2b904d2b62fb3dcaa61b053ca2e8b2bb7be71974cdce4306870",
+				"DiscoKey":   "discokey:8e144a7a9659a77eef738e00b4ff3752d5dce14b11b8bffefda1135826276c7c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:57272", "10.65.0.27:57272", "172.17.0.1:57272"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T10:49:48.451607497Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4938745266024003,
+				"StableID":   "nikkDtTmZf11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bff1dab85d012316bf0f494449937f3a626217a3f81f560d9771dca2b18ce028",
+				"DiscoKey":   "discokey:7b76eb268d98f6279a6c473c43610738414da4d9972308ee11079fcb1505bc39",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:55316", "10.65.0.27:55316", "172.17.0.1:55316"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T10:49:48.99059142Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5717007869107976,
+				"StableID":   "nqhKRw6Fem11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:778958671603dd7ab7e6329ca20c7f129326c2b53b666e9a1ad110fb07ec4200",
+				"DiscoKey":   "discokey:62ba0795a1a73a0e59aca58921ef4bf02dc562a67d72dcb09c763dbf9878441e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:41514", "10.65.0.27:41514", "172.17.0.1:41514"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T10:49:49.539044425Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2681791575458757,
+				"StableID":   "ngUFAo7bwM11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b3998f59a28c54d599dab7f93dca41491b68bf149bd4cdb7bfc6c2a12e43467e",
+				"DiscoKey":   "discokey:2b408dcfd99442c220534cfe6cf009234106918bfa35cd155c4bc373110a2610",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57338", "10.65.0.27:57338", "172.17.0.1:57338"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T10:49:50.077242292Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6843923602848287,
+				"StableID":   "n68NsXGdSv11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35a55ec66e4cda8326413883a0811dfd80ac59d0d3914758bd050f7dbcc7407f",
+				"DiscoKey":   "discokey:e9aca9a712d8b23b1eb95b03b046456a2e75c67dca65a58baa026b9c88267831",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:49062", "10.65.0.27:49062", "172.17.0.1:49062"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T10:49:50.611547224Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5639247385574474,
+				"StableID":   "nukXm3U23m11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f94eea7d87a9966dc52c708dd1d9b2358ba3967e333eab363b20056afeccc32f",
+				"DiscoKey":   "discokey:8b3aa50839dbf30da90c85f2028cb66b27d0b99642ea15a012fcda7b8fb5146c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:56076", "10.65.0.27:56076", "172.17.0.1:56076"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T10:49:51.149343502Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         334927240877647,
+				"StableID":   "nk5aNJygc311CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc734d58cca95b35554d568625022525f4805fd9661485b56dd62c478b903961",
+				"DiscoKey":   "discokey:08860ffc9ad49254248fc284273dc3f1e6cd4500003b3b4180836ac7b297e55c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53569", "10.65.0.27:53569", "172.17.0.1:53569"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T10:49:51.696657826Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6999320821172825,
+				"StableID":   "nvDJvmH1fw11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5d1f86245681cd179cba56fc189351670f3f4614e12b161fb2b9dadad1795447",
+				"KeyExpiry":  "2026-11-09T10:49:52Z",
+				"DiscoKey":   "discokey:c6c54d8ca1c7739b766b9e220290d53920c0598ba35753f259b5493a7dcfb017",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:41270", "10.65.0.27:41270", "172.17.0.1:41270"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T10:49:52.231996754Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3911180766115955,
+				"StableID":   "nGfM626PYX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2ebeea6ee130392da77f4dc5e1166a0f819ac768b8d773808e8d454cd3a46169",
+				"KeyExpiry":  "2026-11-09T10:49:52Z",
+				"DiscoKey":   "discokey:5ffa1f5176b04a6e9c1b22114c7594f9557df41aae4c3c439444f29cbab27f62",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:33581", "10.65.0.27:33581", "172.17.0.1:33581"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T10:49:52.769240823Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3017773562694856,
+				"StableID":   "nh7cr4okZQ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       3017773562694856,
+				"Key":        "nodekey:0ed22425f9400edd4fd7f9b6230fada69809c3f67c5d6e205ac0eb9003874076",
+				"DiscoKey":   "discokey:cecc4ba5b5bec6c80fdbe0cb7284423408923db0827f81de7ba9d756d26b934a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:34716", "10.65.0.27:34716", "172.17.0.1:34716"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T10:49:46.825444131Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0ed22425f9400edd4fd7f9b6230fada69809c3f67c5d6e205ac0eb9003874076",
+			"MachineKey": "mkey:ec51a4a247f298e2b6906444cb62585ae34819b8d2a8f8ed5c213f50915f332a",
+			"Peers": [{
+				"ID":         859261059412166,
+				"StableID":   "nuUJRCLAi711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a7e877e42095005a66e6c1aab51ed3285f7d7cc62ccc078ad1d5217f9766a755",
+				"DiscoKey":   "discokey:bf7ca0736125ef38e6f6b59d7c13ec464d326a7f9eaf2755b2c0e786a87d9e5b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:56022", "10.65.0.27:56022", "172.17.0.1:56022"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T10:49:45.772657121Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4038382799288908,
+				"StableID":   "nDhVBAUzXY11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2d6413a67f6cfa2f0811ea5173d77cb82eea52a994848e24959d79f17685b976",
+				"DiscoKey":   "discokey:de3507d6af75b68423e1c5dc49aecff2ad9aa9960b7adf5b8f08cda91fa33a44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:47955", "10.65.0.27:47955", "172.17.0.1:47955"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T10:49:46.301030305Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         841031876026915,
+				"StableID":   "nxFZuuUuZ711CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:40c5193c938376c182253108a8393e39db387193b50b5a03a504640b92525415",
+				"DiscoKey":   "discokey:e7c83de9c4cc48f6392ec088db09d6967e1ccae6eb202ed929bc594b5a661200",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:37212", "10.65.0.27:37212", "172.17.0.1:37212"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T10:49:47.356999827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5408923338656444,
+				"StableID":   "nVK4TAFiEj11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f270ee1ed3fdaa747b96e3392a25be3014c3b1d705dc821b832d712fc6ec1123",
+				"DiscoKey":   "discokey:27ca093c2966725423323b41a97e26a816094c51fc6e814998cd6c02d004d26f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:33332", "10.65.0.27:33332", "172.17.0.1:33332"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T10:49:47.918004223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3719379002270468,
+				"StableID":   "n3Wu1DnW3W11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4be2686873fed2b904d2b62fb3dcaa61b053ca2e8b2bb7be71974cdce4306870",
+				"DiscoKey":   "discokey:8e144a7a9659a77eef738e00b4ff3752d5dce14b11b8bffefda1135826276c7c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:57272", "10.65.0.27:57272", "172.17.0.1:57272"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T10:49:48.451607497Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4938745266024003,
+				"StableID":   "nikkDtTmZf11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bff1dab85d012316bf0f494449937f3a626217a3f81f560d9771dca2b18ce028",
+				"DiscoKey":   "discokey:7b76eb268d98f6279a6c473c43610738414da4d9972308ee11079fcb1505bc39",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:55316", "10.65.0.27:55316", "172.17.0.1:55316"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T10:49:48.99059142Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5717007869107976,
+				"StableID":   "nqhKRw6Fem11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:778958671603dd7ab7e6329ca20c7f129326c2b53b666e9a1ad110fb07ec4200",
+				"DiscoKey":   "discokey:62ba0795a1a73a0e59aca58921ef4bf02dc562a67d72dcb09c763dbf9878441e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:41514", "10.65.0.27:41514", "172.17.0.1:41514"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T10:49:49.539044425Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2681791575458757,
+				"StableID":   "ngUFAo7bwM11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b3998f59a28c54d599dab7f93dca41491b68bf149bd4cdb7bfc6c2a12e43467e",
+				"DiscoKey":   "discokey:2b408dcfd99442c220534cfe6cf009234106918bfa35cd155c4bc373110a2610",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57338", "10.65.0.27:57338", "172.17.0.1:57338"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T10:49:50.077242292Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6843923602848287,
+				"StableID":   "n68NsXGdSv11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35a55ec66e4cda8326413883a0811dfd80ac59d0d3914758bd050f7dbcc7407f",
+				"DiscoKey":   "discokey:e9aca9a712d8b23b1eb95b03b046456a2e75c67dca65a58baa026b9c88267831",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:49062", "10.65.0.27:49062", "172.17.0.1:49062"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T10:49:50.611547224Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5639247385574474,
+				"StableID":   "nukXm3U23m11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f94eea7d87a9966dc52c708dd1d9b2358ba3967e333eab363b20056afeccc32f",
+				"DiscoKey":   "discokey:8b3aa50839dbf30da90c85f2028cb66b27d0b99642ea15a012fcda7b8fb5146c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:56076", "10.65.0.27:56076", "172.17.0.1:56076"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T10:49:51.149343502Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         334927240877647,
+				"StableID":   "nk5aNJygc311CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc734d58cca95b35554d568625022525f4805fd9661485b56dd62c478b903961",
+				"DiscoKey":   "discokey:08860ffc9ad49254248fc284273dc3f1e6cd4500003b3b4180836ac7b297e55c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53569", "10.65.0.27:53569", "172.17.0.1:53569"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T10:49:51.696657826Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6999320821172825,
+				"StableID":   "nvDJvmH1fw11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5d1f86245681cd179cba56fc189351670f3f4614e12b161fb2b9dadad1795447",
+				"KeyExpiry":  "2026-11-09T10:49:52Z",
+				"DiscoKey":   "discokey:c6c54d8ca1c7739b766b9e220290d53920c0598ba35753f259b5493a7dcfb017",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:41270", "10.65.0.27:41270", "172.17.0.1:41270"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T10:49:52.231996754Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3911180766115955,
+				"StableID":   "nGfM626PYX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2ebeea6ee130392da77f4dc5e1166a0f819ac768b8d773808e8d454cd3a46169",
+				"KeyExpiry":  "2026-11-09T10:49:52Z",
+				"DiscoKey":   "discokey:5ffa1f5176b04a6e9c1b22114c7594f9557df41aae4c3c439444f29cbab27f62",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:33581", "10.65.0.27:33581", "172.17.0.1:33581"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T10:49:52.769240823Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7952933030713537,
+				"StableID":   "nNDJPm4u6521CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e1d5f353569caba6c02adf8f7d450836332b84718111e65686b3d1e1af02cb6d",
+				"KeyExpiry":  "2026-11-09T10:49:53Z",
+				"DiscoKey":   "discokey:cbb9f7d452557afe0040be4401b3886943ad7a102a1117f1170aa343e6ae6a4b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:58443", "10.65.0.27:58443", "172.17.0.1:58443"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T10:49:53.299344535Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3017773562694856": {
+				"ID":          3017773562694856,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5717007869107976,
+				"StableID":   "nqhKRw6Fem11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       5717007869107976,
+				"Key":        "nodekey:778958671603dd7ab7e6329ca20c7f129326c2b53b666e9a1ad110fb07ec4200",
+				"DiscoKey":   "discokey:62ba0795a1a73a0e59aca58921ef4bf02dc562a67d72dcb09c763dbf9878441e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:41514", "10.65.0.27:41514", "172.17.0.1:41514"],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T10:49:49.539044425Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:778958671603dd7ab7e6329ca20c7f129326c2b53b666e9a1ad110fb07ec4200",
+			"MachineKey": "mkey:4bd1aed763aaa00eae2f54432ea206530fbc32be68b851d156ca5b8403c55916",
+			"Peers": [{
+				"ID":         859261059412166,
+				"StableID":   "nuUJRCLAi711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a7e877e42095005a66e6c1aab51ed3285f7d7cc62ccc078ad1d5217f9766a755",
+				"DiscoKey":   "discokey:bf7ca0736125ef38e6f6b59d7c13ec464d326a7f9eaf2755b2c0e786a87d9e5b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:56022", "10.65.0.27:56022", "172.17.0.1:56022"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T10:49:45.772657121Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4038382799288908,
+				"StableID":   "nDhVBAUzXY11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2d6413a67f6cfa2f0811ea5173d77cb82eea52a994848e24959d79f17685b976",
+				"DiscoKey":   "discokey:de3507d6af75b68423e1c5dc49aecff2ad9aa9960b7adf5b8f08cda91fa33a44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:47955", "10.65.0.27:47955", "172.17.0.1:47955"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T10:49:46.301030305Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3017773562694856,
+				"StableID":   "nh7cr4okZQ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ed22425f9400edd4fd7f9b6230fada69809c3f67c5d6e205ac0eb9003874076",
+				"DiscoKey":   "discokey:cecc4ba5b5bec6c80fdbe0cb7284423408923db0827f81de7ba9d756d26b934a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:34716", "10.65.0.27:34716", "172.17.0.1:34716"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T10:49:46.825444131Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         841031876026915,
+				"StableID":   "nxFZuuUuZ711CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:40c5193c938376c182253108a8393e39db387193b50b5a03a504640b92525415",
+				"DiscoKey":   "discokey:e7c83de9c4cc48f6392ec088db09d6967e1ccae6eb202ed929bc594b5a661200",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:37212", "10.65.0.27:37212", "172.17.0.1:37212"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T10:49:47.356999827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5408923338656444,
+				"StableID":   "nVK4TAFiEj11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f270ee1ed3fdaa747b96e3392a25be3014c3b1d705dc821b832d712fc6ec1123",
+				"DiscoKey":   "discokey:27ca093c2966725423323b41a97e26a816094c51fc6e814998cd6c02d004d26f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:33332", "10.65.0.27:33332", "172.17.0.1:33332"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T10:49:47.918004223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3719379002270468,
+				"StableID":   "n3Wu1DnW3W11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4be2686873fed2b904d2b62fb3dcaa61b053ca2e8b2bb7be71974cdce4306870",
+				"DiscoKey":   "discokey:8e144a7a9659a77eef738e00b4ff3752d5dce14b11b8bffefda1135826276c7c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:57272", "10.65.0.27:57272", "172.17.0.1:57272"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T10:49:48.451607497Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4938745266024003,
+				"StableID":   "nikkDtTmZf11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bff1dab85d012316bf0f494449937f3a626217a3f81f560d9771dca2b18ce028",
+				"DiscoKey":   "discokey:7b76eb268d98f6279a6c473c43610738414da4d9972308ee11079fcb1505bc39",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:55316", "10.65.0.27:55316", "172.17.0.1:55316"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T10:49:48.99059142Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2681791575458757,
+				"StableID":   "ngUFAo7bwM11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b3998f59a28c54d599dab7f93dca41491b68bf149bd4cdb7bfc6c2a12e43467e",
+				"DiscoKey":   "discokey:2b408dcfd99442c220534cfe6cf009234106918bfa35cd155c4bc373110a2610",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57338", "10.65.0.27:57338", "172.17.0.1:57338"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T10:49:50.077242292Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6843923602848287,
+				"StableID":   "n68NsXGdSv11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35a55ec66e4cda8326413883a0811dfd80ac59d0d3914758bd050f7dbcc7407f",
+				"DiscoKey":   "discokey:e9aca9a712d8b23b1eb95b03b046456a2e75c67dca65a58baa026b9c88267831",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:49062", "10.65.0.27:49062", "172.17.0.1:49062"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T10:49:50.611547224Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5639247385574474,
+				"StableID":   "nukXm3U23m11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f94eea7d87a9966dc52c708dd1d9b2358ba3967e333eab363b20056afeccc32f",
+				"DiscoKey":   "discokey:8b3aa50839dbf30da90c85f2028cb66b27d0b99642ea15a012fcda7b8fb5146c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:56076", "10.65.0.27:56076", "172.17.0.1:56076"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T10:49:51.149343502Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         334927240877647,
+				"StableID":   "nk5aNJygc311CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc734d58cca95b35554d568625022525f4805fd9661485b56dd62c478b903961",
+				"DiscoKey":   "discokey:08860ffc9ad49254248fc284273dc3f1e6cd4500003b3b4180836ac7b297e55c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53569", "10.65.0.27:53569", "172.17.0.1:53569"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T10:49:51.696657826Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6999320821172825,
+				"StableID":   "nvDJvmH1fw11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5d1f86245681cd179cba56fc189351670f3f4614e12b161fb2b9dadad1795447",
+				"KeyExpiry":  "2026-11-09T10:49:52Z",
+				"DiscoKey":   "discokey:c6c54d8ca1c7739b766b9e220290d53920c0598ba35753f259b5493a7dcfb017",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:41270", "10.65.0.27:41270", "172.17.0.1:41270"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T10:49:52.231996754Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3911180766115955,
+				"StableID":   "nGfM626PYX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2ebeea6ee130392da77f4dc5e1166a0f819ac768b8d773808e8d454cd3a46169",
+				"KeyExpiry":  "2026-11-09T10:49:52Z",
+				"DiscoKey":   "discokey:5ffa1f5176b04a6e9c1b22114c7594f9557df41aae4c3c439444f29cbab27f62",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:33581", "10.65.0.27:33581", "172.17.0.1:33581"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T10:49:52.769240823Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7952933030713537,
+				"StableID":   "nNDJPm4u6521CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e1d5f353569caba6c02adf8f7d450836332b84718111e65686b3d1e1af02cb6d",
+				"KeyExpiry":  "2026-11-09T10:49:53Z",
+				"DiscoKey":   "discokey:cbb9f7d452557afe0040be4401b3886943ad7a102a1117f1170aa343e6ae6a4b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:58443", "10.65.0.27:58443", "172.17.0.1:58443"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T10:49:53.299344535Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5717007869107976": {
+				"ID":          5717007869107976,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6999320821172825,
+				"StableID":   "nvDJvmH1fw11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5d1f86245681cd179cba56fc189351670f3f4614e12b161fb2b9dadad1795447",
+				"KeyExpiry":  "2026-11-09T10:49:52Z",
+				"DiscoKey":   "discokey:c6c54d8ca1c7739b766b9e220290d53920c0598ba35753f259b5493a7dcfb017",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:41270", "10.65.0.27:41270", "172.17.0.1:41270"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T10:49:52.231996754Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5d1f86245681cd179cba56fc189351670f3f4614e12b161fb2b9dadad1795447",
+			"MachineKey": "mkey:6fa10154e25821a8301386b773b6fc501cc434933e0e09314a8d660652949e3e",
+			"Peers": [{
+				"ID":         859261059412166,
+				"StableID":   "nuUJRCLAi711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a7e877e42095005a66e6c1aab51ed3285f7d7cc62ccc078ad1d5217f9766a755",
+				"DiscoKey":   "discokey:bf7ca0736125ef38e6f6b59d7c13ec464d326a7f9eaf2755b2c0e786a87d9e5b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:56022", "10.65.0.27:56022", "172.17.0.1:56022"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T10:49:45.772657121Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4038382799288908,
+				"StableID":   "nDhVBAUzXY11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2d6413a67f6cfa2f0811ea5173d77cb82eea52a994848e24959d79f17685b976",
+				"DiscoKey":   "discokey:de3507d6af75b68423e1c5dc49aecff2ad9aa9960b7adf5b8f08cda91fa33a44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:47955", "10.65.0.27:47955", "172.17.0.1:47955"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T10:49:46.301030305Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3017773562694856,
+				"StableID":   "nh7cr4okZQ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ed22425f9400edd4fd7f9b6230fada69809c3f67c5d6e205ac0eb9003874076",
+				"DiscoKey":   "discokey:cecc4ba5b5bec6c80fdbe0cb7284423408923db0827f81de7ba9d756d26b934a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:34716", "10.65.0.27:34716", "172.17.0.1:34716"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T10:49:46.825444131Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         841031876026915,
+				"StableID":   "nxFZuuUuZ711CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:40c5193c938376c182253108a8393e39db387193b50b5a03a504640b92525415",
+				"DiscoKey":   "discokey:e7c83de9c4cc48f6392ec088db09d6967e1ccae6eb202ed929bc594b5a661200",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:37212", "10.65.0.27:37212", "172.17.0.1:37212"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T10:49:47.356999827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5408923338656444,
+				"StableID":   "nVK4TAFiEj11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f270ee1ed3fdaa747b96e3392a25be3014c3b1d705dc821b832d712fc6ec1123",
+				"DiscoKey":   "discokey:27ca093c2966725423323b41a97e26a816094c51fc6e814998cd6c02d004d26f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:33332", "10.65.0.27:33332", "172.17.0.1:33332"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T10:49:47.918004223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3719379002270468,
+				"StableID":   "n3Wu1DnW3W11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4be2686873fed2b904d2b62fb3dcaa61b053ca2e8b2bb7be71974cdce4306870",
+				"DiscoKey":   "discokey:8e144a7a9659a77eef738e00b4ff3752d5dce14b11b8bffefda1135826276c7c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:57272", "10.65.0.27:57272", "172.17.0.1:57272"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T10:49:48.451607497Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4938745266024003,
+				"StableID":   "nikkDtTmZf11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bff1dab85d012316bf0f494449937f3a626217a3f81f560d9771dca2b18ce028",
+				"DiscoKey":   "discokey:7b76eb268d98f6279a6c473c43610738414da4d9972308ee11079fcb1505bc39",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:55316", "10.65.0.27:55316", "172.17.0.1:55316"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T10:49:48.99059142Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5717007869107976,
+				"StableID":   "nqhKRw6Fem11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:778958671603dd7ab7e6329ca20c7f129326c2b53b666e9a1ad110fb07ec4200",
+				"DiscoKey":   "discokey:62ba0795a1a73a0e59aca58921ef4bf02dc562a67d72dcb09c763dbf9878441e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:41514", "10.65.0.27:41514", "172.17.0.1:41514"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T10:49:49.539044425Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2681791575458757,
+				"StableID":   "ngUFAo7bwM11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b3998f59a28c54d599dab7f93dca41491b68bf149bd4cdb7bfc6c2a12e43467e",
+				"DiscoKey":   "discokey:2b408dcfd99442c220534cfe6cf009234106918bfa35cd155c4bc373110a2610",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57338", "10.65.0.27:57338", "172.17.0.1:57338"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T10:49:50.077242292Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6843923602848287,
+				"StableID":   "n68NsXGdSv11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35a55ec66e4cda8326413883a0811dfd80ac59d0d3914758bd050f7dbcc7407f",
+				"DiscoKey":   "discokey:e9aca9a712d8b23b1eb95b03b046456a2e75c67dca65a58baa026b9c88267831",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:49062", "10.65.0.27:49062", "172.17.0.1:49062"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T10:49:50.611547224Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5639247385574474,
+				"StableID":   "nukXm3U23m11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f94eea7d87a9966dc52c708dd1d9b2358ba3967e333eab363b20056afeccc32f",
+				"DiscoKey":   "discokey:8b3aa50839dbf30da90c85f2028cb66b27d0b99642ea15a012fcda7b8fb5146c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:56076", "10.65.0.27:56076", "172.17.0.1:56076"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T10:49:51.149343502Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         334927240877647,
+				"StableID":   "nk5aNJygc311CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc734d58cca95b35554d568625022525f4805fd9661485b56dd62c478b903961",
+				"DiscoKey":   "discokey:08860ffc9ad49254248fc284273dc3f1e6cd4500003b3b4180836ac7b297e55c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53569", "10.65.0.27:53569", "172.17.0.1:53569"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T10:49:51.696657826Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         3911180766115955,
+				"StableID":   "nGfM626PYX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2ebeea6ee130392da77f4dc5e1166a0f819ac768b8d773808e8d454cd3a46169",
+				"KeyExpiry":  "2026-11-09T10:49:52Z",
+				"DiscoKey":   "discokey:5ffa1f5176b04a6e9c1b22114c7594f9557df41aae4c3c439444f29cbab27f62",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:33581", "10.65.0.27:33581", "172.17.0.1:33581"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T10:49:52.769240823Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7952933030713537,
+				"StableID":   "nNDJPm4u6521CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e1d5f353569caba6c02adf8f7d450836332b84718111e65686b3d1e1af02cb6d",
+				"KeyExpiry":  "2026-11-09T10:49:53Z",
+				"DiscoKey":   "discokey:cbb9f7d452557afe0040be4401b3886943ad7a102a1117f1170aa343e6ae6a4b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:58443", "10.65.0.27:58443", "172.17.0.1:58443"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T10:49:53.299344535Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5639247385574474,
+				"StableID":   "nukXm3U23m11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       5639247385574474,
+				"Key":        "nodekey:f94eea7d87a9966dc52c708dd1d9b2358ba3967e333eab363b20056afeccc32f",
+				"DiscoKey":   "discokey:8b3aa50839dbf30da90c85f2028cb66b27d0b99642ea15a012fcda7b8fb5146c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:56076", "10.65.0.27:56076", "172.17.0.1:56076"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T10:49:51.149343502Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f94eea7d87a9966dc52c708dd1d9b2358ba3967e333eab363b20056afeccc32f",
+			"MachineKey": "mkey:8380bcff507ce2998978a3948f4571514ccd9951357fe9524deba22ba829a706",
+			"Peers": [{
+				"ID":         859261059412166,
+				"StableID":   "nuUJRCLAi711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a7e877e42095005a66e6c1aab51ed3285f7d7cc62ccc078ad1d5217f9766a755",
+				"DiscoKey":   "discokey:bf7ca0736125ef38e6f6b59d7c13ec464d326a7f9eaf2755b2c0e786a87d9e5b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:56022", "10.65.0.27:56022", "172.17.0.1:56022"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T10:49:45.772657121Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4038382799288908,
+				"StableID":   "nDhVBAUzXY11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2d6413a67f6cfa2f0811ea5173d77cb82eea52a994848e24959d79f17685b976",
+				"DiscoKey":   "discokey:de3507d6af75b68423e1c5dc49aecff2ad9aa9960b7adf5b8f08cda91fa33a44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:47955", "10.65.0.27:47955", "172.17.0.1:47955"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T10:49:46.301030305Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3017773562694856,
+				"StableID":   "nh7cr4okZQ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ed22425f9400edd4fd7f9b6230fada69809c3f67c5d6e205ac0eb9003874076",
+				"DiscoKey":   "discokey:cecc4ba5b5bec6c80fdbe0cb7284423408923db0827f81de7ba9d756d26b934a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:34716", "10.65.0.27:34716", "172.17.0.1:34716"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T10:49:46.825444131Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         841031876026915,
+				"StableID":   "nxFZuuUuZ711CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:40c5193c938376c182253108a8393e39db387193b50b5a03a504640b92525415",
+				"DiscoKey":   "discokey:e7c83de9c4cc48f6392ec088db09d6967e1ccae6eb202ed929bc594b5a661200",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:37212", "10.65.0.27:37212", "172.17.0.1:37212"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T10:49:47.356999827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5408923338656444,
+				"StableID":   "nVK4TAFiEj11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f270ee1ed3fdaa747b96e3392a25be3014c3b1d705dc821b832d712fc6ec1123",
+				"DiscoKey":   "discokey:27ca093c2966725423323b41a97e26a816094c51fc6e814998cd6c02d004d26f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:33332", "10.65.0.27:33332", "172.17.0.1:33332"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T10:49:47.918004223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3719379002270468,
+				"StableID":   "n3Wu1DnW3W11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4be2686873fed2b904d2b62fb3dcaa61b053ca2e8b2bb7be71974cdce4306870",
+				"DiscoKey":   "discokey:8e144a7a9659a77eef738e00b4ff3752d5dce14b11b8bffefda1135826276c7c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:57272", "10.65.0.27:57272", "172.17.0.1:57272"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T10:49:48.451607497Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4938745266024003,
+				"StableID":   "nikkDtTmZf11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bff1dab85d012316bf0f494449937f3a626217a3f81f560d9771dca2b18ce028",
+				"DiscoKey":   "discokey:7b76eb268d98f6279a6c473c43610738414da4d9972308ee11079fcb1505bc39",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:55316", "10.65.0.27:55316", "172.17.0.1:55316"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T10:49:48.99059142Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5717007869107976,
+				"StableID":   "nqhKRw6Fem11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:778958671603dd7ab7e6329ca20c7f129326c2b53b666e9a1ad110fb07ec4200",
+				"DiscoKey":   "discokey:62ba0795a1a73a0e59aca58921ef4bf02dc562a67d72dcb09c763dbf9878441e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:41514", "10.65.0.27:41514", "172.17.0.1:41514"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T10:49:49.539044425Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2681791575458757,
+				"StableID":   "ngUFAo7bwM11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b3998f59a28c54d599dab7f93dca41491b68bf149bd4cdb7bfc6c2a12e43467e",
+				"DiscoKey":   "discokey:2b408dcfd99442c220534cfe6cf009234106918bfa35cd155c4bc373110a2610",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57338", "10.65.0.27:57338", "172.17.0.1:57338"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T10:49:50.077242292Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6843923602848287,
+				"StableID":   "n68NsXGdSv11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35a55ec66e4cda8326413883a0811dfd80ac59d0d3914758bd050f7dbcc7407f",
+				"DiscoKey":   "discokey:e9aca9a712d8b23b1eb95b03b046456a2e75c67dca65a58baa026b9c88267831",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:49062", "10.65.0.27:49062", "172.17.0.1:49062"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T10:49:50.611547224Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         334927240877647,
+				"StableID":   "nk5aNJygc311CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc734d58cca95b35554d568625022525f4805fd9661485b56dd62c478b903961",
+				"DiscoKey":   "discokey:08860ffc9ad49254248fc284273dc3f1e6cd4500003b3b4180836ac7b297e55c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53569", "10.65.0.27:53569", "172.17.0.1:53569"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T10:49:51.696657826Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6999320821172825,
+				"StableID":   "nvDJvmH1fw11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5d1f86245681cd179cba56fc189351670f3f4614e12b161fb2b9dadad1795447",
+				"KeyExpiry":  "2026-11-09T10:49:52Z",
+				"DiscoKey":   "discokey:c6c54d8ca1c7739b766b9e220290d53920c0598ba35753f259b5493a7dcfb017",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:41270", "10.65.0.27:41270", "172.17.0.1:41270"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T10:49:52.231996754Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3911180766115955,
+				"StableID":   "nGfM626PYX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2ebeea6ee130392da77f4dc5e1166a0f819ac768b8d773808e8d454cd3a46169",
+				"KeyExpiry":  "2026-11-09T10:49:52Z",
+				"DiscoKey":   "discokey:5ffa1f5176b04a6e9c1b22114c7594f9557df41aae4c3c439444f29cbab27f62",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:33581", "10.65.0.27:33581", "172.17.0.1:33581"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T10:49:52.769240823Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7952933030713537,
+				"StableID":   "nNDJPm4u6521CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e1d5f353569caba6c02adf8f7d450836332b84718111e65686b3d1e1af02cb6d",
+				"KeyExpiry":  "2026-11-09T10:49:53Z",
+				"DiscoKey":   "discokey:cbb9f7d452557afe0040be4401b3886943ad7a102a1117f1170aa343e6ae6a4b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:58443", "10.65.0.27:58443", "172.17.0.1:58443"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T10:49:53.299344535Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5639247385574474": {
+				"ID":          5639247385574474,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4038382799288908,
+				"StableID":   "nDhVBAUzXY11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       4038382799288908,
+				"Key":        "nodekey:2d6413a67f6cfa2f0811ea5173d77cb82eea52a994848e24959d79f17685b976",
+				"DiscoKey":   "discokey:de3507d6af75b68423e1c5dc49aecff2ad9aa9960b7adf5b8f08cda91fa33a44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:47955", "10.65.0.27:47955", "172.17.0.1:47955"],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T10:49:46.301030305Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2d6413a67f6cfa2f0811ea5173d77cb82eea52a994848e24959d79f17685b976",
+			"MachineKey": "mkey:07ecb2727121b6e23340ad8edec8ff43acd1c18ddd281d38e5d578187f571426",
+			"Peers": [{
+				"ID":         859261059412166,
+				"StableID":   "nuUJRCLAi711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a7e877e42095005a66e6c1aab51ed3285f7d7cc62ccc078ad1d5217f9766a755",
+				"DiscoKey":   "discokey:bf7ca0736125ef38e6f6b59d7c13ec464d326a7f9eaf2755b2c0e786a87d9e5b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:56022", "10.65.0.27:56022", "172.17.0.1:56022"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T10:49:45.772657121Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3017773562694856,
+				"StableID":   "nh7cr4okZQ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ed22425f9400edd4fd7f9b6230fada69809c3f67c5d6e205ac0eb9003874076",
+				"DiscoKey":   "discokey:cecc4ba5b5bec6c80fdbe0cb7284423408923db0827f81de7ba9d756d26b934a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:34716", "10.65.0.27:34716", "172.17.0.1:34716"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T10:49:46.825444131Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         841031876026915,
+				"StableID":   "nxFZuuUuZ711CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:40c5193c938376c182253108a8393e39db387193b50b5a03a504640b92525415",
+				"DiscoKey":   "discokey:e7c83de9c4cc48f6392ec088db09d6967e1ccae6eb202ed929bc594b5a661200",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:37212", "10.65.0.27:37212", "172.17.0.1:37212"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T10:49:47.356999827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5408923338656444,
+				"StableID":   "nVK4TAFiEj11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f270ee1ed3fdaa747b96e3392a25be3014c3b1d705dc821b832d712fc6ec1123",
+				"DiscoKey":   "discokey:27ca093c2966725423323b41a97e26a816094c51fc6e814998cd6c02d004d26f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:33332", "10.65.0.27:33332", "172.17.0.1:33332"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T10:49:47.918004223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3719379002270468,
+				"StableID":   "n3Wu1DnW3W11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4be2686873fed2b904d2b62fb3dcaa61b053ca2e8b2bb7be71974cdce4306870",
+				"DiscoKey":   "discokey:8e144a7a9659a77eef738e00b4ff3752d5dce14b11b8bffefda1135826276c7c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:57272", "10.65.0.27:57272", "172.17.0.1:57272"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T10:49:48.451607497Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4938745266024003,
+				"StableID":   "nikkDtTmZf11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bff1dab85d012316bf0f494449937f3a626217a3f81f560d9771dca2b18ce028",
+				"DiscoKey":   "discokey:7b76eb268d98f6279a6c473c43610738414da4d9972308ee11079fcb1505bc39",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:55316", "10.65.0.27:55316", "172.17.0.1:55316"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T10:49:48.99059142Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5717007869107976,
+				"StableID":   "nqhKRw6Fem11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:778958671603dd7ab7e6329ca20c7f129326c2b53b666e9a1ad110fb07ec4200",
+				"DiscoKey":   "discokey:62ba0795a1a73a0e59aca58921ef4bf02dc562a67d72dcb09c763dbf9878441e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:41514", "10.65.0.27:41514", "172.17.0.1:41514"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T10:49:49.539044425Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2681791575458757,
+				"StableID":   "ngUFAo7bwM11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b3998f59a28c54d599dab7f93dca41491b68bf149bd4cdb7bfc6c2a12e43467e",
+				"DiscoKey":   "discokey:2b408dcfd99442c220534cfe6cf009234106918bfa35cd155c4bc373110a2610",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57338", "10.65.0.27:57338", "172.17.0.1:57338"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T10:49:50.077242292Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6843923602848287,
+				"StableID":   "n68NsXGdSv11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35a55ec66e4cda8326413883a0811dfd80ac59d0d3914758bd050f7dbcc7407f",
+				"DiscoKey":   "discokey:e9aca9a712d8b23b1eb95b03b046456a2e75c67dca65a58baa026b9c88267831",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:49062", "10.65.0.27:49062", "172.17.0.1:49062"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T10:49:50.611547224Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5639247385574474,
+				"StableID":   "nukXm3U23m11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f94eea7d87a9966dc52c708dd1d9b2358ba3967e333eab363b20056afeccc32f",
+				"DiscoKey":   "discokey:8b3aa50839dbf30da90c85f2028cb66b27d0b99642ea15a012fcda7b8fb5146c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:56076", "10.65.0.27:56076", "172.17.0.1:56076"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T10:49:51.149343502Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         334927240877647,
+				"StableID":   "nk5aNJygc311CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc734d58cca95b35554d568625022525f4805fd9661485b56dd62c478b903961",
+				"DiscoKey":   "discokey:08860ffc9ad49254248fc284273dc3f1e6cd4500003b3b4180836ac7b297e55c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53569", "10.65.0.27:53569", "172.17.0.1:53569"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T10:49:51.696657826Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6999320821172825,
+				"StableID":   "nvDJvmH1fw11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5d1f86245681cd179cba56fc189351670f3f4614e12b161fb2b9dadad1795447",
+				"KeyExpiry":  "2026-11-09T10:49:52Z",
+				"DiscoKey":   "discokey:c6c54d8ca1c7739b766b9e220290d53920c0598ba35753f259b5493a7dcfb017",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:41270", "10.65.0.27:41270", "172.17.0.1:41270"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T10:49:52.231996754Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3911180766115955,
+				"StableID":   "nGfM626PYX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2ebeea6ee130392da77f4dc5e1166a0f819ac768b8d773808e8d454cd3a46169",
+				"KeyExpiry":  "2026-11-09T10:49:52Z",
+				"DiscoKey":   "discokey:5ffa1f5176b04a6e9c1b22114c7594f9557df41aae4c3c439444f29cbab27f62",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:33581", "10.65.0.27:33581", "172.17.0.1:33581"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T10:49:52.769240823Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7952933030713537,
+				"StableID":   "nNDJPm4u6521CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e1d5f353569caba6c02adf8f7d450836332b84718111e65686b3d1e1af02cb6d",
+				"KeyExpiry":  "2026-11-09T10:49:53Z",
+				"DiscoKey":   "discokey:cbb9f7d452557afe0040be4401b3886943ad7a102a1117f1170aa343e6ae6a4b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:58443", "10.65.0.27:58443", "172.17.0.1:58443"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T10:49:53.299344535Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4038382799288908": {
+				"ID":          4038382799288908,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         859261059412166,
+				"StableID":   "nuUJRCLAi711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       859261059412166,
+				"Key":        "nodekey:a7e877e42095005a66e6c1aab51ed3285f7d7cc62ccc078ad1d5217f9766a755",
+				"DiscoKey":   "discokey:bf7ca0736125ef38e6f6b59d7c13ec464d326a7f9eaf2755b2c0e786a87d9e5b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:56022", "10.65.0.27:56022", "172.17.0.1:56022"],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T10:49:45.772657121Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a7e877e42095005a66e6c1aab51ed3285f7d7cc62ccc078ad1d5217f9766a755",
+			"MachineKey": "mkey:c33b20f01ed76d1ab2568383b634016a633368ff428506330a369d1d5f17c448",
+			"Peers": [{
+				"ID":         4038382799288908,
+				"StableID":   "nDhVBAUzXY11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2d6413a67f6cfa2f0811ea5173d77cb82eea52a994848e24959d79f17685b976",
+				"DiscoKey":   "discokey:de3507d6af75b68423e1c5dc49aecff2ad9aa9960b7adf5b8f08cda91fa33a44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:47955", "10.65.0.27:47955", "172.17.0.1:47955"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T10:49:46.301030305Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3017773562694856,
+				"StableID":   "nh7cr4okZQ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ed22425f9400edd4fd7f9b6230fada69809c3f67c5d6e205ac0eb9003874076",
+				"DiscoKey":   "discokey:cecc4ba5b5bec6c80fdbe0cb7284423408923db0827f81de7ba9d756d26b934a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:34716", "10.65.0.27:34716", "172.17.0.1:34716"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T10:49:46.825444131Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         841031876026915,
+				"StableID":   "nxFZuuUuZ711CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:40c5193c938376c182253108a8393e39db387193b50b5a03a504640b92525415",
+				"DiscoKey":   "discokey:e7c83de9c4cc48f6392ec088db09d6967e1ccae6eb202ed929bc594b5a661200",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:37212", "10.65.0.27:37212", "172.17.0.1:37212"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T10:49:47.356999827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5408923338656444,
+				"StableID":   "nVK4TAFiEj11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f270ee1ed3fdaa747b96e3392a25be3014c3b1d705dc821b832d712fc6ec1123",
+				"DiscoKey":   "discokey:27ca093c2966725423323b41a97e26a816094c51fc6e814998cd6c02d004d26f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:33332", "10.65.0.27:33332", "172.17.0.1:33332"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T10:49:47.918004223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3719379002270468,
+				"StableID":   "n3Wu1DnW3W11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4be2686873fed2b904d2b62fb3dcaa61b053ca2e8b2bb7be71974cdce4306870",
+				"DiscoKey":   "discokey:8e144a7a9659a77eef738e00b4ff3752d5dce14b11b8bffefda1135826276c7c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:57272", "10.65.0.27:57272", "172.17.0.1:57272"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T10:49:48.451607497Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4938745266024003,
+				"StableID":   "nikkDtTmZf11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bff1dab85d012316bf0f494449937f3a626217a3f81f560d9771dca2b18ce028",
+				"DiscoKey":   "discokey:7b76eb268d98f6279a6c473c43610738414da4d9972308ee11079fcb1505bc39",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:55316", "10.65.0.27:55316", "172.17.0.1:55316"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T10:49:48.99059142Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5717007869107976,
+				"StableID":   "nqhKRw6Fem11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:778958671603dd7ab7e6329ca20c7f129326c2b53b666e9a1ad110fb07ec4200",
+				"DiscoKey":   "discokey:62ba0795a1a73a0e59aca58921ef4bf02dc562a67d72dcb09c763dbf9878441e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:41514", "10.65.0.27:41514", "172.17.0.1:41514"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T10:49:49.539044425Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2681791575458757,
+				"StableID":   "ngUFAo7bwM11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b3998f59a28c54d599dab7f93dca41491b68bf149bd4cdb7bfc6c2a12e43467e",
+				"DiscoKey":   "discokey:2b408dcfd99442c220534cfe6cf009234106918bfa35cd155c4bc373110a2610",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57338", "10.65.0.27:57338", "172.17.0.1:57338"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T10:49:50.077242292Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6843923602848287,
+				"StableID":   "n68NsXGdSv11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35a55ec66e4cda8326413883a0811dfd80ac59d0d3914758bd050f7dbcc7407f",
+				"DiscoKey":   "discokey:e9aca9a712d8b23b1eb95b03b046456a2e75c67dca65a58baa026b9c88267831",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:49062", "10.65.0.27:49062", "172.17.0.1:49062"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T10:49:50.611547224Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5639247385574474,
+				"StableID":   "nukXm3U23m11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f94eea7d87a9966dc52c708dd1d9b2358ba3967e333eab363b20056afeccc32f",
+				"DiscoKey":   "discokey:8b3aa50839dbf30da90c85f2028cb66b27d0b99642ea15a012fcda7b8fb5146c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:56076", "10.65.0.27:56076", "172.17.0.1:56076"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T10:49:51.149343502Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         334927240877647,
+				"StableID":   "nk5aNJygc311CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc734d58cca95b35554d568625022525f4805fd9661485b56dd62c478b903961",
+				"DiscoKey":   "discokey:08860ffc9ad49254248fc284273dc3f1e6cd4500003b3b4180836ac7b297e55c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53569", "10.65.0.27:53569", "172.17.0.1:53569"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T10:49:51.696657826Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6999320821172825,
+				"StableID":   "nvDJvmH1fw11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5d1f86245681cd179cba56fc189351670f3f4614e12b161fb2b9dadad1795447",
+				"KeyExpiry":  "2026-11-09T10:49:52Z",
+				"DiscoKey":   "discokey:c6c54d8ca1c7739b766b9e220290d53920c0598ba35753f259b5493a7dcfb017",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:41270", "10.65.0.27:41270", "172.17.0.1:41270"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T10:49:52.231996754Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3911180766115955,
+				"StableID":   "nGfM626PYX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2ebeea6ee130392da77f4dc5e1166a0f819ac768b8d773808e8d454cd3a46169",
+				"KeyExpiry":  "2026-11-09T10:49:52Z",
+				"DiscoKey":   "discokey:5ffa1f5176b04a6e9c1b22114c7594f9557df41aae4c3c439444f29cbab27f62",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:33581", "10.65.0.27:33581", "172.17.0.1:33581"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T10:49:52.769240823Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7952933030713537,
+				"StableID":   "nNDJPm4u6521CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e1d5f353569caba6c02adf8f7d450836332b84718111e65686b3d1e1af02cb6d",
+				"KeyExpiry":  "2026-11-09T10:49:53Z",
+				"DiscoKey":   "discokey:cbb9f7d452557afe0040be4401b3886943ad7a102a1117f1170aa343e6ae6a4b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:58443", "10.65.0.27:58443", "172.17.0.1:58443"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T10:49:53.299344535Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "859261059412166": {
+				"ID":          859261059412166,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5408923338656444,
+				"StableID":   "nVK4TAFiEj11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       5408923338656444,
+				"Key":        "nodekey:f270ee1ed3fdaa747b96e3392a25be3014c3b1d705dc821b832d712fc6ec1123",
+				"DiscoKey":   "discokey:27ca093c2966725423323b41a97e26a816094c51fc6e814998cd6c02d004d26f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:33332", "10.65.0.27:33332", "172.17.0.1:33332"],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T10:49:47.918004223Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f270ee1ed3fdaa747b96e3392a25be3014c3b1d705dc821b832d712fc6ec1123",
+			"MachineKey": "mkey:73d0b57dae0b149e5e83750fefa11506a6e689298bd5691ceb2ccc0c6afcae10",
+			"Peers": [{
+				"ID":         859261059412166,
+				"StableID":   "nuUJRCLAi711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a7e877e42095005a66e6c1aab51ed3285f7d7cc62ccc078ad1d5217f9766a755",
+				"DiscoKey":   "discokey:bf7ca0736125ef38e6f6b59d7c13ec464d326a7f9eaf2755b2c0e786a87d9e5b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:56022", "10.65.0.27:56022", "172.17.0.1:56022"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T10:49:45.772657121Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4038382799288908,
+				"StableID":   "nDhVBAUzXY11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2d6413a67f6cfa2f0811ea5173d77cb82eea52a994848e24959d79f17685b976",
+				"DiscoKey":   "discokey:de3507d6af75b68423e1c5dc49aecff2ad9aa9960b7adf5b8f08cda91fa33a44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:47955", "10.65.0.27:47955", "172.17.0.1:47955"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T10:49:46.301030305Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3017773562694856,
+				"StableID":   "nh7cr4okZQ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ed22425f9400edd4fd7f9b6230fada69809c3f67c5d6e205ac0eb9003874076",
+				"DiscoKey":   "discokey:cecc4ba5b5bec6c80fdbe0cb7284423408923db0827f81de7ba9d756d26b934a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:34716", "10.65.0.27:34716", "172.17.0.1:34716"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T10:49:46.825444131Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         841031876026915,
+				"StableID":   "nxFZuuUuZ711CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:40c5193c938376c182253108a8393e39db387193b50b5a03a504640b92525415",
+				"DiscoKey":   "discokey:e7c83de9c4cc48f6392ec088db09d6967e1ccae6eb202ed929bc594b5a661200",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:37212", "10.65.0.27:37212", "172.17.0.1:37212"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T10:49:47.356999827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3719379002270468,
+				"StableID":   "n3Wu1DnW3W11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4be2686873fed2b904d2b62fb3dcaa61b053ca2e8b2bb7be71974cdce4306870",
+				"DiscoKey":   "discokey:8e144a7a9659a77eef738e00b4ff3752d5dce14b11b8bffefda1135826276c7c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:57272", "10.65.0.27:57272", "172.17.0.1:57272"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T10:49:48.451607497Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4938745266024003,
+				"StableID":   "nikkDtTmZf11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bff1dab85d012316bf0f494449937f3a626217a3f81f560d9771dca2b18ce028",
+				"DiscoKey":   "discokey:7b76eb268d98f6279a6c473c43610738414da4d9972308ee11079fcb1505bc39",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:55316", "10.65.0.27:55316", "172.17.0.1:55316"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T10:49:48.99059142Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5717007869107976,
+				"StableID":   "nqhKRw6Fem11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:778958671603dd7ab7e6329ca20c7f129326c2b53b666e9a1ad110fb07ec4200",
+				"DiscoKey":   "discokey:62ba0795a1a73a0e59aca58921ef4bf02dc562a67d72dcb09c763dbf9878441e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:41514", "10.65.0.27:41514", "172.17.0.1:41514"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T10:49:49.539044425Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2681791575458757,
+				"StableID":   "ngUFAo7bwM11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b3998f59a28c54d599dab7f93dca41491b68bf149bd4cdb7bfc6c2a12e43467e",
+				"DiscoKey":   "discokey:2b408dcfd99442c220534cfe6cf009234106918bfa35cd155c4bc373110a2610",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57338", "10.65.0.27:57338", "172.17.0.1:57338"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T10:49:50.077242292Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6843923602848287,
+				"StableID":   "n68NsXGdSv11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35a55ec66e4cda8326413883a0811dfd80ac59d0d3914758bd050f7dbcc7407f",
+				"DiscoKey":   "discokey:e9aca9a712d8b23b1eb95b03b046456a2e75c67dca65a58baa026b9c88267831",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:49062", "10.65.0.27:49062", "172.17.0.1:49062"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T10:49:50.611547224Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5639247385574474,
+				"StableID":   "nukXm3U23m11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f94eea7d87a9966dc52c708dd1d9b2358ba3967e333eab363b20056afeccc32f",
+				"DiscoKey":   "discokey:8b3aa50839dbf30da90c85f2028cb66b27d0b99642ea15a012fcda7b8fb5146c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:56076", "10.65.0.27:56076", "172.17.0.1:56076"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T10:49:51.149343502Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         334927240877647,
+				"StableID":   "nk5aNJygc311CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc734d58cca95b35554d568625022525f4805fd9661485b56dd62c478b903961",
+				"DiscoKey":   "discokey:08860ffc9ad49254248fc284273dc3f1e6cd4500003b3b4180836ac7b297e55c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53569", "10.65.0.27:53569", "172.17.0.1:53569"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T10:49:51.696657826Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6999320821172825,
+				"StableID":   "nvDJvmH1fw11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5d1f86245681cd179cba56fc189351670f3f4614e12b161fb2b9dadad1795447",
+				"KeyExpiry":  "2026-11-09T10:49:52Z",
+				"DiscoKey":   "discokey:c6c54d8ca1c7739b766b9e220290d53920c0598ba35753f259b5493a7dcfb017",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:41270", "10.65.0.27:41270", "172.17.0.1:41270"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T10:49:52.231996754Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3911180766115955,
+				"StableID":   "nGfM626PYX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2ebeea6ee130392da77f4dc5e1166a0f819ac768b8d773808e8d454cd3a46169",
+				"KeyExpiry":  "2026-11-09T10:49:52Z",
+				"DiscoKey":   "discokey:5ffa1f5176b04a6e9c1b22114c7594f9557df41aae4c3c439444f29cbab27f62",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:33581", "10.65.0.27:33581", "172.17.0.1:33581"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T10:49:52.769240823Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7952933030713537,
+				"StableID":   "nNDJPm4u6521CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e1d5f353569caba6c02adf8f7d450836332b84718111e65686b3d1e1af02cb6d",
+				"KeyExpiry":  "2026-11-09T10:49:53Z",
+				"DiscoKey":   "discokey:cbb9f7d452557afe0040be4401b3886943ad7a102a1117f1170aa343e6ae6a4b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:58443", "10.65.0.27:58443", "172.17.0.1:58443"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T10:49:53.299344535Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5408923338656444": {
+				"ID":          5408923338656444,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         841031876026915,
+				"StableID":   "nxFZuuUuZ711CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       841031876026915,
+				"Key":        "nodekey:40c5193c938376c182253108a8393e39db387193b50b5a03a504640b92525415",
+				"DiscoKey":   "discokey:e7c83de9c4cc48f6392ec088db09d6967e1ccae6eb202ed929bc594b5a661200",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:37212", "10.65.0.27:37212", "172.17.0.1:37212"],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T10:49:47.356999827Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:40c5193c938376c182253108a8393e39db387193b50b5a03a504640b92525415",
+			"MachineKey": "mkey:cabb074d03cdef38e6bb8f95453369749a4b48fce47d534efadffc0c75833a2c",
+			"Peers": [{
+				"ID":         859261059412166,
+				"StableID":   "nuUJRCLAi711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a7e877e42095005a66e6c1aab51ed3285f7d7cc62ccc078ad1d5217f9766a755",
+				"DiscoKey":   "discokey:bf7ca0736125ef38e6f6b59d7c13ec464d326a7f9eaf2755b2c0e786a87d9e5b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:56022", "10.65.0.27:56022", "172.17.0.1:56022"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T10:49:45.772657121Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4038382799288908,
+				"StableID":   "nDhVBAUzXY11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2d6413a67f6cfa2f0811ea5173d77cb82eea52a994848e24959d79f17685b976",
+				"DiscoKey":   "discokey:de3507d6af75b68423e1c5dc49aecff2ad9aa9960b7adf5b8f08cda91fa33a44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:47955", "10.65.0.27:47955", "172.17.0.1:47955"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T10:49:46.301030305Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3017773562694856,
+				"StableID":   "nh7cr4okZQ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ed22425f9400edd4fd7f9b6230fada69809c3f67c5d6e205ac0eb9003874076",
+				"DiscoKey":   "discokey:cecc4ba5b5bec6c80fdbe0cb7284423408923db0827f81de7ba9d756d26b934a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:34716", "10.65.0.27:34716", "172.17.0.1:34716"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T10:49:46.825444131Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5408923338656444,
+				"StableID":   "nVK4TAFiEj11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f270ee1ed3fdaa747b96e3392a25be3014c3b1d705dc821b832d712fc6ec1123",
+				"DiscoKey":   "discokey:27ca093c2966725423323b41a97e26a816094c51fc6e814998cd6c02d004d26f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:33332", "10.65.0.27:33332", "172.17.0.1:33332"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T10:49:47.918004223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3719379002270468,
+				"StableID":   "n3Wu1DnW3W11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4be2686873fed2b904d2b62fb3dcaa61b053ca2e8b2bb7be71974cdce4306870",
+				"DiscoKey":   "discokey:8e144a7a9659a77eef738e00b4ff3752d5dce14b11b8bffefda1135826276c7c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:57272", "10.65.0.27:57272", "172.17.0.1:57272"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T10:49:48.451607497Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4938745266024003,
+				"StableID":   "nikkDtTmZf11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bff1dab85d012316bf0f494449937f3a626217a3f81f560d9771dca2b18ce028",
+				"DiscoKey":   "discokey:7b76eb268d98f6279a6c473c43610738414da4d9972308ee11079fcb1505bc39",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:55316", "10.65.0.27:55316", "172.17.0.1:55316"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T10:49:48.99059142Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5717007869107976,
+				"StableID":   "nqhKRw6Fem11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:778958671603dd7ab7e6329ca20c7f129326c2b53b666e9a1ad110fb07ec4200",
+				"DiscoKey":   "discokey:62ba0795a1a73a0e59aca58921ef4bf02dc562a67d72dcb09c763dbf9878441e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:41514", "10.65.0.27:41514", "172.17.0.1:41514"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T10:49:49.539044425Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2681791575458757,
+				"StableID":   "ngUFAo7bwM11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b3998f59a28c54d599dab7f93dca41491b68bf149bd4cdb7bfc6c2a12e43467e",
+				"DiscoKey":   "discokey:2b408dcfd99442c220534cfe6cf009234106918bfa35cd155c4bc373110a2610",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57338", "10.65.0.27:57338", "172.17.0.1:57338"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T10:49:50.077242292Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6843923602848287,
+				"StableID":   "n68NsXGdSv11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35a55ec66e4cda8326413883a0811dfd80ac59d0d3914758bd050f7dbcc7407f",
+				"DiscoKey":   "discokey:e9aca9a712d8b23b1eb95b03b046456a2e75c67dca65a58baa026b9c88267831",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:49062", "10.65.0.27:49062", "172.17.0.1:49062"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T10:49:50.611547224Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5639247385574474,
+				"StableID":   "nukXm3U23m11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f94eea7d87a9966dc52c708dd1d9b2358ba3967e333eab363b20056afeccc32f",
+				"DiscoKey":   "discokey:8b3aa50839dbf30da90c85f2028cb66b27d0b99642ea15a012fcda7b8fb5146c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:56076", "10.65.0.27:56076", "172.17.0.1:56076"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T10:49:51.149343502Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         334927240877647,
+				"StableID":   "nk5aNJygc311CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc734d58cca95b35554d568625022525f4805fd9661485b56dd62c478b903961",
+				"DiscoKey":   "discokey:08860ffc9ad49254248fc284273dc3f1e6cd4500003b3b4180836ac7b297e55c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53569", "10.65.0.27:53569", "172.17.0.1:53569"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T10:49:51.696657826Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6999320821172825,
+				"StableID":   "nvDJvmH1fw11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5d1f86245681cd179cba56fc189351670f3f4614e12b161fb2b9dadad1795447",
+				"KeyExpiry":  "2026-11-09T10:49:52Z",
+				"DiscoKey":   "discokey:c6c54d8ca1c7739b766b9e220290d53920c0598ba35753f259b5493a7dcfb017",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:41270", "10.65.0.27:41270", "172.17.0.1:41270"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T10:49:52.231996754Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3911180766115955,
+				"StableID":   "nGfM626PYX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2ebeea6ee130392da77f4dc5e1166a0f819ac768b8d773808e8d454cd3a46169",
+				"KeyExpiry":  "2026-11-09T10:49:52Z",
+				"DiscoKey":   "discokey:5ffa1f5176b04a6e9c1b22114c7594f9557df41aae4c3c439444f29cbab27f62",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:33581", "10.65.0.27:33581", "172.17.0.1:33581"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T10:49:52.769240823Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7952933030713537,
+				"StableID":   "nNDJPm4u6521CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e1d5f353569caba6c02adf8f7d450836332b84718111e65686b3d1e1af02cb6d",
+				"KeyExpiry":  "2026-11-09T10:49:53Z",
+				"DiscoKey":   "discokey:cbb9f7d452557afe0040be4401b3886943ad7a102a1117f1170aa343e6ae6a4b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:58443", "10.65.0.27:58443", "172.17.0.1:58443"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T10:49:53.299344535Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "841031876026915": {
+				"ID":          841031876026915,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4938745266024003,
+				"StableID":   "nikkDtTmZf11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       4938745266024003,
+				"Key":        "nodekey:bff1dab85d012316bf0f494449937f3a626217a3f81f560d9771dca2b18ce028",
+				"DiscoKey":   "discokey:7b76eb268d98f6279a6c473c43610738414da4d9972308ee11079fcb1505bc39",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:55316", "10.65.0.27:55316", "172.17.0.1:55316"],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T10:49:48.99059142Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:bff1dab85d012316bf0f494449937f3a626217a3f81f560d9771dca2b18ce028",
+			"MachineKey": "mkey:b050d3695c3530c7586d127345a16efef3b55779aaf6c195991339bba11d6645",
+			"Peers": [{
+				"ID":         859261059412166,
+				"StableID":   "nuUJRCLAi711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a7e877e42095005a66e6c1aab51ed3285f7d7cc62ccc078ad1d5217f9766a755",
+				"DiscoKey":   "discokey:bf7ca0736125ef38e6f6b59d7c13ec464d326a7f9eaf2755b2c0e786a87d9e5b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:56022", "10.65.0.27:56022", "172.17.0.1:56022"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T10:49:45.772657121Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4038382799288908,
+				"StableID":   "nDhVBAUzXY11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2d6413a67f6cfa2f0811ea5173d77cb82eea52a994848e24959d79f17685b976",
+				"DiscoKey":   "discokey:de3507d6af75b68423e1c5dc49aecff2ad9aa9960b7adf5b8f08cda91fa33a44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:47955", "10.65.0.27:47955", "172.17.0.1:47955"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T10:49:46.301030305Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3017773562694856,
+				"StableID":   "nh7cr4okZQ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ed22425f9400edd4fd7f9b6230fada69809c3f67c5d6e205ac0eb9003874076",
+				"DiscoKey":   "discokey:cecc4ba5b5bec6c80fdbe0cb7284423408923db0827f81de7ba9d756d26b934a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:34716", "10.65.0.27:34716", "172.17.0.1:34716"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T10:49:46.825444131Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         841031876026915,
+				"StableID":   "nxFZuuUuZ711CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:40c5193c938376c182253108a8393e39db387193b50b5a03a504640b92525415",
+				"DiscoKey":   "discokey:e7c83de9c4cc48f6392ec088db09d6967e1ccae6eb202ed929bc594b5a661200",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:37212", "10.65.0.27:37212", "172.17.0.1:37212"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T10:49:47.356999827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5408923338656444,
+				"StableID":   "nVK4TAFiEj11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f270ee1ed3fdaa747b96e3392a25be3014c3b1d705dc821b832d712fc6ec1123",
+				"DiscoKey":   "discokey:27ca093c2966725423323b41a97e26a816094c51fc6e814998cd6c02d004d26f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:33332", "10.65.0.27:33332", "172.17.0.1:33332"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T10:49:47.918004223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3719379002270468,
+				"StableID":   "n3Wu1DnW3W11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4be2686873fed2b904d2b62fb3dcaa61b053ca2e8b2bb7be71974cdce4306870",
+				"DiscoKey":   "discokey:8e144a7a9659a77eef738e00b4ff3752d5dce14b11b8bffefda1135826276c7c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:57272", "10.65.0.27:57272", "172.17.0.1:57272"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T10:49:48.451607497Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5717007869107976,
+				"StableID":   "nqhKRw6Fem11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:778958671603dd7ab7e6329ca20c7f129326c2b53b666e9a1ad110fb07ec4200",
+				"DiscoKey":   "discokey:62ba0795a1a73a0e59aca58921ef4bf02dc562a67d72dcb09c763dbf9878441e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:41514", "10.65.0.27:41514", "172.17.0.1:41514"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T10:49:49.539044425Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2681791575458757,
+				"StableID":   "ngUFAo7bwM11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b3998f59a28c54d599dab7f93dca41491b68bf149bd4cdb7bfc6c2a12e43467e",
+				"DiscoKey":   "discokey:2b408dcfd99442c220534cfe6cf009234106918bfa35cd155c4bc373110a2610",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57338", "10.65.0.27:57338", "172.17.0.1:57338"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T10:49:50.077242292Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6843923602848287,
+				"StableID":   "n68NsXGdSv11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35a55ec66e4cda8326413883a0811dfd80ac59d0d3914758bd050f7dbcc7407f",
+				"DiscoKey":   "discokey:e9aca9a712d8b23b1eb95b03b046456a2e75c67dca65a58baa026b9c88267831",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:49062", "10.65.0.27:49062", "172.17.0.1:49062"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T10:49:50.611547224Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5639247385574474,
+				"StableID":   "nukXm3U23m11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f94eea7d87a9966dc52c708dd1d9b2358ba3967e333eab363b20056afeccc32f",
+				"DiscoKey":   "discokey:8b3aa50839dbf30da90c85f2028cb66b27d0b99642ea15a012fcda7b8fb5146c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:56076", "10.65.0.27:56076", "172.17.0.1:56076"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T10:49:51.149343502Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         334927240877647,
+				"StableID":   "nk5aNJygc311CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc734d58cca95b35554d568625022525f4805fd9661485b56dd62c478b903961",
+				"DiscoKey":   "discokey:08860ffc9ad49254248fc284273dc3f1e6cd4500003b3b4180836ac7b297e55c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53569", "10.65.0.27:53569", "172.17.0.1:53569"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T10:49:51.696657826Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6999320821172825,
+				"StableID":   "nvDJvmH1fw11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5d1f86245681cd179cba56fc189351670f3f4614e12b161fb2b9dadad1795447",
+				"KeyExpiry":  "2026-11-09T10:49:52Z",
+				"DiscoKey":   "discokey:c6c54d8ca1c7739b766b9e220290d53920c0598ba35753f259b5493a7dcfb017",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:41270", "10.65.0.27:41270", "172.17.0.1:41270"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T10:49:52.231996754Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3911180766115955,
+				"StableID":   "nGfM626PYX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2ebeea6ee130392da77f4dc5e1166a0f819ac768b8d773808e8d454cd3a46169",
+				"KeyExpiry":  "2026-11-09T10:49:52Z",
+				"DiscoKey":   "discokey:5ffa1f5176b04a6e9c1b22114c7594f9557df41aae4c3c439444f29cbab27f62",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:33581", "10.65.0.27:33581", "172.17.0.1:33581"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T10:49:52.769240823Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7952933030713537,
+				"StableID":   "nNDJPm4u6521CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e1d5f353569caba6c02adf8f7d450836332b84718111e65686b3d1e1af02cb6d",
+				"KeyExpiry":  "2026-11-09T10:49:53Z",
+				"DiscoKey":   "discokey:cbb9f7d452557afe0040be4401b3886943ad7a102a1117f1170aa343e6ae6a4b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:58443", "10.65.0.27:58443", "172.17.0.1:58443"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T10:49:53.299344535Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4938745266024003": {
+				"ID":          4938745266024003,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2681791575458757,
+				"StableID":   "ngUFAo7bwM11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       2681791575458757,
+				"Key":        "nodekey:b3998f59a28c54d599dab7f93dca41491b68bf149bd4cdb7bfc6c2a12e43467e",
+				"DiscoKey":   "discokey:2b408dcfd99442c220534cfe6cf009234106918bfa35cd155c4bc373110a2610",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57338", "10.65.0.27:57338", "172.17.0.1:57338"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T10:49:50.077242292Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b3998f59a28c54d599dab7f93dca41491b68bf149bd4cdb7bfc6c2a12e43467e",
+			"MachineKey": "mkey:460ecd09ab8843ace60a2481c54a151a12c5b68246de0a615b5f2c90d965cb3d",
+			"Peers": [{
+				"ID":         859261059412166,
+				"StableID":   "nuUJRCLAi711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a7e877e42095005a66e6c1aab51ed3285f7d7cc62ccc078ad1d5217f9766a755",
+				"DiscoKey":   "discokey:bf7ca0736125ef38e6f6b59d7c13ec464d326a7f9eaf2755b2c0e786a87d9e5b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:56022", "10.65.0.27:56022", "172.17.0.1:56022"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T10:49:45.772657121Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4038382799288908,
+				"StableID":   "nDhVBAUzXY11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2d6413a67f6cfa2f0811ea5173d77cb82eea52a994848e24959d79f17685b976",
+				"DiscoKey":   "discokey:de3507d6af75b68423e1c5dc49aecff2ad9aa9960b7adf5b8f08cda91fa33a44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:47955", "10.65.0.27:47955", "172.17.0.1:47955"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T10:49:46.301030305Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3017773562694856,
+				"StableID":   "nh7cr4okZQ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ed22425f9400edd4fd7f9b6230fada69809c3f67c5d6e205ac0eb9003874076",
+				"DiscoKey":   "discokey:cecc4ba5b5bec6c80fdbe0cb7284423408923db0827f81de7ba9d756d26b934a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:34716", "10.65.0.27:34716", "172.17.0.1:34716"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T10:49:46.825444131Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         841031876026915,
+				"StableID":   "nxFZuuUuZ711CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:40c5193c938376c182253108a8393e39db387193b50b5a03a504640b92525415",
+				"DiscoKey":   "discokey:e7c83de9c4cc48f6392ec088db09d6967e1ccae6eb202ed929bc594b5a661200",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:37212", "10.65.0.27:37212", "172.17.0.1:37212"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T10:49:47.356999827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5408923338656444,
+				"StableID":   "nVK4TAFiEj11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f270ee1ed3fdaa747b96e3392a25be3014c3b1d705dc821b832d712fc6ec1123",
+				"DiscoKey":   "discokey:27ca093c2966725423323b41a97e26a816094c51fc6e814998cd6c02d004d26f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:33332", "10.65.0.27:33332", "172.17.0.1:33332"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T10:49:47.918004223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3719379002270468,
+				"StableID":   "n3Wu1DnW3W11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4be2686873fed2b904d2b62fb3dcaa61b053ca2e8b2bb7be71974cdce4306870",
+				"DiscoKey":   "discokey:8e144a7a9659a77eef738e00b4ff3752d5dce14b11b8bffefda1135826276c7c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:57272", "10.65.0.27:57272", "172.17.0.1:57272"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T10:49:48.451607497Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4938745266024003,
+				"StableID":   "nikkDtTmZf11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bff1dab85d012316bf0f494449937f3a626217a3f81f560d9771dca2b18ce028",
+				"DiscoKey":   "discokey:7b76eb268d98f6279a6c473c43610738414da4d9972308ee11079fcb1505bc39",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:55316", "10.65.0.27:55316", "172.17.0.1:55316"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T10:49:48.99059142Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5717007869107976,
+				"StableID":   "nqhKRw6Fem11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:778958671603dd7ab7e6329ca20c7f129326c2b53b666e9a1ad110fb07ec4200",
+				"DiscoKey":   "discokey:62ba0795a1a73a0e59aca58921ef4bf02dc562a67d72dcb09c763dbf9878441e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:41514", "10.65.0.27:41514", "172.17.0.1:41514"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T10:49:49.539044425Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6843923602848287,
+				"StableID":   "n68NsXGdSv11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35a55ec66e4cda8326413883a0811dfd80ac59d0d3914758bd050f7dbcc7407f",
+				"DiscoKey":   "discokey:e9aca9a712d8b23b1eb95b03b046456a2e75c67dca65a58baa026b9c88267831",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:49062", "10.65.0.27:49062", "172.17.0.1:49062"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T10:49:50.611547224Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5639247385574474,
+				"StableID":   "nukXm3U23m11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f94eea7d87a9966dc52c708dd1d9b2358ba3967e333eab363b20056afeccc32f",
+				"DiscoKey":   "discokey:8b3aa50839dbf30da90c85f2028cb66b27d0b99642ea15a012fcda7b8fb5146c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:56076", "10.65.0.27:56076", "172.17.0.1:56076"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T10:49:51.149343502Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         334927240877647,
+				"StableID":   "nk5aNJygc311CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc734d58cca95b35554d568625022525f4805fd9661485b56dd62c478b903961",
+				"DiscoKey":   "discokey:08860ffc9ad49254248fc284273dc3f1e6cd4500003b3b4180836ac7b297e55c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53569", "10.65.0.27:53569", "172.17.0.1:53569"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T10:49:51.696657826Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6999320821172825,
+				"StableID":   "nvDJvmH1fw11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5d1f86245681cd179cba56fc189351670f3f4614e12b161fb2b9dadad1795447",
+				"KeyExpiry":  "2026-11-09T10:49:52Z",
+				"DiscoKey":   "discokey:c6c54d8ca1c7739b766b9e220290d53920c0598ba35753f259b5493a7dcfb017",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:41270", "10.65.0.27:41270", "172.17.0.1:41270"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T10:49:52.231996754Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3911180766115955,
+				"StableID":   "nGfM626PYX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2ebeea6ee130392da77f4dc5e1166a0f819ac768b8d773808e8d454cd3a46169",
+				"KeyExpiry":  "2026-11-09T10:49:52Z",
+				"DiscoKey":   "discokey:5ffa1f5176b04a6e9c1b22114c7594f9557df41aae4c3c439444f29cbab27f62",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:33581", "10.65.0.27:33581", "172.17.0.1:33581"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T10:49:52.769240823Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7952933030713537,
+				"StableID":   "nNDJPm4u6521CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e1d5f353569caba6c02adf8f7d450836332b84718111e65686b3d1e1af02cb6d",
+				"KeyExpiry":  "2026-11-09T10:49:53Z",
+				"DiscoKey":   "discokey:cbb9f7d452557afe0040be4401b3886943ad7a102a1117f1170aa343e6ae6a4b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:58443", "10.65.0.27:58443", "172.17.0.1:58443"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T10:49:53.299344535Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2681791575458757": {
+				"ID":          2681791575458757,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3911180766115955,
+				"StableID":   "nGfM626PYX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2ebeea6ee130392da77f4dc5e1166a0f819ac768b8d773808e8d454cd3a46169",
+				"KeyExpiry":  "2026-11-09T10:49:52Z",
+				"DiscoKey":   "discokey:5ffa1f5176b04a6e9c1b22114c7594f9557df41aae4c3c439444f29cbab27f62",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:33581", "10.65.0.27:33581", "172.17.0.1:33581"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T10:49:52.769240823Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2ebeea6ee130392da77f4dc5e1166a0f819ac768b8d773808e8d454cd3a46169",
+			"MachineKey": "mkey:30ee23d58bcf4841e01e65b99d30fc7158923a5db1d8bd1aa62fa14142e42558",
+			"Peers": [{
+				"ID":         859261059412166,
+				"StableID":   "nuUJRCLAi711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a7e877e42095005a66e6c1aab51ed3285f7d7cc62ccc078ad1d5217f9766a755",
+				"DiscoKey":   "discokey:bf7ca0736125ef38e6f6b59d7c13ec464d326a7f9eaf2755b2c0e786a87d9e5b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:56022", "10.65.0.27:56022", "172.17.0.1:56022"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T10:49:45.772657121Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4038382799288908,
+				"StableID":   "nDhVBAUzXY11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2d6413a67f6cfa2f0811ea5173d77cb82eea52a994848e24959d79f17685b976",
+				"DiscoKey":   "discokey:de3507d6af75b68423e1c5dc49aecff2ad9aa9960b7adf5b8f08cda91fa33a44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:47955", "10.65.0.27:47955", "172.17.0.1:47955"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T10:49:46.301030305Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3017773562694856,
+				"StableID":   "nh7cr4okZQ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ed22425f9400edd4fd7f9b6230fada69809c3f67c5d6e205ac0eb9003874076",
+				"DiscoKey":   "discokey:cecc4ba5b5bec6c80fdbe0cb7284423408923db0827f81de7ba9d756d26b934a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:34716", "10.65.0.27:34716", "172.17.0.1:34716"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T10:49:46.825444131Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         841031876026915,
+				"StableID":   "nxFZuuUuZ711CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:40c5193c938376c182253108a8393e39db387193b50b5a03a504640b92525415",
+				"DiscoKey":   "discokey:e7c83de9c4cc48f6392ec088db09d6967e1ccae6eb202ed929bc594b5a661200",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:37212", "10.65.0.27:37212", "172.17.0.1:37212"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T10:49:47.356999827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5408923338656444,
+				"StableID":   "nVK4TAFiEj11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f270ee1ed3fdaa747b96e3392a25be3014c3b1d705dc821b832d712fc6ec1123",
+				"DiscoKey":   "discokey:27ca093c2966725423323b41a97e26a816094c51fc6e814998cd6c02d004d26f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:33332", "10.65.0.27:33332", "172.17.0.1:33332"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T10:49:47.918004223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3719379002270468,
+				"StableID":   "n3Wu1DnW3W11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4be2686873fed2b904d2b62fb3dcaa61b053ca2e8b2bb7be71974cdce4306870",
+				"DiscoKey":   "discokey:8e144a7a9659a77eef738e00b4ff3752d5dce14b11b8bffefda1135826276c7c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:57272", "10.65.0.27:57272", "172.17.0.1:57272"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T10:49:48.451607497Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4938745266024003,
+				"StableID":   "nikkDtTmZf11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bff1dab85d012316bf0f494449937f3a626217a3f81f560d9771dca2b18ce028",
+				"DiscoKey":   "discokey:7b76eb268d98f6279a6c473c43610738414da4d9972308ee11079fcb1505bc39",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:55316", "10.65.0.27:55316", "172.17.0.1:55316"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T10:49:48.99059142Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5717007869107976,
+				"StableID":   "nqhKRw6Fem11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:778958671603dd7ab7e6329ca20c7f129326c2b53b666e9a1ad110fb07ec4200",
+				"DiscoKey":   "discokey:62ba0795a1a73a0e59aca58921ef4bf02dc562a67d72dcb09c763dbf9878441e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:41514", "10.65.0.27:41514", "172.17.0.1:41514"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T10:49:49.539044425Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2681791575458757,
+				"StableID":   "ngUFAo7bwM11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b3998f59a28c54d599dab7f93dca41491b68bf149bd4cdb7bfc6c2a12e43467e",
+				"DiscoKey":   "discokey:2b408dcfd99442c220534cfe6cf009234106918bfa35cd155c4bc373110a2610",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57338", "10.65.0.27:57338", "172.17.0.1:57338"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T10:49:50.077242292Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6843923602848287,
+				"StableID":   "n68NsXGdSv11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35a55ec66e4cda8326413883a0811dfd80ac59d0d3914758bd050f7dbcc7407f",
+				"DiscoKey":   "discokey:e9aca9a712d8b23b1eb95b03b046456a2e75c67dca65a58baa026b9c88267831",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:49062", "10.65.0.27:49062", "172.17.0.1:49062"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T10:49:50.611547224Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5639247385574474,
+				"StableID":   "nukXm3U23m11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f94eea7d87a9966dc52c708dd1d9b2358ba3967e333eab363b20056afeccc32f",
+				"DiscoKey":   "discokey:8b3aa50839dbf30da90c85f2028cb66b27d0b99642ea15a012fcda7b8fb5146c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:56076", "10.65.0.27:56076", "172.17.0.1:56076"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T10:49:51.149343502Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         334927240877647,
+				"StableID":   "nk5aNJygc311CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc734d58cca95b35554d568625022525f4805fd9661485b56dd62c478b903961",
+				"DiscoKey":   "discokey:08860ffc9ad49254248fc284273dc3f1e6cd4500003b3b4180836ac7b297e55c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53569", "10.65.0.27:53569", "172.17.0.1:53569"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T10:49:51.696657826Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6999320821172825,
+				"StableID":   "nvDJvmH1fw11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5d1f86245681cd179cba56fc189351670f3f4614e12b161fb2b9dadad1795447",
+				"KeyExpiry":  "2026-11-09T10:49:52Z",
+				"DiscoKey":   "discokey:c6c54d8ca1c7739b766b9e220290d53920c0598ba35753f259b5493a7dcfb017",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:41270", "10.65.0.27:41270", "172.17.0.1:41270"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T10:49:52.231996754Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7952933030713537,
+				"StableID":   "nNDJPm4u6521CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e1d5f353569caba6c02adf8f7d450836332b84718111e65686b3d1e1af02cb6d",
+				"KeyExpiry":  "2026-11-09T10:49:53Z",
+				"DiscoKey":   "discokey:cbb9f7d452557afe0040be4401b3886943ad7a102a1117f1170aa343e6ae6a4b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:58443", "10.65.0.27:58443", "172.17.0.1:58443"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T10:49:53.299344535Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6843923602848287,
+				"StableID":   "n68NsXGdSv11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       6843923602848287,
+				"Key":        "nodekey:35a55ec66e4cda8326413883a0811dfd80ac59d0d3914758bd050f7dbcc7407f",
+				"DiscoKey":   "discokey:e9aca9a712d8b23b1eb95b03b046456a2e75c67dca65a58baa026b9c88267831",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:49062", "10.65.0.27:49062", "172.17.0.1:49062"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T10:49:50.611547224Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:35a55ec66e4cda8326413883a0811dfd80ac59d0d3914758bd050f7dbcc7407f",
+			"MachineKey": "mkey:7de620dd4547fee92dbb36341d8829fcfca8655af535aee239d41dc4e7bc4451",
+			"Peers": [{
+				"ID":         859261059412166,
+				"StableID":   "nuUJRCLAi711CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a7e877e42095005a66e6c1aab51ed3285f7d7cc62ccc078ad1d5217f9766a755",
+				"DiscoKey":   "discokey:bf7ca0736125ef38e6f6b59d7c13ec464d326a7f9eaf2755b2c0e786a87d9e5b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:56022", "10.65.0.27:56022", "172.17.0.1:56022"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T10:49:45.772657121Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4038382799288908,
+				"StableID":   "nDhVBAUzXY11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2d6413a67f6cfa2f0811ea5173d77cb82eea52a994848e24959d79f17685b976",
+				"DiscoKey":   "discokey:de3507d6af75b68423e1c5dc49aecff2ad9aa9960b7adf5b8f08cda91fa33a44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:47955", "10.65.0.27:47955", "172.17.0.1:47955"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T10:49:46.301030305Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3017773562694856,
+				"StableID":   "nh7cr4okZQ11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ed22425f9400edd4fd7f9b6230fada69809c3f67c5d6e205ac0eb9003874076",
+				"DiscoKey":   "discokey:cecc4ba5b5bec6c80fdbe0cb7284423408923db0827f81de7ba9d756d26b934a",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:34716", "10.65.0.27:34716", "172.17.0.1:34716"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T10:49:46.825444131Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         841031876026915,
+				"StableID":   "nxFZuuUuZ711CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:40c5193c938376c182253108a8393e39db387193b50b5a03a504640b92525415",
+				"DiscoKey":   "discokey:e7c83de9c4cc48f6392ec088db09d6967e1ccae6eb202ed929bc594b5a661200",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:37212", "10.65.0.27:37212", "172.17.0.1:37212"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T10:49:47.356999827Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5408923338656444,
+				"StableID":   "nVK4TAFiEj11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f270ee1ed3fdaa747b96e3392a25be3014c3b1d705dc821b832d712fc6ec1123",
+				"DiscoKey":   "discokey:27ca093c2966725423323b41a97e26a816094c51fc6e814998cd6c02d004d26f",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:33332", "10.65.0.27:33332", "172.17.0.1:33332"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T10:49:47.918004223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3719379002270468,
+				"StableID":   "n3Wu1DnW3W11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4be2686873fed2b904d2b62fb3dcaa61b053ca2e8b2bb7be71974cdce4306870",
+				"DiscoKey":   "discokey:8e144a7a9659a77eef738e00b4ff3752d5dce14b11b8bffefda1135826276c7c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:57272", "10.65.0.27:57272", "172.17.0.1:57272"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T10:49:48.451607497Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4938745266024003,
+				"StableID":   "nikkDtTmZf11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:bff1dab85d012316bf0f494449937f3a626217a3f81f560d9771dca2b18ce028",
+				"DiscoKey":   "discokey:7b76eb268d98f6279a6c473c43610738414da4d9972308ee11079fcb1505bc39",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:55316", "10.65.0.27:55316", "172.17.0.1:55316"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T10:49:48.99059142Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5717007869107976,
+				"StableID":   "nqhKRw6Fem11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:778958671603dd7ab7e6329ca20c7f129326c2b53b666e9a1ad110fb07ec4200",
+				"DiscoKey":   "discokey:62ba0795a1a73a0e59aca58921ef4bf02dc562a67d72dcb09c763dbf9878441e",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:41514", "10.65.0.27:41514", "172.17.0.1:41514"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T10:49:49.539044425Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2681791575458757,
+				"StableID":   "ngUFAo7bwM11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b3998f59a28c54d599dab7f93dca41491b68bf149bd4cdb7bfc6c2a12e43467e",
+				"DiscoKey":   "discokey:2b408dcfd99442c220534cfe6cf009234106918bfa35cd155c4bc373110a2610",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57338", "10.65.0.27:57338", "172.17.0.1:57338"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T10:49:50.077242292Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5639247385574474,
+				"StableID":   "nukXm3U23m11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f94eea7d87a9966dc52c708dd1d9b2358ba3967e333eab363b20056afeccc32f",
+				"DiscoKey":   "discokey:8b3aa50839dbf30da90c85f2028cb66b27d0b99642ea15a012fcda7b8fb5146c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:56076", "10.65.0.27:56076", "172.17.0.1:56076"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T10:49:51.149343502Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         334927240877647,
+				"StableID":   "nk5aNJygc311CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc734d58cca95b35554d568625022525f4805fd9661485b56dd62c478b903961",
+				"DiscoKey":   "discokey:08860ffc9ad49254248fc284273dc3f1e6cd4500003b3b4180836ac7b297e55c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53569", "10.65.0.27:53569", "172.17.0.1:53569"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T10:49:51.696657826Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6999320821172825,
+				"StableID":   "nvDJvmH1fw11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:5d1f86245681cd179cba56fc189351670f3f4614e12b161fb2b9dadad1795447",
+				"KeyExpiry":  "2026-11-09T10:49:52Z",
+				"DiscoKey":   "discokey:c6c54d8ca1c7739b766b9e220290d53920c0598ba35753f259b5493a7dcfb017",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:41270", "10.65.0.27:41270", "172.17.0.1:41270"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T10:49:52.231996754Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3911180766115955,
+				"StableID":   "nGfM626PYX11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:2ebeea6ee130392da77f4dc5e1166a0f819ac768b8d773808e8d454cd3a46169",
+				"KeyExpiry":  "2026-11-09T10:49:52Z",
+				"DiscoKey":   "discokey:5ffa1f5176b04a6e9c1b22114c7594f9557df41aae4c3c439444f29cbab27f62",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:33581", "10.65.0.27:33581", "172.17.0.1:33581"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T10:49:52.769240823Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7952933030713537,
+				"StableID":   "nNDJPm4u6521CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:e1d5f353569caba6c02adf8f7d450836332b84718111e65686b3d1e1af02cb6d",
+				"KeyExpiry":  "2026-11-09T10:49:53Z",
+				"DiscoKey":   "discokey:cbb9f7d452557afe0040be4401b3886943ad7a102a1117f1170aa343e6ae6a4b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:58443", "10.65.0.27:58443", "172.17.0.1:58443"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T10:49:53.299344535Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6843923602848287": {
+				"ID":          6843923602848287,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/sshtest_results/sshtest-malformed-dst-cidr.hujson
+++ b/hscontrol/policy/v2/testdata/sshtest_results/sshtest-malformed-dst-cidr.hujson
@@ -1,0 +1,20084 @@
+// sshtest-malformed-dst-cidr
+//
+// sshTests CIDR dst must be rejected
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T18:43:46Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "sshtest-malformed-dst-cidr",
+	"description":    "sshTests CIDR dst must be rejected",
+	"category":       "sshtest",
+	"captured_at":    "2026-05-12T18:43:46.081292085Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "SSH tests dst contains disallowed element \"100.64.0.0/24\""},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                             \n  \n                                                                      \n                                                          \n{\n\t\"category\":    \"sshtest\",\n\t\"description\": \"sshTests CIDR dst must be rejected\",\n\t\"id\":          \"sshtest-malformed-dst-cidr\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"thor@example.org\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"sshTests\": [{\n\t\t\"accept\": [\"root\"],\n\t\t\"dst\":    [\"100.64.0.0/24\"],\n\t\t\"src\":    \"thor@example.org\"\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/sshtest/sshtest-malformed-dst-cidr.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["thor@example.org"],
+				"users":  ["root"]
+			}],
+			"sshTests": [
+				{"accept": ["root"], "dst": ["100.64.0.0/24"], "src": "thor@example.org"}
+			],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4585853824743584,
+				"StableID":   "njGVy1cwoc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       4585853824743584,
+				"Key":        "nodekey:5f1910e9a909ee4006938458b2570a9e467e28ffb79d6e0ff8848232f3bfad0e",
+				"DiscoKey":   "discokey:262cdf71674ba5ff59d8a49efc5925c692fa96b7b681ba960fbff926fddca666",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38777",
+					"10.65.0.27:38777",
+					"172.17.0.1:38777",
+					"172.19.0.1:38777",
+					"172.20.0.1:38777"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:43:54.509987968Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5f1910e9a909ee4006938458b2570a9e467e28ffb79d6e0ff8848232f3bfad0e",
+			"MachineKey": "mkey:9c72dbfbe63a41389fa3145eaae11eed1573c33bdeeac3dad859a644cf2a0206",
+			"Peers": [{
+				"ID":         6016328770506857,
+				"StableID":   "nGzyVnkoyo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6eaa55db808f028c8d9926ec6f4ab78f8933e1ea37e03d268db81c5b302f3477",
+				"DiscoKey":   "discokey:50f417894fb269b4ba6254b3b861f524f90a0f9cbd0faeba9e90bf10fbd0d831",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:42805",
+					"10.65.0.27:42805",
+					"172.17.0.1:42805",
+					"172.19.0.1:42805",
+					"172.20.0.1:42805"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:43:48.593994629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6154641129028053,
+				"StableID":   "nc8ezBzS4q11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4c4eb20dc31e9ad029147c86c17118d2d5b13292da76e126cb2ac800cddec809",
+				"DiscoKey":   "discokey:70c3a3dbcea00fb90a73b074f6a11a30b7136448a71a13ac6115f168a126c962",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55489",
+					"10.65.0.27:55489",
+					"172.17.0.1:55489",
+					"172.19.0.1:55489",
+					"172.20.0.1:55489"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:43:49.143634273Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2527687880437997,
+				"StableID":   "n4vMLK5ojL11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5bc0a3e0c48383921a95eb735b271067d9be8d4ab74a449d3728b3e22c67a66",
+				"DiscoKey":   "discokey:851c4ea44b24069b6da2d95ba82c9be667abde4854499670615b23a713c6923d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52090",
+					"10.65.0.27:52090",
+					"172.17.0.1:52090",
+					"172.19.0.1:52090",
+					"172.20.0.1:52090"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:43:49.673410113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6673481231443679,
+				"StableID":   "naaGA53S7u11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5e09fb519d29ddc4ab74a92bb89d6a1089c7716b2588c1d69b47e912df2d00c",
+				"DiscoKey":   "discokey:f066bba19b8d1c13819293bed1f438ed9fc201ce2d70398bcd93ab998a08780e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:52398",
+					"10.65.0.27:52398",
+					"172.17.0.1:52398",
+					"172.19.0.1:52398",
+					"172.20.0.1:52398"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:43:50.204057843Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1103769185488624,
+				"StableID":   "njp1FQ9uc911CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87d712ee21f73bf0ae15f1fcea2f0db88a8ded3bcdda829e1a6b035ea3a99a1b",
+				"DiscoKey":   "discokey:8e6d52a4152d9ba4957aff9afb54f1a3cc728a2428dc9f2e28da30144420c42b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37951",
+					"10.65.0.27:37951",
+					"172.17.0.1:37951",
+					"172.19.0.1:37951",
+					"172.20.0.1:37951"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:43:50.748458269Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7307005080874550,
+				"StableID":   "n1vLLidM4z11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6e9450ab4502100f374c42f7a01b088e7c5eb98beb4e623ea8bd16fb020f757",
+				"DiscoKey":   "discokey:c1820b018c93dca427b733d37e9b1648ac6dada69a1f08b72f3b52043051225d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39556",
+					"10.65.0.27:39556",
+					"172.17.0.1:39556",
+					"172.19.0.1:39556",
+					"172.20.0.1:39556"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:43:51.268603179Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3696077596774279,
+				"StableID":   "n6G2c5hxrV11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1bb90812675bb474bf4f2fd55b97ebf702ae289e00e852a2d2d5cf53099ee964",
+				"DiscoKey":   "discokey:ec62448c59384095cd368f18a8bccd1fb134fdab5fff974a7cfba3d690408433",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40858",
+					"10.65.0.27:40858",
+					"172.17.0.1:40858",
+					"172.19.0.1:40858",
+					"172.20.0.1:40858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:43:51.818935512Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2592773546433543,
+				"StableID":   "ngqDmLmGFM11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8f66db443c75af68c597ee14554e226b8b4c9ef896a1e46adacbe8b3c351d60",
+				"DiscoKey":   "discokey:ab0dd2b92d46a1422cf78b935feb4ebdddc4b3ec0b4bffed06a09a015fd19e0b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49237",
+					"10.65.0.27:49237",
+					"172.17.0.1:49237",
+					"172.19.0.1:49237",
+					"172.20.0.1:49237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:43:52.358461504Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2289847623990136,
+				"StableID":   "no4QK2R5tJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c541411b0f74586cd4f08014d118b608aa574404e1c9bca88ada47ef45749d4f",
+				"DiscoKey":   "discokey:d26ec9be1bedbe696ba3a4ee11bc1bbd5bd2da566e249b061301f2bfdaa6be02",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:60165",
+					"10.65.0.27:60165",
+					"172.17.0.1:60165",
+					"172.19.0.1:60165",
+					"172.20.0.1:60165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:43:52.890603684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8439668000907087,
+				"StableID":   "nk3PxVmLu821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c08416080a6c9552ffc92be47c6c4f5e2b1d1418bb2ccfc8caf9e6e851308c49",
+				"DiscoKey":   "discokey:62cf465a66dd2dc170d5f55b9c7d58c19043c23d146ef0439ce60174d3607635",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:41955",
+					"10.65.0.27:41955",
+					"172.17.0.1:41955",
+					"172.19.0.1:41955",
+					"172.20.0.1:41955"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:43:53.438761454Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6164595990854836,
+				"StableID":   "nF4b33Vx8q11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aed457da7acfd20741ce760b6f8537b5a34c7f177c75005997bdd6abc59b1426",
+				"DiscoKey":   "discokey:0665b448de8d2bedd6e200d1a3bb5a24c02f93aa0c2e83ad46eabe0377dfb34f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50956",
+					"10.65.0.27:50956",
+					"172.17.0.1:50956",
+					"172.19.0.1:50956",
+					"172.20.0.1:50956"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:43:53.967751349Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5018486937441265,
+				"StableID":   "nczJfE9tBg11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3065e4e9e503f449b44ac4e25492f90744fe664e86e8a4d460565653032e1b44",
+				"KeyExpiry":  "2026-11-08T18:43:55Z",
+				"DiscoKey":   "discokey:d3dc0cd94529593de76ac7685c0f67d2d64732125d9dce89c844f4adb507e376",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:58752",
+					"10.65.0.27:58752",
+					"172.17.0.1:58752",
+					"172.19.0.1:58752",
+					"172.20.0.1:58752"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:43:55.059593996Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2213377979405502,
+				"StableID":   "nsTdgogSHJ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ea2466fd4129f11b9eabe8bec10c68389d31023a9ffeceaf3a8ea906bfd99247",
+				"KeyExpiry":  "2026-11-08T18:43:55Z",
+				"DiscoKey":   "discokey:01064074e56764c74c67fe64b2e7b3247f3c094034aa7b9e9e243580624b9a52",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:33643",
+					"10.65.0.27:33643",
+					"172.17.0.1:33643",
+					"172.19.0.1:33643",
+					"172.20.0.1:33643"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:43:55.574256897Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3550521138286482,
+				"StableID":   "nXhWoqA3jU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d0a353f9cb159b426b1ca58230ca68e728c53589b40d3b3d8f2d9d192d194e42",
+				"KeyExpiry":  "2026-11-08T18:43:56Z",
+				"DiscoKey":   "discokey:7d3f9a784326feadb082ad78e148b42dad34d55b2bd68707af139d6e7d5f426e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44374",
+					"10.65.0.27:44374",
+					"172.17.0.1:44374",
+					"172.19.0.1:44374",
+					"172.20.0.1:44374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:43:56.09900279Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4585853824743584": {
+				"ID":          4585853824743584,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7307005080874550,
+				"StableID":   "n1vLLidM4z11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       7307005080874550,
+				"Key":        "nodekey:a6e9450ab4502100f374c42f7a01b088e7c5eb98beb4e623ea8bd16fb020f757",
+				"DiscoKey":   "discokey:c1820b018c93dca427b733d37e9b1648ac6dada69a1f08b72f3b52043051225d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39556",
+					"10.65.0.27:39556",
+					"172.17.0.1:39556",
+					"172.19.0.1:39556",
+					"172.20.0.1:39556"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:43:51.268603179Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a6e9450ab4502100f374c42f7a01b088e7c5eb98beb4e623ea8bd16fb020f757",
+			"MachineKey": "mkey:896c656ef3b9cd1e3478932b00655ab161b158e7548fb605aade09b91feb2135",
+			"Peers": [{
+				"ID":         6016328770506857,
+				"StableID":   "nGzyVnkoyo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6eaa55db808f028c8d9926ec6f4ab78f8933e1ea37e03d268db81c5b302f3477",
+				"DiscoKey":   "discokey:50f417894fb269b4ba6254b3b861f524f90a0f9cbd0faeba9e90bf10fbd0d831",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:42805",
+					"10.65.0.27:42805",
+					"172.17.0.1:42805",
+					"172.19.0.1:42805",
+					"172.20.0.1:42805"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:43:48.593994629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6154641129028053,
+				"StableID":   "nc8ezBzS4q11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4c4eb20dc31e9ad029147c86c17118d2d5b13292da76e126cb2ac800cddec809",
+				"DiscoKey":   "discokey:70c3a3dbcea00fb90a73b074f6a11a30b7136448a71a13ac6115f168a126c962",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55489",
+					"10.65.0.27:55489",
+					"172.17.0.1:55489",
+					"172.19.0.1:55489",
+					"172.20.0.1:55489"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:43:49.143634273Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2527687880437997,
+				"StableID":   "n4vMLK5ojL11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5bc0a3e0c48383921a95eb735b271067d9be8d4ab74a449d3728b3e22c67a66",
+				"DiscoKey":   "discokey:851c4ea44b24069b6da2d95ba82c9be667abde4854499670615b23a713c6923d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52090",
+					"10.65.0.27:52090",
+					"172.17.0.1:52090",
+					"172.19.0.1:52090",
+					"172.20.0.1:52090"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:43:49.673410113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6673481231443679,
+				"StableID":   "naaGA53S7u11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5e09fb519d29ddc4ab74a92bb89d6a1089c7716b2588c1d69b47e912df2d00c",
+				"DiscoKey":   "discokey:f066bba19b8d1c13819293bed1f438ed9fc201ce2d70398bcd93ab998a08780e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:52398",
+					"10.65.0.27:52398",
+					"172.17.0.1:52398",
+					"172.19.0.1:52398",
+					"172.20.0.1:52398"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:43:50.204057843Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1103769185488624,
+				"StableID":   "njp1FQ9uc911CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87d712ee21f73bf0ae15f1fcea2f0db88a8ded3bcdda829e1a6b035ea3a99a1b",
+				"DiscoKey":   "discokey:8e6d52a4152d9ba4957aff9afb54f1a3cc728a2428dc9f2e28da30144420c42b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37951",
+					"10.65.0.27:37951",
+					"172.17.0.1:37951",
+					"172.19.0.1:37951",
+					"172.20.0.1:37951"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:43:50.748458269Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3696077596774279,
+				"StableID":   "n6G2c5hxrV11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1bb90812675bb474bf4f2fd55b97ebf702ae289e00e852a2d2d5cf53099ee964",
+				"DiscoKey":   "discokey:ec62448c59384095cd368f18a8bccd1fb134fdab5fff974a7cfba3d690408433",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40858",
+					"10.65.0.27:40858",
+					"172.17.0.1:40858",
+					"172.19.0.1:40858",
+					"172.20.0.1:40858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:43:51.818935512Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2592773546433543,
+				"StableID":   "ngqDmLmGFM11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8f66db443c75af68c597ee14554e226b8b4c9ef896a1e46adacbe8b3c351d60",
+				"DiscoKey":   "discokey:ab0dd2b92d46a1422cf78b935feb4ebdddc4b3ec0b4bffed06a09a015fd19e0b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49237",
+					"10.65.0.27:49237",
+					"172.17.0.1:49237",
+					"172.19.0.1:49237",
+					"172.20.0.1:49237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:43:52.358461504Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2289847623990136,
+				"StableID":   "no4QK2R5tJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c541411b0f74586cd4f08014d118b608aa574404e1c9bca88ada47ef45749d4f",
+				"DiscoKey":   "discokey:d26ec9be1bedbe696ba3a4ee11bc1bbd5bd2da566e249b061301f2bfdaa6be02",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:60165",
+					"10.65.0.27:60165",
+					"172.17.0.1:60165",
+					"172.19.0.1:60165",
+					"172.20.0.1:60165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:43:52.890603684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8439668000907087,
+				"StableID":   "nk3PxVmLu821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c08416080a6c9552ffc92be47c6c4f5e2b1d1418bb2ccfc8caf9e6e851308c49",
+				"DiscoKey":   "discokey:62cf465a66dd2dc170d5f55b9c7d58c19043c23d146ef0439ce60174d3607635",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:41955",
+					"10.65.0.27:41955",
+					"172.17.0.1:41955",
+					"172.19.0.1:41955",
+					"172.20.0.1:41955"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:43:53.438761454Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6164595990854836,
+				"StableID":   "nF4b33Vx8q11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aed457da7acfd20741ce760b6f8537b5a34c7f177c75005997bdd6abc59b1426",
+				"DiscoKey":   "discokey:0665b448de8d2bedd6e200d1a3bb5a24c02f93aa0c2e83ad46eabe0377dfb34f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50956",
+					"10.65.0.27:50956",
+					"172.17.0.1:50956",
+					"172.19.0.1:50956",
+					"172.20.0.1:50956"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:43:53.967751349Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4585853824743584,
+				"StableID":   "njGVy1cwoc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f1910e9a909ee4006938458b2570a9e467e28ffb79d6e0ff8848232f3bfad0e",
+				"DiscoKey":   "discokey:262cdf71674ba5ff59d8a49efc5925c692fa96b7b681ba960fbff926fddca666",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38777",
+					"10.65.0.27:38777",
+					"172.17.0.1:38777",
+					"172.19.0.1:38777",
+					"172.20.0.1:38777"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:43:54.509987968Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5018486937441265,
+				"StableID":   "nczJfE9tBg11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3065e4e9e503f449b44ac4e25492f90744fe664e86e8a4d460565653032e1b44",
+				"KeyExpiry":  "2026-11-08T18:43:55Z",
+				"DiscoKey":   "discokey:d3dc0cd94529593de76ac7685c0f67d2d64732125d9dce89c844f4adb507e376",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:58752",
+					"10.65.0.27:58752",
+					"172.17.0.1:58752",
+					"172.19.0.1:58752",
+					"172.20.0.1:58752"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:43:55.059593996Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2213377979405502,
+				"StableID":   "nsTdgogSHJ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ea2466fd4129f11b9eabe8bec10c68389d31023a9ffeceaf3a8ea906bfd99247",
+				"KeyExpiry":  "2026-11-08T18:43:55Z",
+				"DiscoKey":   "discokey:01064074e56764c74c67fe64b2e7b3247f3c094034aa7b9e9e243580624b9a52",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:33643",
+					"10.65.0.27:33643",
+					"172.17.0.1:33643",
+					"172.19.0.1:33643",
+					"172.20.0.1:33643"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:43:55.574256897Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3550521138286482,
+				"StableID":   "nXhWoqA3jU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d0a353f9cb159b426b1ca58230ca68e728c53589b40d3b3d8f2d9d192d194e42",
+				"KeyExpiry":  "2026-11-08T18:43:56Z",
+				"DiscoKey":   "discokey:7d3f9a784326feadb082ad78e148b42dad34d55b2bd68707af139d6e7d5f426e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44374",
+					"10.65.0.27:44374",
+					"172.17.0.1:44374",
+					"172.19.0.1:44374",
+					"172.20.0.1:44374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:43:56.09900279Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7307005080874550": {
+				"ID":          7307005080874550,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3550521138286482,
+				"StableID":   "nXhWoqA3jU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d0a353f9cb159b426b1ca58230ca68e728c53589b40d3b3d8f2d9d192d194e42",
+				"KeyExpiry":  "2026-11-08T18:43:56Z",
+				"DiscoKey":   "discokey:7d3f9a784326feadb082ad78e148b42dad34d55b2bd68707af139d6e7d5f426e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44374",
+					"10.65.0.27:44374",
+					"172.17.0.1:44374",
+					"172.19.0.1:44374",
+					"172.20.0.1:44374"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:43:56.09900279Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d0a353f9cb159b426b1ca58230ca68e728c53589b40d3b3d8f2d9d192d194e42",
+			"MachineKey": "mkey:cc96b1d320e7c59a16c1067fd683fea794d20f63647e6bc50dcb4d37d2341c76",
+			"Peers": [{
+				"ID":         6016328770506857,
+				"StableID":   "nGzyVnkoyo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6eaa55db808f028c8d9926ec6f4ab78f8933e1ea37e03d268db81c5b302f3477",
+				"DiscoKey":   "discokey:50f417894fb269b4ba6254b3b861f524f90a0f9cbd0faeba9e90bf10fbd0d831",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:42805",
+					"10.65.0.27:42805",
+					"172.17.0.1:42805",
+					"172.19.0.1:42805",
+					"172.20.0.1:42805"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:43:48.593994629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6154641129028053,
+				"StableID":   "nc8ezBzS4q11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4c4eb20dc31e9ad029147c86c17118d2d5b13292da76e126cb2ac800cddec809",
+				"DiscoKey":   "discokey:70c3a3dbcea00fb90a73b074f6a11a30b7136448a71a13ac6115f168a126c962",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55489",
+					"10.65.0.27:55489",
+					"172.17.0.1:55489",
+					"172.19.0.1:55489",
+					"172.20.0.1:55489"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:43:49.143634273Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2527687880437997,
+				"StableID":   "n4vMLK5ojL11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5bc0a3e0c48383921a95eb735b271067d9be8d4ab74a449d3728b3e22c67a66",
+				"DiscoKey":   "discokey:851c4ea44b24069b6da2d95ba82c9be667abde4854499670615b23a713c6923d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52090",
+					"10.65.0.27:52090",
+					"172.17.0.1:52090",
+					"172.19.0.1:52090",
+					"172.20.0.1:52090"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:43:49.673410113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6673481231443679,
+				"StableID":   "naaGA53S7u11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5e09fb519d29ddc4ab74a92bb89d6a1089c7716b2588c1d69b47e912df2d00c",
+				"DiscoKey":   "discokey:f066bba19b8d1c13819293bed1f438ed9fc201ce2d70398bcd93ab998a08780e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:52398",
+					"10.65.0.27:52398",
+					"172.17.0.1:52398",
+					"172.19.0.1:52398",
+					"172.20.0.1:52398"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:43:50.204057843Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1103769185488624,
+				"StableID":   "njp1FQ9uc911CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87d712ee21f73bf0ae15f1fcea2f0db88a8ded3bcdda829e1a6b035ea3a99a1b",
+				"DiscoKey":   "discokey:8e6d52a4152d9ba4957aff9afb54f1a3cc728a2428dc9f2e28da30144420c42b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37951",
+					"10.65.0.27:37951",
+					"172.17.0.1:37951",
+					"172.19.0.1:37951",
+					"172.20.0.1:37951"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:43:50.748458269Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7307005080874550,
+				"StableID":   "n1vLLidM4z11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6e9450ab4502100f374c42f7a01b088e7c5eb98beb4e623ea8bd16fb020f757",
+				"DiscoKey":   "discokey:c1820b018c93dca427b733d37e9b1648ac6dada69a1f08b72f3b52043051225d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39556",
+					"10.65.0.27:39556",
+					"172.17.0.1:39556",
+					"172.19.0.1:39556",
+					"172.20.0.1:39556"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:43:51.268603179Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3696077596774279,
+				"StableID":   "n6G2c5hxrV11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1bb90812675bb474bf4f2fd55b97ebf702ae289e00e852a2d2d5cf53099ee964",
+				"DiscoKey":   "discokey:ec62448c59384095cd368f18a8bccd1fb134fdab5fff974a7cfba3d690408433",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40858",
+					"10.65.0.27:40858",
+					"172.17.0.1:40858",
+					"172.19.0.1:40858",
+					"172.20.0.1:40858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:43:51.818935512Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2592773546433543,
+				"StableID":   "ngqDmLmGFM11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8f66db443c75af68c597ee14554e226b8b4c9ef896a1e46adacbe8b3c351d60",
+				"DiscoKey":   "discokey:ab0dd2b92d46a1422cf78b935feb4ebdddc4b3ec0b4bffed06a09a015fd19e0b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49237",
+					"10.65.0.27:49237",
+					"172.17.0.1:49237",
+					"172.19.0.1:49237",
+					"172.20.0.1:49237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:43:52.358461504Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2289847623990136,
+				"StableID":   "no4QK2R5tJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c541411b0f74586cd4f08014d118b608aa574404e1c9bca88ada47ef45749d4f",
+				"DiscoKey":   "discokey:d26ec9be1bedbe696ba3a4ee11bc1bbd5bd2da566e249b061301f2bfdaa6be02",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:60165",
+					"10.65.0.27:60165",
+					"172.17.0.1:60165",
+					"172.19.0.1:60165",
+					"172.20.0.1:60165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:43:52.890603684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8439668000907087,
+				"StableID":   "nk3PxVmLu821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c08416080a6c9552ffc92be47c6c4f5e2b1d1418bb2ccfc8caf9e6e851308c49",
+				"DiscoKey":   "discokey:62cf465a66dd2dc170d5f55b9c7d58c19043c23d146ef0439ce60174d3607635",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:41955",
+					"10.65.0.27:41955",
+					"172.17.0.1:41955",
+					"172.19.0.1:41955",
+					"172.20.0.1:41955"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:43:53.438761454Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6164595990854836,
+				"StableID":   "nF4b33Vx8q11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aed457da7acfd20741ce760b6f8537b5a34c7f177c75005997bdd6abc59b1426",
+				"DiscoKey":   "discokey:0665b448de8d2bedd6e200d1a3bb5a24c02f93aa0c2e83ad46eabe0377dfb34f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50956",
+					"10.65.0.27:50956",
+					"172.17.0.1:50956",
+					"172.19.0.1:50956",
+					"172.20.0.1:50956"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:43:53.967751349Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4585853824743584,
+				"StableID":   "njGVy1cwoc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f1910e9a909ee4006938458b2570a9e467e28ffb79d6e0ff8848232f3bfad0e",
+				"DiscoKey":   "discokey:262cdf71674ba5ff59d8a49efc5925c692fa96b7b681ba960fbff926fddca666",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38777",
+					"10.65.0.27:38777",
+					"172.17.0.1:38777",
+					"172.19.0.1:38777",
+					"172.20.0.1:38777"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:43:54.509987968Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5018486937441265,
+				"StableID":   "nczJfE9tBg11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3065e4e9e503f449b44ac4e25492f90744fe664e86e8a4d460565653032e1b44",
+				"KeyExpiry":  "2026-11-08T18:43:55Z",
+				"DiscoKey":   "discokey:d3dc0cd94529593de76ac7685c0f67d2d64732125d9dce89c844f4adb507e376",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:58752",
+					"10.65.0.27:58752",
+					"172.17.0.1:58752",
+					"172.19.0.1:58752",
+					"172.20.0.1:58752"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:43:55.059593996Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2213377979405502,
+				"StableID":   "nsTdgogSHJ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ea2466fd4129f11b9eabe8bec10c68389d31023a9ffeceaf3a8ea906bfd99247",
+				"KeyExpiry":  "2026-11-08T18:43:55Z",
+				"DiscoKey":   "discokey:01064074e56764c74c67fe64b2e7b3247f3c094034aa7b9e9e243580624b9a52",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:33643",
+					"10.65.0.27:33643",
+					"172.17.0.1:33643",
+					"172.19.0.1:33643",
+					"172.20.0.1:33643"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:43:55.574256897Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2527687880437997,
+				"StableID":   "n4vMLK5ojL11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       2527687880437997,
+				"Key":        "nodekey:e5bc0a3e0c48383921a95eb735b271067d9be8d4ab74a449d3728b3e22c67a66",
+				"DiscoKey":   "discokey:851c4ea44b24069b6da2d95ba82c9be667abde4854499670615b23a713c6923d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52090",
+					"10.65.0.27:52090",
+					"172.17.0.1:52090",
+					"172.19.0.1:52090",
+					"172.20.0.1:52090"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:43:49.673410113Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e5bc0a3e0c48383921a95eb735b271067d9be8d4ab74a449d3728b3e22c67a66",
+			"MachineKey": "mkey:4b2996c6010d30551756dc269a5310f83ffb9a280fd06ada93e5cc447b66c63d",
+			"Peers": [{
+				"ID":         6016328770506857,
+				"StableID":   "nGzyVnkoyo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6eaa55db808f028c8d9926ec6f4ab78f8933e1ea37e03d268db81c5b302f3477",
+				"DiscoKey":   "discokey:50f417894fb269b4ba6254b3b861f524f90a0f9cbd0faeba9e90bf10fbd0d831",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:42805",
+					"10.65.0.27:42805",
+					"172.17.0.1:42805",
+					"172.19.0.1:42805",
+					"172.20.0.1:42805"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:43:48.593994629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6154641129028053,
+				"StableID":   "nc8ezBzS4q11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4c4eb20dc31e9ad029147c86c17118d2d5b13292da76e126cb2ac800cddec809",
+				"DiscoKey":   "discokey:70c3a3dbcea00fb90a73b074f6a11a30b7136448a71a13ac6115f168a126c962",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55489",
+					"10.65.0.27:55489",
+					"172.17.0.1:55489",
+					"172.19.0.1:55489",
+					"172.20.0.1:55489"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:43:49.143634273Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6673481231443679,
+				"StableID":   "naaGA53S7u11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5e09fb519d29ddc4ab74a92bb89d6a1089c7716b2588c1d69b47e912df2d00c",
+				"DiscoKey":   "discokey:f066bba19b8d1c13819293bed1f438ed9fc201ce2d70398bcd93ab998a08780e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:52398",
+					"10.65.0.27:52398",
+					"172.17.0.1:52398",
+					"172.19.0.1:52398",
+					"172.20.0.1:52398"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:43:50.204057843Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1103769185488624,
+				"StableID":   "njp1FQ9uc911CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87d712ee21f73bf0ae15f1fcea2f0db88a8ded3bcdda829e1a6b035ea3a99a1b",
+				"DiscoKey":   "discokey:8e6d52a4152d9ba4957aff9afb54f1a3cc728a2428dc9f2e28da30144420c42b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37951",
+					"10.65.0.27:37951",
+					"172.17.0.1:37951",
+					"172.19.0.1:37951",
+					"172.20.0.1:37951"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:43:50.748458269Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7307005080874550,
+				"StableID":   "n1vLLidM4z11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6e9450ab4502100f374c42f7a01b088e7c5eb98beb4e623ea8bd16fb020f757",
+				"DiscoKey":   "discokey:c1820b018c93dca427b733d37e9b1648ac6dada69a1f08b72f3b52043051225d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39556",
+					"10.65.0.27:39556",
+					"172.17.0.1:39556",
+					"172.19.0.1:39556",
+					"172.20.0.1:39556"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:43:51.268603179Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3696077596774279,
+				"StableID":   "n6G2c5hxrV11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1bb90812675bb474bf4f2fd55b97ebf702ae289e00e852a2d2d5cf53099ee964",
+				"DiscoKey":   "discokey:ec62448c59384095cd368f18a8bccd1fb134fdab5fff974a7cfba3d690408433",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40858",
+					"10.65.0.27:40858",
+					"172.17.0.1:40858",
+					"172.19.0.1:40858",
+					"172.20.0.1:40858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:43:51.818935512Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2592773546433543,
+				"StableID":   "ngqDmLmGFM11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8f66db443c75af68c597ee14554e226b8b4c9ef896a1e46adacbe8b3c351d60",
+				"DiscoKey":   "discokey:ab0dd2b92d46a1422cf78b935feb4ebdddc4b3ec0b4bffed06a09a015fd19e0b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49237",
+					"10.65.0.27:49237",
+					"172.17.0.1:49237",
+					"172.19.0.1:49237",
+					"172.20.0.1:49237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:43:52.358461504Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2289847623990136,
+				"StableID":   "no4QK2R5tJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c541411b0f74586cd4f08014d118b608aa574404e1c9bca88ada47ef45749d4f",
+				"DiscoKey":   "discokey:d26ec9be1bedbe696ba3a4ee11bc1bbd5bd2da566e249b061301f2bfdaa6be02",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:60165",
+					"10.65.0.27:60165",
+					"172.17.0.1:60165",
+					"172.19.0.1:60165",
+					"172.20.0.1:60165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:43:52.890603684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8439668000907087,
+				"StableID":   "nk3PxVmLu821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c08416080a6c9552ffc92be47c6c4f5e2b1d1418bb2ccfc8caf9e6e851308c49",
+				"DiscoKey":   "discokey:62cf465a66dd2dc170d5f55b9c7d58c19043c23d146ef0439ce60174d3607635",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:41955",
+					"10.65.0.27:41955",
+					"172.17.0.1:41955",
+					"172.19.0.1:41955",
+					"172.20.0.1:41955"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:43:53.438761454Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6164595990854836,
+				"StableID":   "nF4b33Vx8q11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aed457da7acfd20741ce760b6f8537b5a34c7f177c75005997bdd6abc59b1426",
+				"DiscoKey":   "discokey:0665b448de8d2bedd6e200d1a3bb5a24c02f93aa0c2e83ad46eabe0377dfb34f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50956",
+					"10.65.0.27:50956",
+					"172.17.0.1:50956",
+					"172.19.0.1:50956",
+					"172.20.0.1:50956"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:43:53.967751349Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4585853824743584,
+				"StableID":   "njGVy1cwoc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f1910e9a909ee4006938458b2570a9e467e28ffb79d6e0ff8848232f3bfad0e",
+				"DiscoKey":   "discokey:262cdf71674ba5ff59d8a49efc5925c692fa96b7b681ba960fbff926fddca666",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38777",
+					"10.65.0.27:38777",
+					"172.17.0.1:38777",
+					"172.19.0.1:38777",
+					"172.20.0.1:38777"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:43:54.509987968Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5018486937441265,
+				"StableID":   "nczJfE9tBg11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3065e4e9e503f449b44ac4e25492f90744fe664e86e8a4d460565653032e1b44",
+				"KeyExpiry":  "2026-11-08T18:43:55Z",
+				"DiscoKey":   "discokey:d3dc0cd94529593de76ac7685c0f67d2d64732125d9dce89c844f4adb507e376",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:58752",
+					"10.65.0.27:58752",
+					"172.17.0.1:58752",
+					"172.19.0.1:58752",
+					"172.20.0.1:58752"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:43:55.059593996Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2213377979405502,
+				"StableID":   "nsTdgogSHJ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ea2466fd4129f11b9eabe8bec10c68389d31023a9ffeceaf3a8ea906bfd99247",
+				"KeyExpiry":  "2026-11-08T18:43:55Z",
+				"DiscoKey":   "discokey:01064074e56764c74c67fe64b2e7b3247f3c094034aa7b9e9e243580624b9a52",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:33643",
+					"10.65.0.27:33643",
+					"172.17.0.1:33643",
+					"172.19.0.1:33643",
+					"172.20.0.1:33643"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:43:55.574256897Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3550521138286482,
+				"StableID":   "nXhWoqA3jU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d0a353f9cb159b426b1ca58230ca68e728c53589b40d3b3d8f2d9d192d194e42",
+				"KeyExpiry":  "2026-11-08T18:43:56Z",
+				"DiscoKey":   "discokey:7d3f9a784326feadb082ad78e148b42dad34d55b2bd68707af139d6e7d5f426e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44374",
+					"10.65.0.27:44374",
+					"172.17.0.1:44374",
+					"172.19.0.1:44374",
+					"172.20.0.1:44374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:43:56.09900279Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2527687880437997": {
+				"ID":          2527687880437997,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2592773546433543,
+				"StableID":   "ngqDmLmGFM11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       2592773546433543,
+				"Key":        "nodekey:b8f66db443c75af68c597ee14554e226b8b4c9ef896a1e46adacbe8b3c351d60",
+				"DiscoKey":   "discokey:ab0dd2b92d46a1422cf78b935feb4ebdddc4b3ec0b4bffed06a09a015fd19e0b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49237",
+					"10.65.0.27:49237",
+					"172.17.0.1:49237",
+					"172.19.0.1:49237",
+					"172.20.0.1:49237"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:43:52.358461504Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b8f66db443c75af68c597ee14554e226b8b4c9ef896a1e46adacbe8b3c351d60",
+			"MachineKey": "mkey:746cca5d6401d15e956ad45ba15b115fd1dcfed5b8ce33f1eefb1d8ce853cb08",
+			"Peers": [{
+				"ID":         6016328770506857,
+				"StableID":   "nGzyVnkoyo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6eaa55db808f028c8d9926ec6f4ab78f8933e1ea37e03d268db81c5b302f3477",
+				"DiscoKey":   "discokey:50f417894fb269b4ba6254b3b861f524f90a0f9cbd0faeba9e90bf10fbd0d831",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:42805",
+					"10.65.0.27:42805",
+					"172.17.0.1:42805",
+					"172.19.0.1:42805",
+					"172.20.0.1:42805"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:43:48.593994629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6154641129028053,
+				"StableID":   "nc8ezBzS4q11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4c4eb20dc31e9ad029147c86c17118d2d5b13292da76e126cb2ac800cddec809",
+				"DiscoKey":   "discokey:70c3a3dbcea00fb90a73b074f6a11a30b7136448a71a13ac6115f168a126c962",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55489",
+					"10.65.0.27:55489",
+					"172.17.0.1:55489",
+					"172.19.0.1:55489",
+					"172.20.0.1:55489"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:43:49.143634273Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2527687880437997,
+				"StableID":   "n4vMLK5ojL11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5bc0a3e0c48383921a95eb735b271067d9be8d4ab74a449d3728b3e22c67a66",
+				"DiscoKey":   "discokey:851c4ea44b24069b6da2d95ba82c9be667abde4854499670615b23a713c6923d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52090",
+					"10.65.0.27:52090",
+					"172.17.0.1:52090",
+					"172.19.0.1:52090",
+					"172.20.0.1:52090"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:43:49.673410113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6673481231443679,
+				"StableID":   "naaGA53S7u11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5e09fb519d29ddc4ab74a92bb89d6a1089c7716b2588c1d69b47e912df2d00c",
+				"DiscoKey":   "discokey:f066bba19b8d1c13819293bed1f438ed9fc201ce2d70398bcd93ab998a08780e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:52398",
+					"10.65.0.27:52398",
+					"172.17.0.1:52398",
+					"172.19.0.1:52398",
+					"172.20.0.1:52398"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:43:50.204057843Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1103769185488624,
+				"StableID":   "njp1FQ9uc911CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87d712ee21f73bf0ae15f1fcea2f0db88a8ded3bcdda829e1a6b035ea3a99a1b",
+				"DiscoKey":   "discokey:8e6d52a4152d9ba4957aff9afb54f1a3cc728a2428dc9f2e28da30144420c42b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37951",
+					"10.65.0.27:37951",
+					"172.17.0.1:37951",
+					"172.19.0.1:37951",
+					"172.20.0.1:37951"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:43:50.748458269Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7307005080874550,
+				"StableID":   "n1vLLidM4z11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6e9450ab4502100f374c42f7a01b088e7c5eb98beb4e623ea8bd16fb020f757",
+				"DiscoKey":   "discokey:c1820b018c93dca427b733d37e9b1648ac6dada69a1f08b72f3b52043051225d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39556",
+					"10.65.0.27:39556",
+					"172.17.0.1:39556",
+					"172.19.0.1:39556",
+					"172.20.0.1:39556"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:43:51.268603179Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3696077596774279,
+				"StableID":   "n6G2c5hxrV11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1bb90812675bb474bf4f2fd55b97ebf702ae289e00e852a2d2d5cf53099ee964",
+				"DiscoKey":   "discokey:ec62448c59384095cd368f18a8bccd1fb134fdab5fff974a7cfba3d690408433",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40858",
+					"10.65.0.27:40858",
+					"172.17.0.1:40858",
+					"172.19.0.1:40858",
+					"172.20.0.1:40858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:43:51.818935512Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2289847623990136,
+				"StableID":   "no4QK2R5tJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c541411b0f74586cd4f08014d118b608aa574404e1c9bca88ada47ef45749d4f",
+				"DiscoKey":   "discokey:d26ec9be1bedbe696ba3a4ee11bc1bbd5bd2da566e249b061301f2bfdaa6be02",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:60165",
+					"10.65.0.27:60165",
+					"172.17.0.1:60165",
+					"172.19.0.1:60165",
+					"172.20.0.1:60165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:43:52.890603684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8439668000907087,
+				"StableID":   "nk3PxVmLu821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c08416080a6c9552ffc92be47c6c4f5e2b1d1418bb2ccfc8caf9e6e851308c49",
+				"DiscoKey":   "discokey:62cf465a66dd2dc170d5f55b9c7d58c19043c23d146ef0439ce60174d3607635",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:41955",
+					"10.65.0.27:41955",
+					"172.17.0.1:41955",
+					"172.19.0.1:41955",
+					"172.20.0.1:41955"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:43:53.438761454Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6164595990854836,
+				"StableID":   "nF4b33Vx8q11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aed457da7acfd20741ce760b6f8537b5a34c7f177c75005997bdd6abc59b1426",
+				"DiscoKey":   "discokey:0665b448de8d2bedd6e200d1a3bb5a24c02f93aa0c2e83ad46eabe0377dfb34f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50956",
+					"10.65.0.27:50956",
+					"172.17.0.1:50956",
+					"172.19.0.1:50956",
+					"172.20.0.1:50956"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:43:53.967751349Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4585853824743584,
+				"StableID":   "njGVy1cwoc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f1910e9a909ee4006938458b2570a9e467e28ffb79d6e0ff8848232f3bfad0e",
+				"DiscoKey":   "discokey:262cdf71674ba5ff59d8a49efc5925c692fa96b7b681ba960fbff926fddca666",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38777",
+					"10.65.0.27:38777",
+					"172.17.0.1:38777",
+					"172.19.0.1:38777",
+					"172.20.0.1:38777"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:43:54.509987968Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5018486937441265,
+				"StableID":   "nczJfE9tBg11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3065e4e9e503f449b44ac4e25492f90744fe664e86e8a4d460565653032e1b44",
+				"KeyExpiry":  "2026-11-08T18:43:55Z",
+				"DiscoKey":   "discokey:d3dc0cd94529593de76ac7685c0f67d2d64732125d9dce89c844f4adb507e376",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:58752",
+					"10.65.0.27:58752",
+					"172.17.0.1:58752",
+					"172.19.0.1:58752",
+					"172.20.0.1:58752"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:43:55.059593996Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2213377979405502,
+				"StableID":   "nsTdgogSHJ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ea2466fd4129f11b9eabe8bec10c68389d31023a9ffeceaf3a8ea906bfd99247",
+				"KeyExpiry":  "2026-11-08T18:43:55Z",
+				"DiscoKey":   "discokey:01064074e56764c74c67fe64b2e7b3247f3c094034aa7b9e9e243580624b9a52",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:33643",
+					"10.65.0.27:33643",
+					"172.17.0.1:33643",
+					"172.19.0.1:33643",
+					"172.20.0.1:33643"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:43:55.574256897Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3550521138286482,
+				"StableID":   "nXhWoqA3jU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d0a353f9cb159b426b1ca58230ca68e728c53589b40d3b3d8f2d9d192d194e42",
+				"KeyExpiry":  "2026-11-08T18:43:56Z",
+				"DiscoKey":   "discokey:7d3f9a784326feadb082ad78e148b42dad34d55b2bd68707af139d6e7d5f426e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44374",
+					"10.65.0.27:44374",
+					"172.17.0.1:44374",
+					"172.19.0.1:44374",
+					"172.20.0.1:44374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:43:56.09900279Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2592773546433543": {
+				"ID":          2592773546433543,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5018486937441265,
+				"StableID":   "nczJfE9tBg11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3065e4e9e503f449b44ac4e25492f90744fe664e86e8a4d460565653032e1b44",
+				"KeyExpiry":  "2026-11-08T18:43:55Z",
+				"DiscoKey":   "discokey:d3dc0cd94529593de76ac7685c0f67d2d64732125d9dce89c844f4adb507e376",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:58752",
+					"10.65.0.27:58752",
+					"172.17.0.1:58752",
+					"172.19.0.1:58752",
+					"172.20.0.1:58752"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:43:55.059593996Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3065e4e9e503f449b44ac4e25492f90744fe664e86e8a4d460565653032e1b44",
+			"MachineKey": "mkey:f542d91fd508ec6c31f945bcb1f5927bb596415bd895a602da449b56f75af54f",
+			"Peers": [{
+				"ID":         6016328770506857,
+				"StableID":   "nGzyVnkoyo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6eaa55db808f028c8d9926ec6f4ab78f8933e1ea37e03d268db81c5b302f3477",
+				"DiscoKey":   "discokey:50f417894fb269b4ba6254b3b861f524f90a0f9cbd0faeba9e90bf10fbd0d831",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:42805",
+					"10.65.0.27:42805",
+					"172.17.0.1:42805",
+					"172.19.0.1:42805",
+					"172.20.0.1:42805"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:43:48.593994629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6154641129028053,
+				"StableID":   "nc8ezBzS4q11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4c4eb20dc31e9ad029147c86c17118d2d5b13292da76e126cb2ac800cddec809",
+				"DiscoKey":   "discokey:70c3a3dbcea00fb90a73b074f6a11a30b7136448a71a13ac6115f168a126c962",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55489",
+					"10.65.0.27:55489",
+					"172.17.0.1:55489",
+					"172.19.0.1:55489",
+					"172.20.0.1:55489"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:43:49.143634273Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2527687880437997,
+				"StableID":   "n4vMLK5ojL11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5bc0a3e0c48383921a95eb735b271067d9be8d4ab74a449d3728b3e22c67a66",
+				"DiscoKey":   "discokey:851c4ea44b24069b6da2d95ba82c9be667abde4854499670615b23a713c6923d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52090",
+					"10.65.0.27:52090",
+					"172.17.0.1:52090",
+					"172.19.0.1:52090",
+					"172.20.0.1:52090"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:43:49.673410113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6673481231443679,
+				"StableID":   "naaGA53S7u11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5e09fb519d29ddc4ab74a92bb89d6a1089c7716b2588c1d69b47e912df2d00c",
+				"DiscoKey":   "discokey:f066bba19b8d1c13819293bed1f438ed9fc201ce2d70398bcd93ab998a08780e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:52398",
+					"10.65.0.27:52398",
+					"172.17.0.1:52398",
+					"172.19.0.1:52398",
+					"172.20.0.1:52398"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:43:50.204057843Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1103769185488624,
+				"StableID":   "njp1FQ9uc911CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87d712ee21f73bf0ae15f1fcea2f0db88a8ded3bcdda829e1a6b035ea3a99a1b",
+				"DiscoKey":   "discokey:8e6d52a4152d9ba4957aff9afb54f1a3cc728a2428dc9f2e28da30144420c42b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37951",
+					"10.65.0.27:37951",
+					"172.17.0.1:37951",
+					"172.19.0.1:37951",
+					"172.20.0.1:37951"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:43:50.748458269Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7307005080874550,
+				"StableID":   "n1vLLidM4z11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6e9450ab4502100f374c42f7a01b088e7c5eb98beb4e623ea8bd16fb020f757",
+				"DiscoKey":   "discokey:c1820b018c93dca427b733d37e9b1648ac6dada69a1f08b72f3b52043051225d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39556",
+					"10.65.0.27:39556",
+					"172.17.0.1:39556",
+					"172.19.0.1:39556",
+					"172.20.0.1:39556"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:43:51.268603179Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3696077596774279,
+				"StableID":   "n6G2c5hxrV11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1bb90812675bb474bf4f2fd55b97ebf702ae289e00e852a2d2d5cf53099ee964",
+				"DiscoKey":   "discokey:ec62448c59384095cd368f18a8bccd1fb134fdab5fff974a7cfba3d690408433",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40858",
+					"10.65.0.27:40858",
+					"172.17.0.1:40858",
+					"172.19.0.1:40858",
+					"172.20.0.1:40858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:43:51.818935512Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2592773546433543,
+				"StableID":   "ngqDmLmGFM11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8f66db443c75af68c597ee14554e226b8b4c9ef896a1e46adacbe8b3c351d60",
+				"DiscoKey":   "discokey:ab0dd2b92d46a1422cf78b935feb4ebdddc4b3ec0b4bffed06a09a015fd19e0b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49237",
+					"10.65.0.27:49237",
+					"172.17.0.1:49237",
+					"172.19.0.1:49237",
+					"172.20.0.1:49237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:43:52.358461504Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2289847623990136,
+				"StableID":   "no4QK2R5tJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c541411b0f74586cd4f08014d118b608aa574404e1c9bca88ada47ef45749d4f",
+				"DiscoKey":   "discokey:d26ec9be1bedbe696ba3a4ee11bc1bbd5bd2da566e249b061301f2bfdaa6be02",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:60165",
+					"10.65.0.27:60165",
+					"172.17.0.1:60165",
+					"172.19.0.1:60165",
+					"172.20.0.1:60165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:43:52.890603684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8439668000907087,
+				"StableID":   "nk3PxVmLu821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c08416080a6c9552ffc92be47c6c4f5e2b1d1418bb2ccfc8caf9e6e851308c49",
+				"DiscoKey":   "discokey:62cf465a66dd2dc170d5f55b9c7d58c19043c23d146ef0439ce60174d3607635",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:41955",
+					"10.65.0.27:41955",
+					"172.17.0.1:41955",
+					"172.19.0.1:41955",
+					"172.20.0.1:41955"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:43:53.438761454Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6164595990854836,
+				"StableID":   "nF4b33Vx8q11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aed457da7acfd20741ce760b6f8537b5a34c7f177c75005997bdd6abc59b1426",
+				"DiscoKey":   "discokey:0665b448de8d2bedd6e200d1a3bb5a24c02f93aa0c2e83ad46eabe0377dfb34f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50956",
+					"10.65.0.27:50956",
+					"172.17.0.1:50956",
+					"172.19.0.1:50956",
+					"172.20.0.1:50956"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:43:53.967751349Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4585853824743584,
+				"StableID":   "njGVy1cwoc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f1910e9a909ee4006938458b2570a9e467e28ffb79d6e0ff8848232f3bfad0e",
+				"DiscoKey":   "discokey:262cdf71674ba5ff59d8a49efc5925c692fa96b7b681ba960fbff926fddca666",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38777",
+					"10.65.0.27:38777",
+					"172.17.0.1:38777",
+					"172.19.0.1:38777",
+					"172.20.0.1:38777"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:43:54.509987968Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2213377979405502,
+				"StableID":   "nsTdgogSHJ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ea2466fd4129f11b9eabe8bec10c68389d31023a9ffeceaf3a8ea906bfd99247",
+				"KeyExpiry":  "2026-11-08T18:43:55Z",
+				"DiscoKey":   "discokey:01064074e56764c74c67fe64b2e7b3247f3c094034aa7b9e9e243580624b9a52",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:33643",
+					"10.65.0.27:33643",
+					"172.17.0.1:33643",
+					"172.19.0.1:33643",
+					"172.20.0.1:33643"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:43:55.574256897Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3550521138286482,
+				"StableID":   "nXhWoqA3jU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d0a353f9cb159b426b1ca58230ca68e728c53589b40d3b3d8f2d9d192d194e42",
+				"KeyExpiry":  "2026-11-08T18:43:56Z",
+				"DiscoKey":   "discokey:7d3f9a784326feadb082ad78e148b42dad34d55b2bd68707af139d6e7d5f426e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44374",
+					"10.65.0.27:44374",
+					"172.17.0.1:44374",
+					"172.19.0.1:44374",
+					"172.20.0.1:44374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:43:56.09900279Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6164595990854836,
+				"StableID":   "nF4b33Vx8q11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       6164595990854836,
+				"Key":        "nodekey:aed457da7acfd20741ce760b6f8537b5a34c7f177c75005997bdd6abc59b1426",
+				"DiscoKey":   "discokey:0665b448de8d2bedd6e200d1a3bb5a24c02f93aa0c2e83ad46eabe0377dfb34f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50956",
+					"10.65.0.27:50956",
+					"172.17.0.1:50956",
+					"172.19.0.1:50956",
+					"172.20.0.1:50956"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:43:53.967751349Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:aed457da7acfd20741ce760b6f8537b5a34c7f177c75005997bdd6abc59b1426",
+			"MachineKey": "mkey:1b2e73c391966cfc86b4e14849b861f2f113ddf2245e93455de089146a8a0c0f",
+			"Peers": [{
+				"ID":         6016328770506857,
+				"StableID":   "nGzyVnkoyo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6eaa55db808f028c8d9926ec6f4ab78f8933e1ea37e03d268db81c5b302f3477",
+				"DiscoKey":   "discokey:50f417894fb269b4ba6254b3b861f524f90a0f9cbd0faeba9e90bf10fbd0d831",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:42805",
+					"10.65.0.27:42805",
+					"172.17.0.1:42805",
+					"172.19.0.1:42805",
+					"172.20.0.1:42805"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:43:48.593994629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6154641129028053,
+				"StableID":   "nc8ezBzS4q11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4c4eb20dc31e9ad029147c86c17118d2d5b13292da76e126cb2ac800cddec809",
+				"DiscoKey":   "discokey:70c3a3dbcea00fb90a73b074f6a11a30b7136448a71a13ac6115f168a126c962",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55489",
+					"10.65.0.27:55489",
+					"172.17.0.1:55489",
+					"172.19.0.1:55489",
+					"172.20.0.1:55489"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:43:49.143634273Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2527687880437997,
+				"StableID":   "n4vMLK5ojL11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5bc0a3e0c48383921a95eb735b271067d9be8d4ab74a449d3728b3e22c67a66",
+				"DiscoKey":   "discokey:851c4ea44b24069b6da2d95ba82c9be667abde4854499670615b23a713c6923d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52090",
+					"10.65.0.27:52090",
+					"172.17.0.1:52090",
+					"172.19.0.1:52090",
+					"172.20.0.1:52090"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:43:49.673410113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6673481231443679,
+				"StableID":   "naaGA53S7u11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5e09fb519d29ddc4ab74a92bb89d6a1089c7716b2588c1d69b47e912df2d00c",
+				"DiscoKey":   "discokey:f066bba19b8d1c13819293bed1f438ed9fc201ce2d70398bcd93ab998a08780e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:52398",
+					"10.65.0.27:52398",
+					"172.17.0.1:52398",
+					"172.19.0.1:52398",
+					"172.20.0.1:52398"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:43:50.204057843Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1103769185488624,
+				"StableID":   "njp1FQ9uc911CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87d712ee21f73bf0ae15f1fcea2f0db88a8ded3bcdda829e1a6b035ea3a99a1b",
+				"DiscoKey":   "discokey:8e6d52a4152d9ba4957aff9afb54f1a3cc728a2428dc9f2e28da30144420c42b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37951",
+					"10.65.0.27:37951",
+					"172.17.0.1:37951",
+					"172.19.0.1:37951",
+					"172.20.0.1:37951"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:43:50.748458269Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7307005080874550,
+				"StableID":   "n1vLLidM4z11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6e9450ab4502100f374c42f7a01b088e7c5eb98beb4e623ea8bd16fb020f757",
+				"DiscoKey":   "discokey:c1820b018c93dca427b733d37e9b1648ac6dada69a1f08b72f3b52043051225d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39556",
+					"10.65.0.27:39556",
+					"172.17.0.1:39556",
+					"172.19.0.1:39556",
+					"172.20.0.1:39556"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:43:51.268603179Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3696077596774279,
+				"StableID":   "n6G2c5hxrV11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1bb90812675bb474bf4f2fd55b97ebf702ae289e00e852a2d2d5cf53099ee964",
+				"DiscoKey":   "discokey:ec62448c59384095cd368f18a8bccd1fb134fdab5fff974a7cfba3d690408433",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40858",
+					"10.65.0.27:40858",
+					"172.17.0.1:40858",
+					"172.19.0.1:40858",
+					"172.20.0.1:40858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:43:51.818935512Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2592773546433543,
+				"StableID":   "ngqDmLmGFM11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8f66db443c75af68c597ee14554e226b8b4c9ef896a1e46adacbe8b3c351d60",
+				"DiscoKey":   "discokey:ab0dd2b92d46a1422cf78b935feb4ebdddc4b3ec0b4bffed06a09a015fd19e0b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49237",
+					"10.65.0.27:49237",
+					"172.17.0.1:49237",
+					"172.19.0.1:49237",
+					"172.20.0.1:49237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:43:52.358461504Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2289847623990136,
+				"StableID":   "no4QK2R5tJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c541411b0f74586cd4f08014d118b608aa574404e1c9bca88ada47ef45749d4f",
+				"DiscoKey":   "discokey:d26ec9be1bedbe696ba3a4ee11bc1bbd5bd2da566e249b061301f2bfdaa6be02",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:60165",
+					"10.65.0.27:60165",
+					"172.17.0.1:60165",
+					"172.19.0.1:60165",
+					"172.20.0.1:60165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:43:52.890603684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8439668000907087,
+				"StableID":   "nk3PxVmLu821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c08416080a6c9552ffc92be47c6c4f5e2b1d1418bb2ccfc8caf9e6e851308c49",
+				"DiscoKey":   "discokey:62cf465a66dd2dc170d5f55b9c7d58c19043c23d146ef0439ce60174d3607635",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:41955",
+					"10.65.0.27:41955",
+					"172.17.0.1:41955",
+					"172.19.0.1:41955",
+					"172.20.0.1:41955"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:43:53.438761454Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4585853824743584,
+				"StableID":   "njGVy1cwoc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f1910e9a909ee4006938458b2570a9e467e28ffb79d6e0ff8848232f3bfad0e",
+				"DiscoKey":   "discokey:262cdf71674ba5ff59d8a49efc5925c692fa96b7b681ba960fbff926fddca666",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38777",
+					"10.65.0.27:38777",
+					"172.17.0.1:38777",
+					"172.19.0.1:38777",
+					"172.20.0.1:38777"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:43:54.509987968Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5018486937441265,
+				"StableID":   "nczJfE9tBg11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3065e4e9e503f449b44ac4e25492f90744fe664e86e8a4d460565653032e1b44",
+				"KeyExpiry":  "2026-11-08T18:43:55Z",
+				"DiscoKey":   "discokey:d3dc0cd94529593de76ac7685c0f67d2d64732125d9dce89c844f4adb507e376",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:58752",
+					"10.65.0.27:58752",
+					"172.17.0.1:58752",
+					"172.19.0.1:58752",
+					"172.20.0.1:58752"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:43:55.059593996Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2213377979405502,
+				"StableID":   "nsTdgogSHJ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ea2466fd4129f11b9eabe8bec10c68389d31023a9ffeceaf3a8ea906bfd99247",
+				"KeyExpiry":  "2026-11-08T18:43:55Z",
+				"DiscoKey":   "discokey:01064074e56764c74c67fe64b2e7b3247f3c094034aa7b9e9e243580624b9a52",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:33643",
+					"10.65.0.27:33643",
+					"172.17.0.1:33643",
+					"172.19.0.1:33643",
+					"172.20.0.1:33643"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:43:55.574256897Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3550521138286482,
+				"StableID":   "nXhWoqA3jU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d0a353f9cb159b426b1ca58230ca68e728c53589b40d3b3d8f2d9d192d194e42",
+				"KeyExpiry":  "2026-11-08T18:43:56Z",
+				"DiscoKey":   "discokey:7d3f9a784326feadb082ad78e148b42dad34d55b2bd68707af139d6e7d5f426e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44374",
+					"10.65.0.27:44374",
+					"172.17.0.1:44374",
+					"172.19.0.1:44374",
+					"172.20.0.1:44374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:43:56.09900279Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6164595990854836": {
+				"ID":          6164595990854836,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6154641129028053,
+				"StableID":   "nc8ezBzS4q11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       6154641129028053,
+				"Key":        "nodekey:4c4eb20dc31e9ad029147c86c17118d2d5b13292da76e126cb2ac800cddec809",
+				"DiscoKey":   "discokey:70c3a3dbcea00fb90a73b074f6a11a30b7136448a71a13ac6115f168a126c962",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55489",
+					"10.65.0.27:55489",
+					"172.17.0.1:55489",
+					"172.19.0.1:55489",
+					"172.20.0.1:55489"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:43:49.143634273Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4c4eb20dc31e9ad029147c86c17118d2d5b13292da76e126cb2ac800cddec809",
+			"MachineKey": "mkey:81145b94cce10cfa4f3b16d18874f4dbc21fcb71d92fbcb25987203fba0adf61",
+			"Peers": [{
+				"ID":         6016328770506857,
+				"StableID":   "nGzyVnkoyo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6eaa55db808f028c8d9926ec6f4ab78f8933e1ea37e03d268db81c5b302f3477",
+				"DiscoKey":   "discokey:50f417894fb269b4ba6254b3b861f524f90a0f9cbd0faeba9e90bf10fbd0d831",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:42805",
+					"10.65.0.27:42805",
+					"172.17.0.1:42805",
+					"172.19.0.1:42805",
+					"172.20.0.1:42805"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:43:48.593994629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2527687880437997,
+				"StableID":   "n4vMLK5ojL11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5bc0a3e0c48383921a95eb735b271067d9be8d4ab74a449d3728b3e22c67a66",
+				"DiscoKey":   "discokey:851c4ea44b24069b6da2d95ba82c9be667abde4854499670615b23a713c6923d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52090",
+					"10.65.0.27:52090",
+					"172.17.0.1:52090",
+					"172.19.0.1:52090",
+					"172.20.0.1:52090"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:43:49.673410113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6673481231443679,
+				"StableID":   "naaGA53S7u11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5e09fb519d29ddc4ab74a92bb89d6a1089c7716b2588c1d69b47e912df2d00c",
+				"DiscoKey":   "discokey:f066bba19b8d1c13819293bed1f438ed9fc201ce2d70398bcd93ab998a08780e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:52398",
+					"10.65.0.27:52398",
+					"172.17.0.1:52398",
+					"172.19.0.1:52398",
+					"172.20.0.1:52398"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:43:50.204057843Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1103769185488624,
+				"StableID":   "njp1FQ9uc911CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87d712ee21f73bf0ae15f1fcea2f0db88a8ded3bcdda829e1a6b035ea3a99a1b",
+				"DiscoKey":   "discokey:8e6d52a4152d9ba4957aff9afb54f1a3cc728a2428dc9f2e28da30144420c42b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37951",
+					"10.65.0.27:37951",
+					"172.17.0.1:37951",
+					"172.19.0.1:37951",
+					"172.20.0.1:37951"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:43:50.748458269Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7307005080874550,
+				"StableID":   "n1vLLidM4z11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6e9450ab4502100f374c42f7a01b088e7c5eb98beb4e623ea8bd16fb020f757",
+				"DiscoKey":   "discokey:c1820b018c93dca427b733d37e9b1648ac6dada69a1f08b72f3b52043051225d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39556",
+					"10.65.0.27:39556",
+					"172.17.0.1:39556",
+					"172.19.0.1:39556",
+					"172.20.0.1:39556"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:43:51.268603179Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3696077596774279,
+				"StableID":   "n6G2c5hxrV11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1bb90812675bb474bf4f2fd55b97ebf702ae289e00e852a2d2d5cf53099ee964",
+				"DiscoKey":   "discokey:ec62448c59384095cd368f18a8bccd1fb134fdab5fff974a7cfba3d690408433",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40858",
+					"10.65.0.27:40858",
+					"172.17.0.1:40858",
+					"172.19.0.1:40858",
+					"172.20.0.1:40858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:43:51.818935512Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2592773546433543,
+				"StableID":   "ngqDmLmGFM11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8f66db443c75af68c597ee14554e226b8b4c9ef896a1e46adacbe8b3c351d60",
+				"DiscoKey":   "discokey:ab0dd2b92d46a1422cf78b935feb4ebdddc4b3ec0b4bffed06a09a015fd19e0b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49237",
+					"10.65.0.27:49237",
+					"172.17.0.1:49237",
+					"172.19.0.1:49237",
+					"172.20.0.1:49237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:43:52.358461504Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2289847623990136,
+				"StableID":   "no4QK2R5tJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c541411b0f74586cd4f08014d118b608aa574404e1c9bca88ada47ef45749d4f",
+				"DiscoKey":   "discokey:d26ec9be1bedbe696ba3a4ee11bc1bbd5bd2da566e249b061301f2bfdaa6be02",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:60165",
+					"10.65.0.27:60165",
+					"172.17.0.1:60165",
+					"172.19.0.1:60165",
+					"172.20.0.1:60165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:43:52.890603684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8439668000907087,
+				"StableID":   "nk3PxVmLu821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c08416080a6c9552ffc92be47c6c4f5e2b1d1418bb2ccfc8caf9e6e851308c49",
+				"DiscoKey":   "discokey:62cf465a66dd2dc170d5f55b9c7d58c19043c23d146ef0439ce60174d3607635",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:41955",
+					"10.65.0.27:41955",
+					"172.17.0.1:41955",
+					"172.19.0.1:41955",
+					"172.20.0.1:41955"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:43:53.438761454Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6164595990854836,
+				"StableID":   "nF4b33Vx8q11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aed457da7acfd20741ce760b6f8537b5a34c7f177c75005997bdd6abc59b1426",
+				"DiscoKey":   "discokey:0665b448de8d2bedd6e200d1a3bb5a24c02f93aa0c2e83ad46eabe0377dfb34f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50956",
+					"10.65.0.27:50956",
+					"172.17.0.1:50956",
+					"172.19.0.1:50956",
+					"172.20.0.1:50956"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:43:53.967751349Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4585853824743584,
+				"StableID":   "njGVy1cwoc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f1910e9a909ee4006938458b2570a9e467e28ffb79d6e0ff8848232f3bfad0e",
+				"DiscoKey":   "discokey:262cdf71674ba5ff59d8a49efc5925c692fa96b7b681ba960fbff926fddca666",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38777",
+					"10.65.0.27:38777",
+					"172.17.0.1:38777",
+					"172.19.0.1:38777",
+					"172.20.0.1:38777"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:43:54.509987968Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5018486937441265,
+				"StableID":   "nczJfE9tBg11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3065e4e9e503f449b44ac4e25492f90744fe664e86e8a4d460565653032e1b44",
+				"KeyExpiry":  "2026-11-08T18:43:55Z",
+				"DiscoKey":   "discokey:d3dc0cd94529593de76ac7685c0f67d2d64732125d9dce89c844f4adb507e376",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:58752",
+					"10.65.0.27:58752",
+					"172.17.0.1:58752",
+					"172.19.0.1:58752",
+					"172.20.0.1:58752"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:43:55.059593996Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2213377979405502,
+				"StableID":   "nsTdgogSHJ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ea2466fd4129f11b9eabe8bec10c68389d31023a9ffeceaf3a8ea906bfd99247",
+				"KeyExpiry":  "2026-11-08T18:43:55Z",
+				"DiscoKey":   "discokey:01064074e56764c74c67fe64b2e7b3247f3c094034aa7b9e9e243580624b9a52",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:33643",
+					"10.65.0.27:33643",
+					"172.17.0.1:33643",
+					"172.19.0.1:33643",
+					"172.20.0.1:33643"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:43:55.574256897Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3550521138286482,
+				"StableID":   "nXhWoqA3jU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d0a353f9cb159b426b1ca58230ca68e728c53589b40d3b3d8f2d9d192d194e42",
+				"KeyExpiry":  "2026-11-08T18:43:56Z",
+				"DiscoKey":   "discokey:7d3f9a784326feadb082ad78e148b42dad34d55b2bd68707af139d6e7d5f426e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44374",
+					"10.65.0.27:44374",
+					"172.17.0.1:44374",
+					"172.19.0.1:44374",
+					"172.20.0.1:44374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:43:56.09900279Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6154641129028053": {
+				"ID":          6154641129028053,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6016328770506857,
+				"StableID":   "nGzyVnkoyo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       6016328770506857,
+				"Key":        "nodekey:6eaa55db808f028c8d9926ec6f4ab78f8933e1ea37e03d268db81c5b302f3477",
+				"DiscoKey":   "discokey:50f417894fb269b4ba6254b3b861f524f90a0f9cbd0faeba9e90bf10fbd0d831",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:42805",
+					"10.65.0.27:42805",
+					"172.17.0.1:42805",
+					"172.19.0.1:42805",
+					"172.20.0.1:42805"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:43:48.593994629Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6eaa55db808f028c8d9926ec6f4ab78f8933e1ea37e03d268db81c5b302f3477",
+			"MachineKey": "mkey:01639d11947d4cf1fca48e9dc917831f6b5ce0d315fba893fd5bf78346d60e40",
+			"Peers": [{
+				"ID":         6154641129028053,
+				"StableID":   "nc8ezBzS4q11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4c4eb20dc31e9ad029147c86c17118d2d5b13292da76e126cb2ac800cddec809",
+				"DiscoKey":   "discokey:70c3a3dbcea00fb90a73b074f6a11a30b7136448a71a13ac6115f168a126c962",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55489",
+					"10.65.0.27:55489",
+					"172.17.0.1:55489",
+					"172.19.0.1:55489",
+					"172.20.0.1:55489"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:43:49.143634273Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2527687880437997,
+				"StableID":   "n4vMLK5ojL11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5bc0a3e0c48383921a95eb735b271067d9be8d4ab74a449d3728b3e22c67a66",
+				"DiscoKey":   "discokey:851c4ea44b24069b6da2d95ba82c9be667abde4854499670615b23a713c6923d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52090",
+					"10.65.0.27:52090",
+					"172.17.0.1:52090",
+					"172.19.0.1:52090",
+					"172.20.0.1:52090"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:43:49.673410113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6673481231443679,
+				"StableID":   "naaGA53S7u11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5e09fb519d29ddc4ab74a92bb89d6a1089c7716b2588c1d69b47e912df2d00c",
+				"DiscoKey":   "discokey:f066bba19b8d1c13819293bed1f438ed9fc201ce2d70398bcd93ab998a08780e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:52398",
+					"10.65.0.27:52398",
+					"172.17.0.1:52398",
+					"172.19.0.1:52398",
+					"172.20.0.1:52398"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:43:50.204057843Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1103769185488624,
+				"StableID":   "njp1FQ9uc911CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87d712ee21f73bf0ae15f1fcea2f0db88a8ded3bcdda829e1a6b035ea3a99a1b",
+				"DiscoKey":   "discokey:8e6d52a4152d9ba4957aff9afb54f1a3cc728a2428dc9f2e28da30144420c42b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37951",
+					"10.65.0.27:37951",
+					"172.17.0.1:37951",
+					"172.19.0.1:37951",
+					"172.20.0.1:37951"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:43:50.748458269Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7307005080874550,
+				"StableID":   "n1vLLidM4z11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6e9450ab4502100f374c42f7a01b088e7c5eb98beb4e623ea8bd16fb020f757",
+				"DiscoKey":   "discokey:c1820b018c93dca427b733d37e9b1648ac6dada69a1f08b72f3b52043051225d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39556",
+					"10.65.0.27:39556",
+					"172.17.0.1:39556",
+					"172.19.0.1:39556",
+					"172.20.0.1:39556"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:43:51.268603179Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3696077596774279,
+				"StableID":   "n6G2c5hxrV11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1bb90812675bb474bf4f2fd55b97ebf702ae289e00e852a2d2d5cf53099ee964",
+				"DiscoKey":   "discokey:ec62448c59384095cd368f18a8bccd1fb134fdab5fff974a7cfba3d690408433",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40858",
+					"10.65.0.27:40858",
+					"172.17.0.1:40858",
+					"172.19.0.1:40858",
+					"172.20.0.1:40858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:43:51.818935512Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2592773546433543,
+				"StableID":   "ngqDmLmGFM11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8f66db443c75af68c597ee14554e226b8b4c9ef896a1e46adacbe8b3c351d60",
+				"DiscoKey":   "discokey:ab0dd2b92d46a1422cf78b935feb4ebdddc4b3ec0b4bffed06a09a015fd19e0b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49237",
+					"10.65.0.27:49237",
+					"172.17.0.1:49237",
+					"172.19.0.1:49237",
+					"172.20.0.1:49237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:43:52.358461504Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2289847623990136,
+				"StableID":   "no4QK2R5tJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c541411b0f74586cd4f08014d118b608aa574404e1c9bca88ada47ef45749d4f",
+				"DiscoKey":   "discokey:d26ec9be1bedbe696ba3a4ee11bc1bbd5bd2da566e249b061301f2bfdaa6be02",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:60165",
+					"10.65.0.27:60165",
+					"172.17.0.1:60165",
+					"172.19.0.1:60165",
+					"172.20.0.1:60165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:43:52.890603684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8439668000907087,
+				"StableID":   "nk3PxVmLu821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c08416080a6c9552ffc92be47c6c4f5e2b1d1418bb2ccfc8caf9e6e851308c49",
+				"DiscoKey":   "discokey:62cf465a66dd2dc170d5f55b9c7d58c19043c23d146ef0439ce60174d3607635",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:41955",
+					"10.65.0.27:41955",
+					"172.17.0.1:41955",
+					"172.19.0.1:41955",
+					"172.20.0.1:41955"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:43:53.438761454Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6164595990854836,
+				"StableID":   "nF4b33Vx8q11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aed457da7acfd20741ce760b6f8537b5a34c7f177c75005997bdd6abc59b1426",
+				"DiscoKey":   "discokey:0665b448de8d2bedd6e200d1a3bb5a24c02f93aa0c2e83ad46eabe0377dfb34f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50956",
+					"10.65.0.27:50956",
+					"172.17.0.1:50956",
+					"172.19.0.1:50956",
+					"172.20.0.1:50956"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:43:53.967751349Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4585853824743584,
+				"StableID":   "njGVy1cwoc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f1910e9a909ee4006938458b2570a9e467e28ffb79d6e0ff8848232f3bfad0e",
+				"DiscoKey":   "discokey:262cdf71674ba5ff59d8a49efc5925c692fa96b7b681ba960fbff926fddca666",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38777",
+					"10.65.0.27:38777",
+					"172.17.0.1:38777",
+					"172.19.0.1:38777",
+					"172.20.0.1:38777"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:43:54.509987968Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5018486937441265,
+				"StableID":   "nczJfE9tBg11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3065e4e9e503f449b44ac4e25492f90744fe664e86e8a4d460565653032e1b44",
+				"KeyExpiry":  "2026-11-08T18:43:55Z",
+				"DiscoKey":   "discokey:d3dc0cd94529593de76ac7685c0f67d2d64732125d9dce89c844f4adb507e376",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:58752",
+					"10.65.0.27:58752",
+					"172.17.0.1:58752",
+					"172.19.0.1:58752",
+					"172.20.0.1:58752"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:43:55.059593996Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2213377979405502,
+				"StableID":   "nsTdgogSHJ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ea2466fd4129f11b9eabe8bec10c68389d31023a9ffeceaf3a8ea906bfd99247",
+				"KeyExpiry":  "2026-11-08T18:43:55Z",
+				"DiscoKey":   "discokey:01064074e56764c74c67fe64b2e7b3247f3c094034aa7b9e9e243580624b9a52",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:33643",
+					"10.65.0.27:33643",
+					"172.17.0.1:33643",
+					"172.19.0.1:33643",
+					"172.20.0.1:33643"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:43:55.574256897Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3550521138286482,
+				"StableID":   "nXhWoqA3jU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d0a353f9cb159b426b1ca58230ca68e728c53589b40d3b3d8f2d9d192d194e42",
+				"KeyExpiry":  "2026-11-08T18:43:56Z",
+				"DiscoKey":   "discokey:7d3f9a784326feadb082ad78e148b42dad34d55b2bd68707af139d6e7d5f426e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44374",
+					"10.65.0.27:44374",
+					"172.17.0.1:44374",
+					"172.19.0.1:44374",
+					"172.20.0.1:44374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:43:56.09900279Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6016328770506857": {
+				"ID":          6016328770506857,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1103769185488624,
+				"StableID":   "njp1FQ9uc911CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1103769185488624,
+				"Key":        "nodekey:87d712ee21f73bf0ae15f1fcea2f0db88a8ded3bcdda829e1a6b035ea3a99a1b",
+				"DiscoKey":   "discokey:8e6d52a4152d9ba4957aff9afb54f1a3cc728a2428dc9f2e28da30144420c42b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37951",
+					"10.65.0.27:37951",
+					"172.17.0.1:37951",
+					"172.19.0.1:37951",
+					"172.20.0.1:37951"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:43:50.748458269Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:87d712ee21f73bf0ae15f1fcea2f0db88a8ded3bcdda829e1a6b035ea3a99a1b",
+			"MachineKey": "mkey:4208dde24d58c915aaa5c3c4f51649f290bba99b768d9a616ea268fbd1989e08",
+			"Peers": [{
+				"ID":         6016328770506857,
+				"StableID":   "nGzyVnkoyo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6eaa55db808f028c8d9926ec6f4ab78f8933e1ea37e03d268db81c5b302f3477",
+				"DiscoKey":   "discokey:50f417894fb269b4ba6254b3b861f524f90a0f9cbd0faeba9e90bf10fbd0d831",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:42805",
+					"10.65.0.27:42805",
+					"172.17.0.1:42805",
+					"172.19.0.1:42805",
+					"172.20.0.1:42805"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:43:48.593994629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6154641129028053,
+				"StableID":   "nc8ezBzS4q11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4c4eb20dc31e9ad029147c86c17118d2d5b13292da76e126cb2ac800cddec809",
+				"DiscoKey":   "discokey:70c3a3dbcea00fb90a73b074f6a11a30b7136448a71a13ac6115f168a126c962",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55489",
+					"10.65.0.27:55489",
+					"172.17.0.1:55489",
+					"172.19.0.1:55489",
+					"172.20.0.1:55489"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:43:49.143634273Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2527687880437997,
+				"StableID":   "n4vMLK5ojL11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5bc0a3e0c48383921a95eb735b271067d9be8d4ab74a449d3728b3e22c67a66",
+				"DiscoKey":   "discokey:851c4ea44b24069b6da2d95ba82c9be667abde4854499670615b23a713c6923d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52090",
+					"10.65.0.27:52090",
+					"172.17.0.1:52090",
+					"172.19.0.1:52090",
+					"172.20.0.1:52090"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:43:49.673410113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6673481231443679,
+				"StableID":   "naaGA53S7u11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5e09fb519d29ddc4ab74a92bb89d6a1089c7716b2588c1d69b47e912df2d00c",
+				"DiscoKey":   "discokey:f066bba19b8d1c13819293bed1f438ed9fc201ce2d70398bcd93ab998a08780e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:52398",
+					"10.65.0.27:52398",
+					"172.17.0.1:52398",
+					"172.19.0.1:52398",
+					"172.20.0.1:52398"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:43:50.204057843Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7307005080874550,
+				"StableID":   "n1vLLidM4z11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6e9450ab4502100f374c42f7a01b088e7c5eb98beb4e623ea8bd16fb020f757",
+				"DiscoKey":   "discokey:c1820b018c93dca427b733d37e9b1648ac6dada69a1f08b72f3b52043051225d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39556",
+					"10.65.0.27:39556",
+					"172.17.0.1:39556",
+					"172.19.0.1:39556",
+					"172.20.0.1:39556"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:43:51.268603179Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3696077596774279,
+				"StableID":   "n6G2c5hxrV11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1bb90812675bb474bf4f2fd55b97ebf702ae289e00e852a2d2d5cf53099ee964",
+				"DiscoKey":   "discokey:ec62448c59384095cd368f18a8bccd1fb134fdab5fff974a7cfba3d690408433",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40858",
+					"10.65.0.27:40858",
+					"172.17.0.1:40858",
+					"172.19.0.1:40858",
+					"172.20.0.1:40858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:43:51.818935512Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2592773546433543,
+				"StableID":   "ngqDmLmGFM11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8f66db443c75af68c597ee14554e226b8b4c9ef896a1e46adacbe8b3c351d60",
+				"DiscoKey":   "discokey:ab0dd2b92d46a1422cf78b935feb4ebdddc4b3ec0b4bffed06a09a015fd19e0b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49237",
+					"10.65.0.27:49237",
+					"172.17.0.1:49237",
+					"172.19.0.1:49237",
+					"172.20.0.1:49237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:43:52.358461504Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2289847623990136,
+				"StableID":   "no4QK2R5tJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c541411b0f74586cd4f08014d118b608aa574404e1c9bca88ada47ef45749d4f",
+				"DiscoKey":   "discokey:d26ec9be1bedbe696ba3a4ee11bc1bbd5bd2da566e249b061301f2bfdaa6be02",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:60165",
+					"10.65.0.27:60165",
+					"172.17.0.1:60165",
+					"172.19.0.1:60165",
+					"172.20.0.1:60165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:43:52.890603684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8439668000907087,
+				"StableID":   "nk3PxVmLu821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c08416080a6c9552ffc92be47c6c4f5e2b1d1418bb2ccfc8caf9e6e851308c49",
+				"DiscoKey":   "discokey:62cf465a66dd2dc170d5f55b9c7d58c19043c23d146ef0439ce60174d3607635",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:41955",
+					"10.65.0.27:41955",
+					"172.17.0.1:41955",
+					"172.19.0.1:41955",
+					"172.20.0.1:41955"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:43:53.438761454Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6164595990854836,
+				"StableID":   "nF4b33Vx8q11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aed457da7acfd20741ce760b6f8537b5a34c7f177c75005997bdd6abc59b1426",
+				"DiscoKey":   "discokey:0665b448de8d2bedd6e200d1a3bb5a24c02f93aa0c2e83ad46eabe0377dfb34f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50956",
+					"10.65.0.27:50956",
+					"172.17.0.1:50956",
+					"172.19.0.1:50956",
+					"172.20.0.1:50956"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:43:53.967751349Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4585853824743584,
+				"StableID":   "njGVy1cwoc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f1910e9a909ee4006938458b2570a9e467e28ffb79d6e0ff8848232f3bfad0e",
+				"DiscoKey":   "discokey:262cdf71674ba5ff59d8a49efc5925c692fa96b7b681ba960fbff926fddca666",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38777",
+					"10.65.0.27:38777",
+					"172.17.0.1:38777",
+					"172.19.0.1:38777",
+					"172.20.0.1:38777"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:43:54.509987968Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5018486937441265,
+				"StableID":   "nczJfE9tBg11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3065e4e9e503f449b44ac4e25492f90744fe664e86e8a4d460565653032e1b44",
+				"KeyExpiry":  "2026-11-08T18:43:55Z",
+				"DiscoKey":   "discokey:d3dc0cd94529593de76ac7685c0f67d2d64732125d9dce89c844f4adb507e376",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:58752",
+					"10.65.0.27:58752",
+					"172.17.0.1:58752",
+					"172.19.0.1:58752",
+					"172.20.0.1:58752"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:43:55.059593996Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2213377979405502,
+				"StableID":   "nsTdgogSHJ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ea2466fd4129f11b9eabe8bec10c68389d31023a9ffeceaf3a8ea906bfd99247",
+				"KeyExpiry":  "2026-11-08T18:43:55Z",
+				"DiscoKey":   "discokey:01064074e56764c74c67fe64b2e7b3247f3c094034aa7b9e9e243580624b9a52",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:33643",
+					"10.65.0.27:33643",
+					"172.17.0.1:33643",
+					"172.19.0.1:33643",
+					"172.20.0.1:33643"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:43:55.574256897Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3550521138286482,
+				"StableID":   "nXhWoqA3jU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d0a353f9cb159b426b1ca58230ca68e728c53589b40d3b3d8f2d9d192d194e42",
+				"KeyExpiry":  "2026-11-08T18:43:56Z",
+				"DiscoKey":   "discokey:7d3f9a784326feadb082ad78e148b42dad34d55b2bd68707af139d6e7d5f426e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44374",
+					"10.65.0.27:44374",
+					"172.17.0.1:44374",
+					"172.19.0.1:44374",
+					"172.20.0.1:44374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:43:56.09900279Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1103769185488624": {
+				"ID":          1103769185488624,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}, "1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6673481231443679,
+				"StableID":   "naaGA53S7u11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       6673481231443679,
+				"Key":        "nodekey:c5e09fb519d29ddc4ab74a92bb89d6a1089c7716b2588c1d69b47e912df2d00c",
+				"DiscoKey":   "discokey:f066bba19b8d1c13819293bed1f438ed9fc201ce2d70398bcd93ab998a08780e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:52398",
+					"10.65.0.27:52398",
+					"172.17.0.1:52398",
+					"172.19.0.1:52398",
+					"172.20.0.1:52398"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:43:50.204057843Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c5e09fb519d29ddc4ab74a92bb89d6a1089c7716b2588c1d69b47e912df2d00c",
+			"MachineKey": "mkey:bf5d7039fcae4a9d85ad89524388d75c6f9af252abf9598e9199914f29cea07b",
+			"Peers": [{
+				"ID":         6016328770506857,
+				"StableID":   "nGzyVnkoyo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6eaa55db808f028c8d9926ec6f4ab78f8933e1ea37e03d268db81c5b302f3477",
+				"DiscoKey":   "discokey:50f417894fb269b4ba6254b3b861f524f90a0f9cbd0faeba9e90bf10fbd0d831",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:42805",
+					"10.65.0.27:42805",
+					"172.17.0.1:42805",
+					"172.19.0.1:42805",
+					"172.20.0.1:42805"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:43:48.593994629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6154641129028053,
+				"StableID":   "nc8ezBzS4q11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4c4eb20dc31e9ad029147c86c17118d2d5b13292da76e126cb2ac800cddec809",
+				"DiscoKey":   "discokey:70c3a3dbcea00fb90a73b074f6a11a30b7136448a71a13ac6115f168a126c962",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55489",
+					"10.65.0.27:55489",
+					"172.17.0.1:55489",
+					"172.19.0.1:55489",
+					"172.20.0.1:55489"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:43:49.143634273Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2527687880437997,
+				"StableID":   "n4vMLK5ojL11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5bc0a3e0c48383921a95eb735b271067d9be8d4ab74a449d3728b3e22c67a66",
+				"DiscoKey":   "discokey:851c4ea44b24069b6da2d95ba82c9be667abde4854499670615b23a713c6923d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52090",
+					"10.65.0.27:52090",
+					"172.17.0.1:52090",
+					"172.19.0.1:52090",
+					"172.20.0.1:52090"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:43:49.673410113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1103769185488624,
+				"StableID":   "njp1FQ9uc911CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87d712ee21f73bf0ae15f1fcea2f0db88a8ded3bcdda829e1a6b035ea3a99a1b",
+				"DiscoKey":   "discokey:8e6d52a4152d9ba4957aff9afb54f1a3cc728a2428dc9f2e28da30144420c42b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37951",
+					"10.65.0.27:37951",
+					"172.17.0.1:37951",
+					"172.19.0.1:37951",
+					"172.20.0.1:37951"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:43:50.748458269Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7307005080874550,
+				"StableID":   "n1vLLidM4z11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6e9450ab4502100f374c42f7a01b088e7c5eb98beb4e623ea8bd16fb020f757",
+				"DiscoKey":   "discokey:c1820b018c93dca427b733d37e9b1648ac6dada69a1f08b72f3b52043051225d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39556",
+					"10.65.0.27:39556",
+					"172.17.0.1:39556",
+					"172.19.0.1:39556",
+					"172.20.0.1:39556"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:43:51.268603179Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3696077596774279,
+				"StableID":   "n6G2c5hxrV11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1bb90812675bb474bf4f2fd55b97ebf702ae289e00e852a2d2d5cf53099ee964",
+				"DiscoKey":   "discokey:ec62448c59384095cd368f18a8bccd1fb134fdab5fff974a7cfba3d690408433",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40858",
+					"10.65.0.27:40858",
+					"172.17.0.1:40858",
+					"172.19.0.1:40858",
+					"172.20.0.1:40858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:43:51.818935512Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2592773546433543,
+				"StableID":   "ngqDmLmGFM11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8f66db443c75af68c597ee14554e226b8b4c9ef896a1e46adacbe8b3c351d60",
+				"DiscoKey":   "discokey:ab0dd2b92d46a1422cf78b935feb4ebdddc4b3ec0b4bffed06a09a015fd19e0b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49237",
+					"10.65.0.27:49237",
+					"172.17.0.1:49237",
+					"172.19.0.1:49237",
+					"172.20.0.1:49237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:43:52.358461504Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2289847623990136,
+				"StableID":   "no4QK2R5tJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c541411b0f74586cd4f08014d118b608aa574404e1c9bca88ada47ef45749d4f",
+				"DiscoKey":   "discokey:d26ec9be1bedbe696ba3a4ee11bc1bbd5bd2da566e249b061301f2bfdaa6be02",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:60165",
+					"10.65.0.27:60165",
+					"172.17.0.1:60165",
+					"172.19.0.1:60165",
+					"172.20.0.1:60165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:43:52.890603684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8439668000907087,
+				"StableID":   "nk3PxVmLu821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c08416080a6c9552ffc92be47c6c4f5e2b1d1418bb2ccfc8caf9e6e851308c49",
+				"DiscoKey":   "discokey:62cf465a66dd2dc170d5f55b9c7d58c19043c23d146ef0439ce60174d3607635",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:41955",
+					"10.65.0.27:41955",
+					"172.17.0.1:41955",
+					"172.19.0.1:41955",
+					"172.20.0.1:41955"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:43:53.438761454Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6164595990854836,
+				"StableID":   "nF4b33Vx8q11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aed457da7acfd20741ce760b6f8537b5a34c7f177c75005997bdd6abc59b1426",
+				"DiscoKey":   "discokey:0665b448de8d2bedd6e200d1a3bb5a24c02f93aa0c2e83ad46eabe0377dfb34f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50956",
+					"10.65.0.27:50956",
+					"172.17.0.1:50956",
+					"172.19.0.1:50956",
+					"172.20.0.1:50956"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:43:53.967751349Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4585853824743584,
+				"StableID":   "njGVy1cwoc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f1910e9a909ee4006938458b2570a9e467e28ffb79d6e0ff8848232f3bfad0e",
+				"DiscoKey":   "discokey:262cdf71674ba5ff59d8a49efc5925c692fa96b7b681ba960fbff926fddca666",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38777",
+					"10.65.0.27:38777",
+					"172.17.0.1:38777",
+					"172.19.0.1:38777",
+					"172.20.0.1:38777"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:43:54.509987968Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5018486937441265,
+				"StableID":   "nczJfE9tBg11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3065e4e9e503f449b44ac4e25492f90744fe664e86e8a4d460565653032e1b44",
+				"KeyExpiry":  "2026-11-08T18:43:55Z",
+				"DiscoKey":   "discokey:d3dc0cd94529593de76ac7685c0f67d2d64732125d9dce89c844f4adb507e376",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:58752",
+					"10.65.0.27:58752",
+					"172.17.0.1:58752",
+					"172.19.0.1:58752",
+					"172.20.0.1:58752"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:43:55.059593996Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2213377979405502,
+				"StableID":   "nsTdgogSHJ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ea2466fd4129f11b9eabe8bec10c68389d31023a9ffeceaf3a8ea906bfd99247",
+				"KeyExpiry":  "2026-11-08T18:43:55Z",
+				"DiscoKey":   "discokey:01064074e56764c74c67fe64b2e7b3247f3c094034aa7b9e9e243580624b9a52",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:33643",
+					"10.65.0.27:33643",
+					"172.17.0.1:33643",
+					"172.19.0.1:33643",
+					"172.20.0.1:33643"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:43:55.574256897Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3550521138286482,
+				"StableID":   "nXhWoqA3jU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d0a353f9cb159b426b1ca58230ca68e728c53589b40d3b3d8f2d9d192d194e42",
+				"KeyExpiry":  "2026-11-08T18:43:56Z",
+				"DiscoKey":   "discokey:7d3f9a784326feadb082ad78e148b42dad34d55b2bd68707af139d6e7d5f426e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44374",
+					"10.65.0.27:44374",
+					"172.17.0.1:44374",
+					"172.19.0.1:44374",
+					"172.20.0.1:44374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:43:56.09900279Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6673481231443679": {
+				"ID":          6673481231443679,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3696077596774279,
+				"StableID":   "n6G2c5hxrV11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       3696077596774279,
+				"Key":        "nodekey:1bb90812675bb474bf4f2fd55b97ebf702ae289e00e852a2d2d5cf53099ee964",
+				"DiscoKey":   "discokey:ec62448c59384095cd368f18a8bccd1fb134fdab5fff974a7cfba3d690408433",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40858",
+					"10.65.0.27:40858",
+					"172.17.0.1:40858",
+					"172.19.0.1:40858",
+					"172.20.0.1:40858"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:43:51.818935512Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1bb90812675bb474bf4f2fd55b97ebf702ae289e00e852a2d2d5cf53099ee964",
+			"MachineKey": "mkey:10938e789b92b7062a5142469cd459736a26ca6d4b4bbf210e973467d7c72b51",
+			"Peers": [{
+				"ID":         6016328770506857,
+				"StableID":   "nGzyVnkoyo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6eaa55db808f028c8d9926ec6f4ab78f8933e1ea37e03d268db81c5b302f3477",
+				"DiscoKey":   "discokey:50f417894fb269b4ba6254b3b861f524f90a0f9cbd0faeba9e90bf10fbd0d831",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:42805",
+					"10.65.0.27:42805",
+					"172.17.0.1:42805",
+					"172.19.0.1:42805",
+					"172.20.0.1:42805"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:43:48.593994629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6154641129028053,
+				"StableID":   "nc8ezBzS4q11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4c4eb20dc31e9ad029147c86c17118d2d5b13292da76e126cb2ac800cddec809",
+				"DiscoKey":   "discokey:70c3a3dbcea00fb90a73b074f6a11a30b7136448a71a13ac6115f168a126c962",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55489",
+					"10.65.0.27:55489",
+					"172.17.0.1:55489",
+					"172.19.0.1:55489",
+					"172.20.0.1:55489"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:43:49.143634273Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2527687880437997,
+				"StableID":   "n4vMLK5ojL11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5bc0a3e0c48383921a95eb735b271067d9be8d4ab74a449d3728b3e22c67a66",
+				"DiscoKey":   "discokey:851c4ea44b24069b6da2d95ba82c9be667abde4854499670615b23a713c6923d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52090",
+					"10.65.0.27:52090",
+					"172.17.0.1:52090",
+					"172.19.0.1:52090",
+					"172.20.0.1:52090"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:43:49.673410113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6673481231443679,
+				"StableID":   "naaGA53S7u11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5e09fb519d29ddc4ab74a92bb89d6a1089c7716b2588c1d69b47e912df2d00c",
+				"DiscoKey":   "discokey:f066bba19b8d1c13819293bed1f438ed9fc201ce2d70398bcd93ab998a08780e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:52398",
+					"10.65.0.27:52398",
+					"172.17.0.1:52398",
+					"172.19.0.1:52398",
+					"172.20.0.1:52398"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:43:50.204057843Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1103769185488624,
+				"StableID":   "njp1FQ9uc911CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87d712ee21f73bf0ae15f1fcea2f0db88a8ded3bcdda829e1a6b035ea3a99a1b",
+				"DiscoKey":   "discokey:8e6d52a4152d9ba4957aff9afb54f1a3cc728a2428dc9f2e28da30144420c42b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37951",
+					"10.65.0.27:37951",
+					"172.17.0.1:37951",
+					"172.19.0.1:37951",
+					"172.20.0.1:37951"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:43:50.748458269Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7307005080874550,
+				"StableID":   "n1vLLidM4z11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6e9450ab4502100f374c42f7a01b088e7c5eb98beb4e623ea8bd16fb020f757",
+				"DiscoKey":   "discokey:c1820b018c93dca427b733d37e9b1648ac6dada69a1f08b72f3b52043051225d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39556",
+					"10.65.0.27:39556",
+					"172.17.0.1:39556",
+					"172.19.0.1:39556",
+					"172.20.0.1:39556"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:43:51.268603179Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2592773546433543,
+				"StableID":   "ngqDmLmGFM11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8f66db443c75af68c597ee14554e226b8b4c9ef896a1e46adacbe8b3c351d60",
+				"DiscoKey":   "discokey:ab0dd2b92d46a1422cf78b935feb4ebdddc4b3ec0b4bffed06a09a015fd19e0b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49237",
+					"10.65.0.27:49237",
+					"172.17.0.1:49237",
+					"172.19.0.1:49237",
+					"172.20.0.1:49237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:43:52.358461504Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2289847623990136,
+				"StableID":   "no4QK2R5tJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c541411b0f74586cd4f08014d118b608aa574404e1c9bca88ada47ef45749d4f",
+				"DiscoKey":   "discokey:d26ec9be1bedbe696ba3a4ee11bc1bbd5bd2da566e249b061301f2bfdaa6be02",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:60165",
+					"10.65.0.27:60165",
+					"172.17.0.1:60165",
+					"172.19.0.1:60165",
+					"172.20.0.1:60165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:43:52.890603684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8439668000907087,
+				"StableID":   "nk3PxVmLu821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c08416080a6c9552ffc92be47c6c4f5e2b1d1418bb2ccfc8caf9e6e851308c49",
+				"DiscoKey":   "discokey:62cf465a66dd2dc170d5f55b9c7d58c19043c23d146ef0439ce60174d3607635",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:41955",
+					"10.65.0.27:41955",
+					"172.17.0.1:41955",
+					"172.19.0.1:41955",
+					"172.20.0.1:41955"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:43:53.438761454Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6164595990854836,
+				"StableID":   "nF4b33Vx8q11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aed457da7acfd20741ce760b6f8537b5a34c7f177c75005997bdd6abc59b1426",
+				"DiscoKey":   "discokey:0665b448de8d2bedd6e200d1a3bb5a24c02f93aa0c2e83ad46eabe0377dfb34f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50956",
+					"10.65.0.27:50956",
+					"172.17.0.1:50956",
+					"172.19.0.1:50956",
+					"172.20.0.1:50956"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:43:53.967751349Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4585853824743584,
+				"StableID":   "njGVy1cwoc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f1910e9a909ee4006938458b2570a9e467e28ffb79d6e0ff8848232f3bfad0e",
+				"DiscoKey":   "discokey:262cdf71674ba5ff59d8a49efc5925c692fa96b7b681ba960fbff926fddca666",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38777",
+					"10.65.0.27:38777",
+					"172.17.0.1:38777",
+					"172.19.0.1:38777",
+					"172.20.0.1:38777"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:43:54.509987968Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5018486937441265,
+				"StableID":   "nczJfE9tBg11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3065e4e9e503f449b44ac4e25492f90744fe664e86e8a4d460565653032e1b44",
+				"KeyExpiry":  "2026-11-08T18:43:55Z",
+				"DiscoKey":   "discokey:d3dc0cd94529593de76ac7685c0f67d2d64732125d9dce89c844f4adb507e376",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:58752",
+					"10.65.0.27:58752",
+					"172.17.0.1:58752",
+					"172.19.0.1:58752",
+					"172.20.0.1:58752"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:43:55.059593996Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2213377979405502,
+				"StableID":   "nsTdgogSHJ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ea2466fd4129f11b9eabe8bec10c68389d31023a9ffeceaf3a8ea906bfd99247",
+				"KeyExpiry":  "2026-11-08T18:43:55Z",
+				"DiscoKey":   "discokey:01064074e56764c74c67fe64b2e7b3247f3c094034aa7b9e9e243580624b9a52",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:33643",
+					"10.65.0.27:33643",
+					"172.17.0.1:33643",
+					"172.19.0.1:33643",
+					"172.20.0.1:33643"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:43:55.574256897Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3550521138286482,
+				"StableID":   "nXhWoqA3jU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d0a353f9cb159b426b1ca58230ca68e728c53589b40d3b3d8f2d9d192d194e42",
+				"KeyExpiry":  "2026-11-08T18:43:56Z",
+				"DiscoKey":   "discokey:7d3f9a784326feadb082ad78e148b42dad34d55b2bd68707af139d6e7d5f426e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44374",
+					"10.65.0.27:44374",
+					"172.17.0.1:44374",
+					"172.19.0.1:44374",
+					"172.20.0.1:44374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:43:56.09900279Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3696077596774279": {
+				"ID":          3696077596774279,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2289847623990136,
+				"StableID":   "no4QK2R5tJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       2289847623990136,
+				"Key":        "nodekey:c541411b0f74586cd4f08014d118b608aa574404e1c9bca88ada47ef45749d4f",
+				"DiscoKey":   "discokey:d26ec9be1bedbe696ba3a4ee11bc1bbd5bd2da566e249b061301f2bfdaa6be02",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:60165",
+					"10.65.0.27:60165",
+					"172.17.0.1:60165",
+					"172.19.0.1:60165",
+					"172.20.0.1:60165"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:43:52.890603684Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c541411b0f74586cd4f08014d118b608aa574404e1c9bca88ada47ef45749d4f",
+			"MachineKey": "mkey:b4e896f0d584278e59f1ac6f6669dcf557e32959b1d601378ce149e90736d56c",
+			"Peers": [{
+				"ID":         6016328770506857,
+				"StableID":   "nGzyVnkoyo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6eaa55db808f028c8d9926ec6f4ab78f8933e1ea37e03d268db81c5b302f3477",
+				"DiscoKey":   "discokey:50f417894fb269b4ba6254b3b861f524f90a0f9cbd0faeba9e90bf10fbd0d831",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:42805",
+					"10.65.0.27:42805",
+					"172.17.0.1:42805",
+					"172.19.0.1:42805",
+					"172.20.0.1:42805"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:43:48.593994629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6154641129028053,
+				"StableID":   "nc8ezBzS4q11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4c4eb20dc31e9ad029147c86c17118d2d5b13292da76e126cb2ac800cddec809",
+				"DiscoKey":   "discokey:70c3a3dbcea00fb90a73b074f6a11a30b7136448a71a13ac6115f168a126c962",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55489",
+					"10.65.0.27:55489",
+					"172.17.0.1:55489",
+					"172.19.0.1:55489",
+					"172.20.0.1:55489"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:43:49.143634273Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2527687880437997,
+				"StableID":   "n4vMLK5ojL11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5bc0a3e0c48383921a95eb735b271067d9be8d4ab74a449d3728b3e22c67a66",
+				"DiscoKey":   "discokey:851c4ea44b24069b6da2d95ba82c9be667abde4854499670615b23a713c6923d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52090",
+					"10.65.0.27:52090",
+					"172.17.0.1:52090",
+					"172.19.0.1:52090",
+					"172.20.0.1:52090"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:43:49.673410113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6673481231443679,
+				"StableID":   "naaGA53S7u11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5e09fb519d29ddc4ab74a92bb89d6a1089c7716b2588c1d69b47e912df2d00c",
+				"DiscoKey":   "discokey:f066bba19b8d1c13819293bed1f438ed9fc201ce2d70398bcd93ab998a08780e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:52398",
+					"10.65.0.27:52398",
+					"172.17.0.1:52398",
+					"172.19.0.1:52398",
+					"172.20.0.1:52398"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:43:50.204057843Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1103769185488624,
+				"StableID":   "njp1FQ9uc911CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87d712ee21f73bf0ae15f1fcea2f0db88a8ded3bcdda829e1a6b035ea3a99a1b",
+				"DiscoKey":   "discokey:8e6d52a4152d9ba4957aff9afb54f1a3cc728a2428dc9f2e28da30144420c42b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37951",
+					"10.65.0.27:37951",
+					"172.17.0.1:37951",
+					"172.19.0.1:37951",
+					"172.20.0.1:37951"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:43:50.748458269Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7307005080874550,
+				"StableID":   "n1vLLidM4z11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6e9450ab4502100f374c42f7a01b088e7c5eb98beb4e623ea8bd16fb020f757",
+				"DiscoKey":   "discokey:c1820b018c93dca427b733d37e9b1648ac6dada69a1f08b72f3b52043051225d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39556",
+					"10.65.0.27:39556",
+					"172.17.0.1:39556",
+					"172.19.0.1:39556",
+					"172.20.0.1:39556"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:43:51.268603179Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3696077596774279,
+				"StableID":   "n6G2c5hxrV11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1bb90812675bb474bf4f2fd55b97ebf702ae289e00e852a2d2d5cf53099ee964",
+				"DiscoKey":   "discokey:ec62448c59384095cd368f18a8bccd1fb134fdab5fff974a7cfba3d690408433",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40858",
+					"10.65.0.27:40858",
+					"172.17.0.1:40858",
+					"172.19.0.1:40858",
+					"172.20.0.1:40858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:43:51.818935512Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2592773546433543,
+				"StableID":   "ngqDmLmGFM11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8f66db443c75af68c597ee14554e226b8b4c9ef896a1e46adacbe8b3c351d60",
+				"DiscoKey":   "discokey:ab0dd2b92d46a1422cf78b935feb4ebdddc4b3ec0b4bffed06a09a015fd19e0b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49237",
+					"10.65.0.27:49237",
+					"172.17.0.1:49237",
+					"172.19.0.1:49237",
+					"172.20.0.1:49237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:43:52.358461504Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8439668000907087,
+				"StableID":   "nk3PxVmLu821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c08416080a6c9552ffc92be47c6c4f5e2b1d1418bb2ccfc8caf9e6e851308c49",
+				"DiscoKey":   "discokey:62cf465a66dd2dc170d5f55b9c7d58c19043c23d146ef0439ce60174d3607635",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:41955",
+					"10.65.0.27:41955",
+					"172.17.0.1:41955",
+					"172.19.0.1:41955",
+					"172.20.0.1:41955"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:43:53.438761454Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6164595990854836,
+				"StableID":   "nF4b33Vx8q11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aed457da7acfd20741ce760b6f8537b5a34c7f177c75005997bdd6abc59b1426",
+				"DiscoKey":   "discokey:0665b448de8d2bedd6e200d1a3bb5a24c02f93aa0c2e83ad46eabe0377dfb34f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50956",
+					"10.65.0.27:50956",
+					"172.17.0.1:50956",
+					"172.19.0.1:50956",
+					"172.20.0.1:50956"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:43:53.967751349Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4585853824743584,
+				"StableID":   "njGVy1cwoc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f1910e9a909ee4006938458b2570a9e467e28ffb79d6e0ff8848232f3bfad0e",
+				"DiscoKey":   "discokey:262cdf71674ba5ff59d8a49efc5925c692fa96b7b681ba960fbff926fddca666",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38777",
+					"10.65.0.27:38777",
+					"172.17.0.1:38777",
+					"172.19.0.1:38777",
+					"172.20.0.1:38777"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:43:54.509987968Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5018486937441265,
+				"StableID":   "nczJfE9tBg11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3065e4e9e503f449b44ac4e25492f90744fe664e86e8a4d460565653032e1b44",
+				"KeyExpiry":  "2026-11-08T18:43:55Z",
+				"DiscoKey":   "discokey:d3dc0cd94529593de76ac7685c0f67d2d64732125d9dce89c844f4adb507e376",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:58752",
+					"10.65.0.27:58752",
+					"172.17.0.1:58752",
+					"172.19.0.1:58752",
+					"172.20.0.1:58752"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:43:55.059593996Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2213377979405502,
+				"StableID":   "nsTdgogSHJ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ea2466fd4129f11b9eabe8bec10c68389d31023a9ffeceaf3a8ea906bfd99247",
+				"KeyExpiry":  "2026-11-08T18:43:55Z",
+				"DiscoKey":   "discokey:01064074e56764c74c67fe64b2e7b3247f3c094034aa7b9e9e243580624b9a52",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:33643",
+					"10.65.0.27:33643",
+					"172.17.0.1:33643",
+					"172.19.0.1:33643",
+					"172.20.0.1:33643"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:43:55.574256897Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3550521138286482,
+				"StableID":   "nXhWoqA3jU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d0a353f9cb159b426b1ca58230ca68e728c53589b40d3b3d8f2d9d192d194e42",
+				"KeyExpiry":  "2026-11-08T18:43:56Z",
+				"DiscoKey":   "discokey:7d3f9a784326feadb082ad78e148b42dad34d55b2bd68707af139d6e7d5f426e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44374",
+					"10.65.0.27:44374",
+					"172.17.0.1:44374",
+					"172.19.0.1:44374",
+					"172.20.0.1:44374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:43:56.09900279Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2289847623990136": {
+				"ID":          2289847623990136,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2213377979405502,
+				"StableID":   "nsTdgogSHJ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ea2466fd4129f11b9eabe8bec10c68389d31023a9ffeceaf3a8ea906bfd99247",
+				"KeyExpiry":  "2026-11-08T18:43:55Z",
+				"DiscoKey":   "discokey:01064074e56764c74c67fe64b2e7b3247f3c094034aa7b9e9e243580624b9a52",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:33643",
+					"10.65.0.27:33643",
+					"172.17.0.1:33643",
+					"172.19.0.1:33643",
+					"172.20.0.1:33643"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:43:55.574256897Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ea2466fd4129f11b9eabe8bec10c68389d31023a9ffeceaf3a8ea906bfd99247",
+			"MachineKey": "mkey:0f591c7b8b54e859269ef21706bf7d5a51d534955e1d4dbea57824b48a05f85f",
+			"Peers": [{
+				"ID":         6016328770506857,
+				"StableID":   "nGzyVnkoyo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6eaa55db808f028c8d9926ec6f4ab78f8933e1ea37e03d268db81c5b302f3477",
+				"DiscoKey":   "discokey:50f417894fb269b4ba6254b3b861f524f90a0f9cbd0faeba9e90bf10fbd0d831",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:42805",
+					"10.65.0.27:42805",
+					"172.17.0.1:42805",
+					"172.19.0.1:42805",
+					"172.20.0.1:42805"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:43:48.593994629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6154641129028053,
+				"StableID":   "nc8ezBzS4q11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4c4eb20dc31e9ad029147c86c17118d2d5b13292da76e126cb2ac800cddec809",
+				"DiscoKey":   "discokey:70c3a3dbcea00fb90a73b074f6a11a30b7136448a71a13ac6115f168a126c962",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55489",
+					"10.65.0.27:55489",
+					"172.17.0.1:55489",
+					"172.19.0.1:55489",
+					"172.20.0.1:55489"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:43:49.143634273Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2527687880437997,
+				"StableID":   "n4vMLK5ojL11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5bc0a3e0c48383921a95eb735b271067d9be8d4ab74a449d3728b3e22c67a66",
+				"DiscoKey":   "discokey:851c4ea44b24069b6da2d95ba82c9be667abde4854499670615b23a713c6923d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52090",
+					"10.65.0.27:52090",
+					"172.17.0.1:52090",
+					"172.19.0.1:52090",
+					"172.20.0.1:52090"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:43:49.673410113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6673481231443679,
+				"StableID":   "naaGA53S7u11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5e09fb519d29ddc4ab74a92bb89d6a1089c7716b2588c1d69b47e912df2d00c",
+				"DiscoKey":   "discokey:f066bba19b8d1c13819293bed1f438ed9fc201ce2d70398bcd93ab998a08780e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:52398",
+					"10.65.0.27:52398",
+					"172.17.0.1:52398",
+					"172.19.0.1:52398",
+					"172.20.0.1:52398"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:43:50.204057843Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1103769185488624,
+				"StableID":   "njp1FQ9uc911CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87d712ee21f73bf0ae15f1fcea2f0db88a8ded3bcdda829e1a6b035ea3a99a1b",
+				"DiscoKey":   "discokey:8e6d52a4152d9ba4957aff9afb54f1a3cc728a2428dc9f2e28da30144420c42b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37951",
+					"10.65.0.27:37951",
+					"172.17.0.1:37951",
+					"172.19.0.1:37951",
+					"172.20.0.1:37951"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:43:50.748458269Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7307005080874550,
+				"StableID":   "n1vLLidM4z11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6e9450ab4502100f374c42f7a01b088e7c5eb98beb4e623ea8bd16fb020f757",
+				"DiscoKey":   "discokey:c1820b018c93dca427b733d37e9b1648ac6dada69a1f08b72f3b52043051225d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39556",
+					"10.65.0.27:39556",
+					"172.17.0.1:39556",
+					"172.19.0.1:39556",
+					"172.20.0.1:39556"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:43:51.268603179Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3696077596774279,
+				"StableID":   "n6G2c5hxrV11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1bb90812675bb474bf4f2fd55b97ebf702ae289e00e852a2d2d5cf53099ee964",
+				"DiscoKey":   "discokey:ec62448c59384095cd368f18a8bccd1fb134fdab5fff974a7cfba3d690408433",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40858",
+					"10.65.0.27:40858",
+					"172.17.0.1:40858",
+					"172.19.0.1:40858",
+					"172.20.0.1:40858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:43:51.818935512Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2592773546433543,
+				"StableID":   "ngqDmLmGFM11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8f66db443c75af68c597ee14554e226b8b4c9ef896a1e46adacbe8b3c351d60",
+				"DiscoKey":   "discokey:ab0dd2b92d46a1422cf78b935feb4ebdddc4b3ec0b4bffed06a09a015fd19e0b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49237",
+					"10.65.0.27:49237",
+					"172.17.0.1:49237",
+					"172.19.0.1:49237",
+					"172.20.0.1:49237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:43:52.358461504Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2289847623990136,
+				"StableID":   "no4QK2R5tJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c541411b0f74586cd4f08014d118b608aa574404e1c9bca88ada47ef45749d4f",
+				"DiscoKey":   "discokey:d26ec9be1bedbe696ba3a4ee11bc1bbd5bd2da566e249b061301f2bfdaa6be02",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:60165",
+					"10.65.0.27:60165",
+					"172.17.0.1:60165",
+					"172.19.0.1:60165",
+					"172.20.0.1:60165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:43:52.890603684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8439668000907087,
+				"StableID":   "nk3PxVmLu821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c08416080a6c9552ffc92be47c6c4f5e2b1d1418bb2ccfc8caf9e6e851308c49",
+				"DiscoKey":   "discokey:62cf465a66dd2dc170d5f55b9c7d58c19043c23d146ef0439ce60174d3607635",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:41955",
+					"10.65.0.27:41955",
+					"172.17.0.1:41955",
+					"172.19.0.1:41955",
+					"172.20.0.1:41955"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:43:53.438761454Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6164595990854836,
+				"StableID":   "nF4b33Vx8q11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aed457da7acfd20741ce760b6f8537b5a34c7f177c75005997bdd6abc59b1426",
+				"DiscoKey":   "discokey:0665b448de8d2bedd6e200d1a3bb5a24c02f93aa0c2e83ad46eabe0377dfb34f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50956",
+					"10.65.0.27:50956",
+					"172.17.0.1:50956",
+					"172.19.0.1:50956",
+					"172.20.0.1:50956"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:43:53.967751349Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4585853824743584,
+				"StableID":   "njGVy1cwoc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f1910e9a909ee4006938458b2570a9e467e28ffb79d6e0ff8848232f3bfad0e",
+				"DiscoKey":   "discokey:262cdf71674ba5ff59d8a49efc5925c692fa96b7b681ba960fbff926fddca666",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38777",
+					"10.65.0.27:38777",
+					"172.17.0.1:38777",
+					"172.19.0.1:38777",
+					"172.20.0.1:38777"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:43:54.509987968Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5018486937441265,
+				"StableID":   "nczJfE9tBg11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3065e4e9e503f449b44ac4e25492f90744fe664e86e8a4d460565653032e1b44",
+				"KeyExpiry":  "2026-11-08T18:43:55Z",
+				"DiscoKey":   "discokey:d3dc0cd94529593de76ac7685c0f67d2d64732125d9dce89c844f4adb507e376",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:58752",
+					"10.65.0.27:58752",
+					"172.17.0.1:58752",
+					"172.19.0.1:58752",
+					"172.20.0.1:58752"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:43:55.059593996Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         3550521138286482,
+				"StableID":   "nXhWoqA3jU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d0a353f9cb159b426b1ca58230ca68e728c53589b40d3b3d8f2d9d192d194e42",
+				"KeyExpiry":  "2026-11-08T18:43:56Z",
+				"DiscoKey":   "discokey:7d3f9a784326feadb082ad78e148b42dad34d55b2bd68707af139d6e7d5f426e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44374",
+					"10.65.0.27:44374",
+					"172.17.0.1:44374",
+					"172.19.0.1:44374",
+					"172.20.0.1:44374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:43:56.09900279Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8439668000907087,
+				"StableID":   "nk3PxVmLu821CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       8439668000907087,
+				"Key":        "nodekey:c08416080a6c9552ffc92be47c6c4f5e2b1d1418bb2ccfc8caf9e6e851308c49",
+				"DiscoKey":   "discokey:62cf465a66dd2dc170d5f55b9c7d58c19043c23d146ef0439ce60174d3607635",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:41955",
+					"10.65.0.27:41955",
+					"172.17.0.1:41955",
+					"172.19.0.1:41955",
+					"172.20.0.1:41955"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:43:53.438761454Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c08416080a6c9552ffc92be47c6c4f5e2b1d1418bb2ccfc8caf9e6e851308c49",
+			"MachineKey": "mkey:e73d14af55ab8df81215b89d99a76162b138f373629070bf9bc713ad77f4ec13",
+			"Peers": [{
+				"ID":         6016328770506857,
+				"StableID":   "nGzyVnkoyo11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6eaa55db808f028c8d9926ec6f4ab78f8933e1ea37e03d268db81c5b302f3477",
+				"DiscoKey":   "discokey:50f417894fb269b4ba6254b3b861f524f90a0f9cbd0faeba9e90bf10fbd0d831",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:42805",
+					"10.65.0.27:42805",
+					"172.17.0.1:42805",
+					"172.19.0.1:42805",
+					"172.20.0.1:42805"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:43:48.593994629Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6154641129028053,
+				"StableID":   "nc8ezBzS4q11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4c4eb20dc31e9ad029147c86c17118d2d5b13292da76e126cb2ac800cddec809",
+				"DiscoKey":   "discokey:70c3a3dbcea00fb90a73b074f6a11a30b7136448a71a13ac6115f168a126c962",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:55489",
+					"10.65.0.27:55489",
+					"172.17.0.1:55489",
+					"172.19.0.1:55489",
+					"172.20.0.1:55489"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:43:49.143634273Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2527687880437997,
+				"StableID":   "n4vMLK5ojL11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5bc0a3e0c48383921a95eb735b271067d9be8d4ab74a449d3728b3e22c67a66",
+				"DiscoKey":   "discokey:851c4ea44b24069b6da2d95ba82c9be667abde4854499670615b23a713c6923d",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:52090",
+					"10.65.0.27:52090",
+					"172.17.0.1:52090",
+					"172.19.0.1:52090",
+					"172.20.0.1:52090"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:43:49.673410113Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6673481231443679,
+				"StableID":   "naaGA53S7u11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c5e09fb519d29ddc4ab74a92bb89d6a1089c7716b2588c1d69b47e912df2d00c",
+				"DiscoKey":   "discokey:f066bba19b8d1c13819293bed1f438ed9fc201ce2d70398bcd93ab998a08780e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:52398",
+					"10.65.0.27:52398",
+					"172.17.0.1:52398",
+					"172.19.0.1:52398",
+					"172.20.0.1:52398"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:43:50.204057843Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1103769185488624,
+				"StableID":   "njp1FQ9uc911CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:87d712ee21f73bf0ae15f1fcea2f0db88a8ded3bcdda829e1a6b035ea3a99a1b",
+				"DiscoKey":   "discokey:8e6d52a4152d9ba4957aff9afb54f1a3cc728a2428dc9f2e28da30144420c42b",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:37951",
+					"10.65.0.27:37951",
+					"172.17.0.1:37951",
+					"172.19.0.1:37951",
+					"172.20.0.1:37951"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:43:50.748458269Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7307005080874550,
+				"StableID":   "n1vLLidM4z11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6e9450ab4502100f374c42f7a01b088e7c5eb98beb4e623ea8bd16fb020f757",
+				"DiscoKey":   "discokey:c1820b018c93dca427b733d37e9b1648ac6dada69a1f08b72f3b52043051225d",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:39556",
+					"10.65.0.27:39556",
+					"172.17.0.1:39556",
+					"172.19.0.1:39556",
+					"172.20.0.1:39556"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:43:51.268603179Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3696077596774279,
+				"StableID":   "n6G2c5hxrV11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1bb90812675bb474bf4f2fd55b97ebf702ae289e00e852a2d2d5cf53099ee964",
+				"DiscoKey":   "discokey:ec62448c59384095cd368f18a8bccd1fb134fdab5fff974a7cfba3d690408433",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:40858",
+					"10.65.0.27:40858",
+					"172.17.0.1:40858",
+					"172.19.0.1:40858",
+					"172.20.0.1:40858"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:43:51.818935512Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2592773546433543,
+				"StableID":   "ngqDmLmGFM11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8f66db443c75af68c597ee14554e226b8b4c9ef896a1e46adacbe8b3c351d60",
+				"DiscoKey":   "discokey:ab0dd2b92d46a1422cf78b935feb4ebdddc4b3ec0b4bffed06a09a015fd19e0b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:49237",
+					"10.65.0.27:49237",
+					"172.17.0.1:49237",
+					"172.19.0.1:49237",
+					"172.20.0.1:49237"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:43:52.358461504Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2289847623990136,
+				"StableID":   "no4QK2R5tJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c541411b0f74586cd4f08014d118b608aa574404e1c9bca88ada47ef45749d4f",
+				"DiscoKey":   "discokey:d26ec9be1bedbe696ba3a4ee11bc1bbd5bd2da566e249b061301f2bfdaa6be02",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:60165",
+					"10.65.0.27:60165",
+					"172.17.0.1:60165",
+					"172.19.0.1:60165",
+					"172.20.0.1:60165"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:43:52.890603684Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6164595990854836,
+				"StableID":   "nF4b33Vx8q11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aed457da7acfd20741ce760b6f8537b5a34c7f177c75005997bdd6abc59b1426",
+				"DiscoKey":   "discokey:0665b448de8d2bedd6e200d1a3bb5a24c02f93aa0c2e83ad46eabe0377dfb34f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:50956",
+					"10.65.0.27:50956",
+					"172.17.0.1:50956",
+					"172.19.0.1:50956",
+					"172.20.0.1:50956"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:43:53.967751349Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4585853824743584,
+				"StableID":   "njGVy1cwoc11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f1910e9a909ee4006938458b2570a9e467e28ffb79d6e0ff8848232f3bfad0e",
+				"DiscoKey":   "discokey:262cdf71674ba5ff59d8a49efc5925c692fa96b7b681ba960fbff926fddca666",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:38777",
+					"10.65.0.27:38777",
+					"172.17.0.1:38777",
+					"172.19.0.1:38777",
+					"172.20.0.1:38777"
+				],
+				"HomeDERP": 8,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:43:54.509987968Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5018486937441265,
+				"StableID":   "nczJfE9tBg11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:3065e4e9e503f449b44ac4e25492f90744fe664e86e8a4d460565653032e1b44",
+				"KeyExpiry":  "2026-11-08T18:43:55Z",
+				"DiscoKey":   "discokey:d3dc0cd94529593de76ac7685c0f67d2d64732125d9dce89c844f4adb507e376",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:58752",
+					"10.65.0.27:58752",
+					"172.17.0.1:58752",
+					"172.19.0.1:58752",
+					"172.20.0.1:58752"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:43:55.059593996Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2213377979405502,
+				"StableID":   "nsTdgogSHJ11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ea2466fd4129f11b9eabe8bec10c68389d31023a9ffeceaf3a8ea906bfd99247",
+				"KeyExpiry":  "2026-11-08T18:43:55Z",
+				"DiscoKey":   "discokey:01064074e56764c74c67fe64b2e7b3247f3c094034aa7b9e9e243580624b9a52",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:33643",
+					"10.65.0.27:33643",
+					"172.17.0.1:33643",
+					"172.19.0.1:33643",
+					"172.20.0.1:33643"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:43:55.574256897Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         3550521138286482,
+				"StableID":   "nXhWoqA3jU11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:d0a353f9cb159b426b1ca58230ca68e728c53589b40d3b3d8f2d9d192d194e42",
+				"KeyExpiry":  "2026-11-08T18:43:56Z",
+				"DiscoKey":   "discokey:7d3f9a784326feadb082ad78e148b42dad34d55b2bd68707af139d6e7d5f426e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44374",
+					"10.65.0.27:44374",
+					"172.17.0.1:44374",
+					"172.19.0.1:44374",
+					"172.20.0.1:44374"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:43:56.09900279Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8439668000907087": {
+				"ID":          8439668000907087,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/sshtest_results/sshtest-malformed-dst-with-port.hujson
+++ b/hscontrol/policy/v2/testdata/sshtest_results/sshtest-malformed-dst-with-port.hujson
@@ -1,0 +1,20084 @@
+// sshtest-malformed-dst-with-port
+//
+// sshTests dst with :port must be rejected
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T18:44:32Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "sshtest-malformed-dst-with-port",
+	"description":    "sshTests dst with :port must be rejected",
+	"category":       "sshtest",
+	"captured_at":    "2026-05-12T18:44:32.087064854Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "SSH tests dst contains unknown tag \"tag:server:22\""},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                  \n  \n                                                                    \n                           \n{\n\t\"category\":    \"sshtest\",\n\t\"description\": \"sshTests dst with :port must be rejected\",\n\t\"id\":          \"sshtest-malformed-dst-with-port\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"thor@example.org\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"sshTests\": [{\n\t\t\"accept\": [\"root\"],\n\t\t\"dst\":    [\"tag:server:22\"],\n\t\t\"src\":    \"thor@example.org\"\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/sshtest/sshtest-malformed-dst-with-port.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["thor@example.org"],
+				"users":  ["root"]
+			}],
+			"sshTests": [
+				{"accept": ["root"], "dst": ["tag:server:22"], "src": "thor@example.org"}
+			],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2263680032413583,
+				"StableID":   "nGZfr53EgJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       2263680032413583,
+				"Key":        "nodekey:31ad38503e03d30c54d373657d306fd089975d3349635ece6f96eefb56554c11",
+				"DiscoKey":   "discokey:39f736677a6c328a030d8c9e5f2f2956f070f30828358274b20e206ac34f2026",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45681",
+					"10.65.0.27:45681",
+					"172.17.0.1:45681",
+					"172.19.0.1:45681",
+					"172.20.0.1:45681"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:44:40.568859801Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:31ad38503e03d30c54d373657d306fd089975d3349635ece6f96eefb56554c11",
+			"MachineKey": "mkey:c991d192a1b9a3296ceafd172fd28cd1dc58929840c526a58799fbc0d1c85963",
+			"Peers": [{
+				"ID":         4521942798795311,
+				"StableID":   "nGZuTdmzJc11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8e294a6e97850367b4f6c8c1e66ecdd2649ade6adb4b6362ff6824509106d52",
+				"DiscoKey":   "discokey:1056e0c149996e1badf91e52769c3b9c57c9110f19c326c4466992511dfe9060",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38395",
+					"10.65.0.27:38395",
+					"172.17.0.1:38395",
+					"172.19.0.1:38395",
+					"172.20.0.1:38395"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:44:34.657909588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7126116325607834,
+				"StableID":   "nRiPTYzRex11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:669e82a20f1fc7ae1c5905601fdc72876c9c3300a00c547263f9e15c420e6447",
+				"DiscoKey":   "discokey:cdba9faf688adeedfd9966cd667acd7d39a470560812c35c41517fbf7096ca3e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59149",
+					"10.65.0.27:59149",
+					"172.17.0.1:59149",
+					"172.19.0.1:59149",
+					"172.20.0.1:59149"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:44:35.189900261Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3561132190558232,
+				"StableID":   "nfa1ASuqoU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38c2d8d7b40a194c2c39d2a4bf2efdd8c514054788b2a42d8c140be3f4f1a646",
+				"DiscoKey":   "discokey:1585ebeda9a49f4efc8001634e21a9449ba88579bd67e817bab87560e2ad072e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34649",
+					"10.65.0.27:34649",
+					"172.17.0.1:34649",
+					"172.19.0.1:34649",
+					"172.20.0.1:34649"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:44:35.727266924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3153019650170486,
+				"StableID":   "n7hfUpU1dR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6920538458a19d646ef2b20151bbc9d477bff09c897e77fcc84fc7a524f39003",
+				"DiscoKey":   "discokey:cc1aafbd867faa68f2bda551528f20be72277ccec03b70d12ab6eb12c9828325",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55740",
+					"10.65.0.27:55740",
+					"172.17.0.1:55740",
+					"172.19.0.1:55740",
+					"172.20.0.1:55740"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:44:36.263222415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5501678073094238,
+				"StableID":   "noF4iikixj11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4703d7880c68845d5a45cdb1aac1c685d21e64bee5699fa7c40facbc30abd249",
+				"DiscoKey":   "discokey:104c24c3f13eb6fe7356dfa0031fc9e6485b65c29e9cf0bd3b0ba5ca4a650523",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:51946",
+					"10.65.0.27:51946",
+					"172.17.0.1:51946",
+					"172.19.0.1:51946",
+					"172.20.0.1:51946"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:44:36.829161674Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         538490739088266,
+				"StableID":   "njK2eqEtC511CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c41ea0844e70201d6075dc39609b0eca79362968e56767a71abb28ec65d4420a",
+				"DiscoKey":   "discokey:38119dbea36c9309935c384bfe8f650115f8914b6995080d152003456eb48039",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:34088",
+					"10.65.0.27:34088",
+					"172.17.0.1:34088",
+					"172.19.0.1:34088",
+					"172.20.0.1:34088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:44:37.329956683Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6253827107285692,
+				"StableID":   "nBYGF9SNqq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28d7d6489916ba1b6324abd3731f4c0244df1be9dbaf6f9cdcc1ec9278643907",
+				"DiscoKey":   "discokey:15c2eefbe7abb1c68061ffffe36c1ab7d74ffa00a9c5ef4664adf2572a1d2a34",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:36675",
+					"10.65.0.27:36675",
+					"172.17.0.1:36675",
+					"172.19.0.1:36675",
+					"172.20.0.1:36675"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:44:37.861204644Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2405435042157557,
+				"StableID":   "nk4ieahRnK11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:23e8d0ef02e79d38c91519ad7a13826220aed20a1a570d7f8f0cde14ebc58938",
+				"DiscoKey":   "discokey:a00c697b16f2aeb0a31ce057b2f17855749440dcdaf1376373668c082741294d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:35669",
+					"10.65.0.27:35669",
+					"172.17.0.1:35669",
+					"172.19.0.1:35669",
+					"172.20.0.1:35669"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:44:38.404131466Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3288427654510610,
+				"StableID":   "n1zy8GRLgS11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:320c694a094e80f650e89580de8c5500b0d33cd8724184cbfc75f104e94fce79",
+				"DiscoKey":   "discokey:224a233afc25468db3bec38f0a22d6a910571811b270c4a01814e88f419c4d0d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:55078",
+					"10.65.0.27:55078",
+					"172.17.0.1:55078",
+					"172.19.0.1:55078",
+					"172.20.0.1:55078"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:44:38.952553308Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5583262302296445,
+				"StableID":   "nADtfKqfbk11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b699270c9f48e704ff3138a5ee1752827d669f364b90547c96fe08b922626054",
+				"DiscoKey":   "discokey:98cffde6508929296dcd9bb5c9d1f41453e9b8f6e95dc579c1ec9063b7b36d31",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38285",
+					"10.65.0.27:38285",
+					"172.17.0.1:38285",
+					"172.19.0.1:38285",
+					"172.20.0.1:38285"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:44:39.491127718Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5511685850227220,
+				"StableID":   "nwAnhBeF3k11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:33522cbc22aea5361acba0c9b622254c3136708b98af10f8b2849b735fdc2c62",
+				"DiscoKey":   "discokey:5fb5dba31ec64463fb1665cb2d395ca2f8cd3b63b757aacebbb6577f57ba5c73",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41283",
+					"10.65.0.27:41283",
+					"172.17.0.1:41283",
+					"172.19.0.1:41283",
+					"172.20.0.1:41283"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:44:40.031967662Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5198346930574694,
+				"StableID":   "n5WRM2mLbh11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:db7354231d6c0052742b51942193133a12b208081c9654c20161815269588b41",
+				"KeyExpiry":  "2026-11-08T18:44:41Z",
+				"DiscoKey":   "discokey:cae61e363f12d435b12c92ccb738fd83507033f592c62e28d20f4fe879c2b45b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47369",
+					"10.65.0.27:47369",
+					"172.17.0.1:47369",
+					"172.19.0.1:47369",
+					"172.20.0.1:47369"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:44:41.120560002Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7025651806050733,
+				"StableID":   "ntgQtexvrw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:26af846559bfbca72813cb62f78d7d231e197f935d8a67c587a123d17d9a3736",
+				"KeyExpiry":  "2026-11-08T18:44:41Z",
+				"DiscoKey":   "discokey:3a6365e153185298635c4724c737ae80d1cca8e7e92539e1e57948f15af45c56",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:53922",
+					"10.65.0.27:53922",
+					"172.17.0.1:53922",
+					"172.19.0.1:53922",
+					"172.20.0.1:53922"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:44:41.645875081Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4581505740785207,
+				"StableID":   "n8RfgSPymc11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b5ec6926ed04532146458efadcb080333e243c136248e21b6f53c852e6169370",
+				"KeyExpiry":  "2026-11-08T18:44:42Z",
+				"DiscoKey":   "discokey:5de48bbeeacd1e2d716bae0031d9bf6a56a7e1f7bc7f95b50e5726094336e208",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47079",
+					"10.65.0.27:47079",
+					"172.17.0.1:47079",
+					"172.19.0.1:47079",
+					"172.20.0.1:47079"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:44:42.176139251Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2263680032413583": {
+				"ID":          2263680032413583,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         538490739088266,
+				"StableID":   "njK2eqEtC511CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       538490739088266,
+				"Key":        "nodekey:c41ea0844e70201d6075dc39609b0eca79362968e56767a71abb28ec65d4420a",
+				"DiscoKey":   "discokey:38119dbea36c9309935c384bfe8f650115f8914b6995080d152003456eb48039",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:34088",
+					"10.65.0.27:34088",
+					"172.17.0.1:34088",
+					"172.19.0.1:34088",
+					"172.20.0.1:34088"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:44:37.329956683Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c41ea0844e70201d6075dc39609b0eca79362968e56767a71abb28ec65d4420a",
+			"MachineKey": "mkey:fcdd45b76cf7d7afdd80a56b795bf895b686bea0ba9255d0ea4c1cd467d57e76",
+			"Peers": [{
+				"ID":         4521942798795311,
+				"StableID":   "nGZuTdmzJc11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8e294a6e97850367b4f6c8c1e66ecdd2649ade6adb4b6362ff6824509106d52",
+				"DiscoKey":   "discokey:1056e0c149996e1badf91e52769c3b9c57c9110f19c326c4466992511dfe9060",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38395",
+					"10.65.0.27:38395",
+					"172.17.0.1:38395",
+					"172.19.0.1:38395",
+					"172.20.0.1:38395"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:44:34.657909588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7126116325607834,
+				"StableID":   "nRiPTYzRex11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:669e82a20f1fc7ae1c5905601fdc72876c9c3300a00c547263f9e15c420e6447",
+				"DiscoKey":   "discokey:cdba9faf688adeedfd9966cd667acd7d39a470560812c35c41517fbf7096ca3e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59149",
+					"10.65.0.27:59149",
+					"172.17.0.1:59149",
+					"172.19.0.1:59149",
+					"172.20.0.1:59149"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:44:35.189900261Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3561132190558232,
+				"StableID":   "nfa1ASuqoU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38c2d8d7b40a194c2c39d2a4bf2efdd8c514054788b2a42d8c140be3f4f1a646",
+				"DiscoKey":   "discokey:1585ebeda9a49f4efc8001634e21a9449ba88579bd67e817bab87560e2ad072e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34649",
+					"10.65.0.27:34649",
+					"172.17.0.1:34649",
+					"172.19.0.1:34649",
+					"172.20.0.1:34649"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:44:35.727266924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3153019650170486,
+				"StableID":   "n7hfUpU1dR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6920538458a19d646ef2b20151bbc9d477bff09c897e77fcc84fc7a524f39003",
+				"DiscoKey":   "discokey:cc1aafbd867faa68f2bda551528f20be72277ccec03b70d12ab6eb12c9828325",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55740",
+					"10.65.0.27:55740",
+					"172.17.0.1:55740",
+					"172.19.0.1:55740",
+					"172.20.0.1:55740"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:44:36.263222415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5501678073094238,
+				"StableID":   "noF4iikixj11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4703d7880c68845d5a45cdb1aac1c685d21e64bee5699fa7c40facbc30abd249",
+				"DiscoKey":   "discokey:104c24c3f13eb6fe7356dfa0031fc9e6485b65c29e9cf0bd3b0ba5ca4a650523",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:51946",
+					"10.65.0.27:51946",
+					"172.17.0.1:51946",
+					"172.19.0.1:51946",
+					"172.20.0.1:51946"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:44:36.829161674Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6253827107285692,
+				"StableID":   "nBYGF9SNqq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28d7d6489916ba1b6324abd3731f4c0244df1be9dbaf6f9cdcc1ec9278643907",
+				"DiscoKey":   "discokey:15c2eefbe7abb1c68061ffffe36c1ab7d74ffa00a9c5ef4664adf2572a1d2a34",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:36675",
+					"10.65.0.27:36675",
+					"172.17.0.1:36675",
+					"172.19.0.1:36675",
+					"172.20.0.1:36675"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:44:37.861204644Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2405435042157557,
+				"StableID":   "nk4ieahRnK11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:23e8d0ef02e79d38c91519ad7a13826220aed20a1a570d7f8f0cde14ebc58938",
+				"DiscoKey":   "discokey:a00c697b16f2aeb0a31ce057b2f17855749440dcdaf1376373668c082741294d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:35669",
+					"10.65.0.27:35669",
+					"172.17.0.1:35669",
+					"172.19.0.1:35669",
+					"172.20.0.1:35669"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:44:38.404131466Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3288427654510610,
+				"StableID":   "n1zy8GRLgS11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:320c694a094e80f650e89580de8c5500b0d33cd8724184cbfc75f104e94fce79",
+				"DiscoKey":   "discokey:224a233afc25468db3bec38f0a22d6a910571811b270c4a01814e88f419c4d0d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:55078",
+					"10.65.0.27:55078",
+					"172.17.0.1:55078",
+					"172.19.0.1:55078",
+					"172.20.0.1:55078"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:44:38.952553308Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5583262302296445,
+				"StableID":   "nADtfKqfbk11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b699270c9f48e704ff3138a5ee1752827d669f364b90547c96fe08b922626054",
+				"DiscoKey":   "discokey:98cffde6508929296dcd9bb5c9d1f41453e9b8f6e95dc579c1ec9063b7b36d31",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38285",
+					"10.65.0.27:38285",
+					"172.17.0.1:38285",
+					"172.19.0.1:38285",
+					"172.20.0.1:38285"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:44:39.491127718Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5511685850227220,
+				"StableID":   "nwAnhBeF3k11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:33522cbc22aea5361acba0c9b622254c3136708b98af10f8b2849b735fdc2c62",
+				"DiscoKey":   "discokey:5fb5dba31ec64463fb1665cb2d395ca2f8cd3b63b757aacebbb6577f57ba5c73",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41283",
+					"10.65.0.27:41283",
+					"172.17.0.1:41283",
+					"172.19.0.1:41283",
+					"172.20.0.1:41283"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:44:40.031967662Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2263680032413583,
+				"StableID":   "nGZfr53EgJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31ad38503e03d30c54d373657d306fd089975d3349635ece6f96eefb56554c11",
+				"DiscoKey":   "discokey:39f736677a6c328a030d8c9e5f2f2956f070f30828358274b20e206ac34f2026",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45681",
+					"10.65.0.27:45681",
+					"172.17.0.1:45681",
+					"172.19.0.1:45681",
+					"172.20.0.1:45681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:44:40.568859801Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5198346930574694,
+				"StableID":   "n5WRM2mLbh11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:db7354231d6c0052742b51942193133a12b208081c9654c20161815269588b41",
+				"KeyExpiry":  "2026-11-08T18:44:41Z",
+				"DiscoKey":   "discokey:cae61e363f12d435b12c92ccb738fd83507033f592c62e28d20f4fe879c2b45b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47369",
+					"10.65.0.27:47369",
+					"172.17.0.1:47369",
+					"172.19.0.1:47369",
+					"172.20.0.1:47369"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:44:41.120560002Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7025651806050733,
+				"StableID":   "ntgQtexvrw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:26af846559bfbca72813cb62f78d7d231e197f935d8a67c587a123d17d9a3736",
+				"KeyExpiry":  "2026-11-08T18:44:41Z",
+				"DiscoKey":   "discokey:3a6365e153185298635c4724c737ae80d1cca8e7e92539e1e57948f15af45c56",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:53922",
+					"10.65.0.27:53922",
+					"172.17.0.1:53922",
+					"172.19.0.1:53922",
+					"172.20.0.1:53922"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:44:41.645875081Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4581505740785207,
+				"StableID":   "n8RfgSPymc11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b5ec6926ed04532146458efadcb080333e243c136248e21b6f53c852e6169370",
+				"KeyExpiry":  "2026-11-08T18:44:42Z",
+				"DiscoKey":   "discokey:5de48bbeeacd1e2d716bae0031d9bf6a56a7e1f7bc7f95b50e5726094336e208",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47079",
+					"10.65.0.27:47079",
+					"172.17.0.1:47079",
+					"172.19.0.1:47079",
+					"172.20.0.1:47079"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:44:42.176139251Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "538490739088266": {
+				"ID":          538490739088266,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4581505740785207,
+				"StableID":   "n8RfgSPymc11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b5ec6926ed04532146458efadcb080333e243c136248e21b6f53c852e6169370",
+				"KeyExpiry":  "2026-11-08T18:44:42Z",
+				"DiscoKey":   "discokey:5de48bbeeacd1e2d716bae0031d9bf6a56a7e1f7bc7f95b50e5726094336e208",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47079",
+					"10.65.0.27:47079",
+					"172.17.0.1:47079",
+					"172.19.0.1:47079",
+					"172.20.0.1:47079"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:44:42.176139251Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b5ec6926ed04532146458efadcb080333e243c136248e21b6f53c852e6169370",
+			"MachineKey": "mkey:3b452ab5de7436791c3505f86e5d43953043268a3dfc7d5f3169592df22eb33d",
+			"Peers": [{
+				"ID":         4521942798795311,
+				"StableID":   "nGZuTdmzJc11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8e294a6e97850367b4f6c8c1e66ecdd2649ade6adb4b6362ff6824509106d52",
+				"DiscoKey":   "discokey:1056e0c149996e1badf91e52769c3b9c57c9110f19c326c4466992511dfe9060",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38395",
+					"10.65.0.27:38395",
+					"172.17.0.1:38395",
+					"172.19.0.1:38395",
+					"172.20.0.1:38395"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:44:34.657909588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7126116325607834,
+				"StableID":   "nRiPTYzRex11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:669e82a20f1fc7ae1c5905601fdc72876c9c3300a00c547263f9e15c420e6447",
+				"DiscoKey":   "discokey:cdba9faf688adeedfd9966cd667acd7d39a470560812c35c41517fbf7096ca3e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59149",
+					"10.65.0.27:59149",
+					"172.17.0.1:59149",
+					"172.19.0.1:59149",
+					"172.20.0.1:59149"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:44:35.189900261Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3561132190558232,
+				"StableID":   "nfa1ASuqoU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38c2d8d7b40a194c2c39d2a4bf2efdd8c514054788b2a42d8c140be3f4f1a646",
+				"DiscoKey":   "discokey:1585ebeda9a49f4efc8001634e21a9449ba88579bd67e817bab87560e2ad072e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34649",
+					"10.65.0.27:34649",
+					"172.17.0.1:34649",
+					"172.19.0.1:34649",
+					"172.20.0.1:34649"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:44:35.727266924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3153019650170486,
+				"StableID":   "n7hfUpU1dR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6920538458a19d646ef2b20151bbc9d477bff09c897e77fcc84fc7a524f39003",
+				"DiscoKey":   "discokey:cc1aafbd867faa68f2bda551528f20be72277ccec03b70d12ab6eb12c9828325",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55740",
+					"10.65.0.27:55740",
+					"172.17.0.1:55740",
+					"172.19.0.1:55740",
+					"172.20.0.1:55740"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:44:36.263222415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5501678073094238,
+				"StableID":   "noF4iikixj11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4703d7880c68845d5a45cdb1aac1c685d21e64bee5699fa7c40facbc30abd249",
+				"DiscoKey":   "discokey:104c24c3f13eb6fe7356dfa0031fc9e6485b65c29e9cf0bd3b0ba5ca4a650523",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:51946",
+					"10.65.0.27:51946",
+					"172.17.0.1:51946",
+					"172.19.0.1:51946",
+					"172.20.0.1:51946"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:44:36.829161674Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         538490739088266,
+				"StableID":   "njK2eqEtC511CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c41ea0844e70201d6075dc39609b0eca79362968e56767a71abb28ec65d4420a",
+				"DiscoKey":   "discokey:38119dbea36c9309935c384bfe8f650115f8914b6995080d152003456eb48039",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:34088",
+					"10.65.0.27:34088",
+					"172.17.0.1:34088",
+					"172.19.0.1:34088",
+					"172.20.0.1:34088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:44:37.329956683Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6253827107285692,
+				"StableID":   "nBYGF9SNqq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28d7d6489916ba1b6324abd3731f4c0244df1be9dbaf6f9cdcc1ec9278643907",
+				"DiscoKey":   "discokey:15c2eefbe7abb1c68061ffffe36c1ab7d74ffa00a9c5ef4664adf2572a1d2a34",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:36675",
+					"10.65.0.27:36675",
+					"172.17.0.1:36675",
+					"172.19.0.1:36675",
+					"172.20.0.1:36675"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:44:37.861204644Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2405435042157557,
+				"StableID":   "nk4ieahRnK11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:23e8d0ef02e79d38c91519ad7a13826220aed20a1a570d7f8f0cde14ebc58938",
+				"DiscoKey":   "discokey:a00c697b16f2aeb0a31ce057b2f17855749440dcdaf1376373668c082741294d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:35669",
+					"10.65.0.27:35669",
+					"172.17.0.1:35669",
+					"172.19.0.1:35669",
+					"172.20.0.1:35669"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:44:38.404131466Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3288427654510610,
+				"StableID":   "n1zy8GRLgS11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:320c694a094e80f650e89580de8c5500b0d33cd8724184cbfc75f104e94fce79",
+				"DiscoKey":   "discokey:224a233afc25468db3bec38f0a22d6a910571811b270c4a01814e88f419c4d0d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:55078",
+					"10.65.0.27:55078",
+					"172.17.0.1:55078",
+					"172.19.0.1:55078",
+					"172.20.0.1:55078"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:44:38.952553308Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5583262302296445,
+				"StableID":   "nADtfKqfbk11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b699270c9f48e704ff3138a5ee1752827d669f364b90547c96fe08b922626054",
+				"DiscoKey":   "discokey:98cffde6508929296dcd9bb5c9d1f41453e9b8f6e95dc579c1ec9063b7b36d31",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38285",
+					"10.65.0.27:38285",
+					"172.17.0.1:38285",
+					"172.19.0.1:38285",
+					"172.20.0.1:38285"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:44:39.491127718Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5511685850227220,
+				"StableID":   "nwAnhBeF3k11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:33522cbc22aea5361acba0c9b622254c3136708b98af10f8b2849b735fdc2c62",
+				"DiscoKey":   "discokey:5fb5dba31ec64463fb1665cb2d395ca2f8cd3b63b757aacebbb6577f57ba5c73",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41283",
+					"10.65.0.27:41283",
+					"172.17.0.1:41283",
+					"172.19.0.1:41283",
+					"172.20.0.1:41283"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:44:40.031967662Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2263680032413583,
+				"StableID":   "nGZfr53EgJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31ad38503e03d30c54d373657d306fd089975d3349635ece6f96eefb56554c11",
+				"DiscoKey":   "discokey:39f736677a6c328a030d8c9e5f2f2956f070f30828358274b20e206ac34f2026",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45681",
+					"10.65.0.27:45681",
+					"172.17.0.1:45681",
+					"172.19.0.1:45681",
+					"172.20.0.1:45681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:44:40.568859801Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5198346930574694,
+				"StableID":   "n5WRM2mLbh11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:db7354231d6c0052742b51942193133a12b208081c9654c20161815269588b41",
+				"KeyExpiry":  "2026-11-08T18:44:41Z",
+				"DiscoKey":   "discokey:cae61e363f12d435b12c92ccb738fd83507033f592c62e28d20f4fe879c2b45b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47369",
+					"10.65.0.27:47369",
+					"172.17.0.1:47369",
+					"172.19.0.1:47369",
+					"172.20.0.1:47369"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:44:41.120560002Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7025651806050733,
+				"StableID":   "ntgQtexvrw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:26af846559bfbca72813cb62f78d7d231e197f935d8a67c587a123d17d9a3736",
+				"KeyExpiry":  "2026-11-08T18:44:41Z",
+				"DiscoKey":   "discokey:3a6365e153185298635c4724c737ae80d1cca8e7e92539e1e57948f15af45c56",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:53922",
+					"10.65.0.27:53922",
+					"172.17.0.1:53922",
+					"172.19.0.1:53922",
+					"172.20.0.1:53922"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:44:41.645875081Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3561132190558232,
+				"StableID":   "nfa1ASuqoU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       3561132190558232,
+				"Key":        "nodekey:38c2d8d7b40a194c2c39d2a4bf2efdd8c514054788b2a42d8c140be3f4f1a646",
+				"DiscoKey":   "discokey:1585ebeda9a49f4efc8001634e21a9449ba88579bd67e817bab87560e2ad072e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34649",
+					"10.65.0.27:34649",
+					"172.17.0.1:34649",
+					"172.19.0.1:34649",
+					"172.20.0.1:34649"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:44:35.727266924Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:38c2d8d7b40a194c2c39d2a4bf2efdd8c514054788b2a42d8c140be3f4f1a646",
+			"MachineKey": "mkey:120e4adb081a31061e3434be2cd072530d7b003ad18877dbbfa7ecb11f92113a",
+			"Peers": [{
+				"ID":         4521942798795311,
+				"StableID":   "nGZuTdmzJc11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8e294a6e97850367b4f6c8c1e66ecdd2649ade6adb4b6362ff6824509106d52",
+				"DiscoKey":   "discokey:1056e0c149996e1badf91e52769c3b9c57c9110f19c326c4466992511dfe9060",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38395",
+					"10.65.0.27:38395",
+					"172.17.0.1:38395",
+					"172.19.0.1:38395",
+					"172.20.0.1:38395"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:44:34.657909588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7126116325607834,
+				"StableID":   "nRiPTYzRex11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:669e82a20f1fc7ae1c5905601fdc72876c9c3300a00c547263f9e15c420e6447",
+				"DiscoKey":   "discokey:cdba9faf688adeedfd9966cd667acd7d39a470560812c35c41517fbf7096ca3e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59149",
+					"10.65.0.27:59149",
+					"172.17.0.1:59149",
+					"172.19.0.1:59149",
+					"172.20.0.1:59149"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:44:35.189900261Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3153019650170486,
+				"StableID":   "n7hfUpU1dR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6920538458a19d646ef2b20151bbc9d477bff09c897e77fcc84fc7a524f39003",
+				"DiscoKey":   "discokey:cc1aafbd867faa68f2bda551528f20be72277ccec03b70d12ab6eb12c9828325",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55740",
+					"10.65.0.27:55740",
+					"172.17.0.1:55740",
+					"172.19.0.1:55740",
+					"172.20.0.1:55740"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:44:36.263222415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5501678073094238,
+				"StableID":   "noF4iikixj11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4703d7880c68845d5a45cdb1aac1c685d21e64bee5699fa7c40facbc30abd249",
+				"DiscoKey":   "discokey:104c24c3f13eb6fe7356dfa0031fc9e6485b65c29e9cf0bd3b0ba5ca4a650523",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:51946",
+					"10.65.0.27:51946",
+					"172.17.0.1:51946",
+					"172.19.0.1:51946",
+					"172.20.0.1:51946"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:44:36.829161674Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         538490739088266,
+				"StableID":   "njK2eqEtC511CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c41ea0844e70201d6075dc39609b0eca79362968e56767a71abb28ec65d4420a",
+				"DiscoKey":   "discokey:38119dbea36c9309935c384bfe8f650115f8914b6995080d152003456eb48039",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:34088",
+					"10.65.0.27:34088",
+					"172.17.0.1:34088",
+					"172.19.0.1:34088",
+					"172.20.0.1:34088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:44:37.329956683Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6253827107285692,
+				"StableID":   "nBYGF9SNqq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28d7d6489916ba1b6324abd3731f4c0244df1be9dbaf6f9cdcc1ec9278643907",
+				"DiscoKey":   "discokey:15c2eefbe7abb1c68061ffffe36c1ab7d74ffa00a9c5ef4664adf2572a1d2a34",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:36675",
+					"10.65.0.27:36675",
+					"172.17.0.1:36675",
+					"172.19.0.1:36675",
+					"172.20.0.1:36675"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:44:37.861204644Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2405435042157557,
+				"StableID":   "nk4ieahRnK11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:23e8d0ef02e79d38c91519ad7a13826220aed20a1a570d7f8f0cde14ebc58938",
+				"DiscoKey":   "discokey:a00c697b16f2aeb0a31ce057b2f17855749440dcdaf1376373668c082741294d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:35669",
+					"10.65.0.27:35669",
+					"172.17.0.1:35669",
+					"172.19.0.1:35669",
+					"172.20.0.1:35669"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:44:38.404131466Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3288427654510610,
+				"StableID":   "n1zy8GRLgS11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:320c694a094e80f650e89580de8c5500b0d33cd8724184cbfc75f104e94fce79",
+				"DiscoKey":   "discokey:224a233afc25468db3bec38f0a22d6a910571811b270c4a01814e88f419c4d0d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:55078",
+					"10.65.0.27:55078",
+					"172.17.0.1:55078",
+					"172.19.0.1:55078",
+					"172.20.0.1:55078"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:44:38.952553308Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5583262302296445,
+				"StableID":   "nADtfKqfbk11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b699270c9f48e704ff3138a5ee1752827d669f364b90547c96fe08b922626054",
+				"DiscoKey":   "discokey:98cffde6508929296dcd9bb5c9d1f41453e9b8f6e95dc579c1ec9063b7b36d31",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38285",
+					"10.65.0.27:38285",
+					"172.17.0.1:38285",
+					"172.19.0.1:38285",
+					"172.20.0.1:38285"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:44:39.491127718Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5511685850227220,
+				"StableID":   "nwAnhBeF3k11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:33522cbc22aea5361acba0c9b622254c3136708b98af10f8b2849b735fdc2c62",
+				"DiscoKey":   "discokey:5fb5dba31ec64463fb1665cb2d395ca2f8cd3b63b757aacebbb6577f57ba5c73",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41283",
+					"10.65.0.27:41283",
+					"172.17.0.1:41283",
+					"172.19.0.1:41283",
+					"172.20.0.1:41283"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:44:40.031967662Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2263680032413583,
+				"StableID":   "nGZfr53EgJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31ad38503e03d30c54d373657d306fd089975d3349635ece6f96eefb56554c11",
+				"DiscoKey":   "discokey:39f736677a6c328a030d8c9e5f2f2956f070f30828358274b20e206ac34f2026",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45681",
+					"10.65.0.27:45681",
+					"172.17.0.1:45681",
+					"172.19.0.1:45681",
+					"172.20.0.1:45681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:44:40.568859801Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5198346930574694,
+				"StableID":   "n5WRM2mLbh11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:db7354231d6c0052742b51942193133a12b208081c9654c20161815269588b41",
+				"KeyExpiry":  "2026-11-08T18:44:41Z",
+				"DiscoKey":   "discokey:cae61e363f12d435b12c92ccb738fd83507033f592c62e28d20f4fe879c2b45b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47369",
+					"10.65.0.27:47369",
+					"172.17.0.1:47369",
+					"172.19.0.1:47369",
+					"172.20.0.1:47369"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:44:41.120560002Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7025651806050733,
+				"StableID":   "ntgQtexvrw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:26af846559bfbca72813cb62f78d7d231e197f935d8a67c587a123d17d9a3736",
+				"KeyExpiry":  "2026-11-08T18:44:41Z",
+				"DiscoKey":   "discokey:3a6365e153185298635c4724c737ae80d1cca8e7e92539e1e57948f15af45c56",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:53922",
+					"10.65.0.27:53922",
+					"172.17.0.1:53922",
+					"172.19.0.1:53922",
+					"172.20.0.1:53922"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:44:41.645875081Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4581505740785207,
+				"StableID":   "n8RfgSPymc11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b5ec6926ed04532146458efadcb080333e243c136248e21b6f53c852e6169370",
+				"KeyExpiry":  "2026-11-08T18:44:42Z",
+				"DiscoKey":   "discokey:5de48bbeeacd1e2d716bae0031d9bf6a56a7e1f7bc7f95b50e5726094336e208",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47079",
+					"10.65.0.27:47079",
+					"172.17.0.1:47079",
+					"172.19.0.1:47079",
+					"172.20.0.1:47079"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:44:42.176139251Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3561132190558232": {
+				"ID":          3561132190558232,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2405435042157557,
+				"StableID":   "nk4ieahRnK11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       2405435042157557,
+				"Key":        "nodekey:23e8d0ef02e79d38c91519ad7a13826220aed20a1a570d7f8f0cde14ebc58938",
+				"DiscoKey":   "discokey:a00c697b16f2aeb0a31ce057b2f17855749440dcdaf1376373668c082741294d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:35669",
+					"10.65.0.27:35669",
+					"172.17.0.1:35669",
+					"172.19.0.1:35669",
+					"172.20.0.1:35669"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:44:38.404131466Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:23e8d0ef02e79d38c91519ad7a13826220aed20a1a570d7f8f0cde14ebc58938",
+			"MachineKey": "mkey:381d544aaf072ffda448eb8c49545e3f05cbca3b68f4567e0b1935f4d225b820",
+			"Peers": [{
+				"ID":         4521942798795311,
+				"StableID":   "nGZuTdmzJc11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8e294a6e97850367b4f6c8c1e66ecdd2649ade6adb4b6362ff6824509106d52",
+				"DiscoKey":   "discokey:1056e0c149996e1badf91e52769c3b9c57c9110f19c326c4466992511dfe9060",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38395",
+					"10.65.0.27:38395",
+					"172.17.0.1:38395",
+					"172.19.0.1:38395",
+					"172.20.0.1:38395"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:44:34.657909588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7126116325607834,
+				"StableID":   "nRiPTYzRex11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:669e82a20f1fc7ae1c5905601fdc72876c9c3300a00c547263f9e15c420e6447",
+				"DiscoKey":   "discokey:cdba9faf688adeedfd9966cd667acd7d39a470560812c35c41517fbf7096ca3e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59149",
+					"10.65.0.27:59149",
+					"172.17.0.1:59149",
+					"172.19.0.1:59149",
+					"172.20.0.1:59149"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:44:35.189900261Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3561132190558232,
+				"StableID":   "nfa1ASuqoU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38c2d8d7b40a194c2c39d2a4bf2efdd8c514054788b2a42d8c140be3f4f1a646",
+				"DiscoKey":   "discokey:1585ebeda9a49f4efc8001634e21a9449ba88579bd67e817bab87560e2ad072e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34649",
+					"10.65.0.27:34649",
+					"172.17.0.1:34649",
+					"172.19.0.1:34649",
+					"172.20.0.1:34649"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:44:35.727266924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3153019650170486,
+				"StableID":   "n7hfUpU1dR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6920538458a19d646ef2b20151bbc9d477bff09c897e77fcc84fc7a524f39003",
+				"DiscoKey":   "discokey:cc1aafbd867faa68f2bda551528f20be72277ccec03b70d12ab6eb12c9828325",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55740",
+					"10.65.0.27:55740",
+					"172.17.0.1:55740",
+					"172.19.0.1:55740",
+					"172.20.0.1:55740"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:44:36.263222415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5501678073094238,
+				"StableID":   "noF4iikixj11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4703d7880c68845d5a45cdb1aac1c685d21e64bee5699fa7c40facbc30abd249",
+				"DiscoKey":   "discokey:104c24c3f13eb6fe7356dfa0031fc9e6485b65c29e9cf0bd3b0ba5ca4a650523",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:51946",
+					"10.65.0.27:51946",
+					"172.17.0.1:51946",
+					"172.19.0.1:51946",
+					"172.20.0.1:51946"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:44:36.829161674Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         538490739088266,
+				"StableID":   "njK2eqEtC511CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c41ea0844e70201d6075dc39609b0eca79362968e56767a71abb28ec65d4420a",
+				"DiscoKey":   "discokey:38119dbea36c9309935c384bfe8f650115f8914b6995080d152003456eb48039",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:34088",
+					"10.65.0.27:34088",
+					"172.17.0.1:34088",
+					"172.19.0.1:34088",
+					"172.20.0.1:34088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:44:37.329956683Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6253827107285692,
+				"StableID":   "nBYGF9SNqq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28d7d6489916ba1b6324abd3731f4c0244df1be9dbaf6f9cdcc1ec9278643907",
+				"DiscoKey":   "discokey:15c2eefbe7abb1c68061ffffe36c1ab7d74ffa00a9c5ef4664adf2572a1d2a34",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:36675",
+					"10.65.0.27:36675",
+					"172.17.0.1:36675",
+					"172.19.0.1:36675",
+					"172.20.0.1:36675"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:44:37.861204644Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3288427654510610,
+				"StableID":   "n1zy8GRLgS11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:320c694a094e80f650e89580de8c5500b0d33cd8724184cbfc75f104e94fce79",
+				"DiscoKey":   "discokey:224a233afc25468db3bec38f0a22d6a910571811b270c4a01814e88f419c4d0d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:55078",
+					"10.65.0.27:55078",
+					"172.17.0.1:55078",
+					"172.19.0.1:55078",
+					"172.20.0.1:55078"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:44:38.952553308Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5583262302296445,
+				"StableID":   "nADtfKqfbk11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b699270c9f48e704ff3138a5ee1752827d669f364b90547c96fe08b922626054",
+				"DiscoKey":   "discokey:98cffde6508929296dcd9bb5c9d1f41453e9b8f6e95dc579c1ec9063b7b36d31",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38285",
+					"10.65.0.27:38285",
+					"172.17.0.1:38285",
+					"172.19.0.1:38285",
+					"172.20.0.1:38285"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:44:39.491127718Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5511685850227220,
+				"StableID":   "nwAnhBeF3k11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:33522cbc22aea5361acba0c9b622254c3136708b98af10f8b2849b735fdc2c62",
+				"DiscoKey":   "discokey:5fb5dba31ec64463fb1665cb2d395ca2f8cd3b63b757aacebbb6577f57ba5c73",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41283",
+					"10.65.0.27:41283",
+					"172.17.0.1:41283",
+					"172.19.0.1:41283",
+					"172.20.0.1:41283"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:44:40.031967662Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2263680032413583,
+				"StableID":   "nGZfr53EgJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31ad38503e03d30c54d373657d306fd089975d3349635ece6f96eefb56554c11",
+				"DiscoKey":   "discokey:39f736677a6c328a030d8c9e5f2f2956f070f30828358274b20e206ac34f2026",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45681",
+					"10.65.0.27:45681",
+					"172.17.0.1:45681",
+					"172.19.0.1:45681",
+					"172.20.0.1:45681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:44:40.568859801Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5198346930574694,
+				"StableID":   "n5WRM2mLbh11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:db7354231d6c0052742b51942193133a12b208081c9654c20161815269588b41",
+				"KeyExpiry":  "2026-11-08T18:44:41Z",
+				"DiscoKey":   "discokey:cae61e363f12d435b12c92ccb738fd83507033f592c62e28d20f4fe879c2b45b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47369",
+					"10.65.0.27:47369",
+					"172.17.0.1:47369",
+					"172.19.0.1:47369",
+					"172.20.0.1:47369"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:44:41.120560002Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7025651806050733,
+				"StableID":   "ntgQtexvrw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:26af846559bfbca72813cb62f78d7d231e197f935d8a67c587a123d17d9a3736",
+				"KeyExpiry":  "2026-11-08T18:44:41Z",
+				"DiscoKey":   "discokey:3a6365e153185298635c4724c737ae80d1cca8e7e92539e1e57948f15af45c56",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:53922",
+					"10.65.0.27:53922",
+					"172.17.0.1:53922",
+					"172.19.0.1:53922",
+					"172.20.0.1:53922"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:44:41.645875081Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4581505740785207,
+				"StableID":   "n8RfgSPymc11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b5ec6926ed04532146458efadcb080333e243c136248e21b6f53c852e6169370",
+				"KeyExpiry":  "2026-11-08T18:44:42Z",
+				"DiscoKey":   "discokey:5de48bbeeacd1e2d716bae0031d9bf6a56a7e1f7bc7f95b50e5726094336e208",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47079",
+					"10.65.0.27:47079",
+					"172.17.0.1:47079",
+					"172.19.0.1:47079",
+					"172.20.0.1:47079"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:44:42.176139251Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2405435042157557": {
+				"ID":          2405435042157557,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5198346930574694,
+				"StableID":   "n5WRM2mLbh11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:db7354231d6c0052742b51942193133a12b208081c9654c20161815269588b41",
+				"KeyExpiry":  "2026-11-08T18:44:41Z",
+				"DiscoKey":   "discokey:cae61e363f12d435b12c92ccb738fd83507033f592c62e28d20f4fe879c2b45b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47369",
+					"10.65.0.27:47369",
+					"172.17.0.1:47369",
+					"172.19.0.1:47369",
+					"172.20.0.1:47369"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:44:41.120560002Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:db7354231d6c0052742b51942193133a12b208081c9654c20161815269588b41",
+			"MachineKey": "mkey:9f947f66a8954fe1f00c7604678f38920653f800e856a0eefc82daeda1a94424",
+			"Peers": [{
+				"ID":         4521942798795311,
+				"StableID":   "nGZuTdmzJc11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8e294a6e97850367b4f6c8c1e66ecdd2649ade6adb4b6362ff6824509106d52",
+				"DiscoKey":   "discokey:1056e0c149996e1badf91e52769c3b9c57c9110f19c326c4466992511dfe9060",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38395",
+					"10.65.0.27:38395",
+					"172.17.0.1:38395",
+					"172.19.0.1:38395",
+					"172.20.0.1:38395"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:44:34.657909588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7126116325607834,
+				"StableID":   "nRiPTYzRex11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:669e82a20f1fc7ae1c5905601fdc72876c9c3300a00c547263f9e15c420e6447",
+				"DiscoKey":   "discokey:cdba9faf688adeedfd9966cd667acd7d39a470560812c35c41517fbf7096ca3e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59149",
+					"10.65.0.27:59149",
+					"172.17.0.1:59149",
+					"172.19.0.1:59149",
+					"172.20.0.1:59149"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:44:35.189900261Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3561132190558232,
+				"StableID":   "nfa1ASuqoU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38c2d8d7b40a194c2c39d2a4bf2efdd8c514054788b2a42d8c140be3f4f1a646",
+				"DiscoKey":   "discokey:1585ebeda9a49f4efc8001634e21a9449ba88579bd67e817bab87560e2ad072e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34649",
+					"10.65.0.27:34649",
+					"172.17.0.1:34649",
+					"172.19.0.1:34649",
+					"172.20.0.1:34649"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:44:35.727266924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3153019650170486,
+				"StableID":   "n7hfUpU1dR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6920538458a19d646ef2b20151bbc9d477bff09c897e77fcc84fc7a524f39003",
+				"DiscoKey":   "discokey:cc1aafbd867faa68f2bda551528f20be72277ccec03b70d12ab6eb12c9828325",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55740",
+					"10.65.0.27:55740",
+					"172.17.0.1:55740",
+					"172.19.0.1:55740",
+					"172.20.0.1:55740"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:44:36.263222415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5501678073094238,
+				"StableID":   "noF4iikixj11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4703d7880c68845d5a45cdb1aac1c685d21e64bee5699fa7c40facbc30abd249",
+				"DiscoKey":   "discokey:104c24c3f13eb6fe7356dfa0031fc9e6485b65c29e9cf0bd3b0ba5ca4a650523",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:51946",
+					"10.65.0.27:51946",
+					"172.17.0.1:51946",
+					"172.19.0.1:51946",
+					"172.20.0.1:51946"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:44:36.829161674Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         538490739088266,
+				"StableID":   "njK2eqEtC511CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c41ea0844e70201d6075dc39609b0eca79362968e56767a71abb28ec65d4420a",
+				"DiscoKey":   "discokey:38119dbea36c9309935c384bfe8f650115f8914b6995080d152003456eb48039",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:34088",
+					"10.65.0.27:34088",
+					"172.17.0.1:34088",
+					"172.19.0.1:34088",
+					"172.20.0.1:34088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:44:37.329956683Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6253827107285692,
+				"StableID":   "nBYGF9SNqq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28d7d6489916ba1b6324abd3731f4c0244df1be9dbaf6f9cdcc1ec9278643907",
+				"DiscoKey":   "discokey:15c2eefbe7abb1c68061ffffe36c1ab7d74ffa00a9c5ef4664adf2572a1d2a34",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:36675",
+					"10.65.0.27:36675",
+					"172.17.0.1:36675",
+					"172.19.0.1:36675",
+					"172.20.0.1:36675"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:44:37.861204644Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2405435042157557,
+				"StableID":   "nk4ieahRnK11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:23e8d0ef02e79d38c91519ad7a13826220aed20a1a570d7f8f0cde14ebc58938",
+				"DiscoKey":   "discokey:a00c697b16f2aeb0a31ce057b2f17855749440dcdaf1376373668c082741294d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:35669",
+					"10.65.0.27:35669",
+					"172.17.0.1:35669",
+					"172.19.0.1:35669",
+					"172.20.0.1:35669"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:44:38.404131466Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3288427654510610,
+				"StableID":   "n1zy8GRLgS11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:320c694a094e80f650e89580de8c5500b0d33cd8724184cbfc75f104e94fce79",
+				"DiscoKey":   "discokey:224a233afc25468db3bec38f0a22d6a910571811b270c4a01814e88f419c4d0d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:55078",
+					"10.65.0.27:55078",
+					"172.17.0.1:55078",
+					"172.19.0.1:55078",
+					"172.20.0.1:55078"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:44:38.952553308Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5583262302296445,
+				"StableID":   "nADtfKqfbk11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b699270c9f48e704ff3138a5ee1752827d669f364b90547c96fe08b922626054",
+				"DiscoKey":   "discokey:98cffde6508929296dcd9bb5c9d1f41453e9b8f6e95dc579c1ec9063b7b36d31",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38285",
+					"10.65.0.27:38285",
+					"172.17.0.1:38285",
+					"172.19.0.1:38285",
+					"172.20.0.1:38285"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:44:39.491127718Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5511685850227220,
+				"StableID":   "nwAnhBeF3k11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:33522cbc22aea5361acba0c9b622254c3136708b98af10f8b2849b735fdc2c62",
+				"DiscoKey":   "discokey:5fb5dba31ec64463fb1665cb2d395ca2f8cd3b63b757aacebbb6577f57ba5c73",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41283",
+					"10.65.0.27:41283",
+					"172.17.0.1:41283",
+					"172.19.0.1:41283",
+					"172.20.0.1:41283"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:44:40.031967662Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2263680032413583,
+				"StableID":   "nGZfr53EgJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31ad38503e03d30c54d373657d306fd089975d3349635ece6f96eefb56554c11",
+				"DiscoKey":   "discokey:39f736677a6c328a030d8c9e5f2f2956f070f30828358274b20e206ac34f2026",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45681",
+					"10.65.0.27:45681",
+					"172.17.0.1:45681",
+					"172.19.0.1:45681",
+					"172.20.0.1:45681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:44:40.568859801Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7025651806050733,
+				"StableID":   "ntgQtexvrw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:26af846559bfbca72813cb62f78d7d231e197f935d8a67c587a123d17d9a3736",
+				"KeyExpiry":  "2026-11-08T18:44:41Z",
+				"DiscoKey":   "discokey:3a6365e153185298635c4724c737ae80d1cca8e7e92539e1e57948f15af45c56",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:53922",
+					"10.65.0.27:53922",
+					"172.17.0.1:53922",
+					"172.19.0.1:53922",
+					"172.20.0.1:53922"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:44:41.645875081Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4581505740785207,
+				"StableID":   "n8RfgSPymc11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b5ec6926ed04532146458efadcb080333e243c136248e21b6f53c852e6169370",
+				"KeyExpiry":  "2026-11-08T18:44:42Z",
+				"DiscoKey":   "discokey:5de48bbeeacd1e2d716bae0031d9bf6a56a7e1f7bc7f95b50e5726094336e208",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47079",
+					"10.65.0.27:47079",
+					"172.17.0.1:47079",
+					"172.19.0.1:47079",
+					"172.20.0.1:47079"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:44:42.176139251Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5511685850227220,
+				"StableID":   "nwAnhBeF3k11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       5511685850227220,
+				"Key":        "nodekey:33522cbc22aea5361acba0c9b622254c3136708b98af10f8b2849b735fdc2c62",
+				"DiscoKey":   "discokey:5fb5dba31ec64463fb1665cb2d395ca2f8cd3b63b757aacebbb6577f57ba5c73",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41283",
+					"10.65.0.27:41283",
+					"172.17.0.1:41283",
+					"172.19.0.1:41283",
+					"172.20.0.1:41283"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:44:40.031967662Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:33522cbc22aea5361acba0c9b622254c3136708b98af10f8b2849b735fdc2c62",
+			"MachineKey": "mkey:3334c905cb3b757b17bd97f6fc49167947132c79d1a85b98331c5cfd0a87f908",
+			"Peers": [{
+				"ID":         4521942798795311,
+				"StableID":   "nGZuTdmzJc11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8e294a6e97850367b4f6c8c1e66ecdd2649ade6adb4b6362ff6824509106d52",
+				"DiscoKey":   "discokey:1056e0c149996e1badf91e52769c3b9c57c9110f19c326c4466992511dfe9060",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38395",
+					"10.65.0.27:38395",
+					"172.17.0.1:38395",
+					"172.19.0.1:38395",
+					"172.20.0.1:38395"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:44:34.657909588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7126116325607834,
+				"StableID":   "nRiPTYzRex11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:669e82a20f1fc7ae1c5905601fdc72876c9c3300a00c547263f9e15c420e6447",
+				"DiscoKey":   "discokey:cdba9faf688adeedfd9966cd667acd7d39a470560812c35c41517fbf7096ca3e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59149",
+					"10.65.0.27:59149",
+					"172.17.0.1:59149",
+					"172.19.0.1:59149",
+					"172.20.0.1:59149"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:44:35.189900261Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3561132190558232,
+				"StableID":   "nfa1ASuqoU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38c2d8d7b40a194c2c39d2a4bf2efdd8c514054788b2a42d8c140be3f4f1a646",
+				"DiscoKey":   "discokey:1585ebeda9a49f4efc8001634e21a9449ba88579bd67e817bab87560e2ad072e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34649",
+					"10.65.0.27:34649",
+					"172.17.0.1:34649",
+					"172.19.0.1:34649",
+					"172.20.0.1:34649"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:44:35.727266924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3153019650170486,
+				"StableID":   "n7hfUpU1dR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6920538458a19d646ef2b20151bbc9d477bff09c897e77fcc84fc7a524f39003",
+				"DiscoKey":   "discokey:cc1aafbd867faa68f2bda551528f20be72277ccec03b70d12ab6eb12c9828325",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55740",
+					"10.65.0.27:55740",
+					"172.17.0.1:55740",
+					"172.19.0.1:55740",
+					"172.20.0.1:55740"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:44:36.263222415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5501678073094238,
+				"StableID":   "noF4iikixj11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4703d7880c68845d5a45cdb1aac1c685d21e64bee5699fa7c40facbc30abd249",
+				"DiscoKey":   "discokey:104c24c3f13eb6fe7356dfa0031fc9e6485b65c29e9cf0bd3b0ba5ca4a650523",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:51946",
+					"10.65.0.27:51946",
+					"172.17.0.1:51946",
+					"172.19.0.1:51946",
+					"172.20.0.1:51946"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:44:36.829161674Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         538490739088266,
+				"StableID":   "njK2eqEtC511CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c41ea0844e70201d6075dc39609b0eca79362968e56767a71abb28ec65d4420a",
+				"DiscoKey":   "discokey:38119dbea36c9309935c384bfe8f650115f8914b6995080d152003456eb48039",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:34088",
+					"10.65.0.27:34088",
+					"172.17.0.1:34088",
+					"172.19.0.1:34088",
+					"172.20.0.1:34088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:44:37.329956683Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6253827107285692,
+				"StableID":   "nBYGF9SNqq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28d7d6489916ba1b6324abd3731f4c0244df1be9dbaf6f9cdcc1ec9278643907",
+				"DiscoKey":   "discokey:15c2eefbe7abb1c68061ffffe36c1ab7d74ffa00a9c5ef4664adf2572a1d2a34",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:36675",
+					"10.65.0.27:36675",
+					"172.17.0.1:36675",
+					"172.19.0.1:36675",
+					"172.20.0.1:36675"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:44:37.861204644Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2405435042157557,
+				"StableID":   "nk4ieahRnK11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:23e8d0ef02e79d38c91519ad7a13826220aed20a1a570d7f8f0cde14ebc58938",
+				"DiscoKey":   "discokey:a00c697b16f2aeb0a31ce057b2f17855749440dcdaf1376373668c082741294d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:35669",
+					"10.65.0.27:35669",
+					"172.17.0.1:35669",
+					"172.19.0.1:35669",
+					"172.20.0.1:35669"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:44:38.404131466Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3288427654510610,
+				"StableID":   "n1zy8GRLgS11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:320c694a094e80f650e89580de8c5500b0d33cd8724184cbfc75f104e94fce79",
+				"DiscoKey":   "discokey:224a233afc25468db3bec38f0a22d6a910571811b270c4a01814e88f419c4d0d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:55078",
+					"10.65.0.27:55078",
+					"172.17.0.1:55078",
+					"172.19.0.1:55078",
+					"172.20.0.1:55078"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:44:38.952553308Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5583262302296445,
+				"StableID":   "nADtfKqfbk11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b699270c9f48e704ff3138a5ee1752827d669f364b90547c96fe08b922626054",
+				"DiscoKey":   "discokey:98cffde6508929296dcd9bb5c9d1f41453e9b8f6e95dc579c1ec9063b7b36d31",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38285",
+					"10.65.0.27:38285",
+					"172.17.0.1:38285",
+					"172.19.0.1:38285",
+					"172.20.0.1:38285"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:44:39.491127718Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2263680032413583,
+				"StableID":   "nGZfr53EgJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31ad38503e03d30c54d373657d306fd089975d3349635ece6f96eefb56554c11",
+				"DiscoKey":   "discokey:39f736677a6c328a030d8c9e5f2f2956f070f30828358274b20e206ac34f2026",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45681",
+					"10.65.0.27:45681",
+					"172.17.0.1:45681",
+					"172.19.0.1:45681",
+					"172.20.0.1:45681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:44:40.568859801Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5198346930574694,
+				"StableID":   "n5WRM2mLbh11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:db7354231d6c0052742b51942193133a12b208081c9654c20161815269588b41",
+				"KeyExpiry":  "2026-11-08T18:44:41Z",
+				"DiscoKey":   "discokey:cae61e363f12d435b12c92ccb738fd83507033f592c62e28d20f4fe879c2b45b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47369",
+					"10.65.0.27:47369",
+					"172.17.0.1:47369",
+					"172.19.0.1:47369",
+					"172.20.0.1:47369"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:44:41.120560002Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7025651806050733,
+				"StableID":   "ntgQtexvrw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:26af846559bfbca72813cb62f78d7d231e197f935d8a67c587a123d17d9a3736",
+				"KeyExpiry":  "2026-11-08T18:44:41Z",
+				"DiscoKey":   "discokey:3a6365e153185298635c4724c737ae80d1cca8e7e92539e1e57948f15af45c56",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:53922",
+					"10.65.0.27:53922",
+					"172.17.0.1:53922",
+					"172.19.0.1:53922",
+					"172.20.0.1:53922"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:44:41.645875081Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4581505740785207,
+				"StableID":   "n8RfgSPymc11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b5ec6926ed04532146458efadcb080333e243c136248e21b6f53c852e6169370",
+				"KeyExpiry":  "2026-11-08T18:44:42Z",
+				"DiscoKey":   "discokey:5de48bbeeacd1e2d716bae0031d9bf6a56a7e1f7bc7f95b50e5726094336e208",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47079",
+					"10.65.0.27:47079",
+					"172.17.0.1:47079",
+					"172.19.0.1:47079",
+					"172.20.0.1:47079"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:44:42.176139251Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5511685850227220": {
+				"ID":          5511685850227220,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7126116325607834,
+				"StableID":   "nRiPTYzRex11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       7126116325607834,
+				"Key":        "nodekey:669e82a20f1fc7ae1c5905601fdc72876c9c3300a00c547263f9e15c420e6447",
+				"DiscoKey":   "discokey:cdba9faf688adeedfd9966cd667acd7d39a470560812c35c41517fbf7096ca3e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59149",
+					"10.65.0.27:59149",
+					"172.17.0.1:59149",
+					"172.19.0.1:59149",
+					"172.20.0.1:59149"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:44:35.189900261Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:669e82a20f1fc7ae1c5905601fdc72876c9c3300a00c547263f9e15c420e6447",
+			"MachineKey": "mkey:c79060201e88ec73d36e47e5c0c4064f0dce4b93bbdc4ff661821192081b7555",
+			"Peers": [{
+				"ID":         4521942798795311,
+				"StableID":   "nGZuTdmzJc11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8e294a6e97850367b4f6c8c1e66ecdd2649ade6adb4b6362ff6824509106d52",
+				"DiscoKey":   "discokey:1056e0c149996e1badf91e52769c3b9c57c9110f19c326c4466992511dfe9060",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38395",
+					"10.65.0.27:38395",
+					"172.17.0.1:38395",
+					"172.19.0.1:38395",
+					"172.20.0.1:38395"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:44:34.657909588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3561132190558232,
+				"StableID":   "nfa1ASuqoU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38c2d8d7b40a194c2c39d2a4bf2efdd8c514054788b2a42d8c140be3f4f1a646",
+				"DiscoKey":   "discokey:1585ebeda9a49f4efc8001634e21a9449ba88579bd67e817bab87560e2ad072e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34649",
+					"10.65.0.27:34649",
+					"172.17.0.1:34649",
+					"172.19.0.1:34649",
+					"172.20.0.1:34649"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:44:35.727266924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3153019650170486,
+				"StableID":   "n7hfUpU1dR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6920538458a19d646ef2b20151bbc9d477bff09c897e77fcc84fc7a524f39003",
+				"DiscoKey":   "discokey:cc1aafbd867faa68f2bda551528f20be72277ccec03b70d12ab6eb12c9828325",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55740",
+					"10.65.0.27:55740",
+					"172.17.0.1:55740",
+					"172.19.0.1:55740",
+					"172.20.0.1:55740"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:44:36.263222415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5501678073094238,
+				"StableID":   "noF4iikixj11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4703d7880c68845d5a45cdb1aac1c685d21e64bee5699fa7c40facbc30abd249",
+				"DiscoKey":   "discokey:104c24c3f13eb6fe7356dfa0031fc9e6485b65c29e9cf0bd3b0ba5ca4a650523",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:51946",
+					"10.65.0.27:51946",
+					"172.17.0.1:51946",
+					"172.19.0.1:51946",
+					"172.20.0.1:51946"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:44:36.829161674Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         538490739088266,
+				"StableID":   "njK2eqEtC511CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c41ea0844e70201d6075dc39609b0eca79362968e56767a71abb28ec65d4420a",
+				"DiscoKey":   "discokey:38119dbea36c9309935c384bfe8f650115f8914b6995080d152003456eb48039",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:34088",
+					"10.65.0.27:34088",
+					"172.17.0.1:34088",
+					"172.19.0.1:34088",
+					"172.20.0.1:34088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:44:37.329956683Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6253827107285692,
+				"StableID":   "nBYGF9SNqq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28d7d6489916ba1b6324abd3731f4c0244df1be9dbaf6f9cdcc1ec9278643907",
+				"DiscoKey":   "discokey:15c2eefbe7abb1c68061ffffe36c1ab7d74ffa00a9c5ef4664adf2572a1d2a34",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:36675",
+					"10.65.0.27:36675",
+					"172.17.0.1:36675",
+					"172.19.0.1:36675",
+					"172.20.0.1:36675"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:44:37.861204644Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2405435042157557,
+				"StableID":   "nk4ieahRnK11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:23e8d0ef02e79d38c91519ad7a13826220aed20a1a570d7f8f0cde14ebc58938",
+				"DiscoKey":   "discokey:a00c697b16f2aeb0a31ce057b2f17855749440dcdaf1376373668c082741294d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:35669",
+					"10.65.0.27:35669",
+					"172.17.0.1:35669",
+					"172.19.0.1:35669",
+					"172.20.0.1:35669"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:44:38.404131466Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3288427654510610,
+				"StableID":   "n1zy8GRLgS11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:320c694a094e80f650e89580de8c5500b0d33cd8724184cbfc75f104e94fce79",
+				"DiscoKey":   "discokey:224a233afc25468db3bec38f0a22d6a910571811b270c4a01814e88f419c4d0d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:55078",
+					"10.65.0.27:55078",
+					"172.17.0.1:55078",
+					"172.19.0.1:55078",
+					"172.20.0.1:55078"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:44:38.952553308Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5583262302296445,
+				"StableID":   "nADtfKqfbk11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b699270c9f48e704ff3138a5ee1752827d669f364b90547c96fe08b922626054",
+				"DiscoKey":   "discokey:98cffde6508929296dcd9bb5c9d1f41453e9b8f6e95dc579c1ec9063b7b36d31",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38285",
+					"10.65.0.27:38285",
+					"172.17.0.1:38285",
+					"172.19.0.1:38285",
+					"172.20.0.1:38285"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:44:39.491127718Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5511685850227220,
+				"StableID":   "nwAnhBeF3k11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:33522cbc22aea5361acba0c9b622254c3136708b98af10f8b2849b735fdc2c62",
+				"DiscoKey":   "discokey:5fb5dba31ec64463fb1665cb2d395ca2f8cd3b63b757aacebbb6577f57ba5c73",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41283",
+					"10.65.0.27:41283",
+					"172.17.0.1:41283",
+					"172.19.0.1:41283",
+					"172.20.0.1:41283"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:44:40.031967662Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2263680032413583,
+				"StableID":   "nGZfr53EgJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31ad38503e03d30c54d373657d306fd089975d3349635ece6f96eefb56554c11",
+				"DiscoKey":   "discokey:39f736677a6c328a030d8c9e5f2f2956f070f30828358274b20e206ac34f2026",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45681",
+					"10.65.0.27:45681",
+					"172.17.0.1:45681",
+					"172.19.0.1:45681",
+					"172.20.0.1:45681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:44:40.568859801Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5198346930574694,
+				"StableID":   "n5WRM2mLbh11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:db7354231d6c0052742b51942193133a12b208081c9654c20161815269588b41",
+				"KeyExpiry":  "2026-11-08T18:44:41Z",
+				"DiscoKey":   "discokey:cae61e363f12d435b12c92ccb738fd83507033f592c62e28d20f4fe879c2b45b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47369",
+					"10.65.0.27:47369",
+					"172.17.0.1:47369",
+					"172.19.0.1:47369",
+					"172.20.0.1:47369"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:44:41.120560002Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7025651806050733,
+				"StableID":   "ntgQtexvrw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:26af846559bfbca72813cb62f78d7d231e197f935d8a67c587a123d17d9a3736",
+				"KeyExpiry":  "2026-11-08T18:44:41Z",
+				"DiscoKey":   "discokey:3a6365e153185298635c4724c737ae80d1cca8e7e92539e1e57948f15af45c56",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:53922",
+					"10.65.0.27:53922",
+					"172.17.0.1:53922",
+					"172.19.0.1:53922",
+					"172.20.0.1:53922"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:44:41.645875081Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4581505740785207,
+				"StableID":   "n8RfgSPymc11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b5ec6926ed04532146458efadcb080333e243c136248e21b6f53c852e6169370",
+				"KeyExpiry":  "2026-11-08T18:44:42Z",
+				"DiscoKey":   "discokey:5de48bbeeacd1e2d716bae0031d9bf6a56a7e1f7bc7f95b50e5726094336e208",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47079",
+					"10.65.0.27:47079",
+					"172.17.0.1:47079",
+					"172.19.0.1:47079",
+					"172.20.0.1:47079"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:44:42.176139251Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7126116325607834": {
+				"ID":          7126116325607834,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4521942798795311,
+				"StableID":   "nGZuTdmzJc11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       4521942798795311,
+				"Key":        "nodekey:b8e294a6e97850367b4f6c8c1e66ecdd2649ade6adb4b6362ff6824509106d52",
+				"DiscoKey":   "discokey:1056e0c149996e1badf91e52769c3b9c57c9110f19c326c4466992511dfe9060",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38395",
+					"10.65.0.27:38395",
+					"172.17.0.1:38395",
+					"172.19.0.1:38395",
+					"172.20.0.1:38395"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:44:34.657909588Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b8e294a6e97850367b4f6c8c1e66ecdd2649ade6adb4b6362ff6824509106d52",
+			"MachineKey": "mkey:1b362adf9c1e1b62332181b79acba3a3c2ebaa685229fcf9f7da728dfeabc061",
+			"Peers": [{
+				"ID":         7126116325607834,
+				"StableID":   "nRiPTYzRex11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:669e82a20f1fc7ae1c5905601fdc72876c9c3300a00c547263f9e15c420e6447",
+				"DiscoKey":   "discokey:cdba9faf688adeedfd9966cd667acd7d39a470560812c35c41517fbf7096ca3e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59149",
+					"10.65.0.27:59149",
+					"172.17.0.1:59149",
+					"172.19.0.1:59149",
+					"172.20.0.1:59149"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:44:35.189900261Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3561132190558232,
+				"StableID":   "nfa1ASuqoU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38c2d8d7b40a194c2c39d2a4bf2efdd8c514054788b2a42d8c140be3f4f1a646",
+				"DiscoKey":   "discokey:1585ebeda9a49f4efc8001634e21a9449ba88579bd67e817bab87560e2ad072e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34649",
+					"10.65.0.27:34649",
+					"172.17.0.1:34649",
+					"172.19.0.1:34649",
+					"172.20.0.1:34649"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:44:35.727266924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3153019650170486,
+				"StableID":   "n7hfUpU1dR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6920538458a19d646ef2b20151bbc9d477bff09c897e77fcc84fc7a524f39003",
+				"DiscoKey":   "discokey:cc1aafbd867faa68f2bda551528f20be72277ccec03b70d12ab6eb12c9828325",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55740",
+					"10.65.0.27:55740",
+					"172.17.0.1:55740",
+					"172.19.0.1:55740",
+					"172.20.0.1:55740"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:44:36.263222415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5501678073094238,
+				"StableID":   "noF4iikixj11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4703d7880c68845d5a45cdb1aac1c685d21e64bee5699fa7c40facbc30abd249",
+				"DiscoKey":   "discokey:104c24c3f13eb6fe7356dfa0031fc9e6485b65c29e9cf0bd3b0ba5ca4a650523",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:51946",
+					"10.65.0.27:51946",
+					"172.17.0.1:51946",
+					"172.19.0.1:51946",
+					"172.20.0.1:51946"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:44:36.829161674Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         538490739088266,
+				"StableID":   "njK2eqEtC511CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c41ea0844e70201d6075dc39609b0eca79362968e56767a71abb28ec65d4420a",
+				"DiscoKey":   "discokey:38119dbea36c9309935c384bfe8f650115f8914b6995080d152003456eb48039",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:34088",
+					"10.65.0.27:34088",
+					"172.17.0.1:34088",
+					"172.19.0.1:34088",
+					"172.20.0.1:34088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:44:37.329956683Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6253827107285692,
+				"StableID":   "nBYGF9SNqq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28d7d6489916ba1b6324abd3731f4c0244df1be9dbaf6f9cdcc1ec9278643907",
+				"DiscoKey":   "discokey:15c2eefbe7abb1c68061ffffe36c1ab7d74ffa00a9c5ef4664adf2572a1d2a34",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:36675",
+					"10.65.0.27:36675",
+					"172.17.0.1:36675",
+					"172.19.0.1:36675",
+					"172.20.0.1:36675"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:44:37.861204644Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2405435042157557,
+				"StableID":   "nk4ieahRnK11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:23e8d0ef02e79d38c91519ad7a13826220aed20a1a570d7f8f0cde14ebc58938",
+				"DiscoKey":   "discokey:a00c697b16f2aeb0a31ce057b2f17855749440dcdaf1376373668c082741294d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:35669",
+					"10.65.0.27:35669",
+					"172.17.0.1:35669",
+					"172.19.0.1:35669",
+					"172.20.0.1:35669"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:44:38.404131466Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3288427654510610,
+				"StableID":   "n1zy8GRLgS11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:320c694a094e80f650e89580de8c5500b0d33cd8724184cbfc75f104e94fce79",
+				"DiscoKey":   "discokey:224a233afc25468db3bec38f0a22d6a910571811b270c4a01814e88f419c4d0d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:55078",
+					"10.65.0.27:55078",
+					"172.17.0.1:55078",
+					"172.19.0.1:55078",
+					"172.20.0.1:55078"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:44:38.952553308Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5583262302296445,
+				"StableID":   "nADtfKqfbk11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b699270c9f48e704ff3138a5ee1752827d669f364b90547c96fe08b922626054",
+				"DiscoKey":   "discokey:98cffde6508929296dcd9bb5c9d1f41453e9b8f6e95dc579c1ec9063b7b36d31",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38285",
+					"10.65.0.27:38285",
+					"172.17.0.1:38285",
+					"172.19.0.1:38285",
+					"172.20.0.1:38285"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:44:39.491127718Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5511685850227220,
+				"StableID":   "nwAnhBeF3k11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:33522cbc22aea5361acba0c9b622254c3136708b98af10f8b2849b735fdc2c62",
+				"DiscoKey":   "discokey:5fb5dba31ec64463fb1665cb2d395ca2f8cd3b63b757aacebbb6577f57ba5c73",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41283",
+					"10.65.0.27:41283",
+					"172.17.0.1:41283",
+					"172.19.0.1:41283",
+					"172.20.0.1:41283"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:44:40.031967662Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2263680032413583,
+				"StableID":   "nGZfr53EgJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31ad38503e03d30c54d373657d306fd089975d3349635ece6f96eefb56554c11",
+				"DiscoKey":   "discokey:39f736677a6c328a030d8c9e5f2f2956f070f30828358274b20e206ac34f2026",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45681",
+					"10.65.0.27:45681",
+					"172.17.0.1:45681",
+					"172.19.0.1:45681",
+					"172.20.0.1:45681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:44:40.568859801Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5198346930574694,
+				"StableID":   "n5WRM2mLbh11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:db7354231d6c0052742b51942193133a12b208081c9654c20161815269588b41",
+				"KeyExpiry":  "2026-11-08T18:44:41Z",
+				"DiscoKey":   "discokey:cae61e363f12d435b12c92ccb738fd83507033f592c62e28d20f4fe879c2b45b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47369",
+					"10.65.0.27:47369",
+					"172.17.0.1:47369",
+					"172.19.0.1:47369",
+					"172.20.0.1:47369"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:44:41.120560002Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7025651806050733,
+				"StableID":   "ntgQtexvrw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:26af846559bfbca72813cb62f78d7d231e197f935d8a67c587a123d17d9a3736",
+				"KeyExpiry":  "2026-11-08T18:44:41Z",
+				"DiscoKey":   "discokey:3a6365e153185298635c4724c737ae80d1cca8e7e92539e1e57948f15af45c56",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:53922",
+					"10.65.0.27:53922",
+					"172.17.0.1:53922",
+					"172.19.0.1:53922",
+					"172.20.0.1:53922"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:44:41.645875081Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4581505740785207,
+				"StableID":   "n8RfgSPymc11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b5ec6926ed04532146458efadcb080333e243c136248e21b6f53c852e6169370",
+				"KeyExpiry":  "2026-11-08T18:44:42Z",
+				"DiscoKey":   "discokey:5de48bbeeacd1e2d716bae0031d9bf6a56a7e1f7bc7f95b50e5726094336e208",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47079",
+					"10.65.0.27:47079",
+					"172.17.0.1:47079",
+					"172.19.0.1:47079",
+					"172.20.0.1:47079"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:44:42.176139251Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4521942798795311": {
+				"ID":          4521942798795311,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5501678073094238,
+				"StableID":   "noF4iikixj11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       5501678073094238,
+				"Key":        "nodekey:4703d7880c68845d5a45cdb1aac1c685d21e64bee5699fa7c40facbc30abd249",
+				"DiscoKey":   "discokey:104c24c3f13eb6fe7356dfa0031fc9e6485b65c29e9cf0bd3b0ba5ca4a650523",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:51946",
+					"10.65.0.27:51946",
+					"172.17.0.1:51946",
+					"172.19.0.1:51946",
+					"172.20.0.1:51946"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:44:36.829161674Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4703d7880c68845d5a45cdb1aac1c685d21e64bee5699fa7c40facbc30abd249",
+			"MachineKey": "mkey:d93f123b4f707a236f369b18876aa56e5f997a5318cc51ab334b14e825c53f63",
+			"Peers": [{
+				"ID":         4521942798795311,
+				"StableID":   "nGZuTdmzJc11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8e294a6e97850367b4f6c8c1e66ecdd2649ade6adb4b6362ff6824509106d52",
+				"DiscoKey":   "discokey:1056e0c149996e1badf91e52769c3b9c57c9110f19c326c4466992511dfe9060",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38395",
+					"10.65.0.27:38395",
+					"172.17.0.1:38395",
+					"172.19.0.1:38395",
+					"172.20.0.1:38395"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:44:34.657909588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7126116325607834,
+				"StableID":   "nRiPTYzRex11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:669e82a20f1fc7ae1c5905601fdc72876c9c3300a00c547263f9e15c420e6447",
+				"DiscoKey":   "discokey:cdba9faf688adeedfd9966cd667acd7d39a470560812c35c41517fbf7096ca3e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59149",
+					"10.65.0.27:59149",
+					"172.17.0.1:59149",
+					"172.19.0.1:59149",
+					"172.20.0.1:59149"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:44:35.189900261Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3561132190558232,
+				"StableID":   "nfa1ASuqoU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38c2d8d7b40a194c2c39d2a4bf2efdd8c514054788b2a42d8c140be3f4f1a646",
+				"DiscoKey":   "discokey:1585ebeda9a49f4efc8001634e21a9449ba88579bd67e817bab87560e2ad072e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34649",
+					"10.65.0.27:34649",
+					"172.17.0.1:34649",
+					"172.19.0.1:34649",
+					"172.20.0.1:34649"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:44:35.727266924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3153019650170486,
+				"StableID":   "n7hfUpU1dR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6920538458a19d646ef2b20151bbc9d477bff09c897e77fcc84fc7a524f39003",
+				"DiscoKey":   "discokey:cc1aafbd867faa68f2bda551528f20be72277ccec03b70d12ab6eb12c9828325",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55740",
+					"10.65.0.27:55740",
+					"172.17.0.1:55740",
+					"172.19.0.1:55740",
+					"172.20.0.1:55740"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:44:36.263222415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         538490739088266,
+				"StableID":   "njK2eqEtC511CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c41ea0844e70201d6075dc39609b0eca79362968e56767a71abb28ec65d4420a",
+				"DiscoKey":   "discokey:38119dbea36c9309935c384bfe8f650115f8914b6995080d152003456eb48039",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:34088",
+					"10.65.0.27:34088",
+					"172.17.0.1:34088",
+					"172.19.0.1:34088",
+					"172.20.0.1:34088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:44:37.329956683Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6253827107285692,
+				"StableID":   "nBYGF9SNqq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28d7d6489916ba1b6324abd3731f4c0244df1be9dbaf6f9cdcc1ec9278643907",
+				"DiscoKey":   "discokey:15c2eefbe7abb1c68061ffffe36c1ab7d74ffa00a9c5ef4664adf2572a1d2a34",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:36675",
+					"10.65.0.27:36675",
+					"172.17.0.1:36675",
+					"172.19.0.1:36675",
+					"172.20.0.1:36675"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:44:37.861204644Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2405435042157557,
+				"StableID":   "nk4ieahRnK11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:23e8d0ef02e79d38c91519ad7a13826220aed20a1a570d7f8f0cde14ebc58938",
+				"DiscoKey":   "discokey:a00c697b16f2aeb0a31ce057b2f17855749440dcdaf1376373668c082741294d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:35669",
+					"10.65.0.27:35669",
+					"172.17.0.1:35669",
+					"172.19.0.1:35669",
+					"172.20.0.1:35669"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:44:38.404131466Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3288427654510610,
+				"StableID":   "n1zy8GRLgS11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:320c694a094e80f650e89580de8c5500b0d33cd8724184cbfc75f104e94fce79",
+				"DiscoKey":   "discokey:224a233afc25468db3bec38f0a22d6a910571811b270c4a01814e88f419c4d0d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:55078",
+					"10.65.0.27:55078",
+					"172.17.0.1:55078",
+					"172.19.0.1:55078",
+					"172.20.0.1:55078"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:44:38.952553308Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5583262302296445,
+				"StableID":   "nADtfKqfbk11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b699270c9f48e704ff3138a5ee1752827d669f364b90547c96fe08b922626054",
+				"DiscoKey":   "discokey:98cffde6508929296dcd9bb5c9d1f41453e9b8f6e95dc579c1ec9063b7b36d31",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38285",
+					"10.65.0.27:38285",
+					"172.17.0.1:38285",
+					"172.19.0.1:38285",
+					"172.20.0.1:38285"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:44:39.491127718Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5511685850227220,
+				"StableID":   "nwAnhBeF3k11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:33522cbc22aea5361acba0c9b622254c3136708b98af10f8b2849b735fdc2c62",
+				"DiscoKey":   "discokey:5fb5dba31ec64463fb1665cb2d395ca2f8cd3b63b757aacebbb6577f57ba5c73",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41283",
+					"10.65.0.27:41283",
+					"172.17.0.1:41283",
+					"172.19.0.1:41283",
+					"172.20.0.1:41283"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:44:40.031967662Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2263680032413583,
+				"StableID":   "nGZfr53EgJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31ad38503e03d30c54d373657d306fd089975d3349635ece6f96eefb56554c11",
+				"DiscoKey":   "discokey:39f736677a6c328a030d8c9e5f2f2956f070f30828358274b20e206ac34f2026",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45681",
+					"10.65.0.27:45681",
+					"172.17.0.1:45681",
+					"172.19.0.1:45681",
+					"172.20.0.1:45681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:44:40.568859801Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5198346930574694,
+				"StableID":   "n5WRM2mLbh11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:db7354231d6c0052742b51942193133a12b208081c9654c20161815269588b41",
+				"KeyExpiry":  "2026-11-08T18:44:41Z",
+				"DiscoKey":   "discokey:cae61e363f12d435b12c92ccb738fd83507033f592c62e28d20f4fe879c2b45b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47369",
+					"10.65.0.27:47369",
+					"172.17.0.1:47369",
+					"172.19.0.1:47369",
+					"172.20.0.1:47369"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:44:41.120560002Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7025651806050733,
+				"StableID":   "ntgQtexvrw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:26af846559bfbca72813cb62f78d7d231e197f935d8a67c587a123d17d9a3736",
+				"KeyExpiry":  "2026-11-08T18:44:41Z",
+				"DiscoKey":   "discokey:3a6365e153185298635c4724c737ae80d1cca8e7e92539e1e57948f15af45c56",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:53922",
+					"10.65.0.27:53922",
+					"172.17.0.1:53922",
+					"172.19.0.1:53922",
+					"172.20.0.1:53922"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:44:41.645875081Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4581505740785207,
+				"StableID":   "n8RfgSPymc11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b5ec6926ed04532146458efadcb080333e243c136248e21b6f53c852e6169370",
+				"KeyExpiry":  "2026-11-08T18:44:42Z",
+				"DiscoKey":   "discokey:5de48bbeeacd1e2d716bae0031d9bf6a56a7e1f7bc7f95b50e5726094336e208",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47079",
+					"10.65.0.27:47079",
+					"172.17.0.1:47079",
+					"172.19.0.1:47079",
+					"172.20.0.1:47079"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:44:42.176139251Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5501678073094238": {
+				"ID":          5501678073094238,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3153019650170486,
+				"StableID":   "n7hfUpU1dR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       3153019650170486,
+				"Key":        "nodekey:6920538458a19d646ef2b20151bbc9d477bff09c897e77fcc84fc7a524f39003",
+				"DiscoKey":   "discokey:cc1aafbd867faa68f2bda551528f20be72277ccec03b70d12ab6eb12c9828325",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55740",
+					"10.65.0.27:55740",
+					"172.17.0.1:55740",
+					"172.19.0.1:55740",
+					"172.20.0.1:55740"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:44:36.263222415Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6920538458a19d646ef2b20151bbc9d477bff09c897e77fcc84fc7a524f39003",
+			"MachineKey": "mkey:d4172bc0ed3d1a04e2a835d03da3a8c2aa585ad2ab4ec77e4604d1fa45480d50",
+			"Peers": [{
+				"ID":         4521942798795311,
+				"StableID":   "nGZuTdmzJc11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8e294a6e97850367b4f6c8c1e66ecdd2649ade6adb4b6362ff6824509106d52",
+				"DiscoKey":   "discokey:1056e0c149996e1badf91e52769c3b9c57c9110f19c326c4466992511dfe9060",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38395",
+					"10.65.0.27:38395",
+					"172.17.0.1:38395",
+					"172.19.0.1:38395",
+					"172.20.0.1:38395"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:44:34.657909588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7126116325607834,
+				"StableID":   "nRiPTYzRex11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:669e82a20f1fc7ae1c5905601fdc72876c9c3300a00c547263f9e15c420e6447",
+				"DiscoKey":   "discokey:cdba9faf688adeedfd9966cd667acd7d39a470560812c35c41517fbf7096ca3e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59149",
+					"10.65.0.27:59149",
+					"172.17.0.1:59149",
+					"172.19.0.1:59149",
+					"172.20.0.1:59149"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:44:35.189900261Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3561132190558232,
+				"StableID":   "nfa1ASuqoU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38c2d8d7b40a194c2c39d2a4bf2efdd8c514054788b2a42d8c140be3f4f1a646",
+				"DiscoKey":   "discokey:1585ebeda9a49f4efc8001634e21a9449ba88579bd67e817bab87560e2ad072e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34649",
+					"10.65.0.27:34649",
+					"172.17.0.1:34649",
+					"172.19.0.1:34649",
+					"172.20.0.1:34649"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:44:35.727266924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5501678073094238,
+				"StableID":   "noF4iikixj11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4703d7880c68845d5a45cdb1aac1c685d21e64bee5699fa7c40facbc30abd249",
+				"DiscoKey":   "discokey:104c24c3f13eb6fe7356dfa0031fc9e6485b65c29e9cf0bd3b0ba5ca4a650523",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:51946",
+					"10.65.0.27:51946",
+					"172.17.0.1:51946",
+					"172.19.0.1:51946",
+					"172.20.0.1:51946"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:44:36.829161674Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         538490739088266,
+				"StableID":   "njK2eqEtC511CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c41ea0844e70201d6075dc39609b0eca79362968e56767a71abb28ec65d4420a",
+				"DiscoKey":   "discokey:38119dbea36c9309935c384bfe8f650115f8914b6995080d152003456eb48039",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:34088",
+					"10.65.0.27:34088",
+					"172.17.0.1:34088",
+					"172.19.0.1:34088",
+					"172.20.0.1:34088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:44:37.329956683Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6253827107285692,
+				"StableID":   "nBYGF9SNqq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28d7d6489916ba1b6324abd3731f4c0244df1be9dbaf6f9cdcc1ec9278643907",
+				"DiscoKey":   "discokey:15c2eefbe7abb1c68061ffffe36c1ab7d74ffa00a9c5ef4664adf2572a1d2a34",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:36675",
+					"10.65.0.27:36675",
+					"172.17.0.1:36675",
+					"172.19.0.1:36675",
+					"172.20.0.1:36675"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:44:37.861204644Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2405435042157557,
+				"StableID":   "nk4ieahRnK11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:23e8d0ef02e79d38c91519ad7a13826220aed20a1a570d7f8f0cde14ebc58938",
+				"DiscoKey":   "discokey:a00c697b16f2aeb0a31ce057b2f17855749440dcdaf1376373668c082741294d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:35669",
+					"10.65.0.27:35669",
+					"172.17.0.1:35669",
+					"172.19.0.1:35669",
+					"172.20.0.1:35669"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:44:38.404131466Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3288427654510610,
+				"StableID":   "n1zy8GRLgS11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:320c694a094e80f650e89580de8c5500b0d33cd8724184cbfc75f104e94fce79",
+				"DiscoKey":   "discokey:224a233afc25468db3bec38f0a22d6a910571811b270c4a01814e88f419c4d0d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:55078",
+					"10.65.0.27:55078",
+					"172.17.0.1:55078",
+					"172.19.0.1:55078",
+					"172.20.0.1:55078"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:44:38.952553308Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5583262302296445,
+				"StableID":   "nADtfKqfbk11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b699270c9f48e704ff3138a5ee1752827d669f364b90547c96fe08b922626054",
+				"DiscoKey":   "discokey:98cffde6508929296dcd9bb5c9d1f41453e9b8f6e95dc579c1ec9063b7b36d31",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38285",
+					"10.65.0.27:38285",
+					"172.17.0.1:38285",
+					"172.19.0.1:38285",
+					"172.20.0.1:38285"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:44:39.491127718Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5511685850227220,
+				"StableID":   "nwAnhBeF3k11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:33522cbc22aea5361acba0c9b622254c3136708b98af10f8b2849b735fdc2c62",
+				"DiscoKey":   "discokey:5fb5dba31ec64463fb1665cb2d395ca2f8cd3b63b757aacebbb6577f57ba5c73",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41283",
+					"10.65.0.27:41283",
+					"172.17.0.1:41283",
+					"172.19.0.1:41283",
+					"172.20.0.1:41283"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:44:40.031967662Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2263680032413583,
+				"StableID":   "nGZfr53EgJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31ad38503e03d30c54d373657d306fd089975d3349635ece6f96eefb56554c11",
+				"DiscoKey":   "discokey:39f736677a6c328a030d8c9e5f2f2956f070f30828358274b20e206ac34f2026",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45681",
+					"10.65.0.27:45681",
+					"172.17.0.1:45681",
+					"172.19.0.1:45681",
+					"172.20.0.1:45681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:44:40.568859801Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5198346930574694,
+				"StableID":   "n5WRM2mLbh11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:db7354231d6c0052742b51942193133a12b208081c9654c20161815269588b41",
+				"KeyExpiry":  "2026-11-08T18:44:41Z",
+				"DiscoKey":   "discokey:cae61e363f12d435b12c92ccb738fd83507033f592c62e28d20f4fe879c2b45b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47369",
+					"10.65.0.27:47369",
+					"172.17.0.1:47369",
+					"172.19.0.1:47369",
+					"172.20.0.1:47369"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:44:41.120560002Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7025651806050733,
+				"StableID":   "ntgQtexvrw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:26af846559bfbca72813cb62f78d7d231e197f935d8a67c587a123d17d9a3736",
+				"KeyExpiry":  "2026-11-08T18:44:41Z",
+				"DiscoKey":   "discokey:3a6365e153185298635c4724c737ae80d1cca8e7e92539e1e57948f15af45c56",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:53922",
+					"10.65.0.27:53922",
+					"172.17.0.1:53922",
+					"172.19.0.1:53922",
+					"172.20.0.1:53922"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:44:41.645875081Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4581505740785207,
+				"StableID":   "n8RfgSPymc11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b5ec6926ed04532146458efadcb080333e243c136248e21b6f53c852e6169370",
+				"KeyExpiry":  "2026-11-08T18:44:42Z",
+				"DiscoKey":   "discokey:5de48bbeeacd1e2d716bae0031d9bf6a56a7e1f7bc7f95b50e5726094336e208",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47079",
+					"10.65.0.27:47079",
+					"172.17.0.1:47079",
+					"172.19.0.1:47079",
+					"172.20.0.1:47079"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:44:42.176139251Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3153019650170486": {
+				"ID":          3153019650170486,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6253827107285692,
+				"StableID":   "nBYGF9SNqq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       6253827107285692,
+				"Key":        "nodekey:28d7d6489916ba1b6324abd3731f4c0244df1be9dbaf6f9cdcc1ec9278643907",
+				"DiscoKey":   "discokey:15c2eefbe7abb1c68061ffffe36c1ab7d74ffa00a9c5ef4664adf2572a1d2a34",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:36675",
+					"10.65.0.27:36675",
+					"172.17.0.1:36675",
+					"172.19.0.1:36675",
+					"172.20.0.1:36675"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:44:37.861204644Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:28d7d6489916ba1b6324abd3731f4c0244df1be9dbaf6f9cdcc1ec9278643907",
+			"MachineKey": "mkey:8ecbeabfa6402c0534fb0cdee5a16273bd6f6bd178a6b7b0f3d5a45b59a75e40",
+			"Peers": [{
+				"ID":         4521942798795311,
+				"StableID":   "nGZuTdmzJc11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8e294a6e97850367b4f6c8c1e66ecdd2649ade6adb4b6362ff6824509106d52",
+				"DiscoKey":   "discokey:1056e0c149996e1badf91e52769c3b9c57c9110f19c326c4466992511dfe9060",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38395",
+					"10.65.0.27:38395",
+					"172.17.0.1:38395",
+					"172.19.0.1:38395",
+					"172.20.0.1:38395"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:44:34.657909588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7126116325607834,
+				"StableID":   "nRiPTYzRex11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:669e82a20f1fc7ae1c5905601fdc72876c9c3300a00c547263f9e15c420e6447",
+				"DiscoKey":   "discokey:cdba9faf688adeedfd9966cd667acd7d39a470560812c35c41517fbf7096ca3e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59149",
+					"10.65.0.27:59149",
+					"172.17.0.1:59149",
+					"172.19.0.1:59149",
+					"172.20.0.1:59149"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:44:35.189900261Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3561132190558232,
+				"StableID":   "nfa1ASuqoU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38c2d8d7b40a194c2c39d2a4bf2efdd8c514054788b2a42d8c140be3f4f1a646",
+				"DiscoKey":   "discokey:1585ebeda9a49f4efc8001634e21a9449ba88579bd67e817bab87560e2ad072e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34649",
+					"10.65.0.27:34649",
+					"172.17.0.1:34649",
+					"172.19.0.1:34649",
+					"172.20.0.1:34649"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:44:35.727266924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3153019650170486,
+				"StableID":   "n7hfUpU1dR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6920538458a19d646ef2b20151bbc9d477bff09c897e77fcc84fc7a524f39003",
+				"DiscoKey":   "discokey:cc1aafbd867faa68f2bda551528f20be72277ccec03b70d12ab6eb12c9828325",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55740",
+					"10.65.0.27:55740",
+					"172.17.0.1:55740",
+					"172.19.0.1:55740",
+					"172.20.0.1:55740"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:44:36.263222415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5501678073094238,
+				"StableID":   "noF4iikixj11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4703d7880c68845d5a45cdb1aac1c685d21e64bee5699fa7c40facbc30abd249",
+				"DiscoKey":   "discokey:104c24c3f13eb6fe7356dfa0031fc9e6485b65c29e9cf0bd3b0ba5ca4a650523",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:51946",
+					"10.65.0.27:51946",
+					"172.17.0.1:51946",
+					"172.19.0.1:51946",
+					"172.20.0.1:51946"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:44:36.829161674Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         538490739088266,
+				"StableID":   "njK2eqEtC511CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c41ea0844e70201d6075dc39609b0eca79362968e56767a71abb28ec65d4420a",
+				"DiscoKey":   "discokey:38119dbea36c9309935c384bfe8f650115f8914b6995080d152003456eb48039",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:34088",
+					"10.65.0.27:34088",
+					"172.17.0.1:34088",
+					"172.19.0.1:34088",
+					"172.20.0.1:34088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:44:37.329956683Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2405435042157557,
+				"StableID":   "nk4ieahRnK11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:23e8d0ef02e79d38c91519ad7a13826220aed20a1a570d7f8f0cde14ebc58938",
+				"DiscoKey":   "discokey:a00c697b16f2aeb0a31ce057b2f17855749440dcdaf1376373668c082741294d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:35669",
+					"10.65.0.27:35669",
+					"172.17.0.1:35669",
+					"172.19.0.1:35669",
+					"172.20.0.1:35669"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:44:38.404131466Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3288427654510610,
+				"StableID":   "n1zy8GRLgS11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:320c694a094e80f650e89580de8c5500b0d33cd8724184cbfc75f104e94fce79",
+				"DiscoKey":   "discokey:224a233afc25468db3bec38f0a22d6a910571811b270c4a01814e88f419c4d0d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:55078",
+					"10.65.0.27:55078",
+					"172.17.0.1:55078",
+					"172.19.0.1:55078",
+					"172.20.0.1:55078"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:44:38.952553308Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5583262302296445,
+				"StableID":   "nADtfKqfbk11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b699270c9f48e704ff3138a5ee1752827d669f364b90547c96fe08b922626054",
+				"DiscoKey":   "discokey:98cffde6508929296dcd9bb5c9d1f41453e9b8f6e95dc579c1ec9063b7b36d31",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38285",
+					"10.65.0.27:38285",
+					"172.17.0.1:38285",
+					"172.19.0.1:38285",
+					"172.20.0.1:38285"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:44:39.491127718Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5511685850227220,
+				"StableID":   "nwAnhBeF3k11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:33522cbc22aea5361acba0c9b622254c3136708b98af10f8b2849b735fdc2c62",
+				"DiscoKey":   "discokey:5fb5dba31ec64463fb1665cb2d395ca2f8cd3b63b757aacebbb6577f57ba5c73",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41283",
+					"10.65.0.27:41283",
+					"172.17.0.1:41283",
+					"172.19.0.1:41283",
+					"172.20.0.1:41283"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:44:40.031967662Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2263680032413583,
+				"StableID":   "nGZfr53EgJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31ad38503e03d30c54d373657d306fd089975d3349635ece6f96eefb56554c11",
+				"DiscoKey":   "discokey:39f736677a6c328a030d8c9e5f2f2956f070f30828358274b20e206ac34f2026",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45681",
+					"10.65.0.27:45681",
+					"172.17.0.1:45681",
+					"172.19.0.1:45681",
+					"172.20.0.1:45681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:44:40.568859801Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5198346930574694,
+				"StableID":   "n5WRM2mLbh11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:db7354231d6c0052742b51942193133a12b208081c9654c20161815269588b41",
+				"KeyExpiry":  "2026-11-08T18:44:41Z",
+				"DiscoKey":   "discokey:cae61e363f12d435b12c92ccb738fd83507033f592c62e28d20f4fe879c2b45b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47369",
+					"10.65.0.27:47369",
+					"172.17.0.1:47369",
+					"172.19.0.1:47369",
+					"172.20.0.1:47369"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:44:41.120560002Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7025651806050733,
+				"StableID":   "ntgQtexvrw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:26af846559bfbca72813cb62f78d7d231e197f935d8a67c587a123d17d9a3736",
+				"KeyExpiry":  "2026-11-08T18:44:41Z",
+				"DiscoKey":   "discokey:3a6365e153185298635c4724c737ae80d1cca8e7e92539e1e57948f15af45c56",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:53922",
+					"10.65.0.27:53922",
+					"172.17.0.1:53922",
+					"172.19.0.1:53922",
+					"172.20.0.1:53922"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:44:41.645875081Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4581505740785207,
+				"StableID":   "n8RfgSPymc11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b5ec6926ed04532146458efadcb080333e243c136248e21b6f53c852e6169370",
+				"KeyExpiry":  "2026-11-08T18:44:42Z",
+				"DiscoKey":   "discokey:5de48bbeeacd1e2d716bae0031d9bf6a56a7e1f7bc7f95b50e5726094336e208",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47079",
+					"10.65.0.27:47079",
+					"172.17.0.1:47079",
+					"172.19.0.1:47079",
+					"172.20.0.1:47079"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:44:42.176139251Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6253827107285692": {
+				"ID":          6253827107285692,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3288427654510610,
+				"StableID":   "n1zy8GRLgS11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       3288427654510610,
+				"Key":        "nodekey:320c694a094e80f650e89580de8c5500b0d33cd8724184cbfc75f104e94fce79",
+				"DiscoKey":   "discokey:224a233afc25468db3bec38f0a22d6a910571811b270c4a01814e88f419c4d0d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:55078",
+					"10.65.0.27:55078",
+					"172.17.0.1:55078",
+					"172.19.0.1:55078",
+					"172.20.0.1:55078"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:44:38.952553308Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:320c694a094e80f650e89580de8c5500b0d33cd8724184cbfc75f104e94fce79",
+			"MachineKey": "mkey:6f47303e74b7f7c22d85becb6eab2a103371528c4a8d979168b4b911c22ab914",
+			"Peers": [{
+				"ID":         4521942798795311,
+				"StableID":   "nGZuTdmzJc11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8e294a6e97850367b4f6c8c1e66ecdd2649ade6adb4b6362ff6824509106d52",
+				"DiscoKey":   "discokey:1056e0c149996e1badf91e52769c3b9c57c9110f19c326c4466992511dfe9060",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38395",
+					"10.65.0.27:38395",
+					"172.17.0.1:38395",
+					"172.19.0.1:38395",
+					"172.20.0.1:38395"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:44:34.657909588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7126116325607834,
+				"StableID":   "nRiPTYzRex11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:669e82a20f1fc7ae1c5905601fdc72876c9c3300a00c547263f9e15c420e6447",
+				"DiscoKey":   "discokey:cdba9faf688adeedfd9966cd667acd7d39a470560812c35c41517fbf7096ca3e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59149",
+					"10.65.0.27:59149",
+					"172.17.0.1:59149",
+					"172.19.0.1:59149",
+					"172.20.0.1:59149"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:44:35.189900261Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3561132190558232,
+				"StableID":   "nfa1ASuqoU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38c2d8d7b40a194c2c39d2a4bf2efdd8c514054788b2a42d8c140be3f4f1a646",
+				"DiscoKey":   "discokey:1585ebeda9a49f4efc8001634e21a9449ba88579bd67e817bab87560e2ad072e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34649",
+					"10.65.0.27:34649",
+					"172.17.0.1:34649",
+					"172.19.0.1:34649",
+					"172.20.0.1:34649"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:44:35.727266924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3153019650170486,
+				"StableID":   "n7hfUpU1dR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6920538458a19d646ef2b20151bbc9d477bff09c897e77fcc84fc7a524f39003",
+				"DiscoKey":   "discokey:cc1aafbd867faa68f2bda551528f20be72277ccec03b70d12ab6eb12c9828325",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55740",
+					"10.65.0.27:55740",
+					"172.17.0.1:55740",
+					"172.19.0.1:55740",
+					"172.20.0.1:55740"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:44:36.263222415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5501678073094238,
+				"StableID":   "noF4iikixj11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4703d7880c68845d5a45cdb1aac1c685d21e64bee5699fa7c40facbc30abd249",
+				"DiscoKey":   "discokey:104c24c3f13eb6fe7356dfa0031fc9e6485b65c29e9cf0bd3b0ba5ca4a650523",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:51946",
+					"10.65.0.27:51946",
+					"172.17.0.1:51946",
+					"172.19.0.1:51946",
+					"172.20.0.1:51946"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:44:36.829161674Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         538490739088266,
+				"StableID":   "njK2eqEtC511CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c41ea0844e70201d6075dc39609b0eca79362968e56767a71abb28ec65d4420a",
+				"DiscoKey":   "discokey:38119dbea36c9309935c384bfe8f650115f8914b6995080d152003456eb48039",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:34088",
+					"10.65.0.27:34088",
+					"172.17.0.1:34088",
+					"172.19.0.1:34088",
+					"172.20.0.1:34088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:44:37.329956683Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6253827107285692,
+				"StableID":   "nBYGF9SNqq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28d7d6489916ba1b6324abd3731f4c0244df1be9dbaf6f9cdcc1ec9278643907",
+				"DiscoKey":   "discokey:15c2eefbe7abb1c68061ffffe36c1ab7d74ffa00a9c5ef4664adf2572a1d2a34",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:36675",
+					"10.65.0.27:36675",
+					"172.17.0.1:36675",
+					"172.19.0.1:36675",
+					"172.20.0.1:36675"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:44:37.861204644Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2405435042157557,
+				"StableID":   "nk4ieahRnK11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:23e8d0ef02e79d38c91519ad7a13826220aed20a1a570d7f8f0cde14ebc58938",
+				"DiscoKey":   "discokey:a00c697b16f2aeb0a31ce057b2f17855749440dcdaf1376373668c082741294d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:35669",
+					"10.65.0.27:35669",
+					"172.17.0.1:35669",
+					"172.19.0.1:35669",
+					"172.20.0.1:35669"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:44:38.404131466Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5583262302296445,
+				"StableID":   "nADtfKqfbk11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b699270c9f48e704ff3138a5ee1752827d669f364b90547c96fe08b922626054",
+				"DiscoKey":   "discokey:98cffde6508929296dcd9bb5c9d1f41453e9b8f6e95dc579c1ec9063b7b36d31",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38285",
+					"10.65.0.27:38285",
+					"172.17.0.1:38285",
+					"172.19.0.1:38285",
+					"172.20.0.1:38285"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:44:39.491127718Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5511685850227220,
+				"StableID":   "nwAnhBeF3k11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:33522cbc22aea5361acba0c9b622254c3136708b98af10f8b2849b735fdc2c62",
+				"DiscoKey":   "discokey:5fb5dba31ec64463fb1665cb2d395ca2f8cd3b63b757aacebbb6577f57ba5c73",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41283",
+					"10.65.0.27:41283",
+					"172.17.0.1:41283",
+					"172.19.0.1:41283",
+					"172.20.0.1:41283"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:44:40.031967662Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2263680032413583,
+				"StableID":   "nGZfr53EgJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31ad38503e03d30c54d373657d306fd089975d3349635ece6f96eefb56554c11",
+				"DiscoKey":   "discokey:39f736677a6c328a030d8c9e5f2f2956f070f30828358274b20e206ac34f2026",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45681",
+					"10.65.0.27:45681",
+					"172.17.0.1:45681",
+					"172.19.0.1:45681",
+					"172.20.0.1:45681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:44:40.568859801Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5198346930574694,
+				"StableID":   "n5WRM2mLbh11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:db7354231d6c0052742b51942193133a12b208081c9654c20161815269588b41",
+				"KeyExpiry":  "2026-11-08T18:44:41Z",
+				"DiscoKey":   "discokey:cae61e363f12d435b12c92ccb738fd83507033f592c62e28d20f4fe879c2b45b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47369",
+					"10.65.0.27:47369",
+					"172.17.0.1:47369",
+					"172.19.0.1:47369",
+					"172.20.0.1:47369"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:44:41.120560002Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7025651806050733,
+				"StableID":   "ntgQtexvrw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:26af846559bfbca72813cb62f78d7d231e197f935d8a67c587a123d17d9a3736",
+				"KeyExpiry":  "2026-11-08T18:44:41Z",
+				"DiscoKey":   "discokey:3a6365e153185298635c4724c737ae80d1cca8e7e92539e1e57948f15af45c56",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:53922",
+					"10.65.0.27:53922",
+					"172.17.0.1:53922",
+					"172.19.0.1:53922",
+					"172.20.0.1:53922"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:44:41.645875081Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4581505740785207,
+				"StableID":   "n8RfgSPymc11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b5ec6926ed04532146458efadcb080333e243c136248e21b6f53c852e6169370",
+				"KeyExpiry":  "2026-11-08T18:44:42Z",
+				"DiscoKey":   "discokey:5de48bbeeacd1e2d716bae0031d9bf6a56a7e1f7bc7f95b50e5726094336e208",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47079",
+					"10.65.0.27:47079",
+					"172.17.0.1:47079",
+					"172.19.0.1:47079",
+					"172.20.0.1:47079"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:44:42.176139251Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3288427654510610": {
+				"ID":          3288427654510610,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7025651806050733,
+				"StableID":   "ntgQtexvrw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:26af846559bfbca72813cb62f78d7d231e197f935d8a67c587a123d17d9a3736",
+				"KeyExpiry":  "2026-11-08T18:44:41Z",
+				"DiscoKey":   "discokey:3a6365e153185298635c4724c737ae80d1cca8e7e92539e1e57948f15af45c56",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:53922",
+					"10.65.0.27:53922",
+					"172.17.0.1:53922",
+					"172.19.0.1:53922",
+					"172.20.0.1:53922"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:44:41.645875081Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:26af846559bfbca72813cb62f78d7d231e197f935d8a67c587a123d17d9a3736",
+			"MachineKey": "mkey:020a78b65a3fbcba7039d0444b9c9f586f6d842bf23305ba3fc5a6379f281977",
+			"Peers": [{
+				"ID":         4521942798795311,
+				"StableID":   "nGZuTdmzJc11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8e294a6e97850367b4f6c8c1e66ecdd2649ade6adb4b6362ff6824509106d52",
+				"DiscoKey":   "discokey:1056e0c149996e1badf91e52769c3b9c57c9110f19c326c4466992511dfe9060",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38395",
+					"10.65.0.27:38395",
+					"172.17.0.1:38395",
+					"172.19.0.1:38395",
+					"172.20.0.1:38395"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:44:34.657909588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7126116325607834,
+				"StableID":   "nRiPTYzRex11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:669e82a20f1fc7ae1c5905601fdc72876c9c3300a00c547263f9e15c420e6447",
+				"DiscoKey":   "discokey:cdba9faf688adeedfd9966cd667acd7d39a470560812c35c41517fbf7096ca3e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59149",
+					"10.65.0.27:59149",
+					"172.17.0.1:59149",
+					"172.19.0.1:59149",
+					"172.20.0.1:59149"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:44:35.189900261Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3561132190558232,
+				"StableID":   "nfa1ASuqoU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38c2d8d7b40a194c2c39d2a4bf2efdd8c514054788b2a42d8c140be3f4f1a646",
+				"DiscoKey":   "discokey:1585ebeda9a49f4efc8001634e21a9449ba88579bd67e817bab87560e2ad072e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34649",
+					"10.65.0.27:34649",
+					"172.17.0.1:34649",
+					"172.19.0.1:34649",
+					"172.20.0.1:34649"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:44:35.727266924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3153019650170486,
+				"StableID":   "n7hfUpU1dR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6920538458a19d646ef2b20151bbc9d477bff09c897e77fcc84fc7a524f39003",
+				"DiscoKey":   "discokey:cc1aafbd867faa68f2bda551528f20be72277ccec03b70d12ab6eb12c9828325",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55740",
+					"10.65.0.27:55740",
+					"172.17.0.1:55740",
+					"172.19.0.1:55740",
+					"172.20.0.1:55740"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:44:36.263222415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5501678073094238,
+				"StableID":   "noF4iikixj11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4703d7880c68845d5a45cdb1aac1c685d21e64bee5699fa7c40facbc30abd249",
+				"DiscoKey":   "discokey:104c24c3f13eb6fe7356dfa0031fc9e6485b65c29e9cf0bd3b0ba5ca4a650523",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:51946",
+					"10.65.0.27:51946",
+					"172.17.0.1:51946",
+					"172.19.0.1:51946",
+					"172.20.0.1:51946"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:44:36.829161674Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         538490739088266,
+				"StableID":   "njK2eqEtC511CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c41ea0844e70201d6075dc39609b0eca79362968e56767a71abb28ec65d4420a",
+				"DiscoKey":   "discokey:38119dbea36c9309935c384bfe8f650115f8914b6995080d152003456eb48039",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:34088",
+					"10.65.0.27:34088",
+					"172.17.0.1:34088",
+					"172.19.0.1:34088",
+					"172.20.0.1:34088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:44:37.329956683Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6253827107285692,
+				"StableID":   "nBYGF9SNqq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28d7d6489916ba1b6324abd3731f4c0244df1be9dbaf6f9cdcc1ec9278643907",
+				"DiscoKey":   "discokey:15c2eefbe7abb1c68061ffffe36c1ab7d74ffa00a9c5ef4664adf2572a1d2a34",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:36675",
+					"10.65.0.27:36675",
+					"172.17.0.1:36675",
+					"172.19.0.1:36675",
+					"172.20.0.1:36675"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:44:37.861204644Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2405435042157557,
+				"StableID":   "nk4ieahRnK11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:23e8d0ef02e79d38c91519ad7a13826220aed20a1a570d7f8f0cde14ebc58938",
+				"DiscoKey":   "discokey:a00c697b16f2aeb0a31ce057b2f17855749440dcdaf1376373668c082741294d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:35669",
+					"10.65.0.27:35669",
+					"172.17.0.1:35669",
+					"172.19.0.1:35669",
+					"172.20.0.1:35669"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:44:38.404131466Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3288427654510610,
+				"StableID":   "n1zy8GRLgS11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:320c694a094e80f650e89580de8c5500b0d33cd8724184cbfc75f104e94fce79",
+				"DiscoKey":   "discokey:224a233afc25468db3bec38f0a22d6a910571811b270c4a01814e88f419c4d0d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:55078",
+					"10.65.0.27:55078",
+					"172.17.0.1:55078",
+					"172.19.0.1:55078",
+					"172.20.0.1:55078"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:44:38.952553308Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5583262302296445,
+				"StableID":   "nADtfKqfbk11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b699270c9f48e704ff3138a5ee1752827d669f364b90547c96fe08b922626054",
+				"DiscoKey":   "discokey:98cffde6508929296dcd9bb5c9d1f41453e9b8f6e95dc579c1ec9063b7b36d31",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38285",
+					"10.65.0.27:38285",
+					"172.17.0.1:38285",
+					"172.19.0.1:38285",
+					"172.20.0.1:38285"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:44:39.491127718Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         5511685850227220,
+				"StableID":   "nwAnhBeF3k11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:33522cbc22aea5361acba0c9b622254c3136708b98af10f8b2849b735fdc2c62",
+				"DiscoKey":   "discokey:5fb5dba31ec64463fb1665cb2d395ca2f8cd3b63b757aacebbb6577f57ba5c73",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41283",
+					"10.65.0.27:41283",
+					"172.17.0.1:41283",
+					"172.19.0.1:41283",
+					"172.20.0.1:41283"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:44:40.031967662Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2263680032413583,
+				"StableID":   "nGZfr53EgJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31ad38503e03d30c54d373657d306fd089975d3349635ece6f96eefb56554c11",
+				"DiscoKey":   "discokey:39f736677a6c328a030d8c9e5f2f2956f070f30828358274b20e206ac34f2026",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45681",
+					"10.65.0.27:45681",
+					"172.17.0.1:45681",
+					"172.19.0.1:45681",
+					"172.20.0.1:45681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:44:40.568859801Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5198346930574694,
+				"StableID":   "n5WRM2mLbh11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:db7354231d6c0052742b51942193133a12b208081c9654c20161815269588b41",
+				"KeyExpiry":  "2026-11-08T18:44:41Z",
+				"DiscoKey":   "discokey:cae61e363f12d435b12c92ccb738fd83507033f592c62e28d20f4fe879c2b45b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47369",
+					"10.65.0.27:47369",
+					"172.17.0.1:47369",
+					"172.19.0.1:47369",
+					"172.20.0.1:47369"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:44:41.120560002Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4581505740785207,
+				"StableID":   "n8RfgSPymc11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b5ec6926ed04532146458efadcb080333e243c136248e21b6f53c852e6169370",
+				"KeyExpiry":  "2026-11-08T18:44:42Z",
+				"DiscoKey":   "discokey:5de48bbeeacd1e2d716bae0031d9bf6a56a7e1f7bc7f95b50e5726094336e208",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47079",
+					"10.65.0.27:47079",
+					"172.17.0.1:47079",
+					"172.19.0.1:47079",
+					"172.20.0.1:47079"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:44:42.176139251Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5583262302296445,
+				"StableID":   "nADtfKqfbk11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       5583262302296445,
+				"Key":        "nodekey:b699270c9f48e704ff3138a5ee1752827d669f364b90547c96fe08b922626054",
+				"DiscoKey":   "discokey:98cffde6508929296dcd9bb5c9d1f41453e9b8f6e95dc579c1ec9063b7b36d31",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38285",
+					"10.65.0.27:38285",
+					"172.17.0.1:38285",
+					"172.19.0.1:38285",
+					"172.20.0.1:38285"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:44:39.491127718Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b699270c9f48e704ff3138a5ee1752827d669f364b90547c96fe08b922626054",
+			"MachineKey": "mkey:4f8bc428d7868ab83eb1531cd20c4c3ec71adbb554e2a6876de09abf548ab325",
+			"Peers": [{
+				"ID":         4521942798795311,
+				"StableID":   "nGZuTdmzJc11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8e294a6e97850367b4f6c8c1e66ecdd2649ade6adb4b6362ff6824509106d52",
+				"DiscoKey":   "discokey:1056e0c149996e1badf91e52769c3b9c57c9110f19c326c4466992511dfe9060",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:38395",
+					"10.65.0.27:38395",
+					"172.17.0.1:38395",
+					"172.19.0.1:38395",
+					"172.20.0.1:38395"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:44:34.657909588Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7126116325607834,
+				"StableID":   "nRiPTYzRex11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:669e82a20f1fc7ae1c5905601fdc72876c9c3300a00c547263f9e15c420e6447",
+				"DiscoKey":   "discokey:cdba9faf688adeedfd9966cd667acd7d39a470560812c35c41517fbf7096ca3e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:59149",
+					"10.65.0.27:59149",
+					"172.17.0.1:59149",
+					"172.19.0.1:59149",
+					"172.20.0.1:59149"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:44:35.189900261Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3561132190558232,
+				"StableID":   "nfa1ASuqoU11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:38c2d8d7b40a194c2c39d2a4bf2efdd8c514054788b2a42d8c140be3f4f1a646",
+				"DiscoKey":   "discokey:1585ebeda9a49f4efc8001634e21a9449ba88579bd67e817bab87560e2ad072e",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:34649",
+					"10.65.0.27:34649",
+					"172.17.0.1:34649",
+					"172.19.0.1:34649",
+					"172.20.0.1:34649"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:44:35.727266924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3153019650170486,
+				"StableID":   "n7hfUpU1dR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6920538458a19d646ef2b20151bbc9d477bff09c897e77fcc84fc7a524f39003",
+				"DiscoKey":   "discokey:cc1aafbd867faa68f2bda551528f20be72277ccec03b70d12ab6eb12c9828325",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55740",
+					"10.65.0.27:55740",
+					"172.17.0.1:55740",
+					"172.19.0.1:55740",
+					"172.20.0.1:55740"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:44:36.263222415Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5501678073094238,
+				"StableID":   "noF4iikixj11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4703d7880c68845d5a45cdb1aac1c685d21e64bee5699fa7c40facbc30abd249",
+				"DiscoKey":   "discokey:104c24c3f13eb6fe7356dfa0031fc9e6485b65c29e9cf0bd3b0ba5ca4a650523",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:51946",
+					"10.65.0.27:51946",
+					"172.17.0.1:51946",
+					"172.19.0.1:51946",
+					"172.20.0.1:51946"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:44:36.829161674Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         538490739088266,
+				"StableID":   "njK2eqEtC511CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c41ea0844e70201d6075dc39609b0eca79362968e56767a71abb28ec65d4420a",
+				"DiscoKey":   "discokey:38119dbea36c9309935c384bfe8f650115f8914b6995080d152003456eb48039",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:34088",
+					"10.65.0.27:34088",
+					"172.17.0.1:34088",
+					"172.19.0.1:34088",
+					"172.20.0.1:34088"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:44:37.329956683Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6253827107285692,
+				"StableID":   "nBYGF9SNqq11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:28d7d6489916ba1b6324abd3731f4c0244df1be9dbaf6f9cdcc1ec9278643907",
+				"DiscoKey":   "discokey:15c2eefbe7abb1c68061ffffe36c1ab7d74ffa00a9c5ef4664adf2572a1d2a34",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:36675",
+					"10.65.0.27:36675",
+					"172.17.0.1:36675",
+					"172.19.0.1:36675",
+					"172.20.0.1:36675"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:44:37.861204644Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2405435042157557,
+				"StableID":   "nk4ieahRnK11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:23e8d0ef02e79d38c91519ad7a13826220aed20a1a570d7f8f0cde14ebc58938",
+				"DiscoKey":   "discokey:a00c697b16f2aeb0a31ce057b2f17855749440dcdaf1376373668c082741294d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:35669",
+					"10.65.0.27:35669",
+					"172.17.0.1:35669",
+					"172.19.0.1:35669",
+					"172.20.0.1:35669"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:44:38.404131466Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3288427654510610,
+				"StableID":   "n1zy8GRLgS11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:320c694a094e80f650e89580de8c5500b0d33cd8724184cbfc75f104e94fce79",
+				"DiscoKey":   "discokey:224a233afc25468db3bec38f0a22d6a910571811b270c4a01814e88f419c4d0d",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:55078",
+					"10.65.0.27:55078",
+					"172.17.0.1:55078",
+					"172.19.0.1:55078",
+					"172.20.0.1:55078"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:44:38.952553308Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5511685850227220,
+				"StableID":   "nwAnhBeF3k11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:33522cbc22aea5361acba0c9b622254c3136708b98af10f8b2849b735fdc2c62",
+				"DiscoKey":   "discokey:5fb5dba31ec64463fb1665cb2d395ca2f8cd3b63b757aacebbb6577f57ba5c73",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:41283",
+					"10.65.0.27:41283",
+					"172.17.0.1:41283",
+					"172.19.0.1:41283",
+					"172.20.0.1:41283"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:44:40.031967662Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2263680032413583,
+				"StableID":   "nGZfr53EgJ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:31ad38503e03d30c54d373657d306fd089975d3349635ece6f96eefb56554c11",
+				"DiscoKey":   "discokey:39f736677a6c328a030d8c9e5f2f2956f070f30828358274b20e206ac34f2026",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:45681",
+					"10.65.0.27:45681",
+					"172.17.0.1:45681",
+					"172.19.0.1:45681",
+					"172.20.0.1:45681"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:44:40.568859801Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5198346930574694,
+				"StableID":   "n5WRM2mLbh11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:db7354231d6c0052742b51942193133a12b208081c9654c20161815269588b41",
+				"KeyExpiry":  "2026-11-08T18:44:41Z",
+				"DiscoKey":   "discokey:cae61e363f12d435b12c92ccb738fd83507033f592c62e28d20f4fe879c2b45b",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:47369",
+					"10.65.0.27:47369",
+					"172.17.0.1:47369",
+					"172.19.0.1:47369",
+					"172.20.0.1:47369"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:44:41.120560002Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7025651806050733,
+				"StableID":   "ntgQtexvrw11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:26af846559bfbca72813cb62f78d7d231e197f935d8a67c587a123d17d9a3736",
+				"KeyExpiry":  "2026-11-08T18:44:41Z",
+				"DiscoKey":   "discokey:3a6365e153185298635c4724c737ae80d1cca8e7e92539e1e57948f15af45c56",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:53922",
+					"10.65.0.27:53922",
+					"172.17.0.1:53922",
+					"172.19.0.1:53922",
+					"172.20.0.1:53922"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:44:41.645875081Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4581505740785207,
+				"StableID":   "n8RfgSPymc11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b5ec6926ed04532146458efadcb080333e243c136248e21b6f53c852e6169370",
+				"KeyExpiry":  "2026-11-08T18:44:42Z",
+				"DiscoKey":   "discokey:5de48bbeeacd1e2d716bae0031d9bf6a56a7e1f7bc7f95b50e5726094336e208",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:47079",
+					"10.65.0.27:47079",
+					"172.17.0.1:47079",
+					"172.19.0.1:47079",
+					"172.20.0.1:47079"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:44:42.176139251Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5583262302296445": {
+				"ID":          5583262302296445,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/sshtest_results/sshtest-malformed-empty-accept-and-deny.hujson
+++ b/hscontrol/policy/v2/testdata/sshtest_results/sshtest-malformed-empty-accept-and-deny.hujson
@@ -1,0 +1,20082 @@
+// sshtest-malformed-empty-accept-and-deny
+//
+// sshTests with no accept/check/deny
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T18:45:18Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "sshtest-malformed-empty-accept-and-deny",
+	"description":    "sshTests with no accept/check/deny",
+	"category":       "sshtest",
+	"captured_at":    "2026-05-12T18:45:18.184489289Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                          \n  \n                                                                        \n                              \n{\n\t\"category\":    \"sshtest\",\n\t\"description\": \"sshTests with no accept/check/deny\",\n\t\"id\":          \"sshtest-malformed-empty-accept-and-deny\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"thor@example.org\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"sshTests\": [{\n\t\t\"dst\": [\"tag:server\"],\n\t\t\"src\": \"thor@example.org\"\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/sshtest/sshtest-malformed-empty-accept-and-deny.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["thor@example.org"],
+				"users":  ["root"]
+			}],
+			"sshTests":  [{"dst": ["tag:server"], "src": "thor@example.org"}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7916156635023265,
+				"StableID":   "n4tTEf1Fp421CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       7916156635023265,
+				"Key":        "nodekey:f51a703bc03c0293c542d6aeff8195b23ed53c06c37a67aa0f8202b376ce572a",
+				"DiscoKey":   "discokey:58651a90ba83cf5df4d89731a9f3242a9a7701d4785963b2b60101d7332c020d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59781",
+					"10.65.0.27:59781",
+					"172.17.0.1:59781",
+					"172.19.0.1:59781",
+					"172.20.0.1:59781"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:45:26.586955227Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f51a703bc03c0293c542d6aeff8195b23ed53c06c37a67aa0f8202b376ce572a",
+			"MachineKey": "mkey:7c64fe20066eee1c1958b171acaa731abef0d14b20294c151f5fa6b316630108",
+			"Peers": [{
+				"ID":         3005675596089889,
+				"StableID":   "naHVy41HUQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee93fe882ac599a7dbcd960270ac5f271fb8559d3c2af2f24f4e32c756322e7b",
+				"DiscoKey":   "discokey:d62c8b588623d1fe7be251fcff334d4437bee0501c96d1f62117bfce89919c05",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44609",
+					"10.65.0.27:44609",
+					"172.17.0.1:44609",
+					"172.19.0.1:44609",
+					"172.20.0.1:44609"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:45:20.611328771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3884911169048265,
+				"StableID":   "nJTpkf2VLX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5b4edd734cabe00a43bd2c9fcc118e681cf94d2d8af4677ef326698da8ca7019",
+				"DiscoKey":   "discokey:8c869319f397cec875adbe95aeb47a51674e7803df45baf79d734d807110b822",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43888",
+					"10.65.0.27:43888",
+					"172.17.0.1:43888",
+					"172.19.0.1:43888",
+					"172.20.0.1:43888"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:45:21.161596486Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2682102994127782,
+				"StableID":   "nf7LAGJjwM11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:189ff51becd6d0bfed4c66943e0c8d9f036901bd59c9ee50806a2ff5d168d53e",
+				"DiscoKey":   "discokey:245ae4a740ce1251c5454ed092ff41ac94f2a6907a8a42138c6bf397c2e27563",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56842",
+					"10.65.0.27:56842",
+					"172.17.0.1:56842",
+					"172.19.0.1:56842",
+					"172.20.0.1:56842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:45:21.702222683Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         295175053585725,
+				"StableID":   "nrbwhPkgJ311CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f74a84fdb9fa242700f7a36568494257af9cdc1f25b223e0a8138407ad877254",
+				"DiscoKey":   "discokey:0cb0fe1deb7d281965189878323b32fad1c61d16445778eb3695c014146b2437",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55206",
+					"10.65.0.27:55206",
+					"172.17.0.1:55206",
+					"172.19.0.1:55206",
+					"172.20.0.1:55206"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:45:22.242427716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2348972764534612,
+				"StableID":   "nZyJXpXrLK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe5426f56f32bcfc2a58d0aba8b74ac611e4285b2568c64adec88c722b86fc79",
+				"DiscoKey":   "discokey:a7cd78af61a05de65b27fc998dd914bfd3ffb14d2cc03522a09ddda30da41c21",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48950",
+					"10.65.0.27:48950",
+					"172.17.0.1:48950",
+					"172.19.0.1:48950",
+					"172.20.0.1:48950"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:45:22.786821071Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2093377381667358,
+				"StableID":   "nRxTnVU6MH11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:537d8107ecdcd8094edf38eddfa21bf1922ada8a23dba383336c831e9401a81c",
+				"DiscoKey":   "discokey:e08b255837e11a99fae38762214e28f5fbabdceb317d6aa11a5a97fd99449b29",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53554",
+					"10.65.0.27:53554",
+					"172.17.0.1:53554",
+					"172.19.0.1:53554",
+					"172.20.0.1:53554"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:45:23.329614404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4883803390066644,
+				"StableID":   "nyqJnYEt8f11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ef8056591f22e56353373f9a48a44372abc53dedd539c024ff77473f23a8060",
+				"DiscoKey":   "discokey:a4b639350fbdebd216ee7fd9c8d7f4e30b45b8b1cd326b3d2d9fb71ae2418e47",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:45841",
+					"10.65.0.27:45841",
+					"172.17.0.1:45841",
+					"172.19.0.1:45841",
+					"172.20.0.1:45841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:45:23.873352325Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7717738457324610,
+				"StableID":   "n9aZKLuNG321CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ba643b89e9957dadf323bef17dc6099333721d546e2684df357bdb7d4df8631",
+				"DiscoKey":   "discokey:2b367f33370030a9b94333c2ea57e5592a9bfed7c6ecb14ec6a779a0cabcc67c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33449",
+					"10.65.0.27:33449",
+					"172.17.0.1:33449",
+					"172.19.0.1:33449",
+					"172.20.0.1:33449"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:45:24.412538146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7775065919153324,
+				"StableID":   "nKUApFoLi321CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e62287606fa8f9e4d91c9b02e1fe6c4f0ca69f6803ae2e66341b1d5865df96b",
+				"DiscoKey":   "discokey:b3f72c8d3c8cf510efac419485528c206f04e3174a91733f58c3f1dfb30a951a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35815",
+					"10.65.0.27:35815",
+					"172.17.0.1:35815",
+					"172.19.0.1:35815",
+					"172.20.0.1:35815"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:45:24.956739133Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6910355556467664,
+				"StableID":   "n1fC8iKixv11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6bb38945ec51175c2739b5719faea1e0cc792b066db16825c712ab702b35309",
+				"DiscoKey":   "discokey:48eb78ba5de8aa665f5fd9fc365bc748017d1be2ec6d78b25647e2227fdf157e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58789",
+					"10.65.0.27:58789",
+					"172.17.0.1:58789",
+					"172.19.0.1:58789",
+					"172.20.0.1:58789"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:45:25.492965382Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4186940600992235,
+				"StableID":   "nG1WQ8qGhZ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:760ba27fe23da3e3eda944b83a8834d276304c4b6f1955df923b158e8311eb0d",
+				"DiscoKey":   "discokey:250c01d24631f650775faa302225dd1f69daea694940ae6ac78bc8295ea24446",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60690",
+					"10.65.0.27:60690",
+					"172.17.0.1:60690",
+					"172.19.0.1:60690",
+					"172.20.0.1:60690"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:45:26.046135004Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         801010699670203,
+				"StableID":   "ngFfbBCnF711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ad2e6cc741e04a5d763513ff5e4e6cb243484d9f9364b188c38501d44f3ed40f",
+				"KeyExpiry":  "2026-11-08T18:45:27Z",
+				"DiscoKey":   "discokey:842210576b88f2092b6f9db6039b4452570bfcc8438c7b2668e4d4590204ea58",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:56182",
+					"10.65.0.27:56182",
+					"172.17.0.1:56182",
+					"172.19.0.1:56182",
+					"172.20.0.1:56182"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:45:27.121273324Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5937994875226728,
+				"StableID":   "nj87RG4LNo11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3163ea23fd3b28aa95d4240440feb274b0859ebdf70f35f9b334c05e33128113",
+				"KeyExpiry":  "2026-11-08T18:45:27Z",
+				"DiscoKey":   "discokey:e7633eda51a3c2d7012df72d8d2eca6ce0ca6eaebd049db079bc01b0e38b4451",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54896",
+					"10.65.0.27:54896",
+					"172.17.0.1:54896",
+					"172.19.0.1:54896",
+					"172.20.0.1:54896"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:45:27.664103044Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2061318940502245,
+				"StableID":   "nLtn7VMa6H11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c8e8df506c143215ee7232335f87820953f68af2ca6c6d70da33d404a7a66b4e",
+				"KeyExpiry":  "2026-11-08T18:45:28Z",
+				"DiscoKey":   "discokey:dea3c1689bf04862d4ccaf4e4a7c880d27a755ee9bc34ed5e087094331419d5b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41366",
+					"10.65.0.27:41366",
+					"172.17.0.1:41366",
+					"172.19.0.1:41366",
+					"172.20.0.1:41366"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:45:28.218012086Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7916156635023265": {
+				"ID":          7916156635023265,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2093377381667358,
+				"StableID":   "nRxTnVU6MH11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       2093377381667358,
+				"Key":        "nodekey:537d8107ecdcd8094edf38eddfa21bf1922ada8a23dba383336c831e9401a81c",
+				"DiscoKey":   "discokey:e08b255837e11a99fae38762214e28f5fbabdceb317d6aa11a5a97fd99449b29",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53554",
+					"10.65.0.27:53554",
+					"172.17.0.1:53554",
+					"172.19.0.1:53554",
+					"172.20.0.1:53554"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:45:23.329614404Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:537d8107ecdcd8094edf38eddfa21bf1922ada8a23dba383336c831e9401a81c",
+			"MachineKey": "mkey:6dab248c3a99aef12540f79bbd2fcad500f13dc1000dbb14b052d86265ca466a",
+			"Peers": [{
+				"ID":         3005675596089889,
+				"StableID":   "naHVy41HUQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee93fe882ac599a7dbcd960270ac5f271fb8559d3c2af2f24f4e32c756322e7b",
+				"DiscoKey":   "discokey:d62c8b588623d1fe7be251fcff334d4437bee0501c96d1f62117bfce89919c05",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44609",
+					"10.65.0.27:44609",
+					"172.17.0.1:44609",
+					"172.19.0.1:44609",
+					"172.20.0.1:44609"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:45:20.611328771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3884911169048265,
+				"StableID":   "nJTpkf2VLX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5b4edd734cabe00a43bd2c9fcc118e681cf94d2d8af4677ef326698da8ca7019",
+				"DiscoKey":   "discokey:8c869319f397cec875adbe95aeb47a51674e7803df45baf79d734d807110b822",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43888",
+					"10.65.0.27:43888",
+					"172.17.0.1:43888",
+					"172.19.0.1:43888",
+					"172.20.0.1:43888"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:45:21.161596486Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2682102994127782,
+				"StableID":   "nf7LAGJjwM11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:189ff51becd6d0bfed4c66943e0c8d9f036901bd59c9ee50806a2ff5d168d53e",
+				"DiscoKey":   "discokey:245ae4a740ce1251c5454ed092ff41ac94f2a6907a8a42138c6bf397c2e27563",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56842",
+					"10.65.0.27:56842",
+					"172.17.0.1:56842",
+					"172.19.0.1:56842",
+					"172.20.0.1:56842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:45:21.702222683Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         295175053585725,
+				"StableID":   "nrbwhPkgJ311CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f74a84fdb9fa242700f7a36568494257af9cdc1f25b223e0a8138407ad877254",
+				"DiscoKey":   "discokey:0cb0fe1deb7d281965189878323b32fad1c61d16445778eb3695c014146b2437",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55206",
+					"10.65.0.27:55206",
+					"172.17.0.1:55206",
+					"172.19.0.1:55206",
+					"172.20.0.1:55206"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:45:22.242427716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2348972764534612,
+				"StableID":   "nZyJXpXrLK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe5426f56f32bcfc2a58d0aba8b74ac611e4285b2568c64adec88c722b86fc79",
+				"DiscoKey":   "discokey:a7cd78af61a05de65b27fc998dd914bfd3ffb14d2cc03522a09ddda30da41c21",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48950",
+					"10.65.0.27:48950",
+					"172.17.0.1:48950",
+					"172.19.0.1:48950",
+					"172.20.0.1:48950"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:45:22.786821071Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4883803390066644,
+				"StableID":   "nyqJnYEt8f11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ef8056591f22e56353373f9a48a44372abc53dedd539c024ff77473f23a8060",
+				"DiscoKey":   "discokey:a4b639350fbdebd216ee7fd9c8d7f4e30b45b8b1cd326b3d2d9fb71ae2418e47",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:45841",
+					"10.65.0.27:45841",
+					"172.17.0.1:45841",
+					"172.19.0.1:45841",
+					"172.20.0.1:45841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:45:23.873352325Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7717738457324610,
+				"StableID":   "n9aZKLuNG321CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ba643b89e9957dadf323bef17dc6099333721d546e2684df357bdb7d4df8631",
+				"DiscoKey":   "discokey:2b367f33370030a9b94333c2ea57e5592a9bfed7c6ecb14ec6a779a0cabcc67c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33449",
+					"10.65.0.27:33449",
+					"172.17.0.1:33449",
+					"172.19.0.1:33449",
+					"172.20.0.1:33449"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:45:24.412538146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7775065919153324,
+				"StableID":   "nKUApFoLi321CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e62287606fa8f9e4d91c9b02e1fe6c4f0ca69f6803ae2e66341b1d5865df96b",
+				"DiscoKey":   "discokey:b3f72c8d3c8cf510efac419485528c206f04e3174a91733f58c3f1dfb30a951a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35815",
+					"10.65.0.27:35815",
+					"172.17.0.1:35815",
+					"172.19.0.1:35815",
+					"172.20.0.1:35815"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:45:24.956739133Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6910355556467664,
+				"StableID":   "n1fC8iKixv11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6bb38945ec51175c2739b5719faea1e0cc792b066db16825c712ab702b35309",
+				"DiscoKey":   "discokey:48eb78ba5de8aa665f5fd9fc365bc748017d1be2ec6d78b25647e2227fdf157e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58789",
+					"10.65.0.27:58789",
+					"172.17.0.1:58789",
+					"172.19.0.1:58789",
+					"172.20.0.1:58789"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:45:25.492965382Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4186940600992235,
+				"StableID":   "nG1WQ8qGhZ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:760ba27fe23da3e3eda944b83a8834d276304c4b6f1955df923b158e8311eb0d",
+				"DiscoKey":   "discokey:250c01d24631f650775faa302225dd1f69daea694940ae6ac78bc8295ea24446",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60690",
+					"10.65.0.27:60690",
+					"172.17.0.1:60690",
+					"172.19.0.1:60690",
+					"172.20.0.1:60690"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:45:26.046135004Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7916156635023265,
+				"StableID":   "n4tTEf1Fp421CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f51a703bc03c0293c542d6aeff8195b23ed53c06c37a67aa0f8202b376ce572a",
+				"DiscoKey":   "discokey:58651a90ba83cf5df4d89731a9f3242a9a7701d4785963b2b60101d7332c020d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59781",
+					"10.65.0.27:59781",
+					"172.17.0.1:59781",
+					"172.19.0.1:59781",
+					"172.20.0.1:59781"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:45:26.586955227Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         801010699670203,
+				"StableID":   "ngFfbBCnF711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ad2e6cc741e04a5d763513ff5e4e6cb243484d9f9364b188c38501d44f3ed40f",
+				"KeyExpiry":  "2026-11-08T18:45:27Z",
+				"DiscoKey":   "discokey:842210576b88f2092b6f9db6039b4452570bfcc8438c7b2668e4d4590204ea58",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:56182",
+					"10.65.0.27:56182",
+					"172.17.0.1:56182",
+					"172.19.0.1:56182",
+					"172.20.0.1:56182"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:45:27.121273324Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5937994875226728,
+				"StableID":   "nj87RG4LNo11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3163ea23fd3b28aa95d4240440feb274b0859ebdf70f35f9b334c05e33128113",
+				"KeyExpiry":  "2026-11-08T18:45:27Z",
+				"DiscoKey":   "discokey:e7633eda51a3c2d7012df72d8d2eca6ce0ca6eaebd049db079bc01b0e38b4451",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54896",
+					"10.65.0.27:54896",
+					"172.17.0.1:54896",
+					"172.19.0.1:54896",
+					"172.20.0.1:54896"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:45:27.664103044Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2061318940502245,
+				"StableID":   "nLtn7VMa6H11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c8e8df506c143215ee7232335f87820953f68af2ca6c6d70da33d404a7a66b4e",
+				"KeyExpiry":  "2026-11-08T18:45:28Z",
+				"DiscoKey":   "discokey:dea3c1689bf04862d4ccaf4e4a7c880d27a755ee9bc34ed5e087094331419d5b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41366",
+					"10.65.0.27:41366",
+					"172.17.0.1:41366",
+					"172.19.0.1:41366",
+					"172.20.0.1:41366"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:45:28.218012086Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2093377381667358": {
+				"ID":          2093377381667358,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2061318940502245,
+				"StableID":   "nLtn7VMa6H11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c8e8df506c143215ee7232335f87820953f68af2ca6c6d70da33d404a7a66b4e",
+				"KeyExpiry":  "2026-11-08T18:45:28Z",
+				"DiscoKey":   "discokey:dea3c1689bf04862d4ccaf4e4a7c880d27a755ee9bc34ed5e087094331419d5b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41366",
+					"10.65.0.27:41366",
+					"172.17.0.1:41366",
+					"172.19.0.1:41366",
+					"172.20.0.1:41366"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:45:28.218012086Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c8e8df506c143215ee7232335f87820953f68af2ca6c6d70da33d404a7a66b4e",
+			"MachineKey": "mkey:9ff6693851055cb3a34f166c38a3463c840281fdaffcbfd816b470358d622038",
+			"Peers": [{
+				"ID":         3005675596089889,
+				"StableID":   "naHVy41HUQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee93fe882ac599a7dbcd960270ac5f271fb8559d3c2af2f24f4e32c756322e7b",
+				"DiscoKey":   "discokey:d62c8b588623d1fe7be251fcff334d4437bee0501c96d1f62117bfce89919c05",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44609",
+					"10.65.0.27:44609",
+					"172.17.0.1:44609",
+					"172.19.0.1:44609",
+					"172.20.0.1:44609"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:45:20.611328771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3884911169048265,
+				"StableID":   "nJTpkf2VLX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5b4edd734cabe00a43bd2c9fcc118e681cf94d2d8af4677ef326698da8ca7019",
+				"DiscoKey":   "discokey:8c869319f397cec875adbe95aeb47a51674e7803df45baf79d734d807110b822",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43888",
+					"10.65.0.27:43888",
+					"172.17.0.1:43888",
+					"172.19.0.1:43888",
+					"172.20.0.1:43888"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:45:21.161596486Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2682102994127782,
+				"StableID":   "nf7LAGJjwM11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:189ff51becd6d0bfed4c66943e0c8d9f036901bd59c9ee50806a2ff5d168d53e",
+				"DiscoKey":   "discokey:245ae4a740ce1251c5454ed092ff41ac94f2a6907a8a42138c6bf397c2e27563",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56842",
+					"10.65.0.27:56842",
+					"172.17.0.1:56842",
+					"172.19.0.1:56842",
+					"172.20.0.1:56842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:45:21.702222683Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         295175053585725,
+				"StableID":   "nrbwhPkgJ311CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f74a84fdb9fa242700f7a36568494257af9cdc1f25b223e0a8138407ad877254",
+				"DiscoKey":   "discokey:0cb0fe1deb7d281965189878323b32fad1c61d16445778eb3695c014146b2437",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55206",
+					"10.65.0.27:55206",
+					"172.17.0.1:55206",
+					"172.19.0.1:55206",
+					"172.20.0.1:55206"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:45:22.242427716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2348972764534612,
+				"StableID":   "nZyJXpXrLK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe5426f56f32bcfc2a58d0aba8b74ac611e4285b2568c64adec88c722b86fc79",
+				"DiscoKey":   "discokey:a7cd78af61a05de65b27fc998dd914bfd3ffb14d2cc03522a09ddda30da41c21",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48950",
+					"10.65.0.27:48950",
+					"172.17.0.1:48950",
+					"172.19.0.1:48950",
+					"172.20.0.1:48950"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:45:22.786821071Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2093377381667358,
+				"StableID":   "nRxTnVU6MH11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:537d8107ecdcd8094edf38eddfa21bf1922ada8a23dba383336c831e9401a81c",
+				"DiscoKey":   "discokey:e08b255837e11a99fae38762214e28f5fbabdceb317d6aa11a5a97fd99449b29",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53554",
+					"10.65.0.27:53554",
+					"172.17.0.1:53554",
+					"172.19.0.1:53554",
+					"172.20.0.1:53554"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:45:23.329614404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4883803390066644,
+				"StableID":   "nyqJnYEt8f11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ef8056591f22e56353373f9a48a44372abc53dedd539c024ff77473f23a8060",
+				"DiscoKey":   "discokey:a4b639350fbdebd216ee7fd9c8d7f4e30b45b8b1cd326b3d2d9fb71ae2418e47",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:45841",
+					"10.65.0.27:45841",
+					"172.17.0.1:45841",
+					"172.19.0.1:45841",
+					"172.20.0.1:45841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:45:23.873352325Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7717738457324610,
+				"StableID":   "n9aZKLuNG321CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ba643b89e9957dadf323bef17dc6099333721d546e2684df357bdb7d4df8631",
+				"DiscoKey":   "discokey:2b367f33370030a9b94333c2ea57e5592a9bfed7c6ecb14ec6a779a0cabcc67c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33449",
+					"10.65.0.27:33449",
+					"172.17.0.1:33449",
+					"172.19.0.1:33449",
+					"172.20.0.1:33449"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:45:24.412538146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7775065919153324,
+				"StableID":   "nKUApFoLi321CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e62287606fa8f9e4d91c9b02e1fe6c4f0ca69f6803ae2e66341b1d5865df96b",
+				"DiscoKey":   "discokey:b3f72c8d3c8cf510efac419485528c206f04e3174a91733f58c3f1dfb30a951a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35815",
+					"10.65.0.27:35815",
+					"172.17.0.1:35815",
+					"172.19.0.1:35815",
+					"172.20.0.1:35815"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:45:24.956739133Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6910355556467664,
+				"StableID":   "n1fC8iKixv11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6bb38945ec51175c2739b5719faea1e0cc792b066db16825c712ab702b35309",
+				"DiscoKey":   "discokey:48eb78ba5de8aa665f5fd9fc365bc748017d1be2ec6d78b25647e2227fdf157e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58789",
+					"10.65.0.27:58789",
+					"172.17.0.1:58789",
+					"172.19.0.1:58789",
+					"172.20.0.1:58789"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:45:25.492965382Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4186940600992235,
+				"StableID":   "nG1WQ8qGhZ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:760ba27fe23da3e3eda944b83a8834d276304c4b6f1955df923b158e8311eb0d",
+				"DiscoKey":   "discokey:250c01d24631f650775faa302225dd1f69daea694940ae6ac78bc8295ea24446",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60690",
+					"10.65.0.27:60690",
+					"172.17.0.1:60690",
+					"172.19.0.1:60690",
+					"172.20.0.1:60690"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:45:26.046135004Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7916156635023265,
+				"StableID":   "n4tTEf1Fp421CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f51a703bc03c0293c542d6aeff8195b23ed53c06c37a67aa0f8202b376ce572a",
+				"DiscoKey":   "discokey:58651a90ba83cf5df4d89731a9f3242a9a7701d4785963b2b60101d7332c020d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59781",
+					"10.65.0.27:59781",
+					"172.17.0.1:59781",
+					"172.19.0.1:59781",
+					"172.20.0.1:59781"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:45:26.586955227Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         801010699670203,
+				"StableID":   "ngFfbBCnF711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ad2e6cc741e04a5d763513ff5e4e6cb243484d9f9364b188c38501d44f3ed40f",
+				"KeyExpiry":  "2026-11-08T18:45:27Z",
+				"DiscoKey":   "discokey:842210576b88f2092b6f9db6039b4452570bfcc8438c7b2668e4d4590204ea58",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:56182",
+					"10.65.0.27:56182",
+					"172.17.0.1:56182",
+					"172.19.0.1:56182",
+					"172.20.0.1:56182"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:45:27.121273324Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5937994875226728,
+				"StableID":   "nj87RG4LNo11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3163ea23fd3b28aa95d4240440feb274b0859ebdf70f35f9b334c05e33128113",
+				"KeyExpiry":  "2026-11-08T18:45:27Z",
+				"DiscoKey":   "discokey:e7633eda51a3c2d7012df72d8d2eca6ce0ca6eaebd049db079bc01b0e38b4451",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54896",
+					"10.65.0.27:54896",
+					"172.17.0.1:54896",
+					"172.19.0.1:54896",
+					"172.20.0.1:54896"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:45:27.664103044Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2682102994127782,
+				"StableID":   "nf7LAGJjwM11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       2682102994127782,
+				"Key":        "nodekey:189ff51becd6d0bfed4c66943e0c8d9f036901bd59c9ee50806a2ff5d168d53e",
+				"DiscoKey":   "discokey:245ae4a740ce1251c5454ed092ff41ac94f2a6907a8a42138c6bf397c2e27563",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56842",
+					"10.65.0.27:56842",
+					"172.17.0.1:56842",
+					"172.19.0.1:56842",
+					"172.20.0.1:56842"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:45:21.702222683Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:189ff51becd6d0bfed4c66943e0c8d9f036901bd59c9ee50806a2ff5d168d53e",
+			"MachineKey": "mkey:dd83fccdb48cace05c45fce910eec3c85e3b04577a9290f8aacec84b3f1c207b",
+			"Peers": [{
+				"ID":         3005675596089889,
+				"StableID":   "naHVy41HUQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee93fe882ac599a7dbcd960270ac5f271fb8559d3c2af2f24f4e32c756322e7b",
+				"DiscoKey":   "discokey:d62c8b588623d1fe7be251fcff334d4437bee0501c96d1f62117bfce89919c05",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44609",
+					"10.65.0.27:44609",
+					"172.17.0.1:44609",
+					"172.19.0.1:44609",
+					"172.20.0.1:44609"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:45:20.611328771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3884911169048265,
+				"StableID":   "nJTpkf2VLX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5b4edd734cabe00a43bd2c9fcc118e681cf94d2d8af4677ef326698da8ca7019",
+				"DiscoKey":   "discokey:8c869319f397cec875adbe95aeb47a51674e7803df45baf79d734d807110b822",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43888",
+					"10.65.0.27:43888",
+					"172.17.0.1:43888",
+					"172.19.0.1:43888",
+					"172.20.0.1:43888"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:45:21.161596486Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         295175053585725,
+				"StableID":   "nrbwhPkgJ311CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f74a84fdb9fa242700f7a36568494257af9cdc1f25b223e0a8138407ad877254",
+				"DiscoKey":   "discokey:0cb0fe1deb7d281965189878323b32fad1c61d16445778eb3695c014146b2437",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55206",
+					"10.65.0.27:55206",
+					"172.17.0.1:55206",
+					"172.19.0.1:55206",
+					"172.20.0.1:55206"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:45:22.242427716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2348972764534612,
+				"StableID":   "nZyJXpXrLK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe5426f56f32bcfc2a58d0aba8b74ac611e4285b2568c64adec88c722b86fc79",
+				"DiscoKey":   "discokey:a7cd78af61a05de65b27fc998dd914bfd3ffb14d2cc03522a09ddda30da41c21",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48950",
+					"10.65.0.27:48950",
+					"172.17.0.1:48950",
+					"172.19.0.1:48950",
+					"172.20.0.1:48950"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:45:22.786821071Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2093377381667358,
+				"StableID":   "nRxTnVU6MH11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:537d8107ecdcd8094edf38eddfa21bf1922ada8a23dba383336c831e9401a81c",
+				"DiscoKey":   "discokey:e08b255837e11a99fae38762214e28f5fbabdceb317d6aa11a5a97fd99449b29",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53554",
+					"10.65.0.27:53554",
+					"172.17.0.1:53554",
+					"172.19.0.1:53554",
+					"172.20.0.1:53554"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:45:23.329614404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4883803390066644,
+				"StableID":   "nyqJnYEt8f11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ef8056591f22e56353373f9a48a44372abc53dedd539c024ff77473f23a8060",
+				"DiscoKey":   "discokey:a4b639350fbdebd216ee7fd9c8d7f4e30b45b8b1cd326b3d2d9fb71ae2418e47",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:45841",
+					"10.65.0.27:45841",
+					"172.17.0.1:45841",
+					"172.19.0.1:45841",
+					"172.20.0.1:45841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:45:23.873352325Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7717738457324610,
+				"StableID":   "n9aZKLuNG321CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ba643b89e9957dadf323bef17dc6099333721d546e2684df357bdb7d4df8631",
+				"DiscoKey":   "discokey:2b367f33370030a9b94333c2ea57e5592a9bfed7c6ecb14ec6a779a0cabcc67c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33449",
+					"10.65.0.27:33449",
+					"172.17.0.1:33449",
+					"172.19.0.1:33449",
+					"172.20.0.1:33449"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:45:24.412538146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7775065919153324,
+				"StableID":   "nKUApFoLi321CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e62287606fa8f9e4d91c9b02e1fe6c4f0ca69f6803ae2e66341b1d5865df96b",
+				"DiscoKey":   "discokey:b3f72c8d3c8cf510efac419485528c206f04e3174a91733f58c3f1dfb30a951a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35815",
+					"10.65.0.27:35815",
+					"172.17.0.1:35815",
+					"172.19.0.1:35815",
+					"172.20.0.1:35815"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:45:24.956739133Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6910355556467664,
+				"StableID":   "n1fC8iKixv11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6bb38945ec51175c2739b5719faea1e0cc792b066db16825c712ab702b35309",
+				"DiscoKey":   "discokey:48eb78ba5de8aa665f5fd9fc365bc748017d1be2ec6d78b25647e2227fdf157e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58789",
+					"10.65.0.27:58789",
+					"172.17.0.1:58789",
+					"172.19.0.1:58789",
+					"172.20.0.1:58789"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:45:25.492965382Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4186940600992235,
+				"StableID":   "nG1WQ8qGhZ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:760ba27fe23da3e3eda944b83a8834d276304c4b6f1955df923b158e8311eb0d",
+				"DiscoKey":   "discokey:250c01d24631f650775faa302225dd1f69daea694940ae6ac78bc8295ea24446",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60690",
+					"10.65.0.27:60690",
+					"172.17.0.1:60690",
+					"172.19.0.1:60690",
+					"172.20.0.1:60690"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:45:26.046135004Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7916156635023265,
+				"StableID":   "n4tTEf1Fp421CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f51a703bc03c0293c542d6aeff8195b23ed53c06c37a67aa0f8202b376ce572a",
+				"DiscoKey":   "discokey:58651a90ba83cf5df4d89731a9f3242a9a7701d4785963b2b60101d7332c020d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59781",
+					"10.65.0.27:59781",
+					"172.17.0.1:59781",
+					"172.19.0.1:59781",
+					"172.20.0.1:59781"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:45:26.586955227Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         801010699670203,
+				"StableID":   "ngFfbBCnF711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ad2e6cc741e04a5d763513ff5e4e6cb243484d9f9364b188c38501d44f3ed40f",
+				"KeyExpiry":  "2026-11-08T18:45:27Z",
+				"DiscoKey":   "discokey:842210576b88f2092b6f9db6039b4452570bfcc8438c7b2668e4d4590204ea58",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:56182",
+					"10.65.0.27:56182",
+					"172.17.0.1:56182",
+					"172.19.0.1:56182",
+					"172.20.0.1:56182"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:45:27.121273324Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5937994875226728,
+				"StableID":   "nj87RG4LNo11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3163ea23fd3b28aa95d4240440feb274b0859ebdf70f35f9b334c05e33128113",
+				"KeyExpiry":  "2026-11-08T18:45:27Z",
+				"DiscoKey":   "discokey:e7633eda51a3c2d7012df72d8d2eca6ce0ca6eaebd049db079bc01b0e38b4451",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54896",
+					"10.65.0.27:54896",
+					"172.17.0.1:54896",
+					"172.19.0.1:54896",
+					"172.20.0.1:54896"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:45:27.664103044Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2061318940502245,
+				"StableID":   "nLtn7VMa6H11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c8e8df506c143215ee7232335f87820953f68af2ca6c6d70da33d404a7a66b4e",
+				"KeyExpiry":  "2026-11-08T18:45:28Z",
+				"DiscoKey":   "discokey:dea3c1689bf04862d4ccaf4e4a7c880d27a755ee9bc34ed5e087094331419d5b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41366",
+					"10.65.0.27:41366",
+					"172.17.0.1:41366",
+					"172.19.0.1:41366",
+					"172.20.0.1:41366"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:45:28.218012086Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2682102994127782": {
+				"ID":          2682102994127782,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7717738457324610,
+				"StableID":   "n9aZKLuNG321CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       7717738457324610,
+				"Key":        "nodekey:7ba643b89e9957dadf323bef17dc6099333721d546e2684df357bdb7d4df8631",
+				"DiscoKey":   "discokey:2b367f33370030a9b94333c2ea57e5592a9bfed7c6ecb14ec6a779a0cabcc67c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33449",
+					"10.65.0.27:33449",
+					"172.17.0.1:33449",
+					"172.19.0.1:33449",
+					"172.20.0.1:33449"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:45:24.412538146Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7ba643b89e9957dadf323bef17dc6099333721d546e2684df357bdb7d4df8631",
+			"MachineKey": "mkey:4ac08f344910abfe9724756baa47784d5e29189bb5dcb8ca04d80e9ba5d85664",
+			"Peers": [{
+				"ID":         3005675596089889,
+				"StableID":   "naHVy41HUQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee93fe882ac599a7dbcd960270ac5f271fb8559d3c2af2f24f4e32c756322e7b",
+				"DiscoKey":   "discokey:d62c8b588623d1fe7be251fcff334d4437bee0501c96d1f62117bfce89919c05",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44609",
+					"10.65.0.27:44609",
+					"172.17.0.1:44609",
+					"172.19.0.1:44609",
+					"172.20.0.1:44609"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:45:20.611328771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3884911169048265,
+				"StableID":   "nJTpkf2VLX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5b4edd734cabe00a43bd2c9fcc118e681cf94d2d8af4677ef326698da8ca7019",
+				"DiscoKey":   "discokey:8c869319f397cec875adbe95aeb47a51674e7803df45baf79d734d807110b822",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43888",
+					"10.65.0.27:43888",
+					"172.17.0.1:43888",
+					"172.19.0.1:43888",
+					"172.20.0.1:43888"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:45:21.161596486Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2682102994127782,
+				"StableID":   "nf7LAGJjwM11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:189ff51becd6d0bfed4c66943e0c8d9f036901bd59c9ee50806a2ff5d168d53e",
+				"DiscoKey":   "discokey:245ae4a740ce1251c5454ed092ff41ac94f2a6907a8a42138c6bf397c2e27563",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56842",
+					"10.65.0.27:56842",
+					"172.17.0.1:56842",
+					"172.19.0.1:56842",
+					"172.20.0.1:56842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:45:21.702222683Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         295175053585725,
+				"StableID":   "nrbwhPkgJ311CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f74a84fdb9fa242700f7a36568494257af9cdc1f25b223e0a8138407ad877254",
+				"DiscoKey":   "discokey:0cb0fe1deb7d281965189878323b32fad1c61d16445778eb3695c014146b2437",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55206",
+					"10.65.0.27:55206",
+					"172.17.0.1:55206",
+					"172.19.0.1:55206",
+					"172.20.0.1:55206"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:45:22.242427716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2348972764534612,
+				"StableID":   "nZyJXpXrLK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe5426f56f32bcfc2a58d0aba8b74ac611e4285b2568c64adec88c722b86fc79",
+				"DiscoKey":   "discokey:a7cd78af61a05de65b27fc998dd914bfd3ffb14d2cc03522a09ddda30da41c21",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48950",
+					"10.65.0.27:48950",
+					"172.17.0.1:48950",
+					"172.19.0.1:48950",
+					"172.20.0.1:48950"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:45:22.786821071Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2093377381667358,
+				"StableID":   "nRxTnVU6MH11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:537d8107ecdcd8094edf38eddfa21bf1922ada8a23dba383336c831e9401a81c",
+				"DiscoKey":   "discokey:e08b255837e11a99fae38762214e28f5fbabdceb317d6aa11a5a97fd99449b29",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53554",
+					"10.65.0.27:53554",
+					"172.17.0.1:53554",
+					"172.19.0.1:53554",
+					"172.20.0.1:53554"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:45:23.329614404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4883803390066644,
+				"StableID":   "nyqJnYEt8f11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ef8056591f22e56353373f9a48a44372abc53dedd539c024ff77473f23a8060",
+				"DiscoKey":   "discokey:a4b639350fbdebd216ee7fd9c8d7f4e30b45b8b1cd326b3d2d9fb71ae2418e47",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:45841",
+					"10.65.0.27:45841",
+					"172.17.0.1:45841",
+					"172.19.0.1:45841",
+					"172.20.0.1:45841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:45:23.873352325Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7775065919153324,
+				"StableID":   "nKUApFoLi321CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e62287606fa8f9e4d91c9b02e1fe6c4f0ca69f6803ae2e66341b1d5865df96b",
+				"DiscoKey":   "discokey:b3f72c8d3c8cf510efac419485528c206f04e3174a91733f58c3f1dfb30a951a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35815",
+					"10.65.0.27:35815",
+					"172.17.0.1:35815",
+					"172.19.0.1:35815",
+					"172.20.0.1:35815"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:45:24.956739133Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6910355556467664,
+				"StableID":   "n1fC8iKixv11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6bb38945ec51175c2739b5719faea1e0cc792b066db16825c712ab702b35309",
+				"DiscoKey":   "discokey:48eb78ba5de8aa665f5fd9fc365bc748017d1be2ec6d78b25647e2227fdf157e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58789",
+					"10.65.0.27:58789",
+					"172.17.0.1:58789",
+					"172.19.0.1:58789",
+					"172.20.0.1:58789"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:45:25.492965382Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4186940600992235,
+				"StableID":   "nG1WQ8qGhZ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:760ba27fe23da3e3eda944b83a8834d276304c4b6f1955df923b158e8311eb0d",
+				"DiscoKey":   "discokey:250c01d24631f650775faa302225dd1f69daea694940ae6ac78bc8295ea24446",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60690",
+					"10.65.0.27:60690",
+					"172.17.0.1:60690",
+					"172.19.0.1:60690",
+					"172.20.0.1:60690"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:45:26.046135004Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7916156635023265,
+				"StableID":   "n4tTEf1Fp421CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f51a703bc03c0293c542d6aeff8195b23ed53c06c37a67aa0f8202b376ce572a",
+				"DiscoKey":   "discokey:58651a90ba83cf5df4d89731a9f3242a9a7701d4785963b2b60101d7332c020d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59781",
+					"10.65.0.27:59781",
+					"172.17.0.1:59781",
+					"172.19.0.1:59781",
+					"172.20.0.1:59781"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:45:26.586955227Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         801010699670203,
+				"StableID":   "ngFfbBCnF711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ad2e6cc741e04a5d763513ff5e4e6cb243484d9f9364b188c38501d44f3ed40f",
+				"KeyExpiry":  "2026-11-08T18:45:27Z",
+				"DiscoKey":   "discokey:842210576b88f2092b6f9db6039b4452570bfcc8438c7b2668e4d4590204ea58",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:56182",
+					"10.65.0.27:56182",
+					"172.17.0.1:56182",
+					"172.19.0.1:56182",
+					"172.20.0.1:56182"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:45:27.121273324Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5937994875226728,
+				"StableID":   "nj87RG4LNo11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3163ea23fd3b28aa95d4240440feb274b0859ebdf70f35f9b334c05e33128113",
+				"KeyExpiry":  "2026-11-08T18:45:27Z",
+				"DiscoKey":   "discokey:e7633eda51a3c2d7012df72d8d2eca6ce0ca6eaebd049db079bc01b0e38b4451",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54896",
+					"10.65.0.27:54896",
+					"172.17.0.1:54896",
+					"172.19.0.1:54896",
+					"172.20.0.1:54896"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:45:27.664103044Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2061318940502245,
+				"StableID":   "nLtn7VMa6H11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c8e8df506c143215ee7232335f87820953f68af2ca6c6d70da33d404a7a66b4e",
+				"KeyExpiry":  "2026-11-08T18:45:28Z",
+				"DiscoKey":   "discokey:dea3c1689bf04862d4ccaf4e4a7c880d27a755ee9bc34ed5e087094331419d5b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41366",
+					"10.65.0.27:41366",
+					"172.17.0.1:41366",
+					"172.19.0.1:41366",
+					"172.20.0.1:41366"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:45:28.218012086Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7717738457324610": {
+				"ID":          7717738457324610,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         801010699670203,
+				"StableID":   "ngFfbBCnF711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ad2e6cc741e04a5d763513ff5e4e6cb243484d9f9364b188c38501d44f3ed40f",
+				"KeyExpiry":  "2026-11-08T18:45:27Z",
+				"DiscoKey":   "discokey:842210576b88f2092b6f9db6039b4452570bfcc8438c7b2668e4d4590204ea58",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:56182",
+					"10.65.0.27:56182",
+					"172.17.0.1:56182",
+					"172.19.0.1:56182",
+					"172.20.0.1:56182"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:45:27.121273324Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ad2e6cc741e04a5d763513ff5e4e6cb243484d9f9364b188c38501d44f3ed40f",
+			"MachineKey": "mkey:053c3866c505cb72f5c444c6560ae1cb57aeed682b4c5ebdc07cbffbcc4dc705",
+			"Peers": [{
+				"ID":         3005675596089889,
+				"StableID":   "naHVy41HUQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee93fe882ac599a7dbcd960270ac5f271fb8559d3c2af2f24f4e32c756322e7b",
+				"DiscoKey":   "discokey:d62c8b588623d1fe7be251fcff334d4437bee0501c96d1f62117bfce89919c05",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44609",
+					"10.65.0.27:44609",
+					"172.17.0.1:44609",
+					"172.19.0.1:44609",
+					"172.20.0.1:44609"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:45:20.611328771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3884911169048265,
+				"StableID":   "nJTpkf2VLX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5b4edd734cabe00a43bd2c9fcc118e681cf94d2d8af4677ef326698da8ca7019",
+				"DiscoKey":   "discokey:8c869319f397cec875adbe95aeb47a51674e7803df45baf79d734d807110b822",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43888",
+					"10.65.0.27:43888",
+					"172.17.0.1:43888",
+					"172.19.0.1:43888",
+					"172.20.0.1:43888"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:45:21.161596486Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2682102994127782,
+				"StableID":   "nf7LAGJjwM11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:189ff51becd6d0bfed4c66943e0c8d9f036901bd59c9ee50806a2ff5d168d53e",
+				"DiscoKey":   "discokey:245ae4a740ce1251c5454ed092ff41ac94f2a6907a8a42138c6bf397c2e27563",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56842",
+					"10.65.0.27:56842",
+					"172.17.0.1:56842",
+					"172.19.0.1:56842",
+					"172.20.0.1:56842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:45:21.702222683Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         295175053585725,
+				"StableID":   "nrbwhPkgJ311CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f74a84fdb9fa242700f7a36568494257af9cdc1f25b223e0a8138407ad877254",
+				"DiscoKey":   "discokey:0cb0fe1deb7d281965189878323b32fad1c61d16445778eb3695c014146b2437",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55206",
+					"10.65.0.27:55206",
+					"172.17.0.1:55206",
+					"172.19.0.1:55206",
+					"172.20.0.1:55206"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:45:22.242427716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2348972764534612,
+				"StableID":   "nZyJXpXrLK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe5426f56f32bcfc2a58d0aba8b74ac611e4285b2568c64adec88c722b86fc79",
+				"DiscoKey":   "discokey:a7cd78af61a05de65b27fc998dd914bfd3ffb14d2cc03522a09ddda30da41c21",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48950",
+					"10.65.0.27:48950",
+					"172.17.0.1:48950",
+					"172.19.0.1:48950",
+					"172.20.0.1:48950"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:45:22.786821071Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2093377381667358,
+				"StableID":   "nRxTnVU6MH11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:537d8107ecdcd8094edf38eddfa21bf1922ada8a23dba383336c831e9401a81c",
+				"DiscoKey":   "discokey:e08b255837e11a99fae38762214e28f5fbabdceb317d6aa11a5a97fd99449b29",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53554",
+					"10.65.0.27:53554",
+					"172.17.0.1:53554",
+					"172.19.0.1:53554",
+					"172.20.0.1:53554"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:45:23.329614404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4883803390066644,
+				"StableID":   "nyqJnYEt8f11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ef8056591f22e56353373f9a48a44372abc53dedd539c024ff77473f23a8060",
+				"DiscoKey":   "discokey:a4b639350fbdebd216ee7fd9c8d7f4e30b45b8b1cd326b3d2d9fb71ae2418e47",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:45841",
+					"10.65.0.27:45841",
+					"172.17.0.1:45841",
+					"172.19.0.1:45841",
+					"172.20.0.1:45841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:45:23.873352325Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7717738457324610,
+				"StableID":   "n9aZKLuNG321CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ba643b89e9957dadf323bef17dc6099333721d546e2684df357bdb7d4df8631",
+				"DiscoKey":   "discokey:2b367f33370030a9b94333c2ea57e5592a9bfed7c6ecb14ec6a779a0cabcc67c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33449",
+					"10.65.0.27:33449",
+					"172.17.0.1:33449",
+					"172.19.0.1:33449",
+					"172.20.0.1:33449"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:45:24.412538146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7775065919153324,
+				"StableID":   "nKUApFoLi321CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e62287606fa8f9e4d91c9b02e1fe6c4f0ca69f6803ae2e66341b1d5865df96b",
+				"DiscoKey":   "discokey:b3f72c8d3c8cf510efac419485528c206f04e3174a91733f58c3f1dfb30a951a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35815",
+					"10.65.0.27:35815",
+					"172.17.0.1:35815",
+					"172.19.0.1:35815",
+					"172.20.0.1:35815"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:45:24.956739133Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6910355556467664,
+				"StableID":   "n1fC8iKixv11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6bb38945ec51175c2739b5719faea1e0cc792b066db16825c712ab702b35309",
+				"DiscoKey":   "discokey:48eb78ba5de8aa665f5fd9fc365bc748017d1be2ec6d78b25647e2227fdf157e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58789",
+					"10.65.0.27:58789",
+					"172.17.0.1:58789",
+					"172.19.0.1:58789",
+					"172.20.0.1:58789"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:45:25.492965382Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4186940600992235,
+				"StableID":   "nG1WQ8qGhZ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:760ba27fe23da3e3eda944b83a8834d276304c4b6f1955df923b158e8311eb0d",
+				"DiscoKey":   "discokey:250c01d24631f650775faa302225dd1f69daea694940ae6ac78bc8295ea24446",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60690",
+					"10.65.0.27:60690",
+					"172.17.0.1:60690",
+					"172.19.0.1:60690",
+					"172.20.0.1:60690"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:45:26.046135004Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7916156635023265,
+				"StableID":   "n4tTEf1Fp421CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f51a703bc03c0293c542d6aeff8195b23ed53c06c37a67aa0f8202b376ce572a",
+				"DiscoKey":   "discokey:58651a90ba83cf5df4d89731a9f3242a9a7701d4785963b2b60101d7332c020d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59781",
+					"10.65.0.27:59781",
+					"172.17.0.1:59781",
+					"172.19.0.1:59781",
+					"172.20.0.1:59781"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:45:26.586955227Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5937994875226728,
+				"StableID":   "nj87RG4LNo11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3163ea23fd3b28aa95d4240440feb274b0859ebdf70f35f9b334c05e33128113",
+				"KeyExpiry":  "2026-11-08T18:45:27Z",
+				"DiscoKey":   "discokey:e7633eda51a3c2d7012df72d8d2eca6ce0ca6eaebd049db079bc01b0e38b4451",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54896",
+					"10.65.0.27:54896",
+					"172.17.0.1:54896",
+					"172.19.0.1:54896",
+					"172.20.0.1:54896"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:45:27.664103044Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2061318940502245,
+				"StableID":   "nLtn7VMa6H11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c8e8df506c143215ee7232335f87820953f68af2ca6c6d70da33d404a7a66b4e",
+				"KeyExpiry":  "2026-11-08T18:45:28Z",
+				"DiscoKey":   "discokey:dea3c1689bf04862d4ccaf4e4a7c880d27a755ee9bc34ed5e087094331419d5b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41366",
+					"10.65.0.27:41366",
+					"172.17.0.1:41366",
+					"172.19.0.1:41366",
+					"172.20.0.1:41366"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:45:28.218012086Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4186940600992235,
+				"StableID":   "nG1WQ8qGhZ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       4186940600992235,
+				"Key":        "nodekey:760ba27fe23da3e3eda944b83a8834d276304c4b6f1955df923b158e8311eb0d",
+				"DiscoKey":   "discokey:250c01d24631f650775faa302225dd1f69daea694940ae6ac78bc8295ea24446",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60690",
+					"10.65.0.27:60690",
+					"172.17.0.1:60690",
+					"172.19.0.1:60690",
+					"172.20.0.1:60690"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:45:26.046135004Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:760ba27fe23da3e3eda944b83a8834d276304c4b6f1955df923b158e8311eb0d",
+			"MachineKey": "mkey:fec1e52c9a0a4f873be0e3a97492d254056cc4980841791b08530a72ee20537b",
+			"Peers": [{
+				"ID":         3005675596089889,
+				"StableID":   "naHVy41HUQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee93fe882ac599a7dbcd960270ac5f271fb8559d3c2af2f24f4e32c756322e7b",
+				"DiscoKey":   "discokey:d62c8b588623d1fe7be251fcff334d4437bee0501c96d1f62117bfce89919c05",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44609",
+					"10.65.0.27:44609",
+					"172.17.0.1:44609",
+					"172.19.0.1:44609",
+					"172.20.0.1:44609"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:45:20.611328771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3884911169048265,
+				"StableID":   "nJTpkf2VLX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5b4edd734cabe00a43bd2c9fcc118e681cf94d2d8af4677ef326698da8ca7019",
+				"DiscoKey":   "discokey:8c869319f397cec875adbe95aeb47a51674e7803df45baf79d734d807110b822",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43888",
+					"10.65.0.27:43888",
+					"172.17.0.1:43888",
+					"172.19.0.1:43888",
+					"172.20.0.1:43888"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:45:21.161596486Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2682102994127782,
+				"StableID":   "nf7LAGJjwM11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:189ff51becd6d0bfed4c66943e0c8d9f036901bd59c9ee50806a2ff5d168d53e",
+				"DiscoKey":   "discokey:245ae4a740ce1251c5454ed092ff41ac94f2a6907a8a42138c6bf397c2e27563",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56842",
+					"10.65.0.27:56842",
+					"172.17.0.1:56842",
+					"172.19.0.1:56842",
+					"172.20.0.1:56842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:45:21.702222683Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         295175053585725,
+				"StableID":   "nrbwhPkgJ311CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f74a84fdb9fa242700f7a36568494257af9cdc1f25b223e0a8138407ad877254",
+				"DiscoKey":   "discokey:0cb0fe1deb7d281965189878323b32fad1c61d16445778eb3695c014146b2437",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55206",
+					"10.65.0.27:55206",
+					"172.17.0.1:55206",
+					"172.19.0.1:55206",
+					"172.20.0.1:55206"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:45:22.242427716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2348972764534612,
+				"StableID":   "nZyJXpXrLK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe5426f56f32bcfc2a58d0aba8b74ac611e4285b2568c64adec88c722b86fc79",
+				"DiscoKey":   "discokey:a7cd78af61a05de65b27fc998dd914bfd3ffb14d2cc03522a09ddda30da41c21",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48950",
+					"10.65.0.27:48950",
+					"172.17.0.1:48950",
+					"172.19.0.1:48950",
+					"172.20.0.1:48950"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:45:22.786821071Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2093377381667358,
+				"StableID":   "nRxTnVU6MH11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:537d8107ecdcd8094edf38eddfa21bf1922ada8a23dba383336c831e9401a81c",
+				"DiscoKey":   "discokey:e08b255837e11a99fae38762214e28f5fbabdceb317d6aa11a5a97fd99449b29",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53554",
+					"10.65.0.27:53554",
+					"172.17.0.1:53554",
+					"172.19.0.1:53554",
+					"172.20.0.1:53554"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:45:23.329614404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4883803390066644,
+				"StableID":   "nyqJnYEt8f11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ef8056591f22e56353373f9a48a44372abc53dedd539c024ff77473f23a8060",
+				"DiscoKey":   "discokey:a4b639350fbdebd216ee7fd9c8d7f4e30b45b8b1cd326b3d2d9fb71ae2418e47",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:45841",
+					"10.65.0.27:45841",
+					"172.17.0.1:45841",
+					"172.19.0.1:45841",
+					"172.20.0.1:45841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:45:23.873352325Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7717738457324610,
+				"StableID":   "n9aZKLuNG321CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ba643b89e9957dadf323bef17dc6099333721d546e2684df357bdb7d4df8631",
+				"DiscoKey":   "discokey:2b367f33370030a9b94333c2ea57e5592a9bfed7c6ecb14ec6a779a0cabcc67c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33449",
+					"10.65.0.27:33449",
+					"172.17.0.1:33449",
+					"172.19.0.1:33449",
+					"172.20.0.1:33449"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:45:24.412538146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7775065919153324,
+				"StableID":   "nKUApFoLi321CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e62287606fa8f9e4d91c9b02e1fe6c4f0ca69f6803ae2e66341b1d5865df96b",
+				"DiscoKey":   "discokey:b3f72c8d3c8cf510efac419485528c206f04e3174a91733f58c3f1dfb30a951a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35815",
+					"10.65.0.27:35815",
+					"172.17.0.1:35815",
+					"172.19.0.1:35815",
+					"172.20.0.1:35815"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:45:24.956739133Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6910355556467664,
+				"StableID":   "n1fC8iKixv11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6bb38945ec51175c2739b5719faea1e0cc792b066db16825c712ab702b35309",
+				"DiscoKey":   "discokey:48eb78ba5de8aa665f5fd9fc365bc748017d1be2ec6d78b25647e2227fdf157e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58789",
+					"10.65.0.27:58789",
+					"172.17.0.1:58789",
+					"172.19.0.1:58789",
+					"172.20.0.1:58789"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:45:25.492965382Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7916156635023265,
+				"StableID":   "n4tTEf1Fp421CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f51a703bc03c0293c542d6aeff8195b23ed53c06c37a67aa0f8202b376ce572a",
+				"DiscoKey":   "discokey:58651a90ba83cf5df4d89731a9f3242a9a7701d4785963b2b60101d7332c020d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59781",
+					"10.65.0.27:59781",
+					"172.17.0.1:59781",
+					"172.19.0.1:59781",
+					"172.20.0.1:59781"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:45:26.586955227Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         801010699670203,
+				"StableID":   "ngFfbBCnF711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ad2e6cc741e04a5d763513ff5e4e6cb243484d9f9364b188c38501d44f3ed40f",
+				"KeyExpiry":  "2026-11-08T18:45:27Z",
+				"DiscoKey":   "discokey:842210576b88f2092b6f9db6039b4452570bfcc8438c7b2668e4d4590204ea58",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:56182",
+					"10.65.0.27:56182",
+					"172.17.0.1:56182",
+					"172.19.0.1:56182",
+					"172.20.0.1:56182"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:45:27.121273324Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5937994875226728,
+				"StableID":   "nj87RG4LNo11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3163ea23fd3b28aa95d4240440feb274b0859ebdf70f35f9b334c05e33128113",
+				"KeyExpiry":  "2026-11-08T18:45:27Z",
+				"DiscoKey":   "discokey:e7633eda51a3c2d7012df72d8d2eca6ce0ca6eaebd049db079bc01b0e38b4451",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54896",
+					"10.65.0.27:54896",
+					"172.17.0.1:54896",
+					"172.19.0.1:54896",
+					"172.20.0.1:54896"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:45:27.664103044Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2061318940502245,
+				"StableID":   "nLtn7VMa6H11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c8e8df506c143215ee7232335f87820953f68af2ca6c6d70da33d404a7a66b4e",
+				"KeyExpiry":  "2026-11-08T18:45:28Z",
+				"DiscoKey":   "discokey:dea3c1689bf04862d4ccaf4e4a7c880d27a755ee9bc34ed5e087094331419d5b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41366",
+					"10.65.0.27:41366",
+					"172.17.0.1:41366",
+					"172.19.0.1:41366",
+					"172.20.0.1:41366"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:45:28.218012086Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4186940600992235": {
+				"ID":          4186940600992235,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3884911169048265,
+				"StableID":   "nJTpkf2VLX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       3884911169048265,
+				"Key":        "nodekey:5b4edd734cabe00a43bd2c9fcc118e681cf94d2d8af4677ef326698da8ca7019",
+				"DiscoKey":   "discokey:8c869319f397cec875adbe95aeb47a51674e7803df45baf79d734d807110b822",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43888",
+					"10.65.0.27:43888",
+					"172.17.0.1:43888",
+					"172.19.0.1:43888",
+					"172.20.0.1:43888"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:45:21.161596486Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5b4edd734cabe00a43bd2c9fcc118e681cf94d2d8af4677ef326698da8ca7019",
+			"MachineKey": "mkey:405989273c1eb3fb4696e63bcb5d66f0f45e162eb755baf37187be8daefe1e71",
+			"Peers": [{
+				"ID":         3005675596089889,
+				"StableID":   "naHVy41HUQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee93fe882ac599a7dbcd960270ac5f271fb8559d3c2af2f24f4e32c756322e7b",
+				"DiscoKey":   "discokey:d62c8b588623d1fe7be251fcff334d4437bee0501c96d1f62117bfce89919c05",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44609",
+					"10.65.0.27:44609",
+					"172.17.0.1:44609",
+					"172.19.0.1:44609",
+					"172.20.0.1:44609"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:45:20.611328771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2682102994127782,
+				"StableID":   "nf7LAGJjwM11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:189ff51becd6d0bfed4c66943e0c8d9f036901bd59c9ee50806a2ff5d168d53e",
+				"DiscoKey":   "discokey:245ae4a740ce1251c5454ed092ff41ac94f2a6907a8a42138c6bf397c2e27563",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56842",
+					"10.65.0.27:56842",
+					"172.17.0.1:56842",
+					"172.19.0.1:56842",
+					"172.20.0.1:56842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:45:21.702222683Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         295175053585725,
+				"StableID":   "nrbwhPkgJ311CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f74a84fdb9fa242700f7a36568494257af9cdc1f25b223e0a8138407ad877254",
+				"DiscoKey":   "discokey:0cb0fe1deb7d281965189878323b32fad1c61d16445778eb3695c014146b2437",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55206",
+					"10.65.0.27:55206",
+					"172.17.0.1:55206",
+					"172.19.0.1:55206",
+					"172.20.0.1:55206"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:45:22.242427716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2348972764534612,
+				"StableID":   "nZyJXpXrLK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe5426f56f32bcfc2a58d0aba8b74ac611e4285b2568c64adec88c722b86fc79",
+				"DiscoKey":   "discokey:a7cd78af61a05de65b27fc998dd914bfd3ffb14d2cc03522a09ddda30da41c21",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48950",
+					"10.65.0.27:48950",
+					"172.17.0.1:48950",
+					"172.19.0.1:48950",
+					"172.20.0.1:48950"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:45:22.786821071Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2093377381667358,
+				"StableID":   "nRxTnVU6MH11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:537d8107ecdcd8094edf38eddfa21bf1922ada8a23dba383336c831e9401a81c",
+				"DiscoKey":   "discokey:e08b255837e11a99fae38762214e28f5fbabdceb317d6aa11a5a97fd99449b29",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53554",
+					"10.65.0.27:53554",
+					"172.17.0.1:53554",
+					"172.19.0.1:53554",
+					"172.20.0.1:53554"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:45:23.329614404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4883803390066644,
+				"StableID":   "nyqJnYEt8f11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ef8056591f22e56353373f9a48a44372abc53dedd539c024ff77473f23a8060",
+				"DiscoKey":   "discokey:a4b639350fbdebd216ee7fd9c8d7f4e30b45b8b1cd326b3d2d9fb71ae2418e47",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:45841",
+					"10.65.0.27:45841",
+					"172.17.0.1:45841",
+					"172.19.0.1:45841",
+					"172.20.0.1:45841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:45:23.873352325Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7717738457324610,
+				"StableID":   "n9aZKLuNG321CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ba643b89e9957dadf323bef17dc6099333721d546e2684df357bdb7d4df8631",
+				"DiscoKey":   "discokey:2b367f33370030a9b94333c2ea57e5592a9bfed7c6ecb14ec6a779a0cabcc67c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33449",
+					"10.65.0.27:33449",
+					"172.17.0.1:33449",
+					"172.19.0.1:33449",
+					"172.20.0.1:33449"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:45:24.412538146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7775065919153324,
+				"StableID":   "nKUApFoLi321CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e62287606fa8f9e4d91c9b02e1fe6c4f0ca69f6803ae2e66341b1d5865df96b",
+				"DiscoKey":   "discokey:b3f72c8d3c8cf510efac419485528c206f04e3174a91733f58c3f1dfb30a951a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35815",
+					"10.65.0.27:35815",
+					"172.17.0.1:35815",
+					"172.19.0.1:35815",
+					"172.20.0.1:35815"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:45:24.956739133Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6910355556467664,
+				"StableID":   "n1fC8iKixv11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6bb38945ec51175c2739b5719faea1e0cc792b066db16825c712ab702b35309",
+				"DiscoKey":   "discokey:48eb78ba5de8aa665f5fd9fc365bc748017d1be2ec6d78b25647e2227fdf157e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58789",
+					"10.65.0.27:58789",
+					"172.17.0.1:58789",
+					"172.19.0.1:58789",
+					"172.20.0.1:58789"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:45:25.492965382Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4186940600992235,
+				"StableID":   "nG1WQ8qGhZ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:760ba27fe23da3e3eda944b83a8834d276304c4b6f1955df923b158e8311eb0d",
+				"DiscoKey":   "discokey:250c01d24631f650775faa302225dd1f69daea694940ae6ac78bc8295ea24446",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60690",
+					"10.65.0.27:60690",
+					"172.17.0.1:60690",
+					"172.19.0.1:60690",
+					"172.20.0.1:60690"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:45:26.046135004Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7916156635023265,
+				"StableID":   "n4tTEf1Fp421CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f51a703bc03c0293c542d6aeff8195b23ed53c06c37a67aa0f8202b376ce572a",
+				"DiscoKey":   "discokey:58651a90ba83cf5df4d89731a9f3242a9a7701d4785963b2b60101d7332c020d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59781",
+					"10.65.0.27:59781",
+					"172.17.0.1:59781",
+					"172.19.0.1:59781",
+					"172.20.0.1:59781"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:45:26.586955227Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         801010699670203,
+				"StableID":   "ngFfbBCnF711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ad2e6cc741e04a5d763513ff5e4e6cb243484d9f9364b188c38501d44f3ed40f",
+				"KeyExpiry":  "2026-11-08T18:45:27Z",
+				"DiscoKey":   "discokey:842210576b88f2092b6f9db6039b4452570bfcc8438c7b2668e4d4590204ea58",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:56182",
+					"10.65.0.27:56182",
+					"172.17.0.1:56182",
+					"172.19.0.1:56182",
+					"172.20.0.1:56182"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:45:27.121273324Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5937994875226728,
+				"StableID":   "nj87RG4LNo11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3163ea23fd3b28aa95d4240440feb274b0859ebdf70f35f9b334c05e33128113",
+				"KeyExpiry":  "2026-11-08T18:45:27Z",
+				"DiscoKey":   "discokey:e7633eda51a3c2d7012df72d8d2eca6ce0ca6eaebd049db079bc01b0e38b4451",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54896",
+					"10.65.0.27:54896",
+					"172.17.0.1:54896",
+					"172.19.0.1:54896",
+					"172.20.0.1:54896"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:45:27.664103044Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2061318940502245,
+				"StableID":   "nLtn7VMa6H11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c8e8df506c143215ee7232335f87820953f68af2ca6c6d70da33d404a7a66b4e",
+				"KeyExpiry":  "2026-11-08T18:45:28Z",
+				"DiscoKey":   "discokey:dea3c1689bf04862d4ccaf4e4a7c880d27a755ee9bc34ed5e087094331419d5b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41366",
+					"10.65.0.27:41366",
+					"172.17.0.1:41366",
+					"172.19.0.1:41366",
+					"172.20.0.1:41366"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:45:28.218012086Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3884911169048265": {
+				"ID":          3884911169048265,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3005675596089889,
+				"StableID":   "naHVy41HUQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       3005675596089889,
+				"Key":        "nodekey:ee93fe882ac599a7dbcd960270ac5f271fb8559d3c2af2f24f4e32c756322e7b",
+				"DiscoKey":   "discokey:d62c8b588623d1fe7be251fcff334d4437bee0501c96d1f62117bfce89919c05",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44609",
+					"10.65.0.27:44609",
+					"172.17.0.1:44609",
+					"172.19.0.1:44609",
+					"172.20.0.1:44609"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:45:20.611328771Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ee93fe882ac599a7dbcd960270ac5f271fb8559d3c2af2f24f4e32c756322e7b",
+			"MachineKey": "mkey:1fa2335ccc772039cc407169410f5f930a8a160d20115785594f6f3501f34500",
+			"Peers": [{
+				"ID":         3884911169048265,
+				"StableID":   "nJTpkf2VLX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5b4edd734cabe00a43bd2c9fcc118e681cf94d2d8af4677ef326698da8ca7019",
+				"DiscoKey":   "discokey:8c869319f397cec875adbe95aeb47a51674e7803df45baf79d734d807110b822",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43888",
+					"10.65.0.27:43888",
+					"172.17.0.1:43888",
+					"172.19.0.1:43888",
+					"172.20.0.1:43888"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:45:21.161596486Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2682102994127782,
+				"StableID":   "nf7LAGJjwM11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:189ff51becd6d0bfed4c66943e0c8d9f036901bd59c9ee50806a2ff5d168d53e",
+				"DiscoKey":   "discokey:245ae4a740ce1251c5454ed092ff41ac94f2a6907a8a42138c6bf397c2e27563",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56842",
+					"10.65.0.27:56842",
+					"172.17.0.1:56842",
+					"172.19.0.1:56842",
+					"172.20.0.1:56842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:45:21.702222683Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         295175053585725,
+				"StableID":   "nrbwhPkgJ311CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f74a84fdb9fa242700f7a36568494257af9cdc1f25b223e0a8138407ad877254",
+				"DiscoKey":   "discokey:0cb0fe1deb7d281965189878323b32fad1c61d16445778eb3695c014146b2437",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55206",
+					"10.65.0.27:55206",
+					"172.17.0.1:55206",
+					"172.19.0.1:55206",
+					"172.20.0.1:55206"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:45:22.242427716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2348972764534612,
+				"StableID":   "nZyJXpXrLK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe5426f56f32bcfc2a58d0aba8b74ac611e4285b2568c64adec88c722b86fc79",
+				"DiscoKey":   "discokey:a7cd78af61a05de65b27fc998dd914bfd3ffb14d2cc03522a09ddda30da41c21",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48950",
+					"10.65.0.27:48950",
+					"172.17.0.1:48950",
+					"172.19.0.1:48950",
+					"172.20.0.1:48950"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:45:22.786821071Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2093377381667358,
+				"StableID":   "nRxTnVU6MH11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:537d8107ecdcd8094edf38eddfa21bf1922ada8a23dba383336c831e9401a81c",
+				"DiscoKey":   "discokey:e08b255837e11a99fae38762214e28f5fbabdceb317d6aa11a5a97fd99449b29",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53554",
+					"10.65.0.27:53554",
+					"172.17.0.1:53554",
+					"172.19.0.1:53554",
+					"172.20.0.1:53554"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:45:23.329614404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4883803390066644,
+				"StableID":   "nyqJnYEt8f11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ef8056591f22e56353373f9a48a44372abc53dedd539c024ff77473f23a8060",
+				"DiscoKey":   "discokey:a4b639350fbdebd216ee7fd9c8d7f4e30b45b8b1cd326b3d2d9fb71ae2418e47",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:45841",
+					"10.65.0.27:45841",
+					"172.17.0.1:45841",
+					"172.19.0.1:45841",
+					"172.20.0.1:45841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:45:23.873352325Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7717738457324610,
+				"StableID":   "n9aZKLuNG321CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ba643b89e9957dadf323bef17dc6099333721d546e2684df357bdb7d4df8631",
+				"DiscoKey":   "discokey:2b367f33370030a9b94333c2ea57e5592a9bfed7c6ecb14ec6a779a0cabcc67c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33449",
+					"10.65.0.27:33449",
+					"172.17.0.1:33449",
+					"172.19.0.1:33449",
+					"172.20.0.1:33449"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:45:24.412538146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7775065919153324,
+				"StableID":   "nKUApFoLi321CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e62287606fa8f9e4d91c9b02e1fe6c4f0ca69f6803ae2e66341b1d5865df96b",
+				"DiscoKey":   "discokey:b3f72c8d3c8cf510efac419485528c206f04e3174a91733f58c3f1dfb30a951a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35815",
+					"10.65.0.27:35815",
+					"172.17.0.1:35815",
+					"172.19.0.1:35815",
+					"172.20.0.1:35815"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:45:24.956739133Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6910355556467664,
+				"StableID":   "n1fC8iKixv11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6bb38945ec51175c2739b5719faea1e0cc792b066db16825c712ab702b35309",
+				"DiscoKey":   "discokey:48eb78ba5de8aa665f5fd9fc365bc748017d1be2ec6d78b25647e2227fdf157e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58789",
+					"10.65.0.27:58789",
+					"172.17.0.1:58789",
+					"172.19.0.1:58789",
+					"172.20.0.1:58789"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:45:25.492965382Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4186940600992235,
+				"StableID":   "nG1WQ8qGhZ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:760ba27fe23da3e3eda944b83a8834d276304c4b6f1955df923b158e8311eb0d",
+				"DiscoKey":   "discokey:250c01d24631f650775faa302225dd1f69daea694940ae6ac78bc8295ea24446",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60690",
+					"10.65.0.27:60690",
+					"172.17.0.1:60690",
+					"172.19.0.1:60690",
+					"172.20.0.1:60690"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:45:26.046135004Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7916156635023265,
+				"StableID":   "n4tTEf1Fp421CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f51a703bc03c0293c542d6aeff8195b23ed53c06c37a67aa0f8202b376ce572a",
+				"DiscoKey":   "discokey:58651a90ba83cf5df4d89731a9f3242a9a7701d4785963b2b60101d7332c020d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59781",
+					"10.65.0.27:59781",
+					"172.17.0.1:59781",
+					"172.19.0.1:59781",
+					"172.20.0.1:59781"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:45:26.586955227Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         801010699670203,
+				"StableID":   "ngFfbBCnF711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ad2e6cc741e04a5d763513ff5e4e6cb243484d9f9364b188c38501d44f3ed40f",
+				"KeyExpiry":  "2026-11-08T18:45:27Z",
+				"DiscoKey":   "discokey:842210576b88f2092b6f9db6039b4452570bfcc8438c7b2668e4d4590204ea58",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:56182",
+					"10.65.0.27:56182",
+					"172.17.0.1:56182",
+					"172.19.0.1:56182",
+					"172.20.0.1:56182"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:45:27.121273324Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5937994875226728,
+				"StableID":   "nj87RG4LNo11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3163ea23fd3b28aa95d4240440feb274b0859ebdf70f35f9b334c05e33128113",
+				"KeyExpiry":  "2026-11-08T18:45:27Z",
+				"DiscoKey":   "discokey:e7633eda51a3c2d7012df72d8d2eca6ce0ca6eaebd049db079bc01b0e38b4451",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54896",
+					"10.65.0.27:54896",
+					"172.17.0.1:54896",
+					"172.19.0.1:54896",
+					"172.20.0.1:54896"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:45:27.664103044Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2061318940502245,
+				"StableID":   "nLtn7VMa6H11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c8e8df506c143215ee7232335f87820953f68af2ca6c6d70da33d404a7a66b4e",
+				"KeyExpiry":  "2026-11-08T18:45:28Z",
+				"DiscoKey":   "discokey:dea3c1689bf04862d4ccaf4e4a7c880d27a755ee9bc34ed5e087094331419d5b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41366",
+					"10.65.0.27:41366",
+					"172.17.0.1:41366",
+					"172.19.0.1:41366",
+					"172.20.0.1:41366"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:45:28.218012086Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3005675596089889": {
+				"ID":          3005675596089889,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2348972764534612,
+				"StableID":   "nZyJXpXrLK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       2348972764534612,
+				"Key":        "nodekey:fe5426f56f32bcfc2a58d0aba8b74ac611e4285b2568c64adec88c722b86fc79",
+				"DiscoKey":   "discokey:a7cd78af61a05de65b27fc998dd914bfd3ffb14d2cc03522a09ddda30da41c21",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48950",
+					"10.65.0.27:48950",
+					"172.17.0.1:48950",
+					"172.19.0.1:48950",
+					"172.20.0.1:48950"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:45:22.786821071Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:fe5426f56f32bcfc2a58d0aba8b74ac611e4285b2568c64adec88c722b86fc79",
+			"MachineKey": "mkey:d465fabd5c689bced6246a435083781d71550bf5728bf61cb85530c870a1f672",
+			"Peers": [{
+				"ID":         3005675596089889,
+				"StableID":   "naHVy41HUQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee93fe882ac599a7dbcd960270ac5f271fb8559d3c2af2f24f4e32c756322e7b",
+				"DiscoKey":   "discokey:d62c8b588623d1fe7be251fcff334d4437bee0501c96d1f62117bfce89919c05",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44609",
+					"10.65.0.27:44609",
+					"172.17.0.1:44609",
+					"172.19.0.1:44609",
+					"172.20.0.1:44609"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:45:20.611328771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3884911169048265,
+				"StableID":   "nJTpkf2VLX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5b4edd734cabe00a43bd2c9fcc118e681cf94d2d8af4677ef326698da8ca7019",
+				"DiscoKey":   "discokey:8c869319f397cec875adbe95aeb47a51674e7803df45baf79d734d807110b822",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43888",
+					"10.65.0.27:43888",
+					"172.17.0.1:43888",
+					"172.19.0.1:43888",
+					"172.20.0.1:43888"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:45:21.161596486Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2682102994127782,
+				"StableID":   "nf7LAGJjwM11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:189ff51becd6d0bfed4c66943e0c8d9f036901bd59c9ee50806a2ff5d168d53e",
+				"DiscoKey":   "discokey:245ae4a740ce1251c5454ed092ff41ac94f2a6907a8a42138c6bf397c2e27563",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56842",
+					"10.65.0.27:56842",
+					"172.17.0.1:56842",
+					"172.19.0.1:56842",
+					"172.20.0.1:56842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:45:21.702222683Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         295175053585725,
+				"StableID":   "nrbwhPkgJ311CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f74a84fdb9fa242700f7a36568494257af9cdc1f25b223e0a8138407ad877254",
+				"DiscoKey":   "discokey:0cb0fe1deb7d281965189878323b32fad1c61d16445778eb3695c014146b2437",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55206",
+					"10.65.0.27:55206",
+					"172.17.0.1:55206",
+					"172.19.0.1:55206",
+					"172.20.0.1:55206"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:45:22.242427716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2093377381667358,
+				"StableID":   "nRxTnVU6MH11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:537d8107ecdcd8094edf38eddfa21bf1922ada8a23dba383336c831e9401a81c",
+				"DiscoKey":   "discokey:e08b255837e11a99fae38762214e28f5fbabdceb317d6aa11a5a97fd99449b29",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53554",
+					"10.65.0.27:53554",
+					"172.17.0.1:53554",
+					"172.19.0.1:53554",
+					"172.20.0.1:53554"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:45:23.329614404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4883803390066644,
+				"StableID":   "nyqJnYEt8f11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ef8056591f22e56353373f9a48a44372abc53dedd539c024ff77473f23a8060",
+				"DiscoKey":   "discokey:a4b639350fbdebd216ee7fd9c8d7f4e30b45b8b1cd326b3d2d9fb71ae2418e47",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:45841",
+					"10.65.0.27:45841",
+					"172.17.0.1:45841",
+					"172.19.0.1:45841",
+					"172.20.0.1:45841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:45:23.873352325Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7717738457324610,
+				"StableID":   "n9aZKLuNG321CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ba643b89e9957dadf323bef17dc6099333721d546e2684df357bdb7d4df8631",
+				"DiscoKey":   "discokey:2b367f33370030a9b94333c2ea57e5592a9bfed7c6ecb14ec6a779a0cabcc67c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33449",
+					"10.65.0.27:33449",
+					"172.17.0.1:33449",
+					"172.19.0.1:33449",
+					"172.20.0.1:33449"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:45:24.412538146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7775065919153324,
+				"StableID":   "nKUApFoLi321CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e62287606fa8f9e4d91c9b02e1fe6c4f0ca69f6803ae2e66341b1d5865df96b",
+				"DiscoKey":   "discokey:b3f72c8d3c8cf510efac419485528c206f04e3174a91733f58c3f1dfb30a951a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35815",
+					"10.65.0.27:35815",
+					"172.17.0.1:35815",
+					"172.19.0.1:35815",
+					"172.20.0.1:35815"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:45:24.956739133Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6910355556467664,
+				"StableID":   "n1fC8iKixv11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6bb38945ec51175c2739b5719faea1e0cc792b066db16825c712ab702b35309",
+				"DiscoKey":   "discokey:48eb78ba5de8aa665f5fd9fc365bc748017d1be2ec6d78b25647e2227fdf157e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58789",
+					"10.65.0.27:58789",
+					"172.17.0.1:58789",
+					"172.19.0.1:58789",
+					"172.20.0.1:58789"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:45:25.492965382Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4186940600992235,
+				"StableID":   "nG1WQ8qGhZ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:760ba27fe23da3e3eda944b83a8834d276304c4b6f1955df923b158e8311eb0d",
+				"DiscoKey":   "discokey:250c01d24631f650775faa302225dd1f69daea694940ae6ac78bc8295ea24446",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60690",
+					"10.65.0.27:60690",
+					"172.17.0.1:60690",
+					"172.19.0.1:60690",
+					"172.20.0.1:60690"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:45:26.046135004Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7916156635023265,
+				"StableID":   "n4tTEf1Fp421CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f51a703bc03c0293c542d6aeff8195b23ed53c06c37a67aa0f8202b376ce572a",
+				"DiscoKey":   "discokey:58651a90ba83cf5df4d89731a9f3242a9a7701d4785963b2b60101d7332c020d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59781",
+					"10.65.0.27:59781",
+					"172.17.0.1:59781",
+					"172.19.0.1:59781",
+					"172.20.0.1:59781"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:45:26.586955227Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         801010699670203,
+				"StableID":   "ngFfbBCnF711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ad2e6cc741e04a5d763513ff5e4e6cb243484d9f9364b188c38501d44f3ed40f",
+				"KeyExpiry":  "2026-11-08T18:45:27Z",
+				"DiscoKey":   "discokey:842210576b88f2092b6f9db6039b4452570bfcc8438c7b2668e4d4590204ea58",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:56182",
+					"10.65.0.27:56182",
+					"172.17.0.1:56182",
+					"172.19.0.1:56182",
+					"172.20.0.1:56182"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:45:27.121273324Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5937994875226728,
+				"StableID":   "nj87RG4LNo11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3163ea23fd3b28aa95d4240440feb274b0859ebdf70f35f9b334c05e33128113",
+				"KeyExpiry":  "2026-11-08T18:45:27Z",
+				"DiscoKey":   "discokey:e7633eda51a3c2d7012df72d8d2eca6ce0ca6eaebd049db079bc01b0e38b4451",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54896",
+					"10.65.0.27:54896",
+					"172.17.0.1:54896",
+					"172.19.0.1:54896",
+					"172.20.0.1:54896"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:45:27.664103044Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2061318940502245,
+				"StableID":   "nLtn7VMa6H11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c8e8df506c143215ee7232335f87820953f68af2ca6c6d70da33d404a7a66b4e",
+				"KeyExpiry":  "2026-11-08T18:45:28Z",
+				"DiscoKey":   "discokey:dea3c1689bf04862d4ccaf4e4a7c880d27a755ee9bc34ed5e087094331419d5b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41366",
+					"10.65.0.27:41366",
+					"172.17.0.1:41366",
+					"172.19.0.1:41366",
+					"172.20.0.1:41366"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:45:28.218012086Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2348972764534612": {
+				"ID":          2348972764534612,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         295175053585725,
+				"StableID":   "nrbwhPkgJ311CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       295175053585725,
+				"Key":        "nodekey:f74a84fdb9fa242700f7a36568494257af9cdc1f25b223e0a8138407ad877254",
+				"DiscoKey":   "discokey:0cb0fe1deb7d281965189878323b32fad1c61d16445778eb3695c014146b2437",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55206",
+					"10.65.0.27:55206",
+					"172.17.0.1:55206",
+					"172.19.0.1:55206",
+					"172.20.0.1:55206"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:45:22.242427716Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f74a84fdb9fa242700f7a36568494257af9cdc1f25b223e0a8138407ad877254",
+			"MachineKey": "mkey:1417fe0553e59957c5aee4fe6215dd7a351f6d70743960d299dc10f09b15ae6e",
+			"Peers": [{
+				"ID":         3005675596089889,
+				"StableID":   "naHVy41HUQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee93fe882ac599a7dbcd960270ac5f271fb8559d3c2af2f24f4e32c756322e7b",
+				"DiscoKey":   "discokey:d62c8b588623d1fe7be251fcff334d4437bee0501c96d1f62117bfce89919c05",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44609",
+					"10.65.0.27:44609",
+					"172.17.0.1:44609",
+					"172.19.0.1:44609",
+					"172.20.0.1:44609"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:45:20.611328771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3884911169048265,
+				"StableID":   "nJTpkf2VLX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5b4edd734cabe00a43bd2c9fcc118e681cf94d2d8af4677ef326698da8ca7019",
+				"DiscoKey":   "discokey:8c869319f397cec875adbe95aeb47a51674e7803df45baf79d734d807110b822",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43888",
+					"10.65.0.27:43888",
+					"172.17.0.1:43888",
+					"172.19.0.1:43888",
+					"172.20.0.1:43888"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:45:21.161596486Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2682102994127782,
+				"StableID":   "nf7LAGJjwM11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:189ff51becd6d0bfed4c66943e0c8d9f036901bd59c9ee50806a2ff5d168d53e",
+				"DiscoKey":   "discokey:245ae4a740ce1251c5454ed092ff41ac94f2a6907a8a42138c6bf397c2e27563",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56842",
+					"10.65.0.27:56842",
+					"172.17.0.1:56842",
+					"172.19.0.1:56842",
+					"172.20.0.1:56842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:45:21.702222683Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2348972764534612,
+				"StableID":   "nZyJXpXrLK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe5426f56f32bcfc2a58d0aba8b74ac611e4285b2568c64adec88c722b86fc79",
+				"DiscoKey":   "discokey:a7cd78af61a05de65b27fc998dd914bfd3ffb14d2cc03522a09ddda30da41c21",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48950",
+					"10.65.0.27:48950",
+					"172.17.0.1:48950",
+					"172.19.0.1:48950",
+					"172.20.0.1:48950"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:45:22.786821071Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2093377381667358,
+				"StableID":   "nRxTnVU6MH11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:537d8107ecdcd8094edf38eddfa21bf1922ada8a23dba383336c831e9401a81c",
+				"DiscoKey":   "discokey:e08b255837e11a99fae38762214e28f5fbabdceb317d6aa11a5a97fd99449b29",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53554",
+					"10.65.0.27:53554",
+					"172.17.0.1:53554",
+					"172.19.0.1:53554",
+					"172.20.0.1:53554"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:45:23.329614404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4883803390066644,
+				"StableID":   "nyqJnYEt8f11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ef8056591f22e56353373f9a48a44372abc53dedd539c024ff77473f23a8060",
+				"DiscoKey":   "discokey:a4b639350fbdebd216ee7fd9c8d7f4e30b45b8b1cd326b3d2d9fb71ae2418e47",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:45841",
+					"10.65.0.27:45841",
+					"172.17.0.1:45841",
+					"172.19.0.1:45841",
+					"172.20.0.1:45841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:45:23.873352325Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7717738457324610,
+				"StableID":   "n9aZKLuNG321CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ba643b89e9957dadf323bef17dc6099333721d546e2684df357bdb7d4df8631",
+				"DiscoKey":   "discokey:2b367f33370030a9b94333c2ea57e5592a9bfed7c6ecb14ec6a779a0cabcc67c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33449",
+					"10.65.0.27:33449",
+					"172.17.0.1:33449",
+					"172.19.0.1:33449",
+					"172.20.0.1:33449"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:45:24.412538146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7775065919153324,
+				"StableID":   "nKUApFoLi321CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e62287606fa8f9e4d91c9b02e1fe6c4f0ca69f6803ae2e66341b1d5865df96b",
+				"DiscoKey":   "discokey:b3f72c8d3c8cf510efac419485528c206f04e3174a91733f58c3f1dfb30a951a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35815",
+					"10.65.0.27:35815",
+					"172.17.0.1:35815",
+					"172.19.0.1:35815",
+					"172.20.0.1:35815"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:45:24.956739133Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6910355556467664,
+				"StableID":   "n1fC8iKixv11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6bb38945ec51175c2739b5719faea1e0cc792b066db16825c712ab702b35309",
+				"DiscoKey":   "discokey:48eb78ba5de8aa665f5fd9fc365bc748017d1be2ec6d78b25647e2227fdf157e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58789",
+					"10.65.0.27:58789",
+					"172.17.0.1:58789",
+					"172.19.0.1:58789",
+					"172.20.0.1:58789"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:45:25.492965382Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4186940600992235,
+				"StableID":   "nG1WQ8qGhZ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:760ba27fe23da3e3eda944b83a8834d276304c4b6f1955df923b158e8311eb0d",
+				"DiscoKey":   "discokey:250c01d24631f650775faa302225dd1f69daea694940ae6ac78bc8295ea24446",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60690",
+					"10.65.0.27:60690",
+					"172.17.0.1:60690",
+					"172.19.0.1:60690",
+					"172.20.0.1:60690"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:45:26.046135004Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7916156635023265,
+				"StableID":   "n4tTEf1Fp421CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f51a703bc03c0293c542d6aeff8195b23ed53c06c37a67aa0f8202b376ce572a",
+				"DiscoKey":   "discokey:58651a90ba83cf5df4d89731a9f3242a9a7701d4785963b2b60101d7332c020d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59781",
+					"10.65.0.27:59781",
+					"172.17.0.1:59781",
+					"172.19.0.1:59781",
+					"172.20.0.1:59781"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:45:26.586955227Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         801010699670203,
+				"StableID":   "ngFfbBCnF711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ad2e6cc741e04a5d763513ff5e4e6cb243484d9f9364b188c38501d44f3ed40f",
+				"KeyExpiry":  "2026-11-08T18:45:27Z",
+				"DiscoKey":   "discokey:842210576b88f2092b6f9db6039b4452570bfcc8438c7b2668e4d4590204ea58",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:56182",
+					"10.65.0.27:56182",
+					"172.17.0.1:56182",
+					"172.19.0.1:56182",
+					"172.20.0.1:56182"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:45:27.121273324Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5937994875226728,
+				"StableID":   "nj87RG4LNo11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3163ea23fd3b28aa95d4240440feb274b0859ebdf70f35f9b334c05e33128113",
+				"KeyExpiry":  "2026-11-08T18:45:27Z",
+				"DiscoKey":   "discokey:e7633eda51a3c2d7012df72d8d2eca6ce0ca6eaebd049db079bc01b0e38b4451",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54896",
+					"10.65.0.27:54896",
+					"172.17.0.1:54896",
+					"172.19.0.1:54896",
+					"172.20.0.1:54896"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:45:27.664103044Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2061318940502245,
+				"StableID":   "nLtn7VMa6H11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c8e8df506c143215ee7232335f87820953f68af2ca6c6d70da33d404a7a66b4e",
+				"KeyExpiry":  "2026-11-08T18:45:28Z",
+				"DiscoKey":   "discokey:dea3c1689bf04862d4ccaf4e4a7c880d27a755ee9bc34ed5e087094331419d5b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41366",
+					"10.65.0.27:41366",
+					"172.17.0.1:41366",
+					"172.19.0.1:41366",
+					"172.20.0.1:41366"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:45:28.218012086Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "295175053585725": {
+				"ID":          295175053585725,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4883803390066644,
+				"StableID":   "nyqJnYEt8f11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       4883803390066644,
+				"Key":        "nodekey:0ef8056591f22e56353373f9a48a44372abc53dedd539c024ff77473f23a8060",
+				"DiscoKey":   "discokey:a4b639350fbdebd216ee7fd9c8d7f4e30b45b8b1cd326b3d2d9fb71ae2418e47",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:45841",
+					"10.65.0.27:45841",
+					"172.17.0.1:45841",
+					"172.19.0.1:45841",
+					"172.20.0.1:45841"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:45:23.873352325Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0ef8056591f22e56353373f9a48a44372abc53dedd539c024ff77473f23a8060",
+			"MachineKey": "mkey:f88650bd0695fe439d1b2dfe7092a9e01f1d8a3e2971e648f509d61eb57a7b3d",
+			"Peers": [{
+				"ID":         3005675596089889,
+				"StableID":   "naHVy41HUQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee93fe882ac599a7dbcd960270ac5f271fb8559d3c2af2f24f4e32c756322e7b",
+				"DiscoKey":   "discokey:d62c8b588623d1fe7be251fcff334d4437bee0501c96d1f62117bfce89919c05",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44609",
+					"10.65.0.27:44609",
+					"172.17.0.1:44609",
+					"172.19.0.1:44609",
+					"172.20.0.1:44609"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:45:20.611328771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3884911169048265,
+				"StableID":   "nJTpkf2VLX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5b4edd734cabe00a43bd2c9fcc118e681cf94d2d8af4677ef326698da8ca7019",
+				"DiscoKey":   "discokey:8c869319f397cec875adbe95aeb47a51674e7803df45baf79d734d807110b822",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43888",
+					"10.65.0.27:43888",
+					"172.17.0.1:43888",
+					"172.19.0.1:43888",
+					"172.20.0.1:43888"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:45:21.161596486Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2682102994127782,
+				"StableID":   "nf7LAGJjwM11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:189ff51becd6d0bfed4c66943e0c8d9f036901bd59c9ee50806a2ff5d168d53e",
+				"DiscoKey":   "discokey:245ae4a740ce1251c5454ed092ff41ac94f2a6907a8a42138c6bf397c2e27563",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56842",
+					"10.65.0.27:56842",
+					"172.17.0.1:56842",
+					"172.19.0.1:56842",
+					"172.20.0.1:56842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:45:21.702222683Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         295175053585725,
+				"StableID":   "nrbwhPkgJ311CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f74a84fdb9fa242700f7a36568494257af9cdc1f25b223e0a8138407ad877254",
+				"DiscoKey":   "discokey:0cb0fe1deb7d281965189878323b32fad1c61d16445778eb3695c014146b2437",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55206",
+					"10.65.0.27:55206",
+					"172.17.0.1:55206",
+					"172.19.0.1:55206",
+					"172.20.0.1:55206"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:45:22.242427716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2348972764534612,
+				"StableID":   "nZyJXpXrLK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe5426f56f32bcfc2a58d0aba8b74ac611e4285b2568c64adec88c722b86fc79",
+				"DiscoKey":   "discokey:a7cd78af61a05de65b27fc998dd914bfd3ffb14d2cc03522a09ddda30da41c21",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48950",
+					"10.65.0.27:48950",
+					"172.17.0.1:48950",
+					"172.19.0.1:48950",
+					"172.20.0.1:48950"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:45:22.786821071Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2093377381667358,
+				"StableID":   "nRxTnVU6MH11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:537d8107ecdcd8094edf38eddfa21bf1922ada8a23dba383336c831e9401a81c",
+				"DiscoKey":   "discokey:e08b255837e11a99fae38762214e28f5fbabdceb317d6aa11a5a97fd99449b29",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53554",
+					"10.65.0.27:53554",
+					"172.17.0.1:53554",
+					"172.19.0.1:53554",
+					"172.20.0.1:53554"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:45:23.329614404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7717738457324610,
+				"StableID":   "n9aZKLuNG321CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ba643b89e9957dadf323bef17dc6099333721d546e2684df357bdb7d4df8631",
+				"DiscoKey":   "discokey:2b367f33370030a9b94333c2ea57e5592a9bfed7c6ecb14ec6a779a0cabcc67c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33449",
+					"10.65.0.27:33449",
+					"172.17.0.1:33449",
+					"172.19.0.1:33449",
+					"172.20.0.1:33449"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:45:24.412538146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7775065919153324,
+				"StableID":   "nKUApFoLi321CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e62287606fa8f9e4d91c9b02e1fe6c4f0ca69f6803ae2e66341b1d5865df96b",
+				"DiscoKey":   "discokey:b3f72c8d3c8cf510efac419485528c206f04e3174a91733f58c3f1dfb30a951a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35815",
+					"10.65.0.27:35815",
+					"172.17.0.1:35815",
+					"172.19.0.1:35815",
+					"172.20.0.1:35815"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:45:24.956739133Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6910355556467664,
+				"StableID":   "n1fC8iKixv11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6bb38945ec51175c2739b5719faea1e0cc792b066db16825c712ab702b35309",
+				"DiscoKey":   "discokey:48eb78ba5de8aa665f5fd9fc365bc748017d1be2ec6d78b25647e2227fdf157e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58789",
+					"10.65.0.27:58789",
+					"172.17.0.1:58789",
+					"172.19.0.1:58789",
+					"172.20.0.1:58789"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:45:25.492965382Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4186940600992235,
+				"StableID":   "nG1WQ8qGhZ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:760ba27fe23da3e3eda944b83a8834d276304c4b6f1955df923b158e8311eb0d",
+				"DiscoKey":   "discokey:250c01d24631f650775faa302225dd1f69daea694940ae6ac78bc8295ea24446",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60690",
+					"10.65.0.27:60690",
+					"172.17.0.1:60690",
+					"172.19.0.1:60690",
+					"172.20.0.1:60690"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:45:26.046135004Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7916156635023265,
+				"StableID":   "n4tTEf1Fp421CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f51a703bc03c0293c542d6aeff8195b23ed53c06c37a67aa0f8202b376ce572a",
+				"DiscoKey":   "discokey:58651a90ba83cf5df4d89731a9f3242a9a7701d4785963b2b60101d7332c020d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59781",
+					"10.65.0.27:59781",
+					"172.17.0.1:59781",
+					"172.19.0.1:59781",
+					"172.20.0.1:59781"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:45:26.586955227Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         801010699670203,
+				"StableID":   "ngFfbBCnF711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ad2e6cc741e04a5d763513ff5e4e6cb243484d9f9364b188c38501d44f3ed40f",
+				"KeyExpiry":  "2026-11-08T18:45:27Z",
+				"DiscoKey":   "discokey:842210576b88f2092b6f9db6039b4452570bfcc8438c7b2668e4d4590204ea58",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:56182",
+					"10.65.0.27:56182",
+					"172.17.0.1:56182",
+					"172.19.0.1:56182",
+					"172.20.0.1:56182"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:45:27.121273324Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5937994875226728,
+				"StableID":   "nj87RG4LNo11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3163ea23fd3b28aa95d4240440feb274b0859ebdf70f35f9b334c05e33128113",
+				"KeyExpiry":  "2026-11-08T18:45:27Z",
+				"DiscoKey":   "discokey:e7633eda51a3c2d7012df72d8d2eca6ce0ca6eaebd049db079bc01b0e38b4451",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54896",
+					"10.65.0.27:54896",
+					"172.17.0.1:54896",
+					"172.19.0.1:54896",
+					"172.20.0.1:54896"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:45:27.664103044Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2061318940502245,
+				"StableID":   "nLtn7VMa6H11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c8e8df506c143215ee7232335f87820953f68af2ca6c6d70da33d404a7a66b4e",
+				"KeyExpiry":  "2026-11-08T18:45:28Z",
+				"DiscoKey":   "discokey:dea3c1689bf04862d4ccaf4e4a7c880d27a755ee9bc34ed5e087094331419d5b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41366",
+					"10.65.0.27:41366",
+					"172.17.0.1:41366",
+					"172.19.0.1:41366",
+					"172.20.0.1:41366"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:45:28.218012086Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4883803390066644": {
+				"ID":          4883803390066644,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7775065919153324,
+				"StableID":   "nKUApFoLi321CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       7775065919153324,
+				"Key":        "nodekey:8e62287606fa8f9e4d91c9b02e1fe6c4f0ca69f6803ae2e66341b1d5865df96b",
+				"DiscoKey":   "discokey:b3f72c8d3c8cf510efac419485528c206f04e3174a91733f58c3f1dfb30a951a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35815",
+					"10.65.0.27:35815",
+					"172.17.0.1:35815",
+					"172.19.0.1:35815",
+					"172.20.0.1:35815"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:45:24.956739133Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8e62287606fa8f9e4d91c9b02e1fe6c4f0ca69f6803ae2e66341b1d5865df96b",
+			"MachineKey": "mkey:4e15b0e34bbaf776c32197e05251a80b77782a775aee716643481718247e2825",
+			"Peers": [{
+				"ID":         3005675596089889,
+				"StableID":   "naHVy41HUQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee93fe882ac599a7dbcd960270ac5f271fb8559d3c2af2f24f4e32c756322e7b",
+				"DiscoKey":   "discokey:d62c8b588623d1fe7be251fcff334d4437bee0501c96d1f62117bfce89919c05",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44609",
+					"10.65.0.27:44609",
+					"172.17.0.1:44609",
+					"172.19.0.1:44609",
+					"172.20.0.1:44609"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:45:20.611328771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3884911169048265,
+				"StableID":   "nJTpkf2VLX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5b4edd734cabe00a43bd2c9fcc118e681cf94d2d8af4677ef326698da8ca7019",
+				"DiscoKey":   "discokey:8c869319f397cec875adbe95aeb47a51674e7803df45baf79d734d807110b822",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43888",
+					"10.65.0.27:43888",
+					"172.17.0.1:43888",
+					"172.19.0.1:43888",
+					"172.20.0.1:43888"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:45:21.161596486Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2682102994127782,
+				"StableID":   "nf7LAGJjwM11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:189ff51becd6d0bfed4c66943e0c8d9f036901bd59c9ee50806a2ff5d168d53e",
+				"DiscoKey":   "discokey:245ae4a740ce1251c5454ed092ff41ac94f2a6907a8a42138c6bf397c2e27563",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56842",
+					"10.65.0.27:56842",
+					"172.17.0.1:56842",
+					"172.19.0.1:56842",
+					"172.20.0.1:56842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:45:21.702222683Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         295175053585725,
+				"StableID":   "nrbwhPkgJ311CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f74a84fdb9fa242700f7a36568494257af9cdc1f25b223e0a8138407ad877254",
+				"DiscoKey":   "discokey:0cb0fe1deb7d281965189878323b32fad1c61d16445778eb3695c014146b2437",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55206",
+					"10.65.0.27:55206",
+					"172.17.0.1:55206",
+					"172.19.0.1:55206",
+					"172.20.0.1:55206"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:45:22.242427716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2348972764534612,
+				"StableID":   "nZyJXpXrLK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe5426f56f32bcfc2a58d0aba8b74ac611e4285b2568c64adec88c722b86fc79",
+				"DiscoKey":   "discokey:a7cd78af61a05de65b27fc998dd914bfd3ffb14d2cc03522a09ddda30da41c21",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48950",
+					"10.65.0.27:48950",
+					"172.17.0.1:48950",
+					"172.19.0.1:48950",
+					"172.20.0.1:48950"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:45:22.786821071Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2093377381667358,
+				"StableID":   "nRxTnVU6MH11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:537d8107ecdcd8094edf38eddfa21bf1922ada8a23dba383336c831e9401a81c",
+				"DiscoKey":   "discokey:e08b255837e11a99fae38762214e28f5fbabdceb317d6aa11a5a97fd99449b29",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53554",
+					"10.65.0.27:53554",
+					"172.17.0.1:53554",
+					"172.19.0.1:53554",
+					"172.20.0.1:53554"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:45:23.329614404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4883803390066644,
+				"StableID":   "nyqJnYEt8f11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ef8056591f22e56353373f9a48a44372abc53dedd539c024ff77473f23a8060",
+				"DiscoKey":   "discokey:a4b639350fbdebd216ee7fd9c8d7f4e30b45b8b1cd326b3d2d9fb71ae2418e47",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:45841",
+					"10.65.0.27:45841",
+					"172.17.0.1:45841",
+					"172.19.0.1:45841",
+					"172.20.0.1:45841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:45:23.873352325Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7717738457324610,
+				"StableID":   "n9aZKLuNG321CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ba643b89e9957dadf323bef17dc6099333721d546e2684df357bdb7d4df8631",
+				"DiscoKey":   "discokey:2b367f33370030a9b94333c2ea57e5592a9bfed7c6ecb14ec6a779a0cabcc67c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33449",
+					"10.65.0.27:33449",
+					"172.17.0.1:33449",
+					"172.19.0.1:33449",
+					"172.20.0.1:33449"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:45:24.412538146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6910355556467664,
+				"StableID":   "n1fC8iKixv11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6bb38945ec51175c2739b5719faea1e0cc792b066db16825c712ab702b35309",
+				"DiscoKey":   "discokey:48eb78ba5de8aa665f5fd9fc365bc748017d1be2ec6d78b25647e2227fdf157e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58789",
+					"10.65.0.27:58789",
+					"172.17.0.1:58789",
+					"172.19.0.1:58789",
+					"172.20.0.1:58789"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:45:25.492965382Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4186940600992235,
+				"StableID":   "nG1WQ8qGhZ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:760ba27fe23da3e3eda944b83a8834d276304c4b6f1955df923b158e8311eb0d",
+				"DiscoKey":   "discokey:250c01d24631f650775faa302225dd1f69daea694940ae6ac78bc8295ea24446",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60690",
+					"10.65.0.27:60690",
+					"172.17.0.1:60690",
+					"172.19.0.1:60690",
+					"172.20.0.1:60690"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:45:26.046135004Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7916156635023265,
+				"StableID":   "n4tTEf1Fp421CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f51a703bc03c0293c542d6aeff8195b23ed53c06c37a67aa0f8202b376ce572a",
+				"DiscoKey":   "discokey:58651a90ba83cf5df4d89731a9f3242a9a7701d4785963b2b60101d7332c020d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59781",
+					"10.65.0.27:59781",
+					"172.17.0.1:59781",
+					"172.19.0.1:59781",
+					"172.20.0.1:59781"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:45:26.586955227Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         801010699670203,
+				"StableID":   "ngFfbBCnF711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ad2e6cc741e04a5d763513ff5e4e6cb243484d9f9364b188c38501d44f3ed40f",
+				"KeyExpiry":  "2026-11-08T18:45:27Z",
+				"DiscoKey":   "discokey:842210576b88f2092b6f9db6039b4452570bfcc8438c7b2668e4d4590204ea58",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:56182",
+					"10.65.0.27:56182",
+					"172.17.0.1:56182",
+					"172.19.0.1:56182",
+					"172.20.0.1:56182"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:45:27.121273324Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5937994875226728,
+				"StableID":   "nj87RG4LNo11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3163ea23fd3b28aa95d4240440feb274b0859ebdf70f35f9b334c05e33128113",
+				"KeyExpiry":  "2026-11-08T18:45:27Z",
+				"DiscoKey":   "discokey:e7633eda51a3c2d7012df72d8d2eca6ce0ca6eaebd049db079bc01b0e38b4451",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54896",
+					"10.65.0.27:54896",
+					"172.17.0.1:54896",
+					"172.19.0.1:54896",
+					"172.20.0.1:54896"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:45:27.664103044Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2061318940502245,
+				"StableID":   "nLtn7VMa6H11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c8e8df506c143215ee7232335f87820953f68af2ca6c6d70da33d404a7a66b4e",
+				"KeyExpiry":  "2026-11-08T18:45:28Z",
+				"DiscoKey":   "discokey:dea3c1689bf04862d4ccaf4e4a7c880d27a755ee9bc34ed5e087094331419d5b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41366",
+					"10.65.0.27:41366",
+					"172.17.0.1:41366",
+					"172.19.0.1:41366",
+					"172.20.0.1:41366"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:45:28.218012086Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7775065919153324": {
+				"ID":          7775065919153324,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5937994875226728,
+				"StableID":   "nj87RG4LNo11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3163ea23fd3b28aa95d4240440feb274b0859ebdf70f35f9b334c05e33128113",
+				"KeyExpiry":  "2026-11-08T18:45:27Z",
+				"DiscoKey":   "discokey:e7633eda51a3c2d7012df72d8d2eca6ce0ca6eaebd049db079bc01b0e38b4451",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54896",
+					"10.65.0.27:54896",
+					"172.17.0.1:54896",
+					"172.19.0.1:54896",
+					"172.20.0.1:54896"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:45:27.664103044Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3163ea23fd3b28aa95d4240440feb274b0859ebdf70f35f9b334c05e33128113",
+			"MachineKey": "mkey:c68a807692109691179757290374ed302ce900d5a2a0b509cc7d1bc07ea1572c",
+			"Peers": [{
+				"ID":         3005675596089889,
+				"StableID":   "naHVy41HUQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee93fe882ac599a7dbcd960270ac5f271fb8559d3c2af2f24f4e32c756322e7b",
+				"DiscoKey":   "discokey:d62c8b588623d1fe7be251fcff334d4437bee0501c96d1f62117bfce89919c05",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44609",
+					"10.65.0.27:44609",
+					"172.17.0.1:44609",
+					"172.19.0.1:44609",
+					"172.20.0.1:44609"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:45:20.611328771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3884911169048265,
+				"StableID":   "nJTpkf2VLX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5b4edd734cabe00a43bd2c9fcc118e681cf94d2d8af4677ef326698da8ca7019",
+				"DiscoKey":   "discokey:8c869319f397cec875adbe95aeb47a51674e7803df45baf79d734d807110b822",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43888",
+					"10.65.0.27:43888",
+					"172.17.0.1:43888",
+					"172.19.0.1:43888",
+					"172.20.0.1:43888"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:45:21.161596486Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2682102994127782,
+				"StableID":   "nf7LAGJjwM11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:189ff51becd6d0bfed4c66943e0c8d9f036901bd59c9ee50806a2ff5d168d53e",
+				"DiscoKey":   "discokey:245ae4a740ce1251c5454ed092ff41ac94f2a6907a8a42138c6bf397c2e27563",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56842",
+					"10.65.0.27:56842",
+					"172.17.0.1:56842",
+					"172.19.0.1:56842",
+					"172.20.0.1:56842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:45:21.702222683Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         295175053585725,
+				"StableID":   "nrbwhPkgJ311CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f74a84fdb9fa242700f7a36568494257af9cdc1f25b223e0a8138407ad877254",
+				"DiscoKey":   "discokey:0cb0fe1deb7d281965189878323b32fad1c61d16445778eb3695c014146b2437",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55206",
+					"10.65.0.27:55206",
+					"172.17.0.1:55206",
+					"172.19.0.1:55206",
+					"172.20.0.1:55206"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:45:22.242427716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2348972764534612,
+				"StableID":   "nZyJXpXrLK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe5426f56f32bcfc2a58d0aba8b74ac611e4285b2568c64adec88c722b86fc79",
+				"DiscoKey":   "discokey:a7cd78af61a05de65b27fc998dd914bfd3ffb14d2cc03522a09ddda30da41c21",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48950",
+					"10.65.0.27:48950",
+					"172.17.0.1:48950",
+					"172.19.0.1:48950",
+					"172.20.0.1:48950"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:45:22.786821071Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2093377381667358,
+				"StableID":   "nRxTnVU6MH11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:537d8107ecdcd8094edf38eddfa21bf1922ada8a23dba383336c831e9401a81c",
+				"DiscoKey":   "discokey:e08b255837e11a99fae38762214e28f5fbabdceb317d6aa11a5a97fd99449b29",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53554",
+					"10.65.0.27:53554",
+					"172.17.0.1:53554",
+					"172.19.0.1:53554",
+					"172.20.0.1:53554"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:45:23.329614404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4883803390066644,
+				"StableID":   "nyqJnYEt8f11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ef8056591f22e56353373f9a48a44372abc53dedd539c024ff77473f23a8060",
+				"DiscoKey":   "discokey:a4b639350fbdebd216ee7fd9c8d7f4e30b45b8b1cd326b3d2d9fb71ae2418e47",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:45841",
+					"10.65.0.27:45841",
+					"172.17.0.1:45841",
+					"172.19.0.1:45841",
+					"172.20.0.1:45841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:45:23.873352325Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7717738457324610,
+				"StableID":   "n9aZKLuNG321CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ba643b89e9957dadf323bef17dc6099333721d546e2684df357bdb7d4df8631",
+				"DiscoKey":   "discokey:2b367f33370030a9b94333c2ea57e5592a9bfed7c6ecb14ec6a779a0cabcc67c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33449",
+					"10.65.0.27:33449",
+					"172.17.0.1:33449",
+					"172.19.0.1:33449",
+					"172.20.0.1:33449"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:45:24.412538146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7775065919153324,
+				"StableID":   "nKUApFoLi321CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e62287606fa8f9e4d91c9b02e1fe6c4f0ca69f6803ae2e66341b1d5865df96b",
+				"DiscoKey":   "discokey:b3f72c8d3c8cf510efac419485528c206f04e3174a91733f58c3f1dfb30a951a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35815",
+					"10.65.0.27:35815",
+					"172.17.0.1:35815",
+					"172.19.0.1:35815",
+					"172.20.0.1:35815"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:45:24.956739133Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6910355556467664,
+				"StableID":   "n1fC8iKixv11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b6bb38945ec51175c2739b5719faea1e0cc792b066db16825c712ab702b35309",
+				"DiscoKey":   "discokey:48eb78ba5de8aa665f5fd9fc365bc748017d1be2ec6d78b25647e2227fdf157e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58789",
+					"10.65.0.27:58789",
+					"172.17.0.1:58789",
+					"172.19.0.1:58789",
+					"172.20.0.1:58789"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:45:25.492965382Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4186940600992235,
+				"StableID":   "nG1WQ8qGhZ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:760ba27fe23da3e3eda944b83a8834d276304c4b6f1955df923b158e8311eb0d",
+				"DiscoKey":   "discokey:250c01d24631f650775faa302225dd1f69daea694940ae6ac78bc8295ea24446",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60690",
+					"10.65.0.27:60690",
+					"172.17.0.1:60690",
+					"172.19.0.1:60690",
+					"172.20.0.1:60690"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:45:26.046135004Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7916156635023265,
+				"StableID":   "n4tTEf1Fp421CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f51a703bc03c0293c542d6aeff8195b23ed53c06c37a67aa0f8202b376ce572a",
+				"DiscoKey":   "discokey:58651a90ba83cf5df4d89731a9f3242a9a7701d4785963b2b60101d7332c020d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59781",
+					"10.65.0.27:59781",
+					"172.17.0.1:59781",
+					"172.19.0.1:59781",
+					"172.20.0.1:59781"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:45:26.586955227Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         801010699670203,
+				"StableID":   "ngFfbBCnF711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ad2e6cc741e04a5d763513ff5e4e6cb243484d9f9364b188c38501d44f3ed40f",
+				"KeyExpiry":  "2026-11-08T18:45:27Z",
+				"DiscoKey":   "discokey:842210576b88f2092b6f9db6039b4452570bfcc8438c7b2668e4d4590204ea58",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:56182",
+					"10.65.0.27:56182",
+					"172.17.0.1:56182",
+					"172.19.0.1:56182",
+					"172.20.0.1:56182"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:45:27.121273324Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2061318940502245,
+				"StableID":   "nLtn7VMa6H11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c8e8df506c143215ee7232335f87820953f68af2ca6c6d70da33d404a7a66b4e",
+				"KeyExpiry":  "2026-11-08T18:45:28Z",
+				"DiscoKey":   "discokey:dea3c1689bf04862d4ccaf4e4a7c880d27a755ee9bc34ed5e087094331419d5b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41366",
+					"10.65.0.27:41366",
+					"172.17.0.1:41366",
+					"172.19.0.1:41366",
+					"172.20.0.1:41366"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:45:28.218012086Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6910355556467664,
+				"StableID":   "n1fC8iKixv11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       6910355556467664,
+				"Key":        "nodekey:b6bb38945ec51175c2739b5719faea1e0cc792b066db16825c712ab702b35309",
+				"DiscoKey":   "discokey:48eb78ba5de8aa665f5fd9fc365bc748017d1be2ec6d78b25647e2227fdf157e",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:58789",
+					"10.65.0.27:58789",
+					"172.17.0.1:58789",
+					"172.19.0.1:58789",
+					"172.20.0.1:58789"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:45:25.492965382Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b6bb38945ec51175c2739b5719faea1e0cc792b066db16825c712ab702b35309",
+			"MachineKey": "mkey:5bba1b6ed5e6bfe90a5239b00fabf27695ce53d52c39088b3d6f50b026d3af10",
+			"Peers": [{
+				"ID":         3005675596089889,
+				"StableID":   "naHVy41HUQ11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ee93fe882ac599a7dbcd960270ac5f271fb8559d3c2af2f24f4e32c756322e7b",
+				"DiscoKey":   "discokey:d62c8b588623d1fe7be251fcff334d4437bee0501c96d1f62117bfce89919c05",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:44609",
+					"10.65.0.27:44609",
+					"172.17.0.1:44609",
+					"172.19.0.1:44609",
+					"172.20.0.1:44609"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:45:20.611328771Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3884911169048265,
+				"StableID":   "nJTpkf2VLX11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5b4edd734cabe00a43bd2c9fcc118e681cf94d2d8af4677ef326698da8ca7019",
+				"DiscoKey":   "discokey:8c869319f397cec875adbe95aeb47a51674e7803df45baf79d734d807110b822",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:43888",
+					"10.65.0.27:43888",
+					"172.17.0.1:43888",
+					"172.19.0.1:43888",
+					"172.20.0.1:43888"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:45:21.161596486Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2682102994127782,
+				"StableID":   "nf7LAGJjwM11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:189ff51becd6d0bfed4c66943e0c8d9f036901bd59c9ee50806a2ff5d168d53e",
+				"DiscoKey":   "discokey:245ae4a740ce1251c5454ed092ff41ac94f2a6907a8a42138c6bf397c2e27563",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:56842",
+					"10.65.0.27:56842",
+					"172.17.0.1:56842",
+					"172.19.0.1:56842",
+					"172.20.0.1:56842"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:45:21.702222683Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         295175053585725,
+				"StableID":   "nrbwhPkgJ311CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f74a84fdb9fa242700f7a36568494257af9cdc1f25b223e0a8138407ad877254",
+				"DiscoKey":   "discokey:0cb0fe1deb7d281965189878323b32fad1c61d16445778eb3695c014146b2437",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55206",
+					"10.65.0.27:55206",
+					"172.17.0.1:55206",
+					"172.19.0.1:55206",
+					"172.20.0.1:55206"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:45:22.242427716Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2348972764534612,
+				"StableID":   "nZyJXpXrLK11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe5426f56f32bcfc2a58d0aba8b74ac611e4285b2568c64adec88c722b86fc79",
+				"DiscoKey":   "discokey:a7cd78af61a05de65b27fc998dd914bfd3ffb14d2cc03522a09ddda30da41c21",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:48950",
+					"10.65.0.27:48950",
+					"172.17.0.1:48950",
+					"172.19.0.1:48950",
+					"172.20.0.1:48950"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:45:22.786821071Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2093377381667358,
+				"StableID":   "nRxTnVU6MH11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:537d8107ecdcd8094edf38eddfa21bf1922ada8a23dba383336c831e9401a81c",
+				"DiscoKey":   "discokey:e08b255837e11a99fae38762214e28f5fbabdceb317d6aa11a5a97fd99449b29",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53554",
+					"10.65.0.27:53554",
+					"172.17.0.1:53554",
+					"172.19.0.1:53554",
+					"172.20.0.1:53554"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:45:23.329614404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4883803390066644,
+				"StableID":   "nyqJnYEt8f11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ef8056591f22e56353373f9a48a44372abc53dedd539c024ff77473f23a8060",
+				"DiscoKey":   "discokey:a4b639350fbdebd216ee7fd9c8d7f4e30b45b8b1cd326b3d2d9fb71ae2418e47",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:45841",
+					"10.65.0.27:45841",
+					"172.17.0.1:45841",
+					"172.19.0.1:45841",
+					"172.20.0.1:45841"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:45:23.873352325Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7717738457324610,
+				"StableID":   "n9aZKLuNG321CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7ba643b89e9957dadf323bef17dc6099333721d546e2684df357bdb7d4df8631",
+				"DiscoKey":   "discokey:2b367f33370030a9b94333c2ea57e5592a9bfed7c6ecb14ec6a779a0cabcc67c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:33449",
+					"10.65.0.27:33449",
+					"172.17.0.1:33449",
+					"172.19.0.1:33449",
+					"172.20.0.1:33449"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:45:24.412538146Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7775065919153324,
+				"StableID":   "nKUApFoLi321CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8e62287606fa8f9e4d91c9b02e1fe6c4f0ca69f6803ae2e66341b1d5865df96b",
+				"DiscoKey":   "discokey:b3f72c8d3c8cf510efac419485528c206f04e3174a91733f58c3f1dfb30a951a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:35815",
+					"10.65.0.27:35815",
+					"172.17.0.1:35815",
+					"172.19.0.1:35815",
+					"172.20.0.1:35815"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:45:24.956739133Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         4186940600992235,
+				"StableID":   "nG1WQ8qGhZ11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:760ba27fe23da3e3eda944b83a8834d276304c4b6f1955df923b158e8311eb0d",
+				"DiscoKey":   "discokey:250c01d24631f650775faa302225dd1f69daea694940ae6ac78bc8295ea24446",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:60690",
+					"10.65.0.27:60690",
+					"172.17.0.1:60690",
+					"172.19.0.1:60690",
+					"172.20.0.1:60690"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:45:26.046135004Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7916156635023265,
+				"StableID":   "n4tTEf1Fp421CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f51a703bc03c0293c542d6aeff8195b23ed53c06c37a67aa0f8202b376ce572a",
+				"DiscoKey":   "discokey:58651a90ba83cf5df4d89731a9f3242a9a7701d4785963b2b60101d7332c020d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:59781",
+					"10.65.0.27:59781",
+					"172.17.0.1:59781",
+					"172.19.0.1:59781",
+					"172.20.0.1:59781"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:45:26.586955227Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         801010699670203,
+				"StableID":   "ngFfbBCnF711CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ad2e6cc741e04a5d763513ff5e4e6cb243484d9f9364b188c38501d44f3ed40f",
+				"KeyExpiry":  "2026-11-08T18:45:27Z",
+				"DiscoKey":   "discokey:842210576b88f2092b6f9db6039b4452570bfcc8438c7b2668e4d4590204ea58",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:56182",
+					"10.65.0.27:56182",
+					"172.17.0.1:56182",
+					"172.19.0.1:56182",
+					"172.20.0.1:56182"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:45:27.121273324Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5937994875226728,
+				"StableID":   "nj87RG4LNo11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:3163ea23fd3b28aa95d4240440feb274b0859ebdf70f35f9b334c05e33128113",
+				"KeyExpiry":  "2026-11-08T18:45:27Z",
+				"DiscoKey":   "discokey:e7633eda51a3c2d7012df72d8d2eca6ce0ca6eaebd049db079bc01b0e38b4451",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:54896",
+					"10.65.0.27:54896",
+					"172.17.0.1:54896",
+					"172.19.0.1:54896",
+					"172.20.0.1:54896"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:45:27.664103044Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         2061318940502245,
+				"StableID":   "nLtn7VMa6H11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c8e8df506c143215ee7232335f87820953f68af2ca6c6d70da33d404a7a66b4e",
+				"KeyExpiry":  "2026-11-08T18:45:28Z",
+				"DiscoKey":   "discokey:dea3c1689bf04862d4ccaf4e4a7c880d27a755ee9bc34ed5e087094331419d5b",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:41366",
+					"10.65.0.27:41366",
+					"172.17.0.1:41366",
+					"172.19.0.1:41366",
+					"172.20.0.1:41366"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:45:28.218012086Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6910355556467664": {
+				"ID":          6910355556467664,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/sshtest_results/sshtest-malformed-empty-user.hujson
+++ b/hscontrol/policy/v2/testdata/sshtest_results/sshtest-malformed-empty-user.hujson
@@ -1,0 +1,20082 @@
+// sshtest-malformed-empty-user
+//
+// sshTests with empty username in accept
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T18:46:04Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "sshtest-malformed-empty-user",
+	"description":    "sshTests with empty username in accept",
+	"category":       "sshtest",
+	"captured_at":    "2026-05-12T18:46:04.209401848Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                               \n  \n                                                                    \n                                                               \n{\n\t\"category\":    \"sshtest\",\n\t\"description\": \"sshTests with empty username in accept\",\n\t\"id\":          \"sshtest-malformed-empty-user\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"thor@example.org\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"sshTests\": [{\n\t\t\"accept\": [\"\"],\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    \"thor@example.org\"\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/sshtest/sshtest-malformed-empty-user.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["thor@example.org"],
+				"users":  ["root"]
+			}],
+			"sshTests":  [{"accept": [""], "dst": ["tag:server"], "src": "thor@example.org"}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6482308076345644,
+				"StableID":   "nydx5zErcs11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       6482308076345644,
+				"Key":        "nodekey:ecf416e42d62022dde27440cda6b9c174445a15146ab0eed3a7e152ba829b25f",
+				"DiscoKey":   "discokey:fed880d838edcc6058fa48976077bac75df8f55af98720391ebf8cab88655700",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52260",
+					"10.65.0.27:52260",
+					"172.17.0.1:52260",
+					"172.19.0.1:52260",
+					"172.20.0.1:52260"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:46:12.671264204Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ecf416e42d62022dde27440cda6b9c174445a15146ab0eed3a7e152ba829b25f",
+			"MachineKey": "mkey:a29a5be70fdbb510ead35745fcf0230871ceb85877f9ed409e091430737f1109",
+			"Peers": [{
+				"ID":         3974016456418527,
+				"StableID":   "nG3gs4gq2Y11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f9e4cdfcdf5fc4a7c24479e89eeffc6824ee5f1b6a86abadf36e22f7a821935c",
+				"DiscoKey":   "discokey:3fb869cd8a12c370713766714747ad199545f68559d9015ead712ee140f5307a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46891",
+					"10.65.0.27:46891",
+					"172.17.0.1:46891",
+					"172.19.0.1:46891",
+					"172.20.0.1:46891"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:46:06.772762065Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5471650396442347,
+				"StableID":   "nACLkhy7jj11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:abee1047f200278c3c687518f328c12b7fb43858f50c5a028dd88baff1cd254b",
+				"DiscoKey":   "discokey:ad7fddcf604beac8e10939e4becc873b91680cd976c22b7ab30cec2937551b1e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37637",
+					"10.65.0.27:37637",
+					"172.17.0.1:37637",
+					"172.19.0.1:37637",
+					"172.20.0.1:37637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:46:07.270210359Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8020542208079339,
+				"StableID":   "nYhYsW3Xd521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a2a47683cec3941280f0b0aedd74fb24e1f5c25ce80446670feae8c8c30ea59",
+				"DiscoKey":   "discokey:e167dc3d001218cc6d590a0fcdc6579dc83f762a3bc46c18834d410c412ae718",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36559",
+					"10.65.0.27:36559",
+					"172.17.0.1:36559",
+					"172.19.0.1:36559",
+					"172.20.0.1:36559"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:46:07.822437431Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2797993073272656,
+				"StableID":   "nKAGcwXDrN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e94aa159fdc5b80bf5fc43c60251b15fcc63e6082681d86b93933f2c55596621",
+				"DiscoKey":   "discokey:25115f6c6d5fb3b8b127eb923099d324f9da5034d76cfb73f64f034a955e3c32",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:33665",
+					"10.65.0.27:33665",
+					"172.17.0.1:33665",
+					"172.19.0.1:33665",
+					"172.20.0.1:33665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:46:08.359933084Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1398799464861598,
+				"StableID":   "nBqGkD6XvB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:79de947e9512426e55a89c3ebf01d1eceb62c11893cb4a02df249fa37e3c511a",
+				"DiscoKey":   "discokey:5e353d26fa6607e2fada1cdba435131b701c4cc36c4435946d216f2eca38e95a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:45638",
+					"10.65.0.27:45638",
+					"172.17.0.1:45638",
+					"172.19.0.1:45638",
+					"172.20.0.1:45638"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:46:08.891151496Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         105941311146898,
+				"StableID":   "nw7Tt7uyp111CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8513d593a3f964283efef90ae45905b69a65f93a807317d53fc307482ff8a17f",
+				"DiscoKey":   "discokey:3c3a1b50e8b5b22feed5ed5d95be06c62c888fb97cbdee8ddb834afddeebc809",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:35759",
+					"10.65.0.27:35759",
+					"172.17.0.1:35759",
+					"172.19.0.1:35759",
+					"172.20.0.1:35759"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:46:09.425485308Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4840358168485763,
+				"StableID":   "n2edK51Doe11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6e5a753838adff515d8a87cf825dcd331cbcd5c93dbd4d3b04b60f5089fe1568",
+				"DiscoKey":   "discokey:3b195d5217e4399cde29a4a50c9f9f8dbfd46f15c890c97381e0448ab970e45c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33045",
+					"10.65.0.27:33045",
+					"172.17.0.1:33045",
+					"172.19.0.1:33045",
+					"172.20.0.1:33045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:46:09.981722404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7270919369602773,
+				"StableID":   "ni7hbui1ny11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f4abd1605f0fbc62b54202fb79620d4737acc87204cefdad5ff1c2a96d2fd05",
+				"DiscoKey":   "discokey:655688f530ddc605c7775585696b3fca088c474f64c038a7d3b082f930c8b477",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42583",
+					"10.65.0.27:42583",
+					"172.17.0.1:42583",
+					"172.19.0.1:42583",
+					"172.20.0.1:42583"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:46:10.503260754Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8345223381328097,
+				"StableID":   "nAMKLJsZA821CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:273ecb45f41ccdc687846f6c7a770f0ef3d0d8aa24f4b301194dd9f5607e6b4f",
+				"DiscoKey":   "discokey:e88b37938e15df303c7ff19d8254c80048e1a91454b96316b0ab2194e3ee2221",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53326",
+					"10.65.0.27:53326",
+					"172.17.0.1:53326",
+					"172.19.0.1:53326",
+					"172.20.0.1:53326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:46:11.051935902Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7284508780357525,
+				"StableID":   "nUYvHDhAty11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:da30a7aae94b1263e03eee65802ffe8c375186cdd7978829361de3dde7dbf93e",
+				"DiscoKey":   "discokey:ca22ee5eaa9e57bfbf0b82af390f06971341c1ed73416e6d62a3624ba5f85728",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51499",
+					"10.65.0.27:51499",
+					"172.17.0.1:51499",
+					"172.19.0.1:51499",
+					"172.20.0.1:51499"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:46:11.602297689Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1261223189933606,
+				"StableID":   "nPBSSHCDrA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b91904d84c622b2921bfd881a0d31bd3049b37db6540e0e12d263b103ce607a",
+				"DiscoKey":   "discokey:5e9f99363f691068b8cfb655a0699220e19c42e2ddede4b98145fb4efd1ba95a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37859",
+					"10.65.0.27:37859",
+					"172.17.0.1:37859",
+					"172.19.0.1:37859",
+					"172.20.0.1:37859"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:46:12.134872231Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1098906057830437,
+				"StableID":   "nJsbJ8Qha911CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0cc657ba2fbbac04b2fcd974cd92a890157d05671fab8dcae71a246dc2b0b975",
+				"KeyExpiry":  "2026-11-08T18:46:13Z",
+				"DiscoKey":   "discokey:df4371c3d9cd2a83c29db892aebb439b9416e8723a7a7f4f8b158c2639159915",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52980",
+					"10.65.0.27:52980",
+					"172.17.0.1:52980",
+					"172.19.0.1:52980",
+					"172.20.0.1:52980"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:46:13.305949474Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4968233269920452,
+				"StableID":   "nKYY9g48of11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:abc5e4b73bf29fed22d0474639d137ced814e561e955a8d558774f874de5be07",
+				"KeyExpiry":  "2026-11-08T18:46:14Z",
+				"DiscoKey":   "discokey:6bcbb471202963071e864f1c65e332a666760a7c3e8231d3a31334a393c0aa2d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:53906",
+					"10.65.0.27:53906",
+					"172.17.0.1:53906",
+					"172.19.0.1:53906",
+					"172.20.0.1:53906"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:46:14.02309296Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5468679017310369,
+				"StableID":   "ntYb9dvmhj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8c8055fa990ce6570156e10bd77bbb0bba5aec9b7cba1f383c6e11c242515f6c",
+				"KeyExpiry":  "2026-11-08T18:46:14Z",
+				"DiscoKey":   "discokey:2756c5b89e015f8cefe16aca3fe758cd67ad023e74b7c23620011b55ddb9bd01",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38166",
+					"10.65.0.27:38166",
+					"172.17.0.1:38166",
+					"172.19.0.1:38166",
+					"172.20.0.1:38166"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:46:14.556615013Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6482308076345644": {
+				"ID":          6482308076345644,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         105941311146898,
+				"StableID":   "nw7Tt7uyp111CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       105941311146898,
+				"Key":        "nodekey:8513d593a3f964283efef90ae45905b69a65f93a807317d53fc307482ff8a17f",
+				"DiscoKey":   "discokey:3c3a1b50e8b5b22feed5ed5d95be06c62c888fb97cbdee8ddb834afddeebc809",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:35759",
+					"10.65.0.27:35759",
+					"172.17.0.1:35759",
+					"172.19.0.1:35759",
+					"172.20.0.1:35759"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:46:09.425485308Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8513d593a3f964283efef90ae45905b69a65f93a807317d53fc307482ff8a17f",
+			"MachineKey": "mkey:c97d572db261b94577cfbff31b35a9ceb1022b728d03f58b7389413b64d23217",
+			"Peers": [{
+				"ID":         3974016456418527,
+				"StableID":   "nG3gs4gq2Y11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f9e4cdfcdf5fc4a7c24479e89eeffc6824ee5f1b6a86abadf36e22f7a821935c",
+				"DiscoKey":   "discokey:3fb869cd8a12c370713766714747ad199545f68559d9015ead712ee140f5307a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46891",
+					"10.65.0.27:46891",
+					"172.17.0.1:46891",
+					"172.19.0.1:46891",
+					"172.20.0.1:46891"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:46:06.772762065Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5471650396442347,
+				"StableID":   "nACLkhy7jj11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:abee1047f200278c3c687518f328c12b7fb43858f50c5a028dd88baff1cd254b",
+				"DiscoKey":   "discokey:ad7fddcf604beac8e10939e4becc873b91680cd976c22b7ab30cec2937551b1e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37637",
+					"10.65.0.27:37637",
+					"172.17.0.1:37637",
+					"172.19.0.1:37637",
+					"172.20.0.1:37637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:46:07.270210359Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8020542208079339,
+				"StableID":   "nYhYsW3Xd521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a2a47683cec3941280f0b0aedd74fb24e1f5c25ce80446670feae8c8c30ea59",
+				"DiscoKey":   "discokey:e167dc3d001218cc6d590a0fcdc6579dc83f762a3bc46c18834d410c412ae718",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36559",
+					"10.65.0.27:36559",
+					"172.17.0.1:36559",
+					"172.19.0.1:36559",
+					"172.20.0.1:36559"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:46:07.822437431Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2797993073272656,
+				"StableID":   "nKAGcwXDrN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e94aa159fdc5b80bf5fc43c60251b15fcc63e6082681d86b93933f2c55596621",
+				"DiscoKey":   "discokey:25115f6c6d5fb3b8b127eb923099d324f9da5034d76cfb73f64f034a955e3c32",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:33665",
+					"10.65.0.27:33665",
+					"172.17.0.1:33665",
+					"172.19.0.1:33665",
+					"172.20.0.1:33665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:46:08.359933084Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1398799464861598,
+				"StableID":   "nBqGkD6XvB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:79de947e9512426e55a89c3ebf01d1eceb62c11893cb4a02df249fa37e3c511a",
+				"DiscoKey":   "discokey:5e353d26fa6607e2fada1cdba435131b701c4cc36c4435946d216f2eca38e95a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:45638",
+					"10.65.0.27:45638",
+					"172.17.0.1:45638",
+					"172.19.0.1:45638",
+					"172.20.0.1:45638"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:46:08.891151496Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4840358168485763,
+				"StableID":   "n2edK51Doe11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6e5a753838adff515d8a87cf825dcd331cbcd5c93dbd4d3b04b60f5089fe1568",
+				"DiscoKey":   "discokey:3b195d5217e4399cde29a4a50c9f9f8dbfd46f15c890c97381e0448ab970e45c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33045",
+					"10.65.0.27:33045",
+					"172.17.0.1:33045",
+					"172.19.0.1:33045",
+					"172.20.0.1:33045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:46:09.981722404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7270919369602773,
+				"StableID":   "ni7hbui1ny11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f4abd1605f0fbc62b54202fb79620d4737acc87204cefdad5ff1c2a96d2fd05",
+				"DiscoKey":   "discokey:655688f530ddc605c7775585696b3fca088c474f64c038a7d3b082f930c8b477",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42583",
+					"10.65.0.27:42583",
+					"172.17.0.1:42583",
+					"172.19.0.1:42583",
+					"172.20.0.1:42583"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:46:10.503260754Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8345223381328097,
+				"StableID":   "nAMKLJsZA821CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:273ecb45f41ccdc687846f6c7a770f0ef3d0d8aa24f4b301194dd9f5607e6b4f",
+				"DiscoKey":   "discokey:e88b37938e15df303c7ff19d8254c80048e1a91454b96316b0ab2194e3ee2221",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53326",
+					"10.65.0.27:53326",
+					"172.17.0.1:53326",
+					"172.19.0.1:53326",
+					"172.20.0.1:53326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:46:11.051935902Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7284508780357525,
+				"StableID":   "nUYvHDhAty11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:da30a7aae94b1263e03eee65802ffe8c375186cdd7978829361de3dde7dbf93e",
+				"DiscoKey":   "discokey:ca22ee5eaa9e57bfbf0b82af390f06971341c1ed73416e6d62a3624ba5f85728",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51499",
+					"10.65.0.27:51499",
+					"172.17.0.1:51499",
+					"172.19.0.1:51499",
+					"172.20.0.1:51499"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:46:11.602297689Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1261223189933606,
+				"StableID":   "nPBSSHCDrA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b91904d84c622b2921bfd881a0d31bd3049b37db6540e0e12d263b103ce607a",
+				"DiscoKey":   "discokey:5e9f99363f691068b8cfb655a0699220e19c42e2ddede4b98145fb4efd1ba95a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37859",
+					"10.65.0.27:37859",
+					"172.17.0.1:37859",
+					"172.19.0.1:37859",
+					"172.20.0.1:37859"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:46:12.134872231Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6482308076345644,
+				"StableID":   "nydx5zErcs11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ecf416e42d62022dde27440cda6b9c174445a15146ab0eed3a7e152ba829b25f",
+				"DiscoKey":   "discokey:fed880d838edcc6058fa48976077bac75df8f55af98720391ebf8cab88655700",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52260",
+					"10.65.0.27:52260",
+					"172.17.0.1:52260",
+					"172.19.0.1:52260",
+					"172.20.0.1:52260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:46:12.671264204Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1098906057830437,
+				"StableID":   "nJsbJ8Qha911CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0cc657ba2fbbac04b2fcd974cd92a890157d05671fab8dcae71a246dc2b0b975",
+				"KeyExpiry":  "2026-11-08T18:46:13Z",
+				"DiscoKey":   "discokey:df4371c3d9cd2a83c29db892aebb439b9416e8723a7a7f4f8b158c2639159915",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52980",
+					"10.65.0.27:52980",
+					"172.17.0.1:52980",
+					"172.19.0.1:52980",
+					"172.20.0.1:52980"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:46:13.305949474Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4968233269920452,
+				"StableID":   "nKYY9g48of11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:abc5e4b73bf29fed22d0474639d137ced814e561e955a8d558774f874de5be07",
+				"KeyExpiry":  "2026-11-08T18:46:14Z",
+				"DiscoKey":   "discokey:6bcbb471202963071e864f1c65e332a666760a7c3e8231d3a31334a393c0aa2d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:53906",
+					"10.65.0.27:53906",
+					"172.17.0.1:53906",
+					"172.19.0.1:53906",
+					"172.20.0.1:53906"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:46:14.02309296Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5468679017310369,
+				"StableID":   "ntYb9dvmhj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8c8055fa990ce6570156e10bd77bbb0bba5aec9b7cba1f383c6e11c242515f6c",
+				"KeyExpiry":  "2026-11-08T18:46:14Z",
+				"DiscoKey":   "discokey:2756c5b89e015f8cefe16aca3fe758cd67ad023e74b7c23620011b55ddb9bd01",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38166",
+					"10.65.0.27:38166",
+					"172.17.0.1:38166",
+					"172.19.0.1:38166",
+					"172.20.0.1:38166"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:46:14.556615013Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"105941311146898": {
+				"ID":          105941311146898,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}, "1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5468679017310369,
+				"StableID":   "ntYb9dvmhj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8c8055fa990ce6570156e10bd77bbb0bba5aec9b7cba1f383c6e11c242515f6c",
+				"KeyExpiry":  "2026-11-08T18:46:14Z",
+				"DiscoKey":   "discokey:2756c5b89e015f8cefe16aca3fe758cd67ad023e74b7c23620011b55ddb9bd01",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38166",
+					"10.65.0.27:38166",
+					"172.17.0.1:38166",
+					"172.19.0.1:38166",
+					"172.20.0.1:38166"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:46:14.556615013Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8c8055fa990ce6570156e10bd77bbb0bba5aec9b7cba1f383c6e11c242515f6c",
+			"MachineKey": "mkey:06a2ce45118980e42aa76dfe6b781ba9267cf34473275e9cf96ebe6cf8e8e911",
+			"Peers": [{
+				"ID":         3974016456418527,
+				"StableID":   "nG3gs4gq2Y11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f9e4cdfcdf5fc4a7c24479e89eeffc6824ee5f1b6a86abadf36e22f7a821935c",
+				"DiscoKey":   "discokey:3fb869cd8a12c370713766714747ad199545f68559d9015ead712ee140f5307a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46891",
+					"10.65.0.27:46891",
+					"172.17.0.1:46891",
+					"172.19.0.1:46891",
+					"172.20.0.1:46891"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:46:06.772762065Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5471650396442347,
+				"StableID":   "nACLkhy7jj11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:abee1047f200278c3c687518f328c12b7fb43858f50c5a028dd88baff1cd254b",
+				"DiscoKey":   "discokey:ad7fddcf604beac8e10939e4becc873b91680cd976c22b7ab30cec2937551b1e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37637",
+					"10.65.0.27:37637",
+					"172.17.0.1:37637",
+					"172.19.0.1:37637",
+					"172.20.0.1:37637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:46:07.270210359Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8020542208079339,
+				"StableID":   "nYhYsW3Xd521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a2a47683cec3941280f0b0aedd74fb24e1f5c25ce80446670feae8c8c30ea59",
+				"DiscoKey":   "discokey:e167dc3d001218cc6d590a0fcdc6579dc83f762a3bc46c18834d410c412ae718",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36559",
+					"10.65.0.27:36559",
+					"172.17.0.1:36559",
+					"172.19.0.1:36559",
+					"172.20.0.1:36559"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:46:07.822437431Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2797993073272656,
+				"StableID":   "nKAGcwXDrN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e94aa159fdc5b80bf5fc43c60251b15fcc63e6082681d86b93933f2c55596621",
+				"DiscoKey":   "discokey:25115f6c6d5fb3b8b127eb923099d324f9da5034d76cfb73f64f034a955e3c32",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:33665",
+					"10.65.0.27:33665",
+					"172.17.0.1:33665",
+					"172.19.0.1:33665",
+					"172.20.0.1:33665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:46:08.359933084Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1398799464861598,
+				"StableID":   "nBqGkD6XvB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:79de947e9512426e55a89c3ebf01d1eceb62c11893cb4a02df249fa37e3c511a",
+				"DiscoKey":   "discokey:5e353d26fa6607e2fada1cdba435131b701c4cc36c4435946d216f2eca38e95a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:45638",
+					"10.65.0.27:45638",
+					"172.17.0.1:45638",
+					"172.19.0.1:45638",
+					"172.20.0.1:45638"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:46:08.891151496Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         105941311146898,
+				"StableID":   "nw7Tt7uyp111CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8513d593a3f964283efef90ae45905b69a65f93a807317d53fc307482ff8a17f",
+				"DiscoKey":   "discokey:3c3a1b50e8b5b22feed5ed5d95be06c62c888fb97cbdee8ddb834afddeebc809",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:35759",
+					"10.65.0.27:35759",
+					"172.17.0.1:35759",
+					"172.19.0.1:35759",
+					"172.20.0.1:35759"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:46:09.425485308Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4840358168485763,
+				"StableID":   "n2edK51Doe11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6e5a753838adff515d8a87cf825dcd331cbcd5c93dbd4d3b04b60f5089fe1568",
+				"DiscoKey":   "discokey:3b195d5217e4399cde29a4a50c9f9f8dbfd46f15c890c97381e0448ab970e45c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33045",
+					"10.65.0.27:33045",
+					"172.17.0.1:33045",
+					"172.19.0.1:33045",
+					"172.20.0.1:33045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:46:09.981722404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7270919369602773,
+				"StableID":   "ni7hbui1ny11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f4abd1605f0fbc62b54202fb79620d4737acc87204cefdad5ff1c2a96d2fd05",
+				"DiscoKey":   "discokey:655688f530ddc605c7775585696b3fca088c474f64c038a7d3b082f930c8b477",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42583",
+					"10.65.0.27:42583",
+					"172.17.0.1:42583",
+					"172.19.0.1:42583",
+					"172.20.0.1:42583"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:46:10.503260754Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8345223381328097,
+				"StableID":   "nAMKLJsZA821CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:273ecb45f41ccdc687846f6c7a770f0ef3d0d8aa24f4b301194dd9f5607e6b4f",
+				"DiscoKey":   "discokey:e88b37938e15df303c7ff19d8254c80048e1a91454b96316b0ab2194e3ee2221",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53326",
+					"10.65.0.27:53326",
+					"172.17.0.1:53326",
+					"172.19.0.1:53326",
+					"172.20.0.1:53326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:46:11.051935902Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7284508780357525,
+				"StableID":   "nUYvHDhAty11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:da30a7aae94b1263e03eee65802ffe8c375186cdd7978829361de3dde7dbf93e",
+				"DiscoKey":   "discokey:ca22ee5eaa9e57bfbf0b82af390f06971341c1ed73416e6d62a3624ba5f85728",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51499",
+					"10.65.0.27:51499",
+					"172.17.0.1:51499",
+					"172.19.0.1:51499",
+					"172.20.0.1:51499"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:46:11.602297689Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1261223189933606,
+				"StableID":   "nPBSSHCDrA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b91904d84c622b2921bfd881a0d31bd3049b37db6540e0e12d263b103ce607a",
+				"DiscoKey":   "discokey:5e9f99363f691068b8cfb655a0699220e19c42e2ddede4b98145fb4efd1ba95a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37859",
+					"10.65.0.27:37859",
+					"172.17.0.1:37859",
+					"172.19.0.1:37859",
+					"172.20.0.1:37859"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:46:12.134872231Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6482308076345644,
+				"StableID":   "nydx5zErcs11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ecf416e42d62022dde27440cda6b9c174445a15146ab0eed3a7e152ba829b25f",
+				"DiscoKey":   "discokey:fed880d838edcc6058fa48976077bac75df8f55af98720391ebf8cab88655700",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52260",
+					"10.65.0.27:52260",
+					"172.17.0.1:52260",
+					"172.19.0.1:52260",
+					"172.20.0.1:52260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:46:12.671264204Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1098906057830437,
+				"StableID":   "nJsbJ8Qha911CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0cc657ba2fbbac04b2fcd974cd92a890157d05671fab8dcae71a246dc2b0b975",
+				"KeyExpiry":  "2026-11-08T18:46:13Z",
+				"DiscoKey":   "discokey:df4371c3d9cd2a83c29db892aebb439b9416e8723a7a7f4f8b158c2639159915",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52980",
+					"10.65.0.27:52980",
+					"172.17.0.1:52980",
+					"172.19.0.1:52980",
+					"172.20.0.1:52980"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:46:13.305949474Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4968233269920452,
+				"StableID":   "nKYY9g48of11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:abc5e4b73bf29fed22d0474639d137ced814e561e955a8d558774f874de5be07",
+				"KeyExpiry":  "2026-11-08T18:46:14Z",
+				"DiscoKey":   "discokey:6bcbb471202963071e864f1c65e332a666760a7c3e8231d3a31334a393c0aa2d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:53906",
+					"10.65.0.27:53906",
+					"172.17.0.1:53906",
+					"172.19.0.1:53906",
+					"172.20.0.1:53906"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:46:14.02309296Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8020542208079339,
+				"StableID":   "nYhYsW3Xd521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       8020542208079339,
+				"Key":        "nodekey:1a2a47683cec3941280f0b0aedd74fb24e1f5c25ce80446670feae8c8c30ea59",
+				"DiscoKey":   "discokey:e167dc3d001218cc6d590a0fcdc6579dc83f762a3bc46c18834d410c412ae718",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36559",
+					"10.65.0.27:36559",
+					"172.17.0.1:36559",
+					"172.19.0.1:36559",
+					"172.20.0.1:36559"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:46:07.822437431Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1a2a47683cec3941280f0b0aedd74fb24e1f5c25ce80446670feae8c8c30ea59",
+			"MachineKey": "mkey:a011bae05e69bc48446f20394c91aeffd5c111bc3d8b7d06d81ab3742a66dc67",
+			"Peers": [{
+				"ID":         3974016456418527,
+				"StableID":   "nG3gs4gq2Y11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f9e4cdfcdf5fc4a7c24479e89eeffc6824ee5f1b6a86abadf36e22f7a821935c",
+				"DiscoKey":   "discokey:3fb869cd8a12c370713766714747ad199545f68559d9015ead712ee140f5307a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46891",
+					"10.65.0.27:46891",
+					"172.17.0.1:46891",
+					"172.19.0.1:46891",
+					"172.20.0.1:46891"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:46:06.772762065Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5471650396442347,
+				"StableID":   "nACLkhy7jj11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:abee1047f200278c3c687518f328c12b7fb43858f50c5a028dd88baff1cd254b",
+				"DiscoKey":   "discokey:ad7fddcf604beac8e10939e4becc873b91680cd976c22b7ab30cec2937551b1e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37637",
+					"10.65.0.27:37637",
+					"172.17.0.1:37637",
+					"172.19.0.1:37637",
+					"172.20.0.1:37637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:46:07.270210359Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2797993073272656,
+				"StableID":   "nKAGcwXDrN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e94aa159fdc5b80bf5fc43c60251b15fcc63e6082681d86b93933f2c55596621",
+				"DiscoKey":   "discokey:25115f6c6d5fb3b8b127eb923099d324f9da5034d76cfb73f64f034a955e3c32",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:33665",
+					"10.65.0.27:33665",
+					"172.17.0.1:33665",
+					"172.19.0.1:33665",
+					"172.20.0.1:33665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:46:08.359933084Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1398799464861598,
+				"StableID":   "nBqGkD6XvB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:79de947e9512426e55a89c3ebf01d1eceb62c11893cb4a02df249fa37e3c511a",
+				"DiscoKey":   "discokey:5e353d26fa6607e2fada1cdba435131b701c4cc36c4435946d216f2eca38e95a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:45638",
+					"10.65.0.27:45638",
+					"172.17.0.1:45638",
+					"172.19.0.1:45638",
+					"172.20.0.1:45638"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:46:08.891151496Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         105941311146898,
+				"StableID":   "nw7Tt7uyp111CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8513d593a3f964283efef90ae45905b69a65f93a807317d53fc307482ff8a17f",
+				"DiscoKey":   "discokey:3c3a1b50e8b5b22feed5ed5d95be06c62c888fb97cbdee8ddb834afddeebc809",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:35759",
+					"10.65.0.27:35759",
+					"172.17.0.1:35759",
+					"172.19.0.1:35759",
+					"172.20.0.1:35759"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:46:09.425485308Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4840358168485763,
+				"StableID":   "n2edK51Doe11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6e5a753838adff515d8a87cf825dcd331cbcd5c93dbd4d3b04b60f5089fe1568",
+				"DiscoKey":   "discokey:3b195d5217e4399cde29a4a50c9f9f8dbfd46f15c890c97381e0448ab970e45c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33045",
+					"10.65.0.27:33045",
+					"172.17.0.1:33045",
+					"172.19.0.1:33045",
+					"172.20.0.1:33045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:46:09.981722404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7270919369602773,
+				"StableID":   "ni7hbui1ny11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f4abd1605f0fbc62b54202fb79620d4737acc87204cefdad5ff1c2a96d2fd05",
+				"DiscoKey":   "discokey:655688f530ddc605c7775585696b3fca088c474f64c038a7d3b082f930c8b477",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42583",
+					"10.65.0.27:42583",
+					"172.17.0.1:42583",
+					"172.19.0.1:42583",
+					"172.20.0.1:42583"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:46:10.503260754Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8345223381328097,
+				"StableID":   "nAMKLJsZA821CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:273ecb45f41ccdc687846f6c7a770f0ef3d0d8aa24f4b301194dd9f5607e6b4f",
+				"DiscoKey":   "discokey:e88b37938e15df303c7ff19d8254c80048e1a91454b96316b0ab2194e3ee2221",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53326",
+					"10.65.0.27:53326",
+					"172.17.0.1:53326",
+					"172.19.0.1:53326",
+					"172.20.0.1:53326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:46:11.051935902Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7284508780357525,
+				"StableID":   "nUYvHDhAty11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:da30a7aae94b1263e03eee65802ffe8c375186cdd7978829361de3dde7dbf93e",
+				"DiscoKey":   "discokey:ca22ee5eaa9e57bfbf0b82af390f06971341c1ed73416e6d62a3624ba5f85728",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51499",
+					"10.65.0.27:51499",
+					"172.17.0.1:51499",
+					"172.19.0.1:51499",
+					"172.20.0.1:51499"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:46:11.602297689Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1261223189933606,
+				"StableID":   "nPBSSHCDrA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b91904d84c622b2921bfd881a0d31bd3049b37db6540e0e12d263b103ce607a",
+				"DiscoKey":   "discokey:5e9f99363f691068b8cfb655a0699220e19c42e2ddede4b98145fb4efd1ba95a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37859",
+					"10.65.0.27:37859",
+					"172.17.0.1:37859",
+					"172.19.0.1:37859",
+					"172.20.0.1:37859"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:46:12.134872231Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6482308076345644,
+				"StableID":   "nydx5zErcs11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ecf416e42d62022dde27440cda6b9c174445a15146ab0eed3a7e152ba829b25f",
+				"DiscoKey":   "discokey:fed880d838edcc6058fa48976077bac75df8f55af98720391ebf8cab88655700",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52260",
+					"10.65.0.27:52260",
+					"172.17.0.1:52260",
+					"172.19.0.1:52260",
+					"172.20.0.1:52260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:46:12.671264204Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1098906057830437,
+				"StableID":   "nJsbJ8Qha911CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0cc657ba2fbbac04b2fcd974cd92a890157d05671fab8dcae71a246dc2b0b975",
+				"KeyExpiry":  "2026-11-08T18:46:13Z",
+				"DiscoKey":   "discokey:df4371c3d9cd2a83c29db892aebb439b9416e8723a7a7f4f8b158c2639159915",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52980",
+					"10.65.0.27:52980",
+					"172.17.0.1:52980",
+					"172.19.0.1:52980",
+					"172.20.0.1:52980"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:46:13.305949474Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4968233269920452,
+				"StableID":   "nKYY9g48of11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:abc5e4b73bf29fed22d0474639d137ced814e561e955a8d558774f874de5be07",
+				"KeyExpiry":  "2026-11-08T18:46:14Z",
+				"DiscoKey":   "discokey:6bcbb471202963071e864f1c65e332a666760a7c3e8231d3a31334a393c0aa2d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:53906",
+					"10.65.0.27:53906",
+					"172.17.0.1:53906",
+					"172.19.0.1:53906",
+					"172.20.0.1:53906"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:46:14.02309296Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5468679017310369,
+				"StableID":   "ntYb9dvmhj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8c8055fa990ce6570156e10bd77bbb0bba5aec9b7cba1f383c6e11c242515f6c",
+				"KeyExpiry":  "2026-11-08T18:46:14Z",
+				"DiscoKey":   "discokey:2756c5b89e015f8cefe16aca3fe758cd67ad023e74b7c23620011b55ddb9bd01",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38166",
+					"10.65.0.27:38166",
+					"172.17.0.1:38166",
+					"172.19.0.1:38166",
+					"172.20.0.1:38166"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:46:14.556615013Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8020542208079339": {
+				"ID":          8020542208079339,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7270919369602773,
+				"StableID":   "ni7hbui1ny11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       7270919369602773,
+				"Key":        "nodekey:4f4abd1605f0fbc62b54202fb79620d4737acc87204cefdad5ff1c2a96d2fd05",
+				"DiscoKey":   "discokey:655688f530ddc605c7775585696b3fca088c474f64c038a7d3b082f930c8b477",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42583",
+					"10.65.0.27:42583",
+					"172.17.0.1:42583",
+					"172.19.0.1:42583",
+					"172.20.0.1:42583"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:46:10.503260754Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4f4abd1605f0fbc62b54202fb79620d4737acc87204cefdad5ff1c2a96d2fd05",
+			"MachineKey": "mkey:2ae8d4e51965f9cc85475ff31607b77e42e05865fa665dfd3a167bf91bb9c925",
+			"Peers": [{
+				"ID":         3974016456418527,
+				"StableID":   "nG3gs4gq2Y11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f9e4cdfcdf5fc4a7c24479e89eeffc6824ee5f1b6a86abadf36e22f7a821935c",
+				"DiscoKey":   "discokey:3fb869cd8a12c370713766714747ad199545f68559d9015ead712ee140f5307a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46891",
+					"10.65.0.27:46891",
+					"172.17.0.1:46891",
+					"172.19.0.1:46891",
+					"172.20.0.1:46891"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:46:06.772762065Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5471650396442347,
+				"StableID":   "nACLkhy7jj11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:abee1047f200278c3c687518f328c12b7fb43858f50c5a028dd88baff1cd254b",
+				"DiscoKey":   "discokey:ad7fddcf604beac8e10939e4becc873b91680cd976c22b7ab30cec2937551b1e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37637",
+					"10.65.0.27:37637",
+					"172.17.0.1:37637",
+					"172.19.0.1:37637",
+					"172.20.0.1:37637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:46:07.270210359Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8020542208079339,
+				"StableID":   "nYhYsW3Xd521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a2a47683cec3941280f0b0aedd74fb24e1f5c25ce80446670feae8c8c30ea59",
+				"DiscoKey":   "discokey:e167dc3d001218cc6d590a0fcdc6579dc83f762a3bc46c18834d410c412ae718",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36559",
+					"10.65.0.27:36559",
+					"172.17.0.1:36559",
+					"172.19.0.1:36559",
+					"172.20.0.1:36559"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:46:07.822437431Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2797993073272656,
+				"StableID":   "nKAGcwXDrN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e94aa159fdc5b80bf5fc43c60251b15fcc63e6082681d86b93933f2c55596621",
+				"DiscoKey":   "discokey:25115f6c6d5fb3b8b127eb923099d324f9da5034d76cfb73f64f034a955e3c32",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:33665",
+					"10.65.0.27:33665",
+					"172.17.0.1:33665",
+					"172.19.0.1:33665",
+					"172.20.0.1:33665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:46:08.359933084Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1398799464861598,
+				"StableID":   "nBqGkD6XvB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:79de947e9512426e55a89c3ebf01d1eceb62c11893cb4a02df249fa37e3c511a",
+				"DiscoKey":   "discokey:5e353d26fa6607e2fada1cdba435131b701c4cc36c4435946d216f2eca38e95a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:45638",
+					"10.65.0.27:45638",
+					"172.17.0.1:45638",
+					"172.19.0.1:45638",
+					"172.20.0.1:45638"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:46:08.891151496Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         105941311146898,
+				"StableID":   "nw7Tt7uyp111CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8513d593a3f964283efef90ae45905b69a65f93a807317d53fc307482ff8a17f",
+				"DiscoKey":   "discokey:3c3a1b50e8b5b22feed5ed5d95be06c62c888fb97cbdee8ddb834afddeebc809",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:35759",
+					"10.65.0.27:35759",
+					"172.17.0.1:35759",
+					"172.19.0.1:35759",
+					"172.20.0.1:35759"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:46:09.425485308Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4840358168485763,
+				"StableID":   "n2edK51Doe11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6e5a753838adff515d8a87cf825dcd331cbcd5c93dbd4d3b04b60f5089fe1568",
+				"DiscoKey":   "discokey:3b195d5217e4399cde29a4a50c9f9f8dbfd46f15c890c97381e0448ab970e45c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33045",
+					"10.65.0.27:33045",
+					"172.17.0.1:33045",
+					"172.19.0.1:33045",
+					"172.20.0.1:33045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:46:09.981722404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8345223381328097,
+				"StableID":   "nAMKLJsZA821CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:273ecb45f41ccdc687846f6c7a770f0ef3d0d8aa24f4b301194dd9f5607e6b4f",
+				"DiscoKey":   "discokey:e88b37938e15df303c7ff19d8254c80048e1a91454b96316b0ab2194e3ee2221",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53326",
+					"10.65.0.27:53326",
+					"172.17.0.1:53326",
+					"172.19.0.1:53326",
+					"172.20.0.1:53326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:46:11.051935902Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7284508780357525,
+				"StableID":   "nUYvHDhAty11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:da30a7aae94b1263e03eee65802ffe8c375186cdd7978829361de3dde7dbf93e",
+				"DiscoKey":   "discokey:ca22ee5eaa9e57bfbf0b82af390f06971341c1ed73416e6d62a3624ba5f85728",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51499",
+					"10.65.0.27:51499",
+					"172.17.0.1:51499",
+					"172.19.0.1:51499",
+					"172.20.0.1:51499"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:46:11.602297689Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1261223189933606,
+				"StableID":   "nPBSSHCDrA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b91904d84c622b2921bfd881a0d31bd3049b37db6540e0e12d263b103ce607a",
+				"DiscoKey":   "discokey:5e9f99363f691068b8cfb655a0699220e19c42e2ddede4b98145fb4efd1ba95a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37859",
+					"10.65.0.27:37859",
+					"172.17.0.1:37859",
+					"172.19.0.1:37859",
+					"172.20.0.1:37859"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:46:12.134872231Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6482308076345644,
+				"StableID":   "nydx5zErcs11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ecf416e42d62022dde27440cda6b9c174445a15146ab0eed3a7e152ba829b25f",
+				"DiscoKey":   "discokey:fed880d838edcc6058fa48976077bac75df8f55af98720391ebf8cab88655700",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52260",
+					"10.65.0.27:52260",
+					"172.17.0.1:52260",
+					"172.19.0.1:52260",
+					"172.20.0.1:52260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:46:12.671264204Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1098906057830437,
+				"StableID":   "nJsbJ8Qha911CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0cc657ba2fbbac04b2fcd974cd92a890157d05671fab8dcae71a246dc2b0b975",
+				"KeyExpiry":  "2026-11-08T18:46:13Z",
+				"DiscoKey":   "discokey:df4371c3d9cd2a83c29db892aebb439b9416e8723a7a7f4f8b158c2639159915",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52980",
+					"10.65.0.27:52980",
+					"172.17.0.1:52980",
+					"172.19.0.1:52980",
+					"172.20.0.1:52980"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:46:13.305949474Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4968233269920452,
+				"StableID":   "nKYY9g48of11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:abc5e4b73bf29fed22d0474639d137ced814e561e955a8d558774f874de5be07",
+				"KeyExpiry":  "2026-11-08T18:46:14Z",
+				"DiscoKey":   "discokey:6bcbb471202963071e864f1c65e332a666760a7c3e8231d3a31334a393c0aa2d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:53906",
+					"10.65.0.27:53906",
+					"172.17.0.1:53906",
+					"172.19.0.1:53906",
+					"172.20.0.1:53906"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:46:14.02309296Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5468679017310369,
+				"StableID":   "ntYb9dvmhj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8c8055fa990ce6570156e10bd77bbb0bba5aec9b7cba1f383c6e11c242515f6c",
+				"KeyExpiry":  "2026-11-08T18:46:14Z",
+				"DiscoKey":   "discokey:2756c5b89e015f8cefe16aca3fe758cd67ad023e74b7c23620011b55ddb9bd01",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38166",
+					"10.65.0.27:38166",
+					"172.17.0.1:38166",
+					"172.19.0.1:38166",
+					"172.20.0.1:38166"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:46:14.556615013Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7270919369602773": {
+				"ID":          7270919369602773,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1098906057830437,
+				"StableID":   "nJsbJ8Qha911CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0cc657ba2fbbac04b2fcd974cd92a890157d05671fab8dcae71a246dc2b0b975",
+				"KeyExpiry":  "2026-11-08T18:46:13Z",
+				"DiscoKey":   "discokey:df4371c3d9cd2a83c29db892aebb439b9416e8723a7a7f4f8b158c2639159915",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52980",
+					"10.65.0.27:52980",
+					"172.17.0.1:52980",
+					"172.19.0.1:52980",
+					"172.20.0.1:52980"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:46:13.305949474Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0cc657ba2fbbac04b2fcd974cd92a890157d05671fab8dcae71a246dc2b0b975",
+			"MachineKey": "mkey:eb3780867ee474ee2c97d2a00e0b19b96445e084c08df07fe6e8cf18dfa6e73c",
+			"Peers": [{
+				"ID":         3974016456418527,
+				"StableID":   "nG3gs4gq2Y11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f9e4cdfcdf5fc4a7c24479e89eeffc6824ee5f1b6a86abadf36e22f7a821935c",
+				"DiscoKey":   "discokey:3fb869cd8a12c370713766714747ad199545f68559d9015ead712ee140f5307a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46891",
+					"10.65.0.27:46891",
+					"172.17.0.1:46891",
+					"172.19.0.1:46891",
+					"172.20.0.1:46891"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:46:06.772762065Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5471650396442347,
+				"StableID":   "nACLkhy7jj11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:abee1047f200278c3c687518f328c12b7fb43858f50c5a028dd88baff1cd254b",
+				"DiscoKey":   "discokey:ad7fddcf604beac8e10939e4becc873b91680cd976c22b7ab30cec2937551b1e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37637",
+					"10.65.0.27:37637",
+					"172.17.0.1:37637",
+					"172.19.0.1:37637",
+					"172.20.0.1:37637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:46:07.270210359Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8020542208079339,
+				"StableID":   "nYhYsW3Xd521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a2a47683cec3941280f0b0aedd74fb24e1f5c25ce80446670feae8c8c30ea59",
+				"DiscoKey":   "discokey:e167dc3d001218cc6d590a0fcdc6579dc83f762a3bc46c18834d410c412ae718",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36559",
+					"10.65.0.27:36559",
+					"172.17.0.1:36559",
+					"172.19.0.1:36559",
+					"172.20.0.1:36559"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:46:07.822437431Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2797993073272656,
+				"StableID":   "nKAGcwXDrN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e94aa159fdc5b80bf5fc43c60251b15fcc63e6082681d86b93933f2c55596621",
+				"DiscoKey":   "discokey:25115f6c6d5fb3b8b127eb923099d324f9da5034d76cfb73f64f034a955e3c32",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:33665",
+					"10.65.0.27:33665",
+					"172.17.0.1:33665",
+					"172.19.0.1:33665",
+					"172.20.0.1:33665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:46:08.359933084Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1398799464861598,
+				"StableID":   "nBqGkD6XvB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:79de947e9512426e55a89c3ebf01d1eceb62c11893cb4a02df249fa37e3c511a",
+				"DiscoKey":   "discokey:5e353d26fa6607e2fada1cdba435131b701c4cc36c4435946d216f2eca38e95a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:45638",
+					"10.65.0.27:45638",
+					"172.17.0.1:45638",
+					"172.19.0.1:45638",
+					"172.20.0.1:45638"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:46:08.891151496Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         105941311146898,
+				"StableID":   "nw7Tt7uyp111CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8513d593a3f964283efef90ae45905b69a65f93a807317d53fc307482ff8a17f",
+				"DiscoKey":   "discokey:3c3a1b50e8b5b22feed5ed5d95be06c62c888fb97cbdee8ddb834afddeebc809",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:35759",
+					"10.65.0.27:35759",
+					"172.17.0.1:35759",
+					"172.19.0.1:35759",
+					"172.20.0.1:35759"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:46:09.425485308Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4840358168485763,
+				"StableID":   "n2edK51Doe11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6e5a753838adff515d8a87cf825dcd331cbcd5c93dbd4d3b04b60f5089fe1568",
+				"DiscoKey":   "discokey:3b195d5217e4399cde29a4a50c9f9f8dbfd46f15c890c97381e0448ab970e45c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33045",
+					"10.65.0.27:33045",
+					"172.17.0.1:33045",
+					"172.19.0.1:33045",
+					"172.20.0.1:33045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:46:09.981722404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7270919369602773,
+				"StableID":   "ni7hbui1ny11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f4abd1605f0fbc62b54202fb79620d4737acc87204cefdad5ff1c2a96d2fd05",
+				"DiscoKey":   "discokey:655688f530ddc605c7775585696b3fca088c474f64c038a7d3b082f930c8b477",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42583",
+					"10.65.0.27:42583",
+					"172.17.0.1:42583",
+					"172.19.0.1:42583",
+					"172.20.0.1:42583"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:46:10.503260754Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8345223381328097,
+				"StableID":   "nAMKLJsZA821CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:273ecb45f41ccdc687846f6c7a770f0ef3d0d8aa24f4b301194dd9f5607e6b4f",
+				"DiscoKey":   "discokey:e88b37938e15df303c7ff19d8254c80048e1a91454b96316b0ab2194e3ee2221",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53326",
+					"10.65.0.27:53326",
+					"172.17.0.1:53326",
+					"172.19.0.1:53326",
+					"172.20.0.1:53326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:46:11.051935902Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7284508780357525,
+				"StableID":   "nUYvHDhAty11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:da30a7aae94b1263e03eee65802ffe8c375186cdd7978829361de3dde7dbf93e",
+				"DiscoKey":   "discokey:ca22ee5eaa9e57bfbf0b82af390f06971341c1ed73416e6d62a3624ba5f85728",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51499",
+					"10.65.0.27:51499",
+					"172.17.0.1:51499",
+					"172.19.0.1:51499",
+					"172.20.0.1:51499"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:46:11.602297689Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1261223189933606,
+				"StableID":   "nPBSSHCDrA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b91904d84c622b2921bfd881a0d31bd3049b37db6540e0e12d263b103ce607a",
+				"DiscoKey":   "discokey:5e9f99363f691068b8cfb655a0699220e19c42e2ddede4b98145fb4efd1ba95a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37859",
+					"10.65.0.27:37859",
+					"172.17.0.1:37859",
+					"172.19.0.1:37859",
+					"172.20.0.1:37859"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:46:12.134872231Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6482308076345644,
+				"StableID":   "nydx5zErcs11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ecf416e42d62022dde27440cda6b9c174445a15146ab0eed3a7e152ba829b25f",
+				"DiscoKey":   "discokey:fed880d838edcc6058fa48976077bac75df8f55af98720391ebf8cab88655700",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52260",
+					"10.65.0.27:52260",
+					"172.17.0.1:52260",
+					"172.19.0.1:52260",
+					"172.20.0.1:52260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:46:12.671264204Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4968233269920452,
+				"StableID":   "nKYY9g48of11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:abc5e4b73bf29fed22d0474639d137ced814e561e955a8d558774f874de5be07",
+				"KeyExpiry":  "2026-11-08T18:46:14Z",
+				"DiscoKey":   "discokey:6bcbb471202963071e864f1c65e332a666760a7c3e8231d3a31334a393c0aa2d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:53906",
+					"10.65.0.27:53906",
+					"172.17.0.1:53906",
+					"172.19.0.1:53906",
+					"172.20.0.1:53906"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:46:14.02309296Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5468679017310369,
+				"StableID":   "ntYb9dvmhj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8c8055fa990ce6570156e10bd77bbb0bba5aec9b7cba1f383c6e11c242515f6c",
+				"KeyExpiry":  "2026-11-08T18:46:14Z",
+				"DiscoKey":   "discokey:2756c5b89e015f8cefe16aca3fe758cd67ad023e74b7c23620011b55ddb9bd01",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38166",
+					"10.65.0.27:38166",
+					"172.17.0.1:38166",
+					"172.19.0.1:38166",
+					"172.20.0.1:38166"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:46:14.556615013Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1261223189933606,
+				"StableID":   "nPBSSHCDrA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1261223189933606,
+				"Key":        "nodekey:4b91904d84c622b2921bfd881a0d31bd3049b37db6540e0e12d263b103ce607a",
+				"DiscoKey":   "discokey:5e9f99363f691068b8cfb655a0699220e19c42e2ddede4b98145fb4efd1ba95a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37859",
+					"10.65.0.27:37859",
+					"172.17.0.1:37859",
+					"172.19.0.1:37859",
+					"172.20.0.1:37859"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:46:12.134872231Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4b91904d84c622b2921bfd881a0d31bd3049b37db6540e0e12d263b103ce607a",
+			"MachineKey": "mkey:db6a674a8a43dbc028f504207f664a5e16c37b44256a98b7927c429ea6521d7f",
+			"Peers": [{
+				"ID":         3974016456418527,
+				"StableID":   "nG3gs4gq2Y11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f9e4cdfcdf5fc4a7c24479e89eeffc6824ee5f1b6a86abadf36e22f7a821935c",
+				"DiscoKey":   "discokey:3fb869cd8a12c370713766714747ad199545f68559d9015ead712ee140f5307a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46891",
+					"10.65.0.27:46891",
+					"172.17.0.1:46891",
+					"172.19.0.1:46891",
+					"172.20.0.1:46891"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:46:06.772762065Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5471650396442347,
+				"StableID":   "nACLkhy7jj11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:abee1047f200278c3c687518f328c12b7fb43858f50c5a028dd88baff1cd254b",
+				"DiscoKey":   "discokey:ad7fddcf604beac8e10939e4becc873b91680cd976c22b7ab30cec2937551b1e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37637",
+					"10.65.0.27:37637",
+					"172.17.0.1:37637",
+					"172.19.0.1:37637",
+					"172.20.0.1:37637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:46:07.270210359Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8020542208079339,
+				"StableID":   "nYhYsW3Xd521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a2a47683cec3941280f0b0aedd74fb24e1f5c25ce80446670feae8c8c30ea59",
+				"DiscoKey":   "discokey:e167dc3d001218cc6d590a0fcdc6579dc83f762a3bc46c18834d410c412ae718",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36559",
+					"10.65.0.27:36559",
+					"172.17.0.1:36559",
+					"172.19.0.1:36559",
+					"172.20.0.1:36559"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:46:07.822437431Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2797993073272656,
+				"StableID":   "nKAGcwXDrN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e94aa159fdc5b80bf5fc43c60251b15fcc63e6082681d86b93933f2c55596621",
+				"DiscoKey":   "discokey:25115f6c6d5fb3b8b127eb923099d324f9da5034d76cfb73f64f034a955e3c32",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:33665",
+					"10.65.0.27:33665",
+					"172.17.0.1:33665",
+					"172.19.0.1:33665",
+					"172.20.0.1:33665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:46:08.359933084Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1398799464861598,
+				"StableID":   "nBqGkD6XvB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:79de947e9512426e55a89c3ebf01d1eceb62c11893cb4a02df249fa37e3c511a",
+				"DiscoKey":   "discokey:5e353d26fa6607e2fada1cdba435131b701c4cc36c4435946d216f2eca38e95a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:45638",
+					"10.65.0.27:45638",
+					"172.17.0.1:45638",
+					"172.19.0.1:45638",
+					"172.20.0.1:45638"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:46:08.891151496Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         105941311146898,
+				"StableID":   "nw7Tt7uyp111CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8513d593a3f964283efef90ae45905b69a65f93a807317d53fc307482ff8a17f",
+				"DiscoKey":   "discokey:3c3a1b50e8b5b22feed5ed5d95be06c62c888fb97cbdee8ddb834afddeebc809",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:35759",
+					"10.65.0.27:35759",
+					"172.17.0.1:35759",
+					"172.19.0.1:35759",
+					"172.20.0.1:35759"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:46:09.425485308Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4840358168485763,
+				"StableID":   "n2edK51Doe11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6e5a753838adff515d8a87cf825dcd331cbcd5c93dbd4d3b04b60f5089fe1568",
+				"DiscoKey":   "discokey:3b195d5217e4399cde29a4a50c9f9f8dbfd46f15c890c97381e0448ab970e45c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33045",
+					"10.65.0.27:33045",
+					"172.17.0.1:33045",
+					"172.19.0.1:33045",
+					"172.20.0.1:33045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:46:09.981722404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7270919369602773,
+				"StableID":   "ni7hbui1ny11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f4abd1605f0fbc62b54202fb79620d4737acc87204cefdad5ff1c2a96d2fd05",
+				"DiscoKey":   "discokey:655688f530ddc605c7775585696b3fca088c474f64c038a7d3b082f930c8b477",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42583",
+					"10.65.0.27:42583",
+					"172.17.0.1:42583",
+					"172.19.0.1:42583",
+					"172.20.0.1:42583"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:46:10.503260754Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8345223381328097,
+				"StableID":   "nAMKLJsZA821CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:273ecb45f41ccdc687846f6c7a770f0ef3d0d8aa24f4b301194dd9f5607e6b4f",
+				"DiscoKey":   "discokey:e88b37938e15df303c7ff19d8254c80048e1a91454b96316b0ab2194e3ee2221",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53326",
+					"10.65.0.27:53326",
+					"172.17.0.1:53326",
+					"172.19.0.1:53326",
+					"172.20.0.1:53326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:46:11.051935902Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7284508780357525,
+				"StableID":   "nUYvHDhAty11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:da30a7aae94b1263e03eee65802ffe8c375186cdd7978829361de3dde7dbf93e",
+				"DiscoKey":   "discokey:ca22ee5eaa9e57bfbf0b82af390f06971341c1ed73416e6d62a3624ba5f85728",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51499",
+					"10.65.0.27:51499",
+					"172.17.0.1:51499",
+					"172.19.0.1:51499",
+					"172.20.0.1:51499"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:46:11.602297689Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6482308076345644,
+				"StableID":   "nydx5zErcs11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ecf416e42d62022dde27440cda6b9c174445a15146ab0eed3a7e152ba829b25f",
+				"DiscoKey":   "discokey:fed880d838edcc6058fa48976077bac75df8f55af98720391ebf8cab88655700",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52260",
+					"10.65.0.27:52260",
+					"172.17.0.1:52260",
+					"172.19.0.1:52260",
+					"172.20.0.1:52260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:46:12.671264204Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1098906057830437,
+				"StableID":   "nJsbJ8Qha911CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0cc657ba2fbbac04b2fcd974cd92a890157d05671fab8dcae71a246dc2b0b975",
+				"KeyExpiry":  "2026-11-08T18:46:13Z",
+				"DiscoKey":   "discokey:df4371c3d9cd2a83c29db892aebb439b9416e8723a7a7f4f8b158c2639159915",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52980",
+					"10.65.0.27:52980",
+					"172.17.0.1:52980",
+					"172.19.0.1:52980",
+					"172.20.0.1:52980"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:46:13.305949474Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4968233269920452,
+				"StableID":   "nKYY9g48of11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:abc5e4b73bf29fed22d0474639d137ced814e561e955a8d558774f874de5be07",
+				"KeyExpiry":  "2026-11-08T18:46:14Z",
+				"DiscoKey":   "discokey:6bcbb471202963071e864f1c65e332a666760a7c3e8231d3a31334a393c0aa2d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:53906",
+					"10.65.0.27:53906",
+					"172.17.0.1:53906",
+					"172.19.0.1:53906",
+					"172.20.0.1:53906"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:46:14.02309296Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5468679017310369,
+				"StableID":   "ntYb9dvmhj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8c8055fa990ce6570156e10bd77bbb0bba5aec9b7cba1f383c6e11c242515f6c",
+				"KeyExpiry":  "2026-11-08T18:46:14Z",
+				"DiscoKey":   "discokey:2756c5b89e015f8cefe16aca3fe758cd67ad023e74b7c23620011b55ddb9bd01",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38166",
+					"10.65.0.27:38166",
+					"172.17.0.1:38166",
+					"172.19.0.1:38166",
+					"172.20.0.1:38166"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:46:14.556615013Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1261223189933606": {
+				"ID":          1261223189933606,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5471650396442347,
+				"StableID":   "nACLkhy7jj11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       5471650396442347,
+				"Key":        "nodekey:abee1047f200278c3c687518f328c12b7fb43858f50c5a028dd88baff1cd254b",
+				"DiscoKey":   "discokey:ad7fddcf604beac8e10939e4becc873b91680cd976c22b7ab30cec2937551b1e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37637",
+					"10.65.0.27:37637",
+					"172.17.0.1:37637",
+					"172.19.0.1:37637",
+					"172.20.0.1:37637"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:46:07.270210359Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:abee1047f200278c3c687518f328c12b7fb43858f50c5a028dd88baff1cd254b",
+			"MachineKey": "mkey:34d4cf24d42707e65e53ba2afe8a561ceb906726d7920b1276c21d6195db9c57",
+			"Peers": [{
+				"ID":         3974016456418527,
+				"StableID":   "nG3gs4gq2Y11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f9e4cdfcdf5fc4a7c24479e89eeffc6824ee5f1b6a86abadf36e22f7a821935c",
+				"DiscoKey":   "discokey:3fb869cd8a12c370713766714747ad199545f68559d9015ead712ee140f5307a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46891",
+					"10.65.0.27:46891",
+					"172.17.0.1:46891",
+					"172.19.0.1:46891",
+					"172.20.0.1:46891"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:46:06.772762065Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8020542208079339,
+				"StableID":   "nYhYsW3Xd521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a2a47683cec3941280f0b0aedd74fb24e1f5c25ce80446670feae8c8c30ea59",
+				"DiscoKey":   "discokey:e167dc3d001218cc6d590a0fcdc6579dc83f762a3bc46c18834d410c412ae718",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36559",
+					"10.65.0.27:36559",
+					"172.17.0.1:36559",
+					"172.19.0.1:36559",
+					"172.20.0.1:36559"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:46:07.822437431Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2797993073272656,
+				"StableID":   "nKAGcwXDrN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e94aa159fdc5b80bf5fc43c60251b15fcc63e6082681d86b93933f2c55596621",
+				"DiscoKey":   "discokey:25115f6c6d5fb3b8b127eb923099d324f9da5034d76cfb73f64f034a955e3c32",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:33665",
+					"10.65.0.27:33665",
+					"172.17.0.1:33665",
+					"172.19.0.1:33665",
+					"172.20.0.1:33665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:46:08.359933084Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1398799464861598,
+				"StableID":   "nBqGkD6XvB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:79de947e9512426e55a89c3ebf01d1eceb62c11893cb4a02df249fa37e3c511a",
+				"DiscoKey":   "discokey:5e353d26fa6607e2fada1cdba435131b701c4cc36c4435946d216f2eca38e95a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:45638",
+					"10.65.0.27:45638",
+					"172.17.0.1:45638",
+					"172.19.0.1:45638",
+					"172.20.0.1:45638"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:46:08.891151496Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         105941311146898,
+				"StableID":   "nw7Tt7uyp111CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8513d593a3f964283efef90ae45905b69a65f93a807317d53fc307482ff8a17f",
+				"DiscoKey":   "discokey:3c3a1b50e8b5b22feed5ed5d95be06c62c888fb97cbdee8ddb834afddeebc809",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:35759",
+					"10.65.0.27:35759",
+					"172.17.0.1:35759",
+					"172.19.0.1:35759",
+					"172.20.0.1:35759"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:46:09.425485308Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4840358168485763,
+				"StableID":   "n2edK51Doe11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6e5a753838adff515d8a87cf825dcd331cbcd5c93dbd4d3b04b60f5089fe1568",
+				"DiscoKey":   "discokey:3b195d5217e4399cde29a4a50c9f9f8dbfd46f15c890c97381e0448ab970e45c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33045",
+					"10.65.0.27:33045",
+					"172.17.0.1:33045",
+					"172.19.0.1:33045",
+					"172.20.0.1:33045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:46:09.981722404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7270919369602773,
+				"StableID":   "ni7hbui1ny11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f4abd1605f0fbc62b54202fb79620d4737acc87204cefdad5ff1c2a96d2fd05",
+				"DiscoKey":   "discokey:655688f530ddc605c7775585696b3fca088c474f64c038a7d3b082f930c8b477",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42583",
+					"10.65.0.27:42583",
+					"172.17.0.1:42583",
+					"172.19.0.1:42583",
+					"172.20.0.1:42583"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:46:10.503260754Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8345223381328097,
+				"StableID":   "nAMKLJsZA821CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:273ecb45f41ccdc687846f6c7a770f0ef3d0d8aa24f4b301194dd9f5607e6b4f",
+				"DiscoKey":   "discokey:e88b37938e15df303c7ff19d8254c80048e1a91454b96316b0ab2194e3ee2221",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53326",
+					"10.65.0.27:53326",
+					"172.17.0.1:53326",
+					"172.19.0.1:53326",
+					"172.20.0.1:53326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:46:11.051935902Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7284508780357525,
+				"StableID":   "nUYvHDhAty11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:da30a7aae94b1263e03eee65802ffe8c375186cdd7978829361de3dde7dbf93e",
+				"DiscoKey":   "discokey:ca22ee5eaa9e57bfbf0b82af390f06971341c1ed73416e6d62a3624ba5f85728",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51499",
+					"10.65.0.27:51499",
+					"172.17.0.1:51499",
+					"172.19.0.1:51499",
+					"172.20.0.1:51499"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:46:11.602297689Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1261223189933606,
+				"StableID":   "nPBSSHCDrA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b91904d84c622b2921bfd881a0d31bd3049b37db6540e0e12d263b103ce607a",
+				"DiscoKey":   "discokey:5e9f99363f691068b8cfb655a0699220e19c42e2ddede4b98145fb4efd1ba95a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37859",
+					"10.65.0.27:37859",
+					"172.17.0.1:37859",
+					"172.19.0.1:37859",
+					"172.20.0.1:37859"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:46:12.134872231Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6482308076345644,
+				"StableID":   "nydx5zErcs11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ecf416e42d62022dde27440cda6b9c174445a15146ab0eed3a7e152ba829b25f",
+				"DiscoKey":   "discokey:fed880d838edcc6058fa48976077bac75df8f55af98720391ebf8cab88655700",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52260",
+					"10.65.0.27:52260",
+					"172.17.0.1:52260",
+					"172.19.0.1:52260",
+					"172.20.0.1:52260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:46:12.671264204Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1098906057830437,
+				"StableID":   "nJsbJ8Qha911CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0cc657ba2fbbac04b2fcd974cd92a890157d05671fab8dcae71a246dc2b0b975",
+				"KeyExpiry":  "2026-11-08T18:46:13Z",
+				"DiscoKey":   "discokey:df4371c3d9cd2a83c29db892aebb439b9416e8723a7a7f4f8b158c2639159915",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52980",
+					"10.65.0.27:52980",
+					"172.17.0.1:52980",
+					"172.19.0.1:52980",
+					"172.20.0.1:52980"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:46:13.305949474Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4968233269920452,
+				"StableID":   "nKYY9g48of11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:abc5e4b73bf29fed22d0474639d137ced814e561e955a8d558774f874de5be07",
+				"KeyExpiry":  "2026-11-08T18:46:14Z",
+				"DiscoKey":   "discokey:6bcbb471202963071e864f1c65e332a666760a7c3e8231d3a31334a393c0aa2d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:53906",
+					"10.65.0.27:53906",
+					"172.17.0.1:53906",
+					"172.19.0.1:53906",
+					"172.20.0.1:53906"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:46:14.02309296Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5468679017310369,
+				"StableID":   "ntYb9dvmhj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8c8055fa990ce6570156e10bd77bbb0bba5aec9b7cba1f383c6e11c242515f6c",
+				"KeyExpiry":  "2026-11-08T18:46:14Z",
+				"DiscoKey":   "discokey:2756c5b89e015f8cefe16aca3fe758cd67ad023e74b7c23620011b55ddb9bd01",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38166",
+					"10.65.0.27:38166",
+					"172.17.0.1:38166",
+					"172.19.0.1:38166",
+					"172.20.0.1:38166"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:46:14.556615013Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5471650396442347": {
+				"ID":          5471650396442347,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3974016456418527,
+				"StableID":   "nG3gs4gq2Y11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       3974016456418527,
+				"Key":        "nodekey:f9e4cdfcdf5fc4a7c24479e89eeffc6824ee5f1b6a86abadf36e22f7a821935c",
+				"DiscoKey":   "discokey:3fb869cd8a12c370713766714747ad199545f68559d9015ead712ee140f5307a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46891",
+					"10.65.0.27:46891",
+					"172.17.0.1:46891",
+					"172.19.0.1:46891",
+					"172.20.0.1:46891"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:46:06.772762065Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f9e4cdfcdf5fc4a7c24479e89eeffc6824ee5f1b6a86abadf36e22f7a821935c",
+			"MachineKey": "mkey:fb1eacc0ea91aeb562950141940aaa90a7e975d6774ac2ff0511273ece624c15",
+			"Peers": [{
+				"ID":         5471650396442347,
+				"StableID":   "nACLkhy7jj11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:abee1047f200278c3c687518f328c12b7fb43858f50c5a028dd88baff1cd254b",
+				"DiscoKey":   "discokey:ad7fddcf604beac8e10939e4becc873b91680cd976c22b7ab30cec2937551b1e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37637",
+					"10.65.0.27:37637",
+					"172.17.0.1:37637",
+					"172.19.0.1:37637",
+					"172.20.0.1:37637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:46:07.270210359Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8020542208079339,
+				"StableID":   "nYhYsW3Xd521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a2a47683cec3941280f0b0aedd74fb24e1f5c25ce80446670feae8c8c30ea59",
+				"DiscoKey":   "discokey:e167dc3d001218cc6d590a0fcdc6579dc83f762a3bc46c18834d410c412ae718",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36559",
+					"10.65.0.27:36559",
+					"172.17.0.1:36559",
+					"172.19.0.1:36559",
+					"172.20.0.1:36559"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:46:07.822437431Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2797993073272656,
+				"StableID":   "nKAGcwXDrN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e94aa159fdc5b80bf5fc43c60251b15fcc63e6082681d86b93933f2c55596621",
+				"DiscoKey":   "discokey:25115f6c6d5fb3b8b127eb923099d324f9da5034d76cfb73f64f034a955e3c32",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:33665",
+					"10.65.0.27:33665",
+					"172.17.0.1:33665",
+					"172.19.0.1:33665",
+					"172.20.0.1:33665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:46:08.359933084Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1398799464861598,
+				"StableID":   "nBqGkD6XvB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:79de947e9512426e55a89c3ebf01d1eceb62c11893cb4a02df249fa37e3c511a",
+				"DiscoKey":   "discokey:5e353d26fa6607e2fada1cdba435131b701c4cc36c4435946d216f2eca38e95a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:45638",
+					"10.65.0.27:45638",
+					"172.17.0.1:45638",
+					"172.19.0.1:45638",
+					"172.20.0.1:45638"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:46:08.891151496Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         105941311146898,
+				"StableID":   "nw7Tt7uyp111CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8513d593a3f964283efef90ae45905b69a65f93a807317d53fc307482ff8a17f",
+				"DiscoKey":   "discokey:3c3a1b50e8b5b22feed5ed5d95be06c62c888fb97cbdee8ddb834afddeebc809",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:35759",
+					"10.65.0.27:35759",
+					"172.17.0.1:35759",
+					"172.19.0.1:35759",
+					"172.20.0.1:35759"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:46:09.425485308Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4840358168485763,
+				"StableID":   "n2edK51Doe11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6e5a753838adff515d8a87cf825dcd331cbcd5c93dbd4d3b04b60f5089fe1568",
+				"DiscoKey":   "discokey:3b195d5217e4399cde29a4a50c9f9f8dbfd46f15c890c97381e0448ab970e45c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33045",
+					"10.65.0.27:33045",
+					"172.17.0.1:33045",
+					"172.19.0.1:33045",
+					"172.20.0.1:33045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:46:09.981722404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7270919369602773,
+				"StableID":   "ni7hbui1ny11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f4abd1605f0fbc62b54202fb79620d4737acc87204cefdad5ff1c2a96d2fd05",
+				"DiscoKey":   "discokey:655688f530ddc605c7775585696b3fca088c474f64c038a7d3b082f930c8b477",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42583",
+					"10.65.0.27:42583",
+					"172.17.0.1:42583",
+					"172.19.0.1:42583",
+					"172.20.0.1:42583"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:46:10.503260754Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8345223381328097,
+				"StableID":   "nAMKLJsZA821CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:273ecb45f41ccdc687846f6c7a770f0ef3d0d8aa24f4b301194dd9f5607e6b4f",
+				"DiscoKey":   "discokey:e88b37938e15df303c7ff19d8254c80048e1a91454b96316b0ab2194e3ee2221",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53326",
+					"10.65.0.27:53326",
+					"172.17.0.1:53326",
+					"172.19.0.1:53326",
+					"172.20.0.1:53326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:46:11.051935902Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7284508780357525,
+				"StableID":   "nUYvHDhAty11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:da30a7aae94b1263e03eee65802ffe8c375186cdd7978829361de3dde7dbf93e",
+				"DiscoKey":   "discokey:ca22ee5eaa9e57bfbf0b82af390f06971341c1ed73416e6d62a3624ba5f85728",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51499",
+					"10.65.0.27:51499",
+					"172.17.0.1:51499",
+					"172.19.0.1:51499",
+					"172.20.0.1:51499"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:46:11.602297689Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1261223189933606,
+				"StableID":   "nPBSSHCDrA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b91904d84c622b2921bfd881a0d31bd3049b37db6540e0e12d263b103ce607a",
+				"DiscoKey":   "discokey:5e9f99363f691068b8cfb655a0699220e19c42e2ddede4b98145fb4efd1ba95a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37859",
+					"10.65.0.27:37859",
+					"172.17.0.1:37859",
+					"172.19.0.1:37859",
+					"172.20.0.1:37859"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:46:12.134872231Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6482308076345644,
+				"StableID":   "nydx5zErcs11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ecf416e42d62022dde27440cda6b9c174445a15146ab0eed3a7e152ba829b25f",
+				"DiscoKey":   "discokey:fed880d838edcc6058fa48976077bac75df8f55af98720391ebf8cab88655700",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52260",
+					"10.65.0.27:52260",
+					"172.17.0.1:52260",
+					"172.19.0.1:52260",
+					"172.20.0.1:52260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:46:12.671264204Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1098906057830437,
+				"StableID":   "nJsbJ8Qha911CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0cc657ba2fbbac04b2fcd974cd92a890157d05671fab8dcae71a246dc2b0b975",
+				"KeyExpiry":  "2026-11-08T18:46:13Z",
+				"DiscoKey":   "discokey:df4371c3d9cd2a83c29db892aebb439b9416e8723a7a7f4f8b158c2639159915",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52980",
+					"10.65.0.27:52980",
+					"172.17.0.1:52980",
+					"172.19.0.1:52980",
+					"172.20.0.1:52980"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:46:13.305949474Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4968233269920452,
+				"StableID":   "nKYY9g48of11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:abc5e4b73bf29fed22d0474639d137ced814e561e955a8d558774f874de5be07",
+				"KeyExpiry":  "2026-11-08T18:46:14Z",
+				"DiscoKey":   "discokey:6bcbb471202963071e864f1c65e332a666760a7c3e8231d3a31334a393c0aa2d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:53906",
+					"10.65.0.27:53906",
+					"172.17.0.1:53906",
+					"172.19.0.1:53906",
+					"172.20.0.1:53906"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:46:14.02309296Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5468679017310369,
+				"StableID":   "ntYb9dvmhj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8c8055fa990ce6570156e10bd77bbb0bba5aec9b7cba1f383c6e11c242515f6c",
+				"KeyExpiry":  "2026-11-08T18:46:14Z",
+				"DiscoKey":   "discokey:2756c5b89e015f8cefe16aca3fe758cd67ad023e74b7c23620011b55ddb9bd01",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38166",
+					"10.65.0.27:38166",
+					"172.17.0.1:38166",
+					"172.19.0.1:38166",
+					"172.20.0.1:38166"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:46:14.556615013Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3974016456418527": {
+				"ID":          3974016456418527,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1398799464861598,
+				"StableID":   "nBqGkD6XvB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1398799464861598,
+				"Key":        "nodekey:79de947e9512426e55a89c3ebf01d1eceb62c11893cb4a02df249fa37e3c511a",
+				"DiscoKey":   "discokey:5e353d26fa6607e2fada1cdba435131b701c4cc36c4435946d216f2eca38e95a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:45638",
+					"10.65.0.27:45638",
+					"172.17.0.1:45638",
+					"172.19.0.1:45638",
+					"172.20.0.1:45638"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:46:08.891151496Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:79de947e9512426e55a89c3ebf01d1eceb62c11893cb4a02df249fa37e3c511a",
+			"MachineKey": "mkey:5e3e1efc02d61c4fbbe80a9b1a27bf4505b1d1ddb3c29555bba5e9df8bf9884a",
+			"Peers": [{
+				"ID":         3974016456418527,
+				"StableID":   "nG3gs4gq2Y11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f9e4cdfcdf5fc4a7c24479e89eeffc6824ee5f1b6a86abadf36e22f7a821935c",
+				"DiscoKey":   "discokey:3fb869cd8a12c370713766714747ad199545f68559d9015ead712ee140f5307a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46891",
+					"10.65.0.27:46891",
+					"172.17.0.1:46891",
+					"172.19.0.1:46891",
+					"172.20.0.1:46891"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:46:06.772762065Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5471650396442347,
+				"StableID":   "nACLkhy7jj11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:abee1047f200278c3c687518f328c12b7fb43858f50c5a028dd88baff1cd254b",
+				"DiscoKey":   "discokey:ad7fddcf604beac8e10939e4becc873b91680cd976c22b7ab30cec2937551b1e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37637",
+					"10.65.0.27:37637",
+					"172.17.0.1:37637",
+					"172.19.0.1:37637",
+					"172.20.0.1:37637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:46:07.270210359Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8020542208079339,
+				"StableID":   "nYhYsW3Xd521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a2a47683cec3941280f0b0aedd74fb24e1f5c25ce80446670feae8c8c30ea59",
+				"DiscoKey":   "discokey:e167dc3d001218cc6d590a0fcdc6579dc83f762a3bc46c18834d410c412ae718",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36559",
+					"10.65.0.27:36559",
+					"172.17.0.1:36559",
+					"172.19.0.1:36559",
+					"172.20.0.1:36559"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:46:07.822437431Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2797993073272656,
+				"StableID":   "nKAGcwXDrN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e94aa159fdc5b80bf5fc43c60251b15fcc63e6082681d86b93933f2c55596621",
+				"DiscoKey":   "discokey:25115f6c6d5fb3b8b127eb923099d324f9da5034d76cfb73f64f034a955e3c32",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:33665",
+					"10.65.0.27:33665",
+					"172.17.0.1:33665",
+					"172.19.0.1:33665",
+					"172.20.0.1:33665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:46:08.359933084Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         105941311146898,
+				"StableID":   "nw7Tt7uyp111CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8513d593a3f964283efef90ae45905b69a65f93a807317d53fc307482ff8a17f",
+				"DiscoKey":   "discokey:3c3a1b50e8b5b22feed5ed5d95be06c62c888fb97cbdee8ddb834afddeebc809",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:35759",
+					"10.65.0.27:35759",
+					"172.17.0.1:35759",
+					"172.19.0.1:35759",
+					"172.20.0.1:35759"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:46:09.425485308Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4840358168485763,
+				"StableID":   "n2edK51Doe11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6e5a753838adff515d8a87cf825dcd331cbcd5c93dbd4d3b04b60f5089fe1568",
+				"DiscoKey":   "discokey:3b195d5217e4399cde29a4a50c9f9f8dbfd46f15c890c97381e0448ab970e45c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33045",
+					"10.65.0.27:33045",
+					"172.17.0.1:33045",
+					"172.19.0.1:33045",
+					"172.20.0.1:33045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:46:09.981722404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7270919369602773,
+				"StableID":   "ni7hbui1ny11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f4abd1605f0fbc62b54202fb79620d4737acc87204cefdad5ff1c2a96d2fd05",
+				"DiscoKey":   "discokey:655688f530ddc605c7775585696b3fca088c474f64c038a7d3b082f930c8b477",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42583",
+					"10.65.0.27:42583",
+					"172.17.0.1:42583",
+					"172.19.0.1:42583",
+					"172.20.0.1:42583"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:46:10.503260754Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8345223381328097,
+				"StableID":   "nAMKLJsZA821CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:273ecb45f41ccdc687846f6c7a770f0ef3d0d8aa24f4b301194dd9f5607e6b4f",
+				"DiscoKey":   "discokey:e88b37938e15df303c7ff19d8254c80048e1a91454b96316b0ab2194e3ee2221",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53326",
+					"10.65.0.27:53326",
+					"172.17.0.1:53326",
+					"172.19.0.1:53326",
+					"172.20.0.1:53326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:46:11.051935902Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7284508780357525,
+				"StableID":   "nUYvHDhAty11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:da30a7aae94b1263e03eee65802ffe8c375186cdd7978829361de3dde7dbf93e",
+				"DiscoKey":   "discokey:ca22ee5eaa9e57bfbf0b82af390f06971341c1ed73416e6d62a3624ba5f85728",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51499",
+					"10.65.0.27:51499",
+					"172.17.0.1:51499",
+					"172.19.0.1:51499",
+					"172.20.0.1:51499"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:46:11.602297689Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1261223189933606,
+				"StableID":   "nPBSSHCDrA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b91904d84c622b2921bfd881a0d31bd3049b37db6540e0e12d263b103ce607a",
+				"DiscoKey":   "discokey:5e9f99363f691068b8cfb655a0699220e19c42e2ddede4b98145fb4efd1ba95a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37859",
+					"10.65.0.27:37859",
+					"172.17.0.1:37859",
+					"172.19.0.1:37859",
+					"172.20.0.1:37859"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:46:12.134872231Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6482308076345644,
+				"StableID":   "nydx5zErcs11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ecf416e42d62022dde27440cda6b9c174445a15146ab0eed3a7e152ba829b25f",
+				"DiscoKey":   "discokey:fed880d838edcc6058fa48976077bac75df8f55af98720391ebf8cab88655700",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52260",
+					"10.65.0.27:52260",
+					"172.17.0.1:52260",
+					"172.19.0.1:52260",
+					"172.20.0.1:52260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:46:12.671264204Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1098906057830437,
+				"StableID":   "nJsbJ8Qha911CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0cc657ba2fbbac04b2fcd974cd92a890157d05671fab8dcae71a246dc2b0b975",
+				"KeyExpiry":  "2026-11-08T18:46:13Z",
+				"DiscoKey":   "discokey:df4371c3d9cd2a83c29db892aebb439b9416e8723a7a7f4f8b158c2639159915",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52980",
+					"10.65.0.27:52980",
+					"172.17.0.1:52980",
+					"172.19.0.1:52980",
+					"172.20.0.1:52980"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:46:13.305949474Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4968233269920452,
+				"StableID":   "nKYY9g48of11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:abc5e4b73bf29fed22d0474639d137ced814e561e955a8d558774f874de5be07",
+				"KeyExpiry":  "2026-11-08T18:46:14Z",
+				"DiscoKey":   "discokey:6bcbb471202963071e864f1c65e332a666760a7c3e8231d3a31334a393c0aa2d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:53906",
+					"10.65.0.27:53906",
+					"172.17.0.1:53906",
+					"172.19.0.1:53906",
+					"172.20.0.1:53906"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:46:14.02309296Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5468679017310369,
+				"StableID":   "ntYb9dvmhj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8c8055fa990ce6570156e10bd77bbb0bba5aec9b7cba1f383c6e11c242515f6c",
+				"KeyExpiry":  "2026-11-08T18:46:14Z",
+				"DiscoKey":   "discokey:2756c5b89e015f8cefe16aca3fe758cd67ad023e74b7c23620011b55ddb9bd01",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38166",
+					"10.65.0.27:38166",
+					"172.17.0.1:38166",
+					"172.19.0.1:38166",
+					"172.20.0.1:38166"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:46:14.556615013Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1398799464861598": {
+				"ID":          1398799464861598,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2797993073272656,
+				"StableID":   "nKAGcwXDrN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       2797993073272656,
+				"Key":        "nodekey:e94aa159fdc5b80bf5fc43c60251b15fcc63e6082681d86b93933f2c55596621",
+				"DiscoKey":   "discokey:25115f6c6d5fb3b8b127eb923099d324f9da5034d76cfb73f64f034a955e3c32",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:33665",
+					"10.65.0.27:33665",
+					"172.17.0.1:33665",
+					"172.19.0.1:33665",
+					"172.20.0.1:33665"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:46:08.359933084Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e94aa159fdc5b80bf5fc43c60251b15fcc63e6082681d86b93933f2c55596621",
+			"MachineKey": "mkey:49ca484a42e7af60dd35d0244eeeb78645ab6f5977133906096b037cb9600e0e",
+			"Peers": [{
+				"ID":         3974016456418527,
+				"StableID":   "nG3gs4gq2Y11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f9e4cdfcdf5fc4a7c24479e89eeffc6824ee5f1b6a86abadf36e22f7a821935c",
+				"DiscoKey":   "discokey:3fb869cd8a12c370713766714747ad199545f68559d9015ead712ee140f5307a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46891",
+					"10.65.0.27:46891",
+					"172.17.0.1:46891",
+					"172.19.0.1:46891",
+					"172.20.0.1:46891"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:46:06.772762065Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5471650396442347,
+				"StableID":   "nACLkhy7jj11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:abee1047f200278c3c687518f328c12b7fb43858f50c5a028dd88baff1cd254b",
+				"DiscoKey":   "discokey:ad7fddcf604beac8e10939e4becc873b91680cd976c22b7ab30cec2937551b1e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37637",
+					"10.65.0.27:37637",
+					"172.17.0.1:37637",
+					"172.19.0.1:37637",
+					"172.20.0.1:37637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:46:07.270210359Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8020542208079339,
+				"StableID":   "nYhYsW3Xd521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a2a47683cec3941280f0b0aedd74fb24e1f5c25ce80446670feae8c8c30ea59",
+				"DiscoKey":   "discokey:e167dc3d001218cc6d590a0fcdc6579dc83f762a3bc46c18834d410c412ae718",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36559",
+					"10.65.0.27:36559",
+					"172.17.0.1:36559",
+					"172.19.0.1:36559",
+					"172.20.0.1:36559"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:46:07.822437431Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1398799464861598,
+				"StableID":   "nBqGkD6XvB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:79de947e9512426e55a89c3ebf01d1eceb62c11893cb4a02df249fa37e3c511a",
+				"DiscoKey":   "discokey:5e353d26fa6607e2fada1cdba435131b701c4cc36c4435946d216f2eca38e95a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:45638",
+					"10.65.0.27:45638",
+					"172.17.0.1:45638",
+					"172.19.0.1:45638",
+					"172.20.0.1:45638"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:46:08.891151496Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         105941311146898,
+				"StableID":   "nw7Tt7uyp111CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8513d593a3f964283efef90ae45905b69a65f93a807317d53fc307482ff8a17f",
+				"DiscoKey":   "discokey:3c3a1b50e8b5b22feed5ed5d95be06c62c888fb97cbdee8ddb834afddeebc809",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:35759",
+					"10.65.0.27:35759",
+					"172.17.0.1:35759",
+					"172.19.0.1:35759",
+					"172.20.0.1:35759"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:46:09.425485308Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4840358168485763,
+				"StableID":   "n2edK51Doe11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6e5a753838adff515d8a87cf825dcd331cbcd5c93dbd4d3b04b60f5089fe1568",
+				"DiscoKey":   "discokey:3b195d5217e4399cde29a4a50c9f9f8dbfd46f15c890c97381e0448ab970e45c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33045",
+					"10.65.0.27:33045",
+					"172.17.0.1:33045",
+					"172.19.0.1:33045",
+					"172.20.0.1:33045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:46:09.981722404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7270919369602773,
+				"StableID":   "ni7hbui1ny11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f4abd1605f0fbc62b54202fb79620d4737acc87204cefdad5ff1c2a96d2fd05",
+				"DiscoKey":   "discokey:655688f530ddc605c7775585696b3fca088c474f64c038a7d3b082f930c8b477",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42583",
+					"10.65.0.27:42583",
+					"172.17.0.1:42583",
+					"172.19.0.1:42583",
+					"172.20.0.1:42583"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:46:10.503260754Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8345223381328097,
+				"StableID":   "nAMKLJsZA821CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:273ecb45f41ccdc687846f6c7a770f0ef3d0d8aa24f4b301194dd9f5607e6b4f",
+				"DiscoKey":   "discokey:e88b37938e15df303c7ff19d8254c80048e1a91454b96316b0ab2194e3ee2221",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53326",
+					"10.65.0.27:53326",
+					"172.17.0.1:53326",
+					"172.19.0.1:53326",
+					"172.20.0.1:53326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:46:11.051935902Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7284508780357525,
+				"StableID":   "nUYvHDhAty11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:da30a7aae94b1263e03eee65802ffe8c375186cdd7978829361de3dde7dbf93e",
+				"DiscoKey":   "discokey:ca22ee5eaa9e57bfbf0b82af390f06971341c1ed73416e6d62a3624ba5f85728",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51499",
+					"10.65.0.27:51499",
+					"172.17.0.1:51499",
+					"172.19.0.1:51499",
+					"172.20.0.1:51499"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:46:11.602297689Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1261223189933606,
+				"StableID":   "nPBSSHCDrA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b91904d84c622b2921bfd881a0d31bd3049b37db6540e0e12d263b103ce607a",
+				"DiscoKey":   "discokey:5e9f99363f691068b8cfb655a0699220e19c42e2ddede4b98145fb4efd1ba95a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37859",
+					"10.65.0.27:37859",
+					"172.17.0.1:37859",
+					"172.19.0.1:37859",
+					"172.20.0.1:37859"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:46:12.134872231Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6482308076345644,
+				"StableID":   "nydx5zErcs11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ecf416e42d62022dde27440cda6b9c174445a15146ab0eed3a7e152ba829b25f",
+				"DiscoKey":   "discokey:fed880d838edcc6058fa48976077bac75df8f55af98720391ebf8cab88655700",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52260",
+					"10.65.0.27:52260",
+					"172.17.0.1:52260",
+					"172.19.0.1:52260",
+					"172.20.0.1:52260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:46:12.671264204Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1098906057830437,
+				"StableID":   "nJsbJ8Qha911CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0cc657ba2fbbac04b2fcd974cd92a890157d05671fab8dcae71a246dc2b0b975",
+				"KeyExpiry":  "2026-11-08T18:46:13Z",
+				"DiscoKey":   "discokey:df4371c3d9cd2a83c29db892aebb439b9416e8723a7a7f4f8b158c2639159915",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52980",
+					"10.65.0.27:52980",
+					"172.17.0.1:52980",
+					"172.19.0.1:52980",
+					"172.20.0.1:52980"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:46:13.305949474Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4968233269920452,
+				"StableID":   "nKYY9g48of11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:abc5e4b73bf29fed22d0474639d137ced814e561e955a8d558774f874de5be07",
+				"KeyExpiry":  "2026-11-08T18:46:14Z",
+				"DiscoKey":   "discokey:6bcbb471202963071e864f1c65e332a666760a7c3e8231d3a31334a393c0aa2d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:53906",
+					"10.65.0.27:53906",
+					"172.17.0.1:53906",
+					"172.19.0.1:53906",
+					"172.20.0.1:53906"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:46:14.02309296Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5468679017310369,
+				"StableID":   "ntYb9dvmhj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8c8055fa990ce6570156e10bd77bbb0bba5aec9b7cba1f383c6e11c242515f6c",
+				"KeyExpiry":  "2026-11-08T18:46:14Z",
+				"DiscoKey":   "discokey:2756c5b89e015f8cefe16aca3fe758cd67ad023e74b7c23620011b55ddb9bd01",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38166",
+					"10.65.0.27:38166",
+					"172.17.0.1:38166",
+					"172.19.0.1:38166",
+					"172.20.0.1:38166"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:46:14.556615013Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2797993073272656": {
+				"ID":          2797993073272656,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4840358168485763,
+				"StableID":   "n2edK51Doe11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       4840358168485763,
+				"Key":        "nodekey:6e5a753838adff515d8a87cf825dcd331cbcd5c93dbd4d3b04b60f5089fe1568",
+				"DiscoKey":   "discokey:3b195d5217e4399cde29a4a50c9f9f8dbfd46f15c890c97381e0448ab970e45c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33045",
+					"10.65.0.27:33045",
+					"172.17.0.1:33045",
+					"172.19.0.1:33045",
+					"172.20.0.1:33045"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:46:09.981722404Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6e5a753838adff515d8a87cf825dcd331cbcd5c93dbd4d3b04b60f5089fe1568",
+			"MachineKey": "mkey:a7231c2ff0a196c0d274e215d37ad1e0117da1e4d0904f236647d49a331fd01e",
+			"Peers": [{
+				"ID":         3974016456418527,
+				"StableID":   "nG3gs4gq2Y11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f9e4cdfcdf5fc4a7c24479e89eeffc6824ee5f1b6a86abadf36e22f7a821935c",
+				"DiscoKey":   "discokey:3fb869cd8a12c370713766714747ad199545f68559d9015ead712ee140f5307a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46891",
+					"10.65.0.27:46891",
+					"172.17.0.1:46891",
+					"172.19.0.1:46891",
+					"172.20.0.1:46891"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:46:06.772762065Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5471650396442347,
+				"StableID":   "nACLkhy7jj11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:abee1047f200278c3c687518f328c12b7fb43858f50c5a028dd88baff1cd254b",
+				"DiscoKey":   "discokey:ad7fddcf604beac8e10939e4becc873b91680cd976c22b7ab30cec2937551b1e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37637",
+					"10.65.0.27:37637",
+					"172.17.0.1:37637",
+					"172.19.0.1:37637",
+					"172.20.0.1:37637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:46:07.270210359Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8020542208079339,
+				"StableID":   "nYhYsW3Xd521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a2a47683cec3941280f0b0aedd74fb24e1f5c25ce80446670feae8c8c30ea59",
+				"DiscoKey":   "discokey:e167dc3d001218cc6d590a0fcdc6579dc83f762a3bc46c18834d410c412ae718",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36559",
+					"10.65.0.27:36559",
+					"172.17.0.1:36559",
+					"172.19.0.1:36559",
+					"172.20.0.1:36559"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:46:07.822437431Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2797993073272656,
+				"StableID":   "nKAGcwXDrN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e94aa159fdc5b80bf5fc43c60251b15fcc63e6082681d86b93933f2c55596621",
+				"DiscoKey":   "discokey:25115f6c6d5fb3b8b127eb923099d324f9da5034d76cfb73f64f034a955e3c32",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:33665",
+					"10.65.0.27:33665",
+					"172.17.0.1:33665",
+					"172.19.0.1:33665",
+					"172.20.0.1:33665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:46:08.359933084Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1398799464861598,
+				"StableID":   "nBqGkD6XvB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:79de947e9512426e55a89c3ebf01d1eceb62c11893cb4a02df249fa37e3c511a",
+				"DiscoKey":   "discokey:5e353d26fa6607e2fada1cdba435131b701c4cc36c4435946d216f2eca38e95a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:45638",
+					"10.65.0.27:45638",
+					"172.17.0.1:45638",
+					"172.19.0.1:45638",
+					"172.20.0.1:45638"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:46:08.891151496Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         105941311146898,
+				"StableID":   "nw7Tt7uyp111CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8513d593a3f964283efef90ae45905b69a65f93a807317d53fc307482ff8a17f",
+				"DiscoKey":   "discokey:3c3a1b50e8b5b22feed5ed5d95be06c62c888fb97cbdee8ddb834afddeebc809",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:35759",
+					"10.65.0.27:35759",
+					"172.17.0.1:35759",
+					"172.19.0.1:35759",
+					"172.20.0.1:35759"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:46:09.425485308Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7270919369602773,
+				"StableID":   "ni7hbui1ny11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f4abd1605f0fbc62b54202fb79620d4737acc87204cefdad5ff1c2a96d2fd05",
+				"DiscoKey":   "discokey:655688f530ddc605c7775585696b3fca088c474f64c038a7d3b082f930c8b477",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42583",
+					"10.65.0.27:42583",
+					"172.17.0.1:42583",
+					"172.19.0.1:42583",
+					"172.20.0.1:42583"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:46:10.503260754Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8345223381328097,
+				"StableID":   "nAMKLJsZA821CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:273ecb45f41ccdc687846f6c7a770f0ef3d0d8aa24f4b301194dd9f5607e6b4f",
+				"DiscoKey":   "discokey:e88b37938e15df303c7ff19d8254c80048e1a91454b96316b0ab2194e3ee2221",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53326",
+					"10.65.0.27:53326",
+					"172.17.0.1:53326",
+					"172.19.0.1:53326",
+					"172.20.0.1:53326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:46:11.051935902Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7284508780357525,
+				"StableID":   "nUYvHDhAty11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:da30a7aae94b1263e03eee65802ffe8c375186cdd7978829361de3dde7dbf93e",
+				"DiscoKey":   "discokey:ca22ee5eaa9e57bfbf0b82af390f06971341c1ed73416e6d62a3624ba5f85728",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51499",
+					"10.65.0.27:51499",
+					"172.17.0.1:51499",
+					"172.19.0.1:51499",
+					"172.20.0.1:51499"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:46:11.602297689Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1261223189933606,
+				"StableID":   "nPBSSHCDrA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b91904d84c622b2921bfd881a0d31bd3049b37db6540e0e12d263b103ce607a",
+				"DiscoKey":   "discokey:5e9f99363f691068b8cfb655a0699220e19c42e2ddede4b98145fb4efd1ba95a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37859",
+					"10.65.0.27:37859",
+					"172.17.0.1:37859",
+					"172.19.0.1:37859",
+					"172.20.0.1:37859"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:46:12.134872231Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6482308076345644,
+				"StableID":   "nydx5zErcs11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ecf416e42d62022dde27440cda6b9c174445a15146ab0eed3a7e152ba829b25f",
+				"DiscoKey":   "discokey:fed880d838edcc6058fa48976077bac75df8f55af98720391ebf8cab88655700",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52260",
+					"10.65.0.27:52260",
+					"172.17.0.1:52260",
+					"172.19.0.1:52260",
+					"172.20.0.1:52260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:46:12.671264204Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1098906057830437,
+				"StableID":   "nJsbJ8Qha911CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0cc657ba2fbbac04b2fcd974cd92a890157d05671fab8dcae71a246dc2b0b975",
+				"KeyExpiry":  "2026-11-08T18:46:13Z",
+				"DiscoKey":   "discokey:df4371c3d9cd2a83c29db892aebb439b9416e8723a7a7f4f8b158c2639159915",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52980",
+					"10.65.0.27:52980",
+					"172.17.0.1:52980",
+					"172.19.0.1:52980",
+					"172.20.0.1:52980"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:46:13.305949474Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4968233269920452,
+				"StableID":   "nKYY9g48of11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:abc5e4b73bf29fed22d0474639d137ced814e561e955a8d558774f874de5be07",
+				"KeyExpiry":  "2026-11-08T18:46:14Z",
+				"DiscoKey":   "discokey:6bcbb471202963071e864f1c65e332a666760a7c3e8231d3a31334a393c0aa2d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:53906",
+					"10.65.0.27:53906",
+					"172.17.0.1:53906",
+					"172.19.0.1:53906",
+					"172.20.0.1:53906"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:46:14.02309296Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5468679017310369,
+				"StableID":   "ntYb9dvmhj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8c8055fa990ce6570156e10bd77bbb0bba5aec9b7cba1f383c6e11c242515f6c",
+				"KeyExpiry":  "2026-11-08T18:46:14Z",
+				"DiscoKey":   "discokey:2756c5b89e015f8cefe16aca3fe758cd67ad023e74b7c23620011b55ddb9bd01",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38166",
+					"10.65.0.27:38166",
+					"172.17.0.1:38166",
+					"172.19.0.1:38166",
+					"172.20.0.1:38166"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:46:14.556615013Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4840358168485763": {
+				"ID":          4840358168485763,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8345223381328097,
+				"StableID":   "nAMKLJsZA821CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       8345223381328097,
+				"Key":        "nodekey:273ecb45f41ccdc687846f6c7a770f0ef3d0d8aa24f4b301194dd9f5607e6b4f",
+				"DiscoKey":   "discokey:e88b37938e15df303c7ff19d8254c80048e1a91454b96316b0ab2194e3ee2221",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53326",
+					"10.65.0.27:53326",
+					"172.17.0.1:53326",
+					"172.19.0.1:53326",
+					"172.20.0.1:53326"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:46:11.051935902Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:273ecb45f41ccdc687846f6c7a770f0ef3d0d8aa24f4b301194dd9f5607e6b4f",
+			"MachineKey": "mkey:1591bb0abd264080a7f3b228e38b386f8cdb3550bb8af68efe3bb2b8ab8d035f",
+			"Peers": [{
+				"ID":         3974016456418527,
+				"StableID":   "nG3gs4gq2Y11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f9e4cdfcdf5fc4a7c24479e89eeffc6824ee5f1b6a86abadf36e22f7a821935c",
+				"DiscoKey":   "discokey:3fb869cd8a12c370713766714747ad199545f68559d9015ead712ee140f5307a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46891",
+					"10.65.0.27:46891",
+					"172.17.0.1:46891",
+					"172.19.0.1:46891",
+					"172.20.0.1:46891"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:46:06.772762065Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5471650396442347,
+				"StableID":   "nACLkhy7jj11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:abee1047f200278c3c687518f328c12b7fb43858f50c5a028dd88baff1cd254b",
+				"DiscoKey":   "discokey:ad7fddcf604beac8e10939e4becc873b91680cd976c22b7ab30cec2937551b1e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37637",
+					"10.65.0.27:37637",
+					"172.17.0.1:37637",
+					"172.19.0.1:37637",
+					"172.20.0.1:37637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:46:07.270210359Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8020542208079339,
+				"StableID":   "nYhYsW3Xd521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a2a47683cec3941280f0b0aedd74fb24e1f5c25ce80446670feae8c8c30ea59",
+				"DiscoKey":   "discokey:e167dc3d001218cc6d590a0fcdc6579dc83f762a3bc46c18834d410c412ae718",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36559",
+					"10.65.0.27:36559",
+					"172.17.0.1:36559",
+					"172.19.0.1:36559",
+					"172.20.0.1:36559"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:46:07.822437431Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2797993073272656,
+				"StableID":   "nKAGcwXDrN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e94aa159fdc5b80bf5fc43c60251b15fcc63e6082681d86b93933f2c55596621",
+				"DiscoKey":   "discokey:25115f6c6d5fb3b8b127eb923099d324f9da5034d76cfb73f64f034a955e3c32",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:33665",
+					"10.65.0.27:33665",
+					"172.17.0.1:33665",
+					"172.19.0.1:33665",
+					"172.20.0.1:33665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:46:08.359933084Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1398799464861598,
+				"StableID":   "nBqGkD6XvB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:79de947e9512426e55a89c3ebf01d1eceb62c11893cb4a02df249fa37e3c511a",
+				"DiscoKey":   "discokey:5e353d26fa6607e2fada1cdba435131b701c4cc36c4435946d216f2eca38e95a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:45638",
+					"10.65.0.27:45638",
+					"172.17.0.1:45638",
+					"172.19.0.1:45638",
+					"172.20.0.1:45638"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:46:08.891151496Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         105941311146898,
+				"StableID":   "nw7Tt7uyp111CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8513d593a3f964283efef90ae45905b69a65f93a807317d53fc307482ff8a17f",
+				"DiscoKey":   "discokey:3c3a1b50e8b5b22feed5ed5d95be06c62c888fb97cbdee8ddb834afddeebc809",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:35759",
+					"10.65.0.27:35759",
+					"172.17.0.1:35759",
+					"172.19.0.1:35759",
+					"172.20.0.1:35759"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:46:09.425485308Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4840358168485763,
+				"StableID":   "n2edK51Doe11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6e5a753838adff515d8a87cf825dcd331cbcd5c93dbd4d3b04b60f5089fe1568",
+				"DiscoKey":   "discokey:3b195d5217e4399cde29a4a50c9f9f8dbfd46f15c890c97381e0448ab970e45c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33045",
+					"10.65.0.27:33045",
+					"172.17.0.1:33045",
+					"172.19.0.1:33045",
+					"172.20.0.1:33045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:46:09.981722404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7270919369602773,
+				"StableID":   "ni7hbui1ny11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f4abd1605f0fbc62b54202fb79620d4737acc87204cefdad5ff1c2a96d2fd05",
+				"DiscoKey":   "discokey:655688f530ddc605c7775585696b3fca088c474f64c038a7d3b082f930c8b477",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42583",
+					"10.65.0.27:42583",
+					"172.17.0.1:42583",
+					"172.19.0.1:42583",
+					"172.20.0.1:42583"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:46:10.503260754Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7284508780357525,
+				"StableID":   "nUYvHDhAty11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:da30a7aae94b1263e03eee65802ffe8c375186cdd7978829361de3dde7dbf93e",
+				"DiscoKey":   "discokey:ca22ee5eaa9e57bfbf0b82af390f06971341c1ed73416e6d62a3624ba5f85728",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51499",
+					"10.65.0.27:51499",
+					"172.17.0.1:51499",
+					"172.19.0.1:51499",
+					"172.20.0.1:51499"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:46:11.602297689Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1261223189933606,
+				"StableID":   "nPBSSHCDrA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b91904d84c622b2921bfd881a0d31bd3049b37db6540e0e12d263b103ce607a",
+				"DiscoKey":   "discokey:5e9f99363f691068b8cfb655a0699220e19c42e2ddede4b98145fb4efd1ba95a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37859",
+					"10.65.0.27:37859",
+					"172.17.0.1:37859",
+					"172.19.0.1:37859",
+					"172.20.0.1:37859"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:46:12.134872231Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6482308076345644,
+				"StableID":   "nydx5zErcs11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ecf416e42d62022dde27440cda6b9c174445a15146ab0eed3a7e152ba829b25f",
+				"DiscoKey":   "discokey:fed880d838edcc6058fa48976077bac75df8f55af98720391ebf8cab88655700",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52260",
+					"10.65.0.27:52260",
+					"172.17.0.1:52260",
+					"172.19.0.1:52260",
+					"172.20.0.1:52260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:46:12.671264204Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1098906057830437,
+				"StableID":   "nJsbJ8Qha911CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0cc657ba2fbbac04b2fcd974cd92a890157d05671fab8dcae71a246dc2b0b975",
+				"KeyExpiry":  "2026-11-08T18:46:13Z",
+				"DiscoKey":   "discokey:df4371c3d9cd2a83c29db892aebb439b9416e8723a7a7f4f8b158c2639159915",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52980",
+					"10.65.0.27:52980",
+					"172.17.0.1:52980",
+					"172.19.0.1:52980",
+					"172.20.0.1:52980"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:46:13.305949474Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4968233269920452,
+				"StableID":   "nKYY9g48of11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:abc5e4b73bf29fed22d0474639d137ced814e561e955a8d558774f874de5be07",
+				"KeyExpiry":  "2026-11-08T18:46:14Z",
+				"DiscoKey":   "discokey:6bcbb471202963071e864f1c65e332a666760a7c3e8231d3a31334a393c0aa2d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:53906",
+					"10.65.0.27:53906",
+					"172.17.0.1:53906",
+					"172.19.0.1:53906",
+					"172.20.0.1:53906"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:46:14.02309296Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5468679017310369,
+				"StableID":   "ntYb9dvmhj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8c8055fa990ce6570156e10bd77bbb0bba5aec9b7cba1f383c6e11c242515f6c",
+				"KeyExpiry":  "2026-11-08T18:46:14Z",
+				"DiscoKey":   "discokey:2756c5b89e015f8cefe16aca3fe758cd67ad023e74b7c23620011b55ddb9bd01",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38166",
+					"10.65.0.27:38166",
+					"172.17.0.1:38166",
+					"172.19.0.1:38166",
+					"172.20.0.1:38166"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:46:14.556615013Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8345223381328097": {
+				"ID":          8345223381328097,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4968233269920452,
+				"StableID":   "nKYY9g48of11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:abc5e4b73bf29fed22d0474639d137ced814e561e955a8d558774f874de5be07",
+				"KeyExpiry":  "2026-11-08T18:46:14Z",
+				"DiscoKey":   "discokey:6bcbb471202963071e864f1c65e332a666760a7c3e8231d3a31334a393c0aa2d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:53906",
+					"10.65.0.27:53906",
+					"172.17.0.1:53906",
+					"172.19.0.1:53906",
+					"172.20.0.1:53906"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:46:14.02309296Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:abc5e4b73bf29fed22d0474639d137ced814e561e955a8d558774f874de5be07",
+			"MachineKey": "mkey:a8483931a2a0300bc1c5eaaec859f655a43bf13cc05a4bb127d7e036dfaac676",
+			"Peers": [{
+				"ID":         3974016456418527,
+				"StableID":   "nG3gs4gq2Y11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f9e4cdfcdf5fc4a7c24479e89eeffc6824ee5f1b6a86abadf36e22f7a821935c",
+				"DiscoKey":   "discokey:3fb869cd8a12c370713766714747ad199545f68559d9015ead712ee140f5307a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46891",
+					"10.65.0.27:46891",
+					"172.17.0.1:46891",
+					"172.19.0.1:46891",
+					"172.20.0.1:46891"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:46:06.772762065Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5471650396442347,
+				"StableID":   "nACLkhy7jj11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:abee1047f200278c3c687518f328c12b7fb43858f50c5a028dd88baff1cd254b",
+				"DiscoKey":   "discokey:ad7fddcf604beac8e10939e4becc873b91680cd976c22b7ab30cec2937551b1e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37637",
+					"10.65.0.27:37637",
+					"172.17.0.1:37637",
+					"172.19.0.1:37637",
+					"172.20.0.1:37637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:46:07.270210359Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8020542208079339,
+				"StableID":   "nYhYsW3Xd521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a2a47683cec3941280f0b0aedd74fb24e1f5c25ce80446670feae8c8c30ea59",
+				"DiscoKey":   "discokey:e167dc3d001218cc6d590a0fcdc6579dc83f762a3bc46c18834d410c412ae718",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36559",
+					"10.65.0.27:36559",
+					"172.17.0.1:36559",
+					"172.19.0.1:36559",
+					"172.20.0.1:36559"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:46:07.822437431Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2797993073272656,
+				"StableID":   "nKAGcwXDrN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e94aa159fdc5b80bf5fc43c60251b15fcc63e6082681d86b93933f2c55596621",
+				"DiscoKey":   "discokey:25115f6c6d5fb3b8b127eb923099d324f9da5034d76cfb73f64f034a955e3c32",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:33665",
+					"10.65.0.27:33665",
+					"172.17.0.1:33665",
+					"172.19.0.1:33665",
+					"172.20.0.1:33665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:46:08.359933084Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1398799464861598,
+				"StableID":   "nBqGkD6XvB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:79de947e9512426e55a89c3ebf01d1eceb62c11893cb4a02df249fa37e3c511a",
+				"DiscoKey":   "discokey:5e353d26fa6607e2fada1cdba435131b701c4cc36c4435946d216f2eca38e95a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:45638",
+					"10.65.0.27:45638",
+					"172.17.0.1:45638",
+					"172.19.0.1:45638",
+					"172.20.0.1:45638"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:46:08.891151496Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         105941311146898,
+				"StableID":   "nw7Tt7uyp111CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8513d593a3f964283efef90ae45905b69a65f93a807317d53fc307482ff8a17f",
+				"DiscoKey":   "discokey:3c3a1b50e8b5b22feed5ed5d95be06c62c888fb97cbdee8ddb834afddeebc809",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:35759",
+					"10.65.0.27:35759",
+					"172.17.0.1:35759",
+					"172.19.0.1:35759",
+					"172.20.0.1:35759"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:46:09.425485308Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4840358168485763,
+				"StableID":   "n2edK51Doe11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6e5a753838adff515d8a87cf825dcd331cbcd5c93dbd4d3b04b60f5089fe1568",
+				"DiscoKey":   "discokey:3b195d5217e4399cde29a4a50c9f9f8dbfd46f15c890c97381e0448ab970e45c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33045",
+					"10.65.0.27:33045",
+					"172.17.0.1:33045",
+					"172.19.0.1:33045",
+					"172.20.0.1:33045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:46:09.981722404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7270919369602773,
+				"StableID":   "ni7hbui1ny11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f4abd1605f0fbc62b54202fb79620d4737acc87204cefdad5ff1c2a96d2fd05",
+				"DiscoKey":   "discokey:655688f530ddc605c7775585696b3fca088c474f64c038a7d3b082f930c8b477",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42583",
+					"10.65.0.27:42583",
+					"172.17.0.1:42583",
+					"172.19.0.1:42583",
+					"172.20.0.1:42583"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:46:10.503260754Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8345223381328097,
+				"StableID":   "nAMKLJsZA821CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:273ecb45f41ccdc687846f6c7a770f0ef3d0d8aa24f4b301194dd9f5607e6b4f",
+				"DiscoKey":   "discokey:e88b37938e15df303c7ff19d8254c80048e1a91454b96316b0ab2194e3ee2221",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53326",
+					"10.65.0.27:53326",
+					"172.17.0.1:53326",
+					"172.19.0.1:53326",
+					"172.20.0.1:53326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:46:11.051935902Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7284508780357525,
+				"StableID":   "nUYvHDhAty11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:da30a7aae94b1263e03eee65802ffe8c375186cdd7978829361de3dde7dbf93e",
+				"DiscoKey":   "discokey:ca22ee5eaa9e57bfbf0b82af390f06971341c1ed73416e6d62a3624ba5f85728",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51499",
+					"10.65.0.27:51499",
+					"172.17.0.1:51499",
+					"172.19.0.1:51499",
+					"172.20.0.1:51499"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:46:11.602297689Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1261223189933606,
+				"StableID":   "nPBSSHCDrA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b91904d84c622b2921bfd881a0d31bd3049b37db6540e0e12d263b103ce607a",
+				"DiscoKey":   "discokey:5e9f99363f691068b8cfb655a0699220e19c42e2ddede4b98145fb4efd1ba95a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37859",
+					"10.65.0.27:37859",
+					"172.17.0.1:37859",
+					"172.19.0.1:37859",
+					"172.20.0.1:37859"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:46:12.134872231Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6482308076345644,
+				"StableID":   "nydx5zErcs11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ecf416e42d62022dde27440cda6b9c174445a15146ab0eed3a7e152ba829b25f",
+				"DiscoKey":   "discokey:fed880d838edcc6058fa48976077bac75df8f55af98720391ebf8cab88655700",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52260",
+					"10.65.0.27:52260",
+					"172.17.0.1:52260",
+					"172.19.0.1:52260",
+					"172.20.0.1:52260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:46:12.671264204Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1098906057830437,
+				"StableID":   "nJsbJ8Qha911CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0cc657ba2fbbac04b2fcd974cd92a890157d05671fab8dcae71a246dc2b0b975",
+				"KeyExpiry":  "2026-11-08T18:46:13Z",
+				"DiscoKey":   "discokey:df4371c3d9cd2a83c29db892aebb439b9416e8723a7a7f4f8b158c2639159915",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52980",
+					"10.65.0.27:52980",
+					"172.17.0.1:52980",
+					"172.19.0.1:52980",
+					"172.20.0.1:52980"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:46:13.305949474Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5468679017310369,
+				"StableID":   "ntYb9dvmhj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8c8055fa990ce6570156e10bd77bbb0bba5aec9b7cba1f383c6e11c242515f6c",
+				"KeyExpiry":  "2026-11-08T18:46:14Z",
+				"DiscoKey":   "discokey:2756c5b89e015f8cefe16aca3fe758cd67ad023e74b7c23620011b55ddb9bd01",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38166",
+					"10.65.0.27:38166",
+					"172.17.0.1:38166",
+					"172.19.0.1:38166",
+					"172.20.0.1:38166"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:46:14.556615013Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7284508780357525,
+				"StableID":   "nUYvHDhAty11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       7284508780357525,
+				"Key":        "nodekey:da30a7aae94b1263e03eee65802ffe8c375186cdd7978829361de3dde7dbf93e",
+				"DiscoKey":   "discokey:ca22ee5eaa9e57bfbf0b82af390f06971341c1ed73416e6d62a3624ba5f85728",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:51499",
+					"10.65.0.27:51499",
+					"172.17.0.1:51499",
+					"172.19.0.1:51499",
+					"172.20.0.1:51499"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:46:11.602297689Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:da30a7aae94b1263e03eee65802ffe8c375186cdd7978829361de3dde7dbf93e",
+			"MachineKey": "mkey:c336c8da3579913d6caf02f3f2a51b786e798a86939993895c7f53a333ae695c",
+			"Peers": [{
+				"ID":         3974016456418527,
+				"StableID":   "nG3gs4gq2Y11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f9e4cdfcdf5fc4a7c24479e89eeffc6824ee5f1b6a86abadf36e22f7a821935c",
+				"DiscoKey":   "discokey:3fb869cd8a12c370713766714747ad199545f68559d9015ead712ee140f5307a",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:46891",
+					"10.65.0.27:46891",
+					"172.17.0.1:46891",
+					"172.19.0.1:46891",
+					"172.20.0.1:46891"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:46:06.772762065Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5471650396442347,
+				"StableID":   "nACLkhy7jj11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:abee1047f200278c3c687518f328c12b7fb43858f50c5a028dd88baff1cd254b",
+				"DiscoKey":   "discokey:ad7fddcf604beac8e10939e4becc873b91680cd976c22b7ab30cec2937551b1e",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:37637",
+					"10.65.0.27:37637",
+					"172.17.0.1:37637",
+					"172.19.0.1:37637",
+					"172.20.0.1:37637"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:46:07.270210359Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8020542208079339,
+				"StableID":   "nYhYsW3Xd521CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1a2a47683cec3941280f0b0aedd74fb24e1f5c25ce80446670feae8c8c30ea59",
+				"DiscoKey":   "discokey:e167dc3d001218cc6d590a0fcdc6579dc83f762a3bc46c18834d410c412ae718",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:36559",
+					"10.65.0.27:36559",
+					"172.17.0.1:36559",
+					"172.19.0.1:36559",
+					"172.20.0.1:36559"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:46:07.822437431Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2797993073272656,
+				"StableID":   "nKAGcwXDrN11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e94aa159fdc5b80bf5fc43c60251b15fcc63e6082681d86b93933f2c55596621",
+				"DiscoKey":   "discokey:25115f6c6d5fb3b8b127eb923099d324f9da5034d76cfb73f64f034a955e3c32",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:33665",
+					"10.65.0.27:33665",
+					"172.17.0.1:33665",
+					"172.19.0.1:33665",
+					"172.20.0.1:33665"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:46:08.359933084Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1398799464861598,
+				"StableID":   "nBqGkD6XvB11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:79de947e9512426e55a89c3ebf01d1eceb62c11893cb4a02df249fa37e3c511a",
+				"DiscoKey":   "discokey:5e353d26fa6607e2fada1cdba435131b701c4cc36c4435946d216f2eca38e95a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:45638",
+					"10.65.0.27:45638",
+					"172.17.0.1:45638",
+					"172.19.0.1:45638",
+					"172.20.0.1:45638"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:46:08.891151496Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         105941311146898,
+				"StableID":   "nw7Tt7uyp111CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8513d593a3f964283efef90ae45905b69a65f93a807317d53fc307482ff8a17f",
+				"DiscoKey":   "discokey:3c3a1b50e8b5b22feed5ed5d95be06c62c888fb97cbdee8ddb834afddeebc809",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:35759",
+					"10.65.0.27:35759",
+					"172.17.0.1:35759",
+					"172.19.0.1:35759",
+					"172.20.0.1:35759"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:46:09.425485308Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4840358168485763,
+				"StableID":   "n2edK51Doe11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6e5a753838adff515d8a87cf825dcd331cbcd5c93dbd4d3b04b60f5089fe1568",
+				"DiscoKey":   "discokey:3b195d5217e4399cde29a4a50c9f9f8dbfd46f15c890c97381e0448ab970e45c",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:33045",
+					"10.65.0.27:33045",
+					"172.17.0.1:33045",
+					"172.19.0.1:33045",
+					"172.20.0.1:33045"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:46:09.981722404Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         7270919369602773,
+				"StableID":   "ni7hbui1ny11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f4abd1605f0fbc62b54202fb79620d4737acc87204cefdad5ff1c2a96d2fd05",
+				"DiscoKey":   "discokey:655688f530ddc605c7775585696b3fca088c474f64c038a7d3b082f930c8b477",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:42583",
+					"10.65.0.27:42583",
+					"172.17.0.1:42583",
+					"172.19.0.1:42583",
+					"172.20.0.1:42583"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:46:10.503260754Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8345223381328097,
+				"StableID":   "nAMKLJsZA821CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:273ecb45f41ccdc687846f6c7a770f0ef3d0d8aa24f4b301194dd9f5607e6b4f",
+				"DiscoKey":   "discokey:e88b37938e15df303c7ff19d8254c80048e1a91454b96316b0ab2194e3ee2221",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:53326",
+					"10.65.0.27:53326",
+					"172.17.0.1:53326",
+					"172.19.0.1:53326",
+					"172.20.0.1:53326"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:46:11.051935902Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1261223189933606,
+				"StableID":   "nPBSSHCDrA11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4b91904d84c622b2921bfd881a0d31bd3049b37db6540e0e12d263b103ce607a",
+				"DiscoKey":   "discokey:5e9f99363f691068b8cfb655a0699220e19c42e2ddede4b98145fb4efd1ba95a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:37859",
+					"10.65.0.27:37859",
+					"172.17.0.1:37859",
+					"172.19.0.1:37859",
+					"172.20.0.1:37859"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:46:12.134872231Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6482308076345644,
+				"StableID":   "nydx5zErcs11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ecf416e42d62022dde27440cda6b9c174445a15146ab0eed3a7e152ba829b25f",
+				"DiscoKey":   "discokey:fed880d838edcc6058fa48976077bac75df8f55af98720391ebf8cab88655700",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:52260",
+					"10.65.0.27:52260",
+					"172.17.0.1:52260",
+					"172.19.0.1:52260",
+					"172.20.0.1:52260"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:46:12.671264204Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1098906057830437,
+				"StableID":   "nJsbJ8Qha911CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:0cc657ba2fbbac04b2fcd974cd92a890157d05671fab8dcae71a246dc2b0b975",
+				"KeyExpiry":  "2026-11-08T18:46:13Z",
+				"DiscoKey":   "discokey:df4371c3d9cd2a83c29db892aebb439b9416e8723a7a7f4f8b158c2639159915",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:52980",
+					"10.65.0.27:52980",
+					"172.17.0.1:52980",
+					"172.19.0.1:52980",
+					"172.20.0.1:52980"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:46:13.305949474Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4968233269920452,
+				"StableID":   "nKYY9g48of11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:abc5e4b73bf29fed22d0474639d137ced814e561e955a8d558774f874de5be07",
+				"KeyExpiry":  "2026-11-08T18:46:14Z",
+				"DiscoKey":   "discokey:6bcbb471202963071e864f1c65e332a666760a7c3e8231d3a31334a393c0aa2d",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:53906",
+					"10.65.0.27:53906",
+					"172.17.0.1:53906",
+					"172.19.0.1:53906",
+					"172.20.0.1:53906"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:46:14.02309296Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5468679017310369,
+				"StableID":   "ntYb9dvmhj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8c8055fa990ce6570156e10bd77bbb0bba5aec9b7cba1f383c6e11c242515f6c",
+				"KeyExpiry":  "2026-11-08T18:46:14Z",
+				"DiscoKey":   "discokey:2756c5b89e015f8cefe16aca3fe758cd67ad023e74b7c23620011b55ddb9bd01",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:38166",
+					"10.65.0.27:38166",
+					"172.17.0.1:38166",
+					"172.19.0.1:38166",
+					"172.20.0.1:38166"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:46:14.556615013Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7284508780357525": {
+				"ID":          7284508780357525,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/sshtest_results/sshtest-mixed-acls-tcp22-allow-no-ssh-rule.hujson
+++ b/hscontrol/policy/v2/testdata/sshtest_results/sshtest-mixed-acls-tcp22-allow-no-ssh-rule.hujson
@@ -1,0 +1,20082 @@
+// sshtest-mixed-acls-tcp22-allow-no-ssh-rule
+//
+// acls allow tcp:22 but no ssh rule, sshTests accept must fail
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T18:46:50Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "sshtest-mixed-acls-tcp22-allow-no-ssh-rule",
+	"description":    "acls allow tcp:22 but no ssh rule, sshTests accept must fail",
+	"category":       "sshtest",
+	"captured_at":    "2026-05-12T18:46:50.585100921Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                             \n  \n                                                                     \n                                                                         \n{\n\t\"category\":    \"sshtest\",\n\t\"description\": \"acls allow tcp:22 but no ssh rule, sshTests accept must fail\",\n\t\"id\":          \"sshtest-mixed-acls-tcp22-allow-no-ssh-rule\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"acls\": [\n\t\t{\"action\": \"accept\", \"dst\": [\"tag:server:22\"], \"src\": [\"thor@example.org\"]}\n\t], \"ssh\": [], \"sshTests\": [{\n\t\t\"accept\": [\"root\"],\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    \"thor@example.org\"\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/sshtest/sshtest-mixed-acls-tcp22-allow-no-ssh-rule.hujson",
+		"full_policy": {
+			"acls": [{
+				"action": "accept",
+				"dst":    ["tag:server:22"],
+				"src":    ["thor@example.org"]
+			}],
+			"ssh":       [],
+			"sshTests":  [{"accept": ["root"], "dst": ["tag:server"], "src": "thor@example.org"}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3148442288767369,
+				"StableID":   "nSR1jvEwaR11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       3148442288767369,
+				"Key":        "nodekey:f46b838a780d827b180d02d652f9e6f0e9ca828ad45d79cef3145fff06ad6306",
+				"DiscoKey":   "discokey:91777640d9c225e1651413963ff18bca51640d503d5c90fddfd95e1a6dc55d2d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47415",
+					"10.65.0.27:47415",
+					"172.17.0.1:47415",
+					"172.19.0.1:47415",
+					"172.20.0.1:47415"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:47:02.790158711Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f46b838a780d827b180d02d652f9e6f0e9ca828ad45d79cef3145fff06ad6306",
+			"MachineKey": "mkey:5ed5f859a2beca0b085c9b63d52c8c32c342b9571c2a1f20db56b77fe219b37b",
+			"Peers": [{
+				"ID":         3348008648796742,
+				"StableID":   "nhaUaaWK9T11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9ce76fb98a22982637f757b24fc9c2d81c97af4740221c838855d142831fe314",
+				"DiscoKey":   "discokey:a083c54b20dfa85d0422733253739ec17ebaa2dc3208357d4055bf70db465c7b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:39638",
+					"10.65.0.27:39638",
+					"172.17.0.1:39638",
+					"172.19.0.1:39638",
+					"172.20.0.1:39638"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:46:56.697652601Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7277465688330465,
+				"StableID":   "nGYJNdgypy11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:466556dd8919f60b82af055aa64d2bee39ebc43f63610450e45647ef54b4a623",
+				"DiscoKey":   "discokey:be1954a328b007c85d14895411305216b30e8b13206bca2991da58def584c86d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:41114",
+					"10.65.0.27:41114",
+					"172.17.0.1:41114",
+					"172.19.0.1:41114",
+					"172.20.0.1:41114"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:46:57.163827119Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7926432109370923,
+				"StableID":   "nkHPiyvtt421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb80b25b53d7846a3f55bfae2fc4af127e77667327c40440164c255a79781658",
+				"DiscoKey":   "discokey:70d3e62748f64e665af774d4db46d20783c347e9135570bbc5abdd66a971f410",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:50483",
+					"10.65.0.27:50483",
+					"172.17.0.1:50483",
+					"172.19.0.1:50483",
+					"172.20.0.1:50483"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:46:57.694750834Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6897754256649264,
+				"StableID":   "nbLoQrJ1sv11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51a6de329a6892b1f17379ad39a19bb0b91d455061f3f8708b1af69d85a0733c",
+				"DiscoKey":   "discokey:062c98854b4998886382a1cf2cc2505acee50a1fa997ae2104aba52cb3c21e5d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:32981",
+					"10.65.0.27:32981",
+					"172.17.0.1:32981",
+					"172.19.0.1:32981",
+					"172.20.0.1:32981"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:46:58.236702505Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7832544745057696,
+				"StableID":   "nscDqnfNA421CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:737ef157cd230d1806f33953b3843f8b7715755c6bfa83c275816164b8a25834",
+				"DiscoKey":   "discokey:3551f1d7230efc5ecd963a911988a230162630c2bfe46c9dfe48c22fdeb3ee58",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53908",
+					"10.65.0.27:53908",
+					"172.17.0.1:53908",
+					"172.19.0.1:53908",
+					"172.20.0.1:53908"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:46:58.777040016Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         883772907534194,
+				"StableID":   "nMC3WWDGu711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:be7f53c951510fddf7ae55a32c1a7324d2d9e381c49c9ab5d585f1c0b3cedd3c",
+				"DiscoKey":   "discokey:97c40c9cc30190cbbb4f08b3a41c50138a946493164b7a0a1a5651a1b717554a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50488",
+					"10.65.0.27:50488",
+					"172.17.0.1:50488",
+					"172.19.0.1:50488",
+					"172.20.0.1:50488"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:46:59.311511755Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3533628427968141,
+				"StableID":   "nEFaqkRPbU11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4b4a7d05171111bf5fdb459aed82f78dcd9dfa8e834b4d3bd74dbf6b73dd833",
+				"DiscoKey":   "discokey:6db58249552caf4bfd881dc58405ddba40a60514dfb4a40e8cca49b92e528944",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52043",
+					"10.65.0.27:52043",
+					"172.17.0.1:52043",
+					"172.19.0.1:52043",
+					"172.20.0.1:52043"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:46:59.878449221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1899378406578201,
+				"StableID":   "n8k4g6TEqF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a2eff8e0bc4e94c33b13d949551b049359b84dc23fe47bd2e5d711fcf6e4e5f",
+				"DiscoKey":   "discokey:f72a2d1f05fb773f5f1841c5369ce19de6787ba216d6b1b812b7fde5e9bf7331",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:56545",
+					"10.65.0.27:56545",
+					"172.17.0.1:56545",
+					"172.19.0.1:56545",
+					"172.20.0.1:56545"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:47:00.414940937Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5783245827808651,
+				"StableID":   "n8bV1Z4FAn11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3cf0e0a8776f33dac88f65d95b89bb01fabd12fe85b9cff5cdc4e9c25648367e",
+				"DiscoKey":   "discokey:53d9458da519ea025e40e85fe1c9ec7e2fcb3c671bde7c6411b90452d163ba36",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42005",
+					"10.65.0.27:42005",
+					"172.17.0.1:42005",
+					"172.19.0.1:42005",
+					"172.20.0.1:42005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:47:00.928314278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         638830889127582,
+				"StableID":   "nVgi6F1Lz511CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f4c604bdb2bd0483229318ba9623e9914d77d340ce0d8fb53d35da2222f4b40b",
+				"DiscoKey":   "discokey:ad54059bbd58c2f5c3d87ebbd86cdf210f2784eaf80d3d64289ef134c2ae2e68",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33413",
+					"10.65.0.27:33413",
+					"172.17.0.1:33413",
+					"172.19.0.1:33413",
+					"172.20.0.1:33413"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:47:01.710836573Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8951108461894055,
+				"StableID":   "ngPW9aSytC21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d3ab64981f38116c09ebdbb3ed1fa5b8a21ba980e8aeba908a0d6fcff31b722b",
+				"DiscoKey":   "discokey:da6b63ed1872d5d7bd7d35c88cedd8367753a0e23412e3e16af506a7ae56785f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53724",
+					"10.65.0.27:53724",
+					"172.17.0.1:53724",
+					"172.19.0.1:53724",
+					"172.20.0.1:53724"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:47:02.247950824Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2595963247498152,
+				"StableID":   "nDqvi3ZiGM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04d6bf29076c5b8c5c9bc3cab2cd03422984785540461d2089a1f8a1919bcc47",
+				"KeyExpiry":  "2026-11-08T18:47:03Z",
+				"DiscoKey":   "discokey:6f1b01e3c0e9f076f0c7e8af8424f4288284111b7a310ce6afc653f557e16407",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50469",
+					"10.65.0.27:50469",
+					"172.17.0.1:50469",
+					"172.19.0.1:50469",
+					"172.20.0.1:50469"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:47:03.341917671Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1778974702635585,
+				"StableID":   "n2fEfdehtE11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ce71f07116a10272bfafa69288c7bf13bd492b9f27dbbe049e98334a0d14f752",
+				"KeyExpiry":  "2026-11-08T18:47:03Z",
+				"DiscoKey":   "discokey:8a5ded2903d801f7d9f24b3f45d56ace02032b303f2a21160d48cca0709fee48",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57329",
+					"10.65.0.27:57329",
+					"172.17.0.1:57329",
+					"172.19.0.1:57329",
+					"172.20.0.1:57329"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:47:03.889124394Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         218017761311581,
+				"StableID":   "nCC21Wxjh211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f0e33f737aa39d978567b2ab54d02dc0910b58d411495da32ebd6973d68e863d",
+				"KeyExpiry":  "2026-11-08T18:47:04Z",
+				"DiscoKey":   "discokey:3e5631f7d39b6c03347fddc860af14295d4a6acf315f35446573f2a01fc03b62",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56846",
+					"10.65.0.27:56846",
+					"172.17.0.1:56846",
+					"172.19.0.1:56846",
+					"172.20.0.1:56846"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:47:04.426626581Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3148442288767369": {
+				"ID":          3148442288767369,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         883772907534194,
+				"StableID":   "nMC3WWDGu711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       883772907534194,
+				"Key":        "nodekey:be7f53c951510fddf7ae55a32c1a7324d2d9e381c49c9ab5d585f1c0b3cedd3c",
+				"DiscoKey":   "discokey:97c40c9cc30190cbbb4f08b3a41c50138a946493164b7a0a1a5651a1b717554a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50488",
+					"10.65.0.27:50488",
+					"172.17.0.1:50488",
+					"172.19.0.1:50488",
+					"172.20.0.1:50488"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:46:59.311511755Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:be7f53c951510fddf7ae55a32c1a7324d2d9e381c49c9ab5d585f1c0b3cedd3c",
+			"MachineKey": "mkey:7c9c316d7d09e14aae69591b6454df82f36dcdcb1861b6ca1212c96eff25d962",
+			"Peers": [{
+				"ID":         3348008648796742,
+				"StableID":   "nhaUaaWK9T11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9ce76fb98a22982637f757b24fc9c2d81c97af4740221c838855d142831fe314",
+				"DiscoKey":   "discokey:a083c54b20dfa85d0422733253739ec17ebaa2dc3208357d4055bf70db465c7b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:39638",
+					"10.65.0.27:39638",
+					"172.17.0.1:39638",
+					"172.19.0.1:39638",
+					"172.20.0.1:39638"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:46:56.697652601Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7277465688330465,
+				"StableID":   "nGYJNdgypy11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:466556dd8919f60b82af055aa64d2bee39ebc43f63610450e45647ef54b4a623",
+				"DiscoKey":   "discokey:be1954a328b007c85d14895411305216b30e8b13206bca2991da58def584c86d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:41114",
+					"10.65.0.27:41114",
+					"172.17.0.1:41114",
+					"172.19.0.1:41114",
+					"172.20.0.1:41114"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:46:57.163827119Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7926432109370923,
+				"StableID":   "nkHPiyvtt421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb80b25b53d7846a3f55bfae2fc4af127e77667327c40440164c255a79781658",
+				"DiscoKey":   "discokey:70d3e62748f64e665af774d4db46d20783c347e9135570bbc5abdd66a971f410",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:50483",
+					"10.65.0.27:50483",
+					"172.17.0.1:50483",
+					"172.19.0.1:50483",
+					"172.20.0.1:50483"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:46:57.694750834Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6897754256649264,
+				"StableID":   "nbLoQrJ1sv11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51a6de329a6892b1f17379ad39a19bb0b91d455061f3f8708b1af69d85a0733c",
+				"DiscoKey":   "discokey:062c98854b4998886382a1cf2cc2505acee50a1fa997ae2104aba52cb3c21e5d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:32981",
+					"10.65.0.27:32981",
+					"172.17.0.1:32981",
+					"172.19.0.1:32981",
+					"172.20.0.1:32981"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:46:58.236702505Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7832544745057696,
+				"StableID":   "nscDqnfNA421CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:737ef157cd230d1806f33953b3843f8b7715755c6bfa83c275816164b8a25834",
+				"DiscoKey":   "discokey:3551f1d7230efc5ecd963a911988a230162630c2bfe46c9dfe48c22fdeb3ee58",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53908",
+					"10.65.0.27:53908",
+					"172.17.0.1:53908",
+					"172.19.0.1:53908",
+					"172.20.0.1:53908"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:46:58.777040016Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3533628427968141,
+				"StableID":   "nEFaqkRPbU11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4b4a7d05171111bf5fdb459aed82f78dcd9dfa8e834b4d3bd74dbf6b73dd833",
+				"DiscoKey":   "discokey:6db58249552caf4bfd881dc58405ddba40a60514dfb4a40e8cca49b92e528944",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52043",
+					"10.65.0.27:52043",
+					"172.17.0.1:52043",
+					"172.19.0.1:52043",
+					"172.20.0.1:52043"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:46:59.878449221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1899378406578201,
+				"StableID":   "n8k4g6TEqF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a2eff8e0bc4e94c33b13d949551b049359b84dc23fe47bd2e5d711fcf6e4e5f",
+				"DiscoKey":   "discokey:f72a2d1f05fb773f5f1841c5369ce19de6787ba216d6b1b812b7fde5e9bf7331",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:56545",
+					"10.65.0.27:56545",
+					"172.17.0.1:56545",
+					"172.19.0.1:56545",
+					"172.20.0.1:56545"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:47:00.414940937Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5783245827808651,
+				"StableID":   "n8bV1Z4FAn11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3cf0e0a8776f33dac88f65d95b89bb01fabd12fe85b9cff5cdc4e9c25648367e",
+				"DiscoKey":   "discokey:53d9458da519ea025e40e85fe1c9ec7e2fcb3c671bde7c6411b90452d163ba36",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42005",
+					"10.65.0.27:42005",
+					"172.17.0.1:42005",
+					"172.19.0.1:42005",
+					"172.20.0.1:42005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:47:00.928314278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         638830889127582,
+				"StableID":   "nVgi6F1Lz511CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f4c604bdb2bd0483229318ba9623e9914d77d340ce0d8fb53d35da2222f4b40b",
+				"DiscoKey":   "discokey:ad54059bbd58c2f5c3d87ebbd86cdf210f2784eaf80d3d64289ef134c2ae2e68",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33413",
+					"10.65.0.27:33413",
+					"172.17.0.1:33413",
+					"172.19.0.1:33413",
+					"172.20.0.1:33413"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:47:01.710836573Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8951108461894055,
+				"StableID":   "ngPW9aSytC21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d3ab64981f38116c09ebdbb3ed1fa5b8a21ba980e8aeba908a0d6fcff31b722b",
+				"DiscoKey":   "discokey:da6b63ed1872d5d7bd7d35c88cedd8367753a0e23412e3e16af506a7ae56785f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53724",
+					"10.65.0.27:53724",
+					"172.17.0.1:53724",
+					"172.19.0.1:53724",
+					"172.20.0.1:53724"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:47:02.247950824Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3148442288767369,
+				"StableID":   "nSR1jvEwaR11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f46b838a780d827b180d02d652f9e6f0e9ca828ad45d79cef3145fff06ad6306",
+				"DiscoKey":   "discokey:91777640d9c225e1651413963ff18bca51640d503d5c90fddfd95e1a6dc55d2d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47415",
+					"10.65.0.27:47415",
+					"172.17.0.1:47415",
+					"172.19.0.1:47415",
+					"172.20.0.1:47415"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:47:02.790158711Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2595963247498152,
+				"StableID":   "nDqvi3ZiGM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04d6bf29076c5b8c5c9bc3cab2cd03422984785540461d2089a1f8a1919bcc47",
+				"KeyExpiry":  "2026-11-08T18:47:03Z",
+				"DiscoKey":   "discokey:6f1b01e3c0e9f076f0c7e8af8424f4288284111b7a310ce6afc653f557e16407",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50469",
+					"10.65.0.27:50469",
+					"172.17.0.1:50469",
+					"172.19.0.1:50469",
+					"172.20.0.1:50469"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:47:03.341917671Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1778974702635585,
+				"StableID":   "n2fEfdehtE11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ce71f07116a10272bfafa69288c7bf13bd492b9f27dbbe049e98334a0d14f752",
+				"KeyExpiry":  "2026-11-08T18:47:03Z",
+				"DiscoKey":   "discokey:8a5ded2903d801f7d9f24b3f45d56ace02032b303f2a21160d48cca0709fee48",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57329",
+					"10.65.0.27:57329",
+					"172.17.0.1:57329",
+					"172.19.0.1:57329",
+					"172.20.0.1:57329"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:47:03.889124394Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         218017761311581,
+				"StableID":   "nCC21Wxjh211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f0e33f737aa39d978567b2ab54d02dc0910b58d411495da32ebd6973d68e863d",
+				"KeyExpiry":  "2026-11-08T18:47:04Z",
+				"DiscoKey":   "discokey:3e5631f7d39b6c03347fddc860af14295d4a6acf315f35446573f2a01fc03b62",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56846",
+					"10.65.0.27:56846",
+					"172.17.0.1:56846",
+					"172.19.0.1:56846",
+					"172.20.0.1:56846"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:47:04.426626581Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "883772907534194": {
+				"ID":          883772907534194,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         218017761311581,
+				"StableID":   "nCC21Wxjh211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f0e33f737aa39d978567b2ab54d02dc0910b58d411495da32ebd6973d68e863d",
+				"KeyExpiry":  "2026-11-08T18:47:04Z",
+				"DiscoKey":   "discokey:3e5631f7d39b6c03347fddc860af14295d4a6acf315f35446573f2a01fc03b62",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56846",
+					"10.65.0.27:56846",
+					"172.17.0.1:56846",
+					"172.19.0.1:56846",
+					"172.20.0.1:56846"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:47:04.426626581Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f0e33f737aa39d978567b2ab54d02dc0910b58d411495da32ebd6973d68e863d",
+			"MachineKey": "mkey:f2c7591428b1d200c0ba1f0dc831be5d04d8c83315d066c8f9fa353a6c590977",
+			"Peers": [{
+				"ID":         3348008648796742,
+				"StableID":   "nhaUaaWK9T11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9ce76fb98a22982637f757b24fc9c2d81c97af4740221c838855d142831fe314",
+				"DiscoKey":   "discokey:a083c54b20dfa85d0422733253739ec17ebaa2dc3208357d4055bf70db465c7b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:39638",
+					"10.65.0.27:39638",
+					"172.17.0.1:39638",
+					"172.19.0.1:39638",
+					"172.20.0.1:39638"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:46:56.697652601Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7277465688330465,
+				"StableID":   "nGYJNdgypy11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:466556dd8919f60b82af055aa64d2bee39ebc43f63610450e45647ef54b4a623",
+				"DiscoKey":   "discokey:be1954a328b007c85d14895411305216b30e8b13206bca2991da58def584c86d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:41114",
+					"10.65.0.27:41114",
+					"172.17.0.1:41114",
+					"172.19.0.1:41114",
+					"172.20.0.1:41114"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:46:57.163827119Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7926432109370923,
+				"StableID":   "nkHPiyvtt421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb80b25b53d7846a3f55bfae2fc4af127e77667327c40440164c255a79781658",
+				"DiscoKey":   "discokey:70d3e62748f64e665af774d4db46d20783c347e9135570bbc5abdd66a971f410",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:50483",
+					"10.65.0.27:50483",
+					"172.17.0.1:50483",
+					"172.19.0.1:50483",
+					"172.20.0.1:50483"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:46:57.694750834Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6897754256649264,
+				"StableID":   "nbLoQrJ1sv11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51a6de329a6892b1f17379ad39a19bb0b91d455061f3f8708b1af69d85a0733c",
+				"DiscoKey":   "discokey:062c98854b4998886382a1cf2cc2505acee50a1fa997ae2104aba52cb3c21e5d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:32981",
+					"10.65.0.27:32981",
+					"172.17.0.1:32981",
+					"172.19.0.1:32981",
+					"172.20.0.1:32981"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:46:58.236702505Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7832544745057696,
+				"StableID":   "nscDqnfNA421CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:737ef157cd230d1806f33953b3843f8b7715755c6bfa83c275816164b8a25834",
+				"DiscoKey":   "discokey:3551f1d7230efc5ecd963a911988a230162630c2bfe46c9dfe48c22fdeb3ee58",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53908",
+					"10.65.0.27:53908",
+					"172.17.0.1:53908",
+					"172.19.0.1:53908",
+					"172.20.0.1:53908"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:46:58.777040016Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         883772907534194,
+				"StableID":   "nMC3WWDGu711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:be7f53c951510fddf7ae55a32c1a7324d2d9e381c49c9ab5d585f1c0b3cedd3c",
+				"DiscoKey":   "discokey:97c40c9cc30190cbbb4f08b3a41c50138a946493164b7a0a1a5651a1b717554a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50488",
+					"10.65.0.27:50488",
+					"172.17.0.1:50488",
+					"172.19.0.1:50488",
+					"172.20.0.1:50488"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:46:59.311511755Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3533628427968141,
+				"StableID":   "nEFaqkRPbU11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4b4a7d05171111bf5fdb459aed82f78dcd9dfa8e834b4d3bd74dbf6b73dd833",
+				"DiscoKey":   "discokey:6db58249552caf4bfd881dc58405ddba40a60514dfb4a40e8cca49b92e528944",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52043",
+					"10.65.0.27:52043",
+					"172.17.0.1:52043",
+					"172.19.0.1:52043",
+					"172.20.0.1:52043"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:46:59.878449221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1899378406578201,
+				"StableID":   "n8k4g6TEqF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a2eff8e0bc4e94c33b13d949551b049359b84dc23fe47bd2e5d711fcf6e4e5f",
+				"DiscoKey":   "discokey:f72a2d1f05fb773f5f1841c5369ce19de6787ba216d6b1b812b7fde5e9bf7331",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:56545",
+					"10.65.0.27:56545",
+					"172.17.0.1:56545",
+					"172.19.0.1:56545",
+					"172.20.0.1:56545"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:47:00.414940937Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5783245827808651,
+				"StableID":   "n8bV1Z4FAn11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3cf0e0a8776f33dac88f65d95b89bb01fabd12fe85b9cff5cdc4e9c25648367e",
+				"DiscoKey":   "discokey:53d9458da519ea025e40e85fe1c9ec7e2fcb3c671bde7c6411b90452d163ba36",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42005",
+					"10.65.0.27:42005",
+					"172.17.0.1:42005",
+					"172.19.0.1:42005",
+					"172.20.0.1:42005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:47:00.928314278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         638830889127582,
+				"StableID":   "nVgi6F1Lz511CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f4c604bdb2bd0483229318ba9623e9914d77d340ce0d8fb53d35da2222f4b40b",
+				"DiscoKey":   "discokey:ad54059bbd58c2f5c3d87ebbd86cdf210f2784eaf80d3d64289ef134c2ae2e68",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33413",
+					"10.65.0.27:33413",
+					"172.17.0.1:33413",
+					"172.19.0.1:33413",
+					"172.20.0.1:33413"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:47:01.710836573Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8951108461894055,
+				"StableID":   "ngPW9aSytC21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d3ab64981f38116c09ebdbb3ed1fa5b8a21ba980e8aeba908a0d6fcff31b722b",
+				"DiscoKey":   "discokey:da6b63ed1872d5d7bd7d35c88cedd8367753a0e23412e3e16af506a7ae56785f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53724",
+					"10.65.0.27:53724",
+					"172.17.0.1:53724",
+					"172.19.0.1:53724",
+					"172.20.0.1:53724"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:47:02.247950824Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3148442288767369,
+				"StableID":   "nSR1jvEwaR11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f46b838a780d827b180d02d652f9e6f0e9ca828ad45d79cef3145fff06ad6306",
+				"DiscoKey":   "discokey:91777640d9c225e1651413963ff18bca51640d503d5c90fddfd95e1a6dc55d2d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47415",
+					"10.65.0.27:47415",
+					"172.17.0.1:47415",
+					"172.19.0.1:47415",
+					"172.20.0.1:47415"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:47:02.790158711Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2595963247498152,
+				"StableID":   "nDqvi3ZiGM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04d6bf29076c5b8c5c9bc3cab2cd03422984785540461d2089a1f8a1919bcc47",
+				"KeyExpiry":  "2026-11-08T18:47:03Z",
+				"DiscoKey":   "discokey:6f1b01e3c0e9f076f0c7e8af8424f4288284111b7a310ce6afc653f557e16407",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50469",
+					"10.65.0.27:50469",
+					"172.17.0.1:50469",
+					"172.19.0.1:50469",
+					"172.20.0.1:50469"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:47:03.341917671Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1778974702635585,
+				"StableID":   "n2fEfdehtE11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ce71f07116a10272bfafa69288c7bf13bd492b9f27dbbe049e98334a0d14f752",
+				"KeyExpiry":  "2026-11-08T18:47:03Z",
+				"DiscoKey":   "discokey:8a5ded2903d801f7d9f24b3f45d56ace02032b303f2a21160d48cca0709fee48",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57329",
+					"10.65.0.27:57329",
+					"172.17.0.1:57329",
+					"172.19.0.1:57329",
+					"172.20.0.1:57329"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:47:03.889124394Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7926432109370923,
+				"StableID":   "nkHPiyvtt421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       7926432109370923,
+				"Key":        "nodekey:cb80b25b53d7846a3f55bfae2fc4af127e77667327c40440164c255a79781658",
+				"DiscoKey":   "discokey:70d3e62748f64e665af774d4db46d20783c347e9135570bbc5abdd66a971f410",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:50483",
+					"10.65.0.27:50483",
+					"172.17.0.1:50483",
+					"172.19.0.1:50483",
+					"172.20.0.1:50483"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:46:57.694750834Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:cb80b25b53d7846a3f55bfae2fc4af127e77667327c40440164c255a79781658",
+			"MachineKey": "mkey:f9806f51f60cd89788938f4a01c78218556936b0a0f68ce6ed2f85375394ec4a",
+			"Peers": [{
+				"ID":         3348008648796742,
+				"StableID":   "nhaUaaWK9T11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9ce76fb98a22982637f757b24fc9c2d81c97af4740221c838855d142831fe314",
+				"DiscoKey":   "discokey:a083c54b20dfa85d0422733253739ec17ebaa2dc3208357d4055bf70db465c7b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:39638",
+					"10.65.0.27:39638",
+					"172.17.0.1:39638",
+					"172.19.0.1:39638",
+					"172.20.0.1:39638"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:46:56.697652601Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7277465688330465,
+				"StableID":   "nGYJNdgypy11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:466556dd8919f60b82af055aa64d2bee39ebc43f63610450e45647ef54b4a623",
+				"DiscoKey":   "discokey:be1954a328b007c85d14895411305216b30e8b13206bca2991da58def584c86d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:41114",
+					"10.65.0.27:41114",
+					"172.17.0.1:41114",
+					"172.19.0.1:41114",
+					"172.20.0.1:41114"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:46:57.163827119Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6897754256649264,
+				"StableID":   "nbLoQrJ1sv11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51a6de329a6892b1f17379ad39a19bb0b91d455061f3f8708b1af69d85a0733c",
+				"DiscoKey":   "discokey:062c98854b4998886382a1cf2cc2505acee50a1fa997ae2104aba52cb3c21e5d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:32981",
+					"10.65.0.27:32981",
+					"172.17.0.1:32981",
+					"172.19.0.1:32981",
+					"172.20.0.1:32981"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:46:58.236702505Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7832544745057696,
+				"StableID":   "nscDqnfNA421CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:737ef157cd230d1806f33953b3843f8b7715755c6bfa83c275816164b8a25834",
+				"DiscoKey":   "discokey:3551f1d7230efc5ecd963a911988a230162630c2bfe46c9dfe48c22fdeb3ee58",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53908",
+					"10.65.0.27:53908",
+					"172.17.0.1:53908",
+					"172.19.0.1:53908",
+					"172.20.0.1:53908"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:46:58.777040016Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         883772907534194,
+				"StableID":   "nMC3WWDGu711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:be7f53c951510fddf7ae55a32c1a7324d2d9e381c49c9ab5d585f1c0b3cedd3c",
+				"DiscoKey":   "discokey:97c40c9cc30190cbbb4f08b3a41c50138a946493164b7a0a1a5651a1b717554a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50488",
+					"10.65.0.27:50488",
+					"172.17.0.1:50488",
+					"172.19.0.1:50488",
+					"172.20.0.1:50488"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:46:59.311511755Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3533628427968141,
+				"StableID":   "nEFaqkRPbU11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4b4a7d05171111bf5fdb459aed82f78dcd9dfa8e834b4d3bd74dbf6b73dd833",
+				"DiscoKey":   "discokey:6db58249552caf4bfd881dc58405ddba40a60514dfb4a40e8cca49b92e528944",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52043",
+					"10.65.0.27:52043",
+					"172.17.0.1:52043",
+					"172.19.0.1:52043",
+					"172.20.0.1:52043"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:46:59.878449221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1899378406578201,
+				"StableID":   "n8k4g6TEqF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a2eff8e0bc4e94c33b13d949551b049359b84dc23fe47bd2e5d711fcf6e4e5f",
+				"DiscoKey":   "discokey:f72a2d1f05fb773f5f1841c5369ce19de6787ba216d6b1b812b7fde5e9bf7331",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:56545",
+					"10.65.0.27:56545",
+					"172.17.0.1:56545",
+					"172.19.0.1:56545",
+					"172.20.0.1:56545"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:47:00.414940937Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5783245827808651,
+				"StableID":   "n8bV1Z4FAn11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3cf0e0a8776f33dac88f65d95b89bb01fabd12fe85b9cff5cdc4e9c25648367e",
+				"DiscoKey":   "discokey:53d9458da519ea025e40e85fe1c9ec7e2fcb3c671bde7c6411b90452d163ba36",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42005",
+					"10.65.0.27:42005",
+					"172.17.0.1:42005",
+					"172.19.0.1:42005",
+					"172.20.0.1:42005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:47:00.928314278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         638830889127582,
+				"StableID":   "nVgi6F1Lz511CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f4c604bdb2bd0483229318ba9623e9914d77d340ce0d8fb53d35da2222f4b40b",
+				"DiscoKey":   "discokey:ad54059bbd58c2f5c3d87ebbd86cdf210f2784eaf80d3d64289ef134c2ae2e68",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33413",
+					"10.65.0.27:33413",
+					"172.17.0.1:33413",
+					"172.19.0.1:33413",
+					"172.20.0.1:33413"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:47:01.710836573Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8951108461894055,
+				"StableID":   "ngPW9aSytC21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d3ab64981f38116c09ebdbb3ed1fa5b8a21ba980e8aeba908a0d6fcff31b722b",
+				"DiscoKey":   "discokey:da6b63ed1872d5d7bd7d35c88cedd8367753a0e23412e3e16af506a7ae56785f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53724",
+					"10.65.0.27:53724",
+					"172.17.0.1:53724",
+					"172.19.0.1:53724",
+					"172.20.0.1:53724"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:47:02.247950824Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3148442288767369,
+				"StableID":   "nSR1jvEwaR11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f46b838a780d827b180d02d652f9e6f0e9ca828ad45d79cef3145fff06ad6306",
+				"DiscoKey":   "discokey:91777640d9c225e1651413963ff18bca51640d503d5c90fddfd95e1a6dc55d2d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47415",
+					"10.65.0.27:47415",
+					"172.17.0.1:47415",
+					"172.19.0.1:47415",
+					"172.20.0.1:47415"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:47:02.790158711Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2595963247498152,
+				"StableID":   "nDqvi3ZiGM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04d6bf29076c5b8c5c9bc3cab2cd03422984785540461d2089a1f8a1919bcc47",
+				"KeyExpiry":  "2026-11-08T18:47:03Z",
+				"DiscoKey":   "discokey:6f1b01e3c0e9f076f0c7e8af8424f4288284111b7a310ce6afc653f557e16407",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50469",
+					"10.65.0.27:50469",
+					"172.17.0.1:50469",
+					"172.19.0.1:50469",
+					"172.20.0.1:50469"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:47:03.341917671Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1778974702635585,
+				"StableID":   "n2fEfdehtE11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ce71f07116a10272bfafa69288c7bf13bd492b9f27dbbe049e98334a0d14f752",
+				"KeyExpiry":  "2026-11-08T18:47:03Z",
+				"DiscoKey":   "discokey:8a5ded2903d801f7d9f24b3f45d56ace02032b303f2a21160d48cca0709fee48",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57329",
+					"10.65.0.27:57329",
+					"172.17.0.1:57329",
+					"172.19.0.1:57329",
+					"172.20.0.1:57329"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:47:03.889124394Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         218017761311581,
+				"StableID":   "nCC21Wxjh211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f0e33f737aa39d978567b2ab54d02dc0910b58d411495da32ebd6973d68e863d",
+				"KeyExpiry":  "2026-11-08T18:47:04Z",
+				"DiscoKey":   "discokey:3e5631f7d39b6c03347fddc860af14295d4a6acf315f35446573f2a01fc03b62",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56846",
+					"10.65.0.27:56846",
+					"172.17.0.1:56846",
+					"172.19.0.1:56846",
+					"172.20.0.1:56846"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:47:04.426626581Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7926432109370923": {
+				"ID":          7926432109370923,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1899378406578201,
+				"StableID":   "n8k4g6TEqF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1899378406578201,
+				"Key":        "nodekey:8a2eff8e0bc4e94c33b13d949551b049359b84dc23fe47bd2e5d711fcf6e4e5f",
+				"DiscoKey":   "discokey:f72a2d1f05fb773f5f1841c5369ce19de6787ba216d6b1b812b7fde5e9bf7331",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:56545",
+					"10.65.0.27:56545",
+					"172.17.0.1:56545",
+					"172.19.0.1:56545",
+					"172.20.0.1:56545"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:47:00.414940937Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8a2eff8e0bc4e94c33b13d949551b049359b84dc23fe47bd2e5d711fcf6e4e5f",
+			"MachineKey": "mkey:841fc72b52a68dd820763bc1cf0599d80dfbccf1ac92d2ac89322496314ed76a",
+			"Peers": [{
+				"ID":         3348008648796742,
+				"StableID":   "nhaUaaWK9T11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9ce76fb98a22982637f757b24fc9c2d81c97af4740221c838855d142831fe314",
+				"DiscoKey":   "discokey:a083c54b20dfa85d0422733253739ec17ebaa2dc3208357d4055bf70db465c7b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:39638",
+					"10.65.0.27:39638",
+					"172.17.0.1:39638",
+					"172.19.0.1:39638",
+					"172.20.0.1:39638"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:46:56.697652601Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7277465688330465,
+				"StableID":   "nGYJNdgypy11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:466556dd8919f60b82af055aa64d2bee39ebc43f63610450e45647ef54b4a623",
+				"DiscoKey":   "discokey:be1954a328b007c85d14895411305216b30e8b13206bca2991da58def584c86d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:41114",
+					"10.65.0.27:41114",
+					"172.17.0.1:41114",
+					"172.19.0.1:41114",
+					"172.20.0.1:41114"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:46:57.163827119Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7926432109370923,
+				"StableID":   "nkHPiyvtt421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb80b25b53d7846a3f55bfae2fc4af127e77667327c40440164c255a79781658",
+				"DiscoKey":   "discokey:70d3e62748f64e665af774d4db46d20783c347e9135570bbc5abdd66a971f410",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:50483",
+					"10.65.0.27:50483",
+					"172.17.0.1:50483",
+					"172.19.0.1:50483",
+					"172.20.0.1:50483"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:46:57.694750834Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6897754256649264,
+				"StableID":   "nbLoQrJ1sv11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51a6de329a6892b1f17379ad39a19bb0b91d455061f3f8708b1af69d85a0733c",
+				"DiscoKey":   "discokey:062c98854b4998886382a1cf2cc2505acee50a1fa997ae2104aba52cb3c21e5d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:32981",
+					"10.65.0.27:32981",
+					"172.17.0.1:32981",
+					"172.19.0.1:32981",
+					"172.20.0.1:32981"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:46:58.236702505Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7832544745057696,
+				"StableID":   "nscDqnfNA421CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:737ef157cd230d1806f33953b3843f8b7715755c6bfa83c275816164b8a25834",
+				"DiscoKey":   "discokey:3551f1d7230efc5ecd963a911988a230162630c2bfe46c9dfe48c22fdeb3ee58",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53908",
+					"10.65.0.27:53908",
+					"172.17.0.1:53908",
+					"172.19.0.1:53908",
+					"172.20.0.1:53908"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:46:58.777040016Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         883772907534194,
+				"StableID":   "nMC3WWDGu711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:be7f53c951510fddf7ae55a32c1a7324d2d9e381c49c9ab5d585f1c0b3cedd3c",
+				"DiscoKey":   "discokey:97c40c9cc30190cbbb4f08b3a41c50138a946493164b7a0a1a5651a1b717554a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50488",
+					"10.65.0.27:50488",
+					"172.17.0.1:50488",
+					"172.19.0.1:50488",
+					"172.20.0.1:50488"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:46:59.311511755Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3533628427968141,
+				"StableID":   "nEFaqkRPbU11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4b4a7d05171111bf5fdb459aed82f78dcd9dfa8e834b4d3bd74dbf6b73dd833",
+				"DiscoKey":   "discokey:6db58249552caf4bfd881dc58405ddba40a60514dfb4a40e8cca49b92e528944",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52043",
+					"10.65.0.27:52043",
+					"172.17.0.1:52043",
+					"172.19.0.1:52043",
+					"172.20.0.1:52043"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:46:59.878449221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5783245827808651,
+				"StableID":   "n8bV1Z4FAn11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3cf0e0a8776f33dac88f65d95b89bb01fabd12fe85b9cff5cdc4e9c25648367e",
+				"DiscoKey":   "discokey:53d9458da519ea025e40e85fe1c9ec7e2fcb3c671bde7c6411b90452d163ba36",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42005",
+					"10.65.0.27:42005",
+					"172.17.0.1:42005",
+					"172.19.0.1:42005",
+					"172.20.0.1:42005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:47:00.928314278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         638830889127582,
+				"StableID":   "nVgi6F1Lz511CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f4c604bdb2bd0483229318ba9623e9914d77d340ce0d8fb53d35da2222f4b40b",
+				"DiscoKey":   "discokey:ad54059bbd58c2f5c3d87ebbd86cdf210f2784eaf80d3d64289ef134c2ae2e68",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33413",
+					"10.65.0.27:33413",
+					"172.17.0.1:33413",
+					"172.19.0.1:33413",
+					"172.20.0.1:33413"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:47:01.710836573Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8951108461894055,
+				"StableID":   "ngPW9aSytC21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d3ab64981f38116c09ebdbb3ed1fa5b8a21ba980e8aeba908a0d6fcff31b722b",
+				"DiscoKey":   "discokey:da6b63ed1872d5d7bd7d35c88cedd8367753a0e23412e3e16af506a7ae56785f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53724",
+					"10.65.0.27:53724",
+					"172.17.0.1:53724",
+					"172.19.0.1:53724",
+					"172.20.0.1:53724"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:47:02.247950824Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3148442288767369,
+				"StableID":   "nSR1jvEwaR11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f46b838a780d827b180d02d652f9e6f0e9ca828ad45d79cef3145fff06ad6306",
+				"DiscoKey":   "discokey:91777640d9c225e1651413963ff18bca51640d503d5c90fddfd95e1a6dc55d2d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47415",
+					"10.65.0.27:47415",
+					"172.17.0.1:47415",
+					"172.19.0.1:47415",
+					"172.20.0.1:47415"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:47:02.790158711Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2595963247498152,
+				"StableID":   "nDqvi3ZiGM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04d6bf29076c5b8c5c9bc3cab2cd03422984785540461d2089a1f8a1919bcc47",
+				"KeyExpiry":  "2026-11-08T18:47:03Z",
+				"DiscoKey":   "discokey:6f1b01e3c0e9f076f0c7e8af8424f4288284111b7a310ce6afc653f557e16407",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50469",
+					"10.65.0.27:50469",
+					"172.17.0.1:50469",
+					"172.19.0.1:50469",
+					"172.20.0.1:50469"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:47:03.341917671Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1778974702635585,
+				"StableID":   "n2fEfdehtE11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ce71f07116a10272bfafa69288c7bf13bd492b9f27dbbe049e98334a0d14f752",
+				"KeyExpiry":  "2026-11-08T18:47:03Z",
+				"DiscoKey":   "discokey:8a5ded2903d801f7d9f24b3f45d56ace02032b303f2a21160d48cca0709fee48",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57329",
+					"10.65.0.27:57329",
+					"172.17.0.1:57329",
+					"172.19.0.1:57329",
+					"172.20.0.1:57329"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:47:03.889124394Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         218017761311581,
+				"StableID":   "nCC21Wxjh211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f0e33f737aa39d978567b2ab54d02dc0910b58d411495da32ebd6973d68e863d",
+				"KeyExpiry":  "2026-11-08T18:47:04Z",
+				"DiscoKey":   "discokey:3e5631f7d39b6c03347fddc860af14295d4a6acf315f35446573f2a01fc03b62",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56846",
+					"10.65.0.27:56846",
+					"172.17.0.1:56846",
+					"172.19.0.1:56846",
+					"172.20.0.1:56846"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:47:04.426626581Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1899378406578201": {
+				"ID":          1899378406578201,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2595963247498152,
+				"StableID":   "nDqvi3ZiGM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04d6bf29076c5b8c5c9bc3cab2cd03422984785540461d2089a1f8a1919bcc47",
+				"KeyExpiry":  "2026-11-08T18:47:03Z",
+				"DiscoKey":   "discokey:6f1b01e3c0e9f076f0c7e8af8424f4288284111b7a310ce6afc653f557e16407",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50469",
+					"10.65.0.27:50469",
+					"172.17.0.1:50469",
+					"172.19.0.1:50469",
+					"172.20.0.1:50469"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:47:03.341917671Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:04d6bf29076c5b8c5c9bc3cab2cd03422984785540461d2089a1f8a1919bcc47",
+			"MachineKey": "mkey:d1e1cb16c16e89077daaed3a4df8f0062f7c367cf05a55f8ef97dd8459c02024",
+			"Peers": [{
+				"ID":         3348008648796742,
+				"StableID":   "nhaUaaWK9T11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9ce76fb98a22982637f757b24fc9c2d81c97af4740221c838855d142831fe314",
+				"DiscoKey":   "discokey:a083c54b20dfa85d0422733253739ec17ebaa2dc3208357d4055bf70db465c7b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:39638",
+					"10.65.0.27:39638",
+					"172.17.0.1:39638",
+					"172.19.0.1:39638",
+					"172.20.0.1:39638"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:46:56.697652601Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7277465688330465,
+				"StableID":   "nGYJNdgypy11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:466556dd8919f60b82af055aa64d2bee39ebc43f63610450e45647ef54b4a623",
+				"DiscoKey":   "discokey:be1954a328b007c85d14895411305216b30e8b13206bca2991da58def584c86d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:41114",
+					"10.65.0.27:41114",
+					"172.17.0.1:41114",
+					"172.19.0.1:41114",
+					"172.20.0.1:41114"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:46:57.163827119Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7926432109370923,
+				"StableID":   "nkHPiyvtt421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb80b25b53d7846a3f55bfae2fc4af127e77667327c40440164c255a79781658",
+				"DiscoKey":   "discokey:70d3e62748f64e665af774d4db46d20783c347e9135570bbc5abdd66a971f410",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:50483",
+					"10.65.0.27:50483",
+					"172.17.0.1:50483",
+					"172.19.0.1:50483",
+					"172.20.0.1:50483"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:46:57.694750834Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6897754256649264,
+				"StableID":   "nbLoQrJ1sv11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51a6de329a6892b1f17379ad39a19bb0b91d455061f3f8708b1af69d85a0733c",
+				"DiscoKey":   "discokey:062c98854b4998886382a1cf2cc2505acee50a1fa997ae2104aba52cb3c21e5d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:32981",
+					"10.65.0.27:32981",
+					"172.17.0.1:32981",
+					"172.19.0.1:32981",
+					"172.20.0.1:32981"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:46:58.236702505Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7832544745057696,
+				"StableID":   "nscDqnfNA421CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:737ef157cd230d1806f33953b3843f8b7715755c6bfa83c275816164b8a25834",
+				"DiscoKey":   "discokey:3551f1d7230efc5ecd963a911988a230162630c2bfe46c9dfe48c22fdeb3ee58",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53908",
+					"10.65.0.27:53908",
+					"172.17.0.1:53908",
+					"172.19.0.1:53908",
+					"172.20.0.1:53908"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:46:58.777040016Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         883772907534194,
+				"StableID":   "nMC3WWDGu711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:be7f53c951510fddf7ae55a32c1a7324d2d9e381c49c9ab5d585f1c0b3cedd3c",
+				"DiscoKey":   "discokey:97c40c9cc30190cbbb4f08b3a41c50138a946493164b7a0a1a5651a1b717554a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50488",
+					"10.65.0.27:50488",
+					"172.17.0.1:50488",
+					"172.19.0.1:50488",
+					"172.20.0.1:50488"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:46:59.311511755Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3533628427968141,
+				"StableID":   "nEFaqkRPbU11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4b4a7d05171111bf5fdb459aed82f78dcd9dfa8e834b4d3bd74dbf6b73dd833",
+				"DiscoKey":   "discokey:6db58249552caf4bfd881dc58405ddba40a60514dfb4a40e8cca49b92e528944",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52043",
+					"10.65.0.27:52043",
+					"172.17.0.1:52043",
+					"172.19.0.1:52043",
+					"172.20.0.1:52043"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:46:59.878449221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1899378406578201,
+				"StableID":   "n8k4g6TEqF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a2eff8e0bc4e94c33b13d949551b049359b84dc23fe47bd2e5d711fcf6e4e5f",
+				"DiscoKey":   "discokey:f72a2d1f05fb773f5f1841c5369ce19de6787ba216d6b1b812b7fde5e9bf7331",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:56545",
+					"10.65.0.27:56545",
+					"172.17.0.1:56545",
+					"172.19.0.1:56545",
+					"172.20.0.1:56545"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:47:00.414940937Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5783245827808651,
+				"StableID":   "n8bV1Z4FAn11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3cf0e0a8776f33dac88f65d95b89bb01fabd12fe85b9cff5cdc4e9c25648367e",
+				"DiscoKey":   "discokey:53d9458da519ea025e40e85fe1c9ec7e2fcb3c671bde7c6411b90452d163ba36",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42005",
+					"10.65.0.27:42005",
+					"172.17.0.1:42005",
+					"172.19.0.1:42005",
+					"172.20.0.1:42005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:47:00.928314278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         638830889127582,
+				"StableID":   "nVgi6F1Lz511CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f4c604bdb2bd0483229318ba9623e9914d77d340ce0d8fb53d35da2222f4b40b",
+				"DiscoKey":   "discokey:ad54059bbd58c2f5c3d87ebbd86cdf210f2784eaf80d3d64289ef134c2ae2e68",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33413",
+					"10.65.0.27:33413",
+					"172.17.0.1:33413",
+					"172.19.0.1:33413",
+					"172.20.0.1:33413"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:47:01.710836573Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8951108461894055,
+				"StableID":   "ngPW9aSytC21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d3ab64981f38116c09ebdbb3ed1fa5b8a21ba980e8aeba908a0d6fcff31b722b",
+				"DiscoKey":   "discokey:da6b63ed1872d5d7bd7d35c88cedd8367753a0e23412e3e16af506a7ae56785f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53724",
+					"10.65.0.27:53724",
+					"172.17.0.1:53724",
+					"172.19.0.1:53724",
+					"172.20.0.1:53724"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:47:02.247950824Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3148442288767369,
+				"StableID":   "nSR1jvEwaR11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f46b838a780d827b180d02d652f9e6f0e9ca828ad45d79cef3145fff06ad6306",
+				"DiscoKey":   "discokey:91777640d9c225e1651413963ff18bca51640d503d5c90fddfd95e1a6dc55d2d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47415",
+					"10.65.0.27:47415",
+					"172.17.0.1:47415",
+					"172.19.0.1:47415",
+					"172.20.0.1:47415"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:47:02.790158711Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1778974702635585,
+				"StableID":   "n2fEfdehtE11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ce71f07116a10272bfafa69288c7bf13bd492b9f27dbbe049e98334a0d14f752",
+				"KeyExpiry":  "2026-11-08T18:47:03Z",
+				"DiscoKey":   "discokey:8a5ded2903d801f7d9f24b3f45d56ace02032b303f2a21160d48cca0709fee48",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57329",
+					"10.65.0.27:57329",
+					"172.17.0.1:57329",
+					"172.19.0.1:57329",
+					"172.20.0.1:57329"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:47:03.889124394Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         218017761311581,
+				"StableID":   "nCC21Wxjh211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f0e33f737aa39d978567b2ab54d02dc0910b58d411495da32ebd6973d68e863d",
+				"KeyExpiry":  "2026-11-08T18:47:04Z",
+				"DiscoKey":   "discokey:3e5631f7d39b6c03347fddc860af14295d4a6acf315f35446573f2a01fc03b62",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56846",
+					"10.65.0.27:56846",
+					"172.17.0.1:56846",
+					"172.19.0.1:56846",
+					"172.20.0.1:56846"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:47:04.426626581Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8951108461894055,
+				"StableID":   "ngPW9aSytC21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       8951108461894055,
+				"Key":        "nodekey:d3ab64981f38116c09ebdbb3ed1fa5b8a21ba980e8aeba908a0d6fcff31b722b",
+				"DiscoKey":   "discokey:da6b63ed1872d5d7bd7d35c88cedd8367753a0e23412e3e16af506a7ae56785f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53724",
+					"10.65.0.27:53724",
+					"172.17.0.1:53724",
+					"172.19.0.1:53724",
+					"172.20.0.1:53724"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:47:02.247950824Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d3ab64981f38116c09ebdbb3ed1fa5b8a21ba980e8aeba908a0d6fcff31b722b",
+			"MachineKey": "mkey:9d575aab258ceded94f2fd63e13e7c22c7d6a3e0eb349c826f1f51011d175835",
+			"Peers": [{
+				"ID":         3348008648796742,
+				"StableID":   "nhaUaaWK9T11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9ce76fb98a22982637f757b24fc9c2d81c97af4740221c838855d142831fe314",
+				"DiscoKey":   "discokey:a083c54b20dfa85d0422733253739ec17ebaa2dc3208357d4055bf70db465c7b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:39638",
+					"10.65.0.27:39638",
+					"172.17.0.1:39638",
+					"172.19.0.1:39638",
+					"172.20.0.1:39638"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:46:56.697652601Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7277465688330465,
+				"StableID":   "nGYJNdgypy11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:466556dd8919f60b82af055aa64d2bee39ebc43f63610450e45647ef54b4a623",
+				"DiscoKey":   "discokey:be1954a328b007c85d14895411305216b30e8b13206bca2991da58def584c86d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:41114",
+					"10.65.0.27:41114",
+					"172.17.0.1:41114",
+					"172.19.0.1:41114",
+					"172.20.0.1:41114"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:46:57.163827119Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7926432109370923,
+				"StableID":   "nkHPiyvtt421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb80b25b53d7846a3f55bfae2fc4af127e77667327c40440164c255a79781658",
+				"DiscoKey":   "discokey:70d3e62748f64e665af774d4db46d20783c347e9135570bbc5abdd66a971f410",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:50483",
+					"10.65.0.27:50483",
+					"172.17.0.1:50483",
+					"172.19.0.1:50483",
+					"172.20.0.1:50483"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:46:57.694750834Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6897754256649264,
+				"StableID":   "nbLoQrJ1sv11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51a6de329a6892b1f17379ad39a19bb0b91d455061f3f8708b1af69d85a0733c",
+				"DiscoKey":   "discokey:062c98854b4998886382a1cf2cc2505acee50a1fa997ae2104aba52cb3c21e5d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:32981",
+					"10.65.0.27:32981",
+					"172.17.0.1:32981",
+					"172.19.0.1:32981",
+					"172.20.0.1:32981"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:46:58.236702505Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7832544745057696,
+				"StableID":   "nscDqnfNA421CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:737ef157cd230d1806f33953b3843f8b7715755c6bfa83c275816164b8a25834",
+				"DiscoKey":   "discokey:3551f1d7230efc5ecd963a911988a230162630c2bfe46c9dfe48c22fdeb3ee58",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53908",
+					"10.65.0.27:53908",
+					"172.17.0.1:53908",
+					"172.19.0.1:53908",
+					"172.20.0.1:53908"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:46:58.777040016Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         883772907534194,
+				"StableID":   "nMC3WWDGu711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:be7f53c951510fddf7ae55a32c1a7324d2d9e381c49c9ab5d585f1c0b3cedd3c",
+				"DiscoKey":   "discokey:97c40c9cc30190cbbb4f08b3a41c50138a946493164b7a0a1a5651a1b717554a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50488",
+					"10.65.0.27:50488",
+					"172.17.0.1:50488",
+					"172.19.0.1:50488",
+					"172.20.0.1:50488"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:46:59.311511755Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3533628427968141,
+				"StableID":   "nEFaqkRPbU11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4b4a7d05171111bf5fdb459aed82f78dcd9dfa8e834b4d3bd74dbf6b73dd833",
+				"DiscoKey":   "discokey:6db58249552caf4bfd881dc58405ddba40a60514dfb4a40e8cca49b92e528944",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52043",
+					"10.65.0.27:52043",
+					"172.17.0.1:52043",
+					"172.19.0.1:52043",
+					"172.20.0.1:52043"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:46:59.878449221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1899378406578201,
+				"StableID":   "n8k4g6TEqF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a2eff8e0bc4e94c33b13d949551b049359b84dc23fe47bd2e5d711fcf6e4e5f",
+				"DiscoKey":   "discokey:f72a2d1f05fb773f5f1841c5369ce19de6787ba216d6b1b812b7fde5e9bf7331",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:56545",
+					"10.65.0.27:56545",
+					"172.17.0.1:56545",
+					"172.19.0.1:56545",
+					"172.20.0.1:56545"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:47:00.414940937Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5783245827808651,
+				"StableID":   "n8bV1Z4FAn11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3cf0e0a8776f33dac88f65d95b89bb01fabd12fe85b9cff5cdc4e9c25648367e",
+				"DiscoKey":   "discokey:53d9458da519ea025e40e85fe1c9ec7e2fcb3c671bde7c6411b90452d163ba36",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42005",
+					"10.65.0.27:42005",
+					"172.17.0.1:42005",
+					"172.19.0.1:42005",
+					"172.20.0.1:42005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:47:00.928314278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         638830889127582,
+				"StableID":   "nVgi6F1Lz511CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f4c604bdb2bd0483229318ba9623e9914d77d340ce0d8fb53d35da2222f4b40b",
+				"DiscoKey":   "discokey:ad54059bbd58c2f5c3d87ebbd86cdf210f2784eaf80d3d64289ef134c2ae2e68",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33413",
+					"10.65.0.27:33413",
+					"172.17.0.1:33413",
+					"172.19.0.1:33413",
+					"172.20.0.1:33413"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:47:01.710836573Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3148442288767369,
+				"StableID":   "nSR1jvEwaR11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f46b838a780d827b180d02d652f9e6f0e9ca828ad45d79cef3145fff06ad6306",
+				"DiscoKey":   "discokey:91777640d9c225e1651413963ff18bca51640d503d5c90fddfd95e1a6dc55d2d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47415",
+					"10.65.0.27:47415",
+					"172.17.0.1:47415",
+					"172.19.0.1:47415",
+					"172.20.0.1:47415"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:47:02.790158711Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2595963247498152,
+				"StableID":   "nDqvi3ZiGM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04d6bf29076c5b8c5c9bc3cab2cd03422984785540461d2089a1f8a1919bcc47",
+				"KeyExpiry":  "2026-11-08T18:47:03Z",
+				"DiscoKey":   "discokey:6f1b01e3c0e9f076f0c7e8af8424f4288284111b7a310ce6afc653f557e16407",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50469",
+					"10.65.0.27:50469",
+					"172.17.0.1:50469",
+					"172.19.0.1:50469",
+					"172.20.0.1:50469"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:47:03.341917671Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1778974702635585,
+				"StableID":   "n2fEfdehtE11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ce71f07116a10272bfafa69288c7bf13bd492b9f27dbbe049e98334a0d14f752",
+				"KeyExpiry":  "2026-11-08T18:47:03Z",
+				"DiscoKey":   "discokey:8a5ded2903d801f7d9f24b3f45d56ace02032b303f2a21160d48cca0709fee48",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57329",
+					"10.65.0.27:57329",
+					"172.17.0.1:57329",
+					"172.19.0.1:57329",
+					"172.20.0.1:57329"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:47:03.889124394Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         218017761311581,
+				"StableID":   "nCC21Wxjh211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f0e33f737aa39d978567b2ab54d02dc0910b58d411495da32ebd6973d68e863d",
+				"KeyExpiry":  "2026-11-08T18:47:04Z",
+				"DiscoKey":   "discokey:3e5631f7d39b6c03347fddc860af14295d4a6acf315f35446573f2a01fc03b62",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56846",
+					"10.65.0.27:56846",
+					"172.17.0.1:56846",
+					"172.19.0.1:56846",
+					"172.20.0.1:56846"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:47:04.426626581Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8951108461894055": {
+				"ID":          8951108461894055,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7277465688330465,
+				"StableID":   "nGYJNdgypy11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       7277465688330465,
+				"Key":        "nodekey:466556dd8919f60b82af055aa64d2bee39ebc43f63610450e45647ef54b4a623",
+				"DiscoKey":   "discokey:be1954a328b007c85d14895411305216b30e8b13206bca2991da58def584c86d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:41114",
+					"10.65.0.27:41114",
+					"172.17.0.1:41114",
+					"172.19.0.1:41114",
+					"172.20.0.1:41114"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:46:57.163827119Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:466556dd8919f60b82af055aa64d2bee39ebc43f63610450e45647ef54b4a623",
+			"MachineKey": "mkey:de634b79896c701639debfd942b2f384a67216a5f54970cef6a91dd83c16d140",
+			"Peers": [{
+				"ID":         3348008648796742,
+				"StableID":   "nhaUaaWK9T11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9ce76fb98a22982637f757b24fc9c2d81c97af4740221c838855d142831fe314",
+				"DiscoKey":   "discokey:a083c54b20dfa85d0422733253739ec17ebaa2dc3208357d4055bf70db465c7b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:39638",
+					"10.65.0.27:39638",
+					"172.17.0.1:39638",
+					"172.19.0.1:39638",
+					"172.20.0.1:39638"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:46:56.697652601Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7926432109370923,
+				"StableID":   "nkHPiyvtt421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb80b25b53d7846a3f55bfae2fc4af127e77667327c40440164c255a79781658",
+				"DiscoKey":   "discokey:70d3e62748f64e665af774d4db46d20783c347e9135570bbc5abdd66a971f410",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:50483",
+					"10.65.0.27:50483",
+					"172.17.0.1:50483",
+					"172.19.0.1:50483",
+					"172.20.0.1:50483"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:46:57.694750834Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6897754256649264,
+				"StableID":   "nbLoQrJ1sv11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51a6de329a6892b1f17379ad39a19bb0b91d455061f3f8708b1af69d85a0733c",
+				"DiscoKey":   "discokey:062c98854b4998886382a1cf2cc2505acee50a1fa997ae2104aba52cb3c21e5d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:32981",
+					"10.65.0.27:32981",
+					"172.17.0.1:32981",
+					"172.19.0.1:32981",
+					"172.20.0.1:32981"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:46:58.236702505Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7832544745057696,
+				"StableID":   "nscDqnfNA421CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:737ef157cd230d1806f33953b3843f8b7715755c6bfa83c275816164b8a25834",
+				"DiscoKey":   "discokey:3551f1d7230efc5ecd963a911988a230162630c2bfe46c9dfe48c22fdeb3ee58",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53908",
+					"10.65.0.27:53908",
+					"172.17.0.1:53908",
+					"172.19.0.1:53908",
+					"172.20.0.1:53908"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:46:58.777040016Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         883772907534194,
+				"StableID":   "nMC3WWDGu711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:be7f53c951510fddf7ae55a32c1a7324d2d9e381c49c9ab5d585f1c0b3cedd3c",
+				"DiscoKey":   "discokey:97c40c9cc30190cbbb4f08b3a41c50138a946493164b7a0a1a5651a1b717554a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50488",
+					"10.65.0.27:50488",
+					"172.17.0.1:50488",
+					"172.19.0.1:50488",
+					"172.20.0.1:50488"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:46:59.311511755Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3533628427968141,
+				"StableID":   "nEFaqkRPbU11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4b4a7d05171111bf5fdb459aed82f78dcd9dfa8e834b4d3bd74dbf6b73dd833",
+				"DiscoKey":   "discokey:6db58249552caf4bfd881dc58405ddba40a60514dfb4a40e8cca49b92e528944",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52043",
+					"10.65.0.27:52043",
+					"172.17.0.1:52043",
+					"172.19.0.1:52043",
+					"172.20.0.1:52043"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:46:59.878449221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1899378406578201,
+				"StableID":   "n8k4g6TEqF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a2eff8e0bc4e94c33b13d949551b049359b84dc23fe47bd2e5d711fcf6e4e5f",
+				"DiscoKey":   "discokey:f72a2d1f05fb773f5f1841c5369ce19de6787ba216d6b1b812b7fde5e9bf7331",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:56545",
+					"10.65.0.27:56545",
+					"172.17.0.1:56545",
+					"172.19.0.1:56545",
+					"172.20.0.1:56545"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:47:00.414940937Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5783245827808651,
+				"StableID":   "n8bV1Z4FAn11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3cf0e0a8776f33dac88f65d95b89bb01fabd12fe85b9cff5cdc4e9c25648367e",
+				"DiscoKey":   "discokey:53d9458da519ea025e40e85fe1c9ec7e2fcb3c671bde7c6411b90452d163ba36",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42005",
+					"10.65.0.27:42005",
+					"172.17.0.1:42005",
+					"172.19.0.1:42005",
+					"172.20.0.1:42005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:47:00.928314278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         638830889127582,
+				"StableID":   "nVgi6F1Lz511CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f4c604bdb2bd0483229318ba9623e9914d77d340ce0d8fb53d35da2222f4b40b",
+				"DiscoKey":   "discokey:ad54059bbd58c2f5c3d87ebbd86cdf210f2784eaf80d3d64289ef134c2ae2e68",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33413",
+					"10.65.0.27:33413",
+					"172.17.0.1:33413",
+					"172.19.0.1:33413",
+					"172.20.0.1:33413"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:47:01.710836573Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8951108461894055,
+				"StableID":   "ngPW9aSytC21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d3ab64981f38116c09ebdbb3ed1fa5b8a21ba980e8aeba908a0d6fcff31b722b",
+				"DiscoKey":   "discokey:da6b63ed1872d5d7bd7d35c88cedd8367753a0e23412e3e16af506a7ae56785f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53724",
+					"10.65.0.27:53724",
+					"172.17.0.1:53724",
+					"172.19.0.1:53724",
+					"172.20.0.1:53724"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:47:02.247950824Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3148442288767369,
+				"StableID":   "nSR1jvEwaR11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f46b838a780d827b180d02d652f9e6f0e9ca828ad45d79cef3145fff06ad6306",
+				"DiscoKey":   "discokey:91777640d9c225e1651413963ff18bca51640d503d5c90fddfd95e1a6dc55d2d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47415",
+					"10.65.0.27:47415",
+					"172.17.0.1:47415",
+					"172.19.0.1:47415",
+					"172.20.0.1:47415"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:47:02.790158711Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2595963247498152,
+				"StableID":   "nDqvi3ZiGM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04d6bf29076c5b8c5c9bc3cab2cd03422984785540461d2089a1f8a1919bcc47",
+				"KeyExpiry":  "2026-11-08T18:47:03Z",
+				"DiscoKey":   "discokey:6f1b01e3c0e9f076f0c7e8af8424f4288284111b7a310ce6afc653f557e16407",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50469",
+					"10.65.0.27:50469",
+					"172.17.0.1:50469",
+					"172.19.0.1:50469",
+					"172.20.0.1:50469"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:47:03.341917671Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1778974702635585,
+				"StableID":   "n2fEfdehtE11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ce71f07116a10272bfafa69288c7bf13bd492b9f27dbbe049e98334a0d14f752",
+				"KeyExpiry":  "2026-11-08T18:47:03Z",
+				"DiscoKey":   "discokey:8a5ded2903d801f7d9f24b3f45d56ace02032b303f2a21160d48cca0709fee48",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57329",
+					"10.65.0.27:57329",
+					"172.17.0.1:57329",
+					"172.19.0.1:57329",
+					"172.20.0.1:57329"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:47:03.889124394Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         218017761311581,
+				"StableID":   "nCC21Wxjh211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f0e33f737aa39d978567b2ab54d02dc0910b58d411495da32ebd6973d68e863d",
+				"KeyExpiry":  "2026-11-08T18:47:04Z",
+				"DiscoKey":   "discokey:3e5631f7d39b6c03347fddc860af14295d4a6acf315f35446573f2a01fc03b62",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56846",
+					"10.65.0.27:56846",
+					"172.17.0.1:56846",
+					"172.19.0.1:56846",
+					"172.20.0.1:56846"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:47:04.426626581Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7277465688330465": {
+				"ID":          7277465688330465,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3348008648796742,
+				"StableID":   "nhaUaaWK9T11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       3348008648796742,
+				"Key":        "nodekey:9ce76fb98a22982637f757b24fc9c2d81c97af4740221c838855d142831fe314",
+				"DiscoKey":   "discokey:a083c54b20dfa85d0422733253739ec17ebaa2dc3208357d4055bf70db465c7b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:39638",
+					"10.65.0.27:39638",
+					"172.17.0.1:39638",
+					"172.19.0.1:39638",
+					"172.20.0.1:39638"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:46:56.697652601Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9ce76fb98a22982637f757b24fc9c2d81c97af4740221c838855d142831fe314",
+			"MachineKey": "mkey:00dab4c3737115a431f80e4387a9687358ae6fd643ef724427e8db0262241a78",
+			"Peers": [{
+				"ID":         7277465688330465,
+				"StableID":   "nGYJNdgypy11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:466556dd8919f60b82af055aa64d2bee39ebc43f63610450e45647ef54b4a623",
+				"DiscoKey":   "discokey:be1954a328b007c85d14895411305216b30e8b13206bca2991da58def584c86d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:41114",
+					"10.65.0.27:41114",
+					"172.17.0.1:41114",
+					"172.19.0.1:41114",
+					"172.20.0.1:41114"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:46:57.163827119Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7926432109370923,
+				"StableID":   "nkHPiyvtt421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb80b25b53d7846a3f55bfae2fc4af127e77667327c40440164c255a79781658",
+				"DiscoKey":   "discokey:70d3e62748f64e665af774d4db46d20783c347e9135570bbc5abdd66a971f410",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:50483",
+					"10.65.0.27:50483",
+					"172.17.0.1:50483",
+					"172.19.0.1:50483",
+					"172.20.0.1:50483"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:46:57.694750834Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6897754256649264,
+				"StableID":   "nbLoQrJ1sv11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51a6de329a6892b1f17379ad39a19bb0b91d455061f3f8708b1af69d85a0733c",
+				"DiscoKey":   "discokey:062c98854b4998886382a1cf2cc2505acee50a1fa997ae2104aba52cb3c21e5d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:32981",
+					"10.65.0.27:32981",
+					"172.17.0.1:32981",
+					"172.19.0.1:32981",
+					"172.20.0.1:32981"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:46:58.236702505Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7832544745057696,
+				"StableID":   "nscDqnfNA421CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:737ef157cd230d1806f33953b3843f8b7715755c6bfa83c275816164b8a25834",
+				"DiscoKey":   "discokey:3551f1d7230efc5ecd963a911988a230162630c2bfe46c9dfe48c22fdeb3ee58",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53908",
+					"10.65.0.27:53908",
+					"172.17.0.1:53908",
+					"172.19.0.1:53908",
+					"172.20.0.1:53908"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:46:58.777040016Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         883772907534194,
+				"StableID":   "nMC3WWDGu711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:be7f53c951510fddf7ae55a32c1a7324d2d9e381c49c9ab5d585f1c0b3cedd3c",
+				"DiscoKey":   "discokey:97c40c9cc30190cbbb4f08b3a41c50138a946493164b7a0a1a5651a1b717554a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50488",
+					"10.65.0.27:50488",
+					"172.17.0.1:50488",
+					"172.19.0.1:50488",
+					"172.20.0.1:50488"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:46:59.311511755Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3533628427968141,
+				"StableID":   "nEFaqkRPbU11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4b4a7d05171111bf5fdb459aed82f78dcd9dfa8e834b4d3bd74dbf6b73dd833",
+				"DiscoKey":   "discokey:6db58249552caf4bfd881dc58405ddba40a60514dfb4a40e8cca49b92e528944",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52043",
+					"10.65.0.27:52043",
+					"172.17.0.1:52043",
+					"172.19.0.1:52043",
+					"172.20.0.1:52043"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:46:59.878449221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1899378406578201,
+				"StableID":   "n8k4g6TEqF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a2eff8e0bc4e94c33b13d949551b049359b84dc23fe47bd2e5d711fcf6e4e5f",
+				"DiscoKey":   "discokey:f72a2d1f05fb773f5f1841c5369ce19de6787ba216d6b1b812b7fde5e9bf7331",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:56545",
+					"10.65.0.27:56545",
+					"172.17.0.1:56545",
+					"172.19.0.1:56545",
+					"172.20.0.1:56545"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:47:00.414940937Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5783245827808651,
+				"StableID":   "n8bV1Z4FAn11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3cf0e0a8776f33dac88f65d95b89bb01fabd12fe85b9cff5cdc4e9c25648367e",
+				"DiscoKey":   "discokey:53d9458da519ea025e40e85fe1c9ec7e2fcb3c671bde7c6411b90452d163ba36",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42005",
+					"10.65.0.27:42005",
+					"172.17.0.1:42005",
+					"172.19.0.1:42005",
+					"172.20.0.1:42005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:47:00.928314278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         638830889127582,
+				"StableID":   "nVgi6F1Lz511CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f4c604bdb2bd0483229318ba9623e9914d77d340ce0d8fb53d35da2222f4b40b",
+				"DiscoKey":   "discokey:ad54059bbd58c2f5c3d87ebbd86cdf210f2784eaf80d3d64289ef134c2ae2e68",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33413",
+					"10.65.0.27:33413",
+					"172.17.0.1:33413",
+					"172.19.0.1:33413",
+					"172.20.0.1:33413"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:47:01.710836573Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8951108461894055,
+				"StableID":   "ngPW9aSytC21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d3ab64981f38116c09ebdbb3ed1fa5b8a21ba980e8aeba908a0d6fcff31b722b",
+				"DiscoKey":   "discokey:da6b63ed1872d5d7bd7d35c88cedd8367753a0e23412e3e16af506a7ae56785f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53724",
+					"10.65.0.27:53724",
+					"172.17.0.1:53724",
+					"172.19.0.1:53724",
+					"172.20.0.1:53724"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:47:02.247950824Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3148442288767369,
+				"StableID":   "nSR1jvEwaR11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f46b838a780d827b180d02d652f9e6f0e9ca828ad45d79cef3145fff06ad6306",
+				"DiscoKey":   "discokey:91777640d9c225e1651413963ff18bca51640d503d5c90fddfd95e1a6dc55d2d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47415",
+					"10.65.0.27:47415",
+					"172.17.0.1:47415",
+					"172.19.0.1:47415",
+					"172.20.0.1:47415"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:47:02.790158711Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2595963247498152,
+				"StableID":   "nDqvi3ZiGM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04d6bf29076c5b8c5c9bc3cab2cd03422984785540461d2089a1f8a1919bcc47",
+				"KeyExpiry":  "2026-11-08T18:47:03Z",
+				"DiscoKey":   "discokey:6f1b01e3c0e9f076f0c7e8af8424f4288284111b7a310ce6afc653f557e16407",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50469",
+					"10.65.0.27:50469",
+					"172.17.0.1:50469",
+					"172.19.0.1:50469",
+					"172.20.0.1:50469"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:47:03.341917671Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1778974702635585,
+				"StableID":   "n2fEfdehtE11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ce71f07116a10272bfafa69288c7bf13bd492b9f27dbbe049e98334a0d14f752",
+				"KeyExpiry":  "2026-11-08T18:47:03Z",
+				"DiscoKey":   "discokey:8a5ded2903d801f7d9f24b3f45d56ace02032b303f2a21160d48cca0709fee48",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57329",
+					"10.65.0.27:57329",
+					"172.17.0.1:57329",
+					"172.19.0.1:57329",
+					"172.20.0.1:57329"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:47:03.889124394Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         218017761311581,
+				"StableID":   "nCC21Wxjh211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f0e33f737aa39d978567b2ab54d02dc0910b58d411495da32ebd6973d68e863d",
+				"KeyExpiry":  "2026-11-08T18:47:04Z",
+				"DiscoKey":   "discokey:3e5631f7d39b6c03347fddc860af14295d4a6acf315f35446573f2a01fc03b62",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56846",
+					"10.65.0.27:56846",
+					"172.17.0.1:56846",
+					"172.19.0.1:56846",
+					"172.20.0.1:56846"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:47:04.426626581Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3348008648796742": {
+				"ID":          3348008648796742,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7832544745057696,
+				"StableID":   "nscDqnfNA421CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       7832544745057696,
+				"Key":        "nodekey:737ef157cd230d1806f33953b3843f8b7715755c6bfa83c275816164b8a25834",
+				"DiscoKey":   "discokey:3551f1d7230efc5ecd963a911988a230162630c2bfe46c9dfe48c22fdeb3ee58",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53908",
+					"10.65.0.27:53908",
+					"172.17.0.1:53908",
+					"172.19.0.1:53908",
+					"172.20.0.1:53908"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:46:58.777040016Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:737ef157cd230d1806f33953b3843f8b7715755c6bfa83c275816164b8a25834",
+			"MachineKey": "mkey:b1cad17e0adbb34d1207102a25599448329efbd8addc44857f8fb16a932a646e",
+			"Peers": [{
+				"ID":         3348008648796742,
+				"StableID":   "nhaUaaWK9T11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9ce76fb98a22982637f757b24fc9c2d81c97af4740221c838855d142831fe314",
+				"DiscoKey":   "discokey:a083c54b20dfa85d0422733253739ec17ebaa2dc3208357d4055bf70db465c7b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:39638",
+					"10.65.0.27:39638",
+					"172.17.0.1:39638",
+					"172.19.0.1:39638",
+					"172.20.0.1:39638"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:46:56.697652601Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7277465688330465,
+				"StableID":   "nGYJNdgypy11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:466556dd8919f60b82af055aa64d2bee39ebc43f63610450e45647ef54b4a623",
+				"DiscoKey":   "discokey:be1954a328b007c85d14895411305216b30e8b13206bca2991da58def584c86d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:41114",
+					"10.65.0.27:41114",
+					"172.17.0.1:41114",
+					"172.19.0.1:41114",
+					"172.20.0.1:41114"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:46:57.163827119Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7926432109370923,
+				"StableID":   "nkHPiyvtt421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb80b25b53d7846a3f55bfae2fc4af127e77667327c40440164c255a79781658",
+				"DiscoKey":   "discokey:70d3e62748f64e665af774d4db46d20783c347e9135570bbc5abdd66a971f410",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:50483",
+					"10.65.0.27:50483",
+					"172.17.0.1:50483",
+					"172.19.0.1:50483",
+					"172.20.0.1:50483"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:46:57.694750834Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6897754256649264,
+				"StableID":   "nbLoQrJ1sv11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51a6de329a6892b1f17379ad39a19bb0b91d455061f3f8708b1af69d85a0733c",
+				"DiscoKey":   "discokey:062c98854b4998886382a1cf2cc2505acee50a1fa997ae2104aba52cb3c21e5d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:32981",
+					"10.65.0.27:32981",
+					"172.17.0.1:32981",
+					"172.19.0.1:32981",
+					"172.20.0.1:32981"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:46:58.236702505Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         883772907534194,
+				"StableID":   "nMC3WWDGu711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:be7f53c951510fddf7ae55a32c1a7324d2d9e381c49c9ab5d585f1c0b3cedd3c",
+				"DiscoKey":   "discokey:97c40c9cc30190cbbb4f08b3a41c50138a946493164b7a0a1a5651a1b717554a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50488",
+					"10.65.0.27:50488",
+					"172.17.0.1:50488",
+					"172.19.0.1:50488",
+					"172.20.0.1:50488"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:46:59.311511755Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3533628427968141,
+				"StableID":   "nEFaqkRPbU11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4b4a7d05171111bf5fdb459aed82f78dcd9dfa8e834b4d3bd74dbf6b73dd833",
+				"DiscoKey":   "discokey:6db58249552caf4bfd881dc58405ddba40a60514dfb4a40e8cca49b92e528944",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52043",
+					"10.65.0.27:52043",
+					"172.17.0.1:52043",
+					"172.19.0.1:52043",
+					"172.20.0.1:52043"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:46:59.878449221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1899378406578201,
+				"StableID":   "n8k4g6TEqF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a2eff8e0bc4e94c33b13d949551b049359b84dc23fe47bd2e5d711fcf6e4e5f",
+				"DiscoKey":   "discokey:f72a2d1f05fb773f5f1841c5369ce19de6787ba216d6b1b812b7fde5e9bf7331",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:56545",
+					"10.65.0.27:56545",
+					"172.17.0.1:56545",
+					"172.19.0.1:56545",
+					"172.20.0.1:56545"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:47:00.414940937Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5783245827808651,
+				"StableID":   "n8bV1Z4FAn11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3cf0e0a8776f33dac88f65d95b89bb01fabd12fe85b9cff5cdc4e9c25648367e",
+				"DiscoKey":   "discokey:53d9458da519ea025e40e85fe1c9ec7e2fcb3c671bde7c6411b90452d163ba36",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42005",
+					"10.65.0.27:42005",
+					"172.17.0.1:42005",
+					"172.19.0.1:42005",
+					"172.20.0.1:42005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:47:00.928314278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         638830889127582,
+				"StableID":   "nVgi6F1Lz511CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f4c604bdb2bd0483229318ba9623e9914d77d340ce0d8fb53d35da2222f4b40b",
+				"DiscoKey":   "discokey:ad54059bbd58c2f5c3d87ebbd86cdf210f2784eaf80d3d64289ef134c2ae2e68",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33413",
+					"10.65.0.27:33413",
+					"172.17.0.1:33413",
+					"172.19.0.1:33413",
+					"172.20.0.1:33413"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:47:01.710836573Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8951108461894055,
+				"StableID":   "ngPW9aSytC21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d3ab64981f38116c09ebdbb3ed1fa5b8a21ba980e8aeba908a0d6fcff31b722b",
+				"DiscoKey":   "discokey:da6b63ed1872d5d7bd7d35c88cedd8367753a0e23412e3e16af506a7ae56785f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53724",
+					"10.65.0.27:53724",
+					"172.17.0.1:53724",
+					"172.19.0.1:53724",
+					"172.20.0.1:53724"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:47:02.247950824Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3148442288767369,
+				"StableID":   "nSR1jvEwaR11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f46b838a780d827b180d02d652f9e6f0e9ca828ad45d79cef3145fff06ad6306",
+				"DiscoKey":   "discokey:91777640d9c225e1651413963ff18bca51640d503d5c90fddfd95e1a6dc55d2d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47415",
+					"10.65.0.27:47415",
+					"172.17.0.1:47415",
+					"172.19.0.1:47415",
+					"172.20.0.1:47415"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:47:02.790158711Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2595963247498152,
+				"StableID":   "nDqvi3ZiGM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04d6bf29076c5b8c5c9bc3cab2cd03422984785540461d2089a1f8a1919bcc47",
+				"KeyExpiry":  "2026-11-08T18:47:03Z",
+				"DiscoKey":   "discokey:6f1b01e3c0e9f076f0c7e8af8424f4288284111b7a310ce6afc653f557e16407",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50469",
+					"10.65.0.27:50469",
+					"172.17.0.1:50469",
+					"172.19.0.1:50469",
+					"172.20.0.1:50469"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:47:03.341917671Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1778974702635585,
+				"StableID":   "n2fEfdehtE11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ce71f07116a10272bfafa69288c7bf13bd492b9f27dbbe049e98334a0d14f752",
+				"KeyExpiry":  "2026-11-08T18:47:03Z",
+				"DiscoKey":   "discokey:8a5ded2903d801f7d9f24b3f45d56ace02032b303f2a21160d48cca0709fee48",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57329",
+					"10.65.0.27:57329",
+					"172.17.0.1:57329",
+					"172.19.0.1:57329",
+					"172.20.0.1:57329"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:47:03.889124394Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         218017761311581,
+				"StableID":   "nCC21Wxjh211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f0e33f737aa39d978567b2ab54d02dc0910b58d411495da32ebd6973d68e863d",
+				"KeyExpiry":  "2026-11-08T18:47:04Z",
+				"DiscoKey":   "discokey:3e5631f7d39b6c03347fddc860af14295d4a6acf315f35446573f2a01fc03b62",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56846",
+					"10.65.0.27:56846",
+					"172.17.0.1:56846",
+					"172.19.0.1:56846",
+					"172.20.0.1:56846"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:47:04.426626581Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7832544745057696": {
+				"ID":          7832544745057696,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6897754256649264,
+				"StableID":   "nbLoQrJ1sv11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       6897754256649264,
+				"Key":        "nodekey:51a6de329a6892b1f17379ad39a19bb0b91d455061f3f8708b1af69d85a0733c",
+				"DiscoKey":   "discokey:062c98854b4998886382a1cf2cc2505acee50a1fa997ae2104aba52cb3c21e5d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:32981",
+					"10.65.0.27:32981",
+					"172.17.0.1:32981",
+					"172.19.0.1:32981",
+					"172.20.0.1:32981"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:46:58.236702505Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:51a6de329a6892b1f17379ad39a19bb0b91d455061f3f8708b1af69d85a0733c",
+			"MachineKey": "mkey:7fa87327ee683f38bee6a678adebe7659bad4320578953c84deb8f2c7929d448",
+			"Peers": [{
+				"ID":         3348008648796742,
+				"StableID":   "nhaUaaWK9T11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9ce76fb98a22982637f757b24fc9c2d81c97af4740221c838855d142831fe314",
+				"DiscoKey":   "discokey:a083c54b20dfa85d0422733253739ec17ebaa2dc3208357d4055bf70db465c7b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:39638",
+					"10.65.0.27:39638",
+					"172.17.0.1:39638",
+					"172.19.0.1:39638",
+					"172.20.0.1:39638"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:46:56.697652601Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7277465688330465,
+				"StableID":   "nGYJNdgypy11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:466556dd8919f60b82af055aa64d2bee39ebc43f63610450e45647ef54b4a623",
+				"DiscoKey":   "discokey:be1954a328b007c85d14895411305216b30e8b13206bca2991da58def584c86d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:41114",
+					"10.65.0.27:41114",
+					"172.17.0.1:41114",
+					"172.19.0.1:41114",
+					"172.20.0.1:41114"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:46:57.163827119Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7926432109370923,
+				"StableID":   "nkHPiyvtt421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb80b25b53d7846a3f55bfae2fc4af127e77667327c40440164c255a79781658",
+				"DiscoKey":   "discokey:70d3e62748f64e665af774d4db46d20783c347e9135570bbc5abdd66a971f410",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:50483",
+					"10.65.0.27:50483",
+					"172.17.0.1:50483",
+					"172.19.0.1:50483",
+					"172.20.0.1:50483"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:46:57.694750834Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7832544745057696,
+				"StableID":   "nscDqnfNA421CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:737ef157cd230d1806f33953b3843f8b7715755c6bfa83c275816164b8a25834",
+				"DiscoKey":   "discokey:3551f1d7230efc5ecd963a911988a230162630c2bfe46c9dfe48c22fdeb3ee58",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53908",
+					"10.65.0.27:53908",
+					"172.17.0.1:53908",
+					"172.19.0.1:53908",
+					"172.20.0.1:53908"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:46:58.777040016Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         883772907534194,
+				"StableID":   "nMC3WWDGu711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:be7f53c951510fddf7ae55a32c1a7324d2d9e381c49c9ab5d585f1c0b3cedd3c",
+				"DiscoKey":   "discokey:97c40c9cc30190cbbb4f08b3a41c50138a946493164b7a0a1a5651a1b717554a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50488",
+					"10.65.0.27:50488",
+					"172.17.0.1:50488",
+					"172.19.0.1:50488",
+					"172.20.0.1:50488"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:46:59.311511755Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3533628427968141,
+				"StableID":   "nEFaqkRPbU11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4b4a7d05171111bf5fdb459aed82f78dcd9dfa8e834b4d3bd74dbf6b73dd833",
+				"DiscoKey":   "discokey:6db58249552caf4bfd881dc58405ddba40a60514dfb4a40e8cca49b92e528944",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52043",
+					"10.65.0.27:52043",
+					"172.17.0.1:52043",
+					"172.19.0.1:52043",
+					"172.20.0.1:52043"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:46:59.878449221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1899378406578201,
+				"StableID":   "n8k4g6TEqF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a2eff8e0bc4e94c33b13d949551b049359b84dc23fe47bd2e5d711fcf6e4e5f",
+				"DiscoKey":   "discokey:f72a2d1f05fb773f5f1841c5369ce19de6787ba216d6b1b812b7fde5e9bf7331",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:56545",
+					"10.65.0.27:56545",
+					"172.17.0.1:56545",
+					"172.19.0.1:56545",
+					"172.20.0.1:56545"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:47:00.414940937Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5783245827808651,
+				"StableID":   "n8bV1Z4FAn11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3cf0e0a8776f33dac88f65d95b89bb01fabd12fe85b9cff5cdc4e9c25648367e",
+				"DiscoKey":   "discokey:53d9458da519ea025e40e85fe1c9ec7e2fcb3c671bde7c6411b90452d163ba36",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42005",
+					"10.65.0.27:42005",
+					"172.17.0.1:42005",
+					"172.19.0.1:42005",
+					"172.20.0.1:42005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:47:00.928314278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         638830889127582,
+				"StableID":   "nVgi6F1Lz511CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f4c604bdb2bd0483229318ba9623e9914d77d340ce0d8fb53d35da2222f4b40b",
+				"DiscoKey":   "discokey:ad54059bbd58c2f5c3d87ebbd86cdf210f2784eaf80d3d64289ef134c2ae2e68",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33413",
+					"10.65.0.27:33413",
+					"172.17.0.1:33413",
+					"172.19.0.1:33413",
+					"172.20.0.1:33413"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:47:01.710836573Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8951108461894055,
+				"StableID":   "ngPW9aSytC21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d3ab64981f38116c09ebdbb3ed1fa5b8a21ba980e8aeba908a0d6fcff31b722b",
+				"DiscoKey":   "discokey:da6b63ed1872d5d7bd7d35c88cedd8367753a0e23412e3e16af506a7ae56785f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53724",
+					"10.65.0.27:53724",
+					"172.17.0.1:53724",
+					"172.19.0.1:53724",
+					"172.20.0.1:53724"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:47:02.247950824Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3148442288767369,
+				"StableID":   "nSR1jvEwaR11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f46b838a780d827b180d02d652f9e6f0e9ca828ad45d79cef3145fff06ad6306",
+				"DiscoKey":   "discokey:91777640d9c225e1651413963ff18bca51640d503d5c90fddfd95e1a6dc55d2d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47415",
+					"10.65.0.27:47415",
+					"172.17.0.1:47415",
+					"172.19.0.1:47415",
+					"172.20.0.1:47415"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:47:02.790158711Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2595963247498152,
+				"StableID":   "nDqvi3ZiGM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04d6bf29076c5b8c5c9bc3cab2cd03422984785540461d2089a1f8a1919bcc47",
+				"KeyExpiry":  "2026-11-08T18:47:03Z",
+				"DiscoKey":   "discokey:6f1b01e3c0e9f076f0c7e8af8424f4288284111b7a310ce6afc653f557e16407",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50469",
+					"10.65.0.27:50469",
+					"172.17.0.1:50469",
+					"172.19.0.1:50469",
+					"172.20.0.1:50469"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:47:03.341917671Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1778974702635585,
+				"StableID":   "n2fEfdehtE11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ce71f07116a10272bfafa69288c7bf13bd492b9f27dbbe049e98334a0d14f752",
+				"KeyExpiry":  "2026-11-08T18:47:03Z",
+				"DiscoKey":   "discokey:8a5ded2903d801f7d9f24b3f45d56ace02032b303f2a21160d48cca0709fee48",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57329",
+					"10.65.0.27:57329",
+					"172.17.0.1:57329",
+					"172.19.0.1:57329",
+					"172.20.0.1:57329"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:47:03.889124394Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         218017761311581,
+				"StableID":   "nCC21Wxjh211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f0e33f737aa39d978567b2ab54d02dc0910b58d411495da32ebd6973d68e863d",
+				"KeyExpiry":  "2026-11-08T18:47:04Z",
+				"DiscoKey":   "discokey:3e5631f7d39b6c03347fddc860af14295d4a6acf315f35446573f2a01fc03b62",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56846",
+					"10.65.0.27:56846",
+					"172.17.0.1:56846",
+					"172.19.0.1:56846",
+					"172.20.0.1:56846"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:47:04.426626581Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6897754256649264": {
+				"ID":          6897754256649264,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3533628427968141,
+				"StableID":   "nEFaqkRPbU11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       3533628427968141,
+				"Key":        "nodekey:c4b4a7d05171111bf5fdb459aed82f78dcd9dfa8e834b4d3bd74dbf6b73dd833",
+				"DiscoKey":   "discokey:6db58249552caf4bfd881dc58405ddba40a60514dfb4a40e8cca49b92e528944",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52043",
+					"10.65.0.27:52043",
+					"172.17.0.1:52043",
+					"172.19.0.1:52043",
+					"172.20.0.1:52043"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:46:59.878449221Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c4b4a7d05171111bf5fdb459aed82f78dcd9dfa8e834b4d3bd74dbf6b73dd833",
+			"MachineKey": "mkey:035a32029c100d6197ff35dd029d688b535006c4afae974313510bbe8b3ca018",
+			"Peers": [{
+				"ID":         3348008648796742,
+				"StableID":   "nhaUaaWK9T11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9ce76fb98a22982637f757b24fc9c2d81c97af4740221c838855d142831fe314",
+				"DiscoKey":   "discokey:a083c54b20dfa85d0422733253739ec17ebaa2dc3208357d4055bf70db465c7b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:39638",
+					"10.65.0.27:39638",
+					"172.17.0.1:39638",
+					"172.19.0.1:39638",
+					"172.20.0.1:39638"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:46:56.697652601Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7277465688330465,
+				"StableID":   "nGYJNdgypy11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:466556dd8919f60b82af055aa64d2bee39ebc43f63610450e45647ef54b4a623",
+				"DiscoKey":   "discokey:be1954a328b007c85d14895411305216b30e8b13206bca2991da58def584c86d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:41114",
+					"10.65.0.27:41114",
+					"172.17.0.1:41114",
+					"172.19.0.1:41114",
+					"172.20.0.1:41114"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:46:57.163827119Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7926432109370923,
+				"StableID":   "nkHPiyvtt421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb80b25b53d7846a3f55bfae2fc4af127e77667327c40440164c255a79781658",
+				"DiscoKey":   "discokey:70d3e62748f64e665af774d4db46d20783c347e9135570bbc5abdd66a971f410",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:50483",
+					"10.65.0.27:50483",
+					"172.17.0.1:50483",
+					"172.19.0.1:50483",
+					"172.20.0.1:50483"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:46:57.694750834Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6897754256649264,
+				"StableID":   "nbLoQrJ1sv11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51a6de329a6892b1f17379ad39a19bb0b91d455061f3f8708b1af69d85a0733c",
+				"DiscoKey":   "discokey:062c98854b4998886382a1cf2cc2505acee50a1fa997ae2104aba52cb3c21e5d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:32981",
+					"10.65.0.27:32981",
+					"172.17.0.1:32981",
+					"172.19.0.1:32981",
+					"172.20.0.1:32981"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:46:58.236702505Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7832544745057696,
+				"StableID":   "nscDqnfNA421CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:737ef157cd230d1806f33953b3843f8b7715755c6bfa83c275816164b8a25834",
+				"DiscoKey":   "discokey:3551f1d7230efc5ecd963a911988a230162630c2bfe46c9dfe48c22fdeb3ee58",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53908",
+					"10.65.0.27:53908",
+					"172.17.0.1:53908",
+					"172.19.0.1:53908",
+					"172.20.0.1:53908"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:46:58.777040016Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         883772907534194,
+				"StableID":   "nMC3WWDGu711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:be7f53c951510fddf7ae55a32c1a7324d2d9e381c49c9ab5d585f1c0b3cedd3c",
+				"DiscoKey":   "discokey:97c40c9cc30190cbbb4f08b3a41c50138a946493164b7a0a1a5651a1b717554a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50488",
+					"10.65.0.27:50488",
+					"172.17.0.1:50488",
+					"172.19.0.1:50488",
+					"172.20.0.1:50488"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:46:59.311511755Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1899378406578201,
+				"StableID":   "n8k4g6TEqF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a2eff8e0bc4e94c33b13d949551b049359b84dc23fe47bd2e5d711fcf6e4e5f",
+				"DiscoKey":   "discokey:f72a2d1f05fb773f5f1841c5369ce19de6787ba216d6b1b812b7fde5e9bf7331",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:56545",
+					"10.65.0.27:56545",
+					"172.17.0.1:56545",
+					"172.19.0.1:56545",
+					"172.20.0.1:56545"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:47:00.414940937Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5783245827808651,
+				"StableID":   "n8bV1Z4FAn11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3cf0e0a8776f33dac88f65d95b89bb01fabd12fe85b9cff5cdc4e9c25648367e",
+				"DiscoKey":   "discokey:53d9458da519ea025e40e85fe1c9ec7e2fcb3c671bde7c6411b90452d163ba36",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42005",
+					"10.65.0.27:42005",
+					"172.17.0.1:42005",
+					"172.19.0.1:42005",
+					"172.20.0.1:42005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:47:00.928314278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         638830889127582,
+				"StableID":   "nVgi6F1Lz511CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f4c604bdb2bd0483229318ba9623e9914d77d340ce0d8fb53d35da2222f4b40b",
+				"DiscoKey":   "discokey:ad54059bbd58c2f5c3d87ebbd86cdf210f2784eaf80d3d64289ef134c2ae2e68",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33413",
+					"10.65.0.27:33413",
+					"172.17.0.1:33413",
+					"172.19.0.1:33413",
+					"172.20.0.1:33413"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:47:01.710836573Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8951108461894055,
+				"StableID":   "ngPW9aSytC21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d3ab64981f38116c09ebdbb3ed1fa5b8a21ba980e8aeba908a0d6fcff31b722b",
+				"DiscoKey":   "discokey:da6b63ed1872d5d7bd7d35c88cedd8367753a0e23412e3e16af506a7ae56785f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53724",
+					"10.65.0.27:53724",
+					"172.17.0.1:53724",
+					"172.19.0.1:53724",
+					"172.20.0.1:53724"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:47:02.247950824Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3148442288767369,
+				"StableID":   "nSR1jvEwaR11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f46b838a780d827b180d02d652f9e6f0e9ca828ad45d79cef3145fff06ad6306",
+				"DiscoKey":   "discokey:91777640d9c225e1651413963ff18bca51640d503d5c90fddfd95e1a6dc55d2d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47415",
+					"10.65.0.27:47415",
+					"172.17.0.1:47415",
+					"172.19.0.1:47415",
+					"172.20.0.1:47415"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:47:02.790158711Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2595963247498152,
+				"StableID":   "nDqvi3ZiGM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04d6bf29076c5b8c5c9bc3cab2cd03422984785540461d2089a1f8a1919bcc47",
+				"KeyExpiry":  "2026-11-08T18:47:03Z",
+				"DiscoKey":   "discokey:6f1b01e3c0e9f076f0c7e8af8424f4288284111b7a310ce6afc653f557e16407",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50469",
+					"10.65.0.27:50469",
+					"172.17.0.1:50469",
+					"172.19.0.1:50469",
+					"172.20.0.1:50469"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:47:03.341917671Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1778974702635585,
+				"StableID":   "n2fEfdehtE11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ce71f07116a10272bfafa69288c7bf13bd492b9f27dbbe049e98334a0d14f752",
+				"KeyExpiry":  "2026-11-08T18:47:03Z",
+				"DiscoKey":   "discokey:8a5ded2903d801f7d9f24b3f45d56ace02032b303f2a21160d48cca0709fee48",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57329",
+					"10.65.0.27:57329",
+					"172.17.0.1:57329",
+					"172.19.0.1:57329",
+					"172.20.0.1:57329"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:47:03.889124394Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         218017761311581,
+				"StableID":   "nCC21Wxjh211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f0e33f737aa39d978567b2ab54d02dc0910b58d411495da32ebd6973d68e863d",
+				"KeyExpiry":  "2026-11-08T18:47:04Z",
+				"DiscoKey":   "discokey:3e5631f7d39b6c03347fddc860af14295d4a6acf315f35446573f2a01fc03b62",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56846",
+					"10.65.0.27:56846",
+					"172.17.0.1:56846",
+					"172.19.0.1:56846",
+					"172.20.0.1:56846"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:47:04.426626581Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3533628427968141": {
+				"ID":          3533628427968141,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5783245827808651,
+				"StableID":   "n8bV1Z4FAn11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       5783245827808651,
+				"Key":        "nodekey:3cf0e0a8776f33dac88f65d95b89bb01fabd12fe85b9cff5cdc4e9c25648367e",
+				"DiscoKey":   "discokey:53d9458da519ea025e40e85fe1c9ec7e2fcb3c671bde7c6411b90452d163ba36",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42005",
+					"10.65.0.27:42005",
+					"172.17.0.1:42005",
+					"172.19.0.1:42005",
+					"172.20.0.1:42005"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:47:00.928314278Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3cf0e0a8776f33dac88f65d95b89bb01fabd12fe85b9cff5cdc4e9c25648367e",
+			"MachineKey": "mkey:99b4171b3bee6f066974fca55b0e8902b07d7947b734b20ec924a149c375dd66",
+			"Peers": [{
+				"ID":         3348008648796742,
+				"StableID":   "nhaUaaWK9T11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9ce76fb98a22982637f757b24fc9c2d81c97af4740221c838855d142831fe314",
+				"DiscoKey":   "discokey:a083c54b20dfa85d0422733253739ec17ebaa2dc3208357d4055bf70db465c7b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:39638",
+					"10.65.0.27:39638",
+					"172.17.0.1:39638",
+					"172.19.0.1:39638",
+					"172.20.0.1:39638"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:46:56.697652601Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7277465688330465,
+				"StableID":   "nGYJNdgypy11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:466556dd8919f60b82af055aa64d2bee39ebc43f63610450e45647ef54b4a623",
+				"DiscoKey":   "discokey:be1954a328b007c85d14895411305216b30e8b13206bca2991da58def584c86d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:41114",
+					"10.65.0.27:41114",
+					"172.17.0.1:41114",
+					"172.19.0.1:41114",
+					"172.20.0.1:41114"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:46:57.163827119Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7926432109370923,
+				"StableID":   "nkHPiyvtt421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb80b25b53d7846a3f55bfae2fc4af127e77667327c40440164c255a79781658",
+				"DiscoKey":   "discokey:70d3e62748f64e665af774d4db46d20783c347e9135570bbc5abdd66a971f410",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:50483",
+					"10.65.0.27:50483",
+					"172.17.0.1:50483",
+					"172.19.0.1:50483",
+					"172.20.0.1:50483"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:46:57.694750834Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6897754256649264,
+				"StableID":   "nbLoQrJ1sv11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51a6de329a6892b1f17379ad39a19bb0b91d455061f3f8708b1af69d85a0733c",
+				"DiscoKey":   "discokey:062c98854b4998886382a1cf2cc2505acee50a1fa997ae2104aba52cb3c21e5d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:32981",
+					"10.65.0.27:32981",
+					"172.17.0.1:32981",
+					"172.19.0.1:32981",
+					"172.20.0.1:32981"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:46:58.236702505Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7832544745057696,
+				"StableID":   "nscDqnfNA421CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:737ef157cd230d1806f33953b3843f8b7715755c6bfa83c275816164b8a25834",
+				"DiscoKey":   "discokey:3551f1d7230efc5ecd963a911988a230162630c2bfe46c9dfe48c22fdeb3ee58",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53908",
+					"10.65.0.27:53908",
+					"172.17.0.1:53908",
+					"172.19.0.1:53908",
+					"172.20.0.1:53908"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:46:58.777040016Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         883772907534194,
+				"StableID":   "nMC3WWDGu711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:be7f53c951510fddf7ae55a32c1a7324d2d9e381c49c9ab5d585f1c0b3cedd3c",
+				"DiscoKey":   "discokey:97c40c9cc30190cbbb4f08b3a41c50138a946493164b7a0a1a5651a1b717554a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50488",
+					"10.65.0.27:50488",
+					"172.17.0.1:50488",
+					"172.19.0.1:50488",
+					"172.20.0.1:50488"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:46:59.311511755Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3533628427968141,
+				"StableID":   "nEFaqkRPbU11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4b4a7d05171111bf5fdb459aed82f78dcd9dfa8e834b4d3bd74dbf6b73dd833",
+				"DiscoKey":   "discokey:6db58249552caf4bfd881dc58405ddba40a60514dfb4a40e8cca49b92e528944",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52043",
+					"10.65.0.27:52043",
+					"172.17.0.1:52043",
+					"172.19.0.1:52043",
+					"172.20.0.1:52043"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:46:59.878449221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1899378406578201,
+				"StableID":   "n8k4g6TEqF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a2eff8e0bc4e94c33b13d949551b049359b84dc23fe47bd2e5d711fcf6e4e5f",
+				"DiscoKey":   "discokey:f72a2d1f05fb773f5f1841c5369ce19de6787ba216d6b1b812b7fde5e9bf7331",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:56545",
+					"10.65.0.27:56545",
+					"172.17.0.1:56545",
+					"172.19.0.1:56545",
+					"172.20.0.1:56545"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:47:00.414940937Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         638830889127582,
+				"StableID":   "nVgi6F1Lz511CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f4c604bdb2bd0483229318ba9623e9914d77d340ce0d8fb53d35da2222f4b40b",
+				"DiscoKey":   "discokey:ad54059bbd58c2f5c3d87ebbd86cdf210f2784eaf80d3d64289ef134c2ae2e68",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33413",
+					"10.65.0.27:33413",
+					"172.17.0.1:33413",
+					"172.19.0.1:33413",
+					"172.20.0.1:33413"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:47:01.710836573Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8951108461894055,
+				"StableID":   "ngPW9aSytC21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d3ab64981f38116c09ebdbb3ed1fa5b8a21ba980e8aeba908a0d6fcff31b722b",
+				"DiscoKey":   "discokey:da6b63ed1872d5d7bd7d35c88cedd8367753a0e23412e3e16af506a7ae56785f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53724",
+					"10.65.0.27:53724",
+					"172.17.0.1:53724",
+					"172.19.0.1:53724",
+					"172.20.0.1:53724"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:47:02.247950824Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3148442288767369,
+				"StableID":   "nSR1jvEwaR11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f46b838a780d827b180d02d652f9e6f0e9ca828ad45d79cef3145fff06ad6306",
+				"DiscoKey":   "discokey:91777640d9c225e1651413963ff18bca51640d503d5c90fddfd95e1a6dc55d2d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47415",
+					"10.65.0.27:47415",
+					"172.17.0.1:47415",
+					"172.19.0.1:47415",
+					"172.20.0.1:47415"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:47:02.790158711Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2595963247498152,
+				"StableID":   "nDqvi3ZiGM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04d6bf29076c5b8c5c9bc3cab2cd03422984785540461d2089a1f8a1919bcc47",
+				"KeyExpiry":  "2026-11-08T18:47:03Z",
+				"DiscoKey":   "discokey:6f1b01e3c0e9f076f0c7e8af8424f4288284111b7a310ce6afc653f557e16407",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50469",
+					"10.65.0.27:50469",
+					"172.17.0.1:50469",
+					"172.19.0.1:50469",
+					"172.20.0.1:50469"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:47:03.341917671Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1778974702635585,
+				"StableID":   "n2fEfdehtE11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ce71f07116a10272bfafa69288c7bf13bd492b9f27dbbe049e98334a0d14f752",
+				"KeyExpiry":  "2026-11-08T18:47:03Z",
+				"DiscoKey":   "discokey:8a5ded2903d801f7d9f24b3f45d56ace02032b303f2a21160d48cca0709fee48",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57329",
+					"10.65.0.27:57329",
+					"172.17.0.1:57329",
+					"172.19.0.1:57329",
+					"172.20.0.1:57329"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:47:03.889124394Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         218017761311581,
+				"StableID":   "nCC21Wxjh211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f0e33f737aa39d978567b2ab54d02dc0910b58d411495da32ebd6973d68e863d",
+				"KeyExpiry":  "2026-11-08T18:47:04Z",
+				"DiscoKey":   "discokey:3e5631f7d39b6c03347fddc860af14295d4a6acf315f35446573f2a01fc03b62",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56846",
+					"10.65.0.27:56846",
+					"172.17.0.1:56846",
+					"172.19.0.1:56846",
+					"172.20.0.1:56846"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:47:04.426626581Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5783245827808651": {
+				"ID":          5783245827808651,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1778974702635585,
+				"StableID":   "n2fEfdehtE11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ce71f07116a10272bfafa69288c7bf13bd492b9f27dbbe049e98334a0d14f752",
+				"KeyExpiry":  "2026-11-08T18:47:03Z",
+				"DiscoKey":   "discokey:8a5ded2903d801f7d9f24b3f45d56ace02032b303f2a21160d48cca0709fee48",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57329",
+					"10.65.0.27:57329",
+					"172.17.0.1:57329",
+					"172.19.0.1:57329",
+					"172.20.0.1:57329"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:47:03.889124394Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ce71f07116a10272bfafa69288c7bf13bd492b9f27dbbe049e98334a0d14f752",
+			"MachineKey": "mkey:24488a26e257620d4deaa96641e2096007c86297880c69b175dfb8d5029d352d",
+			"Peers": [{
+				"ID":         3348008648796742,
+				"StableID":   "nhaUaaWK9T11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9ce76fb98a22982637f757b24fc9c2d81c97af4740221c838855d142831fe314",
+				"DiscoKey":   "discokey:a083c54b20dfa85d0422733253739ec17ebaa2dc3208357d4055bf70db465c7b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:39638",
+					"10.65.0.27:39638",
+					"172.17.0.1:39638",
+					"172.19.0.1:39638",
+					"172.20.0.1:39638"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:46:56.697652601Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7277465688330465,
+				"StableID":   "nGYJNdgypy11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:466556dd8919f60b82af055aa64d2bee39ebc43f63610450e45647ef54b4a623",
+				"DiscoKey":   "discokey:be1954a328b007c85d14895411305216b30e8b13206bca2991da58def584c86d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:41114",
+					"10.65.0.27:41114",
+					"172.17.0.1:41114",
+					"172.19.0.1:41114",
+					"172.20.0.1:41114"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:46:57.163827119Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7926432109370923,
+				"StableID":   "nkHPiyvtt421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb80b25b53d7846a3f55bfae2fc4af127e77667327c40440164c255a79781658",
+				"DiscoKey":   "discokey:70d3e62748f64e665af774d4db46d20783c347e9135570bbc5abdd66a971f410",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:50483",
+					"10.65.0.27:50483",
+					"172.17.0.1:50483",
+					"172.19.0.1:50483",
+					"172.20.0.1:50483"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:46:57.694750834Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6897754256649264,
+				"StableID":   "nbLoQrJ1sv11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51a6de329a6892b1f17379ad39a19bb0b91d455061f3f8708b1af69d85a0733c",
+				"DiscoKey":   "discokey:062c98854b4998886382a1cf2cc2505acee50a1fa997ae2104aba52cb3c21e5d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:32981",
+					"10.65.0.27:32981",
+					"172.17.0.1:32981",
+					"172.19.0.1:32981",
+					"172.20.0.1:32981"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:46:58.236702505Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7832544745057696,
+				"StableID":   "nscDqnfNA421CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:737ef157cd230d1806f33953b3843f8b7715755c6bfa83c275816164b8a25834",
+				"DiscoKey":   "discokey:3551f1d7230efc5ecd963a911988a230162630c2bfe46c9dfe48c22fdeb3ee58",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53908",
+					"10.65.0.27:53908",
+					"172.17.0.1:53908",
+					"172.19.0.1:53908",
+					"172.20.0.1:53908"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:46:58.777040016Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         883772907534194,
+				"StableID":   "nMC3WWDGu711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:be7f53c951510fddf7ae55a32c1a7324d2d9e381c49c9ab5d585f1c0b3cedd3c",
+				"DiscoKey":   "discokey:97c40c9cc30190cbbb4f08b3a41c50138a946493164b7a0a1a5651a1b717554a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50488",
+					"10.65.0.27:50488",
+					"172.17.0.1:50488",
+					"172.19.0.1:50488",
+					"172.20.0.1:50488"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:46:59.311511755Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3533628427968141,
+				"StableID":   "nEFaqkRPbU11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4b4a7d05171111bf5fdb459aed82f78dcd9dfa8e834b4d3bd74dbf6b73dd833",
+				"DiscoKey":   "discokey:6db58249552caf4bfd881dc58405ddba40a60514dfb4a40e8cca49b92e528944",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52043",
+					"10.65.0.27:52043",
+					"172.17.0.1:52043",
+					"172.19.0.1:52043",
+					"172.20.0.1:52043"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:46:59.878449221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1899378406578201,
+				"StableID":   "n8k4g6TEqF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a2eff8e0bc4e94c33b13d949551b049359b84dc23fe47bd2e5d711fcf6e4e5f",
+				"DiscoKey":   "discokey:f72a2d1f05fb773f5f1841c5369ce19de6787ba216d6b1b812b7fde5e9bf7331",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:56545",
+					"10.65.0.27:56545",
+					"172.17.0.1:56545",
+					"172.19.0.1:56545",
+					"172.20.0.1:56545"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:47:00.414940937Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5783245827808651,
+				"StableID":   "n8bV1Z4FAn11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3cf0e0a8776f33dac88f65d95b89bb01fabd12fe85b9cff5cdc4e9c25648367e",
+				"DiscoKey":   "discokey:53d9458da519ea025e40e85fe1c9ec7e2fcb3c671bde7c6411b90452d163ba36",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42005",
+					"10.65.0.27:42005",
+					"172.17.0.1:42005",
+					"172.19.0.1:42005",
+					"172.20.0.1:42005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:47:00.928314278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         638830889127582,
+				"StableID":   "nVgi6F1Lz511CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f4c604bdb2bd0483229318ba9623e9914d77d340ce0d8fb53d35da2222f4b40b",
+				"DiscoKey":   "discokey:ad54059bbd58c2f5c3d87ebbd86cdf210f2784eaf80d3d64289ef134c2ae2e68",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33413",
+					"10.65.0.27:33413",
+					"172.17.0.1:33413",
+					"172.19.0.1:33413",
+					"172.20.0.1:33413"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:47:01.710836573Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8951108461894055,
+				"StableID":   "ngPW9aSytC21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d3ab64981f38116c09ebdbb3ed1fa5b8a21ba980e8aeba908a0d6fcff31b722b",
+				"DiscoKey":   "discokey:da6b63ed1872d5d7bd7d35c88cedd8367753a0e23412e3e16af506a7ae56785f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53724",
+					"10.65.0.27:53724",
+					"172.17.0.1:53724",
+					"172.19.0.1:53724",
+					"172.20.0.1:53724"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:47:02.247950824Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3148442288767369,
+				"StableID":   "nSR1jvEwaR11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f46b838a780d827b180d02d652f9e6f0e9ca828ad45d79cef3145fff06ad6306",
+				"DiscoKey":   "discokey:91777640d9c225e1651413963ff18bca51640d503d5c90fddfd95e1a6dc55d2d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47415",
+					"10.65.0.27:47415",
+					"172.17.0.1:47415",
+					"172.19.0.1:47415",
+					"172.20.0.1:47415"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:47:02.790158711Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2595963247498152,
+				"StableID":   "nDqvi3ZiGM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04d6bf29076c5b8c5c9bc3cab2cd03422984785540461d2089a1f8a1919bcc47",
+				"KeyExpiry":  "2026-11-08T18:47:03Z",
+				"DiscoKey":   "discokey:6f1b01e3c0e9f076f0c7e8af8424f4288284111b7a310ce6afc653f557e16407",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50469",
+					"10.65.0.27:50469",
+					"172.17.0.1:50469",
+					"172.19.0.1:50469",
+					"172.20.0.1:50469"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:47:03.341917671Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         218017761311581,
+				"StableID":   "nCC21Wxjh211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f0e33f737aa39d978567b2ab54d02dc0910b58d411495da32ebd6973d68e863d",
+				"KeyExpiry":  "2026-11-08T18:47:04Z",
+				"DiscoKey":   "discokey:3e5631f7d39b6c03347fddc860af14295d4a6acf315f35446573f2a01fc03b62",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56846",
+					"10.65.0.27:56846",
+					"172.17.0.1:56846",
+					"172.19.0.1:56846",
+					"172.20.0.1:56846"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:47:04.426626581Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         638830889127582,
+				"StableID":   "nVgi6F1Lz511CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       638830889127582,
+				"Key":        "nodekey:f4c604bdb2bd0483229318ba9623e9914d77d340ce0d8fb53d35da2222f4b40b",
+				"DiscoKey":   "discokey:ad54059bbd58c2f5c3d87ebbd86cdf210f2784eaf80d3d64289ef134c2ae2e68",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:33413",
+					"10.65.0.27:33413",
+					"172.17.0.1:33413",
+					"172.19.0.1:33413",
+					"172.20.0.1:33413"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:47:01.710836573Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f4c604bdb2bd0483229318ba9623e9914d77d340ce0d8fb53d35da2222f4b40b",
+			"MachineKey": "mkey:2d79da77567f3d040f1e8835e8f841f1a9e77f5df506a7fb4670fa1e037ef55d",
+			"Peers": [{
+				"ID":         3348008648796742,
+				"StableID":   "nhaUaaWK9T11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9ce76fb98a22982637f757b24fc9c2d81c97af4740221c838855d142831fe314",
+				"DiscoKey":   "discokey:a083c54b20dfa85d0422733253739ec17ebaa2dc3208357d4055bf70db465c7b",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:39638",
+					"10.65.0.27:39638",
+					"172.17.0.1:39638",
+					"172.19.0.1:39638",
+					"172.20.0.1:39638"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:46:56.697652601Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7277465688330465,
+				"StableID":   "nGYJNdgypy11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:466556dd8919f60b82af055aa64d2bee39ebc43f63610450e45647ef54b4a623",
+				"DiscoKey":   "discokey:be1954a328b007c85d14895411305216b30e8b13206bca2991da58def584c86d",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:41114",
+					"10.65.0.27:41114",
+					"172.17.0.1:41114",
+					"172.19.0.1:41114",
+					"172.20.0.1:41114"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:46:57.163827119Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7926432109370923,
+				"StableID":   "nkHPiyvtt421CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb80b25b53d7846a3f55bfae2fc4af127e77667327c40440164c255a79781658",
+				"DiscoKey":   "discokey:70d3e62748f64e665af774d4db46d20783c347e9135570bbc5abdd66a971f410",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:50483",
+					"10.65.0.27:50483",
+					"172.17.0.1:50483",
+					"172.19.0.1:50483",
+					"172.20.0.1:50483"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:46:57.694750834Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6897754256649264,
+				"StableID":   "nbLoQrJ1sv11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:51a6de329a6892b1f17379ad39a19bb0b91d455061f3f8708b1af69d85a0733c",
+				"DiscoKey":   "discokey:062c98854b4998886382a1cf2cc2505acee50a1fa997ae2104aba52cb3c21e5d",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:32981",
+					"10.65.0.27:32981",
+					"172.17.0.1:32981",
+					"172.19.0.1:32981",
+					"172.20.0.1:32981"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:46:58.236702505Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7832544745057696,
+				"StableID":   "nscDqnfNA421CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:737ef157cd230d1806f33953b3843f8b7715755c6bfa83c275816164b8a25834",
+				"DiscoKey":   "discokey:3551f1d7230efc5ecd963a911988a230162630c2bfe46c9dfe48c22fdeb3ee58",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:53908",
+					"10.65.0.27:53908",
+					"172.17.0.1:53908",
+					"172.19.0.1:53908",
+					"172.20.0.1:53908"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:46:58.777040016Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         883772907534194,
+				"StableID":   "nMC3WWDGu711CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:be7f53c951510fddf7ae55a32c1a7324d2d9e381c49c9ab5d585f1c0b3cedd3c",
+				"DiscoKey":   "discokey:97c40c9cc30190cbbb4f08b3a41c50138a946493164b7a0a1a5651a1b717554a",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:50488",
+					"10.65.0.27:50488",
+					"172.17.0.1:50488",
+					"172.19.0.1:50488",
+					"172.20.0.1:50488"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:46:59.311511755Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3533628427968141,
+				"StableID":   "nEFaqkRPbU11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c4b4a7d05171111bf5fdb459aed82f78dcd9dfa8e834b4d3bd74dbf6b73dd833",
+				"DiscoKey":   "discokey:6db58249552caf4bfd881dc58405ddba40a60514dfb4a40e8cca49b92e528944",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:52043",
+					"10.65.0.27:52043",
+					"172.17.0.1:52043",
+					"172.19.0.1:52043",
+					"172.20.0.1:52043"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:46:59.878449221Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1899378406578201,
+				"StableID":   "n8k4g6TEqF11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a2eff8e0bc4e94c33b13d949551b049359b84dc23fe47bd2e5d711fcf6e4e5f",
+				"DiscoKey":   "discokey:f72a2d1f05fb773f5f1841c5369ce19de6787ba216d6b1b812b7fde5e9bf7331",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:56545",
+					"10.65.0.27:56545",
+					"172.17.0.1:56545",
+					"172.19.0.1:56545",
+					"172.20.0.1:56545"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:47:00.414940937Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5783245827808651,
+				"StableID":   "n8bV1Z4FAn11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:3cf0e0a8776f33dac88f65d95b89bb01fabd12fe85b9cff5cdc4e9c25648367e",
+				"DiscoKey":   "discokey:53d9458da519ea025e40e85fe1c9ec7e2fcb3c671bde7c6411b90452d163ba36",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:42005",
+					"10.65.0.27:42005",
+					"172.17.0.1:42005",
+					"172.19.0.1:42005",
+					"172.20.0.1:42005"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:47:00.928314278Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8951108461894055,
+				"StableID":   "ngPW9aSytC21CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d3ab64981f38116c09ebdbb3ed1fa5b8a21ba980e8aeba908a0d6fcff31b722b",
+				"DiscoKey":   "discokey:da6b63ed1872d5d7bd7d35c88cedd8367753a0e23412e3e16af506a7ae56785f",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:53724",
+					"10.65.0.27:53724",
+					"172.17.0.1:53724",
+					"172.19.0.1:53724",
+					"172.20.0.1:53724"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:47:02.247950824Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         3148442288767369,
+				"StableID":   "nSR1jvEwaR11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f46b838a780d827b180d02d652f9e6f0e9ca828ad45d79cef3145fff06ad6306",
+				"DiscoKey":   "discokey:91777640d9c225e1651413963ff18bca51640d503d5c90fddfd95e1a6dc55d2d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:47415",
+					"10.65.0.27:47415",
+					"172.17.0.1:47415",
+					"172.19.0.1:47415",
+					"172.20.0.1:47415"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:47:02.790158711Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2595963247498152,
+				"StableID":   "nDqvi3ZiGM11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04d6bf29076c5b8c5c9bc3cab2cd03422984785540461d2089a1f8a1919bcc47",
+				"KeyExpiry":  "2026-11-08T18:47:03Z",
+				"DiscoKey":   "discokey:6f1b01e3c0e9f076f0c7e8af8424f4288284111b7a310ce6afc653f557e16407",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:50469",
+					"10.65.0.27:50469",
+					"172.17.0.1:50469",
+					"172.19.0.1:50469",
+					"172.20.0.1:50469"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:47:03.341917671Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1778974702635585,
+				"StableID":   "n2fEfdehtE11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ce71f07116a10272bfafa69288c7bf13bd492b9f27dbbe049e98334a0d14f752",
+				"KeyExpiry":  "2026-11-08T18:47:03Z",
+				"DiscoKey":   "discokey:8a5ded2903d801f7d9f24b3f45d56ace02032b303f2a21160d48cca0709fee48",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:57329",
+					"10.65.0.27:57329",
+					"172.17.0.1:57329",
+					"172.19.0.1:57329",
+					"172.20.0.1:57329"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:47:03.889124394Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         218017761311581,
+				"StableID":   "nCC21Wxjh211CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f0e33f737aa39d978567b2ab54d02dc0910b58d411495da32ebd6973d68e863d",
+				"KeyExpiry":  "2026-11-08T18:47:04Z",
+				"DiscoKey":   "discokey:3e5631f7d39b6c03347fddc860af14295d4a6acf315f35446573f2a01fc03b62",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:56846",
+					"10.65.0.27:56846",
+					"172.17.0.1:56846",
+					"172.19.0.1:56846",
+					"172.20.0.1:56846"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:47:04.426626581Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "638830889127582": {
+				"ID":          638830889127582,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/sshtest_results/sshtest-mixed-acls-tcp22-deny-ssh-rule-allow.hujson
+++ b/hscontrol/policy/v2/testdata/sshtest_results/sshtest-mixed-acls-tcp22-deny-ssh-rule-allow.hujson
@@ -1,0 +1,13556 @@
+// sshtest-mixed-acls-tcp22-deny-ssh-rule-allow
+//
+// acls deny tcp:22 but ssh rule allows, sshTests passes
+//
+// Nodes with filter rules: 1 of 15
+// Captured at:    2026-05-12T18:47:40Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "sshtest-mixed-acls-tcp22-deny-ssh-rule-allow",
+	"description":    "acls deny tcp:22 but ssh rule allows, sshTests passes",
+	"category":       "sshtest",
+	"captured_at":    "2026-05-12T18:47:40.401153043Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                               \n  \n                                                                        \n                                                                           \n{\n\t\"category\":    \"sshtest\",\n\t\"description\": \"acls deny tcp:22 but ssh rule allows, sshTests passes\",\n\t\"id\":          \"sshtest-mixed-acls-tcp22-deny-ssh-rule-allow\",\n\t\"policy\": {\"acls\": [\n\t\t{\"action\": \"accept\", \"dst\": [\"tag:prod:80\"], \"src\": [\"odin@example.com\"]}\n\t], \"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"thor@example.org\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"sshTests\": [{\n\t\t\"accept\": [\"root\"],\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    \"thor@example.org\"\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/sshtest/sshtest-mixed-acls-tcp22-deny-ssh-rule-allow.hujson",
+		"full_policy": {
+			"acls": [
+				{"action": "accept", "dst": ["tag:prod:80"], "src": ["odin@example.com"]}
+			],
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["thor@example.org"],
+				"users":  ["root"]
+			}],
+			"sshTests":  [{"accept": ["root"], "dst": ["tag:server"], "src": "thor@example.org"}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         2547478569649000,
+			"StableID":   "n76dmewktL11CNTRL",
+			"Name":       "beedrill.tail78f774.ts.net.",
+			"User":       2547478569649000,
+			"Key":        "nodekey:f5d07d4a151622b5792846c03f6b58dd8d47594d0e2c3e0b2d437ead87606012",
+			"DiscoKey":   "discokey:b90f2df10904d1f52bc0f1b01ddd5f2281262acf7f4aec647486c1b693054a7b",
+			"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"Endpoints": [
+				"77.164.248.136:57108",
+				"10.65.0.27:57108",
+				"172.17.0.1:57108",
+				"172.18.0.1:57108"
+			],
+			"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+				{"Proto": "peerapi4", "Port": 50358},
+				{"Proto": "peerapi6", "Port": 50358},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-12T18:47:48.62309849Z",
+			"Tags":              ["tag:server"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "beedrill",
+			"ComputedNameWithHost": "beedrill"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:f5d07d4a151622b5792846c03f6b58dd8d47594d0e2c3e0b2d437ead87606012",
+		"MachineKey":        "mkey:88e7e1a1909456520ab6f3e4a761060bb79150d7419e98acdaf0adfbc50a5561",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy": {"rules": [{
+			"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+			"sshUsers":   {"root": "root"},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}
+		}]},
+		"CollectServices": false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"2547478569649000": {
+			"ID":          2547478569649000,
+			"LoginName":   "beedrill.tail78f774.ts.net",
+			"DisplayName": "beedrill"
+		}}
+	}, "ssh_rules": [{
+		"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+		"sshUsers":   {"root": "root"},
+		"action": {
+			"accept":                    true,
+			"allowAgentForwarding":      true,
+			"allowLocalPortForwarding":  true,
+			"allowRemotePortForwarding": true
+		}
+	}]}, "blastoise": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         348197970656,
+			"StableID":   "nBec4W9A1111CNTRL",
+			"Name":       "blastoise.tail78f774.ts.net.",
+			"User":       348197970656,
+			"Key":        "nodekey:82edd06dd8a4fcc71c8d36c6c24cbc5f5304ce2887f80c705160fb80fa5c4478",
+			"DiscoKey":   "discokey:544f4c9fb90b4a7a8d23528320e799f3e51de054e40052806521da413d72e524",
+			"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+			"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+			"Endpoints": [
+				"77.164.248.136:60312",
+				"10.65.0.27:60312",
+				"172.17.0.1:60312",
+				"172.18.0.1:60312"
+			],
+			"Hostinfo": {
+				"Hostname":    "blastoise",
+				"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+				"RequestTags": ["tag:exit", "tag:router"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-12T18:47:45.427465647Z",
+			"Tags":              ["tag:exit", "tag:router"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "blastoise",
+			"ComputedNameWithHost": "blastoise"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:82edd06dd8a4fcc71c8d36c6c24cbc5f5304ce2887f80c705160fb80fa5c4478",
+		"MachineKey":        "mkey:3b2bffe0407c0d0b5168431517ad2f44ea5e4a8250c82cdde791c49a6475c85b",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"348197970656": {
+			"ID":          348197970656,
+			"LoginName":   "blastoise.tail78f774.ts.net",
+			"DisplayName": "blastoise"
+		}}
+	}}, "bulbasaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         2762149708911604,
+			"StableID":   "nXgsENzyZN11CNTRL",
+			"Name":       "bulbasaur.tail78f774.ts.net.",
+			"User":       4156223528223174,
+			"Key":        "nodekey:8fbded01d7aa458b7ba14a57b72b2d3b009d15f7bd5657f49acb2c35034acf64",
+			"KeyExpiry":  "2026-11-08T18:47:50Z",
+			"DiscoKey":   "discokey:848c589123bad5ec2261fa2e628429d22993ea71df645877fa0173430a3bf53e",
+			"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"Endpoints": [
+				"77.164.248.136:44764",
+				"10.65.0.27:44764",
+				"172.17.0.1:44764",
+				"172.18.0.1:44764"
+			],
+			"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+				{"Proto": "peerapi4", "Port": 38156},
+				{"Proto": "peerapi6", "Port": 38156},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-12T18:47:50.312756399Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "bulbasaur",
+			"ComputedNameWithHost": "bulbasaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:8fbded01d7aa458b7ba14a57b72b2d3b009d15f7bd5657f49acb2c35034acf64",
+		"MachineKey": "mkey:12fe501a05f4d252790e0c4b29322bd0cc8ec7dba14c7223517b39a08830ae23",
+		"Peers": [{
+			"ID":         2379236161083680,
+			"StableID":   "nR78FyVZaK11CNTRL",
+			"Name":       "kakuna.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:b2c6c7ab991451c04d7861e1a11237e405f368f81d23f9c3de9d003d389ca042",
+			"DiscoKey":   "discokey:d393e1efbf11639641024656bdc32f5ea6955c00df638a244182669434682436",
+			"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"Endpoints": [
+				"77.164.248.136:44168",
+				"10.65.0.27:44168",
+				"172.17.0.1:44168",
+				"172.18.0.1:44168"
+			],
+			"HomeDERP": 14,
+			"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+				{"Proto": "peerapi4", "Port": 51523},
+				{"Proto": "peerapi6", "Port": 51523}
+			]},
+			"Created":              "2026-05-12T18:47:48.102409503Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:prod"],
+			"Online":               true,
+			"ComputedName":         "kakuna",
+			"ComputedNameWithHost": "kakuna"
+		}],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1260082990019555": {
+			"ID":          1260082990019555,
+			"LoginName":   "tagged-devices",
+			"DisplayName": "Tagged Devices"
+		}, "4156223528223174": {
+			"ID":          4156223528223174,
+			"LoginName":   "odin@example.com",
+			"DisplayName": "odin"
+		}}
+	}}, "charmander": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         7604530551672977,
+			"StableID":   "ncYsM787P221CNTRL",
+			"Name":       "charmander.tail78f774.ts.net.",
+			"User":       7604530551672977,
+			"Key":        "nodekey:98e28612a618d9ab7ec105ae29025cc4b1892c1ec77209594213eb3413e7403f",
+			"DiscoKey":   "discokey:8d7617b6c35a46a3dadc4c5712b6a4cb5bafce024bd09fad34139ff9c655b44b",
+			"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"Endpoints": [
+				"77.164.248.136:49173",
+				"10.65.0.27:49173",
+				"172.17.0.1:49173",
+				"172.18.0.1:49173"
+			],
+			"Hostinfo": {
+				"Hostname":    "charmander",
+				"RoutableIPs": ["0.0.0.0/0", "::/0"],
+				"RequestTags": ["tag:exit"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-12T18:47:43.840658337Z",
+			"Tags":              ["tag:exit"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "charmander",
+			"ComputedNameWithHost": "charmander"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:98e28612a618d9ab7ec105ae29025cc4b1892c1ec77209594213eb3413e7403f",
+		"MachineKey":        "mkey:95a923f57933ece640a197011a44364492fc3bc14ee71bb2071543e7083e1f7d",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"7604530551672977": {
+			"ID":          7604530551672977,
+			"LoginName":   "charmander.tail78f774.ts.net",
+			"DisplayName": "charmander"
+		}}
+	}}, "fearow": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         3949641728487604,
+			"StableID":   "nmwkdfPoqX11CNTRL",
+			"Name":       "fearow.tail78f774.ts.net.",
+			"User":       3949641728487604,
+			"Key":        "nodekey:216f00e12dace9b06a018bd96d58779063a187b89c24345f761a4116d28c0106",
+			"DiscoKey":   "discokey:98ad3373fa8647409e13bbba456fdc87d794df2d1dbff25b5e2d801f1a15694e",
+			"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+			"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+			"Endpoints": [
+				"77.164.248.136:54792",
+				"10.65.0.27:54792",
+				"172.17.0.1:54792",
+				"172.18.0.1:54792"
+			],
+			"Hostinfo": {
+				"Hostname":    "fearow",
+				"RoutableIPs": ["10.55.0.0/16"],
+				"RequestTags": ["tag:fearow"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-12T18:47:46.493919954Z",
+			"Tags":              ["tag:fearow"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "fearow",
+			"ComputedNameWithHost": "fearow"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:216f00e12dace9b06a018bd96d58779063a187b89c24345f761a4116d28c0106",
+		"MachineKey":        "mkey:fd069422335d491404a55d895c72347475893a2653d19ce00c64a66aba205d18",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"3949641728487604": {
+			"ID":          3949641728487604,
+			"LoginName":   "fearow.tail78f774.ts.net",
+			"DisplayName": "fearow"
+		}}
+	}}, "ivysaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         2129078844332460,
+			"StableID":   "nZ1ansHGdH11CNTRL",
+			"Name":       "ivysaur.tail78f774.ts.net.",
+			"User":       4538565228176803,
+			"Key":        "nodekey:c568827d66eeec5f3f0229ab68370547963cb74b123ada6327c165b0828be342",
+			"KeyExpiry":  "2026-11-08T18:47:49Z",
+			"DiscoKey":   "discokey:1b33524479a23b04086246ab8cee2de783e703e56ef905e98b14b3da52e31735",
+			"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"Endpoints": [
+				"77.164.248.136:42224",
+				"10.65.0.27:42224",
+				"172.17.0.1:42224",
+				"172.18.0.1:42224"
+			],
+			"Hostinfo": {"Hostname": "ivysaur", "Services": [
+				{"Proto": "peerapi4", "Port": 62496},
+				{"Proto": "peerapi6", "Port": 62496},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-12T18:47:49.1612463Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "ivysaur",
+			"ComputedNameWithHost": "ivysaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:c568827d66eeec5f3f0229ab68370547963cb74b123ada6327c165b0828be342",
+		"MachineKey":        "mkey:52e0d9ddf74faa2e37e0d26d46dea0a143627d68a482a713f641b1e310fa840c",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4538565228176803": {
+			"ID":          4538565228176803,
+			"LoginName":   "thor@example.org",
+			"DisplayName": "thor"
+		}}
+	}}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": ["100.64.0.19", "fd7a:115c:a1e0::13"], "DstPorts": [
+			{"IP": "100.64.0.15", "Ports": {"First": 80, "Last": 80}},
+			{"IP": "fd7a:115c:a1e0::f", "Ports": {"First": 80, "Last": 80}}
+		]}],
+		"packet_filter_matches": [{
+			"IPProto": [6, 17, 1, 58],
+			"Srcs":    ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"SrcCaps": null,
+			"Dsts": [
+				{"Net": "100.64.0.15/32", "Ports": {"First": 80, "Last": 80}},
+				{"Net": "fd7a:115c:a1e0::f/128", "Ports": {"First": 80, "Last": 80}}
+			],
+			"Caps": []
+		}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2379236161083680,
+				"StableID":   "nR78FyVZaK11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       2379236161083680,
+				"Key":        "nodekey:b2c6c7ab991451c04d7861e1a11237e405f368f81d23f9c3de9d003d389ca042",
+				"DiscoKey":   "discokey:d393e1efbf11639641024656bdc32f5ea6955c00df638a244182669434682436",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:44168",
+					"10.65.0.27:44168",
+					"172.17.0.1:44168",
+					"172.18.0.1:44168"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:47:48.102409503Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b2c6c7ab991451c04d7861e1a11237e405f368f81d23f9c3de9d003d389ca042",
+			"MachineKey": "mkey:64d9cc2f0dcc53185b9eeb65b3c62752b8d61fd1ee5f90fcdc68ff357b76cf0d",
+			"Peers": [{
+				"ID":         2762149708911604,
+				"StableID":   "nXgsENzyZN11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8fbded01d7aa458b7ba14a57b72b2d3b009d15f7bd5657f49acb2c35034acf64",
+				"KeyExpiry":  "2026-11-08T18:47:50Z",
+				"DiscoKey":   "discokey:848c589123bad5ec2261fa2e628429d22993ea71df645877fa0173430a3bf53e",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:44764",
+					"10.65.0.27:44764",
+					"172.17.0.1:44764",
+					"172.18.0.1:44764"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:47:50.312756399Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{
+				"IPProto": [6, 17, 1, 58],
+				"Srcs":    ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"SrcCaps": null,
+				"Dsts": [
+					{"Net": "100.64.0.15/32", "Ports": {"First": 80, "Last": 80}},
+					{"Net": "fd7a:115c:a1e0::f/128", "Ports": {"First": 80, "Last": 80}}
+				],
+				"Caps": []
+			}],
+			"PacketFilterRules": [{"SrcIPs": ["100.64.0.19", "fd7a:115c:a1e0::13"], "DstPorts": [
+				{"IP": "100.64.0.15", "Ports": {"First": 80, "Last": 80}},
+				{"IP": "fd7a:115c:a1e0::f", "Ports": {"First": 80, "Last": 80}}
+			]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"2379236161083680": {
+				"ID":          2379236161083680,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}}
+		}
+	}, "pidgeotto": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         2385989812581963,
+			"StableID":   "nCsNJaucdK11CNTRL",
+			"Name":       "pidgeotto.tail78f774.ts.net.",
+			"User":       2385989812581963,
+			"Key":        "nodekey:4f903c6a25519d0d58e528e6714a9b29f9b41e9fa94d94e0a7caca37c9ebf07d",
+			"DiscoKey":   "discokey:dd2ea2ee166325ffe5a4038b9179b9e39d1aaac2991c49820929c6b3b8ddcb42",
+			"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+			"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+			"Endpoints": [
+				"77.164.248.136:46899",
+				"10.65.0.27:46899",
+				"172.17.0.1:46899",
+				"172.18.0.1:46899"
+			],
+			"Hostinfo": {
+				"Hostname":    "pidgeotto",
+				"RoutableIPs": ["0.0.0.0/0", "::/0"],
+				"RequestTags": ["tag:pidgeotto"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-12T18:47:43.314604906Z",
+			"Tags":              ["tag:pidgeotto"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "pidgeotto",
+			"ComputedNameWithHost": "pidgeotto"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:4f903c6a25519d0d58e528e6714a9b29f9b41e9fa94d94e0a7caca37c9ebf07d",
+		"MachineKey":        "mkey:550311ce8a37e75db9e60ef09dcfd63ee578ee13802fbb2ff735b1d92996ae6a",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"2385989812581963": {
+			"ID":          2385989812581963,
+			"LoginName":   "pidgeotto.tail78f774.ts.net",
+			"DisplayName": "pidgeotto"
+		}}
+	}}, "pidgey": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         168405084104668,
+			"StableID":   "n7JAcXiGK211CNTRL",
+			"Name":       "pidgey.tail78f774.ts.net.",
+			"User":       168405084104668,
+			"Key":        "nodekey:d4bff71e3fc407bfc170af66dfdde4f68e16d9ba0b98eaa30e5b255fff2c6f66",
+			"DiscoKey":   "discokey:72dafd7e75e4e74e95f8c838c6db672f4cc14dd8cfc2bfaf67de255545e31b4d",
+			"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+			"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+			"Endpoints": [
+				"77.164.248.136:52090",
+				"10.65.0.27:52090",
+				"172.17.0.1:52090",
+				"172.18.0.1:52090"
+			],
+			"Hostinfo": {
+				"Hostname":    "pidgey",
+				"RoutableIPs": ["0.0.0.0/0", "::/0"],
+				"RequestTags": ["tag:pidgey"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-12T18:47:42.797965125Z",
+			"Tags":              ["tag:pidgey"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "pidgey",
+			"ComputedNameWithHost": "pidgey"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:d4bff71e3fc407bfc170af66dfdde4f68e16d9ba0b98eaa30e5b255fff2c6f66",
+		"MachineKey":        "mkey:fe00d9fa838870f18295f86e481c271966d3d987bae1bda34f3516e0bd9db673",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"168405084104668": {
+			"ID":          168405084104668,
+			"LoginName":   "pidgey.tail78f774.ts.net",
+			"DisplayName": "pidgey"
+		}}
+	}}, "raticate": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         1615186930139040,
+			"StableID":   "ndjy4sDXcD11CNTRL",
+			"Name":       "raticate.tail78f774.ts.net.",
+			"User":       1615186930139040,
+			"Key":        "nodekey:f8b0a54361fbd6156f8945c4bdd1d796657af1fe5a2ca499a46714b8a0fd2533",
+			"DiscoKey":   "discokey:aa4424c9ad925ccf5571238babf3f5a3b75e4ecb74bd86794136585c1f4b2618",
+			"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+			"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+			"Endpoints": [
+				"77.164.248.136:37423",
+				"10.65.0.27:37423",
+				"172.17.0.1:37423",
+				"172.18.0.1:37423"
+			],
+			"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+				{"Proto": "peerapi4", "Port": 61927},
+				{"Proto": "peerapi6", "Port": 61927},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-12T18:47:44.89747063Z",
+			"Tags":              ["tag:group-b"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "raticate",
+			"ComputedNameWithHost": "raticate"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:f8b0a54361fbd6156f8945c4bdd1d796657af1fe5a2ca499a46714b8a0fd2533",
+		"MachineKey":        "mkey:cbb42582cad2dc0cc1826bc2110196c91304fd9b10d035fe4576fd5ded7fdb45",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1615186930139040": {
+			"ID":          1615186930139040,
+			"LoginName":   "raticate.tail78f774.ts.net",
+			"DisplayName": "raticate"
+		}}
+	}}, "rattata": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         1967735226991648,
+			"StableID":   "nVoMpv4CNG11CNTRL",
+			"Name":       "rattata.tail78f774.ts.net.",
+			"User":       1967735226991648,
+			"Key":        "nodekey:bacd1629d38573b7edac49071cf6d9353dc8e5864fb78924d08873264924ae02",
+			"DiscoKey":   "discokey:7fadab62f31306981c633b842e0a45bd8f9c2ced82d0acd240bc4545e9a49661",
+			"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+			"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+			"Endpoints": [
+				"77.164.248.136:46654",
+				"10.65.0.27:46654",
+				"172.17.0.1:46654",
+				"172.18.0.1:46654"
+			],
+			"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+				{"Proto": "peerapi4", "Port": 41053},
+				{"Proto": "peerapi6", "Port": 41053},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-12T18:47:44.369015236Z",
+			"Tags":              ["tag:group-a"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "rattata",
+			"ComputedNameWithHost": "rattata"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:bacd1629d38573b7edac49071cf6d9353dc8e5864fb78924d08873264924ae02",
+		"MachineKey":        "mkey:c93dfaa8f36c815340a4e6a1533bc4642ec0f9ce82d79ac7b768cfd03dbeed64",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1967735226991648": {
+			"ID":          1967735226991648,
+			"LoginName":   "rattata.tail78f774.ts.net",
+			"DisplayName": "rattata"
+		}}
+	}}, "spearow": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         267069811007631,
+			"StableID":   "ng5MfKUx5311CNTRL",
+			"Name":       "spearow.tail78f774.ts.net.",
+			"User":       267069811007631,
+			"Key":        "nodekey:77c402db10c8ee98076a192e1096e37259ec8bec782ecf8dd9cef0e22817db7c",
+			"DiscoKey":   "discokey:274642fb8083bacc739342bda189b73059a6a8ceb44f659dbe39bdc5bb47b309",
+			"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+			"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+			"Endpoints": [
+				"77.164.248.136:57362",
+				"10.65.0.27:57362",
+				"172.17.0.1:57362",
+				"172.18.0.1:57362"
+			],
+			"Hostinfo": {
+				"Hostname":    "spearow",
+				"RoutableIPs": ["10.44.0.0/16"],
+				"RequestTags": ["tag:spearow"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-12T18:47:45.989209273Z",
+			"Tags":              ["tag:spearow"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "spearow",
+			"ComputedNameWithHost": "spearow"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:77c402db10c8ee98076a192e1096e37259ec8bec782ecf8dd9cef0e22817db7c",
+		"MachineKey":        "mkey:c6202a2013b0ae156c129c39cb245f3d5a12971be933fcbedd41b09985481805",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"267069811007631": {
+			"ID":          267069811007631,
+			"LoginName":   "spearow.tail78f774.ts.net",
+			"DisplayName": "spearow"
+		}}
+	}}, "squirtle": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         5945268754689519,
+			"StableID":   "nSGfEU8dRo11CNTRL",
+			"Name":       "squirtle.tail78f774.ts.net.",
+			"User":       5945268754689519,
+			"Key":        "nodekey:b5329ffd8e9809dbe1d5126dacc328a91be1c47bcb8197dd183e840c327be927",
+			"DiscoKey":   "discokey:5745674a8c3bb029c616c5dcba570cbde6c230187ddb43c08f29f4bdf87be63e",
+			"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+			"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+			"Endpoints": [
+				"77.164.248.136:36421",
+				"10.65.0.27:36421",
+				"172.17.0.1:36421",
+				"172.18.0.1:36421"
+			],
+			"Hostinfo": {
+				"Hostname":    "squirtle",
+				"RoutableIPs": ["10.33.0.0/16"],
+				"RequestTags": ["tag:router"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-12T18:47:47.040080188Z",
+			"Tags":              ["tag:router"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "squirtle",
+			"ComputedNameWithHost": "squirtle"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:b5329ffd8e9809dbe1d5126dacc328a91be1c47bcb8197dd183e840c327be927",
+		"MachineKey":        "mkey:0cb85316eda1e9c1ccf71b73d00c7ce0c5050f56cb922c395aa2641563040f2c",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"5945268754689519": {
+			"ID":          5945268754689519,
+			"LoginName":   "squirtle.tail78f774.ts.net",
+			"DisplayName": "squirtle"
+		}}
+	}}, "venusaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         5175087149336856,
+			"StableID":   "ns6k8KmoQh11CNTRL",
+			"Name":       "venusaur.tail78f774.ts.net.",
+			"User":       3982058329734709,
+			"Key":        "nodekey:7ff774634d32644a0a9ad27870c0a79cab7519dfa1f7acc8322e0899e57d5e13",
+			"KeyExpiry":  "2026-11-08T18:47:49Z",
+			"DiscoKey":   "discokey:8ba476bd326f80478180ec2d487e5ae0a182e68b04c616455ee3e9a7bbab0241",
+			"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"Endpoints": [
+				"77.164.248.136:54444",
+				"10.65.0.27:54444",
+				"172.17.0.1:54444",
+				"172.18.0.1:54444"
+			],
+			"Hostinfo": {"Hostname": "venusaur", "Services": [
+				{"Proto": "peerapi4", "Port": 42394},
+				{"Proto": "peerapi6", "Port": 42394},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-12T18:47:49.793069996Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "venusaur",
+			"ComputedNameWithHost": "venusaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:7ff774634d32644a0a9ad27870c0a79cab7519dfa1f7acc8322e0899e57d5e13",
+		"MachineKey":        "mkey:2bec41a61c59acf4850ef27c78589a58f84254154f4baa375c8aa7e5ac62bc5b",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"3982058329734709": {
+			"ID":          3982058329734709,
+			"LoginName":   "freya@example.com",
+			"DisplayName": "freya"
+		}}
+	}}, "weedle": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         2806542574769092,
+			"StableID":   "njtAnd76vN11CNTRL",
+			"Name":       "weedle.tail78f774.ts.net.",
+			"User":       2806542574769092,
+			"Key":        "nodekey:0b8a7bbb4a288da12b69812e4a84107cdf6acbbaa27c97693c254c2111f40670",
+			"DiscoKey":   "discokey:d182ce73a072210b6b48276a9772606fd20e4683922c4b739170b8cd21358129",
+			"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"Endpoints": [
+				"77.164.248.136:38103",
+				"10.65.0.27:38103",
+				"172.17.0.1:38103",
+				"172.18.0.1:38103"
+			],
+			"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+				{"Proto": "peerapi4", "Port": 63957},
+				{"Proto": "peerapi6", "Port": 63957},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-12T18:47:47.56275653Z",
+			"Tags":              ["tag:client"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "weedle",
+			"ComputedNameWithHost": "weedle"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:0b8a7bbb4a288da12b69812e4a84107cdf6acbbaa27c97693c254c2111f40670",
+		"MachineKey":        "mkey:3f58aacfaf700736f5f724c10d9a49bc716958f258e34e225f7b8da10669d67b",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"2806542574769092": {
+			"ID":          2806542574769092,
+			"LoginName":   "weedle.tail78f774.ts.net",
+			"DisplayName": "weedle"
+		}}
+	}}}
+}

--- a/hscontrol/policy/v2/testdata/sshtest_results/sshtest-mixed-grants-app-cap-with-ssh.hujson
+++ b/hscontrol/policy/v2/testdata/sshtest_results/sshtest-mixed-grants-app-cap-with-ssh.hujson
@@ -1,0 +1,13472 @@
+// sshtest-mixed-grants-app-cap-with-ssh
+//
+// grants ip[tcp:22] plus ssh rule, sshTests passes
+//
+// Nodes with filter rules: 1 of 15
+// Captured at:    2026-05-12T18:48:35Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "sshtest-mixed-grants-app-cap-with-ssh",
+	"description":    "grants ip[tcp:22] plus ssh rule, sshTests passes",
+	"category":       "sshtest",
+	"captured_at":    "2026-05-12T18:48:35.46284593Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                        \n  \n                                                                        \n                                     \n{\n\t\"category\":    \"sshtest\",\n\t\"description\": \"grants ip[tcp:22] plus ssh rule, sshTests passes\",\n\t\"id\":          \"sshtest-mixed-grants-app-cap-with-ssh\",\n\t\"policy\": {\"grants\": [\n\t\t{\"dst\": [\"tag:server\"], \"ip\": [\"tcp:22\"], \"src\": [\"thor@example.org\"]}\n\t], \"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"thor@example.org\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"sshTests\": [{\n\t\t\"accept\": [\"root\"],\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    \"thor@example.org\"\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/sshtest/sshtest-mixed-grants-app-cap-with-ssh.hujson",
+		"full_policy": {
+			"grants": [
+				{"dst": ["tag:server"], "ip": ["tcp:22"], "src": ["thor@example.org"]}
+			],
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["thor@example.org"],
+				"users":  ["root"]
+			}],
+			"sshTests":  [{"accept": ["root"], "dst": ["tag:server"], "src": "thor@example.org"}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": ["100.64.0.17", "fd7a:115c:a1e0::11"], "DstPorts": [
+			{"IP": "100.64.0.16", "Ports": {"First": 22, "Last": 22}},
+			{"IP": "fd7a:115c:a1e0::10", "Ports": {"First": 22, "Last": 22}}
+		], "IPProto": [6]}],
+		"packet_filter_matches": [{
+			"IPProto": [6],
+			"Srcs":    ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"SrcCaps": null,
+			"Dsts": [
+				{"Net": "100.64.0.16/32", "Ports": {"First": 22, "Last": 22}},
+				{"Net": "fd7a:115c:a1e0::10/128", "Ports": {"First": 22, "Last": 22}}
+			],
+			"Caps": []
+		}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3900297319003103,
+				"StableID":   "nWc69RCTTX11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       3900297319003103,
+				"Key":        "nodekey:9b80c14334c0b198521d4dcce6e3b53daa231ea5e65a10b557eab8c22d62fe52",
+				"DiscoKey":   "discokey:433d2b03dbcb50e27dde2ac7d07feebc5b5b9cefaca07af9c923111ddeefed79",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:47901", "10.65.0.27:47901", "172.17.0.1:47901"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:48:44.008510315Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9b80c14334c0b198521d4dcce6e3b53daa231ea5e65a10b557eab8c22d62fe52",
+			"MachineKey": "mkey:360a354567df6814025870f119352dab0b05a78f49b9ef740a2129101f4cd575",
+			"Peers": [{
+				"ID":         8282744978615181,
+				"StableID":   "nJfHqbfGg721CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:2de38ff99ede5b899c9f4ad8cbe5e326a4105de0842573309cf8f3adf5066703",
+				"KeyExpiry":  "2026-11-08T18:48:44Z",
+				"DiscoKey":   "discokey:12a680cb2db78e59ef8ebb366a04b1706b1a244444e015b6c9d72ebea3007d56",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:59105", "10.65.0.27:59105", "172.17.0.1:59105"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:48:44.551551808Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{
+				"IPProto": [6],
+				"Srcs":    ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"SrcCaps": null,
+				"Dsts": [
+					{"Net": "100.64.0.16/32", "Ports": {"First": 22, "Last": 22}},
+					{"Net": "fd7a:115c:a1e0::10/128", "Ports": {"First": 22, "Last": 22}}
+				],
+				"Caps": []
+			}],
+			"PacketFilterRules": [{"SrcIPs": ["100.64.0.17", "fd7a:115c:a1e0::11"], "DstPorts": [
+				{"IP": "100.64.0.16", "Ports": {"First": 22, "Last": 22}},
+				{"IP": "fd7a:115c:a1e0::10", "Ports": {"First": 22, "Last": 22}}
+			], "IPProto": [6]}],
+			"SSHPolicy": {"rules": [{
+				"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+				"sshUsers":   {"root": "root"},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				}
+			}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"3900297319003103": {
+				"ID":          3900297319003103,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		},
+		"ssh_rules": [{
+			"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+			"sshUsers":   {"root": "root"},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}
+		}]
+	}, "blastoise": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         4459310683199606,
+			"StableID":   "nM6BtjXdpb11CNTRL",
+			"Name":       "blastoise.tail78f774.ts.net.",
+			"User":       4459310683199606,
+			"Key":        "nodekey:142df6ea53626659a88eeeeb7f65481e24bc5bd6fbdbe41fb15f3d7b622cf544",
+			"DiscoKey":   "discokey:8cd8c082972ce3dd63cf1a1d13284a4fc72cdf0778676c19bf3481ab7f352664",
+			"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+			"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+			"Endpoints":  ["77.164.248.136:34210", "10.65.0.27:34210", "172.17.0.1:34210"],
+			"Hostinfo": {
+				"Hostname":    "blastoise",
+				"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+				"RequestTags": ["tag:exit", "tag:router"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-12T18:48:40.765713135Z",
+			"Tags":              ["tag:exit", "tag:router"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "blastoise",
+			"ComputedNameWithHost": "blastoise"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:142df6ea53626659a88eeeeb7f65481e24bc5bd6fbdbe41fb15f3d7b622cf544",
+		"MachineKey":        "mkey:c2d3f2b7fd2a91448714e653771b36bc1421b9fadac4b93b53f1eab06dbc4b5b",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4459310683199606": {
+			"ID":          4459310683199606,
+			"LoginName":   "blastoise.tail78f774.ts.net",
+			"DisplayName": "blastoise"
+		}}
+	}}, "bulbasaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         1831239572512163,
+			"StableID":   "nvEnEPZNJF11CNTRL",
+			"Name":       "bulbasaur.tail78f774.ts.net.",
+			"User":       4156223528223174,
+			"Key":        "nodekey:0b0bb947787758b72affa517f9efe8a49abd0aba14fee82b439e244998fd085d",
+			"KeyExpiry":  "2026-11-08T18:48:45Z",
+			"DiscoKey":   "discokey:97ca4a948e975850f0ca47b76f1c3817572e6c0ece59d7b159cd6c0db0426014",
+			"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+			"Endpoints":  ["77.164.248.136:52990", "10.65.0.27:52990", "172.17.0.1:52990"],
+			"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+				{"Proto": "peerapi4", "Port": 38156},
+				{"Proto": "peerapi6", "Port": 38156},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-12T18:48:45.638257363Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "bulbasaur",
+			"ComputedNameWithHost": "bulbasaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:0b0bb947787758b72affa517f9efe8a49abd0aba14fee82b439e244998fd085d",
+		"MachineKey":        "mkey:967aaf8812957801a6cbba9c9d677e44e87ab27673f014ab2ae4c4bb42170b6e",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4156223528223174": {
+			"ID":          4156223528223174,
+			"LoginName":   "odin@example.com",
+			"DisplayName": "odin"
+		}}
+	}}, "charmander": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         4685761189730167,
+			"StableID":   "nUTfh31Cbd11CNTRL",
+			"Name":       "charmander.tail78f774.ts.net.",
+			"User":       4685761189730167,
+			"Key":        "nodekey:2f57d043f4e12d24155ae058d88e5393d0c274209f788d54a0326303d4373672",
+			"DiscoKey":   "discokey:2be0f945d116619471b61aee320d472618bf7c5260d8262962ce9223c984205f",
+			"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+			"Endpoints":  ["77.164.248.136:38845", "10.65.0.27:38845", "172.17.0.1:38845"],
+			"Hostinfo": {
+				"Hostname":    "charmander",
+				"RoutableIPs": ["0.0.0.0/0", "::/0"],
+				"RequestTags": ["tag:exit"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-12T18:48:39.135688332Z",
+			"Tags":              ["tag:exit"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "charmander",
+			"ComputedNameWithHost": "charmander"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:2f57d043f4e12d24155ae058d88e5393d0c274209f788d54a0326303d4373672",
+		"MachineKey":        "mkey:3dd746d3c6427dfaf369deef50e9f57a5ec482b57cd2afe0cb5d87115cc3e07a",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4685761189730167": {
+			"ID":          4685761189730167,
+			"LoginName":   "charmander.tail78f774.ts.net",
+			"DisplayName": "charmander"
+		}}
+	}}, "fearow": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         4407526447083043,
+			"StableID":   "nELHGGFBRb11CNTRL",
+			"Name":       "fearow.tail78f774.ts.net.",
+			"User":       4407526447083043,
+			"Key":        "nodekey:bb9e06a37397466a6ee6c094ac10c4e78c7b1aef17223869f1e7f7c471e1fb00",
+			"DiscoKey":   "discokey:c62a09712a6cf6bb771f588dbcc6c43407e35c06175cf0eb5b8658c041bf9f33",
+			"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+			"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+			"Endpoints":  ["77.164.248.136:44071", "10.65.0.27:44071", "172.17.0.1:44071"],
+			"Hostinfo": {
+				"Hostname":    "fearow",
+				"RoutableIPs": ["10.55.0.0/16"],
+				"RequestTags": ["tag:fearow"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-12T18:48:41.839521072Z",
+			"Tags":              ["tag:fearow"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "fearow",
+			"ComputedNameWithHost": "fearow"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:bb9e06a37397466a6ee6c094ac10c4e78c7b1aef17223869f1e7f7c471e1fb00",
+		"MachineKey":        "mkey:11d32dbff044b9061009e69a63fab204afb52c2d702fe0ec5526530b9e896033",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4407526447083043": {
+			"ID":          4407526447083043,
+			"LoginName":   "fearow.tail78f774.ts.net",
+			"DisplayName": "fearow"
+		}}
+	}}, "ivysaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         8282744978615181,
+			"StableID":   "nJfHqbfGg721CNTRL",
+			"Name":       "ivysaur.tail78f774.ts.net.",
+			"User":       4538565228176803,
+			"Key":        "nodekey:2de38ff99ede5b899c9f4ad8cbe5e326a4105de0842573309cf8f3adf5066703",
+			"KeyExpiry":  "2026-11-08T18:48:44Z",
+			"DiscoKey":   "discokey:12a680cb2db78e59ef8ebb366a04b1706b1a244444e015b6c9d72ebea3007d56",
+			"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+			"Endpoints":  ["77.164.248.136:59105", "10.65.0.27:59105", "172.17.0.1:59105"],
+			"Hostinfo": {"Hostname": "ivysaur", "Services": [
+				{"Proto": "peerapi4", "Port": 62496},
+				{"Proto": "peerapi6", "Port": 62496},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-12T18:48:44.551551808Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "ivysaur",
+			"ComputedNameWithHost": "ivysaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":    "nodekey:2de38ff99ede5b899c9f4ad8cbe5e326a4105de0842573309cf8f3adf5066703",
+		"MachineKey": "mkey:4ed691e8fb00f7fb98110502ec138205efcfb87a702d877af63b7cc37e3b6603",
+		"Peers": [{
+			"ID":         3900297319003103,
+			"StableID":   "nWc69RCTTX11CNTRL",
+			"Name":       "beedrill.tail78f774.ts.net.",
+			"User":       1260082990019555,
+			"Key":        "nodekey:9b80c14334c0b198521d4dcce6e3b53daa231ea5e65a10b557eab8c22d62fe52",
+			"DiscoKey":   "discokey:433d2b03dbcb50e27dde2ac7d07feebc5b5b9cefaca07af9c923111ddeefed79",
+			"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+			"Endpoints":  ["77.164.248.136:47901", "10.65.0.27:47901", "172.17.0.1:47901"],
+			"HomeDERP":   14,
+			"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+				{"Proto": "peerapi4", "Port": 50358},
+				{"Proto": "peerapi6", "Port": 50358}
+			]},
+			"Created":              "2026-05-12T18:48:44.008510315Z",
+			"Cap":                  131,
+			"Tags":                 ["tag:server"],
+			"Online":               true,
+			"ComputedName":         "beedrill",
+			"ComputedNameWithHost": "beedrill"
+		}],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"1260082990019555": {
+			"ID":          1260082990019555,
+			"LoginName":   "tagged-devices",
+			"DisplayName": "Tagged Devices"
+		}, "4538565228176803": {
+			"ID":          4538565228176803,
+			"LoginName":   "thor@example.org",
+			"DisplayName": "thor"
+		}}
+	}}, "kakuna": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         6359096101429593,
+			"StableID":   "neqLnwf3fr11CNTRL",
+			"Name":       "kakuna.tail78f774.ts.net.",
+			"User":       6359096101429593,
+			"Key":        "nodekey:9221159729d2635211b0162ea0ca9e4b80d12f03725296bc7f719ac20b33890e",
+			"DiscoKey":   "discokey:16b425d4493501028c03be9d61c2477dd1bbdb280dec6f4969ca8ab76cd99b6b",
+			"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+			"Endpoints":  ["77.164.248.136:43847", "10.65.0.27:43847", "172.17.0.1:43847"],
+			"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+				{"Proto": "peerapi4", "Port": 51523},
+				{"Proto": "peerapi6", "Port": 51523},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-12T18:48:43.459559516Z",
+			"Tags":              ["tag:prod"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "kakuna",
+			"ComputedNameWithHost": "kakuna"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:9221159729d2635211b0162ea0ca9e4b80d12f03725296bc7f719ac20b33890e",
+		"MachineKey":        "mkey:41398ade247a97d0399a99ec990d11427d7791a9d78e54bf441f750694ea922f",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"6359096101429593": {
+			"ID":          6359096101429593,
+			"LoginName":   "kakuna.tail78f774.ts.net",
+			"DisplayName": "kakuna"
+		}}
+	}}, "pidgeotto": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         8021092215495531,
+			"StableID":   "ncZK9VVmd521CNTRL",
+			"Name":       "pidgeotto.tail78f774.ts.net.",
+			"User":       8021092215495531,
+			"Key":        "nodekey:519bc7c1ab636b41ebda6913de24b38cc4809525a0d8cc14a154d8300ff7bb1f",
+			"DiscoKey":   "discokey:7ad2a9db4743b647cf14d7178d129f4bc1cace4d263dae5c278a9ba3ca22ed36",
+			"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+			"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+			"Endpoints":  ["77.164.248.136:49661", "10.65.0.27:49661", "172.17.0.1:49661"],
+			"Hostinfo": {
+				"Hostname":    "pidgeotto",
+				"RoutableIPs": ["0.0.0.0/0", "::/0"],
+				"RequestTags": ["tag:pidgeotto"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-12T18:48:38.591523858Z",
+			"Tags":              ["tag:pidgeotto"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "pidgeotto",
+			"ComputedNameWithHost": "pidgeotto"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:519bc7c1ab636b41ebda6913de24b38cc4809525a0d8cc14a154d8300ff7bb1f",
+		"MachineKey":        "mkey:cad797f8e37af3157c57e7296ca5a00d7836e09f13d770d6c3bd32bded8e9a02",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"8021092215495531": {
+			"ID":          8021092215495531,
+			"LoginName":   "pidgeotto.tail78f774.ts.net",
+			"DisplayName": "pidgeotto"
+		}}
+	}}, "pidgey": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         2152139429752978,
+			"StableID":   "nKock64ioH11CNTRL",
+			"Name":       "pidgey.tail78f774.ts.net.",
+			"User":       2152139429752978,
+			"Key":        "nodekey:cfc83ae32a4d216eaffde9252d8ec314676d1fe01f56a086c1a9bb3fad74474b",
+			"DiscoKey":   "discokey:438a016dbd4f407ebb44aaddc61aa4560e9d0a81b7ae8d52abead148e46ce960",
+			"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+			"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+			"Endpoints":  ["77.164.248.136:33040", "10.65.0.27:33040", "172.17.0.1:33040"],
+			"Hostinfo": {
+				"Hostname":    "pidgey",
+				"RoutableIPs": ["0.0.0.0/0", "::/0"],
+				"RequestTags": ["tag:pidgey"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-12T18:48:38.064796073Z",
+			"Tags":              ["tag:pidgey"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "pidgey",
+			"ComputedNameWithHost": "pidgey"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:cfc83ae32a4d216eaffde9252d8ec314676d1fe01f56a086c1a9bb3fad74474b",
+		"MachineKey":        "mkey:ca8db7c16e83ce8724a188b30d32ebef37e8e36358a23658a08aa2bc3dfa5d0c",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"2152139429752978": {
+			"ID":          2152139429752978,
+			"LoginName":   "pidgey.tail78f774.ts.net",
+			"DisplayName": "pidgey"
+		}}
+	}}, "raticate": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         8346128914817873,
+			"StableID":   "ncY9EweyA821CNTRL",
+			"Name":       "raticate.tail78f774.ts.net.",
+			"User":       8346128914817873,
+			"Key":        "nodekey:e313cab0785fae26ba082da09ac7280687b4ad3b2fce9c5f2a7c5694ae97e54b",
+			"DiscoKey":   "discokey:529bb816cf6423b4eddf9a2157114bd47b671ebef4265ab72d319f5b1c005951",
+			"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+			"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+			"Endpoints":  ["77.164.248.136:51831", "10.65.0.27:51831", "172.17.0.1:51831"],
+			"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+				{"Proto": "peerapi4", "Port": 61927},
+				{"Proto": "peerapi6", "Port": 61927},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-12T18:48:40.217444375Z",
+			"Tags":              ["tag:group-b"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "raticate",
+			"ComputedNameWithHost": "raticate"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:e313cab0785fae26ba082da09ac7280687b4ad3b2fce9c5f2a7c5694ae97e54b",
+		"MachineKey":        "mkey:d51f93d121d52d59fe60a15401acc5ecb0ee7f4bedcbeebad0ec2d47b9d7fb5d",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"8346128914817873": {
+			"ID":          8346128914817873,
+			"LoginName":   "raticate.tail78f774.ts.net",
+			"DisplayName": "raticate"
+		}}
+	}}, "rattata": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         4725870714902506,
+			"StableID":   "nbKL6PcMud11CNTRL",
+			"Name":       "rattata.tail78f774.ts.net.",
+			"User":       4725870714902506,
+			"Key":        "nodekey:269c5226df14bd0ba76a291a4f58fef67a7e22a812cae701d97cfe076192f320",
+			"DiscoKey":   "discokey:ad023eaac823e20bca099846cfe370a1dba7513cb37f306d2c83e3f6e59ab14c",
+			"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+			"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+			"Endpoints":  ["77.164.248.136:49464", "10.65.0.27:49464", "172.17.0.1:49464"],
+			"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+				{"Proto": "peerapi4", "Port": 41053},
+				{"Proto": "peerapi6", "Port": 41053},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-12T18:48:39.676961034Z",
+			"Tags":              ["tag:group-a"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "rattata",
+			"ComputedNameWithHost": "rattata"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:269c5226df14bd0ba76a291a4f58fef67a7e22a812cae701d97cfe076192f320",
+		"MachineKey":        "mkey:b408943cce7865f3925d8e2443c7a16b07079c82f4b8eed12f57497031ae0d09",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"4725870714902506": {
+			"ID":          4725870714902506,
+			"LoginName":   "rattata.tail78f774.ts.net",
+			"DisplayName": "rattata"
+		}}
+	}}, "spearow": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         8665083252547983,
+			"StableID":   "nGTxqX3SfA21CNTRL",
+			"Name":       "spearow.tail78f774.ts.net.",
+			"User":       8665083252547983,
+			"Key":        "nodekey:30727331f96ccd3a721fc59c56ba1737bcc291000572f25e28039a90cfd33609",
+			"DiscoKey":   "discokey:ac9b31d27b5c54c50a4edf4f045227f1f875c4a7f480917de2a57e34eed33c49",
+			"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+			"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+			"Endpoints":  ["77.164.248.136:60761", "10.65.0.27:60761", "172.17.0.1:60761"],
+			"Hostinfo": {
+				"Hostname":    "spearow",
+				"RoutableIPs": ["10.44.0.0/16"],
+				"RequestTags": ["tag:spearow"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-12T18:48:41.297293192Z",
+			"Tags":              ["tag:spearow"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "spearow",
+			"ComputedNameWithHost": "spearow"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:30727331f96ccd3a721fc59c56ba1737bcc291000572f25e28039a90cfd33609",
+		"MachineKey":        "mkey:7cf305d0a2862f8b321341be942ce1cce302402147f0112c28e3c24958671d76",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"8665083252547983": {
+			"ID":          8665083252547983,
+			"LoginName":   "spearow.tail78f774.ts.net",
+			"DisplayName": "spearow"
+		}}
+	}}, "squirtle": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         6868818038571686,
+			"StableID":   "nDaZujCudv11CNTRL",
+			"Name":       "squirtle.tail78f774.ts.net.",
+			"User":       6868818038571686,
+			"Key":        "nodekey:ee79199c2061a492b1fae29ad6680c231534915cba42c29ba4a86c5a7a92396e",
+			"DiscoKey":   "discokey:a390b311eb02ebe68402280c24c2abc6ed6d4a2675a67f9996d180cd16525817",
+			"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+			"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+			"Endpoints":  ["77.164.248.136:52818", "10.65.0.27:52818", "172.17.0.1:52818"],
+			"Hostinfo": {
+				"Hostname":    "squirtle",
+				"RoutableIPs": ["10.33.0.0/16"],
+				"RequestTags": ["tag:router"],
+				"Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]
+			},
+			"Created":           "2026-05-12T18:48:42.376263433Z",
+			"Tags":              ["tag:router"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "squirtle",
+			"ComputedNameWithHost": "squirtle"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:ee79199c2061a492b1fae29ad6680c231534915cba42c29ba4a86c5a7a92396e",
+		"MachineKey":        "mkey:b45300d17724f116b062439c886e61058bd816cac5bd501eda9b639d4cc65768",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"6868818038571686": {
+			"ID":          6868818038571686,
+			"LoginName":   "squirtle.tail78f774.ts.net",
+			"DisplayName": "squirtle"
+		}}
+	}}, "venusaur": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         5979634935517274,
+			"StableID":   "nfbKxTsBho11CNTRL",
+			"Name":       "venusaur.tail78f774.ts.net.",
+			"User":       3982058329734709,
+			"Key":        "nodekey:59493f5c30e5d76630d768b63509694650d8848a2745d4a9ec729dc17abeeb5b",
+			"KeyExpiry":  "2026-11-08T18:48:45Z",
+			"DiscoKey":   "discokey:7f04542f8ae3bf9ad59c3f4aa8272a664b9a24d7fef00e38944278c4ebd0e209",
+			"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+			"Endpoints":  ["77.164.248.136:58185", "10.65.0.27:58185", "172.17.0.1:58185"],
+			"Hostinfo": {"Hostname": "venusaur", "Services": [
+				{"Proto": "peerapi4", "Port": 42394},
+				{"Proto": "peerapi6", "Port": 42394},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-12T18:48:45.094708187Z",
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-admin":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "venusaur",
+			"ComputedNameWithHost": "venusaur"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-admin",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:59493f5c30e5d76630d768b63509694650d8848a2745d4a9ec729dc17abeeb5b",
+		"MachineKey":        "mkey:7c649caf013f81911dc6dc37364e6e91b874da6faa52a8bbd431e8ff25136632",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"3982058329734709": {
+			"ID":          3982058329734709,
+			"LoginName":   "freya@example.com",
+			"DisplayName": "freya"
+		}}
+	}}, "weedle": {"netmap": {
+		"Cached": false,
+		"SelfNode": {
+			"ID":         5367623688116415,
+			"StableID":   "nAznkbN1vi11CNTRL",
+			"Name":       "weedle.tail78f774.ts.net.",
+			"User":       5367623688116415,
+			"Key":        "nodekey:9efd1b77b73b3083a77f074c6bdd5a6ff0e243f8d0886f006a88b506911c682a",
+			"DiscoKey":   "discokey:e04fc1c233f88715eeee1e8f007707f4aebb108456375d0b58e1d8ca57a30545",
+			"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+			"Endpoints":  ["77.164.248.136:59370", "10.65.0.27:59370", "172.17.0.1:59370"],
+			"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+				{"Proto": "peerapi4", "Port": 63957},
+				{"Proto": "peerapi6", "Port": 63957},
+				{"Proto": "peerapi-dns-proxy", "Port": 1}
+			]},
+			"Created":           "2026-05-12T18:48:42.927860483Z",
+			"Tags":              ["tag:client"],
+			"MachineAuthorized": true,
+			"CapMap": {
+				"default-auto-update":                    [false],
+				"https://tailscale.com/cap/file-sharing": null,
+				"https://tailscale.com/cap/is-owner":     null,
+				"https://tailscale.com/cap/ssh":          null,
+				"https://tailscale.com/cap/tailnet-lock": null,
+				"probe-udp-lifetime":                     null,
+				"ssh-behavior-v1":                        null,
+				"ssh-env-vars":                           null,
+				"store-appc-routes":                      null,
+				"tailnet-display-name":                   ["odin@example.com"]
+			},
+			"ComputedName":         "weedle",
+			"ComputedNameWithHost": "weedle"
+		},
+		"AllCaps": [
+			"default-auto-update",
+			"https://tailscale.com/cap/file-sharing",
+			"https://tailscale.com/cap/is-owner",
+			"https://tailscale.com/cap/ssh",
+			"https://tailscale.com/cap/tailnet-lock",
+			"probe-udp-lifetime",
+			"ssh-behavior-v1",
+			"ssh-env-vars",
+			"store-appc-routes",
+			"tailnet-display-name"
+		],
+		"NodeKey":           "nodekey:9efd1b77b73b3083a77f074c6bdd5a6ff0e243f8d0886f006a88b506911c682a",
+		"MachineKey":        "mkey:b787e1e340147e4279f21c37df6c8ae5b450ec24167f00e37d59cf0cb672a64d",
+		"Peers":             [],
+		"DNS":               {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+		"PacketFilter":      [],
+		"PacketFilterRules": null,
+		"SSHPolicy":         {"rules": []},
+		"CollectServices":   false,
+		"DERPMap": {"Regions": {"1": {
+			"RegionID":   1,
+			"RegionCode": "nyc",
+			"RegionName": "New York City",
+			"Latitude":   40.7128,
+			"Longitude":  -74.006,
+			"Nodes": [{
+				"Name":      "1h",
+				"RegionID":  1,
+				"HostName":  "derp1h.tailscale.com",
+				"IPv4":      "199.38.181.93",
+				"IPv6":      "2607:f740:f::afd",
+				"CanPort80": true
+			}, {
+				"Name":      "1g",
+				"RegionID":  1,
+				"HostName":  "derp1g.tailscale.com",
+				"IPv4":      "209.177.145.120",
+				"IPv6":      "2607:f740:f::3eb",
+				"CanPort80": true
+			}, {
+				"Name":      "1i",
+				"RegionID":  1,
+				"HostName":  "derp1i.tailscale.com",
+				"IPv4":      "199.38.181.103",
+				"IPv6":      "2607:f740:f::e19",
+				"CanPort80": true
+			}, {
+				"Name":      "1f",
+				"RegionID":  1,
+				"HostName":  "derp1f.tailscale.com",
+				"IPv4":      "199.38.181.104",
+				"IPv6":      "2607:f740:f::bc",
+				"CanPort80": true
+			}]
+		}, "10": {
+			"RegionID":   10,
+			"RegionCode": "sea",
+			"RegionName": "Seattle",
+			"Latitude":   47.609722,
+			"Longitude":  -122.333056,
+			"Nodes": [{
+				"Name":      "10c",
+				"RegionID":  10,
+				"HostName":  "derp10c.tailscale.com",
+				"IPv4":      "192.73.240.121",
+				"IPv6":      "2607:f740:14::40c",
+				"CanPort80": true
+			}, {
+				"Name":      "10d",
+				"RegionID":  10,
+				"HostName":  "derp10d.tailscale.com",
+				"IPv4":      "192.73.240.132",
+				"IPv6":      "2607:f740:14::500",
+				"CanPort80": true
+			}, {
+				"Name":      "10b",
+				"RegionID":  10,
+				"HostName":  "derp10b.tailscale.com",
+				"IPv4":      "192.73.240.161",
+				"IPv6":      "2607:f740:14::61c",
+				"CanPort80": true
+			}]
+		}, "11": {
+			"RegionID":   11,
+			"RegionCode": "sao",
+			"RegionName": "São Paulo",
+			"Latitude":   -23.55,
+			"Longitude":  -46.633333,
+			"Nodes": [{
+				"Name":      "11f",
+				"RegionID":  11,
+				"HostName":  "derp11f.tailscale.com",
+				"IPv4":      "172.237.61.197",
+				"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+				"CanPort80": true
+			}, {
+				"Name":      "11g",
+				"RegionID":  11,
+				"HostName":  "derp11g.tailscale.com",
+				"IPv4":      "172.237.61.190",
+				"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+				"CanPort80": true
+			}, {
+				"Name":      "11e",
+				"RegionID":  11,
+				"HostName":  "derp11e.tailscale.com",
+				"IPv4":      "172.237.61.194",
+				"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+				"CanPort80": true
+			}]
+		}, "12": {
+			"RegionID":   12,
+			"RegionCode": "ord",
+			"RegionName": "Chicago",
+			"Latitude":   41.881944,
+			"Longitude":  -87.627778,
+			"Nodes": [{
+				"Name":      "12e",
+				"RegionID":  12,
+				"HostName":  "derp12e.tailscale.com",
+				"IPv4":      "209.177.158.15",
+				"IPv6":      "2607:f740:e::b17",
+				"CanPort80": true
+			}, {
+				"Name":      "12f",
+				"RegionID":  12,
+				"HostName":  "derp12f.tailscale.com",
+				"IPv4":      "199.38.182.118",
+				"IPv6":      "2607:f740:e::4c8",
+				"CanPort80": true
+			}, {
+				"Name":      "12d",
+				"RegionID":  12,
+				"HostName":  "derp12d.tailscale.com",
+				"IPv4":      "209.177.158.246",
+				"IPv6":      "2607:f740:e::811",
+				"CanPort80": true
+			}]
+		}, "13": {
+			"RegionID":   13,
+			"RegionCode": "den",
+			"RegionName": "Denver",
+			"Latitude":   39.7392,
+			"Longitude":  -104.9849,
+			"Nodes": [{
+				"Name":      "13c",
+				"RegionID":  13,
+				"HostName":  "derp13c.tailscale.com",
+				"IPv4":      "192.73.242.28",
+				"IPv6":      "2607:f740:16::5c",
+				"CanPort80": true
+			}, {
+				"Name":      "13d",
+				"RegionID":  13,
+				"HostName":  "derp13d.tailscale.com",
+				"IPv4":      "192.73.242.204",
+				"IPv6":      "2607:f740:16::c23",
+				"CanPort80": true
+			}, {
+				"Name":      "13b",
+				"RegionID":  13,
+				"HostName":  "derp13b.tailscale.com",
+				"IPv4":      "192.73.242.187",
+				"IPv6":      "2607:f740:16::640",
+				"CanPort80": true
+			}]
+		}, "14": {
+			"RegionID":   14,
+			"RegionCode": "ams",
+			"RegionName": "Amsterdam",
+			"Latitude":   52.372778,
+			"Longitude":  4.893611,
+			"Nodes": [{
+				"Name":      "14c",
+				"RegionID":  14,
+				"HostName":  "derp14c.tailscale.com",
+				"IPv4":      "176.58.93.147",
+				"IPv6":      "2a00:dd80:3c::b09",
+				"CanPort80": true
+			}, {
+				"Name":      "14d",
+				"RegionID":  14,
+				"HostName":  "derp14d.tailscale.com",
+				"IPv4":      "176.58.93.154",
+				"IPv6":      "2a00:dd80:3c::3d5",
+				"CanPort80": true
+			}, {
+				"Name":      "14b",
+				"RegionID":  14,
+				"HostName":  "derp14b.tailscale.com",
+				"IPv4":      "176.58.93.248",
+				"IPv6":      "2a00:dd80:3c::807",
+				"CanPort80": true
+			}]
+		}, "15": {
+			"RegionID":   15,
+			"RegionCode": "jnb",
+			"RegionName": "Johannesburg",
+			"Latitude":   -26.204444,
+			"Longitude":  28.045556,
+			"Nodes": [{
+				"Name":      "15c",
+				"RegionID":  15,
+				"HostName":  "derp15c.tailscale.com",
+				"IPv4":      "102.67.165.185",
+				"IPv6":      "2c0f:edb0:0:10::b59",
+				"CanPort80": true
+			}, {
+				"Name":      "15d",
+				"RegionID":  15,
+				"HostName":  "derp15d.tailscale.com",
+				"IPv4":      "102.67.165.36",
+				"IPv6":      "2c0f:edb0:0:10::599",
+				"CanPort80": true
+			}, {
+				"Name":      "15b",
+				"RegionID":  15,
+				"HostName":  "derp15b.tailscale.com",
+				"IPv4":      "102.67.165.90",
+				"IPv6":      "2c0f:edb0:0:10::963",
+				"CanPort80": true
+			}]
+		}, "16": {
+			"RegionID":   16,
+			"RegionCode": "mia",
+			"RegionName": "Miami",
+			"Latitude":   25.78,
+			"Longitude":  -80.21,
+			"Nodes": [{
+				"Name":      "16c",
+				"RegionID":  16,
+				"HostName":  "derp16c.tailscale.com",
+				"IPv4":      "192.73.243.229",
+				"IPv6":      "2607:f740:17::4e4",
+				"CanPort80": true
+			}, {
+				"Name":      "16d",
+				"RegionID":  16,
+				"HostName":  "derp16d.tailscale.com",
+				"IPv4":      "192.73.243.141",
+				"IPv6":      "2607:f740:17::475",
+				"CanPort80": true
+			}, {
+				"Name":      "16b",
+				"RegionID":  16,
+				"HostName":  "derp16b.tailscale.com",
+				"IPv4":      "192.73.243.135",
+				"IPv6":      "2607:f740:17::476",
+				"CanPort80": true
+			}]
+		}, "17": {
+			"RegionID":   17,
+			"RegionCode": "lax",
+			"RegionName": "Los Angeles",
+			"Latitude":   34.05,
+			"Longitude":  -118.25,
+			"Nodes": [{
+				"Name":      "17c",
+				"RegionID":  17,
+				"HostName":  "derp17c.tailscale.com",
+				"IPv4":      "208.111.40.12",
+				"IPv6":      "2607:f740:c::10",
+				"CanPort80": true
+			}, {
+				"Name":      "17d",
+				"RegionID":  17,
+				"HostName":  "derp17d.tailscale.com",
+				"IPv4":      "208.111.40.216",
+				"IPv6":      "2607:f740:c::e1b",
+				"CanPort80": true
+			}, {
+				"Name":      "17b",
+				"RegionID":  17,
+				"HostName":  "derp17b.tailscale.com",
+				"IPv4":      "192.73.244.245",
+				"IPv6":      "2607:f740:c::646",
+				"CanPort80": true
+			}]
+		}, "18": {
+			"RegionID":   18,
+			"RegionCode": "par",
+			"RegionName": "Paris",
+			"Latitude":   48.856667,
+			"Longitude":  2.352222,
+			"Nodes": [{
+				"Name":      "18c",
+				"RegionID":  18,
+				"HostName":  "derp18c.tailscale.com",
+				"IPv4":      "176.58.90.207",
+				"IPv6":      "2a00:dd80:3e::c19",
+				"CanPort80": true
+			}, {
+				"Name":      "18d",
+				"RegionID":  18,
+				"HostName":  "derp18d.tailscale.com",
+				"IPv4":      "176.58.90.104",
+				"IPv6":      "2a00:dd80:3e::f2e",
+				"CanPort80": true
+			}, {
+				"Name":      "18b",
+				"RegionID":  18,
+				"HostName":  "derp18b.tailscale.com",
+				"IPv4":      "176.58.90.147",
+				"IPv6":      "2a00:dd80:3e::363",
+				"CanPort80": true
+			}]
+		}, "19": {
+			"RegionID":   19,
+			"RegionCode": "mad",
+			"RegionName": "Madrid",
+			"Latitude":   40.416944,
+			"Longitude":  -3.703333,
+			"Nodes": [{
+				"Name":      "19c",
+				"RegionID":  19,
+				"HostName":  "derp19c.tailscale.com",
+				"IPv4":      "45.159.97.61",
+				"IPv6":      "2a00:dd80:14:10::20",
+				"CanPort80": true
+			}, {
+				"Name":      "19d",
+				"RegionID":  19,
+				"HostName":  "derp19d.tailscale.com",
+				"IPv4":      "45.159.97.233",
+				"IPv6":      "2a00:dd80:14:10::34a",
+				"CanPort80": true
+			}, {
+				"Name":      "19b",
+				"RegionID":  19,
+				"HostName":  "derp19b.tailscale.com",
+				"IPv4":      "45.159.97.144",
+				"IPv6":      "2a00:dd80:14:10::335",
+				"CanPort80": true
+			}]
+		}, "2": {
+			"RegionID":   2,
+			"RegionCode": "sfo",
+			"RegionName": "San Francisco",
+			"Latitude":   37.7775,
+			"Longitude":  -122.416389,
+			"Nodes": [{
+				"Name":      "2e",
+				"RegionID":  2,
+				"HostName":  "derp2e.tailscale.com",
+				"IPv4":      "192.73.252.134",
+				"IPv6":      "2607:f740:0:3f::44c",
+				"CanPort80": true
+			}, {
+				"Name":      "2f",
+				"RegionID":  2,
+				"HostName":  "derp2f.tailscale.com",
+				"IPv4":      "208.111.34.178",
+				"IPv6":      "2607:f740:0:3f::f4",
+				"CanPort80": true
+			}, {
+				"Name":      "2d",
+				"RegionID":  2,
+				"HostName":  "derp2d.tailscale.com",
+				"IPv4":      "192.73.252.65",
+				"IPv6":      "2607:f740:0:3f::287",
+				"CanPort80": true
+			}]
+		}, "20": {
+			"RegionID":   20,
+			"RegionCode": "hkg",
+			"RegionName": "Hong Kong",
+			"Latitude":   22.3193,
+			"Longitude":  114.1694,
+			"Nodes": [{
+				"Name":      "20c",
+				"RegionID":  20,
+				"HostName":  "derp20c.tailscale.com",
+				"IPv4":      "205.147.105.30",
+				"IPv6":      "2403:2500:8000:1::5fb",
+				"CanPort80": true
+			}, {
+				"Name":      "20d",
+				"RegionID":  20,
+				"HostName":  "derp20d.tailscale.com",
+				"IPv4":      "205.147.105.78",
+				"IPv6":      "2403:2500:8000:1::e9a",
+				"CanPort80": true
+			}, {
+				"Name":      "20b",
+				"RegionID":  20,
+				"HostName":  "derp20b.tailscale.com",
+				"IPv4":      "103.6.84.152",
+				"IPv6":      "2403:2500:8000:1::ef6",
+				"CanPort80": true
+			}]
+		}, "21": {
+			"RegionID":   21,
+			"RegionCode": "tor",
+			"RegionName": "Toronto",
+			"Latitude":   43.741667,
+			"Longitude":  -79.373333,
+			"Nodes": [{
+				"Name":      "21c",
+				"RegionID":  21,
+				"HostName":  "derp21c.tailscale.com",
+				"IPv4":      "162.248.221.215",
+				"IPv6":      "2607:f740:50::f10",
+				"CanPort80": true
+			}, {
+				"Name":      "21d",
+				"RegionID":  21,
+				"HostName":  "derp21d.tailscale.com",
+				"IPv4":      "162.248.221.248",
+				"IPv6":      "2607:f740:50::ca4",
+				"CanPort80": true
+			}, {
+				"Name":      "21b",
+				"RegionID":  21,
+				"HostName":  "derp21b.tailscale.com",
+				"IPv4":      "162.248.221.199",
+				"IPv6":      "2607:f740:50::1d1",
+				"CanPort80": true
+			}]
+		}, "22": {
+			"RegionID":   22,
+			"RegionCode": "waw",
+			"RegionName": "Warsaw",
+			"Latitude":   52.23,
+			"Longitude":  21.011111,
+			"Nodes": [{
+				"Name":      "22c",
+				"RegionID":  22,
+				"HostName":  "derp22c.tailscale.com",
+				"IPv4":      "45.159.98.253",
+				"IPv6":      "2a00:dd80:40:100::3f",
+				"CanPort80": true
+			}, {
+				"Name":      "22d",
+				"RegionID":  22,
+				"HostName":  "derp22d.tailscale.com",
+				"IPv4":      "45.159.98.145",
+				"IPv6":      "2a00:dd80:40:100::211",
+				"CanPort80": true
+			}, {
+				"Name":      "22b",
+				"RegionID":  22,
+				"HostName":  "derp22b.tailscale.com",
+				"IPv4":      "45.159.98.196",
+				"IPv6":      "2a00:dd80:40:100::316",
+				"CanPort80": true
+			}]
+		}, "23": {
+			"RegionID":   23,
+			"RegionCode": "dbi",
+			"RegionName": "Dubai",
+			"Latitude":   25.263056,
+			"Longitude":  55.297222,
+			"Nodes": [{
+				"Name":      "23c",
+				"RegionID":  23,
+				"HostName":  "derp23c.tailscale.com",
+				"IPv4":      "185.34.3.207",
+				"IPv6":      "2a00:dd80:3f:100::a50",
+				"CanPort80": true
+			}, {
+				"Name":      "23d",
+				"RegionID":  23,
+				"HostName":  "derp23d.tailscale.com",
+				"IPv4":      "185.34.3.75",
+				"IPv6":      "2a00:dd80:3f:100::97e",
+				"CanPort80": true
+			}, {
+				"Name":      "23b",
+				"RegionID":  23,
+				"HostName":  "derp23b.tailscale.com",
+				"IPv4":      "185.34.3.232",
+				"IPv6":      "2a00:dd80:3f:100::76f",
+				"CanPort80": true
+			}]
+		}, "24": {
+			"RegionID":   24,
+			"RegionCode": "hnl",
+			"RegionName": "Honolulu",
+			"Latitude":   21.306944,
+			"Longitude":  -157.858333,
+			"Nodes": [{
+				"Name":      "24c",
+				"RegionID":  24,
+				"HostName":  "derp24c.tailscale.com",
+				"IPv4":      "208.83.233.233",
+				"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+				"CanPort80": true
+			}, {
+				"Name":      "24d",
+				"RegionID":  24,
+				"HostName":  "derp24d.tailscale.com",
+				"IPv4":      "208.72.155.133",
+				"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+				"CanPort80": true
+			}, {
+				"Name":      "24b",
+				"RegionID":  24,
+				"HostName":  "derp24b.tailscale.com",
+				"IPv4":      "208.83.234.151",
+				"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+				"CanPort80": true
+			}]
+		}, "25": {
+			"RegionID":   25,
+			"RegionCode": "nai",
+			"RegionName": "Nairobi",
+			"Latitude":   -1.286389,
+			"Longitude":  36.817222,
+			"Nodes": [{
+				"Name":      "25c",
+				"RegionID":  25,
+				"HostName":  "derp25c.tailscale.com",
+				"IPv4":      "102.67.167.37",
+				"IPv6":      "2c0f:edb0:2000:1::2c7",
+				"CanPort80": true
+			}, {
+				"Name":      "25d",
+				"RegionID":  25,
+				"HostName":  "derp25d.tailscale.com",
+				"IPv4":      "102.67.167.188",
+				"IPv6":      "2c0f:edb0:2000:1::188",
+				"CanPort80": true
+			}, {
+				"Name":      "25b",
+				"RegionID":  25,
+				"HostName":  "derp25b.tailscale.com",
+				"IPv4":      "102.67.167.245",
+				"IPv6":      "2c0f:edb0:2000:1::2e9",
+				"CanPort80": true
+			}]
+		}, "26": {
+			"RegionID":   26,
+			"RegionCode": "nue",
+			"RegionName": "Nuremberg",
+			"Latitude":   49.453889,
+			"Longitude":  11.0775,
+			"Nodes": [{
+				"Name":      "26c",
+				"RegionID":  26,
+				"HostName":  "derp26c.tailscale.com",
+				"IPv4":      "49.12.193.137",
+				"IPv6":      "2a01:4f8:1c1c:5c70::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26d",
+				"RegionID":  26,
+				"HostName":  "derp26d.tailscale.com",
+				"IPv4":      "49.13.204.141",
+				"IPv6":      "2a01:4f8:1c0c:7d06::1",
+				"CanPort80": true
+			}, {
+				"Name":      "26b",
+				"RegionID":  26,
+				"HostName":  "derp26b.tailscale.com",
+				"IPv4":      "167.235.72.200",
+				"IPv6":      "2a01:4f8:1c1c:47b6::1",
+				"CanPort80": true
+			}]
+		}, "27": {
+			"RegionID":   27,
+			"RegionCode": "iad",
+			"RegionName": "Ashburn",
+			"Latitude":   39.03,
+			"Longitude":  -77.471111,
+			"Nodes": [{
+				"Name":      "27d",
+				"RegionID":  27,
+				"HostName":  "derp27d.tailscale.com",
+				"IPv4":      "178.156.152.106",
+				"IPv6":      "2a01:4ff:f0:3c8e::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27c",
+				"RegionID":  27,
+				"HostName":  "derp27c.tailscale.com",
+				"IPv4":      "178.156.152.91",
+				"IPv6":      "2a01:4ff:f0:3913::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27e",
+				"RegionID":  27,
+				"HostName":  "derp27e.tailscale.com",
+				"IPv4":      "178.156.134.232",
+				"IPv6":      "2a01:4ff:f0:28d4::1",
+				"CanPort80": true
+			}, {
+				"Name":      "27b",
+				"RegionID":  27,
+				"HostName":  "derp27b.tailscale.com",
+				"IPv4":      "5.161.218.233",
+				"IPv6":      "2a01:4ff:f0:3db9::1",
+				"CanPort80": true
+			}]
+		}, "28": {
+			"RegionID":   28,
+			"RegionCode": "hel",
+			"RegionName": "Helsinki",
+			"Latitude":   60.170833,
+			"Longitude":  24.9375,
+			"Nodes": [{
+				"Name":      "28c",
+				"RegionID":  28,
+				"HostName":  "derp28c.tailscale.com",
+				"IPv4":      "95.217.2.165",
+				"IPv6":      "2a01:4f9:c012:cd74::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28d",
+				"RegionID":  28,
+				"HostName":  "derp28d.tailscale.com",
+				"IPv4":      "157.180.28.32",
+				"IPv6":      "2a01:4f9:c012:2e5b::1",
+				"CanPort80": true
+			}, {
+				"Name":      "28b",
+				"RegionID":  28,
+				"HostName":  "derp28b.tailscale.com",
+				"IPv4":      "65.109.143.62",
+				"IPv6":      "2a01:4f9:c012:d55c::1",
+				"CanPort80": true
+			}]
+		}, "3": {
+			"RegionID":   3,
+			"RegionCode": "sin",
+			"RegionName": "Singapore",
+			"Latitude":   1.3521,
+			"Longitude":  103.8198,
+			"Nodes": [{
+				"Name":      "3g",
+				"RegionID":  3,
+				"HostName":  "derp3g.tailscale.com",
+				"IPv4":      "172.237.72.79",
+				"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+				"CanPort80": true
+			}, {
+				"Name":      "3f",
+				"RegionID":  3,
+				"HostName":  "derp3f.tailscale.com",
+				"IPv4":      "172.237.72.8",
+				"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+				"CanPort80": true
+			}, {
+				"Name":      "3h",
+				"RegionID":  3,
+				"HostName":  "derp3h.tailscale.com",
+				"IPv4":      "172.237.66.30",
+				"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+				"CanPort80": true
+			}, {
+				"Name":      "3e",
+				"RegionID":  3,
+				"HostName":  "derp3e.tailscale.com",
+				"IPv4":      "172.237.72.43",
+				"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+				"CanPort80": true
+			}]
+		}, "4": {
+			"RegionID":   4,
+			"RegionCode": "fra",
+			"RegionName": "Frankfurt",
+			"Latitude":   50.1109,
+			"Longitude":  8.6821,
+			"Nodes": [{
+				"Name":      "4h",
+				"RegionID":  4,
+				"HostName":  "derp4h.tailscale.com",
+				"IPv4":      "185.40.234.77",
+				"IPv6":      "2a00:dd80:20::bcf",
+				"CanPort80": true
+			}, {
+				"Name":      "4i",
+				"RegionID":  4,
+				"HostName":  "derp4i.tailscale.com",
+				"IPv4":      "185.40.234.53",
+				"IPv6":      "2a00:dd80:20::8a6",
+				"CanPort80": true
+			}, {
+				"Name":      "4g",
+				"RegionID":  4,
+				"HostName":  "derp4g.tailscale.com",
+				"IPv4":      "185.40.234.113",
+				"IPv6":      "2a00:dd80:20::8f",
+				"CanPort80": true
+			}, {
+				"Name":      "4j",
+				"RegionID":  4,
+				"HostName":  "derp4j.tailscale.com",
+				"IPv4":      "185.40.234.176",
+				"IPv6":      "2a00:dd80:20::e67",
+				"CanPort80": true
+			}, {
+				"Name":      "4f",
+				"RegionID":  4,
+				"HostName":  "derp4f.tailscale.com",
+				"IPv4":      "185.40.234.219",
+				"IPv6":      "2a00:dd80:20::a25",
+				"CanPort80": true
+			}]
+		}, "5": {
+			"RegionID":   5,
+			"RegionCode": "syd",
+			"RegionName": "Sydney",
+			"Latitude":   -33.867778,
+			"Longitude":  151.21,
+			"Nodes": [{
+				"Name":      "5f",
+				"RegionID":  5,
+				"HostName":  "derp5f.tailscale.com",
+				"IPv4":      "172.105.166.103",
+				"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+				"CanPort80": true
+			}, {
+				"Name":      "5g",
+				"RegionID":  5,
+				"HostName":  "derp5g.tailscale.com",
+				"IPv4":      "172.105.169.57",
+				"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+				"CanPort80": true
+			}, {
+				"Name":      "5e",
+				"RegionID":  5,
+				"HostName":  "derp5e.tailscale.com",
+				"IPv4":      "172.105.179.230",
+				"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+				"CanPort80": true
+			}]
+		}, "6": {
+			"RegionID":   6,
+			"RegionCode": "blr",
+			"RegionName": "Bengaluru",
+			"Latitude":   12.9716,
+			"Longitude":  77.5946,
+			"Nodes": [{
+				"Name":      "6a",
+				"RegionID":  6,
+				"HostName":  "derp6.tailscale.com",
+				"IPv4":      "68.183.90.120",
+				"IPv6":      "2400:6180:100:d0::982:d001",
+				"CanPort80": true
+			}]
+		}, "7": {
+			"RegionID":   7,
+			"RegionCode": "tok",
+			"RegionName": "Tokyo",
+			"Latitude":   35.6764,
+			"Longitude":  139.65,
+			"Nodes": [{
+				"Name":      "7g",
+				"RegionID":  7,
+				"HostName":  "derp7g.tailscale.com",
+				"IPv4":      "172.238.6.179",
+				"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+				"CanPort80": true
+			}, {
+				"Name":      "7f",
+				"RegionID":  7,
+				"HostName":  "derp7f.tailscale.com",
+				"IPv4":      "172.238.6.34",
+				"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+				"CanPort80": true
+			}, {
+				"Name":      "7h",
+				"RegionID":  7,
+				"HostName":  "derp7h.tailscale.com",
+				"IPv4":      "172.237.28.183",
+				"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+				"CanPort80": true
+			}, {
+				"Name":      "7e",
+				"RegionID":  7,
+				"HostName":  "derp7e.tailscale.com",
+				"IPv4":      "172.238.6.180",
+				"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+				"STUNOnly":  true,
+				"CanPort80": true
+			}]
+		}, "8": {
+			"RegionID":   8,
+			"RegionCode": "lhr",
+			"RegionName": "London",
+			"Latitude":   51.5072,
+			"Longitude":  0.1276,
+			"Nodes": [{
+				"Name":      "8f",
+				"RegionID":  8,
+				"HostName":  "derp8f.tailscale.com",
+				"IPv4":      "176.58.88.183",
+				"IPv6":      "2a00:dd80:3a::dfa",
+				"CanPort80": true
+			}, {
+				"Name":      "8g",
+				"RegionID":  8,
+				"HostName":  "derp8g.tailscale.com",
+				"IPv4":      "176.58.92.254",
+				"IPv6":      "2a00:dd80:3a::ed",
+				"CanPort80": true
+			}, {
+				"Name":      "8e",
+				"RegionID":  8,
+				"HostName":  "derp8e.tailscale.com",
+				"IPv4":      "176.58.92.144",
+				"IPv6":      "2a00:dd80:3a::b33",
+				"CanPort80": true
+			}]
+		}, "9": {
+			"RegionID":   9,
+			"RegionCode": "dfw",
+			"RegionName": "Dallas",
+			"Latitude":   32.779167,
+			"Longitude":  -96.808889,
+			"Nodes": [{
+				"Name":      "9e",
+				"RegionID":  9,
+				"HostName":  "derp9e.tailscale.com",
+				"IPv4":      "192.73.248.83",
+				"IPv6":      "2607:f740:100::359",
+				"CanPort80": true
+			}, {
+				"Name":      "9f",
+				"RegionID":  9,
+				"HostName":  "derp9f.tailscale.com",
+				"IPv4":      "209.177.156.197",
+				"IPv6":      "2607:f740:100::cad",
+				"CanPort80": true
+			}, {
+				"Name":      "9d",
+				"RegionID":  9,
+				"HostName":  "derp9d.tailscale.com",
+				"IPv4":      "209.177.156.94",
+				"IPv6":      "2607:f740:100::c05",
+				"CanPort80": true
+			}]
+		}}},
+		"DisplayMessages":  null,
+		"TKAEnabled":       false,
+		"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+		"Domain":           "odin@example.com",
+		"DomainAuditLogID": "",
+		"UserProfiles": {"5367623688116415": {
+			"ID":          5367623688116415,
+			"LoginName":   "weedle.tail78f774.ts.net",
+			"DisplayName": "weedle"
+		}}
+	}}}
+}

--- a/hscontrol/policy/v2/testdata/sshtest_results/sshtest-multi-rule-disjoint-srcs.hujson
+++ b/hscontrol/policy/v2/testdata/sshtest_results/sshtest-multi-rule-disjoint-srcs.hujson
@@ -1,0 +1,21904 @@
+// sshtest-multi-rule-disjoint-srcs
+//
+// sshTests two entries disjoint srcs, overlap accept
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-13T09:31:13Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "sshtest-multi-rule-disjoint-srcs",
+	"description":    "sshTests two entries disjoint srcs, overlap accept",
+	"category":       "sshtest",
+	"captured_at":    "2026-05-13T09:31:13.08475786Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                   \n  \n                                                                    \n                                                           \n{\n\t\"category\":    \"sshtest\",\n\t\"description\": \"sshTests two entries disjoint srcs, overlap accept\",\n\t\"id\":          \"sshtest-multi-rule-disjoint-srcs\",\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"thor@example.org\", \"freya@example.com\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"sshTests\": [{\n\t\t\"accept\": [\"root\"],\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    \"thor@example.org\"\n\t}, {\n\t\t\"accept\": [\"root\"],\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    \"freya@example.com\"\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/ssh-edges/sshtest-multi-rule-disjoint-srcs.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["thor@example.org", "freya@example.com"],
+				"users":  ["root"]
+			}],
+			"sshTests": [
+				{"accept": ["root"], "dst": ["tag:server"], "src": "thor@example.org"},
+				{"accept": ["root"], "dst": ["tag:server"], "src": "freya@example.com"}
+			],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         542612347419738,
+				"StableID":   "nKb44NWkE511CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       542612347419738,
+				"Key":        "nodekey:c28f5a3e4f5eb73dd696df9c66c1a16ca7f21f797c806d41b5c47b7ec5bf3865",
+				"DiscoKey":   "discokey:326b1c406d2c9d2d20af98068cd85525941e94c5a5f625ec9e198718474fef63",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41047",
+					"10.65.0.27:41047",
+					"172.17.0.1:41047",
+					"172.18.0.1:41047",
+					"172.19.0.1:41047",
+					"172.20.0.1:41047",
+					"172.21.0.1:41047",
+					"172.22.0.1:41047",
+					"172.23.0.1:41047",
+					"172.24.0.1:41047",
+					"172.25.0.1:41047",
+					"172.26.0.1:41047",
+					"172.27.0.1:41047"
+				],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:31:21.683118244Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c28f5a3e4f5eb73dd696df9c66c1a16ca7f21f797c806d41b5c47b7ec5bf3865",
+			"MachineKey": "mkey:53c021b9c9f4ae1ddac8c8b0ed1eeb89230ed461590efac913738d2fe4b8b27b",
+			"Peers": [{
+				"ID":         8254899363490767,
+				"StableID":   "nQqFB6DfT721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4a1194f21632107f9ae87c61cdcd49b5513de5f3bbed26c6ea57b140b1db5701",
+				"DiscoKey":   "discokey:92f7e062531900437d0ba7735f2a3eddddf7806a42f8d480bb5408e23df02a1c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33170",
+					"10.65.0.27:33170",
+					"172.17.0.1:33170",
+					"172.18.0.1:33170",
+					"172.19.0.1:33170",
+					"172.20.0.1:33170",
+					"172.21.0.1:33170",
+					"172.22.0.1:33170",
+					"172.23.0.1:33170",
+					"172.24.0.1:33170",
+					"172.25.0.1:33170",
+					"172.26.0.1:33170",
+					"172.27.0.1:33170"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:31:15.78345442Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7713901239591924,
+				"StableID":   "nXJgX67eE321CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:16430c93e36cb955fa5abbe7a66970fd73824f400bc4824e4e2fb05fda584851",
+				"DiscoKey":   "discokey:1f0d417a7eb8e9da3030dcc9df9a40888203abec575f3d9c891a01fe7210bb11",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33907",
+					"10.65.0.27:33907",
+					"172.17.0.1:33907",
+					"172.18.0.1:33907",
+					"172.19.0.1:33907",
+					"172.20.0.1:33907",
+					"172.21.0.1:33907",
+					"172.22.0.1:33907",
+					"172.23.0.1:33907",
+					"172.24.0.1:33907",
+					"172.25.0.1:33907",
+					"172.26.0.1:33907",
+					"172.27.0.1:33907"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:31:16.262119848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7582315319859850,
+				"StableID":   "nFZ2QqZ3D221CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:247f249080e7fd2fcafec11d46373b29a0f37a197ac2ef59c1435f1d422b8c3c",
+				"DiscoKey":   "discokey:7a7dead37ba78b3b7bd83b67e6be2144e406c5d732fc6c5fbfa9c4bec7b1d763",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53868",
+					"10.65.0.27:53868",
+					"172.17.0.1:53868",
+					"172.18.0.1:53868",
+					"172.19.0.1:53868",
+					"172.20.0.1:53868",
+					"172.21.0.1:53868",
+					"172.22.0.1:53868",
+					"172.23.0.1:53868",
+					"172.24.0.1:53868",
+					"172.25.0.1:53868",
+					"172.26.0.1:53868",
+					"172.27.0.1:53868"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:31:16.797992969Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2560487136403379,
+				"StableID":   "nJWXG1fezL11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a075406c8fb1cb5f698faac7a1f3ee254f055b9dde17771016caf1829caaed13",
+				"DiscoKey":   "discokey:c43b5c7425b822c56d547a0523ba075755cb2fc9dfaafba2af677d26a91eac38",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55128",
+					"10.65.0.27:55128",
+					"172.17.0.1:55128",
+					"172.18.0.1:55128",
+					"172.19.0.1:55128",
+					"172.20.0.1:55128",
+					"172.21.0.1:55128",
+					"172.22.0.1:55128",
+					"172.23.0.1:55128",
+					"172.24.0.1:55128",
+					"172.25.0.1:55128",
+					"172.26.0.1:55128",
+					"172.27.0.1:55128"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:31:17.345258924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6886132612070607,
+				"StableID":   "nx7aUZ2kmv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:416b01ff172fe185de22cd955bc5263b0635f48d4f3ff4fba027c05a87984a23",
+				"DiscoKey":   "discokey:1d733d12d18720d90ba1fba796e97c15eb4d46c05e86fc950ce119a5e13b1431",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57519",
+					"10.65.0.27:57519",
+					"172.17.0.1:57519",
+					"172.18.0.1:57519",
+					"172.19.0.1:57519",
+					"172.20.0.1:57519",
+					"172.21.0.1:57519",
+					"172.22.0.1:57519",
+					"172.23.0.1:57519",
+					"172.24.0.1:57519",
+					"172.25.0.1:57519",
+					"172.26.0.1:57519",
+					"172.27.0.1:57519"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:31:17.891339506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8870978364341213,
+				"StableID":   "nCcUpRZgGC21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:01be22a4271b5a219941164bbb03a5c6bac56e47a468eb99249bacef1e005e1b",
+				"DiscoKey":   "discokey:7dd974bc9382eda95714cf999a4a7b47342a17969920476e28605c6e23d35418",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53300",
+					"10.65.0.27:53300",
+					"172.17.0.1:53300",
+					"172.18.0.1:53300",
+					"172.19.0.1:53300",
+					"172.20.0.1:53300",
+					"172.21.0.1:53300",
+					"172.22.0.1:53300",
+					"172.23.0.1:53300",
+					"172.24.0.1:53300",
+					"172.25.0.1:53300",
+					"172.26.0.1:53300",
+					"172.27.0.1:53300"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:31:18.431901823Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2978985931168101,
+				"StableID":   "n21QgiuBGQ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:956795c1ace148b85e3853ea1448a5a30924e90590d358ad3842c5128c14e54a",
+				"DiscoKey":   "discokey:9f088eba31081936a97b75c0a2632506193f0af3d2cb856ec595399fdcfe755b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51397",
+					"10.65.0.27:51397",
+					"172.17.0.1:51397",
+					"172.18.0.1:51397",
+					"172.19.0.1:51397",
+					"172.20.0.1:51397",
+					"172.21.0.1:51397",
+					"172.22.0.1:51397",
+					"172.23.0.1:51397",
+					"172.24.0.1:51397",
+					"172.25.0.1:51397",
+					"172.26.0.1:51397",
+					"172.27.0.1:51397"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:31:18.982822055Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3513817186690356,
+				"StableID":   "nBebH72RSU11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0f9ef7377b722eef4a183de8a96300478faaaaad4ba9f3e902d9db2b5e23d50",
+				"DiscoKey":   "discokey:dbd521e7cc5e2b98779dbe4775b2072c536576f5683cc9e8162a15c670feb34c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36246",
+					"10.65.0.27:36246",
+					"172.17.0.1:36246",
+					"172.18.0.1:36246",
+					"172.19.0.1:36246",
+					"172.20.0.1:36246",
+					"172.21.0.1:36246",
+					"172.22.0.1:36246",
+					"172.23.0.1:36246",
+					"172.24.0.1:36246",
+					"172.25.0.1:36246",
+					"172.26.0.1:36246",
+					"172.27.0.1:36246"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:31:19.515350414Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4350398567006230,
+				"StableID":   "n1xK8RbJya11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47e43fc1bedbc5a00244bd79667ce9198bb13b954a1a0b61da50970657f29b2e",
+				"DiscoKey":   "discokey:7dd40082ad6ea9d3d553235d0fb0435acb20e33aa2d602ff0eafe476bf8f9f5f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41071",
+					"10.65.0.27:41071",
+					"172.17.0.1:41071",
+					"172.18.0.1:41071",
+					"172.19.0.1:41071",
+					"172.20.0.1:41071",
+					"172.21.0.1:41071",
+					"172.22.0.1:41071",
+					"172.23.0.1:41071",
+					"172.24.0.1:41071",
+					"172.25.0.1:41071",
+					"172.26.0.1:41071",
+					"172.27.0.1:41071"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:31:20.079613238Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2304635934592830,
+				"StableID":   "n3FjgvsmzJ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ddd03cabe5a0880bbfd631adbafc26e58abaceef3cbc85200f9556bd5661aa0e",
+				"DiscoKey":   "discokey:03ed13a450d2e8ad8127a5cb0dbd3e30cca5d59853fe38298e8e27e6ebb18306",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38225",
+					"10.65.0.27:38225",
+					"172.17.0.1:38225",
+					"172.18.0.1:38225",
+					"172.19.0.1:38225",
+					"172.20.0.1:38225",
+					"172.21.0.1:38225",
+					"172.22.0.1:38225",
+					"172.23.0.1:38225",
+					"172.24.0.1:38225",
+					"172.25.0.1:38225",
+					"172.26.0.1:38225",
+					"172.27.0.1:38225"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:31:20.585505115Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         147482855567493,
+				"StableID":   "nxg5vD8o9211CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb936fadd41580d07988f0e3cfd39b2789aa45093490bb15faec78200acd191f",
+				"DiscoKey":   "discokey:7e1c52975ca75e69853153072d371cdfdbd060a0b63604f15b2342549ba28360",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42585",
+					"10.65.0.27:42585",
+					"172.17.0.1:42585",
+					"172.18.0.1:42585",
+					"172.19.0.1:42585",
+					"172.20.0.1:42585",
+					"172.21.0.1:42585",
+					"172.22.0.1:42585",
+					"172.23.0.1:42585",
+					"172.24.0.1:42585",
+					"172.25.0.1:42585",
+					"172.26.0.1:42585",
+					"172.27.0.1:42585"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:31:21.132911497Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5033822017498422,
+				"StableID":   "nZp1BBypJg11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ad270101c86b4ba8f163650cd703a6a30d1afa0812420fd67d22053428610818",
+				"KeyExpiry":  "2026-11-09T09:31:22Z",
+				"DiscoKey":   "discokey:10d9dbdd6e5aa94d7ad0dfd0dccec2e1cd5152477d4b86549fe9d78b441aec6a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54827",
+					"10.65.0.27:54827",
+					"172.17.0.1:54827",
+					"172.18.0.1:54827",
+					"172.19.0.1:54827",
+					"172.20.0.1:54827",
+					"172.21.0.1:54827",
+					"172.22.0.1:54827",
+					"172.23.0.1:54827",
+					"172.24.0.1:54827",
+					"172.25.0.1:54827",
+					"172.26.0.1:54827",
+					"172.27.0.1:54827"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:31:22.241162786Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1541088879289822,
+				"StableID":   "n3b14vnx2D11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bf38ae3ffb81086e242916fe5677fa6413c03759c74eca417e8f919d50496d52",
+				"KeyExpiry":  "2026-11-09T09:31:22Z",
+				"DiscoKey":   "discokey:43e9e079f1484f1168947f0d1f887875890d578e9c57292d4adbf393afd63536",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46940",
+					"10.65.0.27:46940",
+					"172.17.0.1:46940",
+					"172.18.0.1:46940",
+					"172.19.0.1:46940",
+					"172.20.0.1:46940",
+					"172.21.0.1:46940",
+					"172.22.0.1:46940",
+					"172.23.0.1:46940",
+					"172.24.0.1:46940",
+					"172.25.0.1:46940",
+					"172.26.0.1:46940",
+					"172.27.0.1:46940"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:31:22.772693001Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5041737289897031,
+				"StableID":   "ngy1hatQNg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3bf5463099cdade9a63193475dfb9fc239ebac3df8c5723bdd2e6967663d7369",
+				"KeyExpiry":  "2026-11-09T09:31:23Z",
+				"DiscoKey":   "discokey:055e128b7b9c29b6b7f2f5e8554d6a59e03859db72d0fcf30fd18dd2b8c93915",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42339",
+					"10.65.0.27:42339",
+					"172.17.0.1:42339",
+					"172.18.0.1:42339",
+					"172.19.0.1:42339",
+					"172.20.0.1:42339",
+					"172.21.0.1:42339",
+					"172.22.0.1:42339",
+					"172.23.0.1:42339",
+					"172.24.0.1:42339",
+					"172.25.0.1:42339",
+					"172.26.0.1:42339",
+					"172.27.0.1:42339"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:31:23.312350289Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{"principals": [
+				{"nodeIP": "100.64.0.17"},
+				{"nodeIP": "100.64.0.18"},
+				{"nodeIP": "fd7a:115c:a1e0::11"},
+				{"nodeIP": "fd7a:115c:a1e0::12"}
+			], "sshUsers": {"root": "root"}, "action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "542612347419738": {
+				"ID":          542612347419738,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		},
+		"ssh_rules": [{"principals": [
+			{"nodeIP": "100.64.0.17"},
+			{"nodeIP": "100.64.0.18"},
+			{"nodeIP": "fd7a:115c:a1e0::11"},
+			{"nodeIP": "fd7a:115c:a1e0::12"}
+		], "sshUsers": {"root": "root"}, "action": {
+			"accept":                    true,
+			"allowAgentForwarding":      true,
+			"allowLocalPortForwarding":  true,
+			"allowRemotePortForwarding": true
+		}}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8870978364341213,
+				"StableID":   "nCcUpRZgGC21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       8870978364341213,
+				"Key":        "nodekey:01be22a4271b5a219941164bbb03a5c6bac56e47a468eb99249bacef1e005e1b",
+				"DiscoKey":   "discokey:7dd974bc9382eda95714cf999a4a7b47342a17969920476e28605c6e23d35418",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53300",
+					"10.65.0.27:53300",
+					"172.17.0.1:53300",
+					"172.18.0.1:53300",
+					"172.19.0.1:53300",
+					"172.20.0.1:53300",
+					"172.21.0.1:53300",
+					"172.22.0.1:53300",
+					"172.23.0.1:53300",
+					"172.24.0.1:53300",
+					"172.25.0.1:53300",
+					"172.26.0.1:53300",
+					"172.27.0.1:53300"
+				],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:31:18.431901823Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:01be22a4271b5a219941164bbb03a5c6bac56e47a468eb99249bacef1e005e1b",
+			"MachineKey": "mkey:5582d3623685e671b88d885f5cbf0ab1e842f20bdf49c46a2f5e5f74ca5fd622",
+			"Peers": [{
+				"ID":         8254899363490767,
+				"StableID":   "nQqFB6DfT721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4a1194f21632107f9ae87c61cdcd49b5513de5f3bbed26c6ea57b140b1db5701",
+				"DiscoKey":   "discokey:92f7e062531900437d0ba7735f2a3eddddf7806a42f8d480bb5408e23df02a1c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33170",
+					"10.65.0.27:33170",
+					"172.17.0.1:33170",
+					"172.18.0.1:33170",
+					"172.19.0.1:33170",
+					"172.20.0.1:33170",
+					"172.21.0.1:33170",
+					"172.22.0.1:33170",
+					"172.23.0.1:33170",
+					"172.24.0.1:33170",
+					"172.25.0.1:33170",
+					"172.26.0.1:33170",
+					"172.27.0.1:33170"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:31:15.78345442Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7713901239591924,
+				"StableID":   "nXJgX67eE321CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:16430c93e36cb955fa5abbe7a66970fd73824f400bc4824e4e2fb05fda584851",
+				"DiscoKey":   "discokey:1f0d417a7eb8e9da3030dcc9df9a40888203abec575f3d9c891a01fe7210bb11",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33907",
+					"10.65.0.27:33907",
+					"172.17.0.1:33907",
+					"172.18.0.1:33907",
+					"172.19.0.1:33907",
+					"172.20.0.1:33907",
+					"172.21.0.1:33907",
+					"172.22.0.1:33907",
+					"172.23.0.1:33907",
+					"172.24.0.1:33907",
+					"172.25.0.1:33907",
+					"172.26.0.1:33907",
+					"172.27.0.1:33907"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:31:16.262119848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7582315319859850,
+				"StableID":   "nFZ2QqZ3D221CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:247f249080e7fd2fcafec11d46373b29a0f37a197ac2ef59c1435f1d422b8c3c",
+				"DiscoKey":   "discokey:7a7dead37ba78b3b7bd83b67e6be2144e406c5d732fc6c5fbfa9c4bec7b1d763",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53868",
+					"10.65.0.27:53868",
+					"172.17.0.1:53868",
+					"172.18.0.1:53868",
+					"172.19.0.1:53868",
+					"172.20.0.1:53868",
+					"172.21.0.1:53868",
+					"172.22.0.1:53868",
+					"172.23.0.1:53868",
+					"172.24.0.1:53868",
+					"172.25.0.1:53868",
+					"172.26.0.1:53868",
+					"172.27.0.1:53868"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:31:16.797992969Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2560487136403379,
+				"StableID":   "nJWXG1fezL11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a075406c8fb1cb5f698faac7a1f3ee254f055b9dde17771016caf1829caaed13",
+				"DiscoKey":   "discokey:c43b5c7425b822c56d547a0523ba075755cb2fc9dfaafba2af677d26a91eac38",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55128",
+					"10.65.0.27:55128",
+					"172.17.0.1:55128",
+					"172.18.0.1:55128",
+					"172.19.0.1:55128",
+					"172.20.0.1:55128",
+					"172.21.0.1:55128",
+					"172.22.0.1:55128",
+					"172.23.0.1:55128",
+					"172.24.0.1:55128",
+					"172.25.0.1:55128",
+					"172.26.0.1:55128",
+					"172.27.0.1:55128"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:31:17.345258924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6886132612070607,
+				"StableID":   "nx7aUZ2kmv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:416b01ff172fe185de22cd955bc5263b0635f48d4f3ff4fba027c05a87984a23",
+				"DiscoKey":   "discokey:1d733d12d18720d90ba1fba796e97c15eb4d46c05e86fc950ce119a5e13b1431",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57519",
+					"10.65.0.27:57519",
+					"172.17.0.1:57519",
+					"172.18.0.1:57519",
+					"172.19.0.1:57519",
+					"172.20.0.1:57519",
+					"172.21.0.1:57519",
+					"172.22.0.1:57519",
+					"172.23.0.1:57519",
+					"172.24.0.1:57519",
+					"172.25.0.1:57519",
+					"172.26.0.1:57519",
+					"172.27.0.1:57519"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:31:17.891339506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2978985931168101,
+				"StableID":   "n21QgiuBGQ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:956795c1ace148b85e3853ea1448a5a30924e90590d358ad3842c5128c14e54a",
+				"DiscoKey":   "discokey:9f088eba31081936a97b75c0a2632506193f0af3d2cb856ec595399fdcfe755b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51397",
+					"10.65.0.27:51397",
+					"172.17.0.1:51397",
+					"172.18.0.1:51397",
+					"172.19.0.1:51397",
+					"172.20.0.1:51397",
+					"172.21.0.1:51397",
+					"172.22.0.1:51397",
+					"172.23.0.1:51397",
+					"172.24.0.1:51397",
+					"172.25.0.1:51397",
+					"172.26.0.1:51397",
+					"172.27.0.1:51397"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:31:18.982822055Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3513817186690356,
+				"StableID":   "nBebH72RSU11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0f9ef7377b722eef4a183de8a96300478faaaaad4ba9f3e902d9db2b5e23d50",
+				"DiscoKey":   "discokey:dbd521e7cc5e2b98779dbe4775b2072c536576f5683cc9e8162a15c670feb34c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36246",
+					"10.65.0.27:36246",
+					"172.17.0.1:36246",
+					"172.18.0.1:36246",
+					"172.19.0.1:36246",
+					"172.20.0.1:36246",
+					"172.21.0.1:36246",
+					"172.22.0.1:36246",
+					"172.23.0.1:36246",
+					"172.24.0.1:36246",
+					"172.25.0.1:36246",
+					"172.26.0.1:36246",
+					"172.27.0.1:36246"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:31:19.515350414Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4350398567006230,
+				"StableID":   "n1xK8RbJya11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47e43fc1bedbc5a00244bd79667ce9198bb13b954a1a0b61da50970657f29b2e",
+				"DiscoKey":   "discokey:7dd40082ad6ea9d3d553235d0fb0435acb20e33aa2d602ff0eafe476bf8f9f5f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41071",
+					"10.65.0.27:41071",
+					"172.17.0.1:41071",
+					"172.18.0.1:41071",
+					"172.19.0.1:41071",
+					"172.20.0.1:41071",
+					"172.21.0.1:41071",
+					"172.22.0.1:41071",
+					"172.23.0.1:41071",
+					"172.24.0.1:41071",
+					"172.25.0.1:41071",
+					"172.26.0.1:41071",
+					"172.27.0.1:41071"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:31:20.079613238Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2304635934592830,
+				"StableID":   "n3FjgvsmzJ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ddd03cabe5a0880bbfd631adbafc26e58abaceef3cbc85200f9556bd5661aa0e",
+				"DiscoKey":   "discokey:03ed13a450d2e8ad8127a5cb0dbd3e30cca5d59853fe38298e8e27e6ebb18306",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38225",
+					"10.65.0.27:38225",
+					"172.17.0.1:38225",
+					"172.18.0.1:38225",
+					"172.19.0.1:38225",
+					"172.20.0.1:38225",
+					"172.21.0.1:38225",
+					"172.22.0.1:38225",
+					"172.23.0.1:38225",
+					"172.24.0.1:38225",
+					"172.25.0.1:38225",
+					"172.26.0.1:38225",
+					"172.27.0.1:38225"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:31:20.585505115Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         147482855567493,
+				"StableID":   "nxg5vD8o9211CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb936fadd41580d07988f0e3cfd39b2789aa45093490bb15faec78200acd191f",
+				"DiscoKey":   "discokey:7e1c52975ca75e69853153072d371cdfdbd060a0b63604f15b2342549ba28360",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42585",
+					"10.65.0.27:42585",
+					"172.17.0.1:42585",
+					"172.18.0.1:42585",
+					"172.19.0.1:42585",
+					"172.20.0.1:42585",
+					"172.21.0.1:42585",
+					"172.22.0.1:42585",
+					"172.23.0.1:42585",
+					"172.24.0.1:42585",
+					"172.25.0.1:42585",
+					"172.26.0.1:42585",
+					"172.27.0.1:42585"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:31:21.132911497Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         542612347419738,
+				"StableID":   "nKb44NWkE511CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c28f5a3e4f5eb73dd696df9c66c1a16ca7f21f797c806d41b5c47b7ec5bf3865",
+				"DiscoKey":   "discokey:326b1c406d2c9d2d20af98068cd85525941e94c5a5f625ec9e198718474fef63",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41047",
+					"10.65.0.27:41047",
+					"172.17.0.1:41047",
+					"172.18.0.1:41047",
+					"172.19.0.1:41047",
+					"172.20.0.1:41047",
+					"172.21.0.1:41047",
+					"172.22.0.1:41047",
+					"172.23.0.1:41047",
+					"172.24.0.1:41047",
+					"172.25.0.1:41047",
+					"172.26.0.1:41047",
+					"172.27.0.1:41047"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:31:21.683118244Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5033822017498422,
+				"StableID":   "nZp1BBypJg11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ad270101c86b4ba8f163650cd703a6a30d1afa0812420fd67d22053428610818",
+				"KeyExpiry":  "2026-11-09T09:31:22Z",
+				"DiscoKey":   "discokey:10d9dbdd6e5aa94d7ad0dfd0dccec2e1cd5152477d4b86549fe9d78b441aec6a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54827",
+					"10.65.0.27:54827",
+					"172.17.0.1:54827",
+					"172.18.0.1:54827",
+					"172.19.0.1:54827",
+					"172.20.0.1:54827",
+					"172.21.0.1:54827",
+					"172.22.0.1:54827",
+					"172.23.0.1:54827",
+					"172.24.0.1:54827",
+					"172.25.0.1:54827",
+					"172.26.0.1:54827",
+					"172.27.0.1:54827"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:31:22.241162786Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1541088879289822,
+				"StableID":   "n3b14vnx2D11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bf38ae3ffb81086e242916fe5677fa6413c03759c74eca417e8f919d50496d52",
+				"KeyExpiry":  "2026-11-09T09:31:22Z",
+				"DiscoKey":   "discokey:43e9e079f1484f1168947f0d1f887875890d578e9c57292d4adbf393afd63536",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46940",
+					"10.65.0.27:46940",
+					"172.17.0.1:46940",
+					"172.18.0.1:46940",
+					"172.19.0.1:46940",
+					"172.20.0.1:46940",
+					"172.21.0.1:46940",
+					"172.22.0.1:46940",
+					"172.23.0.1:46940",
+					"172.24.0.1:46940",
+					"172.25.0.1:46940",
+					"172.26.0.1:46940",
+					"172.27.0.1:46940"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:31:22.772693001Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5041737289897031,
+				"StableID":   "ngy1hatQNg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3bf5463099cdade9a63193475dfb9fc239ebac3df8c5723bdd2e6967663d7369",
+				"KeyExpiry":  "2026-11-09T09:31:23Z",
+				"DiscoKey":   "discokey:055e128b7b9c29b6b7f2f5e8554d6a59e03859db72d0fcf30fd18dd2b8c93915",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42339",
+					"10.65.0.27:42339",
+					"172.17.0.1:42339",
+					"172.18.0.1:42339",
+					"172.19.0.1:42339",
+					"172.20.0.1:42339",
+					"172.21.0.1:42339",
+					"172.22.0.1:42339",
+					"172.23.0.1:42339",
+					"172.24.0.1:42339",
+					"172.25.0.1:42339",
+					"172.26.0.1:42339",
+					"172.27.0.1:42339"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:31:23.312350289Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8870978364341213": {
+				"ID":          8870978364341213,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5041737289897031,
+				"StableID":   "ngy1hatQNg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3bf5463099cdade9a63193475dfb9fc239ebac3df8c5723bdd2e6967663d7369",
+				"KeyExpiry":  "2026-11-09T09:31:23Z",
+				"DiscoKey":   "discokey:055e128b7b9c29b6b7f2f5e8554d6a59e03859db72d0fcf30fd18dd2b8c93915",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42339",
+					"10.65.0.27:42339",
+					"172.17.0.1:42339",
+					"172.18.0.1:42339",
+					"172.19.0.1:42339",
+					"172.20.0.1:42339",
+					"172.21.0.1:42339",
+					"172.22.0.1:42339",
+					"172.23.0.1:42339",
+					"172.24.0.1:42339",
+					"172.25.0.1:42339",
+					"172.26.0.1:42339",
+					"172.27.0.1:42339"
+				],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:31:23.312350289Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:3bf5463099cdade9a63193475dfb9fc239ebac3df8c5723bdd2e6967663d7369",
+			"MachineKey": "mkey:6810090c4baee28c1cf9771bf886489db9687e333abe3d0745cf066e1afd3279",
+			"Peers": [{
+				"ID":         8254899363490767,
+				"StableID":   "nQqFB6DfT721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4a1194f21632107f9ae87c61cdcd49b5513de5f3bbed26c6ea57b140b1db5701",
+				"DiscoKey":   "discokey:92f7e062531900437d0ba7735f2a3eddddf7806a42f8d480bb5408e23df02a1c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33170",
+					"10.65.0.27:33170",
+					"172.17.0.1:33170",
+					"172.18.0.1:33170",
+					"172.19.0.1:33170",
+					"172.20.0.1:33170",
+					"172.21.0.1:33170",
+					"172.22.0.1:33170",
+					"172.23.0.1:33170",
+					"172.24.0.1:33170",
+					"172.25.0.1:33170",
+					"172.26.0.1:33170",
+					"172.27.0.1:33170"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:31:15.78345442Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7713901239591924,
+				"StableID":   "nXJgX67eE321CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:16430c93e36cb955fa5abbe7a66970fd73824f400bc4824e4e2fb05fda584851",
+				"DiscoKey":   "discokey:1f0d417a7eb8e9da3030dcc9df9a40888203abec575f3d9c891a01fe7210bb11",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33907",
+					"10.65.0.27:33907",
+					"172.17.0.1:33907",
+					"172.18.0.1:33907",
+					"172.19.0.1:33907",
+					"172.20.0.1:33907",
+					"172.21.0.1:33907",
+					"172.22.0.1:33907",
+					"172.23.0.1:33907",
+					"172.24.0.1:33907",
+					"172.25.0.1:33907",
+					"172.26.0.1:33907",
+					"172.27.0.1:33907"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:31:16.262119848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7582315319859850,
+				"StableID":   "nFZ2QqZ3D221CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:247f249080e7fd2fcafec11d46373b29a0f37a197ac2ef59c1435f1d422b8c3c",
+				"DiscoKey":   "discokey:7a7dead37ba78b3b7bd83b67e6be2144e406c5d732fc6c5fbfa9c4bec7b1d763",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53868",
+					"10.65.0.27:53868",
+					"172.17.0.1:53868",
+					"172.18.0.1:53868",
+					"172.19.0.1:53868",
+					"172.20.0.1:53868",
+					"172.21.0.1:53868",
+					"172.22.0.1:53868",
+					"172.23.0.1:53868",
+					"172.24.0.1:53868",
+					"172.25.0.1:53868",
+					"172.26.0.1:53868",
+					"172.27.0.1:53868"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:31:16.797992969Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2560487136403379,
+				"StableID":   "nJWXG1fezL11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a075406c8fb1cb5f698faac7a1f3ee254f055b9dde17771016caf1829caaed13",
+				"DiscoKey":   "discokey:c43b5c7425b822c56d547a0523ba075755cb2fc9dfaafba2af677d26a91eac38",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55128",
+					"10.65.0.27:55128",
+					"172.17.0.1:55128",
+					"172.18.0.1:55128",
+					"172.19.0.1:55128",
+					"172.20.0.1:55128",
+					"172.21.0.1:55128",
+					"172.22.0.1:55128",
+					"172.23.0.1:55128",
+					"172.24.0.1:55128",
+					"172.25.0.1:55128",
+					"172.26.0.1:55128",
+					"172.27.0.1:55128"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:31:17.345258924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6886132612070607,
+				"StableID":   "nx7aUZ2kmv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:416b01ff172fe185de22cd955bc5263b0635f48d4f3ff4fba027c05a87984a23",
+				"DiscoKey":   "discokey:1d733d12d18720d90ba1fba796e97c15eb4d46c05e86fc950ce119a5e13b1431",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57519",
+					"10.65.0.27:57519",
+					"172.17.0.1:57519",
+					"172.18.0.1:57519",
+					"172.19.0.1:57519",
+					"172.20.0.1:57519",
+					"172.21.0.1:57519",
+					"172.22.0.1:57519",
+					"172.23.0.1:57519",
+					"172.24.0.1:57519",
+					"172.25.0.1:57519",
+					"172.26.0.1:57519",
+					"172.27.0.1:57519"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:31:17.891339506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8870978364341213,
+				"StableID":   "nCcUpRZgGC21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:01be22a4271b5a219941164bbb03a5c6bac56e47a468eb99249bacef1e005e1b",
+				"DiscoKey":   "discokey:7dd974bc9382eda95714cf999a4a7b47342a17969920476e28605c6e23d35418",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53300",
+					"10.65.0.27:53300",
+					"172.17.0.1:53300",
+					"172.18.0.1:53300",
+					"172.19.0.1:53300",
+					"172.20.0.1:53300",
+					"172.21.0.1:53300",
+					"172.22.0.1:53300",
+					"172.23.0.1:53300",
+					"172.24.0.1:53300",
+					"172.25.0.1:53300",
+					"172.26.0.1:53300",
+					"172.27.0.1:53300"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:31:18.431901823Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2978985931168101,
+				"StableID":   "n21QgiuBGQ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:956795c1ace148b85e3853ea1448a5a30924e90590d358ad3842c5128c14e54a",
+				"DiscoKey":   "discokey:9f088eba31081936a97b75c0a2632506193f0af3d2cb856ec595399fdcfe755b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51397",
+					"10.65.0.27:51397",
+					"172.17.0.1:51397",
+					"172.18.0.1:51397",
+					"172.19.0.1:51397",
+					"172.20.0.1:51397",
+					"172.21.0.1:51397",
+					"172.22.0.1:51397",
+					"172.23.0.1:51397",
+					"172.24.0.1:51397",
+					"172.25.0.1:51397",
+					"172.26.0.1:51397",
+					"172.27.0.1:51397"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:31:18.982822055Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3513817186690356,
+				"StableID":   "nBebH72RSU11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0f9ef7377b722eef4a183de8a96300478faaaaad4ba9f3e902d9db2b5e23d50",
+				"DiscoKey":   "discokey:dbd521e7cc5e2b98779dbe4775b2072c536576f5683cc9e8162a15c670feb34c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36246",
+					"10.65.0.27:36246",
+					"172.17.0.1:36246",
+					"172.18.0.1:36246",
+					"172.19.0.1:36246",
+					"172.20.0.1:36246",
+					"172.21.0.1:36246",
+					"172.22.0.1:36246",
+					"172.23.0.1:36246",
+					"172.24.0.1:36246",
+					"172.25.0.1:36246",
+					"172.26.0.1:36246",
+					"172.27.0.1:36246"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:31:19.515350414Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4350398567006230,
+				"StableID":   "n1xK8RbJya11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47e43fc1bedbc5a00244bd79667ce9198bb13b954a1a0b61da50970657f29b2e",
+				"DiscoKey":   "discokey:7dd40082ad6ea9d3d553235d0fb0435acb20e33aa2d602ff0eafe476bf8f9f5f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41071",
+					"10.65.0.27:41071",
+					"172.17.0.1:41071",
+					"172.18.0.1:41071",
+					"172.19.0.1:41071",
+					"172.20.0.1:41071",
+					"172.21.0.1:41071",
+					"172.22.0.1:41071",
+					"172.23.0.1:41071",
+					"172.24.0.1:41071",
+					"172.25.0.1:41071",
+					"172.26.0.1:41071",
+					"172.27.0.1:41071"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:31:20.079613238Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2304635934592830,
+				"StableID":   "n3FjgvsmzJ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ddd03cabe5a0880bbfd631adbafc26e58abaceef3cbc85200f9556bd5661aa0e",
+				"DiscoKey":   "discokey:03ed13a450d2e8ad8127a5cb0dbd3e30cca5d59853fe38298e8e27e6ebb18306",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38225",
+					"10.65.0.27:38225",
+					"172.17.0.1:38225",
+					"172.18.0.1:38225",
+					"172.19.0.1:38225",
+					"172.20.0.1:38225",
+					"172.21.0.1:38225",
+					"172.22.0.1:38225",
+					"172.23.0.1:38225",
+					"172.24.0.1:38225",
+					"172.25.0.1:38225",
+					"172.26.0.1:38225",
+					"172.27.0.1:38225"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:31:20.585505115Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         147482855567493,
+				"StableID":   "nxg5vD8o9211CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb936fadd41580d07988f0e3cfd39b2789aa45093490bb15faec78200acd191f",
+				"DiscoKey":   "discokey:7e1c52975ca75e69853153072d371cdfdbd060a0b63604f15b2342549ba28360",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42585",
+					"10.65.0.27:42585",
+					"172.17.0.1:42585",
+					"172.18.0.1:42585",
+					"172.19.0.1:42585",
+					"172.20.0.1:42585",
+					"172.21.0.1:42585",
+					"172.22.0.1:42585",
+					"172.23.0.1:42585",
+					"172.24.0.1:42585",
+					"172.25.0.1:42585",
+					"172.26.0.1:42585",
+					"172.27.0.1:42585"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:31:21.132911497Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         542612347419738,
+				"StableID":   "nKb44NWkE511CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c28f5a3e4f5eb73dd696df9c66c1a16ca7f21f797c806d41b5c47b7ec5bf3865",
+				"DiscoKey":   "discokey:326b1c406d2c9d2d20af98068cd85525941e94c5a5f625ec9e198718474fef63",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41047",
+					"10.65.0.27:41047",
+					"172.17.0.1:41047",
+					"172.18.0.1:41047",
+					"172.19.0.1:41047",
+					"172.20.0.1:41047",
+					"172.21.0.1:41047",
+					"172.22.0.1:41047",
+					"172.23.0.1:41047",
+					"172.24.0.1:41047",
+					"172.25.0.1:41047",
+					"172.26.0.1:41047",
+					"172.27.0.1:41047"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:31:21.683118244Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5033822017498422,
+				"StableID":   "nZp1BBypJg11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ad270101c86b4ba8f163650cd703a6a30d1afa0812420fd67d22053428610818",
+				"KeyExpiry":  "2026-11-09T09:31:22Z",
+				"DiscoKey":   "discokey:10d9dbdd6e5aa94d7ad0dfd0dccec2e1cd5152477d4b86549fe9d78b441aec6a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54827",
+					"10.65.0.27:54827",
+					"172.17.0.1:54827",
+					"172.18.0.1:54827",
+					"172.19.0.1:54827",
+					"172.20.0.1:54827",
+					"172.21.0.1:54827",
+					"172.22.0.1:54827",
+					"172.23.0.1:54827",
+					"172.24.0.1:54827",
+					"172.25.0.1:54827",
+					"172.26.0.1:54827",
+					"172.27.0.1:54827"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:31:22.241162786Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1541088879289822,
+				"StableID":   "n3b14vnx2D11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bf38ae3ffb81086e242916fe5677fa6413c03759c74eca417e8f919d50496d52",
+				"KeyExpiry":  "2026-11-09T09:31:22Z",
+				"DiscoKey":   "discokey:43e9e079f1484f1168947f0d1f887875890d578e9c57292d4adbf393afd63536",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46940",
+					"10.65.0.27:46940",
+					"172.17.0.1:46940",
+					"172.18.0.1:46940",
+					"172.19.0.1:46940",
+					"172.20.0.1:46940",
+					"172.21.0.1:46940",
+					"172.22.0.1:46940",
+					"172.23.0.1:46940",
+					"172.24.0.1:46940",
+					"172.25.0.1:46940",
+					"172.26.0.1:46940",
+					"172.27.0.1:46940"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:31:22.772693001Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7582315319859850,
+				"StableID":   "nFZ2QqZ3D221CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       7582315319859850,
+				"Key":        "nodekey:247f249080e7fd2fcafec11d46373b29a0f37a197ac2ef59c1435f1d422b8c3c",
+				"DiscoKey":   "discokey:7a7dead37ba78b3b7bd83b67e6be2144e406c5d732fc6c5fbfa9c4bec7b1d763",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53868",
+					"10.65.0.27:53868",
+					"172.17.0.1:53868",
+					"172.18.0.1:53868",
+					"172.19.0.1:53868",
+					"172.20.0.1:53868",
+					"172.21.0.1:53868",
+					"172.22.0.1:53868",
+					"172.23.0.1:53868",
+					"172.24.0.1:53868",
+					"172.25.0.1:53868",
+					"172.26.0.1:53868",
+					"172.27.0.1:53868"
+				],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:31:16.797992969Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:247f249080e7fd2fcafec11d46373b29a0f37a197ac2ef59c1435f1d422b8c3c",
+			"MachineKey": "mkey:8bae45747ba9f00d16da593b34958d4e3f41d392cc35dc14b1e24024a0c8790f",
+			"Peers": [{
+				"ID":         8254899363490767,
+				"StableID":   "nQqFB6DfT721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4a1194f21632107f9ae87c61cdcd49b5513de5f3bbed26c6ea57b140b1db5701",
+				"DiscoKey":   "discokey:92f7e062531900437d0ba7735f2a3eddddf7806a42f8d480bb5408e23df02a1c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33170",
+					"10.65.0.27:33170",
+					"172.17.0.1:33170",
+					"172.18.0.1:33170",
+					"172.19.0.1:33170",
+					"172.20.0.1:33170",
+					"172.21.0.1:33170",
+					"172.22.0.1:33170",
+					"172.23.0.1:33170",
+					"172.24.0.1:33170",
+					"172.25.0.1:33170",
+					"172.26.0.1:33170",
+					"172.27.0.1:33170"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:31:15.78345442Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7713901239591924,
+				"StableID":   "nXJgX67eE321CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:16430c93e36cb955fa5abbe7a66970fd73824f400bc4824e4e2fb05fda584851",
+				"DiscoKey":   "discokey:1f0d417a7eb8e9da3030dcc9df9a40888203abec575f3d9c891a01fe7210bb11",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33907",
+					"10.65.0.27:33907",
+					"172.17.0.1:33907",
+					"172.18.0.1:33907",
+					"172.19.0.1:33907",
+					"172.20.0.1:33907",
+					"172.21.0.1:33907",
+					"172.22.0.1:33907",
+					"172.23.0.1:33907",
+					"172.24.0.1:33907",
+					"172.25.0.1:33907",
+					"172.26.0.1:33907",
+					"172.27.0.1:33907"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:31:16.262119848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         2560487136403379,
+				"StableID":   "nJWXG1fezL11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a075406c8fb1cb5f698faac7a1f3ee254f055b9dde17771016caf1829caaed13",
+				"DiscoKey":   "discokey:c43b5c7425b822c56d547a0523ba075755cb2fc9dfaafba2af677d26a91eac38",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55128",
+					"10.65.0.27:55128",
+					"172.17.0.1:55128",
+					"172.18.0.1:55128",
+					"172.19.0.1:55128",
+					"172.20.0.1:55128",
+					"172.21.0.1:55128",
+					"172.22.0.1:55128",
+					"172.23.0.1:55128",
+					"172.24.0.1:55128",
+					"172.25.0.1:55128",
+					"172.26.0.1:55128",
+					"172.27.0.1:55128"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:31:17.345258924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6886132612070607,
+				"StableID":   "nx7aUZ2kmv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:416b01ff172fe185de22cd955bc5263b0635f48d4f3ff4fba027c05a87984a23",
+				"DiscoKey":   "discokey:1d733d12d18720d90ba1fba796e97c15eb4d46c05e86fc950ce119a5e13b1431",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57519",
+					"10.65.0.27:57519",
+					"172.17.0.1:57519",
+					"172.18.0.1:57519",
+					"172.19.0.1:57519",
+					"172.20.0.1:57519",
+					"172.21.0.1:57519",
+					"172.22.0.1:57519",
+					"172.23.0.1:57519",
+					"172.24.0.1:57519",
+					"172.25.0.1:57519",
+					"172.26.0.1:57519",
+					"172.27.0.1:57519"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:31:17.891339506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8870978364341213,
+				"StableID":   "nCcUpRZgGC21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:01be22a4271b5a219941164bbb03a5c6bac56e47a468eb99249bacef1e005e1b",
+				"DiscoKey":   "discokey:7dd974bc9382eda95714cf999a4a7b47342a17969920476e28605c6e23d35418",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53300",
+					"10.65.0.27:53300",
+					"172.17.0.1:53300",
+					"172.18.0.1:53300",
+					"172.19.0.1:53300",
+					"172.20.0.1:53300",
+					"172.21.0.1:53300",
+					"172.22.0.1:53300",
+					"172.23.0.1:53300",
+					"172.24.0.1:53300",
+					"172.25.0.1:53300",
+					"172.26.0.1:53300",
+					"172.27.0.1:53300"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:31:18.431901823Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2978985931168101,
+				"StableID":   "n21QgiuBGQ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:956795c1ace148b85e3853ea1448a5a30924e90590d358ad3842c5128c14e54a",
+				"DiscoKey":   "discokey:9f088eba31081936a97b75c0a2632506193f0af3d2cb856ec595399fdcfe755b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51397",
+					"10.65.0.27:51397",
+					"172.17.0.1:51397",
+					"172.18.0.1:51397",
+					"172.19.0.1:51397",
+					"172.20.0.1:51397",
+					"172.21.0.1:51397",
+					"172.22.0.1:51397",
+					"172.23.0.1:51397",
+					"172.24.0.1:51397",
+					"172.25.0.1:51397",
+					"172.26.0.1:51397",
+					"172.27.0.1:51397"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:31:18.982822055Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3513817186690356,
+				"StableID":   "nBebH72RSU11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0f9ef7377b722eef4a183de8a96300478faaaaad4ba9f3e902d9db2b5e23d50",
+				"DiscoKey":   "discokey:dbd521e7cc5e2b98779dbe4775b2072c536576f5683cc9e8162a15c670feb34c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36246",
+					"10.65.0.27:36246",
+					"172.17.0.1:36246",
+					"172.18.0.1:36246",
+					"172.19.0.1:36246",
+					"172.20.0.1:36246",
+					"172.21.0.1:36246",
+					"172.22.0.1:36246",
+					"172.23.0.1:36246",
+					"172.24.0.1:36246",
+					"172.25.0.1:36246",
+					"172.26.0.1:36246",
+					"172.27.0.1:36246"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:31:19.515350414Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4350398567006230,
+				"StableID":   "n1xK8RbJya11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47e43fc1bedbc5a00244bd79667ce9198bb13b954a1a0b61da50970657f29b2e",
+				"DiscoKey":   "discokey:7dd40082ad6ea9d3d553235d0fb0435acb20e33aa2d602ff0eafe476bf8f9f5f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41071",
+					"10.65.0.27:41071",
+					"172.17.0.1:41071",
+					"172.18.0.1:41071",
+					"172.19.0.1:41071",
+					"172.20.0.1:41071",
+					"172.21.0.1:41071",
+					"172.22.0.1:41071",
+					"172.23.0.1:41071",
+					"172.24.0.1:41071",
+					"172.25.0.1:41071",
+					"172.26.0.1:41071",
+					"172.27.0.1:41071"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:31:20.079613238Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2304635934592830,
+				"StableID":   "n3FjgvsmzJ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ddd03cabe5a0880bbfd631adbafc26e58abaceef3cbc85200f9556bd5661aa0e",
+				"DiscoKey":   "discokey:03ed13a450d2e8ad8127a5cb0dbd3e30cca5d59853fe38298e8e27e6ebb18306",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38225",
+					"10.65.0.27:38225",
+					"172.17.0.1:38225",
+					"172.18.0.1:38225",
+					"172.19.0.1:38225",
+					"172.20.0.1:38225",
+					"172.21.0.1:38225",
+					"172.22.0.1:38225",
+					"172.23.0.1:38225",
+					"172.24.0.1:38225",
+					"172.25.0.1:38225",
+					"172.26.0.1:38225",
+					"172.27.0.1:38225"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:31:20.585505115Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         147482855567493,
+				"StableID":   "nxg5vD8o9211CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb936fadd41580d07988f0e3cfd39b2789aa45093490bb15faec78200acd191f",
+				"DiscoKey":   "discokey:7e1c52975ca75e69853153072d371cdfdbd060a0b63604f15b2342549ba28360",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42585",
+					"10.65.0.27:42585",
+					"172.17.0.1:42585",
+					"172.18.0.1:42585",
+					"172.19.0.1:42585",
+					"172.20.0.1:42585",
+					"172.21.0.1:42585",
+					"172.22.0.1:42585",
+					"172.23.0.1:42585",
+					"172.24.0.1:42585",
+					"172.25.0.1:42585",
+					"172.26.0.1:42585",
+					"172.27.0.1:42585"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:31:21.132911497Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         542612347419738,
+				"StableID":   "nKb44NWkE511CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c28f5a3e4f5eb73dd696df9c66c1a16ca7f21f797c806d41b5c47b7ec5bf3865",
+				"DiscoKey":   "discokey:326b1c406d2c9d2d20af98068cd85525941e94c5a5f625ec9e198718474fef63",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41047",
+					"10.65.0.27:41047",
+					"172.17.0.1:41047",
+					"172.18.0.1:41047",
+					"172.19.0.1:41047",
+					"172.20.0.1:41047",
+					"172.21.0.1:41047",
+					"172.22.0.1:41047",
+					"172.23.0.1:41047",
+					"172.24.0.1:41047",
+					"172.25.0.1:41047",
+					"172.26.0.1:41047",
+					"172.27.0.1:41047"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:31:21.683118244Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5033822017498422,
+				"StableID":   "nZp1BBypJg11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ad270101c86b4ba8f163650cd703a6a30d1afa0812420fd67d22053428610818",
+				"KeyExpiry":  "2026-11-09T09:31:22Z",
+				"DiscoKey":   "discokey:10d9dbdd6e5aa94d7ad0dfd0dccec2e1cd5152477d4b86549fe9d78b441aec6a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54827",
+					"10.65.0.27:54827",
+					"172.17.0.1:54827",
+					"172.18.0.1:54827",
+					"172.19.0.1:54827",
+					"172.20.0.1:54827",
+					"172.21.0.1:54827",
+					"172.22.0.1:54827",
+					"172.23.0.1:54827",
+					"172.24.0.1:54827",
+					"172.25.0.1:54827",
+					"172.26.0.1:54827",
+					"172.27.0.1:54827"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:31:22.241162786Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1541088879289822,
+				"StableID":   "n3b14vnx2D11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bf38ae3ffb81086e242916fe5677fa6413c03759c74eca417e8f919d50496d52",
+				"KeyExpiry":  "2026-11-09T09:31:22Z",
+				"DiscoKey":   "discokey:43e9e079f1484f1168947f0d1f887875890d578e9c57292d4adbf393afd63536",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46940",
+					"10.65.0.27:46940",
+					"172.17.0.1:46940",
+					"172.18.0.1:46940",
+					"172.19.0.1:46940",
+					"172.20.0.1:46940",
+					"172.21.0.1:46940",
+					"172.22.0.1:46940",
+					"172.23.0.1:46940",
+					"172.24.0.1:46940",
+					"172.25.0.1:46940",
+					"172.26.0.1:46940",
+					"172.27.0.1:46940"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:31:22.772693001Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5041737289897031,
+				"StableID":   "ngy1hatQNg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3bf5463099cdade9a63193475dfb9fc239ebac3df8c5723bdd2e6967663d7369",
+				"KeyExpiry":  "2026-11-09T09:31:23Z",
+				"DiscoKey":   "discokey:055e128b7b9c29b6b7f2f5e8554d6a59e03859db72d0fcf30fd18dd2b8c93915",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42339",
+					"10.65.0.27:42339",
+					"172.17.0.1:42339",
+					"172.18.0.1:42339",
+					"172.19.0.1:42339",
+					"172.20.0.1:42339",
+					"172.21.0.1:42339",
+					"172.22.0.1:42339",
+					"172.23.0.1:42339",
+					"172.24.0.1:42339",
+					"172.25.0.1:42339",
+					"172.26.0.1:42339",
+					"172.27.0.1:42339"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:31:23.312350289Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7582315319859850": {
+				"ID":          7582315319859850,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3513817186690356,
+				"StableID":   "nBebH72RSU11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       3513817186690356,
+				"Key":        "nodekey:b0f9ef7377b722eef4a183de8a96300478faaaaad4ba9f3e902d9db2b5e23d50",
+				"DiscoKey":   "discokey:dbd521e7cc5e2b98779dbe4775b2072c536576f5683cc9e8162a15c670feb34c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36246",
+					"10.65.0.27:36246",
+					"172.17.0.1:36246",
+					"172.18.0.1:36246",
+					"172.19.0.1:36246",
+					"172.20.0.1:36246",
+					"172.21.0.1:36246",
+					"172.22.0.1:36246",
+					"172.23.0.1:36246",
+					"172.24.0.1:36246",
+					"172.25.0.1:36246",
+					"172.26.0.1:36246",
+					"172.27.0.1:36246"
+				],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:31:19.515350414Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b0f9ef7377b722eef4a183de8a96300478faaaaad4ba9f3e902d9db2b5e23d50",
+			"MachineKey": "mkey:6c8a80da0064177792768618a36de60fcf3409a33bfbc1f55585143d9ae90836",
+			"Peers": [{
+				"ID":         8254899363490767,
+				"StableID":   "nQqFB6DfT721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4a1194f21632107f9ae87c61cdcd49b5513de5f3bbed26c6ea57b140b1db5701",
+				"DiscoKey":   "discokey:92f7e062531900437d0ba7735f2a3eddddf7806a42f8d480bb5408e23df02a1c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33170",
+					"10.65.0.27:33170",
+					"172.17.0.1:33170",
+					"172.18.0.1:33170",
+					"172.19.0.1:33170",
+					"172.20.0.1:33170",
+					"172.21.0.1:33170",
+					"172.22.0.1:33170",
+					"172.23.0.1:33170",
+					"172.24.0.1:33170",
+					"172.25.0.1:33170",
+					"172.26.0.1:33170",
+					"172.27.0.1:33170"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:31:15.78345442Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7713901239591924,
+				"StableID":   "nXJgX67eE321CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:16430c93e36cb955fa5abbe7a66970fd73824f400bc4824e4e2fb05fda584851",
+				"DiscoKey":   "discokey:1f0d417a7eb8e9da3030dcc9df9a40888203abec575f3d9c891a01fe7210bb11",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33907",
+					"10.65.0.27:33907",
+					"172.17.0.1:33907",
+					"172.18.0.1:33907",
+					"172.19.0.1:33907",
+					"172.20.0.1:33907",
+					"172.21.0.1:33907",
+					"172.22.0.1:33907",
+					"172.23.0.1:33907",
+					"172.24.0.1:33907",
+					"172.25.0.1:33907",
+					"172.26.0.1:33907",
+					"172.27.0.1:33907"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:31:16.262119848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7582315319859850,
+				"StableID":   "nFZ2QqZ3D221CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:247f249080e7fd2fcafec11d46373b29a0f37a197ac2ef59c1435f1d422b8c3c",
+				"DiscoKey":   "discokey:7a7dead37ba78b3b7bd83b67e6be2144e406c5d732fc6c5fbfa9c4bec7b1d763",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53868",
+					"10.65.0.27:53868",
+					"172.17.0.1:53868",
+					"172.18.0.1:53868",
+					"172.19.0.1:53868",
+					"172.20.0.1:53868",
+					"172.21.0.1:53868",
+					"172.22.0.1:53868",
+					"172.23.0.1:53868",
+					"172.24.0.1:53868",
+					"172.25.0.1:53868",
+					"172.26.0.1:53868",
+					"172.27.0.1:53868"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:31:16.797992969Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2560487136403379,
+				"StableID":   "nJWXG1fezL11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a075406c8fb1cb5f698faac7a1f3ee254f055b9dde17771016caf1829caaed13",
+				"DiscoKey":   "discokey:c43b5c7425b822c56d547a0523ba075755cb2fc9dfaafba2af677d26a91eac38",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55128",
+					"10.65.0.27:55128",
+					"172.17.0.1:55128",
+					"172.18.0.1:55128",
+					"172.19.0.1:55128",
+					"172.20.0.1:55128",
+					"172.21.0.1:55128",
+					"172.22.0.1:55128",
+					"172.23.0.1:55128",
+					"172.24.0.1:55128",
+					"172.25.0.1:55128",
+					"172.26.0.1:55128",
+					"172.27.0.1:55128"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:31:17.345258924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6886132612070607,
+				"StableID":   "nx7aUZ2kmv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:416b01ff172fe185de22cd955bc5263b0635f48d4f3ff4fba027c05a87984a23",
+				"DiscoKey":   "discokey:1d733d12d18720d90ba1fba796e97c15eb4d46c05e86fc950ce119a5e13b1431",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57519",
+					"10.65.0.27:57519",
+					"172.17.0.1:57519",
+					"172.18.0.1:57519",
+					"172.19.0.1:57519",
+					"172.20.0.1:57519",
+					"172.21.0.1:57519",
+					"172.22.0.1:57519",
+					"172.23.0.1:57519",
+					"172.24.0.1:57519",
+					"172.25.0.1:57519",
+					"172.26.0.1:57519",
+					"172.27.0.1:57519"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:31:17.891339506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8870978364341213,
+				"StableID":   "nCcUpRZgGC21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:01be22a4271b5a219941164bbb03a5c6bac56e47a468eb99249bacef1e005e1b",
+				"DiscoKey":   "discokey:7dd974bc9382eda95714cf999a4a7b47342a17969920476e28605c6e23d35418",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53300",
+					"10.65.0.27:53300",
+					"172.17.0.1:53300",
+					"172.18.0.1:53300",
+					"172.19.0.1:53300",
+					"172.20.0.1:53300",
+					"172.21.0.1:53300",
+					"172.22.0.1:53300",
+					"172.23.0.1:53300",
+					"172.24.0.1:53300",
+					"172.25.0.1:53300",
+					"172.26.0.1:53300",
+					"172.27.0.1:53300"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:31:18.431901823Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2978985931168101,
+				"StableID":   "n21QgiuBGQ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:956795c1ace148b85e3853ea1448a5a30924e90590d358ad3842c5128c14e54a",
+				"DiscoKey":   "discokey:9f088eba31081936a97b75c0a2632506193f0af3d2cb856ec595399fdcfe755b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51397",
+					"10.65.0.27:51397",
+					"172.17.0.1:51397",
+					"172.18.0.1:51397",
+					"172.19.0.1:51397",
+					"172.20.0.1:51397",
+					"172.21.0.1:51397",
+					"172.22.0.1:51397",
+					"172.23.0.1:51397",
+					"172.24.0.1:51397",
+					"172.25.0.1:51397",
+					"172.26.0.1:51397",
+					"172.27.0.1:51397"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:31:18.982822055Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4350398567006230,
+				"StableID":   "n1xK8RbJya11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47e43fc1bedbc5a00244bd79667ce9198bb13b954a1a0b61da50970657f29b2e",
+				"DiscoKey":   "discokey:7dd40082ad6ea9d3d553235d0fb0435acb20e33aa2d602ff0eafe476bf8f9f5f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41071",
+					"10.65.0.27:41071",
+					"172.17.0.1:41071",
+					"172.18.0.1:41071",
+					"172.19.0.1:41071",
+					"172.20.0.1:41071",
+					"172.21.0.1:41071",
+					"172.22.0.1:41071",
+					"172.23.0.1:41071",
+					"172.24.0.1:41071",
+					"172.25.0.1:41071",
+					"172.26.0.1:41071",
+					"172.27.0.1:41071"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:31:20.079613238Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2304635934592830,
+				"StableID":   "n3FjgvsmzJ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ddd03cabe5a0880bbfd631adbafc26e58abaceef3cbc85200f9556bd5661aa0e",
+				"DiscoKey":   "discokey:03ed13a450d2e8ad8127a5cb0dbd3e30cca5d59853fe38298e8e27e6ebb18306",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38225",
+					"10.65.0.27:38225",
+					"172.17.0.1:38225",
+					"172.18.0.1:38225",
+					"172.19.0.1:38225",
+					"172.20.0.1:38225",
+					"172.21.0.1:38225",
+					"172.22.0.1:38225",
+					"172.23.0.1:38225",
+					"172.24.0.1:38225",
+					"172.25.0.1:38225",
+					"172.26.0.1:38225",
+					"172.27.0.1:38225"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:31:20.585505115Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         147482855567493,
+				"StableID":   "nxg5vD8o9211CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb936fadd41580d07988f0e3cfd39b2789aa45093490bb15faec78200acd191f",
+				"DiscoKey":   "discokey:7e1c52975ca75e69853153072d371cdfdbd060a0b63604f15b2342549ba28360",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42585",
+					"10.65.0.27:42585",
+					"172.17.0.1:42585",
+					"172.18.0.1:42585",
+					"172.19.0.1:42585",
+					"172.20.0.1:42585",
+					"172.21.0.1:42585",
+					"172.22.0.1:42585",
+					"172.23.0.1:42585",
+					"172.24.0.1:42585",
+					"172.25.0.1:42585",
+					"172.26.0.1:42585",
+					"172.27.0.1:42585"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:31:21.132911497Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         542612347419738,
+				"StableID":   "nKb44NWkE511CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c28f5a3e4f5eb73dd696df9c66c1a16ca7f21f797c806d41b5c47b7ec5bf3865",
+				"DiscoKey":   "discokey:326b1c406d2c9d2d20af98068cd85525941e94c5a5f625ec9e198718474fef63",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41047",
+					"10.65.0.27:41047",
+					"172.17.0.1:41047",
+					"172.18.0.1:41047",
+					"172.19.0.1:41047",
+					"172.20.0.1:41047",
+					"172.21.0.1:41047",
+					"172.22.0.1:41047",
+					"172.23.0.1:41047",
+					"172.24.0.1:41047",
+					"172.25.0.1:41047",
+					"172.26.0.1:41047",
+					"172.27.0.1:41047"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:31:21.683118244Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5033822017498422,
+				"StableID":   "nZp1BBypJg11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ad270101c86b4ba8f163650cd703a6a30d1afa0812420fd67d22053428610818",
+				"KeyExpiry":  "2026-11-09T09:31:22Z",
+				"DiscoKey":   "discokey:10d9dbdd6e5aa94d7ad0dfd0dccec2e1cd5152477d4b86549fe9d78b441aec6a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54827",
+					"10.65.0.27:54827",
+					"172.17.0.1:54827",
+					"172.18.0.1:54827",
+					"172.19.0.1:54827",
+					"172.20.0.1:54827",
+					"172.21.0.1:54827",
+					"172.22.0.1:54827",
+					"172.23.0.1:54827",
+					"172.24.0.1:54827",
+					"172.25.0.1:54827",
+					"172.26.0.1:54827",
+					"172.27.0.1:54827"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:31:22.241162786Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1541088879289822,
+				"StableID":   "n3b14vnx2D11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bf38ae3ffb81086e242916fe5677fa6413c03759c74eca417e8f919d50496d52",
+				"KeyExpiry":  "2026-11-09T09:31:22Z",
+				"DiscoKey":   "discokey:43e9e079f1484f1168947f0d1f887875890d578e9c57292d4adbf393afd63536",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46940",
+					"10.65.0.27:46940",
+					"172.17.0.1:46940",
+					"172.18.0.1:46940",
+					"172.19.0.1:46940",
+					"172.20.0.1:46940",
+					"172.21.0.1:46940",
+					"172.22.0.1:46940",
+					"172.23.0.1:46940",
+					"172.24.0.1:46940",
+					"172.25.0.1:46940",
+					"172.26.0.1:46940",
+					"172.27.0.1:46940"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:31:22.772693001Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5041737289897031,
+				"StableID":   "ngy1hatQNg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3bf5463099cdade9a63193475dfb9fc239ebac3df8c5723bdd2e6967663d7369",
+				"KeyExpiry":  "2026-11-09T09:31:23Z",
+				"DiscoKey":   "discokey:055e128b7b9c29b6b7f2f5e8554d6a59e03859db72d0fcf30fd18dd2b8c93915",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42339",
+					"10.65.0.27:42339",
+					"172.17.0.1:42339",
+					"172.18.0.1:42339",
+					"172.19.0.1:42339",
+					"172.20.0.1:42339",
+					"172.21.0.1:42339",
+					"172.22.0.1:42339",
+					"172.23.0.1:42339",
+					"172.24.0.1:42339",
+					"172.25.0.1:42339",
+					"172.26.0.1:42339",
+					"172.27.0.1:42339"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:31:23.312350289Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3513817186690356": {
+				"ID":          3513817186690356,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5033822017498422,
+				"StableID":   "nZp1BBypJg11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ad270101c86b4ba8f163650cd703a6a30d1afa0812420fd67d22053428610818",
+				"KeyExpiry":  "2026-11-09T09:31:22Z",
+				"DiscoKey":   "discokey:10d9dbdd6e5aa94d7ad0dfd0dccec2e1cd5152477d4b86549fe9d78b441aec6a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54827",
+					"10.65.0.27:54827",
+					"172.17.0.1:54827",
+					"172.18.0.1:54827",
+					"172.19.0.1:54827",
+					"172.20.0.1:54827",
+					"172.21.0.1:54827",
+					"172.22.0.1:54827",
+					"172.23.0.1:54827",
+					"172.24.0.1:54827",
+					"172.25.0.1:54827",
+					"172.26.0.1:54827",
+					"172.27.0.1:54827"
+				],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:31:22.241162786Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ad270101c86b4ba8f163650cd703a6a30d1afa0812420fd67d22053428610818",
+			"MachineKey": "mkey:0214f7e826f3b562c3c3f5d5147344cfd1efdadf4443a9bb970aebf3d53cb766",
+			"Peers": [{
+				"ID":         8254899363490767,
+				"StableID":   "nQqFB6DfT721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4a1194f21632107f9ae87c61cdcd49b5513de5f3bbed26c6ea57b140b1db5701",
+				"DiscoKey":   "discokey:92f7e062531900437d0ba7735f2a3eddddf7806a42f8d480bb5408e23df02a1c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33170",
+					"10.65.0.27:33170",
+					"172.17.0.1:33170",
+					"172.18.0.1:33170",
+					"172.19.0.1:33170",
+					"172.20.0.1:33170",
+					"172.21.0.1:33170",
+					"172.22.0.1:33170",
+					"172.23.0.1:33170",
+					"172.24.0.1:33170",
+					"172.25.0.1:33170",
+					"172.26.0.1:33170",
+					"172.27.0.1:33170"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:31:15.78345442Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7713901239591924,
+				"StableID":   "nXJgX67eE321CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:16430c93e36cb955fa5abbe7a66970fd73824f400bc4824e4e2fb05fda584851",
+				"DiscoKey":   "discokey:1f0d417a7eb8e9da3030dcc9df9a40888203abec575f3d9c891a01fe7210bb11",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33907",
+					"10.65.0.27:33907",
+					"172.17.0.1:33907",
+					"172.18.0.1:33907",
+					"172.19.0.1:33907",
+					"172.20.0.1:33907",
+					"172.21.0.1:33907",
+					"172.22.0.1:33907",
+					"172.23.0.1:33907",
+					"172.24.0.1:33907",
+					"172.25.0.1:33907",
+					"172.26.0.1:33907",
+					"172.27.0.1:33907"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:31:16.262119848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7582315319859850,
+				"StableID":   "nFZ2QqZ3D221CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:247f249080e7fd2fcafec11d46373b29a0f37a197ac2ef59c1435f1d422b8c3c",
+				"DiscoKey":   "discokey:7a7dead37ba78b3b7bd83b67e6be2144e406c5d732fc6c5fbfa9c4bec7b1d763",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53868",
+					"10.65.0.27:53868",
+					"172.17.0.1:53868",
+					"172.18.0.1:53868",
+					"172.19.0.1:53868",
+					"172.20.0.1:53868",
+					"172.21.0.1:53868",
+					"172.22.0.1:53868",
+					"172.23.0.1:53868",
+					"172.24.0.1:53868",
+					"172.25.0.1:53868",
+					"172.26.0.1:53868",
+					"172.27.0.1:53868"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:31:16.797992969Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2560487136403379,
+				"StableID":   "nJWXG1fezL11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a075406c8fb1cb5f698faac7a1f3ee254f055b9dde17771016caf1829caaed13",
+				"DiscoKey":   "discokey:c43b5c7425b822c56d547a0523ba075755cb2fc9dfaafba2af677d26a91eac38",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55128",
+					"10.65.0.27:55128",
+					"172.17.0.1:55128",
+					"172.18.0.1:55128",
+					"172.19.0.1:55128",
+					"172.20.0.1:55128",
+					"172.21.0.1:55128",
+					"172.22.0.1:55128",
+					"172.23.0.1:55128",
+					"172.24.0.1:55128",
+					"172.25.0.1:55128",
+					"172.26.0.1:55128",
+					"172.27.0.1:55128"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:31:17.345258924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6886132612070607,
+				"StableID":   "nx7aUZ2kmv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:416b01ff172fe185de22cd955bc5263b0635f48d4f3ff4fba027c05a87984a23",
+				"DiscoKey":   "discokey:1d733d12d18720d90ba1fba796e97c15eb4d46c05e86fc950ce119a5e13b1431",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57519",
+					"10.65.0.27:57519",
+					"172.17.0.1:57519",
+					"172.18.0.1:57519",
+					"172.19.0.1:57519",
+					"172.20.0.1:57519",
+					"172.21.0.1:57519",
+					"172.22.0.1:57519",
+					"172.23.0.1:57519",
+					"172.24.0.1:57519",
+					"172.25.0.1:57519",
+					"172.26.0.1:57519",
+					"172.27.0.1:57519"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:31:17.891339506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8870978364341213,
+				"StableID":   "nCcUpRZgGC21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:01be22a4271b5a219941164bbb03a5c6bac56e47a468eb99249bacef1e005e1b",
+				"DiscoKey":   "discokey:7dd974bc9382eda95714cf999a4a7b47342a17969920476e28605c6e23d35418",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53300",
+					"10.65.0.27:53300",
+					"172.17.0.1:53300",
+					"172.18.0.1:53300",
+					"172.19.0.1:53300",
+					"172.20.0.1:53300",
+					"172.21.0.1:53300",
+					"172.22.0.1:53300",
+					"172.23.0.1:53300",
+					"172.24.0.1:53300",
+					"172.25.0.1:53300",
+					"172.26.0.1:53300",
+					"172.27.0.1:53300"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:31:18.431901823Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2978985931168101,
+				"StableID":   "n21QgiuBGQ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:956795c1ace148b85e3853ea1448a5a30924e90590d358ad3842c5128c14e54a",
+				"DiscoKey":   "discokey:9f088eba31081936a97b75c0a2632506193f0af3d2cb856ec595399fdcfe755b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51397",
+					"10.65.0.27:51397",
+					"172.17.0.1:51397",
+					"172.18.0.1:51397",
+					"172.19.0.1:51397",
+					"172.20.0.1:51397",
+					"172.21.0.1:51397",
+					"172.22.0.1:51397",
+					"172.23.0.1:51397",
+					"172.24.0.1:51397",
+					"172.25.0.1:51397",
+					"172.26.0.1:51397",
+					"172.27.0.1:51397"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:31:18.982822055Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3513817186690356,
+				"StableID":   "nBebH72RSU11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0f9ef7377b722eef4a183de8a96300478faaaaad4ba9f3e902d9db2b5e23d50",
+				"DiscoKey":   "discokey:dbd521e7cc5e2b98779dbe4775b2072c536576f5683cc9e8162a15c670feb34c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36246",
+					"10.65.0.27:36246",
+					"172.17.0.1:36246",
+					"172.18.0.1:36246",
+					"172.19.0.1:36246",
+					"172.20.0.1:36246",
+					"172.21.0.1:36246",
+					"172.22.0.1:36246",
+					"172.23.0.1:36246",
+					"172.24.0.1:36246",
+					"172.25.0.1:36246",
+					"172.26.0.1:36246",
+					"172.27.0.1:36246"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:31:19.515350414Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4350398567006230,
+				"StableID":   "n1xK8RbJya11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47e43fc1bedbc5a00244bd79667ce9198bb13b954a1a0b61da50970657f29b2e",
+				"DiscoKey":   "discokey:7dd40082ad6ea9d3d553235d0fb0435acb20e33aa2d602ff0eafe476bf8f9f5f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41071",
+					"10.65.0.27:41071",
+					"172.17.0.1:41071",
+					"172.18.0.1:41071",
+					"172.19.0.1:41071",
+					"172.20.0.1:41071",
+					"172.21.0.1:41071",
+					"172.22.0.1:41071",
+					"172.23.0.1:41071",
+					"172.24.0.1:41071",
+					"172.25.0.1:41071",
+					"172.26.0.1:41071",
+					"172.27.0.1:41071"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:31:20.079613238Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2304635934592830,
+				"StableID":   "n3FjgvsmzJ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ddd03cabe5a0880bbfd631adbafc26e58abaceef3cbc85200f9556bd5661aa0e",
+				"DiscoKey":   "discokey:03ed13a450d2e8ad8127a5cb0dbd3e30cca5d59853fe38298e8e27e6ebb18306",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38225",
+					"10.65.0.27:38225",
+					"172.17.0.1:38225",
+					"172.18.0.1:38225",
+					"172.19.0.1:38225",
+					"172.20.0.1:38225",
+					"172.21.0.1:38225",
+					"172.22.0.1:38225",
+					"172.23.0.1:38225",
+					"172.24.0.1:38225",
+					"172.25.0.1:38225",
+					"172.26.0.1:38225",
+					"172.27.0.1:38225"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:31:20.585505115Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         147482855567493,
+				"StableID":   "nxg5vD8o9211CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb936fadd41580d07988f0e3cfd39b2789aa45093490bb15faec78200acd191f",
+				"DiscoKey":   "discokey:7e1c52975ca75e69853153072d371cdfdbd060a0b63604f15b2342549ba28360",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42585",
+					"10.65.0.27:42585",
+					"172.17.0.1:42585",
+					"172.18.0.1:42585",
+					"172.19.0.1:42585",
+					"172.20.0.1:42585",
+					"172.21.0.1:42585",
+					"172.22.0.1:42585",
+					"172.23.0.1:42585",
+					"172.24.0.1:42585",
+					"172.25.0.1:42585",
+					"172.26.0.1:42585",
+					"172.27.0.1:42585"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:31:21.132911497Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         542612347419738,
+				"StableID":   "nKb44NWkE511CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c28f5a3e4f5eb73dd696df9c66c1a16ca7f21f797c806d41b5c47b7ec5bf3865",
+				"DiscoKey":   "discokey:326b1c406d2c9d2d20af98068cd85525941e94c5a5f625ec9e198718474fef63",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41047",
+					"10.65.0.27:41047",
+					"172.17.0.1:41047",
+					"172.18.0.1:41047",
+					"172.19.0.1:41047",
+					"172.20.0.1:41047",
+					"172.21.0.1:41047",
+					"172.22.0.1:41047",
+					"172.23.0.1:41047",
+					"172.24.0.1:41047",
+					"172.25.0.1:41047",
+					"172.26.0.1:41047",
+					"172.27.0.1:41047"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:31:21.683118244Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1541088879289822,
+				"StableID":   "n3b14vnx2D11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bf38ae3ffb81086e242916fe5677fa6413c03759c74eca417e8f919d50496d52",
+				"KeyExpiry":  "2026-11-09T09:31:22Z",
+				"DiscoKey":   "discokey:43e9e079f1484f1168947f0d1f887875890d578e9c57292d4adbf393afd63536",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46940",
+					"10.65.0.27:46940",
+					"172.17.0.1:46940",
+					"172.18.0.1:46940",
+					"172.19.0.1:46940",
+					"172.20.0.1:46940",
+					"172.21.0.1:46940",
+					"172.22.0.1:46940",
+					"172.23.0.1:46940",
+					"172.24.0.1:46940",
+					"172.25.0.1:46940",
+					"172.26.0.1:46940",
+					"172.27.0.1:46940"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:31:22.772693001Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5041737289897031,
+				"StableID":   "ngy1hatQNg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3bf5463099cdade9a63193475dfb9fc239ebac3df8c5723bdd2e6967663d7369",
+				"KeyExpiry":  "2026-11-09T09:31:23Z",
+				"DiscoKey":   "discokey:055e128b7b9c29b6b7f2f5e8554d6a59e03859db72d0fcf30fd18dd2b8c93915",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42339",
+					"10.65.0.27:42339",
+					"172.17.0.1:42339",
+					"172.18.0.1:42339",
+					"172.19.0.1:42339",
+					"172.20.0.1:42339",
+					"172.21.0.1:42339",
+					"172.22.0.1:42339",
+					"172.23.0.1:42339",
+					"172.24.0.1:42339",
+					"172.25.0.1:42339",
+					"172.26.0.1:42339",
+					"172.27.0.1:42339"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:31:23.312350289Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         147482855567493,
+				"StableID":   "nxg5vD8o9211CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       147482855567493,
+				"Key":        "nodekey:cb936fadd41580d07988f0e3cfd39b2789aa45093490bb15faec78200acd191f",
+				"DiscoKey":   "discokey:7e1c52975ca75e69853153072d371cdfdbd060a0b63604f15b2342549ba28360",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42585",
+					"10.65.0.27:42585",
+					"172.17.0.1:42585",
+					"172.18.0.1:42585",
+					"172.19.0.1:42585",
+					"172.20.0.1:42585",
+					"172.21.0.1:42585",
+					"172.22.0.1:42585",
+					"172.23.0.1:42585",
+					"172.24.0.1:42585",
+					"172.25.0.1:42585",
+					"172.26.0.1:42585",
+					"172.27.0.1:42585"
+				],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:31:21.132911497Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:cb936fadd41580d07988f0e3cfd39b2789aa45093490bb15faec78200acd191f",
+			"MachineKey": "mkey:25c0701e68a8a0843c15fb90195e8b899d65af124ee5379d9dbc32b93af6ba43",
+			"Peers": [{
+				"ID":         8254899363490767,
+				"StableID":   "nQqFB6DfT721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4a1194f21632107f9ae87c61cdcd49b5513de5f3bbed26c6ea57b140b1db5701",
+				"DiscoKey":   "discokey:92f7e062531900437d0ba7735f2a3eddddf7806a42f8d480bb5408e23df02a1c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33170",
+					"10.65.0.27:33170",
+					"172.17.0.1:33170",
+					"172.18.0.1:33170",
+					"172.19.0.1:33170",
+					"172.20.0.1:33170",
+					"172.21.0.1:33170",
+					"172.22.0.1:33170",
+					"172.23.0.1:33170",
+					"172.24.0.1:33170",
+					"172.25.0.1:33170",
+					"172.26.0.1:33170",
+					"172.27.0.1:33170"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:31:15.78345442Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7713901239591924,
+				"StableID":   "nXJgX67eE321CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:16430c93e36cb955fa5abbe7a66970fd73824f400bc4824e4e2fb05fda584851",
+				"DiscoKey":   "discokey:1f0d417a7eb8e9da3030dcc9df9a40888203abec575f3d9c891a01fe7210bb11",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33907",
+					"10.65.0.27:33907",
+					"172.17.0.1:33907",
+					"172.18.0.1:33907",
+					"172.19.0.1:33907",
+					"172.20.0.1:33907",
+					"172.21.0.1:33907",
+					"172.22.0.1:33907",
+					"172.23.0.1:33907",
+					"172.24.0.1:33907",
+					"172.25.0.1:33907",
+					"172.26.0.1:33907",
+					"172.27.0.1:33907"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:31:16.262119848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7582315319859850,
+				"StableID":   "nFZ2QqZ3D221CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:247f249080e7fd2fcafec11d46373b29a0f37a197ac2ef59c1435f1d422b8c3c",
+				"DiscoKey":   "discokey:7a7dead37ba78b3b7bd83b67e6be2144e406c5d732fc6c5fbfa9c4bec7b1d763",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53868",
+					"10.65.0.27:53868",
+					"172.17.0.1:53868",
+					"172.18.0.1:53868",
+					"172.19.0.1:53868",
+					"172.20.0.1:53868",
+					"172.21.0.1:53868",
+					"172.22.0.1:53868",
+					"172.23.0.1:53868",
+					"172.24.0.1:53868",
+					"172.25.0.1:53868",
+					"172.26.0.1:53868",
+					"172.27.0.1:53868"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:31:16.797992969Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2560487136403379,
+				"StableID":   "nJWXG1fezL11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a075406c8fb1cb5f698faac7a1f3ee254f055b9dde17771016caf1829caaed13",
+				"DiscoKey":   "discokey:c43b5c7425b822c56d547a0523ba075755cb2fc9dfaafba2af677d26a91eac38",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55128",
+					"10.65.0.27:55128",
+					"172.17.0.1:55128",
+					"172.18.0.1:55128",
+					"172.19.0.1:55128",
+					"172.20.0.1:55128",
+					"172.21.0.1:55128",
+					"172.22.0.1:55128",
+					"172.23.0.1:55128",
+					"172.24.0.1:55128",
+					"172.25.0.1:55128",
+					"172.26.0.1:55128",
+					"172.27.0.1:55128"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:31:17.345258924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6886132612070607,
+				"StableID":   "nx7aUZ2kmv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:416b01ff172fe185de22cd955bc5263b0635f48d4f3ff4fba027c05a87984a23",
+				"DiscoKey":   "discokey:1d733d12d18720d90ba1fba796e97c15eb4d46c05e86fc950ce119a5e13b1431",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57519",
+					"10.65.0.27:57519",
+					"172.17.0.1:57519",
+					"172.18.0.1:57519",
+					"172.19.0.1:57519",
+					"172.20.0.1:57519",
+					"172.21.0.1:57519",
+					"172.22.0.1:57519",
+					"172.23.0.1:57519",
+					"172.24.0.1:57519",
+					"172.25.0.1:57519",
+					"172.26.0.1:57519",
+					"172.27.0.1:57519"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:31:17.891339506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8870978364341213,
+				"StableID":   "nCcUpRZgGC21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:01be22a4271b5a219941164bbb03a5c6bac56e47a468eb99249bacef1e005e1b",
+				"DiscoKey":   "discokey:7dd974bc9382eda95714cf999a4a7b47342a17969920476e28605c6e23d35418",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53300",
+					"10.65.0.27:53300",
+					"172.17.0.1:53300",
+					"172.18.0.1:53300",
+					"172.19.0.1:53300",
+					"172.20.0.1:53300",
+					"172.21.0.1:53300",
+					"172.22.0.1:53300",
+					"172.23.0.1:53300",
+					"172.24.0.1:53300",
+					"172.25.0.1:53300",
+					"172.26.0.1:53300",
+					"172.27.0.1:53300"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:31:18.431901823Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2978985931168101,
+				"StableID":   "n21QgiuBGQ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:956795c1ace148b85e3853ea1448a5a30924e90590d358ad3842c5128c14e54a",
+				"DiscoKey":   "discokey:9f088eba31081936a97b75c0a2632506193f0af3d2cb856ec595399fdcfe755b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51397",
+					"10.65.0.27:51397",
+					"172.17.0.1:51397",
+					"172.18.0.1:51397",
+					"172.19.0.1:51397",
+					"172.20.0.1:51397",
+					"172.21.0.1:51397",
+					"172.22.0.1:51397",
+					"172.23.0.1:51397",
+					"172.24.0.1:51397",
+					"172.25.0.1:51397",
+					"172.26.0.1:51397",
+					"172.27.0.1:51397"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:31:18.982822055Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3513817186690356,
+				"StableID":   "nBebH72RSU11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0f9ef7377b722eef4a183de8a96300478faaaaad4ba9f3e902d9db2b5e23d50",
+				"DiscoKey":   "discokey:dbd521e7cc5e2b98779dbe4775b2072c536576f5683cc9e8162a15c670feb34c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36246",
+					"10.65.0.27:36246",
+					"172.17.0.1:36246",
+					"172.18.0.1:36246",
+					"172.19.0.1:36246",
+					"172.20.0.1:36246",
+					"172.21.0.1:36246",
+					"172.22.0.1:36246",
+					"172.23.0.1:36246",
+					"172.24.0.1:36246",
+					"172.25.0.1:36246",
+					"172.26.0.1:36246",
+					"172.27.0.1:36246"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:31:19.515350414Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4350398567006230,
+				"StableID":   "n1xK8RbJya11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47e43fc1bedbc5a00244bd79667ce9198bb13b954a1a0b61da50970657f29b2e",
+				"DiscoKey":   "discokey:7dd40082ad6ea9d3d553235d0fb0435acb20e33aa2d602ff0eafe476bf8f9f5f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41071",
+					"10.65.0.27:41071",
+					"172.17.0.1:41071",
+					"172.18.0.1:41071",
+					"172.19.0.1:41071",
+					"172.20.0.1:41071",
+					"172.21.0.1:41071",
+					"172.22.0.1:41071",
+					"172.23.0.1:41071",
+					"172.24.0.1:41071",
+					"172.25.0.1:41071",
+					"172.26.0.1:41071",
+					"172.27.0.1:41071"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:31:20.079613238Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2304635934592830,
+				"StableID":   "n3FjgvsmzJ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ddd03cabe5a0880bbfd631adbafc26e58abaceef3cbc85200f9556bd5661aa0e",
+				"DiscoKey":   "discokey:03ed13a450d2e8ad8127a5cb0dbd3e30cca5d59853fe38298e8e27e6ebb18306",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38225",
+					"10.65.0.27:38225",
+					"172.17.0.1:38225",
+					"172.18.0.1:38225",
+					"172.19.0.1:38225",
+					"172.20.0.1:38225",
+					"172.21.0.1:38225",
+					"172.22.0.1:38225",
+					"172.23.0.1:38225",
+					"172.24.0.1:38225",
+					"172.25.0.1:38225",
+					"172.26.0.1:38225",
+					"172.27.0.1:38225"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:31:20.585505115Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         542612347419738,
+				"StableID":   "nKb44NWkE511CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c28f5a3e4f5eb73dd696df9c66c1a16ca7f21f797c806d41b5c47b7ec5bf3865",
+				"DiscoKey":   "discokey:326b1c406d2c9d2d20af98068cd85525941e94c5a5f625ec9e198718474fef63",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41047",
+					"10.65.0.27:41047",
+					"172.17.0.1:41047",
+					"172.18.0.1:41047",
+					"172.19.0.1:41047",
+					"172.20.0.1:41047",
+					"172.21.0.1:41047",
+					"172.22.0.1:41047",
+					"172.23.0.1:41047",
+					"172.24.0.1:41047",
+					"172.25.0.1:41047",
+					"172.26.0.1:41047",
+					"172.27.0.1:41047"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:31:21.683118244Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5033822017498422,
+				"StableID":   "nZp1BBypJg11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ad270101c86b4ba8f163650cd703a6a30d1afa0812420fd67d22053428610818",
+				"KeyExpiry":  "2026-11-09T09:31:22Z",
+				"DiscoKey":   "discokey:10d9dbdd6e5aa94d7ad0dfd0dccec2e1cd5152477d4b86549fe9d78b441aec6a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54827",
+					"10.65.0.27:54827",
+					"172.17.0.1:54827",
+					"172.18.0.1:54827",
+					"172.19.0.1:54827",
+					"172.20.0.1:54827",
+					"172.21.0.1:54827",
+					"172.22.0.1:54827",
+					"172.23.0.1:54827",
+					"172.24.0.1:54827",
+					"172.25.0.1:54827",
+					"172.26.0.1:54827",
+					"172.27.0.1:54827"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:31:22.241162786Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1541088879289822,
+				"StableID":   "n3b14vnx2D11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bf38ae3ffb81086e242916fe5677fa6413c03759c74eca417e8f919d50496d52",
+				"KeyExpiry":  "2026-11-09T09:31:22Z",
+				"DiscoKey":   "discokey:43e9e079f1484f1168947f0d1f887875890d578e9c57292d4adbf393afd63536",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46940",
+					"10.65.0.27:46940",
+					"172.17.0.1:46940",
+					"172.18.0.1:46940",
+					"172.19.0.1:46940",
+					"172.20.0.1:46940",
+					"172.21.0.1:46940",
+					"172.22.0.1:46940",
+					"172.23.0.1:46940",
+					"172.24.0.1:46940",
+					"172.25.0.1:46940",
+					"172.26.0.1:46940",
+					"172.27.0.1:46940"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:31:22.772693001Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5041737289897031,
+				"StableID":   "ngy1hatQNg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3bf5463099cdade9a63193475dfb9fc239ebac3df8c5723bdd2e6967663d7369",
+				"KeyExpiry":  "2026-11-09T09:31:23Z",
+				"DiscoKey":   "discokey:055e128b7b9c29b6b7f2f5e8554d6a59e03859db72d0fcf30fd18dd2b8c93915",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42339",
+					"10.65.0.27:42339",
+					"172.17.0.1:42339",
+					"172.18.0.1:42339",
+					"172.19.0.1:42339",
+					"172.20.0.1:42339",
+					"172.21.0.1:42339",
+					"172.22.0.1:42339",
+					"172.23.0.1:42339",
+					"172.24.0.1:42339",
+					"172.25.0.1:42339",
+					"172.26.0.1:42339",
+					"172.27.0.1:42339"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:31:23.312350289Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "147482855567493": {
+				"ID":          147482855567493,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7713901239591924,
+				"StableID":   "nXJgX67eE321CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       7713901239591924,
+				"Key":        "nodekey:16430c93e36cb955fa5abbe7a66970fd73824f400bc4824e4e2fb05fda584851",
+				"DiscoKey":   "discokey:1f0d417a7eb8e9da3030dcc9df9a40888203abec575f3d9c891a01fe7210bb11",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33907",
+					"10.65.0.27:33907",
+					"172.17.0.1:33907",
+					"172.18.0.1:33907",
+					"172.19.0.1:33907",
+					"172.20.0.1:33907",
+					"172.21.0.1:33907",
+					"172.22.0.1:33907",
+					"172.23.0.1:33907",
+					"172.24.0.1:33907",
+					"172.25.0.1:33907",
+					"172.26.0.1:33907",
+					"172.27.0.1:33907"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:31:16.262119848Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:16430c93e36cb955fa5abbe7a66970fd73824f400bc4824e4e2fb05fda584851",
+			"MachineKey": "mkey:b140526ebd6d89cb8cb5ebfbdd6a48576e21cffbf7dca32fb05df18771bcf065",
+			"Peers": [{
+				"ID":         8254899363490767,
+				"StableID":   "nQqFB6DfT721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4a1194f21632107f9ae87c61cdcd49b5513de5f3bbed26c6ea57b140b1db5701",
+				"DiscoKey":   "discokey:92f7e062531900437d0ba7735f2a3eddddf7806a42f8d480bb5408e23df02a1c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33170",
+					"10.65.0.27:33170",
+					"172.17.0.1:33170",
+					"172.18.0.1:33170",
+					"172.19.0.1:33170",
+					"172.20.0.1:33170",
+					"172.21.0.1:33170",
+					"172.22.0.1:33170",
+					"172.23.0.1:33170",
+					"172.24.0.1:33170",
+					"172.25.0.1:33170",
+					"172.26.0.1:33170",
+					"172.27.0.1:33170"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:31:15.78345442Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7582315319859850,
+				"StableID":   "nFZ2QqZ3D221CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:247f249080e7fd2fcafec11d46373b29a0f37a197ac2ef59c1435f1d422b8c3c",
+				"DiscoKey":   "discokey:7a7dead37ba78b3b7bd83b67e6be2144e406c5d732fc6c5fbfa9c4bec7b1d763",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53868",
+					"10.65.0.27:53868",
+					"172.17.0.1:53868",
+					"172.18.0.1:53868",
+					"172.19.0.1:53868",
+					"172.20.0.1:53868",
+					"172.21.0.1:53868",
+					"172.22.0.1:53868",
+					"172.23.0.1:53868",
+					"172.24.0.1:53868",
+					"172.25.0.1:53868",
+					"172.26.0.1:53868",
+					"172.27.0.1:53868"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:31:16.797992969Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2560487136403379,
+				"StableID":   "nJWXG1fezL11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a075406c8fb1cb5f698faac7a1f3ee254f055b9dde17771016caf1829caaed13",
+				"DiscoKey":   "discokey:c43b5c7425b822c56d547a0523ba075755cb2fc9dfaafba2af677d26a91eac38",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55128",
+					"10.65.0.27:55128",
+					"172.17.0.1:55128",
+					"172.18.0.1:55128",
+					"172.19.0.1:55128",
+					"172.20.0.1:55128",
+					"172.21.0.1:55128",
+					"172.22.0.1:55128",
+					"172.23.0.1:55128",
+					"172.24.0.1:55128",
+					"172.25.0.1:55128",
+					"172.26.0.1:55128",
+					"172.27.0.1:55128"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:31:17.345258924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6886132612070607,
+				"StableID":   "nx7aUZ2kmv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:416b01ff172fe185de22cd955bc5263b0635f48d4f3ff4fba027c05a87984a23",
+				"DiscoKey":   "discokey:1d733d12d18720d90ba1fba796e97c15eb4d46c05e86fc950ce119a5e13b1431",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57519",
+					"10.65.0.27:57519",
+					"172.17.0.1:57519",
+					"172.18.0.1:57519",
+					"172.19.0.1:57519",
+					"172.20.0.1:57519",
+					"172.21.0.1:57519",
+					"172.22.0.1:57519",
+					"172.23.0.1:57519",
+					"172.24.0.1:57519",
+					"172.25.0.1:57519",
+					"172.26.0.1:57519",
+					"172.27.0.1:57519"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:31:17.891339506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8870978364341213,
+				"StableID":   "nCcUpRZgGC21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:01be22a4271b5a219941164bbb03a5c6bac56e47a468eb99249bacef1e005e1b",
+				"DiscoKey":   "discokey:7dd974bc9382eda95714cf999a4a7b47342a17969920476e28605c6e23d35418",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53300",
+					"10.65.0.27:53300",
+					"172.17.0.1:53300",
+					"172.18.0.1:53300",
+					"172.19.0.1:53300",
+					"172.20.0.1:53300",
+					"172.21.0.1:53300",
+					"172.22.0.1:53300",
+					"172.23.0.1:53300",
+					"172.24.0.1:53300",
+					"172.25.0.1:53300",
+					"172.26.0.1:53300",
+					"172.27.0.1:53300"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:31:18.431901823Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2978985931168101,
+				"StableID":   "n21QgiuBGQ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:956795c1ace148b85e3853ea1448a5a30924e90590d358ad3842c5128c14e54a",
+				"DiscoKey":   "discokey:9f088eba31081936a97b75c0a2632506193f0af3d2cb856ec595399fdcfe755b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51397",
+					"10.65.0.27:51397",
+					"172.17.0.1:51397",
+					"172.18.0.1:51397",
+					"172.19.0.1:51397",
+					"172.20.0.1:51397",
+					"172.21.0.1:51397",
+					"172.22.0.1:51397",
+					"172.23.0.1:51397",
+					"172.24.0.1:51397",
+					"172.25.0.1:51397",
+					"172.26.0.1:51397",
+					"172.27.0.1:51397"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:31:18.982822055Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3513817186690356,
+				"StableID":   "nBebH72RSU11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0f9ef7377b722eef4a183de8a96300478faaaaad4ba9f3e902d9db2b5e23d50",
+				"DiscoKey":   "discokey:dbd521e7cc5e2b98779dbe4775b2072c536576f5683cc9e8162a15c670feb34c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36246",
+					"10.65.0.27:36246",
+					"172.17.0.1:36246",
+					"172.18.0.1:36246",
+					"172.19.0.1:36246",
+					"172.20.0.1:36246",
+					"172.21.0.1:36246",
+					"172.22.0.1:36246",
+					"172.23.0.1:36246",
+					"172.24.0.1:36246",
+					"172.25.0.1:36246",
+					"172.26.0.1:36246",
+					"172.27.0.1:36246"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:31:19.515350414Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4350398567006230,
+				"StableID":   "n1xK8RbJya11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47e43fc1bedbc5a00244bd79667ce9198bb13b954a1a0b61da50970657f29b2e",
+				"DiscoKey":   "discokey:7dd40082ad6ea9d3d553235d0fb0435acb20e33aa2d602ff0eafe476bf8f9f5f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41071",
+					"10.65.0.27:41071",
+					"172.17.0.1:41071",
+					"172.18.0.1:41071",
+					"172.19.0.1:41071",
+					"172.20.0.1:41071",
+					"172.21.0.1:41071",
+					"172.22.0.1:41071",
+					"172.23.0.1:41071",
+					"172.24.0.1:41071",
+					"172.25.0.1:41071",
+					"172.26.0.1:41071",
+					"172.27.0.1:41071"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:31:20.079613238Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2304635934592830,
+				"StableID":   "n3FjgvsmzJ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ddd03cabe5a0880bbfd631adbafc26e58abaceef3cbc85200f9556bd5661aa0e",
+				"DiscoKey":   "discokey:03ed13a450d2e8ad8127a5cb0dbd3e30cca5d59853fe38298e8e27e6ebb18306",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38225",
+					"10.65.0.27:38225",
+					"172.17.0.1:38225",
+					"172.18.0.1:38225",
+					"172.19.0.1:38225",
+					"172.20.0.1:38225",
+					"172.21.0.1:38225",
+					"172.22.0.1:38225",
+					"172.23.0.1:38225",
+					"172.24.0.1:38225",
+					"172.25.0.1:38225",
+					"172.26.0.1:38225",
+					"172.27.0.1:38225"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:31:20.585505115Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         147482855567493,
+				"StableID":   "nxg5vD8o9211CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb936fadd41580d07988f0e3cfd39b2789aa45093490bb15faec78200acd191f",
+				"DiscoKey":   "discokey:7e1c52975ca75e69853153072d371cdfdbd060a0b63604f15b2342549ba28360",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42585",
+					"10.65.0.27:42585",
+					"172.17.0.1:42585",
+					"172.18.0.1:42585",
+					"172.19.0.1:42585",
+					"172.20.0.1:42585",
+					"172.21.0.1:42585",
+					"172.22.0.1:42585",
+					"172.23.0.1:42585",
+					"172.24.0.1:42585",
+					"172.25.0.1:42585",
+					"172.26.0.1:42585",
+					"172.27.0.1:42585"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:31:21.132911497Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         542612347419738,
+				"StableID":   "nKb44NWkE511CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c28f5a3e4f5eb73dd696df9c66c1a16ca7f21f797c806d41b5c47b7ec5bf3865",
+				"DiscoKey":   "discokey:326b1c406d2c9d2d20af98068cd85525941e94c5a5f625ec9e198718474fef63",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41047",
+					"10.65.0.27:41047",
+					"172.17.0.1:41047",
+					"172.18.0.1:41047",
+					"172.19.0.1:41047",
+					"172.20.0.1:41047",
+					"172.21.0.1:41047",
+					"172.22.0.1:41047",
+					"172.23.0.1:41047",
+					"172.24.0.1:41047",
+					"172.25.0.1:41047",
+					"172.26.0.1:41047",
+					"172.27.0.1:41047"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:31:21.683118244Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5033822017498422,
+				"StableID":   "nZp1BBypJg11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ad270101c86b4ba8f163650cd703a6a30d1afa0812420fd67d22053428610818",
+				"KeyExpiry":  "2026-11-09T09:31:22Z",
+				"DiscoKey":   "discokey:10d9dbdd6e5aa94d7ad0dfd0dccec2e1cd5152477d4b86549fe9d78b441aec6a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54827",
+					"10.65.0.27:54827",
+					"172.17.0.1:54827",
+					"172.18.0.1:54827",
+					"172.19.0.1:54827",
+					"172.20.0.1:54827",
+					"172.21.0.1:54827",
+					"172.22.0.1:54827",
+					"172.23.0.1:54827",
+					"172.24.0.1:54827",
+					"172.25.0.1:54827",
+					"172.26.0.1:54827",
+					"172.27.0.1:54827"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:31:22.241162786Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1541088879289822,
+				"StableID":   "n3b14vnx2D11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bf38ae3ffb81086e242916fe5677fa6413c03759c74eca417e8f919d50496d52",
+				"KeyExpiry":  "2026-11-09T09:31:22Z",
+				"DiscoKey":   "discokey:43e9e079f1484f1168947f0d1f887875890d578e9c57292d4adbf393afd63536",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46940",
+					"10.65.0.27:46940",
+					"172.17.0.1:46940",
+					"172.18.0.1:46940",
+					"172.19.0.1:46940",
+					"172.20.0.1:46940",
+					"172.21.0.1:46940",
+					"172.22.0.1:46940",
+					"172.23.0.1:46940",
+					"172.24.0.1:46940",
+					"172.25.0.1:46940",
+					"172.26.0.1:46940",
+					"172.27.0.1:46940"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:31:22.772693001Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5041737289897031,
+				"StableID":   "ngy1hatQNg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3bf5463099cdade9a63193475dfb9fc239ebac3df8c5723bdd2e6967663d7369",
+				"KeyExpiry":  "2026-11-09T09:31:23Z",
+				"DiscoKey":   "discokey:055e128b7b9c29b6b7f2f5e8554d6a59e03859db72d0fcf30fd18dd2b8c93915",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42339",
+					"10.65.0.27:42339",
+					"172.17.0.1:42339",
+					"172.18.0.1:42339",
+					"172.19.0.1:42339",
+					"172.20.0.1:42339",
+					"172.21.0.1:42339",
+					"172.22.0.1:42339",
+					"172.23.0.1:42339",
+					"172.24.0.1:42339",
+					"172.25.0.1:42339",
+					"172.26.0.1:42339",
+					"172.27.0.1:42339"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:31:23.312350289Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7713901239591924": {
+				"ID":          7713901239591924,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8254899363490767,
+				"StableID":   "nQqFB6DfT721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       8254899363490767,
+				"Key":        "nodekey:4a1194f21632107f9ae87c61cdcd49b5513de5f3bbed26c6ea57b140b1db5701",
+				"DiscoKey":   "discokey:92f7e062531900437d0ba7735f2a3eddddf7806a42f8d480bb5408e23df02a1c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33170",
+					"10.65.0.27:33170",
+					"172.17.0.1:33170",
+					"172.18.0.1:33170",
+					"172.19.0.1:33170",
+					"172.20.0.1:33170",
+					"172.21.0.1:33170",
+					"172.22.0.1:33170",
+					"172.23.0.1:33170",
+					"172.24.0.1:33170",
+					"172.25.0.1:33170",
+					"172.26.0.1:33170",
+					"172.27.0.1:33170"
+				],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:31:15.78345442Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4a1194f21632107f9ae87c61cdcd49b5513de5f3bbed26c6ea57b140b1db5701",
+			"MachineKey": "mkey:9426ecf7a64e56160a129fa69a6cc19a1f14c2d9ed38e7a9c48f7c20bb392d23",
+			"Peers": [{
+				"ID":         7713901239591924,
+				"StableID":   "nXJgX67eE321CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:16430c93e36cb955fa5abbe7a66970fd73824f400bc4824e4e2fb05fda584851",
+				"DiscoKey":   "discokey:1f0d417a7eb8e9da3030dcc9df9a40888203abec575f3d9c891a01fe7210bb11",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33907",
+					"10.65.0.27:33907",
+					"172.17.0.1:33907",
+					"172.18.0.1:33907",
+					"172.19.0.1:33907",
+					"172.20.0.1:33907",
+					"172.21.0.1:33907",
+					"172.22.0.1:33907",
+					"172.23.0.1:33907",
+					"172.24.0.1:33907",
+					"172.25.0.1:33907",
+					"172.26.0.1:33907",
+					"172.27.0.1:33907"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:31:16.262119848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7582315319859850,
+				"StableID":   "nFZ2QqZ3D221CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:247f249080e7fd2fcafec11d46373b29a0f37a197ac2ef59c1435f1d422b8c3c",
+				"DiscoKey":   "discokey:7a7dead37ba78b3b7bd83b67e6be2144e406c5d732fc6c5fbfa9c4bec7b1d763",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53868",
+					"10.65.0.27:53868",
+					"172.17.0.1:53868",
+					"172.18.0.1:53868",
+					"172.19.0.1:53868",
+					"172.20.0.1:53868",
+					"172.21.0.1:53868",
+					"172.22.0.1:53868",
+					"172.23.0.1:53868",
+					"172.24.0.1:53868",
+					"172.25.0.1:53868",
+					"172.26.0.1:53868",
+					"172.27.0.1:53868"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:31:16.797992969Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2560487136403379,
+				"StableID":   "nJWXG1fezL11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a075406c8fb1cb5f698faac7a1f3ee254f055b9dde17771016caf1829caaed13",
+				"DiscoKey":   "discokey:c43b5c7425b822c56d547a0523ba075755cb2fc9dfaafba2af677d26a91eac38",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55128",
+					"10.65.0.27:55128",
+					"172.17.0.1:55128",
+					"172.18.0.1:55128",
+					"172.19.0.1:55128",
+					"172.20.0.1:55128",
+					"172.21.0.1:55128",
+					"172.22.0.1:55128",
+					"172.23.0.1:55128",
+					"172.24.0.1:55128",
+					"172.25.0.1:55128",
+					"172.26.0.1:55128",
+					"172.27.0.1:55128"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:31:17.345258924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6886132612070607,
+				"StableID":   "nx7aUZ2kmv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:416b01ff172fe185de22cd955bc5263b0635f48d4f3ff4fba027c05a87984a23",
+				"DiscoKey":   "discokey:1d733d12d18720d90ba1fba796e97c15eb4d46c05e86fc950ce119a5e13b1431",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57519",
+					"10.65.0.27:57519",
+					"172.17.0.1:57519",
+					"172.18.0.1:57519",
+					"172.19.0.1:57519",
+					"172.20.0.1:57519",
+					"172.21.0.1:57519",
+					"172.22.0.1:57519",
+					"172.23.0.1:57519",
+					"172.24.0.1:57519",
+					"172.25.0.1:57519",
+					"172.26.0.1:57519",
+					"172.27.0.1:57519"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:31:17.891339506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8870978364341213,
+				"StableID":   "nCcUpRZgGC21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:01be22a4271b5a219941164bbb03a5c6bac56e47a468eb99249bacef1e005e1b",
+				"DiscoKey":   "discokey:7dd974bc9382eda95714cf999a4a7b47342a17969920476e28605c6e23d35418",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53300",
+					"10.65.0.27:53300",
+					"172.17.0.1:53300",
+					"172.18.0.1:53300",
+					"172.19.0.1:53300",
+					"172.20.0.1:53300",
+					"172.21.0.1:53300",
+					"172.22.0.1:53300",
+					"172.23.0.1:53300",
+					"172.24.0.1:53300",
+					"172.25.0.1:53300",
+					"172.26.0.1:53300",
+					"172.27.0.1:53300"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:31:18.431901823Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2978985931168101,
+				"StableID":   "n21QgiuBGQ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:956795c1ace148b85e3853ea1448a5a30924e90590d358ad3842c5128c14e54a",
+				"DiscoKey":   "discokey:9f088eba31081936a97b75c0a2632506193f0af3d2cb856ec595399fdcfe755b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51397",
+					"10.65.0.27:51397",
+					"172.17.0.1:51397",
+					"172.18.0.1:51397",
+					"172.19.0.1:51397",
+					"172.20.0.1:51397",
+					"172.21.0.1:51397",
+					"172.22.0.1:51397",
+					"172.23.0.1:51397",
+					"172.24.0.1:51397",
+					"172.25.0.1:51397",
+					"172.26.0.1:51397",
+					"172.27.0.1:51397"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:31:18.982822055Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3513817186690356,
+				"StableID":   "nBebH72RSU11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0f9ef7377b722eef4a183de8a96300478faaaaad4ba9f3e902d9db2b5e23d50",
+				"DiscoKey":   "discokey:dbd521e7cc5e2b98779dbe4775b2072c536576f5683cc9e8162a15c670feb34c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36246",
+					"10.65.0.27:36246",
+					"172.17.0.1:36246",
+					"172.18.0.1:36246",
+					"172.19.0.1:36246",
+					"172.20.0.1:36246",
+					"172.21.0.1:36246",
+					"172.22.0.1:36246",
+					"172.23.0.1:36246",
+					"172.24.0.1:36246",
+					"172.25.0.1:36246",
+					"172.26.0.1:36246",
+					"172.27.0.1:36246"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:31:19.515350414Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4350398567006230,
+				"StableID":   "n1xK8RbJya11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47e43fc1bedbc5a00244bd79667ce9198bb13b954a1a0b61da50970657f29b2e",
+				"DiscoKey":   "discokey:7dd40082ad6ea9d3d553235d0fb0435acb20e33aa2d602ff0eafe476bf8f9f5f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41071",
+					"10.65.0.27:41071",
+					"172.17.0.1:41071",
+					"172.18.0.1:41071",
+					"172.19.0.1:41071",
+					"172.20.0.1:41071",
+					"172.21.0.1:41071",
+					"172.22.0.1:41071",
+					"172.23.0.1:41071",
+					"172.24.0.1:41071",
+					"172.25.0.1:41071",
+					"172.26.0.1:41071",
+					"172.27.0.1:41071"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:31:20.079613238Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2304635934592830,
+				"StableID":   "n3FjgvsmzJ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ddd03cabe5a0880bbfd631adbafc26e58abaceef3cbc85200f9556bd5661aa0e",
+				"DiscoKey":   "discokey:03ed13a450d2e8ad8127a5cb0dbd3e30cca5d59853fe38298e8e27e6ebb18306",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38225",
+					"10.65.0.27:38225",
+					"172.17.0.1:38225",
+					"172.18.0.1:38225",
+					"172.19.0.1:38225",
+					"172.20.0.1:38225",
+					"172.21.0.1:38225",
+					"172.22.0.1:38225",
+					"172.23.0.1:38225",
+					"172.24.0.1:38225",
+					"172.25.0.1:38225",
+					"172.26.0.1:38225",
+					"172.27.0.1:38225"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:31:20.585505115Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         147482855567493,
+				"StableID":   "nxg5vD8o9211CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb936fadd41580d07988f0e3cfd39b2789aa45093490bb15faec78200acd191f",
+				"DiscoKey":   "discokey:7e1c52975ca75e69853153072d371cdfdbd060a0b63604f15b2342549ba28360",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42585",
+					"10.65.0.27:42585",
+					"172.17.0.1:42585",
+					"172.18.0.1:42585",
+					"172.19.0.1:42585",
+					"172.20.0.1:42585",
+					"172.21.0.1:42585",
+					"172.22.0.1:42585",
+					"172.23.0.1:42585",
+					"172.24.0.1:42585",
+					"172.25.0.1:42585",
+					"172.26.0.1:42585",
+					"172.27.0.1:42585"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:31:21.132911497Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         542612347419738,
+				"StableID":   "nKb44NWkE511CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c28f5a3e4f5eb73dd696df9c66c1a16ca7f21f797c806d41b5c47b7ec5bf3865",
+				"DiscoKey":   "discokey:326b1c406d2c9d2d20af98068cd85525941e94c5a5f625ec9e198718474fef63",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41047",
+					"10.65.0.27:41047",
+					"172.17.0.1:41047",
+					"172.18.0.1:41047",
+					"172.19.0.1:41047",
+					"172.20.0.1:41047",
+					"172.21.0.1:41047",
+					"172.22.0.1:41047",
+					"172.23.0.1:41047",
+					"172.24.0.1:41047",
+					"172.25.0.1:41047",
+					"172.26.0.1:41047",
+					"172.27.0.1:41047"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:31:21.683118244Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5033822017498422,
+				"StableID":   "nZp1BBypJg11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ad270101c86b4ba8f163650cd703a6a30d1afa0812420fd67d22053428610818",
+				"KeyExpiry":  "2026-11-09T09:31:22Z",
+				"DiscoKey":   "discokey:10d9dbdd6e5aa94d7ad0dfd0dccec2e1cd5152477d4b86549fe9d78b441aec6a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54827",
+					"10.65.0.27:54827",
+					"172.17.0.1:54827",
+					"172.18.0.1:54827",
+					"172.19.0.1:54827",
+					"172.20.0.1:54827",
+					"172.21.0.1:54827",
+					"172.22.0.1:54827",
+					"172.23.0.1:54827",
+					"172.24.0.1:54827",
+					"172.25.0.1:54827",
+					"172.26.0.1:54827",
+					"172.27.0.1:54827"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:31:22.241162786Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1541088879289822,
+				"StableID":   "n3b14vnx2D11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bf38ae3ffb81086e242916fe5677fa6413c03759c74eca417e8f919d50496d52",
+				"KeyExpiry":  "2026-11-09T09:31:22Z",
+				"DiscoKey":   "discokey:43e9e079f1484f1168947f0d1f887875890d578e9c57292d4adbf393afd63536",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46940",
+					"10.65.0.27:46940",
+					"172.17.0.1:46940",
+					"172.18.0.1:46940",
+					"172.19.0.1:46940",
+					"172.20.0.1:46940",
+					"172.21.0.1:46940",
+					"172.22.0.1:46940",
+					"172.23.0.1:46940",
+					"172.24.0.1:46940",
+					"172.25.0.1:46940",
+					"172.26.0.1:46940",
+					"172.27.0.1:46940"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:31:22.772693001Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5041737289897031,
+				"StableID":   "ngy1hatQNg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3bf5463099cdade9a63193475dfb9fc239ebac3df8c5723bdd2e6967663d7369",
+				"KeyExpiry":  "2026-11-09T09:31:23Z",
+				"DiscoKey":   "discokey:055e128b7b9c29b6b7f2f5e8554d6a59e03859db72d0fcf30fd18dd2b8c93915",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42339",
+					"10.65.0.27:42339",
+					"172.17.0.1:42339",
+					"172.18.0.1:42339",
+					"172.19.0.1:42339",
+					"172.20.0.1:42339",
+					"172.21.0.1:42339",
+					"172.22.0.1:42339",
+					"172.23.0.1:42339",
+					"172.24.0.1:42339",
+					"172.25.0.1:42339",
+					"172.26.0.1:42339",
+					"172.27.0.1:42339"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:31:23.312350289Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8254899363490767": {
+				"ID":          8254899363490767,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6886132612070607,
+				"StableID":   "nx7aUZ2kmv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       6886132612070607,
+				"Key":        "nodekey:416b01ff172fe185de22cd955bc5263b0635f48d4f3ff4fba027c05a87984a23",
+				"DiscoKey":   "discokey:1d733d12d18720d90ba1fba796e97c15eb4d46c05e86fc950ce119a5e13b1431",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57519",
+					"10.65.0.27:57519",
+					"172.17.0.1:57519",
+					"172.18.0.1:57519",
+					"172.19.0.1:57519",
+					"172.20.0.1:57519",
+					"172.21.0.1:57519",
+					"172.22.0.1:57519",
+					"172.23.0.1:57519",
+					"172.24.0.1:57519",
+					"172.25.0.1:57519",
+					"172.26.0.1:57519",
+					"172.27.0.1:57519"
+				],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:31:17.891339506Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:416b01ff172fe185de22cd955bc5263b0635f48d4f3ff4fba027c05a87984a23",
+			"MachineKey": "mkey:7419ddb62fb67aa49799d3d933e9c94a624e1a2b11b6ae816ccd306088f4066b",
+			"Peers": [{
+				"ID":         8254899363490767,
+				"StableID":   "nQqFB6DfT721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4a1194f21632107f9ae87c61cdcd49b5513de5f3bbed26c6ea57b140b1db5701",
+				"DiscoKey":   "discokey:92f7e062531900437d0ba7735f2a3eddddf7806a42f8d480bb5408e23df02a1c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33170",
+					"10.65.0.27:33170",
+					"172.17.0.1:33170",
+					"172.18.0.1:33170",
+					"172.19.0.1:33170",
+					"172.20.0.1:33170",
+					"172.21.0.1:33170",
+					"172.22.0.1:33170",
+					"172.23.0.1:33170",
+					"172.24.0.1:33170",
+					"172.25.0.1:33170",
+					"172.26.0.1:33170",
+					"172.27.0.1:33170"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:31:15.78345442Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7713901239591924,
+				"StableID":   "nXJgX67eE321CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:16430c93e36cb955fa5abbe7a66970fd73824f400bc4824e4e2fb05fda584851",
+				"DiscoKey":   "discokey:1f0d417a7eb8e9da3030dcc9df9a40888203abec575f3d9c891a01fe7210bb11",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33907",
+					"10.65.0.27:33907",
+					"172.17.0.1:33907",
+					"172.18.0.1:33907",
+					"172.19.0.1:33907",
+					"172.20.0.1:33907",
+					"172.21.0.1:33907",
+					"172.22.0.1:33907",
+					"172.23.0.1:33907",
+					"172.24.0.1:33907",
+					"172.25.0.1:33907",
+					"172.26.0.1:33907",
+					"172.27.0.1:33907"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:31:16.262119848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7582315319859850,
+				"StableID":   "nFZ2QqZ3D221CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:247f249080e7fd2fcafec11d46373b29a0f37a197ac2ef59c1435f1d422b8c3c",
+				"DiscoKey":   "discokey:7a7dead37ba78b3b7bd83b67e6be2144e406c5d732fc6c5fbfa9c4bec7b1d763",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53868",
+					"10.65.0.27:53868",
+					"172.17.0.1:53868",
+					"172.18.0.1:53868",
+					"172.19.0.1:53868",
+					"172.20.0.1:53868",
+					"172.21.0.1:53868",
+					"172.22.0.1:53868",
+					"172.23.0.1:53868",
+					"172.24.0.1:53868",
+					"172.25.0.1:53868",
+					"172.26.0.1:53868",
+					"172.27.0.1:53868"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:31:16.797992969Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2560487136403379,
+				"StableID":   "nJWXG1fezL11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a075406c8fb1cb5f698faac7a1f3ee254f055b9dde17771016caf1829caaed13",
+				"DiscoKey":   "discokey:c43b5c7425b822c56d547a0523ba075755cb2fc9dfaafba2af677d26a91eac38",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55128",
+					"10.65.0.27:55128",
+					"172.17.0.1:55128",
+					"172.18.0.1:55128",
+					"172.19.0.1:55128",
+					"172.20.0.1:55128",
+					"172.21.0.1:55128",
+					"172.22.0.1:55128",
+					"172.23.0.1:55128",
+					"172.24.0.1:55128",
+					"172.25.0.1:55128",
+					"172.26.0.1:55128",
+					"172.27.0.1:55128"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:31:17.345258924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8870978364341213,
+				"StableID":   "nCcUpRZgGC21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:01be22a4271b5a219941164bbb03a5c6bac56e47a468eb99249bacef1e005e1b",
+				"DiscoKey":   "discokey:7dd974bc9382eda95714cf999a4a7b47342a17969920476e28605c6e23d35418",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53300",
+					"10.65.0.27:53300",
+					"172.17.0.1:53300",
+					"172.18.0.1:53300",
+					"172.19.0.1:53300",
+					"172.20.0.1:53300",
+					"172.21.0.1:53300",
+					"172.22.0.1:53300",
+					"172.23.0.1:53300",
+					"172.24.0.1:53300",
+					"172.25.0.1:53300",
+					"172.26.0.1:53300",
+					"172.27.0.1:53300"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:31:18.431901823Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2978985931168101,
+				"StableID":   "n21QgiuBGQ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:956795c1ace148b85e3853ea1448a5a30924e90590d358ad3842c5128c14e54a",
+				"DiscoKey":   "discokey:9f088eba31081936a97b75c0a2632506193f0af3d2cb856ec595399fdcfe755b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51397",
+					"10.65.0.27:51397",
+					"172.17.0.1:51397",
+					"172.18.0.1:51397",
+					"172.19.0.1:51397",
+					"172.20.0.1:51397",
+					"172.21.0.1:51397",
+					"172.22.0.1:51397",
+					"172.23.0.1:51397",
+					"172.24.0.1:51397",
+					"172.25.0.1:51397",
+					"172.26.0.1:51397",
+					"172.27.0.1:51397"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:31:18.982822055Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3513817186690356,
+				"StableID":   "nBebH72RSU11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0f9ef7377b722eef4a183de8a96300478faaaaad4ba9f3e902d9db2b5e23d50",
+				"DiscoKey":   "discokey:dbd521e7cc5e2b98779dbe4775b2072c536576f5683cc9e8162a15c670feb34c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36246",
+					"10.65.0.27:36246",
+					"172.17.0.1:36246",
+					"172.18.0.1:36246",
+					"172.19.0.1:36246",
+					"172.20.0.1:36246",
+					"172.21.0.1:36246",
+					"172.22.0.1:36246",
+					"172.23.0.1:36246",
+					"172.24.0.1:36246",
+					"172.25.0.1:36246",
+					"172.26.0.1:36246",
+					"172.27.0.1:36246"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:31:19.515350414Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4350398567006230,
+				"StableID":   "n1xK8RbJya11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47e43fc1bedbc5a00244bd79667ce9198bb13b954a1a0b61da50970657f29b2e",
+				"DiscoKey":   "discokey:7dd40082ad6ea9d3d553235d0fb0435acb20e33aa2d602ff0eafe476bf8f9f5f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41071",
+					"10.65.0.27:41071",
+					"172.17.0.1:41071",
+					"172.18.0.1:41071",
+					"172.19.0.1:41071",
+					"172.20.0.1:41071",
+					"172.21.0.1:41071",
+					"172.22.0.1:41071",
+					"172.23.0.1:41071",
+					"172.24.0.1:41071",
+					"172.25.0.1:41071",
+					"172.26.0.1:41071",
+					"172.27.0.1:41071"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:31:20.079613238Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2304635934592830,
+				"StableID":   "n3FjgvsmzJ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ddd03cabe5a0880bbfd631adbafc26e58abaceef3cbc85200f9556bd5661aa0e",
+				"DiscoKey":   "discokey:03ed13a450d2e8ad8127a5cb0dbd3e30cca5d59853fe38298e8e27e6ebb18306",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38225",
+					"10.65.0.27:38225",
+					"172.17.0.1:38225",
+					"172.18.0.1:38225",
+					"172.19.0.1:38225",
+					"172.20.0.1:38225",
+					"172.21.0.1:38225",
+					"172.22.0.1:38225",
+					"172.23.0.1:38225",
+					"172.24.0.1:38225",
+					"172.25.0.1:38225",
+					"172.26.0.1:38225",
+					"172.27.0.1:38225"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:31:20.585505115Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         147482855567493,
+				"StableID":   "nxg5vD8o9211CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb936fadd41580d07988f0e3cfd39b2789aa45093490bb15faec78200acd191f",
+				"DiscoKey":   "discokey:7e1c52975ca75e69853153072d371cdfdbd060a0b63604f15b2342549ba28360",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42585",
+					"10.65.0.27:42585",
+					"172.17.0.1:42585",
+					"172.18.0.1:42585",
+					"172.19.0.1:42585",
+					"172.20.0.1:42585",
+					"172.21.0.1:42585",
+					"172.22.0.1:42585",
+					"172.23.0.1:42585",
+					"172.24.0.1:42585",
+					"172.25.0.1:42585",
+					"172.26.0.1:42585",
+					"172.27.0.1:42585"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:31:21.132911497Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         542612347419738,
+				"StableID":   "nKb44NWkE511CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c28f5a3e4f5eb73dd696df9c66c1a16ca7f21f797c806d41b5c47b7ec5bf3865",
+				"DiscoKey":   "discokey:326b1c406d2c9d2d20af98068cd85525941e94c5a5f625ec9e198718474fef63",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41047",
+					"10.65.0.27:41047",
+					"172.17.0.1:41047",
+					"172.18.0.1:41047",
+					"172.19.0.1:41047",
+					"172.20.0.1:41047",
+					"172.21.0.1:41047",
+					"172.22.0.1:41047",
+					"172.23.0.1:41047",
+					"172.24.0.1:41047",
+					"172.25.0.1:41047",
+					"172.26.0.1:41047",
+					"172.27.0.1:41047"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:31:21.683118244Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5033822017498422,
+				"StableID":   "nZp1BBypJg11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ad270101c86b4ba8f163650cd703a6a30d1afa0812420fd67d22053428610818",
+				"KeyExpiry":  "2026-11-09T09:31:22Z",
+				"DiscoKey":   "discokey:10d9dbdd6e5aa94d7ad0dfd0dccec2e1cd5152477d4b86549fe9d78b441aec6a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54827",
+					"10.65.0.27:54827",
+					"172.17.0.1:54827",
+					"172.18.0.1:54827",
+					"172.19.0.1:54827",
+					"172.20.0.1:54827",
+					"172.21.0.1:54827",
+					"172.22.0.1:54827",
+					"172.23.0.1:54827",
+					"172.24.0.1:54827",
+					"172.25.0.1:54827",
+					"172.26.0.1:54827",
+					"172.27.0.1:54827"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:31:22.241162786Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1541088879289822,
+				"StableID":   "n3b14vnx2D11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bf38ae3ffb81086e242916fe5677fa6413c03759c74eca417e8f919d50496d52",
+				"KeyExpiry":  "2026-11-09T09:31:22Z",
+				"DiscoKey":   "discokey:43e9e079f1484f1168947f0d1f887875890d578e9c57292d4adbf393afd63536",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46940",
+					"10.65.0.27:46940",
+					"172.17.0.1:46940",
+					"172.18.0.1:46940",
+					"172.19.0.1:46940",
+					"172.20.0.1:46940",
+					"172.21.0.1:46940",
+					"172.22.0.1:46940",
+					"172.23.0.1:46940",
+					"172.24.0.1:46940",
+					"172.25.0.1:46940",
+					"172.26.0.1:46940",
+					"172.27.0.1:46940"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:31:22.772693001Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5041737289897031,
+				"StableID":   "ngy1hatQNg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3bf5463099cdade9a63193475dfb9fc239ebac3df8c5723bdd2e6967663d7369",
+				"KeyExpiry":  "2026-11-09T09:31:23Z",
+				"DiscoKey":   "discokey:055e128b7b9c29b6b7f2f5e8554d6a59e03859db72d0fcf30fd18dd2b8c93915",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42339",
+					"10.65.0.27:42339",
+					"172.17.0.1:42339",
+					"172.18.0.1:42339",
+					"172.19.0.1:42339",
+					"172.20.0.1:42339",
+					"172.21.0.1:42339",
+					"172.22.0.1:42339",
+					"172.23.0.1:42339",
+					"172.24.0.1:42339",
+					"172.25.0.1:42339",
+					"172.26.0.1:42339",
+					"172.27.0.1:42339"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:31:23.312350289Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6886132612070607": {
+				"ID":          6886132612070607,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2560487136403379,
+				"StableID":   "nJWXG1fezL11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       2560487136403379,
+				"Key":        "nodekey:a075406c8fb1cb5f698faac7a1f3ee254f055b9dde17771016caf1829caaed13",
+				"DiscoKey":   "discokey:c43b5c7425b822c56d547a0523ba075755cb2fc9dfaafba2af677d26a91eac38",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55128",
+					"10.65.0.27:55128",
+					"172.17.0.1:55128",
+					"172.18.0.1:55128",
+					"172.19.0.1:55128",
+					"172.20.0.1:55128",
+					"172.21.0.1:55128",
+					"172.22.0.1:55128",
+					"172.23.0.1:55128",
+					"172.24.0.1:55128",
+					"172.25.0.1:55128",
+					"172.26.0.1:55128",
+					"172.27.0.1:55128"
+				],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:31:17.345258924Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a075406c8fb1cb5f698faac7a1f3ee254f055b9dde17771016caf1829caaed13",
+			"MachineKey": "mkey:dd7efaea3eafe9b77e3b6537a3e7e581c85f7bc991a6f8d1ac6e1efb7e9bb514",
+			"Peers": [{
+				"ID":         8254899363490767,
+				"StableID":   "nQqFB6DfT721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4a1194f21632107f9ae87c61cdcd49b5513de5f3bbed26c6ea57b140b1db5701",
+				"DiscoKey":   "discokey:92f7e062531900437d0ba7735f2a3eddddf7806a42f8d480bb5408e23df02a1c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33170",
+					"10.65.0.27:33170",
+					"172.17.0.1:33170",
+					"172.18.0.1:33170",
+					"172.19.0.1:33170",
+					"172.20.0.1:33170",
+					"172.21.0.1:33170",
+					"172.22.0.1:33170",
+					"172.23.0.1:33170",
+					"172.24.0.1:33170",
+					"172.25.0.1:33170",
+					"172.26.0.1:33170",
+					"172.27.0.1:33170"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:31:15.78345442Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7713901239591924,
+				"StableID":   "nXJgX67eE321CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:16430c93e36cb955fa5abbe7a66970fd73824f400bc4824e4e2fb05fda584851",
+				"DiscoKey":   "discokey:1f0d417a7eb8e9da3030dcc9df9a40888203abec575f3d9c891a01fe7210bb11",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33907",
+					"10.65.0.27:33907",
+					"172.17.0.1:33907",
+					"172.18.0.1:33907",
+					"172.19.0.1:33907",
+					"172.20.0.1:33907",
+					"172.21.0.1:33907",
+					"172.22.0.1:33907",
+					"172.23.0.1:33907",
+					"172.24.0.1:33907",
+					"172.25.0.1:33907",
+					"172.26.0.1:33907",
+					"172.27.0.1:33907"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:31:16.262119848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7582315319859850,
+				"StableID":   "nFZ2QqZ3D221CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:247f249080e7fd2fcafec11d46373b29a0f37a197ac2ef59c1435f1d422b8c3c",
+				"DiscoKey":   "discokey:7a7dead37ba78b3b7bd83b67e6be2144e406c5d732fc6c5fbfa9c4bec7b1d763",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53868",
+					"10.65.0.27:53868",
+					"172.17.0.1:53868",
+					"172.18.0.1:53868",
+					"172.19.0.1:53868",
+					"172.20.0.1:53868",
+					"172.21.0.1:53868",
+					"172.22.0.1:53868",
+					"172.23.0.1:53868",
+					"172.24.0.1:53868",
+					"172.25.0.1:53868",
+					"172.26.0.1:53868",
+					"172.27.0.1:53868"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:31:16.797992969Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         6886132612070607,
+				"StableID":   "nx7aUZ2kmv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:416b01ff172fe185de22cd955bc5263b0635f48d4f3ff4fba027c05a87984a23",
+				"DiscoKey":   "discokey:1d733d12d18720d90ba1fba796e97c15eb4d46c05e86fc950ce119a5e13b1431",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57519",
+					"10.65.0.27:57519",
+					"172.17.0.1:57519",
+					"172.18.0.1:57519",
+					"172.19.0.1:57519",
+					"172.20.0.1:57519",
+					"172.21.0.1:57519",
+					"172.22.0.1:57519",
+					"172.23.0.1:57519",
+					"172.24.0.1:57519",
+					"172.25.0.1:57519",
+					"172.26.0.1:57519",
+					"172.27.0.1:57519"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:31:17.891339506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8870978364341213,
+				"StableID":   "nCcUpRZgGC21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:01be22a4271b5a219941164bbb03a5c6bac56e47a468eb99249bacef1e005e1b",
+				"DiscoKey":   "discokey:7dd974bc9382eda95714cf999a4a7b47342a17969920476e28605c6e23d35418",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53300",
+					"10.65.0.27:53300",
+					"172.17.0.1:53300",
+					"172.18.0.1:53300",
+					"172.19.0.1:53300",
+					"172.20.0.1:53300",
+					"172.21.0.1:53300",
+					"172.22.0.1:53300",
+					"172.23.0.1:53300",
+					"172.24.0.1:53300",
+					"172.25.0.1:53300",
+					"172.26.0.1:53300",
+					"172.27.0.1:53300"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:31:18.431901823Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2978985931168101,
+				"StableID":   "n21QgiuBGQ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:956795c1ace148b85e3853ea1448a5a30924e90590d358ad3842c5128c14e54a",
+				"DiscoKey":   "discokey:9f088eba31081936a97b75c0a2632506193f0af3d2cb856ec595399fdcfe755b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51397",
+					"10.65.0.27:51397",
+					"172.17.0.1:51397",
+					"172.18.0.1:51397",
+					"172.19.0.1:51397",
+					"172.20.0.1:51397",
+					"172.21.0.1:51397",
+					"172.22.0.1:51397",
+					"172.23.0.1:51397",
+					"172.24.0.1:51397",
+					"172.25.0.1:51397",
+					"172.26.0.1:51397",
+					"172.27.0.1:51397"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:31:18.982822055Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3513817186690356,
+				"StableID":   "nBebH72RSU11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0f9ef7377b722eef4a183de8a96300478faaaaad4ba9f3e902d9db2b5e23d50",
+				"DiscoKey":   "discokey:dbd521e7cc5e2b98779dbe4775b2072c536576f5683cc9e8162a15c670feb34c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36246",
+					"10.65.0.27:36246",
+					"172.17.0.1:36246",
+					"172.18.0.1:36246",
+					"172.19.0.1:36246",
+					"172.20.0.1:36246",
+					"172.21.0.1:36246",
+					"172.22.0.1:36246",
+					"172.23.0.1:36246",
+					"172.24.0.1:36246",
+					"172.25.0.1:36246",
+					"172.26.0.1:36246",
+					"172.27.0.1:36246"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:31:19.515350414Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4350398567006230,
+				"StableID":   "n1xK8RbJya11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47e43fc1bedbc5a00244bd79667ce9198bb13b954a1a0b61da50970657f29b2e",
+				"DiscoKey":   "discokey:7dd40082ad6ea9d3d553235d0fb0435acb20e33aa2d602ff0eafe476bf8f9f5f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41071",
+					"10.65.0.27:41071",
+					"172.17.0.1:41071",
+					"172.18.0.1:41071",
+					"172.19.0.1:41071",
+					"172.20.0.1:41071",
+					"172.21.0.1:41071",
+					"172.22.0.1:41071",
+					"172.23.0.1:41071",
+					"172.24.0.1:41071",
+					"172.25.0.1:41071",
+					"172.26.0.1:41071",
+					"172.27.0.1:41071"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:31:20.079613238Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2304635934592830,
+				"StableID":   "n3FjgvsmzJ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ddd03cabe5a0880bbfd631adbafc26e58abaceef3cbc85200f9556bd5661aa0e",
+				"DiscoKey":   "discokey:03ed13a450d2e8ad8127a5cb0dbd3e30cca5d59853fe38298e8e27e6ebb18306",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38225",
+					"10.65.0.27:38225",
+					"172.17.0.1:38225",
+					"172.18.0.1:38225",
+					"172.19.0.1:38225",
+					"172.20.0.1:38225",
+					"172.21.0.1:38225",
+					"172.22.0.1:38225",
+					"172.23.0.1:38225",
+					"172.24.0.1:38225",
+					"172.25.0.1:38225",
+					"172.26.0.1:38225",
+					"172.27.0.1:38225"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:31:20.585505115Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         147482855567493,
+				"StableID":   "nxg5vD8o9211CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb936fadd41580d07988f0e3cfd39b2789aa45093490bb15faec78200acd191f",
+				"DiscoKey":   "discokey:7e1c52975ca75e69853153072d371cdfdbd060a0b63604f15b2342549ba28360",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42585",
+					"10.65.0.27:42585",
+					"172.17.0.1:42585",
+					"172.18.0.1:42585",
+					"172.19.0.1:42585",
+					"172.20.0.1:42585",
+					"172.21.0.1:42585",
+					"172.22.0.1:42585",
+					"172.23.0.1:42585",
+					"172.24.0.1:42585",
+					"172.25.0.1:42585",
+					"172.26.0.1:42585",
+					"172.27.0.1:42585"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:31:21.132911497Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         542612347419738,
+				"StableID":   "nKb44NWkE511CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c28f5a3e4f5eb73dd696df9c66c1a16ca7f21f797c806d41b5c47b7ec5bf3865",
+				"DiscoKey":   "discokey:326b1c406d2c9d2d20af98068cd85525941e94c5a5f625ec9e198718474fef63",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41047",
+					"10.65.0.27:41047",
+					"172.17.0.1:41047",
+					"172.18.0.1:41047",
+					"172.19.0.1:41047",
+					"172.20.0.1:41047",
+					"172.21.0.1:41047",
+					"172.22.0.1:41047",
+					"172.23.0.1:41047",
+					"172.24.0.1:41047",
+					"172.25.0.1:41047",
+					"172.26.0.1:41047",
+					"172.27.0.1:41047"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:31:21.683118244Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5033822017498422,
+				"StableID":   "nZp1BBypJg11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ad270101c86b4ba8f163650cd703a6a30d1afa0812420fd67d22053428610818",
+				"KeyExpiry":  "2026-11-09T09:31:22Z",
+				"DiscoKey":   "discokey:10d9dbdd6e5aa94d7ad0dfd0dccec2e1cd5152477d4b86549fe9d78b441aec6a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54827",
+					"10.65.0.27:54827",
+					"172.17.0.1:54827",
+					"172.18.0.1:54827",
+					"172.19.0.1:54827",
+					"172.20.0.1:54827",
+					"172.21.0.1:54827",
+					"172.22.0.1:54827",
+					"172.23.0.1:54827",
+					"172.24.0.1:54827",
+					"172.25.0.1:54827",
+					"172.26.0.1:54827",
+					"172.27.0.1:54827"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:31:22.241162786Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1541088879289822,
+				"StableID":   "n3b14vnx2D11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bf38ae3ffb81086e242916fe5677fa6413c03759c74eca417e8f919d50496d52",
+				"KeyExpiry":  "2026-11-09T09:31:22Z",
+				"DiscoKey":   "discokey:43e9e079f1484f1168947f0d1f887875890d578e9c57292d4adbf393afd63536",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46940",
+					"10.65.0.27:46940",
+					"172.17.0.1:46940",
+					"172.18.0.1:46940",
+					"172.19.0.1:46940",
+					"172.20.0.1:46940",
+					"172.21.0.1:46940",
+					"172.22.0.1:46940",
+					"172.23.0.1:46940",
+					"172.24.0.1:46940",
+					"172.25.0.1:46940",
+					"172.26.0.1:46940",
+					"172.27.0.1:46940"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:31:22.772693001Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5041737289897031,
+				"StableID":   "ngy1hatQNg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3bf5463099cdade9a63193475dfb9fc239ebac3df8c5723bdd2e6967663d7369",
+				"KeyExpiry":  "2026-11-09T09:31:23Z",
+				"DiscoKey":   "discokey:055e128b7b9c29b6b7f2f5e8554d6a59e03859db72d0fcf30fd18dd2b8c93915",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42339",
+					"10.65.0.27:42339",
+					"172.17.0.1:42339",
+					"172.18.0.1:42339",
+					"172.19.0.1:42339",
+					"172.20.0.1:42339",
+					"172.21.0.1:42339",
+					"172.22.0.1:42339",
+					"172.23.0.1:42339",
+					"172.24.0.1:42339",
+					"172.25.0.1:42339",
+					"172.26.0.1:42339",
+					"172.27.0.1:42339"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:31:23.312350289Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2560487136403379": {
+				"ID":          2560487136403379,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2978985931168101,
+				"StableID":   "n21QgiuBGQ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       2978985931168101,
+				"Key":        "nodekey:956795c1ace148b85e3853ea1448a5a30924e90590d358ad3842c5128c14e54a",
+				"DiscoKey":   "discokey:9f088eba31081936a97b75c0a2632506193f0af3d2cb856ec595399fdcfe755b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51397",
+					"10.65.0.27:51397",
+					"172.17.0.1:51397",
+					"172.18.0.1:51397",
+					"172.19.0.1:51397",
+					"172.20.0.1:51397",
+					"172.21.0.1:51397",
+					"172.22.0.1:51397",
+					"172.23.0.1:51397",
+					"172.24.0.1:51397",
+					"172.25.0.1:51397",
+					"172.26.0.1:51397",
+					"172.27.0.1:51397"
+				],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:31:18.982822055Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:956795c1ace148b85e3853ea1448a5a30924e90590d358ad3842c5128c14e54a",
+			"MachineKey": "mkey:6dc7bfb467fbb267c04f76b003bf523eadbce5132703ccf29fbf2ca8201f8a7f",
+			"Peers": [{
+				"ID":         8254899363490767,
+				"StableID":   "nQqFB6DfT721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4a1194f21632107f9ae87c61cdcd49b5513de5f3bbed26c6ea57b140b1db5701",
+				"DiscoKey":   "discokey:92f7e062531900437d0ba7735f2a3eddddf7806a42f8d480bb5408e23df02a1c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33170",
+					"10.65.0.27:33170",
+					"172.17.0.1:33170",
+					"172.18.0.1:33170",
+					"172.19.0.1:33170",
+					"172.20.0.1:33170",
+					"172.21.0.1:33170",
+					"172.22.0.1:33170",
+					"172.23.0.1:33170",
+					"172.24.0.1:33170",
+					"172.25.0.1:33170",
+					"172.26.0.1:33170",
+					"172.27.0.1:33170"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:31:15.78345442Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7713901239591924,
+				"StableID":   "nXJgX67eE321CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:16430c93e36cb955fa5abbe7a66970fd73824f400bc4824e4e2fb05fda584851",
+				"DiscoKey":   "discokey:1f0d417a7eb8e9da3030dcc9df9a40888203abec575f3d9c891a01fe7210bb11",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33907",
+					"10.65.0.27:33907",
+					"172.17.0.1:33907",
+					"172.18.0.1:33907",
+					"172.19.0.1:33907",
+					"172.20.0.1:33907",
+					"172.21.0.1:33907",
+					"172.22.0.1:33907",
+					"172.23.0.1:33907",
+					"172.24.0.1:33907",
+					"172.25.0.1:33907",
+					"172.26.0.1:33907",
+					"172.27.0.1:33907"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:31:16.262119848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7582315319859850,
+				"StableID":   "nFZ2QqZ3D221CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:247f249080e7fd2fcafec11d46373b29a0f37a197ac2ef59c1435f1d422b8c3c",
+				"DiscoKey":   "discokey:7a7dead37ba78b3b7bd83b67e6be2144e406c5d732fc6c5fbfa9c4bec7b1d763",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53868",
+					"10.65.0.27:53868",
+					"172.17.0.1:53868",
+					"172.18.0.1:53868",
+					"172.19.0.1:53868",
+					"172.20.0.1:53868",
+					"172.21.0.1:53868",
+					"172.22.0.1:53868",
+					"172.23.0.1:53868",
+					"172.24.0.1:53868",
+					"172.25.0.1:53868",
+					"172.26.0.1:53868",
+					"172.27.0.1:53868"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:31:16.797992969Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2560487136403379,
+				"StableID":   "nJWXG1fezL11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a075406c8fb1cb5f698faac7a1f3ee254f055b9dde17771016caf1829caaed13",
+				"DiscoKey":   "discokey:c43b5c7425b822c56d547a0523ba075755cb2fc9dfaafba2af677d26a91eac38",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55128",
+					"10.65.0.27:55128",
+					"172.17.0.1:55128",
+					"172.18.0.1:55128",
+					"172.19.0.1:55128",
+					"172.20.0.1:55128",
+					"172.21.0.1:55128",
+					"172.22.0.1:55128",
+					"172.23.0.1:55128",
+					"172.24.0.1:55128",
+					"172.25.0.1:55128",
+					"172.26.0.1:55128",
+					"172.27.0.1:55128"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:31:17.345258924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6886132612070607,
+				"StableID":   "nx7aUZ2kmv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:416b01ff172fe185de22cd955bc5263b0635f48d4f3ff4fba027c05a87984a23",
+				"DiscoKey":   "discokey:1d733d12d18720d90ba1fba796e97c15eb4d46c05e86fc950ce119a5e13b1431",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57519",
+					"10.65.0.27:57519",
+					"172.17.0.1:57519",
+					"172.18.0.1:57519",
+					"172.19.0.1:57519",
+					"172.20.0.1:57519",
+					"172.21.0.1:57519",
+					"172.22.0.1:57519",
+					"172.23.0.1:57519",
+					"172.24.0.1:57519",
+					"172.25.0.1:57519",
+					"172.26.0.1:57519",
+					"172.27.0.1:57519"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:31:17.891339506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8870978364341213,
+				"StableID":   "nCcUpRZgGC21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:01be22a4271b5a219941164bbb03a5c6bac56e47a468eb99249bacef1e005e1b",
+				"DiscoKey":   "discokey:7dd974bc9382eda95714cf999a4a7b47342a17969920476e28605c6e23d35418",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53300",
+					"10.65.0.27:53300",
+					"172.17.0.1:53300",
+					"172.18.0.1:53300",
+					"172.19.0.1:53300",
+					"172.20.0.1:53300",
+					"172.21.0.1:53300",
+					"172.22.0.1:53300",
+					"172.23.0.1:53300",
+					"172.24.0.1:53300",
+					"172.25.0.1:53300",
+					"172.26.0.1:53300",
+					"172.27.0.1:53300"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:31:18.431901823Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3513817186690356,
+				"StableID":   "nBebH72RSU11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0f9ef7377b722eef4a183de8a96300478faaaaad4ba9f3e902d9db2b5e23d50",
+				"DiscoKey":   "discokey:dbd521e7cc5e2b98779dbe4775b2072c536576f5683cc9e8162a15c670feb34c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36246",
+					"10.65.0.27:36246",
+					"172.17.0.1:36246",
+					"172.18.0.1:36246",
+					"172.19.0.1:36246",
+					"172.20.0.1:36246",
+					"172.21.0.1:36246",
+					"172.22.0.1:36246",
+					"172.23.0.1:36246",
+					"172.24.0.1:36246",
+					"172.25.0.1:36246",
+					"172.26.0.1:36246",
+					"172.27.0.1:36246"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:31:19.515350414Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4350398567006230,
+				"StableID":   "n1xK8RbJya11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47e43fc1bedbc5a00244bd79667ce9198bb13b954a1a0b61da50970657f29b2e",
+				"DiscoKey":   "discokey:7dd40082ad6ea9d3d553235d0fb0435acb20e33aa2d602ff0eafe476bf8f9f5f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41071",
+					"10.65.0.27:41071",
+					"172.17.0.1:41071",
+					"172.18.0.1:41071",
+					"172.19.0.1:41071",
+					"172.20.0.1:41071",
+					"172.21.0.1:41071",
+					"172.22.0.1:41071",
+					"172.23.0.1:41071",
+					"172.24.0.1:41071",
+					"172.25.0.1:41071",
+					"172.26.0.1:41071",
+					"172.27.0.1:41071"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:31:20.079613238Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2304635934592830,
+				"StableID":   "n3FjgvsmzJ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ddd03cabe5a0880bbfd631adbafc26e58abaceef3cbc85200f9556bd5661aa0e",
+				"DiscoKey":   "discokey:03ed13a450d2e8ad8127a5cb0dbd3e30cca5d59853fe38298e8e27e6ebb18306",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38225",
+					"10.65.0.27:38225",
+					"172.17.0.1:38225",
+					"172.18.0.1:38225",
+					"172.19.0.1:38225",
+					"172.20.0.1:38225",
+					"172.21.0.1:38225",
+					"172.22.0.1:38225",
+					"172.23.0.1:38225",
+					"172.24.0.1:38225",
+					"172.25.0.1:38225",
+					"172.26.0.1:38225",
+					"172.27.0.1:38225"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:31:20.585505115Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         147482855567493,
+				"StableID":   "nxg5vD8o9211CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb936fadd41580d07988f0e3cfd39b2789aa45093490bb15faec78200acd191f",
+				"DiscoKey":   "discokey:7e1c52975ca75e69853153072d371cdfdbd060a0b63604f15b2342549ba28360",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42585",
+					"10.65.0.27:42585",
+					"172.17.0.1:42585",
+					"172.18.0.1:42585",
+					"172.19.0.1:42585",
+					"172.20.0.1:42585",
+					"172.21.0.1:42585",
+					"172.22.0.1:42585",
+					"172.23.0.1:42585",
+					"172.24.0.1:42585",
+					"172.25.0.1:42585",
+					"172.26.0.1:42585",
+					"172.27.0.1:42585"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:31:21.132911497Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         542612347419738,
+				"StableID":   "nKb44NWkE511CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c28f5a3e4f5eb73dd696df9c66c1a16ca7f21f797c806d41b5c47b7ec5bf3865",
+				"DiscoKey":   "discokey:326b1c406d2c9d2d20af98068cd85525941e94c5a5f625ec9e198718474fef63",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41047",
+					"10.65.0.27:41047",
+					"172.17.0.1:41047",
+					"172.18.0.1:41047",
+					"172.19.0.1:41047",
+					"172.20.0.1:41047",
+					"172.21.0.1:41047",
+					"172.22.0.1:41047",
+					"172.23.0.1:41047",
+					"172.24.0.1:41047",
+					"172.25.0.1:41047",
+					"172.26.0.1:41047",
+					"172.27.0.1:41047"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:31:21.683118244Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5033822017498422,
+				"StableID":   "nZp1BBypJg11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ad270101c86b4ba8f163650cd703a6a30d1afa0812420fd67d22053428610818",
+				"KeyExpiry":  "2026-11-09T09:31:22Z",
+				"DiscoKey":   "discokey:10d9dbdd6e5aa94d7ad0dfd0dccec2e1cd5152477d4b86549fe9d78b441aec6a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54827",
+					"10.65.0.27:54827",
+					"172.17.0.1:54827",
+					"172.18.0.1:54827",
+					"172.19.0.1:54827",
+					"172.20.0.1:54827",
+					"172.21.0.1:54827",
+					"172.22.0.1:54827",
+					"172.23.0.1:54827",
+					"172.24.0.1:54827",
+					"172.25.0.1:54827",
+					"172.26.0.1:54827",
+					"172.27.0.1:54827"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:31:22.241162786Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1541088879289822,
+				"StableID":   "n3b14vnx2D11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bf38ae3ffb81086e242916fe5677fa6413c03759c74eca417e8f919d50496d52",
+				"KeyExpiry":  "2026-11-09T09:31:22Z",
+				"DiscoKey":   "discokey:43e9e079f1484f1168947f0d1f887875890d578e9c57292d4adbf393afd63536",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46940",
+					"10.65.0.27:46940",
+					"172.17.0.1:46940",
+					"172.18.0.1:46940",
+					"172.19.0.1:46940",
+					"172.20.0.1:46940",
+					"172.21.0.1:46940",
+					"172.22.0.1:46940",
+					"172.23.0.1:46940",
+					"172.24.0.1:46940",
+					"172.25.0.1:46940",
+					"172.26.0.1:46940",
+					"172.27.0.1:46940"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:31:22.772693001Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5041737289897031,
+				"StableID":   "ngy1hatQNg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3bf5463099cdade9a63193475dfb9fc239ebac3df8c5723bdd2e6967663d7369",
+				"KeyExpiry":  "2026-11-09T09:31:23Z",
+				"DiscoKey":   "discokey:055e128b7b9c29b6b7f2f5e8554d6a59e03859db72d0fcf30fd18dd2b8c93915",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42339",
+					"10.65.0.27:42339",
+					"172.17.0.1:42339",
+					"172.18.0.1:42339",
+					"172.19.0.1:42339",
+					"172.20.0.1:42339",
+					"172.21.0.1:42339",
+					"172.22.0.1:42339",
+					"172.23.0.1:42339",
+					"172.24.0.1:42339",
+					"172.25.0.1:42339",
+					"172.26.0.1:42339",
+					"172.27.0.1:42339"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:31:23.312350289Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2978985931168101": {
+				"ID":          2978985931168101,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4350398567006230,
+				"StableID":   "n1xK8RbJya11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       4350398567006230,
+				"Key":        "nodekey:47e43fc1bedbc5a00244bd79667ce9198bb13b954a1a0b61da50970657f29b2e",
+				"DiscoKey":   "discokey:7dd40082ad6ea9d3d553235d0fb0435acb20e33aa2d602ff0eafe476bf8f9f5f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41071",
+					"10.65.0.27:41071",
+					"172.17.0.1:41071",
+					"172.18.0.1:41071",
+					"172.19.0.1:41071",
+					"172.20.0.1:41071",
+					"172.21.0.1:41071",
+					"172.22.0.1:41071",
+					"172.23.0.1:41071",
+					"172.24.0.1:41071",
+					"172.25.0.1:41071",
+					"172.26.0.1:41071",
+					"172.27.0.1:41071"
+				],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-13T09:31:20.079613238Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:47e43fc1bedbc5a00244bd79667ce9198bb13b954a1a0b61da50970657f29b2e",
+			"MachineKey": "mkey:8b073f0f781d7e767b2c3fb29daf767da447e9e91828592b216d910c366a2348",
+			"Peers": [{
+				"ID":         8254899363490767,
+				"StableID":   "nQqFB6DfT721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4a1194f21632107f9ae87c61cdcd49b5513de5f3bbed26c6ea57b140b1db5701",
+				"DiscoKey":   "discokey:92f7e062531900437d0ba7735f2a3eddddf7806a42f8d480bb5408e23df02a1c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33170",
+					"10.65.0.27:33170",
+					"172.17.0.1:33170",
+					"172.18.0.1:33170",
+					"172.19.0.1:33170",
+					"172.20.0.1:33170",
+					"172.21.0.1:33170",
+					"172.22.0.1:33170",
+					"172.23.0.1:33170",
+					"172.24.0.1:33170",
+					"172.25.0.1:33170",
+					"172.26.0.1:33170",
+					"172.27.0.1:33170"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:31:15.78345442Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7713901239591924,
+				"StableID":   "nXJgX67eE321CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:16430c93e36cb955fa5abbe7a66970fd73824f400bc4824e4e2fb05fda584851",
+				"DiscoKey":   "discokey:1f0d417a7eb8e9da3030dcc9df9a40888203abec575f3d9c891a01fe7210bb11",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33907",
+					"10.65.0.27:33907",
+					"172.17.0.1:33907",
+					"172.18.0.1:33907",
+					"172.19.0.1:33907",
+					"172.20.0.1:33907",
+					"172.21.0.1:33907",
+					"172.22.0.1:33907",
+					"172.23.0.1:33907",
+					"172.24.0.1:33907",
+					"172.25.0.1:33907",
+					"172.26.0.1:33907",
+					"172.27.0.1:33907"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:31:16.262119848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7582315319859850,
+				"StableID":   "nFZ2QqZ3D221CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:247f249080e7fd2fcafec11d46373b29a0f37a197ac2ef59c1435f1d422b8c3c",
+				"DiscoKey":   "discokey:7a7dead37ba78b3b7bd83b67e6be2144e406c5d732fc6c5fbfa9c4bec7b1d763",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53868",
+					"10.65.0.27:53868",
+					"172.17.0.1:53868",
+					"172.18.0.1:53868",
+					"172.19.0.1:53868",
+					"172.20.0.1:53868",
+					"172.21.0.1:53868",
+					"172.22.0.1:53868",
+					"172.23.0.1:53868",
+					"172.24.0.1:53868",
+					"172.25.0.1:53868",
+					"172.26.0.1:53868",
+					"172.27.0.1:53868"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:31:16.797992969Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2560487136403379,
+				"StableID":   "nJWXG1fezL11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a075406c8fb1cb5f698faac7a1f3ee254f055b9dde17771016caf1829caaed13",
+				"DiscoKey":   "discokey:c43b5c7425b822c56d547a0523ba075755cb2fc9dfaafba2af677d26a91eac38",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55128",
+					"10.65.0.27:55128",
+					"172.17.0.1:55128",
+					"172.18.0.1:55128",
+					"172.19.0.1:55128",
+					"172.20.0.1:55128",
+					"172.21.0.1:55128",
+					"172.22.0.1:55128",
+					"172.23.0.1:55128",
+					"172.24.0.1:55128",
+					"172.25.0.1:55128",
+					"172.26.0.1:55128",
+					"172.27.0.1:55128"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:31:17.345258924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6886132612070607,
+				"StableID":   "nx7aUZ2kmv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:416b01ff172fe185de22cd955bc5263b0635f48d4f3ff4fba027c05a87984a23",
+				"DiscoKey":   "discokey:1d733d12d18720d90ba1fba796e97c15eb4d46c05e86fc950ce119a5e13b1431",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57519",
+					"10.65.0.27:57519",
+					"172.17.0.1:57519",
+					"172.18.0.1:57519",
+					"172.19.0.1:57519",
+					"172.20.0.1:57519",
+					"172.21.0.1:57519",
+					"172.22.0.1:57519",
+					"172.23.0.1:57519",
+					"172.24.0.1:57519",
+					"172.25.0.1:57519",
+					"172.26.0.1:57519",
+					"172.27.0.1:57519"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:31:17.891339506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8870978364341213,
+				"StableID":   "nCcUpRZgGC21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:01be22a4271b5a219941164bbb03a5c6bac56e47a468eb99249bacef1e005e1b",
+				"DiscoKey":   "discokey:7dd974bc9382eda95714cf999a4a7b47342a17969920476e28605c6e23d35418",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53300",
+					"10.65.0.27:53300",
+					"172.17.0.1:53300",
+					"172.18.0.1:53300",
+					"172.19.0.1:53300",
+					"172.20.0.1:53300",
+					"172.21.0.1:53300",
+					"172.22.0.1:53300",
+					"172.23.0.1:53300",
+					"172.24.0.1:53300",
+					"172.25.0.1:53300",
+					"172.26.0.1:53300",
+					"172.27.0.1:53300"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:31:18.431901823Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2978985931168101,
+				"StableID":   "n21QgiuBGQ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:956795c1ace148b85e3853ea1448a5a30924e90590d358ad3842c5128c14e54a",
+				"DiscoKey":   "discokey:9f088eba31081936a97b75c0a2632506193f0af3d2cb856ec595399fdcfe755b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51397",
+					"10.65.0.27:51397",
+					"172.17.0.1:51397",
+					"172.18.0.1:51397",
+					"172.19.0.1:51397",
+					"172.20.0.1:51397",
+					"172.21.0.1:51397",
+					"172.22.0.1:51397",
+					"172.23.0.1:51397",
+					"172.24.0.1:51397",
+					"172.25.0.1:51397",
+					"172.26.0.1:51397",
+					"172.27.0.1:51397"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:31:18.982822055Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3513817186690356,
+				"StableID":   "nBebH72RSU11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0f9ef7377b722eef4a183de8a96300478faaaaad4ba9f3e902d9db2b5e23d50",
+				"DiscoKey":   "discokey:dbd521e7cc5e2b98779dbe4775b2072c536576f5683cc9e8162a15c670feb34c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36246",
+					"10.65.0.27:36246",
+					"172.17.0.1:36246",
+					"172.18.0.1:36246",
+					"172.19.0.1:36246",
+					"172.20.0.1:36246",
+					"172.21.0.1:36246",
+					"172.22.0.1:36246",
+					"172.23.0.1:36246",
+					"172.24.0.1:36246",
+					"172.25.0.1:36246",
+					"172.26.0.1:36246",
+					"172.27.0.1:36246"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:31:19.515350414Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2304635934592830,
+				"StableID":   "n3FjgvsmzJ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ddd03cabe5a0880bbfd631adbafc26e58abaceef3cbc85200f9556bd5661aa0e",
+				"DiscoKey":   "discokey:03ed13a450d2e8ad8127a5cb0dbd3e30cca5d59853fe38298e8e27e6ebb18306",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38225",
+					"10.65.0.27:38225",
+					"172.17.0.1:38225",
+					"172.18.0.1:38225",
+					"172.19.0.1:38225",
+					"172.20.0.1:38225",
+					"172.21.0.1:38225",
+					"172.22.0.1:38225",
+					"172.23.0.1:38225",
+					"172.24.0.1:38225",
+					"172.25.0.1:38225",
+					"172.26.0.1:38225",
+					"172.27.0.1:38225"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:31:20.585505115Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         147482855567493,
+				"StableID":   "nxg5vD8o9211CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb936fadd41580d07988f0e3cfd39b2789aa45093490bb15faec78200acd191f",
+				"DiscoKey":   "discokey:7e1c52975ca75e69853153072d371cdfdbd060a0b63604f15b2342549ba28360",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42585",
+					"10.65.0.27:42585",
+					"172.17.0.1:42585",
+					"172.18.0.1:42585",
+					"172.19.0.1:42585",
+					"172.20.0.1:42585",
+					"172.21.0.1:42585",
+					"172.22.0.1:42585",
+					"172.23.0.1:42585",
+					"172.24.0.1:42585",
+					"172.25.0.1:42585",
+					"172.26.0.1:42585",
+					"172.27.0.1:42585"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:31:21.132911497Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         542612347419738,
+				"StableID":   "nKb44NWkE511CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c28f5a3e4f5eb73dd696df9c66c1a16ca7f21f797c806d41b5c47b7ec5bf3865",
+				"DiscoKey":   "discokey:326b1c406d2c9d2d20af98068cd85525941e94c5a5f625ec9e198718474fef63",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41047",
+					"10.65.0.27:41047",
+					"172.17.0.1:41047",
+					"172.18.0.1:41047",
+					"172.19.0.1:41047",
+					"172.20.0.1:41047",
+					"172.21.0.1:41047",
+					"172.22.0.1:41047",
+					"172.23.0.1:41047",
+					"172.24.0.1:41047",
+					"172.25.0.1:41047",
+					"172.26.0.1:41047",
+					"172.27.0.1:41047"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:31:21.683118244Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5033822017498422,
+				"StableID":   "nZp1BBypJg11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ad270101c86b4ba8f163650cd703a6a30d1afa0812420fd67d22053428610818",
+				"KeyExpiry":  "2026-11-09T09:31:22Z",
+				"DiscoKey":   "discokey:10d9dbdd6e5aa94d7ad0dfd0dccec2e1cd5152477d4b86549fe9d78b441aec6a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54827",
+					"10.65.0.27:54827",
+					"172.17.0.1:54827",
+					"172.18.0.1:54827",
+					"172.19.0.1:54827",
+					"172.20.0.1:54827",
+					"172.21.0.1:54827",
+					"172.22.0.1:54827",
+					"172.23.0.1:54827",
+					"172.24.0.1:54827",
+					"172.25.0.1:54827",
+					"172.26.0.1:54827",
+					"172.27.0.1:54827"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:31:22.241162786Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1541088879289822,
+				"StableID":   "n3b14vnx2D11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bf38ae3ffb81086e242916fe5677fa6413c03759c74eca417e8f919d50496d52",
+				"KeyExpiry":  "2026-11-09T09:31:22Z",
+				"DiscoKey":   "discokey:43e9e079f1484f1168947f0d1f887875890d578e9c57292d4adbf393afd63536",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46940",
+					"10.65.0.27:46940",
+					"172.17.0.1:46940",
+					"172.18.0.1:46940",
+					"172.19.0.1:46940",
+					"172.20.0.1:46940",
+					"172.21.0.1:46940",
+					"172.22.0.1:46940",
+					"172.23.0.1:46940",
+					"172.24.0.1:46940",
+					"172.25.0.1:46940",
+					"172.26.0.1:46940",
+					"172.27.0.1:46940"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:31:22.772693001Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5041737289897031,
+				"StableID":   "ngy1hatQNg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3bf5463099cdade9a63193475dfb9fc239ebac3df8c5723bdd2e6967663d7369",
+				"KeyExpiry":  "2026-11-09T09:31:23Z",
+				"DiscoKey":   "discokey:055e128b7b9c29b6b7f2f5e8554d6a59e03859db72d0fcf30fd18dd2b8c93915",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42339",
+					"10.65.0.27:42339",
+					"172.17.0.1:42339",
+					"172.18.0.1:42339",
+					"172.19.0.1:42339",
+					"172.20.0.1:42339",
+					"172.21.0.1:42339",
+					"172.22.0.1:42339",
+					"172.23.0.1:42339",
+					"172.24.0.1:42339",
+					"172.25.0.1:42339",
+					"172.26.0.1:42339",
+					"172.27.0.1:42339"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:31:23.312350289Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4350398567006230": {
+				"ID":          4350398567006230,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1541088879289822,
+				"StableID":   "n3b14vnx2D11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bf38ae3ffb81086e242916fe5677fa6413c03759c74eca417e8f919d50496d52",
+				"KeyExpiry":  "2026-11-09T09:31:22Z",
+				"DiscoKey":   "discokey:43e9e079f1484f1168947f0d1f887875890d578e9c57292d4adbf393afd63536",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46940",
+					"10.65.0.27:46940",
+					"172.17.0.1:46940",
+					"172.18.0.1:46940",
+					"172.19.0.1:46940",
+					"172.20.0.1:46940",
+					"172.21.0.1:46940",
+					"172.22.0.1:46940",
+					"172.23.0.1:46940",
+					"172.24.0.1:46940",
+					"172.25.0.1:46940",
+					"172.26.0.1:46940",
+					"172.27.0.1:46940"
+				],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:31:22.772693001Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:bf38ae3ffb81086e242916fe5677fa6413c03759c74eca417e8f919d50496d52",
+			"MachineKey": "mkey:1e50d6fc8b254c2c5905ce9d698843623bc1eb750db4a28667d283188eb94b62",
+			"Peers": [{
+				"ID":         8254899363490767,
+				"StableID":   "nQqFB6DfT721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4a1194f21632107f9ae87c61cdcd49b5513de5f3bbed26c6ea57b140b1db5701",
+				"DiscoKey":   "discokey:92f7e062531900437d0ba7735f2a3eddddf7806a42f8d480bb5408e23df02a1c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33170",
+					"10.65.0.27:33170",
+					"172.17.0.1:33170",
+					"172.18.0.1:33170",
+					"172.19.0.1:33170",
+					"172.20.0.1:33170",
+					"172.21.0.1:33170",
+					"172.22.0.1:33170",
+					"172.23.0.1:33170",
+					"172.24.0.1:33170",
+					"172.25.0.1:33170",
+					"172.26.0.1:33170",
+					"172.27.0.1:33170"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:31:15.78345442Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7713901239591924,
+				"StableID":   "nXJgX67eE321CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:16430c93e36cb955fa5abbe7a66970fd73824f400bc4824e4e2fb05fda584851",
+				"DiscoKey":   "discokey:1f0d417a7eb8e9da3030dcc9df9a40888203abec575f3d9c891a01fe7210bb11",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33907",
+					"10.65.0.27:33907",
+					"172.17.0.1:33907",
+					"172.18.0.1:33907",
+					"172.19.0.1:33907",
+					"172.20.0.1:33907",
+					"172.21.0.1:33907",
+					"172.22.0.1:33907",
+					"172.23.0.1:33907",
+					"172.24.0.1:33907",
+					"172.25.0.1:33907",
+					"172.26.0.1:33907",
+					"172.27.0.1:33907"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:31:16.262119848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7582315319859850,
+				"StableID":   "nFZ2QqZ3D221CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:247f249080e7fd2fcafec11d46373b29a0f37a197ac2ef59c1435f1d422b8c3c",
+				"DiscoKey":   "discokey:7a7dead37ba78b3b7bd83b67e6be2144e406c5d732fc6c5fbfa9c4bec7b1d763",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53868",
+					"10.65.0.27:53868",
+					"172.17.0.1:53868",
+					"172.18.0.1:53868",
+					"172.19.0.1:53868",
+					"172.20.0.1:53868",
+					"172.21.0.1:53868",
+					"172.22.0.1:53868",
+					"172.23.0.1:53868",
+					"172.24.0.1:53868",
+					"172.25.0.1:53868",
+					"172.26.0.1:53868",
+					"172.27.0.1:53868"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:31:16.797992969Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2560487136403379,
+				"StableID":   "nJWXG1fezL11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a075406c8fb1cb5f698faac7a1f3ee254f055b9dde17771016caf1829caaed13",
+				"DiscoKey":   "discokey:c43b5c7425b822c56d547a0523ba075755cb2fc9dfaafba2af677d26a91eac38",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55128",
+					"10.65.0.27:55128",
+					"172.17.0.1:55128",
+					"172.18.0.1:55128",
+					"172.19.0.1:55128",
+					"172.20.0.1:55128",
+					"172.21.0.1:55128",
+					"172.22.0.1:55128",
+					"172.23.0.1:55128",
+					"172.24.0.1:55128",
+					"172.25.0.1:55128",
+					"172.26.0.1:55128",
+					"172.27.0.1:55128"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:31:17.345258924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6886132612070607,
+				"StableID":   "nx7aUZ2kmv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:416b01ff172fe185de22cd955bc5263b0635f48d4f3ff4fba027c05a87984a23",
+				"DiscoKey":   "discokey:1d733d12d18720d90ba1fba796e97c15eb4d46c05e86fc950ce119a5e13b1431",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57519",
+					"10.65.0.27:57519",
+					"172.17.0.1:57519",
+					"172.18.0.1:57519",
+					"172.19.0.1:57519",
+					"172.20.0.1:57519",
+					"172.21.0.1:57519",
+					"172.22.0.1:57519",
+					"172.23.0.1:57519",
+					"172.24.0.1:57519",
+					"172.25.0.1:57519",
+					"172.26.0.1:57519",
+					"172.27.0.1:57519"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:31:17.891339506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8870978364341213,
+				"StableID":   "nCcUpRZgGC21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:01be22a4271b5a219941164bbb03a5c6bac56e47a468eb99249bacef1e005e1b",
+				"DiscoKey":   "discokey:7dd974bc9382eda95714cf999a4a7b47342a17969920476e28605c6e23d35418",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53300",
+					"10.65.0.27:53300",
+					"172.17.0.1:53300",
+					"172.18.0.1:53300",
+					"172.19.0.1:53300",
+					"172.20.0.1:53300",
+					"172.21.0.1:53300",
+					"172.22.0.1:53300",
+					"172.23.0.1:53300",
+					"172.24.0.1:53300",
+					"172.25.0.1:53300",
+					"172.26.0.1:53300",
+					"172.27.0.1:53300"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:31:18.431901823Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2978985931168101,
+				"StableID":   "n21QgiuBGQ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:956795c1ace148b85e3853ea1448a5a30924e90590d358ad3842c5128c14e54a",
+				"DiscoKey":   "discokey:9f088eba31081936a97b75c0a2632506193f0af3d2cb856ec595399fdcfe755b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51397",
+					"10.65.0.27:51397",
+					"172.17.0.1:51397",
+					"172.18.0.1:51397",
+					"172.19.0.1:51397",
+					"172.20.0.1:51397",
+					"172.21.0.1:51397",
+					"172.22.0.1:51397",
+					"172.23.0.1:51397",
+					"172.24.0.1:51397",
+					"172.25.0.1:51397",
+					"172.26.0.1:51397",
+					"172.27.0.1:51397"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:31:18.982822055Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3513817186690356,
+				"StableID":   "nBebH72RSU11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0f9ef7377b722eef4a183de8a96300478faaaaad4ba9f3e902d9db2b5e23d50",
+				"DiscoKey":   "discokey:dbd521e7cc5e2b98779dbe4775b2072c536576f5683cc9e8162a15c670feb34c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36246",
+					"10.65.0.27:36246",
+					"172.17.0.1:36246",
+					"172.18.0.1:36246",
+					"172.19.0.1:36246",
+					"172.20.0.1:36246",
+					"172.21.0.1:36246",
+					"172.22.0.1:36246",
+					"172.23.0.1:36246",
+					"172.24.0.1:36246",
+					"172.25.0.1:36246",
+					"172.26.0.1:36246",
+					"172.27.0.1:36246"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:31:19.515350414Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4350398567006230,
+				"StableID":   "n1xK8RbJya11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47e43fc1bedbc5a00244bd79667ce9198bb13b954a1a0b61da50970657f29b2e",
+				"DiscoKey":   "discokey:7dd40082ad6ea9d3d553235d0fb0435acb20e33aa2d602ff0eafe476bf8f9f5f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41071",
+					"10.65.0.27:41071",
+					"172.17.0.1:41071",
+					"172.18.0.1:41071",
+					"172.19.0.1:41071",
+					"172.20.0.1:41071",
+					"172.21.0.1:41071",
+					"172.22.0.1:41071",
+					"172.23.0.1:41071",
+					"172.24.0.1:41071",
+					"172.25.0.1:41071",
+					"172.26.0.1:41071",
+					"172.27.0.1:41071"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:31:20.079613238Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2304635934592830,
+				"StableID":   "n3FjgvsmzJ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ddd03cabe5a0880bbfd631adbafc26e58abaceef3cbc85200f9556bd5661aa0e",
+				"DiscoKey":   "discokey:03ed13a450d2e8ad8127a5cb0dbd3e30cca5d59853fe38298e8e27e6ebb18306",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38225",
+					"10.65.0.27:38225",
+					"172.17.0.1:38225",
+					"172.18.0.1:38225",
+					"172.19.0.1:38225",
+					"172.20.0.1:38225",
+					"172.21.0.1:38225",
+					"172.22.0.1:38225",
+					"172.23.0.1:38225",
+					"172.24.0.1:38225",
+					"172.25.0.1:38225",
+					"172.26.0.1:38225",
+					"172.27.0.1:38225"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-13T09:31:20.585505115Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         147482855567493,
+				"StableID":   "nxg5vD8o9211CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb936fadd41580d07988f0e3cfd39b2789aa45093490bb15faec78200acd191f",
+				"DiscoKey":   "discokey:7e1c52975ca75e69853153072d371cdfdbd060a0b63604f15b2342549ba28360",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42585",
+					"10.65.0.27:42585",
+					"172.17.0.1:42585",
+					"172.18.0.1:42585",
+					"172.19.0.1:42585",
+					"172.20.0.1:42585",
+					"172.21.0.1:42585",
+					"172.22.0.1:42585",
+					"172.23.0.1:42585",
+					"172.24.0.1:42585",
+					"172.25.0.1:42585",
+					"172.26.0.1:42585",
+					"172.27.0.1:42585"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:31:21.132911497Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         542612347419738,
+				"StableID":   "nKb44NWkE511CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c28f5a3e4f5eb73dd696df9c66c1a16ca7f21f797c806d41b5c47b7ec5bf3865",
+				"DiscoKey":   "discokey:326b1c406d2c9d2d20af98068cd85525941e94c5a5f625ec9e198718474fef63",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41047",
+					"10.65.0.27:41047",
+					"172.17.0.1:41047",
+					"172.18.0.1:41047",
+					"172.19.0.1:41047",
+					"172.20.0.1:41047",
+					"172.21.0.1:41047",
+					"172.22.0.1:41047",
+					"172.23.0.1:41047",
+					"172.24.0.1:41047",
+					"172.25.0.1:41047",
+					"172.26.0.1:41047",
+					"172.27.0.1:41047"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:31:21.683118244Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5033822017498422,
+				"StableID":   "nZp1BBypJg11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ad270101c86b4ba8f163650cd703a6a30d1afa0812420fd67d22053428610818",
+				"KeyExpiry":  "2026-11-09T09:31:22Z",
+				"DiscoKey":   "discokey:10d9dbdd6e5aa94d7ad0dfd0dccec2e1cd5152477d4b86549fe9d78b441aec6a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54827",
+					"10.65.0.27:54827",
+					"172.17.0.1:54827",
+					"172.18.0.1:54827",
+					"172.19.0.1:54827",
+					"172.20.0.1:54827",
+					"172.21.0.1:54827",
+					"172.22.0.1:54827",
+					"172.23.0.1:54827",
+					"172.24.0.1:54827",
+					"172.25.0.1:54827",
+					"172.26.0.1:54827",
+					"172.27.0.1:54827"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:31:22.241162786Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5041737289897031,
+				"StableID":   "ngy1hatQNg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3bf5463099cdade9a63193475dfb9fc239ebac3df8c5723bdd2e6967663d7369",
+				"KeyExpiry":  "2026-11-09T09:31:23Z",
+				"DiscoKey":   "discokey:055e128b7b9c29b6b7f2f5e8554d6a59e03859db72d0fcf30fd18dd2b8c93915",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42339",
+					"10.65.0.27:42339",
+					"172.17.0.1:42339",
+					"172.18.0.1:42339",
+					"172.19.0.1:42339",
+					"172.20.0.1:42339",
+					"172.21.0.1:42339",
+					"172.22.0.1:42339",
+					"172.23.0.1:42339",
+					"172.24.0.1:42339",
+					"172.25.0.1:42339",
+					"172.26.0.1:42339",
+					"172.27.0.1:42339"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:31:23.312350289Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2304635934592830,
+				"StableID":   "n3FjgvsmzJ11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       2304635934592830,
+				"Key":        "nodekey:ddd03cabe5a0880bbfd631adbafc26e58abaceef3cbc85200f9556bd5661aa0e",
+				"DiscoKey":   "discokey:03ed13a450d2e8ad8127a5cb0dbd3e30cca5d59853fe38298e8e27e6ebb18306",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints": [
+					"77.164.248.136:38225",
+					"10.65.0.27:38225",
+					"172.17.0.1:38225",
+					"172.18.0.1:38225",
+					"172.19.0.1:38225",
+					"172.20.0.1:38225",
+					"172.21.0.1:38225",
+					"172.22.0.1:38225",
+					"172.23.0.1:38225",
+					"172.24.0.1:38225",
+					"172.25.0.1:38225",
+					"172.26.0.1:38225",
+					"172.27.0.1:38225"
+				],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-13T09:31:20.585505115Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ddd03cabe5a0880bbfd631adbafc26e58abaceef3cbc85200f9556bd5661aa0e",
+			"MachineKey": "mkey:b8347dfd3bf4a0f71836bfe7134089a0abebdeb262849773f5c0f69cab8cbc12",
+			"Peers": [{
+				"ID":         8254899363490767,
+				"StableID":   "nQqFB6DfT721CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4a1194f21632107f9ae87c61cdcd49b5513de5f3bbed26c6ea57b140b1db5701",
+				"DiscoKey":   "discokey:92f7e062531900437d0ba7735f2a3eddddf7806a42f8d480bb5408e23df02a1c",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints": [
+					"77.164.248.136:33170",
+					"10.65.0.27:33170",
+					"172.17.0.1:33170",
+					"172.18.0.1:33170",
+					"172.19.0.1:33170",
+					"172.20.0.1:33170",
+					"172.21.0.1:33170",
+					"172.22.0.1:33170",
+					"172.23.0.1:33170",
+					"172.24.0.1:33170",
+					"172.25.0.1:33170",
+					"172.26.0.1:33170",
+					"172.27.0.1:33170"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-13T09:31:15.78345442Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7713901239591924,
+				"StableID":   "nXJgX67eE321CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:16430c93e36cb955fa5abbe7a66970fd73824f400bc4824e4e2fb05fda584851",
+				"DiscoKey":   "discokey:1f0d417a7eb8e9da3030dcc9df9a40888203abec575f3d9c891a01fe7210bb11",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints": [
+					"77.164.248.136:33907",
+					"10.65.0.27:33907",
+					"172.17.0.1:33907",
+					"172.18.0.1:33907",
+					"172.19.0.1:33907",
+					"172.20.0.1:33907",
+					"172.21.0.1:33907",
+					"172.22.0.1:33907",
+					"172.23.0.1:33907",
+					"172.24.0.1:33907",
+					"172.25.0.1:33907",
+					"172.26.0.1:33907",
+					"172.27.0.1:33907"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-13T09:31:16.262119848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7582315319859850,
+				"StableID":   "nFZ2QqZ3D221CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:247f249080e7fd2fcafec11d46373b29a0f37a197ac2ef59c1435f1d422b8c3c",
+				"DiscoKey":   "discokey:7a7dead37ba78b3b7bd83b67e6be2144e406c5d732fc6c5fbfa9c4bec7b1d763",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints": [
+					"77.164.248.136:53868",
+					"10.65.0.27:53868",
+					"172.17.0.1:53868",
+					"172.18.0.1:53868",
+					"172.19.0.1:53868",
+					"172.20.0.1:53868",
+					"172.21.0.1:53868",
+					"172.22.0.1:53868",
+					"172.23.0.1:53868",
+					"172.24.0.1:53868",
+					"172.25.0.1:53868",
+					"172.26.0.1:53868",
+					"172.27.0.1:53868"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-13T09:31:16.797992969Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         2560487136403379,
+				"StableID":   "nJWXG1fezL11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a075406c8fb1cb5f698faac7a1f3ee254f055b9dde17771016caf1829caaed13",
+				"DiscoKey":   "discokey:c43b5c7425b822c56d547a0523ba075755cb2fc9dfaafba2af677d26a91eac38",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints": [
+					"77.164.248.136:55128",
+					"10.65.0.27:55128",
+					"172.17.0.1:55128",
+					"172.18.0.1:55128",
+					"172.19.0.1:55128",
+					"172.20.0.1:55128",
+					"172.21.0.1:55128",
+					"172.22.0.1:55128",
+					"172.23.0.1:55128",
+					"172.24.0.1:55128",
+					"172.25.0.1:55128",
+					"172.26.0.1:55128",
+					"172.27.0.1:55128"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-13T09:31:17.345258924Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         6886132612070607,
+				"StableID":   "nx7aUZ2kmv11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:416b01ff172fe185de22cd955bc5263b0635f48d4f3ff4fba027c05a87984a23",
+				"DiscoKey":   "discokey:1d733d12d18720d90ba1fba796e97c15eb4d46c05e86fc950ce119a5e13b1431",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints": [
+					"77.164.248.136:57519",
+					"10.65.0.27:57519",
+					"172.17.0.1:57519",
+					"172.18.0.1:57519",
+					"172.19.0.1:57519",
+					"172.20.0.1:57519",
+					"172.21.0.1:57519",
+					"172.22.0.1:57519",
+					"172.23.0.1:57519",
+					"172.24.0.1:57519",
+					"172.25.0.1:57519",
+					"172.26.0.1:57519",
+					"172.27.0.1:57519"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-13T09:31:17.891339506Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8870978364341213,
+				"StableID":   "nCcUpRZgGC21CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:01be22a4271b5a219941164bbb03a5c6bac56e47a468eb99249bacef1e005e1b",
+				"DiscoKey":   "discokey:7dd974bc9382eda95714cf999a4a7b47342a17969920476e28605c6e23d35418",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints": [
+					"77.164.248.136:53300",
+					"10.65.0.27:53300",
+					"172.17.0.1:53300",
+					"172.18.0.1:53300",
+					"172.19.0.1:53300",
+					"172.20.0.1:53300",
+					"172.21.0.1:53300",
+					"172.22.0.1:53300",
+					"172.23.0.1:53300",
+					"172.24.0.1:53300",
+					"172.25.0.1:53300",
+					"172.26.0.1:53300",
+					"172.27.0.1:53300"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-13T09:31:18.431901823Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2978985931168101,
+				"StableID":   "n21QgiuBGQ11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:956795c1ace148b85e3853ea1448a5a30924e90590d358ad3842c5128c14e54a",
+				"DiscoKey":   "discokey:9f088eba31081936a97b75c0a2632506193f0af3d2cb856ec595399fdcfe755b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints": [
+					"77.164.248.136:51397",
+					"10.65.0.27:51397",
+					"172.17.0.1:51397",
+					"172.18.0.1:51397",
+					"172.19.0.1:51397",
+					"172.20.0.1:51397",
+					"172.21.0.1:51397",
+					"172.22.0.1:51397",
+					"172.23.0.1:51397",
+					"172.24.0.1:51397",
+					"172.25.0.1:51397",
+					"172.26.0.1:51397",
+					"172.27.0.1:51397"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-13T09:31:18.982822055Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         3513817186690356,
+				"StableID":   "nBebH72RSU11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b0f9ef7377b722eef4a183de8a96300478faaaaad4ba9f3e902d9db2b5e23d50",
+				"DiscoKey":   "discokey:dbd521e7cc5e2b98779dbe4775b2072c536576f5683cc9e8162a15c670feb34c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints": [
+					"77.164.248.136:36246",
+					"10.65.0.27:36246",
+					"172.17.0.1:36246",
+					"172.18.0.1:36246",
+					"172.19.0.1:36246",
+					"172.20.0.1:36246",
+					"172.21.0.1:36246",
+					"172.22.0.1:36246",
+					"172.23.0.1:36246",
+					"172.24.0.1:36246",
+					"172.25.0.1:36246",
+					"172.26.0.1:36246",
+					"172.27.0.1:36246"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-13T09:31:19.515350414Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4350398567006230,
+				"StableID":   "n1xK8RbJya11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:47e43fc1bedbc5a00244bd79667ce9198bb13b954a1a0b61da50970657f29b2e",
+				"DiscoKey":   "discokey:7dd40082ad6ea9d3d553235d0fb0435acb20e33aa2d602ff0eafe476bf8f9f5f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints": [
+					"77.164.248.136:41071",
+					"10.65.0.27:41071",
+					"172.17.0.1:41071",
+					"172.18.0.1:41071",
+					"172.19.0.1:41071",
+					"172.20.0.1:41071",
+					"172.21.0.1:41071",
+					"172.22.0.1:41071",
+					"172.23.0.1:41071",
+					"172.24.0.1:41071",
+					"172.25.0.1:41071",
+					"172.26.0.1:41071",
+					"172.27.0.1:41071"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-13T09:31:20.079613238Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         147482855567493,
+				"StableID":   "nxg5vD8o9211CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cb936fadd41580d07988f0e3cfd39b2789aa45093490bb15faec78200acd191f",
+				"DiscoKey":   "discokey:7e1c52975ca75e69853153072d371cdfdbd060a0b63604f15b2342549ba28360",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints": [
+					"77.164.248.136:42585",
+					"10.65.0.27:42585",
+					"172.17.0.1:42585",
+					"172.18.0.1:42585",
+					"172.19.0.1:42585",
+					"172.20.0.1:42585",
+					"172.21.0.1:42585",
+					"172.22.0.1:42585",
+					"172.23.0.1:42585",
+					"172.24.0.1:42585",
+					"172.25.0.1:42585",
+					"172.26.0.1:42585",
+					"172.27.0.1:42585"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-13T09:31:21.132911497Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         542612347419738,
+				"StableID":   "nKb44NWkE511CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c28f5a3e4f5eb73dd696df9c66c1a16ca7f21f797c806d41b5c47b7ec5bf3865",
+				"DiscoKey":   "discokey:326b1c406d2c9d2d20af98068cd85525941e94c5a5f625ec9e198718474fef63",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints": [
+					"77.164.248.136:41047",
+					"10.65.0.27:41047",
+					"172.17.0.1:41047",
+					"172.18.0.1:41047",
+					"172.19.0.1:41047",
+					"172.20.0.1:41047",
+					"172.21.0.1:41047",
+					"172.22.0.1:41047",
+					"172.23.0.1:41047",
+					"172.24.0.1:41047",
+					"172.25.0.1:41047",
+					"172.26.0.1:41047",
+					"172.27.0.1:41047"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-13T09:31:21.683118244Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5033822017498422,
+				"StableID":   "nZp1BBypJg11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:ad270101c86b4ba8f163650cd703a6a30d1afa0812420fd67d22053428610818",
+				"KeyExpiry":  "2026-11-09T09:31:22Z",
+				"DiscoKey":   "discokey:10d9dbdd6e5aa94d7ad0dfd0dccec2e1cd5152477d4b86549fe9d78b441aec6a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints": [
+					"77.164.248.136:54827",
+					"10.65.0.27:54827",
+					"172.17.0.1:54827",
+					"172.18.0.1:54827",
+					"172.19.0.1:54827",
+					"172.20.0.1:54827",
+					"172.21.0.1:54827",
+					"172.22.0.1:54827",
+					"172.23.0.1:54827",
+					"172.24.0.1:54827",
+					"172.25.0.1:54827",
+					"172.26.0.1:54827",
+					"172.27.0.1:54827"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-13T09:31:22.241162786Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1541088879289822,
+				"StableID":   "n3b14vnx2D11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:bf38ae3ffb81086e242916fe5677fa6413c03759c74eca417e8f919d50496d52",
+				"KeyExpiry":  "2026-11-09T09:31:22Z",
+				"DiscoKey":   "discokey:43e9e079f1484f1168947f0d1f887875890d578e9c57292d4adbf393afd63536",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints": [
+					"77.164.248.136:46940",
+					"10.65.0.27:46940",
+					"172.17.0.1:46940",
+					"172.18.0.1:46940",
+					"172.19.0.1:46940",
+					"172.20.0.1:46940",
+					"172.21.0.1:46940",
+					"172.22.0.1:46940",
+					"172.23.0.1:46940",
+					"172.24.0.1:46940",
+					"172.25.0.1:46940",
+					"172.26.0.1:46940",
+					"172.27.0.1:46940"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-13T09:31:22.772693001Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5041737289897031,
+				"StableID":   "ngy1hatQNg11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:3bf5463099cdade9a63193475dfb9fc239ebac3df8c5723bdd2e6967663d7369",
+				"KeyExpiry":  "2026-11-09T09:31:23Z",
+				"DiscoKey":   "discokey:055e128b7b9c29b6b7f2f5e8554d6a59e03859db72d0fcf30fd18dd2b8c93915",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints": [
+					"77.164.248.136:42339",
+					"10.65.0.27:42339",
+					"172.17.0.1:42339",
+					"172.18.0.1:42339",
+					"172.19.0.1:42339",
+					"172.20.0.1:42339",
+					"172.21.0.1:42339",
+					"172.22.0.1:42339",
+					"172.23.0.1:42339",
+					"172.24.0.1:42339",
+					"172.25.0.1:42339",
+					"172.26.0.1:42339",
+					"172.27.0.1:42339"
+				],
+				"HomeDERP": 14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-13T09:31:23.312350289Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2304635934592830": {
+				"ID":          2304635934592830,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/sshtest_results/sshtest-tag-as-dst.hujson
+++ b/hscontrol/policy/v2/testdata/sshtest_results/sshtest-tag-as-dst.hujson
@@ -1,0 +1,18749 @@
+// sshtest-tag-as-dst
+//
+// tag dst in rule and accept
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T18:49:30Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "sshtest-tag-as-dst",
+	"description":    "tag dst in rule and accept",
+	"category":       "sshtest",
+	"captured_at":    "2026-05-12T18:49:30.79952437Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                     \n  \n                                                         \n{\n\t\"category\":    \"sshtest\",\n\t\"description\": \"tag dst in rule and accept\",\n\t\"id\":          \"sshtest-tag-as-dst\",\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"thor@example.org\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"sshTests\": [{\n\t\t\"accept\": [\"root\"],\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    \"thor@example.org\"\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/sshtest/sshtest-tag-as-dst.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["thor@example.org"],
+				"users":  ["root"]
+			}],
+			"sshTests":  [{"accept": ["root"], "dst": ["tag:server"], "src": "thor@example.org"}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2957510641661268,
+				"StableID":   "nFUHtnnT6Q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       2957510641661268,
+				"Key":        "nodekey:7a531bd87f5a4020e2459ac00cabba5abf26ee9a33564818ab1c012224e17d02",
+				"DiscoKey":   "discokey:67077cb4017129741e4f5a940ff9304bfab77c99e39472119166bd6ff7ed7531",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53301", "10.65.0.27:53301", "172.17.0.1:53301"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:49:39.558897204Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7a531bd87f5a4020e2459ac00cabba5abf26ee9a33564818ab1c012224e17d02",
+			"MachineKey": "mkey:de9581f6f3d74c3b1ce7360b310d2597631729caac4f1957cf9827076c4d7b71",
+			"Peers": [{
+				"ID":         4036485262546260,
+				"StableID":   "nuHhM9d8XY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:446da1fb0929ad6eb9a62dd73fe5948ab1b9e705ac639743dad4b133eb912620",
+				"DiscoKey":   "discokey:4f7b74c7ce8597e34f5d6d975ebf7d7b855dd9d94e3397b7f20f6ef8ae09260f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:33739", "10.65.0.27:33739", "172.17.0.1:33739"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:49:33.468713095Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2706738658132250,
+				"StableID":   "nuzpRDSt8N11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f372f41160436362c4a299ee8e41e9506c0387c24efd651541eeffef73c6c35",
+				"DiscoKey":   "discokey:83f90746253b5f9c6f5c9891a13aea64b05c4d31be8cd253ad52f22d2bd71414",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:60917", "10.65.0.27:60917", "172.17.0.1:60917"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:49:34.149328077Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1092125780826920,
+				"StableID":   "nT2gSxHdX911CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6c39f2eedb619c1b0cfca72a0af98943b411e27411f52287a2ff4a4ca30f116f",
+				"DiscoKey":   "discokey:3381232415d99b31488996be72d25ed42ba86e4ed316cf60486243510bd0bb39",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:34414", "10.65.0.27:34414", "172.17.0.1:34414"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:49:34.687823155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4297525523072750,
+				"StableID":   "nMimH5iMZa11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0055db475743b554b76e77b33a4cc05184228f357ae4950122a707ae4d92ff07",
+				"DiscoKey":   "discokey:2ce059328a9a918999b0b75dccc68b5b1fb416db1dd3f3d71bda5396208fa63f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:60972", "10.65.0.27:60972", "172.17.0.1:60972"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:49:35.242672743Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4630694457717876,
+				"StableID":   "nTLJAVVFAd11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:623173f9b609cdb0a87dc28a1ea577bd73f108678e4a60e79c5b1537baf89a1a",
+				"DiscoKey":   "discokey:11571f055222a7e291c244e9ad7da479025faa5e0044bf58b38b79f4877a5118",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:60343", "10.65.0.27:60343", "172.17.0.1:60343"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:49:35.785634417Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4728549180687201,
+				"StableID":   "nJmbwByZvd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cbf22f012be058dd320ed4dd3267eba26b765c7b0a66d640f391add6b5a7c60e",
+				"DiscoKey":   "discokey:41338c797b5dbe22e272b82b07ffe21f698ec68cb8b212e689fb5e21b76a7b37",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:42284", "10.65.0.27:42284", "172.17.0.1:42284"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:49:36.319517347Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2553292478976651,
+				"StableID":   "n6ec2WfPwL11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc30ec8da75be2c53544f640dd3b36d3a8550a7c556388b7ce1b2ae31bcf4f09",
+				"DiscoKey":   "discokey:2f44d09a8d8c58dd6ece012d557ca7bb959028687c6042448738e868d9dcf867",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:49021", "10.65.0.27:49021", "172.17.0.1:49021"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:49:36.8665194Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8050969568316525,
+				"StableID":   "nNu7WUKJs521CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6fa5c30759b4d3ff3b02427c62682e4aa9bda97510e7fd3a802eeaf4a625319",
+				"DiscoKey":   "discokey:8a77ac47b80f9e87df5c52906964c0be000b057b79069ceadd44172ce37e9259",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:59392", "10.65.0.27:59392", "172.17.0.1:59392"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:49:37.404736658Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2047301492658962,
+				"StableID":   "nKdbF39EzG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c8ab8298a8c53249d893915d6260b0d91de912089d2ead41087a741205883152",
+				"DiscoKey":   "discokey:e8e177a2df69fe1b5dfa29fa5814ff582d9396d9969fd5c3f68058b03407f11e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:52876", "10.65.0.27:52876", "172.17.0.1:52876"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:49:37.945678729Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1272909863032316,
+				"StableID":   "nFrpieBWwA11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0f6926538765127c5ba2d553141ecfd02219dc7af00c8553eb67b6d3aed6563",
+				"DiscoKey":   "discokey:4d3874338ebf469845cf0888427635c146194c3123f1e571cf77ed4de12fef45",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:44464", "10.65.0.27:44464", "172.17.0.1:44464"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:49:38.50203138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2711502179480840,
+				"StableID":   "nsLsVjZ3BN11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7d9aba483ddbb1f668916472455e84df7cc8f4ce4b6b9d6e38ce34ece126b957",
+				"DiscoKey":   "discokey:d1350bcbcfc40d3dcab4ee2e4a42afa795a47570d48796be69b04e76deb64013",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:41283", "10.65.0.27:41283", "172.17.0.1:41283"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:49:39.045851741Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8916411384039549,
+				"StableID":   "naH6CS1GdC21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f825aadbceb6fd7eb4df73e0db44ab533aaef2289a7369b7a9106984daf3ba69",
+				"KeyExpiry":  "2026-11-08T18:49:40Z",
+				"DiscoKey":   "discokey:2f4b97dc0c4c336cc1b859ff79e2c372453e7b6f513d998fe7c72d50aefa9557",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:43652", "10.65.0.27:43652", "172.17.0.1:43652"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:49:40.109443444Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7970113772317226,
+				"StableID":   "nbwrggNgE521CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a2e3ec6c6a12b0f31c410c35f38035da919a7a2941aa9798dce42e55804e5a0a",
+				"KeyExpiry":  "2026-11-08T18:49:40Z",
+				"DiscoKey":   "discokey:657222a191639086d196b38b41d06e4c1c6de2c7679f467473b662724b7ff46e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:41230", "10.65.0.27:41230", "172.17.0.1:41230"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:49:40.642595104Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5356533428254481,
+				"StableID":   "nGt8Uu3zpi11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c9071132b543fe089db243b686de85d3232c567222f8a621958b9428f7667441",
+				"KeyExpiry":  "2026-11-08T18:49:41Z",
+				"DiscoKey":   "discokey:26dfb9035dce059a334c0851e4709a1cf9577ba5cf2216a30802074902c47104",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:40254", "10.65.0.27:40254", "172.17.0.1:40254"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:49:41.195401855Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{
+				"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+				"sshUsers":   {"root": "root"},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				}
+			}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2957510641661268": {
+				"ID":          2957510641661268,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		},
+		"ssh_rules": [{
+			"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+			"sshUsers":   {"root": "root"},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}
+		}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4728549180687201,
+				"StableID":   "nJmbwByZvd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       4728549180687201,
+				"Key":        "nodekey:cbf22f012be058dd320ed4dd3267eba26b765c7b0a66d640f391add6b5a7c60e",
+				"DiscoKey":   "discokey:41338c797b5dbe22e272b82b07ffe21f698ec68cb8b212e689fb5e21b76a7b37",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:42284", "10.65.0.27:42284", "172.17.0.1:42284"],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:49:36.319517347Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:cbf22f012be058dd320ed4dd3267eba26b765c7b0a66d640f391add6b5a7c60e",
+			"MachineKey": "mkey:3e5baef2ed7de18ed5aba093017c09bbca95640f6378849bdc08b0b75d02df6d",
+			"Peers": [{
+				"ID":         4036485262546260,
+				"StableID":   "nuHhM9d8XY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:446da1fb0929ad6eb9a62dd73fe5948ab1b9e705ac639743dad4b133eb912620",
+				"DiscoKey":   "discokey:4f7b74c7ce8597e34f5d6d975ebf7d7b855dd9d94e3397b7f20f6ef8ae09260f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:33739", "10.65.0.27:33739", "172.17.0.1:33739"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:49:33.468713095Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2706738658132250,
+				"StableID":   "nuzpRDSt8N11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f372f41160436362c4a299ee8e41e9506c0387c24efd651541eeffef73c6c35",
+				"DiscoKey":   "discokey:83f90746253b5f9c6f5c9891a13aea64b05c4d31be8cd253ad52f22d2bd71414",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:60917", "10.65.0.27:60917", "172.17.0.1:60917"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:49:34.149328077Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1092125780826920,
+				"StableID":   "nT2gSxHdX911CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6c39f2eedb619c1b0cfca72a0af98943b411e27411f52287a2ff4a4ca30f116f",
+				"DiscoKey":   "discokey:3381232415d99b31488996be72d25ed42ba86e4ed316cf60486243510bd0bb39",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:34414", "10.65.0.27:34414", "172.17.0.1:34414"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:49:34.687823155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4297525523072750,
+				"StableID":   "nMimH5iMZa11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0055db475743b554b76e77b33a4cc05184228f357ae4950122a707ae4d92ff07",
+				"DiscoKey":   "discokey:2ce059328a9a918999b0b75dccc68b5b1fb416db1dd3f3d71bda5396208fa63f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:60972", "10.65.0.27:60972", "172.17.0.1:60972"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:49:35.242672743Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4630694457717876,
+				"StableID":   "nTLJAVVFAd11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:623173f9b609cdb0a87dc28a1ea577bd73f108678e4a60e79c5b1537baf89a1a",
+				"DiscoKey":   "discokey:11571f055222a7e291c244e9ad7da479025faa5e0044bf58b38b79f4877a5118",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:60343", "10.65.0.27:60343", "172.17.0.1:60343"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:49:35.785634417Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2553292478976651,
+				"StableID":   "n6ec2WfPwL11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc30ec8da75be2c53544f640dd3b36d3a8550a7c556388b7ce1b2ae31bcf4f09",
+				"DiscoKey":   "discokey:2f44d09a8d8c58dd6ece012d557ca7bb959028687c6042448738e868d9dcf867",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:49021", "10.65.0.27:49021", "172.17.0.1:49021"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:49:36.8665194Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8050969568316525,
+				"StableID":   "nNu7WUKJs521CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6fa5c30759b4d3ff3b02427c62682e4aa9bda97510e7fd3a802eeaf4a625319",
+				"DiscoKey":   "discokey:8a77ac47b80f9e87df5c52906964c0be000b057b79069ceadd44172ce37e9259",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:59392", "10.65.0.27:59392", "172.17.0.1:59392"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:49:37.404736658Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2047301492658962,
+				"StableID":   "nKdbF39EzG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c8ab8298a8c53249d893915d6260b0d91de912089d2ead41087a741205883152",
+				"DiscoKey":   "discokey:e8e177a2df69fe1b5dfa29fa5814ff582d9396d9969fd5c3f68058b03407f11e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:52876", "10.65.0.27:52876", "172.17.0.1:52876"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:49:37.945678729Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1272909863032316,
+				"StableID":   "nFrpieBWwA11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0f6926538765127c5ba2d553141ecfd02219dc7af00c8553eb67b6d3aed6563",
+				"DiscoKey":   "discokey:4d3874338ebf469845cf0888427635c146194c3123f1e571cf77ed4de12fef45",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:44464", "10.65.0.27:44464", "172.17.0.1:44464"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:49:38.50203138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2711502179480840,
+				"StableID":   "nsLsVjZ3BN11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7d9aba483ddbb1f668916472455e84df7cc8f4ce4b6b9d6e38ce34ece126b957",
+				"DiscoKey":   "discokey:d1350bcbcfc40d3dcab4ee2e4a42afa795a47570d48796be69b04e76deb64013",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:41283", "10.65.0.27:41283", "172.17.0.1:41283"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:49:39.045851741Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2957510641661268,
+				"StableID":   "nFUHtnnT6Q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7a531bd87f5a4020e2459ac00cabba5abf26ee9a33564818ab1c012224e17d02",
+				"DiscoKey":   "discokey:67077cb4017129741e4f5a940ff9304bfab77c99e39472119166bd6ff7ed7531",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53301", "10.65.0.27:53301", "172.17.0.1:53301"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:49:39.558897204Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8916411384039549,
+				"StableID":   "naH6CS1GdC21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f825aadbceb6fd7eb4df73e0db44ab533aaef2289a7369b7a9106984daf3ba69",
+				"KeyExpiry":  "2026-11-08T18:49:40Z",
+				"DiscoKey":   "discokey:2f4b97dc0c4c336cc1b859ff79e2c372453e7b6f513d998fe7c72d50aefa9557",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:43652", "10.65.0.27:43652", "172.17.0.1:43652"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:49:40.109443444Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7970113772317226,
+				"StableID":   "nbwrggNgE521CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a2e3ec6c6a12b0f31c410c35f38035da919a7a2941aa9798dce42e55804e5a0a",
+				"KeyExpiry":  "2026-11-08T18:49:40Z",
+				"DiscoKey":   "discokey:657222a191639086d196b38b41d06e4c1c6de2c7679f467473b662724b7ff46e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:41230", "10.65.0.27:41230", "172.17.0.1:41230"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:49:40.642595104Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5356533428254481,
+				"StableID":   "nGt8Uu3zpi11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c9071132b543fe089db243b686de85d3232c567222f8a621958b9428f7667441",
+				"KeyExpiry":  "2026-11-08T18:49:41Z",
+				"DiscoKey":   "discokey:26dfb9035dce059a334c0851e4709a1cf9577ba5cf2216a30802074902c47104",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:40254", "10.65.0.27:40254", "172.17.0.1:40254"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:49:41.195401855Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4728549180687201": {
+				"ID":          4728549180687201,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5356533428254481,
+				"StableID":   "nGt8Uu3zpi11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c9071132b543fe089db243b686de85d3232c567222f8a621958b9428f7667441",
+				"KeyExpiry":  "2026-11-08T18:49:41Z",
+				"DiscoKey":   "discokey:26dfb9035dce059a334c0851e4709a1cf9577ba5cf2216a30802074902c47104",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:40254", "10.65.0.27:40254", "172.17.0.1:40254"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:49:41.195401855Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c9071132b543fe089db243b686de85d3232c567222f8a621958b9428f7667441",
+			"MachineKey": "mkey:0dd97cab4ff39c0697599dd2e05b42f5d597c7f39434ad27fe7e157e54be2670",
+			"Peers": [{
+				"ID":         4036485262546260,
+				"StableID":   "nuHhM9d8XY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:446da1fb0929ad6eb9a62dd73fe5948ab1b9e705ac639743dad4b133eb912620",
+				"DiscoKey":   "discokey:4f7b74c7ce8597e34f5d6d975ebf7d7b855dd9d94e3397b7f20f6ef8ae09260f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:33739", "10.65.0.27:33739", "172.17.0.1:33739"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:49:33.468713095Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2706738658132250,
+				"StableID":   "nuzpRDSt8N11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f372f41160436362c4a299ee8e41e9506c0387c24efd651541eeffef73c6c35",
+				"DiscoKey":   "discokey:83f90746253b5f9c6f5c9891a13aea64b05c4d31be8cd253ad52f22d2bd71414",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:60917", "10.65.0.27:60917", "172.17.0.1:60917"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:49:34.149328077Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1092125780826920,
+				"StableID":   "nT2gSxHdX911CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6c39f2eedb619c1b0cfca72a0af98943b411e27411f52287a2ff4a4ca30f116f",
+				"DiscoKey":   "discokey:3381232415d99b31488996be72d25ed42ba86e4ed316cf60486243510bd0bb39",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:34414", "10.65.0.27:34414", "172.17.0.1:34414"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:49:34.687823155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4297525523072750,
+				"StableID":   "nMimH5iMZa11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0055db475743b554b76e77b33a4cc05184228f357ae4950122a707ae4d92ff07",
+				"DiscoKey":   "discokey:2ce059328a9a918999b0b75dccc68b5b1fb416db1dd3f3d71bda5396208fa63f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:60972", "10.65.0.27:60972", "172.17.0.1:60972"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:49:35.242672743Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4630694457717876,
+				"StableID":   "nTLJAVVFAd11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:623173f9b609cdb0a87dc28a1ea577bd73f108678e4a60e79c5b1537baf89a1a",
+				"DiscoKey":   "discokey:11571f055222a7e291c244e9ad7da479025faa5e0044bf58b38b79f4877a5118",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:60343", "10.65.0.27:60343", "172.17.0.1:60343"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:49:35.785634417Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4728549180687201,
+				"StableID":   "nJmbwByZvd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cbf22f012be058dd320ed4dd3267eba26b765c7b0a66d640f391add6b5a7c60e",
+				"DiscoKey":   "discokey:41338c797b5dbe22e272b82b07ffe21f698ec68cb8b212e689fb5e21b76a7b37",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:42284", "10.65.0.27:42284", "172.17.0.1:42284"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:49:36.319517347Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2553292478976651,
+				"StableID":   "n6ec2WfPwL11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc30ec8da75be2c53544f640dd3b36d3a8550a7c556388b7ce1b2ae31bcf4f09",
+				"DiscoKey":   "discokey:2f44d09a8d8c58dd6ece012d557ca7bb959028687c6042448738e868d9dcf867",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:49021", "10.65.0.27:49021", "172.17.0.1:49021"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:49:36.8665194Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8050969568316525,
+				"StableID":   "nNu7WUKJs521CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6fa5c30759b4d3ff3b02427c62682e4aa9bda97510e7fd3a802eeaf4a625319",
+				"DiscoKey":   "discokey:8a77ac47b80f9e87df5c52906964c0be000b057b79069ceadd44172ce37e9259",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:59392", "10.65.0.27:59392", "172.17.0.1:59392"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:49:37.404736658Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2047301492658962,
+				"StableID":   "nKdbF39EzG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c8ab8298a8c53249d893915d6260b0d91de912089d2ead41087a741205883152",
+				"DiscoKey":   "discokey:e8e177a2df69fe1b5dfa29fa5814ff582d9396d9969fd5c3f68058b03407f11e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:52876", "10.65.0.27:52876", "172.17.0.1:52876"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:49:37.945678729Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1272909863032316,
+				"StableID":   "nFrpieBWwA11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0f6926538765127c5ba2d553141ecfd02219dc7af00c8553eb67b6d3aed6563",
+				"DiscoKey":   "discokey:4d3874338ebf469845cf0888427635c146194c3123f1e571cf77ed4de12fef45",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:44464", "10.65.0.27:44464", "172.17.0.1:44464"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:49:38.50203138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2711502179480840,
+				"StableID":   "nsLsVjZ3BN11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7d9aba483ddbb1f668916472455e84df7cc8f4ce4b6b9d6e38ce34ece126b957",
+				"DiscoKey":   "discokey:d1350bcbcfc40d3dcab4ee2e4a42afa795a47570d48796be69b04e76deb64013",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:41283", "10.65.0.27:41283", "172.17.0.1:41283"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:49:39.045851741Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2957510641661268,
+				"StableID":   "nFUHtnnT6Q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7a531bd87f5a4020e2459ac00cabba5abf26ee9a33564818ab1c012224e17d02",
+				"DiscoKey":   "discokey:67077cb4017129741e4f5a940ff9304bfab77c99e39472119166bd6ff7ed7531",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53301", "10.65.0.27:53301", "172.17.0.1:53301"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:49:39.558897204Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8916411384039549,
+				"StableID":   "naH6CS1GdC21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f825aadbceb6fd7eb4df73e0db44ab533aaef2289a7369b7a9106984daf3ba69",
+				"KeyExpiry":  "2026-11-08T18:49:40Z",
+				"DiscoKey":   "discokey:2f4b97dc0c4c336cc1b859ff79e2c372453e7b6f513d998fe7c72d50aefa9557",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:43652", "10.65.0.27:43652", "172.17.0.1:43652"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:49:40.109443444Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7970113772317226,
+				"StableID":   "nbwrggNgE521CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a2e3ec6c6a12b0f31c410c35f38035da919a7a2941aa9798dce42e55804e5a0a",
+				"KeyExpiry":  "2026-11-08T18:49:40Z",
+				"DiscoKey":   "discokey:657222a191639086d196b38b41d06e4c1c6de2c7679f467473b662724b7ff46e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:41230", "10.65.0.27:41230", "172.17.0.1:41230"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:49:40.642595104Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1092125780826920,
+				"StableID":   "nT2gSxHdX911CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1092125780826920,
+				"Key":        "nodekey:6c39f2eedb619c1b0cfca72a0af98943b411e27411f52287a2ff4a4ca30f116f",
+				"DiscoKey":   "discokey:3381232415d99b31488996be72d25ed42ba86e4ed316cf60486243510bd0bb39",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:34414", "10.65.0.27:34414", "172.17.0.1:34414"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:49:34.687823155Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6c39f2eedb619c1b0cfca72a0af98943b411e27411f52287a2ff4a4ca30f116f",
+			"MachineKey": "mkey:2d311ae4e93c751e8185a487f971460d91a9ed39dacea21adf62d22841183817",
+			"Peers": [{
+				"ID":         4036485262546260,
+				"StableID":   "nuHhM9d8XY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:446da1fb0929ad6eb9a62dd73fe5948ab1b9e705ac639743dad4b133eb912620",
+				"DiscoKey":   "discokey:4f7b74c7ce8597e34f5d6d975ebf7d7b855dd9d94e3397b7f20f6ef8ae09260f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:33739", "10.65.0.27:33739", "172.17.0.1:33739"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:49:33.468713095Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2706738658132250,
+				"StableID":   "nuzpRDSt8N11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f372f41160436362c4a299ee8e41e9506c0387c24efd651541eeffef73c6c35",
+				"DiscoKey":   "discokey:83f90746253b5f9c6f5c9891a13aea64b05c4d31be8cd253ad52f22d2bd71414",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:60917", "10.65.0.27:60917", "172.17.0.1:60917"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:49:34.149328077Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4297525523072750,
+				"StableID":   "nMimH5iMZa11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0055db475743b554b76e77b33a4cc05184228f357ae4950122a707ae4d92ff07",
+				"DiscoKey":   "discokey:2ce059328a9a918999b0b75dccc68b5b1fb416db1dd3f3d71bda5396208fa63f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:60972", "10.65.0.27:60972", "172.17.0.1:60972"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:49:35.242672743Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4630694457717876,
+				"StableID":   "nTLJAVVFAd11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:623173f9b609cdb0a87dc28a1ea577bd73f108678e4a60e79c5b1537baf89a1a",
+				"DiscoKey":   "discokey:11571f055222a7e291c244e9ad7da479025faa5e0044bf58b38b79f4877a5118",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:60343", "10.65.0.27:60343", "172.17.0.1:60343"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:49:35.785634417Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4728549180687201,
+				"StableID":   "nJmbwByZvd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cbf22f012be058dd320ed4dd3267eba26b765c7b0a66d640f391add6b5a7c60e",
+				"DiscoKey":   "discokey:41338c797b5dbe22e272b82b07ffe21f698ec68cb8b212e689fb5e21b76a7b37",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:42284", "10.65.0.27:42284", "172.17.0.1:42284"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:49:36.319517347Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2553292478976651,
+				"StableID":   "n6ec2WfPwL11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc30ec8da75be2c53544f640dd3b36d3a8550a7c556388b7ce1b2ae31bcf4f09",
+				"DiscoKey":   "discokey:2f44d09a8d8c58dd6ece012d557ca7bb959028687c6042448738e868d9dcf867",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:49021", "10.65.0.27:49021", "172.17.0.1:49021"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:49:36.8665194Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8050969568316525,
+				"StableID":   "nNu7WUKJs521CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6fa5c30759b4d3ff3b02427c62682e4aa9bda97510e7fd3a802eeaf4a625319",
+				"DiscoKey":   "discokey:8a77ac47b80f9e87df5c52906964c0be000b057b79069ceadd44172ce37e9259",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:59392", "10.65.0.27:59392", "172.17.0.1:59392"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:49:37.404736658Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2047301492658962,
+				"StableID":   "nKdbF39EzG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c8ab8298a8c53249d893915d6260b0d91de912089d2ead41087a741205883152",
+				"DiscoKey":   "discokey:e8e177a2df69fe1b5dfa29fa5814ff582d9396d9969fd5c3f68058b03407f11e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:52876", "10.65.0.27:52876", "172.17.0.1:52876"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:49:37.945678729Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1272909863032316,
+				"StableID":   "nFrpieBWwA11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0f6926538765127c5ba2d553141ecfd02219dc7af00c8553eb67b6d3aed6563",
+				"DiscoKey":   "discokey:4d3874338ebf469845cf0888427635c146194c3123f1e571cf77ed4de12fef45",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:44464", "10.65.0.27:44464", "172.17.0.1:44464"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:49:38.50203138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2711502179480840,
+				"StableID":   "nsLsVjZ3BN11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7d9aba483ddbb1f668916472455e84df7cc8f4ce4b6b9d6e38ce34ece126b957",
+				"DiscoKey":   "discokey:d1350bcbcfc40d3dcab4ee2e4a42afa795a47570d48796be69b04e76deb64013",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:41283", "10.65.0.27:41283", "172.17.0.1:41283"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:49:39.045851741Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2957510641661268,
+				"StableID":   "nFUHtnnT6Q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7a531bd87f5a4020e2459ac00cabba5abf26ee9a33564818ab1c012224e17d02",
+				"DiscoKey":   "discokey:67077cb4017129741e4f5a940ff9304bfab77c99e39472119166bd6ff7ed7531",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53301", "10.65.0.27:53301", "172.17.0.1:53301"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:49:39.558897204Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8916411384039549,
+				"StableID":   "naH6CS1GdC21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f825aadbceb6fd7eb4df73e0db44ab533aaef2289a7369b7a9106984daf3ba69",
+				"KeyExpiry":  "2026-11-08T18:49:40Z",
+				"DiscoKey":   "discokey:2f4b97dc0c4c336cc1b859ff79e2c372453e7b6f513d998fe7c72d50aefa9557",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:43652", "10.65.0.27:43652", "172.17.0.1:43652"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:49:40.109443444Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7970113772317226,
+				"StableID":   "nbwrggNgE521CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a2e3ec6c6a12b0f31c410c35f38035da919a7a2941aa9798dce42e55804e5a0a",
+				"KeyExpiry":  "2026-11-08T18:49:40Z",
+				"DiscoKey":   "discokey:657222a191639086d196b38b41d06e4c1c6de2c7679f467473b662724b7ff46e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:41230", "10.65.0.27:41230", "172.17.0.1:41230"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:49:40.642595104Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5356533428254481,
+				"StableID":   "nGt8Uu3zpi11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c9071132b543fe089db243b686de85d3232c567222f8a621958b9428f7667441",
+				"KeyExpiry":  "2026-11-08T18:49:41Z",
+				"DiscoKey":   "discokey:26dfb9035dce059a334c0851e4709a1cf9577ba5cf2216a30802074902c47104",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:40254", "10.65.0.27:40254", "172.17.0.1:40254"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:49:41.195401855Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1092125780826920": {
+				"ID":          1092125780826920,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8050969568316525,
+				"StableID":   "nNu7WUKJs521CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       8050969568316525,
+				"Key":        "nodekey:a6fa5c30759b4d3ff3b02427c62682e4aa9bda97510e7fd3a802eeaf4a625319",
+				"DiscoKey":   "discokey:8a77ac47b80f9e87df5c52906964c0be000b057b79069ceadd44172ce37e9259",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:59392", "10.65.0.27:59392", "172.17.0.1:59392"],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:49:37.404736658Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a6fa5c30759b4d3ff3b02427c62682e4aa9bda97510e7fd3a802eeaf4a625319",
+			"MachineKey": "mkey:29116e34a92634caa2cc87e4169f58f6f16a92c7e051a8446366a8ad9f9e0500",
+			"Peers": [{
+				"ID":         4036485262546260,
+				"StableID":   "nuHhM9d8XY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:446da1fb0929ad6eb9a62dd73fe5948ab1b9e705ac639743dad4b133eb912620",
+				"DiscoKey":   "discokey:4f7b74c7ce8597e34f5d6d975ebf7d7b855dd9d94e3397b7f20f6ef8ae09260f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:33739", "10.65.0.27:33739", "172.17.0.1:33739"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:49:33.468713095Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2706738658132250,
+				"StableID":   "nuzpRDSt8N11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f372f41160436362c4a299ee8e41e9506c0387c24efd651541eeffef73c6c35",
+				"DiscoKey":   "discokey:83f90746253b5f9c6f5c9891a13aea64b05c4d31be8cd253ad52f22d2bd71414",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:60917", "10.65.0.27:60917", "172.17.0.1:60917"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:49:34.149328077Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1092125780826920,
+				"StableID":   "nT2gSxHdX911CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6c39f2eedb619c1b0cfca72a0af98943b411e27411f52287a2ff4a4ca30f116f",
+				"DiscoKey":   "discokey:3381232415d99b31488996be72d25ed42ba86e4ed316cf60486243510bd0bb39",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:34414", "10.65.0.27:34414", "172.17.0.1:34414"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:49:34.687823155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4297525523072750,
+				"StableID":   "nMimH5iMZa11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0055db475743b554b76e77b33a4cc05184228f357ae4950122a707ae4d92ff07",
+				"DiscoKey":   "discokey:2ce059328a9a918999b0b75dccc68b5b1fb416db1dd3f3d71bda5396208fa63f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:60972", "10.65.0.27:60972", "172.17.0.1:60972"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:49:35.242672743Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4630694457717876,
+				"StableID":   "nTLJAVVFAd11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:623173f9b609cdb0a87dc28a1ea577bd73f108678e4a60e79c5b1537baf89a1a",
+				"DiscoKey":   "discokey:11571f055222a7e291c244e9ad7da479025faa5e0044bf58b38b79f4877a5118",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:60343", "10.65.0.27:60343", "172.17.0.1:60343"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:49:35.785634417Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4728549180687201,
+				"StableID":   "nJmbwByZvd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cbf22f012be058dd320ed4dd3267eba26b765c7b0a66d640f391add6b5a7c60e",
+				"DiscoKey":   "discokey:41338c797b5dbe22e272b82b07ffe21f698ec68cb8b212e689fb5e21b76a7b37",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:42284", "10.65.0.27:42284", "172.17.0.1:42284"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:49:36.319517347Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2553292478976651,
+				"StableID":   "n6ec2WfPwL11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc30ec8da75be2c53544f640dd3b36d3a8550a7c556388b7ce1b2ae31bcf4f09",
+				"DiscoKey":   "discokey:2f44d09a8d8c58dd6ece012d557ca7bb959028687c6042448738e868d9dcf867",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:49021", "10.65.0.27:49021", "172.17.0.1:49021"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:49:36.8665194Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2047301492658962,
+				"StableID":   "nKdbF39EzG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c8ab8298a8c53249d893915d6260b0d91de912089d2ead41087a741205883152",
+				"DiscoKey":   "discokey:e8e177a2df69fe1b5dfa29fa5814ff582d9396d9969fd5c3f68058b03407f11e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:52876", "10.65.0.27:52876", "172.17.0.1:52876"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:49:37.945678729Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1272909863032316,
+				"StableID":   "nFrpieBWwA11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0f6926538765127c5ba2d553141ecfd02219dc7af00c8553eb67b6d3aed6563",
+				"DiscoKey":   "discokey:4d3874338ebf469845cf0888427635c146194c3123f1e571cf77ed4de12fef45",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:44464", "10.65.0.27:44464", "172.17.0.1:44464"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:49:38.50203138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2711502179480840,
+				"StableID":   "nsLsVjZ3BN11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7d9aba483ddbb1f668916472455e84df7cc8f4ce4b6b9d6e38ce34ece126b957",
+				"DiscoKey":   "discokey:d1350bcbcfc40d3dcab4ee2e4a42afa795a47570d48796be69b04e76deb64013",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:41283", "10.65.0.27:41283", "172.17.0.1:41283"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:49:39.045851741Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2957510641661268,
+				"StableID":   "nFUHtnnT6Q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7a531bd87f5a4020e2459ac00cabba5abf26ee9a33564818ab1c012224e17d02",
+				"DiscoKey":   "discokey:67077cb4017129741e4f5a940ff9304bfab77c99e39472119166bd6ff7ed7531",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53301", "10.65.0.27:53301", "172.17.0.1:53301"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:49:39.558897204Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8916411384039549,
+				"StableID":   "naH6CS1GdC21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f825aadbceb6fd7eb4df73e0db44ab533aaef2289a7369b7a9106984daf3ba69",
+				"KeyExpiry":  "2026-11-08T18:49:40Z",
+				"DiscoKey":   "discokey:2f4b97dc0c4c336cc1b859ff79e2c372453e7b6f513d998fe7c72d50aefa9557",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:43652", "10.65.0.27:43652", "172.17.0.1:43652"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:49:40.109443444Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7970113772317226,
+				"StableID":   "nbwrggNgE521CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a2e3ec6c6a12b0f31c410c35f38035da919a7a2941aa9798dce42e55804e5a0a",
+				"KeyExpiry":  "2026-11-08T18:49:40Z",
+				"DiscoKey":   "discokey:657222a191639086d196b38b41d06e4c1c6de2c7679f467473b662724b7ff46e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:41230", "10.65.0.27:41230", "172.17.0.1:41230"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:49:40.642595104Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5356533428254481,
+				"StableID":   "nGt8Uu3zpi11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c9071132b543fe089db243b686de85d3232c567222f8a621958b9428f7667441",
+				"KeyExpiry":  "2026-11-08T18:49:41Z",
+				"DiscoKey":   "discokey:26dfb9035dce059a334c0851e4709a1cf9577ba5cf2216a30802074902c47104",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:40254", "10.65.0.27:40254", "172.17.0.1:40254"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:49:41.195401855Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8050969568316525": {
+				"ID":          8050969568316525,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8916411384039549,
+				"StableID":   "naH6CS1GdC21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f825aadbceb6fd7eb4df73e0db44ab533aaef2289a7369b7a9106984daf3ba69",
+				"KeyExpiry":  "2026-11-08T18:49:40Z",
+				"DiscoKey":   "discokey:2f4b97dc0c4c336cc1b859ff79e2c372453e7b6f513d998fe7c72d50aefa9557",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:43652", "10.65.0.27:43652", "172.17.0.1:43652"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:49:40.109443444Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f825aadbceb6fd7eb4df73e0db44ab533aaef2289a7369b7a9106984daf3ba69",
+			"MachineKey": "mkey:c14c50bff2f0346c1cf256d85d2bddf0dbf80450f7ff23707487e18138d95034",
+			"Peers": [{
+				"ID":         4036485262546260,
+				"StableID":   "nuHhM9d8XY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:446da1fb0929ad6eb9a62dd73fe5948ab1b9e705ac639743dad4b133eb912620",
+				"DiscoKey":   "discokey:4f7b74c7ce8597e34f5d6d975ebf7d7b855dd9d94e3397b7f20f6ef8ae09260f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:33739", "10.65.0.27:33739", "172.17.0.1:33739"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:49:33.468713095Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2706738658132250,
+				"StableID":   "nuzpRDSt8N11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f372f41160436362c4a299ee8e41e9506c0387c24efd651541eeffef73c6c35",
+				"DiscoKey":   "discokey:83f90746253b5f9c6f5c9891a13aea64b05c4d31be8cd253ad52f22d2bd71414",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:60917", "10.65.0.27:60917", "172.17.0.1:60917"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:49:34.149328077Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1092125780826920,
+				"StableID":   "nT2gSxHdX911CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6c39f2eedb619c1b0cfca72a0af98943b411e27411f52287a2ff4a4ca30f116f",
+				"DiscoKey":   "discokey:3381232415d99b31488996be72d25ed42ba86e4ed316cf60486243510bd0bb39",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:34414", "10.65.0.27:34414", "172.17.0.1:34414"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:49:34.687823155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4297525523072750,
+				"StableID":   "nMimH5iMZa11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0055db475743b554b76e77b33a4cc05184228f357ae4950122a707ae4d92ff07",
+				"DiscoKey":   "discokey:2ce059328a9a918999b0b75dccc68b5b1fb416db1dd3f3d71bda5396208fa63f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:60972", "10.65.0.27:60972", "172.17.0.1:60972"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:49:35.242672743Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4630694457717876,
+				"StableID":   "nTLJAVVFAd11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:623173f9b609cdb0a87dc28a1ea577bd73f108678e4a60e79c5b1537baf89a1a",
+				"DiscoKey":   "discokey:11571f055222a7e291c244e9ad7da479025faa5e0044bf58b38b79f4877a5118",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:60343", "10.65.0.27:60343", "172.17.0.1:60343"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:49:35.785634417Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4728549180687201,
+				"StableID":   "nJmbwByZvd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cbf22f012be058dd320ed4dd3267eba26b765c7b0a66d640f391add6b5a7c60e",
+				"DiscoKey":   "discokey:41338c797b5dbe22e272b82b07ffe21f698ec68cb8b212e689fb5e21b76a7b37",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:42284", "10.65.0.27:42284", "172.17.0.1:42284"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:49:36.319517347Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2553292478976651,
+				"StableID":   "n6ec2WfPwL11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc30ec8da75be2c53544f640dd3b36d3a8550a7c556388b7ce1b2ae31bcf4f09",
+				"DiscoKey":   "discokey:2f44d09a8d8c58dd6ece012d557ca7bb959028687c6042448738e868d9dcf867",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:49021", "10.65.0.27:49021", "172.17.0.1:49021"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:49:36.8665194Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8050969568316525,
+				"StableID":   "nNu7WUKJs521CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6fa5c30759b4d3ff3b02427c62682e4aa9bda97510e7fd3a802eeaf4a625319",
+				"DiscoKey":   "discokey:8a77ac47b80f9e87df5c52906964c0be000b057b79069ceadd44172ce37e9259",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:59392", "10.65.0.27:59392", "172.17.0.1:59392"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:49:37.404736658Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2047301492658962,
+				"StableID":   "nKdbF39EzG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c8ab8298a8c53249d893915d6260b0d91de912089d2ead41087a741205883152",
+				"DiscoKey":   "discokey:e8e177a2df69fe1b5dfa29fa5814ff582d9396d9969fd5c3f68058b03407f11e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:52876", "10.65.0.27:52876", "172.17.0.1:52876"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:49:37.945678729Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1272909863032316,
+				"StableID":   "nFrpieBWwA11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0f6926538765127c5ba2d553141ecfd02219dc7af00c8553eb67b6d3aed6563",
+				"DiscoKey":   "discokey:4d3874338ebf469845cf0888427635c146194c3123f1e571cf77ed4de12fef45",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:44464", "10.65.0.27:44464", "172.17.0.1:44464"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:49:38.50203138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2711502179480840,
+				"StableID":   "nsLsVjZ3BN11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7d9aba483ddbb1f668916472455e84df7cc8f4ce4b6b9d6e38ce34ece126b957",
+				"DiscoKey":   "discokey:d1350bcbcfc40d3dcab4ee2e4a42afa795a47570d48796be69b04e76deb64013",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:41283", "10.65.0.27:41283", "172.17.0.1:41283"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:49:39.045851741Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2957510641661268,
+				"StableID":   "nFUHtnnT6Q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7a531bd87f5a4020e2459ac00cabba5abf26ee9a33564818ab1c012224e17d02",
+				"DiscoKey":   "discokey:67077cb4017129741e4f5a940ff9304bfab77c99e39472119166bd6ff7ed7531",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53301", "10.65.0.27:53301", "172.17.0.1:53301"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:49:39.558897204Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7970113772317226,
+				"StableID":   "nbwrggNgE521CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a2e3ec6c6a12b0f31c410c35f38035da919a7a2941aa9798dce42e55804e5a0a",
+				"KeyExpiry":  "2026-11-08T18:49:40Z",
+				"DiscoKey":   "discokey:657222a191639086d196b38b41d06e4c1c6de2c7679f467473b662724b7ff46e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:41230", "10.65.0.27:41230", "172.17.0.1:41230"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:49:40.642595104Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5356533428254481,
+				"StableID":   "nGt8Uu3zpi11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c9071132b543fe089db243b686de85d3232c567222f8a621958b9428f7667441",
+				"KeyExpiry":  "2026-11-08T18:49:41Z",
+				"DiscoKey":   "discokey:26dfb9035dce059a334c0851e4709a1cf9577ba5cf2216a30802074902c47104",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:40254", "10.65.0.27:40254", "172.17.0.1:40254"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:49:41.195401855Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2711502179480840,
+				"StableID":   "nsLsVjZ3BN11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       2711502179480840,
+				"Key":        "nodekey:7d9aba483ddbb1f668916472455e84df7cc8f4ce4b6b9d6e38ce34ece126b957",
+				"DiscoKey":   "discokey:d1350bcbcfc40d3dcab4ee2e4a42afa795a47570d48796be69b04e76deb64013",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:41283", "10.65.0.27:41283", "172.17.0.1:41283"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:49:39.045851741Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7d9aba483ddbb1f668916472455e84df7cc8f4ce4b6b9d6e38ce34ece126b957",
+			"MachineKey": "mkey:45bd39c9a76b22b82f457bfae3d49210ce19d45093326dc1917957ffa568720f",
+			"Peers": [{
+				"ID":         4036485262546260,
+				"StableID":   "nuHhM9d8XY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:446da1fb0929ad6eb9a62dd73fe5948ab1b9e705ac639743dad4b133eb912620",
+				"DiscoKey":   "discokey:4f7b74c7ce8597e34f5d6d975ebf7d7b855dd9d94e3397b7f20f6ef8ae09260f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:33739", "10.65.0.27:33739", "172.17.0.1:33739"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:49:33.468713095Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2706738658132250,
+				"StableID":   "nuzpRDSt8N11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f372f41160436362c4a299ee8e41e9506c0387c24efd651541eeffef73c6c35",
+				"DiscoKey":   "discokey:83f90746253b5f9c6f5c9891a13aea64b05c4d31be8cd253ad52f22d2bd71414",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:60917", "10.65.0.27:60917", "172.17.0.1:60917"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:49:34.149328077Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1092125780826920,
+				"StableID":   "nT2gSxHdX911CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6c39f2eedb619c1b0cfca72a0af98943b411e27411f52287a2ff4a4ca30f116f",
+				"DiscoKey":   "discokey:3381232415d99b31488996be72d25ed42ba86e4ed316cf60486243510bd0bb39",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:34414", "10.65.0.27:34414", "172.17.0.1:34414"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:49:34.687823155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4297525523072750,
+				"StableID":   "nMimH5iMZa11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0055db475743b554b76e77b33a4cc05184228f357ae4950122a707ae4d92ff07",
+				"DiscoKey":   "discokey:2ce059328a9a918999b0b75dccc68b5b1fb416db1dd3f3d71bda5396208fa63f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:60972", "10.65.0.27:60972", "172.17.0.1:60972"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:49:35.242672743Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4630694457717876,
+				"StableID":   "nTLJAVVFAd11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:623173f9b609cdb0a87dc28a1ea577bd73f108678e4a60e79c5b1537baf89a1a",
+				"DiscoKey":   "discokey:11571f055222a7e291c244e9ad7da479025faa5e0044bf58b38b79f4877a5118",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:60343", "10.65.0.27:60343", "172.17.0.1:60343"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:49:35.785634417Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4728549180687201,
+				"StableID":   "nJmbwByZvd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cbf22f012be058dd320ed4dd3267eba26b765c7b0a66d640f391add6b5a7c60e",
+				"DiscoKey":   "discokey:41338c797b5dbe22e272b82b07ffe21f698ec68cb8b212e689fb5e21b76a7b37",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:42284", "10.65.0.27:42284", "172.17.0.1:42284"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:49:36.319517347Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2553292478976651,
+				"StableID":   "n6ec2WfPwL11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc30ec8da75be2c53544f640dd3b36d3a8550a7c556388b7ce1b2ae31bcf4f09",
+				"DiscoKey":   "discokey:2f44d09a8d8c58dd6ece012d557ca7bb959028687c6042448738e868d9dcf867",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:49021", "10.65.0.27:49021", "172.17.0.1:49021"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:49:36.8665194Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8050969568316525,
+				"StableID":   "nNu7WUKJs521CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6fa5c30759b4d3ff3b02427c62682e4aa9bda97510e7fd3a802eeaf4a625319",
+				"DiscoKey":   "discokey:8a77ac47b80f9e87df5c52906964c0be000b057b79069ceadd44172ce37e9259",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:59392", "10.65.0.27:59392", "172.17.0.1:59392"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:49:37.404736658Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2047301492658962,
+				"StableID":   "nKdbF39EzG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c8ab8298a8c53249d893915d6260b0d91de912089d2ead41087a741205883152",
+				"DiscoKey":   "discokey:e8e177a2df69fe1b5dfa29fa5814ff582d9396d9969fd5c3f68058b03407f11e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:52876", "10.65.0.27:52876", "172.17.0.1:52876"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:49:37.945678729Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1272909863032316,
+				"StableID":   "nFrpieBWwA11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0f6926538765127c5ba2d553141ecfd02219dc7af00c8553eb67b6d3aed6563",
+				"DiscoKey":   "discokey:4d3874338ebf469845cf0888427635c146194c3123f1e571cf77ed4de12fef45",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:44464", "10.65.0.27:44464", "172.17.0.1:44464"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:49:38.50203138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2957510641661268,
+				"StableID":   "nFUHtnnT6Q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7a531bd87f5a4020e2459ac00cabba5abf26ee9a33564818ab1c012224e17d02",
+				"DiscoKey":   "discokey:67077cb4017129741e4f5a940ff9304bfab77c99e39472119166bd6ff7ed7531",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53301", "10.65.0.27:53301", "172.17.0.1:53301"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:49:39.558897204Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8916411384039549,
+				"StableID":   "naH6CS1GdC21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f825aadbceb6fd7eb4df73e0db44ab533aaef2289a7369b7a9106984daf3ba69",
+				"KeyExpiry":  "2026-11-08T18:49:40Z",
+				"DiscoKey":   "discokey:2f4b97dc0c4c336cc1b859ff79e2c372453e7b6f513d998fe7c72d50aefa9557",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:43652", "10.65.0.27:43652", "172.17.0.1:43652"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:49:40.109443444Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7970113772317226,
+				"StableID":   "nbwrggNgE521CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a2e3ec6c6a12b0f31c410c35f38035da919a7a2941aa9798dce42e55804e5a0a",
+				"KeyExpiry":  "2026-11-08T18:49:40Z",
+				"DiscoKey":   "discokey:657222a191639086d196b38b41d06e4c1c6de2c7679f467473b662724b7ff46e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:41230", "10.65.0.27:41230", "172.17.0.1:41230"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:49:40.642595104Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5356533428254481,
+				"StableID":   "nGt8Uu3zpi11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c9071132b543fe089db243b686de85d3232c567222f8a621958b9428f7667441",
+				"KeyExpiry":  "2026-11-08T18:49:41Z",
+				"DiscoKey":   "discokey:26dfb9035dce059a334c0851e4709a1cf9577ba5cf2216a30802074902c47104",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:40254", "10.65.0.27:40254", "172.17.0.1:40254"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:49:41.195401855Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2711502179480840": {
+				"ID":          2711502179480840,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2706738658132250,
+				"StableID":   "nuzpRDSt8N11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       2706738658132250,
+				"Key":        "nodekey:4f372f41160436362c4a299ee8e41e9506c0387c24efd651541eeffef73c6c35",
+				"DiscoKey":   "discokey:83f90746253b5f9c6f5c9891a13aea64b05c4d31be8cd253ad52f22d2bd71414",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:60917", "10.65.0.27:60917", "172.17.0.1:60917"],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:49:34.149328077Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4f372f41160436362c4a299ee8e41e9506c0387c24efd651541eeffef73c6c35",
+			"MachineKey": "mkey:25f2109a6f2e5ec069a5307e89df9502ca789bd85f6addb52ed7be7576e2a138",
+			"Peers": [{
+				"ID":         4036485262546260,
+				"StableID":   "nuHhM9d8XY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:446da1fb0929ad6eb9a62dd73fe5948ab1b9e705ac639743dad4b133eb912620",
+				"DiscoKey":   "discokey:4f7b74c7ce8597e34f5d6d975ebf7d7b855dd9d94e3397b7f20f6ef8ae09260f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:33739", "10.65.0.27:33739", "172.17.0.1:33739"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:49:33.468713095Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1092125780826920,
+				"StableID":   "nT2gSxHdX911CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6c39f2eedb619c1b0cfca72a0af98943b411e27411f52287a2ff4a4ca30f116f",
+				"DiscoKey":   "discokey:3381232415d99b31488996be72d25ed42ba86e4ed316cf60486243510bd0bb39",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:34414", "10.65.0.27:34414", "172.17.0.1:34414"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:49:34.687823155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4297525523072750,
+				"StableID":   "nMimH5iMZa11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0055db475743b554b76e77b33a4cc05184228f357ae4950122a707ae4d92ff07",
+				"DiscoKey":   "discokey:2ce059328a9a918999b0b75dccc68b5b1fb416db1dd3f3d71bda5396208fa63f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:60972", "10.65.0.27:60972", "172.17.0.1:60972"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:49:35.242672743Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4630694457717876,
+				"StableID":   "nTLJAVVFAd11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:623173f9b609cdb0a87dc28a1ea577bd73f108678e4a60e79c5b1537baf89a1a",
+				"DiscoKey":   "discokey:11571f055222a7e291c244e9ad7da479025faa5e0044bf58b38b79f4877a5118",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:60343", "10.65.0.27:60343", "172.17.0.1:60343"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:49:35.785634417Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4728549180687201,
+				"StableID":   "nJmbwByZvd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cbf22f012be058dd320ed4dd3267eba26b765c7b0a66d640f391add6b5a7c60e",
+				"DiscoKey":   "discokey:41338c797b5dbe22e272b82b07ffe21f698ec68cb8b212e689fb5e21b76a7b37",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:42284", "10.65.0.27:42284", "172.17.0.1:42284"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:49:36.319517347Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2553292478976651,
+				"StableID":   "n6ec2WfPwL11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc30ec8da75be2c53544f640dd3b36d3a8550a7c556388b7ce1b2ae31bcf4f09",
+				"DiscoKey":   "discokey:2f44d09a8d8c58dd6ece012d557ca7bb959028687c6042448738e868d9dcf867",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:49021", "10.65.0.27:49021", "172.17.0.1:49021"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:49:36.8665194Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8050969568316525,
+				"StableID":   "nNu7WUKJs521CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6fa5c30759b4d3ff3b02427c62682e4aa9bda97510e7fd3a802eeaf4a625319",
+				"DiscoKey":   "discokey:8a77ac47b80f9e87df5c52906964c0be000b057b79069ceadd44172ce37e9259",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:59392", "10.65.0.27:59392", "172.17.0.1:59392"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:49:37.404736658Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2047301492658962,
+				"StableID":   "nKdbF39EzG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c8ab8298a8c53249d893915d6260b0d91de912089d2ead41087a741205883152",
+				"DiscoKey":   "discokey:e8e177a2df69fe1b5dfa29fa5814ff582d9396d9969fd5c3f68058b03407f11e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:52876", "10.65.0.27:52876", "172.17.0.1:52876"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:49:37.945678729Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1272909863032316,
+				"StableID":   "nFrpieBWwA11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0f6926538765127c5ba2d553141ecfd02219dc7af00c8553eb67b6d3aed6563",
+				"DiscoKey":   "discokey:4d3874338ebf469845cf0888427635c146194c3123f1e571cf77ed4de12fef45",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:44464", "10.65.0.27:44464", "172.17.0.1:44464"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:49:38.50203138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2711502179480840,
+				"StableID":   "nsLsVjZ3BN11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7d9aba483ddbb1f668916472455e84df7cc8f4ce4b6b9d6e38ce34ece126b957",
+				"DiscoKey":   "discokey:d1350bcbcfc40d3dcab4ee2e4a42afa795a47570d48796be69b04e76deb64013",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:41283", "10.65.0.27:41283", "172.17.0.1:41283"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:49:39.045851741Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2957510641661268,
+				"StableID":   "nFUHtnnT6Q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7a531bd87f5a4020e2459ac00cabba5abf26ee9a33564818ab1c012224e17d02",
+				"DiscoKey":   "discokey:67077cb4017129741e4f5a940ff9304bfab77c99e39472119166bd6ff7ed7531",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53301", "10.65.0.27:53301", "172.17.0.1:53301"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:49:39.558897204Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8916411384039549,
+				"StableID":   "naH6CS1GdC21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f825aadbceb6fd7eb4df73e0db44ab533aaef2289a7369b7a9106984daf3ba69",
+				"KeyExpiry":  "2026-11-08T18:49:40Z",
+				"DiscoKey":   "discokey:2f4b97dc0c4c336cc1b859ff79e2c372453e7b6f513d998fe7c72d50aefa9557",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:43652", "10.65.0.27:43652", "172.17.0.1:43652"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:49:40.109443444Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7970113772317226,
+				"StableID":   "nbwrggNgE521CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a2e3ec6c6a12b0f31c410c35f38035da919a7a2941aa9798dce42e55804e5a0a",
+				"KeyExpiry":  "2026-11-08T18:49:40Z",
+				"DiscoKey":   "discokey:657222a191639086d196b38b41d06e4c1c6de2c7679f467473b662724b7ff46e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:41230", "10.65.0.27:41230", "172.17.0.1:41230"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:49:40.642595104Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5356533428254481,
+				"StableID":   "nGt8Uu3zpi11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c9071132b543fe089db243b686de85d3232c567222f8a621958b9428f7667441",
+				"KeyExpiry":  "2026-11-08T18:49:41Z",
+				"DiscoKey":   "discokey:26dfb9035dce059a334c0851e4709a1cf9577ba5cf2216a30802074902c47104",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:40254", "10.65.0.27:40254", "172.17.0.1:40254"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:49:41.195401855Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2706738658132250": {
+				"ID":          2706738658132250,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4036485262546260,
+				"StableID":   "nuHhM9d8XY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       4036485262546260,
+				"Key":        "nodekey:446da1fb0929ad6eb9a62dd73fe5948ab1b9e705ac639743dad4b133eb912620",
+				"DiscoKey":   "discokey:4f7b74c7ce8597e34f5d6d975ebf7d7b855dd9d94e3397b7f20f6ef8ae09260f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:33739", "10.65.0.27:33739", "172.17.0.1:33739"],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:49:33.468713095Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:446da1fb0929ad6eb9a62dd73fe5948ab1b9e705ac639743dad4b133eb912620",
+			"MachineKey": "mkey:cd0e2743a8a7c31c72d2335395c4a31a95f207048c28aed8fe6b5692e6ed2623",
+			"Peers": [{
+				"ID":         2706738658132250,
+				"StableID":   "nuzpRDSt8N11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f372f41160436362c4a299ee8e41e9506c0387c24efd651541eeffef73c6c35",
+				"DiscoKey":   "discokey:83f90746253b5f9c6f5c9891a13aea64b05c4d31be8cd253ad52f22d2bd71414",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:60917", "10.65.0.27:60917", "172.17.0.1:60917"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:49:34.149328077Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1092125780826920,
+				"StableID":   "nT2gSxHdX911CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6c39f2eedb619c1b0cfca72a0af98943b411e27411f52287a2ff4a4ca30f116f",
+				"DiscoKey":   "discokey:3381232415d99b31488996be72d25ed42ba86e4ed316cf60486243510bd0bb39",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:34414", "10.65.0.27:34414", "172.17.0.1:34414"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:49:34.687823155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4297525523072750,
+				"StableID":   "nMimH5iMZa11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0055db475743b554b76e77b33a4cc05184228f357ae4950122a707ae4d92ff07",
+				"DiscoKey":   "discokey:2ce059328a9a918999b0b75dccc68b5b1fb416db1dd3f3d71bda5396208fa63f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:60972", "10.65.0.27:60972", "172.17.0.1:60972"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:49:35.242672743Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4630694457717876,
+				"StableID":   "nTLJAVVFAd11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:623173f9b609cdb0a87dc28a1ea577bd73f108678e4a60e79c5b1537baf89a1a",
+				"DiscoKey":   "discokey:11571f055222a7e291c244e9ad7da479025faa5e0044bf58b38b79f4877a5118",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:60343", "10.65.0.27:60343", "172.17.0.1:60343"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:49:35.785634417Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4728549180687201,
+				"StableID":   "nJmbwByZvd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cbf22f012be058dd320ed4dd3267eba26b765c7b0a66d640f391add6b5a7c60e",
+				"DiscoKey":   "discokey:41338c797b5dbe22e272b82b07ffe21f698ec68cb8b212e689fb5e21b76a7b37",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:42284", "10.65.0.27:42284", "172.17.0.1:42284"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:49:36.319517347Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2553292478976651,
+				"StableID":   "n6ec2WfPwL11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc30ec8da75be2c53544f640dd3b36d3a8550a7c556388b7ce1b2ae31bcf4f09",
+				"DiscoKey":   "discokey:2f44d09a8d8c58dd6ece012d557ca7bb959028687c6042448738e868d9dcf867",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:49021", "10.65.0.27:49021", "172.17.0.1:49021"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:49:36.8665194Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8050969568316525,
+				"StableID":   "nNu7WUKJs521CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6fa5c30759b4d3ff3b02427c62682e4aa9bda97510e7fd3a802eeaf4a625319",
+				"DiscoKey":   "discokey:8a77ac47b80f9e87df5c52906964c0be000b057b79069ceadd44172ce37e9259",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:59392", "10.65.0.27:59392", "172.17.0.1:59392"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:49:37.404736658Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2047301492658962,
+				"StableID":   "nKdbF39EzG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c8ab8298a8c53249d893915d6260b0d91de912089d2ead41087a741205883152",
+				"DiscoKey":   "discokey:e8e177a2df69fe1b5dfa29fa5814ff582d9396d9969fd5c3f68058b03407f11e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:52876", "10.65.0.27:52876", "172.17.0.1:52876"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:49:37.945678729Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1272909863032316,
+				"StableID":   "nFrpieBWwA11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0f6926538765127c5ba2d553141ecfd02219dc7af00c8553eb67b6d3aed6563",
+				"DiscoKey":   "discokey:4d3874338ebf469845cf0888427635c146194c3123f1e571cf77ed4de12fef45",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:44464", "10.65.0.27:44464", "172.17.0.1:44464"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:49:38.50203138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2711502179480840,
+				"StableID":   "nsLsVjZ3BN11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7d9aba483ddbb1f668916472455e84df7cc8f4ce4b6b9d6e38ce34ece126b957",
+				"DiscoKey":   "discokey:d1350bcbcfc40d3dcab4ee2e4a42afa795a47570d48796be69b04e76deb64013",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:41283", "10.65.0.27:41283", "172.17.0.1:41283"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:49:39.045851741Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2957510641661268,
+				"StableID":   "nFUHtnnT6Q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7a531bd87f5a4020e2459ac00cabba5abf26ee9a33564818ab1c012224e17d02",
+				"DiscoKey":   "discokey:67077cb4017129741e4f5a940ff9304bfab77c99e39472119166bd6ff7ed7531",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53301", "10.65.0.27:53301", "172.17.0.1:53301"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:49:39.558897204Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8916411384039549,
+				"StableID":   "naH6CS1GdC21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f825aadbceb6fd7eb4df73e0db44ab533aaef2289a7369b7a9106984daf3ba69",
+				"KeyExpiry":  "2026-11-08T18:49:40Z",
+				"DiscoKey":   "discokey:2f4b97dc0c4c336cc1b859ff79e2c372453e7b6f513d998fe7c72d50aefa9557",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:43652", "10.65.0.27:43652", "172.17.0.1:43652"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:49:40.109443444Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7970113772317226,
+				"StableID":   "nbwrggNgE521CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a2e3ec6c6a12b0f31c410c35f38035da919a7a2941aa9798dce42e55804e5a0a",
+				"KeyExpiry":  "2026-11-08T18:49:40Z",
+				"DiscoKey":   "discokey:657222a191639086d196b38b41d06e4c1c6de2c7679f467473b662724b7ff46e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:41230", "10.65.0.27:41230", "172.17.0.1:41230"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:49:40.642595104Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5356533428254481,
+				"StableID":   "nGt8Uu3zpi11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c9071132b543fe089db243b686de85d3232c567222f8a621958b9428f7667441",
+				"KeyExpiry":  "2026-11-08T18:49:41Z",
+				"DiscoKey":   "discokey:26dfb9035dce059a334c0851e4709a1cf9577ba5cf2216a30802074902c47104",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:40254", "10.65.0.27:40254", "172.17.0.1:40254"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:49:41.195401855Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4036485262546260": {
+				"ID":          4036485262546260,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4630694457717876,
+				"StableID":   "nTLJAVVFAd11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       4630694457717876,
+				"Key":        "nodekey:623173f9b609cdb0a87dc28a1ea577bd73f108678e4a60e79c5b1537baf89a1a",
+				"DiscoKey":   "discokey:11571f055222a7e291c244e9ad7da479025faa5e0044bf58b38b79f4877a5118",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:60343", "10.65.0.27:60343", "172.17.0.1:60343"],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:49:35.785634417Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:623173f9b609cdb0a87dc28a1ea577bd73f108678e4a60e79c5b1537baf89a1a",
+			"MachineKey": "mkey:2c17842fee746e1f5fc9e213d73b91c43802ef014f61d4a727105b984384084b",
+			"Peers": [{
+				"ID":         4036485262546260,
+				"StableID":   "nuHhM9d8XY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:446da1fb0929ad6eb9a62dd73fe5948ab1b9e705ac639743dad4b133eb912620",
+				"DiscoKey":   "discokey:4f7b74c7ce8597e34f5d6d975ebf7d7b855dd9d94e3397b7f20f6ef8ae09260f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:33739", "10.65.0.27:33739", "172.17.0.1:33739"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:49:33.468713095Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2706738658132250,
+				"StableID":   "nuzpRDSt8N11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f372f41160436362c4a299ee8e41e9506c0387c24efd651541eeffef73c6c35",
+				"DiscoKey":   "discokey:83f90746253b5f9c6f5c9891a13aea64b05c4d31be8cd253ad52f22d2bd71414",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:60917", "10.65.0.27:60917", "172.17.0.1:60917"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:49:34.149328077Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1092125780826920,
+				"StableID":   "nT2gSxHdX911CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6c39f2eedb619c1b0cfca72a0af98943b411e27411f52287a2ff4a4ca30f116f",
+				"DiscoKey":   "discokey:3381232415d99b31488996be72d25ed42ba86e4ed316cf60486243510bd0bb39",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:34414", "10.65.0.27:34414", "172.17.0.1:34414"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:49:34.687823155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4297525523072750,
+				"StableID":   "nMimH5iMZa11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0055db475743b554b76e77b33a4cc05184228f357ae4950122a707ae4d92ff07",
+				"DiscoKey":   "discokey:2ce059328a9a918999b0b75dccc68b5b1fb416db1dd3f3d71bda5396208fa63f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:60972", "10.65.0.27:60972", "172.17.0.1:60972"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:49:35.242672743Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4728549180687201,
+				"StableID":   "nJmbwByZvd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cbf22f012be058dd320ed4dd3267eba26b765c7b0a66d640f391add6b5a7c60e",
+				"DiscoKey":   "discokey:41338c797b5dbe22e272b82b07ffe21f698ec68cb8b212e689fb5e21b76a7b37",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:42284", "10.65.0.27:42284", "172.17.0.1:42284"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:49:36.319517347Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2553292478976651,
+				"StableID":   "n6ec2WfPwL11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc30ec8da75be2c53544f640dd3b36d3a8550a7c556388b7ce1b2ae31bcf4f09",
+				"DiscoKey":   "discokey:2f44d09a8d8c58dd6ece012d557ca7bb959028687c6042448738e868d9dcf867",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:49021", "10.65.0.27:49021", "172.17.0.1:49021"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:49:36.8665194Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8050969568316525,
+				"StableID":   "nNu7WUKJs521CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6fa5c30759b4d3ff3b02427c62682e4aa9bda97510e7fd3a802eeaf4a625319",
+				"DiscoKey":   "discokey:8a77ac47b80f9e87df5c52906964c0be000b057b79069ceadd44172ce37e9259",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:59392", "10.65.0.27:59392", "172.17.0.1:59392"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:49:37.404736658Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2047301492658962,
+				"StableID":   "nKdbF39EzG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c8ab8298a8c53249d893915d6260b0d91de912089d2ead41087a741205883152",
+				"DiscoKey":   "discokey:e8e177a2df69fe1b5dfa29fa5814ff582d9396d9969fd5c3f68058b03407f11e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:52876", "10.65.0.27:52876", "172.17.0.1:52876"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:49:37.945678729Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1272909863032316,
+				"StableID":   "nFrpieBWwA11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0f6926538765127c5ba2d553141ecfd02219dc7af00c8553eb67b6d3aed6563",
+				"DiscoKey":   "discokey:4d3874338ebf469845cf0888427635c146194c3123f1e571cf77ed4de12fef45",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:44464", "10.65.0.27:44464", "172.17.0.1:44464"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:49:38.50203138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2711502179480840,
+				"StableID":   "nsLsVjZ3BN11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7d9aba483ddbb1f668916472455e84df7cc8f4ce4b6b9d6e38ce34ece126b957",
+				"DiscoKey":   "discokey:d1350bcbcfc40d3dcab4ee2e4a42afa795a47570d48796be69b04e76deb64013",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:41283", "10.65.0.27:41283", "172.17.0.1:41283"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:49:39.045851741Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2957510641661268,
+				"StableID":   "nFUHtnnT6Q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7a531bd87f5a4020e2459ac00cabba5abf26ee9a33564818ab1c012224e17d02",
+				"DiscoKey":   "discokey:67077cb4017129741e4f5a940ff9304bfab77c99e39472119166bd6ff7ed7531",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53301", "10.65.0.27:53301", "172.17.0.1:53301"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:49:39.558897204Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8916411384039549,
+				"StableID":   "naH6CS1GdC21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f825aadbceb6fd7eb4df73e0db44ab533aaef2289a7369b7a9106984daf3ba69",
+				"KeyExpiry":  "2026-11-08T18:49:40Z",
+				"DiscoKey":   "discokey:2f4b97dc0c4c336cc1b859ff79e2c372453e7b6f513d998fe7c72d50aefa9557",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:43652", "10.65.0.27:43652", "172.17.0.1:43652"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:49:40.109443444Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7970113772317226,
+				"StableID":   "nbwrggNgE521CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a2e3ec6c6a12b0f31c410c35f38035da919a7a2941aa9798dce42e55804e5a0a",
+				"KeyExpiry":  "2026-11-08T18:49:40Z",
+				"DiscoKey":   "discokey:657222a191639086d196b38b41d06e4c1c6de2c7679f467473b662724b7ff46e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:41230", "10.65.0.27:41230", "172.17.0.1:41230"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:49:40.642595104Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5356533428254481,
+				"StableID":   "nGt8Uu3zpi11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c9071132b543fe089db243b686de85d3232c567222f8a621958b9428f7667441",
+				"KeyExpiry":  "2026-11-08T18:49:41Z",
+				"DiscoKey":   "discokey:26dfb9035dce059a334c0851e4709a1cf9577ba5cf2216a30802074902c47104",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:40254", "10.65.0.27:40254", "172.17.0.1:40254"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:49:41.195401855Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4630694457717876": {
+				"ID":          4630694457717876,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4297525523072750,
+				"StableID":   "nMimH5iMZa11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       4297525523072750,
+				"Key":        "nodekey:0055db475743b554b76e77b33a4cc05184228f357ae4950122a707ae4d92ff07",
+				"DiscoKey":   "discokey:2ce059328a9a918999b0b75dccc68b5b1fb416db1dd3f3d71bda5396208fa63f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:60972", "10.65.0.27:60972", "172.17.0.1:60972"],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:49:35.242672743Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0055db475743b554b76e77b33a4cc05184228f357ae4950122a707ae4d92ff07",
+			"MachineKey": "mkey:ba8dedcdd6210495f73edcd44ad78bcf43f1368d85c93afa600e09fe8fae0d5b",
+			"Peers": [{
+				"ID":         4036485262546260,
+				"StableID":   "nuHhM9d8XY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:446da1fb0929ad6eb9a62dd73fe5948ab1b9e705ac639743dad4b133eb912620",
+				"DiscoKey":   "discokey:4f7b74c7ce8597e34f5d6d975ebf7d7b855dd9d94e3397b7f20f6ef8ae09260f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:33739", "10.65.0.27:33739", "172.17.0.1:33739"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:49:33.468713095Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2706738658132250,
+				"StableID":   "nuzpRDSt8N11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f372f41160436362c4a299ee8e41e9506c0387c24efd651541eeffef73c6c35",
+				"DiscoKey":   "discokey:83f90746253b5f9c6f5c9891a13aea64b05c4d31be8cd253ad52f22d2bd71414",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:60917", "10.65.0.27:60917", "172.17.0.1:60917"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:49:34.149328077Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1092125780826920,
+				"StableID":   "nT2gSxHdX911CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6c39f2eedb619c1b0cfca72a0af98943b411e27411f52287a2ff4a4ca30f116f",
+				"DiscoKey":   "discokey:3381232415d99b31488996be72d25ed42ba86e4ed316cf60486243510bd0bb39",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:34414", "10.65.0.27:34414", "172.17.0.1:34414"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:49:34.687823155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4630694457717876,
+				"StableID":   "nTLJAVVFAd11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:623173f9b609cdb0a87dc28a1ea577bd73f108678e4a60e79c5b1537baf89a1a",
+				"DiscoKey":   "discokey:11571f055222a7e291c244e9ad7da479025faa5e0044bf58b38b79f4877a5118",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:60343", "10.65.0.27:60343", "172.17.0.1:60343"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:49:35.785634417Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4728549180687201,
+				"StableID":   "nJmbwByZvd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cbf22f012be058dd320ed4dd3267eba26b765c7b0a66d640f391add6b5a7c60e",
+				"DiscoKey":   "discokey:41338c797b5dbe22e272b82b07ffe21f698ec68cb8b212e689fb5e21b76a7b37",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:42284", "10.65.0.27:42284", "172.17.0.1:42284"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:49:36.319517347Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2553292478976651,
+				"StableID":   "n6ec2WfPwL11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc30ec8da75be2c53544f640dd3b36d3a8550a7c556388b7ce1b2ae31bcf4f09",
+				"DiscoKey":   "discokey:2f44d09a8d8c58dd6ece012d557ca7bb959028687c6042448738e868d9dcf867",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:49021", "10.65.0.27:49021", "172.17.0.1:49021"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:49:36.8665194Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8050969568316525,
+				"StableID":   "nNu7WUKJs521CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6fa5c30759b4d3ff3b02427c62682e4aa9bda97510e7fd3a802eeaf4a625319",
+				"DiscoKey":   "discokey:8a77ac47b80f9e87df5c52906964c0be000b057b79069ceadd44172ce37e9259",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:59392", "10.65.0.27:59392", "172.17.0.1:59392"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:49:37.404736658Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2047301492658962,
+				"StableID":   "nKdbF39EzG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c8ab8298a8c53249d893915d6260b0d91de912089d2ead41087a741205883152",
+				"DiscoKey":   "discokey:e8e177a2df69fe1b5dfa29fa5814ff582d9396d9969fd5c3f68058b03407f11e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:52876", "10.65.0.27:52876", "172.17.0.1:52876"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:49:37.945678729Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1272909863032316,
+				"StableID":   "nFrpieBWwA11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0f6926538765127c5ba2d553141ecfd02219dc7af00c8553eb67b6d3aed6563",
+				"DiscoKey":   "discokey:4d3874338ebf469845cf0888427635c146194c3123f1e571cf77ed4de12fef45",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:44464", "10.65.0.27:44464", "172.17.0.1:44464"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:49:38.50203138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2711502179480840,
+				"StableID":   "nsLsVjZ3BN11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7d9aba483ddbb1f668916472455e84df7cc8f4ce4b6b9d6e38ce34ece126b957",
+				"DiscoKey":   "discokey:d1350bcbcfc40d3dcab4ee2e4a42afa795a47570d48796be69b04e76deb64013",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:41283", "10.65.0.27:41283", "172.17.0.1:41283"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:49:39.045851741Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2957510641661268,
+				"StableID":   "nFUHtnnT6Q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7a531bd87f5a4020e2459ac00cabba5abf26ee9a33564818ab1c012224e17d02",
+				"DiscoKey":   "discokey:67077cb4017129741e4f5a940ff9304bfab77c99e39472119166bd6ff7ed7531",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53301", "10.65.0.27:53301", "172.17.0.1:53301"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:49:39.558897204Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8916411384039549,
+				"StableID":   "naH6CS1GdC21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f825aadbceb6fd7eb4df73e0db44ab533aaef2289a7369b7a9106984daf3ba69",
+				"KeyExpiry":  "2026-11-08T18:49:40Z",
+				"DiscoKey":   "discokey:2f4b97dc0c4c336cc1b859ff79e2c372453e7b6f513d998fe7c72d50aefa9557",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:43652", "10.65.0.27:43652", "172.17.0.1:43652"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:49:40.109443444Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7970113772317226,
+				"StableID":   "nbwrggNgE521CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a2e3ec6c6a12b0f31c410c35f38035da919a7a2941aa9798dce42e55804e5a0a",
+				"KeyExpiry":  "2026-11-08T18:49:40Z",
+				"DiscoKey":   "discokey:657222a191639086d196b38b41d06e4c1c6de2c7679f467473b662724b7ff46e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:41230", "10.65.0.27:41230", "172.17.0.1:41230"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:49:40.642595104Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5356533428254481,
+				"StableID":   "nGt8Uu3zpi11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c9071132b543fe089db243b686de85d3232c567222f8a621958b9428f7667441",
+				"KeyExpiry":  "2026-11-08T18:49:41Z",
+				"DiscoKey":   "discokey:26dfb9035dce059a334c0851e4709a1cf9577ba5cf2216a30802074902c47104",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:40254", "10.65.0.27:40254", "172.17.0.1:40254"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:49:41.195401855Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4297525523072750": {
+				"ID":          4297525523072750,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2553292478976651,
+				"StableID":   "n6ec2WfPwL11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       2553292478976651,
+				"Key":        "nodekey:dc30ec8da75be2c53544f640dd3b36d3a8550a7c556388b7ce1b2ae31bcf4f09",
+				"DiscoKey":   "discokey:2f44d09a8d8c58dd6ece012d557ca7bb959028687c6042448738e868d9dcf867",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:49021", "10.65.0.27:49021", "172.17.0.1:49021"],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:49:36.8665194Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:dc30ec8da75be2c53544f640dd3b36d3a8550a7c556388b7ce1b2ae31bcf4f09",
+			"MachineKey": "mkey:7e65fce103664e008cccc7d0edec6d89d1d5bc202f4b61849f125c3d47b0555e",
+			"Peers": [{
+				"ID":         4036485262546260,
+				"StableID":   "nuHhM9d8XY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:446da1fb0929ad6eb9a62dd73fe5948ab1b9e705ac639743dad4b133eb912620",
+				"DiscoKey":   "discokey:4f7b74c7ce8597e34f5d6d975ebf7d7b855dd9d94e3397b7f20f6ef8ae09260f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:33739", "10.65.0.27:33739", "172.17.0.1:33739"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:49:33.468713095Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2706738658132250,
+				"StableID":   "nuzpRDSt8N11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f372f41160436362c4a299ee8e41e9506c0387c24efd651541eeffef73c6c35",
+				"DiscoKey":   "discokey:83f90746253b5f9c6f5c9891a13aea64b05c4d31be8cd253ad52f22d2bd71414",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:60917", "10.65.0.27:60917", "172.17.0.1:60917"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:49:34.149328077Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1092125780826920,
+				"StableID":   "nT2gSxHdX911CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6c39f2eedb619c1b0cfca72a0af98943b411e27411f52287a2ff4a4ca30f116f",
+				"DiscoKey":   "discokey:3381232415d99b31488996be72d25ed42ba86e4ed316cf60486243510bd0bb39",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:34414", "10.65.0.27:34414", "172.17.0.1:34414"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:49:34.687823155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4297525523072750,
+				"StableID":   "nMimH5iMZa11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0055db475743b554b76e77b33a4cc05184228f357ae4950122a707ae4d92ff07",
+				"DiscoKey":   "discokey:2ce059328a9a918999b0b75dccc68b5b1fb416db1dd3f3d71bda5396208fa63f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:60972", "10.65.0.27:60972", "172.17.0.1:60972"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:49:35.242672743Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4630694457717876,
+				"StableID":   "nTLJAVVFAd11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:623173f9b609cdb0a87dc28a1ea577bd73f108678e4a60e79c5b1537baf89a1a",
+				"DiscoKey":   "discokey:11571f055222a7e291c244e9ad7da479025faa5e0044bf58b38b79f4877a5118",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:60343", "10.65.0.27:60343", "172.17.0.1:60343"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:49:35.785634417Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4728549180687201,
+				"StableID":   "nJmbwByZvd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cbf22f012be058dd320ed4dd3267eba26b765c7b0a66d640f391add6b5a7c60e",
+				"DiscoKey":   "discokey:41338c797b5dbe22e272b82b07ffe21f698ec68cb8b212e689fb5e21b76a7b37",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:42284", "10.65.0.27:42284", "172.17.0.1:42284"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:49:36.319517347Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8050969568316525,
+				"StableID":   "nNu7WUKJs521CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6fa5c30759b4d3ff3b02427c62682e4aa9bda97510e7fd3a802eeaf4a625319",
+				"DiscoKey":   "discokey:8a77ac47b80f9e87df5c52906964c0be000b057b79069ceadd44172ce37e9259",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:59392", "10.65.0.27:59392", "172.17.0.1:59392"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:49:37.404736658Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2047301492658962,
+				"StableID":   "nKdbF39EzG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c8ab8298a8c53249d893915d6260b0d91de912089d2ead41087a741205883152",
+				"DiscoKey":   "discokey:e8e177a2df69fe1b5dfa29fa5814ff582d9396d9969fd5c3f68058b03407f11e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:52876", "10.65.0.27:52876", "172.17.0.1:52876"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:49:37.945678729Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1272909863032316,
+				"StableID":   "nFrpieBWwA11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0f6926538765127c5ba2d553141ecfd02219dc7af00c8553eb67b6d3aed6563",
+				"DiscoKey":   "discokey:4d3874338ebf469845cf0888427635c146194c3123f1e571cf77ed4de12fef45",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:44464", "10.65.0.27:44464", "172.17.0.1:44464"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:49:38.50203138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2711502179480840,
+				"StableID":   "nsLsVjZ3BN11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7d9aba483ddbb1f668916472455e84df7cc8f4ce4b6b9d6e38ce34ece126b957",
+				"DiscoKey":   "discokey:d1350bcbcfc40d3dcab4ee2e4a42afa795a47570d48796be69b04e76deb64013",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:41283", "10.65.0.27:41283", "172.17.0.1:41283"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:49:39.045851741Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2957510641661268,
+				"StableID":   "nFUHtnnT6Q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7a531bd87f5a4020e2459ac00cabba5abf26ee9a33564818ab1c012224e17d02",
+				"DiscoKey":   "discokey:67077cb4017129741e4f5a940ff9304bfab77c99e39472119166bd6ff7ed7531",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53301", "10.65.0.27:53301", "172.17.0.1:53301"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:49:39.558897204Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8916411384039549,
+				"StableID":   "naH6CS1GdC21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f825aadbceb6fd7eb4df73e0db44ab533aaef2289a7369b7a9106984daf3ba69",
+				"KeyExpiry":  "2026-11-08T18:49:40Z",
+				"DiscoKey":   "discokey:2f4b97dc0c4c336cc1b859ff79e2c372453e7b6f513d998fe7c72d50aefa9557",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:43652", "10.65.0.27:43652", "172.17.0.1:43652"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:49:40.109443444Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7970113772317226,
+				"StableID":   "nbwrggNgE521CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a2e3ec6c6a12b0f31c410c35f38035da919a7a2941aa9798dce42e55804e5a0a",
+				"KeyExpiry":  "2026-11-08T18:49:40Z",
+				"DiscoKey":   "discokey:657222a191639086d196b38b41d06e4c1c6de2c7679f467473b662724b7ff46e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:41230", "10.65.0.27:41230", "172.17.0.1:41230"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:49:40.642595104Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5356533428254481,
+				"StableID":   "nGt8Uu3zpi11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c9071132b543fe089db243b686de85d3232c567222f8a621958b9428f7667441",
+				"KeyExpiry":  "2026-11-08T18:49:41Z",
+				"DiscoKey":   "discokey:26dfb9035dce059a334c0851e4709a1cf9577ba5cf2216a30802074902c47104",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:40254", "10.65.0.27:40254", "172.17.0.1:40254"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:49:41.195401855Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2553292478976651": {
+				"ID":          2553292478976651,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2047301492658962,
+				"StableID":   "nKdbF39EzG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       2047301492658962,
+				"Key":        "nodekey:c8ab8298a8c53249d893915d6260b0d91de912089d2ead41087a741205883152",
+				"DiscoKey":   "discokey:e8e177a2df69fe1b5dfa29fa5814ff582d9396d9969fd5c3f68058b03407f11e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:52876", "10.65.0.27:52876", "172.17.0.1:52876"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:49:37.945678729Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c8ab8298a8c53249d893915d6260b0d91de912089d2ead41087a741205883152",
+			"MachineKey": "mkey:38a0931ad510a0a7e0eeeb75705c1bfbbcf5dfc4e35479288dba35599a41011d",
+			"Peers": [{
+				"ID":         4036485262546260,
+				"StableID":   "nuHhM9d8XY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:446da1fb0929ad6eb9a62dd73fe5948ab1b9e705ac639743dad4b133eb912620",
+				"DiscoKey":   "discokey:4f7b74c7ce8597e34f5d6d975ebf7d7b855dd9d94e3397b7f20f6ef8ae09260f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:33739", "10.65.0.27:33739", "172.17.0.1:33739"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:49:33.468713095Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2706738658132250,
+				"StableID":   "nuzpRDSt8N11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f372f41160436362c4a299ee8e41e9506c0387c24efd651541eeffef73c6c35",
+				"DiscoKey":   "discokey:83f90746253b5f9c6f5c9891a13aea64b05c4d31be8cd253ad52f22d2bd71414",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:60917", "10.65.0.27:60917", "172.17.0.1:60917"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:49:34.149328077Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1092125780826920,
+				"StableID":   "nT2gSxHdX911CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6c39f2eedb619c1b0cfca72a0af98943b411e27411f52287a2ff4a4ca30f116f",
+				"DiscoKey":   "discokey:3381232415d99b31488996be72d25ed42ba86e4ed316cf60486243510bd0bb39",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:34414", "10.65.0.27:34414", "172.17.0.1:34414"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:49:34.687823155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4297525523072750,
+				"StableID":   "nMimH5iMZa11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0055db475743b554b76e77b33a4cc05184228f357ae4950122a707ae4d92ff07",
+				"DiscoKey":   "discokey:2ce059328a9a918999b0b75dccc68b5b1fb416db1dd3f3d71bda5396208fa63f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:60972", "10.65.0.27:60972", "172.17.0.1:60972"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:49:35.242672743Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4630694457717876,
+				"StableID":   "nTLJAVVFAd11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:623173f9b609cdb0a87dc28a1ea577bd73f108678e4a60e79c5b1537baf89a1a",
+				"DiscoKey":   "discokey:11571f055222a7e291c244e9ad7da479025faa5e0044bf58b38b79f4877a5118",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:60343", "10.65.0.27:60343", "172.17.0.1:60343"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:49:35.785634417Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4728549180687201,
+				"StableID":   "nJmbwByZvd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cbf22f012be058dd320ed4dd3267eba26b765c7b0a66d640f391add6b5a7c60e",
+				"DiscoKey":   "discokey:41338c797b5dbe22e272b82b07ffe21f698ec68cb8b212e689fb5e21b76a7b37",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:42284", "10.65.0.27:42284", "172.17.0.1:42284"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:49:36.319517347Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2553292478976651,
+				"StableID":   "n6ec2WfPwL11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc30ec8da75be2c53544f640dd3b36d3a8550a7c556388b7ce1b2ae31bcf4f09",
+				"DiscoKey":   "discokey:2f44d09a8d8c58dd6ece012d557ca7bb959028687c6042448738e868d9dcf867",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:49021", "10.65.0.27:49021", "172.17.0.1:49021"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:49:36.8665194Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8050969568316525,
+				"StableID":   "nNu7WUKJs521CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6fa5c30759b4d3ff3b02427c62682e4aa9bda97510e7fd3a802eeaf4a625319",
+				"DiscoKey":   "discokey:8a77ac47b80f9e87df5c52906964c0be000b057b79069ceadd44172ce37e9259",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:59392", "10.65.0.27:59392", "172.17.0.1:59392"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:49:37.404736658Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1272909863032316,
+				"StableID":   "nFrpieBWwA11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0f6926538765127c5ba2d553141ecfd02219dc7af00c8553eb67b6d3aed6563",
+				"DiscoKey":   "discokey:4d3874338ebf469845cf0888427635c146194c3123f1e571cf77ed4de12fef45",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:44464", "10.65.0.27:44464", "172.17.0.1:44464"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:49:38.50203138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2711502179480840,
+				"StableID":   "nsLsVjZ3BN11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7d9aba483ddbb1f668916472455e84df7cc8f4ce4b6b9d6e38ce34ece126b957",
+				"DiscoKey":   "discokey:d1350bcbcfc40d3dcab4ee2e4a42afa795a47570d48796be69b04e76deb64013",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:41283", "10.65.0.27:41283", "172.17.0.1:41283"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:49:39.045851741Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2957510641661268,
+				"StableID":   "nFUHtnnT6Q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7a531bd87f5a4020e2459ac00cabba5abf26ee9a33564818ab1c012224e17d02",
+				"DiscoKey":   "discokey:67077cb4017129741e4f5a940ff9304bfab77c99e39472119166bd6ff7ed7531",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53301", "10.65.0.27:53301", "172.17.0.1:53301"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:49:39.558897204Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8916411384039549,
+				"StableID":   "naH6CS1GdC21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f825aadbceb6fd7eb4df73e0db44ab533aaef2289a7369b7a9106984daf3ba69",
+				"KeyExpiry":  "2026-11-08T18:49:40Z",
+				"DiscoKey":   "discokey:2f4b97dc0c4c336cc1b859ff79e2c372453e7b6f513d998fe7c72d50aefa9557",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:43652", "10.65.0.27:43652", "172.17.0.1:43652"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:49:40.109443444Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7970113772317226,
+				"StableID":   "nbwrggNgE521CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a2e3ec6c6a12b0f31c410c35f38035da919a7a2941aa9798dce42e55804e5a0a",
+				"KeyExpiry":  "2026-11-08T18:49:40Z",
+				"DiscoKey":   "discokey:657222a191639086d196b38b41d06e4c1c6de2c7679f467473b662724b7ff46e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:41230", "10.65.0.27:41230", "172.17.0.1:41230"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:49:40.642595104Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5356533428254481,
+				"StableID":   "nGt8Uu3zpi11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c9071132b543fe089db243b686de85d3232c567222f8a621958b9428f7667441",
+				"KeyExpiry":  "2026-11-08T18:49:41Z",
+				"DiscoKey":   "discokey:26dfb9035dce059a334c0851e4709a1cf9577ba5cf2216a30802074902c47104",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:40254", "10.65.0.27:40254", "172.17.0.1:40254"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:49:41.195401855Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2047301492658962": {
+				"ID":          2047301492658962,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7970113772317226,
+				"StableID":   "nbwrggNgE521CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a2e3ec6c6a12b0f31c410c35f38035da919a7a2941aa9798dce42e55804e5a0a",
+				"KeyExpiry":  "2026-11-08T18:49:40Z",
+				"DiscoKey":   "discokey:657222a191639086d196b38b41d06e4c1c6de2c7679f467473b662724b7ff46e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:41230", "10.65.0.27:41230", "172.17.0.1:41230"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:49:40.642595104Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a2e3ec6c6a12b0f31c410c35f38035da919a7a2941aa9798dce42e55804e5a0a",
+			"MachineKey": "mkey:39da14bfcd92226d5d86f2c9da4cddd2bb2a0de90b925731a5dc2e543ea26073",
+			"Peers": [{
+				"ID":         4036485262546260,
+				"StableID":   "nuHhM9d8XY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:446da1fb0929ad6eb9a62dd73fe5948ab1b9e705ac639743dad4b133eb912620",
+				"DiscoKey":   "discokey:4f7b74c7ce8597e34f5d6d975ebf7d7b855dd9d94e3397b7f20f6ef8ae09260f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:33739", "10.65.0.27:33739", "172.17.0.1:33739"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:49:33.468713095Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2706738658132250,
+				"StableID":   "nuzpRDSt8N11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f372f41160436362c4a299ee8e41e9506c0387c24efd651541eeffef73c6c35",
+				"DiscoKey":   "discokey:83f90746253b5f9c6f5c9891a13aea64b05c4d31be8cd253ad52f22d2bd71414",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:60917", "10.65.0.27:60917", "172.17.0.1:60917"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:49:34.149328077Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1092125780826920,
+				"StableID":   "nT2gSxHdX911CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6c39f2eedb619c1b0cfca72a0af98943b411e27411f52287a2ff4a4ca30f116f",
+				"DiscoKey":   "discokey:3381232415d99b31488996be72d25ed42ba86e4ed316cf60486243510bd0bb39",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:34414", "10.65.0.27:34414", "172.17.0.1:34414"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:49:34.687823155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4297525523072750,
+				"StableID":   "nMimH5iMZa11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0055db475743b554b76e77b33a4cc05184228f357ae4950122a707ae4d92ff07",
+				"DiscoKey":   "discokey:2ce059328a9a918999b0b75dccc68b5b1fb416db1dd3f3d71bda5396208fa63f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:60972", "10.65.0.27:60972", "172.17.0.1:60972"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:49:35.242672743Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4630694457717876,
+				"StableID":   "nTLJAVVFAd11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:623173f9b609cdb0a87dc28a1ea577bd73f108678e4a60e79c5b1537baf89a1a",
+				"DiscoKey":   "discokey:11571f055222a7e291c244e9ad7da479025faa5e0044bf58b38b79f4877a5118",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:60343", "10.65.0.27:60343", "172.17.0.1:60343"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:49:35.785634417Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4728549180687201,
+				"StableID":   "nJmbwByZvd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cbf22f012be058dd320ed4dd3267eba26b765c7b0a66d640f391add6b5a7c60e",
+				"DiscoKey":   "discokey:41338c797b5dbe22e272b82b07ffe21f698ec68cb8b212e689fb5e21b76a7b37",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:42284", "10.65.0.27:42284", "172.17.0.1:42284"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:49:36.319517347Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2553292478976651,
+				"StableID":   "n6ec2WfPwL11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc30ec8da75be2c53544f640dd3b36d3a8550a7c556388b7ce1b2ae31bcf4f09",
+				"DiscoKey":   "discokey:2f44d09a8d8c58dd6ece012d557ca7bb959028687c6042448738e868d9dcf867",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:49021", "10.65.0.27:49021", "172.17.0.1:49021"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:49:36.8665194Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8050969568316525,
+				"StableID":   "nNu7WUKJs521CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6fa5c30759b4d3ff3b02427c62682e4aa9bda97510e7fd3a802eeaf4a625319",
+				"DiscoKey":   "discokey:8a77ac47b80f9e87df5c52906964c0be000b057b79069ceadd44172ce37e9259",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:59392", "10.65.0.27:59392", "172.17.0.1:59392"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:49:37.404736658Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2047301492658962,
+				"StableID":   "nKdbF39EzG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c8ab8298a8c53249d893915d6260b0d91de912089d2ead41087a741205883152",
+				"DiscoKey":   "discokey:e8e177a2df69fe1b5dfa29fa5814ff582d9396d9969fd5c3f68058b03407f11e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:52876", "10.65.0.27:52876", "172.17.0.1:52876"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:49:37.945678729Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1272909863032316,
+				"StableID":   "nFrpieBWwA11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0f6926538765127c5ba2d553141ecfd02219dc7af00c8553eb67b6d3aed6563",
+				"DiscoKey":   "discokey:4d3874338ebf469845cf0888427635c146194c3123f1e571cf77ed4de12fef45",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:44464", "10.65.0.27:44464", "172.17.0.1:44464"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:49:38.50203138Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         2711502179480840,
+				"StableID":   "nsLsVjZ3BN11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7d9aba483ddbb1f668916472455e84df7cc8f4ce4b6b9d6e38ce34ece126b957",
+				"DiscoKey":   "discokey:d1350bcbcfc40d3dcab4ee2e4a42afa795a47570d48796be69b04e76deb64013",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:41283", "10.65.0.27:41283", "172.17.0.1:41283"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:49:39.045851741Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2957510641661268,
+				"StableID":   "nFUHtnnT6Q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7a531bd87f5a4020e2459ac00cabba5abf26ee9a33564818ab1c012224e17d02",
+				"DiscoKey":   "discokey:67077cb4017129741e4f5a940ff9304bfab77c99e39472119166bd6ff7ed7531",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53301", "10.65.0.27:53301", "172.17.0.1:53301"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:49:39.558897204Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8916411384039549,
+				"StableID":   "naH6CS1GdC21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f825aadbceb6fd7eb4df73e0db44ab533aaef2289a7369b7a9106984daf3ba69",
+				"KeyExpiry":  "2026-11-08T18:49:40Z",
+				"DiscoKey":   "discokey:2f4b97dc0c4c336cc1b859ff79e2c372453e7b6f513d998fe7c72d50aefa9557",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:43652", "10.65.0.27:43652", "172.17.0.1:43652"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:49:40.109443444Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5356533428254481,
+				"StableID":   "nGt8Uu3zpi11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c9071132b543fe089db243b686de85d3232c567222f8a621958b9428f7667441",
+				"KeyExpiry":  "2026-11-08T18:49:41Z",
+				"DiscoKey":   "discokey:26dfb9035dce059a334c0851e4709a1cf9577ba5cf2216a30802074902c47104",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:40254", "10.65.0.27:40254", "172.17.0.1:40254"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:49:41.195401855Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1272909863032316,
+				"StableID":   "nFrpieBWwA11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1272909863032316,
+				"Key":        "nodekey:a0f6926538765127c5ba2d553141ecfd02219dc7af00c8553eb67b6d3aed6563",
+				"DiscoKey":   "discokey:4d3874338ebf469845cf0888427635c146194c3123f1e571cf77ed4de12fef45",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:44464", "10.65.0.27:44464", "172.17.0.1:44464"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:49:38.50203138Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a0f6926538765127c5ba2d553141ecfd02219dc7af00c8553eb67b6d3aed6563",
+			"MachineKey": "mkey:db16e57fefe88af760d8bcf6f8ead9600accbd004b83e7f5c8a82f026ff00575",
+			"Peers": [{
+				"ID":         4036485262546260,
+				"StableID":   "nuHhM9d8XY11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:446da1fb0929ad6eb9a62dd73fe5948ab1b9e705ac639743dad4b133eb912620",
+				"DiscoKey":   "discokey:4f7b74c7ce8597e34f5d6d975ebf7d7b855dd9d94e3397b7f20f6ef8ae09260f",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:33739", "10.65.0.27:33739", "172.17.0.1:33739"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:49:33.468713095Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         2706738658132250,
+				"StableID":   "nuzpRDSt8N11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f372f41160436362c4a299ee8e41e9506c0387c24efd651541eeffef73c6c35",
+				"DiscoKey":   "discokey:83f90746253b5f9c6f5c9891a13aea64b05c4d31be8cd253ad52f22d2bd71414",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:60917", "10.65.0.27:60917", "172.17.0.1:60917"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:49:34.149328077Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1092125780826920,
+				"StableID":   "nT2gSxHdX911CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6c39f2eedb619c1b0cfca72a0af98943b411e27411f52287a2ff4a4ca30f116f",
+				"DiscoKey":   "discokey:3381232415d99b31488996be72d25ed42ba86e4ed316cf60486243510bd0bb39",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:34414", "10.65.0.27:34414", "172.17.0.1:34414"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:49:34.687823155Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4297525523072750,
+				"StableID":   "nMimH5iMZa11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0055db475743b554b76e77b33a4cc05184228f357ae4950122a707ae4d92ff07",
+				"DiscoKey":   "discokey:2ce059328a9a918999b0b75dccc68b5b1fb416db1dd3f3d71bda5396208fa63f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:60972", "10.65.0.27:60972", "172.17.0.1:60972"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:49:35.242672743Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4630694457717876,
+				"StableID":   "nTLJAVVFAd11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:623173f9b609cdb0a87dc28a1ea577bd73f108678e4a60e79c5b1537baf89a1a",
+				"DiscoKey":   "discokey:11571f055222a7e291c244e9ad7da479025faa5e0044bf58b38b79f4877a5118",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:60343", "10.65.0.27:60343", "172.17.0.1:60343"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:49:35.785634417Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4728549180687201,
+				"StableID":   "nJmbwByZvd11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cbf22f012be058dd320ed4dd3267eba26b765c7b0a66d640f391add6b5a7c60e",
+				"DiscoKey":   "discokey:41338c797b5dbe22e272b82b07ffe21f698ec68cb8b212e689fb5e21b76a7b37",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:42284", "10.65.0.27:42284", "172.17.0.1:42284"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:49:36.319517347Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2553292478976651,
+				"StableID":   "n6ec2WfPwL11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:dc30ec8da75be2c53544f640dd3b36d3a8550a7c556388b7ce1b2ae31bcf4f09",
+				"DiscoKey":   "discokey:2f44d09a8d8c58dd6ece012d557ca7bb959028687c6042448738e868d9dcf867",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:49021", "10.65.0.27:49021", "172.17.0.1:49021"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:49:36.8665194Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8050969568316525,
+				"StableID":   "nNu7WUKJs521CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a6fa5c30759b4d3ff3b02427c62682e4aa9bda97510e7fd3a802eeaf4a625319",
+				"DiscoKey":   "discokey:8a77ac47b80f9e87df5c52906964c0be000b057b79069ceadd44172ce37e9259",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:59392", "10.65.0.27:59392", "172.17.0.1:59392"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:49:37.404736658Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2047301492658962,
+				"StableID":   "nKdbF39EzG11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c8ab8298a8c53249d893915d6260b0d91de912089d2ead41087a741205883152",
+				"DiscoKey":   "discokey:e8e177a2df69fe1b5dfa29fa5814ff582d9396d9969fd5c3f68058b03407f11e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:52876", "10.65.0.27:52876", "172.17.0.1:52876"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:49:37.945678729Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2711502179480840,
+				"StableID":   "nsLsVjZ3BN11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7d9aba483ddbb1f668916472455e84df7cc8f4ce4b6b9d6e38ce34ece126b957",
+				"DiscoKey":   "discokey:d1350bcbcfc40d3dcab4ee2e4a42afa795a47570d48796be69b04e76deb64013",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:41283", "10.65.0.27:41283", "172.17.0.1:41283"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:49:39.045851741Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         2957510641661268,
+				"StableID":   "nFUHtnnT6Q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7a531bd87f5a4020e2459ac00cabba5abf26ee9a33564818ab1c012224e17d02",
+				"DiscoKey":   "discokey:67077cb4017129741e4f5a940ff9304bfab77c99e39472119166bd6ff7ed7531",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53301", "10.65.0.27:53301", "172.17.0.1:53301"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:49:39.558897204Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8916411384039549,
+				"StableID":   "naH6CS1GdC21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:f825aadbceb6fd7eb4df73e0db44ab533aaef2289a7369b7a9106984daf3ba69",
+				"KeyExpiry":  "2026-11-08T18:49:40Z",
+				"DiscoKey":   "discokey:2f4b97dc0c4c336cc1b859ff79e2c372453e7b6f513d998fe7c72d50aefa9557",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:43652", "10.65.0.27:43652", "172.17.0.1:43652"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:49:40.109443444Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7970113772317226,
+				"StableID":   "nbwrggNgE521CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:a2e3ec6c6a12b0f31c410c35f38035da919a7a2941aa9798dce42e55804e5a0a",
+				"KeyExpiry":  "2026-11-08T18:49:40Z",
+				"DiscoKey":   "discokey:657222a191639086d196b38b41d06e4c1c6de2c7679f467473b662724b7ff46e",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:41230", "10.65.0.27:41230", "172.17.0.1:41230"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:49:40.642595104Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5356533428254481,
+				"StableID":   "nGt8Uu3zpi11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:c9071132b543fe089db243b686de85d3232c567222f8a621958b9428f7667441",
+				"KeyExpiry":  "2026-11-08T18:49:41Z",
+				"DiscoKey":   "discokey:26dfb9035dce059a334c0851e4709a1cf9577ba5cf2216a30802074902c47104",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:40254", "10.65.0.27:40254", "172.17.0.1:40254"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:49:41.195401855Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1272909863032316": {
+				"ID":          1272909863032316,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/sshtest_results/sshtest-tag-as-src.hujson
+++ b/hscontrol/policy/v2/testdata/sshtest_results/sshtest-tag-as-src.hujson
@@ -1,0 +1,18749 @@
+// sshtest-tag-as-src
+//
+// tag src in rule and test
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T18:50:26Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "sshtest-tag-as-src",
+	"description":    "tag src in rule and test",
+	"category":       "sshtest",
+	"captured_at":    "2026-05-12T18:50:26.451479604Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                     \n  \n                                                           \n{\n\t\"category\":    \"sshtest\",\n\t\"description\": \"tag src in rule and test\",\n\t\"id\":          \"sshtest-tag-as-src\",\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"tag:prod\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"sshTests\": [{\n\t\t\"accept\": [\"root\"],\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    \"tag:prod\"\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/sshtest/sshtest-tag-as-src.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["tag:prod"],
+				"users":  ["root"]
+			}],
+			"sshTests":  [{"accept": ["root"], "dst": ["tag:server"], "src": "tag:prod"}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         416464208629859,
+				"StableID":   "nzW71uocF411CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       416464208629859,
+				"Key":        "nodekey:c7c3dc0221fcb860e72a40893a8f8a40d4c1c4d0aff5ea0762737a861c4a2e63",
+				"DiscoKey":   "discokey:076c6e8f269e32025d8b488ff9cee71cbb8fa8691330b7cceb7625daad3a6e4c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57652", "10.65.0.27:57652", "172.17.0.1:57652"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:50:35.0309695Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c7c3dc0221fcb860e72a40893a8f8a40d4c1c4d0aff5ea0762737a861c4a2e63",
+			"MachineKey": "mkey:8bcbad7df6fbd048c3bf5757559cf9f28a82f04c62f87ffe47f4d18336730213",
+			"Peers": [{
+				"ID":         4848068775639388,
+				"StableID":   "njtkGfYhre11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c2dccf13a166a7b66544f45d03ab772a6f09e2aa81ae2a5c980459746c5a405",
+				"DiscoKey":   "discokey:81e6d4c58a7c272b7b32a802665ceb7f0a9238b0bb856b8421eed511bd3e4c36",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:52285", "10.65.0.27:52285", "172.17.0.1:52285"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:50:29.035878341Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7115789059979959,
+				"StableID":   "nY5dMKikZx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2518b02d135c41e4d1f5fdc81cc8bb7a59b0f15817e6660f10e6192f1248ed60",
+				"DiscoKey":   "discokey:7c0cbbb14eb4b39131cbab93ca2db3269e040fad017de98a21be8d09e58de338",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:40988", "10.65.0.27:40988", "172.17.0.1:40988"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:50:29.587131423Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5129441730058200,
+				"StableID":   "nq5mjhj84h11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5b2b122ab2969a8b0ec7effe2e3830fd92f4f93d4c7011ea34f1480f799c091b",
+				"DiscoKey":   "discokey:99b057ddc616c2274ebb8079e0484ec61e097d292dcc04749c157ecf3edea702",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41267", "10.65.0.27:41267", "172.17.0.1:41267"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:50:30.14063926Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8972801687360610,
+				"StableID":   "nPyNCYHo4D21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0700fd912ade860cd12c2d0b33e8453d1081c2406a1170349708678a9a91ce00",
+				"DiscoKey":   "discokey:782ec6bed5d5ba43364ebdfcec4e659b33958c9d9842972af90507923b6f0d71",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:56471", "10.65.0.27:56471", "172.17.0.1:56471"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:50:30.714012093Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1626766312943096,
+				"StableID":   "n3kZUmPmhD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:60abe045d930e1900b95a6c9c347d4126307a6e3224e1a0bfe37b28151ac9b08",
+				"DiscoKey":   "discokey:6efbfaaaac576d8221f0d418f6b64e89676e84bef7218b58564e6a932f74235a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:40215", "10.65.0.27:40215", "172.17.0.1:40215"],
+				"HomeDERP":   18,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:50:31.229549495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5605597977720546,
+				"StableID":   "nqYip6Znmk11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:69acf5fe1d088dbd42dcd3755a993a4c1b60a6baa889b404d190805197c21b33",
+				"DiscoKey":   "discokey:646b5ca2368ee9420faffa83716d85d340aacc99d04a6d058e431a414253837c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:51426", "10.65.0.27:51426", "172.17.0.1:51426"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:50:31.770150908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2379450406134494,
+				"StableID":   "nsX1MP8faK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:516d92d2b8686dab28c9007a32d56321a1e5b7d7441d7568d4ecbc737cdd5d5c",
+				"DiscoKey":   "discokey:bc476333971dabc88ca2a564b669d3dca3d131da77f67ecad99b9d24f13d0579",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:52883", "10.65.0.27:52883", "172.17.0.1:52883"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:50:32.318514826Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8131526495021484,
+				"StableID":   "nD78GvQnV621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4665af95b54a923290ae72f1f8a0c19654ade55b56db7896ae19184f56787913",
+				"DiscoKey":   "discokey:03bcd8b79257b45e0b6735c2505134cd62faeff756a13a94ddb4bef03e3f976d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:47670", "10.65.0.27:47670", "172.17.0.1:47670"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:50:32.882489646Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         153621018168083,
+				"StableID":   "nJUrK6NaC211CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f07b8d8154e003c310f0697e38d71aa5dc5630a7eac89c86bc0314320858827",
+				"DiscoKey":   "discokey:1826926d01a5869441abec291ee4cc447d4bc629696bcea120aae25cec59ce6f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:43214", "10.65.0.27:43214", "172.17.0.1:43214"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:50:33.402874067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5801362570320204,
+				"StableID":   "nfSNWXxSJn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d79d4010f9f85acb8e8d54c6540cda6b612ddf49ec1fea40a827184250b9ec2a",
+				"DiscoKey":   "discokey:faf0d62bb9057efaf6ec7af6b73db5f0346d0c1ce1fe436a8aba229249907d24",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:37554", "10.65.0.27:37554", "172.17.0.1:37554"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:50:33.955496345Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7824592227270189,
+				"StableID":   "nCxr4emm6421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f8947d9c2c6d64f1a5164163773f0eaa6367c9a179b3dfdfe1a8e10e373d181d",
+				"DiscoKey":   "discokey:b558da10cbd5fed48c3deb733dfac08676a29bdf76f4ae6bbf3015bc3482c87b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43754", "10.65.0.27:43754", "172.17.0.1:43754"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:50:34.498437307Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         7793136910147660,
+				"StableID":   "nVDZQXVXr321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:c80de0dd4c81b6caeea593ad21f448eb7db8780eaed2978a4b916b53ee512e4b",
+				"KeyExpiry":  "2026-11-08T18:50:35Z",
+				"DiscoKey":   "discokey:a91666c0d3665bf6efaf48bc015d030b2981f027b336ca28ae1ff11c2b0c7b29",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:41480", "10.65.0.27:41480", "172.17.0.1:41480"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:50:35.570372163Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7768060240312028,
+				"StableID":   "n59uxfmAf321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:448e7f5c681a0539e0aa7c0db736a07e0ea5e2f2094a875e08215258e04c8c4d",
+				"KeyExpiry":  "2026-11-08T18:50:36Z",
+				"DiscoKey":   "discokey:01f07f0ff1e5ee52eb61273316a52c40f3f4641cc48521d8ee48fe50d190054b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:60152", "10.65.0.27:60152", "172.17.0.1:60152"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:50:36.133805253Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8950596656120624,
+				"StableID":   "njz8dozjtC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ae1be9cb1c92be412a4259af291e9344324b1d4b049190a94aedea158198cc48",
+				"KeyExpiry":  "2026-11-08T18:50:36Z",
+				"DiscoKey":   "discokey:a620f71db99c7043750d0e588b28c9a67ae2038960fb219cc1ddec2a34039a73",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:54343", "10.65.0.27:54343", "172.17.0.1:54343"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:50:36.665566368Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{
+				"principals": [{"nodeIP": "100.64.0.15"}, {"nodeIP": "fd7a:115c:a1e0::f"}],
+				"sshUsers":   {"root": "root"},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				}
+			}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "416464208629859": {
+				"ID":          416464208629859,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		},
+		"ssh_rules": [{
+			"principals": [{"nodeIP": "100.64.0.15"}, {"nodeIP": "fd7a:115c:a1e0::f"}],
+			"sshUsers":   {"root": "root"},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}
+		}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5605597977720546,
+				"StableID":   "nqYip6Znmk11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       5605597977720546,
+				"Key":        "nodekey:69acf5fe1d088dbd42dcd3755a993a4c1b60a6baa889b404d190805197c21b33",
+				"DiscoKey":   "discokey:646b5ca2368ee9420faffa83716d85d340aacc99d04a6d058e431a414253837c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:51426", "10.65.0.27:51426", "172.17.0.1:51426"],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:50:31.770150908Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:69acf5fe1d088dbd42dcd3755a993a4c1b60a6baa889b404d190805197c21b33",
+			"MachineKey": "mkey:7a578b399c6c847f40f2931ff5134222b411121ea653c9c12d604d12ee4b2917",
+			"Peers": [{
+				"ID":         4848068775639388,
+				"StableID":   "njtkGfYhre11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c2dccf13a166a7b66544f45d03ab772a6f09e2aa81ae2a5c980459746c5a405",
+				"DiscoKey":   "discokey:81e6d4c58a7c272b7b32a802665ceb7f0a9238b0bb856b8421eed511bd3e4c36",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:52285", "10.65.0.27:52285", "172.17.0.1:52285"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:50:29.035878341Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7115789059979959,
+				"StableID":   "nY5dMKikZx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2518b02d135c41e4d1f5fdc81cc8bb7a59b0f15817e6660f10e6192f1248ed60",
+				"DiscoKey":   "discokey:7c0cbbb14eb4b39131cbab93ca2db3269e040fad017de98a21be8d09e58de338",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:40988", "10.65.0.27:40988", "172.17.0.1:40988"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:50:29.587131423Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5129441730058200,
+				"StableID":   "nq5mjhj84h11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5b2b122ab2969a8b0ec7effe2e3830fd92f4f93d4c7011ea34f1480f799c091b",
+				"DiscoKey":   "discokey:99b057ddc616c2274ebb8079e0484ec61e097d292dcc04749c157ecf3edea702",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41267", "10.65.0.27:41267", "172.17.0.1:41267"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:50:30.14063926Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8972801687360610,
+				"StableID":   "nPyNCYHo4D21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0700fd912ade860cd12c2d0b33e8453d1081c2406a1170349708678a9a91ce00",
+				"DiscoKey":   "discokey:782ec6bed5d5ba43364ebdfcec4e659b33958c9d9842972af90507923b6f0d71",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:56471", "10.65.0.27:56471", "172.17.0.1:56471"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:50:30.714012093Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1626766312943096,
+				"StableID":   "n3kZUmPmhD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:60abe045d930e1900b95a6c9c347d4126307a6e3224e1a0bfe37b28151ac9b08",
+				"DiscoKey":   "discokey:6efbfaaaac576d8221f0d418f6b64e89676e84bef7218b58564e6a932f74235a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:40215", "10.65.0.27:40215", "172.17.0.1:40215"],
+				"HomeDERP":   18,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:50:31.229549495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2379450406134494,
+				"StableID":   "nsX1MP8faK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:516d92d2b8686dab28c9007a32d56321a1e5b7d7441d7568d4ecbc737cdd5d5c",
+				"DiscoKey":   "discokey:bc476333971dabc88ca2a564b669d3dca3d131da77f67ecad99b9d24f13d0579",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:52883", "10.65.0.27:52883", "172.17.0.1:52883"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:50:32.318514826Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8131526495021484,
+				"StableID":   "nD78GvQnV621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4665af95b54a923290ae72f1f8a0c19654ade55b56db7896ae19184f56787913",
+				"DiscoKey":   "discokey:03bcd8b79257b45e0b6735c2505134cd62faeff756a13a94ddb4bef03e3f976d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:47670", "10.65.0.27:47670", "172.17.0.1:47670"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:50:32.882489646Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         153621018168083,
+				"StableID":   "nJUrK6NaC211CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f07b8d8154e003c310f0697e38d71aa5dc5630a7eac89c86bc0314320858827",
+				"DiscoKey":   "discokey:1826926d01a5869441abec291ee4cc447d4bc629696bcea120aae25cec59ce6f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:43214", "10.65.0.27:43214", "172.17.0.1:43214"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:50:33.402874067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5801362570320204,
+				"StableID":   "nfSNWXxSJn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d79d4010f9f85acb8e8d54c6540cda6b612ddf49ec1fea40a827184250b9ec2a",
+				"DiscoKey":   "discokey:faf0d62bb9057efaf6ec7af6b73db5f0346d0c1ce1fe436a8aba229249907d24",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:37554", "10.65.0.27:37554", "172.17.0.1:37554"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:50:33.955496345Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7824592227270189,
+				"StableID":   "nCxr4emm6421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f8947d9c2c6d64f1a5164163773f0eaa6367c9a179b3dfdfe1a8e10e373d181d",
+				"DiscoKey":   "discokey:b558da10cbd5fed48c3deb733dfac08676a29bdf76f4ae6bbf3015bc3482c87b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43754", "10.65.0.27:43754", "172.17.0.1:43754"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:50:34.498437307Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         416464208629859,
+				"StableID":   "nzW71uocF411CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c7c3dc0221fcb860e72a40893a8f8a40d4c1c4d0aff5ea0762737a861c4a2e63",
+				"DiscoKey":   "discokey:076c6e8f269e32025d8b488ff9cee71cbb8fa8691330b7cceb7625daad3a6e4c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57652", "10.65.0.27:57652", "172.17.0.1:57652"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:50:35.0309695Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7793136910147660,
+				"StableID":   "nVDZQXVXr321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:c80de0dd4c81b6caeea593ad21f448eb7db8780eaed2978a4b916b53ee512e4b",
+				"KeyExpiry":  "2026-11-08T18:50:35Z",
+				"DiscoKey":   "discokey:a91666c0d3665bf6efaf48bc015d030b2981f027b336ca28ae1ff11c2b0c7b29",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:41480", "10.65.0.27:41480", "172.17.0.1:41480"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:50:35.570372163Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7768060240312028,
+				"StableID":   "n59uxfmAf321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:448e7f5c681a0539e0aa7c0db736a07e0ea5e2f2094a875e08215258e04c8c4d",
+				"KeyExpiry":  "2026-11-08T18:50:36Z",
+				"DiscoKey":   "discokey:01f07f0ff1e5ee52eb61273316a52c40f3f4641cc48521d8ee48fe50d190054b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:60152", "10.65.0.27:60152", "172.17.0.1:60152"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:50:36.133805253Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8950596656120624,
+				"StableID":   "njz8dozjtC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ae1be9cb1c92be412a4259af291e9344324b1d4b049190a94aedea158198cc48",
+				"KeyExpiry":  "2026-11-08T18:50:36Z",
+				"DiscoKey":   "discokey:a620f71db99c7043750d0e588b28c9a67ae2038960fb219cc1ddec2a34039a73",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:54343", "10.65.0.27:54343", "172.17.0.1:54343"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:50:36.665566368Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5605597977720546": {
+				"ID":          5605597977720546,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8950596656120624,
+				"StableID":   "njz8dozjtC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ae1be9cb1c92be412a4259af291e9344324b1d4b049190a94aedea158198cc48",
+				"KeyExpiry":  "2026-11-08T18:50:36Z",
+				"DiscoKey":   "discokey:a620f71db99c7043750d0e588b28c9a67ae2038960fb219cc1ddec2a34039a73",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:54343", "10.65.0.27:54343", "172.17.0.1:54343"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:50:36.665566368Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ae1be9cb1c92be412a4259af291e9344324b1d4b049190a94aedea158198cc48",
+			"MachineKey": "mkey:3be6427e575ea28163180283ebf0bb39d58317e5364d32da0684e08ff1164769",
+			"Peers": [{
+				"ID":         4848068775639388,
+				"StableID":   "njtkGfYhre11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c2dccf13a166a7b66544f45d03ab772a6f09e2aa81ae2a5c980459746c5a405",
+				"DiscoKey":   "discokey:81e6d4c58a7c272b7b32a802665ceb7f0a9238b0bb856b8421eed511bd3e4c36",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:52285", "10.65.0.27:52285", "172.17.0.1:52285"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:50:29.035878341Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7115789059979959,
+				"StableID":   "nY5dMKikZx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2518b02d135c41e4d1f5fdc81cc8bb7a59b0f15817e6660f10e6192f1248ed60",
+				"DiscoKey":   "discokey:7c0cbbb14eb4b39131cbab93ca2db3269e040fad017de98a21be8d09e58de338",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:40988", "10.65.0.27:40988", "172.17.0.1:40988"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:50:29.587131423Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5129441730058200,
+				"StableID":   "nq5mjhj84h11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5b2b122ab2969a8b0ec7effe2e3830fd92f4f93d4c7011ea34f1480f799c091b",
+				"DiscoKey":   "discokey:99b057ddc616c2274ebb8079e0484ec61e097d292dcc04749c157ecf3edea702",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41267", "10.65.0.27:41267", "172.17.0.1:41267"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:50:30.14063926Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8972801687360610,
+				"StableID":   "nPyNCYHo4D21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0700fd912ade860cd12c2d0b33e8453d1081c2406a1170349708678a9a91ce00",
+				"DiscoKey":   "discokey:782ec6bed5d5ba43364ebdfcec4e659b33958c9d9842972af90507923b6f0d71",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:56471", "10.65.0.27:56471", "172.17.0.1:56471"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:50:30.714012093Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1626766312943096,
+				"StableID":   "n3kZUmPmhD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:60abe045d930e1900b95a6c9c347d4126307a6e3224e1a0bfe37b28151ac9b08",
+				"DiscoKey":   "discokey:6efbfaaaac576d8221f0d418f6b64e89676e84bef7218b58564e6a932f74235a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:40215", "10.65.0.27:40215", "172.17.0.1:40215"],
+				"HomeDERP":   18,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:50:31.229549495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5605597977720546,
+				"StableID":   "nqYip6Znmk11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:69acf5fe1d088dbd42dcd3755a993a4c1b60a6baa889b404d190805197c21b33",
+				"DiscoKey":   "discokey:646b5ca2368ee9420faffa83716d85d340aacc99d04a6d058e431a414253837c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:51426", "10.65.0.27:51426", "172.17.0.1:51426"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:50:31.770150908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2379450406134494,
+				"StableID":   "nsX1MP8faK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:516d92d2b8686dab28c9007a32d56321a1e5b7d7441d7568d4ecbc737cdd5d5c",
+				"DiscoKey":   "discokey:bc476333971dabc88ca2a564b669d3dca3d131da77f67ecad99b9d24f13d0579",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:52883", "10.65.0.27:52883", "172.17.0.1:52883"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:50:32.318514826Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8131526495021484,
+				"StableID":   "nD78GvQnV621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4665af95b54a923290ae72f1f8a0c19654ade55b56db7896ae19184f56787913",
+				"DiscoKey":   "discokey:03bcd8b79257b45e0b6735c2505134cd62faeff756a13a94ddb4bef03e3f976d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:47670", "10.65.0.27:47670", "172.17.0.1:47670"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:50:32.882489646Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         153621018168083,
+				"StableID":   "nJUrK6NaC211CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f07b8d8154e003c310f0697e38d71aa5dc5630a7eac89c86bc0314320858827",
+				"DiscoKey":   "discokey:1826926d01a5869441abec291ee4cc447d4bc629696bcea120aae25cec59ce6f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:43214", "10.65.0.27:43214", "172.17.0.1:43214"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:50:33.402874067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5801362570320204,
+				"StableID":   "nfSNWXxSJn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d79d4010f9f85acb8e8d54c6540cda6b612ddf49ec1fea40a827184250b9ec2a",
+				"DiscoKey":   "discokey:faf0d62bb9057efaf6ec7af6b73db5f0346d0c1ce1fe436a8aba229249907d24",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:37554", "10.65.0.27:37554", "172.17.0.1:37554"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:50:33.955496345Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7824592227270189,
+				"StableID":   "nCxr4emm6421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f8947d9c2c6d64f1a5164163773f0eaa6367c9a179b3dfdfe1a8e10e373d181d",
+				"DiscoKey":   "discokey:b558da10cbd5fed48c3deb733dfac08676a29bdf76f4ae6bbf3015bc3482c87b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43754", "10.65.0.27:43754", "172.17.0.1:43754"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:50:34.498437307Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         416464208629859,
+				"StableID":   "nzW71uocF411CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c7c3dc0221fcb860e72a40893a8f8a40d4c1c4d0aff5ea0762737a861c4a2e63",
+				"DiscoKey":   "discokey:076c6e8f269e32025d8b488ff9cee71cbb8fa8691330b7cceb7625daad3a6e4c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57652", "10.65.0.27:57652", "172.17.0.1:57652"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:50:35.0309695Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7793136910147660,
+				"StableID":   "nVDZQXVXr321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:c80de0dd4c81b6caeea593ad21f448eb7db8780eaed2978a4b916b53ee512e4b",
+				"KeyExpiry":  "2026-11-08T18:50:35Z",
+				"DiscoKey":   "discokey:a91666c0d3665bf6efaf48bc015d030b2981f027b336ca28ae1ff11c2b0c7b29",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:41480", "10.65.0.27:41480", "172.17.0.1:41480"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:50:35.570372163Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7768060240312028,
+				"StableID":   "n59uxfmAf321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:448e7f5c681a0539e0aa7c0db736a07e0ea5e2f2094a875e08215258e04c8c4d",
+				"KeyExpiry":  "2026-11-08T18:50:36Z",
+				"DiscoKey":   "discokey:01f07f0ff1e5ee52eb61273316a52c40f3f4641cc48521d8ee48fe50d190054b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:60152", "10.65.0.27:60152", "172.17.0.1:60152"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:50:36.133805253Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5129441730058200,
+				"StableID":   "nq5mjhj84h11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       5129441730058200,
+				"Key":        "nodekey:5b2b122ab2969a8b0ec7effe2e3830fd92f4f93d4c7011ea34f1480f799c091b",
+				"DiscoKey":   "discokey:99b057ddc616c2274ebb8079e0484ec61e097d292dcc04749c157ecf3edea702",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41267", "10.65.0.27:41267", "172.17.0.1:41267"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:50:30.14063926Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5b2b122ab2969a8b0ec7effe2e3830fd92f4f93d4c7011ea34f1480f799c091b",
+			"MachineKey": "mkey:0f1c24f493541911665ba13609043efbd088889fd0f12b383f9742b37f491103",
+			"Peers": [{
+				"ID":         4848068775639388,
+				"StableID":   "njtkGfYhre11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c2dccf13a166a7b66544f45d03ab772a6f09e2aa81ae2a5c980459746c5a405",
+				"DiscoKey":   "discokey:81e6d4c58a7c272b7b32a802665ceb7f0a9238b0bb856b8421eed511bd3e4c36",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:52285", "10.65.0.27:52285", "172.17.0.1:52285"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:50:29.035878341Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7115789059979959,
+				"StableID":   "nY5dMKikZx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2518b02d135c41e4d1f5fdc81cc8bb7a59b0f15817e6660f10e6192f1248ed60",
+				"DiscoKey":   "discokey:7c0cbbb14eb4b39131cbab93ca2db3269e040fad017de98a21be8d09e58de338",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:40988", "10.65.0.27:40988", "172.17.0.1:40988"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:50:29.587131423Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8972801687360610,
+				"StableID":   "nPyNCYHo4D21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0700fd912ade860cd12c2d0b33e8453d1081c2406a1170349708678a9a91ce00",
+				"DiscoKey":   "discokey:782ec6bed5d5ba43364ebdfcec4e659b33958c9d9842972af90507923b6f0d71",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:56471", "10.65.0.27:56471", "172.17.0.1:56471"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:50:30.714012093Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1626766312943096,
+				"StableID":   "n3kZUmPmhD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:60abe045d930e1900b95a6c9c347d4126307a6e3224e1a0bfe37b28151ac9b08",
+				"DiscoKey":   "discokey:6efbfaaaac576d8221f0d418f6b64e89676e84bef7218b58564e6a932f74235a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:40215", "10.65.0.27:40215", "172.17.0.1:40215"],
+				"HomeDERP":   18,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:50:31.229549495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5605597977720546,
+				"StableID":   "nqYip6Znmk11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:69acf5fe1d088dbd42dcd3755a993a4c1b60a6baa889b404d190805197c21b33",
+				"DiscoKey":   "discokey:646b5ca2368ee9420faffa83716d85d340aacc99d04a6d058e431a414253837c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:51426", "10.65.0.27:51426", "172.17.0.1:51426"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:50:31.770150908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2379450406134494,
+				"StableID":   "nsX1MP8faK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:516d92d2b8686dab28c9007a32d56321a1e5b7d7441d7568d4ecbc737cdd5d5c",
+				"DiscoKey":   "discokey:bc476333971dabc88ca2a564b669d3dca3d131da77f67ecad99b9d24f13d0579",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:52883", "10.65.0.27:52883", "172.17.0.1:52883"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:50:32.318514826Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8131526495021484,
+				"StableID":   "nD78GvQnV621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4665af95b54a923290ae72f1f8a0c19654ade55b56db7896ae19184f56787913",
+				"DiscoKey":   "discokey:03bcd8b79257b45e0b6735c2505134cd62faeff756a13a94ddb4bef03e3f976d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:47670", "10.65.0.27:47670", "172.17.0.1:47670"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:50:32.882489646Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         153621018168083,
+				"StableID":   "nJUrK6NaC211CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f07b8d8154e003c310f0697e38d71aa5dc5630a7eac89c86bc0314320858827",
+				"DiscoKey":   "discokey:1826926d01a5869441abec291ee4cc447d4bc629696bcea120aae25cec59ce6f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:43214", "10.65.0.27:43214", "172.17.0.1:43214"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:50:33.402874067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5801362570320204,
+				"StableID":   "nfSNWXxSJn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d79d4010f9f85acb8e8d54c6540cda6b612ddf49ec1fea40a827184250b9ec2a",
+				"DiscoKey":   "discokey:faf0d62bb9057efaf6ec7af6b73db5f0346d0c1ce1fe436a8aba229249907d24",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:37554", "10.65.0.27:37554", "172.17.0.1:37554"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:50:33.955496345Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7824592227270189,
+				"StableID":   "nCxr4emm6421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f8947d9c2c6d64f1a5164163773f0eaa6367c9a179b3dfdfe1a8e10e373d181d",
+				"DiscoKey":   "discokey:b558da10cbd5fed48c3deb733dfac08676a29bdf76f4ae6bbf3015bc3482c87b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43754", "10.65.0.27:43754", "172.17.0.1:43754"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:50:34.498437307Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         416464208629859,
+				"StableID":   "nzW71uocF411CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c7c3dc0221fcb860e72a40893a8f8a40d4c1c4d0aff5ea0762737a861c4a2e63",
+				"DiscoKey":   "discokey:076c6e8f269e32025d8b488ff9cee71cbb8fa8691330b7cceb7625daad3a6e4c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57652", "10.65.0.27:57652", "172.17.0.1:57652"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:50:35.0309695Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7793136910147660,
+				"StableID":   "nVDZQXVXr321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:c80de0dd4c81b6caeea593ad21f448eb7db8780eaed2978a4b916b53ee512e4b",
+				"KeyExpiry":  "2026-11-08T18:50:35Z",
+				"DiscoKey":   "discokey:a91666c0d3665bf6efaf48bc015d030b2981f027b336ca28ae1ff11c2b0c7b29",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:41480", "10.65.0.27:41480", "172.17.0.1:41480"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:50:35.570372163Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7768060240312028,
+				"StableID":   "n59uxfmAf321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:448e7f5c681a0539e0aa7c0db736a07e0ea5e2f2094a875e08215258e04c8c4d",
+				"KeyExpiry":  "2026-11-08T18:50:36Z",
+				"DiscoKey":   "discokey:01f07f0ff1e5ee52eb61273316a52c40f3f4641cc48521d8ee48fe50d190054b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:60152", "10.65.0.27:60152", "172.17.0.1:60152"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:50:36.133805253Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8950596656120624,
+				"StableID":   "njz8dozjtC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ae1be9cb1c92be412a4259af291e9344324b1d4b049190a94aedea158198cc48",
+				"KeyExpiry":  "2026-11-08T18:50:36Z",
+				"DiscoKey":   "discokey:a620f71db99c7043750d0e588b28c9a67ae2038960fb219cc1ddec2a34039a73",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:54343", "10.65.0.27:54343", "172.17.0.1:54343"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:50:36.665566368Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5129441730058200": {
+				"ID":          5129441730058200,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8131526495021484,
+				"StableID":   "nD78GvQnV621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       8131526495021484,
+				"Key":        "nodekey:4665af95b54a923290ae72f1f8a0c19654ade55b56db7896ae19184f56787913",
+				"DiscoKey":   "discokey:03bcd8b79257b45e0b6735c2505134cd62faeff756a13a94ddb4bef03e3f976d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:47670", "10.65.0.27:47670", "172.17.0.1:47670"],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:50:32.882489646Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4665af95b54a923290ae72f1f8a0c19654ade55b56db7896ae19184f56787913",
+			"MachineKey": "mkey:1219aba0833bfb5a490ac66064748c2e7b7885797609148fc3783c7a4e059701",
+			"Peers": [{
+				"ID":         4848068775639388,
+				"StableID":   "njtkGfYhre11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c2dccf13a166a7b66544f45d03ab772a6f09e2aa81ae2a5c980459746c5a405",
+				"DiscoKey":   "discokey:81e6d4c58a7c272b7b32a802665ceb7f0a9238b0bb856b8421eed511bd3e4c36",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:52285", "10.65.0.27:52285", "172.17.0.1:52285"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:50:29.035878341Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7115789059979959,
+				"StableID":   "nY5dMKikZx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2518b02d135c41e4d1f5fdc81cc8bb7a59b0f15817e6660f10e6192f1248ed60",
+				"DiscoKey":   "discokey:7c0cbbb14eb4b39131cbab93ca2db3269e040fad017de98a21be8d09e58de338",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:40988", "10.65.0.27:40988", "172.17.0.1:40988"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:50:29.587131423Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5129441730058200,
+				"StableID":   "nq5mjhj84h11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5b2b122ab2969a8b0ec7effe2e3830fd92f4f93d4c7011ea34f1480f799c091b",
+				"DiscoKey":   "discokey:99b057ddc616c2274ebb8079e0484ec61e097d292dcc04749c157ecf3edea702",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41267", "10.65.0.27:41267", "172.17.0.1:41267"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:50:30.14063926Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8972801687360610,
+				"StableID":   "nPyNCYHo4D21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0700fd912ade860cd12c2d0b33e8453d1081c2406a1170349708678a9a91ce00",
+				"DiscoKey":   "discokey:782ec6bed5d5ba43364ebdfcec4e659b33958c9d9842972af90507923b6f0d71",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:56471", "10.65.0.27:56471", "172.17.0.1:56471"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:50:30.714012093Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1626766312943096,
+				"StableID":   "n3kZUmPmhD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:60abe045d930e1900b95a6c9c347d4126307a6e3224e1a0bfe37b28151ac9b08",
+				"DiscoKey":   "discokey:6efbfaaaac576d8221f0d418f6b64e89676e84bef7218b58564e6a932f74235a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:40215", "10.65.0.27:40215", "172.17.0.1:40215"],
+				"HomeDERP":   18,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:50:31.229549495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5605597977720546,
+				"StableID":   "nqYip6Znmk11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:69acf5fe1d088dbd42dcd3755a993a4c1b60a6baa889b404d190805197c21b33",
+				"DiscoKey":   "discokey:646b5ca2368ee9420faffa83716d85d340aacc99d04a6d058e431a414253837c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:51426", "10.65.0.27:51426", "172.17.0.1:51426"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:50:31.770150908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2379450406134494,
+				"StableID":   "nsX1MP8faK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:516d92d2b8686dab28c9007a32d56321a1e5b7d7441d7568d4ecbc737cdd5d5c",
+				"DiscoKey":   "discokey:bc476333971dabc88ca2a564b669d3dca3d131da77f67ecad99b9d24f13d0579",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:52883", "10.65.0.27:52883", "172.17.0.1:52883"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:50:32.318514826Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         153621018168083,
+				"StableID":   "nJUrK6NaC211CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f07b8d8154e003c310f0697e38d71aa5dc5630a7eac89c86bc0314320858827",
+				"DiscoKey":   "discokey:1826926d01a5869441abec291ee4cc447d4bc629696bcea120aae25cec59ce6f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:43214", "10.65.0.27:43214", "172.17.0.1:43214"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:50:33.402874067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5801362570320204,
+				"StableID":   "nfSNWXxSJn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d79d4010f9f85acb8e8d54c6540cda6b612ddf49ec1fea40a827184250b9ec2a",
+				"DiscoKey":   "discokey:faf0d62bb9057efaf6ec7af6b73db5f0346d0c1ce1fe436a8aba229249907d24",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:37554", "10.65.0.27:37554", "172.17.0.1:37554"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:50:33.955496345Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7824592227270189,
+				"StableID":   "nCxr4emm6421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f8947d9c2c6d64f1a5164163773f0eaa6367c9a179b3dfdfe1a8e10e373d181d",
+				"DiscoKey":   "discokey:b558da10cbd5fed48c3deb733dfac08676a29bdf76f4ae6bbf3015bc3482c87b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43754", "10.65.0.27:43754", "172.17.0.1:43754"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:50:34.498437307Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         416464208629859,
+				"StableID":   "nzW71uocF411CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c7c3dc0221fcb860e72a40893a8f8a40d4c1c4d0aff5ea0762737a861c4a2e63",
+				"DiscoKey":   "discokey:076c6e8f269e32025d8b488ff9cee71cbb8fa8691330b7cceb7625daad3a6e4c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57652", "10.65.0.27:57652", "172.17.0.1:57652"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:50:35.0309695Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7793136910147660,
+				"StableID":   "nVDZQXVXr321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:c80de0dd4c81b6caeea593ad21f448eb7db8780eaed2978a4b916b53ee512e4b",
+				"KeyExpiry":  "2026-11-08T18:50:35Z",
+				"DiscoKey":   "discokey:a91666c0d3665bf6efaf48bc015d030b2981f027b336ca28ae1ff11c2b0c7b29",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:41480", "10.65.0.27:41480", "172.17.0.1:41480"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:50:35.570372163Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7768060240312028,
+				"StableID":   "n59uxfmAf321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:448e7f5c681a0539e0aa7c0db736a07e0ea5e2f2094a875e08215258e04c8c4d",
+				"KeyExpiry":  "2026-11-08T18:50:36Z",
+				"DiscoKey":   "discokey:01f07f0ff1e5ee52eb61273316a52c40f3f4641cc48521d8ee48fe50d190054b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:60152", "10.65.0.27:60152", "172.17.0.1:60152"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:50:36.133805253Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8950596656120624,
+				"StableID":   "njz8dozjtC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ae1be9cb1c92be412a4259af291e9344324b1d4b049190a94aedea158198cc48",
+				"KeyExpiry":  "2026-11-08T18:50:36Z",
+				"DiscoKey":   "discokey:a620f71db99c7043750d0e588b28c9a67ae2038960fb219cc1ddec2a34039a73",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:54343", "10.65.0.27:54343", "172.17.0.1:54343"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:50:36.665566368Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8131526495021484": {
+				"ID":          8131526495021484,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7793136910147660,
+				"StableID":   "nVDZQXVXr321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:c80de0dd4c81b6caeea593ad21f448eb7db8780eaed2978a4b916b53ee512e4b",
+				"KeyExpiry":  "2026-11-08T18:50:35Z",
+				"DiscoKey":   "discokey:a91666c0d3665bf6efaf48bc015d030b2981f027b336ca28ae1ff11c2b0c7b29",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:41480", "10.65.0.27:41480", "172.17.0.1:41480"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:50:35.570372163Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c80de0dd4c81b6caeea593ad21f448eb7db8780eaed2978a4b916b53ee512e4b",
+			"MachineKey": "mkey:01757fc2ab7a1686176d06cc0ac6bce7734f37673bf7b6fb86f4cf251f2ed266",
+			"Peers": [{
+				"ID":         4848068775639388,
+				"StableID":   "njtkGfYhre11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c2dccf13a166a7b66544f45d03ab772a6f09e2aa81ae2a5c980459746c5a405",
+				"DiscoKey":   "discokey:81e6d4c58a7c272b7b32a802665ceb7f0a9238b0bb856b8421eed511bd3e4c36",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:52285", "10.65.0.27:52285", "172.17.0.1:52285"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:50:29.035878341Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7115789059979959,
+				"StableID":   "nY5dMKikZx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2518b02d135c41e4d1f5fdc81cc8bb7a59b0f15817e6660f10e6192f1248ed60",
+				"DiscoKey":   "discokey:7c0cbbb14eb4b39131cbab93ca2db3269e040fad017de98a21be8d09e58de338",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:40988", "10.65.0.27:40988", "172.17.0.1:40988"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:50:29.587131423Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5129441730058200,
+				"StableID":   "nq5mjhj84h11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5b2b122ab2969a8b0ec7effe2e3830fd92f4f93d4c7011ea34f1480f799c091b",
+				"DiscoKey":   "discokey:99b057ddc616c2274ebb8079e0484ec61e097d292dcc04749c157ecf3edea702",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41267", "10.65.0.27:41267", "172.17.0.1:41267"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:50:30.14063926Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8972801687360610,
+				"StableID":   "nPyNCYHo4D21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0700fd912ade860cd12c2d0b33e8453d1081c2406a1170349708678a9a91ce00",
+				"DiscoKey":   "discokey:782ec6bed5d5ba43364ebdfcec4e659b33958c9d9842972af90507923b6f0d71",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:56471", "10.65.0.27:56471", "172.17.0.1:56471"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:50:30.714012093Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1626766312943096,
+				"StableID":   "n3kZUmPmhD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:60abe045d930e1900b95a6c9c347d4126307a6e3224e1a0bfe37b28151ac9b08",
+				"DiscoKey":   "discokey:6efbfaaaac576d8221f0d418f6b64e89676e84bef7218b58564e6a932f74235a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:40215", "10.65.0.27:40215", "172.17.0.1:40215"],
+				"HomeDERP":   18,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:50:31.229549495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5605597977720546,
+				"StableID":   "nqYip6Znmk11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:69acf5fe1d088dbd42dcd3755a993a4c1b60a6baa889b404d190805197c21b33",
+				"DiscoKey":   "discokey:646b5ca2368ee9420faffa83716d85d340aacc99d04a6d058e431a414253837c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:51426", "10.65.0.27:51426", "172.17.0.1:51426"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:50:31.770150908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2379450406134494,
+				"StableID":   "nsX1MP8faK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:516d92d2b8686dab28c9007a32d56321a1e5b7d7441d7568d4ecbc737cdd5d5c",
+				"DiscoKey":   "discokey:bc476333971dabc88ca2a564b669d3dca3d131da77f67ecad99b9d24f13d0579",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:52883", "10.65.0.27:52883", "172.17.0.1:52883"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:50:32.318514826Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8131526495021484,
+				"StableID":   "nD78GvQnV621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4665af95b54a923290ae72f1f8a0c19654ade55b56db7896ae19184f56787913",
+				"DiscoKey":   "discokey:03bcd8b79257b45e0b6735c2505134cd62faeff756a13a94ddb4bef03e3f976d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:47670", "10.65.0.27:47670", "172.17.0.1:47670"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:50:32.882489646Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         153621018168083,
+				"StableID":   "nJUrK6NaC211CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f07b8d8154e003c310f0697e38d71aa5dc5630a7eac89c86bc0314320858827",
+				"DiscoKey":   "discokey:1826926d01a5869441abec291ee4cc447d4bc629696bcea120aae25cec59ce6f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:43214", "10.65.0.27:43214", "172.17.0.1:43214"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:50:33.402874067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5801362570320204,
+				"StableID":   "nfSNWXxSJn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d79d4010f9f85acb8e8d54c6540cda6b612ddf49ec1fea40a827184250b9ec2a",
+				"DiscoKey":   "discokey:faf0d62bb9057efaf6ec7af6b73db5f0346d0c1ce1fe436a8aba229249907d24",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:37554", "10.65.0.27:37554", "172.17.0.1:37554"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:50:33.955496345Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7824592227270189,
+				"StableID":   "nCxr4emm6421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f8947d9c2c6d64f1a5164163773f0eaa6367c9a179b3dfdfe1a8e10e373d181d",
+				"DiscoKey":   "discokey:b558da10cbd5fed48c3deb733dfac08676a29bdf76f4ae6bbf3015bc3482c87b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43754", "10.65.0.27:43754", "172.17.0.1:43754"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:50:34.498437307Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         416464208629859,
+				"StableID":   "nzW71uocF411CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c7c3dc0221fcb860e72a40893a8f8a40d4c1c4d0aff5ea0762737a861c4a2e63",
+				"DiscoKey":   "discokey:076c6e8f269e32025d8b488ff9cee71cbb8fa8691330b7cceb7625daad3a6e4c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57652", "10.65.0.27:57652", "172.17.0.1:57652"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:50:35.0309695Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7768060240312028,
+				"StableID":   "n59uxfmAf321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:448e7f5c681a0539e0aa7c0db736a07e0ea5e2f2094a875e08215258e04c8c4d",
+				"KeyExpiry":  "2026-11-08T18:50:36Z",
+				"DiscoKey":   "discokey:01f07f0ff1e5ee52eb61273316a52c40f3f4641cc48521d8ee48fe50d190054b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:60152", "10.65.0.27:60152", "172.17.0.1:60152"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:50:36.133805253Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8950596656120624,
+				"StableID":   "njz8dozjtC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ae1be9cb1c92be412a4259af291e9344324b1d4b049190a94aedea158198cc48",
+				"KeyExpiry":  "2026-11-08T18:50:36Z",
+				"DiscoKey":   "discokey:a620f71db99c7043750d0e588b28c9a67ae2038960fb219cc1ddec2a34039a73",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:54343", "10.65.0.27:54343", "172.17.0.1:54343"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:50:36.665566368Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7824592227270189,
+				"StableID":   "nCxr4emm6421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       7824592227270189,
+				"Key":        "nodekey:f8947d9c2c6d64f1a5164163773f0eaa6367c9a179b3dfdfe1a8e10e373d181d",
+				"DiscoKey":   "discokey:b558da10cbd5fed48c3deb733dfac08676a29bdf76f4ae6bbf3015bc3482c87b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43754", "10.65.0.27:43754", "172.17.0.1:43754"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:50:34.498437307Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f8947d9c2c6d64f1a5164163773f0eaa6367c9a179b3dfdfe1a8e10e373d181d",
+			"MachineKey": "mkey:f2f0f418cdd3073df2ac8ad6eb2feff1fe470d0cf0f468d3a0a84a02314ef452",
+			"Peers": [{
+				"ID":         4848068775639388,
+				"StableID":   "njtkGfYhre11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c2dccf13a166a7b66544f45d03ab772a6f09e2aa81ae2a5c980459746c5a405",
+				"DiscoKey":   "discokey:81e6d4c58a7c272b7b32a802665ceb7f0a9238b0bb856b8421eed511bd3e4c36",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:52285", "10.65.0.27:52285", "172.17.0.1:52285"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:50:29.035878341Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7115789059979959,
+				"StableID":   "nY5dMKikZx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2518b02d135c41e4d1f5fdc81cc8bb7a59b0f15817e6660f10e6192f1248ed60",
+				"DiscoKey":   "discokey:7c0cbbb14eb4b39131cbab93ca2db3269e040fad017de98a21be8d09e58de338",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:40988", "10.65.0.27:40988", "172.17.0.1:40988"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:50:29.587131423Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5129441730058200,
+				"StableID":   "nq5mjhj84h11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5b2b122ab2969a8b0ec7effe2e3830fd92f4f93d4c7011ea34f1480f799c091b",
+				"DiscoKey":   "discokey:99b057ddc616c2274ebb8079e0484ec61e097d292dcc04749c157ecf3edea702",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41267", "10.65.0.27:41267", "172.17.0.1:41267"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:50:30.14063926Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8972801687360610,
+				"StableID":   "nPyNCYHo4D21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0700fd912ade860cd12c2d0b33e8453d1081c2406a1170349708678a9a91ce00",
+				"DiscoKey":   "discokey:782ec6bed5d5ba43364ebdfcec4e659b33958c9d9842972af90507923b6f0d71",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:56471", "10.65.0.27:56471", "172.17.0.1:56471"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:50:30.714012093Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1626766312943096,
+				"StableID":   "n3kZUmPmhD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:60abe045d930e1900b95a6c9c347d4126307a6e3224e1a0bfe37b28151ac9b08",
+				"DiscoKey":   "discokey:6efbfaaaac576d8221f0d418f6b64e89676e84bef7218b58564e6a932f74235a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:40215", "10.65.0.27:40215", "172.17.0.1:40215"],
+				"HomeDERP":   18,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:50:31.229549495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5605597977720546,
+				"StableID":   "nqYip6Znmk11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:69acf5fe1d088dbd42dcd3755a993a4c1b60a6baa889b404d190805197c21b33",
+				"DiscoKey":   "discokey:646b5ca2368ee9420faffa83716d85d340aacc99d04a6d058e431a414253837c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:51426", "10.65.0.27:51426", "172.17.0.1:51426"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:50:31.770150908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2379450406134494,
+				"StableID":   "nsX1MP8faK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:516d92d2b8686dab28c9007a32d56321a1e5b7d7441d7568d4ecbc737cdd5d5c",
+				"DiscoKey":   "discokey:bc476333971dabc88ca2a564b669d3dca3d131da77f67ecad99b9d24f13d0579",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:52883", "10.65.0.27:52883", "172.17.0.1:52883"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:50:32.318514826Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8131526495021484,
+				"StableID":   "nD78GvQnV621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4665af95b54a923290ae72f1f8a0c19654ade55b56db7896ae19184f56787913",
+				"DiscoKey":   "discokey:03bcd8b79257b45e0b6735c2505134cd62faeff756a13a94ddb4bef03e3f976d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:47670", "10.65.0.27:47670", "172.17.0.1:47670"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:50:32.882489646Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         153621018168083,
+				"StableID":   "nJUrK6NaC211CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f07b8d8154e003c310f0697e38d71aa5dc5630a7eac89c86bc0314320858827",
+				"DiscoKey":   "discokey:1826926d01a5869441abec291ee4cc447d4bc629696bcea120aae25cec59ce6f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:43214", "10.65.0.27:43214", "172.17.0.1:43214"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:50:33.402874067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5801362570320204,
+				"StableID":   "nfSNWXxSJn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d79d4010f9f85acb8e8d54c6540cda6b612ddf49ec1fea40a827184250b9ec2a",
+				"DiscoKey":   "discokey:faf0d62bb9057efaf6ec7af6b73db5f0346d0c1ce1fe436a8aba229249907d24",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:37554", "10.65.0.27:37554", "172.17.0.1:37554"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:50:33.955496345Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         416464208629859,
+				"StableID":   "nzW71uocF411CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c7c3dc0221fcb860e72a40893a8f8a40d4c1c4d0aff5ea0762737a861c4a2e63",
+				"DiscoKey":   "discokey:076c6e8f269e32025d8b488ff9cee71cbb8fa8691330b7cceb7625daad3a6e4c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57652", "10.65.0.27:57652", "172.17.0.1:57652"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:50:35.0309695Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7793136910147660,
+				"StableID":   "nVDZQXVXr321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:c80de0dd4c81b6caeea593ad21f448eb7db8780eaed2978a4b916b53ee512e4b",
+				"KeyExpiry":  "2026-11-08T18:50:35Z",
+				"DiscoKey":   "discokey:a91666c0d3665bf6efaf48bc015d030b2981f027b336ca28ae1ff11c2b0c7b29",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:41480", "10.65.0.27:41480", "172.17.0.1:41480"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:50:35.570372163Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7768060240312028,
+				"StableID":   "n59uxfmAf321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:448e7f5c681a0539e0aa7c0db736a07e0ea5e2f2094a875e08215258e04c8c4d",
+				"KeyExpiry":  "2026-11-08T18:50:36Z",
+				"DiscoKey":   "discokey:01f07f0ff1e5ee52eb61273316a52c40f3f4641cc48521d8ee48fe50d190054b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:60152", "10.65.0.27:60152", "172.17.0.1:60152"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:50:36.133805253Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8950596656120624,
+				"StableID":   "njz8dozjtC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ae1be9cb1c92be412a4259af291e9344324b1d4b049190a94aedea158198cc48",
+				"KeyExpiry":  "2026-11-08T18:50:36Z",
+				"DiscoKey":   "discokey:a620f71db99c7043750d0e588b28c9a67ae2038960fb219cc1ddec2a34039a73",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:54343", "10.65.0.27:54343", "172.17.0.1:54343"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:50:36.665566368Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7824592227270189": {
+				"ID":          7824592227270189,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7115789059979959,
+				"StableID":   "nY5dMKikZx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       7115789059979959,
+				"Key":        "nodekey:2518b02d135c41e4d1f5fdc81cc8bb7a59b0f15817e6660f10e6192f1248ed60",
+				"DiscoKey":   "discokey:7c0cbbb14eb4b39131cbab93ca2db3269e040fad017de98a21be8d09e58de338",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:40988", "10.65.0.27:40988", "172.17.0.1:40988"],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:50:29.587131423Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2518b02d135c41e4d1f5fdc81cc8bb7a59b0f15817e6660f10e6192f1248ed60",
+			"MachineKey": "mkey:b2a470f9ac58a688612f7983c3f32baf0472e59a9570cbb965b6357c1731af01",
+			"Peers": [{
+				"ID":         4848068775639388,
+				"StableID":   "njtkGfYhre11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c2dccf13a166a7b66544f45d03ab772a6f09e2aa81ae2a5c980459746c5a405",
+				"DiscoKey":   "discokey:81e6d4c58a7c272b7b32a802665ceb7f0a9238b0bb856b8421eed511bd3e4c36",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:52285", "10.65.0.27:52285", "172.17.0.1:52285"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:50:29.035878341Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         5129441730058200,
+				"StableID":   "nq5mjhj84h11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5b2b122ab2969a8b0ec7effe2e3830fd92f4f93d4c7011ea34f1480f799c091b",
+				"DiscoKey":   "discokey:99b057ddc616c2274ebb8079e0484ec61e097d292dcc04749c157ecf3edea702",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41267", "10.65.0.27:41267", "172.17.0.1:41267"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:50:30.14063926Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8972801687360610,
+				"StableID":   "nPyNCYHo4D21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0700fd912ade860cd12c2d0b33e8453d1081c2406a1170349708678a9a91ce00",
+				"DiscoKey":   "discokey:782ec6bed5d5ba43364ebdfcec4e659b33958c9d9842972af90507923b6f0d71",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:56471", "10.65.0.27:56471", "172.17.0.1:56471"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:50:30.714012093Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1626766312943096,
+				"StableID":   "n3kZUmPmhD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:60abe045d930e1900b95a6c9c347d4126307a6e3224e1a0bfe37b28151ac9b08",
+				"DiscoKey":   "discokey:6efbfaaaac576d8221f0d418f6b64e89676e84bef7218b58564e6a932f74235a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:40215", "10.65.0.27:40215", "172.17.0.1:40215"],
+				"HomeDERP":   18,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:50:31.229549495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5605597977720546,
+				"StableID":   "nqYip6Znmk11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:69acf5fe1d088dbd42dcd3755a993a4c1b60a6baa889b404d190805197c21b33",
+				"DiscoKey":   "discokey:646b5ca2368ee9420faffa83716d85d340aacc99d04a6d058e431a414253837c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:51426", "10.65.0.27:51426", "172.17.0.1:51426"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:50:31.770150908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2379450406134494,
+				"StableID":   "nsX1MP8faK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:516d92d2b8686dab28c9007a32d56321a1e5b7d7441d7568d4ecbc737cdd5d5c",
+				"DiscoKey":   "discokey:bc476333971dabc88ca2a564b669d3dca3d131da77f67ecad99b9d24f13d0579",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:52883", "10.65.0.27:52883", "172.17.0.1:52883"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:50:32.318514826Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8131526495021484,
+				"StableID":   "nD78GvQnV621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4665af95b54a923290ae72f1f8a0c19654ade55b56db7896ae19184f56787913",
+				"DiscoKey":   "discokey:03bcd8b79257b45e0b6735c2505134cd62faeff756a13a94ddb4bef03e3f976d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:47670", "10.65.0.27:47670", "172.17.0.1:47670"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:50:32.882489646Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         153621018168083,
+				"StableID":   "nJUrK6NaC211CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f07b8d8154e003c310f0697e38d71aa5dc5630a7eac89c86bc0314320858827",
+				"DiscoKey":   "discokey:1826926d01a5869441abec291ee4cc447d4bc629696bcea120aae25cec59ce6f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:43214", "10.65.0.27:43214", "172.17.0.1:43214"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:50:33.402874067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5801362570320204,
+				"StableID":   "nfSNWXxSJn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d79d4010f9f85acb8e8d54c6540cda6b612ddf49ec1fea40a827184250b9ec2a",
+				"DiscoKey":   "discokey:faf0d62bb9057efaf6ec7af6b73db5f0346d0c1ce1fe436a8aba229249907d24",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:37554", "10.65.0.27:37554", "172.17.0.1:37554"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:50:33.955496345Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7824592227270189,
+				"StableID":   "nCxr4emm6421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f8947d9c2c6d64f1a5164163773f0eaa6367c9a179b3dfdfe1a8e10e373d181d",
+				"DiscoKey":   "discokey:b558da10cbd5fed48c3deb733dfac08676a29bdf76f4ae6bbf3015bc3482c87b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43754", "10.65.0.27:43754", "172.17.0.1:43754"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:50:34.498437307Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         416464208629859,
+				"StableID":   "nzW71uocF411CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c7c3dc0221fcb860e72a40893a8f8a40d4c1c4d0aff5ea0762737a861c4a2e63",
+				"DiscoKey":   "discokey:076c6e8f269e32025d8b488ff9cee71cbb8fa8691330b7cceb7625daad3a6e4c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57652", "10.65.0.27:57652", "172.17.0.1:57652"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:50:35.0309695Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7793136910147660,
+				"StableID":   "nVDZQXVXr321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:c80de0dd4c81b6caeea593ad21f448eb7db8780eaed2978a4b916b53ee512e4b",
+				"KeyExpiry":  "2026-11-08T18:50:35Z",
+				"DiscoKey":   "discokey:a91666c0d3665bf6efaf48bc015d030b2981f027b336ca28ae1ff11c2b0c7b29",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:41480", "10.65.0.27:41480", "172.17.0.1:41480"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:50:35.570372163Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7768060240312028,
+				"StableID":   "n59uxfmAf321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:448e7f5c681a0539e0aa7c0db736a07e0ea5e2f2094a875e08215258e04c8c4d",
+				"KeyExpiry":  "2026-11-08T18:50:36Z",
+				"DiscoKey":   "discokey:01f07f0ff1e5ee52eb61273316a52c40f3f4641cc48521d8ee48fe50d190054b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:60152", "10.65.0.27:60152", "172.17.0.1:60152"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:50:36.133805253Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8950596656120624,
+				"StableID":   "njz8dozjtC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ae1be9cb1c92be412a4259af291e9344324b1d4b049190a94aedea158198cc48",
+				"KeyExpiry":  "2026-11-08T18:50:36Z",
+				"DiscoKey":   "discokey:a620f71db99c7043750d0e588b28c9a67ae2038960fb219cc1ddec2a34039a73",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:54343", "10.65.0.27:54343", "172.17.0.1:54343"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:50:36.665566368Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7115789059979959": {
+				"ID":          7115789059979959,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4848068775639388,
+				"StableID":   "njtkGfYhre11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       4848068775639388,
+				"Key":        "nodekey:2c2dccf13a166a7b66544f45d03ab772a6f09e2aa81ae2a5c980459746c5a405",
+				"DiscoKey":   "discokey:81e6d4c58a7c272b7b32a802665ceb7f0a9238b0bb856b8421eed511bd3e4c36",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:52285", "10.65.0.27:52285", "172.17.0.1:52285"],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:50:29.035878341Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2c2dccf13a166a7b66544f45d03ab772a6f09e2aa81ae2a5c980459746c5a405",
+			"MachineKey": "mkey:b2d2b9dc6c97c8fe34041d7ce20a382031af0e6035d97c9a706e10e004690605",
+			"Peers": [{
+				"ID":         7115789059979959,
+				"StableID":   "nY5dMKikZx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2518b02d135c41e4d1f5fdc81cc8bb7a59b0f15817e6660f10e6192f1248ed60",
+				"DiscoKey":   "discokey:7c0cbbb14eb4b39131cbab93ca2db3269e040fad017de98a21be8d09e58de338",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:40988", "10.65.0.27:40988", "172.17.0.1:40988"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:50:29.587131423Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5129441730058200,
+				"StableID":   "nq5mjhj84h11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5b2b122ab2969a8b0ec7effe2e3830fd92f4f93d4c7011ea34f1480f799c091b",
+				"DiscoKey":   "discokey:99b057ddc616c2274ebb8079e0484ec61e097d292dcc04749c157ecf3edea702",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41267", "10.65.0.27:41267", "172.17.0.1:41267"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:50:30.14063926Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8972801687360610,
+				"StableID":   "nPyNCYHo4D21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0700fd912ade860cd12c2d0b33e8453d1081c2406a1170349708678a9a91ce00",
+				"DiscoKey":   "discokey:782ec6bed5d5ba43364ebdfcec4e659b33958c9d9842972af90507923b6f0d71",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:56471", "10.65.0.27:56471", "172.17.0.1:56471"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:50:30.714012093Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1626766312943096,
+				"StableID":   "n3kZUmPmhD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:60abe045d930e1900b95a6c9c347d4126307a6e3224e1a0bfe37b28151ac9b08",
+				"DiscoKey":   "discokey:6efbfaaaac576d8221f0d418f6b64e89676e84bef7218b58564e6a932f74235a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:40215", "10.65.0.27:40215", "172.17.0.1:40215"],
+				"HomeDERP":   18,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:50:31.229549495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5605597977720546,
+				"StableID":   "nqYip6Znmk11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:69acf5fe1d088dbd42dcd3755a993a4c1b60a6baa889b404d190805197c21b33",
+				"DiscoKey":   "discokey:646b5ca2368ee9420faffa83716d85d340aacc99d04a6d058e431a414253837c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:51426", "10.65.0.27:51426", "172.17.0.1:51426"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:50:31.770150908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2379450406134494,
+				"StableID":   "nsX1MP8faK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:516d92d2b8686dab28c9007a32d56321a1e5b7d7441d7568d4ecbc737cdd5d5c",
+				"DiscoKey":   "discokey:bc476333971dabc88ca2a564b669d3dca3d131da77f67ecad99b9d24f13d0579",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:52883", "10.65.0.27:52883", "172.17.0.1:52883"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:50:32.318514826Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8131526495021484,
+				"StableID":   "nD78GvQnV621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4665af95b54a923290ae72f1f8a0c19654ade55b56db7896ae19184f56787913",
+				"DiscoKey":   "discokey:03bcd8b79257b45e0b6735c2505134cd62faeff756a13a94ddb4bef03e3f976d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:47670", "10.65.0.27:47670", "172.17.0.1:47670"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:50:32.882489646Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         153621018168083,
+				"StableID":   "nJUrK6NaC211CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f07b8d8154e003c310f0697e38d71aa5dc5630a7eac89c86bc0314320858827",
+				"DiscoKey":   "discokey:1826926d01a5869441abec291ee4cc447d4bc629696bcea120aae25cec59ce6f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:43214", "10.65.0.27:43214", "172.17.0.1:43214"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:50:33.402874067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5801362570320204,
+				"StableID":   "nfSNWXxSJn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d79d4010f9f85acb8e8d54c6540cda6b612ddf49ec1fea40a827184250b9ec2a",
+				"DiscoKey":   "discokey:faf0d62bb9057efaf6ec7af6b73db5f0346d0c1ce1fe436a8aba229249907d24",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:37554", "10.65.0.27:37554", "172.17.0.1:37554"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:50:33.955496345Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7824592227270189,
+				"StableID":   "nCxr4emm6421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f8947d9c2c6d64f1a5164163773f0eaa6367c9a179b3dfdfe1a8e10e373d181d",
+				"DiscoKey":   "discokey:b558da10cbd5fed48c3deb733dfac08676a29bdf76f4ae6bbf3015bc3482c87b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43754", "10.65.0.27:43754", "172.17.0.1:43754"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:50:34.498437307Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         416464208629859,
+				"StableID":   "nzW71uocF411CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c7c3dc0221fcb860e72a40893a8f8a40d4c1c4d0aff5ea0762737a861c4a2e63",
+				"DiscoKey":   "discokey:076c6e8f269e32025d8b488ff9cee71cbb8fa8691330b7cceb7625daad3a6e4c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57652", "10.65.0.27:57652", "172.17.0.1:57652"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:50:35.0309695Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7793136910147660,
+				"StableID":   "nVDZQXVXr321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:c80de0dd4c81b6caeea593ad21f448eb7db8780eaed2978a4b916b53ee512e4b",
+				"KeyExpiry":  "2026-11-08T18:50:35Z",
+				"DiscoKey":   "discokey:a91666c0d3665bf6efaf48bc015d030b2981f027b336ca28ae1ff11c2b0c7b29",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:41480", "10.65.0.27:41480", "172.17.0.1:41480"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:50:35.570372163Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7768060240312028,
+				"StableID":   "n59uxfmAf321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:448e7f5c681a0539e0aa7c0db736a07e0ea5e2f2094a875e08215258e04c8c4d",
+				"KeyExpiry":  "2026-11-08T18:50:36Z",
+				"DiscoKey":   "discokey:01f07f0ff1e5ee52eb61273316a52c40f3f4641cc48521d8ee48fe50d190054b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:60152", "10.65.0.27:60152", "172.17.0.1:60152"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:50:36.133805253Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8950596656120624,
+				"StableID":   "njz8dozjtC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ae1be9cb1c92be412a4259af291e9344324b1d4b049190a94aedea158198cc48",
+				"KeyExpiry":  "2026-11-08T18:50:36Z",
+				"DiscoKey":   "discokey:a620f71db99c7043750d0e588b28c9a67ae2038960fb219cc1ddec2a34039a73",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:54343", "10.65.0.27:54343", "172.17.0.1:54343"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:50:36.665566368Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4848068775639388": {
+				"ID":          4848068775639388,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1626766312943096,
+				"StableID":   "n3kZUmPmhD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1626766312943096,
+				"Key":        "nodekey:60abe045d930e1900b95a6c9c347d4126307a6e3224e1a0bfe37b28151ac9b08",
+				"DiscoKey":   "discokey:6efbfaaaac576d8221f0d418f6b64e89676e84bef7218b58564e6a932f74235a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:40215", "10.65.0.27:40215", "172.17.0.1:40215"],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:50:31.229549495Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:60abe045d930e1900b95a6c9c347d4126307a6e3224e1a0bfe37b28151ac9b08",
+			"MachineKey": "mkey:61d0cc4fbbee14e600c1ef13b8399e1679bd41a6021d99e8c9a1311a3ce3b727",
+			"Peers": [{
+				"ID":         4848068775639388,
+				"StableID":   "njtkGfYhre11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c2dccf13a166a7b66544f45d03ab772a6f09e2aa81ae2a5c980459746c5a405",
+				"DiscoKey":   "discokey:81e6d4c58a7c272b7b32a802665ceb7f0a9238b0bb856b8421eed511bd3e4c36",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:52285", "10.65.0.27:52285", "172.17.0.1:52285"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:50:29.035878341Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7115789059979959,
+				"StableID":   "nY5dMKikZx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2518b02d135c41e4d1f5fdc81cc8bb7a59b0f15817e6660f10e6192f1248ed60",
+				"DiscoKey":   "discokey:7c0cbbb14eb4b39131cbab93ca2db3269e040fad017de98a21be8d09e58de338",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:40988", "10.65.0.27:40988", "172.17.0.1:40988"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:50:29.587131423Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5129441730058200,
+				"StableID":   "nq5mjhj84h11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5b2b122ab2969a8b0ec7effe2e3830fd92f4f93d4c7011ea34f1480f799c091b",
+				"DiscoKey":   "discokey:99b057ddc616c2274ebb8079e0484ec61e097d292dcc04749c157ecf3edea702",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41267", "10.65.0.27:41267", "172.17.0.1:41267"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:50:30.14063926Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8972801687360610,
+				"StableID":   "nPyNCYHo4D21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0700fd912ade860cd12c2d0b33e8453d1081c2406a1170349708678a9a91ce00",
+				"DiscoKey":   "discokey:782ec6bed5d5ba43364ebdfcec4e659b33958c9d9842972af90507923b6f0d71",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:56471", "10.65.0.27:56471", "172.17.0.1:56471"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:50:30.714012093Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5605597977720546,
+				"StableID":   "nqYip6Znmk11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:69acf5fe1d088dbd42dcd3755a993a4c1b60a6baa889b404d190805197c21b33",
+				"DiscoKey":   "discokey:646b5ca2368ee9420faffa83716d85d340aacc99d04a6d058e431a414253837c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:51426", "10.65.0.27:51426", "172.17.0.1:51426"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:50:31.770150908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2379450406134494,
+				"StableID":   "nsX1MP8faK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:516d92d2b8686dab28c9007a32d56321a1e5b7d7441d7568d4ecbc737cdd5d5c",
+				"DiscoKey":   "discokey:bc476333971dabc88ca2a564b669d3dca3d131da77f67ecad99b9d24f13d0579",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:52883", "10.65.0.27:52883", "172.17.0.1:52883"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:50:32.318514826Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8131526495021484,
+				"StableID":   "nD78GvQnV621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4665af95b54a923290ae72f1f8a0c19654ade55b56db7896ae19184f56787913",
+				"DiscoKey":   "discokey:03bcd8b79257b45e0b6735c2505134cd62faeff756a13a94ddb4bef03e3f976d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:47670", "10.65.0.27:47670", "172.17.0.1:47670"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:50:32.882489646Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         153621018168083,
+				"StableID":   "nJUrK6NaC211CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f07b8d8154e003c310f0697e38d71aa5dc5630a7eac89c86bc0314320858827",
+				"DiscoKey":   "discokey:1826926d01a5869441abec291ee4cc447d4bc629696bcea120aae25cec59ce6f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:43214", "10.65.0.27:43214", "172.17.0.1:43214"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:50:33.402874067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5801362570320204,
+				"StableID":   "nfSNWXxSJn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d79d4010f9f85acb8e8d54c6540cda6b612ddf49ec1fea40a827184250b9ec2a",
+				"DiscoKey":   "discokey:faf0d62bb9057efaf6ec7af6b73db5f0346d0c1ce1fe436a8aba229249907d24",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:37554", "10.65.0.27:37554", "172.17.0.1:37554"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:50:33.955496345Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7824592227270189,
+				"StableID":   "nCxr4emm6421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f8947d9c2c6d64f1a5164163773f0eaa6367c9a179b3dfdfe1a8e10e373d181d",
+				"DiscoKey":   "discokey:b558da10cbd5fed48c3deb733dfac08676a29bdf76f4ae6bbf3015bc3482c87b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43754", "10.65.0.27:43754", "172.17.0.1:43754"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:50:34.498437307Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         416464208629859,
+				"StableID":   "nzW71uocF411CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c7c3dc0221fcb860e72a40893a8f8a40d4c1c4d0aff5ea0762737a861c4a2e63",
+				"DiscoKey":   "discokey:076c6e8f269e32025d8b488ff9cee71cbb8fa8691330b7cceb7625daad3a6e4c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57652", "10.65.0.27:57652", "172.17.0.1:57652"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:50:35.0309695Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7793136910147660,
+				"StableID":   "nVDZQXVXr321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:c80de0dd4c81b6caeea593ad21f448eb7db8780eaed2978a4b916b53ee512e4b",
+				"KeyExpiry":  "2026-11-08T18:50:35Z",
+				"DiscoKey":   "discokey:a91666c0d3665bf6efaf48bc015d030b2981f027b336ca28ae1ff11c2b0c7b29",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:41480", "10.65.0.27:41480", "172.17.0.1:41480"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:50:35.570372163Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7768060240312028,
+				"StableID":   "n59uxfmAf321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:448e7f5c681a0539e0aa7c0db736a07e0ea5e2f2094a875e08215258e04c8c4d",
+				"KeyExpiry":  "2026-11-08T18:50:36Z",
+				"DiscoKey":   "discokey:01f07f0ff1e5ee52eb61273316a52c40f3f4641cc48521d8ee48fe50d190054b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:60152", "10.65.0.27:60152", "172.17.0.1:60152"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:50:36.133805253Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8950596656120624,
+				"StableID":   "njz8dozjtC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ae1be9cb1c92be412a4259af291e9344324b1d4b049190a94aedea158198cc48",
+				"KeyExpiry":  "2026-11-08T18:50:36Z",
+				"DiscoKey":   "discokey:a620f71db99c7043750d0e588b28c9a67ae2038960fb219cc1ddec2a34039a73",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:54343", "10.65.0.27:54343", "172.17.0.1:54343"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:50:36.665566368Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1626766312943096": {
+				"ID":          1626766312943096,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8972801687360610,
+				"StableID":   "nPyNCYHo4D21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       8972801687360610,
+				"Key":        "nodekey:0700fd912ade860cd12c2d0b33e8453d1081c2406a1170349708678a9a91ce00",
+				"DiscoKey":   "discokey:782ec6bed5d5ba43364ebdfcec4e659b33958c9d9842972af90507923b6f0d71",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:56471", "10.65.0.27:56471", "172.17.0.1:56471"],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:50:30.714012093Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0700fd912ade860cd12c2d0b33e8453d1081c2406a1170349708678a9a91ce00",
+			"MachineKey": "mkey:6d325498a427c71479103608c2f7676b5eb779f5957c1058b2bbb177b3256b1d",
+			"Peers": [{
+				"ID":         4848068775639388,
+				"StableID":   "njtkGfYhre11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c2dccf13a166a7b66544f45d03ab772a6f09e2aa81ae2a5c980459746c5a405",
+				"DiscoKey":   "discokey:81e6d4c58a7c272b7b32a802665ceb7f0a9238b0bb856b8421eed511bd3e4c36",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:52285", "10.65.0.27:52285", "172.17.0.1:52285"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:50:29.035878341Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7115789059979959,
+				"StableID":   "nY5dMKikZx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2518b02d135c41e4d1f5fdc81cc8bb7a59b0f15817e6660f10e6192f1248ed60",
+				"DiscoKey":   "discokey:7c0cbbb14eb4b39131cbab93ca2db3269e040fad017de98a21be8d09e58de338",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:40988", "10.65.0.27:40988", "172.17.0.1:40988"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:50:29.587131423Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5129441730058200,
+				"StableID":   "nq5mjhj84h11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5b2b122ab2969a8b0ec7effe2e3830fd92f4f93d4c7011ea34f1480f799c091b",
+				"DiscoKey":   "discokey:99b057ddc616c2274ebb8079e0484ec61e097d292dcc04749c157ecf3edea702",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41267", "10.65.0.27:41267", "172.17.0.1:41267"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:50:30.14063926Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1626766312943096,
+				"StableID":   "n3kZUmPmhD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:60abe045d930e1900b95a6c9c347d4126307a6e3224e1a0bfe37b28151ac9b08",
+				"DiscoKey":   "discokey:6efbfaaaac576d8221f0d418f6b64e89676e84bef7218b58564e6a932f74235a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:40215", "10.65.0.27:40215", "172.17.0.1:40215"],
+				"HomeDERP":   18,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:50:31.229549495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5605597977720546,
+				"StableID":   "nqYip6Znmk11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:69acf5fe1d088dbd42dcd3755a993a4c1b60a6baa889b404d190805197c21b33",
+				"DiscoKey":   "discokey:646b5ca2368ee9420faffa83716d85d340aacc99d04a6d058e431a414253837c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:51426", "10.65.0.27:51426", "172.17.0.1:51426"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:50:31.770150908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2379450406134494,
+				"StableID":   "nsX1MP8faK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:516d92d2b8686dab28c9007a32d56321a1e5b7d7441d7568d4ecbc737cdd5d5c",
+				"DiscoKey":   "discokey:bc476333971dabc88ca2a564b669d3dca3d131da77f67ecad99b9d24f13d0579",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:52883", "10.65.0.27:52883", "172.17.0.1:52883"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:50:32.318514826Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8131526495021484,
+				"StableID":   "nD78GvQnV621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4665af95b54a923290ae72f1f8a0c19654ade55b56db7896ae19184f56787913",
+				"DiscoKey":   "discokey:03bcd8b79257b45e0b6735c2505134cd62faeff756a13a94ddb4bef03e3f976d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:47670", "10.65.0.27:47670", "172.17.0.1:47670"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:50:32.882489646Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         153621018168083,
+				"StableID":   "nJUrK6NaC211CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f07b8d8154e003c310f0697e38d71aa5dc5630a7eac89c86bc0314320858827",
+				"DiscoKey":   "discokey:1826926d01a5869441abec291ee4cc447d4bc629696bcea120aae25cec59ce6f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:43214", "10.65.0.27:43214", "172.17.0.1:43214"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:50:33.402874067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5801362570320204,
+				"StableID":   "nfSNWXxSJn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d79d4010f9f85acb8e8d54c6540cda6b612ddf49ec1fea40a827184250b9ec2a",
+				"DiscoKey":   "discokey:faf0d62bb9057efaf6ec7af6b73db5f0346d0c1ce1fe436a8aba229249907d24",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:37554", "10.65.0.27:37554", "172.17.0.1:37554"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:50:33.955496345Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7824592227270189,
+				"StableID":   "nCxr4emm6421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f8947d9c2c6d64f1a5164163773f0eaa6367c9a179b3dfdfe1a8e10e373d181d",
+				"DiscoKey":   "discokey:b558da10cbd5fed48c3deb733dfac08676a29bdf76f4ae6bbf3015bc3482c87b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43754", "10.65.0.27:43754", "172.17.0.1:43754"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:50:34.498437307Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         416464208629859,
+				"StableID":   "nzW71uocF411CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c7c3dc0221fcb860e72a40893a8f8a40d4c1c4d0aff5ea0762737a861c4a2e63",
+				"DiscoKey":   "discokey:076c6e8f269e32025d8b488ff9cee71cbb8fa8691330b7cceb7625daad3a6e4c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57652", "10.65.0.27:57652", "172.17.0.1:57652"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:50:35.0309695Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7793136910147660,
+				"StableID":   "nVDZQXVXr321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:c80de0dd4c81b6caeea593ad21f448eb7db8780eaed2978a4b916b53ee512e4b",
+				"KeyExpiry":  "2026-11-08T18:50:35Z",
+				"DiscoKey":   "discokey:a91666c0d3665bf6efaf48bc015d030b2981f027b336ca28ae1ff11c2b0c7b29",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:41480", "10.65.0.27:41480", "172.17.0.1:41480"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:50:35.570372163Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7768060240312028,
+				"StableID":   "n59uxfmAf321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:448e7f5c681a0539e0aa7c0db736a07e0ea5e2f2094a875e08215258e04c8c4d",
+				"KeyExpiry":  "2026-11-08T18:50:36Z",
+				"DiscoKey":   "discokey:01f07f0ff1e5ee52eb61273316a52c40f3f4641cc48521d8ee48fe50d190054b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:60152", "10.65.0.27:60152", "172.17.0.1:60152"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:50:36.133805253Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8950596656120624,
+				"StableID":   "njz8dozjtC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ae1be9cb1c92be412a4259af291e9344324b1d4b049190a94aedea158198cc48",
+				"KeyExpiry":  "2026-11-08T18:50:36Z",
+				"DiscoKey":   "discokey:a620f71db99c7043750d0e588b28c9a67ae2038960fb219cc1ddec2a34039a73",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:54343", "10.65.0.27:54343", "172.17.0.1:54343"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:50:36.665566368Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8972801687360610": {
+				"ID":          8972801687360610,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2379450406134494,
+				"StableID":   "nsX1MP8faK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       2379450406134494,
+				"Key":        "nodekey:516d92d2b8686dab28c9007a32d56321a1e5b7d7441d7568d4ecbc737cdd5d5c",
+				"DiscoKey":   "discokey:bc476333971dabc88ca2a564b669d3dca3d131da77f67ecad99b9d24f13d0579",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:52883", "10.65.0.27:52883", "172.17.0.1:52883"],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:50:32.318514826Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:516d92d2b8686dab28c9007a32d56321a1e5b7d7441d7568d4ecbc737cdd5d5c",
+			"MachineKey": "mkey:cb1f6adef36c0040c3f8c98dd356b5e4742cbcec92103f35c701a103f663541a",
+			"Peers": [{
+				"ID":         4848068775639388,
+				"StableID":   "njtkGfYhre11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c2dccf13a166a7b66544f45d03ab772a6f09e2aa81ae2a5c980459746c5a405",
+				"DiscoKey":   "discokey:81e6d4c58a7c272b7b32a802665ceb7f0a9238b0bb856b8421eed511bd3e4c36",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:52285", "10.65.0.27:52285", "172.17.0.1:52285"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:50:29.035878341Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7115789059979959,
+				"StableID":   "nY5dMKikZx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2518b02d135c41e4d1f5fdc81cc8bb7a59b0f15817e6660f10e6192f1248ed60",
+				"DiscoKey":   "discokey:7c0cbbb14eb4b39131cbab93ca2db3269e040fad017de98a21be8d09e58de338",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:40988", "10.65.0.27:40988", "172.17.0.1:40988"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:50:29.587131423Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5129441730058200,
+				"StableID":   "nq5mjhj84h11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5b2b122ab2969a8b0ec7effe2e3830fd92f4f93d4c7011ea34f1480f799c091b",
+				"DiscoKey":   "discokey:99b057ddc616c2274ebb8079e0484ec61e097d292dcc04749c157ecf3edea702",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41267", "10.65.0.27:41267", "172.17.0.1:41267"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:50:30.14063926Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8972801687360610,
+				"StableID":   "nPyNCYHo4D21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0700fd912ade860cd12c2d0b33e8453d1081c2406a1170349708678a9a91ce00",
+				"DiscoKey":   "discokey:782ec6bed5d5ba43364ebdfcec4e659b33958c9d9842972af90507923b6f0d71",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:56471", "10.65.0.27:56471", "172.17.0.1:56471"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:50:30.714012093Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1626766312943096,
+				"StableID":   "n3kZUmPmhD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:60abe045d930e1900b95a6c9c347d4126307a6e3224e1a0bfe37b28151ac9b08",
+				"DiscoKey":   "discokey:6efbfaaaac576d8221f0d418f6b64e89676e84bef7218b58564e6a932f74235a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:40215", "10.65.0.27:40215", "172.17.0.1:40215"],
+				"HomeDERP":   18,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:50:31.229549495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5605597977720546,
+				"StableID":   "nqYip6Znmk11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:69acf5fe1d088dbd42dcd3755a993a4c1b60a6baa889b404d190805197c21b33",
+				"DiscoKey":   "discokey:646b5ca2368ee9420faffa83716d85d340aacc99d04a6d058e431a414253837c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:51426", "10.65.0.27:51426", "172.17.0.1:51426"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:50:31.770150908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8131526495021484,
+				"StableID":   "nD78GvQnV621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4665af95b54a923290ae72f1f8a0c19654ade55b56db7896ae19184f56787913",
+				"DiscoKey":   "discokey:03bcd8b79257b45e0b6735c2505134cd62faeff756a13a94ddb4bef03e3f976d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:47670", "10.65.0.27:47670", "172.17.0.1:47670"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:50:32.882489646Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         153621018168083,
+				"StableID":   "nJUrK6NaC211CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f07b8d8154e003c310f0697e38d71aa5dc5630a7eac89c86bc0314320858827",
+				"DiscoKey":   "discokey:1826926d01a5869441abec291ee4cc447d4bc629696bcea120aae25cec59ce6f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:43214", "10.65.0.27:43214", "172.17.0.1:43214"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:50:33.402874067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5801362570320204,
+				"StableID":   "nfSNWXxSJn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d79d4010f9f85acb8e8d54c6540cda6b612ddf49ec1fea40a827184250b9ec2a",
+				"DiscoKey":   "discokey:faf0d62bb9057efaf6ec7af6b73db5f0346d0c1ce1fe436a8aba229249907d24",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:37554", "10.65.0.27:37554", "172.17.0.1:37554"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:50:33.955496345Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7824592227270189,
+				"StableID":   "nCxr4emm6421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f8947d9c2c6d64f1a5164163773f0eaa6367c9a179b3dfdfe1a8e10e373d181d",
+				"DiscoKey":   "discokey:b558da10cbd5fed48c3deb733dfac08676a29bdf76f4ae6bbf3015bc3482c87b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43754", "10.65.0.27:43754", "172.17.0.1:43754"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:50:34.498437307Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         416464208629859,
+				"StableID":   "nzW71uocF411CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c7c3dc0221fcb860e72a40893a8f8a40d4c1c4d0aff5ea0762737a861c4a2e63",
+				"DiscoKey":   "discokey:076c6e8f269e32025d8b488ff9cee71cbb8fa8691330b7cceb7625daad3a6e4c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57652", "10.65.0.27:57652", "172.17.0.1:57652"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:50:35.0309695Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7793136910147660,
+				"StableID":   "nVDZQXVXr321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:c80de0dd4c81b6caeea593ad21f448eb7db8780eaed2978a4b916b53ee512e4b",
+				"KeyExpiry":  "2026-11-08T18:50:35Z",
+				"DiscoKey":   "discokey:a91666c0d3665bf6efaf48bc015d030b2981f027b336ca28ae1ff11c2b0c7b29",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:41480", "10.65.0.27:41480", "172.17.0.1:41480"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:50:35.570372163Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7768060240312028,
+				"StableID":   "n59uxfmAf321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:448e7f5c681a0539e0aa7c0db736a07e0ea5e2f2094a875e08215258e04c8c4d",
+				"KeyExpiry":  "2026-11-08T18:50:36Z",
+				"DiscoKey":   "discokey:01f07f0ff1e5ee52eb61273316a52c40f3f4641cc48521d8ee48fe50d190054b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:60152", "10.65.0.27:60152", "172.17.0.1:60152"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:50:36.133805253Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8950596656120624,
+				"StableID":   "njz8dozjtC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ae1be9cb1c92be412a4259af291e9344324b1d4b049190a94aedea158198cc48",
+				"KeyExpiry":  "2026-11-08T18:50:36Z",
+				"DiscoKey":   "discokey:a620f71db99c7043750d0e588b28c9a67ae2038960fb219cc1ddec2a34039a73",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:54343", "10.65.0.27:54343", "172.17.0.1:54343"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:50:36.665566368Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2379450406134494": {
+				"ID":          2379450406134494,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         153621018168083,
+				"StableID":   "nJUrK6NaC211CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       153621018168083,
+				"Key":        "nodekey:4f07b8d8154e003c310f0697e38d71aa5dc5630a7eac89c86bc0314320858827",
+				"DiscoKey":   "discokey:1826926d01a5869441abec291ee4cc447d4bc629696bcea120aae25cec59ce6f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:43214", "10.65.0.27:43214", "172.17.0.1:43214"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:50:33.402874067Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:4f07b8d8154e003c310f0697e38d71aa5dc5630a7eac89c86bc0314320858827",
+			"MachineKey": "mkey:e7a0db58314ae92699462ebd971bdc86264e31b2543374f1e33388dd4ed02513",
+			"Peers": [{
+				"ID":         4848068775639388,
+				"StableID":   "njtkGfYhre11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c2dccf13a166a7b66544f45d03ab772a6f09e2aa81ae2a5c980459746c5a405",
+				"DiscoKey":   "discokey:81e6d4c58a7c272b7b32a802665ceb7f0a9238b0bb856b8421eed511bd3e4c36",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:52285", "10.65.0.27:52285", "172.17.0.1:52285"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:50:29.035878341Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7115789059979959,
+				"StableID":   "nY5dMKikZx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2518b02d135c41e4d1f5fdc81cc8bb7a59b0f15817e6660f10e6192f1248ed60",
+				"DiscoKey":   "discokey:7c0cbbb14eb4b39131cbab93ca2db3269e040fad017de98a21be8d09e58de338",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:40988", "10.65.0.27:40988", "172.17.0.1:40988"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:50:29.587131423Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5129441730058200,
+				"StableID":   "nq5mjhj84h11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5b2b122ab2969a8b0ec7effe2e3830fd92f4f93d4c7011ea34f1480f799c091b",
+				"DiscoKey":   "discokey:99b057ddc616c2274ebb8079e0484ec61e097d292dcc04749c157ecf3edea702",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41267", "10.65.0.27:41267", "172.17.0.1:41267"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:50:30.14063926Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8972801687360610,
+				"StableID":   "nPyNCYHo4D21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0700fd912ade860cd12c2d0b33e8453d1081c2406a1170349708678a9a91ce00",
+				"DiscoKey":   "discokey:782ec6bed5d5ba43364ebdfcec4e659b33958c9d9842972af90507923b6f0d71",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:56471", "10.65.0.27:56471", "172.17.0.1:56471"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:50:30.714012093Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1626766312943096,
+				"StableID":   "n3kZUmPmhD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:60abe045d930e1900b95a6c9c347d4126307a6e3224e1a0bfe37b28151ac9b08",
+				"DiscoKey":   "discokey:6efbfaaaac576d8221f0d418f6b64e89676e84bef7218b58564e6a932f74235a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:40215", "10.65.0.27:40215", "172.17.0.1:40215"],
+				"HomeDERP":   18,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:50:31.229549495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5605597977720546,
+				"StableID":   "nqYip6Znmk11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:69acf5fe1d088dbd42dcd3755a993a4c1b60a6baa889b404d190805197c21b33",
+				"DiscoKey":   "discokey:646b5ca2368ee9420faffa83716d85d340aacc99d04a6d058e431a414253837c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:51426", "10.65.0.27:51426", "172.17.0.1:51426"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:50:31.770150908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2379450406134494,
+				"StableID":   "nsX1MP8faK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:516d92d2b8686dab28c9007a32d56321a1e5b7d7441d7568d4ecbc737cdd5d5c",
+				"DiscoKey":   "discokey:bc476333971dabc88ca2a564b669d3dca3d131da77f67ecad99b9d24f13d0579",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:52883", "10.65.0.27:52883", "172.17.0.1:52883"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:50:32.318514826Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8131526495021484,
+				"StableID":   "nD78GvQnV621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4665af95b54a923290ae72f1f8a0c19654ade55b56db7896ae19184f56787913",
+				"DiscoKey":   "discokey:03bcd8b79257b45e0b6735c2505134cd62faeff756a13a94ddb4bef03e3f976d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:47670", "10.65.0.27:47670", "172.17.0.1:47670"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:50:32.882489646Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5801362570320204,
+				"StableID":   "nfSNWXxSJn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d79d4010f9f85acb8e8d54c6540cda6b612ddf49ec1fea40a827184250b9ec2a",
+				"DiscoKey":   "discokey:faf0d62bb9057efaf6ec7af6b73db5f0346d0c1ce1fe436a8aba229249907d24",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:37554", "10.65.0.27:37554", "172.17.0.1:37554"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:50:33.955496345Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7824592227270189,
+				"StableID":   "nCxr4emm6421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f8947d9c2c6d64f1a5164163773f0eaa6367c9a179b3dfdfe1a8e10e373d181d",
+				"DiscoKey":   "discokey:b558da10cbd5fed48c3deb733dfac08676a29bdf76f4ae6bbf3015bc3482c87b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43754", "10.65.0.27:43754", "172.17.0.1:43754"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:50:34.498437307Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         416464208629859,
+				"StableID":   "nzW71uocF411CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c7c3dc0221fcb860e72a40893a8f8a40d4c1c4d0aff5ea0762737a861c4a2e63",
+				"DiscoKey":   "discokey:076c6e8f269e32025d8b488ff9cee71cbb8fa8691330b7cceb7625daad3a6e4c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57652", "10.65.0.27:57652", "172.17.0.1:57652"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:50:35.0309695Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7793136910147660,
+				"StableID":   "nVDZQXVXr321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:c80de0dd4c81b6caeea593ad21f448eb7db8780eaed2978a4b916b53ee512e4b",
+				"KeyExpiry":  "2026-11-08T18:50:35Z",
+				"DiscoKey":   "discokey:a91666c0d3665bf6efaf48bc015d030b2981f027b336ca28ae1ff11c2b0c7b29",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:41480", "10.65.0.27:41480", "172.17.0.1:41480"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:50:35.570372163Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7768060240312028,
+				"StableID":   "n59uxfmAf321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:448e7f5c681a0539e0aa7c0db736a07e0ea5e2f2094a875e08215258e04c8c4d",
+				"KeyExpiry":  "2026-11-08T18:50:36Z",
+				"DiscoKey":   "discokey:01f07f0ff1e5ee52eb61273316a52c40f3f4641cc48521d8ee48fe50d190054b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:60152", "10.65.0.27:60152", "172.17.0.1:60152"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:50:36.133805253Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8950596656120624,
+				"StableID":   "njz8dozjtC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ae1be9cb1c92be412a4259af291e9344324b1d4b049190a94aedea158198cc48",
+				"KeyExpiry":  "2026-11-08T18:50:36Z",
+				"DiscoKey":   "discokey:a620f71db99c7043750d0e588b28c9a67ae2038960fb219cc1ddec2a34039a73",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:54343", "10.65.0.27:54343", "172.17.0.1:54343"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:50:36.665566368Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "153621018168083": {
+				"ID":          153621018168083,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7768060240312028,
+				"StableID":   "n59uxfmAf321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:448e7f5c681a0539e0aa7c0db736a07e0ea5e2f2094a875e08215258e04c8c4d",
+				"KeyExpiry":  "2026-11-08T18:50:36Z",
+				"DiscoKey":   "discokey:01f07f0ff1e5ee52eb61273316a52c40f3f4641cc48521d8ee48fe50d190054b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:60152", "10.65.0.27:60152", "172.17.0.1:60152"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:50:36.133805253Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:448e7f5c681a0539e0aa7c0db736a07e0ea5e2f2094a875e08215258e04c8c4d",
+			"MachineKey": "mkey:8cdf3e19a144c3284e0d152f03a9bc69aabcdf19b3c2ba627d3af5ffe46d7759",
+			"Peers": [{
+				"ID":         4848068775639388,
+				"StableID":   "njtkGfYhre11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c2dccf13a166a7b66544f45d03ab772a6f09e2aa81ae2a5c980459746c5a405",
+				"DiscoKey":   "discokey:81e6d4c58a7c272b7b32a802665ceb7f0a9238b0bb856b8421eed511bd3e4c36",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:52285", "10.65.0.27:52285", "172.17.0.1:52285"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:50:29.035878341Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7115789059979959,
+				"StableID":   "nY5dMKikZx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2518b02d135c41e4d1f5fdc81cc8bb7a59b0f15817e6660f10e6192f1248ed60",
+				"DiscoKey":   "discokey:7c0cbbb14eb4b39131cbab93ca2db3269e040fad017de98a21be8d09e58de338",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:40988", "10.65.0.27:40988", "172.17.0.1:40988"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:50:29.587131423Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5129441730058200,
+				"StableID":   "nq5mjhj84h11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5b2b122ab2969a8b0ec7effe2e3830fd92f4f93d4c7011ea34f1480f799c091b",
+				"DiscoKey":   "discokey:99b057ddc616c2274ebb8079e0484ec61e097d292dcc04749c157ecf3edea702",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41267", "10.65.0.27:41267", "172.17.0.1:41267"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:50:30.14063926Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8972801687360610,
+				"StableID":   "nPyNCYHo4D21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0700fd912ade860cd12c2d0b33e8453d1081c2406a1170349708678a9a91ce00",
+				"DiscoKey":   "discokey:782ec6bed5d5ba43364ebdfcec4e659b33958c9d9842972af90507923b6f0d71",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:56471", "10.65.0.27:56471", "172.17.0.1:56471"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:50:30.714012093Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1626766312943096,
+				"StableID":   "n3kZUmPmhD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:60abe045d930e1900b95a6c9c347d4126307a6e3224e1a0bfe37b28151ac9b08",
+				"DiscoKey":   "discokey:6efbfaaaac576d8221f0d418f6b64e89676e84bef7218b58564e6a932f74235a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:40215", "10.65.0.27:40215", "172.17.0.1:40215"],
+				"HomeDERP":   18,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:50:31.229549495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5605597977720546,
+				"StableID":   "nqYip6Znmk11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:69acf5fe1d088dbd42dcd3755a993a4c1b60a6baa889b404d190805197c21b33",
+				"DiscoKey":   "discokey:646b5ca2368ee9420faffa83716d85d340aacc99d04a6d058e431a414253837c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:51426", "10.65.0.27:51426", "172.17.0.1:51426"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:50:31.770150908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2379450406134494,
+				"StableID":   "nsX1MP8faK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:516d92d2b8686dab28c9007a32d56321a1e5b7d7441d7568d4ecbc737cdd5d5c",
+				"DiscoKey":   "discokey:bc476333971dabc88ca2a564b669d3dca3d131da77f67ecad99b9d24f13d0579",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:52883", "10.65.0.27:52883", "172.17.0.1:52883"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:50:32.318514826Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8131526495021484,
+				"StableID":   "nD78GvQnV621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4665af95b54a923290ae72f1f8a0c19654ade55b56db7896ae19184f56787913",
+				"DiscoKey":   "discokey:03bcd8b79257b45e0b6735c2505134cd62faeff756a13a94ddb4bef03e3f976d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:47670", "10.65.0.27:47670", "172.17.0.1:47670"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:50:32.882489646Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         153621018168083,
+				"StableID":   "nJUrK6NaC211CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f07b8d8154e003c310f0697e38d71aa5dc5630a7eac89c86bc0314320858827",
+				"DiscoKey":   "discokey:1826926d01a5869441abec291ee4cc447d4bc629696bcea120aae25cec59ce6f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:43214", "10.65.0.27:43214", "172.17.0.1:43214"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:50:33.402874067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5801362570320204,
+				"StableID":   "nfSNWXxSJn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d79d4010f9f85acb8e8d54c6540cda6b612ddf49ec1fea40a827184250b9ec2a",
+				"DiscoKey":   "discokey:faf0d62bb9057efaf6ec7af6b73db5f0346d0c1ce1fe436a8aba229249907d24",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:37554", "10.65.0.27:37554", "172.17.0.1:37554"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:50:33.955496345Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7824592227270189,
+				"StableID":   "nCxr4emm6421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f8947d9c2c6d64f1a5164163773f0eaa6367c9a179b3dfdfe1a8e10e373d181d",
+				"DiscoKey":   "discokey:b558da10cbd5fed48c3deb733dfac08676a29bdf76f4ae6bbf3015bc3482c87b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43754", "10.65.0.27:43754", "172.17.0.1:43754"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:50:34.498437307Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         416464208629859,
+				"StableID":   "nzW71uocF411CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c7c3dc0221fcb860e72a40893a8f8a40d4c1c4d0aff5ea0762737a861c4a2e63",
+				"DiscoKey":   "discokey:076c6e8f269e32025d8b488ff9cee71cbb8fa8691330b7cceb7625daad3a6e4c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57652", "10.65.0.27:57652", "172.17.0.1:57652"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:50:35.0309695Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7793136910147660,
+				"StableID":   "nVDZQXVXr321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:c80de0dd4c81b6caeea593ad21f448eb7db8780eaed2978a4b916b53ee512e4b",
+				"KeyExpiry":  "2026-11-08T18:50:35Z",
+				"DiscoKey":   "discokey:a91666c0d3665bf6efaf48bc015d030b2981f027b336ca28ae1ff11c2b0c7b29",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:41480", "10.65.0.27:41480", "172.17.0.1:41480"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:50:35.570372163Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         8950596656120624,
+				"StableID":   "njz8dozjtC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ae1be9cb1c92be412a4259af291e9344324b1d4b049190a94aedea158198cc48",
+				"KeyExpiry":  "2026-11-08T18:50:36Z",
+				"DiscoKey":   "discokey:a620f71db99c7043750d0e588b28c9a67ae2038960fb219cc1ddec2a34039a73",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:54343", "10.65.0.27:54343", "172.17.0.1:54343"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:50:36.665566368Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5801362570320204,
+				"StableID":   "nfSNWXxSJn11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       5801362570320204,
+				"Key":        "nodekey:d79d4010f9f85acb8e8d54c6540cda6b612ddf49ec1fea40a827184250b9ec2a",
+				"DiscoKey":   "discokey:faf0d62bb9057efaf6ec7af6b73db5f0346d0c1ce1fe436a8aba229249907d24",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:37554", "10.65.0.27:37554", "172.17.0.1:37554"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:50:33.955496345Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d79d4010f9f85acb8e8d54c6540cda6b612ddf49ec1fea40a827184250b9ec2a",
+			"MachineKey": "mkey:5a6a08b2efbf7e5a278681e0a25a7f120ab0c1ea680f9d7796af207423d02203",
+			"Peers": [{
+				"ID":         4848068775639388,
+				"StableID":   "njtkGfYhre11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2c2dccf13a166a7b66544f45d03ab772a6f09e2aa81ae2a5c980459746c5a405",
+				"DiscoKey":   "discokey:81e6d4c58a7c272b7b32a802665ceb7f0a9238b0bb856b8421eed511bd3e4c36",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:52285", "10.65.0.27:52285", "172.17.0.1:52285"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:50:29.035878341Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         7115789059979959,
+				"StableID":   "nY5dMKikZx11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2518b02d135c41e4d1f5fdc81cc8bb7a59b0f15817e6660f10e6192f1248ed60",
+				"DiscoKey":   "discokey:7c0cbbb14eb4b39131cbab93ca2db3269e040fad017de98a21be8d09e58de338",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:40988", "10.65.0.27:40988", "172.17.0.1:40988"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:50:29.587131423Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5129441730058200,
+				"StableID":   "nq5mjhj84h11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5b2b122ab2969a8b0ec7effe2e3830fd92f4f93d4c7011ea34f1480f799c091b",
+				"DiscoKey":   "discokey:99b057ddc616c2274ebb8079e0484ec61e097d292dcc04749c157ecf3edea702",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41267", "10.65.0.27:41267", "172.17.0.1:41267"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:50:30.14063926Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8972801687360610,
+				"StableID":   "nPyNCYHo4D21CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0700fd912ade860cd12c2d0b33e8453d1081c2406a1170349708678a9a91ce00",
+				"DiscoKey":   "discokey:782ec6bed5d5ba43364ebdfcec4e659b33958c9d9842972af90507923b6f0d71",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:56471", "10.65.0.27:56471", "172.17.0.1:56471"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:50:30.714012093Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1626766312943096,
+				"StableID":   "n3kZUmPmhD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:60abe045d930e1900b95a6c9c347d4126307a6e3224e1a0bfe37b28151ac9b08",
+				"DiscoKey":   "discokey:6efbfaaaac576d8221f0d418f6b64e89676e84bef7218b58564e6a932f74235a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:40215", "10.65.0.27:40215", "172.17.0.1:40215"],
+				"HomeDERP":   18,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:50:31.229549495Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5605597977720546,
+				"StableID":   "nqYip6Znmk11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:69acf5fe1d088dbd42dcd3755a993a4c1b60a6baa889b404d190805197c21b33",
+				"DiscoKey":   "discokey:646b5ca2368ee9420faffa83716d85d340aacc99d04a6d058e431a414253837c",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:51426", "10.65.0.27:51426", "172.17.0.1:51426"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:50:31.770150908Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2379450406134494,
+				"StableID":   "nsX1MP8faK11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:516d92d2b8686dab28c9007a32d56321a1e5b7d7441d7568d4ecbc737cdd5d5c",
+				"DiscoKey":   "discokey:bc476333971dabc88ca2a564b669d3dca3d131da77f67ecad99b9d24f13d0579",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:52883", "10.65.0.27:52883", "172.17.0.1:52883"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:50:32.318514826Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8131526495021484,
+				"StableID":   "nD78GvQnV621CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4665af95b54a923290ae72f1f8a0c19654ade55b56db7896ae19184f56787913",
+				"DiscoKey":   "discokey:03bcd8b79257b45e0b6735c2505134cd62faeff756a13a94ddb4bef03e3f976d",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:47670", "10.65.0.27:47670", "172.17.0.1:47670"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:50:32.882489646Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         153621018168083,
+				"StableID":   "nJUrK6NaC211CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:4f07b8d8154e003c310f0697e38d71aa5dc5630a7eac89c86bc0314320858827",
+				"DiscoKey":   "discokey:1826926d01a5869441abec291ee4cc447d4bc629696bcea120aae25cec59ce6f",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:43214", "10.65.0.27:43214", "172.17.0.1:43214"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:50:33.402874067Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7824592227270189,
+				"StableID":   "nCxr4emm6421CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f8947d9c2c6d64f1a5164163773f0eaa6367c9a179b3dfdfe1a8e10e373d181d",
+				"DiscoKey":   "discokey:b558da10cbd5fed48c3deb733dfac08676a29bdf76f4ae6bbf3015bc3482c87b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43754", "10.65.0.27:43754", "172.17.0.1:43754"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:50:34.498437307Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         416464208629859,
+				"StableID":   "nzW71uocF411CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c7c3dc0221fcb860e72a40893a8f8a40d4c1c4d0aff5ea0762737a861c4a2e63",
+				"DiscoKey":   "discokey:076c6e8f269e32025d8b488ff9cee71cbb8fa8691330b7cceb7625daad3a6e4c",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57652", "10.65.0.27:57652", "172.17.0.1:57652"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:50:35.0309695Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7793136910147660,
+				"StableID":   "nVDZQXVXr321CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:c80de0dd4c81b6caeea593ad21f448eb7db8780eaed2978a4b916b53ee512e4b",
+				"KeyExpiry":  "2026-11-08T18:50:35Z",
+				"DiscoKey":   "discokey:a91666c0d3665bf6efaf48bc015d030b2981f027b336ca28ae1ff11c2b0c7b29",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:41480", "10.65.0.27:41480", "172.17.0.1:41480"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:50:35.570372163Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7768060240312028,
+				"StableID":   "n59uxfmAf321CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:448e7f5c681a0539e0aa7c0db736a07e0ea5e2f2094a875e08215258e04c8c4d",
+				"KeyExpiry":  "2026-11-08T18:50:36Z",
+				"DiscoKey":   "discokey:01f07f0ff1e5ee52eb61273316a52c40f3f4641cc48521d8ee48fe50d190054b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:60152", "10.65.0.27:60152", "172.17.0.1:60152"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:50:36.133805253Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         8950596656120624,
+				"StableID":   "njz8dozjtC21CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:ae1be9cb1c92be412a4259af291e9344324b1d4b049190a94aedea158198cc48",
+				"KeyExpiry":  "2026-11-08T18:50:36Z",
+				"DiscoKey":   "discokey:a620f71db99c7043750d0e588b28c9a67ae2038960fb219cc1ddec2a34039a73",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:54343", "10.65.0.27:54343", "172.17.0.1:54343"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:50:36.665566368Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5801362570320204": {
+				"ID":          5801362570320204,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/sshtest_results/sshtest-user-literal-multi-rule.hujson
+++ b/hscontrol/policy/v2/testdata/sshtest_results/sshtest-user-literal-multi-rule.hujson
@@ -1,0 +1,18776 @@
+// sshtest-user-literal-multi-rule
+//
+// two ssh rules, each with one literal user
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T18:51:21Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "sshtest-user-literal-multi-rule",
+	"description":    "two ssh rules, each with one literal user",
+	"category":       "sshtest",
+	"captured_at":    "2026-05-12T18:51:21.973337869Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                  \n  \n                                                                     \n                                     \n{\n\t\"category\":    \"sshtest\",\n\t\"description\": \"two ssh rules, each with one literal user\",\n\t\"id\":          \"sshtest-user-literal-multi-rule\",\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"thor@example.org\"],\n\t\t\"users\":  [\"root\"]\n\t}, {\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"thor@example.org\"],\n\t\t\"users\":  [\"ubuntu\"]\n\t}], \"sshTests\": [{\n\t\t\"accept\": [\"root\", \"ubuntu\"],\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    \"thor@example.org\"\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/sshtest/sshtest-user-literal-multi-rule.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["thor@example.org"],
+				"users":  ["root"]
+			}, {
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["thor@example.org"],
+				"users":  ["ubuntu"]
+			}],
+			"sshTests": [{
+				"accept": ["root", "ubuntu"],
+				"dst":    ["tag:server"],
+				"src":    "thor@example.org"
+			}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4439855957749030,
+				"StableID":   "nM61RGVpfb11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       4439855957749030,
+				"Key":        "nodekey:8f3a85b8eb24101ac1ede507e0fd2389504e24423deded0b7fbfaf0807e6897c",
+				"DiscoKey":   "discokey:7886b02cd179feebdbbac5955072e70804e54a7d71aa8a13ec161b94400c2a7e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:36709", "10.65.0.27:36709", "172.17.0.1:36709"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:51:30.753353578Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8f3a85b8eb24101ac1ede507e0fd2389504e24423deded0b7fbfaf0807e6897c",
+			"MachineKey": "mkey:20cee42a3f0db64a85e3a5cbf7da4fb9946c6d1fef5a59015a84495c740a5b12",
+			"Peers": [{
+				"ID":         5628128252104044,
+				"StableID":   "nsn52NPzwk11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba6801239b7f5c97f8c5e855d301b1eedbed3d1a5d16f652f6c4d5e34920a96c",
+				"DiscoKey":   "discokey:6ca69ac49c51d4e6d65afb40cd50269fb4fc834a833dfa178262b7e13417216d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:38933", "10.65.0.27:38933", "172.17.0.1:38933"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:51:24.584727992Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         71344946930895,
+				"StableID":   "nzvkeR7KZ111CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:46f63cad496524072339ff16f74dc5ebb63e25d5e0e9d005da489287588fdc0d",
+				"DiscoKey":   "discokey:7e76f4f6c91d763d4d27fbe27b0be8dc3e35631ad25cdd96adf033afa2e71a53",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:38126", "10.65.0.27:38126", "172.17.0.1:38126"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:51:25.115529597Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8297645981819825,
+				"StableID":   "nEFfTC62o721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f323d57536e232692450f2ba506063f9209b495c21889a83647388f48c9eae68",
+				"DiscoKey":   "discokey:e1c844412e64ef5e4267f2829bd76203a23823c8672f3a343e4a9aa54e918158",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:59242", "10.65.0.27:59242", "172.17.0.1:59242"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:51:25.647896301Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5514747121731931,
+				"StableID":   "ncRRnD4e4k11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd98d2d97a17fb12b4a2c3939d6e762a0d4abe3869f1f937bac71c01bdfaa940",
+				"DiscoKey":   "discokey:bd5272f8d3601c1e0573fc1d391f38f02c3b2dbf007435a62ada0ac84a2bcf02",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:44798", "10.65.0.27:44798", "172.17.0.1:44798"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:51:26.191079134Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4971481959757606,
+				"StableID":   "nMU8kFQbpf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a41743ee4fafe1fe75ecdc0faefb323d679324f0e7f9f68bc6fdba9ad9f99d5c",
+				"DiscoKey":   "discokey:beb60092132ea609a4bd40d0a0c20a79fb0299a556c0440ff368555410bb0f7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:49496", "10.65.0.27:49496", "172.17.0.1:49496"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:51:26.728935804Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5141030055159316,
+				"StableID":   "nmTxLE9P9h11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d8ff652871593d098151d2e69758795c414908f0bf7ab8c31b25fb2076517b19",
+				"DiscoKey":   "discokey:187976775212e4ad67e75620fa3c50006aee1e70b05a1cdb88c08032b7610e43",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:55841", "10.65.0.27:55841", "172.17.0.1:55841"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:51:27.302162171Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3416064133656798,
+				"StableID":   "nMzHjJD9gT11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25d2146a049c644507e9ff718ce78bc8d48f6ffe4e7ec6d9f57c97a8cab9514c",
+				"DiscoKey":   "discokey:b14f3582b8cbc98ebecee76d00dbc8c83fd1fe7bedf33db0a24930749847f14d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:42333", "10.65.0.27:42333", "172.17.0.1:42333"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 59245},
+					{"Proto": "peerapi6", "Port": 59245}
+				]},
+				"Created":              "2026-05-12T18:51:27.876907986Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         164931780953466,
+				"StableID":   "nRWdhjUhH211CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5e27e9185cebed651db29cf9ad3ab40177681414afc1047699bc5930fc34f6a",
+				"DiscoKey":   "discokey:84af48a4bd04de3444a4c7e92997bb58d7aaeeecb90aa65803713889f6ee8f42",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:39321", "10.65.0.27:39321", "172.17.0.1:39321"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:51:28.602230915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2690128459323094,
+				"StableID":   "n1gD3Z7N1N11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2ce2603b906e8385bdfae6e5f0c9a932286bfef0f5695b4fe37e421632092b44",
+				"DiscoKey":   "discokey:4d44cf97a08c39ed2e72f7079b74c9d0c8386f15154c3362b74acde2cc9c754a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60586", "10.65.0.27:60586", "172.17.0.1:60586"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:51:29.161742279Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1457385167649690,
+				"StableID":   "noVgg934PC11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a89d1dbd8d0c049c91fbd8887e0a1ac13e66c7a5103e6d69a7348234a24d2a2e",
+				"DiscoKey":   "discokey:bb65eb7b4f5841fbd1b0a9c1b589b44b8b1abc010788a1707da5f853572b906b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:47388", "10.65.0.27:47388", "172.17.0.1:47388"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:51:29.682711854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7494445489970408,
+				"StableID":   "nuKhRjNFX121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe33daa484b41b1bf9e8df2b17d465d41055058865e1f5a7302181cfc6298e36",
+				"DiscoKey":   "discokey:0692d7ba407c762d65964396fef78cc7e3dd4af1ea9d0b73f6d692fd0472d65c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:46231", "10.65.0.27:46231", "172.17.0.1:46231"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:51:30.223129223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1350468164336331,
+				"StableID":   "nntqDWWdYB11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:350ba3b593804a44b74fa9c79239c6944b6ae8fafc1ed0b8aa5c3699edd71d62",
+				"KeyExpiry":  "2026-11-08T18:51:31Z",
+				"DiscoKey":   "discokey:6a5ef513844398f781a03acd907fd46470a55a59f33d61bd0a28cfd3f3de0320",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:36031", "10.65.0.27:36031", "172.17.0.1:36031"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:51:31.294369953Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6228112467025846,
+				"StableID":   "n7uRYJxidq11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9eec78962450387ca8275c9ced55103dd1a5a6fa387ea6623ae570fa22482120",
+				"KeyExpiry":  "2026-11-08T18:51:31Z",
+				"DiscoKey":   "discokey:19d83dcd1531f76e223b176b9e432a883bddb4658e1f57ca666b1a7928baff2a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:53780", "10.65.0.27:53780", "172.17.0.1:53780"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:51:31.839393419Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7328120482284092,
+				"StableID":   "n7St3LJvDz11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b26bc7e9df99066514c538007e9df6593abd4adbc02192b64269fc6fa3760355",
+				"KeyExpiry":  "2026-11-08T18:51:32Z",
+				"DiscoKey":   "discokey:22e38abaee1b6c0b0c9724025647a3c78b8d48a4cfc828d1fa80bfcdf2fc9b33",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:55313", "10.65.0.27:55313", "172.17.0.1:55313"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:51:32.384551884Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{
+				"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+				"sshUsers":   {"root": "root"},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				}
+			}, {
+				"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+				"sshUsers":   {"root": "", "ubuntu": "ubuntu"},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				}
+			}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4439855957749030": {
+				"ID":          4439855957749030,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		},
+		"ssh_rules": [{
+			"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+			"sshUsers":   {"root": "root"},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}
+		}, {
+			"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+			"sshUsers":   {"root": "", "ubuntu": "ubuntu"},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}
+		}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5141030055159316,
+				"StableID":   "nmTxLE9P9h11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       5141030055159316,
+				"Key":        "nodekey:d8ff652871593d098151d2e69758795c414908f0bf7ab8c31b25fb2076517b19",
+				"DiscoKey":   "discokey:187976775212e4ad67e75620fa3c50006aee1e70b05a1cdb88c08032b7610e43",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:55841", "10.65.0.27:55841", "172.17.0.1:55841"],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:51:27.302162171Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d8ff652871593d098151d2e69758795c414908f0bf7ab8c31b25fb2076517b19",
+			"MachineKey": "mkey:0bac0d5cd903b499d9260202b7b9be85b3f88851441105762d4b009854c7aa2b",
+			"Peers": [{
+				"ID":         5628128252104044,
+				"StableID":   "nsn52NPzwk11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba6801239b7f5c97f8c5e855d301b1eedbed3d1a5d16f652f6c4d5e34920a96c",
+				"DiscoKey":   "discokey:6ca69ac49c51d4e6d65afb40cd50269fb4fc834a833dfa178262b7e13417216d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:38933", "10.65.0.27:38933", "172.17.0.1:38933"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:51:24.584727992Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         71344946930895,
+				"StableID":   "nzvkeR7KZ111CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:46f63cad496524072339ff16f74dc5ebb63e25d5e0e9d005da489287588fdc0d",
+				"DiscoKey":   "discokey:7e76f4f6c91d763d4d27fbe27b0be8dc3e35631ad25cdd96adf033afa2e71a53",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:38126", "10.65.0.27:38126", "172.17.0.1:38126"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:51:25.115529597Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8297645981819825,
+				"StableID":   "nEFfTC62o721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f323d57536e232692450f2ba506063f9209b495c21889a83647388f48c9eae68",
+				"DiscoKey":   "discokey:e1c844412e64ef5e4267f2829bd76203a23823c8672f3a343e4a9aa54e918158",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:59242", "10.65.0.27:59242", "172.17.0.1:59242"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:51:25.647896301Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5514747121731931,
+				"StableID":   "ncRRnD4e4k11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd98d2d97a17fb12b4a2c3939d6e762a0d4abe3869f1f937bac71c01bdfaa940",
+				"DiscoKey":   "discokey:bd5272f8d3601c1e0573fc1d391f38f02c3b2dbf007435a62ada0ac84a2bcf02",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:44798", "10.65.0.27:44798", "172.17.0.1:44798"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:51:26.191079134Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4971481959757606,
+				"StableID":   "nMU8kFQbpf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a41743ee4fafe1fe75ecdc0faefb323d679324f0e7f9f68bc6fdba9ad9f99d5c",
+				"DiscoKey":   "discokey:beb60092132ea609a4bd40d0a0c20a79fb0299a556c0440ff368555410bb0f7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:49496", "10.65.0.27:49496", "172.17.0.1:49496"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:51:26.728935804Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3416064133656798,
+				"StableID":   "nMzHjJD9gT11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25d2146a049c644507e9ff718ce78bc8d48f6ffe4e7ec6d9f57c97a8cab9514c",
+				"DiscoKey":   "discokey:b14f3582b8cbc98ebecee76d00dbc8c83fd1fe7bedf33db0a24930749847f14d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:42333", "10.65.0.27:42333", "172.17.0.1:42333"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 59245},
+					{"Proto": "peerapi6", "Port": 59245}
+				]},
+				"Created":              "2026-05-12T18:51:27.876907986Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         164931780953466,
+				"StableID":   "nRWdhjUhH211CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5e27e9185cebed651db29cf9ad3ab40177681414afc1047699bc5930fc34f6a",
+				"DiscoKey":   "discokey:84af48a4bd04de3444a4c7e92997bb58d7aaeeecb90aa65803713889f6ee8f42",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:39321", "10.65.0.27:39321", "172.17.0.1:39321"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:51:28.602230915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2690128459323094,
+				"StableID":   "n1gD3Z7N1N11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2ce2603b906e8385bdfae6e5f0c9a932286bfef0f5695b4fe37e421632092b44",
+				"DiscoKey":   "discokey:4d44cf97a08c39ed2e72f7079b74c9d0c8386f15154c3362b74acde2cc9c754a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60586", "10.65.0.27:60586", "172.17.0.1:60586"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:51:29.161742279Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1457385167649690,
+				"StableID":   "noVgg934PC11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a89d1dbd8d0c049c91fbd8887e0a1ac13e66c7a5103e6d69a7348234a24d2a2e",
+				"DiscoKey":   "discokey:bb65eb7b4f5841fbd1b0a9c1b589b44b8b1abc010788a1707da5f853572b906b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:47388", "10.65.0.27:47388", "172.17.0.1:47388"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:51:29.682711854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7494445489970408,
+				"StableID":   "nuKhRjNFX121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe33daa484b41b1bf9e8df2b17d465d41055058865e1f5a7302181cfc6298e36",
+				"DiscoKey":   "discokey:0692d7ba407c762d65964396fef78cc7e3dd4af1ea9d0b73f6d692fd0472d65c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:46231", "10.65.0.27:46231", "172.17.0.1:46231"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:51:30.223129223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4439855957749030,
+				"StableID":   "nM61RGVpfb11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f3a85b8eb24101ac1ede507e0fd2389504e24423deded0b7fbfaf0807e6897c",
+				"DiscoKey":   "discokey:7886b02cd179feebdbbac5955072e70804e54a7d71aa8a13ec161b94400c2a7e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:36709", "10.65.0.27:36709", "172.17.0.1:36709"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:51:30.753353578Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1350468164336331,
+				"StableID":   "nntqDWWdYB11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:350ba3b593804a44b74fa9c79239c6944b6ae8fafc1ed0b8aa5c3699edd71d62",
+				"KeyExpiry":  "2026-11-08T18:51:31Z",
+				"DiscoKey":   "discokey:6a5ef513844398f781a03acd907fd46470a55a59f33d61bd0a28cfd3f3de0320",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:36031", "10.65.0.27:36031", "172.17.0.1:36031"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:51:31.294369953Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6228112467025846,
+				"StableID":   "n7uRYJxidq11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9eec78962450387ca8275c9ced55103dd1a5a6fa387ea6623ae570fa22482120",
+				"KeyExpiry":  "2026-11-08T18:51:31Z",
+				"DiscoKey":   "discokey:19d83dcd1531f76e223b176b9e432a883bddb4658e1f57ca666b1a7928baff2a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:53780", "10.65.0.27:53780", "172.17.0.1:53780"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:51:31.839393419Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7328120482284092,
+				"StableID":   "n7St3LJvDz11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b26bc7e9df99066514c538007e9df6593abd4adbc02192b64269fc6fa3760355",
+				"KeyExpiry":  "2026-11-08T18:51:32Z",
+				"DiscoKey":   "discokey:22e38abaee1b6c0b0c9724025647a3c78b8d48a4cfc828d1fa80bfcdf2fc9b33",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:55313", "10.65.0.27:55313", "172.17.0.1:55313"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:51:32.384551884Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5141030055159316": {
+				"ID":          5141030055159316,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7328120482284092,
+				"StableID":   "n7St3LJvDz11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b26bc7e9df99066514c538007e9df6593abd4adbc02192b64269fc6fa3760355",
+				"KeyExpiry":  "2026-11-08T18:51:32Z",
+				"DiscoKey":   "discokey:22e38abaee1b6c0b0c9724025647a3c78b8d48a4cfc828d1fa80bfcdf2fc9b33",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:55313", "10.65.0.27:55313", "172.17.0.1:55313"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:51:32.384551884Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b26bc7e9df99066514c538007e9df6593abd4adbc02192b64269fc6fa3760355",
+			"MachineKey": "mkey:cb4eab9f9286ea35d10c0be63261da3fc6d6f63a58ed68e120caa49cf718a04c",
+			"Peers": [{
+				"ID":         5628128252104044,
+				"StableID":   "nsn52NPzwk11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba6801239b7f5c97f8c5e855d301b1eedbed3d1a5d16f652f6c4d5e34920a96c",
+				"DiscoKey":   "discokey:6ca69ac49c51d4e6d65afb40cd50269fb4fc834a833dfa178262b7e13417216d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:38933", "10.65.0.27:38933", "172.17.0.1:38933"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:51:24.584727992Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         71344946930895,
+				"StableID":   "nzvkeR7KZ111CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:46f63cad496524072339ff16f74dc5ebb63e25d5e0e9d005da489287588fdc0d",
+				"DiscoKey":   "discokey:7e76f4f6c91d763d4d27fbe27b0be8dc3e35631ad25cdd96adf033afa2e71a53",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:38126", "10.65.0.27:38126", "172.17.0.1:38126"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:51:25.115529597Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8297645981819825,
+				"StableID":   "nEFfTC62o721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f323d57536e232692450f2ba506063f9209b495c21889a83647388f48c9eae68",
+				"DiscoKey":   "discokey:e1c844412e64ef5e4267f2829bd76203a23823c8672f3a343e4a9aa54e918158",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:59242", "10.65.0.27:59242", "172.17.0.1:59242"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:51:25.647896301Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5514747121731931,
+				"StableID":   "ncRRnD4e4k11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd98d2d97a17fb12b4a2c3939d6e762a0d4abe3869f1f937bac71c01bdfaa940",
+				"DiscoKey":   "discokey:bd5272f8d3601c1e0573fc1d391f38f02c3b2dbf007435a62ada0ac84a2bcf02",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:44798", "10.65.0.27:44798", "172.17.0.1:44798"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:51:26.191079134Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4971481959757606,
+				"StableID":   "nMU8kFQbpf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a41743ee4fafe1fe75ecdc0faefb323d679324f0e7f9f68bc6fdba9ad9f99d5c",
+				"DiscoKey":   "discokey:beb60092132ea609a4bd40d0a0c20a79fb0299a556c0440ff368555410bb0f7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:49496", "10.65.0.27:49496", "172.17.0.1:49496"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:51:26.728935804Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5141030055159316,
+				"StableID":   "nmTxLE9P9h11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d8ff652871593d098151d2e69758795c414908f0bf7ab8c31b25fb2076517b19",
+				"DiscoKey":   "discokey:187976775212e4ad67e75620fa3c50006aee1e70b05a1cdb88c08032b7610e43",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:55841", "10.65.0.27:55841", "172.17.0.1:55841"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:51:27.302162171Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3416064133656798,
+				"StableID":   "nMzHjJD9gT11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25d2146a049c644507e9ff718ce78bc8d48f6ffe4e7ec6d9f57c97a8cab9514c",
+				"DiscoKey":   "discokey:b14f3582b8cbc98ebecee76d00dbc8c83fd1fe7bedf33db0a24930749847f14d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:42333", "10.65.0.27:42333", "172.17.0.1:42333"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 59245},
+					{"Proto": "peerapi6", "Port": 59245}
+				]},
+				"Created":              "2026-05-12T18:51:27.876907986Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         164931780953466,
+				"StableID":   "nRWdhjUhH211CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5e27e9185cebed651db29cf9ad3ab40177681414afc1047699bc5930fc34f6a",
+				"DiscoKey":   "discokey:84af48a4bd04de3444a4c7e92997bb58d7aaeeecb90aa65803713889f6ee8f42",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:39321", "10.65.0.27:39321", "172.17.0.1:39321"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:51:28.602230915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2690128459323094,
+				"StableID":   "n1gD3Z7N1N11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2ce2603b906e8385bdfae6e5f0c9a932286bfef0f5695b4fe37e421632092b44",
+				"DiscoKey":   "discokey:4d44cf97a08c39ed2e72f7079b74c9d0c8386f15154c3362b74acde2cc9c754a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60586", "10.65.0.27:60586", "172.17.0.1:60586"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:51:29.161742279Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1457385167649690,
+				"StableID":   "noVgg934PC11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a89d1dbd8d0c049c91fbd8887e0a1ac13e66c7a5103e6d69a7348234a24d2a2e",
+				"DiscoKey":   "discokey:bb65eb7b4f5841fbd1b0a9c1b589b44b8b1abc010788a1707da5f853572b906b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:47388", "10.65.0.27:47388", "172.17.0.1:47388"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:51:29.682711854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7494445489970408,
+				"StableID":   "nuKhRjNFX121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe33daa484b41b1bf9e8df2b17d465d41055058865e1f5a7302181cfc6298e36",
+				"DiscoKey":   "discokey:0692d7ba407c762d65964396fef78cc7e3dd4af1ea9d0b73f6d692fd0472d65c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:46231", "10.65.0.27:46231", "172.17.0.1:46231"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:51:30.223129223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4439855957749030,
+				"StableID":   "nM61RGVpfb11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f3a85b8eb24101ac1ede507e0fd2389504e24423deded0b7fbfaf0807e6897c",
+				"DiscoKey":   "discokey:7886b02cd179feebdbbac5955072e70804e54a7d71aa8a13ec161b94400c2a7e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:36709", "10.65.0.27:36709", "172.17.0.1:36709"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:51:30.753353578Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1350468164336331,
+				"StableID":   "nntqDWWdYB11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:350ba3b593804a44b74fa9c79239c6944b6ae8fafc1ed0b8aa5c3699edd71d62",
+				"KeyExpiry":  "2026-11-08T18:51:31Z",
+				"DiscoKey":   "discokey:6a5ef513844398f781a03acd907fd46470a55a59f33d61bd0a28cfd3f3de0320",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:36031", "10.65.0.27:36031", "172.17.0.1:36031"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:51:31.294369953Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6228112467025846,
+				"StableID":   "n7uRYJxidq11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9eec78962450387ca8275c9ced55103dd1a5a6fa387ea6623ae570fa22482120",
+				"KeyExpiry":  "2026-11-08T18:51:31Z",
+				"DiscoKey":   "discokey:19d83dcd1531f76e223b176b9e432a883bddb4658e1f57ca666b1a7928baff2a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:53780", "10.65.0.27:53780", "172.17.0.1:53780"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:51:31.839393419Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8297645981819825,
+				"StableID":   "nEFfTC62o721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       8297645981819825,
+				"Key":        "nodekey:f323d57536e232692450f2ba506063f9209b495c21889a83647388f48c9eae68",
+				"DiscoKey":   "discokey:e1c844412e64ef5e4267f2829bd76203a23823c8672f3a343e4a9aa54e918158",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:59242", "10.65.0.27:59242", "172.17.0.1:59242"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:51:25.647896301Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f323d57536e232692450f2ba506063f9209b495c21889a83647388f48c9eae68",
+			"MachineKey": "mkey:868105bd38d4cbad05e1609c8c5ecbfcf0320fb8bb2d0dc613f3a4012dc17965",
+			"Peers": [{
+				"ID":         5628128252104044,
+				"StableID":   "nsn52NPzwk11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba6801239b7f5c97f8c5e855d301b1eedbed3d1a5d16f652f6c4d5e34920a96c",
+				"DiscoKey":   "discokey:6ca69ac49c51d4e6d65afb40cd50269fb4fc834a833dfa178262b7e13417216d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:38933", "10.65.0.27:38933", "172.17.0.1:38933"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:51:24.584727992Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         71344946930895,
+				"StableID":   "nzvkeR7KZ111CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:46f63cad496524072339ff16f74dc5ebb63e25d5e0e9d005da489287588fdc0d",
+				"DiscoKey":   "discokey:7e76f4f6c91d763d4d27fbe27b0be8dc3e35631ad25cdd96adf033afa2e71a53",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:38126", "10.65.0.27:38126", "172.17.0.1:38126"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:51:25.115529597Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5514747121731931,
+				"StableID":   "ncRRnD4e4k11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd98d2d97a17fb12b4a2c3939d6e762a0d4abe3869f1f937bac71c01bdfaa940",
+				"DiscoKey":   "discokey:bd5272f8d3601c1e0573fc1d391f38f02c3b2dbf007435a62ada0ac84a2bcf02",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:44798", "10.65.0.27:44798", "172.17.0.1:44798"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:51:26.191079134Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4971481959757606,
+				"StableID":   "nMU8kFQbpf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a41743ee4fafe1fe75ecdc0faefb323d679324f0e7f9f68bc6fdba9ad9f99d5c",
+				"DiscoKey":   "discokey:beb60092132ea609a4bd40d0a0c20a79fb0299a556c0440ff368555410bb0f7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:49496", "10.65.0.27:49496", "172.17.0.1:49496"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:51:26.728935804Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5141030055159316,
+				"StableID":   "nmTxLE9P9h11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d8ff652871593d098151d2e69758795c414908f0bf7ab8c31b25fb2076517b19",
+				"DiscoKey":   "discokey:187976775212e4ad67e75620fa3c50006aee1e70b05a1cdb88c08032b7610e43",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:55841", "10.65.0.27:55841", "172.17.0.1:55841"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:51:27.302162171Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3416064133656798,
+				"StableID":   "nMzHjJD9gT11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25d2146a049c644507e9ff718ce78bc8d48f6ffe4e7ec6d9f57c97a8cab9514c",
+				"DiscoKey":   "discokey:b14f3582b8cbc98ebecee76d00dbc8c83fd1fe7bedf33db0a24930749847f14d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:42333", "10.65.0.27:42333", "172.17.0.1:42333"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 59245},
+					{"Proto": "peerapi6", "Port": 59245}
+				]},
+				"Created":              "2026-05-12T18:51:27.876907986Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         164931780953466,
+				"StableID":   "nRWdhjUhH211CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5e27e9185cebed651db29cf9ad3ab40177681414afc1047699bc5930fc34f6a",
+				"DiscoKey":   "discokey:84af48a4bd04de3444a4c7e92997bb58d7aaeeecb90aa65803713889f6ee8f42",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:39321", "10.65.0.27:39321", "172.17.0.1:39321"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:51:28.602230915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2690128459323094,
+				"StableID":   "n1gD3Z7N1N11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2ce2603b906e8385bdfae6e5f0c9a932286bfef0f5695b4fe37e421632092b44",
+				"DiscoKey":   "discokey:4d44cf97a08c39ed2e72f7079b74c9d0c8386f15154c3362b74acde2cc9c754a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60586", "10.65.0.27:60586", "172.17.0.1:60586"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:51:29.161742279Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1457385167649690,
+				"StableID":   "noVgg934PC11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a89d1dbd8d0c049c91fbd8887e0a1ac13e66c7a5103e6d69a7348234a24d2a2e",
+				"DiscoKey":   "discokey:bb65eb7b4f5841fbd1b0a9c1b589b44b8b1abc010788a1707da5f853572b906b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:47388", "10.65.0.27:47388", "172.17.0.1:47388"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:51:29.682711854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7494445489970408,
+				"StableID":   "nuKhRjNFX121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe33daa484b41b1bf9e8df2b17d465d41055058865e1f5a7302181cfc6298e36",
+				"DiscoKey":   "discokey:0692d7ba407c762d65964396fef78cc7e3dd4af1ea9d0b73f6d692fd0472d65c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:46231", "10.65.0.27:46231", "172.17.0.1:46231"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:51:30.223129223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4439855957749030,
+				"StableID":   "nM61RGVpfb11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f3a85b8eb24101ac1ede507e0fd2389504e24423deded0b7fbfaf0807e6897c",
+				"DiscoKey":   "discokey:7886b02cd179feebdbbac5955072e70804e54a7d71aa8a13ec161b94400c2a7e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:36709", "10.65.0.27:36709", "172.17.0.1:36709"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:51:30.753353578Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1350468164336331,
+				"StableID":   "nntqDWWdYB11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:350ba3b593804a44b74fa9c79239c6944b6ae8fafc1ed0b8aa5c3699edd71d62",
+				"KeyExpiry":  "2026-11-08T18:51:31Z",
+				"DiscoKey":   "discokey:6a5ef513844398f781a03acd907fd46470a55a59f33d61bd0a28cfd3f3de0320",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:36031", "10.65.0.27:36031", "172.17.0.1:36031"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:51:31.294369953Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6228112467025846,
+				"StableID":   "n7uRYJxidq11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9eec78962450387ca8275c9ced55103dd1a5a6fa387ea6623ae570fa22482120",
+				"KeyExpiry":  "2026-11-08T18:51:31Z",
+				"DiscoKey":   "discokey:19d83dcd1531f76e223b176b9e432a883bddb4658e1f57ca666b1a7928baff2a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:53780", "10.65.0.27:53780", "172.17.0.1:53780"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:51:31.839393419Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7328120482284092,
+				"StableID":   "n7St3LJvDz11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b26bc7e9df99066514c538007e9df6593abd4adbc02192b64269fc6fa3760355",
+				"KeyExpiry":  "2026-11-08T18:51:32Z",
+				"DiscoKey":   "discokey:22e38abaee1b6c0b0c9724025647a3c78b8d48a4cfc828d1fa80bfcdf2fc9b33",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:55313", "10.65.0.27:55313", "172.17.0.1:55313"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:51:32.384551884Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8297645981819825": {
+				"ID":          8297645981819825,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         164931780953466,
+				"StableID":   "nRWdhjUhH211CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       164931780953466,
+				"Key":        "nodekey:e5e27e9185cebed651db29cf9ad3ab40177681414afc1047699bc5930fc34f6a",
+				"DiscoKey":   "discokey:84af48a4bd04de3444a4c7e92997bb58d7aaeeecb90aa65803713889f6ee8f42",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:39321", "10.65.0.27:39321", "172.17.0.1:39321"],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:51:28.602230915Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e5e27e9185cebed651db29cf9ad3ab40177681414afc1047699bc5930fc34f6a",
+			"MachineKey": "mkey:35db93088ffd0acf9cb7a2ea727197628dd633482eca91517344b026d98ff945",
+			"Peers": [{
+				"ID":         5628128252104044,
+				"StableID":   "nsn52NPzwk11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba6801239b7f5c97f8c5e855d301b1eedbed3d1a5d16f652f6c4d5e34920a96c",
+				"DiscoKey":   "discokey:6ca69ac49c51d4e6d65afb40cd50269fb4fc834a833dfa178262b7e13417216d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:38933", "10.65.0.27:38933", "172.17.0.1:38933"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:51:24.584727992Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         71344946930895,
+				"StableID":   "nzvkeR7KZ111CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:46f63cad496524072339ff16f74dc5ebb63e25d5e0e9d005da489287588fdc0d",
+				"DiscoKey":   "discokey:7e76f4f6c91d763d4d27fbe27b0be8dc3e35631ad25cdd96adf033afa2e71a53",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:38126", "10.65.0.27:38126", "172.17.0.1:38126"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:51:25.115529597Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8297645981819825,
+				"StableID":   "nEFfTC62o721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f323d57536e232692450f2ba506063f9209b495c21889a83647388f48c9eae68",
+				"DiscoKey":   "discokey:e1c844412e64ef5e4267f2829bd76203a23823c8672f3a343e4a9aa54e918158",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:59242", "10.65.0.27:59242", "172.17.0.1:59242"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:51:25.647896301Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5514747121731931,
+				"StableID":   "ncRRnD4e4k11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd98d2d97a17fb12b4a2c3939d6e762a0d4abe3869f1f937bac71c01bdfaa940",
+				"DiscoKey":   "discokey:bd5272f8d3601c1e0573fc1d391f38f02c3b2dbf007435a62ada0ac84a2bcf02",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:44798", "10.65.0.27:44798", "172.17.0.1:44798"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:51:26.191079134Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4971481959757606,
+				"StableID":   "nMU8kFQbpf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a41743ee4fafe1fe75ecdc0faefb323d679324f0e7f9f68bc6fdba9ad9f99d5c",
+				"DiscoKey":   "discokey:beb60092132ea609a4bd40d0a0c20a79fb0299a556c0440ff368555410bb0f7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:49496", "10.65.0.27:49496", "172.17.0.1:49496"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:51:26.728935804Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5141030055159316,
+				"StableID":   "nmTxLE9P9h11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d8ff652871593d098151d2e69758795c414908f0bf7ab8c31b25fb2076517b19",
+				"DiscoKey":   "discokey:187976775212e4ad67e75620fa3c50006aee1e70b05a1cdb88c08032b7610e43",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:55841", "10.65.0.27:55841", "172.17.0.1:55841"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:51:27.302162171Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3416064133656798,
+				"StableID":   "nMzHjJD9gT11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25d2146a049c644507e9ff718ce78bc8d48f6ffe4e7ec6d9f57c97a8cab9514c",
+				"DiscoKey":   "discokey:b14f3582b8cbc98ebecee76d00dbc8c83fd1fe7bedf33db0a24930749847f14d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:42333", "10.65.0.27:42333", "172.17.0.1:42333"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 59245},
+					{"Proto": "peerapi6", "Port": 59245}
+				]},
+				"Created":              "2026-05-12T18:51:27.876907986Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2690128459323094,
+				"StableID":   "n1gD3Z7N1N11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2ce2603b906e8385bdfae6e5f0c9a932286bfef0f5695b4fe37e421632092b44",
+				"DiscoKey":   "discokey:4d44cf97a08c39ed2e72f7079b74c9d0c8386f15154c3362b74acde2cc9c754a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60586", "10.65.0.27:60586", "172.17.0.1:60586"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:51:29.161742279Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1457385167649690,
+				"StableID":   "noVgg934PC11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a89d1dbd8d0c049c91fbd8887e0a1ac13e66c7a5103e6d69a7348234a24d2a2e",
+				"DiscoKey":   "discokey:bb65eb7b4f5841fbd1b0a9c1b589b44b8b1abc010788a1707da5f853572b906b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:47388", "10.65.0.27:47388", "172.17.0.1:47388"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:51:29.682711854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7494445489970408,
+				"StableID":   "nuKhRjNFX121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe33daa484b41b1bf9e8df2b17d465d41055058865e1f5a7302181cfc6298e36",
+				"DiscoKey":   "discokey:0692d7ba407c762d65964396fef78cc7e3dd4af1ea9d0b73f6d692fd0472d65c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:46231", "10.65.0.27:46231", "172.17.0.1:46231"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:51:30.223129223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4439855957749030,
+				"StableID":   "nM61RGVpfb11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f3a85b8eb24101ac1ede507e0fd2389504e24423deded0b7fbfaf0807e6897c",
+				"DiscoKey":   "discokey:7886b02cd179feebdbbac5955072e70804e54a7d71aa8a13ec161b94400c2a7e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:36709", "10.65.0.27:36709", "172.17.0.1:36709"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:51:30.753353578Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1350468164336331,
+				"StableID":   "nntqDWWdYB11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:350ba3b593804a44b74fa9c79239c6944b6ae8fafc1ed0b8aa5c3699edd71d62",
+				"KeyExpiry":  "2026-11-08T18:51:31Z",
+				"DiscoKey":   "discokey:6a5ef513844398f781a03acd907fd46470a55a59f33d61bd0a28cfd3f3de0320",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:36031", "10.65.0.27:36031", "172.17.0.1:36031"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:51:31.294369953Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6228112467025846,
+				"StableID":   "n7uRYJxidq11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9eec78962450387ca8275c9ced55103dd1a5a6fa387ea6623ae570fa22482120",
+				"KeyExpiry":  "2026-11-08T18:51:31Z",
+				"DiscoKey":   "discokey:19d83dcd1531f76e223b176b9e432a883bddb4658e1f57ca666b1a7928baff2a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:53780", "10.65.0.27:53780", "172.17.0.1:53780"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:51:31.839393419Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7328120482284092,
+				"StableID":   "n7St3LJvDz11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b26bc7e9df99066514c538007e9df6593abd4adbc02192b64269fc6fa3760355",
+				"KeyExpiry":  "2026-11-08T18:51:32Z",
+				"DiscoKey":   "discokey:22e38abaee1b6c0b0c9724025647a3c78b8d48a4cfc828d1fa80bfcdf2fc9b33",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:55313", "10.65.0.27:55313", "172.17.0.1:55313"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:51:32.384551884Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "164931780953466": {
+				"ID":          164931780953466,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1350468164336331,
+				"StableID":   "nntqDWWdYB11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:350ba3b593804a44b74fa9c79239c6944b6ae8fafc1ed0b8aa5c3699edd71d62",
+				"KeyExpiry":  "2026-11-08T18:51:31Z",
+				"DiscoKey":   "discokey:6a5ef513844398f781a03acd907fd46470a55a59f33d61bd0a28cfd3f3de0320",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:36031", "10.65.0.27:36031", "172.17.0.1:36031"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:51:31.294369953Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:350ba3b593804a44b74fa9c79239c6944b6ae8fafc1ed0b8aa5c3699edd71d62",
+			"MachineKey": "mkey:a63979b39bd811a2e3a37352cfb81a48a6a3dd00972acee7523690135fa64201",
+			"Peers": [{
+				"ID":         5628128252104044,
+				"StableID":   "nsn52NPzwk11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba6801239b7f5c97f8c5e855d301b1eedbed3d1a5d16f652f6c4d5e34920a96c",
+				"DiscoKey":   "discokey:6ca69ac49c51d4e6d65afb40cd50269fb4fc834a833dfa178262b7e13417216d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:38933", "10.65.0.27:38933", "172.17.0.1:38933"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:51:24.584727992Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         71344946930895,
+				"StableID":   "nzvkeR7KZ111CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:46f63cad496524072339ff16f74dc5ebb63e25d5e0e9d005da489287588fdc0d",
+				"DiscoKey":   "discokey:7e76f4f6c91d763d4d27fbe27b0be8dc3e35631ad25cdd96adf033afa2e71a53",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:38126", "10.65.0.27:38126", "172.17.0.1:38126"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:51:25.115529597Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8297645981819825,
+				"StableID":   "nEFfTC62o721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f323d57536e232692450f2ba506063f9209b495c21889a83647388f48c9eae68",
+				"DiscoKey":   "discokey:e1c844412e64ef5e4267f2829bd76203a23823c8672f3a343e4a9aa54e918158",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:59242", "10.65.0.27:59242", "172.17.0.1:59242"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:51:25.647896301Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5514747121731931,
+				"StableID":   "ncRRnD4e4k11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd98d2d97a17fb12b4a2c3939d6e762a0d4abe3869f1f937bac71c01bdfaa940",
+				"DiscoKey":   "discokey:bd5272f8d3601c1e0573fc1d391f38f02c3b2dbf007435a62ada0ac84a2bcf02",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:44798", "10.65.0.27:44798", "172.17.0.1:44798"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:51:26.191079134Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4971481959757606,
+				"StableID":   "nMU8kFQbpf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a41743ee4fafe1fe75ecdc0faefb323d679324f0e7f9f68bc6fdba9ad9f99d5c",
+				"DiscoKey":   "discokey:beb60092132ea609a4bd40d0a0c20a79fb0299a556c0440ff368555410bb0f7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:49496", "10.65.0.27:49496", "172.17.0.1:49496"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:51:26.728935804Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5141030055159316,
+				"StableID":   "nmTxLE9P9h11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d8ff652871593d098151d2e69758795c414908f0bf7ab8c31b25fb2076517b19",
+				"DiscoKey":   "discokey:187976775212e4ad67e75620fa3c50006aee1e70b05a1cdb88c08032b7610e43",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:55841", "10.65.0.27:55841", "172.17.0.1:55841"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:51:27.302162171Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3416064133656798,
+				"StableID":   "nMzHjJD9gT11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25d2146a049c644507e9ff718ce78bc8d48f6ffe4e7ec6d9f57c97a8cab9514c",
+				"DiscoKey":   "discokey:b14f3582b8cbc98ebecee76d00dbc8c83fd1fe7bedf33db0a24930749847f14d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:42333", "10.65.0.27:42333", "172.17.0.1:42333"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 59245},
+					{"Proto": "peerapi6", "Port": 59245}
+				]},
+				"Created":              "2026-05-12T18:51:27.876907986Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         164931780953466,
+				"StableID":   "nRWdhjUhH211CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5e27e9185cebed651db29cf9ad3ab40177681414afc1047699bc5930fc34f6a",
+				"DiscoKey":   "discokey:84af48a4bd04de3444a4c7e92997bb58d7aaeeecb90aa65803713889f6ee8f42",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:39321", "10.65.0.27:39321", "172.17.0.1:39321"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:51:28.602230915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2690128459323094,
+				"StableID":   "n1gD3Z7N1N11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2ce2603b906e8385bdfae6e5f0c9a932286bfef0f5695b4fe37e421632092b44",
+				"DiscoKey":   "discokey:4d44cf97a08c39ed2e72f7079b74c9d0c8386f15154c3362b74acde2cc9c754a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60586", "10.65.0.27:60586", "172.17.0.1:60586"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:51:29.161742279Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1457385167649690,
+				"StableID":   "noVgg934PC11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a89d1dbd8d0c049c91fbd8887e0a1ac13e66c7a5103e6d69a7348234a24d2a2e",
+				"DiscoKey":   "discokey:bb65eb7b4f5841fbd1b0a9c1b589b44b8b1abc010788a1707da5f853572b906b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:47388", "10.65.0.27:47388", "172.17.0.1:47388"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:51:29.682711854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7494445489970408,
+				"StableID":   "nuKhRjNFX121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe33daa484b41b1bf9e8df2b17d465d41055058865e1f5a7302181cfc6298e36",
+				"DiscoKey":   "discokey:0692d7ba407c762d65964396fef78cc7e3dd4af1ea9d0b73f6d692fd0472d65c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:46231", "10.65.0.27:46231", "172.17.0.1:46231"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:51:30.223129223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4439855957749030,
+				"StableID":   "nM61RGVpfb11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f3a85b8eb24101ac1ede507e0fd2389504e24423deded0b7fbfaf0807e6897c",
+				"DiscoKey":   "discokey:7886b02cd179feebdbbac5955072e70804e54a7d71aa8a13ec161b94400c2a7e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:36709", "10.65.0.27:36709", "172.17.0.1:36709"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:51:30.753353578Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6228112467025846,
+				"StableID":   "n7uRYJxidq11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9eec78962450387ca8275c9ced55103dd1a5a6fa387ea6623ae570fa22482120",
+				"KeyExpiry":  "2026-11-08T18:51:31Z",
+				"DiscoKey":   "discokey:19d83dcd1531f76e223b176b9e432a883bddb4658e1f57ca666b1a7928baff2a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:53780", "10.65.0.27:53780", "172.17.0.1:53780"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:51:31.839393419Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7328120482284092,
+				"StableID":   "n7St3LJvDz11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b26bc7e9df99066514c538007e9df6593abd4adbc02192b64269fc6fa3760355",
+				"KeyExpiry":  "2026-11-08T18:51:32Z",
+				"DiscoKey":   "discokey:22e38abaee1b6c0b0c9724025647a3c78b8d48a4cfc828d1fa80bfcdf2fc9b33",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:55313", "10.65.0.27:55313", "172.17.0.1:55313"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:51:32.384551884Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7494445489970408,
+				"StableID":   "nuKhRjNFX121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       7494445489970408,
+				"Key":        "nodekey:fe33daa484b41b1bf9e8df2b17d465d41055058865e1f5a7302181cfc6298e36",
+				"DiscoKey":   "discokey:0692d7ba407c762d65964396fef78cc7e3dd4af1ea9d0b73f6d692fd0472d65c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:46231", "10.65.0.27:46231", "172.17.0.1:46231"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:51:30.223129223Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:fe33daa484b41b1bf9e8df2b17d465d41055058865e1f5a7302181cfc6298e36",
+			"MachineKey": "mkey:90a27c120ed231a416ec30758d83dcf89a893a819977bd76443e00c87c647832",
+			"Peers": [{
+				"ID":         5628128252104044,
+				"StableID":   "nsn52NPzwk11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba6801239b7f5c97f8c5e855d301b1eedbed3d1a5d16f652f6c4d5e34920a96c",
+				"DiscoKey":   "discokey:6ca69ac49c51d4e6d65afb40cd50269fb4fc834a833dfa178262b7e13417216d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:38933", "10.65.0.27:38933", "172.17.0.1:38933"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:51:24.584727992Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         71344946930895,
+				"StableID":   "nzvkeR7KZ111CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:46f63cad496524072339ff16f74dc5ebb63e25d5e0e9d005da489287588fdc0d",
+				"DiscoKey":   "discokey:7e76f4f6c91d763d4d27fbe27b0be8dc3e35631ad25cdd96adf033afa2e71a53",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:38126", "10.65.0.27:38126", "172.17.0.1:38126"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:51:25.115529597Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8297645981819825,
+				"StableID":   "nEFfTC62o721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f323d57536e232692450f2ba506063f9209b495c21889a83647388f48c9eae68",
+				"DiscoKey":   "discokey:e1c844412e64ef5e4267f2829bd76203a23823c8672f3a343e4a9aa54e918158",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:59242", "10.65.0.27:59242", "172.17.0.1:59242"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:51:25.647896301Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5514747121731931,
+				"StableID":   "ncRRnD4e4k11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd98d2d97a17fb12b4a2c3939d6e762a0d4abe3869f1f937bac71c01bdfaa940",
+				"DiscoKey":   "discokey:bd5272f8d3601c1e0573fc1d391f38f02c3b2dbf007435a62ada0ac84a2bcf02",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:44798", "10.65.0.27:44798", "172.17.0.1:44798"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:51:26.191079134Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4971481959757606,
+				"StableID":   "nMU8kFQbpf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a41743ee4fafe1fe75ecdc0faefb323d679324f0e7f9f68bc6fdba9ad9f99d5c",
+				"DiscoKey":   "discokey:beb60092132ea609a4bd40d0a0c20a79fb0299a556c0440ff368555410bb0f7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:49496", "10.65.0.27:49496", "172.17.0.1:49496"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:51:26.728935804Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5141030055159316,
+				"StableID":   "nmTxLE9P9h11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d8ff652871593d098151d2e69758795c414908f0bf7ab8c31b25fb2076517b19",
+				"DiscoKey":   "discokey:187976775212e4ad67e75620fa3c50006aee1e70b05a1cdb88c08032b7610e43",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:55841", "10.65.0.27:55841", "172.17.0.1:55841"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:51:27.302162171Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3416064133656798,
+				"StableID":   "nMzHjJD9gT11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25d2146a049c644507e9ff718ce78bc8d48f6ffe4e7ec6d9f57c97a8cab9514c",
+				"DiscoKey":   "discokey:b14f3582b8cbc98ebecee76d00dbc8c83fd1fe7bedf33db0a24930749847f14d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:42333", "10.65.0.27:42333", "172.17.0.1:42333"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 59245},
+					{"Proto": "peerapi6", "Port": 59245}
+				]},
+				"Created":              "2026-05-12T18:51:27.876907986Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         164931780953466,
+				"StableID":   "nRWdhjUhH211CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5e27e9185cebed651db29cf9ad3ab40177681414afc1047699bc5930fc34f6a",
+				"DiscoKey":   "discokey:84af48a4bd04de3444a4c7e92997bb58d7aaeeecb90aa65803713889f6ee8f42",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:39321", "10.65.0.27:39321", "172.17.0.1:39321"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:51:28.602230915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2690128459323094,
+				"StableID":   "n1gD3Z7N1N11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2ce2603b906e8385bdfae6e5f0c9a932286bfef0f5695b4fe37e421632092b44",
+				"DiscoKey":   "discokey:4d44cf97a08c39ed2e72f7079b74c9d0c8386f15154c3362b74acde2cc9c754a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60586", "10.65.0.27:60586", "172.17.0.1:60586"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:51:29.161742279Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1457385167649690,
+				"StableID":   "noVgg934PC11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a89d1dbd8d0c049c91fbd8887e0a1ac13e66c7a5103e6d69a7348234a24d2a2e",
+				"DiscoKey":   "discokey:bb65eb7b4f5841fbd1b0a9c1b589b44b8b1abc010788a1707da5f853572b906b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:47388", "10.65.0.27:47388", "172.17.0.1:47388"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:51:29.682711854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4439855957749030,
+				"StableID":   "nM61RGVpfb11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f3a85b8eb24101ac1ede507e0fd2389504e24423deded0b7fbfaf0807e6897c",
+				"DiscoKey":   "discokey:7886b02cd179feebdbbac5955072e70804e54a7d71aa8a13ec161b94400c2a7e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:36709", "10.65.0.27:36709", "172.17.0.1:36709"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:51:30.753353578Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1350468164336331,
+				"StableID":   "nntqDWWdYB11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:350ba3b593804a44b74fa9c79239c6944b6ae8fafc1ed0b8aa5c3699edd71d62",
+				"KeyExpiry":  "2026-11-08T18:51:31Z",
+				"DiscoKey":   "discokey:6a5ef513844398f781a03acd907fd46470a55a59f33d61bd0a28cfd3f3de0320",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:36031", "10.65.0.27:36031", "172.17.0.1:36031"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:51:31.294369953Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6228112467025846,
+				"StableID":   "n7uRYJxidq11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9eec78962450387ca8275c9ced55103dd1a5a6fa387ea6623ae570fa22482120",
+				"KeyExpiry":  "2026-11-08T18:51:31Z",
+				"DiscoKey":   "discokey:19d83dcd1531f76e223b176b9e432a883bddb4658e1f57ca666b1a7928baff2a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:53780", "10.65.0.27:53780", "172.17.0.1:53780"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:51:31.839393419Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7328120482284092,
+				"StableID":   "n7St3LJvDz11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b26bc7e9df99066514c538007e9df6593abd4adbc02192b64269fc6fa3760355",
+				"KeyExpiry":  "2026-11-08T18:51:32Z",
+				"DiscoKey":   "discokey:22e38abaee1b6c0b0c9724025647a3c78b8d48a4cfc828d1fa80bfcdf2fc9b33",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:55313", "10.65.0.27:55313", "172.17.0.1:55313"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:51:32.384551884Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7494445489970408": {
+				"ID":          7494445489970408,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         71344946930895,
+				"StableID":   "nzvkeR7KZ111CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       71344946930895,
+				"Key":        "nodekey:46f63cad496524072339ff16f74dc5ebb63e25d5e0e9d005da489287588fdc0d",
+				"DiscoKey":   "discokey:7e76f4f6c91d763d4d27fbe27b0be8dc3e35631ad25cdd96adf033afa2e71a53",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:38126", "10.65.0.27:38126", "172.17.0.1:38126"],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:51:25.115529597Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:46f63cad496524072339ff16f74dc5ebb63e25d5e0e9d005da489287588fdc0d",
+			"MachineKey": "mkey:36026105f509603f3f76bfb7e69ba8ab15cc616ce1abb5c3e15e624432c1ac0a",
+			"Peers": [{
+				"ID":         5628128252104044,
+				"StableID":   "nsn52NPzwk11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba6801239b7f5c97f8c5e855d301b1eedbed3d1a5d16f652f6c4d5e34920a96c",
+				"DiscoKey":   "discokey:6ca69ac49c51d4e6d65afb40cd50269fb4fc834a833dfa178262b7e13417216d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:38933", "10.65.0.27:38933", "172.17.0.1:38933"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:51:24.584727992Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8297645981819825,
+				"StableID":   "nEFfTC62o721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f323d57536e232692450f2ba506063f9209b495c21889a83647388f48c9eae68",
+				"DiscoKey":   "discokey:e1c844412e64ef5e4267f2829bd76203a23823c8672f3a343e4a9aa54e918158",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:59242", "10.65.0.27:59242", "172.17.0.1:59242"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:51:25.647896301Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5514747121731931,
+				"StableID":   "ncRRnD4e4k11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd98d2d97a17fb12b4a2c3939d6e762a0d4abe3869f1f937bac71c01bdfaa940",
+				"DiscoKey":   "discokey:bd5272f8d3601c1e0573fc1d391f38f02c3b2dbf007435a62ada0ac84a2bcf02",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:44798", "10.65.0.27:44798", "172.17.0.1:44798"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:51:26.191079134Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4971481959757606,
+				"StableID":   "nMU8kFQbpf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a41743ee4fafe1fe75ecdc0faefb323d679324f0e7f9f68bc6fdba9ad9f99d5c",
+				"DiscoKey":   "discokey:beb60092132ea609a4bd40d0a0c20a79fb0299a556c0440ff368555410bb0f7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:49496", "10.65.0.27:49496", "172.17.0.1:49496"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:51:26.728935804Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5141030055159316,
+				"StableID":   "nmTxLE9P9h11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d8ff652871593d098151d2e69758795c414908f0bf7ab8c31b25fb2076517b19",
+				"DiscoKey":   "discokey:187976775212e4ad67e75620fa3c50006aee1e70b05a1cdb88c08032b7610e43",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:55841", "10.65.0.27:55841", "172.17.0.1:55841"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:51:27.302162171Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3416064133656798,
+				"StableID":   "nMzHjJD9gT11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25d2146a049c644507e9ff718ce78bc8d48f6ffe4e7ec6d9f57c97a8cab9514c",
+				"DiscoKey":   "discokey:b14f3582b8cbc98ebecee76d00dbc8c83fd1fe7bedf33db0a24930749847f14d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:42333", "10.65.0.27:42333", "172.17.0.1:42333"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 59245},
+					{"Proto": "peerapi6", "Port": 59245}
+				]},
+				"Created":              "2026-05-12T18:51:27.876907986Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         164931780953466,
+				"StableID":   "nRWdhjUhH211CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5e27e9185cebed651db29cf9ad3ab40177681414afc1047699bc5930fc34f6a",
+				"DiscoKey":   "discokey:84af48a4bd04de3444a4c7e92997bb58d7aaeeecb90aa65803713889f6ee8f42",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:39321", "10.65.0.27:39321", "172.17.0.1:39321"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:51:28.602230915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2690128459323094,
+				"StableID":   "n1gD3Z7N1N11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2ce2603b906e8385bdfae6e5f0c9a932286bfef0f5695b4fe37e421632092b44",
+				"DiscoKey":   "discokey:4d44cf97a08c39ed2e72f7079b74c9d0c8386f15154c3362b74acde2cc9c754a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60586", "10.65.0.27:60586", "172.17.0.1:60586"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:51:29.161742279Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1457385167649690,
+				"StableID":   "noVgg934PC11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a89d1dbd8d0c049c91fbd8887e0a1ac13e66c7a5103e6d69a7348234a24d2a2e",
+				"DiscoKey":   "discokey:bb65eb7b4f5841fbd1b0a9c1b589b44b8b1abc010788a1707da5f853572b906b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:47388", "10.65.0.27:47388", "172.17.0.1:47388"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:51:29.682711854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7494445489970408,
+				"StableID":   "nuKhRjNFX121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe33daa484b41b1bf9e8df2b17d465d41055058865e1f5a7302181cfc6298e36",
+				"DiscoKey":   "discokey:0692d7ba407c762d65964396fef78cc7e3dd4af1ea9d0b73f6d692fd0472d65c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:46231", "10.65.0.27:46231", "172.17.0.1:46231"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:51:30.223129223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4439855957749030,
+				"StableID":   "nM61RGVpfb11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f3a85b8eb24101ac1ede507e0fd2389504e24423deded0b7fbfaf0807e6897c",
+				"DiscoKey":   "discokey:7886b02cd179feebdbbac5955072e70804e54a7d71aa8a13ec161b94400c2a7e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:36709", "10.65.0.27:36709", "172.17.0.1:36709"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:51:30.753353578Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1350468164336331,
+				"StableID":   "nntqDWWdYB11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:350ba3b593804a44b74fa9c79239c6944b6ae8fafc1ed0b8aa5c3699edd71d62",
+				"KeyExpiry":  "2026-11-08T18:51:31Z",
+				"DiscoKey":   "discokey:6a5ef513844398f781a03acd907fd46470a55a59f33d61bd0a28cfd3f3de0320",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:36031", "10.65.0.27:36031", "172.17.0.1:36031"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:51:31.294369953Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6228112467025846,
+				"StableID":   "n7uRYJxidq11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9eec78962450387ca8275c9ced55103dd1a5a6fa387ea6623ae570fa22482120",
+				"KeyExpiry":  "2026-11-08T18:51:31Z",
+				"DiscoKey":   "discokey:19d83dcd1531f76e223b176b9e432a883bddb4658e1f57ca666b1a7928baff2a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:53780", "10.65.0.27:53780", "172.17.0.1:53780"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:51:31.839393419Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7328120482284092,
+				"StableID":   "n7St3LJvDz11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b26bc7e9df99066514c538007e9df6593abd4adbc02192b64269fc6fa3760355",
+				"KeyExpiry":  "2026-11-08T18:51:32Z",
+				"DiscoKey":   "discokey:22e38abaee1b6c0b0c9724025647a3c78b8d48a4cfc828d1fa80bfcdf2fc9b33",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:55313", "10.65.0.27:55313", "172.17.0.1:55313"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:51:32.384551884Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "71344946930895": {
+				"ID":          71344946930895,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5628128252104044,
+				"StableID":   "nsn52NPzwk11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       5628128252104044,
+				"Key":        "nodekey:ba6801239b7f5c97f8c5e855d301b1eedbed3d1a5d16f652f6c4d5e34920a96c",
+				"DiscoKey":   "discokey:6ca69ac49c51d4e6d65afb40cd50269fb4fc834a833dfa178262b7e13417216d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:38933", "10.65.0.27:38933", "172.17.0.1:38933"],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:51:24.584727992Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ba6801239b7f5c97f8c5e855d301b1eedbed3d1a5d16f652f6c4d5e34920a96c",
+			"MachineKey": "mkey:bc29f10bbc511f62fc1e7c5a5395792b67fc21d2c97b276afd03877cccfe5c2d",
+			"Peers": [{
+				"ID":         71344946930895,
+				"StableID":   "nzvkeR7KZ111CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:46f63cad496524072339ff16f74dc5ebb63e25d5e0e9d005da489287588fdc0d",
+				"DiscoKey":   "discokey:7e76f4f6c91d763d4d27fbe27b0be8dc3e35631ad25cdd96adf033afa2e71a53",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:38126", "10.65.0.27:38126", "172.17.0.1:38126"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:51:25.115529597Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8297645981819825,
+				"StableID":   "nEFfTC62o721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f323d57536e232692450f2ba506063f9209b495c21889a83647388f48c9eae68",
+				"DiscoKey":   "discokey:e1c844412e64ef5e4267f2829bd76203a23823c8672f3a343e4a9aa54e918158",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:59242", "10.65.0.27:59242", "172.17.0.1:59242"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:51:25.647896301Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5514747121731931,
+				"StableID":   "ncRRnD4e4k11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd98d2d97a17fb12b4a2c3939d6e762a0d4abe3869f1f937bac71c01bdfaa940",
+				"DiscoKey":   "discokey:bd5272f8d3601c1e0573fc1d391f38f02c3b2dbf007435a62ada0ac84a2bcf02",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:44798", "10.65.0.27:44798", "172.17.0.1:44798"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:51:26.191079134Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4971481959757606,
+				"StableID":   "nMU8kFQbpf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a41743ee4fafe1fe75ecdc0faefb323d679324f0e7f9f68bc6fdba9ad9f99d5c",
+				"DiscoKey":   "discokey:beb60092132ea609a4bd40d0a0c20a79fb0299a556c0440ff368555410bb0f7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:49496", "10.65.0.27:49496", "172.17.0.1:49496"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:51:26.728935804Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5141030055159316,
+				"StableID":   "nmTxLE9P9h11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d8ff652871593d098151d2e69758795c414908f0bf7ab8c31b25fb2076517b19",
+				"DiscoKey":   "discokey:187976775212e4ad67e75620fa3c50006aee1e70b05a1cdb88c08032b7610e43",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:55841", "10.65.0.27:55841", "172.17.0.1:55841"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:51:27.302162171Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3416064133656798,
+				"StableID":   "nMzHjJD9gT11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25d2146a049c644507e9ff718ce78bc8d48f6ffe4e7ec6d9f57c97a8cab9514c",
+				"DiscoKey":   "discokey:b14f3582b8cbc98ebecee76d00dbc8c83fd1fe7bedf33db0a24930749847f14d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:42333", "10.65.0.27:42333", "172.17.0.1:42333"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 59245},
+					{"Proto": "peerapi6", "Port": 59245}
+				]},
+				"Created":              "2026-05-12T18:51:27.876907986Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         164931780953466,
+				"StableID":   "nRWdhjUhH211CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5e27e9185cebed651db29cf9ad3ab40177681414afc1047699bc5930fc34f6a",
+				"DiscoKey":   "discokey:84af48a4bd04de3444a4c7e92997bb58d7aaeeecb90aa65803713889f6ee8f42",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:39321", "10.65.0.27:39321", "172.17.0.1:39321"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:51:28.602230915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2690128459323094,
+				"StableID":   "n1gD3Z7N1N11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2ce2603b906e8385bdfae6e5f0c9a932286bfef0f5695b4fe37e421632092b44",
+				"DiscoKey":   "discokey:4d44cf97a08c39ed2e72f7079b74c9d0c8386f15154c3362b74acde2cc9c754a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60586", "10.65.0.27:60586", "172.17.0.1:60586"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:51:29.161742279Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1457385167649690,
+				"StableID":   "noVgg934PC11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a89d1dbd8d0c049c91fbd8887e0a1ac13e66c7a5103e6d69a7348234a24d2a2e",
+				"DiscoKey":   "discokey:bb65eb7b4f5841fbd1b0a9c1b589b44b8b1abc010788a1707da5f853572b906b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:47388", "10.65.0.27:47388", "172.17.0.1:47388"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:51:29.682711854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7494445489970408,
+				"StableID":   "nuKhRjNFX121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe33daa484b41b1bf9e8df2b17d465d41055058865e1f5a7302181cfc6298e36",
+				"DiscoKey":   "discokey:0692d7ba407c762d65964396fef78cc7e3dd4af1ea9d0b73f6d692fd0472d65c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:46231", "10.65.0.27:46231", "172.17.0.1:46231"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:51:30.223129223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4439855957749030,
+				"StableID":   "nM61RGVpfb11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f3a85b8eb24101ac1ede507e0fd2389504e24423deded0b7fbfaf0807e6897c",
+				"DiscoKey":   "discokey:7886b02cd179feebdbbac5955072e70804e54a7d71aa8a13ec161b94400c2a7e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:36709", "10.65.0.27:36709", "172.17.0.1:36709"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:51:30.753353578Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1350468164336331,
+				"StableID":   "nntqDWWdYB11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:350ba3b593804a44b74fa9c79239c6944b6ae8fafc1ed0b8aa5c3699edd71d62",
+				"KeyExpiry":  "2026-11-08T18:51:31Z",
+				"DiscoKey":   "discokey:6a5ef513844398f781a03acd907fd46470a55a59f33d61bd0a28cfd3f3de0320",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:36031", "10.65.0.27:36031", "172.17.0.1:36031"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:51:31.294369953Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6228112467025846,
+				"StableID":   "n7uRYJxidq11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9eec78962450387ca8275c9ced55103dd1a5a6fa387ea6623ae570fa22482120",
+				"KeyExpiry":  "2026-11-08T18:51:31Z",
+				"DiscoKey":   "discokey:19d83dcd1531f76e223b176b9e432a883bddb4658e1f57ca666b1a7928baff2a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:53780", "10.65.0.27:53780", "172.17.0.1:53780"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:51:31.839393419Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7328120482284092,
+				"StableID":   "n7St3LJvDz11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b26bc7e9df99066514c538007e9df6593abd4adbc02192b64269fc6fa3760355",
+				"KeyExpiry":  "2026-11-08T18:51:32Z",
+				"DiscoKey":   "discokey:22e38abaee1b6c0b0c9724025647a3c78b8d48a4cfc828d1fa80bfcdf2fc9b33",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:55313", "10.65.0.27:55313", "172.17.0.1:55313"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:51:32.384551884Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5628128252104044": {
+				"ID":          5628128252104044,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4971481959757606,
+				"StableID":   "nMU8kFQbpf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       4971481959757606,
+				"Key":        "nodekey:a41743ee4fafe1fe75ecdc0faefb323d679324f0e7f9f68bc6fdba9ad9f99d5c",
+				"DiscoKey":   "discokey:beb60092132ea609a4bd40d0a0c20a79fb0299a556c0440ff368555410bb0f7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:49496", "10.65.0.27:49496", "172.17.0.1:49496"],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:51:26.728935804Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a41743ee4fafe1fe75ecdc0faefb323d679324f0e7f9f68bc6fdba9ad9f99d5c",
+			"MachineKey": "mkey:1d3720df5e2ffa5b8b1bfe1e2c1a2c0f0271da27d3b7c552218e5b540795f52e",
+			"Peers": [{
+				"ID":         5628128252104044,
+				"StableID":   "nsn52NPzwk11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba6801239b7f5c97f8c5e855d301b1eedbed3d1a5d16f652f6c4d5e34920a96c",
+				"DiscoKey":   "discokey:6ca69ac49c51d4e6d65afb40cd50269fb4fc834a833dfa178262b7e13417216d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:38933", "10.65.0.27:38933", "172.17.0.1:38933"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:51:24.584727992Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         71344946930895,
+				"StableID":   "nzvkeR7KZ111CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:46f63cad496524072339ff16f74dc5ebb63e25d5e0e9d005da489287588fdc0d",
+				"DiscoKey":   "discokey:7e76f4f6c91d763d4d27fbe27b0be8dc3e35631ad25cdd96adf033afa2e71a53",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:38126", "10.65.0.27:38126", "172.17.0.1:38126"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:51:25.115529597Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8297645981819825,
+				"StableID":   "nEFfTC62o721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f323d57536e232692450f2ba506063f9209b495c21889a83647388f48c9eae68",
+				"DiscoKey":   "discokey:e1c844412e64ef5e4267f2829bd76203a23823c8672f3a343e4a9aa54e918158",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:59242", "10.65.0.27:59242", "172.17.0.1:59242"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:51:25.647896301Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5514747121731931,
+				"StableID":   "ncRRnD4e4k11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd98d2d97a17fb12b4a2c3939d6e762a0d4abe3869f1f937bac71c01bdfaa940",
+				"DiscoKey":   "discokey:bd5272f8d3601c1e0573fc1d391f38f02c3b2dbf007435a62ada0ac84a2bcf02",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:44798", "10.65.0.27:44798", "172.17.0.1:44798"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:51:26.191079134Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5141030055159316,
+				"StableID":   "nmTxLE9P9h11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d8ff652871593d098151d2e69758795c414908f0bf7ab8c31b25fb2076517b19",
+				"DiscoKey":   "discokey:187976775212e4ad67e75620fa3c50006aee1e70b05a1cdb88c08032b7610e43",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:55841", "10.65.0.27:55841", "172.17.0.1:55841"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:51:27.302162171Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3416064133656798,
+				"StableID":   "nMzHjJD9gT11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25d2146a049c644507e9ff718ce78bc8d48f6ffe4e7ec6d9f57c97a8cab9514c",
+				"DiscoKey":   "discokey:b14f3582b8cbc98ebecee76d00dbc8c83fd1fe7bedf33db0a24930749847f14d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:42333", "10.65.0.27:42333", "172.17.0.1:42333"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 59245},
+					{"Proto": "peerapi6", "Port": 59245}
+				]},
+				"Created":              "2026-05-12T18:51:27.876907986Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         164931780953466,
+				"StableID":   "nRWdhjUhH211CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5e27e9185cebed651db29cf9ad3ab40177681414afc1047699bc5930fc34f6a",
+				"DiscoKey":   "discokey:84af48a4bd04de3444a4c7e92997bb58d7aaeeecb90aa65803713889f6ee8f42",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:39321", "10.65.0.27:39321", "172.17.0.1:39321"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:51:28.602230915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2690128459323094,
+				"StableID":   "n1gD3Z7N1N11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2ce2603b906e8385bdfae6e5f0c9a932286bfef0f5695b4fe37e421632092b44",
+				"DiscoKey":   "discokey:4d44cf97a08c39ed2e72f7079b74c9d0c8386f15154c3362b74acde2cc9c754a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60586", "10.65.0.27:60586", "172.17.0.1:60586"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:51:29.161742279Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1457385167649690,
+				"StableID":   "noVgg934PC11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a89d1dbd8d0c049c91fbd8887e0a1ac13e66c7a5103e6d69a7348234a24d2a2e",
+				"DiscoKey":   "discokey:bb65eb7b4f5841fbd1b0a9c1b589b44b8b1abc010788a1707da5f853572b906b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:47388", "10.65.0.27:47388", "172.17.0.1:47388"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:51:29.682711854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7494445489970408,
+				"StableID":   "nuKhRjNFX121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe33daa484b41b1bf9e8df2b17d465d41055058865e1f5a7302181cfc6298e36",
+				"DiscoKey":   "discokey:0692d7ba407c762d65964396fef78cc7e3dd4af1ea9d0b73f6d692fd0472d65c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:46231", "10.65.0.27:46231", "172.17.0.1:46231"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:51:30.223129223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4439855957749030,
+				"StableID":   "nM61RGVpfb11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f3a85b8eb24101ac1ede507e0fd2389504e24423deded0b7fbfaf0807e6897c",
+				"DiscoKey":   "discokey:7886b02cd179feebdbbac5955072e70804e54a7d71aa8a13ec161b94400c2a7e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:36709", "10.65.0.27:36709", "172.17.0.1:36709"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:51:30.753353578Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1350468164336331,
+				"StableID":   "nntqDWWdYB11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:350ba3b593804a44b74fa9c79239c6944b6ae8fafc1ed0b8aa5c3699edd71d62",
+				"KeyExpiry":  "2026-11-08T18:51:31Z",
+				"DiscoKey":   "discokey:6a5ef513844398f781a03acd907fd46470a55a59f33d61bd0a28cfd3f3de0320",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:36031", "10.65.0.27:36031", "172.17.0.1:36031"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:51:31.294369953Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6228112467025846,
+				"StableID":   "n7uRYJxidq11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9eec78962450387ca8275c9ced55103dd1a5a6fa387ea6623ae570fa22482120",
+				"KeyExpiry":  "2026-11-08T18:51:31Z",
+				"DiscoKey":   "discokey:19d83dcd1531f76e223b176b9e432a883bddb4658e1f57ca666b1a7928baff2a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:53780", "10.65.0.27:53780", "172.17.0.1:53780"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:51:31.839393419Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7328120482284092,
+				"StableID":   "n7St3LJvDz11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b26bc7e9df99066514c538007e9df6593abd4adbc02192b64269fc6fa3760355",
+				"KeyExpiry":  "2026-11-08T18:51:32Z",
+				"DiscoKey":   "discokey:22e38abaee1b6c0b0c9724025647a3c78b8d48a4cfc828d1fa80bfcdf2fc9b33",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:55313", "10.65.0.27:55313", "172.17.0.1:55313"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:51:32.384551884Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4971481959757606": {
+				"ID":          4971481959757606,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5514747121731931,
+				"StableID":   "ncRRnD4e4k11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       5514747121731931,
+				"Key":        "nodekey:cd98d2d97a17fb12b4a2c3939d6e762a0d4abe3869f1f937bac71c01bdfaa940",
+				"DiscoKey":   "discokey:bd5272f8d3601c1e0573fc1d391f38f02c3b2dbf007435a62ada0ac84a2bcf02",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:44798", "10.65.0.27:44798", "172.17.0.1:44798"],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:51:26.191079134Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:cd98d2d97a17fb12b4a2c3939d6e762a0d4abe3869f1f937bac71c01bdfaa940",
+			"MachineKey": "mkey:e8d467d45131d88fa246db185f948bb430f2ad7f4396f1cd02dcb887866ec41a",
+			"Peers": [{
+				"ID":         5628128252104044,
+				"StableID":   "nsn52NPzwk11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba6801239b7f5c97f8c5e855d301b1eedbed3d1a5d16f652f6c4d5e34920a96c",
+				"DiscoKey":   "discokey:6ca69ac49c51d4e6d65afb40cd50269fb4fc834a833dfa178262b7e13417216d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:38933", "10.65.0.27:38933", "172.17.0.1:38933"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:51:24.584727992Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         71344946930895,
+				"StableID":   "nzvkeR7KZ111CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:46f63cad496524072339ff16f74dc5ebb63e25d5e0e9d005da489287588fdc0d",
+				"DiscoKey":   "discokey:7e76f4f6c91d763d4d27fbe27b0be8dc3e35631ad25cdd96adf033afa2e71a53",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:38126", "10.65.0.27:38126", "172.17.0.1:38126"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:51:25.115529597Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8297645981819825,
+				"StableID":   "nEFfTC62o721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f323d57536e232692450f2ba506063f9209b495c21889a83647388f48c9eae68",
+				"DiscoKey":   "discokey:e1c844412e64ef5e4267f2829bd76203a23823c8672f3a343e4a9aa54e918158",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:59242", "10.65.0.27:59242", "172.17.0.1:59242"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:51:25.647896301Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4971481959757606,
+				"StableID":   "nMU8kFQbpf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a41743ee4fafe1fe75ecdc0faefb323d679324f0e7f9f68bc6fdba9ad9f99d5c",
+				"DiscoKey":   "discokey:beb60092132ea609a4bd40d0a0c20a79fb0299a556c0440ff368555410bb0f7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:49496", "10.65.0.27:49496", "172.17.0.1:49496"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:51:26.728935804Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5141030055159316,
+				"StableID":   "nmTxLE9P9h11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d8ff652871593d098151d2e69758795c414908f0bf7ab8c31b25fb2076517b19",
+				"DiscoKey":   "discokey:187976775212e4ad67e75620fa3c50006aee1e70b05a1cdb88c08032b7610e43",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:55841", "10.65.0.27:55841", "172.17.0.1:55841"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:51:27.302162171Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3416064133656798,
+				"StableID":   "nMzHjJD9gT11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25d2146a049c644507e9ff718ce78bc8d48f6ffe4e7ec6d9f57c97a8cab9514c",
+				"DiscoKey":   "discokey:b14f3582b8cbc98ebecee76d00dbc8c83fd1fe7bedf33db0a24930749847f14d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:42333", "10.65.0.27:42333", "172.17.0.1:42333"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 59245},
+					{"Proto": "peerapi6", "Port": 59245}
+				]},
+				"Created":              "2026-05-12T18:51:27.876907986Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         164931780953466,
+				"StableID":   "nRWdhjUhH211CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5e27e9185cebed651db29cf9ad3ab40177681414afc1047699bc5930fc34f6a",
+				"DiscoKey":   "discokey:84af48a4bd04de3444a4c7e92997bb58d7aaeeecb90aa65803713889f6ee8f42",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:39321", "10.65.0.27:39321", "172.17.0.1:39321"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:51:28.602230915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2690128459323094,
+				"StableID":   "n1gD3Z7N1N11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2ce2603b906e8385bdfae6e5f0c9a932286bfef0f5695b4fe37e421632092b44",
+				"DiscoKey":   "discokey:4d44cf97a08c39ed2e72f7079b74c9d0c8386f15154c3362b74acde2cc9c754a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60586", "10.65.0.27:60586", "172.17.0.1:60586"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:51:29.161742279Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1457385167649690,
+				"StableID":   "noVgg934PC11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a89d1dbd8d0c049c91fbd8887e0a1ac13e66c7a5103e6d69a7348234a24d2a2e",
+				"DiscoKey":   "discokey:bb65eb7b4f5841fbd1b0a9c1b589b44b8b1abc010788a1707da5f853572b906b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:47388", "10.65.0.27:47388", "172.17.0.1:47388"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:51:29.682711854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7494445489970408,
+				"StableID":   "nuKhRjNFX121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe33daa484b41b1bf9e8df2b17d465d41055058865e1f5a7302181cfc6298e36",
+				"DiscoKey":   "discokey:0692d7ba407c762d65964396fef78cc7e3dd4af1ea9d0b73f6d692fd0472d65c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:46231", "10.65.0.27:46231", "172.17.0.1:46231"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:51:30.223129223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4439855957749030,
+				"StableID":   "nM61RGVpfb11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f3a85b8eb24101ac1ede507e0fd2389504e24423deded0b7fbfaf0807e6897c",
+				"DiscoKey":   "discokey:7886b02cd179feebdbbac5955072e70804e54a7d71aa8a13ec161b94400c2a7e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:36709", "10.65.0.27:36709", "172.17.0.1:36709"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:51:30.753353578Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1350468164336331,
+				"StableID":   "nntqDWWdYB11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:350ba3b593804a44b74fa9c79239c6944b6ae8fafc1ed0b8aa5c3699edd71d62",
+				"KeyExpiry":  "2026-11-08T18:51:31Z",
+				"DiscoKey":   "discokey:6a5ef513844398f781a03acd907fd46470a55a59f33d61bd0a28cfd3f3de0320",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:36031", "10.65.0.27:36031", "172.17.0.1:36031"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:51:31.294369953Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6228112467025846,
+				"StableID":   "n7uRYJxidq11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9eec78962450387ca8275c9ced55103dd1a5a6fa387ea6623ae570fa22482120",
+				"KeyExpiry":  "2026-11-08T18:51:31Z",
+				"DiscoKey":   "discokey:19d83dcd1531f76e223b176b9e432a883bddb4658e1f57ca666b1a7928baff2a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:53780", "10.65.0.27:53780", "172.17.0.1:53780"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:51:31.839393419Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7328120482284092,
+				"StableID":   "n7St3LJvDz11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b26bc7e9df99066514c538007e9df6593abd4adbc02192b64269fc6fa3760355",
+				"KeyExpiry":  "2026-11-08T18:51:32Z",
+				"DiscoKey":   "discokey:22e38abaee1b6c0b0c9724025647a3c78b8d48a4cfc828d1fa80bfcdf2fc9b33",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:55313", "10.65.0.27:55313", "172.17.0.1:55313"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:51:32.384551884Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5514747121731931": {
+				"ID":          5514747121731931,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3416064133656798,
+				"StableID":   "nMzHjJD9gT11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       3416064133656798,
+				"Key":        "nodekey:25d2146a049c644507e9ff718ce78bc8d48f6ffe4e7ec6d9f57c97a8cab9514c",
+				"DiscoKey":   "discokey:b14f3582b8cbc98ebecee76d00dbc8c83fd1fe7bedf33db0a24930749847f14d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:42333", "10.65.0.27:42333", "172.17.0.1:42333"],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 59245},
+						{"Proto": "peerapi6", "Port": 59245},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:51:27.876907986Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:25d2146a049c644507e9ff718ce78bc8d48f6ffe4e7ec6d9f57c97a8cab9514c",
+			"MachineKey": "mkey:9d4403ebb9b7092f18a2ed0246c16d297de5381e0cea242fa0e99c9b934eb511",
+			"Peers": [{
+				"ID":         5628128252104044,
+				"StableID":   "nsn52NPzwk11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba6801239b7f5c97f8c5e855d301b1eedbed3d1a5d16f652f6c4d5e34920a96c",
+				"DiscoKey":   "discokey:6ca69ac49c51d4e6d65afb40cd50269fb4fc834a833dfa178262b7e13417216d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:38933", "10.65.0.27:38933", "172.17.0.1:38933"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:51:24.584727992Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         71344946930895,
+				"StableID":   "nzvkeR7KZ111CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:46f63cad496524072339ff16f74dc5ebb63e25d5e0e9d005da489287588fdc0d",
+				"DiscoKey":   "discokey:7e76f4f6c91d763d4d27fbe27b0be8dc3e35631ad25cdd96adf033afa2e71a53",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:38126", "10.65.0.27:38126", "172.17.0.1:38126"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:51:25.115529597Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8297645981819825,
+				"StableID":   "nEFfTC62o721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f323d57536e232692450f2ba506063f9209b495c21889a83647388f48c9eae68",
+				"DiscoKey":   "discokey:e1c844412e64ef5e4267f2829bd76203a23823c8672f3a343e4a9aa54e918158",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:59242", "10.65.0.27:59242", "172.17.0.1:59242"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:51:25.647896301Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5514747121731931,
+				"StableID":   "ncRRnD4e4k11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd98d2d97a17fb12b4a2c3939d6e762a0d4abe3869f1f937bac71c01bdfaa940",
+				"DiscoKey":   "discokey:bd5272f8d3601c1e0573fc1d391f38f02c3b2dbf007435a62ada0ac84a2bcf02",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:44798", "10.65.0.27:44798", "172.17.0.1:44798"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:51:26.191079134Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4971481959757606,
+				"StableID":   "nMU8kFQbpf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a41743ee4fafe1fe75ecdc0faefb323d679324f0e7f9f68bc6fdba9ad9f99d5c",
+				"DiscoKey":   "discokey:beb60092132ea609a4bd40d0a0c20a79fb0299a556c0440ff368555410bb0f7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:49496", "10.65.0.27:49496", "172.17.0.1:49496"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:51:26.728935804Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5141030055159316,
+				"StableID":   "nmTxLE9P9h11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d8ff652871593d098151d2e69758795c414908f0bf7ab8c31b25fb2076517b19",
+				"DiscoKey":   "discokey:187976775212e4ad67e75620fa3c50006aee1e70b05a1cdb88c08032b7610e43",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:55841", "10.65.0.27:55841", "172.17.0.1:55841"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:51:27.302162171Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         164931780953466,
+				"StableID":   "nRWdhjUhH211CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5e27e9185cebed651db29cf9ad3ab40177681414afc1047699bc5930fc34f6a",
+				"DiscoKey":   "discokey:84af48a4bd04de3444a4c7e92997bb58d7aaeeecb90aa65803713889f6ee8f42",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:39321", "10.65.0.27:39321", "172.17.0.1:39321"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:51:28.602230915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2690128459323094,
+				"StableID":   "n1gD3Z7N1N11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2ce2603b906e8385bdfae6e5f0c9a932286bfef0f5695b4fe37e421632092b44",
+				"DiscoKey":   "discokey:4d44cf97a08c39ed2e72f7079b74c9d0c8386f15154c3362b74acde2cc9c754a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60586", "10.65.0.27:60586", "172.17.0.1:60586"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:51:29.161742279Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1457385167649690,
+				"StableID":   "noVgg934PC11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a89d1dbd8d0c049c91fbd8887e0a1ac13e66c7a5103e6d69a7348234a24d2a2e",
+				"DiscoKey":   "discokey:bb65eb7b4f5841fbd1b0a9c1b589b44b8b1abc010788a1707da5f853572b906b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:47388", "10.65.0.27:47388", "172.17.0.1:47388"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:51:29.682711854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7494445489970408,
+				"StableID":   "nuKhRjNFX121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe33daa484b41b1bf9e8df2b17d465d41055058865e1f5a7302181cfc6298e36",
+				"DiscoKey":   "discokey:0692d7ba407c762d65964396fef78cc7e3dd4af1ea9d0b73f6d692fd0472d65c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:46231", "10.65.0.27:46231", "172.17.0.1:46231"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:51:30.223129223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4439855957749030,
+				"StableID":   "nM61RGVpfb11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f3a85b8eb24101ac1ede507e0fd2389504e24423deded0b7fbfaf0807e6897c",
+				"DiscoKey":   "discokey:7886b02cd179feebdbbac5955072e70804e54a7d71aa8a13ec161b94400c2a7e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:36709", "10.65.0.27:36709", "172.17.0.1:36709"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:51:30.753353578Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1350468164336331,
+				"StableID":   "nntqDWWdYB11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:350ba3b593804a44b74fa9c79239c6944b6ae8fafc1ed0b8aa5c3699edd71d62",
+				"KeyExpiry":  "2026-11-08T18:51:31Z",
+				"DiscoKey":   "discokey:6a5ef513844398f781a03acd907fd46470a55a59f33d61bd0a28cfd3f3de0320",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:36031", "10.65.0.27:36031", "172.17.0.1:36031"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:51:31.294369953Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6228112467025846,
+				"StableID":   "n7uRYJxidq11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9eec78962450387ca8275c9ced55103dd1a5a6fa387ea6623ae570fa22482120",
+				"KeyExpiry":  "2026-11-08T18:51:31Z",
+				"DiscoKey":   "discokey:19d83dcd1531f76e223b176b9e432a883bddb4658e1f57ca666b1a7928baff2a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:53780", "10.65.0.27:53780", "172.17.0.1:53780"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:51:31.839393419Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7328120482284092,
+				"StableID":   "n7St3LJvDz11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b26bc7e9df99066514c538007e9df6593abd4adbc02192b64269fc6fa3760355",
+				"KeyExpiry":  "2026-11-08T18:51:32Z",
+				"DiscoKey":   "discokey:22e38abaee1b6c0b0c9724025647a3c78b8d48a4cfc828d1fa80bfcdf2fc9b33",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:55313", "10.65.0.27:55313", "172.17.0.1:55313"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:51:32.384551884Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3416064133656798": {
+				"ID":          3416064133656798,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2690128459323094,
+				"StableID":   "n1gD3Z7N1N11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       2690128459323094,
+				"Key":        "nodekey:2ce2603b906e8385bdfae6e5f0c9a932286bfef0f5695b4fe37e421632092b44",
+				"DiscoKey":   "discokey:4d44cf97a08c39ed2e72f7079b74c9d0c8386f15154c3362b74acde2cc9c754a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60586", "10.65.0.27:60586", "172.17.0.1:60586"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:51:29.161742279Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2ce2603b906e8385bdfae6e5f0c9a932286bfef0f5695b4fe37e421632092b44",
+			"MachineKey": "mkey:56b708d1f1390209404e860bae14ca83a978b859e8a422a49664ed73aa34ff06",
+			"Peers": [{
+				"ID":         5628128252104044,
+				"StableID":   "nsn52NPzwk11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba6801239b7f5c97f8c5e855d301b1eedbed3d1a5d16f652f6c4d5e34920a96c",
+				"DiscoKey":   "discokey:6ca69ac49c51d4e6d65afb40cd50269fb4fc834a833dfa178262b7e13417216d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:38933", "10.65.0.27:38933", "172.17.0.1:38933"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:51:24.584727992Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         71344946930895,
+				"StableID":   "nzvkeR7KZ111CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:46f63cad496524072339ff16f74dc5ebb63e25d5e0e9d005da489287588fdc0d",
+				"DiscoKey":   "discokey:7e76f4f6c91d763d4d27fbe27b0be8dc3e35631ad25cdd96adf033afa2e71a53",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:38126", "10.65.0.27:38126", "172.17.0.1:38126"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:51:25.115529597Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8297645981819825,
+				"StableID":   "nEFfTC62o721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f323d57536e232692450f2ba506063f9209b495c21889a83647388f48c9eae68",
+				"DiscoKey":   "discokey:e1c844412e64ef5e4267f2829bd76203a23823c8672f3a343e4a9aa54e918158",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:59242", "10.65.0.27:59242", "172.17.0.1:59242"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:51:25.647896301Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5514747121731931,
+				"StableID":   "ncRRnD4e4k11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd98d2d97a17fb12b4a2c3939d6e762a0d4abe3869f1f937bac71c01bdfaa940",
+				"DiscoKey":   "discokey:bd5272f8d3601c1e0573fc1d391f38f02c3b2dbf007435a62ada0ac84a2bcf02",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:44798", "10.65.0.27:44798", "172.17.0.1:44798"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:51:26.191079134Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4971481959757606,
+				"StableID":   "nMU8kFQbpf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a41743ee4fafe1fe75ecdc0faefb323d679324f0e7f9f68bc6fdba9ad9f99d5c",
+				"DiscoKey":   "discokey:beb60092132ea609a4bd40d0a0c20a79fb0299a556c0440ff368555410bb0f7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:49496", "10.65.0.27:49496", "172.17.0.1:49496"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:51:26.728935804Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5141030055159316,
+				"StableID":   "nmTxLE9P9h11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d8ff652871593d098151d2e69758795c414908f0bf7ab8c31b25fb2076517b19",
+				"DiscoKey":   "discokey:187976775212e4ad67e75620fa3c50006aee1e70b05a1cdb88c08032b7610e43",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:55841", "10.65.0.27:55841", "172.17.0.1:55841"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:51:27.302162171Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3416064133656798,
+				"StableID":   "nMzHjJD9gT11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25d2146a049c644507e9ff718ce78bc8d48f6ffe4e7ec6d9f57c97a8cab9514c",
+				"DiscoKey":   "discokey:b14f3582b8cbc98ebecee76d00dbc8c83fd1fe7bedf33db0a24930749847f14d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:42333", "10.65.0.27:42333", "172.17.0.1:42333"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 59245},
+					{"Proto": "peerapi6", "Port": 59245}
+				]},
+				"Created":              "2026-05-12T18:51:27.876907986Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         164931780953466,
+				"StableID":   "nRWdhjUhH211CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5e27e9185cebed651db29cf9ad3ab40177681414afc1047699bc5930fc34f6a",
+				"DiscoKey":   "discokey:84af48a4bd04de3444a4c7e92997bb58d7aaeeecb90aa65803713889f6ee8f42",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:39321", "10.65.0.27:39321", "172.17.0.1:39321"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:51:28.602230915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         1457385167649690,
+				"StableID":   "noVgg934PC11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a89d1dbd8d0c049c91fbd8887e0a1ac13e66c7a5103e6d69a7348234a24d2a2e",
+				"DiscoKey":   "discokey:bb65eb7b4f5841fbd1b0a9c1b589b44b8b1abc010788a1707da5f853572b906b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:47388", "10.65.0.27:47388", "172.17.0.1:47388"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:51:29.682711854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7494445489970408,
+				"StableID":   "nuKhRjNFX121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe33daa484b41b1bf9e8df2b17d465d41055058865e1f5a7302181cfc6298e36",
+				"DiscoKey":   "discokey:0692d7ba407c762d65964396fef78cc7e3dd4af1ea9d0b73f6d692fd0472d65c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:46231", "10.65.0.27:46231", "172.17.0.1:46231"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:51:30.223129223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4439855957749030,
+				"StableID":   "nM61RGVpfb11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f3a85b8eb24101ac1ede507e0fd2389504e24423deded0b7fbfaf0807e6897c",
+				"DiscoKey":   "discokey:7886b02cd179feebdbbac5955072e70804e54a7d71aa8a13ec161b94400c2a7e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:36709", "10.65.0.27:36709", "172.17.0.1:36709"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:51:30.753353578Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1350468164336331,
+				"StableID":   "nntqDWWdYB11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:350ba3b593804a44b74fa9c79239c6944b6ae8fafc1ed0b8aa5c3699edd71d62",
+				"KeyExpiry":  "2026-11-08T18:51:31Z",
+				"DiscoKey":   "discokey:6a5ef513844398f781a03acd907fd46470a55a59f33d61bd0a28cfd3f3de0320",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:36031", "10.65.0.27:36031", "172.17.0.1:36031"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:51:31.294369953Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6228112467025846,
+				"StableID":   "n7uRYJxidq11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9eec78962450387ca8275c9ced55103dd1a5a6fa387ea6623ae570fa22482120",
+				"KeyExpiry":  "2026-11-08T18:51:31Z",
+				"DiscoKey":   "discokey:19d83dcd1531f76e223b176b9e432a883bddb4658e1f57ca666b1a7928baff2a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:53780", "10.65.0.27:53780", "172.17.0.1:53780"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:51:31.839393419Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7328120482284092,
+				"StableID":   "n7St3LJvDz11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b26bc7e9df99066514c538007e9df6593abd4adbc02192b64269fc6fa3760355",
+				"KeyExpiry":  "2026-11-08T18:51:32Z",
+				"DiscoKey":   "discokey:22e38abaee1b6c0b0c9724025647a3c78b8d48a4cfc828d1fa80bfcdf2fc9b33",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:55313", "10.65.0.27:55313", "172.17.0.1:55313"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:51:32.384551884Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2690128459323094": {
+				"ID":          2690128459323094,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6228112467025846,
+				"StableID":   "n7uRYJxidq11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9eec78962450387ca8275c9ced55103dd1a5a6fa387ea6623ae570fa22482120",
+				"KeyExpiry":  "2026-11-08T18:51:31Z",
+				"DiscoKey":   "discokey:19d83dcd1531f76e223b176b9e432a883bddb4658e1f57ca666b1a7928baff2a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:53780", "10.65.0.27:53780", "172.17.0.1:53780"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:51:31.839393419Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9eec78962450387ca8275c9ced55103dd1a5a6fa387ea6623ae570fa22482120",
+			"MachineKey": "mkey:943bfcbe7e911ce88ad64e611125b5159d0040e7f04a4465ce143ab9d4f8cf5a",
+			"Peers": [{
+				"ID":         5628128252104044,
+				"StableID":   "nsn52NPzwk11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba6801239b7f5c97f8c5e855d301b1eedbed3d1a5d16f652f6c4d5e34920a96c",
+				"DiscoKey":   "discokey:6ca69ac49c51d4e6d65afb40cd50269fb4fc834a833dfa178262b7e13417216d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:38933", "10.65.0.27:38933", "172.17.0.1:38933"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:51:24.584727992Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         71344946930895,
+				"StableID":   "nzvkeR7KZ111CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:46f63cad496524072339ff16f74dc5ebb63e25d5e0e9d005da489287588fdc0d",
+				"DiscoKey":   "discokey:7e76f4f6c91d763d4d27fbe27b0be8dc3e35631ad25cdd96adf033afa2e71a53",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:38126", "10.65.0.27:38126", "172.17.0.1:38126"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:51:25.115529597Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8297645981819825,
+				"StableID":   "nEFfTC62o721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f323d57536e232692450f2ba506063f9209b495c21889a83647388f48c9eae68",
+				"DiscoKey":   "discokey:e1c844412e64ef5e4267f2829bd76203a23823c8672f3a343e4a9aa54e918158",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:59242", "10.65.0.27:59242", "172.17.0.1:59242"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:51:25.647896301Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5514747121731931,
+				"StableID":   "ncRRnD4e4k11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd98d2d97a17fb12b4a2c3939d6e762a0d4abe3869f1f937bac71c01bdfaa940",
+				"DiscoKey":   "discokey:bd5272f8d3601c1e0573fc1d391f38f02c3b2dbf007435a62ada0ac84a2bcf02",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:44798", "10.65.0.27:44798", "172.17.0.1:44798"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:51:26.191079134Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4971481959757606,
+				"StableID":   "nMU8kFQbpf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a41743ee4fafe1fe75ecdc0faefb323d679324f0e7f9f68bc6fdba9ad9f99d5c",
+				"DiscoKey":   "discokey:beb60092132ea609a4bd40d0a0c20a79fb0299a556c0440ff368555410bb0f7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:49496", "10.65.0.27:49496", "172.17.0.1:49496"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:51:26.728935804Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5141030055159316,
+				"StableID":   "nmTxLE9P9h11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d8ff652871593d098151d2e69758795c414908f0bf7ab8c31b25fb2076517b19",
+				"DiscoKey":   "discokey:187976775212e4ad67e75620fa3c50006aee1e70b05a1cdb88c08032b7610e43",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:55841", "10.65.0.27:55841", "172.17.0.1:55841"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:51:27.302162171Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3416064133656798,
+				"StableID":   "nMzHjJD9gT11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25d2146a049c644507e9ff718ce78bc8d48f6ffe4e7ec6d9f57c97a8cab9514c",
+				"DiscoKey":   "discokey:b14f3582b8cbc98ebecee76d00dbc8c83fd1fe7bedf33db0a24930749847f14d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:42333", "10.65.0.27:42333", "172.17.0.1:42333"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 59245},
+					{"Proto": "peerapi6", "Port": 59245}
+				]},
+				"Created":              "2026-05-12T18:51:27.876907986Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         164931780953466,
+				"StableID":   "nRWdhjUhH211CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5e27e9185cebed651db29cf9ad3ab40177681414afc1047699bc5930fc34f6a",
+				"DiscoKey":   "discokey:84af48a4bd04de3444a4c7e92997bb58d7aaeeecb90aa65803713889f6ee8f42",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:39321", "10.65.0.27:39321", "172.17.0.1:39321"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:51:28.602230915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2690128459323094,
+				"StableID":   "n1gD3Z7N1N11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2ce2603b906e8385bdfae6e5f0c9a932286bfef0f5695b4fe37e421632092b44",
+				"DiscoKey":   "discokey:4d44cf97a08c39ed2e72f7079b74c9d0c8386f15154c3362b74acde2cc9c754a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60586", "10.65.0.27:60586", "172.17.0.1:60586"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:51:29.161742279Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         1457385167649690,
+				"StableID":   "noVgg934PC11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a89d1dbd8d0c049c91fbd8887e0a1ac13e66c7a5103e6d69a7348234a24d2a2e",
+				"DiscoKey":   "discokey:bb65eb7b4f5841fbd1b0a9c1b589b44b8b1abc010788a1707da5f853572b906b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:47388", "10.65.0.27:47388", "172.17.0.1:47388"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:51:29.682711854Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7494445489970408,
+				"StableID":   "nuKhRjNFX121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe33daa484b41b1bf9e8df2b17d465d41055058865e1f5a7302181cfc6298e36",
+				"DiscoKey":   "discokey:0692d7ba407c762d65964396fef78cc7e3dd4af1ea9d0b73f6d692fd0472d65c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:46231", "10.65.0.27:46231", "172.17.0.1:46231"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:51:30.223129223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4439855957749030,
+				"StableID":   "nM61RGVpfb11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f3a85b8eb24101ac1ede507e0fd2389504e24423deded0b7fbfaf0807e6897c",
+				"DiscoKey":   "discokey:7886b02cd179feebdbbac5955072e70804e54a7d71aa8a13ec161b94400c2a7e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:36709", "10.65.0.27:36709", "172.17.0.1:36709"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:51:30.753353578Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1350468164336331,
+				"StableID":   "nntqDWWdYB11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:350ba3b593804a44b74fa9c79239c6944b6ae8fafc1ed0b8aa5c3699edd71d62",
+				"KeyExpiry":  "2026-11-08T18:51:31Z",
+				"DiscoKey":   "discokey:6a5ef513844398f781a03acd907fd46470a55a59f33d61bd0a28cfd3f3de0320",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:36031", "10.65.0.27:36031", "172.17.0.1:36031"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:51:31.294369953Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7328120482284092,
+				"StableID":   "n7St3LJvDz11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b26bc7e9df99066514c538007e9df6593abd4adbc02192b64269fc6fa3760355",
+				"KeyExpiry":  "2026-11-08T18:51:32Z",
+				"DiscoKey":   "discokey:22e38abaee1b6c0b0c9724025647a3c78b8d48a4cfc828d1fa80bfcdf2fc9b33",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:55313", "10.65.0.27:55313", "172.17.0.1:55313"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:51:32.384551884Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1457385167649690,
+				"StableID":   "noVgg934PC11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1457385167649690,
+				"Key":        "nodekey:a89d1dbd8d0c049c91fbd8887e0a1ac13e66c7a5103e6d69a7348234a24d2a2e",
+				"DiscoKey":   "discokey:bb65eb7b4f5841fbd1b0a9c1b589b44b8b1abc010788a1707da5f853572b906b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:47388", "10.65.0.27:47388", "172.17.0.1:47388"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:51:29.682711854Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a89d1dbd8d0c049c91fbd8887e0a1ac13e66c7a5103e6d69a7348234a24d2a2e",
+			"MachineKey": "mkey:0faba0e5e081ba71bda8275f5b196cdffcfbe323b407baeeeda986d0fc84793c",
+			"Peers": [{
+				"ID":         5628128252104044,
+				"StableID":   "nsn52NPzwk11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba6801239b7f5c97f8c5e855d301b1eedbed3d1a5d16f652f6c4d5e34920a96c",
+				"DiscoKey":   "discokey:6ca69ac49c51d4e6d65afb40cd50269fb4fc834a833dfa178262b7e13417216d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:38933", "10.65.0.27:38933", "172.17.0.1:38933"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:51:24.584727992Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         71344946930895,
+				"StableID":   "nzvkeR7KZ111CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:46f63cad496524072339ff16f74dc5ebb63e25d5e0e9d005da489287588fdc0d",
+				"DiscoKey":   "discokey:7e76f4f6c91d763d4d27fbe27b0be8dc3e35631ad25cdd96adf033afa2e71a53",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:38126", "10.65.0.27:38126", "172.17.0.1:38126"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:51:25.115529597Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8297645981819825,
+				"StableID":   "nEFfTC62o721CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f323d57536e232692450f2ba506063f9209b495c21889a83647388f48c9eae68",
+				"DiscoKey":   "discokey:e1c844412e64ef5e4267f2829bd76203a23823c8672f3a343e4a9aa54e918158",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:59242", "10.65.0.27:59242", "172.17.0.1:59242"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:51:25.647896301Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5514747121731931,
+				"StableID":   "ncRRnD4e4k11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cd98d2d97a17fb12b4a2c3939d6e762a0d4abe3869f1f937bac71c01bdfaa940",
+				"DiscoKey":   "discokey:bd5272f8d3601c1e0573fc1d391f38f02c3b2dbf007435a62ada0ac84a2bcf02",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:44798", "10.65.0.27:44798", "172.17.0.1:44798"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:51:26.191079134Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4971481959757606,
+				"StableID":   "nMU8kFQbpf11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a41743ee4fafe1fe75ecdc0faefb323d679324f0e7f9f68bc6fdba9ad9f99d5c",
+				"DiscoKey":   "discokey:beb60092132ea609a4bd40d0a0c20a79fb0299a556c0440ff368555410bb0f7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:49496", "10.65.0.27:49496", "172.17.0.1:49496"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:51:26.728935804Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5141030055159316,
+				"StableID":   "nmTxLE9P9h11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d8ff652871593d098151d2e69758795c414908f0bf7ab8c31b25fb2076517b19",
+				"DiscoKey":   "discokey:187976775212e4ad67e75620fa3c50006aee1e70b05a1cdb88c08032b7610e43",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:55841", "10.65.0.27:55841", "172.17.0.1:55841"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:51:27.302162171Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         3416064133656798,
+				"StableID":   "nMzHjJD9gT11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:25d2146a049c644507e9ff718ce78bc8d48f6ffe4e7ec6d9f57c97a8cab9514c",
+				"DiscoKey":   "discokey:b14f3582b8cbc98ebecee76d00dbc8c83fd1fe7bedf33db0a24930749847f14d",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:42333", "10.65.0.27:42333", "172.17.0.1:42333"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 59245},
+					{"Proto": "peerapi6", "Port": 59245}
+				]},
+				"Created":              "2026-05-12T18:51:27.876907986Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         164931780953466,
+				"StableID":   "nRWdhjUhH211CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e5e27e9185cebed651db29cf9ad3ab40177681414afc1047699bc5930fc34f6a",
+				"DiscoKey":   "discokey:84af48a4bd04de3444a4c7e92997bb58d7aaeeecb90aa65803713889f6ee8f42",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:39321", "10.65.0.27:39321", "172.17.0.1:39321"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:51:28.602230915Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2690128459323094,
+				"StableID":   "n1gD3Z7N1N11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2ce2603b906e8385bdfae6e5f0c9a932286bfef0f5695b4fe37e421632092b44",
+				"DiscoKey":   "discokey:4d44cf97a08c39ed2e72f7079b74c9d0c8386f15154c3362b74acde2cc9c754a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:60586", "10.65.0.27:60586", "172.17.0.1:60586"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:51:29.161742279Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7494445489970408,
+				"StableID":   "nuKhRjNFX121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fe33daa484b41b1bf9e8df2b17d465d41055058865e1f5a7302181cfc6298e36",
+				"DiscoKey":   "discokey:0692d7ba407c762d65964396fef78cc7e3dd4af1ea9d0b73f6d692fd0472d65c",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:46231", "10.65.0.27:46231", "172.17.0.1:46231"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:51:30.223129223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4439855957749030,
+				"StableID":   "nM61RGVpfb11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8f3a85b8eb24101ac1ede507e0fd2389504e24423deded0b7fbfaf0807e6897c",
+				"DiscoKey":   "discokey:7886b02cd179feebdbbac5955072e70804e54a7d71aa8a13ec161b94400c2a7e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:36709", "10.65.0.27:36709", "172.17.0.1:36709"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:51:30.753353578Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         1350468164336331,
+				"StableID":   "nntqDWWdYB11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:350ba3b593804a44b74fa9c79239c6944b6ae8fafc1ed0b8aa5c3699edd71d62",
+				"KeyExpiry":  "2026-11-08T18:51:31Z",
+				"DiscoKey":   "discokey:6a5ef513844398f781a03acd907fd46470a55a59f33d61bd0a28cfd3f3de0320",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:36031", "10.65.0.27:36031", "172.17.0.1:36031"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:51:31.294369953Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6228112467025846,
+				"StableID":   "n7uRYJxidq11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:9eec78962450387ca8275c9ced55103dd1a5a6fa387ea6623ae570fa22482120",
+				"KeyExpiry":  "2026-11-08T18:51:31Z",
+				"DiscoKey":   "discokey:19d83dcd1531f76e223b176b9e432a883bddb4658e1f57ca666b1a7928baff2a",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:53780", "10.65.0.27:53780", "172.17.0.1:53780"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:51:31.839393419Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7328120482284092,
+				"StableID":   "n7St3LJvDz11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:b26bc7e9df99066514c538007e9df6593abd4adbc02192b64269fc6fa3760355",
+				"KeyExpiry":  "2026-11-08T18:51:32Z",
+				"DiscoKey":   "discokey:22e38abaee1b6c0b0c9724025647a3c78b8d48a4cfc828d1fa80bfcdf2fc9b33",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:55313", "10.65.0.27:55313", "172.17.0.1:55313"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:51:32.384551884Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1457385167649690": {
+				"ID":          1457385167649690,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/sshtest_results/sshtest-user-localpart-domain-match.hujson
+++ b/hscontrol/policy/v2/testdata/sshtest_results/sshtest-user-localpart-domain-match.hujson
@@ -1,0 +1,18804 @@
+// sshtest-user-localpart-domain-match
+//
+// localpart user pattern matches src's domain
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T18:52:17Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "sshtest-user-localpart-domain-match",
+	"description":    "localpart user pattern matches src's domain",
+	"category":       "sshtest",
+	"captured_at":    "2026-05-12T18:52:17.682726181Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                      \n  \n                                                                         \n                                                                           \n                                   \n{\n\t\"category\":    \"sshtest\",\n\t\"description\": \"localpart user pattern matches src's domain\",\n\t\"id\":          \"sshtest-user-localpart-domain-match\",\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"odin@example.com\"],\n\t\t\"users\":  [\"localpart:*@example.com\"]\n\t}], \"sshTests\": [{\n\t\t\"accept\": [\"odin\"],\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    \"odin@example.com\"\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/sshtest/sshtest-user-localpart-domain-match.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["odin@example.com"],
+				"users":  ["localpart:*@example.com"]
+			}],
+			"sshTests":  [{"accept": ["odin"], "dst": ["tag:server"], "src": "odin@example.com"}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1726832356859159,
+				"StableID":   "nWNj7Zx5VE11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1726832356859159,
+				"Key":        "nodekey:b8580b45802a67d96eeed7a5bfe8a034d3e7cd88196974e5a740921460049154",
+				"DiscoKey":   "discokey:bde933df45911314985bb21b42cf0c51a2a56bfc429963bded2d7b71b09a0d34",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57014", "10.65.0.27:57014", "172.17.0.1:57014"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:52:26.213278425Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b8580b45802a67d96eeed7a5bfe8a034d3e7cd88196974e5a740921460049154",
+			"MachineKey": "mkey:5ff3351acbb35b99f00ee7b9a0dc74ae76dff6ae9bb95f6a51612479e78d5b00",
+			"Peers": [{
+				"ID":         7149218115871029,
+				"StableID":   "nCg2ZYqtpx11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:42601141114da4ab1aba019ebe4154a603084088ce50471aa58a448f04dce757",
+				"DiscoKey":   "discokey:5423ad984604c8e069013ccf5fe74cd380798423b962a6b97d328e1e44d8886d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:48216", "10.65.0.27:48216", "172.17.0.1:48216"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:52:20.317209717Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3609278471971550,
+				"StableID":   "nHW8BGdeBV11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f3ce48f5a0d40254f0acd3ad18f0a1e85bc226976fb7309ad36cf40e2124c46",
+				"DiscoKey":   "discokey:8199130784cf44e391026744e1f33ff005933a250461f234b800c647e7d45d44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:47266", "10.65.0.27:47266", "172.17.0.1:47266"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:52:20.822674862Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         952028410362923,
+				"StableID":   "nnAEZyABS811CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:663ca1c0b98b169842a8b616677a0087118a1e990c7382a68fec7376e91af955",
+				"DiscoKey":   "discokey:3cc5eb69a57bc419db9c8add89316d568b03a8cd1dd3bdd34ffe15e7c1a96706",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:46372", "10.65.0.27:46372", "172.17.0.1:46372"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:52:21.355216786Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5619885924616872,
+				"StableID":   "nTEGmfsFtk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d02c43485dfc059a38ab3319bc6f24a1835449baea1d63ec5f7a100e21fb1e71",
+				"DiscoKey":   "discokey:c60b99e6f863197dcf68d76ace08d7f50fa2554b783619249dab23035fe5135e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:59422", "10.65.0.27:59422", "172.17.0.1:59422"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:52:21.884838767Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7375671910666129,
+				"StableID":   "nWXjwrPTbz11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ce0f527473659069dbe7cd3e6a9f69e2ed7f93e720e4e2b8e1039075cffb2e72",
+				"DiscoKey":   "discokey:4c0f72c0cc06331dc9184a977dacf764ae95d7a3a42264b96721c80374066b17",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:53589", "10.65.0.27:53589", "172.17.0.1:53589"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:52:22.42719054Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5885154563695681,
+				"StableID":   "nAmf2o2Qxn11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22813b9d55b26687709c84873941e692c8a317c3a9ebff4281c254cf26175b79",
+				"DiscoKey":   "discokey:98b72e55d8d1c3b9898213489c54eb98b8e1325de01f7371b63f5657d9e34379",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:53301", "10.65.0.27:53301", "172.17.0.1:53301"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:52:22.967745566Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8345061112147022,
+				"StableID":   "nsBMA5cVA821CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aea1a961facd687fdbe29d687b879d88d4360d00c027a8d054dfa00db4821278",
+				"DiscoKey":   "discokey:2b469a8359196a8a9ae135af817ec52705d54492503b54cd9b144d65366f5e03",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:56907", "10.65.0.27:56907", "172.17.0.1:56907"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 59245},
+					{"Proto": "peerapi6", "Port": 59245}
+				]},
+				"Created":              "2026-05-12T18:52:23.511563859Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         12398617935139,
+				"StableID":   "nnkmQ4hc6111CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f932de904df252835e738a5b0966e03451f133f5046d0b4c016c216e8f402579",
+				"DiscoKey":   "discokey:f01f8b0e51b14fe98505563cc5aee03cdf3339052d1fbf85ba5c7dbe8133f738",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:51688", "10.65.0.27:51688", "172.17.0.1:51688"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:52:24.04059057Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         776667949146727,
+				"StableID":   "nLKK6Wkk4711CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15b9b88563aa5d88241ae257e602216e1e091b3666af39e9e65f07007b3a685a",
+				"DiscoKey":   "discokey:b84ccd05567da23b19de9e39a89611218df282a7f1722516a20e5ac6b7a2917a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46018", "10.65.0.27:46018", "172.17.0.1:46018"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:52:24.578430983Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6136404177810293,
+				"StableID":   "nxvi45wBvp11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d84587141b98484705cceed641f846d3cbd08cd2e64f077f2390b7f608e9fc6c",
+				"DiscoKey":   "discokey:b79a127be18fafc50c696955a4f3ef3809a34a4dd3d08575b63d91d3be872166",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:54929", "10.65.0.27:54929", "172.17.0.1:54929"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:52:25.125123532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         19276890580108,
+				"StableID":   "nfgyoXNj9111CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:899e5ce826ca9b46e78daf09e2bc1133503415509539bb4418872bf0f550fd23",
+				"DiscoKey":   "discokey:f963452d76354ed86e6cff0368ecf5dd84bec9de75add5786f94bb7fe696906a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:55569", "10.65.0.27:55569", "172.17.0.1:55569"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:52:25.666040774Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8776597061960922,
+				"StableID":   "nF9cKhKwXB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04e2bc8d22d2000b3ee51a859af82e7812e459e6c18fab78698afd1be8461c4c",
+				"KeyExpiry":  "2026-11-08T18:52:26Z",
+				"DiscoKey":   "discokey:248af9ed3dfa0d89feb04fb06d1d0d80a33d4ba1dd1f8ba709edf23cc61c1a24",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:45734", "10.65.0.27:45734", "172.17.0.1:45734"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:52:26.732179246Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5322461653974364,
+				"StableID":   "nKCzST3ZZi11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:67140cc6cf850ef00336786ac6caba06cd14f518a1cbb09dee12b45e8bc49300",
+				"KeyExpiry":  "2026-11-08T18:52:27Z",
+				"DiscoKey":   "discokey:fabd7cf90d41b9bd91c80d6d9e5e82cdf4021dc26fecb8f83a48e8f4251f5f27",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:37306", "10.65.0.27:37306", "172.17.0.1:37306"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:52:27.282485142Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         71338454102880,
+				"StableID":   "nPNKuXwJZ111CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8c1c5dbed69fc09b9f5e15d71c4bb0338ea5c78ba9d484a1acb3c79fecc1204b",
+				"KeyExpiry":  "2026-11-08T18:52:27Z",
+				"DiscoKey":   "discokey:dcc02fd53cf38c50542af22f0ab5b98b1ca1cf43e881216a20045ee6cdb0b759",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51275", "10.65.0.27:51275", "172.17.0.1:51275"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:52:27.831341295Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{
+				"principals": [{"nodeIP": "100.64.0.19"}, {"nodeIP": "fd7a:115c:a1e0::13"}],
+				"sshUsers":   {"root": ""},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				}
+			}, {
+				"principals": [{"nodeIP": "100.64.0.19"}, {"nodeIP": "fd7a:115c:a1e0::13"}],
+				"sshUsers":   {"odin": "odin"},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				}
+			}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1726832356859159": {
+				"ID":          1726832356859159,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		},
+		"ssh_rules": [{
+			"principals": [{"nodeIP": "100.64.0.19"}, {"nodeIP": "fd7a:115c:a1e0::13"}],
+			"sshUsers":   {"root": ""},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}
+		}, {
+			"principals": [{"nodeIP": "100.64.0.19"}, {"nodeIP": "fd7a:115c:a1e0::13"}],
+			"sshUsers":   {"odin": "odin"},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}
+		}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5885154563695681,
+				"StableID":   "nAmf2o2Qxn11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       5885154563695681,
+				"Key":        "nodekey:22813b9d55b26687709c84873941e692c8a317c3a9ebff4281c254cf26175b79",
+				"DiscoKey":   "discokey:98b72e55d8d1c3b9898213489c54eb98b8e1325de01f7371b63f5657d9e34379",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:53301", "10.65.0.27:53301", "172.17.0.1:53301"],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:52:22.967745566Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:22813b9d55b26687709c84873941e692c8a317c3a9ebff4281c254cf26175b79",
+			"MachineKey": "mkey:b68cac75040ca2b1b6692bc4bc253a9d63dd8537eacfbfa89e1fb6dca8d79b7e",
+			"Peers": [{
+				"ID":         7149218115871029,
+				"StableID":   "nCg2ZYqtpx11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:42601141114da4ab1aba019ebe4154a603084088ce50471aa58a448f04dce757",
+				"DiscoKey":   "discokey:5423ad984604c8e069013ccf5fe74cd380798423b962a6b97d328e1e44d8886d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:48216", "10.65.0.27:48216", "172.17.0.1:48216"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:52:20.317209717Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3609278471971550,
+				"StableID":   "nHW8BGdeBV11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f3ce48f5a0d40254f0acd3ad18f0a1e85bc226976fb7309ad36cf40e2124c46",
+				"DiscoKey":   "discokey:8199130784cf44e391026744e1f33ff005933a250461f234b800c647e7d45d44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:47266", "10.65.0.27:47266", "172.17.0.1:47266"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:52:20.822674862Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         952028410362923,
+				"StableID":   "nnAEZyABS811CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:663ca1c0b98b169842a8b616677a0087118a1e990c7382a68fec7376e91af955",
+				"DiscoKey":   "discokey:3cc5eb69a57bc419db9c8add89316d568b03a8cd1dd3bdd34ffe15e7c1a96706",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:46372", "10.65.0.27:46372", "172.17.0.1:46372"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:52:21.355216786Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5619885924616872,
+				"StableID":   "nTEGmfsFtk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d02c43485dfc059a38ab3319bc6f24a1835449baea1d63ec5f7a100e21fb1e71",
+				"DiscoKey":   "discokey:c60b99e6f863197dcf68d76ace08d7f50fa2554b783619249dab23035fe5135e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:59422", "10.65.0.27:59422", "172.17.0.1:59422"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:52:21.884838767Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7375671910666129,
+				"StableID":   "nWXjwrPTbz11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ce0f527473659069dbe7cd3e6a9f69e2ed7f93e720e4e2b8e1039075cffb2e72",
+				"DiscoKey":   "discokey:4c0f72c0cc06331dc9184a977dacf764ae95d7a3a42264b96721c80374066b17",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:53589", "10.65.0.27:53589", "172.17.0.1:53589"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:52:22.42719054Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8345061112147022,
+				"StableID":   "nsBMA5cVA821CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aea1a961facd687fdbe29d687b879d88d4360d00c027a8d054dfa00db4821278",
+				"DiscoKey":   "discokey:2b469a8359196a8a9ae135af817ec52705d54492503b54cd9b144d65366f5e03",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:56907", "10.65.0.27:56907", "172.17.0.1:56907"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 59245},
+					{"Proto": "peerapi6", "Port": 59245}
+				]},
+				"Created":              "2026-05-12T18:52:23.511563859Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         12398617935139,
+				"StableID":   "nnkmQ4hc6111CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f932de904df252835e738a5b0966e03451f133f5046d0b4c016c216e8f402579",
+				"DiscoKey":   "discokey:f01f8b0e51b14fe98505563cc5aee03cdf3339052d1fbf85ba5c7dbe8133f738",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:51688", "10.65.0.27:51688", "172.17.0.1:51688"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:52:24.04059057Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         776667949146727,
+				"StableID":   "nLKK6Wkk4711CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15b9b88563aa5d88241ae257e602216e1e091b3666af39e9e65f07007b3a685a",
+				"DiscoKey":   "discokey:b84ccd05567da23b19de9e39a89611218df282a7f1722516a20e5ac6b7a2917a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46018", "10.65.0.27:46018", "172.17.0.1:46018"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:52:24.578430983Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6136404177810293,
+				"StableID":   "nxvi45wBvp11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d84587141b98484705cceed641f846d3cbd08cd2e64f077f2390b7f608e9fc6c",
+				"DiscoKey":   "discokey:b79a127be18fafc50c696955a4f3ef3809a34a4dd3d08575b63d91d3be872166",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:54929", "10.65.0.27:54929", "172.17.0.1:54929"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:52:25.125123532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         19276890580108,
+				"StableID":   "nfgyoXNj9111CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:899e5ce826ca9b46e78daf09e2bc1133503415509539bb4418872bf0f550fd23",
+				"DiscoKey":   "discokey:f963452d76354ed86e6cff0368ecf5dd84bec9de75add5786f94bb7fe696906a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:55569", "10.65.0.27:55569", "172.17.0.1:55569"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:52:25.666040774Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1726832356859159,
+				"StableID":   "nWNj7Zx5VE11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8580b45802a67d96eeed7a5bfe8a034d3e7cd88196974e5a740921460049154",
+				"DiscoKey":   "discokey:bde933df45911314985bb21b42cf0c51a2a56bfc429963bded2d7b71b09a0d34",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57014", "10.65.0.27:57014", "172.17.0.1:57014"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:52:26.213278425Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8776597061960922,
+				"StableID":   "nF9cKhKwXB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04e2bc8d22d2000b3ee51a859af82e7812e459e6c18fab78698afd1be8461c4c",
+				"KeyExpiry":  "2026-11-08T18:52:26Z",
+				"DiscoKey":   "discokey:248af9ed3dfa0d89feb04fb06d1d0d80a33d4ba1dd1f8ba709edf23cc61c1a24",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:45734", "10.65.0.27:45734", "172.17.0.1:45734"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:52:26.732179246Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5322461653974364,
+				"StableID":   "nKCzST3ZZi11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:67140cc6cf850ef00336786ac6caba06cd14f518a1cbb09dee12b45e8bc49300",
+				"KeyExpiry":  "2026-11-08T18:52:27Z",
+				"DiscoKey":   "discokey:fabd7cf90d41b9bd91c80d6d9e5e82cdf4021dc26fecb8f83a48e8f4251f5f27",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:37306", "10.65.0.27:37306", "172.17.0.1:37306"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:52:27.282485142Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         71338454102880,
+				"StableID":   "nPNKuXwJZ111CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8c1c5dbed69fc09b9f5e15d71c4bb0338ea5c78ba9d484a1acb3c79fecc1204b",
+				"KeyExpiry":  "2026-11-08T18:52:27Z",
+				"DiscoKey":   "discokey:dcc02fd53cf38c50542af22f0ab5b98b1ca1cf43e881216a20045ee6cdb0b759",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51275", "10.65.0.27:51275", "172.17.0.1:51275"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:52:27.831341295Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5885154563695681": {
+				"ID":          5885154563695681,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         71338454102880,
+				"StableID":   "nPNKuXwJZ111CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8c1c5dbed69fc09b9f5e15d71c4bb0338ea5c78ba9d484a1acb3c79fecc1204b",
+				"KeyExpiry":  "2026-11-08T18:52:27Z",
+				"DiscoKey":   "discokey:dcc02fd53cf38c50542af22f0ab5b98b1ca1cf43e881216a20045ee6cdb0b759",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51275", "10.65.0.27:51275", "172.17.0.1:51275"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:52:27.831341295Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8c1c5dbed69fc09b9f5e15d71c4bb0338ea5c78ba9d484a1acb3c79fecc1204b",
+			"MachineKey": "mkey:98f7190b7ee2c8d9c1b7458d31cc075de63e43f6391143f0d9f13de39f59b612",
+			"Peers": [{
+				"ID":         7149218115871029,
+				"StableID":   "nCg2ZYqtpx11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:42601141114da4ab1aba019ebe4154a603084088ce50471aa58a448f04dce757",
+				"DiscoKey":   "discokey:5423ad984604c8e069013ccf5fe74cd380798423b962a6b97d328e1e44d8886d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:48216", "10.65.0.27:48216", "172.17.0.1:48216"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:52:20.317209717Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3609278471971550,
+				"StableID":   "nHW8BGdeBV11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f3ce48f5a0d40254f0acd3ad18f0a1e85bc226976fb7309ad36cf40e2124c46",
+				"DiscoKey":   "discokey:8199130784cf44e391026744e1f33ff005933a250461f234b800c647e7d45d44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:47266", "10.65.0.27:47266", "172.17.0.1:47266"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:52:20.822674862Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         952028410362923,
+				"StableID":   "nnAEZyABS811CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:663ca1c0b98b169842a8b616677a0087118a1e990c7382a68fec7376e91af955",
+				"DiscoKey":   "discokey:3cc5eb69a57bc419db9c8add89316d568b03a8cd1dd3bdd34ffe15e7c1a96706",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:46372", "10.65.0.27:46372", "172.17.0.1:46372"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:52:21.355216786Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5619885924616872,
+				"StableID":   "nTEGmfsFtk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d02c43485dfc059a38ab3319bc6f24a1835449baea1d63ec5f7a100e21fb1e71",
+				"DiscoKey":   "discokey:c60b99e6f863197dcf68d76ace08d7f50fa2554b783619249dab23035fe5135e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:59422", "10.65.0.27:59422", "172.17.0.1:59422"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:52:21.884838767Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7375671910666129,
+				"StableID":   "nWXjwrPTbz11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ce0f527473659069dbe7cd3e6a9f69e2ed7f93e720e4e2b8e1039075cffb2e72",
+				"DiscoKey":   "discokey:4c0f72c0cc06331dc9184a977dacf764ae95d7a3a42264b96721c80374066b17",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:53589", "10.65.0.27:53589", "172.17.0.1:53589"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:52:22.42719054Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5885154563695681,
+				"StableID":   "nAmf2o2Qxn11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22813b9d55b26687709c84873941e692c8a317c3a9ebff4281c254cf26175b79",
+				"DiscoKey":   "discokey:98b72e55d8d1c3b9898213489c54eb98b8e1325de01f7371b63f5657d9e34379",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:53301", "10.65.0.27:53301", "172.17.0.1:53301"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:52:22.967745566Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8345061112147022,
+				"StableID":   "nsBMA5cVA821CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aea1a961facd687fdbe29d687b879d88d4360d00c027a8d054dfa00db4821278",
+				"DiscoKey":   "discokey:2b469a8359196a8a9ae135af817ec52705d54492503b54cd9b144d65366f5e03",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:56907", "10.65.0.27:56907", "172.17.0.1:56907"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 59245},
+					{"Proto": "peerapi6", "Port": 59245}
+				]},
+				"Created":              "2026-05-12T18:52:23.511563859Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         12398617935139,
+				"StableID":   "nnkmQ4hc6111CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f932de904df252835e738a5b0966e03451f133f5046d0b4c016c216e8f402579",
+				"DiscoKey":   "discokey:f01f8b0e51b14fe98505563cc5aee03cdf3339052d1fbf85ba5c7dbe8133f738",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:51688", "10.65.0.27:51688", "172.17.0.1:51688"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:52:24.04059057Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         776667949146727,
+				"StableID":   "nLKK6Wkk4711CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15b9b88563aa5d88241ae257e602216e1e091b3666af39e9e65f07007b3a685a",
+				"DiscoKey":   "discokey:b84ccd05567da23b19de9e39a89611218df282a7f1722516a20e5ac6b7a2917a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46018", "10.65.0.27:46018", "172.17.0.1:46018"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:52:24.578430983Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6136404177810293,
+				"StableID":   "nxvi45wBvp11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d84587141b98484705cceed641f846d3cbd08cd2e64f077f2390b7f608e9fc6c",
+				"DiscoKey":   "discokey:b79a127be18fafc50c696955a4f3ef3809a34a4dd3d08575b63d91d3be872166",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:54929", "10.65.0.27:54929", "172.17.0.1:54929"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:52:25.125123532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         19276890580108,
+				"StableID":   "nfgyoXNj9111CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:899e5ce826ca9b46e78daf09e2bc1133503415509539bb4418872bf0f550fd23",
+				"DiscoKey":   "discokey:f963452d76354ed86e6cff0368ecf5dd84bec9de75add5786f94bb7fe696906a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:55569", "10.65.0.27:55569", "172.17.0.1:55569"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:52:25.666040774Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1726832356859159,
+				"StableID":   "nWNj7Zx5VE11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8580b45802a67d96eeed7a5bfe8a034d3e7cd88196974e5a740921460049154",
+				"DiscoKey":   "discokey:bde933df45911314985bb21b42cf0c51a2a56bfc429963bded2d7b71b09a0d34",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57014", "10.65.0.27:57014", "172.17.0.1:57014"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:52:26.213278425Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8776597061960922,
+				"StableID":   "nF9cKhKwXB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04e2bc8d22d2000b3ee51a859af82e7812e459e6c18fab78698afd1be8461c4c",
+				"KeyExpiry":  "2026-11-08T18:52:26Z",
+				"DiscoKey":   "discokey:248af9ed3dfa0d89feb04fb06d1d0d80a33d4ba1dd1f8ba709edf23cc61c1a24",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:45734", "10.65.0.27:45734", "172.17.0.1:45734"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:52:26.732179246Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5322461653974364,
+				"StableID":   "nKCzST3ZZi11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:67140cc6cf850ef00336786ac6caba06cd14f518a1cbb09dee12b45e8bc49300",
+				"KeyExpiry":  "2026-11-08T18:52:27Z",
+				"DiscoKey":   "discokey:fabd7cf90d41b9bd91c80d6d9e5e82cdf4021dc26fecb8f83a48e8f4251f5f27",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:37306", "10.65.0.27:37306", "172.17.0.1:37306"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:52:27.282485142Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{
+				"principals": [{"nodeIP": "100.64.0.19"}, {"nodeIP": "fd7a:115c:a1e0::13"}],
+				"sshUsers":   {"root": ""},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				}
+			}, {
+				"principals": [{"nodeIP": "100.64.0.19"}, {"nodeIP": "fd7a:115c:a1e0::13"}],
+				"sshUsers":   {"odin": "odin"},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				}
+			}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		},
+		"ssh_rules": [{
+			"principals": [{"nodeIP": "100.64.0.19"}, {"nodeIP": "fd7a:115c:a1e0::13"}],
+			"sshUsers":   {"root": ""},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}
+		}, {
+			"principals": [{"nodeIP": "100.64.0.19"}, {"nodeIP": "fd7a:115c:a1e0::13"}],
+			"sshUsers":   {"odin": "odin"},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}
+		}]
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         952028410362923,
+				"StableID":   "nnAEZyABS811CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       952028410362923,
+				"Key":        "nodekey:663ca1c0b98b169842a8b616677a0087118a1e990c7382a68fec7376e91af955",
+				"DiscoKey":   "discokey:3cc5eb69a57bc419db9c8add89316d568b03a8cd1dd3bdd34ffe15e7c1a96706",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:46372", "10.65.0.27:46372", "172.17.0.1:46372"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:52:21.355216786Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:663ca1c0b98b169842a8b616677a0087118a1e990c7382a68fec7376e91af955",
+			"MachineKey": "mkey:88c3e14b2952b77ba54c536263f5dbc0c64850ba394e95c06917de765980142a",
+			"Peers": [{
+				"ID":         7149218115871029,
+				"StableID":   "nCg2ZYqtpx11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:42601141114da4ab1aba019ebe4154a603084088ce50471aa58a448f04dce757",
+				"DiscoKey":   "discokey:5423ad984604c8e069013ccf5fe74cd380798423b962a6b97d328e1e44d8886d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:48216", "10.65.0.27:48216", "172.17.0.1:48216"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:52:20.317209717Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3609278471971550,
+				"StableID":   "nHW8BGdeBV11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f3ce48f5a0d40254f0acd3ad18f0a1e85bc226976fb7309ad36cf40e2124c46",
+				"DiscoKey":   "discokey:8199130784cf44e391026744e1f33ff005933a250461f234b800c647e7d45d44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:47266", "10.65.0.27:47266", "172.17.0.1:47266"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:52:20.822674862Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5619885924616872,
+				"StableID":   "nTEGmfsFtk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d02c43485dfc059a38ab3319bc6f24a1835449baea1d63ec5f7a100e21fb1e71",
+				"DiscoKey":   "discokey:c60b99e6f863197dcf68d76ace08d7f50fa2554b783619249dab23035fe5135e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:59422", "10.65.0.27:59422", "172.17.0.1:59422"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:52:21.884838767Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7375671910666129,
+				"StableID":   "nWXjwrPTbz11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ce0f527473659069dbe7cd3e6a9f69e2ed7f93e720e4e2b8e1039075cffb2e72",
+				"DiscoKey":   "discokey:4c0f72c0cc06331dc9184a977dacf764ae95d7a3a42264b96721c80374066b17",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:53589", "10.65.0.27:53589", "172.17.0.1:53589"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:52:22.42719054Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5885154563695681,
+				"StableID":   "nAmf2o2Qxn11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22813b9d55b26687709c84873941e692c8a317c3a9ebff4281c254cf26175b79",
+				"DiscoKey":   "discokey:98b72e55d8d1c3b9898213489c54eb98b8e1325de01f7371b63f5657d9e34379",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:53301", "10.65.0.27:53301", "172.17.0.1:53301"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:52:22.967745566Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8345061112147022,
+				"StableID":   "nsBMA5cVA821CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aea1a961facd687fdbe29d687b879d88d4360d00c027a8d054dfa00db4821278",
+				"DiscoKey":   "discokey:2b469a8359196a8a9ae135af817ec52705d54492503b54cd9b144d65366f5e03",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:56907", "10.65.0.27:56907", "172.17.0.1:56907"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 59245},
+					{"Proto": "peerapi6", "Port": 59245}
+				]},
+				"Created":              "2026-05-12T18:52:23.511563859Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         12398617935139,
+				"StableID":   "nnkmQ4hc6111CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f932de904df252835e738a5b0966e03451f133f5046d0b4c016c216e8f402579",
+				"DiscoKey":   "discokey:f01f8b0e51b14fe98505563cc5aee03cdf3339052d1fbf85ba5c7dbe8133f738",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:51688", "10.65.0.27:51688", "172.17.0.1:51688"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:52:24.04059057Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         776667949146727,
+				"StableID":   "nLKK6Wkk4711CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15b9b88563aa5d88241ae257e602216e1e091b3666af39e9e65f07007b3a685a",
+				"DiscoKey":   "discokey:b84ccd05567da23b19de9e39a89611218df282a7f1722516a20e5ac6b7a2917a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46018", "10.65.0.27:46018", "172.17.0.1:46018"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:52:24.578430983Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6136404177810293,
+				"StableID":   "nxvi45wBvp11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d84587141b98484705cceed641f846d3cbd08cd2e64f077f2390b7f608e9fc6c",
+				"DiscoKey":   "discokey:b79a127be18fafc50c696955a4f3ef3809a34a4dd3d08575b63d91d3be872166",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:54929", "10.65.0.27:54929", "172.17.0.1:54929"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:52:25.125123532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         19276890580108,
+				"StableID":   "nfgyoXNj9111CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:899e5ce826ca9b46e78daf09e2bc1133503415509539bb4418872bf0f550fd23",
+				"DiscoKey":   "discokey:f963452d76354ed86e6cff0368ecf5dd84bec9de75add5786f94bb7fe696906a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:55569", "10.65.0.27:55569", "172.17.0.1:55569"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:52:25.666040774Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1726832356859159,
+				"StableID":   "nWNj7Zx5VE11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8580b45802a67d96eeed7a5bfe8a034d3e7cd88196974e5a740921460049154",
+				"DiscoKey":   "discokey:bde933df45911314985bb21b42cf0c51a2a56bfc429963bded2d7b71b09a0d34",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57014", "10.65.0.27:57014", "172.17.0.1:57014"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:52:26.213278425Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8776597061960922,
+				"StableID":   "nF9cKhKwXB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04e2bc8d22d2000b3ee51a859af82e7812e459e6c18fab78698afd1be8461c4c",
+				"KeyExpiry":  "2026-11-08T18:52:26Z",
+				"DiscoKey":   "discokey:248af9ed3dfa0d89feb04fb06d1d0d80a33d4ba1dd1f8ba709edf23cc61c1a24",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:45734", "10.65.0.27:45734", "172.17.0.1:45734"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:52:26.732179246Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5322461653974364,
+				"StableID":   "nKCzST3ZZi11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:67140cc6cf850ef00336786ac6caba06cd14f518a1cbb09dee12b45e8bc49300",
+				"KeyExpiry":  "2026-11-08T18:52:27Z",
+				"DiscoKey":   "discokey:fabd7cf90d41b9bd91c80d6d9e5e82cdf4021dc26fecb8f83a48e8f4251f5f27",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:37306", "10.65.0.27:37306", "172.17.0.1:37306"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:52:27.282485142Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         71338454102880,
+				"StableID":   "nPNKuXwJZ111CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8c1c5dbed69fc09b9f5e15d71c4bb0338ea5c78ba9d484a1acb3c79fecc1204b",
+				"KeyExpiry":  "2026-11-08T18:52:27Z",
+				"DiscoKey":   "discokey:dcc02fd53cf38c50542af22f0ab5b98b1ca1cf43e881216a20045ee6cdb0b759",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51275", "10.65.0.27:51275", "172.17.0.1:51275"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:52:27.831341295Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "952028410362923": {
+				"ID":          952028410362923,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         12398617935139,
+				"StableID":   "nnkmQ4hc6111CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       12398617935139,
+				"Key":        "nodekey:f932de904df252835e738a5b0966e03451f133f5046d0b4c016c216e8f402579",
+				"DiscoKey":   "discokey:f01f8b0e51b14fe98505563cc5aee03cdf3339052d1fbf85ba5c7dbe8133f738",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:51688", "10.65.0.27:51688", "172.17.0.1:51688"],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:52:24.04059057Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f932de904df252835e738a5b0966e03451f133f5046d0b4c016c216e8f402579",
+			"MachineKey": "mkey:13c186ea433d1efd18c509d3c6d3846cb0021795365c27e111b9152852b3db5c",
+			"Peers": [{
+				"ID":         7149218115871029,
+				"StableID":   "nCg2ZYqtpx11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:42601141114da4ab1aba019ebe4154a603084088ce50471aa58a448f04dce757",
+				"DiscoKey":   "discokey:5423ad984604c8e069013ccf5fe74cd380798423b962a6b97d328e1e44d8886d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:48216", "10.65.0.27:48216", "172.17.0.1:48216"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:52:20.317209717Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3609278471971550,
+				"StableID":   "nHW8BGdeBV11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f3ce48f5a0d40254f0acd3ad18f0a1e85bc226976fb7309ad36cf40e2124c46",
+				"DiscoKey":   "discokey:8199130784cf44e391026744e1f33ff005933a250461f234b800c647e7d45d44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:47266", "10.65.0.27:47266", "172.17.0.1:47266"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:52:20.822674862Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         952028410362923,
+				"StableID":   "nnAEZyABS811CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:663ca1c0b98b169842a8b616677a0087118a1e990c7382a68fec7376e91af955",
+				"DiscoKey":   "discokey:3cc5eb69a57bc419db9c8add89316d568b03a8cd1dd3bdd34ffe15e7c1a96706",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:46372", "10.65.0.27:46372", "172.17.0.1:46372"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:52:21.355216786Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5619885924616872,
+				"StableID":   "nTEGmfsFtk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d02c43485dfc059a38ab3319bc6f24a1835449baea1d63ec5f7a100e21fb1e71",
+				"DiscoKey":   "discokey:c60b99e6f863197dcf68d76ace08d7f50fa2554b783619249dab23035fe5135e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:59422", "10.65.0.27:59422", "172.17.0.1:59422"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:52:21.884838767Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7375671910666129,
+				"StableID":   "nWXjwrPTbz11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ce0f527473659069dbe7cd3e6a9f69e2ed7f93e720e4e2b8e1039075cffb2e72",
+				"DiscoKey":   "discokey:4c0f72c0cc06331dc9184a977dacf764ae95d7a3a42264b96721c80374066b17",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:53589", "10.65.0.27:53589", "172.17.0.1:53589"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:52:22.42719054Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5885154563695681,
+				"StableID":   "nAmf2o2Qxn11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22813b9d55b26687709c84873941e692c8a317c3a9ebff4281c254cf26175b79",
+				"DiscoKey":   "discokey:98b72e55d8d1c3b9898213489c54eb98b8e1325de01f7371b63f5657d9e34379",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:53301", "10.65.0.27:53301", "172.17.0.1:53301"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:52:22.967745566Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8345061112147022,
+				"StableID":   "nsBMA5cVA821CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aea1a961facd687fdbe29d687b879d88d4360d00c027a8d054dfa00db4821278",
+				"DiscoKey":   "discokey:2b469a8359196a8a9ae135af817ec52705d54492503b54cd9b144d65366f5e03",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:56907", "10.65.0.27:56907", "172.17.0.1:56907"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 59245},
+					{"Proto": "peerapi6", "Port": 59245}
+				]},
+				"Created":              "2026-05-12T18:52:23.511563859Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         776667949146727,
+				"StableID":   "nLKK6Wkk4711CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15b9b88563aa5d88241ae257e602216e1e091b3666af39e9e65f07007b3a685a",
+				"DiscoKey":   "discokey:b84ccd05567da23b19de9e39a89611218df282a7f1722516a20e5ac6b7a2917a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46018", "10.65.0.27:46018", "172.17.0.1:46018"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:52:24.578430983Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6136404177810293,
+				"StableID":   "nxvi45wBvp11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d84587141b98484705cceed641f846d3cbd08cd2e64f077f2390b7f608e9fc6c",
+				"DiscoKey":   "discokey:b79a127be18fafc50c696955a4f3ef3809a34a4dd3d08575b63d91d3be872166",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:54929", "10.65.0.27:54929", "172.17.0.1:54929"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:52:25.125123532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         19276890580108,
+				"StableID":   "nfgyoXNj9111CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:899e5ce826ca9b46e78daf09e2bc1133503415509539bb4418872bf0f550fd23",
+				"DiscoKey":   "discokey:f963452d76354ed86e6cff0368ecf5dd84bec9de75add5786f94bb7fe696906a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:55569", "10.65.0.27:55569", "172.17.0.1:55569"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:52:25.666040774Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1726832356859159,
+				"StableID":   "nWNj7Zx5VE11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8580b45802a67d96eeed7a5bfe8a034d3e7cd88196974e5a740921460049154",
+				"DiscoKey":   "discokey:bde933df45911314985bb21b42cf0c51a2a56bfc429963bded2d7b71b09a0d34",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57014", "10.65.0.27:57014", "172.17.0.1:57014"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:52:26.213278425Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8776597061960922,
+				"StableID":   "nF9cKhKwXB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04e2bc8d22d2000b3ee51a859af82e7812e459e6c18fab78698afd1be8461c4c",
+				"KeyExpiry":  "2026-11-08T18:52:26Z",
+				"DiscoKey":   "discokey:248af9ed3dfa0d89feb04fb06d1d0d80a33d4ba1dd1f8ba709edf23cc61c1a24",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:45734", "10.65.0.27:45734", "172.17.0.1:45734"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:52:26.732179246Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5322461653974364,
+				"StableID":   "nKCzST3ZZi11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:67140cc6cf850ef00336786ac6caba06cd14f518a1cbb09dee12b45e8bc49300",
+				"KeyExpiry":  "2026-11-08T18:52:27Z",
+				"DiscoKey":   "discokey:fabd7cf90d41b9bd91c80d6d9e5e82cdf4021dc26fecb8f83a48e8f4251f5f27",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:37306", "10.65.0.27:37306", "172.17.0.1:37306"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:52:27.282485142Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         71338454102880,
+				"StableID":   "nPNKuXwJZ111CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8c1c5dbed69fc09b9f5e15d71c4bb0338ea5c78ba9d484a1acb3c79fecc1204b",
+				"KeyExpiry":  "2026-11-08T18:52:27Z",
+				"DiscoKey":   "discokey:dcc02fd53cf38c50542af22f0ab5b98b1ca1cf43e881216a20045ee6cdb0b759",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51275", "10.65.0.27:51275", "172.17.0.1:51275"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:52:27.831341295Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"12398617935139": {
+				"ID":          12398617935139,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8776597061960922,
+				"StableID":   "nF9cKhKwXB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04e2bc8d22d2000b3ee51a859af82e7812e459e6c18fab78698afd1be8461c4c",
+				"KeyExpiry":  "2026-11-08T18:52:26Z",
+				"DiscoKey":   "discokey:248af9ed3dfa0d89feb04fb06d1d0d80a33d4ba1dd1f8ba709edf23cc61c1a24",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:45734", "10.65.0.27:45734", "172.17.0.1:45734"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:52:26.732179246Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:04e2bc8d22d2000b3ee51a859af82e7812e459e6c18fab78698afd1be8461c4c",
+			"MachineKey": "mkey:25fe628bf17152502398f5fc220fec43bc3eac11d6dac64de160e6fff8e42c1d",
+			"Peers": [{
+				"ID":         7149218115871029,
+				"StableID":   "nCg2ZYqtpx11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:42601141114da4ab1aba019ebe4154a603084088ce50471aa58a448f04dce757",
+				"DiscoKey":   "discokey:5423ad984604c8e069013ccf5fe74cd380798423b962a6b97d328e1e44d8886d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:48216", "10.65.0.27:48216", "172.17.0.1:48216"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:52:20.317209717Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3609278471971550,
+				"StableID":   "nHW8BGdeBV11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f3ce48f5a0d40254f0acd3ad18f0a1e85bc226976fb7309ad36cf40e2124c46",
+				"DiscoKey":   "discokey:8199130784cf44e391026744e1f33ff005933a250461f234b800c647e7d45d44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:47266", "10.65.0.27:47266", "172.17.0.1:47266"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:52:20.822674862Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         952028410362923,
+				"StableID":   "nnAEZyABS811CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:663ca1c0b98b169842a8b616677a0087118a1e990c7382a68fec7376e91af955",
+				"DiscoKey":   "discokey:3cc5eb69a57bc419db9c8add89316d568b03a8cd1dd3bdd34ffe15e7c1a96706",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:46372", "10.65.0.27:46372", "172.17.0.1:46372"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:52:21.355216786Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5619885924616872,
+				"StableID":   "nTEGmfsFtk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d02c43485dfc059a38ab3319bc6f24a1835449baea1d63ec5f7a100e21fb1e71",
+				"DiscoKey":   "discokey:c60b99e6f863197dcf68d76ace08d7f50fa2554b783619249dab23035fe5135e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:59422", "10.65.0.27:59422", "172.17.0.1:59422"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:52:21.884838767Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7375671910666129,
+				"StableID":   "nWXjwrPTbz11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ce0f527473659069dbe7cd3e6a9f69e2ed7f93e720e4e2b8e1039075cffb2e72",
+				"DiscoKey":   "discokey:4c0f72c0cc06331dc9184a977dacf764ae95d7a3a42264b96721c80374066b17",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:53589", "10.65.0.27:53589", "172.17.0.1:53589"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:52:22.42719054Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5885154563695681,
+				"StableID":   "nAmf2o2Qxn11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22813b9d55b26687709c84873941e692c8a317c3a9ebff4281c254cf26175b79",
+				"DiscoKey":   "discokey:98b72e55d8d1c3b9898213489c54eb98b8e1325de01f7371b63f5657d9e34379",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:53301", "10.65.0.27:53301", "172.17.0.1:53301"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:52:22.967745566Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8345061112147022,
+				"StableID":   "nsBMA5cVA821CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aea1a961facd687fdbe29d687b879d88d4360d00c027a8d054dfa00db4821278",
+				"DiscoKey":   "discokey:2b469a8359196a8a9ae135af817ec52705d54492503b54cd9b144d65366f5e03",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:56907", "10.65.0.27:56907", "172.17.0.1:56907"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 59245},
+					{"Proto": "peerapi6", "Port": 59245}
+				]},
+				"Created":              "2026-05-12T18:52:23.511563859Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         12398617935139,
+				"StableID":   "nnkmQ4hc6111CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f932de904df252835e738a5b0966e03451f133f5046d0b4c016c216e8f402579",
+				"DiscoKey":   "discokey:f01f8b0e51b14fe98505563cc5aee03cdf3339052d1fbf85ba5c7dbe8133f738",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:51688", "10.65.0.27:51688", "172.17.0.1:51688"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:52:24.04059057Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         776667949146727,
+				"StableID":   "nLKK6Wkk4711CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15b9b88563aa5d88241ae257e602216e1e091b3666af39e9e65f07007b3a685a",
+				"DiscoKey":   "discokey:b84ccd05567da23b19de9e39a89611218df282a7f1722516a20e5ac6b7a2917a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46018", "10.65.0.27:46018", "172.17.0.1:46018"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:52:24.578430983Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6136404177810293,
+				"StableID":   "nxvi45wBvp11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d84587141b98484705cceed641f846d3cbd08cd2e64f077f2390b7f608e9fc6c",
+				"DiscoKey":   "discokey:b79a127be18fafc50c696955a4f3ef3809a34a4dd3d08575b63d91d3be872166",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:54929", "10.65.0.27:54929", "172.17.0.1:54929"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:52:25.125123532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         19276890580108,
+				"StableID":   "nfgyoXNj9111CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:899e5ce826ca9b46e78daf09e2bc1133503415509539bb4418872bf0f550fd23",
+				"DiscoKey":   "discokey:f963452d76354ed86e6cff0368ecf5dd84bec9de75add5786f94bb7fe696906a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:55569", "10.65.0.27:55569", "172.17.0.1:55569"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:52:25.666040774Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1726832356859159,
+				"StableID":   "nWNj7Zx5VE11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8580b45802a67d96eeed7a5bfe8a034d3e7cd88196974e5a740921460049154",
+				"DiscoKey":   "discokey:bde933df45911314985bb21b42cf0c51a2a56bfc429963bded2d7b71b09a0d34",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57014", "10.65.0.27:57014", "172.17.0.1:57014"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:52:26.213278425Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5322461653974364,
+				"StableID":   "nKCzST3ZZi11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:67140cc6cf850ef00336786ac6caba06cd14f518a1cbb09dee12b45e8bc49300",
+				"KeyExpiry":  "2026-11-08T18:52:27Z",
+				"DiscoKey":   "discokey:fabd7cf90d41b9bd91c80d6d9e5e82cdf4021dc26fecb8f83a48e8f4251f5f27",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:37306", "10.65.0.27:37306", "172.17.0.1:37306"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:52:27.282485142Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         71338454102880,
+				"StableID":   "nPNKuXwJZ111CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8c1c5dbed69fc09b9f5e15d71c4bb0338ea5c78ba9d484a1acb3c79fecc1204b",
+				"KeyExpiry":  "2026-11-08T18:52:27Z",
+				"DiscoKey":   "discokey:dcc02fd53cf38c50542af22f0ab5b98b1ca1cf43e881216a20045ee6cdb0b759",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51275", "10.65.0.27:51275", "172.17.0.1:51275"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:52:27.831341295Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         19276890580108,
+				"StableID":   "nfgyoXNj9111CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       19276890580108,
+				"Key":        "nodekey:899e5ce826ca9b46e78daf09e2bc1133503415509539bb4418872bf0f550fd23",
+				"DiscoKey":   "discokey:f963452d76354ed86e6cff0368ecf5dd84bec9de75add5786f94bb7fe696906a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:55569", "10.65.0.27:55569", "172.17.0.1:55569"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:52:25.666040774Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:899e5ce826ca9b46e78daf09e2bc1133503415509539bb4418872bf0f550fd23",
+			"MachineKey": "mkey:ae2d5b6649a127cb53aa46225a06751b71fb097e2ab2dc9a96602bd53aec336d",
+			"Peers": [{
+				"ID":         7149218115871029,
+				"StableID":   "nCg2ZYqtpx11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:42601141114da4ab1aba019ebe4154a603084088ce50471aa58a448f04dce757",
+				"DiscoKey":   "discokey:5423ad984604c8e069013ccf5fe74cd380798423b962a6b97d328e1e44d8886d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:48216", "10.65.0.27:48216", "172.17.0.1:48216"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:52:20.317209717Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3609278471971550,
+				"StableID":   "nHW8BGdeBV11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f3ce48f5a0d40254f0acd3ad18f0a1e85bc226976fb7309ad36cf40e2124c46",
+				"DiscoKey":   "discokey:8199130784cf44e391026744e1f33ff005933a250461f234b800c647e7d45d44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:47266", "10.65.0.27:47266", "172.17.0.1:47266"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:52:20.822674862Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         952028410362923,
+				"StableID":   "nnAEZyABS811CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:663ca1c0b98b169842a8b616677a0087118a1e990c7382a68fec7376e91af955",
+				"DiscoKey":   "discokey:3cc5eb69a57bc419db9c8add89316d568b03a8cd1dd3bdd34ffe15e7c1a96706",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:46372", "10.65.0.27:46372", "172.17.0.1:46372"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:52:21.355216786Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5619885924616872,
+				"StableID":   "nTEGmfsFtk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d02c43485dfc059a38ab3319bc6f24a1835449baea1d63ec5f7a100e21fb1e71",
+				"DiscoKey":   "discokey:c60b99e6f863197dcf68d76ace08d7f50fa2554b783619249dab23035fe5135e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:59422", "10.65.0.27:59422", "172.17.0.1:59422"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:52:21.884838767Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7375671910666129,
+				"StableID":   "nWXjwrPTbz11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ce0f527473659069dbe7cd3e6a9f69e2ed7f93e720e4e2b8e1039075cffb2e72",
+				"DiscoKey":   "discokey:4c0f72c0cc06331dc9184a977dacf764ae95d7a3a42264b96721c80374066b17",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:53589", "10.65.0.27:53589", "172.17.0.1:53589"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:52:22.42719054Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5885154563695681,
+				"StableID":   "nAmf2o2Qxn11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22813b9d55b26687709c84873941e692c8a317c3a9ebff4281c254cf26175b79",
+				"DiscoKey":   "discokey:98b72e55d8d1c3b9898213489c54eb98b8e1325de01f7371b63f5657d9e34379",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:53301", "10.65.0.27:53301", "172.17.0.1:53301"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:52:22.967745566Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8345061112147022,
+				"StableID":   "nsBMA5cVA821CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aea1a961facd687fdbe29d687b879d88d4360d00c027a8d054dfa00db4821278",
+				"DiscoKey":   "discokey:2b469a8359196a8a9ae135af817ec52705d54492503b54cd9b144d65366f5e03",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:56907", "10.65.0.27:56907", "172.17.0.1:56907"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 59245},
+					{"Proto": "peerapi6", "Port": 59245}
+				]},
+				"Created":              "2026-05-12T18:52:23.511563859Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         12398617935139,
+				"StableID":   "nnkmQ4hc6111CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f932de904df252835e738a5b0966e03451f133f5046d0b4c016c216e8f402579",
+				"DiscoKey":   "discokey:f01f8b0e51b14fe98505563cc5aee03cdf3339052d1fbf85ba5c7dbe8133f738",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:51688", "10.65.0.27:51688", "172.17.0.1:51688"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:52:24.04059057Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         776667949146727,
+				"StableID":   "nLKK6Wkk4711CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15b9b88563aa5d88241ae257e602216e1e091b3666af39e9e65f07007b3a685a",
+				"DiscoKey":   "discokey:b84ccd05567da23b19de9e39a89611218df282a7f1722516a20e5ac6b7a2917a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46018", "10.65.0.27:46018", "172.17.0.1:46018"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:52:24.578430983Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6136404177810293,
+				"StableID":   "nxvi45wBvp11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d84587141b98484705cceed641f846d3cbd08cd2e64f077f2390b7f608e9fc6c",
+				"DiscoKey":   "discokey:b79a127be18fafc50c696955a4f3ef3809a34a4dd3d08575b63d91d3be872166",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:54929", "10.65.0.27:54929", "172.17.0.1:54929"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:52:25.125123532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1726832356859159,
+				"StableID":   "nWNj7Zx5VE11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8580b45802a67d96eeed7a5bfe8a034d3e7cd88196974e5a740921460049154",
+				"DiscoKey":   "discokey:bde933df45911314985bb21b42cf0c51a2a56bfc429963bded2d7b71b09a0d34",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57014", "10.65.0.27:57014", "172.17.0.1:57014"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:52:26.213278425Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8776597061960922,
+				"StableID":   "nF9cKhKwXB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04e2bc8d22d2000b3ee51a859af82e7812e459e6c18fab78698afd1be8461c4c",
+				"KeyExpiry":  "2026-11-08T18:52:26Z",
+				"DiscoKey":   "discokey:248af9ed3dfa0d89feb04fb06d1d0d80a33d4ba1dd1f8ba709edf23cc61c1a24",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:45734", "10.65.0.27:45734", "172.17.0.1:45734"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:52:26.732179246Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5322461653974364,
+				"StableID":   "nKCzST3ZZi11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:67140cc6cf850ef00336786ac6caba06cd14f518a1cbb09dee12b45e8bc49300",
+				"KeyExpiry":  "2026-11-08T18:52:27Z",
+				"DiscoKey":   "discokey:fabd7cf90d41b9bd91c80d6d9e5e82cdf4021dc26fecb8f83a48e8f4251f5f27",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:37306", "10.65.0.27:37306", "172.17.0.1:37306"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:52:27.282485142Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         71338454102880,
+				"StableID":   "nPNKuXwJZ111CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8c1c5dbed69fc09b9f5e15d71c4bb0338ea5c78ba9d484a1acb3c79fecc1204b",
+				"KeyExpiry":  "2026-11-08T18:52:27Z",
+				"DiscoKey":   "discokey:dcc02fd53cf38c50542af22f0ab5b98b1ca1cf43e881216a20045ee6cdb0b759",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51275", "10.65.0.27:51275", "172.17.0.1:51275"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:52:27.831341295Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "19276890580108": {
+				"ID":          19276890580108,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3609278471971550,
+				"StableID":   "nHW8BGdeBV11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       3609278471971550,
+				"Key":        "nodekey:5f3ce48f5a0d40254f0acd3ad18f0a1e85bc226976fb7309ad36cf40e2124c46",
+				"DiscoKey":   "discokey:8199130784cf44e391026744e1f33ff005933a250461f234b800c647e7d45d44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:47266", "10.65.0.27:47266", "172.17.0.1:47266"],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:52:20.822674862Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:5f3ce48f5a0d40254f0acd3ad18f0a1e85bc226976fb7309ad36cf40e2124c46",
+			"MachineKey": "mkey:c419b6bb7de20bbadb0fb68b575734bb71baf3031cbc5327151d23f670332a79",
+			"Peers": [{
+				"ID":         7149218115871029,
+				"StableID":   "nCg2ZYqtpx11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:42601141114da4ab1aba019ebe4154a603084088ce50471aa58a448f04dce757",
+				"DiscoKey":   "discokey:5423ad984604c8e069013ccf5fe74cd380798423b962a6b97d328e1e44d8886d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:48216", "10.65.0.27:48216", "172.17.0.1:48216"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:52:20.317209717Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         952028410362923,
+				"StableID":   "nnAEZyABS811CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:663ca1c0b98b169842a8b616677a0087118a1e990c7382a68fec7376e91af955",
+				"DiscoKey":   "discokey:3cc5eb69a57bc419db9c8add89316d568b03a8cd1dd3bdd34ffe15e7c1a96706",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:46372", "10.65.0.27:46372", "172.17.0.1:46372"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:52:21.355216786Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5619885924616872,
+				"StableID":   "nTEGmfsFtk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d02c43485dfc059a38ab3319bc6f24a1835449baea1d63ec5f7a100e21fb1e71",
+				"DiscoKey":   "discokey:c60b99e6f863197dcf68d76ace08d7f50fa2554b783619249dab23035fe5135e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:59422", "10.65.0.27:59422", "172.17.0.1:59422"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:52:21.884838767Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7375671910666129,
+				"StableID":   "nWXjwrPTbz11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ce0f527473659069dbe7cd3e6a9f69e2ed7f93e720e4e2b8e1039075cffb2e72",
+				"DiscoKey":   "discokey:4c0f72c0cc06331dc9184a977dacf764ae95d7a3a42264b96721c80374066b17",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:53589", "10.65.0.27:53589", "172.17.0.1:53589"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:52:22.42719054Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5885154563695681,
+				"StableID":   "nAmf2o2Qxn11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22813b9d55b26687709c84873941e692c8a317c3a9ebff4281c254cf26175b79",
+				"DiscoKey":   "discokey:98b72e55d8d1c3b9898213489c54eb98b8e1325de01f7371b63f5657d9e34379",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:53301", "10.65.0.27:53301", "172.17.0.1:53301"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:52:22.967745566Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8345061112147022,
+				"StableID":   "nsBMA5cVA821CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aea1a961facd687fdbe29d687b879d88d4360d00c027a8d054dfa00db4821278",
+				"DiscoKey":   "discokey:2b469a8359196a8a9ae135af817ec52705d54492503b54cd9b144d65366f5e03",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:56907", "10.65.0.27:56907", "172.17.0.1:56907"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 59245},
+					{"Proto": "peerapi6", "Port": 59245}
+				]},
+				"Created":              "2026-05-12T18:52:23.511563859Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         12398617935139,
+				"StableID":   "nnkmQ4hc6111CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f932de904df252835e738a5b0966e03451f133f5046d0b4c016c216e8f402579",
+				"DiscoKey":   "discokey:f01f8b0e51b14fe98505563cc5aee03cdf3339052d1fbf85ba5c7dbe8133f738",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:51688", "10.65.0.27:51688", "172.17.0.1:51688"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:52:24.04059057Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         776667949146727,
+				"StableID":   "nLKK6Wkk4711CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15b9b88563aa5d88241ae257e602216e1e091b3666af39e9e65f07007b3a685a",
+				"DiscoKey":   "discokey:b84ccd05567da23b19de9e39a89611218df282a7f1722516a20e5ac6b7a2917a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46018", "10.65.0.27:46018", "172.17.0.1:46018"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:52:24.578430983Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6136404177810293,
+				"StableID":   "nxvi45wBvp11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d84587141b98484705cceed641f846d3cbd08cd2e64f077f2390b7f608e9fc6c",
+				"DiscoKey":   "discokey:b79a127be18fafc50c696955a4f3ef3809a34a4dd3d08575b63d91d3be872166",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:54929", "10.65.0.27:54929", "172.17.0.1:54929"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:52:25.125123532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         19276890580108,
+				"StableID":   "nfgyoXNj9111CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:899e5ce826ca9b46e78daf09e2bc1133503415509539bb4418872bf0f550fd23",
+				"DiscoKey":   "discokey:f963452d76354ed86e6cff0368ecf5dd84bec9de75add5786f94bb7fe696906a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:55569", "10.65.0.27:55569", "172.17.0.1:55569"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:52:25.666040774Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1726832356859159,
+				"StableID":   "nWNj7Zx5VE11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8580b45802a67d96eeed7a5bfe8a034d3e7cd88196974e5a740921460049154",
+				"DiscoKey":   "discokey:bde933df45911314985bb21b42cf0c51a2a56bfc429963bded2d7b71b09a0d34",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57014", "10.65.0.27:57014", "172.17.0.1:57014"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:52:26.213278425Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8776597061960922,
+				"StableID":   "nF9cKhKwXB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04e2bc8d22d2000b3ee51a859af82e7812e459e6c18fab78698afd1be8461c4c",
+				"KeyExpiry":  "2026-11-08T18:52:26Z",
+				"DiscoKey":   "discokey:248af9ed3dfa0d89feb04fb06d1d0d80a33d4ba1dd1f8ba709edf23cc61c1a24",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:45734", "10.65.0.27:45734", "172.17.0.1:45734"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:52:26.732179246Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5322461653974364,
+				"StableID":   "nKCzST3ZZi11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:67140cc6cf850ef00336786ac6caba06cd14f518a1cbb09dee12b45e8bc49300",
+				"KeyExpiry":  "2026-11-08T18:52:27Z",
+				"DiscoKey":   "discokey:fabd7cf90d41b9bd91c80d6d9e5e82cdf4021dc26fecb8f83a48e8f4251f5f27",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:37306", "10.65.0.27:37306", "172.17.0.1:37306"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:52:27.282485142Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         71338454102880,
+				"StableID":   "nPNKuXwJZ111CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8c1c5dbed69fc09b9f5e15d71c4bb0338ea5c78ba9d484a1acb3c79fecc1204b",
+				"KeyExpiry":  "2026-11-08T18:52:27Z",
+				"DiscoKey":   "discokey:dcc02fd53cf38c50542af22f0ab5b98b1ca1cf43e881216a20045ee6cdb0b759",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51275", "10.65.0.27:51275", "172.17.0.1:51275"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:52:27.831341295Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3609278471971550": {
+				"ID":          3609278471971550,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7149218115871029,
+				"StableID":   "nCg2ZYqtpx11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       7149218115871029,
+				"Key":        "nodekey:42601141114da4ab1aba019ebe4154a603084088ce50471aa58a448f04dce757",
+				"DiscoKey":   "discokey:5423ad984604c8e069013ccf5fe74cd380798423b962a6b97d328e1e44d8886d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:48216", "10.65.0.27:48216", "172.17.0.1:48216"],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:52:20.317209717Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:42601141114da4ab1aba019ebe4154a603084088ce50471aa58a448f04dce757",
+			"MachineKey": "mkey:4e24cdab91a3eb807708bc455a8417cc363f2ae47cbf6484a9e417c23d2baa37",
+			"Peers": [{
+				"ID":         3609278471971550,
+				"StableID":   "nHW8BGdeBV11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f3ce48f5a0d40254f0acd3ad18f0a1e85bc226976fb7309ad36cf40e2124c46",
+				"DiscoKey":   "discokey:8199130784cf44e391026744e1f33ff005933a250461f234b800c647e7d45d44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:47266", "10.65.0.27:47266", "172.17.0.1:47266"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:52:20.822674862Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         952028410362923,
+				"StableID":   "nnAEZyABS811CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:663ca1c0b98b169842a8b616677a0087118a1e990c7382a68fec7376e91af955",
+				"DiscoKey":   "discokey:3cc5eb69a57bc419db9c8add89316d568b03a8cd1dd3bdd34ffe15e7c1a96706",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:46372", "10.65.0.27:46372", "172.17.0.1:46372"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:52:21.355216786Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5619885924616872,
+				"StableID":   "nTEGmfsFtk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d02c43485dfc059a38ab3319bc6f24a1835449baea1d63ec5f7a100e21fb1e71",
+				"DiscoKey":   "discokey:c60b99e6f863197dcf68d76ace08d7f50fa2554b783619249dab23035fe5135e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:59422", "10.65.0.27:59422", "172.17.0.1:59422"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:52:21.884838767Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7375671910666129,
+				"StableID":   "nWXjwrPTbz11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ce0f527473659069dbe7cd3e6a9f69e2ed7f93e720e4e2b8e1039075cffb2e72",
+				"DiscoKey":   "discokey:4c0f72c0cc06331dc9184a977dacf764ae95d7a3a42264b96721c80374066b17",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:53589", "10.65.0.27:53589", "172.17.0.1:53589"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:52:22.42719054Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5885154563695681,
+				"StableID":   "nAmf2o2Qxn11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22813b9d55b26687709c84873941e692c8a317c3a9ebff4281c254cf26175b79",
+				"DiscoKey":   "discokey:98b72e55d8d1c3b9898213489c54eb98b8e1325de01f7371b63f5657d9e34379",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:53301", "10.65.0.27:53301", "172.17.0.1:53301"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:52:22.967745566Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8345061112147022,
+				"StableID":   "nsBMA5cVA821CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aea1a961facd687fdbe29d687b879d88d4360d00c027a8d054dfa00db4821278",
+				"DiscoKey":   "discokey:2b469a8359196a8a9ae135af817ec52705d54492503b54cd9b144d65366f5e03",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:56907", "10.65.0.27:56907", "172.17.0.1:56907"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 59245},
+					{"Proto": "peerapi6", "Port": 59245}
+				]},
+				"Created":              "2026-05-12T18:52:23.511563859Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         12398617935139,
+				"StableID":   "nnkmQ4hc6111CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f932de904df252835e738a5b0966e03451f133f5046d0b4c016c216e8f402579",
+				"DiscoKey":   "discokey:f01f8b0e51b14fe98505563cc5aee03cdf3339052d1fbf85ba5c7dbe8133f738",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:51688", "10.65.0.27:51688", "172.17.0.1:51688"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:52:24.04059057Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         776667949146727,
+				"StableID":   "nLKK6Wkk4711CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15b9b88563aa5d88241ae257e602216e1e091b3666af39e9e65f07007b3a685a",
+				"DiscoKey":   "discokey:b84ccd05567da23b19de9e39a89611218df282a7f1722516a20e5ac6b7a2917a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46018", "10.65.0.27:46018", "172.17.0.1:46018"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:52:24.578430983Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6136404177810293,
+				"StableID":   "nxvi45wBvp11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d84587141b98484705cceed641f846d3cbd08cd2e64f077f2390b7f608e9fc6c",
+				"DiscoKey":   "discokey:b79a127be18fafc50c696955a4f3ef3809a34a4dd3d08575b63d91d3be872166",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:54929", "10.65.0.27:54929", "172.17.0.1:54929"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:52:25.125123532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         19276890580108,
+				"StableID":   "nfgyoXNj9111CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:899e5ce826ca9b46e78daf09e2bc1133503415509539bb4418872bf0f550fd23",
+				"DiscoKey":   "discokey:f963452d76354ed86e6cff0368ecf5dd84bec9de75add5786f94bb7fe696906a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:55569", "10.65.0.27:55569", "172.17.0.1:55569"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:52:25.666040774Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1726832356859159,
+				"StableID":   "nWNj7Zx5VE11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8580b45802a67d96eeed7a5bfe8a034d3e7cd88196974e5a740921460049154",
+				"DiscoKey":   "discokey:bde933df45911314985bb21b42cf0c51a2a56bfc429963bded2d7b71b09a0d34",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57014", "10.65.0.27:57014", "172.17.0.1:57014"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:52:26.213278425Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8776597061960922,
+				"StableID":   "nF9cKhKwXB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04e2bc8d22d2000b3ee51a859af82e7812e459e6c18fab78698afd1be8461c4c",
+				"KeyExpiry":  "2026-11-08T18:52:26Z",
+				"DiscoKey":   "discokey:248af9ed3dfa0d89feb04fb06d1d0d80a33d4ba1dd1f8ba709edf23cc61c1a24",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:45734", "10.65.0.27:45734", "172.17.0.1:45734"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:52:26.732179246Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5322461653974364,
+				"StableID":   "nKCzST3ZZi11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:67140cc6cf850ef00336786ac6caba06cd14f518a1cbb09dee12b45e8bc49300",
+				"KeyExpiry":  "2026-11-08T18:52:27Z",
+				"DiscoKey":   "discokey:fabd7cf90d41b9bd91c80d6d9e5e82cdf4021dc26fecb8f83a48e8f4251f5f27",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:37306", "10.65.0.27:37306", "172.17.0.1:37306"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:52:27.282485142Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         71338454102880,
+				"StableID":   "nPNKuXwJZ111CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8c1c5dbed69fc09b9f5e15d71c4bb0338ea5c78ba9d484a1acb3c79fecc1204b",
+				"KeyExpiry":  "2026-11-08T18:52:27Z",
+				"DiscoKey":   "discokey:dcc02fd53cf38c50542af22f0ab5b98b1ca1cf43e881216a20045ee6cdb0b759",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51275", "10.65.0.27:51275", "172.17.0.1:51275"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:52:27.831341295Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7149218115871029": {
+				"ID":          7149218115871029,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7375671910666129,
+				"StableID":   "nWXjwrPTbz11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       7375671910666129,
+				"Key":        "nodekey:ce0f527473659069dbe7cd3e6a9f69e2ed7f93e720e4e2b8e1039075cffb2e72",
+				"DiscoKey":   "discokey:4c0f72c0cc06331dc9184a977dacf764ae95d7a3a42264b96721c80374066b17",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:53589", "10.65.0.27:53589", "172.17.0.1:53589"],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:52:22.42719054Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ce0f527473659069dbe7cd3e6a9f69e2ed7f93e720e4e2b8e1039075cffb2e72",
+			"MachineKey": "mkey:4eeb68a2409aab62c2acf44bdc70beb5ec9f65339e2fc184c0c6fd652d14ce26",
+			"Peers": [{
+				"ID":         7149218115871029,
+				"StableID":   "nCg2ZYqtpx11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:42601141114da4ab1aba019ebe4154a603084088ce50471aa58a448f04dce757",
+				"DiscoKey":   "discokey:5423ad984604c8e069013ccf5fe74cd380798423b962a6b97d328e1e44d8886d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:48216", "10.65.0.27:48216", "172.17.0.1:48216"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:52:20.317209717Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3609278471971550,
+				"StableID":   "nHW8BGdeBV11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f3ce48f5a0d40254f0acd3ad18f0a1e85bc226976fb7309ad36cf40e2124c46",
+				"DiscoKey":   "discokey:8199130784cf44e391026744e1f33ff005933a250461f234b800c647e7d45d44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:47266", "10.65.0.27:47266", "172.17.0.1:47266"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:52:20.822674862Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         952028410362923,
+				"StableID":   "nnAEZyABS811CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:663ca1c0b98b169842a8b616677a0087118a1e990c7382a68fec7376e91af955",
+				"DiscoKey":   "discokey:3cc5eb69a57bc419db9c8add89316d568b03a8cd1dd3bdd34ffe15e7c1a96706",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:46372", "10.65.0.27:46372", "172.17.0.1:46372"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:52:21.355216786Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5619885924616872,
+				"StableID":   "nTEGmfsFtk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d02c43485dfc059a38ab3319bc6f24a1835449baea1d63ec5f7a100e21fb1e71",
+				"DiscoKey":   "discokey:c60b99e6f863197dcf68d76ace08d7f50fa2554b783619249dab23035fe5135e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:59422", "10.65.0.27:59422", "172.17.0.1:59422"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:52:21.884838767Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         5885154563695681,
+				"StableID":   "nAmf2o2Qxn11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22813b9d55b26687709c84873941e692c8a317c3a9ebff4281c254cf26175b79",
+				"DiscoKey":   "discokey:98b72e55d8d1c3b9898213489c54eb98b8e1325de01f7371b63f5657d9e34379",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:53301", "10.65.0.27:53301", "172.17.0.1:53301"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:52:22.967745566Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8345061112147022,
+				"StableID":   "nsBMA5cVA821CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aea1a961facd687fdbe29d687b879d88d4360d00c027a8d054dfa00db4821278",
+				"DiscoKey":   "discokey:2b469a8359196a8a9ae135af817ec52705d54492503b54cd9b144d65366f5e03",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:56907", "10.65.0.27:56907", "172.17.0.1:56907"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 59245},
+					{"Proto": "peerapi6", "Port": 59245}
+				]},
+				"Created":              "2026-05-12T18:52:23.511563859Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         12398617935139,
+				"StableID":   "nnkmQ4hc6111CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f932de904df252835e738a5b0966e03451f133f5046d0b4c016c216e8f402579",
+				"DiscoKey":   "discokey:f01f8b0e51b14fe98505563cc5aee03cdf3339052d1fbf85ba5c7dbe8133f738",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:51688", "10.65.0.27:51688", "172.17.0.1:51688"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:52:24.04059057Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         776667949146727,
+				"StableID":   "nLKK6Wkk4711CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15b9b88563aa5d88241ae257e602216e1e091b3666af39e9e65f07007b3a685a",
+				"DiscoKey":   "discokey:b84ccd05567da23b19de9e39a89611218df282a7f1722516a20e5ac6b7a2917a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46018", "10.65.0.27:46018", "172.17.0.1:46018"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:52:24.578430983Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6136404177810293,
+				"StableID":   "nxvi45wBvp11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d84587141b98484705cceed641f846d3cbd08cd2e64f077f2390b7f608e9fc6c",
+				"DiscoKey":   "discokey:b79a127be18fafc50c696955a4f3ef3809a34a4dd3d08575b63d91d3be872166",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:54929", "10.65.0.27:54929", "172.17.0.1:54929"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:52:25.125123532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         19276890580108,
+				"StableID":   "nfgyoXNj9111CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:899e5ce826ca9b46e78daf09e2bc1133503415509539bb4418872bf0f550fd23",
+				"DiscoKey":   "discokey:f963452d76354ed86e6cff0368ecf5dd84bec9de75add5786f94bb7fe696906a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:55569", "10.65.0.27:55569", "172.17.0.1:55569"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:52:25.666040774Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1726832356859159,
+				"StableID":   "nWNj7Zx5VE11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8580b45802a67d96eeed7a5bfe8a034d3e7cd88196974e5a740921460049154",
+				"DiscoKey":   "discokey:bde933df45911314985bb21b42cf0c51a2a56bfc429963bded2d7b71b09a0d34",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57014", "10.65.0.27:57014", "172.17.0.1:57014"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:52:26.213278425Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8776597061960922,
+				"StableID":   "nF9cKhKwXB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04e2bc8d22d2000b3ee51a859af82e7812e459e6c18fab78698afd1be8461c4c",
+				"KeyExpiry":  "2026-11-08T18:52:26Z",
+				"DiscoKey":   "discokey:248af9ed3dfa0d89feb04fb06d1d0d80a33d4ba1dd1f8ba709edf23cc61c1a24",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:45734", "10.65.0.27:45734", "172.17.0.1:45734"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:52:26.732179246Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5322461653974364,
+				"StableID":   "nKCzST3ZZi11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:67140cc6cf850ef00336786ac6caba06cd14f518a1cbb09dee12b45e8bc49300",
+				"KeyExpiry":  "2026-11-08T18:52:27Z",
+				"DiscoKey":   "discokey:fabd7cf90d41b9bd91c80d6d9e5e82cdf4021dc26fecb8f83a48e8f4251f5f27",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:37306", "10.65.0.27:37306", "172.17.0.1:37306"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:52:27.282485142Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         71338454102880,
+				"StableID":   "nPNKuXwJZ111CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8c1c5dbed69fc09b9f5e15d71c4bb0338ea5c78ba9d484a1acb3c79fecc1204b",
+				"KeyExpiry":  "2026-11-08T18:52:27Z",
+				"DiscoKey":   "discokey:dcc02fd53cf38c50542af22f0ab5b98b1ca1cf43e881216a20045ee6cdb0b759",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51275", "10.65.0.27:51275", "172.17.0.1:51275"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:52:27.831341295Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7375671910666129": {
+				"ID":          7375671910666129,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5619885924616872,
+				"StableID":   "nTEGmfsFtk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       5619885924616872,
+				"Key":        "nodekey:d02c43485dfc059a38ab3319bc6f24a1835449baea1d63ec5f7a100e21fb1e71",
+				"DiscoKey":   "discokey:c60b99e6f863197dcf68d76ace08d7f50fa2554b783619249dab23035fe5135e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:59422", "10.65.0.27:59422", "172.17.0.1:59422"],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:52:21.884838767Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d02c43485dfc059a38ab3319bc6f24a1835449baea1d63ec5f7a100e21fb1e71",
+			"MachineKey": "mkey:93039aa72537c6a8e34230ca3d5eac719e2a02697f3c1383b2c24d19af992012",
+			"Peers": [{
+				"ID":         7149218115871029,
+				"StableID":   "nCg2ZYqtpx11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:42601141114da4ab1aba019ebe4154a603084088ce50471aa58a448f04dce757",
+				"DiscoKey":   "discokey:5423ad984604c8e069013ccf5fe74cd380798423b962a6b97d328e1e44d8886d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:48216", "10.65.0.27:48216", "172.17.0.1:48216"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:52:20.317209717Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3609278471971550,
+				"StableID":   "nHW8BGdeBV11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f3ce48f5a0d40254f0acd3ad18f0a1e85bc226976fb7309ad36cf40e2124c46",
+				"DiscoKey":   "discokey:8199130784cf44e391026744e1f33ff005933a250461f234b800c647e7d45d44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:47266", "10.65.0.27:47266", "172.17.0.1:47266"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:52:20.822674862Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         952028410362923,
+				"StableID":   "nnAEZyABS811CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:663ca1c0b98b169842a8b616677a0087118a1e990c7382a68fec7376e91af955",
+				"DiscoKey":   "discokey:3cc5eb69a57bc419db9c8add89316d568b03a8cd1dd3bdd34ffe15e7c1a96706",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:46372", "10.65.0.27:46372", "172.17.0.1:46372"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:52:21.355216786Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7375671910666129,
+				"StableID":   "nWXjwrPTbz11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ce0f527473659069dbe7cd3e6a9f69e2ed7f93e720e4e2b8e1039075cffb2e72",
+				"DiscoKey":   "discokey:4c0f72c0cc06331dc9184a977dacf764ae95d7a3a42264b96721c80374066b17",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:53589", "10.65.0.27:53589", "172.17.0.1:53589"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:52:22.42719054Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5885154563695681,
+				"StableID":   "nAmf2o2Qxn11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22813b9d55b26687709c84873941e692c8a317c3a9ebff4281c254cf26175b79",
+				"DiscoKey":   "discokey:98b72e55d8d1c3b9898213489c54eb98b8e1325de01f7371b63f5657d9e34379",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:53301", "10.65.0.27:53301", "172.17.0.1:53301"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:52:22.967745566Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8345061112147022,
+				"StableID":   "nsBMA5cVA821CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aea1a961facd687fdbe29d687b879d88d4360d00c027a8d054dfa00db4821278",
+				"DiscoKey":   "discokey:2b469a8359196a8a9ae135af817ec52705d54492503b54cd9b144d65366f5e03",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:56907", "10.65.0.27:56907", "172.17.0.1:56907"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 59245},
+					{"Proto": "peerapi6", "Port": 59245}
+				]},
+				"Created":              "2026-05-12T18:52:23.511563859Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         12398617935139,
+				"StableID":   "nnkmQ4hc6111CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f932de904df252835e738a5b0966e03451f133f5046d0b4c016c216e8f402579",
+				"DiscoKey":   "discokey:f01f8b0e51b14fe98505563cc5aee03cdf3339052d1fbf85ba5c7dbe8133f738",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:51688", "10.65.0.27:51688", "172.17.0.1:51688"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:52:24.04059057Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         776667949146727,
+				"StableID":   "nLKK6Wkk4711CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15b9b88563aa5d88241ae257e602216e1e091b3666af39e9e65f07007b3a685a",
+				"DiscoKey":   "discokey:b84ccd05567da23b19de9e39a89611218df282a7f1722516a20e5ac6b7a2917a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46018", "10.65.0.27:46018", "172.17.0.1:46018"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:52:24.578430983Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6136404177810293,
+				"StableID":   "nxvi45wBvp11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d84587141b98484705cceed641f846d3cbd08cd2e64f077f2390b7f608e9fc6c",
+				"DiscoKey":   "discokey:b79a127be18fafc50c696955a4f3ef3809a34a4dd3d08575b63d91d3be872166",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:54929", "10.65.0.27:54929", "172.17.0.1:54929"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:52:25.125123532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         19276890580108,
+				"StableID":   "nfgyoXNj9111CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:899e5ce826ca9b46e78daf09e2bc1133503415509539bb4418872bf0f550fd23",
+				"DiscoKey":   "discokey:f963452d76354ed86e6cff0368ecf5dd84bec9de75add5786f94bb7fe696906a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:55569", "10.65.0.27:55569", "172.17.0.1:55569"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:52:25.666040774Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1726832356859159,
+				"StableID":   "nWNj7Zx5VE11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8580b45802a67d96eeed7a5bfe8a034d3e7cd88196974e5a740921460049154",
+				"DiscoKey":   "discokey:bde933df45911314985bb21b42cf0c51a2a56bfc429963bded2d7b71b09a0d34",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57014", "10.65.0.27:57014", "172.17.0.1:57014"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:52:26.213278425Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8776597061960922,
+				"StableID":   "nF9cKhKwXB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04e2bc8d22d2000b3ee51a859af82e7812e459e6c18fab78698afd1be8461c4c",
+				"KeyExpiry":  "2026-11-08T18:52:26Z",
+				"DiscoKey":   "discokey:248af9ed3dfa0d89feb04fb06d1d0d80a33d4ba1dd1f8ba709edf23cc61c1a24",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:45734", "10.65.0.27:45734", "172.17.0.1:45734"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:52:26.732179246Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5322461653974364,
+				"StableID":   "nKCzST3ZZi11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:67140cc6cf850ef00336786ac6caba06cd14f518a1cbb09dee12b45e8bc49300",
+				"KeyExpiry":  "2026-11-08T18:52:27Z",
+				"DiscoKey":   "discokey:fabd7cf90d41b9bd91c80d6d9e5e82cdf4021dc26fecb8f83a48e8f4251f5f27",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:37306", "10.65.0.27:37306", "172.17.0.1:37306"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:52:27.282485142Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         71338454102880,
+				"StableID":   "nPNKuXwJZ111CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8c1c5dbed69fc09b9f5e15d71c4bb0338ea5c78ba9d484a1acb3c79fecc1204b",
+				"KeyExpiry":  "2026-11-08T18:52:27Z",
+				"DiscoKey":   "discokey:dcc02fd53cf38c50542af22f0ab5b98b1ca1cf43e881216a20045ee6cdb0b759",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51275", "10.65.0.27:51275", "172.17.0.1:51275"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:52:27.831341295Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5619885924616872": {
+				"ID":          5619885924616872,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8345061112147022,
+				"StableID":   "nsBMA5cVA821CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       8345061112147022,
+				"Key":        "nodekey:aea1a961facd687fdbe29d687b879d88d4360d00c027a8d054dfa00db4821278",
+				"DiscoKey":   "discokey:2b469a8359196a8a9ae135af817ec52705d54492503b54cd9b144d65366f5e03",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:56907", "10.65.0.27:56907", "172.17.0.1:56907"],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 59245},
+						{"Proto": "peerapi6", "Port": 59245},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:52:23.511563859Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:aea1a961facd687fdbe29d687b879d88d4360d00c027a8d054dfa00db4821278",
+			"MachineKey": "mkey:66312c88666e250f44a11418c58b4adbe9f9df1f6015b1507525461603105720",
+			"Peers": [{
+				"ID":         7149218115871029,
+				"StableID":   "nCg2ZYqtpx11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:42601141114da4ab1aba019ebe4154a603084088ce50471aa58a448f04dce757",
+				"DiscoKey":   "discokey:5423ad984604c8e069013ccf5fe74cd380798423b962a6b97d328e1e44d8886d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:48216", "10.65.0.27:48216", "172.17.0.1:48216"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:52:20.317209717Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3609278471971550,
+				"StableID":   "nHW8BGdeBV11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f3ce48f5a0d40254f0acd3ad18f0a1e85bc226976fb7309ad36cf40e2124c46",
+				"DiscoKey":   "discokey:8199130784cf44e391026744e1f33ff005933a250461f234b800c647e7d45d44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:47266", "10.65.0.27:47266", "172.17.0.1:47266"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:52:20.822674862Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         952028410362923,
+				"StableID":   "nnAEZyABS811CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:663ca1c0b98b169842a8b616677a0087118a1e990c7382a68fec7376e91af955",
+				"DiscoKey":   "discokey:3cc5eb69a57bc419db9c8add89316d568b03a8cd1dd3bdd34ffe15e7c1a96706",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:46372", "10.65.0.27:46372", "172.17.0.1:46372"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:52:21.355216786Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5619885924616872,
+				"StableID":   "nTEGmfsFtk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d02c43485dfc059a38ab3319bc6f24a1835449baea1d63ec5f7a100e21fb1e71",
+				"DiscoKey":   "discokey:c60b99e6f863197dcf68d76ace08d7f50fa2554b783619249dab23035fe5135e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:59422", "10.65.0.27:59422", "172.17.0.1:59422"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:52:21.884838767Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7375671910666129,
+				"StableID":   "nWXjwrPTbz11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ce0f527473659069dbe7cd3e6a9f69e2ed7f93e720e4e2b8e1039075cffb2e72",
+				"DiscoKey":   "discokey:4c0f72c0cc06331dc9184a977dacf764ae95d7a3a42264b96721c80374066b17",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:53589", "10.65.0.27:53589", "172.17.0.1:53589"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:52:22.42719054Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5885154563695681,
+				"StableID":   "nAmf2o2Qxn11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22813b9d55b26687709c84873941e692c8a317c3a9ebff4281c254cf26175b79",
+				"DiscoKey":   "discokey:98b72e55d8d1c3b9898213489c54eb98b8e1325de01f7371b63f5657d9e34379",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:53301", "10.65.0.27:53301", "172.17.0.1:53301"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:52:22.967745566Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         12398617935139,
+				"StableID":   "nnkmQ4hc6111CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f932de904df252835e738a5b0966e03451f133f5046d0b4c016c216e8f402579",
+				"DiscoKey":   "discokey:f01f8b0e51b14fe98505563cc5aee03cdf3339052d1fbf85ba5c7dbe8133f738",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:51688", "10.65.0.27:51688", "172.17.0.1:51688"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:52:24.04059057Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         776667949146727,
+				"StableID":   "nLKK6Wkk4711CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15b9b88563aa5d88241ae257e602216e1e091b3666af39e9e65f07007b3a685a",
+				"DiscoKey":   "discokey:b84ccd05567da23b19de9e39a89611218df282a7f1722516a20e5ac6b7a2917a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46018", "10.65.0.27:46018", "172.17.0.1:46018"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:52:24.578430983Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6136404177810293,
+				"StableID":   "nxvi45wBvp11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d84587141b98484705cceed641f846d3cbd08cd2e64f077f2390b7f608e9fc6c",
+				"DiscoKey":   "discokey:b79a127be18fafc50c696955a4f3ef3809a34a4dd3d08575b63d91d3be872166",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:54929", "10.65.0.27:54929", "172.17.0.1:54929"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:52:25.125123532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         19276890580108,
+				"StableID":   "nfgyoXNj9111CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:899e5ce826ca9b46e78daf09e2bc1133503415509539bb4418872bf0f550fd23",
+				"DiscoKey":   "discokey:f963452d76354ed86e6cff0368ecf5dd84bec9de75add5786f94bb7fe696906a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:55569", "10.65.0.27:55569", "172.17.0.1:55569"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:52:25.666040774Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1726832356859159,
+				"StableID":   "nWNj7Zx5VE11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8580b45802a67d96eeed7a5bfe8a034d3e7cd88196974e5a740921460049154",
+				"DiscoKey":   "discokey:bde933df45911314985bb21b42cf0c51a2a56bfc429963bded2d7b71b09a0d34",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57014", "10.65.0.27:57014", "172.17.0.1:57014"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:52:26.213278425Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8776597061960922,
+				"StableID":   "nF9cKhKwXB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04e2bc8d22d2000b3ee51a859af82e7812e459e6c18fab78698afd1be8461c4c",
+				"KeyExpiry":  "2026-11-08T18:52:26Z",
+				"DiscoKey":   "discokey:248af9ed3dfa0d89feb04fb06d1d0d80a33d4ba1dd1f8ba709edf23cc61c1a24",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:45734", "10.65.0.27:45734", "172.17.0.1:45734"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:52:26.732179246Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5322461653974364,
+				"StableID":   "nKCzST3ZZi11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:67140cc6cf850ef00336786ac6caba06cd14f518a1cbb09dee12b45e8bc49300",
+				"KeyExpiry":  "2026-11-08T18:52:27Z",
+				"DiscoKey":   "discokey:fabd7cf90d41b9bd91c80d6d9e5e82cdf4021dc26fecb8f83a48e8f4251f5f27",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:37306", "10.65.0.27:37306", "172.17.0.1:37306"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:52:27.282485142Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         71338454102880,
+				"StableID":   "nPNKuXwJZ111CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8c1c5dbed69fc09b9f5e15d71c4bb0338ea5c78ba9d484a1acb3c79fecc1204b",
+				"KeyExpiry":  "2026-11-08T18:52:27Z",
+				"DiscoKey":   "discokey:dcc02fd53cf38c50542af22f0ab5b98b1ca1cf43e881216a20045ee6cdb0b759",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51275", "10.65.0.27:51275", "172.17.0.1:51275"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:52:27.831341295Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8345061112147022": {
+				"ID":          8345061112147022,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         776667949146727,
+				"StableID":   "nLKK6Wkk4711CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       776667949146727,
+				"Key":        "nodekey:15b9b88563aa5d88241ae257e602216e1e091b3666af39e9e65f07007b3a685a",
+				"DiscoKey":   "discokey:b84ccd05567da23b19de9e39a89611218df282a7f1722516a20e5ac6b7a2917a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46018", "10.65.0.27:46018", "172.17.0.1:46018"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:52:24.578430983Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:15b9b88563aa5d88241ae257e602216e1e091b3666af39e9e65f07007b3a685a",
+			"MachineKey": "mkey:420b96ecdd36e7200c756e59618cfc550f9bae652b24635a482f40a841bcca2d",
+			"Peers": [{
+				"ID":         7149218115871029,
+				"StableID":   "nCg2ZYqtpx11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:42601141114da4ab1aba019ebe4154a603084088ce50471aa58a448f04dce757",
+				"DiscoKey":   "discokey:5423ad984604c8e069013ccf5fe74cd380798423b962a6b97d328e1e44d8886d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:48216", "10.65.0.27:48216", "172.17.0.1:48216"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:52:20.317209717Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3609278471971550,
+				"StableID":   "nHW8BGdeBV11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f3ce48f5a0d40254f0acd3ad18f0a1e85bc226976fb7309ad36cf40e2124c46",
+				"DiscoKey":   "discokey:8199130784cf44e391026744e1f33ff005933a250461f234b800c647e7d45d44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:47266", "10.65.0.27:47266", "172.17.0.1:47266"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:52:20.822674862Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         952028410362923,
+				"StableID":   "nnAEZyABS811CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:663ca1c0b98b169842a8b616677a0087118a1e990c7382a68fec7376e91af955",
+				"DiscoKey":   "discokey:3cc5eb69a57bc419db9c8add89316d568b03a8cd1dd3bdd34ffe15e7c1a96706",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:46372", "10.65.0.27:46372", "172.17.0.1:46372"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:52:21.355216786Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5619885924616872,
+				"StableID":   "nTEGmfsFtk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d02c43485dfc059a38ab3319bc6f24a1835449baea1d63ec5f7a100e21fb1e71",
+				"DiscoKey":   "discokey:c60b99e6f863197dcf68d76ace08d7f50fa2554b783619249dab23035fe5135e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:59422", "10.65.0.27:59422", "172.17.0.1:59422"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:52:21.884838767Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7375671910666129,
+				"StableID":   "nWXjwrPTbz11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ce0f527473659069dbe7cd3e6a9f69e2ed7f93e720e4e2b8e1039075cffb2e72",
+				"DiscoKey":   "discokey:4c0f72c0cc06331dc9184a977dacf764ae95d7a3a42264b96721c80374066b17",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:53589", "10.65.0.27:53589", "172.17.0.1:53589"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:52:22.42719054Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5885154563695681,
+				"StableID":   "nAmf2o2Qxn11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22813b9d55b26687709c84873941e692c8a317c3a9ebff4281c254cf26175b79",
+				"DiscoKey":   "discokey:98b72e55d8d1c3b9898213489c54eb98b8e1325de01f7371b63f5657d9e34379",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:53301", "10.65.0.27:53301", "172.17.0.1:53301"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:52:22.967745566Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8345061112147022,
+				"StableID":   "nsBMA5cVA821CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aea1a961facd687fdbe29d687b879d88d4360d00c027a8d054dfa00db4821278",
+				"DiscoKey":   "discokey:2b469a8359196a8a9ae135af817ec52705d54492503b54cd9b144d65366f5e03",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:56907", "10.65.0.27:56907", "172.17.0.1:56907"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 59245},
+					{"Proto": "peerapi6", "Port": 59245}
+				]},
+				"Created":              "2026-05-12T18:52:23.511563859Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         12398617935139,
+				"StableID":   "nnkmQ4hc6111CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f932de904df252835e738a5b0966e03451f133f5046d0b4c016c216e8f402579",
+				"DiscoKey":   "discokey:f01f8b0e51b14fe98505563cc5aee03cdf3339052d1fbf85ba5c7dbe8133f738",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:51688", "10.65.0.27:51688", "172.17.0.1:51688"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:52:24.04059057Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6136404177810293,
+				"StableID":   "nxvi45wBvp11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d84587141b98484705cceed641f846d3cbd08cd2e64f077f2390b7f608e9fc6c",
+				"DiscoKey":   "discokey:b79a127be18fafc50c696955a4f3ef3809a34a4dd3d08575b63d91d3be872166",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:54929", "10.65.0.27:54929", "172.17.0.1:54929"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:52:25.125123532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         19276890580108,
+				"StableID":   "nfgyoXNj9111CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:899e5ce826ca9b46e78daf09e2bc1133503415509539bb4418872bf0f550fd23",
+				"DiscoKey":   "discokey:f963452d76354ed86e6cff0368ecf5dd84bec9de75add5786f94bb7fe696906a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:55569", "10.65.0.27:55569", "172.17.0.1:55569"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:52:25.666040774Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1726832356859159,
+				"StableID":   "nWNj7Zx5VE11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8580b45802a67d96eeed7a5bfe8a034d3e7cd88196974e5a740921460049154",
+				"DiscoKey":   "discokey:bde933df45911314985bb21b42cf0c51a2a56bfc429963bded2d7b71b09a0d34",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57014", "10.65.0.27:57014", "172.17.0.1:57014"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:52:26.213278425Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8776597061960922,
+				"StableID":   "nF9cKhKwXB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04e2bc8d22d2000b3ee51a859af82e7812e459e6c18fab78698afd1be8461c4c",
+				"KeyExpiry":  "2026-11-08T18:52:26Z",
+				"DiscoKey":   "discokey:248af9ed3dfa0d89feb04fb06d1d0d80a33d4ba1dd1f8ba709edf23cc61c1a24",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:45734", "10.65.0.27:45734", "172.17.0.1:45734"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:52:26.732179246Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5322461653974364,
+				"StableID":   "nKCzST3ZZi11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:67140cc6cf850ef00336786ac6caba06cd14f518a1cbb09dee12b45e8bc49300",
+				"KeyExpiry":  "2026-11-08T18:52:27Z",
+				"DiscoKey":   "discokey:fabd7cf90d41b9bd91c80d6d9e5e82cdf4021dc26fecb8f83a48e8f4251f5f27",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:37306", "10.65.0.27:37306", "172.17.0.1:37306"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:52:27.282485142Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         71338454102880,
+				"StableID":   "nPNKuXwJZ111CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8c1c5dbed69fc09b9f5e15d71c4bb0338ea5c78ba9d484a1acb3c79fecc1204b",
+				"KeyExpiry":  "2026-11-08T18:52:27Z",
+				"DiscoKey":   "discokey:dcc02fd53cf38c50542af22f0ab5b98b1ca1cf43e881216a20045ee6cdb0b759",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51275", "10.65.0.27:51275", "172.17.0.1:51275"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:52:27.831341295Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "776667949146727": {
+				"ID":          776667949146727,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5322461653974364,
+				"StableID":   "nKCzST3ZZi11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:67140cc6cf850ef00336786ac6caba06cd14f518a1cbb09dee12b45e8bc49300",
+				"KeyExpiry":  "2026-11-08T18:52:27Z",
+				"DiscoKey":   "discokey:fabd7cf90d41b9bd91c80d6d9e5e82cdf4021dc26fecb8f83a48e8f4251f5f27",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:37306", "10.65.0.27:37306", "172.17.0.1:37306"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:52:27.282485142Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:67140cc6cf850ef00336786ac6caba06cd14f518a1cbb09dee12b45e8bc49300",
+			"MachineKey": "mkey:ecac8ef03cea5501b4da4e8e66a25f39314754b4ec6585840b0ff880e029a570",
+			"Peers": [{
+				"ID":         7149218115871029,
+				"StableID":   "nCg2ZYqtpx11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:42601141114da4ab1aba019ebe4154a603084088ce50471aa58a448f04dce757",
+				"DiscoKey":   "discokey:5423ad984604c8e069013ccf5fe74cd380798423b962a6b97d328e1e44d8886d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:48216", "10.65.0.27:48216", "172.17.0.1:48216"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:52:20.317209717Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3609278471971550,
+				"StableID":   "nHW8BGdeBV11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f3ce48f5a0d40254f0acd3ad18f0a1e85bc226976fb7309ad36cf40e2124c46",
+				"DiscoKey":   "discokey:8199130784cf44e391026744e1f33ff005933a250461f234b800c647e7d45d44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:47266", "10.65.0.27:47266", "172.17.0.1:47266"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:52:20.822674862Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         952028410362923,
+				"StableID":   "nnAEZyABS811CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:663ca1c0b98b169842a8b616677a0087118a1e990c7382a68fec7376e91af955",
+				"DiscoKey":   "discokey:3cc5eb69a57bc419db9c8add89316d568b03a8cd1dd3bdd34ffe15e7c1a96706",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:46372", "10.65.0.27:46372", "172.17.0.1:46372"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:52:21.355216786Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5619885924616872,
+				"StableID":   "nTEGmfsFtk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d02c43485dfc059a38ab3319bc6f24a1835449baea1d63ec5f7a100e21fb1e71",
+				"DiscoKey":   "discokey:c60b99e6f863197dcf68d76ace08d7f50fa2554b783619249dab23035fe5135e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:59422", "10.65.0.27:59422", "172.17.0.1:59422"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:52:21.884838767Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7375671910666129,
+				"StableID":   "nWXjwrPTbz11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ce0f527473659069dbe7cd3e6a9f69e2ed7f93e720e4e2b8e1039075cffb2e72",
+				"DiscoKey":   "discokey:4c0f72c0cc06331dc9184a977dacf764ae95d7a3a42264b96721c80374066b17",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:53589", "10.65.0.27:53589", "172.17.0.1:53589"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:52:22.42719054Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5885154563695681,
+				"StableID":   "nAmf2o2Qxn11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22813b9d55b26687709c84873941e692c8a317c3a9ebff4281c254cf26175b79",
+				"DiscoKey":   "discokey:98b72e55d8d1c3b9898213489c54eb98b8e1325de01f7371b63f5657d9e34379",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:53301", "10.65.0.27:53301", "172.17.0.1:53301"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:52:22.967745566Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8345061112147022,
+				"StableID":   "nsBMA5cVA821CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aea1a961facd687fdbe29d687b879d88d4360d00c027a8d054dfa00db4821278",
+				"DiscoKey":   "discokey:2b469a8359196a8a9ae135af817ec52705d54492503b54cd9b144d65366f5e03",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:56907", "10.65.0.27:56907", "172.17.0.1:56907"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 59245},
+					{"Proto": "peerapi6", "Port": 59245}
+				]},
+				"Created":              "2026-05-12T18:52:23.511563859Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         12398617935139,
+				"StableID":   "nnkmQ4hc6111CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f932de904df252835e738a5b0966e03451f133f5046d0b4c016c216e8f402579",
+				"DiscoKey":   "discokey:f01f8b0e51b14fe98505563cc5aee03cdf3339052d1fbf85ba5c7dbe8133f738",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:51688", "10.65.0.27:51688", "172.17.0.1:51688"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:52:24.04059057Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         776667949146727,
+				"StableID":   "nLKK6Wkk4711CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15b9b88563aa5d88241ae257e602216e1e091b3666af39e9e65f07007b3a685a",
+				"DiscoKey":   "discokey:b84ccd05567da23b19de9e39a89611218df282a7f1722516a20e5ac6b7a2917a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46018", "10.65.0.27:46018", "172.17.0.1:46018"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:52:24.578430983Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6136404177810293,
+				"StableID":   "nxvi45wBvp11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d84587141b98484705cceed641f846d3cbd08cd2e64f077f2390b7f608e9fc6c",
+				"DiscoKey":   "discokey:b79a127be18fafc50c696955a4f3ef3809a34a4dd3d08575b63d91d3be872166",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:54929", "10.65.0.27:54929", "172.17.0.1:54929"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:52:25.125123532Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         19276890580108,
+				"StableID":   "nfgyoXNj9111CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:899e5ce826ca9b46e78daf09e2bc1133503415509539bb4418872bf0f550fd23",
+				"DiscoKey":   "discokey:f963452d76354ed86e6cff0368ecf5dd84bec9de75add5786f94bb7fe696906a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:55569", "10.65.0.27:55569", "172.17.0.1:55569"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:52:25.666040774Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1726832356859159,
+				"StableID":   "nWNj7Zx5VE11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8580b45802a67d96eeed7a5bfe8a034d3e7cd88196974e5a740921460049154",
+				"DiscoKey":   "discokey:bde933df45911314985bb21b42cf0c51a2a56bfc429963bded2d7b71b09a0d34",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57014", "10.65.0.27:57014", "172.17.0.1:57014"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:52:26.213278425Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8776597061960922,
+				"StableID":   "nF9cKhKwXB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04e2bc8d22d2000b3ee51a859af82e7812e459e6c18fab78698afd1be8461c4c",
+				"KeyExpiry":  "2026-11-08T18:52:26Z",
+				"DiscoKey":   "discokey:248af9ed3dfa0d89feb04fb06d1d0d80a33d4ba1dd1f8ba709edf23cc61c1a24",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:45734", "10.65.0.27:45734", "172.17.0.1:45734"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:52:26.732179246Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         71338454102880,
+				"StableID":   "nPNKuXwJZ111CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8c1c5dbed69fc09b9f5e15d71c4bb0338ea5c78ba9d484a1acb3c79fecc1204b",
+				"KeyExpiry":  "2026-11-08T18:52:27Z",
+				"DiscoKey":   "discokey:dcc02fd53cf38c50542af22f0ab5b98b1ca1cf43e881216a20045ee6cdb0b759",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51275", "10.65.0.27:51275", "172.17.0.1:51275"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:52:27.831341295Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6136404177810293,
+				"StableID":   "nxvi45wBvp11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       6136404177810293,
+				"Key":        "nodekey:d84587141b98484705cceed641f846d3cbd08cd2e64f077f2390b7f608e9fc6c",
+				"DiscoKey":   "discokey:b79a127be18fafc50c696955a4f3ef3809a34a4dd3d08575b63d91d3be872166",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:54929", "10.65.0.27:54929", "172.17.0.1:54929"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:52:25.125123532Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d84587141b98484705cceed641f846d3cbd08cd2e64f077f2390b7f608e9fc6c",
+			"MachineKey": "mkey:e4bcdcab9f6d7a8b496e2897e60e76281f19e391aa0da2d987a79c9d86e37325",
+			"Peers": [{
+				"ID":         7149218115871029,
+				"StableID":   "nCg2ZYqtpx11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:42601141114da4ab1aba019ebe4154a603084088ce50471aa58a448f04dce757",
+				"DiscoKey":   "discokey:5423ad984604c8e069013ccf5fe74cd380798423b962a6b97d328e1e44d8886d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:48216", "10.65.0.27:48216", "172.17.0.1:48216"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:52:20.317209717Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3609278471971550,
+				"StableID":   "nHW8BGdeBV11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:5f3ce48f5a0d40254f0acd3ad18f0a1e85bc226976fb7309ad36cf40e2124c46",
+				"DiscoKey":   "discokey:8199130784cf44e391026744e1f33ff005933a250461f234b800c647e7d45d44",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:47266", "10.65.0.27:47266", "172.17.0.1:47266"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:52:20.822674862Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         952028410362923,
+				"StableID":   "nnAEZyABS811CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:663ca1c0b98b169842a8b616677a0087118a1e990c7382a68fec7376e91af955",
+				"DiscoKey":   "discokey:3cc5eb69a57bc419db9c8add89316d568b03a8cd1dd3bdd34ffe15e7c1a96706",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:46372", "10.65.0.27:46372", "172.17.0.1:46372"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:52:21.355216786Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5619885924616872,
+				"StableID":   "nTEGmfsFtk11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d02c43485dfc059a38ab3319bc6f24a1835449baea1d63ec5f7a100e21fb1e71",
+				"DiscoKey":   "discokey:c60b99e6f863197dcf68d76ace08d7f50fa2554b783619249dab23035fe5135e",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:59422", "10.65.0.27:59422", "172.17.0.1:59422"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:52:21.884838767Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         7375671910666129,
+				"StableID":   "nWXjwrPTbz11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ce0f527473659069dbe7cd3e6a9f69e2ed7f93e720e4e2b8e1039075cffb2e72",
+				"DiscoKey":   "discokey:4c0f72c0cc06331dc9184a977dacf764ae95d7a3a42264b96721c80374066b17",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:53589", "10.65.0.27:53589", "172.17.0.1:53589"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:52:22.42719054Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         5885154563695681,
+				"StableID":   "nAmf2o2Qxn11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:22813b9d55b26687709c84873941e692c8a317c3a9ebff4281c254cf26175b79",
+				"DiscoKey":   "discokey:98b72e55d8d1c3b9898213489c54eb98b8e1325de01f7371b63f5657d9e34379",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:53301", "10.65.0.27:53301", "172.17.0.1:53301"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:52:22.967745566Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8345061112147022,
+				"StableID":   "nsBMA5cVA821CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:aea1a961facd687fdbe29d687b879d88d4360d00c027a8d054dfa00db4821278",
+				"DiscoKey":   "discokey:2b469a8359196a8a9ae135af817ec52705d54492503b54cd9b144d65366f5e03",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:56907", "10.65.0.27:56907", "172.17.0.1:56907"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 59245},
+					{"Proto": "peerapi6", "Port": 59245}
+				]},
+				"Created":              "2026-05-12T18:52:23.511563859Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         12398617935139,
+				"StableID":   "nnkmQ4hc6111CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f932de904df252835e738a5b0966e03451f133f5046d0b4c016c216e8f402579",
+				"DiscoKey":   "discokey:f01f8b0e51b14fe98505563cc5aee03cdf3339052d1fbf85ba5c7dbe8133f738",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:51688", "10.65.0.27:51688", "172.17.0.1:51688"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:52:24.04059057Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         776667949146727,
+				"StableID":   "nLKK6Wkk4711CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:15b9b88563aa5d88241ae257e602216e1e091b3666af39e9e65f07007b3a685a",
+				"DiscoKey":   "discokey:b84ccd05567da23b19de9e39a89611218df282a7f1722516a20e5ac6b7a2917a",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:46018", "10.65.0.27:46018", "172.17.0.1:46018"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:52:24.578430983Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         19276890580108,
+				"StableID":   "nfgyoXNj9111CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:899e5ce826ca9b46e78daf09e2bc1133503415509539bb4418872bf0f550fd23",
+				"DiscoKey":   "discokey:f963452d76354ed86e6cff0368ecf5dd84bec9de75add5786f94bb7fe696906a",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:55569", "10.65.0.27:55569", "172.17.0.1:55569"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:52:25.666040774Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1726832356859159,
+				"StableID":   "nWNj7Zx5VE11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b8580b45802a67d96eeed7a5bfe8a034d3e7cd88196974e5a740921460049154",
+				"DiscoKey":   "discokey:bde933df45911314985bb21b42cf0c51a2a56bfc429963bded2d7b71b09a0d34",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:57014", "10.65.0.27:57014", "172.17.0.1:57014"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:52:26.213278425Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8776597061960922,
+				"StableID":   "nF9cKhKwXB21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:04e2bc8d22d2000b3ee51a859af82e7812e459e6c18fab78698afd1be8461c4c",
+				"KeyExpiry":  "2026-11-08T18:52:26Z",
+				"DiscoKey":   "discokey:248af9ed3dfa0d89feb04fb06d1d0d80a33d4ba1dd1f8ba709edf23cc61c1a24",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:45734", "10.65.0.27:45734", "172.17.0.1:45734"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:52:26.732179246Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5322461653974364,
+				"StableID":   "nKCzST3ZZi11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:67140cc6cf850ef00336786ac6caba06cd14f518a1cbb09dee12b45e8bc49300",
+				"KeyExpiry":  "2026-11-08T18:52:27Z",
+				"DiscoKey":   "discokey:fabd7cf90d41b9bd91c80d6d9e5e82cdf4021dc26fecb8f83a48e8f4251f5f27",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:37306", "10.65.0.27:37306", "172.17.0.1:37306"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:52:27.282485142Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         71338454102880,
+				"StableID":   "nPNKuXwJZ111CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:8c1c5dbed69fc09b9f5e15d71c4bb0338ea5c78ba9d484a1acb3c79fecc1204b",
+				"KeyExpiry":  "2026-11-08T18:52:27Z",
+				"DiscoKey":   "discokey:dcc02fd53cf38c50542af22f0ab5b98b1ca1cf43e881216a20045ee6cdb0b759",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:51275", "10.65.0.27:51275", "172.17.0.1:51275"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:52:27.831341295Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6136404177810293": {
+				"ID":          6136404177810293,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/sshtest_results/sshtest-user-localpart-domain-mismatch.hujson
+++ b/hscontrol/policy/v2/testdata/sshtest_results/sshtest-user-localpart-domain-mismatch.hujson
@@ -1,0 +1,18732 @@
+// sshtest-user-localpart-domain-mismatch
+//
+// localpart domain mismatch must fail
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T18:53:13Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "sshtest-user-localpart-domain-mismatch",
+	"description":    "localpart domain mismatch must fail",
+	"category":       "sshtest",
+	"captured_at":    "2026-05-12T18:53:13.089517206Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                         \n  \n                                                              \n                                                                     \n                 \n{\n\t\"category\":    \"sshtest\",\n\t\"description\": \"localpart domain mismatch must fail\",\n\t\"id\":          \"sshtest-user-localpart-domain-mismatch\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"thor@example.org\"],\n\t\t\"users\":  [\"localpart:*@example.com\"]\n\t}], \"sshTests\": [{\n\t\t\"accept\": [\"thor\"],\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    \"thor@example.org\"\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/sshtest/sshtest-user-localpart-domain-mismatch.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["thor@example.org"],
+				"users":  ["localpart:*@example.com"]
+			}],
+			"sshTests":  [{"accept": ["thor"], "dst": ["tag:server"], "src": "thor@example.org"}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1268500089248214,
+				"StableID":   "nj3X76MWuA11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1268500089248214,
+				"Key":        "nodekey:267b3b83b349cf8620179168c317ffa6962e99dad52b22ee0d30a0fadef5cf5b",
+				"DiscoKey":   "discokey:4848bae7f36e1fbbcb2c28df6d01bceaafae35625a2c44fd2f1d3770ab0a836d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53278", "10.65.0.27:53278", "172.17.0.1:53278"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:53:21.60722728Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:267b3b83b349cf8620179168c317ffa6962e99dad52b22ee0d30a0fadef5cf5b",
+			"MachineKey": "mkey:98f80facc878f760809eba21ec1aac0427596e31b6e2269339b4ece95c913865",
+			"Peers": [{
+				"ID":         6394954766560326,
+				"StableID":   "nF5BEqcHwr11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc3afd4f66228fee158888f1198442f9f7f875eff1fe22b034eb57de755e311b",
+				"DiscoKey":   "discokey:1f7452d562b377202e48329117391f589c15889d9ff108f9d7e379d3826a9373",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:58819", "10.65.0.27:58819", "172.17.0.1:58819"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:53:15.684556003Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3359264466207676,
+				"StableID":   "nb4rcWBRET11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d83f04ed7c3569414dcb92d01458a16bcfc5705a5bea10b4cc74af52d4fd3502",
+				"DiscoKey":   "discokey:5ec328efb87a8cc81cf61d619b3d9c2443889bb475bc325105576e1c2af8d675",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:48436", "10.65.0.27:48436", "172.17.0.1:48436"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:53:16.219864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6235546803700390,
+				"StableID":   "njq8RyE6hq11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0873d6c3d466cf9c8b45a58d8d980bd211d44d8586532d1f390c71dd5446de69",
+				"DiscoKey":   "discokey:c2fbc208776a6190ee6e05dbbf786a3d3db118f5109d9f79a2cb10db5200f603",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:35290", "10.65.0.27:35290", "172.17.0.1:35290"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:53:16.754794566Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7391643971333630,
+				"StableID":   "njjZFHxgiz11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:00490f66c391f2194192492702b82fdae51e8e5e475c4bfae3a45b821bf1e40f",
+				"DiscoKey":   "discokey:d08cd458c2ee3d20e462f653870f0e0880cc11cb199804c796c2652a6316da53",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:38472", "10.65.0.27:38472", "172.17.0.1:38472"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:53:17.278735389Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8485194050284806,
+				"StableID":   "nVJR3FfxF921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:74d9254e7a4e2c9184306736e424ca213c6a6dd4179c42fb657b99c2578f5673",
+				"DiscoKey":   "discokey:e25b8f5616f681bd86f517b4be1e1d372b13cb0103cc4879a56c52ebdb663b15",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:54589", "10.65.0.27:54589", "172.17.0.1:54589"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:53:17.823217253Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2679441641167704,
+				"StableID":   "nFEmWXPXvM11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0751abdee2bc9475bd52e77be0060d5122f5c3c307fd1eb022b19d987f3e1d59",
+				"DiscoKey":   "discokey:8e4eeb7e2be3852cce0f107762030e7db0e16855aa7478e203d7b544a1b38654",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:36715", "10.65.0.27:36715", "172.17.0.1:36715"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:53:18.41482324Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7320202710043211,
+				"StableID":   "nAGYd7KLAz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1da037e6dae2406c92eaf71f0914572c42efffd1c524ec7d8366450bb8c61074",
+				"DiscoKey":   "discokey:0b42d2d9fcac03bd35491165e3e5630091eadd59928ebef6cc6441adbca80278",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:47182", "10.65.0.27:47182", "172.17.0.1:47182"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:53:18.92365686Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8476196647412387,
+				"StableID":   "n89tM9KtB921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:814d7d401caec803d349cb1e32b72675014c39e0062ae5df969e44cc4455a93f",
+				"DiscoKey":   "discokey:ee6be9f35ca3352a90dfffe18988c0ac266fbeda7d88268cd96d2788b4ef7028",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:37759", "10.65.0.27:37759", "172.17.0.1:37759"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:53:19.475238223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2207964944873001,
+				"StableID":   "n2FkMiVzEJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3edf21b43cfe9f2d5914689b74b8907414ab275cf10cef54851087c5bac8839",
+				"DiscoKey":   "discokey:f8f229627c5bacf0711ed19514aa1a97ac2cf82309e26bbe0a58f895a4b84539",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:34868", "10.65.0.27:34868", "172.17.0.1:34868"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:53:19.998408749Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8843890274027626,
+				"StableID":   "nmG7341R4C21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9386a42db11e0ca68e4843223543ef47db9ecd78754cb47075d17a966508fb4d",
+				"DiscoKey":   "discokey:794f8ce28388d192645a60d86d655b38c329549df563fefb8a6c51dd9a7ca87b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:34307", "10.65.0.27:34307", "172.17.0.1:34307"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:53:20.537116622Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7474346318038758,
+				"StableID":   "nVgrRQQ9N121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e303c97d0da36dbf1d59e3e3f2ebc6969c7f536a87ab34a35ff8e0055a429177",
+				"DiscoKey":   "discokey:5d6909df424d734468aeffd3bed0ee7fe9bf4a2fcce531a11ca9cd3c9925175b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:36397", "10.65.0.27:36397", "172.17.0.1:36397"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:53:21.070932133Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4162529281909508,
+				"StableID":   "n7JNjyaDWZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:2ace03bcf2108c1a201c307a69989936bea9f7f7d9aeae7f442e1af9ca013a32",
+				"KeyExpiry":  "2026-11-08T18:53:22Z",
+				"DiscoKey":   "discokey:7d9f40e1e69f473a22adf865350d2d8799e6e51e5990e930ee14212798ba843d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:58061", "10.65.0.27:58061", "172.17.0.1:58061"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:53:22.148599211Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         462010508099750,
+				"StableID":   "nwfAXVEFc411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ae26fddf955389254a6d2a10edbe1158fc791500cfc9c4353c062929e07bc21b",
+				"KeyExpiry":  "2026-11-08T18:53:22Z",
+				"DiscoKey":   "discokey:e7d7a7e9e83b524330f67660934b944d1ea50ab079955a88e91a234c4b9e1200",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:33110", "10.65.0.27:33110", "172.17.0.1:33110"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:53:22.692243454Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1538947703875679,
+				"StableID":   "npPLihYz1D11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:85e6516547038b86b75be2f4353665b54d83b94a2209c3ceacd816f0ef96f073",
+				"KeyExpiry":  "2026-11-08T18:53:23Z",
+				"DiscoKey":   "discokey:8e25ef80188ce5f33e7e93fd2daf1f6f0fbf6085a7dfaa0eed611d69da17f10a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:50256", "10.65.0.27:50256", "172.17.0.1:50256"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:53:23.234818434Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1268500089248214": {
+				"ID":          1268500089248214,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2679441641167704,
+				"StableID":   "nFEmWXPXvM11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       2679441641167704,
+				"Key":        "nodekey:0751abdee2bc9475bd52e77be0060d5122f5c3c307fd1eb022b19d987f3e1d59",
+				"DiscoKey":   "discokey:8e4eeb7e2be3852cce0f107762030e7db0e16855aa7478e203d7b544a1b38654",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:36715", "10.65.0.27:36715", "172.17.0.1:36715"],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:53:18.41482324Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0751abdee2bc9475bd52e77be0060d5122f5c3c307fd1eb022b19d987f3e1d59",
+			"MachineKey": "mkey:eb6aa73abbfbec511278434e019d8fa4453cc934d23504be5c5b1f5d105a2c67",
+			"Peers": [{
+				"ID":         6394954766560326,
+				"StableID":   "nF5BEqcHwr11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc3afd4f66228fee158888f1198442f9f7f875eff1fe22b034eb57de755e311b",
+				"DiscoKey":   "discokey:1f7452d562b377202e48329117391f589c15889d9ff108f9d7e379d3826a9373",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:58819", "10.65.0.27:58819", "172.17.0.1:58819"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:53:15.684556003Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3359264466207676,
+				"StableID":   "nb4rcWBRET11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d83f04ed7c3569414dcb92d01458a16bcfc5705a5bea10b4cc74af52d4fd3502",
+				"DiscoKey":   "discokey:5ec328efb87a8cc81cf61d619b3d9c2443889bb475bc325105576e1c2af8d675",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:48436", "10.65.0.27:48436", "172.17.0.1:48436"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:53:16.219864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6235546803700390,
+				"StableID":   "njq8RyE6hq11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0873d6c3d466cf9c8b45a58d8d980bd211d44d8586532d1f390c71dd5446de69",
+				"DiscoKey":   "discokey:c2fbc208776a6190ee6e05dbbf786a3d3db118f5109d9f79a2cb10db5200f603",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:35290", "10.65.0.27:35290", "172.17.0.1:35290"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:53:16.754794566Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7391643971333630,
+				"StableID":   "njjZFHxgiz11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:00490f66c391f2194192492702b82fdae51e8e5e475c4bfae3a45b821bf1e40f",
+				"DiscoKey":   "discokey:d08cd458c2ee3d20e462f653870f0e0880cc11cb199804c796c2652a6316da53",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:38472", "10.65.0.27:38472", "172.17.0.1:38472"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:53:17.278735389Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8485194050284806,
+				"StableID":   "nVJR3FfxF921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:74d9254e7a4e2c9184306736e424ca213c6a6dd4179c42fb657b99c2578f5673",
+				"DiscoKey":   "discokey:e25b8f5616f681bd86f517b4be1e1d372b13cb0103cc4879a56c52ebdb663b15",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:54589", "10.65.0.27:54589", "172.17.0.1:54589"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:53:17.823217253Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         7320202710043211,
+				"StableID":   "nAGYd7KLAz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1da037e6dae2406c92eaf71f0914572c42efffd1c524ec7d8366450bb8c61074",
+				"DiscoKey":   "discokey:0b42d2d9fcac03bd35491165e3e5630091eadd59928ebef6cc6441adbca80278",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:47182", "10.65.0.27:47182", "172.17.0.1:47182"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:53:18.92365686Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8476196647412387,
+				"StableID":   "n89tM9KtB921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:814d7d401caec803d349cb1e32b72675014c39e0062ae5df969e44cc4455a93f",
+				"DiscoKey":   "discokey:ee6be9f35ca3352a90dfffe18988c0ac266fbeda7d88268cd96d2788b4ef7028",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:37759", "10.65.0.27:37759", "172.17.0.1:37759"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:53:19.475238223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2207964944873001,
+				"StableID":   "n2FkMiVzEJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3edf21b43cfe9f2d5914689b74b8907414ab275cf10cef54851087c5bac8839",
+				"DiscoKey":   "discokey:f8f229627c5bacf0711ed19514aa1a97ac2cf82309e26bbe0a58f895a4b84539",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:34868", "10.65.0.27:34868", "172.17.0.1:34868"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:53:19.998408749Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8843890274027626,
+				"StableID":   "nmG7341R4C21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9386a42db11e0ca68e4843223543ef47db9ecd78754cb47075d17a966508fb4d",
+				"DiscoKey":   "discokey:794f8ce28388d192645a60d86d655b38c329549df563fefb8a6c51dd9a7ca87b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:34307", "10.65.0.27:34307", "172.17.0.1:34307"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:53:20.537116622Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7474346318038758,
+				"StableID":   "nVgrRQQ9N121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e303c97d0da36dbf1d59e3e3f2ebc6969c7f536a87ab34a35ff8e0055a429177",
+				"DiscoKey":   "discokey:5d6909df424d734468aeffd3bed0ee7fe9bf4a2fcce531a11ca9cd3c9925175b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:36397", "10.65.0.27:36397", "172.17.0.1:36397"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:53:21.070932133Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1268500089248214,
+				"StableID":   "nj3X76MWuA11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:267b3b83b349cf8620179168c317ffa6962e99dad52b22ee0d30a0fadef5cf5b",
+				"DiscoKey":   "discokey:4848bae7f36e1fbbcb2c28df6d01bceaafae35625a2c44fd2f1d3770ab0a836d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53278", "10.65.0.27:53278", "172.17.0.1:53278"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:53:21.60722728Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4162529281909508,
+				"StableID":   "n7JNjyaDWZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:2ace03bcf2108c1a201c307a69989936bea9f7f7d9aeae7f442e1af9ca013a32",
+				"KeyExpiry":  "2026-11-08T18:53:22Z",
+				"DiscoKey":   "discokey:7d9f40e1e69f473a22adf865350d2d8799e6e51e5990e930ee14212798ba843d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:58061", "10.65.0.27:58061", "172.17.0.1:58061"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:53:22.148599211Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         462010508099750,
+				"StableID":   "nwfAXVEFc411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ae26fddf955389254a6d2a10edbe1158fc791500cfc9c4353c062929e07bc21b",
+				"KeyExpiry":  "2026-11-08T18:53:22Z",
+				"DiscoKey":   "discokey:e7d7a7e9e83b524330f67660934b944d1ea50ab079955a88e91a234c4b9e1200",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:33110", "10.65.0.27:33110", "172.17.0.1:33110"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:53:22.692243454Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1538947703875679,
+				"StableID":   "npPLihYz1D11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:85e6516547038b86b75be2f4353665b54d83b94a2209c3ceacd816f0ef96f073",
+				"KeyExpiry":  "2026-11-08T18:53:23Z",
+				"DiscoKey":   "discokey:8e25ef80188ce5f33e7e93fd2daf1f6f0fbf6085a7dfaa0eed611d69da17f10a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:50256", "10.65.0.27:50256", "172.17.0.1:50256"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:53:23.234818434Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2679441641167704": {
+				"ID":          2679441641167704,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1538947703875679,
+				"StableID":   "npPLihYz1D11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:85e6516547038b86b75be2f4353665b54d83b94a2209c3ceacd816f0ef96f073",
+				"KeyExpiry":  "2026-11-08T18:53:23Z",
+				"DiscoKey":   "discokey:8e25ef80188ce5f33e7e93fd2daf1f6f0fbf6085a7dfaa0eed611d69da17f10a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:50256", "10.65.0.27:50256", "172.17.0.1:50256"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:53:23.234818434Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:85e6516547038b86b75be2f4353665b54d83b94a2209c3ceacd816f0ef96f073",
+			"MachineKey": "mkey:03f8973bc0098ba1fce7f04b9dc439eba37e378d26a8d5153470f6fd5bf14573",
+			"Peers": [{
+				"ID":         6394954766560326,
+				"StableID":   "nF5BEqcHwr11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc3afd4f66228fee158888f1198442f9f7f875eff1fe22b034eb57de755e311b",
+				"DiscoKey":   "discokey:1f7452d562b377202e48329117391f589c15889d9ff108f9d7e379d3826a9373",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:58819", "10.65.0.27:58819", "172.17.0.1:58819"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:53:15.684556003Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3359264466207676,
+				"StableID":   "nb4rcWBRET11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d83f04ed7c3569414dcb92d01458a16bcfc5705a5bea10b4cc74af52d4fd3502",
+				"DiscoKey":   "discokey:5ec328efb87a8cc81cf61d619b3d9c2443889bb475bc325105576e1c2af8d675",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:48436", "10.65.0.27:48436", "172.17.0.1:48436"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:53:16.219864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6235546803700390,
+				"StableID":   "njq8RyE6hq11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0873d6c3d466cf9c8b45a58d8d980bd211d44d8586532d1f390c71dd5446de69",
+				"DiscoKey":   "discokey:c2fbc208776a6190ee6e05dbbf786a3d3db118f5109d9f79a2cb10db5200f603",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:35290", "10.65.0.27:35290", "172.17.0.1:35290"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:53:16.754794566Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7391643971333630,
+				"StableID":   "njjZFHxgiz11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:00490f66c391f2194192492702b82fdae51e8e5e475c4bfae3a45b821bf1e40f",
+				"DiscoKey":   "discokey:d08cd458c2ee3d20e462f653870f0e0880cc11cb199804c796c2652a6316da53",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:38472", "10.65.0.27:38472", "172.17.0.1:38472"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:53:17.278735389Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8485194050284806,
+				"StableID":   "nVJR3FfxF921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:74d9254e7a4e2c9184306736e424ca213c6a6dd4179c42fb657b99c2578f5673",
+				"DiscoKey":   "discokey:e25b8f5616f681bd86f517b4be1e1d372b13cb0103cc4879a56c52ebdb663b15",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:54589", "10.65.0.27:54589", "172.17.0.1:54589"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:53:17.823217253Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2679441641167704,
+				"StableID":   "nFEmWXPXvM11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0751abdee2bc9475bd52e77be0060d5122f5c3c307fd1eb022b19d987f3e1d59",
+				"DiscoKey":   "discokey:8e4eeb7e2be3852cce0f107762030e7db0e16855aa7478e203d7b544a1b38654",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:36715", "10.65.0.27:36715", "172.17.0.1:36715"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:53:18.41482324Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7320202710043211,
+				"StableID":   "nAGYd7KLAz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1da037e6dae2406c92eaf71f0914572c42efffd1c524ec7d8366450bb8c61074",
+				"DiscoKey":   "discokey:0b42d2d9fcac03bd35491165e3e5630091eadd59928ebef6cc6441adbca80278",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:47182", "10.65.0.27:47182", "172.17.0.1:47182"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:53:18.92365686Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8476196647412387,
+				"StableID":   "n89tM9KtB921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:814d7d401caec803d349cb1e32b72675014c39e0062ae5df969e44cc4455a93f",
+				"DiscoKey":   "discokey:ee6be9f35ca3352a90dfffe18988c0ac266fbeda7d88268cd96d2788b4ef7028",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:37759", "10.65.0.27:37759", "172.17.0.1:37759"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:53:19.475238223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2207964944873001,
+				"StableID":   "n2FkMiVzEJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3edf21b43cfe9f2d5914689b74b8907414ab275cf10cef54851087c5bac8839",
+				"DiscoKey":   "discokey:f8f229627c5bacf0711ed19514aa1a97ac2cf82309e26bbe0a58f895a4b84539",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:34868", "10.65.0.27:34868", "172.17.0.1:34868"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:53:19.998408749Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8843890274027626,
+				"StableID":   "nmG7341R4C21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9386a42db11e0ca68e4843223543ef47db9ecd78754cb47075d17a966508fb4d",
+				"DiscoKey":   "discokey:794f8ce28388d192645a60d86d655b38c329549df563fefb8a6c51dd9a7ca87b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:34307", "10.65.0.27:34307", "172.17.0.1:34307"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:53:20.537116622Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7474346318038758,
+				"StableID":   "nVgrRQQ9N121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e303c97d0da36dbf1d59e3e3f2ebc6969c7f536a87ab34a35ff8e0055a429177",
+				"DiscoKey":   "discokey:5d6909df424d734468aeffd3bed0ee7fe9bf4a2fcce531a11ca9cd3c9925175b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:36397", "10.65.0.27:36397", "172.17.0.1:36397"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:53:21.070932133Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1268500089248214,
+				"StableID":   "nj3X76MWuA11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:267b3b83b349cf8620179168c317ffa6962e99dad52b22ee0d30a0fadef5cf5b",
+				"DiscoKey":   "discokey:4848bae7f36e1fbbcb2c28df6d01bceaafae35625a2c44fd2f1d3770ab0a836d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53278", "10.65.0.27:53278", "172.17.0.1:53278"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:53:21.60722728Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4162529281909508,
+				"StableID":   "n7JNjyaDWZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:2ace03bcf2108c1a201c307a69989936bea9f7f7d9aeae7f442e1af9ca013a32",
+				"KeyExpiry":  "2026-11-08T18:53:22Z",
+				"DiscoKey":   "discokey:7d9f40e1e69f473a22adf865350d2d8799e6e51e5990e930ee14212798ba843d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:58061", "10.65.0.27:58061", "172.17.0.1:58061"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:53:22.148599211Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         462010508099750,
+				"StableID":   "nwfAXVEFc411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ae26fddf955389254a6d2a10edbe1158fc791500cfc9c4353c062929e07bc21b",
+				"KeyExpiry":  "2026-11-08T18:53:22Z",
+				"DiscoKey":   "discokey:e7d7a7e9e83b524330f67660934b944d1ea50ab079955a88e91a234c4b9e1200",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:33110", "10.65.0.27:33110", "172.17.0.1:33110"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:53:22.692243454Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6235546803700390,
+				"StableID":   "njq8RyE6hq11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       6235546803700390,
+				"Key":        "nodekey:0873d6c3d466cf9c8b45a58d8d980bd211d44d8586532d1f390c71dd5446de69",
+				"DiscoKey":   "discokey:c2fbc208776a6190ee6e05dbbf786a3d3db118f5109d9f79a2cb10db5200f603",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:35290", "10.65.0.27:35290", "172.17.0.1:35290"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:53:16.754794566Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0873d6c3d466cf9c8b45a58d8d980bd211d44d8586532d1f390c71dd5446de69",
+			"MachineKey": "mkey:c4f531a3801badf0f55dda805de30d17880eb6eebf88d7b60f26eb81691e2d49",
+			"Peers": [{
+				"ID":         6394954766560326,
+				"StableID":   "nF5BEqcHwr11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc3afd4f66228fee158888f1198442f9f7f875eff1fe22b034eb57de755e311b",
+				"DiscoKey":   "discokey:1f7452d562b377202e48329117391f589c15889d9ff108f9d7e379d3826a9373",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:58819", "10.65.0.27:58819", "172.17.0.1:58819"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:53:15.684556003Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3359264466207676,
+				"StableID":   "nb4rcWBRET11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d83f04ed7c3569414dcb92d01458a16bcfc5705a5bea10b4cc74af52d4fd3502",
+				"DiscoKey":   "discokey:5ec328efb87a8cc81cf61d619b3d9c2443889bb475bc325105576e1c2af8d675",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:48436", "10.65.0.27:48436", "172.17.0.1:48436"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:53:16.219864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         7391643971333630,
+				"StableID":   "njjZFHxgiz11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:00490f66c391f2194192492702b82fdae51e8e5e475c4bfae3a45b821bf1e40f",
+				"DiscoKey":   "discokey:d08cd458c2ee3d20e462f653870f0e0880cc11cb199804c796c2652a6316da53",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:38472", "10.65.0.27:38472", "172.17.0.1:38472"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:53:17.278735389Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8485194050284806,
+				"StableID":   "nVJR3FfxF921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:74d9254e7a4e2c9184306736e424ca213c6a6dd4179c42fb657b99c2578f5673",
+				"DiscoKey":   "discokey:e25b8f5616f681bd86f517b4be1e1d372b13cb0103cc4879a56c52ebdb663b15",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:54589", "10.65.0.27:54589", "172.17.0.1:54589"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:53:17.823217253Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2679441641167704,
+				"StableID":   "nFEmWXPXvM11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0751abdee2bc9475bd52e77be0060d5122f5c3c307fd1eb022b19d987f3e1d59",
+				"DiscoKey":   "discokey:8e4eeb7e2be3852cce0f107762030e7db0e16855aa7478e203d7b544a1b38654",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:36715", "10.65.0.27:36715", "172.17.0.1:36715"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:53:18.41482324Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7320202710043211,
+				"StableID":   "nAGYd7KLAz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1da037e6dae2406c92eaf71f0914572c42efffd1c524ec7d8366450bb8c61074",
+				"DiscoKey":   "discokey:0b42d2d9fcac03bd35491165e3e5630091eadd59928ebef6cc6441adbca80278",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:47182", "10.65.0.27:47182", "172.17.0.1:47182"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:53:18.92365686Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8476196647412387,
+				"StableID":   "n89tM9KtB921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:814d7d401caec803d349cb1e32b72675014c39e0062ae5df969e44cc4455a93f",
+				"DiscoKey":   "discokey:ee6be9f35ca3352a90dfffe18988c0ac266fbeda7d88268cd96d2788b4ef7028",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:37759", "10.65.0.27:37759", "172.17.0.1:37759"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:53:19.475238223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2207964944873001,
+				"StableID":   "n2FkMiVzEJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3edf21b43cfe9f2d5914689b74b8907414ab275cf10cef54851087c5bac8839",
+				"DiscoKey":   "discokey:f8f229627c5bacf0711ed19514aa1a97ac2cf82309e26bbe0a58f895a4b84539",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:34868", "10.65.0.27:34868", "172.17.0.1:34868"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:53:19.998408749Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8843890274027626,
+				"StableID":   "nmG7341R4C21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9386a42db11e0ca68e4843223543ef47db9ecd78754cb47075d17a966508fb4d",
+				"DiscoKey":   "discokey:794f8ce28388d192645a60d86d655b38c329549df563fefb8a6c51dd9a7ca87b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:34307", "10.65.0.27:34307", "172.17.0.1:34307"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:53:20.537116622Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7474346318038758,
+				"StableID":   "nVgrRQQ9N121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e303c97d0da36dbf1d59e3e3f2ebc6969c7f536a87ab34a35ff8e0055a429177",
+				"DiscoKey":   "discokey:5d6909df424d734468aeffd3bed0ee7fe9bf4a2fcce531a11ca9cd3c9925175b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:36397", "10.65.0.27:36397", "172.17.0.1:36397"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:53:21.070932133Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1268500089248214,
+				"StableID":   "nj3X76MWuA11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:267b3b83b349cf8620179168c317ffa6962e99dad52b22ee0d30a0fadef5cf5b",
+				"DiscoKey":   "discokey:4848bae7f36e1fbbcb2c28df6d01bceaafae35625a2c44fd2f1d3770ab0a836d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53278", "10.65.0.27:53278", "172.17.0.1:53278"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:53:21.60722728Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4162529281909508,
+				"StableID":   "n7JNjyaDWZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:2ace03bcf2108c1a201c307a69989936bea9f7f7d9aeae7f442e1af9ca013a32",
+				"KeyExpiry":  "2026-11-08T18:53:22Z",
+				"DiscoKey":   "discokey:7d9f40e1e69f473a22adf865350d2d8799e6e51e5990e930ee14212798ba843d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:58061", "10.65.0.27:58061", "172.17.0.1:58061"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:53:22.148599211Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         462010508099750,
+				"StableID":   "nwfAXVEFc411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ae26fddf955389254a6d2a10edbe1158fc791500cfc9c4353c062929e07bc21b",
+				"KeyExpiry":  "2026-11-08T18:53:22Z",
+				"DiscoKey":   "discokey:e7d7a7e9e83b524330f67660934b944d1ea50ab079955a88e91a234c4b9e1200",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:33110", "10.65.0.27:33110", "172.17.0.1:33110"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:53:22.692243454Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1538947703875679,
+				"StableID":   "npPLihYz1D11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:85e6516547038b86b75be2f4353665b54d83b94a2209c3ceacd816f0ef96f073",
+				"KeyExpiry":  "2026-11-08T18:53:23Z",
+				"DiscoKey":   "discokey:8e25ef80188ce5f33e7e93fd2daf1f6f0fbf6085a7dfaa0eed611d69da17f10a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:50256", "10.65.0.27:50256", "172.17.0.1:50256"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:53:23.234818434Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6235546803700390": {
+				"ID":          6235546803700390,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8476196647412387,
+				"StableID":   "n89tM9KtB921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       8476196647412387,
+				"Key":        "nodekey:814d7d401caec803d349cb1e32b72675014c39e0062ae5df969e44cc4455a93f",
+				"DiscoKey":   "discokey:ee6be9f35ca3352a90dfffe18988c0ac266fbeda7d88268cd96d2788b4ef7028",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:37759", "10.65.0.27:37759", "172.17.0.1:37759"],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:53:19.475238223Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:814d7d401caec803d349cb1e32b72675014c39e0062ae5df969e44cc4455a93f",
+			"MachineKey": "mkey:57b76647262ed84196b681900cb069a5db7d8a804eaa0987fb4fe53d11b2a876",
+			"Peers": [{
+				"ID":         6394954766560326,
+				"StableID":   "nF5BEqcHwr11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc3afd4f66228fee158888f1198442f9f7f875eff1fe22b034eb57de755e311b",
+				"DiscoKey":   "discokey:1f7452d562b377202e48329117391f589c15889d9ff108f9d7e379d3826a9373",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:58819", "10.65.0.27:58819", "172.17.0.1:58819"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:53:15.684556003Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3359264466207676,
+				"StableID":   "nb4rcWBRET11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d83f04ed7c3569414dcb92d01458a16bcfc5705a5bea10b4cc74af52d4fd3502",
+				"DiscoKey":   "discokey:5ec328efb87a8cc81cf61d619b3d9c2443889bb475bc325105576e1c2af8d675",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:48436", "10.65.0.27:48436", "172.17.0.1:48436"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:53:16.219864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6235546803700390,
+				"StableID":   "njq8RyE6hq11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0873d6c3d466cf9c8b45a58d8d980bd211d44d8586532d1f390c71dd5446de69",
+				"DiscoKey":   "discokey:c2fbc208776a6190ee6e05dbbf786a3d3db118f5109d9f79a2cb10db5200f603",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:35290", "10.65.0.27:35290", "172.17.0.1:35290"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:53:16.754794566Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7391643971333630,
+				"StableID":   "njjZFHxgiz11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:00490f66c391f2194192492702b82fdae51e8e5e475c4bfae3a45b821bf1e40f",
+				"DiscoKey":   "discokey:d08cd458c2ee3d20e462f653870f0e0880cc11cb199804c796c2652a6316da53",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:38472", "10.65.0.27:38472", "172.17.0.1:38472"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:53:17.278735389Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8485194050284806,
+				"StableID":   "nVJR3FfxF921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:74d9254e7a4e2c9184306736e424ca213c6a6dd4179c42fb657b99c2578f5673",
+				"DiscoKey":   "discokey:e25b8f5616f681bd86f517b4be1e1d372b13cb0103cc4879a56c52ebdb663b15",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:54589", "10.65.0.27:54589", "172.17.0.1:54589"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:53:17.823217253Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2679441641167704,
+				"StableID":   "nFEmWXPXvM11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0751abdee2bc9475bd52e77be0060d5122f5c3c307fd1eb022b19d987f3e1d59",
+				"DiscoKey":   "discokey:8e4eeb7e2be3852cce0f107762030e7db0e16855aa7478e203d7b544a1b38654",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:36715", "10.65.0.27:36715", "172.17.0.1:36715"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:53:18.41482324Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7320202710043211,
+				"StableID":   "nAGYd7KLAz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1da037e6dae2406c92eaf71f0914572c42efffd1c524ec7d8366450bb8c61074",
+				"DiscoKey":   "discokey:0b42d2d9fcac03bd35491165e3e5630091eadd59928ebef6cc6441adbca80278",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:47182", "10.65.0.27:47182", "172.17.0.1:47182"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:53:18.92365686Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2207964944873001,
+				"StableID":   "n2FkMiVzEJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3edf21b43cfe9f2d5914689b74b8907414ab275cf10cef54851087c5bac8839",
+				"DiscoKey":   "discokey:f8f229627c5bacf0711ed19514aa1a97ac2cf82309e26bbe0a58f895a4b84539",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:34868", "10.65.0.27:34868", "172.17.0.1:34868"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:53:19.998408749Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8843890274027626,
+				"StableID":   "nmG7341R4C21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9386a42db11e0ca68e4843223543ef47db9ecd78754cb47075d17a966508fb4d",
+				"DiscoKey":   "discokey:794f8ce28388d192645a60d86d655b38c329549df563fefb8a6c51dd9a7ca87b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:34307", "10.65.0.27:34307", "172.17.0.1:34307"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:53:20.537116622Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7474346318038758,
+				"StableID":   "nVgrRQQ9N121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e303c97d0da36dbf1d59e3e3f2ebc6969c7f536a87ab34a35ff8e0055a429177",
+				"DiscoKey":   "discokey:5d6909df424d734468aeffd3bed0ee7fe9bf4a2fcce531a11ca9cd3c9925175b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:36397", "10.65.0.27:36397", "172.17.0.1:36397"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:53:21.070932133Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1268500089248214,
+				"StableID":   "nj3X76MWuA11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:267b3b83b349cf8620179168c317ffa6962e99dad52b22ee0d30a0fadef5cf5b",
+				"DiscoKey":   "discokey:4848bae7f36e1fbbcb2c28df6d01bceaafae35625a2c44fd2f1d3770ab0a836d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53278", "10.65.0.27:53278", "172.17.0.1:53278"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:53:21.60722728Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4162529281909508,
+				"StableID":   "n7JNjyaDWZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:2ace03bcf2108c1a201c307a69989936bea9f7f7d9aeae7f442e1af9ca013a32",
+				"KeyExpiry":  "2026-11-08T18:53:22Z",
+				"DiscoKey":   "discokey:7d9f40e1e69f473a22adf865350d2d8799e6e51e5990e930ee14212798ba843d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:58061", "10.65.0.27:58061", "172.17.0.1:58061"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:53:22.148599211Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         462010508099750,
+				"StableID":   "nwfAXVEFc411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ae26fddf955389254a6d2a10edbe1158fc791500cfc9c4353c062929e07bc21b",
+				"KeyExpiry":  "2026-11-08T18:53:22Z",
+				"DiscoKey":   "discokey:e7d7a7e9e83b524330f67660934b944d1ea50ab079955a88e91a234c4b9e1200",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:33110", "10.65.0.27:33110", "172.17.0.1:33110"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:53:22.692243454Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1538947703875679,
+				"StableID":   "npPLihYz1D11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:85e6516547038b86b75be2f4353665b54d83b94a2209c3ceacd816f0ef96f073",
+				"KeyExpiry":  "2026-11-08T18:53:23Z",
+				"DiscoKey":   "discokey:8e25ef80188ce5f33e7e93fd2daf1f6f0fbf6085a7dfaa0eed611d69da17f10a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:50256", "10.65.0.27:50256", "172.17.0.1:50256"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:53:23.234818434Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8476196647412387": {
+				"ID":          8476196647412387,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4162529281909508,
+				"StableID":   "n7JNjyaDWZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:2ace03bcf2108c1a201c307a69989936bea9f7f7d9aeae7f442e1af9ca013a32",
+				"KeyExpiry":  "2026-11-08T18:53:22Z",
+				"DiscoKey":   "discokey:7d9f40e1e69f473a22adf865350d2d8799e6e51e5990e930ee14212798ba843d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:58061", "10.65.0.27:58061", "172.17.0.1:58061"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:53:22.148599211Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2ace03bcf2108c1a201c307a69989936bea9f7f7d9aeae7f442e1af9ca013a32",
+			"MachineKey": "mkey:d01ee714f5467681b4a0a0cc24bd63a7f55d54684733ee05652bec6d3e910836",
+			"Peers": [{
+				"ID":         6394954766560326,
+				"StableID":   "nF5BEqcHwr11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc3afd4f66228fee158888f1198442f9f7f875eff1fe22b034eb57de755e311b",
+				"DiscoKey":   "discokey:1f7452d562b377202e48329117391f589c15889d9ff108f9d7e379d3826a9373",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:58819", "10.65.0.27:58819", "172.17.0.1:58819"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:53:15.684556003Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3359264466207676,
+				"StableID":   "nb4rcWBRET11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d83f04ed7c3569414dcb92d01458a16bcfc5705a5bea10b4cc74af52d4fd3502",
+				"DiscoKey":   "discokey:5ec328efb87a8cc81cf61d619b3d9c2443889bb475bc325105576e1c2af8d675",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:48436", "10.65.0.27:48436", "172.17.0.1:48436"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:53:16.219864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6235546803700390,
+				"StableID":   "njq8RyE6hq11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0873d6c3d466cf9c8b45a58d8d980bd211d44d8586532d1f390c71dd5446de69",
+				"DiscoKey":   "discokey:c2fbc208776a6190ee6e05dbbf786a3d3db118f5109d9f79a2cb10db5200f603",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:35290", "10.65.0.27:35290", "172.17.0.1:35290"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:53:16.754794566Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7391643971333630,
+				"StableID":   "njjZFHxgiz11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:00490f66c391f2194192492702b82fdae51e8e5e475c4bfae3a45b821bf1e40f",
+				"DiscoKey":   "discokey:d08cd458c2ee3d20e462f653870f0e0880cc11cb199804c796c2652a6316da53",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:38472", "10.65.0.27:38472", "172.17.0.1:38472"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:53:17.278735389Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8485194050284806,
+				"StableID":   "nVJR3FfxF921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:74d9254e7a4e2c9184306736e424ca213c6a6dd4179c42fb657b99c2578f5673",
+				"DiscoKey":   "discokey:e25b8f5616f681bd86f517b4be1e1d372b13cb0103cc4879a56c52ebdb663b15",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:54589", "10.65.0.27:54589", "172.17.0.1:54589"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:53:17.823217253Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2679441641167704,
+				"StableID":   "nFEmWXPXvM11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0751abdee2bc9475bd52e77be0060d5122f5c3c307fd1eb022b19d987f3e1d59",
+				"DiscoKey":   "discokey:8e4eeb7e2be3852cce0f107762030e7db0e16855aa7478e203d7b544a1b38654",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:36715", "10.65.0.27:36715", "172.17.0.1:36715"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:53:18.41482324Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7320202710043211,
+				"StableID":   "nAGYd7KLAz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1da037e6dae2406c92eaf71f0914572c42efffd1c524ec7d8366450bb8c61074",
+				"DiscoKey":   "discokey:0b42d2d9fcac03bd35491165e3e5630091eadd59928ebef6cc6441adbca80278",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:47182", "10.65.0.27:47182", "172.17.0.1:47182"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:53:18.92365686Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8476196647412387,
+				"StableID":   "n89tM9KtB921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:814d7d401caec803d349cb1e32b72675014c39e0062ae5df969e44cc4455a93f",
+				"DiscoKey":   "discokey:ee6be9f35ca3352a90dfffe18988c0ac266fbeda7d88268cd96d2788b4ef7028",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:37759", "10.65.0.27:37759", "172.17.0.1:37759"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:53:19.475238223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2207964944873001,
+				"StableID":   "n2FkMiVzEJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3edf21b43cfe9f2d5914689b74b8907414ab275cf10cef54851087c5bac8839",
+				"DiscoKey":   "discokey:f8f229627c5bacf0711ed19514aa1a97ac2cf82309e26bbe0a58f895a4b84539",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:34868", "10.65.0.27:34868", "172.17.0.1:34868"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:53:19.998408749Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8843890274027626,
+				"StableID":   "nmG7341R4C21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9386a42db11e0ca68e4843223543ef47db9ecd78754cb47075d17a966508fb4d",
+				"DiscoKey":   "discokey:794f8ce28388d192645a60d86d655b38c329549df563fefb8a6c51dd9a7ca87b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:34307", "10.65.0.27:34307", "172.17.0.1:34307"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:53:20.537116622Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7474346318038758,
+				"StableID":   "nVgrRQQ9N121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e303c97d0da36dbf1d59e3e3f2ebc6969c7f536a87ab34a35ff8e0055a429177",
+				"DiscoKey":   "discokey:5d6909df424d734468aeffd3bed0ee7fe9bf4a2fcce531a11ca9cd3c9925175b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:36397", "10.65.0.27:36397", "172.17.0.1:36397"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:53:21.070932133Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1268500089248214,
+				"StableID":   "nj3X76MWuA11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:267b3b83b349cf8620179168c317ffa6962e99dad52b22ee0d30a0fadef5cf5b",
+				"DiscoKey":   "discokey:4848bae7f36e1fbbcb2c28df6d01bceaafae35625a2c44fd2f1d3770ab0a836d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53278", "10.65.0.27:53278", "172.17.0.1:53278"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:53:21.60722728Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         462010508099750,
+				"StableID":   "nwfAXVEFc411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ae26fddf955389254a6d2a10edbe1158fc791500cfc9c4353c062929e07bc21b",
+				"KeyExpiry":  "2026-11-08T18:53:22Z",
+				"DiscoKey":   "discokey:e7d7a7e9e83b524330f67660934b944d1ea50ab079955a88e91a234c4b9e1200",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:33110", "10.65.0.27:33110", "172.17.0.1:33110"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:53:22.692243454Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1538947703875679,
+				"StableID":   "npPLihYz1D11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:85e6516547038b86b75be2f4353665b54d83b94a2209c3ceacd816f0ef96f073",
+				"KeyExpiry":  "2026-11-08T18:53:23Z",
+				"DiscoKey":   "discokey:8e25ef80188ce5f33e7e93fd2daf1f6f0fbf6085a7dfaa0eed611d69da17f10a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:50256", "10.65.0.27:50256", "172.17.0.1:50256"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:53:23.234818434Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7474346318038758,
+				"StableID":   "nVgrRQQ9N121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       7474346318038758,
+				"Key":        "nodekey:e303c97d0da36dbf1d59e3e3f2ebc6969c7f536a87ab34a35ff8e0055a429177",
+				"DiscoKey":   "discokey:5d6909df424d734468aeffd3bed0ee7fe9bf4a2fcce531a11ca9cd3c9925175b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:36397", "10.65.0.27:36397", "172.17.0.1:36397"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:53:21.070932133Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e303c97d0da36dbf1d59e3e3f2ebc6969c7f536a87ab34a35ff8e0055a429177",
+			"MachineKey": "mkey:3fa7a93ed0ae3c777a958606de3eb095121ece542c4e361544ee72a239f6411e",
+			"Peers": [{
+				"ID":         6394954766560326,
+				"StableID":   "nF5BEqcHwr11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc3afd4f66228fee158888f1198442f9f7f875eff1fe22b034eb57de755e311b",
+				"DiscoKey":   "discokey:1f7452d562b377202e48329117391f589c15889d9ff108f9d7e379d3826a9373",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:58819", "10.65.0.27:58819", "172.17.0.1:58819"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:53:15.684556003Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3359264466207676,
+				"StableID":   "nb4rcWBRET11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d83f04ed7c3569414dcb92d01458a16bcfc5705a5bea10b4cc74af52d4fd3502",
+				"DiscoKey":   "discokey:5ec328efb87a8cc81cf61d619b3d9c2443889bb475bc325105576e1c2af8d675",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:48436", "10.65.0.27:48436", "172.17.0.1:48436"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:53:16.219864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6235546803700390,
+				"StableID":   "njq8RyE6hq11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0873d6c3d466cf9c8b45a58d8d980bd211d44d8586532d1f390c71dd5446de69",
+				"DiscoKey":   "discokey:c2fbc208776a6190ee6e05dbbf786a3d3db118f5109d9f79a2cb10db5200f603",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:35290", "10.65.0.27:35290", "172.17.0.1:35290"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:53:16.754794566Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7391643971333630,
+				"StableID":   "njjZFHxgiz11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:00490f66c391f2194192492702b82fdae51e8e5e475c4bfae3a45b821bf1e40f",
+				"DiscoKey":   "discokey:d08cd458c2ee3d20e462f653870f0e0880cc11cb199804c796c2652a6316da53",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:38472", "10.65.0.27:38472", "172.17.0.1:38472"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:53:17.278735389Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8485194050284806,
+				"StableID":   "nVJR3FfxF921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:74d9254e7a4e2c9184306736e424ca213c6a6dd4179c42fb657b99c2578f5673",
+				"DiscoKey":   "discokey:e25b8f5616f681bd86f517b4be1e1d372b13cb0103cc4879a56c52ebdb663b15",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:54589", "10.65.0.27:54589", "172.17.0.1:54589"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:53:17.823217253Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2679441641167704,
+				"StableID":   "nFEmWXPXvM11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0751abdee2bc9475bd52e77be0060d5122f5c3c307fd1eb022b19d987f3e1d59",
+				"DiscoKey":   "discokey:8e4eeb7e2be3852cce0f107762030e7db0e16855aa7478e203d7b544a1b38654",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:36715", "10.65.0.27:36715", "172.17.0.1:36715"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:53:18.41482324Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7320202710043211,
+				"StableID":   "nAGYd7KLAz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1da037e6dae2406c92eaf71f0914572c42efffd1c524ec7d8366450bb8c61074",
+				"DiscoKey":   "discokey:0b42d2d9fcac03bd35491165e3e5630091eadd59928ebef6cc6441adbca80278",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:47182", "10.65.0.27:47182", "172.17.0.1:47182"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:53:18.92365686Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8476196647412387,
+				"StableID":   "n89tM9KtB921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:814d7d401caec803d349cb1e32b72675014c39e0062ae5df969e44cc4455a93f",
+				"DiscoKey":   "discokey:ee6be9f35ca3352a90dfffe18988c0ac266fbeda7d88268cd96d2788b4ef7028",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:37759", "10.65.0.27:37759", "172.17.0.1:37759"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:53:19.475238223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2207964944873001,
+				"StableID":   "n2FkMiVzEJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3edf21b43cfe9f2d5914689b74b8907414ab275cf10cef54851087c5bac8839",
+				"DiscoKey":   "discokey:f8f229627c5bacf0711ed19514aa1a97ac2cf82309e26bbe0a58f895a4b84539",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:34868", "10.65.0.27:34868", "172.17.0.1:34868"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:53:19.998408749Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8843890274027626,
+				"StableID":   "nmG7341R4C21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9386a42db11e0ca68e4843223543ef47db9ecd78754cb47075d17a966508fb4d",
+				"DiscoKey":   "discokey:794f8ce28388d192645a60d86d655b38c329549df563fefb8a6c51dd9a7ca87b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:34307", "10.65.0.27:34307", "172.17.0.1:34307"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:53:20.537116622Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         1268500089248214,
+				"StableID":   "nj3X76MWuA11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:267b3b83b349cf8620179168c317ffa6962e99dad52b22ee0d30a0fadef5cf5b",
+				"DiscoKey":   "discokey:4848bae7f36e1fbbcb2c28df6d01bceaafae35625a2c44fd2f1d3770ab0a836d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53278", "10.65.0.27:53278", "172.17.0.1:53278"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:53:21.60722728Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4162529281909508,
+				"StableID":   "n7JNjyaDWZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:2ace03bcf2108c1a201c307a69989936bea9f7f7d9aeae7f442e1af9ca013a32",
+				"KeyExpiry":  "2026-11-08T18:53:22Z",
+				"DiscoKey":   "discokey:7d9f40e1e69f473a22adf865350d2d8799e6e51e5990e930ee14212798ba843d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:58061", "10.65.0.27:58061", "172.17.0.1:58061"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:53:22.148599211Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         462010508099750,
+				"StableID":   "nwfAXVEFc411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ae26fddf955389254a6d2a10edbe1158fc791500cfc9c4353c062929e07bc21b",
+				"KeyExpiry":  "2026-11-08T18:53:22Z",
+				"DiscoKey":   "discokey:e7d7a7e9e83b524330f67660934b944d1ea50ab079955a88e91a234c4b9e1200",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:33110", "10.65.0.27:33110", "172.17.0.1:33110"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:53:22.692243454Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1538947703875679,
+				"StableID":   "npPLihYz1D11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:85e6516547038b86b75be2f4353665b54d83b94a2209c3ceacd816f0ef96f073",
+				"KeyExpiry":  "2026-11-08T18:53:23Z",
+				"DiscoKey":   "discokey:8e25ef80188ce5f33e7e93fd2daf1f6f0fbf6085a7dfaa0eed611d69da17f10a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:50256", "10.65.0.27:50256", "172.17.0.1:50256"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:53:23.234818434Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7474346318038758": {
+				"ID":          7474346318038758,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3359264466207676,
+				"StableID":   "nb4rcWBRET11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       3359264466207676,
+				"Key":        "nodekey:d83f04ed7c3569414dcb92d01458a16bcfc5705a5bea10b4cc74af52d4fd3502",
+				"DiscoKey":   "discokey:5ec328efb87a8cc81cf61d619b3d9c2443889bb475bc325105576e1c2af8d675",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:48436", "10.65.0.27:48436", "172.17.0.1:48436"],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:53:16.219864Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d83f04ed7c3569414dcb92d01458a16bcfc5705a5bea10b4cc74af52d4fd3502",
+			"MachineKey": "mkey:4446cef67624a640d13c96bfce6d0c8e3c22f907799eef8f86f6550ec76e8964",
+			"Peers": [{
+				"ID":         6394954766560326,
+				"StableID":   "nF5BEqcHwr11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc3afd4f66228fee158888f1198442f9f7f875eff1fe22b034eb57de755e311b",
+				"DiscoKey":   "discokey:1f7452d562b377202e48329117391f589c15889d9ff108f9d7e379d3826a9373",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:58819", "10.65.0.27:58819", "172.17.0.1:58819"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:53:15.684556003Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         6235546803700390,
+				"StableID":   "njq8RyE6hq11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0873d6c3d466cf9c8b45a58d8d980bd211d44d8586532d1f390c71dd5446de69",
+				"DiscoKey":   "discokey:c2fbc208776a6190ee6e05dbbf786a3d3db118f5109d9f79a2cb10db5200f603",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:35290", "10.65.0.27:35290", "172.17.0.1:35290"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:53:16.754794566Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7391643971333630,
+				"StableID":   "njjZFHxgiz11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:00490f66c391f2194192492702b82fdae51e8e5e475c4bfae3a45b821bf1e40f",
+				"DiscoKey":   "discokey:d08cd458c2ee3d20e462f653870f0e0880cc11cb199804c796c2652a6316da53",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:38472", "10.65.0.27:38472", "172.17.0.1:38472"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:53:17.278735389Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8485194050284806,
+				"StableID":   "nVJR3FfxF921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:74d9254e7a4e2c9184306736e424ca213c6a6dd4179c42fb657b99c2578f5673",
+				"DiscoKey":   "discokey:e25b8f5616f681bd86f517b4be1e1d372b13cb0103cc4879a56c52ebdb663b15",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:54589", "10.65.0.27:54589", "172.17.0.1:54589"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:53:17.823217253Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2679441641167704,
+				"StableID":   "nFEmWXPXvM11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0751abdee2bc9475bd52e77be0060d5122f5c3c307fd1eb022b19d987f3e1d59",
+				"DiscoKey":   "discokey:8e4eeb7e2be3852cce0f107762030e7db0e16855aa7478e203d7b544a1b38654",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:36715", "10.65.0.27:36715", "172.17.0.1:36715"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:53:18.41482324Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7320202710043211,
+				"StableID":   "nAGYd7KLAz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1da037e6dae2406c92eaf71f0914572c42efffd1c524ec7d8366450bb8c61074",
+				"DiscoKey":   "discokey:0b42d2d9fcac03bd35491165e3e5630091eadd59928ebef6cc6441adbca80278",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:47182", "10.65.0.27:47182", "172.17.0.1:47182"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:53:18.92365686Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8476196647412387,
+				"StableID":   "n89tM9KtB921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:814d7d401caec803d349cb1e32b72675014c39e0062ae5df969e44cc4455a93f",
+				"DiscoKey":   "discokey:ee6be9f35ca3352a90dfffe18988c0ac266fbeda7d88268cd96d2788b4ef7028",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:37759", "10.65.0.27:37759", "172.17.0.1:37759"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:53:19.475238223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2207964944873001,
+				"StableID":   "n2FkMiVzEJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3edf21b43cfe9f2d5914689b74b8907414ab275cf10cef54851087c5bac8839",
+				"DiscoKey":   "discokey:f8f229627c5bacf0711ed19514aa1a97ac2cf82309e26bbe0a58f895a4b84539",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:34868", "10.65.0.27:34868", "172.17.0.1:34868"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:53:19.998408749Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8843890274027626,
+				"StableID":   "nmG7341R4C21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9386a42db11e0ca68e4843223543ef47db9ecd78754cb47075d17a966508fb4d",
+				"DiscoKey":   "discokey:794f8ce28388d192645a60d86d655b38c329549df563fefb8a6c51dd9a7ca87b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:34307", "10.65.0.27:34307", "172.17.0.1:34307"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:53:20.537116622Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7474346318038758,
+				"StableID":   "nVgrRQQ9N121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e303c97d0da36dbf1d59e3e3f2ebc6969c7f536a87ab34a35ff8e0055a429177",
+				"DiscoKey":   "discokey:5d6909df424d734468aeffd3bed0ee7fe9bf4a2fcce531a11ca9cd3c9925175b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:36397", "10.65.0.27:36397", "172.17.0.1:36397"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:53:21.070932133Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1268500089248214,
+				"StableID":   "nj3X76MWuA11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:267b3b83b349cf8620179168c317ffa6962e99dad52b22ee0d30a0fadef5cf5b",
+				"DiscoKey":   "discokey:4848bae7f36e1fbbcb2c28df6d01bceaafae35625a2c44fd2f1d3770ab0a836d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53278", "10.65.0.27:53278", "172.17.0.1:53278"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:53:21.60722728Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4162529281909508,
+				"StableID":   "n7JNjyaDWZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:2ace03bcf2108c1a201c307a69989936bea9f7f7d9aeae7f442e1af9ca013a32",
+				"KeyExpiry":  "2026-11-08T18:53:22Z",
+				"DiscoKey":   "discokey:7d9f40e1e69f473a22adf865350d2d8799e6e51e5990e930ee14212798ba843d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:58061", "10.65.0.27:58061", "172.17.0.1:58061"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:53:22.148599211Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         462010508099750,
+				"StableID":   "nwfAXVEFc411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ae26fddf955389254a6d2a10edbe1158fc791500cfc9c4353c062929e07bc21b",
+				"KeyExpiry":  "2026-11-08T18:53:22Z",
+				"DiscoKey":   "discokey:e7d7a7e9e83b524330f67660934b944d1ea50ab079955a88e91a234c4b9e1200",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:33110", "10.65.0.27:33110", "172.17.0.1:33110"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:53:22.692243454Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1538947703875679,
+				"StableID":   "npPLihYz1D11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:85e6516547038b86b75be2f4353665b54d83b94a2209c3ceacd816f0ef96f073",
+				"KeyExpiry":  "2026-11-08T18:53:23Z",
+				"DiscoKey":   "discokey:8e25ef80188ce5f33e7e93fd2daf1f6f0fbf6085a7dfaa0eed611d69da17f10a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:50256", "10.65.0.27:50256", "172.17.0.1:50256"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:53:23.234818434Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3359264466207676": {
+				"ID":          3359264466207676,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6394954766560326,
+				"StableID":   "nF5BEqcHwr11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       6394954766560326,
+				"Key":        "nodekey:fc3afd4f66228fee158888f1198442f9f7f875eff1fe22b034eb57de755e311b",
+				"DiscoKey":   "discokey:1f7452d562b377202e48329117391f589c15889d9ff108f9d7e379d3826a9373",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:58819", "10.65.0.27:58819", "172.17.0.1:58819"],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:53:15.684556003Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:fc3afd4f66228fee158888f1198442f9f7f875eff1fe22b034eb57de755e311b",
+			"MachineKey": "mkey:7535c7103fc77a9bc31fc7eb33adb7259a4c7c204df7d4e77b7de0ba961a087c",
+			"Peers": [{
+				"ID":         3359264466207676,
+				"StableID":   "nb4rcWBRET11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d83f04ed7c3569414dcb92d01458a16bcfc5705a5bea10b4cc74af52d4fd3502",
+				"DiscoKey":   "discokey:5ec328efb87a8cc81cf61d619b3d9c2443889bb475bc325105576e1c2af8d675",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:48436", "10.65.0.27:48436", "172.17.0.1:48436"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:53:16.219864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6235546803700390,
+				"StableID":   "njq8RyE6hq11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0873d6c3d466cf9c8b45a58d8d980bd211d44d8586532d1f390c71dd5446de69",
+				"DiscoKey":   "discokey:c2fbc208776a6190ee6e05dbbf786a3d3db118f5109d9f79a2cb10db5200f603",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:35290", "10.65.0.27:35290", "172.17.0.1:35290"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:53:16.754794566Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7391643971333630,
+				"StableID":   "njjZFHxgiz11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:00490f66c391f2194192492702b82fdae51e8e5e475c4bfae3a45b821bf1e40f",
+				"DiscoKey":   "discokey:d08cd458c2ee3d20e462f653870f0e0880cc11cb199804c796c2652a6316da53",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:38472", "10.65.0.27:38472", "172.17.0.1:38472"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:53:17.278735389Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8485194050284806,
+				"StableID":   "nVJR3FfxF921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:74d9254e7a4e2c9184306736e424ca213c6a6dd4179c42fb657b99c2578f5673",
+				"DiscoKey":   "discokey:e25b8f5616f681bd86f517b4be1e1d372b13cb0103cc4879a56c52ebdb663b15",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:54589", "10.65.0.27:54589", "172.17.0.1:54589"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:53:17.823217253Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2679441641167704,
+				"StableID":   "nFEmWXPXvM11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0751abdee2bc9475bd52e77be0060d5122f5c3c307fd1eb022b19d987f3e1d59",
+				"DiscoKey":   "discokey:8e4eeb7e2be3852cce0f107762030e7db0e16855aa7478e203d7b544a1b38654",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:36715", "10.65.0.27:36715", "172.17.0.1:36715"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:53:18.41482324Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7320202710043211,
+				"StableID":   "nAGYd7KLAz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1da037e6dae2406c92eaf71f0914572c42efffd1c524ec7d8366450bb8c61074",
+				"DiscoKey":   "discokey:0b42d2d9fcac03bd35491165e3e5630091eadd59928ebef6cc6441adbca80278",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:47182", "10.65.0.27:47182", "172.17.0.1:47182"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:53:18.92365686Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8476196647412387,
+				"StableID":   "n89tM9KtB921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:814d7d401caec803d349cb1e32b72675014c39e0062ae5df969e44cc4455a93f",
+				"DiscoKey":   "discokey:ee6be9f35ca3352a90dfffe18988c0ac266fbeda7d88268cd96d2788b4ef7028",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:37759", "10.65.0.27:37759", "172.17.0.1:37759"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:53:19.475238223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2207964944873001,
+				"StableID":   "n2FkMiVzEJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3edf21b43cfe9f2d5914689b74b8907414ab275cf10cef54851087c5bac8839",
+				"DiscoKey":   "discokey:f8f229627c5bacf0711ed19514aa1a97ac2cf82309e26bbe0a58f895a4b84539",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:34868", "10.65.0.27:34868", "172.17.0.1:34868"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:53:19.998408749Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8843890274027626,
+				"StableID":   "nmG7341R4C21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9386a42db11e0ca68e4843223543ef47db9ecd78754cb47075d17a966508fb4d",
+				"DiscoKey":   "discokey:794f8ce28388d192645a60d86d655b38c329549df563fefb8a6c51dd9a7ca87b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:34307", "10.65.0.27:34307", "172.17.0.1:34307"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:53:20.537116622Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7474346318038758,
+				"StableID":   "nVgrRQQ9N121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e303c97d0da36dbf1d59e3e3f2ebc6969c7f536a87ab34a35ff8e0055a429177",
+				"DiscoKey":   "discokey:5d6909df424d734468aeffd3bed0ee7fe9bf4a2fcce531a11ca9cd3c9925175b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:36397", "10.65.0.27:36397", "172.17.0.1:36397"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:53:21.070932133Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1268500089248214,
+				"StableID":   "nj3X76MWuA11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:267b3b83b349cf8620179168c317ffa6962e99dad52b22ee0d30a0fadef5cf5b",
+				"DiscoKey":   "discokey:4848bae7f36e1fbbcb2c28df6d01bceaafae35625a2c44fd2f1d3770ab0a836d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53278", "10.65.0.27:53278", "172.17.0.1:53278"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:53:21.60722728Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4162529281909508,
+				"StableID":   "n7JNjyaDWZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:2ace03bcf2108c1a201c307a69989936bea9f7f7d9aeae7f442e1af9ca013a32",
+				"KeyExpiry":  "2026-11-08T18:53:22Z",
+				"DiscoKey":   "discokey:7d9f40e1e69f473a22adf865350d2d8799e6e51e5990e930ee14212798ba843d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:58061", "10.65.0.27:58061", "172.17.0.1:58061"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:53:22.148599211Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         462010508099750,
+				"StableID":   "nwfAXVEFc411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ae26fddf955389254a6d2a10edbe1158fc791500cfc9c4353c062929e07bc21b",
+				"KeyExpiry":  "2026-11-08T18:53:22Z",
+				"DiscoKey":   "discokey:e7d7a7e9e83b524330f67660934b944d1ea50ab079955a88e91a234c4b9e1200",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:33110", "10.65.0.27:33110", "172.17.0.1:33110"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:53:22.692243454Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1538947703875679,
+				"StableID":   "npPLihYz1D11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:85e6516547038b86b75be2f4353665b54d83b94a2209c3ceacd816f0ef96f073",
+				"KeyExpiry":  "2026-11-08T18:53:23Z",
+				"DiscoKey":   "discokey:8e25ef80188ce5f33e7e93fd2daf1f6f0fbf6085a7dfaa0eed611d69da17f10a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:50256", "10.65.0.27:50256", "172.17.0.1:50256"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:53:23.234818434Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6394954766560326": {
+				"ID":          6394954766560326,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8485194050284806,
+				"StableID":   "nVJR3FfxF921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       8485194050284806,
+				"Key":        "nodekey:74d9254e7a4e2c9184306736e424ca213c6a6dd4179c42fb657b99c2578f5673",
+				"DiscoKey":   "discokey:e25b8f5616f681bd86f517b4be1e1d372b13cb0103cc4879a56c52ebdb663b15",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:54589", "10.65.0.27:54589", "172.17.0.1:54589"],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:53:17.823217253Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:74d9254e7a4e2c9184306736e424ca213c6a6dd4179c42fb657b99c2578f5673",
+			"MachineKey": "mkey:e15df056246fa3c6c67d961244430b3ae4d9e1849faef6b8ca158f459c22584c",
+			"Peers": [{
+				"ID":         6394954766560326,
+				"StableID":   "nF5BEqcHwr11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc3afd4f66228fee158888f1198442f9f7f875eff1fe22b034eb57de755e311b",
+				"DiscoKey":   "discokey:1f7452d562b377202e48329117391f589c15889d9ff108f9d7e379d3826a9373",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:58819", "10.65.0.27:58819", "172.17.0.1:58819"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:53:15.684556003Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3359264466207676,
+				"StableID":   "nb4rcWBRET11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d83f04ed7c3569414dcb92d01458a16bcfc5705a5bea10b4cc74af52d4fd3502",
+				"DiscoKey":   "discokey:5ec328efb87a8cc81cf61d619b3d9c2443889bb475bc325105576e1c2af8d675",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:48436", "10.65.0.27:48436", "172.17.0.1:48436"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:53:16.219864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6235546803700390,
+				"StableID":   "njq8RyE6hq11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0873d6c3d466cf9c8b45a58d8d980bd211d44d8586532d1f390c71dd5446de69",
+				"DiscoKey":   "discokey:c2fbc208776a6190ee6e05dbbf786a3d3db118f5109d9f79a2cb10db5200f603",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:35290", "10.65.0.27:35290", "172.17.0.1:35290"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:53:16.754794566Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7391643971333630,
+				"StableID":   "njjZFHxgiz11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:00490f66c391f2194192492702b82fdae51e8e5e475c4bfae3a45b821bf1e40f",
+				"DiscoKey":   "discokey:d08cd458c2ee3d20e462f653870f0e0880cc11cb199804c796c2652a6316da53",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:38472", "10.65.0.27:38472", "172.17.0.1:38472"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:53:17.278735389Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2679441641167704,
+				"StableID":   "nFEmWXPXvM11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0751abdee2bc9475bd52e77be0060d5122f5c3c307fd1eb022b19d987f3e1d59",
+				"DiscoKey":   "discokey:8e4eeb7e2be3852cce0f107762030e7db0e16855aa7478e203d7b544a1b38654",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:36715", "10.65.0.27:36715", "172.17.0.1:36715"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:53:18.41482324Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7320202710043211,
+				"StableID":   "nAGYd7KLAz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1da037e6dae2406c92eaf71f0914572c42efffd1c524ec7d8366450bb8c61074",
+				"DiscoKey":   "discokey:0b42d2d9fcac03bd35491165e3e5630091eadd59928ebef6cc6441adbca80278",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:47182", "10.65.0.27:47182", "172.17.0.1:47182"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:53:18.92365686Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8476196647412387,
+				"StableID":   "n89tM9KtB921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:814d7d401caec803d349cb1e32b72675014c39e0062ae5df969e44cc4455a93f",
+				"DiscoKey":   "discokey:ee6be9f35ca3352a90dfffe18988c0ac266fbeda7d88268cd96d2788b4ef7028",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:37759", "10.65.0.27:37759", "172.17.0.1:37759"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:53:19.475238223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2207964944873001,
+				"StableID":   "n2FkMiVzEJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3edf21b43cfe9f2d5914689b74b8907414ab275cf10cef54851087c5bac8839",
+				"DiscoKey":   "discokey:f8f229627c5bacf0711ed19514aa1a97ac2cf82309e26bbe0a58f895a4b84539",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:34868", "10.65.0.27:34868", "172.17.0.1:34868"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:53:19.998408749Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8843890274027626,
+				"StableID":   "nmG7341R4C21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9386a42db11e0ca68e4843223543ef47db9ecd78754cb47075d17a966508fb4d",
+				"DiscoKey":   "discokey:794f8ce28388d192645a60d86d655b38c329549df563fefb8a6c51dd9a7ca87b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:34307", "10.65.0.27:34307", "172.17.0.1:34307"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:53:20.537116622Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7474346318038758,
+				"StableID":   "nVgrRQQ9N121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e303c97d0da36dbf1d59e3e3f2ebc6969c7f536a87ab34a35ff8e0055a429177",
+				"DiscoKey":   "discokey:5d6909df424d734468aeffd3bed0ee7fe9bf4a2fcce531a11ca9cd3c9925175b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:36397", "10.65.0.27:36397", "172.17.0.1:36397"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:53:21.070932133Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1268500089248214,
+				"StableID":   "nj3X76MWuA11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:267b3b83b349cf8620179168c317ffa6962e99dad52b22ee0d30a0fadef5cf5b",
+				"DiscoKey":   "discokey:4848bae7f36e1fbbcb2c28df6d01bceaafae35625a2c44fd2f1d3770ab0a836d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53278", "10.65.0.27:53278", "172.17.0.1:53278"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:53:21.60722728Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4162529281909508,
+				"StableID":   "n7JNjyaDWZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:2ace03bcf2108c1a201c307a69989936bea9f7f7d9aeae7f442e1af9ca013a32",
+				"KeyExpiry":  "2026-11-08T18:53:22Z",
+				"DiscoKey":   "discokey:7d9f40e1e69f473a22adf865350d2d8799e6e51e5990e930ee14212798ba843d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:58061", "10.65.0.27:58061", "172.17.0.1:58061"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:53:22.148599211Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         462010508099750,
+				"StableID":   "nwfAXVEFc411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ae26fddf955389254a6d2a10edbe1158fc791500cfc9c4353c062929e07bc21b",
+				"KeyExpiry":  "2026-11-08T18:53:22Z",
+				"DiscoKey":   "discokey:e7d7a7e9e83b524330f67660934b944d1ea50ab079955a88e91a234c4b9e1200",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:33110", "10.65.0.27:33110", "172.17.0.1:33110"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:53:22.692243454Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1538947703875679,
+				"StableID":   "npPLihYz1D11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:85e6516547038b86b75be2f4353665b54d83b94a2209c3ceacd816f0ef96f073",
+				"KeyExpiry":  "2026-11-08T18:53:23Z",
+				"DiscoKey":   "discokey:8e25ef80188ce5f33e7e93fd2daf1f6f0fbf6085a7dfaa0eed611d69da17f10a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:50256", "10.65.0.27:50256", "172.17.0.1:50256"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:53:23.234818434Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8485194050284806": {
+				"ID":          8485194050284806,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7391643971333630,
+				"StableID":   "njjZFHxgiz11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       7391643971333630,
+				"Key":        "nodekey:00490f66c391f2194192492702b82fdae51e8e5e475c4bfae3a45b821bf1e40f",
+				"DiscoKey":   "discokey:d08cd458c2ee3d20e462f653870f0e0880cc11cb199804c796c2652a6316da53",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:38472", "10.65.0.27:38472", "172.17.0.1:38472"],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:53:17.278735389Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:00490f66c391f2194192492702b82fdae51e8e5e475c4bfae3a45b821bf1e40f",
+			"MachineKey": "mkey:477b9127c7c845c8bf139ec3f6883dda6f871e27938604f59761a89a55dd925e",
+			"Peers": [{
+				"ID":         6394954766560326,
+				"StableID":   "nF5BEqcHwr11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc3afd4f66228fee158888f1198442f9f7f875eff1fe22b034eb57de755e311b",
+				"DiscoKey":   "discokey:1f7452d562b377202e48329117391f589c15889d9ff108f9d7e379d3826a9373",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:58819", "10.65.0.27:58819", "172.17.0.1:58819"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:53:15.684556003Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3359264466207676,
+				"StableID":   "nb4rcWBRET11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d83f04ed7c3569414dcb92d01458a16bcfc5705a5bea10b4cc74af52d4fd3502",
+				"DiscoKey":   "discokey:5ec328efb87a8cc81cf61d619b3d9c2443889bb475bc325105576e1c2af8d675",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:48436", "10.65.0.27:48436", "172.17.0.1:48436"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:53:16.219864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6235546803700390,
+				"StableID":   "njq8RyE6hq11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0873d6c3d466cf9c8b45a58d8d980bd211d44d8586532d1f390c71dd5446de69",
+				"DiscoKey":   "discokey:c2fbc208776a6190ee6e05dbbf786a3d3db118f5109d9f79a2cb10db5200f603",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:35290", "10.65.0.27:35290", "172.17.0.1:35290"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:53:16.754794566Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8485194050284806,
+				"StableID":   "nVJR3FfxF921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:74d9254e7a4e2c9184306736e424ca213c6a6dd4179c42fb657b99c2578f5673",
+				"DiscoKey":   "discokey:e25b8f5616f681bd86f517b4be1e1d372b13cb0103cc4879a56c52ebdb663b15",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:54589", "10.65.0.27:54589", "172.17.0.1:54589"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:53:17.823217253Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2679441641167704,
+				"StableID":   "nFEmWXPXvM11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0751abdee2bc9475bd52e77be0060d5122f5c3c307fd1eb022b19d987f3e1d59",
+				"DiscoKey":   "discokey:8e4eeb7e2be3852cce0f107762030e7db0e16855aa7478e203d7b544a1b38654",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:36715", "10.65.0.27:36715", "172.17.0.1:36715"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:53:18.41482324Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7320202710043211,
+				"StableID":   "nAGYd7KLAz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1da037e6dae2406c92eaf71f0914572c42efffd1c524ec7d8366450bb8c61074",
+				"DiscoKey":   "discokey:0b42d2d9fcac03bd35491165e3e5630091eadd59928ebef6cc6441adbca80278",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:47182", "10.65.0.27:47182", "172.17.0.1:47182"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:53:18.92365686Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8476196647412387,
+				"StableID":   "n89tM9KtB921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:814d7d401caec803d349cb1e32b72675014c39e0062ae5df969e44cc4455a93f",
+				"DiscoKey":   "discokey:ee6be9f35ca3352a90dfffe18988c0ac266fbeda7d88268cd96d2788b4ef7028",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:37759", "10.65.0.27:37759", "172.17.0.1:37759"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:53:19.475238223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2207964944873001,
+				"StableID":   "n2FkMiVzEJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3edf21b43cfe9f2d5914689b74b8907414ab275cf10cef54851087c5bac8839",
+				"DiscoKey":   "discokey:f8f229627c5bacf0711ed19514aa1a97ac2cf82309e26bbe0a58f895a4b84539",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:34868", "10.65.0.27:34868", "172.17.0.1:34868"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:53:19.998408749Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8843890274027626,
+				"StableID":   "nmG7341R4C21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9386a42db11e0ca68e4843223543ef47db9ecd78754cb47075d17a966508fb4d",
+				"DiscoKey":   "discokey:794f8ce28388d192645a60d86d655b38c329549df563fefb8a6c51dd9a7ca87b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:34307", "10.65.0.27:34307", "172.17.0.1:34307"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:53:20.537116622Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7474346318038758,
+				"StableID":   "nVgrRQQ9N121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e303c97d0da36dbf1d59e3e3f2ebc6969c7f536a87ab34a35ff8e0055a429177",
+				"DiscoKey":   "discokey:5d6909df424d734468aeffd3bed0ee7fe9bf4a2fcce531a11ca9cd3c9925175b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:36397", "10.65.0.27:36397", "172.17.0.1:36397"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:53:21.070932133Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1268500089248214,
+				"StableID":   "nj3X76MWuA11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:267b3b83b349cf8620179168c317ffa6962e99dad52b22ee0d30a0fadef5cf5b",
+				"DiscoKey":   "discokey:4848bae7f36e1fbbcb2c28df6d01bceaafae35625a2c44fd2f1d3770ab0a836d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53278", "10.65.0.27:53278", "172.17.0.1:53278"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:53:21.60722728Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4162529281909508,
+				"StableID":   "n7JNjyaDWZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:2ace03bcf2108c1a201c307a69989936bea9f7f7d9aeae7f442e1af9ca013a32",
+				"KeyExpiry":  "2026-11-08T18:53:22Z",
+				"DiscoKey":   "discokey:7d9f40e1e69f473a22adf865350d2d8799e6e51e5990e930ee14212798ba843d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:58061", "10.65.0.27:58061", "172.17.0.1:58061"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:53:22.148599211Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         462010508099750,
+				"StableID":   "nwfAXVEFc411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ae26fddf955389254a6d2a10edbe1158fc791500cfc9c4353c062929e07bc21b",
+				"KeyExpiry":  "2026-11-08T18:53:22Z",
+				"DiscoKey":   "discokey:e7d7a7e9e83b524330f67660934b944d1ea50ab079955a88e91a234c4b9e1200",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:33110", "10.65.0.27:33110", "172.17.0.1:33110"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:53:22.692243454Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1538947703875679,
+				"StableID":   "npPLihYz1D11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:85e6516547038b86b75be2f4353665b54d83b94a2209c3ceacd816f0ef96f073",
+				"KeyExpiry":  "2026-11-08T18:53:23Z",
+				"DiscoKey":   "discokey:8e25ef80188ce5f33e7e93fd2daf1f6f0fbf6085a7dfaa0eed611d69da17f10a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:50256", "10.65.0.27:50256", "172.17.0.1:50256"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:53:23.234818434Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7391643971333630": {
+				"ID":          7391643971333630,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7320202710043211,
+				"StableID":   "nAGYd7KLAz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       7320202710043211,
+				"Key":        "nodekey:1da037e6dae2406c92eaf71f0914572c42efffd1c524ec7d8366450bb8c61074",
+				"DiscoKey":   "discokey:0b42d2d9fcac03bd35491165e3e5630091eadd59928ebef6cc6441adbca80278",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:47182", "10.65.0.27:47182", "172.17.0.1:47182"],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:53:18.92365686Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1da037e6dae2406c92eaf71f0914572c42efffd1c524ec7d8366450bb8c61074",
+			"MachineKey": "mkey:f476faf3e3c14ed9b22c337d7fae8df7dadb6a8341f3f554d8b3f3c1a15b365d",
+			"Peers": [{
+				"ID":         6394954766560326,
+				"StableID":   "nF5BEqcHwr11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc3afd4f66228fee158888f1198442f9f7f875eff1fe22b034eb57de755e311b",
+				"DiscoKey":   "discokey:1f7452d562b377202e48329117391f589c15889d9ff108f9d7e379d3826a9373",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:58819", "10.65.0.27:58819", "172.17.0.1:58819"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:53:15.684556003Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3359264466207676,
+				"StableID":   "nb4rcWBRET11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d83f04ed7c3569414dcb92d01458a16bcfc5705a5bea10b4cc74af52d4fd3502",
+				"DiscoKey":   "discokey:5ec328efb87a8cc81cf61d619b3d9c2443889bb475bc325105576e1c2af8d675",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:48436", "10.65.0.27:48436", "172.17.0.1:48436"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:53:16.219864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6235546803700390,
+				"StableID":   "njq8RyE6hq11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0873d6c3d466cf9c8b45a58d8d980bd211d44d8586532d1f390c71dd5446de69",
+				"DiscoKey":   "discokey:c2fbc208776a6190ee6e05dbbf786a3d3db118f5109d9f79a2cb10db5200f603",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:35290", "10.65.0.27:35290", "172.17.0.1:35290"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:53:16.754794566Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7391643971333630,
+				"StableID":   "njjZFHxgiz11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:00490f66c391f2194192492702b82fdae51e8e5e475c4bfae3a45b821bf1e40f",
+				"DiscoKey":   "discokey:d08cd458c2ee3d20e462f653870f0e0880cc11cb199804c796c2652a6316da53",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:38472", "10.65.0.27:38472", "172.17.0.1:38472"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:53:17.278735389Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8485194050284806,
+				"StableID":   "nVJR3FfxF921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:74d9254e7a4e2c9184306736e424ca213c6a6dd4179c42fb657b99c2578f5673",
+				"DiscoKey":   "discokey:e25b8f5616f681bd86f517b4be1e1d372b13cb0103cc4879a56c52ebdb663b15",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:54589", "10.65.0.27:54589", "172.17.0.1:54589"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:53:17.823217253Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2679441641167704,
+				"StableID":   "nFEmWXPXvM11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0751abdee2bc9475bd52e77be0060d5122f5c3c307fd1eb022b19d987f3e1d59",
+				"DiscoKey":   "discokey:8e4eeb7e2be3852cce0f107762030e7db0e16855aa7478e203d7b544a1b38654",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:36715", "10.65.0.27:36715", "172.17.0.1:36715"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:53:18.41482324Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8476196647412387,
+				"StableID":   "n89tM9KtB921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:814d7d401caec803d349cb1e32b72675014c39e0062ae5df969e44cc4455a93f",
+				"DiscoKey":   "discokey:ee6be9f35ca3352a90dfffe18988c0ac266fbeda7d88268cd96d2788b4ef7028",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:37759", "10.65.0.27:37759", "172.17.0.1:37759"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:53:19.475238223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2207964944873001,
+				"StableID":   "n2FkMiVzEJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3edf21b43cfe9f2d5914689b74b8907414ab275cf10cef54851087c5bac8839",
+				"DiscoKey":   "discokey:f8f229627c5bacf0711ed19514aa1a97ac2cf82309e26bbe0a58f895a4b84539",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:34868", "10.65.0.27:34868", "172.17.0.1:34868"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:53:19.998408749Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8843890274027626,
+				"StableID":   "nmG7341R4C21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9386a42db11e0ca68e4843223543ef47db9ecd78754cb47075d17a966508fb4d",
+				"DiscoKey":   "discokey:794f8ce28388d192645a60d86d655b38c329549df563fefb8a6c51dd9a7ca87b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:34307", "10.65.0.27:34307", "172.17.0.1:34307"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:53:20.537116622Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7474346318038758,
+				"StableID":   "nVgrRQQ9N121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e303c97d0da36dbf1d59e3e3f2ebc6969c7f536a87ab34a35ff8e0055a429177",
+				"DiscoKey":   "discokey:5d6909df424d734468aeffd3bed0ee7fe9bf4a2fcce531a11ca9cd3c9925175b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:36397", "10.65.0.27:36397", "172.17.0.1:36397"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:53:21.070932133Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1268500089248214,
+				"StableID":   "nj3X76MWuA11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:267b3b83b349cf8620179168c317ffa6962e99dad52b22ee0d30a0fadef5cf5b",
+				"DiscoKey":   "discokey:4848bae7f36e1fbbcb2c28df6d01bceaafae35625a2c44fd2f1d3770ab0a836d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53278", "10.65.0.27:53278", "172.17.0.1:53278"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:53:21.60722728Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4162529281909508,
+				"StableID":   "n7JNjyaDWZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:2ace03bcf2108c1a201c307a69989936bea9f7f7d9aeae7f442e1af9ca013a32",
+				"KeyExpiry":  "2026-11-08T18:53:22Z",
+				"DiscoKey":   "discokey:7d9f40e1e69f473a22adf865350d2d8799e6e51e5990e930ee14212798ba843d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:58061", "10.65.0.27:58061", "172.17.0.1:58061"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:53:22.148599211Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         462010508099750,
+				"StableID":   "nwfAXVEFc411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ae26fddf955389254a6d2a10edbe1158fc791500cfc9c4353c062929e07bc21b",
+				"KeyExpiry":  "2026-11-08T18:53:22Z",
+				"DiscoKey":   "discokey:e7d7a7e9e83b524330f67660934b944d1ea50ab079955a88e91a234c4b9e1200",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:33110", "10.65.0.27:33110", "172.17.0.1:33110"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:53:22.692243454Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1538947703875679,
+				"StableID":   "npPLihYz1D11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:85e6516547038b86b75be2f4353665b54d83b94a2209c3ceacd816f0ef96f073",
+				"KeyExpiry":  "2026-11-08T18:53:23Z",
+				"DiscoKey":   "discokey:8e25ef80188ce5f33e7e93fd2daf1f6f0fbf6085a7dfaa0eed611d69da17f10a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:50256", "10.65.0.27:50256", "172.17.0.1:50256"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:53:23.234818434Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7320202710043211": {
+				"ID":          7320202710043211,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2207964944873001,
+				"StableID":   "n2FkMiVzEJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       2207964944873001,
+				"Key":        "nodekey:e3edf21b43cfe9f2d5914689b74b8907414ab275cf10cef54851087c5bac8839",
+				"DiscoKey":   "discokey:f8f229627c5bacf0711ed19514aa1a97ac2cf82309e26bbe0a58f895a4b84539",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:34868", "10.65.0.27:34868", "172.17.0.1:34868"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:53:19.998408749Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e3edf21b43cfe9f2d5914689b74b8907414ab275cf10cef54851087c5bac8839",
+			"MachineKey": "mkey:125ae118661c25d3fa073a2badc0464a1e0ee0bf2330b1f759da9a52b2181c40",
+			"Peers": [{
+				"ID":         6394954766560326,
+				"StableID":   "nF5BEqcHwr11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc3afd4f66228fee158888f1198442f9f7f875eff1fe22b034eb57de755e311b",
+				"DiscoKey":   "discokey:1f7452d562b377202e48329117391f589c15889d9ff108f9d7e379d3826a9373",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:58819", "10.65.0.27:58819", "172.17.0.1:58819"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:53:15.684556003Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3359264466207676,
+				"StableID":   "nb4rcWBRET11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d83f04ed7c3569414dcb92d01458a16bcfc5705a5bea10b4cc74af52d4fd3502",
+				"DiscoKey":   "discokey:5ec328efb87a8cc81cf61d619b3d9c2443889bb475bc325105576e1c2af8d675",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:48436", "10.65.0.27:48436", "172.17.0.1:48436"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:53:16.219864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6235546803700390,
+				"StableID":   "njq8RyE6hq11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0873d6c3d466cf9c8b45a58d8d980bd211d44d8586532d1f390c71dd5446de69",
+				"DiscoKey":   "discokey:c2fbc208776a6190ee6e05dbbf786a3d3db118f5109d9f79a2cb10db5200f603",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:35290", "10.65.0.27:35290", "172.17.0.1:35290"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:53:16.754794566Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7391643971333630,
+				"StableID":   "njjZFHxgiz11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:00490f66c391f2194192492702b82fdae51e8e5e475c4bfae3a45b821bf1e40f",
+				"DiscoKey":   "discokey:d08cd458c2ee3d20e462f653870f0e0880cc11cb199804c796c2652a6316da53",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:38472", "10.65.0.27:38472", "172.17.0.1:38472"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:53:17.278735389Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8485194050284806,
+				"StableID":   "nVJR3FfxF921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:74d9254e7a4e2c9184306736e424ca213c6a6dd4179c42fb657b99c2578f5673",
+				"DiscoKey":   "discokey:e25b8f5616f681bd86f517b4be1e1d372b13cb0103cc4879a56c52ebdb663b15",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:54589", "10.65.0.27:54589", "172.17.0.1:54589"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:53:17.823217253Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2679441641167704,
+				"StableID":   "nFEmWXPXvM11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0751abdee2bc9475bd52e77be0060d5122f5c3c307fd1eb022b19d987f3e1d59",
+				"DiscoKey":   "discokey:8e4eeb7e2be3852cce0f107762030e7db0e16855aa7478e203d7b544a1b38654",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:36715", "10.65.0.27:36715", "172.17.0.1:36715"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:53:18.41482324Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7320202710043211,
+				"StableID":   "nAGYd7KLAz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1da037e6dae2406c92eaf71f0914572c42efffd1c524ec7d8366450bb8c61074",
+				"DiscoKey":   "discokey:0b42d2d9fcac03bd35491165e3e5630091eadd59928ebef6cc6441adbca80278",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:47182", "10.65.0.27:47182", "172.17.0.1:47182"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:53:18.92365686Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8476196647412387,
+				"StableID":   "n89tM9KtB921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:814d7d401caec803d349cb1e32b72675014c39e0062ae5df969e44cc4455a93f",
+				"DiscoKey":   "discokey:ee6be9f35ca3352a90dfffe18988c0ac266fbeda7d88268cd96d2788b4ef7028",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:37759", "10.65.0.27:37759", "172.17.0.1:37759"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:53:19.475238223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         8843890274027626,
+				"StableID":   "nmG7341R4C21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9386a42db11e0ca68e4843223543ef47db9ecd78754cb47075d17a966508fb4d",
+				"DiscoKey":   "discokey:794f8ce28388d192645a60d86d655b38c329549df563fefb8a6c51dd9a7ca87b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:34307", "10.65.0.27:34307", "172.17.0.1:34307"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:53:20.537116622Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7474346318038758,
+				"StableID":   "nVgrRQQ9N121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e303c97d0da36dbf1d59e3e3f2ebc6969c7f536a87ab34a35ff8e0055a429177",
+				"DiscoKey":   "discokey:5d6909df424d734468aeffd3bed0ee7fe9bf4a2fcce531a11ca9cd3c9925175b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:36397", "10.65.0.27:36397", "172.17.0.1:36397"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:53:21.070932133Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1268500089248214,
+				"StableID":   "nj3X76MWuA11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:267b3b83b349cf8620179168c317ffa6962e99dad52b22ee0d30a0fadef5cf5b",
+				"DiscoKey":   "discokey:4848bae7f36e1fbbcb2c28df6d01bceaafae35625a2c44fd2f1d3770ab0a836d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53278", "10.65.0.27:53278", "172.17.0.1:53278"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:53:21.60722728Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4162529281909508,
+				"StableID":   "n7JNjyaDWZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:2ace03bcf2108c1a201c307a69989936bea9f7f7d9aeae7f442e1af9ca013a32",
+				"KeyExpiry":  "2026-11-08T18:53:22Z",
+				"DiscoKey":   "discokey:7d9f40e1e69f473a22adf865350d2d8799e6e51e5990e930ee14212798ba843d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:58061", "10.65.0.27:58061", "172.17.0.1:58061"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:53:22.148599211Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         462010508099750,
+				"StableID":   "nwfAXVEFc411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ae26fddf955389254a6d2a10edbe1158fc791500cfc9c4353c062929e07bc21b",
+				"KeyExpiry":  "2026-11-08T18:53:22Z",
+				"DiscoKey":   "discokey:e7d7a7e9e83b524330f67660934b944d1ea50ab079955a88e91a234c4b9e1200",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:33110", "10.65.0.27:33110", "172.17.0.1:33110"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:53:22.692243454Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1538947703875679,
+				"StableID":   "npPLihYz1D11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:85e6516547038b86b75be2f4353665b54d83b94a2209c3ceacd816f0ef96f073",
+				"KeyExpiry":  "2026-11-08T18:53:23Z",
+				"DiscoKey":   "discokey:8e25ef80188ce5f33e7e93fd2daf1f6f0fbf6085a7dfaa0eed611d69da17f10a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:50256", "10.65.0.27:50256", "172.17.0.1:50256"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:53:23.234818434Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2207964944873001": {
+				"ID":          2207964944873001,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         462010508099750,
+				"StableID":   "nwfAXVEFc411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ae26fddf955389254a6d2a10edbe1158fc791500cfc9c4353c062929e07bc21b",
+				"KeyExpiry":  "2026-11-08T18:53:22Z",
+				"DiscoKey":   "discokey:e7d7a7e9e83b524330f67660934b944d1ea50ab079955a88e91a234c4b9e1200",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:33110", "10.65.0.27:33110", "172.17.0.1:33110"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:53:22.692243454Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ae26fddf955389254a6d2a10edbe1158fc791500cfc9c4353c062929e07bc21b",
+			"MachineKey": "mkey:93b5f88bde07719744d2c7295aa7a4a07caecf040818607d69b56ae46f02b836",
+			"Peers": [{
+				"ID":         6394954766560326,
+				"StableID":   "nF5BEqcHwr11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc3afd4f66228fee158888f1198442f9f7f875eff1fe22b034eb57de755e311b",
+				"DiscoKey":   "discokey:1f7452d562b377202e48329117391f589c15889d9ff108f9d7e379d3826a9373",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:58819", "10.65.0.27:58819", "172.17.0.1:58819"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:53:15.684556003Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3359264466207676,
+				"StableID":   "nb4rcWBRET11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d83f04ed7c3569414dcb92d01458a16bcfc5705a5bea10b4cc74af52d4fd3502",
+				"DiscoKey":   "discokey:5ec328efb87a8cc81cf61d619b3d9c2443889bb475bc325105576e1c2af8d675",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:48436", "10.65.0.27:48436", "172.17.0.1:48436"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:53:16.219864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6235546803700390,
+				"StableID":   "njq8RyE6hq11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0873d6c3d466cf9c8b45a58d8d980bd211d44d8586532d1f390c71dd5446de69",
+				"DiscoKey":   "discokey:c2fbc208776a6190ee6e05dbbf786a3d3db118f5109d9f79a2cb10db5200f603",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:35290", "10.65.0.27:35290", "172.17.0.1:35290"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:53:16.754794566Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7391643971333630,
+				"StableID":   "njjZFHxgiz11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:00490f66c391f2194192492702b82fdae51e8e5e475c4bfae3a45b821bf1e40f",
+				"DiscoKey":   "discokey:d08cd458c2ee3d20e462f653870f0e0880cc11cb199804c796c2652a6316da53",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:38472", "10.65.0.27:38472", "172.17.0.1:38472"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:53:17.278735389Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8485194050284806,
+				"StableID":   "nVJR3FfxF921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:74d9254e7a4e2c9184306736e424ca213c6a6dd4179c42fb657b99c2578f5673",
+				"DiscoKey":   "discokey:e25b8f5616f681bd86f517b4be1e1d372b13cb0103cc4879a56c52ebdb663b15",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:54589", "10.65.0.27:54589", "172.17.0.1:54589"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:53:17.823217253Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2679441641167704,
+				"StableID":   "nFEmWXPXvM11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0751abdee2bc9475bd52e77be0060d5122f5c3c307fd1eb022b19d987f3e1d59",
+				"DiscoKey":   "discokey:8e4eeb7e2be3852cce0f107762030e7db0e16855aa7478e203d7b544a1b38654",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:36715", "10.65.0.27:36715", "172.17.0.1:36715"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:53:18.41482324Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7320202710043211,
+				"StableID":   "nAGYd7KLAz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1da037e6dae2406c92eaf71f0914572c42efffd1c524ec7d8366450bb8c61074",
+				"DiscoKey":   "discokey:0b42d2d9fcac03bd35491165e3e5630091eadd59928ebef6cc6441adbca80278",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:47182", "10.65.0.27:47182", "172.17.0.1:47182"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:53:18.92365686Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8476196647412387,
+				"StableID":   "n89tM9KtB921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:814d7d401caec803d349cb1e32b72675014c39e0062ae5df969e44cc4455a93f",
+				"DiscoKey":   "discokey:ee6be9f35ca3352a90dfffe18988c0ac266fbeda7d88268cd96d2788b4ef7028",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:37759", "10.65.0.27:37759", "172.17.0.1:37759"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:53:19.475238223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2207964944873001,
+				"StableID":   "n2FkMiVzEJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3edf21b43cfe9f2d5914689b74b8907414ab275cf10cef54851087c5bac8839",
+				"DiscoKey":   "discokey:f8f229627c5bacf0711ed19514aa1a97ac2cf82309e26bbe0a58f895a4b84539",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:34868", "10.65.0.27:34868", "172.17.0.1:34868"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:53:19.998408749Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         8843890274027626,
+				"StableID":   "nmG7341R4C21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9386a42db11e0ca68e4843223543ef47db9ecd78754cb47075d17a966508fb4d",
+				"DiscoKey":   "discokey:794f8ce28388d192645a60d86d655b38c329549df563fefb8a6c51dd9a7ca87b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:34307", "10.65.0.27:34307", "172.17.0.1:34307"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:53:20.537116622Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7474346318038758,
+				"StableID":   "nVgrRQQ9N121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e303c97d0da36dbf1d59e3e3f2ebc6969c7f536a87ab34a35ff8e0055a429177",
+				"DiscoKey":   "discokey:5d6909df424d734468aeffd3bed0ee7fe9bf4a2fcce531a11ca9cd3c9925175b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:36397", "10.65.0.27:36397", "172.17.0.1:36397"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:53:21.070932133Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1268500089248214,
+				"StableID":   "nj3X76MWuA11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:267b3b83b349cf8620179168c317ffa6962e99dad52b22ee0d30a0fadef5cf5b",
+				"DiscoKey":   "discokey:4848bae7f36e1fbbcb2c28df6d01bceaafae35625a2c44fd2f1d3770ab0a836d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53278", "10.65.0.27:53278", "172.17.0.1:53278"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:53:21.60722728Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4162529281909508,
+				"StableID":   "n7JNjyaDWZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:2ace03bcf2108c1a201c307a69989936bea9f7f7d9aeae7f442e1af9ca013a32",
+				"KeyExpiry":  "2026-11-08T18:53:22Z",
+				"DiscoKey":   "discokey:7d9f40e1e69f473a22adf865350d2d8799e6e51e5990e930ee14212798ba843d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:58061", "10.65.0.27:58061", "172.17.0.1:58061"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:53:22.148599211Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         1538947703875679,
+				"StableID":   "npPLihYz1D11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:85e6516547038b86b75be2f4353665b54d83b94a2209c3ceacd816f0ef96f073",
+				"KeyExpiry":  "2026-11-08T18:53:23Z",
+				"DiscoKey":   "discokey:8e25ef80188ce5f33e7e93fd2daf1f6f0fbf6085a7dfaa0eed611d69da17f10a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:50256", "10.65.0.27:50256", "172.17.0.1:50256"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:53:23.234818434Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8843890274027626,
+				"StableID":   "nmG7341R4C21CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       8843890274027626,
+				"Key":        "nodekey:9386a42db11e0ca68e4843223543ef47db9ecd78754cb47075d17a966508fb4d",
+				"DiscoKey":   "discokey:794f8ce28388d192645a60d86d655b38c329549df563fefb8a6c51dd9a7ca87b",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:34307", "10.65.0.27:34307", "172.17.0.1:34307"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:53:20.537116622Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9386a42db11e0ca68e4843223543ef47db9ecd78754cb47075d17a966508fb4d",
+			"MachineKey": "mkey:10a18a984229a324f155ac41aea529e5678837612febd7b1537ac5ae48ef4a17",
+			"Peers": [{
+				"ID":         6394954766560326,
+				"StableID":   "nF5BEqcHwr11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc3afd4f66228fee158888f1198442f9f7f875eff1fe22b034eb57de755e311b",
+				"DiscoKey":   "discokey:1f7452d562b377202e48329117391f589c15889d9ff108f9d7e379d3826a9373",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:58819", "10.65.0.27:58819", "172.17.0.1:58819"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:53:15.684556003Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         3359264466207676,
+				"StableID":   "nb4rcWBRET11CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d83f04ed7c3569414dcb92d01458a16bcfc5705a5bea10b4cc74af52d4fd3502",
+				"DiscoKey":   "discokey:5ec328efb87a8cc81cf61d619b3d9c2443889bb475bc325105576e1c2af8d675",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:48436", "10.65.0.27:48436", "172.17.0.1:48436"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:53:16.219864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         6235546803700390,
+				"StableID":   "njq8RyE6hq11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0873d6c3d466cf9c8b45a58d8d980bd211d44d8586532d1f390c71dd5446de69",
+				"DiscoKey":   "discokey:c2fbc208776a6190ee6e05dbbf786a3d3db118f5109d9f79a2cb10db5200f603",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:35290", "10.65.0.27:35290", "172.17.0.1:35290"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:53:16.754794566Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         7391643971333630,
+				"StableID":   "njjZFHxgiz11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:00490f66c391f2194192492702b82fdae51e8e5e475c4bfae3a45b821bf1e40f",
+				"DiscoKey":   "discokey:d08cd458c2ee3d20e462f653870f0e0880cc11cb199804c796c2652a6316da53",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:38472", "10.65.0.27:38472", "172.17.0.1:38472"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:53:17.278735389Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8485194050284806,
+				"StableID":   "nVJR3FfxF921CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:74d9254e7a4e2c9184306736e424ca213c6a6dd4179c42fb657b99c2578f5673",
+				"DiscoKey":   "discokey:e25b8f5616f681bd86f517b4be1e1d372b13cb0103cc4879a56c52ebdb663b15",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:54589", "10.65.0.27:54589", "172.17.0.1:54589"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:53:17.823217253Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2679441641167704,
+				"StableID":   "nFEmWXPXvM11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0751abdee2bc9475bd52e77be0060d5122f5c3c307fd1eb022b19d987f3e1d59",
+				"DiscoKey":   "discokey:8e4eeb7e2be3852cce0f107762030e7db0e16855aa7478e203d7b544a1b38654",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:36715", "10.65.0.27:36715", "172.17.0.1:36715"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:53:18.41482324Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         7320202710043211,
+				"StableID":   "nAGYd7KLAz11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1da037e6dae2406c92eaf71f0914572c42efffd1c524ec7d8366450bb8c61074",
+				"DiscoKey":   "discokey:0b42d2d9fcac03bd35491165e3e5630091eadd59928ebef6cc6441adbca80278",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:47182", "10.65.0.27:47182", "172.17.0.1:47182"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:53:18.92365686Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         8476196647412387,
+				"StableID":   "n89tM9KtB921CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:814d7d401caec803d349cb1e32b72675014c39e0062ae5df969e44cc4455a93f",
+				"DiscoKey":   "discokey:ee6be9f35ca3352a90dfffe18988c0ac266fbeda7d88268cd96d2788b4ef7028",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:37759", "10.65.0.27:37759", "172.17.0.1:37759"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:53:19.475238223Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2207964944873001,
+				"StableID":   "n2FkMiVzEJ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e3edf21b43cfe9f2d5914689b74b8907414ab275cf10cef54851087c5bac8839",
+				"DiscoKey":   "discokey:f8f229627c5bacf0711ed19514aa1a97ac2cf82309e26bbe0a58f895a4b84539",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:34868", "10.65.0.27:34868", "172.17.0.1:34868"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:53:19.998408749Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7474346318038758,
+				"StableID":   "nVgrRQQ9N121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e303c97d0da36dbf1d59e3e3f2ebc6969c7f536a87ab34a35ff8e0055a429177",
+				"DiscoKey":   "discokey:5d6909df424d734468aeffd3bed0ee7fe9bf4a2fcce531a11ca9cd3c9925175b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:36397", "10.65.0.27:36397", "172.17.0.1:36397"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:53:21.070932133Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         1268500089248214,
+				"StableID":   "nj3X76MWuA11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:267b3b83b349cf8620179168c317ffa6962e99dad52b22ee0d30a0fadef5cf5b",
+				"DiscoKey":   "discokey:4848bae7f36e1fbbcb2c28df6d01bceaafae35625a2c44fd2f1d3770ab0a836d",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:53278", "10.65.0.27:53278", "172.17.0.1:53278"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:53:21.60722728Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4162529281909508,
+				"StableID":   "n7JNjyaDWZ11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:2ace03bcf2108c1a201c307a69989936bea9f7f7d9aeae7f442e1af9ca013a32",
+				"KeyExpiry":  "2026-11-08T18:53:22Z",
+				"DiscoKey":   "discokey:7d9f40e1e69f473a22adf865350d2d8799e6e51e5990e930ee14212798ba843d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:58061", "10.65.0.27:58061", "172.17.0.1:58061"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:53:22.148599211Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         462010508099750,
+				"StableID":   "nwfAXVEFc411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ae26fddf955389254a6d2a10edbe1158fc791500cfc9c4353c062929e07bc21b",
+				"KeyExpiry":  "2026-11-08T18:53:22Z",
+				"DiscoKey":   "discokey:e7d7a7e9e83b524330f67660934b944d1ea50ab079955a88e91a234c4b9e1200",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:33110", "10.65.0.27:33110", "172.17.0.1:33110"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:53:22.692243454Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         1538947703875679,
+				"StableID":   "npPLihYz1D11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:85e6516547038b86b75be2f4353665b54d83b94a2209c3ceacd816f0ef96f073",
+				"KeyExpiry":  "2026-11-08T18:53:23Z",
+				"DiscoKey":   "discokey:8e25ef80188ce5f33e7e93fd2daf1f6f0fbf6085a7dfaa0eed611d69da17f10a",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:50256", "10.65.0.27:50256", "172.17.0.1:50256"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:53:23.234818434Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8843890274027626": {
+				"ID":          8843890274027626,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/sshtest_results/sshtest-user-nonroot-allows-alice.hujson
+++ b/hscontrol/policy/v2/testdata/sshtest_results/sshtest-user-nonroot-allows-alice.hujson
@@ -1,0 +1,18751 @@
+// sshtest-user-nonroot-allows-alice
+//
+// autogroup:nonroot allows literal non-root user
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T18:53:59Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "sshtest-user-nonroot-allows-alice",
+	"description":    "autogroup:nonroot allows literal non-root user",
+	"category":       "sshtest",
+	"captured_at":    "2026-05-12T18:53:59.269160314Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                    \n  \n                                                                 \n                              \n{\n\t\"category\":    \"sshtest\",\n\t\"description\": \"autogroup:nonroot allows literal non-root user\",\n\t\"id\":          \"sshtest-user-nonroot-allows-alice\",\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"thor@example.org\"],\n\t\t\"users\":  [\"autogroup:nonroot\"]\n\t}], \"sshTests\": [{\n\t\t\"accept\": [\"alice\"],\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    \"thor@example.org\"\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/sshtest/sshtest-user-nonroot-allows-alice.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["thor@example.org"],
+				"users":  ["autogroup:nonroot"]
+			}],
+			"sshTests": [
+				{"accept": ["alice"], "dst": ["tag:server"], "src": "thor@example.org"}
+			],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4068015540225939,
+				"StableID":   "nk5T2UsQmY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       4068015540225939,
+				"Key":        "nodekey:f14f126ce109498d01ace3748777b88f799e67615a6a022d3b71ae834c623031",
+				"DiscoKey":   "discokey:f874d5cd4880492ccf5a38963abe2eab3544deda67d88e71fa5fe51b1c4ff042",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:60376", "10.65.0.27:60376", "172.17.0.1:60376"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:54:07.810914912Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f14f126ce109498d01ace3748777b88f799e67615a6a022d3b71ae834c623031",
+			"MachineKey": "mkey:2f3e806ce51daae33f01f68faad948bc7d0b8fe194e2e2534547bf8039771732",
+			"Peers": [{
+				"ID":         3897792547780688,
+				"StableID":   "nD7s5FQKSX11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f0076188b775e0689535fb9c31d990bf5d95c7df7725049479cd4b87c89df519",
+				"DiscoKey":   "discokey:6d49012f263f61418941da9f8eb54bf302bf5c3159cd92488d52d8774822db01",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:34760", "10.65.0.27:34760", "172.17.0.1:34760"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:54:01.897993709Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8026726004641457,
+				"StableID":   "n2PJouUKg521CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f3731c586c67c0695183f81823b207e37746a68ebe7789ea7a792c3a0d87ab40",
+				"DiscoKey":   "discokey:9644510e21b3a4e74a47d62d910c126bc9fd819787ed82ba78228dfdd71b8f62",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:59407", "10.65.0.27:59407", "172.17.0.1:59407"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:54:02.423058011Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8114285204469608,
+				"StableID":   "nTaNTkWyM621CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7da79e0e97e32fc2f6403acf69d5d2fd54bd3f87fa3eb771befc3f49ac378615",
+				"DiscoKey":   "discokey:23b158ddffae6c88a2374cb060e5967689a909273a530e48ade94d9ff72fa46c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:57732", "10.65.0.27:57732", "172.17.0.1:57732"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:54:02.954874551Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3097057685873505,
+				"StableID":   "ntkqKKTfBR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc921135f0e6ebcfcc5600a13dca256b2a80af11c8da666451a7e254c97a341a",
+				"DiscoKey":   "discokey:ce291560b52a2ec4b7925bb04c67df5a58bebba9a5383ac8c65074c70eea362c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:59502", "10.65.0.27:59502", "172.17.0.1:59502"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:54:03.504634091Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8355216193210735,
+				"StableID":   "neiDuxM6F821CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:622c88ebee766d76f57395143cad7c1830291116d0075d9578d4c0a27a470803",
+				"DiscoKey":   "discokey:4a07a9cc2b8e3ceb63a0801d86d14a62e2643c4a3426c74c86f6ca74762c3333",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:39103", "10.65.0.27:39103", "172.17.0.1:39103"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:54:04.03346603Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3399209927040729,
+				"StableID":   "nnmtCtUWYT11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0dbadfeecb60fa9a7b973a25c603c58676ad9ee4def449a9014b0b0079a8745",
+				"DiscoKey":   "discokey:0f0435a0f9a6c4c4549f9e93eb72464480572bb5f98428c590e1355398b1da13",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:42460", "10.65.0.27:42460", "172.17.0.1:42460"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:54:04.574472809Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6699531214773499,
+				"StableID":   "nAkzypKEKu11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2e5c883ef9f2b0bb7ad6af707b2ea54b1978fc4111dd182eb86d6326a20dd05f",
+				"DiscoKey":   "discokey:269a74b5128ef83f23505f1c7f2ec786a7ac36938fb85d1c81a9bc1c2e66cd22",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:45169", "10.65.0.27:45169", "172.17.0.1:45169"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:54:05.114383269Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1796629266396125,
+				"StableID":   "nAuC1TQh2F11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:be89e50a1192633e769f46977dfe73da5a62f99d94595e2e782e51e07f39f628",
+				"DiscoKey":   "discokey:4456bfa73aebb6eabc38eb540de896172c9c8570a0e1b6f8ed17f93e89f3834b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:48260", "10.65.0.27:48260", "172.17.0.1:48260"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:54:05.660135064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2055350009717276,
+				"StableID":   "nVwJ9TZs3H11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f44944ff66452fb41228da3b0c34069a3b3ab0397c8be3257b046bdbf0b12d67",
+				"DiscoKey":   "discokey:99d2a0e3b4cd50cb81eb1c502be6d7be8828b09deae5acd7bb7feb950ecb8e20",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:35937", "10.65.0.27:35937", "172.17.0.1:35937"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:54:06.201220848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7724217180562942,
+				"StableID":   "nyzcu46KK321CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c045f71411b49ee2f33ab527ce55537be3db2b0eb051b5f440e58ab5b1811132",
+				"DiscoKey":   "discokey:a1232e943d46aa1d283ef3580487d26d2608bd960a53ed7a38cf4332983e390d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:36234", "10.65.0.27:36234", "172.17.0.1:36234"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:54:06.743488658Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6188909096033515,
+				"StableID":   "nApntY9yKq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af5acad95fc45f5a94cc110e06761a4b826e19bc71eba9fa18f3cba095af096d",
+				"DiscoKey":   "discokey:e48fbefb05535c81445efa3f127ce009c2ec90aea6130308332bb73481428b71",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47189", "10.65.0.27:47189", "172.17.0.1:47189"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:54:07.284202203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         501181918424048,
+				"StableID":   "nKe2vYCzu411CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:c0c227f5ce6d8644c1ff81c05c4b4d741eecfe2438a85140473b110bb7392512",
+				"KeyExpiry":  "2026-11-08T18:54:08Z",
+				"DiscoKey":   "discokey:fea44965172d48ffb62ca95de54f03da1b076bd674ad751777400488bd20aa3a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:49629", "10.65.0.27:49629", "172.17.0.1:49629"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:54:08.357636418Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6539306956443726,
+				"StableID":   "nsdJwHWf4t11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:475fa9a81df138253d4abf021798012727018f41e89066f8e0cf389704dbac32",
+				"KeyExpiry":  "2026-11-08T18:54:08Z",
+				"DiscoKey":   "discokey:048f9cafcb3f558233acffaa72af90f5118a1bfde49a474e6aa0462920f0902f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:38213", "10.65.0.27:38213", "172.17.0.1:38213"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:54:08.896426382Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4469060208632458,
+				"StableID":   "n1vR4kd3ub11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2126353cbdbca8ac938b1e2a0078088feb8304f384e5ce69213819ead0fffa45",
+				"KeyExpiry":  "2026-11-08T18:54:09Z",
+				"DiscoKey":   "discokey:c48b4d2fd6e3b2c2abff711c2d5c9b6c55bce0a5703d52e6f9ebcced7aea8a02",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:35491", "10.65.0.27:35491", "172.17.0.1:35491"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:54:09.433930198Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{
+				"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+				"sshUsers":   {"*": "=", "root": ""},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				}
+			}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4068015540225939": {
+				"ID":          4068015540225939,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		},
+		"ssh_rules": [{
+			"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+			"sshUsers":   {"*": "=", "root": ""},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}
+		}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3399209927040729,
+				"StableID":   "nnmtCtUWYT11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       3399209927040729,
+				"Key":        "nodekey:e0dbadfeecb60fa9a7b973a25c603c58676ad9ee4def449a9014b0b0079a8745",
+				"DiscoKey":   "discokey:0f0435a0f9a6c4c4549f9e93eb72464480572bb5f98428c590e1355398b1da13",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:42460", "10.65.0.27:42460", "172.17.0.1:42460"],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:54:04.574472809Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e0dbadfeecb60fa9a7b973a25c603c58676ad9ee4def449a9014b0b0079a8745",
+			"MachineKey": "mkey:86a757e63b9e45c7a5b5d70d4e409ec20a71460227735c4f21f4c73d497db871",
+			"Peers": [{
+				"ID":         3897792547780688,
+				"StableID":   "nD7s5FQKSX11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f0076188b775e0689535fb9c31d990bf5d95c7df7725049479cd4b87c89df519",
+				"DiscoKey":   "discokey:6d49012f263f61418941da9f8eb54bf302bf5c3159cd92488d52d8774822db01",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:34760", "10.65.0.27:34760", "172.17.0.1:34760"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:54:01.897993709Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8026726004641457,
+				"StableID":   "n2PJouUKg521CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f3731c586c67c0695183f81823b207e37746a68ebe7789ea7a792c3a0d87ab40",
+				"DiscoKey":   "discokey:9644510e21b3a4e74a47d62d910c126bc9fd819787ed82ba78228dfdd71b8f62",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:59407", "10.65.0.27:59407", "172.17.0.1:59407"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:54:02.423058011Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8114285204469608,
+				"StableID":   "nTaNTkWyM621CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7da79e0e97e32fc2f6403acf69d5d2fd54bd3f87fa3eb771befc3f49ac378615",
+				"DiscoKey":   "discokey:23b158ddffae6c88a2374cb060e5967689a909273a530e48ade94d9ff72fa46c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:57732", "10.65.0.27:57732", "172.17.0.1:57732"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:54:02.954874551Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3097057685873505,
+				"StableID":   "ntkqKKTfBR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc921135f0e6ebcfcc5600a13dca256b2a80af11c8da666451a7e254c97a341a",
+				"DiscoKey":   "discokey:ce291560b52a2ec4b7925bb04c67df5a58bebba9a5383ac8c65074c70eea362c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:59502", "10.65.0.27:59502", "172.17.0.1:59502"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:54:03.504634091Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8355216193210735,
+				"StableID":   "neiDuxM6F821CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:622c88ebee766d76f57395143cad7c1830291116d0075d9578d4c0a27a470803",
+				"DiscoKey":   "discokey:4a07a9cc2b8e3ceb63a0801d86d14a62e2643c4a3426c74c86f6ca74762c3333",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:39103", "10.65.0.27:39103", "172.17.0.1:39103"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:54:04.03346603Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         6699531214773499,
+				"StableID":   "nAkzypKEKu11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2e5c883ef9f2b0bb7ad6af707b2ea54b1978fc4111dd182eb86d6326a20dd05f",
+				"DiscoKey":   "discokey:269a74b5128ef83f23505f1c7f2ec786a7ac36938fb85d1c81a9bc1c2e66cd22",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:45169", "10.65.0.27:45169", "172.17.0.1:45169"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:54:05.114383269Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1796629266396125,
+				"StableID":   "nAuC1TQh2F11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:be89e50a1192633e769f46977dfe73da5a62f99d94595e2e782e51e07f39f628",
+				"DiscoKey":   "discokey:4456bfa73aebb6eabc38eb540de896172c9c8570a0e1b6f8ed17f93e89f3834b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:48260", "10.65.0.27:48260", "172.17.0.1:48260"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:54:05.660135064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2055350009717276,
+				"StableID":   "nVwJ9TZs3H11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f44944ff66452fb41228da3b0c34069a3b3ab0397c8be3257b046bdbf0b12d67",
+				"DiscoKey":   "discokey:99d2a0e3b4cd50cb81eb1c502be6d7be8828b09deae5acd7bb7feb950ecb8e20",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:35937", "10.65.0.27:35937", "172.17.0.1:35937"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:54:06.201220848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7724217180562942,
+				"StableID":   "nyzcu46KK321CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c045f71411b49ee2f33ab527ce55537be3db2b0eb051b5f440e58ab5b1811132",
+				"DiscoKey":   "discokey:a1232e943d46aa1d283ef3580487d26d2608bd960a53ed7a38cf4332983e390d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:36234", "10.65.0.27:36234", "172.17.0.1:36234"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:54:06.743488658Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6188909096033515,
+				"StableID":   "nApntY9yKq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af5acad95fc45f5a94cc110e06761a4b826e19bc71eba9fa18f3cba095af096d",
+				"DiscoKey":   "discokey:e48fbefb05535c81445efa3f127ce009c2ec90aea6130308332bb73481428b71",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47189", "10.65.0.27:47189", "172.17.0.1:47189"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:54:07.284202203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4068015540225939,
+				"StableID":   "nk5T2UsQmY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f14f126ce109498d01ace3748777b88f799e67615a6a022d3b71ae834c623031",
+				"DiscoKey":   "discokey:f874d5cd4880492ccf5a38963abe2eab3544deda67d88e71fa5fe51b1c4ff042",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:60376", "10.65.0.27:60376", "172.17.0.1:60376"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:54:07.810914912Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         501181918424048,
+				"StableID":   "nKe2vYCzu411CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:c0c227f5ce6d8644c1ff81c05c4b4d741eecfe2438a85140473b110bb7392512",
+				"KeyExpiry":  "2026-11-08T18:54:08Z",
+				"DiscoKey":   "discokey:fea44965172d48ffb62ca95de54f03da1b076bd674ad751777400488bd20aa3a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:49629", "10.65.0.27:49629", "172.17.0.1:49629"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:54:08.357636418Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6539306956443726,
+				"StableID":   "nsdJwHWf4t11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:475fa9a81df138253d4abf021798012727018f41e89066f8e0cf389704dbac32",
+				"KeyExpiry":  "2026-11-08T18:54:08Z",
+				"DiscoKey":   "discokey:048f9cafcb3f558233acffaa72af90f5118a1bfde49a474e6aa0462920f0902f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:38213", "10.65.0.27:38213", "172.17.0.1:38213"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:54:08.896426382Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4469060208632458,
+				"StableID":   "n1vR4kd3ub11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2126353cbdbca8ac938b1e2a0078088feb8304f384e5ce69213819ead0fffa45",
+				"KeyExpiry":  "2026-11-08T18:54:09Z",
+				"DiscoKey":   "discokey:c48b4d2fd6e3b2c2abff711c2d5c9b6c55bce0a5703d52e6f9ebcced7aea8a02",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:35491", "10.65.0.27:35491", "172.17.0.1:35491"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:54:09.433930198Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3399209927040729": {
+				"ID":          3399209927040729,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4469060208632458,
+				"StableID":   "n1vR4kd3ub11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2126353cbdbca8ac938b1e2a0078088feb8304f384e5ce69213819ead0fffa45",
+				"KeyExpiry":  "2026-11-08T18:54:09Z",
+				"DiscoKey":   "discokey:c48b4d2fd6e3b2c2abff711c2d5c9b6c55bce0a5703d52e6f9ebcced7aea8a02",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:35491", "10.65.0.27:35491", "172.17.0.1:35491"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:54:09.433930198Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2126353cbdbca8ac938b1e2a0078088feb8304f384e5ce69213819ead0fffa45",
+			"MachineKey": "mkey:0ee6b30a0dfc332e06343b082b754d8aaa6c20e68d7d8622260f26bce7352917",
+			"Peers": [{
+				"ID":         3897792547780688,
+				"StableID":   "nD7s5FQKSX11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f0076188b775e0689535fb9c31d990bf5d95c7df7725049479cd4b87c89df519",
+				"DiscoKey":   "discokey:6d49012f263f61418941da9f8eb54bf302bf5c3159cd92488d52d8774822db01",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:34760", "10.65.0.27:34760", "172.17.0.1:34760"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:54:01.897993709Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8026726004641457,
+				"StableID":   "n2PJouUKg521CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f3731c586c67c0695183f81823b207e37746a68ebe7789ea7a792c3a0d87ab40",
+				"DiscoKey":   "discokey:9644510e21b3a4e74a47d62d910c126bc9fd819787ed82ba78228dfdd71b8f62",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:59407", "10.65.0.27:59407", "172.17.0.1:59407"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:54:02.423058011Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8114285204469608,
+				"StableID":   "nTaNTkWyM621CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7da79e0e97e32fc2f6403acf69d5d2fd54bd3f87fa3eb771befc3f49ac378615",
+				"DiscoKey":   "discokey:23b158ddffae6c88a2374cb060e5967689a909273a530e48ade94d9ff72fa46c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:57732", "10.65.0.27:57732", "172.17.0.1:57732"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:54:02.954874551Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3097057685873505,
+				"StableID":   "ntkqKKTfBR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc921135f0e6ebcfcc5600a13dca256b2a80af11c8da666451a7e254c97a341a",
+				"DiscoKey":   "discokey:ce291560b52a2ec4b7925bb04c67df5a58bebba9a5383ac8c65074c70eea362c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:59502", "10.65.0.27:59502", "172.17.0.1:59502"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:54:03.504634091Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8355216193210735,
+				"StableID":   "neiDuxM6F821CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:622c88ebee766d76f57395143cad7c1830291116d0075d9578d4c0a27a470803",
+				"DiscoKey":   "discokey:4a07a9cc2b8e3ceb63a0801d86d14a62e2643c4a3426c74c86f6ca74762c3333",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:39103", "10.65.0.27:39103", "172.17.0.1:39103"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:54:04.03346603Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3399209927040729,
+				"StableID":   "nnmtCtUWYT11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0dbadfeecb60fa9a7b973a25c603c58676ad9ee4def449a9014b0b0079a8745",
+				"DiscoKey":   "discokey:0f0435a0f9a6c4c4549f9e93eb72464480572bb5f98428c590e1355398b1da13",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:42460", "10.65.0.27:42460", "172.17.0.1:42460"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:54:04.574472809Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6699531214773499,
+				"StableID":   "nAkzypKEKu11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2e5c883ef9f2b0bb7ad6af707b2ea54b1978fc4111dd182eb86d6326a20dd05f",
+				"DiscoKey":   "discokey:269a74b5128ef83f23505f1c7f2ec786a7ac36938fb85d1c81a9bc1c2e66cd22",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:45169", "10.65.0.27:45169", "172.17.0.1:45169"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:54:05.114383269Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1796629266396125,
+				"StableID":   "nAuC1TQh2F11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:be89e50a1192633e769f46977dfe73da5a62f99d94595e2e782e51e07f39f628",
+				"DiscoKey":   "discokey:4456bfa73aebb6eabc38eb540de896172c9c8570a0e1b6f8ed17f93e89f3834b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:48260", "10.65.0.27:48260", "172.17.0.1:48260"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:54:05.660135064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2055350009717276,
+				"StableID":   "nVwJ9TZs3H11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f44944ff66452fb41228da3b0c34069a3b3ab0397c8be3257b046bdbf0b12d67",
+				"DiscoKey":   "discokey:99d2a0e3b4cd50cb81eb1c502be6d7be8828b09deae5acd7bb7feb950ecb8e20",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:35937", "10.65.0.27:35937", "172.17.0.1:35937"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:54:06.201220848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7724217180562942,
+				"StableID":   "nyzcu46KK321CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c045f71411b49ee2f33ab527ce55537be3db2b0eb051b5f440e58ab5b1811132",
+				"DiscoKey":   "discokey:a1232e943d46aa1d283ef3580487d26d2608bd960a53ed7a38cf4332983e390d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:36234", "10.65.0.27:36234", "172.17.0.1:36234"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:54:06.743488658Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6188909096033515,
+				"StableID":   "nApntY9yKq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af5acad95fc45f5a94cc110e06761a4b826e19bc71eba9fa18f3cba095af096d",
+				"DiscoKey":   "discokey:e48fbefb05535c81445efa3f127ce009c2ec90aea6130308332bb73481428b71",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47189", "10.65.0.27:47189", "172.17.0.1:47189"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:54:07.284202203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4068015540225939,
+				"StableID":   "nk5T2UsQmY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f14f126ce109498d01ace3748777b88f799e67615a6a022d3b71ae834c623031",
+				"DiscoKey":   "discokey:f874d5cd4880492ccf5a38963abe2eab3544deda67d88e71fa5fe51b1c4ff042",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:60376", "10.65.0.27:60376", "172.17.0.1:60376"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:54:07.810914912Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         501181918424048,
+				"StableID":   "nKe2vYCzu411CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:c0c227f5ce6d8644c1ff81c05c4b4d741eecfe2438a85140473b110bb7392512",
+				"KeyExpiry":  "2026-11-08T18:54:08Z",
+				"DiscoKey":   "discokey:fea44965172d48ffb62ca95de54f03da1b076bd674ad751777400488bd20aa3a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:49629", "10.65.0.27:49629", "172.17.0.1:49629"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:54:08.357636418Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6539306956443726,
+				"StableID":   "nsdJwHWf4t11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:475fa9a81df138253d4abf021798012727018f41e89066f8e0cf389704dbac32",
+				"KeyExpiry":  "2026-11-08T18:54:08Z",
+				"DiscoKey":   "discokey:048f9cafcb3f558233acffaa72af90f5118a1bfde49a474e6aa0462920f0902f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:38213", "10.65.0.27:38213", "172.17.0.1:38213"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:54:08.896426382Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8114285204469608,
+				"StableID":   "nTaNTkWyM621CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       8114285204469608,
+				"Key":        "nodekey:7da79e0e97e32fc2f6403acf69d5d2fd54bd3f87fa3eb771befc3f49ac378615",
+				"DiscoKey":   "discokey:23b158ddffae6c88a2374cb060e5967689a909273a530e48ade94d9ff72fa46c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:57732", "10.65.0.27:57732", "172.17.0.1:57732"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:54:02.954874551Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7da79e0e97e32fc2f6403acf69d5d2fd54bd3f87fa3eb771befc3f49ac378615",
+			"MachineKey": "mkey:a06d723568a04056b3eefa93b07712d8f1f3d45ff844ca97d7a58c1f0b1aa259",
+			"Peers": [{
+				"ID":         3897792547780688,
+				"StableID":   "nD7s5FQKSX11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f0076188b775e0689535fb9c31d990bf5d95c7df7725049479cd4b87c89df519",
+				"DiscoKey":   "discokey:6d49012f263f61418941da9f8eb54bf302bf5c3159cd92488d52d8774822db01",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:34760", "10.65.0.27:34760", "172.17.0.1:34760"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:54:01.897993709Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8026726004641457,
+				"StableID":   "n2PJouUKg521CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f3731c586c67c0695183f81823b207e37746a68ebe7789ea7a792c3a0d87ab40",
+				"DiscoKey":   "discokey:9644510e21b3a4e74a47d62d910c126bc9fd819787ed82ba78228dfdd71b8f62",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:59407", "10.65.0.27:59407", "172.17.0.1:59407"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:54:02.423058011Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         3097057685873505,
+				"StableID":   "ntkqKKTfBR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc921135f0e6ebcfcc5600a13dca256b2a80af11c8da666451a7e254c97a341a",
+				"DiscoKey":   "discokey:ce291560b52a2ec4b7925bb04c67df5a58bebba9a5383ac8c65074c70eea362c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:59502", "10.65.0.27:59502", "172.17.0.1:59502"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:54:03.504634091Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8355216193210735,
+				"StableID":   "neiDuxM6F821CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:622c88ebee766d76f57395143cad7c1830291116d0075d9578d4c0a27a470803",
+				"DiscoKey":   "discokey:4a07a9cc2b8e3ceb63a0801d86d14a62e2643c4a3426c74c86f6ca74762c3333",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:39103", "10.65.0.27:39103", "172.17.0.1:39103"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:54:04.03346603Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3399209927040729,
+				"StableID":   "nnmtCtUWYT11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0dbadfeecb60fa9a7b973a25c603c58676ad9ee4def449a9014b0b0079a8745",
+				"DiscoKey":   "discokey:0f0435a0f9a6c4c4549f9e93eb72464480572bb5f98428c590e1355398b1da13",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:42460", "10.65.0.27:42460", "172.17.0.1:42460"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:54:04.574472809Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6699531214773499,
+				"StableID":   "nAkzypKEKu11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2e5c883ef9f2b0bb7ad6af707b2ea54b1978fc4111dd182eb86d6326a20dd05f",
+				"DiscoKey":   "discokey:269a74b5128ef83f23505f1c7f2ec786a7ac36938fb85d1c81a9bc1c2e66cd22",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:45169", "10.65.0.27:45169", "172.17.0.1:45169"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:54:05.114383269Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1796629266396125,
+				"StableID":   "nAuC1TQh2F11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:be89e50a1192633e769f46977dfe73da5a62f99d94595e2e782e51e07f39f628",
+				"DiscoKey":   "discokey:4456bfa73aebb6eabc38eb540de896172c9c8570a0e1b6f8ed17f93e89f3834b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:48260", "10.65.0.27:48260", "172.17.0.1:48260"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:54:05.660135064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2055350009717276,
+				"StableID":   "nVwJ9TZs3H11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f44944ff66452fb41228da3b0c34069a3b3ab0397c8be3257b046bdbf0b12d67",
+				"DiscoKey":   "discokey:99d2a0e3b4cd50cb81eb1c502be6d7be8828b09deae5acd7bb7feb950ecb8e20",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:35937", "10.65.0.27:35937", "172.17.0.1:35937"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:54:06.201220848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7724217180562942,
+				"StableID":   "nyzcu46KK321CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c045f71411b49ee2f33ab527ce55537be3db2b0eb051b5f440e58ab5b1811132",
+				"DiscoKey":   "discokey:a1232e943d46aa1d283ef3580487d26d2608bd960a53ed7a38cf4332983e390d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:36234", "10.65.0.27:36234", "172.17.0.1:36234"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:54:06.743488658Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6188909096033515,
+				"StableID":   "nApntY9yKq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af5acad95fc45f5a94cc110e06761a4b826e19bc71eba9fa18f3cba095af096d",
+				"DiscoKey":   "discokey:e48fbefb05535c81445efa3f127ce009c2ec90aea6130308332bb73481428b71",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47189", "10.65.0.27:47189", "172.17.0.1:47189"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:54:07.284202203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4068015540225939,
+				"StableID":   "nk5T2UsQmY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f14f126ce109498d01ace3748777b88f799e67615a6a022d3b71ae834c623031",
+				"DiscoKey":   "discokey:f874d5cd4880492ccf5a38963abe2eab3544deda67d88e71fa5fe51b1c4ff042",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:60376", "10.65.0.27:60376", "172.17.0.1:60376"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:54:07.810914912Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         501181918424048,
+				"StableID":   "nKe2vYCzu411CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:c0c227f5ce6d8644c1ff81c05c4b4d741eecfe2438a85140473b110bb7392512",
+				"KeyExpiry":  "2026-11-08T18:54:08Z",
+				"DiscoKey":   "discokey:fea44965172d48ffb62ca95de54f03da1b076bd674ad751777400488bd20aa3a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:49629", "10.65.0.27:49629", "172.17.0.1:49629"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:54:08.357636418Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6539306956443726,
+				"StableID":   "nsdJwHWf4t11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:475fa9a81df138253d4abf021798012727018f41e89066f8e0cf389704dbac32",
+				"KeyExpiry":  "2026-11-08T18:54:08Z",
+				"DiscoKey":   "discokey:048f9cafcb3f558233acffaa72af90f5118a1bfde49a474e6aa0462920f0902f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:38213", "10.65.0.27:38213", "172.17.0.1:38213"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:54:08.896426382Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4469060208632458,
+				"StableID":   "n1vR4kd3ub11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2126353cbdbca8ac938b1e2a0078088feb8304f384e5ce69213819ead0fffa45",
+				"KeyExpiry":  "2026-11-08T18:54:09Z",
+				"DiscoKey":   "discokey:c48b4d2fd6e3b2c2abff711c2d5c9b6c55bce0a5703d52e6f9ebcced7aea8a02",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:35491", "10.65.0.27:35491", "172.17.0.1:35491"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:54:09.433930198Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8114285204469608": {
+				"ID":          8114285204469608,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1796629266396125,
+				"StableID":   "nAuC1TQh2F11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1796629266396125,
+				"Key":        "nodekey:be89e50a1192633e769f46977dfe73da5a62f99d94595e2e782e51e07f39f628",
+				"DiscoKey":   "discokey:4456bfa73aebb6eabc38eb540de896172c9c8570a0e1b6f8ed17f93e89f3834b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:48260", "10.65.0.27:48260", "172.17.0.1:48260"],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:54:05.660135064Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:be89e50a1192633e769f46977dfe73da5a62f99d94595e2e782e51e07f39f628",
+			"MachineKey": "mkey:a9d539e1df87b29d876d4d1acc84f949b6c147b8b7a0a8c09016ab23f4350e10",
+			"Peers": [{
+				"ID":         3897792547780688,
+				"StableID":   "nD7s5FQKSX11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f0076188b775e0689535fb9c31d990bf5d95c7df7725049479cd4b87c89df519",
+				"DiscoKey":   "discokey:6d49012f263f61418941da9f8eb54bf302bf5c3159cd92488d52d8774822db01",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:34760", "10.65.0.27:34760", "172.17.0.1:34760"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:54:01.897993709Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8026726004641457,
+				"StableID":   "n2PJouUKg521CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f3731c586c67c0695183f81823b207e37746a68ebe7789ea7a792c3a0d87ab40",
+				"DiscoKey":   "discokey:9644510e21b3a4e74a47d62d910c126bc9fd819787ed82ba78228dfdd71b8f62",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:59407", "10.65.0.27:59407", "172.17.0.1:59407"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:54:02.423058011Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8114285204469608,
+				"StableID":   "nTaNTkWyM621CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7da79e0e97e32fc2f6403acf69d5d2fd54bd3f87fa3eb771befc3f49ac378615",
+				"DiscoKey":   "discokey:23b158ddffae6c88a2374cb060e5967689a909273a530e48ade94d9ff72fa46c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:57732", "10.65.0.27:57732", "172.17.0.1:57732"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:54:02.954874551Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3097057685873505,
+				"StableID":   "ntkqKKTfBR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc921135f0e6ebcfcc5600a13dca256b2a80af11c8da666451a7e254c97a341a",
+				"DiscoKey":   "discokey:ce291560b52a2ec4b7925bb04c67df5a58bebba9a5383ac8c65074c70eea362c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:59502", "10.65.0.27:59502", "172.17.0.1:59502"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:54:03.504634091Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8355216193210735,
+				"StableID":   "neiDuxM6F821CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:622c88ebee766d76f57395143cad7c1830291116d0075d9578d4c0a27a470803",
+				"DiscoKey":   "discokey:4a07a9cc2b8e3ceb63a0801d86d14a62e2643c4a3426c74c86f6ca74762c3333",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:39103", "10.65.0.27:39103", "172.17.0.1:39103"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:54:04.03346603Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3399209927040729,
+				"StableID":   "nnmtCtUWYT11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0dbadfeecb60fa9a7b973a25c603c58676ad9ee4def449a9014b0b0079a8745",
+				"DiscoKey":   "discokey:0f0435a0f9a6c4c4549f9e93eb72464480572bb5f98428c590e1355398b1da13",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:42460", "10.65.0.27:42460", "172.17.0.1:42460"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:54:04.574472809Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6699531214773499,
+				"StableID":   "nAkzypKEKu11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2e5c883ef9f2b0bb7ad6af707b2ea54b1978fc4111dd182eb86d6326a20dd05f",
+				"DiscoKey":   "discokey:269a74b5128ef83f23505f1c7f2ec786a7ac36938fb85d1c81a9bc1c2e66cd22",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:45169", "10.65.0.27:45169", "172.17.0.1:45169"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:54:05.114383269Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         2055350009717276,
+				"StableID":   "nVwJ9TZs3H11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f44944ff66452fb41228da3b0c34069a3b3ab0397c8be3257b046bdbf0b12d67",
+				"DiscoKey":   "discokey:99d2a0e3b4cd50cb81eb1c502be6d7be8828b09deae5acd7bb7feb950ecb8e20",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:35937", "10.65.0.27:35937", "172.17.0.1:35937"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:54:06.201220848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7724217180562942,
+				"StableID":   "nyzcu46KK321CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c045f71411b49ee2f33ab527ce55537be3db2b0eb051b5f440e58ab5b1811132",
+				"DiscoKey":   "discokey:a1232e943d46aa1d283ef3580487d26d2608bd960a53ed7a38cf4332983e390d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:36234", "10.65.0.27:36234", "172.17.0.1:36234"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:54:06.743488658Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6188909096033515,
+				"StableID":   "nApntY9yKq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af5acad95fc45f5a94cc110e06761a4b826e19bc71eba9fa18f3cba095af096d",
+				"DiscoKey":   "discokey:e48fbefb05535c81445efa3f127ce009c2ec90aea6130308332bb73481428b71",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47189", "10.65.0.27:47189", "172.17.0.1:47189"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:54:07.284202203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4068015540225939,
+				"StableID":   "nk5T2UsQmY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f14f126ce109498d01ace3748777b88f799e67615a6a022d3b71ae834c623031",
+				"DiscoKey":   "discokey:f874d5cd4880492ccf5a38963abe2eab3544deda67d88e71fa5fe51b1c4ff042",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:60376", "10.65.0.27:60376", "172.17.0.1:60376"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:54:07.810914912Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         501181918424048,
+				"StableID":   "nKe2vYCzu411CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:c0c227f5ce6d8644c1ff81c05c4b4d741eecfe2438a85140473b110bb7392512",
+				"KeyExpiry":  "2026-11-08T18:54:08Z",
+				"DiscoKey":   "discokey:fea44965172d48ffb62ca95de54f03da1b076bd674ad751777400488bd20aa3a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:49629", "10.65.0.27:49629", "172.17.0.1:49629"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:54:08.357636418Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6539306956443726,
+				"StableID":   "nsdJwHWf4t11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:475fa9a81df138253d4abf021798012727018f41e89066f8e0cf389704dbac32",
+				"KeyExpiry":  "2026-11-08T18:54:08Z",
+				"DiscoKey":   "discokey:048f9cafcb3f558233acffaa72af90f5118a1bfde49a474e6aa0462920f0902f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:38213", "10.65.0.27:38213", "172.17.0.1:38213"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:54:08.896426382Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4469060208632458,
+				"StableID":   "n1vR4kd3ub11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2126353cbdbca8ac938b1e2a0078088feb8304f384e5ce69213819ead0fffa45",
+				"KeyExpiry":  "2026-11-08T18:54:09Z",
+				"DiscoKey":   "discokey:c48b4d2fd6e3b2c2abff711c2d5c9b6c55bce0a5703d52e6f9ebcced7aea8a02",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:35491", "10.65.0.27:35491", "172.17.0.1:35491"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:54:09.433930198Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1796629266396125": {
+				"ID":          1796629266396125,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         501181918424048,
+				"StableID":   "nKe2vYCzu411CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:c0c227f5ce6d8644c1ff81c05c4b4d741eecfe2438a85140473b110bb7392512",
+				"KeyExpiry":  "2026-11-08T18:54:08Z",
+				"DiscoKey":   "discokey:fea44965172d48ffb62ca95de54f03da1b076bd674ad751777400488bd20aa3a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:49629", "10.65.0.27:49629", "172.17.0.1:49629"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:54:08.357636418Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c0c227f5ce6d8644c1ff81c05c4b4d741eecfe2438a85140473b110bb7392512",
+			"MachineKey": "mkey:9025727d9e79fef682c0829650b4131f0af632bc2291f4a95b1740c2d340814b",
+			"Peers": [{
+				"ID":         3897792547780688,
+				"StableID":   "nD7s5FQKSX11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f0076188b775e0689535fb9c31d990bf5d95c7df7725049479cd4b87c89df519",
+				"DiscoKey":   "discokey:6d49012f263f61418941da9f8eb54bf302bf5c3159cd92488d52d8774822db01",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:34760", "10.65.0.27:34760", "172.17.0.1:34760"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:54:01.897993709Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8026726004641457,
+				"StableID":   "n2PJouUKg521CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f3731c586c67c0695183f81823b207e37746a68ebe7789ea7a792c3a0d87ab40",
+				"DiscoKey":   "discokey:9644510e21b3a4e74a47d62d910c126bc9fd819787ed82ba78228dfdd71b8f62",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:59407", "10.65.0.27:59407", "172.17.0.1:59407"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:54:02.423058011Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8114285204469608,
+				"StableID":   "nTaNTkWyM621CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7da79e0e97e32fc2f6403acf69d5d2fd54bd3f87fa3eb771befc3f49ac378615",
+				"DiscoKey":   "discokey:23b158ddffae6c88a2374cb060e5967689a909273a530e48ade94d9ff72fa46c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:57732", "10.65.0.27:57732", "172.17.0.1:57732"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:54:02.954874551Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3097057685873505,
+				"StableID":   "ntkqKKTfBR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc921135f0e6ebcfcc5600a13dca256b2a80af11c8da666451a7e254c97a341a",
+				"DiscoKey":   "discokey:ce291560b52a2ec4b7925bb04c67df5a58bebba9a5383ac8c65074c70eea362c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:59502", "10.65.0.27:59502", "172.17.0.1:59502"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:54:03.504634091Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8355216193210735,
+				"StableID":   "neiDuxM6F821CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:622c88ebee766d76f57395143cad7c1830291116d0075d9578d4c0a27a470803",
+				"DiscoKey":   "discokey:4a07a9cc2b8e3ceb63a0801d86d14a62e2643c4a3426c74c86f6ca74762c3333",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:39103", "10.65.0.27:39103", "172.17.0.1:39103"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:54:04.03346603Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3399209927040729,
+				"StableID":   "nnmtCtUWYT11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0dbadfeecb60fa9a7b973a25c603c58676ad9ee4def449a9014b0b0079a8745",
+				"DiscoKey":   "discokey:0f0435a0f9a6c4c4549f9e93eb72464480572bb5f98428c590e1355398b1da13",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:42460", "10.65.0.27:42460", "172.17.0.1:42460"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:54:04.574472809Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6699531214773499,
+				"StableID":   "nAkzypKEKu11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2e5c883ef9f2b0bb7ad6af707b2ea54b1978fc4111dd182eb86d6326a20dd05f",
+				"DiscoKey":   "discokey:269a74b5128ef83f23505f1c7f2ec786a7ac36938fb85d1c81a9bc1c2e66cd22",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:45169", "10.65.0.27:45169", "172.17.0.1:45169"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:54:05.114383269Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1796629266396125,
+				"StableID":   "nAuC1TQh2F11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:be89e50a1192633e769f46977dfe73da5a62f99d94595e2e782e51e07f39f628",
+				"DiscoKey":   "discokey:4456bfa73aebb6eabc38eb540de896172c9c8570a0e1b6f8ed17f93e89f3834b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:48260", "10.65.0.27:48260", "172.17.0.1:48260"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:54:05.660135064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2055350009717276,
+				"StableID":   "nVwJ9TZs3H11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f44944ff66452fb41228da3b0c34069a3b3ab0397c8be3257b046bdbf0b12d67",
+				"DiscoKey":   "discokey:99d2a0e3b4cd50cb81eb1c502be6d7be8828b09deae5acd7bb7feb950ecb8e20",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:35937", "10.65.0.27:35937", "172.17.0.1:35937"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:54:06.201220848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7724217180562942,
+				"StableID":   "nyzcu46KK321CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c045f71411b49ee2f33ab527ce55537be3db2b0eb051b5f440e58ab5b1811132",
+				"DiscoKey":   "discokey:a1232e943d46aa1d283ef3580487d26d2608bd960a53ed7a38cf4332983e390d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:36234", "10.65.0.27:36234", "172.17.0.1:36234"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:54:06.743488658Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6188909096033515,
+				"StableID":   "nApntY9yKq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af5acad95fc45f5a94cc110e06761a4b826e19bc71eba9fa18f3cba095af096d",
+				"DiscoKey":   "discokey:e48fbefb05535c81445efa3f127ce009c2ec90aea6130308332bb73481428b71",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47189", "10.65.0.27:47189", "172.17.0.1:47189"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:54:07.284202203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4068015540225939,
+				"StableID":   "nk5T2UsQmY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f14f126ce109498d01ace3748777b88f799e67615a6a022d3b71ae834c623031",
+				"DiscoKey":   "discokey:f874d5cd4880492ccf5a38963abe2eab3544deda67d88e71fa5fe51b1c4ff042",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:60376", "10.65.0.27:60376", "172.17.0.1:60376"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:54:07.810914912Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         6539306956443726,
+				"StableID":   "nsdJwHWf4t11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:475fa9a81df138253d4abf021798012727018f41e89066f8e0cf389704dbac32",
+				"KeyExpiry":  "2026-11-08T18:54:08Z",
+				"DiscoKey":   "discokey:048f9cafcb3f558233acffaa72af90f5118a1bfde49a474e6aa0462920f0902f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:38213", "10.65.0.27:38213", "172.17.0.1:38213"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:54:08.896426382Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4469060208632458,
+				"StableID":   "n1vR4kd3ub11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2126353cbdbca8ac938b1e2a0078088feb8304f384e5ce69213819ead0fffa45",
+				"KeyExpiry":  "2026-11-08T18:54:09Z",
+				"DiscoKey":   "discokey:c48b4d2fd6e3b2c2abff711c2d5c9b6c55bce0a5703d52e6f9ebcced7aea8a02",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:35491", "10.65.0.27:35491", "172.17.0.1:35491"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:54:09.433930198Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6188909096033515,
+				"StableID":   "nApntY9yKq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       6188909096033515,
+				"Key":        "nodekey:af5acad95fc45f5a94cc110e06761a4b826e19bc71eba9fa18f3cba095af096d",
+				"DiscoKey":   "discokey:e48fbefb05535c81445efa3f127ce009c2ec90aea6130308332bb73481428b71",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47189", "10.65.0.27:47189", "172.17.0.1:47189"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:54:07.284202203Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:af5acad95fc45f5a94cc110e06761a4b826e19bc71eba9fa18f3cba095af096d",
+			"MachineKey": "mkey:8a1469cbb718d163c187b1fe75dc389f6e70afa6ceb746e60dedfe0abef26c6c",
+			"Peers": [{
+				"ID":         3897792547780688,
+				"StableID":   "nD7s5FQKSX11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f0076188b775e0689535fb9c31d990bf5d95c7df7725049479cd4b87c89df519",
+				"DiscoKey":   "discokey:6d49012f263f61418941da9f8eb54bf302bf5c3159cd92488d52d8774822db01",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:34760", "10.65.0.27:34760", "172.17.0.1:34760"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:54:01.897993709Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8026726004641457,
+				"StableID":   "n2PJouUKg521CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f3731c586c67c0695183f81823b207e37746a68ebe7789ea7a792c3a0d87ab40",
+				"DiscoKey":   "discokey:9644510e21b3a4e74a47d62d910c126bc9fd819787ed82ba78228dfdd71b8f62",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:59407", "10.65.0.27:59407", "172.17.0.1:59407"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:54:02.423058011Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8114285204469608,
+				"StableID":   "nTaNTkWyM621CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7da79e0e97e32fc2f6403acf69d5d2fd54bd3f87fa3eb771befc3f49ac378615",
+				"DiscoKey":   "discokey:23b158ddffae6c88a2374cb060e5967689a909273a530e48ade94d9ff72fa46c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:57732", "10.65.0.27:57732", "172.17.0.1:57732"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:54:02.954874551Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3097057685873505,
+				"StableID":   "ntkqKKTfBR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc921135f0e6ebcfcc5600a13dca256b2a80af11c8da666451a7e254c97a341a",
+				"DiscoKey":   "discokey:ce291560b52a2ec4b7925bb04c67df5a58bebba9a5383ac8c65074c70eea362c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:59502", "10.65.0.27:59502", "172.17.0.1:59502"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:54:03.504634091Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8355216193210735,
+				"StableID":   "neiDuxM6F821CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:622c88ebee766d76f57395143cad7c1830291116d0075d9578d4c0a27a470803",
+				"DiscoKey":   "discokey:4a07a9cc2b8e3ceb63a0801d86d14a62e2643c4a3426c74c86f6ca74762c3333",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:39103", "10.65.0.27:39103", "172.17.0.1:39103"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:54:04.03346603Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3399209927040729,
+				"StableID":   "nnmtCtUWYT11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0dbadfeecb60fa9a7b973a25c603c58676ad9ee4def449a9014b0b0079a8745",
+				"DiscoKey":   "discokey:0f0435a0f9a6c4c4549f9e93eb72464480572bb5f98428c590e1355398b1da13",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:42460", "10.65.0.27:42460", "172.17.0.1:42460"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:54:04.574472809Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6699531214773499,
+				"StableID":   "nAkzypKEKu11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2e5c883ef9f2b0bb7ad6af707b2ea54b1978fc4111dd182eb86d6326a20dd05f",
+				"DiscoKey":   "discokey:269a74b5128ef83f23505f1c7f2ec786a7ac36938fb85d1c81a9bc1c2e66cd22",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:45169", "10.65.0.27:45169", "172.17.0.1:45169"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:54:05.114383269Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1796629266396125,
+				"StableID":   "nAuC1TQh2F11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:be89e50a1192633e769f46977dfe73da5a62f99d94595e2e782e51e07f39f628",
+				"DiscoKey":   "discokey:4456bfa73aebb6eabc38eb540de896172c9c8570a0e1b6f8ed17f93e89f3834b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:48260", "10.65.0.27:48260", "172.17.0.1:48260"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:54:05.660135064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2055350009717276,
+				"StableID":   "nVwJ9TZs3H11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f44944ff66452fb41228da3b0c34069a3b3ab0397c8be3257b046bdbf0b12d67",
+				"DiscoKey":   "discokey:99d2a0e3b4cd50cb81eb1c502be6d7be8828b09deae5acd7bb7feb950ecb8e20",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:35937", "10.65.0.27:35937", "172.17.0.1:35937"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:54:06.201220848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7724217180562942,
+				"StableID":   "nyzcu46KK321CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c045f71411b49ee2f33ab527ce55537be3db2b0eb051b5f440e58ab5b1811132",
+				"DiscoKey":   "discokey:a1232e943d46aa1d283ef3580487d26d2608bd960a53ed7a38cf4332983e390d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:36234", "10.65.0.27:36234", "172.17.0.1:36234"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:54:06.743488658Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4068015540225939,
+				"StableID":   "nk5T2UsQmY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f14f126ce109498d01ace3748777b88f799e67615a6a022d3b71ae834c623031",
+				"DiscoKey":   "discokey:f874d5cd4880492ccf5a38963abe2eab3544deda67d88e71fa5fe51b1c4ff042",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:60376", "10.65.0.27:60376", "172.17.0.1:60376"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:54:07.810914912Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         501181918424048,
+				"StableID":   "nKe2vYCzu411CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:c0c227f5ce6d8644c1ff81c05c4b4d741eecfe2438a85140473b110bb7392512",
+				"KeyExpiry":  "2026-11-08T18:54:08Z",
+				"DiscoKey":   "discokey:fea44965172d48ffb62ca95de54f03da1b076bd674ad751777400488bd20aa3a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:49629", "10.65.0.27:49629", "172.17.0.1:49629"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:54:08.357636418Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6539306956443726,
+				"StableID":   "nsdJwHWf4t11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:475fa9a81df138253d4abf021798012727018f41e89066f8e0cf389704dbac32",
+				"KeyExpiry":  "2026-11-08T18:54:08Z",
+				"DiscoKey":   "discokey:048f9cafcb3f558233acffaa72af90f5118a1bfde49a474e6aa0462920f0902f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:38213", "10.65.0.27:38213", "172.17.0.1:38213"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:54:08.896426382Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4469060208632458,
+				"StableID":   "n1vR4kd3ub11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2126353cbdbca8ac938b1e2a0078088feb8304f384e5ce69213819ead0fffa45",
+				"KeyExpiry":  "2026-11-08T18:54:09Z",
+				"DiscoKey":   "discokey:c48b4d2fd6e3b2c2abff711c2d5c9b6c55bce0a5703d52e6f9ebcced7aea8a02",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:35491", "10.65.0.27:35491", "172.17.0.1:35491"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:54:09.433930198Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6188909096033515": {
+				"ID":          6188909096033515,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8026726004641457,
+				"StableID":   "n2PJouUKg521CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       8026726004641457,
+				"Key":        "nodekey:f3731c586c67c0695183f81823b207e37746a68ebe7789ea7a792c3a0d87ab40",
+				"DiscoKey":   "discokey:9644510e21b3a4e74a47d62d910c126bc9fd819787ed82ba78228dfdd71b8f62",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:59407", "10.65.0.27:59407", "172.17.0.1:59407"],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:54:02.423058011Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f3731c586c67c0695183f81823b207e37746a68ebe7789ea7a792c3a0d87ab40",
+			"MachineKey": "mkey:e000a8105103b9ee72e10cb7b51d2371ce02a009cf4474306f500dbe93896711",
+			"Peers": [{
+				"ID":         3897792547780688,
+				"StableID":   "nD7s5FQKSX11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f0076188b775e0689535fb9c31d990bf5d95c7df7725049479cd4b87c89df519",
+				"DiscoKey":   "discokey:6d49012f263f61418941da9f8eb54bf302bf5c3159cd92488d52d8774822db01",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:34760", "10.65.0.27:34760", "172.17.0.1:34760"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:54:01.897993709Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8114285204469608,
+				"StableID":   "nTaNTkWyM621CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7da79e0e97e32fc2f6403acf69d5d2fd54bd3f87fa3eb771befc3f49ac378615",
+				"DiscoKey":   "discokey:23b158ddffae6c88a2374cb060e5967689a909273a530e48ade94d9ff72fa46c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:57732", "10.65.0.27:57732", "172.17.0.1:57732"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:54:02.954874551Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3097057685873505,
+				"StableID":   "ntkqKKTfBR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc921135f0e6ebcfcc5600a13dca256b2a80af11c8da666451a7e254c97a341a",
+				"DiscoKey":   "discokey:ce291560b52a2ec4b7925bb04c67df5a58bebba9a5383ac8c65074c70eea362c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:59502", "10.65.0.27:59502", "172.17.0.1:59502"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:54:03.504634091Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8355216193210735,
+				"StableID":   "neiDuxM6F821CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:622c88ebee766d76f57395143cad7c1830291116d0075d9578d4c0a27a470803",
+				"DiscoKey":   "discokey:4a07a9cc2b8e3ceb63a0801d86d14a62e2643c4a3426c74c86f6ca74762c3333",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:39103", "10.65.0.27:39103", "172.17.0.1:39103"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:54:04.03346603Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3399209927040729,
+				"StableID":   "nnmtCtUWYT11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0dbadfeecb60fa9a7b973a25c603c58676ad9ee4def449a9014b0b0079a8745",
+				"DiscoKey":   "discokey:0f0435a0f9a6c4c4549f9e93eb72464480572bb5f98428c590e1355398b1da13",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:42460", "10.65.0.27:42460", "172.17.0.1:42460"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:54:04.574472809Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6699531214773499,
+				"StableID":   "nAkzypKEKu11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2e5c883ef9f2b0bb7ad6af707b2ea54b1978fc4111dd182eb86d6326a20dd05f",
+				"DiscoKey":   "discokey:269a74b5128ef83f23505f1c7f2ec786a7ac36938fb85d1c81a9bc1c2e66cd22",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:45169", "10.65.0.27:45169", "172.17.0.1:45169"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:54:05.114383269Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1796629266396125,
+				"StableID":   "nAuC1TQh2F11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:be89e50a1192633e769f46977dfe73da5a62f99d94595e2e782e51e07f39f628",
+				"DiscoKey":   "discokey:4456bfa73aebb6eabc38eb540de896172c9c8570a0e1b6f8ed17f93e89f3834b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:48260", "10.65.0.27:48260", "172.17.0.1:48260"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:54:05.660135064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2055350009717276,
+				"StableID":   "nVwJ9TZs3H11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f44944ff66452fb41228da3b0c34069a3b3ab0397c8be3257b046bdbf0b12d67",
+				"DiscoKey":   "discokey:99d2a0e3b4cd50cb81eb1c502be6d7be8828b09deae5acd7bb7feb950ecb8e20",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:35937", "10.65.0.27:35937", "172.17.0.1:35937"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:54:06.201220848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7724217180562942,
+				"StableID":   "nyzcu46KK321CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c045f71411b49ee2f33ab527ce55537be3db2b0eb051b5f440e58ab5b1811132",
+				"DiscoKey":   "discokey:a1232e943d46aa1d283ef3580487d26d2608bd960a53ed7a38cf4332983e390d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:36234", "10.65.0.27:36234", "172.17.0.1:36234"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:54:06.743488658Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6188909096033515,
+				"StableID":   "nApntY9yKq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af5acad95fc45f5a94cc110e06761a4b826e19bc71eba9fa18f3cba095af096d",
+				"DiscoKey":   "discokey:e48fbefb05535c81445efa3f127ce009c2ec90aea6130308332bb73481428b71",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47189", "10.65.0.27:47189", "172.17.0.1:47189"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:54:07.284202203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4068015540225939,
+				"StableID":   "nk5T2UsQmY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f14f126ce109498d01ace3748777b88f799e67615a6a022d3b71ae834c623031",
+				"DiscoKey":   "discokey:f874d5cd4880492ccf5a38963abe2eab3544deda67d88e71fa5fe51b1c4ff042",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:60376", "10.65.0.27:60376", "172.17.0.1:60376"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:54:07.810914912Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         501181918424048,
+				"StableID":   "nKe2vYCzu411CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:c0c227f5ce6d8644c1ff81c05c4b4d741eecfe2438a85140473b110bb7392512",
+				"KeyExpiry":  "2026-11-08T18:54:08Z",
+				"DiscoKey":   "discokey:fea44965172d48ffb62ca95de54f03da1b076bd674ad751777400488bd20aa3a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:49629", "10.65.0.27:49629", "172.17.0.1:49629"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:54:08.357636418Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6539306956443726,
+				"StableID":   "nsdJwHWf4t11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:475fa9a81df138253d4abf021798012727018f41e89066f8e0cf389704dbac32",
+				"KeyExpiry":  "2026-11-08T18:54:08Z",
+				"DiscoKey":   "discokey:048f9cafcb3f558233acffaa72af90f5118a1bfde49a474e6aa0462920f0902f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:38213", "10.65.0.27:38213", "172.17.0.1:38213"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:54:08.896426382Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4469060208632458,
+				"StableID":   "n1vR4kd3ub11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2126353cbdbca8ac938b1e2a0078088feb8304f384e5ce69213819ead0fffa45",
+				"KeyExpiry":  "2026-11-08T18:54:09Z",
+				"DiscoKey":   "discokey:c48b4d2fd6e3b2c2abff711c2d5c9b6c55bce0a5703d52e6f9ebcced7aea8a02",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:35491", "10.65.0.27:35491", "172.17.0.1:35491"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:54:09.433930198Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8026726004641457": {
+				"ID":          8026726004641457,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3897792547780688,
+				"StableID":   "nD7s5FQKSX11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       3897792547780688,
+				"Key":        "nodekey:f0076188b775e0689535fb9c31d990bf5d95c7df7725049479cd4b87c89df519",
+				"DiscoKey":   "discokey:6d49012f263f61418941da9f8eb54bf302bf5c3159cd92488d52d8774822db01",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:34760", "10.65.0.27:34760", "172.17.0.1:34760"],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:54:01.897993709Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f0076188b775e0689535fb9c31d990bf5d95c7df7725049479cd4b87c89df519",
+			"MachineKey": "mkey:17a23f40711f9efd35ddeb50105c797ca77588a9960cd0d9b464bbc2cef4e85a",
+			"Peers": [{
+				"ID":         8026726004641457,
+				"StableID":   "n2PJouUKg521CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f3731c586c67c0695183f81823b207e37746a68ebe7789ea7a792c3a0d87ab40",
+				"DiscoKey":   "discokey:9644510e21b3a4e74a47d62d910c126bc9fd819787ed82ba78228dfdd71b8f62",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:59407", "10.65.0.27:59407", "172.17.0.1:59407"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:54:02.423058011Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8114285204469608,
+				"StableID":   "nTaNTkWyM621CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7da79e0e97e32fc2f6403acf69d5d2fd54bd3f87fa3eb771befc3f49ac378615",
+				"DiscoKey":   "discokey:23b158ddffae6c88a2374cb060e5967689a909273a530e48ade94d9ff72fa46c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:57732", "10.65.0.27:57732", "172.17.0.1:57732"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:54:02.954874551Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3097057685873505,
+				"StableID":   "ntkqKKTfBR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc921135f0e6ebcfcc5600a13dca256b2a80af11c8da666451a7e254c97a341a",
+				"DiscoKey":   "discokey:ce291560b52a2ec4b7925bb04c67df5a58bebba9a5383ac8c65074c70eea362c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:59502", "10.65.0.27:59502", "172.17.0.1:59502"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:54:03.504634091Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8355216193210735,
+				"StableID":   "neiDuxM6F821CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:622c88ebee766d76f57395143cad7c1830291116d0075d9578d4c0a27a470803",
+				"DiscoKey":   "discokey:4a07a9cc2b8e3ceb63a0801d86d14a62e2643c4a3426c74c86f6ca74762c3333",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:39103", "10.65.0.27:39103", "172.17.0.1:39103"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:54:04.03346603Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3399209927040729,
+				"StableID":   "nnmtCtUWYT11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0dbadfeecb60fa9a7b973a25c603c58676ad9ee4def449a9014b0b0079a8745",
+				"DiscoKey":   "discokey:0f0435a0f9a6c4c4549f9e93eb72464480572bb5f98428c590e1355398b1da13",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:42460", "10.65.0.27:42460", "172.17.0.1:42460"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:54:04.574472809Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6699531214773499,
+				"StableID":   "nAkzypKEKu11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2e5c883ef9f2b0bb7ad6af707b2ea54b1978fc4111dd182eb86d6326a20dd05f",
+				"DiscoKey":   "discokey:269a74b5128ef83f23505f1c7f2ec786a7ac36938fb85d1c81a9bc1c2e66cd22",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:45169", "10.65.0.27:45169", "172.17.0.1:45169"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:54:05.114383269Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1796629266396125,
+				"StableID":   "nAuC1TQh2F11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:be89e50a1192633e769f46977dfe73da5a62f99d94595e2e782e51e07f39f628",
+				"DiscoKey":   "discokey:4456bfa73aebb6eabc38eb540de896172c9c8570a0e1b6f8ed17f93e89f3834b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:48260", "10.65.0.27:48260", "172.17.0.1:48260"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:54:05.660135064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2055350009717276,
+				"StableID":   "nVwJ9TZs3H11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f44944ff66452fb41228da3b0c34069a3b3ab0397c8be3257b046bdbf0b12d67",
+				"DiscoKey":   "discokey:99d2a0e3b4cd50cb81eb1c502be6d7be8828b09deae5acd7bb7feb950ecb8e20",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:35937", "10.65.0.27:35937", "172.17.0.1:35937"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:54:06.201220848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7724217180562942,
+				"StableID":   "nyzcu46KK321CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c045f71411b49ee2f33ab527ce55537be3db2b0eb051b5f440e58ab5b1811132",
+				"DiscoKey":   "discokey:a1232e943d46aa1d283ef3580487d26d2608bd960a53ed7a38cf4332983e390d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:36234", "10.65.0.27:36234", "172.17.0.1:36234"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:54:06.743488658Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6188909096033515,
+				"StableID":   "nApntY9yKq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af5acad95fc45f5a94cc110e06761a4b826e19bc71eba9fa18f3cba095af096d",
+				"DiscoKey":   "discokey:e48fbefb05535c81445efa3f127ce009c2ec90aea6130308332bb73481428b71",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47189", "10.65.0.27:47189", "172.17.0.1:47189"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:54:07.284202203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4068015540225939,
+				"StableID":   "nk5T2UsQmY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f14f126ce109498d01ace3748777b88f799e67615a6a022d3b71ae834c623031",
+				"DiscoKey":   "discokey:f874d5cd4880492ccf5a38963abe2eab3544deda67d88e71fa5fe51b1c4ff042",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:60376", "10.65.0.27:60376", "172.17.0.1:60376"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:54:07.810914912Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         501181918424048,
+				"StableID":   "nKe2vYCzu411CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:c0c227f5ce6d8644c1ff81c05c4b4d741eecfe2438a85140473b110bb7392512",
+				"KeyExpiry":  "2026-11-08T18:54:08Z",
+				"DiscoKey":   "discokey:fea44965172d48ffb62ca95de54f03da1b076bd674ad751777400488bd20aa3a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:49629", "10.65.0.27:49629", "172.17.0.1:49629"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:54:08.357636418Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6539306956443726,
+				"StableID":   "nsdJwHWf4t11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:475fa9a81df138253d4abf021798012727018f41e89066f8e0cf389704dbac32",
+				"KeyExpiry":  "2026-11-08T18:54:08Z",
+				"DiscoKey":   "discokey:048f9cafcb3f558233acffaa72af90f5118a1bfde49a474e6aa0462920f0902f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:38213", "10.65.0.27:38213", "172.17.0.1:38213"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:54:08.896426382Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4469060208632458,
+				"StableID":   "n1vR4kd3ub11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2126353cbdbca8ac938b1e2a0078088feb8304f384e5ce69213819ead0fffa45",
+				"KeyExpiry":  "2026-11-08T18:54:09Z",
+				"DiscoKey":   "discokey:c48b4d2fd6e3b2c2abff711c2d5c9b6c55bce0a5703d52e6f9ebcced7aea8a02",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:35491", "10.65.0.27:35491", "172.17.0.1:35491"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:54:09.433930198Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3897792547780688": {
+				"ID":          3897792547780688,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8355216193210735,
+				"StableID":   "neiDuxM6F821CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       8355216193210735,
+				"Key":        "nodekey:622c88ebee766d76f57395143cad7c1830291116d0075d9578d4c0a27a470803",
+				"DiscoKey":   "discokey:4a07a9cc2b8e3ceb63a0801d86d14a62e2643c4a3426c74c86f6ca74762c3333",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:39103", "10.65.0.27:39103", "172.17.0.1:39103"],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:54:04.03346603Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:622c88ebee766d76f57395143cad7c1830291116d0075d9578d4c0a27a470803",
+			"MachineKey": "mkey:dc9a1868553fc8bb16158f5f4c8ceda0f655d2408a4765ea92c51856a348ce35",
+			"Peers": [{
+				"ID":         3897792547780688,
+				"StableID":   "nD7s5FQKSX11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f0076188b775e0689535fb9c31d990bf5d95c7df7725049479cd4b87c89df519",
+				"DiscoKey":   "discokey:6d49012f263f61418941da9f8eb54bf302bf5c3159cd92488d52d8774822db01",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:34760", "10.65.0.27:34760", "172.17.0.1:34760"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:54:01.897993709Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8026726004641457,
+				"StableID":   "n2PJouUKg521CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f3731c586c67c0695183f81823b207e37746a68ebe7789ea7a792c3a0d87ab40",
+				"DiscoKey":   "discokey:9644510e21b3a4e74a47d62d910c126bc9fd819787ed82ba78228dfdd71b8f62",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:59407", "10.65.0.27:59407", "172.17.0.1:59407"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:54:02.423058011Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8114285204469608,
+				"StableID":   "nTaNTkWyM621CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7da79e0e97e32fc2f6403acf69d5d2fd54bd3f87fa3eb771befc3f49ac378615",
+				"DiscoKey":   "discokey:23b158ddffae6c88a2374cb060e5967689a909273a530e48ade94d9ff72fa46c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:57732", "10.65.0.27:57732", "172.17.0.1:57732"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:54:02.954874551Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3097057685873505,
+				"StableID":   "ntkqKKTfBR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc921135f0e6ebcfcc5600a13dca256b2a80af11c8da666451a7e254c97a341a",
+				"DiscoKey":   "discokey:ce291560b52a2ec4b7925bb04c67df5a58bebba9a5383ac8c65074c70eea362c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:59502", "10.65.0.27:59502", "172.17.0.1:59502"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:54:03.504634091Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3399209927040729,
+				"StableID":   "nnmtCtUWYT11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0dbadfeecb60fa9a7b973a25c603c58676ad9ee4def449a9014b0b0079a8745",
+				"DiscoKey":   "discokey:0f0435a0f9a6c4c4549f9e93eb72464480572bb5f98428c590e1355398b1da13",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:42460", "10.65.0.27:42460", "172.17.0.1:42460"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:54:04.574472809Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6699531214773499,
+				"StableID":   "nAkzypKEKu11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2e5c883ef9f2b0bb7ad6af707b2ea54b1978fc4111dd182eb86d6326a20dd05f",
+				"DiscoKey":   "discokey:269a74b5128ef83f23505f1c7f2ec786a7ac36938fb85d1c81a9bc1c2e66cd22",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:45169", "10.65.0.27:45169", "172.17.0.1:45169"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:54:05.114383269Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1796629266396125,
+				"StableID":   "nAuC1TQh2F11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:be89e50a1192633e769f46977dfe73da5a62f99d94595e2e782e51e07f39f628",
+				"DiscoKey":   "discokey:4456bfa73aebb6eabc38eb540de896172c9c8570a0e1b6f8ed17f93e89f3834b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:48260", "10.65.0.27:48260", "172.17.0.1:48260"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:54:05.660135064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2055350009717276,
+				"StableID":   "nVwJ9TZs3H11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f44944ff66452fb41228da3b0c34069a3b3ab0397c8be3257b046bdbf0b12d67",
+				"DiscoKey":   "discokey:99d2a0e3b4cd50cb81eb1c502be6d7be8828b09deae5acd7bb7feb950ecb8e20",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:35937", "10.65.0.27:35937", "172.17.0.1:35937"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:54:06.201220848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7724217180562942,
+				"StableID":   "nyzcu46KK321CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c045f71411b49ee2f33ab527ce55537be3db2b0eb051b5f440e58ab5b1811132",
+				"DiscoKey":   "discokey:a1232e943d46aa1d283ef3580487d26d2608bd960a53ed7a38cf4332983e390d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:36234", "10.65.0.27:36234", "172.17.0.1:36234"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:54:06.743488658Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6188909096033515,
+				"StableID":   "nApntY9yKq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af5acad95fc45f5a94cc110e06761a4b826e19bc71eba9fa18f3cba095af096d",
+				"DiscoKey":   "discokey:e48fbefb05535c81445efa3f127ce009c2ec90aea6130308332bb73481428b71",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47189", "10.65.0.27:47189", "172.17.0.1:47189"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:54:07.284202203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4068015540225939,
+				"StableID":   "nk5T2UsQmY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f14f126ce109498d01ace3748777b88f799e67615a6a022d3b71ae834c623031",
+				"DiscoKey":   "discokey:f874d5cd4880492ccf5a38963abe2eab3544deda67d88e71fa5fe51b1c4ff042",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:60376", "10.65.0.27:60376", "172.17.0.1:60376"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:54:07.810914912Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         501181918424048,
+				"StableID":   "nKe2vYCzu411CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:c0c227f5ce6d8644c1ff81c05c4b4d741eecfe2438a85140473b110bb7392512",
+				"KeyExpiry":  "2026-11-08T18:54:08Z",
+				"DiscoKey":   "discokey:fea44965172d48ffb62ca95de54f03da1b076bd674ad751777400488bd20aa3a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:49629", "10.65.0.27:49629", "172.17.0.1:49629"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:54:08.357636418Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6539306956443726,
+				"StableID":   "nsdJwHWf4t11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:475fa9a81df138253d4abf021798012727018f41e89066f8e0cf389704dbac32",
+				"KeyExpiry":  "2026-11-08T18:54:08Z",
+				"DiscoKey":   "discokey:048f9cafcb3f558233acffaa72af90f5118a1bfde49a474e6aa0462920f0902f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:38213", "10.65.0.27:38213", "172.17.0.1:38213"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:54:08.896426382Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4469060208632458,
+				"StableID":   "n1vR4kd3ub11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2126353cbdbca8ac938b1e2a0078088feb8304f384e5ce69213819ead0fffa45",
+				"KeyExpiry":  "2026-11-08T18:54:09Z",
+				"DiscoKey":   "discokey:c48b4d2fd6e3b2c2abff711c2d5c9b6c55bce0a5703d52e6f9ebcced7aea8a02",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:35491", "10.65.0.27:35491", "172.17.0.1:35491"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:54:09.433930198Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8355216193210735": {
+				"ID":          8355216193210735,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3097057685873505,
+				"StableID":   "ntkqKKTfBR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       3097057685873505,
+				"Key":        "nodekey:fc921135f0e6ebcfcc5600a13dca256b2a80af11c8da666451a7e254c97a341a",
+				"DiscoKey":   "discokey:ce291560b52a2ec4b7925bb04c67df5a58bebba9a5383ac8c65074c70eea362c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:59502", "10.65.0.27:59502", "172.17.0.1:59502"],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:54:03.504634091Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:fc921135f0e6ebcfcc5600a13dca256b2a80af11c8da666451a7e254c97a341a",
+			"MachineKey": "mkey:128a04cc28388f82c37a0058f36eb2be6935fd20dbf854365619a7658206d66a",
+			"Peers": [{
+				"ID":         3897792547780688,
+				"StableID":   "nD7s5FQKSX11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f0076188b775e0689535fb9c31d990bf5d95c7df7725049479cd4b87c89df519",
+				"DiscoKey":   "discokey:6d49012f263f61418941da9f8eb54bf302bf5c3159cd92488d52d8774822db01",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:34760", "10.65.0.27:34760", "172.17.0.1:34760"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:54:01.897993709Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8026726004641457,
+				"StableID":   "n2PJouUKg521CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f3731c586c67c0695183f81823b207e37746a68ebe7789ea7a792c3a0d87ab40",
+				"DiscoKey":   "discokey:9644510e21b3a4e74a47d62d910c126bc9fd819787ed82ba78228dfdd71b8f62",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:59407", "10.65.0.27:59407", "172.17.0.1:59407"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:54:02.423058011Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8114285204469608,
+				"StableID":   "nTaNTkWyM621CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7da79e0e97e32fc2f6403acf69d5d2fd54bd3f87fa3eb771befc3f49ac378615",
+				"DiscoKey":   "discokey:23b158ddffae6c88a2374cb060e5967689a909273a530e48ade94d9ff72fa46c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:57732", "10.65.0.27:57732", "172.17.0.1:57732"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:54:02.954874551Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         8355216193210735,
+				"StableID":   "neiDuxM6F821CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:622c88ebee766d76f57395143cad7c1830291116d0075d9578d4c0a27a470803",
+				"DiscoKey":   "discokey:4a07a9cc2b8e3ceb63a0801d86d14a62e2643c4a3426c74c86f6ca74762c3333",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:39103", "10.65.0.27:39103", "172.17.0.1:39103"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:54:04.03346603Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3399209927040729,
+				"StableID":   "nnmtCtUWYT11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0dbadfeecb60fa9a7b973a25c603c58676ad9ee4def449a9014b0b0079a8745",
+				"DiscoKey":   "discokey:0f0435a0f9a6c4c4549f9e93eb72464480572bb5f98428c590e1355398b1da13",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:42460", "10.65.0.27:42460", "172.17.0.1:42460"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:54:04.574472809Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6699531214773499,
+				"StableID":   "nAkzypKEKu11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2e5c883ef9f2b0bb7ad6af707b2ea54b1978fc4111dd182eb86d6326a20dd05f",
+				"DiscoKey":   "discokey:269a74b5128ef83f23505f1c7f2ec786a7ac36938fb85d1c81a9bc1c2e66cd22",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:45169", "10.65.0.27:45169", "172.17.0.1:45169"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:54:05.114383269Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1796629266396125,
+				"StableID":   "nAuC1TQh2F11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:be89e50a1192633e769f46977dfe73da5a62f99d94595e2e782e51e07f39f628",
+				"DiscoKey":   "discokey:4456bfa73aebb6eabc38eb540de896172c9c8570a0e1b6f8ed17f93e89f3834b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:48260", "10.65.0.27:48260", "172.17.0.1:48260"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:54:05.660135064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2055350009717276,
+				"StableID":   "nVwJ9TZs3H11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f44944ff66452fb41228da3b0c34069a3b3ab0397c8be3257b046bdbf0b12d67",
+				"DiscoKey":   "discokey:99d2a0e3b4cd50cb81eb1c502be6d7be8828b09deae5acd7bb7feb950ecb8e20",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:35937", "10.65.0.27:35937", "172.17.0.1:35937"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:54:06.201220848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7724217180562942,
+				"StableID":   "nyzcu46KK321CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c045f71411b49ee2f33ab527ce55537be3db2b0eb051b5f440e58ab5b1811132",
+				"DiscoKey":   "discokey:a1232e943d46aa1d283ef3580487d26d2608bd960a53ed7a38cf4332983e390d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:36234", "10.65.0.27:36234", "172.17.0.1:36234"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:54:06.743488658Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6188909096033515,
+				"StableID":   "nApntY9yKq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af5acad95fc45f5a94cc110e06761a4b826e19bc71eba9fa18f3cba095af096d",
+				"DiscoKey":   "discokey:e48fbefb05535c81445efa3f127ce009c2ec90aea6130308332bb73481428b71",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47189", "10.65.0.27:47189", "172.17.0.1:47189"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:54:07.284202203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4068015540225939,
+				"StableID":   "nk5T2UsQmY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f14f126ce109498d01ace3748777b88f799e67615a6a022d3b71ae834c623031",
+				"DiscoKey":   "discokey:f874d5cd4880492ccf5a38963abe2eab3544deda67d88e71fa5fe51b1c4ff042",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:60376", "10.65.0.27:60376", "172.17.0.1:60376"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:54:07.810914912Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         501181918424048,
+				"StableID":   "nKe2vYCzu411CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:c0c227f5ce6d8644c1ff81c05c4b4d741eecfe2438a85140473b110bb7392512",
+				"KeyExpiry":  "2026-11-08T18:54:08Z",
+				"DiscoKey":   "discokey:fea44965172d48ffb62ca95de54f03da1b076bd674ad751777400488bd20aa3a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:49629", "10.65.0.27:49629", "172.17.0.1:49629"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:54:08.357636418Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6539306956443726,
+				"StableID":   "nsdJwHWf4t11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:475fa9a81df138253d4abf021798012727018f41e89066f8e0cf389704dbac32",
+				"KeyExpiry":  "2026-11-08T18:54:08Z",
+				"DiscoKey":   "discokey:048f9cafcb3f558233acffaa72af90f5118a1bfde49a474e6aa0462920f0902f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:38213", "10.65.0.27:38213", "172.17.0.1:38213"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:54:08.896426382Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4469060208632458,
+				"StableID":   "n1vR4kd3ub11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2126353cbdbca8ac938b1e2a0078088feb8304f384e5ce69213819ead0fffa45",
+				"KeyExpiry":  "2026-11-08T18:54:09Z",
+				"DiscoKey":   "discokey:c48b4d2fd6e3b2c2abff711c2d5c9b6c55bce0a5703d52e6f9ebcced7aea8a02",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:35491", "10.65.0.27:35491", "172.17.0.1:35491"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:54:09.433930198Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3097057685873505": {
+				"ID":          3097057685873505,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6699531214773499,
+				"StableID":   "nAkzypKEKu11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       6699531214773499,
+				"Key":        "nodekey:2e5c883ef9f2b0bb7ad6af707b2ea54b1978fc4111dd182eb86d6326a20dd05f",
+				"DiscoKey":   "discokey:269a74b5128ef83f23505f1c7f2ec786a7ac36938fb85d1c81a9bc1c2e66cd22",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:45169", "10.65.0.27:45169", "172.17.0.1:45169"],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:54:05.114383269Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:2e5c883ef9f2b0bb7ad6af707b2ea54b1978fc4111dd182eb86d6326a20dd05f",
+			"MachineKey": "mkey:c6645b2c571b3924373336ec328f35d767b3446993bb2ed3f311ca84284f0d2a",
+			"Peers": [{
+				"ID":         3897792547780688,
+				"StableID":   "nD7s5FQKSX11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f0076188b775e0689535fb9c31d990bf5d95c7df7725049479cd4b87c89df519",
+				"DiscoKey":   "discokey:6d49012f263f61418941da9f8eb54bf302bf5c3159cd92488d52d8774822db01",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:34760", "10.65.0.27:34760", "172.17.0.1:34760"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:54:01.897993709Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8026726004641457,
+				"StableID":   "n2PJouUKg521CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f3731c586c67c0695183f81823b207e37746a68ebe7789ea7a792c3a0d87ab40",
+				"DiscoKey":   "discokey:9644510e21b3a4e74a47d62d910c126bc9fd819787ed82ba78228dfdd71b8f62",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:59407", "10.65.0.27:59407", "172.17.0.1:59407"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:54:02.423058011Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8114285204469608,
+				"StableID":   "nTaNTkWyM621CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7da79e0e97e32fc2f6403acf69d5d2fd54bd3f87fa3eb771befc3f49ac378615",
+				"DiscoKey":   "discokey:23b158ddffae6c88a2374cb060e5967689a909273a530e48ade94d9ff72fa46c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:57732", "10.65.0.27:57732", "172.17.0.1:57732"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:54:02.954874551Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3097057685873505,
+				"StableID":   "ntkqKKTfBR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc921135f0e6ebcfcc5600a13dca256b2a80af11c8da666451a7e254c97a341a",
+				"DiscoKey":   "discokey:ce291560b52a2ec4b7925bb04c67df5a58bebba9a5383ac8c65074c70eea362c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:59502", "10.65.0.27:59502", "172.17.0.1:59502"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:54:03.504634091Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8355216193210735,
+				"StableID":   "neiDuxM6F821CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:622c88ebee766d76f57395143cad7c1830291116d0075d9578d4c0a27a470803",
+				"DiscoKey":   "discokey:4a07a9cc2b8e3ceb63a0801d86d14a62e2643c4a3426c74c86f6ca74762c3333",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:39103", "10.65.0.27:39103", "172.17.0.1:39103"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:54:04.03346603Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3399209927040729,
+				"StableID":   "nnmtCtUWYT11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0dbadfeecb60fa9a7b973a25c603c58676ad9ee4def449a9014b0b0079a8745",
+				"DiscoKey":   "discokey:0f0435a0f9a6c4c4549f9e93eb72464480572bb5f98428c590e1355398b1da13",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:42460", "10.65.0.27:42460", "172.17.0.1:42460"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:54:04.574472809Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         1796629266396125,
+				"StableID":   "nAuC1TQh2F11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:be89e50a1192633e769f46977dfe73da5a62f99d94595e2e782e51e07f39f628",
+				"DiscoKey":   "discokey:4456bfa73aebb6eabc38eb540de896172c9c8570a0e1b6f8ed17f93e89f3834b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:48260", "10.65.0.27:48260", "172.17.0.1:48260"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:54:05.660135064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2055350009717276,
+				"StableID":   "nVwJ9TZs3H11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f44944ff66452fb41228da3b0c34069a3b3ab0397c8be3257b046bdbf0b12d67",
+				"DiscoKey":   "discokey:99d2a0e3b4cd50cb81eb1c502be6d7be8828b09deae5acd7bb7feb950ecb8e20",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:35937", "10.65.0.27:35937", "172.17.0.1:35937"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:54:06.201220848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7724217180562942,
+				"StableID":   "nyzcu46KK321CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c045f71411b49ee2f33ab527ce55537be3db2b0eb051b5f440e58ab5b1811132",
+				"DiscoKey":   "discokey:a1232e943d46aa1d283ef3580487d26d2608bd960a53ed7a38cf4332983e390d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:36234", "10.65.0.27:36234", "172.17.0.1:36234"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:54:06.743488658Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6188909096033515,
+				"StableID":   "nApntY9yKq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af5acad95fc45f5a94cc110e06761a4b826e19bc71eba9fa18f3cba095af096d",
+				"DiscoKey":   "discokey:e48fbefb05535c81445efa3f127ce009c2ec90aea6130308332bb73481428b71",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47189", "10.65.0.27:47189", "172.17.0.1:47189"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:54:07.284202203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4068015540225939,
+				"StableID":   "nk5T2UsQmY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f14f126ce109498d01ace3748777b88f799e67615a6a022d3b71ae834c623031",
+				"DiscoKey":   "discokey:f874d5cd4880492ccf5a38963abe2eab3544deda67d88e71fa5fe51b1c4ff042",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:60376", "10.65.0.27:60376", "172.17.0.1:60376"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:54:07.810914912Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         501181918424048,
+				"StableID":   "nKe2vYCzu411CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:c0c227f5ce6d8644c1ff81c05c4b4d741eecfe2438a85140473b110bb7392512",
+				"KeyExpiry":  "2026-11-08T18:54:08Z",
+				"DiscoKey":   "discokey:fea44965172d48ffb62ca95de54f03da1b076bd674ad751777400488bd20aa3a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:49629", "10.65.0.27:49629", "172.17.0.1:49629"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:54:08.357636418Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6539306956443726,
+				"StableID":   "nsdJwHWf4t11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:475fa9a81df138253d4abf021798012727018f41e89066f8e0cf389704dbac32",
+				"KeyExpiry":  "2026-11-08T18:54:08Z",
+				"DiscoKey":   "discokey:048f9cafcb3f558233acffaa72af90f5118a1bfde49a474e6aa0462920f0902f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:38213", "10.65.0.27:38213", "172.17.0.1:38213"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:54:08.896426382Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4469060208632458,
+				"StableID":   "n1vR4kd3ub11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2126353cbdbca8ac938b1e2a0078088feb8304f384e5ce69213819ead0fffa45",
+				"KeyExpiry":  "2026-11-08T18:54:09Z",
+				"DiscoKey":   "discokey:c48b4d2fd6e3b2c2abff711c2d5c9b6c55bce0a5703d52e6f9ebcced7aea8a02",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:35491", "10.65.0.27:35491", "172.17.0.1:35491"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:54:09.433930198Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6699531214773499": {
+				"ID":          6699531214773499,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2055350009717276,
+				"StableID":   "nVwJ9TZs3H11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       2055350009717276,
+				"Key":        "nodekey:f44944ff66452fb41228da3b0c34069a3b3ab0397c8be3257b046bdbf0b12d67",
+				"DiscoKey":   "discokey:99d2a0e3b4cd50cb81eb1c502be6d7be8828b09deae5acd7bb7feb950ecb8e20",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:35937", "10.65.0.27:35937", "172.17.0.1:35937"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:54:06.201220848Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f44944ff66452fb41228da3b0c34069a3b3ab0397c8be3257b046bdbf0b12d67",
+			"MachineKey": "mkey:e556ca0e77e2c1b19175e470432ff3df642b28539572008a828c81c92377ae72",
+			"Peers": [{
+				"ID":         3897792547780688,
+				"StableID":   "nD7s5FQKSX11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f0076188b775e0689535fb9c31d990bf5d95c7df7725049479cd4b87c89df519",
+				"DiscoKey":   "discokey:6d49012f263f61418941da9f8eb54bf302bf5c3159cd92488d52d8774822db01",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:34760", "10.65.0.27:34760", "172.17.0.1:34760"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:54:01.897993709Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8026726004641457,
+				"StableID":   "n2PJouUKg521CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f3731c586c67c0695183f81823b207e37746a68ebe7789ea7a792c3a0d87ab40",
+				"DiscoKey":   "discokey:9644510e21b3a4e74a47d62d910c126bc9fd819787ed82ba78228dfdd71b8f62",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:59407", "10.65.0.27:59407", "172.17.0.1:59407"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:54:02.423058011Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8114285204469608,
+				"StableID":   "nTaNTkWyM621CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7da79e0e97e32fc2f6403acf69d5d2fd54bd3f87fa3eb771befc3f49ac378615",
+				"DiscoKey":   "discokey:23b158ddffae6c88a2374cb060e5967689a909273a530e48ade94d9ff72fa46c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:57732", "10.65.0.27:57732", "172.17.0.1:57732"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:54:02.954874551Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3097057685873505,
+				"StableID":   "ntkqKKTfBR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc921135f0e6ebcfcc5600a13dca256b2a80af11c8da666451a7e254c97a341a",
+				"DiscoKey":   "discokey:ce291560b52a2ec4b7925bb04c67df5a58bebba9a5383ac8c65074c70eea362c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:59502", "10.65.0.27:59502", "172.17.0.1:59502"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:54:03.504634091Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8355216193210735,
+				"StableID":   "neiDuxM6F821CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:622c88ebee766d76f57395143cad7c1830291116d0075d9578d4c0a27a470803",
+				"DiscoKey":   "discokey:4a07a9cc2b8e3ceb63a0801d86d14a62e2643c4a3426c74c86f6ca74762c3333",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:39103", "10.65.0.27:39103", "172.17.0.1:39103"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:54:04.03346603Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3399209927040729,
+				"StableID":   "nnmtCtUWYT11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0dbadfeecb60fa9a7b973a25c603c58676ad9ee4def449a9014b0b0079a8745",
+				"DiscoKey":   "discokey:0f0435a0f9a6c4c4549f9e93eb72464480572bb5f98428c590e1355398b1da13",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:42460", "10.65.0.27:42460", "172.17.0.1:42460"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:54:04.574472809Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6699531214773499,
+				"StableID":   "nAkzypKEKu11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2e5c883ef9f2b0bb7ad6af707b2ea54b1978fc4111dd182eb86d6326a20dd05f",
+				"DiscoKey":   "discokey:269a74b5128ef83f23505f1c7f2ec786a7ac36938fb85d1c81a9bc1c2e66cd22",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:45169", "10.65.0.27:45169", "172.17.0.1:45169"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:54:05.114383269Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1796629266396125,
+				"StableID":   "nAuC1TQh2F11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:be89e50a1192633e769f46977dfe73da5a62f99d94595e2e782e51e07f39f628",
+				"DiscoKey":   "discokey:4456bfa73aebb6eabc38eb540de896172c9c8570a0e1b6f8ed17f93e89f3834b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:48260", "10.65.0.27:48260", "172.17.0.1:48260"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:54:05.660135064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         7724217180562942,
+				"StableID":   "nyzcu46KK321CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c045f71411b49ee2f33ab527ce55537be3db2b0eb051b5f440e58ab5b1811132",
+				"DiscoKey":   "discokey:a1232e943d46aa1d283ef3580487d26d2608bd960a53ed7a38cf4332983e390d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:36234", "10.65.0.27:36234", "172.17.0.1:36234"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:54:06.743488658Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6188909096033515,
+				"StableID":   "nApntY9yKq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af5acad95fc45f5a94cc110e06761a4b826e19bc71eba9fa18f3cba095af096d",
+				"DiscoKey":   "discokey:e48fbefb05535c81445efa3f127ce009c2ec90aea6130308332bb73481428b71",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47189", "10.65.0.27:47189", "172.17.0.1:47189"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:54:07.284202203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4068015540225939,
+				"StableID":   "nk5T2UsQmY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f14f126ce109498d01ace3748777b88f799e67615a6a022d3b71ae834c623031",
+				"DiscoKey":   "discokey:f874d5cd4880492ccf5a38963abe2eab3544deda67d88e71fa5fe51b1c4ff042",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:60376", "10.65.0.27:60376", "172.17.0.1:60376"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:54:07.810914912Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         501181918424048,
+				"StableID":   "nKe2vYCzu411CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:c0c227f5ce6d8644c1ff81c05c4b4d741eecfe2438a85140473b110bb7392512",
+				"KeyExpiry":  "2026-11-08T18:54:08Z",
+				"DiscoKey":   "discokey:fea44965172d48ffb62ca95de54f03da1b076bd674ad751777400488bd20aa3a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:49629", "10.65.0.27:49629", "172.17.0.1:49629"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:54:08.357636418Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6539306956443726,
+				"StableID":   "nsdJwHWf4t11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:475fa9a81df138253d4abf021798012727018f41e89066f8e0cf389704dbac32",
+				"KeyExpiry":  "2026-11-08T18:54:08Z",
+				"DiscoKey":   "discokey:048f9cafcb3f558233acffaa72af90f5118a1bfde49a474e6aa0462920f0902f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:38213", "10.65.0.27:38213", "172.17.0.1:38213"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:54:08.896426382Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4469060208632458,
+				"StableID":   "n1vR4kd3ub11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2126353cbdbca8ac938b1e2a0078088feb8304f384e5ce69213819ead0fffa45",
+				"KeyExpiry":  "2026-11-08T18:54:09Z",
+				"DiscoKey":   "discokey:c48b4d2fd6e3b2c2abff711c2d5c9b6c55bce0a5703d52e6f9ebcced7aea8a02",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:35491", "10.65.0.27:35491", "172.17.0.1:35491"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:54:09.433930198Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2055350009717276": {
+				"ID":          2055350009717276,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6539306956443726,
+				"StableID":   "nsdJwHWf4t11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:475fa9a81df138253d4abf021798012727018f41e89066f8e0cf389704dbac32",
+				"KeyExpiry":  "2026-11-08T18:54:08Z",
+				"DiscoKey":   "discokey:048f9cafcb3f558233acffaa72af90f5118a1bfde49a474e6aa0462920f0902f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:38213", "10.65.0.27:38213", "172.17.0.1:38213"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:54:08.896426382Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:475fa9a81df138253d4abf021798012727018f41e89066f8e0cf389704dbac32",
+			"MachineKey": "mkey:0651460b23e9440ba21fe832a232489bd75287f9fd3489735310f850f88a604a",
+			"Peers": [{
+				"ID":         3897792547780688,
+				"StableID":   "nD7s5FQKSX11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f0076188b775e0689535fb9c31d990bf5d95c7df7725049479cd4b87c89df519",
+				"DiscoKey":   "discokey:6d49012f263f61418941da9f8eb54bf302bf5c3159cd92488d52d8774822db01",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:34760", "10.65.0.27:34760", "172.17.0.1:34760"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:54:01.897993709Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8026726004641457,
+				"StableID":   "n2PJouUKg521CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f3731c586c67c0695183f81823b207e37746a68ebe7789ea7a792c3a0d87ab40",
+				"DiscoKey":   "discokey:9644510e21b3a4e74a47d62d910c126bc9fd819787ed82ba78228dfdd71b8f62",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:59407", "10.65.0.27:59407", "172.17.0.1:59407"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:54:02.423058011Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8114285204469608,
+				"StableID":   "nTaNTkWyM621CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7da79e0e97e32fc2f6403acf69d5d2fd54bd3f87fa3eb771befc3f49ac378615",
+				"DiscoKey":   "discokey:23b158ddffae6c88a2374cb060e5967689a909273a530e48ade94d9ff72fa46c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:57732", "10.65.0.27:57732", "172.17.0.1:57732"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:54:02.954874551Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3097057685873505,
+				"StableID":   "ntkqKKTfBR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc921135f0e6ebcfcc5600a13dca256b2a80af11c8da666451a7e254c97a341a",
+				"DiscoKey":   "discokey:ce291560b52a2ec4b7925bb04c67df5a58bebba9a5383ac8c65074c70eea362c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:59502", "10.65.0.27:59502", "172.17.0.1:59502"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:54:03.504634091Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8355216193210735,
+				"StableID":   "neiDuxM6F821CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:622c88ebee766d76f57395143cad7c1830291116d0075d9578d4c0a27a470803",
+				"DiscoKey":   "discokey:4a07a9cc2b8e3ceb63a0801d86d14a62e2643c4a3426c74c86f6ca74762c3333",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:39103", "10.65.0.27:39103", "172.17.0.1:39103"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:54:04.03346603Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3399209927040729,
+				"StableID":   "nnmtCtUWYT11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0dbadfeecb60fa9a7b973a25c603c58676ad9ee4def449a9014b0b0079a8745",
+				"DiscoKey":   "discokey:0f0435a0f9a6c4c4549f9e93eb72464480572bb5f98428c590e1355398b1da13",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:42460", "10.65.0.27:42460", "172.17.0.1:42460"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:54:04.574472809Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6699531214773499,
+				"StableID":   "nAkzypKEKu11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2e5c883ef9f2b0bb7ad6af707b2ea54b1978fc4111dd182eb86d6326a20dd05f",
+				"DiscoKey":   "discokey:269a74b5128ef83f23505f1c7f2ec786a7ac36938fb85d1c81a9bc1c2e66cd22",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:45169", "10.65.0.27:45169", "172.17.0.1:45169"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:54:05.114383269Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1796629266396125,
+				"StableID":   "nAuC1TQh2F11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:be89e50a1192633e769f46977dfe73da5a62f99d94595e2e782e51e07f39f628",
+				"DiscoKey":   "discokey:4456bfa73aebb6eabc38eb540de896172c9c8570a0e1b6f8ed17f93e89f3834b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:48260", "10.65.0.27:48260", "172.17.0.1:48260"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:54:05.660135064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2055350009717276,
+				"StableID":   "nVwJ9TZs3H11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f44944ff66452fb41228da3b0c34069a3b3ab0397c8be3257b046bdbf0b12d67",
+				"DiscoKey":   "discokey:99d2a0e3b4cd50cb81eb1c502be6d7be8828b09deae5acd7bb7feb950ecb8e20",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:35937", "10.65.0.27:35937", "172.17.0.1:35937"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:54:06.201220848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7724217180562942,
+				"StableID":   "nyzcu46KK321CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c045f71411b49ee2f33ab527ce55537be3db2b0eb051b5f440e58ab5b1811132",
+				"DiscoKey":   "discokey:a1232e943d46aa1d283ef3580487d26d2608bd960a53ed7a38cf4332983e390d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:36234", "10.65.0.27:36234", "172.17.0.1:36234"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:54:06.743488658Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6188909096033515,
+				"StableID":   "nApntY9yKq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af5acad95fc45f5a94cc110e06761a4b826e19bc71eba9fa18f3cba095af096d",
+				"DiscoKey":   "discokey:e48fbefb05535c81445efa3f127ce009c2ec90aea6130308332bb73481428b71",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47189", "10.65.0.27:47189", "172.17.0.1:47189"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:54:07.284202203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4068015540225939,
+				"StableID":   "nk5T2UsQmY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f14f126ce109498d01ace3748777b88f799e67615a6a022d3b71ae834c623031",
+				"DiscoKey":   "discokey:f874d5cd4880492ccf5a38963abe2eab3544deda67d88e71fa5fe51b1c4ff042",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:60376", "10.65.0.27:60376", "172.17.0.1:60376"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:54:07.810914912Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         501181918424048,
+				"StableID":   "nKe2vYCzu411CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:c0c227f5ce6d8644c1ff81c05c4b4d741eecfe2438a85140473b110bb7392512",
+				"KeyExpiry":  "2026-11-08T18:54:08Z",
+				"DiscoKey":   "discokey:fea44965172d48ffb62ca95de54f03da1b076bd674ad751777400488bd20aa3a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:49629", "10.65.0.27:49629", "172.17.0.1:49629"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:54:08.357636418Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4469060208632458,
+				"StableID":   "n1vR4kd3ub11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2126353cbdbca8ac938b1e2a0078088feb8304f384e5ce69213819ead0fffa45",
+				"KeyExpiry":  "2026-11-08T18:54:09Z",
+				"DiscoKey":   "discokey:c48b4d2fd6e3b2c2abff711c2d5c9b6c55bce0a5703d52e6f9ebcced7aea8a02",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:35491", "10.65.0.27:35491", "172.17.0.1:35491"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:54:09.433930198Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7724217180562942,
+				"StableID":   "nyzcu46KK321CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       7724217180562942,
+				"Key":        "nodekey:c045f71411b49ee2f33ab527ce55537be3db2b0eb051b5f440e58ab5b1811132",
+				"DiscoKey":   "discokey:a1232e943d46aa1d283ef3580487d26d2608bd960a53ed7a38cf4332983e390d",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:36234", "10.65.0.27:36234", "172.17.0.1:36234"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:54:06.743488658Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c045f71411b49ee2f33ab527ce55537be3db2b0eb051b5f440e58ab5b1811132",
+			"MachineKey": "mkey:ac5131f07499e03784a82e35375917d869fa46fdd1ff4663fa77b7b11eb2d959",
+			"Peers": [{
+				"ID":         3897792547780688,
+				"StableID":   "nD7s5FQKSX11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f0076188b775e0689535fb9c31d990bf5d95c7df7725049479cd4b87c89df519",
+				"DiscoKey":   "discokey:6d49012f263f61418941da9f8eb54bf302bf5c3159cd92488d52d8774822db01",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:34760", "10.65.0.27:34760", "172.17.0.1:34760"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:54:01.897993709Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8026726004641457,
+				"StableID":   "n2PJouUKg521CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f3731c586c67c0695183f81823b207e37746a68ebe7789ea7a792c3a0d87ab40",
+				"DiscoKey":   "discokey:9644510e21b3a4e74a47d62d910c126bc9fd819787ed82ba78228dfdd71b8f62",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:59407", "10.65.0.27:59407", "172.17.0.1:59407"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:54:02.423058011Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         8114285204469608,
+				"StableID":   "nTaNTkWyM621CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7da79e0e97e32fc2f6403acf69d5d2fd54bd3f87fa3eb771befc3f49ac378615",
+				"DiscoKey":   "discokey:23b158ddffae6c88a2374cb060e5967689a909273a530e48ade94d9ff72fa46c",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:57732", "10.65.0.27:57732", "172.17.0.1:57732"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:54:02.954874551Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         3097057685873505,
+				"StableID":   "ntkqKKTfBR11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:fc921135f0e6ebcfcc5600a13dca256b2a80af11c8da666451a7e254c97a341a",
+				"DiscoKey":   "discokey:ce291560b52a2ec4b7925bb04c67df5a58bebba9a5383ac8c65074c70eea362c",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:59502", "10.65.0.27:59502", "172.17.0.1:59502"],
+				"HomeDERP":   8,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:54:03.504634091Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         8355216193210735,
+				"StableID":   "neiDuxM6F821CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:622c88ebee766d76f57395143cad7c1830291116d0075d9578d4c0a27a470803",
+				"DiscoKey":   "discokey:4a07a9cc2b8e3ceb63a0801d86d14a62e2643c4a3426c74c86f6ca74762c3333",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:39103", "10.65.0.27:39103", "172.17.0.1:39103"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:54:04.03346603Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3399209927040729,
+				"StableID":   "nnmtCtUWYT11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e0dbadfeecb60fa9a7b973a25c603c58676ad9ee4def449a9014b0b0079a8745",
+				"DiscoKey":   "discokey:0f0435a0f9a6c4c4549f9e93eb72464480572bb5f98428c590e1355398b1da13",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:42460", "10.65.0.27:42460", "172.17.0.1:42460"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:54:04.574472809Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6699531214773499,
+				"StableID":   "nAkzypKEKu11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:2e5c883ef9f2b0bb7ad6af707b2ea54b1978fc4111dd182eb86d6326a20dd05f",
+				"DiscoKey":   "discokey:269a74b5128ef83f23505f1c7f2ec786a7ac36938fb85d1c81a9bc1c2e66cd22",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:45169", "10.65.0.27:45169", "172.17.0.1:45169"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:54:05.114383269Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         1796629266396125,
+				"StableID":   "nAuC1TQh2F11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:be89e50a1192633e769f46977dfe73da5a62f99d94595e2e782e51e07f39f628",
+				"DiscoKey":   "discokey:4456bfa73aebb6eabc38eb540de896172c9c8570a0e1b6f8ed17f93e89f3834b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:48260", "10.65.0.27:48260", "172.17.0.1:48260"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:54:05.660135064Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2055350009717276,
+				"StableID":   "nVwJ9TZs3H11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f44944ff66452fb41228da3b0c34069a3b3ab0397c8be3257b046bdbf0b12d67",
+				"DiscoKey":   "discokey:99d2a0e3b4cd50cb81eb1c502be6d7be8828b09deae5acd7bb7feb950ecb8e20",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:35937", "10.65.0.27:35937", "172.17.0.1:35937"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:54:06.201220848Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         6188909096033515,
+				"StableID":   "nApntY9yKq11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:af5acad95fc45f5a94cc110e06761a4b826e19bc71eba9fa18f3cba095af096d",
+				"DiscoKey":   "discokey:e48fbefb05535c81445efa3f127ce009c2ec90aea6130308332bb73481428b71",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47189", "10.65.0.27:47189", "172.17.0.1:47189"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:54:07.284202203Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4068015540225939,
+				"StableID":   "nk5T2UsQmY11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:f14f126ce109498d01ace3748777b88f799e67615a6a022d3b71ae834c623031",
+				"DiscoKey":   "discokey:f874d5cd4880492ccf5a38963abe2eab3544deda67d88e71fa5fe51b1c4ff042",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:60376", "10.65.0.27:60376", "172.17.0.1:60376"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:54:07.810914912Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         501181918424048,
+				"StableID":   "nKe2vYCzu411CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:c0c227f5ce6d8644c1ff81c05c4b4d741eecfe2438a85140473b110bb7392512",
+				"KeyExpiry":  "2026-11-08T18:54:08Z",
+				"DiscoKey":   "discokey:fea44965172d48ffb62ca95de54f03da1b076bd674ad751777400488bd20aa3a",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:49629", "10.65.0.27:49629", "172.17.0.1:49629"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:54:08.357636418Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         6539306956443726,
+				"StableID":   "nsdJwHWf4t11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:475fa9a81df138253d4abf021798012727018f41e89066f8e0cf389704dbac32",
+				"KeyExpiry":  "2026-11-08T18:54:08Z",
+				"DiscoKey":   "discokey:048f9cafcb3f558233acffaa72af90f5118a1bfde49a474e6aa0462920f0902f",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:38213", "10.65.0.27:38213", "172.17.0.1:38213"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:54:08.896426382Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4469060208632458,
+				"StableID":   "n1vR4kd3ub11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:2126353cbdbca8ac938b1e2a0078088feb8304f384e5ce69213819ead0fffa45",
+				"KeyExpiry":  "2026-11-08T18:54:09Z",
+				"DiscoKey":   "discokey:c48b4d2fd6e3b2c2abff711c2d5c9b6c55bce0a5703d52e6f9ebcced7aea8a02",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:35491", "10.65.0.27:35491", "172.17.0.1:35491"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:54:09.433930198Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7724217180562942": {
+				"ID":          7724217180562942,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/sshtest_results/sshtest-user-nonroot-blocks-root.hujson
+++ b/hscontrol/policy/v2/testdata/sshtest_results/sshtest-user-nonroot-blocks-root.hujson
@@ -1,0 +1,18732 @@
+// sshtest-user-nonroot-blocks-root
+//
+// autogroup:nonroot blocks root, accept must fail
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T18:54:54Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "sshtest-user-nonroot-blocks-root",
+	"description":    "autogroup:nonroot blocks root, accept must fail",
+	"category":       "sshtest",
+	"captured_at":    "2026-05-12T18:54:54.701473079Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "test(s) failed"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                                   \n  \n                                                                       \n                       \n{\n\t\"category\":    \"sshtest\",\n\t\"description\": \"autogroup:nonroot blocks root, accept must fail\",\n\t\"id\":          \"sshtest-user-nonroot-blocks-root\",\n\t\"options\":     {\"expect_api_error\": true},\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"thor@example.org\"],\n\t\t\"users\":  [\"autogroup:nonroot\"]\n\t}], \"sshTests\": [{\n\t\t\"accept\": [\"root\"],\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    \"thor@example.org\"\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/sshtest/sshtest-user-nonroot-blocks-root.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["thor@example.org"],
+				"users":  ["autogroup:nonroot"]
+			}],
+			"sshTests":  [{"accept": ["root"], "dst": ["tag:server"], "src": "thor@example.org"}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4142969531082554,
+				"StableID":   "nmvgXVnMMZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       4142969531082554,
+				"Key":        "nodekey:c64e08dc977990e0094b182fa6b8ecb09d47ace847f52ded4865105b26c15e1d",
+				"DiscoKey":   "discokey:e186e1d9a6a0ed9548fb249b9c8009e271e6b3e7203e90af2a94b363a7a6957b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:34846", "10.65.0.27:34846", "172.17.0.1:34846"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:55:03.128402107Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c64e08dc977990e0094b182fa6b8ecb09d47ace847f52ded4865105b26c15e1d",
+			"MachineKey": "mkey:225ad5f5164a740ae9b1a9d090b79b07508d43705ed729abc90fd4c116f8b720",
+			"Peers": [{
+				"ID":         8411209950237823,
+				"StableID":   "nxf6UuDTg821CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93dd379d75307db94ff41c81cf35e2ce3ef8a17753c331b8ae1d01486bc14133",
+				"DiscoKey":   "discokey:d6e5d845d4a61d9611039a7a095f2b1c6b5774d1d999f2e66994ae5839be7f5d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:34767", "10.65.0.27:34767", "172.17.0.1:34767"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:54:57.307437635Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8527559154668666,
+				"StableID":   "nyY8F6X9b921CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:18063902586de112035697a7d33c0b0d2437ce86e16ef2fa677c8720d36be118",
+				"DiscoKey":   "discokey:e04f2c91eb9a62c83a908a697e964ae8db5c2669adb58658701e39751ca7b87f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:43915", "10.65.0.27:43915", "172.17.0.1:43915"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:54:57.798391545Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4392928306204163,
+				"StableID":   "ncdVY6nZJb11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7733a8a95d8a6b8d17ae2bc849ff1bdfc2e0876530d475914b13acf2154e970a",
+				"DiscoKey":   "discokey:265fb145c3dd754d0d9008806c47e519d76eef4544263361a634bf3a2e636866",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41036", "10.65.0.27:41036", "172.17.0.1:41036"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:54:58.316468705Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1207939473313067,
+				"StableID":   "nkh1sFX5SA11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:233cb7f748e22261a3f8566bb29545ef608acd94b0f100120fc0273ab86a2717",
+				"DiscoKey":   "discokey:a06ab142ed29e39b67b81ec4a1ce23bd1beb0b37edf5678b6729b847bee38157",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:34232", "10.65.0.27:34232", "172.17.0.1:34232"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:54:58.87037937Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1627276155753729,
+				"StableID":   "npgEYYnzhD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca438abc65fffc9b2bab312b7b07f42bc583d5a0a63663b6a4299666b4693b71",
+				"DiscoKey":   "discokey:252fa7692cd2f4bb76de4ea1ddd0cf02aee70c14cd5c626ba0e7f0ff8ae0a305",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:38759", "10.65.0.27:38759", "172.17.0.1:38759"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:54:59.370753878Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4802895802744196,
+				"StableID":   "notyLrvEWe11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0c2a07339f8330edf21ea79b553d5179ba72ce89847990f43db3bf887d87e6d",
+				"DiscoKey":   "discokey:727125a1a4a8effad0fdc231628ed4ddc54f234c49991b01afa487f12e133979",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:57755", "10.65.0.27:57755", "172.17.0.1:57755"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:54:59.905418907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2735199946774139,
+				"StableID":   "nvpZ3k4nMN11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6de85e40f009cdbb62357629ec0b6ee633584623f61287320fcc63acb947a7f",
+				"DiscoKey":   "discokey:ea96b2b8ff76a83c5af36558bd12f7cc29a71fd7db4349be1d9ca5e3fcff0f58",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:41697", "10.65.0.27:41697", "172.17.0.1:41697"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:55:00.445932525Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5616856630506496,
+				"StableID":   "nsE8RMJtrk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b07f7b08f86823c6d44606204b33fe7ccca8ed9bb4399aebfff18bf34997224c",
+				"DiscoKey":   "discokey:515308583964bbf064a71780cf6ef30726522f0fb162462e8854ce92cbfe4f4b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:36882", "10.65.0.27:36882", "172.17.0.1:36882"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:55:00.989848739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4120313125665865,
+				"StableID":   "ngroZ4e6BZ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6fb376f47fa693213dfca72b61c95eb2f23ebed8522a14b2fe191e0db7cf091b",
+				"DiscoKey":   "discokey:f6cf1fe5bfe11aa31ad82de309ed5557ba85cc40ab52888af04ee6d0e03cb138",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:47911", "10.65.0.27:47911", "172.17.0.1:47911"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:55:01.516466376Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5934169217031598,
+				"StableID":   "nmes6eZbLo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:16d40a42b3b8c7315c450b7a7da71c56927b39a2dd6b7280977c934aaee31f62",
+				"DiscoKey":   "discokey:2ecc3cc255d5ae9e7acaa82ee269721f6792799cec4e4a2f8ee33a91d0c51a27",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:35139", "10.65.0.27:35139", "172.17.0.1:35139"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:55:02.06320188Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3829371369919846,
+				"StableID":   "ns7qtM6LuW11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db797d297cfa42c98d66a85a927be03bd41ddb20317364b14f149e31cf258428",
+				"DiscoKey":   "discokey:3be0883118c8903cae09ad9bf645ef349e73f75eec4042bd473db8859d33c547",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43303", "10.65.0.27:43303", "172.17.0.1:43303"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:55:02.592956052Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4800455758014461,
+				"StableID":   "nEdwwHq8Ve11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:13dfcf0fde718814e3ed7ede12f418bb29efeb7b74504cb9a5b80705c43f985e",
+				"KeyExpiry":  "2026-11-08T18:55:03Z",
+				"DiscoKey":   "discokey:87f03b040575e96d175b430d152c82bb51377bec227b970abdd5fd8cd249bd1d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:39636", "10.65.0.27:39636", "172.17.0.1:39636"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:55:03.668345456Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         495872617439219,
+				"StableID":   "n68hAWjas411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:13e613e286484cf36612d9e22d3bd3f85eebd6bd2c41a36dca1d2cebd51a875d",
+				"KeyExpiry":  "2026-11-08T18:55:04Z",
+				"DiscoKey":   "discokey:cc03681f9cc0baf6ed18522e08ccce3dd47c3549764f4386874d9ee95ba67f16",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:58189", "10.65.0.27:58189", "172.17.0.1:58189"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:55:04.199017017Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4633119923072565,
+				"StableID":   "nkLEEqCMBd11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fbb938f4369157493487e4f585a31f43051f3fcfaf242c3eae351cb65f78397b",
+				"KeyExpiry":  "2026-11-08T18:55:04Z",
+				"DiscoKey":   "discokey:3e4645543c5b7f8f36a0f08e879e82369fb7b9c7c4af7e880111cd54ada6ea39",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:41264", "10.65.0.27:41264", "172.17.0.1:41264"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:55:04.736959081Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4142969531082554": {
+				"ID":          4142969531082554,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4802895802744196,
+				"StableID":   "notyLrvEWe11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       4802895802744196,
+				"Key":        "nodekey:a0c2a07339f8330edf21ea79b553d5179ba72ce89847990f43db3bf887d87e6d",
+				"DiscoKey":   "discokey:727125a1a4a8effad0fdc231628ed4ddc54f234c49991b01afa487f12e133979",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:57755", "10.65.0.27:57755", "172.17.0.1:57755"],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:54:59.905418907Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:a0c2a07339f8330edf21ea79b553d5179ba72ce89847990f43db3bf887d87e6d",
+			"MachineKey": "mkey:3191d5b26f59c8e9ce89a88834a6a9fbfab33f79cab41c8d7b1c6e0a54562a3e",
+			"Peers": [{
+				"ID":         8411209950237823,
+				"StableID":   "nxf6UuDTg821CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93dd379d75307db94ff41c81cf35e2ce3ef8a17753c331b8ae1d01486bc14133",
+				"DiscoKey":   "discokey:d6e5d845d4a61d9611039a7a095f2b1c6b5774d1d999f2e66994ae5839be7f5d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:34767", "10.65.0.27:34767", "172.17.0.1:34767"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:54:57.307437635Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8527559154668666,
+				"StableID":   "nyY8F6X9b921CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:18063902586de112035697a7d33c0b0d2437ce86e16ef2fa677c8720d36be118",
+				"DiscoKey":   "discokey:e04f2c91eb9a62c83a908a697e964ae8db5c2669adb58658701e39751ca7b87f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:43915", "10.65.0.27:43915", "172.17.0.1:43915"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:54:57.798391545Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4392928306204163,
+				"StableID":   "ncdVY6nZJb11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7733a8a95d8a6b8d17ae2bc849ff1bdfc2e0876530d475914b13acf2154e970a",
+				"DiscoKey":   "discokey:265fb145c3dd754d0d9008806c47e519d76eef4544263361a634bf3a2e636866",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41036", "10.65.0.27:41036", "172.17.0.1:41036"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:54:58.316468705Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1207939473313067,
+				"StableID":   "nkh1sFX5SA11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:233cb7f748e22261a3f8566bb29545ef608acd94b0f100120fc0273ab86a2717",
+				"DiscoKey":   "discokey:a06ab142ed29e39b67b81ec4a1ce23bd1beb0b37edf5678b6729b847bee38157",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:34232", "10.65.0.27:34232", "172.17.0.1:34232"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:54:58.87037937Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1627276155753729,
+				"StableID":   "npgEYYnzhD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca438abc65fffc9b2bab312b7b07f42bc583d5a0a63663b6a4299666b4693b71",
+				"DiscoKey":   "discokey:252fa7692cd2f4bb76de4ea1ddd0cf02aee70c14cd5c626ba0e7f0ff8ae0a305",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:38759", "10.65.0.27:38759", "172.17.0.1:38759"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:54:59.370753878Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2735199946774139,
+				"StableID":   "nvpZ3k4nMN11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6de85e40f009cdbb62357629ec0b6ee633584623f61287320fcc63acb947a7f",
+				"DiscoKey":   "discokey:ea96b2b8ff76a83c5af36558bd12f7cc29a71fd7db4349be1d9ca5e3fcff0f58",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:41697", "10.65.0.27:41697", "172.17.0.1:41697"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:55:00.445932525Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5616856630506496,
+				"StableID":   "nsE8RMJtrk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b07f7b08f86823c6d44606204b33fe7ccca8ed9bb4399aebfff18bf34997224c",
+				"DiscoKey":   "discokey:515308583964bbf064a71780cf6ef30726522f0fb162462e8854ce92cbfe4f4b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:36882", "10.65.0.27:36882", "172.17.0.1:36882"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:55:00.989848739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4120313125665865,
+				"StableID":   "ngroZ4e6BZ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6fb376f47fa693213dfca72b61c95eb2f23ebed8522a14b2fe191e0db7cf091b",
+				"DiscoKey":   "discokey:f6cf1fe5bfe11aa31ad82de309ed5557ba85cc40ab52888af04ee6d0e03cb138",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:47911", "10.65.0.27:47911", "172.17.0.1:47911"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:55:01.516466376Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5934169217031598,
+				"StableID":   "nmes6eZbLo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:16d40a42b3b8c7315c450b7a7da71c56927b39a2dd6b7280977c934aaee31f62",
+				"DiscoKey":   "discokey:2ecc3cc255d5ae9e7acaa82ee269721f6792799cec4e4a2f8ee33a91d0c51a27",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:35139", "10.65.0.27:35139", "172.17.0.1:35139"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:55:02.06320188Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3829371369919846,
+				"StableID":   "ns7qtM6LuW11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db797d297cfa42c98d66a85a927be03bd41ddb20317364b14f149e31cf258428",
+				"DiscoKey":   "discokey:3be0883118c8903cae09ad9bf645ef349e73f75eec4042bd473db8859d33c547",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43303", "10.65.0.27:43303", "172.17.0.1:43303"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:55:02.592956052Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4142969531082554,
+				"StableID":   "nmvgXVnMMZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c64e08dc977990e0094b182fa6b8ecb09d47ace847f52ded4865105b26c15e1d",
+				"DiscoKey":   "discokey:e186e1d9a6a0ed9548fb249b9c8009e271e6b3e7203e90af2a94b363a7a6957b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:34846", "10.65.0.27:34846", "172.17.0.1:34846"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:55:03.128402107Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4800455758014461,
+				"StableID":   "nEdwwHq8Ve11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:13dfcf0fde718814e3ed7ede12f418bb29efeb7b74504cb9a5b80705c43f985e",
+				"KeyExpiry":  "2026-11-08T18:55:03Z",
+				"DiscoKey":   "discokey:87f03b040575e96d175b430d152c82bb51377bec227b970abdd5fd8cd249bd1d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:39636", "10.65.0.27:39636", "172.17.0.1:39636"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:55:03.668345456Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         495872617439219,
+				"StableID":   "n68hAWjas411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:13e613e286484cf36612d9e22d3bd3f85eebd6bd2c41a36dca1d2cebd51a875d",
+				"KeyExpiry":  "2026-11-08T18:55:04Z",
+				"DiscoKey":   "discokey:cc03681f9cc0baf6ed18522e08ccce3dd47c3549764f4386874d9ee95ba67f16",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:58189", "10.65.0.27:58189", "172.17.0.1:58189"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:55:04.199017017Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4633119923072565,
+				"StableID":   "nkLEEqCMBd11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fbb938f4369157493487e4f585a31f43051f3fcfaf242c3eae351cb65f78397b",
+				"KeyExpiry":  "2026-11-08T18:55:04Z",
+				"DiscoKey":   "discokey:3e4645543c5b7f8f36a0f08e879e82369fb7b9c7c4af7e880111cd54ada6ea39",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:41264", "10.65.0.27:41264", "172.17.0.1:41264"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:55:04.736959081Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4802895802744196": {
+				"ID":          4802895802744196,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4633119923072565,
+				"StableID":   "nkLEEqCMBd11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fbb938f4369157493487e4f585a31f43051f3fcfaf242c3eae351cb65f78397b",
+				"KeyExpiry":  "2026-11-08T18:55:04Z",
+				"DiscoKey":   "discokey:3e4645543c5b7f8f36a0f08e879e82369fb7b9c7c4af7e880111cd54ada6ea39",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:41264", "10.65.0.27:41264", "172.17.0.1:41264"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:55:04.736959081Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:fbb938f4369157493487e4f585a31f43051f3fcfaf242c3eae351cb65f78397b",
+			"MachineKey": "mkey:bfce599557df47aa9527f9b4d672eb3d02c8667dab43b981a508b6a63b45ae76",
+			"Peers": [{
+				"ID":         8411209950237823,
+				"StableID":   "nxf6UuDTg821CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93dd379d75307db94ff41c81cf35e2ce3ef8a17753c331b8ae1d01486bc14133",
+				"DiscoKey":   "discokey:d6e5d845d4a61d9611039a7a095f2b1c6b5774d1d999f2e66994ae5839be7f5d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:34767", "10.65.0.27:34767", "172.17.0.1:34767"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:54:57.307437635Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8527559154668666,
+				"StableID":   "nyY8F6X9b921CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:18063902586de112035697a7d33c0b0d2437ce86e16ef2fa677c8720d36be118",
+				"DiscoKey":   "discokey:e04f2c91eb9a62c83a908a697e964ae8db5c2669adb58658701e39751ca7b87f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:43915", "10.65.0.27:43915", "172.17.0.1:43915"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:54:57.798391545Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4392928306204163,
+				"StableID":   "ncdVY6nZJb11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7733a8a95d8a6b8d17ae2bc849ff1bdfc2e0876530d475914b13acf2154e970a",
+				"DiscoKey":   "discokey:265fb145c3dd754d0d9008806c47e519d76eef4544263361a634bf3a2e636866",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41036", "10.65.0.27:41036", "172.17.0.1:41036"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:54:58.316468705Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1207939473313067,
+				"StableID":   "nkh1sFX5SA11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:233cb7f748e22261a3f8566bb29545ef608acd94b0f100120fc0273ab86a2717",
+				"DiscoKey":   "discokey:a06ab142ed29e39b67b81ec4a1ce23bd1beb0b37edf5678b6729b847bee38157",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:34232", "10.65.0.27:34232", "172.17.0.1:34232"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:54:58.87037937Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1627276155753729,
+				"StableID":   "npgEYYnzhD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca438abc65fffc9b2bab312b7b07f42bc583d5a0a63663b6a4299666b4693b71",
+				"DiscoKey":   "discokey:252fa7692cd2f4bb76de4ea1ddd0cf02aee70c14cd5c626ba0e7f0ff8ae0a305",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:38759", "10.65.0.27:38759", "172.17.0.1:38759"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:54:59.370753878Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4802895802744196,
+				"StableID":   "notyLrvEWe11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0c2a07339f8330edf21ea79b553d5179ba72ce89847990f43db3bf887d87e6d",
+				"DiscoKey":   "discokey:727125a1a4a8effad0fdc231628ed4ddc54f234c49991b01afa487f12e133979",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:57755", "10.65.0.27:57755", "172.17.0.1:57755"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:54:59.905418907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2735199946774139,
+				"StableID":   "nvpZ3k4nMN11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6de85e40f009cdbb62357629ec0b6ee633584623f61287320fcc63acb947a7f",
+				"DiscoKey":   "discokey:ea96b2b8ff76a83c5af36558bd12f7cc29a71fd7db4349be1d9ca5e3fcff0f58",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:41697", "10.65.0.27:41697", "172.17.0.1:41697"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:55:00.445932525Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5616856630506496,
+				"StableID":   "nsE8RMJtrk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b07f7b08f86823c6d44606204b33fe7ccca8ed9bb4399aebfff18bf34997224c",
+				"DiscoKey":   "discokey:515308583964bbf064a71780cf6ef30726522f0fb162462e8854ce92cbfe4f4b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:36882", "10.65.0.27:36882", "172.17.0.1:36882"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:55:00.989848739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4120313125665865,
+				"StableID":   "ngroZ4e6BZ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6fb376f47fa693213dfca72b61c95eb2f23ebed8522a14b2fe191e0db7cf091b",
+				"DiscoKey":   "discokey:f6cf1fe5bfe11aa31ad82de309ed5557ba85cc40ab52888af04ee6d0e03cb138",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:47911", "10.65.0.27:47911", "172.17.0.1:47911"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:55:01.516466376Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5934169217031598,
+				"StableID":   "nmes6eZbLo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:16d40a42b3b8c7315c450b7a7da71c56927b39a2dd6b7280977c934aaee31f62",
+				"DiscoKey":   "discokey:2ecc3cc255d5ae9e7acaa82ee269721f6792799cec4e4a2f8ee33a91d0c51a27",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:35139", "10.65.0.27:35139", "172.17.0.1:35139"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:55:02.06320188Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3829371369919846,
+				"StableID":   "ns7qtM6LuW11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db797d297cfa42c98d66a85a927be03bd41ddb20317364b14f149e31cf258428",
+				"DiscoKey":   "discokey:3be0883118c8903cae09ad9bf645ef349e73f75eec4042bd473db8859d33c547",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43303", "10.65.0.27:43303", "172.17.0.1:43303"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:55:02.592956052Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4142969531082554,
+				"StableID":   "nmvgXVnMMZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c64e08dc977990e0094b182fa6b8ecb09d47ace847f52ded4865105b26c15e1d",
+				"DiscoKey":   "discokey:e186e1d9a6a0ed9548fb249b9c8009e271e6b3e7203e90af2a94b363a7a6957b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:34846", "10.65.0.27:34846", "172.17.0.1:34846"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:55:03.128402107Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4800455758014461,
+				"StableID":   "nEdwwHq8Ve11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:13dfcf0fde718814e3ed7ede12f418bb29efeb7b74504cb9a5b80705c43f985e",
+				"KeyExpiry":  "2026-11-08T18:55:03Z",
+				"DiscoKey":   "discokey:87f03b040575e96d175b430d152c82bb51377bec227b970abdd5fd8cd249bd1d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:39636", "10.65.0.27:39636", "172.17.0.1:39636"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:55:03.668345456Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         495872617439219,
+				"StableID":   "n68hAWjas411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:13e613e286484cf36612d9e22d3bd3f85eebd6bd2c41a36dca1d2cebd51a875d",
+				"KeyExpiry":  "2026-11-08T18:55:04Z",
+				"DiscoKey":   "discokey:cc03681f9cc0baf6ed18522e08ccce3dd47c3549764f4386874d9ee95ba67f16",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:58189", "10.65.0.27:58189", "172.17.0.1:58189"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:55:04.199017017Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4392928306204163,
+				"StableID":   "ncdVY6nZJb11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       4392928306204163,
+				"Key":        "nodekey:7733a8a95d8a6b8d17ae2bc849ff1bdfc2e0876530d475914b13acf2154e970a",
+				"DiscoKey":   "discokey:265fb145c3dd754d0d9008806c47e519d76eef4544263361a634bf3a2e636866",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41036", "10.65.0.27:41036", "172.17.0.1:41036"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:54:58.316468705Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7733a8a95d8a6b8d17ae2bc849ff1bdfc2e0876530d475914b13acf2154e970a",
+			"MachineKey": "mkey:932c0c59e332e4811ded0926c345bde52d76c0b122ff3f52a46ea9e8de37bb5e",
+			"Peers": [{
+				"ID":         8411209950237823,
+				"StableID":   "nxf6UuDTg821CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93dd379d75307db94ff41c81cf35e2ce3ef8a17753c331b8ae1d01486bc14133",
+				"DiscoKey":   "discokey:d6e5d845d4a61d9611039a7a095f2b1c6b5774d1d999f2e66994ae5839be7f5d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:34767", "10.65.0.27:34767", "172.17.0.1:34767"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:54:57.307437635Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8527559154668666,
+				"StableID":   "nyY8F6X9b921CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:18063902586de112035697a7d33c0b0d2437ce86e16ef2fa677c8720d36be118",
+				"DiscoKey":   "discokey:e04f2c91eb9a62c83a908a697e964ae8db5c2669adb58658701e39751ca7b87f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:43915", "10.65.0.27:43915", "172.17.0.1:43915"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:54:57.798391545Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1207939473313067,
+				"StableID":   "nkh1sFX5SA11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:233cb7f748e22261a3f8566bb29545ef608acd94b0f100120fc0273ab86a2717",
+				"DiscoKey":   "discokey:a06ab142ed29e39b67b81ec4a1ce23bd1beb0b37edf5678b6729b847bee38157",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:34232", "10.65.0.27:34232", "172.17.0.1:34232"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:54:58.87037937Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1627276155753729,
+				"StableID":   "npgEYYnzhD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca438abc65fffc9b2bab312b7b07f42bc583d5a0a63663b6a4299666b4693b71",
+				"DiscoKey":   "discokey:252fa7692cd2f4bb76de4ea1ddd0cf02aee70c14cd5c626ba0e7f0ff8ae0a305",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:38759", "10.65.0.27:38759", "172.17.0.1:38759"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:54:59.370753878Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4802895802744196,
+				"StableID":   "notyLrvEWe11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0c2a07339f8330edf21ea79b553d5179ba72ce89847990f43db3bf887d87e6d",
+				"DiscoKey":   "discokey:727125a1a4a8effad0fdc231628ed4ddc54f234c49991b01afa487f12e133979",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:57755", "10.65.0.27:57755", "172.17.0.1:57755"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:54:59.905418907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2735199946774139,
+				"StableID":   "nvpZ3k4nMN11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6de85e40f009cdbb62357629ec0b6ee633584623f61287320fcc63acb947a7f",
+				"DiscoKey":   "discokey:ea96b2b8ff76a83c5af36558bd12f7cc29a71fd7db4349be1d9ca5e3fcff0f58",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:41697", "10.65.0.27:41697", "172.17.0.1:41697"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:55:00.445932525Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5616856630506496,
+				"StableID":   "nsE8RMJtrk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b07f7b08f86823c6d44606204b33fe7ccca8ed9bb4399aebfff18bf34997224c",
+				"DiscoKey":   "discokey:515308583964bbf064a71780cf6ef30726522f0fb162462e8854ce92cbfe4f4b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:36882", "10.65.0.27:36882", "172.17.0.1:36882"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:55:00.989848739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4120313125665865,
+				"StableID":   "ngroZ4e6BZ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6fb376f47fa693213dfca72b61c95eb2f23ebed8522a14b2fe191e0db7cf091b",
+				"DiscoKey":   "discokey:f6cf1fe5bfe11aa31ad82de309ed5557ba85cc40ab52888af04ee6d0e03cb138",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:47911", "10.65.0.27:47911", "172.17.0.1:47911"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:55:01.516466376Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5934169217031598,
+				"StableID":   "nmes6eZbLo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:16d40a42b3b8c7315c450b7a7da71c56927b39a2dd6b7280977c934aaee31f62",
+				"DiscoKey":   "discokey:2ecc3cc255d5ae9e7acaa82ee269721f6792799cec4e4a2f8ee33a91d0c51a27",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:35139", "10.65.0.27:35139", "172.17.0.1:35139"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:55:02.06320188Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3829371369919846,
+				"StableID":   "ns7qtM6LuW11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db797d297cfa42c98d66a85a927be03bd41ddb20317364b14f149e31cf258428",
+				"DiscoKey":   "discokey:3be0883118c8903cae09ad9bf645ef349e73f75eec4042bd473db8859d33c547",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43303", "10.65.0.27:43303", "172.17.0.1:43303"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:55:02.592956052Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4142969531082554,
+				"StableID":   "nmvgXVnMMZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c64e08dc977990e0094b182fa6b8ecb09d47ace847f52ded4865105b26c15e1d",
+				"DiscoKey":   "discokey:e186e1d9a6a0ed9548fb249b9c8009e271e6b3e7203e90af2a94b363a7a6957b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:34846", "10.65.0.27:34846", "172.17.0.1:34846"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:55:03.128402107Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4800455758014461,
+				"StableID":   "nEdwwHq8Ve11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:13dfcf0fde718814e3ed7ede12f418bb29efeb7b74504cb9a5b80705c43f985e",
+				"KeyExpiry":  "2026-11-08T18:55:03Z",
+				"DiscoKey":   "discokey:87f03b040575e96d175b430d152c82bb51377bec227b970abdd5fd8cd249bd1d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:39636", "10.65.0.27:39636", "172.17.0.1:39636"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:55:03.668345456Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         495872617439219,
+				"StableID":   "n68hAWjas411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:13e613e286484cf36612d9e22d3bd3f85eebd6bd2c41a36dca1d2cebd51a875d",
+				"KeyExpiry":  "2026-11-08T18:55:04Z",
+				"DiscoKey":   "discokey:cc03681f9cc0baf6ed18522e08ccce3dd47c3549764f4386874d9ee95ba67f16",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:58189", "10.65.0.27:58189", "172.17.0.1:58189"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:55:04.199017017Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4633119923072565,
+				"StableID":   "nkLEEqCMBd11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fbb938f4369157493487e4f585a31f43051f3fcfaf242c3eae351cb65f78397b",
+				"KeyExpiry":  "2026-11-08T18:55:04Z",
+				"DiscoKey":   "discokey:3e4645543c5b7f8f36a0f08e879e82369fb7b9c7c4af7e880111cd54ada6ea39",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:41264", "10.65.0.27:41264", "172.17.0.1:41264"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:55:04.736959081Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4392928306204163": {
+				"ID":          4392928306204163,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5616856630506496,
+				"StableID":   "nsE8RMJtrk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       5616856630506496,
+				"Key":        "nodekey:b07f7b08f86823c6d44606204b33fe7ccca8ed9bb4399aebfff18bf34997224c",
+				"DiscoKey":   "discokey:515308583964bbf064a71780cf6ef30726522f0fb162462e8854ce92cbfe4f4b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:36882", "10.65.0.27:36882", "172.17.0.1:36882"],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:55:00.989848739Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b07f7b08f86823c6d44606204b33fe7ccca8ed9bb4399aebfff18bf34997224c",
+			"MachineKey": "mkey:168ec8f589ac213cab8b283f1c2dc620e5250afe8f857e512f024b18cd1fed19",
+			"Peers": [{
+				"ID":         8411209950237823,
+				"StableID":   "nxf6UuDTg821CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93dd379d75307db94ff41c81cf35e2ce3ef8a17753c331b8ae1d01486bc14133",
+				"DiscoKey":   "discokey:d6e5d845d4a61d9611039a7a095f2b1c6b5774d1d999f2e66994ae5839be7f5d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:34767", "10.65.0.27:34767", "172.17.0.1:34767"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:54:57.307437635Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8527559154668666,
+				"StableID":   "nyY8F6X9b921CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:18063902586de112035697a7d33c0b0d2437ce86e16ef2fa677c8720d36be118",
+				"DiscoKey":   "discokey:e04f2c91eb9a62c83a908a697e964ae8db5c2669adb58658701e39751ca7b87f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:43915", "10.65.0.27:43915", "172.17.0.1:43915"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:54:57.798391545Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4392928306204163,
+				"StableID":   "ncdVY6nZJb11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7733a8a95d8a6b8d17ae2bc849ff1bdfc2e0876530d475914b13acf2154e970a",
+				"DiscoKey":   "discokey:265fb145c3dd754d0d9008806c47e519d76eef4544263361a634bf3a2e636866",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41036", "10.65.0.27:41036", "172.17.0.1:41036"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:54:58.316468705Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1207939473313067,
+				"StableID":   "nkh1sFX5SA11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:233cb7f748e22261a3f8566bb29545ef608acd94b0f100120fc0273ab86a2717",
+				"DiscoKey":   "discokey:a06ab142ed29e39b67b81ec4a1ce23bd1beb0b37edf5678b6729b847bee38157",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:34232", "10.65.0.27:34232", "172.17.0.1:34232"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:54:58.87037937Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1627276155753729,
+				"StableID":   "npgEYYnzhD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca438abc65fffc9b2bab312b7b07f42bc583d5a0a63663b6a4299666b4693b71",
+				"DiscoKey":   "discokey:252fa7692cd2f4bb76de4ea1ddd0cf02aee70c14cd5c626ba0e7f0ff8ae0a305",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:38759", "10.65.0.27:38759", "172.17.0.1:38759"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:54:59.370753878Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4802895802744196,
+				"StableID":   "notyLrvEWe11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0c2a07339f8330edf21ea79b553d5179ba72ce89847990f43db3bf887d87e6d",
+				"DiscoKey":   "discokey:727125a1a4a8effad0fdc231628ed4ddc54f234c49991b01afa487f12e133979",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:57755", "10.65.0.27:57755", "172.17.0.1:57755"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:54:59.905418907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2735199946774139,
+				"StableID":   "nvpZ3k4nMN11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6de85e40f009cdbb62357629ec0b6ee633584623f61287320fcc63acb947a7f",
+				"DiscoKey":   "discokey:ea96b2b8ff76a83c5af36558bd12f7cc29a71fd7db4349be1d9ca5e3fcff0f58",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:41697", "10.65.0.27:41697", "172.17.0.1:41697"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:55:00.445932525Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         4120313125665865,
+				"StableID":   "ngroZ4e6BZ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6fb376f47fa693213dfca72b61c95eb2f23ebed8522a14b2fe191e0db7cf091b",
+				"DiscoKey":   "discokey:f6cf1fe5bfe11aa31ad82de309ed5557ba85cc40ab52888af04ee6d0e03cb138",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:47911", "10.65.0.27:47911", "172.17.0.1:47911"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:55:01.516466376Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5934169217031598,
+				"StableID":   "nmes6eZbLo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:16d40a42b3b8c7315c450b7a7da71c56927b39a2dd6b7280977c934aaee31f62",
+				"DiscoKey":   "discokey:2ecc3cc255d5ae9e7acaa82ee269721f6792799cec4e4a2f8ee33a91d0c51a27",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:35139", "10.65.0.27:35139", "172.17.0.1:35139"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:55:02.06320188Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3829371369919846,
+				"StableID":   "ns7qtM6LuW11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db797d297cfa42c98d66a85a927be03bd41ddb20317364b14f149e31cf258428",
+				"DiscoKey":   "discokey:3be0883118c8903cae09ad9bf645ef349e73f75eec4042bd473db8859d33c547",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43303", "10.65.0.27:43303", "172.17.0.1:43303"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:55:02.592956052Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4142969531082554,
+				"StableID":   "nmvgXVnMMZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c64e08dc977990e0094b182fa6b8ecb09d47ace847f52ded4865105b26c15e1d",
+				"DiscoKey":   "discokey:e186e1d9a6a0ed9548fb249b9c8009e271e6b3e7203e90af2a94b363a7a6957b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:34846", "10.65.0.27:34846", "172.17.0.1:34846"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:55:03.128402107Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4800455758014461,
+				"StableID":   "nEdwwHq8Ve11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:13dfcf0fde718814e3ed7ede12f418bb29efeb7b74504cb9a5b80705c43f985e",
+				"KeyExpiry":  "2026-11-08T18:55:03Z",
+				"DiscoKey":   "discokey:87f03b040575e96d175b430d152c82bb51377bec227b970abdd5fd8cd249bd1d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:39636", "10.65.0.27:39636", "172.17.0.1:39636"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:55:03.668345456Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         495872617439219,
+				"StableID":   "n68hAWjas411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:13e613e286484cf36612d9e22d3bd3f85eebd6bd2c41a36dca1d2cebd51a875d",
+				"KeyExpiry":  "2026-11-08T18:55:04Z",
+				"DiscoKey":   "discokey:cc03681f9cc0baf6ed18522e08ccce3dd47c3549764f4386874d9ee95ba67f16",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:58189", "10.65.0.27:58189", "172.17.0.1:58189"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:55:04.199017017Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4633119923072565,
+				"StableID":   "nkLEEqCMBd11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fbb938f4369157493487e4f585a31f43051f3fcfaf242c3eae351cb65f78397b",
+				"KeyExpiry":  "2026-11-08T18:55:04Z",
+				"DiscoKey":   "discokey:3e4645543c5b7f8f36a0f08e879e82369fb7b9c7c4af7e880111cd54ada6ea39",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:41264", "10.65.0.27:41264", "172.17.0.1:41264"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:55:04.736959081Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5616856630506496": {
+				"ID":          5616856630506496,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4800455758014461,
+				"StableID":   "nEdwwHq8Ve11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:13dfcf0fde718814e3ed7ede12f418bb29efeb7b74504cb9a5b80705c43f985e",
+				"KeyExpiry":  "2026-11-08T18:55:03Z",
+				"DiscoKey":   "discokey:87f03b040575e96d175b430d152c82bb51377bec227b970abdd5fd8cd249bd1d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:39636", "10.65.0.27:39636", "172.17.0.1:39636"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:55:03.668345456Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:13dfcf0fde718814e3ed7ede12f418bb29efeb7b74504cb9a5b80705c43f985e",
+			"MachineKey": "mkey:7b5e1b7c4de84c7d2ff46157db8aa92f1a0e4b1faaeb3620e918f121b376a834",
+			"Peers": [{
+				"ID":         8411209950237823,
+				"StableID":   "nxf6UuDTg821CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93dd379d75307db94ff41c81cf35e2ce3ef8a17753c331b8ae1d01486bc14133",
+				"DiscoKey":   "discokey:d6e5d845d4a61d9611039a7a095f2b1c6b5774d1d999f2e66994ae5839be7f5d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:34767", "10.65.0.27:34767", "172.17.0.1:34767"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:54:57.307437635Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8527559154668666,
+				"StableID":   "nyY8F6X9b921CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:18063902586de112035697a7d33c0b0d2437ce86e16ef2fa677c8720d36be118",
+				"DiscoKey":   "discokey:e04f2c91eb9a62c83a908a697e964ae8db5c2669adb58658701e39751ca7b87f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:43915", "10.65.0.27:43915", "172.17.0.1:43915"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:54:57.798391545Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4392928306204163,
+				"StableID":   "ncdVY6nZJb11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7733a8a95d8a6b8d17ae2bc849ff1bdfc2e0876530d475914b13acf2154e970a",
+				"DiscoKey":   "discokey:265fb145c3dd754d0d9008806c47e519d76eef4544263361a634bf3a2e636866",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41036", "10.65.0.27:41036", "172.17.0.1:41036"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:54:58.316468705Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1207939473313067,
+				"StableID":   "nkh1sFX5SA11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:233cb7f748e22261a3f8566bb29545ef608acd94b0f100120fc0273ab86a2717",
+				"DiscoKey":   "discokey:a06ab142ed29e39b67b81ec4a1ce23bd1beb0b37edf5678b6729b847bee38157",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:34232", "10.65.0.27:34232", "172.17.0.1:34232"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:54:58.87037937Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1627276155753729,
+				"StableID":   "npgEYYnzhD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca438abc65fffc9b2bab312b7b07f42bc583d5a0a63663b6a4299666b4693b71",
+				"DiscoKey":   "discokey:252fa7692cd2f4bb76de4ea1ddd0cf02aee70c14cd5c626ba0e7f0ff8ae0a305",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:38759", "10.65.0.27:38759", "172.17.0.1:38759"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:54:59.370753878Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4802895802744196,
+				"StableID":   "notyLrvEWe11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0c2a07339f8330edf21ea79b553d5179ba72ce89847990f43db3bf887d87e6d",
+				"DiscoKey":   "discokey:727125a1a4a8effad0fdc231628ed4ddc54f234c49991b01afa487f12e133979",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:57755", "10.65.0.27:57755", "172.17.0.1:57755"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:54:59.905418907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2735199946774139,
+				"StableID":   "nvpZ3k4nMN11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6de85e40f009cdbb62357629ec0b6ee633584623f61287320fcc63acb947a7f",
+				"DiscoKey":   "discokey:ea96b2b8ff76a83c5af36558bd12f7cc29a71fd7db4349be1d9ca5e3fcff0f58",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:41697", "10.65.0.27:41697", "172.17.0.1:41697"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:55:00.445932525Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5616856630506496,
+				"StableID":   "nsE8RMJtrk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b07f7b08f86823c6d44606204b33fe7ccca8ed9bb4399aebfff18bf34997224c",
+				"DiscoKey":   "discokey:515308583964bbf064a71780cf6ef30726522f0fb162462e8854ce92cbfe4f4b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:36882", "10.65.0.27:36882", "172.17.0.1:36882"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:55:00.989848739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4120313125665865,
+				"StableID":   "ngroZ4e6BZ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6fb376f47fa693213dfca72b61c95eb2f23ebed8522a14b2fe191e0db7cf091b",
+				"DiscoKey":   "discokey:f6cf1fe5bfe11aa31ad82de309ed5557ba85cc40ab52888af04ee6d0e03cb138",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:47911", "10.65.0.27:47911", "172.17.0.1:47911"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:55:01.516466376Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5934169217031598,
+				"StableID":   "nmes6eZbLo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:16d40a42b3b8c7315c450b7a7da71c56927b39a2dd6b7280977c934aaee31f62",
+				"DiscoKey":   "discokey:2ecc3cc255d5ae9e7acaa82ee269721f6792799cec4e4a2f8ee33a91d0c51a27",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:35139", "10.65.0.27:35139", "172.17.0.1:35139"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:55:02.06320188Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3829371369919846,
+				"StableID":   "ns7qtM6LuW11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db797d297cfa42c98d66a85a927be03bd41ddb20317364b14f149e31cf258428",
+				"DiscoKey":   "discokey:3be0883118c8903cae09ad9bf645ef349e73f75eec4042bd473db8859d33c547",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43303", "10.65.0.27:43303", "172.17.0.1:43303"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:55:02.592956052Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4142969531082554,
+				"StableID":   "nmvgXVnMMZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c64e08dc977990e0094b182fa6b8ecb09d47ace847f52ded4865105b26c15e1d",
+				"DiscoKey":   "discokey:e186e1d9a6a0ed9548fb249b9c8009e271e6b3e7203e90af2a94b363a7a6957b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:34846", "10.65.0.27:34846", "172.17.0.1:34846"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:55:03.128402107Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         495872617439219,
+				"StableID":   "n68hAWjas411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:13e613e286484cf36612d9e22d3bd3f85eebd6bd2c41a36dca1d2cebd51a875d",
+				"KeyExpiry":  "2026-11-08T18:55:04Z",
+				"DiscoKey":   "discokey:cc03681f9cc0baf6ed18522e08ccce3dd47c3549764f4386874d9ee95ba67f16",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:58189", "10.65.0.27:58189", "172.17.0.1:58189"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:55:04.199017017Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4633119923072565,
+				"StableID":   "nkLEEqCMBd11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fbb938f4369157493487e4f585a31f43051f3fcfaf242c3eae351cb65f78397b",
+				"KeyExpiry":  "2026-11-08T18:55:04Z",
+				"DiscoKey":   "discokey:3e4645543c5b7f8f36a0f08e879e82369fb7b9c7c4af7e880111cd54ada6ea39",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:41264", "10.65.0.27:41264", "172.17.0.1:41264"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:55:04.736959081Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3829371369919846,
+				"StableID":   "ns7qtM6LuW11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       3829371369919846,
+				"Key":        "nodekey:db797d297cfa42c98d66a85a927be03bd41ddb20317364b14f149e31cf258428",
+				"DiscoKey":   "discokey:3be0883118c8903cae09ad9bf645ef349e73f75eec4042bd473db8859d33c547",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43303", "10.65.0.27:43303", "172.17.0.1:43303"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:55:02.592956052Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:db797d297cfa42c98d66a85a927be03bd41ddb20317364b14f149e31cf258428",
+			"MachineKey": "mkey:e0704ead21128a865c6e8c7877b0ff077730645aa59b9735d45cf30a55860a78",
+			"Peers": [{
+				"ID":         8411209950237823,
+				"StableID":   "nxf6UuDTg821CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93dd379d75307db94ff41c81cf35e2ce3ef8a17753c331b8ae1d01486bc14133",
+				"DiscoKey":   "discokey:d6e5d845d4a61d9611039a7a095f2b1c6b5774d1d999f2e66994ae5839be7f5d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:34767", "10.65.0.27:34767", "172.17.0.1:34767"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:54:57.307437635Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8527559154668666,
+				"StableID":   "nyY8F6X9b921CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:18063902586de112035697a7d33c0b0d2437ce86e16ef2fa677c8720d36be118",
+				"DiscoKey":   "discokey:e04f2c91eb9a62c83a908a697e964ae8db5c2669adb58658701e39751ca7b87f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:43915", "10.65.0.27:43915", "172.17.0.1:43915"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:54:57.798391545Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4392928306204163,
+				"StableID":   "ncdVY6nZJb11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7733a8a95d8a6b8d17ae2bc849ff1bdfc2e0876530d475914b13acf2154e970a",
+				"DiscoKey":   "discokey:265fb145c3dd754d0d9008806c47e519d76eef4544263361a634bf3a2e636866",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41036", "10.65.0.27:41036", "172.17.0.1:41036"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:54:58.316468705Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1207939473313067,
+				"StableID":   "nkh1sFX5SA11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:233cb7f748e22261a3f8566bb29545ef608acd94b0f100120fc0273ab86a2717",
+				"DiscoKey":   "discokey:a06ab142ed29e39b67b81ec4a1ce23bd1beb0b37edf5678b6729b847bee38157",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:34232", "10.65.0.27:34232", "172.17.0.1:34232"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:54:58.87037937Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1627276155753729,
+				"StableID":   "npgEYYnzhD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca438abc65fffc9b2bab312b7b07f42bc583d5a0a63663b6a4299666b4693b71",
+				"DiscoKey":   "discokey:252fa7692cd2f4bb76de4ea1ddd0cf02aee70c14cd5c626ba0e7f0ff8ae0a305",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:38759", "10.65.0.27:38759", "172.17.0.1:38759"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:54:59.370753878Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4802895802744196,
+				"StableID":   "notyLrvEWe11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0c2a07339f8330edf21ea79b553d5179ba72ce89847990f43db3bf887d87e6d",
+				"DiscoKey":   "discokey:727125a1a4a8effad0fdc231628ed4ddc54f234c49991b01afa487f12e133979",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:57755", "10.65.0.27:57755", "172.17.0.1:57755"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:54:59.905418907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2735199946774139,
+				"StableID":   "nvpZ3k4nMN11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6de85e40f009cdbb62357629ec0b6ee633584623f61287320fcc63acb947a7f",
+				"DiscoKey":   "discokey:ea96b2b8ff76a83c5af36558bd12f7cc29a71fd7db4349be1d9ca5e3fcff0f58",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:41697", "10.65.0.27:41697", "172.17.0.1:41697"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:55:00.445932525Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5616856630506496,
+				"StableID":   "nsE8RMJtrk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b07f7b08f86823c6d44606204b33fe7ccca8ed9bb4399aebfff18bf34997224c",
+				"DiscoKey":   "discokey:515308583964bbf064a71780cf6ef30726522f0fb162462e8854ce92cbfe4f4b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:36882", "10.65.0.27:36882", "172.17.0.1:36882"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:55:00.989848739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4120313125665865,
+				"StableID":   "ngroZ4e6BZ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6fb376f47fa693213dfca72b61c95eb2f23ebed8522a14b2fe191e0db7cf091b",
+				"DiscoKey":   "discokey:f6cf1fe5bfe11aa31ad82de309ed5557ba85cc40ab52888af04ee6d0e03cb138",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:47911", "10.65.0.27:47911", "172.17.0.1:47911"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:55:01.516466376Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5934169217031598,
+				"StableID":   "nmes6eZbLo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:16d40a42b3b8c7315c450b7a7da71c56927b39a2dd6b7280977c934aaee31f62",
+				"DiscoKey":   "discokey:2ecc3cc255d5ae9e7acaa82ee269721f6792799cec4e4a2f8ee33a91d0c51a27",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:35139", "10.65.0.27:35139", "172.17.0.1:35139"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:55:02.06320188Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         4142969531082554,
+				"StableID":   "nmvgXVnMMZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c64e08dc977990e0094b182fa6b8ecb09d47ace847f52ded4865105b26c15e1d",
+				"DiscoKey":   "discokey:e186e1d9a6a0ed9548fb249b9c8009e271e6b3e7203e90af2a94b363a7a6957b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:34846", "10.65.0.27:34846", "172.17.0.1:34846"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:55:03.128402107Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4800455758014461,
+				"StableID":   "nEdwwHq8Ve11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:13dfcf0fde718814e3ed7ede12f418bb29efeb7b74504cb9a5b80705c43f985e",
+				"KeyExpiry":  "2026-11-08T18:55:03Z",
+				"DiscoKey":   "discokey:87f03b040575e96d175b430d152c82bb51377bec227b970abdd5fd8cd249bd1d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:39636", "10.65.0.27:39636", "172.17.0.1:39636"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:55:03.668345456Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         495872617439219,
+				"StableID":   "n68hAWjas411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:13e613e286484cf36612d9e22d3bd3f85eebd6bd2c41a36dca1d2cebd51a875d",
+				"KeyExpiry":  "2026-11-08T18:55:04Z",
+				"DiscoKey":   "discokey:cc03681f9cc0baf6ed18522e08ccce3dd47c3549764f4386874d9ee95ba67f16",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:58189", "10.65.0.27:58189", "172.17.0.1:58189"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:55:04.199017017Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4633119923072565,
+				"StableID":   "nkLEEqCMBd11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fbb938f4369157493487e4f585a31f43051f3fcfaf242c3eae351cb65f78397b",
+				"KeyExpiry":  "2026-11-08T18:55:04Z",
+				"DiscoKey":   "discokey:3e4645543c5b7f8f36a0f08e879e82369fb7b9c7c4af7e880111cd54ada6ea39",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:41264", "10.65.0.27:41264", "172.17.0.1:41264"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:55:04.736959081Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3829371369919846": {
+				"ID":          3829371369919846,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8527559154668666,
+				"StableID":   "nyY8F6X9b921CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       8527559154668666,
+				"Key":        "nodekey:18063902586de112035697a7d33c0b0d2437ce86e16ef2fa677c8720d36be118",
+				"DiscoKey":   "discokey:e04f2c91eb9a62c83a908a697e964ae8db5c2669adb58658701e39751ca7b87f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:43915", "10.65.0.27:43915", "172.17.0.1:43915"],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:54:57.798391545Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:18063902586de112035697a7d33c0b0d2437ce86e16ef2fa677c8720d36be118",
+			"MachineKey": "mkey:e9751ee6dddfafd1aac2ffec5ec8661c26490b8ab2bf5f05990cebfda6814b4f",
+			"Peers": [{
+				"ID":         8411209950237823,
+				"StableID":   "nxf6UuDTg821CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93dd379d75307db94ff41c81cf35e2ce3ef8a17753c331b8ae1d01486bc14133",
+				"DiscoKey":   "discokey:d6e5d845d4a61d9611039a7a095f2b1c6b5774d1d999f2e66994ae5839be7f5d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:34767", "10.65.0.27:34767", "172.17.0.1:34767"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:54:57.307437635Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4392928306204163,
+				"StableID":   "ncdVY6nZJb11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7733a8a95d8a6b8d17ae2bc849ff1bdfc2e0876530d475914b13acf2154e970a",
+				"DiscoKey":   "discokey:265fb145c3dd754d0d9008806c47e519d76eef4544263361a634bf3a2e636866",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41036", "10.65.0.27:41036", "172.17.0.1:41036"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:54:58.316468705Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1207939473313067,
+				"StableID":   "nkh1sFX5SA11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:233cb7f748e22261a3f8566bb29545ef608acd94b0f100120fc0273ab86a2717",
+				"DiscoKey":   "discokey:a06ab142ed29e39b67b81ec4a1ce23bd1beb0b37edf5678b6729b847bee38157",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:34232", "10.65.0.27:34232", "172.17.0.1:34232"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:54:58.87037937Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1627276155753729,
+				"StableID":   "npgEYYnzhD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca438abc65fffc9b2bab312b7b07f42bc583d5a0a63663b6a4299666b4693b71",
+				"DiscoKey":   "discokey:252fa7692cd2f4bb76de4ea1ddd0cf02aee70c14cd5c626ba0e7f0ff8ae0a305",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:38759", "10.65.0.27:38759", "172.17.0.1:38759"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:54:59.370753878Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4802895802744196,
+				"StableID":   "notyLrvEWe11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0c2a07339f8330edf21ea79b553d5179ba72ce89847990f43db3bf887d87e6d",
+				"DiscoKey":   "discokey:727125a1a4a8effad0fdc231628ed4ddc54f234c49991b01afa487f12e133979",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:57755", "10.65.0.27:57755", "172.17.0.1:57755"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:54:59.905418907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2735199946774139,
+				"StableID":   "nvpZ3k4nMN11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6de85e40f009cdbb62357629ec0b6ee633584623f61287320fcc63acb947a7f",
+				"DiscoKey":   "discokey:ea96b2b8ff76a83c5af36558bd12f7cc29a71fd7db4349be1d9ca5e3fcff0f58",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:41697", "10.65.0.27:41697", "172.17.0.1:41697"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:55:00.445932525Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5616856630506496,
+				"StableID":   "nsE8RMJtrk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b07f7b08f86823c6d44606204b33fe7ccca8ed9bb4399aebfff18bf34997224c",
+				"DiscoKey":   "discokey:515308583964bbf064a71780cf6ef30726522f0fb162462e8854ce92cbfe4f4b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:36882", "10.65.0.27:36882", "172.17.0.1:36882"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:55:00.989848739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4120313125665865,
+				"StableID":   "ngroZ4e6BZ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6fb376f47fa693213dfca72b61c95eb2f23ebed8522a14b2fe191e0db7cf091b",
+				"DiscoKey":   "discokey:f6cf1fe5bfe11aa31ad82de309ed5557ba85cc40ab52888af04ee6d0e03cb138",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:47911", "10.65.0.27:47911", "172.17.0.1:47911"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:55:01.516466376Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5934169217031598,
+				"StableID":   "nmes6eZbLo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:16d40a42b3b8c7315c450b7a7da71c56927b39a2dd6b7280977c934aaee31f62",
+				"DiscoKey":   "discokey:2ecc3cc255d5ae9e7acaa82ee269721f6792799cec4e4a2f8ee33a91d0c51a27",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:35139", "10.65.0.27:35139", "172.17.0.1:35139"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:55:02.06320188Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3829371369919846,
+				"StableID":   "ns7qtM6LuW11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db797d297cfa42c98d66a85a927be03bd41ddb20317364b14f149e31cf258428",
+				"DiscoKey":   "discokey:3be0883118c8903cae09ad9bf645ef349e73f75eec4042bd473db8859d33c547",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43303", "10.65.0.27:43303", "172.17.0.1:43303"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:55:02.592956052Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4142969531082554,
+				"StableID":   "nmvgXVnMMZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c64e08dc977990e0094b182fa6b8ecb09d47ace847f52ded4865105b26c15e1d",
+				"DiscoKey":   "discokey:e186e1d9a6a0ed9548fb249b9c8009e271e6b3e7203e90af2a94b363a7a6957b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:34846", "10.65.0.27:34846", "172.17.0.1:34846"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:55:03.128402107Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4800455758014461,
+				"StableID":   "nEdwwHq8Ve11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:13dfcf0fde718814e3ed7ede12f418bb29efeb7b74504cb9a5b80705c43f985e",
+				"KeyExpiry":  "2026-11-08T18:55:03Z",
+				"DiscoKey":   "discokey:87f03b040575e96d175b430d152c82bb51377bec227b970abdd5fd8cd249bd1d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:39636", "10.65.0.27:39636", "172.17.0.1:39636"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:55:03.668345456Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         495872617439219,
+				"StableID":   "n68hAWjas411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:13e613e286484cf36612d9e22d3bd3f85eebd6bd2c41a36dca1d2cebd51a875d",
+				"KeyExpiry":  "2026-11-08T18:55:04Z",
+				"DiscoKey":   "discokey:cc03681f9cc0baf6ed18522e08ccce3dd47c3549764f4386874d9ee95ba67f16",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:58189", "10.65.0.27:58189", "172.17.0.1:58189"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:55:04.199017017Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4633119923072565,
+				"StableID":   "nkLEEqCMBd11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fbb938f4369157493487e4f585a31f43051f3fcfaf242c3eae351cb65f78397b",
+				"KeyExpiry":  "2026-11-08T18:55:04Z",
+				"DiscoKey":   "discokey:3e4645543c5b7f8f36a0f08e879e82369fb7b9c7c4af7e880111cd54ada6ea39",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:41264", "10.65.0.27:41264", "172.17.0.1:41264"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:55:04.736959081Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8527559154668666": {
+				"ID":          8527559154668666,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8411209950237823,
+				"StableID":   "nxf6UuDTg821CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       8411209950237823,
+				"Key":        "nodekey:93dd379d75307db94ff41c81cf35e2ce3ef8a17753c331b8ae1d01486bc14133",
+				"DiscoKey":   "discokey:d6e5d845d4a61d9611039a7a095f2b1c6b5774d1d999f2e66994ae5839be7f5d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:34767", "10.65.0.27:34767", "172.17.0.1:34767"],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:54:57.307437635Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:93dd379d75307db94ff41c81cf35e2ce3ef8a17753c331b8ae1d01486bc14133",
+			"MachineKey": "mkey:46ea292ef0b36af88fdb7025210c09e6b441f9a286b02a0f2a5742223d5e6523",
+			"Peers": [{
+				"ID":         8527559154668666,
+				"StableID":   "nyY8F6X9b921CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:18063902586de112035697a7d33c0b0d2437ce86e16ef2fa677c8720d36be118",
+				"DiscoKey":   "discokey:e04f2c91eb9a62c83a908a697e964ae8db5c2669adb58658701e39751ca7b87f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:43915", "10.65.0.27:43915", "172.17.0.1:43915"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:54:57.798391545Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4392928306204163,
+				"StableID":   "ncdVY6nZJb11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7733a8a95d8a6b8d17ae2bc849ff1bdfc2e0876530d475914b13acf2154e970a",
+				"DiscoKey":   "discokey:265fb145c3dd754d0d9008806c47e519d76eef4544263361a634bf3a2e636866",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41036", "10.65.0.27:41036", "172.17.0.1:41036"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:54:58.316468705Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1207939473313067,
+				"StableID":   "nkh1sFX5SA11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:233cb7f748e22261a3f8566bb29545ef608acd94b0f100120fc0273ab86a2717",
+				"DiscoKey":   "discokey:a06ab142ed29e39b67b81ec4a1ce23bd1beb0b37edf5678b6729b847bee38157",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:34232", "10.65.0.27:34232", "172.17.0.1:34232"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:54:58.87037937Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1627276155753729,
+				"StableID":   "npgEYYnzhD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca438abc65fffc9b2bab312b7b07f42bc583d5a0a63663b6a4299666b4693b71",
+				"DiscoKey":   "discokey:252fa7692cd2f4bb76de4ea1ddd0cf02aee70c14cd5c626ba0e7f0ff8ae0a305",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:38759", "10.65.0.27:38759", "172.17.0.1:38759"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:54:59.370753878Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4802895802744196,
+				"StableID":   "notyLrvEWe11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0c2a07339f8330edf21ea79b553d5179ba72ce89847990f43db3bf887d87e6d",
+				"DiscoKey":   "discokey:727125a1a4a8effad0fdc231628ed4ddc54f234c49991b01afa487f12e133979",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:57755", "10.65.0.27:57755", "172.17.0.1:57755"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:54:59.905418907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2735199946774139,
+				"StableID":   "nvpZ3k4nMN11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6de85e40f009cdbb62357629ec0b6ee633584623f61287320fcc63acb947a7f",
+				"DiscoKey":   "discokey:ea96b2b8ff76a83c5af36558bd12f7cc29a71fd7db4349be1d9ca5e3fcff0f58",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:41697", "10.65.0.27:41697", "172.17.0.1:41697"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:55:00.445932525Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5616856630506496,
+				"StableID":   "nsE8RMJtrk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b07f7b08f86823c6d44606204b33fe7ccca8ed9bb4399aebfff18bf34997224c",
+				"DiscoKey":   "discokey:515308583964bbf064a71780cf6ef30726522f0fb162462e8854ce92cbfe4f4b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:36882", "10.65.0.27:36882", "172.17.0.1:36882"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:55:00.989848739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4120313125665865,
+				"StableID":   "ngroZ4e6BZ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6fb376f47fa693213dfca72b61c95eb2f23ebed8522a14b2fe191e0db7cf091b",
+				"DiscoKey":   "discokey:f6cf1fe5bfe11aa31ad82de309ed5557ba85cc40ab52888af04ee6d0e03cb138",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:47911", "10.65.0.27:47911", "172.17.0.1:47911"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:55:01.516466376Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5934169217031598,
+				"StableID":   "nmes6eZbLo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:16d40a42b3b8c7315c450b7a7da71c56927b39a2dd6b7280977c934aaee31f62",
+				"DiscoKey":   "discokey:2ecc3cc255d5ae9e7acaa82ee269721f6792799cec4e4a2f8ee33a91d0c51a27",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:35139", "10.65.0.27:35139", "172.17.0.1:35139"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:55:02.06320188Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3829371369919846,
+				"StableID":   "ns7qtM6LuW11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db797d297cfa42c98d66a85a927be03bd41ddb20317364b14f149e31cf258428",
+				"DiscoKey":   "discokey:3be0883118c8903cae09ad9bf645ef349e73f75eec4042bd473db8859d33c547",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43303", "10.65.0.27:43303", "172.17.0.1:43303"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:55:02.592956052Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4142969531082554,
+				"StableID":   "nmvgXVnMMZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c64e08dc977990e0094b182fa6b8ecb09d47ace847f52ded4865105b26c15e1d",
+				"DiscoKey":   "discokey:e186e1d9a6a0ed9548fb249b9c8009e271e6b3e7203e90af2a94b363a7a6957b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:34846", "10.65.0.27:34846", "172.17.0.1:34846"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:55:03.128402107Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4800455758014461,
+				"StableID":   "nEdwwHq8Ve11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:13dfcf0fde718814e3ed7ede12f418bb29efeb7b74504cb9a5b80705c43f985e",
+				"KeyExpiry":  "2026-11-08T18:55:03Z",
+				"DiscoKey":   "discokey:87f03b040575e96d175b430d152c82bb51377bec227b970abdd5fd8cd249bd1d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:39636", "10.65.0.27:39636", "172.17.0.1:39636"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:55:03.668345456Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         495872617439219,
+				"StableID":   "n68hAWjas411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:13e613e286484cf36612d9e22d3bd3f85eebd6bd2c41a36dca1d2cebd51a875d",
+				"KeyExpiry":  "2026-11-08T18:55:04Z",
+				"DiscoKey":   "discokey:cc03681f9cc0baf6ed18522e08ccce3dd47c3549764f4386874d9ee95ba67f16",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:58189", "10.65.0.27:58189", "172.17.0.1:58189"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:55:04.199017017Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4633119923072565,
+				"StableID":   "nkLEEqCMBd11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fbb938f4369157493487e4f585a31f43051f3fcfaf242c3eae351cb65f78397b",
+				"KeyExpiry":  "2026-11-08T18:55:04Z",
+				"DiscoKey":   "discokey:3e4645543c5b7f8f36a0f08e879e82369fb7b9c7c4af7e880111cd54ada6ea39",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:41264", "10.65.0.27:41264", "172.17.0.1:41264"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:55:04.736959081Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8411209950237823": {
+				"ID":          8411209950237823,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1627276155753729,
+				"StableID":   "npgEYYnzhD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1627276155753729,
+				"Key":        "nodekey:ca438abc65fffc9b2bab312b7b07f42bc583d5a0a63663b6a4299666b4693b71",
+				"DiscoKey":   "discokey:252fa7692cd2f4bb76de4ea1ddd0cf02aee70c14cd5c626ba0e7f0ff8ae0a305",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:38759", "10.65.0.27:38759", "172.17.0.1:38759"],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:54:59.370753878Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ca438abc65fffc9b2bab312b7b07f42bc583d5a0a63663b6a4299666b4693b71",
+			"MachineKey": "mkey:66383c6eaaec46b774b89b444fe472267614f4a5b7394dbc26fd322ba1cb3811",
+			"Peers": [{
+				"ID":         8411209950237823,
+				"StableID":   "nxf6UuDTg821CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93dd379d75307db94ff41c81cf35e2ce3ef8a17753c331b8ae1d01486bc14133",
+				"DiscoKey":   "discokey:d6e5d845d4a61d9611039a7a095f2b1c6b5774d1d999f2e66994ae5839be7f5d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:34767", "10.65.0.27:34767", "172.17.0.1:34767"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:54:57.307437635Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8527559154668666,
+				"StableID":   "nyY8F6X9b921CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:18063902586de112035697a7d33c0b0d2437ce86e16ef2fa677c8720d36be118",
+				"DiscoKey":   "discokey:e04f2c91eb9a62c83a908a697e964ae8db5c2669adb58658701e39751ca7b87f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:43915", "10.65.0.27:43915", "172.17.0.1:43915"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:54:57.798391545Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4392928306204163,
+				"StableID":   "ncdVY6nZJb11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7733a8a95d8a6b8d17ae2bc849ff1bdfc2e0876530d475914b13acf2154e970a",
+				"DiscoKey":   "discokey:265fb145c3dd754d0d9008806c47e519d76eef4544263361a634bf3a2e636866",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41036", "10.65.0.27:41036", "172.17.0.1:41036"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:54:58.316468705Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1207939473313067,
+				"StableID":   "nkh1sFX5SA11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:233cb7f748e22261a3f8566bb29545ef608acd94b0f100120fc0273ab86a2717",
+				"DiscoKey":   "discokey:a06ab142ed29e39b67b81ec4a1ce23bd1beb0b37edf5678b6729b847bee38157",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:34232", "10.65.0.27:34232", "172.17.0.1:34232"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:54:58.87037937Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4802895802744196,
+				"StableID":   "notyLrvEWe11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0c2a07339f8330edf21ea79b553d5179ba72ce89847990f43db3bf887d87e6d",
+				"DiscoKey":   "discokey:727125a1a4a8effad0fdc231628ed4ddc54f234c49991b01afa487f12e133979",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:57755", "10.65.0.27:57755", "172.17.0.1:57755"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:54:59.905418907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2735199946774139,
+				"StableID":   "nvpZ3k4nMN11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6de85e40f009cdbb62357629ec0b6ee633584623f61287320fcc63acb947a7f",
+				"DiscoKey":   "discokey:ea96b2b8ff76a83c5af36558bd12f7cc29a71fd7db4349be1d9ca5e3fcff0f58",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:41697", "10.65.0.27:41697", "172.17.0.1:41697"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:55:00.445932525Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5616856630506496,
+				"StableID":   "nsE8RMJtrk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b07f7b08f86823c6d44606204b33fe7ccca8ed9bb4399aebfff18bf34997224c",
+				"DiscoKey":   "discokey:515308583964bbf064a71780cf6ef30726522f0fb162462e8854ce92cbfe4f4b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:36882", "10.65.0.27:36882", "172.17.0.1:36882"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:55:00.989848739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4120313125665865,
+				"StableID":   "ngroZ4e6BZ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6fb376f47fa693213dfca72b61c95eb2f23ebed8522a14b2fe191e0db7cf091b",
+				"DiscoKey":   "discokey:f6cf1fe5bfe11aa31ad82de309ed5557ba85cc40ab52888af04ee6d0e03cb138",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:47911", "10.65.0.27:47911", "172.17.0.1:47911"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:55:01.516466376Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5934169217031598,
+				"StableID":   "nmes6eZbLo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:16d40a42b3b8c7315c450b7a7da71c56927b39a2dd6b7280977c934aaee31f62",
+				"DiscoKey":   "discokey:2ecc3cc255d5ae9e7acaa82ee269721f6792799cec4e4a2f8ee33a91d0c51a27",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:35139", "10.65.0.27:35139", "172.17.0.1:35139"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:55:02.06320188Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3829371369919846,
+				"StableID":   "ns7qtM6LuW11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db797d297cfa42c98d66a85a927be03bd41ddb20317364b14f149e31cf258428",
+				"DiscoKey":   "discokey:3be0883118c8903cae09ad9bf645ef349e73f75eec4042bd473db8859d33c547",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43303", "10.65.0.27:43303", "172.17.0.1:43303"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:55:02.592956052Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4142969531082554,
+				"StableID":   "nmvgXVnMMZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c64e08dc977990e0094b182fa6b8ecb09d47ace847f52ded4865105b26c15e1d",
+				"DiscoKey":   "discokey:e186e1d9a6a0ed9548fb249b9c8009e271e6b3e7203e90af2a94b363a7a6957b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:34846", "10.65.0.27:34846", "172.17.0.1:34846"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:55:03.128402107Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4800455758014461,
+				"StableID":   "nEdwwHq8Ve11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:13dfcf0fde718814e3ed7ede12f418bb29efeb7b74504cb9a5b80705c43f985e",
+				"KeyExpiry":  "2026-11-08T18:55:03Z",
+				"DiscoKey":   "discokey:87f03b040575e96d175b430d152c82bb51377bec227b970abdd5fd8cd249bd1d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:39636", "10.65.0.27:39636", "172.17.0.1:39636"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:55:03.668345456Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         495872617439219,
+				"StableID":   "n68hAWjas411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:13e613e286484cf36612d9e22d3bd3f85eebd6bd2c41a36dca1d2cebd51a875d",
+				"KeyExpiry":  "2026-11-08T18:55:04Z",
+				"DiscoKey":   "discokey:cc03681f9cc0baf6ed18522e08ccce3dd47c3549764f4386874d9ee95ba67f16",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:58189", "10.65.0.27:58189", "172.17.0.1:58189"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:55:04.199017017Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4633119923072565,
+				"StableID":   "nkLEEqCMBd11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fbb938f4369157493487e4f585a31f43051f3fcfaf242c3eae351cb65f78397b",
+				"KeyExpiry":  "2026-11-08T18:55:04Z",
+				"DiscoKey":   "discokey:3e4645543c5b7f8f36a0f08e879e82369fb7b9c7c4af7e880111cd54ada6ea39",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:41264", "10.65.0.27:41264", "172.17.0.1:41264"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:55:04.736959081Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1627276155753729": {
+				"ID":          1627276155753729,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1207939473313067,
+				"StableID":   "nkh1sFX5SA11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1207939473313067,
+				"Key":        "nodekey:233cb7f748e22261a3f8566bb29545ef608acd94b0f100120fc0273ab86a2717",
+				"DiscoKey":   "discokey:a06ab142ed29e39b67b81ec4a1ce23bd1beb0b37edf5678b6729b847bee38157",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:34232", "10.65.0.27:34232", "172.17.0.1:34232"],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:54:58.87037937Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:233cb7f748e22261a3f8566bb29545ef608acd94b0f100120fc0273ab86a2717",
+			"MachineKey": "mkey:02485a2b0b4cef0b1f6b82be9d253c6eeb1abcb1181577a76f0d00e81926ca5d",
+			"Peers": [{
+				"ID":         8411209950237823,
+				"StableID":   "nxf6UuDTg821CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93dd379d75307db94ff41c81cf35e2ce3ef8a17753c331b8ae1d01486bc14133",
+				"DiscoKey":   "discokey:d6e5d845d4a61d9611039a7a095f2b1c6b5774d1d999f2e66994ae5839be7f5d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:34767", "10.65.0.27:34767", "172.17.0.1:34767"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:54:57.307437635Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8527559154668666,
+				"StableID":   "nyY8F6X9b921CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:18063902586de112035697a7d33c0b0d2437ce86e16ef2fa677c8720d36be118",
+				"DiscoKey":   "discokey:e04f2c91eb9a62c83a908a697e964ae8db5c2669adb58658701e39751ca7b87f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:43915", "10.65.0.27:43915", "172.17.0.1:43915"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:54:57.798391545Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4392928306204163,
+				"StableID":   "ncdVY6nZJb11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7733a8a95d8a6b8d17ae2bc849ff1bdfc2e0876530d475914b13acf2154e970a",
+				"DiscoKey":   "discokey:265fb145c3dd754d0d9008806c47e519d76eef4544263361a634bf3a2e636866",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41036", "10.65.0.27:41036", "172.17.0.1:41036"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:54:58.316468705Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1627276155753729,
+				"StableID":   "npgEYYnzhD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca438abc65fffc9b2bab312b7b07f42bc583d5a0a63663b6a4299666b4693b71",
+				"DiscoKey":   "discokey:252fa7692cd2f4bb76de4ea1ddd0cf02aee70c14cd5c626ba0e7f0ff8ae0a305",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:38759", "10.65.0.27:38759", "172.17.0.1:38759"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:54:59.370753878Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4802895802744196,
+				"StableID":   "notyLrvEWe11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0c2a07339f8330edf21ea79b553d5179ba72ce89847990f43db3bf887d87e6d",
+				"DiscoKey":   "discokey:727125a1a4a8effad0fdc231628ed4ddc54f234c49991b01afa487f12e133979",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:57755", "10.65.0.27:57755", "172.17.0.1:57755"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:54:59.905418907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2735199946774139,
+				"StableID":   "nvpZ3k4nMN11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6de85e40f009cdbb62357629ec0b6ee633584623f61287320fcc63acb947a7f",
+				"DiscoKey":   "discokey:ea96b2b8ff76a83c5af36558bd12f7cc29a71fd7db4349be1d9ca5e3fcff0f58",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:41697", "10.65.0.27:41697", "172.17.0.1:41697"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:55:00.445932525Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5616856630506496,
+				"StableID":   "nsE8RMJtrk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b07f7b08f86823c6d44606204b33fe7ccca8ed9bb4399aebfff18bf34997224c",
+				"DiscoKey":   "discokey:515308583964bbf064a71780cf6ef30726522f0fb162462e8854ce92cbfe4f4b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:36882", "10.65.0.27:36882", "172.17.0.1:36882"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:55:00.989848739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4120313125665865,
+				"StableID":   "ngroZ4e6BZ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6fb376f47fa693213dfca72b61c95eb2f23ebed8522a14b2fe191e0db7cf091b",
+				"DiscoKey":   "discokey:f6cf1fe5bfe11aa31ad82de309ed5557ba85cc40ab52888af04ee6d0e03cb138",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:47911", "10.65.0.27:47911", "172.17.0.1:47911"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:55:01.516466376Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5934169217031598,
+				"StableID":   "nmes6eZbLo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:16d40a42b3b8c7315c450b7a7da71c56927b39a2dd6b7280977c934aaee31f62",
+				"DiscoKey":   "discokey:2ecc3cc255d5ae9e7acaa82ee269721f6792799cec4e4a2f8ee33a91d0c51a27",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:35139", "10.65.0.27:35139", "172.17.0.1:35139"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:55:02.06320188Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3829371369919846,
+				"StableID":   "ns7qtM6LuW11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db797d297cfa42c98d66a85a927be03bd41ddb20317364b14f149e31cf258428",
+				"DiscoKey":   "discokey:3be0883118c8903cae09ad9bf645ef349e73f75eec4042bd473db8859d33c547",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43303", "10.65.0.27:43303", "172.17.0.1:43303"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:55:02.592956052Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4142969531082554,
+				"StableID":   "nmvgXVnMMZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c64e08dc977990e0094b182fa6b8ecb09d47ace847f52ded4865105b26c15e1d",
+				"DiscoKey":   "discokey:e186e1d9a6a0ed9548fb249b9c8009e271e6b3e7203e90af2a94b363a7a6957b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:34846", "10.65.0.27:34846", "172.17.0.1:34846"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:55:03.128402107Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4800455758014461,
+				"StableID":   "nEdwwHq8Ve11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:13dfcf0fde718814e3ed7ede12f418bb29efeb7b74504cb9a5b80705c43f985e",
+				"KeyExpiry":  "2026-11-08T18:55:03Z",
+				"DiscoKey":   "discokey:87f03b040575e96d175b430d152c82bb51377bec227b970abdd5fd8cd249bd1d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:39636", "10.65.0.27:39636", "172.17.0.1:39636"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:55:03.668345456Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         495872617439219,
+				"StableID":   "n68hAWjas411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:13e613e286484cf36612d9e22d3bd3f85eebd6bd2c41a36dca1d2cebd51a875d",
+				"KeyExpiry":  "2026-11-08T18:55:04Z",
+				"DiscoKey":   "discokey:cc03681f9cc0baf6ed18522e08ccce3dd47c3549764f4386874d9ee95ba67f16",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:58189", "10.65.0.27:58189", "172.17.0.1:58189"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:55:04.199017017Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4633119923072565,
+				"StableID":   "nkLEEqCMBd11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fbb938f4369157493487e4f585a31f43051f3fcfaf242c3eae351cb65f78397b",
+				"KeyExpiry":  "2026-11-08T18:55:04Z",
+				"DiscoKey":   "discokey:3e4645543c5b7f8f36a0f08e879e82369fb7b9c7c4af7e880111cd54ada6ea39",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:41264", "10.65.0.27:41264", "172.17.0.1:41264"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:55:04.736959081Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1207939473313067": {
+				"ID":          1207939473313067,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2735199946774139,
+				"StableID":   "nvpZ3k4nMN11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       2735199946774139,
+				"Key":        "nodekey:d6de85e40f009cdbb62357629ec0b6ee633584623f61287320fcc63acb947a7f",
+				"DiscoKey":   "discokey:ea96b2b8ff76a83c5af36558bd12f7cc29a71fd7db4349be1d9ca5e3fcff0f58",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:41697", "10.65.0.27:41697", "172.17.0.1:41697"],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:55:00.445932525Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d6de85e40f009cdbb62357629ec0b6ee633584623f61287320fcc63acb947a7f",
+			"MachineKey": "mkey:cf882a672ef865ab32671a1dad02616d8724d5ad1db325b70a5837128347b719",
+			"Peers": [{
+				"ID":         8411209950237823,
+				"StableID":   "nxf6UuDTg821CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93dd379d75307db94ff41c81cf35e2ce3ef8a17753c331b8ae1d01486bc14133",
+				"DiscoKey":   "discokey:d6e5d845d4a61d9611039a7a095f2b1c6b5774d1d999f2e66994ae5839be7f5d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:34767", "10.65.0.27:34767", "172.17.0.1:34767"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:54:57.307437635Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8527559154668666,
+				"StableID":   "nyY8F6X9b921CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:18063902586de112035697a7d33c0b0d2437ce86e16ef2fa677c8720d36be118",
+				"DiscoKey":   "discokey:e04f2c91eb9a62c83a908a697e964ae8db5c2669adb58658701e39751ca7b87f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:43915", "10.65.0.27:43915", "172.17.0.1:43915"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:54:57.798391545Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4392928306204163,
+				"StableID":   "ncdVY6nZJb11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7733a8a95d8a6b8d17ae2bc849ff1bdfc2e0876530d475914b13acf2154e970a",
+				"DiscoKey":   "discokey:265fb145c3dd754d0d9008806c47e519d76eef4544263361a634bf3a2e636866",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41036", "10.65.0.27:41036", "172.17.0.1:41036"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:54:58.316468705Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1207939473313067,
+				"StableID":   "nkh1sFX5SA11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:233cb7f748e22261a3f8566bb29545ef608acd94b0f100120fc0273ab86a2717",
+				"DiscoKey":   "discokey:a06ab142ed29e39b67b81ec4a1ce23bd1beb0b37edf5678b6729b847bee38157",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:34232", "10.65.0.27:34232", "172.17.0.1:34232"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:54:58.87037937Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1627276155753729,
+				"StableID":   "npgEYYnzhD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca438abc65fffc9b2bab312b7b07f42bc583d5a0a63663b6a4299666b4693b71",
+				"DiscoKey":   "discokey:252fa7692cd2f4bb76de4ea1ddd0cf02aee70c14cd5c626ba0e7f0ff8ae0a305",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:38759", "10.65.0.27:38759", "172.17.0.1:38759"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:54:59.370753878Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4802895802744196,
+				"StableID":   "notyLrvEWe11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0c2a07339f8330edf21ea79b553d5179ba72ce89847990f43db3bf887d87e6d",
+				"DiscoKey":   "discokey:727125a1a4a8effad0fdc231628ed4ddc54f234c49991b01afa487f12e133979",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:57755", "10.65.0.27:57755", "172.17.0.1:57755"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:54:59.905418907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         5616856630506496,
+				"StableID":   "nsE8RMJtrk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b07f7b08f86823c6d44606204b33fe7ccca8ed9bb4399aebfff18bf34997224c",
+				"DiscoKey":   "discokey:515308583964bbf064a71780cf6ef30726522f0fb162462e8854ce92cbfe4f4b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:36882", "10.65.0.27:36882", "172.17.0.1:36882"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:55:00.989848739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4120313125665865,
+				"StableID":   "ngroZ4e6BZ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6fb376f47fa693213dfca72b61c95eb2f23ebed8522a14b2fe191e0db7cf091b",
+				"DiscoKey":   "discokey:f6cf1fe5bfe11aa31ad82de309ed5557ba85cc40ab52888af04ee6d0e03cb138",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:47911", "10.65.0.27:47911", "172.17.0.1:47911"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:55:01.516466376Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5934169217031598,
+				"StableID":   "nmes6eZbLo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:16d40a42b3b8c7315c450b7a7da71c56927b39a2dd6b7280977c934aaee31f62",
+				"DiscoKey":   "discokey:2ecc3cc255d5ae9e7acaa82ee269721f6792799cec4e4a2f8ee33a91d0c51a27",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:35139", "10.65.0.27:35139", "172.17.0.1:35139"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:55:02.06320188Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3829371369919846,
+				"StableID":   "ns7qtM6LuW11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db797d297cfa42c98d66a85a927be03bd41ddb20317364b14f149e31cf258428",
+				"DiscoKey":   "discokey:3be0883118c8903cae09ad9bf645ef349e73f75eec4042bd473db8859d33c547",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43303", "10.65.0.27:43303", "172.17.0.1:43303"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:55:02.592956052Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4142969531082554,
+				"StableID":   "nmvgXVnMMZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c64e08dc977990e0094b182fa6b8ecb09d47ace847f52ded4865105b26c15e1d",
+				"DiscoKey":   "discokey:e186e1d9a6a0ed9548fb249b9c8009e271e6b3e7203e90af2a94b363a7a6957b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:34846", "10.65.0.27:34846", "172.17.0.1:34846"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:55:03.128402107Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4800455758014461,
+				"StableID":   "nEdwwHq8Ve11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:13dfcf0fde718814e3ed7ede12f418bb29efeb7b74504cb9a5b80705c43f985e",
+				"KeyExpiry":  "2026-11-08T18:55:03Z",
+				"DiscoKey":   "discokey:87f03b040575e96d175b430d152c82bb51377bec227b970abdd5fd8cd249bd1d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:39636", "10.65.0.27:39636", "172.17.0.1:39636"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:55:03.668345456Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         495872617439219,
+				"StableID":   "n68hAWjas411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:13e613e286484cf36612d9e22d3bd3f85eebd6bd2c41a36dca1d2cebd51a875d",
+				"KeyExpiry":  "2026-11-08T18:55:04Z",
+				"DiscoKey":   "discokey:cc03681f9cc0baf6ed18522e08ccce3dd47c3549764f4386874d9ee95ba67f16",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:58189", "10.65.0.27:58189", "172.17.0.1:58189"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:55:04.199017017Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4633119923072565,
+				"StableID":   "nkLEEqCMBd11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fbb938f4369157493487e4f585a31f43051f3fcfaf242c3eae351cb65f78397b",
+				"KeyExpiry":  "2026-11-08T18:55:04Z",
+				"DiscoKey":   "discokey:3e4645543c5b7f8f36a0f08e879e82369fb7b9c7c4af7e880111cd54ada6ea39",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:41264", "10.65.0.27:41264", "172.17.0.1:41264"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:55:04.736959081Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2735199946774139": {
+				"ID":          2735199946774139,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4120313125665865,
+				"StableID":   "ngroZ4e6BZ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       4120313125665865,
+				"Key":        "nodekey:6fb376f47fa693213dfca72b61c95eb2f23ebed8522a14b2fe191e0db7cf091b",
+				"DiscoKey":   "discokey:f6cf1fe5bfe11aa31ad82de309ed5557ba85cc40ab52888af04ee6d0e03cb138",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:47911", "10.65.0.27:47911", "172.17.0.1:47911"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:55:01.516466376Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6fb376f47fa693213dfca72b61c95eb2f23ebed8522a14b2fe191e0db7cf091b",
+			"MachineKey": "mkey:471977e9f41a98786c11288c4f1d086ca15a876f4e8e478ef21dba7f395c673d",
+			"Peers": [{
+				"ID":         8411209950237823,
+				"StableID":   "nxf6UuDTg821CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93dd379d75307db94ff41c81cf35e2ce3ef8a17753c331b8ae1d01486bc14133",
+				"DiscoKey":   "discokey:d6e5d845d4a61d9611039a7a095f2b1c6b5774d1d999f2e66994ae5839be7f5d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:34767", "10.65.0.27:34767", "172.17.0.1:34767"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:54:57.307437635Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8527559154668666,
+				"StableID":   "nyY8F6X9b921CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:18063902586de112035697a7d33c0b0d2437ce86e16ef2fa677c8720d36be118",
+				"DiscoKey":   "discokey:e04f2c91eb9a62c83a908a697e964ae8db5c2669adb58658701e39751ca7b87f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:43915", "10.65.0.27:43915", "172.17.0.1:43915"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:54:57.798391545Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4392928306204163,
+				"StableID":   "ncdVY6nZJb11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7733a8a95d8a6b8d17ae2bc849ff1bdfc2e0876530d475914b13acf2154e970a",
+				"DiscoKey":   "discokey:265fb145c3dd754d0d9008806c47e519d76eef4544263361a634bf3a2e636866",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41036", "10.65.0.27:41036", "172.17.0.1:41036"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:54:58.316468705Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1207939473313067,
+				"StableID":   "nkh1sFX5SA11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:233cb7f748e22261a3f8566bb29545ef608acd94b0f100120fc0273ab86a2717",
+				"DiscoKey":   "discokey:a06ab142ed29e39b67b81ec4a1ce23bd1beb0b37edf5678b6729b847bee38157",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:34232", "10.65.0.27:34232", "172.17.0.1:34232"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:54:58.87037937Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1627276155753729,
+				"StableID":   "npgEYYnzhD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca438abc65fffc9b2bab312b7b07f42bc583d5a0a63663b6a4299666b4693b71",
+				"DiscoKey":   "discokey:252fa7692cd2f4bb76de4ea1ddd0cf02aee70c14cd5c626ba0e7f0ff8ae0a305",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:38759", "10.65.0.27:38759", "172.17.0.1:38759"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:54:59.370753878Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4802895802744196,
+				"StableID":   "notyLrvEWe11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0c2a07339f8330edf21ea79b553d5179ba72ce89847990f43db3bf887d87e6d",
+				"DiscoKey":   "discokey:727125a1a4a8effad0fdc231628ed4ddc54f234c49991b01afa487f12e133979",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:57755", "10.65.0.27:57755", "172.17.0.1:57755"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:54:59.905418907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2735199946774139,
+				"StableID":   "nvpZ3k4nMN11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6de85e40f009cdbb62357629ec0b6ee633584623f61287320fcc63acb947a7f",
+				"DiscoKey":   "discokey:ea96b2b8ff76a83c5af36558bd12f7cc29a71fd7db4349be1d9ca5e3fcff0f58",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:41697", "10.65.0.27:41697", "172.17.0.1:41697"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:55:00.445932525Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5616856630506496,
+				"StableID":   "nsE8RMJtrk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b07f7b08f86823c6d44606204b33fe7ccca8ed9bb4399aebfff18bf34997224c",
+				"DiscoKey":   "discokey:515308583964bbf064a71780cf6ef30726522f0fb162462e8854ce92cbfe4f4b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:36882", "10.65.0.27:36882", "172.17.0.1:36882"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:55:00.989848739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         5934169217031598,
+				"StableID":   "nmes6eZbLo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:16d40a42b3b8c7315c450b7a7da71c56927b39a2dd6b7280977c934aaee31f62",
+				"DiscoKey":   "discokey:2ecc3cc255d5ae9e7acaa82ee269721f6792799cec4e4a2f8ee33a91d0c51a27",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:35139", "10.65.0.27:35139", "172.17.0.1:35139"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:55:02.06320188Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3829371369919846,
+				"StableID":   "ns7qtM6LuW11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db797d297cfa42c98d66a85a927be03bd41ddb20317364b14f149e31cf258428",
+				"DiscoKey":   "discokey:3be0883118c8903cae09ad9bf645ef349e73f75eec4042bd473db8859d33c547",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43303", "10.65.0.27:43303", "172.17.0.1:43303"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:55:02.592956052Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4142969531082554,
+				"StableID":   "nmvgXVnMMZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c64e08dc977990e0094b182fa6b8ecb09d47ace847f52ded4865105b26c15e1d",
+				"DiscoKey":   "discokey:e186e1d9a6a0ed9548fb249b9c8009e271e6b3e7203e90af2a94b363a7a6957b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:34846", "10.65.0.27:34846", "172.17.0.1:34846"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:55:03.128402107Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4800455758014461,
+				"StableID":   "nEdwwHq8Ve11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:13dfcf0fde718814e3ed7ede12f418bb29efeb7b74504cb9a5b80705c43f985e",
+				"KeyExpiry":  "2026-11-08T18:55:03Z",
+				"DiscoKey":   "discokey:87f03b040575e96d175b430d152c82bb51377bec227b970abdd5fd8cd249bd1d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:39636", "10.65.0.27:39636", "172.17.0.1:39636"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:55:03.668345456Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         495872617439219,
+				"StableID":   "n68hAWjas411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:13e613e286484cf36612d9e22d3bd3f85eebd6bd2c41a36dca1d2cebd51a875d",
+				"KeyExpiry":  "2026-11-08T18:55:04Z",
+				"DiscoKey":   "discokey:cc03681f9cc0baf6ed18522e08ccce3dd47c3549764f4386874d9ee95ba67f16",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:58189", "10.65.0.27:58189", "172.17.0.1:58189"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:55:04.199017017Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4633119923072565,
+				"StableID":   "nkLEEqCMBd11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fbb938f4369157493487e4f585a31f43051f3fcfaf242c3eae351cb65f78397b",
+				"KeyExpiry":  "2026-11-08T18:55:04Z",
+				"DiscoKey":   "discokey:3e4645543c5b7f8f36a0f08e879e82369fb7b9c7c4af7e880111cd54ada6ea39",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:41264", "10.65.0.27:41264", "172.17.0.1:41264"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:55:04.736959081Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4120313125665865": {
+				"ID":          4120313125665865,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         495872617439219,
+				"StableID":   "n68hAWjas411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:13e613e286484cf36612d9e22d3bd3f85eebd6bd2c41a36dca1d2cebd51a875d",
+				"KeyExpiry":  "2026-11-08T18:55:04Z",
+				"DiscoKey":   "discokey:cc03681f9cc0baf6ed18522e08ccce3dd47c3549764f4386874d9ee95ba67f16",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:58189", "10.65.0.27:58189", "172.17.0.1:58189"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:55:04.199017017Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:13e613e286484cf36612d9e22d3bd3f85eebd6bd2c41a36dca1d2cebd51a875d",
+			"MachineKey": "mkey:6ca482f1710c32e05b988ffa88dc24a374c23675c08826ef8d28bf061d737577",
+			"Peers": [{
+				"ID":         8411209950237823,
+				"StableID":   "nxf6UuDTg821CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93dd379d75307db94ff41c81cf35e2ce3ef8a17753c331b8ae1d01486bc14133",
+				"DiscoKey":   "discokey:d6e5d845d4a61d9611039a7a095f2b1c6b5774d1d999f2e66994ae5839be7f5d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:34767", "10.65.0.27:34767", "172.17.0.1:34767"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:54:57.307437635Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8527559154668666,
+				"StableID":   "nyY8F6X9b921CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:18063902586de112035697a7d33c0b0d2437ce86e16ef2fa677c8720d36be118",
+				"DiscoKey":   "discokey:e04f2c91eb9a62c83a908a697e964ae8db5c2669adb58658701e39751ca7b87f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:43915", "10.65.0.27:43915", "172.17.0.1:43915"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:54:57.798391545Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4392928306204163,
+				"StableID":   "ncdVY6nZJb11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7733a8a95d8a6b8d17ae2bc849ff1bdfc2e0876530d475914b13acf2154e970a",
+				"DiscoKey":   "discokey:265fb145c3dd754d0d9008806c47e519d76eef4544263361a634bf3a2e636866",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41036", "10.65.0.27:41036", "172.17.0.1:41036"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:54:58.316468705Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1207939473313067,
+				"StableID":   "nkh1sFX5SA11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:233cb7f748e22261a3f8566bb29545ef608acd94b0f100120fc0273ab86a2717",
+				"DiscoKey":   "discokey:a06ab142ed29e39b67b81ec4a1ce23bd1beb0b37edf5678b6729b847bee38157",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:34232", "10.65.0.27:34232", "172.17.0.1:34232"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:54:58.87037937Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1627276155753729,
+				"StableID":   "npgEYYnzhD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca438abc65fffc9b2bab312b7b07f42bc583d5a0a63663b6a4299666b4693b71",
+				"DiscoKey":   "discokey:252fa7692cd2f4bb76de4ea1ddd0cf02aee70c14cd5c626ba0e7f0ff8ae0a305",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:38759", "10.65.0.27:38759", "172.17.0.1:38759"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:54:59.370753878Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4802895802744196,
+				"StableID":   "notyLrvEWe11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0c2a07339f8330edf21ea79b553d5179ba72ce89847990f43db3bf887d87e6d",
+				"DiscoKey":   "discokey:727125a1a4a8effad0fdc231628ed4ddc54f234c49991b01afa487f12e133979",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:57755", "10.65.0.27:57755", "172.17.0.1:57755"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:54:59.905418907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2735199946774139,
+				"StableID":   "nvpZ3k4nMN11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6de85e40f009cdbb62357629ec0b6ee633584623f61287320fcc63acb947a7f",
+				"DiscoKey":   "discokey:ea96b2b8ff76a83c5af36558bd12f7cc29a71fd7db4349be1d9ca5e3fcff0f58",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:41697", "10.65.0.27:41697", "172.17.0.1:41697"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:55:00.445932525Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5616856630506496,
+				"StableID":   "nsE8RMJtrk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b07f7b08f86823c6d44606204b33fe7ccca8ed9bb4399aebfff18bf34997224c",
+				"DiscoKey":   "discokey:515308583964bbf064a71780cf6ef30726522f0fb162462e8854ce92cbfe4f4b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:36882", "10.65.0.27:36882", "172.17.0.1:36882"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:55:00.989848739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4120313125665865,
+				"StableID":   "ngroZ4e6BZ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6fb376f47fa693213dfca72b61c95eb2f23ebed8522a14b2fe191e0db7cf091b",
+				"DiscoKey":   "discokey:f6cf1fe5bfe11aa31ad82de309ed5557ba85cc40ab52888af04ee6d0e03cb138",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:47911", "10.65.0.27:47911", "172.17.0.1:47911"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:55:01.516466376Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         5934169217031598,
+				"StableID":   "nmes6eZbLo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:16d40a42b3b8c7315c450b7a7da71c56927b39a2dd6b7280977c934aaee31f62",
+				"DiscoKey":   "discokey:2ecc3cc255d5ae9e7acaa82ee269721f6792799cec4e4a2f8ee33a91d0c51a27",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:35139", "10.65.0.27:35139", "172.17.0.1:35139"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:55:02.06320188Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3829371369919846,
+				"StableID":   "ns7qtM6LuW11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db797d297cfa42c98d66a85a927be03bd41ddb20317364b14f149e31cf258428",
+				"DiscoKey":   "discokey:3be0883118c8903cae09ad9bf645ef349e73f75eec4042bd473db8859d33c547",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43303", "10.65.0.27:43303", "172.17.0.1:43303"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:55:02.592956052Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4142969531082554,
+				"StableID":   "nmvgXVnMMZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c64e08dc977990e0094b182fa6b8ecb09d47ace847f52ded4865105b26c15e1d",
+				"DiscoKey":   "discokey:e186e1d9a6a0ed9548fb249b9c8009e271e6b3e7203e90af2a94b363a7a6957b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:34846", "10.65.0.27:34846", "172.17.0.1:34846"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:55:03.128402107Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4800455758014461,
+				"StableID":   "nEdwwHq8Ve11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:13dfcf0fde718814e3ed7ede12f418bb29efeb7b74504cb9a5b80705c43f985e",
+				"KeyExpiry":  "2026-11-08T18:55:03Z",
+				"DiscoKey":   "discokey:87f03b040575e96d175b430d152c82bb51377bec227b970abdd5fd8cd249bd1d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:39636", "10.65.0.27:39636", "172.17.0.1:39636"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:55:03.668345456Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         4633119923072565,
+				"StableID":   "nkLEEqCMBd11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fbb938f4369157493487e4f585a31f43051f3fcfaf242c3eae351cb65f78397b",
+				"KeyExpiry":  "2026-11-08T18:55:04Z",
+				"DiscoKey":   "discokey:3e4645543c5b7f8f36a0f08e879e82369fb7b9c7c4af7e880111cd54ada6ea39",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:41264", "10.65.0.27:41264", "172.17.0.1:41264"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:55:04.736959081Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5934169217031598,
+				"StableID":   "nmes6eZbLo11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       5934169217031598,
+				"Key":        "nodekey:16d40a42b3b8c7315c450b7a7da71c56927b39a2dd6b7280977c934aaee31f62",
+				"DiscoKey":   "discokey:2ecc3cc255d5ae9e7acaa82ee269721f6792799cec4e4a2f8ee33a91d0c51a27",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:35139", "10.65.0.27:35139", "172.17.0.1:35139"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:55:02.06320188Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:16d40a42b3b8c7315c450b7a7da71c56927b39a2dd6b7280977c934aaee31f62",
+			"MachineKey": "mkey:2ee5d1579c1aa339a137807308c8d36d9d1e9fa10f8f268de90c483172148b23",
+			"Peers": [{
+				"ID":         8411209950237823,
+				"StableID":   "nxf6UuDTg821CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:93dd379d75307db94ff41c81cf35e2ce3ef8a17753c331b8ae1d01486bc14133",
+				"DiscoKey":   "discokey:d6e5d845d4a61d9611039a7a095f2b1c6b5774d1d999f2e66994ae5839be7f5d",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:34767", "10.65.0.27:34767", "172.17.0.1:34767"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:54:57.307437635Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8527559154668666,
+				"StableID":   "nyY8F6X9b921CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:18063902586de112035697a7d33c0b0d2437ce86e16ef2fa677c8720d36be118",
+				"DiscoKey":   "discokey:e04f2c91eb9a62c83a908a697e964ae8db5c2669adb58658701e39751ca7b87f",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:43915", "10.65.0.27:43915", "172.17.0.1:43915"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:54:57.798391545Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4392928306204163,
+				"StableID":   "ncdVY6nZJb11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7733a8a95d8a6b8d17ae2bc849ff1bdfc2e0876530d475914b13acf2154e970a",
+				"DiscoKey":   "discokey:265fb145c3dd754d0d9008806c47e519d76eef4544263361a634bf3a2e636866",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:41036", "10.65.0.27:41036", "172.17.0.1:41036"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:54:58.316468705Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1207939473313067,
+				"StableID":   "nkh1sFX5SA11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:233cb7f748e22261a3f8566bb29545ef608acd94b0f100120fc0273ab86a2717",
+				"DiscoKey":   "discokey:a06ab142ed29e39b67b81ec4a1ce23bd1beb0b37edf5678b6729b847bee38157",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:34232", "10.65.0.27:34232", "172.17.0.1:34232"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:54:58.87037937Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1627276155753729,
+				"StableID":   "npgEYYnzhD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ca438abc65fffc9b2bab312b7b07f42bc583d5a0a63663b6a4299666b4693b71",
+				"DiscoKey":   "discokey:252fa7692cd2f4bb76de4ea1ddd0cf02aee70c14cd5c626ba0e7f0ff8ae0a305",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:38759", "10.65.0.27:38759", "172.17.0.1:38759"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:54:59.370753878Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4802895802744196,
+				"StableID":   "notyLrvEWe11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:a0c2a07339f8330edf21ea79b553d5179ba72ce89847990f43db3bf887d87e6d",
+				"DiscoKey":   "discokey:727125a1a4a8effad0fdc231628ed4ddc54f234c49991b01afa487f12e133979",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:57755", "10.65.0.27:57755", "172.17.0.1:57755"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:54:59.905418907Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         2735199946774139,
+				"StableID":   "nvpZ3k4nMN11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:d6de85e40f009cdbb62357629ec0b6ee633584623f61287320fcc63acb947a7f",
+				"DiscoKey":   "discokey:ea96b2b8ff76a83c5af36558bd12f7cc29a71fd7db4349be1d9ca5e3fcff0f58",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:41697", "10.65.0.27:41697", "172.17.0.1:41697"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:55:00.445932525Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         5616856630506496,
+				"StableID":   "nsE8RMJtrk11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b07f7b08f86823c6d44606204b33fe7ccca8ed9bb4399aebfff18bf34997224c",
+				"DiscoKey":   "discokey:515308583964bbf064a71780cf6ef30726522f0fb162462e8854ce92cbfe4f4b",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:36882", "10.65.0.27:36882", "172.17.0.1:36882"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:55:00.989848739Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         4120313125665865,
+				"StableID":   "ngroZ4e6BZ11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:6fb376f47fa693213dfca72b61c95eb2f23ebed8522a14b2fe191e0db7cf091b",
+				"DiscoKey":   "discokey:f6cf1fe5bfe11aa31ad82de309ed5557ba85cc40ab52888af04ee6d0e03cb138",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:47911", "10.65.0.27:47911", "172.17.0.1:47911"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:55:01.516466376Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3829371369919846,
+				"StableID":   "ns7qtM6LuW11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:db797d297cfa42c98d66a85a927be03bd41ddb20317364b14f149e31cf258428",
+				"DiscoKey":   "discokey:3be0883118c8903cae09ad9bf645ef349e73f75eec4042bd473db8859d33c547",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:43303", "10.65.0.27:43303", "172.17.0.1:43303"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:55:02.592956052Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         4142969531082554,
+				"StableID":   "nmvgXVnMMZ11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c64e08dc977990e0094b182fa6b8ecb09d47ace847f52ded4865105b26c15e1d",
+				"DiscoKey":   "discokey:e186e1d9a6a0ed9548fb249b9c8009e271e6b3e7203e90af2a94b363a7a6957b",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:34846", "10.65.0.27:34846", "172.17.0.1:34846"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:55:03.128402107Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         4800455758014461,
+				"StableID":   "nEdwwHq8Ve11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:13dfcf0fde718814e3ed7ede12f418bb29efeb7b74504cb9a5b80705c43f985e",
+				"KeyExpiry":  "2026-11-08T18:55:03Z",
+				"DiscoKey":   "discokey:87f03b040575e96d175b430d152c82bb51377bec227b970abdd5fd8cd249bd1d",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:39636", "10.65.0.27:39636", "172.17.0.1:39636"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:55:03.668345456Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         495872617439219,
+				"StableID":   "n68hAWjas411CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:13e613e286484cf36612d9e22d3bd3f85eebd6bd2c41a36dca1d2cebd51a875d",
+				"KeyExpiry":  "2026-11-08T18:55:04Z",
+				"DiscoKey":   "discokey:cc03681f9cc0baf6ed18522e08ccce3dd47c3549764f4386874d9ee95ba67f16",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:58189", "10.65.0.27:58189", "172.17.0.1:58189"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:55:04.199017017Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         4633119923072565,
+				"StableID":   "nkLEEqCMBd11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fbb938f4369157493487e4f585a31f43051f3fcfaf242c3eae351cb65f78397b",
+				"KeyExpiry":  "2026-11-08T18:55:04Z",
+				"DiscoKey":   "discokey:3e4645543c5b7f8f36a0f08e879e82369fb7b9c7c4af7e880111cd54ada6ea39",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:41264", "10.65.0.27:41264", "172.17.0.1:41264"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:55:04.736959081Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5934169217031598": {
+				"ID":          5934169217031598,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/sshtest_results/sshtest-user-root-only.hujson
+++ b/hscontrol/policy/v2/testdata/sshtest_results/sshtest-user-root-only.hujson
@@ -1,0 +1,18749 @@
+// sshtest-user-root-only
+//
+// users:[root] allows root login
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T18:55:40Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "sshtest-user-root-only",
+	"description":    "users:[root] allows root login",
+	"category":       "sshtest",
+	"captured_at":    "2026-05-12T18:55:40.667833017Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"input": {
+		"api_response_code": 200,
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                         \n  \n                                                                \n{\n\t\"category\":    \"sshtest\",\n\t\"description\": \"users:[root] allows root login\",\n\t\"id\":          \"sshtest-user-root-only\",\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"thor@example.org\"],\n\t\t\"users\":  [\"root\"]\n\t}], \"sshTests\": [{\n\t\t\"accept\": [\"root\"],\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    \"thor@example.org\"\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/sshtest/sshtest-user-root-only.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["thor@example.org"],
+				"users":  ["root"]
+			}],
+			"sshTests":  [{"accept": ["root"], "dst": ["tag:server"], "src": "thor@example.org"}],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6159030803756667,
+				"StableID":   "ngy2X8JS6q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       6159030803756667,
+				"Key":        "nodekey:ba3a4a8a342d7e2c5296e20a267673ca232ea1874fbf3b74c616f1e7f58e5a03",
+				"DiscoKey":   "discokey:23f15d53be0ffc735905ec11c03e0c6525e5341ac36f77fd7b7b920b74637659",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:42970", "10.65.0.27:42970", "172.17.0.1:42970"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:55:48.917754396Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ba3a4a8a342d7e2c5296e20a267673ca232ea1874fbf3b74c616f1e7f58e5a03",
+			"MachineKey": "mkey:a22ab3dad31424ee521711af97ad892b3f9c25cbab38c195c0aa7925f9ebc176",
+			"Peers": [{
+				"ID":         7574537821997402,
+				"StableID":   "nP1YYLGX9221CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0d5f583bd95b025edb93bfadba2a68ef30828f10c9201450c797494a31154957",
+				"DiscoKey":   "discokey:0cd472111f5eeb608eb57546345224817b76f6680e82178cd22a928b20bb2f50",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:38146", "10.65.0.27:38146", "172.17.0.1:38146"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:55:43.05455785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1124457422242543,
+				"StableID":   "nGR3tCbGn911CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41a9994e26a7a555909ddca54a2ea5f57a237226437eb1a6f7dcdfd481de3e23",
+				"DiscoKey":   "discokey:cca74380213a9a811d06776d30c61025dd8a3f23ad72270d58cda908fedddf61",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:35511", "10.65.0.27:35511", "172.17.0.1:35511"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:55:43.611081748Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1262922201761304,
+				"StableID":   "nVs9JqpyrA11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:82d7bd44688c616e6ba8c45f037f88cbfc0cbbb565e601a4bf5e98bb7007ab00",
+				"DiscoKey":   "discokey:3fdbc83628d93015a00ff0a955ac12334378208ed5933ea2a1af5b931fd55218",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:56475", "10.65.0.27:56475", "172.17.0.1:56475"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:55:44.134231193Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         143186579656124,
+				"StableID":   "n9F3jaGr7211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03726a712a95c9c6604702c4ce7a0d22295500b208d3a39351b3adf251231f4d",
+				"DiscoKey":   "discokey:19c9009f83a64c5349e2991f620e1d10516162321215f306cd5a9c17bce22010",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:45702", "10.65.0.27:45702", "172.17.0.1:45702"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:55:44.672814512Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4218609743689897,
+				"StableID":   "n6fm62jcwZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:225c0d9fb8a56bc197efac7fa83f8c960ceedd2aba457cd43b2f097d2e0cc02b",
+				"DiscoKey":   "discokey:66627884ff0d54506903dfa6e608b63a66b3d839ee60070a6aff488e0df22d7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:56504", "10.65.0.27:56504", "172.17.0.1:56504"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:55:45.210808467Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3784649116951398,
+				"StableID":   "nfVVYFK5ZW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:436ea22cf25b7ab0623050a4cd4deb931f09e1564d6f9e0c4209c4499ec07a76",
+				"DiscoKey":   "discokey:315c285f8853af5177ca5e849ad187931bc2f4cecae9d9f4b6570381ba324e2f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:60758", "10.65.0.27:60758", "172.17.0.1:60758"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:55:45.738349707Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8126768308751190,
+				"StableID":   "nofkdXRdT621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1bfc739041be126427e0a35a5929bf1b98729f780167971323982108cfbf871d",
+				"DiscoKey":   "discokey:22cb0be3eb2ecac46c129116abf3a8a44debda473ce859b663669a2256bb9275",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:36078", "10.65.0.27:36078", "172.17.0.1:36078"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:55:46.260501309Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         101792691512349,
+				"StableID":   "nLWRaSv6o111CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:572a6c971194c402a01fc7095f455cc5b0d4211dadde9b6fee2a730951c9f34b",
+				"DiscoKey":   "discokey:953753a219bb2f744e9b9c230d7b5a2511d4184208fa7559cbd8d3a58dad2f0c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:59864", "10.65.0.27:59864", "172.17.0.1:59864"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:55:46.792557118Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         587147047843869,
+				"StableID":   "nL2b2jMva511CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b25bb9d9f29ddf02691d4ea73e8ebf98847eb7877a3332de6d58d2d13091a75c",
+				"DiscoKey":   "discokey:21e71f6269e9003ba5306ddf9c2d2784f2b15069b2fb50468f1babf65d686443",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57075", "10.65.0.27:57075", "172.17.0.1:57075"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:55:47.332575447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2713887429846554,
+				"StableID":   "nHCUuoD8CN11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a067cbfbe394d17f3907921b058b4dedd146d624512dd527e8814e0205a9801",
+				"DiscoKey":   "discokey:397297a94f7e621fb6e75696a3066d4d0a921d520f218d477552c5c0663f5743",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:53344", "10.65.0.27:53344", "172.17.0.1:53344"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:55:47.859567419Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7448351196262868,
+				"StableID":   "nm9wXEZNA121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9658c60d68240d75ab76570991d3000299b9e51b6fbf9cd893283e8ee9d9515d",
+				"DiscoKey":   "discokey:459a36363611b5bb51b0768c257200b8d379036d3b38d92114314fe455492e06",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47083", "10.65.0.27:47083", "172.17.0.1:47083"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:55:48.387063424Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         5376294992179314,
+				"StableID":   "nwBhCs9wyi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:16951ebb9387bbaf6f7196c8304ba2260a14a33dcf58a7da7ad5c235817ee94e",
+				"KeyExpiry":  "2026-11-08T18:55:50Z",
+				"DiscoKey":   "discokey:d8e2d2e55f0276b4c2b490637a3cf52878391418f9e2c2376bdbb292f8edef50",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:34625", "10.65.0.27:34625", "172.17.0.1:34625"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:55:50.452117454Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7118790738790820,
+				"StableID":   "nRd8SZZ7bx11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6a2e97adca6aa6b02c29e4ad4d1ecbcdaab63299f5494632f948b1dbc2833527",
+				"KeyExpiry":  "2026-11-08T18:55:50Z",
+				"DiscoKey":   "discokey:7f2a1d5f5e129e7d0c8fbd3b5b6c75bdaeaa1e255ab9f9bd5c4d0f553b13215b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:58399", "10.65.0.27:58399", "172.17.0.1:58399"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:55:50.976960192Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7627231953651300,
+				"StableID":   "nVjtW6TPZ221CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fbcd8dd70ff5e4d0a088c185dacd95456c094d15a1a191a9efef5d1f48c65d34",
+				"KeyExpiry":  "2026-11-08T18:55:51Z",
+				"DiscoKey":   "discokey:2bb5db6697ec4a3347b56e55fd6853068e083e10d8055fe0ec217c9610948c18",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:36613", "10.65.0.27:36613", "172.17.0.1:36613"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:55:51.516838863Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy": {"rules": [{
+				"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+				"sshUsers":   {"root": "root"},
+				"action": {
+					"accept":                    true,
+					"allowAgentForwarding":      true,
+					"allowLocalPortForwarding":  true,
+					"allowRemotePortForwarding": true
+				}
+			}]},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6159030803756667": {
+				"ID":          6159030803756667,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		},
+		"ssh_rules": [{
+			"principals": [{"nodeIP": "100.64.0.17"}, {"nodeIP": "fd7a:115c:a1e0::11"}],
+			"sshUsers":   {"root": "root"},
+			"action": {
+				"accept":                    true,
+				"allowAgentForwarding":      true,
+				"allowLocalPortForwarding":  true,
+				"allowRemotePortForwarding": true
+			}
+		}]
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3784649116951398,
+				"StableID":   "nfVVYFK5ZW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       3784649116951398,
+				"Key":        "nodekey:436ea22cf25b7ab0623050a4cd4deb931f09e1564d6f9e0c4209c4499ec07a76",
+				"DiscoKey":   "discokey:315c285f8853af5177ca5e849ad187931bc2f4cecae9d9f4b6570381ba324e2f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:60758", "10.65.0.27:60758", "172.17.0.1:60758"],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:55:45.738349707Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:436ea22cf25b7ab0623050a4cd4deb931f09e1564d6f9e0c4209c4499ec07a76",
+			"MachineKey": "mkey:bf1f11799705132bc24b4d11c7b9fd3abeba5e49ac8254f555c8d3ec9c80c14a",
+			"Peers": [{
+				"ID":         7574537821997402,
+				"StableID":   "nP1YYLGX9221CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0d5f583bd95b025edb93bfadba2a68ef30828f10c9201450c797494a31154957",
+				"DiscoKey":   "discokey:0cd472111f5eeb608eb57546345224817b76f6680e82178cd22a928b20bb2f50",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:38146", "10.65.0.27:38146", "172.17.0.1:38146"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:55:43.05455785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1124457422242543,
+				"StableID":   "nGR3tCbGn911CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41a9994e26a7a555909ddca54a2ea5f57a237226437eb1a6f7dcdfd481de3e23",
+				"DiscoKey":   "discokey:cca74380213a9a811d06776d30c61025dd8a3f23ad72270d58cda908fedddf61",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:35511", "10.65.0.27:35511", "172.17.0.1:35511"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:55:43.611081748Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1262922201761304,
+				"StableID":   "nVs9JqpyrA11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:82d7bd44688c616e6ba8c45f037f88cbfc0cbbb565e601a4bf5e98bb7007ab00",
+				"DiscoKey":   "discokey:3fdbc83628d93015a00ff0a955ac12334378208ed5933ea2a1af5b931fd55218",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:56475", "10.65.0.27:56475", "172.17.0.1:56475"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:55:44.134231193Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         143186579656124,
+				"StableID":   "n9F3jaGr7211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03726a712a95c9c6604702c4ce7a0d22295500b208d3a39351b3adf251231f4d",
+				"DiscoKey":   "discokey:19c9009f83a64c5349e2991f620e1d10516162321215f306cd5a9c17bce22010",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:45702", "10.65.0.27:45702", "172.17.0.1:45702"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:55:44.672814512Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4218609743689897,
+				"StableID":   "n6fm62jcwZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:225c0d9fb8a56bc197efac7fa83f8c960ceedd2aba457cd43b2f097d2e0cc02b",
+				"DiscoKey":   "discokey:66627884ff0d54506903dfa6e608b63a66b3d839ee60070a6aff488e0df22d7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:56504", "10.65.0.27:56504", "172.17.0.1:56504"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:55:45.210808467Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         8126768308751190,
+				"StableID":   "nofkdXRdT621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1bfc739041be126427e0a35a5929bf1b98729f780167971323982108cfbf871d",
+				"DiscoKey":   "discokey:22cb0be3eb2ecac46c129116abf3a8a44debda473ce859b663669a2256bb9275",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:36078", "10.65.0.27:36078", "172.17.0.1:36078"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:55:46.260501309Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         101792691512349,
+				"StableID":   "nLWRaSv6o111CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:572a6c971194c402a01fc7095f455cc5b0d4211dadde9b6fee2a730951c9f34b",
+				"DiscoKey":   "discokey:953753a219bb2f744e9b9c230d7b5a2511d4184208fa7559cbd8d3a58dad2f0c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:59864", "10.65.0.27:59864", "172.17.0.1:59864"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:55:46.792557118Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         587147047843869,
+				"StableID":   "nL2b2jMva511CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b25bb9d9f29ddf02691d4ea73e8ebf98847eb7877a3332de6d58d2d13091a75c",
+				"DiscoKey":   "discokey:21e71f6269e9003ba5306ddf9c2d2784f2b15069b2fb50468f1babf65d686443",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57075", "10.65.0.27:57075", "172.17.0.1:57075"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:55:47.332575447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2713887429846554,
+				"StableID":   "nHCUuoD8CN11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a067cbfbe394d17f3907921b058b4dedd146d624512dd527e8814e0205a9801",
+				"DiscoKey":   "discokey:397297a94f7e621fb6e75696a3066d4d0a921d520f218d477552c5c0663f5743",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:53344", "10.65.0.27:53344", "172.17.0.1:53344"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:55:47.859567419Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7448351196262868,
+				"StableID":   "nm9wXEZNA121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9658c60d68240d75ab76570991d3000299b9e51b6fbf9cd893283e8ee9d9515d",
+				"DiscoKey":   "discokey:459a36363611b5bb51b0768c257200b8d379036d3b38d92114314fe455492e06",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47083", "10.65.0.27:47083", "172.17.0.1:47083"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:55:48.387063424Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6159030803756667,
+				"StableID":   "ngy2X8JS6q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba3a4a8a342d7e2c5296e20a267673ca232ea1874fbf3b74c616f1e7f58e5a03",
+				"DiscoKey":   "discokey:23f15d53be0ffc735905ec11c03e0c6525e5341ac36f77fd7b7b920b74637659",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:42970", "10.65.0.27:42970", "172.17.0.1:42970"],
+				"HomeDERP":   18,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:55:48.917754396Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5376294992179314,
+				"StableID":   "nwBhCs9wyi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:16951ebb9387bbaf6f7196c8304ba2260a14a33dcf58a7da7ad5c235817ee94e",
+				"KeyExpiry":  "2026-11-08T18:55:50Z",
+				"DiscoKey":   "discokey:d8e2d2e55f0276b4c2b490637a3cf52878391418f9e2c2376bdbb292f8edef50",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:34625", "10.65.0.27:34625", "172.17.0.1:34625"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:55:50.452117454Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7118790738790820,
+				"StableID":   "nRd8SZZ7bx11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6a2e97adca6aa6b02c29e4ad4d1ecbcdaab63299f5494632f948b1dbc2833527",
+				"KeyExpiry":  "2026-11-08T18:55:50Z",
+				"DiscoKey":   "discokey:7f2a1d5f5e129e7d0c8fbd3b5b6c75bdaeaa1e255ab9f9bd5c4d0f553b13215b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:58399", "10.65.0.27:58399", "172.17.0.1:58399"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:55:50.976960192Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7627231953651300,
+				"StableID":   "nVjtW6TPZ221CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fbcd8dd70ff5e4d0a088c185dacd95456c094d15a1a191a9efef5d1f48c65d34",
+				"KeyExpiry":  "2026-11-08T18:55:51Z",
+				"DiscoKey":   "discokey:2bb5db6697ec4a3347b56e55fd6853068e083e10d8055fe0ec217c9610948c18",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:36613", "10.65.0.27:36613", "172.17.0.1:36613"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:55:51.516838863Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3784649116951398": {
+				"ID":          3784649116951398,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7627231953651300,
+				"StableID":   "nVjtW6TPZ221CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fbcd8dd70ff5e4d0a088c185dacd95456c094d15a1a191a9efef5d1f48c65d34",
+				"KeyExpiry":  "2026-11-08T18:55:51Z",
+				"DiscoKey":   "discokey:2bb5db6697ec4a3347b56e55fd6853068e083e10d8055fe0ec217c9610948c18",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:36613", "10.65.0.27:36613", "172.17.0.1:36613"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:55:51.516838863Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:fbcd8dd70ff5e4d0a088c185dacd95456c094d15a1a191a9efef5d1f48c65d34",
+			"MachineKey": "mkey:e149aaa6cc98072d1f0d0505b78ec1ac0fa4ebdd0afe838feb95c9034892cd38",
+			"Peers": [{
+				"ID":         7574537821997402,
+				"StableID":   "nP1YYLGX9221CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0d5f583bd95b025edb93bfadba2a68ef30828f10c9201450c797494a31154957",
+				"DiscoKey":   "discokey:0cd472111f5eeb608eb57546345224817b76f6680e82178cd22a928b20bb2f50",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:38146", "10.65.0.27:38146", "172.17.0.1:38146"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:55:43.05455785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1124457422242543,
+				"StableID":   "nGR3tCbGn911CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41a9994e26a7a555909ddca54a2ea5f57a237226437eb1a6f7dcdfd481de3e23",
+				"DiscoKey":   "discokey:cca74380213a9a811d06776d30c61025dd8a3f23ad72270d58cda908fedddf61",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:35511", "10.65.0.27:35511", "172.17.0.1:35511"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:55:43.611081748Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1262922201761304,
+				"StableID":   "nVs9JqpyrA11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:82d7bd44688c616e6ba8c45f037f88cbfc0cbbb565e601a4bf5e98bb7007ab00",
+				"DiscoKey":   "discokey:3fdbc83628d93015a00ff0a955ac12334378208ed5933ea2a1af5b931fd55218",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:56475", "10.65.0.27:56475", "172.17.0.1:56475"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:55:44.134231193Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         143186579656124,
+				"StableID":   "n9F3jaGr7211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03726a712a95c9c6604702c4ce7a0d22295500b208d3a39351b3adf251231f4d",
+				"DiscoKey":   "discokey:19c9009f83a64c5349e2991f620e1d10516162321215f306cd5a9c17bce22010",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:45702", "10.65.0.27:45702", "172.17.0.1:45702"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:55:44.672814512Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4218609743689897,
+				"StableID":   "n6fm62jcwZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:225c0d9fb8a56bc197efac7fa83f8c960ceedd2aba457cd43b2f097d2e0cc02b",
+				"DiscoKey":   "discokey:66627884ff0d54506903dfa6e608b63a66b3d839ee60070a6aff488e0df22d7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:56504", "10.65.0.27:56504", "172.17.0.1:56504"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:55:45.210808467Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3784649116951398,
+				"StableID":   "nfVVYFK5ZW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:436ea22cf25b7ab0623050a4cd4deb931f09e1564d6f9e0c4209c4499ec07a76",
+				"DiscoKey":   "discokey:315c285f8853af5177ca5e849ad187931bc2f4cecae9d9f4b6570381ba324e2f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:60758", "10.65.0.27:60758", "172.17.0.1:60758"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:55:45.738349707Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8126768308751190,
+				"StableID":   "nofkdXRdT621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1bfc739041be126427e0a35a5929bf1b98729f780167971323982108cfbf871d",
+				"DiscoKey":   "discokey:22cb0be3eb2ecac46c129116abf3a8a44debda473ce859b663669a2256bb9275",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:36078", "10.65.0.27:36078", "172.17.0.1:36078"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:55:46.260501309Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         101792691512349,
+				"StableID":   "nLWRaSv6o111CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:572a6c971194c402a01fc7095f455cc5b0d4211dadde9b6fee2a730951c9f34b",
+				"DiscoKey":   "discokey:953753a219bb2f744e9b9c230d7b5a2511d4184208fa7559cbd8d3a58dad2f0c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:59864", "10.65.0.27:59864", "172.17.0.1:59864"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:55:46.792557118Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         587147047843869,
+				"StableID":   "nL2b2jMva511CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b25bb9d9f29ddf02691d4ea73e8ebf98847eb7877a3332de6d58d2d13091a75c",
+				"DiscoKey":   "discokey:21e71f6269e9003ba5306ddf9c2d2784f2b15069b2fb50468f1babf65d686443",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57075", "10.65.0.27:57075", "172.17.0.1:57075"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:55:47.332575447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2713887429846554,
+				"StableID":   "nHCUuoD8CN11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a067cbfbe394d17f3907921b058b4dedd146d624512dd527e8814e0205a9801",
+				"DiscoKey":   "discokey:397297a94f7e621fb6e75696a3066d4d0a921d520f218d477552c5c0663f5743",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:53344", "10.65.0.27:53344", "172.17.0.1:53344"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:55:47.859567419Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7448351196262868,
+				"StableID":   "nm9wXEZNA121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9658c60d68240d75ab76570991d3000299b9e51b6fbf9cd893283e8ee9d9515d",
+				"DiscoKey":   "discokey:459a36363611b5bb51b0768c257200b8d379036d3b38d92114314fe455492e06",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47083", "10.65.0.27:47083", "172.17.0.1:47083"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:55:48.387063424Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6159030803756667,
+				"StableID":   "ngy2X8JS6q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba3a4a8a342d7e2c5296e20a267673ca232ea1874fbf3b74c616f1e7f58e5a03",
+				"DiscoKey":   "discokey:23f15d53be0ffc735905ec11c03e0c6525e5341ac36f77fd7b7b920b74637659",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:42970", "10.65.0.27:42970", "172.17.0.1:42970"],
+				"HomeDERP":   18,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:55:48.917754396Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5376294992179314,
+				"StableID":   "nwBhCs9wyi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:16951ebb9387bbaf6f7196c8304ba2260a14a33dcf58a7da7ad5c235817ee94e",
+				"KeyExpiry":  "2026-11-08T18:55:50Z",
+				"DiscoKey":   "discokey:d8e2d2e55f0276b4c2b490637a3cf52878391418f9e2c2376bdbb292f8edef50",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:34625", "10.65.0.27:34625", "172.17.0.1:34625"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:55:50.452117454Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7118790738790820,
+				"StableID":   "nRd8SZZ7bx11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6a2e97adca6aa6b02c29e4ad4d1ecbcdaab63299f5494632f948b1dbc2833527",
+				"KeyExpiry":  "2026-11-08T18:55:50Z",
+				"DiscoKey":   "discokey:7f2a1d5f5e129e7d0c8fbd3b5b6c75bdaeaa1e255ab9f9bd5c4d0f553b13215b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:58399", "10.65.0.27:58399", "172.17.0.1:58399"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:55:50.976960192Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1262922201761304,
+				"StableID":   "nVs9JqpyrA11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1262922201761304,
+				"Key":        "nodekey:82d7bd44688c616e6ba8c45f037f88cbfc0cbbb565e601a4bf5e98bb7007ab00",
+				"DiscoKey":   "discokey:3fdbc83628d93015a00ff0a955ac12334378208ed5933ea2a1af5b931fd55218",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:56475", "10.65.0.27:56475", "172.17.0.1:56475"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:55:44.134231193Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:82d7bd44688c616e6ba8c45f037f88cbfc0cbbb565e601a4bf5e98bb7007ab00",
+			"MachineKey": "mkey:f39b07bedd710125954890f40673ee3e46a1a330410b0c46f3652e779bf1ee27",
+			"Peers": [{
+				"ID":         7574537821997402,
+				"StableID":   "nP1YYLGX9221CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0d5f583bd95b025edb93bfadba2a68ef30828f10c9201450c797494a31154957",
+				"DiscoKey":   "discokey:0cd472111f5eeb608eb57546345224817b76f6680e82178cd22a928b20bb2f50",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:38146", "10.65.0.27:38146", "172.17.0.1:38146"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:55:43.05455785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1124457422242543,
+				"StableID":   "nGR3tCbGn911CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41a9994e26a7a555909ddca54a2ea5f57a237226437eb1a6f7dcdfd481de3e23",
+				"DiscoKey":   "discokey:cca74380213a9a811d06776d30c61025dd8a3f23ad72270d58cda908fedddf61",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:35511", "10.65.0.27:35511", "172.17.0.1:35511"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:55:43.611081748Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         143186579656124,
+				"StableID":   "n9F3jaGr7211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03726a712a95c9c6604702c4ce7a0d22295500b208d3a39351b3adf251231f4d",
+				"DiscoKey":   "discokey:19c9009f83a64c5349e2991f620e1d10516162321215f306cd5a9c17bce22010",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:45702", "10.65.0.27:45702", "172.17.0.1:45702"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:55:44.672814512Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4218609743689897,
+				"StableID":   "n6fm62jcwZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:225c0d9fb8a56bc197efac7fa83f8c960ceedd2aba457cd43b2f097d2e0cc02b",
+				"DiscoKey":   "discokey:66627884ff0d54506903dfa6e608b63a66b3d839ee60070a6aff488e0df22d7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:56504", "10.65.0.27:56504", "172.17.0.1:56504"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:55:45.210808467Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3784649116951398,
+				"StableID":   "nfVVYFK5ZW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:436ea22cf25b7ab0623050a4cd4deb931f09e1564d6f9e0c4209c4499ec07a76",
+				"DiscoKey":   "discokey:315c285f8853af5177ca5e849ad187931bc2f4cecae9d9f4b6570381ba324e2f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:60758", "10.65.0.27:60758", "172.17.0.1:60758"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:55:45.738349707Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8126768308751190,
+				"StableID":   "nofkdXRdT621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1bfc739041be126427e0a35a5929bf1b98729f780167971323982108cfbf871d",
+				"DiscoKey":   "discokey:22cb0be3eb2ecac46c129116abf3a8a44debda473ce859b663669a2256bb9275",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:36078", "10.65.0.27:36078", "172.17.0.1:36078"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:55:46.260501309Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         101792691512349,
+				"StableID":   "nLWRaSv6o111CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:572a6c971194c402a01fc7095f455cc5b0d4211dadde9b6fee2a730951c9f34b",
+				"DiscoKey":   "discokey:953753a219bb2f744e9b9c230d7b5a2511d4184208fa7559cbd8d3a58dad2f0c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:59864", "10.65.0.27:59864", "172.17.0.1:59864"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:55:46.792557118Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         587147047843869,
+				"StableID":   "nL2b2jMva511CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b25bb9d9f29ddf02691d4ea73e8ebf98847eb7877a3332de6d58d2d13091a75c",
+				"DiscoKey":   "discokey:21e71f6269e9003ba5306ddf9c2d2784f2b15069b2fb50468f1babf65d686443",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57075", "10.65.0.27:57075", "172.17.0.1:57075"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:55:47.332575447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2713887429846554,
+				"StableID":   "nHCUuoD8CN11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a067cbfbe394d17f3907921b058b4dedd146d624512dd527e8814e0205a9801",
+				"DiscoKey":   "discokey:397297a94f7e621fb6e75696a3066d4d0a921d520f218d477552c5c0663f5743",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:53344", "10.65.0.27:53344", "172.17.0.1:53344"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:55:47.859567419Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7448351196262868,
+				"StableID":   "nm9wXEZNA121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9658c60d68240d75ab76570991d3000299b9e51b6fbf9cd893283e8ee9d9515d",
+				"DiscoKey":   "discokey:459a36363611b5bb51b0768c257200b8d379036d3b38d92114314fe455492e06",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47083", "10.65.0.27:47083", "172.17.0.1:47083"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:55:48.387063424Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6159030803756667,
+				"StableID":   "ngy2X8JS6q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba3a4a8a342d7e2c5296e20a267673ca232ea1874fbf3b74c616f1e7f58e5a03",
+				"DiscoKey":   "discokey:23f15d53be0ffc735905ec11c03e0c6525e5341ac36f77fd7b7b920b74637659",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:42970", "10.65.0.27:42970", "172.17.0.1:42970"],
+				"HomeDERP":   18,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:55:48.917754396Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5376294992179314,
+				"StableID":   "nwBhCs9wyi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:16951ebb9387bbaf6f7196c8304ba2260a14a33dcf58a7da7ad5c235817ee94e",
+				"KeyExpiry":  "2026-11-08T18:55:50Z",
+				"DiscoKey":   "discokey:d8e2d2e55f0276b4c2b490637a3cf52878391418f9e2c2376bdbb292f8edef50",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:34625", "10.65.0.27:34625", "172.17.0.1:34625"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:55:50.452117454Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7118790738790820,
+				"StableID":   "nRd8SZZ7bx11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6a2e97adca6aa6b02c29e4ad4d1ecbcdaab63299f5494632f948b1dbc2833527",
+				"KeyExpiry":  "2026-11-08T18:55:50Z",
+				"DiscoKey":   "discokey:7f2a1d5f5e129e7d0c8fbd3b5b6c75bdaeaa1e255ab9f9bd5c4d0f553b13215b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:58399", "10.65.0.27:58399", "172.17.0.1:58399"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:55:50.976960192Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7627231953651300,
+				"StableID":   "nVjtW6TPZ221CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fbcd8dd70ff5e4d0a088c185dacd95456c094d15a1a191a9efef5d1f48c65d34",
+				"KeyExpiry":  "2026-11-08T18:55:51Z",
+				"DiscoKey":   "discokey:2bb5db6697ec4a3347b56e55fd6853068e083e10d8055fe0ec217c9610948c18",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:36613", "10.65.0.27:36613", "172.17.0.1:36613"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:55:51.516838863Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1262922201761304": {
+				"ID":          1262922201761304,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         101792691512349,
+				"StableID":   "nLWRaSv6o111CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       101792691512349,
+				"Key":        "nodekey:572a6c971194c402a01fc7095f455cc5b0d4211dadde9b6fee2a730951c9f34b",
+				"DiscoKey":   "discokey:953753a219bb2f744e9b9c230d7b5a2511d4184208fa7559cbd8d3a58dad2f0c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:59864", "10.65.0.27:59864", "172.17.0.1:59864"],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:55:46.792557118Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:572a6c971194c402a01fc7095f455cc5b0d4211dadde9b6fee2a730951c9f34b",
+			"MachineKey": "mkey:ed4d53ea45956e446a0037921025bad1d0587db43478ccbc528b99203b44d976",
+			"Peers": [{
+				"ID":         7574537821997402,
+				"StableID":   "nP1YYLGX9221CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0d5f583bd95b025edb93bfadba2a68ef30828f10c9201450c797494a31154957",
+				"DiscoKey":   "discokey:0cd472111f5eeb608eb57546345224817b76f6680e82178cd22a928b20bb2f50",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:38146", "10.65.0.27:38146", "172.17.0.1:38146"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:55:43.05455785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1124457422242543,
+				"StableID":   "nGR3tCbGn911CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41a9994e26a7a555909ddca54a2ea5f57a237226437eb1a6f7dcdfd481de3e23",
+				"DiscoKey":   "discokey:cca74380213a9a811d06776d30c61025dd8a3f23ad72270d58cda908fedddf61",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:35511", "10.65.0.27:35511", "172.17.0.1:35511"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:55:43.611081748Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1262922201761304,
+				"StableID":   "nVs9JqpyrA11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:82d7bd44688c616e6ba8c45f037f88cbfc0cbbb565e601a4bf5e98bb7007ab00",
+				"DiscoKey":   "discokey:3fdbc83628d93015a00ff0a955ac12334378208ed5933ea2a1af5b931fd55218",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:56475", "10.65.0.27:56475", "172.17.0.1:56475"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:55:44.134231193Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         143186579656124,
+				"StableID":   "n9F3jaGr7211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03726a712a95c9c6604702c4ce7a0d22295500b208d3a39351b3adf251231f4d",
+				"DiscoKey":   "discokey:19c9009f83a64c5349e2991f620e1d10516162321215f306cd5a9c17bce22010",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:45702", "10.65.0.27:45702", "172.17.0.1:45702"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:55:44.672814512Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4218609743689897,
+				"StableID":   "n6fm62jcwZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:225c0d9fb8a56bc197efac7fa83f8c960ceedd2aba457cd43b2f097d2e0cc02b",
+				"DiscoKey":   "discokey:66627884ff0d54506903dfa6e608b63a66b3d839ee60070a6aff488e0df22d7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:56504", "10.65.0.27:56504", "172.17.0.1:56504"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:55:45.210808467Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3784649116951398,
+				"StableID":   "nfVVYFK5ZW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:436ea22cf25b7ab0623050a4cd4deb931f09e1564d6f9e0c4209c4499ec07a76",
+				"DiscoKey":   "discokey:315c285f8853af5177ca5e849ad187931bc2f4cecae9d9f4b6570381ba324e2f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:60758", "10.65.0.27:60758", "172.17.0.1:60758"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:55:45.738349707Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8126768308751190,
+				"StableID":   "nofkdXRdT621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1bfc739041be126427e0a35a5929bf1b98729f780167971323982108cfbf871d",
+				"DiscoKey":   "discokey:22cb0be3eb2ecac46c129116abf3a8a44debda473ce859b663669a2256bb9275",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:36078", "10.65.0.27:36078", "172.17.0.1:36078"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:55:46.260501309Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         587147047843869,
+				"StableID":   "nL2b2jMva511CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b25bb9d9f29ddf02691d4ea73e8ebf98847eb7877a3332de6d58d2d13091a75c",
+				"DiscoKey":   "discokey:21e71f6269e9003ba5306ddf9c2d2784f2b15069b2fb50468f1babf65d686443",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57075", "10.65.0.27:57075", "172.17.0.1:57075"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:55:47.332575447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2713887429846554,
+				"StableID":   "nHCUuoD8CN11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a067cbfbe394d17f3907921b058b4dedd146d624512dd527e8814e0205a9801",
+				"DiscoKey":   "discokey:397297a94f7e621fb6e75696a3066d4d0a921d520f218d477552c5c0663f5743",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:53344", "10.65.0.27:53344", "172.17.0.1:53344"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:55:47.859567419Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7448351196262868,
+				"StableID":   "nm9wXEZNA121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9658c60d68240d75ab76570991d3000299b9e51b6fbf9cd893283e8ee9d9515d",
+				"DiscoKey":   "discokey:459a36363611b5bb51b0768c257200b8d379036d3b38d92114314fe455492e06",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47083", "10.65.0.27:47083", "172.17.0.1:47083"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:55:48.387063424Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6159030803756667,
+				"StableID":   "ngy2X8JS6q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba3a4a8a342d7e2c5296e20a267673ca232ea1874fbf3b74c616f1e7f58e5a03",
+				"DiscoKey":   "discokey:23f15d53be0ffc735905ec11c03e0c6525e5341ac36f77fd7b7b920b74637659",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:42970", "10.65.0.27:42970", "172.17.0.1:42970"],
+				"HomeDERP":   18,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:55:48.917754396Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5376294992179314,
+				"StableID":   "nwBhCs9wyi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:16951ebb9387bbaf6f7196c8304ba2260a14a33dcf58a7da7ad5c235817ee94e",
+				"KeyExpiry":  "2026-11-08T18:55:50Z",
+				"DiscoKey":   "discokey:d8e2d2e55f0276b4c2b490637a3cf52878391418f9e2c2376bdbb292f8edef50",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:34625", "10.65.0.27:34625", "172.17.0.1:34625"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:55:50.452117454Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7118790738790820,
+				"StableID":   "nRd8SZZ7bx11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6a2e97adca6aa6b02c29e4ad4d1ecbcdaab63299f5494632f948b1dbc2833527",
+				"KeyExpiry":  "2026-11-08T18:55:50Z",
+				"DiscoKey":   "discokey:7f2a1d5f5e129e7d0c8fbd3b5b6c75bdaeaa1e255ab9f9bd5c4d0f553b13215b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:58399", "10.65.0.27:58399", "172.17.0.1:58399"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:55:50.976960192Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7627231953651300,
+				"StableID":   "nVjtW6TPZ221CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fbcd8dd70ff5e4d0a088c185dacd95456c094d15a1a191a9efef5d1f48c65d34",
+				"KeyExpiry":  "2026-11-08T18:55:51Z",
+				"DiscoKey":   "discokey:2bb5db6697ec4a3347b56e55fd6853068e083e10d8055fe0ec217c9610948c18",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:36613", "10.65.0.27:36613", "172.17.0.1:36613"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:55:51.516838863Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"101792691512349": {
+				"ID":          101792691512349,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}, "1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5376294992179314,
+				"StableID":   "nwBhCs9wyi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:16951ebb9387bbaf6f7196c8304ba2260a14a33dcf58a7da7ad5c235817ee94e",
+				"KeyExpiry":  "2026-11-08T18:55:50Z",
+				"DiscoKey":   "discokey:d8e2d2e55f0276b4c2b490637a3cf52878391418f9e2c2376bdbb292f8edef50",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:34625", "10.65.0.27:34625", "172.17.0.1:34625"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:55:50.452117454Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:16951ebb9387bbaf6f7196c8304ba2260a14a33dcf58a7da7ad5c235817ee94e",
+			"MachineKey": "mkey:152ece930eb6db9afaae3fabdab82fa79702e1337b3f3e94add1ba05f7b61a15",
+			"Peers": [{
+				"ID":         7574537821997402,
+				"StableID":   "nP1YYLGX9221CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0d5f583bd95b025edb93bfadba2a68ef30828f10c9201450c797494a31154957",
+				"DiscoKey":   "discokey:0cd472111f5eeb608eb57546345224817b76f6680e82178cd22a928b20bb2f50",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:38146", "10.65.0.27:38146", "172.17.0.1:38146"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:55:43.05455785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1124457422242543,
+				"StableID":   "nGR3tCbGn911CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41a9994e26a7a555909ddca54a2ea5f57a237226437eb1a6f7dcdfd481de3e23",
+				"DiscoKey":   "discokey:cca74380213a9a811d06776d30c61025dd8a3f23ad72270d58cda908fedddf61",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:35511", "10.65.0.27:35511", "172.17.0.1:35511"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:55:43.611081748Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1262922201761304,
+				"StableID":   "nVs9JqpyrA11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:82d7bd44688c616e6ba8c45f037f88cbfc0cbbb565e601a4bf5e98bb7007ab00",
+				"DiscoKey":   "discokey:3fdbc83628d93015a00ff0a955ac12334378208ed5933ea2a1af5b931fd55218",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:56475", "10.65.0.27:56475", "172.17.0.1:56475"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:55:44.134231193Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         143186579656124,
+				"StableID":   "n9F3jaGr7211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03726a712a95c9c6604702c4ce7a0d22295500b208d3a39351b3adf251231f4d",
+				"DiscoKey":   "discokey:19c9009f83a64c5349e2991f620e1d10516162321215f306cd5a9c17bce22010",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:45702", "10.65.0.27:45702", "172.17.0.1:45702"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:55:44.672814512Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4218609743689897,
+				"StableID":   "n6fm62jcwZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:225c0d9fb8a56bc197efac7fa83f8c960ceedd2aba457cd43b2f097d2e0cc02b",
+				"DiscoKey":   "discokey:66627884ff0d54506903dfa6e608b63a66b3d839ee60070a6aff488e0df22d7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:56504", "10.65.0.27:56504", "172.17.0.1:56504"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:55:45.210808467Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3784649116951398,
+				"StableID":   "nfVVYFK5ZW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:436ea22cf25b7ab0623050a4cd4deb931f09e1564d6f9e0c4209c4499ec07a76",
+				"DiscoKey":   "discokey:315c285f8853af5177ca5e849ad187931bc2f4cecae9d9f4b6570381ba324e2f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:60758", "10.65.0.27:60758", "172.17.0.1:60758"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:55:45.738349707Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8126768308751190,
+				"StableID":   "nofkdXRdT621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1bfc739041be126427e0a35a5929bf1b98729f780167971323982108cfbf871d",
+				"DiscoKey":   "discokey:22cb0be3eb2ecac46c129116abf3a8a44debda473ce859b663669a2256bb9275",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:36078", "10.65.0.27:36078", "172.17.0.1:36078"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:55:46.260501309Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         101792691512349,
+				"StableID":   "nLWRaSv6o111CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:572a6c971194c402a01fc7095f455cc5b0d4211dadde9b6fee2a730951c9f34b",
+				"DiscoKey":   "discokey:953753a219bb2f744e9b9c230d7b5a2511d4184208fa7559cbd8d3a58dad2f0c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:59864", "10.65.0.27:59864", "172.17.0.1:59864"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:55:46.792557118Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         587147047843869,
+				"StableID":   "nL2b2jMva511CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b25bb9d9f29ddf02691d4ea73e8ebf98847eb7877a3332de6d58d2d13091a75c",
+				"DiscoKey":   "discokey:21e71f6269e9003ba5306ddf9c2d2784f2b15069b2fb50468f1babf65d686443",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57075", "10.65.0.27:57075", "172.17.0.1:57075"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:55:47.332575447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2713887429846554,
+				"StableID":   "nHCUuoD8CN11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a067cbfbe394d17f3907921b058b4dedd146d624512dd527e8814e0205a9801",
+				"DiscoKey":   "discokey:397297a94f7e621fb6e75696a3066d4d0a921d520f218d477552c5c0663f5743",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:53344", "10.65.0.27:53344", "172.17.0.1:53344"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:55:47.859567419Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7448351196262868,
+				"StableID":   "nm9wXEZNA121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9658c60d68240d75ab76570991d3000299b9e51b6fbf9cd893283e8ee9d9515d",
+				"DiscoKey":   "discokey:459a36363611b5bb51b0768c257200b8d379036d3b38d92114314fe455492e06",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47083", "10.65.0.27:47083", "172.17.0.1:47083"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:55:48.387063424Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6159030803756667,
+				"StableID":   "ngy2X8JS6q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba3a4a8a342d7e2c5296e20a267673ca232ea1874fbf3b74c616f1e7f58e5a03",
+				"DiscoKey":   "discokey:23f15d53be0ffc735905ec11c03e0c6525e5341ac36f77fd7b7b920b74637659",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:42970", "10.65.0.27:42970", "172.17.0.1:42970"],
+				"HomeDERP":   18,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:55:48.917754396Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         7118790738790820,
+				"StableID":   "nRd8SZZ7bx11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6a2e97adca6aa6b02c29e4ad4d1ecbcdaab63299f5494632f948b1dbc2833527",
+				"KeyExpiry":  "2026-11-08T18:55:50Z",
+				"DiscoKey":   "discokey:7f2a1d5f5e129e7d0c8fbd3b5b6c75bdaeaa1e255ab9f9bd5c4d0f553b13215b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:58399", "10.65.0.27:58399", "172.17.0.1:58399"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:55:50.976960192Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7627231953651300,
+				"StableID":   "nVjtW6TPZ221CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fbcd8dd70ff5e4d0a088c185dacd95456c094d15a1a191a9efef5d1f48c65d34",
+				"KeyExpiry":  "2026-11-08T18:55:51Z",
+				"DiscoKey":   "discokey:2bb5db6697ec4a3347b56e55fd6853068e083e10d8055fe0ec217c9610948c18",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:36613", "10.65.0.27:36613", "172.17.0.1:36613"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:55:51.516838863Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7448351196262868,
+				"StableID":   "nm9wXEZNA121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       7448351196262868,
+				"Key":        "nodekey:9658c60d68240d75ab76570991d3000299b9e51b6fbf9cd893283e8ee9d9515d",
+				"DiscoKey":   "discokey:459a36363611b5bb51b0768c257200b8d379036d3b38d92114314fe455492e06",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47083", "10.65.0.27:47083", "172.17.0.1:47083"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:55:48.387063424Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:9658c60d68240d75ab76570991d3000299b9e51b6fbf9cd893283e8ee9d9515d",
+			"MachineKey": "mkey:f1c006d32befbc7b3ac0b8cae506baf907eab9f06757d054c74cd085b7c55742",
+			"Peers": [{
+				"ID":         7574537821997402,
+				"StableID":   "nP1YYLGX9221CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0d5f583bd95b025edb93bfadba2a68ef30828f10c9201450c797494a31154957",
+				"DiscoKey":   "discokey:0cd472111f5eeb608eb57546345224817b76f6680e82178cd22a928b20bb2f50",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:38146", "10.65.0.27:38146", "172.17.0.1:38146"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:55:43.05455785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1124457422242543,
+				"StableID":   "nGR3tCbGn911CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41a9994e26a7a555909ddca54a2ea5f57a237226437eb1a6f7dcdfd481de3e23",
+				"DiscoKey":   "discokey:cca74380213a9a811d06776d30c61025dd8a3f23ad72270d58cda908fedddf61",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:35511", "10.65.0.27:35511", "172.17.0.1:35511"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:55:43.611081748Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1262922201761304,
+				"StableID":   "nVs9JqpyrA11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:82d7bd44688c616e6ba8c45f037f88cbfc0cbbb565e601a4bf5e98bb7007ab00",
+				"DiscoKey":   "discokey:3fdbc83628d93015a00ff0a955ac12334378208ed5933ea2a1af5b931fd55218",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:56475", "10.65.0.27:56475", "172.17.0.1:56475"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:55:44.134231193Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         143186579656124,
+				"StableID":   "n9F3jaGr7211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03726a712a95c9c6604702c4ce7a0d22295500b208d3a39351b3adf251231f4d",
+				"DiscoKey":   "discokey:19c9009f83a64c5349e2991f620e1d10516162321215f306cd5a9c17bce22010",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:45702", "10.65.0.27:45702", "172.17.0.1:45702"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:55:44.672814512Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4218609743689897,
+				"StableID":   "n6fm62jcwZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:225c0d9fb8a56bc197efac7fa83f8c960ceedd2aba457cd43b2f097d2e0cc02b",
+				"DiscoKey":   "discokey:66627884ff0d54506903dfa6e608b63a66b3d839ee60070a6aff488e0df22d7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:56504", "10.65.0.27:56504", "172.17.0.1:56504"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:55:45.210808467Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3784649116951398,
+				"StableID":   "nfVVYFK5ZW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:436ea22cf25b7ab0623050a4cd4deb931f09e1564d6f9e0c4209c4499ec07a76",
+				"DiscoKey":   "discokey:315c285f8853af5177ca5e849ad187931bc2f4cecae9d9f4b6570381ba324e2f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:60758", "10.65.0.27:60758", "172.17.0.1:60758"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:55:45.738349707Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8126768308751190,
+				"StableID":   "nofkdXRdT621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1bfc739041be126427e0a35a5929bf1b98729f780167971323982108cfbf871d",
+				"DiscoKey":   "discokey:22cb0be3eb2ecac46c129116abf3a8a44debda473ce859b663669a2256bb9275",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:36078", "10.65.0.27:36078", "172.17.0.1:36078"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:55:46.260501309Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         101792691512349,
+				"StableID":   "nLWRaSv6o111CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:572a6c971194c402a01fc7095f455cc5b0d4211dadde9b6fee2a730951c9f34b",
+				"DiscoKey":   "discokey:953753a219bb2f744e9b9c230d7b5a2511d4184208fa7559cbd8d3a58dad2f0c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:59864", "10.65.0.27:59864", "172.17.0.1:59864"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:55:46.792557118Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         587147047843869,
+				"StableID":   "nL2b2jMva511CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b25bb9d9f29ddf02691d4ea73e8ebf98847eb7877a3332de6d58d2d13091a75c",
+				"DiscoKey":   "discokey:21e71f6269e9003ba5306ddf9c2d2784f2b15069b2fb50468f1babf65d686443",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57075", "10.65.0.27:57075", "172.17.0.1:57075"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:55:47.332575447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2713887429846554,
+				"StableID":   "nHCUuoD8CN11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a067cbfbe394d17f3907921b058b4dedd146d624512dd527e8814e0205a9801",
+				"DiscoKey":   "discokey:397297a94f7e621fb6e75696a3066d4d0a921d520f218d477552c5c0663f5743",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:53344", "10.65.0.27:53344", "172.17.0.1:53344"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:55:47.859567419Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         6159030803756667,
+				"StableID":   "ngy2X8JS6q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba3a4a8a342d7e2c5296e20a267673ca232ea1874fbf3b74c616f1e7f58e5a03",
+				"DiscoKey":   "discokey:23f15d53be0ffc735905ec11c03e0c6525e5341ac36f77fd7b7b920b74637659",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:42970", "10.65.0.27:42970", "172.17.0.1:42970"],
+				"HomeDERP":   18,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:55:48.917754396Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5376294992179314,
+				"StableID":   "nwBhCs9wyi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:16951ebb9387bbaf6f7196c8304ba2260a14a33dcf58a7da7ad5c235817ee94e",
+				"KeyExpiry":  "2026-11-08T18:55:50Z",
+				"DiscoKey":   "discokey:d8e2d2e55f0276b4c2b490637a3cf52878391418f9e2c2376bdbb292f8edef50",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:34625", "10.65.0.27:34625", "172.17.0.1:34625"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:55:50.452117454Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7118790738790820,
+				"StableID":   "nRd8SZZ7bx11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6a2e97adca6aa6b02c29e4ad4d1ecbcdaab63299f5494632f948b1dbc2833527",
+				"KeyExpiry":  "2026-11-08T18:55:50Z",
+				"DiscoKey":   "discokey:7f2a1d5f5e129e7d0c8fbd3b5b6c75bdaeaa1e255ab9f9bd5c4d0f553b13215b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:58399", "10.65.0.27:58399", "172.17.0.1:58399"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:55:50.976960192Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7627231953651300,
+				"StableID":   "nVjtW6TPZ221CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fbcd8dd70ff5e4d0a088c185dacd95456c094d15a1a191a9efef5d1f48c65d34",
+				"KeyExpiry":  "2026-11-08T18:55:51Z",
+				"DiscoKey":   "discokey:2bb5db6697ec4a3347b56e55fd6853068e083e10d8055fe0ec217c9610948c18",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:36613", "10.65.0.27:36613", "172.17.0.1:36613"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:55:51.516838863Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7448351196262868": {
+				"ID":          7448351196262868,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1124457422242543,
+				"StableID":   "nGR3tCbGn911CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1124457422242543,
+				"Key":        "nodekey:41a9994e26a7a555909ddca54a2ea5f57a237226437eb1a6f7dcdfd481de3e23",
+				"DiscoKey":   "discokey:cca74380213a9a811d06776d30c61025dd8a3f23ad72270d58cda908fedddf61",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:35511", "10.65.0.27:35511", "172.17.0.1:35511"],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:55:43.611081748Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:41a9994e26a7a555909ddca54a2ea5f57a237226437eb1a6f7dcdfd481de3e23",
+			"MachineKey": "mkey:5025d8bbe9838b977ea65139bc66da26563b420170267663aab9c4fed3d0fc1d",
+			"Peers": [{
+				"ID":         7574537821997402,
+				"StableID":   "nP1YYLGX9221CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0d5f583bd95b025edb93bfadba2a68ef30828f10c9201450c797494a31154957",
+				"DiscoKey":   "discokey:0cd472111f5eeb608eb57546345224817b76f6680e82178cd22a928b20bb2f50",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:38146", "10.65.0.27:38146", "172.17.0.1:38146"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:55:43.05455785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1262922201761304,
+				"StableID":   "nVs9JqpyrA11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:82d7bd44688c616e6ba8c45f037f88cbfc0cbbb565e601a4bf5e98bb7007ab00",
+				"DiscoKey":   "discokey:3fdbc83628d93015a00ff0a955ac12334378208ed5933ea2a1af5b931fd55218",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:56475", "10.65.0.27:56475", "172.17.0.1:56475"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:55:44.134231193Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         143186579656124,
+				"StableID":   "n9F3jaGr7211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03726a712a95c9c6604702c4ce7a0d22295500b208d3a39351b3adf251231f4d",
+				"DiscoKey":   "discokey:19c9009f83a64c5349e2991f620e1d10516162321215f306cd5a9c17bce22010",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:45702", "10.65.0.27:45702", "172.17.0.1:45702"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:55:44.672814512Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4218609743689897,
+				"StableID":   "n6fm62jcwZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:225c0d9fb8a56bc197efac7fa83f8c960ceedd2aba457cd43b2f097d2e0cc02b",
+				"DiscoKey":   "discokey:66627884ff0d54506903dfa6e608b63a66b3d839ee60070a6aff488e0df22d7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:56504", "10.65.0.27:56504", "172.17.0.1:56504"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:55:45.210808467Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3784649116951398,
+				"StableID":   "nfVVYFK5ZW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:436ea22cf25b7ab0623050a4cd4deb931f09e1564d6f9e0c4209c4499ec07a76",
+				"DiscoKey":   "discokey:315c285f8853af5177ca5e849ad187931bc2f4cecae9d9f4b6570381ba324e2f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:60758", "10.65.0.27:60758", "172.17.0.1:60758"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:55:45.738349707Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8126768308751190,
+				"StableID":   "nofkdXRdT621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1bfc739041be126427e0a35a5929bf1b98729f780167971323982108cfbf871d",
+				"DiscoKey":   "discokey:22cb0be3eb2ecac46c129116abf3a8a44debda473ce859b663669a2256bb9275",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:36078", "10.65.0.27:36078", "172.17.0.1:36078"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:55:46.260501309Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         101792691512349,
+				"StableID":   "nLWRaSv6o111CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:572a6c971194c402a01fc7095f455cc5b0d4211dadde9b6fee2a730951c9f34b",
+				"DiscoKey":   "discokey:953753a219bb2f744e9b9c230d7b5a2511d4184208fa7559cbd8d3a58dad2f0c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:59864", "10.65.0.27:59864", "172.17.0.1:59864"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:55:46.792557118Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         587147047843869,
+				"StableID":   "nL2b2jMva511CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b25bb9d9f29ddf02691d4ea73e8ebf98847eb7877a3332de6d58d2d13091a75c",
+				"DiscoKey":   "discokey:21e71f6269e9003ba5306ddf9c2d2784f2b15069b2fb50468f1babf65d686443",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57075", "10.65.0.27:57075", "172.17.0.1:57075"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:55:47.332575447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2713887429846554,
+				"StableID":   "nHCUuoD8CN11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a067cbfbe394d17f3907921b058b4dedd146d624512dd527e8814e0205a9801",
+				"DiscoKey":   "discokey:397297a94f7e621fb6e75696a3066d4d0a921d520f218d477552c5c0663f5743",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:53344", "10.65.0.27:53344", "172.17.0.1:53344"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:55:47.859567419Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7448351196262868,
+				"StableID":   "nm9wXEZNA121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9658c60d68240d75ab76570991d3000299b9e51b6fbf9cd893283e8ee9d9515d",
+				"DiscoKey":   "discokey:459a36363611b5bb51b0768c257200b8d379036d3b38d92114314fe455492e06",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47083", "10.65.0.27:47083", "172.17.0.1:47083"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:55:48.387063424Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6159030803756667,
+				"StableID":   "ngy2X8JS6q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba3a4a8a342d7e2c5296e20a267673ca232ea1874fbf3b74c616f1e7f58e5a03",
+				"DiscoKey":   "discokey:23f15d53be0ffc735905ec11c03e0c6525e5341ac36f77fd7b7b920b74637659",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:42970", "10.65.0.27:42970", "172.17.0.1:42970"],
+				"HomeDERP":   18,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:55:48.917754396Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5376294992179314,
+				"StableID":   "nwBhCs9wyi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:16951ebb9387bbaf6f7196c8304ba2260a14a33dcf58a7da7ad5c235817ee94e",
+				"KeyExpiry":  "2026-11-08T18:55:50Z",
+				"DiscoKey":   "discokey:d8e2d2e55f0276b4c2b490637a3cf52878391418f9e2c2376bdbb292f8edef50",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:34625", "10.65.0.27:34625", "172.17.0.1:34625"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:55:50.452117454Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7118790738790820,
+				"StableID":   "nRd8SZZ7bx11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6a2e97adca6aa6b02c29e4ad4d1ecbcdaab63299f5494632f948b1dbc2833527",
+				"KeyExpiry":  "2026-11-08T18:55:50Z",
+				"DiscoKey":   "discokey:7f2a1d5f5e129e7d0c8fbd3b5b6c75bdaeaa1e255ab9f9bd5c4d0f553b13215b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:58399", "10.65.0.27:58399", "172.17.0.1:58399"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:55:50.976960192Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7627231953651300,
+				"StableID":   "nVjtW6TPZ221CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fbcd8dd70ff5e4d0a088c185dacd95456c094d15a1a191a9efef5d1f48c65d34",
+				"KeyExpiry":  "2026-11-08T18:55:51Z",
+				"DiscoKey":   "discokey:2bb5db6697ec4a3347b56e55fd6853068e083e10d8055fe0ec217c9610948c18",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:36613", "10.65.0.27:36613", "172.17.0.1:36613"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:55:51.516838863Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1124457422242543": {
+				"ID":          1124457422242543,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}, "1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7574537821997402,
+				"StableID":   "nP1YYLGX9221CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       7574537821997402,
+				"Key":        "nodekey:0d5f583bd95b025edb93bfadba2a68ef30828f10c9201450c797494a31154957",
+				"DiscoKey":   "discokey:0cd472111f5eeb608eb57546345224817b76f6680e82178cd22a928b20bb2f50",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:38146", "10.65.0.27:38146", "172.17.0.1:38146"],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:55:43.05455785Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0d5f583bd95b025edb93bfadba2a68ef30828f10c9201450c797494a31154957",
+			"MachineKey": "mkey:4e681b2f427867687c24d86cef95516578d04a72d44fb16dc1143a4bd616fe1a",
+			"Peers": [{
+				"ID":         1124457422242543,
+				"StableID":   "nGR3tCbGn911CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41a9994e26a7a555909ddca54a2ea5f57a237226437eb1a6f7dcdfd481de3e23",
+				"DiscoKey":   "discokey:cca74380213a9a811d06776d30c61025dd8a3f23ad72270d58cda908fedddf61",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:35511", "10.65.0.27:35511", "172.17.0.1:35511"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:55:43.611081748Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1262922201761304,
+				"StableID":   "nVs9JqpyrA11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:82d7bd44688c616e6ba8c45f037f88cbfc0cbbb565e601a4bf5e98bb7007ab00",
+				"DiscoKey":   "discokey:3fdbc83628d93015a00ff0a955ac12334378208ed5933ea2a1af5b931fd55218",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:56475", "10.65.0.27:56475", "172.17.0.1:56475"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:55:44.134231193Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         143186579656124,
+				"StableID":   "n9F3jaGr7211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03726a712a95c9c6604702c4ce7a0d22295500b208d3a39351b3adf251231f4d",
+				"DiscoKey":   "discokey:19c9009f83a64c5349e2991f620e1d10516162321215f306cd5a9c17bce22010",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:45702", "10.65.0.27:45702", "172.17.0.1:45702"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:55:44.672814512Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4218609743689897,
+				"StableID":   "n6fm62jcwZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:225c0d9fb8a56bc197efac7fa83f8c960ceedd2aba457cd43b2f097d2e0cc02b",
+				"DiscoKey":   "discokey:66627884ff0d54506903dfa6e608b63a66b3d839ee60070a6aff488e0df22d7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:56504", "10.65.0.27:56504", "172.17.0.1:56504"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:55:45.210808467Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3784649116951398,
+				"StableID":   "nfVVYFK5ZW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:436ea22cf25b7ab0623050a4cd4deb931f09e1564d6f9e0c4209c4499ec07a76",
+				"DiscoKey":   "discokey:315c285f8853af5177ca5e849ad187931bc2f4cecae9d9f4b6570381ba324e2f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:60758", "10.65.0.27:60758", "172.17.0.1:60758"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:55:45.738349707Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8126768308751190,
+				"StableID":   "nofkdXRdT621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1bfc739041be126427e0a35a5929bf1b98729f780167971323982108cfbf871d",
+				"DiscoKey":   "discokey:22cb0be3eb2ecac46c129116abf3a8a44debda473ce859b663669a2256bb9275",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:36078", "10.65.0.27:36078", "172.17.0.1:36078"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:55:46.260501309Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         101792691512349,
+				"StableID":   "nLWRaSv6o111CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:572a6c971194c402a01fc7095f455cc5b0d4211dadde9b6fee2a730951c9f34b",
+				"DiscoKey":   "discokey:953753a219bb2f744e9b9c230d7b5a2511d4184208fa7559cbd8d3a58dad2f0c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:59864", "10.65.0.27:59864", "172.17.0.1:59864"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:55:46.792557118Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         587147047843869,
+				"StableID":   "nL2b2jMva511CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b25bb9d9f29ddf02691d4ea73e8ebf98847eb7877a3332de6d58d2d13091a75c",
+				"DiscoKey":   "discokey:21e71f6269e9003ba5306ddf9c2d2784f2b15069b2fb50468f1babf65d686443",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57075", "10.65.0.27:57075", "172.17.0.1:57075"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:55:47.332575447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2713887429846554,
+				"StableID":   "nHCUuoD8CN11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a067cbfbe394d17f3907921b058b4dedd146d624512dd527e8814e0205a9801",
+				"DiscoKey":   "discokey:397297a94f7e621fb6e75696a3066d4d0a921d520f218d477552c5c0663f5743",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:53344", "10.65.0.27:53344", "172.17.0.1:53344"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:55:47.859567419Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7448351196262868,
+				"StableID":   "nm9wXEZNA121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9658c60d68240d75ab76570991d3000299b9e51b6fbf9cd893283e8ee9d9515d",
+				"DiscoKey":   "discokey:459a36363611b5bb51b0768c257200b8d379036d3b38d92114314fe455492e06",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47083", "10.65.0.27:47083", "172.17.0.1:47083"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:55:48.387063424Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6159030803756667,
+				"StableID":   "ngy2X8JS6q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba3a4a8a342d7e2c5296e20a267673ca232ea1874fbf3b74c616f1e7f58e5a03",
+				"DiscoKey":   "discokey:23f15d53be0ffc735905ec11c03e0c6525e5341ac36f77fd7b7b920b74637659",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:42970", "10.65.0.27:42970", "172.17.0.1:42970"],
+				"HomeDERP":   18,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:55:48.917754396Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5376294992179314,
+				"StableID":   "nwBhCs9wyi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:16951ebb9387bbaf6f7196c8304ba2260a14a33dcf58a7da7ad5c235817ee94e",
+				"KeyExpiry":  "2026-11-08T18:55:50Z",
+				"DiscoKey":   "discokey:d8e2d2e55f0276b4c2b490637a3cf52878391418f9e2c2376bdbb292f8edef50",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:34625", "10.65.0.27:34625", "172.17.0.1:34625"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:55:50.452117454Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7118790738790820,
+				"StableID":   "nRd8SZZ7bx11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6a2e97adca6aa6b02c29e4ad4d1ecbcdaab63299f5494632f948b1dbc2833527",
+				"KeyExpiry":  "2026-11-08T18:55:50Z",
+				"DiscoKey":   "discokey:7f2a1d5f5e129e7d0c8fbd3b5b6c75bdaeaa1e255ab9f9bd5c4d0f553b13215b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:58399", "10.65.0.27:58399", "172.17.0.1:58399"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:55:50.976960192Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7627231953651300,
+				"StableID":   "nVjtW6TPZ221CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fbcd8dd70ff5e4d0a088c185dacd95456c094d15a1a191a9efef5d1f48c65d34",
+				"KeyExpiry":  "2026-11-08T18:55:51Z",
+				"DiscoKey":   "discokey:2bb5db6697ec4a3347b56e55fd6853068e083e10d8055fe0ec217c9610948c18",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:36613", "10.65.0.27:36613", "172.17.0.1:36613"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:55:51.516838863Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "7574537821997402": {
+				"ID":          7574537821997402,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4218609743689897,
+				"StableID":   "n6fm62jcwZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       4218609743689897,
+				"Key":        "nodekey:225c0d9fb8a56bc197efac7fa83f8c960ceedd2aba457cd43b2f097d2e0cc02b",
+				"DiscoKey":   "discokey:66627884ff0d54506903dfa6e608b63a66b3d839ee60070a6aff488e0df22d7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:56504", "10.65.0.27:56504", "172.17.0.1:56504"],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:55:45.210808467Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:225c0d9fb8a56bc197efac7fa83f8c960ceedd2aba457cd43b2f097d2e0cc02b",
+			"MachineKey": "mkey:1daca0967e6dba32b27abe6fceeac656ee8a9a99f67c94f708db05e3b2f5231b",
+			"Peers": [{
+				"ID":         7574537821997402,
+				"StableID":   "nP1YYLGX9221CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0d5f583bd95b025edb93bfadba2a68ef30828f10c9201450c797494a31154957",
+				"DiscoKey":   "discokey:0cd472111f5eeb608eb57546345224817b76f6680e82178cd22a928b20bb2f50",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:38146", "10.65.0.27:38146", "172.17.0.1:38146"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:55:43.05455785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1124457422242543,
+				"StableID":   "nGR3tCbGn911CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41a9994e26a7a555909ddca54a2ea5f57a237226437eb1a6f7dcdfd481de3e23",
+				"DiscoKey":   "discokey:cca74380213a9a811d06776d30c61025dd8a3f23ad72270d58cda908fedddf61",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:35511", "10.65.0.27:35511", "172.17.0.1:35511"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:55:43.611081748Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1262922201761304,
+				"StableID":   "nVs9JqpyrA11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:82d7bd44688c616e6ba8c45f037f88cbfc0cbbb565e601a4bf5e98bb7007ab00",
+				"DiscoKey":   "discokey:3fdbc83628d93015a00ff0a955ac12334378208ed5933ea2a1af5b931fd55218",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:56475", "10.65.0.27:56475", "172.17.0.1:56475"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:55:44.134231193Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         143186579656124,
+				"StableID":   "n9F3jaGr7211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03726a712a95c9c6604702c4ce7a0d22295500b208d3a39351b3adf251231f4d",
+				"DiscoKey":   "discokey:19c9009f83a64c5349e2991f620e1d10516162321215f306cd5a9c17bce22010",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:45702", "10.65.0.27:45702", "172.17.0.1:45702"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:55:44.672814512Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         3784649116951398,
+				"StableID":   "nfVVYFK5ZW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:436ea22cf25b7ab0623050a4cd4deb931f09e1564d6f9e0c4209c4499ec07a76",
+				"DiscoKey":   "discokey:315c285f8853af5177ca5e849ad187931bc2f4cecae9d9f4b6570381ba324e2f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:60758", "10.65.0.27:60758", "172.17.0.1:60758"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:55:45.738349707Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8126768308751190,
+				"StableID":   "nofkdXRdT621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1bfc739041be126427e0a35a5929bf1b98729f780167971323982108cfbf871d",
+				"DiscoKey":   "discokey:22cb0be3eb2ecac46c129116abf3a8a44debda473ce859b663669a2256bb9275",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:36078", "10.65.0.27:36078", "172.17.0.1:36078"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:55:46.260501309Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         101792691512349,
+				"StableID":   "nLWRaSv6o111CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:572a6c971194c402a01fc7095f455cc5b0d4211dadde9b6fee2a730951c9f34b",
+				"DiscoKey":   "discokey:953753a219bb2f744e9b9c230d7b5a2511d4184208fa7559cbd8d3a58dad2f0c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:59864", "10.65.0.27:59864", "172.17.0.1:59864"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:55:46.792557118Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         587147047843869,
+				"StableID":   "nL2b2jMva511CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b25bb9d9f29ddf02691d4ea73e8ebf98847eb7877a3332de6d58d2d13091a75c",
+				"DiscoKey":   "discokey:21e71f6269e9003ba5306ddf9c2d2784f2b15069b2fb50468f1babf65d686443",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57075", "10.65.0.27:57075", "172.17.0.1:57075"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:55:47.332575447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2713887429846554,
+				"StableID":   "nHCUuoD8CN11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a067cbfbe394d17f3907921b058b4dedd146d624512dd527e8814e0205a9801",
+				"DiscoKey":   "discokey:397297a94f7e621fb6e75696a3066d4d0a921d520f218d477552c5c0663f5743",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:53344", "10.65.0.27:53344", "172.17.0.1:53344"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:55:47.859567419Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7448351196262868,
+				"StableID":   "nm9wXEZNA121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9658c60d68240d75ab76570991d3000299b9e51b6fbf9cd893283e8ee9d9515d",
+				"DiscoKey":   "discokey:459a36363611b5bb51b0768c257200b8d379036d3b38d92114314fe455492e06",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47083", "10.65.0.27:47083", "172.17.0.1:47083"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:55:48.387063424Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6159030803756667,
+				"StableID":   "ngy2X8JS6q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba3a4a8a342d7e2c5296e20a267673ca232ea1874fbf3b74c616f1e7f58e5a03",
+				"DiscoKey":   "discokey:23f15d53be0ffc735905ec11c03e0c6525e5341ac36f77fd7b7b920b74637659",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:42970", "10.65.0.27:42970", "172.17.0.1:42970"],
+				"HomeDERP":   18,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:55:48.917754396Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5376294992179314,
+				"StableID":   "nwBhCs9wyi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:16951ebb9387bbaf6f7196c8304ba2260a14a33dcf58a7da7ad5c235817ee94e",
+				"KeyExpiry":  "2026-11-08T18:55:50Z",
+				"DiscoKey":   "discokey:d8e2d2e55f0276b4c2b490637a3cf52878391418f9e2c2376bdbb292f8edef50",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:34625", "10.65.0.27:34625", "172.17.0.1:34625"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:55:50.452117454Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7118790738790820,
+				"StableID":   "nRd8SZZ7bx11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6a2e97adca6aa6b02c29e4ad4d1ecbcdaab63299f5494632f948b1dbc2833527",
+				"KeyExpiry":  "2026-11-08T18:55:50Z",
+				"DiscoKey":   "discokey:7f2a1d5f5e129e7d0c8fbd3b5b6c75bdaeaa1e255ab9f9bd5c4d0f553b13215b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:58399", "10.65.0.27:58399", "172.17.0.1:58399"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:55:50.976960192Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7627231953651300,
+				"StableID":   "nVjtW6TPZ221CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fbcd8dd70ff5e4d0a088c185dacd95456c094d15a1a191a9efef5d1f48c65d34",
+				"KeyExpiry":  "2026-11-08T18:55:51Z",
+				"DiscoKey":   "discokey:2bb5db6697ec4a3347b56e55fd6853068e083e10d8055fe0ec217c9610948c18",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:36613", "10.65.0.27:36613", "172.17.0.1:36613"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:55:51.516838863Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4218609743689897": {
+				"ID":          4218609743689897,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         143186579656124,
+				"StableID":   "n9F3jaGr7211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       143186579656124,
+				"Key":        "nodekey:03726a712a95c9c6604702c4ce7a0d22295500b208d3a39351b3adf251231f4d",
+				"DiscoKey":   "discokey:19c9009f83a64c5349e2991f620e1d10516162321215f306cd5a9c17bce22010",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:45702", "10.65.0.27:45702", "172.17.0.1:45702"],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:55:44.672814512Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:03726a712a95c9c6604702c4ce7a0d22295500b208d3a39351b3adf251231f4d",
+			"MachineKey": "mkey:11f7bdda954ab1eff342a4af0801ca37c101dcb11a39f2f0bd0d365ccddebb14",
+			"Peers": [{
+				"ID":         7574537821997402,
+				"StableID":   "nP1YYLGX9221CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0d5f583bd95b025edb93bfadba2a68ef30828f10c9201450c797494a31154957",
+				"DiscoKey":   "discokey:0cd472111f5eeb608eb57546345224817b76f6680e82178cd22a928b20bb2f50",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:38146", "10.65.0.27:38146", "172.17.0.1:38146"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:55:43.05455785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1124457422242543,
+				"StableID":   "nGR3tCbGn911CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41a9994e26a7a555909ddca54a2ea5f57a237226437eb1a6f7dcdfd481de3e23",
+				"DiscoKey":   "discokey:cca74380213a9a811d06776d30c61025dd8a3f23ad72270d58cda908fedddf61",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:35511", "10.65.0.27:35511", "172.17.0.1:35511"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:55:43.611081748Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1262922201761304,
+				"StableID":   "nVs9JqpyrA11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:82d7bd44688c616e6ba8c45f037f88cbfc0cbbb565e601a4bf5e98bb7007ab00",
+				"DiscoKey":   "discokey:3fdbc83628d93015a00ff0a955ac12334378208ed5933ea2a1af5b931fd55218",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:56475", "10.65.0.27:56475", "172.17.0.1:56475"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:55:44.134231193Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         4218609743689897,
+				"StableID":   "n6fm62jcwZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:225c0d9fb8a56bc197efac7fa83f8c960ceedd2aba457cd43b2f097d2e0cc02b",
+				"DiscoKey":   "discokey:66627884ff0d54506903dfa6e608b63a66b3d839ee60070a6aff488e0df22d7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:56504", "10.65.0.27:56504", "172.17.0.1:56504"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:55:45.210808467Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3784649116951398,
+				"StableID":   "nfVVYFK5ZW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:436ea22cf25b7ab0623050a4cd4deb931f09e1564d6f9e0c4209c4499ec07a76",
+				"DiscoKey":   "discokey:315c285f8853af5177ca5e849ad187931bc2f4cecae9d9f4b6570381ba324e2f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:60758", "10.65.0.27:60758", "172.17.0.1:60758"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:55:45.738349707Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8126768308751190,
+				"StableID":   "nofkdXRdT621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1bfc739041be126427e0a35a5929bf1b98729f780167971323982108cfbf871d",
+				"DiscoKey":   "discokey:22cb0be3eb2ecac46c129116abf3a8a44debda473ce859b663669a2256bb9275",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:36078", "10.65.0.27:36078", "172.17.0.1:36078"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:55:46.260501309Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         101792691512349,
+				"StableID":   "nLWRaSv6o111CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:572a6c971194c402a01fc7095f455cc5b0d4211dadde9b6fee2a730951c9f34b",
+				"DiscoKey":   "discokey:953753a219bb2f744e9b9c230d7b5a2511d4184208fa7559cbd8d3a58dad2f0c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:59864", "10.65.0.27:59864", "172.17.0.1:59864"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:55:46.792557118Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         587147047843869,
+				"StableID":   "nL2b2jMva511CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b25bb9d9f29ddf02691d4ea73e8ebf98847eb7877a3332de6d58d2d13091a75c",
+				"DiscoKey":   "discokey:21e71f6269e9003ba5306ddf9c2d2784f2b15069b2fb50468f1babf65d686443",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57075", "10.65.0.27:57075", "172.17.0.1:57075"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:55:47.332575447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2713887429846554,
+				"StableID":   "nHCUuoD8CN11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a067cbfbe394d17f3907921b058b4dedd146d624512dd527e8814e0205a9801",
+				"DiscoKey":   "discokey:397297a94f7e621fb6e75696a3066d4d0a921d520f218d477552c5c0663f5743",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:53344", "10.65.0.27:53344", "172.17.0.1:53344"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:55:47.859567419Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7448351196262868,
+				"StableID":   "nm9wXEZNA121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9658c60d68240d75ab76570991d3000299b9e51b6fbf9cd893283e8ee9d9515d",
+				"DiscoKey":   "discokey:459a36363611b5bb51b0768c257200b8d379036d3b38d92114314fe455492e06",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47083", "10.65.0.27:47083", "172.17.0.1:47083"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:55:48.387063424Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6159030803756667,
+				"StableID":   "ngy2X8JS6q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba3a4a8a342d7e2c5296e20a267673ca232ea1874fbf3b74c616f1e7f58e5a03",
+				"DiscoKey":   "discokey:23f15d53be0ffc735905ec11c03e0c6525e5341ac36f77fd7b7b920b74637659",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:42970", "10.65.0.27:42970", "172.17.0.1:42970"],
+				"HomeDERP":   18,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:55:48.917754396Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5376294992179314,
+				"StableID":   "nwBhCs9wyi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:16951ebb9387bbaf6f7196c8304ba2260a14a33dcf58a7da7ad5c235817ee94e",
+				"KeyExpiry":  "2026-11-08T18:55:50Z",
+				"DiscoKey":   "discokey:d8e2d2e55f0276b4c2b490637a3cf52878391418f9e2c2376bdbb292f8edef50",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:34625", "10.65.0.27:34625", "172.17.0.1:34625"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:55:50.452117454Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7118790738790820,
+				"StableID":   "nRd8SZZ7bx11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6a2e97adca6aa6b02c29e4ad4d1ecbcdaab63299f5494632f948b1dbc2833527",
+				"KeyExpiry":  "2026-11-08T18:55:50Z",
+				"DiscoKey":   "discokey:7f2a1d5f5e129e7d0c8fbd3b5b6c75bdaeaa1e255ab9f9bd5c4d0f553b13215b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:58399", "10.65.0.27:58399", "172.17.0.1:58399"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:55:50.976960192Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7627231953651300,
+				"StableID":   "nVjtW6TPZ221CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fbcd8dd70ff5e4d0a088c185dacd95456c094d15a1a191a9efef5d1f48c65d34",
+				"KeyExpiry":  "2026-11-08T18:55:51Z",
+				"DiscoKey":   "discokey:2bb5db6697ec4a3347b56e55fd6853068e083e10d8055fe0ec217c9610948c18",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:36613", "10.65.0.27:36613", "172.17.0.1:36613"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:55:51.516838863Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "143186579656124": {
+				"ID":          143186579656124,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8126768308751190,
+				"StableID":   "nofkdXRdT621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       8126768308751190,
+				"Key":        "nodekey:1bfc739041be126427e0a35a5929bf1b98729f780167971323982108cfbf871d",
+				"DiscoKey":   "discokey:22cb0be3eb2ecac46c129116abf3a8a44debda473ce859b663669a2256bb9275",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:36078", "10.65.0.27:36078", "172.17.0.1:36078"],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:55:46.260501309Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:1bfc739041be126427e0a35a5929bf1b98729f780167971323982108cfbf871d",
+			"MachineKey": "mkey:3a860aa7b698f0a8e3ee742d1116ba92da1ecce0f3bbc4fb86104817de0c5e22",
+			"Peers": [{
+				"ID":         7574537821997402,
+				"StableID":   "nP1YYLGX9221CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0d5f583bd95b025edb93bfadba2a68ef30828f10c9201450c797494a31154957",
+				"DiscoKey":   "discokey:0cd472111f5eeb608eb57546345224817b76f6680e82178cd22a928b20bb2f50",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:38146", "10.65.0.27:38146", "172.17.0.1:38146"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:55:43.05455785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1124457422242543,
+				"StableID":   "nGR3tCbGn911CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41a9994e26a7a555909ddca54a2ea5f57a237226437eb1a6f7dcdfd481de3e23",
+				"DiscoKey":   "discokey:cca74380213a9a811d06776d30c61025dd8a3f23ad72270d58cda908fedddf61",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:35511", "10.65.0.27:35511", "172.17.0.1:35511"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:55:43.611081748Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1262922201761304,
+				"StableID":   "nVs9JqpyrA11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:82d7bd44688c616e6ba8c45f037f88cbfc0cbbb565e601a4bf5e98bb7007ab00",
+				"DiscoKey":   "discokey:3fdbc83628d93015a00ff0a955ac12334378208ed5933ea2a1af5b931fd55218",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:56475", "10.65.0.27:56475", "172.17.0.1:56475"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:55:44.134231193Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         143186579656124,
+				"StableID":   "n9F3jaGr7211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03726a712a95c9c6604702c4ce7a0d22295500b208d3a39351b3adf251231f4d",
+				"DiscoKey":   "discokey:19c9009f83a64c5349e2991f620e1d10516162321215f306cd5a9c17bce22010",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:45702", "10.65.0.27:45702", "172.17.0.1:45702"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:55:44.672814512Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4218609743689897,
+				"StableID":   "n6fm62jcwZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:225c0d9fb8a56bc197efac7fa83f8c960ceedd2aba457cd43b2f097d2e0cc02b",
+				"DiscoKey":   "discokey:66627884ff0d54506903dfa6e608b63a66b3d839ee60070a6aff488e0df22d7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:56504", "10.65.0.27:56504", "172.17.0.1:56504"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:55:45.210808467Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3784649116951398,
+				"StableID":   "nfVVYFK5ZW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:436ea22cf25b7ab0623050a4cd4deb931f09e1564d6f9e0c4209c4499ec07a76",
+				"DiscoKey":   "discokey:315c285f8853af5177ca5e849ad187931bc2f4cecae9d9f4b6570381ba324e2f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:60758", "10.65.0.27:60758", "172.17.0.1:60758"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:55:45.738349707Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         101792691512349,
+				"StableID":   "nLWRaSv6o111CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:572a6c971194c402a01fc7095f455cc5b0d4211dadde9b6fee2a730951c9f34b",
+				"DiscoKey":   "discokey:953753a219bb2f744e9b9c230d7b5a2511d4184208fa7559cbd8d3a58dad2f0c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:59864", "10.65.0.27:59864", "172.17.0.1:59864"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:55:46.792557118Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         587147047843869,
+				"StableID":   "nL2b2jMva511CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b25bb9d9f29ddf02691d4ea73e8ebf98847eb7877a3332de6d58d2d13091a75c",
+				"DiscoKey":   "discokey:21e71f6269e9003ba5306ddf9c2d2784f2b15069b2fb50468f1babf65d686443",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57075", "10.65.0.27:57075", "172.17.0.1:57075"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:55:47.332575447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2713887429846554,
+				"StableID":   "nHCUuoD8CN11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a067cbfbe394d17f3907921b058b4dedd146d624512dd527e8814e0205a9801",
+				"DiscoKey":   "discokey:397297a94f7e621fb6e75696a3066d4d0a921d520f218d477552c5c0663f5743",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:53344", "10.65.0.27:53344", "172.17.0.1:53344"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:55:47.859567419Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7448351196262868,
+				"StableID":   "nm9wXEZNA121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9658c60d68240d75ab76570991d3000299b9e51b6fbf9cd893283e8ee9d9515d",
+				"DiscoKey":   "discokey:459a36363611b5bb51b0768c257200b8d379036d3b38d92114314fe455492e06",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47083", "10.65.0.27:47083", "172.17.0.1:47083"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:55:48.387063424Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6159030803756667,
+				"StableID":   "ngy2X8JS6q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba3a4a8a342d7e2c5296e20a267673ca232ea1874fbf3b74c616f1e7f58e5a03",
+				"DiscoKey":   "discokey:23f15d53be0ffc735905ec11c03e0c6525e5341ac36f77fd7b7b920b74637659",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:42970", "10.65.0.27:42970", "172.17.0.1:42970"],
+				"HomeDERP":   18,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:55:48.917754396Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5376294992179314,
+				"StableID":   "nwBhCs9wyi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:16951ebb9387bbaf6f7196c8304ba2260a14a33dcf58a7da7ad5c235817ee94e",
+				"KeyExpiry":  "2026-11-08T18:55:50Z",
+				"DiscoKey":   "discokey:d8e2d2e55f0276b4c2b490637a3cf52878391418f9e2c2376bdbb292f8edef50",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:34625", "10.65.0.27:34625", "172.17.0.1:34625"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:55:50.452117454Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7118790738790820,
+				"StableID":   "nRd8SZZ7bx11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6a2e97adca6aa6b02c29e4ad4d1ecbcdaab63299f5494632f948b1dbc2833527",
+				"KeyExpiry":  "2026-11-08T18:55:50Z",
+				"DiscoKey":   "discokey:7f2a1d5f5e129e7d0c8fbd3b5b6c75bdaeaa1e255ab9f9bd5c4d0f553b13215b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:58399", "10.65.0.27:58399", "172.17.0.1:58399"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:55:50.976960192Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7627231953651300,
+				"StableID":   "nVjtW6TPZ221CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fbcd8dd70ff5e4d0a088c185dacd95456c094d15a1a191a9efef5d1f48c65d34",
+				"KeyExpiry":  "2026-11-08T18:55:51Z",
+				"DiscoKey":   "discokey:2bb5db6697ec4a3347b56e55fd6853068e083e10d8055fe0ec217c9610948c18",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:36613", "10.65.0.27:36613", "172.17.0.1:36613"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:55:51.516838863Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8126768308751190": {
+				"ID":          8126768308751190,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         587147047843869,
+				"StableID":   "nL2b2jMva511CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       587147047843869,
+				"Key":        "nodekey:b25bb9d9f29ddf02691d4ea73e8ebf98847eb7877a3332de6d58d2d13091a75c",
+				"DiscoKey":   "discokey:21e71f6269e9003ba5306ddf9c2d2784f2b15069b2fb50468f1babf65d686443",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57075", "10.65.0.27:57075", "172.17.0.1:57075"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:55:47.332575447Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b25bb9d9f29ddf02691d4ea73e8ebf98847eb7877a3332de6d58d2d13091a75c",
+			"MachineKey": "mkey:6682523c77c582e294348b6e4f95823521d192601c590d9e61d92814cc4d7b05",
+			"Peers": [{
+				"ID":         7574537821997402,
+				"StableID":   "nP1YYLGX9221CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0d5f583bd95b025edb93bfadba2a68ef30828f10c9201450c797494a31154957",
+				"DiscoKey":   "discokey:0cd472111f5eeb608eb57546345224817b76f6680e82178cd22a928b20bb2f50",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:38146", "10.65.0.27:38146", "172.17.0.1:38146"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:55:43.05455785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1124457422242543,
+				"StableID":   "nGR3tCbGn911CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41a9994e26a7a555909ddca54a2ea5f57a237226437eb1a6f7dcdfd481de3e23",
+				"DiscoKey":   "discokey:cca74380213a9a811d06776d30c61025dd8a3f23ad72270d58cda908fedddf61",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:35511", "10.65.0.27:35511", "172.17.0.1:35511"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:55:43.611081748Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1262922201761304,
+				"StableID":   "nVs9JqpyrA11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:82d7bd44688c616e6ba8c45f037f88cbfc0cbbb565e601a4bf5e98bb7007ab00",
+				"DiscoKey":   "discokey:3fdbc83628d93015a00ff0a955ac12334378208ed5933ea2a1af5b931fd55218",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:56475", "10.65.0.27:56475", "172.17.0.1:56475"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:55:44.134231193Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         143186579656124,
+				"StableID":   "n9F3jaGr7211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03726a712a95c9c6604702c4ce7a0d22295500b208d3a39351b3adf251231f4d",
+				"DiscoKey":   "discokey:19c9009f83a64c5349e2991f620e1d10516162321215f306cd5a9c17bce22010",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:45702", "10.65.0.27:45702", "172.17.0.1:45702"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:55:44.672814512Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4218609743689897,
+				"StableID":   "n6fm62jcwZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:225c0d9fb8a56bc197efac7fa83f8c960ceedd2aba457cd43b2f097d2e0cc02b",
+				"DiscoKey":   "discokey:66627884ff0d54506903dfa6e608b63a66b3d839ee60070a6aff488e0df22d7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:56504", "10.65.0.27:56504", "172.17.0.1:56504"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:55:45.210808467Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3784649116951398,
+				"StableID":   "nfVVYFK5ZW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:436ea22cf25b7ab0623050a4cd4deb931f09e1564d6f9e0c4209c4499ec07a76",
+				"DiscoKey":   "discokey:315c285f8853af5177ca5e849ad187931bc2f4cecae9d9f4b6570381ba324e2f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:60758", "10.65.0.27:60758", "172.17.0.1:60758"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:55:45.738349707Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8126768308751190,
+				"StableID":   "nofkdXRdT621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1bfc739041be126427e0a35a5929bf1b98729f780167971323982108cfbf871d",
+				"DiscoKey":   "discokey:22cb0be3eb2ecac46c129116abf3a8a44debda473ce859b663669a2256bb9275",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:36078", "10.65.0.27:36078", "172.17.0.1:36078"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:55:46.260501309Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         101792691512349,
+				"StableID":   "nLWRaSv6o111CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:572a6c971194c402a01fc7095f455cc5b0d4211dadde9b6fee2a730951c9f34b",
+				"DiscoKey":   "discokey:953753a219bb2f744e9b9c230d7b5a2511d4184208fa7559cbd8d3a58dad2f0c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:59864", "10.65.0.27:59864", "172.17.0.1:59864"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:55:46.792557118Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         2713887429846554,
+				"StableID":   "nHCUuoD8CN11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a067cbfbe394d17f3907921b058b4dedd146d624512dd527e8814e0205a9801",
+				"DiscoKey":   "discokey:397297a94f7e621fb6e75696a3066d4d0a921d520f218d477552c5c0663f5743",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:53344", "10.65.0.27:53344", "172.17.0.1:53344"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:55:47.859567419Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7448351196262868,
+				"StableID":   "nm9wXEZNA121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9658c60d68240d75ab76570991d3000299b9e51b6fbf9cd893283e8ee9d9515d",
+				"DiscoKey":   "discokey:459a36363611b5bb51b0768c257200b8d379036d3b38d92114314fe455492e06",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47083", "10.65.0.27:47083", "172.17.0.1:47083"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:55:48.387063424Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6159030803756667,
+				"StableID":   "ngy2X8JS6q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba3a4a8a342d7e2c5296e20a267673ca232ea1874fbf3b74c616f1e7f58e5a03",
+				"DiscoKey":   "discokey:23f15d53be0ffc735905ec11c03e0c6525e5341ac36f77fd7b7b920b74637659",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:42970", "10.65.0.27:42970", "172.17.0.1:42970"],
+				"HomeDERP":   18,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:55:48.917754396Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5376294992179314,
+				"StableID":   "nwBhCs9wyi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:16951ebb9387bbaf6f7196c8304ba2260a14a33dcf58a7da7ad5c235817ee94e",
+				"KeyExpiry":  "2026-11-08T18:55:50Z",
+				"DiscoKey":   "discokey:d8e2d2e55f0276b4c2b490637a3cf52878391418f9e2c2376bdbb292f8edef50",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:34625", "10.65.0.27:34625", "172.17.0.1:34625"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:55:50.452117454Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7118790738790820,
+				"StableID":   "nRd8SZZ7bx11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6a2e97adca6aa6b02c29e4ad4d1ecbcdaab63299f5494632f948b1dbc2833527",
+				"KeyExpiry":  "2026-11-08T18:55:50Z",
+				"DiscoKey":   "discokey:7f2a1d5f5e129e7d0c8fbd3b5b6c75bdaeaa1e255ab9f9bd5c4d0f553b13215b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:58399", "10.65.0.27:58399", "172.17.0.1:58399"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:55:50.976960192Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7627231953651300,
+				"StableID":   "nVjtW6TPZ221CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fbcd8dd70ff5e4d0a088c185dacd95456c094d15a1a191a9efef5d1f48c65d34",
+				"KeyExpiry":  "2026-11-08T18:55:51Z",
+				"DiscoKey":   "discokey:2bb5db6697ec4a3347b56e55fd6853068e083e10d8055fe0ec217c9610948c18",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:36613", "10.65.0.27:36613", "172.17.0.1:36613"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:55:51.516838863Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "587147047843869": {
+				"ID":          587147047843869,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         7118790738790820,
+				"StableID":   "nRd8SZZ7bx11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6a2e97adca6aa6b02c29e4ad4d1ecbcdaab63299f5494632f948b1dbc2833527",
+				"KeyExpiry":  "2026-11-08T18:55:50Z",
+				"DiscoKey":   "discokey:7f2a1d5f5e129e7d0c8fbd3b5b6c75bdaeaa1e255ab9f9bd5c4d0f553b13215b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:58399", "10.65.0.27:58399", "172.17.0.1:58399"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:55:50.976960192Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:6a2e97adca6aa6b02c29e4ad4d1ecbcdaab63299f5494632f948b1dbc2833527",
+			"MachineKey": "mkey:b474f3d17992f3088898a3fee6454e745f39e96d7ce290eedfccca406357c236",
+			"Peers": [{
+				"ID":         7574537821997402,
+				"StableID":   "nP1YYLGX9221CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0d5f583bd95b025edb93bfadba2a68ef30828f10c9201450c797494a31154957",
+				"DiscoKey":   "discokey:0cd472111f5eeb608eb57546345224817b76f6680e82178cd22a928b20bb2f50",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:38146", "10.65.0.27:38146", "172.17.0.1:38146"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:55:43.05455785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1124457422242543,
+				"StableID":   "nGR3tCbGn911CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41a9994e26a7a555909ddca54a2ea5f57a237226437eb1a6f7dcdfd481de3e23",
+				"DiscoKey":   "discokey:cca74380213a9a811d06776d30c61025dd8a3f23ad72270d58cda908fedddf61",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:35511", "10.65.0.27:35511", "172.17.0.1:35511"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:55:43.611081748Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1262922201761304,
+				"StableID":   "nVs9JqpyrA11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:82d7bd44688c616e6ba8c45f037f88cbfc0cbbb565e601a4bf5e98bb7007ab00",
+				"DiscoKey":   "discokey:3fdbc83628d93015a00ff0a955ac12334378208ed5933ea2a1af5b931fd55218",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:56475", "10.65.0.27:56475", "172.17.0.1:56475"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:55:44.134231193Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         143186579656124,
+				"StableID":   "n9F3jaGr7211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03726a712a95c9c6604702c4ce7a0d22295500b208d3a39351b3adf251231f4d",
+				"DiscoKey":   "discokey:19c9009f83a64c5349e2991f620e1d10516162321215f306cd5a9c17bce22010",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:45702", "10.65.0.27:45702", "172.17.0.1:45702"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:55:44.672814512Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4218609743689897,
+				"StableID":   "n6fm62jcwZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:225c0d9fb8a56bc197efac7fa83f8c960ceedd2aba457cd43b2f097d2e0cc02b",
+				"DiscoKey":   "discokey:66627884ff0d54506903dfa6e608b63a66b3d839ee60070a6aff488e0df22d7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:56504", "10.65.0.27:56504", "172.17.0.1:56504"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:55:45.210808467Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3784649116951398,
+				"StableID":   "nfVVYFK5ZW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:436ea22cf25b7ab0623050a4cd4deb931f09e1564d6f9e0c4209c4499ec07a76",
+				"DiscoKey":   "discokey:315c285f8853af5177ca5e849ad187931bc2f4cecae9d9f4b6570381ba324e2f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:60758", "10.65.0.27:60758", "172.17.0.1:60758"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:55:45.738349707Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8126768308751190,
+				"StableID":   "nofkdXRdT621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1bfc739041be126427e0a35a5929bf1b98729f780167971323982108cfbf871d",
+				"DiscoKey":   "discokey:22cb0be3eb2ecac46c129116abf3a8a44debda473ce859b663669a2256bb9275",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:36078", "10.65.0.27:36078", "172.17.0.1:36078"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:55:46.260501309Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         101792691512349,
+				"StableID":   "nLWRaSv6o111CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:572a6c971194c402a01fc7095f455cc5b0d4211dadde9b6fee2a730951c9f34b",
+				"DiscoKey":   "discokey:953753a219bb2f744e9b9c230d7b5a2511d4184208fa7559cbd8d3a58dad2f0c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:59864", "10.65.0.27:59864", "172.17.0.1:59864"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:55:46.792557118Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         587147047843869,
+				"StableID":   "nL2b2jMva511CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b25bb9d9f29ddf02691d4ea73e8ebf98847eb7877a3332de6d58d2d13091a75c",
+				"DiscoKey":   "discokey:21e71f6269e9003ba5306ddf9c2d2784f2b15069b2fb50468f1babf65d686443",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57075", "10.65.0.27:57075", "172.17.0.1:57075"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:55:47.332575447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         2713887429846554,
+				"StableID":   "nHCUuoD8CN11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:8a067cbfbe394d17f3907921b058b4dedd146d624512dd527e8814e0205a9801",
+				"DiscoKey":   "discokey:397297a94f7e621fb6e75696a3066d4d0a921d520f218d477552c5c0663f5743",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:53344", "10.65.0.27:53344", "172.17.0.1:53344"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:55:47.859567419Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         7448351196262868,
+				"StableID":   "nm9wXEZNA121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9658c60d68240d75ab76570991d3000299b9e51b6fbf9cd893283e8ee9d9515d",
+				"DiscoKey":   "discokey:459a36363611b5bb51b0768c257200b8d379036d3b38d92114314fe455492e06",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47083", "10.65.0.27:47083", "172.17.0.1:47083"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:55:48.387063424Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6159030803756667,
+				"StableID":   "ngy2X8JS6q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba3a4a8a342d7e2c5296e20a267673ca232ea1874fbf3b74c616f1e7f58e5a03",
+				"DiscoKey":   "discokey:23f15d53be0ffc735905ec11c03e0c6525e5341ac36f77fd7b7b920b74637659",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:42970", "10.65.0.27:42970", "172.17.0.1:42970"],
+				"HomeDERP":   18,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:55:48.917754396Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5376294992179314,
+				"StableID":   "nwBhCs9wyi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:16951ebb9387bbaf6f7196c8304ba2260a14a33dcf58a7da7ad5c235817ee94e",
+				"KeyExpiry":  "2026-11-08T18:55:50Z",
+				"DiscoKey":   "discokey:d8e2d2e55f0276b4c2b490637a3cf52878391418f9e2c2376bdbb292f8edef50",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:34625", "10.65.0.27:34625", "172.17.0.1:34625"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:55:50.452117454Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7627231953651300,
+				"StableID":   "nVjtW6TPZ221CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fbcd8dd70ff5e4d0a088c185dacd95456c094d15a1a191a9efef5d1f48c65d34",
+				"KeyExpiry":  "2026-11-08T18:55:51Z",
+				"DiscoKey":   "discokey:2bb5db6697ec4a3347b56e55fd6853068e083e10d8055fe0ec217c9610948c18",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:36613", "10.65.0.27:36613", "172.17.0.1:36613"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:55:51.516838863Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2713887429846554,
+				"StableID":   "nHCUuoD8CN11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       2713887429846554,
+				"Key":        "nodekey:8a067cbfbe394d17f3907921b058b4dedd146d624512dd527e8814e0205a9801",
+				"DiscoKey":   "discokey:397297a94f7e621fb6e75696a3066d4d0a921d520f218d477552c5c0663f5743",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:53344", "10.65.0.27:53344", "172.17.0.1:53344"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:55:47.859567419Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:8a067cbfbe394d17f3907921b058b4dedd146d624512dd527e8814e0205a9801",
+			"MachineKey": "mkey:748a218ebf524b87c6bf7436cafba80c211622d3fb473bda38e1510a93b0196c",
+			"Peers": [{
+				"ID":         7574537821997402,
+				"StableID":   "nP1YYLGX9221CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0d5f583bd95b025edb93bfadba2a68ef30828f10c9201450c797494a31154957",
+				"DiscoKey":   "discokey:0cd472111f5eeb608eb57546345224817b76f6680e82178cd22a928b20bb2f50",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:38146", "10.65.0.27:38146", "172.17.0.1:38146"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:55:43.05455785Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         1124457422242543,
+				"StableID":   "nGR3tCbGn911CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:41a9994e26a7a555909ddca54a2ea5f57a237226437eb1a6f7dcdfd481de3e23",
+				"DiscoKey":   "discokey:cca74380213a9a811d06776d30c61025dd8a3f23ad72270d58cda908fedddf61",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:35511", "10.65.0.27:35511", "172.17.0.1:35511"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:55:43.611081748Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         1262922201761304,
+				"StableID":   "nVs9JqpyrA11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:82d7bd44688c616e6ba8c45f037f88cbfc0cbbb565e601a4bf5e98bb7007ab00",
+				"DiscoKey":   "discokey:3fdbc83628d93015a00ff0a955ac12334378208ed5933ea2a1af5b931fd55218",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:56475", "10.65.0.27:56475", "172.17.0.1:56475"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:55:44.134231193Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         143186579656124,
+				"StableID":   "n9F3jaGr7211CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:03726a712a95c9c6604702c4ce7a0d22295500b208d3a39351b3adf251231f4d",
+				"DiscoKey":   "discokey:19c9009f83a64c5349e2991f620e1d10516162321215f306cd5a9c17bce22010",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:45702", "10.65.0.27:45702", "172.17.0.1:45702"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:55:44.672814512Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         4218609743689897,
+				"StableID":   "n6fm62jcwZ11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:225c0d9fb8a56bc197efac7fa83f8c960ceedd2aba457cd43b2f097d2e0cc02b",
+				"DiscoKey":   "discokey:66627884ff0d54506903dfa6e608b63a66b3d839ee60070a6aff488e0df22d7e",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:56504", "10.65.0.27:56504", "172.17.0.1:56504"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:55:45.210808467Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         3784649116951398,
+				"StableID":   "nfVVYFK5ZW11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:436ea22cf25b7ab0623050a4cd4deb931f09e1564d6f9e0c4209c4499ec07a76",
+				"DiscoKey":   "discokey:315c285f8853af5177ca5e849ad187931bc2f4cecae9d9f4b6570381ba324e2f",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:60758", "10.65.0.27:60758", "172.17.0.1:60758"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:55:45.738349707Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         8126768308751190,
+				"StableID":   "nofkdXRdT621CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:1bfc739041be126427e0a35a5929bf1b98729f780167971323982108cfbf871d",
+				"DiscoKey":   "discokey:22cb0be3eb2ecac46c129116abf3a8a44debda473ce859b663669a2256bb9275",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:36078", "10.65.0.27:36078", "172.17.0.1:36078"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:55:46.260501309Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         101792691512349,
+				"StableID":   "nLWRaSv6o111CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:572a6c971194c402a01fc7095f455cc5b0d4211dadde9b6fee2a730951c9f34b",
+				"DiscoKey":   "discokey:953753a219bb2f744e9b9c230d7b5a2511d4184208fa7559cbd8d3a58dad2f0c",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:59864", "10.65.0.27:59864", "172.17.0.1:59864"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:55:46.792557118Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         587147047843869,
+				"StableID":   "nL2b2jMva511CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b25bb9d9f29ddf02691d4ea73e8ebf98847eb7877a3332de6d58d2d13091a75c",
+				"DiscoKey":   "discokey:21e71f6269e9003ba5306ddf9c2d2784f2b15069b2fb50468f1babf65d686443",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57075", "10.65.0.27:57075", "172.17.0.1:57075"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:55:47.332575447Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         7448351196262868,
+				"StableID":   "nm9wXEZNA121CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:9658c60d68240d75ab76570991d3000299b9e51b6fbf9cd893283e8ee9d9515d",
+				"DiscoKey":   "discokey:459a36363611b5bb51b0768c257200b8d379036d3b38d92114314fe455492e06",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:47083", "10.65.0.27:47083", "172.17.0.1:47083"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:55:48.387063424Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         6159030803756667,
+				"StableID":   "ngy2X8JS6q11CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:ba3a4a8a342d7e2c5296e20a267673ca232ea1874fbf3b74c616f1e7f58e5a03",
+				"DiscoKey":   "discokey:23f15d53be0ffc735905ec11c03e0c6525e5341ac36f77fd7b7b920b74637659",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:42970", "10.65.0.27:42970", "172.17.0.1:42970"],
+				"HomeDERP":   18,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:55:48.917754396Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         5376294992179314,
+				"StableID":   "nwBhCs9wyi11CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:16951ebb9387bbaf6f7196c8304ba2260a14a33dcf58a7da7ad5c235817ee94e",
+				"KeyExpiry":  "2026-11-08T18:55:50Z",
+				"DiscoKey":   "discokey:d8e2d2e55f0276b4c2b490637a3cf52878391418f9e2c2376bdbb292f8edef50",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:34625", "10.65.0.27:34625", "172.17.0.1:34625"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:55:50.452117454Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         7118790738790820,
+				"StableID":   "nRd8SZZ7bx11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:6a2e97adca6aa6b02c29e4ad4d1ecbcdaab63299f5494632f948b1dbc2833527",
+				"KeyExpiry":  "2026-11-08T18:55:50Z",
+				"DiscoKey":   "discokey:7f2a1d5f5e129e7d0c8fbd3b5b6c75bdaeaa1e255ab9f9bd5c4d0f553b13215b",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:58399", "10.65.0.27:58399", "172.17.0.1:58399"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:55:50.976960192Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         7627231953651300,
+				"StableID":   "nVjtW6TPZ221CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:fbcd8dd70ff5e4d0a088c185dacd95456c094d15a1a191a9efef5d1f48c65d34",
+				"KeyExpiry":  "2026-11-08T18:55:51Z",
+				"DiscoKey":   "discokey:2bb5db6697ec4a3347b56e55fd6853068e083e10d8055fe0ec217c9610948c18",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:36613", "10.65.0.27:36613", "172.17.0.1:36613"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:55:51.516838863Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2713887429846554": {
+				"ID":          2713887429846554,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/testdata/sshtest_results/sshtest-user-wildcard.hujson
+++ b/hscontrol/policy/v2/testdata/sshtest_results/sshtest-user-wildcard.hujson
@@ -1,0 +1,18734 @@
+// sshtest-user-wildcard
+//
+// users wildcard allows arbitrary test user
+//
+// Nodes with filter rules: 15 of 15
+// Captured at:    2026-05-12T18:56:36Z
+// tool version:   tscap/dev
+// schema version: 1
+{
+	"schema_version": 1,
+	"test_id":        "sshtest-user-wildcard",
+	"description":    "users wildcard allows arbitrary test user",
+	"category":       "sshtest",
+	"captured_at":    "2026-05-12T18:56:36.779941414Z",
+	"tool_version":   "tscap/dev",
+	"tailnet":        "odin@example.com",
+	"error":          true,
+	"input": {
+		"api_response_code": 400,
+		"api_response_body": {"message": "user \"*\" is not valid"},
+		"tailnet": {
+			"dns":      {"magic_dns": false, "nameservers": [], "search_paths": [], "split_dns": {}},
+			"settings": {}
+		},
+		"scenario_hujson": "                        \n  \n                                                                         \n                                   \n{\n\t\"category\":    \"sshtest\",\n\t\"description\": \"users wildcard allows arbitrary test user\",\n\t\"id\":          \"sshtest-user-wildcard\",\n\t\"policy\": {\"ssh\": [{\n\t\t\"action\": \"accept\",\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    [\"thor@example.org\"],\n\t\t\"users\":  [\"*\"]\n\t}], \"sshTests\": [{\n\t\t\"accept\": [\"mallory\"],\n\t\t\"dst\":    [\"tag:server\"],\n\t\t\"src\":    \"thor@example.org\"\n\t}], \"tagOwners\": {\n\t\t\"tag:prod\":   [\"odin@example.com\"],\n\t\t\"tag:server\": [\"odin@example.com\"]\n\t}},\n\t\"tailnet\": {\n\t\t\"dns\":      {\"magic_dns\": false, \"nameservers\": [], \"search_paths\": [], \"split_dns\": {}},\n\t\t\"settings\": {}\n\t},\n\t\"topology\": \"../_topologies/grant.hujson\"\n}\n",
+		"scenario_path":   "scenarios/sshtest/sshtest-user-wildcard.hujson",
+		"full_policy": {
+			"ssh": [{
+				"action": "accept",
+				"dst":    ["tag:server"],
+				"src":    ["thor@example.org"],
+				"users":  ["*"]
+			}],
+			"sshTests": [
+				{"accept": ["mallory"], "dst": ["tag:server"], "src": "thor@example.org"}
+			],
+			"tagOwners": {"tag:prod": ["odin@example.com"], "tag:server": ["odin@example.com"]}
+		}
+	},
+	"topology": {"users": [
+		{"id": 1, "name": "odin", "email": "odin@example.com"},
+		{"id": 2, "name": "thor", "email": "thor@example.org"},
+		{"id": 3, "name": "freya", "email": "freya@example.com"}
+	], "nodes": {"beedrill": {
+		"hostname":        "beedrill",
+		"tags":            ["tag:server"],
+		"ipv4":            "100.64.0.16",
+		"ipv6":            "fd7a:115c:a1e0::10",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "blastoise": {
+		"hostname":        "blastoise",
+		"tags":            ["tag:exit", "tag:router"],
+		"ipv4":            "100.64.0.9",
+		"ipv6":            "fd7a:115c:a1e0::9",
+		"routable_ips":    ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "bulbasaur": {
+		"hostname":        "bulbasaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.19",
+		"ipv6":            "fd7a:115c:a1e0::13",
+		"user":            "odin",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "charmander": {
+		"hostname":        "charmander",
+		"tags":            ["tag:exit"],
+		"ipv4":            "100.64.0.4",
+		"ipv6":            "fd7a:115c:a1e0::4",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "fearow": {
+		"hostname":        "fearow",
+		"tags":            ["tag:fearow"],
+		"ipv4":            "100.64.0.12",
+		"ipv6":            "fd7a:115c:a1e0::c",
+		"routable_ips":    ["10.55.0.0/16"],
+		"approved_routes": []
+	}, "ivysaur": {
+		"hostname":        "ivysaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.17",
+		"ipv6":            "fd7a:115c:a1e0::11",
+		"user":            "thor",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "kakuna": {
+		"hostname":        "kakuna",
+		"tags":            ["tag:prod"],
+		"ipv4":            "100.64.0.15",
+		"ipv6":            "fd7a:115c:a1e0::f",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "pidgeotto": {
+		"hostname":        "pidgeotto",
+		"tags":            ["tag:pidgeotto"],
+		"ipv4":            "100.64.0.3",
+		"ipv6":            "fd7a:115c:a1e0::3",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "pidgey": {
+		"hostname":        "pidgey",
+		"tags":            ["tag:pidgey"],
+		"ipv4":            "100.64.0.2",
+		"ipv6":            "fd7a:115c:a1e0::2",
+		"routable_ips":    ["0.0.0.0/0", "::/0"],
+		"approved_routes": []
+	}, "raticate": {
+		"hostname":        "raticate",
+		"tags":            ["tag:group-b"],
+		"ipv4":            "100.64.0.6",
+		"ipv6":            "fd7a:115c:a1e0::6",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "rattata": {
+		"hostname":        "rattata",
+		"tags":            ["tag:group-a"],
+		"ipv4":            "100.64.0.5",
+		"ipv6":            "fd7a:115c:a1e0::5",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "spearow": {
+		"hostname":        "spearow",
+		"tags":            ["tag:spearow"],
+		"ipv4":            "100.64.0.11",
+		"ipv6":            "fd7a:115c:a1e0::b",
+		"routable_ips":    ["10.44.0.0/16"],
+		"approved_routes": []
+	}, "squirtle": {
+		"hostname":        "squirtle",
+		"tags":            ["tag:router"],
+		"ipv4":            "100.64.0.13",
+		"ipv6":            "fd7a:115c:a1e0::d",
+		"routable_ips":    ["10.33.0.0/16"],
+		"approved_routes": []
+	}, "venusaur": {
+		"hostname":        "venusaur",
+		"tags":            [],
+		"ipv4":            "100.64.0.18",
+		"ipv6":            "fd7a:115c:a1e0::12",
+		"user":            "freya",
+		"routable_ips":    [],
+		"approved_routes": []
+	}, "weedle": {
+		"hostname":        "weedle",
+		"tags":            ["tag:client"],
+		"ipv4":            "100.64.0.14",
+		"ipv6":            "fd7a:115c:a1e0::e",
+		"routable_ips":    [],
+		"approved_routes": []
+	}}},
+	"captures": {"beedrill": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8469822311997169,
+				"StableID":   "nzhhATsz8921CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       8469822311997169,
+				"Key":        "nodekey:c085b4af66b3aeffe1b1af5667b97e761d42c2c90a7ca746c3e8ed7c283df232",
+				"DiscoKey":   "discokey:d453ebf750661733027eb4e6eb47fa1b1bfee9c9ab74718d5d9cd065ab3c342e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:55630", "10.65.0.27:55630", "172.17.0.1:55630"],
+				"Hostinfo": {"Hostname": "beedrill", "RequestTags": ["tag:server"], "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:56:45.398858419Z",
+				"Tags":              ["tag:server"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:c085b4af66b3aeffe1b1af5667b97e761d42c2c90a7ca746c3e8ed7c283df232",
+			"MachineKey": "mkey:9ac8ab0f2d01c99d2640802387c1cd34085073fd2d099ee8b49d74d8d27b3000",
+			"Peers": [{
+				"ID":         3302763550688450,
+				"StableID":   "nsX8CtzpnS11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:483cc9dd06471e98b3c2ba341f914133cbcdf9da37afd3036534e736133fcd51",
+				"DiscoKey":   "discokey:09b54ed35673329fe55a14d64c99b458fd66501f9b6d746af74b15f36d07c527",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:57830", "10.65.0.27:57830", "172.17.0.1:57830"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:56:39.448002312Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8983340446595960,
+				"StableID":   "nTnAGz7a9D21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdbfb180fe9b0a28b4d6bb337796c478c1cdd7c3a4bd9235cce8ed291ac3f178",
+				"DiscoKey":   "discokey:744cb082c4f2bbc4760a898e334652c5f09536f89cb0637758f0f500ad598c14",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:39965", "10.65.0.27:39965", "172.17.0.1:39965"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:56:39.977417102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4574845337037595,
+				"StableID":   "nWEWcuRxic11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0cc0597d5c1c0106ae516d9de0a4bd4dde38f373db384084b96b13b38161254d",
+				"DiscoKey":   "discokey:395270cfebf94a3afdb2063543435c1272ed8bc6a7ecf30120e413946b80e516",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:52825", "10.65.0.27:52825", "172.17.0.1:52825"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:56:40.511090494Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5143573950832586,
+				"StableID":   "nZ8Eh1yXAh11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:34fc6b4a55e81b81c49843fa5682cc263d94e6fe767560892d3ee1177df9535e",
+				"DiscoKey":   "discokey:bf492cd12f31675477e8238d4a0b16ad71ce83d6549e696b44edb5d9a38b464f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:58696", "10.65.0.27:58696", "172.17.0.1:58696"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:56:41.05713905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1602861061893332,
+				"StableID":   "n36PJeSwWD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4171affbb592d976955e324a8d9f76684607cda4f0ef9c3de8824c2ae76a06b",
+				"DiscoKey":   "discokey:aa732a139c3b0d4cf4aeb228091f93946695f2cd538d1b56b76f9141ef6f780a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:45913", "10.65.0.27:45913", "172.17.0.1:45913"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:56:41.595068864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2043994585938075,
+				"StableID":   "naQGEmGjxG11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ff126a4720c78b7c123660aff9e48ca8b34b3b1fbce6ef51e9464f0b8406202",
+				"DiscoKey":   "discokey:4e803675e31ed070602ff749c86243570aeea836549a82ea4b8f8061c7aa4752",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:34046", "10.65.0.27:34046", "172.17.0.1:34046"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:56:42.141887485Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4293716256204730,
+				"StableID":   "nViNRRedXa11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7659f801c7d36a1331b4ab6450e6a8af5c7e8fe0a1726fe336ba4bdf2feec801",
+				"DiscoKey":   "discokey:fac5b3b492c8b0eb9991dd1f54f7bc8cdd4410c21d920618eca2b7a9e7bc4d2b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:49654", "10.65.0.27:49654", "172.17.0.1:49654"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:56:42.685656154Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6023756866091993,
+				"StableID":   "n6VUswsA3p11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b1f3917fbb107fd9bb950dca72d8e96d1a4732cc31ee971e25645e91e3be930f",
+				"DiscoKey":   "discokey:95b6dede8210e54b25eb7218a64371c4e2adf5b41efe7b954a00278ca5955176",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:47881", "10.65.0.27:47881", "172.17.0.1:47881"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:56:43.232495172Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6197061833183856,
+				"StableID":   "njWiMkJfPq11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:672e03a11542fa0a6a3ab0fd01e92d8d0cda6327e29291bdd1c9e107377b7f3e",
+				"DiscoKey":   "discokey:aab45f5222fec5a45e511491258bda2443038be1d2873557f3b5922a00fba04e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57047", "10.65.0.27:57047", "172.17.0.1:57047"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:56:43.766280602Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3609737328847972,
+				"StableID":   "nqXZnMgrBV11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83c60d89b6fe62a54be43f4af9d8a53b75d7e68d6e59a2a688b2359d40c1d51d",
+				"DiscoKey":   "discokey:999258f1861d640280c7064b322610cfe262055fc42fd34d2b6ca53b6f37c128",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59383", "10.65.0.27:59383", "172.17.0.1:59383"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:56:44.310386715Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3280894969718241,
+				"StableID":   "nW1UakYvcS11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35ef232ffb2de15ec88ab100a2bfeb284dbf74be4b9f98bae1a21d8117f62212",
+				"DiscoKey":   "discokey:c6d5105154b59b4cb01fc26c599fb53280ac80bb9c1467f1c1341c00874cd82b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:49333", "10.65.0.27:49333", "172.17.0.1:49333"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:56:44.855443956Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8710528569918882,
+				"StableID":   "nwjMvGp12B21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d35b556ae2bcb8330c1c318d96f3614f075573dffe44b3f929100f761232f46b",
+				"KeyExpiry":  "2026-11-08T18:56:45Z",
+				"DiscoKey":   "discokey:79169f1629964b873fb2123834e5bcd556654464df7aa725324c77d68e949614",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:37650", "10.65.0.27:37650", "172.17.0.1:37650"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:56:45.938463432Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2696553646490874,
+				"StableID":   "nfVvpitG4N11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ccc45abf8bef1e9d2e1a5147ca76e36ef66a9f5d34ebf0e2cd1315fdd9bc1762",
+				"KeyExpiry":  "2026-11-08T18:56:46Z",
+				"DiscoKey":   "discokey:59623d2f79997f011a5c0ff6d6944bd43f67c256e254839dd3b9f9512d59f967",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:48500", "10.65.0.27:48500", "172.17.0.1:48500"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:56:46.483877479Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5424390421852946,
+				"StableID":   "n3ZMdDYiMj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f3e21bafd26c807da8c7ddb68628a06f59ba0f58034d086d3820f0f56fdc5c11",
+				"KeyExpiry":  "2026-11-08T18:56:47Z",
+				"DiscoKey":   "discokey:ba309c3cf8b0cf5c21e7dfde594b26f2f1ace39fb754a0e035236f6486a29b42",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:52233", "10.65.0.27:52233", "172.17.0.1:52233"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:56:47.027196914Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8469822311997169": {
+				"ID":          8469822311997169,
+				"LoginName":   "beedrill.tail78f774.ts.net",
+				"DisplayName": "beedrill"
+			}}
+		}
+	}, "blastoise": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2043994585938075,
+				"StableID":   "naQGEmGjxG11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       2043994585938075,
+				"Key":        "nodekey:0ff126a4720c78b7c123660aff9e48ca8b34b3b1fbce6ef51e9464f0b8406202",
+				"DiscoKey":   "discokey:4e803675e31ed070602ff749c86243570aeea836549a82ea4b8f8061c7aa4752",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:34046", "10.65.0.27:34046", "172.17.0.1:34046"],
+				"Hostinfo": {
+					"Hostname":    "blastoise",
+					"RoutableIPs": ["10.33.0.0/16", "0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit", "tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 60534},
+						{"Proto": "peerapi6", "Port": 60534},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:56:42.141887485Z",
+				"Tags":              ["tag:exit", "tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0ff126a4720c78b7c123660aff9e48ca8b34b3b1fbce6ef51e9464f0b8406202",
+			"MachineKey": "mkey:5c6f1eb5da598b8d5064be9fde80e300cc243e21850907e425c0becbfc8d132a",
+			"Peers": [{
+				"ID":         3302763550688450,
+				"StableID":   "nsX8CtzpnS11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:483cc9dd06471e98b3c2ba341f914133cbcdf9da37afd3036534e736133fcd51",
+				"DiscoKey":   "discokey:09b54ed35673329fe55a14d64c99b458fd66501f9b6d746af74b15f36d07c527",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:57830", "10.65.0.27:57830", "172.17.0.1:57830"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:56:39.448002312Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8983340446595960,
+				"StableID":   "nTnAGz7a9D21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdbfb180fe9b0a28b4d6bb337796c478c1cdd7c3a4bd9235cce8ed291ac3f178",
+				"DiscoKey":   "discokey:744cb082c4f2bbc4760a898e334652c5f09536f89cb0637758f0f500ad598c14",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:39965", "10.65.0.27:39965", "172.17.0.1:39965"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:56:39.977417102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4574845337037595,
+				"StableID":   "nWEWcuRxic11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0cc0597d5c1c0106ae516d9de0a4bd4dde38f373db384084b96b13b38161254d",
+				"DiscoKey":   "discokey:395270cfebf94a3afdb2063543435c1272ed8bc6a7ecf30120e413946b80e516",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:52825", "10.65.0.27:52825", "172.17.0.1:52825"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:56:40.511090494Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5143573950832586,
+				"StableID":   "nZ8Eh1yXAh11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:34fc6b4a55e81b81c49843fa5682cc263d94e6fe767560892d3ee1177df9535e",
+				"DiscoKey":   "discokey:bf492cd12f31675477e8238d4a0b16ad71ce83d6549e696b44edb5d9a38b464f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:58696", "10.65.0.27:58696", "172.17.0.1:58696"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:56:41.05713905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1602861061893332,
+				"StableID":   "n36PJeSwWD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4171affbb592d976955e324a8d9f76684607cda4f0ef9c3de8824c2ae76a06b",
+				"DiscoKey":   "discokey:aa732a139c3b0d4cf4aeb228091f93946695f2cd538d1b56b76f9141ef6f780a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:45913", "10.65.0.27:45913", "172.17.0.1:45913"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:56:41.595068864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         4293716256204730,
+				"StableID":   "nViNRRedXa11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7659f801c7d36a1331b4ab6450e6a8af5c7e8fe0a1726fe336ba4bdf2feec801",
+				"DiscoKey":   "discokey:fac5b3b492c8b0eb9991dd1f54f7bc8cdd4410c21d920618eca2b7a9e7bc4d2b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:49654", "10.65.0.27:49654", "172.17.0.1:49654"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:56:42.685656154Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6023756866091993,
+				"StableID":   "n6VUswsA3p11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b1f3917fbb107fd9bb950dca72d8e96d1a4732cc31ee971e25645e91e3be930f",
+				"DiscoKey":   "discokey:95b6dede8210e54b25eb7218a64371c4e2adf5b41efe7b954a00278ca5955176",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:47881", "10.65.0.27:47881", "172.17.0.1:47881"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:56:43.232495172Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6197061833183856,
+				"StableID":   "njWiMkJfPq11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:672e03a11542fa0a6a3ab0fd01e92d8d0cda6327e29291bdd1c9e107377b7f3e",
+				"DiscoKey":   "discokey:aab45f5222fec5a45e511491258bda2443038be1d2873557f3b5922a00fba04e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57047", "10.65.0.27:57047", "172.17.0.1:57047"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:56:43.766280602Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3609737328847972,
+				"StableID":   "nqXZnMgrBV11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83c60d89b6fe62a54be43f4af9d8a53b75d7e68d6e59a2a688b2359d40c1d51d",
+				"DiscoKey":   "discokey:999258f1861d640280c7064b322610cfe262055fc42fd34d2b6ca53b6f37c128",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59383", "10.65.0.27:59383", "172.17.0.1:59383"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:56:44.310386715Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3280894969718241,
+				"StableID":   "nW1UakYvcS11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35ef232ffb2de15ec88ab100a2bfeb284dbf74be4b9f98bae1a21d8117f62212",
+				"DiscoKey":   "discokey:c6d5105154b59b4cb01fc26c599fb53280ac80bb9c1467f1c1341c00874cd82b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:49333", "10.65.0.27:49333", "172.17.0.1:49333"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:56:44.855443956Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8469822311997169,
+				"StableID":   "nzhhATsz8921CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c085b4af66b3aeffe1b1af5667b97e761d42c2c90a7ca746c3e8ed7c283df232",
+				"DiscoKey":   "discokey:d453ebf750661733027eb4e6eb47fa1b1bfee9c9ab74718d5d9cd065ab3c342e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:55630", "10.65.0.27:55630", "172.17.0.1:55630"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:56:45.398858419Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8710528569918882,
+				"StableID":   "nwjMvGp12B21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d35b556ae2bcb8330c1c318d96f3614f075573dffe44b3f929100f761232f46b",
+				"KeyExpiry":  "2026-11-08T18:56:45Z",
+				"DiscoKey":   "discokey:79169f1629964b873fb2123834e5bcd556654464df7aa725324c77d68e949614",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:37650", "10.65.0.27:37650", "172.17.0.1:37650"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:56:45.938463432Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2696553646490874,
+				"StableID":   "nfVvpitG4N11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ccc45abf8bef1e9d2e1a5147ca76e36ef66a9f5d34ebf0e2cd1315fdd9bc1762",
+				"KeyExpiry":  "2026-11-08T18:56:46Z",
+				"DiscoKey":   "discokey:59623d2f79997f011a5c0ff6d6944bd43f67c256e254839dd3b9f9512d59f967",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:48500", "10.65.0.27:48500", "172.17.0.1:48500"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:56:46.483877479Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5424390421852946,
+				"StableID":   "n3ZMdDYiMj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f3e21bafd26c807da8c7ddb68628a06f59ba0f58034d086d3820f0f56fdc5c11",
+				"KeyExpiry":  "2026-11-08T18:56:47Z",
+				"DiscoKey":   "discokey:ba309c3cf8b0cf5c21e7dfde594b26f2f1ace39fb754a0e035236f6486a29b42",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:52233", "10.65.0.27:52233", "172.17.0.1:52233"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:56:47.027196914Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "2043994585938075": {
+				"ID":          2043994585938075,
+				"LoginName":   "blastoise.tail78f774.ts.net",
+				"DisplayName": "blastoise"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "bulbasaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5424390421852946,
+				"StableID":   "n3ZMdDYiMj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f3e21bafd26c807da8c7ddb68628a06f59ba0f58034d086d3820f0f56fdc5c11",
+				"KeyExpiry":  "2026-11-08T18:56:47Z",
+				"DiscoKey":   "discokey:ba309c3cf8b0cf5c21e7dfde594b26f2f1ace39fb754a0e035236f6486a29b42",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:52233", "10.65.0.27:52233", "172.17.0.1:52233"],
+				"Hostinfo": {"Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:56:47.027196914Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:f3e21bafd26c807da8c7ddb68628a06f59ba0f58034d086d3820f0f56fdc5c11",
+			"MachineKey": "mkey:215a9508515f1cc0817f5c9aa0fe2d40fdc19f9ddd3bc6327faa73ee01024a16",
+			"Peers": [{
+				"ID":         3302763550688450,
+				"StableID":   "nsX8CtzpnS11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:483cc9dd06471e98b3c2ba341f914133cbcdf9da37afd3036534e736133fcd51",
+				"DiscoKey":   "discokey:09b54ed35673329fe55a14d64c99b458fd66501f9b6d746af74b15f36d07c527",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:57830", "10.65.0.27:57830", "172.17.0.1:57830"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:56:39.448002312Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8983340446595960,
+				"StableID":   "nTnAGz7a9D21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdbfb180fe9b0a28b4d6bb337796c478c1cdd7c3a4bd9235cce8ed291ac3f178",
+				"DiscoKey":   "discokey:744cb082c4f2bbc4760a898e334652c5f09536f89cb0637758f0f500ad598c14",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:39965", "10.65.0.27:39965", "172.17.0.1:39965"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:56:39.977417102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4574845337037595,
+				"StableID":   "nWEWcuRxic11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0cc0597d5c1c0106ae516d9de0a4bd4dde38f373db384084b96b13b38161254d",
+				"DiscoKey":   "discokey:395270cfebf94a3afdb2063543435c1272ed8bc6a7ecf30120e413946b80e516",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:52825", "10.65.0.27:52825", "172.17.0.1:52825"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:56:40.511090494Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5143573950832586,
+				"StableID":   "nZ8Eh1yXAh11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:34fc6b4a55e81b81c49843fa5682cc263d94e6fe767560892d3ee1177df9535e",
+				"DiscoKey":   "discokey:bf492cd12f31675477e8238d4a0b16ad71ce83d6549e696b44edb5d9a38b464f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:58696", "10.65.0.27:58696", "172.17.0.1:58696"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:56:41.05713905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1602861061893332,
+				"StableID":   "n36PJeSwWD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4171affbb592d976955e324a8d9f76684607cda4f0ef9c3de8824c2ae76a06b",
+				"DiscoKey":   "discokey:aa732a139c3b0d4cf4aeb228091f93946695f2cd538d1b56b76f9141ef6f780a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:45913", "10.65.0.27:45913", "172.17.0.1:45913"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:56:41.595068864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2043994585938075,
+				"StableID":   "naQGEmGjxG11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ff126a4720c78b7c123660aff9e48ca8b34b3b1fbce6ef51e9464f0b8406202",
+				"DiscoKey":   "discokey:4e803675e31ed070602ff749c86243570aeea836549a82ea4b8f8061c7aa4752",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:34046", "10.65.0.27:34046", "172.17.0.1:34046"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:56:42.141887485Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4293716256204730,
+				"StableID":   "nViNRRedXa11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7659f801c7d36a1331b4ab6450e6a8af5c7e8fe0a1726fe336ba4bdf2feec801",
+				"DiscoKey":   "discokey:fac5b3b492c8b0eb9991dd1f54f7bc8cdd4410c21d920618eca2b7a9e7bc4d2b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:49654", "10.65.0.27:49654", "172.17.0.1:49654"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:56:42.685656154Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6023756866091993,
+				"StableID":   "n6VUswsA3p11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b1f3917fbb107fd9bb950dca72d8e96d1a4732cc31ee971e25645e91e3be930f",
+				"DiscoKey":   "discokey:95b6dede8210e54b25eb7218a64371c4e2adf5b41efe7b954a00278ca5955176",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:47881", "10.65.0.27:47881", "172.17.0.1:47881"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:56:43.232495172Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6197061833183856,
+				"StableID":   "njWiMkJfPq11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:672e03a11542fa0a6a3ab0fd01e92d8d0cda6327e29291bdd1c9e107377b7f3e",
+				"DiscoKey":   "discokey:aab45f5222fec5a45e511491258bda2443038be1d2873557f3b5922a00fba04e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57047", "10.65.0.27:57047", "172.17.0.1:57047"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:56:43.766280602Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3609737328847972,
+				"StableID":   "nqXZnMgrBV11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83c60d89b6fe62a54be43f4af9d8a53b75d7e68d6e59a2a688b2359d40c1d51d",
+				"DiscoKey":   "discokey:999258f1861d640280c7064b322610cfe262055fc42fd34d2b6ca53b6f37c128",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59383", "10.65.0.27:59383", "172.17.0.1:59383"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:56:44.310386715Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3280894969718241,
+				"StableID":   "nW1UakYvcS11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35ef232ffb2de15ec88ab100a2bfeb284dbf74be4b9f98bae1a21d8117f62212",
+				"DiscoKey":   "discokey:c6d5105154b59b4cb01fc26c599fb53280ac80bb9c1467f1c1341c00874cd82b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:49333", "10.65.0.27:49333", "172.17.0.1:49333"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:56:44.855443956Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8469822311997169,
+				"StableID":   "nzhhATsz8921CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c085b4af66b3aeffe1b1af5667b97e761d42c2c90a7ca746c3e8ed7c283df232",
+				"DiscoKey":   "discokey:d453ebf750661733027eb4e6eb47fa1b1bfee9c9ab74718d5d9cd065ab3c342e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:55630", "10.65.0.27:55630", "172.17.0.1:55630"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:56:45.398858419Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8710528569918882,
+				"StableID":   "nwjMvGp12B21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d35b556ae2bcb8330c1c318d96f3614f075573dffe44b3f929100f761232f46b",
+				"KeyExpiry":  "2026-11-08T18:56:45Z",
+				"DiscoKey":   "discokey:79169f1629964b873fb2123834e5bcd556654464df7aa725324c77d68e949614",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:37650", "10.65.0.27:37650", "172.17.0.1:37650"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:56:45.938463432Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2696553646490874,
+				"StableID":   "nfVvpitG4N11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ccc45abf8bef1e9d2e1a5147ca76e36ef66a9f5d34ebf0e2cd1315fdd9bc1762",
+				"KeyExpiry":  "2026-11-08T18:56:46Z",
+				"DiscoKey":   "discokey:59623d2f79997f011a5c0ff6d6944bd43f67c256e254839dd3b9f9512d59f967",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:48500", "10.65.0.27:48500", "172.17.0.1:48500"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:56:46.483877479Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "charmander": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4574845337037595,
+				"StableID":   "nWEWcuRxic11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       4574845337037595,
+				"Key":        "nodekey:0cc0597d5c1c0106ae516d9de0a4bd4dde38f373db384084b96b13b38161254d",
+				"DiscoKey":   "discokey:395270cfebf94a3afdb2063543435c1272ed8bc6a7ecf30120e413946b80e516",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:52825", "10.65.0.27:52825", "172.17.0.1:52825"],
+				"Hostinfo": {
+					"Hostname":    "charmander",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:exit"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 37067},
+						{"Proto": "peerapi6", "Port": 37067},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:56:40.511090494Z",
+				"Tags":              ["tag:exit"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:0cc0597d5c1c0106ae516d9de0a4bd4dde38f373db384084b96b13b38161254d",
+			"MachineKey": "mkey:41699d8e79e0655be4187950b01340a6a505ea6af1453e072d07fd593b96440b",
+			"Peers": [{
+				"ID":         3302763550688450,
+				"StableID":   "nsX8CtzpnS11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:483cc9dd06471e98b3c2ba341f914133cbcdf9da37afd3036534e736133fcd51",
+				"DiscoKey":   "discokey:09b54ed35673329fe55a14d64c99b458fd66501f9b6d746af74b15f36d07c527",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:57830", "10.65.0.27:57830", "172.17.0.1:57830"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:56:39.448002312Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8983340446595960,
+				"StableID":   "nTnAGz7a9D21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdbfb180fe9b0a28b4d6bb337796c478c1cdd7c3a4bd9235cce8ed291ac3f178",
+				"DiscoKey":   "discokey:744cb082c4f2bbc4760a898e334652c5f09536f89cb0637758f0f500ad598c14",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:39965", "10.65.0.27:39965", "172.17.0.1:39965"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:56:39.977417102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         5143573950832586,
+				"StableID":   "nZ8Eh1yXAh11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:34fc6b4a55e81b81c49843fa5682cc263d94e6fe767560892d3ee1177df9535e",
+				"DiscoKey":   "discokey:bf492cd12f31675477e8238d4a0b16ad71ce83d6549e696b44edb5d9a38b464f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:58696", "10.65.0.27:58696", "172.17.0.1:58696"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:56:41.05713905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1602861061893332,
+				"StableID":   "n36PJeSwWD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4171affbb592d976955e324a8d9f76684607cda4f0ef9c3de8824c2ae76a06b",
+				"DiscoKey":   "discokey:aa732a139c3b0d4cf4aeb228091f93946695f2cd538d1b56b76f9141ef6f780a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:45913", "10.65.0.27:45913", "172.17.0.1:45913"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:56:41.595068864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2043994585938075,
+				"StableID":   "naQGEmGjxG11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ff126a4720c78b7c123660aff9e48ca8b34b3b1fbce6ef51e9464f0b8406202",
+				"DiscoKey":   "discokey:4e803675e31ed070602ff749c86243570aeea836549a82ea4b8f8061c7aa4752",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:34046", "10.65.0.27:34046", "172.17.0.1:34046"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:56:42.141887485Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4293716256204730,
+				"StableID":   "nViNRRedXa11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7659f801c7d36a1331b4ab6450e6a8af5c7e8fe0a1726fe336ba4bdf2feec801",
+				"DiscoKey":   "discokey:fac5b3b492c8b0eb9991dd1f54f7bc8cdd4410c21d920618eca2b7a9e7bc4d2b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:49654", "10.65.0.27:49654", "172.17.0.1:49654"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:56:42.685656154Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6023756866091993,
+				"StableID":   "n6VUswsA3p11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b1f3917fbb107fd9bb950dca72d8e96d1a4732cc31ee971e25645e91e3be930f",
+				"DiscoKey":   "discokey:95b6dede8210e54b25eb7218a64371c4e2adf5b41efe7b954a00278ca5955176",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:47881", "10.65.0.27:47881", "172.17.0.1:47881"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:56:43.232495172Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6197061833183856,
+				"StableID":   "njWiMkJfPq11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:672e03a11542fa0a6a3ab0fd01e92d8d0cda6327e29291bdd1c9e107377b7f3e",
+				"DiscoKey":   "discokey:aab45f5222fec5a45e511491258bda2443038be1d2873557f3b5922a00fba04e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57047", "10.65.0.27:57047", "172.17.0.1:57047"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:56:43.766280602Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3609737328847972,
+				"StableID":   "nqXZnMgrBV11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83c60d89b6fe62a54be43f4af9d8a53b75d7e68d6e59a2a688b2359d40c1d51d",
+				"DiscoKey":   "discokey:999258f1861d640280c7064b322610cfe262055fc42fd34d2b6ca53b6f37c128",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59383", "10.65.0.27:59383", "172.17.0.1:59383"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:56:44.310386715Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3280894969718241,
+				"StableID":   "nW1UakYvcS11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35ef232ffb2de15ec88ab100a2bfeb284dbf74be4b9f98bae1a21d8117f62212",
+				"DiscoKey":   "discokey:c6d5105154b59b4cb01fc26c599fb53280ac80bb9c1467f1c1341c00874cd82b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:49333", "10.65.0.27:49333", "172.17.0.1:49333"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:56:44.855443956Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8469822311997169,
+				"StableID":   "nzhhATsz8921CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c085b4af66b3aeffe1b1af5667b97e761d42c2c90a7ca746c3e8ed7c283df232",
+				"DiscoKey":   "discokey:d453ebf750661733027eb4e6eb47fa1b1bfee9c9ab74718d5d9cd065ab3c342e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:55630", "10.65.0.27:55630", "172.17.0.1:55630"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:56:45.398858419Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8710528569918882,
+				"StableID":   "nwjMvGp12B21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d35b556ae2bcb8330c1c318d96f3614f075573dffe44b3f929100f761232f46b",
+				"KeyExpiry":  "2026-11-08T18:56:45Z",
+				"DiscoKey":   "discokey:79169f1629964b873fb2123834e5bcd556654464df7aa725324c77d68e949614",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:37650", "10.65.0.27:37650", "172.17.0.1:37650"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:56:45.938463432Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2696553646490874,
+				"StableID":   "nfVvpitG4N11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ccc45abf8bef1e9d2e1a5147ca76e36ef66a9f5d34ebf0e2cd1315fdd9bc1762",
+				"KeyExpiry":  "2026-11-08T18:56:46Z",
+				"DiscoKey":   "discokey:59623d2f79997f011a5c0ff6d6944bd43f67c256e254839dd3b9f9512d59f967",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:48500", "10.65.0.27:48500", "172.17.0.1:48500"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:56:46.483877479Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5424390421852946,
+				"StableID":   "n3ZMdDYiMj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f3e21bafd26c807da8c7ddb68628a06f59ba0f58034d086d3820f0f56fdc5c11",
+				"KeyExpiry":  "2026-11-08T18:56:47Z",
+				"DiscoKey":   "discokey:ba309c3cf8b0cf5c21e7dfde594b26f2f1ace39fb754a0e035236f6486a29b42",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:52233", "10.65.0.27:52233", "172.17.0.1:52233"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:56:47.027196914Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "4574845337037595": {
+				"ID":          4574845337037595,
+				"LoginName":   "charmander.tail78f774.ts.net",
+				"DisplayName": "charmander"
+			}}
+		}
+	}, "fearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6023756866091993,
+				"StableID":   "n6VUswsA3p11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       6023756866091993,
+				"Key":        "nodekey:b1f3917fbb107fd9bb950dca72d8e96d1a4732cc31ee971e25645e91e3be930f",
+				"DiscoKey":   "discokey:95b6dede8210e54b25eb7218a64371c4e2adf5b41efe7b954a00278ca5955176",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:47881", "10.65.0.27:47881", "172.17.0.1:47881"],
+				"Hostinfo": {
+					"Hostname":    "fearow",
+					"RoutableIPs": ["10.55.0.0/16"],
+					"RequestTags": ["tag:fearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 39161},
+						{"Proto": "peerapi6", "Port": 39161},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:56:43.232495172Z",
+				"Tags":              ["tag:fearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:b1f3917fbb107fd9bb950dca72d8e96d1a4732cc31ee971e25645e91e3be930f",
+			"MachineKey": "mkey:4833053c7259540c0f91cb722058b533117e71822b4bb2d5ec215ac5599ca066",
+			"Peers": [{
+				"ID":         3302763550688450,
+				"StableID":   "nsX8CtzpnS11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:483cc9dd06471e98b3c2ba341f914133cbcdf9da37afd3036534e736133fcd51",
+				"DiscoKey":   "discokey:09b54ed35673329fe55a14d64c99b458fd66501f9b6d746af74b15f36d07c527",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:57830", "10.65.0.27:57830", "172.17.0.1:57830"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:56:39.448002312Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8983340446595960,
+				"StableID":   "nTnAGz7a9D21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdbfb180fe9b0a28b4d6bb337796c478c1cdd7c3a4bd9235cce8ed291ac3f178",
+				"DiscoKey":   "discokey:744cb082c4f2bbc4760a898e334652c5f09536f89cb0637758f0f500ad598c14",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:39965", "10.65.0.27:39965", "172.17.0.1:39965"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:56:39.977417102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4574845337037595,
+				"StableID":   "nWEWcuRxic11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0cc0597d5c1c0106ae516d9de0a4bd4dde38f373db384084b96b13b38161254d",
+				"DiscoKey":   "discokey:395270cfebf94a3afdb2063543435c1272ed8bc6a7ecf30120e413946b80e516",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:52825", "10.65.0.27:52825", "172.17.0.1:52825"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:56:40.511090494Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5143573950832586,
+				"StableID":   "nZ8Eh1yXAh11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:34fc6b4a55e81b81c49843fa5682cc263d94e6fe767560892d3ee1177df9535e",
+				"DiscoKey":   "discokey:bf492cd12f31675477e8238d4a0b16ad71ce83d6549e696b44edb5d9a38b464f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:58696", "10.65.0.27:58696", "172.17.0.1:58696"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:56:41.05713905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1602861061893332,
+				"StableID":   "n36PJeSwWD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4171affbb592d976955e324a8d9f76684607cda4f0ef9c3de8824c2ae76a06b",
+				"DiscoKey":   "discokey:aa732a139c3b0d4cf4aeb228091f93946695f2cd538d1b56b76f9141ef6f780a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:45913", "10.65.0.27:45913", "172.17.0.1:45913"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:56:41.595068864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2043994585938075,
+				"StableID":   "naQGEmGjxG11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ff126a4720c78b7c123660aff9e48ca8b34b3b1fbce6ef51e9464f0b8406202",
+				"DiscoKey":   "discokey:4e803675e31ed070602ff749c86243570aeea836549a82ea4b8f8061c7aa4752",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:34046", "10.65.0.27:34046", "172.17.0.1:34046"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:56:42.141887485Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4293716256204730,
+				"StableID":   "nViNRRedXa11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7659f801c7d36a1331b4ab6450e6a8af5c7e8fe0a1726fe336ba4bdf2feec801",
+				"DiscoKey":   "discokey:fac5b3b492c8b0eb9991dd1f54f7bc8cdd4410c21d920618eca2b7a9e7bc4d2b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:49654", "10.65.0.27:49654", "172.17.0.1:49654"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:56:42.685656154Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6197061833183856,
+				"StableID":   "njWiMkJfPq11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:672e03a11542fa0a6a3ab0fd01e92d8d0cda6327e29291bdd1c9e107377b7f3e",
+				"DiscoKey":   "discokey:aab45f5222fec5a45e511491258bda2443038be1d2873557f3b5922a00fba04e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57047", "10.65.0.27:57047", "172.17.0.1:57047"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:56:43.766280602Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3609737328847972,
+				"StableID":   "nqXZnMgrBV11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83c60d89b6fe62a54be43f4af9d8a53b75d7e68d6e59a2a688b2359d40c1d51d",
+				"DiscoKey":   "discokey:999258f1861d640280c7064b322610cfe262055fc42fd34d2b6ca53b6f37c128",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59383", "10.65.0.27:59383", "172.17.0.1:59383"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:56:44.310386715Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3280894969718241,
+				"StableID":   "nW1UakYvcS11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35ef232ffb2de15ec88ab100a2bfeb284dbf74be4b9f98bae1a21d8117f62212",
+				"DiscoKey":   "discokey:c6d5105154b59b4cb01fc26c599fb53280ac80bb9c1467f1c1341c00874cd82b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:49333", "10.65.0.27:49333", "172.17.0.1:49333"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:56:44.855443956Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8469822311997169,
+				"StableID":   "nzhhATsz8921CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c085b4af66b3aeffe1b1af5667b97e761d42c2c90a7ca746c3e8ed7c283df232",
+				"DiscoKey":   "discokey:d453ebf750661733027eb4e6eb47fa1b1bfee9c9ab74718d5d9cd065ab3c342e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:55630", "10.65.0.27:55630", "172.17.0.1:55630"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:56:45.398858419Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8710528569918882,
+				"StableID":   "nwjMvGp12B21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d35b556ae2bcb8330c1c318d96f3614f075573dffe44b3f929100f761232f46b",
+				"KeyExpiry":  "2026-11-08T18:56:45Z",
+				"DiscoKey":   "discokey:79169f1629964b873fb2123834e5bcd556654464df7aa725324c77d68e949614",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:37650", "10.65.0.27:37650", "172.17.0.1:37650"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:56:45.938463432Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2696553646490874,
+				"StableID":   "nfVvpitG4N11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ccc45abf8bef1e9d2e1a5147ca76e36ef66a9f5d34ebf0e2cd1315fdd9bc1762",
+				"KeyExpiry":  "2026-11-08T18:56:46Z",
+				"DiscoKey":   "discokey:59623d2f79997f011a5c0ff6d6944bd43f67c256e254839dd3b9f9512d59f967",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:48500", "10.65.0.27:48500", "172.17.0.1:48500"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:56:46.483877479Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5424390421852946,
+				"StableID":   "n3ZMdDYiMj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f3e21bafd26c807da8c7ddb68628a06f59ba0f58034d086d3820f0f56fdc5c11",
+				"KeyExpiry":  "2026-11-08T18:56:47Z",
+				"DiscoKey":   "discokey:ba309c3cf8b0cf5c21e7dfde594b26f2f1ace39fb754a0e035236f6486a29b42",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:52233", "10.65.0.27:52233", "172.17.0.1:52233"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:56:47.027196914Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6023756866091993": {
+				"ID":          6023756866091993,
+				"LoginName":   "fearow.tail78f774.ts.net",
+				"DisplayName": "fearow"
+			}}
+		}
+	}, "ivysaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8710528569918882,
+				"StableID":   "nwjMvGp12B21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d35b556ae2bcb8330c1c318d96f3614f075573dffe44b3f929100f761232f46b",
+				"KeyExpiry":  "2026-11-08T18:56:45Z",
+				"DiscoKey":   "discokey:79169f1629964b873fb2123834e5bcd556654464df7aa725324c77d68e949614",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:37650", "10.65.0.27:37650", "172.17.0.1:37650"],
+				"Hostinfo": {"Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:56:45.938463432Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:d35b556ae2bcb8330c1c318d96f3614f075573dffe44b3f929100f761232f46b",
+			"MachineKey": "mkey:4638760b5f1d545835b4d099ba654e6abbd1f3f14b7144e302bf28ce3033cd13",
+			"Peers": [{
+				"ID":         3302763550688450,
+				"StableID":   "nsX8CtzpnS11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:483cc9dd06471e98b3c2ba341f914133cbcdf9da37afd3036534e736133fcd51",
+				"DiscoKey":   "discokey:09b54ed35673329fe55a14d64c99b458fd66501f9b6d746af74b15f36d07c527",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:57830", "10.65.0.27:57830", "172.17.0.1:57830"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:56:39.448002312Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8983340446595960,
+				"StableID":   "nTnAGz7a9D21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdbfb180fe9b0a28b4d6bb337796c478c1cdd7c3a4bd9235cce8ed291ac3f178",
+				"DiscoKey":   "discokey:744cb082c4f2bbc4760a898e334652c5f09536f89cb0637758f0f500ad598c14",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:39965", "10.65.0.27:39965", "172.17.0.1:39965"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:56:39.977417102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4574845337037595,
+				"StableID":   "nWEWcuRxic11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0cc0597d5c1c0106ae516d9de0a4bd4dde38f373db384084b96b13b38161254d",
+				"DiscoKey":   "discokey:395270cfebf94a3afdb2063543435c1272ed8bc6a7ecf30120e413946b80e516",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:52825", "10.65.0.27:52825", "172.17.0.1:52825"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:56:40.511090494Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5143573950832586,
+				"StableID":   "nZ8Eh1yXAh11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:34fc6b4a55e81b81c49843fa5682cc263d94e6fe767560892d3ee1177df9535e",
+				"DiscoKey":   "discokey:bf492cd12f31675477e8238d4a0b16ad71ce83d6549e696b44edb5d9a38b464f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:58696", "10.65.0.27:58696", "172.17.0.1:58696"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:56:41.05713905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1602861061893332,
+				"StableID":   "n36PJeSwWD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4171affbb592d976955e324a8d9f76684607cda4f0ef9c3de8824c2ae76a06b",
+				"DiscoKey":   "discokey:aa732a139c3b0d4cf4aeb228091f93946695f2cd538d1b56b76f9141ef6f780a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:45913", "10.65.0.27:45913", "172.17.0.1:45913"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:56:41.595068864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2043994585938075,
+				"StableID":   "naQGEmGjxG11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ff126a4720c78b7c123660aff9e48ca8b34b3b1fbce6ef51e9464f0b8406202",
+				"DiscoKey":   "discokey:4e803675e31ed070602ff749c86243570aeea836549a82ea4b8f8061c7aa4752",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:34046", "10.65.0.27:34046", "172.17.0.1:34046"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:56:42.141887485Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4293716256204730,
+				"StableID":   "nViNRRedXa11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7659f801c7d36a1331b4ab6450e6a8af5c7e8fe0a1726fe336ba4bdf2feec801",
+				"DiscoKey":   "discokey:fac5b3b492c8b0eb9991dd1f54f7bc8cdd4410c21d920618eca2b7a9e7bc4d2b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:49654", "10.65.0.27:49654", "172.17.0.1:49654"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:56:42.685656154Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6023756866091993,
+				"StableID":   "n6VUswsA3p11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b1f3917fbb107fd9bb950dca72d8e96d1a4732cc31ee971e25645e91e3be930f",
+				"DiscoKey":   "discokey:95b6dede8210e54b25eb7218a64371c4e2adf5b41efe7b954a00278ca5955176",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:47881", "10.65.0.27:47881", "172.17.0.1:47881"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:56:43.232495172Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6197061833183856,
+				"StableID":   "njWiMkJfPq11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:672e03a11542fa0a6a3ab0fd01e92d8d0cda6327e29291bdd1c9e107377b7f3e",
+				"DiscoKey":   "discokey:aab45f5222fec5a45e511491258bda2443038be1d2873557f3b5922a00fba04e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57047", "10.65.0.27:57047", "172.17.0.1:57047"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:56:43.766280602Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3609737328847972,
+				"StableID":   "nqXZnMgrBV11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83c60d89b6fe62a54be43f4af9d8a53b75d7e68d6e59a2a688b2359d40c1d51d",
+				"DiscoKey":   "discokey:999258f1861d640280c7064b322610cfe262055fc42fd34d2b6ca53b6f37c128",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59383", "10.65.0.27:59383", "172.17.0.1:59383"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:56:44.310386715Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3280894969718241,
+				"StableID":   "nW1UakYvcS11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35ef232ffb2de15ec88ab100a2bfeb284dbf74be4b9f98bae1a21d8117f62212",
+				"DiscoKey":   "discokey:c6d5105154b59b4cb01fc26c599fb53280ac80bb9c1467f1c1341c00874cd82b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:49333", "10.65.0.27:49333", "172.17.0.1:49333"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:56:44.855443956Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8469822311997169,
+				"StableID":   "nzhhATsz8921CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c085b4af66b3aeffe1b1af5667b97e761d42c2c90a7ca746c3e8ed7c283df232",
+				"DiscoKey":   "discokey:d453ebf750661733027eb4e6eb47fa1b1bfee9c9ab74718d5d9cd065ab3c342e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:55630", "10.65.0.27:55630", "172.17.0.1:55630"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:56:45.398858419Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         2696553646490874,
+				"StableID":   "nfVvpitG4N11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ccc45abf8bef1e9d2e1a5147ca76e36ef66a9f5d34ebf0e2cd1315fdd9bc1762",
+				"KeyExpiry":  "2026-11-08T18:56:46Z",
+				"DiscoKey":   "discokey:59623d2f79997f011a5c0ff6d6944bd43f67c256e254839dd3b9f9512d59f967",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:48500", "10.65.0.27:48500", "172.17.0.1:48500"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:56:46.483877479Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5424390421852946,
+				"StableID":   "n3ZMdDYiMj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f3e21bafd26c807da8c7ddb68628a06f59ba0f58034d086d3820f0f56fdc5c11",
+				"KeyExpiry":  "2026-11-08T18:56:47Z",
+				"DiscoKey":   "discokey:ba309c3cf8b0cf5c21e7dfde594b26f2f1ace39fb754a0e035236f6486a29b42",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:52233", "10.65.0.27:52233", "172.17.0.1:52233"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:56:47.027196914Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "kakuna": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3280894969718241,
+				"StableID":   "nW1UakYvcS11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       3280894969718241,
+				"Key":        "nodekey:35ef232ffb2de15ec88ab100a2bfeb284dbf74be4b9f98bae1a21d8117f62212",
+				"DiscoKey":   "discokey:c6d5105154b59b4cb01fc26c599fb53280ac80bb9c1467f1c1341c00874cd82b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:49333", "10.65.0.27:49333", "172.17.0.1:49333"],
+				"Hostinfo": {"Hostname": "kakuna", "RequestTags": ["tag:prod"], "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:56:44.855443956Z",
+				"Tags":              ["tag:prod"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:35ef232ffb2de15ec88ab100a2bfeb284dbf74be4b9f98bae1a21d8117f62212",
+			"MachineKey": "mkey:f7c9da101340b692e8cb5c06defb1033b3b6c9033f31d53cd9395fb618c4435d",
+			"Peers": [{
+				"ID":         3302763550688450,
+				"StableID":   "nsX8CtzpnS11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:483cc9dd06471e98b3c2ba341f914133cbcdf9da37afd3036534e736133fcd51",
+				"DiscoKey":   "discokey:09b54ed35673329fe55a14d64c99b458fd66501f9b6d746af74b15f36d07c527",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:57830", "10.65.0.27:57830", "172.17.0.1:57830"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:56:39.448002312Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8983340446595960,
+				"StableID":   "nTnAGz7a9D21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdbfb180fe9b0a28b4d6bb337796c478c1cdd7c3a4bd9235cce8ed291ac3f178",
+				"DiscoKey":   "discokey:744cb082c4f2bbc4760a898e334652c5f09536f89cb0637758f0f500ad598c14",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:39965", "10.65.0.27:39965", "172.17.0.1:39965"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:56:39.977417102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4574845337037595,
+				"StableID":   "nWEWcuRxic11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0cc0597d5c1c0106ae516d9de0a4bd4dde38f373db384084b96b13b38161254d",
+				"DiscoKey":   "discokey:395270cfebf94a3afdb2063543435c1272ed8bc6a7ecf30120e413946b80e516",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:52825", "10.65.0.27:52825", "172.17.0.1:52825"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:56:40.511090494Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5143573950832586,
+				"StableID":   "nZ8Eh1yXAh11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:34fc6b4a55e81b81c49843fa5682cc263d94e6fe767560892d3ee1177df9535e",
+				"DiscoKey":   "discokey:bf492cd12f31675477e8238d4a0b16ad71ce83d6549e696b44edb5d9a38b464f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:58696", "10.65.0.27:58696", "172.17.0.1:58696"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:56:41.05713905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1602861061893332,
+				"StableID":   "n36PJeSwWD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4171affbb592d976955e324a8d9f76684607cda4f0ef9c3de8824c2ae76a06b",
+				"DiscoKey":   "discokey:aa732a139c3b0d4cf4aeb228091f93946695f2cd538d1b56b76f9141ef6f780a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:45913", "10.65.0.27:45913", "172.17.0.1:45913"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:56:41.595068864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2043994585938075,
+				"StableID":   "naQGEmGjxG11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ff126a4720c78b7c123660aff9e48ca8b34b3b1fbce6ef51e9464f0b8406202",
+				"DiscoKey":   "discokey:4e803675e31ed070602ff749c86243570aeea836549a82ea4b8f8061c7aa4752",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:34046", "10.65.0.27:34046", "172.17.0.1:34046"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:56:42.141887485Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4293716256204730,
+				"StableID":   "nViNRRedXa11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7659f801c7d36a1331b4ab6450e6a8af5c7e8fe0a1726fe336ba4bdf2feec801",
+				"DiscoKey":   "discokey:fac5b3b492c8b0eb9991dd1f54f7bc8cdd4410c21d920618eca2b7a9e7bc4d2b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:49654", "10.65.0.27:49654", "172.17.0.1:49654"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:56:42.685656154Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6023756866091993,
+				"StableID":   "n6VUswsA3p11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b1f3917fbb107fd9bb950dca72d8e96d1a4732cc31ee971e25645e91e3be930f",
+				"DiscoKey":   "discokey:95b6dede8210e54b25eb7218a64371c4e2adf5b41efe7b954a00278ca5955176",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:47881", "10.65.0.27:47881", "172.17.0.1:47881"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:56:43.232495172Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6197061833183856,
+				"StableID":   "njWiMkJfPq11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:672e03a11542fa0a6a3ab0fd01e92d8d0cda6327e29291bdd1c9e107377b7f3e",
+				"DiscoKey":   "discokey:aab45f5222fec5a45e511491258bda2443038be1d2873557f3b5922a00fba04e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57047", "10.65.0.27:57047", "172.17.0.1:57047"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:56:43.766280602Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3609737328847972,
+				"StableID":   "nqXZnMgrBV11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83c60d89b6fe62a54be43f4af9d8a53b75d7e68d6e59a2a688b2359d40c1d51d",
+				"DiscoKey":   "discokey:999258f1861d640280c7064b322610cfe262055fc42fd34d2b6ca53b6f37c128",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59383", "10.65.0.27:59383", "172.17.0.1:59383"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:56:44.310386715Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         8469822311997169,
+				"StableID":   "nzhhATsz8921CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c085b4af66b3aeffe1b1af5667b97e761d42c2c90a7ca746c3e8ed7c283df232",
+				"DiscoKey":   "discokey:d453ebf750661733027eb4e6eb47fa1b1bfee9c9ab74718d5d9cd065ab3c342e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:55630", "10.65.0.27:55630", "172.17.0.1:55630"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:56:45.398858419Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8710528569918882,
+				"StableID":   "nwjMvGp12B21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d35b556ae2bcb8330c1c318d96f3614f075573dffe44b3f929100f761232f46b",
+				"KeyExpiry":  "2026-11-08T18:56:45Z",
+				"DiscoKey":   "discokey:79169f1629964b873fb2123834e5bcd556654464df7aa725324c77d68e949614",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:37650", "10.65.0.27:37650", "172.17.0.1:37650"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:56:45.938463432Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2696553646490874,
+				"StableID":   "nfVvpitG4N11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ccc45abf8bef1e9d2e1a5147ca76e36ef66a9f5d34ebf0e2cd1315fdd9bc1762",
+				"KeyExpiry":  "2026-11-08T18:56:46Z",
+				"DiscoKey":   "discokey:59623d2f79997f011a5c0ff6d6944bd43f67c256e254839dd3b9f9512d59f967",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:48500", "10.65.0.27:48500", "172.17.0.1:48500"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:56:46.483877479Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5424390421852946,
+				"StableID":   "n3ZMdDYiMj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f3e21bafd26c807da8c7ddb68628a06f59ba0f58034d086d3820f0f56fdc5c11",
+				"KeyExpiry":  "2026-11-08T18:56:47Z",
+				"DiscoKey":   "discokey:ba309c3cf8b0cf5c21e7dfde594b26f2f1ace39fb754a0e035236f6486a29b42",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:52233", "10.65.0.27:52233", "172.17.0.1:52233"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:56:47.027196914Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3280894969718241": {
+				"ID":          3280894969718241,
+				"LoginName":   "kakuna.tail78f774.ts.net",
+				"DisplayName": "kakuna"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "pidgeotto": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         8983340446595960,
+				"StableID":   "nTnAGz7a9D21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       8983340446595960,
+				"Key":        "nodekey:cdbfb180fe9b0a28b4d6bb337796c478c1cdd7c3a4bd9235cce8ed291ac3f178",
+				"DiscoKey":   "discokey:744cb082c4f2bbc4760a898e334652c5f09536f89cb0637758f0f500ad598c14",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:39965", "10.65.0.27:39965", "172.17.0.1:39965"],
+				"Hostinfo": {
+					"Hostname":    "pidgeotto",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgeotto"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 34152},
+						{"Proto": "peerapi6", "Port": 34152},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:56:39.977417102Z",
+				"Tags":              ["tag:pidgeotto"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:cdbfb180fe9b0a28b4d6bb337796c478c1cdd7c3a4bd9235cce8ed291ac3f178",
+			"MachineKey": "mkey:477556a8b25dfb70a5d1f9ef9b90665b685fc27009ccb54bfa774792988ac562",
+			"Peers": [{
+				"ID":         3302763550688450,
+				"StableID":   "nsX8CtzpnS11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:483cc9dd06471e98b3c2ba341f914133cbcdf9da37afd3036534e736133fcd51",
+				"DiscoKey":   "discokey:09b54ed35673329fe55a14d64c99b458fd66501f9b6d746af74b15f36d07c527",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:57830", "10.65.0.27:57830", "172.17.0.1:57830"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:56:39.448002312Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         4574845337037595,
+				"StableID":   "nWEWcuRxic11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0cc0597d5c1c0106ae516d9de0a4bd4dde38f373db384084b96b13b38161254d",
+				"DiscoKey":   "discokey:395270cfebf94a3afdb2063543435c1272ed8bc6a7ecf30120e413946b80e516",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:52825", "10.65.0.27:52825", "172.17.0.1:52825"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:56:40.511090494Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5143573950832586,
+				"StableID":   "nZ8Eh1yXAh11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:34fc6b4a55e81b81c49843fa5682cc263d94e6fe767560892d3ee1177df9535e",
+				"DiscoKey":   "discokey:bf492cd12f31675477e8238d4a0b16ad71ce83d6549e696b44edb5d9a38b464f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:58696", "10.65.0.27:58696", "172.17.0.1:58696"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:56:41.05713905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1602861061893332,
+				"StableID":   "n36PJeSwWD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4171affbb592d976955e324a8d9f76684607cda4f0ef9c3de8824c2ae76a06b",
+				"DiscoKey":   "discokey:aa732a139c3b0d4cf4aeb228091f93946695f2cd538d1b56b76f9141ef6f780a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:45913", "10.65.0.27:45913", "172.17.0.1:45913"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:56:41.595068864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2043994585938075,
+				"StableID":   "naQGEmGjxG11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ff126a4720c78b7c123660aff9e48ca8b34b3b1fbce6ef51e9464f0b8406202",
+				"DiscoKey":   "discokey:4e803675e31ed070602ff749c86243570aeea836549a82ea4b8f8061c7aa4752",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:34046", "10.65.0.27:34046", "172.17.0.1:34046"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:56:42.141887485Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4293716256204730,
+				"StableID":   "nViNRRedXa11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7659f801c7d36a1331b4ab6450e6a8af5c7e8fe0a1726fe336ba4bdf2feec801",
+				"DiscoKey":   "discokey:fac5b3b492c8b0eb9991dd1f54f7bc8cdd4410c21d920618eca2b7a9e7bc4d2b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:49654", "10.65.0.27:49654", "172.17.0.1:49654"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:56:42.685656154Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6023756866091993,
+				"StableID":   "n6VUswsA3p11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b1f3917fbb107fd9bb950dca72d8e96d1a4732cc31ee971e25645e91e3be930f",
+				"DiscoKey":   "discokey:95b6dede8210e54b25eb7218a64371c4e2adf5b41efe7b954a00278ca5955176",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:47881", "10.65.0.27:47881", "172.17.0.1:47881"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:56:43.232495172Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6197061833183856,
+				"StableID":   "njWiMkJfPq11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:672e03a11542fa0a6a3ab0fd01e92d8d0cda6327e29291bdd1c9e107377b7f3e",
+				"DiscoKey":   "discokey:aab45f5222fec5a45e511491258bda2443038be1d2873557f3b5922a00fba04e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57047", "10.65.0.27:57047", "172.17.0.1:57047"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:56:43.766280602Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3609737328847972,
+				"StableID":   "nqXZnMgrBV11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83c60d89b6fe62a54be43f4af9d8a53b75d7e68d6e59a2a688b2359d40c1d51d",
+				"DiscoKey":   "discokey:999258f1861d640280c7064b322610cfe262055fc42fd34d2b6ca53b6f37c128",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59383", "10.65.0.27:59383", "172.17.0.1:59383"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:56:44.310386715Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3280894969718241,
+				"StableID":   "nW1UakYvcS11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35ef232ffb2de15ec88ab100a2bfeb284dbf74be4b9f98bae1a21d8117f62212",
+				"DiscoKey":   "discokey:c6d5105154b59b4cb01fc26c599fb53280ac80bb9c1467f1c1341c00874cd82b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:49333", "10.65.0.27:49333", "172.17.0.1:49333"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:56:44.855443956Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8469822311997169,
+				"StableID":   "nzhhATsz8921CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c085b4af66b3aeffe1b1af5667b97e761d42c2c90a7ca746c3e8ed7c283df232",
+				"DiscoKey":   "discokey:d453ebf750661733027eb4e6eb47fa1b1bfee9c9ab74718d5d9cd065ab3c342e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:55630", "10.65.0.27:55630", "172.17.0.1:55630"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:56:45.398858419Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8710528569918882,
+				"StableID":   "nwjMvGp12B21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d35b556ae2bcb8330c1c318d96f3614f075573dffe44b3f929100f761232f46b",
+				"KeyExpiry":  "2026-11-08T18:56:45Z",
+				"DiscoKey":   "discokey:79169f1629964b873fb2123834e5bcd556654464df7aa725324c77d68e949614",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:37650", "10.65.0.27:37650", "172.17.0.1:37650"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:56:45.938463432Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2696553646490874,
+				"StableID":   "nfVvpitG4N11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ccc45abf8bef1e9d2e1a5147ca76e36ef66a9f5d34ebf0e2cd1315fdd9bc1762",
+				"KeyExpiry":  "2026-11-08T18:56:46Z",
+				"DiscoKey":   "discokey:59623d2f79997f011a5c0ff6d6944bd43f67c256e254839dd3b9f9512d59f967",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:48500", "10.65.0.27:48500", "172.17.0.1:48500"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:56:46.483877479Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5424390421852946,
+				"StableID":   "n3ZMdDYiMj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f3e21bafd26c807da8c7ddb68628a06f59ba0f58034d086d3820f0f56fdc5c11",
+				"KeyExpiry":  "2026-11-08T18:56:47Z",
+				"DiscoKey":   "discokey:ba309c3cf8b0cf5c21e7dfde594b26f2f1ace39fb754a0e035236f6486a29b42",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:52233", "10.65.0.27:52233", "172.17.0.1:52233"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:56:47.027196914Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "8983340446595960": {
+				"ID":          8983340446595960,
+				"LoginName":   "pidgeotto.tail78f774.ts.net",
+				"DisplayName": "pidgeotto"
+			}}
+		}
+	}, "pidgey": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3302763550688450,
+				"StableID":   "nsX8CtzpnS11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       3302763550688450,
+				"Key":        "nodekey:483cc9dd06471e98b3c2ba341f914133cbcdf9da37afd3036534e736133fcd51",
+				"DiscoKey":   "discokey:09b54ed35673329fe55a14d64c99b458fd66501f9b6d746af74b15f36d07c527",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:57830", "10.65.0.27:57830", "172.17.0.1:57830"],
+				"Hostinfo": {
+					"Hostname":    "pidgey",
+					"RoutableIPs": ["0.0.0.0/0", "::/0"],
+					"RequestTags": ["tag:pidgey"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 46590},
+						{"Proto": "peerapi6", "Port": 46590},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:56:39.448002312Z",
+				"Tags":              ["tag:pidgey"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:483cc9dd06471e98b3c2ba341f914133cbcdf9da37afd3036534e736133fcd51",
+			"MachineKey": "mkey:ca8ce9a7777648a92a9012dd38c2d617597e9c8ec680f31dee7c65ba5043075e",
+			"Peers": [{
+				"ID":         8983340446595960,
+				"StableID":   "nTnAGz7a9D21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdbfb180fe9b0a28b4d6bb337796c478c1cdd7c3a4bd9235cce8ed291ac3f178",
+				"DiscoKey":   "discokey:744cb082c4f2bbc4760a898e334652c5f09536f89cb0637758f0f500ad598c14",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:39965", "10.65.0.27:39965", "172.17.0.1:39965"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:56:39.977417102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4574845337037595,
+				"StableID":   "nWEWcuRxic11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0cc0597d5c1c0106ae516d9de0a4bd4dde38f373db384084b96b13b38161254d",
+				"DiscoKey":   "discokey:395270cfebf94a3afdb2063543435c1272ed8bc6a7ecf30120e413946b80e516",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:52825", "10.65.0.27:52825", "172.17.0.1:52825"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:56:40.511090494Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5143573950832586,
+				"StableID":   "nZ8Eh1yXAh11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:34fc6b4a55e81b81c49843fa5682cc263d94e6fe767560892d3ee1177df9535e",
+				"DiscoKey":   "discokey:bf492cd12f31675477e8238d4a0b16ad71ce83d6549e696b44edb5d9a38b464f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:58696", "10.65.0.27:58696", "172.17.0.1:58696"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:56:41.05713905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1602861061893332,
+				"StableID":   "n36PJeSwWD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4171affbb592d976955e324a8d9f76684607cda4f0ef9c3de8824c2ae76a06b",
+				"DiscoKey":   "discokey:aa732a139c3b0d4cf4aeb228091f93946695f2cd538d1b56b76f9141ef6f780a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:45913", "10.65.0.27:45913", "172.17.0.1:45913"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:56:41.595068864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2043994585938075,
+				"StableID":   "naQGEmGjxG11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ff126a4720c78b7c123660aff9e48ca8b34b3b1fbce6ef51e9464f0b8406202",
+				"DiscoKey":   "discokey:4e803675e31ed070602ff749c86243570aeea836549a82ea4b8f8061c7aa4752",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:34046", "10.65.0.27:34046", "172.17.0.1:34046"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:56:42.141887485Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4293716256204730,
+				"StableID":   "nViNRRedXa11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7659f801c7d36a1331b4ab6450e6a8af5c7e8fe0a1726fe336ba4bdf2feec801",
+				"DiscoKey":   "discokey:fac5b3b492c8b0eb9991dd1f54f7bc8cdd4410c21d920618eca2b7a9e7bc4d2b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:49654", "10.65.0.27:49654", "172.17.0.1:49654"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:56:42.685656154Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6023756866091993,
+				"StableID":   "n6VUswsA3p11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b1f3917fbb107fd9bb950dca72d8e96d1a4732cc31ee971e25645e91e3be930f",
+				"DiscoKey":   "discokey:95b6dede8210e54b25eb7218a64371c4e2adf5b41efe7b954a00278ca5955176",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:47881", "10.65.0.27:47881", "172.17.0.1:47881"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:56:43.232495172Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6197061833183856,
+				"StableID":   "njWiMkJfPq11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:672e03a11542fa0a6a3ab0fd01e92d8d0cda6327e29291bdd1c9e107377b7f3e",
+				"DiscoKey":   "discokey:aab45f5222fec5a45e511491258bda2443038be1d2873557f3b5922a00fba04e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57047", "10.65.0.27:57047", "172.17.0.1:57047"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:56:43.766280602Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3609737328847972,
+				"StableID":   "nqXZnMgrBV11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83c60d89b6fe62a54be43f4af9d8a53b75d7e68d6e59a2a688b2359d40c1d51d",
+				"DiscoKey":   "discokey:999258f1861d640280c7064b322610cfe262055fc42fd34d2b6ca53b6f37c128",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59383", "10.65.0.27:59383", "172.17.0.1:59383"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:56:44.310386715Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3280894969718241,
+				"StableID":   "nW1UakYvcS11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35ef232ffb2de15ec88ab100a2bfeb284dbf74be4b9f98bae1a21d8117f62212",
+				"DiscoKey":   "discokey:c6d5105154b59b4cb01fc26c599fb53280ac80bb9c1467f1c1341c00874cd82b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:49333", "10.65.0.27:49333", "172.17.0.1:49333"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:56:44.855443956Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8469822311997169,
+				"StableID":   "nzhhATsz8921CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c085b4af66b3aeffe1b1af5667b97e761d42c2c90a7ca746c3e8ed7c283df232",
+				"DiscoKey":   "discokey:d453ebf750661733027eb4e6eb47fa1b1bfee9c9ab74718d5d9cd065ab3c342e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:55630", "10.65.0.27:55630", "172.17.0.1:55630"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:56:45.398858419Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8710528569918882,
+				"StableID":   "nwjMvGp12B21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d35b556ae2bcb8330c1c318d96f3614f075573dffe44b3f929100f761232f46b",
+				"KeyExpiry":  "2026-11-08T18:56:45Z",
+				"DiscoKey":   "discokey:79169f1629964b873fb2123834e5bcd556654464df7aa725324c77d68e949614",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:37650", "10.65.0.27:37650", "172.17.0.1:37650"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:56:45.938463432Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2696553646490874,
+				"StableID":   "nfVvpitG4N11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ccc45abf8bef1e9d2e1a5147ca76e36ef66a9f5d34ebf0e2cd1315fdd9bc1762",
+				"KeyExpiry":  "2026-11-08T18:56:46Z",
+				"DiscoKey":   "discokey:59623d2f79997f011a5c0ff6d6944bd43f67c256e254839dd3b9f9512d59f967",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:48500", "10.65.0.27:48500", "172.17.0.1:48500"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:56:46.483877479Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5424390421852946,
+				"StableID":   "n3ZMdDYiMj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f3e21bafd26c807da8c7ddb68628a06f59ba0f58034d086d3820f0f56fdc5c11",
+				"KeyExpiry":  "2026-11-08T18:56:47Z",
+				"DiscoKey":   "discokey:ba309c3cf8b0cf5c21e7dfde594b26f2f1ace39fb754a0e035236f6486a29b42",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:52233", "10.65.0.27:52233", "172.17.0.1:52233"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:56:47.027196914Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3302763550688450": {
+				"ID":          3302763550688450,
+				"LoginName":   "pidgey.tail78f774.ts.net",
+				"DisplayName": "pidgey"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "raticate": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         1602861061893332,
+				"StableID":   "n36PJeSwWD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1602861061893332,
+				"Key":        "nodekey:e4171affbb592d976955e324a8d9f76684607cda4f0ef9c3de8824c2ae76a06b",
+				"DiscoKey":   "discokey:aa732a139c3b0d4cf4aeb228091f93946695f2cd538d1b56b76f9141ef6f780a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:45913", "10.65.0.27:45913", "172.17.0.1:45913"],
+				"Hostinfo": {"Hostname": "raticate", "RequestTags": ["tag:group-b"], "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:56:41.595068864Z",
+				"Tags":              ["tag:group-b"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:e4171affbb592d976955e324a8d9f76684607cda4f0ef9c3de8824c2ae76a06b",
+			"MachineKey": "mkey:1dd8e06ff2639f5cde66f08066e071318c262301f762117aa1d790ed32b1e510",
+			"Peers": [{
+				"ID":         3302763550688450,
+				"StableID":   "nsX8CtzpnS11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:483cc9dd06471e98b3c2ba341f914133cbcdf9da37afd3036534e736133fcd51",
+				"DiscoKey":   "discokey:09b54ed35673329fe55a14d64c99b458fd66501f9b6d746af74b15f36d07c527",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:57830", "10.65.0.27:57830", "172.17.0.1:57830"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:56:39.448002312Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8983340446595960,
+				"StableID":   "nTnAGz7a9D21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdbfb180fe9b0a28b4d6bb337796c478c1cdd7c3a4bd9235cce8ed291ac3f178",
+				"DiscoKey":   "discokey:744cb082c4f2bbc4760a898e334652c5f09536f89cb0637758f0f500ad598c14",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:39965", "10.65.0.27:39965", "172.17.0.1:39965"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:56:39.977417102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4574845337037595,
+				"StableID":   "nWEWcuRxic11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0cc0597d5c1c0106ae516d9de0a4bd4dde38f373db384084b96b13b38161254d",
+				"DiscoKey":   "discokey:395270cfebf94a3afdb2063543435c1272ed8bc6a7ecf30120e413946b80e516",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:52825", "10.65.0.27:52825", "172.17.0.1:52825"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:56:40.511090494Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5143573950832586,
+				"StableID":   "nZ8Eh1yXAh11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:34fc6b4a55e81b81c49843fa5682cc263d94e6fe767560892d3ee1177df9535e",
+				"DiscoKey":   "discokey:bf492cd12f31675477e8238d4a0b16ad71ce83d6549e696b44edb5d9a38b464f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:58696", "10.65.0.27:58696", "172.17.0.1:58696"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:56:41.05713905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         2043994585938075,
+				"StableID":   "naQGEmGjxG11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ff126a4720c78b7c123660aff9e48ca8b34b3b1fbce6ef51e9464f0b8406202",
+				"DiscoKey":   "discokey:4e803675e31ed070602ff749c86243570aeea836549a82ea4b8f8061c7aa4752",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:34046", "10.65.0.27:34046", "172.17.0.1:34046"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:56:42.141887485Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4293716256204730,
+				"StableID":   "nViNRRedXa11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7659f801c7d36a1331b4ab6450e6a8af5c7e8fe0a1726fe336ba4bdf2feec801",
+				"DiscoKey":   "discokey:fac5b3b492c8b0eb9991dd1f54f7bc8cdd4410c21d920618eca2b7a9e7bc4d2b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:49654", "10.65.0.27:49654", "172.17.0.1:49654"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:56:42.685656154Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6023756866091993,
+				"StableID":   "n6VUswsA3p11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b1f3917fbb107fd9bb950dca72d8e96d1a4732cc31ee971e25645e91e3be930f",
+				"DiscoKey":   "discokey:95b6dede8210e54b25eb7218a64371c4e2adf5b41efe7b954a00278ca5955176",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:47881", "10.65.0.27:47881", "172.17.0.1:47881"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:56:43.232495172Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6197061833183856,
+				"StableID":   "njWiMkJfPq11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:672e03a11542fa0a6a3ab0fd01e92d8d0cda6327e29291bdd1c9e107377b7f3e",
+				"DiscoKey":   "discokey:aab45f5222fec5a45e511491258bda2443038be1d2873557f3b5922a00fba04e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57047", "10.65.0.27:57047", "172.17.0.1:57047"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:56:43.766280602Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3609737328847972,
+				"StableID":   "nqXZnMgrBV11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83c60d89b6fe62a54be43f4af9d8a53b75d7e68d6e59a2a688b2359d40c1d51d",
+				"DiscoKey":   "discokey:999258f1861d640280c7064b322610cfe262055fc42fd34d2b6ca53b6f37c128",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59383", "10.65.0.27:59383", "172.17.0.1:59383"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:56:44.310386715Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3280894969718241,
+				"StableID":   "nW1UakYvcS11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35ef232ffb2de15ec88ab100a2bfeb284dbf74be4b9f98bae1a21d8117f62212",
+				"DiscoKey":   "discokey:c6d5105154b59b4cb01fc26c599fb53280ac80bb9c1467f1c1341c00874cd82b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:49333", "10.65.0.27:49333", "172.17.0.1:49333"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:56:44.855443956Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8469822311997169,
+				"StableID":   "nzhhATsz8921CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c085b4af66b3aeffe1b1af5667b97e761d42c2c90a7ca746c3e8ed7c283df232",
+				"DiscoKey":   "discokey:d453ebf750661733027eb4e6eb47fa1b1bfee9c9ab74718d5d9cd065ab3c342e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:55630", "10.65.0.27:55630", "172.17.0.1:55630"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:56:45.398858419Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8710528569918882,
+				"StableID":   "nwjMvGp12B21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d35b556ae2bcb8330c1c318d96f3614f075573dffe44b3f929100f761232f46b",
+				"KeyExpiry":  "2026-11-08T18:56:45Z",
+				"DiscoKey":   "discokey:79169f1629964b873fb2123834e5bcd556654464df7aa725324c77d68e949614",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:37650", "10.65.0.27:37650", "172.17.0.1:37650"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:56:45.938463432Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2696553646490874,
+				"StableID":   "nfVvpitG4N11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ccc45abf8bef1e9d2e1a5147ca76e36ef66a9f5d34ebf0e2cd1315fdd9bc1762",
+				"KeyExpiry":  "2026-11-08T18:56:46Z",
+				"DiscoKey":   "discokey:59623d2f79997f011a5c0ff6d6944bd43f67c256e254839dd3b9f9512d59f967",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:48500", "10.65.0.27:48500", "172.17.0.1:48500"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:56:46.483877479Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5424390421852946,
+				"StableID":   "n3ZMdDYiMj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f3e21bafd26c807da8c7ddb68628a06f59ba0f58034d086d3820f0f56fdc5c11",
+				"KeyExpiry":  "2026-11-08T18:56:47Z",
+				"DiscoKey":   "discokey:ba309c3cf8b0cf5c21e7dfde594b26f2f1ace39fb754a0e035236f6486a29b42",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:52233", "10.65.0.27:52233", "172.17.0.1:52233"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:56:47.027196914Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "1602861061893332": {
+				"ID":          1602861061893332,
+				"LoginName":   "raticate.tail78f774.ts.net",
+				"DisplayName": "raticate"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "rattata": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         5143573950832586,
+				"StableID":   "nZ8Eh1yXAh11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       5143573950832586,
+				"Key":        "nodekey:34fc6b4a55e81b81c49843fa5682cc263d94e6fe767560892d3ee1177df9535e",
+				"DiscoKey":   "discokey:bf492cd12f31675477e8238d4a0b16ad71ce83d6549e696b44edb5d9a38b464f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:58696", "10.65.0.27:58696", "172.17.0.1:58696"],
+				"Hostinfo": {"Hostname": "rattata", "RequestTags": ["tag:group-a"], "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:56:41.05713905Z",
+				"Tags":              ["tag:group-a"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:34fc6b4a55e81b81c49843fa5682cc263d94e6fe767560892d3ee1177df9535e",
+			"MachineKey": "mkey:abee734efd731dff20164769610185cf9395abe7282a7a1df9820f35e52ddc14",
+			"Peers": [{
+				"ID":         3302763550688450,
+				"StableID":   "nsX8CtzpnS11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:483cc9dd06471e98b3c2ba341f914133cbcdf9da37afd3036534e736133fcd51",
+				"DiscoKey":   "discokey:09b54ed35673329fe55a14d64c99b458fd66501f9b6d746af74b15f36d07c527",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:57830", "10.65.0.27:57830", "172.17.0.1:57830"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:56:39.448002312Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8983340446595960,
+				"StableID":   "nTnAGz7a9D21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdbfb180fe9b0a28b4d6bb337796c478c1cdd7c3a4bd9235cce8ed291ac3f178",
+				"DiscoKey":   "discokey:744cb082c4f2bbc4760a898e334652c5f09536f89cb0637758f0f500ad598c14",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:39965", "10.65.0.27:39965", "172.17.0.1:39965"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:56:39.977417102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4574845337037595,
+				"StableID":   "nWEWcuRxic11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0cc0597d5c1c0106ae516d9de0a4bd4dde38f373db384084b96b13b38161254d",
+				"DiscoKey":   "discokey:395270cfebf94a3afdb2063543435c1272ed8bc6a7ecf30120e413946b80e516",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:52825", "10.65.0.27:52825", "172.17.0.1:52825"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:56:40.511090494Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         1602861061893332,
+				"StableID":   "n36PJeSwWD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4171affbb592d976955e324a8d9f76684607cda4f0ef9c3de8824c2ae76a06b",
+				"DiscoKey":   "discokey:aa732a139c3b0d4cf4aeb228091f93946695f2cd538d1b56b76f9141ef6f780a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:45913", "10.65.0.27:45913", "172.17.0.1:45913"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:56:41.595068864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2043994585938075,
+				"StableID":   "naQGEmGjxG11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ff126a4720c78b7c123660aff9e48ca8b34b3b1fbce6ef51e9464f0b8406202",
+				"DiscoKey":   "discokey:4e803675e31ed070602ff749c86243570aeea836549a82ea4b8f8061c7aa4752",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:34046", "10.65.0.27:34046", "172.17.0.1:34046"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:56:42.141887485Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4293716256204730,
+				"StableID":   "nViNRRedXa11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7659f801c7d36a1331b4ab6450e6a8af5c7e8fe0a1726fe336ba4bdf2feec801",
+				"DiscoKey":   "discokey:fac5b3b492c8b0eb9991dd1f54f7bc8cdd4410c21d920618eca2b7a9e7bc4d2b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:49654", "10.65.0.27:49654", "172.17.0.1:49654"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:56:42.685656154Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6023756866091993,
+				"StableID":   "n6VUswsA3p11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b1f3917fbb107fd9bb950dca72d8e96d1a4732cc31ee971e25645e91e3be930f",
+				"DiscoKey":   "discokey:95b6dede8210e54b25eb7218a64371c4e2adf5b41efe7b954a00278ca5955176",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:47881", "10.65.0.27:47881", "172.17.0.1:47881"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:56:43.232495172Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6197061833183856,
+				"StableID":   "njWiMkJfPq11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:672e03a11542fa0a6a3ab0fd01e92d8d0cda6327e29291bdd1c9e107377b7f3e",
+				"DiscoKey":   "discokey:aab45f5222fec5a45e511491258bda2443038be1d2873557f3b5922a00fba04e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57047", "10.65.0.27:57047", "172.17.0.1:57047"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:56:43.766280602Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3609737328847972,
+				"StableID":   "nqXZnMgrBV11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83c60d89b6fe62a54be43f4af9d8a53b75d7e68d6e59a2a688b2359d40c1d51d",
+				"DiscoKey":   "discokey:999258f1861d640280c7064b322610cfe262055fc42fd34d2b6ca53b6f37c128",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59383", "10.65.0.27:59383", "172.17.0.1:59383"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:56:44.310386715Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3280894969718241,
+				"StableID":   "nW1UakYvcS11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35ef232ffb2de15ec88ab100a2bfeb284dbf74be4b9f98bae1a21d8117f62212",
+				"DiscoKey":   "discokey:c6d5105154b59b4cb01fc26c599fb53280ac80bb9c1467f1c1341c00874cd82b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:49333", "10.65.0.27:49333", "172.17.0.1:49333"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:56:44.855443956Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8469822311997169,
+				"StableID":   "nzhhATsz8921CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c085b4af66b3aeffe1b1af5667b97e761d42c2c90a7ca746c3e8ed7c283df232",
+				"DiscoKey":   "discokey:d453ebf750661733027eb4e6eb47fa1b1bfee9c9ab74718d5d9cd065ab3c342e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:55630", "10.65.0.27:55630", "172.17.0.1:55630"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:56:45.398858419Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8710528569918882,
+				"StableID":   "nwjMvGp12B21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d35b556ae2bcb8330c1c318d96f3614f075573dffe44b3f929100f761232f46b",
+				"KeyExpiry":  "2026-11-08T18:56:45Z",
+				"DiscoKey":   "discokey:79169f1629964b873fb2123834e5bcd556654464df7aa725324c77d68e949614",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:37650", "10.65.0.27:37650", "172.17.0.1:37650"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:56:45.938463432Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2696553646490874,
+				"StableID":   "nfVvpitG4N11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ccc45abf8bef1e9d2e1a5147ca76e36ef66a9f5d34ebf0e2cd1315fdd9bc1762",
+				"KeyExpiry":  "2026-11-08T18:56:46Z",
+				"DiscoKey":   "discokey:59623d2f79997f011a5c0ff6d6944bd43f67c256e254839dd3b9f9512d59f967",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:48500", "10.65.0.27:48500", "172.17.0.1:48500"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:56:46.483877479Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5424390421852946,
+				"StableID":   "n3ZMdDYiMj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f3e21bafd26c807da8c7ddb68628a06f59ba0f58034d086d3820f0f56fdc5c11",
+				"KeyExpiry":  "2026-11-08T18:56:47Z",
+				"DiscoKey":   "discokey:ba309c3cf8b0cf5c21e7dfde594b26f2f1ace39fb754a0e035236f6486a29b42",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:52233", "10.65.0.27:52233", "172.17.0.1:52233"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:56:47.027196914Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "5143573950832586": {
+				"ID":          5143573950832586,
+				"LoginName":   "rattata.tail78f774.ts.net",
+				"DisplayName": "rattata"
+			}}
+		}
+	}, "spearow": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         4293716256204730,
+				"StableID":   "nViNRRedXa11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       4293716256204730,
+				"Key":        "nodekey:7659f801c7d36a1331b4ab6450e6a8af5c7e8fe0a1726fe336ba4bdf2feec801",
+				"DiscoKey":   "discokey:fac5b3b492c8b0eb9991dd1f54f7bc8cdd4410c21d920618eca2b7a9e7bc4d2b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:49654", "10.65.0.27:49654", "172.17.0.1:49654"],
+				"Hostinfo": {
+					"Hostname":    "spearow",
+					"RoutableIPs": ["10.44.0.0/16"],
+					"RequestTags": ["tag:spearow"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 36186},
+						{"Proto": "peerapi6", "Port": 36186},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:56:42.685656154Z",
+				"Tags":              ["tag:spearow"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:7659f801c7d36a1331b4ab6450e6a8af5c7e8fe0a1726fe336ba4bdf2feec801",
+			"MachineKey": "mkey:5d6e9111128f47003db0e139e87dc421721dd585d6a3d8f47d614fae72918a34",
+			"Peers": [{
+				"ID":         3302763550688450,
+				"StableID":   "nsX8CtzpnS11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:483cc9dd06471e98b3c2ba341f914133cbcdf9da37afd3036534e736133fcd51",
+				"DiscoKey":   "discokey:09b54ed35673329fe55a14d64c99b458fd66501f9b6d746af74b15f36d07c527",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:57830", "10.65.0.27:57830", "172.17.0.1:57830"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:56:39.448002312Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8983340446595960,
+				"StableID":   "nTnAGz7a9D21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdbfb180fe9b0a28b4d6bb337796c478c1cdd7c3a4bd9235cce8ed291ac3f178",
+				"DiscoKey":   "discokey:744cb082c4f2bbc4760a898e334652c5f09536f89cb0637758f0f500ad598c14",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:39965", "10.65.0.27:39965", "172.17.0.1:39965"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:56:39.977417102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4574845337037595,
+				"StableID":   "nWEWcuRxic11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0cc0597d5c1c0106ae516d9de0a4bd4dde38f373db384084b96b13b38161254d",
+				"DiscoKey":   "discokey:395270cfebf94a3afdb2063543435c1272ed8bc6a7ecf30120e413946b80e516",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:52825", "10.65.0.27:52825", "172.17.0.1:52825"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:56:40.511090494Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5143573950832586,
+				"StableID":   "nZ8Eh1yXAh11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:34fc6b4a55e81b81c49843fa5682cc263d94e6fe767560892d3ee1177df9535e",
+				"DiscoKey":   "discokey:bf492cd12f31675477e8238d4a0b16ad71ce83d6549e696b44edb5d9a38b464f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:58696", "10.65.0.27:58696", "172.17.0.1:58696"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:56:41.05713905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1602861061893332,
+				"StableID":   "n36PJeSwWD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4171affbb592d976955e324a8d9f76684607cda4f0ef9c3de8824c2ae76a06b",
+				"DiscoKey":   "discokey:aa732a139c3b0d4cf4aeb228091f93946695f2cd538d1b56b76f9141ef6f780a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:45913", "10.65.0.27:45913", "172.17.0.1:45913"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:56:41.595068864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2043994585938075,
+				"StableID":   "naQGEmGjxG11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ff126a4720c78b7c123660aff9e48ca8b34b3b1fbce6ef51e9464f0b8406202",
+				"DiscoKey":   "discokey:4e803675e31ed070602ff749c86243570aeea836549a82ea4b8f8061c7aa4752",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:34046", "10.65.0.27:34046", "172.17.0.1:34046"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:56:42.141887485Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         6023756866091993,
+				"StableID":   "n6VUswsA3p11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b1f3917fbb107fd9bb950dca72d8e96d1a4732cc31ee971e25645e91e3be930f",
+				"DiscoKey":   "discokey:95b6dede8210e54b25eb7218a64371c4e2adf5b41efe7b954a00278ca5955176",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:47881", "10.65.0.27:47881", "172.17.0.1:47881"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:56:43.232495172Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6197061833183856,
+				"StableID":   "njWiMkJfPq11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:672e03a11542fa0a6a3ab0fd01e92d8d0cda6327e29291bdd1c9e107377b7f3e",
+				"DiscoKey":   "discokey:aab45f5222fec5a45e511491258bda2443038be1d2873557f3b5922a00fba04e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57047", "10.65.0.27:57047", "172.17.0.1:57047"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:56:43.766280602Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3609737328847972,
+				"StableID":   "nqXZnMgrBV11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83c60d89b6fe62a54be43f4af9d8a53b75d7e68d6e59a2a688b2359d40c1d51d",
+				"DiscoKey":   "discokey:999258f1861d640280c7064b322610cfe262055fc42fd34d2b6ca53b6f37c128",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59383", "10.65.0.27:59383", "172.17.0.1:59383"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:56:44.310386715Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3280894969718241,
+				"StableID":   "nW1UakYvcS11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35ef232ffb2de15ec88ab100a2bfeb284dbf74be4b9f98bae1a21d8117f62212",
+				"DiscoKey":   "discokey:c6d5105154b59b4cb01fc26c599fb53280ac80bb9c1467f1c1341c00874cd82b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:49333", "10.65.0.27:49333", "172.17.0.1:49333"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:56:44.855443956Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8469822311997169,
+				"StableID":   "nzhhATsz8921CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c085b4af66b3aeffe1b1af5667b97e761d42c2c90a7ca746c3e8ed7c283df232",
+				"DiscoKey":   "discokey:d453ebf750661733027eb4e6eb47fa1b1bfee9c9ab74718d5d9cd065ab3c342e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:55630", "10.65.0.27:55630", "172.17.0.1:55630"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:56:45.398858419Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8710528569918882,
+				"StableID":   "nwjMvGp12B21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d35b556ae2bcb8330c1c318d96f3614f075573dffe44b3f929100f761232f46b",
+				"KeyExpiry":  "2026-11-08T18:56:45Z",
+				"DiscoKey":   "discokey:79169f1629964b873fb2123834e5bcd556654464df7aa725324c77d68e949614",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:37650", "10.65.0.27:37650", "172.17.0.1:37650"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:56:45.938463432Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2696553646490874,
+				"StableID":   "nfVvpitG4N11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ccc45abf8bef1e9d2e1a5147ca76e36ef66a9f5d34ebf0e2cd1315fdd9bc1762",
+				"KeyExpiry":  "2026-11-08T18:56:46Z",
+				"DiscoKey":   "discokey:59623d2f79997f011a5c0ff6d6944bd43f67c256e254839dd3b9f9512d59f967",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:48500", "10.65.0.27:48500", "172.17.0.1:48500"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:56:46.483877479Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5424390421852946,
+				"StableID":   "n3ZMdDYiMj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f3e21bafd26c807da8c7ddb68628a06f59ba0f58034d086d3820f0f56fdc5c11",
+				"KeyExpiry":  "2026-11-08T18:56:47Z",
+				"DiscoKey":   "discokey:ba309c3cf8b0cf5c21e7dfde594b26f2f1ace39fb754a0e035236f6486a29b42",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:52233", "10.65.0.27:52233", "172.17.0.1:52233"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:56:47.027196914Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4293716256204730": {
+				"ID":          4293716256204730,
+				"LoginName":   "spearow.tail78f774.ts.net",
+				"DisplayName": "spearow"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "squirtle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         6197061833183856,
+				"StableID":   "njWiMkJfPq11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       6197061833183856,
+				"Key":        "nodekey:672e03a11542fa0a6a3ab0fd01e92d8d0cda6327e29291bdd1c9e107377b7f3e",
+				"DiscoKey":   "discokey:aab45f5222fec5a45e511491258bda2443038be1d2873557f3b5922a00fba04e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57047", "10.65.0.27:57047", "172.17.0.1:57047"],
+				"Hostinfo": {
+					"Hostname":    "squirtle",
+					"RoutableIPs": ["10.33.0.0/16"],
+					"RequestTags": ["tag:router"],
+					"Services": [
+						{"Proto": "peerapi4", "Port": 43119},
+						{"Proto": "peerapi6", "Port": 43119},
+						{"Proto": "peerapi-dns-proxy", "Port": 1}
+					]
+				},
+				"Created":           "2026-05-12T18:56:43.766280602Z",
+				"Tags":              ["tag:router"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:672e03a11542fa0a6a3ab0fd01e92d8d0cda6327e29291bdd1c9e107377b7f3e",
+			"MachineKey": "mkey:69b751cd16758d7cd1f5d96773f78476e73b66bd5e7a7657587795f1caf51959",
+			"Peers": [{
+				"ID":         3302763550688450,
+				"StableID":   "nsX8CtzpnS11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:483cc9dd06471e98b3c2ba341f914133cbcdf9da37afd3036534e736133fcd51",
+				"DiscoKey":   "discokey:09b54ed35673329fe55a14d64c99b458fd66501f9b6d746af74b15f36d07c527",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:57830", "10.65.0.27:57830", "172.17.0.1:57830"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:56:39.448002312Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8983340446595960,
+				"StableID":   "nTnAGz7a9D21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdbfb180fe9b0a28b4d6bb337796c478c1cdd7c3a4bd9235cce8ed291ac3f178",
+				"DiscoKey":   "discokey:744cb082c4f2bbc4760a898e334652c5f09536f89cb0637758f0f500ad598c14",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:39965", "10.65.0.27:39965", "172.17.0.1:39965"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:56:39.977417102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4574845337037595,
+				"StableID":   "nWEWcuRxic11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0cc0597d5c1c0106ae516d9de0a4bd4dde38f373db384084b96b13b38161254d",
+				"DiscoKey":   "discokey:395270cfebf94a3afdb2063543435c1272ed8bc6a7ecf30120e413946b80e516",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:52825", "10.65.0.27:52825", "172.17.0.1:52825"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:56:40.511090494Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5143573950832586,
+				"StableID":   "nZ8Eh1yXAh11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:34fc6b4a55e81b81c49843fa5682cc263d94e6fe767560892d3ee1177df9535e",
+				"DiscoKey":   "discokey:bf492cd12f31675477e8238d4a0b16ad71ce83d6549e696b44edb5d9a38b464f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:58696", "10.65.0.27:58696", "172.17.0.1:58696"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:56:41.05713905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1602861061893332,
+				"StableID":   "n36PJeSwWD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4171affbb592d976955e324a8d9f76684607cda4f0ef9c3de8824c2ae76a06b",
+				"DiscoKey":   "discokey:aa732a139c3b0d4cf4aeb228091f93946695f2cd538d1b56b76f9141ef6f780a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:45913", "10.65.0.27:45913", "172.17.0.1:45913"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:56:41.595068864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2043994585938075,
+				"StableID":   "naQGEmGjxG11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ff126a4720c78b7c123660aff9e48ca8b34b3b1fbce6ef51e9464f0b8406202",
+				"DiscoKey":   "discokey:4e803675e31ed070602ff749c86243570aeea836549a82ea4b8f8061c7aa4752",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:34046", "10.65.0.27:34046", "172.17.0.1:34046"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:56:42.141887485Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4293716256204730,
+				"StableID":   "nViNRRedXa11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7659f801c7d36a1331b4ab6450e6a8af5c7e8fe0a1726fe336ba4bdf2feec801",
+				"DiscoKey":   "discokey:fac5b3b492c8b0eb9991dd1f54f7bc8cdd4410c21d920618eca2b7a9e7bc4d2b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:49654", "10.65.0.27:49654", "172.17.0.1:49654"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:56:42.685656154Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6023756866091993,
+				"StableID":   "n6VUswsA3p11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b1f3917fbb107fd9bb950dca72d8e96d1a4732cc31ee971e25645e91e3be930f",
+				"DiscoKey":   "discokey:95b6dede8210e54b25eb7218a64371c4e2adf5b41efe7b954a00278ca5955176",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:47881", "10.65.0.27:47881", "172.17.0.1:47881"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:56:43.232495172Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         3609737328847972,
+				"StableID":   "nqXZnMgrBV11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83c60d89b6fe62a54be43f4af9d8a53b75d7e68d6e59a2a688b2359d40c1d51d",
+				"DiscoKey":   "discokey:999258f1861d640280c7064b322610cfe262055fc42fd34d2b6ca53b6f37c128",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59383", "10.65.0.27:59383", "172.17.0.1:59383"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:56:44.310386715Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3280894969718241,
+				"StableID":   "nW1UakYvcS11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35ef232ffb2de15ec88ab100a2bfeb284dbf74be4b9f98bae1a21d8117f62212",
+				"DiscoKey":   "discokey:c6d5105154b59b4cb01fc26c599fb53280ac80bb9c1467f1c1341c00874cd82b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:49333", "10.65.0.27:49333", "172.17.0.1:49333"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:56:44.855443956Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8469822311997169,
+				"StableID":   "nzhhATsz8921CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c085b4af66b3aeffe1b1af5667b97e761d42c2c90a7ca746c3e8ed7c283df232",
+				"DiscoKey":   "discokey:d453ebf750661733027eb4e6eb47fa1b1bfee9c9ab74718d5d9cd065ab3c342e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:55630", "10.65.0.27:55630", "172.17.0.1:55630"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:56:45.398858419Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8710528569918882,
+				"StableID":   "nwjMvGp12B21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d35b556ae2bcb8330c1c318d96f3614f075573dffe44b3f929100f761232f46b",
+				"KeyExpiry":  "2026-11-08T18:56:45Z",
+				"DiscoKey":   "discokey:79169f1629964b873fb2123834e5bcd556654464df7aa725324c77d68e949614",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:37650", "10.65.0.27:37650", "172.17.0.1:37650"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:56:45.938463432Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2696553646490874,
+				"StableID":   "nfVvpitG4N11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ccc45abf8bef1e9d2e1a5147ca76e36ef66a9f5d34ebf0e2cd1315fdd9bc1762",
+				"KeyExpiry":  "2026-11-08T18:56:46Z",
+				"DiscoKey":   "discokey:59623d2f79997f011a5c0ff6d6944bd43f67c256e254839dd3b9f9512d59f967",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:48500", "10.65.0.27:48500", "172.17.0.1:48500"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:56:46.483877479Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5424390421852946,
+				"StableID":   "n3ZMdDYiMj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f3e21bafd26c807da8c7ddb68628a06f59ba0f58034d086d3820f0f56fdc5c11",
+				"KeyExpiry":  "2026-11-08T18:56:47Z",
+				"DiscoKey":   "discokey:ba309c3cf8b0cf5c21e7dfde594b26f2f1ace39fb754a0e035236f6486a29b42",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:52233", "10.65.0.27:52233", "172.17.0.1:52233"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:56:47.027196914Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}, "6197061833183856": {
+				"ID":          6197061833183856,
+				"LoginName":   "squirtle.tail78f774.ts.net",
+				"DisplayName": "squirtle"
+			}}
+		}
+	}, "venusaur": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         2696553646490874,
+				"StableID":   "nfVvpitG4N11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ccc45abf8bef1e9d2e1a5147ca76e36ef66a9f5d34ebf0e2cd1315fdd9bc1762",
+				"KeyExpiry":  "2026-11-08T18:56:46Z",
+				"DiscoKey":   "discokey:59623d2f79997f011a5c0ff6d6944bd43f67c256e254839dd3b9f9512d59f967",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:48500", "10.65.0.27:48500", "172.17.0.1:48500"],
+				"Hostinfo": {"Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:56:46.483877479Z",
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-admin":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-admin",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:ccc45abf8bef1e9d2e1a5147ca76e36ef66a9f5d34ebf0e2cd1315fdd9bc1762",
+			"MachineKey": "mkey:54dbaa4f43e009a7535bb1f45f9ce2070f93e0708b4b95183bb19023df8bb752",
+			"Peers": [{
+				"ID":         3302763550688450,
+				"StableID":   "nsX8CtzpnS11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:483cc9dd06471e98b3c2ba341f914133cbcdf9da37afd3036534e736133fcd51",
+				"DiscoKey":   "discokey:09b54ed35673329fe55a14d64c99b458fd66501f9b6d746af74b15f36d07c527",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:57830", "10.65.0.27:57830", "172.17.0.1:57830"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:56:39.448002312Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8983340446595960,
+				"StableID":   "nTnAGz7a9D21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdbfb180fe9b0a28b4d6bb337796c478c1cdd7c3a4bd9235cce8ed291ac3f178",
+				"DiscoKey":   "discokey:744cb082c4f2bbc4760a898e334652c5f09536f89cb0637758f0f500ad598c14",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:39965", "10.65.0.27:39965", "172.17.0.1:39965"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:56:39.977417102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4574845337037595,
+				"StableID":   "nWEWcuRxic11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0cc0597d5c1c0106ae516d9de0a4bd4dde38f373db384084b96b13b38161254d",
+				"DiscoKey":   "discokey:395270cfebf94a3afdb2063543435c1272ed8bc6a7ecf30120e413946b80e516",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:52825", "10.65.0.27:52825", "172.17.0.1:52825"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:56:40.511090494Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5143573950832586,
+				"StableID":   "nZ8Eh1yXAh11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:34fc6b4a55e81b81c49843fa5682cc263d94e6fe767560892d3ee1177df9535e",
+				"DiscoKey":   "discokey:bf492cd12f31675477e8238d4a0b16ad71ce83d6549e696b44edb5d9a38b464f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:58696", "10.65.0.27:58696", "172.17.0.1:58696"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:56:41.05713905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1602861061893332,
+				"StableID":   "n36PJeSwWD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4171affbb592d976955e324a8d9f76684607cda4f0ef9c3de8824c2ae76a06b",
+				"DiscoKey":   "discokey:aa732a139c3b0d4cf4aeb228091f93946695f2cd538d1b56b76f9141ef6f780a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:45913", "10.65.0.27:45913", "172.17.0.1:45913"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:56:41.595068864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2043994585938075,
+				"StableID":   "naQGEmGjxG11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ff126a4720c78b7c123660aff9e48ca8b34b3b1fbce6ef51e9464f0b8406202",
+				"DiscoKey":   "discokey:4e803675e31ed070602ff749c86243570aeea836549a82ea4b8f8061c7aa4752",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:34046", "10.65.0.27:34046", "172.17.0.1:34046"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:56:42.141887485Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4293716256204730,
+				"StableID":   "nViNRRedXa11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7659f801c7d36a1331b4ab6450e6a8af5c7e8fe0a1726fe336ba4bdf2feec801",
+				"DiscoKey":   "discokey:fac5b3b492c8b0eb9991dd1f54f7bc8cdd4410c21d920618eca2b7a9e7bc4d2b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:49654", "10.65.0.27:49654", "172.17.0.1:49654"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:56:42.685656154Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6023756866091993,
+				"StableID":   "n6VUswsA3p11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b1f3917fbb107fd9bb950dca72d8e96d1a4732cc31ee971e25645e91e3be930f",
+				"DiscoKey":   "discokey:95b6dede8210e54b25eb7218a64371c4e2adf5b41efe7b954a00278ca5955176",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:47881", "10.65.0.27:47881", "172.17.0.1:47881"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:56:43.232495172Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6197061833183856,
+				"StableID":   "njWiMkJfPq11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:672e03a11542fa0a6a3ab0fd01e92d8d0cda6327e29291bdd1c9e107377b7f3e",
+				"DiscoKey":   "discokey:aab45f5222fec5a45e511491258bda2443038be1d2873557f3b5922a00fba04e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57047", "10.65.0.27:57047", "172.17.0.1:57047"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:56:43.766280602Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3609737328847972,
+				"StableID":   "nqXZnMgrBV11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:83c60d89b6fe62a54be43f4af9d8a53b75d7e68d6e59a2a688b2359d40c1d51d",
+				"DiscoKey":   "discokey:999258f1861d640280c7064b322610cfe262055fc42fd34d2b6ca53b6f37c128",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59383", "10.65.0.27:59383", "172.17.0.1:59383"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "weedle", "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957}
+				]},
+				"Created":              "2026-05-12T18:56:44.310386715Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:client"],
+				"Online":               true,
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			}, {
+				"ID":         3280894969718241,
+				"StableID":   "nW1UakYvcS11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35ef232ffb2de15ec88ab100a2bfeb284dbf74be4b9f98bae1a21d8117f62212",
+				"DiscoKey":   "discokey:c6d5105154b59b4cb01fc26c599fb53280ac80bb9c1467f1c1341c00874cd82b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:49333", "10.65.0.27:49333", "172.17.0.1:49333"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:56:44.855443956Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8469822311997169,
+				"StableID":   "nzhhATsz8921CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c085b4af66b3aeffe1b1af5667b97e761d42c2c90a7ca746c3e8ed7c283df232",
+				"DiscoKey":   "discokey:d453ebf750661733027eb4e6eb47fa1b1bfee9c9ab74718d5d9cd065ab3c342e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:55630", "10.65.0.27:55630", "172.17.0.1:55630"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:56:45.398858419Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8710528569918882,
+				"StableID":   "nwjMvGp12B21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d35b556ae2bcb8330c1c318d96f3614f075573dffe44b3f929100f761232f46b",
+				"KeyExpiry":  "2026-11-08T18:56:45Z",
+				"DiscoKey":   "discokey:79169f1629964b873fb2123834e5bcd556654464df7aa725324c77d68e949614",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:37650", "10.65.0.27:37650", "172.17.0.1:37650"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:56:45.938463432Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         5424390421852946,
+				"StableID":   "n3ZMdDYiMj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f3e21bafd26c807da8c7ddb68628a06f59ba0f58034d086d3820f0f56fdc5c11",
+				"KeyExpiry":  "2026-11-08T18:56:47Z",
+				"DiscoKey":   "discokey:ba309c3cf8b0cf5c21e7dfde594b26f2f1ace39fb754a0e035236f6486a29b42",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:52233", "10.65.0.27:52233", "172.17.0.1:52233"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:56:47.027196914Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}, "weedle": {
+		"packet_filter_rules": [{"SrcIPs": [
+			"100.115.94.0-100.127.255.255",
+			"100.64.0.0-100.115.91.255",
+			"fd7a:115c:a1e0::/48"
+		], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+		"packet_filter_matches": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+			"100.115.94.0/23",
+			"100.115.96.0/19",
+			"100.115.128.0/17",
+			"100.116.0.0/14",
+			"100.120.0.0/13",
+			"100.64.0.0/11",
+			"100.96.0.0/12",
+			"100.112.0.0/15",
+			"100.114.0.0/16",
+			"100.115.0.0/18",
+			"100.115.64.0/20",
+			"100.115.80.0/21",
+			"100.115.88.0/22",
+			"fd7a:115c:a1e0::/48"
+		], "SrcCaps": null, "Dsts": [
+			{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+			{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+		], "Caps": []}],
+		"netmap": {
+			"Cached": false,
+			"SelfNode": {
+				"ID":         3609737328847972,
+				"StableID":   "nqXZnMgrBV11CNTRL",
+				"Name":       "weedle.tail78f774.ts.net.",
+				"User":       3609737328847972,
+				"Key":        "nodekey:83c60d89b6fe62a54be43f4af9d8a53b75d7e68d6e59a2a688b2359d40c1d51d",
+				"DiscoKey":   "discokey:999258f1861d640280c7064b322610cfe262055fc42fd34d2b6ca53b6f37c128",
+				"Addresses":  ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"AllowedIPs": ["100.64.0.14/32", "fd7a:115c:a1e0::e/128"],
+				"Endpoints":  ["77.164.248.136:59383", "10.65.0.27:59383", "172.17.0.1:59383"],
+				"Hostinfo": {"Hostname": "weedle", "RequestTags": ["tag:client"], "Services": [
+					{"Proto": "peerapi4", "Port": 63957},
+					{"Proto": "peerapi6", "Port": 63957},
+					{"Proto": "peerapi-dns-proxy", "Port": 1}
+				]},
+				"Created":           "2026-05-12T18:56:44.310386715Z",
+				"Tags":              ["tag:client"],
+				"MachineAuthorized": true,
+				"CapMap": {
+					"default-auto-update":                    [false],
+					"https://tailscale.com/cap/file-sharing": null,
+					"https://tailscale.com/cap/is-owner":     null,
+					"https://tailscale.com/cap/ssh":          null,
+					"https://tailscale.com/cap/tailnet-lock": null,
+					"probe-udp-lifetime":                     null,
+					"ssh-behavior-v1":                        null,
+					"ssh-env-vars":                           null,
+					"store-appc-routes":                      null,
+					"tailnet-display-name":                   ["odin@example.com"]
+				},
+				"ComputedName":         "weedle",
+				"ComputedNameWithHost": "weedle"
+			},
+			"AllCaps": [
+				"default-auto-update",
+				"https://tailscale.com/cap/file-sharing",
+				"https://tailscale.com/cap/is-owner",
+				"https://tailscale.com/cap/ssh",
+				"https://tailscale.com/cap/tailnet-lock",
+				"probe-udp-lifetime",
+				"ssh-behavior-v1",
+				"ssh-env-vars",
+				"store-appc-routes",
+				"tailnet-display-name"
+			],
+			"NodeKey":    "nodekey:83c60d89b6fe62a54be43f4af9d8a53b75d7e68d6e59a2a688b2359d40c1d51d",
+			"MachineKey": "mkey:c7f9a9c522c10c03edc1bd181603b4b942351015894e786ccd5d5fd9c3c0882c",
+			"Peers": [{
+				"ID":         3302763550688450,
+				"StableID":   "nsX8CtzpnS11CNTRL",
+				"Name":       "pidgey.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:483cc9dd06471e98b3c2ba341f914133cbcdf9da37afd3036534e736133fcd51",
+				"DiscoKey":   "discokey:09b54ed35673329fe55a14d64c99b458fd66501f9b6d746af74b15f36d07c527",
+				"Addresses":  ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"AllowedIPs": ["100.64.0.2/32", "fd7a:115c:a1e0::2/128"],
+				"Endpoints":  ["77.164.248.136:57830", "10.65.0.27:57830", "172.17.0.1:57830"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgey", "Services": [
+					{"Proto": "peerapi4", "Port": 46590},
+					{"Proto": "peerapi6", "Port": 46590}
+				]},
+				"Created":              "2026-05-12T18:56:39.448002312Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgey"],
+				"Online":               true,
+				"ComputedName":         "pidgey",
+				"ComputedNameWithHost": "pidgey"
+			}, {
+				"ID":         8983340446595960,
+				"StableID":   "nTnAGz7a9D21CNTRL",
+				"Name":       "pidgeotto.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:cdbfb180fe9b0a28b4d6bb337796c478c1cdd7c3a4bd9235cce8ed291ac3f178",
+				"DiscoKey":   "discokey:744cb082c4f2bbc4760a898e334652c5f09536f89cb0637758f0f500ad598c14",
+				"Addresses":  ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"AllowedIPs": ["100.64.0.3/32", "fd7a:115c:a1e0::3/128"],
+				"Endpoints":  ["77.164.248.136:39965", "10.65.0.27:39965", "172.17.0.1:39965"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "pidgeotto", "Services": [
+					{"Proto": "peerapi4", "Port": 34152},
+					{"Proto": "peerapi6", "Port": 34152}
+				]},
+				"Created":              "2026-05-12T18:56:39.977417102Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:pidgeotto"],
+				"Online":               true,
+				"ComputedName":         "pidgeotto",
+				"ComputedNameWithHost": "pidgeotto"
+			}, {
+				"ID":         4574845337037595,
+				"StableID":   "nWEWcuRxic11CNTRL",
+				"Name":       "charmander.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0cc0597d5c1c0106ae516d9de0a4bd4dde38f373db384084b96b13b38161254d",
+				"DiscoKey":   "discokey:395270cfebf94a3afdb2063543435c1272ed8bc6a7ecf30120e413946b80e516",
+				"Addresses":  ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"AllowedIPs": ["100.64.0.4/32", "fd7a:115c:a1e0::4/128"],
+				"Endpoints":  ["77.164.248.136:52825", "10.65.0.27:52825", "172.17.0.1:52825"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "charmander", "Services": [
+					{"Proto": "peerapi4", "Port": 37067},
+					{"Proto": "peerapi6", "Port": 37067}
+				]},
+				"Created":              "2026-05-12T18:56:40.511090494Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit"],
+				"Online":               true,
+				"ComputedName":         "charmander",
+				"ComputedNameWithHost": "charmander"
+			}, {
+				"ID":         5143573950832586,
+				"StableID":   "nZ8Eh1yXAh11CNTRL",
+				"Name":       "rattata.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:34fc6b4a55e81b81c49843fa5682cc263d94e6fe767560892d3ee1177df9535e",
+				"DiscoKey":   "discokey:bf492cd12f31675477e8238d4a0b16ad71ce83d6549e696b44edb5d9a38b464f",
+				"Addresses":  ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"AllowedIPs": ["100.64.0.5/32", "fd7a:115c:a1e0::5/128"],
+				"Endpoints":  ["77.164.248.136:58696", "10.65.0.27:58696", "172.17.0.1:58696"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "rattata", "Services": [
+					{"Proto": "peerapi4", "Port": 41053},
+					{"Proto": "peerapi6", "Port": 41053}
+				]},
+				"Created":              "2026-05-12T18:56:41.05713905Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-a"],
+				"Online":               true,
+				"ComputedName":         "rattata",
+				"ComputedNameWithHost": "rattata"
+			}, {
+				"ID":         1602861061893332,
+				"StableID":   "n36PJeSwWD11CNTRL",
+				"Name":       "raticate.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:e4171affbb592d976955e324a8d9f76684607cda4f0ef9c3de8824c2ae76a06b",
+				"DiscoKey":   "discokey:aa732a139c3b0d4cf4aeb228091f93946695f2cd538d1b56b76f9141ef6f780a",
+				"Addresses":  ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"AllowedIPs": ["100.64.0.6/32", "fd7a:115c:a1e0::6/128"],
+				"Endpoints":  ["77.164.248.136:45913", "10.65.0.27:45913", "172.17.0.1:45913"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "raticate", "Services": [
+					{"Proto": "peerapi4", "Port": 61927},
+					{"Proto": "peerapi6", "Port": 61927}
+				]},
+				"Created":              "2026-05-12T18:56:41.595068864Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:group-b"],
+				"Online":               true,
+				"ComputedName":         "raticate",
+				"ComputedNameWithHost": "raticate"
+			}, {
+				"ID":         2043994585938075,
+				"StableID":   "naQGEmGjxG11CNTRL",
+				"Name":       "blastoise.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:0ff126a4720c78b7c123660aff9e48ca8b34b3b1fbce6ef51e9464f0b8406202",
+				"DiscoKey":   "discokey:4e803675e31ed070602ff749c86243570aeea836549a82ea4b8f8061c7aa4752",
+				"Addresses":  ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"AllowedIPs": ["100.64.0.9/32", "fd7a:115c:a1e0::9/128"],
+				"Endpoints":  ["77.164.248.136:34046", "10.65.0.27:34046", "172.17.0.1:34046"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "blastoise", "Services": [
+					{"Proto": "peerapi4", "Port": 60534},
+					{"Proto": "peerapi6", "Port": 60534}
+				]},
+				"Created":              "2026-05-12T18:56:42.141887485Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:exit", "tag:router"],
+				"Online":               true,
+				"ComputedName":         "blastoise",
+				"ComputedNameWithHost": "blastoise"
+			}, {
+				"ID":         4293716256204730,
+				"StableID":   "nViNRRedXa11CNTRL",
+				"Name":       "spearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:7659f801c7d36a1331b4ab6450e6a8af5c7e8fe0a1726fe336ba4bdf2feec801",
+				"DiscoKey":   "discokey:fac5b3b492c8b0eb9991dd1f54f7bc8cdd4410c21d920618eca2b7a9e7bc4d2b",
+				"Addresses":  ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"AllowedIPs": ["100.64.0.11/32", "fd7a:115c:a1e0::b/128"],
+				"Endpoints":  ["77.164.248.136:49654", "10.65.0.27:49654", "172.17.0.1:49654"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "spearow", "Services": [
+					{"Proto": "peerapi4", "Port": 36186},
+					{"Proto": "peerapi6", "Port": 36186}
+				]},
+				"Created":              "2026-05-12T18:56:42.685656154Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:spearow"],
+				"Online":               true,
+				"ComputedName":         "spearow",
+				"ComputedNameWithHost": "spearow"
+			}, {
+				"ID":         6023756866091993,
+				"StableID":   "n6VUswsA3p11CNTRL",
+				"Name":       "fearow.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:b1f3917fbb107fd9bb950dca72d8e96d1a4732cc31ee971e25645e91e3be930f",
+				"DiscoKey":   "discokey:95b6dede8210e54b25eb7218a64371c4e2adf5b41efe7b954a00278ca5955176",
+				"Addresses":  ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"AllowedIPs": ["100.64.0.12/32", "fd7a:115c:a1e0::c/128"],
+				"Endpoints":  ["77.164.248.136:47881", "10.65.0.27:47881", "172.17.0.1:47881"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "fearow", "Services": [
+					{"Proto": "peerapi4", "Port": 39161},
+					{"Proto": "peerapi6", "Port": 39161}
+				]},
+				"Created":              "2026-05-12T18:56:43.232495172Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:fearow"],
+				"Online":               true,
+				"ComputedName":         "fearow",
+				"ComputedNameWithHost": "fearow"
+			}, {
+				"ID":         6197061833183856,
+				"StableID":   "njWiMkJfPq11CNTRL",
+				"Name":       "squirtle.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:672e03a11542fa0a6a3ab0fd01e92d8d0cda6327e29291bdd1c9e107377b7f3e",
+				"DiscoKey":   "discokey:aab45f5222fec5a45e511491258bda2443038be1d2873557f3b5922a00fba04e",
+				"Addresses":  ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"AllowedIPs": ["100.64.0.13/32", "fd7a:115c:a1e0::d/128"],
+				"Endpoints":  ["77.164.248.136:57047", "10.65.0.27:57047", "172.17.0.1:57047"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "squirtle", "Services": [
+					{"Proto": "peerapi4", "Port": 43119},
+					{"Proto": "peerapi6", "Port": 43119}
+				]},
+				"Created":              "2026-05-12T18:56:43.766280602Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:router"],
+				"Online":               true,
+				"ComputedName":         "squirtle",
+				"ComputedNameWithHost": "squirtle"
+			}, {
+				"ID":         3280894969718241,
+				"StableID":   "nW1UakYvcS11CNTRL",
+				"Name":       "kakuna.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:35ef232ffb2de15ec88ab100a2bfeb284dbf74be4b9f98bae1a21d8117f62212",
+				"DiscoKey":   "discokey:c6d5105154b59b4cb01fc26c599fb53280ac80bb9c1467f1c1341c00874cd82b",
+				"Addresses":  ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"AllowedIPs": ["100.64.0.15/32", "fd7a:115c:a1e0::f/128"],
+				"Endpoints":  ["77.164.248.136:49333", "10.65.0.27:49333", "172.17.0.1:49333"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "kakuna", "Services": [
+					{"Proto": "peerapi4", "Port": 51523},
+					{"Proto": "peerapi6", "Port": 51523}
+				]},
+				"Created":              "2026-05-12T18:56:44.855443956Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:prod"],
+				"Online":               true,
+				"ComputedName":         "kakuna",
+				"ComputedNameWithHost": "kakuna"
+			}, {
+				"ID":         8469822311997169,
+				"StableID":   "nzhhATsz8921CNTRL",
+				"Name":       "beedrill.tail78f774.ts.net.",
+				"User":       1260082990019555,
+				"Key":        "nodekey:c085b4af66b3aeffe1b1af5667b97e761d42c2c90a7ca746c3e8ed7c283df232",
+				"DiscoKey":   "discokey:d453ebf750661733027eb4e6eb47fa1b1bfee9c9ab74718d5d9cd065ab3c342e",
+				"Addresses":  ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"AllowedIPs": ["100.64.0.16/32", "fd7a:115c:a1e0::10/128"],
+				"Endpoints":  ["77.164.248.136:55630", "10.65.0.27:55630", "172.17.0.1:55630"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "beedrill", "Services": [
+					{"Proto": "peerapi4", "Port": 50358},
+					{"Proto": "peerapi6", "Port": 50358}
+				]},
+				"Created":              "2026-05-12T18:56:45.398858419Z",
+				"Cap":                  131,
+				"Tags":                 ["tag:server"],
+				"Online":               true,
+				"ComputedName":         "beedrill",
+				"ComputedNameWithHost": "beedrill"
+			}, {
+				"ID":         8710528569918882,
+				"StableID":   "nwjMvGp12B21CNTRL",
+				"Name":       "ivysaur.tail78f774.ts.net.",
+				"User":       4538565228176803,
+				"Key":        "nodekey:d35b556ae2bcb8330c1c318d96f3614f075573dffe44b3f929100f761232f46b",
+				"KeyExpiry":  "2026-11-08T18:56:45Z",
+				"DiscoKey":   "discokey:79169f1629964b873fb2123834e5bcd556654464df7aa725324c77d68e949614",
+				"Addresses":  ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"AllowedIPs": ["100.64.0.17/32", "fd7a:115c:a1e0::11/128"],
+				"Endpoints":  ["77.164.248.136:37650", "10.65.0.27:37650", "172.17.0.1:37650"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "ivysaur", "Services": [
+					{"Proto": "peerapi4", "Port": 62496},
+					{"Proto": "peerapi6", "Port": 62496}
+				]},
+				"Created":              "2026-05-12T18:56:45.938463432Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "ivysaur",
+				"ComputedNameWithHost": "ivysaur"
+			}, {
+				"ID":         2696553646490874,
+				"StableID":   "nfVvpitG4N11CNTRL",
+				"Name":       "venusaur.tail78f774.ts.net.",
+				"User":       3982058329734709,
+				"Key":        "nodekey:ccc45abf8bef1e9d2e1a5147ca76e36ef66a9f5d34ebf0e2cd1315fdd9bc1762",
+				"KeyExpiry":  "2026-11-08T18:56:46Z",
+				"DiscoKey":   "discokey:59623d2f79997f011a5c0ff6d6944bd43f67c256e254839dd3b9f9512d59f967",
+				"Addresses":  ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"AllowedIPs": ["100.64.0.18/32", "fd7a:115c:a1e0::12/128"],
+				"Endpoints":  ["77.164.248.136:48500", "10.65.0.27:48500", "172.17.0.1:48500"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "venusaur", "Services": [
+					{"Proto": "peerapi4", "Port": 42394},
+					{"Proto": "peerapi6", "Port": 42394}
+				]},
+				"Created":              "2026-05-12T18:56:46.483877479Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "venusaur",
+				"ComputedNameWithHost": "venusaur"
+			}, {
+				"ID":         5424390421852946,
+				"StableID":   "n3ZMdDYiMj11CNTRL",
+				"Name":       "bulbasaur.tail78f774.ts.net.",
+				"User":       4156223528223174,
+				"Key":        "nodekey:f3e21bafd26c807da8c7ddb68628a06f59ba0f58034d086d3820f0f56fdc5c11",
+				"KeyExpiry":  "2026-11-08T18:56:47Z",
+				"DiscoKey":   "discokey:ba309c3cf8b0cf5c21e7dfde594b26f2f1ace39fb754a0e035236f6486a29b42",
+				"Addresses":  ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"AllowedIPs": ["100.64.0.19/32", "fd7a:115c:a1e0::13/128"],
+				"Endpoints":  ["77.164.248.136:52233", "10.65.0.27:52233", "172.17.0.1:52233"],
+				"HomeDERP":   14,
+				"Hostinfo": {"OS": "linux", "Hostname": "bulbasaur", "Services": [
+					{"Proto": "peerapi4", "Port": 38156},
+					{"Proto": "peerapi6", "Port": 38156}
+				]},
+				"Created":              "2026-05-12T18:56:47.027196914Z",
+				"Cap":                  131,
+				"Online":               true,
+				"ComputedName":         "bulbasaur",
+				"ComputedNameWithHost": "bulbasaur"
+			}],
+			"DNS": {"ExitNodeFilteredSet": [".ts.net", ".tailscale.net"]},
+			"PacketFilter": [{"IPProto": [6, 17, 1, 58], "Srcs": [
+				"100.115.94.0/23",
+				"100.115.96.0/19",
+				"100.115.128.0/17",
+				"100.116.0.0/14",
+				"100.120.0.0/13",
+				"100.64.0.0/11",
+				"100.96.0.0/12",
+				"100.112.0.0/15",
+				"100.114.0.0/16",
+				"100.115.0.0/18",
+				"100.115.64.0/20",
+				"100.115.80.0/21",
+				"100.115.88.0/22",
+				"fd7a:115c:a1e0::/48"
+			], "SrcCaps": null, "Dsts": [
+				{"Net": "0.0.0.0/0", "Ports": {"First": 0, "Last": 65535}},
+				{"Net": "::/0", "Ports": {"First": 0, "Last": 65535}}
+			], "Caps": []}],
+			"PacketFilterRules": [{"SrcIPs": [
+				"100.115.94.0-100.127.255.255",
+				"100.64.0.0-100.115.91.255",
+				"fd7a:115c:a1e0::/48"
+			], "DstPorts": [{"IP": "*", "Ports": {"First": 0, "Last": 65535}}]}],
+			"SSHPolicy":       {"rules": []},
+			"CollectServices": false,
+			"DERPMap": {"Regions": {"1": {
+				"RegionID":   1,
+				"RegionCode": "nyc",
+				"RegionName": "New York City",
+				"Latitude":   40.7128,
+				"Longitude":  -74.006,
+				"Nodes": [{
+					"Name":      "1h",
+					"RegionID":  1,
+					"HostName":  "derp1h.tailscale.com",
+					"IPv4":      "199.38.181.93",
+					"IPv6":      "2607:f740:f::afd",
+					"CanPort80": true
+				}, {
+					"Name":      "1g",
+					"RegionID":  1,
+					"HostName":  "derp1g.tailscale.com",
+					"IPv4":      "209.177.145.120",
+					"IPv6":      "2607:f740:f::3eb",
+					"CanPort80": true
+				}, {
+					"Name":      "1i",
+					"RegionID":  1,
+					"HostName":  "derp1i.tailscale.com",
+					"IPv4":      "199.38.181.103",
+					"IPv6":      "2607:f740:f::e19",
+					"CanPort80": true
+				}, {
+					"Name":      "1f",
+					"RegionID":  1,
+					"HostName":  "derp1f.tailscale.com",
+					"IPv4":      "199.38.181.104",
+					"IPv6":      "2607:f740:f::bc",
+					"CanPort80": true
+				}]
+			}, "10": {
+				"RegionID":   10,
+				"RegionCode": "sea",
+				"RegionName": "Seattle",
+				"Latitude":   47.609722,
+				"Longitude":  -122.333056,
+				"Nodes": [{
+					"Name":      "10c",
+					"RegionID":  10,
+					"HostName":  "derp10c.tailscale.com",
+					"IPv4":      "192.73.240.121",
+					"IPv6":      "2607:f740:14::40c",
+					"CanPort80": true
+				}, {
+					"Name":      "10d",
+					"RegionID":  10,
+					"HostName":  "derp10d.tailscale.com",
+					"IPv4":      "192.73.240.132",
+					"IPv6":      "2607:f740:14::500",
+					"CanPort80": true
+				}, {
+					"Name":      "10b",
+					"RegionID":  10,
+					"HostName":  "derp10b.tailscale.com",
+					"IPv4":      "192.73.240.161",
+					"IPv6":      "2607:f740:14::61c",
+					"CanPort80": true
+				}]
+			}, "11": {
+				"RegionID":   11,
+				"RegionCode": "sao",
+				"RegionName": "São Paulo",
+				"Latitude":   -23.55,
+				"Longitude":  -46.633333,
+				"Nodes": [{
+					"Name":      "11f",
+					"RegionID":  11,
+					"HostName":  "derp11f.tailscale.com",
+					"IPv4":      "172.237.61.197",
+					"IPv6":      "2600:3c0d::2000:3bff:fe44:6166",
+					"CanPort80": true
+				}, {
+					"Name":      "11g",
+					"RegionID":  11,
+					"HostName":  "derp11g.tailscale.com",
+					"IPv4":      "172.237.61.190",
+					"IPv6":      "2600:3c0d::2000:62ff:febe:2e67",
+					"CanPort80": true
+				}, {
+					"Name":      "11e",
+					"RegionID":  11,
+					"HostName":  "derp11e.tailscale.com",
+					"IPv4":      "172.237.61.194",
+					"IPv6":      "2600:3c0d::2000:d2ff:fe43:1790",
+					"CanPort80": true
+				}]
+			}, "12": {
+				"RegionID":   12,
+				"RegionCode": "ord",
+				"RegionName": "Chicago",
+				"Latitude":   41.881944,
+				"Longitude":  -87.627778,
+				"Nodes": [{
+					"Name":      "12e",
+					"RegionID":  12,
+					"HostName":  "derp12e.tailscale.com",
+					"IPv4":      "209.177.158.15",
+					"IPv6":      "2607:f740:e::b17",
+					"CanPort80": true
+				}, {
+					"Name":      "12f",
+					"RegionID":  12,
+					"HostName":  "derp12f.tailscale.com",
+					"IPv4":      "199.38.182.118",
+					"IPv6":      "2607:f740:e::4c8",
+					"CanPort80": true
+				}, {
+					"Name":      "12d",
+					"RegionID":  12,
+					"HostName":  "derp12d.tailscale.com",
+					"IPv4":      "209.177.158.246",
+					"IPv6":      "2607:f740:e::811",
+					"CanPort80": true
+				}]
+			}, "13": {
+				"RegionID":   13,
+				"RegionCode": "den",
+				"RegionName": "Denver",
+				"Latitude":   39.7392,
+				"Longitude":  -104.9849,
+				"Nodes": [{
+					"Name":      "13c",
+					"RegionID":  13,
+					"HostName":  "derp13c.tailscale.com",
+					"IPv4":      "192.73.242.28",
+					"IPv6":      "2607:f740:16::5c",
+					"CanPort80": true
+				}, {
+					"Name":      "13d",
+					"RegionID":  13,
+					"HostName":  "derp13d.tailscale.com",
+					"IPv4":      "192.73.242.204",
+					"IPv6":      "2607:f740:16::c23",
+					"CanPort80": true
+				}, {
+					"Name":      "13b",
+					"RegionID":  13,
+					"HostName":  "derp13b.tailscale.com",
+					"IPv4":      "192.73.242.187",
+					"IPv6":      "2607:f740:16::640",
+					"CanPort80": true
+				}]
+			}, "14": {
+				"RegionID":   14,
+				"RegionCode": "ams",
+				"RegionName": "Amsterdam",
+				"Latitude":   52.372778,
+				"Longitude":  4.893611,
+				"Nodes": [{
+					"Name":      "14c",
+					"RegionID":  14,
+					"HostName":  "derp14c.tailscale.com",
+					"IPv4":      "176.58.93.147",
+					"IPv6":      "2a00:dd80:3c::b09",
+					"CanPort80": true
+				}, {
+					"Name":      "14d",
+					"RegionID":  14,
+					"HostName":  "derp14d.tailscale.com",
+					"IPv4":      "176.58.93.154",
+					"IPv6":      "2a00:dd80:3c::3d5",
+					"CanPort80": true
+				}, {
+					"Name":      "14b",
+					"RegionID":  14,
+					"HostName":  "derp14b.tailscale.com",
+					"IPv4":      "176.58.93.248",
+					"IPv6":      "2a00:dd80:3c::807",
+					"CanPort80": true
+				}]
+			}, "15": {
+				"RegionID":   15,
+				"RegionCode": "jnb",
+				"RegionName": "Johannesburg",
+				"Latitude":   -26.204444,
+				"Longitude":  28.045556,
+				"Nodes": [{
+					"Name":      "15c",
+					"RegionID":  15,
+					"HostName":  "derp15c.tailscale.com",
+					"IPv4":      "102.67.165.185",
+					"IPv6":      "2c0f:edb0:0:10::b59",
+					"CanPort80": true
+				}, {
+					"Name":      "15d",
+					"RegionID":  15,
+					"HostName":  "derp15d.tailscale.com",
+					"IPv4":      "102.67.165.36",
+					"IPv6":      "2c0f:edb0:0:10::599",
+					"CanPort80": true
+				}, {
+					"Name":      "15b",
+					"RegionID":  15,
+					"HostName":  "derp15b.tailscale.com",
+					"IPv4":      "102.67.165.90",
+					"IPv6":      "2c0f:edb0:0:10::963",
+					"CanPort80": true
+				}]
+			}, "16": {
+				"RegionID":   16,
+				"RegionCode": "mia",
+				"RegionName": "Miami",
+				"Latitude":   25.78,
+				"Longitude":  -80.21,
+				"Nodes": [{
+					"Name":      "16c",
+					"RegionID":  16,
+					"HostName":  "derp16c.tailscale.com",
+					"IPv4":      "192.73.243.229",
+					"IPv6":      "2607:f740:17::4e4",
+					"CanPort80": true
+				}, {
+					"Name":      "16d",
+					"RegionID":  16,
+					"HostName":  "derp16d.tailscale.com",
+					"IPv4":      "192.73.243.141",
+					"IPv6":      "2607:f740:17::475",
+					"CanPort80": true
+				}, {
+					"Name":      "16b",
+					"RegionID":  16,
+					"HostName":  "derp16b.tailscale.com",
+					"IPv4":      "192.73.243.135",
+					"IPv6":      "2607:f740:17::476",
+					"CanPort80": true
+				}]
+			}, "17": {
+				"RegionID":   17,
+				"RegionCode": "lax",
+				"RegionName": "Los Angeles",
+				"Latitude":   34.05,
+				"Longitude":  -118.25,
+				"Nodes": [{
+					"Name":      "17c",
+					"RegionID":  17,
+					"HostName":  "derp17c.tailscale.com",
+					"IPv4":      "208.111.40.12",
+					"IPv6":      "2607:f740:c::10",
+					"CanPort80": true
+				}, {
+					"Name":      "17d",
+					"RegionID":  17,
+					"HostName":  "derp17d.tailscale.com",
+					"IPv4":      "208.111.40.216",
+					"IPv6":      "2607:f740:c::e1b",
+					"CanPort80": true
+				}, {
+					"Name":      "17b",
+					"RegionID":  17,
+					"HostName":  "derp17b.tailscale.com",
+					"IPv4":      "192.73.244.245",
+					"IPv6":      "2607:f740:c::646",
+					"CanPort80": true
+				}]
+			}, "18": {
+				"RegionID":   18,
+				"RegionCode": "par",
+				"RegionName": "Paris",
+				"Latitude":   48.856667,
+				"Longitude":  2.352222,
+				"Nodes": [{
+					"Name":      "18c",
+					"RegionID":  18,
+					"HostName":  "derp18c.tailscale.com",
+					"IPv4":      "176.58.90.207",
+					"IPv6":      "2a00:dd80:3e::c19",
+					"CanPort80": true
+				}, {
+					"Name":      "18d",
+					"RegionID":  18,
+					"HostName":  "derp18d.tailscale.com",
+					"IPv4":      "176.58.90.104",
+					"IPv6":      "2a00:dd80:3e::f2e",
+					"CanPort80": true
+				}, {
+					"Name":      "18b",
+					"RegionID":  18,
+					"HostName":  "derp18b.tailscale.com",
+					"IPv4":      "176.58.90.147",
+					"IPv6":      "2a00:dd80:3e::363",
+					"CanPort80": true
+				}]
+			}, "19": {
+				"RegionID":   19,
+				"RegionCode": "mad",
+				"RegionName": "Madrid",
+				"Latitude":   40.416944,
+				"Longitude":  -3.703333,
+				"Nodes": [{
+					"Name":      "19c",
+					"RegionID":  19,
+					"HostName":  "derp19c.tailscale.com",
+					"IPv4":      "45.159.97.61",
+					"IPv6":      "2a00:dd80:14:10::20",
+					"CanPort80": true
+				}, {
+					"Name":      "19d",
+					"RegionID":  19,
+					"HostName":  "derp19d.tailscale.com",
+					"IPv4":      "45.159.97.233",
+					"IPv6":      "2a00:dd80:14:10::34a",
+					"CanPort80": true
+				}, {
+					"Name":      "19b",
+					"RegionID":  19,
+					"HostName":  "derp19b.tailscale.com",
+					"IPv4":      "45.159.97.144",
+					"IPv6":      "2a00:dd80:14:10::335",
+					"CanPort80": true
+				}]
+			}, "2": {
+				"RegionID":   2,
+				"RegionCode": "sfo",
+				"RegionName": "San Francisco",
+				"Latitude":   37.7775,
+				"Longitude":  -122.416389,
+				"Nodes": [{
+					"Name":      "2e",
+					"RegionID":  2,
+					"HostName":  "derp2e.tailscale.com",
+					"IPv4":      "192.73.252.134",
+					"IPv6":      "2607:f740:0:3f::44c",
+					"CanPort80": true
+				}, {
+					"Name":      "2f",
+					"RegionID":  2,
+					"HostName":  "derp2f.tailscale.com",
+					"IPv4":      "208.111.34.178",
+					"IPv6":      "2607:f740:0:3f::f4",
+					"CanPort80": true
+				}, {
+					"Name":      "2d",
+					"RegionID":  2,
+					"HostName":  "derp2d.tailscale.com",
+					"IPv4":      "192.73.252.65",
+					"IPv6":      "2607:f740:0:3f::287",
+					"CanPort80": true
+				}]
+			}, "20": {
+				"RegionID":   20,
+				"RegionCode": "hkg",
+				"RegionName": "Hong Kong",
+				"Latitude":   22.3193,
+				"Longitude":  114.1694,
+				"Nodes": [{
+					"Name":      "20c",
+					"RegionID":  20,
+					"HostName":  "derp20c.tailscale.com",
+					"IPv4":      "205.147.105.30",
+					"IPv6":      "2403:2500:8000:1::5fb",
+					"CanPort80": true
+				}, {
+					"Name":      "20d",
+					"RegionID":  20,
+					"HostName":  "derp20d.tailscale.com",
+					"IPv4":      "205.147.105.78",
+					"IPv6":      "2403:2500:8000:1::e9a",
+					"CanPort80": true
+				}, {
+					"Name":      "20b",
+					"RegionID":  20,
+					"HostName":  "derp20b.tailscale.com",
+					"IPv4":      "103.6.84.152",
+					"IPv6":      "2403:2500:8000:1::ef6",
+					"CanPort80": true
+				}]
+			}, "21": {
+				"RegionID":   21,
+				"RegionCode": "tor",
+				"RegionName": "Toronto",
+				"Latitude":   43.741667,
+				"Longitude":  -79.373333,
+				"Nodes": [{
+					"Name":      "21c",
+					"RegionID":  21,
+					"HostName":  "derp21c.tailscale.com",
+					"IPv4":      "162.248.221.215",
+					"IPv6":      "2607:f740:50::f10",
+					"CanPort80": true
+				}, {
+					"Name":      "21d",
+					"RegionID":  21,
+					"HostName":  "derp21d.tailscale.com",
+					"IPv4":      "162.248.221.248",
+					"IPv6":      "2607:f740:50::ca4",
+					"CanPort80": true
+				}, {
+					"Name":      "21b",
+					"RegionID":  21,
+					"HostName":  "derp21b.tailscale.com",
+					"IPv4":      "162.248.221.199",
+					"IPv6":      "2607:f740:50::1d1",
+					"CanPort80": true
+				}]
+			}, "22": {
+				"RegionID":   22,
+				"RegionCode": "waw",
+				"RegionName": "Warsaw",
+				"Latitude":   52.23,
+				"Longitude":  21.011111,
+				"Nodes": [{
+					"Name":      "22c",
+					"RegionID":  22,
+					"HostName":  "derp22c.tailscale.com",
+					"IPv4":      "45.159.98.253",
+					"IPv6":      "2a00:dd80:40:100::3f",
+					"CanPort80": true
+				}, {
+					"Name":      "22d",
+					"RegionID":  22,
+					"HostName":  "derp22d.tailscale.com",
+					"IPv4":      "45.159.98.145",
+					"IPv6":      "2a00:dd80:40:100::211",
+					"CanPort80": true
+				}, {
+					"Name":      "22b",
+					"RegionID":  22,
+					"HostName":  "derp22b.tailscale.com",
+					"IPv4":      "45.159.98.196",
+					"IPv6":      "2a00:dd80:40:100::316",
+					"CanPort80": true
+				}]
+			}, "23": {
+				"RegionID":   23,
+				"RegionCode": "dbi",
+				"RegionName": "Dubai",
+				"Latitude":   25.263056,
+				"Longitude":  55.297222,
+				"Nodes": [{
+					"Name":      "23c",
+					"RegionID":  23,
+					"HostName":  "derp23c.tailscale.com",
+					"IPv4":      "185.34.3.207",
+					"IPv6":      "2a00:dd80:3f:100::a50",
+					"CanPort80": true
+				}, {
+					"Name":      "23d",
+					"RegionID":  23,
+					"HostName":  "derp23d.tailscale.com",
+					"IPv4":      "185.34.3.75",
+					"IPv6":      "2a00:dd80:3f:100::97e",
+					"CanPort80": true
+				}, {
+					"Name":      "23b",
+					"RegionID":  23,
+					"HostName":  "derp23b.tailscale.com",
+					"IPv4":      "185.34.3.232",
+					"IPv6":      "2a00:dd80:3f:100::76f",
+					"CanPort80": true
+				}]
+			}, "24": {
+				"RegionID":   24,
+				"RegionCode": "hnl",
+				"RegionName": "Honolulu",
+				"Latitude":   21.306944,
+				"Longitude":  -157.858333,
+				"Nodes": [{
+					"Name":      "24c",
+					"RegionID":  24,
+					"HostName":  "derp24c.tailscale.com",
+					"IPv4":      "208.83.233.233",
+					"IPv6":      "2001:19f0:c000:c591:5400:04ff:fe26:2c5f",
+					"CanPort80": true
+				}, {
+					"Name":      "24d",
+					"RegionID":  24,
+					"HostName":  "derp24d.tailscale.com",
+					"IPv4":      "208.72.155.133",
+					"IPv6":      "2001:19f0:c000:c564:5400:04ff:fe26:2ba8",
+					"CanPort80": true
+				}, {
+					"Name":      "24b",
+					"RegionID":  24,
+					"HostName":  "derp24b.tailscale.com",
+					"IPv4":      "208.83.234.151",
+					"IPv6":      "2001:19f0:c000:c586:5400:04ff:fe26:2ba6",
+					"CanPort80": true
+				}]
+			}, "25": {
+				"RegionID":   25,
+				"RegionCode": "nai",
+				"RegionName": "Nairobi",
+				"Latitude":   -1.286389,
+				"Longitude":  36.817222,
+				"Nodes": [{
+					"Name":      "25c",
+					"RegionID":  25,
+					"HostName":  "derp25c.tailscale.com",
+					"IPv4":      "102.67.167.37",
+					"IPv6":      "2c0f:edb0:2000:1::2c7",
+					"CanPort80": true
+				}, {
+					"Name":      "25d",
+					"RegionID":  25,
+					"HostName":  "derp25d.tailscale.com",
+					"IPv4":      "102.67.167.188",
+					"IPv6":      "2c0f:edb0:2000:1::188",
+					"CanPort80": true
+				}, {
+					"Name":      "25b",
+					"RegionID":  25,
+					"HostName":  "derp25b.tailscale.com",
+					"IPv4":      "102.67.167.245",
+					"IPv6":      "2c0f:edb0:2000:1::2e9",
+					"CanPort80": true
+				}]
+			}, "26": {
+				"RegionID":   26,
+				"RegionCode": "nue",
+				"RegionName": "Nuremberg",
+				"Latitude":   49.453889,
+				"Longitude":  11.0775,
+				"Nodes": [{
+					"Name":      "26c",
+					"RegionID":  26,
+					"HostName":  "derp26c.tailscale.com",
+					"IPv4":      "49.12.193.137",
+					"IPv6":      "2a01:4f8:1c1c:5c70::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26d",
+					"RegionID":  26,
+					"HostName":  "derp26d.tailscale.com",
+					"IPv4":      "49.13.204.141",
+					"IPv6":      "2a01:4f8:1c0c:7d06::1",
+					"CanPort80": true
+				}, {
+					"Name":      "26b",
+					"RegionID":  26,
+					"HostName":  "derp26b.tailscale.com",
+					"IPv4":      "167.235.72.200",
+					"IPv6":      "2a01:4f8:1c1c:47b6::1",
+					"CanPort80": true
+				}]
+			}, "27": {
+				"RegionID":   27,
+				"RegionCode": "iad",
+				"RegionName": "Ashburn",
+				"Latitude":   39.03,
+				"Longitude":  -77.471111,
+				"Nodes": [{
+					"Name":      "27d",
+					"RegionID":  27,
+					"HostName":  "derp27d.tailscale.com",
+					"IPv4":      "178.156.152.106",
+					"IPv6":      "2a01:4ff:f0:3c8e::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27c",
+					"RegionID":  27,
+					"HostName":  "derp27c.tailscale.com",
+					"IPv4":      "178.156.152.91",
+					"IPv6":      "2a01:4ff:f0:3913::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27e",
+					"RegionID":  27,
+					"HostName":  "derp27e.tailscale.com",
+					"IPv4":      "178.156.134.232",
+					"IPv6":      "2a01:4ff:f0:28d4::1",
+					"CanPort80": true
+				}, {
+					"Name":      "27b",
+					"RegionID":  27,
+					"HostName":  "derp27b.tailscale.com",
+					"IPv4":      "5.161.218.233",
+					"IPv6":      "2a01:4ff:f0:3db9::1",
+					"CanPort80": true
+				}]
+			}, "28": {
+				"RegionID":   28,
+				"RegionCode": "hel",
+				"RegionName": "Helsinki",
+				"Latitude":   60.170833,
+				"Longitude":  24.9375,
+				"Nodes": [{
+					"Name":      "28c",
+					"RegionID":  28,
+					"HostName":  "derp28c.tailscale.com",
+					"IPv4":      "95.217.2.165",
+					"IPv6":      "2a01:4f9:c012:cd74::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28d",
+					"RegionID":  28,
+					"HostName":  "derp28d.tailscale.com",
+					"IPv4":      "157.180.28.32",
+					"IPv6":      "2a01:4f9:c012:2e5b::1",
+					"CanPort80": true
+				}, {
+					"Name":      "28b",
+					"RegionID":  28,
+					"HostName":  "derp28b.tailscale.com",
+					"IPv4":      "65.109.143.62",
+					"IPv6":      "2a01:4f9:c012:d55c::1",
+					"CanPort80": true
+				}]
+			}, "3": {
+				"RegionID":   3,
+				"RegionCode": "sin",
+				"RegionName": "Singapore",
+				"Latitude":   1.3521,
+				"Longitude":  103.8198,
+				"Nodes": [{
+					"Name":      "3g",
+					"RegionID":  3,
+					"HostName":  "derp3g.tailscale.com",
+					"IPv4":      "172.237.72.79",
+					"IPv6":      "2600:3c15::2000:adff:fe08:6fab",
+					"CanPort80": true
+				}, {
+					"Name":      "3f",
+					"RegionID":  3,
+					"HostName":  "derp3f.tailscale.com",
+					"IPv4":      "172.237.72.8",
+					"IPv6":      "2600:3c15::2000:53ff:fe48:a668",
+					"CanPort80": true
+				}, {
+					"Name":      "3h",
+					"RegionID":  3,
+					"HostName":  "derp3h.tailscale.com",
+					"IPv4":      "172.237.66.30",
+					"IPv6":      "2600:3c15::2000:3dff:fe44:50aa",
+					"CanPort80": true
+				}, {
+					"Name":      "3e",
+					"RegionID":  3,
+					"HostName":  "derp3e.tailscale.com",
+					"IPv4":      "172.237.72.43",
+					"IPv6":      "2600:3c15::2000:6cff:fee4:d799",
+					"CanPort80": true
+				}]
+			}, "4": {
+				"RegionID":   4,
+				"RegionCode": "fra",
+				"RegionName": "Frankfurt",
+				"Latitude":   50.1109,
+				"Longitude":  8.6821,
+				"Nodes": [{
+					"Name":      "4h",
+					"RegionID":  4,
+					"HostName":  "derp4h.tailscale.com",
+					"IPv4":      "185.40.234.77",
+					"IPv6":      "2a00:dd80:20::bcf",
+					"CanPort80": true
+				}, {
+					"Name":      "4i",
+					"RegionID":  4,
+					"HostName":  "derp4i.tailscale.com",
+					"IPv4":      "185.40.234.53",
+					"IPv6":      "2a00:dd80:20::8a6",
+					"CanPort80": true
+				}, {
+					"Name":      "4g",
+					"RegionID":  4,
+					"HostName":  "derp4g.tailscale.com",
+					"IPv4":      "185.40.234.113",
+					"IPv6":      "2a00:dd80:20::8f",
+					"CanPort80": true
+				}, {
+					"Name":      "4j",
+					"RegionID":  4,
+					"HostName":  "derp4j.tailscale.com",
+					"IPv4":      "185.40.234.176",
+					"IPv6":      "2a00:dd80:20::e67",
+					"CanPort80": true
+				}, {
+					"Name":      "4f",
+					"RegionID":  4,
+					"HostName":  "derp4f.tailscale.com",
+					"IPv4":      "185.40.234.219",
+					"IPv6":      "2a00:dd80:20::a25",
+					"CanPort80": true
+				}]
+			}, "5": {
+				"RegionID":   5,
+				"RegionCode": "syd",
+				"RegionName": "Sydney",
+				"Latitude":   -33.867778,
+				"Longitude":  151.21,
+				"Nodes": [{
+					"Name":      "5f",
+					"RegionID":  5,
+					"HostName":  "derp5f.tailscale.com",
+					"IPv4":      "172.105.166.103",
+					"IPv6":      "2400:8907::2000:ccff:fe1f:80da",
+					"CanPort80": true
+				}, {
+					"Name":      "5g",
+					"RegionID":  5,
+					"HostName":  "derp5g.tailscale.com",
+					"IPv4":      "172.105.169.57",
+					"IPv6":      "2400:8907::2000:2fff:fea7:57f4",
+					"CanPort80": true
+				}, {
+					"Name":      "5e",
+					"RegionID":  5,
+					"HostName":  "derp5e.tailscale.com",
+					"IPv4":      "172.105.179.230",
+					"IPv6":      "2400:8907::2000:ceff:fe8d:4f4e",
+					"CanPort80": true
+				}]
+			}, "6": {
+				"RegionID":   6,
+				"RegionCode": "blr",
+				"RegionName": "Bengaluru",
+				"Latitude":   12.9716,
+				"Longitude":  77.5946,
+				"Nodes": [{
+					"Name":      "6a",
+					"RegionID":  6,
+					"HostName":  "derp6.tailscale.com",
+					"IPv4":      "68.183.90.120",
+					"IPv6":      "2400:6180:100:d0::982:d001",
+					"CanPort80": true
+				}]
+			}, "7": {
+				"RegionID":   7,
+				"RegionCode": "tok",
+				"RegionName": "Tokyo",
+				"Latitude":   35.6764,
+				"Longitude":  139.65,
+				"Nodes": [{
+					"Name":      "7g",
+					"RegionID":  7,
+					"HostName":  "derp7g.tailscale.com",
+					"IPv4":      "172.238.6.179",
+					"IPv6":      "2600:3c18::2000:3fff:fe80:3ebd",
+					"CanPort80": true
+				}, {
+					"Name":      "7f",
+					"RegionID":  7,
+					"HostName":  "derp7f.tailscale.com",
+					"IPv4":      "172.238.6.34",
+					"IPv6":      "2600:3c18::2000:acff:fe8e:3ed5",
+					"CanPort80": true
+				}, {
+					"Name":      "7h",
+					"RegionID":  7,
+					"HostName":  "derp7h.tailscale.com",
+					"IPv4":      "172.237.28.183",
+					"IPv6":      "2600:3c18::2000:b1ff:fea9:4560",
+					"CanPort80": true
+				}, {
+					"Name":      "7e",
+					"RegionID":  7,
+					"HostName":  "derp7e.tailscale.com",
+					"IPv4":      "172.238.6.180",
+					"IPv6":      "2600:3c18::2000:60ff:fe0f:6e83",
+					"STUNOnly":  true,
+					"CanPort80": true
+				}]
+			}, "8": {
+				"RegionID":   8,
+				"RegionCode": "lhr",
+				"RegionName": "London",
+				"Latitude":   51.5072,
+				"Longitude":  0.1276,
+				"Nodes": [{
+					"Name":      "8f",
+					"RegionID":  8,
+					"HostName":  "derp8f.tailscale.com",
+					"IPv4":      "176.58.88.183",
+					"IPv6":      "2a00:dd80:3a::dfa",
+					"CanPort80": true
+				}, {
+					"Name":      "8g",
+					"RegionID":  8,
+					"HostName":  "derp8g.tailscale.com",
+					"IPv4":      "176.58.92.254",
+					"IPv6":      "2a00:dd80:3a::ed",
+					"CanPort80": true
+				}, {
+					"Name":      "8e",
+					"RegionID":  8,
+					"HostName":  "derp8e.tailscale.com",
+					"IPv4":      "176.58.92.144",
+					"IPv6":      "2a00:dd80:3a::b33",
+					"CanPort80": true
+				}]
+			}, "9": {
+				"RegionID":   9,
+				"RegionCode": "dfw",
+				"RegionName": "Dallas",
+				"Latitude":   32.779167,
+				"Longitude":  -96.808889,
+				"Nodes": [{
+					"Name":      "9e",
+					"RegionID":  9,
+					"HostName":  "derp9e.tailscale.com",
+					"IPv4":      "192.73.248.83",
+					"IPv6":      "2607:f740:100::359",
+					"CanPort80": true
+				}, {
+					"Name":      "9f",
+					"RegionID":  9,
+					"HostName":  "derp9f.tailscale.com",
+					"IPv4":      "209.177.156.197",
+					"IPv6":      "2607:f740:100::cad",
+					"CanPort80": true
+				}, {
+					"Name":      "9d",
+					"RegionID":  9,
+					"HostName":  "derp9d.tailscale.com",
+					"IPv4":      "209.177.156.94",
+					"IPv6":      "2607:f740:100::c05",
+					"CanPort80": true
+				}]
+			}}},
+			"DisplayMessages":  null,
+			"TKAEnabled":       false,
+			"TKAHead":          "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+			"Domain":           "odin@example.com",
+			"DomainAuditLogID": "",
+			"UserProfiles": {"1260082990019555": {
+				"ID":          1260082990019555,
+				"LoginName":   "tagged-devices",
+				"DisplayName": "Tagged Devices"
+			}, "3609737328847972": {
+				"ID":          3609737328847972,
+				"LoginName":   "weedle.tail78f774.ts.net",
+				"DisplayName": "weedle"
+			}, "3982058329734709": {
+				"ID":          3982058329734709,
+				"LoginName":   "freya@example.com",
+				"DisplayName": "freya"
+			}, "4156223528223174": {
+				"ID":          4156223528223174,
+				"LoginName":   "odin@example.com",
+				"DisplayName": "odin"
+			}, "4538565228176803": {
+				"ID":          4538565228176803,
+				"LoginName":   "thor@example.org",
+				"DisplayName": "thor"
+			}}
+		}
+	}}
+}

--- a/hscontrol/policy/v2/types.go
+++ b/hscontrol/policy/v2/types.go
@@ -863,6 +863,12 @@ type Alias interface {
 	Validate() error
 	UnmarshalJSON(b []byte) error
 
+	// String renders the alias back to its policy-file form. Implementations
+	// are expected to return a value that round-trips through parseAlias for
+	// any alias the parser accepted, so callers can use it as a stable
+	// identity in rendered errors and logs.
+	String() string
+
 	// Resolve resolves the Alias to an IPSet. The IPSet will contain all the IP
 	// addresses that the Alias represents within Headscale. It is the product
 	// of the Alias and the Policy, Users and Nodes.
@@ -2927,10 +2933,6 @@ func (p *SSHCheckPeriod) UnmarshalJSON(b []byte) error {
 		return nil
 	}
 
-	// time.ParseDuration produces error strings like
-	// `time: invalid duration "abc"` which match SaaS body wording
-	// exactly; model.ParseDuration wraps the same parse with custom
-	// phrasing and would diverge.
 	d, err := time.ParseDuration(str)
 	if err != nil {
 		return err
@@ -3407,7 +3409,7 @@ func validateSSHTests(pol *Policy, tests []SSHPolicyTest) error {
 	var errs []error
 
 	for i, t := range tests {
-		if t.Src == "" {
+		if t.Src == nil {
 			errs = append(errs, fmt.Errorf("sshTest %d: %w", i, ErrSSHTestEmptySrc))
 		}
 
@@ -3439,11 +3441,8 @@ func validateSSHTests(pol *Policy, tests []SSHPolicyTest) error {
 //
 // A bare IP literal (single-host /BitLen prefix) is accepted. Tag
 // entries must exist in tagOwners.
-func validateSSHTestDestination(pol *Policy, dst string) error {
-	alias, err := parseAlias(dst)
-	if err != nil {
-		return fmt.Errorf("%w %q", ErrSSHTestDstDisallowedElement, dst)
-	}
+func validateSSHTestDestination(pol *Policy, alias Alias) error {
+	dst := alias.String()
 
 	switch a := alias.(type) {
 	case *AutoGroup:
@@ -3454,9 +3453,10 @@ func validateSSHTestDestination(pol *Policy, dst string) error {
 		}
 
 	case *Prefix:
-		// Bare IP parses to a *Prefix without slash; reject any
-		// explicit CIDR.
-		if strings.Contains(dst, "/") {
+		// A bare IP parses as `/BitLen` and is a valid single-host dst;
+		// any narrower CIDR is a multi-host range and is rejected.
+		p := netip.Prefix(*a)
+		if p.Bits() < p.Addr().BitLen() {
 			return fmt.Errorf("%w %q", ErrSSHTestDstDisallowedElement, dst)
 		}
 

--- a/hscontrol/policy/v2/types.go
+++ b/hscontrol/policy/v2/types.go
@@ -153,6 +153,10 @@ var (
 	ErrTestDestinationMultiPort    = errors.New("test destination port must be a single port")
 	ErrTestDestinationCIDR         = errors.New("test destination must be a single host, not a CIDR range")
 	ErrAutogroupInternetTestDst    = errors.New("autogroup:internet not valid as a test destination")
+	ErrSSHTestEmptySrc             = errors.New("SSH tests entry must have a non-empty src")
+	ErrSSHTestEmptyDst             = errors.New("SSH tests entry must have at least one dst")
+	ErrSSHTestDstUnknownTag        = errors.New("SSH tests dst contains unknown tag")
+	ErrSSHTestDstDisallowedElement = errors.New("SSH tests dst contains disallowed element")
 )
 
 type resolved struct {
@@ -2084,6 +2088,7 @@ type Policy struct {
 	AutoApprovers       AutoApproverPolicy `json:"autoApprovers"`
 	SSHs                []SSH              `json:"ssh,omitempty"`
 	Tests               []PolicyTest       `json:"tests,omitempty"`
+	SSHTests            []SSHPolicyTest    `json:"sshTests,omitempty"`
 	RandomizeClientPort bool               `json:"randomizeClientPort,omitempty"`
 }
 
@@ -2891,6 +2896,10 @@ func (p *Policy) validate() error {
 		errs = append(errs, err)
 	}
 
+	if err := validateSSHTests(p, p.SSHTests); err != nil { //nolint:noinlineerr
+		errs = append(errs, err)
+	}
+
 	if len(errs) > 0 {
 		return multierr.New(errs...)
 	}
@@ -3384,6 +3393,101 @@ func validateTestDestination(pol *Policy, dst string) error {
 			if p.Bits() < p.Addr().BitLen() {
 				return ErrTestDestinationCIDR
 			}
+		}
+	}
+
+	return nil
+}
+
+// validateSSHTests enforces parse-time shape on every sshTests entry:
+// non-empty src, at least one dst, and each dst describing a single
+// SSH-reachable host. Login-user assertions land with the engine so
+// failures surface through the same errSSHPolicyTestsFailed wrapper.
+func validateSSHTests(pol *Policy, tests []SSHPolicyTest) error {
+	var errs []error
+
+	for i, t := range tests {
+		if t.Src == "" {
+			errs = append(errs, fmt.Errorf("sshTest %d: %w", i, ErrSSHTestEmptySrc))
+		}
+
+		if len(t.Dst) == 0 {
+			errs = append(errs, fmt.Errorf("sshTest %d: %w", i, ErrSSHTestEmptyDst))
+		}
+
+		for _, dst := range t.Dst {
+			err := validateSSHTestDestination(pol, dst)
+			if err != nil {
+				errs = append(errs, fmt.Errorf("sshTest %d: %w", i, err))
+			}
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("%w:\n%w", errSSHPolicyTestsFailed, multierr.New(errs...))
+	}
+
+	return nil
+}
+
+// validateSSHTestDestination rejects sshTests dst shapes that cannot
+// name a single SSH-reachable host:
+//
+//   - `host:port` suffixes (parsed as an unknown tag),
+//   - multi-host CIDRs (raw `/N` or a hosts: entry resolving wider),
+//   - autogroup:internet (valid as ACL dst only).
+//
+// A bare IP literal (single-host /BitLen prefix) is accepted. Tag
+// entries must exist in tagOwners.
+func validateSSHTestDestination(pol *Policy, dst string) error {
+	alias, err := parseAlias(dst)
+	if err != nil {
+		return fmt.Errorf("%w %q", ErrSSHTestDstDisallowedElement, dst)
+	}
+
+	switch a := alias.(type) {
+	case *AutoGroup:
+		// autogroup:internet is the only autogroup not valid here;
+		// member/tagged/self/nonroot pass to engine evaluation.
+		if *a == AutoGroupInternet {
+			return fmt.Errorf("%w %q", ErrSSHTestDstDisallowedElement, dst)
+		}
+
+	case *Prefix:
+		// Bare IP parses to a *Prefix without slash; reject any
+		// explicit CIDR.
+		if strings.Contains(dst, "/") {
+			return fmt.Errorf("%w %q", ErrSSHTestDstDisallowedElement, dst)
+		}
+
+	case *Tag:
+		// A tag must be declared in tagOwners. `tag:server:22` lands
+		// here too because isTag only checks the prefix, so the lookup
+		// misses and the colon-port suffix surfaces as unknown-tag.
+		if pol == nil {
+			return fmt.Errorf("%w %q", ErrSSHTestDstUnknownTag, string(*a))
+		}
+
+		err := pol.TagOwners.Contains(a)
+		if err != nil {
+			return fmt.Errorf("%w %q", ErrSSHTestDstUnknownTag, string(*a))
+		}
+
+	case *Host:
+		// A hosts: alias that resolves to multiple addresses is a CIDR
+		// in disguise.
+		if pol == nil {
+			return nil
+		}
+
+		pref, ok := pol.Hosts[*a]
+		if !ok {
+			return nil
+		}
+
+		p := netip.Prefix(pref)
+		if p.Bits() < p.Addr().BitLen() {
+			return fmt.Errorf("%w %q", ErrSSHTestDstDisallowedElement, dst)
 		}
 	}
 

--- a/hscontrol/policy/v2/types.go
+++ b/hscontrol/policy/v2/types.go
@@ -14,7 +14,6 @@ import (
 	"github.com/go-json-experiment/json"
 	"github.com/juanfont/headscale/hscontrol/types"
 	"github.com/juanfont/headscale/hscontrol/util"
-	"github.com/prometheus/common/model"
 	"github.com/tailscale/hujson"
 	"go4.org/netipx"
 	"tailscale.com/net/tsaddr"
@@ -35,8 +34,6 @@ const Wildcard = Asterix(0)
 
 var ErrAutogroupSelfRequiresPerNodeResolution = errors.New("autogroup:self requires per-node resolution and cannot be resolved in this context")
 
-var ErrCircularReference = errors.New("circular reference detected")
-
 var ErrUndefinedTagReference = errors.New("references undefined tag")
 
 // SSH validation errors.
@@ -46,17 +43,25 @@ var (
 	ErrSSHAutogroupSelfRequiresUserSource = errors.New("autogroup:self destination requires source to contain only users or groups, not tags or autogroup:tagged")
 	ErrSSHTagSourceToAutogroupMember      = errors.New("tags in SSH source cannot access autogroup:member (user-owned devices)")
 	ErrSSHWildcardDestination             = errors.New("wildcard (*) is not supported as SSH destination")
-	ErrSSHCheckPeriodBelowMin             = errors.New("checkPeriod below minimum of 1 minute")
-	ErrSSHCheckPeriodAboveMax             = errors.New("checkPeriod above maximum of 168 hours (1 week)")
+	ErrSSHCheckPeriodAboveMax             = errors.New("is above the max (168h)")
+	ErrSSHCheckPeriodNegative             = errors.New("must be a positive duration")
 	ErrSSHCheckPeriodOnNonCheck           = errors.New("checkPeriod is only valid with action \"check\"")
 	ErrInvalidLocalpart                   = errors.New("invalid localpart format, must be localpart:*@<domain>")
+	ErrSSHUsersMustBeSpecified            = errors.New("users must be specified")
+	ErrSSHUserInvalid                     = errors.New("is not valid")
+	ErrSSHAcceptEnvEmpty                  = errors.New("acceptEnv values cannot be empty")
+	ErrSSHActionMustBeSpecified           = errors.New("action must be specified")
+	ErrSSHActionInvalid                   = errors.New("is not a valid action")
+	ErrSSHDestinationHostAlias            = errors.New("invalid dst")
+	ErrTagNameMustStartWithLetter         = errors.New("tag names must start with a letter, after 'tag:'")
+	ErrGroupMembersCannotBeRecursive      = errors.New("group members cannot be recursive")
 )
 
 // SSH check period constants per Tailscale docs:
 // https://tailscale.com/docs/features/tailscale-ssh#checkperiod
+// SaaS imposes no minimum (0s is accepted) so headscale matches.
 const (
 	SSHCheckPeriodDefault = 12 * time.Hour
-	SSHCheckPeriodMin     = time.Minute
 	SSHCheckPeriodMax     = 168 * time.Hour
 )
 
@@ -120,7 +125,6 @@ var (
 	ErrGroupNotDefined             = errors.New("group not defined in policy")
 	ErrInvalidGroupMember          = errors.New("invalid group member type")
 	ErrGroupValueNotArray          = errors.New("group value must be an array of users")
-	ErrNestedGroups                = errors.New("nested groups are not allowed")
 	ErrInvalidHostIP               = errors.New("hostname contains invalid IP address")
 	ErrTagNotDefined               = errors.New("tag not found")
 	ErrAutoApproverNotAlias        = errors.New("auto approver is not an alias")
@@ -137,7 +141,6 @@ var (
 	ErrAutogroupDangerAllDst       = errors.New("cannot use autogroup:danger-all as a dst")
 	ErrAutogroupNotSupportedSSHSrc = errors.New("autogroup not supported for SSH sources")
 	ErrAutogroupNotSupportedSSHDst = errors.New("autogroup not supported for SSH destinations")
-	ErrAutogroupNotSupportedSSHUsr = errors.New("autogroup not supported for SSH user")
 	ErrHostNotDefined              = errors.New("host not defined in policy")
 	ErrSSHSourceAliasNotSupported  = errors.New("alias not supported for SSH source")
 	ErrSSHDestAliasNotSupported    = errors.New("alias not supported for SSH destination")
@@ -539,12 +542,27 @@ func (g *Group) resolve(p *Policy, users types.Users, nodes views.Slice[types.No
 // Tag is a special string which is always prefixed with `tag:`.
 type Tag string
 
+// Validate enforces the `tag:` prefix and the SaaS rule that the
+// first character after the prefix is an ASCII letter ([A-Za-z]).
+// Subsequent characters may be ASCII letters, digits, hyphens, or
+// dots — those are checked by the existing alias parser elsewhere.
 func (t *Tag) Validate() error {
-	if isTag(string(*t)) {
-		return nil
+	s := string(*t)
+	if !isTag(s) {
+		return fmt.Errorf("%w, got: %q", ErrInvalidTagFormat, *t)
 	}
 
-	return fmt.Errorf("%w, got: %q", ErrInvalidTagFormat, *t)
+	rest := strings.TrimPrefix(s, "tag:")
+	if rest == "" {
+		return ErrTagNameMustStartWithLetter
+	}
+
+	first := rest[0]
+	if (first < 'a' || first > 'z') && (first < 'A' || first > 'Z') {
+		return ErrTagNameMustStartWithLetter
+	}
+
+	return nil
 }
 
 func (t *Tag) UnmarshalJSON(b []byte) error {
@@ -1056,10 +1074,17 @@ func parseAlias(vs string) (Alias, error) {
 // AliasEnc is used to deserialize a Alias.
 type AliasEnc struct{ Alias }
 
+// UnmarshalJSON trims surrounding whitespace from each alias string
+// before dispatching so that `"tag:server "` or `" odin@example.com"`
+// resolves to the same tag or user SaaS would resolve. SaaS trims
+// before lookup; a literal-match policy here would drop the affected
+// node from every rule referencing it.
 func (ve *AliasEnc) UnmarshalJSON(b []byte) error {
 	ptr, err := unmarshalPointer(
 		b,
-		parseAlias,
+		func(s string) (Alias, error) {
+			return parseAlias(strings.TrimSpace(s))
+		},
 	)
 	if err != nil {
 		return err
@@ -1379,6 +1404,25 @@ func (g *Groups) UnmarshalJSON(b []byte) error {
 		}
 	}
 
+	// Reject group-in-group references. Reverse-sort the keys so the
+	// reported (parent, child) pair names the deepest non-leaf parent
+	// first.
+	keys := make([]string, 0, len(rawGroups))
+	for k := range rawGroups {
+		keys = append(keys, k)
+	}
+
+	slices.Sort(keys)
+	slices.Reverse(keys)
+
+	for _, key := range keys {
+		for _, u := range rawGroups[key] {
+			if isGroup(u) {
+				return fmt.Errorf("groups[%q]: %q: %w", key, u, ErrGroupMembersCannotBeRecursive)
+			}
+		}
+	}
+
 	*g = make(Groups)
 
 	for key, value := range rawGroups {
@@ -1391,10 +1435,6 @@ func (g *Groups) UnmarshalJSON(b []byte) error {
 
 			err := username.Validate()
 			if err != nil {
-				if isGroup(u) {
-					return fmt.Errorf("%w: found %q inside %q", ErrNestedGroups, u, group)
-				}
-
 				return err
 			}
 
@@ -1646,16 +1686,20 @@ func (a *SSHAction) String() string {
 	return string(*a)
 }
 
-// UnmarshalJSON implements JSON unmarshaling for SSHAction.
+// UnmarshalJSON trims surrounding whitespace before matching, lets the
+// empty string through (per-rule Validate() surfaces it later), and
+// rejects every other unknown value here.
 func (a *SSHAction) UnmarshalJSON(b []byte) error {
-	str := strings.Trim(string(b), `"`)
+	str := strings.TrimSpace(strings.Trim(string(b), `"`))
 	switch str {
+	case "":
+		*a = SSHAction("")
 	case "accept":
 		*a = SSHActionAccept
 	case "check":
 		*a = SSHActionCheck
 	default:
-		return fmt.Errorf("%w: %q, must be one of: accept, check", ErrInvalidSSHAction, str)
+		return fmt.Errorf("%q %w", str, ErrSSHActionInvalid)
 	}
 
 	return nil
@@ -2052,7 +2096,6 @@ var (
 	autogroupForDst       = []AutoGroup{AutoGroupInternet, AutoGroupMember, AutoGroupTagged, AutoGroupSelf}
 	autogroupForSSHSrc    = []AutoGroup{AutoGroupMember, AutoGroupTagged}
 	autogroupForSSHDst    = []AutoGroup{AutoGroupMember, AutoGroupTagged, AutoGroupSelf}
-	autogroupForSSHUser   = []AutoGroup{AutoGroupNonRoot}
 	autogroupForNodeAttrs = []AutoGroup{AutoGroupMember, AutoGroupTagged}
 	autogroupNotSupported = []AutoGroup{}
 
@@ -2187,18 +2230,6 @@ func validateAutogroupForSSHDst(dst *AutoGroup) error {
 
 	if !slices.Contains(autogroupForSSHDst, *dst) {
 		return fmt.Errorf("%w: %q, can be %v", ErrAutogroupNotSupportedSSHDst, *dst, autogroupForSSHDst)
-	}
-
-	return nil
-}
-
-func validateAutogroupForSSHUser(user *AutoGroup) error {
-	if user == nil {
-		return nil
-	}
-
-	if !slices.Contains(autogroupForSSHUser, *user) {
-		return fmt.Errorf("%w: %q, can be %v", ErrAutogroupNotSupportedSSHUsr, *user, autogroupForSSHUser)
 	}
 
 	return nil
@@ -2479,23 +2510,29 @@ func (p *Policy) validate() error {
 	}
 
 	for _, ssh := range p.SSHs {
+		// Empty action and users survive parse; surface them here.
+		if ssh.Action == "" {
+			errs = append(errs, ErrSSHActionMustBeSpecified)
+		}
+
+		if len(ssh.Users) == 0 {
+			errs = append(errs, ErrSSHUsersMustBeSpecified)
+		}
+
+		// "" and "*" are not valid login users; any other string
+		// (including autogroup, group, tag, malformed localpart) is
+		// treated as a literal user name.
 		for _, user := range ssh.Users {
-			if strings.HasPrefix(string(user), "autogroup:") {
-				maybeAuto := AutoGroup(user)
-
-				err := validateAutogroupForSSHUser(&maybeAuto)
-				if err != nil {
-					errs = append(errs, err)
-					continue
-				}
+			switch user {
+			case "", "*":
+				errs = append(errs, fmt.Errorf("user %q %w", user, ErrSSHUserInvalid))
 			}
+		}
 
-			if user.IsLocalpart() {
-				_, err := user.ParseLocalpart()
-				if err != nil {
-					errs = append(errs, err)
-					continue
-				}
+		// acceptEnv entries cannot be empty; "*" and "**" are valid.
+		for _, env := range ssh.AcceptEnv {
+			if env == "" {
+				errs = append(errs, ErrSSHAcceptEnvEmpty)
 			}
 		}
 
@@ -2555,6 +2592,10 @@ func (p *Policy) validate() error {
 				if err != nil {
 					errs = append(errs, err)
 				}
+			case *Host:
+				// Hosts-table aliases are valid on ACL dst but
+				// rejected here for SSH dst.
+				errs = append(errs, fmt.Errorf("%w %q", ErrSSHDestinationHostAlias, string(*dst)))
 			}
 		}
 
@@ -2877,12 +2918,16 @@ func (p *SSHCheckPeriod) UnmarshalJSON(b []byte) error {
 		return nil
 	}
 
-	d, err := model.ParseDuration(str)
+	// time.ParseDuration produces error strings like
+	// `time: invalid duration "abc"` which match SaaS body wording
+	// exactly; model.ParseDuration wraps the same parse with custom
+	// phrasing and would diverge.
+	d, err := time.ParseDuration(str)
 	if err != nil {
-		return fmt.Errorf("parsing checkPeriod %q: %w", str, err)
+		return err
 	}
 
-	p.Duration = time.Duration(d)
+	p.Duration = d
 
 	return nil
 }
@@ -2896,26 +2941,19 @@ func (p SSHCheckPeriod) MarshalJSON() ([]byte, error) {
 	return fmt.Appendf(nil, "%q", p.Duration.String()), nil
 }
 
-// Validate checks that the SSHCheckPeriod is within allowed bounds.
+// Validate rejects negative durations and anything above the inclusive
+// 168h max.
 func (p *SSHCheckPeriod) Validate() error {
 	if p.Always {
 		return nil
 	}
 
-	if p.Duration < SSHCheckPeriodMin {
-		return fmt.Errorf(
-			"%w: got %s",
-			ErrSSHCheckPeriodBelowMin,
-			p.Duration,
-		)
+	if p.Duration < 0 {
+		return fmt.Errorf("checkPeriod %s %w", p.Duration, ErrSSHCheckPeriodNegative)
 	}
 
 	if p.Duration > SSHCheckPeriodMax {
-		return fmt.Errorf(
-			"%w: got %s",
-			ErrSSHCheckPeriodAboveMax,
-			p.Duration,
-		)
+		return fmt.Errorf("checkPeriod %s %w", p.Duration, ErrSSHCheckPeriodAboveMax)
 	}
 
 	return nil
@@ -3093,25 +3131,31 @@ func (u SSHUsers) ContainsNonRoot() bool {
 	return slices.Contains(u, SSHUser(AutoGroupNonRoot))
 }
 
-// ContainsLocalpart returns true if any entry has the localpart: prefix.
+// ContainsLocalpart returns true if any entry is a canonical
+// `localpart:*@<domain>` form. Non-canonical strings starting with
+// `localpart:` are treated as literal usernames.
 func (u SSHUsers) ContainsLocalpart() bool {
 	return slices.ContainsFunc(u, func(user SSHUser) bool {
-		return user.IsLocalpart()
+		return user.IsCanonicalLocalpart()
 	})
 }
 
-// NormalUsers returns all SSH users that are not root, autogroup:nonroot,
-// or localpart: entries.
+// NormalUsers returns users that land in the compiled literal user map
+// (everything except root, autogroup:nonroot, and canonical
+// `localpart:*@<domain>`). Malformed `localpart:` strings stay here as
+// literals.
 func (u SSHUsers) NormalUsers() []SSHUser {
 	return slicesx.Filter(nil, u, func(user SSHUser) bool {
-		return user != "root" && user != SSHUser(AutoGroupNonRoot) && !user.IsLocalpart()
+		return user != "root" && user != SSHUser(AutoGroupNonRoot) && !user.IsCanonicalLocalpart()
 	})
 }
 
-// LocalpartEntries returns only the localpart: prefixed entries.
+// LocalpartEntries returns only canonical `localpart:*@<domain>` entries.
+// Non-canonical localpart strings are excluded so they do not trigger
+// the resolution path; they are emitted literally by NormalUsers.
 func (u SSHUsers) LocalpartEntries() []SSHUser {
 	return slicesx.Filter(nil, u, func(user SSHUser) bool {
-		return user.IsLocalpart()
+		return user.IsCanonicalLocalpart()
 	})
 }
 
@@ -3121,9 +3165,23 @@ func (u SSHUser) String() string {
 	return string(u)
 }
 
-// IsLocalpart returns true if the SSHUser has the localpart: prefix.
+// IsLocalpart returns true if the SSHUser has the literal `localpart:`
+// prefix. It is a syntactic check only — non-canonical shapes still
+// pass.
 func (u SSHUser) IsLocalpart() bool {
 	return strings.HasPrefix(string(u), SSHUserLocalpartPrefix)
+}
+
+// IsCanonicalLocalpart reports whether the SSHUser parses as the
+// canonical `localpart:*@<domain>` form that resolution acts on.
+func (u SSHUser) IsCanonicalLocalpart() bool {
+	if !u.IsLocalpart() {
+		return false
+	}
+
+	_, err := u.ParseLocalpart()
+
+	return err == nil
 }
 
 // ParseLocalpart validates and extracts the domain from a localpart: entry.
@@ -3161,6 +3219,20 @@ func (u SSHUser) MarshalJSON() ([]byte, error) {
 	return json.Marshal(string(u))
 }
 
+// UnmarshalJSON trims surrounding whitespace per element. A whitespace-
+// only entry collapses to `""` and surfaces as `user "" is not valid` in
+// the per-rule Validate() pass.
+func (u *SSHUser) UnmarshalJSON(b []byte) error {
+	var s string
+	if err := json.Unmarshal(b, &s); err != nil { //nolint:noinlineerr
+		return err
+	}
+
+	*u = SSHUser(strings.TrimSpace(s))
+
+	return nil
+}
+
 // unmarshalPolicy takes a byte slice and unmarshals it into a Policy struct.
 // In addition to unmarshalling, it will also validate the policy.
 // This is the only entrypoint of reading a policy from a file or other source.
@@ -3188,9 +3260,18 @@ func unmarshalPolicy(b []byte) (*Policy, error) {
 			}
 
 			// Non-tag entries in grant.via surface as type errors on
-			// []Tag; match SaaS wording instead of Go's JSON diagnostic.
+			// []Tag; rephrase to the wire-compatible body.
 			if strings.Contains(string(serr.JSONPointer), "/via/") {
 				return nil, ErrGrantViaNotATag
+			}
+
+			// Non-ASCII tag-name failures surface from Tag.Validate
+			// at unmarshal time. Reshape to `tagOwners["tag:X"]: …`.
+			if errors.Is(serr.Err, ErrTagNameMustStartWithLetter) {
+				ptr := serr.JSONPointer
+				name := ptr.LastToken()
+
+				return nil, fmt.Errorf("tagOwners[%q]: %w", name, ErrTagNameMustStartWithLetter)
 			}
 		}
 

--- a/hscontrol/policy/v2/types_test.go
+++ b/hscontrol/policy/v2/types_test.go
@@ -5973,3 +5973,225 @@ func TestUnmarshalPolicyEmptyArrays(t *testing.T) {
 		})
 	}
 }
+
+// TestUnmarshalPolicySSHTests covers the parse-time shape rules for the
+// sshTests block. Positive rows confirm the SSHPolicyTest struct fields
+// round-trip through JSON. Rejection rows pin each parse-time sentinel
+// against a representative malformed input. SaaS evaluation-time failures
+// (empty assertions, empty user strings) are deliberately accepted at
+// parse — they share the "test(s) failed" body with true failures and
+// land with the engine.
+func TestUnmarshalPolicySSHTests(t *testing.T) {
+	cases := []struct {
+		name           string
+		input          string
+		wantErr        error   // sentinel for errors.Is; nil means parse must succeed
+		extraSentinels []error // additional sentinels reachable via errors.Is
+		check          func(t *testing.T, pol *Policy)
+	}{
+		{
+			name: "valid-minimal-shape",
+			input: `
+{
+  "tagOwners": {"tag:server": ["admin@example.org"]},
+  "sshTests": [
+    {"src": "thor@example.org", "dst": ["tag:server"], "accept": ["root"]}
+  ]
+}
+`,
+			check: func(t *testing.T, pol *Policy) {
+				t.Helper()
+				require.Len(t, pol.SSHTests, 1)
+				got := pol.SSHTests[0]
+				require.Equal(t, "thor@example.org", got.Src)
+				require.Equal(t, []string{"tag:server"}, got.Dst)
+				require.Equal(t, []string{"root"}, got.Accept)
+				require.Empty(t, got.Deny)
+				require.Empty(t, got.Check)
+			},
+		},
+		{
+			name: "valid-all-three-action-arrays",
+			input: `
+{
+  "tagOwners": {"tag:server": ["admin@example.org"]},
+  "sshTests": [
+    {
+      "src": "thor@example.org",
+      "dst": ["tag:server"],
+      "accept": ["root"],
+      "deny":   ["nobody"],
+      "check":  ["alice"]
+    }
+  ]
+}
+`,
+			check: func(t *testing.T, pol *Policy) {
+				t.Helper()
+				require.Len(t, pol.SSHTests, 1)
+				got := pol.SSHTests[0]
+				require.Equal(t, []string{"root"}, got.Accept)
+				require.Equal(t, []string{"nobody"}, got.Deny)
+				require.Equal(t, []string{"alice"}, got.Check)
+			},
+		},
+		{
+			// Empty accept+deny+check is rejected by SaaS at evaluation,
+			// not at parse — the captured body is the same "test(s) failed"
+			// that true evaluation failures emit. The parse layer must let
+			// this through so the engine reports it consistently.
+			name: "valid-empty-arrays-engine-deferred",
+			input: `
+{
+  "tagOwners": {"tag:server": ["admin@example.org"]},
+  "sshTests": [
+    {"src": "thor@example.org", "dst": ["tag:server"]}
+  ]
+}
+`,
+			check: func(t *testing.T, pol *Policy) {
+				t.Helper()
+				require.Len(t, pol.SSHTests, 1)
+				got := pol.SSHTests[0]
+				require.Empty(t, got.Accept)
+				require.Empty(t, got.Deny)
+				require.Empty(t, got.Check)
+			},
+		},
+		{
+			// `tag:server:22` parses as a Tag because isTag only checks
+			// the `tag:` prefix; the colon-port suffix is retained in the
+			// tag string and the tagOwners lookup misses. SaaS reports
+			// this as an unknown tag with the bad value quoted.
+			name: "dst-with-port",
+			input: `
+{
+  "tagOwners": {"tag:server": ["admin@example.org"]},
+  "sshTests": [
+    {"src": "thor@example.org", "dst": ["tag:server:22"], "accept": ["root"]}
+  ]
+}
+`,
+			wantErr: ErrSSHTestDstUnknownTag,
+		},
+		{
+			name: "dst-cidr",
+			input: `
+{
+  "tagOwners": {"tag:server": ["admin@example.org"]},
+  "sshTests": [
+    {"src": "thor@example.org", "dst": ["10.0.0.0/8"], "accept": ["root"]}
+  ]
+}
+`,
+			wantErr: ErrSSHTestDstDisallowedElement,
+		},
+		{
+			name: "dst-autogroup-internet",
+			input: `
+{
+  "tagOwners": {"tag:server": ["admin@example.org"]},
+  "sshTests": [
+    {"src": "thor@example.org", "dst": ["autogroup:internet"], "accept": ["root"]}
+  ]
+}
+`,
+			wantErr: ErrSSHTestDstDisallowedElement,
+		},
+		{
+			name: "dst-unknown-tag",
+			input: `
+{
+  "tagOwners": {"tag:server": ["admin@example.org"]},
+  "sshTests": [
+    {"src": "thor@example.org", "dst": ["tag:not-in-tagOwners"], "accept": ["root"]}
+  ]
+}
+`,
+			wantErr: ErrSSHTestDstUnknownTag,
+		},
+		{
+			name: "empty-src",
+			input: `
+{
+  "tagOwners": {"tag:server": ["admin@example.org"]},
+  "sshTests": [
+    {"src": "", "dst": ["tag:server"], "accept": ["root"]}
+  ]
+}
+`,
+			wantErr: ErrSSHTestEmptySrc,
+		},
+		{
+			name: "empty-dst",
+			input: `
+{
+  "tagOwners": {"tag:server": ["admin@example.org"]},
+  "sshTests": [
+    {"src": "thor@example.org", "dst": [], "accept": ["root"]}
+  ]
+}
+`,
+			wantErr: ErrSSHTestEmptyDst,
+		},
+		{
+			// Multiple shape failures in one entry must aggregate through
+			// multierr.New under errSSHPolicyTestsFailed so the surfaced
+			// body matches the SaaS body byte-for-byte and every
+			// individual sentinel remains reachable via errors.Is.
+			name: "multierr-wrap",
+			input: `
+{
+  "tagOwners": {"tag:server": ["admin@example.org"]},
+  "sshTests": [
+    {"src": "", "dst": ["10.0.0.0/8", "autogroup:internet"], "accept": ["root"]}
+  ]
+}
+`,
+			wantErr:        ErrSSHTestEmptySrc,
+			extraSentinels: []error{ErrSSHTestDstDisallowedElement},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pol, err := unmarshalPolicy([]byte(tc.input))
+
+			if tc.wantErr == nil {
+				require.NoError(t, err)
+				require.NotNil(t, pol)
+
+				if tc.check != nil {
+					tc.check(t, pol)
+				}
+
+				return
+			}
+
+			require.Error(t, err)
+			require.ErrorIs(
+				t,
+				err, tc.wantErr,
+				"want errors.Is(err, %v); got %v",
+				tc.wantErr,
+				err,
+			)
+			require.Contains(
+				t,
+				err.Error(), "test(s) failed",
+				`want err to contain "test(s) failed"; got %q`,
+				err.Error(),
+			)
+
+			for _, sentinel := range tc.extraSentinels {
+				require.ErrorIs(
+					t,
+					err, sentinel,
+					"want errors.Is(err, %v); got %v",
+					sentinel,
+					err,
+				)
+			}
+		})
+	}
+}

--- a/hscontrol/policy/v2/types_test.go
+++ b/hscontrol/policy/v2/types_test.go
@@ -407,8 +407,50 @@ func TestUnmarshalPolicy(t *testing.T) {
 	},
 }
 `,
-			// wantErr: `username must contain @, got: "group:inner"`,
-			wantErr: `nested groups are not allowed: found "group:inner" inside "group:example"`,
+			wantErr: `groups["group:example"]: "group:inner": group members cannot be recursive`,
+		},
+		{
+			// SaaS reports the deepest non-leaf parent first: for
+			// the three-deep chain `a -> b -> c -> user`, the
+			// reported pair is `b -> c` rather than `a -> b`.
+			name: "group-nested-three-deep",
+			input: `
+{
+	"groups": {
+		"group:a": ["group:b"],
+		"group:b": ["group:c"],
+		"group:c": ["thor@example.org"],
+	},
+}
+`,
+			wantErr: `groups["group:b"]: "group:c": group members cannot be recursive`,
+		},
+		{
+			// Cycle `a <-> b`: reported as `b -> a` so the body
+			// matches SaaS exactly.
+			name: "group-nested-cycle",
+			input: `
+{
+	"groups": {
+		"group:a": ["group:b"],
+		"group:b": ["group:a"],
+	},
+}
+`,
+			wantErr: `groups["group:b"]: "group:a": group members cannot be recursive`,
+		},
+		{
+			// Self-cycle: the same group appears as its own
+			// member. Same wording.
+			name: "group-nested-self-cycle",
+			input: `
+{
+	"groups": {
+		"group:a": ["group:a"],
+	},
+}
+`,
+			wantErr: `groups["group:a"]: "group:a": group members cannot be recursive`,
 		},
 		{
 			name: "invalid-addr",
@@ -660,7 +702,7 @@ func TestUnmarshalPolicy(t *testing.T) {
 			},
 		},
 		{
-			name: "ssh-with-tag-and-user",
+			name: "ssh-with-tag-and-wildcard-user",
 			input: `
 {
   "tagOwners": {
@@ -681,26 +723,7 @@ func TestUnmarshalPolicy(t *testing.T) {
   ]
 }
 `,
-			want: &Policy{
-				TagOwners: TagOwners{
-					Tag("tag:web"):    Owners{new(Username("admin@example.com"))},
-					Tag("tag:server"): Owners{new(Username("admin@example.com"))},
-				},
-				SSHs: []SSH{
-					{
-						Action: "accept",
-						Sources: SSHSrcAliases{
-							tp("tag:web"),
-						},
-						Destinations: SSHDstAliases{
-							tp("tag:server"),
-						},
-						Users: []SSHUser{
-							SSHUser("*"),
-						},
-					},
-				},
-			},
+			wantErr: `user "*" is not valid`,
 		},
 		{
 			name: "ssh-with-check-period",
@@ -2006,8 +2029,11 @@ func TestUnmarshalPolicy(t *testing.T) {
 `,
 			wantErr: "square brackets are only valid around IPv6 addresses",
 		},
+		// Non-canonical `localpart:` strings flow through as literal
+		// user names per SaaS behaviour — captured in
+		// ssh-malformed-user-localpart-{no-at,no-glob,no-domain}.
 		{
-			name: "ssh-localpart-invalid-no-at-sign",
+			name: "ssh-localpart-non-canonical-no-at-sign",
 			input: `
 {
   "tagOwners": {"tag:prod": ["admin@"]},
@@ -2019,10 +2045,22 @@ func TestUnmarshalPolicy(t *testing.T) {
   }]
 }
 `,
-			wantErr: "invalid localpart format",
+			want: &Policy{
+				TagOwners: TagOwners{
+					Tag("tag:prod"): Owners{new(Username("admin@"))},
+				},
+				SSHs: []SSH{
+					{
+						Action:       "accept",
+						Sources:      SSHSrcAliases{agp("autogroup:member")},
+						Destinations: SSHDstAliases{tp("tag:prod")},
+						Users:        []SSHUser{SSHUser("localpart:foo")},
+					},
+				},
+			},
 		},
 		{
-			name: "ssh-localpart-invalid-non-wildcard",
+			name: "ssh-localpart-non-canonical-non-wildcard",
 			input: `
 {
   "tagOwners": {"tag:prod": ["admin@"]},
@@ -2034,10 +2072,22 @@ func TestUnmarshalPolicy(t *testing.T) {
   }]
 }
 `,
-			wantErr: "invalid localpart format",
+			want: &Policy{
+				TagOwners: TagOwners{
+					Tag("tag:prod"): Owners{new(Username("admin@"))},
+				},
+				SSHs: []SSH{
+					{
+						Action:       "accept",
+						Sources:      SSHSrcAliases{agp("autogroup:member")},
+						Destinations: SSHDstAliases{tp("tag:prod")},
+						Users:        []SSHUser{SSHUser("localpart:alice@example.com")},
+					},
+				},
+			},
 		},
 		{
-			name: "ssh-localpart-invalid-empty-domain",
+			name: "ssh-localpart-non-canonical-empty-domain",
 			input: `
 {
   "tagOwners": {"tag:prod": ["admin@"]},
@@ -2049,7 +2099,19 @@ func TestUnmarshalPolicy(t *testing.T) {
   }]
 }
 `,
-			wantErr: "invalid localpart format",
+			want: &Policy{
+				TagOwners: TagOwners{
+					Tag("tag:prod"): Owners{new(Username("admin@"))},
+				},
+				SSHs: []SSH{
+					{
+						Action:       "accept",
+						Sources:      SSHSrcAliases{agp("autogroup:member")},
+						Destinations: SSHDstAliases{tp("tag:prod")},
+						Users:        []SSHUser{SSHUser("localpart:*@")},
+					},
+				},
+			},
 		},
 		// A test entry with neither accept nor deny asserts nothing
 		// and is silently accepted today. Tailscale rejects the policy.
@@ -4133,13 +4195,45 @@ func TestFlattenTagOwners(t *testing.T) {
 			wantErr: "",
 		},
 		{
-			name: "circular-reference",
+			// SaaS tolerates tag:a <-> tag:b cycles by dropping the
+			// cycle edge; both tags resolve to an empty owner set
+			// because neither chain reaches a non-tag owner.
+			name: "circular-reference-resolves-to-empty",
 			input: TagOwners{
 				Tag("tag:a"): Owners{new(Tag("tag:b"))},
 				Tag("tag:b"): Owners{new(Tag("tag:a"))},
 			},
-			want:    nil,
-			wantErr: "circular reference detected: tag:a -> tag:b",
+			want: TagOwners{
+				Tag("tag:a"): nil,
+				Tag("tag:b"): nil,
+			},
+			wantErr: "",
+		},
+		{
+			// tag:a -> tag:a self-reference: the only owner is the
+			// cycle edge itself; result is empty.
+			name: "self-reference-resolves-to-empty",
+			input: TagOwners{
+				Tag("tag:a"): Owners{new(Tag("tag:a"))},
+			},
+			want: TagOwners{
+				Tag("tag:a"): nil,
+			},
+			wantErr: "",
+		},
+		{
+			// Cycle plus a sibling non-tag owner: the cycle edge
+			// drops out, the sibling owner survives.
+			name: "cycle-plus-sibling-keeps-sibling",
+			input: TagOwners{
+				Tag("tag:a"): Owners{new(Tag("tag:b")), new(Username("alice@example.com"))},
+				Tag("tag:b"): Owners{new(Tag("tag:a"))},
+			},
+			want: TagOwners{
+				Tag("tag:a"): Owners{new(Username("alice@example.com"))},
+				Tag("tag:b"): Owners{new(Username("alice@example.com"))},
+			},
+			wantErr: "",
 		},
 		{
 			name: "mixed-owners",
@@ -4198,7 +4292,9 @@ func TestFlattenTagOwners(t *testing.T) {
 			wantErr: "",
 		},
 		{
-			name: "tag-long-circular-chain",
+			// Long cycle: every tag eventually points back to itself.
+			// Each tag resolves to the empty owner set.
+			name: "tag-long-circular-chain-resolves-to-empty",
 			input: TagOwners{
 				Tag("tag:a"): Owners{new(Tag("tag:g"))},
 				Tag("tag:b"): Owners{new(Tag("tag:a"))},
@@ -4208,7 +4304,16 @@ func TestFlattenTagOwners(t *testing.T) {
 				Tag("tag:f"): Owners{new(Tag("tag:e"))},
 				Tag("tag:g"): Owners{new(Tag("tag:f"))},
 			},
-			wantErr: "circular reference detected: tag:a -> tag:b -> tag:c -> tag:d -> tag:e -> tag:f -> tag:g",
+			want: TagOwners{
+				Tag("tag:a"): nil,
+				Tag("tag:b"): nil,
+				Tag("tag:c"): nil,
+				Tag("tag:d"): nil,
+				Tag("tag:e"): nil,
+				Tag("tag:f"): nil,
+				Tag("tag:g"): nil,
+			},
+			wantErr: "",
 		},
 		{
 			name: "undefined-tag-reference",
@@ -4364,7 +4469,15 @@ func TestSSHCheckPeriodValidate(t *testing.T) {
 			period: SSHCheckPeriod{Always: true},
 		},
 		{
-			name:   "1m minimum valid",
+			name:   "zero duration is valid",
+			period: SSHCheckPeriod{Duration: 0},
+		},
+		{
+			name:   "30s below previous minimum is valid (matches SaaS)",
+			period: SSHCheckPeriod{Duration: 30 * time.Second},
+		},
+		{
+			name:   "1m valid",
 			period: SSHCheckPeriod{Duration: time.Minute},
 		},
 		{
@@ -4372,14 +4485,19 @@ func TestSSHCheckPeriodValidate(t *testing.T) {
 			period: SSHCheckPeriod{Duration: 168 * time.Hour},
 		},
 		{
-			name:    "30s below minimum",
-			period:  SSHCheckPeriod{Duration: 30 * time.Second},
-			wantErr: ErrSSHCheckPeriodBelowMin,
+			name:    "168h0m1s above maximum",
+			period:  SSHCheckPeriod{Duration: 168*time.Hour + time.Second},
+			wantErr: ErrSSHCheckPeriodAboveMax,
 		},
 		{
 			name:    "169h above maximum",
 			period:  SSHCheckPeriod{Duration: 169 * time.Hour},
 			wantErr: ErrSSHCheckPeriodAboveMax,
+		},
+		{
+			name:    "negative duration rejected",
+			period:  SSHCheckPeriod{Duration: -time.Minute},
+			wantErr: ErrSSHCheckPeriodNegative,
 		},
 	}
 
@@ -4444,7 +4562,7 @@ func TestSSHCheckPeriodPolicyValidation(t *testing.T) {
 			wantErr: ErrSSHCheckPeriodOnNonCheck,
 		},
 		{
-			name: "check with 30s is invalid",
+			name: "check with 30s is valid (matches SaaS, no minimum)",
 			ssh: SSH{
 				Action:       SSHActionCheck,
 				Sources:      SSHSrcAliases{up("user@")},
@@ -4452,7 +4570,49 @@ func TestSSHCheckPeriodPolicyValidation(t *testing.T) {
 				Users:        SSHUsers{"root"},
 				CheckPeriod:  &SSHCheckPeriod{Duration: 30 * time.Second},
 			},
-			wantErr: ErrSSHCheckPeriodBelowMin,
+		},
+		{
+			name: "check with 168h exactly is valid",
+			ssh: SSH{
+				Action:       SSHActionCheck,
+				Sources:      SSHSrcAliases{up("user@")},
+				Destinations: SSHDstAliases{agp("autogroup:member")},
+				Users:        SSHUsers{"root"},
+				CheckPeriod:  &SSHCheckPeriod{Duration: 168 * time.Hour},
+			},
+		},
+		{
+			name: "check with 168h0m1s just above max is invalid",
+			ssh: SSH{
+				Action:       SSHActionCheck,
+				Sources:      SSHSrcAliases{up("user@")},
+				Destinations: SSHDstAliases{agp("autogroup:member")},
+				Users:        SSHUsers{"root"},
+				CheckPeriod:  &SSHCheckPeriod{Duration: 168*time.Hour + time.Second},
+			},
+			wantErr: ErrSSHCheckPeriodAboveMax,
+		},
+		{
+			name: "check with 200h above max is invalid",
+			ssh: SSH{
+				Action:       SSHActionCheck,
+				Sources:      SSHSrcAliases{up("user@")},
+				Destinations: SSHDstAliases{agp("autogroup:member")},
+				Users:        SSHUsers{"root"},
+				CheckPeriod:  &SSHCheckPeriod{Duration: 200 * time.Hour},
+			},
+			wantErr: ErrSSHCheckPeriodAboveMax,
+		},
+		{
+			name: "check with negative duration is invalid",
+			ssh: SSH{
+				Action:       SSHActionCheck,
+				Sources:      SSHSrcAliases{up("user@")},
+				Destinations: SSHDstAliases{agp("autogroup:member")},
+				Users:        SSHUsers{"root"},
+				CheckPeriod:  &SSHCheckPeriod{Duration: -time.Minute},
+			},
+			wantErr: ErrSSHCheckPeriodNegative,
 		},
 	}
 
@@ -4470,6 +4630,406 @@ func TestSSHCheckPeriodPolicyValidation(t *testing.T) {
 			require.NoError(t, err)
 		})
 	}
+}
+
+// TestSSHRuleSaaSValidation exercises the SaaS-aligned rejections
+// added to match the API body strings exactly.
+func TestSSHRuleSaaSValidation(t *testing.T) {
+	baseSSH := func(modify func(*SSH)) SSH {
+		ssh := SSH{
+			Action:       SSHActionAccept,
+			Sources:      SSHSrcAliases{up("user@")},
+			Destinations: SSHDstAliases{agp("autogroup:member")},
+			Users:        SSHUsers{"root"},
+		}
+		if modify != nil {
+			modify(&ssh)
+		}
+
+		return ssh
+	}
+
+	tests := []struct {
+		name    string
+		ssh     SSH
+		wantErr error
+	}{
+		{
+			name:    "users empty rejected",
+			ssh:     baseSSH(func(s *SSH) { s.Users = nil }),
+			wantErr: ErrSSHUsersMustBeSpecified,
+		},
+		{
+			name:    "users empty array rejected",
+			ssh:     baseSSH(func(s *SSH) { s.Users = SSHUsers{} }),
+			wantErr: ErrSSHUsersMustBeSpecified,
+		},
+		{
+			name:    "user empty string rejected",
+			ssh:     baseSSH(func(s *SSH) { s.Users = SSHUsers{""} }),
+			wantErr: ErrSSHUserInvalid,
+		},
+		{
+			name:    "user wildcard rejected",
+			ssh:     baseSSH(func(s *SSH) { s.Users = SSHUsers{"*"} }),
+			wantErr: ErrSSHUserInvalid,
+		},
+		{
+			name:    "acceptEnv empty entry rejected",
+			ssh:     baseSSH(func(s *SSH) { s.AcceptEnv = []string{"FOO", ""} }),
+			wantErr: ErrSSHAcceptEnvEmpty,
+		},
+		{
+			name:    "action empty rejected",
+			ssh:     baseSSH(func(s *SSH) { s.Action = "" }),
+			wantErr: ErrSSHActionMustBeSpecified,
+		},
+		{
+			name: "user autogroup non-nonroot accepted (literal)",
+			ssh: baseSSH(func(s *SSH) {
+				s.Users = SSHUsers{"autogroup:internet"}
+			}),
+		},
+		{
+			name: "user malformed localpart accepted (literal)",
+			ssh: baseSSH(func(s *SSH) {
+				s.Users = SSHUsers{"localpart:foo"}
+			}),
+		},
+		{
+			name: "acceptEnv double-glob accepted",
+			ssh: baseSSH(func(s *SSH) {
+				s.AcceptEnv = []string{"**"}
+			}),
+		},
+		{
+			// SaaS rejects hosts-table aliases on SSH dst with
+			// `invalid dst "srv"`. headscale validates the same
+			// regardless of whether the alias resolves to a
+			// single IP or a CIDR.
+			name: "host alias as SSH dst rejected",
+			ssh: baseSSH(func(s *SSH) {
+				s.Destinations = SSHDstAliases{hp("srv")}
+			}),
+			wantErr: ErrSSHDestinationHostAlias,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pol := &Policy{
+				Hosts: Hosts{Host("srv"): Prefix(mp("100.64.0.16/32"))},
+				SSHs:  []SSH{tt.ssh},
+			}
+			err := pol.validate()
+
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+// TestSSHActionInvalidUnmarshal verifies the SaaS-aligned wording for
+// non-empty unknown actions surfaces at JSON parse time.
+func TestSSHActionInvalidUnmarshal(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantValue SSHAction
+		wantErr   error
+		wantMsg   string
+	}{
+		{
+			name:      "exact match accept",
+			input:     `"accept"`,
+			wantValue: SSHActionAccept,
+		},
+		{
+			name:      "exact match check",
+			input:     `"check"`,
+			wantValue: SSHActionCheck,
+		},
+		{
+			name:      "whitespace trimmed to accept",
+			input:     `" accept "`,
+			wantValue: SSHActionAccept,
+		},
+		{
+			name:    "uppercase rejected",
+			input:   `"ACCEPT"`,
+			wantErr: ErrSSHActionInvalid,
+			wantMsg: `"ACCEPT" is not a valid action`,
+		},
+		{
+			name:    "mixedcase rejected",
+			input:   `"Accept"`,
+			wantErr: ErrSSHActionInvalid,
+			wantMsg: `"Accept" is not a valid action`,
+		},
+		{
+			name:    "whitespace trimmed then mixedcase rejected",
+			input:   `" Accept"`,
+			wantErr: ErrSSHActionInvalid,
+			wantMsg: `"Accept" is not a valid action`,
+		},
+		{
+			name:    "unknown action rejected",
+			input:   `"deny"`,
+			wantErr: ErrSSHActionInvalid,
+			wantMsg: `"deny" is not a valid action`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var a SSHAction
+
+			err := json.Unmarshal([]byte(tt.input), &a)
+			if tt.wantErr != nil {
+				require.Error(t, err)
+				require.ErrorIs(t, err, tt.wantErr)
+				require.Contains(t, err.Error(), tt.wantMsg)
+
+				return
+			}
+
+			require.NoError(t, err)
+			require.Equal(t, tt.wantValue, a)
+		})
+	}
+}
+
+// TestSSHUserUnmarshalTrim verifies per-element whitespace trimming so
+// that the compiled `sshUsers` map matches SaaS exactly. A
+// whitespace-only entry collapses to "" and is left for the per-rule
+// validate() pass to reject via ErrSSHUserInvalid.
+func TestSSHUserUnmarshalTrim(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  SSHUser
+	}{
+		{
+			name:  "leading whitespace trimmed",
+			input: `" root"`,
+			want:  SSHUser("root"),
+		},
+		{
+			name:  "trailing whitespace trimmed",
+			input: `"root "`,
+			want:  SSHUser("root"),
+		},
+		{
+			name:  "whitespace-only collapses to empty",
+			input: `"  "`,
+			want:  SSHUser(""),
+		},
+		{
+			name:  "no trim needed",
+			input: `"root"`,
+			want:  SSHUser("root"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var u SSHUser
+
+			err := json.Unmarshal([]byte(tt.input), &u)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, u)
+		})
+	}
+}
+
+// TestSSHUserTrimEndToEnd verifies that a policy with `[" root"]`
+// parses cleanly and that the policy validate() pass treats `[" "]`
+// as the empty-user case (per-element trim happens at unmarshal time).
+func TestSSHUserTrimEndToEnd(t *testing.T) {
+	t.Run("leading whitespace user accepted and trimmed", func(t *testing.T) {
+		policy := `
+{
+	"tagOwners": {"tag:server": ["odin@example.com"]},
+	"ssh": [{
+		"action": "accept",
+		"src":    ["autogroup:member"],
+		"dst":    ["tag:server"],
+		"users":  [" root"]
+	}]
+}`
+		pol, err := unmarshalPolicy([]byte(policy))
+		require.NoError(t, err)
+		require.Len(t, pol.SSHs, 1)
+		require.Equal(t, SSHUsers{SSHUser("root")}, pol.SSHs[0].Users)
+	})
+
+	t.Run("whitespace-only user rejected as empty", func(t *testing.T) {
+		policy := `
+{
+	"tagOwners": {"tag:server": ["odin@example.com"]},
+	"ssh": [{
+		"action": "accept",
+		"src":    ["autogroup:member"],
+		"dst":    ["tag:server"],
+		"users":  [" "]
+	}]
+}`
+		_, err := unmarshalPolicy([]byte(policy))
+		require.Error(t, err)
+		require.ErrorIs(t, err, ErrSSHUserInvalid)
+		require.Contains(t, err.Error(), `user "" is not valid`)
+	})
+}
+
+// TestAliasEncUnmarshalTrim verifies that src/dst entries get
+// trimmed before alias dispatch so `"tag:server "` resolves to the
+// same Tag alias SaaS uses and `" odin@example.com"` resolves to the
+// same Username alias. Covers tag, group, user, and autogroup entries
+// on both the leading- and trailing-whitespace edges.
+func TestAliasEncUnmarshalTrim(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  Alias
+	}{
+		{
+			name:  "tag trailing whitespace",
+			input: `"tag:server "`,
+			want:  new(Tag("tag:server")),
+		},
+		{
+			name:  "tag leading whitespace",
+			input: `" tag:server"`,
+			want:  new(Tag("tag:server")),
+		},
+		{
+			name:  "group leading whitespace",
+			input: `" group:admins"`,
+			want:  new(Group("group:admins")),
+		},
+		{
+			name:  "user trailing whitespace",
+			input: `"odin@example.com "`,
+			want:  new(Username("odin@example.com")),
+		},
+		{
+			name:  "autogroup trailing whitespace",
+			input: `"autogroup:member "`,
+			want:  new(AutoGroup("autogroup:member")),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var a AliasEnc
+
+			err := json.Unmarshal([]byte(tt.input), &a)
+			require.NoError(t, err)
+			require.Equal(t, tt.want, a.Alias)
+		})
+	}
+}
+
+// TestTagValidateFirstCharLetter exercises the SaaS rule that the
+// first character after `tag:` must be an ASCII letter. Digits,
+// punctuation, and non-ASCII Unicode letters are rejected with the
+// same body SaaS produces. Subsequent characters are unconstrained.
+func TestTagValidateFirstCharLetter(t *testing.T) {
+	tests := []struct {
+		name    string
+		tag     Tag
+		wantErr error
+	}{
+		{
+			name: "ascii lowercase letter",
+			tag:  Tag("tag:server"),
+		},
+		{
+			name: "ascii uppercase letter",
+			tag:  Tag("tag:Server"),
+		},
+		{
+			name: "ascii letter then digit",
+			tag:  Tag("tag:a1"),
+		},
+		{
+			name:    "leading digit rejected",
+			tag:     Tag("tag:1server"),
+			wantErr: ErrTagNameMustStartWithLetter,
+		},
+		{
+			name:    "leading hyphen rejected",
+			tag:     Tag("tag:-server"),
+			wantErr: ErrTagNameMustStartWithLetter,
+		},
+		{
+			name:    "cyrillic letter rejected",
+			tag:     Tag("tag:сервер"),
+			wantErr: ErrTagNameMustStartWithLetter,
+		},
+		{
+			name:    "empty name rejected",
+			tag:     Tag("tag:"),
+			wantErr: ErrTagNameMustStartWithLetter,
+		},
+		{
+			name:    "missing prefix rejected",
+			tag:     Tag("server"),
+			wantErr: ErrInvalidTagFormat,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.tag.Validate()
+			if tt.wantErr != nil {
+				require.ErrorIs(t, err, tt.wantErr)
+
+				return
+			}
+
+			require.NoError(t, err)
+		})
+	}
+}
+
+// TestUnmarshalPolicyCyrillicTagOwner verifies the full SaaS body
+// (`tagOwners["tag:сервер"]: …`) surfaces when a non-ASCII tag
+// appears as a tagOwners key.
+func TestUnmarshalPolicyCyrillicTagOwner(t *testing.T) {
+	policy := []byte(`{"tagOwners": {"tag:сервер": ["odin@example.com"]}}`)
+
+	_, err := unmarshalPolicy(policy)
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrTagNameMustStartWithLetter)
+	require.Contains(t, err.Error(),
+		`tagOwners["tag:сервер"]: tag names must start with a letter, after 'tag:'`)
+}
+
+// TestSSHCheckPeriodInvalidDuration verifies the SaaS body for the
+// malformed-duration case (`time: invalid duration "abc"`).
+func TestSSHCheckPeriodInvalidDuration(t *testing.T) {
+	var p SSHCheckPeriod
+
+	err := json.Unmarshal([]byte(`"abc"`), &p)
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `time: invalid duration "abc"`)
+}
+
+// TestSSHCheckPeriodNegativeMessage verifies the SaaS body for the
+// negative-duration case (`checkPeriod -1m0s must be a positive duration`).
+func TestSSHCheckPeriodNegativeMessage(t *testing.T) {
+	p := SSHCheckPeriod{Duration: -time.Minute}
+
+	err := p.Validate()
+	require.Error(t, err)
+	require.ErrorIs(t, err, ErrSSHCheckPeriodNegative)
+	require.Contains(t, err.Error(), "checkPeriod -1m0s must be a positive duration")
 }
 
 func TestUnmarshalGrants(t *testing.T) {

--- a/hscontrol/policy/v2/types_test.go
+++ b/hscontrol/policy/v2/types_test.go
@@ -6003,9 +6003,12 @@ func TestUnmarshalPolicySSHTests(t *testing.T) {
 				t.Helper()
 				require.Len(t, pol.SSHTests, 1)
 				got := pol.SSHTests[0]
-				require.Equal(t, "thor@example.org", got.Src)
-				require.Equal(t, []string{"tag:server"}, got.Dst)
-				require.Equal(t, []string{"root"}, got.Accept)
+				require.IsType(t, (*Username)(nil), got.Src)
+				require.Equal(t, "thor@example.org", got.Src.String())
+				require.Len(t, got.Dst, 1)
+				require.IsType(t, (*Tag)(nil), got.Dst[0])
+				require.Equal(t, "tag:server", got.Dst[0].String())
+				require.Equal(t, []SSHUser{"root"}, got.Accept)
 				require.Empty(t, got.Deny)
 				require.Empty(t, got.Check)
 			},
@@ -6030,9 +6033,9 @@ func TestUnmarshalPolicySSHTests(t *testing.T) {
 				t.Helper()
 				require.Len(t, pol.SSHTests, 1)
 				got := pol.SSHTests[0]
-				require.Equal(t, []string{"root"}, got.Accept)
-				require.Equal(t, []string{"nobody"}, got.Deny)
-				require.Equal(t, []string{"alice"}, got.Check)
+				require.Equal(t, []SSHUser{"root"}, got.Accept)
+				require.Equal(t, []SSHUser{"nobody"}, got.Deny)
+				require.Equal(t, []SSHUser{"alice"}, got.Check) //nolint:goconst
 			},
 		},
 		{
@@ -6085,6 +6088,52 @@ func TestUnmarshalPolicySSHTests(t *testing.T) {
 }
 `,
 			wantErr: ErrSSHTestDstDisallowedElement,
+		},
+		{
+			// SaaS accepts a bare IPv4 literal as a host address. The
+			// Prefix parser turns it into a /32 so validateSSHTestDestination
+			// must match Bits() against Addr().BitLen() rather than reject
+			// the whole *Prefix branch.
+			name: "dst-bare-ipv4-accepted",
+			input: `
+{
+  "tagOwners": {"tag:server": ["admin@example.org"]},
+  "sshTests": [
+    {"src": "thor@example.org", "dst": ["100.64.0.16"], "accept": ["root"]}
+  ]
+}
+`,
+			check: func(t *testing.T, pol *Policy) {
+				t.Helper()
+				require.Len(t, pol.SSHTests, 1)
+				got := pol.SSHTests[0]
+				require.Len(t, got.Dst, 1)
+				pref, ok := got.Dst[0].(*Prefix)
+				require.True(t, ok, "want *Prefix, got %T", got.Dst[0])
+				require.Equal(t, "100.64.0.16/32", pref.String())
+			},
+		},
+		{
+			// IPv6 mirror of the IPv4 case: bare `fd7a::10` parses to
+			// /128 and must pass the parse-time shape check.
+			name: "dst-bare-ipv6-accepted",
+			input: `
+{
+  "tagOwners": {"tag:server": ["admin@example.org"]},
+  "sshTests": [
+    {"src": "thor@example.org", "dst": ["fd7a:115c:a1e0::10"], "accept": ["root"]}
+  ]
+}
+`,
+			check: func(t *testing.T, pol *Policy) {
+				t.Helper()
+				require.Len(t, pol.SSHTests, 1)
+				got := pol.SSHTests[0]
+				require.Len(t, got.Dst, 1)
+				pref, ok := got.Dst[0].(*Prefix)
+				require.True(t, ok, "want *Prefix, got %T", got.Dst[0])
+				require.Equal(t, "fd7a:115c:a1e0::10/128", pref.String())
+			},
 		},
 		{
 			name: "dst-autogroup-internet",

--- a/integration/cli_policy_test.go
+++ b/integration/cli_policy_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	policyv2 "github.com/juanfont/headscale/hscontrol/policy/v2"
+	"github.com/juanfont/headscale/hscontrol/types"
 	"github.com/juanfont/headscale/integration/hsic"
 	"github.com/juanfont/headscale/integration/tsic"
 	"github.com/stretchr/testify/require"
@@ -163,4 +164,117 @@ func TestPolicyCheckCommand(t *testing.T) {
 			require.Contains(t, stdout, tt.wantStdout)
 		})
 	}
+}
+
+// TestSSHTestsRejectFailingPolicy asserts `headscale policy set` rejects
+// a policy whose sshTests fail, surfaces the engine's "test(s) failed"
+// sentinel, and leaves the stored policy unchanged. autogroup:member as
+// dst lets every scenario node count, so no tagged node is needed.
+func TestSSHTestsRejectFailingPolicy(t *testing.T) {
+	IntegrationSkip(t)
+
+	const (
+		user1 = "user1@"
+		user2 = "user2@"
+	)
+
+	// Good policy: user1@ may SSH as root, and the sshTests asserts it.
+	goodPolicy := policyv2.Policy{
+		SSHs: []policyv2.SSH{
+			{
+				Action:  policyv2.SSHActionAccept,
+				Sources: policyv2.SSHSrcAliases{usernamep(user1)},
+				Destinations: policyv2.SSHDstAliases{
+					new(policyv2.AutoGroupMember),
+				},
+				Users: []policyv2.SSHUser{policyv2.SSHUser("root")},
+			},
+		},
+		SSHTests: []policyv2.SSHPolicyTest{
+			{
+				Src:    usernamep(user1),
+				Dst:    policyv2.SSHTestDestinations{new(policyv2.AutoGroupMember)},
+				Accept: []policyv2.SSHUser{policyv2.SSHUser("root")},
+			},
+		},
+	}
+
+	// Bad policy: same SSH rule, but the sshTests asserts user2@ — who
+	// the rule does not admit — can SSH. Must be rejected.
+	badPolicy := goodPolicy
+	badPolicy.SSHTests = []policyv2.SSHPolicyTest{
+		{
+			Src:    usernamep(user2),
+			Dst:    policyv2.SSHTestDestinations{new(policyv2.AutoGroupMember)},
+			Accept: []policyv2.SSHUser{policyv2.SSHUser("root")},
+		},
+	}
+
+	spec := ScenarioSpec{
+		NodesPerUser: 1,
+		Users:        []string{"user1", "user2"},
+	}
+
+	scenario, err := NewScenario(spec)
+	require.NoError(t, err)
+
+	defer scenario.ShutdownAssertNoPanics(t)
+
+	err = scenario.CreateHeadscaleEnv(
+		[]tsic.Option{},
+		hsic.WithTestName("cli-policyset-sshtests"),
+		hsic.WithConfigEnv(map[string]string{
+			"HEADSCALE_POLICY_MODE": types.PolicyModeDB,
+		}),
+	)
+	require.NoError(t, err)
+
+	headscale, err := scenario.Headscale()
+	require.NoError(t, err)
+
+	goodBytes, err := json.Marshal(goodPolicy)
+	require.NoError(t, err)
+
+	badBytes, err := json.Marshal(badPolicy)
+	require.NoError(t, err)
+
+	const (
+		goodPath = "/etc/headscale/policy-good.json"
+		badPath  = "/etc/headscale/policy-bad.json"
+	)
+
+	require.NoError(t, headscale.WriteFile(goodPath, goodBytes))
+	require.NoError(t, headscale.WriteFile(badPath, badBytes))
+
+	// Establish the good policy as the live policy.
+	_, err = headscale.Execute([]string{
+		"headscale", "policy", "set", "-f", goodPath,
+	})
+	require.NoError(t, err, "setting the good policy must succeed")
+
+	// Confirm the server returns the good policy.
+	stdoutBefore, err := headscale.Execute([]string{
+		"headscale", "policy", "get",
+	})
+	require.NoError(t, err)
+	require.JSONEq(t, string(goodBytes), stdoutBefore,
+		"server should report the good policy after the initial set")
+
+	// Attempt to overwrite with a policy whose sshTests fail. The CLI
+	// must surface the engine's "test(s) failed" sentinel and exit
+	// non-zero.
+	_, err = headscale.Execute([]string{
+		"headscale", "policy", "set", "-f", badPath,
+	})
+	require.Error(t, err, "setting a policy with failing sshTests must fail")
+	require.ErrorContains(t, err, "test(s) failed",
+		"CLI error must surface the engine's test failure sentinel")
+
+	// The rejected write must not have mutated the stored policy.
+	stdoutAfter, err := headscale.Execute([]string{
+		"headscale", "policy", "get",
+	})
+	require.NoError(t, err)
+	require.JSONEq(t, string(goodBytes), stdoutAfter,
+		"stored policy must be unchanged after a rejected set")
 }


### PR DESCRIPTION
Adds `sshTests`: the SSH-side parallel of the recently merged ACL `tests:` block. Entries are `{src, dst[], accept[users], deny[users], check[users]}` and evaluate on `SetPolicy`, SIGHUP reload, and `headscale policy check`. `accept` and `check` both count as reachable; `check` additionally requires the matching rule to carry `HoldAndDelegate`. Failures reject the write without mutating live state; boot-time reload warns and continues so a stale reference does not block startup.

Bundled with the engine: SSH rule validation tightenings to match Tailscale — whitespace trim on `action`/`users`/`src`/`dst`, rejection of empty/wildcard users and empty `acceptEnv`, rejection of negative `checkPeriod`, rejection of `hosts:` aliases as SSH dst, rejection of non-ASCII tag names, tolerance for tag-owner cycles, and matching wording on group-nesting rejections.

Compat coverage in `testdata/sshtest_results/` and `testdata/ssh_results/` replays recorded policy responses; 8 known-divergent captures are listed with the engine gap each represents (passkey wildcard, configured-tailnet-domain matching, one IPv6 dst evaluator asymmetry).
